### PR TITLE
feat: preserve smooth unipotence under semidirect products

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SemidirectProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SemidirectProduct.lean
@@ -46,7 +46,7 @@ universe u
 
 noncomputable section
 
-variable {k : Type u} [Field k]
+variable {k : Type u} [CommRing k]
 variable {H K : _root_.CommHopfAlgCat.{u} k}
 
 /-- The coordinate Hopf algebra of an internal semidirect product. -/
@@ -78,6 +78,7 @@ noncomputable def coordinateInr
 
 /-- The represented group-object morphism associated to `coordinateInl` is the canonical
 inclusion of the normal factor. -/
+@[simp]
 theorem grpObjMap_coordinateInl
     (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
     letI := A.semidirectProductGrpObj
@@ -89,6 +90,7 @@ theorem grpObjMap_coordinateInl
 
 /-- The represented group-object morphism associated to `coordinateInr` is the canonical
 inclusion of the acting factor. -/
+@[simp]
 theorem grpObjMap_coordinateInr
     (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
     letI := A.semidirectProductGrpObj
@@ -119,11 +121,19 @@ theorem pointMulEquiv_mapDomain_coordinateInl
       (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm
           (AlgHom.mapDomain A.coordinateInl.hom g) =
         (CommHopfAlgCat.grpObjPointsMulEquiv H (op L)).symm g ≫ A.inl.hom.hom := by
-    rw [CommHopfAlgCat.grpObjPointsMulEquiv_symm_apply,
-      CommHopfAlgCat.grpObjPointsMulEquiv_symm_apply]
-    apply Quiver.Hom.unop_inj
-    ext h
-    rfl
+    have hnat := CommHopfAlgCat.grpObjPointsMulEquiv_comp_grpObjMap A.coordinateInl
+      (op L) ((CommHopfAlgCat.grpObjPointsMulEquiv H (op L)).symm g)
+    apply (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).injective
+    calc
+      _ = (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L))
+          ((CommHopfAlgCat.grpObjPointsMulEquiv H (op L)).symm g ≫
+            CommHopfAlgCat.grpObjMap A.coordinateInl) := by
+        simpa only [CommHopfAlgCat.mapPointsFunctor_app_apply, AlgHom.mapDomain_apply,
+          MulEquiv.apply_symm_apply] using hnat.symm
+      _ = _ := by
+        rw [A.grpObjMap_coordinateInl]
+        apply WithConv.ofConv_injective
+        rfl
   rw [hcat, A.pointMulEquiv_comp_inl]
 
 /-- Under the point equivalence for a semidirect product, precomposition with `coordinateInr`
@@ -145,11 +155,19 @@ theorem pointMulEquiv_mapDomain_coordinateInr
       (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm
           (AlgHom.mapDomain A.coordinateInr.hom g) =
         (CommHopfAlgCat.grpObjPointsMulEquiv K (op L)).symm g ≫ A.inr.hom.hom := by
-    rw [CommHopfAlgCat.grpObjPointsMulEquiv_symm_apply,
-      CommHopfAlgCat.grpObjPointsMulEquiv_symm_apply]
-    apply Quiver.Hom.unop_inj
-    ext h
-    rfl
+    have hnat := CommHopfAlgCat.grpObjPointsMulEquiv_comp_grpObjMap A.coordinateInr
+      (op L) ((CommHopfAlgCat.grpObjPointsMulEquiv K (op L)).symm g)
+    apply (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).injective
+    calc
+      _ = (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L))
+          ((CommHopfAlgCat.grpObjPointsMulEquiv K (op L)).symm g ≫
+            CommHopfAlgCat.grpObjMap A.coordinateInr) := by
+        simpa only [CommHopfAlgCat.mapPointsFunctor_app_apply, AlgHom.mapDomain_apply,
+          MulEquiv.apply_symm_apply] using hnat.symm
+      _ = _ := by
+        rw [A.grpObjMap_coordinateInr]
+        apply WithConv.ofConv_injective
+        rfl
   rw [hcat, A.pointMulEquiv_comp_inr]
 
 end

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SemidirectProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SemidirectProduct.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.Product
+public import TauCeti.CategoryTheory.Monoidal.SemidirectProduct.Basic
+
+/-!
+# Coordinate Hopf algebras of semidirect products
+
+An internal action between the group objects represented by commutative Hopf algebras equips the
+product of their underlying affine schemes with a semidirect-product group law. This file carries
+that group object back across Mathlib's commutative-Hopf-algebra/cogroup equivalence, records the
+coordinate morphisms representing the two canonical factor inclusions, and computes them on
+algebra-valued points.
+
+## Main declarations
+
+* `TauCeti.GrpObj.Action.coordinateHopfAlgebra`: the coordinate Hopf algebra of an internal
+  semidirect product.
+* `TauCeti.GrpObj.Action.coordinateInl` and `coordinateInr`: the coordinate morphisms representing
+  the two factor inclusions.
+* `TauCeti.GrpObj.Action.pointMulEquiv_mapDomain_coordinateInl` and
+  `pointMulEquiv_mapDomain_coordinateInr`: their formulas under the semidirect-product point
+  equivalence.
+
+## References
+
+This uses Mathlib's `commHopfAlgCatEquivCogrpCommAlgCat` and Tau Ceti's group-object Yoneda
+equivalence. It is the coordinate bridge used by the semidirect-product construction in Layer 5,
+"The unipotent radical", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory Opposite WithConv
+open scoped CategoryTheory.MonObj TensorProduct
+
+namespace TauCeti.GrpObj.Action
+
+universe u
+
+noncomputable section
+
+variable {k : Type u} [Field k]
+variable {H K : _root_.CommHopfAlgCat.{u} k}
+
+/-- The coordinate Hopf algebra of an internal semidirect product. -/
+noncomputable abbrev coordinateHopfAlgebra
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
+    _root_.CommHopfAlgCat.{u} k :=
+  (commHopfAlgCatEquivCogrpCommAlgCat k).inverse.obj (op A.semidirectProduct)
+
+/-- The coordinate algebra of a semidirect product is finite type when both factors are. -/
+noncomputable instance coordinateHopfAlgebra_finiteType
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H))
+    [Algebra.FiniteType k H] [Algebra.FiniteType k K] :
+    Algebra.FiniteType k A.coordinateHopfAlgebra :=
+  FiniteTypeCommHopfAlgCat.tensorProduct_finiteType (R := k) H K
+
+/-- The coordinate morphism representing inclusion of the normal factor in a semidirect
+product. -/
+noncomputable def coordinateInl
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
+    A.coordinateHopfAlgebra ⟶ H :=
+  (commHopfAlgCatEquivCogrpCommAlgCat k).inverse.map (op A.inl)
+
+/-- The coordinate morphism representing inclusion of the acting factor in a semidirect
+product. -/
+noncomputable def coordinateInr
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
+    A.coordinateHopfAlgebra ⟶ K :=
+  (commHopfAlgCatEquivCogrpCommAlgCat k).inverse.map (op A.inr)
+
+/-- The represented group-object morphism associated to `coordinateInl` is the canonical
+inclusion of the normal factor. -/
+theorem grpObjMap_coordinateInl
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
+    letI := A.semidirectProductGrpObj
+    CommHopfAlgCat.grpObjMap A.coordinateInl = A.inl.hom.hom := by
+  let _ := A.semidirectProductGrpObj
+  apply Quiver.Hom.unop_inj
+  rw [CommHopfAlgCat.grpObjMap_unop]
+  rfl
+
+/-- The represented group-object morphism associated to `coordinateInr` is the canonical
+inclusion of the acting factor. -/
+theorem grpObjMap_coordinateInr
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
+    letI := A.semidirectProductGrpObj
+    CommHopfAlgCat.grpObjMap A.coordinateInr = A.inr.hom.hom := by
+  let _ := A.semidirectProductGrpObj
+  apply Quiver.Hom.unop_inj
+  rw [CommHopfAlgCat.grpObjMap_unop]
+  rfl
+
+/-- Under the point equivalence for a semidirect product, precomposition with `coordinateInl`
+is the ordinary inclusion of the normal factor. -/
+theorem pointMulEquiv_mapDomain_coordinateInl
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H))
+    (L : CommAlgCat.{u} k) (g : HopfAlgebra.points (R := k) (H := H) L) :
+    letI := A.semidirectProductGrpObj
+    ((CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm.trans
+        (A.pointMulEquiv (op L))) (AlgHom.mapDomain A.coordinateInl.hom g) =
+      SemidirectProduct.inl
+        ((CommHopfAlgCat.grpObjPointsMulEquiv H (op L)).symm g) := by
+  let _ := A.semidirectProductGrpObj
+  -- Expose application of the composite equivalence; its intermediate object is definitionally
+  -- the carrier of `A.semidirectProduct`, whose group-object implementation is intentionally
+  -- hidden by the categorical semidirect-product API.
+  change (A.pointMulEquiv (op L))
+    ((CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm
+      (AlgHom.mapDomain A.coordinateInl.hom g)) = _
+  have hcat :
+      (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm
+          (AlgHom.mapDomain A.coordinateInl.hom g) =
+        (CommHopfAlgCat.grpObjPointsMulEquiv H (op L)).symm g ≫ A.inl.hom.hom := by
+    rw [CommHopfAlgCat.grpObjPointsMulEquiv_symm_apply,
+      CommHopfAlgCat.grpObjPointsMulEquiv_symm_apply]
+    apply Quiver.Hom.unop_inj
+    ext h
+    rfl
+  rw [hcat, A.pointMulEquiv_comp_inl]
+
+/-- Under the point equivalence for a semidirect product, precomposition with `coordinateInr`
+is the ordinary inclusion of the acting factor. -/
+theorem pointMulEquiv_mapDomain_coordinateInr
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H))
+    (L : CommAlgCat.{u} k) (g : HopfAlgebra.points (R := k) (H := K) L) :
+    letI := A.semidirectProductGrpObj
+    ((CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm.trans
+        (A.pointMulEquiv (op L))) (AlgHom.mapDomain A.coordinateInr.hom g) =
+      SemidirectProduct.inr
+        ((CommHopfAlgCat.grpObjPointsMulEquiv K (op L)).symm g) := by
+  let _ := A.semidirectProductGrpObj
+  -- As above, expose application of the composite across the hidden group-object carrier.
+  change (A.pointMulEquiv (op L))
+    ((CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm
+      (AlgHom.mapDomain A.coordinateInr.hom g)) = _
+  have hcat :
+      (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm
+          (AlgHom.mapDomain A.coordinateInr.hom g) =
+        (CommHopfAlgCat.grpObjPointsMulEquiv K (op L)).symm g ≫ A.inr.hom.hom := by
+    rw [CommHopfAlgCat.grpObjPointsMulEquiv_symm_apply,
+      CommHopfAlgCat.grpObjPointsMulEquiv_symm_apply]
+    apply Quiver.Hom.unop_inj
+    ext h
+    rfl
+  rw [hcat, A.pointMulEquiv_comp_inr]
+
+end
+
+end TauCeti.GrpObj.Action

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SemidirectProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SemidirectProduct.lean
@@ -22,6 +22,7 @@ algebra-valued points.
 
 * `TauCeti.GrpObj.Action.coordinateHopfAlgebra`: the coordinate Hopf algebra of an internal
   semidirect product.
+* `TauCeti.GrpObj.Action.coordinateAlgEquiv`: its underlying tensor-product coordinate algebra.
 * `TauCeti.GrpObj.Action.coordinateInl` and `coordinateInr`: the coordinate morphisms representing
   the two factor inclusions.
 * `TauCeti.GrpObj.Action.pointMulEquiv_mapDomain_coordinateInl` and
@@ -55,12 +56,20 @@ noncomputable abbrev coordinateHopfAlgebra
     _root_.CommHopfAlgCat.{u} k :=
   (commHopfAlgCatEquivCogrpCommAlgCat k).inverse.obj (op A.semidirectProduct)
 
+/-- The underlying coordinate algebra of a semidirect product is the tensor product of the
+coordinate algebras of its factors. -/
+noncomputable def coordinateAlgEquiv
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H)) :
+    A.coordinateHopfAlgebra ≃ₐ[k] H ⊗[k] K :=
+  AlgEquiv.refl
+
 /-- The coordinate algebra of a semidirect product is finite type when both factors are. -/
 noncomputable instance coordinateHopfAlgebra_finiteType
     (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H))
     [Algebra.FiniteType k H] [Algebra.FiniteType k K] :
     Algebra.FiniteType k A.coordinateHopfAlgebra :=
-  FiniteTypeCommHopfAlgCat.tensorProduct_finiteType (R := k) H K
+  Algebra.FiniteType.equiv
+    (FiniteTypeCommHopfAlgCat.tensorProduct_finiteType (R := k) H K) A.coordinateAlgEquiv.symm
 
 /-- The coordinate morphism representing inclusion of the normal factor in a semidirect
 product. -/
@@ -100,6 +109,17 @@ theorem grpObjMap_coordinateInr
   rw [CommHopfAlgCat.grpObjMap_unop]
   rfl
 
+private theorem grpObjPointsMulEquiv_symm_mapDomain {B C : _root_.CommHopfAlgCat.{u} k}
+    (f : B ⟶ C) (L : CommAlgCat.{u} k) (g : HopfAlgebra.points (R := k) (H := C) L) :
+    (CommHopfAlgCat.grpObjPointsMulEquiv B (op L)).symm (AlgHom.mapDomain f.hom g) =
+      (CommHopfAlgCat.grpObjPointsMulEquiv C (op L)).symm g ≫
+        CommHopfAlgCat.grpObjMap f := by
+  have hnat := CommHopfAlgCat.grpObjPointsMulEquiv_comp_grpObjMap f
+    (op L) ((CommHopfAlgCat.grpObjPointsMulEquiv C (op L)).symm g)
+  apply (CommHopfAlgCat.grpObjPointsMulEquiv B (op L)).injective
+  simpa only [CommHopfAlgCat.mapPointsFunctor_app_apply, AlgHom.mapDomain_apply,
+    MulEquiv.apply_symm_apply] using hnat.symm
+
 /-- Under the point equivalence for a semidirect product, precomposition with `coordinateInl`
 is the ordinary inclusion of the normal factor. -/
 theorem pointMulEquiv_mapDomain_coordinateInl
@@ -121,19 +141,9 @@ theorem pointMulEquiv_mapDomain_coordinateInl
       (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm
           (AlgHom.mapDomain A.coordinateInl.hom g) =
         (CommHopfAlgCat.grpObjPointsMulEquiv H (op L)).symm g ≫ A.inl.hom.hom := by
-    have hnat := CommHopfAlgCat.grpObjPointsMulEquiv_comp_grpObjMap A.coordinateInl
-      (op L) ((CommHopfAlgCat.grpObjPointsMulEquiv H (op L)).symm g)
-    apply (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).injective
-    calc
-      _ = (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L))
-          ((CommHopfAlgCat.grpObjPointsMulEquiv H (op L)).symm g ≫
-            CommHopfAlgCat.grpObjMap A.coordinateInl) := by
-        simpa only [CommHopfAlgCat.mapPointsFunctor_app_apply, AlgHom.mapDomain_apply,
-          MulEquiv.apply_symm_apply] using hnat.symm
-      _ = _ := by
-        rw [A.grpObjMap_coordinateInl]
-        apply WithConv.ofConv_injective
-        rfl
+    rw [grpObjPointsMulEquiv_symm_mapDomain]
+    rw [A.grpObjMap_coordinateInl]
+    rfl
   rw [hcat, A.pointMulEquiv_comp_inl]
 
 /-- Under the point equivalence for a semidirect product, precomposition with `coordinateInr`
@@ -155,19 +165,9 @@ theorem pointMulEquiv_mapDomain_coordinateInr
       (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).symm
           (AlgHom.mapDomain A.coordinateInr.hom g) =
         (CommHopfAlgCat.grpObjPointsMulEquiv K (op L)).symm g ≫ A.inr.hom.hom := by
-    have hnat := CommHopfAlgCat.grpObjPointsMulEquiv_comp_grpObjMap A.coordinateInr
-      (op L) ((CommHopfAlgCat.grpObjPointsMulEquiv K (op L)).symm g)
-    apply (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L)).injective
-    calc
-      _ = (CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra (op L))
-          ((CommHopfAlgCat.grpObjPointsMulEquiv K (op L)).symm g ≫
-            CommHopfAlgCat.grpObjMap A.coordinateInr) := by
-        simpa only [CommHopfAlgCat.mapPointsFunctor_app_apply, AlgHom.mapDomain_apply,
-          MulEquiv.apply_symm_apply] using hnat.symm
-      _ = _ := by
-        rw [A.grpObjMap_coordinateInr]
-        apply WithConv.ofConv_injective
-        rfl
+    rw [grpObjPointsMulEquiv_symm_mapDomain]
+    rw [A.grpObjMap_coordinateInr]
+    rfl
   rw [hcat, A.pointMulEquiv_comp_inr]
 
 end

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/SemidirectProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/SemidirectProduct.lean
@@ -119,18 +119,19 @@ theorem semidirectProduct (H K : _root_.CommHopfAlgCat.{u} k)
     let qU := ePoint.symm (SemidirectProduct.inl (ePoint g).left)
     let qW := ePoint.symm (SemidirectProduct.inr (ePoint g).right)
     have hqU : qU ∈ U := by
