### PR TITLE
feat: add the standard special-linear comodule

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/StandardComodule.lean
@@ -253,27 +253,15 @@ private theorem exists_generalLinearGroup_mulVec {v w : Fin m → k} (hv : v ≠
 /-- **The standard comodule of `GLₘ` over a field is simple** for `m ≠ 0`: its only subcomodules
 are the zero comodule and the whole column space. -/
 instance instIsSimpleOrderSubcomodule :
-    IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) where
-  exists_pair_ne := by
-    refine ⟨⊥, ⊤, fun h ↦ ?_⟩
-    have hone : (Pi.single (0 : Fin m) (1 : k) : Fin m → k) ∈
-        (⊥ : Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) :=
-      h ▸ Subcomodule.mem_top _
-    rw [Subcomodule.mem_bot] at hone
-    simpa using congrFun hone (0 : Fin m)
-  eq_bot_or_eq_top N := by
-    by_cases hN : ∀ w ∈ N, w = 0
-    · left
-      exact Subcomodule.ext fun w ↦ ⟨fun hw ↦ Subcomodule.mem_bot.mpr (hN w hw),
-        fun hw ↦ Subcomodule.mem_bot.mp hw ▸ zero_mem N⟩
-    · right
-      simp only [not_forall] at hN
-      obtain ⟨w, hwN, hw⟩ := hN
-      refine Subcomodule.ext fun v ↦ ⟨fun _ ↦ Subcomodule.mem_top v, fun _ ↦ ?_⟩
-      by_cases hv : v = 0
-      · exact hv ▸ zero_mem N
-      · obtain ⟨g, hg⟩ := exists_generalLinearGroup_mulVec k m hv hw
-        exact hg ▸ mulVec_mem k m N g hwN
+    IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) := by
+  refine Subcomodule.isSimpleOrder_of_transitive
+    (Pi.single (0 : Fin m) (1 : k) : Fin m → k) ?_
+    (fun (g : Matrix.GeneralLinearGroup (Fin m) k) w ↦
+      (g : Matrix (Fin m) (Fin m) k) *ᵥ w) ?_ ?_
+  · intro h
+    simpa using congrFun h (0 : Fin m)
+  · exact fun hv hw ↦ exists_generalLinearGroup_mulVec k m hv hw
+  · exact fun N g _ hw ↦ mulVec_mem k m N g hw
 
 end Simple
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
@@ -68,12 +68,16 @@ noncomputable def standardComodule :
 
 attribute [local instance] GeneralLinear.standardComodule standardComodule
 
-private theorem standardComodule_corestrictCoact :
+/-- The standard `SL_n` coaction is the standard `GL_n` coaction followed by the quotient map on
+the coordinate factor. -/
+@[simp]
+theorem standardComodule_coact :
     let _ := GeneralLinear.standardComodule R n
     Comodule.corestrictCoact
         (R := R) (C := GeneralLinear.coordinateHopfAlgebra R n)
         (D := coordinateHopfAlgebra R n) (M := Fin n → R)
-        (coordinateMap R n).hom.toCoalgHom =
+        (Bialgebra.Quotient.mkBialgHom (R := R)
+          (definingHopfIdeal R n).toIdeal).toCoalgHom =
       TensorProduct.map LinearMap.id
           (Bialgebra.Quotient.mkBialgHom (R := R)
             (definingHopfIdeal R n).toIdeal).toLinearMap ∘ₗ
@@ -81,18 +85,7 @@ private theorem standardComodule_corestrictCoact :
   apply LinearMap.ext
   intro v
   rw [Comodule.corestrictCoact_apply, LinearMap.comp_apply,
-    GeneralLinear.standardComodule_coact, CommHopfAlgCat.hom_mkQuotient]
-
-/-- The standard `SL_n` coaction is the standard `GL_n` coaction followed by the quotient map on
-the coordinate factor. -/
-@[simp]
-theorem standardComodule_coact :
-    (standardComodule R n).coact =
-      TensorProduct.map LinearMap.id
-          (Bialgebra.Quotient.mkBialgHom (R := R)
-            (definingHopfIdeal R n).toIdeal).toLinearMap ∘ₗ
-        GeneralLinear.standardCoact R n :=
-  standardComodule_corestrictCoact R n
+    GeneralLinear.standardComodule_coact]
 
 /-- **The standard comodule of `SL_n` is faithful.** -/
 theorem isFaithful_standardComodule :
@@ -159,6 +152,11 @@ theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
           (LinearMap.lTensor (Fin n → R) q.ofConv.toLinearMap
             ((standardComodule R n).coact w)) ∈ N :=
     N.rid_lTensor_coact_mem q.ofConv.toLinearMap hw
