### PR TITLE
feat: principal powers of a height one prime and the valuations of a generator

### DIFF
--- a/TauCeti/RingTheory/DedekindDomain/PrincipalPower.lean
+++ b/TauCeti/RingTheory/DedekindDomain/PrincipalPower.lean
@@ -11,16 +11,17 @@ public import TauCeti.RingTheory.ClassGroup.Basic
 /-!
 # Principal powers of a height one prime, and the valuations of a generator
 
-Over a Dedekind domain with finite class group, no height one prime need be principal, but some
-positive power of it always is: the class `[v]` has finite order `m` in the class group, and
-`[v] ^ m = 1` says exactly that `v ^ m` is principal. This file records that fact together with
-its companion, which is what makes the generator useful: a generator of `v ^ m` is a unit at
-every height one prime other than `v`.
+Over a Dedekind domain no height one prime need be principal, but a positive power of one is as
+soon as its class `[v]` has finite order `m` in the class group: `[v] ^ m = 1` says exactly that
+`v ^ m` is principal. A finite class group is the usual source of that hypothesis, but only the
+single class `[v]` is at stake. This file records that fact together with its companion, which is
+what makes the generator useful: a generator of `v ^ m` is a unit at every height one prime other
+than `v`.
 
 ## Main results
 
-* `IsDedekindDomain.HeightOneSpectrum.exists_pow_eq_span`: if `ClassGroup R` is finite, some
-  positive power of `v` is `Ideal.span {π}` for a nonzero `π : R`.
+* `IsDedekindDomain.HeightOneSpectrum.exists_pow_eq_span`: if the class of `v` has finite order,
+  some positive power of `v` is `Ideal.span {π}` for a nonzero `π : R`.
 * `IsDedekindDomain.HeightOneSpectrum.valuation_algebraMap_eq_one_of_pow_le_span`: if `π`
   divides `v.asIdeal ^ n`, then `w.valuation K (algebraMap R K π) = 1` for every height one
   prime `w ≠ v`.
@@ -32,34 +33,42 @@ standard basis vector at `v`, and hence what makes the range of the `S`-unit log
 
 ## Implementation notes
 
-The class group hypothesis is confined to `exists_pow_eq_span`; the second result is
-unconditional, and is proved by reducing `w.valuation K (algebraMap R K π) = 1` to
-`π ∉ w.asIdeal` through Mathlib's
+`exists_pow_eq_span` asks only that the single class `[v]` have finite order, not that the whole
+class group be finite: all the proof takes from the hypothesis is one positive `m` with
+`[v] ^ m = 1`, which is `IsOfFinOrder.exists_pow_eq_one`. A caller carrying
+`[Finite (ClassGroup R)]` supplies the hypothesis as `isOfFinOrder_of_finite _`, so no separate
+finite-class-group form is stated here. Nothing weaker will do either: a nonzero `π` with
+`v.asIdeal ^ m = Ideal.span {π}` and `0 < m` forces `[v] ^ m = 1`, so finite order of `[v]` is
+necessary as well as sufficient.
+
+The second result needs no class hypothesis at all. It is proved by reducing
+`w.valuation K (algebraMap R K π) = 1` to `π ∉ w.asIdeal` through Mathlib's
 `IsDedekindDomain.HeightOneSpectrum.valuation_eq_one_iff_notMem`, then using that a prime
 containing `v ^ n` contains `v`, and `v` is maximal.
 
-That second result asks only for the containment `v.asIdeal ^ n ≤ Ideal.span {π}` — `π` divides
-`v ^ n` — rather than the equality a principal power gives. The proof uses the containment in one
-direction only, and the weaker hypothesis is the honest statement of what makes `π` a `w`-adic
-unit: its ideal support is contained in `{v}`.
+It also asks only for the containment `v.asIdeal ^ n ≤ Ideal.span {π}` — `π` divides `v ^ n` —
+rather than the equality a principal power gives. The proof uses the containment in one direction
+only, and the weaker hypothesis is the honest statement of what makes `π` a `w`-adic unit: its
+ideal support is contained in `{v}`.
 
 Passing from `[v] ^ m` to the class of `v.asIdeal ^ m` is Mathlib's `SubmonoidClass.mk_pow`,
 which is exactly the coercion `(⟨I, hI⟩ : (Ideal R)⁰) ^ m = ⟨I ^ m, _⟩`; Mathlib's own
 `Ideal.IsPrincipal.of_isPrincipal_pow_of_coprime` takes the same step the same way.
 
