### PR TITLE
refactor(ZSMul): drop 19 simp arguments that were never necessary

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -384,7 +384,7 @@ lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
     smulX m - smulX n = polyToField (curve.ψ (n + m)) * polyToField (curve.ψ (n - m)) /
       (polyToField (curve.ψ n) * polyToField (curve.ψ m)) ^ 2 := by
   have key := isEllipticNet_polyToField_ψ n m 1 0
-  simp only [IsEllipticNet.rel, add_zero, ψ_one, map_one, mul_one] at key
+  simp only [IsEllipticNet.rel, add_zero, ψ_one, map_one] at key
   rw [smulX_eq hm, smulX_eq hn, sub_sub_sub_cancel_left,
     div_sub_div _ _ (pow_ne_zero 2 (polyToField_ψ_ne_zero hn))
       (pow_ne_zero 2 (polyToField_ψ_ne_zero hm)), mul_pow]
@@ -392,7 +392,7 @@ lemma smulX_sub_smulX (hm : m ≠ 0) (hn : n ≠ 0) :
   linear_combination -key
 
 /-- `smulX` is even in `n`. -/
-@[simp] lemma smulX_neg : smulX (-n) = smulX n := by simp [smulX_def, φ_neg, ψ_neg]
+@[simp] lemma smulX_neg : smulX (-n) = smulX n := by simp [smulX_def]
 
 /-- Negating a nonzero index negates the point: `smulY (-n)` is the long-Weierstrass `negY`
 of the coordinates `(smulX n, smulY n)`. -/
@@ -402,9 +402,8 @@ of the coordinates `(smulX n, smulY n)`. -/
   have key := WeierstrassCurve.Jacobian.negY_of_Z_ne_zero (W := pointedCurve)
     (P := ![polyToField (curve.φ n), polyToField (curve.ω n), polyToField (curve.ψ n)])
     (by simpa using polyToField_ψ_ne_zero h0)
-  simp only [WeierstrassCurve.Jacobian.negY_eq, pointedCurve_a₁, pointedCurve_a₃,
-    Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons, Matrix.cons_val_two,
-    Matrix.tail_cons] at key
+  simp only [WeierstrassCurve.Jacobian.negY_eq, pointedCurve_a₁, pointedCurve_a₃, Matrix.head_cons,
+    Matrix.cons_val_two, Matrix.tail_cons] at key
   refine .trans ?_ key
   -- `ω_neg` negates the numerator and `ψ_neg` the denominator's cube, so the signs cancel.
   rw [smulY_def, ψ_neg, ω_neg]
@@ -499,7 +498,7 @@ lemma addX_smul_one_smul_one :
   have hψ₂ : polyToField (curve.ψ 2) ≠ 0 := polyToField_ψ_ne_zero two_ne_zero
   have hF := congrArg polyToField (C_Ψ₃ curve)
   simp only [map_sub polyToField, map_add polyToField, map_mul polyToField, map_pow polyToField,
-    map_ofNat, polyToField_Ψ₂Sq, polyToField_polynomial, mul_zero, ← ψ_three, ← ψ_two] at hF
+    map_ofNat, polyToField_Ψ₂Sq, polyToField_polynomial, ← ψ_three, ← ψ_two] at hF
   rw [Affine.addX, slopeOne_eq_neg_div, smulX_two, smulX_one, pointedCurve_a₁, pointedCurve_a₂]
   field_simp
   linear_combination hF
@@ -521,7 +520,7 @@ lemma addY_smul_one_smul_one :
   have hF := congrArg polyToField (ω_def curve 2)
   simp only [reducedInvarDenom_two, complEDS₂Aux_two, one_mul, sub_zero, hY, hneg, ← ψ_three,
     map_add polyToField, map_sub polyToField, map_mul polyToField, map_pow polyToField,
-    map_neg polyToField, map_ofNat, polyToField_polynomial, mul_zero, zero_mul, add_zero] at hF
+    map_neg polyToField, polyToField_polynomial, mul_zero] at hF
   rw [Affine.addY, Affine.negAddY, addX_smul_one_smul_one, smulY_one, smulX_two, smulX_one,
     slopeOne_eq_neg_div, Affine.negY, pointedCurve_a₁, pointedCurve_a₃, smulY_def 2, hF]
   field_simp
