### PR TITLE
refactor(MinusFive): name the two-class cover of the class group

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
@@ -7,10 +7,9 @@ module
 
 public import Mathlib.NumberTheory.NumberField.ClassNumber
 public import TauCeti.NumberTheory.Multiquadratic.MinusFive.Basic
-import TauCeti.NumberTheory.NumberField.PrimeIdeal
 import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
+import TauCeti.NumberTheory.NumberField.Quadratic.RamifiedPrimesClassGroup
 import TauCeti.NumberTheory.NumberField.Quadratic.RingOfIntegers
-import TauCeti.NumberTheory.NumberField.Quadratic.TotalRamification
 import TauCeti.RingTheory.Norm.Quadratic
 
 /-!
@@ -202,37 +201,6 @@ private theorem not_isPrincipal_primeAboveTwo
   · have hbpos : 0 < b ^ 2 := sq_pos_of_ne_zero hb
     have hb1 : (1 : ℤ) ≤ b ^ 2 := by omega
     nlinarith [sq_nonneg a]
-
-/-- With Minkowski bound below `3` and `2` ramified in a quadratic field, every ideal class is
-trivial or the class of a prime `P` above `2`. -/
-private theorem class_eq_one_or_mk0_primeAboveTwo_of_minkowskiBound_lt_three
-    (hfin : finrank ℚ K = 2) (hram : 2 ∈ ramifiedPrimes K)
-    (hM : (4 / Real.pi) ^ InfinitePlace.nrComplexPlaces K *
-        ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) *
-          Real.sqrt |(NumberField.discr K : ℝ)|) < 3)
-    (P : Ideal (𝓞 K)) [P.IsPrime] [P.LiesOver (span {(2 : ℤ)})]
-    (C : ClassGroup (𝓞 K)) :
-    C = 1 ∨ C = ClassGroup.mk0 ⟨P, mem_nonZeroDivisors_of_prime_of_liesOver Nat.prime_two P⟩ := by
-  classical
-  -- Minkowski gives a representative of norm at most `2`; norm `1` is principal and norm `2`
-  -- must be the ramified prime.
-  obtain ⟨I, hIC, hIle⟩ := NumberField.exists_ideal_in_class_of_norm_le C
-  have hIlt : (I.1.absNorm : ℝ) < 3 := hIle.trans_lt hM
-  have hIleTwo : I.1.absNorm ≤ 2 := by
-    exact_mod_cast (Nat.lt_succ_iff.mp (by exact_mod_cast hIlt))
-  have hIpos : 0 < I.1.absNorm := absNorm_pos_of_nonZeroDivisors I
-  rcases (by omega : I.1.absNorm = 1 ∨ I.1.absNorm = 2) with hnorm | hnorm
-  · left
-    rw [← hIC]
-    exact (ClassGroup.mk0_eq_one_iff I.2).mpr <| by
-      rw [Ideal.absNorm_eq_one_iff.mp hnorm]
-      exact top_isPrincipal
-  · right
-    rw [← hIC]
-    have hIP : I.1 = P :=
-      eq_of_absNorm_eq_of_mem_ramifiedPrimes hfin hram P I.1 hnorm
-    apply congrArg ClassGroup.mk0
-    exact Subtype.ext hIP
 
 /-- **The class number of `ℚ(√-5)` is two.** This presentation-independent statement assumes an
 integral generator with minimal polynomial `X² + 5` which generates the field over `ℚ`. -/

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
@@ -232,7 +232,7 @@ theorem classNumber_eq_two_of_minpoly_eq_X_sq_add_five
       (by simpa [P0] using h)
   have hM := minkowski_bound_lt_three hmin hgen
   have hclasses : ∀ C : ClassGroup (𝓞 K), C = 1 ∨ C = ClassGroup.mk0 P0 :=
-    class_eq_one_or_mk0_primeAboveTwo_of_minkowskiBound_lt_three hfin hram hM P
+    class_eq_one_or_eq_classGroupMk0_primeAboveTwo_of_minkowskiBound_lt_three hfin hram hM P
   have hupper : NumberField.classNumber K ≤ 2 := by
     rw [NumberField.classNumber]
     calc

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
@@ -202,6 +202,37 @@ private theorem not_isPrincipal_primeAboveTwo
     have hb1 : (1 : ℤ) ≤ b ^ 2 := by omega
     nlinarith [sq_nonneg a]
 
