### PR TITLE
feat: add finite module morphisms

### DIFF
--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
@@ -442,6 +442,19 @@ theorem apply_symm_apply (f : Isometry A B) (x : B) : f (f.symm x) = x :=
 theorem trans_apply (f : Isometry A B) (g : Isometry B C) (x : A) : (f.trans g) x = g (f x) :=
   f.toAddEquiv.trans_apply g.toAddEquiv x
 
+/-- Forgetting the identity isometry gives the identity morphism. -/
+@[simp]
+theorem refl_toHom (A : FiniteBilinearModule) : (refl A).toHom = Hom.id A := by
+  ext x
+  rw [toHom_apply, refl_apply, Hom.id_apply]
+
+/-- Forgetting a composite isometry gives the composite morphism. -/
+@[simp]
+theorem trans_toHom (f : Isometry A B) (g : Isometry B C) :
+    (f.trans g).toHom = g.toHom.comp f.toHom := by
+  ext x
+  rw [toHom_apply, trans_apply, Hom.comp_apply, toHom_apply, toHom_apply]
+
 /-- Nondegeneracy transfers along an isometry. -/
 theorem isNondegenerate (f : Isometry A B) (hA : A.IsNondegenerate) : B.IsNondegenerate := by
   rw [B.isNondegenerate_iff_injective]

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
@@ -279,13 +279,13 @@ namespace Hom
 variable {A : FiniteBilinearModule.{u}} {B : FiniteBilinearModule.{v}}
   {C : FiniteBilinearModule.{w}}
 
-theorem toAddMonoidHom_injective :
-    Function.Injective (toAddMonoidHom : Hom A B → A →+ B)
-  | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
-
 instance : FunLike (Hom A B) A B where
   coe f := f.toAddMonoidHom
-  coe_injective _ _ h := toAddMonoidHom_injective (DFunLike.coe_injective h)
+  coe_injective f g h := by
+    cases f
+    cases g
+    congr
+    exact DFunLike.coe_injective h
 
 instance : AddMonoidHomClass (Hom A B) A B where
   map_add f := f.toAddMonoidHom.map_add
@@ -330,6 +330,7 @@ theorem comp_id (f : Hom A B) : f.comp (id A) = f := by
   ext
   rfl
 
+@[simp]
 theorem comp_assoc {D : FiniteBilinearModule} (h : Hom C D) (g : Hom B C) (f : Hom A B) :
     (h.comp g).comp f = h.comp (g.comp f) := by
   ext
@@ -390,13 +391,8 @@ theorem toHom_apply (f : Isometry A B) (x : A) : f.toHom x = f x := (rfl)
 
 /-- The underlying morphism of an isometry is bijective. -/
 theorem toHom_bijective (f : Isometry A B) : Function.Bijective f.toHom := by
