### PR TITLE
feat: characterize principal degree-zero divisors

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Divisor/Principal.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/Principal.lean
@@ -51,6 +51,9 @@ the places themselves.
   when `z ∈ kˣ`.
 * `TauCeti.Divisor.linearlyEquivalent_iff`: two divisors are linearly equivalent exactly when
   their difference is the divisor of a function (Definition 1.4.3).
+* `TauCeti.Divisor.mem_principalSubgroup_iff` and
+  `TauCeti.Divisor.divisorClass_eq_zero_iff`: the principal-subgroup and trivial-class predicates
+  in terms of the divisor of a function.
 
 ## Implementation notes
 
@@ -176,18 +179,29 @@ theorem principalDivisor_eq (hF : IsFunctionField k F) (z : Additive Fˣ) :
     (Place.orderSystem hF).principalDivisor z = principal hF (Additive.toMul z) := by
   rw [principal, principalHom, WeilDivisor.OrderSystem.principalHom_apply, ofMul_toMul]
 
+/-- A divisor belongs to the principal subgroup exactly when it is the divisor of a nonzero
+function. -/
+theorem mem_principalSubgroup_iff (hF : IsFunctionField k F) {D : Divisor k F} :
+    D ∈ (Place.orderSystem hF).principalSubgroup ↔ ∃ z : Fˣ, principal hF z = D := by
+  rw [WeilDivisor.OrderSystem.mem_principalSubgroup]
+  constructor
+  · rintro ⟨z, hz⟩
+    exact ⟨Additive.toMul z, by rwa [← principalDivisor_eq]⟩
+  · rintro ⟨z, hz⟩
+    exact ⟨Additive.ofMul z, by rwa [principalDivisor_eq, toMul_ofMul]⟩
+
+/-- A divisor has trivial divisor class exactly when it is the divisor of a nonzero function. -/
+theorem divisorClass_eq_zero_iff (hF : IsFunctionField k F) {D : Divisor k F} :
+    (Place.orderSystem hF).divisorClass D = 0 ↔ ∃ z : Fˣ, principal hF z = D := by
+  rw [WeilDivisor.OrderSystem.divisorClass_eq_zero_iff, mem_principalSubgroup_iff hF]
+
 /-- **Linear equivalence, in terms of functions**: two divisors are linearly equivalent exactly
 when their difference is the divisor of a function.  This is the multiplicative reading of
 `TauCeti.AlgebraicGeometry.WeilDivisor.OrderSystem.LinearlyEquivalent` for the order system of
 places (Stichtenoth, Definition 1.4.3). -/
 theorem linearlyEquivalent_iff (hF : IsFunctionField k F) {A B : Divisor k F} :
     (Place.orderSystem hF).LinearlyEquivalent A B ↔ ∃ z : Fˣ, principal hF z = A - B := by
-  rw [WeilDivisor.OrderSystem.linearlyEquivalent_iff_exists_principalDivisor]
-  constructor
-  · rintro ⟨g, hg⟩
-    exact ⟨Additive.toMul g, by rwa [← principalDivisor_eq]⟩
-  · rintro ⟨z, hz⟩
-    exact ⟨Additive.ofMul z, by rwa [principalDivisor_eq, toMul_ofMul]⟩
+  rw [WeilDivisor.OrderSystem.linearlyEquivalent_iff, mem_principalSubgroup_iff hF]
 
 /-- The divisor of a function algebraic over the constants is trivial: such a function has
 neither zeros nor poles. -/

