### PR TITLE
refactor(DivisionPolynomial): drop seven simp arguments that were never necessary

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Descent.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Descent.lean
@@ -108,8 +108,7 @@ theorem mul_eval_ΨSq_eq_eval_Φ_of_zsmul {x y : F} (hns : E.toAffine.Nonsingula
   have hequiv : smulEval E x y n ≈ ![x', y', 1] := by
     rw [Jacobian.Point.ext_iff, hsmul] at hJac; exact Quotient.exact hJac
   have hX := Jacobian.X_eq_of_equiv hequiv
-  simp only [smulEval, Function.comp, Matrix.cons_val_zero, Matrix.cons_val_two,
-    Matrix.head_cons, Matrix.tail_cons] at hX
+  simp only [smulEval, Function.comp, Matrix.cons_val_two] at hX
   norm_num at hX
   rw [evalEval_φ_eq_eval_Φ E hns.left n] at hX
   have hΨSq := evalEval_Ψ_sq_eq_eval_ΨSq E hns.left n

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
@@ -75,7 +75,7 @@ over a subsingleton every polynomial is monic. -/
 theorem monic_Φ_sub_C_mul_ΨSq (n : ℤ) (c : R) : (W.Φ n - C c * W.ΨSq n).Monic := by
   nontriviality R
   rcases eq_or_ne n 0 with rfl | hn0
-  · simp [_root_.WeierstrassCurve.ΨSq_zero, _root_.WeierstrassCurve.Φ_zero]
+  · simp [_root_.WeierstrassCurve.Φ_zero]
   · refine Polynomial.Monic.sub_of_left (W.leadingCoeff_Φ n) (degree_lt_degree ?_)
     calc (C c * W.ΨSq n).natDegree
       _ ≤ (W.ΨSq n).natDegree := natDegree_C_mul_le _ _

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Universal.lean
@@ -179,7 +179,7 @@ lemma polyEval_cusp_φ : polyEval (cusp ℤ) 1 1 (curve.φ n) = 1 := by
   rw [WeierstrassCurve.φ, map_sub (polyEval (cusp ℤ) 1 1), map_mul (polyEval (cusp ℤ) 1 1),
     map_mul (polyEval (cusp ℤ) 1 1), map_pow (polyEval (cusp ℤ) 1 1), polyEval_cusp_ψ,
     polyEval_cusp_ψ, polyEval_cusp_ψ]
-  simp [polyEval_apply, evalEval]
+  simp [evalEval]
   ring
 
 /-- The `ω`-division polynomial of `W` at `(x, y)` is the universal one under `polyEval`. -/
@@ -201,8 +201,8 @@ lemma polyEval_cusp_ω : polyEval (cusp ℤ) 1 1 (curve.ω n) = 1 := by
   -- Evaluate `two_mul_ω` at the cusp: `ψc` gives `2`, `φ` gives `1`, the cusp's `a₁` and `a₃`
   -- vanish, so `h` collapses to `2 * (the goal's left side) = 2` and the `2` cancels.
   have h := congr(polyEval (cusp ℤ) 1 1 $(two_mul_ω curve n))
-  simp only [map_mul (polyEval (cusp ℤ) 1 1), map_sub (polyEval (cusp ℤ) 1 1),
-    map_pow (polyEval (cusp ℤ) 1 1), polyEval_cusp_ψc, polyEval_cusp_ψ, polyEval_cusp_φ] at h
+  simp only [map_mul (polyEval (cusp ℤ) 1 1), map_sub (polyEval (cusp ℤ) 1 1), polyEval_cusp_ψc,
+    polyEval_cusp_φ] at h
   -- The residual `a₁`/`a₃` terms sit under `CC`, whose body is unexposed and has no cusp value
   -- lemma, so no named rewrite can kill them; evaluating the wrappers is the one route left.
   simpa [polyEval_apply, evalEval] using h


### PR DESCRIPTION
Seven simp arguments across three division-polynomial files were doing nothing. Removing them.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"divpoly-simp-minimisation"}-->

## The defect class

Lean errors on a simp argument that **never fires**. It is silent about one that **fires yet is
unnecessary** — another lemma in the same set reaches the same normal form without it. These files
compiled clean and `lint-env` passed with all seven present.

| file | removed |
|---|---|
| `Integral.lean` | `ΨSq_zero` |
| `Universal.lean` | `polyEval_apply`, `map_pow (polyEval (cusp ℤ) 1 1)`, `polyEval_cusp_ψ` |
| `Descent.lean` | `Matrix.cons_val_zero`, `Matrix.head_cons`, `Matrix.tail_cons` |

Method: remove one argument, rebuild, keep the removal if it still compiles. 24 sets, 130 builds.
Greedy — one at a time, rebuilding after each — because the removals interact, so it finds *a*
minimal set rather than *the* minimum.

## An eighth candidate, rejected

The sweep also flagged `smulEval` in `Descent.lean`. **That one is kept.** `smulEval` is an
`abbrev`, hence `@[reducible]`, so `simp` unfolds it whether or not it is named — "still compiles
without it" is answered by *reducibility*, not by *redundancy*, and such a name is removable by
construction. Dropping it would have hidden a live dependency rather than eliminating one.

This is the defect `proof-quality` raised on #4381, where six such names had been removed; all are
restored there, and #4383 fixes the one instance that reached `main`. The sweep now guards on the
declaration keyword. The guard is discriminating rather than blanket: `shortCurve` in the same
family of files is a plain `def`, not reducible, and dropping it was correct.

The diff is also audited against a comment/docstring mask — a tactic-shaped regex otherwise matches
a `simp only` *quoted in prose*, where nothing compiles and every argument therefore tests as
removable. 0 hunks land in prose here.

No statement changes; every edit is inside a proof, and the declaration set is identical to `main`
(0 added, 0 removed).

## Provenance

No new mathematics; a refactor of merged code. Attribution follows each file's own provenance block:
AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0,
`main @ 1c1c74664e40071c2c2165bc55ca2616a67ccd6b`).

Gates: `lake build` 0 errors 0 warnings · `lint-env` PASS · `lint-dot-notation` 0 new.