+  change
+    TensorProduct.rid R (Fin n → R)
+        (LinearMap.lTensor (Fin n → R) q.ofConv.toLinearMap
+          (Comodule.corestrictCoact (coordinateMap R n).hom.toCoalgHom w)) ∈ N at h
+  rw [CommHopfAlgCat.hom_mkQuotient] at h
   rw [standardComodule_coact R n, LinearMap.comp_apply] at h
   have hcoordinate :
       (Bialgebra.Quotient.mkBialgHom

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
@@ -87,6 +87,13 @@ theorem standardComodule_coact :
   rw [Comodule.corestrictCoact_apply, LinearMap.comp_apply,
     GeneralLinear.standardComodule_coact]
 
+/-- The coaction bundled by `standardComodule` is its defining corestriction. This explicit bridge
+keeps proofs from depending directly on reducibility of the comodule wrapper. -/
+private theorem standardComodule_coact_eq_corestrictCoact :
+    (standardComodule R n).coact =
+      Comodule.corestrictCoact (coordinateMap R n).hom.toCoalgHom :=
+  rfl
+
 /-- **The standard comodule of `SL_n` is faithful.** -/
 theorem isFaithful_standardComodule :
     Comodule.IsFaithful (k := R) (H := coordinateHopfAlgebra R n) (V := Fin n → R) := by
@@ -152,10 +159,7 @@ theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
           (LinearMap.lTensor (Fin n → R) q.ofConv.toLinearMap
             ((standardComodule R n).coact w)) ∈ N :=
     N.rid_lTensor_coact_mem q.ofConv.toLinearMap hw
-  change
-    TensorProduct.rid R (Fin n → R)
-        (LinearMap.lTensor (Fin n → R) q.ofConv.toLinearMap
-          (Comodule.corestrictCoact (coordinateMap R n).hom.toCoalgHom w)) ∈ N at h
+  rw [standardComodule_coact_eq_corestrictCoact R n] at h
   rw [CommHopfAlgCat.hom_mkQuotient] at h
   rw [standardComodule_coact R n, LinearMap.comp_apply] at h
   have hcoordinate :

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
@@ -68,23 +68,31 @@ noncomputable def standardComodule :
 
 attribute [local instance] GeneralLinear.standardComodule standardComodule
 
-/-- The standard `SL_n` coaction is the standard `GL_n` coaction followed by the quotient map on
-the coordinate factor. -/
-@[simp]
-theorem standardComodule_coact :
+private theorem standardComodule_corestrictCoact :
+    let _ := GeneralLinear.standardComodule R n
     Comodule.corestrictCoact
         (R := R) (C := GeneralLinear.coordinateHopfAlgebra R n)
         (D := coordinateHopfAlgebra R n) (M := Fin n → R)
-        (Bialgebra.Quotient.mkBialgHom (R := R)
-          (definingHopfIdeal R n).toIdeal).toCoalgHom =
+        (coordinateMap R n).hom.toCoalgHom =
       TensorProduct.map LinearMap.id
           (Bialgebra.Quotient.mkBialgHom (R := R)
             (definingHopfIdeal R n).toIdeal).toLinearMap ∘ₗ
         GeneralLinear.standardCoact R n := by
   apply LinearMap.ext
   intro v
-  rw [LinearMap.comp_apply, Comodule.corestrictCoact_apply,
-    GeneralLinear.standardComodule_coact]
+  rw [Comodule.corestrictCoact_apply, LinearMap.comp_apply,
+    GeneralLinear.standardComodule_coact, CommHopfAlgCat.hom_mkQuotient]
+
+/-- The standard `SL_n` coaction is the standard `GL_n` coaction followed by the quotient map on
+the coordinate factor. -/
+@[simp]
+theorem standardComodule_coact :
+    (standardComodule R n).coact =
+      TensorProduct.map LinearMap.id
+          (Bialgebra.Quotient.mkBialgHom (R := R)
+            (definingHopfIdeal R n).toIdeal).toLinearMap ∘ₗ
+        GeneralLinear.standardCoact R n :=
+  standardComodule_corestrictCoact R n
 
 /-- **The standard comodule of `SL_n` is faithful.** -/
 theorem isFaithful_standardComodule :
@@ -146,11 +154,12 @@ theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
     (g : Matrix.SpecialLinearGroup (Fin n) R) {w : Fin n → R} (hw : w ∈ N) :
     (g : Matrix (Fin n) (Fin n) R) *ᵥ w ∈ N := by
   let q := (pointsMulEquiv (R := R) (A := R) n).symm g
-  have h := N.rid_lTensor_coact_mem q.ofConv.toLinearMap hw
-  rw [Comodule.corestrict_coact,
-    CommHopfAlgCat.hom_mkQuotient (GeneralLinear.coordinateHopfAlgebra R n)
-      (definingHopfIdeal R n),
-    standardComodule_coact R n, LinearMap.comp_apply] at h
+  have h :
+      TensorProduct.rid R (Fin n → R)
+          (LinearMap.lTensor (Fin n → R) q.ofConv.toLinearMap
+            ((standardComodule R n).coact w)) ∈ N :=
+    N.rid_lTensor_coact_mem q.ofConv.toLinearMap hw
+  rw [standardComodule_coact R n, LinearMap.comp_apply] at h
   have hcoordinate :
       (Bialgebra.Quotient.mkBialgHom
           (R := R) (definingHopfIdeal R n).toIdeal).toCoalgHom.toLinearMap =
@@ -253,20 +262,20 @@ private theorem exists_specialLinearGroup_mulVec {v w : Fin m → k} (hm : 2 ≤
 /-- **The standard comodule of `SL_m` over a field is simple** for `m ≠ 0`: its only
 subcomodules are the zero comodule and the whole column space. -/
 instance instIsSimpleOrderSubcomodule :
-    IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) where
-  exists_pair_ne := by
-    refine ⟨⊥, ⊤, fun h ↦ ?_⟩
-    have hone : (Pi.single (0 : Fin m) (1 : k) : Fin m → k) ∈
-        (⊥ : Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) :=
-      h ▸ Subcomodule.mem_top _
-    rw [Subcomodule.mem_bot] at hone
-    simpa using congrFun hone (0 : Fin m)
-  eq_bot_or_eq_top N := by
-    by_cases hm : m = 1
-    · have hfin : Module.finrank k (Fin m → k) = 1 := by
-        rw [Module.finrank_pi k, Fintype.card_fin, hm]
-      let hsimple : IsSimpleOrder (Submodule k (Fin m → k)) :=
-        is_simple_module_of_finrank_eq_one hfin
+    IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) := by
+  by_cases hm : m = 1
+  · have hfin : Module.finrank k (Fin m → k) = 1 := by
+      rw [Module.finrank_pi k, Fintype.card_fin, hm]
+    let hsimple : IsSimpleOrder (Submodule k (Fin m → k)) :=
+      is_simple_module_of_finrank_eq_one hfin
+    refine { exists_pair_ne := ?_, eq_bot_or_eq_top := ?_ }
+    · refine ⟨⊥, ⊤, fun h ↦ ?_⟩
+      have hone : (Pi.single (0 : Fin m) (1 : k) : Fin m → k) ∈
+          (⊥ : Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) :=
+        h ▸ Subcomodule.mem_top _
+      rw [Subcomodule.mem_bot] at hone
+      simpa using congrFun hone (0 : Fin m)
+    · intro N
       rcases hsimple.eq_bot_or_eq_top N.toSubmodule with hN | hN
       · left
         exact Subcomodule.ext fun x ↦ by
