### PR TITLE
feat: prove the special linear group geometrically connected

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/AlgebraicallyClosed.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/AlgebraicallyClosed.lean
@@ -79,7 +79,7 @@ theorem geometricallyConnectedCommHopfAlgProperty_iff_connectedSpace_of_isAlgClo
 namespace HopfAlgebra
 
 /-- Two specializations of a domain-valued algebra homomorphism agree on an idempotent. -/
-theorem algHom_apply_eq_of_isIdempotentElem
+private theorem algHom_apply_eq_of_isIdempotentElem
     {K H A : Type u} [CommSemiring K] [Semiring H] [Algebra K H]
     [CommSemiring A] [Algebra K A] [IsDomain A]
     (e : H) (he : IsIdempotentElem e) (q : H →ₐ[K] A)

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/AlgebraicallyClosed.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/AlgebraicallyClosed.lean
@@ -78,16 +78,14 @@ theorem geometricallyConnectedCommHopfAlgProperty_iff_connectedSpace_of_isAlgClo
 
 namespace HopfAlgebra
 
-/-- Two specializations of a domain-valued point agree on an idempotent. -/
-theorem mapValue_apply_eq_of_isIdempotentElem
-    {K H A : Type u} [CommSemiring K] [Semiring H] [_root_.Bialgebra K H]
+/-- Two specializations of a domain-valued algebra homomorphism agree on an idempotent. -/
+theorem algHom_apply_eq_of_isIdempotentElem
+    {K H A : Type u} [CommSemiring K] [Semiring H] [Algebra K H]
     [CommSemiring A] [Algebra K A] [IsDomain A]
-    (e : H) (he : IsIdempotentElem e) (q : WithConv (H →ₐ[K] A))
+    (e : H) (he : IsIdempotentElem e) (q : H →ₐ[K] A)
     (phi psi : A →ₐ[K] K) :
-    (AlgHom.mapValue (H := H) phi q).ofConv e =
-      (AlgHom.mapValue (H := H) psi q).ofConv e := by
-  rcases IsIdempotentElem.iff_eq_zero_or_one.mp (he.map q.ofConv) with h | h <;>
-    simp [AlgHom.mapValue_apply, h]
+    phi (q e) = psi (q e) := by
+  rcases IsIdempotentElem.iff_eq_zero_or_one.mp (he.map q) with h | h <;> simp [h]
 
 /-- If a point of a finite-type Hopf algebra is connected to the identity by a path valued in a
 domain, its right translation fixes every idempotent. -/
@@ -112,8 +110,11 @@ theorem rightTranslationAlgHom_eq_self_of_path
     dsimp only [c]
     rw [← MonoidHom.comp_apply, ← AlgHom.mapValue_comp, hcomp,
       AlgHom.mapValue_id, MonoidHom.id_apply]
-  have hpath := mapValue_apply_eq_of_isIdempotentElem
-    (K := K) e he (c * x) phi psi
+  have hpath :
+      (AlgHom.mapValue (H := H) phi (c * x)).ofConv e =
+        (AlgHom.mapValue (H := H) psi (c * x)).ofConv e := by
+    simpa only [AlgHom.mapValue_apply, AlgHom.comp_apply] using
+      algHom_apply_eq_of_isIdempotentElem e he (c * x).ofConv phi psi
   rw [map_mul, hc phi, hphi] at hpath
   rw [map_mul, hc psi, hpsi, mul_one] at hpath
   calc

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/AlgebraicallyClosed.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/AlgebraicallyClosed.lean
@@ -7,8 +7,11 @@ module
 
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Translation
 import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+import Mathlib.Algebra.GroupWithZero.Idempotent
 import Mathlib.RingTheory.Flat.Basic
+import TauCeti.RingTheory.FiniteType.PointSeparation
 
 /-!
 # Testing geometric connectedness over algebraically closed fields
@@ -29,6 +32,10 @@ descends to the source by the idempotent characterization of connected affine sp
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty_iff_connectedSpace_of_isAlgClosed`:
   geometric connectedness is equivalent to connectedness after every algebraically closed field
   extension.
+* `TauCeti.HopfAlgebra.rightTranslationAlgHom_eq_self_of_path`: a domain-valued path from the
+  identity to a point makes that point's translation fix every idempotent.
+* `TauCeti.HopfAlgebra.connectedSpace_primeSpectrum_of_forall_rightTranslationAlgHom_eq_self`:
+  if every point translation fixes every idempotent, the spectrum is connected.
 
 ## References
 
@@ -41,6 +48,7 @@ connectedness using a chosen algebraic closure of the ground field.
 
 public section
 
+open WithConv
 open scoped TensorProduct
 
 namespace TauCeti
@@ -67,5 +75,83 @@ theorem geometricallyConnectedCommHopfAlgProperty_iff_connectedSpace_of_isAlgClo
     have hf : Function.Injective f :=
       Module.Flat.lTensor_preserves_injective_linearMap g.toLinearMap hg
     exact connectedSpace_primeSpectrum_of_injective f.toRingHom hf
+
+namespace HopfAlgebra
+
+/-- Two specializations of a domain-valued point agree on an idempotent. -/
+theorem mapValue_apply_eq_of_isIdempotentElem
+    {K H A : Type u} [CommSemiring K] [Semiring H] [_root_.Bialgebra K H]
+    [CommSemiring A] [Algebra K A] [IsDomain A]
+    (e : H) (he : IsIdempotentElem e) (q : WithConv (H →ₐ[K] A))
+    (phi psi : A →ₐ[K] K) :
+    (AlgHom.mapValue (H := H) phi q).ofConv e =
+      (AlgHom.mapValue (H := H) psi q).ofConv e := by
+  rcases IsIdempotentElem.iff_eq_zero_or_one.mp (he.map q.ofConv) with h | h <;>
+    simp [AlgHom.mapValue_apply, h]
+
+/-- If a point of a finite-type Hopf algebra is connected to the identity by a path valued in a
+domain, its right translation fixes every idempotent. -/
+theorem rightTranslationAlgHom_eq_self_of_path
+    {K H D : Type u} [Field K] [CommRing H] [_root_.HopfAlgebra K H]
+    [Algebra.FiniteType K H] [CommRing D] [Algebra K D] [IsDomain D]
+    [IsAlgClosed K] (e : H) (he : IsIdempotentElem e)
+    (g : WithConv (H →ₐ[K] K)) (x : WithConv (H →ₐ[K] D))
+    (phi psi : D →ₐ[K] K)
+    (hphi : AlgHom.mapValue (H := H) phi x = g)
+    (hpsi : AlgHom.mapValue (H := H) psi x = 1) :
+    rightTranslationAlgHom g e = e := by
+  apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
+    (k := K) (A := H) (K := K) (he.map _) he
+  intro f
+  let c : WithConv (H →ₐ[K] D) :=
+    AlgHom.mapValue (H := H) (IsScalarTower.toAlgHom K K D) (toConv f)
+  have hc (theta : D →ₐ[K] K) :
+      AlgHom.mapValue (H := H) theta c = toConv f := by
+    have hcomp : theta.comp (IsScalarTower.toAlgHom K K D) = AlgHom.id K K :=
+      AlgHom.ext fun z ↦ theta.commutes z
+    dsimp only [c]
+    rw [← MonoidHom.comp_apply, ← AlgHom.mapValue_comp, hcomp,
+      AlgHom.mapValue_id, MonoidHom.id_apply]
+  have hpath := mapValue_apply_eq_of_isIdempotentElem
+    (K := K) e he (c * x) phi psi
+  rw [map_mul, hc phi, hphi] at hpath
+  rw [map_mul, hc psi, hpsi, mul_one] at hpath
+  calc
+    f (rightTranslationAlgHom g e) = (toConv f * g).ofConv e :=
+      ofConv_rightTranslationAlgHom (toConv f) g e
+    _ = f e := hpath
+
+/-- If right translation by every rational point fixes every idempotent of a finite-type Hopf
+algebra over an algebraically closed field, its prime spectrum is connected. -/
+theorem connectedSpace_primeSpectrum_of_forall_rightTranslationAlgHom_eq_self
+    {K H : Type u} [Field K] [CommRing H] [_root_.HopfAlgebra K H]
+    [Algebra.FiniteType K H] [IsAlgClosed K]
+    (htranslate : ∀ (e : H), IsIdempotentElem e →
+      ∀ g : WithConv (H →ₐ[K] K), rightTranslationAlgHom g e = e) :
+    ConnectedSpace (PrimeSpectrum H) := by
+  let _ : Nontrivial H := Bialgebra.nontrivial (A := H) K
+  apply connectedSpace_primeSpectrum_iff_idempotent_eq_zero_or_one.mpr
+  intro e he
+  have heval (g : WithConv (H →ₐ[K] K)) :
+      g.ofConv e = Coalgebra.counit (R := K) e := by
+    have h := DFunLike.congr_fun (counitAlgHom_comp_rightTranslationAlgHom g) e
+    rw [AlgHom.comp_apply, htranslate e he g] at h
+    exact h.symm
+  rcases IsIdempotentElem.iff_eq_zero_or_one.mp
+    (he.map (_root_.Bialgebra.counitAlgHom K H)) with hzero | hone
+  · left
+    rw [Bialgebra.counitAlgHom_apply] at hzero
+    apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
+      (k := K) (A := H) (K := K) he IsIdempotentElem.zero
+    intro f
+    simpa using (heval (toConv f)).trans hzero
+  · right
+    rw [Bialgebra.counitAlgHom_apply] at hone
+    apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
+      (k := K) (A := H) (K := K) he IsIdempotentElem.one
+    intro f
+    simpa using (heval (toConv f)).trans hone
+
+end HopfAlgebra
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -65,7 +65,7 @@ theorem rightTranslationHomeomorph_kernelPoint
         (AlgHom.kernelPoint g.ofConv) = _
   rw [AlgHom.comap_kernelPoint, rightTranslationAlgEquiv_toAlgHom]
   congr 1
-  exact congrArg WithConv.ofConv (ofConv_comp_rightTranslationAlgHom g h)
+  exact congrArg WithConv.ofConv (toConv_comp_rightTranslationAlgHom g h)
 
 /-- Right translation transports the connected component of a point to the connected component
 of its translate. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Translation.lean
@@ -65,17 +65,7 @@ theorem rightTranslationHomeomorph_kernelPoint
         (AlgHom.kernelPoint g.ofConv) = _
   rw [AlgHom.comap_kernelPoint, rightTranslationAlgEquiv_toAlgHom]
   congr 1
-  ext x
-  -- Composition of algebra homomorphisms must be exposed at application level before the
-  -- translation formula can rewrite it.
-  change g.ofConv (rightTranslationAlgHom h x) = (g * h).ofConv x
-  rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
-  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
-  | zero => simp
-  | add x y hx hy => simp [hx, hy]
-  | tmul x y =>
-      simp [TensorProduct.map_tmul, TensorProduct.rid_tmul,
-        Algebra.TensorProduct.lift_tmul, Algebra.smul_def, mul_comm]
+  exact congrArg WithConv.ofConv (ofConv_comp_rightTranslationAlgHom g h)
 
 /-- Right translation transports the connected component of a point to the connected component
 of its translate. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Parabolic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Parabolic.lean
@@ -206,11 +206,12 @@ variable (A) in
 evaluated at the tautological point `T` of the multiplicative group. -/
 noncomputable def genericPoint (l : H →ₐc[R] LaurentPolynomial R) :
     WithConv (H →ₐ[R] LaurentPolynomial A) :=
-  pointsHom (LaurentPolynomial A) l (genericUnit A)
+  pointsHom (LaurentPolynomial A) l (MultiplicativeGroup.genericUnit A)
 
 /-- The generic point is the value of the cocharacter at the generic unit `T`. -/
 theorem genericPoint_eq_pointsHom (l : H →ₐc[R] LaurentPolynomial R) :
-    genericPoint A l = pointsHom (LaurentPolynomial A) l (genericUnit A) := by
+    genericPoint A l =
+      pointsHom (LaurentPolynomial A) l (MultiplicativeGroup.genericUnit A) := by
   rw [genericPoint]
 
 variable (A) in
@@ -246,8 +247,14 @@ theorem mapValue_pointsHom (u : Aˣ) :
 
 /-- The induced map on Laurent coefficient algebras fixes the Laurent variable. -/
 theorem map_genericUnit :
-    Units.map (AddMonoidAlgebra.mapAlgHom ℤ φ).toMonoidHom (genericUnit A) = genericUnit B :=
-  Units.ext ((AddMonoidAlgebra.mapAlgHom_single φ (1 : ℤ) 1).trans (by rw [map_one]; rfl))
+    Units.map (AddMonoidAlgebra.mapAlgHom ℤ φ).toMonoidHom
+        (MultiplicativeGroup.genericUnit A) = MultiplicativeGroup.genericUnit B := by
+  apply Units.ext
+  change (AddMonoidAlgebra.mapAlgHom ℤ φ)
+      (MultiplicativeGroup.genericUnit A : LaurentPolynomial A) =
+    (MultiplicativeGroup.genericUnit B : LaurentPolynomial B)
+  rw [MultiplicativeGroup.genericUnit_val, MultiplicativeGroup.genericUnit_val,
+    mapAlgHom_T]
 
 /-- The constant-point inclusion is natural in the value algebra. -/
 theorem mapValue_constPoint (g : WithConv (H →ₐ[R] A)) :
@@ -266,9 +273,9 @@ theorem mapValue_genericPoint :
 theorem mapValue_conjugate {C : Type*} [CommSemiring C] [Algebra R C]
     (ψ : LaurentPolynomial A →ₐ[R] C) (g : WithConv (H →ₐ[R] A)) :
     AlgHom.mapValue ψ (conjugate A l g) =
-      pointsHom C l (Units.map ψ.toMonoidHom (genericUnit A)) *
+      pointsHom C l (Units.map ψ.toMonoidHom (MultiplicativeGroup.genericUnit A)) *
         AlgHom.mapValue (ψ.comp (IsScalarTower.toAlgHom R A (LaurentPolynomial A))) g *
-        (pointsHom C l (Units.map ψ.toMonoidHom (genericUnit A)))⁻¹ := by
+        (pointsHom C l (Units.map ψ.toMonoidHom (MultiplicativeGroup.genericUnit A)))⁻¹ := by
   rw [conjugate_apply, map_mul, map_mul, map_inv, genericPoint, mapValue_pointsHom, constPoint,
     AlgHom.mapValue_comp, MonoidHom.comp_apply]
 
@@ -403,7 +410,8 @@ theorem pointsHom_mem_levi (u : Aˣ) : pointsHom A l u ∈ levi A l := by
   have h : constPoint A (pointsHom A l u) = pointsHom (LaurentPolynomial A) l v :=
     mapValue_pointsHom _ l u
   rw [mem_levi_iff, conjugate_apply, h, genericPoint,
-    (pointsHom_commute (A := LaurentPolynomial A) l (genericUnit A) v).eq, mul_assoc,
+    (pointsHom_commute (A := LaurentPolynomial A) l (MultiplicativeGroup.genericUnit A) v).eq,
+    mul_assoc,
     mul_inv_cancel, mul_one]
 
 /-- For a commutative affine group every point is fixed by conjugation, so the dynamic Levi
@@ -494,8 +502,9 @@ variable (R A) in
 /-- The unit `T · T'` of `A[T;T⁻¹][T';T'⁻¹]`, the product of the two Laurent variables. -/
 private noncomputable def prodUnit : (LaurentPolynomial (LaurentPolynomial A))ˣ :=
   Units.map (IsScalarTower.toAlgHom R (LaurentPolynomial A)
-      (LaurentPolynomial (LaurentPolynomial A))).toMonoidHom (genericUnit A) *
-    genericUnit (LaurentPolynomial A)
+      (LaurentPolynomial (LaurentPolynomial A))).toMonoidHom
+        (MultiplicativeGroup.genericUnit A) *
+    MultiplicativeGroup.genericUnit (LaurentPolynomial A)
 
 variable (R A) in
 /-- The substitution `T ↦ T · T'`, as an `R`-algebra homomorphism
