### PR TITLE
feat: prove the special linear group is smooth

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Smooth.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Smooth.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
+public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Lift
+
+/-!
+# Smoothness of the special linear group
+
+The coordinate algebra of `SLₙ` is smooth over every commutative ring. The proof uses the
+infinitesimal lifting criterion for formal smoothness. Under the algebra-valued-points
+equivalence, lifting a coordinate-algebra map through a square-zero quotient is exactly lifting a
+special-linear matrix;
+`Matrix.SpecialLinearGroup.map_quotient_mk_surjective` supplies that lift. Finite presentation is
+inherited from the determinant localization presenting `GLₙ` and the principal determinant-one
+quotient presenting `SLₙ`.
+
+The result is valid in every natural rank, including rank zero, over bases with zero divisors and
+in every characteristic.
+
+## Main declarations
+
+* `TauCeti.SpecialLinear.instSmoothCoordinateHopfAlgebra`: the coordinate algebra of `SLₙ` is
+  smooth.
+* `TauCeti.SpecialLinear.smoothCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`: the same
+  result stated for the finite-type commutative Hopf algebra.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 2.
+* The Stacks Project, Tags 00TH and 00T2 (formal smoothness and smooth algebras).
+-/
+
+public section
+
+open WithConv
+
+namespace TauCeti.SpecialLinear
+
+universe u
+
+noncomputable section
+
+variable (R : Type u) [CommRing R] (n : ℕ)
+
+/-- The special-linear coordinate algebra is formally smooth over its ground ring.
+
+Via the functor-of-points description, this is the assertion that determinant-one matrices lift
+through square-zero quotients. -/
+instance instFormallySmoothCoordinateHopfAlgebra :
+    Algebra.FormallySmooth R (coordinateHopfAlgebra R n) := by
+  apply Algebra.FormallySmooth.of_comp_surjective
+  intro B _ _ I hI f
+  obtain ⟨t, ht⟩ := Matrix.SpecialLinearGroup.map_quotient_mk_surjective I ⟨2, hI⟩
+    ((pointsMulEquiv (R := R) (A := B ⧸ I) n) (toConv f))
+  let g : WithConv (coordinateHopfAlgebra R n →ₐ[R] B) :=
+    (pointsMulEquiv (R := R) (A := B) n).symm t
+  refine ⟨g.ofConv, ?_⟩
+  apply toConv_injective
+  apply (pointsMulEquiv (R := R) (A := B ⧸ I) n).injective
+  rw [← AlgHom.mapValue_apply]
+  rw [pointsMulEquiv_mapValue]
+  have hg : (pointsMulEquiv (R := R) (A := B) n) g = t := by simp [g]
+  rw [hg]
+  have hq : (Ideal.Quotient.mkₐ R I).toRingHom = Ideal.Quotient.mk I :=
+    Ideal.Quotient.mkₐ_toRingHom (R₁ := R) I
+  rw [hq]
+  exact ht
+
+/-- The coordinate algebra of `SLₙ` is smooth over every commutative ring. -/
+instance instSmoothCoordinateHopfAlgebra :
+    Algebra.Smooth R (coordinateHopfAlgebra R n) := by
+  let _ : Algebra.FinitePresentation
+      (MatrixMonoid.CoordinateRing R n) (GeneralLinear.CoordinateRing R n) :=
+    IsLocalization.Away.finitePresentation
+      (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R))
+  let _ : Algebra.FinitePresentation R (GeneralLinear.CoordinateRing R n) :=
+    Algebra.FinitePresentation.trans R (MatrixMonoid.CoordinateRing R n)
+      (GeneralLinear.CoordinateRing R n)
+  let _ : Algebra.FinitePresentation R (GeneralLinear.coordinateHopfAlgebra R n) :=
+    Algebra.FinitePresentation.equiv (GeneralLinear.coordinateHopfAlgebraAlgEquiv R n)
+  have hfg : (definingHopfIdeal R n).toIdeal.FG := by
+    rw [definingHopfIdeal_toIdeal]
+    exact Submodule.fg_span_singleton _
+  let _ : Algebra.FinitePresentation R (coordinateHopfAlgebra R n) :=
+    Algebra.FinitePresentation.quotient hfg
+  exact ⟨inferInstance, inferInstance⟩
+
+/-- The finite-type commutative Hopf algebra representing `SLₙ` has smooth coordinate ring. -/
+theorem smoothCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra :
+    smoothCommHopfAlgProperty R (finiteTypeCoordinateHopfAlgebra R n).obj := by
+  rw [smoothCommHopfAlgProperty_iff, finiteTypeCoordinateHopfAlgebra_obj]
+  infer_instance
+
+end
+
+end TauCeti.SpecialLinear

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Smooth.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Smooth.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.SmoothConnected
 public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
 public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Lift
 
