### PR TITLE
refactor(Nilpotent): reindex the binomial convolution with Finset.sum_fiberwise_eq_sum_filter

### DIFF
--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -328,44 +328,8 @@ theorem baseChangeExp_tmul_of_pow_eq_zero (x : A) (M : S)
       ∑ n ∈ range k, (t ^ n * r) ⊗ₜ[ℤ] integralDividedPower x M n (hM n) v := by
   simp [baseChangeExp_of_pow_eq_zero x M hM hk, smul_tmul']
 
-/-- Summing a function of a pair over the antidiagonals of `0, …, k - 1` is summing it over the
-pairs in `range k ×ˢ range k` whose entries add to less than `k`. -/
-private theorem sum_range_sum_antidiagonal_eq_sum_filter_lt {β : Type*} [AddCommMonoid β]
-    (k : ℕ) (f : ℕ × ℕ → β) :
-    ∑ n ∈ range k, ∑ ij ∈ antidiagonal n, f ij =
-      ∑ ij ∈ range k ×ˢ range k with ij.1 + ij.2 < k, f ij := by
-  rw [sum_sigma']
-  symm
-  -- The pair `(i, j)` is the point `(i, j)` of the antidiagonal at `i + j`, and both entries of a
-  -- pair summing to less than `k` are themselves less than `k`.
-  apply sum_bij (fun (ij : ℕ × ℕ) _ =>
-    (⟨ij.1 + ij.2, (ij.1, ij.2)⟩ : Sigma fun _ => ℕ × ℕ))
-  · intro ij hij
-    rw [mem_filter] at hij
-    exact mem_sigma.2 ⟨mem_range.2 hij.2, mem_antidiagonal.2 rfl⟩
-  · intro a _ b _ hab
-    have hsnd : (a.1, a.2) = (b.1, b.2) :=
-      congrArg (fun z : Sigma fun _ => ℕ × ℕ => z.2) hab
-    exact Prod.ext (congrArg Prod.fst hsnd) (congrArg Prod.snd hsnd)
-  · rintro ⟨n, ij⟩ hij
-    rw [mem_sigma] at hij
-    have hn : n < k := mem_range.1 hij.1
-    have hij_sum : ij.1 + ij.2 = n := mem_antidiagonal.1 hij.2
-    exact ⟨ij, by
-      rw [mem_filter, mem_product]
-      exact ⟨⟨mem_range.2 (Nat.lt_of_le_of_lt (Nat.le_add_right _ _) (hij_sum ▸ hn)),
-        mem_range.2 (Nat.lt_of_le_of_lt (Nat.le_add_left _ _) (hij_sum ▸ hn))⟩,
-        hij_sum ▸ hn⟩, by
-      apply Sigma.ext hij_sum
-      rfl⟩
-  · intro ij _
-    rfl
-
 omit [Algebra ℤ R] in
-/-- Binomial convolution identity for truncated divided-power series.
-
-Adapted from Mathlib's `IsNilpotent.exp_add_of_commute` in
-`Mathlib/RingTheory/Nilpotent/Exp.lean` (Janos Wolosz). -/
+/-- Binomial convolution identity for truncated divided-power series. -/
 private theorem sum_pow_smul_mul_sum_pow_smul
     {B : Type*} [Ring B] [Algebra R B] (D : ℕ → B) (k : ℕ)
     (hzero : ∀ n, k ≤ n → D n = 0)
@@ -402,12 +366,19 @@ private theorem sum_pow_smul_mul_sum_pow_smul
       subst hij
       simp only [nsmul_eq_mul]
       rw [mul_comm (Nat.choose (ij.1 + ij.2) ij.1 : R), mul_assoc]
-    -- Step 4: the antidiagonals of `0, …, k - 1` reindex the low-degree part of the product range.
+    -- Step 4: the antidiagonals of `0, …, k - 1` are the fibres of `ij ↦ ij.1 + ij.2` over
+    -- `range k`, so they reindex the low-degree part of the product range.
     _ = ∑ ij ∈ range k ×ˢ range k with ¬k ≤ ij.1 + ij.2,
         (t ^ ij.1 * u ^ ij.2 * Nat.choose (ij.1 + ij.2) ij.1) •
           D (ij.1 + ij.2) := by
-      simp only [not_le]
-      exact sum_range_sum_antidiagonal_eq_sum_filter_lt k _
+      simp only [not_le, ← mem_range]
+      rw [← sum_fiberwise_eq_sum_filter (range k ×ˢ range k) (range k)
+        (fun ij : ℕ × ℕ => ij.1 + ij.2) _]
+      refine sum_congr rfl fun n hn => ?_
+      refine sum_congr ?_ fun ij _ => rfl
+      ext ij
+      simp only [mem_filter, mem_product, mem_range, mem_antidiagonal] at hn ⊢
+      omega
 
 /-- The integral divided-power exponential satisfies the additive one-parameter group law over
 every commutative base ring. -/

--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -330,7 +330,8 @@ theorem baseChangeExp_tmul_of_pow_eq_zero (x : A) (M : S)
 
 /-- Binomial convolution identity for truncated divided-power series. -/
 private theorem sum_pow_smul_mul_sum_pow_smul {R : Type*} [CommSemiring R]
-    {B : Type*} [Semiring B] [Algebra R B] (D : ℕ → B) (k : ℕ)
+    {B : Type*} [NonUnitalNonAssocSemiring B] [Module R B] [SMulCommClass R B B]
+    [IsScalarTower R B B] (D : ℕ → B) (k : ℕ)
     (hzero : ∀ n, k ≤ n → D n = 0)
     (hmul : ∀ m n, D m * D n = Nat.choose (m + n) m • D (m + n))
     (t u : R) :

--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -328,10 +328,9 @@ theorem baseChangeExp_tmul_of_pow_eq_zero (x : A) (M : S)
       ∑ n ∈ range k, (t ^ n * r) ⊗ₜ[ℤ] integralDividedPower x M n (hM n) v := by
   simp [baseChangeExp_of_pow_eq_zero x M hM hk, smul_tmul']
 
-omit [Algebra ℤ R] in
 /-- Binomial convolution identity for truncated divided-power series. -/
-private theorem sum_pow_smul_mul_sum_pow_smul
-    {B : Type*} [Ring B] [Algebra R B] (D : ℕ → B) (k : ℕ)
+private theorem sum_pow_smul_mul_sum_pow_smul {R : Type*} [CommSemiring R]
+    {B : Type*} [Semiring B] [Algebra R B] (D : ℕ → B) (k : ℕ)
     (hzero : ∀ n, k ≤ n → D n = 0)
     (hmul : ∀ m n, D m * D n = Nat.choose (m + n) m • D (m + n))
     (t u : R) :

--- a/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
+++ b/TauCeti/RingTheory/Nilpotent/BaseChangeAction.lean
@@ -328,6 +328,39 @@ theorem baseChangeExp_tmul_of_pow_eq_zero (x : A) (M : S)
       ∑ n ∈ range k, (t ^ n * r) ⊗ₜ[ℤ] integralDividedPower x M n (hM n) v := by
   simp [baseChangeExp_of_pow_eq_zero x M hM hk, smul_tmul']
 
+/-- Summing a function of a pair over the antidiagonals of `0, …, k - 1` is summing it over the
+pairs in `range k ×ˢ range k` whose entries add to less than `k`. -/
+private theorem sum_range_sum_antidiagonal_eq_sum_filter_lt {β : Type*} [AddCommMonoid β]
+    (k : ℕ) (f : ℕ × ℕ → β) :
+    ∑ n ∈ range k, ∑ ij ∈ antidiagonal n, f ij =
+      ∑ ij ∈ range k ×ˢ range k with ij.1 + ij.2 < k, f ij := by
+  rw [sum_sigma']
+  symm
+  -- The pair `(i, j)` is the point `(i, j)` of the antidiagonal at `i + j`, and both entries of a
+  -- pair summing to less than `k` are themselves less than `k`.
+  apply sum_bij (fun (ij : ℕ × ℕ) _ =>
+    (⟨ij.1 + ij.2, (ij.1, ij.2)⟩ : Sigma fun _ => ℕ × ℕ))
+  · intro ij hij
+    rw [mem_filter] at hij
+    exact mem_sigma.2 ⟨mem_range.2 hij.2, mem_antidiagonal.2 rfl⟩
+  · intro a _ b _ hab
+    have hsnd : (a.1, a.2) = (b.1, b.2) :=
+      congrArg (fun z : Sigma fun _ => ℕ × ℕ => z.2) hab
+    exact Prod.ext (congrArg Prod.fst hsnd) (congrArg Prod.snd hsnd)
+  · rintro ⟨n, ij⟩ hij
+    rw [mem_sigma] at hij
+    have hn : n < k := mem_range.1 hij.1
+    have hij_sum : ij.1 + ij.2 = n := mem_antidiagonal.1 hij.2
+    exact ⟨ij, by
+      rw [mem_filter, mem_product]
+      exact ⟨⟨mem_range.2 (Nat.lt_of_le_of_lt (Nat.le_add_right _ _) (hij_sum ▸ hn)),
+        mem_range.2 (Nat.lt_of_le_of_lt (Nat.le_add_left _ _) (hij_sum ▸ hn))⟩,
+        hij_sum ▸ hn⟩, by
+      apply Sigma.ext hij_sum
+      rfl⟩
+  · intro ij _
+    rfl
+
 omit [Algebra ℤ R] in
 /-- Binomial convolution identity for truncated divided-power series.
 
@@ -357,48 +390,24 @@ private theorem sum_pow_smul_mul_sum_pow_smul
   rw [hlarge, zero_add] at hsplit
   rw [← hsplit]
   symm
-  -- Step 3: Expand (t + u)^n by the binomial theorem and reindex via antidiagonals.
+  -- Step 3: Expand (t + u)^n by the binomial theorem, in a form depending only on the pair.
   calc
     ∑ n ∈ range k, (t + u) ^ n • D n =
-        ∑ n ∈ range k, (∑ ij ∈ antidiagonal n,
-          t ^ ij.1 * u ^ ij.2 * Nat.choose n ij.1) • D n := by
+        ∑ n ∈ range k, ∑ ij ∈ antidiagonal n,
+          (t ^ ij.1 * u ^ ij.2 * Nat.choose (ij.1 + ij.2) ij.1) • D (ij.1 + ij.2) := by
       refine sum_congr rfl fun n _ => ?_
-      rw [(Commute.all t u).add_pow']
-      simp only [sum_smul]
-      apply sum_congr rfl
-      intro ij hij
+      rw [(Commute.all t u).add_pow', sum_smul]
+      refine sum_congr rfl fun ij hij => ?_
+      rw [mem_antidiagonal] at hij
+      subst hij
       simp only [nsmul_eq_mul]
-      rw [mul_comm (Nat.choose n ij.1 : R), mul_assoc]
+      rw [mul_comm (Nat.choose (ij.1 + ij.2) ij.1 : R), mul_assoc]
+    -- Step 4: the antidiagonals of `0, …, k - 1` reindex the low-degree part of the product range.
     _ = ∑ ij ∈ range k ×ˢ range k with ¬k ≤ ij.1 + ij.2,
         (t ^ ij.1 * u ^ ij.2 * Nat.choose (ij.1 + ij.2) ij.1) •
           D (ij.1 + ij.2) := by
-      simp_rw [sum_smul]
-      rw [sum_sigma']
-      symm
-      -- Step 4: Bijection between the disjoint antidiagonals and the filtered product range.
-      apply sum_bij (fun (ij : ℕ × ℕ) _ =>
-        (⟨ij.1 + ij.2, (ij.1, ij.2)⟩ : Sigma fun _ => ℕ × ℕ))
-      · intro ij hij
-        rw [mem_filter] at hij
-        exact mem_sigma.2 ⟨mem_range.2 (Nat.lt_of_not_ge hij.2),
-          mem_antidiagonal.2 rfl⟩
-      · intro a ha b hb hab
-        have hsnd : (a.1, a.2) = (b.1, b.2) :=
-          congrArg (fun z : Sigma fun _ => ℕ × ℕ => z.2) hab
-        exact Prod.ext (congrArg Prod.fst hsnd) (congrArg Prod.snd hsnd)
-      · rintro ⟨n, ij⟩ hij
-        rw [mem_sigma] at hij
-        have hn : n < k := mem_range.1 hij.1
-        have hij_sum : ij.1 + ij.2 = n := mem_antidiagonal.1 hij.2
-        exact ⟨ij, by
-          rw [mem_filter, mem_product]
-          exact ⟨⟨mem_range.2 (Nat.lt_of_le_of_lt (Nat.le_add_right _ _) (hij_sum ▸ hn)),
-            mem_range.2 (Nat.lt_of_le_of_lt (Nat.le_add_left _ _) (hij_sum ▸ hn))⟩,
-            not_le.2 (hij_sum ▸ hn)⟩, by
-          apply Sigma.ext hij_sum
-          rfl⟩
-      · intro ij _
-        rfl
+      simp only [not_le]
+      exact sum_range_sum_antidiagonal_eq_sum_filter_lt k _
 
 /-- The integral divided-power exponential satisfies the additive one-parameter group law over
 every commutative base ring. -/


### PR DESCRIPTION
`sum_pow_smul_mul_sum_pow_smul` is the convolution identity behind the divided-power exponential's
one-parameter group law. Its proof was 59 lines, of which thirty were a hand-rolled
`Finset.sum_bij` between the antidiagonals of `0, …, k - 1` and the pairs of `range k ×ˢ range k`
summing to less than `k`.

That reindexing is an instance of a lemma Mathlib already has:

```lean
Finset.sum_fiberwise_eq_sum_filter (s : Finset ι) (t : Finset κ) (g : ι → κ) (f : ι → M) :
    ∑ j ∈ t, ∑ i ∈ s with g i = j, f i = ∑ i ∈ s with g i ∈ t, f i
```

with `s := range k ×ˢ range k`, `t := range k`, `g := fun ij => ij.1 + ij.2`. The fibre of `g` over
`n < k` is exactly `antidiagonal n`, which is one `ext` and an `omega`; the `sum_bij` and its four
obligations are gone. The unprimed member of the family is the right one — the primed variant takes
a summand depending only on `ij.1 + ij.2`, and `t ^ ij.1 * u ^ ij.2 * (ij.1 + ij.2).choose ij.1`
varies within a fibre.

To let the lemma apply, the binomial step now produces a summand depending only on the pair: on
`antidiagonal n` we have `ij.1 + ij.2 = n`, so `subst` eliminates the outer index inside the inner
sum.

| | proof body | file |
|---|---|---|
| before | 59 | 637 |
| after | **42** | **616** |

The declaration set of the file is unchanged — 39 before and after, nothing added or removed — so
this adds no name to the namespace while removing twenty-one lines.

## Hypotheses

The theorem now binds its own coefficients instead of inheriting the section's
`[CommRing R] [Algebra ℤ R]`:

```lean
{R : Type*} [CommSemiring R] {B : Type*} [NonUnitalNonAssocSemiring B] [Module R B]
    [SMulCommClass R B B] [IsScalarTower R B B]
```

Nothing in the argument uses subtraction, additive inverses, a unit in `B`, or associativity of its
multiplication, so `[CommRing R]` and `[Ring B]` were both stronger than the statement needs. Note
that unbundling `Algebra R B` alone would gain nothing — with `[Semiring B]` retained, those two
compatibility classes reconstruct it through `Algebra.ofModule`; the content is dropping unitality
and associativity. Four class binders is the standard Mathlib level for a scalar-weighted product of
sums.

Rebinding also retires the `omit [Algebra ℤ R] in` wrapper, which existed only to shed an instance
the section forced on the declaration. The single call site is unchanged.

## Docstring

The declaration docstring's second paragraph — "Adapted from Mathlib's
`IsNilpotent.exp_add_of_commute`…" — described where the proof came from rather than what the
theorem says. Deleted; the module's References section already carries that credit, and still does.
The credit remains accurate: the proof still follows that theorem's binomial-expansion, truncation
and reindexing plan, and only the reindexing implementation has changed.

One file, `+21/-42`, no new declaration, no public API change.

Roadmap: ReductiveGroups
