### PR TITLE
feat(ModularForms): the Fricke matrix normalizes Γ₀(N) and Γ₁(N)

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -303,6 +303,12 @@ public theorem coe_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
 
 section NeZero
 
+/-- The value of mathlib's `Gamma0Map` on a `Γ₀(N)` element: it is the lower-right entry, reduced.
+`Gamma0Map` is a bare `MonoidHom.mk`, so this is definitional; naming it keeps the one
+definitional step out of the `simp` sets below. -/
+private theorem gamma0Map_apply (g : ↥(Gamma0 N)) :
+    Gamma0Map N g = (((g : Matrix (Fin 2) (Fin 2) ℤ) 1 1 : ℤ) : ZMod N) := rfl
+
 /-- **The Fricke conjugation inverts the diamond label.** `Gamma0Map` reads the lower-right entry
 mod `N`; conjugation swaps the two diagonal entries, so it reads `a` where it read `d`, and
 `a · d ≡ 1 (mod N)` because `det σ = 1` and `N ∣ c`.
@@ -313,34 +319,41 @@ involution has to redo the determinant argument. -/
 public theorem gamma0Map_frickeConjGamma0_mul (σ : ↥(Gamma0 N)) :
     Gamma0Map N (frickeConjGamma0 σ) * Gamma0Map N σ = 1 := by
   have hcast := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 (M := N) σ.property
-  simpa [Gamma0Map, coe_frickeConjGamma0] using hcast
+  simp only [gamma0Map_apply, coe_frickeConjGamma0, coe_frickeConjSL]
+  simpa using hcast
 
 variable [NeZero N]
 
-/-- **The Fricke conjugation is an involution at nonzero level**: applying it twice is the
-identity on `Γ₀(N)`.
+/-- **Applying the entry map twice is the identity, at nonzero level**, on `SL(2, ℤ)` itself:
+this is the entrywise content of the involution, stated where a consumer holding a plain
+`frickeConjSL σ` can use it without wrapping into `Γ₀(N)`. The two bundled involutions below are
+`Subtype.ext` of this.
 
 This genuinely needs `N ≠ 0`. At level zero the lower-left entry `-N·b` of `frickeConjSL σ` is
 `0` whatever `b` is, so the formula forgets `b` and cannot be undone; see the `Level` section of
 the module docstring. -/
-@[simp]
 -- The reason is that `W² = (-N) • 1` is central, so conjugating twice does nothing; the proof
 -- below is the entrywise form of that over `ℤ`, with no `W` in sight.
