### PR TITLE
feat(Huber): a submodule whose closure is module-finite is closed

### DIFF
--- a/TauCeti/RingTheory/Huber/ClosedSubmodule.lean
+++ b/TauCeti/RingTheory/Huber/ClosedSubmodule.lean
@@ -16,12 +16,12 @@ is module-finite is itself closed. This is Bosch–Güntzer–Remmert §3.7.2/1 
 it is the closedness prerequisite on the route to Wedhorn 6.17/6.18.
 
 The proof is one application of `TauCeti.Huber.eq_top_of_dense_of_module_finite`, made inside the
-closure rather than inside the ambient module. The closure `N̄` is closed in a complete space, so
-it is complete — the one instance that has to be supplied by hand; it is a uniform additive group
-with a countably generated uniformity by `Submodule.isUniformAddGroup` and
-`Submodule.isCountablyGenerated_uniformity`; and it is module-finite by hypothesis. Inside `N̄`
-the submodule `N` is dense, by the very definition of the closure. So `N` is everything in `N̄`,
-that is `N̄ = N`, and `N` is closed because `N̄` is.
+closure `N.topologicalClosure` rather than inside the ambient module. That closure is closed in a
+complete space, so it is complete — the one instance that has to be supplied by hand; it is a
+uniform additive group with a countably generated uniformity by `Submodule.isUniformAddGroup` and
+`Submodule.isCountablyGenerated_uniformity`; and it is module-finite by hypothesis. Inside that
+closure the submodule `N` is dense, by the very definition of the closure. So `N` is everything in
+the closure, that is `N.topologicalClosure = N`, and `N` is closed because its closure is.
 
 ## Main results
 
@@ -45,8 +45,9 @@ instance search — the first two from `Submodule.isUniformAddGroup` and
 `Submodule.isCountablyGenerated_uniformity`, the last from this repository's `ContinuousSMul`
 instance on a submodule — so only completeness is supplied. The engine is this repository's
 `TauCeti.Huber.eq_top_of_dense_of_module_finite`, stated with `T0Space`, rather than AINTLIB's
-`T2Space`-based `eq_top_of_dense_of_finite`. And the passage from `N' = ⊤` back to `N̄ ≤ N` is
-`Submodule.comap_subtype_eq_top` rather than AINTLIB's element-level unfolding.
+`T2Space`-based `eq_top_of_dense_of_finite`. And the passage from `N' = ⊤` back to
+`N.topologicalClosure ≤ N` is `Submodule.comap_subtype_eq_top` rather than AINTLIB's element-level
+unfolding.
 -/
 
 open Filter Topology