--- a/TauCeti/FieldTheory/FunctionField/Divisor/ProductFormula.lean
+++ b/TauCeti/FieldTheory/FunctionField/Divisor/ProductFormula.lean
@@ -401,7 +401,7 @@ theorem riemannRochSpace_eq_bot_of_degree_neg (hF : IsFunctionField k F) {D : Di
 /-- A divisor of negative degree has Riemann–Roch dimension zero. -/
 theorem Divisor.dim_eq_zero_of_degree_neg (hF : IsFunctionField k F) {D : Divisor k F}
     (hD : Divisor.degree D < 0) : Divisor.dim D = 0 := by
-  rw [Divisor.dim_def, riemannRochSpace_eq_bot_of_degree_neg hF hD,
-    finrank_bot]
+  exact (Divisor.dim_eq_zero_iff_riemannRochSpace_eq_bot hF D).mpr
+    (riemannRochSpace_eq_bot_of_degree_neg hF hD)
 
 end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/Basic.lean
@@ -369,6 +369,18 @@ theorem finiteDimensional_riemannRochSpace (hF : IsFunctionField k F) (D : Divis
     (finiteDimensional_riemannRochSpace_zero hF)).1
   exact Submodule.finiteDimensional_of_le (riemannRochSpace_mono (le_posPart D))
 
+/-- The Riemann–Roch dimension is zero exactly when the Riemann–Roch space is zero. -/
+theorem Divisor.dim_eq_zero_iff_riemannRochSpace_eq_bot (hF : IsFunctionField k F)
+    (D : Divisor k F) : Divisor.dim D = 0 ↔ riemannRochSpace D = ⊥ := by
+  let _ := finiteDimensional_riemannRochSpace hF D
+  rw [Divisor.dim_def, Submodule.finrank_eq_zero]
+
+/-- The Riemann–Roch dimension is positive exactly when the Riemann–Roch space is nonzero. -/
+theorem Divisor.one_le_dim_iff_riemannRochSpace_ne_bot (hF : IsFunctionField k F)
+    (D : Divisor k F) : 1 ≤ Divisor.dim D ↔ riemannRochSpace D ≠ ⊥ := by
+  let _ := finiteDimensional_riemannRochSpace hF D
+  rw [Divisor.dim_def, Submodule.one_le_finrank_iff]
+
 /-- `ℓ` is monotone in the divisor (Stichtenoth, Lemma 1.4.8, first part). -/
 theorem Divisor.dim_mono (hF : IsFunctionField k F) {D E : Divisor k F} (h : D ≤ E) :
     Divisor.dim D ≤ Divisor.dim E := by
@@ -433,6 +445,7 @@ theorem Divisor.dim_zero_of_isIntegrallyClosedIn (hF : IsFunctionField k F)
 /-- `ℓ(D) = 0` for a negative divisor (Stichtenoth, Lemma 1.4.7(b)). -/
 theorem Divisor.dim_eq_zero_of_lt_zero (hF : IsFunctionField k F) {D : Divisor k F} (hD : D < 0) :
     Divisor.dim D = 0 := by
-  rw [Divisor.dim_def, riemannRochSpace_eq_bot_of_lt_zero hF hD, finrank_bot]
+  exact (Divisor.dim_eq_zero_iff_riemannRochSpace_eq_bot hF D).mpr
+    (riemannRochSpace_eq_bot_of_lt_zero hF hD)
 
 end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/DegreeZero.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/DegreeZero.lean
@@ -12,8 +12,9 @@ public import TauCeti.FieldTheory.FunctionField.Divisor.ProductFormula
 
 For an algebraic function field, an effective divisor of degree zero is zero.  Consequently, a
 degree-zero divisor `D` has a nonzero function in its Riemann–Roch space exactly when `D` is
-principal.  Over an exact constant field this is equivalent to `ℓ(D) = 1`; otherwise the same
-argument identifies `ℓ(D)` with the degree of the full constant field.
+principal, equivalently when its divisor class is zero.  In general this is equivalent to
+`ℓ(D) = [algebraicClosure k F : k]`; over an exact constant field it specializes to
+`ℓ(D) = 1`.
 
 These are the degree-zero statements of Stichtenoth, *Algebraic Function Fields and Codes*,
 second edition, Corollary 1.4.12(c).  They use the product formula through invariance of degree
@@ -23,12 +24,17 @@ under linear equivalence.
 
 * `TauCeti.riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero`: `L(D)` is nonzero
   exactly when a degree-zero `D` is principal.
+* `TauCeti.riemannRochSpace_ne_bot_iff_divisorClass_eq_zero_of_degree_eq_zero`: equivalently,
+  a degree-zero divisor has nonzero `L(D)` exactly when its divisor class is zero.
 * `TauCeti.Divisor.dim_eq_finrank_algebraicClosure_iff_exists_principal_eq_of_degree_eq_zero`:
   in that case `ℓ(D)` is the degree of the full constant field, and only then.
 * `TauCeti.Divisor.one_le_dim_iff_exists_principal_eq_of_degree_eq_zero`: a degree-zero divisor
   has `ℓ(D) ≥ 1` exactly when it is principal.
 * `TauCeti.Divisor.dim_eq_one_iff_exists_principal_eq_of_degree_eq_zero`: over an exact constant
   field, `D` is principal exactly when `ℓ(D) = 1`.
+* `TauCeti.Divisor.dim_eq_zero_or_finrank_algebraicClosure_of_degree_eq_zero`: in general the
+  dimension is zero or the degree of the full constant field; over an exact constant field,
+  `TauCeti.Divisor.dim_eq_zero_or_one_of_degree_eq_zero` gives the zero-or-one dichotomy.
 
 ## References
 
@@ -44,57 +50,30 @@ open AlgebraicGeometry
 
 variable {k F : Type*} [Field k] [Field F] [Algebra k F]
 
-/-- A degree-zero divisor has a nonzero Riemann–Roch space exactly when it is principal
-(Stichtenoth, Corollary 1.4.12(c)).
-
-Indeed, a nonzero function in `L(D)` makes `D` linearly equivalent to an effective divisor.
-The product formula preserves degree under this equivalence, and an effective divisor of degree
-zero is zero. -/
-theorem riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero
-    (hF : IsFunctionField k F) {D : Divisor k F} (hD : Divisor.degree D = 0) :
-    riemannRochSpace D ≠ ⊥ ↔ ∃ z : Fˣ, Divisor.principal hF z = D := by
-  rw [riemannRochSpace_ne_bot_iff hF]
-  constructor
-  · rintro ⟨E, hE, hDE⟩
-    have hEdeg : Divisor.degree E = 0 :=
-      (Divisor.degree_eq_of_linearlyEquivalent hF hDE).symm.trans hD
-    have hE0 : E = 0 := (Divisor.degree_eq_zero_iff hF hE).mp hEdeg
-    obtain ⟨z, hz⟩ := (Divisor.linearlyEquivalent_iff hF).mp hDE
-    rw [hE0, sub_zero] at hz
-    exact ⟨z, hz⟩
-  · rintro ⟨z, rfl⟩
-    refine ⟨0, le_rfl, (Divisor.linearlyEquivalent_iff hF).mpr ⟨z, ?_⟩⟩
-    simp
-
 /-- A degree-zero divisor has zero divisor class exactly when its Riemann–Roch space is nonzero. -/
 theorem riemannRochSpace_ne_bot_iff_divisorClass_eq_zero_of_degree_eq_zero
     (hF : IsFunctionField k F) {D : Divisor k F} (hD : Divisor.degree D = 0) :
     riemannRochSpace D ≠ ⊥ ↔ (Place.orderSystem hF).divisorClass D = 0 := by
-  rw [riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero hF hD,
-    WeilDivisor.OrderSystem.divisorClass_eq_zero_iff,
-    WeilDivisor.OrderSystem.mem_principalSubgroup]
-  constructor
-  · rintro ⟨z, hz⟩
-    refine ⟨Additive.ofMul z, ?_⟩
-    rw [Divisor.principalDivisor_eq, toMul_ofMul]
-    exact hz
-  · rintro ⟨z, hz⟩
-    refine ⟨Additive.toMul z, ?_⟩
-    rw [← Divisor.principalDivisor_eq]
-    exact hz
+  rw [riemannRochSpace_ne_bot_iff hF]
+  let S := Place.orderSystem hF
+  have hcriterion :=
+    S.nonempty_completeLinearSystem_iff_divisorClass_eq_zero_of_weightedDegree_zero
+      (fun P ↦ by exact_mod_cast P.one_le_degree_of_isFunctionField hF)
+      (Place.isWeightedDegreeZero_orderSystem hF)
+      (by
+        rw [WeilDivisor.weightedDegree_apply]
+        rw [Divisor.degree_apply] at hD
+        exact hD)
+  simpa only [Set.nonempty_def, WeilDivisor.OrderSystem.mem_completeLinearSystem,
+    WeilDivisor.isEffective_iff_zero_le] using hcriterion
 
-/-- If a divisor is principal, its Riemann–Roch dimension equals the degree of the full constant
-field.  This statement does not require the divisor to have degree zero: the product formula
-already guarantees that for principal divisors. -/
-theorem Divisor.dim_eq_finrank_algebraicClosure_of_exists_principal_eq
-    (hF : IsFunctionField k F) {D : Divisor k F}
-    (hD : ∃ z : Fˣ, Divisor.principal hF z = D) :
-    Divisor.dim D = Module.finrank k (algebraicClosure k F) := by
-  obtain ⟨z, rfl⟩ := hD
-  have hlin : (Place.orderSystem hF).LinearlyEquivalent (Divisor.principal hF z)
-      (0 : Divisor k F) :=
-    (Divisor.linearlyEquivalent_iff hF).mpr ⟨z, by simp⟩
-  rw [Divisor.dim_eq_of_linearlyEquivalent hF hlin, Divisor.dim_zero hF]
+/-- A degree-zero divisor has a nonzero Riemann–Roch space exactly when it is principal
+(Stichtenoth, Corollary 1.4.12(c)). -/
+theorem riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero
+    (hF : IsFunctionField k F) {D : Divisor k F} (hD : Divisor.degree D = 0) :
+    riemannRochSpace D ≠ ⊥ ↔ ∃ z : Fˣ, Divisor.principal hF z = D := by
+  rw [riemannRochSpace_ne_bot_iff_divisorClass_eq_zero_of_degree_eq_zero hF hD,
+    Divisor.divisorClass_eq_zero_iff hF]
 
 /-- For a degree-zero divisor, `ℓ(D)` equals the degree of the full constant field exactly when
 `D` is principal.  A nonprincipal degree-zero divisor has `L(D) = 0`, while a principal one has a
@@ -106,13 +85,13 @@ theorem Divisor.dim_eq_finrank_algebraicClosure_iff_exists_principal_eq_of_degre
   constructor
   · intro hdim
     apply (riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero hF hD).mp
-    intro hbot
+    rw [← Divisor.one_le_dim_iff_riemannRochSpace_ne_bot hF]
     have hconstants : 0 < Module.finrank k (algebraicClosure k F) := by
       let _ := hF.finiteDimensional_algebraicClosure
       exact Module.finrank_pos
-    rw [Divisor.dim_def, hbot, finrank_bot] at hdim
     omega
-  · exact Divisor.dim_eq_finrank_algebraicClosure_of_exists_principal_eq hF
+  · rintro ⟨z, rfl⟩
+    exact Divisor.dim_principal hF z
 
 /-- A degree-zero divisor has Riemann–Roch dimension at least one exactly when it is principal
 (Stichtenoth, Corollary 1.4.12(c)).  Exactness of the constant field is unnecessary for this
@@ -120,16 +99,8 @@ form: the full constant field always contributes at least one dimension. -/
 theorem Divisor.one_le_dim_iff_exists_principal_eq_of_degree_eq_zero
     (hF : IsFunctionField k F) {D : Divisor k F} (hD : Divisor.degree D = 0) :
     1 ≤ Divisor.dim D ↔ ∃ z : Fˣ, Divisor.principal hF z = D := by
-  constructor
-  · intro hdim
-    apply (riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero hF hD).mp
-    intro hbot
-    rw [Divisor.dim_def, hbot, finrank_bot] at hdim
-    omega
-  · intro hprincipal
-    rw [Divisor.dim_eq_finrank_algebraicClosure_of_exists_principal_eq hF hprincipal]
-    let _ := hF.finiteDimensional_algebraicClosure
-    exact Module.finrank_pos
+  rw [Divisor.one_le_dim_iff_riemannRochSpace_ne_bot hF,
+    riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero hF hD]
 
 /-- Over an exact constant field, a degree-zero divisor is principal exactly when its
 Riemann–Roch dimension is one (Stichtenoth, Corollary 1.4.12(c)). -/
@@ -140,19 +111,24 @@ theorem Divisor.dim_eq_one_iff_exists_principal_eq_of_degree_eq_zero
   rw [← isIntegrallyClosedIn_iff_finrank_algebraicClosure_eq_one.mp hex]
   exact Divisor.dim_eq_finrank_algebraicClosure_iff_exists_principal_eq_of_degree_eq_zero hF hD
 
+/-- A degree-zero divisor has Riemann–Roch dimension either zero or the degree of the full
+constant field. -/
+theorem Divisor.dim_eq_zero_or_finrank_algebraicClosure_of_degree_eq_zero
+    (hF : IsFunctionField k F) {D : Divisor k F} (hD : Divisor.degree D = 0) :
+    Divisor.dim D = 0 ∨ Divisor.dim D = Module.finrank k (algebraicClosure k F) := by
+  rcases Nat.eq_zero_or_pos (Divisor.dim D) with h | h
+  · exact Or.inl h
+  · exact Or.inr <|
+      (Divisor.dim_eq_finrank_algebraicClosure_iff_exists_principal_eq_of_degree_eq_zero hF hD).mpr
+        ((Divisor.one_le_dim_iff_exists_principal_eq_of_degree_eq_zero hF hD).mp h)
+
 /-- Over an exact constant field, a degree-zero divisor has Riemann–Roch dimension either zero or
-one.  The second case is characterized by
-`Divisor.dim_eq_one_iff_exists_principal_eq_of_degree_eq_zero`. -/
+one. -/
 theorem Divisor.dim_eq_zero_or_one_of_degree_eq_zero
     (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F)
     {D : Divisor k F} (hD : Divisor.degree D = 0) :
     Divisor.dim D = 0 ∨ Divisor.dim D = 1 := by
-  by_cases hprincipal : ∃ z : Fˣ, Divisor.principal hF z = D
-  · exact Or.inr <|
-      (Divisor.dim_eq_one_iff_exists_principal_eq_of_degree_eq_zero hF hex hD).mpr hprincipal
-  · left
-    have hbot : riemannRochSpace D = ⊥ := not_ne_iff.mp <|
-      mt (riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero hF hD).mp hprincipal
-    rw [Divisor.dim_def, hbot, finrank_bot]
+  rw [← isIntegrallyClosedIn_iff_finrank_algebraicClosure_eq_one.mp hex]
+  exact Divisor.dim_eq_zero_or_finrank_algebraicClosure_of_degree_eq_zero hF hD
 
 end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/DegreeZero.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/DegreeZero.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.FunctionField.Divisor.ProductFormula
+
+/-!
+# Riemann–Roch spaces of degree-zero divisors
+
+For an algebraic function field, an effective divisor of degree zero is zero.  Consequently, a
+degree-zero divisor `D` has a nonzero function in its Riemann–Roch space exactly when `D` is
+principal.  Over an exact constant field this is equivalent to `ℓ(D) = 1`; otherwise the same
+argument identifies `ℓ(D)` with the degree of the full constant field.
+
+These are the degree-zero statements of Stichtenoth, *Algebraic Function Fields and Codes*,
+second edition, Corollary 1.4.12(c).  They use the product formula through invariance of degree
+under linear equivalence.
+
+## Main results
+
+* `TauCeti.riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero`: `L(D)` is nonzero
+  exactly when a degree-zero `D` is principal.
+* `TauCeti.Divisor.dim_eq_finrank_algebraicClosure_iff_exists_principal_eq_of_degree_eq_zero`:
+  in that case `ℓ(D)` is the degree of the full constant field, and only then.
+* `TauCeti.Divisor.one_le_dim_iff_exists_principal_eq_of_degree_eq_zero`: a degree-zero divisor
+  has `ℓ(D) ≥ 1` exactly when it is principal.
+* `TauCeti.Divisor.dim_eq_one_iff_exists_principal_eq_of_degree_eq_zero`: over an exact constant
+  field, `D` is principal exactly when `ℓ(D) = 1`.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, second edition, GTM 254, Springer,
+  2009, Corollary 1.4.12(c).
+-/
+
+public section
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+variable {k F : Type*} [Field k] [Field F] [Algebra k F]
+
+/-- A degree-zero divisor has a nonzero Riemann–Roch space exactly when it is principal
+(Stichtenoth, Corollary 1.4.12(c)).
+
+Indeed, a nonzero function in `L(D)` makes `D` linearly equivalent to an effective divisor.
+The product formula preserves degree under this equivalence, and an effective divisor of degree
+zero is zero. -/
+theorem riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero
+    (hF : IsFunctionField k F) {D : Divisor k F} (hD : Divisor.degree D = 0) :
+    riemannRochSpace D ≠ ⊥ ↔ ∃ z : Fˣ, Divisor.principal hF z = D := by
+  rw [riemannRochSpace_ne_bot_iff hF]
+  constructor
+  · rintro ⟨E, hE, hDE⟩
+    have hEdeg : Divisor.degree E = 0 :=
+      (Divisor.degree_eq_of_linearlyEquivalent hF hDE).symm.trans hD
+    have hE0 : E = 0 := (Divisor.degree_eq_zero_iff hF hE).mp hEdeg
+    obtain ⟨z, hz⟩ := (Divisor.linearlyEquivalent_iff hF).mp hDE
+    rw [hE0, sub_zero] at hz
+    exact ⟨z, hz⟩
+  · rintro ⟨z, rfl⟩
+    refine ⟨0, le_rfl, (Divisor.linearlyEquivalent_iff hF).mpr ⟨z, ?_⟩⟩
+    simp
+
+/-- A degree-zero divisor has zero divisor class exactly when its Riemann–Roch space is nonzero. -/
+theorem riemannRochSpace_ne_bot_iff_divisorClass_eq_zero_of_degree_eq_zero
+    (hF : IsFunctionField k F) {D : Divisor k F} (hD : Divisor.degree D = 0) :
+    riemannRochSpace D ≠ ⊥ ↔ (Place.orderSystem hF).divisorClass D = 0 := by
+  rw [riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero hF hD,
+    WeilDivisor.OrderSystem.divisorClass_eq_zero_iff,
+    WeilDivisor.OrderSystem.mem_principalSubgroup]
+  constructor
+  · rintro ⟨z, hz⟩
+    refine ⟨Additive.ofMul z, ?_⟩
+    rw [Divisor.principalDivisor_eq, toMul_ofMul]
+    exact hz
+  · rintro ⟨z, hz⟩
+    refine ⟨Additive.toMul z, ?_⟩
+    rw [← Divisor.principalDivisor_eq]
+    exact hz
+
+/-- If a divisor is principal, its Riemann–Roch dimension equals the degree of the full constant
+field.  This statement does not require the divisor to have degree zero: the product formula
+already guarantees that for principal divisors. -/
+theorem Divisor.dim_eq_finrank_algebraicClosure_of_exists_principal_eq
+    (hF : IsFunctionField k F) {D : Divisor k F}
+    (hD : ∃ z : Fˣ, Divisor.principal hF z = D) :
+    Divisor.dim D = Module.finrank k (algebraicClosure k F) := by
+  obtain ⟨z, rfl⟩ := hD
+  have hlin : (Place.orderSystem hF).LinearlyEquivalent (Divisor.principal hF z)
+      (0 : Divisor k F) :=
+    (Divisor.linearlyEquivalent_iff hF).mpr ⟨z, by simp⟩
+  rw [Divisor.dim_eq_of_linearlyEquivalent hF hlin, Divisor.dim_zero hF]
+
+/-- For a degree-zero divisor, `ℓ(D)` equals the degree of the full constant field exactly when
+`D` is principal.  A nonprincipal degree-zero divisor has `L(D) = 0`, while a principal one has a
+Riemann–Roch space obtained from `L(0)` by multiplication by a nonzero function. -/
+theorem Divisor.dim_eq_finrank_algebraicClosure_iff_exists_principal_eq_of_degree_eq_zero
+    (hF : IsFunctionField k F) {D : Divisor k F} (hD : Divisor.degree D = 0) :
+    Divisor.dim D = Module.finrank k (algebraicClosure k F) ↔
+      ∃ z : Fˣ, Divisor.principal hF z = D := by
+  constructor
+  · intro hdim
+    apply (riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero hF hD).mp
+    intro hbot
+    have hconstants : 0 < Module.finrank k (algebraicClosure k F) := by
+      let _ := hF.finiteDimensional_algebraicClosure
+      exact Module.finrank_pos
+    rw [Divisor.dim_def, hbot, finrank_bot] at hdim
+    omega
+  · exact Divisor.dim_eq_finrank_algebraicClosure_of_exists_principal_eq hF
+
+/-- A degree-zero divisor has Riemann–Roch dimension at least one exactly when it is principal
+(Stichtenoth, Corollary 1.4.12(c)).  Exactness of the constant field is unnecessary for this
+form: the full constant field always contributes at least one dimension. -/
+theorem Divisor.one_le_dim_iff_exists_principal_eq_of_degree_eq_zero
+    (hF : IsFunctionField k F) {D : Divisor k F} (hD : Divisor.degree D = 0) :
+    1 ≤ Divisor.dim D ↔ ∃ z : Fˣ, Divisor.principal hF z = D := by
+  constructor
+  · intro hdim
+    apply (riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero hF hD).mp
+    intro hbot
+    rw [Divisor.dim_def, hbot, finrank_bot] at hdim
+    omega
+  · intro hprincipal
+    rw [Divisor.dim_eq_finrank_algebraicClosure_of_exists_principal_eq hF hprincipal]
+    let _ := hF.finiteDimensional_algebraicClosure
+    exact Module.finrank_pos
+
+/-- Over an exact constant field, a degree-zero divisor is principal exactly when its
+Riemann–Roch dimension is one (Stichtenoth, Corollary 1.4.12(c)). -/
+theorem Divisor.dim_eq_one_iff_exists_principal_eq_of_degree_eq_zero
+    (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F)
+    {D : Divisor k F} (hD : Divisor.degree D = 0) :
+    Divisor.dim D = 1 ↔ ∃ z : Fˣ, Divisor.principal hF z = D := by
+  rw [← isIntegrallyClosedIn_iff_finrank_algebraicClosure_eq_one.mp hex]
+  exact Divisor.dim_eq_finrank_algebraicClosure_iff_exists_principal_eq_of_degree_eq_zero hF hD
+
+/-- Over an exact constant field, a degree-zero divisor has Riemann–Roch dimension either zero or
+one.  The second case is characterized by
+`Divisor.dim_eq_one_iff_exists_principal_eq_of_degree_eq_zero`. -/
+theorem Divisor.dim_eq_zero_or_one_of_degree_eq_zero
+    (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F)
+    {D : Divisor k F} (hD : Divisor.degree D = 0) :
+    Divisor.dim D = 0 ∨ Divisor.dim D = 1 := by
+  by_cases hprincipal : ∃ z : Fˣ, Divisor.principal hF z = D
+  · exact Or.inr <|
+      (Divisor.dim_eq_one_iff_exists_principal_eq_of_degree_eq_zero hF hex hD).mpr hprincipal
+  · left
+    have hbot : riemannRochSpace D = ⊥ := not_ne_iff.mp <|
+      mt (riemannRochSpace_ne_bot_iff_exists_principal_eq_of_degree_eq_zero hF hD).mp hprincipal
+    rw [Divisor.dim_def, hbot, finrank_bot]
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/Principal.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/Principal.lean
@@ -27,6 +27,8 @@ so that `ℓ` depends only on the linear equivalence class of a divisor.  It is 
   multiplication by `z` is a `k`-linear isomorphism `L(A) ≅ L(A - div z)`; hence
   `TauCeti.Divisor.dim_eq_of_linearlyEquivalent`, `ℓ` is an invariant of the linear equivalence
   class of a divisor.
+* `TauCeti.Divisor.dim_principal`: the dimension of a principal divisor is the degree of the
+  full constant field over `k`.
 * `TauCeti.riemannRochSpace_ne_bot_iff`: `L(D) ≠ 0` exactly when `D` is linearly equivalent to
   an effective divisor (Remark 1.4.5(b)).
 
@@ -123,6 +125,22 @@ theorem Divisor.dim_eq_of_linearlyEquivalent (hF : IsFunctionField k F) {A B : D
   obtain ⟨z, hz⟩ := (Divisor.linearlyEquivalent_iff hF).mp h
   have hB : B = A - Divisor.principal hF z := by rw [hz]; abel
   rw [hB, Divisor.dim_sub_principal]
+
+/-- The Riemann–Roch dimension of a principal divisor is the degree of the full constant field. -/
+@[simp]
+theorem Divisor.dim_principal (hF : IsFunctionField k F) (z : Fˣ) :
+    Divisor.dim (Divisor.principal hF z) = Module.finrank k (algebraicClosure k F) := by
+  have hlin : (Place.orderSystem hF).LinearlyEquivalent (Divisor.principal hF z)
+      (0 : Divisor k F) :=
+    (Divisor.linearlyEquivalent_iff hF).mpr ⟨z, by simp⟩
+  rw [Divisor.dim_eq_of_linearlyEquivalent hF hlin, Divisor.dim_zero hF]
+
+/-- Over an exact constant field, the Riemann–Roch dimension of a principal divisor is one. -/
+@[simp]
+theorem Divisor.dim_principal_of_isIntegrallyClosedIn (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) (z : Fˣ) :
+    Divisor.dim (Divisor.principal hF z) = 1 := by
+  rw [Divisor.dim_principal hF, isIntegrallyClosedIn_iff_finrank_algebraicClosure_eq_one.mp hex]
 
 /-- **A Riemann–Roch space is nonzero exactly when its divisor is linearly equivalent to an
 effective divisor** (Stichtenoth, Remark 1.4.5(b)).  A nonzero `f ∈ L(D)` makes `div f + D`

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/Principal.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/Principal.lean
@@ -136,7 +136,6 @@ theorem Divisor.dim_principal (hF : IsFunctionField k F) (z : Fˣ) :
   rw [Divisor.dim_eq_of_linearlyEquivalent hF hlin, Divisor.dim_zero hF]
 
 /-- Over an exact constant field, the Riemann–Roch dimension of a principal divisor is one. -/
-@[simp]
 theorem Divisor.dim_principal_of_isIntegrallyClosedIn (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) (z : Fˣ) :
     Divisor.dim (Divisor.principal hF z) = 1 := by


### PR DESCRIPTION
This PR proves the AlgebraicCurves Layer 3 degree-zero criterion: characterize a degree-zero divisor `D` as principal exactly when `L(D) ≠ 0`, exactly when `1 ≤ ℓ(D)`, and, over an exact constant field, exactly when `ℓ(D) = 1`. Preserve the sharper arbitrary-constant-field statement by identifying the principal case with `ℓ(D) = [k̃ : k]`, and connect the criterion to the zero divisor class.

The exact roadmap target is `AlgebraicCurves/README.md`, Layer 3, “a degree-0 divisor is principal iff `ℓ ≥ 1` iff `ℓ = 1` (Cor. 1.4.12(c)).” This is the next small step unlocked by the newly landed product formula and degree invariance. After this PR, the Layer 3 critical path still needs Riemann's theorem and the genus, together with its rational-function-field and affine-bridge milestones.

The designated EllipticCurves Layer 0 class-group anchor delegates its place/divisor implementation to the AlgebraicCurves coordination point. The explicit dependency edge is: EllipticCurves Layer 0's principal-divisor/class-group milestone consumes AlgebraicCurves Layer 3's general divisor, principal-class, and degree-zero infrastructure before specializing it through the point–place dictionary and `Point.toClass`; the elliptic-specific `toClass_surjective` work remains in flight. I switch to this supplier step because that direct class-anchor PR is already open, while the other immediately adjacent isogeny path is explicitly blocked on inseparable finite normalization.

The proofs reuse Tau Ceti's `riemannRochSpace_ne_bot_iff`, product-formula consequence `Divisor.degree_eq_of_linearlyEquivalent`, effective degree-zero criterion `Divisor.degree_eq_zero_iff`, and the existing linear-equivalence and divisor-class APIs. No Mathlib infrastructure is vendored.

Roadmap: AlgebraicCurves

Consumer roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"degree-zero-divisor-principal-iff-dim-one"}-->

🤖 Prepared with Codex
