### PR TITLE
feat(ModularForms): the Fricke matrix W = (0, -1; N, 0)

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+
+/-!
+# The Fricke matrix
+
+The Fricke matrix `W = !![0, -1; N, 0]`, as an element of `GL (Fin 2) ℚ`. Its determinant is
+`N`, which is nonzero exactly under the standing `[NeZero N]` hypothesis, so `W` is a unit.
+
+This file is only the matrix; the Fricke *operator* on `M_k(Γ₁(N))` — slashing by `W`, with
+the normalizing scalar that makes it an involution — is built on top of it.
+
+## Main definitions
+
+* `TauCeti.frickeGL`: the Fricke matrix as an element of `GL (Fin 2) ℚ`.
+
+## Main results
+
+* `TauCeti.frickeGL_inv_coe`: `W⁻¹ = !![0, 1/N; -1, 0]`.
+* `TauCeti.frickeGL_sq_coe`: `W² = (-N) • 1` as matrices.
+* `TauCeti.frickeGL_det_pos`: the determinant is positive. This is about the single matrix `W`,
+  deliberately not a general statement about `SL`-type elements.
+
+## Relation to the Atkin–Lehner anti-involution
+
+Both this matrix and the conjugating matrix of
+`TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean` are called "Atkin–Lehner" in the
+literature, and they are **different matrices**. That file conjugates by `natDiagGL 2 ![1, N]`,
+the diagonal rescaling repairing the transpose's failure to preserve `Γ₀(N)`; its docstring
+already records that it is *not* `!![0, -1; N, 0]`. This file is the latter.
+
+At `N = 1` the Fricke matrix coincides numerically with the level-one `S = !![0, -1; 1, 0]` of
+`TauCeti/NumberTheory/ModularForms/STransform.lean` and with `TauCeti.SU2.weylMatrix`. Those are
+different objects in different settings — neither is an element of `GL (Fin 2) ℚ` carrying a
+determinant-`N` normalization — so `frickeGL` is not a restatement of either.
+
+Ported from the AINTLIB `LeanModularForms` project
+(`projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Fricke.lean`, Chris Birkbeck,
+Apache-2.0, <https://github.com/CBirkbeck/AINTLIB>), realizing part of Layer 6 of the
+ModularForms roadmap.
+-/
+
+open Matrix
+
+namespace TauCeti
+
+variable {N : ℕ} [NeZero N]
+
+/-- The Fricke matrix `W = !![0, -1; N, 0]` as an element of `GL (Fin 2) ℚ`, of determinant
+`N`. -/
+public noncomputable def frickeGL (N : ℕ) [NeZero N] : GL (Fin 2) ℚ :=
+  Matrix.GeneralLinearGroup.mkOfDetNeZero !![0, -1; (N : ℚ), 0]
+    (by rw [det_fin_two_of]; simpa using NeZero.ne (N : ℚ))
+
+/-- The underlying matrix of `frickeGL N`. -/
+@[simp]
+public theorem frickeGL_coe :
+    (↑(frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ) = !![0, -1; (N : ℚ), 0] := by
+  simp [frickeGL, Matrix.GeneralLinearGroup.mkOfDetNeZero]
+
+/-- The determinant of `frickeGL N` is positive. This is about the single matrix `W`; it is
+deliberately not a general statement about determinants of `SL`-type elements.
+
+The determinant itself is `N`, but that needs no lemma of its own: `frickeGL_coe` is `simp`,
+so `(frickeGL N).det.val = N` and its matrix form are both closed by `simp` alone. -/
+public theorem frickeGL_det_pos : 0 < (frickeGL N).det.val := by
+  have : (frickeGL N).det.val = (N : ℚ) := by simp
+  rw [this]
+  exact_mod_cast NeZero.pos N
+
+/-- `W⁻¹ = !![0, 1/N; -1, 0]`. -/
+public theorem frickeGL_inv_coe :
+    (↑(frickeGL N)⁻¹ : Matrix (Fin 2) (Fin 2) ℚ) = !![0, 1 / (N : ℚ); -1, 0] := by
+  rw [Matrix.coe_units_inv, Matrix.inv_def, frickeGL_coe, Matrix.adjugate_fin_two_of,
+    Ring.inverse_eq_inv]
+  simp [Matrix.det_fin_two_of, NeZero.ne (N : ℚ)]
+
+/-- `W² = (-N) • 1` as matrices. This is the entrywise identity the Fricke operator's
+involution property consumes; it is not itself a statement that `W²` is central in `GL`. -/
+public theorem frickeGL_sq_coe :
+    (↑(frickeGL N * frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ) =
+      (-(N : ℚ)) • (1 : Matrix (Fin 2) (Fin 2) ℚ) := by
+  rw [Units.val_mul, frickeGL_coe, Matrix.mul_fin_two]
+  simp [Matrix.one_fin_two]
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
@@ -10,24 +10,31 @@ public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 /-!
 # The Fricke matrix
 
-The Fricke matrix `W = !![0, -1; N, 0]`, as an element of `GL (Fin 2) ℚ`. Its determinant is
-`N`, which is nonzero exactly under the standing `[NeZero N]` hypothesis, so `W` is a unit.
+The Fricke matrix `W = !![0, -1; N, 0]`, as an element of `GL (Fin 2) K` for a field `K` in
+which `N` is invertible. Its determinant is `N`, which is nonzero exactly under the standing
+`[NeZero (N : K)]` hypothesis, so `W` is a unit.
+
+The base field is a parameter rather than `ℚ`: the two consumers sit over different fields.
+The weight-`k` slash is an action of `GL (Fin 2) ℝ`, while the `GL (Fin 2) ℚ` Hecke-ring stack
+of `TauCeti/NumberTheory/HeckeRing/GL2/Delta0.lean` wants the rational form; both are
+`frickeGL _ N`, with no transport lemmas between them. `NeZero.charZero` supplies
+`NeZero (N : K)` for `ℚ` and `ℝ` automatically.
 
 This file is only the matrix; the Fricke *operator* on `M_k(Γ₁(N))` — slashing by `W`, with
 the normalizing scalar that makes it an involution — is built on top of it.
 
 ## Main definitions
 
-* `TauCeti.frickeGL`: the Fricke matrix as an element of `GL (Fin 2) ℚ`.
+* `TauCeti.frickeGL`: the Fricke matrix as an element of `GL (Fin 2) K`.
 
 ## Main results
 
-* `TauCeti.coe_frickeGL_inv`: `W⁻¹ = !![0, 1/N; -1, 0]`.
+* `TauCeti.coe_frickeGL`: the underlying matrix is `!![0, -1; N, 0]`.
+* `TauCeti.val_det_frickeGL`: the determinant is `N`.
+* `TauCeti.val_det_frickeGL_pos`: over an ordered field, that determinant is positive. This is
+  about the single matrix `W`, deliberately not a general statement about `SL`-type elements.
+* `TauCeti.coe_inv_frickeGL`: `W⁻¹ = !![0, 1/N; -1, 0]`.
 * `TauCeti.coe_frickeGL_sq`: `W² = (-N) • 1` as matrices.
-* `TauCeti.det_coe_frickeGL`, `TauCeti.frickeGL_det`: the determinant is `N`, as the determinant
-  of the underlying matrix and as the `GL` determinant; `TauCeti.frickeGL_det_pos` derives its
-  positivity. These are about the single matrix `W`, deliberately not general statements about
-  `SL`-type elements.
 
 ## Relation to the Atkin–Lehner anti-involution
 
@@ -39,8 +46,8 @@ already records that it is *not* `!![0, -1; N, 0]`. This file is the latter.
 
 At `N = 1` the Fricke matrix coincides numerically with the level-one `S = !![0, -1; 1, 0]` of
 `TauCeti/NumberTheory/ModularForms/STransform.lean` and with `TauCeti.SU2.weylMatrix`. Those are
-different objects in different settings — neither is an element of `GL (Fin 2) ℚ` carrying a
-determinant-`N` normalization — so `frickeGL` is not a restatement of either.
+different objects in different settings — neither carries a determinant-`N` normalization — so
+`frickeGL` is not a restatement of either.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Fricke.lean`, Chris Birkbeck,
@@ -52,54 +59,42 @@ open Matrix
 
 namespace TauCeti
 
-variable {N : ℕ} [NeZero N]
+variable {K : Type*} [Field K] {N : ℕ} [NeZero (N : K)]
 
-/-- The Fricke matrix `W = !![0, -1; N, 0]` as an element of `GL (Fin 2) ℚ`, of determinant
+/-- The Fricke matrix `W = !![0, -1; N, 0]` as an element of `GL (Fin 2) K`, of determinant
 `N`. -/
-public noncomputable def frickeGL (N : ℕ) [NeZero N] : GL (Fin 2) ℚ :=
-  Matrix.GeneralLinearGroup.mkOfDetNeZero !![0, -1; (N : ℚ), 0]
-    (by rw [det_fin_two_of]; simpa using NeZero.ne (N : ℚ))
+public noncomputable def frickeGL (K : Type*) [Field K] (N : ℕ) [NeZero (N : K)] : GL (Fin 2) K :=
+  Matrix.GeneralLinearGroup.mkOfDetNeZero !![0, -1; (N : K), 0]
+    (by rw [det_fin_two_of]; simpa using NeZero.ne (N : K))
 
-/-- The underlying matrix of `frickeGL N`. -/
+/-- The underlying matrix of `frickeGL K N`. -/
 @[simp]
 public theorem coe_frickeGL :
-    (↑(frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ) = !![0, -1; (N : ℚ), 0] := by
-  simp [frickeGL, Matrix.GeneralLinearGroup.mkOfDetNeZero]
+    (↑(frickeGL K N) : Matrix (Fin 2) (Fin 2) K) = !![0, -1; (N : K), 0] := by
+  simp [frickeGL]
 
-/-- The determinant of the underlying matrix of `frickeGL N` is `N`.
-
-Deliberately not `@[simp]`: `coe_frickeGL` and `Matrix.det_fin_two_of` are `simp`, so simp
-already proves this outright and the `simpNF` linter rejects it as a simp lemma. It exists as
-the named `rw` target for the determinant value. -/
-public theorem det_coe_frickeGL : (↑(frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ).det = N := by
-  rw [coe_frickeGL, det_fin_two_of]
+/-- The determinant of `frickeGL K N` is `N`. -/
+public theorem val_det_frickeGL : ((frickeGL K N).det : K) = N := by
+  rw [Matrix.GeneralLinearGroup.val_det_apply, coe_frickeGL, det_fin_two_of]
   ring
 
-/-- The determinant of `frickeGL N`, as an element of `GL (Fin 2) ℚ`, is `N`. This is the shape
-the slash action consumes (`|γ.det.val| ^ (k - 1)`), so the Fricke normalization rewrites by it
-directly.
-
-Deliberately not `@[simp]`: `Matrix.GeneralLinearGroup.val_det_apply` is `simp`, so simp
-already reduces this to `det_coe_frickeGL` and proves it outright; the `simpNF` linter rejects it
-as a simp lemma. -/
-public theorem frickeGL_det : ((frickeGL N).det : ℚ) = N := by
-  rw [Matrix.GeneralLinearGroup.val_det_apply, det_coe_frickeGL]
-
-/-- The determinant of `frickeGL N` is positive. This is about the single matrix `W`; it is
-deliberately not a general statement about determinants of `SL`-type elements. -/
-public theorem frickeGL_det_pos : 0 < ((frickeGL N).det : ℚ) := by
-  rw [frickeGL_det]
+/-- Over an ordered field the determinant of `frickeGL K N` is positive. This is about the
+single matrix `W`; it is deliberately not a general statement about determinants of `SL`-type
+elements. -/
+public theorem val_det_frickeGL_pos [LinearOrder K] [IsStrictOrderedRing K] [NeZero N] :
+    0 < ((frickeGL K N).det : K) := by
+  rw [val_det_frickeGL]
   exact_mod_cast NeZero.pos N
 
 /-- `W⁻¹ = !![0, 1/N; -1, 0]`.
 
 Deliberately not `@[simp]`: `Matrix.coe_units_inv` is itself `simp`, so simp rewrites this
 left-hand side to `(!![0, -1; N, 0])⁻¹` and it is not in simp-normal form. -/
-public theorem coe_frickeGL_inv :
-    (↑(frickeGL N)⁻¹ : Matrix (Fin 2) (Fin 2) ℚ) = !![0, 1 / (N : ℚ); -1, 0] := by
+public theorem coe_inv_frickeGL :
+    (↑(frickeGL K N)⁻¹ : Matrix (Fin 2) (Fin 2) K) = !![0, 1 / (N : K); -1, 0] := by
   rw [Matrix.coe_units_inv, Matrix.inv_def, coe_frickeGL, Matrix.adjugate_fin_two_of,
     Ring.inverse_eq_inv]
-  simp [Matrix.det_fin_two_of, NeZero.ne (N : ℚ)]
+  simp [Matrix.det_fin_two_of, NeZero.ne (N : K)]
 
 /-- `W² = (-N) • 1` as matrices. This is the entrywise identity the Fricke operator's
 involution property consumes; it is not itself a statement that `W²` is central in `GL`.
@@ -109,9 +104,9 @@ side all the way to the entry-level normal form `!![-N, 0; 0, -N]`. The lemma ex
 `(-N) • 1` packaging, which is not that normal form, so tagging it would put a non-normal
 left-hand side in the simp set. -/
 public theorem coe_frickeGL_sq :
-    (↑(frickeGL N * frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ) =
-      (-(N : ℚ)) • (1 : Matrix (Fin 2) (Fin 2) ℚ) := by
-  rw [Units.val_mul, coe_frickeGL, Matrix.mul_fin_two]
+    (↑(frickeGL K N ^ 2) : Matrix (Fin 2) (Fin 2) K) =
+      (-(N : K)) • (1 : Matrix (Fin 2) (Fin 2) K) := by
+  rw [sq, Units.val_mul, coe_frickeGL, Matrix.mul_fin_two]
   simp [Matrix.one_fin_two]
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
@@ -24,8 +24,10 @@ the normalizing scalar that makes it an involution — is built on top of it.
 
 * `TauCeti.coe_frickeGL_inv`: `W⁻¹ = !![0, 1/N; -1, 0]`.
 * `TauCeti.coe_frickeGL_sq`: `W² = (-N) • 1` as matrices.
-* `TauCeti.frickeGL_det_pos`: the determinant is positive. This is about the single matrix `W`,
-  deliberately not a general statement about `SL`-type elements.
+* `TauCeti.det_coe_frickeGL`, `TauCeti.frickeGL_det`: the determinant is `N`, as the determinant
+  of the underlying matrix and as the `GL` determinant; `TauCeti.frickeGL_det_pos` derives its
+  positivity. These are about the single matrix `W`, deliberately not general statements about
+  `SL`-type elements.
 
 ## Relation to the Atkin–Lehner anti-involution
 
@@ -64,13 +66,29 @@ public theorem coe_frickeGL :
     (↑(frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ) = !![0, -1; (N : ℚ), 0] := by
   simp [frickeGL, Matrix.GeneralLinearGroup.mkOfDetNeZero]
 
--- No separate determinant lemma is provided: `coe_frickeGL` already exposes the underlying
--- matrix, from which the value `N` and its matrix form both follow.
+/-- The determinant of the underlying matrix of `frickeGL N` is `N`.
+
+Deliberately not `@[simp]`: `coe_frickeGL` and `Matrix.det_fin_two_of` are `simp`, so simp
+already proves this outright and the `simpNF` linter rejects it as a simp lemma. It exists as
+the named `rw` target for the determinant value. -/
+public theorem det_coe_frickeGL : (↑(frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ).det = N := by
+  rw [coe_frickeGL, det_fin_two_of]
+  ring
+
+/-- The determinant of `frickeGL N`, as an element of `GL (Fin 2) ℚ`, is `N`. This is the shape
+the slash action consumes (`|γ.det.val| ^ (k - 1)`), so the Fricke normalization rewrites by it
+directly.
+
+Deliberately not `@[simp]`: `Matrix.GeneralLinearGroup.val_det_apply` is `simp`, so simp
+already reduces this to `det_coe_frickeGL` and proves it outright; the `simpNF` linter rejects it
+as a simp lemma. -/
+public theorem frickeGL_det : ((frickeGL N).det : ℚ) = N := by
+  rw [Matrix.GeneralLinearGroup.val_det_apply, det_coe_frickeGL]
+
 /-- The determinant of `frickeGL N` is positive. This is about the single matrix `W`; it is
 deliberately not a general statement about determinants of `SL`-type elements. -/
-public theorem frickeGL_det_pos : 0 < (frickeGL N).det.val := by
-  have : (frickeGL N).det.val = (N : ℚ) := by simp
-  rw [this]
+public theorem frickeGL_det_pos : 0 < ((frickeGL N).det : ℚ) := by
+  rw [frickeGL_det]
   exact_mod_cast NeZero.pos N
 
 /-- `W⁻¹ = !![0, 1/N; -1, 0]`.

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
@@ -22,8 +22,8 @@ the normalizing scalar that makes it an involution — is built on top of it.
 
 ## Main results
 
-* `TauCeti.frickeGL_inv_coe`: `W⁻¹ = !![0, 1/N; -1, 0]`.
-* `TauCeti.frickeGL_sq_coe`: `W² = (-N) • 1` as matrices.
+* `TauCeti.coe_frickeGL_inv`: `W⁻¹ = !![0, 1/N; -1, 0]`.
+* `TauCeti.coe_frickeGL_sq`: `W² = (-N) • 1` as matrices.
 * `TauCeti.frickeGL_det_pos`: the determinant is positive. This is about the single matrix `W`,
   deliberately not a general statement about `SL`-type elements.
 
@@ -60,33 +60,41 @@ public noncomputable def frickeGL (N : ℕ) [NeZero N] : GL (Fin 2) ℚ :=
 
 /-- The underlying matrix of `frickeGL N`. -/
 @[simp]
-public theorem frickeGL_coe :
+public theorem coe_frickeGL :
     (↑(frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ) = !![0, -1; (N : ℚ), 0] := by
   simp [frickeGL, Matrix.GeneralLinearGroup.mkOfDetNeZero]
 
 /-- The determinant of `frickeGL N` is positive. This is about the single matrix `W`; it is
 deliberately not a general statement about determinants of `SL`-type elements.
 
-The determinant itself is `N`, but that needs no lemma of its own: `frickeGL_coe` is `simp`,
+The determinant itself is `N`, but that needs no lemma of its own: `coe_frickeGL` is `simp`,
 so `(frickeGL N).det.val = N` and its matrix form are both closed by `simp` alone. -/
 public theorem frickeGL_det_pos : 0 < (frickeGL N).det.val := by
   have : (frickeGL N).det.val = (N : ℚ) := by simp
   rw [this]
   exact_mod_cast NeZero.pos N
 
-/-- `W⁻¹ = !![0, 1/N; -1, 0]`. -/
-public theorem frickeGL_inv_coe :
+/-- `W⁻¹ = !![0, 1/N; -1, 0]`.
+
+Deliberately not `@[simp]`: `Matrix.coe_units_inv` is itself `simp`, so simp rewrites this
+left-hand side to `(!![0, -1; N, 0])⁻¹` and it is not in simp-normal form. -/
+public theorem coe_frickeGL_inv :
     (↑(frickeGL N)⁻¹ : Matrix (Fin 2) (Fin 2) ℚ) = !![0, 1 / (N : ℚ); -1, 0] := by
-  rw [Matrix.coe_units_inv, Matrix.inv_def, frickeGL_coe, Matrix.adjugate_fin_two_of,
+  rw [Matrix.coe_units_inv, Matrix.inv_def, coe_frickeGL, Matrix.adjugate_fin_two_of,
     Ring.inverse_eq_inv]
   simp [Matrix.det_fin_two_of, NeZero.ne (N : ℚ)]
 
 /-- `W² = (-N) • 1` as matrices. This is the entrywise identity the Fricke operator's
-involution property consumes; it is not itself a statement that `W²` is central in `GL`. -/
-public theorem frickeGL_sq_coe :
+involution property consumes; it is not itself a statement that `W²` is central in `GL`.
+
+Deliberately not `@[simp]`: `Units.val_mul` is `simp`, so simp already carries this left-hand
+side all the way to the entry-level normal form `!![-N, 0; 0, -N]`. The lemma exists for the
+`(-N) • 1` packaging, which is not that normal form, so tagging it would put a non-normal
+left-hand side in the simp set. -/
+public theorem coe_frickeGL_sq :
     (↑(frickeGL N * frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ) =
       (-(N : ℚ)) • (1 : Matrix (Fin 2) (Fin 2) ℚ) := by
-  rw [Units.val_mul, frickeGL_coe, Matrix.mul_fin_two]
+  rw [Units.val_mul, coe_frickeGL, Matrix.mul_fin_two]
   simp [Matrix.one_fin_two]
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
@@ -17,8 +17,9 @@ which `N` is invertible. Its determinant is `N`, which is nonzero exactly under 
 The base field is a parameter rather than `ℚ`: the two consumers sit over different fields.
 The weight-`k` slash is an action of `GL (Fin 2) ℝ`, while the `GL (Fin 2) ℚ` Hecke-ring stack
 of `TauCeti/NumberTheory/HeckeRing/GL2/Delta0.lean` wants the rational form; both are
-`frickeGL _ N`, with no transport lemmas between them. `NeZero.charZero` supplies
-`NeZero (N : K)` for `ℚ` and `ℝ` automatically.
+`frickeGL _ N`, with no transport lemmas between them. Over `ℚ` and `ℝ` a caller holding
+`[NeZero N]` on the natural number gets the standing `[NeZero (N : K)]` by instance search,
+through `NeZero.charZero`; the instance runs only in that direction.
 
 This file is only the matrix; the Fricke *operator* on `M_k(Γ₁(N))` — slashing by `W`, with
 the normalizing scalar that makes it an involution — is built on top of it.
@@ -31,9 +32,9 @@ the normalizing scalar that makes it an involution — is built on top of it.
 
 * `TauCeti.coe_frickeGL`: the underlying matrix is `!![0, -1; N, 0]`.
 * `TauCeti.val_det_frickeGL`: the determinant is `N`.
-* `TauCeti.val_det_frickeGL_pos`: over an ordered field, that determinant is positive. This is
+* `TauCeti.val_det_frickeGL_pos`: over an ordered ring, that determinant is positive. This is
   about the single matrix `W`, deliberately not a general statement about `SL`-type elements.
-* `TauCeti.coe_inv_frickeGL`: `W⁻¹ = !![0, 1/N; -1, 0]`.
+* `TauCeti.coe_inv_frickeGL`: `W⁻¹ = !![0, N⁻¹; -1, 0]`.
 * `TauCeti.coe_frickeGL_sq`: `W² = (-N) • 1` as matrices.
 
 ## Relation to the Atkin–Lehner anti-involution
@@ -78,20 +79,20 @@ public theorem val_det_frickeGL : ((frickeGL K N).det : K) = N := by
   rw [Matrix.GeneralLinearGroup.val_det_apply, coe_frickeGL, det_fin_two_of]
   ring
 
-/-- Over an ordered field the determinant of `frickeGL K N` is positive. This is about the
+/-- Over an ordered ring the determinant of `frickeGL K N` is positive. This is about the
 single matrix `W`; it is deliberately not a general statement about determinants of `SL`-type
 elements. -/
-public theorem val_det_frickeGL_pos [LinearOrder K] [IsStrictOrderedRing K] [NeZero N] :
+public theorem val_det_frickeGL_pos [PartialOrder K] [IsOrderedRing K] :
     0 < ((frickeGL K N).det : K) := by
   rw [val_det_frickeGL]
-  exact_mod_cast NeZero.pos N
+  exact (Nat.cast_nonneg N).lt_of_ne' (NeZero.ne (N : K))
 
-/-- `W⁻¹ = !![0, 1/N; -1, 0]`.
+/-- `W⁻¹ = !![0, N⁻¹; -1, 0]`.
 
 Deliberately not `@[simp]`: `Matrix.coe_units_inv` is itself `simp`, so simp rewrites this
 left-hand side to `(!![0, -1; N, 0])⁻¹` and it is not in simp-normal form. -/
 public theorem coe_inv_frickeGL :
-    (↑(frickeGL K N)⁻¹ : Matrix (Fin 2) (Fin 2) K) = !![0, 1 / (N : K); -1, 0] := by
+    (↑(frickeGL K N)⁻¹ : Matrix (Fin 2) (Fin 2) K) = !![0, (N : K)⁻¹; -1, 0] := by
   rw [Matrix.coe_units_inv, Matrix.inv_def, coe_frickeGL, Matrix.adjugate_fin_two_of,
     Ring.inverse_eq_inv]
   simp [Matrix.det_fin_two_of, NeZero.ne (N : K)]
@@ -99,10 +100,9 @@ public theorem coe_inv_frickeGL :
 /-- `W² = (-N) • 1` as matrices. This is the entrywise identity the Fricke operator's
 involution property consumes; it is not itself a statement that `W²` is central in `GL`.
 
-Deliberately not `@[simp]`: `Units.val_mul` is `simp`, so simp already carries this left-hand
-side all the way to the entry-level normal form `!![-N, 0; 0, -N]`. The lemma exists for the
-`(-N) • 1` packaging, which is not that normal form, so tagging it would put a non-normal
-left-hand side in the simp set. -/
+Deliberately not `@[simp]`: the left-hand side `↑(W ^ 2)` is not in simp-normal form, since
+`Units.val_pow_eq_pow_val` and the in-file simp lemma `coe_frickeGL` already rewrite its head to
+`(!![0, -1; N, 0]) ^ 2`. Tagging it would put a non-normal left-hand side in the simp set. -/
 public theorem coe_frickeGL_sq :
     (↑(frickeGL K N ^ 2) : Matrix (Fin 2) (Fin 2) K) =
       (-(N : K)) • (1 : Matrix (Fin 2) (Fin 2) K) := by

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean
@@ -64,11 +64,10 @@ public theorem coe_frickeGL :
     (↑(frickeGL N) : Matrix (Fin 2) (Fin 2) ℚ) = !![0, -1; (N : ℚ), 0] := by
   simp [frickeGL, Matrix.GeneralLinearGroup.mkOfDetNeZero]
 
+-- No separate determinant lemma is provided: `coe_frickeGL` already exposes the underlying
+-- matrix, from which the value `N` and its matrix form both follow.
 /-- The determinant of `frickeGL N` is positive. This is about the single matrix `W`; it is
-deliberately not a general statement about determinants of `SL`-type elements.
-
-The determinant itself is `N`, but that needs no lemma of its own: `coe_frickeGL` is `simp`,
-so `(frickeGL N).det.val = N` and its matrix form are both closed by `simp` alone. -/
+deliberately not a general statement about determinants of `SL`-type elements. -/
 public theorem frickeGL_det_pos : 0 < (frickeGL N).det.val := by
   have : (frickeGL N).det.val = (N : ℚ) := by simp
   rw [this]


### PR DESCRIPTION
The Fricke matrix `W = !![0, -1; N, 0]` as an element of `GL (Fin 2) K`, for any field `K` in
which `N` is invertible, with its determinant `N`, that determinant's positivity, its inverse,
and `W² = (-N) • 1`.

The base field is a parameter rather than `ℚ` because the two consumers sit over different
fields: the weight-`k` slash is an action of `GL (Fin 2) ℝ`, while the `GL (Fin 2) ℚ` Hecke-ring
stack of `HeckeRing/GL2/Delta0.lean` wants the rational form.

This is the matrix layer only. The Fricke *operator* on `M_k(Γ₁(N))` — slashing by `W` with the
normalizing scalar that makes it an involution — sits on top of it and follows separately; that
operator is the consumer of `coe_frickeGL_sq`.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"layer6-fricke-migration"}-->

Layer 6 of the ModularForms roadmap names the Fricke side as AINTLIB material to migrate:
`frickeOperator`/`frickeOperatorCusp`, the normalizing `frickeScalar`, and the character-space
transport `frickeCharRestrict`/`frickeCharEquiv`. The general `W_Q` family for exact divisors
`Q ‖ N` and the sign theory on newforms are flagged **new** there and are not touched here.

Provenance: github.com/CBirkbeck/AINTLIB @ `340875adfb298c189bc2c86e514981c264d7bbbd`,
Apache-2.0, `projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Fricke.lean`
(`frickeGL`, `frickeGL_coe`, `frickeGL_det`, `frickeGL_det_val`, `frickeGL_det_pos`,
`frickeGL_inv_coe`, `frickeGL_sq_coe`). Those are the source's names. The full landing map, after
the naming, api-design, reuse and generality reviews:

| AINTLIB | here |
| --- | --- |
| `frickeGL` | `frickeGL` (over a field parameter `K`) |
| `frickeGL_coe` | `coe_frickeGL` |
| `frickeGL_det`, `frickeGL_det_val` | `val_det_frickeGL` (one lemma, not two) |
| `frickeGL_det_pos` | `val_det_frickeGL_pos` |
| `frickeGL_inv_coe` | `coe_inv_frickeGL` |
| `frickeGL_sq_coe` | `coe_frickeGL_sq` |

Three proofs are not verbatim against this Mathlib. `coe_frickeGL` is no longer `rfl` — the
`mkOfDetNeZero` coercion is not definitional here. The inverse and the square go through
`Matrix.adjugate_fin_two_of` and `Matrix.mul_fin_two` rather than the source's entrywise `Fin`
case bashes.

The source states the determinant twice, at the matrix and `GL` coercion levels. Both were at
first dropped as closed by `simp` alone; the api-design review asked for the determinant value as
named API (the slash action consumes `|γ.det.val| ^ (k - 1)`), and the reuse review then objected
to carrying it at two coercion levels, so exactly one lemma lands: `val_det_frickeGL`, at the
`GL`-determinant level, matching the adjacent slash-consumed `TauCeti.scaleGL`
(`val_det_scaleGL`, `val_det_scaleGL_pos` in `ModularForms/Degeneracy.lean`), which likewise
carries no matrix-level determinant lemma. `val_det_frickeGL_pos` is derived from it.

Unlike the source's `@[simp]` on `frickeGL_det_val`, it is not a simp lemma here: simp already
proves it through `Matrix.GeneralLinearGroup.val_det_apply`, the in-file `coe_frickeGL` and
`Matrix.det_fin_two_of`, so tagging it is a `simpNF` violation under CI's environment-linter set
(`scripts/lint-env.sh`, `#lint only … in TauCeti`). `coe_inv_frickeGL` and `coe_frickeGL_sq` are
untagged for the same reason — a `simp` lemma already rewrites each left-hand side, so neither
stated form is simp-normal; both docstrings record which lemma does it.

The source's `lunipRep` and the `U_p` conjugation identity are deferred: they depend on
`GL_adjugate` and `T_p_upper`, which are `0 declared` in TauCeti.

### Two disambiguations, in the module docstring

Both are things a reader would otherwise reasonably take for duplication.

`HeckeRing/GL2/Gamma0/AtkinLehner.lean` conjugates by `natDiagGL 2 ![1, N]` — a *different*
matrix that the literature also calls Atkin–Lehner. That file's own docstring already records
that its `w` is **not** `!![0, -1; N, 0]`; this file is the latter, and says so.

At `N = 1` the Fricke matrix coincides numerically with the level-one `S` of
`ModularForms/STransform.lean` and with `SU2.weylMatrix`. Different objects in different
settings — neither carries the determinant-`N` normalization.

### Absence, at `origin/main` `b1e65172c`

Queried under the source's names (this is the sweep as run, before the rename):
`frickeGL`, `frickeGL_inv_coe`, `frickeGL_sq_coe`, `frickeOperator`, `frickeScalar`:
**0 textual / 0 declared**, with `atkinLehnerAntiInvolution` (1/1) fired as a positive control
through the identical query form. No Fricke module exists anywhere in the tree. A shape-key
sweep on the literal `!![0, -1;` returns 5 files; all four non-Atkin–Lehner hits are cleared
above.
