### PR TITLE
feat: add Aldous-Hoover array codings

### DIFF
--- a/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
@@ -185,13 +185,15 @@ theorem separateArray_apply (f : I × I × I × I → α)
       f (u .global, u (.vertex .row p.1), u (.vertex .column p.2), u (.cell p.1 p.2)) :=
   (rfl)
 
-/-- Every entry of a measurable separate Aldous--Hoover coding is measurable in the noise. -/
-theorem measurable_separateArray_apply (f : I × I × I × I → α)
-    (hf : Measurable f) (p : ℕ × ℕ) : Measurable (separateArray f p) := by
-  exact hf.comp ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Axis)).prodMk
-    ((measurable_pi_apply (NoiseIndex.vertex Axis.row p.1)).prodMk
-      ((measurable_pi_apply (NoiseIndex.vertex Axis.column p.2)).prodMk
-        (measurable_pi_apply (NoiseIndex.cell p.1 p.2)))))
+/-- A measurable separate Aldous--Hoover coding is measurable as an array-valued random
+variable. -/
+theorem measurable_separateArray (f : I × I × I × I → α) (hf : Measurable f) :
+    Measurable fun u : NoiseIndex Axis → I => fun p => separateArray f p u :=
+  measurable_pi_lambda _ fun p => hf.comp
+    ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Axis)).prodMk
+      ((measurable_pi_apply (NoiseIndex.vertex Axis.row p.1)).prodMk
+        ((measurable_pi_apply (NoiseIndex.vertex Axis.column p.2)).prodMk
+          (measurable_pi_apply (NoiseIndex.cell p.1 p.2)))))
 
 /-- **Every measurable separate Aldous--Hoover coding is separately exchangeable.** -/
 theorem separatelyExchangeable_separateArray
@@ -203,8 +205,7 @@ theorem separatelyExchangeable_separateArray
     | .row => rowPerm
     | .column => colPerm
   have hcode : Measurable fun u : NoiseIndex Axis → I =>
-      fun p => separateArray f p u :=
-    measurable_pi_lambda _ fun p => measurable_separateArray_apply f hf p
+      fun p => separateArray f p u := measurable_separateArray f hf
   have hfun : (fun u : NoiseIndex Axis → I =>
       fun p => separateArray f (rowPerm p.1, colPerm p.2) u) =
         (fun u => fun p => separateArray f p u) ∘
@@ -229,13 +230,14 @@ theorem jointArray_apply (f : I × I × I × I → α)
       f (u .global, u (.vertex () p.1), u (.vertex () p.2), u (.cell p.1 p.2)) :=
   (rfl)
 
-/-- Every entry of a measurable joint Aldous--Hoover coding is measurable in the noise. -/
-theorem measurable_jointArray_apply (f : I × I × I × I → α)
-    (hf : Measurable f) (p : ℕ × ℕ) : Measurable (jointArray f p) := by
-  exact hf.comp ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Unit)).prodMk
-    ((measurable_pi_apply (NoiseIndex.vertex () p.1)).prodMk
-      ((measurable_pi_apply (NoiseIndex.vertex () p.2)).prodMk
-        (measurable_pi_apply (NoiseIndex.cell p.1 p.2)))))
+/-- A measurable joint Aldous--Hoover coding is measurable as an array-valued random variable. -/
+theorem measurable_jointArray (f : I × I × I × I → α) (hf : Measurable f) :
+    Measurable fun u : NoiseIndex Unit → I => fun p => jointArray f p u :=
+  measurable_pi_lambda _ fun p => hf.comp
+    ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Unit)).prodMk
+      ((measurable_pi_apply (NoiseIndex.vertex () p.1)).prodMk
+        ((measurable_pi_apply (NoiseIndex.vertex () p.2)).prodMk
+          (measurable_pi_apply (NoiseIndex.cell p.1 p.2)))))
 
 /-- **Every measurable joint Aldous--Hoover coding is jointly exchangeable.** -/
 theorem jointlyExchangeable_jointArray
@@ -245,8 +247,7 @@ theorem jointlyExchangeable_jointArray
   intro perm
   let vertexPerm : Unit → Equiv.Perm ℕ := fun _ => perm
   have hcode : Measurable fun u : NoiseIndex Unit → I =>
-      fun p => jointArray f p u :=
-    measurable_pi_lambda _ fun p => measurable_jointArray_apply f hf p
+      fun p => jointArray f p u := measurable_jointArray f hf
   have hfun : (fun u : NoiseIndex Unit → I =>
       fun p => jointArray f (perm p.1, perm p.2) u) =
         (fun u => fun p => jointArray f p u) ∘ noiseReindex vertexPerm perm perm := by

