### PR TITLE
feat: the Berg--Christensen--Ressel representation theorem

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Basic.lean
@@ -49,7 +49,8 @@ argument.
 
 * `TauCeti.fwdDiffList`: the forward difference `Δ_{h₁} ⋯ Δ_{hₙ} f` along a list of steps.
 * `TauCeti.fwdDiffList_congr`: on `[0, ∞)` a mixed difference with nonnegative steps only sees the
-  values of the function there.
+  values of the function there, and `TauCeti.fwdDiffList_congr_of_add_mem` sharpens this to any
+  set of arguments closed under adding the steps.
 * `TauCeti.IsDifferenceCompletelyMonotone`: complete monotonicity in the finite-difference sense.
 * `TauCeti.isDifferenceCompletelyMonotone_of_tendsto`: the predicate is closed under pointwise
   limits on `[0, ∞)`, unlike its derivative form.
@@ -145,6 +146,27 @@ theorem fwdDiffList_const_smul {R : Type*} [Monoid R] [DistribMulAction R G]
 theorem fwdDiffList_neg (l : List M) (f : M → G) :
     fwdDiffList l (fun t => -f t) = fun t => -fwdDiffList l f t := by
   simpa only [neg_one_zsmul] using fwdDiffList_const_smul (-1 : ℤ) l f
+
+/-- Consing a step, at a point: one more forward difference reads the previous one at `t` and at
+the translate `t + h`. -/
+theorem fwdDiffList_cons_apply (h : M) (l : List M) (f : M → G) (t : M) :
+    fwdDiffList (h :: l) f t = fwdDiffList l f (t + h) - fwdDiffList l f t := by
+  rw [fwdDiffList_cons]
+  rfl
+
+/-- **A mixed forward difference only reads the function on a set closed under its steps.** If `S`
+contains the base point and is closed under adding each step, the difference at that point depends
+on the function only through its values on `S`. Compare `TauCeti.fwdDiffList_congr`, which is the
+case of nonnegative real steps and `S = [0, ∞)`. -/
+theorem fwdDiffList_congr_of_add_mem {S : Set M} {l : List M} {f g : M → G} {t : M}
+    (hS : ∀ h ∈ l, ∀ u ∈ S, u + h ∈ S) (ht : t ∈ S) (hfg : ∀ u ∈ S, f u = g u) :
+    fwdDiffList l f t = fwdDiffList l g t := by
+  induction l generalizing t with
+  | nil => simpa using hfg t ht
+  | cons h l ih =>
+      have hrest : ∀ k ∈ l, ∀ u ∈ S, u + k ∈ S := fun k hk => hS k (List.mem_cons_of_mem h hk)
+      rw [fwdDiffList_cons_apply, fwdDiffList_cons_apply, ih hrest (hS h (by simp) t ht),
+        ih hrest ht]
 
 variable {f g : ℝ → ℝ}
 

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Basic.lean
@@ -147,13 +147,6 @@ theorem fwdDiffList_neg (l : List M) (f : M → G) :
     fwdDiffList l (fun t => -f t) = fun t => -fwdDiffList l f t := by
   simpa only [neg_one_zsmul] using fwdDiffList_const_smul (-1 : ℤ) l f
 
-/-- Consing a step, at a point: one more forward difference reads the previous one at `t` and at
-the translate `t + h`. -/
-theorem fwdDiffList_cons_apply (h : M) (l : List M) (f : M → G) (t : M) :
-    fwdDiffList (h :: l) f t = fwdDiffList l f (t + h) - fwdDiffList l f t := by
-  rw [fwdDiffList_cons]
-  rfl
-
 /-- **A mixed forward difference only reads the function on a set closed under its steps.** If `S`
 contains the base point and is closed under adding each step, the difference at that point depends
 on the function only through its values on `S`. Compare `TauCeti.fwdDiffList_congr`, which is the