+/-- With Minkowski bound below `3` and `2` ramified in a quadratic field, every ideal class is
+trivial or the class of a prime `P` above `2`. -/
+private theorem classGroup_eq_one_or_mk0_of_minkowskiBound_lt_three
+    (hfin : finrank ℚ K = 2) (hram : 2 ∈ ramifiedPrimes K)
+    (hM : (4 / Real.pi) ^ InfinitePlace.nrComplexPlaces K *
+        ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) *
+          Real.sqrt |(NumberField.discr K : ℝ)|) < 3)
+    (P : Ideal (𝓞 K)) [P.IsPrime] [P.LiesOver (span {(2 : ℤ)})] (hPne : P ≠ 0)
+    (C : ClassGroup (𝓞 K)) :
+    C = 1 ∨ C = ClassGroup.mk0 ⟨P, mem_nonZeroDivisors_of_ne_zero hPne⟩ := by
+  classical
+  -- Minkowski gives a representative of norm at most `2`; norm `1` is principal and norm `2`
+  -- must be the ramified prime.
+  obtain ⟨I, hIC, hIle⟩ := NumberField.exists_ideal_in_class_of_norm_le C
+  have hIlt : (I.1.absNorm : ℝ) < 3 := hIle.trans_lt hM
+  have hIleTwo : I.1.absNorm ≤ 2 := by
+    exact_mod_cast (Nat.lt_succ_iff.mp (by exact_mod_cast hIlt))
+  have hIpos : 0 < I.1.absNorm := absNorm_pos_of_nonZeroDivisors I
+  rcases (by omega : I.1.absNorm = 1 ∨ I.1.absNorm = 2) with hnorm | hnorm
+  · left
+    rw [← hIC]
+    exact (ClassGroup.mk0_eq_one_iff I.2).mpr <| by
+      rw [Ideal.absNorm_eq_one_iff.mp hnorm]
+      exact top_isPrincipal
+  · right
+    rw [← hIC]
+    have hIP : I.1 = P :=
+      eq_of_absNorm_eq_of_mem_ramifiedPrimes hfin hram P I.1 hnorm
+    apply congrArg ClassGroup.mk0
+    exact Subtype.ext hIP
+
 /-- **The class number of `ℚ(√-5)` is two.** This presentation-independent statement assumes an
 integral generator with minimal polynomial `X² + 5` which generates the field over `ℚ`. -/
 theorem classNumber_eq_two_of_minpoly_eq_X_sq_add_five
@@ -231,25 +262,8 @@ theorem classNumber_eq_two_of_minpoly_eq_X_sq_add_five
     exact (ClassGroup.mk0_eq_one_iff (mem_nonZeroDivisors_of_ne_zero hPne)).mp
       (by simpa [P0] using h)
   have hM := minkowski_bound_lt_three hmin hgen
-  have hclasses : ∀ C : ClassGroup (𝓞 K), C = 1 ∨ C = ClassGroup.mk0 P0 := by
-    intro C
-    obtain ⟨I, hIC, hIle⟩ := NumberField.exists_ideal_in_class_of_norm_le C
-    have hIlt : (I.1.absNorm : ℝ) < 3 := hIle.trans_lt hM
-    have hIleTwo : I.1.absNorm ≤ 2 := by
-      exact_mod_cast (Nat.lt_succ_iff.mp (by exact_mod_cast hIlt))
-    have hIpos : 0 < I.1.absNorm := absNorm_pos_of_nonZeroDivisors I
-    rcases (by omega : I.1.absNorm = 1 ∨ I.1.absNorm = 2) with hnorm | hnorm
-    · left
-      rw [← hIC]
-      exact (ClassGroup.mk0_eq_one_iff I.2).mpr <| by
-        rw [Ideal.absNorm_eq_one_iff.mp hnorm]
-        exact top_isPrincipal
-    · right
-      rw [← hIC]
-      have hIP : I.1 = P :=
-        eq_of_absNorm_eq_of_mem_ramifiedPrimes hfin hram P I.1 hnorm
-      apply congrArg ClassGroup.mk0
-      exact Subtype.ext hIP
+  have hclasses : ∀ C : ClassGroup (𝓞 K), C = 1 ∨ C = ClassGroup.mk0 P0 :=
+    classGroup_eq_one_or_mk0_of_minkowskiBound_lt_three hfin hram hM P hPne
   have hupper : NumberField.classNumber K ≤ 2 := by
     rw [NumberField.classNumber]
     calc

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.NumberTheory.NumberField.ClassNumber
 public import TauCeti.NumberTheory.Multiquadratic.MinusFive.Basic