-`exists_pow_eq_span` is stated with the exponent existentially quantified rather than as
-`orderOf v.classGroupMk`, because no consumer so far needs the exponent to be the order: what is
-used is only that it is positive. Naming the order in the statement would force every consumer to
-carry `ClassGroup` vocabulary that the conclusion does not otherwise mention.
+The exponent is existentially quantified rather than named as `orderOf v.classGroupMk`, because no
+consumer so far needs the exponent to be the order: what is used is only that it is positive.
+Leaving it existential also keeps the conclusion free of the `ClassGroup` vocabulary that the
+hypothesis alone mentions, and lets the proof read the exponent straight off the hypothesis.
 
 Adapted from Michael Stoll's elliptic-curves formalisation
 (`github.com/MichaelStollBayreuth/EllipticCurves`, `EllipticCurves/Mathlib/FractionalIdeal.lean`
 and `EllipticCurves/Mathlib/Basic.lean` at the roadmap's pin `66889eada51a`, Apache 2.0, by
 Michael Stoll); following this repository's convention for adapted material, the upstream
-authorship is credited here rather than in the copyright header. Two deliberate departures from
-the source: `exists_pow_eq_span` reaches the class of `v.asIdeal ^ m` through this repository's
+authorship is credited here rather than in the copyright header. Three deliberate departures from
+the source: `exists_pow_eq_span` weakens the source's `[Finite (ClassGroup R)]` to finite order of
+the single class `[v]`, and reaches the class of `v.asIdeal ^ m` through this repository's
 `classGroupMk_eq_mk0` and Mathlib's `SubmonoidClass.mk_pow` instead of an inline `Subtype.ext`
-step, and the valuation lemma is stated over the containment rather than the equality.
+step; and the valuation lemma is stated over the containment rather than the equality.
 -/
 
 public section
@@ -68,15 +77,16 @@ namespace IsDedekindDomain.HeightOneSpectrum
 
 variable {R : Type*} [CommRing R] [IsDedekindDomain R]
 
-/-- If the class group is finite, then some positive power of every height one prime is
-principal, with a nonzero generator. -/
-lemma exists_pow_eq_span [Finite (ClassGroup R)] (v : HeightOneSpectrum R) :
+/-- If the class of the height one prime `v` has finite order, then some positive power of `v` is
+principal, with a nonzero generator. When `ClassGroup R` is finite, pass
+`isOfFinOrder_of_finite _` for the hypothesis. -/
+lemma exists_pow_eq_span (v : HeightOneSpectrum R) (hv : IsOfFinOrder v.classGroupMk) :
     ∃ (n : ℕ) (π : R), 0 < n ∧ π ≠ 0 ∧ v.asIdeal ^ n = Ideal.span {π} := by
-  have h1 : v.classGroupMk ^ orderOf v.classGroupMk = 1 := pow_orderOf_eq_one _
+  obtain ⟨m, hm, h1⟩ := hv.exists_pow_eq_one
   rw [classGroupMk_eq_mk0, ← map_pow, SubmonoidClass.mk_pow] at h1
   obtain ⟨π, hπ⟩ := (ClassGroup.mk0_eq_one_iff _).mp h1
   rw [Ideal.submodule_span_eq] at hπ
-  exact ⟨_, π, orderOf_pos _, fun h ↦ pow_ne_zero _ v.ne_bot (hπ.trans (by simp [h])), hπ⟩
+  exact ⟨m, π, hm, fun h ↦ pow_ne_zero _ v.ne_bot (hπ.trans (by simp [h])), hπ⟩
 
 /-- If `π` divides a power of the height one prime `v` — that is, `v.asIdeal ^ n` is contained
 in `Ideal.span {π}` — then `π` is a unit for the `w`-adic valuation at every height one prime

