### PR TITLE
feat: naturality of the discriminant form of an even overlattice

### DIFF
--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
@@ -41,6 +41,8 @@ subgroup can be degenerate.
 
 * `TauCeti.FiniteBilinearModule.Isometry.map_orthogonalComplement`: an isometry carries
   orthogonal complements to orthogonal complements.
+* `TauCeti.FiniteBilinearModule.Isometry.orthogonalComplementEquiv`: the induced equivalence
+  between corresponding orthogonal complements.
 * `TauCeti.FiniteBilinearModule.Isometry.isIsotropic_map_iff`: an isometry transports isotropic
   subgroups.
 * `TauCeti.FiniteBilinearModule.Isometry.isLagrangian_map_iff`: an isometry transports Lagrangian
@@ -666,6 +668,50 @@ theorem Isometry.map_orthogonalComplement {B : FiniteBilinearModule} (f : Isomet
     intro z hz
     rw [← f.map_pairing (f.symm y) z, f.apply_symm_apply]
     exact hy (f z) (AddSubgroup.mem_map.mpr ⟨z, hz, rfl⟩)
+
+/-- An isometry restricts to an additive equivalence from the orthogonal complement of a subgroup
+onto the orthogonal complement of its image. -/
+def Isometry.orthogonalComplementEquiv {B : FiniteBilinearModule} (f : Isometry A B)
+    (H : AddSubgroup A) :
+    A.orthogonalComplement H ≃+ B.orthogonalComplement (H.map f.toAddEquiv) :=
+  (f.toAddEquiv.addSubgroupMap (A.orthogonalComplement H)).trans
+    (AddEquiv.addSubgroupCongr (f.map_orthogonalComplement (H := H)))
+
+/-- The restricted equivalence of orthogonal complements acts by the isometry. -/
+@[simp]
+theorem Isometry.coe_orthogonalComplementEquiv_apply {B : FiniteBilinearModule}
+    (f : Isometry A B) (H : AddSubgroup A) (x : A.orthogonalComplement H) :
+    (Isometry.orthogonalComplementEquiv A f H x : B) = f (x : A) := (rfl)
+
+/-- The inverse restricted equivalence of orthogonal complements acts by the inverse isometry. -/
+@[simp]
+theorem Isometry.coe_orthogonalComplementEquiv_symm_apply {B : FiniteBilinearModule}
+    (f : Isometry A B) (H : AddSubgroup A)
+    (y : B.orthogonalComplement (H.map f.toAddEquiv)) :
+    ((Isometry.orthogonalComplementEquiv A f H).symm y : A) = f.symm (y : B) := (rfl)
+
+/-- An isometry carries an element of the orthogonal complement of `H` into the orthogonal
+complement of `K` whenever the preimage of `K` is contained in `H`. -/
+theorem Isometry.map_mem_orthogonalComplement_of_forall_mem {B : FiniteBilinearModule}
+    (f : Isometry A B) {H : AddSubgroup A} {K : AddSubgroup B}
+    (h : ∀ x : A, f x ∈ K → x ∈ H) {x : A} (hx : x ∈ A.orthogonalComplement H) :
+    f x ∈ B.orthogonalComplement K := by
+  have hle : K ≤ H.map f.toAddEquiv := by
+    intro y hy
+    have hy' : f (f.symm y) ∈ K := by simpa
+    have hpre : f.symm y ∈ H := h (f.symm y) hy'
+    exact (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := y)).mpr hpre
+  apply B.orthogonalComplement_anti hle
+  rw [← f.map_orthogonalComplement (H := H)]
+  exact AddSubgroup.mem_map_of_mem _ hx
+
+/-- An isometry carrying `H` onto `K` carries every element of `H^⊥` into `K^⊥`. -/
+theorem Isometry.map_mem_orthogonalComplement_of_map_eq {B : FiniteBilinearModule}
+    (f : Isometry A B) {H : AddSubgroup A} {K : AddSubgroup B}
+    (h : H.map f.toAddEquiv = K) {x : A} (hx : x ∈ A.orthogonalComplement H) :
+    f x ∈ B.orthogonalComplement K := by
+  rw [← h, ← f.map_orthogonalComplement (H := H)]
+  exact AddSubgroup.mem_map_of_mem _ hx
 
 /-- An isometry transports isotropic subgroups. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -723,35 +723,42 @@ namespace Isometry
 
 variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
 
-/-- The bilinear orthogonal-complement equivalence, with its map rewritten to the underlying map
-of the quadratic isometry. -/
-private def orthogonalComplementEquivAux (f : Isometry A B) (H : AddSubgroup A) :
+/-- The bilinear orthogonal-complement equivalence, with the underlying map normalized to the
+quadratic isometry's additive equivalence. -/
+private def orthogonalComplementEquiv (f : Isometry A B) (H : AddSubgroup A) :
     A.toFiniteBilinearModule.orthogonalComplement H ≃+
-      B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv) :=
-  (f.toAddEquiv.addSubgroupMap (A.toFiniteBilinearModule.orthogonalComplement H)).trans
-    (AddEquiv.addSubgroupCongr
-      (FiniteBilinearModule.Isometry.map_orthogonalComplement A.toFiniteBilinearModule
-        f.toFiniteBilinearModule H))
+      B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv) := by
+  refine (FiniteBilinearModule.Isometry.orthogonalComplementEquiv
+    A.toFiniteBilinearModule f.toFiniteBilinearModule H).trans
+      (AddEquiv.addSubgroupCongr ?_)
+  rw [toFiniteBilinearModule_toAddEquiv]
 
 @[simp]
-private theorem coe_orthogonalComplementEquivAux_apply (f : Isometry A B) (H : AddSubgroup A)
+private theorem coe_orthogonalComplementEquiv_apply (f : Isometry A B) (H : AddSubgroup A)
     (x : A.toFiniteBilinearModule.orthogonalComplement H) :
-    (f.orthogonalComplementEquivAux H x : B) = f (x : A) := by
-  rfl
+    (f.orthogonalComplementEquiv H x : B) = f (x : A) := by
+  simp only [orthogonalComplementEquiv, AddEquiv.trans_apply,
+    AddEquiv.addSubgroupCongr_apply,
+    FiniteBilinearModule.Isometry.coe_orthogonalComplementEquiv_apply]
+  exact congrArg (fun e : A ≃+ B => e (x : A)) f.toFiniteBilinearModule_toAddEquiv
 
 @[simp]
-private theorem coe_orthogonalComplementEquivAux_symm_apply (f : Isometry A B)
+private theorem coe_orthogonalComplementEquiv_symm_apply (f : Isometry A B)
     (H : AddSubgroup A)
     (y : B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv)) :
-    ((f.orthogonalComplementEquivAux H).symm y : A) = f.symm (y : B) := by
-  rfl
+    ((f.orthogonalComplementEquiv H).symm y : A) = f.symm (y : B) := by
+  simp only [orthogonalComplementEquiv, AddEquiv.symm_trans_apply,
+    AddEquiv.addSubgroupCongr_symm_apply,
+    FiniteBilinearModule.Isometry.coe_orthogonalComplementEquiv_symm_apply]
+  change f.toFiniteBilinearModule.symm.toAddEquiv (y : B) = f.toAddEquiv.symm (y : B)
+  rw [FiniteBilinearModule.Isometry.symm_toAddEquiv, toFiniteBilinearModule_toAddEquiv]
 
 /-- The copy of `H` inside `H⊥` is carried onto the copy of the image of `H` inside its orthogonal
 complement. This is the hypothesis which makes the two quotients correspond. -/
 private theorem map_toIntSubmodule_subgroupInOrthogonalComplement (f : Isometry A B)
     (H : AddSubgroup A) :
     (A.subgroupInOrthogonalComplement H).toIntSubmodule.map
-        ((f.orthogonalComplementEquivAux H).toIntLinearEquiv :
+        ((f.orthogonalComplementEquiv H).toIntLinearEquiv :
           A.toFiniteBilinearModule.orthogonalComplement H →ₗ[ℤ]
             B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv)) =
       (B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)).toIntSubmodule := by
@@ -761,11 +768,11 @@ private theorem map_toIntSubmodule_subgroupInOrthogonalComplement (f : Isometry 
   -- membership lemmas concern the underlying additive subgroups.  This `change` crosses that
   -- subtype/coercion boundary so those named lemmas can be used; `rw` cannot unfold the inferred
   -- `Module ℤ` instances far enough to expose the same goal.
-  change (f.orthogonalComplementEquivAux H).symm y ∈
+  change (f.orthogonalComplementEquiv H).symm y ∈
       A.subgroupInOrthogonalComplement H ↔
     y ∈ B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)
   rw [A.mem_subgroupInOrthogonalComplement_iff,
-    B.mem_subgroupInOrthogonalComplement_iff, coe_orthogonalComplementEquivAux_symm_apply]
+    B.mem_subgroupInOrthogonalComplement_iff, coe_orthogonalComplementEquiv_symm_apply]
   exact (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := (y : B))).symm
 
 /-- A quadratic isometry carrying `H` onto `K` transports quadratic isotropy from `H` to `K`. -/
