### PR TITLE
feat: Kostant's left-regular module on the Clifford algebra of the Killing form

### DIFF
--- a/TauCeti/Algebra/Lie/OfAssociative.lean
+++ b/TauCeti/Algebra/Lie/OfAssociative.lean
@@ -71,11 +71,14 @@ algebra `L` acts on `A` by left multiplication by the image of `q`, which is a L
 def leftRegularRep (q : L →ₗ⁅R⁆ A) : L →ₗ⁅R⁆ Module.End R A :=
   ((Algebra.lmul R A : A →ₐ[R] Module.End R A) : A →ₗ⁅R⁆ Module.End R A).comp q
 
+/-- **The action formula.** `x` acts on `a` by left multiplication by `q x`. -/
 @[simp]
 theorem leftRegularRep_apply (q : L →ₗ⁅R⁆ A) (x : L) (a : A) :
     leftRegularRep q x a = q x * a :=
   (rfl)
 
+/-- The endomorphism by which `x` acts is `LinearMap.mulLeft R (q x)`, which is how the
+left-multiplication API of an associative algebra reaches the left-regular representation. -/
 theorem leftRegularRep_eq_mulLeft (q : L →ₗ⁅R⁆ A) (x : L) :
     leftRegularRep q x = LinearMap.mulLeft R (q x) :=
   (rfl)
@@ -100,8 +103,8 @@ the image of `leftRegularRep q`. -/
 theorem leftRegularRep_comp_mulRight (q : L →ₗ⁅R⁆ A) (x : L) (b : A) :
     (leftRegularRep q x).comp (LinearMap.mulRight R b) =
       (LinearMap.mulRight R b).comp (leftRegularRep q x) := by
-  ext a
-  simp [mul_assoc]
+  rw [leftRegularRep_eq_mulLeft, ← Module.End.mul_eq_comp, ← Module.End.mul_eq_comp]
+  exact LinearMap.commute_mulLeft_right (R := R) (q x) b
 
 /-- **Left ideals are invariant** under the left-regular representation: the action is by left
 multiplication, which is exactly what a left ideal absorbs. -/