@@ -716,7 +715,7 @@ lemma algebraMap_comp_smulRing (n : ℤ) : algebraMap _ _ ∘ smulRing n = smulF
   -- Not `rfl`: `polyToField`'s body is unexposed, so its factorisation through `AdjoinRoot.mk`
   -- has to come from the equation lemma.
   ext i
-  fin_cases i <;> simp [Function.comp_def, polyToField_apply]
+  fin_cases i <;> simp [polyToField_apply]
 
 /-- **The Jacobian coordinates of `n • (X, Y)` are `(φₙ : ωₙ : ψₙ)`.** The Jacobian form of
 `Affine.zsmul_point_eq_smulX_smulY`: where the affine statement divides by `ψₙ²` and `ψₙ³`, the
@@ -753,11 +752,11 @@ theorem zsmul_point_eq_smulField : (n • Jacobian.point).point = ⟦smulField n
 /-- `smulRing` at `0` is the triple `(1, 1, 0)`, the universal-ring representation of the point
 at infinity. -/
 @[simp] lemma smulRing_zero : smulRing 0 = ![1, 1, 0] := by
-  simp [smulRing, smulPoly_zero, comp_fin3]
+  simp [comp_fin3]
 
 /-- `smulField` at `0` is the triple `(1 : 1 : 0)`, the point at infinity. -/
 @[simp] lemma smulField_zero : smulField 0 = ![1, 1, 0] := by
-  simp [smulField, smulPoly_zero, comp_fin3]
+  simp [comp_fin3]
 
 /-- **The `Z`-coordinate of Mathlib's Jacobian doubling formula at `(φₙ, ωₙ, ψₙ)` is `ψ₂ₙ`** —
 already in the polynomial ring, with no reduction modulo the Weierstrass polynomial. -/
@@ -769,7 +768,7 @@ lemma dblZ_smulPoly : dblZ curvePoly (smulPoly n) = curve.ψ (2 * n) := by
   have key : 2 * curve.ω n + curvePoly.a₁ * curve.φ n * curve.ψ n
       + curvePoly.a₃ * curve.ψ n ^ 3 = curve.ψc n := curve.ω_spec n
   rw [← ψ_mul_ψc, ← key]
-  simp only [dblZ, smulPoly, negY_eq, fin3_def_ext]
+  simp only [dblZ, negY_eq, fin3_def_ext]
   ring
 
 /-- The triple `(φₙ : ωₙ : ψₙ)` is a nonsingular Jacobian point representative of the universal
@@ -818,10 +817,10 @@ lemma dblXYZ_smulRing : dblXYZ curveRing (smulRing n) = smulRing (2 * n) := by
 -- discharged through `sub_eq_zero` and `ring` instead.
 lemma addZ_smulPoly : addZ (smulPoly m) (smulPoly n) = curve.ψ (n + m) * curve.ψ (n - m) := by
   have key := curve.isEllipticNet_ψ.isEllipticSequence n m 1
-  simp only [IsEllipticNet.rel, add_zero, ψ_one, mul_one] at key
+  simp only [IsEllipticNet.rel, add_zero, ψ_one] at key
   symm
   rw [← sub_eq_zero, ← key, addZ]
-  simp only [smulPoly, fin3_def_ext, WeierstrassCurve.φ]
+  simp only [fin3_def_ext, WeierstrassCurve.φ]
   ring
 
 /-- **Negating the index negates the point**: the triple at `-n` is Mathlib's Jacobian negation of
@@ -834,7 +833,7 @@ the triple at `n`, rescaled by `-1`. -/
   -- explicit `Matrix.cons_val_*` lemmas cannot match; the default `simp` set can, via the
   -- `Fin.reduceFinMk` simproc, after which the tuple projections and `ring` finish all three.
   funext i