@@ -530,8 +539,12 @@ private theorem prodSubst_T :
   (MultiplicativeGroup.point_T (R := A) (prodUnit R A) 1).trans (by rw [zpow_one])
 
 private theorem map_prodSubst_genericUnit :
-    Units.map (prodSubst R A).toMonoidHom (genericUnit A) = prodUnit R A :=
-  Units.ext prodSubst_T
+    Units.map (prodSubst R A).toMonoidHom (MultiplicativeGroup.genericUnit A) = prodUnit R A :=
+  Units.ext (by
+    change prodSubst R A
+        (MultiplicativeGroup.genericUnit A : LaurentPolynomial A) = prodUnit R A
+    rw [MultiplicativeGroup.genericUnit_val]
+    exact prodSubst_T)
 
 private theorem prodSubst_comp_const :
     (prodSubst R A).comp (IsScalarTower.toAlgHom R A (LaurentPolynomial A)) =
@@ -588,8 +601,9 @@ theorem limit_mem_levi (g : parabolic A l) : limit A l g ∈ levi A l := by
     rw [hl, hr, conjugate_apply, constPoint, mapValue_conjugate, genericPoint, conj_conj, ← map_mul,
       mapValue_conjugate, map_prodSubst_genericUnit, prodSubst_comp_const, prodUnit,
       mul_comm (Units.map (IsScalarTower.toAlgHom R (LaurentPolynomial A)
-        (LaurentPolynomial (LaurentPolynomial A))).toMonoidHom (genericUnit A))
-        (genericUnit (LaurentPolynomial A))]
+        (LaurentPolynomial (LaurentPolynomial A))).toMonoidHom
+          (MultiplicativeGroup.genericUnit A))
+        (MultiplicativeGroup.genericUnit (LaurentPolynomial A))]
   -- Specialize the generic identity at `X = 0`.
   rw [mem_levi_iff, limit_apply, evalZeroPoint, constPoint, ← mapValue_conjugate_mapAlgHom, key,
     ← MonoidHom.comp_apply, ← AlgHom.mapValue_comp, mapAlgHom_evalZero_comp_scaleSubst,

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Parabolic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Parabolic.lean
@@ -250,11 +250,9 @@ theorem map_genericUnit :
     Units.map (AddMonoidAlgebra.mapAlgHom ℤ φ).toMonoidHom
         (MultiplicativeGroup.genericUnit A) = MultiplicativeGroup.genericUnit B := by
   apply Units.ext
-  change (AddMonoidAlgebra.mapAlgHom ℤ φ)
-      (MultiplicativeGroup.genericUnit A : LaurentPolynomial A) =
-    (MultiplicativeGroup.genericUnit B : LaurentPolynomial B)
-  rw [MultiplicativeGroup.genericUnit_val, MultiplicativeGroup.genericUnit_val,
-    mapAlgHom_T]
+  rw [Units.coe_map, MultiplicativeGroup.genericUnit_val,
+    MultiplicativeGroup.genericUnit_val]
+  exact mapAlgHom_T φ 1
 
 /-- The constant-point inclusion is natural in the value algebra. -/
 theorem mapValue_constPoint (g : WithConv (H →ₐ[R] A)) :
@@ -541,9 +539,7 @@ private theorem prodSubst_T :
 private theorem map_prodSubst_genericUnit :
     Units.map (prodSubst R A).toMonoidHom (MultiplicativeGroup.genericUnit A) = prodUnit R A :=
   Units.ext (by
-    change prodSubst R A
-        (MultiplicativeGroup.genericUnit A : LaurentPolynomial A) = prodUnit R A
-    rw [MultiplicativeGroup.genericUnit_val]
+    rw [Units.coe_map, MultiplicativeGroup.genericUnit_val]
     exact prodSubst_T)
 
 private theorem prodSubst_comp_const :

--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Parabolic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Parabolic.lean
@@ -181,17 +181,6 @@ theorem evalZeroPoint_constPolyPoint (g : WithConv (H →ₐ[R] A)) :
 /-! ### The generic point of a cocharacter and conjugation by it -/
 
 variable (A) in
-/-- The Laurent variable `T`, as a unit of `A[T;T⁻¹]`. It is the tautological `A[T;T⁻¹]`-point of
-the multiplicative group. -/
-noncomputable def genericUnit : (LaurentPolynomial A)ˣ :=
-  unitOfInvertible (LaurentPolynomial.T 1)
-
-/-- The generic unit is the Laurent variable `T`. -/
-@[simp]
-theorem genericUnit_val : (genericUnit A : LaurentPolynomial A) = LaurentPolynomial.T 1 := by
-  simp [genericUnit]
-
-variable (A) in
 /-- **A cocharacter on points**: the group homomorphism `𝔾ₘ(A) = Aˣ → G(A)` obtained from a
 cocharacter `l : 𝔾ₘ → G`, presented contravariantly as a bialgebra homomorphism
 `H →ₐc[R] R[T;T⁻¹]`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Basic.lean
@@ -83,21 +83,21 @@ theorem pointsMulEquiv_pointsHom_weightCocharacter (w : Fin N → ℤ) (t : Aˣ)
 theorem pointsMulEquiv_conjugate_weightCocharacter (w : Fin N → ℤ)
     (g : WithConv (coordinateHopfAlgebra R N →ₐ[R] A)) :
     pointsMulEquiv N (Cocharacter.conjugate A (weightCocharacter (R := R) w) g) =
-      diagGL (weightDiagonalUnits w (Cocharacter.genericUnit A)) *
+      diagGL (weightDiagonalUnits w (MultiplicativeGroup.genericUnit A)) *
         Matrix.GeneralLinearGroup.map
           (IsScalarTower.toAlgHom R A (LaurentPolynomial A)).toRingHom
           (pointsMulEquiv N g) *
-        (diagGL (weightDiagonalUnits w (Cocharacter.genericUnit A)))⁻¹ := by
+        (diagGL (weightDiagonalUnits w (MultiplicativeGroup.genericUnit A)))⁻¹ := by
   rw [Cocharacter.conjugate_apply, map_mul, map_mul, map_inv,
     Cocharacter.genericPoint_eq_pointsHom,
     pointsMulEquiv_pointsHom_weightCocharacter, Cocharacter.constPoint_apply,
     ← AlgHom.mapValue_apply, pointsMulEquiv_mapValue]
 
 private theorem genericUnit_zpow_val (n : ℤ) :
-    ((Cocharacter.genericUnit A ^ n : (LaurentPolynomial A)ˣ) : LaurentPolynomial A) =
+    ((MultiplicativeGroup.genericUnit A ^ n : (LaurentPolynomial A)ˣ) : LaurentPolynomial A) =
       LaurentPolynomial.T n := by
   let f : LaurentPolynomial A →ₐ[A] LaurentPolynomial A := AlgHom.id A _
-  have hunit : Cocharacter.genericUnit A = MultiplicativeGroup.unitOfPoint f := by
+  have hunit : MultiplicativeGroup.genericUnit A = MultiplicativeGroup.unitOfPoint f := by
     apply Units.ext
     simp [f]
   rw [hunit, ← MultiplicativeGroup.point_T (R := A)]
@@ -116,7 +116,7 @@ theorem pointsMulEquiv_conjugate_weightCocharacter_apply (w : Fin N → ℤ)
     Matrix.diagonal_mul, Matrix.mul_diagonal, Matrix.GeneralLinearGroup.map_apply,
     Pi.inv_apply, weightDiagonalUnits_apply]
   have hinv :