+import TauCeti.NumberTheory.NumberField.PrimeIdeal
 import TauCeti.NumberTheory.NumberField.Quadratic.InfinitePlace
 import TauCeti.NumberTheory.NumberField.Quadratic.RingOfIntegers
 import TauCeti.NumberTheory.NumberField.Quadratic.TotalRamification
@@ -204,14 +205,14 @@ private theorem not_isPrincipal_primeAboveTwo
 
 /-- With Minkowski bound below `3` and `2` ramified in a quadratic field, every ideal class is
 trivial or the class of a prime `P` above `2`. -/
-private theorem classGroup_eq_one_or_mk0_of_minkowskiBound_lt_three
+private theorem class_eq_one_or_mk0_primeAboveTwo_of_minkowskiBound_lt_three
     (hfin : finrank ℚ K = 2) (hram : 2 ∈ ramifiedPrimes K)
     (hM : (4 / Real.pi) ^ InfinitePlace.nrComplexPlaces K *
         ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) *
           Real.sqrt |(NumberField.discr K : ℝ)|) < 3)
-    (P : Ideal (𝓞 K)) [P.IsPrime] [P.LiesOver (span {(2 : ℤ)})] (hPne : P ≠ 0)
+    (P : Ideal (𝓞 K)) [P.IsPrime] [P.LiesOver (span {(2 : ℤ)})]
     (C : ClassGroup (𝓞 K)) :
-    C = 1 ∨ C = ClassGroup.mk0 ⟨P, mem_nonZeroDivisors_of_ne_zero hPne⟩ := by
+    C = 1 ∨ C = ClassGroup.mk0 ⟨P, mem_nonZeroDivisors_of_prime_of_liesOver Nat.prime_two P⟩ := by
   classical
   -- Minkowski gives a representative of norm at most `2`; norm `1` is principal and norm `2`
   -- must be the ramified prime.
@@ -263,7 +264,7 @@ theorem classNumber_eq_two_of_minpoly_eq_X_sq_add_five
       (by simpa [P0] using h)
   have hM := minkowski_bound_lt_three hmin hgen
   have hclasses : ∀ C : ClassGroup (𝓞 K), C = 1 ∨ C = ClassGroup.mk0 P0 :=
-    classGroup_eq_one_or_mk0_of_minkowskiBound_lt_three hfin hram hM P hPne
+    class_eq_one_or_mk0_primeAboveTwo_of_minkowskiBound_lt_three hfin hram hM P
   have hupper : NumberField.classNumber K ≤ 2 := by
     rw [NumberField.classNumber]
     calc

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RamifiedPrimesClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RamifiedPrimesClassGroup.lean
@@ -38,8 +38,9 @@ classical genus theory this result underlies.
 * `NumberField.classGroupMk0_sq_eq_one_of_mem_ramifiedPrimes`: the class of a ramified prime
   is 2-torsion.
 * `NumberField.NarrowClassGroup.mk0_sq_eq_one_of_mem_ramifiedPrimes`: so is its narrow class.
-* `TauCeti.NumberField.class_eq_one_or_mk0_primeAboveTwo_of_minkowskiBound_lt_three`: with Minkowski
-  bound below `3` and `2` ramified, every ideal class is trivial or the class of a prime above `2`.
+* `TauCeti.NumberField.class_eq_one_or_eq_classGroupMk0_primeAboveTwo_of_minkowskiBound_lt_three`:
+  with Minkowski bound below `3` and `2` ramified, every ideal class is trivial or the class of a
+  prime above `2`.
 -/
 
 public section
@@ -100,7 +101,7 @@ variable {K : Type*} [Field K] [NumberField K]
 
 /-- With Minkowski bound below `3` and `2` ramified in a quadratic field, every ideal class is
 trivial or the class of a prime `P` above `2`. -/