-  fin_cases i <;> simp [smulPoly, smul_fin3, neg, negY, φ_neg, ψ_neg] <;> ring
+  fin_cases i <;> simp [smul_fin3, neg, negY] <;> ring
 
 /-- The negation rule over the universal ring. -/
 @[simp] lemma smulRing_neg :
@@ -879,8 +878,8 @@ lemma addXYZ_smulField :
   · rw [addXYZ_Z,
       (smul_fin3_ext (smulField (n + m)) (polyToField (curve.ψ (n - m)))).2.2, smulField_Z]
     have hF := congrArg polyToField (addZ_smulPoly (m := m) (n := n))
-    simp only [addZ, smulPoly, smulField, Function.comp_def, fin3_def_ext, map_sub polyToField,
-      map_mul polyToField, map_pow polyToField] at hF ⊢
+    simp only [addZ, Function.comp_def, map_sub polyToField, map_mul polyToField,
+      map_pow polyToField] at hF ⊢
     linear_combination hF
   -- The nonvanishing side-goal is that same scaled projection, rewritten the same way.
   · rw [(smul_fin3_ext (smulField (n + m)) (polyToField (curve.ψ (n - m)))).2.2, smulField_Z]
@@ -928,11 +927,11 @@ abbrev smulEval (n : ℤ) : Fin 3 → R := evalEval x y ∘ ![W.φ n, W.ω n, W.
 
 /-- `smulEval` at `0` is `(1, 1, 0)`, the Jacobian triple of the point at infinity. -/
 @[simp] lemma smulEval_zero : smulEval W x y 0 = ![1, 1, 0] := by
-  simp [smulEval, comp_fin3, evalEval]
+  simp [comp_fin3]
 
 /-- `smulEval` at `1` is `(x, y, 1)`: the point `(x, y)` itself, in Jacobian coordinates. -/
 @[simp] lemma smulEval_one : smulEval W x y 1 = ![x, y, 1] := by
-  simp [smulEval, comp_fin3, evalEval]
+  simp [comp_fin3, evalEval]
 
 variable {W} (eqn : Affine.Equation W x y)
 
@@ -948,8 +947,7 @@ what turns each identity over `curveRing` into the same identity for `W` at `(x,
   -- `Matrix.cons_val_*` lemmas cannot match it; the default `simp` set reduces it through the
   -- `Fin.reduceFinMk` simproc, and the three coordinates then close uniformly.
   funext i
-  fin_cases i <;> simp [Jacobian.smulRing, smulEval, ringEval_mk, evalEval_φ, evalEval_ω,
-    evalEval_ψ]
+  fin_cases i <;> simp [evalEval_φ, evalEval_ω, evalEval_ψ]
 
 end Universal
 
@@ -959,7 +957,7 @@ evaluations and needs no equation on `(x, y)`. -/
 @[simp] lemma smulEval_neg (n : ℤ) :
     smulEval W x y (-n) = (-1 : R) • Jacobian.neg W (smulEval W x y n) := by
   funext i
-  fin_cases i <;> (simp [smulEval, smul_fin3, Jacobian.neg, Jacobian.negY, φ_neg, ψ_neg]; try ring)
+  fin_cases i <;> (simp [smul_fin3, Jacobian.neg, Jacobian.negY]; try ring)
 
 include eqn in
 /-- **The doubling formula for a concrete curve**: `dblXYZ_smulRing` specialized along the point

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ZSMul.lean
@@ -752,11 +752,11 @@ theorem zsmul_point_eq_smulField : (n • Jacobian.point).point = ⟦smulField n
 /-- `smulRing` at `0` is the triple `(1, 1, 0)`, the universal-ring representation of the point
 at infinity. -/
 @[simp] lemma smulRing_zero : smulRing 0 = ![1, 1, 0] := by
-  simp [comp_fin3]
+  simp [smulRing, comp_fin3]
 
 /-- `smulField` at `0` is the triple `(1 : 1 : 0)`, the point at infinity. -/
 @[simp] lemma smulField_zero : smulField 0 = ![1, 1, 0] := by
-  simp [comp_fin3]
+  simp [smulField, comp_fin3]
 
 /-- **The `Z`-coordinate of Mathlib's Jacobian doubling formula at `(φₙ, ωₙ, ψₙ)` is `ψ₂ₙ`** —
 already in the polynomial ring, with no reduction modulo the Weierstrass polynomial. -/
@@ -768,7 +768,7 @@ lemma dblZ_smulPoly : dblZ curvePoly (smulPoly n) = curve.ψ (2 * n) := by
   have key : 2 * curve.ω n + curvePoly.a₁ * curve.φ n * curve.ψ n
       + curvePoly.a₃ * curve.ψ n ^ 3 = curve.ψc n := curve.ω_spec n
   rw [← ψ_mul_ψc, ← key]
-  simp only [dblZ, negY_eq, fin3_def_ext]
+  simp only [dblZ, smulPoly, negY_eq, fin3_def_ext]
   ring
 
 /-- The triple `(φₙ : ωₙ : ψₙ)` is a nonsingular Jacobian point representative of the universal
@@ -820,7 +820,7 @@ lemma addZ_smulPoly : addZ (smulPoly m) (smulPoly n) = curve.ψ (n + m) * curve.
   simp only [IsEllipticNet.rel, add_zero, ψ_one] at key
   symm
   rw [← sub_eq_zero, ← key, addZ]
-  simp only [fin3_def_ext, WeierstrassCurve.φ]
+  simp only [smulPoly, fin3_def_ext, WeierstrassCurve.φ]
   ring
 
 /-- **Negating the index negates the point**: the triple at `-n` is Mathlib's Jacobian negation of
@@ -833,7 +833,7 @@ the triple at `n`, rescaled by `-1`. -/
   -- explicit `Matrix.cons_val_*` lemmas cannot match; the default `simp` set can, via the
   -- `Fin.reduceFinMk` simproc, after which the tuple projections and `ring` finish all three.
   funext i
-  fin_cases i <;> simp [smul_fin3, neg, negY] <;> ring
+  fin_cases i <;> simp [smulPoly, smul_fin3, neg, negY] <;> ring
 
 /-- The negation rule over the universal ring. -/
 @[simp] lemma smulRing_neg :
@@ -878,8 +878,8 @@ lemma addXYZ_smulField :
   · rw [addXYZ_Z,
       (smul_fin3_ext (smulField (n + m)) (polyToField (curve.ψ (n - m)))).2.2, smulField_Z]
     have hF := congrArg polyToField (addZ_smulPoly (m := m) (n := n))
-    simp only [addZ, Function.comp_def, map_sub polyToField, map_mul polyToField,
-      map_pow polyToField] at hF ⊢
+    simp only [addZ, smulPoly, smulField, Function.comp_def, map_sub polyToField,
+      map_mul polyToField, map_pow polyToField] at hF ⊢
     linear_combination hF
   -- The nonvanishing side-goal is that same scaled projection, rewritten the same way.
   · rw [(smul_fin3_ext (smulField (n + m)) (polyToField (curve.ψ (n - m)))).2.2, smulField_Z]
@@ -927,11 +927,11 @@ abbrev smulEval (n : ℤ) : Fin 3 → R := evalEval x y ∘ ![W.φ n, W.ω n, W.
 
 /-- `smulEval` at `0` is `(1, 1, 0)`, the Jacobian triple of the point at infinity. -/
 @[simp] lemma smulEval_zero : smulEval W x y 0 = ![1, 1, 0] := by
-  simp [comp_fin3]
+  simp [smulEval, comp_fin3, evalEval]
 
 /-- `smulEval` at `1` is `(x, y, 1)`: the point `(x, y)` itself, in Jacobian coordinates. -/
 @[simp] lemma smulEval_one : smulEval W x y 1 = ![x, y, 1] := by
-  simp [comp_fin3, evalEval]
+  simp [smulEval, comp_fin3, evalEval]
 
 variable {W} (eqn : Affine.Equation W x y)
 
@@ -947,7 +947,7 @@ what turns each identity over `curveRing` into the same identity for `W` at `(x,
   -- `Matrix.cons_val_*` lemmas cannot match it; the default `simp` set reduces it through the
   -- `Fin.reduceFinMk` simproc, and the three coordinates then close uniformly.
   funext i
-  fin_cases i <;> simp [evalEval_φ, evalEval_ω, evalEval_ψ]
+  fin_cases i <;> simp [Jacobian.smulRing, smulEval, evalEval_φ, evalEval_ω, evalEval_ψ]
 
 end Universal
 
@@ -957,7 +957,7 @@ evaluations and needs no equation on `(x, y)`. -/
 @[simp] lemma smulEval_neg (n : ℤ) :
     smulEval W x y (-n) = (-1 : R) • Jacobian.neg W (smulEval W x y n) := by
   funext i
-  fin_cases i <;> (simp [smul_fin3, Jacobian.neg, Jacobian.negY]; try ring)
+  fin_cases i <;> (simp [smulEval, smul_fin3, Jacobian.neg, Jacobian.negY]; try ring)
 
 include eqn in
 /-- **The doubling formula for a concrete curve**: `dblXYZ_smulRing` specialized along the point


### PR DESCRIPTION
Every multi-argument simp set in `ZSMul.lean` deletion-tested. 19 arguments were doing nothing.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"zsmul-simp-minimisation"}-->

## The defect class

Lean errors on a simp argument that **never fires**. It is silent about one that **fires yet is
unnecessary** — another lemma in the same set reaches the same normal form without it. The file
compiled clean and `lint-env` passed with all 32 present, because nothing in the toolchain asks
this question.

**41 sets tested, 0 skipped, 212 builds. 19 arguments came out.**

> **Round 1 correction (proof-quality).** The first push claimed 32. Thirteen of those were
> occurrences of `abbrev`s — `smulPoly`, `smulRing`, `smulField`, `smulEval`,
> `Jacobian.smulRing`, `evalEval` — and an `abbrev` is `@[reducible]`, so `simp` unfolds it
> whether or not it is named. They were removable *by construction*, and removing them left the
> dependency in force while hiding it. All 13 are restored at their original positions. The
> deletion test cannot judge a reducible name, so the sweep now refuses them as candidates.

Several are more than shorter text:

* `smulX_neg` goes from three lemmas to `simp [smulX_def]`.
* `addY_smul_one_smul_one` sheds four.

## Method, and its two failure modes

Remove one argument, rebuild, keep the removal if it still compiles.

**Greedy is not optional.** The removals interact: dropping four entries of one set together made a
fifth stop firing, and Lean rejected that outright. Being greedy this finds *a* minimal set, not
*the* minimum.

**A tactic-shaped regex also matches prose.** One match was inside a docstring, quoting the AINTLIB
source's own `simp only [φ, ψᵤ, map_sub, map_mul, map_pow, ← add_div]`. Prose does not compile, so
*every* argument in it tested as removable — the false positive arrived looking like the strongest
finding in the run. It was caught by masking comments and docstrings and re-checking every diff
hunk against that mask, and reverted. 0 prose hunks remain; the quotation is verbatim again.

No statement changes; every edit is inside a proof. Declaration name set verified identical to
`main` — 66 and 66, symmetric difference 0.

## Provenance

No new mathematics; a refactor of merged code. Attribution follows the file's own provenance block:
AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`), `LutzNagell/ZSMul.lean`.

Checked against that pin: the source carries the same redundancy — `LutzNagell/ZSMul.lean:506` is
`simp [smulField, smulPoly_zero, comp_fin3]`. So this improves on the source rather than diverging
from a deliberate choice.

Gates: `lake build` 0 errors 0 warnings · `lint-env` PASS · `lint-dot-notation` 0 new.