@@ -16,9 +17,9 @@ The coordinate algebra of `SLₙ` is smooth over every commutative ring. The pro
 infinitesimal lifting criterion for formal smoothness. Under the algebra-valued-points
 equivalence, lifting a coordinate-algebra map through a square-zero quotient is exactly lifting a
 special-linear matrix;
-`Matrix.SpecialLinearGroup.map_quotient_mk_surjective` supplies that lift. Finite presentation is
-inherited from the determinant localization presenting `GLₙ` and the principal determinant-one
-quotient presenting `SLₙ`.
+`Matrix.SpecialLinearGroup.map_quotient_mk_surjective_of_isNilpotent` supplies that lift. Finite
+presentation is inherited from the determinant localization presenting `GLₙ` and the principal
+determinant-one quotient presenting `SLₙ`.
 
 The result is valid in every natural rank, including rank zero, over bases with zero divisors and
 in every characteristic.
@@ -33,7 +34,8 @@ in every characteristic.
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), Chapter 2.
-* The Stacks Project, Tags 00TH and 00T2 (formal smoothness and smooth algebras).
+* The Stacks Project, Tag 00TI (formal smoothness), and Tags 00T2 and 00TN (equivalent notions of
+  smooth algebras).
 -/
 
 public section
@@ -56,8 +58,9 @@ private instance instFormallySmoothCoordinateHopfAlgebra :
     Algebra.FormallySmooth R (coordinateHopfAlgebra R n) := by
   apply Algebra.FormallySmooth.of_comp_surjective
   intro B _ _ I hI f
-  obtain ⟨t, ht⟩ := Matrix.SpecialLinearGroup.map_quotient_mk_surjective I ⟨2, hI⟩
-    ((pointsMulEquiv (R := R) (A := B ⧸ I) n) (toConv f))
+  obtain ⟨t, ht⟩ :=
+    Matrix.SpecialLinearGroup.map_quotient_mk_surjective_of_isNilpotent I ⟨2, hI⟩
+      ((pointsMulEquiv (R := R) (A := B ⧸ I) n) (toConv f))
   let g : WithConv (coordinateHopfAlgebra R n →ₐ[R] B) :=
     (pointsMulEquiv (R := R) (A := B) n).symm t
   refine ⟨g.ofConv, ?_⟩
@@ -75,15 +78,6 @@ private instance instFormallySmoothCoordinateHopfAlgebra :
 /-- The coordinate algebra of `SLₙ` is smooth over every commutative ring. -/
 instance instSmoothCoordinateHopfAlgebra :
     Algebra.Smooth R (coordinateHopfAlgebra R n) := by
-  let _ : Algebra.FinitePresentation
-      (MatrixMonoid.CoordinateRing R n) (GeneralLinear.CoordinateRing R n) :=
-    IsLocalization.Away.finitePresentation
-      (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R))
-  let _ : Algebra.FinitePresentation R (GeneralLinear.CoordinateRing R n) :=
-    Algebra.FinitePresentation.trans R (MatrixMonoid.CoordinateRing R n)
-      (GeneralLinear.CoordinateRing R n)
-  let _ : Algebra.FinitePresentation R (GeneralLinear.coordinateHopfAlgebra R n) :=
-    Algebra.FinitePresentation.equiv (GeneralLinear.coordinateHopfAlgebraAlgEquiv R n)
   have hfg : (definingHopfIdeal R n).toIdeal.FG := by
     rw [definingHopfIdeal_toIdeal]
     exact Submodule.fg_span_singleton _

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Smooth.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Smooth.lean
@@ -52,7 +52,7 @@ variable (R : Type u) [CommRing R] (n : ℕ)
 
 Via the functor-of-points description, this is the assertion that determinant-one matrices lift
 through square-zero quotients. -/