@@ -780,7 +787,7 @@ private noncomputable def orthogonalQuotientMap (f : Isometry A B) (H : AddSubgr
     Isometry (A.orthogonalQuotient H hH)
       (B.orthogonalQuotient (H.map f.toAddEquiv) ((f.isIsotropic_map_iff (H := H)).mpr hH)) where
   toLinearEquiv := Submodule.Quotient.equiv _ _
-    (f.orthogonalComplementEquivAux H).toIntLinearEquiv
+    (f.orthogonalComplementEquiv H).toIntLinearEquiv
     (map_toIntSubmodule_subgroupInOrthogonalComplement f H)
   map_app' q := by
     induction q using orthogonalQuotient_induction_on with
@@ -791,7 +798,7 @@ private noncomputable def orthogonalQuotientMap (f : Isometry A B) (H : AddSubgr
       -- inferred `Module ℤ` instances.
       change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
           ((Submodule.Quotient.equiv _ _
-            (f.orthogonalComplementEquivAux H).toIntLinearEquiv
+            (f.orthogonalComplementEquiv H).toIntLinearEquiv
             (map_toIntSubmodule_subgroupInOrthogonalComplement f H))
             (Submodule.Quotient.mk x)) = A.quadratic (x : A)
       rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
@@ -800,8 +807,8 @@ private noncomputable def orthogonalQuotientMap (f : Isometry A B) (H : AddSubgr
       -- cannot state that bridge without fixing the otherwise definitionally equal module instance.
       change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
           (B.orthogonalQuotientMk (H.map f.toAddEquiv) _
-            (f.orthogonalComplementEquivAux H x)) = A.quadratic (x : A)
-      rw [B.orthogonalQuotient_quadratic_mk, coe_orthogonalComplementEquivAux_apply]
+            (f.orthogonalComplementEquiv H x)) = A.quadratic (x : A)
+      rw [B.orthogonalQuotient_quadratic_mk, coe_orthogonalComplementEquiv_apply]
       exact f.map_app (x : A)
 
 /-- The image-subgroup transport sends the class of `x ∈ H⊥` to the class of `f x`. -/
@@ -811,12 +818,12 @@ private theorem orthogonalQuotientMap_orthogonalQuotientMk (f : Isometry A B)
     (x : A.toFiniteBilinearModule.orthogonalComplement H) :
     f.orthogonalQuotientMap H hH (A.orthogonalQuotientMk H hH x) =
       B.orthogonalQuotientMk (H.map f.toAddEquiv) ((f.isIsotropic_map_iff (H := H)).mpr hH)
-        (f.orthogonalComplementEquivAux H x) := by
+        (f.orthogonalComplementEquiv H x) := by
   -- Both sides are quotient representatives, but their public constructors hide distinct inferred
   -- `Module ℤ` instances.  Crossing that opaque boundary once here lets the Mathlib quotient-map
   -- formulas finish the proof; `rw` or `convert` cannot expose a well-typed named bridge.
   change (Submodule.Quotient.equiv _ _
-      (f.orthogonalComplementEquivAux H).toIntLinearEquiv
+      (f.orthogonalComplementEquiv H).toIntLinearEquiv
       (map_toIntSubmodule_subgroupInOrthogonalComplement f H))
       (Submodule.Quotient.mk x) = Submodule.Quotient.mk _
   rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
@@ -850,7 +857,7 @@ theorem orthogonalQuotientEquiv_orthogonalQuotientMk (f : Isometry A B)
   rw [orthogonalQuotientEquiv, trans_apply, orthogonalQuotientMap_orthogonalQuotientMk,
     B.orthogonalQuotientCongr_orthogonalQuotientMk]
   apply congrArg (B.orthogonalQuotientMk K _)
-  exact Subtype.ext (coe_orthogonalComplementEquivAux_apply f H x)
+  exact Subtype.ext (coe_orthogonalComplementEquiv_apply f H x)
 
 /-- **The inverse representative formula for a transported orthogonal quotient.** The inverse
 transport sends the class of `y ∈ K⊥` to the class of `f.symm y ∈ H⊥`. -/

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -757,6 +757,10 @@ private theorem map_toIntSubmodule_subgroupInOrthogonalComplement (f : Isometry 
       (B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)).toIntSubmodule := by
   ext y
   rw [Submodule.mem_map_equiv]
+  -- `Submodule.mem_map_equiv` exposes the restricted linear equivalence, while the available
+  -- membership lemmas concern the underlying additive subgroups.  This `change` crosses that
+  -- subtype/coercion boundary so those named lemmas can be used; `rw` cannot unfold the inferred
+  -- `Module ℤ` instances far enough to expose the same goal.
   change (f.orthogonalComplementEquivAux H).symm y ∈
       A.subgroupInOrthogonalComplement H ↔
     y ∈ B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)
@@ -781,12 +785,19 @@ private noncomputable def orthogonalQuotientMap (f : Isometry A B) (H : AddSubgr
   map_app' q := by
     induction q using orthogonalQuotient_induction_on with
     | mk x =>
+      -- The quotient is definitionally a `Submodule.Quotient`, but its quadratic map is packaged
+      -- through two exposed finite-quadratic-module constructions.  This `change` reveals the
+      -- quotient representative without asking `rw` or `convert` to identify their distinct
+      -- inferred `Module ℤ` instances.
       change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
           ((Submodule.Quotient.equiv _ _
             (f.orthogonalComplementEquivAux H).toIntLinearEquiv
             (map_toIntSubmodule_subgroupInOrthogonalComplement f H))
             (Submodule.Quotient.mk x)) = A.quadratic (x : A)
       rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+      -- After evaluating the quotient equivalence, the same representation boundary remains
+      -- between `Submodule.Quotient.mk` and the packaged `orthogonalQuotientMk`; named rewriting
+      -- cannot state that bridge without fixing the otherwise definitionally equal module instance.
       change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
           (B.orthogonalQuotientMk (H.map f.toAddEquiv) _
             (f.orthogonalComplementEquivAux H x)) = A.quadratic (x : A)
@@ -801,6 +812,9 @@ private theorem orthogonalQuotientMap_orthogonalQuotientMk (f : Isometry A B)
     f.orthogonalQuotientMap H hH (A.orthogonalQuotientMk H hH x) =
       B.orthogonalQuotientMk (H.map f.toAddEquiv) ((f.isIsotropic_map_iff (H := H)).mpr hH)
         (f.orthogonalComplementEquivAux H x) := by
+  -- Both sides are quotient representatives, but their public constructors hide distinct inferred
+  -- `Module ℤ` instances.  Crossing that opaque boundary once here lets the Mathlib quotient-map
+  -- formulas finish the proof; `rw` or `convert` cannot expose a well-typed named bridge.
   change (Submodule.Quotient.equiv _ _
       (f.orthogonalComplementEquivAux H).toIntLinearEquiv
       (map_toIntSubmodule_subgroupInOrthogonalComplement f H))
@@ -837,6 +851,41 @@ theorem orthogonalQuotientEquiv_orthogonalQuotientMk (f : Isometry A B)
     B.orthogonalQuotientCongr_orthogonalQuotientMk]
   apply congrArg (B.orthogonalQuotientMk K _)
   exact Subtype.ext (coe_orthogonalComplementEquivAux_apply f H x)
+
+/-- **The inverse representative formula for a transported orthogonal quotient.** The inverse
+transport sends the class of `y ∈ K⊥` to the class of `f.symm y ∈ H⊥`. -/
+@[simp]
+theorem orthogonalQuotientEquiv_symm_orthogonalQuotientMk (f : Isometry A B)
+    {H : AddSubgroup A} {K : AddSubgroup B} (hH : A.IsIsotropic H)
+    (h : H.map f.toAddEquiv = K)
+    (y : B.toFiniteBilinearModule.orthogonalComplement K) :
+    (f.orthogonalQuotientEquiv hH h).symm
+        (B.orthogonalQuotientMk K (f.isIsotropic_of_map_eq hH h) y) =
+      A.orthogonalQuotientMk H hH
+        ⟨f.symm (y : B), by
+          apply (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K :=
+            A.toFiniteBilinearModule.orthogonalComplement H) (x := (y : B))).mp
+          have hcomp :
+              (A.toFiniteBilinearModule.orthogonalComplement H).map f.toAddEquiv =
+                B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv) := by
+            simpa only [toFiniteBilinearModule_toAddEquiv] using
+              f.toFiniteBilinearModule.map_orthogonalComplement (H := H)
+          -- `mem_map_equiv` leaves the additive equivalence coerced through its monoid hom;
+          -- normalize that coercion before rewriting with the subgroup equality.
+          change (y : B) ∈
+            (A.toFiniteBilinearModule.orthogonalComplement H).map f.toAddEquiv
+          rw [hcomp, h]
+          exact y.2⟩ := by
+  refine (Equiv.symm_apply_eq
+    (f.orthogonalQuotientEquiv hH h).toLinearEquiv.toEquiv).mpr ?_
+  -- `Equiv.symm_apply_eq` exposes the `toEquiv` coercion; normalize it to the isometry coercion
+  -- so the public forward representative formula applies.
+  change B.orthogonalQuotientMk K (f.isIsotropic_of_map_eq hH h) y =
+    f.orthogonalQuotientEquiv hH h
+      (A.orthogonalQuotientMk H hH ⟨f.symm (y : B), _⟩)
+  rw [orthogonalQuotientEquiv_orthogonalQuotientMk]
+  congr 1
+  exact Subtype.ext (f.apply_symm_apply (y : B)).symm
 
 end Isometry
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -766,17 +766,9 @@ private theorem map_toIntSubmodule_subgroupInOrthogonalComplement (f : Isometry 
       (B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)).toIntSubmodule := by
   ext y
   rw [Submodule.mem_map_equiv]
+  -- The two submodule memberships reduce to the underlying subgroup memberships.
   change f.symm (y : B) ∈ H ↔ (y : B) ∈ H.map (f.toAddEquiv : A →+ B)
-  rw [AddSubgroup.mem_map]
-  constructor
-  · intro hy
-    exact ⟨f.symm (y : B), hy, f.toAddEquiv.apply_symm_apply (y : B)⟩
-  · rintro ⟨a, ha, hay⟩
-    have hya : f.symm (y : B) = a := by
-      rw [← hay]
-      exact f.toAddEquiv.symm_apply_apply a
-    rw [hya]
-    exact ha
+  exact (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := (y : B))).symm
 
 /-- A quadratic isometry which carries a subgroup `H` of `A` onto a subgroup `K` of `B`
 elementwise maps `H` onto `K`. -/
@@ -792,21 +784,22 @@ private theorem map_eq_of_forall_mem_iff (f : Isometry A B) {H : AddSubgroup A}
     rw [f.apply_symm_apply]
     exact hz
 
-/-- An isometry which carries `H` onto `K` carries the orthogonal complement of `H` into the
-orthogonal complement of `K`. -/
+/-- An isometry carries the orthogonal complement of `H` into that of `K` whenever the preimage
+of `K` is contained in `H`. -/
 theorem mem_orthogonalComplement_of_forall_mem_iff (f : Isometry A B) {H : AddSubgroup A}
-    {K : AddSubgroup B} (h : ∀ x : A, f x ∈ K ↔ x ∈ H) {x : A}
+    {K : AddSubgroup B} (h : ∀ x : A, f x ∈ K → x ∈ H) {x : A}
     (hx : x ∈ A.toFiniteBilinearModule.orthogonalComplement H) :
     f x ∈ B.toFiniteBilinearModule.orthogonalComplement K := by
-  rw [B.toFiniteBilinearModule.mem_orthogonalComplement_iff]
-  intro w hw
-  have hsymm : f.symm w ∈ H := (h (f.symm w)).mp (by rw [f.apply_symm_apply]; exact hw)
-  have hpair : B.toFiniteBilinearModule.pairing (f x) (f (f.symm w)) =
-      A.toFiniteBilinearModule.pairing x (f.symm w) :=
-    f.toFiniteBilinearModule.map_pairing x (f.symm w)
-  rw [f.apply_symm_apply] at hpair
-  rw [hpair]
-  exact (A.toFiniteBilinearModule.mem_orthogonalComplement_iff H x).mp hx _ hsymm
+  have hle : K ≤ H.map f.toAddEquiv := by
+    intro y hy
+    have hy' : f (f.symm y) ∈ K := by simpa
+    have hpre : f.symm y ∈ H := h (f.symm y) hy'
+    exact (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := y)).mpr hpre
+  apply B.toFiniteBilinearModule.orthogonalComplement_anti hle
+  rw [← f.map_orthogonalComplement H]
+  change f.toAddEquiv x ∈ (A.toFiniteBilinearModule.orthogonalComplement H).map f.toAddEquiv
+  exact (AddSubgroup.mem_map_iff_mem (f := f.toAddEquiv.toAddMonoidHom)
+    f.toAddEquiv.injective).mpr hx
 
 /-- **Transport of an orthogonal quotient along an isometry.** An isometry `f : A ≅ B` of finite
 quadratic modules which carries a quadratic-isotropic subgroup `H` of `A` onto a subgroup `K` of
@@ -815,8 +808,11 @@ quadratic modules which carries a quadratic-isotropic subgroup `H` of `A` onto a
 The hypothesis is the elementwise form of `H.map f = K`; it is the form in which a lattice
 isometry supplies the correspondence of discriminant subgroups. -/
 noncomputable def orthogonalQuotient (f : Isometry A B) {H : AddSubgroup A} {K : AddSubgroup B}
-    (hH : A.IsIsotropic H) (hK : B.IsIsotropic K) (h : ∀ x : A, f x ∈ K ↔ x ∈ H) :
-    Isometry (A.orthogonalQuotient H hH) (B.orthogonalQuotient K hK) := by
+    (hH : A.IsIsotropic H) (h : ∀ x : A, f x ∈ K ↔ x ∈ H) :
+    Isometry (A.orthogonalQuotient H hH)
+      (B.orthogonalQuotient K (by
+        rw [← f.map_eq_of_forall_mem_iff h, f.isIsotropic_map_iff]
+        exact hH)) := by
   have hmap := f.map_eq_of_forall_mem_iff h
   subst hmap
   exact
@@ -826,24 +822,39 @@ noncomputable def orthogonalQuotient (f : Isometry A B) {H : AddSubgroup A} {K :
       map_app' := fun q ↦ by
         induction q using orthogonalQuotient_induction_on with
         | mk x =>
-          change (B.orthogonalQuotient (H.map f.toAddEquiv) hK).quadratic
-              (B.orthogonalQuotientMk (H.map f.toAddEquiv) hK
-                (f.orthogonalComplementEquiv H x)) = _
-          rw [B.orthogonalQuotient_quadratic_mk, A.orthogonalQuotient_quadratic_mk,
-            coe_orthogonalComplementEquiv_apply]
+          -- Expose the quotient equivalence so its public representative lemmas apply.
+          change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
+              ((Submodule.Quotient.equiv _ _
+                (f.orthogonalComplementEquiv H).toIntLinearEquiv
+                (f.map_toIntSubmodule_subgroupInOrthogonalComplement H))
+                (Submodule.Quotient.mk x)) = A.quadratic (x : A)
+          rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+          -- Repackage the quotient constructor through the public orthogonal-quotient map.
+          change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
+              (B.orthogonalQuotientMk (H.map f.toAddEquiv) _
+                (f.orthogonalComplementEquiv H x)) = A.quadratic (x : A)
+          rw [B.orthogonalQuotient_quadratic_mk, coe_orthogonalComplementEquiv_apply]
           exact f.map_app (x : A) }
 
 /-- **The representative formula for a transported orthogonal quotient.** -/
+@[simp]
 theorem orthogonalQuotient_orthogonalQuotientMk (f : Isometry A B) {H : AddSubgroup A}
-    {K : AddSubgroup B} (hH : A.IsIsotropic H) (hK : B.IsIsotropic K)
-    (h : ∀ x : A, f x ∈ K ↔ x ∈ H) (x : A.toFiniteBilinearModule.orthogonalComplement H)
-    (hx : f (x : A) ∈ B.toFiniteBilinearModule.orthogonalComplement K) :
-    f.orthogonalQuotient hH hK h (A.orthogonalQuotientMk H hH x) =
-      B.orthogonalQuotientMk K hK ⟨f (x : A), hx⟩ := by
-  unfold orthogonalQuotient
+    {K : AddSubgroup B} (hH : A.IsIsotropic H) (h : ∀ x : A, f x ∈ K ↔ x ∈ H)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    f.orthogonalQuotient hH h (A.orthogonalQuotientMk H hH x) =
+      B.orthogonalQuotientMk K (by
+        rw [← f.map_eq_of_forall_mem_iff h, f.isIsotropic_map_iff]
+        exact hH)
+        ⟨f (x : A), f.mem_orthogonalComplement_of_forall_mem_iff (fun y ↦ (h y).mp) x.2⟩ := by
   have hmap := f.map_eq_of_forall_mem_iff h
   subst hmap
-  rfl
+  -- Expose the quotient equivalence so its public representative lemmas apply.
+  change (Submodule.Quotient.equiv _ _
+      (f.orthogonalComplementEquiv H).toIntLinearEquiv
+      (f.map_toIntSubmodule_subgroupInOrthogonalComplement H))
+      (Submodule.Quotient.mk x) = Submodule.Quotient.mk _
+  rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+  congr 1
 
 end Isometry
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -750,8 +750,10 @@ private theorem coe_orthogonalComplementEquiv_symm_apply (f : Isometry A B)
   simp only [orthogonalComplementEquiv, AddEquiv.symm_trans_apply,
     AddEquiv.addSubgroupCongr_symm_apply,
     FiniteBilinearModule.Isometry.coe_orthogonalComplementEquiv_symm_apply]