-      (((Cocharacter.genericUnit A ^ w j)⁻¹ : (LaurentPolynomial A)ˣ) :
+      (((MultiplicativeGroup.genericUnit A ^ w j)⁻¹ : (LaurentPolynomial A)ˣ) :
           LaurentPolynomial A) = LaurentPolynomial.T (-w j) := by
     rw [← zpow_neg, genericUnit_zpow_val]
   rw [genericUnit_zpow_val]
@@ -124,7 +124,7 @@ theorem pointsMulEquiv_conjugate_weightCocharacter_apply (w : Fin N → ℤ)
   -- neither wrapper has an application lemma at this expression.
   change LaurentPolynomial.T (w i) *
       LaurentPolynomial.C ((pointsMulEquiv N g : Matrix (Fin N) (Fin N) A) i j) *
-        (((Cocharacter.genericUnit A ^ w j)⁻¹ : (LaurentPolynomial A)ˣ) :
+        (((MultiplicativeGroup.genericUnit A ^ w j)⁻¹ : (LaurentPolynomial A)ˣ) :
           LaurentPolynomial A) = _
   rw [hinv, LaurentPolynomial.T_mul, LaurentPolynomial.mul_T_assoc, ← sub_eq_add_neg]
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Basic.lean
@@ -93,16 +93,6 @@ theorem pointsMulEquiv_conjugate_weightCocharacter (w : Fin N → ℤ)
     pointsMulEquiv_pointsHom_weightCocharacter, Cocharacter.constPoint_apply,
     ← AlgHom.mapValue_apply, pointsMulEquiv_mapValue]
 
-private theorem genericUnit_zpow_val (n : ℤ) :
-    ((MultiplicativeGroup.genericUnit A ^ n : (LaurentPolynomial A)ˣ) : LaurentPolynomial A) =
-      LaurentPolynomial.T n := by
-  let f : LaurentPolynomial A →ₐ[A] LaurentPolynomial A := AlgHom.id A _
-  have hunit : MultiplicativeGroup.genericUnit A = MultiplicativeGroup.unitOfPoint f := by
-    apply Units.ext
-    simp [f]
-  rw [hunit, ← MultiplicativeGroup.point_T (R := A)]
-  exact DFunLike.congr_fun (MultiplicativeGroup.point_unitOfPoint f) (LaurentPolynomial.T n)
-
 /-- The `(i,j)` entry of conjugation by the weight cocharacter is
 `g_ij * T ^ (w i - w j)`. -/
 theorem pointsMulEquiv_conjugate_weightCocharacter_apply (w : Fin N → ℤ)
@@ -118,8 +108,8 @@ theorem pointsMulEquiv_conjugate_weightCocharacter_apply (w : Fin N → ℤ)
   have hinv :
       (((MultiplicativeGroup.genericUnit A ^ w j)⁻¹ : (LaurentPolynomial A)ˣ) :
           LaurentPolynomial A) = LaurentPolynomial.T (-w j) := by
-    rw [← zpow_neg, genericUnit_zpow_val]
-  rw [genericUnit_zpow_val]
+    rw [← zpow_neg, MultiplicativeGroup.genericUnit_zpow_val]
+  rw [MultiplicativeGroup.genericUnit_zpow_val]
   -- Normalize the pointwise inverse of the diagonal function and the scalar-extension map;
   -- neither wrapper has an application lemma at this expression.
   change LaurentPolynomial.T (w i) *

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
@@ -72,6 +72,18 @@ theorem rightTranslationAlgHom_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
   | add z w hz hw => simp [hz, hw]
   | tmul z w => simp [Algebra.smul_def, mul_comm]
 
+/-- Composing a point with right translation is convolution by the translating point. -/
+theorem ofConv_comp_rightTranslationAlgHom (f g : WithConv (H →ₐ[k] k)) :
+    WithConv.toConv (f.ofConv.comp (rightTranslationAlgHom g)) = f * g := by
+  apply WithConv.ofConv_injective
+  ext x
+  change f.ofConv (rightTranslationAlgHom g x) = (f * g).ofConv x
+  rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
+  induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
+  | zero => simp
+  | add y z hy hz => simp [hy, hz]
+  | tmul y z => simp [Algebra.smul_def, mul_comm]
+
 /-- The linear equivalence underlying right translation. -/
 private noncomputable def rightTranslationLinearEquiv (g : WithConv (H →ₐ[k] k)) :
     H ≃ₗ[k] H :=

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
@@ -198,26 +198,24 @@ theorem rightTranslationAlgEquiv_mul (g h : WithConv (H →ₐ[k] k)) :
 
 /-- Translation by the identity point is the identity algebra endomorphism. -/
 @[simp]
-theorem rightTranslationAlgHom_one (x : H) :
-    rightTranslationAlgHom (1 : WithConv (H →ₐ[k] k)) x = x := by
-  rw [← DFunLike.congr_fun
-    (rightTranslationAlgEquiv_toAlgHom (1 : WithConv (H →ₐ[k] k))) x,
-    rightTranslationAlgEquiv_one]
+theorem rightTranslationAlgHom_one :
+    rightTranslationAlgHom (1 : WithConv (H →ₐ[k] k)) = AlgHom.id k H := by
+  rw [← rightTranslationAlgEquiv_toAlgHom, rightTranslationAlgEquiv_one]
   rfl
 
 /-- Translation by a convolution product is the composite of the two translation algebra
 endomorphisms. -/
 @[simp]
-theorem rightTranslationAlgHom_mul (g h : WithConv (H →ₐ[k] k)) (x : H) :
-    rightTranslationAlgHom (g * h) x =
-      rightTranslationAlgHom g (rightTranslationAlgHom h x) := by
-  rw [← DFunLike.congr_fun (rightTranslationAlgEquiv_toAlgHom (g * h)) x,
-    rightTranslationAlgEquiv_mul]
-  change rightTranslationAlgEquiv g (rightTranslationAlgEquiv h x) =
-    rightTranslationAlgHom g (rightTranslationAlgHom h x)
+theorem rightTranslationAlgHom_mul (g h : WithConv (H →ₐ[k] k)) :
+    rightTranslationAlgHom (g * h) =
+      (rightTranslationAlgHom g).comp (rightTranslationAlgHom h) := by
+  ext x
   calc
-    rightTranslationAlgEquiv g (rightTranslationAlgEquiv h x) =
-        rightTranslationAlgHom g (rightTranslationAlgEquiv h x) :=
+    rightTranslationAlgHom (g * h) x = rightTranslationAlgEquiv (g * h) x :=
+      (DFunLike.congr_fun (rightTranslationAlgEquiv_toAlgHom (g * h)) x).symm
+    _ = rightTranslationAlgEquiv g (rightTranslationAlgEquiv h x) :=
+      DFunLike.congr_fun (rightTranslationAlgEquiv_mul g h) x
+    _ = rightTranslationAlgHom g (rightTranslationAlgEquiv h x) :=
       DFunLike.congr_fun (rightTranslationAlgEquiv_toAlgHom g) _
     _ = rightTranslationAlgHom g (rightTranslationAlgHom h x) :=
       congrArg (rightTranslationAlgHom g)

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
@@ -75,7 +75,7 @@ theorem rightTranslationAlgHom_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
 
 /-- Composing a point with right translation is convolution by the translating point. -/
 @[simp]
-theorem ofConv_comp_rightTranslationAlgHom (f g : WithConv (H →ₐ[k] k)) :
+theorem toConv_comp_rightTranslationAlgHom (f g : WithConv (H →ₐ[k] k)) :
     WithConv.toConv (f.ofConv.comp (rightTranslationAlgHom g)) = f * g := by
   apply WithConv.ofConv_injective
   ext x
@@ -92,7 +92,7 @@ theorem ofConv_comp_rightTranslationAlgHom (f g : WithConv (H →ₐ[k] k)) :
 theorem ofConv_rightTranslationAlgHom (f g : WithConv (H →ₐ[k] k)) (x : H) :
     f.ofConv (rightTranslationAlgHom g x) = (f * g).ofConv x := by
   exact DFunLike.congr_fun
-    (congrArg WithConv.ofConv (ofConv_comp_rightTranslationAlgHom f g)) x
+    (congrArg WithConv.ofConv (toConv_comp_rightTranslationAlgHom f g)) x
 
 /-- The linear equivalence underlying right translation. -/
 private noncomputable def rightTranslationLinearEquiv (g : WithConv (H →ₐ[k] k)) :

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/Translation.lean
@@ -26,7 +26,8 @@ action laws, and identifies its action on the prime spectrum.
 
 * `TauCeti.HopfAlgebra.rightTranslationAlgHom`: pullback by right translation by a point.
 * `TauCeti.HopfAlgebra.rightTranslationAlgEquiv`: right translation as an algebra automorphism.
-* `TauCeti.HopfAlgebra.rightTranslationAlgEquiv_mul`: right translation respects the convolution
+* `TauCeti.HopfAlgebra.rightTranslationAlgEquiv_mul` and
+  `TauCeti.HopfAlgebra.rightTranslationAlgHom_mul`: right translation respects the convolution
   product of points.
 * `TauCeti.HopfAlgebra.comap_rightTranslationAlgEquiv_augmentationPoint`: the translated counit
   point is the given point.
@@ -73,16 +74,25 @@ theorem rightTranslationAlgHom_apply (g : WithConv (H →ₐ[k] k)) (x : H) :
   | tmul z w => simp [Algebra.smul_def, mul_comm]
 
 /-- Composing a point with right translation is convolution by the translating point. -/
+@[simp]
 theorem ofConv_comp_rightTranslationAlgHom (f g : WithConv (H →ₐ[k] k)) :
     WithConv.toConv (f.ofConv.comp (rightTranslationAlgHom g)) = f * g := by
   apply WithConv.ofConv_injective
   ext x
+  -- Composition must be exposed at application level before the translation formula rewrites.
   change f.ofConv (rightTranslationAlgHom g x) = (f * g).ofConv x
   rw [rightTranslationAlgHom_apply, AlgHom.convMul_apply]
   induction Coalgebra.comul (R := k) x using TensorProduct.induction_on with
   | zero => simp
   | add y z hy hz => simp [hy, hz]
   | tmul y z => simp [Algebra.smul_def, mul_comm]
+
+/-- Applying a point to a right-translated function is convolution by the translating point. -/
+@[simp]
+theorem ofConv_rightTranslationAlgHom (f g : WithConv (H →ₐ[k] k)) (x : H) :
+    f.ofConv (rightTranslationAlgHom g x) = (f * g).ofConv x := by
+  exact DFunLike.congr_fun
+    (congrArg WithConv.ofConv (ofConv_comp_rightTranslationAlgHom f g)) x
 
 /-- The linear equivalence underlying right translation. -/
 private noncomputable def rightTranslationLinearEquiv (g : WithConv (H →ₐ[k] k)) :
@@ -185,6 +195,33 @@ theorem rightTranslationAlgEquiv_mul (g h : WithConv (H →ₐ[k] k)) :
         (rightTranslationAlgEquiv h x)).symm
     _ = (rightTranslationAlgEquiv g * rightTranslationAlgEquiv h) x :=
       (AlgEquiv.mul_apply _ _ x).symm
+
+/-- Translation by the identity point is the identity algebra endomorphism. -/
+@[simp]
+theorem rightTranslationAlgHom_one (x : H) :
+    rightTranslationAlgHom (1 : WithConv (H →ₐ[k] k)) x = x := by
+  rw [← DFunLike.congr_fun
+    (rightTranslationAlgEquiv_toAlgHom (1 : WithConv (H →ₐ[k] k))) x,
+    rightTranslationAlgEquiv_one]
+  rfl
+
+/-- Translation by a convolution product is the composite of the two translation algebra
+endomorphisms. -/
+@[simp]
+theorem rightTranslationAlgHom_mul (g h : WithConv (H →ₐ[k] k)) (x : H) :
+    rightTranslationAlgHom (g * h) x =
+      rightTranslationAlgHom g (rightTranslationAlgHom h x) := by
+  rw [← DFunLike.congr_fun (rightTranslationAlgEquiv_toAlgHom (g * h)) x,
+    rightTranslationAlgEquiv_mul]
+  change rightTranslationAlgEquiv g (rightTranslationAlgEquiv h x) =
+    rightTranslationAlgHom g (rightTranslationAlgHom h x)
+  calc
+    rightTranslationAlgEquiv g (rightTranslationAlgEquiv h x) =
+        rightTranslationAlgHom g (rightTranslationAlgEquiv h x) :=
+      DFunLike.congr_fun (rightTranslationAlgEquiv_toAlgHom g) _
+    _ = rightTranslationAlgHom g (rightTranslationAlgHom h x) :=
+      congrArg (rightTranslationAlgHom g)
+        (DFunLike.congr_fun (rightTranslationAlgEquiv_toAlgHom h) x)
 
 /-- Translation by an inverse point is the inverse algebra automorphism. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Basic.lean
@@ -29,6 +29,7 @@ group" and the listed example `𝔾_m`.
   equivalence from the convolution group to `Aˣ`.
 * `TauCeti.MultiplicativeGroup.pointsMulEquiv_mapValue`: the points equivalence is natural
   in the value algebra.
+* `TauCeti.Cocharacter.genericUnit`: the tautological unit `T` of a Laurent polynomial ring.
 
 ## References
 
@@ -235,5 +236,21 @@ theorem mapValue_pointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : Aˣ) :
 end Naturality
 
 end MultiplicativeGroup
+
+namespace Cocharacter
+
+variable (A : Type v) [CommSemiring A]
+
+/-- The Laurent variable `T`, as a unit of `A[T;T⁻¹]`. It is the tautological
+`A[T;T⁻¹]`-point of the multiplicative group. -/
+@[expose] noncomputable def genericUnit : (LaurentPolynomial A)ˣ :=
+  unitOfInvertible (LaurentPolynomial.T 1)
+
+/-- The generic unit is the Laurent variable `T`. -/
+@[simp]
+theorem genericUnit_val : (genericUnit A : LaurentPolynomial A) = LaurentPolynomial.T 1 := by
+  simp [genericUnit]
+
+end Cocharacter
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Basic.lean
@@ -29,7 +29,8 @@ group" and the listed example `𝔾_m`.
   equivalence from the convolution group to `Aˣ`.
 * `TauCeti.MultiplicativeGroup.pointsMulEquiv_mapValue`: the points equivalence is natural
   in the value algebra.
-* `TauCeti.Cocharacter.genericUnit`: the tautological unit `T` of a Laurent polynomial ring.
+* `TauCeti.MultiplicativeGroup.genericUnit`: the tautological unit `T` of a Laurent polynomial
+  ring.
 
 ## References
 
@@ -235,15 +236,11 @@ theorem mapValue_pointsMulEquiv_symm_apply (φ : A →ₐ[R] B) (u : Aˣ) :
 
 end Naturality
 
-end MultiplicativeGroup
-
-namespace Cocharacter
-
 variable (A : Type v) [CommSemiring A]
 
 /-- The Laurent variable `T`, as a unit of `A[T;T⁻¹]`. It is the tautological
 `A[T;T⁻¹]`-point of the multiplicative group. -/
-@[expose] noncomputable def genericUnit : (LaurentPolynomial A)ˣ :=
+noncomputable def genericUnit : (LaurentPolynomial A)ˣ :=
   unitOfInvertible (LaurentPolynomial.T 1)
 
 /-- The generic unit is the Laurent variable `T`. -/
@@ -251,6 +248,21 @@ variable (A : Type v) [CommSemiring A]
 theorem genericUnit_val : (genericUnit A : LaurentPolynomial A) = LaurentPolynomial.T 1 := by
   simp [genericUnit]
 
-end Cocharacter
+/-- The inverse of the generic unit is the inverse Laurent variable. -/
+@[simp]
+theorem genericUnit_inv : (((genericUnit A)⁻¹ : (LaurentPolynomial A)ˣ) :
+    LaurentPolynomial A) = LaurentPolynomial.T (-1) := by
+  simp [genericUnit]
+
+/-- Mapping the generic unit along a Laurent-polynomial point gives the unit represented by
+that point. -/
+@[simp]
+theorem map_genericUnit {B : Type w} [CommSemiring B] [Algebra A B]
+    (φ : A[T;T⁻¹] →ₐ[A] B) :
+    Units.map φ (genericUnit A) = unitOfPoint φ := by
+  apply Units.ext
+  simp
+
+end MultiplicativeGroup
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/MultiplicativeGroup/Basic.lean
@@ -254,6 +254,18 @@ theorem genericUnit_inv : (((genericUnit A)⁻¹ : (LaurentPolynomial A)ˣ) :
     LaurentPolynomial A) = LaurentPolynomial.T (-1) := by
   simp [genericUnit]
 
+/-- An integer power of the generic unit is the corresponding Laurent monomial. -/
+@[simp]
+theorem genericUnit_zpow_val (n : ℤ) :
+    ((genericUnit A ^ n : (LaurentPolynomial A)ˣ) : LaurentPolynomial A) =
+      LaurentPolynomial.T n := by
+  let f : LaurentPolynomial A →ₐ[A] LaurentPolynomial A := AlgHom.id A _
+  have hunit : genericUnit A = unitOfPoint f := by
+    apply Units.ext
+    simp [f]
+  rw [hunit, ← point_T (R := A)]
+  exact DFunLike.congr_fun (point_unitOfPoint f) (LaurentPolynomial.T n)
+
 /-- Mapping the generic unit along a Laurent-polynomial point gives the unit represented by
 that point. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
@@ -230,6 +230,12 @@ theorem finiteTypeCoordinateHopfAlgebra_obj :
     (finiteTypeCoordinateHopfAlgebra R n).obj = coordinateHopfAlgebra R n :=
   by rw [finiteTypeCoordinateHopfAlgebra]
 
+/-- The special-linear coordinate Hopf algebra carries the finite-type instance recorded by its
+bundled finite-type coordinate algebra. -/
+instance instAlgebraFiniteTypeCoordinateHopfAlgebra :
+    Algebra.FiniteType R (coordinateHopfAlgebra R n) := by
+  exact Algebra.FiniteType.quotient R (definingHopfIdeal R n).toIdeal
+
 /-! ### Algebra-valued points -/
 
 section Points

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Basic.lean
@@ -230,11 +230,11 @@ theorem finiteTypeCoordinateHopfAlgebra_obj :
     (finiteTypeCoordinateHopfAlgebra R n).obj = coordinateHopfAlgebra R n :=
   by rw [finiteTypeCoordinateHopfAlgebra]
 
-/-- The special-linear coordinate Hopf algebra carries the finite-type instance recorded by its
-bundled finite-type coordinate algebra. -/
+/-- The special-linear coordinate Hopf algebra is a finite-type `R`-algebra, being a quotient of
+the finite-type general-linear coordinate Hopf algebra. -/
 instance instAlgebraFiniteTypeCoordinateHopfAlgebra :
-    Algebra.FiniteType R (coordinateHopfAlgebra R n) := by
-  exact Algebra.FiniteType.quotient R (definingHopfIdeal R n).toIdeal
+    Algebra.FiniteType R (coordinateHopfAlgebra R n) :=
+  Algebra.FiniteType.quotient R (definingHopfIdeal R n).toIdeal
 
 /-! ### Algebra-valued points -/
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
@@ -9,7 +9,6 @@ public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
 public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
 import TauCeti.Algebra.AlgebraicGroup.BaseChange.Naturality
 import TauCeti.Algebra.AlgebraicGroup.Connected.AlgebraicallyClosed
