### PR TITLE
feat: coderivations of the reduced tensor coalgebra and their Taylor components

### DIFF
--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Basic.lean
@@ -31,9 +31,10 @@ the `DGAInfinity` roadmap.
 
 ## Main results
 
-* `TauCeti.ReducedTensorWords.of_tprod_congr` and `TauCeti.ReducedTensorWords.subword_congr`:
-  a pure tensor word, respectively a block of one, depends only on its letters, even when the two
-  sides present its length by different arithmetic expressions.
+* `TauCeti.ReducedTensorWords.of_tprod_congr`: a pure tensor word depends only on its letters,
+  even when the two sides present its length by different arithmetic expressions.
+* `TauCeti.ReducedTensorWords.subword_congr`: equal-length blocks in different ambient tuples or
+  at different offsets agree when their letters agree.
 * `TauCeti.ReducedTensorWords.deconcatenation_subword`: deconcatenation of a block.
 
 ## References
@@ -83,9 +84,10 @@ theorem linearMap_ext {N : Type uN} [AddCommMonoid N] [Module R N]
 /-- Two pure tensor words of the same length with the same letters are equal.  The two lengths
 are separate arguments, so that this closes goals whose two sides were assembled from different
 arithmetic expressions for one length. -/
-theorem of_tprod_congr {k l : ℕ} (hk : 0 < k) (hl : 0 < l) (hkl : k = l) {u : Fin k → M}
+theorem of_tprod_congr {k l : ℕ} (hk : 0 < k) (hkl : k = l) {u : Fin k → M}
     {v : Fin l → M} (h : ∀ i : Fin k, u i = v (Fin.cast hkl i)) :
-    of R M ⟨k, hk⟩ (PiTensorProduct.tprod R u) = of R M ⟨l, hl⟩ (PiTensorProduct.tprod R v) := by
+    of R M ⟨k, hk⟩ (PiTensorProduct.tprod R u) =
+      of R M ⟨l, hkl ▸ hk⟩ (PiTensorProduct.tprod R v) := by
   subst hkl
   exact congrArg _ (congrArg _ (funext h))
 
