### PR TITLE
feat: prove the general linear group is reductive

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Coordinate/BaseChange.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.RingTheory.Localization.BaseChange
 public import Mathlib.RingTheory.TensorProduct.MvPolynomial
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.HopfAlgebra
 
 /-!
@@ -35,6 +36,8 @@ Chevalley--Demazure construction in Layer 9 of the ReductiveGroups roadmap.
 * `TauCeti.GeneralLinear.coordinateHopfAlgebraBaseChangeBialgEquiv`: the bialgebra equivalence.
 * `TauCeti.GeneralLinear.coordinateHopfAlgebraBaseChangeIso`: its bundled
   commutative-Hopf-algebra form, when the extension ring's universe contains the base ring's.
+* `TauCeti.GeneralLinear.finiteTypeCoordinateHopfAlgebraBaseChangeIso`: the corresponding
+  isomorphism of finite-type commutative Hopf algebras.
 * `TauCeti.GeneralLinear.coordinateHopfAlgebraBaseChangeMap_X`: the value on a generic matrix
   entry after transporting the base change of any coordinate morphism.
 
@@ -61,9 +64,11 @@ universe u v
 variable (R : Type u) (K : Type v) [CommRing R] [CommRing K] [Algebra R K]
 variable (n : ℕ)
 
+/-- The determinant of the generic `n × n` matrix over a commutative ring. -/
 private noncomputable abbrev genericDeterminant (S : Type*) [CommRing S] :=
   Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) S)
 
+/-- The standard scalar-extension equivalence for the polynomial coordinate ring of matrices. -/
 private noncomputable abbrev polynomialBaseChangeEquiv :
     K ⊗[R] MatrixMonoid.CoordinateRing R n ≃ₐ[K] MatrixMonoid.CoordinateRing K n :=
   MvPolynomial.algebraTensorAlgEquiv R K
@@ -78,6 +83,7 @@ private theorem polynomialBaseChangeEquiv_one_tmul_genericDeterminant :
   ext i j
   simp [Matrix.mvPolynomialX]
 
+/-- The polynomial base-change equivalence after localizing at the generic determinant. -/
 private noncomputable def localizedPolynomialBaseChangeEquiv :
     Localization.Away ((1 : K) ⊗ₜ[R] genericDeterminant (n := n) R) ≃ₐ[K]
       CoordinateRing K n :=
@@ -123,6 +129,7 @@ theorem coordinateRingBaseChangeAlgEquiv_symm_coordinateRingMap
   apply (coordinateRingBaseChangeAlgEquiv R K n).symm_apply_eq.mpr
   simp
 