-theorem class_eq_one_or_mk0_primeAboveTwo_of_minkowskiBound_lt_three
+theorem class_eq_one_or_eq_classGroupMk0_primeAboveTwo_of_minkowskiBound_lt_three
     (hfin : finrank ℚ K = 2) (hram : 2 ∈ ramifiedPrimes K)
     (hM : (4 / Real.pi) ^ InfinitePlace.nrComplexPlaces K *
         ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) *

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RamifiedPrimesClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RamifiedPrimesClassGroup.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.NumberTheory.NumberField.ClassNumber
 public import TauCeti.NumberTheory.NumberField.PrimeIdeal
 public import TauCeti.NumberTheory.NumberField.NarrowClassGroup.Basic
 public import TauCeti.NumberTheory.NumberField.Quadratic.TotalRamification
@@ -25,6 +26,10 @@ explicit ambiguous 2-torsion classes. Determining all of `Cl(𝓞 K)[2]` (the am
 2-rank theorem of genus theory, which for real fields carries a unit-index correction relating these
 strongly ambiguous classes to the ambiguous ones) is left to later work.
 
+A ramified prime also *exhausts* the class group when the Minkowski bound is small enough: if that
+bound is below `3` and `2` is ramified, then every ideal class is trivial or the class of the prime
+above `2`, so `Cl(𝓞 K)` has at most two elements.
+
 See D. A. Cox, *Primes of the Form x² + ny²*, and F. Lemmermeyer, *Reciprocity Laws*, for the
 classical genus theory this result underlies.
 
@@ -33,6 +38,8 @@ classical genus theory this result underlies.
 * `NumberField.classGroupMk0_sq_eq_one_of_mem_ramifiedPrimes`: the class of a ramified prime
   is 2-torsion.
 * `NumberField.NarrowClassGroup.mk0_sq_eq_one_of_mem_ramifiedPrimes`: so is its narrow class.
+* `TauCeti.NumberField.class_eq_one_or_mk0_primeAboveTwo_of_minkowskiBound_lt_three`: with Minkowski
+  bound below `3` and `2` ramified, every ideal class is trivial or the class of a prime above `2`.
 -/
 
 public section
@@ -84,3 +91,42 @@ theorem NarrowClassGroup.mk0_sq_eq_one_of_mem_ramifiedPrimes (hK : finrank ℚ K
   simpa using isTotallyPositive_intCast (K := K) (n := (p : ℤ)) (by exact_mod_cast hprime.pos)
 
 end NumberField
+
+namespace TauCeti.NumberField
+
+open NumberField
+
+variable {K : Type*} [Field K] [NumberField K]
+
+/-- With Minkowski bound below `3` and `2` ramified in a quadratic field, every ideal class is
+trivial or the class of a prime `P` above `2`. -/
+theorem class_eq_one_or_mk0_primeAboveTwo_of_minkowskiBound_lt_three
+    (hfin : finrank ℚ K = 2) (hram : 2 ∈ ramifiedPrimes K)
+    (hM : (4 / Real.pi) ^ InfinitePlace.nrComplexPlaces K *
+        ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) *
+          Real.sqrt |(NumberField.discr K : ℝ)|) < 3)
+    (P : Ideal (𝓞 K)) [P.IsPrime] [P.LiesOver (span {(2 : ℤ)})]
+    (C : ClassGroup (𝓞 K)) :
+    C = 1 ∨ C = ClassGroup.mk0 ⟨P, mem_nonZeroDivisors_of_prime_of_liesOver Nat.prime_two P⟩ := by
+  classical
+  -- Minkowski gives a representative of norm at most `2`; norm `1` is principal and norm `2`
+  -- must be the ramified prime.
+  obtain ⟨I, hIC, hIle⟩ := NumberField.exists_ideal_in_class_of_norm_le C
+  have hIlt : (I.1.absNorm : ℝ) < 3 := hIle.trans_lt hM
+  have hIleTwo : I.1.absNorm ≤ 2 := by
+    exact_mod_cast (Nat.lt_succ_iff.mp (by exact_mod_cast hIlt))
+  have hIpos : 0 < I.1.absNorm := absNorm_pos_of_nonZeroDivisors I
+  rcases (by omega : I.1.absNorm = 1 ∨ I.1.absNorm = 2) with hnorm | hnorm
+  · left
+    rw [← hIC]
+    exact (ClassGroup.mk0_eq_one_iff I.2).mpr <| by
+      rw [Ideal.absNorm_eq_one_iff.mp hnorm]
+      exact top_isPrincipal
+  · right
+    rw [← hIC]
+    have hIP : I.1 = P :=
+      eq_of_absNorm_eq_of_mem_ramifiedPrimes hfin hram P I.1 hnorm
+    apply congrArg ClassGroup.mk0
+    exact Subtype.ext hIP
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RamifiedPrimesClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RamifiedPrimesClassGroup.lean
@@ -5,10 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.NumberTheory.NumberField.ClassNumber
 public import TauCeti.NumberTheory.NumberField.PrimeIdeal
 public import TauCeti.NumberTheory.NumberField.NarrowClassGroup.Basic
 public import TauCeti.NumberTheory.NumberField.Quadratic.TotalRamification