@@ -165,8 +158,8 @@ theorem fwdDiffList_congr_of_add_mem {S : Set M} {l : List M} {f g : M → G} {t
   | nil => simpa using hfg t ht
   | cons h l ih =>
       have hrest : ∀ k ∈ l, ∀ u ∈ S, u + k ∈ S := fun k hk => hS k (List.mem_cons_of_mem h hk)
-      rw [fwdDiffList_cons_apply, fwdDiffList_cons_apply, ih hrest (hS h (by simp) t ht),
-        ih hrest ht]
+      simp only [fwdDiffList_cons, fwdDiff]
+      rw [ih hrest (hS h (by simp) t ht), ih hrest ht]
 
 variable {f g : ℝ → ℝ}
 

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Rational.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Rational.lean
@@ -1,0 +1,180 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Basic
+
+/-!
+# Complete monotonicity in the finite-difference sense, from rational data
+
+`TauCeti.IsDifferenceCompletelyMonotone` quantifies over *all* lists of nonnegative real steps and
+all nonnegative real base points. A construction that produces a candidate function as a countable
+limit — for instance a fibrewise Radon--Nikodym density, which is only defined up to a null set —
+can verify the sign condition on a countable set of data and no more. This file closes that gap:
+for a function that is continuous from the right on `[0, ∞)`, the sign condition on **rational
+lists at rational base points** already implies the full predicate
+(`TauCeti.isDifferenceCompletelyMonotone_of_forall_rat`).
+
+No density argument in several variables is needed. The steps are freed one at a time, each one
+costing a single one-variable limit: if every mixed difference of `f` along `l ++ m` alternates
+whenever the extra step is rational, then the signed difference along `l ++ m` is nonincreasing
+along rational increments, hence — being right-continuous — nonincreasing outright, which is the
+sign condition for one further *real* step. The permutation invariance of a mixed difference
+(`TauCeti.fwdDiffList_eq_of_perm`) is what lets the new step be peeled off the front.
+
+The right-continuity hypothesis is doing real work: rational data say nothing whatsoever about the
+value of `f` at an irrational point, so lowering `f` there below zero leaves every rational datum
+untouched while destroying the sign condition for the empty list of steps.
+
+## Main declarations
+
+* `TauCeti.tendsto_fwdDiffList_nhdsGT`: a mixed forward difference of a right-continuous function
+  is right-continuous.
+* `TauCeti.isDifferenceCompletelyMonotone_of_forall_rat`: rational data suffice.
+
+## References
+
+* D. V. Widder, *The Laplace Transform* (Princeton, 1941), Chapter IV.
+-/
+
+public section
+
+open Filter Set
+open scoped Topology
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ}
+
+/-- **A mixed forward difference of a right-continuous function is right-continuous.** The steps
+are assumed nonnegative so that the shifted base points stay in `[0, ∞)`, where the hypothesis
+lives. -/
+theorem tendsto_fwdDiffList_nhdsGT
+    (hf : ∀ u : ℝ, 0 ≤ u → Tendsto f (𝓝[>] u) (𝓝 (f u))) {l : List ℝ}
+    (hl : ∀ h ∈ l, 0 ≤ h) {u : ℝ} (hu : 0 ≤ u) :
+    Tendsto (fwdDiffList l f) (𝓝[>] u) (𝓝 (fwdDiffList l f u)) := by
+  induction l generalizing u with
+  | nil => simpa using hf u hu
+  | cons h l ih =>
+      have hh : 0 ≤ h := hl h (by simp)
+      have hrest : ∀ k ∈ l, 0 ≤ k := fun k hk => hl k (List.mem_cons_of_mem h hk)
+      have hid : Tendsto (fun v : ℝ => v) (𝓝[>] u) (𝓝 u) :=
+        tendsto_id.mono_left nhdsWithin_le_nhds
+      have hshift : Tendsto (fun v : ℝ => v + h) (𝓝[>] u) (𝓝[>] (u + h)) := by
+        refine tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _ (hid.add_const h) ?_
+        filter_upwards [self_mem_nhdsWithin] with v hv
+        exact mem_Ioi.2 (by linarith [mem_Ioi.1 hv])
+      have h₁ : Tendsto (fun v : ℝ => fwdDiffList l f (v + h)) (𝓝[>] u)
+          (𝓝 (fwdDiffList l f (u + h))) := (ih hrest (by linarith)).comp hshift
+      have hrw : fwdDiffList (h :: l) f
+          = fun v : ℝ => fwdDiffList l f (v + h) - fwdDiffList l f v :=
+        funext fun v => fwdDiffList_cons_apply h l f v
+      simp only [hrw]
+      exact h₁.sub (ih hrest hu)
+
+/-- A sequence of rationals converging to a real number from the right. -/
+private theorem exists_seq_rat_tendsto_nhdsGT (u : ℝ) :
+    ∃ r : ℕ → ℚ, (∀ n, u < (r n : ℝ)) ∧ Tendsto (fun n => (r n : ℝ)) atTop (𝓝[>] u) := by
+  have hlt : ∀ n : ℕ, ∃ q : ℚ, u < (q : ℝ) ∧ (q : ℝ) < u + 1 / ((n : ℝ) + 1) := by
+    intro n
+    have hpos : (0 : ℝ) < 1 / ((n : ℝ) + 1) := by positivity
+    exact exists_rat_btwn (by linarith)
+  choose r hr₁ hr₂ using hlt
+  refine ⟨r, hr₁, tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _ ?_
+    (Eventually.of_forall hr₁)⟩
+  have hup : Tendsto (fun n : ℕ => u + 1 / ((n : ℝ) + 1)) atTop (𝓝 (u + 0)) :=
+    tendsto_const_nhds.add tendsto_one_div_add_atTop_nhds_zero_nat
+  rw [add_zero] at hup
+  exact tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds hup
+    (fun n => (hr₁ n).le) fun n => (hr₂ n).le
+
+/-- **Rational data suffice for complete monotonicity in the finite-difference sense.** A function
+that is continuous from the right at every point of `[0, ∞)` and whose mixed forward differences
+along lists of nonnegative *rational* steps alternate at every nonnegative *rational* base point is
+completely monotone in the finite-difference sense.
+
+This is the form in which a fibrewise construction verifies the hypothesis of the
+Hausdorff--Bernstein--Widder theorem: countably many almost-everywhere statements can be
+intersected, whereas the uncountable family of conditions packaged in
+`TauCeti.IsDifferenceCompletelyMonotone` cannot. -/
+theorem isDifferenceCompletelyMonotone_of_forall_rat
+    (hcont : ∀ u : ℝ, 0 ≤ u → Tendsto f (𝓝[>] u) (𝓝 (f u)))
+    (hrat : ∀ l : List ℚ, (∀ h ∈ l, 0 ≤ h) → ∀ s : ℚ, 0 ≤ s →
+      0 ≤ (-1) ^ l.length * fwdDiffList (l.map (Rat.cast)) f (s : ℝ)) :
+    IsDifferenceCompletelyMonotone f := by
+  have hmap : ∀ l : List ℚ, (∀ h ∈ l, 0 ≤ h) → ∀ h ∈ l.map (Rat.cast : ℚ → ℝ), (0 : ℝ) ≤ h := by
+    intro l hl h hh
+    obtain ⟨q, hq, rfl⟩ := List.mem_map.1 hh
+    exact_mod_cast hl q hq
+  -- The base point is freed first: a mixed difference along a fixed list is right-continuous.
+  have step₁ : ∀ l : List ℚ, (∀ h ∈ l, 0 ≤ h) → ∀ t : ℝ, 0 ≤ t →
+      0 ≤ (-1) ^ l.length * fwdDiffList (l.map (Rat.cast)) f t := by
+    intro l hl t ht
+    obtain ⟨r, hr, hrt⟩ := exists_seq_rat_tendsto_nhdsGT t
+    refine ge_of_tendsto (((tendsto_const_nhds (x := ((-1 : ℝ) ^ l.length))).mul
+      (tendsto_fwdDiffList_nhdsGT hcont (hmap l hl) ht)).comp hrt)
+      (Eventually.of_forall fun n => ?_)
+    simpa using hrat l hl (r n) (by exact_mod_cast (ht.trans (hr n).le))
+  -- The steps are freed one at a time.
+  have step₂ : ∀ m : List ℝ, (∀ h ∈ m, 0 ≤ h) → ∀ l : List ℚ, (∀ h ∈ l, 0 ≤ h) → ∀ t : ℝ, 0 ≤ t →
+      0 ≤ (-1) ^ (l.length + m.length) * fwdDiffList (l.map (Rat.cast) ++ m) f t := by
+    intro m
+    induction m with
+    | nil => intro _ l hl t ht; simpa using step₁ l hl t ht
+    | cons h m ih =>
+        intro hm l hl t ht
+        have hh : 0 ≤ h := hm h (by simp)
+        have hmrest : ∀ k ∈ m, 0 ≤ k := fun k hk => hm k (List.mem_cons_of_mem h hk)
+        set Φ : ℝ → ℝ := fwdDiffList (l.map (Rat.cast) ++ m) f with hΦ
+        have hLnonneg : ∀ k ∈ l.map (Rat.cast : ℚ → ℝ) ++ m, (0 : ℝ) ≤ k := by
+          intro k hk
+          rcases List.mem_append.1 hk with hk | hk
+          · exact hmap l hl k hk
+          · exact hmrest k hk
+        have hpow : ∀ k : ℕ, ((-1 : ℝ)) ^ (k + 1) = -((-1 : ℝ) ^ k) := by
+          intro k; rw [pow_succ]; ring
+        -- Rational increments do not increase the signed difference, by the inductive hypothesis
+        -- applied to the list with one further rational step.
+        have hanti : ∀ u : ℝ, 0 ≤ u → ∀ q : ℚ, 0 ≤ q →
+            (-1 : ℝ) ^ (l.length + m.length) * Φ (u + (q : ℝ))
+              ≤ (-1 : ℝ) ^ (l.length + m.length) * Φ u := by
+          intro u hu q hq
+          have hcons : ∀ k ∈ q :: l, (0 : ℚ) ≤ k := by
+            intro k hk
+            rcases List.mem_cons.1 hk with rfl | hk
+            · exact hq
+            · exact hl k hk
+          have hstep := ih hmrest (q :: l) hcons u hu
+          rw [List.map_cons, List.cons_append, List.length_cons, fwdDiffList_cons_apply, ← hΦ,
+            show l.length + 1 + m.length = l.length + m.length + 1 by ring, hpow] at hstep
+          nlinarith [hstep]
+        -- Right-continuity turns rational increments into arbitrary ones.
+        have hreal : (-1 : ℝ) ^ (l.length + m.length) * Φ (t + h)
+            ≤ (-1 : ℝ) ^ (l.length + m.length) * Φ t := by
+          obtain ⟨r, hr, hrt⟩ := exists_seq_rat_tendsto_nhdsGT h
+          have hid : Tendsto (fun n => (r n : ℝ)) atTop (𝓝 h) := hrt.mono_right nhdsWithin_le_nhds
+          have hshift : Tendsto (fun n => t + (r n : ℝ)) atTop (𝓝[>] (t + h)) := by
+            refine tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
+              (tendsto_const_nhds.add hid) (Eventually.of_forall fun n => ?_)
+            exact mem_Ioi.2 (by linarith [hr n])
+          have hΦcont : Tendsto (fun v => (-1 : ℝ) ^ (l.length + m.length) * Φ v)
+              (𝓝[>] (t + h)) (𝓝 ((-1 : ℝ) ^ (l.length + m.length) * Φ (t + h))) :=
+            tendsto_const_nhds.mul
+              (hΦ ▸ tendsto_fwdDiffList_nhdsGT hcont hLnonneg (by linarith : (0 : ℝ) ≤ t + h))
+          refine le_of_tendsto (hΦcont.comp hshift) (Eventually.of_forall fun n => ?_)
+          exact hanti t ht (r n) (by exact_mod_cast (hh.trans (hr n).le))
+        -- Peel the new step off the front and read the sign condition off `hreal`.
+        have hpermeq : fwdDiffList (l.map (Rat.cast) ++ h :: m) f = fwdDiffList (h :: (l.map
+            (Rat.cast) ++ m)) f := fwdDiffList_eq_of_perm List.perm_middle f
+        rw [List.length_cons, hpermeq, fwdDiffList_cons_apply, ← hΦ,
+          show l.length + (m.length + 1) = l.length + m.length + 1 by ring, hpow]
+        nlinarith [hreal]
+  refine isDifferenceCompletelyMonotone_iff.2 fun m hm t ht => ?_
+  simpa using step₂ m hm [] (by simp) t ht
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Rational.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Rational.lean
@@ -70,8 +70,9 @@ theorem tendsto_fwdDiffList_nhdsGT
       have h₁ : Tendsto (fun v : ℝ => fwdDiffList l f (v + h)) (𝓝[>] u)
           (𝓝 (fwdDiffList l f (u + h))) := (ih hrest (by linarith)).comp hshift
       have hrw : fwdDiffList (h :: l) f
-          = fun v : ℝ => fwdDiffList l f (v + h) - fwdDiffList l f v :=
-        funext fun v => fwdDiffList_cons_apply h l f v
+          = fun v : ℝ => fwdDiffList l f (v + h) - fwdDiffList l f v := by
+        funext v
+        simp only [fwdDiffList_cons, fwdDiff]
       simp only [hrw]
       exact h₁.sub (ih hrest hu)
 
@@ -136,6 +137,10 @@ theorem isDifferenceCompletelyMonotone_of_forall_rat
           · exact hmrest k hk
         have hpow : ∀ k : ℕ, ((-1 : ℝ)) ^ (k + 1) = -((-1 : ℝ) ^ k) := by
           intro k; rw [pow_succ]; ring