@@ -121,7 +124,6 @@ theorem map_leftRegularRep_le (q : L →ₗ⁅R⁆ A) (I : Submodule A A) (x : L
 left-regular one is built here. -/
 theorem ad_apply_eq_leftRegularRep_sub_mulRight (q : L →ₗ⁅R⁆ A) (x : L) :
     LieAlgebra.ad R A (q x) = leftRegularRep q x - LinearMap.mulRight R (q x) := by
-  ext a
-  simp [LieRing.of_associative_ring_bracket]
+  rw [leftRegularRep_eq_mulLeft, LieAlgebra.ad_eq_lmul_left_sub_lmul_right, Pi.sub_apply]
 
 end LieHom

--- a/TauCeti/Algebra/Lie/OfAssociative.lean
+++ b/TauCeti/Algebra/Lie/OfAssociative.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Bilinear
+public import Mathlib.Algebra.Lie.OfAssociative
+
+/-!
+# The left-regular representation of a Lie map into an associative algebra
+
+Let `q : L →ₗ⁅R⁆ A` be a Lie algebra map from `L` into an associative `R`-algebra `A`, the latter
+bracketed by its ring commutator. Left multiplication by the image of `q` makes `A` itself a
+representation of `L`:
+
+`x • a = q x * a`.
+
+This is the *left-regular* action along `q`, and it is a different `L`-module from the inner
+derivation action `x • a = ⁅q x, a⁆` that `LieAlgebra.ad` supplies; the two differ by right
+multiplication (`LieHom.ad_apply_eq_leftRegularRep_sub_mulRight`), and only the left-regular one
+has the left ideals of `A` among its submodules. Kostant's isotypy theorem is a statement about
+the left-regular action of a semisimple Lie algebra on the Clifford algebra of its Killing form,
+so this file supplies the general construction that specialization needs.
+
+Because the module structure it defines competes with the self-module structure of `A` as a Lie
+ring, the action is packaged as a homomorphism `L →ₗ⁅R⁆ Module.End R A` rather than as an
+instance: a consumer installs the associated `LieRingModule` where it wants it, with
+`LieRingModule.compLieHom`.
+
+## Main definitions
+
+* `LieHom.leftRegularRep`: the left-regular representation `L →ₗ⁅R⁆ Module.End R A` along `q`.
+
+## Main results
+
+* `LieHom.leftRegularRep_apply`: it acts by left multiplication.
+* `LieHom.leftRegularRep_injective_iff`: it is faithful exactly when `q` is injective, which is
+  read off its value at `1`.
+* `LieHom.leftRegularRep_comp_mulRight`: right multiplications are intertwiners of the
+  left-regular representation; this is the commutant that makes the isotypy arguments run.
+* `LieHom.leftRegularRep_mem_of_mem`: every left ideal of `A` is invariant.
+* `LieHom.ad_apply_eq_leftRegularRep_sub_mulRight`: the inner derivation action is the difference
+  of the left-regular action and right multiplication.
+
+## References
+
+This is the general construction behind the "Kostant's setting, packaged" target of Layer 9 in
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`; see
+`TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean` for that specialization.
+
+* B. Kostant, *Clifford algebra analogue of the Hopf--Koszul--Samelson theorem*, Adv. Math. 125
+  (1997), 275--350.
+-/
+
+public section
+
+universe u v w
+
+namespace LieHom
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable {R : Type u} {L : Type v} {A : Type w}
+variable [CommRing R] [LieRing L] [LieAlgebra R L] [Ring A] [Algebra R A]
+
+/-- **The left-regular representation along a Lie map into an associative algebra.** The Lie
+algebra `L` acts on `A` by left multiplication by the image of `q`, which is a Lie action because
+`q` turns the bracket of `L` into the ring commutator of `A`. -/
+def leftRegularRep (q : L →ₗ⁅R⁆ A) : L →ₗ⁅R⁆ Module.End R A :=
+  ((Algebra.lmul R A : A →ₐ[R] Module.End R A) : A →ₗ⁅R⁆ Module.End R A).comp q
+
+@[simp]
+theorem leftRegularRep_apply (q : L →ₗ⁅R⁆ A) (x : L) (a : A) :
+    leftRegularRep q x a = q x * a :=
+  (rfl)
+
+theorem leftRegularRep_eq_mulLeft (q : L →ₗ⁅R⁆ A) (x : L) :
+    leftRegularRep q x = LinearMap.mulLeft R (q x) :=
+  (rfl)
+
+/-- The left-regular action recovers `q` at `1 : A`. Not a `simp` lemma: `simp` already reduces
+the left-hand side through `LieHom.leftRegularRep_apply` and `mul_one`. -/
+theorem leftRegularRep_one (q : L →ₗ⁅R⁆ A) (x : L) : leftRegularRep q x 1 = q x := by
+  rw [leftRegularRep_apply, mul_one]
+
+/-- **The left-regular representation is faithful exactly when `q` is injective.** Its value at
+`1 : A` recovers `q`, so no information is lost in passing to left multiplications. -/
+theorem leftRegularRep_injective_iff (q : L →ₗ⁅R⁆ A) :
+    Function.Injective (leftRegularRep q) ↔ Function.Injective q := by
+  refine ⟨fun h x y hxy ↦ h ?_, fun h x y hxy ↦ h ?_⟩
+  · ext a
+    rw [leftRegularRep_apply, leftRegularRep_apply, hxy]
+  · simpa only [leftRegularRep_one] using congrArg (fun f : Module.End R A ↦ f 1) hxy
+
+/-- **Right multiplication intertwines the left-regular representation with itself.** This is
+associativity of `A`, read as the statement that the right multiplications lie in the commutant of
+the image of `leftRegularRep q`. -/
+theorem leftRegularRep_comp_mulRight (q : L →ₗ⁅R⁆ A) (x : L) (b : A) :
+    (leftRegularRep q x).comp (LinearMap.mulRight R b) =
+      (LinearMap.mulRight R b).comp (leftRegularRep q x) := by
+  ext a
+  simp [mul_assoc]
+
+/-- **Left ideals are invariant** under the left-regular representation: the action is by left
+multiplication, which is exactly what a left ideal absorbs. -/
+theorem leftRegularRep_mem_of_mem (q : L →ₗ⁅R⁆ A) (I : Submodule A A) (x : L) {a : A}
+    (ha : a ∈ I) : leftRegularRep q x a ∈ I := by
+  rw [leftRegularRep_apply, ← smul_eq_mul]
+  exact I.smul_mem _ ha
+
+/-- The submodule form of `LieHom.leftRegularRep_mem_of_mem`. -/
+theorem map_leftRegularRep_le (q : L →ₗ⁅R⁆ A) (I : Submodule A A) (x : L) :
+    (I.restrictScalars R).map (leftRegularRep q x) ≤ I.restrictScalars R := by
+  rintro _ ⟨a, ha, rfl⟩
+  exact leftRegularRep_mem_of_mem q I x ha
+
+/-- **The inner derivation action is the left-regular action minus right multiplication.** The two
+`L`-module structures on `A` that `q` produces are therefore genuinely different; only the
+left-regular one is built here. -/
+theorem ad_apply_eq_leftRegularRep_sub_mulRight (q : L →ₗ⁅R⁆ A) (x : L) :
+    LieAlgebra.ad R A (q x) = leftRegularRep q x - LinearMap.mulRight R (q x) := by
+  ext a
+  simp [LieRing.of_associative_ring_bracket]
+
+end LieHom

--- a/TauCeti/Algebra/Lie/OfAssociative.lean
+++ b/TauCeti/Algebra/Lie/OfAssociative.lean
@@ -36,8 +36,8 @@ instance: a consumer installs the associated `LieRingModule` where it wants it, 
 ## Main results
 
 * `LieHom.leftRegularRep_apply`: it acts by left multiplication.
-* `LieHom.leftRegularRep_injective_iff`: it is faithful exactly when `q` is injective, which is
-  read off its value at `1`.
+* `LieHom.leftRegularRep_injective_iff`: it is faithful exactly when `q` is injective, because
+  left multiplication determines the multiplier.
 * `LieHom.leftRegularRep_comp_mulRight`: right multiplications are intertwiners of the
   left-regular representation; this is the commutant that makes the isotypy arguments run.
 * `LieHom.leftRegularRep_mem_of_mem`: every left ideal of `A` is invariant.
@@ -72,7 +72,7 @@ def leftRegularRep (q : L →ₗ⁅R⁆ A) : L →ₗ⁅R⁆ Module.End R A :=
   ((Algebra.lmul R A : A →ₐ[R] Module.End R A) : A →ₗ⁅R⁆ Module.End R A).comp q
 
 /-- **The action formula.** `x` acts on `a` by left multiplication by `q x`. -/
-@[simp]
+@[simp, grind =]
 theorem leftRegularRep_apply (q : L →ₗ⁅R⁆ A) (x : L) (a : A) :
     leftRegularRep q x a = q x * a :=
   (rfl)
@@ -83,19 +83,12 @@ theorem leftRegularRep_eq_mulLeft (q : L →ₗ⁅R⁆ A) (x : L) :
     leftRegularRep q x = LinearMap.mulLeft R (q x) :=
   (rfl)
 
-/-- The left-regular action recovers `q` at `1 : A`. Not a `simp` lemma: `simp` already reduces
-the left-hand side through `LieHom.leftRegularRep_apply` and `mul_one`. -/
-theorem leftRegularRep_one (q : L →ₗ⁅R⁆ A) (x : L) : leftRegularRep q x 1 = q x := by
-  rw [leftRegularRep_apply, mul_one]
-
-/-- **The left-regular representation is faithful exactly when `q` is injective.** Its value at
-`1 : A` recovers `q`, so no information is lost in passing to left multiplications. -/
+/-- **The left-regular representation is faithful exactly when `q` is injective.** It is the
+composite of `q` with `Algebra.lmul`, and left multiplication determines the multiplier
+(`Algebra.lmul_injective`), so no information is lost in passing to left multiplications. -/
 theorem leftRegularRep_injective_iff (q : L →ₗ⁅R⁆ A) :
-    Function.Injective (leftRegularRep q) ↔ Function.Injective q := by
-  refine ⟨fun h x y hxy ↦ h ?_, fun h x y hxy ↦ h ?_⟩
-  · ext a
-    rw [leftRegularRep_apply, leftRegularRep_apply, hxy]
-  · simpa only [leftRegularRep_one] using congrArg (fun f : Module.End R A ↦ f 1) hxy
+    Function.Injective (leftRegularRep q) ↔ Function.Injective q :=
+  Algebra.lmul_injective.of_comp_iff q
 
 /-- **Right multiplication intertwines the left-regular representation with itself.** This is
 associativity of `A`, read as the statement that the right multiplications lie in the commutant of

--- a/TauCeti/Algebra/Lie/OfAssociative.lean
+++ b/TauCeti/Algebra/Lie/OfAssociative.lean
@@ -106,12 +106,6 @@ theorem leftRegularRep_mem_of_mem (q : L →ₗ⁅R⁆ A) (I : Submodule A A) (x
   rw [leftRegularRep_apply, ← smul_eq_mul]
   exact I.smul_mem _ ha
 
-/-- The submodule form of `LieHom.leftRegularRep_mem_of_mem`. -/
-theorem map_leftRegularRep_le (q : L →ₗ⁅R⁆ A) (I : Submodule A A) (x : L) :
-    (I.restrictScalars R).map (leftRegularRep q x) ≤ I.restrictScalars R := by
-  rintro _ ⟨a, ha, rfl⟩
-  exact leftRegularRep_mem_of_mem q I x ha
-
 /-- **The inner derivation action is the left-regular action minus right multiplication.** The two
 `L`-module structures on `A` that `q` produces are therefore genuinely different; only the
 left-regular one is built here. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
@@ -93,20 +93,16 @@ variable {K L}
 
 /-- **The defining equation of Kostant's module**: `L` acts by left multiplication by the adjoint
 quadratic lift. -/
-@[simp]
+@[simp, grind =]
 theorem kostant_lie_def (x : L) (c : CliffordAlgebra (killingQuadraticForm K L)) :
     ⁅x, c⁆ = adjointCliffordHom K L x * c :=
   LieHom.leftRegularRep_apply _ x c
 
-/-- Acting on `1` recovers the adjoint quadratic lift. Not a `simp` lemma: `simp` already reduces
-the left-hand side through `CliffordAlgebra.kostant_lie_def` and `mul_one`. -/
-theorem kostant_lie_one (x : L) :
-    ⁅x, (1 : CliffordAlgebra (killingQuadraticForm K L))⁆ = adjointCliffordHom K L x := by
-  rw [kostant_lie_def, mul_one]
-
 /-- **The action on a Clifford generator.** The adjoint action of `L` on itself is visible in
 Kostant's module, but only up to a right-multiplication term: left multiplication is not the
-derivation action. -/
+derivation action. Not a `simp` lemma: `CliffordAlgebra.kostant_lie_def` already rewrites its
+left-hand side, so `simp` would never see this one in simp-normal form. -/
+@[grind =]
 theorem kostant_lie_ι (x y : L) :
     ⁅x, ι (killingQuadraticForm K L) y⁆ =
       ι (killingQuadraticForm K L) ⁅x, y⁆ +
@@ -120,9 +116,7 @@ precise sense in which the left-regular module and the exterior extension of the
 representation are different modules on the same carrier. -/
 theorem kostant_lie_sub_mul (x : L) (c : CliffordAlgebra (killingQuadraticForm K L)) :
     ⁅x, c⁆ - c * adjointCliffordHom K L x = ⁅adjointCliffordHom K L x, c⁆ := by
-  have h := congrArg (fun f : Module.End K (CliffordAlgebra (killingQuadraticForm K L)) ↦ f c)
-    (LieHom.ad_apply_eq_leftRegularRep_sub_mulRight (adjointCliffordHom K L) x)
-  simpa using h.symm
+  rw [kostant_lie_def, LieRing.of_associative_ring_bracket]
 
 /-- **Right multiplication is an endomorphism of Kostant's module.** Associativity of the Clifford
 algebra says that left and right multiplications commute, so every right multiplication lies in
@@ -135,14 +129,15 @@ noncomputable def kostantRightMul (d : CliffordAlgebra (killingQuadraticForm K L
     (congrArg (fun f : Module.End K (CliffordAlgebra (killingQuadraticForm K L)) ↦ f c)
       (LieHom.leftRegularRep_comp_mulRight (adjointCliffordHom K L) x d)).symm
 
-@[simp]
+@[simp, grind =]
 theorem kostantRightMul_apply (d c : CliffordAlgebra (killingQuadraticForm K L)) :
     kostantRightMul d c = c * d :=
   (rfl)
 
 /-- **A left ideal of the Clifford algebra is a Lie submodule of Kostant's module.** The action is
-by left multiplication, which a left ideal absorbs; this is the correspondence that turns minimal
-left ideals into simple submodules. -/
+by left multiplication, which a left ideal absorbs, so every left ideal is an invariant subspace;
+what such a submodule decomposes into is the business of the later Kostant theorems, not of this
+construction. -/
 noncomputable def kostantLieSubmoduleOfLeftIdeal
     (I : Submodule (CliffordAlgebra (killingQuadraticForm K L))
       (CliffordAlgebra (killingQuadraticForm K L))) :
@@ -150,7 +145,7 @@ noncomputable def kostantLieSubmoduleOfLeftIdeal
   __ := I.restrictScalars K
   lie_mem {x _} h := LieHom.leftRegularRep_mem_of_mem (adjointCliffordHom K L) I x h
 
-@[simp]
+@[simp, grind =]
 theorem mem_kostantLieSubmoduleOfLeftIdeal
     {I : Submodule (CliffordAlgebra (killingQuadraticForm K L))
       (CliffordAlgebra (killingQuadraticForm K L))}

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
@@ -114,10 +114,12 @@ theorem kostant_lie_ι (x y : L) :
 
 /-- **Kostant's action minus right multiplication is the inner derivation action.** This is the
 precise sense in which the left-regular module and the exterior extension of the adjoint
-representation are different modules on the same carrier. -/
+representation are different modules on the same carrier; it is the pointwise form of
+`LieHom.ad_apply_eq_leftRegularRep_sub_mulRight` for the adjoint quadratic lift. -/
 theorem kostant_lie_sub_mul (x : L) (c : CliffordAlgebra (killingQuadraticForm K L)) :
-    ⁅x, c⁆ - c * adjointCliffordHom K L x = ⁅adjointCliffordHom K L x, c⁆ := by
-  rw [kostant_lie_def, LieRing.of_associative_ring_bracket]
+    ⁅x, c⁆ - c * adjointCliffordHom K L x = ⁅adjointCliffordHom K L x, c⁆ :=
+  (congrArg (fun f : Module.End K (CliffordAlgebra (killingQuadraticForm K L)) ↦ f c)
+    (LieHom.ad_apply_eq_leftRegularRep_sub_mulRight (adjointCliffordHom K L) x)).symm
 
 /-- **Right multiplication is an endomorphism of Kostant's module.** Associativity of the Clifford
 algebra says that left and right multiplications commute, so every right multiplication lies in

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.OfAssociative
-public import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
 
 /-!
@@ -50,8 +49,10 @@ every consumer. Write `open scoped CliffordAlgebra` to use them.
   representation of a Killing-semisimple Lie algebra is
   (`CliffordAlgebra.adjointCliffordHom_injective`, proved alongside the lift itself).
 
-The carrier is a finite module over `K` (`CliffordAlgebra.instFinite`), which is what makes the
-statement that its simple submodules are all isomorphic a statement about something.
+The carrier is a finite module over `K`, which is what makes the statement that its simple
+submodules are all isomorphic a statement about something; nothing here needs that, so the
+instance saying so is left to `TauCeti.LinearAlgebra.CliffordAlgebra.Dimension`, to be imported
+by whichever later file uses it.
 
 ## References
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
@@ -22,12 +22,12 @@ isotypy theorem is about: the Clifford algebra acted on by **left multiplication
 The choice of action is not cosmetic. The other `L`-module structure the same lift produces is the
 inner derivation action `⁅x, c⁆ = ⁅adjointCliffordHom K L x, c⁆` of
 `CliffordAlgebra.cliffordDerivationRep`, which under `CliffordAlgebra.equivExterior` is the
-exterior extension of the adjoint representation and is *not* isotypic; the two differ by right
-multiplication (`CliffordAlgebra.kostant_lie_sub_mul`). What distinguishes the left-regular action
-is that its submodules include every left ideal
-(`CliffordAlgebra.kostantLieSubmoduleOfLeftIdeal`) and its endomorphisms include every right
-multiplication (`CliffordAlgebra.kostantRightMul`), which is the commutant the isotypy argument
-runs on.
+exterior extension of the adjoint representation and is in general *not* the isotypic action that
+Kostant's theorem is about; the two differ by right multiplication
+(`CliffordAlgebra.kostant_lie_sub_mul`). What distinguishes the left-regular action is that its
+submodules include every left ideal (`CliffordAlgebra.kostantLieSubmoduleOfLeftIdeal`) and its
+endomorphisms include every right multiplication (`CliffordAlgebra.kostantRightMul`), which is the
+commutant the isotypy argument runs on.
 
 The two instances are `scoped`, as the roadmap asks: the Clifford algebra of the Killing form is
 not otherwise an `L`-module, and a global instance would fix one of the two competing actions for
@@ -93,11 +93,13 @@ variable {K L}
 
 /-- **The defining equation of Kostant's module**: `L` acts by left multiplication by the adjoint
 quadratic lift. -/
+@[simp]
 theorem kostant_lie_def (x : L) (c : CliffordAlgebra (killingQuadraticForm K L)) :
     ⁅x, c⁆ = adjointCliffordHom K L x * c :=
   LieHom.leftRegularRep_apply _ x c
 
-@[simp]
+/-- Acting on `1` recovers the adjoint quadratic lift. Not a `simp` lemma: `simp` already reduces
+the left-hand side through `CliffordAlgebra.kostant_lie_def` and `mul_one`. -/
 theorem kostant_lie_one (x : L) :
     ⁅x, (1 : CliffordAlgebra (killingQuadraticForm K L))⁆ = adjointCliffordHom K L x := by
   rw [kostant_lie_def, mul_one]
@@ -118,7 +120,9 @@ precise sense in which the left-regular module and the exterior extension of the
 representation are different modules on the same carrier. -/
 theorem kostant_lie_sub_mul (x : L) (c : CliffordAlgebra (killingQuadraticForm K L)) :
     ⁅x, c⁆ - c * adjointCliffordHom K L x = ⁅adjointCliffordHom K L x, c⁆ := by
-  rw [kostant_lie_def, LieRing.of_associative_ring_bracket]
+  have h := congrArg (fun f : Module.End K (CliffordAlgebra (killingQuadraticForm K L)) ↦ f c)
+    (LieHom.ad_apply_eq_leftRegularRep_sub_mulRight (adjointCliffordHom K L) x)
+  simpa using h.symm
 
 /-- **Right multiplication is an endomorphism of Kostant's module.** Associativity of the Clifford
 algebra says that left and right multiplications commute, so every right multiplication lies in
@@ -127,10 +131,9 @@ noncomputable def kostantRightMul (d : CliffordAlgebra (killingQuadraticForm K L
     CliffordAlgebra (killingQuadraticForm K L) →ₗ⁅K, L⁆
       CliffordAlgebra (killingQuadraticForm K L) where
   __ := LinearMap.mulRight K d
-  map_lie' {_ _} := by
-    have hmul : ∀ e : CliffordAlgebra (killingQuadraticForm K L),
-        (LinearMap.mulRight K d).toFun e = e * d := fun _ ↦ rfl
-    rw [hmul, hmul, kostant_lie_def, kostant_lie_def, mul_assoc]
+  map_lie' {x c} :=
+    (congrArg (fun f : Module.End K (CliffordAlgebra (killingQuadraticForm K L)) ↦ f c)
+      (LieHom.leftRegularRep_comp_mulRight (adjointCliffordHom K L) x d)).symm
 
 @[simp]
 theorem kostantRightMul_apply (d c : CliffordAlgebra (killingQuadraticForm K L)) :
@@ -145,9 +148,7 @@ noncomputable def kostantLieSubmoduleOfLeftIdeal
       (CliffordAlgebra (killingQuadraticForm K L))) :
     LieSubmodule K L (CliffordAlgebra (killingQuadraticForm K L)) where
   __ := I.restrictScalars K
-  lie_mem {_ _} h := by
-    rw [kostant_lie_def, ← smul_eq_mul]
-    exact I.smul_mem _ h
+  lie_mem {x _} h := LieHom.leftRegularRep_mem_of_mem (adjointCliffordHom K L) I x h
 
 @[simp]
 theorem mem_kostantLieSubmoduleOfLeftIdeal
@@ -163,9 +164,10 @@ variable (K L)
 injective because the centre of a Killing-semisimple Lie algebra vanishes. -/
 scoped instance kostantLieModuleIsFaithful :
     LieModule.IsFaithful K L (CliffordAlgebra (killingQuadraticForm K L)) where
-  injective_toEnd x y hxy := by
-    refine adjointCliffordHom_injective K L ?_
-    have h := congrArg (fun f : Module.End K (CliffordAlgebra (killingQuadraticForm K L)) ↦ f 1) hxy
-    simpa only [LieModule.toEnd_apply_apply, kostant_lie_one] using h
+  injective_toEnd _ _ hxy :=
+    (LieHom.leftRegularRep_injective_iff (adjointCliffordHom K L)).2
+      (adjointCliffordHom_injective K L) <|
+      LinearMap.ext fun c ↦
+        congrArg (fun f : Module.End K (CliffordAlgebra (killingQuadraticForm K L)) ↦ f c) hxy
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.OfAssociative
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
+
+/-!
+# Kostant's module: the Clifford algebra of the Killing form, left-regularly
+
+For a Killing-semisimple Lie algebra `L` the adjoint action is skew-adjoint for the Killing form,
+so it lifts to the quadratic elements of the Clifford algebra of that form
+(`CliffordAlgebra.adjointCliffordHom`). This file installs the `L`-module structure that Kostant's
+isotypy theorem is about: the Clifford algebra acted on by **left multiplication** by that lift,
+
+`⁅x, c⁆ = adjointCliffordHom K L x * c`.
+
+The choice of action is not cosmetic. The other `L`-module structure the same lift produces is the
+inner derivation action `⁅x, c⁆ = ⁅adjointCliffordHom K L x, c⁆` of
+`CliffordAlgebra.cliffordDerivationRep`, which under `CliffordAlgebra.equivExterior` is the
+exterior extension of the adjoint representation and is *not* isotypic; the two differ by right
+multiplication (`CliffordAlgebra.kostant_lie_sub_mul`). What distinguishes the left-regular action
+is that its submodules include every left ideal
+(`CliffordAlgebra.kostantLieSubmoduleOfLeftIdeal`) and its endomorphisms include every right
+multiplication (`CliffordAlgebra.kostantRightMul`), which is the commutant the isotypy argument
+runs on.
+
+The two instances are `scoped`, as the roadmap asks: the Clifford algebra of the Killing form is
+not otherwise an `L`-module, and a global instance would fix one of the two competing actions for
+every consumer. Write `open scoped CliffordAlgebra` to use them.
+
+## Main definitions
+
+* `CliffordAlgebra.kostantLieRingModule` and `CliffordAlgebra.kostantLieModule`: the scoped
+  left-regular `L`-module structure on `CliffordAlgebra (killingQuadraticForm K L)`.
+* `CliffordAlgebra.kostantRightMul`: right multiplication, as an endomorphism of that module.
+* `CliffordAlgebra.kostantLieSubmoduleOfLeftIdeal`: a left ideal, as a Lie submodule.
+
+## Main results
+
+* `CliffordAlgebra.kostant_lie_def`: the defining equation of the action.
+* `CliffordAlgebra.kostant_lie_ι`: its value on a Clifford generator, where the adjoint action of
+  `L` reappears together with a right-multiplication term.
+* `CliffordAlgebra.kostant_lie_sub_mul`: the comparison with the inner derivation action.
+* `CliffordAlgebra.kostantLieModuleIsFaithful`: the action is faithful, because the adjoint
+  representation of a Killing-semisimple Lie algebra is
+  (`CliffordAlgebra.adjointCliffordHom_injective`, proved alongside the lift itself).
+
+The carrier is a finite module over `K` (`CliffordAlgebra.instFinite`), which is what makes the
+statement that its simple submodules are all isomorphic a statement about something.
+
+## References
+
+This implements the "Kostant's setting, packaged" target (`kostantLieRingModule`,
+`kostantLieModule`, `kostant_lie_def`) of Layer 9 in
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`.
+
+* B. Kostant, *Clifford algebra analogue of the Hopf--Koszul--Samelson theorem*, Adv. Math. 125
+  (1997), 275--350.
+-/
+
+public section
+
+universe u v
+
+namespace CliffordAlgebra
+
+open TauCeti.LieAlgebra
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable (K : Type u) (L : Type v) [Field K] [LieRing L] [LieAlgebra K L]
+  [FiniteDimensional K L] [Invertible (2 : K)] [_root_.LieAlgebra.IsKilling K L]
+
+/-- **Kostant's module.** The Clifford algebra of the Killing quadratic form, acted on by `L`
+through left multiplication by the adjoint quadratic lift. Scoped: the inner derivation action of
+`CliffordAlgebra.cliffordDerivationRep` is a competing `L`-module structure on the same carrier,
+so neither may be global. -/
+noncomputable scoped instance kostantLieRingModule :
+    LieRingModule L (CliffordAlgebra (killingQuadraticForm K L)) :=
+  LieRingModule.compLieHom _ (LieHom.leftRegularRep (adjointCliffordHom K L))
+
+/-- Kostant's module is a Lie module over the base field. -/
+noncomputable scoped instance kostantLieModule :
+    LieModule K L (CliffordAlgebra (killingQuadraticForm K L)) :=
+  LieModule.compLieHom _ (LieHom.leftRegularRep (adjointCliffordHom K L))
+
+variable {K L}
+
+/-- **The defining equation of Kostant's module**: `L` acts by left multiplication by the adjoint
+quadratic lift. -/
+theorem kostant_lie_def (x : L) (c : CliffordAlgebra (killingQuadraticForm K L)) :
+    ⁅x, c⁆ = adjointCliffordHom K L x * c :=
+  LieHom.leftRegularRep_apply _ x c
+
+@[simp]
+theorem kostant_lie_one (x : L) :
+    ⁅x, (1 : CliffordAlgebra (killingQuadraticForm K L))⁆ = adjointCliffordHom K L x := by
+  rw [kostant_lie_def, mul_one]
+
+/-- **The action on a Clifford generator.** The adjoint action of `L` on itself is visible in
+Kostant's module, but only up to a right-multiplication term: left multiplication is not the
+derivation action. -/
+theorem kostant_lie_ι (x y : L) :
+    ⁅x, ι (killingQuadraticForm K L) y⁆ =
+      ι (killingQuadraticForm K L) ⁅x, y⁆ +
+        ι (killingQuadraticForm K L) y * adjointCliffordHom K L x := by
+  have h := adjointCliffordHom_lie_ι K L x y
+  rw [LieRing.of_associative_ring_bracket] at h
+  rw [kostant_lie_def, ← h, sub_add_cancel]
+
+/-- **Kostant's action minus right multiplication is the inner derivation action.** This is the
+precise sense in which the left-regular module and the exterior extension of the adjoint
+representation are different modules on the same carrier. -/
+theorem kostant_lie_sub_mul (x : L) (c : CliffordAlgebra (killingQuadraticForm K L)) :
+    ⁅x, c⁆ - c * adjointCliffordHom K L x = ⁅adjointCliffordHom K L x, c⁆ := by
+  rw [kostant_lie_def, LieRing.of_associative_ring_bracket]
+
+/-- **Right multiplication is an endomorphism of Kostant's module.** Associativity of the Clifford
+algebra says that left and right multiplications commute, so every right multiplication lies in
+the commutant of the action; this is the supply of intertwiners behind the isotypy statement. -/
+noncomputable def kostantRightMul (d : CliffordAlgebra (killingQuadraticForm K L)) :
+    CliffordAlgebra (killingQuadraticForm K L) →ₗ⁅K, L⁆
+      CliffordAlgebra (killingQuadraticForm K L) where
+  __ := LinearMap.mulRight K d
+  map_lie' {_ _} := by
+    have hmul : ∀ e : CliffordAlgebra (killingQuadraticForm K L),
+        (LinearMap.mulRight K d).toFun e = e * d := fun _ ↦ rfl
+    rw [hmul, hmul, kostant_lie_def, kostant_lie_def, mul_assoc]
+
+@[simp]
+theorem kostantRightMul_apply (d c : CliffordAlgebra (killingQuadraticForm K L)) :
+    kostantRightMul d c = c * d :=
+  (rfl)
+
+/-- **A left ideal of the Clifford algebra is a Lie submodule of Kostant's module.** The action is
+by left multiplication, which a left ideal absorbs; this is the correspondence that turns minimal
+left ideals into simple submodules. -/
+noncomputable def kostantLieSubmoduleOfLeftIdeal
+    (I : Submodule (CliffordAlgebra (killingQuadraticForm K L))
+      (CliffordAlgebra (killingQuadraticForm K L))) :
+    LieSubmodule K L (CliffordAlgebra (killingQuadraticForm K L)) where
+  __ := I.restrictScalars K
+  lie_mem {_ _} h := by
+    rw [kostant_lie_def, ← smul_eq_mul]
+    exact I.smul_mem _ h
+
+@[simp]
+theorem mem_kostantLieSubmoduleOfLeftIdeal
+    {I : Submodule (CliffordAlgebra (killingQuadraticForm K L))
+      (CliffordAlgebra (killingQuadraticForm K L))}
+    {c : CliffordAlgebra (killingQuadraticForm K L)} :
+    c ∈ kostantLieSubmoduleOfLeftIdeal I ↔ c ∈ I :=
+  Iff.rfl
+
+variable (K L)
+
+/-- **Kostant's module is faithful.** Acting on `1` recovers the adjoint quadratic lift, which is
+injective because the centre of a Killing-semisimple Lie algebra vanishes. -/
+scoped instance kostantLieModuleIsFaithful :
+    LieModule.IsFaithful K L (CliffordAlgebra (killingQuadraticForm K L)) where
+  injective_toEnd x y hxy := by
+    refine adjointCliffordHom_injective K L ?_
+    have h := congrArg (fun f : Module.End K (CliffordAlgebra (killingQuadraticForm K L)) ↦ f 1) hxy
+    simpa only [LieModule.toEnd_apply_apply, kostant_lie_one] using h
+
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -7,6 +7,8 @@ module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Realization
 public import TauCeti.Algebra.Lie.SkewAdjoint
+-- Private: `CliffordAlgebra.ι_injective` is used only inside a proof.
+import TauCeti.LinearAlgebra.CliffordAlgebra.Vectors
 
 /-!
 # Lie representations induced from Clifford modules
@@ -29,6 +31,8 @@ Clifford action makes the target Clifford module a module for the original Lie a
   for a Killing-semisimple Lie algebra.
 * `CliffordAlgebra.adjointCliffordHom_lie_ι`: the lift acts on Clifford generators by the
   original adjoint action.
+* `CliffordAlgebra.adjointCliffordHom_injective`: the lift is injective, since the adjoint action
+  it encodes is faithful.
 
 ## References
 
@@ -147,5 +151,23 @@ theorem adjointCliffordHom_lie_ι (K : Type u) (L : Type v) [Field K]
       CliffordAlgebra.ι (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L) ⁅x, y⁆ := by
   rw [adjointCliffordHom, quadraticLift_lie_ι,
     _root_.TauCeti.LieAlgebra.coe_killingAdjointSO, _root_.LieAlgebra.ad_apply]
+
+/-- **The adjoint quadratic lift of a Killing-semisimple Lie algebra is injective.** Bracketing
+with a Clifford generator recovers the adjoint action, and the adjoint representation is faithful
+because the centre of a Killing-semisimple Lie algebra vanishes. -/
+theorem adjointCliffordHom_injective (K : Type u) (L : Type v) [Field K]
+    [LieRing L] [LieAlgebra K L] [FiniteDimensional K L] [Invertible (2 : K)]
+    [_root_.LieAlgebra.IsKilling K L] :
+    Function.Injective (adjointCliffordHom K L) := by
+  intro x y hxy
+  have hz : ∀ z : L, ⁅x, z⁆ = ⁅y, z⁆ := fun z ↦ by
+    refine ι_injective (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L) ?_
+    rw [← adjointCliffordHom_lie_ι K L x z, ← adjointCliffordHom_lie_ι K L y z, hxy]
+  refine (_root_.TauCeti.LieAlgebra.killingAdjointSO_injective_iff K L).mpr
+    (_root_.LieAlgebra.center_eq_bot K L) (Subtype.ext (LinearMap.ext fun z ↦ ?_))
+  rw [_root_.TauCeti.LieAlgebra.coe_killingAdjointSO,
+    _root_.TauCeti.LieAlgebra.coe_killingAdjointSO, _root_.LieAlgebra.ad_apply,
+    _root_.LieAlgebra.ad_apply]
+  exact hz z
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean
@@ -7,8 +7,6 @@ module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Realization
 public import TauCeti.Algebra.Lie.SkewAdjoint
--- Private: `CliffordAlgebra.ι_injective` is used only inside a proof.
-import TauCeti.LinearAlgebra.CliffordAlgebra.Vectors
 
 /-!
 # Lie representations induced from Clifford modules
@@ -21,6 +19,8 @@ Clifford action makes the target Clifford module a module for the original Lie a
 
 * `CliffordAlgebra.quadraticLift`: the quadratic realization of a skew-adjoint Lie action.
 * `CliffordAlgebra.quadraticLift_lie_ι`: its defining action on Clifford generators.
+* `CliffordAlgebra.quadraticLift_injective_iff`: the lift is injective exactly when the
+  skew-adjoint action it lifts is.
 * `CliffordAlgebra.cliffordInducedRep`: the induced Lie representation on a Clifford
   module.
 * `CliffordAlgebra.cliffordInducedRep_apply`: its defining equation.
@@ -88,6 +88,17 @@ theorem quadraticLift_lie_ι {K : Type u} [Field K]
     ⁅quadraticLift Q hQ θ x, ι Q v⁆ = ι Q ((θ x : Module.End K V) v) := by
   rw [quadraticLift_apply, soEquivQuadratic_lie_ι]
 
+/-- **The quadratic lift is injective exactly when the action it lifts is.** The lift is the
+skew-adjoint action followed by the quadratic realization equivalence and the inclusion of the
+quadratic Lie subalgebra, both of which are injective. -/
+theorem quadraticLift_injective_iff {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] [FiniteDimensional K V]
+    [Invertible (2 : K)] (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    {L : Type w} [LieRing L] [LieAlgebra K L]
+    (θ : L →ₗ⁅K⁆ skewAdjointLieSubalgebra (QuadraticMap.polarBilin Q)) :
+    Function.Injective (quadraticLift Q hQ θ) ↔ Function.Injective θ :=
+  (Subtype.val_injective.of_comp_iff _).trans ((soEquivQuadratic Q hQ).injective.of_comp_iff θ)
+
 /-- The Lie representation on a Clifford module induced through the quadratic realization. -/
 noncomputable def cliffordInducedRep {K : Type u} [Field K] {V : Type v} [AddCommGroup V]
     [Module K V] [FiniteDimensional K V] [Invertible (2 : K)] (Q : QuadraticForm K V)
@@ -152,22 +163,16 @@ theorem adjointCliffordHom_lie_ι (K : Type u) (L : Type v) [Field K]
   rw [adjointCliffordHom, quadraticLift_lie_ι,
     _root_.TauCeti.LieAlgebra.coe_killingAdjointSO, _root_.LieAlgebra.ad_apply]
 
-/-- **The adjoint quadratic lift of a Killing-semisimple Lie algebra is injective.** Bracketing
-with a Clifford generator recovers the adjoint action, and the adjoint representation is faithful
-because the centre of a Killing-semisimple Lie algebra vanishes. -/
+/-- **The adjoint quadratic lift of a Killing-semisimple Lie algebra is injective.** The lift is
+injective exactly when the adjoint action it lifts is
+(`CliffordAlgebra.quadraticLift_injective_iff`), and that action is faithful because the centre of
+a Killing-semisimple Lie algebra vanishes. -/
 theorem adjointCliffordHom_injective (K : Type u) (L : Type v) [Field K]
     [LieRing L] [LieAlgebra K L] [FiniteDimensional K L] [Invertible (2 : K)]
     [_root_.LieAlgebra.IsKilling K L] :
-    Function.Injective (adjointCliffordHom K L) := by
-  intro x y hxy
-  have hz : ∀ z : L, ⁅x, z⁆ = ⁅y, z⁆ := fun z ↦ by
-    refine ι_injective (_root_.TauCeti.LieAlgebra.killingQuadraticForm K L) ?_
-    rw [← adjointCliffordHom_lie_ι K L x z, ← adjointCliffordHom_lie_ι K L y z, hxy]
-  refine (_root_.TauCeti.LieAlgebra.killingAdjointSO_injective_iff K L).mpr
-    (_root_.LieAlgebra.center_eq_bot K L) (Subtype.ext (LinearMap.ext fun z ↦ ?_))
-  rw [_root_.TauCeti.LieAlgebra.coe_killingAdjointSO,
-    _root_.TauCeti.LieAlgebra.coe_killingAdjointSO, _root_.LieAlgebra.ad_apply,
-    _root_.LieAlgebra.ad_apply]
-  exact hz z
+    Function.Injective (adjointCliffordHom K L) :=
+  (quadraticLift_injective_iff _ _ _).2 <|
+    (_root_.TauCeti.LieAlgebra.killingAdjointSO_injective_iff K L).mpr
+      (_root_.LieAlgebra.center_eq_bot K L)
 
 end CliffordAlgebra


### PR DESCRIPTION
This PR packages the `L`-module that Kostant's isotypy theorem is a statement about: the Clifford algebra of the Killing quadratic form of a Killing-semisimple Lie algebra `L`, acted on by **left multiplication** by the adjoint quadratic lift `CliffordAlgebra.adjointCliffordHom`, so that `⁅x, c⁆ = adjointCliffordHom K L x * c`. This is the Layer 9 target "Kostant's setting, packaged" — `kostantLieRingModule`, `kostantLieModule`, `kostant_lie_def` — of `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md` and its `Suggested.lean`; the quadratic realization, `cliffordInducedRep`, `cliffordDerivationRep` and `adjointCliffordHom` that it sits on top of are already in the repository, and this is the module structure they were missing.

The choice of action is the point, so it is made twice. `TauCeti/Algebra/Lie/OfAssociative.lean` introduces `LieHom.leftRegularRep`, the representation `L →ₗ⁅R⁆ Module.End R A` attached to any Lie map `q : L →ₗ⁅R⁆ A` into an associative algebra bracketed by its ring commutator, with the API that distinguishes it from the inner derivation action: it is faithful exactly when `q` is (`LieHom.leftRegularRep_injective_iff`, read off the value at `1`), right multiplications intertwine it (`LieHom.leftRegularRep_comp_mulRight`), every left ideal of `A` is invariant (`LieHom.leftRegularRep_mem_of_mem`), and `LieHom.ad_apply_eq_leftRegularRep_sub_mulRight` records that the derivation action is this one minus right multiplication. The action is packaged as a homomorphism rather than an instance because it competes with the self-module structure of `A` as a Lie ring. `TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/LeftRegular.lean` then installs the two `scoped` instances the roadmap asks for and proves the defining equation, the value on a Clifford generator (`kostant_lie_ι`, where the adjoint action of `L` reappears together with a right-multiplication term), the comparison `kostant_lie_sub_mul` with the derivation action that `CliffordAlgebra.cliffordDerivationRep` supplies on the same carrier, right multiplication as a Lie module endomorphism (`kostantRightMul`), a left ideal as a Lie submodule (`kostantLieSubmoduleOfLeftIdeal`), and faithfulness as a `LieModule.IsFaithful` instance. The instances are scoped, not global, precisely because the derivation action is a different `L`-module on the same Clifford algebra and neither may be the default.

Faithfulness needs the adjoint quadratic lift to be injective, which is a statement about `adjointCliffordHom` rather than about the module, so `CliffordAlgebra.adjointCliffordHom_injective` is added beside that definition in `TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Lie/Representation.lean`; it is proved by bracketing with a Clifford generator to recover the adjoint action and then using that the centre of a Killing-semisimple Lie algebra vanishes. No Mathlib source was vendored; the construction consumes Mathlib's `LieRingModule.compLieHom`, `LieModule.compLieHom`, `Module.End.instLieRingModule` and `Algebra.lmul`, and the repository's existing quadratic-realization layer. The summits of the layer — `kostant_isotypic` and `kostant_multiplicity` — are deliberately not claimed here; this PR supplies the module they quantify over.

`lake build` and `lake exe axioms` are green (74203 declarations audited, allowlist only), and `scripts/lint-style.sh`, `scripts/lint-env.sh` and `scripts/lint-dot-notation.py` report no new violations.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"kostantlieringmodule"}-->

🤖 Prepared with Claude Code