-import TauCeti.Algebra.AlgebraicGroup.Hopf.Translation
 import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.DiagonalPath
 import Mathlib.RingTheory.FiniteStability
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Transvection
@@ -193,13 +192,13 @@ private theorem rightTranslationAlgHom_eq_self
             rw [map_mul]
           _ = HopfAlgebra.rightTranslationAlgHom (E.symm A)
               (HopfAlgebra.rightTranslationAlgHom (E.symm B) e) :=
-            HopfAlgebra.rightTranslationAlgHom_mul _ _ _
+            DFunLike.congr_fun (HopfAlgebra.rightTranslationAlgHom_mul _ _) e
           _ = e := by rw [hB, hA]
     simpa [P] using hp
   · let _ : Subsingleton (Fin n) := not_nontrivial_iff_subsingleton.mp h
     have hmatrix : E g = 1 := Subsingleton.elim _ _
     have hg : g = 1 := E.injective (by simpa using hmatrix)
-    rw [hg, HopfAlgebra.rightTranslationAlgHom_one]
+    rw [hg, HopfAlgebra.rightTranslationAlgHom_one, AlgHom.id_apply]
 
 /-- The coordinate Hopf algebra of `SLₙ` is geometrically connected over every field. -/
 theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
@@ -54,10 +54,6 @@ noncomputable section
 
 variable {k K : Type u} [Field k] [Field K] [Algebra k K]
 
-private noncomputable instance instFiniteTypeCoordinateHopfAlgebra (n : ℕ) :
-    Algebra.FiniteType k (coordinateHopfAlgebra k n) := by
-  exact Algebra.FiniteType.quotient k (definingHopfIdeal k n).toIdeal
-
 /-- Base-changed special-linear points identified with determinant-one matrices. -/
 private def baseChangeSpecialLinearPointsMulEquiv
     (n : ℕ) (A : Type u) [CommRing A] [Algebra k A] [Algebra K A]
@@ -84,19 +80,6 @@ private theorem baseChangeSpecialLinearPointsMulEquiv_mapValue
   exact pointsMulEquiv_mapValue (R := k) (A := A) (B := B) n
     (phi.restrictScalars k) _
 
-private theorem point_comp_rightTranslationAlgHom
-    {H : Type u} [CommRing H] [_root_.HopfAlgebra K H]
-    (f g : WithConv (H →ₐ[K] K)) :
-    toConv (f.ofConv.comp (HopfAlgebra.rightTranslationAlgHom g)) = f * g := by
-  apply WithConv.ofConv_injective
-  ext x
-  change f.ofConv (HopfAlgebra.rightTranslationAlgHom g x) = (f * g).ofConv x
-  rw [HopfAlgebra.rightTranslationAlgHom_apply, AlgHom.convMul_apply]
-  induction Coalgebra.comul (R := K) x using TensorProduct.induction_on with
-  | zero => simp
-  | add y z hy hz => simp [hy, hz]
-  | tmul y z => simp [Algebra.smul_def, mul_comm]
-
 private theorem mapValue_apply_eq_of_isIdempotentElem
     {H A : Type u} [CommRing H] [_root_.HopfAlgebra K H]
     [CommRing A] [Algebra K A] [IsDomain A]
@@ -107,21 +90,45 @@ private theorem mapValue_apply_eq_of_isIdempotentElem
   rcases IsIdempotentElem.iff_eq_zero_or_one.mp (he.map q.ofConv) with h | h <;>
     simp [AlgHom.mapValue_apply, h]
 
+private theorem rightTranslationAlgHom_eq_self_of_path
+    {H D : Type u} [CommRing H] [_root_.HopfAlgebra K H]
+    [Algebra.FiniteType K H] [CommRing D] [Algebra K D] [IsDomain D]
+    [IsAlgClosed K] (e : H) (he : IsIdempotentElem e)
+    (g : WithConv (H →ₐ[K] K)) (x : WithConv (H →ₐ[K] D))
+    (phi psi : D →ₐ[K] K)
+    (hphi : AlgHom.mapValue (H := H) phi x = g)
+    (hpsi : AlgHom.mapValue (H := H) psi x = 1) :
+    HopfAlgebra.rightTranslationAlgHom g e = e := by
+  apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
+    (k := K) (A := H) (K := K) (he.map _) he
+  intro f
+  let c : WithConv (H →ₐ[K] D) :=
+    AlgHom.mapValue (H := H) (IsScalarTower.toAlgHom K K D) (toConv f)
+  have hc (theta : D →ₐ[K] K) :
+      AlgHom.mapValue (H := H) theta c = toConv f := by
+    have hcomp : theta.comp (IsScalarTower.toAlgHom K K D) = AlgHom.id K K :=
+      AlgHom.ext fun z ↦ theta.commutes z
+    dsimp only [c]
+    rw [← MonoidHom.comp_apply, ← AlgHom.mapValue_comp, hcomp,
+      AlgHom.mapValue_id, MonoidHom.id_apply]
+  have hpath := mapValue_apply_eq_of_isIdempotentElem
+    (K := K) e he (c * x) phi psi
+  rw [map_mul, hc phi, hphi] at hpath
+  rw [map_mul, hc psi, hpsi, mul_one] at hpath
+  calc
+    f (HopfAlgebra.rightTranslationAlgHom g e) = (toConv f * g).ofConv e :=
+      congrArg (fun q : WithConv (H →ₐ[K] K) ↦ q.ofConv e)
+        (HopfAlgebra.ofConv_comp_rightTranslationAlgHom (toConv f) g)
+    _ = f e := hpath
+
 private theorem rightTranslationAlgHom_eq_self_of_transvection
     (n : ℕ) (e : K ⊗[k] coordinateHopfAlgebra k n)
     [IsAlgClosed K] (he : IsIdempotentElem e) {i j : Fin n} (hij : i ≠ j) (a : K) :
     HopfAlgebra.rightTranslationAlgHom
         ((baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
           (Matrix.SpecialLinearGroup.transvection hij a)) e = e := by
-  apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
-    (k := K) (A := K ⊗[k] coordinateHopfAlgebra k n) (K := K) (he.map _) he
-  intro f
   let _ : Algebra k (Polynomial K) := Algebra.compHom (Polynomial K) (algebraMap k K)
   let _ : IsScalarTower k K (Polynomial K) := IsScalarTower.of_algebraMap_eq' rfl
-  let fX : WithConv
-      (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] Polynomial K) :=
-    AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
-      (IsScalarTower.toAlgHom K K (Polynomial K)) (toConv f)
   let xX : WithConv
       (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] Polynomial K) :=
     (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n (Polynomial K)).symm
@@ -135,24 +142,11 @@ private theorem rightTranslationAlgHom_eq_self_of_transvection
     apply (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).injective
     rw [baseChangeSpecialLinearPointsMulEquiv_mapValue (k := k) (K := K)]
     simp [xX, eval]
-  have hf (c : K) :
-      AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n) (eval c) fX = toConv f := by
-    apply WithConv.ofConv_injective
-    ext z
-    simp [fX, eval, AlgHom.mapValue_apply]
-  have hpath := mapValue_apply_eq_of_isIdempotentElem
-    (K := K) e he (fX * xX) (eval a) (eval 0)
-  rw [map_mul, hf a, hx a] at hpath
-  rw [map_mul, hf 0, hx 0] at hpath
-  rw [Matrix.SpecialLinearGroup.transvection_coeff_zero] at hpath
   let ga := (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
     (Matrix.SpecialLinearGroup.transvection hij a)
-  calc
-    f (HopfAlgebra.rightTranslationAlgHom ga e) = (toConv f * ga).ofConv e :=
-      congrArg (fun q : WithConv
-        (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) ↦ q.ofConv e)
-        (point_comp_rightTranslationAlgHom (toConv f) ga)
-    _ = f e := by simpa [ga] using hpath
+  apply rightTranslationAlgHom_eq_self_of_path e he ga xX (eval a) (eval 0)
+  · simpa [ga] using hx a
+  · simpa using hx 0
 
 /-- The generic two-coordinate diagonal point over the Laurent-polynomial ring. -/
 private noncomputable def diag2nLaurentPath
@@ -164,7 +158,7 @@ private noncomputable def diag2nLaurentPath
   let _ : IsScalarTower k K (LaurentPolynomial K) := IsScalarTower.of_algebraMap_eq' rfl
   exact (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n
     (LaurentPolynomial K)).symm
-      (diag2nUnit hij (laurentVariableUnit (K := K)))
+      (diag2nUnit hij (Cocharacter.genericUnit K))
 
 private theorem mapValue_diag2nLaurentPath
     (n : ℕ) {i j : Fin n} (hij : i ≠ j) (b : Kˣ) :
@@ -181,44 +175,21 @@ private theorem mapValue_diag2nLaurentPath
   simp only [MulEquiv.apply_symm_apply]
   exact map_diag2nUnit_laurent hij b
 
-/-- A rational point extended to a constant Laurent-polynomial-valued point. -/
-private noncomputable def constantLaurentPath
-    (n : ℕ) (f : K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) :
-    WithConv
-      (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] LaurentPolynomial K) :=
-  AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
-    (IsScalarTower.toAlgHom K K (LaurentPolynomial K)) (toConv f)
-
-private theorem mapValue_constantLaurentPath
-    (n : ℕ) (f : K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) (b : Kˣ) :
-    AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
-        (MultiplicativeGroup.point b) (constantLaurentPath n f) = toConv f := by
-  apply WithConv.ofConv_injective
-  ext z
-  simp [constantLaurentPath, AlgHom.mapValue_apply]
-
-private theorem algHom_apply_rightTranslationAlgHom_diag2n
+private theorem rightTranslationAlgHom_eq_self_of_diag2n
     (n : ℕ) (e : K ⊗[k] coordinateHopfAlgebra k n)
-    (he : IsIdempotentElem e) {i j : Fin n}
-    (hij : i ≠ j) (a : K) (ha : a ≠ 0)
-    (f : K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) :
-    f (HopfAlgebra.rightTranslationAlgHom
+    [IsAlgClosed K] (he : IsIdempotentElem e) {i j : Fin n}
+    (hij : i ≠ j) (a : K) (ha : a ≠ 0) :
+    HopfAlgebra.rightTranslationAlgHom
         ((baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
-          (Matrix.SpecialLinearGroup.diag2n hij a ha)) e) = f e := by
+          (Matrix.SpecialLinearGroup.diag2n hij a ha)) e = e := by
   let _ : Algebra k (LaurentPolynomial K) :=
     Algebra.compHom (LaurentPolynomial K) (algebraMap k K)
   let _ : IsScalarTower k K (LaurentPolynomial K) := IsScalarTower.of_algebraMap_eq' rfl
-  let fT := constantLaurentPath n f
   let xT := diag2nLaurentPath (k := k) (K := K) n hij
   let eval (b : Kˣ) : LaurentPolynomial K →ₐ[K] K :=
     MultiplicativeGroup.point b
   have hx (b : Kˣ) := mapValue_diag2nLaurentPath (k := k) (K := K) n hij b
-  have hf (b : Kˣ) := mapValue_constantLaurentPath (k := k) n f b
   let au : Kˣ := Units.mk0 a ha
-  have hpath := mapValue_apply_eq_of_isIdempotentElem
-    (K := K) e he (fT * xT) (eval au) (eval 1)
-  rw [map_mul, hf au, hx au] at hpath
-  rw [map_mul, hf 1, hx 1] at hpath
   have hdiagone : Matrix.SpecialLinearGroup.diag2n hij
       ((1 : Kˣ) : K) (Units.ne_zero (1 : Kˣ)) = 1 := by
     ext r s
