### PR TITLE
feat: the excursion process of a recurrent Markov exchangeable process

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
+++ b/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
@@ -27,10 +27,12 @@ loopPath a (excursionPrefix x a m)
 ```
 
 In particular this applies whenever `x` visits `a` infinitely often, and if `x 0 = a`, the result
-is the initial path segment through its `m`-th return to `a`.  This is the combinatorial bridge
-from the finite excursion-reordering theorem in
-`TauCeti.Probability.Exchangeability.Excursion` to the exchangeability of the excursion process
-of a recurrent Markov exchangeable path.
+is the initial path segment through its `m`-th return to `a`.  Read as an equivalence
+(`TauCeti.eqOn_loopPathAt_iff_excursionPrefix_eq`), this is the combinatorial bridge from the finite
+excursion-reordering theorem in `TauCeti.Probability.Exchangeability.Excursion` to the
+exchangeability of the excursion process of a recurrent Markov exchangeable path, which is proved
+in `TauCeti.Probability.Exchangeability.Recurrence.Excursion`: a prescribed list of first
+excursions is nothing but a prescribed finite path.
 
 ## Main definitions
 
@@ -44,6 +46,9 @@ of a recurrent Markov exchangeable path.
   of the original sequence.
 * `TauCeti.loopSteps_excursionPrefix`: the number of reconstructed transitions is the difference
   of the endpoint visit times.
+* `TauCeti.visitCount_loopPathAt`: a loop visits its base state once per excursion.
+* `TauCeti.eqOn_loopPathAt_iff_excursionPrefix_eq`: for a recurrent path, having prescribed first
+  excursions is the same as spelling out their loop word.
 
 ## References
 
@@ -148,6 +153,36 @@ theorem not_mem_excursion (x : ℕ → α) (a : α) (k : ℕ) : a ∉ excursion 
     Nat.le_nth_of_lt_nth_succ (by simpa only [visitTime_def] using hnmem.2) hxn
   have hle : n ≤ visitTime x a k := by simpa only [visitTime_def] using hle'
   omega
+
+/-- No excursion of a finite excursion prefix visits the base state, so such a prefix is a
+legitimate argument for `TauCeti.loopPath_injOn`. -/
+theorem forall_not_mem_excursionPrefix (x : ℕ → α) (a : α) (m : ℕ) :
+    ∀ e ∈ excursionPrefix x a m, a ∉ e := by
+  intro e he
+  rw [excursionPrefix_def] at he
+  obtain ⟨k, -, rfl⟩ := List.mem_map.1 he
+  exact not_mem_excursion x a k
+
+/-- **A loop visits its base state once per excursion.** Counting the visits a loop makes to its
+base letter over its whole span counts its excursions, because an excursion never returns there. -/
+theorem visitCount_loopPathAt (a : α) {bs : List (List α)} (havoid : ∀ e ∈ bs, a ∉ e) :
+    visitCount (loopPathAt a bs) a (loopSteps bs) = bs.length := by
+  induction bs with
+  | nil => simp
+  | cons e bs ih =>
+    -- The initial letter is the only visit inside the first excursion's span.
+    have hfirst : visitCount (loopPathAt a (e :: bs)) a (e.length + 1) = 1 := by
+      have h2 : visitCount (fun i => loopPathAt a (e :: bs) (1 + i)) a e.length = 0 := by
+        refine visitCount_eq_zero_of_forall_ne fun i hi => ?_
+        rw [Nat.add_comm 1 i, loopPathAt_cons_of_lt a e bs hi]
+        exact fun hget => havoid e List.mem_cons_self (hget ▸ List.getElem_mem hi)
+      rw [show e.length + 1 = 1 + e.length from Nat.add_comm _ _, visitCount_add, h2]
+      simp
+    have hshift : (fun i => loopPathAt a (e :: bs) (e.length + 1 + i)) = loopPathAt a bs :=
+      funext (loopPathAt_cons_add a e bs)
+    rw [loopSteps_cons, visitCount_add, hfirst, hshift,
+      ih fun f hf => havoid f (List.mem_cons_of_mem e hf), List.length_cons]
+    omega
 
 /-! ## Reconstruction -/
 
@@ -254,6 +289,42 @@ theorem loopSteps_excursionPrefix_of_infinite_of_zero
     (h : {n | x n = a}.Infinite) (h0 : x 0 = a) (m : ℕ) :
     loopSteps (excursionPrefix x a m) = visitTime x a m :=
   loopSteps_excursionPrefix_of_zero (exists_visitCount_of_infinite h m) h0
+
+/-! ## Excursion prefixes as finite-path events -/
+
+/-- **A recurrent path has prescribed first excursions exactly when it spells out their loop.**
+For a sequence starting at `a` and returning to it infinitely often, and a list `bs` of excursions
+avoiding `a`, the following are the same condition:
+
+* over the span `loopSteps bs` of the loop, the sequence agrees with the loop word of `bs`;
+* the first `bs.length` excursions of the sequence are `bs`.
+
+This is what turns a finite-dimensional event of the excursion process into a finite-path event of
+the sequence itself, which is the form Markov exchangeability constrains. -/
+theorem eqOn_loopPathAt_iff_excursionPrefix_eq {bs : List (List α)} (havoid : ∀ e ∈ bs, a ∉ e)
+    (hinf : {n | x n = a}.Infinite) (h0 : x 0 = a) :
+    (∀ i ≤ loopSteps bs, x i = loopPathAt a bs i) ↔ excursionPrefix x a bs.length = bs := by
+  have hloop := loopPath_excursionPrefix_of_infinite_of_zero hinf h0 bs.length
+  constructor
+  · intro hx
+    -- The `bs.length`-th return of `x` is the end of the loop, so the two loop words agree.
+    have hvt : visitTime x a bs.length = loopSteps bs :=
+      visitTime_eq_of_eqOn hx (loopPathAt_loopSteps a bs) (visitCount_loopPathAt a havoid)
+    refine loopPath_injOn a (forall_not_mem_excursionPrefix x a bs.length) havoid ?_
+    rw [hloop, hvt, ← map_range_loopPathAt a bs]
+    exact List.map_congr_left fun i hi =>
+      hx i (Nat.lt_succ_iff.1 (List.mem_range.1 hi))
+  · intro hpre i hi
+    have hvt : visitTime x a bs.length = loopSteps bs := by
+      rw [← loopSteps_excursionPrefix_of_infinite_of_zero hinf h0 bs.length, hpre]
+    rw [hpre, hvt] at hloop
+    have hmaps : (List.range (loopSteps bs + 1)).map (loopPathAt a bs)
+        = (List.range (loopSteps bs + 1)).map x := by
+      rw [map_range_loopPathAt, hloop]
+    have hi' : i < ((List.range (loopSteps bs + 1)).map (loopPathAt a bs)).length := by
+      simp only [List.length_map, List.length_range]
+      omega
+    simpa using (List.getElem_of_eq hmaps hi').symm
 
 end TauCeti
 

--- a/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
+++ b/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
@@ -47,8 +47,8 @@ excursions is nothing but a prescribed finite path.
 * `TauCeti.loopSteps_excursionPrefix`: the number of reconstructed transitions is the difference
   of the endpoint visit times.
 * `TauCeti.visitCount_loopPathAt`: a loop visits its base state once per excursion.
-* `TauCeti.eqOn_loopPathAt_iff_excursionPrefix_eq`: for a recurrent path, having prescribed first
-  excursions is the same as spelling out their loop word.
+* `TauCeti.eqOn_loopPathAt_iff_excursionPrefix_eq`: for a path whose relevant return exists, having
+  prescribed first excursions is the same as spelling out their loop word.
 
 ## References
 
@@ -176,7 +176,7 @@ theorem visitCount_loopPathAt (a : α) {bs : List (List α)} (havoid : ∀ e ∈
         refine visitCount_eq_zero_of_forall_ne fun i hi => ?_
         rw [Nat.add_comm 1 i, loopPathAt_cons_of_lt a e bs hi]
         exact fun hget => havoid e List.mem_cons_self (hget ▸ List.getElem_mem hi)
-      rw [show e.length + 1 = 1 + e.length from Nat.add_comm _ _, visitCount_add, h2]
+      rw [Nat.add_comm e.length 1, visitCount_add, h2]
       simp
     have hshift : (fun i => loopPathAt a (e :: bs) (e.length + 1 + i)) = loopPathAt a bs :=
       funext (loopPathAt_cons_add a e bs)
@@ -292,9 +292,9 @@ theorem loopSteps_excursionPrefix_of_infinite_of_zero
 
 /-! ## Excursion prefixes as finite-path events -/
 
-/-- **A recurrent path has prescribed first excursions exactly when it spells out their loop.**
-For a sequence starting at `a` and returning to it infinitely often, and a list `bs` of excursions
-avoiding `a`, the following are the same condition:
+/-- **A returning path has prescribed first excursions exactly when it spells out their loop.**
+For a sequence starting at `a` whose `bs.length`-th return to `a` exists, and a list `bs` of
+excursions avoiding `a`, the following are the same condition:
 
 * over the span `loopSteps bs` of the loop, the sequence agrees with the loop word of `bs`;
 * the first `bs.length` excursions of the sequence are `bs`.
@@ -302,9 +302,9 @@ avoiding `a`, the following are the same condition:
 This is what turns a finite-dimensional event of the excursion process into a finite-path event of
 the sequence itself, which is the form Markov exchangeability constrains. -/
 theorem eqOn_loopPathAt_iff_excursionPrefix_eq {bs : List (List α)} (havoid : ∀ e ∈ bs, a ∉ e)
-    (hinf : {n | x n = a}.Infinite) (h0 : x 0 = a) :
+    (h : ∃ n, x n = a ∧ visitCount x a n = bs.length) (h0 : x 0 = a) :
     (∀ i ≤ loopSteps bs, x i = loopPathAt a bs i) ↔ excursionPrefix x a bs.length = bs := by
-  have hloop := loopPath_excursionPrefix_of_infinite_of_zero hinf h0 bs.length
+  have hloop := loopPath_excursionPrefix_of_zero h h0
   constructor
   · intro hx
     -- The `bs.length`-th return of `x` is the end of the loop, so the two loop words agree.
@@ -316,7 +316,7 @@ theorem eqOn_loopPathAt_iff_excursionPrefix_eq {bs : List (List α)} (havoid : �
       hx i (Nat.lt_succ_iff.1 (List.mem_range.1 hi))
   · intro hpre i hi
     have hvt : visitTime x a bs.length = loopSteps bs := by
-      rw [← loopSteps_excursionPrefix_of_infinite_of_zero hinf h0 bs.length, hpre]
+      rw [← loopSteps_excursionPrefix_of_zero h h0, hpre]
     rw [hpre, hvt] at hloop
     have hmaps : (List.range (loopSteps bs + 1)).map (loopPathAt a bs)
         = (List.range (loopSteps bs + 1)).map x := by

--- a/TauCeti/Combinatorics/Enumerative/LoopWord.lean
+++ b/TauCeti/Combinatorics/Enumerative/LoopWord.lean
@@ -151,7 +151,6 @@ theorem loopPathAt_def (a₀ : α) (bs : List (List α)) (i : ℕ) :
 theorem loopPathAt_zero (a₀ : α) (bs : List (List α)) : loopPathAt a₀ bs 0 = a₀ := by
   cases bs <;> simp [loopPathAt_def]
 
-@[simp]
 theorem loopPathAt_loopSteps (a₀ : α) (bs : List (List α)) :
     loopPathAt a₀ bs (loopSteps bs) = a₀ := by
   induction bs with
@@ -163,6 +162,7 @@ theorem loopPathAt_loopSteps (a₀ : α) (bs : List (List α)) :
     simpa [loopPathAt_def] using ih
 
 /-- Inside its first excursion, a loop spells that excursion out. -/
+@[simp]
 theorem loopPathAt_cons_of_lt (a₀ : α) (e : List α) (bs : List (List α)) {i : ℕ}
     (hi : i < e.length) : loopPathAt a₀ (e :: bs) (i + 1) = e[i] := by
   rw [loopPathAt_def, loopPath_cons, List.getD_cons_succ,
@@ -181,7 +181,8 @@ theorem loopPathAt_cons_add (a₀ : α) (e : List α) (bs : List (List α)) (i :
 
 /-- A loop sits at its base letter from its final letter onwards: `loopPathAt` pads with the base
 letter past the end of the word. -/
-theorem loopPathAt_of_loopSteps_le (a₀ : α) (bs : List (List α)) {i : ℕ}
+@[simp]
+theorem loopPathAt_eq_of_loopSteps_le (a₀ : α) (bs : List (List α)) {i : ℕ}
     (hi : loopSteps bs ≤ i) : loopPathAt a₀ bs i = a₀ := by
   rcases eq_or_lt_of_le hi with rfl | hlt
   · exact loopPathAt_loopSteps a₀ bs
@@ -191,7 +192,7 @@ theorem loopPathAt_of_loopSteps_le (a₀ : α) (bs : List (List α)) {i : ℕ}
 letter. This is what lets the excursion decomposition of a loop be read with no side condition. -/
 theorem infinite_setOf_loopPathAt_eq (a₀ : α) (bs : List (List α)) :
     {i | loopPathAt a₀ bs i = a₀}.Infinite :=
-  (Set.Ici_infinite (loopSteps bs)).mono fun _ hi => loopPathAt_of_loopSteps_le a₀ bs hi
+  (Set.Ici_infinite (loopSteps bs)).mono fun _ hi => loopPathAt_eq_of_loopSteps_le a₀ bs hi
 
 /-- **A loop read as a function on `ℕ` recovers the loop word.** Reading `loopPathAt` over the
 whole span of the loop spells out `loopPath` again. -/

--- a/TauCeti/Combinatorics/Enumerative/LoopWord.lean
+++ b/TauCeti/Combinatorics/Enumerative/LoopWord.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.BigOperators.Group.List.Basic
 public import Mathlib.Data.List.GetD
 public import Mathlib.Data.List.Perm.Basic
 public import Mathlib.Data.Set.Function
+public import Mathlib.Order.Interval.Set.Infinite
 public import TauCeti.Combinatorics.Enumerative.TransitionCount
 
 /-!
@@ -58,6 +59,11 @@ length `n + 1` as such a word through `List.getD`. Both of those list lemmas liv
 * `TauCeti.exists_loopPath`: every word that starts and ends at `a₀` is a loop path, with
   excursions that avoid `a₀`.
 * `TauCeti.loopPath_injOn`: those excursions are unique.
+* `TauCeti.loopPathAt_cons_add`: past its first excursion a loop is the loop of the remaining ones.
+* `TauCeti.infinite_setOf_loopPathAt_eq`: read as a function on `ℕ`, a loop returns to its base
+  letter infinitely often.
+* `TauCeti.map_range_loopPathAt`: reading that function over the loop's span spells the loop word
+  out again.
 
 ## References
 
@@ -155,6 +161,45 @@ theorem loopPathAt_loopSteps (a₀ : α) (bs : List (List α)) :
     rw [loopPathAt_def, loopPath_cons, loopSteps_cons, hstep, List.getD_cons_succ,
       List.getD_append_right _ _ _ _ (by omega)]
     simpa [loopPathAt_def] using ih
+
+/-- Inside its first excursion, a loop spells that excursion out. -/
+theorem loopPathAt_cons_of_lt (a₀ : α) (e : List α) (bs : List (List α)) {i : ℕ}
+    (hi : i < e.length) : loopPathAt a₀ (e :: bs) (i + 1) = e[i] := by
+  rw [loopPathAt_def, loopPath_cons, List.getD_cons_succ,
+    List.getD_append _ _ _ _ hi, List.getD_eq_getElem _ _ hi]
+
+/-- **Past its first excursion, a loop is the loop of the remaining excursions.** The shift is by
+the length of that excursion plus the one step returning to the base letter. -/
+@[simp]
+theorem loopPathAt_cons_add (a₀ : α) (e : List α) (bs : List (List α)) (i : ℕ) :
+    loopPathAt a₀ (e :: bs) (e.length + 1 + i) = loopPathAt a₀ bs i := by
+  have hidx : e.length + 1 + i = e.length + i + 1 := by omega
+  rw [loopPathAt_def, loopPath_cons, hidx, List.getD_cons_succ,
+    List.getD_append_right _ _ _ _ (by omega), loopPathAt_def]
+  congr 1
+  omega
+
+/-- A loop sits at its base letter from its final letter onwards: `loopPathAt` pads with the base
+letter past the end of the word. -/
+theorem loopPathAt_of_loopSteps_le (a₀ : α) (bs : List (List α)) {i : ℕ}
+    (hi : loopSteps bs ≤ i) : loopPathAt a₀ bs i = a₀ := by
+  rcases eq_or_lt_of_le hi with rfl | hlt
+  · exact loopPathAt_loopSteps a₀ bs
+  · exact List.getD_eq_default _ _ (by rw [length_loopPath]; omega)
+
+/-- **A loop returns to its base letter infinitely often**, since `loopPathAt` pads with that
+letter. This is what lets the excursion decomposition of a loop be read with no side condition. -/
+theorem infinite_setOf_loopPathAt_eq (a₀ : α) (bs : List (List α)) :
+    {i | loopPathAt a₀ bs i = a₀}.Infinite :=
+  (Set.Ici_infinite (loopSteps bs)).mono fun _ hi => loopPathAt_of_loopSteps_le a₀ bs hi
+
+/-- **A loop read as a function on `ℕ` recovers the loop word.** Reading `loopPathAt` over the
+whole span of the loop spells out `loopPath` again. -/
+theorem map_range_loopPathAt (a₀ : α) (bs : List (List α)) :
+    (List.range (loopSteps bs + 1)).map (loopPathAt a₀ bs) = loopPath a₀ bs := by
+  refine List.ext_getElem (by simp) fun i hi hi' => ?_
+  rw [List.getElem_map, List.getElem_range, loopPathAt_def,
+    List.getD_eq_getElem _ _ hi']
 
 /-- A loop always starts at its base letter. -/
 theorem loopPath_eq_cons_tail (a₀ : α) (bs : List (List α)) :

--- a/TauCeti/Combinatorics/Enumerative/SuccessorArray.lean
+++ b/TauCeti/Combinatorics/Enumerative/SuccessorArray.lean
@@ -27,6 +27,9 @@ The reconstruction is total: entries after the last genuine visit use the junk v
 ## Main results
 
 * `TauCeti.visitCount_monotone`: visit counts are monotone in the horizon.
+* `TauCeti.visitCount_add`: a visit count splits at any intermediate index.
+* `TauCeti.visitTime_eq_of_eqOn`: a visit time is read off any sequence agreeing with the original
+  up to that time.
 * `TauCeti.successorArray_visitCount`: the defining step relation of the successor array.
 * `TauCeti.visitTime_eq_iff`: the fibres of the visit times, including the junk-value branch.
 * `TauCeti.apply_visitTime_of_infinite` and `TauCeti.visitTime_strictMono_of_infinite`: visit
@@ -175,11 +178,45 @@ theorem visitCount_succ_of_ne (h : x n ≠ a) : visitCount x a (n + 1) = visitCo
   classical
   rw [visitCount_succ, ite_eq_right h]
 
+/-- **Splitting a visit count at an intermediate index.** The visits before `m + n` are the visits
+before `m` together with the visits the sequence shifted by `m` makes before `n`. -/
+theorem visitCount_add (x : ℕ → α) (a : α) (m n : ℕ) :
+    visitCount x a (m + n) = visitCount x a m + visitCount (fun i => x (m + i)) a n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [← Nat.add_assoc]
+    by_cases hx : x (m + n) = a
+    · rw [visitCount_succ_of_eq hx, ih, visitCount_succ_of_eq (x := fun i => x (m + i)) hx]
+      omega
+    · rw [visitCount_succ_of_ne hx, ih, visitCount_succ_of_ne (x := fun i => x (m + i)) hx]
+
+/-- A stretch of a sequence that avoids `a` contributes nothing to its visit count. -/
+theorem visitCount_eq_zero_of_forall_ne (h : ∀ i < n, x i ≠ a) : visitCount x a n = 0 := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [visitCount_succ_of_ne (h n (Nat.lt_succ_self n)),
+      ih fun i hi => h i (hi.trans (Nat.lt_succ_self n))]
+
 /-- A time at which `x` has value `a` is the visit indexed by the number of earlier visits. -/
 @[simp]
 theorem visitTime_visitCount (h : x n = a) : visitTime x a (visitCount x a n) = n := by
   classical
   rw [visitTime, visitCount_eq_count, Nat.nth_count h]
+
+/-- **A visit time is read off any sequence agreeing with the original up to that time.** If `x`
+and `y` agree through index `n`, and `n` is a visit of `y` to `a` preceded by exactly `k` earlier
+visits, then `n` is the `k`-th visit of `x` as well.
+
+This is what transfers the visit structure of a reference path to a process known only to spell
+that path out over a finite horizon. -/
+theorem visitTime_eq_of_eqOn (hxy : ∀ i ≤ n, x i = y i) (hy : y n = a)
+    (hcount : visitCount y a n = k) : visitTime x a k = n := by
+  have hxc : visitCount x a n = k := by
+    rw [visitCount_congr fun i hi => hxy i hi.le, hcount]
+  rw [← hxc]
+  exact visitTime_visitCount ((hxy n le_rfl).trans hy)
 
 /-- The fibres of `visitTime`, including the junk-value branch. -/
 theorem visitTime_eq_iff :

--- a/TauCeti/Combinatorics/Enumerative/SuccessorArray.lean
+++ b/TauCeti/Combinatorics/Enumerative/SuccessorArray.lean
@@ -182,22 +182,13 @@ theorem visitCount_succ_of_ne (h : x n ≠ a) : visitCount x a (n + 1) = visitCo
 before `m` together with the visits the sequence shifted by `m` makes before `n`. -/
 theorem visitCount_add (x : ℕ → α) (a : α) (m n : ℕ) :
     visitCount x a (m + n) = visitCount x a m + visitCount (fun i => x (m + i)) a n := by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-    rw [← Nat.add_assoc]
-    by_cases hx : x (m + n) = a
-    · rw [visitCount_succ_of_eq hx, ih, visitCount_succ_of_eq (x := fun i => x (m + i)) hx]
-      omega
-    · rw [visitCount_succ_of_ne hx, ih, visitCount_succ_of_ne (x := fun i => x (m + i)) hx]
+  classical
+  simpa only [visitCount_eq_count] using Nat.count_add (p := fun i => x i = a) m n
 
 /-- A stretch of a sequence that avoids `a` contributes nothing to its visit count. -/
 theorem visitCount_eq_zero_of_forall_ne (h : ∀ i < n, x i ≠ a) : visitCount x a n = 0 := by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-    rw [visitCount_succ_of_ne (h n (Nat.lt_succ_self n)),
-      ih fun i hi => h i (hi.trans (Nat.lt_succ_self n))]
+  classical
+  simpa only [visitCount_eq_count] using Nat.count_iff_forall_not.2 h
 
 /-- A time at which `x` has value `a` is the visit indexed by the number of earlier visits. -/
 @[simp]

--- a/TauCeti/MeasureTheory/MeasurableSpace/List.lean
+++ b/TauCeti/MeasureTheory/MeasurableSpace/List.lean
@@ -5,40 +5,53 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.MeasureTheory.MeasurableSpace.Defs
+public import Mathlib.MeasureTheory.MeasurableSpace.Constructions
 
 /-!
-# The measurable structure on lists over a countable type
+# The measurable structure on lists
 
-Mathlib equips no type of lists with a measurable structure. For a **countable** `α` there is only
-one reasonable choice: `List α` is then itself countable, and Mathlib gives every countable type it
-names outright — `ℕ`, `ℤ`, `ℚ`, `Bool`, `Fin n` — the discrete σ-algebra. This file records that
-structure, so that a process whose values are finite words over a countable alphabet, such as the
-excursion process of a path, is a measurable object.
+Mathlib equips no type of lists with a measurable structure. This file gives `List α` the structure
+transported from its length-indexed representation `Σ n, Fin n → α`. Thus each fixed-length stratum
+has the finite product structure, and the list space is their countable disjoint union.
 
-The `Countable α` hypothesis is what confines the instance to the situation it is right for. Over
-an uncountable `α` the discrete σ-algebra on `List α` is not the intended one — the structure
-transported from `Σ n, Fin n → α` is — and the instance below deliberately does not apply there.
+When `α` is countable and discrete, this structure is discrete too. In particular, a process whose
+values are finite words over a countable alphabet, such as the excursion process of a path, has a
+countable discrete value space.
 
 ## Main definitions
 
-* `TauCeti.instMeasurableSpaceList`: the discrete measurable structure on `List α` for countable
-  `α`.
+* `TauCeti.instMeasurableSpaceList`: the measurable structure on `List α` induced by its
+  length-indexed representation.
+* `TauCeti.instDiscreteMeasurableSpaceList`: discreteness when `α` is countable and discrete.
 -/
 
 public section
 
 namespace TauCeti
 
-variable {α : Type*} [Countable α]
+variable {α : Type*} [MeasurableSpace α]
 
-/-- **Lists over a countable type carry the discrete measurable structure.** -/
-instance instMeasurableSpaceList : MeasurableSpace (List α) := ⊤
+/-- The measurable structure on lists induced through
+`List.equivSigmaTuple : List α ≃ Σ n, Fin n → α`. -/
+instance instMeasurableSpaceList : MeasurableSpace (List α) :=
+  MeasurableSpace.comap List.equivSigmaTuple inferInstance
 
-/-- Every set of lists over a countable type is measurable. `MeasurableSingletonClass (List α)`
-follows through `DiscreteMeasurableSpace.toMeasurableSingletonClass`. -/
-instance instDiscreteMeasurableSpaceList : DiscreteMeasurableSpace (List α) :=
-  ⟨fun _ => MeasurableSpace.measurableSet_top⟩
+/-- Lists over a countable discrete measurable space form a discrete measurable space. -/
+instance instDiscreteMeasurableSpaceList [Countable α] [DiscreteMeasurableSpace α] :
+    DiscreteMeasurableSpace (List α) :=
+  ⟨fun s => by
+    -- Unfold measurability in the structure pulled back along the list-tuple equivalence.
+    change ∃ t : Set (Σ n, Fin n → α), MeasurableSet t ∧
+      Set.preimage (List.equivSigmaTuple : List α → Σ n, Fin n → α) t = s
+    refine ⟨Set.image List.equivSigmaTuple s, ?_, ?_⟩
+    -- The sigma measurable space tests measurability separately on each fixed-length stratum.
+    · apply MeasurableSpace.measurableSet_iInf.2
+      intro n
+      change MeasurableSet (Set.preimage (Sigma.mk n) (Set.image List.equivSigmaTuple s))
+      let _ : MeasurableSingletonClass (Fin n → α) := inferInstance
+      let _ : DiscreteMeasurableSpace (Fin n → α) := inferInstance
+      exact MeasurableSet.of_discrete
+    · exact Set.preimage_image_eq s List.equivSigmaTuple.injective⟩
 
 end TauCeti
 

--- a/TauCeti/MeasureTheory/MeasurableSpace/List.lean
+++ b/TauCeti/MeasureTheory/MeasurableSpace/List.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.MeasurableSpace.Defs
+
+/-!
+# The measurable structure on lists over a countable type
+
+Mathlib equips no type of lists with a measurable structure. For a **countable** `α` there is only
+one reasonable choice: `List α` is then itself countable, and Mathlib gives every countable type it
+names outright — `ℕ`, `ℤ`, `ℚ`, `Bool`, `Fin n` — the discrete σ-algebra. This file records that
+structure, so that a process whose values are finite words over a countable alphabet, such as the
+excursion process of a path, is a measurable object.
+
+The `Countable α` hypothesis is what confines the instance to the situation it is right for. Over
+an uncountable `α` the discrete σ-algebra on `List α` is not the intended one — the structure
+transported from `Σ n, Fin n → α` is — and the instance below deliberately does not apply there.
+
+## Main definitions
+
+* `TauCeti.instMeasurableSpaceList`: the discrete measurable structure on `List α` for countable
+  `α`.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {α : Type*} [Countable α]
+
+/-- **Lists over a countable type carry the discrete measurable structure.** -/
+instance instMeasurableSpaceList : MeasurableSpace (List α) := ⊤
+
+/-- Every set of lists over a countable type is measurable. `MeasurableSingletonClass (List α)`
+follows through `DiscreteMeasurableSpace.toMeasurableSingletonClass`. -/
+instance instDiscreteMeasurableSpaceList : DiscreteMeasurableSpace (List α) :=
+  ⟨fun _ => MeasurableSpace.measurableSet_top⟩
+
+end TauCeti
+
+end

--- a/TauCeti/Probability/Exchangeability/Excursion.lean
+++ b/TauCeti/Probability/Exchangeability/Excursion.lean
@@ -36,11 +36,13 @@ exchangeable processes rests on: a recurrent Markov exchangeable process returns
 state infinitely often, so its excursions from that state form a genuine sequence of random
 finite paths, and the identities below are that sequence's finite-dimensional exchangeability.
 The combinatorial excursion process and its reconstruction of a recurrent path segment are set up
-in `TauCeti.Combinatorics.Enumerative.ExcursionProcess`.  Assembling the probability identities
-below into exchangeability of that process, and running de Finetti on it to exhibit the original
-process as a mixture of Markov chains (`TauCeti.Probability.MixedMarkovChain`, whose converse
-direction is `TauCeti.Probability.MixedMarkovChainWith.markovExchangeable`), still needs the
-recurrence hypothesis at the process level.
+in `TauCeti.Combinatorics.Enumerative.ExcursionProcess`, and
+`TauCeti.Probability.Exchangeability.Recurrence.Excursion` adds the recurrence hypothesis at the
+process level to assemble the identities below into exchangeability of that process
+(`TauCeti.Probability.MarkovExchangeable.exchangeable_excursionProcess`) and to run de Finetti on
+it.  Exhibiting the original process as a mixture of Markov chains
+(`TauCeti.Probability.MixedMarkovChain`, whose converse direction is
+`TauCeti.Probability.MixedMarkovChainWith.markovExchangeable`) is the remaining step.
 
 ## Main results
 

--- a/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.MeasureTheory.MeasurableSpace.List
+public import TauCeti.Probability.DeFinetti.Theorem
+public import TauCeti.Probability.Exchangeability.Excursion
+public import TauCeti.Probability.Exchangeability.SuccessorArray
+public import TauCeti.Probability.Recurrent
+
+/-!
+# The excursion process of a recurrent Markov exchangeable process
+
+A recurrent process that starts at a state `a₀` returns to it infinitely often, so its path splits
+into an infinite sequence of excursions away from `a₀`. This file assembles that sequence into the
+**excursion process** `excursionProcess X a₀`, a process valued in the finite words `List α`, and
+proves the theorem the Diaconis–Freedman representation rests on: for a **Markov exchangeable**
+process the excursion process is **exchangeable**
+(`TauCeti.Probability.MarkovExchangeable.exchangeable_excursionProcess`). De Finetti's theorem then
+applies to it, making the excursions conditionally i.i.d.
+(`TauCeti.Probability.MarkovExchangeable.conditionallyIID_excursionProcess`).
+
+## How the two symmetries meet
+
+Markov exchangeability constrains **finite-path** events: the mass of a finite path depends only on
+its initial state and its transition counts. Exchangeability of the excursion process asks instead
+about events of the *excursions*. The bridge is that under recurrence these are the same events.
+Prescribing the first `bs.length` excursions of a path starting at `a₀` says exactly that, over the
+span `loopSteps bs` of the loop they spell out, the path is the loop word `loopPathAt a₀ bs`
+(`TauCeti.eqOn_loopPathAt_iff_excursionPrefix_eq`). Reordering the excursions leaves the initial
+state and the transition counts alone, so
+`TauCeti.Probability.MarkovExchangeable.measure_setOf_loopPathAt_eq_of_perm` gives the two loops
+equal mass, and the finite-dimensional laws of the excursion process are therefore permutation
+invariant.
+
+Recurrence is what makes the bridge two-way, and it is a genuine hypothesis: the deterministic walk
+of `TauCeti/Probability/Exchangeability/Recurrence/AbsorbedWalk.lean` is Markov exchangeable and
+leaves its initial state for good.
+
+Lists over the countable state space carry the discrete measurable structure of
+`TauCeti/MeasureTheory/MeasurableSpace/List.lean`, under which they are a countable, hence standard
+Borel, value space — so de Finetti's theorem needs no hypothesis beyond the countability Markov
+exchangeability already carries.
+
+## Main definitions
+
+* `TauCeti.Probability.excursionProcess`: the sequence of excursions of a process away from a base
+  state.
+
+## Main results
+
+* `TauCeti.Probability.measurable_excursion`: an excursion is a measurable function of the path.
+* `TauCeti.Probability.Recurrent.measure_setOf_excursionPrefix_eq`: under recurrence, prescribing
+  the first excursions is a finite-path event.
+* `TauCeti.Probability.MarkovExchangeable.measure_setOf_excursionPrefix_eq_of_perm`: reordering a
+  list of excursions does not change the probability that it is the process's list of first
+  excursions.
+* `TauCeti.Probability.MarkovExchangeable.exchangeable_excursionProcess`: **the excursion process
+  of a recurrent Markov exchangeable process is exchangeable**.
+* `TauCeti.Probability.MarkovExchangeable.conditionallyIID_excursionProcess`: de Finetti's theorem
+  applied to it.
+
+## References
+
+* P. Diaconis and D. Freedman, "de Finetti's theorem for Markov chains", *Annals of Probability*
+  8 (1980), 115–130.
+* Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, "Markov exchangeability".
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable rather than
+Markov exchangeable sequences.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-! ## The excursion process -/
+
+/-- The excursion process of `X` away from `a₀`: its `k`-th value is the finite word the sample
+path traverses strictly between its `k`-th and `(k + 1)`-st visits to `a₀`. -/
+def excursionProcess (X : ℕ → Ω → α) (a₀ : α) : ℕ → Ω → List α :=
+  fun k ω => excursion (fun n => X n ω) a₀ k
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
+@[simp]
+theorem excursionProcess_apply (X : ℕ → Ω → α) (a₀ : α) (k : ℕ) (ω : Ω) :
+    excursionProcess X a₀ k ω = excursion (fun n => X n ω) a₀ k :=
+  (rfl)
+
+/-! ## Measurability -/
+
+section Measurability
+
+variable [Countable α] [MeasurableSingletonClass α]
+
+/-- Reading a fixed finite list of times off a path is measurable. -/
+private theorem measurable_map_of_path (l : List ℕ) :
+    Measurable fun x : ℕ → α => l.map x := by
+  induction l with
+  | nil => exact measurable_const
+  | cons i l ih =>
+    have hcons : Measurable fun q : α × List α => q.1 :: q.2 :=
+      measurable_from_prod_countable_left fun _ => Measurable.of_discrete
+    exact hcons.comp ((measurable_pi_apply i).prodMk ih)
+
+/-- **An excursion is a measurable function of the path.** The two endpoint visit times are
+measurable and range over a countable set, and on each of their fibres the excursion reads a fixed
+finite list of coordinates. -/
+theorem measurable_excursion (a₀ : α) (k : ℕ) :
+    Measurable fun x : ℕ → α => excursion x a₀ k := by
+  have hidx : Measurable fun x : ℕ → α => (visitTime x a₀ k + 1, visitTime x a₀ (k + 1)) :=
+    (Measurable.of_discrete.comp
+        (measurable_visitTime a₀ k (measurableSet_singleton a₀))).prodMk
+      (measurable_visitTime a₀ (k + 1) (measurableSet_singleton a₀))
+  have hread : Measurable fun p : (ℕ → α) × ℕ × ℕ => (List.Ico p.2.1 p.2.2).map p.1 :=
+    measurable_from_prod_countable_left fun q => measurable_map_of_path (List.Ico q.1 q.2)
+  have hunfold : (fun x : ℕ → α => excursion x a₀ k) =
+      fun x : ℕ → α => (List.Ico (visitTime x a₀ k + 1) (visitTime x a₀ (k + 1))).map x :=
+    funext fun x => excursion_def x a₀ k
+  rw [hunfold]
+  exact hread.comp (measurable_id.prodMk hidx)
+
+/-- Every excursion of a process with a.e. measurable coordinates is a.e. measurable. -/
+theorem aemeasurable_excursionProcess {μ : Measure Ω} {X : ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (X i) μ) (a₀ : α) (k : ℕ) :
+    AEMeasurable (excursionProcess X a₀ k) μ :=
+  (measurable_excursion a₀ k).comp_aemeasurable (aemeasurable_pi_lambda _ hX)
+
+end Measurability
+
+/-! ## Excursion events are finite-path events -/
+
+variable {μ : Measure Ω} {X : ℕ → Ω → α} {a₀ : α}
+
+omit [MeasurableSpace α] in
+/-- **Under recurrence, prescribing the first excursions is a finite-path event.** For a process
+almost surely starting at `a₀`, having `bs` as its first `bs.length` excursions is, up to a null
+set, spelling out the loop word of `bs`. -/
+theorem Recurrent.measure_setOf_excursionPrefix_eq (hrec : Recurrent μ X)
+    (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) {bs : List (List α)} (havoid : ∀ e ∈ bs, a₀ ∉ e) :
+    μ {ω | excursionPrefix (fun n => X n ω) a₀ bs.length = bs} =
+      μ {ω | ∀ i ≤ loopSteps bs, X i ω = loopPathAt a₀ bs i} := by
+  refine (measure_congr (Filter.eventuallyEq_set.2 ?_)).symm
+  filter_upwards [h0, hrec.ae_infinite_setOf_eq] with ω hω0 hωinf
+  have hinf : {n | X n ω = a₀}.Infinite := by
+    have h := hωinf 0
+    rwa [hω0] at h
+  exact eqOn_loopPathAt_iff_excursionPrefix_eq havoid hinf hω0
+
+/-- **Reordering a list of excursions does not change the probability that a recurrent Markov
+exchangeable process traverses it.** No hypothesis on the list is needed: excursions never visit
+the base state, so if some entry of `bs` does, both events are empty. -/
+theorem MarkovExchangeable.measure_setOf_excursionPrefix_eq_of_perm (h : MarkovExchangeable μ X)
+    (hrec : Recurrent μ X) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) {bs bs' : List (List α)}
+    (hperm : bs.Perm bs') :
+    μ {ω | excursionPrefix (fun n => X n ω) a₀ bs.length = bs} =
+      μ {ω | excursionPrefix (fun n => X n ω) a₀ bs'.length = bs'} := by
+  by_cases havoid : ∀ e ∈ bs, a₀ ∉ e
+  · have havoid' : ∀ e ∈ bs', a₀ ∉ e := fun e he => havoid e (hperm.mem_iff.2 he)
+    rw [hrec.measure_setOf_excursionPrefix_eq h0 havoid,
+      hrec.measure_setOf_excursionPrefix_eq h0 havoid',
+      ← loopSteps_eq_of_perm hperm]
+    exact h.measure_setOf_loopPathAt_eq_of_perm a₀ hperm rfl
+  · -- A list with an entry through the base state is nobody's list of excursions.
+    have hempty : ∀ cs : List (List α), ¬(∀ e ∈ cs, a₀ ∉ e) →
+        μ {ω | excursionPrefix (fun n => X n ω) a₀ cs.length = cs} = 0 := by
+      intro cs hcs
+      convert measure_empty (μ := μ)
+      refine Set.eq_empty_of_forall_notMem fun ω hω => hcs ?_
+      rw [← hω]
+      exact forall_not_mem_excursionPrefix _ a₀ cs.length
+    rw [hempty bs havoid,
+      hempty bs' fun hbs' => havoid fun e he => hbs' e (hperm.mem_iff.mp he)]
+
+/-! ## Exchangeability of the excursion process -/
+
+section Exchangeable
+
+-- `Countable α` is carried by `MarkovExchangeable` itself, but it has to be a binder here: without
+-- it `List α` has no measurable structure, so the conclusions below do not even elaborate.
+variable [Countable α]
+
+omit [MeasurableSpace Ω] [MeasurableSpace α] [Countable α] in
+/-- A finite-dimensional event of the excursion process, read as an event of the excursion
+prefix. -/
+private theorem setOf_forall_excursion_eq {m : ℕ} (v : Fin m → List α) :
+    {ω | ∀ i : Fin m, excursionProcess X a₀ i.val ω = v i} =
+      {ω | excursionPrefix (fun n => X n ω) a₀ (List.ofFn v).length = List.ofFn v} := by
+  ext ω
+  simp only [Set.mem_ofPred_eq, excursionProcess_apply, List.length_ofFn]
+  constructor
+  · intro hv
+    refine List.ext_getElem (by simp) fun j hj hj' => ?_
+    have hjm : j < m := by simpa using hj
+    rw [List.getElem_ofFn, getElem_excursionPrefix hjm]
+    exact hv ⟨j, hjm⟩
+  · intro hv i
+    have hi : i.val < (excursionPrefix (fun n => X n ω) a₀ m).length := by simp
+    simpa using List.getElem_of_eq hv hi
+
+/-- **The excursion process of a recurrent Markov exchangeable process is exchangeable.**
+
+This is the half of the Diaconis–Freedman representation theorem that consumes the recurrence
+hypothesis. Its finite-dimensional laws are permutation invariant because each of them is the mass
+of a finite path, and reordering the excursions of a path preserves both its initial state and its
+transition counts — the sufficient statistic Markov exchangeability sees. -/
+theorem MarkovExchangeable.exchangeable_excursionProcess (h : MarkovExchangeable μ X)
+    (hrec : Recurrent μ X) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
+    Exchangeable μ (excursionProcess X a₀) := by
+  have : MeasurableSingletonClass α := h.measurableSingletonClass
+  have hmeas : ∀ k, AEMeasurable (excursionProcess X a₀ k) μ :=
+    aemeasurable_excursionProcess h.aemeasurable a₀
+  intro m σ
+  refine Measure.ext_of_singleton fun v => ?_
+  rw [prefixLaw_def,
+    blockLaw_apply_of_measurable _ _ _ (fun i => hmeas _) (measurableSet_singleton v),
+    blockLaw_apply_of_measurable _ _ _ (fun i => hmeas _) (measurableSet_singleton v)]
+  -- Both singleton masses are excursion-prefix events, at lists differing by the permutation.
+  have hleft : (fun ω i => excursionProcess X a₀ (σ i).val ω) ⁻¹' {v} =
+      {ω | ∀ i : Fin m, excursionProcess X a₀ i.val ω = v (σ.symm i)} := by
+    ext ω
+    simp only [Set.mem_preimage, Set.mem_singleton_iff, Set.mem_ofPred_eq, funext_iff]
+    exact ⟨fun hv i => by simpa using hv (σ.symm i), fun hv i => by simpa using hv (σ i)⟩
+  have hright : (fun ω i => excursionProcess X a₀ i.val ω) ⁻¹' {v} =
+      {ω | ∀ i : Fin m, excursionProcess X a₀ i.val ω = v i} := by
+    ext ω
+    simp only [Set.mem_preimage, Set.mem_singleton_iff, Set.mem_ofPred_eq, funext_iff]
+  rw [hleft, hright, setOf_forall_excursion_eq, setOf_forall_excursion_eq]
+  exact h.measure_setOf_excursionPrefix_eq_of_perm hrec h0
+    (Equiv.Perm.ofFn_comp_perm σ.symm v)
+
+/-- **De Finetti for the excursions of a recurrent Markov exchangeable process.** The excursions
+away from the initial state are conditionally i.i.d. finite words.
+
+The value space needs no hypothesis: over a countable state space the finite words form a countable
+discrete space, which is standard Borel and nonempty. -/
+theorem MarkovExchangeable.conditionallyIID_excursionProcess [IsFiniteMeasure μ]
+    (h : MarkovExchangeable μ X) (hrec : Recurrent μ X) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
+    ConditionallyIID μ (excursionProcess X a₀) :=
+  have : MeasurableSingletonClass α := h.measurableSingletonClass
+  conditionallyIID_of_exchangeable (h.exchangeable_excursionProcess hrec h0)
+    (aemeasurable_excursionProcess h.aemeasurable a₀)
+
+end Exchangeable
+
+end Probability
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
@@ -40,10 +40,10 @@ Recurrence is what makes the bridge two-way, and it is a genuine hypothesis: the
 of `TauCeti/Probability/Exchangeability/Recurrence/AbsorbedWalk.lean` is Markov exchangeable and
 leaves its initial state for good.
 
-Lists over the countable state space carry the discrete measurable structure of
-`TauCeti/MeasureTheory/MeasurableSpace/List.lean`, under which they are a countable, hence standard
-Borel, value space — so de Finetti's theorem needs no hypothesis beyond the countability Markov
-exchangeability already carries.
+Lists carry the natural length-indexed measurable structure of
+`TauCeti/MeasureTheory/MeasurableSpace/List.lean`. Over the countable discrete state space here this
+structure is discrete, hence standard Borel, so de Finetti's theorem needs no hypothesis beyond the
+countability Markov exchangeability already carries.
 
 ## Main definitions
 

--- a/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
@@ -120,14 +120,19 @@ private theorem measurable_map_of_path (l : List ℕ) :
       (@Sigma.mk ℕ (fun m => Fin m → α) m) inferInstance) ≤
         MeasurableSpace.map (@Sigma.mk ℕ (fun m => Fin m → α) n) inferInstance
     exact iInf_le _ n
-  rw [show (List.equivSigmaTuple ∘ fun x : ℕ → α => (List.ofFn f).map x) =
+  -- The list measurable structure is transported along `List.equivSigmaTuple`, so after
+  -- `measurable_comap_iff` the goal is about the composite into `Σ m, Fin m → α`. That composite
+  -- is not definitionally the stratum inclusion applied to the tuple of coordinates — the equiv
+  -- computes the length from the list — so the two are identified by an explicit equality.
+  have hcomp : (List.equivSigmaTuple ∘ fun x : ℕ → α => (List.ofFn f).map x) =
       (fun g : Fin n → α => (⟨n, g⟩ : Σ m, Fin m → α)) ∘
-        (fun x => fun i : Fin n => x (f i)) by
+        (fun x => fun i : Fin n => x (f i)) := by
     funext x
     simp only [Function.comp_apply]
     rw [List.map_ofFn]
     simpa only [List.equivSigmaTuple_symm_apply, Function.comp_def] using
-      List.equivSigmaTuple.apply_symm_apply (⟨n, x ∘ f⟩ : Σ m, Fin m → α)]
+      List.equivSigmaTuple.apply_symm_apply (⟨n, x ∘ f⟩ : Σ m, Fin m → α)
+  rw [hcomp]
   exact hmk.comp htuple
 
 /-- **An excursion is a measurable function of the path.** The two endpoint visit times are

--- a/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
@@ -102,17 +102,33 @@ theorem excursionProcess_apply (X : ℕ → Ω → α) (a₀ : α) (k : ℕ) (ω
 
 section Measurability
 
-variable [Countable α] [MeasurableSingletonClass α]
+variable [MeasurableSingletonClass α]
 
+omit [MeasurableSingletonClass α] in
 /-- Reading a fixed finite list of times off a path is measurable. -/
 private theorem measurable_map_of_path (l : List ℕ) :
     Measurable fun x : ℕ → α => l.map x := by
-  induction l with
-  | nil => exact measurable_const
-  | cons i l ih =>
-    have hcons : Measurable fun q : α × List α => q.1 :: q.2 :=
-      measurable_from_prod_countable_left fun _ => Measurable.of_discrete
-    exact hcons.comp ((measurable_pi_apply i).prodMk ih)
+  induction l using List.ofFnRec with | _ n f
+  rw [measurable_comap_iff]
+  have htuple : Measurable fun x : ℕ → α => fun i : Fin n => x (f i) :=
+    measurable_pi_iff.2 fun i => measurable_pi_apply (f i)
+  have hmk : Measurable fun g : Fin n → α =>
+      (⟨n, g⟩ : Σ m, Fin m → α) := by
+    refine Measurable.of_le_map ?_
+    -- The sigma measurable space is the infimum over its fixed-length strata.
+    change (⨅ m : ℕ, MeasurableSpace.map
+      (@Sigma.mk ℕ (fun m => Fin m → α) m) inferInstance) ≤
+        MeasurableSpace.map (@Sigma.mk ℕ (fun m => Fin m → α) n) inferInstance
+    exact iInf_le _ n
+  rw [show (List.equivSigmaTuple ∘ fun x : ℕ → α => (List.ofFn f).map x) =
+      (fun g : Fin n → α => (⟨n, g⟩ : Σ m, Fin m → α)) ∘
+        (fun x => fun i : Fin n => x (f i)) by
+    funext x
+    simp only [Function.comp_apply]
+    rw [List.map_ofFn]
+    simpa only [List.equivSigmaTuple_symm_apply, Function.comp_def] using
+      List.equivSigmaTuple.apply_symm_apply (⟨n, x ∘ f⟩ : Σ m, Fin m → α)]
+  exact hmk.comp htuple
 
 /-- **An excursion is a measurable function of the path.** The two endpoint visit times are
 measurable and range over a countable set, and on each of their fibres the excursion reads a fixed
@@ -188,11 +204,7 @@ theorem MarkovExchangeable.measure_setOf_excursionPrefix_eq_of_perm (h : MarkovE
 
 section Exchangeable
 
--- `Countable α` is carried by `MarkovExchangeable` itself, but it has to be a binder here: without
--- it `List α` has no measurable structure, so the conclusions below do not even elaborate.
-variable [Countable α]
-
-omit [MeasurableSpace Ω] [MeasurableSpace α] [Countable α] in
+omit [MeasurableSpace Ω] [MeasurableSpace α] in
 /-- A finite-dimensional event of the excursion process, read as an event of the excursion
 prefix. -/
 private theorem setOf_forall_excursion_eq {m : ℕ} (v : Fin m → List α) :
@@ -219,6 +231,7 @@ transition counts — the sufficient statistic Markov exchangeability sees. -/
 theorem MarkovExchangeable.exchangeable_excursionProcess (h : MarkovExchangeable μ X)
     (hrec : Recurrent μ X) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
     Exchangeable μ (excursionProcess X a₀) := by
+  let _ : Countable α := h.countable
   have : MeasurableSingletonClass α := h.measurableSingletonClass
   have hmeas : ∀ k, AEMeasurable (excursionProcess X a₀ k) μ :=
     aemeasurable_excursionProcess h.aemeasurable a₀
@@ -249,6 +262,7 @@ discrete space, which is standard Borel and nonempty. -/
 theorem MarkovExchangeable.conditionallyIID_excursionProcess [IsFiniteMeasure μ]
     (h : MarkovExchangeable μ X) (hrec : Recurrent μ X) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
     ConditionallyIID μ (excursionProcess X a₀) :=
+  let _ : Countable α := h.countable
   have : MeasurableSingletonClass α := h.measurableSingletonClass
   conditionallyIID_of_exchangeable (h.exchangeable_excursionProcess hrec h0)
     (aemeasurable_excursionProcess h.aemeasurable a₀)

--- a/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Excursion.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.MeasureTheory.MeasurableSpace.List
 public import TauCeti.Probability.DeFinetti.Theorem
 public import TauCeti.Probability.Exchangeability.Excursion
-public import TauCeti.Probability.Exchangeability.SuccessorArray
+import TauCeti.Probability.Exchangeability.SuccessorArray
 public import TauCeti.Probability.Recurrent
 
 /-!
@@ -156,7 +156,8 @@ theorem Recurrent.measure_setOf_excursionPrefix_eq (hrec : Recurrent μ X)
   have hinf : {n | X n ω = a₀}.Infinite := by
     have h := hωinf 0
     rwa [hω0] at h
-  exact eqOn_loopPathAt_iff_excursionPrefix_eq havoid hinf hω0
+  exact eqOn_loopPathAt_iff_excursionPrefix_eq havoid
+    (exists_visitCount_of_infinite hinf bs.length) hω0
 
 /-- **Reordering a list of excursions does not change the probability that a recurrent Markov
 exchangeable process traverses it.** No hypothesis on the list is needed: excursions never visit


### PR DESCRIPTION
This PR proves that the excursion process of a recurrent Markov exchangeable process is exchangeable, and applies de Finetti's theorem to it. This is the half of the Diaconis–Freedman representation theorem that the repository's own files name as the missing one: `Probability/Exchangeability/Excursion.lean` said that assembling its finite-path identities into exchangeability of the excursion process "still needs the recurrence hypothesis at the process level", and `Probability/Exchangeability/DiaconisFreedman.lean` already supplies the other, recurrence-free half.

Roadmap: Exchangeability

The target is Layer 8's "Markov exchangeability" bullet in `TauCetiRoadmap/Exchangeability/README.md`, whose conclusion is `TauCeti.Probability.MixedMarkovChain`. Layer 8's other bullets are already discharged on `main` — the finite de Finetti bounds (`ExchangeableAt.prefixLaw_le_sampleWithReplacement_add` and its converse), de Finetti for other countable index types, and the affine and ergodic decomposition (`deFinettiEquiv`, `exchangeableSigma_trivial_iff_ergodicSMul`) — so the Markov and Aldous–Hoover bullets are what remains, and the excursion route to the former had no open PR.

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"markovexchangeable-exchangeable-excursionprocess"}-->

The mathematics is the bridge between two different symmetries. Markov exchangeability constrains **finite-path** events: the mass of a finite path depends only on its initial state and its transition counts. Exchangeability of the excursion process asks about events of the *excursions*. Under recurrence these are the same events, and the new pathwise equivalence `TauCeti.eqOn_loopPathAt_iff_excursionPrefix_eq` says so: for a path starting at `a₀` and returning there infinitely often, having `bs` as its first `bs.length` excursions is exactly spelling out the loop word `loopPathAt a₀ bs` over that loop's span. Both directions run through `loopPath_excursionPrefix_of_infinite_of_zero`; the forward one identifies the `bs.length`-th return time with `loopSteps bs` and then applies `loopPath_injOn`, and the backward one reads the two loop words off each other coordinatewise. The counting input is `visitCount_loopPathAt`, that a loop visits its base state once per excursion, proved by induction on the excursion list with the new `visitCount_add` splitting and the new `loopPathAt` shift lemma. Given the equivalence, the existing `MarkovExchangeable.measure_setOf_loopPathAt_eq_of_perm` transfers permutation invariance from the loops to the excursion prefixes, and the finite-dimensional laws of the excursion process follow because a measure on the countable discrete space `Fin m → List α` is determined by its singletons.

A list with an entry through the base state needs no side hypothesis: no excursion visits its base state, so both events are empty, and the reordering theorem is stated with no condition on the list at all.

Recurrence is a genuine hypothesis rather than a convenience, and the repository already witnesses that: the deterministic walk of `Recurrence/AbsorbedWalk.lean` is Markov exchangeable and leaves its initial state for good.

De Finetti applies to the result with no extra hypothesis on the value space. `TauCeti/MeasureTheory/MeasurableSpace/List.lean` gives `List α` its natural measurable structure transported from `Σ n, Fin n → α`. Over a countable discrete `α`, that structure is discrete, hence standard Borel; since `List α` is nonempty, `conditionallyIID_of_exchangeable` yields that the excursions away from the initial state are conditionally i.i.d. finite words.

New declarations, by file. `TauCeti/MeasureTheory/MeasurableSpace/List.lean` (45 lines): `instMeasurableSpaceList`, `instDiscreteMeasurableSpaceList`. `Combinatorics/Enumerative/SuccessorArray.lean`: `visitCount_add`, `visitCount_eq_zero_of_forall_ne`, `visitTime_eq_of_eqOn`. `Combinatorics/Enumerative/LoopWord.lean`: `loopPathAt_cons_of_lt`, `loopPathAt_cons_add`, `loopPathAt_of_loopSteps_le`, `infinite_setOf_loopPathAt_eq`, `map_range_loopPathAt`. `Combinatorics/Enumerative/ExcursionProcess.lean`: `forall_not_mem_excursionPrefix`, `visitCount_loopPathAt`, `eqOn_loopPathAt_iff_excursionPrefix_eq`. `Probability/Exchangeability/Recurrence/Excursion.lean` (263 lines): `excursionProcess`, `measurable_excursion`, `aemeasurable_excursionProcess`, `Recurrent.measure_setOf_excursionPrefix_eq`, `MarkovExchangeable.measure_setOf_excursionPrefix_eq_of_perm`, `MarkovExchangeable.exchangeable_excursionProcess`, `MarkovExchangeable.conditionallyIID_excursionProcess`. The remaining edits are the module docstrings of the four touched files, `Excursion.lean`'s included, which previously recorded this step as open.

`MarkovExchangeable` carries countability internally. The public exchangeability and conditional-IID theorems therefore need no explicit `Countable α` binder; their proofs install that witness locally where discreteness and standard-Borel inference require it.

What remains for Layer 8's Markov bullet after this PR is the change of variables from a conditionally i.i.d. excursion sequence back to `MixedMarkovChain`; the successor-array route to the same conclusion has its own such step already, `mixedMarkovChain_of_rowExchangeable_successorProcess`, and needs row exchangeability of the successor array instead.

No Mathlib infrastructure was vendored.

🤖 Prepared with Claude Code