--- a/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
@@ -1,0 +1,266 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.Arrays.Basic
+import Mathlib.MeasureTheory.Constructions.UnitInterval
+import Mathlib.Probability.Independence.InfinitePi
+
+/-!
+# Aldous--Hoover array codings are exchangeable
+
+The functional forms in the Aldous--Hoover representation use four independent kinds of uniform
+randomness.  A separately exchangeable array is coded from a global variable, one variable for
+each row, one for each column, and one for each cell:
+
+```text
+X i j = f(U, Uᵣ i, U꜀ j, Uᵢⱼ).
+```
+
+For a jointly exchangeable array, the row and column variables are replaced by one family of
+vertex variables:
+
+```text
+X i j = f(U, Uᵥ i, Uᵥ j, Uᵢⱼ).
+```
+
+This file defines canonical product probability spaces carrying those sources and proves the easy
+direction of the Aldous--Hoover representation theorem: every measurable coding of the first form
+is separately exchangeable, and every measurable coding of the second form is jointly
+exchangeable.  The proof reindexes the independent source family.  Row and column permutations
+act on their respective vertex variables and together on the cell variables, while leaving the
+global variable fixed.
+
+These results advance the exchangeable-arrays milestone in
+`TauCetiRoadmap/Exchangeability/README.md`, Layer 8.  The converse representation direction still
+has to construct the coding function from an exchangeable array.
+
+## Main definitions
+
+* `TauCeti.Probability.AldousHoover.Axis` labels the row and column noise families;
+* `TauCeti.Probability.AldousHoover.NoiseIndex` indexes global, vertex, and cell noise;
+* `TauCeti.Probability.AldousHoover.noiseMeasure` is the corresponding i.i.d. uniform law;
+* `TauCeti.Probability.AldousHoover.separateArray` and
+  `TauCeti.Probability.AldousHoover.jointArray` are the two coding forms.
+
+## Main results
+
+* `TauCeti.Probability.AldousHoover.separatelyExchangeable_separateArray`;
+* `TauCeti.Probability.AldousHoover.jointlyExchangeable_jointArray`.
+
+## References
+
+* D. Aldous, "Representations for partially exchangeable arrays of random variables", *Journal of
+  Multivariate Analysis* 11 (1981), 581--598.
+* O. Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005, Chapter 7.
+
+No material is adapted from `cameronfreer/exchangeability`, which treats sequences rather than
+exchangeable arrays.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory unitInterval
+
+namespace TauCeti
+
+namespace Probability
+
+namespace AldousHoover
+
+/-- Indices for the independent noise in an Aldous--Hoover coding.  The parameter `κ` indexes
+families of vertex variables: use `Axis` for separate row and column families and `Unit` for one
+common family in the jointly exchangeable form. -/
+inductive NoiseIndex (κ : Type*) where
+  | global
+  | vertex (axis : κ) (i : ℕ)
+  | cell (i j : ℕ)
+
+/-- The two vertex-noise families in the separately exchangeable coding. -/
+inductive Axis where
+  | row
+  | column
+
+/-- Reindex Aldous--Hoover noise by a permutation of each vertex family and by permutations of the
+two cell coordinates. -/
+def indexEquiv {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (rowPerm colPerm : Equiv.Perm ℕ) :
+    NoiseIndex κ ≃ NoiseIndex κ where
+  toFun
+    | .global => .global
+    | .vertex a i => .vertex a (vertexPerm a i)
+    | .cell i j => .cell (rowPerm i) (colPerm j)
+  invFun
+    | .global => .global
+    | .vertex a i => .vertex a ((vertexPerm a).symm i)
+    | .cell i j => .cell (rowPerm.symm i) (colPerm.symm j)
+  left_inv x := by
+    cases x <;> simp
+  right_inv x := by
+    cases x <;> simp
+
+@[simp]
+theorem indexEquiv_global {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (rowPerm colPerm : Equiv.Perm ℕ) :
+    indexEquiv vertexPerm rowPerm colPerm (.global : NoiseIndex κ) = .global :=
+  (rfl)
+
+@[simp]
+theorem indexEquiv_vertex {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (rowPerm colPerm : Equiv.Perm ℕ)
+    (a : κ) (i : ℕ) :
+    indexEquiv vertexPerm rowPerm colPerm (.vertex a i) = .vertex a (vertexPerm a i) :=
+  (rfl)
+
+@[simp]
+theorem indexEquiv_cell {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (rowPerm colPerm : Equiv.Perm ℕ) (i j : ℕ) :
+    indexEquiv vertexPerm rowPerm colPerm (.cell i j) = .cell (rowPerm i) (colPerm j) :=
+  (rfl)
+
+/-- The canonical law of the independent uniform variables used by an Aldous--Hoover coding. -/
+def noiseMeasure (κ : Type*) : Measure (NoiseIndex κ → I) :=
+  Measure.infinitePi fun _ => (volume : Measure I)
+
+/-- The canonical Aldous--Hoover noise law is a probability measure. -/
+instance instIsProbabilityMeasureNoiseMeasure (κ : Type*) : IsProbabilityMeasure (noiseMeasure κ) :=
+  inferInstanceAs (IsProbabilityMeasure
+    (Measure.infinitePi fun _ : NoiseIndex κ => (volume : Measure I)))
+
+/-- Reindex a realization of the Aldous--Hoover noise. -/
+def noiseReindex {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (rowPerm colPerm : Equiv.Perm ℕ)
+    (u : NoiseIndex κ → I) : NoiseIndex κ → I :=
+  fun q => u (indexEquiv vertexPerm rowPerm colPerm q)
+
+@[simp]
+theorem noiseReindex_apply {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (rowPerm colPerm : Equiv.Perm ℕ)
+    (u : NoiseIndex κ → I) (q : NoiseIndex κ) :
+    noiseReindex vertexPerm rowPerm colPerm u q =
+      u (indexEquiv vertexPerm rowPerm colPerm q) :=
+  (rfl)
+
+/-- Reindexing the noise is measurable. -/
+@[fun_prop]
+theorem measurable_noiseReindex {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (rowPerm colPerm : Equiv.Perm ℕ) :
+    Measurable (noiseReindex vertexPerm rowPerm colPerm) :=
+  measurable_pi_lambda _ fun q =>
+    measurable_pi_apply (indexEquiv vertexPerm rowPerm colPerm q)
+
+/-- The independent uniform noise law is invariant under reindexing its vertex and cell
+coordinates. -/
+@[simp]
+theorem map_noiseReindex_noiseMeasure {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (rowPerm colPerm : Equiv.Perm ℕ) :
+    (noiseMeasure κ).map (noiseReindex vertexPerm rowPerm colPerm) = noiseMeasure κ := by
+  -- Expose the two wrappers so the generic infinite-product reindexing theorem sees its expected
+  -- coordinate projection literally.
+  change (Measure.infinitePi fun _ : NoiseIndex κ => (volume : Measure I)).map
+      (fun u q => u (indexEquiv vertexPerm rowPerm colPerm q)) =
+    Measure.infinitePi fun _ : NoiseIndex κ => (volume : Measure I)
+  rw [Measure.map_infinitePi_infinitePi_of_inj
+    (indexEquiv vertexPerm rowPerm colPerm).injective]
+
+section Codings
+
+variable {α : Type*} [MeasurableSpace α]
+
+/-- The separately exchangeable Aldous--Hoover coding. -/
+def separateArray (f : I × I × I × I → α)
+    (p : ℕ × ℕ) (u : NoiseIndex Axis → I) : α :=
+  f (u .global, u (.vertex .row p.1), u (.vertex .column p.2), u (.cell p.1 p.2))
+
+omit [MeasurableSpace α] in
+@[simp]
+theorem separateArray_apply (f : I × I × I × I → α)
+    (p : ℕ × ℕ) (u : NoiseIndex Axis → I) :
+    separateArray f p u =
+      f (u .global, u (.vertex .row p.1), u (.vertex .column p.2), u (.cell p.1 p.2)) :=
+  (rfl)
+
+/-- Every entry of a measurable separate Aldous--Hoover coding is measurable in the noise. -/
+theorem measurable_separateArray_apply (f : I × I × I × I → α)
+    (hf : Measurable f) (p : ℕ × ℕ) : Measurable (separateArray f p) := by
+  exact hf.comp ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Axis)).prodMk
+    ((measurable_pi_apply (NoiseIndex.vertex Axis.row p.1)).prodMk
+      ((measurable_pi_apply (NoiseIndex.vertex Axis.column p.2)).prodMk
+        (measurable_pi_apply (NoiseIndex.cell p.1 p.2)))))
+
+/-- **Every measurable separate Aldous--Hoover coding is separately exchangeable.** -/
+theorem separatelyExchangeable_separateArray
+    (f : I × I × I × I → α) (hf : Measurable f) :
+    SeparatelyExchangeable (noiseMeasure Axis) (separateArray f) := by
+  rw [separatelyExchangeable_iff]
+  intro rowPerm colPerm
+  let vertexPerm : Axis → Equiv.Perm ℕ
+    | .row => rowPerm
+    | .column => colPerm
+  have hcode : Measurable fun u : NoiseIndex Axis → I =>
+      fun p => separateArray f p u :=
+    measurable_pi_lambda _ fun p => measurable_separateArray_apply f hf p
+  have hfun : (fun u : NoiseIndex Axis → I =>
+      fun p => separateArray f (rowPerm p.1, colPerm p.2) u) =
+        (fun u => fun p => separateArray f p u) ∘
+          noiseReindex vertexPerm rowPerm colPerm := by
+    funext u p
+    simp [separateArray_apply, Function.comp_apply, vertexPerm]
+  rw [hfun, ← Measure.map_map hcode
+      (measurable_noiseReindex vertexPerm rowPerm colPerm),
+    map_noiseReindex_noiseMeasure]
+
+/-- The jointly exchangeable Aldous--Hoover coding, using one common family of vertex variables
+for the two axes. -/
+def jointArray (f : I × I × I × I → α)
+    (p : ℕ × ℕ) (u : NoiseIndex Unit → I) : α :=
+  f (u .global, u (.vertex () p.1), u (.vertex () p.2), u (.cell p.1 p.2))
+
+omit [MeasurableSpace α] in
+@[simp]
+theorem jointArray_apply (f : I × I × I × I → α)
+    (p : ℕ × ℕ) (u : NoiseIndex Unit → I) :
+    jointArray f p u =
+      f (u .global, u (.vertex () p.1), u (.vertex () p.2), u (.cell p.1 p.2)) :=
+  (rfl)
+
+/-- Every entry of a measurable joint Aldous--Hoover coding is measurable in the noise. -/
+theorem measurable_jointArray_apply (f : I × I × I × I → α)
+    (hf : Measurable f) (p : ℕ × ℕ) : Measurable (jointArray f p) := by
+  exact hf.comp ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Unit)).prodMk
+    ((measurable_pi_apply (NoiseIndex.vertex () p.1)).prodMk
+      ((measurable_pi_apply (NoiseIndex.vertex () p.2)).prodMk
+        (measurable_pi_apply (NoiseIndex.cell p.1 p.2)))))
+
+/-- **Every measurable joint Aldous--Hoover coding is jointly exchangeable.** -/
+theorem jointlyExchangeable_jointArray
+    (f : I × I × I × I → α) (hf : Measurable f) :
+    JointlyExchangeable (noiseMeasure Unit) (jointArray f) := by
+  rw [jointlyExchangeable_iff]
+  intro perm
+  let vertexPerm : Unit → Equiv.Perm ℕ := fun _ => perm
+  have hcode : Measurable fun u : NoiseIndex Unit → I =>
+      fun p => jointArray f p u :=
+    measurable_pi_lambda _ fun p => measurable_jointArray_apply f hf p
+  have hfun : (fun u : NoiseIndex Unit → I =>
+      fun p => jointArray f (perm p.1, perm p.2) u) =
+        (fun u => fun p => jointArray f p u) ∘ noiseReindex vertexPerm perm perm := by
+    funext u p
+    simp [jointArray_apply, Function.comp_apply, vertexPerm]
+  rw [hfun, ← Measure.map_map hcode (measurable_noiseReindex vertexPerm perm perm),
+    map_noiseReindex_noiseMeasure]
+
+end Codings
+
+end AldousHoover
+
+end Probability
+
+end TauCeti
+
+end

--- a/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
@@ -6,6 +6,7 @@ Authors: Codex
 module
 
 public import TauCeti.Probability.Exchangeability.Arrays.Basic
+public import Mathlib.Data.Sym.Sym2
 import Mathlib.MeasureTheory.Constructions.UnitInterval
 import Mathlib.Probability.Independence.InfinitePi
 
@@ -24,7 +25,7 @@ For a jointly exchangeable array, the row and column variables are replaced by o
 vertex variables:
 
 ```text
-X i j = f(U, U_vert i, U_vert j, U_cell i j).
+X i j = f(U, U_vert i, U_vert j, U_cell {i, j}).
 ```
 
 This file defines canonical product probability spaces carrying those sources and proves the easy
@@ -74,99 +75,93 @@ namespace Probability
 namespace AldousHoover
 
 /-- Indices for the independent noise in an Aldous--Hoover coding.  The parameter `κ` indexes
-families of vertex variables: use `Axis` for separate row and column families and `Unit` for one
-common family in the jointly exchangeable form. -/
-inductive NoiseIndex (κ : Type*) where
+families of vertex variables, while `ι` indexes the cell variables. -/
+inductive NoiseIndex (κ ι : Type*) where
   | global
   | vertex (axis : κ) (i : ℕ)
-  | cell (i j : ℕ)
+  | cell (p : ι)
 
 /-- The two vertex-noise families in the separately exchangeable coding. -/
 inductive Axis where
   | row
   | column
 
-/-- Reindex Aldous--Hoover noise by a permutation of each vertex family and by permutations of the
-two cell coordinates. -/
-def indexEquiv {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
-    (rowPerm colPerm : Equiv.Perm ℕ) :
-    NoiseIndex κ ≃ NoiseIndex κ where
+/-- Reindex Aldous--Hoover noise by a permutation of each vertex family and of the cell indices. -/
+def indexEquiv {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ) (cellPerm : ι ≃ ι) :
+    NoiseIndex κ ι ≃ NoiseIndex κ ι where
   toFun
     | .global => .global
     | .vertex a i => .vertex a (vertexPerm a i)
-    | .cell i j => .cell (rowPerm i) (colPerm j)
+    | .cell p => .cell (cellPerm p)
   invFun
     | .global => .global
     | .vertex a i => .vertex a ((vertexPerm a).symm i)
-    | .cell i j => .cell (rowPerm.symm i) (colPerm.symm j)
+    | .cell p => .cell (cellPerm.symm p)
   left_inv x := by
     cases x <;> simp
   right_inv x := by
     cases x <;> simp
 
 @[simp]
-theorem indexEquiv_global {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
-    (rowPerm colPerm : Equiv.Perm ℕ) :
-    indexEquiv vertexPerm rowPerm colPerm (.global : NoiseIndex κ) = .global :=
+theorem indexEquiv_global {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (cellPerm : ι ≃ ι) :
+    indexEquiv vertexPerm cellPerm (.global : NoiseIndex κ ι) = .global :=
   (rfl)
 
 @[simp]
-theorem indexEquiv_vertex {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
-    (rowPerm colPerm : Equiv.Perm ℕ)
+theorem indexEquiv_vertex {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ) (cellPerm : ι ≃ ι)
     (a : κ) (i : ℕ) :
-    indexEquiv vertexPerm rowPerm colPerm (.vertex a i) = .vertex a (vertexPerm a i) :=
+    indexEquiv vertexPerm cellPerm (.vertex a i) = .vertex a (vertexPerm a i) :=
   (rfl)
 
 @[simp]
-theorem indexEquiv_cell {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
-    (rowPerm colPerm : Equiv.Perm ℕ) (i j : ℕ) :
-    indexEquiv vertexPerm rowPerm colPerm (.cell i j) = .cell (rowPerm i) (colPerm j) :=
+theorem indexEquiv_cell {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (cellPerm : ι ≃ ι) (p : ι) :
+    indexEquiv vertexPerm cellPerm (.cell p) = .cell (cellPerm p) :=
   (rfl)
 
 /-- The canonical law of the independent uniform variables used by an Aldous--Hoover coding. -/
-def noiseMeasure (κ : Type*) : Measure (NoiseIndex κ → I) :=
+def noiseMeasure (κ ι : Type*) : Measure (NoiseIndex κ ι → I) :=
   Measure.infinitePi fun _ => (volume : Measure I)
 
 /-- The canonical Aldous--Hoover noise law is a probability measure. -/
-instance instIsProbabilityMeasureNoiseMeasure (κ : Type*) : IsProbabilityMeasure (noiseMeasure κ) :=
+instance instIsProbabilityMeasureNoiseMeasure (κ ι : Type*) :
+    IsProbabilityMeasure (noiseMeasure κ ι) :=
   inferInstanceAs (IsProbabilityMeasure
-    (Measure.infinitePi fun _ : NoiseIndex κ => (volume : Measure I)))
+    (Measure.infinitePi fun _ : NoiseIndex κ ι => (volume : Measure I)))
 
 /-- Reindex a realization of the Aldous--Hoover noise. -/
-def noiseReindex {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
-    (rowPerm colPerm : Equiv.Perm ℕ)
-    (u : NoiseIndex κ → I) : NoiseIndex κ → I :=
-  fun q => u (indexEquiv vertexPerm rowPerm colPerm q)
+def noiseReindex {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ) (cellPerm : ι ≃ ι)
+    (u : NoiseIndex κ ι → I) : NoiseIndex κ ι → I :=
+  fun q => u (indexEquiv vertexPerm cellPerm q)
 
 @[simp]
-theorem noiseReindex_apply {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
-    (rowPerm colPerm : Equiv.Perm ℕ)
-    (u : NoiseIndex κ → I) (q : NoiseIndex κ) :
-    noiseReindex vertexPerm rowPerm colPerm u q =
-      u (indexEquiv vertexPerm rowPerm colPerm q) :=
+theorem noiseReindex_apply {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ) (cellPerm : ι ≃ ι)
+    (u : NoiseIndex κ ι → I) (q : NoiseIndex κ ι) :
+    noiseReindex vertexPerm cellPerm u q = u (indexEquiv vertexPerm cellPerm q) :=
   (rfl)
 
 /-- Reindexing the noise is measurable. -/
 @[fun_prop]
-theorem measurable_noiseReindex {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
-    (rowPerm colPerm : Equiv.Perm ℕ) :
-    Measurable (noiseReindex vertexPerm rowPerm colPerm) :=
+theorem measurable_noiseReindex {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+    (cellPerm : ι ≃ ι) :
+    Measurable (noiseReindex vertexPerm cellPerm) :=
   measurable_pi_lambda _ fun q =>
-    measurable_pi_apply (indexEquiv vertexPerm rowPerm colPerm q)
+    measurable_pi_apply (indexEquiv vertexPerm cellPerm q)
 
 /-- The independent uniform noise law is invariant under reindexing its vertex and cell
 coordinates. -/
 @[simp]
 theorem map_noiseReindex_noiseMeasure {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
-    (rowPerm colPerm : Equiv.Perm ℕ) :
-    (noiseMeasure κ).map (noiseReindex vertexPerm rowPerm colPerm) = noiseMeasure κ := by
+    {ι : Type*} (cellPerm : ι ≃ ι) :
+    (noiseMeasure κ ι).map (noiseReindex vertexPerm cellPerm) = noiseMeasure κ ι := by
   -- Expose the two wrappers so the generic infinite-product reindexing theorem sees its expected
   -- coordinate projection literally.
-  change (Measure.infinitePi fun _ : NoiseIndex κ => (volume : Measure I)).map
-      (fun u q => u (indexEquiv vertexPerm rowPerm colPerm q)) =
-    Measure.infinitePi fun _ : NoiseIndex κ => (volume : Measure I)
+  change (Measure.infinitePi fun _ : NoiseIndex κ ι => (volume : Measure I)).map
+      (fun u q => u (indexEquiv vertexPerm cellPerm q)) =
+    Measure.infinitePi fun _ : NoiseIndex κ ι => (volume : Measure I)
   rw [Measure.map_infinitePi_infinitePi_of_inj
-    (indexEquiv vertexPerm rowPerm colPerm).injective]
+    (indexEquiv vertexPerm cellPerm).injective]
 
 section Codings
 
@@ -174,86 +169,93 @@ variable {α : Type*} [MeasurableSpace α]
 
 /-- The separately exchangeable Aldous--Hoover coding. -/
 def separateArray (f : I × I × I × I → α)
-    (p : ℕ × ℕ) (u : NoiseIndex Axis → I) : α :=
-  f (u .global, u (.vertex .row p.1), u (.vertex .column p.2), u (.cell p.1 p.2))
+    (p : ℕ × ℕ) (u : NoiseIndex Axis (ℕ × ℕ) → I) : α :=
+  f (u .global, u (.vertex .row p.1), u (.vertex .column p.2), u (.cell p))
 
 omit [MeasurableSpace α] in
 @[simp]
 theorem separateArray_apply (f : I × I × I × I → α)
-    (p : ℕ × ℕ) (u : NoiseIndex Axis → I) :
+    (p : ℕ × ℕ) (u : NoiseIndex Axis (ℕ × ℕ) → I) :
     separateArray f p u =
-      f (u .global, u (.vertex .row p.1), u (.vertex .column p.2), u (.cell p.1 p.2)) :=
+      f (u .global, u (.vertex .row p.1), u (.vertex .column p.2), u (.cell p)) :=
   (rfl)
 
 /-- A measurable separate Aldous--Hoover coding is measurable as an array-valued random
 variable. -/
 theorem measurable_separateArray (f : I × I × I × I → α) (hf : Measurable f) :
-    Measurable fun u : NoiseIndex Axis → I => fun p => separateArray f p u :=
+    Measurable fun u : NoiseIndex Axis (ℕ × ℕ) → I => fun p => separateArray f p u :=
   measurable_pi_lambda _ fun p => hf.comp
-    ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Axis)).prodMk
+    ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Axis (ℕ × ℕ))).prodMk
       ((measurable_pi_apply (NoiseIndex.vertex Axis.row p.1)).prodMk
         ((measurable_pi_apply (NoiseIndex.vertex Axis.column p.2)).prodMk
-          (measurable_pi_apply (NoiseIndex.cell p.1 p.2)))))
+          (measurable_pi_apply (NoiseIndex.cell p)))))
 
 /-- **Every measurable separate Aldous--Hoover coding is separately exchangeable.** -/
 theorem separatelyExchangeable_separateArray
     (f : I × I × I × I → α) (hf : Measurable f) :
-    SeparatelyExchangeable (noiseMeasure Axis) (separateArray f) := by
+    SeparatelyExchangeable (noiseMeasure Axis (ℕ × ℕ)) (separateArray f) := by
   rw [separatelyExchangeable_iff]
   intro rowPerm colPerm
   let vertexPerm : Axis → Equiv.Perm ℕ
     | .row => rowPerm
     | .column => colPerm
-  have hcode : Measurable fun u : NoiseIndex Axis → I =>
+  let cellPerm : ℕ × ℕ ≃ ℕ × ℕ := rowPerm.prodCongr colPerm
+  have hcode : Measurable fun u : NoiseIndex Axis (ℕ × ℕ) → I =>
       fun p => separateArray f p u := measurable_separateArray f hf
-  have hfun : (fun u : NoiseIndex Axis → I =>
+  have hfun : (fun u : NoiseIndex Axis (ℕ × ℕ) → I =>
       fun p => separateArray f (rowPerm p.1, colPerm p.2) u) =
         (fun u => fun p => separateArray f p u) ∘
-          noiseReindex vertexPerm rowPerm colPerm := by
-    funext u p
-    simp [separateArray_apply, Function.comp_apply, vertexPerm]
+          noiseReindex vertexPerm cellPerm := by
+    funext u ⟨i, j⟩
+    simp [separateArray_apply, Function.comp_apply, vertexPerm, cellPerm]
   rw [hfun, ← Measure.map_map hcode
-      (measurable_noiseReindex vertexPerm rowPerm colPerm),
+      (measurable_noiseReindex vertexPerm cellPerm),
     map_noiseReindex_noiseMeasure]
 
 /-- The jointly exchangeable Aldous--Hoover coding, using one common family of vertex variables
 for the two axes. -/
 def jointArray (f : I × I × I × I → α)
-    (p : ℕ × ℕ) (u : NoiseIndex Unit → I) : α :=
-  f (u .global, u (.vertex () p.1), u (.vertex () p.2), u (.cell p.1 p.2))
+    (p : ℕ × ℕ) (u : NoiseIndex Unit (Sym2 ℕ) → I) : α :=
+  f (u .global, u (.vertex () p.1), u (.vertex () p.2), u (.cell s(p.1, p.2)))
 
 omit [MeasurableSpace α] in
 @[simp]
 theorem jointArray_apply (f : I × I × I × I → α)
-    (p : ℕ × ℕ) (u : NoiseIndex Unit → I) :
+    (p : ℕ × ℕ) (u : NoiseIndex Unit (Sym2 ℕ) → I) :
     jointArray f p u =
-      f (u .global, u (.vertex () p.1), u (.vertex () p.2), u (.cell p.1 p.2)) :=
+      f (u .global, u (.vertex () p.1), u (.vertex () p.2), u (.cell s(p.1, p.2))) :=
   (rfl)
 
 /-- A measurable joint Aldous--Hoover coding is measurable as an array-valued random variable. -/
 theorem measurable_jointArray (f : I × I × I × I → α) (hf : Measurable f) :
-    Measurable fun u : NoiseIndex Unit → I => fun p => jointArray f p u :=
+    Measurable fun u : NoiseIndex Unit (Sym2 ℕ) → I => fun p => jointArray f p u :=
   measurable_pi_lambda _ fun p => hf.comp
-    ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Unit)).prodMk
+    ((measurable_pi_apply (NoiseIndex.global : NoiseIndex Unit (Sym2 ℕ))).prodMk
       ((measurable_pi_apply (NoiseIndex.vertex () p.1)).prodMk
         ((measurable_pi_apply (NoiseIndex.vertex () p.2)).prodMk
-          (measurable_pi_apply (NoiseIndex.cell p.1 p.2)))))
+          (measurable_pi_apply (NoiseIndex.cell s(p.1, p.2))))))
 
 /-- **Every measurable joint Aldous--Hoover coding is jointly exchangeable.** -/
 theorem jointlyExchangeable_jointArray
     (f : I × I × I × I → α) (hf : Measurable f) :
