### PR TITLE
feat: add the ideal von Mangoldt transform

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -91,6 +91,7 @@ theorem vonMangoldt_apply_of_eq_prime_pow {A : (Ideal (𝓞 K))⁰} {P : Ideal (
   rw [hchosen]
 
 /-- The ideal von Mangoldt function at a positive power of a prime nonzero ideal. -/
+@[simp]
 theorem vonMangoldt_apply_prime_pow {P : (Ideal (𝓞 K))⁰}
     (hP : Prime (P : Ideal (𝓞 K))) {n : ℕ} (hn : 0 < n) :
     (vonMangoldt : IdealArithmeticFunction K) (P ^ n) =
@@ -99,6 +100,7 @@ theorem vonMangoldt_apply_prime_pow {P : (Ideal (𝓞 K))⁰}
   simp
 
 /-- The ideal von Mangoldt function at a prime ideal. -/
+@[simp]
 theorem vonMangoldt_apply_prime {P : (Ideal (𝓞 K))⁰}
     (hP : Prime (P : Ideal (𝓞 K))) :
     (vonMangoldt : IdealArithmeticFunction K) P =
@@ -107,7 +109,7 @@ theorem vonMangoldt_apply_prime {P : (Ideal (𝓞 K))⁰}
 
 /-- The ideal von Mangoldt function vanishes away from prime powers. -/
 @[simp]
-theorem vonMangoldt_of_not_isPrimePow {A : (Ideal (𝓞 K))⁰}
+theorem vonMangoldt_eq_zero_of_not_isPrimePow {A : (Ideal (𝓞 K))⁰}
     (hA : ¬ IsPrimePow (A : Ideal (𝓞 K))) :
     (vonMangoldt : IdealArithmeticFunction K) A = 0 := by
   simp [vonMangoldt, hA]
@@ -118,7 +120,7 @@ theorem vonMangoldt_ne_zero_iff {A : (Ideal (𝓞 K))⁰} :
   constructor
   · intro hne
     by_contra hnot
-    exact hne (vonMangoldt_of_not_isPrimePow hnot)
+    exact hne (vonMangoldt_eq_zero_of_not_isPrimePow hnot)
   · rintro ⟨P, n, hP, hn, hpow⟩
     rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow]
     apply Complex.ofReal_ne_zero.mpr
@@ -141,7 +143,7 @@ theorem vonMangoldt_im {A : (Ideal (𝓞 K))⁰} :
   by_cases hA : IsPrimePow (A : Ideal (𝓞 K))
   · obtain ⟨P, n, hP, hn, hpow⟩ := hA
     rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow, Complex.ofReal_im]
-  · rw [vonMangoldt_of_not_isPrimePow hA, Complex.zero_im]
+  · rw [vonMangoldt_eq_zero_of_not_isPrimePow hA, Complex.zero_im]
 
 /-- The (real) values of the ideal von Mangoldt function are nonnegative. -/
 theorem vonMangoldt_re_nonneg {A : (Ideal (𝓞 K))⁰} :
@@ -152,7 +154,7 @@ theorem vonMangoldt_re_nonneg {A : (Ideal (𝓞 K))⁰} :
     exact Real.log_nonneg (by exact_mod_cast
       (NumberField.HeightOneSpectrum.one_lt_absNorm
         (IsDedekindDomain.HeightOneSpectrum.ofPrime hP)).le)
-  · rw [vonMangoldt_of_not_isPrimePow hA, Complex.zero_re]
+  · rw [vonMangoldt_eq_zero_of_not_isPrimePow hA, Complex.zero_re]
 
 end IdealArithmeticFunction
 
@@ -165,6 +167,7 @@ noncomputable def vonMangoldtTransform (χ : MultiplicativeIdealWeight K) :
   χ.toIdealArithmeticFunction * IdealArithmeticFunction.vonMangoldt
 
 /-- Evaluation of the weighted von Mangoldt transform. -/
+@[simp]
 theorem vonMangoldtTransform_apply (χ : MultiplicativeIdealWeight K)
     (A : (Ideal (𝓞 K))⁰) :
     χ.vonMangoldtTransform A = χ A * IdealArithmeticFunction.vonMangoldt A := by
@@ -177,6 +180,7 @@ theorem vonMangoldtTransform_one (χ : MultiplicativeIdealWeight K) :
   rw [vonMangoldtTransform_apply, IdealArithmeticFunction.vonMangoldt_one, mul_zero]
 
 /-- The weighted von Mangoldt transform on a positive power of a prime ideal. -/
+@[simp]
 theorem vonMangoldtTransform_apply_prime_pow (χ : MultiplicativeIdealWeight K)
     {P : (Ideal (𝓞 K))⁰} (hP : Prime (P : Ideal (𝓞 K))) {n : ℕ} (hn : 0 < n) :
     χ.vonMangoldtTransform (P ^ n) =
@@ -195,12 +199,20 @@ theorem vonMangoldtTransform_ne_zero_iff (χ : MultiplicativeIdealWeight K)
   rw [vonMangoldtTransform_apply, mul_ne_zero_iff,
     IdealArithmeticFunction.vonMangoldt_ne_zero_iff, χ.apply_ne_zero_iff_isGood, and_comm]
 
+/-- The weighted von Mangoldt transform vanishes exactly away from the good prime powers. -/
+@[simp]
+theorem vonMangoldtTransform_eq_zero_iff (χ : MultiplicativeIdealWeight K)
+    {A : (Ideal (𝓞 K))⁰} :
+    χ.vonMangoldtTransform A = 0 ↔
+      ¬ (IsPrimePow (A : Ideal (𝓞 K)) ∧ χ.IsGood (A : Ideal (𝓞 K))) := by
+  simpa only [not_ne_iff] using not_congr (χ.vonMangoldtTransform_ne_zero_iff (A := A))
+
 /-- In particular, the weighted von Mangoldt transform is supported on prime powers. -/
 theorem vonMangoldtTransform_eq_zero_of_not_isPrimePow (χ : MultiplicativeIdealWeight K)
     {A : (Ideal (𝓞 K))⁰} (hA : ¬ IsPrimePow (A : Ideal (𝓞 K))) :
     χ.vonMangoldtTransform A = 0 := by
-  rw [vonMangoldtTransform_apply, IdealArithmeticFunction.vonMangoldt_of_not_isPrimePow hA,
-    mul_zero]
+  rw [vonMangoldtTransform_apply,
+    IdealArithmeticFunction.vonMangoldt_eq_zero_of_not_isPrimePow hA, mul_zero]
 
 /-- The transform of the trivial ideal weight is the ideal von Mangoldt function. -/
 @[simp]

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.IsPrimePow
+public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Weight
 
 /-!
@@ -61,13 +62,6 @@ variable {K : Type*} [Field K] [NumberField K]
 
 namespace IdealArithmeticFunction
 