+/-- The coordinate-ring base-change equivalence transported to the bundled coordinate algebra. -/
 private noncomputable def bundledCoordinateBaseChangeAlgEquiv :
     K ⊗[R] coordinateHopfAlgebra R n ≃ₐ[K] coordinateHopfAlgebra K n :=
   (Algebra.TensorProduct.congr (AlgEquiv.refl (R := K) (A₁ := K))
@@ -376,5 +383,34 @@ theorem coordinateHopfAlgebraBaseChangeMap_X
   rw [_root_.CommHopfAlgCat.hom_comp, _root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp,
     Function.comp_apply, BialgHom.coe_comp, Function.comp_apply,
     coordinateHopfAlgebraBaseChangeIso_inv_X, CommHopfAlgCat.baseChangeMap_apply_tmul]
+
+/-- The canonical isomorphism
+`baseChange K (finiteTypeCoordinateHopfAlgebra R n) ≅ finiteTypeCoordinateHopfAlgebra K n`
+induced by `coordinateHopfAlgebraBaseChangeIso`. -/
+noncomputable def finiteTypeCoordinateHopfAlgebraBaseChangeIso
+    (R : Type u) (K : Type max u v) [CommRing R] [CommRing K] [Algebra R K] (n : Nat) :
+    FiniteTypeCommHopfAlgCat.baseChange (K := K) (finiteTypeCoordinateHopfAlgebra R n) ≅
+      finiteTypeCoordinateHopfAlgebra K n :=
+  ObjectProperty.isoMk _ <|
+    eqToIso (congrArg (CommHopfAlgCat.baseChange (K := K))
+      (finiteTypeCoordinateHopfAlgebra_obj R n)) ≪≫
+    coordinateHopfAlgebraBaseChangeIso R K n ≪≫
+    eqToIso (finiteTypeCoordinateHopfAlgebra_obj K n).symm
+
+/-- The underlying commutative-Hopf-algebra morphism of the finite-type base-change isomorphism
+is the canonical coordinate-Hopf-algebra base-change isomorphism, with the definitional object
+equalities made explicit. -/
+@[simp]
+theorem finiteTypeCoordinateHopfAlgebraBaseChangeIso_hom
+    (R : Type u) (K : Type max u v) [CommRing R] [CommRing K] [Algebra R K]
+    (n : Nat) :
+    (finiteTypeCoordinateHopfAlgebraBaseChangeIso R K n).hom.hom =
+      (eqToIso (congrArg (CommHopfAlgCat.baseChange (K := K))
+          (finiteTypeCoordinateHopfAlgebra_obj R n)) ≪≫
+        coordinateHopfAlgebraBaseChangeIso R K n ≪≫
+        eqToIso (finiteTypeCoordinateHopfAlgebra_obj K n).symm).hom :=
+  by
+    simp only [finiteTypeCoordinateHopfAlgebraBaseChangeIso,
+      CategoryTheory.ObjectProperty.isoMk_hom, CategoryTheory.ObjectProperty.homMk_hom]
 
 end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
@@ -6,14 +6,11 @@ Authors: Codex
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.SmoothConnected
 public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
-import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.BaseChange
+import TauCeti.Algebra.AlgebraicGroup.Reductive.LinearlyReductive
 import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
-import TauCeti.Algebra.AlgebraicGroup.Representation.NormalInvariants
-import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Naturality
-import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
-import TauCeti.Algebra.Coalgebra.Subcomodule.PointSeparation
 
 /-!
 # The general linear group is reductive
@@ -23,11 +20,9 @@ The proof uses the geometric definition, so it works in arbitrary characteristic
 
 First, the determinant localization defining `O(GL_n)` is smooth and geometrically connected.
 For the normal-subgroup condition, work over an algebraically closed field and let `I` cut out a
-normal smooth unipotent closed subgroup. Its fixed vectors in the standard representation are
-stable under the ambient group. Geometric point separation promotes this fixed subspace to a
-subcomodule. Kolchin's fixed-vector theorem makes it nonzero, while simplicity of the standard
-`GL_n`-comodule makes it the whole representation. The subgroup therefore acts trivially, and
-faithfulness of the standard representation identifies `I` with the augmentation ideal.
+normal smooth unipotent closed subgroup. The simple standard `GL_n`-comodule is completely
+reducible, so the general normal-unipotent elimination theorem makes the subgroup act trivially.
+Faithfulness of the standard representation then identifies `I` with the augmentation ideal.
 
 The final theorem transports this argument across the canonical identification
 
@@ -35,9 +30,6 @@ The final theorem transports this argument across the canonical identification
 
 ## Main declarations
 
-* `TauCeti.GeneralLinear.smooth_coordinateHopfAlgebra`: `O(GL_n)` is smooth.
-* `TauCeti.GeneralLinear.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra`:
-  `GL_n` is geometrically connected.
 * `TauCeti.GeneralLinear.eq_augmentation_of_isNormal_of_smoothUnipotent`: a normal smooth
   unipotent closed subgroup of `GL_n` over an algebraically closed field is trivial.
 * `TauCeti.GeneralLinear.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`:
@@ -45,17 +37,17 @@ The final theorem transports this argument across the canonical identification
 
 ## References
 
-* J. S. Milne, *Algebraic Groups* (2017), §§4.a, 5, and 12.45.
+* J. S. Milne, *Algebraic Groups* (2017), §§4.a, 5, 19.b, and Chapter 14.
 * T. A. Springer, *Linear Algebraic Groups*, §§2.2 and 2.4.
 
-This completes the `GL_n` worked example requested alongside Layer 6, "Reductive and semisimple
-groups", of the ReductiveGroups roadmap.
+This gives the reductivity half of the `GL_n` worked example requested alongside Layer 6,
+"Reductive and semisimple groups", of the ReductiveGroups roadmap. The characteristic-zero
+complete-reducibility route remains open.
 -/
 
 public section
 
-open CategoryTheory WithConv
-open scoped TensorProduct
+open CategoryTheory
 
 namespace TauCeti.GeneralLinear
 
@@ -63,47 +55,7 @@ universe u v
 
 noncomputable section
 
-/-- The coordinate Hopf algebra of `GL_n` is smooth over its base ring. -/
-theorem smooth_coordinateHopfAlgebra (R : Type u) [CommRing R] (n : Nat) :
-    Algebra.Smooth R (coordinateHopfAlgebra R n) := by
-  let _ : Algebra.Smooth R (MatrixMonoid.CoordinateRing R n) :=
-    ⟨inferInstance, inferInstance⟩
-  let _ : Algebra.Smooth (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) :=
-    Algebra.Smooth.of_isLocalization_Away
-      (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R))
-  let _ : Algebra.Smooth R (CoordinateRing R n) :=
-    Algebra.Smooth.comp R (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n)
-  exact Algebra.Smooth.of_equiv (coordinateHopfAlgebraAlgEquiv R n)
-
-/-- Over a field, the coordinate Hopf algebra of `GL_n` is an integral domain. -/
-theorem isDomain_coordinateHopfAlgebra (k : Type u) [Field k] (n : Nat) :
-    IsDomain (coordinateHopfAlgebra k n) := by
-  let _ : IsDomain (CoordinateRing k n) :=
-    Localization.Away.isDomain (Matrix.det_mvPolynomialX_ne_zero (Fin n) k)
-  exact (coordinateHopfAlgebraAlgEquiv k n).toRingEquiv.isDomain_iff.mp inferInstance
-
-/-- The coordinate Hopf algebra of `GL_n` is geometrically connected over every field. -/
-theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra
-    (k : Type u) [Field k] (n : Nat) :
-    geometricallyConnectedCommHopfAlgProperty k (coordinateHopfAlgebra k n) := by
-  rw [geometricallyConnectedCommHopfAlgProperty_iff]
-  intro K _ _
-  let e : coordinateHopfAlgebra k n ⊗[k] K ≃+* coordinateHopfAlgebra K n :=
-    (Algebra.TensorProduct.comm k (coordinateHopfAlgebra k n) K).toRingEquiv.trans
-      (coordinateHopfAlgebraBaseChangeBialgEquiv k K n).toAlgEquiv.toRingEquiv
-  let _ : IsDomain (coordinateHopfAlgebra K n) := isDomain_coordinateHopfAlgebra K n
-  exact (PrimeSpectrum.homeomorphOfRingEquiv e).connectedSpace_iff.mpr inferInstance
-
-/-- The finite-type coordinate Hopf algebra of `GL_n` commutes with base change. -/
-noncomputable def finiteTypeCoordinateHopfAlgebraBaseChangeIso
-    (R : Type u) (K : Type max u v) [CommRing R] [CommRing K] [Algebra R K] (n : Nat) :
-    FiniteTypeCommHopfAlgCat.baseChange (K := K) (finiteTypeCoordinateHopfAlgebra R n) ≅
-      finiteTypeCoordinateHopfAlgebra K n :=
-  ObjectProperty.isoMk _ <|
-    eqToIso (congrArg (CommHopfAlgCat.baseChange (K := K))
-      (finiteTypeCoordinateHopfAlgebra_obj R n)) ≪≫
-    coordinateHopfAlgebraBaseChangeIso R K n ≪≫
-    eqToIso (finiteTypeCoordinateHopfAlgebra_obj K n).symm
+open HopfIdeal
 
 /-- The coordinate Hopf algebra and the underlying object of its finite-type package are
 canonically identical. -/
