### PR TITLE
feat: classify GLn diagonal adjoint root spaces

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/Classification.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/Classification.lean
@@ -74,11 +74,9 @@ theorem matrixUnitWeight_eq_of_mem_adjointWeightSpace_of_apply_ne_zero
     haction
   rw [tangentMatrix_tangentScalarExtensionEquiv_adjointAction_diagonalTorus_apply,
     tangentMatrix_tangentScalarExtensionEquiv_tmul, Matrix.smul_apply, Matrix.map_apply,
-    smul_eq_mul, mul_comm] at hentryAction
-  change MonoidAlgebra.single (matrixUnitWeight i j) (cotangentDualMatrixEquiv x i j) =
-    algebraMap k K (cotangentDualMatrixEquiv x i j) *
-      MonoidAlgebra.of k M alpha at hentryAction
-  rw [← MonoidAlgebra.single_eq_algebraMap_mul_of] at hentryAction
+    smul_eq_mul] at hentryAction
+  rw [mul_comm (MonoidAlgebra.single alpha 1), ← MonoidAlgebra.of_apply,
+    ← MonoidAlgebra.single_eq_algebraMap_mul_of] at hentryAction
   exact MonoidAlgebra.single_left_injective hentry hentryAction
 
 /-- The nontrivial adjoint weights of `GL_n` relative to its diagonal torus are exactly the
@@ -110,7 +108,7 @@ theorem mem_nontrivialAdjointWeights_diagonalTorus_iff
 
 /-- The set of nontrivial adjoint weights of `GL_n` is the set of off-diagonal matrix-unit
 characters. -/
-theorem nontrivialAdjointWeights_eq_setOf_matrixUnitWeight :
+theorem nontrivialAdjointWeights_diagonalTorus_eq_setOf_matrixUnitWeight :
     Derivation.nontrivialAdjointWeights
         (diagonalTorusCoordinateMap (R := k) (N := n)).hom =
       {alpha | ∃ i j, i ≠ j ∧ alpha = matrixUnitWeight i j} := by

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/Classification.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/Classification.lean
@@ -106,17 +106,9 @@ theorem mem_nontrivialAdjointWeights_diagonalTorus_iff
   · rintro ⟨i, j, hij, rfl⟩
     exact matrixUnitWeight_mem_nontrivialAdjointWeights (k := k) hij
 
-/-- The set of nontrivial adjoint weights of `GL_n` is the set of off-diagonal matrix-unit
-characters. -/
-theorem nontrivialAdjointWeights_diagonalTorus_eq_setOf_matrixUnitWeight :
-    Derivation.nontrivialAdjointWeights
-        (diagonalTorusCoordinateMap (R := k) (N := n)).hom =
-      {alpha | ∃ i j, i ≠ j ∧ alpha = matrixUnitWeight i j} := by
-  ext alpha
-  exact mem_nontrivialAdjointWeights_diagonalTorus_iff alpha
-
 /-- The adjoint weight space for an off-diagonal character `e_i - e_j` is exactly the line
 spanned by the matrix-unit tangent vector `E_ij`. -/
+@[simp]
 theorem adjointWeightSpace_matrixUnitWeight_eq_span_singleton {i j : Fin n} (hij : i ≠ j) :
     Derivation.adjointWeightSpace
         (diagonalTorusCoordinateMap (R := k) (N := n)).hom (matrixUnitWeight i j) =