--- a/TauCeti/RingTheory/DedekindDomain/PrincipalPower.lean
+++ b/TauCeti/RingTheory/DedekindDomain/PrincipalPower.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.AdicValuation
+public import TauCeti.RingTheory.ClassGroup.Basic
+
+/-!
+# Principal powers of a height one prime, and the valuations of a generator
+
+Over a Dedekind domain with finite class group, no height one prime need be principal, but some
+positive power of it always is: the class `[v]` has finite order `m` in the class group, and
+`[v] ^ m = 1` says exactly that `v ^ m` is principal. This file records that fact together with
+its companion, which is what makes the generator useful: a generator of `v ^ m` is a unit at
+every height one prime other than `v`.
+
+## Main results
+
+* `IsDedekindDomain.HeightOneSpectrum.exists_pow_eq_span`: if `ClassGroup R` is finite, some
+  positive power of `v` is `Ideal.span {π}` for a nonzero `π : R`.
+* `IsDedekindDomain.HeightOneSpectrum.valuation_algebraMap_eq_one_of_pow_le_span`: if `π`
+  divides `v.asIdeal ^ n`, then `w.valuation K (algebraMap R K π) = 1` for every height one
+  prime `w ≠ v`.
+
+Together these say that a principal power of `v` supplies an element whose divisor is supported
+at `v` alone. That is the substrate for the rank half of Dirichlet's `S`-unit theorem: it is what
+exhibits, for each `v ∈ S`, an `S`-unit whose valuation vector is a nonzero multiple of the
+standard basis vector at `v`, and hence what makes the range of the `S`-unit logarithm full rank.
+
+## Implementation notes
+
+The class group hypothesis is confined to `exists_pow_eq_span`; the second result is
+unconditional, and is proved by reducing `w.valuation K (algebraMap R K π) = 1` to
+`π ∉ w.asIdeal` through Mathlib's
+`IsDedekindDomain.HeightOneSpectrum.valuation_eq_one_iff_notMem`, then using that a prime
+containing `v ^ n` contains `v`, and `v` is maximal.
+
+That second result asks only for the containment `v.asIdeal ^ n ≤ Ideal.span {π}` — `π` divides
+`v ^ n` — rather than the equality a principal power gives. The proof uses the containment in one
+direction only, and the weaker hypothesis is the honest statement of what makes `π` a `w`-adic
+unit: its ideal support is contained in `{v}`.
+
+Passing from `[v] ^ m` to the class of `v.asIdeal ^ m` is Mathlib's `SubmonoidClass.mk_pow`,
+which is exactly the coercion `(⟨I, hI⟩ : (Ideal R)⁰) ^ m = ⟨I ^ m, _⟩`; Mathlib's own
+`Ideal.IsPrincipal.of_isPrincipal_pow_of_coprime` takes the same step the same way.
+
+`exists_pow_eq_span` is stated with the exponent existentially quantified rather than as
+`orderOf v.classGroupMk`, because no consumer so far needs the exponent to be the order: what is
+used is only that it is positive. Naming the order in the statement would force every consumer to
+carry `ClassGroup` vocabulary that the conclusion does not otherwise mention.
+
+Adapted from Michael Stoll's elliptic-curves formalisation
+(`github.com/MichaelStollBayreuth/EllipticCurves`, `EllipticCurves/Mathlib/FractionalIdeal.lean`
+and `EllipticCurves/Mathlib/Basic.lean` at the roadmap's pin `66889eada51a`, Apache 2.0, by
+Michael Stoll); following this repository's convention for adapted material, the upstream
+authorship is credited here rather than in the copyright header. Two deliberate departures from
+the source: `exists_pow_eq_span` reaches the class of `v.asIdeal ^ m` through this repository's
+`classGroupMk_eq_mk0` and Mathlib's `SubmonoidClass.mk_pow` instead of an inline `Subtype.ext`
+step, and the valuation lemma is stated over the containment rather than the equality.
+-/
+
+public section
+
+namespace IsDedekindDomain.HeightOneSpectrum
+
+variable {R : Type*} [CommRing R] [IsDedekindDomain R]
+
+/-- If the class group is finite, then some positive power of every height one prime is
+principal, with a nonzero generator. -/
+lemma exists_pow_eq_span [Finite (ClassGroup R)] (v : HeightOneSpectrum R) :
+    ∃ (n : ℕ) (π : R), 0 < n ∧ π ≠ 0 ∧ v.asIdeal ^ n = Ideal.span {π} := by
+  have h1 : v.classGroupMk ^ orderOf v.classGroupMk = 1 := pow_orderOf_eq_one _
+  rw [classGroupMk_eq_mk0, ← map_pow, SubmonoidClass.mk_pow] at h1
+  obtain ⟨π, hπ⟩ := (ClassGroup.mk0_eq_one_iff _).mp h1
+  rw [Ideal.submodule_span_eq] at hπ
+  exact ⟨_, π, orderOf_pos _, fun h ↦ pow_ne_zero _ v.ne_bot (hπ.trans (by simp [h])), hπ⟩
+
+/-- If `π` divides a power of the height one prime `v` — that is, `v.asIdeal ^ n` is contained
+in `Ideal.span {π}` — then `π` is a unit for the `w`-adic valuation at every height one prime
+`w ≠ v`. Containment is the weakest hypothesis the proof needs; `exists_pow_eq_span` supplies the
+equality, so a caller holding one passes `h.le`. -/
+lemma valuation_algebraMap_eq_one_of_pow_le_span {K : Type*} [Field K] [Algebra R K]
+    [IsFractionRing R K] {v w : HeightOneSpectrum R} (hne : w ≠ v) {n : ℕ} {π : R}
+    (h : v.asIdeal ^ n ≤ Ideal.span {π}) : w.valuation K (algebraMap R K π) = 1 := by
+  refine w.valuation_eq_one_iff_notMem.mpr fun hmem ↦ hne (HeightOneSpectrum.ext ?_).symm
+  refine v.isMaximal.eq_of_le w.isPrime.ne_top (Ideal.IsPrime.le_of_pow_le (n := n) ?_)
+  exact h.trans (by rwa [Ideal.span_le, Set.singleton_subset_iff])
+
+end IsDedekindDomain.HeightOneSpectrum