-  change f.toFiniteBilinearModule.symm.toAddEquiv (y : B) = f.toAddEquiv.symm (y : B)
-  rw [FiniteBilinearModule.Isometry.symm_toAddEquiv, toFiniteBilinearModule_toAddEquiv]
+  rw [← FiniteBilinearModule.Isometry.coe_toAddEquiv,
+    FiniteBilinearModule.Isometry.symm_toAddEquiv, toFiniteBilinearModule_toAddEquiv]
+  exact congrArg (fun e : B ≃ₗ[ℤ] A => e (y : B))
+    (QuadraticMap.IsometryEquiv.coe_symm_toLinearEquiv f)
 
 /-- The copy of `H` inside `H⊥` is carried onto the copy of the image of `H` inside its orthogonal
 complement. This is the hypothesis which makes the two quotients correspond. -/

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -36,6 +36,10 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
   `H^⊥ / H` by a quadratic-isotropic subgroup `H`.
 * `TauCeti.FiniteQuadraticModule.orthogonalQuotientCongr`: the canonical isometry between the
   orthogonal quotients along equal subgroups.
+* `TauCeti.FiniteQuadraticModule.Isometry.orthogonalComplementEquiv`: the equivalence of
+  orthogonal complements restricted from an isometry.
+* `TauCeti.FiniteQuadraticModule.Isometry.orthogonalQuotient`: transport of an orthogonal
+  quotient along an isometry carrying one isotropic subgroup onto another.
 
 ## References
 
@@ -714,6 +718,134 @@ theorem IsNondegenerate.card_orthogonalQuotient_mul_card_sq (hA : A.IsNondegener
   rw [pow_two, ← mul_assoc, hquot, mul_comm]
   exact FiniteBilinearModule.IsNondegenerate.card_mul_card_orthogonalComplement
     A.toFiniteBilinearModule hA H
+
+/-! ### Transport of an orthogonal quotient along an isometry -/
+
+namespace Isometry
+
+variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
+
+/-- A quadratic isometry carries the orthogonal complement of a subgroup onto the orthogonal
+complement of its image. -/
+@[simp]
+theorem map_orthogonalComplement (f : Isometry A B) (H : AddSubgroup A) :
+    (A.toFiniteBilinearModule.orthogonalComplement H).map f.toAddEquiv =
+      B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv) :=
+  FiniteBilinearModule.Isometry.map_orthogonalComplement A.toFiniteBilinearModule
+    f.toFiniteBilinearModule H
+
+/-- A quadratic isometry restricts to an additive equivalence from the orthogonal complement of a
+subgroup onto the orthogonal complement of the image of that subgroup. -/
+def orthogonalComplementEquiv (f : Isometry A B) (H : AddSubgroup A) :
+    A.toFiniteBilinearModule.orthogonalComplement H ≃+
+      B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv) :=
+  (f.toAddEquiv.addSubgroupMap (A.toFiniteBilinearModule.orthogonalComplement H)).trans
+    (AddEquiv.addSubgroupCongr (f.map_orthogonalComplement H))
+
+/-- The restricted equivalence of orthogonal complements acts by the isometry. -/
+@[simp]
+theorem coe_orthogonalComplementEquiv_apply (f : Isometry A B) (H : AddSubgroup A)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    (f.orthogonalComplementEquiv H x : B) = f (x : A) := (rfl)
+
+/-- The inverse of the restricted equivalence of orthogonal complements acts by the inverse
+isometry. -/
+@[simp]
+theorem coe_orthogonalComplementEquiv_symm_apply (f : Isometry A B) (H : AddSubgroup A)
+    (y : B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv)) :
+    ((f.orthogonalComplementEquiv H).symm y : A) = f.symm (y : B) := (rfl)
+
+/-- The copy of `H` inside `H⊥` is carried onto the copy of the image of `H` inside its orthogonal
+complement. This is the hypothesis which makes the two quotients correspond. -/
+private theorem map_toIntSubmodule_subgroupInOrthogonalComplement (f : Isometry A B)
+    (H : AddSubgroup A) :
+    (A.subgroupInOrthogonalComplement H).toIntSubmodule.map
+        ((f.orthogonalComplementEquiv H).toIntLinearEquiv :
+          A.toFiniteBilinearModule.orthogonalComplement H →ₗ[ℤ]
+            B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv)) =
+      (B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)).toIntSubmodule := by
+  ext y
+  rw [Submodule.mem_map_equiv]
+  change f.symm (y : B) ∈ H ↔ (y : B) ∈ H.map (f.toAddEquiv : A →+ B)
+  rw [AddSubgroup.mem_map]
+  constructor
+  · intro hy
+    exact ⟨f.symm (y : B), hy, f.toAddEquiv.apply_symm_apply (y : B)⟩
+  · rintro ⟨a, ha, hay⟩
+    have hya : f.symm (y : B) = a := by
+      rw [← hay]
+      exact f.toAddEquiv.symm_apply_apply a
+    rw [hya]
+    exact ha
+
+/-- A quadratic isometry which carries a subgroup `H` of `A` onto a subgroup `K` of `B`
+elementwise maps `H` onto `K`. -/
+private theorem map_eq_of_forall_mem_iff (f : Isometry A B) {H : AddSubgroup A}
+    {K : AddSubgroup B} (h : ∀ x : A, f x ∈ K ↔ x ∈ H) : H.map f.toAddEquiv = K := by
+  ext z
+  rw [AddSubgroup.mem_map]
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact (h x).mpr hx
+  · intro hz
+    refine ⟨f.symm z, (h (f.symm z)).mp ?_, f.toAddEquiv.apply_symm_apply z⟩
+    rw [f.apply_symm_apply]
+    exact hz
+
+/-- An isometry which carries `H` onto `K` carries the orthogonal complement of `H` into the
+orthogonal complement of `K`. -/
+theorem mem_orthogonalComplement_of_forall_mem_iff (f : Isometry A B) {H : AddSubgroup A}
+    {K : AddSubgroup B} (h : ∀ x : A, f x ∈ K ↔ x ∈ H) {x : A}
+    (hx : x ∈ A.toFiniteBilinearModule.orthogonalComplement H) :
+    f x ∈ B.toFiniteBilinearModule.orthogonalComplement K := by
+  rw [B.toFiniteBilinearModule.mem_orthogonalComplement_iff]
+  intro w hw
+  have hsymm : f.symm w ∈ H := (h (f.symm w)).mp (by rw [f.apply_symm_apply]; exact hw)
+  have hpair : B.toFiniteBilinearModule.pairing (f x) (f (f.symm w)) =
+      A.toFiniteBilinearModule.pairing x (f.symm w) :=
+    f.toFiniteBilinearModule.map_pairing x (f.symm w)
+  rw [f.apply_symm_apply] at hpair
+  rw [hpair]
+  exact (A.toFiniteBilinearModule.mem_orthogonalComplement_iff H x).mp hx _ hsymm
+
+/-- **Transport of an orthogonal quotient along an isometry.** An isometry `f : A ≅ B` of finite
+quadratic modules which carries a quadratic-isotropic subgroup `H` of `A` onto a subgroup `K` of
+`B` induces an isometry `H⊥ / H ≅ K⊥ / K`.
+
+The hypothesis is the elementwise form of `H.map f = K`; it is the form in which a lattice
+isometry supplies the correspondence of discriminant subgroups. -/
+noncomputable def orthogonalQuotient (f : Isometry A B) {H : AddSubgroup A} {K : AddSubgroup B}
+    (hH : A.IsIsotropic H) (hK : B.IsIsotropic K) (h : ∀ x : A, f x ∈ K ↔ x ∈ H) :
+    Isometry (A.orthogonalQuotient H hH) (B.orthogonalQuotient K hK) := by
+  have hmap := f.map_eq_of_forall_mem_iff h
+  subst hmap
+  exact
+    { toLinearEquiv := Submodule.Quotient.equiv _ _
+        (f.orthogonalComplementEquiv H).toIntLinearEquiv
+        (f.map_toIntSubmodule_subgroupInOrthogonalComplement H)
+      map_app' := fun q ↦ by
+        induction q using orthogonalQuotient_induction_on with
+        | mk x =>
+          change (B.orthogonalQuotient (H.map f.toAddEquiv) hK).quadratic
+              (B.orthogonalQuotientMk (H.map f.toAddEquiv) hK
+                (f.orthogonalComplementEquiv H x)) = _
+          rw [B.orthogonalQuotient_quadratic_mk, A.orthogonalQuotient_quadratic_mk,
+            coe_orthogonalComplementEquiv_apply]
+          exact f.map_app (x : A) }
+
+/-- **The representative formula for a transported orthogonal quotient.** -/
+theorem orthogonalQuotient_orthogonalQuotientMk (f : Isometry A B) {H : AddSubgroup A}
+    {K : AddSubgroup B} (hH : A.IsIsotropic H) (hK : B.IsIsotropic K)
+    (h : ∀ x : A, f x ∈ K ↔ x ∈ H) (x : A.toFiniteBilinearModule.orthogonalComplement H)
+    (hx : f (x : A) ∈ B.toFiniteBilinearModule.orthogonalComplement K) :
+    f.orthogonalQuotient hH hK h (A.orthogonalQuotientMk H hH x) =
+      B.orthogonalQuotientMk K hK ⟨f (x : A), hx⟩ := by
+  unfold orthogonalQuotient
+  have hmap := f.map_eq_of_forall_mem_iff h
+  subst hmap
+  rfl
+
+end Isometry
 
 end FiniteQuadraticModule
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -775,18 +775,12 @@ elementwise maps `H` onto `K`. -/
 private theorem map_eq_of_forall_mem_iff (f : Isometry A B) {H : AddSubgroup A}
     {K : AddSubgroup B} (h : ∀ x : A, f x ∈ K ↔ x ∈ H) : H.map f.toAddEquiv = K := by
   ext z
-  rw [AddSubgroup.mem_map]
-  constructor
-  · rintro ⟨x, hx, rfl⟩
-    exact (h x).mpr hx
-  · intro hz
-    refine ⟨f.symm z, (h (f.symm z)).mp ?_, f.toAddEquiv.apply_symm_apply z⟩
-    rw [f.apply_symm_apply]
-    exact hz
+  refine (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := z)).trans ?_
+  simpa using (h (f.symm z)).symm
 
 /-- An isometry carries the orthogonal complement of `H` into that of `K` whenever the preimage
 of `K` is contained in `H`. -/
-theorem mem_orthogonalComplement_of_forall_mem_iff (f : Isometry A B) {H : AddSubgroup A}
+theorem mem_orthogonalComplement_of_forall_mem_imp (f : Isometry A B) {H : AddSubgroup A}
     {K : AddSubgroup B} (h : ∀ x : A, f x ∈ K → x ∈ H) {x : A}
     (hx : x ∈ A.toFiniteBilinearModule.orthogonalComplement H) :
     f x ∈ B.toFiniteBilinearModule.orthogonalComplement K := by
@@ -797,9 +791,7 @@ theorem mem_orthogonalComplement_of_forall_mem_iff (f : Isometry A B) {H : AddSu
     exact (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := y)).mpr hpre
   apply B.toFiniteBilinearModule.orthogonalComplement_anti hle
   rw [← f.map_orthogonalComplement H]
-  change f.toAddEquiv x ∈ (A.toFiniteBilinearModule.orthogonalComplement H).map f.toAddEquiv
-  exact (AddSubgroup.mem_map_iff_mem (f := f.toAddEquiv.toAddMonoidHom)
-    f.toAddEquiv.injective).mpr hx
+  exact AddSubgroup.mem_map_of_mem _ hx
 
 /-- **Transport of an orthogonal quotient along an isometry.** An isometry `f : A ≅ B` of finite
 quadratic modules which carries a quadratic-isotropic subgroup `H` of `A` onto a subgroup `K` of