-/-- Two prime ideals with equal positive powers are equal. -/
-private theorem prime_eq_of_pow_eq_pow {P Q : Ideal (𝓞 K)} (hP : Prime P) (hQ : Prime Q)
-    {m n : ℕ} (hm : 0 < m) (hn : 0 < n) (hpow : P ^ m = Q ^ n) : P = Q := by
-  apply dvd_antisymm
-  · exact hP.dvd_of_dvd_pow (by rw [← hpow]; exact dvd_pow_self P hm.ne')
-  · exact hQ.dvd_of_dvd_pow (by rw [hpow]; exact dvd_pow_self Q hn.ne')
-
 /-- The **ideal von Mangoldt function**.  It takes the value `log N(P)` on every positive power of
 a prime ideal `P`, and vanishes on ideals which are not prime powers.
 
@@ -92,9 +86,8 @@ theorem vonMangoldt_apply_of_eq_prime_pow {A : (Ideal (𝓞 K))⁰} {P : Ideal (
   let hA : IsPrimePow (A : Ideal (𝓞 K)) := ⟨P, n, hP, hn, hpow⟩
   simp only [vonMangoldt, hA, dite_true]
   have hchosen : hA.choose = P := by
-    apply prime_eq_of_pow_eq_pow hA.choose_spec.choose_spec.1 hP
-      hA.choose_spec.choose_spec.2.1 hn
-    exact hA.choose_spec.choose_spec.2.2.trans hpow.symm
+    exact eq_of_prime_pow_eq hA.choose_spec.choose_spec.1 hP
+      hA.choose_spec.choose_spec.2.1 (hA.choose_spec.choose_spec.2.2.trans hpow.symm)
   rw [hchosen]
 
 /-- The ideal von Mangoldt function at a positive power of a prime nonzero ideal. -/
@@ -119,17 +112,6 @@ theorem vonMangoldt_of_not_isPrimePow {A : (Ideal (𝓞 K))⁰}
     (vonMangoldt : IdealArithmeticFunction K) A = 0 := by
   simp [vonMangoldt, hA]
 
-/-- The norm of a prime ideal is strictly greater than one. -/
-private theorem one_lt_absNorm_of_prime {P : Ideal (𝓞 K)} (hP : Prime P) :
-    1 < Ideal.absNorm P := by
-  have hP0 : P ≠ ⊥ := hP.ne_zero
-  have hpos : 0 < Ideal.absNorm P :=
-    Ideal.absNorm_pos_of_nonZeroDivisors ⟨P, mem_nonZeroDivisors_of_ne_zero hP0⟩
-  have hne : Ideal.absNorm P ≠ 1 := by
-    intro h
-    exact hP.not_isUnit (_root_.Ideal.isUnit_iff.mpr (Ideal.absNorm_eq_one_iff.mp h))
-  omega
-
 /-- The support of the ideal von Mangoldt function is exactly the set of prime-power ideals. -/
 theorem vonMangoldt_ne_zero_iff {A : (Ideal (𝓞 K))⁰} :
     (vonMangoldt : IdealArithmeticFunction K) A ≠ 0 ↔ IsPrimePow (A : Ideal (𝓞 K)) := by
@@ -141,8 +123,11 @@ theorem vonMangoldt_ne_zero_iff {A : (Ideal (𝓞 K))⁰} :
     rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow]
     apply Complex.ofReal_ne_zero.mpr
     apply Real.log_ne_zero_of_pos_of_ne_one
-    · exact_mod_cast (Nat.zero_lt_one.trans (one_lt_absNorm_of_prime hP))
-    · exact_mod_cast (one_lt_absNorm_of_prime hP).ne'
+    · exact_mod_cast (Nat.zero_lt_one.trans
+        (NumberField.HeightOneSpectrum.one_lt_absNorm
+          (IsDedekindDomain.HeightOneSpectrum.ofPrime hP)))
+    · exact_mod_cast (NumberField.HeightOneSpectrum.one_lt_absNorm
+        (IsDedekindDomain.HeightOneSpectrum.ofPrime hP)).ne'
 
 /-- The ideal von Mangoldt function vanishes exactly away from prime powers. -/
 @[simp]
@@ -164,7 +149,9 @@ theorem vonMangoldt_re_nonneg {A : (Ideal (𝓞 K))⁰} :
   by_cases hA : IsPrimePow (A : Ideal (𝓞 K))
   · obtain ⟨P, n, hP, hn, hpow⟩ := hA
     rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow, Complex.ofReal_re]
-    exact Real.log_nonneg (by exact_mod_cast (one_lt_absNorm_of_prime hP).le)
+    exact Real.log_nonneg (by exact_mod_cast
+      (NumberField.HeightOneSpectrum.one_lt_absNorm
+        (IsDedekindDomain.HeightOneSpectrum.ofPrime hP)).le)
   · rw [vonMangoldt_of_not_isPrimePow hA, Complex.zero_re]
 
 end IdealArithmeticFunction
@@ -223,26 +210,5 @@ theorem one_vonMangoldtTransform :
   rw [vonMangoldtTransform, toIdealArithmeticFunction_one, one_mul]
 
 end MultiplicativeIdealWeight
-
-namespace UnitaryIdealWeight
-
-/-- The von Mangoldt transform of a unitary ideal weight, obtained from its underlying completely
-multiplicative weight. -/
-noncomputable def vonMangoldtTransform (χ : UnitaryIdealWeight K) : IdealArithmeticFunction K :=
-  χ.1.vonMangoldtTransform
-
-/-- Evaluation of the von Mangoldt transform of a unitary ideal weight. -/
-theorem vonMangoldtTransform_apply (χ : UnitaryIdealWeight K) (A : (Ideal (𝓞 K))⁰) :
-    χ.vonMangoldtTransform A = χ.1 A * IdealArithmeticFunction.vonMangoldt A :=
-  χ.1.vonMangoldtTransform_apply A
-
-/-- The support of the unitary weighted transform consists exactly of its good prime powers. -/
-theorem vonMangoldtTransform_ne_zero_iff (χ : UnitaryIdealWeight K)
-    {A : (Ideal (𝓞 K))⁰} :
-    χ.vonMangoldtTransform A ≠ 0 ↔
-      IsPrimePow (A : Ideal (𝓞 K)) ∧ χ.1.IsGood (A : Ideal (𝓞 K)) :=
-  χ.1.vonMangoldtTransform_ne_zero_iff
-
-end UnitaryIdealWeight
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -1,0 +1,248 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.IsPrimePow
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Weight
+
+/-!
+# The ideal von Mangoldt function
+
+The von Mangoldt function of a nonzero ideal `A` of the ring of integers of a number field is
+`log N(P)` when `A` is a positive power of a prime ideal `P`, and zero otherwise.  This file
+packages that function as an `IdealArithmeticFunction` and defines its pointwise twist by a
+completely multiplicative ideal weight.
+
+## Main definitions
+
+* `TauCeti.IdealArithmeticFunction.vonMangoldt` is the complex-valued ideal von Mangoldt
+  function.
+* `TauCeti.MultiplicativeIdealWeight.vonMangoldtTransform` is the weighted function
+  `A ↦ χ(A) Λ(A)`.
+
+## Main results
+
+* `TauCeti.IdealArithmeticFunction.vonMangoldt_apply_prime_pow` computes the value on a positive
+  power of a prime ideal.
+* `TauCeti.IdealArithmeticFunction.vonMangoldt_ne_zero_iff` says that its support is exactly the
+  prime-power ideals.
+* `TauCeti.MultiplicativeIdealWeight.vonMangoldtTransform_ne_zero_iff` identifies the support of
+  the weighted transform as the good prime powers for the weight.
+
+The definition chooses a prime base from a proof that `A` is a prime power.  The prime base is
+unique for ideals: if positive powers of two prime ideals agree, each prime divides the other, and
+associated ideals are equal.  The public evaluation theorem therefore removes the choice from
+every computation.
+
+## Roadmap role
+
+This is the algebraic part of Layer **2.3** of
+`TauCetiRoadmap/ArithmeticDirichletSeries/README.md`.  The logarithmic-derivative identity named in
+that target additionally requires the Euler-product package of Layer 3; this file supplies its
+coefficient and exact prime-power support in advance.
+
+## References
+
+* J. Neukirch, *Algebraic Number Theory*, Chapter VII.
+* G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapter I.2.
+-/
+
+public section
+
+namespace TauCeti
+
+open NumberField IsDedekindDomain
+open scoped nonZeroDivisors NumberField
+
+variable {K : Type*} [Field K] [NumberField K]
+
+namespace IdealArithmeticFunction
+
+/-- Two prime ideals with equal positive powers are equal. -/
+private theorem prime_eq_of_pow_eq_pow {P Q : Ideal (𝓞 K)} (hP : Prime P) (hQ : Prime Q)
+    {m n : ℕ} (hm : 0 < m) (hn : 0 < n) (hpow : P ^ m = Q ^ n) : P = Q := by
+  apply dvd_antisymm
+  · exact hP.dvd_of_dvd_pow (by rw [← hpow]; exact dvd_pow_self P hm.ne')
+  · exact hQ.dvd_of_dvd_pow (by rw [hpow]; exact dvd_pow_self Q hn.ne')
+
+/-- The **ideal von Mangoldt function**.  It takes the value `log N(P)` on every positive power of
+a prime ideal `P`, and vanishes on ideals which are not prime powers.
+
+The codomain is `ℂ`, matching `IdealArithmeticFunction`, although every value is real. -/
+noncomputable def vonMangoldt : IdealArithmeticFunction K := fun A ↦ by
+  classical
+  exact if h : IsPrimePow (A : Ideal (𝓞 K)) then
+      (Real.log (Ideal.absNorm h.choose) : ℂ)
+    else 0
+
+/-- The ideal von Mangoldt function vanishes at the unit ideal. -/
+@[simp]
+theorem vonMangoldt_one : (vonMangoldt : IdealArithmeticFunction K) 1 = 0 := by
+  rw [vonMangoldt, dite_eq_right]
+  exact isUnit_one.not_isPrimePow
+
+/-- The value of the ideal von Mangoldt function at a positive power of a prime ideal.  This is the
+choice-free characterization of `vonMangoldt` on its support. -/
+theorem vonMangoldt_apply_of_eq_prime_pow {A : (Ideal (𝓞 K))⁰} {P : Ideal (𝓞 K)}
+    (hP : Prime P) {n : ℕ} (hn : 0 < n) (hpow : P ^ n = (A : Ideal (𝓞 K))) :
+    (vonMangoldt : IdealArithmeticFunction K) A = Real.log (Ideal.absNorm P) := by
+  let hA : IsPrimePow (A : Ideal (𝓞 K)) := ⟨P, n, hP, hn, hpow⟩
+  simp only [vonMangoldt, hA, dite_true]
+  have hchosen : hA.choose = P := by
+    apply prime_eq_of_pow_eq_pow hA.choose_spec.choose_spec.1 hP
+      hA.choose_spec.choose_spec.2.1 hn
+    exact hA.choose_spec.choose_spec.2.2.trans hpow.symm
+  rw [hchosen]
+
+/-- The ideal von Mangoldt function at a positive power of a prime nonzero ideal. -/
+theorem vonMangoldt_apply_prime_pow {P : (Ideal (𝓞 K))⁰}
+    (hP : Prime (P : Ideal (𝓞 K))) {n : ℕ} (hn : 0 < n) :
+    (vonMangoldt : IdealArithmeticFunction K) (P ^ n) =
+      Real.log (Ideal.absNorm (P : Ideal (𝓞 K))) := by
+  apply vonMangoldt_apply_of_eq_prime_pow hP hn
+  simp
+
+/-- The ideal von Mangoldt function at a prime ideal. -/
+theorem vonMangoldt_apply_prime {P : (Ideal (𝓞 K))⁰}
+    (hP : Prime (P : Ideal (𝓞 K))) :
+    (vonMangoldt : IdealArithmeticFunction K) P =
+      Real.log (Ideal.absNorm (P : Ideal (𝓞 K))) := by
+  simpa using vonMangoldt_apply_prime_pow hP (n := 1) zero_lt_one
+
+/-- The ideal von Mangoldt function vanishes away from prime powers. -/
+@[simp]
+theorem vonMangoldt_of_not_isPrimePow {A : (Ideal (𝓞 K))⁰}
+    (hA : ¬ IsPrimePow (A : Ideal (𝓞 K))) :
+    (vonMangoldt : IdealArithmeticFunction K) A = 0 := by
+  simp [vonMangoldt, hA]
+
+/-- The norm of a prime ideal is strictly greater than one. -/
+private theorem one_lt_absNorm_of_prime {P : Ideal (𝓞 K)} (hP : Prime P) :
+    1 < Ideal.absNorm P := by
+  have hP0 : P ≠ ⊥ := hP.ne_zero
+  have hpos : 0 < Ideal.absNorm P :=
+    Ideal.absNorm_pos_of_nonZeroDivisors ⟨P, mem_nonZeroDivisors_of_ne_zero hP0⟩
+  have hne : Ideal.absNorm P ≠ 1 := by
+    intro h
+    exact hP.not_isUnit (_root_.Ideal.isUnit_iff.mpr (Ideal.absNorm_eq_one_iff.mp h))
+  omega
+
+/-- The support of the ideal von Mangoldt function is exactly the set of prime-power ideals. -/
+theorem vonMangoldt_ne_zero_iff {A : (Ideal (𝓞 K))⁰} :
+    (vonMangoldt : IdealArithmeticFunction K) A ≠ 0 ↔ IsPrimePow (A : Ideal (𝓞 K)) := by
+  constructor
+  · intro hne
+    by_contra hnot
+    exact hne (vonMangoldt_of_not_isPrimePow hnot)
+  · rintro ⟨P, n, hP, hn, hpow⟩
+    rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow]
+    apply Complex.ofReal_ne_zero.mpr
+    apply Real.log_ne_zero_of_pos_of_ne_one
+    · exact_mod_cast (Nat.zero_lt_one.trans (one_lt_absNorm_of_prime hP))
+    · exact_mod_cast (one_lt_absNorm_of_prime hP).ne'
+
+/-- The ideal von Mangoldt function vanishes exactly away from prime powers. -/
+@[simp]
+theorem vonMangoldt_eq_zero_iff {A : (Ideal (𝓞 K))⁰} :
+    (vonMangoldt : IdealArithmeticFunction K) A = 0 ↔ ¬ IsPrimePow (A : Ideal (𝓞 K)) :=
+  by simpa only [not_ne_iff] using not_congr (vonMangoldt_ne_zero_iff (K := K) (A := A))
+
+/-- Every value of the ideal von Mangoldt function is real. -/
+theorem vonMangoldt_im {A : (Ideal (𝓞 K))⁰} :
+    ((vonMangoldt : IdealArithmeticFunction K) A).im = 0 := by
+  by_cases hA : IsPrimePow (A : Ideal (𝓞 K))
+  · obtain ⟨P, n, hP, hn, hpow⟩ := hA
+    rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow, Complex.ofReal_im]
+  · rw [vonMangoldt_of_not_isPrimePow hA, Complex.zero_im]
+
+/-- The (real) values of the ideal von Mangoldt function are nonnegative. -/
+theorem vonMangoldt_re_nonneg {A : (Ideal (𝓞 K))⁰} :
+    0 ≤ ((vonMangoldt : IdealArithmeticFunction K) A).re := by
+  by_cases hA : IsPrimePow (A : Ideal (𝓞 K))
+  · obtain ⟨P, n, hP, hn, hpow⟩ := hA
+    rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow, Complex.ofReal_re]
+    exact Real.log_nonneg (by exact_mod_cast (one_lt_absNorm_of_prime hP).le)
+  · rw [vonMangoldt_of_not_isPrimePow hA, Complex.zero_re]
+
+end IdealArithmeticFunction
+
+namespace MultiplicativeIdealWeight
+
+/-- The **von Mangoldt transform** attached to a completely multiplicative ideal weight `χ`:
+the ideal arithmetic function `A ↦ χ(A) Λ(A)`. -/
+noncomputable def vonMangoldtTransform (χ : MultiplicativeIdealWeight K) :
+    IdealArithmeticFunction K :=
+  χ.toIdealArithmeticFunction * IdealArithmeticFunction.vonMangoldt
+
+/-- Evaluation of the weighted von Mangoldt transform. -/
+theorem vonMangoldtTransform_apply (χ : MultiplicativeIdealWeight K)
+    (A : (Ideal (𝓞 K))⁰) :
+    χ.vonMangoldtTransform A = χ A * IdealArithmeticFunction.vonMangoldt A := by
+  rw [vonMangoldtTransform, Pi.mul_apply, toIdealArithmeticFunction_apply]
+
+/-- The weighted von Mangoldt transform vanishes at the unit ideal. -/
+@[simp]
+theorem vonMangoldtTransform_one (χ : MultiplicativeIdealWeight K) :
+    χ.vonMangoldtTransform 1 = 0 := by
+  rw [vonMangoldtTransform_apply, IdealArithmeticFunction.vonMangoldt_one, mul_zero]
+
+/-- The weighted von Mangoldt transform on a positive power of a prime ideal. -/
+theorem vonMangoldtTransform_apply_prime_pow (χ : MultiplicativeIdealWeight K)
+    {P : (Ideal (𝓞 K))⁰} (hP : Prime (P : Ideal (𝓞 K))) {n : ℕ} (hn : 0 < n) :
+    χ.vonMangoldtTransform (P ^ n) =
+      χ P ^ n * Real.log (Ideal.absNorm (P : Ideal (𝓞 K))) := by
+  rw [vonMangoldtTransform_apply,
+    IdealArithmeticFunction.vonMangoldt_apply_prime_pow hP hn]
+  congr 1
+  exact map_pow χ (P : Ideal (𝓞 K)) n
+
+/-- The support of the weighted von Mangoldt transform consists exactly of the prime powers on
+which the weight is good. -/
+theorem vonMangoldtTransform_ne_zero_iff (χ : MultiplicativeIdealWeight K)
+    {A : (Ideal (𝓞 K))⁰} :
+    χ.vonMangoldtTransform A ≠ 0 ↔
+      IsPrimePow (A : Ideal (𝓞 K)) ∧ χ.IsGood (A : Ideal (𝓞 K)) := by
+  rw [vonMangoldtTransform_apply, mul_ne_zero_iff,
+    IdealArithmeticFunction.vonMangoldt_ne_zero_iff, χ.apply_ne_zero_iff_isGood, and_comm]
+
+/-- In particular, the weighted von Mangoldt transform is supported on prime powers. -/
+theorem vonMangoldtTransform_eq_zero_of_not_isPrimePow (χ : MultiplicativeIdealWeight K)
+    {A : (Ideal (𝓞 K))⁰} (hA : ¬ IsPrimePow (A : Ideal (𝓞 K))) :
+    χ.vonMangoldtTransform A = 0 := by
+  rw [vonMangoldtTransform_apply, IdealArithmeticFunction.vonMangoldt_of_not_isPrimePow hA,
+    mul_zero]
+
+/-- The transform of the trivial ideal weight is the ideal von Mangoldt function. -/
+@[simp]
+theorem one_vonMangoldtTransform :
+    (1 : MultiplicativeIdealWeight K).vonMangoldtTransform =
+      IdealArithmeticFunction.vonMangoldt := by
+  rw [vonMangoldtTransform, toIdealArithmeticFunction_one, one_mul]
+
+end MultiplicativeIdealWeight
+
+namespace UnitaryIdealWeight
+
+/-- The von Mangoldt transform of a unitary ideal weight, obtained from its underlying completely
+multiplicative weight. -/
+noncomputable def vonMangoldtTransform (χ : UnitaryIdealWeight K) : IdealArithmeticFunction K :=
+  χ.1.vonMangoldtTransform
+
+/-- Evaluation of the von Mangoldt transform of a unitary ideal weight. -/
+theorem vonMangoldtTransform_apply (χ : UnitaryIdealWeight K) (A : (Ideal (𝓞 K))⁰) :
+    χ.vonMangoldtTransform A = χ.1 A * IdealArithmeticFunction.vonMangoldt A :=
+  χ.1.vonMangoldtTransform_apply A
+
+/-- The support of the unitary weighted transform consists exactly of its good prime powers. -/
+theorem vonMangoldtTransform_ne_zero_iff (χ : UnitaryIdealWeight K)
+    {A : (Ideal (𝓞 K))⁰} :
+    χ.vonMangoldtTransform A ≠ 0 ↔
+      IsPrimePow (A : Ideal (𝓞 K)) ∧ χ.1.IsGood (A : Ideal (𝓞 K)) :=
+  χ.1.vonMangoldtTransform_ne_zero_iff
+
+end UnitaryIdealWeight
+
+end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.IsPrimePow
-public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
+import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Weight
 
 /-!
@@ -14,15 +14,15 @@ public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Weight
 
 The von Mangoldt function of a nonzero ideal `A` of the ring of integers of a number field is
 `log N(P)` when `A` is a positive power of a prime ideal `P`, and zero otherwise.  This file
-packages that function as an `IdealArithmeticFunction` and defines its pointwise twist by a
-completely multiplicative ideal weight.
+packages that function as an `IdealArithmeticFunction` and defines its pointwise product with an
+ideal arithmetic function.
 
 ## Main definitions
 
 * `TauCeti.IdealArithmeticFunction.vonMangoldt` is the complex-valued ideal von Mangoldt
   function.
-* `TauCeti.MultiplicativeIdealWeight.vonMangoldtTransform` is the weighted function
-  `A ↦ χ(A) Λ(A)`.
+* `TauCeti.IdealArithmeticFunction.vonMangoldtTransform` sends `f` to the weighted function
+  `A ↦ f(A) Λ(A)`.
 
 ## Main results
 
@@ -30,8 +30,9 @@ completely multiplicative ideal weight.
   power of a prime ideal.
 * `TauCeti.IdealArithmeticFunction.vonMangoldt_ne_zero_iff` says that its support is exactly the
   prime-power ideals.
-* `TauCeti.MultiplicativeIdealWeight.vonMangoldtTransform_ne_zero_iff` identifies the support of
-  the weighted transform as the good prime powers for the weight.
+* `TauCeti.IdealArithmeticFunction.vonMangoldtTransform_ne_zero_iff` identifies the support of
+  the transform, and its specialization in `TauCeti.MultiplicativeIdealWeight` describes this as
+  the good prime powers for a completely multiplicative weight.
 
 The definition chooses a prime base from a proof that `A` is a prime power.  The prime base is
 unique for ideals: if positive powers of two prime ideals agree, each prime divides the other, and
@@ -156,76 +157,100 @@ theorem vonMangoldt_re_nonneg {A : (Ideal (𝓞 K))⁰} :
         (IsDedekindDomain.HeightOneSpectrum.ofPrime hP)).le)
   · rw [vonMangoldt_eq_zero_of_not_isPrimePow hA, Complex.zero_re]
 
