### PR TITLE
feat: count fully blocked rectangle decompositions

### DIFF
--- a/TauCeti/KnotTheory/Grid/Differential/Square/Count.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Count.lean
@@ -22,6 +22,14 @@ now act directly on `GridDiagram.fullyBlockedDecompositions G x z`: a fixed-poin
 of this finite set proves that its cardinality is even, and hence that the corresponding
 coefficient of the differential square vanishes.
 
+*Which region carries a marking.* Every statement below is relative to the ambient
+`GridDiagram.fullyBlockedRectangles`, and none of them unfolds the marking condition: they relate
+two objects assembled from that one finite set. The marking region is fixed upstream by
+`GridRectangle.AvoidsMarkings`, which still tests the open grid-line interior rather than the
+square-centred domain used by the Lane G.2 gradings; aligning it with the square-centred
+convention is a separate correction to that predicate, after which the identities here read off
+the corrected rectangle sets unchanged.
+
 ## Main definitions
 
 * `TauCeti.GridDiagram.fullyBlockedDecompositions`: composable pairs of fully blocked empty

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Count.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Count.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
+import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
 public import TauCeti.KnotTheory.Grid.Differential.Square.Coefficient
 public import TauCeti.KnotTheory.Grid.Differential.Square.Decomposition
 
@@ -96,28 +96,28 @@ theorem mem_fullyBlockedDecompositions (D : GridRectangleDecomposition x z) :
   simp [fullyBlockedDecompositions, decompositionSigmaEquiv]
 
 /-- The first rectangle in a fully blocked decomposition is empty. -/
-theorem first_isEmpty_of_mem_fullyBlockedDecompositions
+theorem isEmpty_first_of_mem_fullyBlockedDecompositions
     {D : GridRectangleDecomposition x z} (hD : D ∈ G.fullyBlockedDecompositions x z) :
     D.first.IsEmpty :=
   G.isEmpty_of_mem_fullyBlockedRectangles x D.middle
     ((G.mem_fullyBlockedDecompositions x z D).mp hD).1
 
 /-- The second rectangle in a fully blocked decomposition is empty. -/
-theorem second_isEmpty_of_mem_fullyBlockedDecompositions
+theorem isEmpty_second_of_mem_fullyBlockedDecompositions
     {D : GridRectangleDecomposition x z} (hD : D ∈ G.fullyBlockedDecompositions x z) :
     D.second.IsEmpty :=
   G.isEmpty_of_mem_fullyBlockedRectangles D.middle z
     ((G.mem_fullyBlockedDecompositions x z D).mp hD).2
 
 /-- The first rectangle in a fully blocked decomposition avoids every marking. -/
-theorem first_avoidsMarkings_of_mem_fullyBlockedDecompositions
+theorem avoidsMarkings_first_of_mem_fullyBlockedDecompositions
     {D : GridRectangleDecomposition x z} (hD : D ∈ G.fullyBlockedDecompositions x z) :
     D.first.AvoidsMarkings G :=
   G.avoidsMarkings_of_mem_fullyBlockedRectangles x D.middle
     ((G.mem_fullyBlockedDecompositions x z D).mp hD).1
 
 /-- The second rectangle in a fully blocked decomposition avoids every marking. -/
-theorem second_avoidsMarkings_of_mem_fullyBlockedDecompositions
+theorem avoidsMarkings_second_of_mem_fullyBlockedDecompositions
     {D : GridRectangleDecomposition x z} (hD : D ∈ G.fullyBlockedDecompositions x z) :
     D.second.AvoidsMarkings G :=
   G.avoidsMarkings_of_mem_fullyBlockedRectangles D.middle z
@@ -135,19 +135,9 @@ theorem card_fullyBlockedDecompositions :
 /-- There are no fully blocked decompositions from `x` to a state outside the two-step
 column-swap support of `x`. -/
 theorem fullyBlockedDecompositions_eq_empty_of_notMem_twoStep