@@ -845,7 +837,7 @@ theorem orthogonalQuotient_orthogonalQuotientMk (f : Isometry A B) {H : AddSubgr
       B.orthogonalQuotientMk K (by
         rw [← f.map_eq_of_forall_mem_iff h, f.isIsotropic_map_iff]
         exact hH)
-        ⟨f (x : A), f.mem_orthogonalComplement_of_forall_mem_iff (fun y ↦ (h y).mp) x.2⟩ := by
+        ⟨f (x : A), f.mem_orthogonalComplement_of_forall_mem_imp (fun y ↦ (h y).mp) x.2⟩ := by
   have hmap := f.map_eq_of_forall_mem_iff h
   subst hmap
   -- Expose the quotient equivalence so its public representative lemmas apply.

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -36,9 +36,7 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
   `H^⊥ / H` by a quadratic-isotropic subgroup `H`.
 * `TauCeti.FiniteQuadraticModule.orthogonalQuotientCongr`: the canonical isometry between the
   orthogonal quotients along equal subgroups.
-* `TauCeti.FiniteQuadraticModule.Isometry.orthogonalComplementEquiv`: the equivalence of
-  orthogonal complements restricted from an isometry.
-* `TauCeti.FiniteQuadraticModule.Isometry.orthogonalQuotient`: transport of an orthogonal
+* `TauCeti.FiniteQuadraticModule.Isometry.orthogonalQuotientEquiv`: transport of an orthogonal
   quotient along an isometry carrying one isotropic subgroup onto another.
 
 ## References
@@ -725,128 +723,120 @@ namespace Isometry
 
 variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
 
-/-- A quadratic isometry carries the orthogonal complement of a subgroup onto the orthogonal
-complement of its image. -/
-@[simp]
-theorem map_orthogonalComplement (f : Isometry A B) (H : AddSubgroup A) :
-    (A.toFiniteBilinearModule.orthogonalComplement H).map f.toAddEquiv =
-      B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv) :=
-  FiniteBilinearModule.Isometry.map_orthogonalComplement A.toFiniteBilinearModule
-    f.toFiniteBilinearModule H
-
-/-- A quadratic isometry restricts to an additive equivalence from the orthogonal complement of a
-subgroup onto the orthogonal complement of the image of that subgroup. -/
-def orthogonalComplementEquiv (f : Isometry A B) (H : AddSubgroup A) :
+/-- The bilinear orthogonal-complement equivalence, with its map rewritten to the underlying map
+of the quadratic isometry. -/
+private def orthogonalComplementEquivAux (f : Isometry A B) (H : AddSubgroup A) :
     A.toFiniteBilinearModule.orthogonalComplement H ≃+
       B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv) :=
   (f.toAddEquiv.addSubgroupMap (A.toFiniteBilinearModule.orthogonalComplement H)).trans
-    (AddEquiv.addSubgroupCongr (f.map_orthogonalComplement H))
+    (AddEquiv.addSubgroupCongr
+      (FiniteBilinearModule.Isometry.map_orthogonalComplement A.toFiniteBilinearModule
+        f.toFiniteBilinearModule H))
 
-/-- The restricted equivalence of orthogonal complements acts by the isometry. -/
 @[simp]
-theorem coe_orthogonalComplementEquiv_apply (f : Isometry A B) (H : AddSubgroup A)
+private theorem coe_orthogonalComplementEquivAux_apply (f : Isometry A B) (H : AddSubgroup A)
     (x : A.toFiniteBilinearModule.orthogonalComplement H) :
-    (f.orthogonalComplementEquiv H x : B) = f (x : A) := (rfl)
+    (f.orthogonalComplementEquivAux H x : B) = f (x : A) := by
+  rfl
 
-/-- The inverse of the restricted equivalence of orthogonal complements acts by the inverse
-isometry. -/
 @[simp]
-theorem coe_orthogonalComplementEquiv_symm_apply (f : Isometry A B) (H : AddSubgroup A)
+private theorem coe_orthogonalComplementEquivAux_symm_apply (f : Isometry A B)
+    (H : AddSubgroup A)
     (y : B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv)) :
-    ((f.orthogonalComplementEquiv H).symm y : A) = f.symm (y : B) := (rfl)
+    ((f.orthogonalComplementEquivAux H).symm y : A) = f.symm (y : B) := by
+  rfl
 
 /-- The copy of `H` inside `H⊥` is carried onto the copy of the image of `H` inside its orthogonal
 complement. This is the hypothesis which makes the two quotients correspond. -/
 private theorem map_toIntSubmodule_subgroupInOrthogonalComplement (f : Isometry A B)
     (H : AddSubgroup A) :
     (A.subgroupInOrthogonalComplement H).toIntSubmodule.map
-        ((f.orthogonalComplementEquiv H).toIntLinearEquiv :
+        ((f.orthogonalComplementEquivAux H).toIntLinearEquiv :
           A.toFiniteBilinearModule.orthogonalComplement H →ₗ[ℤ]
             B.toFiniteBilinearModule.orthogonalComplement (H.map f.toAddEquiv)) =
       (B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)).toIntSubmodule := by
   ext y
   rw [Submodule.mem_map_equiv]
-  -- The two submodule memberships reduce to the underlying subgroup memberships.
-  change f.symm (y : B) ∈ H ↔ (y : B) ∈ H.map (f.toAddEquiv : A →+ B)
+  change (f.orthogonalComplementEquivAux H).symm y ∈
+      A.subgroupInOrthogonalComplement H ↔
+    y ∈ B.subgroupInOrthogonalComplement (H.map f.toAddEquiv)
+  rw [A.mem_subgroupInOrthogonalComplement_iff,
+    B.mem_subgroupInOrthogonalComplement_iff, coe_orthogonalComplementEquivAux_symm_apply]
   exact (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := (y : B))).symm
 
-/-- A quadratic isometry which carries a subgroup `H` of `A` onto a subgroup `K` of `B`
-elementwise maps `H` onto `K`. -/
-private theorem map_eq_of_forall_mem_iff (f : Isometry A B) {H : AddSubgroup A}
-    {K : AddSubgroup B} (h : ∀ x : A, f x ∈ K ↔ x ∈ H) : H.map f.toAddEquiv = K := by
-  ext z
-  refine (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := z)).trans ?_
-  simpa using (h (f.symm z)).symm
+/-- A quadratic isometry carrying `H` onto `K` transports quadratic isotropy from `H` to `K`. -/
+theorem isIsotropic_of_map_eq (f : Isometry A B) {H : AddSubgroup A} {K : AddSubgroup B}
+    (hH : A.IsIsotropic H) (h : H.map f.toAddEquiv = K) : B.IsIsotropic K := by
+  rw [← h, f.isIsotropic_map_iff]
+  exact hH
 
-/-- An isometry carries the orthogonal complement of `H` into that of `K` whenever the preimage
-of `K` is contained in `H`. -/
-theorem mem_orthogonalComplement_of_forall_mem_imp (f : Isometry A B) {H : AddSubgroup A}
-    {K : AddSubgroup B} (h : ∀ x : A, f x ∈ K → x ∈ H) {x : A}
-    (hx : x ∈ A.toFiniteBilinearModule.orthogonalComplement H) :
-    f x ∈ B.toFiniteBilinearModule.orthogonalComplement K := by
-  have hle : K ≤ H.map f.toAddEquiv := by
-    intro y hy
-    have hy' : f (f.symm y) ∈ K := by simpa
-    have hpre : f.symm y ∈ H := h (f.symm y) hy'
-    exact (AddSubgroup.mem_map_equiv (f := f.toAddEquiv) (K := H) (x := y)).mpr hpre
-  apply B.toFiniteBilinearModule.orthogonalComplement_anti hle
-  rw [← f.map_orthogonalComplement H]
-  exact AddSubgroup.mem_map_of_mem _ hx
-
-/-- **Transport of an orthogonal quotient along an isometry.** An isometry `f : A ≅ B` of finite
-quadratic modules which carries a quadratic-isotropic subgroup `H` of `A` onto a subgroup `K` of
-`B` induces an isometry `H⊥ / H ≅ K⊥ / K`.
-
-The hypothesis is the elementwise form of `H.map f = K`; it is the form in which a lattice
-isometry supplies the correspondence of discriminant subgroups. -/
-noncomputable def orthogonalQuotient (f : Isometry A B) {H : AddSubgroup A} {K : AddSubgroup B}
-    (hH : A.IsIsotropic H) (h : ∀ x : A, f x ∈ K ↔ x ∈ H) :
+/-- The isometry of orthogonal quotients when the target subgroup is exactly the image. -/
+private noncomputable def orthogonalQuotientMap (f : Isometry A B) (H : AddSubgroup A)
+    (hH : A.IsIsotropic H) :
     Isometry (A.orthogonalQuotient H hH)
-      (B.orthogonalQuotient K (by
-        rw [← f.map_eq_of_forall_mem_iff h, f.isIsotropic_map_iff]
-        exact hH)) := by
-  have hmap := f.map_eq_of_forall_mem_iff h
-  subst hmap
-  exact
-    { toLinearEquiv := Submodule.Quotient.equiv _ _
-        (f.orthogonalComplementEquiv H).toIntLinearEquiv
-        (f.map_toIntSubmodule_subgroupInOrthogonalComplement H)
-      map_app' := fun q ↦ by
-        induction q using orthogonalQuotient_induction_on with
-        | mk x =>
-          -- Expose the quotient equivalence so its public representative lemmas apply.
-          change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
-              ((Submodule.Quotient.equiv _ _
-                (f.orthogonalComplementEquiv H).toIntLinearEquiv
-                (f.map_toIntSubmodule_subgroupInOrthogonalComplement H))
-                (Submodule.Quotient.mk x)) = A.quadratic (x : A)
-          rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
-          -- Repackage the quotient constructor through the public orthogonal-quotient map.
-          change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
-              (B.orthogonalQuotientMk (H.map f.toAddEquiv) _
-                (f.orthogonalComplementEquiv H x)) = A.quadratic (x : A)
-          rw [B.orthogonalQuotient_quadratic_mk, coe_orthogonalComplementEquiv_apply]
-          exact f.map_app (x : A) }
+      (B.orthogonalQuotient (H.map f.toAddEquiv) ((f.isIsotropic_map_iff (H := H)).mpr hH)) where
+  toLinearEquiv := Submodule.Quotient.equiv _ _
+    (f.orthogonalComplementEquivAux H).toIntLinearEquiv
+    (map_toIntSubmodule_subgroupInOrthogonalComplement f H)
+  map_app' q := by
+    induction q using orthogonalQuotient_induction_on with
+    | mk x =>
+      change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
+          ((Submodule.Quotient.equiv _ _
+            (f.orthogonalComplementEquivAux H).toIntLinearEquiv
+            (map_toIntSubmodule_subgroupInOrthogonalComplement f H))
+            (Submodule.Quotient.mk x)) = A.quadratic (x : A)
+      rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+      change (B.orthogonalQuotient (H.map f.toAddEquiv) _).quadratic
+          (B.orthogonalQuotientMk (H.map f.toAddEquiv) _
+            (f.orthogonalComplementEquivAux H x)) = A.quadratic (x : A)
+      rw [B.orthogonalQuotient_quadratic_mk, coe_orthogonalComplementEquivAux_apply]
+      exact f.map_app (x : A)
 
-/-- **The representative formula for a transported orthogonal quotient.** -/
+/-- The image-subgroup transport sends the class of `x ∈ H⊥` to the class of `f x`. -/
 @[simp]
-theorem orthogonalQuotient_orthogonalQuotientMk (f : Isometry A B) {H : AddSubgroup A}
-    {K : AddSubgroup B} (hH : A.IsIsotropic H) (h : ∀ x : A, f x ∈ K ↔ x ∈ H)
+private theorem orthogonalQuotientMap_orthogonalQuotientMk (f : Isometry A B)
+    (H : AddSubgroup A) (hH : A.IsIsotropic H)
     (x : A.toFiniteBilinearModule.orthogonalComplement H) :