+import Mathlib.NumberTheory.NumberField.ClassNumber
 
 /-!
 # The class of a ramified prime is 2-torsion


### PR DESCRIPTION
`classNumber_eq_two_of_minpoly_eq_X_sq_add_five` had a 56-line proof body, over the 50-line ceiling.
Its largest block classifies an ideal class, and that classification turns out not to be about the
chosen generator at all — nor about `ℚ(√-5)`. It is now a public theorem in
`TauCeti/NumberTheory/NumberField/Quadratic/RamifiedPrimesClassGroup.lean`:

```lean
theorem class_eq_one_or_eq_classGroupMk0_primeAboveTwo_of_minkowskiBound_lt_three
    (hfin : finrank ℚ K = 2) (hram : 2 ∈ ramifiedPrimes K)
    (hM : (4 / Real.pi) ^ InfinitePlace.nrComplexPlaces K *
        ((finrank ℚ K).factorial / (finrank ℚ K) ^ (finrank ℚ K) *
          Real.sqrt |(NumberField.discr K : ℝ)|) < 3)
    (P : Ideal (𝓞 K)) [P.IsPrime] [P.LiesOver (span {(2 : ℤ)})] (C : ClassGroup (𝓞 K)) :
    C = 1 ∨ C = ClassGroup.mk0 ⟨P, mem_nonZeroDivisors_of_prime_of_liesOver Nat.prime_two P⟩
```

| declaration | before | after |
|---|---|---|
| `classNumber_eq_two_of_minpoly_eq_X_sq_add_five` | 56 | 39 |
| `class_eq_one_or_eq_classGroupMk0_primeAboveTwo_of_minkowskiBound_lt_three` | — | 20 |

## Placement

`RamifiedPrimesClassGroup.lean` is the file whose subject is what the ramified primes contribute to
the class group. It already owns the two 2-torsion results about the class of a ramified prime,
already imports both `PrimeIdeal` and `TotalRamification`, and already spells `ClassGroup.mk0` over
`mem_nonZeroDivisors_of_prime_of_liesOver` in exactly this shape. It gains one import — Mathlib's
`NumberField.ClassNumber` — for Minkowski's theorem.

The theorem lands in the `TauCeti.NumberField` namespace rather than `NumberField`, because
`eq_of_absNorm_eq_of_mem_ramifiedPrimes` lives there; `NumberField` compiles to
`Unknown identifier`. That also leaves its fully qualified name unchanged.

Two imports in the `ℚ(√-5)` file are redundant once it imports the new home, which re-exports them:
`PrimeIdeal` and `TotalRamification` are dropped, verified by rebuilding the module without them.

## Minimal hypotheses

The block mentions neither `θ` nor `hmin` nor `hgen`, so the theorem drops all three: it holds for
any quadratic field with `2` ramified and Minkowski bound below `3`, given a prime above `2`. `hram`
is load-bearing rather than implied — the real quadratic field of discriminant `5` has degree two
and Minkowski bound below `3`, but `2` is unramified there; `hram` is what makes the prime above `2`
unique.

`hPne : P ≠ 0` was also redundant: `NumberField.mem_nonZeroDivisors_of_prime_of_liesOver` already
gives non-zero-divisor membership from the `LiesOver` instance the statement carries.

Both instance arguments are used: `eq_of_absNorm_eq_of_mem_ramifiedPrimes` itself takes
`[𝔭.IsPrime]` and `[𝔭.LiesOver (span {(p : ℤ)})]`, and neither subsumes the other — `LiesOver`
records only equality with the contraction.

The parent's `let P0` no longer appears in the theorem's statement, which names the
`nonZeroDivisors` element directly.

## Degenerate ends

`C = 1` is fine — the disjunction is inclusive. `P = ⊤` is excluded by `P.IsPrime`, and `P = ⊥` by
lying over `(2)`. `I.absNorm = 0` cannot occur: the representative has type `(Ideal (𝓞 K))⁰`.

Roadmap: Multiquadratic
