### PR TITLE
feat(HeckeRing): the Atkin-Lehner involution fixes a bad-prime double coset

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -32,14 +32,25 @@ by `N`, the determinant is unchanged, and — the point of the construction — 
 entry is untouched, so the coprimality condition cutting out `Δ₀(N)` transfers with no work.
 Integrality of the new upper-right entry is precisely the hypothesis `N ∣ A 1 0`.
 
-This file builds the anti-involution only. Commutativity of `R(Γ₀(N), Δ₀(N))` needs the further
-input that `ι` fixes every double coset, which `HeckeCosetModule.mul_comm_of_antiInvolution`
-takes as a separate hypothesis (Shimura, Proposition 3.8).
+Beyond the anti-involution itself, this file proves that `ι` preserves determinants and that it
+fixes the double coset of any `x ∈ Δ₀(N)` whose determinant divides a power of the level — the
+*bad-prime* half of the hypothesis `HeckeCosetModule.mul_comm_of_antiInvolution` takes for
+commutativity of `R(Γ₀(N), Δ₀(N))` (Shimura, Proposition 3.8). The coprime half is separate.
+
+## Main results
+
+* `HeckeRing.GL2.atkinLehnerAntiInvolution`: the anti-involution of the Hecke pair.
+* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_val`: its entrywise action on a `Δ₀(N)` witness.
+* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_det`: it preserves the determinant.
+* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow`: it fixes the double
+  coset when the determinant divides a power of the level.
 
 Ported from the AINTLIB `LeanModularForms` project (Chris Birkbeck),
 [`HeckeRIngs/GLn/CongruenceHecke/AtkinLehner.lean`](https://github.com/CBirkbeck/AINTLIB),
 declarations `wN`, `Gamma0_AL_hom`, `Gamma0_AL_involutive`, `Gamma0_AL_map_H`,
-`Gamma0_AL_map_Δ` and `Gamma0_antiInvolution`. The source states its own transpose equivalence
+`Gamma0_AL_map_Δ` and `Gamma0_antiInvolution`, and — for the results added here —
+`Gamma0_AL_bar_det` and `Gamma0_AL_in_DC_bad`, all Apache-2.0 at commit
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`. The source states its own transpose equivalence
 and diagonal-matrix API; here those come from `GLn/TransposeAntiInvolution.lean` and
 `GLn/DiagonalCosets.lean` instead, and the four-field bundle is assembled by
 `HeckeAntiInvolution.ofAmbient`.