-  constructor
-  · intro x y hxy
-    apply f.toAddEquiv.injective
-    simpa only [toHom_apply, coe_toAddEquiv] using hxy
-  · intro y
-    obtain ⟨x, hx⟩ := f.toAddEquiv.surjective y
-    exact ⟨x, by simpa only [toHom_apply, coe_toAddEquiv] using hx⟩
+  simpa only [Function.Bijective, Function.Injective, Function.Surjective, toHom_apply,
+    coe_toAddEquiv] using f.toAddEquiv.bijective
 
 /-- Two isometries are equal when they agree on all elements. -/
 @[ext]

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Basic.lean
@@ -16,10 +16,10 @@ A finite abelian group equipped with a symmetric biadditive pairing into `ℚ/�
 is stored as its adjoint into Mathlib's `CharacterModule`; nondegeneracy asserts that this
 adjoint is bijective.
 
-This file provides the basic constructions needed for discriminant forms: isometries, restriction,
-form negation, orthogonal direct sums, radicals, orthogonal complements, isotropic elements,
-isotropic subgroups, and Lagrangians.  Nondegeneracy remains a predicate because restriction to a
-subgroup can be degenerate.
+This file provides the basic constructions needed for discriminant forms: morphisms, isometries,
+restriction, form negation, orthogonal direct sums, radicals, orthogonal complements, isotropic
+elements, isotropic subgroups, and Lagrangians. Nondegeneracy remains a predicate because
+restriction to a subgroup can be degenerate.
 
 ## References
 
@@ -31,6 +31,7 @@ subgroup can be degenerate.
 * `TauCeti.FiniteBilinearModule`: a finite abelian group with a symmetric `ℚ/ℤ`-valued pairing.
 * `TauCeti.FiniteBilinearModule.toBilin`: the pairing as a `ℤ`-bilinear map.
 * `TauCeti.FiniteBilinearModule.IsNondegenerate`: bijectivity of the adjoint pairing.
+* `TauCeti.FiniteBilinearModule.Hom`: a pairing-preserving additive homomorphism.
 * `TauCeti.FiniteBilinearModule.Isometry`: a pairing-preserving additive equivalence.
 * `TauCeti.FiniteBilinearModule.orthogonalComplement`: the orthogonal complement of a subgroup.
 * `TauCeti.FiniteBilinearModule.IsIsotropicElem`: vanishing of the self-pairing on an element.
@@ -264,6 +265,85 @@ noncomputable def adjointEquiv (hA : A.IsNondegenerate) : A ≃+ CharacterModule
 theorem adjointEquiv_apply (hA : A.IsNondegenerate) (x : A) : A.adjointEquiv hA x = A.pairing x :=
   (rfl)
 
+/-! ## Morphisms and isometries -/
+
+/-- A morphism of finite bilinear modules is a pairing-preserving additive homomorphism. -/
+structure Hom (A : FiniteBilinearModule.{u}) (B : FiniteBilinearModule.{v}) where
+  /-- The underlying additive homomorphism. -/
+  toAddMonoidHom : A →+ B
+  /-- The homomorphism preserves the bilinear pairing. -/
+  map_pairing' : ∀ x y, B.pairing (toAddMonoidHom x) (toAddMonoidHom y) = A.pairing x y
+
+namespace Hom
+
+variable {A : FiniteBilinearModule.{u}} {B : FiniteBilinearModule.{v}}
+  {C : FiniteBilinearModule.{w}}
+
+theorem toAddMonoidHom_injective :
+    Function.Injective (toAddMonoidHom : Hom A B → A →+ B)
+  | ⟨_, _⟩, ⟨_, _⟩, rfl => rfl
+
+instance : FunLike (Hom A B) A B where
+  coe f := f.toAddMonoidHom
+  coe_injective _ _ h := toAddMonoidHom_injective (DFunLike.coe_injective h)
+
+instance : AddMonoidHomClass (Hom A B) A B where
+  map_add f := f.toAddMonoidHom.map_add
+  map_zero f := f.toAddMonoidHom.map_zero
+
+@[simp]
+theorem coe_toAddMonoidHom (f : Hom A B) : ⇑f.toAddMonoidHom = f := rfl
+
+/-- A morphism of finite bilinear modules preserves the stored pairing. -/
+@[simp]
+theorem map_pairing (f : Hom A B) (x y : A) : B.pairing (f x) (f y) = A.pairing x y :=
+  f.map_pairing' x y
+
+/-- Two morphisms are equal when they agree on every element. -/
+@[ext]
+theorem ext {f g : Hom A B} (h : ∀ x, f x = g x) : f = g :=
+  DFunLike.ext f g h
+
+/-- The identity morphism of a finite bilinear module. -/
+def id (A : FiniteBilinearModule) : Hom A A where
+  toAddMonoidHom := AddMonoidHom.id A
+  map_pairing' _ _ := rfl
+
+/-- The composite of two finite bilinear module morphisms. -/
+def comp (g : Hom B C) (f : Hom A B) : Hom A C where
+  toAddMonoidHom := g.toAddMonoidHom.comp f.toAddMonoidHom
+  map_pairing' x y := (g.map_pairing (f x) (f y)).trans (f.map_pairing x y)
+
+@[simp]
+theorem id_apply (A : FiniteBilinearModule) (x : A) : id A x = x := (rfl)
+
+@[simp]
+theorem comp_apply (g : Hom B C) (f : Hom A B) (x : A) : g.comp f x = g (f x) := (rfl)
+
+@[simp]
+theorem id_comp (f : Hom A B) : (id B).comp f = f := by
+  ext
+  rfl
+
+@[simp]
+theorem comp_id (f : Hom A B) : f.comp (id A) = f := by
+  ext
+  rfl
+
+theorem comp_assoc {D : FiniteBilinearModule} (h : Hom C D) (g : Hom B C) (f : Hom A B) :
+    (h.comp g).comp f = h.comp (g.comp f) := by
+  ext
+  rfl
+
+/-- A morphism out of a nondegenerate finite bilinear module is injective. -/
+theorem injective (f : Hom A B) (hA : A.IsNondegenerate) : Function.Injective f := by
+  intro x y hxy
+  apply hA.injective
+  ext z
+  rw [← f.map_pairing x z, ← f.map_pairing y z, hxy]
+
+end Hom
+
 /-- An isometry of finite bilinear modules is an additive equivalence preserving the pairing. -/
 structure Isometry (A : FiniteBilinearModule.{u}) (B : FiniteBilinearModule.{v}) where
   /-- The underlying additive equivalence. -/
@@ -299,6 +379,24 @@ theorem coe_toAddEquiv (f : Isometry A B) : ⇑f.toAddEquiv = f := rfl
 @[simp]
 theorem map_pairing (f : Isometry A B) (x y : A) : B.pairing (f x) (f y) = A.pairing x y :=
   f.map_pairing' x y
+
+/-- An isometry is, after forgetting bijectivity, a morphism of finite bilinear modules. -/
+def toHom (f : Isometry A B) : Hom A B where
+  toAddMonoidHom := f.toAddEquiv.toAddMonoidHom
+  map_pairing' := f.map_pairing
+
+@[simp]
+theorem toHom_apply (f : Isometry A B) (x : A) : f.toHom x = f x := (rfl)
+
+/-- The underlying morphism of an isometry is bijective. -/
+theorem toHom_bijective (f : Isometry A B) : Function.Bijective f.toHom := by
+  constructor
+  · intro x y hxy
+    apply f.toAddEquiv.injective
+    simpa only [toHom_apply, coe_toAddEquiv] using hxy
+  · intro y
+    obtain ⟨x, hx⟩ := f.toAddEquiv.surjective y
+    exact ⟨x, by simpa only [toHom_apply, coe_toAddEquiv] using hx⟩
 
 /-- Two isometries are equal when they agree on all elements. -/
 @[ext]
@@ -366,6 +464,35 @@ theorem isNondegenerate_iff (f : Isometry A B) : A.IsNondegenerate ↔ B.IsNonde
 
 end Isometry
 
+namespace Hom
+
+variable {A : FiniteBilinearModule.{u}} {B : FiniteBilinearModule.{v}}
+
+/-- A bijective morphism of finite bilinear modules is an isometry. -/
+noncomputable def toIsometry (f : Hom A B) (hf : Function.Bijective f) : Isometry A B where
+  toAddEquiv := AddEquiv.ofBijective f.toAddMonoidHom hf
+  map_pairing' := f.map_pairing
+
+@[simp]
+theorem toIsometry_apply (f : Hom A B) (hf : Function.Bijective f) (x : A) :
+    f.toIsometry hf x = f x := (rfl)
+
+/-- Forgetting a bijective morphism after packaging it as an isometry recovers the morphism. -/
+@[simp]
+theorem toIsometry_toHom (f : Hom A B) (hf : Function.Bijective f) :
+    (f.toIsometry hf).toHom = f := by
+  ext
+  rfl
+
+/-- Packaging the underlying morphism of an isometry recovers the isometry. -/
+@[simp]
+theorem toHom_toIsometry (f : Isometry A B) :
+    f.toHom.toIsometry f.toHom_bijective = f := by
+  ext
+  rfl
+
+end Hom
+
 /-- Restrict a finite bilinear module to an additive subgroup.
 
 No nondegeneracy conclusion is asserted: a subgroup of a nondegenerate module can have a
@@ -388,6 +515,14 @@ abbrev restrict (H : AddSubgroup A) : FiniteBilinearModule where
 
 theorem restrict_pairing (H : AddSubgroup A) (x y : H) :
     (restrict A H).pairing x y = A.pairing x.1 y.1 := (rfl)
+
+/-- The inclusion of a restricted finite bilinear module into the original module. -/
+def restrictHom (H : AddSubgroup A) : Hom (restrict A H) A where
+  toAddMonoidHom := H.subtype
+  map_pairing' _ _ := rfl
+
+@[simp]
+theorem restrictHom_apply (H : AddSubgroup A) (x : H) : A.restrictHom H x = x := (rfl)
 
 /-- Negate the pairing of a finite bilinear module. -/
 abbrev neg : FiniteBilinearModule where

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -162,14 +162,8 @@ theorem toHom_apply (f : Isometry A B) (x : A) : f.toHom x = f x := (rfl)
 
 /-- The underlying morphism of a quadratic isometry is bijective. -/
 theorem toHom_bijective (f : Isometry A B) : Function.Bijective f.toHom := by
-  constructor
-  · intro x y hxy
-    apply f.toLinearEquiv.injective
-    simpa only [toHom_apply, QuadraticMap.IsometryEquiv.coe_toLinearEquiv] using hxy
-  · intro y
-    obtain ⟨x, hx⟩ := f.toLinearEquiv.surjective y
-    exact ⟨x, by
-      simpa only [toHom_apply, QuadraticMap.IsometryEquiv.coe_toLinearEquiv] using hx⟩
+  simpa only [Function.Bijective, Function.Injective, Function.Surjective, toHom_apply,
+    QuadraticMap.IsometryEquiv.coe_toLinearEquiv] using f.toLinearEquiv.bijective
 
 /-- A quadratic isometry induces an isometry of the canonical polar bilinear modules. -/
 def toFiniteBilinearModule (f : Isometry A B) :
@@ -267,6 +261,7 @@ theorem restrictHom_apply (H : AddSubgroup A) (x : H) : A.restrictHom H x = x :=
 
 /-- Forgetting the quadratic structure of a restriction inclusion gives the bilinear restriction
 inclusion. -/
+@[simp]
 theorem restrictHom_toFiniteBilinearModule (H : AddSubgroup A) :
     (A.restrictHom H).toFiniteBilinearModule = A.toFiniteBilinearModule.restrictHom H := by
   ext x

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -113,11 +113,6 @@ namespace Hom
 
 variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
 
-/-- A morphism of finite quadratic modules preserves the stored quadratic map. -/
-@[simp]
-theorem map_quadratic (f : Hom A B) (x : A) : B.quadratic (f x) = A.quadratic x :=
-  f.map_app x
-
 /-- A morphism of finite quadratic modules preserves the canonical polar pairing. -/
 @[simp]
 theorem map_pairing (f : Hom A B) (x y : A) :
@@ -125,7 +120,7 @@ theorem map_pairing (f : Hom A B) (x y : A) :
       A.toFiniteBilinearModule.pairing x y := by
   rw [← B.polar_eq_pairing, ← A.polar_eq_pairing]
   simp only [QuadraticMap.polar]
-  rw [← map_add f, f.map_quadratic, f.map_quadratic, f.map_quadratic]
+  rw [← map_add f, f.map_app, f.map_app, f.map_app]
 
 /-- A quadratic-module morphism induces a morphism of the canonical polar bilinear modules. -/
 def toFiniteBilinearModule (f : Hom A B) :
@@ -211,7 +206,7 @@ variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
 /-- A bijective morphism of finite quadratic modules is an isometry. -/
 noncomputable def toIsometry (f : Hom A B) (hf : Function.Bijective f) : Isometry A B where
   toLinearEquiv := (AddEquiv.ofBijective f.toLinearMap.toAddMonoidHom hf).toIntLinearEquiv
-  map_app' := f.map_quadratic
+  map_app' := f.map_app
 
 @[simp]
 theorem toIsometry_apply (f : Hom A B) (hf : Function.Bijective f) (x : A) :

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -114,11 +114,11 @@ variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
   {C : FiniteQuadraticModule}
 
 /-- The identity morphism of a finite quadratic module. -/
-@[expose] def id (A : FiniteQuadraticModule) : Hom A A :=
+def id (A : FiniteQuadraticModule) : Hom A A :=
   QuadraticMap.Isometry.id A.quadratic
 
 /-- The composite of two finite quadratic module morphisms. -/
-@[expose] def comp (g : Hom B C) (f : Hom A B) : Hom A C :=
+def comp (g : Hom B C) (f : Hom A B) : Hom A C :=
   QuadraticMap.Isometry.comp g f
 
 /-- Two finite quadratic module morphisms are equal when they agree on every element. -/
@@ -128,11 +128,11 @@ theorem ext {f g : Hom A B} (h : ∀ x, f x = g x) : f = g :=
 
 @[simp]
 theorem id_apply (A : FiniteQuadraticModule) (x : A) : id A x = x :=
-  rfl
+  (rfl)
 
 @[simp]
 theorem comp_apply (g : Hom B C) (f : Hom A B) (x : A) : g.comp f x = g (f x) :=
-  rfl
+  (rfl)
 
 @[simp]
 theorem id_comp (f : Hom A B) : (id B).comp f = f :=

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -16,8 +16,8 @@ public import Mathlib.LinearAlgebra.QuadraticForm.Prod
 A finite quadratic module is a finite abelian group equipped with a quadratic map to `ℚ/ℤ`.
 Its symmetric bilinear pairing is not stored separately: it is the polar form of the quadratic
 map.  This file packages that canonical underlying finite bilinear module and develops restriction,
-form negation, orthogonal products, isometries, quadratic-isotropic subgroups, and quadratic
-Lagrangians.
+form negation, orthogonal products, morphisms, isometries, quadratic-isotropic subgroups, and
+quadratic Lagrangians.
 
 The convention is the half-norm convention used for discriminant forms: for an even integral
 lattice the quadratic value of a dual class represented by `x` is `B(x, x) / 2` modulo `ℤ`, and
@@ -28,6 +28,7 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
 * `TauCeti.FiniteQuadraticModule`: a finite abelian group with an `AddCircle (1 : ℚ)`-valued
   quadratic map.
 * `TauCeti.FiniteQuadraticModule.toFiniteBilinearModule`: the canonical polar bilinear module.
+* `TauCeti.FiniteQuadraticModule.Hom`: a quadratic-map-preserving additive homomorphism.
 * `TauCeti.FiniteQuadraticModule.Isometry`: a quadratic-map isometric equivalence.
 * `TauCeti.FiniteQuadraticModule.IsIsotropic`: quadratic isotropy of an additive subgroup.
 * `TauCeti.FiniteQuadraticModule.IsLagrangian`: a quadratic-isotropic subgroup equal to its
@@ -98,6 +99,50 @@ theorem adjointEquiv_apply (hA : A.IsNondegenerate) (x : A) :
     A.adjointEquiv hA x = A.toFiniteBilinearModule.pairing x := by
   exact A.toFiniteBilinearModule.adjointEquiv_apply hA x
 
+/-! ## Morphisms and isometries -/
+
+/-- A morphism of finite quadratic modules is an additive homomorphism preserving the quadratic
+map.
+
+This is Mathlib's `QuadraticMap.Isometry` applied to the stored quadratic maps. In particular,
+identity morphisms, composition, and extensionality are inherited from Mathlib. -/
+abbrev Hom (A : FiniteQuadraticModule.{u}) (B : FiniteQuadraticModule.{v}) : Type (max u v) :=
+  A.quadratic.Isometry B.quadratic
+
+namespace Hom
+
+variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
+
+/-- A morphism of finite quadratic modules preserves the stored quadratic map. -/
+@[simp]
+theorem map_quadratic (f : Hom A B) (x : A) : B.quadratic (f x) = A.quadratic x :=
+  f.map_app x
+
+/-- A morphism of finite quadratic modules preserves the canonical polar pairing. -/
+@[simp]
+theorem map_pairing (f : Hom A B) (x y : A) :
+    B.toFiniteBilinearModule.pairing (f x) (f y) =
+      A.toFiniteBilinearModule.pairing x y := by
+  rw [← B.polar_eq_pairing, ← A.polar_eq_pairing]
+  simp only [QuadraticMap.polar]
+  rw [← map_add f, f.map_quadratic, f.map_quadratic, f.map_quadratic]
+
+/-- A quadratic-module morphism induces a morphism of the canonical polar bilinear modules. -/
+def toFiniteBilinearModule (f : Hom A B) :
+    FiniteBilinearModule.Hom A.toFiniteBilinearModule B.toFiniteBilinearModule where
+  toAddMonoidHom := f.toLinearMap.toAddMonoidHom
+  map_pairing' := f.map_pairing
+
+@[simp]
+theorem toFiniteBilinearModule_apply (f : Hom A B) (x : A) :
+    f.toFiniteBilinearModule x = f x := (rfl)
+
+/-- A morphism out of a nondegenerate finite quadratic module is injective. -/
+theorem injective (f : Hom A B) (hA : A.IsNondegenerate) : Function.Injective f :=
+  fun _ _ hxy ↦ f.toFiniteBilinearModule.injective hA hxy
+
+end Hom
+
 /-- An isometry of finite quadratic modules is Mathlib's isometric equivalence of their quadratic
 maps. -/
 abbrev Isometry (A : FiniteQuadraticModule.{u}) (B : FiniteQuadraticModule.{v}) : Type (max u v) :=
@@ -112,6 +157,24 @@ variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
 theorem trans_apply {C : FiniteQuadraticModule} (f : Isometry A B) (g : Isometry B C) (x : A) :
     (f.trans g) x = g (f x) :=
   rfl
+
+/-- A quadratic isometry is, after forgetting bijectivity, a morphism. -/
+def toHom (f : Isometry A B) : Hom A B :=
+  f.toIsometry
+
+@[simp]
+theorem toHom_apply (f : Isometry A B) (x : A) : f.toHom x = f x := (rfl)
+
+/-- The underlying morphism of a quadratic isometry is bijective. -/
+theorem toHom_bijective (f : Isometry A B) : Function.Bijective f.toHom := by
+  constructor
+  · intro x y hxy
+    apply f.toLinearEquiv.injective
+    simpa only [toHom_apply, QuadraticMap.IsometryEquiv.coe_toLinearEquiv] using hxy
+  · intro y
+    obtain ⟨x, hx⟩ := f.toLinearEquiv.surjective y
+    exact ⟨x, by
+      simpa only [toHom_apply, QuadraticMap.IsometryEquiv.coe_toLinearEquiv] using hx⟩
 
 /-- A quadratic isometry induces an isometry of the canonical polar bilinear modules. -/
 def toFiniteBilinearModule (f : Isometry A B) :
@@ -140,6 +203,34 @@ theorem isNondegenerate_iff (f : Isometry A B) : A.IsNondegenerate ↔ B.IsNonde
   f.toFiniteBilinearModule.isNondegenerate_iff
 
 end Isometry
+
+namespace Hom
+
+variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
+
+/-- A bijective morphism of finite quadratic modules is an isometry. -/
+noncomputable def toIsometry (f : Hom A B) (hf : Function.Bijective f) : Isometry A B where
+  toLinearEquiv := (AddEquiv.ofBijective f.toLinearMap.toAddMonoidHom hf).toIntLinearEquiv
+  map_app' := f.map_quadratic
+
+@[simp]
+theorem toIsometry_apply (f : Hom A B) (hf : Function.Bijective f) (x : A) :
+    f.toIsometry hf x = f x := (rfl)
+
+/-- Forgetting a bijective morphism after packaging it as an isometry recovers the morphism. -/
+@[simp]
+theorem toIsometry_toHom (f : Hom A B) (hf : Function.Bijective f) :
+    (f.toIsometry hf).toHom = f := by
+  ext
+  rfl
+
+/-- Packaging the underlying morphism of an isometry recovers the isometry. -/
+@[simp]
+theorem toHom_toIsometry (f : Isometry A B) :
+    f.toHom.toIsometry f.toHom_bijective = f := by
+  exact DFunLike.ext _ _ fun _ ↦ rfl
+
+end Hom
 
 /-! ## Canonical constructions -/
 
@@ -170,6 +261,26 @@ theorem restrict_pairing (H : AddSubgroup A) (x y : H) :
 theorem restrict_toFiniteBilinearModule (H : AddSubgroup A) :
     (A.restrict H).toFiniteBilinearModule = A.toFiniteBilinearModule.restrict H := by
   rfl
+
+/-- The inclusion of a restricted finite quadratic module into the original module. -/
+def restrictHom (H : AddSubgroup A) : Hom (restrict A H) A where
+  toLinearMap := H.toIntSubmodule.subtype
+  map_app' _ := rfl
+
+@[simp]
+theorem restrictHom_apply (H : AddSubgroup A) (x : H) : A.restrictHom H x = x := (rfl)
+
+/-- Forgetting the quadratic structure of a restriction inclusion gives the bilinear restriction
+inclusion. -/
+theorem restrictHom_toFiniteBilinearModule (H : AddSubgroup A) :
+    (A.restrictHom H).toFiniteBilinearModule = A.toFiniteBilinearModule.restrictHom H := by
+  ext x
+  calc
+    (A.restrictHom H).toFiniteBilinearModule x = A.restrictHom H x :=
+      Hom.toFiniteBilinearModule_apply _ _
+    _ = x.1 := restrictHom_apply A H x
+    _ = A.toFiniteBilinearModule.restrictHom H x :=
+      (FiniteBilinearModule.restrictHom_apply _ H x).symm
 
 /-- Negate the quadratic map of a finite quadratic module. -/
 @[expose] def neg : FiniteQuadraticModule where

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -104,14 +104,48 @@ theorem adjointEquiv_apply (hA : A.IsNondegenerate) (x : A) :
 /-- A morphism of finite quadratic modules is an additive homomorphism preserving the quadratic
 map.
 
-This is Mathlib's `QuadraticMap.Isometry` applied to the stored quadratic maps. In particular,
-identity morphisms, composition, and extensionality are inherited from Mathlib. -/
+This is Mathlib's `QuadraticMap.Isometry` applied to the stored quadratic maps. -/
 abbrev Hom (A : FiniteQuadraticModule.{u}) (B : FiniteQuadraticModule.{v}) : Type (max u v) :=
   A.quadratic.Isometry B.quadratic
 
 namespace Hom
 
 variable {A : FiniteQuadraticModule.{u}} {B : FiniteQuadraticModule.{v}}
+  {C : FiniteQuadraticModule}
+
+/-- The identity morphism of a finite quadratic module. -/
+@[expose] def id (A : FiniteQuadraticModule) : Hom A A :=
+  QuadraticMap.Isometry.id A.quadratic
+
+/-- The composite of two finite quadratic module morphisms. -/
+@[expose] def comp (g : Hom B C) (f : Hom A B) : Hom A C :=
+  QuadraticMap.Isometry.comp g f
+
+/-- Two finite quadratic module morphisms are equal when they agree on every element. -/
+@[ext]
+theorem ext {f g : Hom A B} (h : ∀ x, f x = g x) : f = g :=
+  QuadraticMap.Isometry.ext h
+
+@[simp]
+theorem id_apply (A : FiniteQuadraticModule) (x : A) : id A x = x :=
+  rfl
+
+@[simp]
+theorem comp_apply (g : Hom B C) (f : Hom A B) (x : A) : g.comp f x = g (f x) :=
+  rfl
+
+@[simp]
+theorem id_comp (f : Hom A B) : (id B).comp f = f :=
+  QuadraticMap.Isometry.id_comp f
+
+@[simp]
+theorem comp_id (f : Hom A B) : f.comp (id A) = f :=
+  QuadraticMap.Isometry.comp_id f
+
+@[simp]
+theorem comp_assoc {D : FiniteQuadraticModule} (h : Hom C D) (g : Hom B C) (f : Hom A B) :
+    (h.comp g).comp f = h.comp (g.comp f) :=
+  QuadraticMap.Isometry.comp_assoc h g f
 
 /-- A morphism of finite quadratic modules preserves the canonical polar pairing. -/
 @[simp]
@@ -131,6 +165,22 @@ def toFiniteBilinearModule (f : Hom A B) :
 @[simp]
 theorem toFiniteBilinearModule_apply (f : Hom A B) (x : A) :
     f.toFiniteBilinearModule x = f x := (rfl)
+
+/-- Forgetting the identity quadratic morphism gives the identity bilinear morphism. -/
+@[simp]
+theorem toFiniteBilinearModule_id (A : FiniteQuadraticModule) :
+    (id A).toFiniteBilinearModule = FiniteBilinearModule.Hom.id A.toFiniteBilinearModule := by
+  ext x
+  rw [toFiniteBilinearModule_apply, id_apply, FiniteBilinearModule.Hom.id_apply]
+
+/-- Forgetting a composite quadratic morphism gives the composite bilinear morphism. -/
+@[simp]
+theorem toFiniteBilinearModule_comp (g : Hom B C) (f : Hom A B) :
+    (g.comp f).toFiniteBilinearModule =
+      g.toFiniteBilinearModule.comp f.toFiniteBilinearModule := by
+  ext x
+  rw [toFiniteBilinearModule_apply, comp_apply, FiniteBilinearModule.Hom.comp_apply,
+    toFiniteBilinearModule_apply, toFiniteBilinearModule_apply]
 
 /-- A morphism out of a nondegenerate finite quadratic module is injective. -/
 theorem injective (f : Hom A B) (hA : A.IsNondegenerate) : Function.Injective f :=
@@ -159,6 +209,20 @@ def toHom (f : Isometry A B) : Hom A B :=
 
 @[simp]
 theorem toHom_apply (f : Isometry A B) (x : A) : f.toHom x = f x := (rfl)
+
+/-- Forgetting the identity quadratic isometry gives the identity quadratic morphism. -/
+@[simp]
+theorem refl_toHom (A : FiniteQuadraticModule) :
+    toHom (QuadraticMap.IsometryEquiv.refl A.quadratic) = Hom.id A := by
+  ext
+  rfl
+
+/-- Forgetting a composite quadratic isometry gives the composite quadratic morphism. -/
+@[simp]
+theorem trans_toHom {C : FiniteQuadraticModule} (f : Isometry A B) (g : Isometry B C) :
+    toHom (f.trans g) = g.toHom.comp f.toHom := by
+  ext
+  rfl
 
 /-- The underlying morphism of a quadratic isometry is bijective. -/
 theorem toHom_bijective (f : Isometry A B) : Function.Bijective f.toHom := by


### PR DESCRIPTION
This PR supplies the missing morphism API for finite bilinear and finite quadratic modules required by `TauCetiRoadmap/IntegralLattices/README.md`, Layer 3, in the bullets that require “morphisms, isometries” for both kinds of finite module. It defines a finite bilinear module morphism as an additive homomorphism preserving the `ℚ/ℤ`-valued pairing, with extensionality, identity, composition, and the identity and associativity laws; defines the quadratic analogue by specializing Mathlib’s general-codomain `QuadraticMap.Isometry`; and connects both notions to the existing isometries by mutually inverse conversions between bijective morphisms and isometries.

The nondegeneracy hypothesis is exercised rather than merely stored: every morphism out of a nondegenerate finite bilinear or quadratic module is proved injective. Restriction inclusions give concrete morphisms that need not be surjective, and forgetting the quadratic restriction inclusion is proved to recover the bilinear one. Thus the new notion genuinely covers maps that the existing equivalence-based isometries could not express.

This closes the morphism clauses of the Layer 3 finite bilinear and quadratic module milestone; after this PR, Layer 3 has no declared item left, while roadmap completion still awaits the bilinear `A_{L_H} ≅ H^⊥/H` path in Layer 4 (gated by open PR #3805) and the already-open final naturality and `D₈⁺ ≅ E₈` work.

The implementation reuses Mathlib’s `QuadraticMap.Isometry`, `AddEquiv.ofBijective`, and additive-homomorphism API directly. Mathlib’s `LinearMap.BilinForm.Isometry` is not applicable to the bilinear case because it is scalar-valued, whereas a finite bilinear module pairs into `AddCircle (1 : ℚ)`; no Mathlib code is vendored.

The changes add 252 lines and remove 6 across `FiniteBilinearModule/Basic.lean` and `FiniteBilinearModule/Quadratic.lean`.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"finite-bilinear-quadratic-module-morphisms"}-->

🤖 Prepared with Codex