+/-- The **von Mangoldt transform** of an ideal arithmetic function `f`: the pointwise product
+`A ↦ f(A) Λ(A)`. -/
+noncomputable def vonMangoldtTransform (f : IdealArithmeticFunction K) :
+    IdealArithmeticFunction K :=
+  f * vonMangoldt
+
+/-- Evaluation of the von Mangoldt transform. -/
+@[simp]
+theorem vonMangoldtTransform_apply (f : IdealArithmeticFunction K)
+    (A : (Ideal (𝓞 K))⁰) :
+    f.vonMangoldtTransform A = f A * vonMangoldt A := by
+  rw [vonMangoldtTransform, Pi.mul_apply]
+
+/-- Every von Mangoldt transform vanishes at the unit ideal.
+
+This is a named convenience lemma rather than a simp lemma: the general evaluation rule already
+simplifies this case. -/
+theorem vonMangoldtTransform_one (f : IdealArithmeticFunction K) :
+    f.vonMangoldtTransform 1 = 0 := by
+  rw [vonMangoldtTransform_apply, vonMangoldt_one, mul_zero]
+
+/-- The von Mangoldt transform on a positive power of a prime ideal.
+
+This is a named convenience lemma rather than a simp lemma: the general evaluation rule already
+simplifies this case. -/
+theorem vonMangoldtTransform_apply_prime_pow (f : IdealArithmeticFunction K)
+    {P : (Ideal (𝓞 K))⁰} (hP : Prime (P : Ideal (𝓞 K))) {n : ℕ} (hn : 0 < n) :
+    f.vonMangoldtTransform (P ^ n) =
+      f (P ^ n) * Real.log (Ideal.absNorm (P : Ideal (𝓞 K))) := by
+  rw [vonMangoldtTransform_apply, vonMangoldt_apply_prime_pow hP hn]
+
+/-- The support of a von Mangoldt transform is the intersection of the support of the original
+function with the prime-power ideals. -/
+theorem vonMangoldtTransform_ne_zero_iff (f : IdealArithmeticFunction K)
+    {A : (Ideal (𝓞 K))⁰} :
+    f.vonMangoldtTransform A ≠ 0 ↔
+      IsPrimePow (A : Ideal (𝓞 K)) ∧ f A ≠ 0 := by
+  rw [vonMangoldtTransform_apply, mul_ne_zero_iff, vonMangoldt_ne_zero_iff, and_comm]
+
+/-- A von Mangoldt transform vanishes exactly when it lies outside the intersection of the
+original support with the prime powers.
+
+This is not a simp lemma because the general evaluation rule normalizes its left-hand side to a
+pointwise product. -/
+theorem vonMangoldtTransform_eq_zero_iff (f : IdealArithmeticFunction K)
+    {A : (Ideal (𝓞 K))⁰} :
+    f.vonMangoldtTransform A = 0 ↔
+      ¬ (IsPrimePow (A : Ideal (𝓞 K)) ∧ f A ≠ 0) := by
+  simpa only [not_ne_iff] using not_congr (f.vonMangoldtTransform_ne_zero_iff (A := A))
+
+/-- In particular, every von Mangoldt transform is supported on prime powers. -/
+theorem vonMangoldtTransform_eq_zero_of_not_isPrimePow (f : IdealArithmeticFunction K)
+    {A : (Ideal (𝓞 K))⁰} (hA : ¬ IsPrimePow (A : Ideal (𝓞 K))) :
+    f.vonMangoldtTransform A = 0 := by
+  rw [vonMangoldtTransform_apply, vonMangoldt_eq_zero_of_not_isPrimePow hA, mul_zero]
+
+/-- The transform of the constant-one ideal arithmetic function is the ideal von Mangoldt
+function. -/
+@[simp]
+theorem one_vonMangoldtTransform :
+    (1 : IdealArithmeticFunction K).vonMangoldtTransform = vonMangoldt := by
+  rw [vonMangoldtTransform, one_mul]
+
 end IdealArithmeticFunction
 
 namespace MultiplicativeIdealWeight
 