@@ -112,82 +64,8 @@ private noncomputable def coordinateHopfAlgebraFiniteTypeObjIso
     coordinateHopfAlgebra R n ≅ (finiteTypeCoordinateHopfAlgebra R n).obj :=
   eqToIso (finiteTypeCoordinateHopfAlgebra_obj R n).symm
 
-private theorem eq_augmentation_of_isNormal_of_smooth_of_geometricallyUnipotent_of_neZero
-    (k : Type u) [Field k] [IsAlgClosed k] (n : Nat) [NeZero n]
-    (I : HopfIdeal k (coordinateHopfAlgebra k n)) (hI : I.IsNormal)
-    (hSmooth : Algebra.Smooth k
-      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I))
-    (hU : geometricallyUnipotentPointsCommHopfAlgProperty k
-      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I)) :
-    I = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) := by
-  let Q := CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I
-  let q : coordinateHopfAlgebra k n →ₐc[k] Q :=
-    (CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k n) I).hom
-  let _ : IsDomain (coordinateHopfAlgebra k n) := isDomain_coordinateHopfAlgebra k n
-  let _ : IsReduced (coordinateHopfAlgebra k n) := inferInstance
-  let _ : Algebra.Smooth k Q := hSmooth
-  let _ : IsReduced Q := isReduced_of_smooth_of_field k Q
-  let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n
-  -- Geometric unipotence also detects the base-valued points because the base is algebraically
-  -- closed and unipotence is reflected by an injective extension of the value field.
-  have hu : ∀ g : WithConv (Q →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g := by
-    intro g
-    let φ : k →ₐ[k] AlgebraicClosure k := Algebra.ofId k (AlgebraicClosure k)
-    exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
-      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k Q).mp hU
-        (AlgHom.mapValue (H := Q) φ g))
-  -- Normality makes the subgroup-fixed vectors pointwise stable under the ambient group; reduced
-  -- finite-type point separation upgrades that stability to an ambient subcomodule.
-  let hstable : ∀ (g : coordinateHopfAlgebra k n →ₐ[k] k) {m : Fin n → k},
-      m ∈ I.basePointFixedSubmodule (Fin n → k) →
-        Comodule.endOfPoint (Fin n → k) g (1 ⊗ₜ[k] m) ∈
-          (I.basePointFixedSubmodule (Fin n → k)).baseChange k := fun g _ hm ↦ by
-    simpa only [WithConv.ofConv_toConv] using
-      hI.endOfPoint_one_tmul_mem_basePointFixedSubmodule_baseChange
-        (WithConv.toConv g) hm
-  let S : Subcomodule k (coordinateHopfAlgebra k n) (Fin n → k) :=
-    Subcomodule.ofEndOfPointStable (I.basePointFixedSubmodule (Fin n → k)) hstable
-  have hSto : S.toSubmodule = I.basePointFixedSubmodule (Fin n → k) :=
-    Subcomodule.ofEndOfPointStable_toSubmodule _ hstable
-  -- Kolchin supplies a nonzero subgroup-fixed vector in the standard representation.
-  let _ : Comodule k Q (Fin n → k) := Comodule.Corestrict q.toCoalgHom
-  obtain ⟨v, hv, hvcoact⟩ :=
-    (Comodule.hasNonzeroFixedVector_iff (k := k) (H := Q) (M := Fin n → k)).mp
-      (Comodule.hasNonzeroFixedVector_of_forall_isUnipotentPoint (M := Fin n → k) hu)
-  have hvfixed : v ∈ I.basePointFixedSubmodule (Fin n → k) :=
-    HopfIdeal.mem_basePointFixedSubmodule_of_quotient_coact_eq_tmul_one I v <| by
-      simpa only [Comodule.corestrict_coact_apply] using hvcoact
-  have hvS : v ∈ S := by
-    -- Expose the underlying submodule so the construction's characteristic equality rewrites.
-    change v ∈ S.toSubmodule
-    rw [hSto]
-    exact hvfixed
-  -- Simplicity of the standard ambient representation makes its nonzero fixed subcomodule all.
-  have hS : S = ⊤ := by
-    rcases eq_bot_or_eq_top S with hbot | htop
-    · exfalso
-      rw [hbot, Subcomodule.mem_bot] at hvS
-      exact hv hvS
-    · exact htop
-  -- The whole standard representation is now subgroup-fixed, and its faithfulness eliminates the
-  -- subgroup scheme rather than merely its rational points.
-  apply Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one I
-    (isFaithful_standardComodule k n)
-  intro m
-  apply (HopfIdeal.mem_basePointFixedSubmodule_iff_quotient_coact_eq_tmul_one I m).mp
-  have hmS : m ∈ S := by
-    rw [hS]
-    exact Subcomodule.mem_top m
-  -- Expose the fixed submodule to transfer membership back from the bundled subcomodule.
-  change m ∈ I.basePointFixedSubmodule (Fin n → k)
-  rw [← hSto]
-  exact hmS
-
 /-- A normal smooth unipotent closed subgroup of `GL_n` over an algebraically closed field is