-    (hz : z ∉ x.twoStepColumnSwapNeighbors) : G.fullyBlockedDecompositions x z = ∅ := by
-  classical
-  rw [Finset.eq_empty_iff_forall_notMem]
-  intro D _hD
-  apply hz
-  rw [GridState.mem_twoStepColumnSwapNeighbors]
-  exact ⟨D.middle,
-    GridState.mem_columnSwapNeighbors.mpr
-      ⟨D.first.left, D.first.right, D.first.left_ne_right,
-        D.first.target_eq_swapColumns⟩,
-    GridState.mem_columnSwapNeighbors.mpr
-      ⟨D.second.left, D.second.right, D.second.left_ne_right,
-        D.second.target_eq_swapColumns⟩⟩
+    (hz : z ∉ x.twoStepColumnSwapNeighbors) : G.fullyBlockedDecompositions x z = ∅ :=
+  Finset.eq_empty_iff_forall_notMem.mpr fun D _ =>
+    hz D.target_mem_twoStepColumnSwapNeighbors
 
 /-- The number modulo two of fully blocked two-rectangle decompositions from `x` to `z`. -/
 noncomputable def fullyBlockedDecompositionCount : ZMod 2 :=

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Count.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Count.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Group.Finset.Sigma
+public import TauCeti.KnotTheory.Grid.Differential.Square.Coefficient
+public import TauCeti.KnotTheory.Grid.Differential.Square.Decomposition
+
+/-!
+# Counting fully blocked two-rectangle decompositions
+
+The coefficient of the square of the fully blocked grid differential is a sum over intermediate
+states of products of rectangle counts. This file identifies that expression with the parity of a
+single finite set: the set of pairs of composable fully blocked empty rectangles with prescribed
+source and target.
+
+This is the algebraic handoff needed by the juxtaposition proof of `∂² = 0`. Its geometric part can
+now act directly on `GridDiagram.fullyBlockedDecompositions G x z`: a fixed-point-free involution
+of this finite set proves that its cardinality is even, and hence that the corresponding
+coefficient of the differential square vanishes.
+
+## Main definitions
+
+* `TauCeti.GridDiagram.fullyBlockedDecompositions`: composable pairs of fully blocked empty
+  rectangles with fixed endpoints.
+* `TauCeti.GridDiagram.fullyBlockedDecompositionCount`: the cardinality of this set modulo two.
+
+## Main results
+
+* `TauCeti.GridDiagram.mem_fullyBlockedDecompositions`: membership means that both rectangles in
+  the decomposition are fully blocked.
+* `TauCeti.GridDiagram.card_fullyBlockedDecompositions`: the cardinality is the sum, over
+  intermediate states, of the product of the two rectangle-set cardinalities.
+* `TauCeti.GridDiagram.fullyBlockedDecompositionCount_eq_sum`: the parity count is the coefficient
+  sum appearing in the square of the differential.
+* `TauCeti.GridDiagram.fullyBlockedDecompositionCount_eq_zero_iff_even`: its vanishing is exactly
+  evenness of the finite decomposition set.
+* `TauCeti.GridDiagram.fullyBlockedDifferential_comp_self_eq_zero_iff_decompositionCount`: the
+  differential squares to zero exactly when every decomposition count vanishes.
+
+## References
+
+This supplies the counting step for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane
+G.3, "The complexes and `∂² = 0`". The pairing of juxtaposed empty rectangles follows
+Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.6.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridDiagram
+
+variable {n : ℕ} (G : GridDiagram n) (x z : GridState n)
+
+private def decompositionSigmaEquiv :
+    GridRectangleDecomposition x z ≃
+      (Σ y : GridState n,
+        Σ _first : GridRectangleBetween x y, GridRectangleBetween y z) where
+  toFun D := ⟨D.middle, D.first, D.second⟩
+  invFun D := ⟨D.1, D.2.1, D.2.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+/-- The finite set of decompositions from `x` to `z` in which both constituent rectangles are
+fully blocked and empty for the grid diagram `G`.
+
+The intermediate state is retained as part of `GridRectangleDecomposition`; it is determined by
+the first rectangle, but is the index over which the differential-square coefficient is summed. -/
+noncomputable def fullyBlockedDecompositions :
+    Finset (GridRectangleDecomposition x z) :=
+  (((Finset.univ : Finset (GridState n)).sigma fun y =>
+      (G.fullyBlockedRectangles x y).sigma fun _first =>
+        G.fullyBlockedRectangles y z).map
+    (decompositionSigmaEquiv (x := x) (z := z)).symm.toEmbedding)
+
+/-- A decomposition is fully blocked exactly when each of its two rectangles belongs to the
+corresponding fully blocked rectangle set. -/
+@[simp]
+theorem mem_fullyBlockedDecompositions (D : GridRectangleDecomposition x z) :
+    D ∈ G.fullyBlockedDecompositions x z ↔
+      D.first ∈ G.fullyBlockedRectangles x D.middle ∧
+        D.second ∈ G.fullyBlockedRectangles D.middle z := by
+  classical
+  simp [fullyBlockedDecompositions, decompositionSigmaEquiv]
+
+/-- The first rectangle in a fully blocked decomposition is empty. -/
+theorem first_isEmpty_of_mem_fullyBlockedDecompositions
+    {D : GridRectangleDecomposition x z} (hD : D ∈ G.fullyBlockedDecompositions x z) :
+    D.first.IsEmpty :=
+  G.isEmpty_of_mem_fullyBlockedRectangles x D.middle
+    ((G.mem_fullyBlockedDecompositions x z D).mp hD).1
+
+/-- The second rectangle in a fully blocked decomposition is empty. -/
+theorem second_isEmpty_of_mem_fullyBlockedDecompositions
+    {D : GridRectangleDecomposition x z} (hD : D ∈ G.fullyBlockedDecompositions x z) :
+    D.second.IsEmpty :=
+  G.isEmpty_of_mem_fullyBlockedRectangles D.middle z
+    ((G.mem_fullyBlockedDecompositions x z D).mp hD).2
+
+/-- The first rectangle in a fully blocked decomposition avoids every marking. -/
+theorem first_avoidsMarkings_of_mem_fullyBlockedDecompositions
+    {D : GridRectangleDecomposition x z} (hD : D ∈ G.fullyBlockedDecompositions x z) :
+    D.first.AvoidsMarkings G :=
+  G.avoidsMarkings_of_mem_fullyBlockedRectangles x D.middle
+    ((G.mem_fullyBlockedDecompositions x z D).mp hD).1
+
+/-- The second rectangle in a fully blocked decomposition avoids every marking. -/
+theorem second_avoidsMarkings_of_mem_fullyBlockedDecompositions
+    {D : GridRectangleDecomposition x z} (hD : D ∈ G.fullyBlockedDecompositions x z) :
+    D.second.AvoidsMarkings G :=
+  G.avoidsMarkings_of_mem_fullyBlockedRectangles D.middle z
+    ((G.mem_fullyBlockedDecompositions x z D).mp hD).2
+
+/-- The number of fully blocked decompositions is the sum over intermediate states of the product
+of the two rectangle-set cardinalities. -/
+theorem card_fullyBlockedDecompositions :
+    (G.fullyBlockedDecompositions x z).card =
+      ∑ y : GridState n,
+        (G.fullyBlockedRectangles x y).card * (G.fullyBlockedRectangles y z).card := by
+  classical
+  simp [fullyBlockedDecompositions, Finset.card_sigma]
+
+/-- There are no fully blocked decompositions from `x` to a state outside the two-step
+column-swap support of `x`. -/
+theorem fullyBlockedDecompositions_eq_empty_of_notMem_twoStep
+    (hz : z ∉ x.twoStepColumnSwapNeighbors) : G.fullyBlockedDecompositions x z = ∅ := by
+  classical
+  rw [Finset.eq_empty_iff_forall_notMem]
+  intro D _hD
+  apply hz
+  rw [GridState.mem_twoStepColumnSwapNeighbors]
+  exact ⟨D.middle,
+    GridState.mem_columnSwapNeighbors.mpr
+      ⟨D.first.left, D.first.right, D.first.left_ne_right,
+        D.first.target_eq_swapColumns⟩,
+    GridState.mem_columnSwapNeighbors.mpr
+      ⟨D.second.left, D.second.right, D.second.left_ne_right,
+        D.second.target_eq_swapColumns⟩⟩
+
+/-- The number modulo two of fully blocked two-rectangle decompositions from `x` to `z`. -/
+noncomputable def fullyBlockedDecompositionCount : ZMod 2 :=
+  (G.fullyBlockedDecompositions x z).card
+
+/-- The fully blocked decomposition count is the cardinality of
+`fullyBlockedDecompositions`, coerced to `ZMod 2`. -/
+theorem fullyBlockedDecompositionCount_def :
+    G.fullyBlockedDecompositionCount x z =
+      ((G.fullyBlockedDecompositions x z).card : ZMod 2) :=
+  (rfl)
+
+/-- A fully blocked decomposition count vanishes exactly when the corresponding finite set has
+even cardinality. This is the parity form consumed by a fixed-point-free pairing of
+decompositions. -/
+theorem fullyBlockedDecompositionCount_eq_zero_iff_even :
+    G.fullyBlockedDecompositionCount x z = 0 ↔
+      Even (G.fullyBlockedDecompositions x z).card := by
+  rw [fullyBlockedDecompositionCount_def, ZMod.natCast_eq_zero_iff_even]
+
+/-- The fully blocked decomposition count vanishes outside the two-step column-swap support. -/
+theorem fullyBlockedDecompositionCount_eq_zero_of_notMem_twoStep
+    (hz : z ∉ x.twoStepColumnSwapNeighbors) : G.fullyBlockedDecompositionCount x z = 0 := by
+  rw [fullyBlockedDecompositionCount_def,
+    G.fullyBlockedDecompositions_eq_empty_of_notMem_twoStep x z hz]
+  simp
+
+/-- The parity of fully blocked decompositions is the sum over intermediate states of the product
+of the two fully blocked rectangle counts. -/
+theorem fullyBlockedDecompositionCount_eq_sum :
+    G.fullyBlockedDecompositionCount x z =
+      ∑ y : GridState n, G.fullyBlockedRectangleCount x y *
+        G.fullyBlockedRectangleCount y z := by
+  rw [fullyBlockedDecompositionCount_def, G.card_fullyBlockedDecompositions x z]
+  simp only [Nat.cast_sum, Nat.cast_mul, fullyBlockedRectangleCount_def]
+
+/-- The coefficient of `z` in the square of the differential applied to the generator `x` is the
+parity of the fully blocked decompositions from `x` to `z`. -/
+theorem fullyBlockedDifferential_sq_single_apply_eq_decompositionCount :
+    G.fullyBlockedDifferential
+        (G.fullyBlockedDifferential (Finsupp.single x (1 : ZMod 2))) z =
+      G.fullyBlockedDecompositionCount x z := by
+  rw [fullyBlockedDifferential_apply_apply, fullyBlockedDifferential_single,
+    G.fullyBlockedDifferential_sq_single_apply x z,
+    G.fullyBlockedDecompositionCount_eq_sum x z]
+
+/-- The fully blocked differential squares to zero exactly when every fully blocked
+two-rectangle decomposition set has even cardinality. -/
+theorem fullyBlockedDifferential_comp_self_eq_zero_iff_decompositionCount :
+    G.fullyBlockedDifferential.comp G.fullyBlockedDifferential = 0 ↔
+      ∀ x z : GridState n, G.fullyBlockedDecompositionCount x z = 0 := by
+  rw [G.fullyBlockedDifferential_comp_self_eq_zero_iff]
+  simp only [G.fullyBlockedDecompositionCount_eq_sum]
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.KnotTheory.Grid.Differential.Square.Support
 public import TauCeti.KnotTheory.Grid.Rectangle.Swap
 
 /-!