@@ -278,22 +287,17 @@ instance instIsSimpleOrderSubcomodule :
           have hx : x ∈ N.toSubmodule ↔ x ∈ (⊤ : Submodule k (Fin m → k)) :=
             SetLike.ext_iff.mp hN x
           exact hx
-    · have hm2 : 2 ≤ m := by
-        have hm0 : m ≠ 0 := NeZero.ne m
-        omega
-      by_cases hN : ∀ w ∈ N, w = 0
-      · left
-        exact Subcomodule.ext fun w ↦
-          ⟨fun hw ↦ Subcomodule.mem_bot.mpr (hN w hw),
-            fun hw ↦ Subcomodule.mem_bot.mp hw ▸ zero_mem N⟩
-      · right
-        simp only [not_forall] at hN
-        obtain ⟨w, hwN, hw⟩ := hN
-        refine Subcomodule.ext fun v ↦ ⟨fun _ ↦ Subcomodule.mem_top v, fun _ ↦ ?_⟩
-        by_cases hv : v = 0
-        · exact hv ▸ zero_mem N
-        · obtain ⟨g, hg⟩ := exists_specialLinearGroup_mulVec k m hm2 hv hw
-          exact hg ▸ mulVec_mem k m N g hwN
+  · have hm2 : 2 ≤ m := by
+      have hm0 : m ≠ 0 := NeZero.ne m
+      omega
+    refine Subcomodule.isSimpleOrder_of_transitive
+      (Pi.single (0 : Fin m) (1 : k) : Fin m → k) ?_
+      (fun (g : Matrix.SpecialLinearGroup (Fin m) k) w ↦
+        (g : Matrix (Fin m) (Fin m) k) *ᵥ w) ?_ ?_
+    · intro h
+      simpa using congrFun h (0 : Fin m)
+    · exact fun hv hw ↦ exists_specialLinearGroup_mulVec k m hm2 hv hw
+    · exact fun N g _ hw ↦ mulVec_mem k m N g hw
 
 end Simple
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
@@ -68,16 +68,6 @@ noncomputable def standardComodule :
 
 attribute [local instance] GeneralLinear.standardComodule standardComodule
 
-/-- The standard `SL_n` coaction is the standard `GL_n` coaction followed by the quotient map on
-the coordinate factor. -/
-@[simp]
-theorem standardComodule_coact_apply (v : Fin n → R) :
-    Comodule.coact (R := R) (C := coordinateHopfAlgebra R n) v =
-      TensorProduct.map LinearMap.id (coordinateMap R n).hom.toLinearMap
-        (GeneralLinear.standardCoact R n v) :=
-  by
-    rw [Comodule.corestrict_coact_apply, GeneralLinear.standardComodule_coact]
-
 /-- **The standard comodule of `SL_n` is faithful.** -/
 theorem isFaithful_standardComodule :
     Comodule.IsFaithful (k := R) (H := coordinateHopfAlgebra R n) (V := Fin n → R) := by
@@ -139,7 +129,7 @@ theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
     (g : Matrix (Fin n) (Fin n) R) *ᵥ w ∈ N := by
   let q := (pointsMulEquiv (R := R) (A := R) n).symm g
   have h := N.rid_lTensor_coact_mem q.ofConv.toLinearMap hw