-    f.orthogonalQuotient hH h (A.orthogonalQuotientMk H hH x) =
-      B.orthogonalQuotientMk K (by
-        rw [← f.map_eq_of_forall_mem_iff h, f.isIsotropic_map_iff]
-        exact hH)
-        ⟨f (x : A), f.mem_orthogonalComplement_of_forall_mem_imp (fun y ↦ (h y).mp) x.2⟩ := by
-  have hmap := f.map_eq_of_forall_mem_iff h
-  subst hmap
-  -- Expose the quotient equivalence so its public representative lemmas apply.
+    f.orthogonalQuotientMap H hH (A.orthogonalQuotientMk H hH x) =
+      B.orthogonalQuotientMk (H.map f.toAddEquiv) ((f.isIsotropic_map_iff (H := H)).mpr hH)
+        (f.orthogonalComplementEquivAux H x) := by
   change (Submodule.Quotient.equiv _ _
-      (f.orthogonalComplementEquiv H).toIntLinearEquiv
-      (f.map_toIntSubmodule_subgroupInOrthogonalComplement H))
+      (f.orthogonalComplementEquivAux H).toIntLinearEquiv
+      (map_toIntSubmodule_subgroupInOrthogonalComplement f H))
       (Submodule.Quotient.mk x) = Submodule.Quotient.mk _
   rw [Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
   congr 1
+
+/-- **Transport of an orthogonal quotient along an isometry.** An isometry `f : A ≅ B` of finite
+quadratic modules carrying a quadratic-isotropic subgroup `H` of `A` onto `K` induces an isometry
+`H⊥ / H ≅ K⊥ / K`. -/
+noncomputable def orthogonalQuotientEquiv (f : Isometry A B) {H : AddSubgroup A}
+    {K : AddSubgroup B} (hH : A.IsIsotropic H) (h : H.map f.toAddEquiv = K) :
+    Isometry (A.orthogonalQuotient H hH)
+      (B.orthogonalQuotient K (f.isIsotropic_of_map_eq hH h)) :=
+  (f.orthogonalQuotientMap H hH).trans
+    (B.orthogonalQuotientCongr ((f.isIsotropic_map_iff (H := H)).mpr hH)
+      (f.isIsotropic_of_map_eq hH h) h)
+
+/-- **The representative formula for a transported orthogonal quotient.** The transported
+isometry sends the class of `x ∈ H⊥` to the class of `f x ∈ K⊥`. -/
+@[simp]
+theorem orthogonalQuotientEquiv_orthogonalQuotientMk (f : Isometry A B)
+    {H : AddSubgroup A} {K : AddSubgroup B} (hH : A.IsIsotropic H)
+    (h : H.map f.toAddEquiv = K)
+    (x : A.toFiniteBilinearModule.orthogonalComplement H) :
+    f.orthogonalQuotientEquiv hH h (A.orthogonalQuotientMk H hH x) =
+      B.orthogonalQuotientMk K (f.isIsotropic_of_map_eq hH h)
+        ⟨f (x : A), by
+          apply FiniteBilinearModule.Isometry.map_mem_orthogonalComplement_of_map_eq
+            A.toFiniteBilinearModule f.toFiniteBilinearModule (K := K) (x := (x : A))
+          · simpa only [toFiniteBilinearModule_toAddEquiv] using h
+          · exact x.2⟩ := by
+  rw [orthogonalQuotientEquiv, trans_apply, orthogonalQuotientMap_orthogonalQuotientMk,
+    B.orthogonalQuotientCongr_orthogonalQuotientMk]
+  apply congrArg (B.orthogonalQuotientMk K _)
+  exact Subtype.ext (coe_orthogonalComplementEquivAux_apply f H x)
 
 end Isometry
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
@@ -35,6 +35,8 @@ The pairing `b_L` is `B(x, y) mod ℤ`; the even-lattice refinement
 * `TauCeti.IntegralLattice.discriminantBilinearModule`: the packaged finite bilinear module.
 * `TauCeti.IntegralLattice.isNondegenerate_discriminantBilinearModule`: nondegeneracy of the
   discriminant pairing.
+* `TauCeti.IntegralLattice.Isometry.map_discriminantPairing`: a lattice isometry preserves the
+  discriminant pairing.
 * `TauCeti.IntegralLattice.Isometry.discriminantBilinearIsometry`: functoriality under lattice
   isometry.
 
@@ -177,8 +179,8 @@ variable [AddCommGroup W] [Module ℚ W]
 variable [AddCommGroup U] [Module ℚ U]
 variable {L : IntegralLattice V} {M : IntegralLattice W} {N : IntegralLattice U}
 
-/-- An integral-lattice isometry preserves the discriminant pairing. -/
-private theorem map_discriminantPairing (e : Isometry L M) (x y : L.DiscriminantGroup) :
+/-- **An integral-lattice isometry preserves the discriminant pairing.** -/
+theorem map_discriminantPairing (e : Isometry L M) (x y : L.DiscriminantGroup) :
     M.discriminantPairing (e.discriminantGroupEquiv x) (e.discriminantGroupEquiv y) =
       L.discriminantPairing x y := by
   induction x using Submodule.Quotient.induction_on with

--- a/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Discriminant/Bilinear.lean
@@ -35,8 +35,6 @@ The pairing `b_L` is `B(x, y) mod ℤ`; the even-lattice refinement
 * `TauCeti.IntegralLattice.discriminantBilinearModule`: the packaged finite bilinear module.
 * `TauCeti.IntegralLattice.isNondegenerate_discriminantBilinearModule`: nondegeneracy of the
   discriminant pairing.
-* `TauCeti.IntegralLattice.Isometry.map_discriminantPairing`: a lattice isometry preserves the
-  discriminant pairing.
 * `TauCeti.IntegralLattice.Isometry.discriminantBilinearIsometry`: functoriality under lattice
   isometry.
 
@@ -179,8 +177,8 @@ variable [AddCommGroup W] [Module ℚ W]
 variable [AddCommGroup U] [Module ℚ U]
 variable {L : IntegralLattice V} {M : IntegralLattice W} {N : IntegralLattice U}
 
-/-- **An integral-lattice isometry preserves the discriminant pairing.** -/
-theorem map_discriminantPairing (e : Isometry L M) (x y : L.DiscriminantGroup) :
+/-- An integral-lattice isometry preserves the discriminant pairing. -/
+private theorem map_discriminantPairing (e : Isometry L M) (x y : L.DiscriminantGroup) :
     M.discriminantPairing (e.discriminantGroupEquiv x) (e.discriminantGroupEquiv y) =
       L.discriminantPairing x y := by
   induction x using Submodule.Quotient.induction_on with

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Naturality.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Naturality.lean
@@ -425,6 +425,21 @@ theorem toIntegralLatticeIsometry_apply (e : Isometry L M) {P : L.IntermediateCa
     (hP : IntermediateCarrier.IsIntegral P) (x : V) :
     e.toIntegralLatticeIsometry hP x = e x := (rfl)
 
+/-- The inverse restricted isometry of integral overlattices acts by the inverse ambient
+equivalence. -/
+@[simp]
+theorem toIntegralLatticeIsometry_symm_apply (e : Isometry L M) {P : L.IntermediateCarrier}
+    (hP : IntermediateCarrier.IsIntegral P) (y : W) :
+    (e.toIntegralLatticeIsometry hP).symm y = e.symm y := by
+  calc
+    (e.toIntegralLatticeIsometry hP).symm y =
+        e.symm (e ((e.toIntegralLatticeIsometry hP).symm y)) :=
+      (e.symm_apply_apply _).symm
+    _ = e.symm (e.toIntegralLatticeIsometry hP
+        ((e.toIntegralLatticeIsometry hP).symm y)) := by
+      rw [toIntegralLatticeIsometry_apply]
+    _ = e.symm y := by rw [Isometry.apply_symm_apply]
+
 end Nondegenerate
 
 end Isometry

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Naturality.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Naturality.lean
@@ -43,13 +43,16 @@ even, exactly when both components are.
   `IntegralLattice.Isometry.intermediateCarrierEquiv_intermediateCarrierOfDiscriminantSubgroup`:
   the transport commutes with the discriminant-subgroup correspondence and with its inverse-image
   construction.
+* `Isometry.orthogonalComplement_discriminantSubgroup_intermediateCarrierEquiv`:
+  transport carries the orthogonal complements of corresponding discriminant subgroups to one
+  another.
 * `TauCeti.IntegralLattice.Isometry.isIntegral_intermediateCarrierEquiv_iff` and
   `TauCeti.IntegralLattice.Isometry.isEven_intermediateCarrierEquiv_iff`: integrality and evenness
   of an intermediate carrier are isometry invariants.
 * `TauCeti.IntegralLattice.Isometry.integralIntermediateCarrierEquiv` and
   `TauCeti.IntegralLattice.Isometry.evenIntermediateCarrierEquiv`: the corresponding transports
   restricted to integral and even intermediate carriers.
-* `TauCeti.IntegralLattice.Isometry.intermediateCarrierIsometry`: the induced isometry between
+* `TauCeti.IntegralLattice.Isometry.toIntegralLatticeIsometry`: the induced isometry between
   the integral lattices carried by an integral intermediate carrier and by its transport.
 * `TauCeti.IntegralLattice.orthogonalSumIntermediateCarrier`: the intermediate carrier of an
   orthogonal sum assembled from a pair of intermediate carriers.
@@ -170,6 +173,16 @@ theorem mem_discriminantSubgroup_intermediateCarrierEquiv_iff (e : Isometry L M)
       discriminantGroupEquiv_symm_mk, L.mk_mem_discriminantSubgroup_iff,
       coe_dualCarrierEquiv_apply]
 
+/-- A discriminant class lies in the subgroup of a transported carrier exactly when its image
+under the induced discriminant equivalence lies in that subgroup. -/
+theorem discriminantGroupEquiv_mem_discriminantSubgroup_iff (e : Isometry L M)
+    (P : L.IntermediateCarrier) (x : L.DiscriminantGroup) :
+    e.discriminantGroupEquiv x ∈ M.discriminantSubgroup (e.intermediateCarrierEquiv P) ↔
+      x ∈ L.discriminantSubgroup P := by
+  have h := mem_discriminantSubgroup_intermediateCarrierEquiv_iff e P
+    (e.discriminantGroupEquiv x)
+  rwa [LinearEquiv.symm_apply_apply] at h
+
 /-- **The transport commutes with the discriminant-subgroup correspondence.** The subgroup of
 `A_M` attached to a transported intermediate carrier is the image, under the induced equivalence
 of discriminant groups, of the subgroup of `A_L` attached to the original carrier. -/
@@ -186,6 +199,37 @@ theorem discriminantSubgroup_intermediateCarrierEquiv (e : Isometry L M)
     simp
   · rintro ⟨z, hz, rfl⟩
     simpa using hz
+
+section Nondegenerate
+
+variable [L.IsNondegenerate] [M.IsNondegenerate]
+
+/-- **An isometry carries the orthogonal complements of corresponding discriminant subgroups to
+one another.** -/
+@[simp]
+theorem orthogonalComplement_discriminantSubgroup_intermediateCarrierEquiv
+    (e : Isometry L M) (P : L.IntermediateCarrier) :
+    (L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P)).map
+        (e.discriminantGroupEquiv.toAddEquiv :
+          L.DiscriminantGroup →+ M.DiscriminantGroup) =
+      M.discriminantBilinearModule.orthogonalComplement
+        (M.discriminantSubgroup (e.intermediateCarrierEquiv P)) := by
+  rw [discriminantSubgroup_intermediateCarrierEquiv,
+    ← discriminantBilinearIsometry_toAddEquiv]
+  exact e.discriminantBilinearIsometry.map_orthogonalComplement
+    (H := L.discriminantSubgroup P)
+
+/-- A discriminant class is orthogonal to the subgroup of an intermediate carrier exactly when
+its image is orthogonal to the subgroup of the transported carrier. -/
+theorem discriminantGroupEquiv_mem_orthogonalComplement_iff
+    (e : Isometry L M) (P : L.IntermediateCarrier) (x : L.DiscriminantGroup) :
+    e.discriminantGroupEquiv x ∈ M.discriminantBilinearModule.orthogonalComplement
+        (M.discriminantSubgroup (e.intermediateCarrierEquiv P)) ↔
+      x ∈ L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P) := by
+  rw [← e.orthogonalComplement_discriminantSubgroup_intermediateCarrierEquiv P]
+  exact AddSubgroup.mem_map_iff_mem e.discriminantGroupEquiv.injective
+
+end Nondegenerate
 
 /-- **The transport commutes with the inverse-image construction.** Transporting the carrier
 `L_H` attached to a subgroup `H ≤ A_L` gives the carrier attached to the image of `H` in
@@ -361,7 +405,7 @@ variable [L.IsNondegenerate] [M.IsNondegenerate]
 /-- **An isometry restricts to an isometry of integral overlattices.** The lattice carried by an
 integral intermediate carrier and the lattice carried by its transport are isometric through the
 same ambient rational equivalence. -/
-def intermediateCarrierIsometry (e : Isometry L M) {P : L.IntermediateCarrier}
+def toIntegralLatticeIsometry (e : Isometry L M) {P : L.IntermediateCarrier}
     (hP : IntermediateCarrier.IsIntegral P) :
     Isometry hP.toIntegralLattice
       ((e.isIntegral_intermediateCarrierEquiv_iff P).mpr hP).toIntegralLattice where
@@ -377,9 +421,9 @@ def intermediateCarrierIsometry (e : Isometry L M) {P : L.IntermediateCarrier}
 
 /-- The restricted isometry of integral overlattices acts by the ambient equivalence. -/
 @[simp]
-theorem intermediateCarrierIsometry_apply (e : Isometry L M) {P : L.IntermediateCarrier}
+theorem toIntegralLatticeIsometry_apply (e : Isometry L M) {P : L.IntermediateCarrier}
     (hP : IntermediateCarrier.IsIntegral P) (x : V) :
-    e.intermediateCarrierIsometry hP x = e x := (rfl)
+    e.toIntegralLatticeIsometry hP x = e x := (rfl)
 
 end Nondegenerate
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Naturality.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/Naturality.lean
@@ -26,6 +26,10 @@ invariants of the transport, so the two refined correspondences are natural as w
 nondegenerate lattices, orthogonal complements and isotropy transport directly through the
 generic finite-bilinear-module API applied to the induced discriminant bilinear isometry.
 
+The ambient equivalence also restricts to an isometry between the lattice carried by an integral
+intermediate carrier and the lattice carried by its transport, which is what lets the discriminant
+constructions of the overlattices themselves be compared.
+
 For an orthogonal direct sum, a pair of intermediate carriers assembles into the intermediate
 carrier `P₁ ⊕ P₂` of `L ⊥ M`, order-embedding the pairs into the carriers of the sum. Its
 subgroup of `A_(L ⊥ M) ≃ A_L × A_M` is the product subgroup, and it is integral, respectively
@@ -45,6 +49,8 @@ even, exactly when both components are.
 * `TauCeti.IntegralLattice.Isometry.integralIntermediateCarrierEquiv` and
   `TauCeti.IntegralLattice.Isometry.evenIntermediateCarrierEquiv`: the corresponding transports
   restricted to integral and even intermediate carriers.
+* `TauCeti.IntegralLattice.Isometry.intermediateCarrierIsometry`: the induced isometry between
+  the integral lattices carried by an integral intermediate carrier and by its transport.
 * `TauCeti.IntegralLattice.orthogonalSumIntermediateCarrier`: the intermediate carrier of an
   orthogonal sum assembled from a pair of intermediate carriers.
 * `TauCeti.IntegralLattice.map_discriminantSubgroup_orthogonalSumIntermediateCarrier` and