-trivial.
-
-For positive rank the proof uses a nonzero fixed vector in the simple standard representation;
-in rank zero the faithful standard representation is already trivial. -/
+trivial. No positivity hypothesis on `n` is needed. -/
 theorem eq_augmentation_of_isNormal_of_smoothUnipotent
     (k : Type u) [Field k] [IsAlgClosed k] (n : Nat)
     (I : HopfIdeal k (finiteTypeCoordinateHopfAlgebra k n)) (hI : I.IsNormal)
@@ -205,7 +83,7 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
     CommHopfAlgCat.quotientIsoOfIso e I
   have hU' := (smoothUnipotentCommHopfAlgProperty_iff k
     (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I)).mp hU
-  have hJsmooth : Algebra.Smooth k
+  let _ : Algebra.Smooth k
       (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
     (smoothCommHopfAlgProperty_iff _).mp <|
       (smoothCommHopfAlgProperty k).prop_of_iso qIso.symm
@@ -214,20 +92,42 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
       (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
     (geometricallyUnipotentPointsCommHopfAlgProperty k).prop_of_iso qIso.symm
       ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2)
-  have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) := by
+  let _ : IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
+    isReduced_of_smooth_of_field k _
+  let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n
+  have hu :=
+    geometricallyUnipotentPointsCommHopfAlgProperty.forall_isUnipotentPoint hJunipotent
+  have hcr : Comodule.IsCompletelyReducible k (coordinateHopfAlgebra k n) (Fin n → k) := by
+    apply Comodule.IsCompletelyReducible.of_exists_isCompl
+    intro W
     cases n with
     | zero =>
-        let _ : Comodule k (coordinateHopfAlgebra k 0) (Fin 0 → k) := standardComodule k 0
-        apply Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one J
-          (isFaithful_standardComodule k 0)
-        intro m
-        have hm : m = 0 := Subsingleton.elim _ _
-        rw [hm]
-        simp only [map_zero, TensorProduct.zero_tmul]
+        have hW : W = ⊥ := by
+          ext m
+          constructor
+          · intro _
+            rw [Subcomodule.mem_bot]
+            exact Subsingleton.elim _ _
+          · intro hm
+            exact (Subcomodule.mem_bot.mp hm) ▸ zero_mem W
+        refine ⟨⊤, ?_⟩
+        simpa [hW] using
+          (isCompl_bot_top : IsCompl (⊥ : Submodule k (Fin 0 → k)) ⊤)
     | succ n =>
         let _ : NeZero n.succ := ⟨Nat.succ_ne_zero n⟩
-        exact eq_augmentation_of_isNormal_of_smooth_of_geometricallyUnipotent_of_neZero
-          k n.succ J hJnormal hJsmooth hJunipotent
+        exact (eq_bot_or_eq_top W).elim
+          (fun h ↦ ⟨⊤, by
+            simpa [h] using
+              (isCompl_bot_top : IsCompl (⊥ : Submodule k (Fin n.succ → k)) ⊤)⟩)
+          (fun h ↦ ⟨⊥, by
+            simpa [h] using
+              (isCompl_top_bot : IsCompl (⊤ : Submodule k (Fin n.succ → k)) ⊥)⟩)
+  have htrivial :=
+    mkQuotient_coact_eq_tmul_one_of_isNormal_of_forall_isUnipotentPoint_of_isCompletelyReducible
+      hJnormal hu hcr
+  have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) :=
+    Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one J
+      (isFaithful_standardComodule k n) htrivial
   rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hf.2,
     HopfIdeal.comap_augmentation]
   exact hJ
@@ -240,7 +140,7 @@ theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
   let e := coordinateHopfAlgebraFiniteTypeObjIso k n
   refine ⟨(smoothCommHopfAlgProperty_iff _).mp <|
       (smoothCommHopfAlgProperty k).prop_of_iso e
