### PR TITLE
feat: preserve geometric connectedness under products

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -5,16 +5,16 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Product
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
+public import TauCeti.AlgebraicGeometry.Geometrically.Connected
 
 /-!
 # Geometric connectedness of products of affine groups
 
 The direct product of two affine groups over a field has coordinate Hopf algebra given by the
-tensor product of their coordinate algebras. This file proves that geometric connectedness is
-preserved by this construction.
+tensor product of their coordinate algebras. This file applies the affine tensor-product
+connectedness theorem to show that geometric connectedness is preserved by this construction.
 
 On the scheme side, the product is the fibre product of the two Hopf spectra over the spectrum of
 the ground field. Each projection has geometrically connected fibres by base change, and the
@@ -24,12 +24,10 @@ isomorphism then identifies the result with the spectrum of the tensor product.
 
 ## Main declarations
 
-* `TauCeti.geometricallyConnected_tensorProduct`: the tensor product of two commutative algebras
-  with geometrically connected spectra is geometrically connected.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty.tensorProduct`: the tensor product of two
   geometrically connected commutative Hopf algebras is geometrically connected.
-* `TauCeti.geometricallyConnectedCommHopfAlgProperty.semidirectProduct`: an internal semidirect
-  product of geometrically connected affine groups is geometrically connected.
+* `TauCeti.geometricallyConnectedCommHopfAlgProperty.semidirectProduct`: a semidirect product
+  associated to an action of geometrically connected affine groups is geometrically connected.
 
 ## References
 
@@ -43,7 +41,7 @@ result below proves that source is geometrically connected.
 
 public section
 
-open CategoryTheory Limits
+open CategoryTheory
 open scoped TensorProduct
 
 namespace TauCeti
@@ -57,31 +55,6 @@ private instance geometricallyConnected_respectsIso :
   MorphismProperty.IsStableUnderBaseChange.respectsIso
 
 variable {k : Type u} [Field k]
-
-/-- The spectrum of a tensor product of commutative algebras over a field is geometrically
-connected when the spectra of both factors are geometrically connected over that field. -/
-theorem geometricallyConnected_tensorProduct
-    (S T : Type u) [CommRing S] [CommRing T] [Algebra k S] [Algebra k T]
-    (hS : GeometricallyConnected (Spec.map (CommRingCat.ofHom (algebraMap k S))))
-    (hT : GeometricallyConnected (Spec.map (CommRingCat.ofHom (algebraMap k T)))) :
-    GeometricallyConnected
-      (Spec.map (CommRingCat.ofHom (algebraMap k (S ⊗[k] T)))) := by
-  let f := Spec.map (CommRingCat.ofHom (algebraMap k S))
-  let g := Spec.map (CommRingCat.ofHom (algebraMap k T))
-  let _ : GeometricallyConnected f := hS
-  let _ : GeometricallyConnected g := hT
-  let _ : UniversallyOpen f := inferInstance
-  let _ : UniversallyOpen g := inferInstance
-  have hproduct : GeometricallyConnected (pullback.fst f g ≫ f) :=
-    GeometricallyConnected.comp (pullback.fst f g) f
-  have hproduct' : GeometricallyConnected
-      ((pullbackSpecIso k S T).hom ≫
-        Spec.map (CommRingCat.ofHom (algebraMap k (S ⊗[k] T)))) := by
-    rw [pullbackSpecIso_hom_base]
-    exact hproduct
-  rw [MorphismProperty.cancel_left_of_respectsIso
-    (P := @GeometricallyConnected) (pullbackSpecIso k S T).hom] at hproduct'
-  exact hproduct'
 
 namespace geometricallyConnectedCommHopfAlgProperty
 
@@ -113,8 +86,8 @@ theorem tensorProduct (H K : CommHopfAlgCat.{u} k)
   exact (morphismProperty_hopfSpec_obj_X_hom_iff
     (P := @GeometricallyConnected) k (CommHopfAlgCat.of k (H ⊗[k] K))).mpr hspectrum
 
-/-- An internal semidirect product of geometrically connected affine groups is geometrically
-connected.
+/-- The semidirect product associated to an action of geometrically connected affine groups is
+geometrically connected.
 
 The action changes the group law but not the underlying affine scheme: on coordinate algebras,
 the carrier remains the tensor product. This formulation is the one used when multiplication of

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Product
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
-public import TauCeti.CategoryTheory.Monoidal.SemidirectProduct.Basic
 
 /-!
 # Geometric connectedness of products of affine groups
@@ -24,6 +24,8 @@ isomorphism then identifies the result with the spectrum of the tensor product.
 
 ## Main declarations
 
+* `TauCeti.geometricallyConnected_tensorProduct`: the tensor product of two commutative algebras
+  with geometrically connected spectra is geometrically connected.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty.tensorProduct`: the tensor product of two
   geometrically connected commutative Hopf algebras is geometrically connected.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty.semidirectProduct`: an internal semidirect
@@ -54,9 +56,34 @@ private instance geometricallyConnected_respectsIso :
     MorphismProperty.RespectsIso @GeometricallyConnected :=
   MorphismProperty.IsStableUnderBaseChange.respectsIso
 
-namespace geometricallyConnectedCommHopfAlgProperty
-
 variable {k : Type u} [Field k]
+
+/-- The spectrum of a tensor product of commutative algebras over a field is geometrically
+connected when the spectra of both factors are geometrically connected over that field. -/
+theorem geometricallyConnected_tensorProduct
+    (S T : Type u) [CommRing S] [CommRing T] [Algebra k S] [Algebra k T]
+    (hS : GeometricallyConnected (Spec.map (CommRingCat.ofHom (algebraMap k S))))
+    (hT : GeometricallyConnected (Spec.map (CommRingCat.ofHom (algebraMap k T)))) :
+    GeometricallyConnected
+      (Spec.map (CommRingCat.ofHom (algebraMap k (S ⊗[k] T)))) := by
+  let f := Spec.map (CommRingCat.ofHom (algebraMap k S))
+  let g := Spec.map (CommRingCat.ofHom (algebraMap k T))
+  let _ : GeometricallyConnected f := hS
+  let _ : GeometricallyConnected g := hT
+  let _ : UniversallyOpen f := inferInstance
+  let _ : UniversallyOpen g := inferInstance
+  have hproduct : GeometricallyConnected (pullback.fst f g ≫ f) :=
+    GeometricallyConnected.comp (pullback.fst f g) f
+  have hproduct' : GeometricallyConnected
+      ((pullbackSpecIso k S T).hom ≫
+        Spec.map (CommRingCat.ofHom (algebraMap k (S ⊗[k] T)))) := by
+    rw [pullbackSpecIso_hom_base]
+    exact hproduct
+  rw [MorphismProperty.cancel_left_of_respectsIso
+    (P := @GeometricallyConnected) (pullbackSpecIso k S T).hom] at hproduct'
+  exact hproduct'
+
+namespace geometricallyConnectedCommHopfAlgProperty
 
 /-- The tensor product of two geometrically connected commutative Hopf algebras is geometrically
 connected. Contravariantly, direct products of geometrically connected affine groups over a
@@ -70,49 +97,21 @@ theorem tensorProduct (H K : CommHopfAlgCat.{u} k)
     (hK : geometricallyConnectedCommHopfAlgProperty k K) :
     geometricallyConnectedCommHopfAlgProperty k
       (CommHopfAlgCat.of k (H ⊗[k] K)) := by
-  let f := Spec.map (CommRingCat.ofHom (algebraMap k H))
-  let g := Spec.map (CommRingCat.ofHom (algebraMap k K))
-  have hf : GeometricallyConnected f := by
+  have hf : GeometricallyConnected
+      (Spec.map (CommRingCat.ofHom (algebraMap k H))) := by
     rw [← morphismProperty_hopfSpec_obj_X_hom_iff
       (P := @GeometricallyConnected) k H]
     exact (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H).mp hH
-  have hg : GeometricallyConnected g := by
+  have hg : GeometricallyConnected
+      (Spec.map (CommRingCat.ofHom (algebraMap k K))) := by
     rw [← morphismProperty_hopfSpec_obj_X_hom_iff
       (P := @GeometricallyConnected) k K]
     exact (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k K).mp hK
-  let _ : GeometricallyConnected f := hf
-  let _ : GeometricallyConnected g := hg
-  let _ : UniversallyOpen f := inferInstance
-  let _ : UniversallyOpen g := inferInstance
-  have hproduct : GeometricallyConnected (pullback.fst f g ≫ f) :=
-    GeometricallyConnected.comp (pullback.fst f g) f
-  have hspectrum : GeometricallyConnected
-      (Spec.map (CommRingCat.ofHom (algebraMap k (H ⊗[k] K)))) := by
-    have hproduct' : GeometricallyConnected
-        ((pullbackSpecIso k H K).hom ≫
-          Spec.map (CommRingCat.ofHom (algebraMap k (H ⊗[k] K)))) := by
-      rw [pullbackSpecIso_hom_base]
-      exact hproduct
-    rw [MorphismProperty.cancel_left_of_respectsIso
-      (P := @GeometricallyConnected) (pullbackSpecIso k H K).hom] at hproduct'
-    exact hproduct'
+  have hspectrum := geometricallyConnected_tensorProduct H K hf hg
   apply (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec
     k (CommHopfAlgCat.of k (H ⊗[k] K))).mpr
   exact (morphismProperty_hopfSpec_obj_X_hom_iff
     (P := @GeometricallyConnected) k (CommHopfAlgCat.of k (H ⊗[k] K))).mpr hspectrum
-
-/-- The coordinate algebra underlying a semidirect product is explicitly equivalent to the
-tensor product of the two coordinate algebras. -/
-private noncomputable def semidirectProductCarrierAlgEquiv
-    (H K : CommHopfAlgCat.{u} k)
-    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
-    (((commHopfAlgCatEquivCogrpCommAlgCat k).inverse.obj
-      (Opposite.op A.semidirectProduct) : CommHopfAlgCat.{u} k) : Type u) ≃ₐ[k]
-      (H ⊗[k] K) := by
-  let _ := A.semidirectProductGrpObj
-  exact CommAlgCat.algEquivOfIso
-    (A := A.semidirectProduct.X.unop) (B := CommAlgCat.of k (H ⊗[k] K))
-    (eqToIso (congrArg Opposite.unop A.semidirectProduct_X))
 
 /-- An internal semidirect product of geometrically connected affine groups is geometrically
 connected.
@@ -125,15 +124,13 @@ theorem semidirectProduct (H K : CommHopfAlgCat.{u} k)
     (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H))
     (hH : geometricallyConnectedCommHopfAlgProperty k H)
     (hK : geometricallyConnectedCommHopfAlgProperty k K) :
-    geometricallyConnectedCommHopfAlgProperty k
-      ((commHopfAlgCatEquivCogrpCommAlgCat k).inverse.obj (Opposite.op A.semidirectProduct)) := by
-  let _ := A.semidirectProductGrpObj
+    geometricallyConnectedCommHopfAlgProperty k A.coordinateHopfAlgebra := by
   have h := tensorProduct H K hH hK
   rw [geometricallyConnectedCommHopfAlgProperty_iff] at h
   rw [geometricallyConnectedCommHopfAlgProperty_iff]
   intro L _ _
   let eL := Algebra.TensorProduct.congr
-    (semidirectProductCarrierAlgEquiv H K A) (AlgEquiv.refl : L ≃ₐ[k] L)
+    A.coordinateAlgEquiv (AlgEquiv.refl : L ≃ₐ[k] L)
   exact (PrimeSpectrum.homeomorphOfRingEquiv eL.toRingEquiv).connectedSpace_iff.mpr (h L)
 
 end geometricallyConnectedCommHopfAlgProperty

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -101,6 +101,19 @@ theorem tensorProduct (H K : CommHopfAlgCat.{u} k)
   exact (morphismProperty_hopfSpec_obj_X_hom_iff
     (P := @GeometricallyConnected) k (CommHopfAlgCat.of k (H ⊗[k] K))).mpr hspectrum
 
+/-- The coordinate algebra underlying a semidirect product is explicitly equivalent to the
+tensor product of the two coordinate algebras. -/
+private noncomputable def semidirectProductCarrierAlgEquiv
+    (H K : CommHopfAlgCat.{u} k)
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
+    (((commHopfAlgCatEquivCogrpCommAlgCat k).inverse.obj
+      (Opposite.op A.semidirectProduct) : CommHopfAlgCat.{u} k) : Type u) ≃ₐ[k]
+      (H ⊗[k] K) := by
+  let _ := A.semidirectProductGrpObj
+  exact CommAlgCat.algEquivOfIso
+    (A := A.semidirectProduct.X.unop) (B := CommAlgCat.of k (H ⊗[k] K))
+    (eqToIso (congrArg Opposite.unop A.semidirectProduct_X))
+
 /-- An internal semidirect product of geometrically connected affine groups is geometrically
 connected.
 
@@ -119,11 +132,9 @@ theorem semidirectProduct (H K : CommHopfAlgCat.{u} k)
   rw [geometricallyConnectedCommHopfAlgProperty_iff] at h
   rw [geometricallyConnectedCommHopfAlgProperty_iff]
   intro L _ _
-  -- Mathlib's `commHopfAlgCatEquivCogrpCommAlgCat_inverse_obj` exposes the carrier as
-  -- `A.semidirectProduct.X.unop`; the structural lemma then identifies that object.
-  change ConnectedSpace (PrimeSpectrum ((A.semidirectProduct.X.unop : Type u) ⊗[k] L))
-  rw [A.semidirectProduct_X, unop_tensorObj]
-  exact h L
+  let eL := Algebra.TensorProduct.congr
+    (semidirectProductCarrierAlgEquiv H K A) (AlgEquiv.refl : L ≃ₐ[k] L)
+  exact (PrimeSpectrum.homeomorphOfRingEquiv eL.toRingEquiv).connectedSpace_iff.mpr (h L)
 
 end geometricallyConnectedCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Product
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
+public import TauCeti.CategoryTheory.Monoidal.SemidirectProduct.Basic
+
+/-!
+# Geometric connectedness of products of affine groups
+
+The direct product of two affine groups over a field has coordinate Hopf algebra given by the
+tensor product of their coordinate algebras. This file proves that geometric connectedness is
+preserved by this construction.
+
+On the scheme side, the product is the fibre product of the two Hopf spectra over the spectrum of
+the ground field. Each projection has geometrically connected fibres by base change, and the
+other factor is connected. Structure morphisms to the spectrum of a field are universally open,
+so Mathlib's connectedness theorem for pullbacks applies. The standard affine pullback
+isomorphism then identifies the result with the spectrum of the tensor product.
+
+## Main declarations
+
+* `TauCeti.geometricallyConnectedCommHopfAlgProperty.tensorProduct`: the tensor product of two
+  geometrically connected commutative Hopf algebras is geometrically connected.
+* `TauCeti.geometricallyConnectedCommHopfAlgProperty.semidirectProduct`: an internal semidirect
+  product of geometrically connected affine groups is geometrically connected.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Sections 1.c and 2.a.
+
+This supplies the connectedness step in Layer 5, "The unipotent radical", of the
+ReductiveGroups roadmap. The binary product of two radical candidates is formed as the image of
+multiplication from a semidirect product whose underlying scheme is the direct product; the
+result below proves that source is geometrically connected.
+-/
+
+public section
+
+open CategoryTheory Limits
+open scoped TensorProduct
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+universe u
+
+private instance geometricallyConnected_respectsIso :
+    MorphismProperty.RespectsIso @GeometricallyConnected :=
+  MorphismProperty.IsStableUnderBaseChange.respectsIso
+
+namespace geometricallyConnectedCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+
+/-- The tensor product of two geometrically connected commutative Hopf algebras is geometrically
+connected. Contravariantly, direct products of geometrically connected affine groups over a
+field are geometrically connected.
+
+The Hopf structure on the tensor product is irrelevant to connectedness, but packages the
+coordinate ring as the direct product in the same category used by the functor-of-points and
+unipotent-radical constructions. -/
+theorem tensorProduct (H K : CommHopfAlgCat.{u} k)
+    (hH : geometricallyConnectedCommHopfAlgProperty k H)
+    (hK : geometricallyConnectedCommHopfAlgProperty k K) :
+    geometricallyConnectedCommHopfAlgProperty k
+      (CommHopfAlgCat.of k (H ⊗[k] K)) := by
+  let f := Spec.map (CommRingCat.ofHom (algebraMap k H))
+  let g := Spec.map (CommRingCat.ofHom (algebraMap k K))
+  have hf : GeometricallyConnected f := by
+    rw [← morphismProperty_hopfSpec_obj_X_hom_iff
+      (P := @GeometricallyConnected) k H]
+    exact (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k H).mp hH
+  have hg : GeometricallyConnected g := by
+    rw [← morphismProperty_hopfSpec_obj_X_hom_iff
+      (P := @GeometricallyConnected) k K]
+    exact (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec k K).mp hK
+  let _ : GeometricallyConnected f := hf
+  let _ : GeometricallyConnected g := hg
+  let _ : UniversallyOpen f := inferInstance
+  let _ : UniversallyOpen g := inferInstance
+  have hproduct : GeometricallyConnected (pullback.fst f g ≫ f) :=
+    GeometricallyConnected.comp (pullback.fst f g) f
+  have hspectrum : GeometricallyConnected
+      (Spec.map (CommRingCat.ofHom (algebraMap k (H ⊗[k] K)))) := by
+    have hproduct' : GeometricallyConnected
+        ((pullbackSpecIso k H K).hom ≫
+          Spec.map (CommRingCat.ofHom (algebraMap k (H ⊗[k] K)))) := by
+      rw [pullbackSpecIso_hom_base]
+      exact hproduct
+    rw [MorphismProperty.cancel_left_of_respectsIso
+      (P := @GeometricallyConnected) (pullbackSpecIso k H K).hom] at hproduct'
+    exact hproduct'
+  apply (geometricallyConnectedCommHopfAlg_iff_geometricallyConnected_hopfSpec
+    k (CommHopfAlgCat.of k (H ⊗[k] K))).mpr
+  exact (morphismProperty_hopfSpec_obj_X_hom_iff
+    (P := @GeometricallyConnected) k (CommHopfAlgCat.of k (H ⊗[k] K))).mpr hspectrum
+
+/-- An internal semidirect product of geometrically connected affine groups is geometrically
+connected.
+
+The action changes the group law but not the underlying affine scheme: on coordinate algebras,
+the carrier remains the tensor product. This formulation is the one used when multiplication of
+two normal closed subgroups is made into a homomorphism by equipping their product with the
+conjugation semidirect-product structure. -/
+theorem semidirectProduct (H K : CommHopfAlgCat.{u} k)
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H))
+    (hH : geometricallyConnectedCommHopfAlgProperty k H)
+    (hK : geometricallyConnectedCommHopfAlgProperty k K) :
+    geometricallyConnectedCommHopfAlgProperty k
+      ((commHopfAlgCatEquivCogrpCommAlgCat k).inverse.obj (Opposite.op A.semidirectProduct)) := by
+  let _ := A.semidirectProductGrpObj
+  have h := tensorProduct H K hH hK
+  rw [geometricallyConnectedCommHopfAlgProperty_iff] at h ⊢
+  exact h
+
+end geometricallyConnectedCommHopfAlgProperty
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -101,6 +101,17 @@ theorem tensorProduct (H K : CommHopfAlgCat.{u} k)
   exact (morphismProperty_hopfSpec_obj_X_hom_iff
     (P := @GeometricallyConnected) k (CommHopfAlgCat.of k (H ⊗[k] K))).mpr hspectrum
 
+/-- The coordinate algebra underlying a semidirect product is the tensor product of the two
+coordinate algebras; only its Hopf structure depends on the action. -/
+private noncomputable def semidirectProductCarrierAlgEquiv
+    (H K : CommHopfAlgCat.{u} k)
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
+    (((commHopfAlgCatEquivCogrpCommAlgCat k).inverse.obj
+      (Opposite.op A.semidirectProduct) : CommHopfAlgCat.{u} k) : Type u) ≃ₐ[k]
+      (H ⊗[k] K) := by
+  let _ := A.semidirectProductGrpObj
+  exact AlgEquiv.refl
+
 /-- An internal semidirect product of geometrically connected affine groups is geometrically
 connected.
 
@@ -116,8 +127,13 @@ theorem semidirectProduct (H K : CommHopfAlgCat.{u} k)
       ((commHopfAlgCatEquivCogrpCommAlgCat k).inverse.obj (Opposite.op A.semidirectProduct)) := by
   let _ := A.semidirectProductGrpObj
   have h := tensorProduct H K hH hK
-  rw [geometricallyConnectedCommHopfAlgProperty_iff] at h ⊢
-  exact h
+  rw [geometricallyConnectedCommHopfAlgProperty_iff] at h
+  rw [geometricallyConnectedCommHopfAlgProperty_iff]
+  intro L _ _
+  let eL := Algebra.TensorProduct.congr
+    (semidirectProductCarrierAlgEquiv H K A) (AlgEquiv.refl : L ≃ₐ[k] L)
+  exact (PrimeSpectrum.homeomorphOfRingEquiv eL.toRingEquiv).connectedSpace_iff.mpr
+    (h L)
 
 end geometricallyConnectedCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -101,17 +101,6 @@ theorem tensorProduct (H K : CommHopfAlgCat.{u} k)
   exact (morphismProperty_hopfSpec_obj_X_hom_iff
     (P := @GeometricallyConnected) k (CommHopfAlgCat.of k (H ⊗[k] K))).mpr hspectrum
 
-/-- The coordinate algebra underlying a semidirect product is the tensor product of the two
-coordinate algebras; only its Hopf structure depends on the action. -/
-private noncomputable def semidirectProductCarrierAlgEquiv
-    (H K : CommHopfAlgCat.{u} k)
-    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
-    (((commHopfAlgCatEquivCogrpCommAlgCat k).inverse.obj
-      (Opposite.op A.semidirectProduct) : CommHopfAlgCat.{u} k) : Type u) ≃ₐ[k]
-      (H ⊗[k] K) := by
-  let _ := A.semidirectProductGrpObj
-  exact AlgEquiv.refl
-
 /-- An internal semidirect product of geometrically connected affine groups is geometrically
 connected.
 
@@ -130,10 +119,11 @@ theorem semidirectProduct (H K : CommHopfAlgCat.{u} k)
   rw [geometricallyConnectedCommHopfAlgProperty_iff] at h
   rw [geometricallyConnectedCommHopfAlgProperty_iff]
   intro L _ _
-  let eL := Algebra.TensorProduct.congr
-    (semidirectProductCarrierAlgEquiv H K A) (AlgEquiv.refl : L ≃ₐ[k] L)
-  exact (PrimeSpectrum.homeomorphOfRingEquiv eL.toRingEquiv).connectedSpace_iff.mpr
-    (h L)
+  -- Mathlib's `commHopfAlgCatEquivCogrpCommAlgCat_inverse_obj` exposes the carrier as
+  -- `A.semidirectProduct.X.unop`; the structural lemma then identifies that object.
+  change ConnectedSpace (PrimeSpectrum ((A.semidirectProduct.X.unop : Type u) ⊗[k] L))
+  rw [A.semidirectProduct_X, unop_tensorObj]
+  exact h L
 
 end geometricallyConnectedCommHopfAlgProperty
 

--- a/TauCeti/AlgebraicGeometry/Geometrically/Connected.lean
+++ b/TauCeti/AlgebraicGeometry/Geometrically/Connected.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Geometrically.Connected
+
+/-!
+# Geometric connectedness of affine products
+
+This file proves that the spectrum of a tensor product of commutative algebras over a field is
+geometrically connected when the spectra of both factors are geometrically connected. The tensor
+product spectrum is identified with the fibre product of the two spectra over the ground field.
+
+## Main declarations
+
+* `TauCeti.geometricallyConnected_tensorProduct`: the tensor product of two commutative algebras
+  with geometrically connected spectra is geometrically connected.
+
+This is an affine-scheme prerequisite for the product constructions in Layer 5, "The unipotent
+radical", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory Limits
+open scoped TensorProduct
+
+namespace TauCeti
+
+open AlgebraicGeometry
+
+universe u
+
+private instance geometricallyConnected_respectsIso :
+    MorphismProperty.RespectsIso @GeometricallyConnected :=
+  MorphismProperty.IsStableUnderBaseChange.respectsIso
+
+variable {k : Type u} [Field k]
+
+/-- The spectrum of a tensor product of commutative algebras over a field is geometrically
+connected when the spectra of both factors are geometrically connected over that field. -/
+theorem geometricallyConnected_tensorProduct
+    (S T : Type u) [CommRing S] [CommRing T] [Algebra k S] [Algebra k T]
+    (hS : GeometricallyConnected (Spec.map (CommRingCat.ofHom (algebraMap k S))))
+    (hT : GeometricallyConnected (Spec.map (CommRingCat.ofHom (algebraMap k T)))) :
+    GeometricallyConnected
+      (Spec.map (CommRingCat.ofHom (algebraMap k (S ⊗[k] T)))) := by
+  let f := Spec.map (CommRingCat.ofHom (algebraMap k S))
+  let g := Spec.map (CommRingCat.ofHom (algebraMap k T))
+  let _ : GeometricallyConnected f := hS
+  let _ : GeometricallyConnected g := hT
+  let _ : UniversallyOpen f := inferInstance
+  let _ : UniversallyOpen g := inferInstance
+  have hproduct : GeometricallyConnected (pullback.fst f g ≫ f) :=
+    GeometricallyConnected.comp (pullback.fst f g) f
+  have hproduct' : GeometricallyConnected
+      ((pullbackSpecIso k S T).hom ≫
+        Spec.map (CommRingCat.ofHom (algebraMap k (S ⊗[k] T)))) := by
+    rw [pullbackSpecIso_hom_base]
+    exact hproduct
+  rw [MorphismProperty.cancel_left_of_respectsIso
+    (P := @GeometricallyConnected) (pullbackSpecIso k S T).hom] at hproduct'
+  exact hproduct'
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
@@ -188,6 +188,11 @@ noncomputable abbrev semidirectProduct : Grp C where
   X := N ⊗ G
   grp := A.semidirectProductGrpObj
 
+/-- The underlying object of an internal semidirect product is the product of its two factors. -/
+@[simp]
+theorem semidirectProduct_X : A.semidirectProduct.X = N ⊗ G :=
+  rfl
+
 /-- The Yoneda group of the internal semidirect product is the pointwise semidirect-product
 presheaf. -/
 private noncomputable def pointIso :

--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
@@ -188,12 +188,6 @@ noncomputable abbrev semidirectProduct : Grp C where
   X := N ⊗ G
   grp := A.semidirectProductGrpObj
 
-/-- The underlying object of an internal semidirect product is the tensor product of its two
-factors. -/
-@[simp]
-theorem semidirectProduct_X : A.semidirectProduct.X = N ⊗ G :=
-  rfl
-
 /-- The Yoneda group of the internal semidirect product is the pointwise semidirect-product
 presheaf. -/
 private noncomputable def pointIso :

--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Basic.lean
@@ -188,7 +188,8 @@ noncomputable abbrev semidirectProduct : Grp C where
   X := N ⊗ G
   grp := A.semidirectProductGrpObj
 
-/-- The underlying object of an internal semidirect product is the product of its two factors. -/
+/-- The underlying object of an internal semidirect product is the tensor product of its two
+factors. -/
 @[simp]
 theorem semidirectProduct_X : A.semidirectProduct.X = N ⊗ G :=
   rfl


### PR DESCRIPTION
This PR proves that tensor products of geometrically connected commutative Hopf algebras are geometrically connected, and derives the same result for every internal semidirect product. It advances `ReductiveGroups/README.md`, Layer 5 milestone “The unipotent radical `R_u(G)`,” specifically the connectedness prerequisite in the binary-product closure of connected normal smooth unipotent closed subgroups. The in-flight multiplication-image construction in #4434 defines `CommHopfAlgCat.normalProductSource` from the conjugation semidirect product, and consumes `geometricallyConnectedCommHopfAlgProperty.semidirectProduct` to show that source is geometrically connected.

The proof passes through the affine-group-scheme dictionary: geometric connectedness is stable under the pullback projection, composition gives the structure map of the product, and Mathlib's `pullbackSpecIso` identifies that fibre product with `Spec (H ⊗[k] K)`. The semidirect-product corollary then observes that the action changes the group law but leaves this underlying affine scheme unchanged. The mathematical organization follows Milne, *Algebraic Groups* (2017), §§1.c and 2.a, as cited in the module documentation; no Mathlib infrastructure is vendored.

After this PR, the Layer 5 binary-product step still needs #4434 to land, containment of both factors, normality and smooth-unipotence of the image, and then the maximal-dimension argument showing that the chosen candidate contains every other candidate.

Add `TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean` (124 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geometrically-connected-tensor-product"}-->

🤖 Prepared with Codex
