### PR TITLE
refactor(Multiquadratic): name the shared odd-radicand mod-four argument

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/QuadraticSubfield.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/QuadraticSubfield.lean
@@ -73,6 +73,17 @@ theorem squarefree_prod_primeDiscriminantRadicands_of_forall_isEvenPrimeDiscrimi
       (hi8.symm ▸ isEvenPrimeDiscriminant_neg_eight)
       (hj8.symm ▸ isEvenPrimeDiscriminant_eight)))
 
+/-- A product of the radicands of non-even prime discriminants is congruent to `1` modulo `4`,
+because the radicand of each such discriminant is. -/
+private theorem prod_primeDiscriminantRadicands_mod_four_eq_one_of_not_even
+    (hD : ∀ i ∈ S, IsPrimeDiscriminant (D i)) (hodd : ∀ i ∈ S, ¬ IsEvenPrimeDiscriminant (D i)) :
+    (∏ i ∈ S, primeDiscriminantRadicand (D i)) % 4 = 1 := by
+  rw [Finset.prod_int_mod,
+    Finset.prod_congr rfl fun i hi =>
+      (isEvenPrimeDiscriminant_or_primeDiscriminantRadicand_mod_four_eq_one
+        (hD i hi)).resolve_left (hodd i hi)]
+  simp
+
 /-- **Fundamental discriminant of a subset product of prime-discriminant radicands.** For a
 distinct family of prime discriminants with at most one even member,
 
@@ -99,15 +110,8 @@ theorem fundamentalDiscriminant_prod_primeDiscriminantRadicands
     have hrad : ∀ j ∈ S.erase i, primeDiscriminantRadicand (D j) = D j :=
       fun j hj => primeDiscriminantRadicand_eq_self_of_not_even
         (hD j (Finset.mem_of_mem_erase hj)) (hodd j hj)
-    have hterms : ∏ j ∈ S.erase i, D j % 4 = 1 := by
-      apply Finset.prod_eq_one
-      intro j hj
-      have h := (isEvenPrimeDiscriminant_or_primeDiscriminantRadicand_mod_four_eq_one
-        (hD j (Finset.mem_of_mem_erase hj))).resolve_left (hodd j hj)
-      rwa [hrad j hj] at h
-    have hoddmod : (∏ j ∈ S.erase i, primeDiscriminantRadicand (D j)) % 4 = 1 := by
-      rw [Finset.prod_congr rfl hrad, Finset.prod_int_mod, hterms]
-      norm_num
+    have hoddmod := prod_primeDiscriminantRadicands_mod_four_eq_one_of_not_even
+      (S := S.erase i) (fun j hj => hD j (Finset.mem_of_mem_erase hj)) hodd
     have hiMod := primeDiscriminantRadicand_mod_four_eq_three_or_two_of_even hiEven
     have hprodRad : (∏ j ∈ S, primeDiscriminantRadicand (D j)) =
         primeDiscriminantRadicand (D i) * ∏ j ∈ S.erase i,
@@ -138,15 +142,7 @@ theorem fundamentalDiscriminant_prod_primeDiscriminantRadicands
       fun i hi hiEven => hex ⟨i, hi, hiEven⟩
     have hrad : ∀ i ∈ S, primeDiscriminantRadicand (D i) = D i :=
       fun i hi => primeDiscriminantRadicand_eq_self_of_not_even (hD i hi) (hodd i hi)
-    have hterms : ∏ i ∈ S, D i % 4 = 1 := by
-      apply Finset.prod_eq_one
-      intro i hi
-      have h := (isEvenPrimeDiscriminant_or_primeDiscriminantRadicand_mod_four_eq_one
-        (hD i hi)).resolve_left (hodd i hi)
-      rwa [hrad i hi] at h
-    have hmod : (∏ i ∈ S, primeDiscriminantRadicand (D i)) % 4 = 1 := by
-      rw [Finset.prod_congr rfl hrad, Finset.prod_int_mod, hterms]
-      norm_num
+    have hmod := prod_primeDiscriminantRadicands_mod_four_eq_one_of_not_even hD hodd
     rw [fundamentalDiscriminant_of_mod_four_eq_one hmod, Finset.prod_congr rfl hrad]
 
 section Subfields


### PR DESCRIPTION
Both branches of the `by_cases` in `fundamentalDiscriminant_prod_primeDiscriminantRadicands`
contained the *same* nine-line argument, once at `S.erase i` and once at `S`: the radicands of
non-even prime discriminants are each `1` modulo `4`, so their product is too.

This names that argument as `prod_primeDiscriminantRadicands_mod_four_eq_one_of_not_even` and
calls it from both branches. The proof body of the parent drops from 61 to 46 lines and the
duplicated block disappears.

### The helper needs strictly fewer hypotheses than the parent

The parent carries `hD`, `hinj` and `heven`; the argument itself uses only

* `hD   : ∀ i ∈ S, IsPrimeDiscriminant (D i)`
* `hodd : ∀ i ∈ S, ¬ IsEvenPrimeDiscriminant (D i)`

`hinj` and `heven` are exactly the distinctness / at-most-one-even conditions that the *ambient*
theorem needs in order to isolate the even factor; they play no part in the odd-factor
computation, so they are dropped rather than threaded through. No typeclass assumptions are
involved at all (`D : ι → ℤ`), so there is no inherited-instance question.

Neither remaining hypothesis is redundant, and singleton `S` shows why:

* drop `hodd` and take `D i = -4` — a prime discriminant whose radicand is `-1`, and
  `(-1 : ℤ) % 4 = 3`;
* drop `hD` and take `D i = 2` — not an even prime discriminant, but its radicand is `2`.

### Notes for review

* **The proof works at the radicand level directly.** An earlier draft rewrote each radicand to
  its discriminant (via the file's `primeDiscriminantRadicand_eq_self_of_not_even`) only to reach
  a fact that `isEvenPrimeDiscriminant_or_primeDiscriminantRadicand_mod_four_eq_one` already
  states about the radicand. Removing that detour makes the proof four lines shorter and gives it
  the same shape as the existing `prod_oddPrimeDiscriminant_mod_four_eq_one` —
  `Finset.prod_int_mod`, then `Finset.prod_congr`, then a terminal `simp`.
* **Placement is forced.** The lemma sits immediately before its only consumer, beside the other
  product-of-radicands lemma in this file.
* **It is `private`** because its only consumers are in this file, matching the existing private
  helper above it. It is therefore deliberately not added to the module docstring's
  `Main results`, which lists public API.
* **Not a duplicate of `prod_oddPrimeDiscriminant_mod_four_eq_one`**
  (`FundamentalDiscriminant/Basic.lean`): that lemma is about `oddPrimeDiscriminant (p i)` for
  primes `p : ι → ℕ`, not about `primeDiscriminantRadicand (D i)` for prime discriminants
  `D : ι → ℤ`. Deriving this one from it would first require normalising every `D i` into the
  form `oddPrimeDiscriminant _`, which is strictly more work than proving it directly. It did fix
  the naming convention used here.
* `(S := S.erase i)` is given explicitly at the first call site: `S` is otherwise inferred only
  from `hodd`, and naming it keeps the instantiation legible.
* `have hoddmod := …` and `have hmod := …` are left unannotated, matching the neighbouring
  `have hiMod := primeDiscriminantRadicand_mod_four_eq_three_or_two_of_even hiEven`.

Each branch keeps its own local `hrad`, which is still needed afterwards for a different purpose
— rewriting `∏ radicand` into `∏ D` in the final computation.

No new mathematics: this only gives an existing argument a name.

Roadmap: Multiquadratic