-/-- The **von Mangoldt transform** attached to a completely multiplicative ideal weight `χ`:
-the ideal arithmetic function `A ↦ χ(A) Λ(A)`. -/
-noncomputable def vonMangoldtTransform (χ : MultiplicativeIdealWeight K) :
-    IdealArithmeticFunction K :=
-  χ.toIdealArithmeticFunction * IdealArithmeticFunction.vonMangoldt
-
-/-- Evaluation of the weighted von Mangoldt transform. -/
-@[simp]
-theorem vonMangoldtTransform_apply (χ : MultiplicativeIdealWeight K)
-    (A : (Ideal (𝓞 K))⁰) :
-    χ.vonMangoldtTransform A = χ A * IdealArithmeticFunction.vonMangoldt A := by
-  rw [vonMangoldtTransform, Pi.mul_apply, toIdealArithmeticFunction_apply]
-
-/-- The weighted von Mangoldt transform vanishes at the unit ideal.
-
-This is a named convenience lemma rather than a simp lemma: the general evaluation rule already
-simplifies this case. -/
-theorem vonMangoldtTransform_one (χ : MultiplicativeIdealWeight K) :
-    χ.vonMangoldtTransform 1 = 0 := by
-  rw [vonMangoldtTransform_apply, IdealArithmeticFunction.vonMangoldt_one, mul_zero]
-
-/-- The weighted von Mangoldt transform on a positive power of a prime ideal.
-
-This is a named convenience lemma rather than a simp lemma: the general evaluation rule already
-simplifies this case. -/
+/-- The von Mangoldt transform of a completely multiplicative weight on a positive power of a
+prime ideal. -/
 theorem vonMangoldtTransform_apply_prime_pow (χ : MultiplicativeIdealWeight K)
     {P : (Ideal (𝓞 K))⁰} (hP : Prime (P : Ideal (𝓞 K))) {n : ℕ} (hn : 0 < n) :
