### PR TITLE
feat: fix coprime Atkin-Lehner double cosets

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -368,13 +368,12 @@ private lemma exists_sl2_mul_mul_eq_atkinLehnerEntries
     _ = atkinLehnerEntries N A c := hB
 
 /-- **The Atkin–Lehner involution fixes a coprime-determinant double coset.** If `x ∈ Δ₀(N)`
-has determinant coprime to `N`, then its bar lies in the `Γ₀(N)`-double coset of `x`.
-
-The Smith normal forms of an integral witness for `x` and its entry-swapped bar agree: their
-first invariant factors agree because the upper-left entry is coprime to `N`, and their second
-invariant factors then agree because the determinants do. Thus they define the same level-one
-double coset. Shimura's Proposition 3.31, `toLevelOneCoset_injOn`, recovers equality of the
-`Γ₀(N)`-double cosets from that equality. -/
+has determinant coprime to `N`, then its bar lies in the `Γ₀(N)`-double coset of `x`. -/
+-- The Smith normal forms of an integral witness for `x` and its entry-swapped bar agree: their
+-- first invariant factors agree because the upper-left entry is coprime to `N`, and their second
+-- invariant factors then agree because the determinants do. Thus they define the same level-one
+-- double coset. Shimura's Proposition 3.31, `toLevelOneCoset_injOn`, recovers equality of the
+-- `Γ₀(N)`-double cosets from that equality.
 theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_coprime_det [NeZero N]
     (x : GL (Fin 2) ℚ) (hx : x ∈ Delta0 N) (hcop : CoprimeDet N ⟨x, hx⟩) :
     (atkinLehnerAntiInvolution N).bar x hx ∈
@@ -409,25 +408,9 @@ theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_coprime_det [NeZero N]
     simp only [toLevelOneCoset_mk]
     symm
     apply HeckeCoset.mk_eq_mk_of_mem