@@ -345,6 +351,37 @@ theorem evenIntermediateCarrierEquiv_trans (e : Isometry L M) (f : Isometry M N)
     (e.trans f).evenIntermediateCarrierEquiv =
       e.evenIntermediateCarrierEquiv.trans f.evenIntermediateCarrierEquiv :=
   RelIso.ext fun P ↦ Subtype.ext (by simp)
+
+/-! ## Transport of the attached overlattice -/
+
+section Nondegenerate
+
+variable [L.IsNondegenerate] [M.IsNondegenerate]
+
+/-- **An isometry restricts to an isometry of integral overlattices.** The lattice carried by an
+integral intermediate carrier and the lattice carried by its transport are isometric through the
+same ambient rational equivalence. -/
+def intermediateCarrierIsometry (e : Isometry L M) {P : L.IntermediateCarrier}
+    (hP : IntermediateCarrier.IsIntegral P) :
+    Isometry hP.toIntegralLattice
+      ((e.isIntegral_intermediateCarrierEquiv_iff P).mpr hP).toIntegralLattice where
+  toLinearEquiv := (e : V ≃ₗ[ℚ] W)
+  map_app' x y := by
+    simp only [IntermediateCarrier.IsIntegral.toIntegralLattice_form]
+    exact e.map_app x y
+  map_carrier := by
+    simp only [IntermediateCarrier.IsIntegral.toIntegralLattice_carrier,
+      intermediateCarrierEquiv_apply_coe]
+    refine congrArg (fun f ↦ Submodule.map f (P : Submodule ℤ V)) (LinearMap.ext fun x ↦ ?_)
+    simp
+
+/-- The restricted isometry of integral overlattices acts by the ambient equivalence. -/
+@[simp]
+theorem intermediateCarrierIsometry_apply (e : Isometry L M) {P : L.IntermediateCarrier}
+    (hP : IntermediateCarrier.IsIntegral P) (x : V) :
+    e.intermediateCarrierIsometry hP x = e x := (rfl)
+
+end Nondegenerate
 
 end Isometry
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -314,17 +314,6 @@ section Naturality
 
 variable {W : Type*} [AddCommGroup W] [Module ℚ W] {L' : IntegralLattice W} [L'.IsNondegenerate]
 
-/-- Orthogonality to the subgroup of an intermediate carrier, read in the discriminant group.
-
-The carrier of `L.discriminantBilinearModule` is `L.DiscriminantGroup` by definition only, and
-`discriminantBilinearModule` is a plain definition, so no rewrite can move a membership statement
-between the two spellings; this restatement performs the identification once, by `exact`. -/
-private theorem mem_orthogonalComplement_discriminantSubgroup_iff (L : IntegralLattice V)
-    [L.IsNondegenerate] (P : L.IntermediateCarrier) (x : L.DiscriminantGroup) :
-    x ∈ L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P) ↔
-      ∀ y ∈ L.discriminantSubgroup P, L.discriminantPairing x y = 0 :=
-  L.discriminantBilinearModule.mem_orthogonalComplement_iff _ x
-
 namespace Isometry
 
 /-- **The discriminant-subgroup correspondence is natural.** A discriminant class of `L` lies in
@@ -348,18 +337,17 @@ theorem discriminantGroupEquiv_mem_orthogonalComplement_iff
     e.discriminantGroupEquiv x ∈ L'.discriminantBilinearModule.orthogonalComplement
         (L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) ↔
       x ∈ L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P) := by
-  rw [mem_orthogonalComplement_discriminantSubgroup_iff,
-    mem_orthogonalComplement_discriminantSubgroup_iff]
-  constructor
-  · intro h y hy
-    rw [← e.map_discriminantPairing x y]
-    refine h _ ?_
-    rw [mem_discriminantSubgroup_intermediateCarrierEquiv_iff, LinearEquiv.symm_apply_apply]
-    exact hy
-  · intro h y hy
-    rw [mem_discriminantSubgroup_intermediateCarrierEquiv_iff] at hy
-    rw [← e.discriminantGroupEquiv.apply_symm_apply y, e.map_discriminantPairing]
-    exact h _ hy
+  -- The carrier of `discriminantBilinearModule` is `DiscriminantGroup` by definition only, so the
+  -- transporting map is ascribed and the two spellings are bridged by `exact`.
+  have hmap : (L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P)).map
+        (e.discriminantGroupEquiv.toAddEquiv : L.DiscriminantGroup →+ L'.DiscriminantGroup) =
+      L'.discriminantBilinearModule.orthogonalComplement
+        (L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) := by
+    rw [discriminantSubgroup_intermediateCarrierEquiv,
+      ← discriminantBilinearIsometry_toAddEquiv]
+    exact e.discriminantBilinearIsometry.map_orthogonalComplement (H := L.discriminantSubgroup P)
+  rw [← hmap]
+  exact AddSubgroup.mem_map_iff_mem e.discriminantGroupEquiv.injective
 
 /-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`, on a discriminant class.** -/
 theorem discriminantOrthogonalQuotientIsometry_naturality_apply (e : Isometry L L')

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -61,9 +61,6 @@ not yet have.
   `H⊥ / H` is the discriminant of `M`.
 * `TauCeti.IntegralLattice.IntermediateCarrier.subsingleton_orthogonalQuotient_iff_isUnimodular`:
   `M` is unimodular exactly when `H⊥ / H` is trivial.
-* `TauCeti.IntegralLattice.Isometry.discriminantGroupEquiv_mem_orthogonalComplement_iff`:
-  an isometry carries the orthogonal complements of corresponding discriminant subgroups to one
-  another.
 * `TauCeti.IntegralLattice.Isometry.discriminantOrthogonalQuotientIsometry_naturality`: the
   comparison isometry is natural under a lattice isometry.
 * `TauCeti.IntegralLattice.discriminantOrthogonalQuotientIsometryOfSubgroup`: the same isometry
@@ -303,98 +300,9 @@ theorem subsingleton_orthogonalQuotient_iff_isUnimodular :
 
 end IntermediateCarrier
 
-/-! ## The comparison isometry read on subgroups -/
-
 open IntermediateCarrier
 
-/-! ## Naturality under a lattice isometry -/
-
-section Naturality
-
-variable {W : Type*} [AddCommGroup W] [Module ℚ W] {L' : IntegralLattice W} [L'.IsNondegenerate]
-
-namespace Isometry
-
-/-- **The discriminant-subgroup correspondence is natural.** A discriminant class of `L` lies in
-the subgroup attached to an intermediate carrier exactly when its image under the induced
-discriminant isometry lies in the subgroup attached to the transported carrier. -/
-theorem discriminantQuadraticIsometry_mem_discriminantSubgroup_iff (e : Isometry L L')
-    (hL : L.IsEven) (P : L.IntermediateCarrier) (x : L.DiscriminantGroup) :
-    e.discriminantQuadraticIsometry hL x ∈
-        L'.discriminantSubgroup (e.intermediateCarrierEquiv P) ↔
-      x ∈ L.discriminantSubgroup P := by
-  have h := mem_discriminantSubgroup_intermediateCarrierEquiv_iff e P (e.discriminantGroupEquiv x)
-  rw [LinearEquiv.symm_apply_apply] at h
-  rw [discriminantQuadraticIsometry_apply]
-  exact h
-
-/-- **An isometry carries the orthogonal complements of corresponding discriminant subgroups to
-one another.** A discriminant class of `L` is orthogonal to the subgroup of an intermediate
-carrier exactly when its image is orthogonal to the subgroup of the transported carrier. -/
-theorem discriminantGroupEquiv_mem_orthogonalComplement_iff
-    (e : Isometry L L') (P : L.IntermediateCarrier) (x : L.DiscriminantGroup) :
-    e.discriminantGroupEquiv x ∈ L'.discriminantBilinearModule.orthogonalComplement
-        (L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) ↔
-      x ∈ L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P) := by
-  -- The carrier of `discriminantBilinearModule` is `DiscriminantGroup` by definition only, so the
-  -- transporting map is ascribed and the two spellings are bridged by `exact`.
-  have hmap : (L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P)).map
-        (e.discriminantGroupEquiv.toAddEquiv : L.DiscriminantGroup →+ L'.DiscriminantGroup) =
-      L'.discriminantBilinearModule.orthogonalComplement
-        (L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) := by
-    rw [discriminantSubgroup_intermediateCarrierEquiv,
-      ← discriminantBilinearIsometry_toAddEquiv]
-    exact e.discriminantBilinearIsometry.map_orthogonalComplement (H := L.discriminantSubgroup P)
-  rw [← hmap]
-  exact AddSubgroup.mem_map_iff_mem e.discriminantGroupEquiv.injective
-
-/-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`, on a discriminant class.** -/
-theorem discriminantOrthogonalQuotientIsometry_naturality_apply (e : Isometry L L')
-    (hL : L.IsEven) {P : L.IntermediateCarrier} (hP : IntermediateCarrier.IsEven P)
-    (q : hP.isIntegral.toIntegralLattice.DiscriminantGroup) :
-    (e.discriminantQuadraticIsometry hL).orthogonalQuotient
-        ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)
-        (e.discriminantQuadraticIsometry_mem_discriminantSubgroup_iff hL P)
-        (discriminantOrthogonalQuotientIsometry hL hP q) =
-      discriminantOrthogonalQuotientIsometry (e.isEven_iff.mp hL)
-        ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP)
-        ((e.intermediateCarrierIsometry hP.isIntegral).discriminantQuadraticIsometry
-          hP.isEven_toIntegralLattice q) := by
-  induction q using Submodule.Quotient.induction_on with
-  | _ y =>
-    rw [discriminantOrthogonalQuotientIsometry_mk, discriminantQuadraticIsometry_mk,
-      discriminantOrthogonalQuotientIsometry_mk]
-    refine Eq.trans (FiniteQuadraticModule.Isometry.orthogonalQuotient_orthogonalQuotientMk
-      _ _ _ _) ?_
-    have hclass : (e.discriminantQuadraticIsometry hL) (hP.isIntegral.dualClassHom y) =
-          ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP).isIntegral.dualClassHom
-            ((e.intermediateCarrierIsometry hP.isIntegral).dualCarrierEquiv y) := by
-      rw [discriminantQuadraticIsometry_apply,
-        IntermediateCarrier.IsIntegral.dualClassHom_apply, discriminantGroupEquiv_mk,
-        IntermediateCarrier.IsIntegral.dualClassHom_apply]
-      exact congrArg _ (Subtype.ext (by simp))
-    exact congrArg _ (Subtype.ext hclass)
-
-/-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`.** An isometry `e : L ≅ L'` of even
-nondegenerate lattices transports an even intermediate carrier `P` of `L` to one of `L'`, and the
-square built from the two comparison isometries, the induced isometry of the discriminant
-quadratic modules of the two overlattices, and the transported orthogonal quotient commutes. -/
-theorem discriminantOrthogonalQuotientIsometry_naturality (e : Isometry L L') (hL : L.IsEven)
-    {P : L.IntermediateCarrier} (hP : IntermediateCarrier.IsEven P) :
-    ((e.intermediateCarrierIsometry hP.isIntegral).discriminantQuadraticIsometry
-          hP.isEven_toIntegralLattice).trans
-        (discriminantOrthogonalQuotientIsometry (e.isEven_iff.mp hL)
-          ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP)) =
-        (discriminantOrthogonalQuotientIsometry hL hP).trans
-        ((e.discriminantQuadraticIsometry hL).orthogonalQuotient
-          ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)
-          (e.discriminantQuadraticIsometry_mem_discriminantSubgroup_iff hL P)) :=
-  DFunLike.ext _ _ fun q ↦
-    (e.discriminantOrthogonalQuotientIsometry_naturality_apply hL hP q).symm
-
-end Isometry
-
-end Naturality
+/-! ## The comparison isometry read on subgroups -/
 
 variable (L)
 
@@ -454,6 +362,70 @@ theorem natCard_orthogonalQuotient_of_subgroup (hL : L.IsEven)
   exact (Nat.card_congr (L.discriminantOrthogonalQuotientIsometryOfSubgroup hL
       hH).toLinearEquiv.toEquiv).symm.trans
     hM.isIntegral.toIntegralLattice.natCard_discriminantGroup