-instance instFormallySmoothCoordinateHopfAlgebra :
+private instance instFormallySmoothCoordinateHopfAlgebra :
     Algebra.FormallySmooth R (coordinateHopfAlgebra R n) := by
   apply Algebra.FormallySmooth.of_comp_surjective
   intro B _ _ I hI f

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Lift.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Lift.lean
@@ -17,8 +17,8 @@ by the inverse determinant corrects the lift without changing its image.
 
 ## Main declaration
 
-* `Matrix.SpecialLinearGroup.map_quotient_mk_surjective`: entrywise reduction modulo a nilpotent
-  ideal is surjective on special-linear groups.
+* `Matrix.SpecialLinearGroup.map_quotient_mk_surjective_of_isNilpotent`: entrywise reduction
+  modulo a nilpotent ideal is surjective on special-linear groups.
 
 ## References
 
@@ -36,51 +36,53 @@ variable {n : Type*} [Fintype n] [DecidableEq n] {R : Type u} [CommRing R]
 /-- Every determinant-one matrix modulo a nilpotent ideal lifts to a determinant-one matrix.
 
 The statement includes the empty index type, where both special-linear groups are trivial. -/
-theorem map_quotient_mk_surjective (I : Ideal R) (hI : IsNilpotent I) :
+theorem map_quotient_mk_surjective_of_isNilpotent (I : Ideal R) (hI : IsNilpotent I) :
     Function.Surjective
       (Matrix.SpecialLinearGroup.map (n := n) (Ideal.Quotient.mk I)) := by
-  classical
   intro A
   cases isEmpty_or_nonempty n with
   | inl _ =>
       exact ⟨1, Subsingleton.elim _ _⟩
   | inr _ =>
-      let M : Matrix n n R := fun i j => (Ideal.Quotient.mk_surjective (A.1 i j)).choose
-      have hM : M.map (Ideal.Quotient.mk I) = A.1 := by
+      choose m hm using fun i j => Ideal.Quotient.mk_surjective (A.1 i j)
+      let M : Matrix n n R := m
+      have hM (i j) : Ideal.Quotient.mk I (M i j) = A.1 i j := hm i j
+      have hM_map : M.map (Ideal.Quotient.mk I) = A.1 := by
         ext i j
-        exact (Ideal.Quotient.mk_surjective (A.1 i j)).choose_spec
+        exact hM i j
       have hdet_map : Ideal.Quotient.mk I M.det = 1 := by
-        rw [RingHom.map_det, RingHom.mapMatrix_apply, hM, A.prop]
-      have hdet_unit : IsUnit M.det :=
-        (IsNilpotent.isUnit_quotient_mk_iff hI).mp (hdet_map ▸ isUnit_one)
+        rw [RingHom.map_det, RingHom.mapMatrix_apply, hM_map, A.prop]
+      have hdet_unit : IsUnit M.det := (IsNilpotent.isUnit_quotient_mk_iff hI).mp (by
+        rw [hdet_map]
+        exact isUnit_one)
       let u : Rˣ := hdet_unit.unit
       have hu : (u : R) = M.det := hdet_unit.unit_spec
       have hu_map : Ideal.Quotient.mk I (u : R) = 1 := by
         rw [hu]
         exact hdet_map
       have hu_inv_map : Ideal.Quotient.mk I (↑(u⁻¹) : R) = 1 := by