@@ -227,31 +198,26 @@ private theorem algHom_apply_rightTranslationAlgHom_diag2n
   have hEone :
       (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm 1 = 1 :=
     map_one _
-  rw [hdiagone, hEone] at hpath
   have hdiagau : Matrix.SpecialLinearGroup.diag2n hij
       ((au : Kˣ) : K) (Units.ne_zero au) =
         Matrix.SpecialLinearGroup.diag2n hij a ha := by
     rfl
   let ga := (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
     (Matrix.SpecialLinearGroup.diag2n hij a ha)
-  calc
-    f (HopfAlgebra.rightTranslationAlgHom ga e) = (toConv f * ga).ofConv e :=
-      congrArg (fun q : WithConv
-        (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) ↦ q.ofConv e)
-        (point_comp_rightTranslationAlgHom (toConv f) ga)
-    _ = f e := by simpa [ga, hdiagau] using hpath
-
-private theorem rightTranslationAlgHom_eq_self_of_diag2n
-    (n : ℕ) (e : K ⊗[k] coordinateHopfAlgebra k n)
-    [IsAlgClosed K] (he : IsIdempotentElem e) {i j : Fin n}
-    (hij : i ≠ j) (a : K) (ha : a ≠ 0) :
-    HopfAlgebra.rightTranslationAlgHom
-        ((baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
-          (Matrix.SpecialLinearGroup.diag2n hij a ha)) e = e := by
-  apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
-    (k := K) (A := K ⊗[k] coordinateHopfAlgebra k n) (K := K) (he.map _) he
-  intro f
-  exact algHom_apply_rightTranslationAlgHom_diag2n n e he hij a ha f
+  apply rightTranslationAlgHom_eq_self_of_path e he ga xT (eval au) (eval 1)
+  · simpa [ga, hdiagau] using hx au
+  · change AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
+        (MultiplicativeGroup.point (1 : Kˣ))
+        (diag2nLaurentPath (k := k) (K := K) n hij) = 1
+    calc
+      AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
+          (MultiplicativeGroup.point (1 : Kˣ))
+          (diag2nLaurentPath (k := k) (K := K) n hij) =
+          (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
+            (Matrix.SpecialLinearGroup.diag2n hij (1 : K) (Units.ne_zero (1 : Kˣ))) := hx 1
+      _ = (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm 1 :=
+        congrArg (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm hdiagone
+      _ = 1 := hEone
 
 private theorem rightTranslationAlgHom_eq_self
     (n : ℕ) [IsAlgClosed K] (e : K ⊗[k] coordinateHopfAlgebra k n)

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
@@ -199,7 +199,7 @@ private theorem mapValue_constantLaurentPath
 
 private theorem algHom_apply_rightTranslationAlgHom_diag2n
     (n : ℕ) (e : K ⊗[k] coordinateHopfAlgebra k n)
-    [IsAlgClosed K] (he : IsIdempotentElem e) {i j : Fin n}
+    (he : IsIdempotentElem e) {i j : Fin n}
     (hij : i ≠ j) (a : K) (ha : a ≠ 0)
     (f : K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) :
     f (HopfAlgebra.rightTranslationAlgHom

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
@@ -1,0 +1,344 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
+import TauCeti.Algebra.AlgebraicGroup.BaseChange.Naturality
+import TauCeti.Algebra.AlgebraicGroup.Connected.AlgebraicallyClosed
+import TauCeti.Algebra.AlgebraicGroup.Hopf.Translation
+import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.DiagonalPath
+import TauCeti.RingTheory.FiniteType.PointSeparation
+import Mathlib.Algebra.GroupWithZero.Idempotent
+import Mathlib.RingTheory.FiniteStability
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Transvection
+
+/-!
+# Geometric connectedness of the special linear group
+
+The coordinate Hopf algebra of `SLₙ` is geometrically connected over every field. The proof
+uses idempotents and algebraically closed points, so it does not depend on an irreducibility
+theorem for the generic determinant polynomial.
+
+Over an algebraically closed extension, a finite-type coordinate algebra has no nontrivial
+idempotent once every idempotent has the same value at all rational points. Right translation
+reduces that constancy to generators of the ordinary special linear group. Mathlib's
+`Matrix.SpecialLinearGroup.diagonal_transvection_induction'` gives elementary transvections and
+two-coordinate diagonal matrices as generators. Their one-parameter families are defined over
+`K[X]` and `K[T,T⁻¹]`; these rings are domains, so an idempotent function on either family is
+constant. The argument includes ranks zero and one, where the special linear group is trivial.
+
+## Main declaration
+
+* `TauCeti.SpecialLinear.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra`:
+  `SLₙ` is geometrically connected.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§2.a and 21.a.
+-/
+
+public section
+
+open CategoryTheory WithConv
+open scoped LaurentPolynomial TensorProduct
+
+namespace TauCeti.SpecialLinear
+
+universe u v
+
+noncomputable section
+
+variable {k K : Type u} [Field k] [Field K] [Algebra k K]
+
+private noncomputable instance instFiniteTypeCoordinateHopfAlgebra (n : ℕ) :
+    Algebra.FiniteType k (coordinateHopfAlgebra k n) := by
+  exact Algebra.FiniteType.quotient k (definingHopfIdeal k n).toIdeal
+
+/-- Base-changed special-linear points identified with determinant-one matrices. -/
+private def baseChangeSpecialLinearPointsMulEquiv
+    (n : ℕ) (A : Type u) [CommRing A] [Algebra k A] [Algebra K A]
+    [IsScalarTower k K A] :
+    WithConv (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] A) ≃*
+      Matrix.SpecialLinearGroup (Fin n) A :=
+  (AlgHom.baseChangePointsMulEquiv (k := k) (K := K)
+    (A := coordinateHopfAlgebra k n) (R := A)).symm.trans
+      (pointsMulEquiv (R := k) (A := A) n)
+
+private theorem baseChangeSpecialLinearPointsMulEquiv_mapValue
+    (n : ℕ) {A B : Type u} [CommRing A] [CommRing B]
+    [Algebra k A] [Algebra K A] [IsScalarTower k K A]
+    [Algebra k B] [Algebra K B] [IsScalarTower k K B]
+    (f : WithConv (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] A))
+    (phi : A →ₐ[K] B) :
+    baseChangeSpecialLinearPointsMulEquiv n B
+        (AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n) phi f) =
+      Matrix.SpecialLinearGroup.map phi.toRingHom
+        (baseChangeSpecialLinearPointsMulEquiv n A f) := by
+  rw [baseChangeSpecialLinearPointsMulEquiv, MulEquiv.trans_apply,
+    AlgHom.baseChangePointsMulEquiv_symm_mapValue,
+    baseChangeSpecialLinearPointsMulEquiv, MulEquiv.trans_apply]
+  exact pointsMulEquiv_mapValue (R := k) (A := A) (B := B) n
+    (phi.restrictScalars k) _
+
+private theorem point_comp_rightTranslationAlgHom
+    {H : Type u} [CommRing H] [_root_.HopfAlgebra K H]
+    (f g : WithConv (H →ₐ[K] K)) :
+    toConv (f.ofConv.comp (HopfAlgebra.rightTranslationAlgHom g)) = f * g := by
+  apply WithConv.ofConv_injective
+  ext x
+  change f.ofConv (HopfAlgebra.rightTranslationAlgHom g x) = (f * g).ofConv x
+  rw [HopfAlgebra.rightTranslationAlgHom_apply, AlgHom.convMul_apply]
+  induction Coalgebra.comul (R := K) x using TensorProduct.induction_on with
+  | zero => simp
+  | add y z hy hz => simp [hy, hz]
+  | tmul y z => simp [Algebra.smul_def, mul_comm]
+
+private theorem mapValue_apply_eq_of_isIdempotentElem
+    {H A : Type u} [CommRing H] [_root_.HopfAlgebra K H]
+    [CommRing A] [Algebra K A] [IsDomain A]
+    (e : H) (he : IsIdempotentElem e) (q : WithConv (H →ₐ[K] A))
+    (phi psi : A →ₐ[K] K) :
+    (AlgHom.mapValue (H := H) phi q).ofConv e =
+      (AlgHom.mapValue (H := H) psi q).ofConv e := by
+  rcases IsIdempotentElem.iff_eq_zero_or_one.mp (he.map q.ofConv) with h | h <;>
+    simp [AlgHom.mapValue_apply, h]
+
+private theorem rightTranslationAlgHom_eq_self_of_transvection
+    (n : ℕ) (e : K ⊗[k] coordinateHopfAlgebra k n)
+    [IsAlgClosed K] (he : IsIdempotentElem e) {i j : Fin n} (hij : i ≠ j) (a : K) :
+    HopfAlgebra.rightTranslationAlgHom
+        ((baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
+          (Matrix.SpecialLinearGroup.transvection hij a)) e = e := by
+  apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
+    (k := K) (A := K ⊗[k] coordinateHopfAlgebra k n) (K := K) (he.map _) he
+  intro f
+  let _ : Algebra k (Polynomial K) := Algebra.compHom (Polynomial K) (algebraMap k K)
+  let _ : IsScalarTower k K (Polynomial K) := IsScalarTower.of_algebraMap_eq' rfl
+  let fX : WithConv
+      (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] Polynomial K) :=
+    AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
+      (IsScalarTower.toAlgHom K K (Polynomial K)) (toConv f)
+  let xX : WithConv
+      (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] Polynomial K) :=
+    (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n (Polynomial K)).symm
+      (Matrix.SpecialLinearGroup.transvection hij Polynomial.X)
+  let eval (c : K) : Polynomial K →ₐ[K] K :=
+    Polynomial.aevalTower (AlgHom.id K K) c
+  have hx (c : K) :
+      AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n) (eval c) xX =
+        (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
+          (Matrix.SpecialLinearGroup.transvection hij c) := by
+    apply (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).injective
+    rw [baseChangeSpecialLinearPointsMulEquiv_mapValue (k := k) (K := K)]
+    simp [xX, eval]
+  have hf (c : K) :
+      AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n) (eval c) fX = toConv f := by
+    apply WithConv.ofConv_injective
+    ext z
+    simp [fX, eval, AlgHom.mapValue_apply]
+  have hpath := mapValue_apply_eq_of_isIdempotentElem
+    (K := K) e he (fX * xX) (eval a) (eval 0)
+  rw [map_mul, hf a, hx a] at hpath
+  rw [map_mul, hf 0, hx 0] at hpath
+  rw [Matrix.SpecialLinearGroup.transvection_coeff_zero] at hpath
+  let ga := (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
+    (Matrix.SpecialLinearGroup.transvection hij a)
+  calc
+    f (HopfAlgebra.rightTranslationAlgHom ga e) = (toConv f * ga).ofConv e :=
+      congrArg (fun q : WithConv
+        (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) ↦ q.ofConv e)
+        (point_comp_rightTranslationAlgHom (toConv f) ga)
+    _ = f e := by simpa [ga] using hpath
+
+/-- The generic two-coordinate diagonal point over the Laurent-polynomial ring. -/
+private noncomputable def diag2nLaurentPath
+    (n : ℕ) {i j : Fin n} (hij : i ≠ j) :
+    WithConv
+      (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] LaurentPolynomial K) := by
+  let _ : Algebra k (LaurentPolynomial K) :=
+    Algebra.compHom (LaurentPolynomial K) (algebraMap k K)
+  let _ : IsScalarTower k K (LaurentPolynomial K) := IsScalarTower.of_algebraMap_eq' rfl
+  exact (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n
+    (LaurentPolynomial K)).symm
+      (diag2nUnit hij (laurentVariableUnit (K := K)))
+
+private theorem mapValue_diag2nLaurentPath
+    (n : ℕ) {i j : Fin n} (hij : i ≠ j) (b : Kˣ) :
+    AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
+        (MultiplicativeGroup.point b) (diag2nLaurentPath (k := k) n hij) =
+      (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
+        (Matrix.SpecialLinearGroup.diag2n hij b (Units.ne_zero b)) := by
+  let _ : Algebra k (LaurentPolynomial K) :=
+    Algebra.compHom (LaurentPolynomial K) (algebraMap k K)
+  let _ : IsScalarTower k K (LaurentPolynomial K) := IsScalarTower.of_algebraMap_eq' rfl
+  apply (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).injective
+  rw [baseChangeSpecialLinearPointsMulEquiv_mapValue (k := k) (K := K)]
+  dsimp only [diag2nLaurentPath]
+  simp only [MulEquiv.apply_symm_apply]
+  exact map_diag2nUnit_laurent hij b
+
+/-- A rational point extended to a constant Laurent-polynomial-valued point. -/
+private noncomputable def constantLaurentPath
+    (n : ℕ) (f : K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) :
+    WithConv
+      (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] LaurentPolynomial K) :=
+  AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
+    (IsScalarTower.toAlgHom K K (LaurentPolynomial K)) (toConv f)
+
+private theorem mapValue_constantLaurentPath
+    (n : ℕ) (f : K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) (b : Kˣ) :
+    AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
+        (MultiplicativeGroup.point b) (constantLaurentPath n f) = toConv f := by
+  apply WithConv.ofConv_injective
+  ext z
+  simp [constantLaurentPath, AlgHom.mapValue_apply]
+
+private theorem algHom_apply_rightTranslationAlgHom_diag2n
+    (n : ℕ) (e : K ⊗[k] coordinateHopfAlgebra k n)
+    [IsAlgClosed K] (he : IsIdempotentElem e) {i j : Fin n}
+    (hij : i ≠ j) (a : K) (ha : a ≠ 0)
+    (f : K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) :
+    f (HopfAlgebra.rightTranslationAlgHom
+        ((baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
+          (Matrix.SpecialLinearGroup.diag2n hij a ha)) e) = f e := by
+  let _ : Algebra k (LaurentPolynomial K) :=
+    Algebra.compHom (LaurentPolynomial K) (algebraMap k K)
+  let _ : IsScalarTower k K (LaurentPolynomial K) := IsScalarTower.of_algebraMap_eq' rfl
+  let fT := constantLaurentPath n f
+  let xT := diag2nLaurentPath (k := k) (K := K) n hij
+  let eval (b : Kˣ) : LaurentPolynomial K →ₐ[K] K :=
+    MultiplicativeGroup.point b
+  have hx (b : Kˣ) := mapValue_diag2nLaurentPath (k := k) (K := K) n hij b
+  have hf (b : Kˣ) := mapValue_constantLaurentPath (k := k) n f b
+  let au : Kˣ := Units.mk0 a ha
+  have hpath := mapValue_apply_eq_of_isIdempotentElem
+    (K := K) e he (fT * xT) (eval au) (eval 1)
+  rw [map_mul, hf au, hx au] at hpath
+  rw [map_mul, hf 1, hx 1] at hpath
+  have hdiagone : Matrix.SpecialLinearGroup.diag2n hij
+      ((1 : Kˣ) : K) (Units.ne_zero (1 : Kˣ)) = 1 := by
+    ext r s
+    simp [Matrix.SpecialLinearGroup.diag2n_coe, Matrix.diagonal_apply,
+      Matrix.one_apply]
+  have hEone :
+      (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm 1 = 1 :=
+    map_one _
+  rw [hdiagone, hEone] at hpath
+  have hdiagau : Matrix.SpecialLinearGroup.diag2n hij
+      ((au : Kˣ) : K) (Units.ne_zero au) =
+        Matrix.SpecialLinearGroup.diag2n hij a ha := by
+    rfl
+  let ga := (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
+    (Matrix.SpecialLinearGroup.diag2n hij a ha)
+  calc
+    f (HopfAlgebra.rightTranslationAlgHom ga e) = (toConv f * ga).ofConv e :=
+      congrArg (fun q : WithConv
+        (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K) ↦ q.ofConv e)
+        (point_comp_rightTranslationAlgHom (toConv f) ga)
+    _ = f e := by simpa [ga, hdiagau] using hpath
+
+private theorem rightTranslationAlgHom_eq_self_of_diag2n
+    (n : ℕ) (e : K ⊗[k] coordinateHopfAlgebra k n)
+    [IsAlgClosed K] (he : IsIdempotentElem e) {i j : Fin n}
+    (hij : i ≠ j) (a : K) (ha : a ≠ 0) :
+    HopfAlgebra.rightTranslationAlgHom
+        ((baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
+          (Matrix.SpecialLinearGroup.diag2n hij a ha)) e = e := by
+  apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
+    (k := K) (A := K ⊗[k] coordinateHopfAlgebra k n) (K := K) (he.map _) he
+  intro f
+  exact algHom_apply_rightTranslationAlgHom_diag2n n e he hij a ha f
+
+private theorem rightTranslationAlgHom_eq_self
+    (n : ℕ) [IsAlgClosed K] (e : K ⊗[k] coordinateHopfAlgebra k n)
+    (he : IsIdempotentElem e)
+    (g : WithConv (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K)) :
+    HopfAlgebra.rightTranslationAlgHom g e = e := by
+  let E := baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K
+  by_cases h : Nontrivial (Fin n)
+  · let _ := h
+    let P : Matrix.SpecialLinearGroup (Fin n) K → Prop := fun M ↦
+      HopfAlgebra.rightTranslationAlgHom (E.symm M) e = e
+    have hp : P (E g) := by
+      apply Matrix.SpecialLinearGroup.diagonal_transvection_induction' P (E g)
+      · intro i j hij a ha
+        exact rightTranslationAlgHom_eq_self_of_diag2n n e he hij a ha
+      · intro i j hij a
+        exact rightTranslationAlgHom_eq_self_of_transvection n e he hij a
+      · intro A B hA hB
+        have hequiv (q : WithConv
+            (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K)) :
+            HopfAlgebra.rightTranslationAlgEquiv q e =
+              HopfAlgebra.rightTranslationAlgHom q e :=
+          DFunLike.congr_fun (HopfAlgebra.rightTranslationAlgEquiv_toAlgHom q) e
+        calc
+          HopfAlgebra.rightTranslationAlgHom (E.symm (A * B)) e =
+              HopfAlgebra.rightTranslationAlgEquiv (E.symm (A * B)) e :=
+            (hequiv _).symm
+          _ = HopfAlgebra.rightTranslationAlgEquiv (E.symm A)
+              (HopfAlgebra.rightTranslationAlgEquiv (E.symm B) e) := by
+            rw [map_mul, HopfAlgebra.rightTranslationAlgEquiv_mul,
+              AlgEquiv.mul_apply]
+          _ = HopfAlgebra.rightTranslationAlgEquiv (E.symm A) e := by
+            rw [hequiv, hB]
+          _ = e := by rw [hequiv, hA]
+    simpa [P] using hp
+  · let _ : Subsingleton (Fin n) := not_nontrivial_iff_subsingleton.mp h
+    have hmatrix : E g = 1 := Subsingleton.elim _ _
+    have hg : g = 1 := E.injective (by simpa using hmatrix)
+    rw [hg]
+    calc
+      HopfAlgebra.rightTranslationAlgHom 1 e =
+          HopfAlgebra.rightTranslationAlgEquiv 1 e :=
+        (DFunLike.congr_fun
+          (HopfAlgebra.rightTranslationAlgEquiv_toAlgHom
+            (1 : WithConv
+              (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K))) e).symm
+      _ = e := by rw [HopfAlgebra.rightTranslationAlgEquiv_one]; rfl
+
+/-- The coordinate Hopf algebra of `SLₙ` is geometrically connected over every field. -/
+theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra
+    (k : Type u) [Field k] (n : ℕ) :
+    geometricallyConnectedCommHopfAlgProperty k (coordinateHopfAlgebra k n) := by
+  rw [geometricallyConnectedCommHopfAlgProperty_iff_connectedSpace_of_isAlgClosed]
+  intro K _ _ _
+  let H := coordinateHopfAlgebra k n
+  let _ : Nontrivial H := Bialgebra.nontrivial (A := H) k
+  let _ : Nontrivial (K ⊗[k] H) :=
+    Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_flat_left k K H
+      (RingHom.injective (algebraMap k H))
+  have hconnected : ConnectedSpace (PrimeSpectrum (K ⊗[k] H)) := by
+    apply connectedSpace_primeSpectrum_iff_idempotent_eq_zero_or_one.mpr
+    intro e he
+    have heval (g : WithConv (K ⊗[k] H →ₐ[K] K)) :
+        g.ofConv e = Coalgebra.counit (R := K) e := by
+      have htranslate := rightTranslationAlgHom_eq_self n e he g
+      have h := DFunLike.congr_fun
+        (HopfAlgebra.counitAlgHom_comp_rightTranslationAlgHom g) e
+      rw [AlgHom.comp_apply, htranslate] at h
+      exact h.symm
+    rcases IsIdempotentElem.iff_eq_zero_or_one.mp
+      (he.map (_root_.Bialgebra.counitAlgHom K (K ⊗[k] H))) with hzero | hone
+    · left
+      change Coalgebra.counit (R := K) e = 0 at hzero
+      apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
+        (k := K) (A := K ⊗[k] H) (K := K) he IsIdempotentElem.zero
+      intro f
+      simpa using (heval (toConv f)).trans hzero
+    · right
+      change Coalgebra.counit (R := K) e = 1 at hone
+      apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
+        (k := K) (A := K ⊗[k] H) (K := K) he IsIdempotentElem.one
+      intro f
+      simpa using (heval (toConv f)).trans hone
+  let e : (H : Type u) ⊗[k] K ≃+* K ⊗[k] H :=
+    (Algebra.TensorProduct.comm k H K).toRingEquiv
+  exact (PrimeSpectrum.homeomorphOfRingEquiv e).connectedSpace_iff.mpr hconnected
+
+end
+
+end TauCeti.SpecialLinear

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Connected.lean
@@ -11,8 +11,6 @@ import TauCeti.Algebra.AlgebraicGroup.BaseChange.Naturality
 import TauCeti.Algebra.AlgebraicGroup.Connected.AlgebraicallyClosed
 import TauCeti.Algebra.AlgebraicGroup.Hopf.Translation
 import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.DiagonalPath
-import TauCeti.RingTheory.FiniteType.PointSeparation
-import Mathlib.Algebra.GroupWithZero.Idempotent
 import Mathlib.RingTheory.FiniteStability
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Transvection
 
@@ -54,6 +52,12 @@ noncomputable section
 
 variable {k K : Type u} [Field k] [Field K] [Algebra k K]
 
+local instance : IsScalarTower k K (Polynomial K) :=
+  IsScalarTower.of_algebraMap_eq (by simp)
+
+local instance : IsScalarTower k K (LaurentPolynomial K) :=
+  IsScalarTower.of_algebraMap_eq (by simp)
+
 /-- Base-changed special-linear points identified with determinant-one matrices. -/
 private def baseChangeSpecialLinearPointsMulEquiv
     (n : ℕ) (A : Type u) [CommRing A] [Algebra k A] [Algebra K A]
@@ -80,55 +84,12 @@ private theorem baseChangeSpecialLinearPointsMulEquiv_mapValue
   exact pointsMulEquiv_mapValue (R := k) (A := A) (B := B) n
     (phi.restrictScalars k) _
 
-private theorem mapValue_apply_eq_of_isIdempotentElem
-    {H A : Type u} [CommRing H] [_root_.HopfAlgebra K H]
-    [CommRing A] [Algebra K A] [IsDomain A]
-    (e : H) (he : IsIdempotentElem e) (q : WithConv (H →ₐ[K] A))
-    (phi psi : A →ₐ[K] K) :
-    (AlgHom.mapValue (H := H) phi q).ofConv e =
-      (AlgHom.mapValue (H := H) psi q).ofConv e := by
-  rcases IsIdempotentElem.iff_eq_zero_or_one.mp (he.map q.ofConv) with h | h <;>
-    simp [AlgHom.mapValue_apply, h]
-
-private theorem rightTranslationAlgHom_eq_self_of_path
-    {H D : Type u} [CommRing H] [_root_.HopfAlgebra K H]
-    [Algebra.FiniteType K H] [CommRing D] [Algebra K D] [IsDomain D]
-    [IsAlgClosed K] (e : H) (he : IsIdempotentElem e)
-    (g : WithConv (H →ₐ[K] K)) (x : WithConv (H →ₐ[K] D))
-    (phi psi : D →ₐ[K] K)
-    (hphi : AlgHom.mapValue (H := H) phi x = g)
-    (hpsi : AlgHom.mapValue (H := H) psi x = 1) :
-    HopfAlgebra.rightTranslationAlgHom g e = e := by
-  apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
-    (k := K) (A := H) (K := K) (he.map _) he
-  intro f
-  let c : WithConv (H →ₐ[K] D) :=
-    AlgHom.mapValue (H := H) (IsScalarTower.toAlgHom K K D) (toConv f)
-  have hc (theta : D →ₐ[K] K) :
-      AlgHom.mapValue (H := H) theta c = toConv f := by
-    have hcomp : theta.comp (IsScalarTower.toAlgHom K K D) = AlgHom.id K K :=
-      AlgHom.ext fun z ↦ theta.commutes z
-    dsimp only [c]
-    rw [← MonoidHom.comp_apply, ← AlgHom.mapValue_comp, hcomp,
-      AlgHom.mapValue_id, MonoidHom.id_apply]
-  have hpath := mapValue_apply_eq_of_isIdempotentElem
-    (K := K) e he (c * x) phi psi
-  rw [map_mul, hc phi, hphi] at hpath
-  rw [map_mul, hc psi, hpsi, mul_one] at hpath
-  calc
-    f (HopfAlgebra.rightTranslationAlgHom g e) = (toConv f * g).ofConv e :=
-      congrArg (fun q : WithConv (H →ₐ[K] K) ↦ q.ofConv e)
-        (HopfAlgebra.ofConv_comp_rightTranslationAlgHom (toConv f) g)
-    _ = f e := hpath
-
 private theorem rightTranslationAlgHom_eq_self_of_transvection
     (n : ℕ) (e : K ⊗[k] coordinateHopfAlgebra k n)
     [IsAlgClosed K] (he : IsIdempotentElem e) {i j : Fin n} (hij : i ≠ j) (a : K) :
     HopfAlgebra.rightTranslationAlgHom
         ((baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
           (Matrix.SpecialLinearGroup.transvection hij a)) e = e := by
-  let _ : Algebra k (Polynomial K) := Algebra.compHom (Polynomial K) (algebraMap k K)
-  let _ : IsScalarTower k K (Polynomial K) := IsScalarTower.of_algebraMap_eq' rfl
   let xX : WithConv
       (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] Polynomial K) :=
     (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n (Polynomial K)).symm
@@ -144,7 +105,7 @@ private theorem rightTranslationAlgHom_eq_self_of_transvection
     simp [xX, eval]
   let ga := (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
     (Matrix.SpecialLinearGroup.transvection hij a)
-  apply rightTranslationAlgHom_eq_self_of_path e he ga xX (eval a) (eval 0)
+  apply HopfAlgebra.rightTranslationAlgHom_eq_self_of_path e he ga xX (eval a) (eval 0)
   · simpa [ga] using hx a
   · simpa using hx 0
 
@@ -152,13 +113,10 @@ private theorem rightTranslationAlgHom_eq_self_of_transvection
 private noncomputable def diag2nLaurentPath
     (n : ℕ) {i j : Fin n} (hij : i ≠ j) :
     WithConv
-      (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] LaurentPolynomial K) := by
-  let _ : Algebra k (LaurentPolynomial K) :=
-    Algebra.compHom (LaurentPolynomial K) (algebraMap k K)
-  let _ : IsScalarTower k K (LaurentPolynomial K) := IsScalarTower.of_algebraMap_eq' rfl
-  exact (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n
+      (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] LaurentPolynomial K) :=
+  (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n
     (LaurentPolynomial K)).symm
-      (diag2nUnit hij (Cocharacter.genericUnit K))
+      (Matrix.SpecialLinearGroup.diag2nUnit hij (MultiplicativeGroup.genericUnit K))
 
 private theorem mapValue_diag2nLaurentPath
     (n : ℕ) {i j : Fin n} (hij : i ≠ j) (b : Kˣ) :
@@ -166,14 +124,32 @@ private theorem mapValue_diag2nLaurentPath
         (MultiplicativeGroup.point b) (diag2nLaurentPath (k := k) n hij) =
       (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
         (Matrix.SpecialLinearGroup.diag2n hij b (Units.ne_zero b)) := by
-  let _ : Algebra k (LaurentPolynomial K) :=
-    Algebra.compHom (LaurentPolynomial K) (algebraMap k K)
-  let _ : IsScalarTower k K (LaurentPolynomial K) := IsScalarTower.of_algebraMap_eq' rfl
   apply (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).injective
   rw [baseChangeSpecialLinearPointsMulEquiv_mapValue (k := k) (K := K)]
   dsimp only [diag2nLaurentPath]
   simp only [MulEquiv.apply_symm_apply]
-  exact map_diag2nUnit_laurent hij b
+  exact map_diag2nUnit_genericUnit hij b
+
+private theorem mapValue_diag2nLaurentPath_one
+    (n : ℕ) {i j : Fin n} (hij : i ≠ j) :
+    AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
+        (MultiplicativeGroup.point (1 : Kˣ))
+        (diag2nLaurentPath (k := k) n hij) = 1 := by
+  have hdiag : Matrix.SpecialLinearGroup.diag2n hij
+      (1 : K) (Units.ne_zero (1 : Kˣ)) = 1 := by
+    rw [← Matrix.SpecialLinearGroup.diag2nUnit_mk0]
+    simp
+  calc
+    AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
+        (MultiplicativeGroup.point (1 : Kˣ))
+        (diag2nLaurentPath (k := k) n hij) =
+      (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
+        (Matrix.SpecialLinearGroup.diag2n hij
+          (1 : K) (Units.ne_zero (1 : Kˣ))) :=
+      mapValue_diag2nLaurentPath (k := k) (K := K) n hij 1
+    _ = (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm 1 :=
+      congrArg _ hdiag
+    _ = 1 := map_one _
 
 private theorem rightTranslationAlgHom_eq_self_of_diag2n
     (n : ℕ) (e : K ⊗[k] coordinateHopfAlgebra k n)
@@ -182,42 +158,17 @@ private theorem rightTranslationAlgHom_eq_self_of_diag2n
     HopfAlgebra.rightTranslationAlgHom
         ((baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
           (Matrix.SpecialLinearGroup.diag2n hij a ha)) e = e := by
-  let _ : Algebra k (LaurentPolynomial K) :=
-    Algebra.compHom (LaurentPolynomial K) (algebraMap k K)
-  let _ : IsScalarTower k K (LaurentPolynomial K) := IsScalarTower.of_algebraMap_eq' rfl
   let xT := diag2nLaurentPath (k := k) (K := K) n hij
   let eval (b : Kˣ) : LaurentPolynomial K →ₐ[K] K :=
     MultiplicativeGroup.point b
   have hx (b : Kˣ) := mapValue_diag2nLaurentPath (k := k) (K := K) n hij b
   let au : Kˣ := Units.mk0 a ha
-  have hdiagone : Matrix.SpecialLinearGroup.diag2n hij
-      ((1 : Kˣ) : K) (Units.ne_zero (1 : Kˣ)) = 1 := by
-    ext r s
-    simp [Matrix.SpecialLinearGroup.diag2n_coe, Matrix.diagonal_apply,
-      Matrix.one_apply]
-  have hEone :
-      (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm 1 = 1 :=
-    map_one _
-  have hdiagau : Matrix.SpecialLinearGroup.diag2n hij
-      ((au : Kˣ) : K) (Units.ne_zero au) =
-        Matrix.SpecialLinearGroup.diag2n hij a ha := by
-    rfl
   let ga := (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
     (Matrix.SpecialLinearGroup.diag2n hij a ha)
-  apply rightTranslationAlgHom_eq_self_of_path e he ga xT (eval au) (eval 1)
-  · simpa [ga, hdiagau] using hx au
-  · change AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
-        (MultiplicativeGroup.point (1 : Kˣ))
-        (diag2nLaurentPath (k := k) (K := K) n hij) = 1
-    calc
-      AlgHom.mapValue (H := K ⊗[k] coordinateHopfAlgebra k n)
-          (MultiplicativeGroup.point (1 : Kˣ))
-          (diag2nLaurentPath (k := k) (K := K) n hij) =
-          (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm
-            (Matrix.SpecialLinearGroup.diag2n hij (1 : K) (Units.ne_zero (1 : Kˣ))) := hx 1
-      _ = (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm 1 :=
-        congrArg (baseChangeSpecialLinearPointsMulEquiv (k := k) (K := K) n K).symm hdiagone
-      _ = 1 := hEone
+  apply HopfAlgebra.rightTranslationAlgHom_eq_self_of_path e he ga xT (eval au) (eval 1)
+  · simpa only [ga, au, Units.val_mk0] using hx au
+  · simpa only [xT, eval] using
+      mapValue_diag2nLaurentPath_one (k := k) (K := K) n hij
 
 private theorem rightTranslationAlgHom_eq_self
     (n : ℕ) [IsAlgClosed K] (e : K ⊗[k] coordinateHopfAlgebra k n)
@@ -236,35 +187,19 @@ private theorem rightTranslationAlgHom_eq_self
       · intro i j hij a
         exact rightTranslationAlgHom_eq_self_of_transvection n e he hij a
       · intro A B hA hB
-        have hequiv (q : WithConv
-            (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K)) :
-            HopfAlgebra.rightTranslationAlgEquiv q e =
-              HopfAlgebra.rightTranslationAlgHom q e :=
-          DFunLike.congr_fun (HopfAlgebra.rightTranslationAlgEquiv_toAlgHom q) e
         calc
           HopfAlgebra.rightTranslationAlgHom (E.symm (A * B)) e =
-              HopfAlgebra.rightTranslationAlgEquiv (E.symm (A * B)) e :=
-            (hequiv _).symm
-          _ = HopfAlgebra.rightTranslationAlgEquiv (E.symm A)
-              (HopfAlgebra.rightTranslationAlgEquiv (E.symm B) e) := by
-            rw [map_mul, HopfAlgebra.rightTranslationAlgEquiv_mul,
-              AlgEquiv.mul_apply]
-          _ = HopfAlgebra.rightTranslationAlgEquiv (E.symm A) e := by
-            rw [hequiv, hB]
-          _ = e := by rw [hequiv, hA]
+              HopfAlgebra.rightTranslationAlgHom (E.symm A * E.symm B) e := by
+            rw [map_mul]
+          _ = HopfAlgebra.rightTranslationAlgHom (E.symm A)
+              (HopfAlgebra.rightTranslationAlgHom (E.symm B) e) :=
+            HopfAlgebra.rightTranslationAlgHom_mul _ _ _
+          _ = e := by rw [hB, hA]
     simpa [P] using hp
   · let _ : Subsingleton (Fin n) := not_nontrivial_iff_subsingleton.mp h
     have hmatrix : E g = 1 := Subsingleton.elim _ _
     have hg : g = 1 := E.injective (by simpa using hmatrix)
-    rw [hg]
-    calc
-      HopfAlgebra.rightTranslationAlgHom 1 e =
-          HopfAlgebra.rightTranslationAlgEquiv 1 e :=
-        (DFunLike.congr_fun
-          (HopfAlgebra.rightTranslationAlgEquiv_toAlgHom
-            (1 : WithConv
-              (K ⊗[k] coordinateHopfAlgebra k n →ₐ[K] K))) e).symm
-      _ = e := by rw [HopfAlgebra.rightTranslationAlgEquiv_one]; rfl
+    rw [hg, HopfAlgebra.rightTranslationAlgHom_one]
 
 /-- The coordinate Hopf algebra of `SLₙ` is geometrically connected over every field. -/
 theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra
@@ -277,30 +212,9 @@ theorem geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra
   let _ : Nontrivial (K ⊗[k] H) :=
     Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_flat_left k K H
       (RingHom.injective (algebraMap k H))
-  have hconnected : ConnectedSpace (PrimeSpectrum (K ⊗[k] H)) := by
-    apply connectedSpace_primeSpectrum_iff_idempotent_eq_zero_or_one.mpr
-    intro e he
-    have heval (g : WithConv (K ⊗[k] H →ₐ[K] K)) :
-        g.ofConv e = Coalgebra.counit (R := K) e := by
-      have htranslate := rightTranslationAlgHom_eq_self n e he g
-      have h := DFunLike.congr_fun
-        (HopfAlgebra.counitAlgHom_comp_rightTranslationAlgHom g) e
-      rw [AlgHom.comp_apply, htranslate] at h
-      exact h.symm
-    rcases IsIdempotentElem.iff_eq_zero_or_one.mp
-      (he.map (_root_.Bialgebra.counitAlgHom K (K ⊗[k] H))) with hzero | hone
-    · left
-      change Coalgebra.counit (R := K) e = 0 at hzero
-      apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
-        (k := K) (A := K ⊗[k] H) (K := K) he IsIdempotentElem.zero
-      intro f
-      simpa using (heval (toConv f)).trans hzero
-    · right
-      change Coalgebra.counit (R := K) e = 1 at hone
-      apply eq_of_isIdempotentElem_of_forall_algHom_apply_eq
-        (k := K) (A := K ⊗[k] H) (K := K) he IsIdempotentElem.one
-      intro f
-      simpa using (heval (toConv f)).trans hone
+  have hconnected : ConnectedSpace (PrimeSpectrum (K ⊗[k] H)) :=
+    HopfAlgebra.connectedSpace_primeSpectrum_of_forall_rightTranslationAlgHom_eq_self
+      (fun e he g ↦ rightTranslationAlgHom_eq_self n e he g)
   let e : (H : Type u) ⊗[k] K ≃+* K ⊗[k] H :=
     (Algebra.TensorProduct.comm k H K).toRingEquiv
   exact (PrimeSpectrum.homeomorphOfRingEquiv e).connectedSpace_iff.mpr hconnected

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/DiagonalPath.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/DiagonalPath.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup.Basic
 public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Diagonal
-public import Mathlib.Algebra.Polynomial.Laurent
 
 /-!
 # A Laurent-polynomial path in the special linear group

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/DiagonalPath.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/DiagonalPath.lean
@@ -6,21 +6,20 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup.Basic
-public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
+public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Diagonal
 public import Mathlib.Algebra.Polynomial.Laurent
 
 /-!
 # A Laurent-polynomial path in the special linear group
 
-A unit in a commutative ring defines a determinant-one diagonal matrix by placing the unit and
-its inverse in two distinct diagonal positions. Over a field, specializing the Laurent variable
-recovers Mathlib's `Matrix.SpecialLinearGroup.diag2n` matrix. This supplies the diagonal
-one-parameter family used to prove connectedness of `SLₙ`.
+Specializing the generic Laurent unit in the two-coordinate unit diagonal family recovers
+Mathlib's `Matrix.SpecialLinearGroup.diag2n` matrix. This supplies the diagonal one-parameter
+family used to prove connectedness of `SLₙ`.
 
 ## Main declarations
 
-* `TauCeti.SpecialLinear.diag2nUnit`: the two-coordinate diagonal matrix attached to a unit.
-* `TauCeti.SpecialLinear.map_diag2nUnit_laurent`: specialization of the generic Laurent matrix.
+* `TauCeti.SpecialLinear.map_diag2nUnit_genericUnit`: specialization of the generic Laurent
+  matrix.
 -/
 
 public section
@@ -33,68 +32,29 @@ universe u v
 
 noncomputable section
 
-/-- The determinant-one diagonal matrix with a unit in position `i`, its inverse in position
-`j`, and ones in every other position. -/
-noncomputable def diag2nUnit {R : Type u} [CommRing R]
-    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j)
-    (a : Rˣ) : Matrix.SpecialLinearGroup m R :=
-  ⟨Matrix.diagonal (fun r ↦
-      if r = i then (a : R) else if r = j then ((a⁻¹ : Rˣ) : R) else 1), by
-    rw [Matrix.det_diagonal]
-    simp [Finset.prod_ite, hij.symm,
-      Finset.card_eq_one (s := {r : m | r = i}).2 ⟨i, by grind⟩]⟩
-
-/-- Mapping the coefficients of a unit diagonal matrix maps its defining unit. -/
-theorem map_diag2nUnit {R S : Type u} [CommRing R] [CommRing S]
-    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j)
-    (f : R →+* S) (a : Rˣ) :
-    Matrix.SpecialLinearGroup.map f (diag2nUnit hij a) =
-      diag2nUnit hij (Units.map f a) := by
-  apply Subtype.ext
-  change f.mapMatrix (Matrix.diagonal fun r ↦
-      if r = i then (a : R) else if r = j then ((a⁻¹ : Rˣ) : R) else 1) =
-    Matrix.diagonal fun r ↦
-      if r = i then ((Units.map f a : Sˣ) : S) else
-        if r = j then (((Units.map f a)⁻¹ : Sˣ) : S) else 1
-  rw [RingHom.mapMatrix_apply, Matrix.diagonal_map (map_zero f)]
-  congr 1
-  funext r
-  rw [apply_ite (f := f), apply_ite (f := f), map_one]
-  congr 1
-
-/-- Over a field, the unit construction specializes to Mathlib's two-coordinate diagonal
-matrix. -/
-theorem diag2nUnit_mk0 {K : Type u} [Field K]
-    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j)
-    (b : K) (hb : b ≠ 0) :
-    diag2nUnit hij (Units.mk0 b hb) = Matrix.SpecialLinearGroup.diag2n hij b hb := by
-  apply Subtype.ext
-  rw [Matrix.SpecialLinearGroup.diag2n_coe]
-  rfl
-
 /-- Evaluating the generic Laurent diagonal matrix at a unit `b` gives the ordinary
 two-coordinate diagonal matrix with entries `b` and `b⁻¹`. -/
-theorem map_diag2nUnit_laurent
-    {K : Type u} [Field K] {n : ℕ} {i j : Fin n} (hij : i ≠ j) (b : Kˣ) :
+theorem map_diag2nUnit_genericUnit
+    {K : Type u} [Field K] {m : Type v} [Fintype m] [DecidableEq m]
+    {i j : m} (hij : i ≠ j) (b : Kˣ) :
     Matrix.SpecialLinearGroup.map
         (MultiplicativeGroup.point (R := K) b).toRingHom
-        (diag2nUnit hij (Cocharacter.genericUnit K)) =
+        (Matrix.SpecialLinearGroup.diag2nUnit hij (MultiplicativeGroup.genericUnit K)) =
       Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b) := by
-  rw [map_diag2nUnit]
-  have hunit : Units.map
-      (MultiplicativeGroup.point (R := K) b).toRingHom.toMonoidHom
-      (Cocharacter.genericUnit K) = b := by
-    apply Units.ext
-    simp
-  have hb : Units.mk0 (b : K) (Units.ne_zero b) = b := Units.ext rfl
+  rw [Matrix.SpecialLinearGroup.map_diag2nUnit]
+  have hunit : Units.map (MultiplicativeGroup.point (R := K) b).toRingHom
+      (MultiplicativeGroup.genericUnit K) = b := by
+    exact ((MultiplicativeGroup.map_genericUnit K
+      (MultiplicativeGroup.point (R := K) b)).trans
+        (MultiplicativeGroup.unitOfPoint_point b))
   calc
-    diag2nUnit hij
-        (Units.map (MultiplicativeGroup.point (R := K) b).toRingHom.toMonoidHom
-          (Cocharacter.genericUnit K)) = diag2nUnit hij b := congrArg (diag2nUnit hij) hunit
-    _ = diag2nUnit hij (Units.mk0 (b : K) (Units.ne_zero b)) :=
-      congrArg (diag2nUnit hij) hb.symm
-    _ = Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b) :=
-      diag2nUnit_mk0 hij (b : K) (Units.ne_zero b)
+    Matrix.SpecialLinearGroup.diag2nUnit hij
+        (Units.map (MultiplicativeGroup.point (R := K) b).toRingHom
+          (MultiplicativeGroup.genericUnit K)) =
+        Matrix.SpecialLinearGroup.diag2nUnit hij b := congrArg _ hunit
+    _ = Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b) := by
+      simpa using
+        Matrix.SpecialLinearGroup.diag2nUnit_mk0 hij (b : K) (Units.ne_zero b)
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/DiagonalPath.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/DiagonalPath.lean
@@ -33,15 +33,6 @@ universe u v
 
 noncomputable section
 
-/-- The Laurent variable regarded as a unit of the Laurent-polynomial ring. -/
-def laurentVariableUnit {K : Type u} [Field K] : (LaurentPolynomial K)ˣ :=
-  unitOfInvertible (LaurentPolynomial.T 1)
-
-@[simp]
-theorem laurentVariableUnit_val {K : Type u} [Field K] :
-    (laurentVariableUnit (K := K) : LaurentPolynomial K) = LaurentPolynomial.T 1 := by
-  simp [laurentVariableUnit]
-
 /-- The determinant-one diagonal matrix with a unit in position `i`, its inverse in position
 `j`, and ones in every other position. -/
 noncomputable def diag2nUnit {R : Type u} [CommRing R]
@@ -53,33 +44,33 @@ noncomputable def diag2nUnit {R : Type u} [CommRing R]
     simp [Finset.prod_ite, hij.symm,
       Finset.card_eq_one (s := {r : m | r = i}).2 ⟨i, by grind⟩]⟩
 
-private theorem point_diag2nUnit_laurent_apply
-    {K : Type u} [Field K] {n : ℕ} {i j : Fin n} (hij : i ≠ j) (b : Kˣ)
-    (r s : Fin n) :
-    MultiplicativeGroup.point (R := K) b
-        ((diag2nUnit hij (laurentVariableUnit (K := K))).1 r s) =
-      (Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b)).1 r s := by
-  let eval : LaurentPolynomial K →ₐ[K] K := MultiplicativeGroup.point b
-  have hunit : Units.map eval.toMonoidHom (laurentVariableUnit (K := K)) = b := by
-    apply Units.ext
-    simp [eval]
-  have hinv : eval
-      (((laurentVariableUnit (K := K))⁻¹ : (LaurentPolynomial K)ˣ) : LaurentPolynomial K) =
-        ((b⁻¹ : Kˣ) : K) := by
-    change ((Units.map eval.toMonoidHom ((laurentVariableUnit (K := K))⁻¹) : Kˣ) : K) = _
-    rw [map_inv, hunit]
-  rw [Matrix.SpecialLinearGroup.diag2n_coe, Matrix.diagonal_apply]
-  change eval ((diag2nUnit hij (laurentVariableUnit (K := K))).1 r s) = _
-  dsimp only [diag2nUnit]
-  rw [Matrix.diagonal_apply]
-  by_cases hrs : r = s
-  · subst s
-    by_cases hri : r = i
-    · simp [hri, eval]
-    · by_cases hrj : r = j
-      · simpa [hri, hrj, hij.symm] using hinv
-      · simp [hri, hrj]
-  · simp [hrs]
+/-- Mapping the coefficients of a unit diagonal matrix maps its defining unit. -/
+theorem map_diag2nUnit {R S : Type u} [CommRing R] [CommRing S]
+    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j)
+    (f : R →+* S) (a : Rˣ) :
+    Matrix.SpecialLinearGroup.map f (diag2nUnit hij a) =
+      diag2nUnit hij (Units.map f a) := by
+  apply Subtype.ext
+  change f.mapMatrix (Matrix.diagonal fun r ↦
+      if r = i then (a : R) else if r = j then ((a⁻¹ : Rˣ) : R) else 1) =
+    Matrix.diagonal fun r ↦
+      if r = i then ((Units.map f a : Sˣ) : S) else
+        if r = j then (((Units.map f a)⁻¹ : Sˣ) : S) else 1
+  rw [RingHom.mapMatrix_apply, Matrix.diagonal_map (map_zero f)]
+  congr 1
+  funext r
+  rw [apply_ite (f := f), apply_ite (f := f), map_one]
+  congr 1
+
+/-- Over a field, the unit construction specializes to Mathlib's two-coordinate diagonal
+matrix. -/
+theorem diag2nUnit_mk0 {K : Type u} [Field K]
+    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j)
+    (b : K) (hb : b ≠ 0) :
+    diag2nUnit hij (Units.mk0 b hb) = Matrix.SpecialLinearGroup.diag2n hij b hb := by
+  apply Subtype.ext
+  rw [Matrix.SpecialLinearGroup.diag2n_coe]
+  rfl
 
 /-- Evaluating the generic Laurent diagonal matrix at a unit `b` gives the ordinary
 two-coordinate diagonal matrix with entries `b` and `b⁻¹`. -/
@@ -87,13 +78,23 @@ theorem map_diag2nUnit_laurent
     {K : Type u} [Field K] {n : ℕ} {i j : Fin n} (hij : i ≠ j) (b : Kˣ) :
     Matrix.SpecialLinearGroup.map
         (MultiplicativeGroup.point (R := K) b).toRingHom
-        (diag2nUnit hij (laurentVariableUnit (K := K))) =
+        (diag2nUnit hij (Cocharacter.genericUnit K)) =
       Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b) := by
-  ext r s
-  change MultiplicativeGroup.point (R := K) b
-      ((diag2nUnit hij (laurentVariableUnit (K := K))).1 r s) =
-    (Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b)).1 r s
-  exact point_diag2nUnit_laurent_apply hij b r s
+  rw [map_diag2nUnit]
+  have hunit : Units.map
+      (MultiplicativeGroup.point (R := K) b).toRingHom.toMonoidHom
+      (Cocharacter.genericUnit K) = b := by
+    apply Units.ext
+    simp
+  have hb : Units.mk0 (b : K) (Units.ne_zero b) = b := Units.ext rfl
+  calc
+    diag2nUnit hij
+        (Units.map (MultiplicativeGroup.point (R := K) b).toRingHom.toMonoidHom
+          (Cocharacter.genericUnit K)) = diag2nUnit hij b := congrArg (diag2nUnit hij) hunit
+    _ = diag2nUnit hij (Units.mk0 (b : K) (Units.ne_zero b)) :=
+      congrArg (diag2nUnit hij) hb.symm
+    _ = Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b) :=
+      diag2nUnit_mk0 hij (b : K) (Units.ne_zero b)
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/DiagonalPath.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/DiagonalPath.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.MultiplicativeGroup.Basic
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
+public import Mathlib.Algebra.Polynomial.Laurent
+
+/-!
+# A Laurent-polynomial path in the special linear group
+
+A unit in a commutative ring defines a determinant-one diagonal matrix by placing the unit and
+its inverse in two distinct diagonal positions. Over a field, specializing the Laurent variable
+recovers Mathlib's `Matrix.SpecialLinearGroup.diag2n` matrix. This supplies the diagonal
+one-parameter family used to prove connectedness of `SLₙ`.
+
+## Main declarations
+
+* `TauCeti.SpecialLinear.diag2nUnit`: the two-coordinate diagonal matrix attached to a unit.
+* `TauCeti.SpecialLinear.map_diag2nUnit_laurent`: specialization of the generic Laurent matrix.
+-/
+
+public section
+
+open scoped LaurentPolynomial
+
+namespace TauCeti.SpecialLinear
+
+universe u v
+
+noncomputable section
+
+/-- The Laurent variable regarded as a unit of the Laurent-polynomial ring. -/
+def laurentVariableUnit {K : Type u} [Field K] : (LaurentPolynomial K)ˣ :=
+  unitOfInvertible (LaurentPolynomial.T 1)
+
+@[simp]
+theorem laurentVariableUnit_val {K : Type u} [Field K] :
+    (laurentVariableUnit (K := K) : LaurentPolynomial K) = LaurentPolynomial.T 1 := by
+  simp [laurentVariableUnit]
+
+/-- The determinant-one diagonal matrix with a unit in position `i`, its inverse in position
+`j`, and ones in every other position. -/
+noncomputable def diag2nUnit {R : Type u} [CommRing R]
+    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j)
+    (a : Rˣ) : Matrix.SpecialLinearGroup m R :=
+  ⟨Matrix.diagonal (fun r ↦
+      if r = i then (a : R) else if r = j then ((a⁻¹ : Rˣ) : R) else 1), by
+    rw [Matrix.det_diagonal]
+    simp [Finset.prod_ite, hij.symm,
+      Finset.card_eq_one (s := {r : m | r = i}).2 ⟨i, by grind⟩]⟩
+
+private theorem point_diag2nUnit_laurent_apply
+    {K : Type u} [Field K] {n : ℕ} {i j : Fin n} (hij : i ≠ j) (b : Kˣ)
+    (r s : Fin n) :
+    MultiplicativeGroup.point (R := K) b
+        ((diag2nUnit hij (laurentVariableUnit (K := K))).1 r s) =
+      (Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b)).1 r s := by
+  let eval : LaurentPolynomial K →ₐ[K] K := MultiplicativeGroup.point b
+  have hunit : Units.map eval.toMonoidHom (laurentVariableUnit (K := K)) = b := by
+    apply Units.ext
+    simp [eval]
+  have hinv : eval
+      (((laurentVariableUnit (K := K))⁻¹ : (LaurentPolynomial K)ˣ) : LaurentPolynomial K) =
+        ((b⁻¹ : Kˣ) : K) := by
+    change ((Units.map eval.toMonoidHom ((laurentVariableUnit (K := K))⁻¹) : Kˣ) : K) = _
+    rw [map_inv, hunit]
+  rw [Matrix.SpecialLinearGroup.diag2n_coe, Matrix.diagonal_apply]
+  change eval ((diag2nUnit hij (laurentVariableUnit (K := K))).1 r s) = _
+  dsimp only [diag2nUnit]
+  rw [Matrix.diagonal_apply]
+  by_cases hrs : r = s
+  · subst s
+    by_cases hri : r = i
+    · simp [hri, eval]
+    · by_cases hrj : r = j
+      · simpa [hri, hrj, hij.symm] using hinv
+      · simp [hri, hrj]
+  · simp [hrs]
+
+/-- Evaluating the generic Laurent diagonal matrix at a unit `b` gives the ordinary
+two-coordinate diagonal matrix with entries `b` and `b⁻¹`. -/
+theorem map_diag2nUnit_laurent
+    {K : Type u} [Field K] {n : ℕ} {i j : Fin n} (hij : i ≠ j) (b : Kˣ) :
+    Matrix.SpecialLinearGroup.map
+        (MultiplicativeGroup.point (R := K) b).toRingHom
+        (diag2nUnit hij (laurentVariableUnit (K := K))) =
+      Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b) := by
+  ext r s
+  change MultiplicativeGroup.point (R := K) b
+      ((diag2nUnit hij (laurentVariableUnit (K := K))).1 r s) =
+    (Matrix.SpecialLinearGroup.diag2n hij (b : K) (Units.ne_zero b)).1 r s
+  exact point_diag2nUnit_laurent_apply hij b r s
+
+end
+
+end TauCeti.SpecialLinear

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Diagonal.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Diagonal.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
+
+/-!
+# Diagonal matrices in the special linear group
+
+A unit in a commutative ring defines a determinant-one diagonal matrix by placing the unit and
+its inverse in two distinct diagonal positions. This generalizes Mathlib's field-valued
+`Matrix.SpecialLinearGroup.diag2n` construction.
+
+## Main declarations
+
+* `Matrix.SpecialLinearGroup.diag2nUnit`: the two-coordinate diagonal matrix attached to a unit.
+* `Matrix.SpecialLinearGroup.map_diag2nUnit`: naturality under a ring homomorphism.
+
+## References
+
+The definition of `diag2nUnit` and its determinant proof generalize and are adapted from Mathlib's
+`Matrix.SpecialLinearGroup.diag2n`.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w
+
+noncomputable section
+
+/-- The determinant-one diagonal matrix with a unit in position `i`, its inverse in position
+`j`, and ones in every other position. This generalizes Mathlib's
+`Matrix.SpecialLinearGroup.diag2n`; the determinant proof is adapted from that construction. -/
+noncomputable def _root_.Matrix.SpecialLinearGroup.diag2nUnit {R : Type u} [CommRing R]
+    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j)
+    (a : Rˣ) : Matrix.SpecialLinearGroup m R :=
+  ⟨Matrix.diagonal (fun r ↦
+      if r = i then (a : R) else if r = j then ((a⁻¹ : Rˣ) : R) else 1), by
+    rw [Matrix.det_diagonal]
+    simp [Finset.prod_ite, hij.symm,
+      Finset.card_eq_one (s := {r : m | r = i}).2 ⟨i, by grind⟩]⟩
+
+/-- The matrix underlying `diag2nUnit` is its defining diagonal matrix. -/
+@[simp]
+theorem _root_.Matrix.SpecialLinearGroup.diag2nUnit_coe {R : Type u} [CommRing R]
+    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j) (a : Rˣ) :
+    (Matrix.SpecialLinearGroup.diag2nUnit hij a).1 = Matrix.diagonal (fun r ↦
+      if r = i then (a : R) else if r = j then ((a⁻¹ : Rˣ) : R) else 1) :=
+  by rw [Matrix.SpecialLinearGroup.diag2nUnit]
+
+/-- Mapping the coefficients of a unit diagonal matrix maps its defining unit. -/
+@[simp]
+theorem _root_.Matrix.SpecialLinearGroup.map_diag2nUnit
+    {R : Type u} {S : Type w} [CommRing R] [CommRing S]
+    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j)
+    (f : R →+* S) (a : Rˣ) :
+    Matrix.SpecialLinearGroup.map f (Matrix.SpecialLinearGroup.diag2nUnit hij a) =
+      Matrix.SpecialLinearGroup.diag2nUnit hij (Units.map f a) := by
+  ext r s
+  simp [Matrix.SpecialLinearGroup.map_apply_coe, RingHom.mapMatrix_apply,
+    Matrix.diagonal_apply, apply_ite f]
+
+/-- The unit diagonal family takes the identity unit to the identity matrix. -/
+@[simp]
+theorem _root_.Matrix.SpecialLinearGroup.diag2nUnit_one {R : Type u} [CommRing R]
+    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j) :
+    Matrix.SpecialLinearGroup.diag2nUnit hij (1 : Rˣ) = 1 := by
+  ext r s
+  simp [Matrix.SpecialLinearGroup.diag2nUnit_coe, Matrix.diagonal_apply, Matrix.one_apply]
+
+/-- Over a field, the unit construction specializes to Mathlib's two-coordinate diagonal
+matrix. -/
+@[simp]
+theorem _root_.Matrix.SpecialLinearGroup.diag2nUnit_mk0 {K : Type u} [Field K]
+    {m : Type v} [Fintype m] [DecidableEq m] {i j : m} (hij : i ≠ j)
+    (b : K) (hb : b ≠ 0) :
+    Matrix.SpecialLinearGroup.diag2nUnit hij (Units.mk0 b hb) =
+      Matrix.SpecialLinearGroup.diag2n hij b hb := by
+  apply Subtype.ext
+  simp [Matrix.SpecialLinearGroup.diag2nUnit_coe, Matrix.SpecialLinearGroup.diag2n_coe,
+    Units.val_mk0, Units.val_inv_eq_inv_val]
+
+end
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the coordinate Hopf algebra of `SLₙ` is geometrically connected over every field. It adds the generic Laurent-polynomial path through two-coordinate diagonal matrices and uses polynomial paths through transvections, algebraically closed point separation for idempotents, and right translation to show that every base-changed coordinate algebra has connected prime spectrum.

This advances the ReductiveGroups roadmap's Layer 6 "reductive and semisimple groups" worked-example target to prove `SLₙ` reductive, specifically supplying its connectedness prerequisite. After this PR, the smoothness work currently in flight and the proof that the geometric unipotent radical of `SLₙ` is trivial remain before that worked example is reductive via the roadmap definition.

The generator argument reuses Mathlib's `Matrix.SpecialLinearGroup.diagonal_transvection_induction'` and its transvection API, while the idempotent argument reuses Tau Ceti's finite-type algebraically closed point-separation and Hopf-algebra translation infrastructure. Ranks zero and one are handled separately by triviality of the special linear group, so the theorem has no hidden positive-rank hypothesis.

The two changed modules build individually; `tauceti-axioms` audits all 38 changed declarations within the project allowlist, and `tauceti-lint-env` reports no new violations.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-linear-geometrically-connected"}-->

🤖 Prepared with Codex