@@ -220,7 +222,7 @@ theorem subword_congr {n m : ℕ} (x : Fin n → M) (y : Fin m → M) {a a' b : 
   rcases Nat.eq_zero_or_pos b with rfl | hb
   · rw [subword_length_zero, subword_length_zero]
   · rw [subword_eq_of_tprod R x hb hab, subword_eq_of_tprod R y hb hab']
-    exact of_tprod_congr R M _ _ rfl fun j ↦ h j.1 j.isLt
+    exact of_tprod_congr R M _ rfl fun j ↦ h j.1 j.isLt
 
 /-- Deconcatenating a block cuts it at each of its nontrivial internal positions. -/
 theorem deconcatenation_subword {n : ℕ} (x : Fin n → M) {a b : ℕ} :

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Basic.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Basic.lean
@@ -29,6 +29,13 @@ the `DGAInfinity` roadmap.
 * `TauCeti.ReducedTensorWords.deconcatenation`: sum over every nontrivial cut of a tensor word.
 * `TauCeti.ReducedTensorWords.subword`: a block of consecutive letters in a tensor word.
 
+## Main results
+
+* `TauCeti.ReducedTensorWords.of_tprod_congr` and `TauCeti.ReducedTensorWords.subword_congr`:
+  a pure tensor word, respectively a block of one, depends only on its letters, even when the two
+  sides present its length by different arithmetic expressions.
+* `TauCeti.ReducedTensorWords.deconcatenation_subword`: deconcatenation of a block.
+
 ## References
 
 * E. Getzler and J. D. S. Jones, *A-infinity algebras and the cyclic bar complex*, Sections 1--2.
@@ -73,6 +80,15 @@ theorem linearMap_ext {N : Type uN} [AddCommMonoid N] [Module R N]
   ext x
   exact h n x
 
+/-- Two pure tensor words of the same length with the same letters are equal.  The two lengths
+are separate arguments, so that this closes goals whose two sides were assembled from different
+arithmetic expressions for one length. -/
+theorem of_tprod_congr {k l : ℕ} (hk : 0 < k) (hl : 0 < l) (hkl : k = l) {u : Fin k → M}
+    {v : Fin l → M} (h : ∀ i : Fin k, u i = v (Fin.cast hkl i)) :
+    of R M ⟨k, hk⟩ (PiTensorProduct.tprod R u) = of R M ⟨l, hl⟩ (PiTensorProduct.tprod R v) := by
+  subst hkl
+  exact congrArg _ (congrArg _ (funext h))
+
 /-- Project reduced tensor words to a fixed positive tensor length. -/
 noncomputable def component (n : {n : ℕ // 0 < n}) :
     ReducedTensorWords R M →ₗ[R] TensorPower R n.1 M :=
@@ -89,12 +105,28 @@ theorem component_of (n : {n : ℕ // 0 < n}) (x : TensorPower R n.1 M) :
     component R M n (of R M n x) = x := by
   simp [component, of]
 
+/-- Reading off the component of a tensor word at its own length, presented by a second
+arithmetic expression for that length. -/
+theorem component_of_eq {m n : {k : ℕ // 0 < k}} (h : m = n) (z : TensorPower R m.1 M) :
+    component R M n (of R M m z) = TensorPower.cast R M (congrArg Subtype.val h) z := by
+  subst h
+  rw [component_of, TensorPower.cast_refl, LinearEquiv.refl_apply]
+
 /-- Projecting an included tensor power vanishes when the two lengths differ. -/
 @[simp]
 theorem component_of_of_ne {m n : {n : ℕ // 0 < n}} (h : m ≠ n) (x : TensorPower R m.1 M) :
     component R M n (of R M m x) = 0 := by
   simp [component, of, DirectSum.component.of, h]
 
+
+/-- A linear map assembled from its length components is that component on a tensor word of that
+length. -/
+@[simp]
+theorem toModule_of {N : Type uN} [AddCommMonoid N] [Module R N]
+    (φ : ∀ n : {n : ℕ // 0 < n}, TensorPower R n.1 M →ₗ[R] N) (n : {n : ℕ // 0 < n})
+    (z : TensorPower R n.1 M) :
+    DirectSum.toModule R {n : ℕ // 0 < n} N φ (of R M n z) = φ n z := by
+  simp [of]
 
 /-- Deconcatenation on words of one fixed length, summed over all nontrivial cuts. -/
 noncomputable def deconcatenationComponent (n : {n : ℕ // 0 < n}) :
@@ -178,6 +210,17 @@ theorem of_tprod_eq_subword {n : ℕ} (hn : 0 < n) (x : Fin n → M) :
   rw [subword_eq_of_tprod R x hn (by omega)]
   congr 1
   exact congrArg _ (funext fun j ↦ (congrArg x (Fin.ext (Nat.zero_add j.1))).symm)
+
+/-- A block of a tensor word depends only on its letters, not on the tuple carrying them nor on
+where the block sits inside it. -/
+theorem subword_congr {n m : ℕ} (x : Fin n → M) (y : Fin m → M) {a a' b : ℕ} (hab : a + b ≤ n)
+    (hab' : a' + b ≤ m)
+    (h : ∀ (j : ℕ) (hj : j < b), x ⟨a + j, by omega⟩ = y ⟨a' + j, by omega⟩) :
+    subword R x a b = subword R y a' b := by
+  rcases Nat.eq_zero_or_pos b with rfl | hb
+  · rw [subword_length_zero, subword_length_zero]
+  · rw [subword_eq_of_tprod R x hb hab, subword_eq_of_tprod R y hb hab']
+    exact of_tprod_congr R M _ _ rfl fun j ↦ h j.1 j.isLt
 
 /-- Deconcatenating a block cuts it at each of its nontrivial internal positions. -/
 theorem deconcatenation_subword {n : ℕ} (x : Fin n → M) {a b : ℕ} :

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -85,7 +85,7 @@ produces from them.
 
 It is zero unless the collapsed block is nonempty and fits, that is unless `0 < d` and
 `p + d ≤ n`. -/
-noncomputable def coderivSummand (F : ReducedTensorWords R M →ₗ[R] M) (n p d : ℕ) :
+private noncomputable def coderivSummand (F : ReducedTensorWords R M →ₗ[R] M) (n p d : ℕ) :
     TensorPower R n M →ₗ[R] ReducedTensorWords R M :=
   if h : 0 < d ∧ p + d ≤ n then
     of R M ⟨n + 1 - d, by omega⟩ ∘ₗ
@@ -100,13 +100,13 @@ noncomputable def coderivSummand (F : ReducedTensorWords R M →ₗ[R] M) (n p d
   else 0
 
 /-- Outside its range a Taylor summand vanishes. -/
-theorem coderivSummand_eq_zero (F : ReducedTensorWords R M →ₗ[R] M) {n p d : ℕ}
+private theorem coderivSummand_eq_zero (F : ReducedTensorWords R M →ₗ[R] M) {n p d : ℕ}
     (h : ¬(0 < d ∧ p + d ≤ n)) : coderivSummand R F n p d = 0 := by
   rw [coderivSummand, dite_eq_right h]
 
 /-- On a pure tensor word, a Taylor summand is the splice of the value of `F` on the collapsed
 block. -/
-theorem coderivSummand_tprod (F : ReducedTensorWords R M →ₗ[R] M) {n p d : ℕ} (hd : 0 < d)
+private theorem coderivSummand_tprod (F : ReducedTensorWords R M →ₗ[R] M) {n p d : ℕ} (hd : 0 < d)
     (hpd : p + d ≤ n) (x : Fin n → M) :
     coderivSummand R F n p d (PiTensorProduct.tprod R x) =
       splice R x 0 n p d (F (subword R x p d)) := by
@@ -139,7 +139,12 @@ noncomputable def coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
   DirectSum.toModule R {n : ℕ // 0 < n} _ fun n ↦
     ∑ p ∈ Finset.range n.1, ∑ d ∈ Finset.range (n.1 + 1), coderivSummand R F n.1 p d
 
-theorem coderiv_of (F : ReducedTensorWords R M →ₗ[R] M) (n : {n : ℕ // 0 < n})
+/-- Evaluation of `coderiv F` on a homogeneous tensor word `of R M n z`: the sum, over a position
+`p` and a block length `d`, of the Taylor summands collapsing the `d` letters at position `p`.
+
+The public form of this evaluation rule is `TauCeti.ReducedTensorWords.coderiv_subword`, which
+states the same sum in terms of `TauCeti.ReducedTensorWords.splice`. -/
+private theorem coderiv_of (F : ReducedTensorWords R M →ₗ[R] M) (n : {n : ℕ // 0 < n})
     (z : TensorPower R n.1 M) :
     coderiv R F (of R M n z) =
       ∑ p ∈ Finset.range n.1, ∑ d ∈ Finset.range (n.1 + 1), coderivSummand R F n.1 p d z := by
@@ -151,7 +156,7 @@ private theorem splice_eq_zero_of_not_fits {n : ℕ} (x : Fin n → M) {a b p d 
     (h : ¬(0 < d ∧ p + d ≤ b)) : splice R x a b p d e = 0 := by
   rcases Nat.eq_zero_or_pos d with rfl | hd
   · exact splice_zero_length R x a b p e
-  · exact splice_eq_zero_of_lt_add R x e (by omega)
+  · exact splice_eq_zero_of_block_lt_add R x e (by omega)
 
 /-- A Taylor summand on a tensor word that is a block of a longer tuple, read back in that
 tuple. -/
@@ -406,7 +411,7 @@ theorem letter_comp_coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
     refine Finset.sum_eq_zero fun d _ ↦ ?_
     by_cases hd : d = n.1
     · subst hd
-      rw [splice_eq_zero_of_lt_add R x _ (by omega), map_zero]
+      rw [splice_eq_zero_of_block_lt_add R x _ (by omega), map_zero]
     · exact letter_splice_eq_zero R x _ hd
   · intro hp
     exact absurd (Finset.mem_range.2 hn) hp
@@ -418,11 +423,8 @@ theorem letter_comp_coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
 
 variable (M)
 
-/-- The submodule of coderivations of the reduced tensor coalgebra.
-
-It is `@[expose]`d so that membership in it reduces to `TauCeti.ReducedTensorWords.IsCoderivation`
-outside this module. -/
-@[expose]
+/-- The submodule of coderivations of the reduced tensor coalgebra.  Membership in it is
+`TauCeti.ReducedTensorWords.mem_coderivations`. -/
 def coderivations : Submodule R (ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) where
   carrier := {b | IsCoderivation R b}
   zero_mem' := by
@@ -446,16 +448,21 @@ theorem mem_coderivations {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWor
 
 /-- Coderivations of the reduced tensor coalgebra are exactly their Taylor components: taking the
 letter of the value is a linear isomorphism onto the maps to single letters, with inverse the
-Taylor expansion `coderiv`. -/
+Taylor expansion `coderiv`.
+
+Its body is `@[expose]`d because the characteristic lemmas
+`TauCeti.ReducedTensorWords.coderivEquivTaylor_apply` and
+`TauCeti.ReducedTensorWords.coderivEquivTaylor_symm_apply` are proved by `rfl`, which an importing
+module cannot check for a sealed definition. -/
 @[expose]
 noncomputable def coderivEquivTaylor :
     coderivations R M ≃ₗ[R] (ReducedTensorWords R M →ₗ[R] M) where
   toFun b := letter R M ∘ₗ b.1
   map_add' _ _ := LinearMap.comp_add _ _ _
   map_smul' _ _ := LinearMap.comp_smul _ _ _
-  invFun F := ⟨coderiv R F, isCoderivation_coderiv R F⟩
-  left_inv b := Subtype.ext <| (isCoderivation_coderiv R _).eq_of_letter_comp_eq b.2
-    (letter_comp_coderiv R _)
+  invFun F := ⟨coderiv R F, (mem_coderivations R M).2 (isCoderivation_coderiv R F)⟩
+  left_inv b := Subtype.ext <| (isCoderivation_coderiv R _).eq_of_letter_comp_eq
+    ((mem_coderivations R M).1 b.2) (letter_comp_coderiv R _)
   right_inv F := letter_comp_coderiv R F
 
 @[simp]
@@ -464,7 +471,8 @@ theorem coderivEquivTaylor_apply (b : coderivations R M) :
 
 @[simp]
 theorem coderivEquivTaylor_symm_apply (F : ReducedTensorWords R M →ₗ[R] M) :
-    (coderivEquivTaylor R M).symm F = ⟨coderiv R F, isCoderivation_coderiv R F⟩ := rfl
+    (coderivEquivTaylor R M).symm F =
+      ⟨coderiv R F, (mem_coderivations R M).2 (isCoderivation_coderiv R F)⟩ := rfl
 
 end ReducedTensorWords
 

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -113,8 +113,8 @@ theorem coderivSummand_tprod (F : ReducedTensorWords R M →ₗ[R] M) {n p d : �
   rw [coderivSummand, dite_eq_left ⟨hd, hpd⟩]
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe,
     TensorPower.splitAt_tprod, LinearMap.lTensor_tmul, LinearMap.rTensor_tmul,
-    TauCeti.TensorPower.oneEquiv_symm_apply, TensorPower.mulEquiv_tprod_tmul_tprod,
-    TensorPower.cast_tprod, Fin.val_castLE]
+    TauCeti.TensorPower.oneEquiv_symm_apply, ← TensorPower.gMul_def,
+    TensorPower.tprod_mul_tprod, TensorPower.cast_tprod, Fin.val_castLE]
   rw [← subword_eq_of_tprod R x (a := p) (b := d) hd (by omega),
     splice_eq_of_tprod R x _ hd (by omega) (by omega)]
   refine of_tprod_congr R M _ _ rfl fun i ↦ ?_

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -122,7 +122,7 @@ private theorem coderivSummand_tprod (F : ReducedTensorWords R M →ₗ[R] M) {n
     TensorPower.tprod_mul_tprod, TensorPower.cast_tprod, Fin.val_castLE]
   rw [← subword_eq_of_tprod R x (a := p) (b := d) hd (by omega),
     splice_eq_of_tprod R x _ hd (by omega) (by omega)]
-  refine of_tprod_congr R M _ _ rfl fun i ↦ ?_
+  refine of_tprod_congr R M _ rfl fun i ↦ ?_
   have hi := i.isLt
   rw [Function.comp_apply, append_eq_dite]
   simp only [Fin.val_cast]
@@ -187,34 +187,39 @@ as large as convenient, since a summand whose collapsed block does not fit insid
 vanishes; that is what lets the expansions of a word and of its two halves be summed over one
 common range. -/
 theorem coderiv_subword (F : ReducedTensorWords R M →ₗ[R] M) {n : ℕ} (x : Fin n → M) {a b K : ℕ}
-    (hab : a + b ≤ n) (hK : b ≤ K) :
+    (hK : b ≤ K) :
     coderiv R F (subword R x a b) =
       ∑ p ∈ Finset.range K, ∑ d ∈ Finset.range (K + 1),
         splice R x a b p d (F (subword R x (a + p) d)) := by
-  have hvanish : ∀ p d : ℕ, b ≤ p ∨ b < d →
-      splice R x a b p d (F (subword R x (a + p) d)) = 0 := fun p d h ↦
-    splice_eq_zero_of_not_fits R x _ (by omega)
-  rcases Nat.eq_zero_or_pos b with rfl | hb
-  · rw [subword_length_zero, map_zero]
-    exact (Finset.sum_eq_zero fun p _ ↦ Finset.sum_eq_zero fun d _ ↦
-      hvanish p d (Or.inl (Nat.zero_le p))).symm
-  have inner : ∀ p : ℕ, ∑ d ∈ Finset.range (b + 1),
-      splice R x a b p d (F (subword R x (a + p) d)) =
-      ∑ d ∈ Finset.range (K + 1), splice R x a b p d (F (subword R x (a + p) d)) :=
-    fun p ↦ Finset.sum_subset (Finset.range_subset_range.mpr (by omega)) fun d _ hd ↦ by
-      simp only [Finset.mem_range, not_lt] at hd
-      exact hvanish p d (Or.inr (by omega))
-  have outer : ∑ p ∈ Finset.range b, ∑ d ∈ Finset.range (K + 1),
-      splice R x a b p d (F (subword R x (a + p) d)) =
-      ∑ p ∈ Finset.range K, ∑ d ∈ Finset.range (K + 1),
-        splice R x a b p d (F (subword R x (a + p) d)) :=
-    Finset.sum_subset (Finset.range_subset_range.mpr hK) fun p _ hp ↦ by
-      simp only [Finset.mem_range, not_lt] at hp
-      exact Finset.sum_eq_zero fun d _ ↦ hvanish p d (Or.inl hp)
-  rw [subword_eq_of_tprod R x hb hab, coderiv_of, ← outer,
-    ← Finset.sum_congr rfl (fun p (_ : p ∈ Finset.range b) ↦ inner p)]
-  exact Finset.sum_congr rfl fun p _ ↦ Finset.sum_congr rfl fun d _ ↦
-    coderivSummand_tprod_of_eq R F x _ hab (fun j hj ↦ rfl) p d
+  by_cases hab : a + b ≤ n
+  · have hvanish : ∀ p d : ℕ, b ≤ p ∨ b < d →
+        splice R x a b p d (F (subword R x (a + p) d)) = 0 := fun p d h ↦
+      splice_eq_zero_of_not_fits R x _ (by omega)
+    rcases Nat.eq_zero_or_pos b with rfl | hb
+    · rw [subword_length_zero, map_zero]
+      exact (Finset.sum_eq_zero fun p _ ↦ Finset.sum_eq_zero fun d _ ↦
+        hvanish p d (Or.inl (Nat.zero_le p))).symm
+    have inner : ∀ p : ℕ, ∑ d ∈ Finset.range (b + 1),
+        splice R x a b p d (F (subword R x (a + p) d)) =
+        ∑ d ∈ Finset.range (K + 1), splice R x a b p d (F (subword R x (a + p) d)) :=
+      fun p ↦ Finset.sum_subset (Finset.range_subset_range.mpr (by omega)) fun d _ hd ↦ by
+        simp only [Finset.mem_range, not_lt] at hd
+        exact hvanish p d (Or.inr (by omega))
+    have outer : ∑ p ∈ Finset.range b, ∑ d ∈ Finset.range (K + 1),
+        splice R x a b p d (F (subword R x (a + p) d)) =
+        ∑ p ∈ Finset.range K, ∑ d ∈ Finset.range (K + 1),
+          splice R x a b p d (F (subword R x (a + p) d)) :=
+      Finset.sum_subset (Finset.range_subset_range.mpr hK) fun p _ hp ↦ by
+        simp only [Finset.mem_range, not_lt] at hp
+        exact Finset.sum_eq_zero fun d _ ↦ hvanish p d (Or.inl hp)
+    rw [subword_eq_of_tprod R x hb hab, coderiv_of, ← outer,
+      ← Finset.sum_congr rfl (fun p (_ : p ∈ Finset.range b) ↦ inner p)]
+    exact Finset.sum_congr rfl fun p _ ↦ Finset.sum_congr rfl fun d _ ↦
+      coderivSummand_tprod_of_eq R F x _ hab (fun j hj ↦ rfl) p d
+  · rw [subword_eq_zero_of_lt_add R x (by omega), map_zero]
+    symm
+    exact Finset.sum_eq_zero fun p _ ↦ Finset.sum_eq_zero fun d _ ↦
+      splice_eq_zero_of_length_lt_add R x _ (by omega)
 
 
 /-- A linear endomorphism of the reduced tensor coalgebra is a *coderivation* when it satisfies
@@ -322,6 +327,7 @@ private theorem sum_range_triangle {N : Type*} [AddCommMonoid N] (K : ℕ) (g : 
 position and a collapsed block, of the tensor of the two halves with the block collapsed in
 whichever half contains it; a block is never split by a cut, and a cut never splits the new
 letter. -/
+@[simp]
 theorem isCoderivation_coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
     IsCoderivation R (coderiv R F) := by
   refine linearMap_ext R M fun n x ↦ ?_
@@ -334,12 +340,12 @@ theorem isCoderivation_coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
             splice R x c (n.1 - c) (p - c) d (F (subword R x p d))) +
         ∑ p ∈ Finset.range n.1, ∑ d ∈ Finset.range (n.1 + 1), ∑ c ∈ Finset.range n.1,
           splice R x 0 c p d (F (subword R x p d)) ⊗ₜ[R] subword R x c (n.1 - c) := by
-    rw [coderiv_subword R F x (a := 0) (b := n.1) (K := n.1) (by omega) (le_refl n.1), map_sum,
+    rw [coderiv_subword R F x (a := 0) (b := n.1) (K := n.1) (le_refl n.1), map_sum,
       ← Finset.sum_add_distrib]
     refine Finset.sum_congr rfl fun p _ ↦ ?_
     rw [map_sum, ← Finset.sum_add_distrib]
     refine Finset.sum_congr rfl fun d _ ↦ ?_
-    rw [deconcatenation_splice R x _ (by omega)]
+    rw [deconcatenation_splice R x _]
     simp only [Nat.zero_add]
   have hdelta : deconcatenation R M (subword R x 0 n.1) =
       ∑ c ∈ Finset.range n.1, subword R x 0 c ⊗ₜ[R] subword R x c (n.1 - c) := by
@@ -359,13 +365,13 @@ theorem isCoderivation_coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
     congr 1 <;> refine Finset.sum_congr rfl fun c hc ↦ ?_ <;>
       simp only [Finset.mem_range] at hc
     · rw [LinearMap.rTensor_tmul,
-        coderiv_subword R F x (a := 0) (b := c) (K := n.1) (by omega) (by omega),
+        coderiv_subword R F x (a := 0) (b := c) (K := n.1) (by omega),
         TensorProduct.sum_tmul]
       exact Finset.sum_congr rfl fun p _ ↦ by
         rw [TensorProduct.sum_tmul]
         simp only [Nat.zero_add]
     · rw [LinearMap.lTensor_tmul,
-        coderiv_subword R F x (a := c) (b := n.1 - c) (K := n.1) (by omega) (by omega),
+        coderiv_subword R F x (a := c) (b := n.1 - c) (K := n.1) (by omega),
         TensorProduct.tmul_sum]
       exact Finset.sum_congr rfl fun p _ ↦ by rw [TensorProduct.tmul_sum]
   rw [hLHS, hRHS, add_comm]
@@ -414,7 +420,7 @@ theorem letter_comp_coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
   have hn : 0 < n.1 := n.2
   simp only [LinearMap.coe_comp, Function.comp_apply]
   rw [of_tprod_eq_subword R hn x,
-    coderiv_subword R F x (a := 0) (b := n.1) (K := n.1) (by omega) (le_refl n.1), map_sum]
+    coderiv_subword R F x (a := 0) (b := n.1) (K := n.1) (le_refl n.1), map_sum]
   refine (Finset.sum_eq_single 0 ?_ ?_).trans ?_
   · intro p _ hp
     rw [map_sum]

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -460,11 +460,9 @@ theorem mem_coderivations {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWor
 letter of the value is a linear isomorphism onto the maps to single letters, with inverse the
 Taylor expansion `coderiv`.
 
-Its body is `@[expose]`d because the characteristic lemmas
+Its body is sealed; reason about it through
 `TauCeti.ReducedTensorWords.coderivEquivTaylor_apply` and
-`TauCeti.ReducedTensorWords.coderivEquivTaylor_symm_apply` are proved by `rfl`, which an importing
-module cannot check for a sealed definition. -/
-@[expose]
+`TauCeti.ReducedTensorWords.coderivEquivTaylor_symm_apply`. -/
 noncomputable def coderivEquivTaylor :
     coderivations R M ≃ₗ[R] (ReducedTensorWords R M →ₗ[R] M) where
   toFun b := letter R M ∘ₗ b.1
@@ -477,12 +475,12 @@ noncomputable def coderivEquivTaylor :
 
 @[simp]
 theorem coderivEquivTaylor_apply (b : coderivations R M) :
-    coderivEquivTaylor R M b = letter R M ∘ₗ b.1 := rfl
+    coderivEquivTaylor R M b = letter R M ∘ₗ b.1 := (rfl)
 
 @[simp]
 theorem coderivEquivTaylor_symm_apply (F : ReducedTensorWords R M →ₗ[R] M) :
     (coderivEquivTaylor R M).symm F =
-      ⟨coderiv R F, (mem_coderivations R M).2 (isCoderivation_coderiv R F)⟩ := rfl
+      ⟨coderiv R F, (mem_coderivations R M).2 (isCoderivation_coderiv R F)⟩ := (rfl)
 
 end ReducedTensorWords
 

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -1,0 +1,471 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.TensorCoalgebra.Filtration
+public import TauCeti.LinearAlgebra.TensorCoalgebra.Primitives
+public import TauCeti.LinearAlgebra.TensorCoalgebra.Splice
+
+/-!
+# Coderivations of the reduced tensor coalgebra
+
+For an `R`-module `M`, the reduced tensor words `⨁_{n ≥ 1} M^{⊗n}` carry the reduced
+deconcatenation coproduct `Δ` built in `TauCeti.ReducedTensorWords.deconcatenation`.  A
+*coderivation* is a linear endomorphism `b` satisfying the co-Leibniz rule
+`Δ ∘ b = (b ⊗ 1 + 1 ⊗ b) ∘ Δ`.  This file proves that coderivations are exactly their Taylor
+components: composing with the projection `letter` onto single letters is a linear isomorphism
+from the coderivations onto the linear maps `⨁_{n ≥ 1} M^{⊗n} ⟶ M`.
+
+That coderivations are *determined* by their Taylor components is an induction along the
+conilpotence filtration: a word of length at most `n + 1` is cut into two words of length at most
+`n`, so the right-hand side of the co-Leibniz rule is already known by induction, and a tensor word
+is determined by its cut together with its letter.  That *every* family of components occurs is the
+explicit Taylor expansion `coderiv`, which collapses each nonempty block of letters of a word to the
+single letter the components produce from that block.  Verifying its co-Leibniz rule is a
+reindexing: on both sides the summands are indexed by a cut position together with a collapsed
+block, and a cut never splits a block nor the letter that replaced one.
+
+This is the encoding in which an `A∞` algebra is a square-zero coderivation of the bar coalgebra of
+a suspended graded module, and its Taylor components are the operations `m_n`; that use is
+downstream, in the `DGAInfinity` roadmap.
+
+## Main definitions
+
+* `TauCeti.ReducedTensorWords.IsCoderivation`: the co-Leibniz rule.
+* `TauCeti.ReducedTensorWords.coderiv`: the coderivation with prescribed Taylor components.
+* `TauCeti.ReducedTensorWords.coderivations`: the submodule of coderivations.
+
+## Main results
+
+* `TauCeti.ReducedTensorWords.IsCoderivation.eq_of_letter_comp_eq`: a coderivation is determined by
+  its Taylor components.
+* `TauCeti.ReducedTensorWords.isCoderivation_coderiv` and
+  `TauCeti.ReducedTensorWords.letter_comp_coderiv`: `coderiv F` is a coderivation with Taylor
+  components `F`.
+* `TauCeti.ReducedTensorWords.coderivEquivTaylor`: coderivations are linearly isomorphic to their
+  Taylor components.
+
+## References
+
+* E. Getzler and J. D. S. Jones, *A-infinity algebras and the cyclic bar complex*, Sections 1--2.
+* B. Keller, *Introduction to A-infinity algebras and modules*, Sections 3.1 and 3.6.
+-/
+public section
+
+open scoped BigOperators DirectSum TensorProduct
+
+universe uR uM
+
+namespace TauCeti
+
+namespace ReducedTensorWords
+
+variable (R : Type uR) {M : Type uM} [CommSemiring R] [AddCommMonoid M] [Module R M]
+
+/-- Evaluation of a concatenated tuple at an index that is not presented as an index of one of
+the two factors. -/
+private theorem append_eq_dite {α : Type*} {k l : ℕ} (u : Fin k → α) (v : Fin l → α)
+    (i : Fin (k + l)) :
+    Fin.append u v i = if hi : i.1 < k then u ⟨i.1, hi⟩ else v ⟨i.1 - k, by omega⟩ := by
+  induction i using Fin.addCases with
+  | left j =>
+      rw [Fin.append_left, dite_eq_left (show (Fin.castAdd l j).1 < k from j.isLt)]
+      rfl
+  | right j =>
+      rw [Fin.append_right,
+        dite_eq_right (show ¬(Fin.natAdd k j).1 < k by simp only [Fin.val_natAdd]; omega)]
+      exact congrArg v (Fin.ext (show (j : ℕ) = k + (j : ℕ) - k by omega))
+
+/-- The `(p, d)` summand of the Taylor expansion of a coderivation with components `F`, on tensor
+words of length `n`: collapse the `d` letters at position `p` to the single letter that `F`
+produces from them.
+
+It is zero unless the collapsed block is nonempty and fits, that is unless `0 < d` and
+`p + d ≤ n`. -/
+noncomputable def coderivSummand (F : ReducedTensorWords R M →ₗ[R] M) (n p d : ℕ) :
+    TensorPower R n M →ₗ[R] ReducedTensorWords R M :=
+  if h : 0 < d ∧ p + d ≤ n then
+    of R M ⟨n + 1 - d, by omega⟩ ∘ₗ
+      (TensorPower.cast R M (show p + (1 + (n - p - d)) = n + 1 - d by omega)).toLinearMap ∘ₗ
+      (TensorPower.mulEquiv (R := R) (M := M)).toLinearMap ∘ₗ
+      LinearMap.lTensor (TensorPower R p M)
+        ((TensorPower.mulEquiv (R := R) (M := M)).toLinearMap ∘ₗ
+          LinearMap.rTensor (TensorPower R (n - p - d) M)
+            ((TauCeti.TensorPower.oneEquiv R M).symm.toLinearMap ∘ₗ F ∘ₗ of R M ⟨d, h.1⟩)) ∘ₗ
+      LinearMap.lTensor (TensorPower R p M) (TensorPower.splitAt R M (n - p) d (by omega)) ∘ₗ
+      TensorPower.splitAt R M n p (by omega)
+  else 0
+
+/-- Outside its range a Taylor summand vanishes. -/
+theorem coderivSummand_eq_zero (F : ReducedTensorWords R M →ₗ[R] M) {n p d : ℕ}
+    (h : ¬(0 < d ∧ p + d ≤ n)) : coderivSummand R F n p d = 0 := by
+  rw [coderivSummand, dite_eq_right h]
+
+/-- On a pure tensor word, a Taylor summand is the splice of the value of `F` on the collapsed
+block. -/
+theorem coderivSummand_tprod (F : ReducedTensorWords R M →ₗ[R] M) {n p d : ℕ} (hd : 0 < d)
+    (hpd : p + d ≤ n) (x : Fin n → M) :
+    coderivSummand R F n p d (PiTensorProduct.tprod R x) =
+      splice R x 0 n p d (F (subword R x p d)) := by
+  rw [coderivSummand, dite_eq_left ⟨hd, hpd⟩]
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe,
+    TensorPower.splitAt_tprod, LinearMap.lTensor_tmul, LinearMap.rTensor_tmul,
+    TauCeti.TensorPower.oneEquiv_symm_apply, TensorPower.mulEquiv_tprod_tmul_tprod,
+    TensorPower.cast_tprod, Fin.val_castLE]
+  rw [← subword_eq_of_tprod R x (a := p) (b := d) hd (by omega),
+    splice_eq_of_tprod R x _ hd (by omega) (by omega)]
+  refine of_tprod_congr R M _ _ rfl fun i ↦ ?_
+  have hi := i.isLt
+  rw [Function.comp_apply, append_eq_dite]
+  simp only [Fin.val_cast]
+  by_cases h₁ : i.1 < p
+  · rw [dite_eq_left h₁, dite_eq_left h₁]
+    exact congrArg x (Fin.ext (by simp only [Fin.val_castLE]; omega))
+  · rw [dite_eq_right h₁, dite_eq_right h₁, append_eq_dite]
+    by_cases h₂ : i.1 = p
+    · rw [dite_eq_left (show i.1 - p < 1 by omega), dite_eq_left h₂]
+    · rw [dite_eq_right (show ¬i.1 - p < 1 by omega), dite_eq_right h₂]
+      exact congrArg x (by simp only [Fin.mk.injEq]; omega)
+
+
+/-- The linear endomorphism of the reduced tensor coalgebra whose Taylor components are `F`: on a
+tensor word it collapses each nonempty block of letters to the single letter that `F` produces
+from that block, and sums over all blocks. -/
+noncomputable def coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
+    ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M :=
+  DirectSum.toModule R {n : ℕ // 0 < n} _ fun n ↦
+    ∑ p ∈ Finset.range n.1, ∑ d ∈ Finset.range (n.1 + 1), coderivSummand R F n.1 p d
+
+theorem coderiv_of (F : ReducedTensorWords R M →ₗ[R] M) (n : {n : ℕ // 0 < n})
+    (z : TensorPower R n.1 M) :
+    coderiv R F (of R M n z) =
+      ∑ p ∈ Finset.range n.1, ∑ d ∈ Finset.range (n.1 + 1), coderivSummand R F n.1 p d z := by
+  rw [coderiv, toModule_of]
+  simp only [LinearMap.sum_apply]
+
+/-- A Taylor summand vanishes when its collapsed block does not fit in the block it splices. -/
+private theorem splice_eq_zero_of_not_fits {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M)
+    (h : ¬(0 < d ∧ p + d ≤ b)) : splice R x a b p d e = 0 := by
+  rcases Nat.eq_zero_or_pos d with rfl | hd
+  · exact splice_zero_length R x a b p e
+  · exact splice_eq_zero_of_lt_add R x e (by omega)
+
+/-- A Taylor summand on a tensor word that is a block of a longer tuple, read back in that
+tuple. -/
+private theorem coderivSummand_tprod_of_eq (F : ReducedTensorWords R M →ₗ[R] M) {n b : ℕ}
+    (x : Fin n → M) (y : Fin b → M) {a : ℕ} (hab : a + b ≤ n)
+    (hy : ∀ (j : ℕ) (hj : j < b), y ⟨j, hj⟩ = x ⟨a + j, by omega⟩) (p d : ℕ) :
+    coderivSummand R F b p d (PiTensorProduct.tprod R y) =
+      splice R x a b p d (F (subword R x (a + p) d)) := by
+  by_cases h : 0 < d ∧ p + d ≤ b
+  · rw [coderivSummand_tprod R F h.1 h.2,
+      subword_congr R y x (a := p) (a' := a + p) (by omega) (by omega) fun j hj ↦ by
+        rw [hy (p + j) (by omega)]
+        exact congrArg x (by simp only [Fin.mk.injEq]; omega)]
+    exact splice_congr R y x _ (by omega) (by omega) fun j hj ↦ by
+      rw [hy (0 + j) (by omega)]
+      exact congrArg x (by simp only [Fin.mk.injEq]; omega)
+  · rw [coderivSummand_eq_zero R F h, LinearMap.zero_apply, splice_eq_zero_of_not_fits R x _ h]
+
+/-- The Taylor expansion of `coderiv F` on a block of a tensor word.  The two ranges may be taken
+as large as convenient, since a summand whose collapsed block does not fit inside the block
+vanishes; that is what lets the expansions of a word and of its two halves be summed over one
+common range. -/
+theorem coderiv_subword (F : ReducedTensorWords R M →ₗ[R] M) {n : ℕ} (x : Fin n → M) {a b K : ℕ}
+    (hab : a + b ≤ n) (hK : b ≤ K) :
+    coderiv R F (subword R x a b) =
+      ∑ p ∈ Finset.range K, ∑ d ∈ Finset.range (K + 1),
+        splice R x a b p d (F (subword R x (a + p) d)) := by
+  have hvanish : ∀ p d : ℕ, b ≤ p ∨ b < d →
+      splice R x a b p d (F (subword R x (a + p) d)) = 0 := fun p d h ↦
+    splice_eq_zero_of_not_fits R x _ (by omega)
+  rcases Nat.eq_zero_or_pos b with rfl | hb
+  · rw [subword_length_zero, map_zero]
+    exact (Finset.sum_eq_zero fun p _ ↦ Finset.sum_eq_zero fun d _ ↦
+      hvanish p d (Or.inl (Nat.zero_le p))).symm
+  have inner : ∀ p : ℕ, ∑ d ∈ Finset.range (b + 1),
+      splice R x a b p d (F (subword R x (a + p) d)) =
+      ∑ d ∈ Finset.range (K + 1), splice R x a b p d (F (subword R x (a + p) d)) :=
+    fun p ↦ Finset.sum_subset (Finset.range_subset_range.mpr (by omega)) fun d _ hd ↦ by
+      simp only [Finset.mem_range, not_lt] at hd
+      exact hvanish p d (Or.inr (by omega))
+  have outer : ∑ p ∈ Finset.range b, ∑ d ∈ Finset.range (K + 1),
+      splice R x a b p d (F (subword R x (a + p) d)) =
+      ∑ p ∈ Finset.range K, ∑ d ∈ Finset.range (K + 1),
+        splice R x a b p d (F (subword R x (a + p) d)) :=
+    Finset.sum_subset (Finset.range_subset_range.mpr hK) fun p _ hp ↦ by
+      simp only [Finset.mem_range, not_lt] at hp
+      exact Finset.sum_eq_zero fun d _ ↦ hvanish p d (Or.inl hp)
+  rw [subword_eq_of_tprod R x hb hab, coderiv_of, ← outer,
+    ← Finset.sum_congr rfl (fun p (_ : p ∈ Finset.range b) ↦ inner p)]
+  exact Finset.sum_congr rfl fun p _ ↦ Finset.sum_congr rfl fun d _ ↦
+    coderivSummand_tprod_of_eq R F x _ hab (fun j hj ↦ rfl) p d
+
+
+/-- A linear endomorphism of the reduced tensor coalgebra is a *coderivation* when it satisfies
+the co-Leibniz rule: cutting its value is the same as cutting first and applying it to one of the
+two halves. -/
+def IsCoderivation (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) : Prop :=
+  deconcatenation R M ∘ₗ b =
+    (LinearMap.rTensor (ReducedTensorWords R M) b +
+        LinearMap.lTensor (ReducedTensorWords R M) b) ∘ₗ deconcatenation R M
+
+variable {R}
+
+/-- The co-Leibniz rule of a coderivation, applied to an element. -/
+theorem IsCoderivation.deconcatenation_apply
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} (hb : IsCoderivation R b)
+    (z : ReducedTensorWords R M) :
+    deconcatenation R M (b z) =
+      LinearMap.rTensor (ReducedTensorWords R M) b (deconcatenation R M z) +
+        LinearMap.lTensor (ReducedTensorWords R M) b (deconcatenation R M z) := by
+  have h := congrArg (fun f ↦ f z) hb
+  simpa only [LinearMap.coe_comp, Function.comp_apply, LinearMap.add_apply] using h
+
+/-- Two endomorphisms agreeing on a submodule have the same co-Leibniz term on tensors of two
+elements of that submodule. -/
+private theorem rTensor_add_lTensor_congr
+    {b₁ b₂ : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
+    (P : Submodule R (ReducedTensorWords R M)) (h : ∀ z ∈ P, b₁ z = b₂ z) (w : P ⊗[R] P) :
+    LinearMap.rTensor (ReducedTensorWords R M) b₁ (TensorProduct.mapIncl P P w) +
+        LinearMap.lTensor (ReducedTensorWords R M) b₁ (TensorProduct.mapIncl P P w) =
+      LinearMap.rTensor (ReducedTensorWords R M) b₂ (TensorProduct.mapIncl P P w) +
+        LinearMap.lTensor (ReducedTensorWords R M) b₂ (TensorProduct.mapIncl P P w) := by
+  induction w using TensorProduct.induction_on with
+  | zero => simp only [map_zero, add_zero]
+  | tmul u v =>
+      simp only [TensorProduct.mapIncl, TensorProduct.map_tmul, Submodule.coe_subtype,
+        LinearMap.rTensor_tmul, LinearMap.lTensor_tmul, h _ u.2, h _ v.2]
+  | add u v hu hv =>
+      simp only [map_add]
+      rw [add_add_add_comm, hu, hv, ← add_add_add_comm]
+
+/-- A coderivation of the reduced tensor coalgebra is determined by its Taylor components, that is
+by its composite with the projection onto single letters.  Two coderivations agreeing there agree
+on every tensor word, by induction along the conilpotence filtration. -/
+theorem IsCoderivation.eq_of_letter_comp_eq
+    {b₁ b₂ : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} (h₁ : IsCoderivation R b₁)
+    (h₂ : IsCoderivation R b₂) (hl : letter R M ∘ₗ b₁ = letter R M ∘ₗ b₂) : b₁ = b₂ := by
+  have hletter : ∀ z, letter R M (b₁ z) = letter R M (b₂ z) := fun z ↦ by
+    have h := congrArg (fun f ↦ f z) hl
+    simpa only [LinearMap.coe_comp, Function.comp_apply] using h
+  have key : ∀ n : ℕ, ∀ z ∈ filtration R M n, b₁ z = b₂ z := by
+    intro n
+    induction n with
+    | zero =>
+        intro z hz
+        rw [filtration_zero] at hz
+        rw [(Submodule.mem_bot R).1 hz, map_zero, map_zero]
+    | succ n ih =>
+        intro z hz
+        refine eq_of_deconcatenation_eq_of_letter_eq R M ?_ (hletter z)
+        obtain ⟨w, hw⟩ := map_deconcatenation_filtration_succ_le R M n ⟨z, hz, rfl⟩
+        rw [h₁.deconcatenation_apply, h₂.deconcatenation_apply, ← hw]
+        exact rTensor_add_lTensor_congr _ ih w
+  refine LinearMap.ext fun z ↦ ?_
+  have hz : z ∈ ⨆ n : ℕ, filtration R M n := by rw [iSup_filtration_eq_top]; trivial
+  obtain ⟨n, hn⟩ :=
+    (Submodule.mem_iSup_of_directed _ (filtration_monotone R M).directed_le).1 hz
+  exact key n z hn
+
+variable (R)
+
+/-- Cutting a word at every nontrivial position, indexed by the length of the left half. -/
+private theorem sum_Ioo_eq_sum_range {N : Type*} [AddCommMonoid N] (n : ℕ) (g : ℕ → N)
+    (hg : g 0 = 0) : ∑ c ∈ Finset.Ioo 0 n, g c = ∑ c ∈ Finset.range n, g c := by
+  refine Finset.sum_subset (fun c hc ↦ ?_) fun c hc hc' ↦ ?_
+  · simp only [Finset.mem_Ioo, Finset.mem_range] at hc ⊢
+    omega
+  · simp only [Finset.mem_range] at hc
+    have hc0 : c = 0 := by
+      by_contra hne
+      exact hc' (Finset.mem_Ioo.2 ⟨by omega, hc⟩)
+    rw [hc0, hg]
+
+/-- Summing a two-variable family over the pairs `(c, p - c)` with `c ≤ p < K` is the same as
+summing it over the square `range K ×ˢ range K`, when the family vanishes off the triangle. -/
+private theorem sum_range_triangle {N : Type*} [AddCommMonoid N] (K : ℕ) (g : ℕ → ℕ → N)
+    (hg : ∀ c q : ℕ, K ≤ c + q → g c q = 0) :
+    ∑ p ∈ Finset.range K, ∑ c ∈ Finset.range (p + 1), g c (p - c) =
+      ∑ c ∈ Finset.range K, ∑ q ∈ Finset.range K, g c q := by
+  simp only [Finset.range_eq_Ico]
+  rw [← Finset.sum_Ico_Ico_comm 0 K fun i j ↦ g i (j - i)]
+  refine Finset.sum_congr rfl fun i hi ↦ ?_
+  simp only [Finset.mem_Ico] at hi
+  rw [show Finset.Ico i K = Finset.Ico (0 + i) (K - i + i) by congr 1 <;> omega,
+    ← Finset.sum_Ico_add' (fun j ↦ g i (j - i)) 0 (K - i) i]
+  simp only [Nat.add_sub_cancel]
+  refine Finset.sum_subset (Finset.Ico_subset_Ico (le_refl 0) (by omega)) fun q _ hq ↦ ?_
+  have hqge : K - i ≤ q := by
+    by_contra hlt
+    exact hq (Finset.mem_Ico.2 ⟨Nat.zero_le q, by omega⟩)
+  exact hg i q (by omega)
+
+/-- `coderiv F` is a coderivation.  Both sides of the co-Leibniz rule are the sum, over a cut
+position and a collapsed block, of the tensor of the two halves with the block collapsed in
+whichever half contains it; a block is never split by a cut, and a cut never splits the new
+letter. -/
+theorem isCoderivation_coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
+    IsCoderivation R (coderiv R F) := by
+  refine linearMap_ext R M fun n x ↦ ?_
+  have hn : 0 < n.1 := n.2
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.add_apply]
+  rw [of_tprod_eq_subword R hn x]
+  have hLHS : deconcatenation R M (coderiv R F (subword R x 0 n.1)) =
+      (∑ p ∈ Finset.range n.1, ∑ d ∈ Finset.range (n.1 + 1), ∑ c ∈ Finset.range (p + 1),
+          subword R x 0 c ⊗ₜ[R]
+            splice R x c (n.1 - c) (p - c) d (F (subword R x p d))) +
+        ∑ p ∈ Finset.range n.1, ∑ d ∈ Finset.range (n.1 + 1), ∑ c ∈ Finset.range n.1,
+          splice R x 0 c p d (F (subword R x p d)) ⊗ₜ[R] subword R x c (n.1 - c) := by
+    rw [coderiv_subword R F x (a := 0) (b := n.1) (K := n.1) (by omega) (le_refl n.1), map_sum,
+      ← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl fun p _ ↦ ?_
+    rw [map_sum, ← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl fun d _ ↦ ?_
+    rw [deconcatenation_splice R x _ (by omega)]
+    simp only [Nat.zero_add]
+  have hdelta : deconcatenation R M (subword R x 0 n.1) =
+      ∑ c ∈ Finset.range n.1, subword R x 0 c ⊗ₜ[R] subword R x c (n.1 - c) := by
+    rw [deconcatenation_subword R x (a := 0) (b := n.1)]
+    simp only [Nat.zero_add]
+    exact sum_Ioo_eq_sum_range n.1 _ (by rw [subword_length_zero, TensorProduct.zero_tmul])
+  have hRHS : LinearMap.rTensor (ReducedTensorWords R M) (coderiv R F)
+        (deconcatenation R M (subword R x 0 n.1)) +
+      LinearMap.lTensor (ReducedTensorWords R M) (coderiv R F)
+        (deconcatenation R M (subword R x 0 n.1)) =
+      (∑ c ∈ Finset.range n.1, ∑ p ∈ Finset.range n.1, ∑ d ∈ Finset.range (n.1 + 1),
+          splice R x 0 c p d (F (subword R x p d)) ⊗ₜ[R] subword R x c (n.1 - c)) +
+        ∑ c ∈ Finset.range n.1, ∑ p ∈ Finset.range n.1, ∑ d ∈ Finset.range (n.1 + 1),
+          subword R x 0 c ⊗ₜ[R]
+            splice R x c (n.1 - c) p d (F (subword R x (c + p) d)) := by
+    rw [hdelta, map_sum, map_sum]
+    congr 1 <;> refine Finset.sum_congr rfl fun c hc ↦ ?_ <;>
+      simp only [Finset.mem_range] at hc
+    · rw [LinearMap.rTensor_tmul,
+        coderiv_subword R F x (a := 0) (b := c) (K := n.1) (by omega) (by omega),
+        TensorProduct.sum_tmul]
+      exact Finset.sum_congr rfl fun p _ ↦ by
+        rw [TensorProduct.sum_tmul]
+        simp only [Nat.zero_add]
+    · rw [LinearMap.lTensor_tmul,
+        coderiv_subword R F x (a := c) (b := n.1 - c) (K := n.1) (by omega) (by omega),
+        TensorProduct.tmul_sum]
+      exact Finset.sum_congr rfl fun p _ ↦ by rw [TensorProduct.tmul_sum]
+  rw [hLHS, hRHS, add_comm]
+  congr 1
+  · exact Eq.trans (Finset.sum_congr rfl fun p _ ↦ Finset.sum_comm) Finset.sum_comm
+  · have hg : ∀ c q : ℕ, n.1 ≤ c + q →
+        (∑ d ∈ Finset.range (n.1 + 1), subword R x 0 c ⊗ₜ[R]
+          splice R x c (n.1 - c) q d (F (subword R x (c + q) d))) = 0 :=
+      fun c q h ↦ Finset.sum_eq_zero fun d _ ↦ by
+        rw [splice_eq_zero_of_not_fits R x _ (by omega), TensorProduct.tmul_zero]
+    refine Eq.trans ?_ (sum_range_triangle n.1 _ hg)
+    refine Finset.sum_congr rfl fun p _ ↦ ?_
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun c hc ↦ Finset.sum_congr rfl fun d _ ↦ ?_
+    simp only [Finset.mem_range] at hc
+    rw [show c + (p - c) = p by omega]
+
+
+/-- The letter of a spliced word vanishes unless the whole block was collapsed, since otherwise
+the word has length at least two. -/
+private theorem letter_splice_eq_zero {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M) (hdb : d ≠ b) :
+    letter R M (splice R x a b p d e) = 0 := by
+  by_cases h : 0 < d ∧ p + d ≤ b ∧ a + b ≤ n
+  · rw [letter_apply, splice_eq_of_tprod R x e h.1 h.2.1 h.2.2,
+      component_of_of_ne R M
+        (by simp only [ne_eq, Subtype.ext_iff, Positive.val_one]; omega), map_zero]
+  · rw [splice_eq_zero R x e h, map_zero]
+
+/-- Collapsing a whole block leaves the single new letter. -/
+private theorem letter_splice_self {n : ℕ} (x : Fin n → M) {a b : ℕ} (e : M) (hb : 0 < b)
+    (hab : a + b ≤ n) : letter R M (splice R x a b 0 b e) = e := by
+  rw [letter_apply, splice_eq_of_tprod R x e hb (by omega) hab,
+    component_of_eq R M (m := ⟨b + 1 - b, by omega⟩) (n := 1)
+      (Subtype.ext (by simp only [Positive.val_one]; omega)),
+    TensorPower.cast_tprod, TauCeti.TensorPower.oneEquiv_tprod]
+  simp only [Function.comp_apply]
+  rw [dite_eq_right (by simp), dite_eq_left (by simp)]
+
+/-- The Taylor components of `coderiv F` are `F`: the only summand of the expansion that leaves a
+single letter is the one collapsing the whole word. -/
+@[simp]
+theorem letter_comp_coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
+    letter R M ∘ₗ coderiv R F = F := by
+  refine linearMap_ext R M fun n x ↦ ?_
+  have hn : 0 < n.1 := n.2
+  simp only [LinearMap.coe_comp, Function.comp_apply]
+  rw [of_tprod_eq_subword R hn x,
+    coderiv_subword R F x (a := 0) (b := n.1) (K := n.1) (by omega) (le_refl n.1), map_sum]
+  refine (Finset.sum_eq_single 0 ?_ ?_).trans ?_
+  · intro p _ hp
+    rw [map_sum]
+    refine Finset.sum_eq_zero fun d _ ↦ ?_
+    by_cases hd : d = n.1
+    · subst hd
+      rw [splice_eq_zero_of_lt_add R x _ (by omega), map_zero]
+    · exact letter_splice_eq_zero R x _ hd
+  · intro hp
+    exact absurd (Finset.mem_range.2 hn) hp
+  · rw [map_sum]
+    refine (Finset.sum_eq_single n.1 (fun d _ hd ↦ letter_splice_eq_zero R x _ hd) ?_).trans ?_
+    · intro hd
+      exact absurd (Finset.mem_range.2 (by omega)) hd
+    · rw [letter_splice_self R x _ hn (by omega), Nat.zero_add]
+
+variable (M)
+
+/-- The submodule of coderivations of the reduced tensor coalgebra.
+
+It is `@[expose]`d so that membership in it reduces to `TauCeti.ReducedTensorWords.IsCoderivation`
+outside this module. -/
+@[expose]
+def coderivations : Submodule R (ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) where
+  carrier := {b | IsCoderivation R b}
+  zero_mem' := by
+    simp only [Set.mem_ofPred_eq, IsCoderivation, LinearMap.comp_zero, LinearMap.rTensor_zero,
+      LinearMap.lTensor_zero, add_zero, LinearMap.zero_comp]
+  add_mem' := by
+    intro b₁ b₂ h₁ h₂
+    simp only [Set.mem_ofPred_eq, IsCoderivation, LinearMap.comp_add, LinearMap.rTensor_add,
+      LinearMap.lTensor_add] at h₁ h₂ ⊢
+    rw [h₁, h₂, ← LinearMap.add_comp]
+    exact congrArg (· ∘ₗ deconcatenation R M) (add_add_add_comm _ _ _ _)
+  smul_mem' := by
+    intro r b hb
+    simp only [Set.mem_ofPred_eq, IsCoderivation, LinearMap.comp_smul, LinearMap.rTensor_smul,
+      LinearMap.lTensor_smul] at hb ⊢
+    rw [hb, ← smul_add, LinearMap.smul_comp]
+
+@[simp]
+theorem mem_coderivations {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} :
+    b ∈ coderivations R M ↔ IsCoderivation R b := Iff.rfl
+
+/-- Coderivations of the reduced tensor coalgebra are exactly their Taylor components: taking the
+letter of the value is a linear isomorphism onto the maps to single letters, with inverse the
+Taylor expansion `coderiv`. -/
+@[expose]
+noncomputable def coderivEquivTaylor :
+    coderivations R M ≃ₗ[R] (ReducedTensorWords R M →ₗ[R] M) where
+  toFun b := letter R M ∘ₗ b.1
+  map_add' _ _ := LinearMap.comp_add _ _ _
+  map_smul' _ _ := LinearMap.comp_smul _ _ _
+  invFun F := ⟨coderiv R F, isCoderivation_coderiv R F⟩
+  left_inv b := Subtype.ext <| (isCoderivation_coderiv R _).eq_of_letter_comp_eq b.2
+    (letter_comp_coderiv R _)
+  right_inv F := letter_comp_coderiv R F
+
+@[simp]
+theorem coderivEquivTaylor_apply (b : coderivations R M) :
+    coderivEquivTaylor R M b = letter R M ∘ₗ b.1 := rfl
+
+@[simp]
+theorem coderivEquivTaylor_symm_apply (F : ReducedTensorWords R M →ₗ[R] M) :
+    (coderivEquivTaylor R M).symm F = ⟨coderiv R F, isCoderivation_coderiv R F⟩ := rfl
+
+end ReducedTensorWords
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -72,12 +72,16 @@ private theorem append_eq_dite {α : Type*} {k l : ℕ} (u : Fin k → α) (v : 
     Fin.append u v i = if hi : i.1 < k then u ⟨i.1, hi⟩ else v ⟨i.1 - k, by omega⟩ := by
   induction i using Fin.addCases with
   | left j =>
-      rw [Fin.append_left, dite_eq_left (show (Fin.castAdd l j).1 < k from j.isLt)]
+      have hj : (Fin.castAdd l j).1 < k := j.isLt
+      rw [Fin.append_left, dite_eq_left hj]
       rfl
   | right j =>
-      rw [Fin.append_right,
-        dite_eq_right (show ¬(Fin.natAdd k j).1 < k by simp only [Fin.val_natAdd]; omega)]
-      exact congrArg v (Fin.ext (show (j : ℕ) = k + (j : ℕ) - k by omega))
+      have hj : ¬(Fin.natAdd k j).1 < k := by
+        simp only [Fin.val_natAdd]
+        omega
+      have hj_sub : (j : ℕ) = k + (j : ℕ) - k := by omega
+      rw [Fin.append_right, dite_eq_right hj]
+      exact congrArg v (Fin.ext hj_sub)
 
 /-- The `(p, d)` summand of the Taylor expansion of a coderivation with components `F`, on tensor
 words of length `n`: collapse the `d` letters at position `p` to the single letter that `F`
@@ -88,8 +92,9 @@ It is zero unless the collapsed block is nonempty and fits, that is unless `0 < 
 private noncomputable def coderivSummand (F : ReducedTensorWords R M →ₗ[R] M) (n p d : ℕ) :
     TensorPower R n M →ₗ[R] ReducedTensorWords R M :=
   if h : 0 < d ∧ p + d ≤ n then
+    let hlength : p + (1 + (n - p - d)) = n + 1 - d := by omega
     of R M ⟨n + 1 - d, by omega⟩ ∘ₗ
-      (TensorPower.cast R M (show p + (1 + (n - p - d)) = n + 1 - d by omega)).toLinearMap ∘ₗ
+      (TensorPower.cast R M hlength).toLinearMap ∘ₗ
       (TensorPower.mulEquiv (R := R) (M := M)).toLinearMap ∘ₗ
       LinearMap.lTensor (TensorPower R p M)
         ((TensorPower.mulEquiv (R := R) (M := M)).toLinearMap ∘ₗ
@@ -126,8 +131,10 @@ private theorem coderivSummand_tprod (F : ReducedTensorWords R M →ₗ[R] M) {n
     exact congrArg x (Fin.ext (by simp only [Fin.val_castLE]; omega))
   · rw [dite_eq_right h₁, dite_eq_right h₁, append_eq_dite]
     by_cases h₂ : i.1 = p
-    · rw [dite_eq_left (show i.1 - p < 1 by omega), dite_eq_left h₂]
-    · rw [dite_eq_right (show ¬i.1 - p < 1 by omega), dite_eq_right h₂]
+    · have hi_sub : i.1 - p < 1 := by omega
+      rw [dite_eq_left hi_sub, dite_eq_left h₂]
+    · have hi_sub : ¬i.1 - p < 1 := by omega
+      rw [dite_eq_right hi_sub, dite_eq_right h₂]
       exact congrArg x (by simp only [Fin.mk.injEq]; omega)
 
 
@@ -300,7 +307,9 @@ private theorem sum_range_triangle {N : Type*} [AddCommMonoid N] (K : ℕ) (g : 
   rw [← Finset.sum_Ico_Ico_comm 0 K fun i j ↦ g i (j - i)]
   refine Finset.sum_congr rfl fun i hi ↦ ?_
   simp only [Finset.mem_Ico] at hi
-  rw [show Finset.Ico i K = Finset.Ico (0 + i) (K - i + i) by congr 1 <;> omega,
+  have hIco : Finset.Ico i K = Finset.Ico (0 + i) (K - i + i) := by
+    congr 1 <;> omega
+  rw [hIco,
     ← Finset.sum_Ico_add' (fun j ↦ g i (j - i)) 0 (K - i) i]
   simp only [Nat.add_sub_cancel]
   refine Finset.sum_subset (Finset.Ico_subset_Ico (le_refl 0) (by omega)) fun q _ hq ↦ ?_
@@ -372,7 +381,8 @@ theorem isCoderivation_coderiv (F : ReducedTensorWords R M →ₗ[R] M) :
     rw [Finset.sum_comm]
     refine Finset.sum_congr rfl fun c hc ↦ Finset.sum_congr rfl fun d _ ↦ ?_
     simp only [Finset.mem_range] at hc
-    rw [show c + (p - c) = p by omega]
+    have hcp : c + (p - c) = p := by omega
+    rw [hcp]
 
 
 /-- The letter of a spliced word vanishes unless the whole block was collapsed, since otherwise

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Splice.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Splice.lean
@@ -1,0 +1,283 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.TensorCoalgebra.Basic
+
+/-!
+# Collapsing a block of a tensor word to a single letter
+
+For an `R`-module `M`, `TauCeti.ReducedTensorWords.splice x a b p d e` is the tensor word obtained
+from the block `x a ⋯ x (a + b - 1)` by deleting its `d` letters at relative offset `p` and putting
+the single letter `e` in their place.  It is the shape of every summand of a coderivation of the
+reduced tensor coalgebra, whose Taylor expansion replaces one block of letters by the value of a
+single operation on that block.
+
+The main computation here is `TauCeti.ReducedTensorWords.deconcatenation_splice`: a cut of a spliced
+word falls either weakly to the left of the new letter, leaving a plain block on the left and a
+spliced word on the right, or strictly to its right, leaving a spliced word on the left and a plain
+block on the right.  No cut splits the new letter, a letter having no internal position.  Written
+this way both halves are again of the two shapes `subword` and `splice`, which is what makes the
+coderivation identity an equality of two sums over the same pairs of a cut position and a collapsed
+block.
+
+## Main definitions
+
+* `TauCeti.ReducedTensorWords.splice`: a block of a tensor word with one of its subblocks collapsed
+  to a single letter.
+
+## Main results
+
+* `TauCeti.ReducedTensorWords.splice_congr`: a spliced word depends only on the letters spliced.
+* `TauCeti.ReducedTensorWords.deconcatenation_splice`: reduced deconcatenation of a spliced word.
+
+## References
+
+* E. Getzler and J. D. S. Jones, *A-infinity algebras and the cyclic bar complex*, Sections 1--2.
+* B. Keller, *Introduction to A-infinity algebras and modules*, Sections 3.1 and 3.6.
+-/
+
+public section
+
+open scoped BigOperators DirectSum TensorProduct
+
+universe uR uM
+
+namespace TauCeti
+
+namespace ReducedTensorWords
+
+variable (R : Type uR) {M : Type uM} [CommSemiring R] [AddCommMonoid M] [Module R M]
+
+/-- The block `x a ⊗ ⋯ ⊗ x (a + b - 1)` with its `d` letters at relative offset `p` replaced by the
+single letter `e`, a tensor word of length `b + 1 - d`.
+
+It is zero unless the collapsed block is nonempty and fits inside the block being spliced, which
+fits inside `x`; the intended range of the definition is `0 < d`, `p + d ≤ b` and `a + b ≤ n`. -/
+noncomputable def splice {n : ℕ} (x : Fin n → M) (a b p d : ℕ) (e : M) :
+    ReducedTensorWords R M :=
+  if h : 0 < d ∧ p + d ≤ b ∧ a + b ≤ n then
+    of R M ⟨b + 1 - d, by omega⟩
+      (PiTensorProduct.tprod R fun j : Fin (b + 1 - d) ↦
+        if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+        else if _ : j.1 = p then e
+        else x ⟨a + (j.1 + d - 1), by omega⟩)
+  else 0
+
+/-- On its intended range, a spliced word is the pure tensor of its letters: the letters of the
+block before the collapsed subblock, then the new letter, then the letters after it. -/
+theorem splice_eq_of_tprod {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M) (hd : 0 < d)
+    (hpd : p + d ≤ b) (hab : a + b ≤ n) :
+    splice R x a b p d e =
+      of R M ⟨b + 1 - d, by omega⟩
+        (PiTensorProduct.tprod R fun j : Fin (b + 1 - d) ↦
+          if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+          else if _ : j.1 = p then e
+          else x ⟨a + (j.1 + d - 1), by omega⟩) := by
+  rw [splice, dite_eq_left ⟨hd, hpd, hab⟩]
+
+/-- Collapsing an empty subblock is zero: a letter is never produced out of nothing. -/
+@[simp]
+theorem splice_zero_length {n : ℕ} (x : Fin n → M) (a b p : ℕ) (e : M) :
+    splice R x a b p 0 e = 0 := by
+  rw [splice, dite_eq_right (by omega)]
+
+/-- A collapsed subblock running past the end of the spliced block is zero. -/
+@[simp]
+theorem splice_eq_zero_of_lt_add {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M) (hpd : b < p + d) :
+    splice R x a b p d e = 0 := by
+  rw [splice, dite_eq_right (by omega)]
+
+/-- A spliced block running past the end of the tuple is zero. -/
+@[simp]
+theorem splice_eq_zero_of_lt_add' {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M) (hab : n < a + b) :
+    splice R x a b p d e = 0 := by
+  rw [splice, dite_eq_right (by omega)]
+
+/-- A spliced word is zero outside the intended range of the definition. -/
+theorem splice_eq_zero {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M)
+    (h : ¬(0 < d ∧ p + d ≤ b ∧ a + b ≤ n)) : splice R x a b p d e = 0 := by
+  rw [splice, dite_eq_right h]
+
+/-- A spliced word depends only on the letters of the block it splices, not on the tuple carrying
+them nor on the position of the block in it. -/
+theorem splice_congr {n m : ℕ} (x : Fin n → M) (y : Fin m → M) {a a' b p d : ℕ} (e : M)
+    (hab : a + b ≤ n) (hab' : a' + b ≤ m)
+    (h : ∀ (j : ℕ) (hj : j < b), x ⟨a + j, by omega⟩ = y ⟨a' + j, by omega⟩) :
+    splice R x a b p d e = splice R y a' b p d e := by
+  by_cases hd : 0 < d ∧ p + d ≤ b
+  · rw [splice_eq_of_tprod R x e hd.1 hd.2 hab, splice_eq_of_tprod R y e hd.1 hd.2 hab']
+    refine of_tprod_congr R M _ _ rfl fun j ↦ ?_
+    have hj := j.isLt
+    simp only [Fin.val_cast]
+    split_ifs with h₁ h₂
+    · exact h j.1 (by omega)
+    · rfl
+    · exact h (j.1 + d - 1) (by omega)
+  · rw [splice, splice, dite_eq_right (by tauto), dite_eq_right (by tauto)]
+
+
+/-- Reduced deconcatenation of a pure tensor word, cut at every nontrivial position. -/
+private theorem deconcatenation_of_tprod {L : ℕ} (hL : 0 < L) (y : Fin L → M) :
+    deconcatenation R M (of R M ⟨L, hL⟩ (PiTensorProduct.tprod R y)) =
+      ∑ c ∈ Finset.Ioo 0 L, subword R y 0 c ⊗ₜ[R] subword R y c (L - c) := by
+  rw [of_tprod_eq_subword R hL y, deconcatenation_subword R y (a := 0) (b := L)]
+  exact Finset.sum_congr rfl fun c _ ↦ by rw [Nat.zero_add]
+
+/-- Cutting a spliced word weakly to the left of the new letter leaves a shorter block on the left
+and a spliced word on the right. -/
+private theorem deconcatenation_splice_left {n : ℕ} (x : Fin n → M) {a b p d c : ℕ} (e : M)
+    (hd : 0 < d) (hpd : p + d ≤ b) (hab : a + b ≤ n) (hc : 0 < c) (hcp : c ≤ p) :
+    subword R
+        (fun j : Fin (b + 1 - d) ↦
+          if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+          else if _ : j.1 = p then e
+          else x ⟨a + (j.1 + d - 1), by omega⟩) 0 c ⊗ₜ[R]
+      subword R
+        (fun j : Fin (b + 1 - d) ↦
+          if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+          else if _ : j.1 = p then e
+          else x ⟨a + (j.1 + d - 1), by omega⟩) c (b + 1 - d - c) =
+      subword R x a c ⊗ₜ[R] splice R x (a + c) (b - c) (p - c) d e := by
+  have hfst : subword R
+      (fun j : Fin (b + 1 - d) ↦
+        if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+        else if _ : j.1 = p then e
+        else x ⟨a + (j.1 + d - 1), by omega⟩) 0 c = subword R x a c := by
+    rw [subword_eq_of_tprod R _ hc (by omega), subword_eq_of_tprod R x hc (by omega)]
+    refine of_tprod_congr R M _ _ rfl fun j ↦ ?_
+    have hj := j.isLt
+    simp only [Fin.val_cast]
+    rw [dite_eq_left (show (0 + j.1) < p by omega)]
+    exact congrArg x (by simp only [Fin.mk.injEq]; omega)
+  have hsnd : subword R
+      (fun j : Fin (b + 1 - d) ↦
+        if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+        else if _ : j.1 = p then e
+        else x ⟨a + (j.1 + d - 1), by omega⟩) c (b + 1 - d - c) =
+      splice R x (a + c) (b - c) (p - c) d e := by
+    rw [subword_eq_of_tprod R _ (by omega) (by omega),
+      splice_eq_of_tprod R x e hd (by omega) (by omega)]
+    refine of_tprod_congr R M _ _ (by omega) fun j ↦ ?_
+    have hj := j.isLt
+    simp only [Fin.val_cast]
+    split_ifs <;> first | rfl | exact congrArg x (by simp only [Fin.mk.injEq]; omega) | omega
+  rw [hfst, hsnd]
+
+/-- Cutting a spliced word strictly to the right of the new letter leaves a spliced word on the
+left and a shorter block on the right. -/
+private theorem deconcatenation_splice_right {n : ℕ} (x : Fin n → M) {a b p d c : ℕ} (e : M)
+    (hd : 0 < d) (hpd : p + d ≤ b) (hab : a + b ≤ n) (hpc : p < c) (hc : c < b + 1 - d) :
+    subword R
+        (fun j : Fin (b + 1 - d) ↦
+          if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+          else if _ : j.1 = p then e
+          else x ⟨a + (j.1 + d - 1), by omega⟩) 0 c ⊗ₜ[R]
+      subword R
+        (fun j : Fin (b + 1 - d) ↦
+          if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+          else if _ : j.1 = p then e
+          else x ⟨a + (j.1 + d - 1), by omega⟩) c (b + 1 - d - c) =
+      splice R x a (c + (d - 1)) p d e ⊗ₜ[R]
+        subword R x (a + (c + (d - 1))) (b - (c + (d - 1))) := by
+  have hfst : subword R
+      (fun j : Fin (b + 1 - d) ↦
+        if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+        else if _ : j.1 = p then e
+        else x ⟨a + (j.1 + d - 1), by omega⟩) 0 c = splice R x a (c + (d - 1)) p d e := by
+    rw [subword_eq_of_tprod R _ (by omega) (by omega),
+      splice_eq_of_tprod R x e hd (by omega) (by omega)]
+    refine of_tprod_congr R M _ _ (by omega) fun j ↦ ?_
+    have hj := j.isLt
+    simp only [Fin.val_cast]
+    split_ifs <;> first | rfl | exact congrArg x (by simp only [Fin.mk.injEq]; omega) | omega
+  have hsnd : subword R
+      (fun j : Fin (b + 1 - d) ↦
+        if _ : j.1 < p then x ⟨a + j.1, by omega⟩
+        else if _ : j.1 = p then e
+        else x ⟨a + (j.1 + d - 1), by omega⟩) c (b + 1 - d - c) =
+      subword R x (a + (c + (d - 1))) (b - (c + (d - 1))) := by
+    rw [subword_eq_of_tprod R _ (by omega) (by omega),
+      subword_eq_of_tprod R x (by omega) (by omega)]
+    refine of_tprod_congr R M _ _ (by omega) fun j ↦ ?_
+    have hj := j.isLt
+    simp only [Fin.val_cast]
+    rw [dite_eq_right (show ¬(c + j.1) < p by omega),
+      dite_eq_right (show ¬(c + j.1) = p by omega)]
+    exact congrArg x (by simp only [Fin.mk.injEq]; omega)
+  rw [hfst, hsnd]
+
+/-- Reduced deconcatenation of a spliced word, when the collapsed block really is a nonempty
+block of the spliced block. -/
+private theorem deconcatenation_splice_of_le {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M)
+    (hd : 0 < d) (hpd : p + d ≤ b) (hab : a + b ≤ n) :
+    deconcatenation R M (splice R x a b p d e) =
+      (∑ c ∈ Finset.range (p + 1), subword R x a c ⊗ₜ[R] splice R x (a + c) (b - c) (p - c) d e) +
+        ∑ c ∈ Finset.range b, splice R x a c p d e ⊗ₜ[R] subword R x (a + c) (b - c) := by
+  rw [splice_eq_of_tprod R x e hd hpd hab, deconcatenation_of_tprod R (by omega)]
+  have hIoo : Finset.Ioo 0 (b + 1 - d) =
+      Finset.Ico 1 (p + 1) ∪ Finset.Ico (p + 1) (b + 1 - d) := by
+    rw [Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)]
+    ext c
+    simp only [Finset.mem_Ioo, Finset.mem_Ico]
+    omega
+  rw [hIoo, Finset.sum_union (Finset.Ico_disjoint_Ico_consecutive 1 (p + 1) (b + 1 - d))]
+  congr 1
+  · have hzero : ∀ c ∈ Finset.Ico 0 (p + 1), c ∉ Finset.Ico 1 (p + 1) →
+        subword R x a c ⊗ₜ[R] splice R x (a + c) (b - c) (p - c) d e = 0 := by
+      intro c hc hc'
+      have hc0 : c = 0 := by
+        by_contra hne
+        exact hc' (Finset.mem_Ico.2 ⟨by omega, (Finset.mem_Ico.1 hc).2⟩)
+      rw [hc0, subword_length_zero, TensorProduct.zero_tmul]
+    rw [Finset.range_eq_Ico,
+      ← Finset.sum_subset (Finset.Ico_subset_Ico_left (Nat.zero_le 1)) hzero]
+    refine Finset.sum_congr rfl fun c hc ↦ ?_
+    simp only [Finset.mem_Ico] at hc
+    exact deconcatenation_splice_left R x e hd hpd hab (by omega) (by omega)
+  · have hzero : ∀ c ∈ Finset.Ico 0 b, c ∉ Finset.Ico (p + d) b →
+        splice R x a c p d e ⊗ₜ[R] subword R x (a + c) (b - c) = 0 := by
+      intro c hc hc'
+      have hlt : c < p + d := by
+        by_contra hge
+        exact hc' (Finset.mem_Ico.2 ⟨by omega, (Finset.mem_Ico.1 hc).2⟩)
+      rw [splice_eq_zero_of_lt_add R x e hlt, TensorProduct.zero_tmul]
+    rw [Finset.range_eq_Ico,
+      ← Finset.sum_subset (Finset.Ico_subset_Ico (Nat.zero_le (p + d)) (le_refl b)) hzero,
+      show Finset.Ico (p + d) b = Finset.Ico (p + 1 + (d - 1)) (b + 1 - d + (d - 1)) by
+        congr 1 <;> omega,
+      ← Finset.sum_Ico_add'
+        (fun c ↦ splice R x a c p d e ⊗ₜ[R] subword R x (a + c) (b - c)) (p + 1) (b + 1 - d)
+        (d - 1)]
+    refine Finset.sum_congr rfl fun c hc ↦ ?_
+    simp only [Finset.mem_Ico] at hc
+    exact deconcatenation_splice_right R x e hd hpd hab (by omega) (by omega)
+
+/-- Reduced deconcatenation of a spliced word.  A cut never splits the new letter, so it falls
+either weakly to its left, leaving a plain block and a spliced word, or strictly to its right,
+leaving a spliced word and a plain block.  Both sums range over the cut position measured in the
+original block, and their summands vanish outside the positions that really occur; that is what
+makes the identity hold for a degenerate collapsed block too, both sides then being zero. -/
+theorem deconcatenation_splice {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M) (hab : a + b ≤ n) :
+    deconcatenation R M (splice R x a b p d e) =
+      (∑ c ∈ Finset.range (p + 1), subword R x a c ⊗ₜ[R] splice R x (a + c) (b - c) (p - c) d e) +
+        ∑ c ∈ Finset.range b, splice R x a c p d e ⊗ₜ[R] subword R x (a + c) (b - c) := by
+  by_cases h : 0 < d ∧ p + d ≤ b
+  · exact deconcatenation_splice_of_le R x e h.1 h.2 hab
+  · rw [splice, dite_eq_right (by tauto), map_zero]
+    rw [Finset.sum_eq_zero fun c hc ↦ ?_, Finset.sum_eq_zero fun c hc ↦ ?_, add_zero]
+    · simp only [Finset.mem_range] at hc
+      rcases Nat.eq_zero_or_pos d with rfl | hd
+      · rw [splice_zero_length, TensorProduct.zero_tmul]
+      · rw [splice_eq_zero_of_lt_add R x e (by omega), TensorProduct.zero_tmul]
+    · simp only [Finset.mem_range] at hc
+      rcases Nat.eq_zero_or_pos d with rfl | hd
+      · rw [splice_zero_length, TensorProduct.tmul_zero]
+      · rw [splice_eq_zero_of_lt_add R x e (by omega), TensorProduct.tmul_zero]
+
+end ReducedTensorWords
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Splice.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Splice.lean
@@ -85,15 +85,19 @@ theorem splice_zero_length {n : ℕ} (x : Fin n → M) (a b p : ℕ) (e : M) :
     splice R x a b p 0 e = 0 := by
   rw [splice, dite_eq_right (by omega)]
 
-/-- A collapsed subblock running past the end of the spliced block is zero. -/
+/-- A collapsed subblock running past the end of the spliced block is zero: the length `b` of that
+block is smaller than the end `p + d` of the subblock. -/
 @[simp]
-theorem splice_eq_zero_of_lt_add {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M) (hpd : b < p + d) :
+theorem splice_eq_zero_of_block_lt_add {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M)
+    (hpd : b < p + d) :
     splice R x a b p d e = 0 := by
   rw [splice, dite_eq_right (by omega)]
 
-/-- A spliced block running past the end of the tuple is zero. -/
+/-- A spliced block running past the end of the tuple is zero: the length `n` of the tuple is
+smaller than the end `a + b` of the block. -/
 @[simp]
-theorem splice_eq_zero_of_lt_add' {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M) (hab : n < a + b) :
+theorem splice_eq_zero_of_length_lt_add {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M)
+    (hab : n < a + b) :
     splice R x a b p d e = 0 := by
   rw [splice, dite_eq_right (by omega)]
 
@@ -244,7 +248,7 @@ private theorem deconcatenation_splice_of_le {n : ℕ} (x : Fin n → M) {a b p 
       have hlt : c < p + d := by
         by_contra hge
         exact hc' (Finset.mem_Ico.2 ⟨by omega, (Finset.mem_Ico.1 hc).2⟩)
-      rw [splice_eq_zero_of_lt_add R x e hlt, TensorProduct.zero_tmul]
+      rw [splice_eq_zero_of_block_lt_add R x e hlt, TensorProduct.zero_tmul]
     rw [Finset.range_eq_Ico,
       ← Finset.sum_subset (Finset.Ico_subset_Ico (Nat.zero_le (p + d)) (le_refl b)) hzero,
       show Finset.Ico (p + d) b = Finset.Ico (p + 1 + (d - 1)) (b + 1 - d + (d - 1)) by
@@ -272,11 +276,11 @@ theorem deconcatenation_splice {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : 
     · simp only [Finset.mem_range] at hc
       rcases Nat.eq_zero_or_pos d with rfl | hd
       · rw [splice_zero_length, TensorProduct.zero_tmul]
-      · rw [splice_eq_zero_of_lt_add R x e (by omega), TensorProduct.zero_tmul]
+      · rw [splice_eq_zero_of_block_lt_add R x e (by omega), TensorProduct.zero_tmul]
     · simp only [Finset.mem_range] at hc
       rcases Nat.eq_zero_or_pos d with rfl | hd
       · rw [splice_zero_length, TensorProduct.tmul_zero]
-      · rw [splice_eq_zero_of_lt_add R x e (by omega), TensorProduct.tmul_zero]
+      · rw [splice_eq_zero_of_block_lt_add R x e (by omega), TensorProduct.tmul_zero]
 
 end ReducedTensorWords
 

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Splice.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Splice.lean
@@ -114,7 +114,7 @@ theorem splice_congr {n m : ℕ} (x : Fin n → M) (y : Fin m → M) {a a' b p d
     splice R x a b p d e = splice R y a' b p d e := by
   by_cases hd : 0 < d ∧ p + d ≤ b
   · rw [splice_eq_of_tprod R x e hd.1 hd.2 hab, splice_eq_of_tprod R y e hd.1 hd.2 hab']
-    refine of_tprod_congr R M _ _ rfl fun j ↦ ?_
+    refine of_tprod_congr R M _ rfl fun j ↦ ?_
     have hj := j.isLt
     simp only [Fin.val_cast]
     split_ifs with h₁ h₂
@@ -152,7 +152,7 @@ private theorem deconcatenation_splice_left {n : ℕ} (x : Fin n → M) {a b p d
         else if _ : j.1 = p then e
         else x ⟨a + (j.1 + d - 1), by omega⟩) 0 c = subword R x a c := by
     rw [subword_eq_of_tprod R _ hc (by omega), subword_eq_of_tprod R x hc (by omega)]
-    refine of_tprod_congr R M _ _ rfl fun j ↦ ?_
+    refine of_tprod_congr R M _ rfl fun j ↦ ?_
     have hj := j.isLt
     simp only [Fin.val_cast]
     have hjp : 0 + j.1 < p := by omega
@@ -166,7 +166,7 @@ private theorem deconcatenation_splice_left {n : ℕ} (x : Fin n → M) {a b p d
       splice R x (a + c) (b - c) (p - c) d e := by
     rw [subword_eq_of_tprod R _ (by omega) (by omega),
       splice_eq_of_tprod R x e hd (by omega) (by omega)]
-    refine of_tprod_congr R M _ _ (by omega) fun j ↦ ?_
+    refine of_tprod_congr R M _ (by omega) fun j ↦ ?_
     have hj := j.isLt
     simp only [Fin.val_cast]
     split_ifs <;> first | rfl | exact congrArg x (by simp only [Fin.mk.injEq]; omega) | omega
@@ -195,7 +195,7 @@ private theorem deconcatenation_splice_right {n : ℕ} (x : Fin n → M) {a b p 
         else x ⟨a + (j.1 + d - 1), by omega⟩) 0 c = splice R x a (c + (d - 1)) p d e := by
     rw [subword_eq_of_tprod R _ (by omega) (by omega),
       splice_eq_of_tprod R x e hd (by omega) (by omega)]
-    refine of_tprod_congr R M _ _ (by omega) fun j ↦ ?_
+    refine of_tprod_congr R M _ (by omega) fun j ↦ ?_
     have hj := j.isLt
     simp only [Fin.val_cast]
     split_ifs <;> first | rfl | exact congrArg x (by simp only [Fin.mk.injEq]; omega) | omega
@@ -207,7 +207,7 @@ private theorem deconcatenation_splice_right {n : ℕ} (x : Fin n → M) {a b p 
       subword R x (a + (c + (d - 1))) (b - (c + (d - 1))) := by
     rw [subword_eq_of_tprod R _ (by omega) (by omega),
       subword_eq_of_tprod R x (by omega) (by omega)]
-    refine of_tprod_congr R M _ _ (by omega) fun j ↦ ?_
+    refine of_tprod_congr R M _ (by omega) fun j ↦ ?_
     have hj := j.isLt
     simp only [Fin.val_cast]
     have hjp : ¬(c + j.1) < p := by omega
@@ -269,22 +269,38 @@ either weakly to its left, leaving a plain block and a spliced word, or strictly
 leaving a spliced word and a plain block.  Both sums range over the cut position measured in the
 original block, and their summands vanish outside the positions that really occur; that is what
 makes the identity hold for a degenerate collapsed block too, both sides then being zero. -/
-theorem deconcatenation_splice {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M) (hab : a + b ≤ n) :
+theorem deconcatenation_splice {n : ℕ} (x : Fin n → M) {a b p d : ℕ} (e : M) :
     deconcatenation R M (splice R x a b p d e) =
       (∑ c ∈ Finset.range (p + 1), subword R x a c ⊗ₜ[R] splice R x (a + c) (b - c) (p - c) d e) +
         ∑ c ∈ Finset.range b, splice R x a c p d e ⊗ₜ[R] subword R x (a + c) (b - c) := by
-  by_cases h : 0 < d ∧ p + d ≤ b
-  · exact deconcatenation_splice_of_le R x e h.1 h.2 hab
-  · rw [splice, dite_eq_right (by tauto), map_zero]
-    rw [Finset.sum_eq_zero fun c hc ↦ ?_, Finset.sum_eq_zero fun c hc ↦ ?_, add_zero]
-    · simp only [Finset.mem_range] at hc
-      rcases Nat.eq_zero_or_pos d with rfl | hd
-      · rw [splice_zero_length, TensorProduct.zero_tmul]
-      · rw [splice_eq_zero_of_block_lt_add R x e (by omega), TensorProduct.zero_tmul]
-    · simp only [Finset.mem_range] at hc
-      rcases Nat.eq_zero_or_pos d with rfl | hd
-      · rw [splice_zero_length, TensorProduct.tmul_zero]
-      · rw [splice_eq_zero_of_block_lt_add R x e (by omega), TensorProduct.tmul_zero]
+  by_cases hab : a + b ≤ n
+  · by_cases h : 0 < d ∧ p + d ≤ b
+    · exact deconcatenation_splice_of_le R x e h.1 h.2 hab
+    · rw [splice, dite_eq_right (by tauto), map_zero]
+      rw [Finset.sum_eq_zero fun c hc ↦ ?_, Finset.sum_eq_zero fun c hc ↦ ?_, add_zero]
+      · simp only [Finset.mem_range] at hc
+        rcases Nat.eq_zero_or_pos d with rfl | hd
+        · rw [splice_zero_length, TensorProduct.zero_tmul]
+        · rw [splice_eq_zero_of_block_lt_add R x e (by omega), TensorProduct.zero_tmul]
+      · simp only [Finset.mem_range] at hc
+        rcases Nat.eq_zero_or_pos d with rfl | hd
+        · rw [splice_zero_length, TensorProduct.tmul_zero]
+        · rw [splice_eq_zero_of_block_lt_add R x e (by omega), TensorProduct.tmul_zero]
+  · rw [splice_eq_zero_of_length_lt_add R x e (by omega), map_zero]
+    have hleft :
+        ∑ c ∈ Finset.range (p + 1),
+          subword R x a c ⊗ₜ[R] splice R x (a + c) (b - c) (p - c) d e = 0 :=
+      Finset.sum_eq_zero fun c hc ↦ by
+        simp only [Finset.mem_range] at hc
+        by_cases hcb : c ≤ b
+        · rw [splice_eq_zero_of_length_lt_add R x e (by omega), TensorProduct.tmul_zero]
+        · rw [subword_eq_zero_of_lt_add R x (by omega), TensorProduct.zero_tmul]
+    have hright : ∑ c ∈ Finset.range b,
+        splice R x a c p d e ⊗ₜ[R] subword R x (a + c) (b - c) = 0 :=
+      Finset.sum_eq_zero fun c hc ↦ by
+        simp only [Finset.mem_range] at hc
+        rw [subword_eq_zero_of_lt_add R x (by omega), TensorProduct.tmul_zero]
+    rw [hleft, hright, add_zero]
 
 end ReducedTensorWords
 

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Splice.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Splice.lean
@@ -155,7 +155,8 @@ private theorem deconcatenation_splice_left {n : ℕ} (x : Fin n → M) {a b p d
     refine of_tprod_congr R M _ _ rfl fun j ↦ ?_
     have hj := j.isLt
     simp only [Fin.val_cast]
-    rw [dite_eq_left (show (0 + j.1) < p by omega)]
+    have hjp : 0 + j.1 < p := by omega
+    rw [dite_eq_left hjp]
     exact congrArg x (by simp only [Fin.mk.injEq]; omega)
   have hsnd : subword R
       (fun j : Fin (b + 1 - d) ↦
@@ -209,8 +210,9 @@ private theorem deconcatenation_splice_right {n : ℕ} (x : Fin n → M) {a b p 
     refine of_tprod_congr R M _ _ (by omega) fun j ↦ ?_
     have hj := j.isLt
     simp only [Fin.val_cast]
-    rw [dite_eq_right (show ¬(c + j.1) < p by omega),
-      dite_eq_right (show ¬(c + j.1) = p by omega)]
+    have hjp : ¬(c + j.1) < p := by omega
+    have hjp_ne : ¬(c + j.1) = p := by omega
+    rw [dite_eq_right hjp, dite_eq_right hjp_ne]
     exact congrArg x (by simp only [Fin.mk.injEq]; omega)
   rw [hfst, hsnd]
 
@@ -249,10 +251,12 @@ private theorem deconcatenation_splice_of_le {n : ℕ} (x : Fin n → M) {a b p 
         by_contra hge
         exact hc' (Finset.mem_Ico.2 ⟨by omega, (Finset.mem_Ico.1 hc).2⟩)
       rw [splice_eq_zero_of_block_lt_add R x e hlt, TensorProduct.zero_tmul]
+    have hIco :
+        Finset.Ico (p + d) b = Finset.Ico (p + 1 + (d - 1)) (b + 1 - d + (d - 1)) := by
+      congr 1 <;> omega
     rw [Finset.range_eq_Ico,
       ← Finset.sum_subset (Finset.Ico_subset_Ico (Nat.zero_le (p + d)) (le_refl b)) hzero,
-      show Finset.Ico (p + d) b = Finset.Ico (p + 1 + (d - 1)) (b + 1 - d + (d - 1)) by
-        congr 1 <;> omega,
+      hIco,
       ← Finset.sum_Ico_add'
         (fun c ↦ splice R x a c p d e ⊗ₜ[R] subword R x (a + c) (b - c)) (p + 1) (b + 1 - d)
         (d - 1)]

--- a/TauCeti/LinearAlgebra/TensorPower/Basic.lean
+++ b/TauCeti/LinearAlgebra/TensorPower/Basic.lean
@@ -13,13 +13,17 @@ public import Mathlib.LinearAlgebra.TensorPower.Basic
 Mathlib's `TensorPower.mulEquiv` identifies `⨂[R]^k M ⊗[R] ⨂[R]^m M` with `⨂[R]^(k + m) M`.  This
 file records the inverse operation: `TensorPower.splitAt` cuts a tensor power of length `n` after
 its first `k` factors, landing in `⨂[R]^k M ⊗[R] ⨂[R]^(n - k) M`, together with its value on pure
-tensors and the fact that it is injective. It also identifies the first tensor power with the
-underlying module.
+tensors and the fact that it is injective. It also records the value of `TensorPower.mulEquiv`
+itself on a pair of pure tensors, and identifies the first tensor power with the underlying module.
 
 ## Main definitions
 
 * `TensorPower.splitAt`: split a tensor power at a specified position.
 * `TauCeti.TensorPower.oneEquiv`: identify the first tensor power with the underlying module.
+
+## Main results
+
+* `TensorPower.mulEquiv_tprod_tmul_tprod`: multiplying pure tensors concatenates their entries.
 -/
 
 public section
@@ -52,6 +56,15 @@ theorem oneEquiv_symm_apply (a : M) :
 end TauCeti.TensorPower
 
 namespace TensorPower
+
+/-- Multiplying two pure tensors concatenates their entries. -/
+@[simp]
+theorem mulEquiv_tprod_tmul_tprod {k l : ℕ} (u : Fin k → M) (v : Fin l → M) :
+    TensorPower.mulEquiv (R := R) (M := M) (n := k) (m := l)
+        (PiTensorProduct.tprod R u ⊗ₜ[R] PiTensorProduct.tprod R v) =
+      PiTensorProduct.tprod R (Fin.append u v) := by
+  rw [← TensorPower.gMul_def]
+  exact TensorPower.tprod_mul_tprod R u v
 
 /-- Split a tensor power after its first `k` factors. -/
 noncomputable def splitAt (n k : ℕ) (hk : k ≤ n) :

--- a/TauCeti/LinearAlgebra/TensorPower/Basic.lean
+++ b/TauCeti/LinearAlgebra/TensorPower/Basic.lean
@@ -13,17 +13,14 @@ public import Mathlib.LinearAlgebra.TensorPower.Basic
 Mathlib's `TensorPower.mulEquiv` identifies `⨂[R]^k M ⊗[R] ⨂[R]^m M` with `⨂[R]^(k + m) M`.  This
 file records the inverse operation: `TensorPower.splitAt` cuts a tensor power of length `n` after
 its first `k` factors, landing in `⨂[R]^k M ⊗[R] ⨂[R]^(n - k) M`, together with its value on pure
-tensors and the fact that it is injective. It also records the value of `TensorPower.mulEquiv`
-itself on a pair of pure tensors, and identifies the first tensor power with the underlying module.
+tensors and the fact that it is injective. It also identifies the first tensor power with the
+underlying module.
 
 ## Main definitions
 
 * `TensorPower.splitAt`: split a tensor power at a specified position.
 * `TauCeti.TensorPower.oneEquiv`: identify the first tensor power with the underlying module.
 
-## Main results
-
-* `TensorPower.mulEquiv_tprod_tmul_tprod`: multiplying pure tensors concatenates their entries.
 -/
 
 public section
@@ -56,15 +53,6 @@ theorem oneEquiv_symm_apply (a : M) :
 end TauCeti.TensorPower
 
 namespace TensorPower
-
-/-- Multiplying two pure tensors concatenates their entries. -/
-@[simp]
-theorem mulEquiv_tprod_tmul_tprod {k l : ℕ} (u : Fin k → M) (v : Fin l → M) :
-    TensorPower.mulEquiv (R := R) (M := M) (n := k) (m := l)
-        (PiTensorProduct.tprod R u ⊗ₜ[R] PiTensorProduct.tprod R v) =
-      PiTensorProduct.tprod R (Fin.append u v) := by
-  rw [← TensorPower.gMul_def]
-  exact TensorPower.tprod_mul_tprod R u v
 
 /-- Split a tensor power after its first `k` factors. -/
 noncomputable def splitAt (n k : ℕ) (hk : k ≤ n) :


### PR DESCRIPTION
This PR constructs the coderivations of the reduced tensor coalgebra and proves that a coderivation is exactly its family of Taylor components. For an `R`-module `M`, `TauCeti.ReducedTensorWords.IsCoderivation` is the co-Leibniz rule `Δ ∘ b = (b ⊗ 1 + 1 ⊗ b) ∘ Δ` for the reduced deconcatenation coproduct; `IsCoderivation.eq_of_letter_comp_eq` proves that two coderivations agreeing after the projection `letter` onto single letters are equal; `coderiv F` is the explicit Taylor expansion attached to a family of components, `isCoderivation_coderiv` and `letter_comp_coderiv` prove that it is a coderivation with those components, and `coderivEquivTaylor` bundles the two halves as a linear isomorphism `coderivations R M ≃ₗ[R] (ReducedTensorWords R M →ₗ[R] M)`.

The roadmap target is the third bullet of DGAInfinity Layer 0: "Construct reduced and coaugmented tensor coalgebras with deconcatenation, their conilpotence filtration, coderivations, and the equivalence between degree-one coderivations and their Taylor components." That roadmap's `Suggested.lean` sketches this same content as `TensorCoderivation`, `TensorCoderivation.taylor`, `extendTaylor` and `extendTaylor_taylor`, the last two left as `sorry` there. Layer 0 is the layer Layer 2 consumes when it asks to "Define nonunital `A∞` algebras by square-zero coderivations and expose their unsuspended operations", so the cofreeness statement proved here is what makes that definition possible at all; without it there is no way to hand over a family `m_n` and receive the coderivation `b` whose square is the Stasheff relation.

The uniqueness half is an induction along the conilpotence filtration already on `main`: a word of length at most `n + 1` deconcatenates into a sum of tensors of words of length at most `n` (`map_deconcatenation_filtration_succ_le`), so the right-hand side of the co-Leibniz rule is known by induction, and `eq_of_deconcatenation_eq_of_letter_eq` recovers the word from its cut and its letter. The existence half needs the shape of a single Taylor summand, which is the new `TauCeti/LinearAlgebra/TensorCoalgebra/Splice.lean`: `splice x a b p d e` is the block `x a ⋯ x (a + b - 1)` with its `d` letters at relative offset `p` replaced by the single letter `e`, and `deconcatenation_splice` says that a cut of such a word falls either weakly to the left of the new letter, leaving a plain block and a spliced word, or strictly to its right, leaving a spliced word and a plain block — no cut ever splits a letter. Both sides of the co-Leibniz rule for `coderiv F` are then sums over a cut position together with a collapsed block, and the identity is the reindexing between the two orders, a triangle swap on one family and a plain `Finset.sum_comm` on the other. The summands are stated over generous ranges and vanish where the collapsed block does not fit, which is what lets the expansion of a word and the expansions of its two halves be summed over one common range.

The new files sit beside the existing tensor-coalgebra lane in `TauCeti/LinearAlgebra/TensorCoalgebra/` (`Basic`, `Coassoc`, `Filtration`, `Primitives`) rather than under the roadmap's suggested `TauCeti/Algebra/Homology/`, since that is where every declaration they extend already lives and the roadmap states that the file split is an implementation choice. Four general lemmas are added to `TensorCoalgebra/Basic.lean` (`of_tprod_congr`, `toModule_of`, `component_of_eq`, `subword_congr` — the first three transport along a second arithmetic expression for one length, the last says a block depends only on its letters) and one to `TensorPower/Basic.lean` (`mulEquiv_tprod_tmul_tprod`, that multiplying pure tensors concatenates their entries). No Mathlib source was vendored.

Everything here is over a plain commutative semiring and an ungraded module, matching the existing files in the directory. What remains of the Layer 0 bullet after this PR is the coaugmented tensor coalgebra and the completed one, and the transfer of this correspondence into `ℤ`-graded modules, where the coderivation acquires degree one and the Koszul signs of the suspension enter; that graded form is the one Layer 2 stores as `b² = 0`.

Roadmap: DGAInfinity

<!--tauceti-target:v1 {"focus":"DGAInfinity","id":"coderivations-of-the-reduced-tensor-coalgebra"}-->

🤖 Prepared with Claude Code