+
+variable {L}
+
+/-! ## Naturality under a lattice isometry -/
+
+section Naturality
+
+variable {W : Type*} [AddCommGroup W] [Module ℚ W] {L' : IntegralLattice W} [L'.IsNondegenerate]
+
+namespace Isometry
+
+/-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`, on a discriminant class.** The
+equation identifies comparison after transport on `A_M` with transport after comparison. -/
+theorem discriminantOrthogonalQuotientIsometry_naturality_apply (e : Isometry L L')
+    (hL : L.IsEven) {P : L.IntermediateCarrier} (hP : IntermediateCarrier.IsEven P)
+    (q : hP.isIntegral.toIntegralLattice.DiscriminantGroup) :
+    discriminantOrthogonalQuotientIsometry (e.isEven_iff.mp hL)
+        ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP)
+        ((e.toIntegralLatticeIsometry hP.isIntegral).discriminantQuadraticIsometry
+          hP.isEven_toIntegralLattice q) =
+      (e.discriminantQuadraticIsometry hL).orthogonalQuotientEquiv
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)
+        (by
+          rw [discriminantQuadraticIsometry_toAddEquiv]
+          exact (e.discriminantSubgroup_intermediateCarrierEquiv P).symm)
+        (discriminantOrthogonalQuotientIsometry hL hP q) := by
+  symm
+  induction q using Submodule.Quotient.induction_on with
+  | _ y =>
+    rw [discriminantOrthogonalQuotientIsometry_mk, discriminantQuadraticIsometry_mk,
+      discriminantOrthogonalQuotientIsometry_mk]
+    refine Eq.trans (FiniteQuadraticModule.Isometry.orthogonalQuotientEquiv_orthogonalQuotientMk
+      _ _ _ _) ?_
+    have hclass : (e.discriminantQuadraticIsometry hL) (hP.isIntegral.dualClassHom y) =
+          ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP).isIntegral.dualClassHom
+            ((e.toIntegralLatticeIsometry hP.isIntegral).dualCarrierEquiv y) := by
+      rw [discriminantQuadraticIsometry_apply,
+        IntermediateCarrier.IsIntegral.dualClassHom_apply, discriminantGroupEquiv_mk,
+        IntermediateCarrier.IsIntegral.dualClassHom_apply]
+      exact congrArg _ (Subtype.ext (by simp))
+    exact congrArg _ (Subtype.ext hclass)
+
+/-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`.** An isometry `e : L ≅ L'` of even
+nondegenerate lattices transports an even intermediate carrier `P` of `L` to one of `L'`, and the
+square built from the two comparison isometries, the induced isometry of the discriminant
+quadratic modules of the two overlattices, and the transported orthogonal quotient commutes. -/
+theorem discriminantOrthogonalQuotientIsometry_naturality (e : Isometry L L') (hL : L.IsEven)
+    {P : L.IntermediateCarrier} (hP : IntermediateCarrier.IsEven P) :
+    ((e.toIntegralLatticeIsometry hP.isIntegral).discriminantQuadraticIsometry
+          hP.isEven_toIntegralLattice).trans
+        (discriminantOrthogonalQuotientIsometry (e.isEven_iff.mp hL)
+          ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP)) =
+        (discriminantOrthogonalQuotientIsometry hL hP).trans
+        ((e.discriminantQuadraticIsometry hL).orthogonalQuotientEquiv
+          ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)
+          (by
+            rw [discriminantQuadraticIsometry_toAddEquiv]
+            exact (e.discriminantSubgroup_intermediateCarrierEquiv P).symm)) :=
+  DFunLike.ext _ _ fun q ↦
+    e.discriminantOrthogonalQuotientIsometry_naturality_apply hL hP q
+
+end Isometry
+
+end Naturality
 
 end IntegralLattice
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -337,32 +337,22 @@ theorem discriminantGroupEquiv_mem_orthogonalComplement_iff
     e.discriminantGroupEquiv x ∈ L'.discriminantBilinearModule.orthogonalComplement
         (L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) ↔
       x ∈ L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P) := by
-  have hmem : ∀ u : L.DiscriminantGroup, u ∈ L.discriminantSubgroup P →
-      e.discriminantGroupEquiv u ∈
-        L'.discriminantSubgroup (e.intermediateCarrierEquiv P) := by
-    intro u hu
-    rw [mem_discriminantSubgroup_intermediateCarrierEquiv_iff, LinearEquiv.symm_apply_apply]
-    exact hu
-  constructor
-  · intro hx
-    refine (L.discriminantBilinearModule.mem_orthogonalComplement_iff _ x).mpr fun w hw ↦ ?_
-    refine (L.discriminantBilinearModule_pairing x w).trans ?_
-    refine (e.map_discriminantPairing x w).symm.trans ?_
-    exact (L'.discriminantBilinearModule_pairing _ _).symm.trans
-      ((L'.discriminantBilinearModule.mem_orthogonalComplement_iff _ _).mp hx _ (hmem w hw))
-  · intro hx
-    refine (L'.discriminantBilinearModule.mem_orthogonalComplement_iff _ _).mpr fun w hw ↦ ?_
-    refine (L'.discriminantBilinearModule_pairing _ w).trans ?_
-    have hw₂ : e.discriminantGroupEquiv.symm w ∈ L.discriminantSubgroup P :=
-      (mem_discriminantSubgroup_intermediateCarrierEquiv_iff e P w).mp hw
-    have hx₂ : L.discriminantPairing x (e.discriminantGroupEquiv.symm w) = 0 :=
-      (L.discriminantBilinearModule_pairing _ _).symm.trans
-        ((L.discriminantBilinearModule.mem_orthogonalComplement_iff _ x).mp hx _ hw₂)
-    have hcancel : e.discriminantGroupEquiv (e.discriminantGroupEquiv.symm w) = w :=
-      e.discriminantGroupEquiv.apply_symm_apply w
-    have hstep := e.map_discriminantPairing x (e.discriminantGroupEquiv.symm w)
-    rw [hcancel] at hstep
-    exact hstep.trans hx₂
+  rw [← e.discriminantBilinearIsometry_apply x]
+  change e.discriminantBilinearIsometry x ∈
+      L'.discriminantBilinearModule.orthogonalComplement
+        (show AddSubgroup L'.discriminantBilinearModule from
+          L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) ↔
+    x ∈ L.discriminantBilinearModule.orthogonalComplement
+      (show AddSubgroup L.discriminantBilinearModule from L.discriminantSubgroup P)
+  have hmap :
+      (show AddSubgroup L.discriminantBilinearModule from L.discriminantSubgroup P).map
+          e.discriminantBilinearIsometry.toAddEquiv =
+        (show AddSubgroup L'.discriminantBilinearModule from
+          L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) := by
+    rw [e.discriminantBilinearIsometry_toAddEquiv]
+    exact (discriminantSubgroup_intermediateCarrierEquiv e P).symm
+  rw [← hmap, ← e.discriminantBilinearIsometry.map_orthogonalComplement]
+  exact AddSubgroup.mem_map_iff_mem e.discriminantBilinearIsometry.toAddEquiv.injective
 
 /-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`, on a discriminant class.** -/
 theorem discriminantOrthogonalQuotientIsometry_naturality_apply (e : Isometry L L')
@@ -370,9 +360,6 @@ theorem discriminantOrthogonalQuotientIsometry_naturality_apply (e : Isometry L 
     (q : hP.isIntegral.toIntegralLattice.DiscriminantGroup) :
     (e.discriminantQuadraticIsometry hL).orthogonalQuotient
         ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)
-        ((isEven_iff_isIsotropic_discriminantSubgroup (e.isEven_iff.mp hL)
-            (e.intermediateCarrierEquiv P)).mp
-          ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP))
         (e.discriminantQuadraticIsometry_mem_discriminantSubgroup_iff hL P)
         (discriminantOrthogonalQuotientIsometry hL hP q) =
       discriminantOrthogonalQuotientIsometry (e.isEven_iff.mp hL)
@@ -384,18 +371,15 @@ theorem discriminantOrthogonalQuotientIsometry_naturality_apply (e : Isometry L 
     rw [discriminantOrthogonalQuotientIsometry_mk, discriminantQuadraticIsometry_mk,
       discriminantOrthogonalQuotientIsometry_mk]
     refine Eq.trans (FiniteQuadraticModule.Isometry.orthogonalQuotient_orthogonalQuotientMk
-      _ _ _ _ _ ?_) ?_
-    · exact (e.discriminantQuadraticIsometry hL).mem_orthogonalComplement_of_forall_mem_iff
-        (e.discriminantQuadraticIsometry_mem_discriminantSubgroup_iff hL P)
-        (hP.isIntegral.dualClassHom_mem_orthogonalComplement y)
-    · have hclass : (e.discriminantQuadraticIsometry hL) (hP.isIntegral.dualClassHom y) =
+      _ _ _ _) ?_
+    have hclass : (e.discriminantQuadraticIsometry hL) (hP.isIntegral.dualClassHom y) =
           ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP).isIntegral.dualClassHom
             ((e.intermediateCarrierIsometry hP.isIntegral).dualCarrierEquiv y) := by
-        rw [discriminantQuadraticIsometry_apply,
-          IntermediateCarrier.IsIntegral.dualClassHom_apply, discriminantGroupEquiv_mk,
-          IntermediateCarrier.IsIntegral.dualClassHom_apply]
-        exact congrArg _ (Subtype.ext (by simp))
-      exact congrArg _ (Subtype.ext hclass)
+      rw [discriminantQuadraticIsometry_apply,
+        IntermediateCarrier.IsIntegral.dualClassHom_apply, discriminantGroupEquiv_mk,
+        IntermediateCarrier.IsIntegral.dualClassHom_apply]
+      exact congrArg _ (Subtype.ext (by simp))
+    exact congrArg _ (Subtype.ext hclass)
 
 /-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`.** An isometry `e : L ≅ L'` of even
 nondegenerate lattices transports an even intermediate carrier `P` of `L` to one of `L'`, and the
@@ -407,12 +391,9 @@ theorem discriminantOrthogonalQuotientIsometry_naturality (e : Isometry L L') (h
           hP.isEven_toIntegralLattice).trans
         (discriminantOrthogonalQuotientIsometry (e.isEven_iff.mp hL)
           ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP)) =
-      (discriminantOrthogonalQuotientIsometry hL hP).trans
+        (discriminantOrthogonalQuotientIsometry hL hP).trans
         ((e.discriminantQuadraticIsometry hL).orthogonalQuotient
           ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)
-          ((isEven_iff_isIsotropic_discriminantSubgroup (e.isEven_iff.mp hL)
-              (e.intermediateCarrierEquiv P)).mp
-            ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP))
           (e.discriminantQuadraticIsometry_mem_discriminantSubgroup_iff hL P)) :=
   DFunLike.ext _ _ fun q ↦
     (e.discriminantOrthogonalQuotientIsometry_naturality_apply hL hP q).symm

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -314,6 +314,17 @@ section Naturality
 
 variable {W : Type*} [AddCommGroup W] [Module ℚ W] {L' : IntegralLattice W} [L'.IsNondegenerate]
 
+/-- Orthogonality to the subgroup of an intermediate carrier, read in the discriminant group.
+
+The carrier of `L.discriminantBilinearModule` is `L.DiscriminantGroup` by definition only, and
+`discriminantBilinearModule` is a plain definition, so no rewrite can move a membership statement
+between the two spellings; this restatement performs the identification once, by `exact`. -/
+private theorem mem_orthogonalComplement_discriminantSubgroup_iff (L : IntegralLattice V)
+    [L.IsNondegenerate] (P : L.IntermediateCarrier) (x : L.DiscriminantGroup) :
+    x ∈ L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P) ↔
+      ∀ y ∈ L.discriminantSubgroup P, L.discriminantPairing x y = 0 :=
+  L.discriminantBilinearModule.mem_orthogonalComplement_iff _ x
+
 namespace Isometry
 
 /-- **The discriminant-subgroup correspondence is natural.** A discriminant class of `L` lies in
@@ -337,22 +348,18 @@ theorem discriminantGroupEquiv_mem_orthogonalComplement_iff
     e.discriminantGroupEquiv x ∈ L'.discriminantBilinearModule.orthogonalComplement
         (L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) ↔
       x ∈ L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P) := by
-  rw [← e.discriminantBilinearIsometry_apply x]
-  change e.discriminantBilinearIsometry x ∈
-      L'.discriminantBilinearModule.orthogonalComplement
-        (show AddSubgroup L'.discriminantBilinearModule from
-          L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) ↔
-    x ∈ L.discriminantBilinearModule.orthogonalComplement
-      (show AddSubgroup L.discriminantBilinearModule from L.discriminantSubgroup P)
-  have hmap :
-      (show AddSubgroup L.discriminantBilinearModule from L.discriminantSubgroup P).map
-          e.discriminantBilinearIsometry.toAddEquiv =
-        (show AddSubgroup L'.discriminantBilinearModule from
-          L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) := by
-    rw [e.discriminantBilinearIsometry_toAddEquiv]
-    exact (discriminantSubgroup_intermediateCarrierEquiv e P).symm
-  rw [← hmap, ← e.discriminantBilinearIsometry.map_orthogonalComplement]
-  exact AddSubgroup.mem_map_iff_mem e.discriminantBilinearIsometry.toAddEquiv.injective
+  rw [mem_orthogonalComplement_discriminantSubgroup_iff,
+    mem_orthogonalComplement_discriminantSubgroup_iff]
+  constructor
+  · intro h y hy
+    rw [← e.map_discriminantPairing x y]
+    refine h _ ?_
+    rw [mem_discriminantSubgroup_intermediateCarrierEquiv_iff, LinearEquiv.symm_apply_apply]
+    exact hy
+  · intro h y hy
+    rw [mem_discriminantSubgroup_intermediateCarrierEquiv_iff] at hy
+    rw [← e.discriminantGroupEquiv.apply_symm_apply y, e.map_discriminantPairing]
+    exact h _ hy
 
 /-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`, on a discriminant class.** -/
 theorem discriminantOrthogonalQuotientIsometry_naturality_apply (e : Isometry L L')

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
 public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual
+public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Naturality
 public import TauCeti.LinearAlgebra.IntegralLattice.Unimodular
 
 /-!
@@ -42,11 +43,14 @@ criterion of `TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual`. The isome
 restated for the overlattice `L_H` glued along a quadratic-isotropic subgroup `H ≤ A_L`, which is
 the form in which the ADE glue calculations use it.
 
-Two things are deliberately left out. The bilinear analogue for a merely integral overlattice of
-an odd lattice needs the orthogonal quotient of a finite *bilinear* module, which the library does
-not yet have. And naturality of the comparison isometry under a lattice isometry needs the induced
-map of orthogonal quotients, which is likewise still missing from the finite-quadratic-module
-layer.
+The comparison is natural. An isometry `e : L ≅ L'` transports the intermediate carrier `M`, and
+also restricts to an isometry of the overlattices themselves; the discriminant subgroups and their
+orthogonal complements correspond under the induced isometry of discriminant modules, and the
+square built from the two comparison isometries commutes.
+
+One thing is deliberately left out: the bilinear analogue for a merely integral overlattice of an
+odd lattice needs the orthogonal quotient of a finite *bilinear* module, which the library does
+not yet have.
 
 ## Main declarations
 
