### PR TITLE
refactor(RootSystem): name the half-total of a type D simple root

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
@@ -488,6 +488,30 @@ def typeDSimpleRootCoordinates (n : ℕ) (hn : 4 ≤ n) (x : TypeDRoot n) : Fin 
   else if (k : ℕ) + 1 < n then typeDHalfTotal x - x.1 ⟨n - 1, by omega⟩
   else typeDHalfTotal x
 
+/-- The half-total of the `i`-th type `Dₙ` simple root. The chain roots `e_i - e_{i+1}` have
+coordinate sum `0`, so half-total `0`; the fork root `e_{n-2} + e_{n-1}` has coordinate sum `2`,
+so half-total `1`. -/
+private lemma typeDHalfTotal_typeDRootEquiv_typeDSimpleIndex (hn : 4 ≤ n) (i : Fin n) :
+    typeDHalfTotal (typeDRootEquiv n hn (typeDSimpleIndex n hn i)) =
+      if (i : ℕ) + 1 < n then 0 else 1 := by
+  by_cases hi : (i : ℕ) + 1 < n
+  · have htotal : ∑ j : Fin n, typeDSimpleRoot n hn i j = 0 := by
+      rw [typeDSimpleRoot_of_add_one_lt hn hi]
+      simp_rw [Pi.sub_apply]
+      rw [Finset.sum_sub_distrib, Fintype.sum_pi_single', Fintype.sum_pi_single']
+      omega
+    rw [ite_eq_left hi]
+    simp only [typeDHalfTotal, typeDRootEquiv_apply_typeDSimpleIndex, htotal]
+    norm_num
+  · have htotal : ∑ j : Fin n, typeDSimpleRoot n hn i j = 2 := by
+      rw [typeDSimpleRoot_of_not_add_one_lt hn hi]
+      simp_rw [Pi.add_apply]
+      rw [Finset.sum_add_distrib, Fintype.sum_pi_single', Fintype.sum_pi_single']
+      norm_num
+    rw [ite_eq_right hi]
+    simp only [typeDHalfTotal, typeDRootEquiv_apply_typeDSimpleIndex, htotal]
+    norm_num
+
 /-- The coordinates of the `i`-th simple root are the `i`-th standard basis vector. -/
 @[simp] theorem typeDSimpleRootCoordinates_typeDRootEquiv_apply_typeDSimpleIndex
     (hn : 4 ≤ n) (i : Fin n) :
@@ -496,16 +520,9 @@ def typeDSimpleRootCoordinates (n : ℕ) (hn : 4 ≤ n) (x : TypeDRoot n) : Fin 
   funext k
   rw [typeDSimpleRootCoordinates]
   simp only [typeDRootEquiv_apply_typeDSimpleIndex]
+  have hhalf := typeDHalfTotal_typeDRootEquiv_typeDSimpleIndex hn i
   by_cases hi : (i : ℕ) + 1 < n
-  · have htotal : ∑ j : Fin n, typeDSimpleRoot n hn i j = 0 := by
-      rw [typeDSimpleRoot, dite_eq_left hi]
-      simp_rw [Pi.sub_apply]
-      rw [Finset.sum_sub_distrib, Fintype.sum_pi_single', Fintype.sum_pi_single']
-      omega
-    have hhalf : typeDHalfTotal
-        (typeDRootEquiv n hn (typeDSimpleIndex n hn i)) = 0 := by
-      simp only [typeDHalfTotal, typeDRootEquiv_apply_typeDSimpleIndex, htotal]
-      norm_num
+  · rw [ite_eq_left hi] at hhalf
     by_cases hk₂ : (k : ℕ) + 2 < n
     · rw [ite_eq_left hk₂]
       rw [typeDSimpleRoot, dite_eq_left hi]
@@ -523,15 +540,7 @@ def typeDSimpleRootCoordinates (n : ℕ) (hn : 4 ≤ n) (x : TypeDRoot n) : Fin 
         simp only [Pi.single_apply]
         omega
   · have hiv : (i : ℕ) = n - 1 := by omega
-    have htotal : ∑ j : Fin n, typeDSimpleRoot n hn i j = 2 := by
-      rw [typeDSimpleRoot, dite_eq_right hi]
-      simp_rw [Pi.add_apply]
-      rw [Finset.sum_add_distrib, Fintype.sum_pi_single', Fintype.sum_pi_single']
-      norm_num
-    have hhalf : typeDHalfTotal
-        (typeDRootEquiv n hn (typeDSimpleIndex n hn i)) = 1 := by
-      simp only [typeDHalfTotal, typeDRootEquiv_apply_typeDSimpleIndex, htotal]
-      norm_num
+    rw [ite_eq_right hi] at hhalf
     by_cases hk₂ : (k : ℕ) + 2 < n
     · rw [ite_eq_left hk₂]
       rw [typeDSimpleRoot, dite_eq_right hi]

--- a/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
@@ -491,7 +491,7 @@ def typeDSimpleRootCoordinates (n : ℕ) (hn : 4 ≤ n) (x : TypeDRoot n) : Fin 
 /-- The half-total of the `i`-th type `Dₙ` simple root. The chain roots `e_i - e_{i+1}` have
 coordinate sum `0`, so half-total `0`; the fork root `e_{n-2} + e_{n-1}` has coordinate sum `2`,
 so half-total `1`. -/