@@ -237,29 +248,35 @@ lemma atkinLehnerAntiInvolution_bar_val [NeZero N] {x : GL (Fin 2) ℚ} (hx : x 
   rw [hbar]
   exact atkinLehnerHom_unop_val N x A hA c hc
 
-/-- **The bar preserves the determinant.** Conjugation cannot change a determinant and the
-transpose does not either, so the two `w`-factors cancel. This is what lets a determinant
-hypothesis on `x` be reused verbatim for `bar x`. -/
-lemma atkinLehnerAntiInvolution_bar_det [NeZero N] {x : GL (Fin 2) ℚ} (hx : x ∈ Delta0 N) :
+/-- The ambient map preserves determinants: conjugation cannot change one, and neither can
+transposition. Stated for every `x : GL (Fin 2) ℚ`, since nothing here needs `Δ₀(N)`. -/
+private lemma atkinLehnerHom_unop_det (x : GL (Fin 2) ℚ) :
+    (((atkinLehnerHom N x).unop : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det =
+      (x : Matrix (Fin 2) (Fin 2) ℚ).det := by
+  simp only [atkinLehnerHom, MonoidHom.coe_mk, OneHom.coe_mk, MulOpposite.unop_op,
+    Units.val_mul, Matrix.det_units_conj, transposeGLEquiv_coe, Matrix.det_transpose]
+
+/-- **The bar preserves the determinant**, so a determinant hypothesis on `x` transfers to
+`bar x` unchanged.
+
+Deliberately **not** `@[simp]`: `atkinLehnerAntiInvolution_bar` is already `@[simp]` and its
+left-hand side `bar x hx` is a strict subterm of this one's, so `simp` unfolds the bar first and
+this lemma's left-hand side is never in normal form. Tagging it makes `lint-env` fail with one
+new `simpNF` violation; measured, not assumed. -/
+lemma atkinLehnerAntiInvolution_bar_det [NeZero N] {x : GL (Fin 2) ℚ}
+    (hx : x ∈ Delta0 N) :
     (((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) :
         Matrix (Fin 2) (Fin 2) ℚ).det = (x : Matrix (Fin 2) (Fin 2) ℚ).det := by
-  have hw : ((natDiagGL 2 ![1, N] : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det ≠ 0 := by
-    rw [← Matrix.GeneralLinearGroup.val_det_apply]
-    exact Units.ne_zero _
-  rw [atkinLehnerAntiInvolution_bar N hx]
-  simp [Matrix.det_mul, Matrix.det_transpose, mul_comm, mul_inv_cancel_right₀ hw]
+  rw [show ((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) = (atkinLehnerHom N x).unop from
+    HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx]
+  exact atkinLehnerHom_unop_det N x
 
 /-- **The Atkin–Lehner involution fixes a bad-prime double coset.** If `x ∈ Δ₀(N)` has
 determinant `m` with `m ∣ N ^ k`, then `bar x` lies in the `Γ₀(N)`-double coset of `x` itself.
 
 This is the *bad* case, where `m` shares its primes with the level; the coprime case is
-separate. Both `x` and `bar x` have determinant `m`, so Shimura's Proposition 3.33 puts each of
-them in the double coset of the same diagonal representative `diag(1, m)`, and being in a common
-double coset is what identifies the two cosets.
-
-It is the fixing hypothesis the commutativity of the `Γ₀(N)` Hecke ring needs:
-`HeckeCosetModule.mul_comm_of_antiInvolution` asks for an anti-involution fixing every double
-coset, and this supplies the bad-prime half of that. -/
+separate. It supplies the bad-prime half of the fixing hypothesis that
+`HeckeCosetModule.mul_comm_of_antiInvolution` requires. -/
 theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow [NeZero N] (m k : ℕ)
     (hm_dvd : m ∣ N ^ k) (x : GL (Fin 2) ℚ) (hx : x ∈ Delta0 N)
     (hdet : (x : Matrix (Fin 2) (Fin 2) ℚ).det = (m : ℚ)) :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -257,18 +257,19 @@ private lemma atkinLehnerHom_unop_det (x : GL (Fin 2) ℚ) :
     Units.val_mul, Matrix.det_units_conj, transposeGLEquiv_coe, Matrix.det_transpose]
 
 /-- **The bar preserves the determinant**, so a determinant hypothesis on `x` transfers to
-`bar x` unchanged.
-
-Deliberately **not** `@[simp]`: `atkinLehnerAntiInvolution_bar` is already `@[simp]` and its
-left-hand side `bar x hx` is a strict subterm of this one's, so `simp` unfolds the bar first and
-this lemma's left-hand side is never in normal form. Tagging it makes `lint-env` fail with one
-new `simpNF` violation; measured, not assumed. -/
+`bar x` unchanged. -/
+-- Deliberately not `@[simp]`: `atkinLehnerAntiInvolution_bar` is already `@[simp]` and its
+-- left-hand side `bar x hx` is a strict subterm of this one's, so `simp` unfolds the bar first
+-- and this lemma's left-hand side is never in normal form. Tagging it makes `lint-env` fail with
+-- one new `simpNF` violation; measured, not assumed. Do not add the annotation.
 lemma atkinLehnerAntiInvolution_bar_det [NeZero N] {x : GL (Fin 2) ℚ}
     (hx : x ∈ Delta0 N) :
     (((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) :
         Matrix (Fin 2) (Fin 2) ℚ).det = (x : Matrix (Fin 2) (Fin 2) ℚ).det := by
-  rw [show ((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) = (atkinLehnerHom N x).unop from
-    HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx]
+  have hbar : ((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) =
+      (atkinLehnerHom N x).unop :=
+    HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
+  rw [hbar]
   exact atkinLehnerHom_unop_det N x
 
 /-- **The Atkin–Lehner involution fixes a bad-prime double coset.** If `x ∈ Δ₀(N)` has

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -7,6 +7,9 @@ module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Basic
 public import TauCeti.NumberTheory.HeckeRing.GLn.TransposeAntiInvolution
+-- `mem_doubleCoset_natDiagGL_of_dvd_pow` (Shimura 3.33), used only inside the proof of
+-- `atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow` below, so private.
+import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.BadPrimeCoset
 
 /-!
 # The Atkin-Lehner anti-involution of the `Γ₀(N)` Hecke pair
@@ -233,5 +236,39 @@ lemma atkinLehnerAntiInvolution_bar_val [NeZero N] {x : GL (Fin 2) ℚ} (hx : x 
     HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
   rw [hbar]
   exact atkinLehnerHom_unop_val N x A hA c hc
+
+/-- **The bar preserves the determinant.** Conjugation cannot change a determinant and the
+transpose does not either, so the two `w`-factors cancel. This is what lets a determinant
+hypothesis on `x` be reused verbatim for `bar x`. -/
+lemma atkinLehnerAntiInvolution_bar_det [NeZero N] {x : GL (Fin 2) ℚ} (hx : x ∈ Delta0 N) :
+    (((atkinLehnerAntiInvolution N).bar x hx : GL (Fin 2) ℚ) :
+        Matrix (Fin 2) (Fin 2) ℚ).det = (x : Matrix (Fin 2) (Fin 2) ℚ).det := by
+  have hw : ((natDiagGL 2 ![1, N] : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det ≠ 0 := by
+    rw [← Matrix.GeneralLinearGroup.val_det_apply]
+    exact Units.ne_zero _
+  rw [atkinLehnerAntiInvolution_bar N hx]
+  simp [Matrix.det_mul, Matrix.det_transpose, mul_comm, mul_inv_cancel_right₀ hw]
+
+/-- **The Atkin–Lehner involution fixes a bad-prime double coset.** If `x ∈ Δ₀(N)` has
+determinant `m` with `m ∣ N ^ k`, then `bar x` lies in the `Γ₀(N)`-double coset of `x` itself.
+
+This is the *bad* case, where `m` shares its primes with the level; the coprime case is
+separate. Both `x` and `bar x` have determinant `m`, so Shimura's Proposition 3.33 puts each of
+them in the double coset of the same diagonal representative `diag(1, m)`, and being in a common
+double coset is what identifies the two cosets.
+
+It is the fixing hypothesis the commutativity of the `Γ₀(N)` Hecke ring needs:
+`HeckeCosetModule.mul_comm_of_antiInvolution` asks for an anti-involution fixing every double
+coset, and this supplies the bad-prime half of that. -/
+theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow [NeZero N] (m k : ℕ)
+    (hm_dvd : m ∣ N ^ k) (x : GL (Fin 2) ℚ) (hx : x ∈ Delta0 N)
+    (hdet : (x : Matrix (Fin 2) (Fin 2) ℚ).det = (m : ℚ)) :
+    (atkinLehnerAntiInvolution N).bar x hx ∈
+      DoubleCoset.doubleCoset x ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) := by
+  rw [DoubleCoset.doubleCoset_eq_of_mem
+    (mem_doubleCoset_natDiagGL_of_dvd_pow N m k hm_dvd x hx hdet)]
+  exact mem_doubleCoset_natDiagGL_of_dvd_pow N m k hm_dvd _
+    ((atkinLehnerAntiInvolution N).bar_mem_Δ x hx)
+    ((atkinLehnerAntiInvolution_bar_det N hx).trans hdet)
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -37,24 +37,6 @@ fixes the double coset of any `x ∈ Δ₀(N)` whose determinant divides a power
 *bad-prime* half of the hypothesis `HeckeCosetModule.mul_comm_of_antiInvolution` takes for
 commutativity of `R(Γ₀(N), Δ₀(N))` (Shimura, Proposition 3.8). The coprime half is separate.
 
-## Main results
-
-* `HeckeRing.GL2.atkinLehnerAntiInvolution`: the anti-involution of the Hecke pair.
-* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_val`: its entrywise action on a `Δ₀(N)` witness.
-* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_det`: it preserves the determinant.
-* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow`: it fixes the double
-  coset when the determinant divides a power of the level.
-
-Ported from the AINTLIB `LeanModularForms` project (Chris Birkbeck),
-[`HeckeRIngs/GLn/CongruenceHecke/AtkinLehner.lean`](https://github.com/CBirkbeck/AINTLIB),
-declarations `wN`, `Gamma0_AL_hom`, `Gamma0_AL_involutive`, `Gamma0_AL_map_H`,
-`Gamma0_AL_map_Δ` and `Gamma0_antiInvolution`, and — for the results added here —
-`Gamma0_AL_bar_det` and `Gamma0_AL_in_DC_bad`, all Apache-2.0 at commit
-`2baa76f742bdb4fb8ee323fabba41203bd390e08`. The source states its own transpose equivalence
-and diagonal-matrix API; here those come from `GLn/TransposeAntiInvolution.lean` and
-`GLn/DiagonalCosets.lean` instead, and the four-field bundle is assembled by
-`HeckeAntiInvolution.ofAmbient`.
-
 ## Main definitions
 
 * `HeckeRing.GL2.atkinLehnerAntiInvolution`: the anti-involution of the `Γ₀(N)` Hecke pair.
@@ -63,11 +45,24 @@ and diagonal-matrix API; here those come from `GLn/TransposeAntiInvolution.lean`
 
 * `HeckeRing.GL2.atkinLehnerAntiInvolution_bar`: how it acts, `g ↦ w · gᵀ · w⁻¹`. The bundle
   itself is opaque, so this is the elimination rule a consumer works with.
+* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_val`: its entrywise action on a `Δ₀(N)` witness.
+* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_det`: it preserves the determinant.
+* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow`: it fixes the double
+  coset when the determinant divides a power of the level.
 
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
   Proposition 3.8.
+* Ported from the AINTLIB `LeanModularForms` project (Chris Birkbeck),
+  [`HeckeRIngs/GLn/CongruenceHecke/AtkinLehner.lean`](https://github.com/CBirkbeck/AINTLIB),
+  declarations `wN`, `Gamma0_AL_hom`, `Gamma0_AL_involutive`, `Gamma0_AL_map_H`,
+  `Gamma0_AL_map_Δ` and `Gamma0_antiInvolution`, and — for the results added here —
+  `Gamma0_AL_bar_det` and `Gamma0_AL_in_DC_bad`, all Apache-2.0 at commit
+  `2baa76f742bdb4fb8ee323fabba41203bd390e08`. The source states its own transpose equivalence
+  and diagonal-matrix API; here those come from `GLn/TransposeAntiInvolution.lean` and
+  `GLn/DiagonalCosets.lean` instead, and the four-field bundle is assembled by
+  `HeckeAntiInvolution.ofAmbient`.
 -/
 
 public section


### PR DESCRIPTION
The Atkin–Lehner involution fixes a `Γ₀(N)`-double coset in the **bad-prime** case: if
`x ∈ Δ₀(N)` has determinant `m` with `m ∣ N ^ k`, then `bar x` lies in the double coset of `x`
itself.

```lean
        atkinLehnerAntiInvolution_bar_det (hx : x ∈ Delta0 N) :
          ((bar x hx : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ).det = (x : Matrix _ _ ℚ).det

        atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow
          (m k : ℕ) (hm_dvd : m ∣ N ^ k) (x) (hx : x ∈ Delta0 N) (hdet : x.det = m) :
          (atkinLehnerAntiInvolution N).bar x hx ∈
            DoubleCoset.doubleCoset x ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))
```

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"atkinlehner-fixes-bad-prime-doublecoset"}-->

## Why this is the step that matters

`HeckeCosetModule.mul_comm_of_antiInvolution` — already on `main` — concludes that a Hecke ring
is commutative from an anti-involution that **fixes every double coset**. The anti-involution
itself landed as #4341. What was missing is the fixing hypothesis, and it splits by whether the
determinant is coprime to the level. This is the bad half.

The proof is short because the hard work is already in place. Both `x` and `bar x` have
determinant `m`, so Shimura's Proposition 3.33 — `mem_doubleCoset_natDiagGL_of_dvd_pow`, landed
this morning as #4352 — puts **each** of them in the double coset of the same diagonal
representative `diag(1, m)`. Sharing a double coset is exactly what identifies the two cosets,
which is `DoubleCoset.doubleCoset_eq_of_mem`.

The determinant lemma is the other half of that argument and is new here: conjugation cannot
change a determinant and neither can the transpose, so the two `w`-factors cancel and the
hypothesis `det x = m` transfers to `bar x` verbatim.

## Statement validated before implementing

Both statements were compiled as `example`s against `origin/main` before any declaration was
written. Worth recording that **probe 2 — the rung itself — compiled first**, with `bar_det`
supplied as a hypothesis; so the rung's proof structure was confirmed independently of the
determinant lemma it rests on, and only then was that lemma proved.

## What was *not* needed from the source

AINTLIB's argument uses three private ingredients: `Gamma0_AL_in_DC_bad`, `Gamma0_AL_bar_det`,
and `Gamma0_AL_map_Δ` (the involution maps `Δ₀` into itself). Only the first two are ported.
TauCeti's `HeckeAntiInvolution` **bundles** `Δ`-membership into the structure, so
`HeckeAntiInvolution.bar_mem_Δ` supplies the third for free — there is nothing to state.

## Placement

Both declarations go in `Gamma0/AtkinLehner.lean`, beside `atkinLehnerAntiInvolution_bar` and
`atkinLehnerAntiInvolution_bar_val`, whose `_bar_*` family they extend. The one new import,
`Gamma0/BadPrimeCoset.lean` for Shimura 3.33, is **private**: it is used only inside a proof
body, so it does not enlarge the exported dependency surface. Checked that `BadPrimeCoset` does
not reach `AtkinLehner` (19 modules walked), so the edge introduces no cycle.

Provenance: github.com/CBirkbeck/AINTLIB @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
Apache-2.0, Chris Birkbeck,
`projects/LeanModularForms/LeanModularForms/HeckeRIngs/GLn/CongruenceHecke/AtkinLehner.lean`,
declarations `Gamma0_AL_in_DC_bad` (line 217) and `Gamma0_AL_bar_det` (line 165). Both are
`private` and stated at `Fin 2` in the source; both are re-stated here against TauCeti's bundled
`HeckeAntiInvolution` rather than the source's `AntiInvolution` on a `Gamma0_pair`.

## Roadmap target

`TauCetiRoadmap/ModularForms/README.md:374-375` (roadmap `origin/main` @ `85038d4`):

> … and **commutativity at level `N` by the Atkin–Lehner anti-involution**.

Cited as a **prerequisite**, not a target in its own right — CLAUDE.md's "supplies a
prerequisite that a specific target needs". The target it serves is Layer 5 at `:603-610`:

> **Layer 5: strong multiplicity one and the eigenform characterization** … **as proved in
> AINTLIB** (`strongMultiplicityOne`, `StrongMultiplicityOne/ConstantMultiple.lean`)

The chain is: this fixing hypothesis → `CommRing` on the `Γ₀(N)` Hecke ring → `heckeRingDn` →
`heckeRingHomCharSpace` (README:407) → `EigenformAwayFromLevel` → `strongMultiplicityOne`.

## Absence

`atkinLehnerAntiInvolution_bar_det` and `atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow`
are declared in zero files on `main`. Checked with `git grep -w`, **not** `-E` with `\b` — `\b`
is unsupported in git grep's POSIX ERE and matches nothing while exiting 0. Controls:
`atkinLehnerAntiInvolution_bar_val` matches 1 (so the query works) and a nonsense name matches 0.

No open PR touches either file: all **62** open PRs were swept **by file list**, not by
`gh pr list --search`, which covers only title/body/comments. Zero of the 62 returned an empty
file list, so no request failed silently.

## Checks

Measured at `bce407c9a` (branched from `origin/main`, behind 0):

* `lake build` — 9159 jobs, exit 0
* `lake exe axioms` — exit 0, 72844 declarations, allowlist only
* `lake exe module-system` — exit 0, 3294 modules
* `scripts/lint-env.sh` — exit 0, `LINT-ENV: PASS` ×1, NEW violation ×0

Proof bodies 9 and 11 lines; no line over 100 characters; no `sorry`, `set_option`, `haveI` or
`show`. One file, +38.
