### PR TITLE
feat: the Euler class of a finite projective resolution and the resolution theorem

### DIFF
--- a/TauCeti/CategoryTheory/Exact/ExtensionClosed.lean
+++ b/TauCeti/CategoryTheory/Exact/ExtensionClosed.lean
@@ -42,7 +42,8 @@ finite projective resolution, be treated as an exact category in its own right.
   closure is closure under binary biproducts, and for the canonical exact structure of an abelian
   category it agrees with Mathlib's
   `CategoryTheory.ObjectProperty.IsClosedUnderExtensions`.
-* `TauCeti.ExactStructure.isConflationExact_ι` and
+* `TauCeti.ExactStructure.isConflationExact_ι`,
+  `TauCeti.ExactStructure.isConflationExact_ιOfLE`, and
   `TauCeti.ExactStructure.reflectsConflations_ι`: the inclusion of the subcategory is
   conflation-exact and reflects conflations.
 
@@ -295,6 +296,16 @@ theorem fullSubcategory_conflation_iff (S : ShortComplex P.FullSubcategory) :
 /-- The inclusion of an extension-closed full subcategory is conflation-exact. -/
 theorem isConflationExact_ι : (E.fullSubcategory P hP).IsConflationExact E P.ι where
   map_conflation hS := hS
+
+/-- The inclusion associated to an implication between two extension-closed object properties is
+conflation-exact for their induced exact structures. -/
+theorem isConflationExact_ιOfLE {Q : ObjectProperty C} [Q.ContainsZero]
+    [Q.IsClosedUnderBinaryProducts] (hQ : E.IsExtensionClosed Q) (h : P ≤ Q) :
+    (E.fullSubcategory P hP).IsConflationExact (E.fullSubcategory Q hQ)
+      (ObjectProperty.ιOfLE h) where
+  map_conflation {S} hS := by
+    rw [fullSubcategory_conflation_iff] at hS ⊢
+    exact hS
 
 /-- The inclusion of an extension-closed full subcategory reflects conflations: a short complex
 of the subcategory whose image is a conflation of `E` is a conflation of the induced structure. -/

--- a/TauCeti/CategoryTheory/Exact/Projective.lean
+++ b/TauCeti/CategoryTheory/Exact/Projective.lean
@@ -318,7 +318,7 @@ term is the biproduct of the two outer ones.
 
 Together with `TauCeti.ExactStructure.fullSubcategory` this equips the objects satisfying `P`
 with an induced exact structure — necessarily the split one, by
-`TauCeti.ExactStructure.fullSubcategory_conflation_iff_split`. -/
+`TauCeti.ExactStructure.fullSubcategory_eq_split`. -/
 theorem isExtensionClosed_of_le_isProjective [P.IsClosedUnderIsomorphisms]
     [P.IsClosedUnderBinaryProducts] (hP : P ≤ E.isProjective) : E.IsExtensionClosed P where
   prop_X₂ hS h₁ h₃ :=
@@ -350,14 +350,6 @@ theorem fullSubcategory_eq_split (hP : P ≤ E.isProjective) :
     f_r := ObjectProperty.hom_ext _ hs.f_r
     s_g := ObjectProperty.hom_ext _ hs.s_g
     id := ObjectProperty.hom_ext _ hs.id }⟩
-
-/-- A short complex in a full subcategory of projectives is a conflation of the induced exact
-structure exactly when it is a split conflation. -/
-theorem fullSubcategory_conflation_iff_split (hP : P ≤ E.isProjective)
-    (S : ShortComplex P.FullSubcategory) :
-    (E.fullSubcategory P (E.isExtensionClosed_of_le_isProjective hP)).Conflation S ↔
-      (ExactStructure.split P.FullSubcategory).Conflation S := by
-  rw [E.fullSubcategory_eq_split hP]
 
 /-- **Finite resolutions by projectives lift along a conflation.** If `P` consists of
 `E`-projectives, contains a zero object and is closed under binary biproducts, and both outer

--- a/TauCeti/CategoryTheory/Exact/Projective.lean
+++ b/TauCeti/CategoryTheory/Exact/Projective.lean
@@ -68,6 +68,9 @@ by the projectives themselves.
   and is closed under binary biproducts.
 * `TauCeti.ExactStructure.isExtensionClosed_admitsFiniteResolution`: under those same hypotheses
   on `P`, admitting a finite `P`-resolution is closed under extensions.
+* `TauCeti.ExactStructure.isExtensionClosed_of_le_isProjective` and
+  `TauCeti.ExactStructure.fullSubcategory_conflation_iff_split`: a property consisting of
+  projectives is itself extension closed, and the exact structure it inherits is the split one.
 
 ## Implementation notes
 
@@ -319,6 +322,36 @@ local instance [P.ContainsZero] [P.IsClosedUnderBinaryProducts] :
 
 variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
 
+/-- **A property consisting of projectives is extension closed**, as soon as it contains a zero
+object and is closed under binary biproducts: a conflation whose third term is projective
+splits, so its middle term is the biproduct of the two outer ones.
+
+Together with `TauCeti.ExactStructure.fullSubcategory` this equips the objects satisfying `P`
+with an induced exact structure — necessarily the split one, by
+`TauCeti.ExactStructure.fullSubcategory_conflation_iff_split`. -/
+theorem isExtensionClosed_of_le_isProjective (hP : P ≤ E.isProjective) :
+    E.IsExtensionClosed P where
+  prop_X₂ hS h₁ h₃ :=
+    P.prop_of_iso (E.splittingOfProjective hS (hP _ h₃)).isoBinaryBiproduct.symm
+      (P.prop_biprod_of_isClosedUnderBinaryProducts h₁ h₃)
+
+/-- **The exact structure induced on a subcategory of projectives is the split one.** Every
+conflation between projectives splits, and a split short complex is a conflation of every exact
+structure. -/
+theorem fullSubcategory_conflation_iff_split (hP : P ≤ E.isProjective)
+    (S : ShortComplex P.FullSubcategory) :
+    (E.fullSubcategory P (E.isExtensionClosed_of_le_isProjective hP)).Conflation S ↔
+      (ExactStructure.split P.FullSubcategory).Conflation S := by
+  refine ⟨fun hS => ?_, fun hS => ExactStructure.conflation_of_split_conflation _ hS⟩
+  rw [fullSubcategory_conflation_iff] at hS
+  have hs := E.splittingOfProjective hS (hP _ S.X₃.property)
+  exact (ExactStructure.split_conflation S).mpr ⟨{
+    r := ObjectProperty.homMk hs.r
+    s := ObjectProperty.homMk hs.s
+    f_r := ObjectProperty.hom_ext _ hs.f_r
+    s_g := ObjectProperty.hom_ext _ hs.s_g
+    id := ObjectProperty.hom_ext _ hs.id }⟩
+
 /-- **Finite resolutions by projectives lift along a conflation.** If `P` consists of
 `E`-projectives, contains a zero object and is closed under binary biproducts, and both outer
 terms of a conflation admit a finite `P`-resolution of length at most `n`, then so does its
@@ -338,7 +371,7 @@ theorem exists_finiteResolution_length_le_of_conflation (hP : P ≤ E.isProjecti
       have hX₁ : P S.X₁ := by simpa using r.prop_syzygy hr
       have hX₃ : P S.X₃ := by simpa using t.prop_syzygy ht
       refine ⟨.base (P.prop_of_iso (E.splittingOfProjective hS (hP _ hX₃)).isoBinaryBiproduct.symm
-        (P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hX₁ hX₃)), by simp⟩
+        (P.prop_biprod_of_isClosedUnderBinaryProducts hX₁ hX₃)), by simp⟩
   | succ n ih =>
       obtain ⟨KX, QX, mX, aX, hmX, hQX, hcX, hKX⟩ :=
         E.exists_conflation_of_exists_finiteResolution_length_le_succ h₁
@@ -348,7 +381,7 @@ theorem exists_finiteResolution_length_le_of_conflation (hP : P ≤ E.isProjecti
         E.exists_conflation_biprod_of_conflation_of_projective hS hcX hcZ (hP _ hQZ)
       obtain ⟨s, hs⟩ := ih (S := ShortComplex.mk v w hv) hKv hKX hKZ
       have hQ : P (QX ⊞ QZ) :=
-        P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hQX hQZ
+        P.prop_biprod_of_isClosedUnderBinaryProducts hQX hQZ
       exact ⟨.step hQ u a hu hKu s,
         by rw [FiniteResolution.length_step]; exact Nat.succ_le_succ hs⟩
 

--- a/TauCeti/CategoryTheory/Exact/Projective.lean
+++ b/TauCeti/CategoryTheory/Exact/Projective.lean
@@ -338,7 +338,7 @@ variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
 /-- **The exact structure induced on a subcategory of projectives is the split one.** Every
 conflation between projectives splits, and a split short complex is a conflation of every exact
 structure. -/
-@[simp] theorem fullSubcategory_conflation_iff_split (hP : P ≤ E.isProjective)
+theorem fullSubcategory_conflation_iff_split (hP : P ≤ E.isProjective)
     (S : ShortComplex P.FullSubcategory) :
     (E.fullSubcategory P (E.isExtensionClosed_of_le_isProjective hP)).Conflation S ↔
       (ExactStructure.split P.FullSubcategory).Conflation S := by

--- a/TauCeti/CategoryTheory/Exact/Projective.lean
+++ b/TauCeti/CategoryTheory/Exact/Projective.lean
@@ -377,8 +377,7 @@ theorem exists_finiteResolution_length_le_of_conflation (hP : P ≤ E.isProjecti
       obtain ⟨t, ht⟩ := h₃
       have hX₁ : P S.X₁ := by simpa using r.prop_syzygy hr
       have hX₃ : P S.X₃ := by simpa using t.prop_syzygy ht
-      refine ⟨.base (P.prop_of_iso (E.splittingOfProjective hS (hP _ hX₃)).isoBinaryBiproduct.symm
-        (P.prop_biprod_of_isClosedUnderBinaryProducts hX₁ hX₃)), by simp⟩
+      refine ⟨.base ((E.isExtensionClosed_of_le_isProjective hP).prop_X₂ hS hX₁ hX₃), by simp⟩
   | succ n ih =>
       obtain ⟨KX, QX, mX, aX, hmX, hQX, hcX, hKX⟩ :=
         E.exists_conflation_of_exists_finiteResolution_length_le_succ h₁

--- a/TauCeti/CategoryTheory/Exact/Projective.lean
+++ b/TauCeti/CategoryTheory/Exact/Projective.lean
@@ -69,8 +69,8 @@ by the projectives themselves.
 * `TauCeti.ExactStructure.isExtensionClosed_admitsFiniteResolution`: under those same hypotheses
   on `P`, admitting a finite `P`-resolution is closed under extensions.
 * `TauCeti.ExactStructure.isExtensionClosed_of_le_isProjective` and
-  `TauCeti.ExactStructure.fullSubcategory_conflation_iff_split`: a property consisting of
-  projectives is itself extension closed, and the exact structure it inherits is the split one.
+  `TauCeti.ExactStructure.fullSubcategory_eq_split`: a property consisting of projectives is
+  itself extension closed, and the exact structure it inherits is the split one.
 
 ## Implementation notes
 
@@ -335,13 +335,12 @@ local instance [P.ContainsZero] [P.IsClosedUnderBinaryProducts] :
 
 variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
 
-/-- **The exact structure induced on a subcategory of projectives is the split one.** Every
-conflation between projectives splits, and a split short complex is a conflation of every exact
-structure. -/
-theorem fullSubcategory_conflation_iff_split (hP : P ≤ E.isProjective)
-    (S : ShortComplex P.FullSubcategory) :
-    (E.fullSubcategory P (E.isExtensionClosed_of_le_isProjective hP)).Conflation S ↔
-      (ExactStructure.split P.FullSubcategory).Conflation S := by
+/-- **The exact structure induced on a subcategory of projectives is the split one.** -/
+theorem fullSubcategory_eq_split (hP : P ≤ E.isProjective) :
+    E.fullSubcategory P (E.isExtensionClosed_of_le_isProjective hP) =
+      ExactStructure.split P.FullSubcategory := by
+  apply ExactStructure.ext
+  intro S
   refine ⟨fun hS => ?_, fun hS => ExactStructure.conflation_of_split_conflation _ hS⟩
   rw [fullSubcategory_conflation_iff] at hS
   have hs := E.splittingOfProjective hS (hP _ S.X₃.property)
@@ -351,6 +350,14 @@ theorem fullSubcategory_conflation_iff_split (hP : P ≤ E.isProjective)
     f_r := ObjectProperty.hom_ext _ hs.f_r
     s_g := ObjectProperty.hom_ext _ hs.s_g
     id := ObjectProperty.hom_ext _ hs.id }⟩
+
+/-- A short complex in a full subcategory of projectives is a conflation of the induced exact
+structure exactly when it is a split conflation. -/
+theorem fullSubcategory_conflation_iff_split (hP : P ≤ E.isProjective)
+    (S : ShortComplex P.FullSubcategory) :
+    (E.fullSubcategory P (E.isExtensionClosed_of_le_isProjective hP)).Conflation S ↔
+      (ExactStructure.split P.FullSubcategory).Conflation S := by
+  rw [E.fullSubcategory_eq_split hP]
 
 /-- **Finite resolutions by projectives lift along a conflation.** If `P` consists of
 `E`-projectives, contains a zero object and is closed under binary biproducts, and both outer

--- a/TauCeti/CategoryTheory/Exact/Projective.lean
+++ b/TauCeti/CategoryTheory/Exact/Projective.lean
@@ -312,6 +312,19 @@ section Resolutions
 
 variable {P : ObjectProperty C}
 
+/-- **A property consisting of projectives is extension closed**, as soon as it is replete and
+closed under binary biproducts: a conflation whose third term is projective splits, so its middle
+term is the biproduct of the two outer ones.
+
+Together with `TauCeti.ExactStructure.fullSubcategory` this equips the objects satisfying `P`
+with an induced exact structure — necessarily the split one, by
+`TauCeti.ExactStructure.fullSubcategory_conflation_iff_split`. -/
+theorem isExtensionClosed_of_le_isProjective [P.IsClosedUnderIsomorphisms]
+    [P.IsClosedUnderBinaryProducts] (hP : P ≤ E.isProjective) : E.IsExtensionClosed P where
+  prop_X₂ hS h₁ h₃ :=
+    P.prop_of_iso (E.splittingOfProjective hS (hP _ h₃)).isoBinaryBiproduct.symm
+      (P.prop_biprod_of_isClosedUnderBinaryProducts h₁ h₃)
+
 /-- A property containing a zero object and closed under binary products is automatically
 replete, by `CategoryTheory.ObjectProperty.isClosedUnderIsomorphisms_of_containsZero`; so the
 results below need no separate repleteness hypothesis, even though the resolution API they call
@@ -322,23 +335,10 @@ local instance [P.ContainsZero] [P.IsClosedUnderBinaryProducts] :
 
 variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
 
-/-- **A property consisting of projectives is extension closed**, as soon as it contains a zero
-object and is closed under binary biproducts: a conflation whose third term is projective
-splits, so its middle term is the biproduct of the two outer ones.
-
-Together with `TauCeti.ExactStructure.fullSubcategory` this equips the objects satisfying `P`
-with an induced exact structure — necessarily the split one, by
-`TauCeti.ExactStructure.fullSubcategory_conflation_iff_split`. -/
-theorem isExtensionClosed_of_le_isProjective (hP : P ≤ E.isProjective) :
-    E.IsExtensionClosed P where
-  prop_X₂ hS h₁ h₃ :=
-    P.prop_of_iso (E.splittingOfProjective hS (hP _ h₃)).isoBinaryBiproduct.symm
-      (P.prop_biprod_of_isClosedUnderBinaryProducts h₁ h₃)
-
 /-- **The exact structure induced on a subcategory of projectives is the split one.** Every
 conflation between projectives splits, and a split short complex is a conflation of every exact
 structure. -/
-theorem fullSubcategory_conflation_iff_split (hP : P ≤ E.isProjective)
+@[simp] theorem fullSubcategory_conflation_iff_split (hP : P ≤ E.isProjective)
     (S : ShortComplex P.FullSubcategory) :
     (E.fullSubcategory P (E.isExtensionClosed_of_le_isProjective hP)).Conflation S ↔
       (ExactStructure.split P.FullSubcategory).Conflation S := by

--- a/TauCeti/CategoryTheory/Exact/Resolution.lean
+++ b/TauCeti/CategoryTheory/Exact/Resolution.lean
@@ -85,8 +85,9 @@ only typecheck when its body is exposed.
 The closure hypotheses on `P` are Mathlib's object-property type classes, and are assumed only
 where they are used: repleteness for `ofIso`, `CategoryTheory.ObjectProperty.ContainsZero` for
 padding, and closure under binary products for direct sums, the last of these reaching
-biproducts through `CategoryTheory.ObjectProperty.prop_of_isLimit_binaryFan` applied to
-`CategoryTheory.Limits.BinaryBiproduct.isLimit`. The resolving-subcategory package,
+biproducts through
+`CategoryTheory.ObjectProperty.prop_biprod_of_isClosedUnderBinaryProducts`. The
+resolving-subcategory package,
 which bundles these with extension closure and closure under kernels of deflations, is
 downstream.
 
@@ -367,35 +368,35 @@ noncomputable def biprod :
     ∀ {X Y : C}, FiniteResolution E P X → FiniteResolution E P Y →
       FiniteResolution E P (X ⊞ Y)
   | _, _, .base hX, .base hY =>
-      .base (P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hX hY)
+      .base (P.prop_biprod_of_isClosedUnderBinaryProducts hX hY)
   | X, _, .base hX, .step hQ i p zero hp s =>
-      .step (P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hX hQ)
+      .step (P.prop_biprod_of_isClosedUnderBinaryProducts hX hQ)
         (Limits.biprod.map (0 : (0 : C) ⟶ X) i) (Limits.biprod.map (𝟙 X) p)
         (by apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero])
         (E.conflation_biprod (E.conflation_zero_id X) hp)
         (s.ofIso (isoZeroBiprod (isZero_zero C)))
   | _, Y, .step hQ i p zero hp r, .base hY =>
-      .step (P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hQ hY)
+      .step (P.prop_biprod_of_isClosedUnderBinaryProducts hQ hY)
         (Limits.biprod.map i (0 : (0 : C) ⟶ Y)) (Limits.biprod.map p (𝟙 Y))
         (by apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero])
         (E.conflation_biprod hp (E.conflation_zero_id Y))
         (r.ofIso (isoBiprodZero (isZero_zero C)))
   | _, _, .step hQ i p zero hp r, .step hQ' i' p' zero' hp' s =>
