### PR TITLE
feat: the explicit continuous complex of a discrete group is Mathlib's

### DIFF
--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/GroupCohomologyIso.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/GroupCohomologyIso.lean
@@ -125,6 +125,7 @@ section DictionaryDegree0
 variable {G : Type u} [Group G] {M : Type v} [AddCommGroup M] [DistribMulAction G M]
 
 /-- Degree `0`: the invariants of the induced representation are the explicit `H⁰ = M^G`. -/
+@[simp]
 theorem mem_invariants_iff_mem_H0 (m : M) :
     m ∈ (Rep.ofDistribMulAction ℤ G M).ρ.invariants ↔ m ∈ H0 G M :=
   ⟨fun h => (FixedPoints.mem_addSubgroup G M m).2 fun g => h g,
@@ -140,6 +141,7 @@ variable {G : Type} [Group G] [TopologicalSpace G] [DiscreteTopology G]
 
 /-- Degree `1`, cocycles: over a discrete group the continuity half of `Z¹` is free, so the
 continuous `1`-cocycles are Mathlib's `1`-cocycles. -/
+@[simp]
 theorem mem_cocycles₁_iff_mem_Z1 (f : G → M) :
     f ∈ cocycles₁ (Rep.ofDistribMulAction ℤ G M) ↔ f ∈ Z1 G M :=
   ⟨fun h => mem_Z1_iff.2 ⟨continuous_of_discreteTopology,
@@ -150,6 +152,7 @@ theorem mem_cocycles₁_iff_mem_Z1 (f : G → M) :
 omit [TopologicalSpace G] [DiscreteTopology G] [TopologicalSpace M] [IsTopologicalAddGroup M] in
 /-- Degree `1`, coboundaries: `B¹` carries no continuity condition on its primitive, so the two
 definitions agree over any topological group; discreteness is not used. -/
+@[simp]
 theorem mem_coboundaries₁_iff_mem_B1 (f : G → M) :
     f ∈ coboundaries₁ (Rep.ofDistribMulAction ℤ G M) ↔ f ∈ B1 G M :=
   ⟨fun ⟨m, hm⟩ => mem_B1_iff.2 ⟨m, fun g => congrFun hm g⟩,
@@ -157,6 +160,7 @@ theorem mem_coboundaries₁_iff_mem_B1 (f : G → M) :
 
 /-- Degree `2`, cocycles: as in degree `1`, over a discrete group the continuity half of `Z²` is
 free, `G × G` being discrete as well. -/
+@[simp]
 theorem mem_cocycles₂_iff_mem_Z2 (f : G × G → M) :
     f ∈ cocycles₂ (Rep.ofDistribMulAction ℤ G M) ↔ f ∈ Z2 G M :=
   ⟨fun h => mem_Z2_iff.2 ⟨continuous_of_discreteTopology,
@@ -166,6 +170,7 @@ theorem mem_cocycles₂_iff_mem_Z2 (f : G × G → M) :
 
 /-- Degree `2`, coboundaries. Here discreteness *is* used: `B²` is by definition the image of the
 **continuous** `1`-cochains, and over a discrete group those are all of them. -/
+@[simp]
 theorem mem_coboundaries₂_iff_mem_B2 (f : G × G → M) :
     f ∈ coboundaries₂ (Rep.ofDistribMulAction ℤ G M) ↔ f ∈ B2 G M :=
   ⟨fun ⟨c, hc⟩ => mem_B2_iff'.2 ⟨c, continuous_of_discreteTopology,

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/GroupCohomologyIso.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/GroupCohomologyIso.lean
@@ -40,8 +40,8 @@ degree `2` where discreteness enters the denominator, `B²` being the image of t
 
 * `TauCeti.ContCohomology.C1_eq_top` and `TauCeti.ContCohomology.C2_eq_top`: over a discrete group
   every cochain is continuous.
-* `TauCeti.ContCohomology.d0_eq_d₀₁`, `d1_eq_d₁₂` and `d2_eq_d₂₃`: the explicit differentials are
-  Mathlib's, on the nose.
+* `TauCeti.ContCohomology.d0_apply_eq_d₀₁_hom_apply` and its degree-`1` and degree-`2`
+  counterparts: the explicit differentials are Mathlib's, on the nose.
 * `TauCeti.ContCohomology.mem_cocycles₁_iff_mem_Z1`,
   `TauCeti.ContCohomology.mem_coboundaries₁_iff_mem_B1` and their degree-`2` and degree-`0`
   counterparts: the dictionary between the two sets of cocycles and coboundaries.
@@ -52,11 +52,10 @@ The universes are pinned by the pin and not by the mathematics. Mathlib states i
 group cohomology for `{k G : Type u}`, so taking `k = ℤ` forces `G` into `Type 0` in every
 statement below that mentions a `Rep ℤ G`; and it states `groupCohomology` for `A : Rep.{u} k G`,
 which forces the coefficient module into that universe too. So the three comparison isomorphisms
-carry `G M : Type`, while the differentials and the four membership dictionaries — which mention
-`cocycles₁`, `cocycles₂`, `coboundaries₁` and `coboundaries₂`, whose universes constrain only `k`
-and `G` — keep `M` in an arbitrary universe. `C1_eq_top` and `C2_eq_top` mention nothing of
-Mathlib's theory and are fully polymorphic. When the pin drops these restrictions the binders
-here can simply be widened.
+carry `G M : Type`, while the differentials, membership dictionaries, and numerator equivalences
+keep every universe not constrained by Mathlib's representation API arbitrary. `C1_eq_top` and
+`C2_eq_top` mention nothing of Mathlib's theory and are fully polymorphic. When the pin drops these
+restrictions the binders here can simply be widened.
 
 The isomorphisms are built as `AddEquiv`s and not as isomorphisms in `ModuleCat ℤ`. The explicit
 `H¹` and `H²` are bare additive groups by construction, their inherited quotient topology being the
@@ -92,39 +91,28 @@ universe u v
 
 open groupCohomology
 