-        ((smoothCommHopfAlgProperty_iff _).mpr (smooth_coordinateHopfAlgebra k n)),
+        ((smoothCommHopfAlgProperty_iff _).mpr inferInstance),
     (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e
       (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n), ?_⟩
   intro I hI _ hU

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
@@ -1,0 +1,270 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule
+public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
+import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.BaseChange
+import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
+import TauCeti.Algebra.AlgebraicGroup.Representation.NormalInvariants
+import TauCeti.Algebra.AlgebraicGroup.Representation.UnipotentPoint.Naturality
+import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
+import TauCeti.Algebra.Coalgebra.Subcomodule.PointSeparation
+
+/-!
+# The general linear group is reductive
+
+The coordinate Hopf algebra of `GL_n` is reductive over every field and in every natural rank.
+The proof uses the geometric definition, so it works in arbitrary characteristic.
+
+First, the determinant localization defining `O(GL_n)` is smooth and geometrically connected.
+For the normal-subgroup condition, work over an algebraically closed field and let `I` cut out a
+normal smooth unipotent closed subgroup. Its fixed vectors in the standard representation are
+stable under the ambient group. Geometric point separation promotes this fixed subspace to a
+subcomodule. Kolchin's fixed-vector theorem makes it nonzero, while simplicity of the standard
+`GL_n`-comodule makes it the whole representation. The subgroup therefore acts trivially, and
+faithfulness of the standard representation identifies `I` with the augmentation ideal.
+
+The final theorem transports this argument across the canonical identification
+
+`AlgebraicClosure k ⊗[k] O(GL_n) ≃ O(GL_n, AlgebraicClosure k)`.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.smooth_coordinateHopfAlgebra`: `O(GL_n)` is smooth.
+* `TauCeti.GeneralLinear.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra`:
+  `GL_n` is geometrically connected.
+* `TauCeti.GeneralLinear.eq_augmentation_of_isNormal_of_smoothUnipotent`: a normal smooth
+  unipotent closed subgroup of `GL_n` over an algebraically closed field is trivial.
+* `TauCeti.GeneralLinear.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`:
+  **`GL_n` is reductive.**
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§4.a, 5, and 12.45.
+* T. A. Springer, *Linear Algebraic Groups*, §§2.2 and 2.4.
+
+This completes the `GL_n` worked example requested alongside Layer 6, "Reductive and semisimple
+groups", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory WithConv
+open scoped TensorProduct
+
+namespace TauCeti.GeneralLinear
+
+universe u v
+
+noncomputable section
+
+/-- The coordinate Hopf algebra of `GL_n` is smooth over its base ring. -/
+theorem smooth_coordinateHopfAlgebra (R : Type u) [CommRing R] (n : Nat) :
+    Algebra.Smooth R (coordinateHopfAlgebra R n) := by
+  let _ : Algebra.Smooth R (MatrixMonoid.CoordinateRing R n) :=
+    ⟨inferInstance, inferInstance⟩
+  let _ : Algebra.Smooth (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) :=
+    Algebra.Smooth.of_isLocalization_Away
+      (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R))
+  let _ : Algebra.Smooth R (CoordinateRing R n) :=
+    Algebra.Smooth.comp R (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n)
+  exact Algebra.Smooth.of_equiv (coordinateHopfAlgebraAlgEquiv R n)
+
+/-- Over a field, the coordinate Hopf algebra of `GL_n` is an integral domain. -/
+theorem isDomain_coordinateHopfAlgebra (k : Type u) [Field k] (n : Nat) :
+    IsDomain (coordinateHopfAlgebra k n) := by
+  let _ : IsDomain (CoordinateRing k n) :=
+    Localization.Away.isDomain (Matrix.det_mvPolynomialX_ne_zero (Fin n) k)
+  exact (coordinateHopfAlgebraAlgEquiv k n).toRingEquiv.isDomain_iff.mp inferInstance
+
+/-- The coordinate Hopf algebra of `GL_n` is geometrically connected over every field. -/
+theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra
+    (k : Type u) [Field k] (n : Nat) :
+    geometricallyConnectedCommHopfAlgProperty k (coordinateHopfAlgebra k n) := by
+  rw [geometricallyConnectedCommHopfAlgProperty_iff]
+  intro K _ _
+  let e : coordinateHopfAlgebra k n ⊗[k] K ≃+* coordinateHopfAlgebra K n :=
+    (Algebra.TensorProduct.comm k (coordinateHopfAlgebra k n) K).toRingEquiv.trans
+      (coordinateHopfAlgebraBaseChangeBialgEquiv k K n).toAlgEquiv.toRingEquiv
+  let _ : IsDomain (coordinateHopfAlgebra K n) := isDomain_coordinateHopfAlgebra K n
+  exact (PrimeSpectrum.homeomorphOfRingEquiv e).connectedSpace_iff.mpr inferInstance
+
+/-- The finite-type coordinate Hopf algebra of `GL_n` commutes with base change. -/
+noncomputable def finiteTypeCoordinateHopfAlgebraBaseChangeIso
+    (R : Type u) (K : Type max u v) [CommRing R] [CommRing K] [Algebra R K] (n : Nat) :
+    FiniteTypeCommHopfAlgCat.baseChange (K := K) (finiteTypeCoordinateHopfAlgebra R n) ≅
+      finiteTypeCoordinateHopfAlgebra K n :=
+  ObjectProperty.isoMk _ <|
+    eqToIso (congrArg (CommHopfAlgCat.baseChange (K := K))
+      (finiteTypeCoordinateHopfAlgebra_obj R n)) ≪≫
+    coordinateHopfAlgebraBaseChangeIso R K n ≪≫
+    eqToIso (finiteTypeCoordinateHopfAlgebra_obj K n).symm
+
+/-- The coordinate Hopf algebra and the underlying object of its finite-type package are
+canonically identical. -/
+private noncomputable def coordinateHopfAlgebraFiniteTypeObjIso
+    (R : Type u) [CommRing R] (n : Nat) :
+    coordinateHopfAlgebra R n ≅ (finiteTypeCoordinateHopfAlgebra R n).obj :=
+  eqToIso (finiteTypeCoordinateHopfAlgebra_obj R n).symm
+
+private theorem eq_augmentation_of_isNormal_of_smooth_of_geometricallyUnipotent_of_neZero
+    (k : Type u) [Field k] [IsAlgClosed k] (n : Nat) [NeZero n]
+    (I : HopfIdeal k (coordinateHopfAlgebra k n)) (hI : I.IsNormal)
+    (hSmooth : Algebra.Smooth k
+      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I))
+    (hU : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I)) :
+    I = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) := by
+  let Q := CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I
+  let q : coordinateHopfAlgebra k n →ₐc[k] Q :=
+    (CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k n) I).hom
+  let _ : IsDomain (coordinateHopfAlgebra k n) := isDomain_coordinateHopfAlgebra k n
+  let _ : IsReduced (coordinateHopfAlgebra k n) := inferInstance
+  let _ : Algebra.Smooth k Q := hSmooth
+  let _ : IsReduced Q := isReduced_of_smooth_of_field k Q
+  let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n
+  -- Geometric unipotence also detects the base-valued points because the base is algebraically
+  -- closed and unipotence is reflected by an injective extension of the value field.
+  have hu : ∀ g : WithConv (Q →ₐ[k] k), HopfAlgebra.IsUnipotentPoint g := by
+    intro g
+    let φ : k →ₐ[k] AlgebraicClosure k := Algebra.ofId k (AlgebraicClosure k)
+    exact (HopfAlgebra.isUnipotentPoint_mapValue_iff_of_injective g φ φ.injective).mp
+      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k Q).mp hU
+        (AlgHom.mapValue (H := Q) φ g))
+  -- Normality makes the subgroup-fixed vectors pointwise stable under the ambient group; reduced
+  -- finite-type point separation upgrades that stability to an ambient subcomodule.
+  let hstable : ∀ (g : coordinateHopfAlgebra k n →ₐ[k] k) {m : Fin n → k},
+      m ∈ I.basePointFixedSubmodule (Fin n → k) →
+        Comodule.endOfPoint (Fin n → k) g (1 ⊗ₜ[k] m) ∈
+          (I.basePointFixedSubmodule (Fin n → k)).baseChange k := fun g _ hm ↦ by
+    simpa only [WithConv.ofConv_toConv] using
+      hI.endOfPoint_one_tmul_mem_basePointFixedSubmodule_baseChange
+        (WithConv.toConv g) hm
+  let S : Subcomodule k (coordinateHopfAlgebra k n) (Fin n → k) :=
+    Subcomodule.ofEndOfPointStable (I.basePointFixedSubmodule (Fin n → k)) hstable
+  have hSto : S.toSubmodule = I.basePointFixedSubmodule (Fin n → k) :=
+    Subcomodule.ofEndOfPointStable_toSubmodule _ hstable
+  -- Kolchin supplies a nonzero subgroup-fixed vector in the standard representation.
+  let _ : Comodule k Q (Fin n → k) := Comodule.Corestrict q.toCoalgHom
+  obtain ⟨v, hv, hvcoact⟩ :=
+    (Comodule.hasNonzeroFixedVector_iff (k := k) (H := Q) (M := Fin n → k)).mp
+      (Comodule.hasNonzeroFixedVector_of_forall_isUnipotentPoint (M := Fin n → k) hu)
+  have hvfixed : v ∈ I.basePointFixedSubmodule (Fin n → k) :=
+    HopfIdeal.mem_basePointFixedSubmodule_of_quotient_coact_eq_tmul_one I v <| by
+      simpa only [Comodule.corestrict_coact_apply] using hvcoact
+  have hvS : v ∈ S := by
+    -- Expose the underlying submodule so the construction's characteristic equality rewrites.
+    change v ∈ S.toSubmodule
+    rw [hSto]
+    exact hvfixed
+  -- Simplicity of the standard ambient representation makes its nonzero fixed subcomodule all.
+  have hS : S = ⊤ := by
+    rcases eq_bot_or_eq_top S with hbot | htop
+    · exfalso
+      rw [hbot, Subcomodule.mem_bot] at hvS
+      exact hv hvS
+    · exact htop
+  -- The whole standard representation is now subgroup-fixed, and its faithfulness eliminates the
+  -- subgroup scheme rather than merely its rational points.
+  apply Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one I
+    (isFaithful_standardComodule k n)
+  intro m
+  apply (HopfIdeal.mem_basePointFixedSubmodule_iff_quotient_coact_eq_tmul_one I m).mp
+  have hmS : m ∈ S := by
+    rw [hS]
+    exact Subcomodule.mem_top m
+  -- Expose the fixed submodule to transfer membership back from the bundled subcomodule.
+  change m ∈ I.basePointFixedSubmodule (Fin n → k)
+  rw [← hSto]
+  exact hmS
+
+/-- A normal smooth unipotent closed subgroup of `GL_n` over an algebraically closed field is
+trivial.
+
+For positive rank the proof uses a nonzero fixed vector in the simple standard representation;
+in rank zero the faithful standard representation is already trivial. -/
+theorem eq_augmentation_of_isNormal_of_smoothUnipotent
+    (k : Type u) [Field k] [IsAlgClosed k] (n : Nat)
+    (I : HopfIdeal k (finiteTypeCoordinateHopfAlgebra k n)) (hI : I.IsNormal)
+    (hU : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I)) :
+    I = HopfIdeal.augmentation k (finiteTypeCoordinateHopfAlgebra k n) := by
+  let e := coordinateHopfAlgebraFiniteTypeObjIso k n
+  let f : coordinateHopfAlgebra k n →ₐc[k] (finiteTypeCoordinateHopfAlgebra k n) :=
+    CommHopfAlgCat.ofIso e
+  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.hom
+  let J : HopfIdeal k (coordinateHopfAlgebra k n) := I.comap f hf.2
+  have hJnormal : J.IsNormal := hI.comap_of_bijective f hf.1 hf.2
+  let qIso : CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J ≅
+      CommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n).obj I :=
+    CommHopfAlgCat.quotientIsoOfIso e I
+  have hU' := (smoothUnipotentCommHopfAlgProperty_iff k
+    (FiniteTypeCommHopfAlgCat.quotient (finiteTypeCoordinateHopfAlgebra k n) I)).mp hU
+  have hJsmooth : Algebra.Smooth k
+      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
+    (smoothCommHopfAlgProperty_iff _).mp <|
+      (smoothCommHopfAlgProperty k).prop_of_iso qIso.symm
+        ((smoothCommHopfAlgProperty_iff _).mpr hU'.1)
+  have hJunipotent : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
+    (geometricallyUnipotentPointsCommHopfAlgProperty k).prop_of_iso qIso.symm
+      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2)
+  have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) := by
+    cases n with
+    | zero =>
+        let _ : Comodule k (coordinateHopfAlgebra k 0) (Fin 0 → k) := standardComodule k 0
+        apply Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one J
+          (isFaithful_standardComodule k 0)
+        intro m
+        have hm : m = 0 := Subsingleton.elim _ _
+        rw [hm]
+        simp only [map_zero, TensorProduct.zero_tmul]
+    | succ n =>
+        let _ : NeZero n.succ := ⟨Nat.succ_ne_zero n⟩
+        exact eq_augmentation_of_isNormal_of_smooth_of_geometricallyUnipotent_of_neZero
+          k n.succ J hJnormal hJsmooth hJunipotent
+  rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hf.2,
+    HopfIdeal.comap_augmentation]
+  exact hJ
+
+/-- **The general linear group is reductive over every field.** -/
+theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
+    (k : Type u) [Field k] (n : Nat) :
+    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) := by
+  rw [reductiveCommHopfAlgProperty_iff]
+  let e := coordinateHopfAlgebraFiniteTypeObjIso k n
+  refine ⟨(smoothCommHopfAlgProperty_iff _).mp <|
+      (smoothCommHopfAlgProperty k).prop_of_iso e
+        ((smoothCommHopfAlgProperty_iff _).mpr (smooth_coordinateHopfAlgebra k n)),
+    (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e
+      (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n), ?_⟩
+  intro I hI _ hU
+  let K := AlgebraicClosure k
+  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := K)
+    (finiteTypeCoordinateHopfAlgebra k n)
+  let Gbar := finiteTypeCoordinateHopfAlgebra K n
+  let e : Hbar ≅ Gbar := finiteTypeCoordinateHopfAlgebraBaseChangeIso k K n
+  let f : Gbar →ₐc[K] Hbar := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
+  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.inv
+  let J : HopfIdeal K Gbar := I.comap f hf.2
+  have hJnormal : J.IsNormal := hI.comap_of_bijective f hf.1 hf.2
+  let qIso : FiniteTypeCommHopfAlgCat.quotient Gbar J ≅
+      FiniteTypeCommHopfAlgCat.quotient Hbar I :=
+    FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm I
+  have hJU : smoothUnipotentCommHopfAlgProperty K
+      (FiniteTypeCommHopfAlgCat.quotient Gbar J) :=
+    (smoothUnipotentCommHopfAlgProperty K).prop_of_iso qIso.symm hU
+  have hJ : J = HopfIdeal.augmentation K Gbar :=
+    eq_augmentation_of_isNormal_of_smoothUnipotent K n J hJnormal hJU
+  rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hf.2,
+    HopfIdeal.comap_augmentation]
+  exact hJ
+
+end
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/SmoothConnected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/SmoothConnected.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.GeometricallyReduced
+
+/-!
+# Smoothness and connectedness of the general linear group
+
+The determinant localization defining the coordinate Hopf algebra of `GL_n` is smooth. It is
+also an integral domain whenever the base ring is an integral domain. After base change to any
+field it therefore has connected prime spectrum, proving geometric connectedness over a field.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.instSmoothCoordinateHopfAlgebra`: `O(GL_n)` is smooth.
+* `TauCeti.GeneralLinear.instIsDomainCoordinateHopfAlgebra`: `O(GL_n)` is an integral domain
+  over an integral domain.
+* `TauCeti.GeneralLinear.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra`:
+  `GL_n` is geometrically connected.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+noncomputable section
+
+/-- The coordinate Hopf algebra of `GL_n` is smooth over its base ring. -/
+instance instSmoothCoordinateHopfAlgebra (R : Type u) [CommRing R] (n : Nat) :
+    Algebra.Smooth R (coordinateHopfAlgebra R n) := by
+  let _ : Algebra.Smooth R (MatrixMonoid.CoordinateRing R n) :=
+    ⟨inferInstance, inferInstance⟩
+  let _ : Algebra.Smooth (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) :=
+    Algebra.Smooth.of_isLocalization_Away
+      (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R))
+  let _ : Algebra.Smooth R (CoordinateRing R n) :=
+    Algebra.Smooth.comp R (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n)
+  exact Algebra.Smooth.of_equiv (coordinateHopfAlgebraAlgEquiv R n)
+
+/-- Over an integral domain, the coordinate Hopf algebra of `GL_n` is an integral domain. -/
+instance instIsDomainCoordinateHopfAlgebra
+    (R : Type u) [CommRing R] [IsDomain R] (n : Nat) :
+    IsDomain (coordinateHopfAlgebra R n) := by
+  let _ : IsDomain (CoordinateRing R n) :=
+    Localization.Away.isDomain (Matrix.det_mvPolynomialX_ne_zero (Fin n) R)
+  exact (coordinateHopfAlgebraAlgEquiv R n).toRingEquiv.isDomain_iff.mp inferInstance
+
+/-- The coordinate Hopf algebra of `GL_n` is geometrically connected over every field. -/
+theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra
+    (k : Type u) [Field k] (n : Nat) :
+    geometricallyConnectedCommHopfAlgProperty k (coordinateHopfAlgebra k n) := by
+  rw [geometricallyConnectedCommHopfAlgProperty_iff]
+  intro K _ _
+  let e : coordinateHopfAlgebra k n ⊗[k] K ≃+* coordinateHopfAlgebra K n :=
+    (Algebra.TensorProduct.comm k (coordinateHopfAlgebra k n) K).toRingEquiv.trans
+      (coordinateHopfAlgebraBaseChangeBialgEquiv k K n).toAlgEquiv.toRingEquiv
+  exact (PrimeSpectrum.homeomorphOfRingEquiv e).connectedSpace_iff.mpr inferInstance
+
+end
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -40,8 +40,9 @@ milestone in Layer 6 of the ReductiveGroups roadmap.
 ## Main declarations
 
 * `TauCeti.Comodule.IsCompletelyReducible`: every subcomodule has a subcomodule complement.