+        -- The two length normalizations needed to match the exponent produced by the inductive
+        -- hypothesis against the one in the goal.
+        have hlenl : l.length + 1 + m.length = l.length + m.length + 1 := by omega
+        have hlenm : l.length + (m.length + 1) = l.length + m.length + 1 := by omega
         -- Rational increments do not increase the signed difference, by the inductive hypothesis
         -- applied to the list with one further rational step.
         have hanti : ∀ u : ℝ, 0 ≤ u → ∀ q : ℚ, 0 ≤ q →
@@ -148,8 +153,9 @@ theorem isDifferenceCompletelyMonotone_of_forall_rat
             · exact hq
             · exact hl k hk
           have hstep := ih hmrest (q :: l) hcons u hu
-          rw [List.map_cons, List.cons_append, List.length_cons, fwdDiffList_cons_apply, ← hΦ,
-            show l.length + 1 + m.length = l.length + m.length + 1 by ring, hpow] at hstep
+          rw [List.map_cons, List.cons_append, List.length_cons] at hstep
+          simp only [fwdDiffList_cons, fwdDiff] at hstep
+          rw [← hΦ, hlenl, hpow] at hstep
           nlinarith [hstep]
         -- Right-continuity turns rational increments into arbitrary ones.
         have hreal : (-1 : ℝ) ^ (l.length + m.length) * Φ (t + h)
@@ -169,8 +175,9 @@ theorem isDifferenceCompletelyMonotone_of_forall_rat
         -- Peel the new step off the front and read the sign condition off `hreal`.
         have hpermeq : fwdDiffList (l.map (Rat.cast) ++ h :: m) f = fwdDiffList (h :: (l.map
             (Rat.cast) ++ m)) f := fwdDiffList_eq_of_perm List.perm_middle f