-private lemma typeDHalfTotal_typeDRootEquiv_typeDSimpleIndex (hn : 4 ≤ n) (i : Fin n) :
+private lemma typeDHalfTotal_typeDRootEquiv_apply_typeDSimpleIndex (hn : 4 ≤ n) (i : Fin n) :
     typeDHalfTotal (typeDRootEquiv n hn (typeDSimpleIndex n hn i)) =
       if (i : ℕ) + 1 < n then 0 else 1 := by
   by_cases hi : (i : ℕ) + 1 < n
@@ -501,16 +501,18 @@ private lemma typeDHalfTotal_typeDRootEquiv_typeDSimpleIndex (hn : 4 ≤ n) (i :
       rw [Finset.sum_sub_distrib, Fintype.sum_pi_single', Fintype.sum_pi_single']
       omega
     rw [ite_eq_left hi]
-    simp only [typeDHalfTotal, typeDRootEquiv_apply_typeDSimpleIndex, htotal]
-    norm_num
+    have h2 := two_mul_typeDHalfTotal (typeDRootEquiv n hn (typeDSimpleIndex n hn i))
+    rw [typeDRootEquiv_apply_typeDSimpleIndex, htotal] at h2
+    omega
   · have htotal : ∑ j : Fin n, typeDSimpleRoot n hn i j = 2 := by
       rw [typeDSimpleRoot_of_not_add_one_lt hn hi]
       simp_rw [Pi.add_apply]
       rw [Finset.sum_add_distrib, Fintype.sum_pi_single', Fintype.sum_pi_single']
       norm_num
     rw [ite_eq_right hi]
-    simp only [typeDHalfTotal, typeDRootEquiv_apply_typeDSimpleIndex, htotal]
-    norm_num
+    have h2 := two_mul_typeDHalfTotal (typeDRootEquiv n hn (typeDSimpleIndex n hn i))
+    rw [typeDRootEquiv_apply_typeDSimpleIndex, htotal] at h2
+    omega
 
 /-- The coordinates of the `i`-th simple root are the `i`-th standard basis vector. -/
 @[simp] theorem typeDSimpleRootCoordinates_typeDRootEquiv_apply_typeDSimpleIndex
@@ -520,7 +522,7 @@ private lemma typeDHalfTotal_typeDRootEquiv_typeDSimpleIndex (hn : 4 ≤ n) (i :
   funext k
   rw [typeDSimpleRootCoordinates]
   simp only [typeDRootEquiv_apply_typeDSimpleIndex]
-  have hhalf := typeDHalfTotal_typeDRootEquiv_typeDSimpleIndex hn i
+  have hhalf := typeDHalfTotal_typeDRootEquiv_apply_typeDSimpleIndex hn i
   by_cases hi : (i : ℕ) + 1 < n
   · rw [ite_eq_left hi] at hhalf
     by_cases hk₂ : (k : ℕ) + 2 < n


### PR DESCRIPTION
`typeDSimpleRootCoordinates_typeDRootEquiv_apply_typeDSimpleIndex` splits on whether `i` is a
chain node (`e_i - e_{i+1}`) or the fork node (`e_{n-2} + e_{n-1}`). Each branch then opened
by recomputing the same two facts from scratch — the coordinate sum of the `i`-th simple root,
and the half-total that follows from it — nine lines apiece, differing only in the values
`0`/`0` and `2`/`1`.

Those are one fact with an `if`, so name it:

```lean
private lemma typeDHalfTotal_typeDRootEquiv_typeDSimpleIndex (hn : 4 ≤ n) (i : Fin n) :
    typeDHalfTotal (typeDRootEquiv n hn (typeDSimpleIndex n hn i)) =
      if (i : ℕ) + 1 < n then 0 else 1
```

The parent derives it once, before the split; each branch then just reduces the `if`.

| | before | after |
|---|---|---|
| `typeDSimpleRootCoordinates_typeDRootEquiv_apply_typeDSimpleIndex` body | 55 lines | **40 lines** |
| `typeDHalfTotal_typeDRootEquiv_typeDSimpleIndex` | — | 17 lines |

## Using the file's own API

The two derivations reached the branch forms of `typeDSimpleRoot` by unfolding the definition
and reducing its `dite` by hand (`rw [typeDSimpleRoot, dite_eq_left hi]`). The file already
exports exactly those two forms as simp lemmas — `typeDSimpleRoot_of_add_one_lt` and
`typeDSimpleRoot_of_not_add_one_lt` — so the extracted lemma rewrites with them instead.

The four remaining hand-unfoldings inside the parent's sub-cases are left alone: they are
pre-existing lines in goals this PR does not otherwise touch, and converting them is a
separate, purely mechanical change.

## Note on `if_pos` / `if_neg`

A first draft used `if_pos`/`if_neg`; the compiler rejects them as deprecated in favour of
`ite_eq_left`/`ite_eq_right`, which is what the rest of this file already uses. The diff uses
the file's idiom throughout.

## Gates

- `lake build TauCeti.LinearAlgebra.RootSystem.ClassicalTypeD` — exit 0, 2475 jobs.
- Both direct importers (`SimplyConnectedRootDatum.E8.Lattice`, `SimplyConnectedRootDatum.D.Basic`)
  — exit 0, 2482 jobs.
- LSP diagnostics on the file — clean, no warnings.
- No line in the diff exceeds 100 codepoints; both signature breaks are justified
  (87 + 1 + 14 = 102, 68 + 1 + 38 = 107).
- Branch is level with `main`; no pin change; `merge-tree` reports 0 conflicts.

The full-build gates (`lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`) are
left to CI's `pr-build`, per the module-scoped local-build policy.

Roadmap: RepresentationTheory