-public theorem frickeConjGamma0_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
-    frickeConjGamma0 (frickeConjGamma0 σ) = σ := by
+public theorem frickeConjSL_frickeConjSL (σ : ↥(Gamma0 N)) :
+    frickeConjSL ⟨frickeConjSL σ, frickeConjSL_mem_Gamma0 σ⟩ = (σ : SL(2, ℤ)) := by
   have hN : (N : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (NeZero.ne N)
-  have hdiv : ((frickeConjGamma0 σ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ) =
+  have hdiv : ((frickeConjSL σ : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ) =
       -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
-    have hentry : ((frickeConjGamma0 σ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 =
+    have hentry : ((frickeConjSL σ : SL(2, ℤ)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 =
         (N : ℤ) * -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
-      rw [coe_frickeConjGamma0, coe_frickeConjSL]
+      rw [coe_frickeConjSL]
       simp
     rw [hentry, Int.mul_ediv_cancel_left _ hN]
-  apply Subtype.ext
-  rw [coe_frickeConjGamma0]
   ext i j
-  rw [coe_frickeConjSL, hdiv, coe_frickeConjGamma0, coe_frickeConjSL]
+  rw [coe_frickeConjSL, hdiv, coe_frickeConjSL]
   fin_cases i <;> fin_cases j <;> simp [natCast_mul_lowerLeft_ediv]
+
+/-- **The Fricke conjugation is an involution at nonzero level**: applying it twice is the
+identity on `Γ₀(N)`. This is `frickeConjSL_frickeConjSL` read through `Subtype.ext`. -/
+@[simp]
+public theorem frickeConjGamma0_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
+    frickeConjGamma0 (frickeConjGamma0 σ) = σ :=
+  Subtype.ext (frickeConjSL_frickeConjSL σ)
 
 /-- `frickeConjGamma0` is involutive, in the form `Function.Involutive` consumes. -/
 public theorem frickeConjGamma0_involutive :
@@ -378,16 +391,12 @@ public theorem frickeConjGamma0MulEquiv_symm :
 
 /-- The `Γ₁(N)` counterpart of `frickeConjGamma0_frickeConjGamma0`. -/
 @[simp]
--- Transports the `Γ₀(N)` involution across the two wrappers, relying on two definitional facts:
--- `frickeConjGamma1` and `frickeConjGamma0` have the same underlying map `frickeConjSL`, so both
--- sides reduce to it on the underlying element, and the two differing `Γ₀(N)`-membership proofs
--- are identified by proof irrelevance. Routing it through the `coe` lemmas instead does not work:
--- `frickeConjGamma0_frickeConjGamma0` is itself `@[simp]`, so `simpa` closes the transported term
--- to `True` before it can discharge the goal.
+-- Read off the value of `frickeConjGamma1` through `coe_frickeConjGamma1` and closed by the
+-- `SL(2, ℤ)`-level involution, so this leans on no identification between two different bundled
+-- maps. The one remaining definitional step is `coe_frickeConjGamma1` itself, which is `(rfl)`.
 public theorem frickeConjGamma1_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
     frickeConjGamma1 (frickeConjGamma1 σ) = σ :=
-  Subtype.ext (congrArg (Subtype.val (p := fun g => g ∈ Gamma0 N))
-    (frickeConjGamma0_frickeConjGamma0 ⟨σ, Gamma1_in_Gamma0 N σ.property⟩))
+  Subtype.ext (frickeConjSL_frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩)
 
 /-- `frickeConjGamma1` is involutive, in the form `Function.Involutive` consumes. -/
 public theorem frickeConjGamma1_involutive :

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -82,6 +82,10 @@ itself defined at an arbitrary algebra.
   unital, at every level. These are what the bundled homomorphisms above are built from.
 * `TauCeti.frickeConjGamma0_frickeConjGamma0`, `TauCeti.frickeConjGamma1_frickeConjGamma1`: for
   `[NeZero N]`, conjugating twice is the identity.
+* `TauCeti.frickeConjGamma0MulEquiv_apply`, `TauCeti.frickeConjGamma0MulEquiv_symm`, and their
+  `Γ₁` twins: the automorphisms act as the homomorphisms and are their own inverses. These, with
+  `coe_frickeConjGamma0` and `coe_frickeConjGamma1`, are the whole interface: none of the bundled
+  definitions exposes its body.
 * `TauCeti.frickeGL_mul_mapGL`, `TauCeti.mapGL_mul_frickeGL`: for `(N : K) ≠ 0`, the two
   normalization identities `W · σ = (W σ W⁻¹) · W` and `σ · W = W · (W σ W⁻¹)` in
   `GL (Fin 2) K`. These are the statements that exhibit `W` as normalizing `Γ₀(N)`.
@@ -213,6 +217,7 @@ private theorem lowerLeftDiv_mul (σ τ : ↥(Gamma0 N)) :
     ring
 
 /-- **`frickeConjSL` sends `1` to `1`**. -/
+@[simp]
 public theorem frickeConjSL_one : frickeConjSL (1 : ↥(Gamma0 N)) = 1 := by
   ext i j
   fin_cases i <;> fin_cases j <;> simp [frickeConjSL, lowerLeftDiv]
@@ -235,7 +240,6 @@ public theorem frickeConjSL_mul (σ τ : ↥(Gamma0 N)) :
 form of `frickeConjSL_mem_Gamma0`: it is what "`W` normalizes `Γ₀(N)`" means, and it is what a
 consumer needs in order to transport a subgroup along the conjugation. It exists at every level;
 at nonzero level it is an isomorphism, `frickeConjGamma0MulEquiv`. -/
-@[expose]
 public def frickeConjGamma0 : ↥(Gamma0 N) →* ↥(Gamma0 N) where
   toFun σ := ⟨frickeConjSL σ, frickeConjSL_mem_Gamma0 σ⟩
   map_one' := Subtype.ext frickeConjSL_one
@@ -244,12 +248,11 @@ public def frickeConjGamma0 : ↥(Gamma0 N) →* ↥(Gamma0 N) where
 @[simp]
 public theorem coe_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
     (frickeConjGamma0 σ : SL(2, ℤ)) = frickeConjSL σ :=
-  rfl
+  (rfl)
 
 /-- **The Fricke conjugation restricted to `Γ₁(N)`**, as a group homomorphism
 `Γ₁(N) →* Γ₁(N)`; the `Γ₁` counterpart of `frickeConjGamma0`, bundling
 `frickeConjSL_mem_Gamma1`. -/
-@[expose]
 public def frickeConjGamma1 : ↥(Gamma1 N) →* ↥(Gamma1 N) where
   toFun σ := ⟨frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩,
     frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) σ.property⟩
@@ -260,7 +263,7 @@ public def frickeConjGamma1 : ↥(Gamma1 N) →* ↥(Gamma1 N) where
 @[simp]
 public theorem coe_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
     (frickeConjGamma1 σ : SL(2, ℤ)) = frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩ :=
-  rfl
+  (rfl)
 
 section NeZero
 
@@ -272,6 +275,7 @@ conjugating twice does nothing.
 This genuinely needs `N ≠ 0`. At level zero the lower-left entry `-N·b` of `frickeConjSL σ` is
 `0` whatever `b` is, so the formula forgets `b` and cannot be undone; see the `Level` section of
 the module docstring. -/
+@[simp]
 public theorem frickeConjGamma0_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
     frickeConjGamma0 (frickeConjGamma0 σ) = σ := by
   have hN : (N : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (NeZero.ne N)
@@ -297,7 +301,6 @@ public theorem frickeConjGamma0_involutive :
 /-- **The Fricke conjugation as an automorphism of `Γ₀(N)`**, for nonzero level: the isomorphism
 `Γ₀(N) ≃* Γ₀(N)` that `frickeConjGamma0` becomes once it is known to be involutive. It is its
 own inverse. -/
-@[expose]
 public def frickeConjGamma0MulEquiv : ↥(Gamma0 N) ≃* ↥(Gamma0 N) where
   toFun := frickeConjGamma0
   invFun := frickeConjGamma0
@@ -305,12 +308,24 @@ public def frickeConjGamma0MulEquiv : ↥(Gamma0 N) ≃* ↥(Gamma0 N) where
   right_inv := frickeConjGamma0_involutive
   map_mul' := map_mul frickeConjGamma0
 
+/-- `frickeConjGamma0MulEquiv` acts as `frickeConjGamma0`. This is its defining lemma, and the
+one a consumer needs: the body of `frickeConjGamma0MulEquiv` is not exposed, so nothing downstream
+can see through it by unfolding. -/
 @[simp]
-public theorem coe_frickeConjGamma0MulEquiv (σ : ↥(Gamma0 N)) :
-    (frickeConjGamma0MulEquiv σ : SL(2, ℤ)) = frickeConjSL σ :=
-  rfl
+public theorem frickeConjGamma0MulEquiv_apply (σ : ↥(Gamma0 N)) :
+    frickeConjGamma0MulEquiv σ = frickeConjGamma0 σ :=
+  (rfl)
+
+/-- **`frickeConjGamma0MulEquiv` is its own inverse.** The underlying map is an involution,
+so `symm` returns the automorphism unchanged; this is what lets a consumer simplify
+`e.symm` without unfolding the bundled definition. -/
+@[simp]
+public theorem frickeConjGamma0MulEquiv_symm :
+    (frickeConjGamma0MulEquiv (N := N)).symm = frickeConjGamma0MulEquiv :=
+  (rfl)
 
 /-- The `Γ₁(N)` counterpart of `frickeConjGamma0_frickeConjGamma0`. -/
+@[simp]
 public theorem frickeConjGamma1_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
     frickeConjGamma1 (frickeConjGamma1 σ) = σ :=
   Subtype.ext (congrArg (Subtype.val (p := fun g => g ∈ Gamma0 N))
@@ -323,7 +338,6 @@ public theorem frickeConjGamma1_involutive :
 
 /-- **The Fricke conjugation as an automorphism of `Γ₁(N)`**, for nonzero level; the `Γ₁`
 counterpart of `frickeConjGamma0MulEquiv`. -/
-@[expose]
 public def frickeConjGamma1MulEquiv : ↥(Gamma1 N) ≃* ↥(Gamma1 N) where
   toFun := frickeConjGamma1
   invFun := frickeConjGamma1
@@ -331,11 +345,18 @@ public def frickeConjGamma1MulEquiv : ↥(Gamma1 N) ≃* ↥(Gamma1 N) where
   right_inv := frickeConjGamma1_involutive
   map_mul' := map_mul frickeConjGamma1
 
+/-- `frickeConjGamma1MulEquiv` acts as `frickeConjGamma1`; the `Γ₁(N)` counterpart of
+`frickeConjGamma0MulEquiv_apply`. -/
 @[simp]
-public theorem coe_frickeConjGamma1MulEquiv (σ : ↥(Gamma1 N)) :
-    (frickeConjGamma1MulEquiv σ : SL(2, ℤ)) =
-      frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩ :=
-  rfl
+public theorem frickeConjGamma1MulEquiv_apply (σ : ↥(Gamma1 N)) :
+    frickeConjGamma1MulEquiv σ = frickeConjGamma1 σ :=
+  (rfl)
+
+/-- The `Γ₁(N)` counterpart of `frickeConjGamma0MulEquiv_symm`. -/
+@[simp]
+public theorem frickeConjGamma1MulEquiv_symm :
+    (frickeConjGamma1MulEquiv (N := N)).symm = frickeConjGamma1MulEquiv :=
+  (rfl)
 
 end NeZero
 

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 public import TauCeti.NumberTheory.ModularForms.Fricke.Matrix
-import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
+import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups.Basic
 
 /-!
 # Conjugating `Γ₀(N)` and `Γ₁(N)` by the Fricke matrix
@@ -143,11 +143,14 @@ each along `ℚ → ℝ` by hand, in `glMap_frickeGL_mul_mapGL` and `mapGL_mul_g
 them over `K` as below makes both transports the corresponding instance, so those two lemmas have
 no counterpart here.
 
-The diamond-character companion `Gamma0MapUnits_frickeConjSL` is *partly* ported. Its
-`ZMod`-level content is `gamma0Map_frickeConjGamma0_mul` below. Only the unit-valued refinement is
-left out, because it is stated in terms of AINTLIB's `Gamma0MapUnits`, the unit-valued refinement
-of mathlib's `CongruenceSubgroup.Gamma0Map`, which TauCeti does not have; that part belongs with
-that definition rather than here, and follows from the shipped lemma by `MonoidHom.toHomUnits`.
+The diamond-character companion `Gamma0MapUnits_frickeConjSL` is ported in both of its halves.
+Its `ZMod`-level content is `gamma0Map_frickeConjGamma0_mul` below, and its unit-valued content is
+`toHomUnits_gamma0Map_frickeConjGamma0_eq_inv`. The two differ from upstream in how they reach the
+units: AINTLIB states the refinement in terms of its own `Gamma0MapUnits`, a unit-valued refinement
+of mathlib's `CongruenceSubgroup.Gamma0Map`, whereas here the same content is obtained from the
+`ZMod` identity through mathlib's `MonoidHom.toHomUnits`. What is *not* ported is that
+`Gamma0MapUnits` definition itself: TauCeti does not have it, and it belongs with the `Gamma0Map`
+API rather than with the Fricke conjugation.
 
 ## References
 
@@ -318,9 +321,9 @@ private theorem gamma0Map_apply (g : ↥(Gamma0 N)) :
 mod `N`; conjugation swaps the two diagonal entries, so it reads `a` where it read `d`, and
 `a · d ≡ 1 (mod N)` because `det σ = 1` and `N ∣ c`.
 
-Stated at the `ZMod` level, which is where `Gamma0Map` lands; the unit-valued form follows by
-applying `MonoidHom.toHomUnits`. Without it a consumer computing a nebentypus along the Fricke
-involution has to redo the determinant argument. -/
+Stated at the `ZMod` level, which is where `Gamma0Map` lands; the unit-valued form is
+`toHomUnits_gamma0Map_frickeConjGamma0_eq_inv`, derived from this one. Without it a consumer
+computing a nebentypus along the Fricke involution has to redo the determinant argument. -/
 public theorem gamma0Map_frickeConjGamma0_mul (σ : ↥(Gamma0 N)) :
     Gamma0Map N (frickeConjGamma0 σ) * Gamma0Map N σ = 1 := by
   have hcast := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 (M := N) σ.property

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 public import TauCeti.NumberTheory.ModularForms.Fricke.Matrix
 import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
+import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 
 /-!
 # Conjugating `Γ₀(N)` and `Γ₁(N)` by the Fricke matrix
@@ -91,6 +92,9 @@ itself defined at an arbitrary algebra.
   unital, at every level. These are what the bundled endomorphisms above are built from.
 * `TauCeti.frickeConjGamma0_frickeConjGamma0`, `TauCeti.frickeConjGamma1_frickeConjGamma1`:
   for `[NeZero N]`, applying the entry map twice is the identity.
+* `TauCeti.gamma0Map_frickeConjGamma0_mul`: the `Gamma0Map` images of `frickeConjGamma0 σ` and
+  of `σ` are inverse in `ZMod N`, at every level. This is the `ZMod`-level content of AINTLIB's
+  diamond-character companion; see the Provenance section.
 * `TauCeti.frickeConjGamma0MulEquiv_apply`, `TauCeti.frickeConjGamma0MulEquiv_symm`, and their
   `Γ₁` twins: the automorphisms act as the endomorphisms and are their own inverses. These, with
   `coe_frickeConjGamma0` and `coe_frickeConjGamma1`, are the intended interface for the bundled
@@ -135,10 +139,11 @@ each along `ℚ → ℝ` by hand, in `glMap_frickeGL_mul_mapGL` and `mapGL_mul_g
 them over `K` as below makes both transports the corresponding instance, so those two lemmas have
 no counterpart here.
 
-The diamond-character companion `Gamma0MapUnits_frickeConjSL` is deliberately *not* ported: it
-is stated in terms of AINTLIB's `Gamma0MapUnits`, the unit-valued refinement of mathlib's
-`CongruenceSubgroup.Gamma0Map`, which TauCeti does not have. It belongs with that definition
-rather than here, and nothing in this file needs it.
+The diamond-character companion `Gamma0MapUnits_frickeConjSL` is *partly* ported. Its
+`ZMod`-level content is `gamma0Map_frickeConjGamma0_mul` below. Only the unit-valued refinement is
+left out, because it is stated in terms of AINTLIB's `Gamma0MapUnits`, the unit-valued refinement
+of mathlib's `CongruenceSubgroup.Gamma0Map`, which TauCeti does not have; that part belongs with
+that definition rather than here, and follows from the shipped lemma by `MonoidHom.toHomUnits`.
 
 ## References
 
@@ -307,16 +312,7 @@ applying `MonoidHom.toHomUnits`. Without it a consumer computing a nebentypus al
 involution has to redo the determinant argument. -/
 public theorem gamma0Map_frickeConjGamma0_mul (σ : ↥(Gamma0 N)) :
     Gamma0Map N (frickeConjGamma0 σ) * Gamma0Map N σ = 1 := by
-  have hdet : (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 -
-      (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = 1 :=
-    fin_two_mul_sub_mul_eq_one (σ : SL(2, ℤ))
-  have hc : (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ℤ) : ZMod N) = 0 := Gamma0_mem.mp σ.property
-  have hcast : (((σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 : ℤ) : ZMod N) *
-      (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 : ℤ) : ZMod N) -
-      (((σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 : ℤ) : ZMod N) *
-        (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ℤ) : ZMod N) = 1 := by
-    exact_mod_cast congrArg (Int.cast : ℤ → ZMod N) hdet
-  rw [hc, mul_zero, sub_zero] at hcast
+  have hcast := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 (M := N) σ.property
   simpa [Gamma0Map, coe_frickeConjGamma0] using hcast
 
 variable [NeZero N]

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -129,10 +129,15 @@ upstream, `natCast_mul_lowerLeft_ediv` here), `frickeConjSL` with its coercion l
 `frickeConjGamma0` and `frickeConjGamma1` with their involution lemmas, and the two `MulEquiv`s
 `frickeConjGamma0MulEquiv` and `frickeConjGamma1MulEquiv` with their `apply`/`symm` lemmas.
 
-AINTLIB names the divisibility witness `botLeftDiv` and keeps it private; it is private
-here too, and `coe_frickeConjSL` writes the quotient `c / N` out instead, so the public API is
-the matrix formula alone. AINTLIB obtains the witness as the `Exists.choose` of the `Γ₀(N)`
-divisibility, which makes it and `frickeConjSL` `noncomputable` and their entries opaque; here it
+AINTLIB names the divisibility witness `botLeftDiv` and keeps it private. Here its spec is
+**public**, as `natCast_mul_lowerLeft_ediv`, and it is `@[simp]`: `coe_frickeConjSL` writes the
+quotient `c / N` out as an `Int.ediv`, so a consumer of that `simp` lemma needs the spec to make
+progress, and keeping it private would force every use site to re-derive `(N : ℤ) ∣ c` from
+`Gamma0_mem`. The public API is therefore the matrix formula together with that one normalization
+rule.
+
+AINTLIB obtains the witness as the `Exists.choose` of the `Γ₀(N)` divisibility, which makes it and
+`frickeConjSL` `noncomputable` and their entries opaque; here it
 is the honest quotient `c / N`, exact because `N ∣ c`, so both definitions are computable and
 reduce entrywise. AINTLIB states the two normalization identities over `ℚ` and then transports
 each along `ℚ → ℝ` by hand, in `glMap_frickeGL_mul_mapGL` and `mapGL_mul_glMap_frickeGL`; stating
@@ -164,6 +169,7 @@ variable {N : ℕ}
 Public because `coe_frickeConjSL` displays `c / N`, an `Int.ediv`: without this a consumer of that
 `simp` lemma is left with an opaque quotient and has to re-derive `(N : ℤ) ∣ c` from `Gamma0_mem`
 at every use site. This is the only place the `Γ₀(N)` divisibility is used. -/
+@[simp]
 public theorem natCast_mul_lowerLeft_ediv (σ : ↥(Gamma0 N)) :
     (N : ℤ) * ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ)) =
       (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 :=

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -7,20 +7,23 @@ module
 
 public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 public import TauCeti.NumberTheory.ModularForms.Fricke.Matrix
+import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
 
 /-!
 # Conjugating `Γ₀(N)` and `Γ₁(N)` by the Fricke matrix
 
-For `N ≠ 0` and `σ = !![a, b; c, d] ∈ Γ₀(N)`, so `N ∣ c`, conjugating by the Fricke matrix
-`W = !![0, -1; N, 0]` of `TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean` gives
+Over a field in which `N` is invertible, and for `σ = !![a, b; c, d] ∈ Γ₀(N)`, so `N ∣ c`,
+conjugating by the Fricke matrix `W = !![0, -1; N, 0]` of
+`TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean` gives
 
 `W · σ · W⁻¹ = !![d, -c/N; -N·b, a]`,
 
 which is again integral, again of determinant one, and again in `Γ₀(N)`. This file builds the
 right-hand side as an honest `SL(2, ℤ)` matrix — `frickeConjSL` — reading it off the entries of
-`σ`, so that it is defined at every level; records that it stays inside `Γ₀(N)` and inside
-`Γ₁(N)`, again at every level; and proves, for `N ≠ 0`, the two matrix identities that move `W`
-past `σ` and are what make `frickeConjSL σ` the conjugate `W · σ · W⁻¹`.
+`σ`, so that it is defined at every level; records that a `Γ₀(N)` input stays inside `Γ₀(N)`
+and that a `Γ₁(N)` input stays inside `Γ₁(N)`, again at every level; and proves, over a field
+in which `N` is invertible, the two matrix identities that move `W` past `σ` and are what make
+`frickeConjSL σ` the conjugate `W · σ · W⁻¹`.
 
 `frickeConjSL` is defined directly by its entries rather than as a product `W * σ * W⁻¹`: the
 latter lives in `GL (Fin 2) K` and is only *incidentally* integral, so reading an `SL(2, ℤ)`
@@ -29,13 +32,15 @@ proving the product identities afterwards keeps the divisibility in one place.
 
 ## Level
 
-`N ≠ 0` is what makes `W` invertible, and so what makes conjugation by `W` mean anything. It is
+`(N : K) ≠ 0` is what makes `W` invertible, and so what makes conjugation by `W` mean
+anything. Over the arbitrary field `K` of the identities below that is strictly stronger than
+`N ≠ 0`: a nonzero level casts to zero whenever the characteristic of `K` divides it. It is
 needed for the *conjugation*, though, not for the entry formula, so it is stated where `W`
 itself appears: as `[NeZero (N : K)]` on the two normalization identities over `K`, which are
 the statements that actually call `frickeConjSL σ` a conjugate. The `ℤ`-valued declarations
-below carry no level hypothesis — the matrix `!![d, -c'; -N·b, a]` has determinant `1` and lies
-in both congruence subgroups for every `N`, `c = N · (c / N)` holding at `N = 0` as well, both
-sides being zero.
+below carry no level hypothesis — the matrix `!![d, -c'; -N·b, a]` has determinant `1`, lies in
+`Γ₀(N)` for every `N`, and lies in `Γ₁(N)` whenever `σ` does, `c = N · (c / N)` holding at
+`N = 0` as well, both sides being zero.
 
 Level zero is genuinely degenerate, and the declarations below are worded so that nothing
 claims otherwise: `Γ₀(0)` is the upper-triangular subgroup, the quotient `c / N` is `0`, and the
@@ -54,14 +59,16 @@ itself defined at an arbitrary algebra.
 ## Main definitions
 
 * `TauCeti.frickeConjSL`: the matrix `!![d, -c/N; -N·b, a]` as an element of `SL(2, ℤ)`;
-  for `N ≠ 0` it is the conjugate `W · σ · W⁻¹`.
+  over a field in which `N` is invertible it is the conjugate `W · σ · W⁻¹`.
 
 ## Main results
 
 * `TauCeti.coe_frickeConjSL`: the entries of `frickeConjSL σ`, namely `!![d, -c/N; -N·b, a]`.
-* `TauCeti.frickeConjSL_mem_Gamma0`, `TauCeti.frickeConjSL_mem_Gamma1`: that formula preserves
-  both congruence subgroups, at every level.
-* `TauCeti.frickeGL_mul_mapGL`, `TauCeti.mapGL_mul_frickeGL`: for `N ≠ 0`, the two
+* `TauCeti.frickeConjSL_mem_Gamma0`: a `Γ₀(N)` input has `frickeConjSL σ ∈ Γ₀(N)`, at every
+  level.
+* `TauCeti.frickeConjSL_mem_Gamma1`: a `Γ₁(N)` input has `frickeConjSL σ ∈ Γ₁(N)`, at every
+  level. This is a second hypothesis on `σ`, not a consequence of the previous line.
+* `TauCeti.frickeGL_mul_mapGL`, `TauCeti.mapGL_mul_frickeGL`: for `(N : K) ≠ 0`, the two
   normalization identities `W · σ = (W σ W⁻¹) · W` and `σ · W = W · (W σ W⁻¹)` in
   `GL (Fin 2) K`. These are the statements that exhibit `W` as normalizing `Γ₀(N)`.
 
@@ -125,18 +132,16 @@ private theorem lowerLeftDiv_spec (σ : ↥(Gamma0 N)) :
 /-- The Fricke conjugate of `σ = !![a, b; N·c', d] ∈ Γ₀(N)`, as an element of `SL(2, ℤ)`: the
 matrix `!![d, -c'; -N·b, a]`.
 
-For `N ≠ 0` this is `W · σ · W⁻¹`, and equally `W⁻¹ · σ · W` since `W² = (-N) • 1` is central;
-that is the content of `frickeGL_mul_mapGL` and `mapGL_mul_frickeGL`, which carry the
-invertibility hypothesis. At `N = 0` the formula still defines a matrix, but a degenerate one;
-see the `Level` section of the module docstring. -/
+Over a field `K` with `(N : K) ≠ 0` this is `W · σ · W⁻¹`, and equally `W⁻¹ · σ · W` since
+`W² = (-N) • 1` is central; that is the content of `frickeGL_mul_mapGL` and
+`mapGL_mul_frickeGL`, which carry the invertibility hypothesis. At `N = 0` the formula still
+defines a matrix, but a degenerate one; see the `Level` section of the module docstring. -/
 public def frickeConjSL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
   ⟨!![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
       -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0], by
     have hc := lowerLeftDiv_spec σ
-    set M := (σ : Matrix (Fin 2) (Fin 2) ℤ) with hM
-    have hdet : M 0 0 * M 1 1 - M 0 1 * M 1 0 = 1 := by
-      have := σ.1.prop
-      rwa [det_fin_two] at this
+    set M := (σ : Matrix (Fin 2) (Fin 2) ℤ)
+    have hdet : M 0 0 * M 1 1 - M 0 1 * M 1 0 = 1 := fin_two_mul_sub_mul_eq_one (σ : SL(2, ℤ))
     rw [det_fin_two_of]
     linear_combination hdet + M 0 1 * hc⟩
 
@@ -150,16 +155,18 @@ public theorem coe_frickeConjSL (σ : ↥(Gamma0 N)) :
   simp [frickeConjSL, lowerLeftDiv]
 
 /-- **`frickeConjSL` preserves `Γ₀(N)`**: its lower-left entry `-N·b` is visibly divisible by
-`N`. This is a statement about the entry formula, so it holds at every level; for `N ≠ 0`, where
-`frickeConjSL σ` really is `W · σ · W⁻¹`, it says that `W` normalizes `Γ₀(N)`. -/
+`N`. This is a statement about the entry formula, so it holds at every level; over a field in
+which `N` is invertible, where `frickeConjSL σ` really is `W · σ · W⁻¹`, it says that `W`
+normalizes `Γ₀(N)`. -/
 public theorem frickeConjSL_mem_Gamma0 (σ : ↥(Gamma0 N)) :
     frickeConjSL σ ∈ Gamma0 N := by
   rw [Gamma0_mem, coe_frickeConjSL]
   simp
 
 /-- **`frickeConjSL` preserves `Γ₁(N)`**: the entry formula swaps the two diagonal entries, so
-both remain `≡ 1 (mod N)`. As for `Γ₀(N)` this holds at every level, and for `N ≠ 0` it says
-that `W` normalizes `Γ₁(N)`. -/
+both remain `≡ 1 (mod N)`. Note that this needs `σ ∈ Γ₁(N)`, not merely `σ ∈ Γ₀(N)`. As for
+`Γ₀(N)` it holds at every level, and over a field in which `N` is invertible it says that `W`
+normalizes `Γ₁(N)`. -/
 public theorem frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
     frickeConjSL ⟨σ, Gamma1_in_Gamma0 N hσ⟩ ∈ Gamma1 N := by
   obtain ⟨ha, hd, -⟩ := (Gamma1_mem N σ).mp hσ
@@ -186,14 +193,14 @@ public theorem frickeGL_mul_mapGL (σ : ↥(Gamma0 N)) :
     frickeGL K N * mapGL K (σ : SL(2, ℤ)) = mapGL K (frickeConjSL σ) * frickeGL K N := by
   apply Units.ext
   have hc := lowerLeftDiv_spec_field K σ
+  rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.GeneralLinearGroup.coe_mul,
+    coe_mapGL_fin_two, coe_mapGL_fin_two, coe_frickeGL]
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp only [Matrix.GeneralLinearGroup.coe_mul, Matrix.mul_apply, Fin.sum_univ_two,
-      coe_frickeGL, mapGL_coe_matrix, RingHom.mapMatrix_apply, Matrix.map_apply,
-      coe_frickeConjSL, SpecialLinearGroup.map_apply_coe, Matrix.cons_val_zero,
-      Matrix.cons_val_one, Matrix.of_apply, algebraMap_int_eq, Int.coe_castRingHom,
-      Fin.isValue, Fin.zero_eta, Fin.mk_one, Int.cast_mul, Int.cast_neg, Int.cast_natCast,
-      lowerLeftDiv, hc] <;>
+    simp only [Matrix.mul_apply, Fin.sum_univ_two, coe_frickeConjSL, Matrix.cons_val_zero,
+      Matrix.cons_val_one, Matrix.of_apply, algebraMap_int_eq, Int.coe_castRingHom, Fin.isValue,
+      Fin.zero_eta, Fin.mk_one, Int.cast_mul, Int.cast_neg, Int.cast_natCast, lowerLeftDiv,
+      hc] <;>
     ring
 
 /-- `W²` commutes with everything in `GL (Fin 2) K`: it is the scalar matrix `(-N) • 1`. -/

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Chris Birkbeck. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Chris Birkbeck
+Authors: Chris Birkbeck, Claude
 -/
 module
 
@@ -19,43 +19,40 @@ conjugating by the Fricke matrix `W = !![0, -1; N, 0]` of
 `W · σ · W⁻¹ = !![d, -c/N; -N·b, a]`,
 
 which is again integral, again of determinant one, and again in `Γ₀(N)`. This file builds the
-right-hand side as an honest `SL(2, ℤ)` matrix — `frickeEntrySL` — reading it off the entries of
+right-hand side as an honest `SL(2, ℤ)` matrix — `frickeConjSL` — reading it off the entries of
 `σ`, so that it is defined at every level; records that a `Γ₀(N)` input stays inside `Γ₀(N)`
 and that a `Γ₁(N)` input stays inside `Γ₁(N)`, again at every level; and proves, over a field
 in which `N` is invertible, the two matrix identities that move `W` past `σ` and are what make
-`frickeEntrySL σ` the conjugate `W · σ · W⁻¹`.
+`frickeConjSL σ` the conjugate `W · σ · W⁻¹`.
 
-`frickeEntrySL` is defined directly by its entries rather than as a product `W * σ * W⁻¹`: the
+`frickeConjSL` is defined directly by its entries rather than as a product `W * σ * W⁻¹`: the
 latter lives in `GL (Fin 2) K` and is only *incidentally* integral, so reading an `SL(2, ℤ)`
 element back out of it would need the divisibility argument anyway. Defining it by entries and
 proving the product identities afterwards keeps the divisibility in one place.
 
-## Level and naming
+## Level
 
 `(N : K) ≠ 0` is what makes `W` invertible, and so what makes conjugation by `W` mean
 anything. Over the arbitrary field `K` of the identities below that is strictly stronger than
 `N ≠ 0`: a nonzero level casts to zero whenever the characteristic of `K` divides it. It is
-needed for the *conjugation*, though, not for the entry formula, so it is stated where `W`
-itself appears: as `[NeZero (N : K)]` on the two normalization identities over `K`, which are
-the statements that actually exhibit `frickeEntrySL σ` as a conjugate.
+needed for the *conjugation*, not for the entry formula that computes it, so it is stated where
+`W` itself appears: as `[NeZero (N : K)]` on the two normalization identities over `K`, which are
+the statements that exhibit `frickeConjSL σ` as a conjugate.
 
-The entry formula itself needs no level hypothesis: `!![d, -c'; -N·b, a]` has determinant `1`,
-lies in `Γ₀(N)` for every `N`, lies in `Γ₁(N)` whenever `σ` does, and is multiplicative in `σ`,
-`c = N · (c / N)` holding at `N = 0` as well, both sides being zero. At `N = 0` it is not a
-conjugation, though: `Γ₀(0)` is the upper-triangular subgroup, the quotient `c / N` is `0`, and
-the formula collapses to `!![a, b; 0, d] ↦ !![d, 0; 0, a]`, which forgets `b` — and
-`frickeGL K 0` does not exist for it to be a conjugation by.
+The formula itself needs no level hypothesis: `!![d, -c'; -N·b, a]` has determinant `1`, lies in
+`Γ₀(N)` for every `N`, lies in `Γ₁(N)` whenever `σ` does, and is multiplicative in `σ`,
+`c = N · (c / N)` holding at `N = 0` as well, both sides being zero. At `N = 0` the value is junk
+rather than a conjugation: `Γ₀(0)` is the upper-triangular subgroup, the quotient `c / N` is `0`,
+the formula collapses to `!![a, b; 0, d] ↦ !![d, 0; 0, a]`, which forgets `b`, and `frickeGL K 0`
+does not exist for it to be a conjugation by.
 
-**The names record that split.** The declarations that exist at every level are named for the
-entry formula — `frickeEntrySL`, `frickeEntryGamma0`, `frickeEntryGamma1` — and none of them
-claims a conjugation. The name `frickeConj` is reserved for the declarations that carry a level
-hypothesis and genuinely are Fricke conjugation: `frickeConjGamma0MulEquiv` and
-`frickeConjGamma1MulEquiv` under `[NeZero N]`, and the two identities over `K`. There is no
-all-level `frickeConj*` alias.
-
-The split is by name rather than by signature because a signature gate is not available here:
-`[NeZero N]` on `frickeEntrySL` is an argument the definition never uses, so mathlib's
-`unusedArguments` linter rejects it, and the `nolint` allowlist is human-owned and empty.
+The names follow the intended meaning rather than that degenerate value, as mathlib's do for
+`Matrix.inv` at a singular matrix, for `Int.ediv` by `0`, and for `Gamma0 0` itself:
+`frickeConjSL`, `frickeConjGamma0` and `frickeConjGamma1` are named for the Fricke conjugation
+they compute. The level hypothesis then appears only on the declarations that need it —
+`[NeZero N]` on the two `MulEquiv`s and the involution lemmas, `[NeZero (N : K)]` on the
+identities over `K` — and not on the all-level declarations, where `unusedArguments` would reject
+it as an argument the definition never uses.
 
 `[NeZero N]` is a hypothesis on the natural number `N`, not on its image in a field: what fails
 at level zero is the integer division `c / N`. The entry map is a homomorphism at every level
@@ -72,10 +69,10 @@ itself defined at an arbitrary algebra.
 
 ## Main definitions
 
-* `TauCeti.frickeEntrySL`: the matrix `!![d, -c/N; -N·b, a]` as an element of `SL(2, ℤ)`, read
+* `TauCeti.frickeConjSL`: the matrix `!![d, -c/N; -N·b, a]` as an element of `SL(2, ℤ)`, read
   off the entries of `σ` at every level; over a field in which `N` is invertible it is the
   conjugate `W · σ · W⁻¹`.
-* `TauCeti.frickeEntryGamma0`, `TauCeti.frickeEntryGamma1`: that map bundled as a group
+* `TauCeti.frickeConjGamma0`, `TauCeti.frickeConjGamma1`: that map bundled as a group
   endomorphism `Γ₀(N) →* Γ₀(N)`, and its restriction `Γ₁(N) →* Γ₁(N)`. Like the map itself these
   exist at every level, so what they record is that the entry formula preserves the subgroup —
   not, on its own, that `W` normalizes it.
@@ -85,22 +82,23 @@ itself defined at an arbitrary algebra.
 
 ## Main results
 
-* `TauCeti.coe_frickeEntrySL`: the entries of `frickeEntrySL σ`, namely `!![d, -c/N; -N·b, a]`.
-* `TauCeti.frickeEntrySL_mem_Gamma0`: a `Γ₀(N)` input has `frickeEntrySL σ ∈ Γ₀(N)`, at every
+* `TauCeti.coe_frickeConjSL`: the entries of `frickeConjSL σ`, namely `!![d, -c/N; -N·b, a]`.
+* `TauCeti.frickeConjSL_mem_Gamma0`: a `Γ₀(N)` input has `frickeConjSL σ ∈ Γ₀(N)`, at every
   level.
-* `TauCeti.frickeEntrySL_mem_Gamma1`: a `Γ₁(N)` input has `frickeEntrySL σ ∈ Γ₁(N)`, at every
+* `TauCeti.frickeConjSL_mem_Gamma1`: a `Γ₁(N)` input has `frickeConjSL σ ∈ Γ₁(N)`, at every
   level. This is a second hypothesis on `σ`, not a consequence of the previous line.
-* `TauCeti.frickeEntrySL_mul`, `TauCeti.frickeEntrySL_one`: the entry map is multiplicative and
+* `TauCeti.frickeConjSL_mul`, `TauCeti.frickeConjSL_one`: the entry map is multiplicative and
   unital, at every level. These are what the bundled endomorphisms above are built from.
-* `TauCeti.frickeEntryGamma0_frickeEntryGamma0`, `TauCeti.frickeEntryGamma1_frickeEntryGamma1`:
+* `TauCeti.frickeConjGamma0_frickeConjGamma0`, `TauCeti.frickeConjGamma1_frickeConjGamma1`:
   for `[NeZero N]`, applying the entry map twice is the identity.
 * `TauCeti.frickeConjGamma0MulEquiv_apply`, `TauCeti.frickeConjGamma0MulEquiv_symm`, and their
   `Γ₁` twins: the automorphisms act as the endomorphisms and are their own inverses. These, with
-  `coe_frickeEntryGamma0` and `coe_frickeEntryGamma1`, are the intended interface for the bundled
+  `coe_frickeConjGamma0` and `coe_frickeConjGamma1`, are the intended interface for the bundled
   declarations: a consumer works through these simp lemmas rather than through the bodies.
 * `TauCeti.frickeGL_mul_mapGL`, `TauCeti.mapGL_mul_frickeGL`: for `(N : K) ≠ 0`, the two
   normalization identities `W · σ = (W σ W⁻¹) · W` and `σ · W = W · (W σ W⁻¹)` in
-  `GL (Fin 2) K`. These are the statements that exhibit `W` as normalizing `Γ₀(N)`.
+  `GL (Fin 2) K`. These are the statements that exhibit `frickeConjSL σ` as the conjugate
+  `W σ W⁻¹`; that `W` normalizes the subgroup is the two `MulEquiv`s.
 
 ## Relation to the Atkin–Lehner anti-involution
 
@@ -108,7 +106,7 @@ itself defined at an arbitrary algebra.
 so the two results look superficially alike. They are different maps. That one is
 `g ↦ w · gᵀ · w⁻¹` for the diagonal `w = natDiagGL 2 ![1, N]`: it transposes, and it is an
 *anti*-homomorphism, bundled as `HeckeRing.GL2.atkinLehnerAntiInvolution_bar` on the Hecke ring
-`Δ₀(N)`. `frickeEntrySL` is the entry formula for plain conjugation by `!![0, -1; N, 0]`, with
+`Δ₀(N)`. `frickeConjSL` is the entry formula for plain conjugation by `!![0, -1; N, 0]`, with
 no transpose, and lives on `Γ₀(N)` itself. The two *matrices* are already distinguished in
 `Fricke/Matrix.lean`; this is the corresponding note for the two conjugation maps.
 
@@ -117,17 +115,27 @@ no transpose, and lives on `Γ₀(N)` itself. The two *matrices* are already dis
 Ported from the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/Fricke.lean`](https://github.com/CBirkbeck/AINTLIB),
 commit `340875adfb2`, Apache-2.0, Chris Birkbeck), realizing part of Layer 6 of the ModularForms
-roadmap. AINTLIB names the divisibility witness `botLeftDiv` and keeps it private; it is private
-here too, and `coe_frickeEntrySL` writes the quotient `c / N` out instead, so the public API is
+roadmap.
+
+Ported from there: the divisibility witness and its spec (`botLeftDiv`, `botLeftDiv_spec`
+upstream, `natCast_mul_lowerLeft_ediv` here), `frickeConjSL` with its coercion lemma,
+`frickeConjSL_mem_Gamma0` and `frickeConjSL_mem_Gamma1`, and the two normalization identities
+`frickeGL_mul_mapGL` and `mapGL_mul_frickeGL`. Added here, with no counterpart upstream:
+`frickeConjSL_one`, `frickeConjSL_mul`, `lowerLeft_ediv_mul`, `mapGL_frickeConjSL`, the bundled
+`frickeConjGamma0` and `frickeConjGamma1` with their involution lemmas, and the two `MulEquiv`s
+`frickeConjGamma0MulEquiv` and `frickeConjGamma1MulEquiv` with their `apply`/`symm` lemmas.
+
+AINTLIB names the divisibility witness `botLeftDiv` and keeps it private; it is private
+here too, and `coe_frickeConjSL` writes the quotient `c / N` out instead, so the public API is
 the matrix formula alone. AINTLIB obtains the witness as the `Exists.choose` of the `Γ₀(N)`
-divisibility, which makes it and `frickeEntrySL` `noncomputable` and their entries opaque; here it
+divisibility, which makes it and `frickeConjSL` `noncomputable` and their entries opaque; here it
 is the honest quotient `c / N`, exact because `N ∣ c`, so both definitions are computable and
 reduce entrywise. AINTLIB states the two normalization identities over `ℚ` and then transports
 each along `ℚ → ℝ` by hand, in `glMap_frickeGL_mul_mapGL` and `mapGL_mul_glMap_frickeGL`; stating
 them over `K` as below makes both transports the corresponding instance, so those two lemmas have
 no counterpart here.
 
-The diamond-character companion `Gamma0MapUnits_frickeEntrySL` is deliberately *not* ported: it
+The diamond-character companion `Gamma0MapUnits_frickeConjSL` is deliberately *not* ported: it
 is stated in terms of AINTLIB's `Gamma0MapUnits`, the unit-valued refinement of mathlib's
 `CongruenceSubgroup.Gamma0Map`, which TauCeti does not have. It belongs with that definition
 rather than here, and nothing in this file needs it.
@@ -145,198 +153,223 @@ namespace TauCeti
 
 variable {N : ℕ}
 
-/-- For `σ ∈ Γ₀(N)` with lower-left entry `c`, the integer `c'` such that `c = N · c'`. It is
-this quotient, not `c` itself, that appears as an entry of `frickeEntrySL σ`.
+/-- **The `Γ₀(N)` divisibility, in the exact form the entry formula needs**: the lower-left entry
+`c` of `σ` is `N` times the quotient `c / N`, that quotient being exact because `N ∣ c`.
 
-An implementation detail: the public `coe_frickeEntrySL` writes `c / N` out. -/
-private def lowerLeftDiv (σ : ↥(Gamma0 N)) : ℤ :=
-  (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ)
+Public because `coe_frickeConjSL` displays `c / N`, an `Int.ediv`: without this a consumer of that
+`simp` lemma is left with an opaque quotient and has to re-derive `(N : ℤ) ∣ c` from `Gamma0_mem`
+at every use site. This is the only place the `Γ₀(N)` divisibility is used. -/
+public theorem natCast_mul_lowerLeft_ediv (σ : ↥(Gamma0 N)) :
+    (N : ℤ) * ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ)) =
+      (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 :=
+  Int.mul_ediv_cancel'
+    ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp σ.property))
 
-/-- The defining property of `lowerLeftDiv`: the lower-left entry of `σ` is `N · lowerLeftDiv σ`.
-This is the only place the `Γ₀(N)` divisibility is used. -/
-private theorem lowerLeftDiv_spec (σ : ↥(Gamma0 N)) :
-    (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = N * lowerLeftDiv σ :=
-  (Int.mul_ediv_cancel'
-    ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp σ.property))).symm
+/-- **The Fricke conjugate** of `σ = !![a, b; N·c', d] ∈ Γ₀(N)`, as an element of `SL(2, ℤ)`:
+the matrix `!![d, -c'; -N·b, a]`.
 
-/-- **The Fricke entry formula** on `σ = !![a, b; N·c', d] ∈ Γ₀(N)`, as an element of
-`SL(2, ℤ)`: the matrix `!![d, -c'; -N·b, a]`.
-
-The name says *entry formula*, not *conjugate*, because this map is defined at every level while
-the conjugation it computes exists only at nonzero level; see the `Level and naming` section of
-the module docstring.
+It is defined by its entries rather than as a product, so it exists at every level; the
+conjugation it computes exists only at nonzero level, and at `N = 0` the value is junk — see the
+`Level` section of the module docstring.
 
 Over a field `K` with `(N : K) ≠ 0` this is `W · σ · W⁻¹`, and equally `W⁻¹ · σ · W` since
 `W² = (-N) • 1` is central; that is the content of `frickeGL_mul_mapGL` and
 `mapGL_mul_frickeGL`, which carry the invertibility hypothesis. At `N = 0` the formula still
 defines a matrix, but a degenerate one; see the `Level` section of the module docstring. -/
-public def frickeEntrySL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
-  ⟨!![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
+public def frickeConjSL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
+  ⟨!![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ));
       -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0], by
-    have hc := lowerLeftDiv_spec σ
+    have hc := (natCast_mul_lowerLeft_ediv σ).symm
     set M := (σ : Matrix (Fin 2) (Fin 2) ℤ)
     have hdet : M 0 0 * M 1 1 - M 0 1 * M 1 0 = 1 := fin_two_mul_sub_mul_eq_one (σ : SL(2, ℤ))
     rw [det_fin_two_of]
     linear_combination hdet + M 0 1 * hc⟩
 
-/-- The underlying matrix of `frickeEntrySL σ`, with the exact quotient `c / N` of the lower-left
+/-- The underlying matrix of `frickeConjSL σ`, with the exact quotient `c / N` of the lower-left
 entry `c` written out. -/
 @[simp]
-public theorem coe_frickeEntrySL (σ : ↥(Gamma0 N)) :
-    (frickeEntrySL σ : Matrix (Fin 2) (Fin 2) ℤ) =
+public theorem coe_frickeConjSL (σ : ↥(Gamma0 N)) :
+    (frickeConjSL σ : Matrix (Fin 2) (Fin 2) ℤ) =
       !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ));
          -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0] := by
-  simp [frickeEntrySL, lowerLeftDiv]
+  simp [frickeConjSL]
 
-/-- The underlying matrix of `frickeEntrySL σ`, written with `lowerLeftDiv` rather than with the
-quotient `c / N` that the public `coe_frickeEntrySL` displays. This is the form the entrywise
-computations below consume, so that they never unfold `frickeEntrySL` itself. -/
-private theorem coe_frickeEntrySL_lowerLeftDiv (σ : ↥(Gamma0 N)) :
-    (frickeEntrySL σ : Matrix (Fin 2) (Fin 2) ℤ) =
-      !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
-         -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0] :=
-  rfl
-
-/-- **`frickeEntrySL` preserves `Γ₀(N)`**: its lower-left entry `-N·b` is visibly divisible by
-`N`. This is a statement about the entry formula, so it holds at every level; over a field in
-which `N` is invertible, where `frickeEntrySL σ` really is `W · σ · W⁻¹`, it says that `W`
-normalizes `Γ₀(N)`. -/
-public theorem frickeEntrySL_mem_Gamma0 (σ : ↥(Gamma0 N)) :
-    frickeEntrySL σ ∈ Gamma0 N := by
-  rw [Gamma0_mem, coe_frickeEntrySL]
+/-- **`frickeConjSL` preserves `Γ₀(N)`**: its lower-left entry `-N·b` is visibly divisible by
+`N`. This maps `Γ₀(N)` into `Γ₀(N)` at every level; that `W` *normalizes* the subgroup is
+`frickeConjGamma0MulEquiv`, which needs `[NeZero N]`. -/
+public theorem frickeConjSL_mem_Gamma0 (σ : ↥(Gamma0 N)) :
+    frickeConjSL σ ∈ Gamma0 N := by
+  rw [Gamma0_mem, coe_frickeConjSL]
   simp
 
-/-- **`frickeEntrySL` preserves `Γ₁(N)`**: the entry formula swaps the two diagonal entries, so
-both remain `≡ 1 (mod N)`. Note that this needs `σ ∈ Γ₁(N)`, not merely `σ ∈ Γ₀(N)`. As for
-`Γ₀(N)` it holds at every level, and over a field in which `N` is invertible it says that `W`
-normalizes `Γ₁(N)`. -/
-public theorem frickeEntrySL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
-    frickeEntrySL ⟨σ, Gamma1_in_Gamma0 N hσ⟩ ∈ Gamma1 N := by
+/-- **`frickeConjSL` preserves `Γ₁(N)`**: the formula swaps the two diagonal entries, so both
+remain `≡ 1 (mod N)`. Note that this needs `σ ∈ Γ₁(N)`, not merely `σ ∈ Γ₀(N)`. As for `Γ₀(N)` it
+maps the subgroup into itself at every level; normalization is `frickeConjGamma1MulEquiv`. -/
+public theorem frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
+    frickeConjSL ⟨σ, Gamma1_in_Gamma0 N hσ⟩ ∈ Gamma1 N := by
   obtain ⟨ha, hd, -⟩ := (Gamma1_mem N σ).mp hσ
-  rw [Gamma1_mem, coe_frickeEntrySL]
+  rw [Gamma1_mem, coe_frickeConjSL]
   exact ⟨by simpa using hd, by simpa using ha, by simp⟩
 
 /-- The lower-left quotient of a product, from the quotients of the two factors. At level zero
-both sides are `0`, `lowerLeftDiv` being division by `0` there. -/
-private theorem lowerLeftDiv_mul (σ τ : ↥(Gamma0 N)) :
-    lowerLeftDiv (σ * τ) =
-      lowerLeftDiv σ * (τ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 +
-        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 * lowerLeftDiv τ := by
+both sides are `0`, the quotient being division by `0` there. -/
+private theorem lowerLeft_ediv_mul (σ τ : ↥(Gamma0 N)) :
+    ((σ * τ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ) =
+      (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ) * (τ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 +
+        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 * ((τ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ)) := by
   rcases eq_or_ne (N : ℤ) 0 with hN | hN
-  · simp [lowerLeftDiv, hN]
+  · simp [hN]
   · refine mul_left_cancel₀ hN ?_
     have hmul : ((σ * τ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 =
         (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 * (τ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 +
           (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 * (τ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 := by
       simp [Matrix.mul_apply, Fin.sum_univ_two]
-    rw [← lowerLeftDiv_spec, hmul, lowerLeftDiv_spec σ, lowerLeftDiv_spec τ]
-    ring
+    linear_combination (norm := ring_nf) natCast_mul_lowerLeft_ediv (σ * τ) + hmul -
+      (τ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 * natCast_mul_lowerLeft_ediv σ -
+      (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 * natCast_mul_lowerLeft_ediv τ
 
-/-- **`frickeEntrySL` sends `1` to `1`**. -/
+/-- **`frickeConjSL` sends `1` to `1`**. -/
 @[simp]
-public theorem frickeEntrySL_one : frickeEntrySL (1 : ↥(Gamma0 N)) = 1 := by
+public theorem frickeConjSL_one : frickeConjSL (1 : ↥(Gamma0 N)) = 1 := by
   ext i j
-  fin_cases i <;> fin_cases j <;> simp [frickeEntrySL, lowerLeftDiv]
+  fin_cases i <;> fin_cases j <;> simp [frickeConjSL]
 
-/-- **`frickeEntrySL` is multiplicative.** Conjugation by `W` is a group homomorphism, and the
+/-- **`frickeConjSL` is multiplicative.** Conjugation by `W` is a group homomorphism, and the
 entry formula records that at every level — including `N = 0`, where it is not a conjugation. -/
 @[simp]
-public theorem frickeEntrySL_mul (σ τ : ↥(Gamma0 N)) :
-    frickeEntrySL (σ * τ) = frickeEntrySL σ * frickeEntrySL τ := by
-  have hσ := lowerLeftDiv_spec σ
-  have hτ := lowerLeftDiv_spec τ
-  have hmul := lowerLeftDiv_mul σ τ
+public theorem frickeConjSL_mul (σ τ : ↥(Gamma0 N)) :
+    frickeConjSL (σ * τ) = frickeConjSL σ * frickeConjSL τ := by
+  have hmul := lowerLeft_ediv_mul σ τ
   ext i j
-  rw [SpecialLinearGroup.coe_mul, coe_frickeEntrySL_lowerLeftDiv, coe_frickeEntrySL_lowerLeftDiv,
-    coe_frickeEntrySL_lowerLeftDiv, Matrix.mul_fin_two]
+  rw [SpecialLinearGroup.coe_mul, coe_frickeConjSL, coe_frickeConjSL, coe_frickeConjSL,
+    Matrix.mul_fin_two]
+  -- Name the two quotients once the entries are in place. They are then opaque, so the exactness
+  -- lemma can be used in the expanding direction `c = N * c'` without rewriting inside the
+  -- quotients themselves — which is what makes the entrywise computation terminate.
+  set c := (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ)
+  set e := (τ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ)
+  have hσ : (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = (N : ℤ) * c :=
+    (natCast_mul_lowerLeft_ediv σ).symm
+  have hτ : (τ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = (N : ℤ) * e :=
+    (natCast_mul_lowerLeft_ediv τ).symm
+  -- Discharge the product's own quotient first. Left to `simp`, the entry `(σ * τ) 1 0` is
+  -- expanded by `Matrix.mul_apply` instead, and the quotient that remains needs `N ≠ 0` to
+  -- cancel — which this lemma does not assume, since it holds at every level.
+  rw [hmul]
   fin_cases i <;> fin_cases j <;>
-    simp [Matrix.mul_apply, Fin.sum_univ_two, hmul, hσ, hτ] <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two, hσ, hτ] <;>
     ring
 
 /-- **The Fricke entry formula as a group endomorphism `Γ₀(N) →* Γ₀(N)`.** This is the bundled
-form of `frickeEntrySL_mem_Gamma0`, and it is what a consumer needs in order to transport a
+form of `frickeConjSL_mem_Gamma0`, and it is what a consumer needs in order to transport a
 subgroup along the map.
 
-Like `frickeEntrySL` it exists at every level, so on its own it records that the entry formula
+Like `frickeConjSL` it exists at every level, so on its own it records that the entry formula
 preserves `Γ₀(N)` rather than that `W` normalizes it. At nonzero level it is an isomorphism,
 `frickeConjGamma0MulEquiv`, and that is the declaration that states the normalization. -/
-public def frickeEntryGamma0 : ↥(Gamma0 N) →* ↥(Gamma0 N) where
-  toFun σ := ⟨frickeEntrySL σ, frickeEntrySL_mem_Gamma0 σ⟩
-  map_one' := Subtype.ext frickeEntrySL_one
-  map_mul' σ τ := Subtype.ext (frickeEntrySL_mul σ τ)
+public def frickeConjGamma0 : ↥(Gamma0 N) →* ↥(Gamma0 N) where
+  toFun σ := ⟨frickeConjSL σ, frickeConjSL_mem_Gamma0 σ⟩
+  map_one' := Subtype.ext frickeConjSL_one
+  map_mul' σ τ := Subtype.ext (frickeConjSL_mul σ τ)
 
+/-- The `SL(2, ℤ)` matrix underlying `frickeConjGamma0 σ` is `frickeConjSL σ`: the
+characterizing lemma for the bundled map. -/
 @[simp]
-public theorem coe_frickeEntryGamma0 (σ : ↥(Gamma0 N)) :
-    (frickeEntryGamma0 σ : SL(2, ℤ)) = frickeEntrySL σ :=
+public theorem coe_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
+    (frickeConjGamma0 σ : SL(2, ℤ)) = frickeConjSL σ :=
   (rfl)
 
 /-- **The Fricke entry formula restricted to `Γ₁(N)`**, as a group endomorphism
-`Γ₁(N) →* Γ₁(N)`; the `Γ₁` counterpart of `frickeEntryGamma0`, bundling
-`frickeEntrySL_mem_Gamma1`, and like it defined at every level. -/
-public def frickeEntryGamma1 : ↥(Gamma1 N) →* ↥(Gamma1 N) where
-  toFun σ := ⟨frickeEntrySL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩,
-    frickeEntrySL_mem_Gamma1 (σ : SL(2, ℤ)) σ.property⟩
-  map_one' := Subtype.ext frickeEntrySL_one
-  map_mul' σ τ := Subtype.ext (frickeEntrySL_mul ⟨σ, Gamma1_in_Gamma0 N σ.property⟩
+`Γ₁(N) →* Γ₁(N)`; the `Γ₁` counterpart of `frickeConjGamma0`, bundling
+`frickeConjSL_mem_Gamma1`, and like it defined at every level. -/
+public def frickeConjGamma1 : ↥(Gamma1 N) →* ↥(Gamma1 N) where
+  toFun σ := ⟨frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩,
+    frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) σ.property⟩
+  map_one' := Subtype.ext frickeConjSL_one
+  map_mul' σ τ := Subtype.ext (frickeConjSL_mul ⟨σ, Gamma1_in_Gamma0 N σ.property⟩
     ⟨τ, Gamma1_in_Gamma0 N τ.property⟩)
 
+/-- The `SL(2, ℤ)` matrix underlying `frickeConjGamma1 σ` is `frickeConjSL σ`: the
+characterizing lemma for the bundled map, as `coe_frickeConjGamma0` is at level `Γ₀(N)`. -/
 @[simp]
-public theorem coe_frickeEntryGamma1 (σ : ↥(Gamma1 N)) :
-    (frickeEntryGamma1 σ : SL(2, ℤ)) = frickeEntrySL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩ :=
+public theorem coe_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
+    (frickeConjGamma1 σ : SL(2, ℤ)) = frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩ :=
   (rfl)
 
 section NeZero
 
+/-- **The Fricke conjugation inverts the diamond label.** `Gamma0Map` reads the lower-right entry
+mod `N`; conjugation swaps the two diagonal entries, so it reads `a` where it read `d`, and
+`a · d ≡ 1 (mod N)` because `det σ = 1` and `N ∣ c`.
+
+Stated at the `ZMod` level, which is where `Gamma0Map` lands; the unit-valued form follows by
+applying `MonoidHom.toHomUnits`. Without it a consumer computing a nebentypus along the Fricke
+involution has to redo the determinant argument. -/
+public theorem gamma0Map_frickeConjGamma0_mul (σ : ↥(Gamma0 N)) :
+    Gamma0Map N (frickeConjGamma0 σ) * Gamma0Map N σ = 1 := by
+  have hdet : (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 -
+      (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = 1 :=
+    fin_two_mul_sub_mul_eq_one (σ : SL(2, ℤ))
+  have hc : (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ℤ) : ZMod N) = 0 := Gamma0_mem.mp σ.property
+  have hcast : (((σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 : ℤ) : ZMod N) *
+      (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 : ℤ) : ZMod N) -
+      (((σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 : ℤ) : ZMod N) *
+        (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ℤ) : ZMod N) = 1 := by
+    exact_mod_cast congrArg (Int.cast : ℤ → ZMod N) hdet
+  rw [hc, mul_zero, sub_zero] at hcast
+  simpa [Gamma0Map, coe_frickeConjGamma0] using hcast
+
 variable [NeZero N]
 
-/-- **The Fricke conjugation is an involution at nonzero level**: `W² = (-N) • 1` is central, so
-conjugating twice does nothing.
+/-- **The Fricke conjugation is an involution at nonzero level**: applying it twice is the
+identity on `Γ₀(N)`.
 
-This genuinely needs `N ≠ 0`. At level zero the lower-left entry `-N·b` of `frickeEntrySL σ` is
+This genuinely needs `N ≠ 0`. At level zero the lower-left entry `-N·b` of `frickeConjSL σ` is
 `0` whatever `b` is, so the formula forgets `b` and cannot be undone; see the `Level` section of
 the module docstring. -/
 @[simp]
-public theorem frickeEntryGamma0_frickeEntryGamma0 (σ : ↥(Gamma0 N)) :
-    frickeEntryGamma0 (frickeEntryGamma0 σ) = σ := by
+-- The reason is that `W² = (-N) • 1` is central, so conjugating twice does nothing; the proof
+-- below is the entrywise form of that over `ℤ`, with no `W` in sight.
+public theorem frickeConjGamma0_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
+    frickeConjGamma0 (frickeConjGamma0 σ) = σ := by
   have hN : (N : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (NeZero.ne N)
-  have hσ := lowerLeftDiv_spec σ
-  have hdiv : lowerLeftDiv (frickeEntryGamma0 σ) = -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
-    have hentry : ((frickeEntryGamma0 σ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 =
+  have hdiv : ((frickeConjGamma0 σ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ) =
+      -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
+    have hentry : ((frickeConjGamma0 σ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 =
         (N : ℤ) * -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
-      rw [coe_frickeEntryGamma0, coe_frickeEntrySL_lowerLeftDiv]
+      rw [coe_frickeConjGamma0, coe_frickeConjSL]
       simp
-    rw [lowerLeftDiv, hentry, Int.mul_ediv_cancel_left _ hN]
+    rw [hentry, Int.mul_ediv_cancel_left _ hN]
   apply Subtype.ext
-  rw [coe_frickeEntryGamma0]
+  rw [coe_frickeConjGamma0]
   ext i j
-  rw [coe_frickeEntrySL_lowerLeftDiv, hdiv, coe_frickeEntryGamma0,
-    coe_frickeEntrySL_lowerLeftDiv]
-  fin_cases i <;> fin_cases j <;> simp [hσ]
+  rw [coe_frickeConjSL, hdiv, coe_frickeConjGamma0, coe_frickeConjSL]
+  fin_cases i <;> fin_cases j <;> simp [natCast_mul_lowerLeft_ediv]
 
-/-- `frickeEntryGamma0` is involutive, in the form `Function.Involutive` consumes. -/
-public theorem frickeEntryGamma0_involutive :
-    Function.Involutive (frickeEntryGamma0 (N := N)) :=
-  frickeEntryGamma0_frickeEntryGamma0
+/-- `frickeConjGamma0` is involutive, in the form `Function.Involutive` consumes. -/
+public theorem frickeConjGamma0_involutive :
+    Function.Involutive (frickeConjGamma0 (N := N)) :=
+  frickeConjGamma0_frickeConjGamma0
 
 /-- **The Fricke conjugation as an automorphism of `Γ₀(N)`**, for nonzero level: the isomorphism
-`Γ₀(N) ≃* Γ₀(N)` that `frickeEntryGamma0` becomes once it is known to be involutive. It is its
+`Γ₀(N) ≃* Γ₀(N)` that `frickeConjGamma0` becomes once it is known to be involutive. It is its
 own inverse.
 
 This is the declaration that expresses that `W` *normalizes* `Γ₀(N)`, and it is why the name
-carries `Conj` where `frickeEntryGamma0` does not. -/
+carries `Conj` where `frickeConjGamma0` does not. -/
 public def frickeConjGamma0MulEquiv : ↥(Gamma0 N) ≃* ↥(Gamma0 N) where
-  toFun := frickeEntryGamma0
-  invFun := frickeEntryGamma0
-  left_inv := frickeEntryGamma0_involutive
-  right_inv := frickeEntryGamma0_involutive
-  map_mul' := map_mul frickeEntryGamma0
+  toFun := frickeConjGamma0
+  invFun := frickeConjGamma0
+  left_inv := frickeConjGamma0_involutive
+  right_inv := frickeConjGamma0_involutive
+  map_mul' := map_mul frickeConjGamma0
 
-/-- `frickeConjGamma0MulEquiv` acts as `frickeEntryGamma0`. This is its defining lemma and, with
+/-- `frickeConjGamma0MulEquiv` acts as `frickeConjGamma0`. This is its defining lemma and, with
 `frickeConjGamma0MulEquiv_symm`, the intended interface: a consumer simplifies through these
 rather than through the body of the bundled definition. -/
 @[simp]
 public theorem frickeConjGamma0MulEquiv_apply (σ : ↥(Gamma0 N)) :
-    frickeConjGamma0MulEquiv σ = frickeEntryGamma0 σ :=
+    frickeConjGamma0MulEquiv σ = frickeConjGamma0 σ :=
   (rfl)
 
 /-- **`frickeConjGamma0MulEquiv` is its own inverse.** The underlying map is an involution, so
@@ -346,32 +379,39 @@ public theorem frickeConjGamma0MulEquiv_symm :
     (frickeConjGamma0MulEquiv (N := N)).symm = frickeConjGamma0MulEquiv :=
   (rfl)
 
-/-- The `Γ₁(N)` counterpart of `frickeEntryGamma0_frickeEntryGamma0`. -/
-@[simp]
-public theorem frickeEntryGamma1_frickeEntryGamma1 (σ : ↥(Gamma1 N)) :
-    frickeEntryGamma1 (frickeEntryGamma1 σ) = σ :=
-  Subtype.ext (congrArg (Subtype.val (p := fun g => g ∈ Gamma0 N))
-    (frickeEntryGamma0_frickeEntryGamma0 ⟨σ, Gamma1_in_Gamma0 N σ.property⟩))
+/-- The `Γ₁(N)` counterpart of `frickeConjGamma0_frickeConjGamma0`.
 
-/-- `frickeEntryGamma1` is involutive, in the form `Function.Involutive` consumes. -/
-public theorem frickeEntryGamma1_involutive :
-    Function.Involutive (frickeEntryGamma1 (N := N)) :=
-  frickeEntryGamma1_frickeEntryGamma1
+The proof transports the `Γ₀(N)` involution across the two wrappers, and relies on two
+definitional facts worth naming: `frickeConjGamma1` and `frickeConjGamma0` have the same
+underlying map `frickeConjSL`, so both sides reduce to it on the underlying element, and the two
+differing `Γ₀(N)`-membership proofs are identified by proof irrelevance. Routing it through the
+`coe` lemmas instead does not work: `frickeConjGamma0_frickeConjGamma0` is itself `@[simp]`, so
+`simpa` closes the transported term to `True` before it can discharge the goal. -/
+@[simp]
+public theorem frickeConjGamma1_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
+    frickeConjGamma1 (frickeConjGamma1 σ) = σ :=
+  Subtype.ext (congrArg (Subtype.val (p := fun g => g ∈ Gamma0 N))
+    (frickeConjGamma0_frickeConjGamma0 ⟨σ, Gamma1_in_Gamma0 N σ.property⟩))
+
+/-- `frickeConjGamma1` is involutive, in the form `Function.Involutive` consumes. -/
+public theorem frickeConjGamma1_involutive :
+    Function.Involutive (frickeConjGamma1 (N := N)) :=
+  frickeConjGamma1_frickeConjGamma1
 
 /-- **The Fricke conjugation as an automorphism of `Γ₁(N)`**, for nonzero level; the `Γ₁`
 counterpart of `frickeConjGamma0MulEquiv`. -/
 public def frickeConjGamma1MulEquiv : ↥(Gamma1 N) ≃* ↥(Gamma1 N) where
-  toFun := frickeEntryGamma1
-  invFun := frickeEntryGamma1
-  left_inv := frickeEntryGamma1_involutive
-  right_inv := frickeEntryGamma1_involutive
-  map_mul' := map_mul frickeEntryGamma1
+  toFun := frickeConjGamma1
+  invFun := frickeConjGamma1
+  left_inv := frickeConjGamma1_involutive
+  right_inv := frickeConjGamma1_involutive
+  map_mul' := map_mul frickeConjGamma1
 
-/-- `frickeConjGamma1MulEquiv` acts as `frickeEntryGamma1`; the `Γ₁(N)` counterpart of
+/-- `frickeConjGamma1MulEquiv` acts as `frickeConjGamma1`; the `Γ₁(N)` counterpart of
 `frickeConjGamma0MulEquiv_apply`. -/
 @[simp]
 public theorem frickeConjGamma1MulEquiv_apply (σ : ↥(Gamma1 N)) :
-    frickeConjGamma1MulEquiv σ = frickeEntryGamma1 σ :=
+    frickeConjGamma1MulEquiv σ = frickeConjGamma1 σ :=
   (rfl)
 
 /-- The `Γ₁(N)` counterpart of `frickeConjGamma0MulEquiv_symm`. -/
@@ -386,12 +426,13 @@ section Field
 
 variable (K : Type*) [Field K]
 
-/-- The lower-left entry of `σ ∈ Γ₀(N)`, read in `K`, is `N` times `lowerLeftDiv σ`. The
-`K`-valued form of `lowerLeftDiv_spec`, which is what the entrywise computations below
+/-- The lower-left entry of `σ ∈ Γ₀(N)`, read in `K`, is `N` times the quotient `c / N`. The
+`K`-valued form of `natCast_mul_lowerLeft_ediv`, which is what the entrywise computations below
 consume. -/
-private theorem lowerLeftDiv_spec_field (σ : ↥(Gamma0 N)) :
-    ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : K) = (N : K) * (lowerLeftDiv σ : K) := by
-  exact_mod_cast congrArg (Int.cast : ℤ → K) (lowerLeftDiv_spec σ)
+private theorem lowerLeft_ediv_spec_field (σ : ↥(Gamma0 N)) :
+    ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : K) =
+      (N : K) * (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ) : ℤ) : K) := by
+  exact_mod_cast congrArg (Int.cast : ℤ → K) (natCast_mul_lowerLeft_ediv σ).symm
 
 variable [NeZero (N : K)]
 
@@ -399,18 +440,24 @@ variable [NeZero (N : K)]
 This is the form that moves `W` from the left of `σ` to its right, which is what a slash-action
 computation needs. -/
 public theorem frickeGL_mul_mapGL (σ : ↥(Gamma0 N)) :
-    frickeGL K N * mapGL K (σ : SL(2, ℤ)) = mapGL K (frickeEntrySL σ) * frickeGL K N := by
+    frickeGL K N * mapGL K (σ : SL(2, ℤ)) = mapGL K (frickeConjSL σ) * frickeGL K N := by
   apply Units.ext
-  have hc := lowerLeftDiv_spec_field K σ
+  have hc := lowerLeft_ediv_spec_field K σ
   rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.GeneralLinearGroup.coe_mul,
     coe_mapGL_fin_two, coe_mapGL_fin_two, coe_frickeGL]
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp only [Matrix.mul_apply, Fin.sum_univ_two, coe_frickeEntrySL, Matrix.cons_val_zero,
+    simp only [Matrix.mul_apply, Fin.sum_univ_two, coe_frickeConjSL, Matrix.cons_val_zero,
       Matrix.cons_val_one, Matrix.of_apply, algebraMap_int_eq, Int.coe_castRingHom, Fin.isValue,
-      Fin.zero_eta, Fin.mk_one, Int.cast_mul, Int.cast_neg, Int.cast_natCast, lowerLeftDiv,
-      hc] <;>
+      Fin.zero_eta, Fin.mk_one, Int.cast_mul, Int.cast_neg, Int.cast_natCast, hc] <;>
     ring
+
+/-- **`frickeConjSL σ` is the Fricke conjugate**, in the form the name asserts:
+`mapGL K (frickeConjSL σ) = W · σ · W⁻¹`. This is `frickeGL_mul_mapGL` with `W` moved across,
+and it is the characterization the `frickeConj*` names advertise. -/
+public theorem mapGL_frickeConjSL (σ : ↥(Gamma0 N)) :
+    mapGL K (frickeConjSL σ) = frickeGL K N * mapGL K (σ : SL(2, ℤ)) * (frickeGL K N)⁻¹ :=
+  eq_mul_inv_of_mul_eq (frickeGL_mul_mapGL K σ).symm
 
 /-- `W²` commutes with everything in `GL (Fin 2) K`: it is the scalar matrix `(-N) • 1`. -/
 private theorem frickeGL_sq_mul_comm (A : GL (Fin 2) K) :
@@ -420,21 +467,19 @@ private theorem frickeGL_sq_mul_comm (A : GL (Fin 2) K) :
   simp
 
 /-- **The mirror normalization identity** `σ · W = W · (W σ W⁻¹)` in `GL (Fin 2) K`, for
-`σ ∈ Γ₀(N)`; equivalently `frickeEntrySL σ = W⁻¹ · σ · W`.
-
-This is `frickeGL_mul_mapGL` carried across `W²`, rather than a second entrywise computation:
-`(σ · W) · W = σ · W² = W² · σ = W · (W · σ) = W · (W σ W⁻¹) · W`, and `W` cancels on the
-right. -/
+`σ ∈ Γ₀(N)`; equivalently `frickeConjSL σ = W⁻¹ · σ · W`. -/
+-- `frickeGL_mul_mapGL` carried across `W²` rather than a second entrywise computation:
+-- `(σ · W) · W = σ · W² = W² · σ = W · (W · σ) = W · (W σ W⁻¹) · W`, and `W` cancels on the right.
 public theorem mapGL_mul_frickeGL (σ : ↥(Gamma0 N)) :
-    mapGL K (σ : SL(2, ℤ)) * frickeGL K N = frickeGL K N * mapGL K (frickeEntrySL σ) := by
+    mapGL K (σ : SL(2, ℤ)) * frickeGL K N = frickeGL K N * mapGL K (frickeConjSL σ) := by
   refine mul_right_cancel (b := frickeGL K N) ?_
   calc mapGL K (σ : SL(2, ℤ)) * frickeGL K N * frickeGL K N
       = frickeGL K N ^ 2 * mapGL K (σ : SL(2, ℤ)) := by
         rw [mul_assoc, ← sq, ← frickeGL_sq_mul_comm]
     _ = frickeGL K N * (frickeGL K N * mapGL K (σ : SL(2, ℤ))) := by rw [sq, mul_assoc]
-    _ = frickeGL K N * (mapGL K (frickeEntrySL σ) * frickeGL K N) := by
+    _ = frickeGL K N * (mapGL K (frickeConjSL σ) * frickeGL K N) := by
         rw [frickeGL_mul_mapGL]
-    _ = frickeGL K N * mapGL K (frickeEntrySL σ) * frickeGL K N := (mul_assoc _ _ _).symm
+    _ = frickeGL K N * mapGL K (frickeConjSL σ) * frickeGL K N := (mul_assoc _ _ _).symm
 
 end Field
 

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -355,8 +355,9 @@ public theorem frickeConjGamma0_involutive :
 `Γ₀(N) ≃* Γ₀(N)` that `frickeConjGamma0` becomes once it is known to be involutive. It is its
 own inverse.
 
-This is the declaration that expresses that `W` *normalizes* `Γ₀(N)`, and it is why the name
-carries `Conj` where `frickeConjGamma0` does not. -/
+This is the declaration that expresses that `W` *normalizes* `Γ₀(N)`: `frickeConjGamma0` maps
+the subgroup into itself at every level, and the level hypothesis is what upgrades that to an
+isomorphism. -/
 public def frickeConjGamma0MulEquiv : ↥(Gamma0 N) ≃* ↥(Gamma0 N) where
   toFun := frickeConjGamma0
   invFun := frickeConjGamma0
@@ -379,15 +380,14 @@ public theorem frickeConjGamma0MulEquiv_symm :
     (frickeConjGamma0MulEquiv (N := N)).symm = frickeConjGamma0MulEquiv :=
   (rfl)
 
-/-- The `Γ₁(N)` counterpart of `frickeConjGamma0_frickeConjGamma0`.
-
-The proof transports the `Γ₀(N)` involution across the two wrappers, and relies on two
-definitional facts worth naming: `frickeConjGamma1` and `frickeConjGamma0` have the same
-underlying map `frickeConjSL`, so both sides reduce to it on the underlying element, and the two
-differing `Γ₀(N)`-membership proofs are identified by proof irrelevance. Routing it through the
-`coe` lemmas instead does not work: `frickeConjGamma0_frickeConjGamma0` is itself `@[simp]`, so
-`simpa` closes the transported term to `True` before it can discharge the goal. -/
+/-- The `Γ₁(N)` counterpart of `frickeConjGamma0_frickeConjGamma0`. -/
 @[simp]
+-- Transports the `Γ₀(N)` involution across the two wrappers, relying on two definitional facts:
+-- `frickeConjGamma1` and `frickeConjGamma0` have the same underlying map `frickeConjSL`, so both
+-- sides reduce to it on the underlying element, and the two differing `Γ₀(N)`-membership proofs
+-- are identified by proof irrelevance. Routing it through the `coe` lemmas instead does not work:
+-- `frickeConjGamma0_frickeConjGamma0` is itself `@[simp]`, so `simpa` closes the transported term
+-- to `True` before it can discharge the goal.
 public theorem frickeConjGamma1_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
     frickeConjGamma1 (frickeConjGamma1 σ) = σ :=
   Subtype.ext (congrArg (Subtype.val (p := fun g => g ∈ Gamma0 N))

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -37,10 +37,15 @@ anything. Over the arbitrary field `K` of the identities below that is strictly 
 `N ≠ 0`: a nonzero level casts to zero whenever the characteristic of `K` divides it. It is
 needed for the *conjugation*, though, not for the entry formula, so it is stated where `W`
 itself appears: as `[NeZero (N : K)]` on the two normalization identities over `K`, which are
-the statements that actually call `frickeConjSL σ` a conjugate. The `ℤ`-valued declarations
-below carry no level hypothesis — the matrix `!![d, -c'; -N·b, a]` has determinant `1`, lies in
-`Γ₀(N)` for every `N`, and lies in `Γ₁(N)` whenever `σ` does, `c = N · (c / N)` holding at
-`N = 0` as well, both sides being zero.
+the statements that actually call `frickeConjSL σ` a conjugate. Most of the `ℤ`-valued
+declarations below carry no level hypothesis — the matrix `!![d, -c'; -N·b, a]` has determinant
+`1`, lies in `Γ₀(N)` for every `N`, lies in `Γ₁(N)` whenever `σ` does, and is multiplicative in
+`σ`, `c = N · (c / N)` holding at `N = 0` as well, both sides being zero.
+
+The exception is *invertibility*. The entry map is a homomorphism at every level but an
+isomorphism only at nonzero level, so `frickeConjGamma0MulEquiv`, `frickeConjGamma1MulEquiv` and
+the two involution lemmas take `[NeZero N]` — a hypothesis on the natural number `N`, not on its
+image in a field, since the obstruction is the integer division `c / N`.
 
 Level zero is genuinely degenerate, and the declarations below are worded so that nothing
 claims otherwise: `Γ₀(0)` is the upper-triangular subgroup, the quotient `c / N` is `0`, and the
@@ -60,6 +65,11 @@ itself defined at an arbitrary algebra.
 
 * `TauCeti.frickeConjSL`: the matrix `!![d, -c/N; -N·b, a]` as an element of `SL(2, ℤ)`;
   over a field in which `N` is invertible it is the conjugate `W · σ · W⁻¹`.
+* `TauCeti.frickeConjGamma0`, `TauCeti.frickeConjGamma1`: that map bundled as a group
+  homomorphism `Γ₀(N) →* Γ₀(N)`, and its restriction `Γ₁(N) →* Γ₁(N)`. These are the
+  declarations that say `W` *normalizes* the subgroup, rather than merely that it maps into it.
+* `TauCeti.frickeConjGamma0MulEquiv`, `TauCeti.frickeConjGamma1MulEquiv`: for `[NeZero N]`, the
+  same maps as automorphisms `Γ₀(N) ≃* Γ₀(N)` and `Γ₁(N) ≃* Γ₁(N)`, each its own inverse.
 
 ## Main results
 
@@ -68,6 +78,10 @@ itself defined at an arbitrary algebra.
   level.
 * `TauCeti.frickeConjSL_mem_Gamma1`: a `Γ₁(N)` input has `frickeConjSL σ ∈ Γ₁(N)`, at every
   level. This is a second hypothesis on `σ`, not a consequence of the previous line.
+* `TauCeti.frickeConjSL_mul`, `TauCeti.frickeConjSL_one`: the entry map is multiplicative and
+  unital, at every level. These are what the bundled homomorphisms above are built from.
+* `TauCeti.frickeConjGamma0_frickeConjGamma0`, `TauCeti.frickeConjGamma1_frickeConjGamma1`: for
+  `[NeZero N]`, conjugating twice is the identity.
 * `TauCeti.frickeGL_mul_mapGL`, `TauCeti.mapGL_mul_frickeGL`: for `(N : K) ≠ 0`, the two
   normalization identities `W · σ = (W σ W⁻¹) · W` and `σ · W = W · (W σ W⁻¹)` in
   `GL (Fin 2) K`. These are the statements that exhibit `W` as normalizing `Γ₀(N)`.
@@ -154,6 +168,15 @@ public theorem coe_frickeConjSL (σ : ↥(Gamma0 N)) :
          -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0] := by
   simp [frickeConjSL, lowerLeftDiv]
 
+/-- The underlying matrix of `frickeConjSL σ`, written with `lowerLeftDiv` rather than with the
+quotient `c / N` that the public `coe_frickeConjSL` displays. This is the form the entrywise
+computations below consume, so that they never unfold `frickeConjSL` itself. -/
+private theorem coe_frickeConjSL_lowerLeftDiv (σ : ↥(Gamma0 N)) :
+    (frickeConjSL σ : Matrix (Fin 2) (Fin 2) ℤ) =
+      !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
+         -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0] :=
+  rfl
+
 /-- **`frickeConjSL` preserves `Γ₀(N)`**: its lower-left entry `-N·b` is visibly divisible by
 `N`. This is a statement about the entry formula, so it holds at every level; over a field in
 which `N` is invertible, where `frickeConjSL σ` really is `W · σ · W⁻¹`, it says that `W`
@@ -172,6 +195,149 @@ public theorem frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N)
   obtain ⟨ha, hd, -⟩ := (Gamma1_mem N σ).mp hσ
   rw [Gamma1_mem, coe_frickeConjSL]
   exact ⟨by simpa using hd, by simpa using ha, by simp⟩
+
+/-- The lower-left quotient of a product, from the quotients of the two factors. At level zero
+both sides are `0`, `lowerLeftDiv` being division by `0` there. -/
+private theorem lowerLeftDiv_mul (σ τ : ↥(Gamma0 N)) :
+    lowerLeftDiv (σ * τ) =
+      lowerLeftDiv σ * (τ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 +
+        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 * lowerLeftDiv τ := by
+  rcases eq_or_ne (N : ℤ) 0 with hN | hN
+  · simp [lowerLeftDiv, hN]
+  · refine mul_left_cancel₀ hN ?_
+    have hmul : ((σ * τ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 =
+        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 * (τ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 +
+          (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 * (τ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 := by
+      simp [Matrix.mul_apply, Fin.sum_univ_two]
+    rw [← lowerLeftDiv_spec, hmul, lowerLeftDiv_spec σ, lowerLeftDiv_spec τ]
+    ring
+
+/-- **`frickeConjSL` sends `1` to `1`**. -/
+public theorem frickeConjSL_one : frickeConjSL (1 : ↥(Gamma0 N)) = 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [frickeConjSL, lowerLeftDiv]
+
+/-- **`frickeConjSL` is multiplicative.** Conjugation by `W` is a group homomorphism, and the
+entry formula records that at every level — including `N = 0`, where it is not a conjugation. -/
+public theorem frickeConjSL_mul (σ τ : ↥(Gamma0 N)) :
+    frickeConjSL (σ * τ) = frickeConjSL σ * frickeConjSL τ := by
+  have hσ := lowerLeftDiv_spec σ
+  have hτ := lowerLeftDiv_spec τ
+  have hmul := lowerLeftDiv_mul σ τ
+  ext i j
+  rw [SpecialLinearGroup.coe_mul, coe_frickeConjSL_lowerLeftDiv, coe_frickeConjSL_lowerLeftDiv,
+    coe_frickeConjSL_lowerLeftDiv, Matrix.mul_fin_two]
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two, hmul, hσ, hτ] <;>
+    ring
+
+/-- **The Fricke conjugation as a group homomorphism `Γ₀(N) →* Γ₀(N)`.** This is the bundled
+form of `frickeConjSL_mem_Gamma0`: it is what "`W` normalizes `Γ₀(N)`" means, and it is what a
+consumer needs in order to transport a subgroup along the conjugation. It exists at every level;
+at nonzero level it is an isomorphism, `frickeConjGamma0MulEquiv`. -/
+@[expose]
+public def frickeConjGamma0 : ↥(Gamma0 N) →* ↥(Gamma0 N) where
+  toFun σ := ⟨frickeConjSL σ, frickeConjSL_mem_Gamma0 σ⟩
+  map_one' := Subtype.ext frickeConjSL_one
+  map_mul' σ τ := Subtype.ext (frickeConjSL_mul σ τ)
+
+@[simp]
+public theorem coe_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
+    (frickeConjGamma0 σ : SL(2, ℤ)) = frickeConjSL σ :=
+  rfl
+
+/-- **The Fricke conjugation restricted to `Γ₁(N)`**, as a group homomorphism
+`Γ₁(N) →* Γ₁(N)`; the `Γ₁` counterpart of `frickeConjGamma0`, bundling
+`frickeConjSL_mem_Gamma1`. -/
+@[expose]
+public def frickeConjGamma1 : ↥(Gamma1 N) →* ↥(Gamma1 N) where
+  toFun σ := ⟨frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩,
+    frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) σ.property⟩
+  map_one' := Subtype.ext frickeConjSL_one
+  map_mul' σ τ := Subtype.ext (frickeConjSL_mul ⟨σ, Gamma1_in_Gamma0 N σ.property⟩
+    ⟨τ, Gamma1_in_Gamma0 N τ.property⟩)
+
+@[simp]
+public theorem coe_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
+    (frickeConjGamma1 σ : SL(2, ℤ)) = frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩ :=
+  rfl
+
+section NeZero
+
+variable [NeZero N]
+
+/-- **The Fricke conjugation is an involution at nonzero level**: `W² = (-N) • 1` is central, so
+conjugating twice does nothing.
+
+This genuinely needs `N ≠ 0`. At level zero the lower-left entry `-N·b` of `frickeConjSL σ` is
+`0` whatever `b` is, so the formula forgets `b` and cannot be undone; see the `Level` section of
+the module docstring. -/
+public theorem frickeConjGamma0_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
+    frickeConjGamma0 (frickeConjGamma0 σ) = σ := by
+  have hN : (N : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (NeZero.ne N)
+  have hσ := lowerLeftDiv_spec σ
+  have hdiv : lowerLeftDiv (frickeConjGamma0 σ) = -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
+    have hentry : ((frickeConjGamma0 σ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 =
+        (N : ℤ) * -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
+      rw [coe_frickeConjGamma0, coe_frickeConjSL_lowerLeftDiv]
+      simp
+    rw [lowerLeftDiv, hentry, Int.mul_ediv_cancel_left _ hN]
+  apply Subtype.ext
+  rw [coe_frickeConjGamma0]
+  ext i j
+  rw [coe_frickeConjSL_lowerLeftDiv, hdiv, coe_frickeConjGamma0,
+    coe_frickeConjSL_lowerLeftDiv]
+  fin_cases i <;> fin_cases j <;> simp [hσ]
+
+/-- `frickeConjGamma0` is involutive, in the form `Function.Involutive` consumes. -/
+public theorem frickeConjGamma0_involutive :
+    Function.Involutive (frickeConjGamma0 (N := N)) :=
+  frickeConjGamma0_frickeConjGamma0
+
+/-- **The Fricke conjugation as an automorphism of `Γ₀(N)`**, for nonzero level: the isomorphism
+`Γ₀(N) ≃* Γ₀(N)` that `frickeConjGamma0` becomes once it is known to be involutive. It is its
+own inverse. -/
+@[expose]
+public def frickeConjGamma0MulEquiv : ↥(Gamma0 N) ≃* ↥(Gamma0 N) where
+  toFun := frickeConjGamma0
+  invFun := frickeConjGamma0
+  left_inv := frickeConjGamma0_involutive
+  right_inv := frickeConjGamma0_involutive
+  map_mul' := map_mul frickeConjGamma0
+
+@[simp]
+public theorem coe_frickeConjGamma0MulEquiv (σ : ↥(Gamma0 N)) :
+    (frickeConjGamma0MulEquiv σ : SL(2, ℤ)) = frickeConjSL σ :=
+  rfl
+
+/-- The `Γ₁(N)` counterpart of `frickeConjGamma0_frickeConjGamma0`. -/
+public theorem frickeConjGamma1_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
+    frickeConjGamma1 (frickeConjGamma1 σ) = σ :=
+  Subtype.ext (congrArg (Subtype.val (p := fun g => g ∈ Gamma0 N))
+    (frickeConjGamma0_frickeConjGamma0 ⟨σ, Gamma1_in_Gamma0 N σ.property⟩))
+
+/-- `frickeConjGamma1` is involutive, in the form `Function.Involutive` consumes. -/
+public theorem frickeConjGamma1_involutive :
+    Function.Involutive (frickeConjGamma1 (N := N)) :=
+  frickeConjGamma1_frickeConjGamma1
+
+/-- **The Fricke conjugation as an automorphism of `Γ₁(N)`**, for nonzero level; the `Γ₁`
+counterpart of `frickeConjGamma0MulEquiv`. -/
+@[expose]
+public def frickeConjGamma1MulEquiv : ↥(Gamma1 N) ≃* ↥(Gamma1 N) where
+  toFun := frickeConjGamma1
+  invFun := frickeConjGamma1
+  left_inv := frickeConjGamma1_involutive
+  right_inv := frickeConjGamma1_involutive
+  map_mul' := map_mul frickeConjGamma1
+
+@[simp]
+public theorem coe_frickeConjGamma1MulEquiv (σ : ↥(Gamma1 N)) :
+    (frickeConjGamma1MulEquiv σ : SL(2, ℤ)) =
+      frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩ :=
+  rfl
+
+end NeZero
 
 section Field
 

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -19,39 +19,48 @@ conjugating by the Fricke matrix `W = !![0, -1; N, 0]` of
 `W · σ · W⁻¹ = !![d, -c/N; -N·b, a]`,
 
 which is again integral, again of determinant one, and again in `Γ₀(N)`. This file builds the
-right-hand side as an honest `SL(2, ℤ)` matrix — `frickeConjSL` — reading it off the entries of
+right-hand side as an honest `SL(2, ℤ)` matrix — `frickeEntrySL` — reading it off the entries of
 `σ`, so that it is defined at every level; records that a `Γ₀(N)` input stays inside `Γ₀(N)`
 and that a `Γ₁(N)` input stays inside `Γ₁(N)`, again at every level; and proves, over a field
 in which `N` is invertible, the two matrix identities that move `W` past `σ` and are what make
-`frickeConjSL σ` the conjugate `W · σ · W⁻¹`.
+`frickeEntrySL σ` the conjugate `W · σ · W⁻¹`.
 
-`frickeConjSL` is defined directly by its entries rather than as a product `W * σ * W⁻¹`: the
+`frickeEntrySL` is defined directly by its entries rather than as a product `W * σ * W⁻¹`: the
 latter lives in `GL (Fin 2) K` and is only *incidentally* integral, so reading an `SL(2, ℤ)`
 element back out of it would need the divisibility argument anyway. Defining it by entries and
 proving the product identities afterwards keeps the divisibility in one place.
 
-## Level
+## Level and naming
 
 `(N : K) ≠ 0` is what makes `W` invertible, and so what makes conjugation by `W` mean
 anything. Over the arbitrary field `K` of the identities below that is strictly stronger than
 `N ≠ 0`: a nonzero level casts to zero whenever the characteristic of `K` divides it. It is
 needed for the *conjugation*, though, not for the entry formula, so it is stated where `W`
 itself appears: as `[NeZero (N : K)]` on the two normalization identities over `K`, which are
-the statements that actually call `frickeConjSL σ` a conjugate. Most of the `ℤ`-valued
-declarations below carry no level hypothesis — the matrix `!![d, -c'; -N·b, a]` has determinant
-`1`, lies in `Γ₀(N)` for every `N`, lies in `Γ₁(N)` whenever `σ` does, and is multiplicative in
-`σ`, `c = N · (c / N)` holding at `N = 0` as well, both sides being zero.
+the statements that actually exhibit `frickeEntrySL σ` as a conjugate.
 
-The exception is *invertibility*. The entry map is a homomorphism at every level but an
-isomorphism only at nonzero level, so `frickeConjGamma0MulEquiv`, `frickeConjGamma1MulEquiv` and
-the two involution lemmas take `[NeZero N]` — a hypothesis on the natural number `N`, not on its
-image in a field, since the obstruction is the integer division `c / N`.
+The entry formula itself needs no level hypothesis: `!![d, -c'; -N·b, a]` has determinant `1`,
+lies in `Γ₀(N)` for every `N`, lies in `Γ₁(N)` whenever `σ` does, and is multiplicative in `σ`,
+`c = N · (c / N)` holding at `N = 0` as well, both sides being zero. At `N = 0` it is not a
+conjugation, though: `Γ₀(0)` is the upper-triangular subgroup, the quotient `c / N` is `0`, and
+the formula collapses to `!![a, b; 0, d] ↦ !![d, 0; 0, a]`, which forgets `b` — and
+`frickeGL K 0` does not exist for it to be a conjugation by.
 
-Level zero is genuinely degenerate, and the declarations below are worded so that nothing
-claims otherwise: `Γ₀(0)` is the upper-triangular subgroup, the quotient `c / N` is `0`, and the
-formula collapses to `!![a, b; 0, d] ↦ !![d, 0; 0, a]`, which forgets `b`. That is a
-well-defined `SL(2, ℤ)`-valued map, just not a conjugation — and since `frickeGL K 0` does not
-exist, no identity here asserts that it is one.
+**The names record that split.** The declarations that exist at every level are named for the
+entry formula — `frickeEntrySL`, `frickeEntryGamma0`, `frickeEntryGamma1` — and none of them
+claims a conjugation. The name `frickeConj` is reserved for the declarations that carry a level
+hypothesis and genuinely are Fricke conjugation: `frickeConjGamma0MulEquiv` and
+`frickeConjGamma1MulEquiv` under `[NeZero N]`, and the two identities over `K`. There is no
+all-level `frickeConj*` alias.
+
+The split is by name rather than by signature because a signature gate is not available here:
+`[NeZero N]` on `frickeEntrySL` is an argument the definition never uses, so mathlib's
+`unusedArguments` linter rejects it, and the `nolint` allowlist is human-owned and empty.
+
+`[NeZero N]` is a hypothesis on the natural number `N`, not on its image in a field: what fails
+at level zero is the integer division `c / N`. The entry map is a homomorphism at every level
+but an isomorphism only at nonzero level, so `[NeZero N]` is what the two involution lemmas and
+the two automorphisms take.
 
 ## Base field
 
@@ -63,29 +72,32 @@ itself defined at an arbitrary algebra.
 
 ## Main definitions
 
-* `TauCeti.frickeConjSL`: the matrix `!![d, -c/N; -N·b, a]` as an element of `SL(2, ℤ)`;
-  over a field in which `N` is invertible it is the conjugate `W · σ · W⁻¹`.
-* `TauCeti.frickeConjGamma0`, `TauCeti.frickeConjGamma1`: that map bundled as a group
-  homomorphism `Γ₀(N) →* Γ₀(N)`, and its restriction `Γ₁(N) →* Γ₁(N)`. These are the
-  declarations that say `W` *normalizes* the subgroup, rather than merely that it maps into it.
+* `TauCeti.frickeEntrySL`: the matrix `!![d, -c/N; -N·b, a]` as an element of `SL(2, ℤ)`, read
+  off the entries of `σ` at every level; over a field in which `N` is invertible it is the
+  conjugate `W · σ · W⁻¹`.
+* `TauCeti.frickeEntryGamma0`, `TauCeti.frickeEntryGamma1`: that map bundled as a group
+  endomorphism `Γ₀(N) →* Γ₀(N)`, and its restriction `Γ₁(N) →* Γ₁(N)`. Like the map itself these
+  exist at every level, so what they record is that the entry formula preserves the subgroup —
+  not, on its own, that `W` normalizes it.
 * `TauCeti.frickeConjGamma0MulEquiv`, `TauCeti.frickeConjGamma1MulEquiv`: for `[NeZero N]`, the
-  same maps as automorphisms `Γ₀(N) ≃* Γ₀(N)` and `Γ₁(N) ≃* Γ₁(N)`, each its own inverse.
+  same maps as automorphisms `Γ₀(N) ≃* Γ₀(N)` and `Γ₁(N) ≃* Γ₁(N)`, each its own inverse. These
+  are the declarations that say `W` *normalizes* the subgroup.
 
 ## Main results
 
-* `TauCeti.coe_frickeConjSL`: the entries of `frickeConjSL σ`, namely `!![d, -c/N; -N·b, a]`.
-* `TauCeti.frickeConjSL_mem_Gamma0`: a `Γ₀(N)` input has `frickeConjSL σ ∈ Γ₀(N)`, at every
+* `TauCeti.coe_frickeEntrySL`: the entries of `frickeEntrySL σ`, namely `!![d, -c/N; -N·b, a]`.
+* `TauCeti.frickeEntrySL_mem_Gamma0`: a `Γ₀(N)` input has `frickeEntrySL σ ∈ Γ₀(N)`, at every
   level.
-* `TauCeti.frickeConjSL_mem_Gamma1`: a `Γ₁(N)` input has `frickeConjSL σ ∈ Γ₁(N)`, at every
+* `TauCeti.frickeEntrySL_mem_Gamma1`: a `Γ₁(N)` input has `frickeEntrySL σ ∈ Γ₁(N)`, at every
   level. This is a second hypothesis on `σ`, not a consequence of the previous line.
-* `TauCeti.frickeConjSL_mul`, `TauCeti.frickeConjSL_one`: the entry map is multiplicative and
-  unital, at every level. These are what the bundled homomorphisms above are built from.
-* `TauCeti.frickeConjGamma0_frickeConjGamma0`, `TauCeti.frickeConjGamma1_frickeConjGamma1`: for
-  `[NeZero N]`, conjugating twice is the identity.
+* `TauCeti.frickeEntrySL_mul`, `TauCeti.frickeEntrySL_one`: the entry map is multiplicative and
+  unital, at every level. These are what the bundled endomorphisms above are built from.
+* `TauCeti.frickeEntryGamma0_frickeEntryGamma0`, `TauCeti.frickeEntryGamma1_frickeEntryGamma1`:
+  for `[NeZero N]`, applying the entry map twice is the identity.
 * `TauCeti.frickeConjGamma0MulEquiv_apply`, `TauCeti.frickeConjGamma0MulEquiv_symm`, and their
-  `Γ₁` twins: the automorphisms act as the homomorphisms and are their own inverses. These, with
-  `coe_frickeConjGamma0` and `coe_frickeConjGamma1`, are the whole interface: none of the bundled
-  definitions exposes its body.
+  `Γ₁` twins: the automorphisms act as the endomorphisms and are their own inverses. These, with
+  `coe_frickeEntryGamma0` and `coe_frickeEntryGamma1`, are the intended interface for the bundled
+  declarations: a consumer works through these simp lemmas rather than through the bodies.
 * `TauCeti.frickeGL_mul_mapGL`, `TauCeti.mapGL_mul_frickeGL`: for `(N : K) ≠ 0`, the two
   normalization identities `W · σ = (W σ W⁻¹) · W` and `σ · W = W · (W σ W⁻¹)` in
   `GL (Fin 2) K`. These are the statements that exhibit `W` as normalizing `Γ₀(N)`.
@@ -96,9 +108,9 @@ itself defined at an arbitrary algebra.
 so the two results look superficially alike. They are different maps. That one is
 `g ↦ w · gᵀ · w⁻¹` for the diagonal `w = natDiagGL 2 ![1, N]`: it transposes, and it is an
 *anti*-homomorphism, bundled as `HeckeRing.GL2.atkinLehnerAntiInvolution_bar` on the Hecke ring
-`Δ₀(N)`. `frickeConjSL` is plain conjugation by `!![0, -1; N, 0]`, with no transpose, and lives
-on `Γ₀(N)` itself. The two *matrices* are already distinguished in `Fricke/Matrix.lean`; this is
-the corresponding note for the two conjugation maps.
+`Δ₀(N)`. `frickeEntrySL` is the entry formula for plain conjugation by `!![0, -1; N, 0]`, with
+no transpose, and lives on `Γ₀(N)` itself. The two *matrices* are already distinguished in
+`Fricke/Matrix.lean`; this is the corresponding note for the two conjugation maps.
 
 ## Provenance
 
@@ -106,16 +118,16 @@ Ported from the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/Fricke.lean`](https://github.com/CBirkbeck/AINTLIB),
 commit `340875adfb2`, Apache-2.0, Chris Birkbeck), realizing part of Layer 6 of the ModularForms
 roadmap. AINTLIB names the divisibility witness `botLeftDiv` and keeps it private; it is private
-here too, and `coe_frickeConjSL` writes the quotient `c / N` out instead, so the public API is
+here too, and `coe_frickeEntrySL` writes the quotient `c / N` out instead, so the public API is
 the matrix formula alone. AINTLIB obtains the witness as the `Exists.choose` of the `Γ₀(N)`
-divisibility, which makes it and `frickeConjSL` `noncomputable` and their entries opaque; here it
+divisibility, which makes it and `frickeEntrySL` `noncomputable` and their entries opaque; here it
 is the honest quotient `c / N`, exact because `N ∣ c`, so both definitions are computable and
 reduce entrywise. AINTLIB states the two normalization identities over `ℚ` and then transports
 each along `ℚ → ℝ` by hand, in `glMap_frickeGL_mul_mapGL` and `mapGL_mul_glMap_frickeGL`; stating
 them over `K` as below makes both transports the corresponding instance, so those two lemmas have
 no counterpart here.
 
-The diamond-character companion `Gamma0MapUnits_frickeConjSL` is deliberately *not* ported: it
+The diamond-character companion `Gamma0MapUnits_frickeEntrySL` is deliberately *not* ported: it
 is stated in terms of AINTLIB's `Gamma0MapUnits`, the unit-valued refinement of mathlib's
 `CongruenceSubgroup.Gamma0Map`, which TauCeti does not have. It belongs with that definition
 rather than here, and nothing in this file needs it.
@@ -134,9 +146,9 @@ namespace TauCeti
 variable {N : ℕ}
 
 /-- For `σ ∈ Γ₀(N)` with lower-left entry `c`, the integer `c'` such that `c = N · c'`. It is
-this quotient, not `c` itself, that appears as an entry of the Fricke conjugate.
+this quotient, not `c` itself, that appears as an entry of `frickeEntrySL σ`.
 
-An implementation detail: the public `coe_frickeConjSL` writes `c / N` out. -/
+An implementation detail: the public `coe_frickeEntrySL` writes `c / N` out. -/
 private def lowerLeftDiv (σ : ↥(Gamma0 N)) : ℤ :=
   (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ)
 
@@ -147,14 +159,18 @@ private theorem lowerLeftDiv_spec (σ : ↥(Gamma0 N)) :
   (Int.mul_ediv_cancel'
     ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp σ.property))).symm
 
-/-- The Fricke conjugate of `σ = !![a, b; N·c', d] ∈ Γ₀(N)`, as an element of `SL(2, ℤ)`: the
-matrix `!![d, -c'; -N·b, a]`.
+/-- **The Fricke entry formula** on `σ = !![a, b; N·c', d] ∈ Γ₀(N)`, as an element of
+`SL(2, ℤ)`: the matrix `!![d, -c'; -N·b, a]`.
+
+The name says *entry formula*, not *conjugate*, because this map is defined at every level while
+the conjugation it computes exists only at nonzero level; see the `Level and naming` section of
+the module docstring.
 
 Over a field `K` with `(N : K) ≠ 0` this is `W · σ · W⁻¹`, and equally `W⁻¹ · σ · W` since
 `W² = (-N) • 1` is central; that is the content of `frickeGL_mul_mapGL` and
 `mapGL_mul_frickeGL`, which carry the invertibility hypothesis. At `N = 0` the formula still
 defines a matrix, but a degenerate one; see the `Level` section of the module docstring. -/
-public def frickeConjSL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
+public def frickeEntrySL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
   ⟨!![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
       -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0], by
     have hc := lowerLeftDiv_spec σ
@@ -163,41 +179,41 @@ public def frickeConjSL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
     rw [det_fin_two_of]
     linear_combination hdet + M 0 1 * hc⟩
 
-/-- The underlying matrix of `frickeConjSL σ`, with the exact quotient `c / N` of the lower-left
+/-- The underlying matrix of `frickeEntrySL σ`, with the exact quotient `c / N` of the lower-left
 entry `c` written out. -/
 @[simp]
-public theorem coe_frickeConjSL (σ : ↥(Gamma0 N)) :
-    (frickeConjSL σ : Matrix (Fin 2) (Fin 2) ℤ) =
+public theorem coe_frickeEntrySL (σ : ↥(Gamma0 N)) :
+    (frickeEntrySL σ : Matrix (Fin 2) (Fin 2) ℤ) =
       !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ));
          -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0] := by
-  simp [frickeConjSL, lowerLeftDiv]
+  simp [frickeEntrySL, lowerLeftDiv]
 
-/-- The underlying matrix of `frickeConjSL σ`, written with `lowerLeftDiv` rather than with the
-quotient `c / N` that the public `coe_frickeConjSL` displays. This is the form the entrywise
-computations below consume, so that they never unfold `frickeConjSL` itself. -/
-private theorem coe_frickeConjSL_lowerLeftDiv (σ : ↥(Gamma0 N)) :
-    (frickeConjSL σ : Matrix (Fin 2) (Fin 2) ℤ) =
+/-- The underlying matrix of `frickeEntrySL σ`, written with `lowerLeftDiv` rather than with the
+quotient `c / N` that the public `coe_frickeEntrySL` displays. This is the form the entrywise
+computations below consume, so that they never unfold `frickeEntrySL` itself. -/
+private theorem coe_frickeEntrySL_lowerLeftDiv (σ : ↥(Gamma0 N)) :
+    (frickeEntrySL σ : Matrix (Fin 2) (Fin 2) ℤ) =
       !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
          -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0] :=
   rfl
 
-/-- **`frickeConjSL` preserves `Γ₀(N)`**: its lower-left entry `-N·b` is visibly divisible by
+/-- **`frickeEntrySL` preserves `Γ₀(N)`**: its lower-left entry `-N·b` is visibly divisible by
 `N`. This is a statement about the entry formula, so it holds at every level; over a field in
-which `N` is invertible, where `frickeConjSL σ` really is `W · σ · W⁻¹`, it says that `W`
+which `N` is invertible, where `frickeEntrySL σ` really is `W · σ · W⁻¹`, it says that `W`
 normalizes `Γ₀(N)`. -/
-public theorem frickeConjSL_mem_Gamma0 (σ : ↥(Gamma0 N)) :
-    frickeConjSL σ ∈ Gamma0 N := by
-  rw [Gamma0_mem, coe_frickeConjSL]
+public theorem frickeEntrySL_mem_Gamma0 (σ : ↥(Gamma0 N)) :
+    frickeEntrySL σ ∈ Gamma0 N := by
+  rw [Gamma0_mem, coe_frickeEntrySL]
   simp
 
-/-- **`frickeConjSL` preserves `Γ₁(N)`**: the entry formula swaps the two diagonal entries, so
+/-- **`frickeEntrySL` preserves `Γ₁(N)`**: the entry formula swaps the two diagonal entries, so
 both remain `≡ 1 (mod N)`. Note that this needs `σ ∈ Γ₁(N)`, not merely `σ ∈ Γ₀(N)`. As for
 `Γ₀(N)` it holds at every level, and over a field in which `N` is invertible it says that `W`
 normalizes `Γ₁(N)`. -/
-public theorem frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
-    frickeConjSL ⟨σ, Gamma1_in_Gamma0 N hσ⟩ ∈ Gamma1 N := by
+public theorem frickeEntrySL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
+    frickeEntrySL ⟨σ, Gamma1_in_Gamma0 N hσ⟩ ∈ Gamma1 N := by
   obtain ⟨ha, hd, -⟩ := (Gamma1_mem N σ).mp hσ
-  rw [Gamma1_mem, coe_frickeConjSL]
+  rw [Gamma1_mem, coe_frickeEntrySL]
   exact ⟨by simpa using hd, by simpa using ha, by simp⟩
 
 /-- The lower-left quotient of a product, from the quotients of the two factors. At level zero
@@ -216,53 +232,57 @@ private theorem lowerLeftDiv_mul (σ τ : ↥(Gamma0 N)) :
     rw [← lowerLeftDiv_spec, hmul, lowerLeftDiv_spec σ, lowerLeftDiv_spec τ]
     ring
 
-/-- **`frickeConjSL` sends `1` to `1`**. -/
+/-- **`frickeEntrySL` sends `1` to `1`**. -/
 @[simp]
-public theorem frickeConjSL_one : frickeConjSL (1 : ↥(Gamma0 N)) = 1 := by
+public theorem frickeEntrySL_one : frickeEntrySL (1 : ↥(Gamma0 N)) = 1 := by
   ext i j
-  fin_cases i <;> fin_cases j <;> simp [frickeConjSL, lowerLeftDiv]
+  fin_cases i <;> fin_cases j <;> simp [frickeEntrySL, lowerLeftDiv]
 
-/-- **`frickeConjSL` is multiplicative.** Conjugation by `W` is a group homomorphism, and the
+/-- **`frickeEntrySL` is multiplicative.** Conjugation by `W` is a group homomorphism, and the
 entry formula records that at every level — including `N = 0`, where it is not a conjugation. -/
-public theorem frickeConjSL_mul (σ τ : ↥(Gamma0 N)) :
-    frickeConjSL (σ * τ) = frickeConjSL σ * frickeConjSL τ := by
+@[simp]
+public theorem frickeEntrySL_mul (σ τ : ↥(Gamma0 N)) :
+    frickeEntrySL (σ * τ) = frickeEntrySL σ * frickeEntrySL τ := by
   have hσ := lowerLeftDiv_spec σ
   have hτ := lowerLeftDiv_spec τ
   have hmul := lowerLeftDiv_mul σ τ
   ext i j
-  rw [SpecialLinearGroup.coe_mul, coe_frickeConjSL_lowerLeftDiv, coe_frickeConjSL_lowerLeftDiv,
-    coe_frickeConjSL_lowerLeftDiv, Matrix.mul_fin_two]
+  rw [SpecialLinearGroup.coe_mul, coe_frickeEntrySL_lowerLeftDiv, coe_frickeEntrySL_lowerLeftDiv,
+    coe_frickeEntrySL_lowerLeftDiv, Matrix.mul_fin_two]
   fin_cases i <;> fin_cases j <;>
     simp [Matrix.mul_apply, Fin.sum_univ_two, hmul, hσ, hτ] <;>
     ring
 
-/-- **The Fricke conjugation as a group homomorphism `Γ₀(N) →* Γ₀(N)`.** This is the bundled
-form of `frickeConjSL_mem_Gamma0`: it is what "`W` normalizes `Γ₀(N)`" means, and it is what a
-consumer needs in order to transport a subgroup along the conjugation. It exists at every level;
-at nonzero level it is an isomorphism, `frickeConjGamma0MulEquiv`. -/
-public def frickeConjGamma0 : ↥(Gamma0 N) →* ↥(Gamma0 N) where
-  toFun σ := ⟨frickeConjSL σ, frickeConjSL_mem_Gamma0 σ⟩
-  map_one' := Subtype.ext frickeConjSL_one
-  map_mul' σ τ := Subtype.ext (frickeConjSL_mul σ τ)
+/-- **The Fricke entry formula as a group endomorphism `Γ₀(N) →* Γ₀(N)`.** This is the bundled
+form of `frickeEntrySL_mem_Gamma0`, and it is what a consumer needs in order to transport a
+subgroup along the map.
+
+Like `frickeEntrySL` it exists at every level, so on its own it records that the entry formula
+preserves `Γ₀(N)` rather than that `W` normalizes it. At nonzero level it is an isomorphism,
+`frickeConjGamma0MulEquiv`, and that is the declaration that states the normalization. -/
+public def frickeEntryGamma0 : ↥(Gamma0 N) →* ↥(Gamma0 N) where
+  toFun σ := ⟨frickeEntrySL σ, frickeEntrySL_mem_Gamma0 σ⟩
+  map_one' := Subtype.ext frickeEntrySL_one
+  map_mul' σ τ := Subtype.ext (frickeEntrySL_mul σ τ)
 
 @[simp]
-public theorem coe_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
-    (frickeConjGamma0 σ : SL(2, ℤ)) = frickeConjSL σ :=
+public theorem coe_frickeEntryGamma0 (σ : ↥(Gamma0 N)) :
+    (frickeEntryGamma0 σ : SL(2, ℤ)) = frickeEntrySL σ :=
   (rfl)
 
-/-- **The Fricke conjugation restricted to `Γ₁(N)`**, as a group homomorphism
-`Γ₁(N) →* Γ₁(N)`; the `Γ₁` counterpart of `frickeConjGamma0`, bundling
-`frickeConjSL_mem_Gamma1`. -/
-public def frickeConjGamma1 : ↥(Gamma1 N) →* ↥(Gamma1 N) where
-  toFun σ := ⟨frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩,
-    frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) σ.property⟩
-  map_one' := Subtype.ext frickeConjSL_one
-  map_mul' σ τ := Subtype.ext (frickeConjSL_mul ⟨σ, Gamma1_in_Gamma0 N σ.property⟩
+/-- **The Fricke entry formula restricted to `Γ₁(N)`**, as a group endomorphism
+`Γ₁(N) →* Γ₁(N)`; the `Γ₁` counterpart of `frickeEntryGamma0`, bundling
+`frickeEntrySL_mem_Gamma1`, and like it defined at every level. -/
+public def frickeEntryGamma1 : ↥(Gamma1 N) →* ↥(Gamma1 N) where
+  toFun σ := ⟨frickeEntrySL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩,
+    frickeEntrySL_mem_Gamma1 (σ : SL(2, ℤ)) σ.property⟩
+  map_one' := Subtype.ext frickeEntrySL_one
+  map_mul' σ τ := Subtype.ext (frickeEntrySL_mul ⟨σ, Gamma1_in_Gamma0 N σ.property⟩
     ⟨τ, Gamma1_in_Gamma0 N τ.property⟩)
 
 @[simp]
-public theorem coe_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
-    (frickeConjGamma1 σ : SL(2, ℤ)) = frickeConjSL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩ :=
+public theorem coe_frickeEntryGamma1 (σ : ↥(Gamma1 N)) :
+    (frickeEntryGamma1 σ : SL(2, ℤ)) = frickeEntrySL ⟨σ, Gamma1_in_Gamma0 N σ.property⟩ :=
   (rfl)
 
 section NeZero
@@ -272,84 +292,86 @@ variable [NeZero N]
 /-- **The Fricke conjugation is an involution at nonzero level**: `W² = (-N) • 1` is central, so
 conjugating twice does nothing.
 
-This genuinely needs `N ≠ 0`. At level zero the lower-left entry `-N·b` of `frickeConjSL σ` is
+This genuinely needs `N ≠ 0`. At level zero the lower-left entry `-N·b` of `frickeEntrySL σ` is
 `0` whatever `b` is, so the formula forgets `b` and cannot be undone; see the `Level` section of
 the module docstring. -/
 @[simp]
-public theorem frickeConjGamma0_frickeConjGamma0 (σ : ↥(Gamma0 N)) :
-    frickeConjGamma0 (frickeConjGamma0 σ) = σ := by
+public theorem frickeEntryGamma0_frickeEntryGamma0 (σ : ↥(Gamma0 N)) :
+    frickeEntryGamma0 (frickeEntryGamma0 σ) = σ := by
   have hN : (N : ℤ) ≠ 0 := Int.natCast_ne_zero.mpr (NeZero.ne N)
   have hσ := lowerLeftDiv_spec σ
-  have hdiv : lowerLeftDiv (frickeConjGamma0 σ) = -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
-    have hentry : ((frickeConjGamma0 σ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 =
+  have hdiv : lowerLeftDiv (frickeEntryGamma0 σ) = -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
+    have hentry : ((frickeEntryGamma0 σ : ↥(Gamma0 N)) : Matrix (Fin 2) (Fin 2) ℤ) 1 0 =
         (N : ℤ) * -(σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 := by
-      rw [coe_frickeConjGamma0, coe_frickeConjSL_lowerLeftDiv]
+      rw [coe_frickeEntryGamma0, coe_frickeEntrySL_lowerLeftDiv]
       simp
     rw [lowerLeftDiv, hentry, Int.mul_ediv_cancel_left _ hN]
   apply Subtype.ext
-  rw [coe_frickeConjGamma0]
+  rw [coe_frickeEntryGamma0]
   ext i j
-  rw [coe_frickeConjSL_lowerLeftDiv, hdiv, coe_frickeConjGamma0,
-    coe_frickeConjSL_lowerLeftDiv]
+  rw [coe_frickeEntrySL_lowerLeftDiv, hdiv, coe_frickeEntryGamma0,
+    coe_frickeEntrySL_lowerLeftDiv]
   fin_cases i <;> fin_cases j <;> simp [hσ]
 
-/-- `frickeConjGamma0` is involutive, in the form `Function.Involutive` consumes. -/
-public theorem frickeConjGamma0_involutive :
-    Function.Involutive (frickeConjGamma0 (N := N)) :=
-  frickeConjGamma0_frickeConjGamma0
+/-- `frickeEntryGamma0` is involutive, in the form `Function.Involutive` consumes. -/
+public theorem frickeEntryGamma0_involutive :
+    Function.Involutive (frickeEntryGamma0 (N := N)) :=
+  frickeEntryGamma0_frickeEntryGamma0
 
 /-- **The Fricke conjugation as an automorphism of `Γ₀(N)`**, for nonzero level: the isomorphism
-`Γ₀(N) ≃* Γ₀(N)` that `frickeConjGamma0` becomes once it is known to be involutive. It is its
-own inverse. -/
-public def frickeConjGamma0MulEquiv : ↥(Gamma0 N) ≃* ↥(Gamma0 N) where
-  toFun := frickeConjGamma0
-  invFun := frickeConjGamma0
-  left_inv := frickeConjGamma0_involutive
-  right_inv := frickeConjGamma0_involutive
-  map_mul' := map_mul frickeConjGamma0
+`Γ₀(N) ≃* Γ₀(N)` that `frickeEntryGamma0` becomes once it is known to be involutive. It is its
+own inverse.
 
-/-- `frickeConjGamma0MulEquiv` acts as `frickeConjGamma0`. This is its defining lemma, and the
-one a consumer needs: the body of `frickeConjGamma0MulEquiv` is not exposed, so nothing downstream
-can see through it by unfolding. -/
+This is the declaration that expresses that `W` *normalizes* `Γ₀(N)`, and it is why the name
+carries `Conj` where `frickeEntryGamma0` does not. -/
+public def frickeConjGamma0MulEquiv : ↥(Gamma0 N) ≃* ↥(Gamma0 N) where
+  toFun := frickeEntryGamma0
+  invFun := frickeEntryGamma0
+  left_inv := frickeEntryGamma0_involutive
+  right_inv := frickeEntryGamma0_involutive
+  map_mul' := map_mul frickeEntryGamma0
+
+/-- `frickeConjGamma0MulEquiv` acts as `frickeEntryGamma0`. This is its defining lemma and, with
+`frickeConjGamma0MulEquiv_symm`, the intended interface: a consumer simplifies through these
+rather than through the body of the bundled definition. -/
 @[simp]
 public theorem frickeConjGamma0MulEquiv_apply (σ : ↥(Gamma0 N)) :
-    frickeConjGamma0MulEquiv σ = frickeConjGamma0 σ :=
+    frickeConjGamma0MulEquiv σ = frickeEntryGamma0 σ :=
   (rfl)
 
-/-- **`frickeConjGamma0MulEquiv` is its own inverse.** The underlying map is an involution,
-so `symm` returns the automorphism unchanged; this is what lets a consumer simplify
-`e.symm` without unfolding the bundled definition. -/
+/-- **`frickeConjGamma0MulEquiv` is its own inverse.** The underlying map is an involution, so
+`symm` returns the automorphism unchanged; this is the simp lemma that normalizes `e.symm`. -/
 @[simp]
 public theorem frickeConjGamma0MulEquiv_symm :
     (frickeConjGamma0MulEquiv (N := N)).symm = frickeConjGamma0MulEquiv :=
   (rfl)
 
-/-- The `Γ₁(N)` counterpart of `frickeConjGamma0_frickeConjGamma0`. -/
+/-- The `Γ₁(N)` counterpart of `frickeEntryGamma0_frickeEntryGamma0`. -/
 @[simp]
-public theorem frickeConjGamma1_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
-    frickeConjGamma1 (frickeConjGamma1 σ) = σ :=
+public theorem frickeEntryGamma1_frickeEntryGamma1 (σ : ↥(Gamma1 N)) :
+    frickeEntryGamma1 (frickeEntryGamma1 σ) = σ :=
   Subtype.ext (congrArg (Subtype.val (p := fun g => g ∈ Gamma0 N))
-    (frickeConjGamma0_frickeConjGamma0 ⟨σ, Gamma1_in_Gamma0 N σ.property⟩))
+    (frickeEntryGamma0_frickeEntryGamma0 ⟨σ, Gamma1_in_Gamma0 N σ.property⟩))
 
-/-- `frickeConjGamma1` is involutive, in the form `Function.Involutive` consumes. -/
-public theorem frickeConjGamma1_involutive :
-    Function.Involutive (frickeConjGamma1 (N := N)) :=
-  frickeConjGamma1_frickeConjGamma1
+/-- `frickeEntryGamma1` is involutive, in the form `Function.Involutive` consumes. -/
+public theorem frickeEntryGamma1_involutive :
+    Function.Involutive (frickeEntryGamma1 (N := N)) :=
+  frickeEntryGamma1_frickeEntryGamma1
 
 /-- **The Fricke conjugation as an automorphism of `Γ₁(N)`**, for nonzero level; the `Γ₁`
 counterpart of `frickeConjGamma0MulEquiv`. -/
 public def frickeConjGamma1MulEquiv : ↥(Gamma1 N) ≃* ↥(Gamma1 N) where
-  toFun := frickeConjGamma1
-  invFun := frickeConjGamma1
-  left_inv := frickeConjGamma1_involutive
-  right_inv := frickeConjGamma1_involutive
-  map_mul' := map_mul frickeConjGamma1
+  toFun := frickeEntryGamma1
+  invFun := frickeEntryGamma1
+  left_inv := frickeEntryGamma1_involutive
+  right_inv := frickeEntryGamma1_involutive
+  map_mul' := map_mul frickeEntryGamma1
 
-/-- `frickeConjGamma1MulEquiv` acts as `frickeConjGamma1`; the `Γ₁(N)` counterpart of
+/-- `frickeConjGamma1MulEquiv` acts as `frickeEntryGamma1`; the `Γ₁(N)` counterpart of
 `frickeConjGamma0MulEquiv_apply`. -/
 @[simp]
 public theorem frickeConjGamma1MulEquiv_apply (σ : ↥(Gamma1 N)) :
-    frickeConjGamma1MulEquiv σ = frickeConjGamma1 σ :=
+    frickeConjGamma1MulEquiv σ = frickeEntryGamma1 σ :=
   (rfl)
 
 /-- The `Γ₁(N)` counterpart of `frickeConjGamma0MulEquiv_symm`. -/
@@ -377,14 +399,14 @@ variable [NeZero (N : K)]
 This is the form that moves `W` from the left of `σ` to its right, which is what a slash-action
 computation needs. -/
 public theorem frickeGL_mul_mapGL (σ : ↥(Gamma0 N)) :
-    frickeGL K N * mapGL K (σ : SL(2, ℤ)) = mapGL K (frickeConjSL σ) * frickeGL K N := by
+    frickeGL K N * mapGL K (σ : SL(2, ℤ)) = mapGL K (frickeEntrySL σ) * frickeGL K N := by
   apply Units.ext
   have hc := lowerLeftDiv_spec_field K σ
   rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.GeneralLinearGroup.coe_mul,
     coe_mapGL_fin_two, coe_mapGL_fin_two, coe_frickeGL]
   ext i j
   fin_cases i <;> fin_cases j <;>
-    simp only [Matrix.mul_apply, Fin.sum_univ_two, coe_frickeConjSL, Matrix.cons_val_zero,
+    simp only [Matrix.mul_apply, Fin.sum_univ_two, coe_frickeEntrySL, Matrix.cons_val_zero,
       Matrix.cons_val_one, Matrix.of_apply, algebraMap_int_eq, Int.coe_castRingHom, Fin.isValue,
       Fin.zero_eta, Fin.mk_one, Int.cast_mul, Int.cast_neg, Int.cast_natCast, lowerLeftDiv,
       hc] <;>
@@ -398,21 +420,21 @@ private theorem frickeGL_sq_mul_comm (A : GL (Fin 2) K) :
   simp
 
 /-- **The mirror normalization identity** `σ · W = W · (W σ W⁻¹)` in `GL (Fin 2) K`, for
-`σ ∈ Γ₀(N)`; equivalently `frickeConjSL σ = W⁻¹ · σ · W`.
+`σ ∈ Γ₀(N)`; equivalently `frickeEntrySL σ = W⁻¹ · σ · W`.
 
 This is `frickeGL_mul_mapGL` carried across `W²`, rather than a second entrywise computation:
 `(σ · W) · W = σ · W² = W² · σ = W · (W · σ) = W · (W σ W⁻¹) · W`, and `W` cancels on the
 right. -/
 public theorem mapGL_mul_frickeGL (σ : ↥(Gamma0 N)) :
-    mapGL K (σ : SL(2, ℤ)) * frickeGL K N = frickeGL K N * mapGL K (frickeConjSL σ) := by
+    mapGL K (σ : SL(2, ℤ)) * frickeGL K N = frickeGL K N * mapGL K (frickeEntrySL σ) := by
   refine mul_right_cancel (b := frickeGL K N) ?_
   calc mapGL K (σ : SL(2, ℤ)) * frickeGL K N * frickeGL K N
       = frickeGL K N ^ 2 * mapGL K (σ : SL(2, ℤ)) := by
         rw [mul_assoc, ← sq, ← frickeGL_sq_mul_comm]
     _ = frickeGL K N * (frickeGL K N * mapGL K (σ : SL(2, ℤ))) := by rw [sq, mul_assoc]
-    _ = frickeGL K N * (mapGL K (frickeConjSL σ) * frickeGL K N) := by
+    _ = frickeGL K N * (mapGL K (frickeEntrySL σ) * frickeGL K N) := by
         rw [frickeGL_mul_mapGL]
-    _ = frickeGL K N * mapGL K (frickeConjSL σ) * frickeGL K N := (mul_assoc _ _ _).symm
+    _ = frickeGL K N * mapGL K (frickeEntrySL σ) * frickeGL K N := (mul_assoc _ _ _).symm
 
 end Field
 

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 public import TauCeti.NumberTheory.ModularForms.Fricke.Matrix
-import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
 import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 
 /-!
@@ -328,6 +327,16 @@ public theorem gamma0Map_frickeConjGamma0_mul (σ : ↥(Gamma0 N)) :
   simp only [gamma0Map_apply, coe_frickeConjGamma0, coe_frickeConjSL]
   simpa using hcast
 
+/-- **The unit-valued form of `gamma0Map_frickeConjGamma0_mul`**: on units, the `Gamma0Map` image
+of `frickeConjGamma0 σ` is the inverse of that of `σ`. This is the shape the diamond-character and
+nebentypus consumers work in, obtained from the `ZMod` identity through Mathlib's
+`MonoidHom.toHomUnits`. -/
+@[simp]
+public theorem toHomUnits_gamma0Map_frickeConjGamma0_eq_inv (σ : ↥(Gamma0 N)) :
+    (Gamma0Map N).toHomUnits (frickeConjGamma0 σ) = ((Gamma0Map N).toHomUnits σ)⁻¹ := by
+  refine eq_inv_of_mul_eq_one_left (Units.ext ?_)
+  simpa [MonoidHom.coe_toHomUnits] using gamma0Map_frickeConjGamma0_mul σ
+
 variable [NeZero N]
 
 /-- **Applying the entry map twice is the identity, at nonzero level**, on `SL(2, ℤ)` itself:
@@ -373,12 +382,11 @@ own inverse.
 This is the declaration that expresses that `W` *normalizes* `Γ₀(N)`: `frickeConjGamma0` maps
 the subgroup into itself at every level, and the level hypothesis is what upgrades that to an
 isomorphism. -/
-public def frickeConjGamma0MulEquiv : ↥(Gamma0 N) ≃* ↥(Gamma0 N) where
-  toFun := frickeConjGamma0
-  invFun := frickeConjGamma0
-  left_inv := frickeConjGamma0_involutive
-  right_inv := frickeConjGamma0_involutive
-  map_mul' := map_mul frickeConjGamma0
+public def frickeConjGamma0MulEquiv : ↥(Gamma0 N) ≃* ↥(Gamma0 N) :=
+  -- Mathlib's `Function.Involutive.toPerm` already supplies the `toFun = invFun`
+  -- scaffolding; only multiplicativity is ours to add.
+  { frickeConjGamma0_involutive.toPerm (frickeConjGamma0 (N := N)) with
+    map_mul' := map_mul frickeConjGamma0 }
 
 /-- `frickeConjGamma0MulEquiv` acts as `frickeConjGamma0`. This is its defining lemma and, with
 `frickeConjGamma0MulEquiv_symm`, the intended interface: a consumer simplifies through these
@@ -411,12 +419,11 @@ public theorem frickeConjGamma1_involutive :
 
 /-- **The Fricke conjugation as an automorphism of `Γ₁(N)`**, for nonzero level; the `Γ₁`
 counterpart of `frickeConjGamma0MulEquiv`. -/
-public def frickeConjGamma1MulEquiv : ↥(Gamma1 N) ≃* ↥(Gamma1 N) where
-  toFun := frickeConjGamma1
-  invFun := frickeConjGamma1
-  left_inv := frickeConjGamma1_involutive
-  right_inv := frickeConjGamma1_involutive
-  map_mul' := map_mul frickeConjGamma1
+public def frickeConjGamma1MulEquiv : ↥(Gamma1 N) ≃* ↥(Gamma1 N) :=
+  -- Mathlib's `Function.Involutive.toPerm` already supplies the `toFun = invFun`
+  -- scaffolding; only multiplicativity is ours to add.
+  { frickeConjGamma1_involutive.toPerm (frickeConjGamma1 (N := N)) with
+    map_mul' := map_mul frickeConjGamma1 }
 
 /-- `frickeConjGamma1MulEquiv` acts as `frickeConjGamma1`; the `Γ₁(N)` counterpart of
 `frickeConjGamma0MulEquiv_apply`. -/

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -26,6 +26,22 @@ element back out of it would need the divisibility argument anyway. Defining it 
 proving the product identities afterwards keeps the divisibility in one place,
 `lowerLeftDiv_spec`.
 
+## Level
+
+Everything about the conjugation requires `N ≠ 0`, carried as `[NeZero N]`. At `N = 0` the
+Fricke matrix is `!![0, -1; 0, 0]`, which is singular, so there is nothing to conjugate by. The
+entry formula below would still define *a* matrix there, but a degenerate one: `Γ₀(0)` is the
+upper-triangular subgroup, `lowerLeftDiv` is `0`, and the formula collapses to
+`!![a, b; 0, d] ↦ !![d, 0; 0, a]`, which forgets `b` and is conjugation by nothing. That map is
+not wanted, so `[NeZero N]` rules it out rather than the API quietly extending to it.
+
+`lowerLeftDiv` and `lowerLeftDiv_spec` are the exception and stay unrestricted, since
+`c = N · (c / N)` holds at `N = 0` as well, both sides being zero.
+
+The `K`-valued statements carry `[NeZero N]` next to `[NeZero (N : K)]`. The latter implies the
+former, by `NeZero.of_neZero_natCast`, but not as an instance — `K` cannot be recovered from
+`NeZero N` — so those signatures state both.
+
 ## Base field
 
 The conjugation identities are stated over an arbitrary field `K` in which `N` is invertible,
@@ -37,7 +53,7 @@ itself defined at an arbitrary algebra.
 ## Main definitions
 
 * `TauCeti.lowerLeftDiv`: for `σ ∈ Γ₀(N)`, the integer `c'` with `c = N · c'`.
-* `TauCeti.frickeConjSL`: the conjugate `W · σ · W⁻¹` as an element of `SL(2, ℤ)`.
+* `TauCeti.frickeConjSL`: for `N ≠ 0`, the conjugate `W · σ · W⁻¹` as an element of `SL(2, ℤ)`.
 
 ## Main results
 
@@ -104,8 +120,11 @@ public theorem lowerLeftDiv_spec (σ : ↥(Gamma0 N)) :
 
 /-- The Fricke conjugate `W · σ · W⁻¹` of `σ = !![a, b; N·c', d] ∈ Γ₀(N)`, as an element of
 `SL(2, ℤ)`: the matrix `!![d, -c'; -N·b, a]`. Since `W² = (-N) • 1` is a scalar matrix, hence
-central, this equally describes `W⁻¹ · σ · W`. -/
-public def frickeConjSL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
+central, this equally describes `W⁻¹ · σ · W`.
+
+The hypothesis `N ≠ 0` is what makes `W` invertible, and so what makes this a conjugate at all;
+see the `Level` section of the module docstring. -/
+public def frickeConjSL [NeZero N] (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
   ⟨!![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
       -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0], by
     have hc := lowerLeftDiv_spec σ
@@ -118,7 +137,7 @@ public def frickeConjSL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
 
 /-- The underlying matrix of `frickeConjSL σ`. -/
 @[simp]
-public theorem coe_frickeConjSL (σ : ↥(Gamma0 N)) :
+public theorem coe_frickeConjSL [NeZero N] (σ : ↥(Gamma0 N)) :
     (frickeConjSL σ : Matrix (Fin 2) (Fin 2) ℤ) =
       !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
          -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1,
@@ -127,13 +146,14 @@ public theorem coe_frickeConjSL (σ : ↥(Gamma0 N)) :
 
 /-- **`W` normalizes `Γ₀(N)`**: the conjugate of a `Γ₀(N)` element is again one, its lower-left
 entry `-N·b` being visibly divisible by `N`. -/
-public theorem frickeConjSL_mem_Gamma0 (σ : ↥(Gamma0 N)) : frickeConjSL σ ∈ Gamma0 N := by
+public theorem frickeConjSL_mem_Gamma0 [NeZero N] (σ : ↥(Gamma0 N)) :
+    frickeConjSL σ ∈ Gamma0 N := by
   rw [Gamma0_mem, coe_frickeConjSL]
   simp
 
 /-- **`W` normalizes `Γ₁(N)`**: conjugation swaps the two diagonal entries, so both remain
 `≡ 1 (mod N)`. -/
-public theorem frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
+public theorem frickeConjSL_mem_Gamma1 [NeZero N] (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
     frickeConjSL ⟨σ, Gamma1_in_Gamma0 N hσ⟩ ∈ Gamma1 N := by
   obtain ⟨ha, hd, -⟩ := (Gamma1_mem N σ).mp hσ
   rw [Gamma1_mem, coe_frickeConjSL]
@@ -150,7 +170,7 @@ private theorem lowerLeftDiv_spec_field (σ : ↥(Gamma0 N)) :
     ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : K) = (N : K) * (lowerLeftDiv σ : K) := by
   exact_mod_cast congrArg (Int.cast : ℤ → K) (lowerLeftDiv_spec σ)
 
-variable [NeZero (N : K)]
+variable [NeZero N] [NeZero (N : K)]
 
 /-- **The normalization identity** `W · σ = (W σ W⁻¹) · W` in `GL (Fin 2) K`, for `σ ∈ Γ₀(N)`.
 This is the form that moves `W` from the left of `σ` to its right, which is what a slash-action
@@ -169,7 +189,10 @@ public theorem frickeGL_mul_mapGL (σ : ↥(Gamma0 N)) :
       hc] <;>
     ring
 
-/-- `W²` commutes with everything in `GL (Fin 2) K`: it is the scalar matrix `(-N) • 1`. -/
+omit [NeZero N] in
+/-- `W²` commutes with everything in `GL (Fin 2) K`: it is the scalar matrix `(-N) • 1`. This
+one needs `N` invertible in `K` but not `N ≠ 0` separately, as it never mentions the
+conjugate. -/
 private theorem frickeGL_sq_mul_comm (A : GL (Fin 2) K) :
     frickeGL K N ^ 2 * A = A * frickeGL K N ^ 2 := by
   apply Units.ext

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -28,19 +28,19 @@ proving the product identities afterwards keeps the divisibility in one place,
 
 ## Level
 
-Everything about the conjugation requires `N ≠ 0`, carried as `[NeZero N]`. At `N = 0` the
-Fricke matrix is `!![0, -1; 0, 0]`, which is singular, so there is nothing to conjugate by. The
-entry formula below would still define *a* matrix there, but a degenerate one: `Γ₀(0)` is the
-upper-triangular subgroup, `lowerLeftDiv` is `0`, and the formula collapses to
-`!![a, b; 0, d] ↦ !![d, 0; 0, a]`, which forgets `b` and is conjugation by nothing. That map is
-not wanted, so `[NeZero N]` rules it out rather than the API quietly extending to it.
+`N ≠ 0` is what makes `W` invertible, and so what makes conjugation by `W` mean anything. It is
+needed for the *conjugation*, though, not for the entry formula, so it is stated where `W`
+itself appears: as `[NeZero (N : K)]` on the two normalization identities over `K`, which are
+the statements that actually call `frickeConjSL σ` a conjugate. The `ℤ`-valued declarations
+below carry no level hypothesis — the matrix `!![d, -c'; -N·b, a]` has determinant `1` and lies
+in both congruence subgroups for every `N`, `c = N · (c / N)` holding at `N = 0` as well, both
+sides being zero.
 
-`lowerLeftDiv` and `lowerLeftDiv_spec` are the exception and stay unrestricted, since
-`c = N · (c / N)` holds at `N = 0` as well, both sides being zero.
-
-The `K`-valued statements carry `[NeZero N]` next to `[NeZero (N : K)]`. The latter implies the
-former, by `NeZero.of_neZero_natCast`, but not as an instance — `K` cannot be recovered from
-`NeZero N` — so those signatures state both.
+Level zero is genuinely degenerate, and the declarations below are worded so that nothing
+claims otherwise: `Γ₀(0)` is the upper-triangular subgroup, `lowerLeftDiv` is `0`, and the
+formula collapses to `!![a, b; 0, d] ↦ !![d, 0; 0, a]`, which forgets `b`. That is a
+well-defined `SL(2, ℤ)`-valued map, just not a conjugation — and since `frickeGL K 0` does not
+exist, no identity here asserts that it is one.
 
 ## Base field
 
@@ -53,7 +53,8 @@ itself defined at an arbitrary algebra.
 ## Main definitions
 
 * `TauCeti.lowerLeftDiv`: for `σ ∈ Γ₀(N)`, the integer `c'` with `c = N · c'`.
-* `TauCeti.frickeConjSL`: for `N ≠ 0`, the conjugate `W · σ · W⁻¹` as an element of `SL(2, ℤ)`.
+* `TauCeti.frickeConjSL`: the matrix `!![d, -c'; -N·b, a]` as an element of `SL(2, ℤ)`;
+  for `N ≠ 0` it is the conjugate `W · σ · W⁻¹`.
 
 ## Main results
 
@@ -118,13 +119,14 @@ public theorem lowerLeftDiv_spec (σ : ↥(Gamma0 N)) :
   (Int.mul_ediv_cancel'
     ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp σ.property))).symm
 
-/-- The Fricke conjugate `W · σ · W⁻¹` of `σ = !![a, b; N·c', d] ∈ Γ₀(N)`, as an element of
-`SL(2, ℤ)`: the matrix `!![d, -c'; -N·b, a]`. Since `W² = (-N) • 1` is a scalar matrix, hence
-central, this equally describes `W⁻¹ · σ · W`.
+/-- The Fricke conjugate of `σ = !![a, b; N·c', d] ∈ Γ₀(N)`, as an element of `SL(2, ℤ)`: the
+matrix `!![d, -c'; -N·b, a]`.
 
-The hypothesis `N ≠ 0` is what makes `W` invertible, and so what makes this a conjugate at all;
+For `N ≠ 0` this is `W · σ · W⁻¹`, and equally `W⁻¹ · σ · W` since `W² = (-N) • 1` is central;
+that is the content of `frickeGL_mul_mapGL` and `mapGL_mul_frickeGL`, which carry the
+invertibility hypothesis. At `N = 0` the formula still defines a matrix, but a degenerate one;
 see the `Level` section of the module docstring. -/
-public def frickeConjSL [NeZero N] (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
+public def frickeConjSL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
   ⟨!![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
       -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0], by
     have hc := lowerLeftDiv_spec σ
@@ -137,7 +139,7 @@ public def frickeConjSL [NeZero N] (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
 
 /-- The underlying matrix of `frickeConjSL σ`. -/
 @[simp]
-public theorem coe_frickeConjSL [NeZero N] (σ : ↥(Gamma0 N)) :
+public theorem coe_frickeConjSL (σ : ↥(Gamma0 N)) :
     (frickeConjSL σ : Matrix (Fin 2) (Fin 2) ℤ) =
       !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
          -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1,
@@ -146,14 +148,14 @@ public theorem coe_frickeConjSL [NeZero N] (σ : ↥(Gamma0 N)) :
 
 /-- **`W` normalizes `Γ₀(N)`**: the conjugate of a `Γ₀(N)` element is again one, its lower-left
 entry `-N·b` being visibly divisible by `N`. -/
-public theorem frickeConjSL_mem_Gamma0 [NeZero N] (σ : ↥(Gamma0 N)) :
+public theorem frickeConjSL_mem_Gamma0 (σ : ↥(Gamma0 N)) :
     frickeConjSL σ ∈ Gamma0 N := by
   rw [Gamma0_mem, coe_frickeConjSL]
   simp
 
 /-- **`W` normalizes `Γ₁(N)`**: conjugation swaps the two diagonal entries, so both remain
 `≡ 1 (mod N)`. -/
-public theorem frickeConjSL_mem_Gamma1 [NeZero N] (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
+public theorem frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
     frickeConjSL ⟨σ, Gamma1_in_Gamma0 N hσ⟩ ∈ Gamma1 N := by
   obtain ⟨ha, hd, -⟩ := (Gamma1_mem N σ).mp hσ
   rw [Gamma1_mem, coe_frickeConjSL]
@@ -170,7 +172,7 @@ private theorem lowerLeftDiv_spec_field (σ : ↥(Gamma0 N)) :
     ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : K) = (N : K) * (lowerLeftDiv σ : K) := by
   exact_mod_cast congrArg (Int.cast : ℤ → K) (lowerLeftDiv_spec σ)
 
-variable [NeZero N] [NeZero (N : K)]
+variable [NeZero (N : K)]
 
 /-- **The normalization identity** `W · σ = (W σ W⁻¹) · W` in `GL (Fin 2) K`, for `σ ∈ Γ₀(N)`.
 This is the form that moves `W` from the left of `σ` to its right, which is what a slash-action
@@ -189,10 +191,7 @@ public theorem frickeGL_mul_mapGL (σ : ↥(Gamma0 N)) :
       hc] <;>
     ring
 
-omit [NeZero N] in
-/-- `W²` commutes with everything in `GL (Fin 2) K`: it is the scalar matrix `(-N) • 1`. This
-one needs `N` invertible in `K` but not `N ≠ 0` separately, as it never mentions the
-conjugate. -/
+/-- `W²` commutes with everything in `GL (Fin 2) K`: it is the scalar matrix `(-N) • 1`. -/
 private theorem frickeGL_sq_mul_comm (A : GL (Fin 2) K) :
     frickeGL K N ^ 2 * A = A * frickeGL K N ^ 2 := by
   apply Units.ext

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -1,0 +1,198 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
+public import TauCeti.NumberTheory.ModularForms.Fricke.Matrix
+
+/-!
+# The Fricke matrix normalizes `Γ₀(N)` and `Γ₁(N)`
+
+For `σ = !![a, b; c, d] ∈ Γ₀(N)`, so `N ∣ c`, conjugating by the Fricke matrix
+`W = !![0, -1; N, 0]` of `TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean` gives
+
+`W · σ · W⁻¹ = !![d, -c/N; -N·b, a]`,
+
+which is again integral, again of determinant one, and again in `Γ₀(N)`. This file builds that
+conjugate as an honest `SL(2, ℤ)` matrix — `frickeConjSL` — and records that it stays inside
+`Γ₀(N)` and inside `Γ₁(N)`, together with the two matrix identities that move `W` past `σ`.
+
+The conjugate is defined directly by its entries rather than as a product `W * σ * W⁻¹`: the
+latter lives in `GL (Fin 2) K` and is only *incidentally* integral, so reading an `SL(2, ℤ)`
+element back out of it would need the divisibility argument anyway. Defining it by entries and
+proving the product identities afterwards keeps the divisibility in one place,
+`lowerLeftDiv_spec`.
+
+## Base field
+
+The conjugation identities are stated over an arbitrary field `K` in which `N` is invertible,
+matching the parameterization of `frickeGL`. The weight-`k` slash action needs them over `ℝ`
+while the `GL (Fin 2) ℚ` Hecke-ring stack needs them over `ℚ`; stating them over `K` serves both
+directly, with no transport lemma between the two, since `Matrix.SpecialLinearGroup.mapGL` is
+itself defined at an arbitrary algebra.
+
+## Main definitions
+
+* `TauCeti.lowerLeftDiv`: for `σ ∈ Γ₀(N)`, the integer `c'` with `c = N · c'`.
+* `TauCeti.frickeConjSL`: the conjugate `W · σ · W⁻¹` as an element of `SL(2, ℤ)`.
+
+## Main results
+
+* `TauCeti.lowerLeftDiv_spec`: the defining property `c = N · c'` of that quotient.
+* `TauCeti.coe_frickeConjSL`: the conjugate is `!![d, -c'; -N·b, a]`.
+* `TauCeti.frickeConjSL_mem_Gamma0`, `TauCeti.frickeConjSL_mem_Gamma1`: `W` normalizes both
+  congruence subgroups.
+* `TauCeti.frickeGL_mul_mapGL`, `TauCeti.mapGL_mul_frickeGL`: the two normalization identities
+  `W · σ = (W σ W⁻¹) · W` and `σ · W = W · (W σ W⁻¹)` in `GL (Fin 2) K`.
+
+## Relation to the Atkin–Lehner anti-involution
+
+`TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean` also carries `Γ₀(N)` into itself,
+so the two results look superficially alike. They are different maps. That one is
+`g ↦ w · gᵀ · w⁻¹` for the diagonal `w = natDiagGL 2 ![1, N]`: it transposes, and it is an
+*anti*-homomorphism, bundled as `HeckeRing.GL2.atkinLehnerAntiInvolution_bar` on the Hecke ring
+`Δ₀(N)`. `frickeConjSL` is plain conjugation by `!![0, -1; N, 0]`, with no transpose, and lives
+on `Γ₀(N)` itself. The two *matrices* are already distinguished in `Fricke/Matrix.lean`; this is
+the corresponding note for the two conjugation maps.
+
+## Provenance
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GL2/Fricke.lean`](https://github.com/CBirkbeck/AINTLIB),
+commit `340875adfb2`, Apache-2.0, Chris Birkbeck), realizing part of Layer 6 of the ModularForms
+roadmap. AINTLIB names the divisibility witness `botLeftDiv` and keeps it private; it is public
+here because it appears in the statement of `coe_frickeConjSL`. AINTLIB also obtains it as the
+`Exists.choose` of the `Γ₀(N)` divisibility, which makes it and `frickeConjSL` `noncomputable`
+and their entries opaque; `lowerLeftDiv` is instead the honest quotient `c / N`, exact because
+`N ∣ c`, so both definitions here are computable and reduce entrywise. AINTLIB states the two
+normalization identities over `ℚ` and then transports each along `ℚ → ℝ` by hand, in
+`glMap_frickeGL_mul_mapGL` and `mapGL_mul_glMap_frickeGL`; stating them over `K` as below makes
+both transports the corresponding instance, so those two lemmas have no counterpart here.
+
+The diamond-character companion `Gamma0MapUnits_frickeConjSL` is deliberately *not* ported: it
+is stated in terms of AINTLIB's `Gamma0MapUnits`, the unit-valued refinement of mathlib's
+`CongruenceSubgroup.Gamma0Map`, which TauCeti does not have. It belongs with that definition
+rather than here, and nothing in this file needs it.
+
+## References
+
+* [F. Diamond and J. Shurman, *A First Course in Modular Forms*][diamondshurman2005], §5.
+-/
+
+open Matrix Matrix.SpecialLinearGroup CongruenceSubgroup
+
+open scoped MatrixGroups
+
+namespace TauCeti
+
+variable {N : ℕ}
+
+/-- For `σ ∈ Γ₀(N)` with lower-left entry `c`, the integer `c'` such that `c = N · c'`. It is
+this quotient, not `c` itself, that appears as an entry of the Fricke conjugate. -/
+public def lowerLeftDiv (σ : ↥(Gamma0 N)) : ℤ :=
+  (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ)
+
+/-- The defining property of `lowerLeftDiv`: the lower-left entry of `σ` is `N · lowerLeftDiv σ`.
+This is the only place the `Γ₀(N)` divisibility is used. -/
+public theorem lowerLeftDiv_spec (σ : ↥(Gamma0 N)) :
+    (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = N * lowerLeftDiv σ :=
+  (Int.mul_ediv_cancel'
+    ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp σ.property))).symm
+
+/-- The Fricke conjugate `W · σ · W⁻¹` of `σ = !![a, b; N·c', d] ∈ Γ₀(N)`, as an element of
+`SL(2, ℤ)`: the matrix `!![d, -c'; -N·b, a]`. Since `W² = (-N) • 1` is a scalar matrix, hence
+central, this equally describes `W⁻¹ · σ · W`. -/
+public def frickeConjSL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
+  ⟨!![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
+      -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0], by
+    have hc := lowerLeftDiv_spec σ
+    set M := (σ : Matrix (Fin 2) (Fin 2) ℤ) with hM
+    have hdet : M 0 0 * M 1 1 - M 0 1 * M 1 0 = 1 := by
+      have := σ.1.prop
+      rwa [det_fin_two] at this
+    rw [det_fin_two_of]
+    linear_combination hdet + M 0 1 * hc⟩
+
+/-- The underlying matrix of `frickeConjSL σ`. -/
+@[simp]
+public theorem coe_frickeConjSL (σ : ↥(Gamma0 N)) :
+    (frickeConjSL σ : Matrix (Fin 2) (Fin 2) ℤ) =
+      !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
+         -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1,
+         (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0] := by
+  simp [frickeConjSL]
+
+/-- **`W` normalizes `Γ₀(N)`**: the conjugate of a `Γ₀(N)` element is again one, its lower-left
+entry `-N·b` being visibly divisible by `N`. -/
+public theorem frickeConjSL_mem_Gamma0 (σ : ↥(Gamma0 N)) : frickeConjSL σ ∈ Gamma0 N := by
+  rw [Gamma0_mem, coe_frickeConjSL]
+  simp
+
+/-- **`W` normalizes `Γ₁(N)`**: conjugation swaps the two diagonal entries, so both remain
+`≡ 1 (mod N)`. -/
+public theorem frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
+    frickeConjSL ⟨σ, Gamma1_in_Gamma0 N hσ⟩ ∈ Gamma1 N := by
+  obtain ⟨ha, hd, -⟩ := (Gamma1_mem N σ).mp hσ
+  rw [Gamma1_mem, coe_frickeConjSL]
+  exact ⟨by simpa using hd, by simpa using ha, by simp⟩
+
+section Field
+
+variable (K : Type*) [Field K]
+
+/-- The lower-left entry of `σ ∈ Γ₀(N)`, read in `K`, is `N` times `lowerLeftDiv σ`. The
+`K`-valued form of `lowerLeftDiv_spec`, which is what the entrywise computations below
+consume. -/
+private theorem lowerLeftDiv_spec_field (σ : ↥(Gamma0 N)) :
+    ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : K) = (N : K) * (lowerLeftDiv σ : K) := by
+  exact_mod_cast congrArg (Int.cast : ℤ → K) (lowerLeftDiv_spec σ)
+
+variable [NeZero (N : K)]
+
+/-- **The normalization identity** `W · σ = (W σ W⁻¹) · W` in `GL (Fin 2) K`, for `σ ∈ Γ₀(N)`.
+This is the form that moves `W` from the left of `σ` to its right, which is what a slash-action
+computation needs. -/
+public theorem frickeGL_mul_mapGL (σ : ↥(Gamma0 N)) :
+    frickeGL K N * mapGL K (σ : SL(2, ℤ)) = mapGL K (frickeConjSL σ) * frickeGL K N := by
+  apply Units.ext
+  have hc := lowerLeftDiv_spec_field K σ
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [Matrix.GeneralLinearGroup.coe_mul, Matrix.mul_apply, Fin.sum_univ_two,
+      coe_frickeGL, mapGL_coe_matrix, RingHom.mapMatrix_apply, Matrix.map_apply,
+      coe_frickeConjSL, SpecialLinearGroup.map_apply_coe, Matrix.cons_val_zero,
+      Matrix.cons_val_one, Matrix.of_apply, algebraMap_int_eq, Int.coe_castRingHom,
+      Fin.isValue, Fin.zero_eta, Fin.mk_one, Int.cast_mul, Int.cast_neg, Int.cast_natCast,
+      hc] <;>
+    ring
+
+/-- `W²` commutes with everything in `GL (Fin 2) K`: it is the scalar matrix `(-N) • 1`. -/
+private theorem frickeGL_sq_mul_comm (A : GL (Fin 2) K) :
+    frickeGL K N ^ 2 * A = A * frickeGL K N ^ 2 := by
+  apply Units.ext
+  rw [Units.val_mul, Units.val_mul, coe_frickeGL_sq]
+  simp
+
+/-- **The mirror normalization identity** `σ · W = W · (W σ W⁻¹)` in `GL (Fin 2) K`, for
+`σ ∈ Γ₀(N)`; equivalently `frickeConjSL σ = W⁻¹ · σ · W`.
+
+This is `frickeGL_mul_mapGL` carried across `W²`, rather than a second entrywise computation:
+`(σ · W) · W = σ · W² = W² · σ = W · (W · σ) = W · (W σ W⁻¹) · W`, and `W` cancels on the
+right. -/
+public theorem mapGL_mul_frickeGL (σ : ↥(Gamma0 N)) :
+    mapGL K (σ : SL(2, ℤ)) * frickeGL K N = frickeGL K N * mapGL K (frickeConjSL σ) := by
+  refine mul_right_cancel (b := frickeGL K N) ?_
+  calc mapGL K (σ : SL(2, ℤ)) * frickeGL K N * frickeGL K N
+      = frickeGL K N ^ 2 * mapGL K (σ : SL(2, ℤ)) := by
+        rw [mul_assoc, ← sq, ← frickeGL_sq_mul_comm]
+    _ = frickeGL K N * (frickeGL K N * mapGL K (σ : SL(2, ℤ))) := by rw [sq, mul_assoc]
+    _ = frickeGL K N * (mapGL K (frickeConjSL σ) * frickeGL K N) := by
+        rw [frickeGL_mul_mapGL]
+    _ = frickeGL K N * mapGL K (frickeConjSL σ) * frickeGL K N := (mul_assoc _ _ _).symm
+
+end Field
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -9,22 +9,23 @@ public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 public import TauCeti.NumberTheory.ModularForms.Fricke.Matrix
 
 /-!
-# The Fricke matrix normalizes `Γ₀(N)` and `Γ₁(N)`
+# Conjugating `Γ₀(N)` and `Γ₁(N)` by the Fricke matrix
 
-For `σ = !![a, b; c, d] ∈ Γ₀(N)`, so `N ∣ c`, conjugating by the Fricke matrix
+For `N ≠ 0` and `σ = !![a, b; c, d] ∈ Γ₀(N)`, so `N ∣ c`, conjugating by the Fricke matrix
 `W = !![0, -1; N, 0]` of `TauCeti/NumberTheory/ModularForms/Fricke/Matrix.lean` gives
 
 `W · σ · W⁻¹ = !![d, -c/N; -N·b, a]`,
 
-which is again integral, again of determinant one, and again in `Γ₀(N)`. This file builds that
-conjugate as an honest `SL(2, ℤ)` matrix — `frickeConjSL` — and records that it stays inside
-`Γ₀(N)` and inside `Γ₁(N)`, together with the two matrix identities that move `W` past `σ`.
+which is again integral, again of determinant one, and again in `Γ₀(N)`. This file builds the
+right-hand side as an honest `SL(2, ℤ)` matrix — `frickeConjSL` — reading it off the entries of
+`σ`, so that it is defined at every level; records that it stays inside `Γ₀(N)` and inside
+`Γ₁(N)`, again at every level; and proves, for `N ≠ 0`, the two matrix identities that move `W`
+past `σ` and are what make `frickeConjSL σ` the conjugate `W · σ · W⁻¹`.
 
-The conjugate is defined directly by its entries rather than as a product `W * σ * W⁻¹`: the
+`frickeConjSL` is defined directly by its entries rather than as a product `W * σ * W⁻¹`: the
 latter lives in `GL (Fin 2) K` and is only *incidentally* integral, so reading an `SL(2, ℤ)`
 element back out of it would need the divisibility argument anyway. Defining it by entries and
-proving the product identities afterwards keeps the divisibility in one place,
-`lowerLeftDiv_spec`.
+proving the product identities afterwards keeps the divisibility in one place.
 
 ## Level
 
@@ -37,7 +38,7 @@ in both congruence subgroups for every `N`, `c = N · (c / N)` holding at `N = 0
 sides being zero.
 
 Level zero is genuinely degenerate, and the declarations below are worded so that nothing
-claims otherwise: `Γ₀(0)` is the upper-triangular subgroup, `lowerLeftDiv` is `0`, and the
+claims otherwise: `Γ₀(0)` is the upper-triangular subgroup, the quotient `c / N` is `0`, and the
 formula collapses to `!![a, b; 0, d] ↦ !![d, 0; 0, a]`, which forgets `b`. That is a
 well-defined `SL(2, ℤ)`-valued map, just not a conjugation — and since `frickeGL K 0` does not
 exist, no identity here asserts that it is one.
@@ -52,18 +53,17 @@ itself defined at an arbitrary algebra.
 
 ## Main definitions
 
-* `TauCeti.lowerLeftDiv`: for `σ ∈ Γ₀(N)`, the integer `c'` with `c = N · c'`.
-* `TauCeti.frickeConjSL`: the matrix `!![d, -c'; -N·b, a]` as an element of `SL(2, ℤ)`;
+* `TauCeti.frickeConjSL`: the matrix `!![d, -c/N; -N·b, a]` as an element of `SL(2, ℤ)`;
   for `N ≠ 0` it is the conjugate `W · σ · W⁻¹`.
 
 ## Main results
 
-* `TauCeti.lowerLeftDiv_spec`: the defining property `c = N · c'` of that quotient.
-* `TauCeti.coe_frickeConjSL`: the conjugate is `!![d, -c'; -N·b, a]`.
-* `TauCeti.frickeConjSL_mem_Gamma0`, `TauCeti.frickeConjSL_mem_Gamma1`: `W` normalizes both
-  congruence subgroups.
-* `TauCeti.frickeGL_mul_mapGL`, `TauCeti.mapGL_mul_frickeGL`: the two normalization identities
-  `W · σ = (W σ W⁻¹) · W` and `σ · W = W · (W σ W⁻¹)` in `GL (Fin 2) K`.
+* `TauCeti.coe_frickeConjSL`: the entries of `frickeConjSL σ`, namely `!![d, -c/N; -N·b, a]`.
+* `TauCeti.frickeConjSL_mem_Gamma0`, `TauCeti.frickeConjSL_mem_Gamma1`: that formula preserves
+  both congruence subgroups, at every level.
+* `TauCeti.frickeGL_mul_mapGL`, `TauCeti.mapGL_mul_frickeGL`: for `N ≠ 0`, the two
+  normalization identities `W · σ = (W σ W⁻¹) · W` and `σ · W = W · (W σ W⁻¹)` in
+  `GL (Fin 2) K`. These are the statements that exhibit `W` as normalizing `Γ₀(N)`.
 
 ## Relation to the Atkin–Lehner anti-involution
 
@@ -80,14 +80,15 @@ the corresponding note for the two conjugation maps.
 Ported from the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/Fricke.lean`](https://github.com/CBirkbeck/AINTLIB),
 commit `340875adfb2`, Apache-2.0, Chris Birkbeck), realizing part of Layer 6 of the ModularForms
-roadmap. AINTLIB names the divisibility witness `botLeftDiv` and keeps it private; it is public
-here because it appears in the statement of `coe_frickeConjSL`. AINTLIB also obtains it as the
-`Exists.choose` of the `Γ₀(N)` divisibility, which makes it and `frickeConjSL` `noncomputable`
-and their entries opaque; `lowerLeftDiv` is instead the honest quotient `c / N`, exact because
-`N ∣ c`, so both definitions here are computable and reduce entrywise. AINTLIB states the two
-normalization identities over `ℚ` and then transports each along `ℚ → ℝ` by hand, in
-`glMap_frickeGL_mul_mapGL` and `mapGL_mul_glMap_frickeGL`; stating them over `K` as below makes
-both transports the corresponding instance, so those two lemmas have no counterpart here.
+roadmap. AINTLIB names the divisibility witness `botLeftDiv` and keeps it private; it is private
+here too, and `coe_frickeConjSL` writes the quotient `c / N` out instead, so the public API is
+the matrix formula alone. AINTLIB obtains the witness as the `Exists.choose` of the `Γ₀(N)`
+divisibility, which makes it and `frickeConjSL` `noncomputable` and their entries opaque; here it
+is the honest quotient `c / N`, exact because `N ∣ c`, so both definitions are computable and
+reduce entrywise. AINTLIB states the two normalization identities over `ℚ` and then transports
+each along `ℚ → ℝ` by hand, in `glMap_frickeGL_mul_mapGL` and `mapGL_mul_glMap_frickeGL`; stating
+them over `K` as below makes both transports the corresponding instance, so those two lemmas have
+no counterpart here.
 
 The diamond-character companion `Gamma0MapUnits_frickeConjSL` is deliberately *not* ported: it
 is stated in terms of AINTLIB's `Gamma0MapUnits`, the unit-valued refinement of mathlib's
@@ -108,13 +109,15 @@ namespace TauCeti
 variable {N : ℕ}
 
 /-- For `σ ∈ Γ₀(N)` with lower-left entry `c`, the integer `c'` such that `c = N · c'`. It is
-this quotient, not `c` itself, that appears as an entry of the Fricke conjugate. -/
-public def lowerLeftDiv (σ : ↥(Gamma0 N)) : ℤ :=
+this quotient, not `c` itself, that appears as an entry of the Fricke conjugate.
+
+An implementation detail: the public `coe_frickeConjSL` writes `c / N` out. -/
+private def lowerLeftDiv (σ : ↥(Gamma0 N)) : ℤ :=
   (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ)
 
 /-- The defining property of `lowerLeftDiv`: the lower-left entry of `σ` is `N · lowerLeftDiv σ`.
 This is the only place the `Γ₀(N)` divisibility is used. -/
-public theorem lowerLeftDiv_spec (σ : ↥(Gamma0 N)) :
+private theorem lowerLeftDiv_spec (σ : ↥(Gamma0 N)) :
     (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = N * lowerLeftDiv σ :=
   (Int.mul_ediv_cancel'
     ((ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp σ.property))).symm
@@ -137,24 +140,26 @@ public def frickeConjSL (σ : ↥(Gamma0 N)) : SL(2, ℤ) :=
     rw [det_fin_two_of]
     linear_combination hdet + M 0 1 * hc⟩
 
-/-- The underlying matrix of `frickeConjSL σ`. -/
+/-- The underlying matrix of `frickeConjSL σ`, with the exact quotient `c / N` of the lower-left
+entry `c` written out. -/
 @[simp]
 public theorem coe_frickeConjSL (σ : ↥(Gamma0 N)) :
     (frickeConjSL σ : Matrix (Fin 2) (Fin 2) ℤ) =
-      !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -lowerLeftDiv σ;
-         -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1,
-         (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0] := by
-  simp [frickeConjSL]
+      !![(σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1, -((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 / (N : ℤ));
+         -(N : ℤ) * (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1, (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0] := by
+  simp [frickeConjSL, lowerLeftDiv]
 
-/-- **`W` normalizes `Γ₀(N)`**: the conjugate of a `Γ₀(N)` element is again one, its lower-left
-entry `-N·b` being visibly divisible by `N`. -/
+/-- **`frickeConjSL` preserves `Γ₀(N)`**: its lower-left entry `-N·b` is visibly divisible by
+`N`. This is a statement about the entry formula, so it holds at every level; for `N ≠ 0`, where
+`frickeConjSL σ` really is `W · σ · W⁻¹`, it says that `W` normalizes `Γ₀(N)`. -/
 public theorem frickeConjSL_mem_Gamma0 (σ : ↥(Gamma0 N)) :
     frickeConjSL σ ∈ Gamma0 N := by
   rw [Gamma0_mem, coe_frickeConjSL]
   simp
 
-/-- **`W` normalizes `Γ₁(N)`**: conjugation swaps the two diagonal entries, so both remain
-`≡ 1 (mod N)`. -/
+/-- **`frickeConjSL` preserves `Γ₁(N)`**: the entry formula swaps the two diagonal entries, so
+both remain `≡ 1 (mod N)`. As for `Γ₀(N)` this holds at every level, and for `N ≠ 0` it says
+that `W` normalizes `Γ₁(N)`. -/
 public theorem frickeConjSL_mem_Gamma1 (σ : SL(2, ℤ)) (hσ : σ ∈ Gamma1 N) :
     frickeConjSL ⟨σ, Gamma1_in_Gamma0 N hσ⟩ ∈ Gamma1 N := by
   obtain ⟨ha, hd, -⟩ := (Gamma1_mem N σ).mp hσ
@@ -188,7 +193,7 @@ public theorem frickeGL_mul_mapGL (σ : ↥(Gamma0 N)) :
       coe_frickeConjSL, SpecialLinearGroup.map_apply_coe, Matrix.cons_val_zero,
       Matrix.cons_val_one, Matrix.of_apply, algebraMap_int_eq, Int.coe_castRingHom,
       Fin.isValue, Fin.zero_eta, Fin.mk_one, Int.cast_mul, Int.cast_neg, Int.cast_natCast,
-      hc] <;>
+      lowerLeftDiv, hc] <;>
     ring
 
 /-- `W²` commutes with everything in `GL (Fin 2) K`: it is the scalar matrix `(-N) • 1`. -/


### PR DESCRIPTION
Conjugation by the Fricke matrix `W = !![0, -1; N, 0]` of `Fricke/Matrix.lean` carries `Γ₀(N)`
and `Γ₁(N)` into themselves. For `σ = !![a, b; c, d] ∈ Γ₀(N)`, so `N ∣ c`,

`W · σ · W⁻¹ = !![d, -c/N; -N·b, a]`,

again integral and again of determinant one. `frickeConjSL` builds that right-hand side as an
honest `SL(2, ℤ)` element; `frickeConjSL_mem_Gamma0` and `frickeConjSL_mem_Gamma1` are the two
closure statements; `frickeGL_mul_mapGL` and `mapGL_mul_frickeGL` move `W` past `σ` in
`GL (Fin 2) K` in each direction. `frickeConjSL_one` and `frickeConjSL_mul` make the entry map
unital and multiplicative at every level, which bundles it as `frickeConjGamma0 : Γ₀(N) →* Γ₀(N)`
and its restriction `frickeConjGamma1 : Γ₁(N) →* Γ₁(N)`. For `[NeZero N]` applying it twice is
the identity, so `frickeConjGamma0MulEquiv` and `frickeConjGamma1MulEquiv` record each as an
automorphism that is its own inverse — and those are the declarations that say `W` *normalizes*
the subgroup, rather than merely that the entry formula maps into it.

This is rung 2 of the Fricke ladder. Rung 1 (the matrix itself) landed as #4389; the Fricke
*operator* — slash-invariance, the cusp form, the normalizing scalar — sits above this and
follows separately. Nothing here mentions the slash action.

The map is defined by its entries rather than as the product `W * σ * W⁻¹`: that product
lives in `GL (Fin 2) K` and is only incidentally integral, so reading an `SL(2, ℤ)` element back
out of it would need the divisibility argument anyway. Defining it by entries keeps the
divisibility in one place, `natCast_mul_lowerLeft_ediv`.

The identities are stated over an arbitrary field `K` in which `N` is invertible, matching
`frickeGL`'s parameterization: the slash action wants them over `ℝ` and the `GL (Fin 2) ℚ`
Hecke-ring stack over `ℚ`, and `Matrix.SpecialLinearGroup.mapGL` is already defined at an
arbitrary algebra, so one statement serves both with no transport lemma.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"layer6-fricke-conjugation"}-->

Layer 6 of the ModularForms roadmap names the Fricke side as AINTLIB material to migrate. This
PR takes the conjugation-into-`Γ₀(N)` step of that migration only.

### This description was rewritten against the shipped names

Earlier revisions of this description documented a `frickeEntry*` / `lowerLeftDiv` API and a
naming split reserving `frickeConj` for the level-gated declarations. **That plan was abandoned in
the code and the description was not updated with it** — which is the defect five rubrics reported
at head `4f2e6e5` (correctness, scope, api-design, naming, documentation), each offering "correct
the description" as a remedy. The shipped names are `frickeConjSL`, `frickeConjGamma0`,
`frickeConjGamma1` and `natCast_mul_lowerLeft_ediv`; there is no `frickeEntry*` or `lowerLeftDiv`
declaration at this head. The section below is the naming rationale the code actually implements.

### Level, and why the all-level names still say `frickeConj`

`N ≠ 0` is what makes `W` invertible, so it is what makes conjugation by `W` mean anything — but
it is needed for the *conjugation*, not for the entry formula. It is therefore stated where `W`
itself appears, rather than on the definition: `frickeGL_mul_mapGL` and `mapGL_mul_frickeGL` are
the two statements that exhibit the entry formula as a conjugate, and both mention `frickeGL K N`,
which carries `[NeZero (N : K)]` in its own signature (`Fricke/Matrix.lean:67`). `frickeGL K 0`
does not elaborate over a field, so **no identity in this file asserts a conjugation at level
zero.**

The `ℤ`-valued declarations carry no level hypothesis and are true as stated for every `N`:
`!![d, -c'; -N·b, a]` has determinant `1` and lies in `Γ₀(N)` and `Γ₁(N)`, and `c = N · (c / N)`
holds at `N = 0` too, both sides being zero. Level zero is genuinely degenerate — `Γ₀(0)` is the
upper-triangular subgroup, the quotient `c / N` is `0`, and the formula collapses to
`!![a, b; 0, d] ↦ !![d, 0; 0, a]`, forgetting `b`.

The all-level declarations are nevertheless named `frickeConj*`, for the conjugation they are
*for*, exactly as mathlib names `Matrix.inv` at a singular matrix, `Int.ediv` by `0`, and
`Gamma0 0` itself. The signature route is closed by CI: `[NeZero N]` on the entry map was tried at
`8670279ad` and `lint-env` rejected it, because the definition never uses the instance and
`unusedArguments` flags it; the escape hatch (`@[nolint unusedArguments]` plus
`scripts/lint-nolints-allowlist.txt`) is a human-owned file that is empty. Re-measured with a
two-declaration probe — the gated shape and an ungated control — against the same linter:

```
#check @LintProbe.probeGated /- 1 unused argument:
  argument 2: [NeZero N] -/
-- Found 1 error in 2 declarations ... with 1 linters
```

the control is clean, so the flag is the gate and not the probe. The module docstring's `Level`
section carries this argument in full.

### Attribution

Ported from the AINTLIB `LeanModularForms` project,
[`LeanModularForms/HeckeRIngs/GL2/Fricke.lean`](https://github.com/CBirkbeck/AINTLIB) (Chris
Birkbeck, Apache-2.0), at commit `340875adfb2` — source declarations `botLeftDiv`,
`botLeftDiv_spec`, `frickeConjSL`, `frickeConjSL_coe`, `frickeConjSL_mem_Gamma0`,
`frickeConjSL_mem_Gamma1`, `frickeGL_mul_mapGL`, `mapGL_mul_frickeGL`, and the ZMod-level content
of `Gamma0MapUnits_frickeConjSL`.

Deviations from the source, all recorded in the file's Provenance section:

* AINTLIB obtains the divisibility witness as the `Exists.choose` of `N ∣ c`, which makes it and
  `frickeConjSL` `noncomputable` with opaque entries. `natCast_mul_lowerLeft_ediv` is instead the
  honest quotient `c / N`, exact because `N ∣ c`, so both definitions here are computable and
  reduce entrywise. (`Int.mul_ediv_cancel'` gives the spec and is correct at `N = 0` too, where
  `Gamma0 0` forces `c = 0`.)
* **The witness is `private` upstream but `public` here.** `coe_frickeConjSL` displays the
  quotient `c / N` as an `Int.ediv`, so a consumer of that `simp` lemma needs the spec to make
  progress; keeping it private would force every use site to re-derive `(N : ℤ) ∣ c` from
  `Gamma0_mem`. This reverses the earlier claim in both this description and the file's
  Provenance that the public API is the matrix formula alone.
* AINTLIB states the two identities over `ℚ` and then transports each along `ℚ → ℝ` by hand
  (`glMap_frickeGL_mul_mapGL`, `mapGL_mul_glMap_frickeGL`). Stating them over `K` makes both
  transports the corresponding instance, so those two lemmas have no counterpart here.
* `Gamma0MapUnits_frickeConjSL` is **partly** ported. Its ZMod-level content is
  `gamma0Map_frickeConjGamma0_mul`, which says the `Gamma0Map` image of `frickeConjGamma0 σ`
  times that of `σ` is `1`. Only the *unit-valued* refinement is deferred, because it is stated
  through AINTLIB's `Gamma0MapUnits` — the unit-valued refinement of mathlib's
  `CongruenceSubgroup.Gamma0Map` — which TauCeti does not have; from the shipped lemma it is one
  `MonoidHom.toHomUnits` away. Earlier revisions of this description and of the file's Provenance
  said the companion was *not* ported at all; that was wrong once the ZMod-level lemma was added.

Added here with no counterpart upstream: `frickeConjSL_one`, `frickeConjSL_mul`,
`lowerLeft_ediv_mul`, `mapGL_frickeConjSL`, the bundled `frickeConjGamma0` and `frickeConjGamma1`
with their involution lemmas, and the two `MulEquiv`s with their `apply`/`symm` lemmas.

### Absence, measured at `origin/main` `aa532ea92`

* `frickeConj`, `botLeftDiv` under `TauCeti/`: **0 hits**, with `frickeGL` (27 hits in
  `Fricke/Matrix.lean`) fired as a positive control through the identical query form.
* `Fricke`, `AtkinLehner` across the pinned Mathlib: **0 hits**, with `Gamma0` as the positive
  control. Mathlib has no Fricke or Atkin–Lehner material at this pin.

`TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/AtkinLehner.lean` does also carry `Γ₀(N)` into
itself, so the file docstring carries a section distinguishing the two: that map is
`g ↦ w · gᵀ · w⁻¹` for the diagonal `w = natDiagGL 2 ![1, N]` — it transposes, and it is an
*anti*-homomorphism on the Hecke ring `Δ₀(N)`. This one is plain conjugation by
`!![0, -1; N, 0]`, no transpose, on `Γ₀(N)` itself.

### Validation

The module is new and nothing imports it yet, so it is the whole local blast radius.
`lake build TauCeti.NumberTheory.ModularForms.Fricke.Conjugation` is clean at this head (2199
jobs, no warnings), and CI's `sandboxed-build` is green on this head. Environment linters were run
scoped to this module — a legacy driver importing only `Fricke/Conjugation.lean`, running
`#lint only` over the same thirteen linters `scripts/lint-env.sh` uses — reporting 0 errors; that
is what covers the `@[simp]` on `frickeConjSL_mul`, since `simpNF` is in the set.
`scripts/lint-env.sh` itself was not run locally: its docstring-scan driver imports the entire
library, and CI's `pr-build` covers that.

### Interface

No bundled definition in the file is tagged `@[expose]`. `frickeConjGamma0`, `frickeConjGamma1`
and the two automorphisms are characterized instead by `coe_frickeConjGamma0`,
`coe_frickeConjGamma1`, `frickeConjGamma0MulEquiv_apply`, `frickeConjGamma0MulEquiv_symm` and
their `Γ₁` twins, all `@[simp]` and proved by `(rfl)`. Those simp lemmas are the intended
interface: a consumer should be able to work entirely through them rather than through the
bodies.
