### PR TITLE
fix(Basic): put evalEval back in the simp set — it is an abbrev, so the removal hid a live dependency

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Basic.lean
@@ -127,6 +127,6 @@ sites are unchanged. Over any commutative ring, because both `ℤ` (for the inte
 `ℚ` (for the point) need it. -/
 @[simp] lemma evalEval_ψ₂_of_isCharNeTwoNF {R : Type*} [CommRing R] (W : WeierstrassCurve R)
     [W.IsCharNeTwoNF] (x y : R) : W.ψ₂.evalEval x y = 2 * y := by
-  simp [WeierstrassCurve.ψ₂, Affine.polynomialY]
+  simp [WeierstrassCurve.ψ₂, Affine.polynomialY, evalEval]
 
 end WeierstrassCurve


### PR DESCRIPTION
One simp argument, put back. #4380 removed it and merged before the fix could be pushed, so the
defect is on `main`.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"evaleval-abbrev-fix"}-->

## What went wrong

#4380 dropped `evalEval` from the simp set of `evalEval_ψ₂_of_isCharNeTwoNF`, on the strength of a
deletion test: remove the argument, rebuild, keep the removal if it still compiles.

**That test cannot judge a reducible name.** Mathlib's `evalEval` is an `abbrev`
(`Algebra/Polynomial/Bivariate.lean:44`), hence `@[reducible]`, so `simp` unfolds it whether or not
it appears in the set. "Still compiles without it" is therefore answered by *reducibility*, not by
*redundancy* — such a name is removable by construction. Removing it left the dependency in force
and made it invisible, which is worse for robustness than leaving it written down.

`proof-quality` raised exactly this class on the sibling PR #4381:

> `smulRing_zero`, `smulField_zero`, `smulEval_zero` and `smulEval_one` rely on `simp` implicitly
> unfolding the `smulRing`/`smulField`/`smulEval` abbreviations to expose `comp_fin3`.

Six names were affected there and all are restored on that PR. This one had merged by then.

## Scope of the audit

The whole file was re-checked for reducible names dropped from simp sets; `evalEval` is the only
one. #4380's other removal is unaffected and stays: `shortCurve` is a plain `def`, **not**
reducible, so `simp` does not unfold it implicitly and dropping it genuinely did route
`map_shortCurve` through the five `@[simp]` coefficient lemmas.

No statement changes; the declaration set is identical to `main`.

Gates: `lake build` 0 errors 0 warnings · `lint-env` PASS · `lint-dot-notation` 0 new.