-* `TauCeti.Comodule.IsCompletelyReducible.exists_isCompl`: the accessor producing that
-  complement.
+* `TauCeti.Comodule.IsCompletelyReducible.of_exists_isCompl` and
+  `TauCeti.Comodule.IsCompletelyReducible.exists_isCompl`: construct and use complete
+  reducibility through complementary subcomodules.
 * `TauCeti.Comodule.fixedSubcomodule_eq_top_of_isCompletelyReducible_of_forall_exists_fixed` and
   `TauCeti.Comodule.coact_eq_tmul_one_of_isCompletelyReducible_of_forall_exists_fixed`: a
   completely reducible comodule all of whose nonzero subcomodules contain nonzero fixed vectors
@@ -92,6 +93,14 @@ def IsCompletelyReducible : Prop :=
     IsCompl W.toSubmodule Q.toSubmodule
 
 variable {k C V}
+
+/-- Construct complete reducibility by supplying a complementary subcomodule for every
+subcomodule. -/
+theorem IsCompletelyReducible.of_exists_isCompl
+    (h : ∀ W : Subcomodule k C V, ∃ Q : Subcomodule k C V,
+      IsCompl W.toSubmodule Q.toSubmodule) :
+    IsCompletelyReducible k C V :=
+  h
 
 /-- The subcomodule complement supplied by complete reducibility.
 