@@ -64,9 +65,9 @@ variable {A : Type*} [CommRing A] [UniformSpace A] [IsUniformAddGroup A] [Comple
 /-- **A submodule whose topological closure is module-finite is closed**
 (Bosch–Güntzer–Remmert §3.7.2/1).
 
-Working inside the closure `N̄`, which is complete because it is closed in a complete space, the
-submodule `N` is dense and `N̄` is module-finite, so `eq_top_of_dense_of_module_finite` gives
-`N = N̄`. -/
+Working inside `N.topologicalClosure`, which is complete because it is closed in a complete space,
+the submodule `N` is dense and that closure is module-finite, so
+`eq_top_of_dense_of_module_finite` gives `N = N.topologicalClosure`. -/
 theorem isClosed_of_module_finite_topologicalClosure (N : Submodule A V)
     (hfin : Module.Finite A N.topologicalClosure) : IsClosed (N : Set V) := by
   have hclosed : IsClosed (N.topologicalClosure : Set V) := N.isClosed_topologicalClosure

--- a/TauCeti/RingTheory/Huber/ClosedSubmodule.lean
+++ b/TauCeti/RingTheory/Huber/ClosedSubmodule.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Huber.DenseSubmodule
+public import TauCeti.Topology.Algebra.IsUniformGroup.Submodule
+
+/-!
+# Submodules with a module-finite closure are closed
+
+A submodule of a complete, metrisable module over a complete Tate ring whose topological closure
+is module-finite is itself closed. This is Bosch–Güntzer–Remmert §3.7.2/1 in its closure form, and
+it is the closedness prerequisite on the route to Wedhorn 6.17/6.18.
+
+The proof is one application of `TauCeti.Huber.eq_top_of_dense_of_module_finite`, made inside the
+closure rather than inside the ambient module. The closure `N̄` is closed in a complete space, so
+it is complete — the one instance that has to be supplied by hand; it is a uniform additive group
+with a countably generated uniformity by `Submodule.isUniformAddGroup` and
+`Submodule.isCountablyGenerated_uniformity`; and it is module-finite by hypothesis. Inside `N̄`
+the submodule `N` is dense, by the very definition of the closure. So `N` is everything in `N̄`,
+that is `N̄ = N`, and `N` is closed because `N̄` is.
+
+## Main results
+
+* `TauCeti.Huber.isClosed_of_module_finite_topologicalClosure`: a submodule whose topological
+  closure is module-finite is closed.
+
+## References
+
+* [Bosch, Güntzer, Remmert, *Non-Archimedean Analysis*][bosch_guntzer_remmert], §3.7.2/1.
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Propositions 6.17–6.18.
+
+## Provenance
+
+Adapted from the AINTLIB development (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), branch
+`dev/adic-spaces` at commit `37bbdaeb9ad9`, file
+`projects/AdicSpaces/Adic spaces/WedhornBanachTheorem.lean`, where the same statement is
+`fg_topologicalClosure_isClosed`. The argument is AINTLIB's, and the density step follows its
+proof closely. Three things differ. AINTLIB establishes the uniform-group, countable-generation,
+separation and `ContinuousSMul` instances on the closure by hand; here all four are found by
+instance search — the first two from `Submodule.isUniformAddGroup` and
+`Submodule.isCountablyGenerated_uniformity`, the last from this repository's `ContinuousSMul`
+instance on a submodule — so only completeness is supplied. The engine is this repository's
+`TauCeti.Huber.eq_top_of_dense_of_module_finite`, stated with `T0Space`, rather than AINTLIB's
+`T2Space`-based `eq_top_of_dense_of_finite`. And the passage from `N' = ⊤` back to `N̄ ≤ N` is
+`Submodule.comap_subtype_eq_top` rather than AINTLIB's element-level unfolding.
+-/
+
+open Filter Topology
+open scoped Uniformity
+
+public section
+
+namespace TauCeti.Huber
+
+variable {A : Type*} [CommRing A] [UniformSpace A] [IsUniformAddGroup A] [CompleteSpace A]
+  [T2Space A] [IsTopologicalRing A] [IsTateRing A]
+  {V : Type*} [AddCommGroup V] [UniformSpace V] [IsUniformAddGroup V] [CompleteSpace V]
+  [(𝓤 V).IsCountablyGenerated] [T0Space V] [Module A V] [ContinuousSMul A V]
+
+/-- **A submodule whose topological closure is module-finite is closed**
+(Bosch–Güntzer–Remmert §3.7.2/1).
+
+Working inside the closure `N̄`, which is complete because it is closed in a complete space, the
+submodule `N` is dense and `N̄` is module-finite, so `eq_top_of_dense_of_module_finite` gives
+`N = N̄`. -/
+theorem isClosed_of_module_finite_topologicalClosure (N : Submodule A V)
+    (hfin : Module.Finite A N.topologicalClosure) : IsClosed (N : Set V) := by
+  have hclosed : IsClosed (N.topologicalClosure : Set V) := N.isClosed_topologicalClosure
+  have : CompleteSpace N.topologicalClosure := hclosed.completeSpace_coe
+  -- `N` seen inside its own closure, where it is dense.
+  set N' : Submodule A N.topologicalClosure := N.comap N.topologicalClosure.subtype
+  have himg : Subtype.val '' (N' : Set N.topologicalClosure) = (N : Set V) := by
+    ext z
+    exact ⟨fun ⟨⟨_, _⟩, hw, hwz⟩ ↦ hwz ▸ hw, fun hz ↦ ⟨⟨z, N.le_topologicalClosure hz⟩, hz, rfl⟩⟩
+  have hdense : Dense (N' : Set N.topologicalClosure) := fun x ↦ by
+    rw [closure_subtype, himg, ← N.topologicalClosure_coe]
+    exact x.2
+  -- `N' = ⊤` inside the closure says exactly that the closure is contained in `N`.
+  have hle : N.topologicalClosure ≤ N :=
+    Submodule.comap_subtype_eq_top.mp (eq_top_of_dense_of_module_finite N' hdense)
+  exact le_antisymm hle N.le_topologicalClosure ▸ hclosed
+
+end TauCeti.Huber


### PR DESCRIPTION
Adds `TauCeti.Huber.isClosed_of_module_finite_topologicalClosure`: for a complete
Hausdorff Tate ring `A` and a complete `T0` topological `A`-module `V` with countably
generated uniformity and continuous scalar action, a submodule `N` whose topological
closure is module-finite over `A` is itself closed.

This is Bosch–Güntzer–Remmert §3.7.2/1 in its closure form.

## Why this is the shape of the proof

The engine is `eq_top_of_dense_of_module_finite` (landed in #4414), applied **inside the
closure** rather than in the ambient module. `N̄` is closed in a complete space, hence
complete; `N` is dense in `N̄` by the definition of the closure; and `N̄` is module-finite
by hypothesis. So `N = N̄`, and `N` is closed because `N̄` is.

The one instance supplied by hand is completeness of `N̄`. The uniform-additive-group and
countably-generated-uniformity instances come from `Submodule.isUniformAddGroup` and
`Submodule.isCountablyGenerated_uniformity`, and `ContinuousSMul` on a submodule is
already an instance in this repository (#3963) — so none of them is re-derived here.

## Roadmap target

AdicSpaces Layer 4.1 step 1 (Wedhorn Remark 8.29) consumes this closedness statement;
the Layer 0.6 open-mapping / strict-morphism material feeds it.

## Base

The bead that scheduled this work said to stack on #4414. **#4414 has since merged**
(2026-08-24T20:39Z), so this branches from plain `main` and the diff is a single new file.

## Provenance

Adapted with attribution from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pin
`37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`, file
`projects/AdicSpaces/Adic spaces/WedhornBanachTheorem.lean:723`, where the same statement
is `fg_topologicalClosure_isClosed`. The argument is AINTLIB's. Three things differ, and
the module docstring records them:

* AINTLIB establishes the uniform-group, countable-generation, separation and
  `ContinuousSMul` instances on the closure by hand; here all four are found by instance
  search, so only completeness is supplied.
* The engine here is `eq_top_of_dense_of_module_finite`, stated with `T0Space`, rather
  than AINTLIB's `T2Space`-based `eq_top_of_dense_of_finite`.
* The passage from `N' = ⊤` back to `N̄ ≤ N` is `Submodule.comap_subtype_eq_top` rather
  than AINTLIB's element-level unfolding.

The source declaration is sorry-free: the two sorries in that AINTLIB file (lines 611 and
1316) are not reachable from `:723` — the 611 lemma's only call site is line 792, a later
declaration, and 1316 is referenced only from a docstring.

## Prior art

Absent from mathlib (checked with a resolving control, `le_topologicalClosure`) and from
`main` (no `isClosed_of_module_finite_topologicalClosure`, no `IsClosed`/`topologicalClosure`
pairing). Mathlib carries no `IsTateRing` at all, so the whole Tate layer is TauCeti-local.

Roadmap: AdicSpaces