-section DiscreteCochains
-
-variable (G : Type u) [TopologicalSpace G] [DiscreteTopology G]
-  (M : Type v) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
-
-/-- Over a discrete group every `1`-cochain is continuous. -/
-theorem C1_eq_top : C1 G M = ⊤ :=
-  (AddSubgroup.eq_top_iff' _).2 fun _ => mem_C1_iff.2 continuous_of_discreteTopology
-
-/-- Over a discrete group every `2`-cochain is continuous: `G × G` is discrete too. -/
-theorem C2_eq_top : C2 G M = ⊤ :=
-  (AddSubgroup.eq_top_iff' _).2 fun _ => mem_C2_iff.2 continuous_of_discreteTopology
-
-end DiscreteCochains
-
 section Differentials
 
 variable (G : Type) [Group G] (M : Type v) [AddCommGroup M] [DistribMulAction G M]
 
+/- `Rep.ofDistribMulAction ℤ G M` has carrier definitionally equal to `M`, and its action is
+definitionally the original `G`-action. The comparison proofs below use those definitional
+identifications; the named Mathlib formulas record the two sides being identified. -/
+
 /-- The explicit degree-`0` differential is Mathlib's `d₀₁`. -/
-theorem d0_eq_d₀₁ (m : M) :
+theorem d0_apply_eq_d₀₁_hom_apply (m : M) :
     d0 G M m = (groupCohomology.d₀₁ (Rep.ofDistribMulAction ℤ G M)).hom m :=
   funext fun g =>
     (d0_apply m g).trans (d₀₁_hom_apply (A := Rep.ofDistribMulAction ℤ G M) m g).symm
 
 /-- The explicit degree-`1` differential is Mathlib's `d₁₂`. -/
-theorem d1_eq_d₁₂ (f : G → M) :
+theorem d1_apply_eq_d₁₂_hom_apply (f : G → M) :
     d1 G M f = (groupCohomology.d₁₂ (Rep.ofDistribMulAction ℤ G M)).hom f :=
   funext fun q =>
     (d1_apply f q.1 q.2).trans (d₁₂_hom_apply (A := Rep.ofDistribMulAction ℤ G M) f q).symm
 
 /-- The explicit degree-`2` differential is Mathlib's `d₂₃`. -/
-theorem d2_eq_d₂₃ (f : G × G → M) :
+theorem d2_apply_eq_d₂₃_hom_apply (f : G × G → M) :
     d2 G M f = (groupCohomology.d₂₃ (Rep.ofDistribMulAction ℤ G M)).hom f :=
   funext fun q =>
     (d2_apply f q.1 q.2.1 q.2.2).trans
@@ -132,18 +120,23 @@ theorem d2_eq_d₂₃ (f : G × G → M) :
 
 end Differentials
 
-section Dictionary
+section DictionaryDegree0
 
-variable {G : Type} [Group G] [TopologicalSpace G] [DiscreteTopology G]
-  {M : Type v} [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
-  [DistribMulAction G M]
+variable {G : Type u} [Group G] {M : Type v} [AddCommGroup M] [DistribMulAction G M]
 
-omit [TopologicalSpace G] [DiscreteTopology G] [TopologicalSpace M] [IsTopologicalAddGroup M] in
 /-- Degree `0`: the invariants of the induced representation are the explicit `H⁰ = M^G`. -/
 theorem mem_invariants_iff_mem_H0 (m : M) :
     m ∈ (Rep.ofDistribMulAction ℤ G M).ρ.invariants ↔ m ∈ H0 G M :=
   ⟨fun h => (FixedPoints.mem_addSubgroup G M m).2 fun g => h g,
     fun h g => (FixedPoints.mem_addSubgroup G M m).1 h g⟩
+
+end DictionaryDegree0
+
+section DictionaryPositiveDegree
+
+variable {G : Type} [Group G] [TopologicalSpace G] [DiscreteTopology G]
+  {M : Type v} [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  [DistribMulAction G M]
 
 /-- Degree `1`, cocycles: over a discrete group the continuity half of `Z¹` is free, so the
 continuous `1`-cocycles are Mathlib's `1`-cocycles. -/
@@ -179,14 +172,14 @@ theorem mem_coboundaries₂_iff_mem_B2 (f : G × G → M) :
       fun g h => congrFun hc (g, h)⟩,
     fun h => (mem_B2_iff'.1 h).elim fun c hc => ⟨c, funext fun p => hc.2 p.1 p.2⟩⟩
 
-end Dictionary
+end DictionaryPositiveDegree
 
-section ComparisonDegree0
+section NumeratorDegree0
 
 /-! Degree `0` is the one degree where the comparison needs no hypothesis on the topology at all:
 both sides are the invariants, and continuity constrains no `0`-cochain. -/
 
-variable (G : Type) [Group G] (M : Type) [AddCommGroup M] [DistribMulAction G M]
+variable (G : Type u) [Group G] (M : Type v) [AddCommGroup M] [DistribMulAction G M]
 
 /-- Degree `0`, on the carriers: the explicit `H⁰(G, M) = M^G` is the submodule of invariants of
 the induced representation. -/
@@ -203,6 +196,12 @@ theorem H0AddEquivInvariants_val (m : H0 G M) : (H0AddEquivInvariants G M m).1 =
 @[simp]
 theorem H0AddEquivInvariants_symm_val (m : (Rep.ofDistribMulAction ℤ G M).ρ.invariants) :
     ((H0AddEquivInvariants G M).symm m).1 = m.1 := (rfl)
+
+end NumeratorDegree0
+
+section ComparisonDegree0
+
+variable (G : Type) [Group G] (M : Type) [AddCommGroup M] [DistribMulAction G M]
 
 /-- **Layer 3, degree 0 against Mathlib's discrete group cohomology.** The explicit `H⁰(G, M)` is
 Mathlib's `H⁰` of the representation attached to the action. -/
@@ -227,10 +226,10 @@ theorem explicitH0IsoGroupCohomology_symm_apply
 
 end ComparisonDegree0
 
-section ComparisonDegree1
+section NumeratorDegree1
 
 variable (G : Type) [Group G] [TopologicalSpace G] [DiscreteTopology G]
-  (M : Type) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  (M : Type v) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
   [DistribMulAction G M]
 
 /-- Degree `1`, on the numerators: the continuous `1`-cocycles are Mathlib's `1`-cocycles. -/
@@ -249,47 +248,54 @@ theorem Z1AddEquivCocycles₁_coe (z : Z1 G M) :
 theorem Z1AddEquivCocycles₁_symm_coe (c : cocycles₁ (Rep.ofDistribMulAction ℤ G M)) :
     (((Z1AddEquivCocycles₁ G M).symm c : Z1 G M) : G → M) = ⇑c := (rfl)
 
+end NumeratorDegree1
+
+section ComparisonDegree1
+
+variable (G : Type) [Group G] [TopologicalSpace G] [DiscreteTopology G]
+  (M : Type) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  [DistribMulAction G M]
+
 variable [ContinuousSMul G M]
 
 /-- **Layer 3, degree 1 against Mathlib's discrete group cohomology.** Every continuity condition
 is vacuous for a discrete group, so this identifies subquotients of the same function space.
 Layer 4 uses it at every finite level. -/
 noncomputable def explicitH1IsoGroupCohomology :
-    H1 G M ≃+ groupCohomology (Rep.ofDistribMulAction ℤ G M) 1 :=
-  AddEquiv.ofBijective
-    (QuotientAddGroup.lift _
-      ((groupCohomology.H1π (Rep.ofDistribMulAction ℤ G M)).hom.toAddMonoidHom.comp
-        (Z1AddEquivCocycles₁ G M).toAddMonoidHom)
-      fun z hz => (groupCohomology.H1π_eq_zero_iff _).2
-        ((mem_coboundaries₁_iff_mem_B1 z.1).2 (AddSubgroup.mem_addSubgroupOf.1 hz)))
-    ⟨(injective_iff_map_eq_zero _).2 fun x hx => by
-        induction x using QuotientAddGroup.induction_on with
-        | _ z =>
-          rw [QuotientAddGroup.eq_zero_iff, AddSubgroup.mem_addSubgroupOf]
-          exact (mem_coboundaries₁_iff_mem_B1 z.1).1 ((groupCohomology.H1π_eq_zero_iff _).1 hx),
-      fun y => by
-        induction y using groupCohomology.H1_induction_on with
-        | h c => exact ⟨((Z1AddEquivCocycles₁ G M).symm c : Z1 G M), rfl⟩⟩
+    H1 G M ≃+ groupCohomology (Rep.ofDistribMulAction ℤ G M) 1 := by
+  let φ := (groupCohomology.H1π (Rep.ofDistribMulAction ℤ G M)).hom.toAddMonoidHom.comp
+    (Z1AddEquivCocycles₁ G M).toAddMonoidHom
+  have hφ : Function.Surjective φ := fun y => by
+    induction y using groupCohomology.H1_induction_on with
+    | h c => exact ⟨((Z1AddEquivCocycles₁ G M).symm c : Z1 G M), rfl⟩
+  have hker : (B1 G M).addSubgroupOf (Z1 G M) = φ.ker := by
+    ext z
+    constructor
+    · exact fun hz => (groupCohomology.H1π_eq_zero_iff _).2
+        ((mem_coboundaries₁_iff_mem_B1 z.1).2 hz)
+    · exact fun hz => (mem_coboundaries₁_iff_mem_B1 z.1).1
+        ((groupCohomology.H1π_eq_zero_iff _).1 hz)
+  exact QuotientAddGroup.liftEquiv _ hφ hker
 
 @[simp]
-theorem explicitH1IsoGroupCohomology_apply (z : Z1 G M) :
+theorem explicitH1IsoGroupCohomology_mk (z : Z1 G M) :
     explicitH1IsoGroupCohomology G M (z : H1 G M) =
       groupCohomology.H1π _ (Z1AddEquivCocycles₁ G M z) :=
   (rfl)
 
 @[simp]
-theorem explicitH1IsoGroupCohomology_symm_apply
+theorem explicitH1IsoGroupCohomology_symm_H1π
     (c : cocycles₁ (Rep.ofDistribMulAction ℤ G M)) :
     (explicitH1IsoGroupCohomology G M).symm (groupCohomology.H1π _ c) =
       (((Z1AddEquivCocycles₁ G M).symm c : Z1 G M) : H1 G M) := by
-  rw [AddEquiv.symm_apply_eq, explicitH1IsoGroupCohomology_apply, AddEquiv.apply_symm_apply]
+  rw [AddEquiv.symm_apply_eq, explicitH1IsoGroupCohomology_mk, AddEquiv.apply_symm_apply]
 
 end ComparisonDegree1
 
-section ComparisonDegree2
+section NumeratorDegree2
 
 variable (G : Type) [Group G] [TopologicalSpace G] [DiscreteTopology G]
-  (M : Type) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  (M : Type v) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
   [DistribMulAction G M]
 
 /-- Degree `2`, on the numerators: the continuous `2`-cocycles are Mathlib's `2`-cocycles. -/
@@ -308,40 +314,47 @@ theorem Z2AddEquivCocycles₂_coe (z : Z2 G M) :
 theorem Z2AddEquivCocycles₂_symm_coe (c : cocycles₂ (Rep.ofDistribMulAction ℤ G M)) :
     (((Z2AddEquivCocycles₂ G M).symm c : Z2 G M) : G × G → M) = ⇑c := (rfl)
 
+end NumeratorDegree2
+
+section ComparisonDegree2
+
+variable (G : Type) [Group G] [TopologicalSpace G] [DiscreteTopology G]
+  (M : Type) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  [DistribMulAction G M]
+
 variable [ContinuousSMul G M]
 
 /-- **Layer 3, degree 2 against Mathlib's discrete group cohomology.** The denominator is where
 discreteness is used twice over: `B²` is the image of the *continuous* `1`-cochains, and over a
 discrete group those exhaust `G → M`. -/
 noncomputable def explicitH2IsoGroupCohomology :
-    H2 G M ≃+ groupCohomology (Rep.ofDistribMulAction ℤ G M) 2 :=
-  AddEquiv.ofBijective
-    (QuotientAddGroup.lift _
-      ((groupCohomology.H2π (Rep.ofDistribMulAction ℤ G M)).hom.toAddMonoidHom.comp
-        (Z2AddEquivCocycles₂ G M).toAddMonoidHom)
-      fun z hz => (groupCohomology.H2π_eq_zero_iff _).2
-        ((mem_coboundaries₂_iff_mem_B2 z.1).2 (AddSubgroup.mem_addSubgroupOf.1 hz)))
-    ⟨(injective_iff_map_eq_zero _).2 fun x hx => by
-        induction x using QuotientAddGroup.induction_on with
-        | _ z =>
-          rw [QuotientAddGroup.eq_zero_iff, AddSubgroup.mem_addSubgroupOf]
-          exact (mem_coboundaries₂_iff_mem_B2 z.1).1 ((groupCohomology.H2π_eq_zero_iff _).1 hx),
-      fun y => by
-        induction y using groupCohomology.H2_induction_on with
-        | h c => exact ⟨((Z2AddEquivCocycles₂ G M).symm c : Z2 G M), rfl⟩⟩
+    H2 G M ≃+ groupCohomology (Rep.ofDistribMulAction ℤ G M) 2 := by
+  let φ := (groupCohomology.H2π (Rep.ofDistribMulAction ℤ G M)).hom.toAddMonoidHom.comp
+    (Z2AddEquivCocycles₂ G M).toAddMonoidHom
+  have hφ : Function.Surjective φ := fun y => by
+    induction y using groupCohomology.H2_induction_on with
+    | h c => exact ⟨((Z2AddEquivCocycles₂ G M).symm c : Z2 G M), rfl⟩
+  have hker : (B2 G M).addSubgroupOf (Z2 G M) = φ.ker := by
+    ext z
+    constructor
+    · exact fun hz => (groupCohomology.H2π_eq_zero_iff _).2
+        ((mem_coboundaries₂_iff_mem_B2 z.1).2 hz)
+    · exact fun hz => (mem_coboundaries₂_iff_mem_B2 z.1).1
+        ((groupCohomology.H2π_eq_zero_iff _).1 hz)
+  exact QuotientAddGroup.liftEquiv _ hφ hker
 
 @[simp]
-theorem explicitH2IsoGroupCohomology_apply (z : Z2 G M) :
+theorem explicitH2IsoGroupCohomology_mk (z : Z2 G M) :
     explicitH2IsoGroupCohomology G M (z : H2 G M) =
       groupCohomology.H2π _ (Z2AddEquivCocycles₂ G M z) :=
   (rfl)
 
 @[simp]
-theorem explicitH2IsoGroupCohomology_symm_apply
+theorem explicitH2IsoGroupCohomology_symm_H2π
     (c : cocycles₂ (Rep.ofDistribMulAction ℤ G M)) :
     (explicitH2IsoGroupCohomology G M).symm (groupCohomology.H2π _ c) =
       (((Z2AddEquivCocycles₂ G M).symm c : Z2 G M) : H2 G M) := by
-  rw [AddEquiv.symm_apply_eq, explicitH2IsoGroupCohomology_apply, AddEquiv.apply_symm_apply]
+  rw [AddEquiv.symm_apply_eq, explicitH2IsoGroupCohomology_mk, AddEquiv.apply_symm_apply]
 
 end ComparisonDegree2
 

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/GroupCohomologyIso.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/GroupCohomologyIso.lean
@@ -1,0 +1,348 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RepresentationTheory.Homological.GroupCohomology.LowDegree
+public import TauCeti.RepresentationTheory.Homological.ContCohomology.LowDegree
+
+/-!
+# The explicit continuous complex of a discrete group is Mathlib's inhomogeneous complex
+
+For a group `G` carrying the *discrete* topology every continuity condition in the explicit
+low-degree complex of continuous cochains is vacuous, so that complex is literally Mathlib's
+complex of inhomogeneous cochains of the representation `Rep.ofDistribMulAction ℤ G M`. This file
+proves that, degree by degree, and concludes with the three additive isomorphisms
+
+```text
+H⁰(G, M) ≃+ H⁰_grp(G, M),   H¹(G, M) ≃+ H¹_grp(G, M),   H²(G, M) ≃+ H²_grp(G, M).
+```
+
+## Main definitions
+
+* `TauCeti.ContCohomology.explicitH0IsoGroupCohomology`,
+  `TauCeti.ContCohomology.explicitH1IsoGroupCohomology` and
+  `TauCeti.ContCohomology.explicitH2IsoGroupCohomology`: the three comparison isomorphisms.
+* `TauCeti.ContCohomology.H0AddEquivInvariants`,
+  `TauCeti.ContCohomology.Z1AddEquivCocycles₁` and
+  `TauCeti.ContCohomology.Z2AddEquivCocycles₂`: the underlying identifications of the numerators,
+  which is where the mathematical content sits; the two isomorphisms in degrees `1` and `2` are
+  the induced maps on the subquotients, and in degree `0` there is no denominator to divide by.
+
+Degree `0` needs no topological hypothesis whatever, and degree `1` needs discreteness only for
+the cocycles: `B¹` is the image of *all* of `M`, so it never sees a continuity condition. It is
+degree `2` where discreteness enters the denominator, `B²` being the image of the continuous
+`1`-cochains.
+
+## Main statements
+
+* `TauCeti.ContCohomology.C1_eq_top` and `TauCeti.ContCohomology.C2_eq_top`: over a discrete group
+  every cochain is continuous.
+* `TauCeti.ContCohomology.d0_eq_d₀₁`, `d1_eq_d₁₂` and `d2_eq_d₂₃`: the explicit differentials are
+  Mathlib's, on the nose.
+* `TauCeti.ContCohomology.mem_cocycles₁_iff_mem_Z1`,
+  `TauCeti.ContCohomology.mem_coboundaries₁_iff_mem_B1` and their degree-`2` and degree-`0`
+  counterparts: the dictionary between the two sets of cocycles and coboundaries.
+
+## Implementation notes
+
+The universes are pinned by the pin and not by the mathematics. Mathlib states its low-degree
+group cohomology for `{k G : Type u}`, so taking `k = ℤ` forces `G` into `Type 0` in every
+statement below that mentions a `Rep ℤ G`; and it states `groupCohomology` for `A : Rep.{u} k G`,
+which forces the coefficient module into that universe too. So the three comparison isomorphisms
+carry `G M : Type`, while the differentials and the four membership dictionaries — which mention
+`cocycles₁`, `cocycles₂`, `coboundaries₁` and `coboundaries₂`, whose universes constrain only `k`
+and `G` — keep `M` in an arbitrary universe. `C1_eq_top` and `C2_eq_top` mention nothing of
+Mathlib's theory and are fully polymorphic. When the pin drops these restrictions the binders
+here can simply be widened.
+
+The isomorphisms are built as `AddEquiv`s and not as isomorphisms in `ModuleCat ℤ`. The explicit
+`H¹` and `H²` are bare additive groups by construction, their inherited quotient topology being the
+wrong one; `TauCeti.ContCohomology.DiscreteH1` and `DiscreteH2` are the carriers used when a
+topology is wanted, and the comparison with the *canonical* continuous cohomology is where that
+choice matters. Against `groupCohomology` there is no topology on either side, so an additive
+isomorphism is the whole statement.
+
+`Rep.ofDistribMulAction ℤ G M` is Mathlib's translation of an unbundled `DistribMulAction` into
+`Rep ℤ G`; the `ℤ`-linearity of the comparison is automatic and is not restated, because the
+explicit complex is a complex of additive groups. Mathlib's `cocyclesOfIsCocycle₁`,
+`isCocycle₁_of_mem_cocycles₁` and their siblings prove the same dictionary as the four membership
+lemmas here, but they are stated for `{k G A : Type u}` — all three in one universe — so they are
+not reused; the proofs below go through `groupCohomology.mem_cocycles₁_iff` and
+`mem_cocycles₂_iff`, which carry no such constraint.
+
+This implements the "continuous against discrete" milestone of Layer 3 of the human-authored
+roadmap at `TauCetiRoadmap/ProfiniteCohomology/README.md`, whose `Suggested.lean` fixes the names
+`explicitH0IsoGroupCohomology`, `explicitH1IsoGroupCohomology` and `explicitH2IsoGroupCohomology`.
+
+## References
+
+* J. Neukirch, A. Schmidt, K. Wingberg, *Cohomology of Number Fields*, 2nd ed., Ch. I, §2: the
+  cohomology of a profinite group is computed by the complex of continuous cochains, which for a
+  discrete group is the abstract inhomogeneous complex.
+-/
+
+public section
+
+namespace TauCeti.ContCohomology
+
+universe u v
+
+open groupCohomology
+
+section DiscreteCochains
+
+variable (G : Type u) [TopologicalSpace G] [DiscreteTopology G]
+  (M : Type v) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+
+/-- Over a discrete group every `1`-cochain is continuous. -/
+theorem C1_eq_top : C1 G M = ⊤ :=
+  (AddSubgroup.eq_top_iff' _).2 fun _ => mem_C1_iff.2 continuous_of_discreteTopology
+
+/-- Over a discrete group every `2`-cochain is continuous: `G × G` is discrete too. -/
+theorem C2_eq_top : C2 G M = ⊤ :=
+  (AddSubgroup.eq_top_iff' _).2 fun _ => mem_C2_iff.2 continuous_of_discreteTopology
+
+end DiscreteCochains
+
+section Differentials
+
+variable (G : Type) [Group G] (M : Type v) [AddCommGroup M] [DistribMulAction G M]
+
+/-- The explicit degree-`0` differential is Mathlib's `d₀₁`. -/
+theorem d0_eq_d₀₁ (m : M) :
+    d0 G M m = (groupCohomology.d₀₁ (Rep.ofDistribMulAction ℤ G M)).hom m :=
+  funext fun g =>
+    (d0_apply m g).trans (d₀₁_hom_apply (A := Rep.ofDistribMulAction ℤ G M) m g).symm
+
+/-- The explicit degree-`1` differential is Mathlib's `d₁₂`. -/
+theorem d1_eq_d₁₂ (f : G → M) :
+    d1 G M f = (groupCohomology.d₁₂ (Rep.ofDistribMulAction ℤ G M)).hom f :=
+  funext fun q =>
+    (d1_apply f q.1 q.2).trans (d₁₂_hom_apply (A := Rep.ofDistribMulAction ℤ G M) f q).symm
+
+/-- The explicit degree-`2` differential is Mathlib's `d₂₃`. -/
+theorem d2_eq_d₂₃ (f : G × G → M) :
+    d2 G M f = (groupCohomology.d₂₃ (Rep.ofDistribMulAction ℤ G M)).hom f :=
+  funext fun q =>
+    (d2_apply f q.1 q.2.1 q.2.2).trans
+      (d₂₃_hom_apply (A := Rep.ofDistribMulAction ℤ G M) f q).symm
+
+end Differentials
+
+section Dictionary
+
+variable {G : Type} [Group G] [TopologicalSpace G] [DiscreteTopology G]
+  {M : Type v} [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  [DistribMulAction G M]
+
+omit [TopologicalSpace G] [DiscreteTopology G] [TopologicalSpace M] [IsTopologicalAddGroup M] in
+/-- Degree `0`: the invariants of the induced representation are the explicit `H⁰ = M^G`. -/
+theorem mem_invariants_iff_mem_H0 (m : M) :
+    m ∈ (Rep.ofDistribMulAction ℤ G M).ρ.invariants ↔ m ∈ H0 G M :=
+  ⟨fun h => (FixedPoints.mem_addSubgroup G M m).2 fun g => h g,
+    fun h g => (FixedPoints.mem_addSubgroup G M m).1 h g⟩
+
+/-- Degree `1`, cocycles: over a discrete group the continuity half of `Z¹` is free, so the
+continuous `1`-cocycles are Mathlib's `1`-cocycles. -/
+theorem mem_cocycles₁_iff_mem_Z1 (f : G → M) :
+    f ∈ cocycles₁ (Rep.ofDistribMulAction ℤ G M) ↔ f ∈ Z1 G M :=
+  ⟨fun h => mem_Z1_iff.2 ⟨continuous_of_discreteTopology,
+      fun g h' => (mem_cocycles₁_iff (A := Rep.ofDistribMulAction ℤ G M) f).1 h g h'⟩,
+    fun h => (mem_cocycles₁_iff (A := Rep.ofDistribMulAction ℤ G M) f).2
+      fun g h' => (mem_Z1_iff.1 h).2 g h'⟩
+
+omit [TopologicalSpace G] [DiscreteTopology G] [TopologicalSpace M] [IsTopologicalAddGroup M] in
+/-- Degree `1`, coboundaries: `B¹` carries no continuity condition on its primitive, so the two
+definitions agree over any topological group; discreteness is not used. -/
+theorem mem_coboundaries₁_iff_mem_B1 (f : G → M) :
+    f ∈ coboundaries₁ (Rep.ofDistribMulAction ℤ G M) ↔ f ∈ B1 G M :=
+  ⟨fun ⟨m, hm⟩ => mem_B1_iff.2 ⟨m, fun g => congrFun hm g⟩,
+    fun h => (mem_B1_iff.1 h).elim fun m hm => ⟨m, funext hm⟩⟩
+
+/-- Degree `2`, cocycles: as in degree `1`, over a discrete group the continuity half of `Z²` is
+free, `G × G` being discrete as well. -/
+theorem mem_cocycles₂_iff_mem_Z2 (f : G × G → M) :
+    f ∈ cocycles₂ (Rep.ofDistribMulAction ℤ G M) ↔ f ∈ Z2 G M :=
+  ⟨fun h => mem_Z2_iff.2 ⟨continuous_of_discreteTopology,
+      fun g h' j => (mem_cocycles₂_iff (A := Rep.ofDistribMulAction ℤ G M) f).1 h g h' j⟩,
+    fun h => (mem_cocycles₂_iff (A := Rep.ofDistribMulAction ℤ G M) f).2
+      fun g h' j => (mem_Z2_iff.1 h).2 g h' j⟩
+
+/-- Degree `2`, coboundaries. Here discreteness *is* used: `B²` is by definition the image of the
+**continuous** `1`-cochains, and over a discrete group those are all of them. -/
+theorem mem_coboundaries₂_iff_mem_B2 (f : G × G → M) :
+    f ∈ coboundaries₂ (Rep.ofDistribMulAction ℤ G M) ↔ f ∈ B2 G M :=
+  ⟨fun ⟨c, hc⟩ => mem_B2_iff'.2 ⟨c, continuous_of_discreteTopology,
+      fun g h => congrFun hc (g, h)⟩,
+    fun h => (mem_B2_iff'.1 h).elim fun c hc => ⟨c, funext fun p => hc.2 p.1 p.2⟩⟩
+
+end Dictionary
+
+section ComparisonDegree0
+
+/-! Degree `0` is the one degree where the comparison needs no hypothesis on the topology at all:
+both sides are the invariants, and continuity constrains no `0`-cochain. -/
+
+variable (G : Type) [Group G] (M : Type) [AddCommGroup M] [DistribMulAction G M]
+
+/-- Degree `0`, on the carriers: the explicit `H⁰(G, M) = M^G` is the submodule of invariants of
+the induced representation. -/
+def H0AddEquivInvariants : H0 G M ≃+ (Rep.ofDistribMulAction ℤ G M).ρ.invariants where
+  toFun m := ⟨m.1, (mem_invariants_iff_mem_H0 m.1).2 m.2⟩
+  invFun m := ⟨m.1, (mem_invariants_iff_mem_H0 (G := G) (M := M) m.1).1 m.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+
+@[simp]
+theorem H0AddEquivInvariants_val (m : H0 G M) : (H0AddEquivInvariants G M m).1 = m.1 := (rfl)
+
+@[simp]
+theorem H0AddEquivInvariants_symm_val (m : (Rep.ofDistribMulAction ℤ G M).ρ.invariants) :
+    ((H0AddEquivInvariants G M).symm m).1 = m.1 := (rfl)
+
+/-- **Layer 3, degree 0 against Mathlib's discrete group cohomology.** The explicit `H⁰(G, M)` is
+Mathlib's `H⁰` of the representation attached to the action. -/
+noncomputable def explicitH0IsoGroupCohomology :
+    H0 G M ≃+ groupCohomology (Rep.ofDistribMulAction ℤ G M) 0 :=
+  (H0AddEquivInvariants G M).trans
+    (groupCohomology.H0Iso (Rep.ofDistribMulAction ℤ G M)).toLinearEquiv.symm.toAddEquiv
+
+@[simp]
+theorem explicitH0IsoGroupCohomology_apply (m : H0 G M) :
+    explicitH0IsoGroupCohomology G M m =
+      (groupCohomology.H0Iso (Rep.ofDistribMulAction ℤ G M)).inv (H0AddEquivInvariants G M m) :=
+  (rfl)
+
+@[simp]
+theorem explicitH0IsoGroupCohomology_symm_apply
+    (x : groupCohomology (Rep.ofDistribMulAction ℤ G M) 0) :
+    (explicitH0IsoGroupCohomology G M).symm x =
+      (H0AddEquivInvariants G M).symm
+        ((groupCohomology.H0Iso (Rep.ofDistribMulAction ℤ G M)).hom x) :=
+  (rfl)
+
+end ComparisonDegree0
+
+section ComparisonDegree1
+
+variable (G : Type) [Group G] [TopologicalSpace G] [DiscreteTopology G]
+  (M : Type) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  [DistribMulAction G M]
+
+/-- Degree `1`, on the numerators: the continuous `1`-cocycles are Mathlib's `1`-cocycles. -/
+def Z1AddEquivCocycles₁ : Z1 G M ≃+ cocycles₁ (Rep.ofDistribMulAction ℤ G M) where
+  toFun z := ⟨z.1, (mem_cocycles₁_iff_mem_Z1 z.1).2 z.2⟩
+  invFun c := ⟨c.1, (mem_cocycles₁_iff_mem_Z1 (G := G) (M := M) c.1).1 c.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+
+@[simp]
+theorem Z1AddEquivCocycles₁_coe (z : Z1 G M) :
+    ⇑(Z1AddEquivCocycles₁ G M z) = (z : G → M) := (rfl)
+
+@[simp]
+theorem Z1AddEquivCocycles₁_symm_coe (c : cocycles₁ (Rep.ofDistribMulAction ℤ G M)) :
+    (((Z1AddEquivCocycles₁ G M).symm c : Z1 G M) : G → M) = ⇑c := (rfl)
+
+variable [ContinuousSMul G M]
+
+/-- **Layer 3, degree 1 against Mathlib's discrete group cohomology.** Every continuity condition
+is vacuous for a discrete group, so this identifies subquotients of the same function space.
+Layer 4 uses it at every finite level. -/
+noncomputable def explicitH1IsoGroupCohomology :
+    H1 G M ≃+ groupCohomology (Rep.ofDistribMulAction ℤ G M) 1 :=
+  AddEquiv.ofBijective
+    (QuotientAddGroup.lift _
+      ((groupCohomology.H1π (Rep.ofDistribMulAction ℤ G M)).hom.toAddMonoidHom.comp
+        (Z1AddEquivCocycles₁ G M).toAddMonoidHom)
+      fun z hz => (groupCohomology.H1π_eq_zero_iff _).2
+        ((mem_coboundaries₁_iff_mem_B1 z.1).2 (AddSubgroup.mem_addSubgroupOf.1 hz)))
+    ⟨(injective_iff_map_eq_zero _).2 fun x hx => by
+        induction x using QuotientAddGroup.induction_on with
+        | _ z =>
+          rw [QuotientAddGroup.eq_zero_iff, AddSubgroup.mem_addSubgroupOf]
+          exact (mem_coboundaries₁_iff_mem_B1 z.1).1 ((groupCohomology.H1π_eq_zero_iff _).1 hx),
+      fun y => by
+        induction y using groupCohomology.H1_induction_on with
+        | h c => exact ⟨((Z1AddEquivCocycles₁ G M).symm c : Z1 G M), rfl⟩⟩
+
+@[simp]
+theorem explicitH1IsoGroupCohomology_apply (z : Z1 G M) :
+    explicitH1IsoGroupCohomology G M (z : H1 G M) =
+      groupCohomology.H1π _ (Z1AddEquivCocycles₁ G M z) :=
+  (rfl)
+
+@[simp]
+theorem explicitH1IsoGroupCohomology_symm_apply
+    (c : cocycles₁ (Rep.ofDistribMulAction ℤ G M)) :
+    (explicitH1IsoGroupCohomology G M).symm (groupCohomology.H1π _ c) =
+      (((Z1AddEquivCocycles₁ G M).symm c : Z1 G M) : H1 G M) := by
+  rw [AddEquiv.symm_apply_eq, explicitH1IsoGroupCohomology_apply, AddEquiv.apply_symm_apply]
+
+end ComparisonDegree1
+
+section ComparisonDegree2
+
+variable (G : Type) [Group G] [TopologicalSpace G] [DiscreteTopology G]
+  (M : Type) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  [DistribMulAction G M]
+
+/-- Degree `2`, on the numerators: the continuous `2`-cocycles are Mathlib's `2`-cocycles. -/
+def Z2AddEquivCocycles₂ : Z2 G M ≃+ cocycles₂ (Rep.ofDistribMulAction ℤ G M) where
+  toFun z := ⟨z.1, (mem_cocycles₂_iff_mem_Z2 z.1).2 z.2⟩
+  invFun c := ⟨c.1, (mem_cocycles₂_iff_mem_Z2 (G := G) (M := M) c.1).1 c.2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+
+@[simp]
+theorem Z2AddEquivCocycles₂_coe (z : Z2 G M) :
+    ⇑(Z2AddEquivCocycles₂ G M z) = (z : G × G → M) := (rfl)
+
+@[simp]
+theorem Z2AddEquivCocycles₂_symm_coe (c : cocycles₂ (Rep.ofDistribMulAction ℤ G M)) :
+    (((Z2AddEquivCocycles₂ G M).symm c : Z2 G M) : G × G → M) = ⇑c := (rfl)
+
+variable [ContinuousSMul G M]
+
+/-- **Layer 3, degree 2 against Mathlib's discrete group cohomology.** The denominator is where
+discreteness is used twice over: `B²` is the image of the *continuous* `1`-cochains, and over a
+discrete group those exhaust `G → M`. -/
+noncomputable def explicitH2IsoGroupCohomology :
+    H2 G M ≃+ groupCohomology (Rep.ofDistribMulAction ℤ G M) 2 :=
+  AddEquiv.ofBijective
+    (QuotientAddGroup.lift _
+      ((groupCohomology.H2π (Rep.ofDistribMulAction ℤ G M)).hom.toAddMonoidHom.comp
+        (Z2AddEquivCocycles₂ G M).toAddMonoidHom)
+      fun z hz => (groupCohomology.H2π_eq_zero_iff _).2
+        ((mem_coboundaries₂_iff_mem_B2 z.1).2 (AddSubgroup.mem_addSubgroupOf.1 hz)))
+    ⟨(injective_iff_map_eq_zero _).2 fun x hx => by
+        induction x using QuotientAddGroup.induction_on with
+        | _ z =>
+          rw [QuotientAddGroup.eq_zero_iff, AddSubgroup.mem_addSubgroupOf]
+          exact (mem_coboundaries₂_iff_mem_B2 z.1).1 ((groupCohomology.H2π_eq_zero_iff _).1 hx),
+      fun y => by
+        induction y using groupCohomology.H2_induction_on with
+        | h c => exact ⟨((Z2AddEquivCocycles₂ G M).symm c : Z2 G M), rfl⟩⟩
+
+@[simp]
+theorem explicitH2IsoGroupCohomology_apply (z : Z2 G M) :
+    explicitH2IsoGroupCohomology G M (z : H2 G M) =
+      groupCohomology.H2π _ (Z2AddEquivCocycles₂ G M z) :=
+  (rfl)
+
+@[simp]
+theorem explicitH2IsoGroupCohomology_symm_apply
+    (c : cocycles₂ (Rep.ofDistribMulAction ℤ G M)) :
+    (explicitH2IsoGroupCohomology G M).symm (groupCohomology.H2π _ c) =
+      (((Z2AddEquivCocycles₂ G M).symm c : Z2 G M) : H2 G M) := by
+  rw [AddEquiv.symm_apply_eq, explicitH2IsoGroupCohomology_apply, AddEquiv.apply_symm_apply]
+
+end ComparisonDegree2
+
+end TauCeti.ContCohomology

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/GroupCohomologyIso.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/GroupCohomologyIso.lean
@@ -48,14 +48,13 @@ degree `2` where discreteness enters the denominator, `B²` being the image of t
 
 ## Implementation notes
 
-The universes are pinned by the pin and not by the mathematics. Mathlib states its low-degree
-group cohomology for `{k G : Type u}`, so taking `k = ℤ` forces `G` into `Type 0` in every
-statement below that mentions a `Rep ℤ G`; and it states `groupCohomology` for `A : Rep.{u} k G`,
-which forces the coefficient module into that universe too. So the three comparison isomorphisms
-carry `G M : Type`, while the differentials, membership dictionaries, and numerator equivalences
-keep every universe not constrained by Mathlib's representation API arbitrary. `C1_eq_top` and
-`C2_eq_top` mention nothing of Mathlib's theory and are fully polymorphic. When the pin drops these
-restrictions the binders here can simply be widened.
+The universes are pinned by the pin and not by the mathematics. Mathlib's low-degree
+`groupCohomology` comparison API forces the group and coefficient module into `Type 0` when the
+coefficient ring is `ℤ`. Thus the three final comparison isomorphisms carry `G M : Type`, while the
+differentials, membership dictionaries, and numerator equivalences keep every universe not
+constrained by Mathlib's representation API arbitrary. `C1_eq_top` and `C2_eq_top` mention nothing
+of Mathlib's theory and are fully polymorphic. When the pin drops these restrictions the binders
+here can simply be widened.
 
 The isomorphisms are built as `AddEquiv`s and not as isomorphisms in `ModuleCat ℤ`. The explicit
 `H¹` and `H²` are bare additive groups by construction, their inherited quotient topology being the

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/LowDegree.lean
@@ -136,10 +136,12 @@ theorem mem_C1_iff {f : G → M} : f ∈ C1 G M ↔ Continuous f := (Iff.rfl)
 theorem mem_C2_iff {f : G × G → M} : f ∈ C2 G M ↔ Continuous f := mem_C1_iff
 
 /-- Over a discrete group every `1`-cochain is continuous. -/
+@[simp]
 theorem C1_eq_top [DiscreteTopology G] : C1 G M = ⊤ :=
   (AddSubgroup.eq_top_iff' _).2 fun _ => mem_C1_iff.2 continuous_of_discreteTopology
 
 /-- Over a discrete group every `2`-cochain is continuous: `G × G` is discrete too. -/
+@[simp]
 theorem C2_eq_top [DiscreteTopology G] : C2 G M = ⊤ := C1_eq_top (G := G × G) (M := M)
 
 end Cochains

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/LowDegree.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/LowDegree.lean
@@ -135,6 +135,13 @@ theorem mem_C1_iff {f : G → M} : f ∈ C1 G M ↔ Continuous f := (Iff.rfl)
 @[simp]
 theorem mem_C2_iff {f : G × G → M} : f ∈ C2 G M ↔ Continuous f := mem_C1_iff
 
+/-- Over a discrete group every `1`-cochain is continuous. -/
+theorem C1_eq_top [DiscreteTopology G] : C1 G M = ⊤ :=
+  (AddSubgroup.eq_top_iff' _).2 fun _ => mem_C1_iff.2 continuous_of_discreteTopology
+
+/-- Over a discrete group every `2`-cochain is continuous: `G × G` is discrete too. -/
+theorem C2_eq_top [DiscreteTopology G] : C2 G M = ⊤ := C1_eq_top (G := G × G) (M := M)
+
 end Cochains
 
 section Differentials


### PR DESCRIPTION
This PR proves that over a group carrying the *discrete* topology the explicit low-degree complex of continuous cochains is Mathlib's complex of inhomogeneous cochains, and concludes with the three additive isomorphisms `explicitH0IsoGroupCohomology`, `explicitH1IsoGroupCohomology` and `explicitH2IsoGroupCohomology` between `TauCeti.ContCohomology.H0/H1/H2` and `groupCohomology (Rep.ofDistribMulAction ℤ G M) n`. It targets the "Continuous against discrete" milestone of Layer 3 of `TauCetiRoadmap/ProfiniteCohomology/README.md`, which names exactly those three declarations and records them with `sorry` in `Suggested.lean`; Layer 4 consumes them at every finite level of the tower `U ↦ Hⁱ(G ⧸ U, M^U)`, and Layer 3 is what keeps the explicit complex a second *description* of the canonical theory rather than a second theory.

This is the effective next step because Layer 2's "the complex" milestone landed in #3930, so `C1`, `C2`, `Z1`, `Z2`, `B1`, `B2`, `H0`, `H1`, `H2` are all on `main`, and this comparison depends on the complex alone, not on Layer 2's functoriality (in flight for degree 1 as #4422). Nothing here overlaps #4422, #4043 or #4034: those add the compatible-pair pullback, the smooth-discrete dictionary and the internal hom, none of which is mentioned below.

The single new 348-line module `TauCeti/RepresentationTheory/Homological/ContCohomology/GroupCohomologyIso.lean` supplies, in order: `C1_eq_top` and `C2_eq_top`, that over a discrete group every cochain is continuous; `d0_eq_d₀₁`, `d1_eq_d₁₂` and `d2_eq_d₂₃`, that the explicit differentials are Mathlib's `d₀₁`, `d₁₂` and `d₂₃` on the nose; the four membership dictionaries `mem_invariants_iff_mem_H0`, `mem_cocycles₁_iff_mem_Z1`, `mem_coboundaries₁_iff_mem_B1`, `mem_cocycles₂_iff_mem_Z2` and `mem_coboundaries₂_iff_mem_B2`; the identifications of the numerators `H0AddEquivInvariants`, `Z1AddEquivCocycles₁` and `Z2AddEquivCocycles₂` with their `coe` and `symm_coe` lemmas; and the three comparison isomorphisms with their `apply` and `symm_apply` lemmas. The hypotheses are the ones actually used and no more: degree `0` needs no topological hypothesis at all, degree `1` needs discreteness only for the cocycles because `B¹` is the image of all of `M` and carries no continuity condition on its primitive, and it is degree `2` where discreteness enters the denominator, `B²` being by definition the image of the *continuous* `1`-cochains.

Mathlib's `cocyclesOfIsCocycle₁`, `isCocycle₁_of_mem_cocycles₁` and their five siblings prove the same dictionary, and they are named in the module docstring rather than reused: they are stated for `{k G A : Type u}`, all three in one universe, whereas the proofs here go through `groupCohomology.mem_cocycles₁_iff` and `mem_cocycles₂_iff` and so keep the coefficient module in an arbitrary universe. The remaining universe pins — `G M : Type` on the three isomorphisms — are the pin's and not the mathematics': Mathlib states low-degree group cohomology for `{k G : Type u}` and `groupCohomology` for `A : Rep.{u} k G`, so `k = ℤ` forces both. The module docstring says so and says that the binders widen when the pin does. No Mathlib infrastructure is vendored.

After this PR, Layer 3 still needs its second half — the comparison of the explicit complex with the *canonical* continuous cohomology for profinite `G` through the compact-open exponential law, stated in `TopModuleCat ℤ` against `DiscreteH1`/`DiscreteH2` — together with the four transport lemmas `explicitIso_map`, `explicitIso_res`, `explicitIso_infl` and `explicitIso_coeffMap`, each of which needs a Layer 2 operation that is not yet on `main`.

Roadmap: ProfiniteCohomology

<!--tauceti-target:v1 {"focus":"ProfiniteCohomology","id":"continuous-against-discrete"}-->

🤖 Prepared with Claude Code