@@ -27,6 +28,8 @@ between two given states is determined by its side columns.
 
 * `TauCeti.GridRectangleDecomposition.ext`: a decomposition is determined by the ordered side
   columns of its two rectangles.
+* `TauCeti.GridRectangleDecomposition.target_mem_twoStepColumnSwapNeighbors`: the target of a
+  decomposition is reached from its source by two nontrivial column transpositions.
 
 ## References
 
@@ -78,6 +81,17 @@ theorem ext {D E : GridRectangleDecomposition x z}
             GridRectangleBetween.eq_of_sides hsecondLeft hsecondRight
           subst Esecond
           rfl
+
+/-- The target of a two-step rectangle decomposition is a two-step column-swap neighbour of its
+source: each of the two rectangles transposes its pair of distinct side columns. -/
+theorem target_mem_twoStepColumnSwapNeighbors (D : GridRectangleDecomposition x z) :
+    z ∈ x.twoStepColumnSwapNeighbors :=
+  GridState.mem_twoStepColumnSwapNeighbors.mpr
+    ⟨D.middle,
+      GridState.mem_columnSwapNeighbors.mpr
+        ⟨D.first.left, D.first.right, D.first.left_ne_right, D.first.target_eq_swapColumns⟩,
+      GridState.mem_columnSwapNeighbors.mpr
+        ⟨D.second.left, D.second.right, D.second.left_ne_right, D.second.target_eq_swapColumns⟩⟩
 
 end GridRectangleDecomposition
 