-        rw [List.length_cons, hpermeq, fwdDiffList_cons_apply, ← hΦ,
-          show l.length + (m.length + 1) = l.length + m.length + 1 by ring, hpow]
+        rw [List.length_cons, hpermeq]
+        simp only [fwdDiffList_cons, fwdDiff]
+        rw [← hΦ, hlenm, hpow]
         nlinarith [hreal]
   refine isDifferenceCompletelyMonotone_iff.2 fun m hm t ht => ?_
   simpa using step₂ m hm [] (by simp) t ht

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Existence.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Existence.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Kernel
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Kernel
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.PositiveDefinite
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Uniqueness
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.Time.Slice.Density
+
+/-!
+# The Berg--Christensen--Ressel representation theorem
+
+A bounded continuous positive-definite function on the involutive semigroup `ℝ≥0 × V`, with `V` a
+finite-dimensional real inner-product space, is the Laplace--Fourier transform of a unique finite
+measure on `ℝ≥0 × V`. This file proves the existence half and packages it with the uniqueness half
+of `TauCeti.Analysis.PositiveDefinite.SemigroupGroup.FourierLaplace.Uniqueness` into the
+equivalence `TauCeti.bcr_semigroup_bochner`.
+
+Every ingredient is already in place, and the proof here is the assembly.
+
+* Freezing the time variable and applying Bochner's theorem on `V` turns `F` into a family of
+  finite spatial measures, and the representation holds exactly when that family is the family of
+  Laplace-weighted spatial slices of a single measure
+  (`TauCeti.representsLaplaceFourier_iff_forall_spatialSlice_eq`). Disintegrating over the spatial
+  marginal reduces this to producing a *kernel* from `V` to `ℝ≥0` whose fibrewise Laplace
+  transforms are the densities of the spatial measures against the one at time `0`
+  (`TauCeti.exists_representsLaplaceFourier_iff_exists_timeKernel`).
+* Almost every fibre of `TauCeti.timeSliceDensity`, the right-continuous version of that family of
+  densities, is a completely monotone function of time
+  (`TauCeti.ae_isContinuousCompletelyMonotoneOnIoi_timeSliceDensity`), normalized at time `0`.
+* The Hausdorff--Bernstein--Widder theorem therefore represents each such fibre by a finite measure
+  on `ℝ≥0`, and those measures depend measurably on the fibre, so they assemble into
+  `TauCeti.bernsteinMeasureKernel`.
+
+The only step needing care is that "almost every fibre" is not "every fibre", while a kernel must
+be defined at every point: the density is corrected to `0` on a measurable null set containing the
+exceptional fibres, which changes neither the Bernstein measures elsewhere nor the resulting
+representation.
+
+## Main declarations
+
+* `TauCeti.exists_representsLaplaceFourier`: **the existence half** of the
+  Berg--Christensen--Ressel representation.
+* `TauCeti.bcr_semigroup_bochner`: the representation theorem as an equivalence, with uniqueness.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Theorem 4.1.13.
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
+  ("BCR semigroup--Bochner").
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory Set
+open scoped ENNReal NNReal
+
+namespace TauCeti
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+  [MeasurableSpace V] [BorelSpace V] {F : ℝ≥0 × V → ℂ}
+
+/-- **The existence half of the Berg--Christensen--Ressel representation theorem.** A bounded
+continuous positive-definite function on the involutive semigroup `ℝ≥0 × V` is the Laplace--Fourier
+transform of a finite measure on `ℝ≥0 × V`.
+
+The representing measure is assembled from the spatial Bochner measure at time `0` and the
+Bernstein measures of the fibres of `TauCeti.timeSliceDensity`. -/
+theorem exists_representsLaplaceFourier (hFpd : IsSemigroupGroupPD F) (hFcont : Continuous F)
+    (hFbdd : Bornology.IsBounded (range F)) :
+    ∃ μ : Measure (ℝ≥0 × V), RepresentsLaplaceFourier μ F := by
+  classical
+  -- The fibres that are completely monotone in time and normalized at time `0` are almost all of
+  -- them; the others are absorbed into a measurable null set.
+  have hae : ∀ᵐ q ∂(bochnerMeasure fun a => F (0, a)),
+      IsContinuousCompletelyMonotoneOnIoi
+          (fun s : ℝ => (timeSliceDensity F s.toNNReal q).toReal)
+        ∧ timeSliceDensity F 0 q = 1 :=
+    (ae_isContinuousCompletelyMonotoneOnIoi_timeSliceDensity hFpd hFcont hFbdd).and
+      (ae_timeSliceDensity_zero_eq_one hFpd hFcont hFbdd)
+  set B : Set V := {q | ¬(IsContinuousCompletelyMonotoneOnIoi
+    (fun s : ℝ => (timeSliceDensity F s.toNNReal q).toReal) ∧ timeSliceDensity F 0 q = 1)}
+  set N : Set V := toMeasurable (bochnerMeasure fun a => F (0, a)) B with hN
+  have hNmeas : MeasurableSet N := measurableSet_toMeasurable _ _
+  have hN0 : (bochnerMeasure fun a => F (0, a)) N = 0 := by
+    rw [hN, measure_toMeasurable]
+    exact ae_iff.1 hae
+  have hgood : ∀ q ∈ Nᶜ, IsContinuousCompletelyMonotoneOnIoi
+      (fun s : ℝ => (timeSliceDensity F s.toNNReal q).toReal) ∧ timeSliceDensity F 0 q = 1 :=
+    fun q hq => not_not.1 fun hcon => hq (subset_toMeasurable _ B hcon)
+  -- The corrected family of time profiles, one for each spatial frequency.
+  set g : V → ℝ → ℝ := fun q s =>
+    Nᶜ.indicator (fun q' => (timeSliceDensity F s.toNNReal q').toReal) q
+  have hg_mem : ∀ q ∈ Nᶜ, ∀ s : ℝ, g q s = (timeSliceDensity F s.toNNReal q).toReal :=
+    fun q hq s => Set.indicator_of_mem hq _
+  have hg_notMem : ∀ q ∉ Nᶜ, ∀ s : ℝ, g q s = 0 := fun q hq s => Set.indicator_of_notMem hq _
+  have hcm : ∀ q, IsContinuousCompletelyMonotoneOnIoi (g q) := by
+    intro q
+    by_cases hq : q ∈ Nᶜ
+    · have hfun : g q = fun s : ℝ => (timeSliceDensity F s.toNNReal q).toReal :=
+        funext (hg_mem q hq)
+      rw [hfun]
+      exact (hgood q hq).1
+    · have hfun : g q = 0 := funext (hg_notMem q hq)
+      rw [hfun]
+      exact representsLaplace_zero.isContinuousCompletelyMonotoneOnIoi
+  have hmeas : ∀ n : ℕ, Measurable fun q => g q (n : ℝ) := fun n =>
+    Measurable.indicator (by fun_prop) hNmeas.compl
+  have hmass : ∀ q, g q 0 ≤ 1 := by
+    intro q
+    by_cases hq : q ∈ Nᶜ
+    · rw [hg_mem q hq, Real.toNNReal_zero, (hgood q hq).2]
+      simp
+    · rw [hg_notMem q hq]
+      exact zero_le_one
+  have _ : IsFiniteKernel (bernsteinMeasureKernel g hcm hmeas) :=
+    isFiniteKernel_bernsteinMeasureKernel hcm hmeas hmass
+  refine ⟨_, representsLaplaceFourier_swapCompProd_of_ae_rnDeriv hFpd hFcont hFbdd
+    (bernsteinMeasureKernel g hcm hmeas) fun t => ?_⟩
+  have hcompl : ∀ᵐ q ∂(bochnerMeasure fun a => F (0, a)), q ∈ Nᶜ := by
+    rw [ae_iff]
+    simpa using hN0
+  filter_upwards [timeSliceDensity_ae_eq_rnDeriv hFpd hFcont hFbdd t, hcompl] with q hq hqN
+  have hle : timeSliceDensity F t q ≤ 1 := by
+    rw [← (hgood q hqN).2]
+    exact timeSliceDensity_antitone F q (zero_le : (0 : ℝ≥0) ≤ t)
+  rw [← hq, Kernel.laplaceTransform_apply,
+    (representsLaplace_bernsteinMeasureKernel hcm hmeas q).laplaceTransformENN_eq t,
+    hg_mem q hqN, Real.toNNReal_coe,
+    ENNReal.ofReal_toReal (hle.trans_lt ENNReal.one_lt_top).ne]
+
+/-- **The Berg--Christensen--Ressel representation theorem** (Berg--Christensen--Ressel 4.1.13).
+A function on the involutive semigroup `ℝ≥0 × V`, for `V` a finite-dimensional real inner-product
+space, is positive definite, continuous and bounded **if and only if** it is the Laplace--Fourier
+transform of a unique finite measure on `ℝ≥0 × V`:
+
+`F (t, a) = ∫ (p, q), exp (-t p) * exp (-2πi⟪a, q⟫) dμ (p, q)`.
+
+The forward direction is `TauCeti.exists_representsLaplaceFourier` together with the transform
+injectivity of `TauCeti.RepresentsLaplaceFourier.unique`; the converse direction is the elementary
+fact that such a transform is positive definite, continuous, and bounded by the total mass. -/
+theorem bcr_semigroup_bochner (F : ℝ≥0 × V → ℂ) :
+    (IsSemigroupGroupPD F ∧ Continuous F ∧ Bornology.IsBounded (range F))
+      ↔ ∃! μ : Measure (ℝ≥0 × V), RepresentsLaplaceFourier μ F := by
+  constructor
+  · rintro ⟨hFpd, hFcont, hFbdd⟩
+    obtain ⟨μ, hμ⟩ := exists_representsLaplaceFourier hFpd hFcont hFbdd
+    exact ⟨μ, hμ, fun ν hν => hν.unique hμ⟩
+  · rintro ⟨μ, hμ, -⟩
+    have := hμ.isFiniteMeasure
+    exact ⟨hμ.isSemigroupGroupPD, hμ.continuous, isBounded_iff_forall_norm_le.2
+      ⟨μ.real univ, by rintro _ ⟨x, rfl⟩; exact hμ.norm_le_mass x⟩⟩
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Slice/Density.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Slice/Density.lean
@@ -1,0 +1,365 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.NNRat.Encodable
+public import TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Laplace
+public import TauCeti.Analysis.CompletelyMonotone.FiniteDifference.Rational
+public import TauCeti.Analysis.PositiveDefinite.SemigroupGroup.Time.Slice.Measure
+
+/-!
+# The fibrewise spatial densities of a Berg--Christensen--Ressel positive-definite function
+
+Let `F` be a bounded continuous positive-definite function on the involutive semigroup `ℝ≥0 × V`,
+with `V` a finite-dimensional real inner-product space. Its spatial Bochner measures
+`bochnerMeasure (F (t, ·))` decrease in time, so each of them has a Radon--Nikodym derivative
+against the one at time `0`
+(`TauCeti.withDensity_rnDeriv_bochnerMeasure_timeSlice`). The existence half of the
+Berg--Christensen--Ressel representation is exactly the problem of realizing that family of
+densities as a family of *fibrewise Laplace transforms*
+(`TauCeti.exists_representsLaplaceFourier_iff_exists_timeKernel`), which is a Bernstein problem in
+the time variable at almost every spatial frequency.
+
+This file supplies the input of that Bernstein problem. Two obstacles have to be cleared.
+
+* A Radon--Nikodym derivative is defined only up to a null set, so the alternating time
+  differences of the densities can only be controlled at *countably many* times at once, whereas
+  complete monotonicity quantifies over all real times. The countable version is
+  `TauCeti.toReal_rnDeriv_bochnerMeasure_timeSlice_listTimeDifference`: the density of the Bochner
+  measure of a list time difference of `F` is, almost everywhere, the corresponding mixed forward
+  difference of the densities, and it is nonnegative because it is a density.
+* The version of the density that is used must be right-continuous in time, since
+  `TauCeti.isDifferenceCompletelyMonotone_of_forall_rat` upgrades rational data to real data only
+  for a right-continuous function. `TauCeti.timeSliceDensity` is that version: the supremum of the
+  Radon--Nikodym derivatives over rational times `r > t`. Being a supremum over a shrinking family
+  of rational times it is antitone and right-continuous *for every* spatial frequency, with no null
+  set attached, and it agrees almost everywhere with the Radon--Nikodym derivative at each fixed
+  time (`TauCeti.timeSliceDensity_ae_eq_rnDeriv`) because the total masses are continuous in time.
+
+The conclusion is `TauCeti.ae_isContinuousCompletelyMonotoneOnIoi_timeSliceDensity`: almost every
+fibre of `TauCeti.timeSliceDensity` is a completely monotone function of time, hence a Laplace
+transform.
+
+## Main declarations
+
+* `TauCeti.bochnerMeasure_timeSlice_listTimeDifference_le`: the Bochner measure of a list time
+  difference is dominated by the Bochner measure of the time slice it differences.
+* `TauCeti.toReal_rnDeriv_bochnerMeasure_timeSlice_listTimeDifference`: mixed forward differences
+  of the densities are themselves densities, almost everywhere.
+* `TauCeti.timeSliceDensity`: the right-continuous version of the family of densities.
+* `TauCeti.timeSliceDensity_ae_eq_rnDeriv`: it is a Radon--Nikodym derivative at every fixed time.
+* `TauCeti.ae_isDifferenceCompletelyMonotone_timeSliceDensity` and
+  `TauCeti.ae_isContinuousCompletelyMonotoneOnIoi_timeSliceDensity`: almost every fibre is
+  completely monotone in time.
+* `TauCeti.ae_timeSliceDensity_zero_eq_one`: almost every fibre is normalized at time `0`.
+
+## References
+
+* C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984),
+  Theorem 4.1.13.
+
+* Roadmap: `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part C, Milestone 2
+  ("BCR semigroup--Bochner"), the existence half.
+-/
+
+public section
+
+noncomputable section
+
+open Filter MeasureTheory Set
+open scoped ENNReal NNReal Topology
+
+namespace TauCeti
+
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+  [MeasurableSpace V] [BorelSpace V] {F : ℝ≥0 × V → ℂ}
+
+/-! ## Time differences of the spatial Bochner measures -/
+
+/-- **A list time difference has a smaller Bochner measure than the slice it differences.** Each
+further first difference splits the Bochner measure of the previous one into two summands
+(`TauCeti.bochnerMeasure_timeSlice_eq_add`), and a summand of measures is dominated by their
+sum. -/
+theorem bochnerMeasure_timeSlice_listTimeDifference_le (hFpd : IsSemigroupGroupPD F)
+    (hFcont : Continuous F) (hFbdd : Bornology.IsBounded (range F)) (l : List ℝ≥0) (t : ℝ≥0) :
+    (bochnerMeasure fun a => listTimeDifference l F (t, a))
+      ≤ bochnerMeasure fun a => F (t, a) := by
+  induction l with
+  | nil => simp
+  | cons h l ih =>
+      have hsplit := bochnerMeasure_timeSlice_eq_add (hFpd.listTimeDifference hFbdd l)
+        (continuous_listTimeDifference hFcont l) (isBounded_range_listTimeDifference hFbdd l) t h
+      rw [listTimeDifference_cons]
+      exact ((Measure.le_add_right le_rfl).trans hsplit.ge).trans ih
+
+/-- **The densities decrease in time**, almost everywhere against the time-`0` Bochner measure:
+the earlier spatial measure is the later one plus the Bochner measure of the time difference
+between them. -/
+theorem rnDeriv_bochnerMeasure_timeSlice_antitone (hFpd : IsSemigroupGroupPD F)
+    (hFcont : Continuous F) (hFbdd : Bornology.IsBounded (range F)) {t s : ℝ≥0} (hts : t ≤ s) :
+    (bochnerMeasure fun a => F (s, a)).rnDeriv (bochnerMeasure fun a => F (0, a))
+      ≤ᵐ[bochnerMeasure fun a => F (0, a)]
+        (bochnerMeasure fun a => F (t, a)).rnDeriv (bochnerMeasure fun a => F (0, a)) := by
+  have hsplit := bochnerMeasure_timeSlice_eq_add hFpd hFcont hFbdd t (s - t)
+  rw [add_tsub_cancel_of_le hts] at hsplit
+  filter_upwards [Measure.rnDeriv_add (bochnerMeasure fun a => timeDifference (s - t) F (t, a))
+    (bochnerMeasure fun a => F (s, a)) (bochnerMeasure fun a => F (0, a))] with q hq
+  rw [hsplit, hq, Pi.add_apply]
+  exact le_add_self
+
+/-- **Mixed forward differences of the densities are densities.** The Radon--Nikodym derivative of
+the Bochner measure of a list time difference of `F` is, almost everywhere, the corresponding
+mixed forward difference of the Radon--Nikodym derivatives of the time slices. Since the left-hand
+side is a density it is nonnegative, which is the sign condition of the
+Hausdorff--Bernstein--Widder theorem at the times involved. -/
+theorem toReal_rnDeriv_bochnerMeasure_timeSlice_listTimeDifference (hFpd : IsSemigroupGroupPD F)
+    (hFcont : Continuous F) (hFbdd : Bornology.IsBounded (range F)) (l : List ℝ≥0) (t : ℝ≥0) :
+    ∀ᵐ q ∂(bochnerMeasure fun a => F (0, a)),
+      ((bochnerMeasure fun a => listTimeDifference l F (t, a)).rnDeriv
+          (bochnerMeasure fun a => F (0, a)) q).toReal
+        = (-1) ^ l.length * fwdDiffList (l.map (fun h : ℝ≥0 => (h : ℝ)))
+            (fun s : ℝ => ((bochnerMeasure fun a => F (s.toNNReal, a)).rnDeriv
+              (bochnerMeasure fun a => F (0, a)) q).toReal) (t : ℝ) := by
+  induction l generalizing t with
+  | nil =>
+      filter_upwards with q
+      simp
+  | cons h l ih =>
+      have hsplit := bochnerMeasure_timeSlice_eq_add (hFpd.listTimeDifference hFbdd l)
+        (continuous_listTimeDifference hFcont l) (isBounded_range_listTimeDifference hFbdd l) t h
+      filter_upwards [ih t, ih (t + h),
+        Measure.rnDeriv_add
+          (bochnerMeasure fun a => timeDifference h (listTimeDifference l F) (t, a))
+          (bochnerMeasure fun a => listTimeDifference l F (t + h, a))
+          (bochnerMeasure fun a => F (0, a)),
+        Measure.rnDeriv_lt_top
+          (bochnerMeasure fun a => timeDifference h (listTimeDifference l F) (t, a))
+          (bochnerMeasure fun a => F (0, a)),
+        Measure.rnDeriv_lt_top (bochnerMeasure fun a => listTimeDifference l F (t + h, a))
+          (bochnerMeasure fun a => F (0, a))] with q ht hth hadd hfin₁ hfin₂
+      have hsum : ((bochnerMeasure fun a => listTimeDifference l F (t, a)).rnDeriv
+            (bochnerMeasure fun a => F (0, a)) q).toReal
+          = ((bochnerMeasure fun a => timeDifference h (listTimeDifference l F) (t, a)).rnDeriv
+              (bochnerMeasure fun a => F (0, a)) q).toReal
+            + ((bochnerMeasure fun a => listTimeDifference l F (t + h, a)).rnDeriv
+              (bochnerMeasure fun a => F (0, a)) q).toReal := by
+        rw [hsplit, hadd, Pi.add_apply, ENNReal.toReal_add hfin₁.ne hfin₂.ne]
+      rw [listTimeDifference_cons, List.map_cons, List.length_cons, fwdDiffList_cons_apply]
+      have hcoe : ((t + h : ℝ≥0) : ℝ) = (t : ℝ) + (h : ℝ) := NNReal.coe_add t h
+      rw [hcoe] at hth
+      rw [pow_succ]
+      nlinarith [hsum, ht, hth]
+
+/-! ## The right-continuous version of the densities -/
+
+/-- **The right-continuous spatial density** of a function on `ℝ≥0 × V` at time `t`: the supremum,
+over rational times `r > t`, of the Radon--Nikodym derivative of the spatial Bochner measure at
+time `r` against the one at time `0`.
+
+Taking the supremum over rational times to the right of `t` costs nothing at a fixed time — the
+family of Radon--Nikodym derivatives decreases in time and the total masses are continuous, so
+`TauCeti.timeSliceDensity_ae_eq_rnDeriv` identifies this with the Radon--Nikodym derivative itself
+— while it buys antitonicity and right-continuity in time at *every* point of `V`, with no null
+set attached. That is what makes a fibrewise Bernstein argument possible. -/
+def timeSliceDensity (F : ℝ≥0 × V → ℂ) (t : ℝ≥0) (q : V) : ℝ≥0∞ :=
+  ⨆ r : {r : ℚ≥0 // t < (r : ℝ≥0)},
+    (bochnerMeasure fun a => F ((r.1 : ℝ≥0), a)).rnDeriv (bochnerMeasure fun a => F (0, a)) q
+
+/-- Each Radon--Nikodym derivative at a rational time to the right of `t` is dominated by the
+right-continuous density at `t`. -/
+theorem rnDeriv_le_timeSliceDensity (F : ℝ≥0 × V → ℂ) {t : ℝ≥0} {r : ℚ≥0}
+    (hr : t < (r : ℝ≥0)) (q : V) :
+    (bochnerMeasure fun a => F ((r : ℝ≥0), a)).rnDeriv (bochnerMeasure fun a => F (0, a)) q
+      ≤ timeSliceDensity F t q :=
+  le_iSup (fun r : {r : ℚ≥0 // t < (r : ℝ≥0)} =>
+    (bochnerMeasure fun a => F ((r.1 : ℝ≥0), a)).rnDeriv
+      (bochnerMeasure fun a => F (0, a)) q) ⟨r, hr⟩
+
+/-- The right-continuous density decreases in time, at every point. -/
+theorem timeSliceDensity_antitone (F : ℝ≥0 × V → ℂ) (q : V) :
+    Antitone fun t => timeSliceDensity F t q := fun _ _ htt' =>
+  iSup_le fun r => le_iSup_of_le ⟨r.1, htt'.trans_lt r.2⟩ le_rfl
+
+@[fun_prop]
+theorem measurable_timeSliceDensity (F : ℝ≥0 × V → ℂ) (t : ℝ≥0) :
+    Measurable (timeSliceDensity F t) :=
+  Measurable.iSup fun _ => Measure.measurable_rnDeriv _ _
+
+/-- A sequence of rational times decreasing to a given time. -/
+private theorem exists_seq_nnrat_tendsto (t : ℝ≥0) :
+    ∃ r : ℕ → ℚ≥0, (∀ n, t < (r n : ℝ≥0)) ∧
+      Tendsto (fun n => (((r n : ℝ≥0)) : ℝ)) atTop (𝓝 (t : ℝ)) := by
+  have hlt : ∀ n : ℕ, ∃ r : ℚ≥0, t < (r : ℝ≥0) ∧
+      ((r : ℝ≥0) : ℝ) < (t : ℝ) + 1 / ((n : ℝ) + 1) := by
+    intro n
+    have hpos : (0 : ℝ) < 1 / ((n : ℝ) + 1) := by positivity
+    obtain ⟨q, hq₁, hq₂⟩ := exists_rat_btwn (show (t : ℝ) < (t : ℝ) + 1 / ((n : ℝ) + 1) by linarith)
+    have hq₀ : (0 : ℚ) ≤ q := by exact_mod_cast t.coe_nonneg.trans hq₁.le
+    have hcast : ((q.toNNRat : ℝ≥0) : ℝ) = (q : ℝ) := by
+      rw [show ((q.toNNRat : ℝ≥0) : ℝ) = ((q.toNNRat : ℚ) : ℝ) from by norm_cast,
+        Rat.coe_toNNRat _ hq₀]
+    exact ⟨q.toNNRat, by rw [← NNReal.coe_lt_coe, hcast]; exact hq₁, by rw [hcast]; exact hq₂⟩
+  choose r hr₁ hr₂ using hlt
+  refine ⟨r, hr₁, ?_⟩
+  have hup : Tendsto (fun n : ℕ => (t : ℝ) + 1 / ((n : ℝ) + 1)) atTop (𝓝 ((t : ℝ) + 0)) :=
+    tendsto_const_nhds.add tendsto_one_div_add_atTop_nhds_zero_nat
+  rw [add_zero] at hup
+  exact tendsto_of_tendsto_of_tendsto_of_le_of_le tendsto_const_nhds hup
+    (fun n => (NNReal.coe_lt_coe.2 (hr₁ n)).le) fun n => (hr₂ n).le
+
+/-- The right-continuous density is dominated by the Radon--Nikodym derivative at the same time. -/
+theorem timeSliceDensity_le_rnDeriv (hFpd : IsSemigroupGroupPD F) (hFcont : Continuous F)
+    (hFbdd : Bornology.IsBounded (range F)) (t : ℝ≥0) :
+    timeSliceDensity F t
+      ≤ᵐ[bochnerMeasure fun a => F (0, a)]
+        (bochnerMeasure fun a => F (t, a)).rnDeriv (bochnerMeasure fun a => F (0, a)) := by
+  filter_upwards [ae_all_iff.2 fun r : {r : ℚ≥0 // t < (r : ℝ≥0)} =>
+    rnDeriv_bochnerMeasure_timeSlice_antitone hFpd hFcont hFbdd r.2.le] with q hq
+  exact iSup_le hq
+
+/-- **The right-continuous density is a Radon--Nikodym derivative at every fixed time.** The
+supremum over rational times to the right loses no mass, because the total mass
+`t ↦ (F (t, 0)).re` is continuous. -/
+theorem timeSliceDensity_ae_eq_rnDeriv (hFpd : IsSemigroupGroupPD F) (hFcont : Continuous F)
+    (hFbdd : Bornology.IsBounded (range F)) (t : ℝ≥0) :
+    timeSliceDensity F t
+      =ᵐ[bochnerMeasure fun a => F (0, a)]
+        (bochnerMeasure fun a => F (t, a)).rnDeriv (bochnerMeasure fun a => F (0, a)) := by
+  have hac := bochnerMeasure_timeSlice_absolutelyContinuous hFpd hFcont hFbdd
+  have hle := timeSliceDensity_le_rnDeriv hFpd hFcont hFbdd t
+  have hmass : ∀ s : ℝ≥0, (bochnerMeasure fun a => F (s, a)) univ
+      = ENNReal.ofReal ((F (s, 0)).re) := fun s =>
+    bochnerMeasure_univ (hFcont.comp (.prodMk_right s)) (hFpd.isPositiveDefiniteSub_timeSlice s)
+  have hint : ∫⁻ q, (bochnerMeasure fun a => F (t, a)).rnDeriv
+        (bochnerMeasure fun a => F (0, a)) q ∂(bochnerMeasure fun a => F (0, a))
+      ≤ ∫⁻ q, timeSliceDensity F t q ∂(bochnerMeasure fun a => F (0, a)) := by
+    rw [Measure.lintegral_rnDeriv (hac t), hmass t]
+    obtain ⟨r, hr, hrt⟩ := exists_seq_nnrat_tendsto t
+    have hstep : ∀ n, ENNReal.ofReal ((F (((r n : ℝ≥0)), 0)).re)
+        ≤ ∫⁻ q, timeSliceDensity F t q ∂(bochnerMeasure fun a => F (0, a)) := by
+      intro n
+      rw [← hmass, ← Measure.lintegral_rnDeriv (hac _)]
+      exact lintegral_mono fun q => rnDeriv_le_timeSliceDensity F (hr n) q
+    have hFt : Tendsto (fun n => F (((r n : ℝ≥0)), 0)) atTop (𝓝 (F (t, 0))) :=
+      (hFcont.tendsto (t, 0)).comp ((NNReal.tendsto_coe.1 hrt).prodMk_nhds tendsto_const_nhds)
+    exact le_of_tendsto
+      ((ENNReal.continuous_ofReal.tendsto _).comp ((Complex.continuous_re.tendsto _).comp hFt))
+      (Eventually.of_forall hstep)
+  refine ae_eq_of_ae_le_of_lintegral_le hle ?_
+    (Measure.measurable_rnDeriv _ _).aemeasurable hint
+  refine ne_top_of_le_ne_top ?_ (lintegral_mono_ae hle)
+  rw [Measure.lintegral_rnDeriv (hac t)]
+  exact measure_ne_top _ _
+
+/-- Almost every fibre of the right-continuous density is normalized at time `0`. -/
+theorem ae_timeSliceDensity_zero_eq_one (hFpd : IsSemigroupGroupPD F) (hFcont : Continuous F)
+    (hFbdd : Bornology.IsBounded (range F)) :
+    ∀ᵐ q ∂(bochnerMeasure fun a => F (0, a)), timeSliceDensity F 0 q = 1 := by
+  filter_upwards [timeSliceDensity_ae_eq_rnDeriv hFpd hFcont hFbdd 0,
+    Measure.rnDeriv_self (bochnerMeasure fun a => F (0, a))] with q h₁ h₂
+  rw [h₁, h₂]
+
+/-- **The right-continuous density is right-continuous in time.** No null set is involved: the
+supremum defining it runs over the rational times to the right of `t`, so it is both antitone and
+its own right limit. -/
+theorem tendsto_timeSliceDensity_nhdsGT (F : ℝ≥0 × V → ℂ) (t : ℝ≥0) (q : V) :
+    Tendsto (fun s => timeSliceDensity F s q) (𝓝[>] t) (𝓝 (timeSliceDensity F t q)) := by
+  refine tendsto_order.2 ⟨fun a ha => ?_, fun b hb => ?_⟩
+  · obtain ⟨r, hr⟩ := lt_iSup_iff.1 ha
+    filter_upwards [Ioo_mem_nhdsGT r.2] with s hs
+    exact hr.trans_le (rnDeriv_le_timeSliceDensity F hs.2 q)
+  · filter_upwards [self_mem_nhdsWithin] with s hs
+    exact (timeSliceDensity_antitone F q (mem_Ioi.1 hs).le).trans_lt hb
+
+/-- The real-valued time profile of a fibre, reparametrized by a real time, is right-continuous
+on `[0, ∞)`. -/
+theorem tendsto_toReal_timeSliceDensity_nhdsGT (F : ℝ≥0 × V → ℂ) {q : V}
+    (hq : timeSliceDensity F 0 q ≠ ⊤) {u : ℝ} (hu : 0 ≤ u) :
+    Tendsto (fun s : ℝ => (timeSliceDensity F s.toNNReal q).toReal) (𝓝[>] u)
+      (𝓝 ((timeSliceDensity F u.toNNReal q).toReal)) := by
+  have hne : timeSliceDensity F u.toNNReal q ≠ ⊤ :=
+    ne_top_of_le_ne_top hq (timeSliceDensity_antitone F q (zero_le : (0 : ℝ≥0) ≤ u.toNNReal))
+  have htoNN : Tendsto (fun s : ℝ => s.toNNReal) (𝓝[>] u) (𝓝[>] u.toNNReal) := by
+    refine tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
+      ((continuous_real_toNNReal.tendsto u).mono_left nhdsWithin_le_nhds) ?_
+    filter_upwards [self_mem_nhdsWithin] with s hs
+    exact mem_Ioi.2 ((Real.toNNReal_lt_toNNReal_iff_of_nonneg hu).2 (mem_Ioi.1 hs))
+  exact (ENNReal.tendsto_toReal hne).comp ((tendsto_timeSliceDensity_nhdsGT F _ q).comp htoNN)
+
+/-! ## Complete monotonicity of the fibres -/
+
+/-- **Almost every fibre of the right-continuous density is completely monotone in the
+finite-difference sense.** The mixed forward differences at rational data are densities of the
+Bochner measures of the corresponding list time differences of `F`, hence nonnegative; rational
+data suffice because the fibres are right-continuous
+(`TauCeti.isDifferenceCompletelyMonotone_of_forall_rat`). -/
+theorem ae_isDifferenceCompletelyMonotone_timeSliceDensity (hFpd : IsSemigroupGroupPD F)
+    (hFcont : Continuous F) (hFbdd : Bornology.IsBounded (range F)) :
+    ∀ᵐ q ∂(bochnerMeasure fun a => F (0, a)),
+      IsDifferenceCompletelyMonotone fun s : ℝ => (timeSliceDensity F s.toNNReal q).toReal := by
+  have hfin : ∀ᵐ q ∂(bochnerMeasure fun a => F (0, a)), timeSliceDensity F 0 q ≠ ⊤ := by
+    filter_upwards [ae_timeSliceDensity_zero_eq_one hFpd hFcont hFbdd] with q hq
+    rw [hq]
+    exact ENNReal.one_ne_top
+  have hDd : ∀ᵐ q ∂(bochnerMeasure fun a => F (0, a)), ∀ r : ℚ, 0 ≤ r →
+      timeSliceDensity F (Real.toNNReal (r : ℝ)) q
+        = (bochnerMeasure fun a => F (Real.toNNReal (r : ℝ), a)).rnDeriv
+            (bochnerMeasure fun a => F (0, a)) q := by
+    refine ae_all_iff.2 fun r => ?_
+    filter_upwards [timeSliceDensity_ae_eq_rnDeriv hFpd hFcont hFbdd
+      (Real.toNNReal (r : ℝ))] with q hq _ using hq
+  have hsign : ∀ᵐ q ∂(bochnerMeasure fun a => F (0, a)), ∀ p : List ℚ × ℚ,
+      (∀ h ∈ p.1, 0 ≤ h) → 0 ≤ p.2 →
+      0 ≤ (-1) ^ p.1.length * fwdDiffList (p.1.map (Rat.cast))
+        (fun s : ℝ => ((bochnerMeasure fun a => F (s.toNNReal, a)).rnDeriv
+          (bochnerMeasure fun a => F (0, a)) q).toReal) ((p.2 : ℝ)) := by
+    refine ae_all_iff.2 fun p => ?_
+    filter_upwards [toReal_rnDeriv_bochnerMeasure_timeSlice_listTimeDifference hFpd hFcont hFbdd
+      (p.1.map fun r : ℚ => Real.toNNReal (r : ℝ)) (Real.toNNReal (p.2 : ℝ))] with q hq hl hs
+    have hlist : (p.1.map fun r : ℚ => Real.toNNReal (r : ℝ)).map (fun h : ℝ≥0 => (h : ℝ))
+        = p.1.map (Rat.cast) := by
+      rw [List.map_map]
+      refine List.map_congr_left fun r hr => ?_
+      exact Real.coe_toNNReal (r : ℝ) (by exact_mod_cast hl r hr)
+    rw [hlist, List.length_map, Real.coe_toNNReal (p.2 : ℝ) (by exact_mod_cast hs)] at hq
+    rw [← hq]
+    exact ENNReal.toReal_nonneg
+  filter_upwards [hfin, hDd, hsign] with q hq₁ hq₂ hq₃
+  refine isDifferenceCompletelyMonotone_of_forall_rat
+    (fun u hu => tendsto_toReal_timeSliceDensity_nhdsGT F hq₁ hu) fun l hl s hs => ?_
+  have hcongr : fwdDiffList (l.map (Rat.cast))
+        (fun s : ℝ => (timeSliceDensity F s.toNNReal q).toReal) ((s : ℝ))
+      = fwdDiffList (l.map (Rat.cast))
+        (fun s : ℝ => ((bochnerMeasure fun a => F (s.toNNReal, a)).rnDeriv
+          (bochnerMeasure fun a => F (0, a)) q).toReal) ((s : ℝ)) := by
+    refine fwdDiffList_congr_of_add_mem (S := {u : ℝ | ∃ r : ℚ, 0 ≤ r ∧ (r : ℝ) = u}) ?_
+      ⟨s, hs, rfl⟩ ?_
+    · rintro h hh u ⟨r, hr₀, rfl⟩
+      obtain ⟨k, hk, rfl⟩ := List.mem_map.1 hh
+      exact ⟨r + k, add_nonneg hr₀ (hl k hk), by push_cast; ring⟩
+    · rintro u ⟨r, hr₀, rfl⟩
+      rw [hq₂ r hr₀]
+  rw [hcongr]
+  exact hq₃ (l, s) hl hs
+
+/-- **Almost every fibre of the right-continuous density is a completely monotone function of
+time.** This is the hypothesis of `TauCeti.bernsteinMeasureKernel`, so almost every fibre carries a
+Bernstein representing measure on `ℝ≥0`. -/
+theorem ae_isContinuousCompletelyMonotoneOnIoi_timeSliceDensity (hFpd : IsSemigroupGroupPD F)
+    (hFcont : Continuous F) (hFbdd : Bornology.IsBounded (range F)) :
+    ∀ᵐ q ∂(bochnerMeasure fun a => F (0, a)),
+      IsContinuousCompletelyMonotoneOnIoi fun s : ℝ =>
+        (timeSliceDensity F s.toNNReal q).toReal := by
+  filter_upwards [ae_isDifferenceCompletelyMonotone_timeSliceDensity hFpd hFcont hFbdd,
+    ae_timeSliceDensity_zero_eq_one hFpd hFcont hFbdd] with q hq hone
+  refine hq.isContinuousCompletelyMonotoneOnIoi (continuousWithinAt_Ioi_iff_Ici.1 ?_)
+  exact tendsto_toReal_timeSliceDensity_nhdsGT F (by rw [hone]; exact ENNReal.one_ne_top) le_rfl
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Slice/Density.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Slice/Density.lean
@@ -98,7 +98,7 @@ theorem bochnerMeasure_timeSlice_listTimeDifference_le (hFpd : IsSemigroupGroupP
 /-- **The densities decrease in time**, almost everywhere against the time-`0` Bochner measure:
 the earlier spatial measure is the later one plus the Bochner measure of the time difference
 between them. -/
-theorem rnDeriv_bochnerMeasure_timeSlice_antitone (hFpd : IsSemigroupGroupPD F)
+theorem rnDeriv_bochnerMeasure_timeSlice_ae_le (hFpd : IsSemigroupGroupPD F)
     (hFcont : Continuous F) (hFbdd : Bornology.IsBounded (range F)) {t s : ℝ≥0} (hts : t ≤ s) :
     (bochnerMeasure fun a => F (s, a)).rnDeriv (bochnerMeasure fun a => F (0, a))
       ≤ᵐ[bochnerMeasure fun a => F (0, a)]
@@ -147,7 +147,8 @@ theorem toReal_rnDeriv_bochnerMeasure_timeSlice_listTimeDifference (hFpd : IsSem
             + ((bochnerMeasure fun a => listTimeDifference l F (t + h, a)).rnDeriv
               (bochnerMeasure fun a => F (0, a)) q).toReal := by
         rw [hsplit, hadd, Pi.add_apply, ENNReal.toReal_add hfin₁.ne hfin₂.ne]
-      rw [listTimeDifference_cons, List.map_cons, List.length_cons, fwdDiffList_cons_apply]
+      rw [listTimeDifference_cons, List.map_cons, List.length_cons]
+      simp only [fwdDiffList_cons, fwdDiff]
       have hcoe : ((t + h : ℝ≥0) : ℝ) = (t : ℝ) + (h : ℝ) := NNReal.coe_add t h
       rw [hcoe] at hth
       rw [pow_succ]
@@ -196,11 +197,12 @@ private theorem exists_seq_nnrat_tendsto (t : ℝ≥0) :
       ((r : ℝ≥0) : ℝ) < (t : ℝ) + 1 / ((n : ℝ) + 1) := by
     intro n
     have hpos : (0 : ℝ) < 1 / ((n : ℝ) + 1) := by positivity
-    obtain ⟨q, hq₁, hq₂⟩ := exists_rat_btwn (show (t : ℝ) < (t : ℝ) + 1 / ((n : ℝ) + 1) by linarith)
+    have hgap : (t : ℝ) < (t : ℝ) + 1 / ((n : ℝ) + 1) := by linarith
+    obtain ⟨q, hq₁, hq₂⟩ := exists_rat_btwn hgap
     have hq₀ : (0 : ℚ) ≤ q := by exact_mod_cast t.coe_nonneg.trans hq₁.le
     have hcast : ((q.toNNRat : ℝ≥0) : ℝ) = (q : ℝ) := by
-      rw [show ((q.toNNRat : ℝ≥0) : ℝ) = ((q.toNNRat : ℚ) : ℝ) from by norm_cast,
-        Rat.coe_toNNRat _ hq₀]
+      have hstep : ((q.toNNRat : ℝ≥0) : ℝ) = ((q.toNNRat : ℚ) : ℝ) := by norm_cast
+      rw [hstep, Rat.coe_toNNRat _ hq₀]
     exact ⟨q.toNNRat, by rw [← NNReal.coe_lt_coe, hcast]; exact hq₁, by rw [hcast]; exact hq₂⟩
   choose r hr₁ hr₂ using hlt
   refine ⟨r, hr₁, ?_⟩
@@ -217,7 +219,7 @@ theorem timeSliceDensity_le_rnDeriv (hFpd : IsSemigroupGroupPD F) (hFcont : Cont
       ≤ᵐ[bochnerMeasure fun a => F (0, a)]
         (bochnerMeasure fun a => F (t, a)).rnDeriv (bochnerMeasure fun a => F (0, a)) := by
   filter_upwards [ae_all_iff.2 fun r : {r : ℚ≥0 // t < (r : ℝ≥0)} =>
-    rnDeriv_bochnerMeasure_timeSlice_antitone hFpd hFcont hFbdd r.2.le] with q hq
+    rnDeriv_bochnerMeasure_timeSlice_ae_le hFpd hFcont hFbdd r.2.le] with q hq
   exact iSup_le hq
 
 /-- **The right-continuous density is a Radon--Nikodym derivative at every fixed time.** The

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Slice/Density.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Slice/Density.lean
@@ -277,19 +277,17 @@ theorem tendsto_timeSliceDensity_nhdsGT (F : ℝ≥0 × V → ℂ) (t : ℝ≥0)
     exact (timeSliceDensity_antitone F q (mem_Ioi.1 hs).le).trans_lt hb
 
 /-- The real-valued time profile of a fibre, reparametrized by a real time, is right-continuous
-on `[0, ∞)`. -/
+at every nonnegative time where its value is finite. -/
 theorem tendsto_toReal_timeSliceDensity_nhdsGT (F : ℝ≥0 × V → ℂ) {q : V}
-    (hq : timeSliceDensity F 0 q ≠ ⊤) {u : ℝ} (hu : 0 ≤ u) :
+    {u : ℝ} (hq : timeSliceDensity F u.toNNReal q ≠ ⊤) (hu : 0 ≤ u) :
     Tendsto (fun s : ℝ => (timeSliceDensity F s.toNNReal q).toReal) (𝓝[>] u)
       (𝓝 ((timeSliceDensity F u.toNNReal q).toReal)) := by
-  have hne : timeSliceDensity F u.toNNReal q ≠ ⊤ :=
-    ne_top_of_le_ne_top hq (timeSliceDensity_antitone F q (zero_le : (0 : ℝ≥0) ≤ u.toNNReal))
   have htoNN : Tendsto (fun s : ℝ => s.toNNReal) (𝓝[>] u) (𝓝[>] u.toNNReal) := by
     refine tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _
       ((continuous_real_toNNReal.tendsto u).mono_left nhdsWithin_le_nhds) ?_
     filter_upwards [self_mem_nhdsWithin] with s hs
     exact mem_Ioi.2 ((Real.toNNReal_lt_toNNReal_iff_of_nonneg hu).2 (mem_Ioi.1 hs))
-  exact (ENNReal.tendsto_toReal hne).comp ((tendsto_timeSliceDensity_nhdsGT F _ q).comp htoNN)
+  exact (ENNReal.tendsto_toReal hq).comp ((tendsto_timeSliceDensity_nhdsGT F _ q).comp htoNN)
 
 /-! ## Complete monotonicity of the fibres -/
 
@@ -330,8 +328,12 @@ theorem ae_isDifferenceCompletelyMonotone_timeSliceDensity (hFpd : IsSemigroupGr
     rw [← hq]
     exact ENNReal.toReal_nonneg
   filter_upwards [hfin, hDd, hsign] with q hq₁ hq₂ hq₃
+  have hfin_at (u : ℝ) : timeSliceDensity F u.toNNReal q ≠ ⊤ :=
+    ne_top_of_le_ne_top hq₁
+      (timeSliceDensity_antitone F q (zero_le : (0 : ℝ≥0) ≤ u.toNNReal))
   refine isDifferenceCompletelyMonotone_of_forall_rat
-    (fun u hu => tendsto_toReal_timeSliceDensity_nhdsGT F hq₁ hu) fun l hl s hs => ?_
+    (fun u hu => tendsto_toReal_timeSliceDensity_nhdsGT F (hfin_at u) hu)
+    fun l hl s hs => ?_
   have hcongr : fwdDiffList (l.map (Rat.cast))
         (fun s : ℝ => (timeSliceDensity F s.toNNReal q).toReal) ((s : ℝ))
       = fwdDiffList (l.map (Rat.cast))
@@ -358,7 +360,8 @@ theorem ae_isContinuousCompletelyMonotoneOnIoi_timeSliceDensity (hFpd : IsSemigr
   filter_upwards [ae_isDifferenceCompletelyMonotone_timeSliceDensity hFpd hFcont hFbdd,
     ae_timeSliceDensity_zero_eq_one hFpd hFcont hFbdd] with q hq hone
   refine hq.isContinuousCompletelyMonotoneOnIoi (continuousWithinAt_Ioi_iff_Ici.1 ?_)
-  exact tendsto_toReal_timeSliceDensity_nhdsGT F (by rw [hone]; exact ENNReal.one_ne_top) le_rfl
+  exact tendsto_toReal_timeSliceDensity_nhdsGT F
+    (by simpa only [Real.toNNReal_zero, hone] using ENNReal.one_ne_top) le_rfl
 
 end TauCeti
 


### PR DESCRIPTION
This PR proves the existence half of the Berg--Christensen--Ressel representation theorem and packages it with the uniqueness half already on `main`, closing `OneParameterSemigroups` Part C, Milestone 2 ("BCR semigroup--Bochner"): a function `F` on the involutive semigroup `ℝ≥0 × V`, for `V` a finite-dimensional real inner-product space, is positive definite, continuous and bounded if and only if it is the Laplace--Fourier transform of a unique finite measure on `ℝ≥0 × V`. That is `TauCeti.bcr_semigroup_bochner`, stated in the roadmap's own naming, with the existence half exported separately as `TauCeti.exists_representsLaplaceFourier`.

The reduction of the milestone to a fibrewise Bernstein problem was already in place: `TauCeti.exists_representsLaplaceFourier_iff_exists_timeKernel` turns the representation into the search for a kernel from `V` to `ℝ≥0` whose fibrewise Laplace transforms are the Radon--Nikodym derivatives `d(bochnerMeasure (F (t, ·)))/d(bochnerMeasure (F (0, ·)))`, `TauCeti.isDifferenceCompletelyMonotone_bochnerMeasure_timeSlice_real` supplies the alternating-difference regularity of the slab masses, `TauCeti.hausdorff_bernstein_widder_difference` represents an alternating-difference function on `[0, ∞)` by a finite measure on `ℝ≥0`, and `TauCeti.bernsteinMeasureKernel` makes those representing measures depend measurably on a parameter. What was missing is the passage from slab masses to *densities*, which is where the two obstacles this PR clears live.

The first is that a Radon--Nikodym derivative is defined only up to a null set, so the alternating time differences of the densities can be controlled at countably many times at once, whereas complete monotonicity quantifies over all real times. `TauCeti.isDifferenceCompletelyMonotone_of_forall_rat` (new file `TauCeti/Analysis/CompletelyMonotone/FiniteDifference/Rational.lean`) removes the discrepancy for a function that is continuous from the right on `[0, ∞)`: the sign condition at rational lists and rational base points implies the full predicate. The proof frees one step at a time rather than arguing density in several variables at once — the signed difference along the steps already available is nonincreasing along rational increments, hence, being right-continuous, nonincreasing outright, which is exactly the sign condition for one further real step; permutation invariance of a mixed difference peels the new step off the front. A general lemma about `TauCeti.fwdDiffList` is added to `FiniteDifference/Basic.lean` for this: `fwdDiffList_congr_of_add_mem` (a mixed difference reads the function only on a set containing the base point and closed under the steps).

The second is that no version of the densities is right-continuous in time on the nose. `TauCeti.timeSliceDensity` (new file `TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Time/Slice/Density.lean`) is the supremum of the Radon--Nikodym derivatives over rational times to the right of `t`; being a supremum over a shrinking family of rational times it is antitone and right-continuous at every point of `V`, with no null set attached, and it agrees almost everywhere with the Radon--Nikodym derivative at each fixed time (`timeSliceDensity_ae_eq_rnDeriv`) because the total masses `t ↦ (F (t, 0)).re` are continuous. The alternating differences of the densities are themselves densities — of the Bochner measures of the list time differences of `F` — hence nonnegative (`toReal_rnDeriv_bochnerMeasure_timeSlice_listTimeDifference`), so almost every fibre is completely monotone in time and normalized at time `0`.

`TauCeti/Analysis/PositiveDefinite/SemigroupGroup/FourierLaplace/Existence.lean` is then the assembly. The only care needed is that "almost every fibre" is not "every fibre" while a kernel must be defined everywhere, so the density is corrected to `0` on a measurable null set containing the exceptional fibres; the Bernstein kernel of the corrected family is finite, its fibrewise Laplace transform at time `t` is almost everywhere the Radon--Nikodym derivative at time `t`, and `representsLaplaceFourier_swapCompProd_of_ae_rnDeriv` produces the representing measure. Nothing remains of the milestone after this PR: with `TauCeti.bochner` (Milestone 1) and `Measure.ext_of_forall_laplaceFourierTransform_eq` (uniqueness) already on `main`, `bcr_semigroup_bochner` is the roadmap's final target for Part C, and the roadmap's acceptance example that `V = 0` collapses BCR to Bernstein is now a statement about two theorems both of which exist.

No Mathlib infrastructure was vendored; the new material consumes `Measure.rnDeriv_add`, `Measure.lintegral_rnDeriv`, `ae_eq_of_ae_le_of_lintegral_le` and the `ProbabilityTheory.Kernel` API in place.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"bcr-semigroup-bochner-existence"}-->

🤖 Prepared with Claude Code

