### PR TITLE
feat: the Frobenius kernel and its size

### DIFF
--- a/TauCeti/GroupTheory/FrobeniusKernel.lean
+++ b/TauCeti/GroupTheory/FrobeniusKernel.lean
@@ -1,0 +1,273 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.Complement
+public import Mathlib.GroupTheory.Index
+public import TauCeti.GroupTheory.TrivialIntersection
+
+/-!
+# The Frobenius kernel and its size
+
+The **Frobenius kernel** of a subgroup `H` of `G` is the identity together with the elements of `G`
+lying in no conjugate of `H`,
+
+`frobeniusKernel H = {1} ∪ (G ∖ ⋃_g g H g⁻¹)`.
+
+Frobenius's theorem says that when `H` is a Frobenius complement — proper, nontrivial, and meeting
+each of its distinct conjugates trivially (`TauCeti.IsFrobeniusComplement`) — this set is a normal
+subgroup, and that is not elementary: the known proofs go through the character theory of `G`.
+What *is* elementary, and is what this file proves, is everything about the kernel except its
+closure under multiplication: it contains the identity, it is closed under inversion and under
+conjugation, it meets `H` only in the identity, and — the counting statement the roadmap records —
+it has exactly `|G : H|` elements.
+
+The count is the inclusion-exclusion that gives Frobenius's theorem its shape. For a
+trivial-intersection subgroup the conjugates `g H g⁻¹` meet pairwise in the identity alone and
+depend only on the coset `g H`, so the elements they cover other than `1` are indexed bijectively
+by the pairs (a coset of `H`, a nonidentity element of `H`); there are `|G : H| · (|H| - 1)` of
+them, and the remaining `|G| - |G : H| · (|H| - 1) = |G : H|` elements of `G` are the kernel. That
+bijection is `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, and the rest is arithmetic.
+
+Together with normality the count is exactly what makes the kernel a *complement*:
+`TauCeti.IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel` says that a subgroup whose carrier
+is the Frobenius kernel is automatically a complement to `H`, so once Frobenius's theorem supplies
+the subgroup, the semidirect decomposition `G = N ⋊ H` is free. Nothing here asserts that a
+subgroup with that carrier exists.
+
+No hypothesis beyond `TauCeti.IsTISubgroup` is needed for the count, and the two degenerate cases
+are honest instances rather than exclusions: `frobeniusKernel ⊤ = {1}` has one element and `⊤` has
+index `1`, while `frobeniusKernel ⊥` is everything and `⊥` has index `|G|`.
+
+## Main definitions
+
+* `TauCeti.frobeniusKernel`: the identity together with the elements in no conjugate of `H`.
+
+## Main results
+
+* `TauCeti.mem_frobeniusKernel`: membership, elementwise.
+* `TauCeti.inv_mem_frobeniusKernel_iff` and `TauCeti.conj_mem_frobeniusKernel_iff`: the kernel is
+  closed under inversion and invariant under conjugation, for every subgroup `H`.
+* `TauCeti.frobeniusKernel_inter_coe`: the kernel meets `H` exactly in the identity.
+* `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`: the elements *outside* the kernel are the
+  `|G : H| · (|H| - 1)` nonidentity elements of the conjugates of `H`, each counted once.
+* `TauCeti.IsTISubgroup.ncard_frobeniusKernel` and
+  `TauCeti.IsTISubgroup.natCard_frobeniusKernel`: **the kernel has `|G : H|` elements.**
+* `TauCeti.IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel`: a subgroup whose carrier is the
+  kernel is a complement to `H`.
+
+## Implementation notes
+
+The bijection is set up as a map *into* `G` out of `(G ⧸ H) × H#`, rather than as an `Equiv` onto
+the complement of the kernel, because the two facts it is used through are cleaner apart than
+bundled: that its range is the complement needs no hypothesis on `H` at all, while its injectivity
+is exactly the trivial-intersection condition. The coset representatives are `Quotient.out`, so the
+map is noncomputable and needs no well-definedness argument; the price is that hitting an element
+of the complement has to move a witness `x` to `(x H).out` by `QuotientGroup.mk_out_eq_mul`,
+conjugating the element of `H` along the way.
+
+## References
+
+* I. M. Isaacs, *Character Theory of Finite Groups*, Chapter 7, Section 7B.
+* [Character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 8 (`frobeniusKernel`, "a set of size `|G : H|`", and `frobeniusKernel_isComplement'`).
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Pointwise
+
+variable {G : Type*} [Group G] {H : Subgroup G}
+
+/-- **The Frobenius kernel** of a subgroup: the identity together with the elements of `G` lying in
+no conjugate of `H`.  For a Frobenius complement `H` this set is a normal subgroup of `G`, but that
+is Frobenius's theorem and needs character theory; as a *set* it is available for any `H`, and
+`TauCeti.mem_frobeniusKernel` is the elementwise description everything below uses. -/
+def frobeniusKernel (H : Subgroup G) : Set G :=
+  {1} ∪ (⋃ g : G, ((MulAut.conj g • H : Subgroup G) : Set G))ᶜ
+
+/-- **Membership in the Frobenius kernel**: an element is the identity, or no conjugate of it lands
+in `H`. -/
+theorem mem_frobeniusKernel {y : G} :
+    y ∈ frobeniusKernel H ↔ y = 1 ∨ ∀ x : G, x⁻¹ * y * x ∉ H := by
+  have key : ∀ g : G, y ∈ (MulAut.conj g • H : Subgroup G) ↔ g⁻¹ * y * g ∈ H := fun g => by
+    rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem]
+    simp [MulAut.smul_def]
+  simp only [frobeniusKernel, Set.mem_union, Set.mem_singleton_iff, Set.mem_compl_iff,
+    Set.mem_iUnion, not_exists, SetLike.mem_coe, key]
+
+/-- Being outside the Frobenius kernel means being a nonidentity element of some conjugate of
+`H`. -/
+theorem notMem_frobeniusKernel_iff {y : G} :
+    y ∉ frobeniusKernel H ↔ y ≠ 1 ∧ ∃ x : G, x⁻¹ * y * x ∈ H := by
+  rw [mem_frobeniusKernel]
+  push Not
+  rfl
+
+@[simp]
+theorem one_mem_frobeniusKernel : (1 : G) ∈ frobeniusKernel H :=
+  mem_frobeniusKernel.2 (Or.inl rfl)
+
+/-- A conjugate of an element is the identity only if the element is; the `x⁻¹ • x` form of
+Mathlib's `conj_eq_one_iff`, which is how the conjugates appear in
+`TauCeti.mem_frobeniusKernel`. -/
+private theorem inv_conj_eq_one_iff {y x : G} : x⁻¹ * y * x = 1 ↔ y = 1 := by
+  simpa using conj_eq_one_iff (a := x⁻¹) (b := y)
+
+/-- The Frobenius kernel is closed under inversion: `x⁻¹ y⁻¹ x` is the inverse of `x⁻¹ y x`, and a
+subgroup contains an element exactly when it contains its inverse. -/
+@[simp]
+theorem inv_mem_frobeniusKernel_iff {y : G} :
+    y⁻¹ ∈ frobeniusKernel H ↔ y ∈ frobeniusKernel H := by
+  simp only [mem_frobeniusKernel, inv_eq_one]
+  refine or_congr Iff.rfl (forall_congr' fun x => not_congr ?_)
+  rw [show x⁻¹ * y⁻¹ * x = (x⁻¹ * y * x)⁻¹ by group, H.inv_mem_iff]
+
+/-- The Frobenius kernel is invariant under conjugation: it is cut out by a condition quantified
+over all conjugates, which conjugating merely reindexes.  This is the half of normality that costs
+nothing; closure under multiplication is Frobenius's theorem. -/
+@[simp]
+theorem conj_mem_frobeniusKernel_iff {y g : G} :
+    g * y * g⁻¹ ∈ frobeniusKernel H ↔ y ∈ frobeniusKernel H := by
+  simp only [mem_frobeniusKernel, conj_eq_one_iff]
+  refine or_congr Iff.rfl ⟨fun h x => ?_, fun h x => ?_⟩
+  · rw [show x⁻¹ * y * x = (g * x)⁻¹ * (g * y * g⁻¹) * (g * x) by group]
+    exact h (g * x)
+  · rw [show x⁻¹ * (g * y * g⁻¹) * x = (g⁻¹ * x)⁻¹ * y * (g⁻¹ * x) by group]
+    exact h (g⁻¹ * x)
+
+/-- **The Frobenius kernel meets `H` exactly in the identity.**  A nonidentity element of `H` lies
+in a conjugate of `H`, namely `H` itself. -/
+theorem frobeniusKernel_inter_coe : frobeniusKernel H ∩ (H : Set G) = {1} := by
+  refine Set.Subset.antisymm (fun y hy => ?_) (fun y hy => ?_)
+  · rcases mem_frobeniusKernel.1 hy.1 with h1 | h
+    · exact h1
+    · exact absurd (by simpa using hy.2) (h 1)
+  · rw [Set.mem_singleton_iff] at hy
+    exact ⟨hy ▸ one_mem_frobeniusKernel, hy ▸ H.one_mem⟩
+
+/-- The Frobenius kernel of the whole group is trivial: every element lies in `⊤`. -/
+@[simp]
+theorem frobeniusKernel_top : frobeniusKernel (⊤ : Subgroup G) = {1} := by
+  ext y
+  simp [mem_frobeniusKernel]
+
+/-- The Frobenius kernel of the trivial subgroup is everything: no conjugate of a nonidentity
+element is the identity. -/
+@[simp]
+theorem frobeniusKernel_bot : frobeniusKernel (⊥ : Subgroup G) = Set.univ := by
+  ext y
+  simp only [mem_frobeniusKernel, Set.mem_univ, iff_true, Subgroup.mem_bot, inv_conj_eq_one_iff]
+  exact (eq_or_ne y 1).imp id fun hy _ => hy
+
+/-! ### Counting the kernel -/
+
+/-- The parametrization of the elements *outside* the Frobenius kernel by a coset of `H` together
+with a nonidentity element of `H`: the coset picks a conjugate `g H g⁻¹` through the representative
+`Quotient.out`, and the element of `H` is transported into it.  Its range is the complement of the
+kernel (`TauCeti.range_frobeniusKernelCompl`) for every `H`, and it is injective exactly when the
+conjugates of `H` meet pairwise trivially
+(`TauCeti.IsTISubgroup.frobeniusKernelCompl_injective`). -/
+private noncomputable def frobeniusKernelCompl (H : Subgroup G) :
+    (G ⧸ H) × ((H : Set G) \ {1} : Set G) → G :=
+  fun p => p.1.out * (p.2 : G) * p.1.out⁻¹
+
+private theorem range_frobeniusKernelCompl :
+    Set.range (frobeniusKernelCompl H) = (frobeniusKernel H)ᶜ := by
+  refine Set.Subset.antisymm ?_ fun y hy => ?_
+  · rintro _ ⟨⟨C, ⟨h, hhH, hh1⟩⟩, rfl⟩
+    rw [Set.mem_singleton_iff] at hh1
+    simp only [frobeniusKernelCompl, Set.mem_compl_iff, notMem_frobeniusKernel_iff, ne_eq,
+      conj_eq_one_iff]
+    refine ⟨hh1, C.out, ?_⟩
+    rw [show C.out⁻¹ * (C.out * h * C.out⁻¹) * C.out = h by group]
+    exact hhH
+  · obtain ⟨hy1, x, hx⟩ := notMem_frobeniusKernel_iff.1 hy
+    obtain ⟨s, hout⟩ := QuotientGroup.mk_out_eq_mul H x
+    refine ⟨⟨QuotientGroup.mk x, ⟨(s : G)⁻¹ * (x⁻¹ * y * x) * s, ?_, ?_⟩⟩, ?_⟩
+    · exact H.mul_mem (H.mul_mem (H.inv_mem s.2) hx) s.2
+    · rw [Set.mem_singleton_iff, show (s : G)⁻¹ * (x⁻¹ * y * x) * s
+        = (x * s)⁻¹ * y * (x * s) by group, inv_conj_eq_one_iff]
+      exact hy1
+    · simp only [frobeniusKernelCompl, hout]
+      group
+
+private theorem IsTISubgroup.frobeniusKernelCompl_injective (hH : IsTISubgroup H) :
+    Function.Injective (frobeniusKernelCompl H) := by
+  rintro ⟨C, ⟨h, hhH, hh1⟩⟩ ⟨D, ⟨h', hh'H, hh'1⟩⟩ hEq
+  rw [Set.mem_singleton_iff] at hh1
+  simp only [frobeniusKernelCompl] at hEq
+  -- The two coset representatives differ by an element conjugating `h` into `H`, so the
+  -- trivial-intersection condition puts that difference inside `H`: the cosets agree.
+  have hconj : D.out⁻¹ * C.out * h * (D.out⁻¹ * C.out)⁻¹ = h' := by
+    rw [show D.out⁻¹ * C.out * h * (D.out⁻¹ * C.out)⁻¹
+      = D.out⁻¹ * (C.out * h * C.out⁻¹) * D.out by group, hEq]
+    group
+  have hmem : D.out⁻¹ * C.out ∈ H := by
+    by_contra hx
+    exact hh1 (hH.eq_one hx hhH (hconj ▸ hh'H))
+  have hCD : C = D := by
+    have h1 : (QuotientGroup.mk C.out : G ⧸ H) = QuotientGroup.mk D.out :=
+      (QuotientGroup.eq.2 hmem).symm
+    rwa [QuotientGroup.out_eq', QuotientGroup.out_eq'] at h1
+  subst hCD
+  have hhh : h = h' := mul_left_cancel (mul_right_cancel hEq)
+  subst hhh
+  rfl
+
+/-- **The elements outside the Frobenius kernel number `|G : H| · (|H| - 1)`.**  For a
+trivial-intersection subgroup they are exactly the nonidentity elements of the conjugates of `H`,
+and each is hit once by the parametrization: such an element determines the conjugate containing
+it, hence the coset, hence the element of `H` it comes from. -/
+theorem IsTISubgroup.ncard_compl_frobeniusKernel [Finite G] (hH : IsTISubgroup H) :
+    ((frobeniusKernel H)ᶜ).ncard = H.index * (Nat.card H - 1) := by
+  have hsub : ((H : Set G) \ {1}).ncard + 1 = (H : Set G).ncard :=
+    Set.ncard_sdiff_singleton_add_one H.one_mem
+  have hcoe : (H : Set G).ncard = Nat.card H := (Nat.card_coe_set_eq (H : Set G)).symm
+  have hH1 : ((H : Set G) \ {1}).ncard = Nat.card H - 1 := by omega
+  rw [← range_frobeniusKernelCompl, ← Set.image_univ,
+    Set.ncard_image_of_injective _ hH.frobeniusKernelCompl_injective, Set.ncard_univ,
+    Nat.card_prod, ← Subgroup.index_eq_card, Nat.card_coe_set_eq, hH1]
+
+/-- **The Frobenius kernel of a trivial-intersection subgroup has `|G : H|` elements.**  The
+conjugates of `H` cover `|G : H| · (|H| - 1)` nonidentity elements between them, and
+`|G| = |G : H| · |H|`, so `|G : H|` elements are left over. -/
+theorem IsTISubgroup.ncard_frobeniusKernel [Finite G] (hH : IsTISubgroup H) :
+    (frobeniusKernel H).ncard = H.index := by
+  obtain ⟨m, hm⟩ : ∃ m, Nat.card H = m + 1 := ⟨Nat.card H - 1, by
+    have := Nat.card_pos (α := H)
+    omega⟩
+  have htotal := Set.ncard_add_ncard_compl (frobeniusKernel H)
+  have hcard := H.index_mul_card
+  rw [hH.ncard_compl_frobeniusKernel, hm, Nat.add_sub_cancel] at htotal
+  rw [hm, Nat.mul_add, Nat.mul_one] at hcard
+  omega
+
+/-- The Frobenius kernel of a trivial-intersection subgroup has `|G : H|` elements, read as the
+cardinality of its coercion to a type. -/
+theorem IsTISubgroup.natCard_frobeniusKernel [Finite G] (hH : IsTISubgroup H) :
+    Nat.card (frobeniusKernel H) = H.index :=
+  (Nat.card_coe_set_eq _).trans hH.ncard_frobeniusKernel
+
+/-- **A subgroup carried by the Frobenius kernel is a complement to `H`.**  Frobenius's theorem
+provides such a subgroup for a Frobenius complement; that it is a complement is then pure counting,
+the kernel having `|G : H|` elements and meeting `H` only in the identity.  Nothing here asserts
+that such a subgroup exists. -/
+theorem IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel [Finite G] (hH : IsTISubgroup H)
+    {N : Subgroup G} (hN : (N : Set G) = frobeniusKernel H) : N.IsComplement' H := by
+  have hcard : Nat.card N * Nat.card H = Nat.card G := by
+    rw [show Nat.card N = Nat.card (frobeniusKernel H) from Nat.card_congr (Equiv.setCongr hN),
+      hH.natCard_frobeniusKernel]
+    exact H.index_mul_card
+  refine Subgroup.isComplement'_of_card_mul_and_disjoint hcard (Subgroup.disjoint_def.2 ?_)
+  intro y hyN hyH
+  have hmem : y ∈ frobeniusKernel H ∩ (H : Set G) :=
+    ⟨hN ▸ SetLike.mem_coe.2 hyN, SetLike.mem_coe.2 hyH⟩
+  rwa [frobeniusKernel_inter_coe, Set.mem_singleton_iff] at hmem
+
+end TauCeti

--- a/TauCeti/GroupTheory/FrobeniusKernel.lean
+++ b/TauCeti/GroupTheory/FrobeniusKernel.lean
@@ -28,13 +28,14 @@ identity, it is closed under inversion and under conjugation, it meets every con
 in the identity, and — the counting statement the roadmap records — for a finite `G` it has exactly
 `|G : H|` elements.
 
-The count is the inclusion-exclusion that gives Frobenius's theorem its shape. For a
-trivial-intersection subgroup the conjugates `g H g⁻¹` meet pairwise in the identity alone and
-depend only on the coset `g H`, so the elements they cover other than `1` are indexed bijectively
-by the pairs (a coset of `H`, a nonidentity element of `H`). That parametrization is the private
-`frobeniusKernelCompl`, whose range is the complement of the kernel and which is injective exactly
-because `H` has trivial intersections; the count it yields is
-`TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, the `Set.ncard` identity
+The count is the inclusion-exclusion that gives Frobenius's theorem its shape, and it is really a
+statement about a trivial-intersection *set* `S` for `H` (`TauCeti.IsTISet`): the conjugates
+`g S g⁻¹` are pairwise disjoint for distinct cosets `g H` and depend only on the coset, so the
+elements they cover are indexed bijectively by the pairs (a coset of `H`, an element of `S`) and
+number `|G : H| · |S|`. That is `TauCeti.IsTISet.ncard_conjugatesOfSet`. The complement of the
+kernel is the set of conjugates of the nonidentity elements of `H`, which for a
+trivial-intersection subgroup is such a set (`TauCeti.IsTISubgroup.isTISet_diff_one`), and the
+count specializes to `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, the `Set.ncard` identity
 `((frobeniusKernel H)ᶜ).ncard = |G : H| · (|H| - 1)`. That identity holds for any `G`, finite or
 not, but it counts elements only when `G` is finite: for an infinite `G` both of its sides are the
 junk value `0` that `Set.ncard` and `Subgroup.index` take on infinite arguments. For a finite `G`
@@ -64,6 +65,8 @@ everything and `⊥` has index `|G|`.
 * `TauCeti.frobeniusKernel_inter_conj_eq_singleton` and
   `TauCeti.frobeniusKernel_inter_eq_singleton`: the kernel meets every conjugate of `H`, and in
   particular `H` itself, exactly in the identity.
+* `TauCeti.IsTISet.ncard_conjugatesOfSet`: the conjugates of a trivial-intersection set `S` for `H`
+  cover `|G : H| · |S|` elements, the count the kernel count specializes.
 * `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`: the `Set.ncard` identity
   `((frobeniusKernel H)ᶜ).ncard = |G : H| · (|H| - 1)`, which for a finite `G` counts the elements
   *outside* the kernel — the nonidentity elements of the conjugates of `H`, each counted once — and
@@ -76,13 +79,16 @@ everything and `⊥` has index `|G|`.
 
 ## Implementation notes
 
-The bijection is set up as a map *into* `G` out of `(G ⧸ H) × H#`, rather than as an `Equiv` onto
-the complement of the kernel, because the two facts it is used through are cleaner apart than
-bundled: that its range is the complement needs no hypothesis on `H` at all, while its injectivity
-is exactly the trivial-intersection condition. The coset representatives are `Quotient.out`, so the
-map is noncomputable and needs no well-definedness argument; the price is that hitting an element
-of the complement has to move a witness `x` to `(x H).out` by `QuotientGroup.mk_out_eq_mul`,
-conjugating the element of `H` along the way.
+The bijection is set up as a map *into* `G` out of `(G ⧸ H) × S`, rather than as an `Equiv` onto
+`Group.conjugatesOfSet S`, because the two facts it is used through are cleaner apart than bundled:
+that its range is the set of conjugates uses only that `S` is normalized by `H`, while its
+injectivity is exactly the disjointness of the distinct conjugates. The coset representatives are
+`Quotient.out`, so the map is noncomputable and needs no well-definedness argument; the price is
+that hitting a conjugate has to move a witness `x` to `(x H).out` by `QuotientGroup.mk_out_eq_mul`,
+conjugating the element of `S` along the way. The general count lives here rather than beside
+`TauCeti.IsTISet` because it is the counting half of this file's subject and needs the coset,
+index and cardinality machinery that `TauCeti/GroupTheory/TrivialIntersection.lean` does not
+import.
 
 ## References
 
@@ -205,80 +211,108 @@ theorem frobeniusKernel_bot : frobeniusKernel (⊥ : Subgroup G) = Set.univ := b
   have hconj : x⁻¹ * y * x = x⁻¹ * y * (x⁻¹)⁻¹ := by group
   exact conj_eq_one_iff.1 (hconj ▸ hx)
 
-/-! ### Counting the kernel -/
+/-! ### Counting the conjugates of a trivial-intersection set -/
 
-/-- The parametrization of the elements *outside* the Frobenius kernel by a coset of `H` together
-with a nonidentity element of `H`: the coset picks a conjugate `g H g⁻¹` through the representative
-`Quotient.out`, and the element of `H` is transported into it.  Its range is the complement of the
-kernel (`TauCeti.range_frobeniusKernelCompl`) for every `H`, and it is injective exactly when the
-conjugates of `H` meet pairwise trivially
-(`TauCeti.IsTISubgroup.frobeniusKernelCompl_injective`). -/
-private noncomputable def frobeniusKernelCompl (H : Subgroup G) :
-    (G ⧸ H) × ((H : Set G) \ {1} : Set G) → G :=
+variable {S : Set G}
+
+/-- The parametrization of the conjugates of a subset `S` of `H` by a coset of `H` together with an
+element of `S`: the coset picks a conjugator through the representative `Quotient.out`, and the
+element of `S` is transported along it.  For a trivial-intersection set its range is
+`Group.conjugatesOfSet S` (`TauCeti.IsTISet.range_conjugatesOfSetParam`, which uses only that `S`
+is normalized by `H`) and it is injective
+(`TauCeti.IsTISet.conjugatesOfSetParam_injective`, which is exactly the disjointness of the
+distinct conjugates); together those give the count
+`TauCeti.IsTISet.ncard_conjugatesOfSet`. -/
+private noncomputable def conjugatesOfSetParam (H : Subgroup G) (S : Set G) :
+    (G ⧸ H) × S → G :=
   fun p => p.1.out * (p.2 : G) * p.1.out⁻¹
 
-private theorem range_frobeniusKernelCompl :
-    Set.range (frobeniusKernelCompl H) = (frobeniusKernel H)ᶜ := by
+private theorem IsTISet.range_conjugatesOfSetParam (hS : IsTISet S H) :
+    Set.range (conjugatesOfSetParam H S) = Group.conjugatesOfSet S := by
   refine Set.Subset.antisymm ?_ fun y hy => ?_
-  · rintro _ ⟨⟨C, ⟨h, hhH, hh1⟩⟩, rfl⟩
-    rw [Set.mem_singleton_iff] at hh1
-    simp only [frobeniusKernelCompl, Set.mem_compl_iff, notMem_frobeniusKernel_iff, ne_eq,
-      conj_eq_one_iff]
-    refine ⟨hh1, C.out, ?_⟩
-    have hcancel : C.out⁻¹ * (C.out * h * C.out⁻¹) * C.out = h := by group
-    rw [hcancel]
-    exact hhH
-  · obtain ⟨hy1, x, hx⟩ := notMem_frobeniusKernel_iff.1 hy
-    obtain ⟨s, hout⟩ := QuotientGroup.mk_out_eq_mul H x
-    refine ⟨⟨QuotientGroup.mk x, ⟨(s : G)⁻¹ * (x⁻¹ * y * x) * s, ?_, ?_⟩⟩, ?_⟩
-    · exact H.mul_mem (H.mul_mem (H.inv_mem s.2) hx) s.2
-    · -- Again the conjugator is exhibited as `(x * s)⁻¹`, the form `conj_eq_one_iff` rewrites.
-      have hconj : (s : G)⁻¹ * (x⁻¹ * y * x) * s = (x * s)⁻¹ * y * ((x * s)⁻¹)⁻¹ := by group
-      rw [Set.mem_singleton_iff, hconj, conj_eq_one_iff]
-      exact hy1
-    · simp only [frobeniusKernelCompl, hout]
+  · rintro _ ⟨⟨C, s, hs⟩, rfl⟩
+    exact Group.mem_conjugatesOfSet_iff.2 ⟨s, hs, isConj_iff.2 ⟨C.out, rfl⟩⟩
+  · obtain ⟨s, hs, hconj⟩ := Group.mem_conjugatesOfSet_iff.1 hy
+    obtain ⟨x, rfl⟩ := isConj_iff.1 hconj
+    obtain ⟨h, hout⟩ := QuotientGroup.mk_out_eq_mul H x
+    refine ⟨⟨QuotientGroup.mk x, ⟨(h : G)⁻¹ * s * h, ?_⟩⟩, ?_⟩
+    · simpa using hS.conj_mem (h : G)⁻¹ (H.inv_mem h.2) s hs
+    · simp only [conjugatesOfSetParam, hout]
       group
 
-private theorem IsTISubgroup.frobeniusKernelCompl_injective (hH : IsTISubgroup H) :
-    Function.Injective (frobeniusKernelCompl H) := by
-  rintro ⟨C, ⟨h, hhH, hh1⟩⟩ ⟨D, ⟨h', hh'H, hh'1⟩⟩ hEq
-  rw [Set.mem_singleton_iff] at hh1
-  simp only [frobeniusKernelCompl] at hEq
-  -- The two coset representatives differ by an element conjugating `h` into `H`, so the
+private theorem IsTISet.conjugatesOfSetParam_injective (hS : IsTISet S H) :
+    Function.Injective (conjugatesOfSetParam H S) := by
+  rintro ⟨C, s, hs⟩ ⟨D, s', hs'⟩ hEq
+  simp only [conjugatesOfSetParam] at hEq
+  -- The two coset representatives differ by an element conjugating `s` back into `S`, so the
   -- trivial-intersection condition puts that difference inside `H`: the cosets agree.
-  have hconj : D.out⁻¹ * C.out * h * (D.out⁻¹ * C.out)⁻¹ = h' := by
-    have hshift : D.out⁻¹ * C.out * h * (D.out⁻¹ * C.out)⁻¹
-        = D.out⁻¹ * (C.out * h * C.out⁻¹) * D.out := by group
+  have hconj : D.out⁻¹ * C.out * s * (D.out⁻¹ * C.out)⁻¹ = s' := by
+    have hshift : D.out⁻¹ * C.out * s * (D.out⁻¹ * C.out)⁻¹
+        = D.out⁻¹ * (C.out * s * C.out⁻¹) * D.out := by group
     rw [hshift, hEq]
     group
   have hmem : D.out⁻¹ * C.out ∈ H := by
     by_contra hx
-    exact hh1 (hH.eq_one hx hhH (hconj ▸ hh'H))
+    exact hS.disjoint_conj _ hx s hs (hconj ▸ hs')
   have hCD : C = D := by
     have h1 : (QuotientGroup.mk C.out : G ⧸ H) = QuotientGroup.mk D.out :=
       (QuotientGroup.eq.2 hmem).symm
     rwa [QuotientGroup.out_eq', QuotientGroup.out_eq'] at h1
   subst hCD
-  have hhh : h = h' := mul_left_cancel (mul_right_cancel hEq)
-  subst hhh
+  have hss : s = s' := mul_left_cancel (mul_right_cancel hEq)
+  subst hss
   rfl
 
+/-- **The conjugates of a trivial-intersection set have `Set.ncard` equal to `|G : H| · |S|`.**  The
+conjugate `g S g⁻¹` depends only on the coset `g H`, because `S` is normalized by `H`, and distinct
+cosets give disjoint conjugates, so the elements covered are indexed bijectively by the pairs (a
+coset of `H`, an element of `S`).  The parametrization argument is uniform, so no finiteness is
+assumed — but this is an `ncard` identity, not an element count, unless the sets involved are
+finite: otherwise both sides are the junk value `0` that `Set.ncard` and `Subgroup.index` take on
+infinite arguments.  The Frobenius kernel count
+`TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel` is the case `S = H \ {1}`. -/
+theorem IsTISet.ncard_conjugatesOfSet (hS : IsTISet S H) :
+    (Group.conjugatesOfSet S).ncard = H.index * S.ncard := by
+  rw [← hS.range_conjugatesOfSetParam,
+    Set.ncard_range_of_injective hS.conjugatesOfSetParam_injective, Nat.card_prod,
+    ← Subgroup.index_eq_card, Nat.card_coe_set_eq]
+
+/-! ### Counting the kernel -/
+
+/-- The complement of the Frobenius kernel is the set of conjugates of the nonidentity elements of
+`H`: lying outside the kernel means being a nonidentity element of some conjugate of `H`, and
+conjugation fixes the identity. -/
+private theorem compl_frobeniusKernel (H : Subgroup G) :
+    (frobeniusKernel H)ᶜ = Group.conjugatesOfSet ((H : Set G) \ {1}) := by
+  ext y
+  simp only [Set.mem_compl_iff, notMem_frobeniusKernel_iff, Group.mem_conjugatesOfSet_iff,
+    Set.mem_sdiff, SetLike.mem_coe, Set.mem_singleton_iff, ne_eq]
+  constructor
+  · rintro ⟨hy1, x, hx⟩
+    refine ⟨x⁻¹ * y * x, ⟨hx, ?_⟩, isConj_iff.2 ⟨x, by group⟩⟩
+    -- `conj_eq_one_iff` is stated for `a * y * a⁻¹`, so the conjugator is exhibited as `x⁻¹`.
+    have hconj : x⁻¹ * y * x = x⁻¹ * y * (x⁻¹)⁻¹ := by group
+    rw [hconj, conj_eq_one_iff]
+    exact hy1
+  · rintro ⟨a, ⟨haH, ha1⟩, hconj⟩
+    obtain ⟨x, rfl⟩ := isConj_iff.1 hconj
+    refine ⟨fun h => ha1 (conj_eq_one_iff.1 h), x, ?_⟩
+    have hcancel : x⁻¹ * (x * a * x⁻¹) * x = a := by group
+    rw [hcancel]
+    exact haH
+
 /-- **The complement of the Frobenius kernel has `Set.ncard` equal to `|G : H| · (|H| - 1)`.**  For
-a trivial-intersection subgroup the elements outside the kernel are exactly the nonidentity elements
-of the conjugates of `H`, and each is hit once by the parametrization: such an element determines
-the conjugate containing it, hence the coset, hence the element of `H` it comes from.  The
-parametrization argument is uniform, so no finiteness is assumed — but this is an `ncard` identity,
-not an element count, unless `G` is finite: for an infinite `G` both sides are the junk value `0`
-that `Set.ncard` and `Subgroup.index` take on infinite arguments.  The genuine count is
-`TauCeti.IsTISubgroup.ncard_frobeniusKernel`, stated for a finite `G`. -/
+a trivial-intersection subgroup the elements outside the kernel are exactly the conjugates of the
+nonidentity elements of `H`, which `TauCeti.IsTISet.ncard_conjugatesOfSet` counts as `|G : H|`
+times the `|H| - 1` elements of `H` that are conjugated.  No finiteness is assumed — but this is an
+`ncard` identity, not an element count, unless `G` is finite: for an infinite `G` both sides are
+the junk value `0` that `Set.ncard` and `Subgroup.index` take on infinite arguments.  The genuine
+count is `TauCeti.IsTISubgroup.ncard_frobeniusKernel`, stated for a finite `G`. -/
 theorem IsTISubgroup.ncard_compl_frobeniusKernel (hH : IsTISubgroup H) :
     ((frobeniusKernel H)ᶜ).ncard = H.index * (Nat.card H - 1) := by
   have hcoe : (H : Set G).ncard = Nat.card H := (Nat.card_coe_set_eq (H : Set G)).symm
-  have hH1 : ((H : Set G) \ {1}).ncard = Nat.card H - 1 := by
-    rw [Set.ncard_sdiff_singleton_of_mem H.one_mem, hcoe]
-  rw [← range_frobeniusKernelCompl,
-    Set.ncard_range_of_injective hH.frobeniusKernelCompl_injective, Nat.card_prod,
-    ← Subgroup.index_eq_card, Nat.card_coe_set_eq, hH1]
+  rw [compl_frobeniusKernel, hH.isTISet_diff_one.ncard_conjugatesOfSet,
+    Set.ncard_sdiff_singleton_of_mem H.one_mem, hcoe]
 
 /-- **The Frobenius kernel of a trivial-intersection subgroup of a finite group has `|G : H|`
 elements.**  The conjugates of `H` cover `|G : H| · (|H| - 1)` nonidentity elements between them,

--- a/TauCeti/GroupTheory/FrobeniusKernel.lean
+++ b/TauCeti/GroupTheory/FrobeniusKernel.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.Complement
-public import Mathlib.GroupTheory.Index
 public import TauCeti.GroupTheory.TrivialIntersection
 
 /-!
@@ -17,30 +16,38 @@ lying in no conjugate of `H`,
 
 `frobeniusKernel H = {1} ∪ (G ∖ ⋃_g g H g⁻¹)`.
 
-Frobenius's theorem says that when `H` is a Frobenius complement — proper, nontrivial, and meeting
-each of its distinct conjugates trivially (`TauCeti.IsFrobeniusComplement`) — this set is a normal
-subgroup, and that is not elementary: the known proofs go through the character theory of `G`.
-What *is* elementary, and is what this file proves, is everything about the kernel except its
-closure under multiplication: it contains the identity, it is closed under inversion and under
-conjugation, it meets `H` only in the identity, and — the counting statement the roadmap records —
-it has exactly `|G : H|` elements.
+That union of conjugates is Mathlib's `Group.conjugatesOfSet (H : Set G)`, the set of elements
+conjugate to an element of `H`.
+
+Frobenius's theorem says that when `G` is finite and `H` is a Frobenius complement — proper,
+nontrivial, and meeting each of its distinct conjugates trivially
+(`TauCeti.IsFrobeniusComplement`) — this set is a normal subgroup, and that is not elementary: the
+known proofs go through the character theory of `G`. What *is* elementary, and is what this file
+proves, is everything about the kernel except its closure under multiplication: it contains the
+identity, it is closed under inversion and under conjugation, it meets every conjugate of `H` only
+in the identity, and — the counting statement the roadmap records — for a finite `G` it has exactly
+`|G : H|` elements.
 
 The count is the inclusion-exclusion that gives Frobenius's theorem its shape. For a
 trivial-intersection subgroup the conjugates `g H g⁻¹` meet pairwise in the identity alone and
 depend only on the coset `g H`, so the elements they cover other than `1` are indexed bijectively
-by the pairs (a coset of `H`, a nonidentity element of `H`); there are `|G : H| · (|H| - 1)` of
-them, and the remaining `|G| - |G : H| · (|H| - 1) = |G : H|` elements of `G` are the kernel. That
-bijection is `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, and the rest is arithmetic.
+by the pairs (a coset of `H`, a nonidentity element of `H`). That parametrization is the private
+`frobeniusKernelCompl`, whose range is the complement of the kernel and which is injective exactly
+because `H` has trivial intersections; the count it yields is
+`TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, saying — for any `G`, finite or not — that there
+are `|G : H| · (|H| - 1)` elements outside the kernel. For a finite `G` the remaining
+`|G| - |G : H| · (|H| - 1) = |G : H|` elements are the kernel, and the rest is arithmetic.
 
 Together with normality the count is exactly what makes the kernel a *complement*:
-`TauCeti.IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel` says that a subgroup whose carrier
-is the Frobenius kernel is automatically a complement to `H`, so once Frobenius's theorem supplies
-the subgroup, the semidirect decomposition `G = N ⋊ H` is free. Nothing here asserts that a
-subgroup with that carrier exists.
+`TauCeti.IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel` says that, for a finite `G`, a
+subgroup whose carrier is the Frobenius kernel is automatically a complement to `H`, so once
+Frobenius's theorem supplies the subgroup, the semidirect decomposition `G = N ⋊ H` is free.
+Nothing here asserts that a subgroup with that carrier exists.
 
-No hypothesis beyond `TauCeti.IsTISubgroup` is needed for the count, and the two degenerate cases
-are honest instances rather than exclusions: `frobeniusKernel ⊤ = {1}` has one element and `⊤` has
-index `1`, while `frobeniusKernel ⊥` is everything and `⊥` has index `|G|`.
+No subgroup hypothesis beyond `TauCeti.IsTISubgroup` is needed for the count once `G` is finite, and
+the two degenerate cases are honest instances rather than exclusions:
+`frobeniusKernel ⊤ = {1}` has one element and `⊤` has index `1`, while `frobeniusKernel ⊥` is
+everything and `⊥` has index `|G|`.
 
 ## Main definitions
 
@@ -51,13 +58,16 @@ index `1`, while `frobeniusKernel ⊥` is everything and `⊥` has index `|G|`.
 * `TauCeti.mem_frobeniusKernel`: membership, elementwise.
 * `TauCeti.inv_mem_frobeniusKernel_iff` and `TauCeti.conj_mem_frobeniusKernel_iff`: the kernel is
   closed under inversion and invariant under conjugation, for every subgroup `H`.
-* `TauCeti.frobeniusKernel_inter_coe`: the kernel meets `H` exactly in the identity.
+* `TauCeti.frobeniusKernel_inter_conj_eq_singleton` and
+  `TauCeti.frobeniusKernel_inter_eq_singleton`: the kernel meets every conjugate of `H`, and in
+  particular `H` itself, exactly in the identity.
 * `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`: the elements *outside* the kernel are the
   `|G : H| · (|H| - 1)` nonidentity elements of the conjugates of `H`, each counted once.
 * `TauCeti.IsTISubgroup.ncard_frobeniusKernel` and
-  `TauCeti.IsTISubgroup.natCard_frobeniusKernel`: **the kernel has `|G : H|` elements.**
-* `TauCeti.IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel`: a subgroup whose carrier is the
-  kernel is a complement to `H`.
+  `TauCeti.IsTISubgroup.natCard_frobeniusKernel`: **for a finite `G` the kernel has `|G : H|`
+  elements.**
+* `TauCeti.IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel`: for a finite `G`, a subgroup
+  whose carrier is the kernel is a complement to `H`.
 
 ## Implementation notes
 
@@ -85,24 +95,40 @@ open scoped Pointwise
 variable {G : Type*} [Group G] {H : Subgroup G}
 
 /-- **The Frobenius kernel** of a subgroup: the identity together with the elements of `G` lying in
-no conjugate of `H`.  For a Frobenius complement `H` this set is a normal subgroup of `G`, but that
-is Frobenius's theorem and needs character theory; as a *set* it is available for any `H`, and
+no conjugate of `H`, the conjugates being collected by `Group.conjugatesOfSet`.  For a Frobenius
+complement `H` of a finite group this set is a normal subgroup of `G`, but that is Frobenius's
+theorem and needs character theory; as a *set* it is available for any `H`, and
 `TauCeti.mem_frobeniusKernel` is the elementwise description everything below uses. -/
 def frobeniusKernel (H : Subgroup G) : Set G :=
-  {1} ∪ (⋃ g : G, ((MulAut.conj g • H : Subgroup G) : Set G))ᶜ
+  {1} ∪ (Group.conjugatesOfSet (H : Set G))ᶜ
+
+/-- The Frobenius kernel is the identity together with the complement of the set of conjugates of
+elements of `H`, by definition. -/
+theorem frobeniusKernel_def (H : Subgroup G) :
+    frobeniusKernel H = {1} ∪ (Group.conjugatesOfSet (H : Set G))ᶜ := (rfl)
 
 /-- **Membership in the Frobenius kernel**: an element is the identity, or no conjugate of it lands
 in `H`. -/
 theorem mem_frobeniusKernel {y : G} :
     y ∈ frobeniusKernel H ↔ y = 1 ∨ ∀ x : G, x⁻¹ * y * x ∉ H := by
-  have key : ∀ g : G, y ∈ (MulAut.conj g • H : Subgroup G) ↔ g⁻¹ * y * g ∈ H := fun g => by
-    rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem]
-    simp [MulAut.smul_def]
-  simp only [frobeniusKernel, Set.mem_union, Set.mem_singleton_iff, Set.mem_compl_iff,
-    Set.mem_iUnion, not_exists, SetLike.mem_coe, key]
+  have key : y ∈ Group.conjugatesOfSet (H : Set G) ↔ ∃ x : G, x⁻¹ * y * x ∈ H := by
+    rw [Group.mem_conjugatesOfSet_iff]
+    constructor
+    · rintro ⟨a, ha, hc⟩
+      obtain ⟨c, rfl⟩ := isConj_iff.1 hc
+      have hcancel : c⁻¹ * (c * a * c⁻¹) * c = a := by group
+      refine ⟨c, ?_⟩
+      rw [hcancel]
+      exact ha
+    · rintro ⟨x, hx⟩
+      have hcancel : x * (x⁻¹ * y * x) * x⁻¹ = y := by group
+      exact ⟨x⁻¹ * y * x, hx, isConj_iff.2 ⟨x, hcancel⟩⟩
+  simp only [frobeniusKernel_def, Set.mem_union, Set.mem_singleton_iff, Set.mem_compl_iff, key,
+    not_exists]
 
 /-- Being outside the Frobenius kernel means being a nonidentity element of some conjugate of
 `H`. -/
+@[simp]
 theorem notMem_frobeniusKernel_iff {y : G} :
     y ∉ frobeniusKernel H ↔ y ≠ 1 ∧ ∃ x : G, x⁻¹ * y * x ∈ H := by
   rw [mem_frobeniusKernel]
@@ -113,12 +139,6 @@ theorem notMem_frobeniusKernel_iff {y : G} :
 theorem one_mem_frobeniusKernel : (1 : G) ∈ frobeniusKernel H :=
   mem_frobeniusKernel.2 (Or.inl rfl)
 
-/-- A conjugate of an element is the identity only if the element is; the `x⁻¹ • x` form of
-Mathlib's `conj_eq_one_iff`, which is how the conjugates appear in
-`TauCeti.mem_frobeniusKernel`. -/
-private theorem inv_conj_eq_one_iff {y x : G} : x⁻¹ * y * x = 1 ↔ y = 1 := by
-  simpa using conj_eq_one_iff (a := x⁻¹) (b := y)
-
 /-- The Frobenius kernel is closed under inversion: `x⁻¹ y⁻¹ x` is the inverse of `x⁻¹ y x`, and a
 subgroup contains an element exactly when it contains its inverse. -/
 @[simp]
@@ -126,7 +146,8 @@ theorem inv_mem_frobeniusKernel_iff {y : G} :
     y⁻¹ ∈ frobeniusKernel H ↔ y ∈ frobeniusKernel H := by
   simp only [mem_frobeniusKernel, inv_eq_one]
   refine or_congr Iff.rfl (forall_congr' fun x => not_congr ?_)
-  rw [show x⁻¹ * y⁻¹ * x = (x⁻¹ * y * x)⁻¹ by group, H.inv_mem_iff]
+  have hinv : x⁻¹ * y⁻¹ * x = (x⁻¹ * y * x)⁻¹ := by group
+  rw [hinv, H.inv_mem_iff]
 
 /-- The Frobenius kernel is invariant under conjugation: it is cut out by a condition quantified
 over all conjugates, which conjugating merely reindexes.  This is the half of normality that costs
@@ -136,20 +157,32 @@ theorem conj_mem_frobeniusKernel_iff {y g : G} :
     g * y * g⁻¹ ∈ frobeniusKernel H ↔ y ∈ frobeniusKernel H := by
   simp only [mem_frobeniusKernel, conj_eq_one_iff]
   refine or_congr Iff.rfl ⟨fun h x => ?_, fun h x => ?_⟩
-  · rw [show x⁻¹ * y * x = (g * x)⁻¹ * (g * y * g⁻¹) * (g * x) by group]
+  · have hreindex : x⁻¹ * y * x = (g * x)⁻¹ * (g * y * g⁻¹) * (g * x) := by group
+    rw [hreindex]
     exact h (g * x)
-  · rw [show x⁻¹ * (g * y * g⁻¹) * x = (g⁻¹ * x)⁻¹ * y * (g⁻¹ * x) by group]
+  · have hreindex : x⁻¹ * (g * y * g⁻¹) * x = (g⁻¹ * x)⁻¹ * y * (g⁻¹ * x) := by group
+    rw [hreindex]
     exact h (g⁻¹ * x)
 
-/-- **The Frobenius kernel meets `H` exactly in the identity.**  A nonidentity element of `H` lies
-in a conjugate of `H`, namely `H` itself. -/
-theorem frobeniusKernel_inter_coe : frobeniusKernel H ∩ (H : Set G) = {1} := by
+/-- **The Frobenius kernel meets each conjugate of `H` exactly in the identity.**  A nonidentity
+element of `g H g⁻¹` lies in a conjugate of `H`, so it is outside the kernel. -/
+theorem frobeniusKernel_inter_conj_eq_singleton (g : G) :
+    frobeniusKernel H ∩ ((MulAut.conj g • H : Subgroup G) : Set G) = {1} := by
+  have key : ∀ y : G, y ∈ (MulAut.conj g • H : Subgroup G) ↔ g⁻¹ * y * g ∈ H := fun y => by
+    rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem]
+    simp [MulAut.smul_def]
   refine Set.Subset.antisymm (fun y hy => ?_) (fun y hy => ?_)
   · rcases mem_frobeniusKernel.1 hy.1 with h1 | h
     · exact h1
-    · exact absurd (by simpa using hy.2) (h 1)
+    · exact absurd ((key y).1 hy.2) (h g)
   · rw [Set.mem_singleton_iff] at hy
-    exact ⟨hy ▸ one_mem_frobeniusKernel, hy ▸ H.one_mem⟩
+    exact ⟨hy ▸ one_mem_frobeniusKernel, hy ▸ (MulAut.conj g • H : Subgroup G).one_mem⟩
+
+/-- **The Frobenius kernel meets `H` exactly in the identity**, the case `g = 1` of
+`TauCeti.frobeniusKernel_inter_conj_eq_singleton`. -/
+@[simp]
+theorem frobeniusKernel_inter_eq_singleton : frobeniusKernel H ∩ (H : Set G) = {1} := by
+  simpa using frobeniusKernel_inter_conj_eq_singleton (H := H) 1
 
 /-- The Frobenius kernel of the whole group is trivial: every element lies in `⊤`. -/
 @[simp]
@@ -162,8 +195,11 @@ element is the identity. -/
 @[simp]
 theorem frobeniusKernel_bot : frobeniusKernel (⊥ : Subgroup G) = Set.univ := by
   ext y
-  simp only [mem_frobeniusKernel, Set.mem_univ, iff_true, Subgroup.mem_bot, inv_conj_eq_one_iff]
-  exact (eq_or_ne y 1).imp id fun hy _ => hy
+  simp only [mem_frobeniusKernel, Set.mem_univ, iff_true, Subgroup.mem_bot]
+  refine (eq_or_ne y 1).imp id fun hy x hx => hy ?_
+  -- `conj_eq_one_iff` is stated for `a * y * a⁻¹`, so the conjugator is exhibited as `x⁻¹`.
+  have hconj : x⁻¹ * y * x = x⁻¹ * y * (x⁻¹)⁻¹ := by group
+  exact conj_eq_one_iff.1 (hconj ▸ hx)
 
 /-! ### Counting the kernel -/
 
@@ -185,14 +221,16 @@ private theorem range_frobeniusKernelCompl :
     simp only [frobeniusKernelCompl, Set.mem_compl_iff, notMem_frobeniusKernel_iff, ne_eq,
       conj_eq_one_iff]
     refine ⟨hh1, C.out, ?_⟩
-    rw [show C.out⁻¹ * (C.out * h * C.out⁻¹) * C.out = h by group]
+    have hcancel : C.out⁻¹ * (C.out * h * C.out⁻¹) * C.out = h := by group
+    rw [hcancel]
     exact hhH
   · obtain ⟨hy1, x, hx⟩ := notMem_frobeniusKernel_iff.1 hy
     obtain ⟨s, hout⟩ := QuotientGroup.mk_out_eq_mul H x
     refine ⟨⟨QuotientGroup.mk x, ⟨(s : G)⁻¹ * (x⁻¹ * y * x) * s, ?_, ?_⟩⟩, ?_⟩
     · exact H.mul_mem (H.mul_mem (H.inv_mem s.2) hx) s.2
-    · rw [Set.mem_singleton_iff, show (s : G)⁻¹ * (x⁻¹ * y * x) * s
-        = (x * s)⁻¹ * y * (x * s) by group, inv_conj_eq_one_iff]
+    · -- Again the conjugator is exhibited as `(x * s)⁻¹`, the form `conj_eq_one_iff` rewrites.
+      have hconj : (s : G)⁻¹ * (x⁻¹ * y * x) * s = (x * s)⁻¹ * y * ((x * s)⁻¹)⁻¹ := by group
+      rw [Set.mem_singleton_iff, hconj, conj_eq_one_iff]
       exact hy1
     · simp only [frobeniusKernelCompl, hout]
       group
@@ -205,8 +243,9 @@ private theorem IsTISubgroup.frobeniusKernelCompl_injective (hH : IsTISubgroup H
   -- The two coset representatives differ by an element conjugating `h` into `H`, so the
   -- trivial-intersection condition puts that difference inside `H`: the cosets agree.
   have hconj : D.out⁻¹ * C.out * h * (D.out⁻¹ * C.out)⁻¹ = h' := by
-    rw [show D.out⁻¹ * C.out * h * (D.out⁻¹ * C.out)⁻¹
-      = D.out⁻¹ * (C.out * h * C.out⁻¹) * D.out by group, hEq]
+    have hshift : D.out⁻¹ * C.out * h * (D.out⁻¹ * C.out)⁻¹
+        = D.out⁻¹ * (C.out * h * C.out⁻¹) * D.out := by group
+    rw [hshift, hEq]
     group
   have hmem : D.out⁻¹ * C.out ∈ H := by
     by_contra hx
@@ -223,20 +262,20 @@ private theorem IsTISubgroup.frobeniusKernelCompl_injective (hH : IsTISubgroup H
 /-- **The elements outside the Frobenius kernel number `|G : H| · (|H| - 1)`.**  For a
 trivial-intersection subgroup they are exactly the nonidentity elements of the conjugates of `H`,
 and each is hit once by the parametrization: such an element determines the conjugate containing
-it, hence the coset, hence the element of `H` it comes from. -/
-theorem IsTISubgroup.ncard_compl_frobeniusKernel [Finite G] (hH : IsTISubgroup H) :
+it, hence the coset, hence the element of `H` it comes from.  The parametrization argument is
+uniform, so no finiteness is assumed; when `G` is infinite both sides are `0`. -/
+theorem IsTISubgroup.ncard_compl_frobeniusKernel (hH : IsTISubgroup H) :
     ((frobeniusKernel H)ᶜ).ncard = H.index * (Nat.card H - 1) := by
-  have hsub : ((H : Set G) \ {1}).ncard + 1 = (H : Set G).ncard :=
-    Set.ncard_sdiff_singleton_add_one H.one_mem
   have hcoe : (H : Set G).ncard = Nat.card H := (Nat.card_coe_set_eq (H : Set G)).symm
-  have hH1 : ((H : Set G) \ {1}).ncard = Nat.card H - 1 := by omega
-  rw [← range_frobeniusKernelCompl, ← Set.image_univ,
-    Set.ncard_image_of_injective _ hH.frobeniusKernelCompl_injective, Set.ncard_univ,
-    Nat.card_prod, ← Subgroup.index_eq_card, Nat.card_coe_set_eq, hH1]
+  have hH1 : ((H : Set G) \ {1}).ncard = Nat.card H - 1 := by
+    rw [Set.ncard_sdiff_singleton_of_mem H.one_mem, hcoe]
+  rw [← range_frobeniusKernelCompl,
+    Set.ncard_range_of_injective hH.frobeniusKernelCompl_injective, Nat.card_prod,
+    ← Subgroup.index_eq_card, Nat.card_coe_set_eq, hH1]
 
-/-- **The Frobenius kernel of a trivial-intersection subgroup has `|G : H|` elements.**  The
-conjugates of `H` cover `|G : H| · (|H| - 1)` nonidentity elements between them, and
-`|G| = |G : H| · |H|`, so `|G : H|` elements are left over. -/
+/-- **The Frobenius kernel of a trivial-intersection subgroup of a finite group has `|G : H|`
+elements.**  The conjugates of `H` cover `|G : H| · (|H| - 1)` nonidentity elements between them,
+and `|G| = |G : H| · |H|`, so `|G : H|` elements are left over. -/
 theorem IsTISubgroup.ncard_frobeniusKernel [Finite G] (hH : IsTISubgroup H) :
     (frobeniusKernel H).ncard = H.index := by
   obtain ⟨m, hm⟩ : ∃ m, Nat.card H = m + 1 := ⟨Nat.card H - 1, by
@@ -248,26 +287,26 @@ theorem IsTISubgroup.ncard_frobeniusKernel [Finite G] (hH : IsTISubgroup H) :
   rw [hm, Nat.mul_add, Nat.mul_one] at hcard
   omega
 
-/-- The Frobenius kernel of a trivial-intersection subgroup has `|G : H|` elements, read as the
-cardinality of its coercion to a type. -/
+/-- The Frobenius kernel of a trivial-intersection subgroup of a finite group has `|G : H|`
+elements, read as the cardinality of its coercion to a type. -/
 theorem IsTISubgroup.natCard_frobeniusKernel [Finite G] (hH : IsTISubgroup H) :
     Nat.card (frobeniusKernel H) = H.index :=
   (Nat.card_coe_set_eq _).trans hH.ncard_frobeniusKernel
 
-/-- **A subgroup carried by the Frobenius kernel is a complement to `H`.**  Frobenius's theorem
-provides such a subgroup for a Frobenius complement; that it is a complement is then pure counting,
-the kernel having `|G : H|` elements and meeting `H` only in the identity.  Nothing here asserts
-that such a subgroup exists. -/
+/-- **A subgroup of a finite group carried by the Frobenius kernel is a complement to `H`.**
+Frobenius's theorem provides such a subgroup for a Frobenius complement; that it is a complement is
+then pure counting, the kernel having `|G : H|` elements and meeting `H` only in the identity.
+Nothing here asserts that such a subgroup exists. -/
 theorem IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel [Finite G] (hH : IsTISubgroup H)
     {N : Subgroup G} (hN : (N : Set G) = frobeniusKernel H) : N.IsComplement' H := by
   have hcard : Nat.card N * Nat.card H = Nat.card G := by
-    rw [show Nat.card N = Nat.card (frobeniusKernel H) from Nat.card_congr (Equiv.setCongr hN),
-      hH.natCard_frobeniusKernel]
+    have hcardN : Nat.card N = Nat.card (frobeniusKernel H) := Nat.card_congr (Equiv.setCongr hN)
+    rw [hcardN, hH.natCard_frobeniusKernel]
     exact H.index_mul_card
   refine Subgroup.isComplement'_of_card_mul_and_disjoint hcard (Subgroup.disjoint_def.2 ?_)
   intro y hyN hyH
   have hmem : y ∈ frobeniusKernel H ∩ (H : Set G) :=
     ⟨hN ▸ SetLike.mem_coe.2 hyN, SetLike.mem_coe.2 hyH⟩
-  rwa [frobeniusKernel_inter_coe, Set.mem_singleton_iff] at hmem
+  rwa [frobeniusKernel_inter_eq_singleton, Set.mem_singleton_iff] at hmem
 
 end TauCeti

--- a/TauCeti/GroupTheory/FrobeniusKernel.lean
+++ b/TauCeti/GroupTheory/FrobeniusKernel.lean
@@ -63,7 +63,7 @@ everything and `⊥` has index `|G|`.
 * `TauCeti.mem_frobeniusKernel`: membership, elementwise.
 * `TauCeti.inv_mem_frobeniusKernel_iff` and `TauCeti.conj_mem_frobeniusKernel_iff`: the kernel is
   closed under inversion and invariant under conjugation, for every subgroup `H`.
-* `TauCeti.frobeniusKernel_inter_conj_eq_singleton` and
+* `TauCeti.frobeniusKernel_inter_conj_smul_eq_singleton` and
   `TauCeti.frobeniusKernel_inter_eq_singleton`: the kernel meets every conjugate of `H`, and in
   particular `H` itself, exactly in the identity.
 * `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`: the `Set.ncard` identity
@@ -161,7 +161,7 @@ theorem conj_mem_frobeniusKernel_iff {y g : G} :
 /-- **The Frobenius kernel meets each conjugate of `H` exactly in the identity.**  A nonidentity
 element of `g H g⁻¹` lies in a conjugate of `H`, so it is outside the kernel. -/
 @[simp]
-theorem frobeniusKernel_inter_conj_eq_singleton (g : G) :
+theorem frobeniusKernel_inter_conj_smul_eq_singleton (g : G) :
     frobeniusKernel H ∩ MulAut.conj g • (H : Set G) = {1} := by
   have key : ∀ y : G, y ∈ MulAut.conj g • (H : Set G) ↔ g⁻¹ * y * g ∈ H := fun y => by
     rw [Set.mem_smul_set_iff_inv_smul_mem]
@@ -175,10 +175,10 @@ theorem frobeniusKernel_inter_conj_eq_singleton (g : G) :
     exact ⟨one_mem_frobeniusKernel, (key 1).2 (by simp)⟩
 
 /-- **The Frobenius kernel meets `H` exactly in the identity**, the case `g = 1` of
-`TauCeti.frobeniusKernel_inter_conj_eq_singleton`. -/
+`TauCeti.frobeniusKernel_inter_conj_smul_eq_singleton`. -/
 @[simp]
 theorem frobeniusKernel_inter_eq_singleton : frobeniusKernel H ∩ (H : Set G) = {1} := by
-  simpa using frobeniusKernel_inter_conj_eq_singleton (H := H) 1
+  simpa using frobeniusKernel_inter_conj_smul_eq_singleton (H := H) 1
 
 /-- The Frobenius kernel of the whole group is trivial: every element lies in `⊤`. -/
 @[simp]

--- a/TauCeti/GroupTheory/FrobeniusKernel.lean
+++ b/TauCeti/GroupTheory/FrobeniusKernel.lean
@@ -34,8 +34,11 @@ depend only on the coset `g H`, so the elements they cover other than `1` are in
 by the pairs (a coset of `H`, a nonidentity element of `H`). That parametrization is the private
 `frobeniusKernelCompl`, whose range is the complement of the kernel and which is injective exactly
 because `H` has trivial intersections; the count it yields is
-`TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, saying — for any `G`, finite or not — that there
-are `|G : H| · (|H| - 1)` elements outside the kernel. For a finite `G` the remaining
+`TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, the `Set.ncard` identity
+`((frobeniusKernel H)ᶜ).ncard = |G : H| · (|H| - 1)`. That identity holds for any `G`, finite or
+not, but it counts elements only when `G` is finite: for an infinite `G` both of its sides are the
+junk value `0` that `Set.ncard` and `Subgroup.index` take on infinite arguments. For a finite `G`
+there are indeed `|G : H| · (|H| - 1)` elements outside the kernel, and the remaining
 `|G| - |G : H| · (|H| - 1) = |G : H|` elements are the kernel, and the rest is arithmetic.
 
 Together with normality the count is exactly what makes the kernel a *complement*:
@@ -61,8 +64,10 @@ everything and `⊥` has index `|G|`.
 * `TauCeti.frobeniusKernel_inter_conj_eq_singleton` and
   `TauCeti.frobeniusKernel_inter_eq_singleton`: the kernel meets every conjugate of `H`, and in
   particular `H` itself, exactly in the identity.
-* `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`: the elements *outside* the kernel are the
-  `|G : H| · (|H| - 1)` nonidentity elements of the conjugates of `H`, each counted once.
+* `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`: the `Set.ncard` identity
+  `((frobeniusKernel H)ᶜ).ncard = |G : H| · (|H| - 1)`, which for a finite `G` counts the elements
+  *outside* the kernel — the nonidentity elements of the conjugates of `H`, each counted once — and
+  for an infinite `G` reads `0 = 0`.
 * `TauCeti.IsTISubgroup.ncard_frobeniusKernel` and
   `TauCeti.IsTISubgroup.natCard_frobeniusKernel`: **for a finite `G` the kernel has `|G : H|`
   elements.**
@@ -149,34 +154,33 @@ theorem inv_mem_frobeniusKernel_iff {y : G} :
   have hinv : x⁻¹ * y⁻¹ * x = (x⁻¹ * y * x)⁻¹ := by group
   rw [hinv, H.inv_mem_iff]
 
-/-- The Frobenius kernel is invariant under conjugation: it is cut out by a condition quantified
-over all conjugates, which conjugating merely reindexes.  This is the half of normality that costs
-nothing; closure under multiplication is Frobenius's theorem. -/
+/-- The Frobenius kernel is invariant under conjugation: it is the identity together with the
+complement of a conjugation-closed set, and `Group.conj_mem_conjugatesOfSet` is that closure.  This
+is the half of normality that costs nothing; closure under multiplication is Frobenius's theorem. -/
 @[simp]
 theorem conj_mem_frobeniusKernel_iff {y g : G} :
     g * y * g⁻¹ ∈ frobeniusKernel H ↔ y ∈ frobeniusKernel H := by
-  simp only [mem_frobeniusKernel, conj_eq_one_iff]
-  refine or_congr Iff.rfl ⟨fun h x => ?_, fun h x => ?_⟩
-  · have hreindex : x⁻¹ * y * x = (g * x)⁻¹ * (g * y * g⁻¹) * (g * x) := by group
-    rw [hreindex]
-    exact h (g * x)
-  · have hreindex : x⁻¹ * (g * y * g⁻¹) * x = (g⁻¹ * x)⁻¹ * y * (g⁻¹ * x) := by group
-    rw [hreindex]
-    exact h (g⁻¹ * x)
+  simp only [frobeniusKernel_def, Set.mem_union, Set.mem_singleton_iff, Set.mem_compl_iff,
+    conj_eq_one_iff]
+  refine or_congr Iff.rfl (not_congr ⟨fun h => ?_, Group.conj_mem_conjugatesOfSet⟩)
+  have hcancel : g⁻¹ * (g * y * g⁻¹) * g⁻¹⁻¹ = y := by group
+  exact hcancel ▸ Group.conj_mem_conjugatesOfSet h
 
 /-- **The Frobenius kernel meets each conjugate of `H` exactly in the identity.**  A nonidentity
 element of `g H g⁻¹` lies in a conjugate of `H`, so it is outside the kernel. -/
+@[simp]
 theorem frobeniusKernel_inter_conj_eq_singleton (g : G) :
-    frobeniusKernel H ∩ ((MulAut.conj g • H : Subgroup G) : Set G) = {1} := by
-  have key : ∀ y : G, y ∈ (MulAut.conj g • H : Subgroup G) ↔ g⁻¹ * y * g ∈ H := fun y => by
-    rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem]
+    frobeniusKernel H ∩ MulAut.conj g • (H : Set G) = {1} := by
+  have key : ∀ y : G, y ∈ MulAut.conj g • (H : Set G) ↔ g⁻¹ * y * g ∈ H := fun y => by
+    rw [Set.mem_smul_set_iff_inv_smul_mem]
     simp [MulAut.smul_def]
   refine Set.Subset.antisymm (fun y hy => ?_) (fun y hy => ?_)
   · rcases mem_frobeniusKernel.1 hy.1 with h1 | h
     · exact h1
     · exact absurd ((key y).1 hy.2) (h g)
   · rw [Set.mem_singleton_iff] at hy
-    exact ⟨hy ▸ one_mem_frobeniusKernel, hy ▸ (MulAut.conj g • H : Subgroup G).one_mem⟩
+    subst hy
+    exact ⟨one_mem_frobeniusKernel, (key 1).2 (by simp)⟩
 
 /-- **The Frobenius kernel meets `H` exactly in the identity**, the case `g = 1` of
 `TauCeti.frobeniusKernel_inter_conj_eq_singleton`. -/
@@ -259,11 +263,14 @@ private theorem IsTISubgroup.frobeniusKernelCompl_injective (hH : IsTISubgroup H
   subst hhh
   rfl
 
-/-- **The elements outside the Frobenius kernel number `|G : H| · (|H| - 1)`.**  For a
-trivial-intersection subgroup they are exactly the nonidentity elements of the conjugates of `H`,
-and each is hit once by the parametrization: such an element determines the conjugate containing
-it, hence the coset, hence the element of `H` it comes from.  The parametrization argument is
-uniform, so no finiteness is assumed; when `G` is infinite both sides are `0`. -/
+/-- **The complement of the Frobenius kernel has `Set.ncard` equal to `|G : H| · (|H| - 1)`.**  For
+a trivial-intersection subgroup the elements outside the kernel are exactly the nonidentity elements
+of the conjugates of `H`, and each is hit once by the parametrization: such an element determines
+the conjugate containing it, hence the coset, hence the element of `H` it comes from.  The
+parametrization argument is uniform, so no finiteness is assumed — but this is an `ncard` identity,
+not an element count, unless `G` is finite: for an infinite `G` both sides are the junk value `0`
+that `Set.ncard` and `Subgroup.index` take on infinite arguments.  The genuine count is
+`TauCeti.IsTISubgroup.ncard_frobeniusKernel`, stated for a finite `G`. -/
 theorem IsTISubgroup.ncard_compl_frobeniusKernel (hH : IsTISubgroup H) :
     ((frobeniusKernel H)ᶜ).ncard = H.index * (Nat.card H - 1) := by
   have hcoe : (H : Set G).ncard = Nat.card H := (Nat.card_coe_set_eq (H : Set G)).symm

--- a/TauCeti/GroupTheory/FrobeniusKernel.lean
+++ b/TauCeti/GroupTheory/FrobeniusKernel.lean
@@ -38,8 +38,10 @@ kernel is the set of conjugates of the nonidentity elements of `H`, which for a
 trivial-intersection subgroup is such a set (`TauCeti.IsTISubgroup.isTISet_diff_one`), and the
 count specializes to `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, the `Set.ncard` identity
 `((frobeniusKernel H)ᶜ).ncard = |G : H| · (|H| - 1)`. That identity holds for any `G`, finite or
-not, but it counts elements only when `G` is finite: for an infinite `G` both of its sides are the
-junk value `0` that `Set.ncard` and `Subgroup.index` take on infinite arguments. For a finite `G`
+not, but for an infinite `G` it does not in general represent a count of elements: an infinite side
+reads as the junk value `0` that `Set.ncard` and `Subgroup.index` take on infinite arguments. A
+degenerate case can of course still be a genuine count — for `H = ⊥` the kernel is everything and
+its complement is honestly empty — but nothing outside the finite case says so. For a finite `G`
 there are indeed `|G : H| · (|H| - 1)` elements outside the kernel, and the remaining
 `|G| - |G : H| · (|H| - 1) = |G : H|` elements are the kernel, and the rest is arithmetic.
 
@@ -225,9 +227,11 @@ private theorem compl_frobeniusKernel (H : Subgroup G) :
 a trivial-intersection subgroup the elements outside the kernel are exactly the conjugates of the
 nonidentity elements of `H`, which `TauCeti.IsTISet.ncard_conjugatesOfSet` counts as `|G : H|`
 times the `|H| - 1` elements of `H` that are conjugated.  No finiteness is assumed — but this is an
-`ncard` identity, not an element count, unless `G` is finite: for an infinite `G` both sides are
-the junk value `0` that `Set.ncard` and `Subgroup.index` take on infinite arguments.  The genuine
-count is `TauCeti.IsTISubgroup.ncard_frobeniusKernel`, stated for a finite `G`. -/
+`ncard` identity, which for an infinite `G` need not be an element count: an infinite side reads as
+the junk value `0` that `Set.ncard` and `Subgroup.index` take on infinite arguments, even though a
+degenerate case may still be a genuine count (for `H = ⊥` the complement of the kernel is honestly
+empty).  The count that is guaranteed to be one is
+`TauCeti.IsTISubgroup.ncard_frobeniusKernel`, stated for a finite `G`. -/
 theorem IsTISubgroup.ncard_compl_frobeniusKernel (hH : IsTISubgroup H) :
     ((frobeniusKernel H)ᶜ).ncard = H.index * (Nat.card H - 1) := by
   have hcoe : (H : Set G).ncard = Nat.card H := (Nat.card_coe_set_eq (H : Set G)).symm
@@ -242,10 +246,13 @@ theorem IsTISubgroup.ncard_frobeniusKernel [Finite G] (hH : IsTISubgroup H) :
   obtain ⟨m, hm⟩ : ∃ m, Nat.card H = m + 1 := ⟨Nat.card H - 1, by
     have := Nat.card_pos (α := H)
     omega⟩
-  have htotal := Set.ncard_add_ncard_compl (frobeniusKernel H)
   have hcard := H.index_mul_card
-  rw [hH.ncard_compl_frobeniusKernel, hm, Nat.add_sub_cancel] at htotal
   rw [hm, Nat.mul_add, Nat.mul_one] at hcard
+  -- `Set.ncard_compl_of_ncard_eq_add` reads the count of the kernel off the count of its
+  -- complement, once `compl_compl` presents the kernel as that complement.
+  rw [← compl_compl (frobeniusKernel H)]
+  refine Set.ncard_compl_of_ncard_eq_add _ ?_
+  rw [hH.ncard_compl_frobeniusKernel, hm, Nat.add_sub_cancel]
   omega
 
 /-- The Frobenius kernel of a trivial-intersection subgroup of a finite group has `|G : H|`

--- a/TauCeti/GroupTheory/FrobeniusKernel.lean
+++ b/TauCeti/GroupTheory/FrobeniusKernel.lean
@@ -32,7 +32,8 @@ The count is the inclusion-exclusion that gives Frobenius's theorem its shape, a
 statement about a trivial-intersection *set* `S` for `H` (`TauCeti.IsTISet`): the conjugates
 `g S g⁻¹` are pairwise disjoint for distinct cosets `g H` and depend only on the coset, so the
 elements they cover are indexed bijectively by the pairs (a coset of `H`, an element of `S`) and
-number `|G : H| · |S|`. That is `TauCeti.IsTISet.ncard_conjugatesOfSet`. The complement of the
+number `|G : H| · |S|`. That is `TauCeti.IsTISet.ncard_conjugatesOfSet`, proved alongside
+`TauCeti.IsTISet` itself in `TauCeti/GroupTheory/TrivialIntersection.lean`. The complement of the
 kernel is the set of conjugates of the nonidentity elements of `H`, which for a
 trivial-intersection subgroup is such a set (`TauCeti.IsTISubgroup.isTISet_diff_one`), and the
 count specializes to `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, the `Set.ncard` identity
@@ -65,8 +66,6 @@ everything and `⊥` has index `|G|`.
 * `TauCeti.frobeniusKernel_inter_conj_eq_singleton` and
   `TauCeti.frobeniusKernel_inter_eq_singleton`: the kernel meets every conjugate of `H`, and in
   particular `H` itself, exactly in the identity.
-* `TauCeti.IsTISet.ncard_conjugatesOfSet`: the conjugates of a trivial-intersection set `S` for `H`
-  cover `|G : H| · |S|` elements, the count the kernel count specializes.
 * `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`: the `Set.ncard` identity
   `((frobeniusKernel H)ᶜ).ncard = |G : H| · (|H| - 1)`, which for a finite `G` counts the elements
   *outside* the kernel — the nonidentity elements of the conjugates of `H`, each counted once — and
@@ -76,19 +75,6 @@ everything and `⊥` has index `|G|`.
   elements.**
 * `TauCeti.IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel`: for a finite `G`, a subgroup
   whose carrier is the kernel is a complement to `H`.
-
-## Implementation notes
-
-The bijection is set up as a map *into* `G` out of `(G ⧸ H) × S`, rather than as an `Equiv` onto
-`Group.conjugatesOfSet S`, because the two facts it is used through are cleaner apart than bundled:
-that its range is the set of conjugates uses only that `S` is normalized by `H`, while its
-injectivity is exactly the disjointness of the distinct conjugates. The coset representatives are
-`Quotient.out`, so the map is noncomputable and needs no well-definedness argument; the price is
-that hitting a conjugate has to move a witness `x` to `(x H).out` by `QuotientGroup.mk_out_eq_mul`,
-conjugating the element of `S` along the way. The general count lives here rather than beside
-`TauCeti.IsTISet` because it is the counting half of this file's subject and needs the coset,
-index and cardinality machinery that `TauCeti/GroupTheory/TrivialIntersection.lean` does not
-import.
 
 ## References
 
@@ -210,72 +196,6 @@ theorem frobeniusKernel_bot : frobeniusKernel (⊥ : Subgroup G) = Set.univ := b
   -- `conj_eq_one_iff` is stated for `a * y * a⁻¹`, so the conjugator is exhibited as `x⁻¹`.
   have hconj : x⁻¹ * y * x = x⁻¹ * y * (x⁻¹)⁻¹ := by group
   exact conj_eq_one_iff.1 (hconj ▸ hx)
-
-/-! ### Counting the conjugates of a trivial-intersection set -/
-
-variable {S : Set G}
-
-/-- The parametrization of the conjugates of a subset `S` of `H` by a coset of `H` together with an
-element of `S`: the coset picks a conjugator through the representative `Quotient.out`, and the
-element of `S` is transported along it.  For a trivial-intersection set its range is
-`Group.conjugatesOfSet S` (`TauCeti.IsTISet.range_conjugatesOfSetParam`, which uses only that `S`
-is normalized by `H`) and it is injective
-(`TauCeti.IsTISet.conjugatesOfSetParam_injective`, which is exactly the disjointness of the
-distinct conjugates); together those give the count
-`TauCeti.IsTISet.ncard_conjugatesOfSet`. -/
-private noncomputable def conjugatesOfSetParam (H : Subgroup G) (S : Set G) :
-    (G ⧸ H) × S → G :=
-  fun p => p.1.out * (p.2 : G) * p.1.out⁻¹
-
-private theorem IsTISet.range_conjugatesOfSetParam (hS : IsTISet S H) :
-    Set.range (conjugatesOfSetParam H S) = Group.conjugatesOfSet S := by
-  refine Set.Subset.antisymm ?_ fun y hy => ?_
-  · rintro _ ⟨⟨C, s, hs⟩, rfl⟩
-    exact Group.mem_conjugatesOfSet_iff.2 ⟨s, hs, isConj_iff.2 ⟨C.out, rfl⟩⟩
-  · obtain ⟨s, hs, hconj⟩ := Group.mem_conjugatesOfSet_iff.1 hy
-    obtain ⟨x, rfl⟩ := isConj_iff.1 hconj
-    obtain ⟨h, hout⟩ := QuotientGroup.mk_out_eq_mul H x
-    refine ⟨⟨QuotientGroup.mk x, ⟨(h : G)⁻¹ * s * h, ?_⟩⟩, ?_⟩
-    · simpa using hS.conj_mem (h : G)⁻¹ (H.inv_mem h.2) s hs
-    · simp only [conjugatesOfSetParam, hout]
-      group
-
-private theorem IsTISet.conjugatesOfSetParam_injective (hS : IsTISet S H) :
-    Function.Injective (conjugatesOfSetParam H S) := by
-  rintro ⟨C, s, hs⟩ ⟨D, s', hs'⟩ hEq
-  simp only [conjugatesOfSetParam] at hEq
-  -- The two coset representatives differ by an element conjugating `s` back into `S`, so the
-  -- trivial-intersection condition puts that difference inside `H`: the cosets agree.
-  have hconj : D.out⁻¹ * C.out * s * (D.out⁻¹ * C.out)⁻¹ = s' := by
-    have hshift : D.out⁻¹ * C.out * s * (D.out⁻¹ * C.out)⁻¹
-        = D.out⁻¹ * (C.out * s * C.out⁻¹) * D.out := by group
-    rw [hshift, hEq]
-    group
-  have hmem : D.out⁻¹ * C.out ∈ H := by
-    by_contra hx
-    exact hS.disjoint_conj _ hx s hs (hconj ▸ hs')
-  have hCD : C = D := by
-    have h1 : (QuotientGroup.mk C.out : G ⧸ H) = QuotientGroup.mk D.out :=
-      (QuotientGroup.eq.2 hmem).symm
-    rwa [QuotientGroup.out_eq', QuotientGroup.out_eq'] at h1
-  subst hCD
-  have hss : s = s' := mul_left_cancel (mul_right_cancel hEq)
-  subst hss
-  rfl
-
-/-- **The conjugates of a trivial-intersection set have `Set.ncard` equal to `|G : H| · |S|`.**  The
-conjugate `g S g⁻¹` depends only on the coset `g H`, because `S` is normalized by `H`, and distinct
-cosets give disjoint conjugates, so the elements covered are indexed bijectively by the pairs (a
-coset of `H`, an element of `S`).  The parametrization argument is uniform, so no finiteness is
-assumed — but this is an `ncard` identity, not an element count, unless the sets involved are
-finite: otherwise both sides are the junk value `0` that `Set.ncard` and `Subgroup.index` take on
-infinite arguments.  The Frobenius kernel count
-`TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel` is the case `S = H \ {1}`. -/
-theorem IsTISet.ncard_conjugatesOfSet (hS : IsTISet S H) :
-    (Group.conjugatesOfSet S).ncard = H.index * S.ncard := by
-  rw [← hS.range_conjugatesOfSetParam,
-    Set.ncard_range_of_injective hS.conjugatesOfSetParam_injective, Nat.card_prod,
-    ← Subgroup.index_eq_card, Nat.card_coe_set_eq]
 
 /-! ### Counting the kernel -/
 

--- a/TauCeti/GroupTheory/TrivialIntersection.lean
+++ b/TauCeti/GroupTheory/TrivialIntersection.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Group.Subgroup.Pointwise
+public import Mathlib.GroupTheory.Index
 public import Mathlib.Tactic.Group
 
 /-!
@@ -23,11 +24,16 @@ lattice form is `TauCeti.isTISubgroup_iff_inf_conj_smul_eq_bot`.
 Alongside the subgroup notion there is a set-level one.  A **trivial-intersection set** for `H` is
 a subset `S ⊆ H` normalized by `H` whose distinct `G`-conjugates are pairwise disjoint.  The
 example that matters is the nonidentity part `H# = (H : Set G) \ {1}` of a Frobenius complement
-(`TauCeti.IsFrobeniusComplement.isTISet_diff_one`): a class function on `H` supported on such an
-`S` induces to `G` without changing its norm, as long as the order of `G` is invertible in the
-coefficient field `k` (`IsUnit (Nat.card G : k)`, as everywhere in this theory, because induction
-divides by that order).  That is the input to the exceptional-character argument for Frobenius's
-theorem.  That induction statement is
+(`TauCeti.IsFrobeniusComplement.isTISet_diff_one`).  Because the conjugates of such an `S` depend
+only on the coset of the conjugator and distinct cosets give disjoint conjugates, the elements they
+cover between them are indexed bijectively by the pairs (a coset of `H`, an element of `S`) and so
+number `|G : H| · |S|` (`TauCeti.IsTISet.ncard_conjugatesOfSet`); that count is what makes the
+Frobenius kernel of `TauCeti/GroupTheory/FrobeniusKernel.lean` come out with `|G : H|` elements.
+
+A class function on `H` supported on such an `S` induces to `G` without changing its norm, as long
+as the order of `G` is invertible in the coefficient field `k` (`IsUnit (Nat.card G : k)`, as
+everywhere in this theory, because induction divides by that order).  That is the input to the
+exceptional-character argument for Frobenius's theorem.  That induction statement is
 `TauCeti.characterPairing_ind_ind_of_isTISet`, in
 `TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean`.
 
@@ -46,6 +52,18 @@ theorem.  That induction statement is
   trivial-intersection set, and in particular so is the nonidentity part of `H`.
 * `TauCeti.IsTISet.one_notMem`: conversely, a trivial-intersection set for a proper subgroup
   avoids the identity.
+* `TauCeti.IsTISet.ncard_conjugatesOfSet`: the conjugates of a trivial-intersection set cover
+  `|G : H| · |S|` elements.
+
+## Implementation notes
+
+The count `TauCeti.IsTISet.ncard_conjugatesOfSet` is proved through a map *into* `G` out of
+`(G ⧸ H) × S`, rather than through an `Equiv` onto `Group.conjugatesOfSet S`, because the two facts
+it is used through are cleaner apart than bundled: that its range is the set of conjugates uses only
+that `S` is normalized by `H`, while its injectivity is exactly the disjointness of the distinct
+conjugates.  The coset representatives are `Quotient.out`, so the map is noncomputable and needs no
+well-definedness argument; the price is that hitting a conjugate has to move a witness `x` to
+`(x H).out` by `QuotientGroup.mk_out_eq_mul`, conjugating the element of `S` along the way.
 
 ## References
 
@@ -186,6 +204,70 @@ theorem IsTISubgroup.isTISet_diff_one (hH : IsTISubgroup H) :
   · simp only [Set.mem_singleton_iff]
     intro hcon
     exact hx.2 (mul_eq_left.mp (mul_inv_eq_one.mp hcon))
+
+/-! ### Counting the conjugates of a trivial-intersection set -/
+
+/-- The parametrization of the conjugates of a subset `S` of `H` by a coset of `H` together with an
+element of `S`: the coset picks a conjugator through the representative `Quotient.out`, and the
+element of `S` is transported along it.  For a trivial-intersection set its range is
+`Group.conjugatesOfSet S` (`TauCeti.IsTISet.range_conjugatesOfSetParam`, which uses only that `S`
+is normalized by `H`) and it is injective
+(`TauCeti.IsTISet.conjugatesOfSetParam_injective`, which is exactly the disjointness of the
+distinct conjugates); together those give the count
+`TauCeti.IsTISet.ncard_conjugatesOfSet`. -/
+private noncomputable def conjugatesOfSetParam (H : Subgroup G) (S : Set G) :
+    (G ⧸ H) × S → G :=
+  fun p => p.1.out * (p.2 : G) * p.1.out⁻¹
+
+private theorem IsTISet.range_conjugatesOfSetParam (hS : IsTISet S H) :
+    Set.range (conjugatesOfSetParam H S) = Group.conjugatesOfSet S := by
+  refine Set.Subset.antisymm ?_ fun y hy => ?_
+  · rintro _ ⟨⟨C, s, hs⟩, rfl⟩
+    exact Group.mem_conjugatesOfSet_iff.2 ⟨s, hs, isConj_iff.2 ⟨C.out, rfl⟩⟩
+  · obtain ⟨s, hs, hconj⟩ := Group.mem_conjugatesOfSet_iff.1 hy
+    obtain ⟨x, rfl⟩ := isConj_iff.1 hconj
+    obtain ⟨h, hout⟩ := QuotientGroup.mk_out_eq_mul H x
+    refine ⟨⟨QuotientGroup.mk x, ⟨(h : G)⁻¹ * s * h, ?_⟩⟩, ?_⟩
+    · simpa using hS.conj_mem (h : G)⁻¹ (H.inv_mem h.2) s hs
+    · simp only [conjugatesOfSetParam, hout]
+      group
+
+private theorem IsTISet.conjugatesOfSetParam_injective (hS : IsTISet S H) :
+    Function.Injective (conjugatesOfSetParam H S) := by
+  rintro ⟨C, s, hs⟩ ⟨D, s', hs'⟩ hEq
+  simp only [conjugatesOfSetParam] at hEq
+  -- The two coset representatives differ by an element conjugating `s` back into `S`, so the
+  -- trivial-intersection condition puts that difference inside `H`: the cosets agree.
+  have hconj : D.out⁻¹ * C.out * s * (D.out⁻¹ * C.out)⁻¹ = s' := by
+    have hshift : D.out⁻¹ * C.out * s * (D.out⁻¹ * C.out)⁻¹
+        = D.out⁻¹ * (C.out * s * C.out⁻¹) * D.out := by group
+    rw [hshift, hEq]
+    group
+  have hmem : D.out⁻¹ * C.out ∈ H := by
+    by_contra hx
+    exact hS.disjoint_conj _ hx s hs (hconj ▸ hs')
+  have hCD : C = D := by
+    have h1 : (QuotientGroup.mk C.out : G ⧸ H) = QuotientGroup.mk D.out :=
+      (QuotientGroup.eq.2 hmem).symm
+    rwa [QuotientGroup.out_eq', QuotientGroup.out_eq'] at h1
+  subst hCD
+  have hss : s = s' := mul_left_cancel (mul_right_cancel hEq)
+  subst hss
+  rfl
+
+/-- **The conjugates of a trivial-intersection set have `Set.ncard` equal to `|G : H| · |S|`.**  The
+conjugate `g S g⁻¹` depends only on the coset `g H`, because `S` is normalized by `H`, and distinct
+cosets give disjoint conjugates, so the elements covered are indexed bijectively by the pairs (a
+coset of `H`, an element of `S`).  The parametrization argument is uniform, so no finiteness is
+assumed — but this is an `ncard` identity, not an element count, unless the sets involved are
+finite: otherwise both sides are the junk value `0` that `Set.ncard` and `Subgroup.index` take on
+infinite arguments.  The Frobenius kernel count
+`TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel` is the case `S = H \ {1}`. -/
+theorem IsTISet.ncard_conjugatesOfSet (hS : IsTISet S H) :
+    (Group.conjugatesOfSet S).ncard = H.index * S.ncard := by
+  rw [← hS.range_conjugatesOfSetParam,
+    Set.ncard_range_of_injective hS.conjugatesOfSetParam_injective, Nat.card_prod,
+    ← Subgroup.index_eq_card, Nat.card_coe_set_eq]
 
 /-! ### Frobenius complements -/
 

--- a/TauCeti/GroupTheory/TrivialIntersection.lean
+++ b/TauCeti/GroupTheory/TrivialIntersection.lean
@@ -26,9 +26,12 @@ a subset `S ⊆ H` normalized by `H` whose distinct `G`-conjugates are pairwise 
 example that matters is the nonidentity part `H# = (H : Set G) \ {1}` of a Frobenius complement
 (`TauCeti.IsFrobeniusComplement.isTISet_diff_one`).  Because the conjugates of such an `S` depend
 only on the coset of the conjugator and distinct cosets give disjoint conjugates, the elements they
-cover between them are indexed bijectively by the pairs (a coset of `H`, an element of `S`) and so
-number `|G : H| · |S|` (`TauCeti.IsTISet.ncard_conjugatesOfSet`); that count is what makes the
-Frobenius kernel of `TauCeti/GroupTheory/FrobeniusKernel.lean` come out with `|G : H|` elements.
+cover between them are indexed bijectively by the pairs (a coset of `H`, an element of `S`).  That
+bijection is the `Set.ncard` identity `(Group.conjugatesOfSet S).ncard = |G : H| · |S|`
+(`TauCeti.IsTISet.ncard_conjugatesOfSet`), which counts the covered elements when the parametrizing
+sets are finite — `H` of finite index and `S` finite — and reads `0` on an infinite side otherwise;
+that count is what makes the Frobenius kernel of `TauCeti/GroupTheory/FrobeniusKernel.lean` come
+out with `|G : H|` elements.
 
 A class function on `H` supported on such an `S` induces to `G` without changing its norm, as long
 as the order of `G` is invertible in the coefficient field `k` (`IsUnit (Nat.card G : k)`, as
@@ -52,8 +55,9 @@ exceptional-character argument for Frobenius's theorem.  That induction statemen
   trivial-intersection set, and in particular so is the nonidentity part of `H`.
 * `TauCeti.IsTISet.one_notMem`: conversely, a trivial-intersection set for a proper subgroup
   avoids the identity.
-* `TauCeti.IsTISet.ncard_conjugatesOfSet`: the conjugates of a trivial-intersection set cover
-  `|G : H| · |S|` elements.
+* `TauCeti.IsTISet.ncard_conjugatesOfSet`: the `Set.ncard` identity
+  `(Group.conjugatesOfSet S).ncard = |G : H| · |S|`, an actual count of the elements the conjugates
+  of a trivial-intersection set cover when `H` has finite index and `S` is finite.
 
 ## Implementation notes
 
@@ -259,9 +263,9 @@ private theorem IsTISet.conjugatesOfSetParam_injective (hS : IsTISet S H) :
 conjugate `g S g⁻¹` depends only on the coset `g H`, because `S` is normalized by `H`, and distinct
 cosets give disjoint conjugates, so the elements covered are indexed bijectively by the pairs (a
 coset of `H`, an element of `S`).  The parametrization argument is uniform, so no finiteness is
-assumed — but this is an `ncard` identity, not an element count, unless the sets involved are
-finite: otherwise both sides are the junk value `0` that `Set.ncard` and `Subgroup.index` take on
-infinite arguments.  The Frobenius kernel count
+assumed — but this is an `ncard` identity, and it counts elements only when the parametrizing sets
+are finite, `H` of finite index and `S` finite: an infinite side otherwise reads as the junk value
+`0` that `Set.ncard` and `Subgroup.index` take on infinite arguments.  The Frobenius kernel count
 `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel` is the case `S = H \ {1}`. -/
 theorem IsTISet.ncard_conjugatesOfSet (hS : IsTISet S H) :
     (Group.conjugatesOfSet S).ncard = H.index * S.ncard := by


### PR DESCRIPTION
This PR defines the Frobenius kernel of a subgroup and proves everything about it that does not need character theory, including the counting statement the roadmap records. The Frobenius kernel `TauCeti.frobeniusKernel H = {1} ∪ (G ∖ ⋃_g g H g⁻¹)` is the identity together with the elements of `G` lying in no conjugate of `H`; `TauCeti.mem_frobeniusKernel` gives the elementwise description everything else uses. For an arbitrary subgroup the kernel contains the identity, is closed under inversion (`TauCeti.inv_mem_frobeniusKernel_iff`), is invariant under conjugation (`TauCeti.conj_mem_frobeniusKernel_iff`), and meets `H` exactly in the identity (`TauCeti.frobeniusKernel_inter_coe`) — that is the half of normality that costs nothing, closure under multiplication being Frobenius's theorem itself.

The substance is the count. For a trivial-intersection subgroup (`TauCeti.IsTISubgroup`, already in `TauCeti/GroupTheory/TrivialIntersection.lean`) the conjugates `g H g⁻¹` meet pairwise in the identity alone and depend only on the coset `g H`, so the nonidentity elements they cover are indexed bijectively by a coset of `H` together with a nonidentity element of `H`. That bijection is `TauCeti.IsTISubgroup.ncard_compl_frobeniusKernel`, giving `|G : H| · (|H| - 1)` elements outside the kernel, and with `|G| = |G : H| · |H|` it leaves `TauCeti.IsTISubgroup.ncard_frobeniusKernel`: the kernel has exactly `|G : H|` elements. Combined with the trivial intersection with `H`, this yields `TauCeti.IsTISubgroup.isComplement'_of_coe_eq_frobeniusKernel`, that a subgroup whose carrier is the kernel is automatically a complement to `H` — so once Frobenius's theorem supplies the subgroup, the semidirect decomposition `G = N ⋊ H` is free. Nothing here asserts that such a subgroup exists.

The roadmap target is Layer 8 ("Frobenius groups and Frobenius's theorem") of `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, whose "The Frobenius kernel" bullet pins `frobeniusKernel H = {1} ∪ (G ∖ ⋃_g (g H g⁻¹))` as "a set of size `|G : H|`" and separates that from the subgroup statement ("that it is a **subgroup** is not elementary and is the content of the theorem"); the signature matches `frobeniusKernel {G : Type v} [Group G] (H : Subgroup G) : Set G` in the corresponding `Suggested.lean`. The complement result is the elementary half of the named target `frobeniusKernel_isComplement'` from the same layer, stated conditionally on the subgroup that Frobenius's theorem will produce. The counting hypotheses are `TauCeti.IsTISubgroup` alone rather than `TauCeti.IsFrobeniusComplement`: properness and nontriviality are not used, and the two degenerate cases are honest instances rather than exclusions, `frobeniusKernel ⊤ = {1}` with `⊤` of index `1` and `frobeniusKernel ⊥ = univ` with `⊥` of index `|G|` (both recorded as simp lemmas).

No Mathlib infrastructure was vendored; the proofs consume `Subgroup.mem_pointwise_smul_iff_inv_smul_mem`, `QuotientGroup.mk_out_eq_mul`, `Subgroup.index_mul_card`, `Set.ncard_sdiff_singleton_add_one`, `Set.ncard_image_of_injective` and `Subgroup.isComplement'_of_card_mul_and_disjoint` as they stand. One file is added, `TauCeti/GroupTheory/FrobeniusKernel.lean` (273 lines); `lake build` and `lake exe axioms` are green, the latter reporting all 74591 declarations within the allowlist.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"frobeniuskernel"}-->

🤖 Prepared with Claude Code
