### PR TITLE
refactor(Laplace): name the dominated-convergence step for the slope integrals

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
@@ -327,18 +327,17 @@ private lemma norm_slope_neg_pow_mul_exp_neg_mul_le (n : ℕ) {y : ℝ} (hy : 0 
           simpa [hpow_abs] using mul_le_mul_of_nonneg_left hquot hpow_nonneg
     _ = (x : ℝ) ^ (n + 1) := by rw [pow_succ]
 
-/-- Dominated convergence for the pointwise slopes at `0` of the signed moment kernel
-`y ↦ (-x) ^ n * exp (-(y * x))`: the integrals of those slopes converge to the `(n+1)`-st signed
-moment, dominated by the `(n+1)`-st absolute moment. -/
-private lemma tendsto_integral_slope_neg_pow_mul_exp (μ : Measure ℝ≥0)
-    (hmom : ∀ n : ℕ, Integrable (fun x : ℝ≥0 => (x : ℝ) ^ n) μ) (n : ℕ) :
+/-- As `y` tends to `0` from the right, the integrals of the slopes at `0` of
+`z ↦ (-x) ^ n * exp (-(z * x))` tend to the `(n+1)`-st signed moment. -/
+private lemma tendsto_integral_slope_neg_pow_mul_exp_neg_mul_at_zero (μ : Measure ℝ≥0) (n : ℕ)
+    (hbound : Integrable (fun x : ℝ≥0 => (x : ℝ) ^ (n + 1)) μ) :
     Tendsto (fun y : ℝ => ∫ x : ℝ≥0,
         slope (fun z : ℝ => (-(x : ℝ)) ^ n * Real.exp (-(z * (x : ℝ)))) 0 y ∂μ)
       (𝓝[Ici (0 : ℝ) \ {0}] 0) (𝓝 (∫ x : ℝ≥0, (-(x : ℝ)) ^ (n + 1) ∂μ)) := by
   let K : ℝ → ℝ≥0 → ℝ := fun y x => (-(x : ℝ)) ^ n * Real.exp (-(y * (x : ℝ)))
   refine tendsto_integral_filter_of_dominated_convergence
     (μ := μ) (bound := fun x : ℝ≥0 => (x : ℝ) ^ (n + 1))
-    ?_ ?_ (hmom (n + 1)) ?_
+    ?_ ?_ hbound ?_
   · refine Filter.Eventually.of_forall fun y => ?_
     simp only [slope_def_field]
     fun_prop
@@ -368,7 +367,7 @@ private lemma hasDerivWithinAt_laplaceMomentTransform_zero (μ : Measure ℝ≥0
   have hlim :
       Tendsto (fun y : ℝ => ∫ x : ℝ≥0, slope (fun z : ℝ => K z x) 0 y ∂μ) l
         (𝓝 (∫ x : ℝ≥0, (-(x : ℝ)) ^ (n + 1) ∂μ)) :=
-    tendsto_integral_slope_neg_pow_mul_exp μ hmom n
+    tendsto_integral_slope_neg_pow_mul_exp_neg_mul_at_zero μ n (hmom (n + 1))
   -- Stage 2: the slope of the integral is the integral of the pointwise slopes.
   have hslope :
       (fun y : ℝ => slope (laplaceMomentTransform μ n) 0 y)

--- a/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Laplace/Representation.lean
@@ -327,10 +327,36 @@ private lemma norm_slope_neg_pow_mul_exp_neg_mul_le (n : ℕ) {y : ℝ} (hy : 0 
           simpa [hpow_abs] using mul_le_mul_of_nonneg_left hquot hpow_nonneg
     _ = (x : ℝ) ^ (n + 1) := by rw [pow_succ]
 
+/-- Dominated convergence for the pointwise slopes at `0` of the signed moment kernel
+`y ↦ (-x) ^ n * exp (-(y * x))`: the integrals of those slopes converge to the `(n+1)`-st signed
+moment, dominated by the `(n+1)`-st absolute moment. -/
+private lemma tendsto_integral_slope_neg_pow_mul_exp (μ : Measure ℝ≥0)
+    (hmom : ∀ n : ℕ, Integrable (fun x : ℝ≥0 => (x : ℝ) ^ n) μ) (n : ℕ) :
+    Tendsto (fun y : ℝ => ∫ x : ℝ≥0,
+        slope (fun z : ℝ => (-(x : ℝ)) ^ n * Real.exp (-(z * (x : ℝ)))) 0 y ∂μ)
+      (𝓝[Ici (0 : ℝ) \ {0}] 0) (𝓝 (∫ x : ℝ≥0, (-(x : ℝ)) ^ (n + 1) ∂μ)) := by
+  let K : ℝ → ℝ≥0 → ℝ := fun y x => (-(x : ℝ)) ^ n * Real.exp (-(y * (x : ℝ)))
+  refine tendsto_integral_filter_of_dominated_convergence
+    (μ := μ) (bound := fun x : ℝ≥0 => (x : ℝ) ^ (n + 1))
+    ?_ ?_ (hmom (n + 1)) ?_
+  · refine Filter.Eventually.of_forall fun y => ?_
+    simp only [slope_def_field]
+    fun_prop
+  · filter_upwards [eventually_mem_nhdsWithin] with y hy
+    refine Filter.Eventually.of_forall fun x => ?_
+    exact norm_slope_neg_pow_mul_exp_neg_mul_le n hy.1 x
+  · refine Filter.Eventually.of_forall fun x => ?_
+    have hderiv :
+        HasDerivWithinAt (fun y : ℝ => K y x) ((-(x : ℝ)) ^ (n + 1)) (Ici 0) 0 := by
+      have hlin : HasDerivAt (fun y : ℝ => -(y * (x : ℝ))) (-(x : ℝ)) 0 :=
+        (hasDerivAt_mul_const (x : ℝ)).neg
+      have hder := hlin.exp.const_mul ((-(x : ℝ)) ^ n)
+      simpa [K, pow_succ, mul_assoc, mul_comm, mul_left_comm] using hder.hasDerivWithinAt
+    exact (hasDerivWithinAt_iff_tendsto_slope.mp hderiv)
+
 /-- One-sided differentiation under the integral at the endpoint `t = 0`: within `[0, ∞)` the
 `n`-th signed moment kernel integral has the `(n+1)`-st as derivative, provided all moments are
-finite. Dominated convergence over the pointwise slopes supplies the limit; the slope of the
-integral is first exchanged with the integral of the slopes. -/
+finite. -/
 private lemma hasDerivWithinAt_laplaceMomentTransform_zero (μ : Measure ℝ≥0)
     (hmom : ∀ n : ℕ, Integrable (fun x : ℝ≥0 => (x : ℝ) ^ n) μ) (n : ℕ) :
     HasDerivWithinAt (laplaceMomentTransform μ n) (laplaceMomentTransform μ (n + 1) 0)
@@ -341,25 +367,8 @@ private lemma hasDerivWithinAt_laplaceMomentTransform_zero (μ : Measure ℝ≥0
     (-(x : ℝ)) ^ n * Real.exp (-(y * (x : ℝ)))
   have hlim :
       Tendsto (fun y : ℝ => ∫ x : ℝ≥0, slope (fun z : ℝ => K z x) 0 y ∂μ) l
-        (𝓝 (∫ x : ℝ≥0, (-(x : ℝ)) ^ (n + 1) ∂μ)) := by
-    refine tendsto_integral_filter_of_dominated_convergence
-      (μ := μ) (l := l) (bound := fun x : ℝ≥0 => (x : ℝ) ^ (n + 1))
-      ?_ ?_ (hmom (n + 1)) ?_
-    · exact Filter.Eventually.of_forall fun y => by
-        simpa [slope_def_field] using
-          (by fun_prop : AEStronglyMeasurable
-            (fun x : ℝ≥0 => (K y x - K 0 x) / (y - 0)) μ)
-    · filter_upwards [eventually_mem_nhdsWithin] with y hy
-      refine Filter.Eventually.of_forall fun x => ?_
-      exact norm_slope_neg_pow_mul_exp_neg_mul_le n hy.1 x
-    · refine Filter.Eventually.of_forall fun x => ?_
-      have hderiv :
-          HasDerivWithinAt (fun y : ℝ => K y x) ((-(x : ℝ)) ^ (n + 1)) (Ici 0) 0 := by
-        have hlin : HasDerivAt (fun y : ℝ => -(y * (x : ℝ))) (-(x : ℝ)) 0 := by
-          exact (hasDerivAt_mul_const (x : ℝ)).neg
-        have hder := hlin.exp.const_mul ((-(x : ℝ)) ^ n)
-        simpa [K, pow_succ, mul_assoc, mul_comm, mul_left_comm] using hder.hasDerivWithinAt
-      exact (hasDerivWithinAt_iff_tendsto_slope.mp hderiv)
+        (𝓝 (∫ x : ℝ≥0, (-(x : ℝ)) ^ (n + 1) ∂μ)) :=
+    tendsto_integral_slope_neg_pow_mul_exp μ hmom n
   -- Stage 2: the slope of the integral is the integral of the pointwise slopes.
   have hslope :
       (fun y : ℝ => slope (laplaceMomentTransform μ n) 0 y)


### PR DESCRIPTION
`hasDerivWithinAt_laplaceMomentTransform_zero` had a 52-line proof body, over the 50-line ceiling.
It ran in two stages, and the first is a self-contained dominated-convergence argument.

```
private lemma tendsto_integral_slope_neg_pow_mul_exp_neg_mul_at_zero (μ : Measure ℝ≥0) (n : ℕ)
    (hbound : Integrable (fun x : ℝ≥0 => (x : ℝ) ^ (n + 1)) μ) :
    Tendsto (fun y : ℝ => ∫ x : ℝ≥0,
        slope (fun z : ℝ => (-(x : ℝ)) ^ n * Real.exp (-(z * (x : ℝ)))) 0 y ∂μ)
      (𝓝[Ici (0 : ℝ) \ {0}] 0) (𝓝 (∫ x : ℝ≥0, (-(x : ℝ)) ^ (n + 1) ∂μ))
```

| declaration | before | after |
|---|---|---|
| `hasDerivWithinAt_laplaceMomentTransform_zero` | 52 | 35 |
| `tendsto_integral_slope_neg_pow_mul_exp_neg_mul_at_zero` | — | 18 |

## Minimal hypotheses

The parent carries `hmom : ∀ n, Integrable (fun x => (x : ℝ) ^ n) μ`, but this stage uses exactly
one of those moments, so the helper takes that one. The weakening is real rather than cosmetic:
`hmom 0` is integrability of the constant `1`, which forces `IsFiniteMeasure μ` — the file's own
`isFiniteMeasure_of_integrable_moments` makes that argument — whereas an infinite measure can still
have a finite `(n+1)`-st moment.

The parent's `l` and `K` are inlined into the helper's statement rather than threaded through it,
so the helper mentions neither.

## Filter

`𝓝[Ici (0:ℝ) \ {0}] 0` is exactly what `hasDerivWithinAt_iff_tendsto_slope` produces at
`s = Ici 0`, `x = 0`; no filter conversion is hidden. That set is `Ioi 0`, whose neighbourhood
filter is `NeBot`, so the limit has content rather than holding vacuously.

## Degenerate end

At `n = 0` the kernel is `y ↦ exp (-(y * x))` and the limit is `∫ x, (-(x:ℝ)) ^ 1 ∂μ`, i.e.
`-∫ x, (x:ℝ) ∂μ`; `hbound` is then integrability of the first moment. At `μ = 0` both sides are `0`.

`private`, matching the file's other 13 private declarations. The parent's docstring loses its
sentence describing the proof — the `-- Stage 1` / `-- Stage 2` comments in the body carry that.

Roadmap: OneParameterSemigroups