-    χ.vonMangoldtTransform (P ^ n) =
+    χ.toIdealArithmeticFunction.vonMangoldtTransform (P ^ n) =
       χ P ^ n * Real.log (Ideal.absNorm (P : Ideal (𝓞 K))) := by
-  rw [vonMangoldtTransform_apply,
-    IdealArithmeticFunction.vonMangoldt_apply_prime_pow hP hn]
+  rw [IdealArithmeticFunction.vonMangoldtTransform_apply_prime_pow _ hP hn,
+    toIdealArithmeticFunction_apply]
   congr 1
   exact map_pow χ (P : Ideal (𝓞 K)) n
 
-/-- The support of the weighted von Mangoldt transform consists exactly of the prime powers on
-which the weight is good. -/
+/-- The support of the von Mangoldt transform of a completely multiplicative weight consists
+exactly of the prime powers on which the weight is good. -/
 theorem vonMangoldtTransform_ne_zero_iff (χ : MultiplicativeIdealWeight K)
     {A : (Ideal (𝓞 K))⁰} :
-    χ.vonMangoldtTransform A ≠ 0 ↔
+    χ.toIdealArithmeticFunction.vonMangoldtTransform A ≠ 0 ↔
       IsPrimePow (A : Ideal (𝓞 K)) ∧ χ.IsGood (A : Ideal (𝓞 K)) := by