### PR DESCRIPTION
This PR proves that the finite-type coordinate Hopf algebra of `GLₙ` is reductive over every field and in every natural rank, completing the explicit `GLₙ` worked-example target attached to Layer 6, “Reductive and semisimple groups,” of `TauCetiRoadmap/ReductiveGroups/README.md`.

The proof uses the roadmap’s geometric definition, so it is valid in arbitrary characteristic. The determinant localization `O(GLₙ)` is smooth, and its base change to every field is identified with a domain `O(GLₙ)` over that field, giving geometric connectedness. Over an algebraically closed field, a normal smooth unipotent closed subgroup has a nonzero fixed vector in the standard representation by the existing Kolchin theorem. Normality and geometric point separation make the fixed space an ambient subcomodule; simplicity of the standard `GLₙ`-comodule makes that subcomodule top, and faithfulness then identifies the subgroup’s Hopf ideal with the augmentation ideal. Rank zero is handled separately by the already-faithful trivial standard representation. The final theorem transports this subgroup argument across the canonical finite-type base-change isomorphism `k̄ ⊗[k] O(GLₙ) ≅ O(GLₙ, k̄)`.

This is the most effective current step because the exact prerequisite chain has landed on `main`: the faithful simple standard comodule, point-stable-submodule detection, normal-subgroup invariant stability, Kolchin’s fixed-vector theorem, and faithful trivial-action elimination now assemble directly into the roadmap’s named example rather than another prerequisite.

After this PR, Layer 6 still needs the converse comparison from reductivity to linear reductivity in characteristic zero, the remaining radical/centre/derived-group and central-isogeny structure theory, and the other worked examples such as `SLₙ`.

The new module is `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean` (270 lines). It also records smoothness, integral-domain and geometric-connectedness results for `O(GLₙ)`, the finite-type base-change isomorphism, and the algebraically closed normal-unipotent-subgroup elimination theorem used by the final result.

No Mathlib infrastructure or external formalization is vendored. The proof reuses Mathlib’s smooth-localization and domain-localization APIs together with Tau Ceti’s existing representation, Hopf-ideal, point-separation, unipotence, and reductivity infrastructure. The mathematical argument follows Milne, *Algebraic Groups* (2017), §§4.a, 5, and 12.45, and Springer, *Linear Algebraic Groups*, §§2.2 and 2.4, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"gln-is-reductive"}-->

🤖 Prepared with Codex
