### PR TITLE
feat: multiply formal characters over tensor products

### DIFF
--- a/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
+++ b/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
@@ -339,10 +339,9 @@ theorem finrank_genWeightSpace_tensorProduct (χ : Dual K L) :
     · refine iSup_le fun p ↦ ?_
       have hp : (p.1.1 : L → K) + (p.1.2 : L → K) = (χ : L → K) := by
         exact congrArg (fun f : Dual K L ↦ (f : L → K)) p.property
-      change A p ≤ (genWeightSpace (M ⊗[K] N) (χ : L → K)).toSubmodule
       rw [← hp]
-      exact map₂_mk_genWeightSpace_le M N p.1.1 p.1.2
-  change finrank K (genWeightSpace (M ⊗[K] N) (χ : L → K)).toSubmodule = _
+      simpa only [A] using map₂_mk_genWeightSpace_le M N p.1.1 p.1.2
+  rw [← finrank_toSubmodule]
   rw [hspace, finrank_iSup_eq_sum_finrank_of_iSupIndep hindep]
   rw [← Finset.sum_subtype
     (s := (Finset.univ : Finset (Weight K L M × Weight K L N)).filter fun p ↦
@@ -351,6 +350,8 @@ theorem finrank_genWeightSpace_tensorProduct (χ : Dual K L) :
   refine Finset.sum_congr rfl fun p _ ↦ ?_
   by_cases hp : (p.1 : Dual K L) + (p.2 : Dual K L) = χ
   · simp only [hp, ite_true]
+    -- Unfolding `A` in the carrier does not update the dependent module instances inferred by
+    -- `finrank`; restating the goal makes those instances use the displayed `map₂` submodule.
     change finrank K (Submodule.map₂ (TensorProduct.mk K M N)
       (genWeightSpace M p.1).toSubmodule (genWeightSpace N p.2).toSubmodule) = _
     rw [← TensorProduct.range_mapIncl,
@@ -375,21 +376,7 @@ theorem formalCharacter_tensor :
   push_cast
   rw [Fintype.sum_prod_type]
   simp_rw [Finset.sum_apply]
-  change (∑ μ : Weight K L M, ∑ ν : Weight K L N,
-      if (μ : Dual K L) + (ν : Dual K L) = χ then
-        (finrank K (genWeightSpace M (μ : L → K)) : ℤ) *
-          (finrank K (genWeightSpace N (ν : L → K)) : ℤ) else 0) =
-    ∑ μ : Weight K L M, ∑ ν : Weight K L N,
-      (Finsupp.single ((μ : Dual K L) + (ν : Dual K L))
-        ((finrank K (genWeightSpace M (μ : L → K)) : ℤ) *
-          (finrank K (genWeightSpace N (ν : L → K)) : ℤ))) χ
-  refine @Finset.sum_congr (Weight K L M) ℤ Finset.univ Finset.univ inferInstance _ _ rfl
-    fun μ _ ↦ ?_
-  refine @Finset.sum_congr (Weight K L N) ℤ Finset.univ Finset.univ inferInstance _ _ rfl
-    fun ν _ ↦ ?_
-  by_cases hμν : (μ : Dual K L) + (ν : Dual K L) = χ
-  · rw [ite_eq_left hμν, hμν, Finsupp.single_eq_same]
-  · rw [ite_eq_right hμν, Finsupp.single_eq_of_ne (Ne.symm hμν)]
+  simp only [Finsupp.single_apply, eq_comm]
 
 end TensorProduct
 

--- a/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
+++ b/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
@@ -8,8 +8,10 @@ module
 public import Mathlib.Algebra.MonoidAlgebra.Defs
 public import TauCeti.Algebra.Lie.Weights.Integrality
 public import TauCeti.Algebra.Lie.Weights.Prod
+public import TauCeti.Algebra.Lie.Weights.TensorProduct
 public import TauCeti.Algebra.Lie.Weights.WeylInvariance
 public import TauCeti.LinearAlgebra.Dimension.DirectSum
+public import TauCeti.LinearAlgebra.TensorProduct.Decomposition
 
 public section
 
@@ -56,6 +58,10 @@ multiplicativity on tensor products expressible.
   `TauCeti.genWeightSpace_prod_eq_bot_iff` and
   `TauCeti.instLinearWeightsProd` the consequences a product of modules needs to have a character
   at all.
+* `TauCeti.finrank_genWeightSpace_tensorProduct`: the multiplicity of a tensor-product weight is
+  the convolution of the multiplicities in the two factors.
+* `TauCeti.formalCharacter_tensor`: **multiplicativity.** The character of a tensor product is the
+  product of the characters.
 * `TauCeti.formalCharacter_coeff_eq_finrank_weightSpace`: over an algebraically closed field of
   characteristic zero, for a Cartan subalgebra of a Killing-semisimple Lie algebra, the coefficients
   are the *honest* weight multiplicities.
@@ -275,6 +281,117 @@ theorem formalCharacter_prod :
   simp
 
 end Prod
+
+/-! ### Multiplicativity -/
+
+section TensorProduct
+
+open TensorProduct
+
+variable {K : Type u} {L : Type v} {M : Type w} {N : Type w₁} [Field K] [LieRing L]
+  [LieAlgebra K L] [LieRing.IsNilpotent L]
+  [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M] [LinearWeights K L M]
+  [FiniteDimensional K M] [IsTriangularizable K L M]
+  [AddCommGroup N] [Module K N] [LieRingModule L N] [LieModule K L N] [LinearWeights K L N]
+  [FiniteDimensional K N] [IsTriangularizable K L N]
+
+open scoped Classical in
+/-- **Weight multiplicities in a tensor product are the convolution of the multiplicities in its
+factors.** The dimension of the `χ`-weight space is the sum of
+`dim Mμ * dim Nν` over the pairs of weights satisfying `μ + ν = χ`.
+
+The products of the weight spaces form an independent family because the weight-space
+decompositions of both factors are internal; their tensor products therefore decompose the
+ambient tensor product internally. -/
+theorem finrank_genWeightSpace_tensorProduct (χ : Dual K L) :
+    finrank K (genWeightSpace (M ⊗[K] N) (χ : L → K)) =
+      ∑ p : Weight K L M × Weight K L N,
+        if (p.1 : Dual K L) + (p.2 : Dual K L) = χ then
+          finrank K (genWeightSpace M (p.1 : L → K)) *
+            finrank K (genWeightSpace N (p.2 : L → K)) else 0 := by
+  classical
+  let A : Weight K L M × Weight K L N → Submodule K (M ⊗[K] N) := fun p ↦
+    Submodule.map₂ (TensorProduct.mk K M N) (genWeightSpace M p.1).toSubmodule
+      (genWeightSpace N p.2).toSubmodule
+  have hint : DirectSum.IsInternal A :=
+    DirectSum.IsInternal.tensorProduct
+      (fun μ : Weight K L M ↦ (genWeightSpace M μ).toSubmodule)
+      (fun ν : Weight K L N ↦ (genWeightSpace N ν).toSubmodule)
+      (isInternal_genWeightSpace K L M) (isInternal_genWeightSpace K L N)
+  let S := {p : Weight K L M × Weight K L N //
+    (p.1 : Dual K L) + (p.2 : Dual K L) = χ}
+  have hindep : iSupIndep fun p : S ↦ A p :=
+    hint.submodule_iSupIndep.comp Subtype.val_injective
+  have hspace : (genWeightSpace (M ⊗[K] N) (χ : L → K)).toSubmodule = ⨆ p : S, A p := by
+    apply le_antisymm
+    · rw [genWeightSpace_tensorProduct_eq_iSup]
+      refine iSup₂_le fun μ ν ↦ iSup_le fun hμν ↦ ?_
+      by_cases hμ : genWeightSpace M μ = ⊥
+      · simp [hμ, A]
+      by_cases hν : genWeightSpace N ν = ⊥
+      · simp [hν, A]
+      let m : Weight K L M := ⟨μ, hμ⟩
+      let n : Weight K L N := ⟨ν, hν⟩
+      have hadd : (m : Dual K L) + (n : Dual K L) = χ := by
+        ext x
+        simpa [m, n] using congrFun hμν x
+      exact le_iSup (fun p : S ↦ A p) ⟨(m, n), hadd⟩
+    · refine iSup_le fun p ↦ ?_
+      have hp : (p.1.1 : L → K) + (p.1.2 : L → K) = (χ : L → K) := by
+        exact congrArg (fun f : Dual K L ↦ (f : L → K)) p.property
+      change A p ≤ (genWeightSpace (M ⊗[K] N) (χ : L → K)).toSubmodule
+      rw [← hp]
+      exact map₂_mk_genWeightSpace_le M N p.1.1 p.1.2
+  change finrank K (genWeightSpace (M ⊗[K] N) (χ : L → K)).toSubmodule = _
+  rw [hspace, finrank_iSup_eq_sum_finrank_of_iSupIndep hindep]
+  rw [← Finset.sum_subtype
+    (s := (Finset.univ : Finset (Weight K L M × Weight K L N)).filter fun p ↦
+      (p.1 : Dual K L) + (p.2 : Dual K L) = χ)
+    (fun p ↦ by simp) (fun p ↦ finrank K (A p)), Finset.sum_filter]
+  refine Finset.sum_congr rfl fun p _ ↦ ?_
+  by_cases hp : (p.1 : Dual K L) + (p.2 : Dual K L) = χ
+  · simp only [hp, ite_true]
+    change finrank K (Submodule.map₂ (TensorProduct.mk K M N)
+      (genWeightSpace M p.1).toSubmodule (genWeightSpace N p.2).toSubmodule) = _
+    rw [← TensorProduct.range_mapIncl,
+      LinearMap.finrank_range_of_inj
+        (Module.Flat.tensorProduct_mapIncl_injective_of_right
+          (genWeightSpace M p.1).toSubmodule (genWeightSpace N p.2).toSubmodule),
+      Module.finrank_tensorProduct]
+    rfl
+  · simp only [hp, ite_false]
+
+/-- **Multiplicativity of formal characters.** The formal character of a tensor product is the
+product of the formal characters of its two factors. -/
+@[simp]
+theorem formalCharacter_tensor :
+    formalCharacter K L (M ⊗[K] N) = formalCharacter K L M * formalCharacter K L N := by
+  classical
+  refine AddMonoidAlgebra.ext (Finsupp.ext fun χ ↦ ?_)
+  rw [formalCharacter_coeff, finrank_genWeightSpace_tensorProduct]
+  rw [formalCharacter_eq_sum_single, formalCharacter_eq_sum_single, Finset.sum_mul_sum]
+  simp only [AddMonoidAlgebra.single_mul_single, AddMonoidAlgebra.coeff_sum,
+    AddMonoidAlgebra.coeff_single]
+  push_cast
+  rw [Fintype.sum_prod_type]
+  simp_rw [Finset.sum_apply]
+  change (∑ μ : Weight K L M, ∑ ν : Weight K L N,
+      if (μ : Dual K L) + (ν : Dual K L) = χ then
+        (finrank K (genWeightSpace M (μ : L → K)) : ℤ) *
+          (finrank K (genWeightSpace N (ν : L → K)) : ℤ) else 0) =
+    ∑ μ : Weight K L M, ∑ ν : Weight K L N,
+      (Finsupp.single ((μ : Dual K L) + (ν : Dual K L))
+        ((finrank K (genWeightSpace M (μ : L → K)) : ℤ) *
+          (finrank K (genWeightSpace N (ν : L → K)) : ℤ))) χ
+  refine @Finset.sum_congr (Weight K L M) ℤ Finset.univ Finset.univ inferInstance _ _ rfl
+    fun μ _ ↦ ?_
+  refine @Finset.sum_congr (Weight K L N) ℤ Finset.univ Finset.univ inferInstance _ _ rfl
+    fun ν _ ↦ ?_
+  by_cases hμν : (μ : Dual K L) + (ν : Dual K L) = χ
+  · rw [ite_eq_left hμν, hμν, Finsupp.single_eq_same]
+  · rw [ite_eq_right hμν, Finsupp.single_eq_of_ne (Ne.symm hμν)]
+
+end TensorProduct
 
 /-! ### The Cartan subalgebra of a Killing-semisimple Lie algebra over an algebraically closed field
 of characteristic zero -/

--- a/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
+++ b/TauCeti/Algebra/Lie/Weights/FormalCharacter.lean
@@ -297,12 +297,12 @@ variable {K : Type u} {L : Type v} {M : Type w} {N : Type w₁} [Field K] [LieRi
 
 open scoped Classical in
 /-- **Weight multiplicities in a tensor product are the convolution of the multiplicities in its
-factors.** The dimension of the `χ`-weight space is the sum of
+factors.** The dimension of the generalized `χ`-weight space is the sum of
 `dim Mμ * dim Nν` over the pairs of weights satisfying `μ + ν = χ`.
 
-The products of the weight spaces form an independent family because the weight-space
-decompositions of both factors are internal; their tensor products therefore decompose the
-ambient tensor product internally. -/
+The tensor products of the generalized weight spaces form an independent family because the
+generalized weight-space decompositions of both factors are internal; their tensor products
+therefore decompose the ambient tensor product internally. -/
 theorem finrank_genWeightSpace_tensorProduct (χ : Dual K L) :
     finrank K (genWeightSpace (M ⊗[K] N) (χ : L → K)) =
       ∑ p : Weight K L M × Weight K L N,

--- a/TauCeti/Algebra/Lie/Weights/TensorProduct.lean
+++ b/TauCeti/Algebra/Lie/Weights/TensorProduct.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Algebra.Lie.TensorProduct
 public import Mathlib.Algebra.Lie.Weights.Basic
+public import Mathlib.Algebra.Lie.Weights.Linear
 public import Mathlib.LinearAlgebra.Dual.Lemmas
 
 /-!
@@ -41,6 +42,8 @@ weight spaces of `M ⊗ N` and must agree with it termwise
   `μ + ν = χ`, of the submodules spanned by `Mμ ⊗ Nν`.
 * `TauCeti.genWeightSpace_tensorProduct_ne_bot` and `TauCeti.exists_weight_add_eq`: **the weights of
   `M ⊗ N` are exactly the sums of a weight of `M` and a weight of `N`.**
+* `TauCeti.instLinearWeightsTensorProduct`: tensor products inherit linear weights from their
+  finite-dimensional triangularizable factors.
 
 ## Implementation notes
 
@@ -254,6 +257,30 @@ theorem exists_weight_add_eq (χ : Weight K L (M ⊗[K] N)) :
       simp
     exact absurd hμν (hc ⟨μ, hμ⟩ ⟨ν, hν⟩)
   exact absurd hbot χ.genWeightSpace_ne_bot
+
+/-- A tensor product of finite-dimensional triangularizable modules with linear weights again has
+linear weights. Every weight of the tensor product is a sum of weights of the two factors. -/
+instance instLinearWeightsTensorProduct [LinearWeights K L M] [LinearWeights K L N] :
+    LinearWeights K L (M ⊗[K] N) where
+  map_add χ hχ x y := by
+    obtain ⟨μ, ν, hμν⟩ := exists_weight_add_eq (⟨χ, hχ⟩ : Weight K L (M ⊗[K] N))
+    have hχ_eq : χ = (μ : L → K) + (ν : L → K) := by
+      simpa using hμν.symm
+    rw [hχ_eq]
+    simp only [Pi.add_apply, map_add]
+    ac_rfl
+  map_smul χ hχ t x := by
+    obtain ⟨μ, ν, hμν⟩ := exists_weight_add_eq (⟨χ, hχ⟩ : Weight K L (M ⊗[K] N))
+    have hχ_eq : χ = (μ : L → K) + (ν : L → K) := by
+      simpa using hμν.symm
+    rw [hχ_eq]
+    simp only [Pi.add_apply, map_smul, smul_eq_mul, mul_add]
+  map_lie χ hχ x y := by
+    obtain ⟨μ, ν, hμν⟩ := exists_weight_add_eq (⟨χ, hχ⟩ : Weight K L (M ⊗[K] N))
+    have hχ_eq : χ = (μ : L → K) + (ν : L → K) := by
+      simpa using hμν.symm
+    rw [hχ_eq]
+    simp only [Pi.add_apply, Weight.apply_lie, add_zero]
 
 end Field
 

--- a/TauCeti/LinearAlgebra/Dimension/DirectSum.lean
+++ b/TauCeti/LinearAlgebra/Dimension/DirectSum.lean
@@ -55,8 +55,9 @@ theorem finrank_iSup_eq_sum_finrank_of_iSupIndep {K M ι : Type*} [DivisionRing 
   have hV : ∀ i, V i ≤ S := fun i ↦ le_iSup V i
   let e : Submodule K S ≃o Set.Iic S := S.mapIic
   have he : (e ∘ fun i ↦ (V i).comap S.subtype) = fun i ↦ ⟨V i, hV i⟩ := by
-    ext i m
-    change m ∈ ((V i).comap S.subtype).map S.subtype ↔ _
+    funext i
+    apply Subtype.ext
+    simp only [Function.comp_apply, e, Submodule.coe_mapIic_apply]
     rw [Submodule.map_comap_subtype, inf_of_le_right (hV i)]
   have hindep : iSupIndep fun i ↦ (V i).comap S.subtype := by
     rw [← iSupIndep_map_orderIso_iff e, he]

--- a/TauCeti/LinearAlgebra/Dimension/DirectSum.lean
+++ b/TauCeti/LinearAlgebra/Dimension/DirectSum.lean
@@ -43,6 +43,36 @@ theorem finrank_eq_sum_finrank_of_isInternal {K M ι : Type*} [DivisionRing K] [
   rw [← (LinearEquiv.ofBijective (DirectSum.coeLinearMap V) h).finrank_eq,
     Module.finrank_directSum]
 
+/-- **The dimension of an independent finite sum of subspaces is the sum of their dimensions.**
+Unlike `TauCeti.finrank_eq_sum_finrank_of_isInternal`, the ambient module here is the supremum of
+the given family rather than an independently supplied module. -/
+theorem finrank_iSup_eq_sum_finrank_of_iSupIndep {K M ι : Type*} [DivisionRing K]
+    [AddCommGroup M] [Module K M] [Fintype ι] {V : ι → Submodule K M}
+    [∀ i, Module.Finite K (V i)] (h : iSupIndep V) :
+    Module.finrank K ((⨆ i, V i) : Submodule K M) = ∑ i, Module.finrank K (V i) := by
+  classical
+  let S : Submodule K M := ⨆ i, V i
+  have hV : ∀ i, V i ≤ S := fun i ↦ le_iSup V i
+  let e : Submodule K S ≃o Set.Iic S := S.mapIic
+  have he : (e ∘ fun i ↦ (V i).comap S.subtype) = fun i ↦ ⟨V i, hV i⟩ := by
+    ext i m
+    change m ∈ ((V i).comap S.subtype).map S.subtype ↔ _
+    rw [Submodule.map_comap_subtype, inf_of_le_right (hV i)]
+  have hindep : iSupIndep fun i ↦ (V i).comap S.subtype := by
+    rw [← iSupIndep_map_orderIso_iff e, he]
+    exact iSupIndep.of_coe_Iic_comp h
+  have hint : DirectSum.IsInternal fun i ↦ (V i).comap S.subtype := by
+    refine DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top hindep ?_
+    apply e.injective
+    calc
+      e (⨆ i, (V i).comap S.subtype) = ⨆ i, e ((V i).comap S.subtype) := e.map_iSup _
+      _ = ⨆ i, ⟨V i, hV i⟩ := congrArg iSup he
+      _ = ⟨S, Set.mem_Iic.mpr le_rfl⟩ := Subtype.ext (by simp [S])
+      _ = e ⊤ := e.map_top.symm
+  rw [finrank_eq_sum_finrank_of_isInternal hint]
+  exact Finset.sum_congr rfl fun i _ ↦
+    (Submodule.comapSubtypeEquivOfLe (hV i)).finrank_eq
+
 /-- **The dimensions of the summands of an internal direct sum add up**, for a decomposition
 indexed by an arbitrary type in which only finitely many summands are nonzero. -/
 theorem finsum_finrank_eq_finrank_of_isInternal {K M ι : Type*} [DivisionRing K] [AddCommGroup M]

--- a/TauCeti/LinearAlgebra/TensorProduct/Decomposition.lean
+++ b/TauCeti/LinearAlgebra/TensorProduct/Decomposition.lean
@@ -33,7 +33,7 @@ universe u v w x y
 variable {K : Type u} [Field K]
 variable {M : Type v} {N : Type w} [AddCommGroup M] [Module K M]
   [AddCommGroup N] [Module K N]
-variable {ι : Type x} {κ : Type y} [DecidableEq ι] [DecidableEq κ]
+variable {ι : Type x} {κ : Type y}
 variable (A : ι → Submodule K M) (B : κ → Submodule K N)
 
 attribute [local instance 1100] Module.Free.of_divisionRing Module.Flat.of_free
@@ -57,12 +57,12 @@ private noncomputable def summandEquiv (i : ι) (j : κ) :
       apply Subtype.ext
       exact hx⟩
 
-omit [DecidableEq ι] [DecidableEq κ] in
 @[simp] private theorem coe_summandEquiv (i : ι) (j : κ) (x : A i ⊗[K] B j) :
     ((summandEquiv A B i j x :
       Submodule.map₂ (TensorProduct.mk K M N) (A i) (B j)) : M ⊗[K] N) =
       TensorProduct.mapIncl (A i) (B j) x := rfl
 
+open scoped Classical in
 /-- **Tensor products of internal decompositions are internal.** If `A` and `B` internally
 decompose `M` and `N`, the images of `A i ⊗ B j` under the canonical map internally decompose
 `M ⊗ N`.
@@ -72,7 +72,6 @@ ambient tensor product spanned by pure tensors from the two factors. -/
 theorem tensorProduct (hA : DirectSum.IsInternal A) (hB : DirectSum.IsInternal B) :
     DirectSum.IsInternal fun p : ι × κ ↦
       Submodule.map₂ (TensorProduct.mk K M N) (A p.1) (B p.2) := by
-  classical
   let _ := hA.chooseDecomposition
   let _ := hB.chooseDecomposition
   let E : M ⊗[K] N ≃ₗ[K]

--- a/TauCeti/LinearAlgebra/TensorProduct/Decomposition.lean
+++ b/TauCeti/LinearAlgebra/TensorProduct/Decomposition.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.TensorProduct.Decomposition
-public import Mathlib.RingTheory.Flat.Domain
 
 /-!
 # Tensor products of internal decompositions
@@ -30,17 +29,17 @@ namespace DirectSum.IsInternal
 
 universe u v w x y
 
-variable {K : Type u} [Field K]
-variable {M : Type v} {N : Type w} [AddCommGroup M] [Module K M]
-  [AddCommGroup N] [Module K N]
+variable {K : Type u} [CommSemiring K]
+variable {M : Type v} {N : Type w} [AddCommMonoid M] [Module K M]
+  [AddCommMonoid N] [Module K N]
 variable {ι : Type x} {κ : Type y}
 variable (A : ι → Submodule K M) (B : κ → Submodule K N)
 
-attribute [local instance 1100] Module.Free.of_divisionRing Module.Flat.of_free
-
 /-- The tensor product of two submodules is linearly equivalent to its image in the tensor product
-of the ambient modules. Over a field the canonical map is injective. -/
-private noncomputable def summandEquiv (i : ι) (j : κ) :
+of the ambient modules. The internal decompositions split both summand inclusions, so their tensor
+product is injective. -/
+private noncomputable def summandEquiv [DecidableEq ι] [DecidableEq κ]
+    [DirectSum.Decomposition A] [DirectSum.Decomposition B] (i : ι) (j : κ) :
     A i ⊗[K] B j ≃ₗ[K] Submodule.map₂ (TensorProduct.mk K M N) (A i) (B j) :=
   LinearEquiv.ofBijective
     (LinearMap.codRestrict
@@ -48,8 +47,16 @@ private noncomputable def summandEquiv (i : ι) (j : κ) :
       (TensorProduct.mapIncl (A i) (B j)) fun z ↦ by
         rw [← TensorProduct.range_mapIncl]
         exact ⟨z, rfl⟩)
-    ⟨fun x y h ↦ Module.Flat.tensorProduct_mapIncl_injective_of_right (A i) (B j)
-        (congrArg Subtype.val h), fun z ↦ by
+    ⟨fun x y h ↦ LinearMap.injective_of_comp_eq_id (TensorProduct.mapIncl (A i) (B j))
+        (TensorProduct.map
+          (DirectSum.component K ι (fun i ↦ A i) i ∘ₗ DirectSum.decomposeLinearEquiv A)
+          (DirectSum.component K κ (fun j ↦ B j) j ∘ₗ DirectSum.decomposeLinearEquiv B)) (by
+            rw [← TensorProduct.map_comp, LinearMap.comp_assoc,
+              DirectSum.decomposeLinearEquiv_comp_subtype,
+              DirectSum.component_comp_lof_same, LinearMap.comp_assoc,
+              DirectSum.decomposeLinearEquiv_comp_subtype,
+              DirectSum.component_comp_lof_same, TensorProduct.map_id]) (congrArg Subtype.val h),
+      fun z ↦ by
       have hz : (z : M ⊗[K] N) ∈ LinearMap.range (TensorProduct.mapIncl (A i) (B j)) := by
         simpa only [TensorProduct.range_mapIncl] using z.property
       obtain ⟨x, hx⟩ := hz
@@ -57,7 +64,9 @@ private noncomputable def summandEquiv (i : ι) (j : κ) :
       apply Subtype.ext
       exact hx⟩
 
-@[simp] private theorem coe_summandEquiv (i : ι) (j : κ) (x : A i ⊗[K] B j) :
+@[simp] private theorem coe_summandEquiv [DecidableEq ι] [DecidableEq κ]
+    [DirectSum.Decomposition A] [DirectSum.Decomposition B]
+    (i : ι) (j : κ) (x : A i ⊗[K] B j) :
     ((summandEquiv A B i j x :
       Submodule.map₂ (TensorProduct.mk K M N) (A i) (B j)) : M ⊗[K] N) =
       TensorProduct.mapIncl (A i) (B j) x := rfl

--- a/TauCeti/LinearAlgebra/TensorProduct/Decomposition.lean
+++ b/TauCeti/LinearAlgebra/TensorProduct/Decomposition.lean
@@ -89,7 +89,12 @@ theorem tensorProduct (hA : DirectSum.IsInternal A) (hB : DirectSum.IsInternal B
     rw [coe_summandEquiv]
     induction x using TensorProduct.induction_on with
     | zero => simp
-    | tmul a b => simp [E, summandEquiv, DirectSum.coe_congrLinearEquiv]
+    | tmul a b =>
+      simp only [TensorProduct.map_tmul, Submodule.coe_subtype, E, LinearEquiv.trans_apply,
+        TensorProduct.congr_tmul, DirectSum.decomposeLinearEquiv_apply_coe,
+        TensorProduct.directSum_lof_tmul_lof]
+      rw [DirectSum.coe_congrLinearEquiv, DirectSum.lmap_lof]
+      rfl
     | add a b ha hb => simp [ha, hb]
   have hcoe :
       DirectSum.coeLinearMap
@@ -104,6 +109,8 @@ theorem tensorProduct (hA : DirectSum.IsInternal A) (hB : DirectSum.IsInternal B
     rw [DirectSum.coeLinearMap_lof]
     apply E.injective
     simpa using hE i j x
+  -- `DirectSum.IsInternal` is defined using `coeAddMonoidHom`; its underlying function is
+  -- definitionally the same as this linear map, whose inverse is the linear equivalence `E.symm`.
   change Function.Bijective
     (DirectSum.coeLinearMap
       (fun p : ι × κ ↦ Submodule.map₂ (TensorProduct.mk K M N) (A p.1) (B p.2)))

--- a/TauCeti/LinearAlgebra/TensorProduct/Decomposition.lean
+++ b/TauCeti/LinearAlgebra/TensorProduct/Decomposition.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.TensorProduct.Decomposition
+public import Mathlib.RingTheory.Flat.Domain
+
+/-!
+# Tensor products of internal decompositions
+
+If `M` and `N` are internal direct sums of families of submodules `A i` and `B j`, then
+`M ⊗ N` is the internal direct sum of the images `A i ⊗ B j`. Mathlib supplies the external
+tensor-product/direct-sum equivalence and the decomposition obtained from one decomposed factor;
+this file records the symmetric two-factor consequence for internal decompositions.
+
+## Main result
+
+* `DirectSum.IsInternal.tensorProduct`: the images of the tensor products of the summands form an
+  internal decomposition of the ambient tensor product.
+-/
+
+public section
+
+open TensorProduct
+
+namespace DirectSum.IsInternal
+
+universe u v w x y
+
+variable {K : Type u} [Field K]
+variable {M : Type v} {N : Type w} [AddCommGroup M] [Module K M]
+  [AddCommGroup N] [Module K N]
+variable {ι : Type x} {κ : Type y} [DecidableEq ι] [DecidableEq κ]
+variable (A : ι → Submodule K M) (B : κ → Submodule K N)
+
+attribute [local instance 1100] Module.Free.of_divisionRing Module.Flat.of_free
+
+/-- The tensor product of two submodules is linearly equivalent to its image in the tensor product
+of the ambient modules. Over a field the canonical map is injective. -/
+private noncomputable def summandEquiv (i : ι) (j : κ) :
+    A i ⊗[K] B j ≃ₗ[K] Submodule.map₂ (TensorProduct.mk K M N) (A i) (B j) :=
+  LinearEquiv.ofBijective
+    (LinearMap.codRestrict
+      (Submodule.map₂ (TensorProduct.mk K M N) (A i) (B j))
+      (TensorProduct.mapIncl (A i) (B j)) fun z ↦ by
+        rw [← TensorProduct.range_mapIncl]
+        exact ⟨z, rfl⟩)
+    ⟨fun x y h ↦ Module.Flat.tensorProduct_mapIncl_injective_of_right (A i) (B j)
+        (congrArg Subtype.val h), fun z ↦ by
+      have hz : (z : M ⊗[K] N) ∈ LinearMap.range (TensorProduct.mapIncl (A i) (B j)) := by
+        simpa only [TensorProduct.range_mapIncl] using z.property
+      obtain ⟨x, hx⟩ := hz
+      refine ⟨x, ?_⟩
+      apply Subtype.ext
+      exact hx⟩
+
+omit [DecidableEq ι] [DecidableEq κ] in
+@[simp] private theorem coe_summandEquiv (i : ι) (j : κ) (x : A i ⊗[K] B j) :
+    ((summandEquiv A B i j x :
+      Submodule.map₂ (TensorProduct.mk K M N) (A i) (B j)) : M ⊗[K] N) =
+      TensorProduct.mapIncl (A i) (B j) x := rfl
+
+/-- **Tensor products of internal decompositions are internal.** If `A` and `B` internally
+decompose `M` and `N`, the images of `A i ⊗ B j` under the canonical map internally decompose
+`M ⊗ N`.
+
+The summand is written with `Submodule.map₂` because this is the canonical submodule of the
+ambient tensor product spanned by pure tensors from the two factors. -/
+theorem tensorProduct (hA : DirectSum.IsInternal A) (hB : DirectSum.IsInternal B) :
+    DirectSum.IsInternal fun p : ι × κ ↦
+      Submodule.map₂ (TensorProduct.mk K M N) (A p.1) (B p.2) := by
+  classical
+  let _ := hA.chooseDecomposition
+  let _ := hB.chooseDecomposition
+  let E : M ⊗[K] N ≃ₗ[K]
+      ⨁ p : ι × κ, Submodule.map₂ (TensorProduct.mk K M N) (A p.1) (B p.2) :=
+    TensorProduct.congr (DirectSum.decomposeLinearEquiv A) (DirectSum.decomposeLinearEquiv B) ≪≫ₗ
+      TensorProduct.directSum K K (fun i ↦ A i) (fun j ↦ B j) ≪≫ₗ
+      DirectSum.congrLinearEquiv (fun p ↦ summandEquiv A B p.1 p.2)
+  have hE (i : ι) (j : κ) (x : A i ⊗[K] B j) :
+      E (((summandEquiv A B i j x :
+        Submodule.map₂ (TensorProduct.mk K M N) (A i) (B j)) : M ⊗[K] N)) =
+        DirectSum.lof K (ι × κ)
+          (fun p ↦ Submodule.map₂ (TensorProduct.mk K M N) (A p.1) (B p.2)) (i, j)
+          (summandEquiv A B i j x) := by
+    rw [coe_summandEquiv]
+    induction x using TensorProduct.induction_on with
+    | zero => simp
+    | tmul a b => simp [E, summandEquiv, DirectSum.coe_congrLinearEquiv]
+    | add a b ha hb => simp [ha, hb]
+  have hcoe :
+      DirectSum.coeLinearMap
+          (fun p : ι × κ ↦ Submodule.map₂ (TensorProduct.mk K M N) (A p.1) (B p.2)) =
+        E.symm.toLinearMap := by
+    apply DirectSum.linearMap_ext
+    rintro ⟨i, j⟩
+    apply LinearMap.ext
+    intro z
+    obtain ⟨x, rfl⟩ := (summandEquiv A B i j).surjective z
+    simp only [LinearMap.comp_apply]
+    rw [DirectSum.coeLinearMap_lof]
+    apply E.injective
+    simpa using hE i j x
+  change Function.Bijective
+    (DirectSum.coeLinearMap
+      (fun p : ι × κ ↦ Submodule.map₂ (TensorProduct.mk K M N) (A p.1) (B p.2)))
+  rw [hcoe]
+  exact E.symm.bijective
+
+end DirectSum.IsInternal


### PR DESCRIPTION
This PR proves that formal characters multiply over tensor products by first deriving the exact convolution formula for generalized weight-space dimensions. It also equips the tensor product with its required `LinearWeights` instance and packages the two reusable linear-algebra facts that make the dimension count transparent.

The exact roadmap target is RepresentationTheory/LieHighestWeight Layer 6, “Formal characters”: `formalCharacter` is multiplicative on tensor products, serving the “representation ring and the character algebra” milestone. The proof consumes the already-landed `genWeightSpace_tensorProduct_eq_iSup` decomposition and the internal generalized-weight-space decompositions of both factors; Mathlib's `TensorProduct.directSum`, `DirectSum.decomposeLinearEquiv`, and tensor-product finrank infrastructure supply the underlying canonical equivalences.

After this PR, that milestone still needs additivity on short exact sequences and the Grothendieck-ring/integral-weight-lattice packaging before `formalCharacter` is exposed as the requested ring homomorphism; the Weyl character, dimension, and Kostant formulas remain later Layer 6 work.

The new `LinearAlgebra.TensorProduct.Decomposition` module proves that tensor products of two internal decompositions are internal. `LinearAlgebra.Dimension.DirectSum` gains the corresponding finite independent-sum dimension lemma, and `Algebra.Lie.Weights.FormalCharacter` applies both to prove the multiplicity convolution and `formalCharacter_tensor`.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"formalcharacter-tensor"}-->

🤖 Prepared with Codex