-    JointlyExchangeable (noiseMeasure Unit) (jointArray f) := by
+    JointlyExchangeable (noiseMeasure Unit (Sym2 ℕ)) (jointArray f) := by
   rw [jointlyExchangeable_iff]
   intro perm
   let vertexPerm : Unit → Equiv.Perm ℕ := fun _ => perm
-  have hcode : Measurable fun u : NoiseIndex Unit → I =>
+  let cellPerm : Sym2 ℕ ≃ Sym2 ℕ := {
+    toFun := Sym2.map perm
+    invFun := Sym2.map perm.symm
+    left_inv p := by simp [Sym2.map_map]
+    right_inv p := by simp [Sym2.map_map]
+  }
+  have hcode : Measurable fun u : NoiseIndex Unit (Sym2 ℕ) → I =>
       fun p => jointArray f p u := measurable_jointArray f hf
-  have hfun : (fun u : NoiseIndex Unit → I =>
+  have hfun : (fun u : NoiseIndex Unit (Sym2 ℕ) → I =>
       fun p => jointArray f (perm p.1, perm p.2) u) =
-        (fun u => fun p => jointArray f p u) ∘ noiseReindex vertexPerm perm perm := by
+        (fun u => fun p => jointArray f p u) ∘ noiseReindex vertexPerm cellPerm := by
     funext u p
-    simp [jointArray_apply, Function.comp_apply, vertexPerm]
-  rw [hfun, ← Measure.map_map hcode (measurable_noiseReindex vertexPerm perm perm),
+    simp [jointArray_apply, Function.comp_apply, vertexPerm, cellPerm]
+  rw [hfun, ← Measure.map_map hcode (measurable_noiseReindex vertexPerm cellPerm),
     map_noiseReindex_noiseMeasure]
 
 end Codings

--- a/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
@@ -7,8 +7,8 @@ module
 
 public import TauCeti.Probability.Exchangeability.Arrays.Basic
 public import Mathlib.Data.Sym.Sym2
-import Mathlib.MeasureTheory.Constructions.UnitInterval
-import Mathlib.Probability.Independence.InfinitePi
+public import Mathlib.MeasureTheory.Constructions.UnitInterval
+public import Mathlib.Probability.Independence.InfinitePi
 
 /-!
 # Aldous--Hoover array codings are exchangeable
@@ -66,7 +66,7 @@ public section
 
 noncomputable section
 
-open MeasureTheory unitInterval
+open MeasureTheory ProbabilityTheory unitInterval
 
 namespace TauCeti
 
@@ -130,38 +130,37 @@ instance instIsProbabilityMeasureNoiseMeasure (κ ι : Type*) :
   inferInstanceAs (IsProbabilityMeasure
     (Measure.infinitePi fun _ : NoiseIndex κ ι => (volume : Measure I)))
 
-/-- Reindex a realization of the Aldous--Hoover noise. -/
-def noiseReindex {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ) (cellPerm : ι ≃ ι)
-    (u : NoiseIndex κ ι → I) : NoiseIndex κ ι → I :=
-  fun q => u (indexEquiv vertexPerm cellPerm q)
+/-- Each coordinate of the canonical Aldous--Hoover noise law is uniform on the unit interval. -/
+@[simp]
+theorem map_eval_noiseMeasure {κ ι : Type*} (q : NoiseIndex κ ι) :
+    (noiseMeasure κ ι).map (fun u => u q) = (volume : Measure I) :=
+  Measure.infinitePi_map_eval _ q
+
+/-- The coordinates of the canonical Aldous--Hoover noise law are independent. -/
+theorem iIndepFun_eval_noiseMeasure (κ ι : Type*) :
+    iIndepFun (fun (q : NoiseIndex κ ι) u => u q) (noiseMeasure κ ι) :=
+  iIndepFun_infinitePi (X := fun _ u => u) fun _ => measurable_id
+
+/-- Reindexing a realization of the Aldous--Hoover noise by a permutation of each vertex family
+and of the cell indices, as a measurable equivalence. -/
+abbrev noiseCongr {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ) (cellPerm : ι ≃ ι) :
+    (NoiseIndex κ ι → I) ≃ᵐ (NoiseIndex κ ι → I) :=
+  MeasurableEquiv.piCongrLeft (fun _ => I) (indexEquiv vertexPerm cellPerm).symm
 
 @[simp]
-theorem noiseReindex_apply {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ) (cellPerm : ι ≃ ι)
+theorem noiseCongr_apply {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ) (cellPerm : ι ≃ ι)
     (u : NoiseIndex κ ι → I) (q : NoiseIndex κ ι) :
-    noiseReindex vertexPerm cellPerm u q = u (indexEquiv vertexPerm cellPerm q) :=
-  (rfl)
-
-/-- Reindexing the noise is measurable. -/
-@[fun_prop]
-theorem measurable_noiseReindex {κ ι : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
-    (cellPerm : ι ≃ ι) :
-    Measurable (noiseReindex vertexPerm cellPerm) :=
-  measurable_pi_lambda _ fun q =>
-    measurable_pi_apply (indexEquiv vertexPerm cellPerm q)
+    noiseCongr vertexPerm cellPerm u q = u (indexEquiv vertexPerm cellPerm q) := by
+  simp [noiseCongr, MeasurableEquiv.piCongrLeft, Equiv.piCongrLeft_apply_eq_cast]
 
 /-- The independent uniform noise law is invariant under reindexing its vertex and cell
 coordinates. -/
 @[simp]
-theorem map_noiseReindex_noiseMeasure {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
+theorem map_noiseCongr_noiseMeasure {κ : Type*} (vertexPerm : κ → Equiv.Perm ℕ)
     {ι : Type*} (cellPerm : ι ≃ ι) :
-    (noiseMeasure κ ι).map (noiseReindex vertexPerm cellPerm) = noiseMeasure κ ι := by
-  -- Expose the two wrappers so the generic infinite-product reindexing theorem sees its expected
-  -- coordinate projection literally.
-  change (Measure.infinitePi fun _ : NoiseIndex κ ι => (volume : Measure I)).map
-      (fun u q => u (indexEquiv vertexPerm cellPerm q)) =
-    Measure.infinitePi fun _ : NoiseIndex κ ι => (volume : Measure I)
-  rw [Measure.map_infinitePi_infinitePi_of_inj
-    (indexEquiv vertexPerm cellPerm).injective]
+    (noiseMeasure κ ι).map (noiseCongr vertexPerm cellPerm) = noiseMeasure κ ι :=
+  Measure.infinitePi_map_piCongrLeft (fun _ => (volume : Measure I))
+    (indexEquiv vertexPerm cellPerm).symm
 
 section Codings
 
@@ -205,12 +204,11 @@ theorem separatelyExchangeable_separateArray
   have hfun : (fun u : NoiseIndex Axis (ℕ × ℕ) → I =>
       fun p => separateArray f (rowPerm p.1, colPerm p.2) u) =
         (fun u => fun p => separateArray f p u) ∘
-          noiseReindex vertexPerm cellPerm := by
+          noiseCongr vertexPerm cellPerm := by
     funext u ⟨i, j⟩
     simp [separateArray_apply, Function.comp_apply, vertexPerm, cellPerm]
-  rw [hfun, ← Measure.map_map hcode
-      (measurable_noiseReindex vertexPerm cellPerm),
-    map_noiseReindex_noiseMeasure]
+  rw [hfun, ← Measure.map_map hcode (noiseCongr vertexPerm cellPerm).measurable,
+    map_noiseCongr_noiseMeasure]
 
 /-- The jointly exchangeable Aldous--Hoover coding, using one common family of vertex variables
 for the two axes. -/
@@ -252,11 +250,11 @@ theorem jointlyExchangeable_jointArray
       fun p => jointArray f p u := measurable_jointArray f hf
   have hfun : (fun u : NoiseIndex Unit (Sym2 ℕ) → I =>
       fun p => jointArray f (perm p.1, perm p.2) u) =
-        (fun u => fun p => jointArray f p u) ∘ noiseReindex vertexPerm cellPerm := by
+        (fun u => fun p => jointArray f p u) ∘ noiseCongr vertexPerm cellPerm := by
     funext u p
     simp [jointArray_apply, Function.comp_apply, vertexPerm, cellPerm]
-  rw [hfun, ← Measure.map_map hcode (measurable_noiseReindex vertexPerm cellPerm),
-    map_noiseReindex_noiseMeasure]
+  rw [hfun, ← Measure.map_map hcode (noiseCongr vertexPerm cellPerm).measurable,
+    map_noiseCongr_noiseMeasure]
 
 end Codings
 

--- a/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean
@@ -17,14 +17,14 @@ randomness.  A separately exchangeable array is coded from a global variable, on
 each row, one for each column, and one for each cell:
 
 ```text
-X i j = f(U, Uᵣ i, U꜀ j, Uᵢⱼ).
+X i j = f(U, U_row i, U_col j, U_cell i j).
 ```
 
 For a jointly exchangeable array, the row and column variables are replaced by one family of
 vertex variables:
 
 ```text
-X i j = f(U, Uᵥ i, Uᵥ j, Uᵢⱼ).
+X i j = f(U, U_vert i, U_vert j, U_cell i j).
 ```
 
 This file defines canonical product probability spaces carrying those sources and proves the easy


### PR DESCRIPTION
This PR defines the canonical independent uniform-noise spaces for the separate and joint Aldous–Hoover array codings and proves that every measurable four-noise coding has the corresponding exchangeability. In the separate form, `X i j = f(U, Uᵣ i, U꜀ j, Uᵢⱼ)` is separately exchangeable; in the joint form, `X i j = f(U, Uᵥ i, Uᵥ j, Uᵢⱼ)` is jointly exchangeable.

The exact roadmap target is `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, “exchangeable arrays and the Aldous–Hoover representation.” The designated milestone is the Aldous–Hoover functional representation of separately and jointly exchangeable arrays. This is the most effective current unclaimed step because the row decomposition, inherited mixing-law symmetry, separately exchangeable row coding, and jointly exchangeable block reduction have landed, while the functional target still lacked its necessary converse direction and a canonical four-source noise model.

After this PR, the milestone still needs the hard direction: construct the measurable coding function from an arbitrary separately exchangeable array, and then complete the transfer from the jointly exchangeable block analysis to the joint representation.

`TauCeti/Probability/Exchangeability/Arrays/AldousHoover.lean` is new (266 lines). It defines `AldousHoover.NoiseIndex`, `Axis`, `noiseMeasure`, the two coding maps, and the source-reindexing API. The proof consumes Mathlib's `Measure.map_infinitePi_infinitePi_of_inj` directly; no Mathlib source or external formalization is vendored. The mathematical forms follow Aldous, “Representations for partially exchangeable arrays of random variables” (1981), and Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Chapter 7, both credited in the module documentation. No material is adapted from `cameronfreer/exchangeability`.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"aldous-hoover-coding-exchangeable"}-->

🤖 Prepared with Codex