-  rw [vonMangoldtTransform_apply, mul_ne_zero_iff,
-    IdealArithmeticFunction.vonMangoldt_ne_zero_iff, χ.apply_ne_zero_iff_isGood, and_comm]
+  rw [IdealArithmeticFunction.vonMangoldtTransform_ne_zero_iff,
+    toIdealArithmeticFunction_apply, χ.apply_ne_zero_iff_isGood]
 
-/-- The weighted von Mangoldt transform vanishes exactly away from the good prime powers.
-
-This is not a simp lemma because the general evaluation rule normalizes its left-hand side to a
-condition on `χ A` and prime-power support. -/
+/-- The von Mangoldt transform of a completely multiplicative weight vanishes exactly away from
+the good prime powers. -/
 theorem vonMangoldtTransform_eq_zero_iff (χ : MultiplicativeIdealWeight K)
     {A : (Ideal (𝓞 K))⁰} :
-    χ.vonMangoldtTransform A = 0 ↔
+    χ.toIdealArithmeticFunction.vonMangoldtTransform A = 0 ↔
       ¬ (IsPrimePow (A : Ideal (𝓞 K)) ∧ χ.IsGood (A : Ideal (𝓞 K))) := by
   simpa only [not_ne_iff] using not_congr (χ.vonMangoldtTransform_ne_zero_iff (A := A))
-
-/-- In particular, the weighted von Mangoldt transform is supported on prime powers. -/
-theorem vonMangoldtTransform_eq_zero_of_not_isPrimePow (χ : MultiplicativeIdealWeight K)
-    {A : (Ideal (𝓞 K))⁰} (hA : ¬ IsPrimePow (A : Ideal (𝓞 K))) :
-    χ.vonMangoldtTransform A = 0 := by
-  rw [vonMangoldtTransform_apply,
-    IdealArithmeticFunction.vonMangoldt_eq_zero_of_not_isPrimePow hA, mul_zero]
-
-/-- The transform of the trivial ideal weight is the ideal von Mangoldt function. -/
-@[simp]
-theorem one_vonMangoldtTransform :
-    (1 : MultiplicativeIdealWeight K).vonMangoldtTransform =
-      IdealArithmeticFunction.vonMangoldt := by
-  rw [vonMangoldtTransform, toIdealArithmeticFunction_one, one_mul]
 
 end MultiplicativeIdealWeight
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.IsPrimePow
-import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Weight
 
 /-!
@@ -34,10 +33,16 @@ ideal arithmetic function.
   the transform, and its specialization in `TauCeti.MultiplicativeIdealWeight` describes this as
   the good prime powers for a completely multiplicative weight.
 
-The definition chooses a prime base from a proof that `A` is a prime power.  The prime base is
-unique for ideals: if positive powers of two prime ideals agree, each prime divides the other, and
-associated ideals are equal.  The public evaluation theorem therefore removes the choice from
-every computation.
+The definition chooses a prime base from a proof that `A` is a prime power.  Mathlib's
+`eq_of_prime_pow_eq`, applied to ideals, identifies that choice with any prime base supplied by a
+caller.  The public evaluation theorem therefore removes the choice from every computation.
+
+## Implementation notes
+
+This is the ideal analogue of Mathlib's `ArithmeticFunction.vonMangoldt`.  Here the prime base is
+chosen from `IsPrimePow` rather than computed by `Nat.minFac`, its logarithmic weight is
+`Ideal.absNorm P` rather than `p`, and the function is complex-valued to match
+`IdealArithmeticFunction`.
 
 ## Roadmap role
 
@@ -56,27 +61,27 @@ public section
 
 namespace TauCeti
 
-open NumberField IsDedekindDomain
+open NumberField
 open scoped nonZeroDivisors NumberField
 
 variable {K : Type*} [Field K] [NumberField K]
 
 namespace IdealArithmeticFunction
 
+open Classical in
 /-- The **ideal von Mangoldt function**.  It takes the value `log N(P)` on every positive power of
 a prime ideal `P`, and vanishes on ideals which are not prime powers.
 
 The codomain is `ℂ`, matching `IdealArithmeticFunction`, although every value is real. -/
-noncomputable def vonMangoldt : IdealArithmeticFunction K := fun A ↦ by
-  classical
-  exact if h : IsPrimePow (A : Ideal (𝓞 K)) then
-      (Real.log (Ideal.absNorm h.choose) : ℂ)
-    else 0
+noncomputable def vonMangoldt : IdealArithmeticFunction K := fun A ↦
+  if h : IsPrimePow (A : Ideal (𝓞 K)) then
+    (Real.log (Ideal.absNorm h.choose) : ℂ)
+  else 0
 
 /-- The ideal von Mangoldt function vanishes at the unit ideal. -/
 @[simp]
 theorem vonMangoldt_one : (vonMangoldt : IdealArithmeticFunction K) 1 = 0 := by
-  rw [vonMangoldt, dite_eq_right]
+  rw [vonMangoldt, Submonoid.coe_one, dite_eq_right]
   exact isUnit_one.not_isPrimePow
 
 /-- The value of the ideal von Mangoldt function at a positive power of a prime ideal.  This is the
@@ -84,12 +89,11 @@ choice-free characterization of `vonMangoldt` on its support. -/
 theorem vonMangoldt_apply_of_eq_prime_pow {A : (Ideal (𝓞 K))⁰} {P : Ideal (𝓞 K)}
     (hP : Prime P) {n : ℕ} (hn : 0 < n) (hpow : P ^ n = (A : Ideal (𝓞 K))) :
     (vonMangoldt : IdealArithmeticFunction K) A = Real.log (Ideal.absNorm P) := by
-  let hA : IsPrimePow (A : Ideal (𝓞 K)) := ⟨P, n, hP, hn, hpow⟩
-  simp only [vonMangoldt, hA, dite_true]
+  have hA : IsPrimePow (A : Ideal (𝓞 K)) := ⟨P, n, hP, hn, hpow⟩
   have hchosen : hA.choose = P := by
     exact eq_of_prime_pow_eq hA.choose_spec.choose_spec.1 hP
       hA.choose_spec.choose_spec.2.1 (hA.choose_spec.choose_spec.2.2.trans hpow.symm)
-  rw [hchosen]
+  rw [vonMangoldt, dite_eq_left hA, hchosen]
 
 /-- The ideal von Mangoldt function at a positive power of a prime nonzero ideal. -/
 @[simp]
@@ -115,6 +119,13 @@ theorem vonMangoldt_eq_zero_of_not_isPrimePow {A : (Ideal (𝓞 K))⁰}
     (vonMangoldt : IdealArithmeticFunction K) A = 0 := by
   simp [vonMangoldt, hA]
 
+private theorem one_lt_absNorm_of_prime {P : Ideal (𝓞 K)} (hP : Prime P) :
+    1 < Ideal.absNorm P := by
+  rw [Nat.one_lt_iff_ne_zero_and_ne_one]
+  exact ⟨Ideal.absNorm_eq_zero_iff.not.mpr hP.ne_zero,
+    Ideal.absNorm_eq_one_iff.not.mpr fun htop ↦
+      hP.not_isUnit (Ideal.isUnit_iff.mpr htop)⟩
+
 /-- The support of the ideal von Mangoldt function is exactly the set of prime-power ideals. -/
 theorem vonMangoldt_ne_zero_iff {A : (Ideal (𝓞 K))⁰} :
     (vonMangoldt : IdealArithmeticFunction K) A ≠ 0 ↔ IsPrimePow (A : Ideal (𝓞 K)) := by