-    rw [DoubleCoset.mem_doubleCoset]
-    refine ⟨mapGL ℚ P, coe_mem_SLnZ 2 P, mapGL ℚ Q, coe_mem_SLnZ 2 Q, Units.ext ?_⟩
-    change ((b : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
-      (((mapGL ℚ P) * (a : GL (Fin 2) ℚ) * (mapGL ℚ Q) : GL (Fin 2) ℚ) :
-        Matrix (Fin 2) (Fin 2) ℚ)
-    rw [hbar]
-    change B.map (Int.cast : ℤ → ℚ) =
-      (mapGL ℚ P).val * x.val * (mapGL ℚ Q).val
-    rw [hA]
-    rw [hB]
-    change (atkinLehnerEntries N A c).map (Int.cast : ℤ → ℚ) =
-      P.val.map (Int.cast : ℤ → ℚ) * A.map (Int.cast : ℤ → ℚ) *
-        Q.val.map (Int.cast : ℤ → ℚ)
-    ext i j
-    have hcast := congr_fun₂
-      (congrArg (fun M ↦ M.map (Int.cast : ℤ → ℚ)) hPQ) i j
-    simp only [Matrix.mul_apply, Matrix.map_apply, Fin.sum_univ_two, Int.cast_add,
-      Int.cast_mul] at hcast ⊢
-    exact hcast.symm
+    rw [Submonoid.coe_inclusion, Submonoid.coe_inclusion]
+    exact mem_doubleCoset_SLnZ_of_intMatrix_eq 2 P Q x (b : GL (Fin 2) ℚ) A B hA hbar
+      (hPQ.trans hB.symm)
   have hcoset := toLevelOneCoset_injOn N
     (show HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) a ∈
       {D | CoprimeDetCoset N D} by simpa [a] using hcop)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -52,7 +52,7 @@ power of it. These are the good-prime and bad-prime extremes of the hypothesis
   itself is opaque, so this is the elimination rule a consumer works with.
 * `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_val`: its entrywise action on a `Δ₀(N)` witness.
 * `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_det`: it preserves the determinant.
-* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_coprime_det`: it fixes the
+* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_coprimeDet`: it fixes the
   double coset when the determinant is coprime to the level.
 * `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow`: it fixes the double
   coset when the determinant divides a power of the level.
@@ -362,9 +362,7 @@ private lemma exists_sl2_mul_mul_eq_atkinLehnerEntries
     _ = (LB⁻¹).val * (LB.val * B * RB.val) * (RB⁻¹).val := by rw [hB_snf]
     _ = B := by
       simp only [Matrix.mul_assoc]
-      rw [show (LB⁻¹).val * (LB.val * (B * (RB.val * (RB⁻¹).val))) =
-          (LB⁻¹).val * (LB.val * (B * 1)) by rw [hRB]]
-      rw [Matrix.mul_one, ← Matrix.mul_assoc (LB⁻¹).val, hLB, Matrix.one_mul]
+      rw [hRB, Matrix.mul_one, ← Matrix.mul_assoc (LB⁻¹).val, hLB, Matrix.one_mul]
     _ = atkinLehnerEntries N A c := hB
 
 /-- **The Atkin–Lehner involution fixes a coprime-determinant double coset.** If `x ∈ Δ₀(N)`
@@ -374,7 +372,7 @@ has determinant coprime to `N`, then its bar lies in the `Γ₀(N)`-double coset
 -- invariant factors then agree because the determinants do. Thus they define the same level-one
 -- double coset. Shimura's Proposition 3.31, `toLevelOneCoset_injOn`, recovers equality of the
 -- `Γ₀(N)`-double cosets from that equality.
-theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_coprime_det [NeZero N]
+theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_coprimeDet [NeZero N]
     (x : GL (Fin 2) ℚ) (hx : x ∈ Delta0 N) (hcop : CoprimeDet N ⟨x, hx⟩) :
     (atkinLehnerAntiInvolution N).bar x hx ∈
       DoubleCoset.doubleCoset x ((Gamma0 N).map (mapGL ℚ))
@@ -411,16 +409,18 @@ theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_coprime_det [NeZero N]
     rw [Submonoid.coe_inclusion, Submonoid.coe_inclusion]
     exact mem_doubleCoset_SLnZ_of_intMatrix_eq 2 P Q x (b : GL (Fin 2) ℚ) A B hA hbar
       (hPQ.trans hB.symm)
-  have hcoset := toLevelOneCoset_injOn N
-    (show HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) a ∈
-      {D | CoprimeDetCoset N D} by simpa [a] using hcop)
-    (show HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) b ∈
-      {D | CoprimeDetCoset N D} by simpa using hb_cop) hlevel
-  have hdc := HeckeCoset.eq_iff.mp hcoset
-  rw [show DoubleCoset.doubleCoset x ((Gamma0 N).map (mapGL ℚ))
+  have ha_cop : HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) a ∈
+      {D | CoprimeDetCoset N D} := by simpa [a] using hcop
+  have hb_coset_cop :
+      HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) b ∈
+        {D | CoprimeDetCoset N D} := by simpa using hb_cop
+  have hcoset := toLevelOneCoset_injOn N ha_cop hb_coset_cop hlevel
+  have hdc : DoubleCoset.doubleCoset x ((Gamma0 N).map (mapGL ℚ))
       ((Gamma0 N).map (mapGL ℚ)) =