-      .step (P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hQ hQ')
+      .step (P.prop_biprod_of_isClosedUnderBinaryProducts hQ hQ')
         (Limits.biprod.map i i') (Limits.biprod.map p p')
         (by apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero, reassoc_of% zero'])
         (E.conflation_biprod hp hp') (r.biprod s)
 
 @[simp] theorem biprod_base_base {X Y : C} (hX : P X) (hY : P Y) :
     (base (E := E) hX).biprod (base hY) =
-      base (P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hX hY) := by
+      base (P.prop_biprod_of_isClosedUnderBinaryProducts hX hY) := by
   simp [biprod]
 
 @[simp] theorem biprod_base_step {X K Q Y : C} (hX : P X) (hQ : P Q) (i : K ⟶ Q) (p : Q ⟶ Y)
     (zero : i ≫ p = 0) (hp : E.Conflation (ShortComplex.mk i p zero))
     (s : FiniteResolution E P K) :
     (base (E := E) hX).biprod (step hQ i p zero hp s) =
-      step (P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hX hQ)
+      step (P.prop_biprod_of_isClosedUnderBinaryProducts hX hQ)
         (Limits.biprod.map (0 : (0 : C) ⟶ X) i) (Limits.biprod.map (𝟙 X) p)
         (by apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero])
         (E.conflation_biprod (E.conflation_zero_id X) hp)
@@ -406,7 +407,7 @@ noncomputable def biprod :
     (zero : i ≫ p = 0) (hp : E.Conflation (ShortComplex.mk i p zero))
     (r : FiniteResolution E P K) (hY : P Y) :
     (step hQ i p zero hp r).biprod (base hY) =
-      step (P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hQ hY)
+      step (P.prop_biprod_of_isClosedUnderBinaryProducts hQ hY)
         (Limits.biprod.map i (0 : (0 : C) ⟶ Y)) (Limits.biprod.map p (𝟙 Y))
         (by apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero])
         (E.conflation_biprod hp (E.conflation_zero_id Y))
@@ -419,7 +420,7 @@ noncomputable def biprod :
     (zero' : i' ≫ p' = 0) (hp' : E.Conflation (ShortComplex.mk i' p' zero'))
     (s : FiniteResolution E P K') :
     (step hQ i p zero hp r).biprod (step hQ' i' p' zero' hp' s) =
-      step (P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit _ _) hQ hQ')
+      step (P.prop_biprod_of_isClosedUnderBinaryProducts hQ hQ')
         (Limits.biprod.map i i') (Limits.biprod.map p p')
         (by apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero, reassoc_of% zero'])
         (E.conflation_biprod hp hp') (r.biprod s) := by

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Exact.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Exact.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.CategoryTheory.Exact.Equivalence
+public import TauCeti.CategoryTheory.Exact.ExtensionClosed
 public import TauCeti.CategoryTheory.Exact.Split
 public import TauCeti.CategoryTheory.GrothendieckGroup.Presentation
 public import TauCeti.CategoryTheory.GrothendieckGroup.Split
@@ -183,6 +184,27 @@ biproduct conflations. -/
 @[simp]
 theorem of_biprod (X Z : C) : (of (X ⊞ Z) : ExactK0 E) = of X + of Z :=
   of_conflation (E.conflation_biprodShortComplex X Z)
+
+section FullSubcategory
+
+variable {P : ObjectProperty C} [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
+
+/-- The class of an explicitly presented ambient biproduct in the exact `K₀` of an induced full
+subcategory is the sum of the classes of its summands. -/
+theorem of_biprod_fullSubcategory (hP : E.IsExtensionClosed P) {X Y : C}
+    (hX : P X) (hY : P Y) (hXY : P (X ⊞ Y)) :
+    (of ⟨X ⊞ Y, hXY⟩ : ExactK0 (E.fullSubcategory P hP)) =
+      of ⟨X, hX⟩ + of ⟨Y, hY⟩ := by
+  have hzero : (ObjectProperty.homMk (biprod.inl : X ⟶ X ⊞ Y) :
+        (⟨X, hX⟩ : P.FullSubcategory) ⟶ ⟨X ⊞ Y, hXY⟩) ≫
+      (ObjectProperty.homMk (biprod.snd : X ⊞ Y ⟶ Y) :
+        (⟨X ⊞ Y, hXY⟩ : P.FullSubcategory) ⟶ ⟨Y, hY⟩) = 0 :=
+    ObjectProperty.hom_ext _ (by simp)
+  refine of_eq_add_of_conflation hzero ?_
+  rw [ExactStructure.fullSubcategory_conflation_iff]
+  exact E.conflation_biprodShortComplex X Y
+
+end FullSubcategory
 
 /-- The class of an object which is zero vanishes. -/
 @[simp]

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Exact.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Exact.lean
@@ -190,15 +190,20 @@ section FullSubcategory
 variable {P : ObjectProperty C} [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
 
 /-- The class of an explicitly presented ambient biproduct in the exact `K₀` of an induced full
-subcategory is the sum of the classes of its summands. -/
+subcategory is the sum of the classes of its summands. The middle object is the one supplied by
+closure under binary products; by proof irrelevance the statement applies to any presentation of
+it. -/
 theorem of_biprod_fullSubcategory (hP : E.IsExtensionClosed P) {X Y : C}
-    (hX : P X) (hY : P Y) (hXY : P (X ⊞ Y)) :
-    (of ⟨X ⊞ Y, hXY⟩ : ExactK0 (E.fullSubcategory P hP)) =
+    (hX : P X) (hY : P Y) :
+    (of ⟨X ⊞ Y, P.prop_biprod_of_isClosedUnderBinaryProducts hX hY⟩ :
+        ExactK0 (E.fullSubcategory P hP)) =
       of ⟨X, hX⟩ + of ⟨Y, hY⟩ := by
   have hzero : (ObjectProperty.homMk (biprod.inl : X ⟶ X ⊞ Y) :
-        (⟨X, hX⟩ : P.FullSubcategory) ⟶ ⟨X ⊞ Y, hXY⟩) ≫
+        (⟨X, hX⟩ : P.FullSubcategory) ⟶
+          ⟨X ⊞ Y, P.prop_biprod_of_isClosedUnderBinaryProducts hX hY⟩) ≫
       (ObjectProperty.homMk (biprod.snd : X ⊞ Y ⟶ Y) :
-        (⟨X ⊞ Y, hXY⟩ : P.FullSubcategory) ⟶ ⟨Y, hY⟩) = 0 :=
+        (⟨X ⊞ Y, P.prop_biprod_of_isClosedUnderBinaryProducts hX hY⟩ : P.FullSubcategory) ⟶
+          ⟨Y, hY⟩) = 0 :=
     ObjectProperty.hom_ext _ (by simp)
   refine of_eq_add_of_conflation hzero ?_
   rw [ExactStructure.fullSubcategory_conflation_iff]

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Exact.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Exact.lean
@@ -173,9 +173,11 @@ theorem of_eq_add_of_conflation {X Y Z : C} {i : X ⟶ Y} {p : Y ⟶ Z} (zero : 
     (hS : E.Conflation (ShortComplex.mk i p zero)) : (of Y : ExactK0 E) = of X + of Z :=
   of_conflation hS
 
+omit [EssentiallySmall.{w} C] in
 /-- An ambient conflation whose outer terms satisfy an extension-closed property gives the
 defining relation in the exact `K₀` of the induced full subcategory. -/
-theorem of_conflation_fullSubcategory {P : ObjectProperty C} [P.ContainsZero]
+theorem of_conflation_fullSubcategory {P : ObjectProperty C} [LocallySmall.{w} C]
+    [ObjectProperty.EssentiallySmall.{w} P] [P.ContainsZero]
     [P.IsClosedUnderBinaryProducts] (hP : E.IsExtensionClosed P)
     {S : ShortComplex C} (hS : E.Conflation S)
     (h₁ : P S.X₁) (h₃ : P S.X₃) :
@@ -207,11 +209,13 @@ section FullSubcategory
 
 variable {P : ObjectProperty C} [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
 
+omit [EssentiallySmall.{w} C] in
 /-- The class of an explicitly presented ambient biproduct in the exact `K₀` of an induced full
 subcategory is the sum of the classes of its summands. The middle object is the one supplied by
 closure under binary products; by proof irrelevance the statement applies to any presentation of
 it. -/
-theorem of_biprod_fullSubcategory (hP : E.IsExtensionClosed P) {X Y : C}
+theorem of_biprod_fullSubcategory [LocallySmall.{w} C]
+    [ObjectProperty.EssentiallySmall.{w} P] (hP : E.IsExtensionClosed P) {X Y : C}
     (hX : P X) (hY : P Y) :
     (of ⟨X ⊞ Y, P.prop_biprod_of_isClosedUnderBinaryProducts hX hY⟩ :
         ExactK0 (E.fullSubcategory P hP)) =

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Exact.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Exact.lean
@@ -173,6 +173,24 @@ theorem of_eq_add_of_conflation {X Y Z : C} {i : X ⟶ Y} {p : Y ⟶ Z} (zero : 
     (hS : E.Conflation (ShortComplex.mk i p zero)) : (of Y : ExactK0 E) = of X + of Z :=
   of_conflation hS
 
+/-- An ambient conflation whose outer terms satisfy an extension-closed property gives the
+defining relation in the exact `K₀` of the induced full subcategory. -/
+theorem of_conflation_fullSubcategory {P : ObjectProperty C} [P.ContainsZero]
+    [P.IsClosedUnderBinaryProducts] (hP : E.IsExtensionClosed P)
+    {S : ShortComplex C} (hS : E.Conflation S)
+    (h₁ : P S.X₁) (h₃ : P S.X₃) :
+    (of ⟨S.X₂, hP.prop_X₂ hS h₁ h₃⟩ : ExactK0 (E.fullSubcategory P hP)) =
+      of ⟨S.X₁, h₁⟩ + of ⟨S.X₃, h₃⟩ := by
+  have hzero : (ObjectProperty.homMk S.f :
+        (⟨S.X₁, h₁⟩ : P.FullSubcategory) ⟶ ⟨S.X₂, hP.prop_X₂ hS h₁ h₃⟩) ≫
+      (ObjectProperty.homMk S.g :
+        (⟨S.X₂, hP.prop_X₂ hS h₁ h₃⟩ : P.FullSubcategory) ⟶ ⟨S.X₃, h₃⟩) = 0 :=
+    ObjectProperty.hom_ext _ S.zero
+  refine of_eq_add_of_conflation hzero ?_
+  rw [ExactStructure.fullSubcategory_conflation_iff]
+  convert hS using 1
+  rfl
+
 /-- The class of the subobject of a conflation is the difference of the other two classes. -/
 theorem of_eq_sub_of_conflation {S : ShortComplex C} (hS : E.Conflation S) :
     (of S.X₁ : ExactK0 E) = of S.X₂ - of S.X₃ := by
@@ -197,17 +215,8 @@ theorem of_biprod_fullSubcategory (hP : E.IsExtensionClosed P) {X Y : C}
     (hX : P X) (hY : P Y) :
     (of ⟨X ⊞ Y, P.prop_biprod_of_isClosedUnderBinaryProducts hX hY⟩ :
         ExactK0 (E.fullSubcategory P hP)) =
-      of ⟨X, hX⟩ + of ⟨Y, hY⟩ := by
-  have hzero : (ObjectProperty.homMk (biprod.inl : X ⟶ X ⊞ Y) :
-        (⟨X, hX⟩ : P.FullSubcategory) ⟶
-          ⟨X ⊞ Y, P.prop_biprod_of_isClosedUnderBinaryProducts hX hY⟩) ≫
-      (ObjectProperty.homMk (biprod.snd : X ⊞ Y ⟶ Y) :
-        (⟨X ⊞ Y, P.prop_biprod_of_isClosedUnderBinaryProducts hX hY⟩ : P.FullSubcategory) ⟶
-          ⟨Y, hY⟩) = 0 :=
-    ObjectProperty.hom_ext _ (by simp)
-  refine of_eq_add_of_conflation hzero ?_
-  rw [ExactStructure.fullSubcategory_conflation_iff]
-  exact E.conflation_biprodShortComplex X Y
+      of ⟨X, hX⟩ + of ⟨Y, hY⟩ :=
+  of_conflation_fullSubcategory hP (E.conflation_biprodShortComplex X Y) hX hY
 
 end FullSubcategory
 

--- a/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
@@ -116,89 +116,6 @@ variable (hP : E.IsExtensionClosed P)
 
 namespace FiniteResolution
 
-/-- **The Euler class of a finite `P`-resolution in the `K₀` of the full subcategory on `P`**: the
-alternating sum `[Q₀] - [Q₁] + ⋯ + (-1)ⁿ [Kₙ]` of the classes of its resolving terms and its last
-syzygy, all of which satisfy `P`, formed in the exact `K₀` of the exact structure induced on the
-full subcategory on `P`.
-
-Unlike `TauCeti.ExactStructure.FiniteResolution.eulerClass`, which lives in the `K₀` of the
-ambient category and telescopes to `[X]`, this class carries genuine information: nothing in the
-subcategory relates it to `X`. That it depends only on `X` is
-`TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory`,
-and needs `P` to consist of projectives. -/
-noncomputable def eulerClassFullSubcategory :
-    ∀ {X : C}, E.FiniteResolution P X → ExactK0 (E.fullSubcategory P hP)
-  | _, .base hX => ExactK0.of ⟨_, hX⟩
-  | _, .step (Q := Q) hQ _ _ _ _ r => ExactK0.of ⟨Q, hQ⟩ - eulerClassFullSubcategory r
-
-@[simp] theorem eulerClassFullSubcategory_base {X : C} (hX : P X) :
-    (base (E := E) hX).eulerClassFullSubcategory hP = ExactK0.of ⟨X, hX⟩ := (rfl)
-
-@[simp] theorem eulerClassFullSubcategory_step {K Q X : C} (hQ : P Q) (i : K ⟶ Q) (p : Q ⟶ X)
-    (zero : i ≫ p = 0) (hp : E.Conflation (ShortComplex.mk i p zero))
-    (r : E.FiniteResolution P K) :
-    (step hQ i p zero hp r).eulerClassFullSubcategory hP =
-      ExactK0.of ⟨Q, hQ⟩ - r.eulerClassFullSubcategory hP := (rfl)
-
-@[simp] theorem eulerClassFullSubcategory_ofIso {X Y : C} (e : X ≅ Y)
-    (r : E.FiniteResolution P X) :
-    (ofIso e r).eulerClassFullSubcategory hP = r.eulerClassFullSubcategory hP := by
-  cases r with
-  | base hX =>
-      rw [ofIso_base, eulerClassFullSubcategory_base, eulerClassFullSubcategory_base]
-      exact ExactK0.of_congr (ObjectProperty.isoMk _ e.symm :
-        (⟨Y, P.prop_of_iso e hX⟩ : P.FullSubcategory) ≅ ⟨X, hX⟩)
-  | step hQ i p zero hp r =>
-      rw [ofIso_step, eulerClassFullSubcategory_step, eulerClassFullSubcategory_step]
-
-/-- Padding a finite resolution by one trivial conflation does not change its Euler class. -/
-@[simp] theorem eulerClassFullSubcategory_zeroPad {X : C} (r : E.FiniteResolution P X) :
-    r.zeroPad.eulerClassFullSubcategory hP = r.eulerClassFullSubcategory hP := by
-  induction r with
-  | base hX =>
-      have hzero : IsZero (⟨0, P.prop_zero⟩ : P.FullSubcategory) :=
-        IsZero.of_full_of_faithful_of_isZero P.ι _ (isZero_zero C)
-      rw [zeroPad_base, eulerClassFullSubcategory_step, eulerClassFullSubcategory_base,
-        eulerClassFullSubcategory_base, ExactK0.of_eq_zero_of_isZero hzero, sub_zero]
-  | step hQ i p zero hp r ih =>
-      rw [zeroPad_step, eulerClassFullSubcategory_step, eulerClassFullSubcategory_step, ih]
-
-/-- Padding a finite resolution by any number of trivial conflations does not change its Euler
-class. -/
-@[simp] theorem eulerClassFullSubcategory_pad {X : C} (r : E.FiniteResolution P X) (n : ℕ) :
-    (r.pad n).eulerClassFullSubcategory hP = r.eulerClassFullSubcategory hP := by
-  induction n with
-  | zero => rw [pad_zero]
-  | succ n ih => rw [pad_succ, eulerClassFullSubcategory_zeroPad, ih]
-
-@[simp] theorem eulerClassFullSubcategory_biprod {X Y : C} (r : E.FiniteResolution P X)
-    (s : E.FiniteResolution P Y) :
-    (r.biprod s).eulerClassFullSubcategory hP =
-      r.eulerClassFullSubcategory hP + s.eulerClassFullSubcategory hP := by
-  induction r generalizing Y with
-  | @base X hX =>
-      cases s with
-      | @base Y hY =>
-          rw [biprod_base_base, eulerClassFullSubcategory_base, eulerClassFullSubcategory_base,
-            eulerClassFullSubcategory_base]
-          exact ExactK0.of_biprod_fullSubcategory hP hX hY
-      | @step K Q Y hQ i p zero hp s =>
-          simp only [biprod_base_step, eulerClassFullSubcategory]
-          rw [eulerClassFullSubcategory_ofIso,
-            ExactK0.of_biprod_fullSubcategory hP hX hQ]
-          abel
-  | @step K Q X hQ i p zero hp r ih =>
-      cases s with
-      | @base Y hY =>
-          simp only [biprod_step_base, eulerClassFullSubcategory]
-          rw [eulerClassFullSubcategory_ofIso,
-            ExactK0.of_biprod_fullSubcategory hP hQ hY]
-          abel
-      | @step K' Q' Y hQ' i' p' zero' hp' s =>
-          simp only [biprod_step_step, eulerClassFullSubcategory]
-          rw [ih, ExactK0.of_biprod_fullSubcategory hP hQ hQ']
-          abel
-
 section Projective
 
 /-- The inductive core of
@@ -282,8 +199,8 @@ end FiniteResolution
 section EulerClassOf
 
 /-- **The Euler class of an object of finite `P`-dimension**, in the exact `K₀` of the structure
-induced on the full subcategory on `P`: the alternating class of some, hence by
-`TauCeti.ExactStructure.eulerClassOf_eq` of any, finite `P`-resolution of it. -/
+induced on the full subcategory on `P`: the alternating class of some, hence when `P` consists of
+`E`-projectives, by `TauCeti.ExactStructure.eulerClassOf_eq` of any, finite `P`-resolution of it. -/
 noncomputable def eulerClassOf {X : C} (hX : E.admitsFiniteResolution P X) :
     ExactK0 (E.fullSubcategory P hP) :=
   ((E.admitsFiniteResolution_iff P).mp hX).some.eulerClassFullSubcategory hP
@@ -336,23 +253,13 @@ private theorem eulerClassOf_add_aux (n : ℕ) :
       obtain ⟨t, htl⟩ := ht
       have hX₁ : P S.X₁ := by simpa using r.prop_syzygy hrl
       have hX₃ : P S.X₃ := by simpa using t.prop_syzygy htl
-      have hzero : (ObjectProperty.homMk S.f :
-            (⟨S.X₁, hX₁⟩ : P.FullSubcategory) ⟶
-              ⟨S.X₂, hP.prop_X₂ hS hX₁ hX₃⟩) ≫
-          (ObjectProperty.homMk S.g :
-            (⟨S.X₂, hP.prop_X₂ hS hX₁ hX₃⟩ : P.FullSubcategory) ⟶
-              ⟨S.X₃, hX₃⟩) = 0 :=
-        ObjectProperty.hom_ext _ S.zero
-      have hconf : (E.fullSubcategory P hP).Conflation (ShortComplex.mk _ _ hzero) := by
-        rw [fullSubcategory_conflation_iff]
-        exact hS
       rw [E.eulerClassOf_eq hP hproj h₂ (.base (hP.prop_X₂ hS hX₁ hX₃)),
         E.eulerClassOf_eq hP hproj h₁ (.base hX₁),
         E.eulerClassOf_eq hP hproj h₃ (.base hX₃),
         FiniteResolution.eulerClassFullSubcategory_base,
         FiniteResolution.eulerClassFullSubcategory_base,
         FiniteResolution.eulerClassFullSubcategory_base]
-      exact ExactK0.of_conflation hconf
+      exact ExactK0.of_conflation_fullSubcategory hP hS hX₁ hX₃
   | succ n ih =>
       intro S hS h₁ h₃ h₂ hr ht
       obtain ⟨KX, QX, mX, aX, hmX, hQX, hcX, hKX⟩ :=
@@ -427,29 +334,18 @@ theorem map_eulerClassFullSubcategory_eq_of {X : C} (r : E.FiniteResolution P X)
       have hK : E.admitsFiniteResolution P K := (E.admitsFiniteResolution_iff P).mpr ⟨r⟩
       have hX : E.admitsFiniteResolution P X :=
         E.admitsFiniteResolution_of_conflation P hQ hp hK
-      have hzero : (ObjectProperty.homMk i :
-            (⟨K, hK⟩ : (E.admitsFiniteResolution P).FullSubcategory) ⟶
-              ⟨Q, E.le_admitsFiniteResolution P Q hQ⟩) ≫
-          (ObjectProperty.homMk p :
-            (⟨Q, E.le_admitsFiniteResolution P Q hQ⟩ :
-              (E.admitsFiniteResolution P).FullSubcategory) ⟶ ⟨X, hX⟩) = 0 :=
-        ObjectProperty.hom_ext _ zero
-      have hconf : (E.fullSubcategory (E.admitsFiniteResolution P)
-          (E.isExtensionClosed_admitsFiniteResolution hproj)).Conflation
-            (ShortComplex.mk _ _ hzero) := by
-        rw [fullSubcategory_conflation_iff]
-        exact hp
       have hsum : ExactK0.of ((ObjectProperty.ιOfLE (E.le_admitsFiniteResolution P)).obj
             (⟨Q, hQ⟩ : P.FullSubcategory)) =
           ExactK0.of (⟨K, hK⟩ : (E.admitsFiniteResolution P).FullSubcategory) +
             ExactK0.of (⟨X, hX⟩ : (E.admitsFiniteResolution P).FullSubcategory) :=
-        ExactK0.of_conflation hconf
+        ExactK0.of_conflation_fullSubcategory
+          (E.isExtensionClosed_admitsFiniteResolution hproj) hp hK hX
       rw [FiniteResolution.eulerClassFullSubcategory_step, map_sub, ExactK0.map_of, ih, hsum]
       abel
 
 /-- The Euler class of the objects of finite `P`-dimension, as a conflation-additive invariant
 with values in the exact `K₀` of the full subcategory on `P`. -/
-noncomputable def eulerInvariant :
+private noncomputable def eulerInvariant :
     ExactK0.AdditiveInvariant
       (E.fullSubcategory (E.admitsFiniteResolution P)
         (E.isExtensionClosed_admitsFiniteResolution hproj))

--- a/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
@@ -181,7 +181,7 @@ class. -/
       | @base Y hY =>
           rw [biprod_base_base, eulerClassFullSubcategory_base, eulerClassFullSubcategory_base,
             eulerClassFullSubcategory_base]
-          exact ExactK0.of_biprod_fullSubcategory hP hX hY _
+          exact ExactK0.of_biprod_fullSubcategory hP hX hY
       | @step K Q Y hQ i p zero hp s =>
           simp only [biprod_base_step, eulerClassFullSubcategory]
           rw [eulerClassFullSubcategory_ofIso,

--- a/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
@@ -43,8 +43,8 @@ theorem** in the projective case.
 
 ## Main results
 
-* `TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq`: **the Euler class
-  depends only on the resolved object**, by Schanuel's lemma.
+* `TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory`:
+  **the Euler class depends only on the resolved object**, by Schanuel's lemma.
 * `TauCeti.ExactStructure.eulerClassOf_conflation` and
   `TauCeti.ExactStructure.eulerClassOf_add_of_conflation`: the Euler class drops by one step
   along a conflation with resolving middle term, and is additive on conflations. The second is
@@ -58,8 +58,10 @@ theorem** in the projective case.
 
 ## Implementation notes
 
-Every statement here carries `P ≤ E.isProjective` as an explicit hypothesis and none of them is
-asserted for a general resolving subcategory. The resolution theorem is true in that generality —
+The well-definedness, conflation-additivity, and resolution-theorem results here carry
+`P ≤ E.isProjective` as an explicit hypothesis; the underlying Euler-class definitions and formal
+computation lemmas need only extension closure. None of the substantive results is asserted for a
+general resolving subcategory. The resolution theorem is true in that generality —
 for a replete, additive, extension-closed `P` closed under kernels of deflations between its own
 objects — but its proof replaces Schanuel's lemma and the horseshoe by Weibel's common-refinement
 argument, and is not carried out here. The projective case is the one that Layer 4's Cartan
@@ -97,6 +99,11 @@ universe w v u
 variable {C : Type u} [Category.{v} C] [Preadditive C] [HasZeroObject C] [HasBinaryBiproducts C]
   [EssentiallySmall.{w} C] {E : ExactStructure C} {P : ObjectProperty C}
 
+/-- Mathlib's smallness instance for a full subcategory consumes smallness of its object
+property. -/
+local instance : ObjectProperty.EssentiallySmall.{w} P :=
+  ObjectProperty.EssentiallySmall.of_le le_top
+
 namespace ExactK0
 
 section
@@ -117,7 +124,7 @@ This is not an instance of `TauCeti.ExactK0.of_biprod`: the biproduct of `⟨X, 
 `⟨Y, hY⟩` in the subcategory is merely *isomorphic* to `⟨X ⊞ Y, hXY⟩`, and it is the latter that
 the recursion of `TauCeti.ExactStructure.FiniteResolution.biprod` produces. The split biproduct
 short complex on `⟨X ⊞ Y, hXY⟩` itself is a conflation, which gives the relation directly. -/
-theorem of_biprod_fullSubcategory {X Y : C} (hX : P X) (hY : P Y) (hXY : P (X ⊞ Y)) :
+@[simp] theorem of_biprod_fullSubcategory {X Y : C} (hX : P X) (hY : P Y) (hXY : P (X ⊞ Y)) :
     (of ⟨X ⊞ Y, hXY⟩ : ExactK0 (E.fullSubcategory P hP)) = of ⟨X, hX⟩ + of ⟨Y, hY⟩ := by
   have hzero : (ObjectProperty.homMk (biprod.inl : X ⟶ X ⊞ Y) :
         (⟨X, hX⟩ : P.FullSubcategory) ⟶ ⟨X ⊞ Y, hXY⟩) ≫
@@ -151,7 +158,7 @@ variable (hP : E.IsExtensionClosed P)
 
 namespace FiniteResolution
 
-/-- **The Euler class of a finite `P`-resolution in the `K₀` of the resolving subcategory**: the
+/-- **The Euler class of a finite `P`-resolution in the `K₀` of the full subcategory on `P`**: the
 alternating sum `[Q₀] - [Q₁] + ⋯ + (-1)ⁿ [Kₙ]` of the classes of its resolving terms and its last
 syzygy, all of which satisfy `P`, formed in the exact `K₀` of the exact structure induced on the
 full subcategory on `P`.
@@ -159,8 +166,8 @@ full subcategory on `P`.
 Unlike `TauCeti.ExactStructure.FiniteResolution.eulerClass`, which lives in the `K₀` of the
 ambient category and telescopes to `[X]`, this class carries genuine information: nothing in the
 subcategory relates it to `X`. That it depends only on `X` is
-`TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq`, and needs `P` to consist
-of projectives. -/
+`TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory`,
+and needs `P` to consist of projectives. -/
 noncomputable def eulerClassFullSubcategory :
     ∀ {X : C}, E.FiniteResolution P X → ExactK0 (E.fullSubcategory P hP)
   | _, .base hX => ExactK0.of ⟨_, hX⟩
@@ -241,9 +248,9 @@ noncomputable def eulerClassFullSubcategory :
 section Projective
 
 /-- The inductive core of
-`TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq`, on the sum of the two
-lengths. Schanuel's lemma compares the two first steps, and the induction hypothesis then
-compares the two remaining chains, each enlarged by the other's resolving term. -/
+`TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory`,
+on the sum of the two lengths. Schanuel's lemma compares the two first steps, and the induction
+hypothesis then compares the two remaining chains, each enlarged by the other's resolving term. -/
 private theorem eulerClassFullSubcategory_eq_aux (hproj : P ≤ E.isProjective) (n : ℕ) :
     ∀ {X : C} (r s : E.FiniteResolution P X), r.length + s.length ≤ n →
       r.eulerClassFullSubcategory hP = s.eulerClassFullSubcategory hP := by
@@ -299,7 +306,7 @@ private theorem eulerClassFullSubcategory_eq_aux (hproj : P ≤ E.isProjective) 
                 sub_eq_sub_iff_add_eq_add]
               exact (add_comm _ _).trans (hcmp.symm.trans (add_comm _ _))
 
-/-- **The Euler class in the `K₀` of the resolving subcategory depends only on the resolved
+/-- **The Euler class in the `K₀` of the full subcategory on `P` depends only on the resolved
 object.** Any two finite `P`-resolutions of the same object have the same alternating class in
 `ExactK0 (E.fullSubcategory P hP)`, as soon as every object satisfying `P` is `E`-projective.
 
@@ -307,7 +314,8 @@ The proof is an induction on the sum of the two lengths whose only geometric inp
 lemma `TauCeti.ExactStructure.nonempty_iso_biprod_of_projective`: it turns the two first steps
 `K ↪ Q ↠ X` and `K' ↪ Q' ↠ X` into an isomorphism `K ⊞ Q' ≅ K' ⊞ Q`, and the two remaining
 chains, each enlarged by the other's resolving term, resolve the two sides. -/
-theorem eulerClassFullSubcategory_eq (hproj : P ≤ E.isProjective) {X : C}
+theorem eulerClassFullSubcategory_eq_eulerClassFullSubcategory
+    (hproj : P ≤ E.isProjective) {X : C}
     (r s : E.FiniteResolution P X) :
     r.eulerClassFullSubcategory hP = s.eulerClassFullSubcategory hP :=
   eulerClassFullSubcategory_eq_aux hP hproj _ r s le_rfl
@@ -333,11 +341,11 @@ include hproj in
 theorem eulerClassOf_eq {X : C} (hX : E.admitsFiniteResolution P X)
     (r : E.FiniteResolution P X) :
     E.eulerClassOf hP hX = r.eulerClassFullSubcategory hP :=
-  FiniteResolution.eulerClassFullSubcategory_eq hP hproj _ r
+  FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory hP hproj _ r
 
 include hproj in
 /-- On an object satisfying `P` the Euler class is the class of that object. -/
-theorem eulerClassOf_of_prop {X : C} (hX : P X) :
+@[simp] theorem eulerClassOf_of_prop {X : C} (hX : P X) :
     E.eulerClassOf hP (E.le_admitsFiniteResolution P X hX) =
       ExactK0.of (⟨X, hX⟩ : P.FullSubcategory) := by
   rw [E.eulerClassOf_eq hP hproj _ (.base hX),
@@ -441,7 +449,7 @@ section ResolutionTheorem
 variable (hproj : P ≤ E.isProjective)
 
 omit [EssentiallySmall.{w} C] in
-/-- **The inclusion of the resolving subcategory into the objects of finite `P`-dimension is
+/-- **The inclusion of the full subcategory on `P` into the objects of finite `P`-dimension is
 conflation-exact.** Both induced structures detect their conflations in the ambient category. -/
 theorem isConflationExact_ιOfLE :
     (E.fullSubcategory P hP).IsConflationExact
@@ -490,7 +498,7 @@ theorem map_eulerClassFullSubcategory {X : C} (r : E.FiniteResolution P X) :
       abel
 
 /-- The Euler class of the objects of finite `P`-dimension, as a conflation-additive invariant
-with values in the exact `K₀` of the resolving subcategory. -/
+with values in the exact `K₀` of the full subcategory on `P`. -/
 noncomputable def eulerInvariant :
     ExactK0.AdditiveInvariant
       (E.fullSubcategory (E.admitsFiniteResolution P)

--- a/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
@@ -1,0 +1,561 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.CategoryTheory.Exact.Projective
+public import TauCeti.CategoryTheory.GrothendieckGroup.Resolution
+
+/-!
+# The Euler class of a finite projective resolution, and the resolution theorem
+
+Let `E` be an exact structure on an additive category `C` and let `P` be a property of objects
+consisting of `E`-projectives, containing a zero object and closed under binary biproducts. Then
+`P` is extension closed, so the full subcategory on `P` carries an induced exact structure — in
+fact the split one — and every finite `P`-resolution
+
+```text
+Kₙ ↪ Qₙ₋₁ ↠ Kₙ₋₁,   …,   K₁ ↪ Q₀ ↠ X
+```
+
+has an alternating class `[Q₀] - [Q₁] + ⋯ + (-1)ⁿ [Kₙ]` in the exact `K₀` of that subcategory.
+Unlike the ambient class of `TauCeti/CategoryTheory/GrothendieckGroup/Resolution.lean`, which
+telescopes to `[X]` and is therefore independent of every choice for trivial reasons, this class
+is not visibly determined by `X`: nothing in the subcategory relates `[Q₀] - [K₁]` to `X`.
+
+That it *is* determined by `X` is the content of this file. Schanuel's lemma turns two first
+steps `K ↪ Q ↠ X` and `K' ↪ Q' ↠ X` into an isomorphism `K ⊞ Q' ≅ K' ⊞ Q`, and an induction on
+the sum of the two lengths does the rest. The horseshoe lemma then makes the resulting invariant
+additive on conflations, so it factors through the exact `K₀` of the objects of finite
+`P`-dimension and inverts the map induced by the inclusion: this is Weibel's **resolution
+theorem** in the projective case.
+
+## Main definitions
+
+* `TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory`: the alternating class of a
+  finite `P`-resolution, in the exact `K₀` of the exact structure induced on the full subcategory
+  on `P`. Its definition needs only extension closure of `P`.
+* `TauCeti.ExactStructure.eulerClassOf`: the Euler class of an object admitting a finite
+  `P`-resolution.
+* `TauCeti.ExactStructure.resolutionEquiv`: the isomorphism of the resolution theorem.
+
+## Main results
+
+* `TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq`: **the Euler class
+  depends only on the resolved object**, by Schanuel's lemma.
+* `TauCeti.ExactStructure.eulerClassOf_conflation` and
+  `TauCeti.ExactStructure.eulerClassOf_add_of_conflation`: the Euler class drops by one step
+  along a conflation with resolving middle term, and is additive on conflations. The second is
+  the horseshoe lemma, iterated.
+* `TauCeti.ExactStructure.map_eulerClassFullSubcategory`: in the exact `K₀` of the objects of
+  finite `P`-dimension the alternating class of a resolution of `X` is `[X]`.
+* `TauCeti.ExactStructure.resolutionEquiv`, `TauCeti.ExactStructure.resolutionEquiv_of` and
+  `TauCeti.ExactStructure.resolutionEquiv_symm_of`: **the resolution theorem**. The inclusion of
+  the full subcategory on `P` into the objects admitting a finite `P`-resolution induces an
+  isomorphism on exact `K₀`, whose inverse is the Euler class.
+
+## Implementation notes
+
+Every statement here carries `P ≤ E.isProjective` as an explicit hypothesis and none of them is
+asserted for a general resolving subcategory. The resolution theorem is true in that generality —
+for a replete, additive, extension-closed `P` closed under kernels of deflations between its own
+objects — but its proof replaces Schanuel's lemma and the horseshoe by Weibel's common-refinement
+argument, and is not carried out here. The projective case is the one that Layer 4's Cartan
+comparison consumes.
+
+The class of an object, as opposed to that of a resolution, is defined by choosing a resolution
+with `Nonempty.some`; `TauCeti.ExactStructure.eulerClassOf_eq` immediately removes the choice, so
+no result below depends on it.
+
+Two inductions are carried out on a numerical bound rather than on the resolutions themselves:
+the well-definedness induction consumes the sum of the two lengths, because Schanuel's lemma
+replaces both chains at once, and the additivity induction consumes a common bound for the two
+outer lengths, because the horseshoe replaces both at once. Both are stated as `private`
+auxiliaries over an explicit `n`.
+
+## References
+
+* Charles A. Weibel, *The K-book: An Introduction to Algebraic K-theory*, Chapter II, Theorem 7.6
+  and Lemma 7.6.1: the resolution theorem and the independence of the Euler class.
+* Theo Bühler, *Exact categories*, Expositiones Mathematicae **28** (2010), 1--69, Sections
+  11--12, for Schanuel's lemma and the horseshoe lemma in a Quillen exact category.
+* [The Tau Ceti Grothendieck groups, Cartan maps, and Euler forms roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/GrothendieckEulerForms/README.md),
+  Layer 3, whose Euler-class and resolution-theorem bullets are the targets proved here in the
+  projective case, and whose Layer 4 Cartan comparison consumes them.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits ZeroObject
+
+universe w v u
+
+variable {C : Type u} [Category.{v} C] [Preadditive C] [HasZeroObject C] [HasBinaryBiproducts C]
+  [EssentiallySmall.{w} C] {E : ExactStructure C} {P : ObjectProperty C}
+
+namespace ExactK0
+
+section
+
+variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
+
+/-- A property containing a zero object and closed under binary products is automatically
+replete, by `CategoryTheory.ObjectProperty.isClosedUnderIsomorphisms_of_containsZero`. -/
+local instance : P.IsClosedUnderIsomorphisms :=
+  ObjectProperty.isClosedUnderIsomorphisms_of_containsZero P
+
+variable (hP : E.IsExtensionClosed P)
+
+/-- The class of a biproduct in the exact `K₀` of the structure induced on the full subcategory
+on `P`.
+
+This is not an instance of `TauCeti.ExactK0.of_biprod`: the biproduct of `⟨X, hX⟩` and
+`⟨Y, hY⟩` in the subcategory is merely *isomorphic* to `⟨X ⊞ Y, hXY⟩`, and it is the latter that
+the recursion of `TauCeti.ExactStructure.FiniteResolution.biprod` produces. The split biproduct
+short complex on `⟨X ⊞ Y, hXY⟩` itself is a conflation, which gives the relation directly. -/
+theorem of_biprod_fullSubcategory {X Y : C} (hX : P X) (hY : P Y) (hXY : P (X ⊞ Y)) :
+    (of ⟨X ⊞ Y, hXY⟩ : ExactK0 (E.fullSubcategory P hP)) = of ⟨X, hX⟩ + of ⟨Y, hY⟩ := by
+  have hzero : (ObjectProperty.homMk (biprod.inl : X ⟶ X ⊞ Y) :
+        (⟨X, hX⟩ : P.FullSubcategory) ⟶ ⟨X ⊞ Y, hXY⟩) ≫
+      (ObjectProperty.homMk (biprod.snd : X ⊞ Y ⟶ Y) :
+        (⟨X ⊞ Y, hXY⟩ : P.FullSubcategory) ⟶ ⟨Y, hY⟩) = 0 :=
+    ObjectProperty.hom_ext _ (by simp)
+  refine of_eq_add_of_conflation hzero (ExactStructure.conflation_of_splitting _ ?_)
+  exact
+    { r := ObjectProperty.homMk biprod.fst
+      s := ObjectProperty.homMk biprod.inr
+      f_r := ObjectProperty.hom_ext _ (by simp)
+      s_g := ObjectProperty.hom_ext _ (by simp)
+      id := ObjectProperty.hom_ext _ biprod.total }
+
+end
+
+end ExactK0
+
+namespace ExactStructure
+
+section
+
+variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
+
+/-- A property containing a zero object and closed under binary products is automatically
+replete, by `CategoryTheory.ObjectProperty.isClosedUnderIsomorphisms_of_containsZero`. -/
+local instance : P.IsClosedUnderIsomorphisms :=
+  ObjectProperty.isClosedUnderIsomorphisms_of_containsZero P
+
+variable (hP : E.IsExtensionClosed P)
+
+namespace FiniteResolution
+
+/-- **The Euler class of a finite `P`-resolution in the `K₀` of the resolving subcategory**: the
+alternating sum `[Q₀] - [Q₁] + ⋯ + (-1)ⁿ [Kₙ]` of the classes of its resolving terms and its last
+syzygy, all of which satisfy `P`, formed in the exact `K₀` of the exact structure induced on the
+full subcategory on `P`.
+
+Unlike `TauCeti.ExactStructure.FiniteResolution.eulerClass`, which lives in the `K₀` of the
+ambient category and telescopes to `[X]`, this class carries genuine information: nothing in the
+subcategory relates it to `X`. That it depends only on `X` is
+`TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq`, and needs `P` to consist
+of projectives. -/
+noncomputable def eulerClassFullSubcategory :
+    ∀ {X : C}, E.FiniteResolution P X → ExactK0 (E.fullSubcategory P hP)
+  | _, .base hX => ExactK0.of ⟨_, hX⟩
+  | _, .step (Q := Q) hQ _ _ _ _ r => ExactK0.of ⟨Q, hQ⟩ - eulerClassFullSubcategory r
+
+@[simp] theorem eulerClassFullSubcategory_base {X : C} (hX : P X) :
+    (base (E := E) hX).eulerClassFullSubcategory hP = ExactK0.of ⟨X, hX⟩ := (rfl)
+
+@[simp] theorem eulerClassFullSubcategory_step {K Q X : C} (hQ : P Q) (i : K ⟶ Q) (p : Q ⟶ X)
+    (zero : i ≫ p = 0) (hp : E.Conflation (ShortComplex.mk i p zero))
+    (r : E.FiniteResolution P K) :
+    (step hQ i p zero hp r).eulerClassFullSubcategory hP =
+      ExactK0.of ⟨Q, hQ⟩ - r.eulerClassFullSubcategory hP := (rfl)
+
+@[simp] theorem eulerClassFullSubcategory_ofIso {X Y : C} (e : X ≅ Y)
+    (r : E.FiniteResolution P X) :
+    (ofIso e r).eulerClassFullSubcategory hP = r.eulerClassFullSubcategory hP := by
+  cases r with
+  | base hX =>
+      rw [ofIso_base, eulerClassFullSubcategory_base, eulerClassFullSubcategory_base]
+      exact ExactK0.of_congr (ObjectProperty.isoMk _ e.symm :
+        (⟨Y, P.prop_of_iso e hX⟩ : P.FullSubcategory) ≅ ⟨X, hX⟩)
+  | step hQ i p zero hp r =>
+      rw [ofIso_step, eulerClassFullSubcategory_step, eulerClassFullSubcategory_step]
+
+@[simp] theorem eulerClassFullSubcategory_biprod {X Y : C} (r : E.FiniteResolution P X)
+    (s : E.FiniteResolution P Y) :
+    (r.biprod s).eulerClassFullSubcategory hP =
+      r.eulerClassFullSubcategory hP + s.eulerClassFullSubcategory hP := by
+  induction r generalizing Y with
+  | @base X hX =>
+      cases s with
+      | @base Y hY =>
+          rw [biprod_base_base, eulerClassFullSubcategory_base, eulerClassFullSubcategory_base,
+            eulerClassFullSubcategory_base]
+          exact ExactK0.of_biprod_fullSubcategory hP hX hY _
+      | @step K Q Y hQ i p zero hp s =>
+          have hz : (biprod.map (0 : (0 : C) ⟶ X) i) ≫ (biprod.map (𝟙 X) p) = 0 := by
+            apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero]
+          have hc : E.Conflation (ShortComplex.mk (biprod.map (0 : (0 : C) ⟶ X) i)
+              (biprod.map (𝟙 X) p) hz) := E.conflation_biprod (E.conflation_zero_id X) hp
+          have key : (base (E := E) hX).biprod (step hQ i p zero hp s) =
+              step (hP.prop_biprod hX hQ) (biprod.map (0 : (0 : C) ⟶ X) i)
+                (biprod.map (𝟙 X) p) hz hc (s.ofIso (isoZeroBiprod (isZero_zero C))) :=
+            biprod_base_step hX hQ i p zero hp s
+          rw [key, eulerClassFullSubcategory_step, eulerClassFullSubcategory_ofIso,
+            eulerClassFullSubcategory_base, eulerClassFullSubcategory_step,
+            ExactK0.of_biprod_fullSubcategory hP hX hQ]
+          abel
+  | @step K Q X hQ i p zero hp r ih =>
+      cases s with
+      | @base Y hY =>
+          have hz : (biprod.map i (0 : (0 : C) ⟶ Y)) ≫ (biprod.map p (𝟙 Y)) = 0 := by
+            apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero]
+          have hc : E.Conflation (ShortComplex.mk (biprod.map i (0 : (0 : C) ⟶ Y))
+              (biprod.map p (𝟙 Y)) hz) := E.conflation_biprod hp (E.conflation_zero_id Y)
+          have key : (step hQ i p zero hp r).biprod (base (E := E) hY) =
+              step (hP.prop_biprod hQ hY) (biprod.map i (0 : (0 : C) ⟶ Y))
+                (biprod.map p (𝟙 Y)) hz hc (r.ofIso (isoBiprodZero (isZero_zero C))) :=
+            biprod_step_base hQ i p zero hp r hY
+          rw [key, eulerClassFullSubcategory_step, eulerClassFullSubcategory_ofIso,
+            eulerClassFullSubcategory_base, eulerClassFullSubcategory_step,
+            ExactK0.of_biprod_fullSubcategory hP hQ hY]
+          abel
+      | @step K' Q' Y hQ' i' p' zero' hp' s =>
+          have hz : (biprod.map i i') ≫ (biprod.map p p') = 0 := by
+            apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero, reassoc_of% zero']
+          have hc : E.Conflation (ShortComplex.mk (biprod.map i i') (biprod.map p p') hz) :=
+            E.conflation_biprod hp hp'
+          have key : (step hQ i p zero hp r).biprod (step hQ' i' p' zero' hp' s) =
+              step (hP.prop_biprod hQ hQ') (biprod.map i i') (biprod.map p p') hz hc
+                (r.biprod s) :=
+            biprod_step_step hQ i p zero hp r hQ' i' p' zero' hp' s
+          rw [key, eulerClassFullSubcategory_step, ih, eulerClassFullSubcategory_step,
+            eulerClassFullSubcategory_step, ExactK0.of_biprod_fullSubcategory hP hQ hQ']
+          abel
+
+section Projective
+
+/-- The inductive core of
+`TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq`, on the sum of the two
+lengths. Schanuel's lemma compares the two first steps, and the induction hypothesis then
+compares the two remaining chains, each enlarged by the other's resolving term. -/
+private theorem eulerClassFullSubcategory_eq_aux (hproj : P ≤ E.isProjective) (n : ℕ) :
+    ∀ {X : C} (r s : E.FiniteResolution P X), r.length + s.length ≤ n →
+      r.eulerClassFullSubcategory hP = s.eulerClassFullSubcategory hP := by
+  induction n with
+  | zero =>
+      intro X r s h
+      cases r with
+      | @base X hX =>
+          cases s with
+          | @base _ hX' => rfl
+          | @step K Q _ hQ i p zero hp s => simp only [length_base, length_step] at h; omega
+      | @step K Q X hQ i p zero hp r => simp only [length_step] at h; omega
+  | succ n ih =>
+      -- The mixed case: a resolution of length zero against one that begins with a conflation.
+      have key : ∀ {X K Q : C} (hX : P X) (hQ : P Q) (i : K ⟶ Q) (p : Q ⟶ X)
+          (zero : i ≫ p = 0) (hp : E.Conflation (ShortComplex.mk i p zero))
+          (s : E.FiniteResolution P K), s.length ≤ n →
+          (base (E := E) hX).eulerClassFullSubcategory hP =
+            (step hQ i p zero hp s).eulerClassFullSubcategory hP := by
+        intro X K Q hX hQ i p zero hp s hs
+        obtain ⟨e⟩ := E.nonempty_iso_biprod_of_projective hp (hproj _ hQ)
+          (E.conflation_zero_id X) (hproj _ hX)
+        have hcmp := ih ((s.biprod (base hX)).ofIso e)
+          ((base (E := E) hQ).ofIso (isoZeroBiprod (isZero_zero C)))
+          (by simp only [length_ofIso, length_biprod, length_base]; omega)
+        rw [eulerClassFullSubcategory_ofIso, eulerClassFullSubcategory_ofIso,
+          eulerClassFullSubcategory_biprod, eulerClassFullSubcategory_base,
+          eulerClassFullSubcategory_base] at hcmp
+        rw [eulerClassFullSubcategory_base, eulerClassFullSubcategory_step, ← hcmp]
+        abel
+      intro X r s h
+      cases r with
+      | @base X hX =>
+          cases s with
+          | @base _ hX' => rfl
+          | @step K Q _ hQ i p zero hp s =>
+              refine key hX hQ i p zero hp s ?_
+              simp only [length_base, length_step] at h; omega
+      | @step K Q X hQ i p zero hp r =>
+          cases s with
+          | @base _ hX' =>
+              refine (key hX' hQ i p zero hp r ?_).symm
+              simp only [length_base, length_step] at h; omega
+          | @step K' Q' _ hQ' i' p' zero' hp' s =>
+              simp only [length_step] at h
+              obtain ⟨e⟩ := E.nonempty_iso_biprod_of_projective hp (hproj _ hQ) hp' (hproj _ hQ')
+              have hcmp := ih ((r.biprod (base hQ')).ofIso e) (s.biprod (base hQ))
+                (by simp only [length_ofIso, length_biprod, length_base]; omega)
+              rw [eulerClassFullSubcategory_ofIso, eulerClassFullSubcategory_biprod,
+                eulerClassFullSubcategory_biprod, eulerClassFullSubcategory_base,
+                eulerClassFullSubcategory_base] at hcmp
+              rw [eulerClassFullSubcategory_step, eulerClassFullSubcategory_step,
+                sub_eq_sub_iff_add_eq_add]
+              exact (add_comm _ _).trans (hcmp.symm.trans (add_comm _ _))
+
+/-- **The Euler class in the `K₀` of the resolving subcategory depends only on the resolved
+object.** Any two finite `P`-resolutions of the same object have the same alternating class in
+`ExactK0 (E.fullSubcategory P hP)`, as soon as every object satisfying `P` is `E`-projective.
+
+The proof is an induction on the sum of the two lengths whose only geometric input is Schanuel's
+lemma `TauCeti.ExactStructure.nonempty_iso_biprod_of_projective`: it turns the two first steps
+`K ↪ Q ↠ X` and `K' ↪ Q' ↠ X` into an isomorphism `K ⊞ Q' ≅ K' ⊞ Q`, and the two remaining
+chains, each enlarged by the other's resolving term, resolve the two sides. -/
+theorem eulerClassFullSubcategory_eq (hproj : P ≤ E.isProjective) {X : C}
+    (r s : E.FiniteResolution P X) :
+    r.eulerClassFullSubcategory hP = s.eulerClassFullSubcategory hP :=
+  eulerClassFullSubcategory_eq_aux hP hproj _ r s le_rfl
+
+end Projective
+
+end FiniteResolution
+
+
+section EulerClassOf
+
+/-- **The Euler class of an object of finite `P`-dimension**, in the exact `K₀` of the structure
+induced on the full subcategory on `P`: the alternating class of some, hence by
+`TauCeti.ExactStructure.eulerClassOf_eq` of any, finite `P`-resolution of it. -/
+noncomputable def eulerClassOf {X : C} (hX : E.admitsFiniteResolution P X) :
+    ExactK0 (E.fullSubcategory P hP) :=
+  ((E.admitsFiniteResolution_iff P).mp hX).some.eulerClassFullSubcategory hP
+
+variable (hproj : P ≤ E.isProjective)
+
+include hproj in
+/-- Every finite `P`-resolution of `X` computes `TauCeti.ExactStructure.eulerClassOf`. -/
+theorem eulerClassOf_eq {X : C} (hX : E.admitsFiniteResolution P X)
+    (r : E.FiniteResolution P X) :
+    E.eulerClassOf hP hX = r.eulerClassFullSubcategory hP :=
+  FiniteResolution.eulerClassFullSubcategory_eq hP hproj _ r
+
+include hproj in
+/-- On an object satisfying `P` the Euler class is the class of that object. -/
+theorem eulerClassOf_of_prop {X : C} (hX : P X) :
+    E.eulerClassOf hP (E.le_admitsFiniteResolution P X hX) =
+      ExactK0.of (⟨X, hX⟩ : P.FullSubcategory) := by
+  rw [E.eulerClassOf_eq hP hproj _ (.base hX),
+    FiniteResolution.eulerClassFullSubcategory_base]
+
+include hproj in
+/-- **The Euler class drops by one step along a conflation with resolving middle term**:
+`χ(X) = [Q] - χ(K)` for a conflation `K ↪ Q ↠ X` with `P Q`. -/
+theorem eulerClassOf_conflation {K Q X : C} (hQ : P Q) {i : K ⟶ Q} {p : Q ⟶ X}
+    {zero : i ≫ p = 0} (hp : E.Conflation (ShortComplex.mk i p zero))
+    (hK : E.admitsFiniteResolution P K) :
+    E.eulerClassOf hP (E.admitsFiniteResolution_of_conflation P hQ hp hK) =
+      ExactK0.of (⟨Q, hQ⟩ : P.FullSubcategory) - E.eulerClassOf hP hK := by
+  rw [E.eulerClassOf_eq hP hproj _ (.step hQ i p zero hp
+      ((E.admitsFiniteResolution_iff P).mp hK).some),
+    FiniteResolution.eulerClassFullSubcategory_step]
+  rfl
+
+include hproj in
+/-- The inductive core of `TauCeti.ExactStructure.eulerClassOf_add_of_conflation`, on a common
+bound for the lengths of resolutions of the two outer terms. Its inductive step is the horseshoe
+lemma: the resolving terms add, and the new syzygy is an extension of the two old ones. -/
+private theorem eulerClassOf_add_aux (n : ℕ) :
+    ∀ {S : ShortComplex C}, E.Conflation S →
+      ∀ (h₁ : E.admitsFiniteResolution P S.X₁) (h₃ : E.admitsFiniteResolution P S.X₃)
+        (h₂ : E.admitsFiniteResolution P S.X₂),
+        (∃ r : E.FiniteResolution P S.X₁, r.length ≤ n) →
+        (∃ t : E.FiniteResolution P S.X₃, t.length ≤ n) →
+        E.eulerClassOf hP h₂ = E.eulerClassOf hP h₁ + E.eulerClassOf hP h₃ := by
+  induction n with
+  | zero =>
+      intro S hS h₁ h₃ h₂ hr ht
+      obtain ⟨r, hrl⟩ := hr
+      obtain ⟨t, htl⟩ := ht
+      have hX₁ : P S.X₁ := by simpa using r.prop_syzygy hrl
+      have hX₃ : P S.X₃ := by simpa using t.prop_syzygy htl
+      rw [E.eulerClassOf_eq hP hproj h₂ (.base (hP.prop_X₂ hS hX₁ hX₃)),
+        E.eulerClassOf_eq hP hproj h₁ (.base hX₁),
+        E.eulerClassOf_eq hP hproj h₃ (.base hX₃),
+        FiniteResolution.eulerClassFullSubcategory_base,
+        FiniteResolution.eulerClassFullSubcategory_base,
+        FiniteResolution.eulerClassFullSubcategory_base,
+        ExactK0.of_congr (ObjectProperty.isoMk _
+          (E.splittingOfProjective hS (hproj _ hX₃)).isoBinaryBiproduct :
+          (⟨S.X₂, hP.prop_X₂ hS hX₁ hX₃⟩ : P.FullSubcategory) ≅
+            ⟨S.X₁ ⊞ S.X₃, hP.prop_biprod hX₁ hX₃⟩)]
+      exact ExactK0.of_biprod_fullSubcategory hP hX₁ hX₃ _
+  | succ n ih =>
+      intro S hS h₁ h₃ h₂ hr ht
+      obtain ⟨KX, QX, mX, aX, hmX, hQX, hcX, hKX⟩ :=
+        E.exists_conflation_of_exists_finiteResolution_length_le_succ hr
+      obtain ⟨KZ, QZ, mZ, aZ, hmZ, hQZ, hcZ, hKZ⟩ :=
+        E.exists_conflation_of_exists_finiteResolution_length_le_succ ht
+      obtain ⟨K, u, a, hu, v, w, hv, hKu, hKv, -, -, -, -⟩ :=
+        E.exists_conflation_biprod_of_conflation_of_projective hS hcX hcZ (hproj _ hQZ)
+      have haX : E.admitsFiniteResolution P KX :=
+        (E.admitsFiniteResolution_iff P).mpr ⟨hKX.choose⟩
+      have haZ : E.admitsFiniteResolution P KZ :=
+        (E.admitsFiniteResolution_iff P).mpr ⟨hKZ.choose⟩
+      have haK : E.admitsFiniteResolution P K :=
+        (E.isExtensionClosed_admitsFiniteResolution hproj).prop_X₂ hKv haX haZ
+      have e₂ : E.eulerClassOf hP h₂ =
+          ExactK0.of (⟨QX ⊞ QZ, hP.prop_biprod hQX hQZ⟩ : P.FullSubcategory) -
+            E.eulerClassOf hP haK :=
+        E.eulerClassOf_conflation hP hproj (hP.prop_biprod hQX hQZ) hKu haK
+      have e₁ : E.eulerClassOf hP h₁ =
+          ExactK0.of (⟨QX, hQX⟩ : P.FullSubcategory) - E.eulerClassOf hP haX :=
+        E.eulerClassOf_conflation hP hproj hQX hcX haX
+      have e₃ : E.eulerClassOf hP h₃ =
+          ExactK0.of (⟨QZ, hQZ⟩ : P.FullSubcategory) - E.eulerClassOf hP haZ :=
+        E.eulerClassOf_conflation hP hproj hQZ hcZ haZ
+      have eK : E.eulerClassOf hP haK =
+          E.eulerClassOf hP haX + E.eulerClassOf hP haZ := ih hKv haX haZ haK hKX hKZ
+      rw [e₁, e₂, e₃, eK, ExactK0.of_biprod_fullSubcategory hP hQX hQZ]
+      abel
+
+/-- **The Euler class is additive on conflations.** This is the second half of the Euler-class
+package: together with `TauCeti.ExactStructure.eulerClassOf_eq` it makes the alternating class of
+a finite projective resolution a conflation-additive invariant of the objects of finite
+`P`-dimension. -/
+theorem eulerClassOf_add_of_conflation {S : ShortComplex C} (hS : E.Conflation S)
+    (h₁ : E.admitsFiniteResolution P S.X₁) (h₃ : E.admitsFiniteResolution P S.X₃) :
+    E.eulerClassOf hP ((E.isExtensionClosed_admitsFiniteResolution hproj).prop_X₂ hS h₁ h₃) =
+      E.eulerClassOf hP h₁ + E.eulerClassOf hP h₃ :=
+  E.eulerClassOf_add_aux hP hproj
+    (max ((E.admitsFiniteResolution_iff P).mp h₁).some.length
+      ((E.admitsFiniteResolution_iff P).mp h₃).some.length) hS h₁ h₃ _
+    ⟨_, le_max_left _ _⟩ ⟨_, le_max_right _ _⟩
+
+include hproj in
+/-- The Euler class is invariant under isomorphism of the resolved object. -/
+theorem eulerClassOf_congr {X Y : C} (e : X ≅ Y) (hX : E.admitsFiniteResolution P X)
+    (hY : E.admitsFiniteResolution P Y) : E.eulerClassOf hP hX = E.eulerClassOf hP hY := by
+  rw [E.eulerClassOf_eq hP hproj hY
+      (((E.admitsFiniteResolution_iff P).mp hX).some.ofIso e),
+    FiniteResolution.eulerClassFullSubcategory_ofIso]
+  rfl
+
+section ResolutionTheorem
+
+variable (hproj : P ≤ E.isProjective)
+
+omit [EssentiallySmall.{w} C] in
+/-- **The inclusion of the resolving subcategory into the objects of finite `P`-dimension is
+conflation-exact.** Both induced structures detect their conflations in the ambient category. -/
+theorem isConflationExact_ιOfLE :
+    (E.fullSubcategory P hP).IsConflationExact
+      (E.fullSubcategory (E.admitsFiniteResolution P)
+        (E.isExtensionClosed_admitsFiniteResolution hproj))
+      (ObjectProperty.ιOfLE (E.le_admitsFiniteResolution P)) where
+  map_conflation {S} hS := by
+    rw [fullSubcategory_conflation_iff] at hS ⊢
+    exact hS
+
+/-- **The class of an object of finite `P`-dimension is the alternating class of any of its
+finite `P`-resolutions**, after pushing the latter forward along the inclusion. This is the
+telescoping computation of `TauCeti.ExactStructure.FiniteResolution.eulerClass_eq_of`, carried
+out in the exact `K₀` of the objects of finite `P`-dimension rather than in that of the whole
+ambient category. -/
+theorem map_eulerClassFullSubcategory {X : C} (r : E.FiniteResolution P X) :
+    ExactK0.map _ (E.isConflationExact_ιOfLE hP hproj) (r.eulerClassFullSubcategory hP) =
+      ExactK0.of (⟨X, (E.admitsFiniteResolution_iff P).mpr ⟨r⟩⟩ :
+        (E.admitsFiniteResolution P).FullSubcategory) := by
+  induction r with
+  | @base X hX =>
+      rw [FiniteResolution.eulerClassFullSubcategory_base, ExactK0.map_of]
+      rfl
+  | @step K Q X hQ i p zero hp r ih =>
+      have hK : E.admitsFiniteResolution P K := (E.admitsFiniteResolution_iff P).mpr ⟨r⟩
+      have hX : E.admitsFiniteResolution P X :=
+        E.admitsFiniteResolution_of_conflation P hQ hp hK
+      have hzero : (ObjectProperty.homMk i :
+            (⟨K, hK⟩ : (E.admitsFiniteResolution P).FullSubcategory) ⟶
+              ⟨Q, E.le_admitsFiniteResolution P Q hQ⟩) ≫
+          (ObjectProperty.homMk p :
+            (⟨Q, E.le_admitsFiniteResolution P Q hQ⟩ :
+              (E.admitsFiniteResolution P).FullSubcategory) ⟶ ⟨X, hX⟩) = 0 :=
+        ObjectProperty.hom_ext _ zero
+      have hconf : (E.fullSubcategory (E.admitsFiniteResolution P)
+          (E.isExtensionClosed_admitsFiniteResolution hproj)).Conflation
+            (ShortComplex.mk _ _ hzero) := by
+        rw [fullSubcategory_conflation_iff]
+        exact hp
+      have hsum : ExactK0.of ((ObjectProperty.ιOfLE (E.le_admitsFiniteResolution P)).obj
+            (⟨Q, hQ⟩ : P.FullSubcategory)) =
+          ExactK0.of (⟨K, hK⟩ : (E.admitsFiniteResolution P).FullSubcategory) +
+            ExactK0.of (⟨X, hX⟩ : (E.admitsFiniteResolution P).FullSubcategory) :=
+        ExactK0.of_conflation hconf
+      rw [FiniteResolution.eulerClassFullSubcategory_step, map_sub, ExactK0.map_of, ih, hsum]
+      abel
+
+/-- The Euler class of the objects of finite `P`-dimension, as a conflation-additive invariant
+with values in the exact `K₀` of the resolving subcategory. -/
+noncomputable def eulerInvariant :
+    ExactK0.AdditiveInvariant
+      (E.fullSubcategory (E.admitsFiniteResolution P)
+        (E.isExtensionClosed_admitsFiniteResolution hproj))
+      (ExactK0 (E.fullSubcategory P hP)) where
+  obj X := E.eulerClassOf hP X.property
+  map_iso _ _ e := E.eulerClassOf_congr hP hproj ((E.admitsFiniteResolution P).ι.mapIso e) _ _
+  map_conflation S hS := by
+    rw [fullSubcategory_conflation_iff] at hS
+    exact E.eulerClassOf_add_of_conflation hP hproj hS _ _
+
+/-- **The inverse of the comparison map of the resolution theorem**: the homomorphism sending the
+class of an object of finite `P`-dimension to the alternating class of any of its finite
+`P`-resolutions. -/
+noncomputable def eulerHom :
+    ExactK0 (E.fullSubcategory (E.admitsFiniteResolution P)
+        (E.isExtensionClosed_admitsFiniteResolution hproj)) →+
+      ExactK0 (E.fullSubcategory P hP) :=
+  ExactK0.lift (E.eulerInvariant hP hproj)
+
+@[simp] theorem eulerHom_of {X : C} (hX : E.admitsFiniteResolution P X) :
+    E.eulerHom hP hproj (ExactK0.of ⟨X, hX⟩) = E.eulerClassOf hP hX :=
+  ExactK0.lift_of _ _
+
+/-- **The resolution theorem for finite projective resolutions.** When every object satisfying
+`P` is `E`-projective, the inclusion of the full subcategory on `P` into the full subcategory of
+objects admitting a finite `P`-resolution induces an isomorphism of exact Grothendieck groups.
+Its inverse sends the class of an object to the alternating class of any finite `P`-resolution of
+it, by `TauCeti.ExactStructure.resolutionEquiv_symm_of`. -/
+noncomputable def resolutionEquiv :
+    ExactK0 (E.fullSubcategory P hP) ≃+
+      ExactK0 (E.fullSubcategory (E.admitsFiniteResolution P)
+        (E.isExtensionClosed_admitsFiniteResolution hproj)) where
+  toFun := ExactK0.map _ (E.isConflationExact_ιOfLE hP hproj)
+  invFun := E.eulerHom hP hproj
+  map_add' _ _ := map_add _ _ _
+  left_inv x := by
+    refine DFunLike.congr_fun (ExactK0.hom_ext (f := (E.eulerHom hP hproj).comp
+      (ExactK0.map _ (E.isConflationExact_ιOfLE hP hproj))) (g := AddMonoidHom.id _)
+      fun Y => ?_) x
+    rw [AddMonoidHom.coe_comp, Function.comp_apply, ExactK0.map_of, E.eulerHom_of,
+      E.eulerClassOf_of_prop hP hproj Y.property, AddMonoidHom.id_apply]
+  right_inv x := by
+    refine DFunLike.congr_fun (ExactK0.hom_ext
+      (f := (ExactK0.map _ (E.isConflationExact_ιOfLE hP hproj)).comp (E.eulerHom hP hproj))
+      (g := AddMonoidHom.id _) fun Y => ?_) x
+    rw [AddMonoidHom.coe_comp, Function.comp_apply, E.eulerHom_of, AddMonoidHom.id_apply,
+      E.eulerClassOf_eq hP hproj Y.property ((E.admitsFiniteResolution_iff P).mp Y.property).some,
+      E.map_eulerClassFullSubcategory hP hproj]
+
+@[simp] theorem resolutionEquiv_of (X : P.FullSubcategory) :
+    E.resolutionEquiv hP hproj (ExactK0.of X) =
+      ExactK0.of ⟨X.obj, E.le_admitsFiniteResolution P X.obj X.property⟩ :=
+  ExactK0.map_of _ _ _
+
+@[simp] theorem resolutionEquiv_symm_of {X : C} (hX : E.admitsFiniteResolution P X) :
+    (E.resolutionEquiv hP hproj).symm (ExactK0.of ⟨X, hX⟩) = E.eulerClassOf hP hX :=
+  E.eulerHom_of hP hproj hX
+
+end ResolutionTheorem
+
+end EulerClassOf
+
+end
+
+end ExactStructure
+
+end TauCeti

--- a/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
@@ -99,7 +99,8 @@ open CategoryTheory CategoryTheory.Limits ZeroObject
 universe w v u
 
 variable {C : Type u} [Category.{v} C] [Preadditive C] [HasZeroObject C] [HasBinaryBiproducts C]
-  [EssentiallySmall.{w} C] {E : ExactStructure C} {P : ObjectProperty C}
+  [LocallySmall.{w} C] {E : ExactStructure C} {P : ObjectProperty C}
+  [ObjectProperty.EssentiallySmall.{w} P]
 
 namespace ExactStructure
 
@@ -216,6 +217,7 @@ theorem eulerClassOf_eq {X : C} (hX : E.admitsFiniteResolution P X)
 
 include hproj in
 /-- On an object satisfying `P` the Euler class is the class of that object. -/
+@[simp]
 theorem eulerClassOf_of_prop {X : C} (hX : P X) :
     E.eulerClassOf hP (E.le_admitsFiniteResolution P X hX) =
       ExactK0.of (⟨X, hX⟩ : P.FullSubcategory) := by
@@ -314,12 +316,14 @@ theorem eulerClassOf_congr {X Y : C} (e : X ≅ Y) (hX : E.admitsFiniteResolutio
 section ResolutionTheorem
 
 variable (hproj : P ≤ E.isProjective)
+  [ObjectProperty.EssentiallySmall.{w} (E.admitsFiniteResolution P)]
 
 /-- **The class of an object of finite `P`-dimension is the alternating class of any of its
 finite `P`-resolutions**, after pushing the latter forward along the inclusion. This is the
 telescoping computation of `TauCeti.ExactStructure.FiniteResolution.eulerClass_eq_of`, carried
 out in the exact `K₀` of the objects of finite `P`-dimension rather than in that of the whole
 ambient category. -/
+@[simp]
 theorem map_eulerClassFullSubcategory_eq_of {X : C} (r : E.FiniteResolution P X) :
     ExactK0.map _ (E.isConflationExact_ιOfLE hP
       (E.isExtensionClosed_admitsFiniteResolution hproj) (E.le_admitsFiniteResolution P))

--- a/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
@@ -113,17 +113,19 @@ replete, by `CategoryTheory.ObjectProperty.isClosedUnderIsomorphisms_of_contains
 local instance : P.IsClosedUnderIsomorphisms :=
   ObjectProperty.isClosedUnderIsomorphisms_of_containsZero P
 
-variable (hP : E.IsExtensionClosed P)
-
 namespace FiniteResolution
 
 section Projective
+
+variable (hproj : P ≤ E.isProjective)
+
+local notation "hP" => E.isExtensionClosed_of_le_isProjective hproj
 
 /-- The inductive core of
 `TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory`,
 on the sum of the two lengths. Schanuel's lemma compares the two first steps, and the induction
 hypothesis then compares the two remaining chains, each enlarged by the other's resolving term. -/
-private theorem eulerClassFullSubcategory_eq_aux (hproj : P ≤ E.isProjective) (n : ℕ) :
+private theorem eulerClassFullSubcategory_eq_aux (n : ℕ) :
     ∀ {X : C} (r s : E.FiniteResolution P X), r.length + s.length ≤ n →
       r.eulerClassFullSubcategory hP = s.eulerClassFullSubcategory hP := by
   induction n with
@@ -179,18 +181,18 @@ private theorem eulerClassFullSubcategory_eq_aux (hproj : P ≤ E.isProjective) 
               exact (add_comm _ _).trans (hcmp.symm.trans (add_comm _ _))
 
 /-- **The Euler class in the `K₀` of the full subcategory on `P` depends only on the resolved
-object.** Any two finite `P`-resolutions of the same object have the same alternating class in
-`ExactK0 (E.fullSubcategory P hP)`, as soon as every object satisfying `P` is `E`-projective.
+object.** Any two finite `P`-resolutions of the same object have the same alternating class in the
+exact `K₀` of the canonically induced structure on `P`, as soon as every object satisfying `P` is
+`E`-projective.
 
 The proof is an induction on the sum of the two lengths whose only geometric input is Schanuel's
 lemma `TauCeti.ExactStructure.nonempty_iso_biprod_of_projective`: it turns the two first steps
 `K ↪ Q ↠ X` and `K' ↪ Q' ↠ X` into an isomorphism `K ⊞ Q' ≅ K' ⊞ Q`, and the two remaining
 chains, each enlarged by the other's resolving term, resolve the two sides. -/
 theorem eulerClassFullSubcategory_eq_eulerClassFullSubcategory
-    (hproj : P ≤ E.isProjective) {X : C}
-    (r s : E.FiniteResolution P X) :
+    {X : C} (r s : E.FiniteResolution P X) :
     r.eulerClassFullSubcategory hP = s.eulerClassFullSubcategory hP :=
-  eulerClassFullSubcategory_eq_aux hP hproj _ r s le_rfl
+  eulerClassFullSubcategory_eq_aux hproj _ r s le_rfl
 
 end Projective
 
@@ -199,6 +201,10 @@ end FiniteResolution
 
 section EulerClassOf
 
+section General
+
+variable (hP : E.IsExtensionClosed P)
+
 /-- **The Euler class of an object of finite `P`-dimension**, in the exact `K₀` of the structure
 induced on the full subcategory on `P`: the alternating class of some, hence when `P` consists of
 `E`-projectives, by `TauCeti.ExactStructure.eulerClassOf_eq` of any, finite `P`-resolution of it. -/
@@ -206,14 +212,18 @@ noncomputable def eulerClassOf {X : C} (hX : E.admitsFiniteResolution P X) :
     ExactK0 (E.fullSubcategory P hP) :=
   ((E.admitsFiniteResolution_iff P).mp hX).some.eulerClassFullSubcategory hP
 
+end General
+
 variable (hproj : P ≤ E.isProjective)
+
+local notation "hP" => E.isExtensionClosed_of_le_isProjective hproj
 
 include hproj in
 /-- Every finite `P`-resolution of `X` computes `TauCeti.ExactStructure.eulerClassOf`. -/
 theorem eulerClassOf_eq {X : C} (hX : E.admitsFiniteResolution P X)
     (r : E.FiniteResolution P X) :
     E.eulerClassOf hP hX = r.eulerClassFullSubcategory hP :=
-  FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory hP hproj _ r
+  FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory hproj _ r
 
 include hproj in
 /-- On an object satisfying `P` the Euler class is the class of that object. -/
@@ -221,7 +231,7 @@ include hproj in
 theorem eulerClassOf_of_prop {X : C} (hX : P X) :
     E.eulerClassOf hP (E.le_admitsFiniteResolution P X hX) =
       ExactK0.of (⟨X, hX⟩ : P.FullSubcategory) := by
-  rw [E.eulerClassOf_eq hP hproj _ (.base hX),
+  rw [E.eulerClassOf_eq hproj _ (.base hX),
     FiniteResolution.eulerClassFullSubcategory_base]
 
 include hproj in
@@ -232,10 +242,10 @@ theorem eulerClassOf_eq_sub_of_conflation {K Q X : C} (hQ : P Q) {i : K ⟶ Q} {
     (hK : E.admitsFiniteResolution P K) :
     E.eulerClassOf hP (E.admitsFiniteResolution_of_conflation P hQ hp hK) =
       ExactK0.of (⟨Q, hQ⟩ : P.FullSubcategory) - E.eulerClassOf hP hK := by
-  rw [E.eulerClassOf_eq hP hproj _ (.step hQ i p zero hp
+  rw [E.eulerClassOf_eq hproj _ (.step hQ i p zero hp
       ((E.admitsFiniteResolution_iff P).mp hK).some),
     FiniteResolution.eulerClassFullSubcategory_step,
-    E.eulerClassOf_eq hP hproj hK ((E.admitsFiniteResolution_iff P).mp hK).some]
+    E.eulerClassOf_eq hproj hK ((E.admitsFiniteResolution_iff P).mp hK).some]
 
 include hproj in
 /-- The inductive core of `TauCeti.ExactStructure.eulerClassOf_eq_add_of_conflation`, on a common
@@ -255,9 +265,10 @@ private theorem eulerClassOf_add_aux (n : ℕ) :
       obtain ⟨t, htl⟩ := ht
       have hX₁ : P S.X₁ := by simpa using r.prop_syzygy hrl
       have hX₃ : P S.X₃ := by simpa using t.prop_syzygy htl
-      rw [E.eulerClassOf_eq hP hproj h₂ (.base (hP.prop_X₂ hS hX₁ hX₃)),
-        E.eulerClassOf_eq hP hproj h₁ (.base hX₁),
-        E.eulerClassOf_eq hP hproj h₃ (.base hX₃),
+      rw [E.eulerClassOf_eq hproj h₂
+          (.base ((E.isExtensionClosed_of_le_isProjective hproj).prop_X₂ hS hX₁ hX₃)),
+        E.eulerClassOf_eq hproj h₁ (.base hX₁),
+        E.eulerClassOf_eq hproj h₃ (.base hX₃),
         FiniteResolution.eulerClassFullSubcategory_base,
         FiniteResolution.eulerClassFullSubcategory_base,
         FiniteResolution.eulerClassFullSubcategory_base]
@@ -277,15 +288,17 @@ private theorem eulerClassOf_add_aux (n : ℕ) :
       have haK : E.admitsFiniteResolution P K :=
         (E.isExtensionClosed_admitsFiniteResolution hproj).prop_X₂ hKv haX haZ
       have e₂ : E.eulerClassOf hP h₂ =
-          ExactK0.of (⟨QX ⊞ QZ, hP.prop_biprod hQX hQZ⟩ : P.FullSubcategory) -
-            E.eulerClassOf hP haK :=
-        E.eulerClassOf_eq_sub_of_conflation hP hproj (hP.prop_biprod hQX hQZ) hKu haK
+          ExactK0.of (⟨QX ⊞ QZ,
+            (E.isExtensionClosed_of_le_isProjective hproj).prop_biprod hQX hQZ⟩ :
+              P.FullSubcategory) - E.eulerClassOf hP haK :=
+        E.eulerClassOf_eq_sub_of_conflation hproj
+          ((E.isExtensionClosed_of_le_isProjective hproj).prop_biprod hQX hQZ) hKu haK
       have e₁ : E.eulerClassOf hP h₁ =
           ExactK0.of (⟨QX, hQX⟩ : P.FullSubcategory) - E.eulerClassOf hP haX :=
-        E.eulerClassOf_eq_sub_of_conflation hP hproj hQX hcX haX
+        E.eulerClassOf_eq_sub_of_conflation hproj hQX hcX haX
       have e₃ : E.eulerClassOf hP h₃ =
           ExactK0.of (⟨QZ, hQZ⟩ : P.FullSubcategory) - E.eulerClassOf hP haZ :=
-        E.eulerClassOf_eq_sub_of_conflation hP hproj hQZ hcZ haZ
+        E.eulerClassOf_eq_sub_of_conflation hproj hQZ hcZ haZ
       have eK : E.eulerClassOf hP haK =
           E.eulerClassOf hP haX + E.eulerClassOf hP haZ := ih hKv haX haZ haK hKX hKZ
       rw [e₁, e₂, e₃, eK, ExactK0.of_biprod_fullSubcategory hP hQX hQZ]
@@ -299,7 +312,7 @@ theorem eulerClassOf_eq_add_of_conflation {S : ShortComplex C} (hS : E.Conflatio
     (h₁ : E.admitsFiniteResolution P S.X₁) (h₃ : E.admitsFiniteResolution P S.X₃) :
     E.eulerClassOf hP ((E.isExtensionClosed_admitsFiniteResolution hproj).prop_X₂ hS h₁ h₃) =
       E.eulerClassOf hP h₁ + E.eulerClassOf hP h₃ :=
-  E.eulerClassOf_add_aux hP hproj
+  E.eulerClassOf_add_aux hproj
     (max ((E.admitsFiniteResolution_iff P).mp h₁).some.length
       ((E.admitsFiniteResolution_iff P).mp h₃).some.length) hS h₁ h₃ _
     ⟨_, le_max_left _ _⟩ ⟨_, le_max_right _ _⟩
@@ -308,15 +321,14 @@ include hproj in
 /-- The Euler class is invariant under isomorphism of the resolved object. -/
 theorem eulerClassOf_congr {X Y : C} (e : X ≅ Y) (hX : E.admitsFiniteResolution P X)
     (hY : E.admitsFiniteResolution P Y) : E.eulerClassOf hP hX = E.eulerClassOf hP hY := by
-  rw [E.eulerClassOf_eq hP hproj hY
+  rw [E.eulerClassOf_eq hproj hY
       (((E.admitsFiniteResolution_iff P).mp hX).some.ofIso e),
     FiniteResolution.eulerClassFullSubcategory_ofIso]
-  exact E.eulerClassOf_eq hP hproj hX _
+  exact E.eulerClassOf_eq hproj hX _
 
 section ResolutionTheorem
 
-variable (hproj : P ≤ E.isProjective)
-  [ObjectProperty.EssentiallySmall.{w} (E.admitsFiniteResolution P)]
+variable [ObjectProperty.EssentiallySmall.{w} (E.admitsFiniteResolution P)]
 
 /-- **The class of an object of finite `P`-dimension is the alternating class of any of its
 finite `P`-resolutions**, after pushing the latter forward along the inclusion. This is the
@@ -355,10 +367,10 @@ private noncomputable def eulerInvariant :
         (E.isExtensionClosed_admitsFiniteResolution hproj))
       (ExactK0 (E.fullSubcategory P hP)) where
   obj X := E.eulerClassOf hP X.property
-  map_iso _ _ e := E.eulerClassOf_congr hP hproj ((E.admitsFiniteResolution P).ι.mapIso e) _ _
+  map_iso _ _ e := E.eulerClassOf_congr hproj ((E.admitsFiniteResolution P).ι.mapIso e) _ _
   map_conflation S hS := by
     rw [fullSubcategory_conflation_iff] at hS
-    exact E.eulerClassOf_eq_add_of_conflation hP hproj hS _ _
+    exact E.eulerClassOf_eq_add_of_conflation hproj hS _ _
 
 /-- **The inverse of the comparison map of the resolution theorem**: the homomorphism sending the
 class of an object of finite `P`-dimension to the alternating class of any of its finite
@@ -367,10 +379,10 @@ noncomputable def eulerHom :
     ExactK0 (E.fullSubcategory (E.admitsFiniteResolution P)
         (E.isExtensionClosed_admitsFiniteResolution hproj)) →+
       ExactK0 (E.fullSubcategory P hP) :=
-  ExactK0.lift (E.eulerInvariant hP hproj)
+  ExactK0.lift (E.eulerInvariant hproj)
 
 @[simp] theorem eulerHom_of {X : C} (hX : E.admitsFiniteResolution P X) :
-    E.eulerHom hP hproj (ExactK0.of ⟨X, hX⟩) = E.eulerClassOf hP hX :=
+    E.eulerHom hproj (ExactK0.of ⟨X, hX⟩) = E.eulerClassOf hP hX :=
   ExactK0.lift_of _ _
 
 /-- **The resolution theorem for finite projective resolutions.** When every object satisfying
@@ -384,37 +396,37 @@ noncomputable def resolutionEquiv :
         (E.isExtensionClosed_admitsFiniteResolution hproj)) where
   toFun := ExactK0.map _ (E.isConflationExact_ιOfLE hP
     (E.isExtensionClosed_admitsFiniteResolution hproj) (E.le_admitsFiniteResolution P))
-  invFun := E.eulerHom hP hproj
+  invFun := E.eulerHom hproj
   map_add' _ _ := map_add _ _ _
   left_inv x := by
-    refine DFunLike.congr_fun (ExactK0.hom_ext (f := (E.eulerHom hP hproj).comp
+    refine DFunLike.congr_fun (ExactK0.hom_ext (f := (E.eulerHom hproj).comp
       (ExactK0.map _ (E.isConflationExact_ιOfLE hP
         (E.isExtensionClosed_admitsFiniteResolution hproj) (E.le_admitsFiniteResolution P))))
       (g := AddMonoidHom.id _)
       fun Y => ?_) x
     rw [AddMonoidHom.coe_comp, Function.comp_apply, ExactK0.map_of, E.eulerHom_of,
-      E.eulerClassOf_of_prop hP hproj Y.property, AddMonoidHom.id_apply]
+      E.eulerClassOf_of_prop hproj Y.property, AddMonoidHom.id_apply]
   right_inv x := by
     refine DFunLike.congr_fun (ExactK0.hom_ext
       (f := (ExactK0.map _ (E.isConflationExact_ιOfLE hP
         (E.isExtensionClosed_admitsFiniteResolution hproj) (E.le_admitsFiniteResolution P))).comp
-          (E.eulerHom hP hproj))
+          (E.eulerHom hproj))
       (g := AddMonoidHom.id _) fun Y => ?_) x
     rw [AddMonoidHom.coe_comp, Function.comp_apply, E.eulerHom_of, AddMonoidHom.id_apply,
-      E.eulerClassOf_eq hP hproj Y.property ((E.admitsFiniteResolution_iff P).mp Y.property).some,
-      E.map_eulerClassFullSubcategory_eq_of hP hproj]
+      E.eulerClassOf_eq hproj Y.property ((E.admitsFiniteResolution_iff P).mp Y.property).some,
+      E.map_eulerClassFullSubcategory_eq_of hproj]
 
 /-- The forward map of the resolution equivalence sends a `P`-object to its class in the full
 subcategory of objects admitting a finite `P`-resolution. -/
 @[simp] theorem resolutionEquiv_of (X : P.FullSubcategory) :
-    E.resolutionEquiv hP hproj (ExactK0.of X) =
+    E.resolutionEquiv hproj (ExactK0.of X) =
       ExactK0.of ⟨X.obj, E.le_admitsFiniteResolution P X.obj X.property⟩ :=
   ExactK0.map_of _ _ _
 
 /-- The inverse map of the resolution equivalence sends an object class to its Euler class. -/
 @[simp] theorem resolutionEquiv_symm_of {X : C} (hX : E.admitsFiniteResolution P X) :
-    (E.resolutionEquiv hP hproj).symm (ExactK0.of ⟨X, hX⟩) = E.eulerClassOf hP hX :=
-  E.eulerHom_of hP hproj hX
+    (E.resolutionEquiv hproj).symm (ExactK0.of ⟨X, hX⟩) = E.eulerClassOf hP hX :=
+  E.eulerHom_of hproj hX
 
 end ResolutionTheorem
 

--- a/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean
@@ -36,7 +36,8 @@ theorem** in the projective case.
 
 * `TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory`: the alternating class of a
   finite `P`-resolution, in the exact `K₀` of the exact structure induced on the full subcategory
-  on `P`. Its definition needs only extension closure of `P`.
+  on `P`. On top of the additivity hypotheses assumed throughout, its definition needs only
+  extension closure of `P`, not projectivity.
 * `TauCeti.ExactStructure.eulerClassOf`: the Euler class of an object admitting a finite
   `P`-resolution.
 * `TauCeti.ExactStructure.resolutionEquiv`: the isomorphism of the resolution theorem.
@@ -45,12 +46,12 @@ theorem** in the projective case.
 
 * `TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory`:
   **the Euler class depends only on the resolved object**, by Schanuel's lemma.
-* `TauCeti.ExactStructure.eulerClassOf_conflation` and
-  `TauCeti.ExactStructure.eulerClassOf_add_of_conflation`: the Euler class drops by one step
+* `TauCeti.ExactStructure.eulerClassOf_eq_sub_of_conflation` and
+  `TauCeti.ExactStructure.eulerClassOf_eq_add_of_conflation`: the Euler class drops by one step
   along a conflation with resolving middle term, and is additive on conflations. The second is
   the horseshoe lemma, iterated.
-* `TauCeti.ExactStructure.map_eulerClassFullSubcategory`: in the exact `K₀` of the objects of
-  finite `P`-dimension the alternating class of a resolution of `X` is `[X]`.
+* `TauCeti.ExactStructure.map_eulerClassFullSubcategory_eq_of`: in the exact `K₀` of the objects
+  of finite `P`-dimension the alternating class of a resolution of `X` is `[X]`.
 * `TauCeti.ExactStructure.resolutionEquiv`, `TauCeti.ExactStructure.resolutionEquiv_of` and
   `TauCeti.ExactStructure.resolutionEquiv_symm_of`: **the resolution theorem**. The inclusion of
   the full subcategory on `P` into the objects admitting a finite `P`-resolution induces an
@@ -59,9 +60,10 @@ theorem** in the projective case.
 ## Implementation notes
 
 The well-definedness, conflation-additivity, and resolution-theorem results here carry
-`P ≤ E.isProjective` as an explicit hypothesis; the underlying Euler-class definitions and formal
-computation lemmas need only extension closure. None of the substantive results is asserted for a
-general resolving subcategory. The resolution theorem is true in that generality —
+`P ≤ E.isProjective` as an explicit hypothesis. On top of `ContainsZero` and
+`IsClosedUnderBinaryProducts`, which are assumed throughout, the underlying Euler-class definitions
+and formal computation lemmas need only extension closure. None of the substantive results is
+asserted for a general resolving subcategory. The resolution theorem is true in that generality —
 for a replete, additive, extension-closed `P` closed under kernels of deflations between its own
 objects — but its proof replaces Schanuel's lemma and the horseshoe by Weibel's common-refinement
 argument, and is not carried out here. The projective case is the one that Layer 4's Cartan
@@ -98,50 +100,6 @@ universe w v u
 
 variable {C : Type u} [Category.{v} C] [Preadditive C] [HasZeroObject C] [HasBinaryBiproducts C]
   [EssentiallySmall.{w} C] {E : ExactStructure C} {P : ObjectProperty C}
-
-/-- Mathlib's smallness instance for a full subcategory consumes smallness of its object
-property. -/
-local instance : ObjectProperty.EssentiallySmall.{w} P :=
-  ObjectProperty.EssentiallySmall.of_le le_top
-
-namespace ExactK0
-
-section
-
-variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
-
-/-- A property containing a zero object and closed under binary products is automatically
-replete, by `CategoryTheory.ObjectProperty.isClosedUnderIsomorphisms_of_containsZero`. -/
-local instance : P.IsClosedUnderIsomorphisms :=
-  ObjectProperty.isClosedUnderIsomorphisms_of_containsZero P
-
-variable (hP : E.IsExtensionClosed P)
-
-/-- The class of a biproduct in the exact `K₀` of the structure induced on the full subcategory
-on `P`.
-
-This is not an instance of `TauCeti.ExactK0.of_biprod`: the biproduct of `⟨X, hX⟩` and
-`⟨Y, hY⟩` in the subcategory is merely *isomorphic* to `⟨X ⊞ Y, hXY⟩`, and it is the latter that
-the recursion of `TauCeti.ExactStructure.FiniteResolution.biprod` produces. The split biproduct
-short complex on `⟨X ⊞ Y, hXY⟩` itself is a conflation, which gives the relation directly. -/
-@[simp] theorem of_biprod_fullSubcategory {X Y : C} (hX : P X) (hY : P Y) (hXY : P (X ⊞ Y)) :
-    (of ⟨X ⊞ Y, hXY⟩ : ExactK0 (E.fullSubcategory P hP)) = of ⟨X, hX⟩ + of ⟨Y, hY⟩ := by
-  have hzero : (ObjectProperty.homMk (biprod.inl : X ⟶ X ⊞ Y) :
-        (⟨X, hX⟩ : P.FullSubcategory) ⟶ ⟨X ⊞ Y, hXY⟩) ≫
-      (ObjectProperty.homMk (biprod.snd : X ⊞ Y ⟶ Y) :
-        (⟨X ⊞ Y, hXY⟩ : P.FullSubcategory) ⟶ ⟨Y, hY⟩) = 0 :=
-    ObjectProperty.hom_ext _ (by simp)
-  refine of_eq_add_of_conflation hzero (ExactStructure.conflation_of_splitting _ ?_)
-  exact
-    { r := ObjectProperty.homMk biprod.fst
-      s := ObjectProperty.homMk biprod.inr
-      f_r := ObjectProperty.hom_ext _ (by simp)
-      s_g := ObjectProperty.hom_ext _ (by simp)
-      id := ObjectProperty.hom_ext _ biprod.total }
-
-end
-
-end ExactK0
 
 namespace ExactStructure
 
@@ -193,6 +151,26 @@ noncomputable def eulerClassFullSubcategory :
   | step hQ i p zero hp r =>
       rw [ofIso_step, eulerClassFullSubcategory_step, eulerClassFullSubcategory_step]
 
+/-- Padding a finite resolution by one trivial conflation does not change its Euler class. -/
+@[simp] theorem eulerClassFullSubcategory_zeroPad {X : C} (r : E.FiniteResolution P X) :
+    r.zeroPad.eulerClassFullSubcategory hP = r.eulerClassFullSubcategory hP := by
+  induction r with
+  | base hX =>
+      have hzero : IsZero (⟨0, P.prop_zero⟩ : P.FullSubcategory) :=
+        IsZero.of_full_of_faithful_of_isZero P.ι _ (isZero_zero C)
+      rw [zeroPad_base, eulerClassFullSubcategory_step, eulerClassFullSubcategory_base,
+        eulerClassFullSubcategory_base, ExactK0.of_eq_zero_of_isZero hzero, sub_zero]
+  | step hQ i p zero hp r ih =>
+      rw [zeroPad_step, eulerClassFullSubcategory_step, eulerClassFullSubcategory_step, ih]
+
+/-- Padding a finite resolution by any number of trivial conflations does not change its Euler
+class. -/
+@[simp] theorem eulerClassFullSubcategory_pad {X : C} (r : E.FiniteResolution P X) (n : ℕ) :
+    (r.pad n).eulerClassFullSubcategory hP = r.eulerClassFullSubcategory hP := by
+  induction n with
+  | zero => rw [pad_zero]
+  | succ n ih => rw [pad_succ, eulerClassFullSubcategory_zeroPad, ih]
+
 @[simp] theorem eulerClassFullSubcategory_biprod {X Y : C} (r : E.FiniteResolution P X)
     (s : E.FiniteResolution P Y) :
     (r.biprod s).eulerClassFullSubcategory hP =
@@ -205,44 +183,20 @@ noncomputable def eulerClassFullSubcategory :
             eulerClassFullSubcategory_base]
           exact ExactK0.of_biprod_fullSubcategory hP hX hY _
       | @step K Q Y hQ i p zero hp s =>
-          have hz : (biprod.map (0 : (0 : C) ⟶ X) i) ≫ (biprod.map (𝟙 X) p) = 0 := by
-            apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero]
-          have hc : E.Conflation (ShortComplex.mk (biprod.map (0 : (0 : C) ⟶ X) i)
-              (biprod.map (𝟙 X) p) hz) := E.conflation_biprod (E.conflation_zero_id X) hp
-          have key : (base (E := E) hX).biprod (step hQ i p zero hp s) =
-              step (hP.prop_biprod hX hQ) (biprod.map (0 : (0 : C) ⟶ X) i)
-                (biprod.map (𝟙 X) p) hz hc (s.ofIso (isoZeroBiprod (isZero_zero C))) :=
-            biprod_base_step hX hQ i p zero hp s
-          rw [key, eulerClassFullSubcategory_step, eulerClassFullSubcategory_ofIso,
-            eulerClassFullSubcategory_base, eulerClassFullSubcategory_step,
+          simp only [biprod_base_step, eulerClassFullSubcategory]
+          rw [eulerClassFullSubcategory_ofIso,
             ExactK0.of_biprod_fullSubcategory hP hX hQ]
           abel
   | @step K Q X hQ i p zero hp r ih =>
       cases s with
       | @base Y hY =>
-          have hz : (biprod.map i (0 : (0 : C) ⟶ Y)) ≫ (biprod.map p (𝟙 Y)) = 0 := by
-            apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero]
-          have hc : E.Conflation (ShortComplex.mk (biprod.map i (0 : (0 : C) ⟶ Y))
-              (biprod.map p (𝟙 Y)) hz) := E.conflation_biprod hp (E.conflation_zero_id Y)
-          have key : (step hQ i p zero hp r).biprod (base (E := E) hY) =
-              step (hP.prop_biprod hQ hY) (biprod.map i (0 : (0 : C) ⟶ Y))
-                (biprod.map p (𝟙 Y)) hz hc (r.ofIso (isoBiprodZero (isZero_zero C))) :=
-            biprod_step_base hQ i p zero hp r hY
-          rw [key, eulerClassFullSubcategory_step, eulerClassFullSubcategory_ofIso,
-            eulerClassFullSubcategory_base, eulerClassFullSubcategory_step,
+          simp only [biprod_step_base, eulerClassFullSubcategory]
+          rw [eulerClassFullSubcategory_ofIso,
             ExactK0.of_biprod_fullSubcategory hP hQ hY]
           abel
       | @step K' Q' Y hQ' i' p' zero' hp' s =>
-          have hz : (biprod.map i i') ≫ (biprod.map p p') = 0 := by
-            apply Limits.biprod.hom_ext' <;> simp [reassoc_of% zero, reassoc_of% zero']
-          have hc : E.Conflation (ShortComplex.mk (biprod.map i i') (biprod.map p p') hz) :=
-            E.conflation_biprod hp hp'
-          have key : (step hQ i p zero hp r).biprod (step hQ' i' p' zero' hp' s) =
-              step (hP.prop_biprod hQ hQ') (biprod.map i i') (biprod.map p p') hz hc
-                (r.biprod s) :=
-            biprod_step_step hQ i p zero hp r hQ' i' p' zero' hp' s
-          rw [key, eulerClassFullSubcategory_step, ih, eulerClassFullSubcategory_step,
-            eulerClassFullSubcategory_step, ExactK0.of_biprod_fullSubcategory hP hQ hQ']
+          simp only [biprod_step_step, eulerClassFullSubcategory]
+          rw [ih, ExactK0.of_biprod_fullSubcategory hP hQ hQ']
           abel
 
 section Projective
@@ -345,7 +299,7 @@ theorem eulerClassOf_eq {X : C} (hX : E.admitsFiniteResolution P X)
 
 include hproj in
 /-- On an object satisfying `P` the Euler class is the class of that object. -/
-@[simp] theorem eulerClassOf_of_prop {X : C} (hX : P X) :
+theorem eulerClassOf_of_prop {X : C} (hX : P X) :
     E.eulerClassOf hP (E.le_admitsFiniteResolution P X hX) =
       ExactK0.of (⟨X, hX⟩ : P.FullSubcategory) := by
   rw [E.eulerClassOf_eq hP hproj _ (.base hX),
@@ -354,18 +308,18 @@ include hproj in
 include hproj in
 /-- **The Euler class drops by one step along a conflation with resolving middle term**:
 `χ(X) = [Q] - χ(K)` for a conflation `K ↪ Q ↠ X` with `P Q`. -/
-theorem eulerClassOf_conflation {K Q X : C} (hQ : P Q) {i : K ⟶ Q} {p : Q ⟶ X}
+theorem eulerClassOf_eq_sub_of_conflation {K Q X : C} (hQ : P Q) {i : K ⟶ Q} {p : Q ⟶ X}
     {zero : i ≫ p = 0} (hp : E.Conflation (ShortComplex.mk i p zero))
     (hK : E.admitsFiniteResolution P K) :
     E.eulerClassOf hP (E.admitsFiniteResolution_of_conflation P hQ hp hK) =
       ExactK0.of (⟨Q, hQ⟩ : P.FullSubcategory) - E.eulerClassOf hP hK := by
   rw [E.eulerClassOf_eq hP hproj _ (.step hQ i p zero hp
       ((E.admitsFiniteResolution_iff P).mp hK).some),
-    FiniteResolution.eulerClassFullSubcategory_step]
-  rfl
+    FiniteResolution.eulerClassFullSubcategory_step,
+    E.eulerClassOf_eq hP hproj hK ((E.admitsFiniteResolution_iff P).mp hK).some]
 
 include hproj in
-/-- The inductive core of `TauCeti.ExactStructure.eulerClassOf_add_of_conflation`, on a common
+/-- The inductive core of `TauCeti.ExactStructure.eulerClassOf_eq_add_of_conflation`, on a common
 bound for the lengths of resolutions of the two outer terms. Its inductive step is the horseshoe
 lemma: the resolving terms add, and the new syzygy is an extension of the two old ones. -/
 private theorem eulerClassOf_add_aux (n : ℕ) :
@@ -382,17 +336,23 @@ private theorem eulerClassOf_add_aux (n : ℕ) :
       obtain ⟨t, htl⟩ := ht
       have hX₁ : P S.X₁ := by simpa using r.prop_syzygy hrl
       have hX₃ : P S.X₃ := by simpa using t.prop_syzygy htl
+      have hzero : (ObjectProperty.homMk S.f :
+            (⟨S.X₁, hX₁⟩ : P.FullSubcategory) ⟶
+              ⟨S.X₂, hP.prop_X₂ hS hX₁ hX₃⟩) ≫
+          (ObjectProperty.homMk S.g :
+            (⟨S.X₂, hP.prop_X₂ hS hX₁ hX₃⟩ : P.FullSubcategory) ⟶
+              ⟨S.X₃, hX₃⟩) = 0 :=
+        ObjectProperty.hom_ext _ S.zero
+      have hconf : (E.fullSubcategory P hP).Conflation (ShortComplex.mk _ _ hzero) := by
+        rw [fullSubcategory_conflation_iff]
+        exact hS
       rw [E.eulerClassOf_eq hP hproj h₂ (.base (hP.prop_X₂ hS hX₁ hX₃)),
         E.eulerClassOf_eq hP hproj h₁ (.base hX₁),
         E.eulerClassOf_eq hP hproj h₃ (.base hX₃),
         FiniteResolution.eulerClassFullSubcategory_base,
         FiniteResolution.eulerClassFullSubcategory_base,
-        FiniteResolution.eulerClassFullSubcategory_base,
-        ExactK0.of_congr (ObjectProperty.isoMk _
-          (E.splittingOfProjective hS (hproj _ hX₃)).isoBinaryBiproduct :
-          (⟨S.X₂, hP.prop_X₂ hS hX₁ hX₃⟩ : P.FullSubcategory) ≅
-            ⟨S.X₁ ⊞ S.X₃, hP.prop_biprod hX₁ hX₃⟩)]
-      exact ExactK0.of_biprod_fullSubcategory hP hX₁ hX₃ _
+        FiniteResolution.eulerClassFullSubcategory_base]
+      exact ExactK0.of_conflation hconf
   | succ n ih =>
       intro S hS h₁ h₃ h₂ hr ht
       obtain ⟨KX, QX, mX, aX, hmX, hQX, hcX, hKX⟩ :=
@@ -410,13 +370,13 @@ private theorem eulerClassOf_add_aux (n : ℕ) :
       have e₂ : E.eulerClassOf hP h₂ =
           ExactK0.of (⟨QX ⊞ QZ, hP.prop_biprod hQX hQZ⟩ : P.FullSubcategory) -
             E.eulerClassOf hP haK :=
-        E.eulerClassOf_conflation hP hproj (hP.prop_biprod hQX hQZ) hKu haK
+        E.eulerClassOf_eq_sub_of_conflation hP hproj (hP.prop_biprod hQX hQZ) hKu haK
       have e₁ : E.eulerClassOf hP h₁ =
           ExactK0.of (⟨QX, hQX⟩ : P.FullSubcategory) - E.eulerClassOf hP haX :=
-        E.eulerClassOf_conflation hP hproj hQX hcX haX
+        E.eulerClassOf_eq_sub_of_conflation hP hproj hQX hcX haX
       have e₃ : E.eulerClassOf hP h₃ =
           ExactK0.of (⟨QZ, hQZ⟩ : P.FullSubcategory) - E.eulerClassOf hP haZ :=
-        E.eulerClassOf_conflation hP hproj hQZ hcZ haZ
+        E.eulerClassOf_eq_sub_of_conflation hP hproj hQZ hcZ haZ
       have eK : E.eulerClassOf hP haK =
           E.eulerClassOf hP haX + E.eulerClassOf hP haZ := ih hKv haX haZ haK hKX hKZ
       rw [e₁, e₂, e₃, eK, ExactK0.of_biprod_fullSubcategory hP hQX hQZ]
@@ -426,7 +386,7 @@ private theorem eulerClassOf_add_aux (n : ℕ) :
 package: together with `TauCeti.ExactStructure.eulerClassOf_eq` it makes the alternating class of
 a finite projective resolution a conflation-additive invariant of the objects of finite
 `P`-dimension. -/
-theorem eulerClassOf_add_of_conflation {S : ShortComplex C} (hS : E.Conflation S)
+theorem eulerClassOf_eq_add_of_conflation {S : ShortComplex C} (hS : E.Conflation S)
     (h₁ : E.admitsFiniteResolution P S.X₁) (h₃ : E.admitsFiniteResolution P S.X₃) :
     E.eulerClassOf hP ((E.isExtensionClosed_admitsFiniteResolution hproj).prop_X₂ hS h₁ h₃) =
       E.eulerClassOf hP h₁ + E.eulerClassOf hP h₃ :=
@@ -442,31 +402,21 @@ theorem eulerClassOf_congr {X Y : C} (e : X ≅ Y) (hX : E.admitsFiniteResolutio
   rw [E.eulerClassOf_eq hP hproj hY
       (((E.admitsFiniteResolution_iff P).mp hX).some.ofIso e),
     FiniteResolution.eulerClassFullSubcategory_ofIso]
-  rfl
+  exact E.eulerClassOf_eq hP hproj hX _
 
 section ResolutionTheorem
 
 variable (hproj : P ≤ E.isProjective)
-
-omit [EssentiallySmall.{w} C] in
-/-- **The inclusion of the full subcategory on `P` into the objects of finite `P`-dimension is
-conflation-exact.** Both induced structures detect their conflations in the ambient category. -/
-theorem isConflationExact_ιOfLE :
-    (E.fullSubcategory P hP).IsConflationExact
-      (E.fullSubcategory (E.admitsFiniteResolution P)
-        (E.isExtensionClosed_admitsFiniteResolution hproj))
-      (ObjectProperty.ιOfLE (E.le_admitsFiniteResolution P)) where
-  map_conflation {S} hS := by
-    rw [fullSubcategory_conflation_iff] at hS ⊢
-    exact hS
 
 /-- **The class of an object of finite `P`-dimension is the alternating class of any of its
 finite `P`-resolutions**, after pushing the latter forward along the inclusion. This is the
 telescoping computation of `TauCeti.ExactStructure.FiniteResolution.eulerClass_eq_of`, carried
 out in the exact `K₀` of the objects of finite `P`-dimension rather than in that of the whole
 ambient category. -/
-theorem map_eulerClassFullSubcategory {X : C} (r : E.FiniteResolution P X) :
-    ExactK0.map _ (E.isConflationExact_ιOfLE hP hproj) (r.eulerClassFullSubcategory hP) =
+theorem map_eulerClassFullSubcategory_eq_of {X : C} (r : E.FiniteResolution P X) :
+    ExactK0.map _ (E.isConflationExact_ιOfLE hP
+      (E.isExtensionClosed_admitsFiniteResolution hproj) (E.le_admitsFiniteResolution P))
+        (r.eulerClassFullSubcategory hP) =
       ExactK0.of (⟨X, (E.admitsFiniteResolution_iff P).mpr ⟨r⟩⟩ :
         (E.admitsFiniteResolution P).FullSubcategory) := by
   induction r with
@@ -508,7 +458,7 @@ noncomputable def eulerInvariant :
   map_iso _ _ e := E.eulerClassOf_congr hP hproj ((E.admitsFiniteResolution P).ι.mapIso e) _ _
   map_conflation S hS := by
     rw [fullSubcategory_conflation_iff] at hS
-    exact E.eulerClassOf_add_of_conflation hP hproj hS _ _
+    exact E.eulerClassOf_eq_add_of_conflation hP hproj hS _ _
 
 /-- **The inverse of the comparison map of the resolution theorem**: the homomorphism sending the
 class of an object of finite `P`-dimension to the alternating class of any of its finite
@@ -532,28 +482,36 @@ noncomputable def resolutionEquiv :
     ExactK0 (E.fullSubcategory P hP) ≃+
       ExactK0 (E.fullSubcategory (E.admitsFiniteResolution P)
         (E.isExtensionClosed_admitsFiniteResolution hproj)) where
-  toFun := ExactK0.map _ (E.isConflationExact_ιOfLE hP hproj)
+  toFun := ExactK0.map _ (E.isConflationExact_ιOfLE hP
+    (E.isExtensionClosed_admitsFiniteResolution hproj) (E.le_admitsFiniteResolution P))
   invFun := E.eulerHom hP hproj
   map_add' _ _ := map_add _ _ _
   left_inv x := by
     refine DFunLike.congr_fun (ExactK0.hom_ext (f := (E.eulerHom hP hproj).comp
-      (ExactK0.map _ (E.isConflationExact_ιOfLE hP hproj))) (g := AddMonoidHom.id _)
+      (ExactK0.map _ (E.isConflationExact_ιOfLE hP
+        (E.isExtensionClosed_admitsFiniteResolution hproj) (E.le_admitsFiniteResolution P))))
+      (g := AddMonoidHom.id _)
       fun Y => ?_) x
     rw [AddMonoidHom.coe_comp, Function.comp_apply, ExactK0.map_of, E.eulerHom_of,
       E.eulerClassOf_of_prop hP hproj Y.property, AddMonoidHom.id_apply]
   right_inv x := by
     refine DFunLike.congr_fun (ExactK0.hom_ext
-      (f := (ExactK0.map _ (E.isConflationExact_ιOfLE hP hproj)).comp (E.eulerHom hP hproj))
+      (f := (ExactK0.map _ (E.isConflationExact_ιOfLE hP
+        (E.isExtensionClosed_admitsFiniteResolution hproj) (E.le_admitsFiniteResolution P))).comp
+          (E.eulerHom hP hproj))
       (g := AddMonoidHom.id _) fun Y => ?_) x
     rw [AddMonoidHom.coe_comp, Function.comp_apply, E.eulerHom_of, AddMonoidHom.id_apply,
       E.eulerClassOf_eq hP hproj Y.property ((E.admitsFiniteResolution_iff P).mp Y.property).some,
-      E.map_eulerClassFullSubcategory hP hproj]
+      E.map_eulerClassFullSubcategory_eq_of hP hproj]
 
+/-- The forward map of the resolution equivalence sends a `P`-object to its class in the full
+subcategory of objects admitting a finite `P`-resolution. -/
 @[simp] theorem resolutionEquiv_of (X : P.FullSubcategory) :
     E.resolutionEquiv hP hproj (ExactK0.of X) =
       ExactK0.of ⟨X.obj, E.le_admitsFiniteResolution P X.obj X.property⟩ :=
   ExactK0.map_of _ _ _
 
+/-- The inverse map of the resolution equivalence sends an object class to its Euler class. -/
 @[simp] theorem resolutionEquiv_symm_of {X : C} (hX : E.admitsFiniteResolution P X) :
     (E.resolutionEquiv hP hproj).symm (ExactK0.of ⟨X, hX⟩) = E.eulerClassOf hP hX :=
   E.eulerHom_of hP hproj hX

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Resolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Resolution.lean
@@ -34,7 +34,9 @@ resolving hypotheses and Weibel's common-refinement argument, and is not proved 
 ## Main definitions
 
 * `TauCeti.ExactStructure.FiniteResolution.eulerClass`: the alternating class of a finite
-  resolution in exact `K₀`.
+  resolution in ambient exact `K₀`.
+* `TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory`: the alternating class in
+  the exact `K₀` of an extension-closed full subcategory containing the resolution terms.
 
 ## Main results
 
@@ -113,6 +115,104 @@ theorem eulerClass_eq_eulerClass {X : C} (r s : E.FiniteResolution P X) :
     {X Y : C} (r : E.FiniteResolution P X) (s : E.FiniteResolution P Y) :
     (r.biprod s).eulerClass = r.eulerClass + s.eulerClass := by
   rw [eulerClass_eq_of, eulerClass_eq_of, eulerClass_eq_of, ExactK0.of_biprod]
+
+section FullSubcategory
+
+variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
+
+/-- A property containing a zero object and closed under binary products is automatically
+replete, by `CategoryTheory.ObjectProperty.isClosedUnderIsomorphisms_of_containsZero`. -/
+local instance : P.IsClosedUnderIsomorphisms :=
+  ObjectProperty.isClosedUnderIsomorphisms_of_containsZero P
+
+variable (hP : E.IsExtensionClosed P)
+
+/-- **The Euler class of a finite `P`-resolution in the `K₀` of the full subcategory on `P`**: the
+alternating sum `[Q₀] - [Q₁] + ⋯ + (-1)ⁿ [Kₙ]` of the classes of its resolving terms and its last
+syzygy, all of which satisfy `P`, formed in the exact `K₀` of the exact structure induced on the
+full subcategory on `P`.
+
+Unlike `TauCeti.ExactStructure.FiniteResolution.eulerClass`, which lives in the `K₀` of the
+ambient category and telescopes to `[X]`, this class carries genuine information: nothing in the
+subcategory relates it to `X`. When `P` consists of projectives, its independence of the chosen
+resolution is
+`TauCeti.ExactStructure.FiniteResolution.eulerClassFullSubcategory_eq_eulerClassFullSubcategory`.
+-/
+noncomputable def eulerClassFullSubcategory :
+    ∀ {X : C}, E.FiniteResolution P X → ExactK0 (E.fullSubcategory P hP)
+  | _, .base hX => ExactK0.of ⟨_, hX⟩
+  | _, .step (Q := Q) hQ _ _ _ _ r =>
+      ExactK0.of ⟨Q, hQ⟩ - eulerClassFullSubcategory r
+
+@[simp] theorem eulerClassFullSubcategory_base {X : C} (hX : P X) :
+    (base (E := E) hX).eulerClassFullSubcategory hP = ExactK0.of ⟨X, hX⟩ := (rfl)
+
+@[simp] theorem eulerClassFullSubcategory_step {K Q X : C} (hQ : P Q) (i : K ⟶ Q) (p : Q ⟶ X)
+    (zero : i ≫ p = 0) (hp : E.Conflation (ShortComplex.mk i p zero))
+    (r : E.FiniteResolution P K) :
+    (step hQ i p zero hp r).eulerClassFullSubcategory hP =
+      ExactK0.of ⟨Q, hQ⟩ - r.eulerClassFullSubcategory hP := (rfl)
+
+@[simp] theorem eulerClassFullSubcategory_ofIso {X Y : C} (e : X ≅ Y)
+    (r : E.FiniteResolution P X) :
+    (ofIso e r).eulerClassFullSubcategory hP = r.eulerClassFullSubcategory hP := by
+  cases r with
+  | base hX =>
+      rw [ofIso_base, eulerClassFullSubcategory_base, eulerClassFullSubcategory_base]
+      exact ExactK0.of_congr (ObjectProperty.isoMk _ e.symm :
+        (⟨Y, P.prop_of_iso e hX⟩ : P.FullSubcategory) ≅ ⟨X, hX⟩)
+  | step hQ i p zero hp r =>
+      rw [ofIso_step, eulerClassFullSubcategory_step, eulerClassFullSubcategory_step]
+
+/-- Padding a finite resolution by one trivial conflation does not change its Euler class. -/
+@[simp] theorem eulerClassFullSubcategory_zeroPad {X : C} (r : E.FiniteResolution P X) :
+    r.zeroPad.eulerClassFullSubcategory hP = r.eulerClassFullSubcategory hP := by
+  induction r with
+  | base hX =>
+      have hzero : IsZero (⟨0, P.prop_zero⟩ : P.FullSubcategory) :=
+        IsZero.of_full_of_faithful_of_isZero P.ι _ (isZero_zero C)
+      rw [zeroPad_base, eulerClassFullSubcategory_step, eulerClassFullSubcategory_base,
+        eulerClassFullSubcategory_base, ExactK0.of_eq_zero_of_isZero hzero, sub_zero]
+  | step hQ i p zero hp r ih =>
+      rw [zeroPad_step, eulerClassFullSubcategory_step, eulerClassFullSubcategory_step, ih]
+
+/-- Padding a finite resolution by any number of trivial conflations does not change its Euler
+class. -/
+@[simp] theorem eulerClassFullSubcategory_pad {X : C} (r : E.FiniteResolution P X) (n : ℕ) :
+    (r.pad n).eulerClassFullSubcategory hP = r.eulerClassFullSubcategory hP := by
+  induction n with
+  | zero => rw [pad_zero]
+  | succ n ih => rw [pad_succ, eulerClassFullSubcategory_zeroPad, ih]
+
+@[simp] theorem eulerClassFullSubcategory_biprod {X Y : C} (r : E.FiniteResolution P X)
+    (s : E.FiniteResolution P Y) :
+    (r.biprod s).eulerClassFullSubcategory hP =
+      r.eulerClassFullSubcategory hP + s.eulerClassFullSubcategory hP := by
+  induction r generalizing Y with
+  | @base X hX =>
+      cases s with
+      | @base Y hY =>
+          rw [biprod_base_base, eulerClassFullSubcategory_base, eulerClassFullSubcategory_base,
+            eulerClassFullSubcategory_base]
+          exact ExactK0.of_biprod_fullSubcategory hP hX hY
+      | @step K Q Y hQ i p zero hp s =>
+          simp only [biprod_base_step, eulerClassFullSubcategory]
+          rw [eulerClassFullSubcategory_ofIso,
+            ExactK0.of_biprod_fullSubcategory hP hX hQ]
+          abel
+  | @step K Q X hQ i p zero hp r ih =>
+      cases s with
+      | @base Y hY =>
+          simp only [biprod_step_base, eulerClassFullSubcategory]
+          rw [eulerClassFullSubcategory_ofIso,
+            ExactK0.of_biprod_fullSubcategory hP hQ hY]
+          abel
+      | @step K' Q' Y hQ' i' p' zero' hp' s =>
+          simp only [biprod_step_step, eulerClassFullSubcategory]
+          rw [ih, ExactK0.of_biprod_fullSubcategory hP hQ hQ']
+          abel
+
+end FullSubcategory
 
 end ExactStructure.FiniteResolution
 

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Resolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Resolution.lean
@@ -25,9 +25,11 @@ zero padding, and of every other choice -- and it is the first half of Weibel's 
 theorem: it exhibits `[X]` as an integral combination of classes of objects satisfying `P`, so
 those classes generate exact `K₀` as soon as every object admits a finite `P`-resolution.
 
-The second half, that the comparison map from the exact `K₀` of the full subcategory on `P` is
-also injective, needs the resolving hypotheses on `P` and Weibel's common-refinement argument,
-and is not proved here.
+For a property consisting of projectives, the second half — injectivity of the comparison map from
+the exact `K₀` of the full subcategory on `P` — is proved by Schanuel's and the horseshoe lemmas
+in `TauCeti/CategoryTheory/GrothendieckGroup/ProjectiveResolution.lean`; see
+`TauCeti.ExactStructure.resolutionEquiv`. The general resolving-subcategory case needs the packaged
+resolving hypotheses and Weibel's common-refinement argument, and is not proved here.
 
 ## Main definitions
 

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Resolution.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Resolution.lean
@@ -64,9 +64,13 @@ open CategoryTheory CategoryTheory.Limits ZeroObject
 universe w v u
 
 variable {C : Type u} [Category.{v} C] [Preadditive C] [HasZeroObject C] [HasBinaryBiproducts C]
-  [EssentiallySmall.{w} C] {E : ExactStructure C} {P : ObjectProperty C}
+  {E : ExactStructure C} {P : ObjectProperty C}
 
 namespace ExactStructure.FiniteResolution
+
+section Ambient
+
+variable [EssentiallySmall.{w} C]
 
 /-- The Euler class of a finite `P`-resolution: the alternating sum of the classes of its
 resolving terms, ending with the class of its last syzygy. -/
@@ -116,9 +120,12 @@ theorem eulerClass_eq_eulerClass {X : C} (r s : E.FiniteResolution P X) :
     (r.biprod s).eulerClass = r.eulerClass + s.eulerClass := by
   rw [eulerClass_eq_of, eulerClass_eq_of, eulerClass_eq_of, ExactK0.of_biprod]
 
+end Ambient
+
 section FullSubcategory
 
-variable [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
+variable [LocallySmall.{w} C] [ObjectProperty.EssentiallySmall.{w} P]
+  [P.ContainsZero] [P.IsClosedUnderBinaryProducts]
 
 /-- A property containing a zero object and closed under binary products is automatically
 replete, by `CategoryTheory.ObjectProperty.isClosedUnderIsomorphisms_of_containsZero`. -/
@@ -217,6 +224,8 @@ end FullSubcategory
 end ExactStructure.FiniteResolution
 
 namespace ExactK0
+
+variable [EssentiallySmall.{w} C]
 
 variable (E P) in
 /-- The classes of the objects satisfying `P`, as a subset of exact `K₀`. -/

--- a/TauCeti/CategoryTheory/ObjectProperty.lean
+++ b/TauCeti/CategoryTheory/ObjectProperty.lean
@@ -10,13 +10,15 @@ public import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
 public import Mathlib.CategoryTheory.ObjectProperty.ClosedUnderIsomorphisms
 public import Mathlib.CategoryTheory.ObjectProperty.ContainsZero
 public import Mathlib.CategoryTheory.ObjectProperty.FiniteProducts
+public import Mathlib.CategoryTheory.ObjectProperty.Small
+public import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 
 /-!
 # Object properties: transport along equivalences, and closure properties
 
 This file contains general lemmas about object properties: transporting them along an
-equivalence, and comparing Mathlib's closure type classes with one another in the presence of a
-zero object and of binary biproducts.
+equivalence, comparing Mathlib's closure type classes with one another in the presence of a
+zero object and of binary biproducts, and two instances for the associated full subcategory.
 
 ## Main declarations
 
@@ -27,11 +29,18 @@ zero object and of binary biproducts.
 * `CategoryTheory.ObjectProperty.isClosedUnderBinaryProducts_of_prop_biprod`: for a replete
   property in a category with binary biproducts, closure under binary products only has to be
   checked on biproducts.
+* `CategoryTheory.ObjectProperty.prop_biprod_of_isClosedUnderBinaryProducts`: a property closed
+  under binary products holds for binary biproducts, with `X ⊞ Y` as the syntactic form of the
+  conclusion.
+* `CategoryTheory.ObjectProperty.essentiallySmall_fullSubcategory` and
+  `CategoryTheory.ObjectProperty.additive_ιOfLE`: a full subcategory of an essentially small
+  category is essentially small, and the inclusion of a smaller property into a larger one is
+  additive.
 -/
 
 public section
 
-universe u₁ v₁ u₂ v₂
+universe w u₁ v₁ u₂ v₂
 
 namespace CategoryTheory
 
@@ -78,6 +87,32 @@ theorem isClosedUnderBinaryProducts_of_prop_biprod {C : Type u₁} [Category.{v�
   rintro _ ⟨F, hF⟩
   refine P.prop_of_iso ?_ (h _ _ (hF ⟨WalkingPair.left⟩) (hF ⟨WalkingPair.right⟩))
   exact (biprod.isoProd _ _).trans (HasLimit.isoOfNatIso (diagramIsoPair F)).symm
+
+/-- **A property closed under binary products holds for binary biproducts.** In a category with
+binary biproducts the biproduct is a binary product, so this is
+`CategoryTheory.ObjectProperty.prop_of_isLimit_binaryFan` applied to
+`CategoryTheory.Limits.BinaryBiproduct.isLimit`; naming it keeps the index of the conclusion
+syntactically `X ⊞ Y`, which matters when the conclusion is the type index of a dependent
+family. -/
+theorem prop_biprod_of_isClosedUnderBinaryProducts {C : Type u₁} [Category.{v₁} C]
+    [HasZeroMorphisms C] [HasBinaryBiproducts C] (P : ObjectProperty C)
+    [P.IsClosedUnderBinaryProducts] {X Y : C} (hX : P X) (hY : P Y) : P (X ⊞ Y) :=
+  P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit X Y) hX hY
+
+/-- **A full subcategory of an essentially small category is essentially small.** Mathlib
+derives this from `CategoryTheory.ObjectProperty.EssentiallySmall` of the property itself, which
+here comes from the top property by
+`CategoryTheory.ObjectProperty.EssentiallySmall.of_le`. -/
+instance essentiallySmall_fullSubcategory {C : Type u₁} [Category.{v₁} C]
+    [EssentiallySmall.{w} C] (P : ObjectProperty C) : EssentiallySmall.{w} P.FullSubcategory :=
+  have : ObjectProperty.EssentiallySmall.{w} P := EssentiallySmall.of_le le_top
+  inferInstance
+
+/-- The inclusion of a smaller object property into a larger one is an additive functor: both
+categories carry the addition of the ambient one. -/
+instance additive_ιOfLE {C : Type u₁} [Category.{v₁} C] [Preadditive C]
+    {P P' : ObjectProperty C} (h : P ≤ P') : (ObjectProperty.ιOfLE h).Additive where
+  map_add := rfl
 
 end ObjectProperty
 

--- a/TauCeti/CategoryTheory/ObjectProperty.lean
+++ b/TauCeti/CategoryTheory/ObjectProperty.lean
@@ -18,7 +18,8 @@ public import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 
 This file contains general lemmas about object properties: transporting them along an
 equivalence, comparing Mathlib's closure type classes with one another in the presence of a
-zero object and of binary biproducts, and additivity of inclusions between full subcategories.
+zero object and of binary biproducts, smallness of full subcategories, and additivity of inclusions
+between full subcategories.
 
 ## Main declarations
 
@@ -32,13 +33,15 @@ zero object and of binary biproducts, and additivity of inclusions between full 
 * `CategoryTheory.ObjectProperty.prop_biprod_of_isClosedUnderBinaryProducts`: a property closed
   under binary products holds for binary biproducts, with `X ⊞ Y` as the syntactic form of the
   conclusion.
-* `CategoryTheory.ObjectProperty.additive_ιOfLE`: the inclusion of a smaller property into a
-  larger one is additive.
+* `CategoryTheory.ObjectProperty.essentiallySmall_of_ambient`: every property in an essentially
+  small category is essentially small.
+* `CategoryTheory.ObjectProperty.ιOfLE_additive`: the inclusion of a smaller property into a larger
+  one is additive.
 -/
 
 public section
 
-universe u₁ v₁ u₂ v₂
+universe w u₁ v₁ u₂ v₂
 
 namespace CategoryTheory
 
@@ -93,13 +96,20 @@ binary biproducts the biproduct is a binary product, so this is
 syntactically `X ⊞ Y`, which matters when the conclusion is the type index of a dependent
 family. -/
 theorem prop_biprod_of_isClosedUnderBinaryProducts {C : Type u₁} [Category.{v₁} C]
-    [HasZeroMorphisms C] [HasBinaryBiproducts C] (P : ObjectProperty C)
-    [P.IsClosedUnderBinaryProducts] {X Y : C} (hX : P X) (hY : P Y) : P (X ⊞ Y) :=
+    [HasZeroMorphisms C] (P : ObjectProperty C) [P.IsClosedUnderBinaryProducts]
+    {X Y : C} [HasBinaryBiproduct X Y] (hX : P X) (hY : P Y) : P (X ⊞ Y) :=
   P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit X Y) hX hY
+
+/-- Every object property in an essentially small category is essentially small. This supplies
+the smallness instance for its full subcategory through Mathlib's object-property API. -/
+instance essentiallySmall_of_ambient {C : Type u₁} [Category.{v₁} C]
+    [CategoryTheory.EssentiallySmall.{w} C] (P : ObjectProperty C) :
+    ObjectProperty.EssentiallySmall.{w} P :=
+  ObjectProperty.EssentiallySmall.of_le.{w} (Q := (⊤ : ObjectProperty C)) le_top
 
 /-- The inclusion of a smaller object property into a larger one is an additive functor: both
 categories carry the addition of the ambient one. -/
-instance additive_ιOfLE {C : Type u₁} [Category.{v₁} C] [Preadditive C]
+instance ιOfLE_additive {C : Type u₁} [Category.{v₁} C] [Preadditive C]
     {P P' : ObjectProperty C} (h : P ≤ P') : (ObjectProperty.ιOfLE h).Additive where
   map_add := rfl
 

--- a/TauCeti/CategoryTheory/ObjectProperty.lean
+++ b/TauCeti/CategoryTheory/ObjectProperty.lean
@@ -18,7 +18,7 @@ public import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 
 This file contains general lemmas about object properties: transporting them along an
 equivalence, comparing Mathlib's closure type classes with one another in the presence of a
-zero object and of binary biproducts, and two instances for the associated full subcategory.
+zero object and of binary biproducts, and additivity of inclusions between full subcategories.
 
 ## Main declarations
 
@@ -32,15 +32,13 @@ zero object and of binary biproducts, and two instances for the associated full 
 * `CategoryTheory.ObjectProperty.prop_biprod_of_isClosedUnderBinaryProducts`: a property closed
   under binary products holds for binary biproducts, with `X ⊞ Y` as the syntactic form of the
   conclusion.
-* `CategoryTheory.ObjectProperty.essentiallySmall_fullSubcategory` and
-  `CategoryTheory.ObjectProperty.additive_ιOfLE`: a full subcategory of an essentially small
-  category is essentially small, and the inclusion of a smaller property into a larger one is
-  additive.
+* `CategoryTheory.ObjectProperty.additive_ιOfLE`: the inclusion of a smaller property into a
+  larger one is additive.
 -/
 
 public section
 
-universe w u₁ v₁ u₂ v₂
+universe u₁ v₁ u₂ v₂
 
 namespace CategoryTheory
 
@@ -98,15 +96,6 @@ theorem prop_biprod_of_isClosedUnderBinaryProducts {C : Type u₁} [Category.{v�
     [HasZeroMorphisms C] [HasBinaryBiproducts C] (P : ObjectProperty C)
     [P.IsClosedUnderBinaryProducts] {X Y : C} (hX : P X) (hY : P Y) : P (X ⊞ Y) :=
   P.prop_of_isLimit_binaryFan (BinaryBiproduct.isLimit X Y) hX hY
-
-/-- **A full subcategory of an essentially small category is essentially small.** Mathlib
-derives this from `CategoryTheory.ObjectProperty.EssentiallySmall` of the property itself, which
-here comes from the top property by
-`CategoryTheory.ObjectProperty.EssentiallySmall.of_le`. -/
-instance essentiallySmall_fullSubcategory {C : Type u₁} [Category.{v₁} C]
-    [EssentiallySmall.{w} C] (P : ObjectProperty C) : EssentiallySmall.{w} P.FullSubcategory :=
-  have : ObjectProperty.EssentiallySmall.{w} P := EssentiallySmall.of_le le_top
-  inferInstance
 
 /-- The inclusion of a smaller object property into a larger one is an additive functor: both
 categories carry the addition of the ambient one. -/


### PR DESCRIPTION
This PR proves the resolution theorem for finite projective resolutions in a Quillen exact category, closing the Euler-class and resolution-theorem bullets of Layer 3 of the Grothendieck-groups roadmap in the case its Layer 4 Cartan comparison consumes. For an object property `P` consisting of `E`-projectives which contains a zero object and is closed under binary biproducts, it adds the alternating class of a finite `P`-resolution *in the exact `K₀` of the full subcategory on `P`* — as opposed to the ambient class already on `main`, which telescopes to `[X]` and is therefore independent of every choice for trivial reasons — and shows that this class depends only on the resolved object, is additive on conflations, and inverts the map on exact `K₀` induced by the inclusion of the subcategory into the objects of finite `P`-dimension.

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"projective-resolution-euler-class"}-->

The milestone is Layer 3, "finite resolutions and the resolution theorem": its third bullet asks for the alternating `K₀` class of a finite resolution to be independent of length, zero padding and choice of resolution and additive on conflations, its fourth for the inclusion to induce an isomorphism on exact `K₀` with inverse the alternating class, and its fifth ("Projective-resolution calculus") for the horseshoe and Schanuel statements to be used for the later projective-module application. `TauCeti/CategoryTheory/Exact/Projective.lean` already supplies Schanuel's lemma and the horseshoe lemma, and `TauCeti/CategoryTheory/GrothendieckGroup/Resolution.lean` supplies only the telescoping half; this PR supplies injectivity in the projective case.

`FiniteResolution.eulerClassFullSubcategory` is the alternating class `[Q₀] - [Q₁] + ⋯ + (-1)ⁿ [Kₙ]` taken in `ExactK0 (E.fullSubcategory P hP)`. On top of the `ContainsZero` and `IsClosedUnderBinaryProducts` assumptions used throughout, its definition and formal computation lemmas need extension closure but no projectivity hypothesis. It is computed on `ofIso`, `zeroPad`, `pad`, and `biprod`. `eulerClassFullSubcategory_eq_eulerClassFullSubcategory` is the well-definedness theorem: an induction on the sum of the two lengths whose only geometric input is Schanuel's lemma, which turns two first steps `K ↪ Q ↠ X` and `K' ↪ Q' ↠ X` into `K ⊞ Q' ≅ K' ⊞ Q`, after which the two remaining chains — each enlarged by the other's resolving term — resolve the two sides. `eulerClassOf` then attaches the class to an object of finite `P`-dimension, `eulerClassOf_eq_sub_of_conflation` gives `χ(X) = [Q] - χ(K)`, and `eulerClassOf_eq_add_of_conflation` gives additivity by iterating the horseshoe. Packaging that as an `ExactK0.AdditiveInvariant` and matching it against the telescoping computation `map_eulerClassFullSubcategory_eq_of` yields `resolutionEquiv`, together with `resolutionEquiv_of` and `resolutionEquiv_symm_of` characterising both directions on object classes.

Supporting projectivity results live in `TauCeti/CategoryTheory/Exact/Projective.lean`: `isExtensionClosed_of_le_isProjective`, needed to form the induced structure on `P`, and `fullSubcategory_eq_split` with its conflation-wise corollary `fullSubcategory_conflation_iff_split`, identifying that induced structure as the split one. The general inclusion theorem `isConflationExact_ιOfLE` lives with induced exact structures in `TauCeti/CategoryTheory/Exact/ExtensionClosed.lean`, and `ExactK0.of_biprod_fullSubcategory` lives beside the exact `K₀` API in `TauCeti/CategoryTheory/GrothendieckGroup/Exact.lean`.

`TauCeti/CategoryTheory/ObjectProperty.lean` gains three general-purpose declarations: `prop_biprod_of_isClosedUnderBinaryProducts` (the pairwise-biproduct form needed by dependent resolution indices), `essentiallySmall_of_ambient` (which exposes the smallness of every full subcategory of an essentially small ambient category through Mathlib's object-property API), and `ιOfLE_additive`.

Every well-definedness, additivity, and resolution-theorem statement carries `P ≤ E.isProjective` explicitly; the formal computation layer does not need it. Nothing is asserted for a general resolving subcategory. What remains of Layer 3 after this PR includes the packaged resolving-subcategory theorem via common refinement, naturality under compatible exact functors, the comparison-map and chain-homotopy half of projective-resolution calculus, and the graded and linear counterparts.

No Mathlib infrastructure was vendored.

🤖 Prepared with Claude Code and Codex
