### PR TITLE
refactor(RootSystem): reuse the global dot-product perfect-pairing instance

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
@@ -296,14 +296,6 @@ private lemma typeBEnum_symm_typeBSimpleIndex (i : Fin n) :
 
 /-! ## The root datum -/
 
-/-- The standard dot-product pairing on the character and cocharacter coordinate lattices is
-perfect; this local instance supplies the perfect pairing required to construct the root datum. -/
-private instance : (dotProductBilin ℤ ℤ :
-    (Fin n → ℤ) →ₗ[ℤ] (Fin n → ℤ) →ₗ[ℤ] ℤ).IsPerfPair := by
-  -- `dotProductEquiv` has `dotProductBilin` as its underlying linear map by definition.
-  change (dotProductEquiv ℤ (Fin n)).toLinearMap.IsPerfPair
-  infer_instance
-
 /-- The reflection in the root at index `k`, transported to the enumerated index type. -/
 private def typeBReflPerm (n : ℕ) (k : Fin (2 * n ^ 2)) : Equiv.Perm (Fin (2 * n ^ 2)) :=
   ((typeBEnum n).symm.trans

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
@@ -328,12 +328,6 @@ def typeCIndexEquiv (n : ℕ) : TypeCIndex n ≃ Fin (2 * n ^ 2) :=
       (((finTwoEquiv.symm.prodCongr (Equiv.refl (Fin n))).trans finProdFinEquiv).prodCongr
         (Equiv.refl (Fin n)))).trans (finProdFinEquiv.trans (finCongr (by ring)))
 
-private instance : (dotProductBilin ℤ ℤ :
-    (Fin n → ℤ) →ₗ[ℤ] (Fin n → ℤ) →ₗ[ℤ] ℤ).IsPerfPair := by
-  -- These maps have definitionally identical linear-map fields; Mathlib provides no named bridge.
-  change (dotProductEquiv ℤ (Fin n)).toLinearMap.IsPerfPair
-  infer_instance
-
 /-- The pinned simply connected root datum of type `Cₙ`.
 
 Both lattices are `Fin n → ℤ`: the character lattice in the fundamental-weight basis and the


### PR DESCRIPTION
The pinned type `Bₙ` and `Cₙ` root data each carried a `private instance` proving that
`dotProductBilin ℤ ℤ` on `Fin n → ℤ` is a perfect pairing. Both are exactly the global
`TauCeti.dotProductBilin_isPerfPair` from `TauCeti/LinearAlgebra/Matrix/Dual.lean` at
`R := ℤ`, `ι := Fin n`, and both files already import it publicly through
`SimplyConnectedRootDatum/Basic.lean`. This deletes the two copies.

## Why the global instance suffices

The other simply connected data already show it. `A` and `D` state the same pairing —
`toLinearMap := dotProductBilin ℤ ℤ` (`A.lean:367`, `D/Basic.lean:272`) — and declare no
local `IsPerfPair` instance at all: they resolve against the global one. `B` and `C` were
the only two files in the directory that restated it; a grep for `IsPerfPair` across
`SimplyConnectedRootDatum/` now returns nothing.

`C/Datum.lean`'s copy justified itself with the comment *"Mathlib provides no named
bridge"*. That is true of Mathlib and beside the point: TauCeti's own bridge is precisely
this instance, and it is already in scope. The comment went with the block.

## Scope

Deletions only — 14 lines across two files, no declaration added, renamed, moved or
restated. The dedup finding that prompted this also proposes unifying all nine data on one
`toLinearMap` normal form (`A`–`D` write `dotProductBilin ℤ ℤ`, `E6`/`G2` write
`(dotProductEquiv ℤ (Fin n)).toLinearMap`). That edits the pinned data themselves rather
than removing a duplicate, so it is deliberately **not** in this PR — one topic per PR.

## Verification

`lake build` of both changed modules and their direct importers
(`SimplyConnectedRootDatum.Assembly`, `SimplyConnectedRootDatum.B.RankTwo`) completes
successfully — 2501 jobs, no errors, no warnings. That both data still elaborate *is* the
check: without an `IsPerfPair` instance in scope, the `toLinearMap` field of each
`RootDatum` would not typecheck.

Roadmap: RepresentationTheory