@@ -58,6 +62,11 @@ layer.
   `H⊥ / H` is the discriminant of `M`.
 * `TauCeti.IntegralLattice.IntermediateCarrier.subsingleton_orthogonalQuotient_iff_isUnimodular`:
   `M` is unimodular exactly when `H⊥ / H` is trivial.
+* `TauCeti.IntegralLattice.Isometry.discriminantGroupEquiv_mem_orthogonalComplement_iff`:
+  an isometry carries the orthogonal complements of corresponding discriminant subgroups to one
+  another.
+* `TauCeti.IntegralLattice.Isometry.discriminantOrthogonalQuotientIsometry_naturality`: the
+  comparison isometry is natural under a lattice isometry.
 * `TauCeti.IntegralLattice.discriminantOrthogonalQuotientIsometryOfSubgroup`: the same isometry
   read as `A_(L_H) ≅ H⊥ / H` for a quadratic-isotropic subgroup `H` of `A_L`.
 
@@ -298,6 +307,119 @@ end IntermediateCarrier
 /-! ## The comparison isometry read on subgroups -/
 
 open IntermediateCarrier
+
+/-! ## Naturality under a lattice isometry -/
+
+section Naturality
+
+variable {W : Type*} [AddCommGroup W] [Module ℚ W] {L' : IntegralLattice W} [L'.IsNondegenerate]
+
+namespace Isometry
+
+/-- **The discriminant-subgroup correspondence is natural.** A discriminant class of `L` lies in
+the subgroup attached to an intermediate carrier exactly when its image under the induced
+discriminant isometry lies in the subgroup attached to the transported carrier. -/
+theorem discriminantQuadraticIsometry_mem_discriminantSubgroup_iff (e : Isometry L L')
+    (hL : L.IsEven) (P : L.IntermediateCarrier) (x : L.DiscriminantGroup) :
+    e.discriminantQuadraticIsometry hL x ∈
+        L'.discriminantSubgroup (e.intermediateCarrierEquiv P) ↔
+      x ∈ L.discriminantSubgroup P := by
+  have h := mem_discriminantSubgroup_intermediateCarrierEquiv_iff e P (e.discriminantGroupEquiv x)
+  rw [LinearEquiv.symm_apply_apply] at h
+  rw [discriminantQuadraticIsometry_apply]
+  exact h
+
+/-- **An isometry carries the orthogonal complements of corresponding discriminant subgroups to
+one another.** A discriminant class of `L` is orthogonal to the subgroup of an intermediate
+carrier exactly when its image is orthogonal to the subgroup of the transported carrier. -/
+theorem discriminantGroupEquiv_mem_orthogonalComplement_iff
+    (e : Isometry L L') (P : L.IntermediateCarrier) (x : L.DiscriminantGroup) :
+    e.discriminantGroupEquiv x ∈ L'.discriminantBilinearModule.orthogonalComplement
+        (L'.discriminantSubgroup (e.intermediateCarrierEquiv P)) ↔
+      x ∈ L.discriminantBilinearModule.orthogonalComplement (L.discriminantSubgroup P) := by
+  have hmem : ∀ u : L.DiscriminantGroup, u ∈ L.discriminantSubgroup P →
+      e.discriminantGroupEquiv u ∈
+        L'.discriminantSubgroup (e.intermediateCarrierEquiv P) := by
+    intro u hu
+    rw [mem_discriminantSubgroup_intermediateCarrierEquiv_iff, LinearEquiv.symm_apply_apply]
+    exact hu
+  constructor
+  · intro hx
+    refine (L.discriminantBilinearModule.mem_orthogonalComplement_iff _ x).mpr fun w hw ↦ ?_
+    refine (L.discriminantBilinearModule_pairing x w).trans ?_
+    refine (e.map_discriminantPairing x w).symm.trans ?_
+    exact (L'.discriminantBilinearModule_pairing _ _).symm.trans
+      ((L'.discriminantBilinearModule.mem_orthogonalComplement_iff _ _).mp hx _ (hmem w hw))
+  · intro hx
+    refine (L'.discriminantBilinearModule.mem_orthogonalComplement_iff _ _).mpr fun w hw ↦ ?_
+    refine (L'.discriminantBilinearModule_pairing _ w).trans ?_
+    have hw₂ : e.discriminantGroupEquiv.symm w ∈ L.discriminantSubgroup P :=
+      (mem_discriminantSubgroup_intermediateCarrierEquiv_iff e P w).mp hw
+    have hx₂ : L.discriminantPairing x (e.discriminantGroupEquiv.symm w) = 0 :=
+      (L.discriminantBilinearModule_pairing _ _).symm.trans
+        ((L.discriminantBilinearModule.mem_orthogonalComplement_iff _ x).mp hx _ hw₂)
+    have hcancel : e.discriminantGroupEquiv (e.discriminantGroupEquiv.symm w) = w :=
+      e.discriminantGroupEquiv.apply_symm_apply w
+    have hstep := e.map_discriminantPairing x (e.discriminantGroupEquiv.symm w)
+    rw [hcancel] at hstep
+    exact hstep.trans hx₂
+
+/-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`, on a discriminant class.** -/
+theorem discriminantOrthogonalQuotientIsometry_naturality_apply (e : Isometry L L')
+    (hL : L.IsEven) {P : L.IntermediateCarrier} (hP : IntermediateCarrier.IsEven P)
+    (q : hP.isIntegral.toIntegralLattice.DiscriminantGroup) :
+    (e.discriminantQuadraticIsometry hL).orthogonalQuotient
+        ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)
+        ((isEven_iff_isIsotropic_discriminantSubgroup (e.isEven_iff.mp hL)
+            (e.intermediateCarrierEquiv P)).mp
+          ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP))
+        (e.discriminantQuadraticIsometry_mem_discriminantSubgroup_iff hL P)
+        (discriminantOrthogonalQuotientIsometry hL hP q) =
+      discriminantOrthogonalQuotientIsometry (e.isEven_iff.mp hL)
+        ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP)
+        ((e.intermediateCarrierIsometry hP.isIntegral).discriminantQuadraticIsometry
+          hP.isEven_toIntegralLattice q) := by
+  induction q using Submodule.Quotient.induction_on with
+  | _ y =>
+    rw [discriminantOrthogonalQuotientIsometry_mk, discriminantQuadraticIsometry_mk,
+      discriminantOrthogonalQuotientIsometry_mk]
+    refine Eq.trans (FiniteQuadraticModule.Isometry.orthogonalQuotient_orthogonalQuotientMk
+      _ _ _ _ _ ?_) ?_
+    · exact (e.discriminantQuadraticIsometry hL).mem_orthogonalComplement_of_forall_mem_iff
+        (e.discriminantQuadraticIsometry_mem_discriminantSubgroup_iff hL P)
+        (hP.isIntegral.dualClassHom_mem_orthogonalComplement y)
+    · have hclass : (e.discriminantQuadraticIsometry hL) (hP.isIntegral.dualClassHom y) =
+          ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP).isIntegral.dualClassHom
+            ((e.intermediateCarrierIsometry hP.isIntegral).dualCarrierEquiv y) := by
+        rw [discriminantQuadraticIsometry_apply,
+          IntermediateCarrier.IsIntegral.dualClassHom_apply, discriminantGroupEquiv_mk,
+          IntermediateCarrier.IsIntegral.dualClassHom_apply]
+        exact congrArg _ (Subtype.ext (by simp))
+      exact congrArg _ (Subtype.ext hclass)
+
+/-- **Naturality of the comparison isometry `A_M ≅ H⊥ / H`.** An isometry `e : L ≅ L'` of even
+nondegenerate lattices transports an even intermediate carrier `P` of `L` to one of `L'`, and the
+square built from the two comparison isometries, the induced isometry of the discriminant
+quadratic modules of the two overlattices, and the transported orthogonal quotient commutes. -/
+theorem discriminantOrthogonalQuotientIsometry_naturality (e : Isometry L L') (hL : L.IsEven)
+    {P : L.IntermediateCarrier} (hP : IntermediateCarrier.IsEven P) :
+    ((e.intermediateCarrierIsometry hP.isIntegral).discriminantQuadraticIsometry
+          hP.isEven_toIntegralLattice).trans
+        (discriminantOrthogonalQuotientIsometry (e.isEven_iff.mp hL)
+          ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP)) =
+      (discriminantOrthogonalQuotientIsometry hL hP).trans
+        ((e.discriminantQuadraticIsometry hL).orthogonalQuotient
+          ((isEven_iff_isIsotropic_discriminantSubgroup hL P).mp hP)
+          ((isEven_iff_isIsotropic_discriminantSubgroup (e.isEven_iff.mp hL)
+              (e.intermediateCarrierEquiv P)).mp
+            ((e.isEven_intermediateCarrierEquiv_iff P).mpr hP))
+          (e.discriminantQuadraticIsometry_mem_discriminantSubgroup_iff hL P)) :=
+  DFunLike.ext _ _ fun q ↦
+    (e.discriminantOrthogonalQuotientIsometry_naturality_apply hL hP q).symm
+
+end Isometry
+
+end Naturality
 
 variable (L)
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/Overlattice/OrthogonalQuotient.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
 public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Dual
-public import TauCeti.LinearAlgebra.IntegralLattice.Overlattice.Naturality
 public import TauCeti.LinearAlgebra.IntegralLattice.Unimodular
 
 /-!


### PR DESCRIPTION
This PR closes the naturality clause of Layer 4 of the `IntegralLattices` roadmap: "Prove naturality: a lattice isometry transports intermediate and integral/even overlattices, carries their corresponding subgroups and orthogonal complements to one another, and commutes with `A_{L_H} ≅ H^⊥/H`." The transport of carriers, subgroups and the integral/even refinements already landed in `Overlattice/Naturality.lean`; the two clauses left open were the orthogonal complements and the commutation with the comparison isometry of `Overlattice/OrthogonalQuotient.lean`, whose module docstring recorded the second as "deliberately left out" for want of an induced map of orthogonal quotients in the finite-quadratic-module layer. This PR supplies that map and proves the square commutes.

Three things are added. In `FiniteBilinearModule/Quadratic.lean`, an isometry `f : A ≅ B` of finite quadratic modules now restricts to an equivalence `H⊥ ≃+ f(H)⊥` of orthogonal complements, carries `H⊥` into `K⊥` whenever it carries `H` onto `K`, and induces an isometry `H⊥ / H ≅ K⊥ / K` of orthogonal quotients, with the representative formula for that isometry. The hypothesis is the elementwise form `∀ x, f x ∈ K ↔ x ∈ H` of `H.map f = K`; that is the form a lattice isometry can supply without fighting the coercion between a discriminant group and the carrier of its packaged quadratic module. In `Overlattice/Naturality.lean`, a lattice isometry `e : L ≅ L'` restricts to an isometry between the integral lattice carried by an integral intermediate carrier and the one carried by its transport, through the same ambient rational equivalence. In `Overlattice/OrthogonalQuotient.lean`, the discriminant-subgroup correspondence and the orthogonal complements of corresponding subgroups are shown to match under the induced discriminant isometry, and the naturality square

```text
A_M  ---->  A_(e M)
 |            |
 v            v
H⊥/H ----> H'⊥/H'
```

is proved to commute, both on a discriminant class and as an equality of composite isometries. The orthogonal-complement clause is derived from the generic `FiniteBilinearModule.Isometry.map_orthogonalComplement` applied to the existing `Isometry.discriminantBilinearIsometry`, so no pairing-level argument is repeated and `Discriminant/Bilinear.lean` is left untouched.

The milestone this serves is Layer 4, overlattices and isotropic subgroups. With this PR that layer is complete except for the bilinear analogue for a merely integral overlattice of an odd lattice, which is still gated on the orthogonal quotient of a finite *bilinear* module (open PR #3805); the module docstring of `Overlattice/OrthogonalQuotient.lean` is updated to say so and no longer claims naturality is missing.

No Mathlib code is vendored. `Submodule.Quotient.equiv`, `AddEquiv.addSubgroupMap`, `AddEquiv.addSubgroupCongr` and `AddEquiv.toIntLinearEquiv` are used from Mathlib as-is.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"naturality-discriminant-orthogonal-quotient-isometry"}-->

🤖 Prepared with Claude Code