### PR TITLE
docs(Huber): correct the AINTLIB attribution URL in DenseSubmodule

### DIFF
--- a/TauCeti/RingTheory/Huber/DenseSubmodule.lean
+++ b/TauCeti/RingTheory/Huber/DenseSubmodule.lean
@@ -39,7 +39,7 @@ definition nor a pseudouniformiser has to be chosen.
 * [Bosch, Güntzer, Remmert, *Non-Archimedean Analysis*][bosch_guntzer_remmert], §3.7.2/1.
 * [Wedhorn, *Adic Spaces*][wedhorn_adic], Propositions 6.17–6.18.
 
-Adapted from the AINTLIB development (`github.com/smwyin/aintlib`, Apache-2.0), branch
+Adapted from the AINTLIB development (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), branch
 `dev/adic-spaces` at commit `37bbdaeb9ad9`, file
 `projects/AdicSpaces/Adic spaces/WedhornBanachTheorem.lean`, where the same statement is
 `eq_top_of_dense_of_finite`. The argument is AINTLIB's; three things differ. The target is


### PR DESCRIPTION
`TauCeti/RingTheory/Huber/DenseSubmodule.lean` credits its port source as
`github.com/smwyin/aintlib`. That repository is not the port source: AINTLIB is
`github.com/CBirkbeck/AINTLIB`. This corrects the URL and changes nothing else.

Roadmap: none

Attribution correction to existing code — no new mathematics, so no roadmap target is claimed.
Improving code that already exists is in scope at any time under `.claude/CLAUDE.md`.

## The measurement

The file landed on `main` via #4414. Every other AINTLIB citation in the library uses the
canonical URL; this one is the sole outlier:

```console
$ git grep -h -oE "github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+" origin/main -- 'TauCeti/**/*.lean' \
    | grep -i aintlib | sort | uniq -c | sort -rn
 213 github.com/CBirkbeck/AINTLIB
   1 github.com/smwyin/aintlib
```

and that one hit is `DenseSubmodule.lean:42`. The rest of the citation — branch `dev/adic-spaces`,
commit `37bbdaeb9ad9`, file `projects/AdicSpaces/Adic spaces/WedhornBanachTheorem.lean`, source
declaration `eq_top_of_dense_of_finite` — is correct and is left untouched, as is the paragraph
recording the three ways this statement differs from AINTLIB's.

## Why this is its own PR

The defect was found while porting the sibling lemma for #4444, and deliberately not folded into
it: one topic per PR, and #4444's topic is the new closedness lemma. #4444 uses the correct URL in
its own new file, so nothing here overlaps that diff.

## Scope

One line, inside the module docstring. No declaration, statement, proof, import or name changes;
`git diff` is a single `-`/`+` pair.