### PR DESCRIPTION
Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"none"}-->

> **⛔ Parked 2026-08-25 pending a human roadmap decision: this PR claims no roadmap target and
> must not land as it stands.** The `scope` review is right and I am not contesting it. The two
> lemmas here are substrate for the *rank* half of Dirichlet's `S`-unit theorem, and no node of
> `TauCetiRoadmap/EllipticCurves/README.md` asks for that. Layer 6 (`README.md:799`) needs only
> that "the `S`-units are finitely generated", and that input is already on `main` as
> `Set.unit_fg` in `TauCeti/RingTheory/DedekindDomain/SInteger/Unit.lean` — whose own docstring
> draws the same line the reviewer draws: *"The rank refinement — that the rank is exactly
> `rank Rˣ + |S|` when the class group is finite — is a separate topic and is not here."* The
> former target id `layer-6-principal-power-substrate` named no actual roadmap node, so it is
> withdrawn here (`"id":"none"`).
>
> The reviewer offers two remedies. Adding the `S`-unit rank theorem as a roadmap target is not
> mine to do — `.claude/CLAUDE.md`: *"Never open a PR or an issue in TauCetiRoadmap yourself;
> reviewing a roadmap change needs human attention."* So I take the second one: **defer**. The
> Lean is correct and CI-green; nothing in the diff needs fixing. It waits for a human either to
> add a rank target to `EllipticCurves/README.md`, or to close this.
>
> **⚠ A human needs to apply the `keep` label.** Releasing the target id puts this PR into the
> target-less pool, where the oldest survives and the rest are swept closed — as of now that pool
> is `#4018` (2026-08-21) and this PR (2026-08-24), so **this is the one that gets closed**; a
> blocked board also draws the 7-day stale janitor. I tried and cannot: `gh pr edit --add-label`
> returns *"CBirkbeck does not have the correct permissions to execute `AddLabelsToLabelable`"*.
> The branch is preserved either way, so an auto-close is recoverable rather than fatal — but the
> label is what keeps the park visible while the roadmap question is open.

Over a Dedekind domain no height one prime need be principal — but a positive power of one is as
soon as its class `[v]` has finite order `m` in the class group: `[v] ^ m = 1` says exactly that
`v ^ m` is. This PR records that, with the companion fact that makes such a generator useful: if
`π` divides `v ^ n`, then `π` is a unit for the `w`-adic valuation at every height one prime
`w ≠ v`. Together they exhibit, for each `v`, an element whose ideal support is `{v}` alone.

New file `TauCeti/RingTheory/DedekindDomain/PrincipalPower.lean`, two results:

* `IsDedekindDomain.HeightOneSpectrum.exists_pow_eq_span` — given `IsOfFinOrder v.classGroupMk`,
  some positive power of `v` is `Ideal.span {π}` for a nonzero `π : R`. A caller carrying
  `Finite (ClassGroup R)` supplies the hypothesis as `isOfFinOrder_of_finite _`.
* `IsDedekindDomain.HeightOneSpectrum.valuation_algebraMap_eq_one_of_pow_le_span` — if
  `v.asIdeal ^ n ≤ Ideal.span {π}`, then `w.valuation K (algebraMap R K π) = 1` for `w ≠ v`.