@@ -126,11 +137,8 @@ theorem vonMangoldt_ne_zero_iff {A : (Ideal (𝓞 K))⁰} :
     rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow]
     apply Complex.ofReal_ne_zero.mpr
     apply Real.log_ne_zero_of_pos_of_ne_one
-    · exact_mod_cast (Nat.zero_lt_one.trans
-        (NumberField.HeightOneSpectrum.one_lt_absNorm
-          (IsDedekindDomain.HeightOneSpectrum.ofPrime hP)))
-    · exact_mod_cast (NumberField.HeightOneSpectrum.one_lt_absNorm
-        (IsDedekindDomain.HeightOneSpectrum.ofPrime hP)).ne'
+    · exact_mod_cast Nat.zero_lt_one.trans (one_lt_absNorm_of_prime hP)
+    · exact_mod_cast (one_lt_absNorm_of_prime hP).ne'
 
 /-- The ideal von Mangoldt function vanishes exactly away from prime powers. -/
 @[simp]
@@ -138,24 +146,27 @@ theorem vonMangoldt_eq_zero_iff {A : (Ideal (𝓞 K))⁰} :
     (vonMangoldt : IdealArithmeticFunction K) A = 0 ↔ ¬ IsPrimePow (A : Ideal (𝓞 K)) :=
   by simpa only [not_ne_iff] using not_congr (vonMangoldt_ne_zero_iff (K := K) (A := A))
 
+private theorem exists_ofReal_eq_vonMangoldt (A : (Ideal (𝓞 K))⁰) :
+    ∃ r : ℝ, 0 ≤ r ∧ (vonMangoldt : IdealArithmeticFunction K) A = (r : ℂ) := by
+  by_cases hA : IsPrimePow (A : Ideal (𝓞 K))
+  · obtain ⟨P, n, hP, hn, hpow⟩ := hA
+    refine ⟨Real.log (Ideal.absNorm P), Real.log_nonneg ?_,
+      vonMangoldt_apply_of_eq_prime_pow hP hn hpow⟩
+    exact_mod_cast (one_lt_absNorm_of_prime hP).le
+  · exact ⟨0, le_rfl, vonMangoldt_eq_zero_of_not_isPrimePow hA⟩
+
 /-- Every value of the ideal von Mangoldt function is real. -/
 theorem vonMangoldt_im {A : (Ideal (𝓞 K))⁰} :
     ((vonMangoldt : IdealArithmeticFunction K) A).im = 0 := by
-  by_cases hA : IsPrimePow (A : Ideal (𝓞 K))
-  · obtain ⟨P, n, hP, hn, hpow⟩ := hA
-    rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow, Complex.ofReal_im]
-  · rw [vonMangoldt_eq_zero_of_not_isPrimePow hA, Complex.zero_im]
+  obtain ⟨r, -, hr⟩ := exists_ofReal_eq_vonMangoldt A
+  rw [hr, Complex.ofReal_im]
 
 /-- The (real) values of the ideal von Mangoldt function are nonnegative. -/
 theorem vonMangoldt_re_nonneg {A : (Ideal (𝓞 K))⁰} :
     0 ≤ ((vonMangoldt : IdealArithmeticFunction K) A).re := by
-  by_cases hA : IsPrimePow (A : Ideal (𝓞 K))
-  · obtain ⟨P, n, hP, hn, hpow⟩ := hA
-    rw [vonMangoldt_apply_of_eq_prime_pow hP hn hpow, Complex.ofReal_re]
-    exact Real.log_nonneg (by exact_mod_cast
-      (NumberField.HeightOneSpectrum.one_lt_absNorm
-        (IsDedekindDomain.HeightOneSpectrum.ofPrime hP)).le)
-  · rw [vonMangoldt_eq_zero_of_not_isPrimePow hA, Complex.zero_re]
+  obtain ⟨r, hr, hvalue⟩ := exists_ofReal_eq_vonMangoldt A
+  rw [hvalue, Complex.ofReal_re]
+  exact hr
 
 /-- The **von Mangoldt transform** of an ideal arithmetic function `f`: the pointwise product
 `A ↦ f(A) Λ(A)`. -/
@@ -164,24 +175,13 @@ noncomputable def vonMangoldtTransform (f : IdealArithmeticFunction K) :
   f * vonMangoldt
 
 /-- Evaluation of the von Mangoldt transform. -/
-@[simp]
 theorem vonMangoldtTransform_apply (f : IdealArithmeticFunction K)
     (A : (Ideal (𝓞 K))⁰) :
     f.vonMangoldtTransform A = f A * vonMangoldt A := by
   rw [vonMangoldtTransform, Pi.mul_apply]
 
-/-- Every von Mangoldt transform vanishes at the unit ideal.
-
-This is a named convenience lemma rather than a simp lemma: the general evaluation rule already
-simplifies this case. -/
-theorem vonMangoldtTransform_one (f : IdealArithmeticFunction K) :
-    f.vonMangoldtTransform 1 = 0 := by
-  rw [vonMangoldtTransform_apply, vonMangoldt_one, mul_zero]
-
-/-- The von Mangoldt transform on a positive power of a prime ideal.
-
-This is a named convenience lemma rather than a simp lemma: the general evaluation rule already
-simplifies this case. -/
+/-- The von Mangoldt transform on a positive power of a prime ideal. -/
+@[simp]
 theorem vonMangoldtTransform_apply_prime_pow (f : IdealArithmeticFunction K)
     {P : (Ideal (𝓞 K))⁰} (hP : Prime (P : Ideal (𝓞 K))) {n : ℕ} (hn : 0 < n) :
     f.vonMangoldtTransform (P ^ n) =
@@ -196,27 +196,10 @@ theorem vonMangoldtTransform_ne_zero_iff (f : IdealArithmeticFunction K)
       IsPrimePow (A : Ideal (𝓞 K)) ∧ f A ≠ 0 := by
   rw [vonMangoldtTransform_apply, mul_ne_zero_iff, vonMangoldt_ne_zero_iff, and_comm]
 
-/-- A von Mangoldt transform vanishes exactly when it lies outside the intersection of the
-original support with the prime powers.
-
-This is not a simp lemma because the general evaluation rule normalizes its left-hand side to a
-pointwise product. -/
-theorem vonMangoldtTransform_eq_zero_iff (f : IdealArithmeticFunction K)
-    {A : (Ideal (𝓞 K))⁰} :
-    f.vonMangoldtTransform A = 0 ↔
-      ¬ (IsPrimePow (A : Ideal (𝓞 K)) ∧ f A ≠ 0) := by
-  simpa only [not_ne_iff] using not_congr (f.vonMangoldtTransform_ne_zero_iff (A := A))
-
-/-- In particular, every von Mangoldt transform is supported on prime powers. -/
-theorem vonMangoldtTransform_eq_zero_of_not_isPrimePow (f : IdealArithmeticFunction K)
-    {A : (Ideal (𝓞 K))⁰} (hA : ¬ IsPrimePow (A : Ideal (𝓞 K))) :
-    f.vonMangoldtTransform A = 0 := by
-  rw [vonMangoldtTransform_apply, vonMangoldt_eq_zero_of_not_isPrimePow hA, mul_zero]
-
 /-- The transform of the constant-one ideal arithmetic function is the ideal von Mangoldt
 function. -/
 @[simp]
-theorem one_vonMangoldtTransform :
+theorem vonMangoldtTransform_one :
     (1 : IdealArithmeticFunction K).vonMangoldtTransform = vonMangoldt := by
   rw [vonMangoldtTransform, one_mul]
 