@@ -143,6 +135,7 @@ theorem adjointWeightSpace_matrixUnitWeight_eq_span_singleton {i j : Fin n} (hij
     exact matrixUnitTangent_mem_adjointWeightSpace (k := k) i j
 
 /-- Every nontrivial matrix-unit adjoint weight space of `GL_n` is one-dimensional. -/
+@[simp]
 theorem finrank_adjointWeightSpace_matrixUnitWeight_eq_one {i j : Fin n} (hij : i ≠ j) :
     Module.finrank k
       (Derivation.adjointWeightSpace

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/Classification.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/Classification.lean
@@ -1,0 +1,196 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Adjoint.RootSpace
+
+/-!
+# Classification of the adjoint roots of the general linear group
+
+For `GL_n` with its diagonal split torus, this file proves the converse to the matrix-unit weight
+calculation: every nontrivial adjoint weight is uniquely `e_i - e_j` for an ordered pair `i ≠ j`,
+and its weight space is the line spanned by `E_ij`.  In particular, every such root space has
+dimension one over the base field.
+
+The proof reads an arbitrary weight vector entrywise.  The universal diagonal adjoint action
+multiplies its `(i, j)` entry by the group-algebra basis element for `e_i - e_j`; comparing this
+with the defining action of its weight shows that every nonzero entry determines the weight.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.matrixUnitWeight_eq_matrixUnitWeight_iff`: off the diagonal, matrix-unit
+  weights remember their ordered pairs.
+* `TauCeti.GeneralLinear.matrixUnitWeight_eq_of_mem_adjointWeightSpace`: a nonzero entry of a
+  weight vector determines its weight.
+* `TauCeti.GeneralLinear.mem_nontrivialAdjointWeights_iff`: the nontrivial adjoint weights are
+  exactly the characters `e_i - e_j` with `i ≠ j`.
+* `TauCeti.GeneralLinear.adjointWeightSpace_matrixUnitWeight_eq_span`: the `e_i - e_j` weight space
+  is the line spanned by `E_ij`.
+* `TauCeti.GeneralLinear.finrank_adjointWeightSpace_matrixUnitWeight`: every root space has
+  dimension one.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §21.1.
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), §26.3.
+
+This completes the adjoint-root classification for the `GL_n` worked example in Layer 7, "Root
+datum of `(G,T)`", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory TensorProduct WithConv
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+noncomputable section
+
+variable {k : Type u} [Field k] {n : ℕ}
+
+/-- Off the diagonal, the character `e_i - e_j` determines the ordered pair `(i, j)`.  Character
+lattices retain this distinction in every field characteristic, including characteristic two. -/
+@[simp]
+theorem matrixUnitWeight_eq_matrixUnitWeight_iff {i j : Fin n} (hij : i ≠ j) (a b : Fin n) :
+    (matrixUnitWeight a b : Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) =
+      matrixUnitWeight i j ↔ a = i ∧ b = j := by
+  constructor
+  · intro h
+    have hi := congrArg
+      (fun alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ) ↦
+        Multiplicative.toAdd alpha (ULift.up i)) h
+    have hai : a = i := by
+      by_contra hai
+      by_cases hbi : b = i
+      · subst b
+        simp [toAdd_matrixUnitWeight_apply, Ne.symm hai, hij] at hi
+      · simp [toAdd_matrixUnitWeight_apply, Ne.symm hai, Ne.symm hbi, hij] at hi
+    subst a
+    have hj := congrArg
+      (fun alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ) ↦
+        Multiplicative.toAdd alpha (ULift.up j)) h
+    have hbj : b = j := by
+      by_contra hbj
+      simp [toAdd_matrixUnitWeight_apply] at hj
+      exact hbj hj.symm
+    exact ⟨rfl, hbj⟩
+  · rintro ⟨rfl, rfl⟩
+    rfl
+
+/-- A scalar from the coefficient field can be absorbed into the coefficient of a group-algebra
+basis element. -/
+private theorem single_one_mul_algebraMap (alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ))
+    (c : k) :
+    MonoidAlgebra.single alpha 1 *
+        algebraMap k (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))) c =
+      MonoidAlgebra.single alpha c := by
+  rw [mul_comm, ← Algebra.smul_def, MonoidAlgebra.smul_single]
+  simp
+
+/-- If the `(i, j)` entry of an adjoint weight vector is nonzero, then its weight is
+`e_i - e_j`. -/
+theorem matrixUnitWeight_eq_of_mem_adjointWeightSpace
+    {alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ)}
+    {x : Module.Dual k (Bialgebra.CotangentSpace k (coordinateHopfAlgebra k n))}
+    (hx : x ∈ Derivation.adjointWeightSpace
+      (diagonalTorusCoordinateMap (R := k) (N := n)).hom alpha)
+    {i j : Fin n} (hentry : (cotangentDualMatrixEquiv x) i j ≠ 0) :
+    matrixUnitWeight i j = alpha := by
+  let M := Multiplicative (ULift.{u} (Fin n) →₀ ℤ)
+  let K := MonoidAlgebra k M
+  have haction :=
+    (Derivation.mem_adjointWeightSpace_iff_universalPointAction
+      (diagonalTorusCoordinateMap (R := k) (N := n)).hom alpha x).mp hx
+  have hentryAction := congrArg
+    (fun y : K ⊗[k]
+        Module.Dual k (Bialgebra.CotangentSpace k (coordinateHopfAlgebra k n)) ↦
+      tangentMatrix n
+        (Derivation.tangentScalarExtensionEquiv
+          (R := k) (A := coordinateHopfAlgebra k n) (B := K) y) i j)
+    haction
+  rw [tangentMatrix_universalDiagonalAdjointAction_apply,
+    tangentMatrix_tangentScalarExtensionEquiv_tmul, Matrix.smul_apply, Matrix.map_apply,
+    smul_eq_mul, single_one_mul_algebraMap] at hentryAction
+  exact MonoidAlgebra.single_left_injective hentry hentryAction
+
+/-- The nontrivial adjoint weights of `GL_n` relative to its diagonal torus are exactly the
+characters `e_i - e_j` for ordered pairs `i ≠ j`. -/
+theorem mem_nontrivialAdjointWeights_iff
+    (alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) :
+    alpha ∈ Derivation.nontrivialAdjointWeights
+        (diagonalTorusCoordinateMap (R := k) (N := n)).hom ↔
+      ∃ i j, i ≠ j ∧ alpha = matrixUnitWeight i j := by
+  constructor
+  · rw [Derivation.mem_nontrivialAdjointWeights]
+    rintro ⟨halpha, hspace⟩
+    obtain ⟨x, hx, hx0⟩ := (Submodule.ne_bot_iff _).mp hspace
+    have hmatrix0 : cotangentDualMatrixEquiv x ≠ 0 := by
+      intro hmatrix
+      apply hx0
+      apply (cotangentDualMatrixEquiv (k := k) (n := n)).injective
+      simpa using hmatrix
+    obtain ⟨i, j, hentry⟩ : ∃ i j, (cotangentDualMatrixEquiv x) i j ≠ 0 := by
+      by_contra hentries
+      push Not at hentries
+      apply hmatrix0
+      ext i j
+      exact hentries i j
+    have hweight := matrixUnitWeight_eq_of_mem_adjointWeightSpace hx hentry
+    refine ⟨i, j, ?_, hweight.symm⟩
+    intro hij
+    subst j
+    exact halpha (hweight.symm.trans (matrixUnitWeight_self i))
+  · rintro ⟨i, j, hij, rfl⟩
+    exact matrixUnitWeight_mem_nontrivialAdjointWeights (k := k) hij
+
+/-- The set of nontrivial adjoint weights of `GL_n` is the set of off-diagonal matrix-unit
+characters. -/
+theorem nontrivialAdjointWeights_eq_setOf_matrixUnitWeight :
+    Derivation.nontrivialAdjointWeights
+        (diagonalTorusCoordinateMap (R := k) (N := n)).hom =
+      {alpha | ∃ i j, i ≠ j ∧ alpha = matrixUnitWeight i j} := by
+  ext alpha
+  exact mem_nontrivialAdjointWeights_iff alpha
+
+/-- The adjoint weight space for an off-diagonal character `e_i - e_j` is exactly the line
+spanned by the matrix-unit tangent vector `E_ij`. -/
+theorem adjointWeightSpace_matrixUnitWeight_eq_span {i j : Fin n} (hij : i ≠ j) :
+    Derivation.adjointWeightSpace
+        (diagonalTorusCoordinateMap (R := k) (N := n)).hom (matrixUnitWeight i j) =
+      k ∙ matrixUnitTangent (k := k) i j := by
+  apply le_antisymm
+  · intro x hx
+    rw [Submodule.mem_span_singleton]
+    refine ⟨(cotangentDualMatrixEquiv x) i j, ?_⟩
+    apply (cotangentDualMatrixEquiv (k := k) (n := n)).injective
+    ext a b
+    rw [map_smul, cotangentDualMatrixEquiv_matrixUnitTangent, Matrix.smul_apply]
+    simp only [Matrix.single_apply, smul_eq_mul]
+    by_cases hab : i = a ∧ j = b
+    · obtain ⟨rfl, rfl⟩ := hab
+      simp
+    · rw [ite_eq_right hab, mul_zero]
+      apply Eq.symm
+      by_contra hentry
+      have hweight := matrixUnitWeight_eq_of_mem_adjointWeightSpace hx hentry
+      have hpairs := (matrixUnitWeight_eq_matrixUnitWeight_iff hij a b).mp hweight
+      exact hab ⟨hpairs.1.symm, hpairs.2.symm⟩
+  · rw [Submodule.span_le, Set.singleton_subset_iff]
+    exact matrixUnitTangent_mem_adjointWeightSpace (k := k) i j
+
+/-- Every nontrivial matrix-unit adjoint weight space of `GL_n` is one-dimensional. -/
+theorem finrank_adjointWeightSpace_matrixUnitWeight {i j : Fin n} (hij : i ≠ j) :
+    Module.finrank k
+      (Derivation.adjointWeightSpace
+        (diagonalTorusCoordinateMap (R := k) (N := n)).hom (matrixUnitWeight i j)) = 1 := by
+  rw [adjointWeightSpace_matrixUnitWeight_eq_span hij]
+  exact finrank_span_singleton (matrixUnitTangent_ne_zero (k := k) i j)
+
+end
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/Classification.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/Classification.lean
@@ -21,16 +21,14 @@ with the defining action of its weight shows that every nonzero entry determines
 
 ## Main declarations
 
-* `TauCeti.GeneralLinear.matrixUnitWeight_eq_matrixUnitWeight_iff`: off the diagonal, matrix-unit
-  weights remember their ordered pairs.
-* `TauCeti.GeneralLinear.matrixUnitWeight_eq_of_mem_adjointWeightSpace`: a nonzero entry of a
-  weight vector determines its weight.
-* `TauCeti.GeneralLinear.mem_nontrivialAdjointWeights_iff`: the nontrivial adjoint weights are
-  exactly the characters `e_i - e_j` with `i ≠ j`.
-* `TauCeti.GeneralLinear.adjointWeightSpace_matrixUnitWeight_eq_span`: the `e_i - e_j` weight space
-  is the line spanned by `E_ij`.
-* `TauCeti.GeneralLinear.finrank_adjointWeightSpace_matrixUnitWeight`: every root space has
-  dimension one.
+* `TauCeti.GeneralLinear.matrixUnitWeight_eq_of_mem_adjointWeightSpace_of_apply_ne_zero`: a
+  nonzero entry of a weight vector determines its weight.
+* `TauCeti.GeneralLinear.mem_nontrivialAdjointWeights_diagonalTorus_iff`: the nontrivial adjoint
+  weights are exactly the characters `e_i - e_j` with `i ≠ j`.
+* `TauCeti.GeneralLinear.adjointWeightSpace_matrixUnitWeight_eq_span_singleton`: the `e_i - e_j`
+  weight space is the line spanned by `E_ij`.
+* `TauCeti.GeneralLinear.finrank_adjointWeightSpace_eq_one_of_mem_nontrivialAdjointWeights`:
+  every root space has dimension one.
 
 ## References
 
@@ -53,48 +51,9 @@ noncomputable section
 
 variable {k : Type u} [Field k] {n : ℕ}
 
-/-- Off the diagonal, the character `e_i - e_j` determines the ordered pair `(i, j)`.  Character
-lattices retain this distinction in every field characteristic, including characteristic two. -/
-@[simp]
-theorem matrixUnitWeight_eq_matrixUnitWeight_iff {i j : Fin n} (hij : i ≠ j) (a b : Fin n) :
-    (matrixUnitWeight a b : Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) =
-      matrixUnitWeight i j ↔ a = i ∧ b = j := by
-  constructor
-  · intro h
-    have hi := congrArg
-      (fun alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ) ↦
-        Multiplicative.toAdd alpha (ULift.up i)) h
-    have hai : a = i := by
-      by_contra hai
-      by_cases hbi : b = i
-      · subst b
-        simp [toAdd_matrixUnitWeight_apply, Ne.symm hai, hij] at hi
-      · simp [toAdd_matrixUnitWeight_apply, Ne.symm hai, Ne.symm hbi, hij] at hi
-    subst a
-    have hj := congrArg
-      (fun alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ) ↦
-        Multiplicative.toAdd alpha (ULift.up j)) h
-    have hbj : b = j := by
-      by_contra hbj
-      simp [toAdd_matrixUnitWeight_apply] at hj
-      exact hbj hj.symm
-    exact ⟨rfl, hbj⟩
-  · rintro ⟨rfl, rfl⟩
-    rfl
-
-/-- A scalar from the coefficient field can be absorbed into the coefficient of a group-algebra
-basis element. -/
-private theorem single_one_mul_algebraMap (alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ))
-    (c : k) :
-    MonoidAlgebra.single alpha 1 *
-        algebraMap k (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))) c =
-      MonoidAlgebra.single alpha c := by
-  rw [mul_comm, ← Algebra.smul_def, MonoidAlgebra.smul_single]
-  simp
-
 /-- If the `(i, j)` entry of an adjoint weight vector is nonzero, then its weight is
 `e_i - e_j`. -/
-theorem matrixUnitWeight_eq_of_mem_adjointWeightSpace
+theorem matrixUnitWeight_eq_of_mem_adjointWeightSpace_of_apply_ne_zero
     {alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ)}
     {x : Module.Dual k (Bialgebra.CotangentSpace k (coordinateHopfAlgebra k n))}
     (hx : x ∈ Derivation.adjointWeightSpace
@@ -113,14 +72,18 @@ theorem matrixUnitWeight_eq_of_mem_adjointWeightSpace
         (Derivation.tangentScalarExtensionEquiv
           (R := k) (A := coordinateHopfAlgebra k n) (B := K) y) i j)
     haction
-  rw [tangentMatrix_universalDiagonalAdjointAction_apply,
+  rw [tangentMatrix_tangentScalarExtensionEquiv_adjointAction_diagonalTorus_apply,
     tangentMatrix_tangentScalarExtensionEquiv_tmul, Matrix.smul_apply, Matrix.map_apply,
-    smul_eq_mul, single_one_mul_algebraMap] at hentryAction
+    smul_eq_mul, mul_comm] at hentryAction
+  change MonoidAlgebra.single (matrixUnitWeight i j) (cotangentDualMatrixEquiv x i j) =
+    algebraMap k K (cotangentDualMatrixEquiv x i j) *
+      MonoidAlgebra.of k M alpha at hentryAction
+  rw [← MonoidAlgebra.single_eq_algebraMap_mul_of] at hentryAction
   exact MonoidAlgebra.single_left_injective hentry hentryAction
 
 /-- The nontrivial adjoint weights of `GL_n` relative to its diagonal torus are exactly the
 characters `e_i - e_j` for ordered pairs `i ≠ j`. -/
-theorem mem_nontrivialAdjointWeights_iff
+theorem mem_nontrivialAdjointWeights_diagonalTorus_iff
     (alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) :
     alpha ∈ Derivation.nontrivialAdjointWeights
         (diagonalTorusCoordinateMap (R := k) (N := n)).hom ↔
@@ -129,18 +92,15 @@ theorem mem_nontrivialAdjointWeights_iff
   · rw [Derivation.mem_nontrivialAdjointWeights]
     rintro ⟨halpha, hspace⟩
     obtain ⟨x, hx, hx0⟩ := (Submodule.ne_bot_iff _).mp hspace
-    have hmatrix0 : cotangentDualMatrixEquiv x ≠ 0 := by
-      intro hmatrix
-      apply hx0
-      apply (cotangentDualMatrixEquiv (k := k) (n := n)).injective
-      simpa using hmatrix
+    have hmatrix0 := (cotangentDualMatrixEquiv (k := k) (n := n)).map_ne_zero_iff.mpr hx0
     obtain ⟨i, j, hentry⟩ : ∃ i j, (cotangentDualMatrixEquiv x) i j ≠ 0 := by
       by_contra hentries
       push Not at hentries
       apply hmatrix0
       ext i j
       exact hentries i j
-    have hweight := matrixUnitWeight_eq_of_mem_adjointWeightSpace hx hentry
+    have hweight :=
+      matrixUnitWeight_eq_of_mem_adjointWeightSpace_of_apply_ne_zero hx hentry
     refine ⟨i, j, ?_, hweight.symm⟩
     intro hij
     subst j
@@ -155,11 +115,11 @@ theorem nontrivialAdjointWeights_eq_setOf_matrixUnitWeight :
         (diagonalTorusCoordinateMap (R := k) (N := n)).hom =
       {alpha | ∃ i j, i ≠ j ∧ alpha = matrixUnitWeight i j} := by
   ext alpha
-  exact mem_nontrivialAdjointWeights_iff alpha
+  exact mem_nontrivialAdjointWeights_diagonalTorus_iff alpha
 
 /-- The adjoint weight space for an off-diagonal character `e_i - e_j` is exactly the line
 spanned by the matrix-unit tangent vector `E_ij`. -/
-theorem adjointWeightSpace_matrixUnitWeight_eq_span {i j : Fin n} (hij : i ≠ j) :
+theorem adjointWeightSpace_matrixUnitWeight_eq_span_singleton {i j : Fin n} (hij : i ≠ j) :
     Derivation.adjointWeightSpace
         (diagonalTorusCoordinateMap (R := k) (N := n)).hom (matrixUnitWeight i j) =
       k ∙ matrixUnitTangent (k := k) i j := by
@@ -177,19 +137,33 @@ theorem adjointWeightSpace_matrixUnitWeight_eq_span {i j : Fin n} (hij : i ≠ j
     · rw [ite_eq_right hab, mul_zero]
       apply Eq.symm
       by_contra hentry
-      have hweight := matrixUnitWeight_eq_of_mem_adjointWeightSpace hx hentry
+      have hweight :=
+        matrixUnitWeight_eq_of_mem_adjointWeightSpace_of_apply_ne_zero hx hentry
       have hpairs := (matrixUnitWeight_eq_matrixUnitWeight_iff hij a b).mp hweight
       exact hab ⟨hpairs.1.symm, hpairs.2.symm⟩
   · rw [Submodule.span_le, Set.singleton_subset_iff]
     exact matrixUnitTangent_mem_adjointWeightSpace (k := k) i j
 
 /-- Every nontrivial matrix-unit adjoint weight space of `GL_n` is one-dimensional. -/
-theorem finrank_adjointWeightSpace_matrixUnitWeight {i j : Fin n} (hij : i ≠ j) :
+theorem finrank_adjointWeightSpace_matrixUnitWeight_eq_one {i j : Fin n} (hij : i ≠ j) :
     Module.finrank k
       (Derivation.adjointWeightSpace
         (diagonalTorusCoordinateMap (R := k) (N := n)).hom (matrixUnitWeight i j)) = 1 := by
-  rw [adjointWeightSpace_matrixUnitWeight_eq_span hij]
+  rw [adjointWeightSpace_matrixUnitWeight_eq_span_singleton hij]
   exact finrank_span_singleton (matrixUnitTangent_ne_zero (k := k) i j)
+
+/-- Every nontrivial adjoint weight space of `GL_n` relative to its diagonal torus is
+one-dimensional. -/
+theorem finrank_adjointWeightSpace_eq_one_of_mem_nontrivialAdjointWeights
+    {alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ)}
+    (halpha : alpha ∈ Derivation.nontrivialAdjointWeights
+      (diagonalTorusCoordinateMap (R := k) (N := n)).hom) :
+    Module.finrank k
+      (Derivation.adjointWeightSpace
+        (diagonalTorusCoordinateMap (R := k) (N := n)).hom alpha) = 1 := by
+  obtain ⟨i, j, hij, rfl⟩ :=
+    (mem_nontrivialAdjointWeights_diagonalTorus_iff alpha).mp halpha
+  exact finrank_adjointWeightSpace_matrixUnitWeight_eq_one hij
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/RootSpace.lean
@@ -28,6 +28,8 @@ identifying the diagonal tangent directions as torus-fixed vectors.
 
 * `TauCeti.GeneralLinear.matrixUnitWeight`: the weight `e_i - e_j`.
 * `TauCeti.GeneralLinear.matrixUnitTangent`: the tangent vector corresponding to `E_ij`.
+* `TauCeti.GeneralLinear.tangentMatrix_universalDiagonalAdjointAction_apply`: the universal
+  diagonal adjoint action on an arbitrary matrix entry.
 * `TauCeti.GeneralLinear.matrixUnitTangent_mem_adjointWeightSpace`: `E_ij` has weight
   `e_i - e_j` under the diagonal torus.
 * `TauCeti.GeneralLinear.matrixUnitWeight_mem_nontrivialAdjointWeights`: every off-diagonal
@@ -211,6 +213,46 @@ theorem cotangentDualMatrixEquiv_matrixUnitTangent (i j : Fin n) :
     cotangentDualMatrixEquiv (matrixUnitTangent (k := k) i j) = Matrix.single i j 1 := by
   exact LinearEquiv.apply_symm_apply _ _
 
+/-- The universal diagonal-torus adjoint action multiplies the `(i, j)` matrix entry by the
+character `e_i - e_j`.  Unlike the matrix-unit specialization below, this formula applies to an
+arbitrary tangent vector and is the coefficient calculation used to classify all adjoint weight
+spaces of `GL_n`. -/
+theorem tangentMatrix_universalDiagonalAdjointAction_apply
+    (x : Module.Dual k (Bialgebra.CotangentSpace k (coordinateHopfAlgebra k n)))
+    (i j : Fin n) :
+    tangentMatrix n
+        (Derivation.tangentScalarExtensionEquiv
+          (R := k) (A := coordinateHopfAlgebra k n)
+          (B := MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))
+          ((Derivation.adjointAction
+            (CommAlgCat.of k
+              (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))))
+            (toConv ((diagonalTorusCoordinateMap (R := k) (N := n)).hom :
+              coordinateHopfAlgebra k n →ₐ[k]
+                MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))))).val
+              (1 ⊗ₜ[k] x))) i j =
+      MonoidAlgebra.single (matrixUnitWeight i j)
+        ((cotangentDualMatrixEquiv (k := k) (n := n) x) i j) := by
+  let M := Multiplicative (ULift.{u} (Fin n) →₀ ℤ)
+  let K := MonoidAlgebra k M
+  let p : WithConv (K →ₐ[k] K) := toConv (AlgHom.id k K)
+  rw [Derivation.tangentScalarExtensionEquiv_adjointAction
+    (CommAlgCat.of k K)
+    (toConv ((diagonalTorusCoordinateMap (R := k) (N := n)).hom :
+      coordinateHopfAlgebra k n →ₐ[k] K))]
+  rw [pointInCounitAlgebra_universalPoint_diagonalTorus]
+  rw [tangentMatrix_adDerivation_apply_diagonalTorusPoints,
+    tangentMatrix_tangentScalarExtensionEquiv_one_tmul, Matrix.map_apply]
+  rw [mul_assoc, mul_comm
+    (algebraMap k K ((cotangentDualMatrixEquiv (k := k) (n := n) x) i j)), ← mul_assoc]
+  rw [show
+    (SplitTorus.pointsMulEquiv p (ULift.up i) : K) *
+        (((SplitTorus.pointsMulEquiv p (ULift.up j))⁻¹ : Kˣ) : K) =
+      MonoidAlgebra.single (matrixUnitWeight i j) 1 from
+        universalPoint_coordinate_mul_inv (k := k) i j]
+  rw [mul_comm, ← Algebra.smul_def, MonoidAlgebra.smul_single]
+  simp
+
 /-- The matrix unit `E_ij` belongs to the adjoint weight space of the diagonal-torus character
 `e_i - e_j`.  This is the formal root-space version of diagonal conjugation scaling the
 `(i, j)` matrix entry by `t_i t_j⁻¹`. -/
@@ -222,20 +264,13 @@ theorem matrixUnitTangent_mem_adjointWeightSpace (i j : Fin n) :
   rw [Derivation.mem_adjointWeightSpace_iff_universalPointAction]
   let M := Multiplicative (ULift.{u} (Fin n) →₀ ℤ)
   let K := MonoidAlgebra k M
-  let p : WithConv (K →ₐ[k] K) := toConv (AlgHom.id k K)
   apply (Derivation.tangentScalarExtensionEquiv
     (R := k) (A := coordinateHopfAlgebra k n) (B := K)).injective
-  rw [Derivation.tangentScalarExtensionEquiv_adjointAction
-    (CommAlgCat.of k K)
-    (toConv ((diagonalTorusCoordinateMap (R := k) (N := n)).hom :
-      coordinateHopfAlgebra k n →ₐ[k] K))]
-  rw [pointInCounitAlgebra_universalPoint_diagonalTorus]
   apply (tangentLinearEquivMatrix n).injective
-  rw [tangentLinearEquivMatrix_apply, tangentLinearEquivMatrix_apply]
   apply Matrix.ext
   intro a b
-  rw [tangentMatrix_adDerivation_apply_diagonalTorusPoints,
-    tangentMatrix_tangentScalarExtensionEquiv_one_tmul,
+  rw [tangentLinearEquivMatrix_apply, tangentLinearEquivMatrix_apply,
+    tangentMatrix_universalDiagonalAdjointAction_apply,
     tangentMatrix_tangentScalarExtensionEquiv_tmul,
     cotangentDualMatrixEquiv_matrixUnitTangent]
   simp only [Matrix.map_apply, Matrix.smul_apply, smul_eq_mul]
@@ -243,9 +278,7 @@ theorem matrixUnitTangent_mem_adjointWeightSpace (i j : Fin n) :
   · subst a
     by_cases hbj : b = j
     · subst b
-      rw [Matrix.single_apply_same, map_one, mul_one, mul_one]
-      simpa only [p] using
-        universalPoint_coordinate_mul_inv (k := k) i j
+      simp
     · simp [Ne.symm hbj]
   · simp [Ne.symm hai]
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/RootSpace.lean
@@ -254,7 +254,6 @@ theorem tangentMatrix_tangentScalarExtensionEquiv_adjointAction_diagonalTorus_ap
         ((cotangentDualMatrixEquiv (k := k) (n := n) x) i j) := by
   let M := Multiplicative (ULift.{u} (Fin n) →₀ ℤ)
   let K := MonoidAlgebra k M
-  let p : WithConv (K →ₐ[k] K) := toConv (AlgHom.id k K)
   rw [Derivation.tangentScalarExtensionEquiv_adjointAction
     (CommAlgCat.of k K)
     (toConv ((diagonalTorusCoordinateMap (R := k) (N := n)).hom :
@@ -265,8 +264,8 @@ theorem tangentMatrix_tangentScalarExtensionEquiv_adjointAction_diagonalTorus_ap
   rw [mul_assoc, mul_comm
     (algebraMap k K ((cotangentDualMatrixEquiv (k := k) (n := n) x) i j)), ← mul_assoc]
   rw [universalPoint_coordinate_mul_inv]
-  rw [mul_comm]
-  exact (MonoidAlgebra.single_eq_algebraMap_mul_of _ _).symm
+  rw [mul_comm (MonoidAlgebra.single (matrixUnitWeight i j) (1 : k)),
+    ← MonoidAlgebra.of_apply, ← MonoidAlgebra.single_eq_algebraMap_mul_of]
 
 /-- The matrix unit `E_ij` belongs to the adjoint weight space of the diagonal-torus character
 `e_i - e_j`.  This is the formal root-space version of diagonal conjugation scaling the

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/RootSpace.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/RootSpace.lean
@@ -28,8 +28,8 @@ identifying the diagonal tangent directions as torus-fixed vectors.
 
 * `TauCeti.GeneralLinear.matrixUnitWeight`: the weight `e_i - e_j`.
 * `TauCeti.GeneralLinear.matrixUnitTangent`: the tangent vector corresponding to `E_ij`.
-* `TauCeti.GeneralLinear.tangentMatrix_universalDiagonalAdjointAction_apply`: the universal
-  diagonal adjoint action on an arbitrary matrix entry.
+* `tangentMatrix_tangentScalarExtensionEquiv_adjointAction_diagonalTorus_apply`:
+  the universal diagonal adjoint action on an arbitrary matrix entry.
 * `TauCeti.GeneralLinear.matrixUnitTangent_mem_adjointWeightSpace`: `E_ij` has weight
   `e_i - e_j` under the diagonal torus.
 * `TauCeti.GeneralLinear.matrixUnitWeight_mem_nontrivialAdjointWeights`: every off-diagonal
@@ -105,49 +105,68 @@ theorem matrixUnitWeight_ne_one {i j : Fin n} (hij : i ≠ j) :
   intro h
   exact hij ((matrixUnitWeight_eq_one_iff i j).mp h)
 
+/-- Off the diagonal, the character `e_i - e_j` determines the ordered pair `(i, j)`.  This
+follows in the torsion-free character lattice `ULift (Fin n) →₀ ℤ`, independently of the base
+field. -/
+@[simp]
+theorem matrixUnitWeight_eq_matrixUnitWeight_iff {i j : Fin n} (hij : i ≠ j) (a b : Fin n) :
+    (matrixUnitWeight a b : Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) =
+      matrixUnitWeight i j ↔ a = i ∧ b = j := by
+  constructor
+  · intro h
+    have hi := congrArg
+      (fun alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ) ↦
+        Multiplicative.toAdd alpha (ULift.up i)) h
+    have hai : a = i := by
+      by_contra hai
+      by_cases hbi : b = i
+      · subst b
+        simp [toAdd_matrixUnitWeight_apply, Ne.symm hai, hij] at hi
+      · simp [toAdd_matrixUnitWeight_apply, Ne.symm hai, Ne.symm hbi, hij] at hi
+    subst a
+    have hj := congrArg
+      (fun alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ) ↦
+        Multiplicative.toAdd alpha (ULift.up j)) h
+    have hbj : b = j := by
+      by_contra hbj
+      simp [Ne.symm hij, Ne.symm hbj] at hj
+    exact ⟨rfl, hbj⟩
+  · rintro ⟨rfl, rfl⟩
+    rfl
+
 private theorem universalPoint_coordinate_mul_inv (i j : Fin n) :
-    let M := Multiplicative (ULift.{u} (Fin n) →₀ ℤ)
-    let K := MonoidAlgebra k M
-    let p : WithConv (K →ₐ[k] K) := toConv (AlgHom.id k K)
-    (SplitTorus.pointsMulEquiv p (ULift.up i) : K) *
-        (((SplitTorus.pointsMulEquiv p (ULift.up j))⁻¹ : Kˣ) : K) =
+    (SplitTorus.pointsMulEquiv
+        (toConv (AlgHom.id k
+          (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))))
+        (ULift.up i) :
+      MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))) *
+        (((SplitTorus.pointsMulEquiv
+          (toConv (AlgHom.id k
+            (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))))
+          (ULift.up j))⁻¹ :
+            (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))ˣ) :
+          MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))) =
       MonoidAlgebra.single (matrixUnitWeight i j) 1 := by
-  dsimp only
-  let p := toConv (AlgHom.id k
-    (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))))
-  have hi : (SplitTorus.pointsMulEquiv p (ULift.up i) :
+  have hi : (SplitTorus.pointsMulEquiv
+      (toConv (AlgHom.id k
+        (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))))
+      (ULift.up i) :
       MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))) =
       MonoidAlgebra.single
         (Multiplicative.ofAdd (Finsupp.single (ULift.up i) 1)) 1 := by
     rw [SplitTorus.pointsMulEquiv_apply_coe]
     rfl
-  have hj : (((SplitTorus.pointsMulEquiv p (ULift.up j))⁻¹ :
+  have hj : (((SplitTorus.pointsMulEquiv
+      (toConv (AlgHom.id k
+        (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))))
+      (ULift.up j))⁻¹ :
       (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))ˣ) :
       MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))) =
       MonoidAlgebra.single
         (Multiplicative.ofAdd (Finsupp.single (ULift.up j) 1))⁻¹ 1 := by
-    -- The character API returns a unit. Expose the coercion of its inverse to the group algebra
-    -- because `charOfPoint_apply_inv_coe` is stated at that underlying value.
-    change (↑((SplitTorus.pointsMulEquiv
-      (toConv (AlgHom.id k
-        (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))))
-      (ULift.up j))⁻¹ :
-        (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))ˣ) :
-          MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))) =
-      (MonoidAlgebra.single
-        (Multiplicative.ofAdd (Finsupp.single (ULift.up j) (1 : ℤ)))⁻¹ (1 : k) :
-          MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))
     rw [SplitTorus.pointsMulEquiv_eq_freeAbelianCharEquiv,
       freeAbelianCharEquiv_apply]
     exact DiagonalizableGroup.charOfPoint_apply_inv_coe _ _
-  -- Unfold the local abbreviation `p` and the coercion from the inverse unit so that the two
-  -- previously computed coordinate identities rewrite the product.
-  change
-    (SplitTorus.pointsMulEquiv p (ULift.up i) :
-        MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))) *
-      (↑((SplitTorus.pointsMulEquiv p (ULift.up j))⁻¹ :
-        (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)))ˣ) :
-          MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ))) = _
   rw [hi, hj, MonoidAlgebra.single_mul_single, one_mul]
   congr 1
   apply Multiplicative.toAdd.injective
@@ -215,9 +234,9 @@ theorem cotangentDualMatrixEquiv_matrixUnitTangent (i j : Fin n) :
 
 /-- The universal diagonal-torus adjoint action multiplies the `(i, j)` matrix entry by the
 character `e_i - e_j`.  Unlike the matrix-unit specialization below, this formula applies to an
-arbitrary tangent vector and is the coefficient calculation used to classify all adjoint weight
-spaces of `GL_n`. -/
-theorem tangentMatrix_universalDiagonalAdjointAction_apply
+arbitrary tangent vector and is the coefficient calculation used to classify all nontrivial
+adjoint weight spaces of `GL_n`. -/
+theorem tangentMatrix_tangentScalarExtensionEquiv_adjointAction_diagonalTorus_apply
     (x : Module.Dual k (Bialgebra.CotangentSpace k (coordinateHopfAlgebra k n)))
     (i j : Fin n) :
     tangentMatrix n
@@ -245,13 +264,9 @@ theorem tangentMatrix_universalDiagonalAdjointAction_apply
     tangentMatrix_tangentScalarExtensionEquiv_one_tmul, Matrix.map_apply]
   rw [mul_assoc, mul_comm
     (algebraMap k K ((cotangentDualMatrixEquiv (k := k) (n := n) x) i j)), ← mul_assoc]
-  rw [show
-    (SplitTorus.pointsMulEquiv p (ULift.up i) : K) *
-        (((SplitTorus.pointsMulEquiv p (ULift.up j))⁻¹ : Kˣ) : K) =
-      MonoidAlgebra.single (matrixUnitWeight i j) 1 from
-        universalPoint_coordinate_mul_inv (k := k) i j]
-  rw [mul_comm, ← Algebra.smul_def, MonoidAlgebra.smul_single]
-  simp
+  rw [universalPoint_coordinate_mul_inv]
+  rw [mul_comm]
+  exact (MonoidAlgebra.single_eq_algebraMap_mul_of _ _).symm
 
 /-- The matrix unit `E_ij` belongs to the adjoint weight space of the diagonal-torus character
 `e_i - e_j`.  This is the formal root-space version of diagonal conjugation scaling the
@@ -270,7 +285,7 @@ theorem matrixUnitTangent_mem_adjointWeightSpace (i j : Fin n) :
   apply Matrix.ext
   intro a b
   rw [tangentLinearEquivMatrix_apply, tangentLinearEquivMatrix_apply,
-    tangentMatrix_universalDiagonalAdjointAction_apply,
+    tangentMatrix_tangentScalarExtensionEquiv_adjointAction_diagonalTorus_apply,
     tangentMatrix_tangentScalarExtensionEquiv_tmul,
     cotangentDualMatrixEquiv_matrixUnitTangent]
   simp only [Matrix.map_apply, Matrix.smul_apply, smul_eq_mul]


### PR DESCRIPTION
This PR classifies the diagonal-torus adjoint roots of `GL_n`: prove that every nontrivial weight is uniquely `e_i - e_j` for `i ≠ j`, identify its weight space with the line spanned by `E_ij`, and deduce that every such root space has finrank one. It advances the Layer 7 target "Root datum `(X*(T), Φ, X_*(T), Φˇ)` of `(G, T)` — do the split case first" in `TauCetiRoadmap/ReductiveGroups/README.md`, using the roadmap's `GL_n` worked example to validate the abstract adjoint-weight API.

The implementation factors the universal diagonal adjoint action into a reusable entrywise coefficient formula, then compares group-algebra basis elements at every nonzero matrix entry. No Mathlib infrastructure is vendored.

Milestone: Layer 7 split root datum, `GL_n` adjoint-root classification. After this PR, the milestone still needs the coroot and character/cocharacter pairing, Weyl-group action, and the corresponding abstract construction for general split reductive groups.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"gln-adjoint-root-space-classification"}-->

🤖 Prepared with Codex