-  rw [standardComodule_coact_apply R n] at h
+  rw [Comodule.corestrict_coact_apply, GeneralLinear.standardComodule_coact] at h
   have hcoordinate : (coordinateMap R n).hom.toCoalgHom.toLinearMap =
       ((coordinateMap R n).hom :
         GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] coordinateHopfAlgebra R n).toLinearMap :=

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
@@ -1,0 +1,285 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
+import Mathlib.LinearAlgebra.Transvection.Basic
+
+/-!
+# The standard representation of the special linear group
+
+The standard representation of `SL_n` is obtained by restricting the standard representation of
+`GL_n` along the determinant-one closed immersion. In coordinate algebras, this is corestriction
+of the standard `O(GL_n)`-comodule along the quotient map
+
+```text
+O(GL_n) ⟶ O(SL_n).
+```
+
+This representation is faithful in every rank. Over a field it is simple in every positive rank.
+For `n ≥ 2`, the special linear group acts transitively on nonzero column vectors, so a nonzero
+invariant subspace contains every nonzero vector; rank one follows from one-dimensional submodule
+theory.
+
+## Main declarations
+
+* `TauCeti.SpecialLinear.standardComodule`: the standard `O(SL_n)`-comodule on `R^n`.
+* `TauCeti.SpecialLinear.isFaithful_standardComodule`: the standard representation is faithful.
+* `TauCeti.SpecialLinear.mulVec_mem`: a standard subcomodule is stable under every determinant-one
+  matrix.
+* `TauCeti.SpecialLinear.instIsSimpleOrderSubcomodule`: over a field, the standard comodule is
+  simple in every positive rank.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §4.a.
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+
+The construction and the invariant-subspace argument extend
+`TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule`; the determinant-correction step
+is new here.
+
+Faithfulness and simplicity are the representation-theoretic inputs for proving that `SL_n` is
+reductive, one of the worked examples accompanying Layer 6 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open Module WithConv
+open scoped Matrix TensorProduct
+
+namespace TauCeti.SpecialLinear
+
+universe u
+
+variable (R : Type u) [CommRing R] (n : ℕ)
+
+/-- The standard right comodule of the special linear coordinate Hopf algebra, obtained by
+corestricting the standard `GL_n`-comodule along the determinant-one quotient map. -/
+@[instance_reducible]
+noncomputable def standardComodule :
+    Comodule R (coordinateHopfAlgebra R n) (Fin n → R) :=
+  let _ := GeneralLinear.standardComodule R n
+  Comodule.Corestrict (coordinateMap R n).hom.toCoalgHom
+
+attribute [local instance] GeneralLinear.standardComodule standardComodule
+
+/-- The standard `SL_n` coaction is the standard `GL_n` coaction followed by the quotient map on
+the coordinate factor. -/
+@[simp]
+theorem standardComodule_coact_apply (v : Fin n → R) :
+    Comodule.coact (R := R) (C := coordinateHopfAlgebra R n) v =
+      TensorProduct.map LinearMap.id (coordinateMap R n).hom.toLinearMap
+        (GeneralLinear.standardCoact R n v) :=
+  by
+    rw [Comodule.corestrict_coact_apply, GeneralLinear.standardComodule_coact]
+
+/-- **The standard comodule of `SL_n` is faithful.** -/
+theorem isFaithful_standardComodule :
+    Comodule.IsFaithful (k := R) (H := coordinateHopfAlgebra R n) (V := Fin n → R) := by
+  exact Comodule.isFaithful_corestrict_of_surjective (coordinateMap R n).hom
+    (CommHopfAlgCat.mkQuotient_surjective
+      (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n))
+    (GeneralLinear.isFaithful_standardComodule R n)
+
+section PointAction
+
+variable {A : Type*} [CommRing A] [Algebra R A]
+
+/-- Under the canonical scalar-extension identification `A ⊗[R] R^n ≃ A^n`, a point of
+`SL_n` acts on the standard comodule by multiplication with its determinant-one matrix. -/
+theorem piScalarRight_comp_endOfPoint
+    (g : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    (TensorProduct.piScalarRight R A A (Fin n)).toLinearMap.comp
+        (Comodule.endOfPoint (Fin n → R) g.ofConv) =
+      (Matrix.GeneralLinearGroup.toLin
+          (Matrix.SpecialLinearGroup.toGL
+            ((pointsMulEquiv (R := R) (A := A) n) g)) :
+          (Fin n → A) →ₗ[A] Fin n → A).comp
+        (TensorProduct.piScalarRight R A A (Fin n)).toLinearMap := by
+  rw [Comodule.endOfPoint_corestrict]
+  have hpoint :
+      g.ofConv.comp ((coordinateMap R n).hom :
+        GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] coordinateHopfAlgebra R n) =
+        (CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n)
+          (CommAlgCat.of R A) g).ofConv := by
+    rw [CommHopfAlgCat.quotientPointsHom_apply]
+  rw [hpoint]
+  let q := CommHopfAlgCat.quotientPointsHom
+    (GeneralLinear.coordinateHopfAlgebra R n) (definingHopfIdeal R n)
+    (CommAlgCat.of R A) g
+  have hmatrix : GeneralLinear.pointToGeneralLinear n q =
+      Matrix.SpecialLinearGroup.toGL ((pointsMulEquiv (R := R) (A := A) n) g) := by
+    rw [← GeneralLinear.pointsMulEquiv_apply, pointsMulEquiv_toGL]
+  rw [← hmatrix]
+  exact GeneralLinear.piScalarRight_comp_endOfPoint R n q
+
+end PointAction
+
+private theorem piScalarRight_comm_eq_rid
+    (t : (Fin n → R) ⊗[R] R) :
+    TensorProduct.piScalarRightHom R R R (Fin n) (TensorProduct.comm R (Fin n → R) R t) =
+      TensorProduct.rid R (Fin n → R) t := by
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | tmul v r =>
+      ext i
+      simp [TensorProduct.piScalarRightHom_tmul, mul_comm]
+  | add x y hx hy => simpa only [map_add] using congrArg₂ (fun a b ↦ a + b) hx hy
+
+/-- **A subcomodule of the standard comodule of `SL_n` is stable under every determinant-one
+matrix.** -/
+theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
+    (g : Matrix.SpecialLinearGroup (Fin n) R) {w : Fin n → R} (hw : w ∈ N) :
+    (g : Matrix (Fin n) (Fin n) R) *ᵥ w ∈ N := by
+  let q := (pointsMulEquiv (R := R) (A := R) n).symm g
+  have h := N.rid_lTensor_coact_mem q.ofConv.toLinearMap hw
+  rw [standardComodule_coact_apply R n] at h
+  have hcoordinate : (coordinateMap R n).hom.toCoalgHom.toLinearMap =
+      ((coordinateMap R n).hom :
+        GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] coordinateHopfAlgebra R n).toLinearMap :=
+    (_root_.BialgHom.toAlgHom_toLinearMap (coordinateMap R n).hom).symm
+  rw [hcoordinate] at h
+  have h' :
+      TensorProduct.piScalarRight R R R (Fin n)
+          (Comodule.endOfPoint (Fin n → R) q.ofConv (1 ⊗ₜ[R] w)) ∈ N := by
+    simpa [Comodule.endOfPoint_tmul, TensorProduct.piScalarRight_apply,
+      piScalarRight_comm_eq_rid, LinearMap.lTensor_def, TensorProduct.map_map] using h
+  have haction := DFunLike.congr_fun (piScalarRight_comp_endOfPoint R n q) (1 ⊗ₜ[R] w)
+  simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, Matrix.GeneralLinearGroup.toLin_apply,
+    Matrix.mulVecLin_apply] at haction
+  rw [haction] at h'
+  rw [MulEquiv.apply_symm_apply] at h'
+  simpa only [Matrix.SpecialLinearGroup.coe_GL_coe_matrix,
+    TensorProduct.piScalarRight_apply, TensorProduct.piScalarRightHom_tmul, smul_eq_mul,
+    mul_one] using h'
+
+section Simple
+
+variable (k : Type u) [Field k] (m : ℕ) [NeZero m]
+
+omit [NeZero m] in
+/-- For `m ≥ 2`, every nonzero vector of `k^m` is the image of every other one under a
+determinant-one matrix. -/
+private theorem exists_specialLinearGroup_mulVec {v w : Fin m → k} (hm : 2 ≤ m)
+    (hv : v ≠ 0) (hw : w ≠ 0) :
+    ∃ g : Matrix.SpecialLinearGroup (Fin m) k,
+      (g : Matrix (Fin m) (Fin m) k) *ᵥ w = v := by
+  -- First extend the equivalence between the two lines to an arbitrary ambient equivalence.
+  let e : (k ∙ w) ≃ₗ[k] (k ∙ v) :=
+    (LinearEquiv.toSpanNonzeroSingleton k (Fin m → k) w hw).symm.trans
+      (LinearEquiv.toSpanNonzeroSingleton k (Fin m → k) v hv)
+  obtain ⟨φ, hφ⟩ := Submodule.exists_linearEquiv_restrict_eq e
+  have hφw : φ w = v := by
+    have hone := hφ ⟨w, Submodule.mem_span_singleton_self w⟩
+    have he : e ⟨w, Submodule.mem_span_singleton_self w⟩ =
+        ⟨v, Submodule.mem_span_singleton_self v⟩ := by
+      simp only [e, LinearEquiv.trans_apply]
+      rw [LinearEquiv.coord_self k (Fin m → k) w hw]
+      exact LinearEquiv.toSpanNonzeroSingleton_one k (Fin m → k) v hv
+    rw [he] at hone
+    exact hone.symm
+  -- A second direction modulo `k · v` gives a rank-one correction that fixes `v` and has
+  -- determinant inverse to that of `φ`.
+  have hspan : k ∙ v ≠ ⊤ := by
+    intro htop
+    have hfin := congrArg
+      (fun S : Submodule k (Fin m → k) ↦ Module.finrank k S) htop
+    rw [finrank_span_singleton hv, finrank_top, Module.finrank_pi k] at hfin
+    simp only [Fintype.card_fin] at hfin
+    omega
+  obtain ⟨z, hz⟩ := SetLike.exists_not_mem_of_ne_top (k ∙ v) hspan rfl
+  obtain ⟨f, hfz, hfspan⟩ :=
+    Submodule.exists_dual_map_eq_bot_of_notMem hz inferInstance
+  have hfv : f v = 0 := by
+    have hvmap : f v ∈ (k ∙ v).map f :=
+      ⟨v, Submodule.mem_span_singleton_self v, rfl⟩
+    rw [hfspan, Submodule.mem_bot] at hvmap
+    exact hvmap
+  let f' : Module.Dual k (Fin m → k) := (f z)⁻¹ • f
+  have hf'z : f' z = 1 := by
+    simp [f', hfz]
+  have hf'v : f' v = 0 := by
+    simp [f', hfv]
+  let d := LinearEquiv.det φ
+  let z' : Fin m → k := ((↑d⁻¹ : k) - 1) • z
+  have hf'z' : f' z' = (↑d⁻¹ : k) - 1 := by
+    simp [z', hf'z]
+  have hunit : IsUnit (1 + f' z') := by
+    rw [hf'z']
+    have heq : 1 + ((↑d⁻¹ : k) - 1) = (↑d⁻¹ : k) := by ring
+    rw [heq]
+    exact Units.isUnit _
+  let ψ : (Fin m → k) ≃ₗ[k] (Fin m → k) := LinearEquiv.dilatransvection hunit
+  have hψv : ψ v = v := by
+    rw [LinearEquiv.dilatransvection.apply]
+    simp [hf'v]
+  have hψdet : LinearEquiv.det ψ = d⁻¹ := by
+    apply Units.ext
+    rw [LinearEquiv.coe_det]
+    change LinearMap.det (LinearMap.transvection f' z') = _
+    rw [LinearMap.transvection.det, hf'z']
+    simp
+  let θ := ψ * φ
+  have hθdet : LinearEquiv.det θ = 1 := by
+    simp [θ, hψdet, d]
+  have hθw : θ w = v := by
+    simp [θ, hφw, hψv]
+  -- Read the corrected equivalence as a determinant-one matrix.
+  refine ⟨⟨LinearMap.toMatrix' (θ : (Fin m → k) →ₗ[k] Fin m → k), ?_⟩, ?_⟩
+  · rw [LinearMap.det_toMatrix', ← LinearEquiv.coe_det, hθdet]
+    rfl
+  · rw [← Matrix.toLin'_apply, Matrix.toLin'_toMatrix']
+    exact hθw
+
+/-- **The standard comodule of `SL_m` over a field is simple** for `m ≠ 0`: its only
+subcomodules are the zero comodule and the whole column space. -/
+instance instIsSimpleOrderSubcomodule :
+    IsSimpleOrder (Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) where
+  exists_pair_ne := by
+    refine ⟨⊥, ⊤, fun h ↦ ?_⟩
+    have hone : (Pi.single (0 : Fin m) (1 : k) : Fin m → k) ∈
+        (⊥ : Subcomodule k (coordinateHopfAlgebra k m) (Fin m → k)) :=
+      h ▸ Subcomodule.mem_top _
+    rw [Subcomodule.mem_bot] at hone
+    simpa using congrFun hone (0 : Fin m)
+  eq_bot_or_eq_top N := by
+    by_cases hm : m = 1
+    · have hfin : Module.finrank k (Fin m → k) = 1 := by
+        rw [Module.finrank_pi k, Fintype.card_fin, hm]
+      let hsimple : IsSimpleOrder (Submodule k (Fin m → k)) :=
+        is_simple_module_of_finrank_eq_one hfin
+      rcases hsimple.eq_bot_or_eq_top N.toSubmodule with hN | hN
+      · left
+        exact Subcomodule.ext fun x ↦ by
+          change x ∈ N.toSubmodule ↔ x ∈ (⊥ : Submodule k (Fin m → k))
+          rw [hN]
+      · right
+        exact Subcomodule.ext fun x ↦ by
+          change x ∈ N.toSubmodule ↔ x ∈ (⊤ : Submodule k (Fin m → k))
+          rw [hN]
+    · have hm2 : 2 ≤ m := by
+        have hm0 : m ≠ 0 := NeZero.ne m
+        omega
+      by_cases hN : ∀ w ∈ N, w = 0
+      · left
+        exact Subcomodule.ext fun w ↦
+          ⟨fun hw ↦ Subcomodule.mem_bot.mpr (hN w hw),
+            fun hw ↦ Subcomodule.mem_bot.mp hw ▸ zero_mem N⟩
+      · right
+        simp only [not_forall] at hN
+        obtain ⟨w, hwN, hw⟩ := hN
+        refine Subcomodule.ext fun v ↦ ⟨fun _ ↦ Subcomodule.mem_top v, fun _ ↦ ?_⟩
+        by_cases hv : v = 0
+        · exact hv ▸ zero_mem N
+        · obtain ⟨g, hg⟩ := exists_specialLinearGroup_mulVec k m hm2 hv hw
+          exact hg ▸ mulVec_mem k m N g hwN
+
+end Simple
+
+end TauCeti.SpecialLinear

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
@@ -72,12 +72,18 @@ attribute [local instance] GeneralLinear.standardComodule standardComodule
 the coordinate factor. -/
 @[simp]
 theorem standardComodule_coact :
-    (standardComodule R n).coact =
-      TensorProduct.map LinearMap.id (coordinateMap R n).hom.toLinearMap ∘ₗ
+    Comodule.corestrictCoact
+        (R := R) (C := GeneralLinear.coordinateHopfAlgebra R n)
+        (D := coordinateHopfAlgebra R n) (M := Fin n → R)
+        (Bialgebra.Quotient.mkBialgHom (R := R)
+          (definingHopfIdeal R n).toIdeal).toCoalgHom =
+      TensorProduct.map LinearMap.id
+          (Bialgebra.Quotient.mkBialgHom (R := R)
+            (definingHopfIdeal R n).toIdeal).toLinearMap ∘ₗ
         GeneralLinear.standardCoact R n := by
   apply LinearMap.ext
   intro v
-  rw [LinearMap.comp_apply, Comodule.corestrict_coact_apply,
+  rw [LinearMap.comp_apply, Comodule.corestrictCoact_apply,
     GeneralLinear.standardComodule_coact]
 
 /-- **The standard comodule of `SL_n` is faithful.** -/
@@ -141,11 +147,17 @@ theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
     (g : Matrix (Fin n) (Fin n) R) *ᵥ w ∈ N := by
   let q := (pointsMulEquiv (R := R) (A := R) n).symm g
   have h := N.rid_lTensor_coact_mem q.ofConv.toLinearMap hw
-  rw [standardComodule_coact R n, LinearMap.comp_apply] at h
-  have hcoordinate : (coordinateMap R n).hom.toCoalgHom.toLinearMap =
-      ((coordinateMap R n).hom :
-        GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] coordinateHopfAlgebra R n).toLinearMap :=
-    (_root_.BialgHom.toAlgHom_toLinearMap (coordinateMap R n).hom).symm
+  rw [Comodule.corestrict_coact,
+    CommHopfAlgCat.hom_mkQuotient (GeneralLinear.coordinateHopfAlgebra R n)
+      (definingHopfIdeal R n),
+    standardComodule_coact R n, LinearMap.comp_apply] at h
+  have hcoordinate :
+      (Bialgebra.Quotient.mkBialgHom
+          (R := R) (definingHopfIdeal R n).toIdeal).toCoalgHom.toLinearMap =
+        (Bialgebra.Quotient.mkBialgHom
+          (R := R) (definingHopfIdeal R n).toIdeal).toAlgHom.toLinearMap :=
+    (_root_.BialgHom.toAlgHom_toLinearMap
+      (Bialgebra.Quotient.mkBialgHom (R := R) (definingHopfIdeal R n).toIdeal)).symm
   rw [hcoordinate] at h
   have h' :
       TensorProduct.piScalarRight R R R (Fin n)

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean
@@ -68,6 +68,18 @@ noncomputable def standardComodule :
 
 attribute [local instance] GeneralLinear.standardComodule standardComodule
 
+/-- The standard `SL_n` coaction is the standard `GL_n` coaction followed by the quotient map on
+the coordinate factor. -/
+@[simp]
+theorem standardComodule_coact :
+    (standardComodule R n).coact =
+      TensorProduct.map LinearMap.id (coordinateMap R n).hom.toLinearMap ∘ₗ
+        GeneralLinear.standardCoact R n := by
+  apply LinearMap.ext
+  intro v
+  rw [LinearMap.comp_apply, Comodule.corestrict_coact_apply,
+    GeneralLinear.standardComodule_coact]
+
 /-- **The standard comodule of `SL_n` is faithful.** -/
 theorem isFaithful_standardComodule :
     Comodule.IsFaithful (k := R) (H := coordinateHopfAlgebra R n) (V := Fin n → R) := by
@@ -129,7 +141,7 @@ theorem mulVec_mem (N : Subcomodule R (coordinateHopfAlgebra R n) (Fin n → R))
     (g : Matrix (Fin n) (Fin n) R) *ᵥ w ∈ N := by
   let q := (pointsMulEquiv (R := R) (A := R) n).symm g
   have h := N.rid_lTensor_coact_mem q.ofConv.toLinearMap hw
-  rw [Comodule.corestrict_coact_apply, GeneralLinear.standardComodule_coact] at h
+  rw [standardComodule_coact R n, LinearMap.comp_apply] at h
   have hcoordinate : (coordinateMap R n).hom.toCoalgHom.toLinearMap =
       ((coordinateMap R n).hom :
         GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] coordinateHopfAlgebra R n).toLinearMap :=
@@ -212,8 +224,7 @@ private theorem exists_specialLinearGroup_mulVec {v w : Fin m → k} (hm : 2 ≤
   have hψdet : LinearEquiv.det ψ = d⁻¹ := by
     apply Units.ext
     rw [LinearEquiv.coe_det]
-    change LinearMap.det (LinearMap.transvection f' z') = _
-    rw [LinearMap.transvection.det, hf'z']
+    rw [LinearEquiv.dilatransvection.coe_toLinearMap, LinearMap.transvection.det, hf'z']
     simp
   let θ := ψ * φ
   have hθdet : LinearEquiv.det θ = 1 := by
@@ -247,12 +258,14 @@ instance instIsSimpleOrderSubcomodule :
       rcases hsimple.eq_bot_or_eq_top N.toSubmodule with hN | hN
       · left
         exact Subcomodule.ext fun x ↦ by
-          change x ∈ N.toSubmodule ↔ x ∈ (⊥ : Submodule k (Fin m → k))
-          rw [hN]
+          have hx : x ∈ N.toSubmodule ↔ x ∈ (⊥ : Submodule k (Fin m → k)) :=
+            SetLike.ext_iff.mp hN x
+          exact hx
       · right
         exact Subcomodule.ext fun x ↦ by
-          change x ∈ N.toSubmodule ↔ x ∈ (⊤ : Submodule k (Fin m → k))
-          rw [hN]
+          have hx : x ∈ N.toSubmodule ↔ x ∈ (⊤ : Submodule k (Fin m → k)) :=
+            SetLike.ext_iff.mp hN x
+          exact hx
     · have hm2 : 2 ≤ m := by
         have hm0 : m ≠ 0 := NeZero.ne m
         omega

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
@@ -34,6 +34,8 @@ subcomodules and the fundamental theorem of comodules. Later work can use
   underlying submodule detects the extreme subcomodules.
 * `TauCeti.Subcomodule.ne_bot_iff`: a subcomodule is nonzero exactly when it contains a nonzero
   vector.
+* `TauCeti.Subcomodule.isSimpleOrder_of_transitive`: a family of maps that preserves every
+  subcomodule and acts transitively on nonzero vectors makes the subcomodule lattice simple.
 * `TauCeti.Subcomodule.map`: the image of a subcomodule under a comodule morphism.
 * `TauCeti.Subcomodule.map_finite`: images preserve finite generation of the underlying
   submodule.
@@ -253,8 +255,32 @@ theorem toSubmodule_eq_bot {N : Subcomodule R C M} : N.toSubmodule = ⊥ ↔ N =
 theorem ne_bot_iff {N : Subcomodule R C M} : N ≠ ⊥ ↔ ∃ m ∈ N, m ≠ 0 :=
   (not_congr toSubmodule_eq_bot).symm.trans (Submodule.ne_bot_iff N.toSubmodule)
 
+/-- If a family of maps preserves every subcomodule and acts transitively on nonzero vectors,
+then the subcomodule lattice is simple. -/
+theorem isSimpleOrder_of_transitive {G : Type x} (v₀ : M) (hv₀ : v₀ ≠ 0)
+    (act : G → M → M)
+    (htrans : ∀ {v w : M}, v ≠ 0 → w ≠ 0 → ∃ g, act g w = v)
+    (hmem : ∀ (N : Subcomodule R C M) (g : G) {w : M}, w ∈ N → act g w ∈ N) :
+    IsSimpleOrder (Subcomodule R C M) where
+  exists_pair_ne := by
+    refine ⟨⊥, ⊤, fun h ↦ hv₀ ?_⟩
+    exact mem_bot.mp (h ▸ mem_top v₀)
+  eq_bot_or_eq_top N := by
+    by_cases hN : N = ⊥
+    · exact Or.inl hN
+    · right
+      obtain ⟨w, hwN, hw⟩ := ne_bot_iff.mp hN
+      apply Subcomodule.ext
+      intro v
+      refine ⟨fun _ ↦ mem_top v, fun _ ↦ ?_⟩
+      by_cases hv : v = 0
+      · exact hv ▸ zero_mem N
+      · obtain ⟨g, hg⟩ := htrans hv hw
+        exact hg ▸ hmem N g hwN
+
 variable {N : Type x} [AddCommMonoid N] [Module R N] [Comodule R C N]
 
+/-- The restriction of a comodule morphism from a subcomodule to its image submodule. -/
 private def mapSubtype (f : Comodule.Hom R C M N) (A : Subcomodule R C M) :
     A.carrier →ₗ[R] A.carrier.map f.toLinearMap where
   toFun a := ⟨f a, Submodule.mem_map_of_mem a.2⟩

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
@@ -280,24 +280,6 @@ theorem isSimpleOrder_of_transitive {G : Type x} (v₀ : M) (hv₀ : v₀ ≠ 0)
 
 variable {N : Type x} [AddCommMonoid N] [Module R N] [Comodule R C N]
 
-/-- The restriction of a comodule morphism from a subcomodule to its image submodule. -/
-private def mapSubtype (f : Comodule.Hom R C M N) (A : Subcomodule R C M) :
-    A.carrier →ₗ[R] A.carrier.map f.toLinearMap where
-  toFun a := ⟨f a, Submodule.mem_map_of_mem a.2⟩
-  map_add' a b := Subtype.ext (map_add f.toLinearMap (a : M) (b : M))
-  map_smul' r a := Subtype.ext (map_smul f.toLinearMap r (a : M))
-
-private theorem image_tensor_apply (f : Comodule.Hom R C M N) (A : Subcomodule R C M)
-    (t : A.carrier ⊗[R] C) :
-    TensorProduct.map (A.carrier.map f.toLinearMap).subtype (LinearMap.id : C →ₗ[R] C)
-        (TensorProduct.map (mapSubtype f A) (LinearMap.id : C →ₗ[R] C) t) =
-      TensorProduct.map f.toLinearMap (LinearMap.id : C →ₗ[R] C)
-        (TensorProduct.map A.carrier.subtype (LinearMap.id : C →ₗ[R] C) t) := by
-  induction t with
-  | zero => simp only [map_zero]
-  | tmul a c => rfl
-  | add x y hx hy => simp only [map_add, hx, hy]
-
 /-- The image of a subcomodule under a comodule morphism. -/
 @[expose] def map (A : Subcomodule R C M) (f : Comodule.Hom R C M N) : Subcomodule R C N where
   carrier := A.carrier.map f.toLinearMap
@@ -305,8 +287,22 @@ private theorem image_tensor_apply (f : Comodule.Hom R C M N) (A : Subcomodule R
     intro n hn
     rcases Submodule.mem_map.mp hn with ⟨m, hm, rfl⟩
     rcases A.coact_mem hm with ⟨t, ht⟩
-    refine ⟨TensorProduct.map (mapSubtype f A) (LinearMap.id : C →ₗ[R] C) t, ?_⟩
-    rw [image_tensor_apply, ht]
+    let g : A.carrier →ₗ[R] A.carrier.map f.toLinearMap :=
+      { toFun := fun a ↦ ⟨f a, Submodule.mem_map_of_mem a.2⟩
+        map_add' := fun a b ↦ Subtype.ext (map_add f.toLinearMap (a : M) (b : M))
+        map_smul' := fun r a ↦ Subtype.ext (map_smul f.toLinearMap r (a : M)) }
+    refine ⟨TensorProduct.map g (LinearMap.id : C →ₗ[R] C) t, ?_⟩
+    have hmap :
+        TensorProduct.map (A.carrier.map f.toLinearMap).subtype (LinearMap.id : C →ₗ[R] C)
+            (TensorProduct.map g (LinearMap.id : C →ₗ[R] C) t) =
+          TensorProduct.map f.toLinearMap (LinearMap.id : C →ₗ[R] C)
+            (TensorProduct.map A.carrier.subtype (LinearMap.id : C →ₗ[R] C) t) := by
+      clear ht
+      induction t with
+      | zero => simp only [map_zero]
+      | tmul a c => rfl
+      | add x y hx hy => simp only [map_add, hx, hy]
+    rw [hmap, ht]
     exact Comodule.Hom.map_coact_apply f m
 
 /-- The underlying submodule of the image subcomodule is the image of the underlying

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Basic.lean
@@ -280,6 +280,24 @@ theorem isSimpleOrder_of_transitive {G : Type x} (v₀ : M) (hv₀ : v₀ ≠ 0)
 
 variable {N : Type x} [AddCommMonoid N] [Module R N] [Comodule R C N]
 
+/-- The linear map between subtype modules induced by a comodule morphism. -/
+private def mapSubtype (f : Comodule.Hom R C M N) (A : Subcomodule R C M) :
+    A.carrier →ₗ[R] A.carrier.map f.toLinearMap where
+  toFun a := ⟨f a, Submodule.mem_map_of_mem a.2⟩
+  map_add' a b := Subtype.ext (map_add f.toLinearMap (a : M) (b : M))
+  map_smul' r a := Subtype.ext (map_smul f.toLinearMap r (a : M))
+
+private theorem image_tensor_apply (f : Comodule.Hom R C M N) (A : Subcomodule R C M)
+    (t : A.carrier ⊗[R] C) :
+    TensorProduct.map (A.carrier.map f.toLinearMap).subtype (LinearMap.id : C →ₗ[R] C)
+        (TensorProduct.map (mapSubtype f A) (LinearMap.id : C →ₗ[R] C) t) =
+      TensorProduct.map f.toLinearMap (LinearMap.id : C →ₗ[R] C)
+        (TensorProduct.map A.carrier.subtype (LinearMap.id : C →ₗ[R] C) t) := by
+  induction t with
+  | zero => simp only [map_zero]
+  | tmul a c => rfl
+  | add x y hx hy => simp only [map_add, hx, hy]
+
 /-- The image of a subcomodule under a comodule morphism. -/
 @[expose] def map (A : Subcomodule R C M) (f : Comodule.Hom R C M N) : Subcomodule R C N where
   carrier := A.carrier.map f.toLinearMap
@@ -287,22 +305,8 @@ variable {N : Type x} [AddCommMonoid N] [Module R N] [Comodule R C N]
     intro n hn
     rcases Submodule.mem_map.mp hn with ⟨m, hm, rfl⟩
     rcases A.coact_mem hm with ⟨t, ht⟩
-    let g : A.carrier →ₗ[R] A.carrier.map f.toLinearMap :=
-      { toFun := fun a ↦ ⟨f a, Submodule.mem_map_of_mem a.2⟩
-        map_add' := fun a b ↦ Subtype.ext (map_add f.toLinearMap (a : M) (b : M))
-        map_smul' := fun r a ↦ Subtype.ext (map_smul f.toLinearMap r (a : M)) }
-    refine ⟨TensorProduct.map g (LinearMap.id : C →ₗ[R] C) t, ?_⟩
-    have hmap :
-        TensorProduct.map (A.carrier.map f.toLinearMap).subtype (LinearMap.id : C →ₗ[R] C)
-            (TensorProduct.map g (LinearMap.id : C →ₗ[R] C) t) =
-          TensorProduct.map f.toLinearMap (LinearMap.id : C →ₗ[R] C)
-            (TensorProduct.map A.carrier.subtype (LinearMap.id : C →ₗ[R] C) t) := by
-      clear ht
-      induction t with
-      | zero => simp only [map_zero]
-      | tmul a c => rfl
-      | add x y hx hy => simp only [map_add, hx, hy]
-    rw [hmap, ht]
+    refine ⟨TensorProduct.map (mapSubtype f A) (LinearMap.id : C →ₗ[R] C) t, ?_⟩
+    rw [image_tensor_apply, ht]
     exact Comodule.Hom.map_coact_apply f m
 
 /-- The underlying submodule of the image subcomodule is the image of the underlying


### PR DESCRIPTION
This PR adds the faithful simple standard representation of `SLₙ` as the next prerequisite for the worked-example target in `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, “Reductive and semisimple groups”: prove the classical groups, including `SLₙ`, reductive using the geometric unipotent-radical definition.

Corestrict the existing standard `O(GLₙ)`-comodule along the determinant-one quotient `O(GLₙ) ⟶ O(SLₙ)`, and identify the resulting action of every algebra-valued point with multiplication by its special-linear matrix. Surjectivity of the quotient coordinate map transports faithfulness from the ambient standard comodule. Over a field, prove simplicity in every positive rank: rank one follows from one-dimensional submodule theory, while in rank at least two a rank-one dilatation corrects an arbitrary linear equivalence to determinant one without moving its target vector, showing that `SLₙ(k)` acts transitively on nonzero vectors.

This is the most effective independent step toward the milestone because the coordinate Hopf algebra of `SLₙ`, the faithful-restriction theorem, and the normal-subgroup invariant machinery are already on `main`, while the analogous `GLₙ` reductivity endpoint is already in flight and is not used here. After this PR, the `SLₙ` worked example still needs smoothness and geometric connectedness of its coordinate Hopf algebra and the final elimination of connected normal smooth unipotent closed subgroups using this standard representation.

Add `TauCeti/Algebra/AlgebraicGroup/SpecialLinear/StandardComodule.lean` (285 lines). The construction and invariant-subspace argument extend the existing `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule`; the determinant-correction argument is new here. The mathematical organization follows Milne, *Algebraic Groups* (2017), §4.a, and Jantzen, *Representations of Algebraic Groups*, I.2, as cited in the module documentation. No Mathlib infrastructure or external formalization is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"sln-standard-comodule-simple-faithful"}-->

🤖 Prepared with Codex