-      change SemidirectProduct.rightHom (ePoint qU) = 1
-      simp only [qU, MulEquiv.apply_symm_apply, SemidirectProduct.rightHom_inl]
+      simp only [U, Subgroup.mem_comap, MonoidHom.mem_ker]
+      simp only [qU, MulEquiv.coe_toMonoidHom, MulEquiv.apply_symm_apply,
+        SemidirectProduct.rightHom_inl]
     have hqW : qW ∈ W := by
-      change ePoint qW ∈ SemidirectProduct.inr.range
-      exact ⟨(ePoint g).right, by simp only [qW, MulEquiv.apply_symm_apply]⟩
+      simp only [W, Subgroup.mem_comap, MonoidHom.mem_range]
+      exact ⟨(ePoint g).right, by
+        simp only [qW, MulEquiv.coe_toMonoidHom, MulEquiv.apply_symm_apply]⟩
     have hfactor : g = qU * qW := by
       apply ePoint.injective
       simp only [map_mul, qU, qW, MulEquiv.apply_symm_apply,
         SemidirectProduct.inl_left_mul_inr_right]
     rw [hfactor]
-    exact (U ⊔ W).mul_mem ((show U ≤ U ⊔ W from le_sup_left) hqU)
-      ((show W ≤ U ⊔ W from le_sup_right) hqW)
+    exact Subgroup.mul_mem_sup hqU hqW
   have hgnilpotent := rho.isNilpotent_sub_one_of_mem_sup_of_le_normalizer_isUnipotent
     U W Subgroup.le_normalizer_of_normal hU hW hg
   simpa only [rho, Comodule.pointsRepresentation_apply] using hgnilpotent

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/SemidirectProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/SemidirectProduct.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Product
+public import TauCeti.RepresentationTheory.Unipotent.NormalJoin
+
+/-!
+# Smooth unipotence of semidirect products
+
+An internal action of affine groups equips the product of their underlying affine schemes with
+the semidirect-product group law. This file proves that if both factors are geometrically
+unipotent, then so is the semidirect product, and consequently that semidirect products of smooth
+unipotent affine groups are smooth unipotent.
+
+The pointwise argument works in an arbitrary finite-dimensional representation of the semidirect
+product. The images of the two factors act unipotently by restriction. The first factor is normal,
+and the two factor images generate the whole semidirect product, so the normal-join theorem makes
+every element act unipotently. Smoothness depends only on the underlying algebra, which is the
+tensor product of the coordinate algebras.
+
+## Main declarations
+
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.semidirectProduct`: internal
+  semidirect products preserve geometric-point unipotence.
+* `TauCeti.smoothUnipotentCommHopfAlgProperty.semidirectProduct`: internal semidirect products of
+  smooth unipotent affine groups are smooth unipotent.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, Proposition 2.4.12.
+
+This supplies the smooth-unipotence step in Layer 5, "The unipotent radical", of the
+ReductiveGroups roadmap. The binary product of two radical candidates is formed as the image of
+multiplication from their conjugation semidirect product; the source must first be known to be
+smooth unipotent.
+-/
+
+public section
+
+open CategoryTheory Opposite WithConv
+open scoped CategoryTheory.MonObj TensorProduct
+
+namespace TauCeti
+
+universe u
+
+
+noncomputable section
+
+namespace geometricallyUnipotentPointsCommHopfAlgProperty
+
+variable (k : Type u) [Field k]
+
+/-- An internal semidirect product of affine groups with geometrically unipotent points again has
+geometrically unipotent points. -/
+theorem semidirectProduct (H K : _root_.CommHopfAlgCat.{u} k)
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H))
+    (hH : geometricallyUnipotentPointsCommHopfAlgProperty k H)
+    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k A.coordinateHopfAlgebra := by
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hH hK ⊢
+  intro g
+  rw [HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one]
+  intro M
+  let L := CommAlgCat.of k (AlgebraicClosure k)
+  let X := op L
+  let _ := A.semidirectProductGrpObj
+  let eS := CommHopfAlgCat.grpObjPointsMulEquiv A.coordinateHopfAlgebra X
+  let e := A.pointMulEquiv X
+  let ePoint : HopfAlgebra.points (R := k) (H := A.coordinateHopfAlgebra) L ≃*
+      ((X ⟶ CommHopfAlgCat.grpObj H) ⋊[A.toMulAutHom X]
+        (X ⟶ CommHopfAlgCat.grpObj K)) := eS.symm.trans e
+  let rho := Comodule.pointsRepresentation (R := k) (H := A.coordinateHopfAlgebra)
+    (A := AlgebraicClosure k) M
+  let U : Subgroup (HopfAlgebra.points (R := k) (H := A.coordinateHopfAlgebra) L) :=
+    Subgroup.comap ePoint.toMonoidHom
+      (SemidirectProduct.rightHom (N := X ⟶ CommHopfAlgCat.grpObj H)
+        (G := X ⟶ CommHopfAlgCat.grpObj K)).ker
+  let W : Subgroup (HopfAlgebra.points (R := k) (H := A.coordinateHopfAlgebra) L) :=
+    Subgroup.comap ePoint.toMonoidHom
+      (SemidirectProduct.inr (N := X ⟶ CommHopfAlgCat.grpObj H)
+        (G := X ⟶ CommHopfAlgCat.grpObj K)).range
+  let _ : U.Normal := Subgroup.normal_comap ePoint.toMonoidHom
+  have hU (x : U) : IsNilpotent (rho x - 1) := by
+    let n : X ⟶ CommHopfAlgCat.grpObj H := (ePoint x).left
+    let p := CommHopfAlgCat.grpObjPointsMulEquiv H X n
+    have hxright : (ePoint x).right = 1 := by
+      exact x.2
+    have hpoint : x = AlgHom.mapDomain A.coordinateInl.hom p := by
+      apply ePoint.injective
+      rw [A.pointMulEquiv_mapDomain_coordinateInl]
+      rw [MulEquiv.symm_apply_apply]
+      exact SemidirectProduct.ext rfl hxright
+    have hu := (hH p).mapDomain A.coordinateInl.hom
+    rw [← hpoint] at hu
+    have huM := hu
+    rw [HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one] at huM
+    simpa only [rho, Comodule.pointsRepresentation_apply] using huM M
+  have hW (x : W) : IsNilpotent (rho x - 1) := by
+    obtain ⟨r, hr⟩ := x.2
+    let p := CommHopfAlgCat.grpObjPointsMulEquiv K X r
+    have hpoint : x = AlgHom.mapDomain A.coordinateInr.hom p := by
+      apply ePoint.injective
+      rw [A.pointMulEquiv_mapDomain_coordinateInr]
+      rw [MulEquiv.symm_apply_apply]
+      exact hr.symm
+    have hu := (hK p).mapDomain A.coordinateInr.hom
+    rw [← hpoint] at hu
+    have huM := hu
+    rw [HopfAlgebra.isUnipotentPoint_iff_forall_isNilpotent_endOfPoint_sub_one] at huM
+    simpa only [rho, Comodule.pointsRepresentation_apply] using huM M
+  have hg : g ∈ U ⊔ W := by
+    let qU := ePoint.symm (SemidirectProduct.inl (ePoint g).left)
+    let qW := ePoint.symm (SemidirectProduct.inr (ePoint g).right)
+    have hqU : qU ∈ U := by
+      change SemidirectProduct.rightHom (ePoint qU) = 1
+      simp only [qU, MulEquiv.apply_symm_apply, SemidirectProduct.rightHom_inl]
+    have hqW : qW ∈ W := by
+      change ePoint qW ∈ SemidirectProduct.inr.range
+      exact ⟨(ePoint g).right, by simp only [qW, MulEquiv.apply_symm_apply]⟩
+    have hfactor : g = qU * qW := by
+      apply ePoint.injective
+      simp only [map_mul, qU, qW, MulEquiv.apply_symm_apply,
+        SemidirectProduct.inl_left_mul_inr_right]
+    rw [hfactor]
+    exact (U ⊔ W).mul_mem ((show U ≤ U ⊔ W from le_sup_left) hqU)
+      ((show W ≤ U ⊔ W from le_sup_right) hqW)
+  have hgnilpotent := rho.isNilpotent_sub_one_of_mem_sup_of_le_normalizer_isUnipotent
+    U W Subgroup.le_normalizer_of_normal hU hW hg
+  simpa only [rho, Comodule.pointsRepresentation_apply] using hgnilpotent
+
+end geometricallyUnipotentPointsCommHopfAlgProperty
+
+namespace smoothUnipotentCommHopfAlgProperty
+
+variable (k : Type u) [Field k]
+
+/-- An internal semidirect product of smooth unipotent finite-type affine groups is smooth
+unipotent. -/
+theorem semidirectProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K.obj) (CommHopfAlgCat.grpObj H.obj))
+    (hH : smoothUnipotentCommHopfAlgProperty k H)
+    (hK : smoothUnipotentCommHopfAlgProperty k K) :
+    smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.of k A.coordinateHopfAlgebra) := by
+  have hH' := (smoothUnipotentCommHopfAlgProperty_iff k H).mp hH
+  have hK' := (smoothUnipotentCommHopfAlgProperty_iff k K).mp hK
+  have hHpoints : geometricallyUnipotentPointsCommHopfAlgProperty k H.obj := by
+    rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+    exact hH'.2
+  have hKpoints : geometricallyUnipotentPointsCommHopfAlgProperty k K.obj := by
+    rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+    exact hK'.2
+  have hproduct := smoothUnipotentCommHopfAlgProperty.tensorProduct k H K hH hK
+  have hproduct' :=
+    (smoothUnipotentCommHopfAlgProperty_iff k
+      (FiniteTypeCommHopfAlgCat.tensorProduct H K)).mp hproduct
+  rw [smoothUnipotentCommHopfAlgProperty_iff]
+  refine ⟨hproduct'.1, ?_⟩
+  rw [← geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+  exact geometricallyUnipotentPointsCommHopfAlgProperty.semidirectProduct
+    k H.obj K.obj A hHpoints hKpoints
+
+end smoothUnipotentCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/SemidirectProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/SemidirectProduct.lean
@@ -163,7 +163,8 @@ theorem semidirectProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
     (smoothUnipotentCommHopfAlgProperty_iff k
       (FiniteTypeCommHopfAlgCat.tensorProduct H K)).mp hproduct
   rw [smoothUnipotentCommHopfAlgProperty_iff]
-  refine ⟨hproduct'.1, ?_⟩
+  let smoothProduct : Algebra.Smooth k (H.obj ⊗[k] K.obj) := hproduct'.1
+  refine ⟨Algebra.Smooth.of_equiv A.coordinateAlgEquiv.symm, ?_⟩
   rw [← geometricallyUnipotentPointsCommHopfAlgProperty_iff]
   exact geometricallyUnipotentPointsCommHopfAlgProperty.semidirectProduct
     k H.obj K.obj A hHpoints hKpoints


### PR DESCRIPTION
This PR proves that internal semidirect products of geometrically unipotent affine groups are geometrically unipotent, and that semidirect products of smooth unipotent finite-type affine groups are smooth unipotent. It advances `ReductiveGroups/README.md`, Layer 5 milestone “The unipotent radical `R_u(G)`,” specifically the binary-product closure step for connected normal smooth unipotent closed subgroups: the in-flight `CommHopfAlgCat.normalProductSource` construction in #4434 consumes this theorem to show that the source of normal-subgroup multiplication is smooth unipotent before passing those properties to its scheme-theoretic image.

The proof restricts an arbitrary finite-dimensional representation of the semidirect product to its normal and acting factors, transports factor unipotence through the two coordinate inclusions, and applies `Representation.isNilpotent_sub_one_of_mem_sup_of_le_normalizer_isUnipotent` because those factor images generate the semidirect product. The companion coordinate module transports the internal group object through Mathlib’s `commHopfAlgCatEquivCogrpCommAlgCat`, identifies its two canonical coordinate morphisms on algebra-valued points, and records finite type. Smoothness reuses the existing direct-product theorem because the action changes the Hopf structure but not the underlying tensor-product algebra. No Mathlib implementation is vendored; the mathematical organization follows Jantzen, *Representations of Algebraic Groups*, I.2, and Springer, *Linear Algebraic Groups*, Proposition 2.4.12, as cited in the module documentation.

After this PR, the Layer 5 binary-product step still needs the connectedness PR #4436 and multiplication-image PR #4434 to land, then containment of both factors, normality and smooth-unipotence of the image, and the maximal-dimension argument identifying the greatest candidate.

Add `TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SemidirectProduct.lean` (157 lines) and `TauCeti/Algebra/AlgebraicGroup/Unipotent/SemidirectProduct.lean` (174 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"smooth-unipotent-semidirect-product"}-->

🤖 Prepared with Codex