@@ -232,8 +215,7 @@ theorem vonMangoldtTransform_apply_prime_pow (χ : MultiplicativeIdealWeight K)
       χ P ^ n * Real.log (Ideal.absNorm (P : Ideal (𝓞 K))) := by
   rw [IdealArithmeticFunction.vonMangoldtTransform_apply_prime_pow _ hP hn,
     toIdealArithmeticFunction_apply]
-  congr 1
-  exact map_pow χ (P : Ideal (𝓞 K)) n
+  rw [SubmonoidClass.coe_pow, map_pow]
 
 /-- The support of the von Mangoldt transform of a completely multiplicative weight consists
 exactly of the prime powers on which the weight is good. -/
@@ -243,14 +225,6 @@ theorem vonMangoldtTransform_ne_zero_iff (χ : MultiplicativeIdealWeight K)
       IsPrimePow (A : Ideal (𝓞 K)) ∧ χ.IsGood (A : Ideal (𝓞 K)) := by
   rw [IdealArithmeticFunction.vonMangoldtTransform_ne_zero_iff,
     toIdealArithmeticFunction_apply, χ.apply_ne_zero_iff_isGood]
-
-/-- The von Mangoldt transform of a completely multiplicative weight vanishes exactly away from
-the good prime powers. -/
-theorem vonMangoldtTransform_eq_zero_iff (χ : MultiplicativeIdealWeight K)
-    {A : (Ideal (𝓞 K))⁰} :
-    χ.toIdealArithmeticFunction.vonMangoldtTransform A = 0 ↔
-      ¬ (IsPrimePow (A : Ideal (𝓞 K)) ∧ χ.IsGood (A : Ideal (𝓞 K))) := by
-  simpa only [not_ne_iff] using not_congr (χ.vonMangoldtTransform_ne_zero_iff (A := A))
 
 end MultiplicativeIdealWeight
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -190,6 +190,7 @@ theorem vonMangoldtTransform_apply_prime_pow (f : IdealArithmeticFunction K)
 
 /-- The support of a von Mangoldt transform is the intersection of the support of the original
 function with the prime-power ideals. -/
+@[simp]
 theorem vonMangoldtTransform_ne_zero_iff (f : IdealArithmeticFunction K)
     {A : (Ideal (𝓞 K))⁰} :
     f.vonMangoldtTransform A ≠ 0 ↔
@@ -219,6 +220,7 @@ theorem vonMangoldtTransform_apply_prime_pow (χ : MultiplicativeIdealWeight K)
 
 /-- The support of the von Mangoldt transform of a completely multiplicative weight consists
 exactly of the prime powers on which the weight is good. -/
+@[simp 1100]
 theorem vonMangoldtTransform_ne_zero_iff (χ : MultiplicativeIdealWeight K)
     {A : (Ideal (𝓞 K))⁰} :
     χ.toIdealArithmeticFunction.vonMangoldtTransform A ≠ 0 ↔

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -173,14 +173,18 @@ theorem vonMangoldtTransform_apply (χ : MultiplicativeIdealWeight K)
     χ.vonMangoldtTransform A = χ A * IdealArithmeticFunction.vonMangoldt A := by
   rw [vonMangoldtTransform, Pi.mul_apply, toIdealArithmeticFunction_apply]
 
-/-- The weighted von Mangoldt transform vanishes at the unit ideal. -/
-@[simp]
+/-- The weighted von Mangoldt transform vanishes at the unit ideal.
+
+This is a named convenience lemma rather than a simp lemma: the general evaluation rule already
+simplifies this case. -/
 theorem vonMangoldtTransform_one (χ : MultiplicativeIdealWeight K) :
     χ.vonMangoldtTransform 1 = 0 := by
   rw [vonMangoldtTransform_apply, IdealArithmeticFunction.vonMangoldt_one, mul_zero]
 
-/-- The weighted von Mangoldt transform on a positive power of a prime ideal. -/
-@[simp]
+/-- The weighted von Mangoldt transform on a positive power of a prime ideal.
+
+This is a named convenience lemma rather than a simp lemma: the general evaluation rule already
+simplifies this case. -/
 theorem vonMangoldtTransform_apply_prime_pow (χ : MultiplicativeIdealWeight K)
     {P : (Ideal (𝓞 K))⁰} (hP : Prime (P : Ideal (𝓞 K))) {n : ℕ} (hn : 0 < n) :
     χ.vonMangoldtTransform (P ^ n) =
@@ -199,8 +203,10 @@ theorem vonMangoldtTransform_ne_zero_iff (χ : MultiplicativeIdealWeight K)
   rw [vonMangoldtTransform_apply, mul_ne_zero_iff,
     IdealArithmeticFunction.vonMangoldt_ne_zero_iff, χ.apply_ne_zero_iff_isGood, and_comm]
 
-/-- The weighted von Mangoldt transform vanishes exactly away from the good prime powers. -/
-@[simp]
+/-- The weighted von Mangoldt transform vanishes exactly away from the good prime powers.
+
+This is not a simp lemma because the general evaluation rule normalizes its left-hand side to a
+condition on `χ A` and prime-power support. -/
 theorem vonMangoldtTransform_eq_zero_iff (χ : MultiplicativeIdealWeight K)
     {A : (Ideal (𝓞 K))⁰} :
     χ.vonMangoldtTransform A = 0 ↔


### PR DESCRIPTION
This PR defines the ideal von Mangoldt function on nonzero integral ideals by `Λ(P^n) = log N(P)` for positive prime powers and zero otherwise, and defines the transform `A ↦ f(A) Λ(A)` for every `IdealArithmeticFunction`, with a specialization for multiplicative ideal weights. It reuses Mathlib's `eq_of_prime_pow_eq` to identify the prime base selected by `IsPrimePow`, exposes choice-free prime-power evaluation lemmas, characterizes the exact support of `Λ` and of each weighted transform, and records that `Λ` is real-valued and nonnegative.

This advances `TauCetiRoadmap/ArithmeticDirichletSeries/README.md`, Layer 2, milestone “convolution and logarithmic derivatives,” target 2.3 “Von Mangoldt transform”: “Define the ideal von Mangoldt weight and the transform attached to a weight. Prove support on prime powers and the exact coefficient identity for the logarithmic derivative of an Euler product on its absolute-convergence half-plane.” It completes the algebraic coefficient and prime-power-support portion; after this PR, the exact logarithmic-derivative identity remains and must consume the Layer 3 Euler-product package, as the roadmap ordering requires.

The designated `IntegralLattices` roadmap has no viable unclaimed step: its only unmet odd-lattice branch, the bilinear `A_{L_H} ≅ H^⊥/H` comparison, is explicitly gated by the finite bilinear orthogonal quotient already in flight as #3805; the even naturality and `D₈⁺ ≅ E₈` endpoints have merged. `ArithmeticDirichletSeries` has no open intention or overlapping PR, Layer 1 is complete, and target 2.3 is its next unmet Layer 2 step.

The implementation reuses Mathlib’s general `IsPrimePow`, `eq_of_prime_pow_eq`, `Prime.dvd_of_dvd_pow`, ideal absolute norm, and real logarithm APIs directly. It does not vendor Mathlib code or confuse Mathlib’s natural-number `ArithmeticFunction.vonMangoldt` with the ideal function: norm alone cannot detect whether an ideal itself is a prime power.

The new module is `TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean`.

Roadmap: ArithmeticDirichletSeries

<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"ideal-von-mangoldt-transform"}-->

🤖 Prepared with Codex