-        have hu_map_units : Units.map (Ideal.Quotient.mk I).toMonoidHom u = 1 := Units.ext hu_map
-        have hu_inv_map_units : Units.map (Ideal.Quotient.mk I).toMonoidHom u⁻¹ = 1 := by
-          rw [map_inv, hu_map_units, inv_one]
-        exact congrArg Units.val hu_inv_map_units
+        have h := congrArg (Ideal.Quotient.mk I) u.inv_mul
+        rw [map_mul, hu_map, mul_one, map_one] at h
+        exact h
       let i₀ : n := Classical.choice inferInstance
       let N : Matrix n n R := M.updateRow i₀ ((↑(u⁻¹) : R) • M i₀)
       have hNdet : N.det = 1 := by
         dsimp only [N]
         rw [Matrix.det_updateRow_smul, Matrix.updateRow_eq_self]
         simpa only [hu] using Units.inv_mul u
+      have hN_map : N.map (Ideal.Quotient.mk I) = A.1 := by
+        ext i j
+        simp only [Matrix.map_apply]
+        dsimp only [N]
+        by_cases hi : i = i₀
+        · subst i
+          rw [Matrix.updateRow_self, Pi.smul_apply, smul_eq_mul, map_mul, hu_inv_map, one_mul]
+          exact hM i₀ j
+        · rw [Matrix.updateRow_apply, ite_eq_right hi]
+          exact hM i j
       refine ⟨⟨N, hNdet⟩, ?_⟩
       apply Subtype.ext
-      ext i j
-      -- `SpecialLinearGroup.map` packages the entrywise matrix map in two subtypes; expose its
-      -- scalar equality before using the row-update API.
-      change Ideal.Quotient.mk I (N i j) = A.1 i j
-      dsimp only [N]
-      by_cases hi : i = i₀
-      · subst i
-        rw [Matrix.updateRow_self, Pi.smul_apply, smul_eq_mul, map_mul, hu_inv_map, one_mul]
-        exact congrFun (congrFun hM i₀) j
-      · rw [Matrix.updateRow_apply, ite_eq_right hi]
-        exact congrFun (congrFun hM i) j
+      exact (Matrix.SpecialLinearGroup.map_apply_coe (Ideal.Quotient.mk I) ⟨N, hNdet⟩).trans
+        (by simpa only [RingHom.mapMatrix_apply] using hN_map)
 
 end Matrix.SpecialLinearGroup

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Lift.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Lift.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+public import Mathlib.RingTheory.Ideal.Quotient.Nilpotent
+
+/-!
+# Lifting special-linear matrices
+
+A special-linear matrix lifts across a quotient by a nilpotent ideal. Lift its entries
+arbitrarily; its determinant is then a unit because it is one modulo the ideal. Scaling one row
+by the inverse determinant corrects the lift without changing its image.
+
+## Main declaration
+
+* `Matrix.SpecialLinearGroup.map_quotient_mk_surjective`: entrywise reduction modulo a nilpotent
+  ideal is surjective on special-linear groups.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 2.
+-/
+
+public section
+
+namespace Matrix.SpecialLinearGroup
+
+universe u
+
+variable {n : Type*} [Fintype n] [DecidableEq n] {R : Type u} [CommRing R]
+
+/-- Every determinant-one matrix modulo a nilpotent ideal lifts to a determinant-one matrix.
+
+The statement includes the empty index type, where both special-linear groups are trivial. -/
+theorem map_quotient_mk_surjective (I : Ideal R) (hI : IsNilpotent I) :
+    Function.Surjective
+      (Matrix.SpecialLinearGroup.map (n := n) (Ideal.Quotient.mk I)) := by
+  classical
+  intro A
+  cases isEmpty_or_nonempty n with
+  | inl _ =>
+      exact ⟨1, Subsingleton.elim _ _⟩
+  | inr _ =>
+      let M : Matrix n n R := fun i j => (Ideal.Quotient.mk_surjective (A.1 i j)).choose
+      have hM : M.map (Ideal.Quotient.mk I) = A.1 := by
+        ext i j
+        exact (Ideal.Quotient.mk_surjective (A.1 i j)).choose_spec
+      have hdet_map : Ideal.Quotient.mk I M.det = 1 := by
+        rw [RingHom.map_det, RingHom.mapMatrix_apply, hM, A.prop]
+      have hdet_unit : IsUnit M.det :=
+        (IsNilpotent.isUnit_quotient_mk_iff hI).mp (hdet_map ▸ isUnit_one)
+      let u : Rˣ := hdet_unit.unit
+      have hu : (u : R) = M.det := hdet_unit.unit_spec
+      have hu_map : Ideal.Quotient.mk I (u : R) = 1 := by
+        rw [hu]
+        exact hdet_map
+      have hu_inv_map : Ideal.Quotient.mk I (↑(u⁻¹) : R) = 1 := by
+        have hu_map_units : Units.map (Ideal.Quotient.mk I).toMonoidHom u = 1 := Units.ext hu_map
+        have hu_inv_map_units : Units.map (Ideal.Quotient.mk I).toMonoidHom u⁻¹ = 1 := by
+          rw [map_inv, hu_map_units, inv_one]
+        exact congrArg Units.val hu_inv_map_units
+      let i₀ : n := Classical.choice inferInstance
+      let N : Matrix n n R := M.updateRow i₀ ((↑(u⁻¹) : R) • M i₀)
+      have hNdet : N.det = 1 := by
+        dsimp only [N]
+        rw [Matrix.det_updateRow_smul, Matrix.updateRow_eq_self]
+        simpa only [hu] using Units.inv_mul u
+      refine ⟨⟨N, hNdet⟩, ?_⟩
+      apply Subtype.ext
+      ext i j
+      -- `SpecialLinearGroup.map` packages the entrywise matrix map in two subtypes; expose its
+      -- scalar equality before using the row-update API.
+      change Ideal.Quotient.mk I (N i j) = A.1 i j
+      dsimp only [N]
+      by_cases hi : i = i₀
+      · subst i
+        rw [Matrix.updateRow_self, Pi.smul_apply, smul_eq_mul, map_mul, hu_inv_map, one_mul]
+        exact congrFun (congrFun hM i₀) j
+      · rw [Matrix.updateRow_apply, ite_eq_right hi]
+        exact congrFun (congrFun hM i) j
+
+end Matrix.SpecialLinearGroup