### PR DESCRIPTION
This PR packages fully blocked two-rectangle paths with prescribed endpoints as the finite set `GridDiagram.fullyBlockedDecompositions`, and identifies its parity with the corresponding coefficient of the square of the fully blocked grid differential. This turns the existing sum of products of rectangle counts into the concrete finite object on which the juxtaposition proof acts.

The exact roadmap target is `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G milestone 3, “The complexes and `∂² = 0`,” specifically the disjoint / overlapping / annular pairing of empty rectangle decompositions. This is the most effective current step because the coefficient expansion and the side-overlap case split have landed, while the marking-region correction remains independently in flight in #3135; the enumeration here uses only the stable `fullyBlockedRectangles` API and therefore does not overlap that correction.

Define the decomposition set by a dependent finite sum over the intermediate state and the two fully blocked rectangle sets. Prove its membership API, extract emptiness and marking avoidance for each constituent rectangle, calculate its cardinality as the sum of products of rectangle-set cardinalities, and show that it is empty outside the existing two-step column-swap support. Define `fullyBlockedDecompositionCount : ZMod 2`, identify its vanishing with even cardinality, identify it with the coefficient of `∂ (∂ x)` at `z`, and reformulate global square-zero as the vanishing of every such count.

After this PR, Lane G.3 still needs the corrected marking domain from #3135, fixed-point-free pairings in the disjoint, one-common-side, and diagonal annular cases, and their assembly into `fullyBlockedDifferential.comp fullyBlockedDifferential = 0` and the resulting chain complex.

The rectangle juxtaposition follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.6, as cited in the module documentation. The implementation reuses Mathlib's dependent `Finset.sigma`, `Finset.card_sigma`, and `ZMod.natCast_eq_zero_iff_even`; no Mathlib infrastructure is vendored.

Add `TauCeti/KnotTheory/Grid/Differential/Square/Count.lean`; the only existing file changed is `TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean`, which gains the structural fact that the target of any rectangle decomposition is a two-step column-swap neighbour of its source.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"fully-blocked-rectangle-decomposition-count"}-->

🤖 Prepared with Codex

