### PR TITLE
feat: cut-norm invariance under measure-preserving pullback

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Coupling.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Coupling.lean
@@ -126,8 +126,9 @@ back along the diagonal `x ↦ (x, x)` to their plain difference as kernels.
 `TauCeti.MeasureTheory.diagonalCoupling μ` is the pushforward of `μ` along that same diagonal, and
 by `TauCeti.MeasureTheory.isCoupling_diagonalCoupling` it is one of the couplings the cross-carrier
 cut distance takes an infimum over. This identity computes the kernel it contributes; recognizing
-the resulting value as the same-carrier cut norm `‖U - W‖□` additionally needs the cut norm's
-change of variables along a pushforward, which is not part of this file. -/
+the resulting value as the same-carrier cut norm `‖U - W‖□` additionally needs the invariance of
+the cut norm under measure-preserving pullback, and is `cutNorm_overlayDiff_diagonalCoupling` in
+`TauCeti.Combinatorics.DenseGraphLimits.CutMetric.Distance`. -/
 theorem comap_overlayDiff_diagonalCoupling {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
     [IsProbabilityMeasure μ] (U W : Graphon Ω μ) :
     (overlayDiff U W (TauCeti.MeasureTheory.diagonalCoupling μ)).comap (fun x => (x, x))

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Coupling.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Coupling.lean
@@ -42,6 +42,8 @@ hypotheses at all.
 * `overlayDiff_apply`, `abs_overlayDiff_apply_le_one` — the eliminator and the `[-1, 1]` bound;
 * `overlayDiff_swap` — swapping the two graphons negates the overlaid difference, up to the pullback
   along `Prod.swap`, for *any* two measures on the two products;
+* `comap_overlayDiff_prodMk` — pulling back along a pair of maps gives the difference of the two
+  kernel pullbacks;
 * `comap_overlayDiff_diagonalCoupling` — on a common carrier the overlaid difference along the
   diagonal coupling pulls back along the diagonal to the plain difference `U - W`.
 
@@ -120,6 +122,16 @@ theorem overlayDiff_swap (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂) (π
   ext p q
   simp
 
+/-- Pulling an overlaid difference back along `x ↦ (f x, g x)` gives the difference of the two
+pulled-back kernels. -/
+theorem comap_overlayDiff_prodMk {Ω : Type*} [MeasurableSpace Ω] (U : Graphon Ω₁ μ₁)
+    (W : Graphon Ω₂ μ₂) (π : Measure (Ω₁ × Ω₂)) {f : Ω → Ω₁} {g : Ω → Ω₂}
+    (hf : Measurable f) (hg : Measurable g) (ν : Measure Ω) :
+    (overlayDiff U W π).comap (fun x => (f x, g x)) (hf.prodMk hg) ν =
+      U.toSymmKernel.comap f hf ν - W.toSymmKernel.comap g hg ν := by
+  ext x y
+  simp
+
 /-- On a common carrier, the overlaid difference of `U` and `W` along the diagonal coupling pulls
 back along the diagonal `x ↦ (x, x)` to their plain difference as kernels.
 
@@ -133,8 +145,9 @@ theorem comap_overlayDiff_diagonalCoupling {Ω : Type*} [MeasurableSpace Ω] {μ
     [IsProbabilityMeasure μ] (U W : Graphon Ω μ) :
     (overlayDiff U W (TauCeti.MeasureTheory.diagonalCoupling μ)).comap (fun x => (x, x))
         (measurable_id'.prodMk measurable_id') μ = U.toSymmKernel - W.toSymmKernel := by
-  ext x y
-  simp
+  rw [comap_overlayDiff_prodMk U W (TauCeti.MeasureTheory.diagonalCoupling μ)
+    measurable_id' measurable_id' μ]
+  simp only [show (fun x : Ω => x) = id from rfl, SymmKernel.comap_id]
 
 end OverlayDiff
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Coupling.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Coupling.lean
@@ -147,7 +147,8 @@ theorem comap_overlayDiff_diagonalCoupling {Ω : Type*} [MeasurableSpace Ω] {μ
         (measurable_id'.prodMk measurable_id') μ = U.toSymmKernel - W.toSymmKernel := by
   rw [comap_overlayDiff_prodMk U W (TauCeti.MeasureTheory.diagonalCoupling μ)
     measurable_id' measurable_id' μ]
-  simp only [show (fun x : Ω => x) = id from rfl, SymmKernel.comap_id]
+  ext x y
+  simp
 
 end OverlayDiff
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
@@ -203,23 +203,18 @@ section CommonCarrier
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
 
-/-- **A graph coupling has the cut norm of the difference of the two pullbacks.** If `f` and `g`
-are measure preserving from a common finite-measure space, pulling the overlaid difference back
-along `x ↦ (f x, g x)` gives the difference of the pullbacks. Invariance under this
-measure-preserving map then identifies the two cut norms. -/
+/-- **A graph coupling has the cut norm of the difference of the two pullbacks.** Pulling the
+overlaid difference back along `x ↦ (f x, g x)` gives the difference of the pullbacks. Invariance
+under this measure-preserving map then identifies the two cut norms. -/
 theorem cutNorm_overlayDiff_map_prodMk [IsFiniteMeasure μ]
     (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂)
-    {f : Ω → Ω₁} {g : Ω → Ω₂} (hf : MeasurePreserving f μ μ₁)
-    (hg : MeasurePreserving g μ μ₂) {π : Measure (Ω₁ × Ω₂)} [IsFiniteMeasure π]
+    {f : Ω → Ω₁} {g : Ω → Ω₂} (hf : Measurable f)
+    (hg : Measurable g) {π : Measure (Ω₁ × Ω₂)} [IsFiniteMeasure π]
     (hπ : MeasurePreserving (fun x => (f x, g x)) μ π) :
     cutNorm π (overlayDiff U W π) =
       cutNorm μ
-        (U.toSymmKernel.comap f hf.measurable μ -
-          W.toSymmKernel.comap g hg.measurable μ) := by
-  rw [← cutNorm_comap hπ]
-  congr 1
-  ext x y
-  simp
+        (U.toSymmKernel.comap f hf μ - W.toSymmKernel.comap g hg μ) := by
+  rw [← cutNorm_comap hπ, comap_overlayDiff_prodMk]
 
 /-- **A common carrier bounds the cut distance.** If `f` and `g` are measure preserving from a
 common finite-measure space onto the two carriers, then the cut distance is at most the ordinary cut
@@ -238,7 +233,7 @@ theorem cutDist_le_cutNorm_sub_of_measurePreserving [IsFiniteMeasure μ]
         (U.toSymmKernel.comap f hf.measurable μ - W.toSymmKernel.comap g hg.measurable μ) := by
   let _ := (isCoupling_map_prodMk hf hg).isProbabilityMeasure
   exact (cutDist_le U W (isCoupling_map_prodMk hf hg)).trans_eq
-    (cutNorm_overlayDiff_map_prodMk U W hf hg
+    (cutNorm_overlayDiff_map_prodMk U W hf.measurable hg.measurable
       ⟨hf.measurable.prodMk hg.measurable, rfl⟩)
 
 variable [IsProbabilityMeasure μ]
@@ -256,20 +251,15 @@ theorem cutDist_le_cutNorm_sub (U W : Graphon Ω μ) :
     (MeasurePreserving.id μ)
   rwa [SymmKernel.comap_id, SymmKernel.comap_id] at this
 
-/-- **The diagonal coupling realises the same-carrier cut norm.**  Of all the couplings the cut
-distance takes an infimum over, the diagonal one contributes exactly `‖U - W‖□`.
-
-`comap_overlayDiff_diagonalCoupling` identifies the pullback of the overlaid difference along the
-diagonal with the plain kernel difference; the invariance of the cut norm under measure-preserving
-pullback (`cutNorm_comap`) turns that kernel identity into an identity of cut norms, which is the
-step that file left open. -/
+/-- **The diagonal coupling realises the same-carrier cut norm.** Of all the couplings the cut
+distance takes an infimum over, the diagonal one contributes exactly `‖U - W‖□`. -/
+@[simp]
 theorem cutNorm_overlayDiff_diagonalCoupling (U W : Graphon Ω μ) :
     cutNorm (TauCeti.MeasureTheory.diagonalCoupling μ)
         (overlayDiff U W (TauCeti.MeasureTheory.diagonalCoupling μ)) =
       cutNorm μ (U.toSymmKernel - W.toSymmKernel) := by
-  simpa only [SymmKernel.comap_id] using cutNorm_overlayDiff_map_prodMk U W
-    (MeasurePreserving.id μ) (MeasurePreserving.id μ)
-    (TauCeti.MeasureTheory.measurePreserving_diagonal μ)
+  rw [← cutNorm_comap (TauCeti.MeasureTheory.measurePreserving_diagonal μ),
+    comap_overlayDiff_diagonalCoupling]
 
 /-- The cut distance of a graphon to itself is zero. -/
 @[simp]

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
@@ -203,9 +203,9 @@ section CommonCarrier
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
 
-/-- **A graph coupling has the cut norm of the difference of the two pullbacks.** Pulling the
-overlaid difference back along `x ↦ (f x, g x)` gives the difference of the pullbacks. Invariance
-under this measure-preserving map then identifies the two cut norms. -/
+/-- **A measure induced by two maps gives the cut norm of the difference of the two pullbacks.**
+Pulling the overlaid difference back along `x ↦ (f x, g x)` gives the difference of the pullbacks.
+Invariance under this measure-preserving map then identifies the two cut norms. -/
 theorem cutNorm_overlayDiff_map_prodMk [IsFiniteMeasure μ]
     (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂)
     {f : Ω → Ω₁} {g : Ω → Ω₂} (hf : Measurable f)

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
@@ -47,9 +47,10 @@ overlaid difference, and the cut norm is even and drops along a pushforward
   `exists_isCoupling_cutNorm_lt` produces a coupling beating any strict upper bound;
 * `cutDist_nonneg` and `cutDist_le_one` are the range;
 * `cutDist_comm` is symmetry;
-* `cutDist_le_cutNorm_sub_of_measurePreserving` bounds the cut distance by the same-carrier cut
-  norm of the difference of two pullbacks, `cutDist_le_cutNorm_sub` is its identity case, and
-  `cutDist_self` follows;
+* `cutNorm_overlayDiff_map_prodMk` computes the overlaid cut norm of a coupling induced by two
+  measure-preserving maps, and `cutDist_le_cutNorm_sub_of_measurePreserving` bounds the cut
+  distance by that value; `cutDist_le_cutNorm_sub` is its identity case, and `cutDist_self`
+  follows;
 * `cutNorm_overlayDiff_diagonalCoupling` computes the value the diagonal coupling contributes to
   that infimum: it is exactly the same-carrier cut norm of the difference.
 
@@ -202,6 +203,24 @@ section CommonCarrier
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
 
+/-- **A graph coupling has the cut norm of the difference of the two pullbacks.** If `f` and `g`
+are measure preserving from a common finite-measure space, pulling the overlaid difference back
+along `x ↦ (f x, g x)` gives the difference of the pullbacks. Invariance under this
+measure-preserving map then identifies the two cut norms. -/
+theorem cutNorm_overlayDiff_map_prodMk [IsFiniteMeasure μ]
+    (U : Graphon Ω₁ μ₁) (W : Graphon Ω₂ μ₂)
+    {f : Ω → Ω₁} {g : Ω → Ω₂} (hf : MeasurePreserving f μ μ₁)
+    (hg : MeasurePreserving g μ μ₂) {π : Measure (Ω₁ × Ω₂)} [IsFiniteMeasure π]
+    (hπ : MeasurePreserving (fun x => (f x, g x)) μ π) :
+    cutNorm π (overlayDiff U W π) =
+      cutNorm μ
+        (U.toSymmKernel.comap f hf.measurable μ -
+          W.toSymmKernel.comap g hg.measurable μ) := by
+  rw [← cutNorm_comap hπ]
+  congr 1
+  ext x y
+  simp
+
 /-- **A common carrier bounds the cut distance.** If `f` and `g` are measure preserving from a
 common finite-measure space onto the two carriers, then the cut distance is at most the ordinary cut
 norm of the difference of the two pullbacks.
@@ -217,14 +236,10 @@ theorem cutDist_le_cutNorm_sub_of_measurePreserving [IsFiniteMeasure μ]
     cutDist U W ≤
       cutNorm μ
         (U.toSymmKernel.comap f hf.measurable μ - W.toSymmKernel.comap g hg.measurable μ) := by
-  set h : Ω → Ω₁ × Ω₂ := fun x => (f x, g x) with hdef
-  have : IsProbabilityMeasure (μ.map h) := (isCoupling_map_prodMk hf hg).isProbabilityMeasure
-  refine (cutDist_le U W (isCoupling_map_prodMk hf hg)).trans ?_
-  have hmp : MeasurePreserving h μ (μ.map h) := ⟨hf.measurable.prodMk hg.measurable, rfl⟩
-  refine (cutNorm_le_cutNorm_comap _ hmp (overlayDiff U W (μ.map h))).trans_eq ?_
-  congr 1
-  ext x y
-  simp [hdef]
+  let _ := (isCoupling_map_prodMk hf hg).isProbabilityMeasure
+  exact (cutDist_le U W (isCoupling_map_prodMk hf hg)).trans_eq
+    (cutNorm_overlayDiff_map_prodMk U W hf hg
+      ⟨hf.measurable.prodMk hg.measurable, rfl⟩)
 
 variable [IsProbabilityMeasure μ]
 
@@ -252,8 +267,9 @@ theorem cutNorm_overlayDiff_diagonalCoupling (U W : Graphon Ω μ) :
     cutNorm (TauCeti.MeasureTheory.diagonalCoupling μ)
         (overlayDiff U W (TauCeti.MeasureTheory.diagonalCoupling μ)) =
       cutNorm μ (U.toSymmKernel - W.toSymmKernel) := by
-  rw [← comap_overlayDiff_diagonalCoupling U W,
-    cutNorm_comap (TauCeti.MeasureTheory.measurePreserving_diagonalCoupling μ)]
+  simpa only [SymmKernel.comap_id] using cutNorm_overlayDiff_map_prodMk U W
+    (MeasurePreserving.id μ) (MeasurePreserving.id μ)
+    (TauCeti.MeasureTheory.measurePreserving_diagonal μ)
 
 /-- The cut distance of a graphon to itself is zero. -/
 @[simp]

--- a/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.CutMetric.Coupling
 public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
+import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Pullback
 
 /-!
 # The cut distance of two graphons
@@ -48,7 +49,9 @@ overlaid difference, and the cut norm is even and drops along a pushforward
 * `cutDist_comm` is symmetry;
 * `cutDist_le_cutNorm_sub_of_measurePreserving` bounds the cut distance by the same-carrier cut
   norm of the difference of two pullbacks, `cutDist_le_cutNorm_sub` is its identity case, and
-  `cutDist_self` follows.
+  `cutDist_self` follows;
+* `cutNorm_overlayDiff_diagonalCoupling` computes the value the diagonal coupling contributes to
+  that infimum: it is exactly the same-carrier cut norm of the difference.
 
 ## Implementation
 
@@ -237,6 +240,20 @@ theorem cutDist_le_cutNorm_sub (U W : Graphon Ω μ) :
   have := cutDist_le_cutNorm_sub_of_measurePreserving U W (MeasurePreserving.id μ)
     (MeasurePreserving.id μ)
   rwa [SymmKernel.comap_id, SymmKernel.comap_id] at this
+
+/-- **The diagonal coupling realises the same-carrier cut norm.**  Of all the couplings the cut
+distance takes an infimum over, the diagonal one contributes exactly `‖U - W‖□`.
+
+`comap_overlayDiff_diagonalCoupling` identifies the pullback of the overlaid difference along the
+diagonal with the plain kernel difference; the invariance of the cut norm under measure-preserving
+pullback (`cutNorm_comap`) turns that kernel identity into an identity of cut norms, which is the
+step that file left open. -/
+theorem cutNorm_overlayDiff_diagonalCoupling (U W : Graphon Ω μ) :
+    cutNorm (TauCeti.MeasureTheory.diagonalCoupling μ)
+        (overlayDiff U W (TauCeti.MeasureTheory.diagonalCoupling μ)) =
+      cutNorm μ (U.toSymmKernel - W.toSymmKernel) := by
+  rw [← comap_overlayDiff_diagonalCoupling U W,
+    cutNorm_comap (TauCeti.MeasureTheory.measurePreserving_diagonalCoupling μ)]
 
 /-- The cut distance of a graphon to itself is zero. -/
 @[simp]

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Pullback.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Pullback.lean
@@ -20,7 +20,8 @@ one upstairs with the same integral, so `cutNorm μ K ≤ cutNorm ν (K.comap f)
 elementary: a rectangle `S × T` upstairs need not be the preimage of anything, so its integral must
 be *pushed down* rather than transported. The push is by conditional density: the part of `ν`
 carried by `S` pushes forward to a measure below `μ`, whose Radon–Nikodym derivative
-`pushDensity f ν μ S` is a `[0, 1]`-valued function on `Ω`, and the rectangle integral upstairs
+`mapRestrictDensity f ν μ S` is a `[0, 1]`-valued function on `Ω`, and the rectangle integral
+upstairs
 equals the pairing of `K` against the two densities (`rectIntegral_comap_eq_testIntegral`). Since
 the cut norm already dominates every `[0, 1]`-test integral with no loss of constant
 (`abs_testIntegral_le_cutNorm`), the bound follows.
@@ -73,35 +74,38 @@ above it.
 
 This is the transport that replaces `rectIntegral_comap_preimage` when the rectangle upstairs is
 *not* a preimage: instead of moving the rectangle, it moves the two indicators, which become the
-`[0, 1]`-valued densities `pushDensity f ν μ S` and `pushDensity f ν μ T`.  Neither set needs to be
+`[0, 1]`-valued densities `mapRestrictDensity f ν μ S` and `mapRestrictDensity f ν μ T`. Neither set
+needs to be
 measurable. -/
 theorem rectIntegral_comap_eq_testIntegral [IsFiniteMeasure ν]
     (hf : MeasurePreserving f ν μ) (K : SymmKernel Ω μ) (S T : Set Ω') :
     (K.comap f hf.measurable ν).rectIntegral ν S T =
-      K.testIntegral μ (pushDensity f ν μ S) (pushDensity f ν μ T) := by
-  have hμ : IsFiniteMeasure μ := by
-    rw [← hf.map_eq]; exact Measure.isFiniteMeasure_map _ _
-  have hu : Measurable (pushDensity f ν μ S) := measurable_pushDensity f ν μ S
-  have hv : Measurable (pushDensity f ν μ T) := measurable_pushDensity f ν μ T
-  have hu1 : ∀ x, pushDensity f ν μ S x ∈ Icc (-1 : ℝ) 1 := fun x =>
-    ⟨by linarith [(pushDensity_mem_Icc f ν μ S x).1], (pushDensity_mem_Icc f ν μ S x).2⟩
-  have hv1 : ∀ y, pushDensity f ν μ T y ∈ Icc (-1 : ℝ) 1 := fun y =>
-    ⟨by linarith [(pushDensity_mem_Icc f ν μ T y).1], (pushDensity_mem_Icc f ν μ T y).2⟩
+      K.testIntegral μ (mapRestrictDensity f ν μ S) (mapRestrictDensity f ν μ T) := by
+  let _ := isFiniteMeasure_of_measurePreserving hf
+  have hu : Measurable (mapRestrictDensity f ν μ S) := measurable_mapRestrictDensity f ν μ S
+  have hv : Measurable (mapRestrictDensity f ν μ T) := measurable_mapRestrictDensity f ν μ T
+  have hu1 : ∀ x, mapRestrictDensity f ν μ S x ∈ Icc (-1 : ℝ) 1 := fun x =>
+    ⟨by linarith [(mapRestrictDensity_mem_Icc f ν μ S x).1],
+      (mapRestrictDensity_mem_Icc f ν μ S x).2⟩
+  have hv1 : ∀ y, mapRestrictDensity f ν μ T y ∈ Icc (-1 : ℝ) 1 := fun y =>
+    ⟨by linarith [(mapRestrictDensity_mem_Icc f ν μ T y).1],
+      (mapRestrictDensity_mem_Icc f ν μ T y).2⟩
   have hinner : ∀ x : Ω',
-      ∫ y in T, K (f x) (f y) ∂ν = K.partialIntegral μ (pushDensity f ν μ T) (f x) := by
+      ∫ y in T, K (f x) (f y) ∂ν = K.partialIntegral μ (mapRestrictDensity f ν μ T) (f x) := by
     intro x
     rw [partialIntegral_def]
-    exact (integral_pushDensity_mul hf T (g := fun b => K (f x) b) (K.measurable.comp
-      (measurable_const.prodMk measurable_id))).symm
+    exact (integral_mapRestrictDensity_mul hf T (g := fun b => K (f x) b)
+      (K.measurable.comp (measurable_const.prodMk measurable_id))).symm
   calc (K.comap f hf.measurable ν).rectIntegral ν S T
       = ∫ x in S, ∫ y in T, K (f x) (f y) ∂ν ∂ν := by
         rw [rectIntegral_eq_setIntegral_setIntegral]
         simp only [comap_apply]
-    _ = ∫ x in S, K.partialIntegral μ (pushDensity f ν μ T) (f x) ∂ν := by
+    _ = ∫ x in S, K.partialIntegral μ (mapRestrictDensity f ν μ T) (f x) ∂ν := by
         simp only [hinner]
-    _ = ∫ a, pushDensity f ν μ S a * K.partialIntegral μ (pushDensity f ν μ T) a ∂μ :=
-        (integral_pushDensity_mul hf S (K.measurable_partialIntegral μ hv)).symm
-    _ = K.testIntegral μ (pushDensity f ν μ S) (pushDensity f ν μ T) :=
+    _ = ∫ a, mapRestrictDensity f ν μ S a *
+          K.partialIntegral μ (mapRestrictDensity f ν μ T) a ∂μ :=
+        (integral_mapRestrictDensity_mul hf S (K.measurable_partialIntegral μ hv)).symm
+    _ = K.testIntegral μ (mapRestrictDensity f ν μ S) (mapRestrictDensity f ν μ T) :=
         (K.testIntegral_eq_integral_partialIntegral μ
           (K.integrable_testIntegrand μ hu hv hu1 hv1)).symm
 
@@ -119,9 +123,9 @@ theorem cutNorm_comap_le [IsFiniteMeasure ν] [IsFiniteMeasure μ] (hf : Measure
     cutNorm ν (K.comap f hf.measurable ν) ≤ cutNorm μ K :=
   cutNorm_le ν fun S _ T _ => by
     rw [SymmKernel.rectIntegral_comap_eq_testIntegral hf K S T]
-    exact abs_testIntegral_le_cutNorm μ K (measurable_pushDensity f ν μ S)
-      (measurable_pushDensity f ν μ T) (pushDensity_mem_Icc f ν μ S)
-      (pushDensity_mem_Icc f ν μ T)
+    exact abs_testIntegral_le_cutNorm μ K (measurable_mapRestrictDensity f ν μ S)
+      (measurable_mapRestrictDensity f ν μ T) (mapRestrictDensity_mem_Icc f ν μ S)
+      (mapRestrictDensity_mem_Icc f ν μ T)
 
 /-- **The cut norm is invariant under measure-preserving pullback.**  Pulling a kernel back along a
 map from any carrier that maps measure preservingly *onto* the kernel's own carrier leaves its cut

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Pullback.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Pullback.lean
@@ -6,7 +6,7 @@ Authors: Claude
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
-public import TauCeti.MeasureTheory.Measure.PushforwardDensity
+public import TauCeti.MeasureTheory.Measure.MapRestrictDensity
 
 /-!
 # The cut norm is invariant under measure-preserving pullback
@@ -95,7 +95,7 @@ theorem rectIntegral_comap_eq_testIntegral [IsFiniteMeasure ν]
     intro x
     rw [partialIntegral_def]
     exact (integral_mapRestrictDensity_mul hf T (g := fun b => K (f x) b)
-      (K.measurable.comp (measurable_const.prodMk measurable_id))).symm
+      (K.measurable.comp (measurable_const.prodMk measurable_id)).aestronglyMeasurable).symm
   calc (K.comap f hf.measurable ν).rectIntegral ν S T
       = ∫ x in S, ∫ y in T, K (f x) (f y) ∂ν ∂ν := by
         rw [rectIntegral_eq_setIntegral_setIntegral]
@@ -104,7 +104,8 @@ theorem rectIntegral_comap_eq_testIntegral [IsFiniteMeasure ν]
         simp only [hinner]
     _ = ∫ a, mapRestrictDensity f ν μ S a *
           K.partialIntegral μ (mapRestrictDensity f ν μ T) a ∂μ :=
-        (integral_mapRestrictDensity_mul hf S (K.measurable_partialIntegral μ hv)).symm
+        (integral_mapRestrictDensity_mul hf S
+          (K.measurable_partialIntegral μ hv).aestronglyMeasurable).symm
     _ = K.testIntegral μ (mapRestrictDensity f ν μ S) (mapRestrictDensity f ν μ T) :=
         (K.testIntegral_eq_integral_partialIntegral μ
           (K.integrable_testIntegrand μ hu hv hu1 hv1)).symm

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Pullback.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Pullback.lean
@@ -42,8 +42,6 @@ exactly the direction proved here. The triangle inequality itself is not proved 
 * `TauCeti.DenseGraphLimits.cutNorm_comap_le` — the cut norm does not increase under
   measure-preserving pullback.
 * `TauCeti.DenseGraphLimits.cutNorm_comap` — hence it is invariant.
-* `TauCeti.DenseGraphLimits.cutNorm_comap_eq_cutNorm_comap` — two measure-preserving maps onto the
-  same carrier give the same cut norm, so the quantity depends only on the pushforward.
 
 ## References
 
@@ -77,16 +75,18 @@ This is the transport that replaces `rectIntegral_comap_preimage` when the recta
 *not* a preimage: instead of moving the rectangle, it moves the two indicators, which become the
 `[0, 1]`-valued densities `pushDensity f ν μ S` and `pushDensity f ν μ T`.  Neither set needs to be
 measurable. -/
-theorem rectIntegral_comap_eq_testIntegral [IsFiniteMeasure ν] [IsFiniteMeasure μ]
+theorem rectIntegral_comap_eq_testIntegral [IsFiniteMeasure ν]
     (hf : MeasurePreserving f ν μ) (K : SymmKernel Ω μ) (S T : Set Ω') :
     (K.comap f hf.measurable ν).rectIntegral ν S T =
       K.testIntegral μ (pushDensity f ν μ S) (pushDensity f ν μ T) := by
+  have hμ : IsFiniteMeasure μ := by
+    rw [← hf.map_eq]; exact Measure.isFiniteMeasure_map _ _
   have hu : Measurable (pushDensity f ν μ S) := measurable_pushDensity f ν μ S
   have hv : Measurable (pushDensity f ν μ T) := measurable_pushDensity f ν μ T
   have hu1 : ∀ x, pushDensity f ν μ S x ∈ Icc (-1 : ℝ) 1 := fun x =>
-    ⟨by linarith [pushDensity_nonneg f ν μ S x], pushDensity_le_one f ν μ S x⟩
+    ⟨by linarith [(pushDensity_mem_Icc f ν μ S x).1], (pushDensity_mem_Icc f ν μ S x).2⟩
   have hv1 : ∀ y, pushDensity f ν μ T y ∈ Icc (-1 : ℝ) 1 := fun y =>
-    ⟨by linarith [pushDensity_nonneg f ν μ T y], pushDensity_le_one f ν μ T y⟩
+    ⟨by linarith [(pushDensity_mem_Icc f ν μ T y).1], (pushDensity_mem_Icc f ν μ T y).2⟩
   have hinner : ∀ x : Ω',
       ∫ y in T, K (f x) (f y) ∂ν = K.partialIntegral μ (pushDensity f ν μ T) (f x) := by
     intro x
@@ -123,8 +123,9 @@ theorem cutNorm_comap_le [IsFiniteMeasure ν] [IsFiniteMeasure μ] (hf : Measure
       (measurable_pushDensity f ν μ T) (pushDensity_mem_Icc f ν μ S)
       (pushDensity_mem_Icc f ν μ T)
 
-/-- **The cut norm is invariant under measure-preserving pullback.**  Reading a kernel on a carrier
-that maps onto its own, measure preservingly, changes nothing.
+/-- **The cut norm is invariant under measure-preserving pullback.**  Pulling a kernel back along a
+map from any carrier that maps measure preservingly *onto* the kernel's own carrier leaves its cut
+norm unchanged.
 
 The two inequalities have different characters: `cutNorm_le_cutNorm_comap` transports rectangles
 along the map, while `cutNorm_comap_le` pushes them down by conditional density. -/
@@ -132,14 +133,6 @@ theorem cutNorm_comap [IsFiniteMeasure ν] [IsFiniteMeasure μ] (hf : MeasurePre
     (K : SymmKernel Ω μ) :
     cutNorm ν (K.comap f hf.measurable ν) = cutNorm μ K :=
   le_antisymm (cutNorm_comap_le hf K) (cutNorm_le_cutNorm_comap μ hf K)
-
-/-- **The cut norm of a pullback depends only on the pushforward measure.**  Two carriers mapping
-measure preservingly onto the same one see the same cut norm, however different they are. -/
-theorem cutNorm_comap_eq_cutNorm_comap {Ω'' : Type*} [MeasurableSpace Ω''] {ν' : Measure Ω''}
-    [IsFiniteMeasure ν] [IsFiniteMeasure ν'] [IsFiniteMeasure μ] {g : Ω'' → Ω}
-    (hf : MeasurePreserving f ν μ) (hg : MeasurePreserving g ν' μ) (K : SymmKernel Ω μ) :
-    cutNorm ν (K.comap f hf.measurable ν) = cutNorm ν' (K.comap g hg.measurable ν') :=
-  (cutNorm_comap hf K).trans (cutNorm_comap hg K).symm
 
 end DenseGraphLimits
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Pullback.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Pullback.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
+public import TauCeti.MeasureTheory.Measure.PushforwardDensity
+
+/-!
+# The cut norm is invariant under measure-preserving pullback
+
+If `f : Ω' → Ω` pushes a probability measure `ν` forward to `μ`, then a symmetric kernel `K` on
+`(Ω, μ)` and its pullback `K.comap f` on `(Ω', ν)` have the *same* cut norm.
+
+One inequality is elementary and already available: a measurable rectangle downstairs pulls back to
+one upstairs with the same integral, so `cutNorm μ K ≤ cutNorm ν (K.comap f)`
+(`cutNorm_le_cutNorm_comap`). The reverse inequality is the substance of this file, and it is not
+elementary: a rectangle `S × T` upstairs need not be the preimage of anything, so its integral must
+be *pushed down* rather than transported. The push is by conditional density: the part of `ν`
+carried by `S` pushes forward to a measure below `μ`, whose Radon–Nikodym derivative
+`pushDensity f ν μ S` is a `[0, 1]`-valued function on `Ω`, and the rectangle integral upstairs
+equals the pairing of `K` against the two densities (`rectIntegral_comap_eq_testIntegral`). Since
+the cut norm already dominates every `[0, 1]`-test integral with no loss of constant
+(`abs_testIntegral_le_cutNorm`), the bound follows.
+
+**Why the `[0, 1]`-test form is the right input.** Replacing it by the signed cut norm would cost a
+factor of `4` (`cutNormSigned_le_four_mul_cutNorm`) and give only a comparison, not an equality;
+the sharp `abs_testIntegral_le_cutNorm` is what makes the invariance exact.
+
+This is the analytic gate in front of the arbitrary-carrier triangle inequality for the cut
+distance (Janson, Lemma 6.5). There a coupling of three carriers is built over the middle one, and
+the two outer cut norms have to be compared with cut norms computed on the glued space along its
+coordinate projections; those projections are measure preserving, and the comparison needed is
+exactly the direction proved here. The triangle inequality itself is not proved in this file.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.SymmKernel.rectIntegral_comap_eq_testIntegral` — a rectangle integral
+  of a pullback is a `[0, 1]`-test integral of the original kernel.
+* `TauCeti.DenseGraphLimits.cutNorm_comap_le` — the cut norm does not increase under
+  measure-preserving pullback.
+* `TauCeti.DenseGraphLimits.cutNorm_comap` — hence it is invariant.
+* `TauCeti.DenseGraphLimits.cutNorm_comap_eq_cutNorm_comap` — two measure-preserving maps onto the
+  same carrier give the same cut norm, so the quantity depends only on the pushforward.
+
+## References
+
+* S. Janson, *Graphons, cut norm and distance, couplings and rearrangements*, NYJM Monographs 4
+  (2013), §4 and Lemma 6.5.
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), §8.2.
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 1 — the cut norm and its full basic
+  API, as the prerequisite named there for the arbitrary-carrier triangle inequality.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set TauCeti.MeasureTheory
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω Ω' : Type*} [MeasurableSpace Ω] [MeasurableSpace Ω']
+variable {μ : Measure Ω} {ν : Measure Ω'} {f : Ω' → Ω}
+
+namespace SymmKernel
+
+/-- **A rectangle integral upstairs is a `[0, 1]`-test integral downstairs.**  Integrating a
+pullback over `S × T` weights each point of the base by the conditional density of `S`, resp. `T`,
+above it.
+
+This is the transport that replaces `rectIntegral_comap_preimage` when the rectangle upstairs is
+*not* a preimage: instead of moving the rectangle, it moves the two indicators, which become the
+`[0, 1]`-valued densities `pushDensity f ν μ S` and `pushDensity f ν μ T`.  Neither set needs to be
+measurable. -/
+theorem rectIntegral_comap_eq_testIntegral [IsFiniteMeasure ν] [IsFiniteMeasure μ]
+    (hf : MeasurePreserving f ν μ) (K : SymmKernel Ω μ) (S T : Set Ω') :
+    (K.comap f hf.measurable ν).rectIntegral ν S T =
+      K.testIntegral μ (pushDensity f ν μ S) (pushDensity f ν μ T) := by
+  have hu : Measurable (pushDensity f ν μ S) := measurable_pushDensity f ν μ S
+  have hv : Measurable (pushDensity f ν μ T) := measurable_pushDensity f ν μ T
+  have hu1 : ∀ x, pushDensity f ν μ S x ∈ Icc (-1 : ℝ) 1 := fun x =>
+    ⟨by linarith [pushDensity_nonneg f ν μ S x], pushDensity_le_one f ν μ S x⟩
+  have hv1 : ∀ y, pushDensity f ν μ T y ∈ Icc (-1 : ℝ) 1 := fun y =>
+    ⟨by linarith [pushDensity_nonneg f ν μ T y], pushDensity_le_one f ν μ T y⟩
+  have hinner : ∀ x : Ω',
+      ∫ y in T, K (f x) (f y) ∂ν = K.partialIntegral μ (pushDensity f ν μ T) (f x) := by
+    intro x
+    rw [partialIntegral_def]
+    exact (integral_pushDensity_mul hf T (g := fun b => K (f x) b) (K.measurable.comp
+      (measurable_const.prodMk measurable_id))).symm
+  calc (K.comap f hf.measurable ν).rectIntegral ν S T
+      = ∫ x in S, ∫ y in T, K (f x) (f y) ∂ν ∂ν := by
+        rw [rectIntegral_eq_setIntegral_setIntegral]
+        simp only [comap_apply]
+    _ = ∫ x in S, K.partialIntegral μ (pushDensity f ν μ T) (f x) ∂ν := by
+        simp only [hinner]
+    _ = ∫ a, pushDensity f ν μ S a * K.partialIntegral μ (pushDensity f ν μ T) a ∂μ :=
+        (integral_pushDensity_mul hf S (K.measurable_partialIntegral μ hv)).symm
+    _ = K.testIntegral μ (pushDensity f ν μ S) (pushDensity f ν μ T) :=
+        (K.testIntegral_eq_integral_partialIntegral μ
+          (K.integrable_testIntegrand μ hu hv hu1 hv1)).symm
+
+end SymmKernel
+
+/-- **The cut norm does not increase under measure-preserving pullback.**  This is the direction
+that a change of variables cannot give, since a rectangle upstairs need not come from one
+downstairs.
+
+Every rectangle integral upstairs is a `[0, 1]`-test integral of `K` downstairs
+(`rectIntegral_comap_eq_testIntegral`), and the cut norm dominates those with no loss of constant
+(`abs_testIntegral_le_cutNorm`). -/
+theorem cutNorm_comap_le [IsFiniteMeasure ν] [IsFiniteMeasure μ] (hf : MeasurePreserving f ν μ)
+    (K : SymmKernel Ω μ) :
+    cutNorm ν (K.comap f hf.measurable ν) ≤ cutNorm μ K :=
+  cutNorm_le ν fun S _ T _ => by
+    rw [SymmKernel.rectIntegral_comap_eq_testIntegral hf K S T]
+    exact abs_testIntegral_le_cutNorm μ K (measurable_pushDensity f ν μ S)
+      (measurable_pushDensity f ν μ T) (pushDensity_mem_Icc f ν μ S)
+      (pushDensity_mem_Icc f ν μ T)
+
+/-- **The cut norm is invariant under measure-preserving pullback.**  Reading a kernel on a carrier
+that maps onto its own, measure preservingly, changes nothing.
+
+The two inequalities have different characters: `cutNorm_le_cutNorm_comap` transports rectangles
+along the map, while `cutNorm_comap_le` pushes them down by conditional density. -/
+theorem cutNorm_comap [IsFiniteMeasure ν] [IsFiniteMeasure μ] (hf : MeasurePreserving f ν μ)
+    (K : SymmKernel Ω μ) :
+    cutNorm ν (K.comap f hf.measurable ν) = cutNorm μ K :=
+  le_antisymm (cutNorm_comap_le hf K) (cutNorm_le_cutNorm_comap μ hf K)
+
+/-- **The cut norm of a pullback depends only on the pushforward measure.**  Two carriers mapping
+measure preservingly onto the same one see the same cut norm, however different they are. -/
+theorem cutNorm_comap_eq_cutNorm_comap {Ω'' : Type*} [MeasurableSpace Ω''] {ν' : Measure Ω''}
+    [IsFiniteMeasure ν] [IsFiniteMeasure ν'] [IsFiniteMeasure μ] {g : Ω'' → Ω}
+    (hf : MeasurePreserving f ν μ) (hg : MeasurePreserving g ν' μ) (K : SymmKernel Ω μ) :
+    cutNorm ν (K.comap f hf.measurable ν) = cutNorm ν' (K.comap g hg.measurable ν') :=
+  (cutNorm_comap hf K).trans (cutNorm_comap hg K).symm
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Measure/Coupling.lean
+++ b/TauCeti/MeasureTheory/Measure/Coupling.lean
@@ -38,7 +38,8 @@ The declarations live in `TauCeti.MeasureTheory` because none depends on graphon
   one coordinate to the corresponding marginal;
 * `IsCoupling.swap` swaps the coordinates of a coupling;
 * `isCoupling_map_prodMk` builds the graph coupling of two measure-preserving maps out of a common
-  carrier, of which `isCoupling_diagonalCoupling` is the identity case.
+  carrier, of which `isCoupling_diagonalCoupling` is the identity case;
+* `measurePreserving_diagonalCoupling` records the diagonal itself as measure preserving.
 
 ## References
 
@@ -167,6 +168,15 @@ theorem diagonalCoupling_apply (μ : Measure Ω) {s : Set (Ω × Ω)} (hs : Meas
     diagonalCoupling μ s = μ {x | (x, x) ∈ s} := by
   rw [diagonalCoupling, Measure.map_apply (measurable_id'.prodMk measurable_id') hs]
   rfl
+
+/-- The diagonal is measure preserving onto the diagonal coupling.
+
+This is the defining pushforward, packaged for the transport lemmas that ask for a
+`MeasurePreserving` hypothesis. It is stated here because `diagonalCoupling` is not reducible
+outside this module, so a caller cannot supply the pushforward identity by `rfl`. -/
+theorem measurePreserving_diagonalCoupling (μ : Measure Ω) :
+    MeasurePreserving (fun x => (x, x)) μ (diagonalCoupling μ) :=
+  ⟨measurable_id'.prodMk measurable_id', (rfl)⟩
 
 /-- The diagonal coupling is a coupling of `μ` with itself: the graph coupling of the identity
 with itself. -/

--- a/TauCeti/MeasureTheory/Measure/Coupling.lean
+++ b/TauCeti/MeasureTheory/Measure/Coupling.lean
@@ -176,7 +176,7 @@ This is the defining pushforward, packaged for the transport lemmas that ask for
 outside this module, so a caller cannot supply the pushforward identity by `rfl`. -/
 theorem measurePreserving_diagonalCoupling (μ : Measure Ω) :
     MeasurePreserving (fun x => (x, x)) μ (diagonalCoupling μ) :=
-  ⟨measurable_id'.prodMk measurable_id', (rfl)⟩
+  (measurable_id'.prodMk measurable_id').measurePreserving μ
 
 /-- The diagonal coupling is a coupling of `μ` with itself: the graph coupling of the identity
 with itself. -/

--- a/TauCeti/MeasureTheory/Measure/Coupling.lean
+++ b/TauCeti/MeasureTheory/Measure/Coupling.lean
@@ -39,7 +39,7 @@ The declarations live in `TauCeti.MeasureTheory` because none depends on graphon
 * `IsCoupling.swap` swaps the coordinates of a coupling;
 * `isCoupling_map_prodMk` builds the graph coupling of two measure-preserving maps out of a common
   carrier, of which `isCoupling_diagonalCoupling` is the identity case;
-* `measurePreserving_diagonalCoupling` records the diagonal itself as measure preserving.
+* `measurePreserving_diagonal` records the diagonal itself as measure preserving.
 
 ## References
 
@@ -174,7 +174,7 @@ theorem diagonalCoupling_apply (μ : Measure Ω) {s : Set (Ω × Ω)} (hs : Meas
 This is the defining pushforward, packaged for the transport lemmas that ask for a
 `MeasurePreserving` hypothesis. It is stated here because `diagonalCoupling` is not reducible
 outside this module, so a caller cannot supply the pushforward identity by `rfl`. -/
-theorem measurePreserving_diagonalCoupling (μ : Measure Ω) :
+theorem measurePreserving_diagonal (μ : Measure Ω) :
     MeasurePreserving (fun x => (x, x)) μ (diagonalCoupling μ) :=
   (measurable_id'.prodMk measurable_id').measurePreserving μ
 

--- a/TauCeti/MeasureTheory/Measure/MapRestrictDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/MapRestrictDensity.lean
@@ -19,9 +19,9 @@ it is characterised by
 
 `∫ a, mapRestrictDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν`
 
-for every `μ`-a.e. strongly measurable `g : Ω → ℝ` (`integral_mapRestrictDensity_mul`). In
-probabilistic language
-it is the conditional probability of `s` given `f`, read as a function on the base: composing it
+for every `μ`-a.e. strongly measurable `g : Ω → ℝ` (`integral_mapRestrictDensity_mul`). This
+Radon–Nikodym identity holds for arbitrary `s`. When `s` is measurable, the density has the
+additional probabilistic reading of the conditional probability of `s` given `f`: composing it
 with `f` gives a version of `ν[s.indicator 1 | comap f]`. Nothing here needs that reading, so the
 conditional-expectation machinery is not used; the elementary Radon–Nikodym route is enough.
 

--- a/TauCeti/MeasureTheory/Measure/MapRestrictDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/MapRestrictDensity.lean
@@ -30,6 +30,8 @@ that the `[0, 1]` bounds hold *everywhere*, not merely almost everywhere. Consum
 function against a kernel and need a strict pointwise bound to feed an extremal argument; the
 truncation is invisible to every integral statement below, because it changes the derivative only
 on a `μ`-null set (`mapRestrictDensity_ae_eq_rnDeriv`).
+The private product-carrier regression below confirms that the density can be a genuinely
+fractional multiple of an indicator, rather than always an indicator itself.
 
 ## Main definitions
 
@@ -51,9 +53,6 @@ on a `μ`-null set (`mapRestrictDensity_ae_eq_rnDeriv`).
   `TauCeti.MeasureTheory.mapRestrictDensity_univ` — on a
   preimage the density collapses `μ`-almost everywhere to an indicator, so the construction extends
   the trivial case.
-* `TauCeti.MeasureTheory.mapRestrictDensity_fst_prod` — on a product carrier the density of a
-  rectangle is `μ`-almost everywhere a genuinely fractional multiple of an indicator, so no such
-  collapse holds in general.
 * `TauCeti.MeasureTheory.isFiniteMeasure_of_measurePreserving` — an auxiliary fact transferring
   finiteness from the source to the target of a measure-preserving map.
 
@@ -197,7 +196,7 @@ factor, a rectangle `s ×ˢ t` has density `ν.real t · 1_s` `μ`-almost everyw
 contributes its mass, not an indicator.  Together with `mapRestrictDensity_preimage` this pins the
 construction down — an indicator of a set on the base would be wrong whenever
 `0 < ν.real t < 1`. -/
-theorem mapRestrictDensity_fst_prod [SigmaFinite μ] [IsProbabilityMeasure ν] {s : Set Ω}
+private theorem mapRestrictDensity_fst_prod [SigmaFinite μ] [IsProbabilityMeasure ν] {s : Set Ω}
     (hs : MeasurableSet s) (t : Set Ω') :
     mapRestrictDensity Prod.fst (μ.prod ν) μ (s ×ˢ t) =ᵐ[μ]
       fun a => ν.real t * s.indicator 1 a := by

--- a/TauCeti/MeasureTheory/Measure/MapRestrictDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/MapRestrictDensity.lean
@@ -19,7 +19,8 @@ it is characterised by
 
 `∫ a, mapRestrictDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν`
 
-for every measurable `g : Ω → ℝ` (`integral_mapRestrictDensity_mul`). In probabilistic language
+for every `μ`-a.e. strongly measurable `g : Ω → ℝ` (`integral_mapRestrictDensity_mul`). In
+probabilistic language
 it is the conditional probability of `s` given `f`, read as a function on the base: composing it
 with `f` gives a version of `ν[s.indicator 1 | comap f]`. Nothing here needs that reading, so the
 conditional-expectation machinery is not used; the elementary Radon–Nikodym route is enough.
@@ -41,10 +42,11 @@ on a `μ`-null set (`mapRestrictDensity_ae_eq_rnDeriv`).
   against the density downstairs computes the integral over the set upstairs. No measurability of
   the set is needed.
 * `TauCeti.MeasureTheory.mapRestrictDensity_ae_eq_rnDeriv` — the truncation is a.e. invisible.
+* `TauCeti.MeasureTheory.mapRestrictDensity_mem_Icc` — the density lies in `[0, 1]` everywhere.
 * `TauCeti.MeasureTheory.integral_mapRestrictDensity` — the density integrates to the measure of
   the set, the case `g = 1`.
-* `TauCeti.MeasureTheory.mapRestrictDensity_congr` — the density depends on the set upstairs only
-  through its `ν`-a.e. class; this equality is exact, not almost everywhere.
+* `TauCeti.MeasureTheory.mapRestrictDensity_congr_set` — the density depends on the set upstairs
+  only through its `ν`-a.e. class; this equality is exact, not almost everywhere.
 * `TauCeti.MeasureTheory.mapRestrictDensity_preimage` and
   `TauCeti.MeasureTheory.mapRestrictDensity_univ` — on a
   preimage the density collapses `μ`-almost everywhere to an indicator, so the construction extends
@@ -52,6 +54,8 @@ on a `μ`-null set (`mapRestrictDensity_ae_eq_rnDeriv`).
 * `TauCeti.MeasureTheory.mapRestrictDensity_fst_prod` — on a product carrier the density of a
   rectangle is `μ`-almost everywhere a genuinely fractional multiple of an indicator, so no such
   collapse holds in general.
+* `TauCeti.MeasureTheory.isFiniteMeasure_of_measurePreserving` — an auxiliary fact transferring
+  finiteness from the source to the target of a measure-preserving map.
 
 ## References
 
@@ -105,14 +109,14 @@ theorem mapRestrictDensity_mem_Icc (f : Ω' → Ω) (ν : Measure Ω') (μ : Mea
 
 /-- **The density depends on the set upstairs only through its `ν`-a.e. class.**  Replacing `s` by
 an a.e. equal set does not change the function at all, since it does not change `ν.restrict s`. -/
-theorem mapRestrictDensity_congr (f : Ω' → Ω) (μ : Measure Ω) {s t : Set Ω'}
+theorem mapRestrictDensity_congr_set (f : Ω' → Ω) (μ : Measure Ω) {s t : Set Ω'}
     (h : s =ᵐ[ν] t) : mapRestrictDensity f ν μ s = mapRestrictDensity f ν μ t := by
   funext a
   rw [mapRestrictDensity_def, mapRestrictDensity_def, Measure.restrict_congr_set h]
 
 /-- Pushing forward the part of `ν` carried by `s` gives a measure below `μ`.  This is the whole
 reason the density is `[0, 1]`-valued, and it needs no hypothesis on `s`. -/
-theorem map_restrict_le (hf : MeasurePreserving f ν μ) (s : Set Ω') :
+private theorem map_restrict_le_of_measurePreserving (hf : MeasurePreserving f ν μ) (s : Set Ω') :
     (ν.restrict s).map f ≤ μ := by
   rw [← hf.map_eq]
   exact Measure.map_mono Measure.restrict_le_self hf.measurable
@@ -129,7 +133,7 @@ below `μ`. -/
 theorem mapRestrictDensity_ae_eq_rnDeriv [SigmaFinite μ] (hf : MeasurePreserving f ν μ)
     (s : Set Ω') :
     mapRestrictDensity f ν μ s =ᵐ[μ] fun a => (((ν.restrict s).map f).rnDeriv μ a).toReal := by
-  filter_upwards [Measure.rnDeriv_le_one_of_le (map_restrict_le hf s)]
+  filter_upwards [Measure.rnDeriv_le_one_of_le (map_restrict_le_of_measurePreserving hf s)]
     with a ha
   have h1 : (((ν.restrict s).map f).rnDeriv μ a).toReal ≤ 1 := by
     simpa using ENNReal.toReal_mono ENNReal.one_ne_top ha
@@ -141,10 +145,10 @@ against the density computes its integral, composed with `f`, over the set upsta
 The set is arbitrary: `Measure.restrict` and every step of the computation are insensitive to its
 measurability. -/
 theorem integral_mapRestrictDensity_mul [SigmaFinite μ] (hf : MeasurePreserving f ν μ) (s : Set Ω')
-    {g : Ω → ℝ} (hg : Measurable g) :
+    {g : Ω → ℝ} (hg : AEStronglyMeasurable g μ) :
     ∫ a, mapRestrictDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν := by
   let _ : SigmaFinite ((ν.restrict s).map f) :=
-    Measure.sigmaFinite_of_le μ (map_restrict_le hf s)
+    Measure.sigmaFinite_of_le μ (map_restrict_le_of_measurePreserving hf s)
   calc ∫ a, mapRestrictDensity f ν μ s a * g a ∂μ
       = ∫ a, (((ν.restrict s).map f).rnDeriv μ a).toReal * g a ∂μ :=
         integral_congr_ae (by
@@ -152,15 +156,17 @@ theorem integral_mapRestrictDensity_mul [SigmaFinite μ] (hf : MeasurePreserving
           rw [ha])
     _ = ∫ a, g a ∂((ν.restrict s).map f) :=
         integral_toReal_rnDeriv_mul
-          (Measure.absolutelyContinuous_of_le (map_restrict_le hf s))
+          (Measure.absolutelyContinuous_of_le (map_restrict_le_of_measurePreserving hf s))
     _ = ∫ x in s, g (f x) ∂ν :=
-        integral_map hf.measurable.aemeasurable hg.aestronglyMeasurable
+        integral_map hf.measurable.aemeasurable
+          (hg.mono_measure (map_restrict_le_of_measurePreserving hf s))
 
 /-- The density integrates to the measure of the set it came from: the case `g = 1` of
 `integral_mapRestrictDensity_mul`. -/
 theorem integral_mapRestrictDensity [SigmaFinite μ] (hf : MeasurePreserving f ν μ) (s : Set Ω') :
     ∫ a, mapRestrictDensity f ν μ s a ∂μ = ν.real s := by
-  have h := integral_mapRestrictDensity_mul hf s (g := fun _ => (1 : ℝ)) measurable_const
+  have h := integral_mapRestrictDensity_mul hf s (g := fun _ => (1 : ℝ))
+    measurable_const.aestronglyMeasurable
   simpa [Measure.restrict_apply_univ] using h
 
 /-- **On a preimage the density is `μ`-almost everywhere an indicator.**  Nothing is lost when the
@@ -204,8 +210,7 @@ theorem mapRestrictDensity_fst_prod [SigmaFinite μ] [IsProbabilityMeasure ν] {
     filter_upwards [Measure.rnDeriv_smul_left_of_ne_top' (μ.restrict s) μ
       (measure_ne_top ν t), Measure.rnDeriv_restrict_self μ hs] with a ha hb
     rw [ha]
-    change ν t * (μ.restrict s).rnDeriv μ a = ν t * s.indicator 1 a
-    rw [hb]
+    rw [Pi.smul_apply, smul_eq_mul, hb]
   filter_upwards [mapRestrictDensity_ae_eq_rnDeriv hf (s ×ˢ t), hrn] with a ha hb
   rw [ha, hb]
   by_cases has : a ∈ s

--- a/TauCeti/MeasureTheory/Measure/PushforwardDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/PushforwardDensity.lean
@@ -1,0 +1,212 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
+
+/-!
+# The density of a set upstairs, seen on the base of a measure-preserving map
+
+Let `f : Ω' → Ω` push a finite measure `ν` forward to `μ`, and let `s ⊆ Ω'` be a set upstairs.
+The part of `ν` carried by `s` pushes forward to a measure `≤ μ`, so it has a Radon–Nikodym
+density with respect to `μ` taking values in `[0, 1]`. That density is `pushDensity f ν μ s`, and
+it is characterised by
+
+`∫ a, pushDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν`
+
+for every bounded measurable `g : Ω → ℝ` (`integral_pushDensity_mul`). In probabilistic language
+it is the conditional probability of `s` given `f`, read as a function on the base: composing it
+with `f` gives a version of `ν[s.indicator 1 | comap f]`. Nothing here needs that reading, so the
+conditional-expectation machinery is not used; the elementary Radon–Nikodym route is enough.
+
+**Truncation is deliberate.** The definition applies `min 1` to the Radon–Nikodym derivative so
+that the `[0, 1]` bounds hold *everywhere*, not merely almost everywhere. Consumers pair this
+function against a kernel and need a strict pointwise bound to feed an extremal argument; the
+truncation is invisible to every integral statement below, because it changes the derivative only
+on a `μ`-null set (`pushDensity_ae_eq_rnDeriv`).
+
+## Main definitions
+
+* `TauCeti.MeasureTheory.pushDensity` — the `[0, 1]`-valued density on the base of the part of `ν`
+  carried by a set upstairs.
+
+## Main results
+
+* `TauCeti.MeasureTheory.integral_pushDensity_mul` — the characterising identity: integrating
+  against the density downstairs computes the integral over the set upstairs. No measurability of
+  the set is needed.
+* `TauCeti.MeasureTheory.pushDensity_ae_eq_rnDeriv` — the truncation is a.e. invisible.
+* `TauCeti.MeasureTheory.integral_pushDensity` — the density integrates to the measure of the set,
+  the case `g = 1`.
+* `TauCeti.MeasureTheory.pushDensity_preimage` and `TauCeti.MeasureTheory.pushDensity_univ` — on a
+  preimage the density collapses to an indicator, so the construction extends the trivial case.
+* `TauCeti.MeasureTheory.pushDensity_prod_fst` — on a product carrier the density of a rectangle
+  is a genuinely fractional multiple of an indicator, so no such collapse holds in general.
+
+## References
+
+* Mathlib's `MeasureTheory.toReal_rnDeriv_map` identifies the Radon–Nikodym derivative of a
+  pushforward with a conditional expectation; it is the abstract form of the reading above and is
+  not needed for any statement here.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+variable {Ω Ω' : Type*} [MeasurableSpace Ω] [MeasurableSpace Ω']
+variable {μ : Measure Ω} {ν : Measure Ω'} {f : Ω' → Ω}
+
+/-- The **density on the base of the part of `ν` carried by `s`**: the Radon–Nikodym derivative of
+`(ν.restrict s).map f` with respect to `μ`, truncated to `[0, 1]`.
+
+When `f` pushes `ν` forward to `μ` the truncation is a.e. invisible
+(`pushDensity_ae_eq_rnDeriv`) and the function is characterised by
+`integral_pushDensity_mul`. The measures are explicit arguments because neither is determined by
+the others: `μ` is not forced to be `ν.map f` by the type. -/
+def pushDensity (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) : ℝ :=
+  min 1 (((ν.restrict s).map f).rnDeriv μ a).toReal
+
+/-- The defining formula of `pushDensity`. -/
+theorem pushDensity_def (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) :
+    pushDensity f ν μ s a = min 1 (((ν.restrict s).map f).rnDeriv μ a).toReal := (rfl)
+
+/-- The density is measurable, being a truncated Radon–Nikodym derivative. -/
+@[fun_prop]
+theorem measurable_pushDensity (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') :
+    Measurable (pushDensity f ν μ s) :=
+  measurable_const.min (Measure.measurable_rnDeriv _ _).ennreal_toReal
+
+/-- The density is nonnegative everywhere. -/
+theorem pushDensity_nonneg (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) :
+    0 ≤ pushDensity f ν μ s a :=
+  le_min zero_le_one ENNReal.toReal_nonneg
+
+/-- The density is at most `1` everywhere: this is what the truncation buys. -/
+theorem pushDensity_le_one (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) :
+    pushDensity f ν μ s a ≤ 1 :=
+  min_le_left _ _
+
+/-- The density is `[0, 1]`-valued everywhere, in the packaged form the extremal arguments of the
+cut-norm theory consume. -/
+theorem pushDensity_mem_Icc (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) :
+    pushDensity f ν μ s a ∈ Icc (0 : ℝ) 1 :=
+  ⟨pushDensity_nonneg f ν μ s a, pushDensity_le_one f ν μ s a⟩
+
+/-- Pushing forward the part of `ν` carried by `s` gives a measure below `μ`.  This is the whole
+reason the density is `[0, 1]`-valued, and it needs no hypothesis on `s`. -/
+theorem map_restrict_le_of_measurePreserving (hf : MeasurePreserving f ν μ) (s : Set Ω') :
+    (ν.restrict s).map f ≤ μ := by
+  rw [← hf.map_eq]
+  exact Measure.map_mono Measure.restrict_le_self hf.measurable
+
+/-- The pushforward of the restriction is absolutely continuous with respect to `μ`. -/
+theorem map_restrict_absolutelyContinuous (hf : MeasurePreserving f ν μ) (s : Set Ω') :
+    (ν.restrict s).map f ≪ μ :=
+  Measure.absolutelyContinuous_of_le (map_restrict_le_of_measurePreserving hf s)
+
+/-- **The truncation in `pushDensity` is a.e. invisible.**  The underlying Radon–Nikodym derivative
+is already at most `1` almost everywhere, because the measure it differentiates is below `μ`. -/
+theorem pushDensity_ae_eq_rnDeriv [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) (s : Set Ω') :
+    pushDensity f ν μ s =ᵐ[μ] fun a => (((ν.restrict s).map f).rnDeriv μ a).toReal := by
+  have hμ : IsFiniteMeasure μ := by
+    rw [← hf.map_eq]; exact Measure.isFiniteMeasure_map _ _
+  filter_upwards [Measure.rnDeriv_le_one_of_le (map_restrict_le_of_measurePreserving hf s)]
+    with a ha
+  have h1 : (((ν.restrict s).map f).rnDeriv μ a).toReal ≤ 1 := by
+    simpa using ENNReal.toReal_mono ENNReal.one_ne_top ha
+  exact min_eq_right h1
+
+/-- **The characterising identity of `pushDensity`.**  Integrating a function on the base against
+the density computes its integral, composed with `f`, over the set upstairs.
+
+The set is arbitrary: `Measure.restrict` and every step of the computation are insensitive to its
+measurability. -/
+theorem integral_pushDensity_mul [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) (s : Set Ω')
+    {g : Ω → ℝ} (hg : Measurable g) :
+    ∫ a, pushDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν := by
+  have hμ : IsFiniteMeasure μ := by
+    rw [← hf.map_eq]; exact Measure.isFiniteMeasure_map _ _
+  have hρ : IsFiniteMeasure ((ν.restrict s).map f) := Measure.isFiniteMeasure_map _ _
+  calc ∫ a, pushDensity f ν μ s a * g a ∂μ
+      = ∫ a, (((ν.restrict s).map f).rnDeriv μ a).toReal * g a ∂μ :=
+        integral_congr_ae (by
+          filter_upwards [pushDensity_ae_eq_rnDeriv hf s] with a ha
+          rw [ha])
+    _ = ∫ a, g a ∂((ν.restrict s).map f) :=
+        integral_toReal_rnDeriv_mul (map_restrict_absolutelyContinuous hf s)
+    _ = ∫ x in s, g (f x) ∂ν :=
+        integral_map hf.measurable.aemeasurable hg.aestronglyMeasurable
+
+/-- The density integrates to the measure of the set it came from: the case `g = 1` of
+`integral_pushDensity_mul`. -/
+theorem integral_pushDensity [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) (s : Set Ω') :
+    ∫ a, pushDensity f ν μ s a ∂μ = ν.real s := by
+  have h := integral_pushDensity_mul hf s (g := fun _ => (1 : ℝ)) measurable_const
+  simpa [Measure.restrict_apply_univ] using h
+
+/-- **On a preimage the density is an indicator.**  Nothing is lost when the set upstairs is
+already cut out by a set on the base, so `pushDensity` extends the trivial case rather than
+replacing it. -/
+theorem pushDensity_preimage [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) {t : Set Ω}
+    (ht : MeasurableSet t) :
+    pushDensity f ν μ (f ⁻¹' t) =ᵐ[μ] t.indicator 1 := by
+  have hμ : IsFiniteMeasure μ := by
+    rw [← hf.map_eq]; exact Measure.isFiniteMeasure_map _ _
+  have hmap : (ν.restrict (f ⁻¹' t)).map f = μ.restrict t := by
+    rw [← Measure.restrict_map hf.measurable ht, hf.map_eq]
+  have hrn : ((ν.restrict (f ⁻¹' t)).map f).rnDeriv μ =ᵐ[μ] t.indicator 1 := by
+    rw [hmap]; exact Measure.rnDeriv_restrict_self μ ht
+  filter_upwards [pushDensity_ae_eq_rnDeriv hf (f ⁻¹' t), hrn] with a ha hb
+  rw [ha, hb]
+  by_cases hat : a ∈ t <;> simp [hat]
+
+/-- The whole carrier upstairs has density `1`. -/
+theorem pushDensity_univ [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) :
+    pushDensity f ν μ univ =ᵐ[μ] 1 := by
+  have h := pushDensity_preimage hf (t := univ) MeasurableSet.univ
+  simpa using h
+
+/-- **The density genuinely takes fractional values.**  On a product carrier projected to its first
+factor, a rectangle `s ×ˢ t` has density `ν.real t · 1_s`: the second factor contributes its mass,
+not an indicator.  Together with `pushDensity_preimage` this pins the construction down — an
+indicator of a set on the base would be wrong whenever `0 < ν.real t < 1`. -/
+theorem pushDensity_prod_fst [IsFiniteMeasure μ] [IsProbabilityMeasure ν] {s : Set Ω}
+    (hs : MeasurableSet s) (t : Set Ω') :
+    pushDensity Prod.fst (μ.prod ν) μ (s ×ˢ t) =ᵐ[μ] fun a => ν.real t * s.indicator 1 a := by
+  have hf : MeasurePreserving (Prod.fst : Ω × Ω' → Ω) (μ.prod ν) μ := measurePreserving_fst
+  have hmap : ((μ.prod ν).restrict (s ×ˢ t)).map Prod.fst
+      = μ.withDensity (fun a => ν t * s.indicator 1 a) := by
+    refine Measure.ext fun A hA => ?_
+    have hcut : (Prod.fst : Ω × Ω' → Ω) ⁻¹' A ∩ s ×ˢ t = (A ∩ s) ×ˢ t := by
+      ext p; simp only [Set.mem_inter_iff, Set.mem_preimage, Set.mem_prod]; tauto
+    rw [Measure.map_apply measurable_fst hA, Measure.restrict_apply (measurable_fst hA), hcut,
+      Measure.prod_prod, withDensity_apply _ hA,
+      lintegral_const_mul' _ _ (measure_ne_top ν t), lintegral_indicator hs]
+    simp [Measure.restrict_apply hs, Set.inter_comm, mul_comm]
+  have hrn : (((μ.prod ν).restrict (s ×ˢ t)).map Prod.fst).rnDeriv μ
+      =ᵐ[μ] fun a => ν t * s.indicator 1 a := by
+    rw [hmap]
+    exact Measure.rnDeriv_withDensity μ (measurable_const.mul (measurable_one.indicator hs))
+  filter_upwards [pushDensity_ae_eq_rnDeriv hf (s ×ˢ t), hrn] with a ha hb
+  rw [ha, hb]
+  by_cases has : a ∈ s
+  · have hval : (ν t * s.indicator (1 : Ω → ℝ≥0∞) a).toReal = ν.real t := by
+      simp [Set.indicator_of_mem has, measureReal_def]
+    rw [hval, Set.indicator_of_mem has, Pi.one_apply, mul_one]
+  · simp [Set.indicator_of_notMem has]
+
+end MeasureTheory
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Measure/PushforwardDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/PushforwardDensity.lean
@@ -10,14 +10,16 @@ public import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
 /-!
 # The density of a set upstairs, seen on the base of a measure-preserving map
 
-Let `f : Ω' → Ω` push a finite measure `ν` forward to `μ`, and let `s ⊆ Ω'` be a set upstairs.
+Let `f : Ω' → Ω` push a measure `ν` forward to a σ-finite measure `μ`, and let `s ⊆ Ω'` be a
+set upstairs.
 The part of `ν` carried by `s` pushes forward to a measure `≤ μ`, so it has a Radon–Nikodym
-density with respect to `μ` taking values in `[0, 1]`. That density is `pushDensity f ν μ s`, and
+density with respect to `μ` taking values in `[0, 1]`. That density is
+`mapRestrictDensity f ν μ s`, and
 it is characterised by
 
-`∫ a, pushDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν`
+`∫ a, mapRestrictDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν`
 
-for every bounded measurable `g : Ω → ℝ` (`integral_pushDensity_mul`). In probabilistic language
+for every measurable `g : Ω → ℝ` (`integral_mapRestrictDensity_mul`). In probabilistic language
 it is the conditional probability of `s` given `f`, read as a function on the base: composing it
 with `f` gives a version of `ν[s.indicator 1 | comap f]`. Nothing here needs that reading, so the
 conditional-expectation machinery is not used; the elementary Radon–Nikodym route is enough.
@@ -26,29 +28,30 @@ conditional-expectation machinery is not used; the elementary Radon–Nikodym ro
 that the `[0, 1]` bounds hold *everywhere*, not merely almost everywhere. Consumers pair this
 function against a kernel and need a strict pointwise bound to feed an extremal argument; the
 truncation is invisible to every integral statement below, because it changes the derivative only
-on a `μ`-null set (`pushDensity_ae_eq_rnDeriv`).
+on a `μ`-null set (`mapRestrictDensity_ae_eq_rnDeriv`).
 
 ## Main definitions
 
-* `TauCeti.MeasureTheory.pushDensity` — the `[0, 1]`-valued density on the base of the part of `ν`
-  carried by a set upstairs.
+* `TauCeti.MeasureTheory.mapRestrictDensity` — the `[0, 1]`-valued density on the base of the part
+  of `ν` carried by a set upstairs.
 
 ## Main results
 
-* `TauCeti.MeasureTheory.integral_pushDensity_mul` — the characterising identity: integrating
+* `TauCeti.MeasureTheory.integral_mapRestrictDensity_mul` — the characterising identity: integrating
   against the density downstairs computes the integral over the set upstairs. No measurability of
   the set is needed.
-* `TauCeti.MeasureTheory.pushDensity_ae_eq_rnDeriv` — the truncation is a.e. invisible.
-* `TauCeti.MeasureTheory.integral_pushDensity` — the density integrates to the measure of the set,
-  the case `g = 1`.
-* `TauCeti.MeasureTheory.pushDensity_congr` — the density depends on the set upstairs only through
-  its `ν`-a.e. class; this equality is exact, not almost everywhere.
-* `TauCeti.MeasureTheory.pushDensity_preimage` and `TauCeti.MeasureTheory.pushDensity_univ` — on a
+* `TauCeti.MeasureTheory.mapRestrictDensity_ae_eq_rnDeriv` — the truncation is a.e. invisible.
+* `TauCeti.MeasureTheory.integral_mapRestrictDensity` — the density integrates to the measure of
+  the set, the case `g = 1`.
+* `TauCeti.MeasureTheory.mapRestrictDensity_congr` — the density depends on the set upstairs only
+  through its `ν`-a.e. class; this equality is exact, not almost everywhere.
+* `TauCeti.MeasureTheory.mapRestrictDensity_preimage` and
+  `TauCeti.MeasureTheory.mapRestrictDensity_univ` — on a
   preimage the density collapses `μ`-almost everywhere to an indicator, so the construction extends
   the trivial case.
-* `TauCeti.MeasureTheory.pushDensity_prod_fst` — on a product carrier the density of a rectangle is
-  `μ`-almost everywhere a genuinely fractional multiple of an indicator, so no such collapse holds
-  in general.
+* `TauCeti.MeasureTheory.mapRestrictDensity_fst_prod` — on a product carrier the density of a
+  rectangle is `μ`-almost everywhere a genuinely fractional multiple of an indicator, so no such
+  collapse holds in general.
 
 ## References
 
@@ -76,136 +79,134 @@ variable {μ : Measure Ω} {ν : Measure Ω'} {f : Ω' → Ω}
 `(ν.restrict s).map f` with respect to `μ`, truncated to `[0, 1]`.
 
 When `f` pushes `ν` forward to `μ` the truncation is a.e. invisible
-(`pushDensity_ae_eq_rnDeriv`) and the function is characterised by
-`integral_pushDensity_mul`. The measures are explicit arguments because neither is determined by
-the others: `μ` is not forced to be `ν.map f` by the type. -/
-def pushDensity (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) : ℝ :=
+(`mapRestrictDensity_ae_eq_rnDeriv`) and the function is characterised by
+`integral_mapRestrictDensity_mul`. The measures are explicit arguments because neither is
+determined by the others: `μ` is not forced to be `ν.map f` by the type. -/
+def mapRestrictDensity (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) : ℝ :=
   min 1 (((ν.restrict s).map f).rnDeriv μ a).toReal
 
-/-- The defining formula of `pushDensity`. -/
-theorem pushDensity_def (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) :
-    pushDensity f ν μ s a = min 1 (((ν.restrict s).map f).rnDeriv μ a).toReal := (rfl)
+/-- The defining formula of `mapRestrictDensity`. -/
+theorem mapRestrictDensity_def (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω)
+    (s : Set Ω') (a : Ω) :
+    mapRestrictDensity f ν μ s a = min 1 (((ν.restrict s).map f).rnDeriv μ a).toReal := (rfl)
 
 /-- The density is measurable, being a truncated Radon–Nikodym derivative. -/
 @[fun_prop]
-theorem measurable_pushDensity (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') :
-    Measurable (pushDensity f ν μ s) :=
+theorem measurable_mapRestrictDensity (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω)
+    (s : Set Ω') : Measurable (mapRestrictDensity f ν μ s) :=
   measurable_const.min (Measure.measurable_rnDeriv _ _).ennreal_toReal
 
 /-- **The density is `[0, 1]`-valued everywhere.**  The upper bound is what the truncation in the
 definition buys; both bounds are packaged together, in the form the extremal arguments of the
 cut-norm theory consume, and the two halves are `.1` and `.2`. -/
-theorem pushDensity_mem_Icc (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) :
-    pushDensity f ν μ s a ∈ Icc (0 : ℝ) 1 :=
+theorem mapRestrictDensity_mem_Icc (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω)
+    (s : Set Ω') (a : Ω) : mapRestrictDensity f ν μ s a ∈ Icc (0 : ℝ) 1 :=
   ⟨le_min zero_le_one ENNReal.toReal_nonneg, min_le_left _ _⟩
 
 /-- **The density depends on the set upstairs only through its `ν`-a.e. class.**  Replacing `s` by
 an a.e. equal set does not change the function at all, since it does not change `ν.restrict s`. -/
-theorem pushDensity_congr (f : Ω' → Ω) (μ : Measure Ω) {s t : Set Ω'} (h : s =ᵐ[ν] t) :
-    pushDensity f ν μ s = pushDensity f ν μ t := by
+theorem mapRestrictDensity_congr (f : Ω' → Ω) (μ : Measure Ω) {s t : Set Ω'}
+    (h : s =ᵐ[ν] t) : mapRestrictDensity f ν μ s = mapRestrictDensity f ν μ t := by
   funext a
-  rw [pushDensity_def, pushDensity_def, Measure.restrict_congr_set h]
+  rw [mapRestrictDensity_def, mapRestrictDensity_def, Measure.restrict_congr_set h]
 
 /-- Pushing forward the part of `ν` carried by `s` gives a measure below `μ`.  This is the whole
 reason the density is `[0, 1]`-valued, and it needs no hypothesis on `s`. -/
-theorem map_restrict_le_of_measurePreserving (hf : MeasurePreserving f ν μ) (s : Set Ω') :
+theorem map_restrict_le (hf : MeasurePreserving f ν μ) (s : Set Ω') :
     (ν.restrict s).map f ≤ μ := by
   rw [← hf.map_eq]
   exact Measure.map_mono Measure.restrict_le_self hf.measurable
 
-/-- The pushforward of the restriction is absolutely continuous with respect to `μ`. -/
-theorem map_restrict_absolutelyContinuous (hf : MeasurePreserving f ν μ) (s : Set Ω') :
-    (ν.restrict s).map f ≪ μ :=
-  Measure.absolutelyContinuous_of_le (map_restrict_le_of_measurePreserving hf s)
+/-- A finite source measure makes the target of a measure-preserving map finite. -/
+theorem isFiniteMeasure_of_measurePreserving [IsFiniteMeasure ν]
+    (hf : MeasurePreserving f ν μ) : IsFiniteMeasure μ := by
+  rw [← hf.map_eq]
+  exact Measure.isFiniteMeasure_map _ _
 
-/-- **The truncation in `pushDensity` is a.e. invisible.**  The underlying Radon–Nikodym derivative
-is already at most `1` almost everywhere, because the measure it differentiates is below `μ`. -/
-theorem pushDensity_ae_eq_rnDeriv [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) (s : Set Ω') :
-    pushDensity f ν μ s =ᵐ[μ] fun a => (((ν.restrict s).map f).rnDeriv μ a).toReal := by
-  have hμ : IsFiniteMeasure μ := by
-    rw [← hf.map_eq]; exact Measure.isFiniteMeasure_map _ _
-  filter_upwards [Measure.rnDeriv_le_one_of_le (map_restrict_le_of_measurePreserving hf s)]
+/-- **The truncation in `mapRestrictDensity` is a.e. invisible.**  The underlying Radon–Nikodym
+derivative is already at most `1` almost everywhere, because the measure it differentiates is
+below `μ`. -/
+theorem mapRestrictDensity_ae_eq_rnDeriv [SigmaFinite μ] (hf : MeasurePreserving f ν μ)
+    (s : Set Ω') :
+    mapRestrictDensity f ν μ s =ᵐ[μ] fun a => (((ν.restrict s).map f).rnDeriv μ a).toReal := by
+  filter_upwards [Measure.rnDeriv_le_one_of_le (map_restrict_le hf s)]
     with a ha
   have h1 : (((ν.restrict s).map f).rnDeriv μ a).toReal ≤ 1 := by
     simpa using ENNReal.toReal_mono ENNReal.one_ne_top ha
   exact min_eq_right h1
 
-/-- **The characterising identity of `pushDensity`.**  Integrating a function on the base against
-the density computes its integral, composed with `f`, over the set upstairs.
+/-- **The characterising identity of `mapRestrictDensity`.**  Integrating a function on the base
+against the density computes its integral, composed with `f`, over the set upstairs.
 
 The set is arbitrary: `Measure.restrict` and every step of the computation are insensitive to its
 measurability. -/
-theorem integral_pushDensity_mul [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) (s : Set Ω')
+theorem integral_mapRestrictDensity_mul [SigmaFinite μ] (hf : MeasurePreserving f ν μ) (s : Set Ω')
     {g : Ω → ℝ} (hg : Measurable g) :
-    ∫ a, pushDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν := by
-  have hμ : IsFiniteMeasure μ := by
-    rw [← hf.map_eq]; exact Measure.isFiniteMeasure_map _ _
-  have hρ : IsFiniteMeasure ((ν.restrict s).map f) := Measure.isFiniteMeasure_map _ _
-  calc ∫ a, pushDensity f ν μ s a * g a ∂μ
+    ∫ a, mapRestrictDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν := by
+  let _ : SigmaFinite ((ν.restrict s).map f) :=
+    Measure.sigmaFinite_of_le μ (map_restrict_le hf s)
+  calc ∫ a, mapRestrictDensity f ν μ s a * g a ∂μ
       = ∫ a, (((ν.restrict s).map f).rnDeriv μ a).toReal * g a ∂μ :=
         integral_congr_ae (by
-          filter_upwards [pushDensity_ae_eq_rnDeriv hf s] with a ha
+          filter_upwards [mapRestrictDensity_ae_eq_rnDeriv hf s] with a ha
           rw [ha])
     _ = ∫ a, g a ∂((ν.restrict s).map f) :=
-        integral_toReal_rnDeriv_mul (map_restrict_absolutelyContinuous hf s)
+        integral_toReal_rnDeriv_mul
+          (Measure.absolutelyContinuous_of_le (map_restrict_le hf s))
     _ = ∫ x in s, g (f x) ∂ν :=
         integral_map hf.measurable.aemeasurable hg.aestronglyMeasurable
 
 /-- The density integrates to the measure of the set it came from: the case `g = 1` of
-`integral_pushDensity_mul`. -/
-theorem integral_pushDensity [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) (s : Set Ω') :
-    ∫ a, pushDensity f ν μ s a ∂μ = ν.real s := by
-  have h := integral_pushDensity_mul hf s (g := fun _ => (1 : ℝ)) measurable_const
+`integral_mapRestrictDensity_mul`. -/
+theorem integral_mapRestrictDensity [SigmaFinite μ] (hf : MeasurePreserving f ν μ) (s : Set Ω') :
+    ∫ a, mapRestrictDensity f ν μ s a ∂μ = ν.real s := by
+  have h := integral_mapRestrictDensity_mul hf s (g := fun _ => (1 : ℝ)) measurable_const
   simpa [Measure.restrict_apply_univ] using h
 
 /-- **On a preimage the density is `μ`-almost everywhere an indicator.**  Nothing is lost when the
-set upstairs is already cut out by a set on the base, so `pushDensity` extends the trivial case
-rather than replacing it.
+set upstairs is already cut out by a set on the base, so `mapRestrictDensity` extends the trivial
+case rather than replacing it.
 
 The conclusion is only `μ`-a.e., as it must be: the Radon–Nikodym derivative is itself defined only
 up to a `μ`-null set. -/
-theorem pushDensity_preimage [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) {t : Set Ω}
+theorem mapRestrictDensity_preimage [SigmaFinite μ] (hf : MeasurePreserving f ν μ) {t : Set Ω}
     (ht : MeasurableSet t) :
-    pushDensity f ν μ (f ⁻¹' t) =ᵐ[μ] t.indicator 1 := by
-  have hμ : IsFiniteMeasure μ := by
-    rw [← hf.map_eq]; exact Measure.isFiniteMeasure_map _ _
+    mapRestrictDensity f ν μ (f ⁻¹' t) =ᵐ[μ] t.indicator 1 := by
   have hmap : (ν.restrict (f ⁻¹' t)).map f = μ.restrict t := by
     rw [← Measure.restrict_map hf.measurable ht, hf.map_eq]
   have hrn : ((ν.restrict (f ⁻¹' t)).map f).rnDeriv μ =ᵐ[μ] t.indicator 1 := by
     rw [hmap]; exact Measure.rnDeriv_restrict_self μ ht
-  filter_upwards [pushDensity_ae_eq_rnDeriv hf (f ⁻¹' t), hrn] with a ha hb
+  filter_upwards [mapRestrictDensity_ae_eq_rnDeriv hf (f ⁻¹' t), hrn] with a ha hb
   rw [ha, hb]
   by_cases hat : a ∈ t <;> simp [hat]
 
 /-- The whole carrier upstairs has density `1` `μ`-almost everywhere. -/
-theorem pushDensity_univ [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) :
-    pushDensity f ν μ univ =ᵐ[μ] 1 := by
-  have h := pushDensity_preimage hf (t := univ) MeasurableSet.univ
+theorem mapRestrictDensity_univ [SigmaFinite μ] (hf : MeasurePreserving f ν μ) :
+    mapRestrictDensity f ν μ univ =ᵐ[μ] 1 := by
+  have h := mapRestrictDensity_preimage hf (t := univ) MeasurableSet.univ
   simpa using h
 
 /-- **The density genuinely takes fractional values.**  On a product carrier projected to its first
 factor, a rectangle `s ×ˢ t` has density `ν.real t · 1_s` `μ`-almost everywhere: the second factor
-contributes its mass, not an indicator.  Together with `pushDensity_preimage` this pins the
+contributes its mass, not an indicator.  Together with `mapRestrictDensity_preimage` this pins the
 construction down — an indicator of a set on the base would be wrong whenever
 `0 < ν.real t < 1`. -/
-theorem pushDensity_prod_fst [IsFiniteMeasure μ] [IsProbabilityMeasure ν] {s : Set Ω}
+theorem mapRestrictDensity_fst_prod [SigmaFinite μ] [IsProbabilityMeasure ν] {s : Set Ω}
     (hs : MeasurableSet s) (t : Set Ω') :
-    pushDensity Prod.fst (μ.prod ν) μ (s ×ˢ t) =ᵐ[μ] fun a => ν.real t * s.indicator 1 a := by
+    mapRestrictDensity Prod.fst (μ.prod ν) μ (s ×ˢ t) =ᵐ[μ]
+      fun a => ν.real t * s.indicator 1 a := by
   have hf : MeasurePreserving (Prod.fst : Ω × Ω' → Ω) (μ.prod ν) μ := measurePreserving_fst
-  have hmap : ((μ.prod ν).restrict (s ×ˢ t)).map Prod.fst
-      = μ.withDensity (fun a => ν t * s.indicator 1 a) := by
-    refine Measure.ext fun A hA => ?_
-    have hcut : (Prod.fst : Ω × Ω' → Ω) ⁻¹' A ∩ s ×ˢ t = (A ∩ s) ×ˢ t := by
-      ext p; simp only [Set.mem_inter_iff, Set.mem_preimage, Set.mem_prod]; tauto
-    rw [Measure.map_apply measurable_fst hA, Measure.restrict_apply (measurable_fst hA), hcut,
-      Measure.prod_prod, withDensity_apply _ hA,
-      lintegral_const_mul' _ _ (measure_ne_top ν t), lintegral_indicator hs]
-    simp [Measure.restrict_apply hs, Set.inter_comm, mul_comm]
+  have hmap : ((μ.prod ν).restrict (s ×ˢ t)).map Prod.fst = ν t • μ.restrict s := by
+    rw [← Measure.prod_restrict, Measure.map_fst_prod, Measure.restrict_apply_univ]
   have hrn : (((μ.prod ν).restrict (s ×ˢ t)).map Prod.fst).rnDeriv μ
       =ᵐ[μ] fun a => ν t * s.indicator 1 a := by
     rw [hmap]
-    exact Measure.rnDeriv_withDensity μ (measurable_const.mul (measurable_one.indicator hs))
-  filter_upwards [pushDensity_ae_eq_rnDeriv hf (s ×ˢ t), hrn] with a ha hb
+    filter_upwards [Measure.rnDeriv_smul_left_of_ne_top' (μ.restrict s) μ
+      (measure_ne_top ν t), Measure.rnDeriv_restrict_self μ hs] with a ha hb
+    rw [ha]
+    change ν t * (μ.restrict s).rnDeriv μ a = ν t * s.indicator 1 a
+    rw [hb]
+  filter_upwards [mapRestrictDensity_ae_eq_rnDeriv hf (s ×ˢ t), hrn] with a ha hb
   rw [ha, hb]
   by_cases has : a ∈ s
   · have hval : (ν t * s.indicator (1 : Ω → ℝ≥0∞) a).toReal = ν.real t := by

--- a/TauCeti/MeasureTheory/Measure/PushforwardDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/PushforwardDensity.lean
@@ -41,10 +41,14 @@ on a `μ`-null set (`pushDensity_ae_eq_rnDeriv`).
 * `TauCeti.MeasureTheory.pushDensity_ae_eq_rnDeriv` — the truncation is a.e. invisible.
 * `TauCeti.MeasureTheory.integral_pushDensity` — the density integrates to the measure of the set,
   the case `g = 1`.
+* `TauCeti.MeasureTheory.pushDensity_congr` — the density depends on the set upstairs only through
+  its `ν`-a.e. class; this equality is exact, not almost everywhere.
 * `TauCeti.MeasureTheory.pushDensity_preimage` and `TauCeti.MeasureTheory.pushDensity_univ` — on a
-  preimage the density collapses to an indicator, so the construction extends the trivial case.
-* `TauCeti.MeasureTheory.pushDensity_prod_fst` — on a product carrier the density of a rectangle
-  is a genuinely fractional multiple of an indicator, so no such collapse holds in general.
+  preimage the density collapses `μ`-almost everywhere to an indicator, so the construction extends
+  the trivial case.
+* `TauCeti.MeasureTheory.pushDensity_prod_fst` — on a product carrier the density of a rectangle is
+  `μ`-almost everywhere a genuinely fractional multiple of an indicator, so no such collapse holds
+  in general.
 
 ## References
 
@@ -88,21 +92,19 @@ theorem measurable_pushDensity (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure
     Measurable (pushDensity f ν μ s) :=
   measurable_const.min (Measure.measurable_rnDeriv _ _).ennreal_toReal
 
-/-- The density is nonnegative everywhere. -/
-theorem pushDensity_nonneg (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) :
-    0 ≤ pushDensity f ν μ s a :=
-  le_min zero_le_one ENNReal.toReal_nonneg
-
-/-- The density is at most `1` everywhere: this is what the truncation buys. -/
-theorem pushDensity_le_one (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) :
-    pushDensity f ν μ s a ≤ 1 :=
-  min_le_left _ _
-
-/-- The density is `[0, 1]`-valued everywhere, in the packaged form the extremal arguments of the
-cut-norm theory consume. -/
+/-- **The density is `[0, 1]`-valued everywhere.**  The upper bound is what the truncation in the
+definition buys; both bounds are packaged together, in the form the extremal arguments of the
+cut-norm theory consume, and the two halves are `.1` and `.2`. -/
 theorem pushDensity_mem_Icc (f : Ω' → Ω) (ν : Measure Ω') (μ : Measure Ω) (s : Set Ω') (a : Ω) :
     pushDensity f ν μ s a ∈ Icc (0 : ℝ) 1 :=
-  ⟨pushDensity_nonneg f ν μ s a, pushDensity_le_one f ν μ s a⟩
+  ⟨le_min zero_le_one ENNReal.toReal_nonneg, min_le_left _ _⟩
+
+/-- **The density depends on the set upstairs only through its `ν`-a.e. class.**  Replacing `s` by
+an a.e. equal set does not change the function at all, since it does not change `ν.restrict s`. -/
+theorem pushDensity_congr (f : Ω' → Ω) (μ : Measure Ω) {s t : Set Ω'} (h : s =ᵐ[ν] t) :
+    pushDensity f ν μ s = pushDensity f ν μ t := by
+  funext a
+  rw [pushDensity_def, pushDensity_def, Measure.restrict_congr_set h]
 
 /-- Pushing forward the part of `ν` carried by `s` gives a measure below `μ`.  This is the whole
 reason the density is `[0, 1]`-valued, and it needs no hypothesis on `s`. -/
@@ -156,9 +158,12 @@ theorem integral_pushDensity [IsFiniteMeasure ν] (hf : MeasurePreserving f ν �
   have h := integral_pushDensity_mul hf s (g := fun _ => (1 : ℝ)) measurable_const
   simpa [Measure.restrict_apply_univ] using h
 
-/-- **On a preimage the density is an indicator.**  Nothing is lost when the set upstairs is
-already cut out by a set on the base, so `pushDensity` extends the trivial case rather than
-replacing it. -/
+/-- **On a preimage the density is `μ`-almost everywhere an indicator.**  Nothing is lost when the
+set upstairs is already cut out by a set on the base, so `pushDensity` extends the trivial case
+rather than replacing it.
+
+The conclusion is only `μ`-a.e., as it must be: the Radon–Nikodym derivative is itself defined only
+up to a `μ`-null set. -/
 theorem pushDensity_preimage [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) {t : Set Ω}
     (ht : MeasurableSet t) :
     pushDensity f ν μ (f ⁻¹' t) =ᵐ[μ] t.indicator 1 := by
@@ -172,16 +177,17 @@ theorem pushDensity_preimage [IsFiniteMeasure ν] (hf : MeasurePreserving f ν �
   rw [ha, hb]
   by_cases hat : a ∈ t <;> simp [hat]
 
-/-- The whole carrier upstairs has density `1`. -/
+/-- The whole carrier upstairs has density `1` `μ`-almost everywhere. -/
 theorem pushDensity_univ [IsFiniteMeasure ν] (hf : MeasurePreserving f ν μ) :
     pushDensity f ν μ univ =ᵐ[μ] 1 := by
   have h := pushDensity_preimage hf (t := univ) MeasurableSet.univ
   simpa using h
 
 /-- **The density genuinely takes fractional values.**  On a product carrier projected to its first
-factor, a rectangle `s ×ˢ t` has density `ν.real t · 1_s`: the second factor contributes its mass,
-not an indicator.  Together with `pushDensity_preimage` this pins the construction down — an
-indicator of a set on the base would be wrong whenever `0 < ν.real t < 1`. -/
+factor, a rectangle `s ×ˢ t` has density `ν.real t · 1_s` `μ`-almost everywhere: the second factor
+contributes its mass, not an indicator.  Together with `pushDensity_preimage` this pins the
+construction down — an indicator of a set on the base would be wrong whenever
+`0 < ν.real t < 1`. -/
 theorem pushDensity_prod_fst [IsFiniteMeasure μ] [IsProbabilityMeasure ν] {s : Set Ω}
     (hs : MeasurableSet s) (t : Set Ω') :
     pushDensity Prod.fst (μ.prod ν) μ (s ×ˢ t) =ᵐ[μ] fun a => ν.real t * s.indicator 1 a := by


### PR DESCRIPTION
This PR proves that the cut norm of a symmetric kernel is invariant under measure-preserving pullback: if `f : Ω' → Ω` pushes `ν` forward to `μ`, then `cutNorm ν (K.comap f) = cutNorm μ K`. One half was already on `main` — a measurable rectangle downstairs pulls back to one upstairs with the same integral, giving `cutNorm_le_cutNorm_comap`. The reverse half is the content here, and it is not a change of variables: a rectangle `S × T` upstairs need not be the preimage of anything, so its integral has to be pushed *down*. The push is by conditional density — the part of `ν` carried by `S` pushes forward to a measure below `μ`, whose Radon–Nikodym derivative is a `[0,1]`-valued function on the base — after which the sharp, constant-free `abs_testIntegral_le_cutNorm` already on `main` closes the bound.

The target is the `DenseGraphLimits` **Layer 1** milestone "`cutNorm` with its seminorm laws, the `L¹` bound, and the equivalent set form" together with the coupling-primary `cutDist` "and its triangle inequality on arbitrary probability carriers (Janson, Lemma 6.5)". The README gates that triangle inequality behind a design-validation milestone — "finite coupling gluing with zero-mass middle atoms explicit, then stability of the reduction under step approximation." The finite-gluing half landed as #4365; stability under step approximation remains a mandatory prerequisite. This PR supplies the pullback-invariance input used within that reduction: after step approximation reduces the couplings to finite data and finite gluing produces a three-fold measure, the two outer cut norms on `π₁₂` and `π₂₃` must be compared with cut norms on the glued space along its measure-preserving coordinate projections. The required comparison is precisely `cutNorm_comap_le`. Thus the next Layer 1 step is stability of the finite reduction under step approximation; only then can the triangle inequality be assembled from that stability, #4365, and this invariance. The fixed-carrier quotient `GraphonSpace Ω μ` follows afterward.

New files:

- `TauCeti/MeasureTheory/Measure/MapRestrictDensity.lean` — the general measure-theoretic ingredient, in `TauCeti.MeasureTheory` because nothing in it mentions graphons. `mapRestrictDensity f ν μ s` is the Radon–Nikodym derivative of `(ν.restrict s).map f` with respect to `μ`, truncated to `[0,1]` so the bounds hold everywhere rather than almost everywhere; `mapRestrictDensity_ae_eq_rnDeriv` records that the truncation is a.e. invisible, `mapRestrictDensity_congr_set` records that the set upstairs matters only through its `ν`-a.e. class, and `integral_mapRestrictDensity_mul` is the characterising identity `∫ a, mapRestrictDensity f ν μ s a * g a ∂μ = ∫ x in s, g (f x) ∂ν`, which needs no measurability of `s`. Three regressions pin the construction down: `mapRestrictDensity_preimage` and `mapRestrictDensity_univ` show it collapses `μ`-almost everywhere to an indicator when the set upstairs is already cut out on the base, and `mapRestrictDensity_fst_prod` exhibits a rectangle in a product carrier whose density is a genuinely fractional multiple `ν.real t · 1_s` of an indicator — the case an indicator-valued reading of the definition would get wrong. When `s` is measurable, Mathlib's `MeasureTheory.toReal_rnDeriv_map` identifies this object with a conditional expectation of that set's indicator; that reading is recorded in the module docstring but is not used, since the elementary Radon–Nikodym route through `integral_toReal_rnDeriv_mul` is shorter.
- `TauCeti/Combinatorics/DenseGraphLimits/Kernel/Pullback.lean` — `SymmKernel.rectIntegral_comap_eq_testIntegral` (a rectangle integral of a pullback is a `[0,1]`-test integral of the original kernel), `cutNorm_comap_le`, and `cutNorm_comap`. The file is named `Pullback.lean` rather than `CutNormPullback.lean` so that `Kernel/` keeps no two flat siblings sharing a CamelCase prefix.

Three existing files change:

- `TauCeti/MeasureTheory/Measure/Coupling.lean` gains `measurePreserving_diagonal`. `diagonalCoupling` is not reducible outside its own module, so a caller cannot supply the pushforward identity by `rfl`; the lemma is stated where the definition is visible.
- `TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Distance.lean` gains `cutNorm_overlayDiff_diagonalCoupling`: the diagonal coupling contributes exactly the same-carrier cut norm `‖U − W‖□` to the cut-distance infimum. This closes a gap that `comap_overlayDiff_diagonalCoupling` names in its own docstring ("recognizing the resulting value as the same-carrier cut norm additionally needs the cut norm's change of variables along a pushforward, which is not part of this file"). The new import is a plain `import`, not a `public import`, since `Pullback` is used only inside a proof.
- `TauCeti/Combinatorics/DenseGraphLimits/CutMetric/Coupling.lean` — that docstring is updated to point at the theorem instead of at an absent one.

No Mathlib infrastructure was vendored. The `[0,1]`-test form is what makes the invariance exact: routing through `cutNormSigned` instead would cost the factor of `4` from `cutNormSigned_le_four_mul_cutNorm` and yield only a comparison.

Roadmap: DenseGraphLimits

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"cutnorm-comap"}-->

🤖 Prepared with Claude Code