### PR DESCRIPTION
This PR proves that the special-linear coordinate algebra is smooth over every commutative base ring, advancing `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “Reductive and semisimple groups,” specifically the worked-example target to prove the classical groups, including `SLₙ`, reductive using the geometric unipotent-radical definition.

Lift determinant-one matrices across quotients by nilpotent ideals: lift all entries arbitrarily, observe that the lifted determinant is a unit because it is one modulo the ideal, and scale one row by its inverse. The theorem includes the empty index type. Transport this lifting result through the existing functor-of-points equivalence to discharge Mathlib’s infinitesimal criterion for formal smoothness. Obtain finite presentation from the determinant localization presenting `GLₙ` and the principal determinant-one quotient presenting `SLₙ`, giving `Algebra.Smooth R (SpecialLinear.coordinateHopfAlgebra R n)` without Noetherian, domain, or field hypotheses.

This is the most effective distinct step because the open standard-comodule work explicitly leaves smoothness and geometric connectedness as its two coordinate-ring prerequisites, while the faithful simple representation and final subgroup argument can proceed independently. After this PR, the `SLₙ` worked example still needs geometric connectedness of its coordinate Hopf algebra and the final elimination of connected normal smooth unipotent closed subgroups before `reductiveCommHopfAlgProperty` can be proved.

Add `TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Lift.lean` (86 lines) and `TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Smooth.lean` (102 lines). The proof consumes Mathlib’s nilpotent-ideal unit criterion, determinant row-scaling formula, formal-smoothness lifting criterion, and finite-presentation APIs together with Tau Ceti’s existing `SLₙ` point equivalence; no Mathlib infrastructure or external formalization is vendored. The mathematical construction follows Milne, *Algebraic Groups* (2017), Chapter 2, and the Stacks Project’s formal-smoothness and smooth-algebra criteria (Tags 00TH and 00T2), as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-linear-smooth"}-->

🤖 Prepared with Codex