-      DoubleCoset.doubleCoset ((b : Delta0 N) : GL (Fin 2) ℚ)
-        ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) from hdc]
+      DoubleCoset.doubleCoset (b : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+        ((Gamma0 N).map (mapGL ℚ)) := by
+    simpa only [a] using HeckeCoset.eq_iff.mp hcoset
+  rw [hdc]
   exact DoubleCoset.mem_doubleCoset_self _ _ _
 
 /-- **The Atkin–Lehner involution fixes a bad-prime double coset.** If `x ∈ Δ₀(N)` has

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -291,7 +291,7 @@ private lemma dvd_atkinLehnerEntries (A : Matrix (Fin 2) (Fin 2) ℤ) (e c : ℤ
 /-- The integral matrices of `x` and its Atkin–Lehner bar are equivalent under determinant-one
 row and column operations. Smith normal form reduces this to preservation of the determinant
 and of the content; the latter is where the `Δ₀(N)` upper-left coprimality is used. -/
-private lemma exists_sl2_mul_mul_eq_atkinLehnerEntries [NeZero N]
+private lemma exists_sl2_mul_mul_eq_atkinLehnerEntries
     (A : Matrix (Fin 2) (Fin 2) ℤ) (hA_det_pos : 0 < A.det) (c : ℤ)
     (hc : A 1 0 = (N : ℤ) * c) (hAco : Int.gcd (A 0 0) N = 1) :
     ∃ P Q : SpecialLinearGroup (Fin 2) ℤ,

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean
@@ -10,6 +10,10 @@ public import TauCeti.NumberTheory.HeckeRing.GLn.TransposeAntiInvolution
 -- `mem_doubleCoset_natDiagGL_of_dvd_pow` (Shimura 3.33), used only inside the proof of
 -- `atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow` below, so private.
 import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.BadPrimeCoset
+import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.CosetMap
+import TauCeti.LinearAlgebra.Matrix.Divisibility
+import TauCeti.LinearAlgebra.Matrix.SmithNormalForm
+import Mathlib.Data.ZMod.Units
 
 /-!
 # The Atkin-Lehner anti-involution of the `Γ₀(N)` Hecke pair
@@ -32,10 +36,11 @@ by `N`, the determinant is unchanged, and — the point of the construction — 
 entry is untouched, so the coprimality condition cutting out `Δ₀(N)` transfers with no work.
 Integrality of the new upper-right entry is precisely the hypothesis `N ∣ A 1 0`.
 
-Beyond the anti-involution itself, this file proves that `ι` preserves determinants and that it
-fixes the double coset of any `x ∈ Δ₀(N)` whose determinant divides a power of the level — the
-*bad-prime* half of the hypothesis `HeckeCosetModule.mul_comm_of_antiInvolution` takes for
-commutativity of `R(Γ₀(N), Δ₀(N))` (Shimura, Proposition 3.8). The coprime half is separate.
+Beyond the anti-involution itself, this file proves that `ι` preserves determinants and fixes
+the double coset of any `x ∈ Δ₀(N)` whose determinant is coprime to the level, or divides a
+power of it. These are the good-prime and bad-prime extremes of the hypothesis
+`HeckeCosetModule.mul_comm_of_antiInvolution` takes for commutativity of
+`R(Γ₀(N), Δ₀(N))` (Shimura, Proposition 3.8); a mixed determinant requires both arguments.
 
 ## Main definitions
 
@@ -47,6 +52,8 @@ commutativity of `R(Γ₀(N), Δ₀(N))` (Shimura, Proposition 3.8). The coprime
   itself is opaque, so this is the elimination rule a consumer works with.
 * `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_val`: its entrywise action on a `Δ₀(N)` witness.
 * `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_det`: it preserves the determinant.
+* `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_coprime_det`: it fixes the
+  double coset when the determinant is coprime to the level.
 * `HeckeRing.GL2.atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_dvd_pow`: it fixes the double
   coset when the determinant divides a power of the level.
 
@@ -58,7 +65,8 @@ commutativity of `R(Γ₀(N), Δ₀(N))` (Shimura, Proposition 3.8). The coprime
   [`HeckeRIngs/GLn/CongruenceHecke/AtkinLehner.lean`](https://github.com/CBirkbeck/AINTLIB),
   declarations `wN`, `Gamma0_AL_hom`, `Gamma0_AL_involutive`, `Gamma0_AL_map_H`,
   `Gamma0_AL_map_Δ` and `Gamma0_antiInvolution`, and — for the results added here —
-  `Gamma0_AL_bar_det` and `Gamma0_AL_in_DC_bad`, all Apache-2.0 at commit
+  `Gamma0_AL_bar_det`, `bar_eq_SL2_conj`, `Gamma0_AL_in_DC_coprime` and
+  `Gamma0_AL_in_DC_bad`, all Apache-2.0 at commit
   `2baa76f742bdb4fb8ee323fabba41203bd390e08`. The source states its own transpose equivalence
   and diagonal-matrix API; here those come from `GLn/TransposeAntiInvolution.lean` and
   `GLn/DiagonalCosets.lean` instead, and the four-field bundle is assembled by
@@ -266,6 +274,171 @@ lemma atkinLehnerAntiInvolution_bar_det [NeZero N] {x : GL (Fin 2) ℚ}
     HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
   rw [hbar]
   exact atkinLehnerHom_unop_det N x
+
+/-- Common divisors of an integral matrix survive the entry swap defining the Atkin–Lehner
+bar, provided they are coprime to the level. -/
+private lemma dvd_atkinLehnerEntries (A : Matrix (Fin 2) (Fin 2) ℤ) (e c : ℤ)
+    (hc : A 1 0 = (N : ℤ) * c) (he : ∀ i j, e ∣ A i j)
+    (heN : IsCoprime e (N : ℤ)) :
+    ∀ i j, e ∣ atkinLehnerEntries N A c i j := by
+  intro i j
+  fin_cases i <;> fin_cases j
+  · simpa [atkinLehnerEntries] using he 0 0
+  · simpa [atkinLehnerEntries] using heN.dvd_of_dvd_mul_left (hc ▸ he 1 0)
+  · simpa [atkinLehnerEntries] using dvd_mul_of_dvd_right (he 0 1) (N : ℤ)
+  · simpa [atkinLehnerEntries] using he 1 1
+
+/-- The integral matrices of `x` and its Atkin–Lehner bar are equivalent under determinant-one
+row and column operations. Smith normal form reduces this to preservation of the determinant
+and of the content; the latter is where the `Δ₀(N)` upper-left coprimality is used. -/
+private lemma exists_sl2_mul_mul_eq_atkinLehnerEntries [NeZero N]
+    (A : Matrix (Fin 2) (Fin 2) ℤ) (hA_det_pos : 0 < A.det) (c : ℤ)
+    (hc : A 1 0 = (N : ℤ) * c) (hAco : Int.gcd (A 0 0) N = 1) :
+    ∃ P Q : SpecialLinearGroup (Fin 2) ℤ,
+      (P : Matrix (Fin 2) (Fin 2) ℤ) * A * (Q : Matrix (Fin 2) (Fin 2) ℤ) =
+        atkinLehnerEntries N A c := by
+  set B := atkinLehnerEntries N A c with hB
+  have hB_det : B.det = A.det := by rw [hB, atkinLehnerEntries_det N A c hc]
+  obtain ⟨LA, RA, dA, hdA_pos, hdA_div, hA_snf⟩ :=
+    A.exists_smith_normal_form_of_det_pos hA_det_pos
+  obtain ⟨LB, RB, dB, hdB_pos, hdB_div, hB_snf⟩ :=
+    B.exists_smith_normal_form_of_det_pos (hB_det ▸ hA_det_pos)
+  have hdA_A : ∀ i j, dA 0 ∣ A i j := fun i j ↦
+    Matrix.invariant_factor_zero_dvd_entries A dA (fun k ↦ hdA_div (Fin.zero_le k))
+      LA.toGL RA.toGL hA_snf i j
+  have hdB_B : ∀ i j, dB 0 ∣ B i j := fun i j ↦
+    Matrix.invariant_factor_zero_dvd_entries B dB (fun k ↦ hdB_div (Fin.zero_le k))
+      LB.toGL RB.toGL hB_snf i j
+  have hAco' : IsCoprime (A 0 0) (N : ℤ) := Int.isCoprime_iff_gcd_eq_one.mpr hAco
+  have hdA_B : ∀ i j, dA 0 ∣ B i j := by
+    rw [hB]
+    exact dvd_atkinLehnerEntries N A (dA 0) c hc hdA_A
+      (hAco'.of_isCoprime_of_dvd_left (hdA_A 0 0))
+  have hB00 : B 0 0 = A 0 0 := by simp [hB, atkinLehnerEntries]
+  have hBc : B 1 0 = (N : ℤ) * A 0 1 := by simp [hB, atkinLehnerEntries]
+  have hswap : atkinLehnerEntries N B (A 0 1) = A := by
+    ext i j
+    fin_cases i <;> fin_cases j <;> simp [hB, atkinLehnerEntries, hc]
+  have hdB_A : ∀ i j, dB 0 ∣ A i j := fun i j ↦ by
+    have h := dvd_atkinLehnerEntries N B (dB 0) (A 0 1) hBc hdB_B
+      (hAco'.of_isCoprime_of_dvd_left (hB00 ▸ hdB_B 0 0)) i j
+    rwa [hswap] at h
+  have hdA0_dvd_dB0 : dA 0 ∣ dB 0 :=
+    Matrix.dvd_diag_of_dvd_entries B (dA 0) dB LB RB hB_snf hdA_B 0
+  have hdB0_dvd_dA0 : dB 0 ∣ dA 0 :=
+    Matrix.dvd_diag_of_dvd_entries A (dB 0) dA LA RA hA_snf hdB_A 0
+  have hd0 : dA 0 = dB 0 := le_antisymm
+    (Int.le_of_dvd (hdB_pos 0) hdA0_dvd_dB0)
+    (Int.le_of_dvd (hdA_pos 0) hdB0_dvd_dA0)
+  have hprodA : dA 0 * dA 1 = A.det := by
+    have h := congrArg Matrix.det hA_snf
+    simp only [Matrix.det_mul, LA.2, RA.2, one_mul, mul_one, Matrix.det_diagonal,
+      Fin.prod_univ_two] at h
+    exact h.symm
+  have hprodB : dB 0 * dB 1 = B.det := by
+    have h := congrArg Matrix.det hB_snf
+    simp only [Matrix.det_mul, LB.2, RB.2, one_mul, mul_one, Matrix.det_diagonal,
+      Fin.prod_univ_two] at h
+    exact h.symm
+  have hd1 : dA 1 = dB 1 := mul_left_cancel₀ (ne_of_gt (hdA_pos 0)) (by
+    rw [hprodA, hd0, hprodB, hB_det])
+  have hdiag : Matrix.diagonal dA = Matrix.diagonal dB := by
+    congr 1
+    funext i
+    fin_cases i <;> assumption
+  refine ⟨LB⁻¹ * LA, RA * RB⁻¹, ?_⟩
+  have hLB : (LB⁻¹).val * LB.val = (1 : Matrix (Fin 2) (Fin 2) ℤ) := by
+    rw [← SpecialLinearGroup.coe_mul, inv_mul_cancel]
+    rfl
+  have hRB : RB.val * (RB⁻¹).val = (1 : Matrix (Fin 2) (Fin 2) ℤ) := by
+    rw [← SpecialLinearGroup.coe_mul, mul_inv_cancel]
+    rfl
+  calc
+    ((LB⁻¹ * LA : SpecialLinearGroup (Fin 2) ℤ) : Matrix (Fin 2) (Fin 2) ℤ) * A *
+        ((RA * RB⁻¹ : SpecialLinearGroup (Fin 2) ℤ) : Matrix (Fin 2) (Fin 2) ℤ) =
+        (LB⁻¹).val * (LA.val * A * RA.val) * (RB⁻¹).val := by
+          simp only [SpecialLinearGroup.coe_mul, Matrix.mul_assoc]
+    _ = (LB⁻¹).val * Matrix.diagonal dB * (RB⁻¹).val := by rw [hA_snf, hdiag]
+    _ = (LB⁻¹).val * (LB.val * B * RB.val) * (RB⁻¹).val := by rw [hB_snf]
+    _ = B := by
+      simp only [Matrix.mul_assoc]
+      rw [show (LB⁻¹).val * (LB.val * (B * (RB.val * (RB⁻¹).val))) =
+          (LB⁻¹).val * (LB.val * (B * 1)) by rw [hRB]]
+      rw [Matrix.mul_one, ← Matrix.mul_assoc (LB⁻¹).val, hLB, Matrix.one_mul]
+    _ = atkinLehnerEntries N A c := hB
+
+/-- **The Atkin–Lehner involution fixes a coprime-determinant double coset.** If `x ∈ Δ₀(N)`
+has determinant coprime to `N`, then its bar lies in the `Γ₀(N)`-double coset of `x`.
+
+The Smith normal forms of an integral witness for `x` and its entry-swapped bar agree: their
+first invariant factors agree because the upper-left entry is coprime to `N`, and their second
+invariant factors then agree because the determinants do. Thus they define the same level-one
+double coset. Shimura's Proposition 3.31, `toLevelOneCoset_injOn`, recovers equality of the
+`Γ₀(N)`-double cosets from that equality. -/
+theorem atkinLehnerAntiInvolution_bar_mem_doubleCoset_of_coprime_det [NeZero N]
+    (x : GL (Fin 2) ℚ) (hx : x ∈ Delta0 N) (hcop : CoprimeDet N ⟨x, hx⟩) :
+    (atkinLehnerAntiInvolution N).bar x hx ∈
+      DoubleCoset.doubleCoset x ((Gamma0 N).map (mapGL ℚ))
+        ((Gamma0 N).map (mapGL ℚ)) := by
+  obtain ⟨A, hA, hdet, hAN, hAunit⟩ := (mem_Delta0_iff N).mp hx
+  obtain ⟨c, hc⟩ := hAN
+  set a : Delta0 N := ⟨x, hx⟩
+  set b : Delta0 N :=
+    ⟨(atkinLehnerAntiInvolution N).bar x hx,
+      (atkinLehnerAntiInvolution N).bar_mem_Δ x hx⟩
+  set B := atkinLehnerEntries N A c with hB
+  have hbar : ((b : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      B.map (Int.cast : ℤ → ℚ) := by
+    simpa only [b, hB, atkinLehnerEntries] using
+      atkinLehnerAntiInvolution_bar_val N hx A hA c hc
+  have hA_det_pos : 0 < A.det := by
+    rw [← Int.cast_pos (R := ℚ), Int.cast_det, ← hA]
+    exact hdet
+  have hAco : Int.gcd (A 0 0) N = 1 := by
+    exact Int.isCoprime_iff_gcd_eq_one.mp
+      (isCoprime_comm.mp ((ZMod.coe_int_isUnit_iff_isCoprime _ _).mp hAunit))
+  obtain ⟨P, Q, hPQ⟩ :=
+    exists_sl2_mul_mul_eq_atkinLehnerEntries N A hA_det_pos c hc hAco
+  have hb_cop : CoprimeDet N b := by
+    rw [coprimeDet_iff N hbar, hB, atkinLehnerEntries_det N A c hc]
+    exact (coprimeDet_iff N hA).mp hcop
+  have hlevel : toLevelOneCoset N
+      (HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) a) =
+      toLevelOneCoset N
+        (HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) b) := by
+    simp only [toLevelOneCoset_mk]
+    symm
+    apply HeckeCoset.mk_eq_mk_of_mem
+    rw [DoubleCoset.mem_doubleCoset]
+    refine ⟨mapGL ℚ P, coe_mem_SLnZ 2 P, mapGL ℚ Q, coe_mem_SLnZ 2 Q, Units.ext ?_⟩
+    change ((b : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      (((mapGL ℚ P) * (a : GL (Fin 2) ℚ) * (mapGL ℚ Q) : GL (Fin 2) ℚ) :
+        Matrix (Fin 2) (Fin 2) ℚ)
+    rw [hbar]
+    change B.map (Int.cast : ℤ → ℚ) =
+      (mapGL ℚ P).val * x.val * (mapGL ℚ Q).val
+    rw [hA]
+    rw [hB]
+    change (atkinLehnerEntries N A c).map (Int.cast : ℤ → ℚ) =
+      P.val.map (Int.cast : ℤ → ℚ) * A.map (Int.cast : ℤ → ℚ) *
+        Q.val.map (Int.cast : ℤ → ℚ)
+    ext i j
+    have hcast := congr_fun₂
+      (congrArg (fun M ↦ M.map (Int.cast : ℤ → ℚ)) hPQ) i j
+    simp only [Matrix.mul_apply, Matrix.map_apply, Fin.sum_univ_two, Int.cast_add,
+      Int.cast_mul] at hcast ⊢
+    exact hcast.symm
+  have hcoset := toLevelOneCoset_injOn N
+    (show HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) a ∈
+      {D | CoprimeDetCoset N D} by simpa [a] using hcop)
+    (show HeckeCoset.mk ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) b ∈
+      {D | CoprimeDetCoset N D} by simpa using hb_cop) hlevel
+  have hdc := HeckeCoset.eq_iff.mp hcoset
+  rw [show DoubleCoset.doubleCoset x ((Gamma0 N).map (mapGL ℚ))
+      ((Gamma0 N).map (mapGL ℚ)) =
+      DoubleCoset.doubleCoset ((b : Delta0 N) : GL (Fin 2) ℚ)
+        ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) from hdc]
+  exact DoubleCoset.mem_doubleCoset_self _ _ _
 
 /-- **The Atkin–Lehner involution fixes a bad-prime double coset.** If `x ∈ Δ₀(N)` has
 determinant `m` with `m ∣ N ^ k`, then `bar x` lies in the `Γ₀(N)`-double coset of `x` itself.


### PR DESCRIPTION
This PR proves that the Atkin–Lehner anti-involution fixes every `Γ₀(N)` double coset in `Δ₀(N)` whose determinant is coprime to `N`. It identifies the Smith normal forms of an integral representative and its entry-swapped bar, then applies Shimura Proposition 3.31 through the existing `toLevelOneCoset_injOn` API.

This advances the ModularForms Layer 2(a) target “commutativity at level `N` by the Atkin–Lehner anti-involution” by completing its coprime-determinant fixing case. After this PR, the mixed-determinant reduction remains before the anti-involution fixes every double coset and Shimura Proposition 3.8 yields commutativity of `R(Γ₀(N), Δ₀(N))`.

The proof ports the mathematical argument behind AINTLIB's `bar_eq_SL2_conj` and `Gamma0_AL_in_DC_coprime` from `LeanModularForms/HeckeRIngs/GLn/CongruenceHecke/AtkinLehner.lean` (Chris Birkbeck, Apache-2.0, commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`). It reuses Tau Ceti's general Smith normal form and matrix-divisibility infrastructure together with `Gamma0/CosetMap.lean`; no Mathlib result duplicates this congruence-level theorem.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"atkin-lehner-fixes-coprime-double-coset"}-->

🤖 Prepared with Codex