**Why here — withdrawn.** This section previously presented the Layer 6 `S`-unit node as
motivating these lemmas. That reading does not hold and I withdraw it. `EllipticCurves/README.md`
line 799 asks that `A(S, 2)` be finite because "the `S`-class group is finite and the `S`-units are
finitely generated" (AEC VIII.1) — finite generation only, and that half is already discharged on
`main` by `Set.unit_fg`. The `S`-unit **rank** is a different statement and no roadmap node names
it. These two lemmas are substrate for precisely that rank statement: they exhibit, for each
`v ∈ S`, an `S`-unit whose valuation vector is a nonzero multiple of the standard basis vector at
`v`, which is what makes the range of the `S`-unit logarithm full rank — as my own module docstring
says. That is the `scope` reviewer's finding; I verified it against roadmap `85038d4` and TauCeti
`main` and it is correct. The PR therefore claims no target — see the banner above.

**Placement.** Neither statement mentions `S`-integers, so the file sits in
`TauCeti/RingTheory/DedekindDomain/` beside `AdicValuation.lean` and `Factorization.lean` rather
than under `SInteger/`. It imports only `Mathlib.RingTheory.DedekindDomain.AdicValuation` and this
repository's `TauCeti.RingTheory.ClassGroup.Basic` (for `classGroupMk` / `classGroupMk_eq_mk0`).

**Prior art, measured.** Absent from Mathlib and from `main`. `exists_pow_eq_span` and
`valuation_algebraMap_eq_one_of_pow_eq_span` return zero hits on a full-name grep of
`.lake/packages/mathlib` and of `TauCeti/`; the instrument is validated by controls in the same
sweeps (`HeightOneSpectrum` matches 24 Mathlib files and `classGroupMk` 14 `TauCeti/` files, and
`valuation_eq_one_iff_notMem` — used by the second proof — resolves). By statement rather than
name: Mathlib's `Ideal.IsPrincipal.of_isPrincipal_pow_of_coprime` runs the other way (`I ^ n`
principal with `n` coprime to the class number gives `I` principal), `Ideal.span_singleton_pow`
is `span {s} ^ n = span {s ^ n}`, and `FiniteField.valuation_algebraMap_eq_one` is about
function-field constants. `TauCeti/RingTheory/DedekindDomain/SInteger/ClassGroup.lean` carries the
`S`-class group as a quotient of `Cl(R)`, which is a different statement and is reused, not
duplicated.

The bead that scoped this work also listed Stoll's `toAdd_valuationOfNeZero` as a third candidate.
It is deliberately **not** ported: `main` already carries its content in divisor language as
`adicOrd` in `TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/Basic.lean`, so the consumer derives
it there rather than getting a second copy here.

**Deviations from the source**, all recorded in the module docstring:

* `exists_pow_eq_span` weakens the source's `[Finite (ClassGroup R)]` to finite order of the single
  class `[v]`. Finiteness enters the proof only through `0 < orderOf [v]`, so that is the honest
  hypothesis; no separate finite-class-group form is stated, because
  `isOfFinOrder_of_finite _` is the one term a caller with a finite class group has to write.
* `exists_pow_eq_span` reaches the class of `v.asIdeal ^ m` through this repository's
  `classGroupMk_eq_mk0` and Mathlib's `SubmonoidClass.mk_pow` instead of the source's inline
  `Subtype.ext (SubmonoidClass.coe_pow _ m)` step.
* The valuation lemma is stated over the containment `v.asIdeal ^ n ≤ Ideal.span {π}` rather than
  the source's equality, and named `_of_pow_le_span` to match. The proof uses the hypothesis in
  one direction only, and "`π` divides `v ^ n`" is the honest statement of what makes `π` a
  `w`-adic unit. A caller holding the equality from `exists_pow_eq_span` passes `h.le`.

Provenance: `github.com/MichaelStollBayreuth/EllipticCurves` @ `66889eada51a`, Apache-2.0, by
Michael Stoll — `EllipticCurves/Mathlib/FractionalIdeal.lean:205`
(`IsDedekindDomain.HeightOneSpectrum.exists_pow_eq_span`) and
`EllipticCurves/Mathlib/Basic.lean:427`
(`IsDedekindDomain.HeightOneSpectrum.valuation_algebraMap_eq_one_of_pow_eq_span`). Following this
repository's convention for adapted material, the upstream authorship is credited in the module
docstring rather than in the copyright header.

