### PR TITLE
feat(Huber): the restricted-series functor is exact in the middle

### DIFF
--- a/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean
@@ -12,6 +12,7 @@ import Mathlib.Data.Finsupp.Encodable
 import TauCeti.Topology.LiftTendstoCofinite
 import TauCeti.Order.Filter.ZeroAndBoundedAtFilter
 import TauCeti.RingTheory.Huber.Bounded
+import TauCeti.Topology.Algebra.Module.Submodule
 
 /-!
 # Restricted Power Series
@@ -50,6 +51,9 @@ where the convergent/restricted power series ring is (5.6.1) in §5.6.
   coefficientwise, so the functor preserves injectivity. Together with
   `restrictedMvPowerSeriesSubmoduleMap_surjective` these are the exactness inputs Remark 8.29
   needs at the two ends.
+* `restrictedMvPowerSeriesSubmoduleMap_range_eq_ker`: and the input it needs **in the middle** —
+  for `range u = ker p` with `u` open onto its image, the induced row is exact at `N⟨T₁, …, Tₖ⟩`.
+  With the two above, Remark 8.29's row is exact everywhere.
 * `restrictedMvPowerSeriesSubmodule_ext`: coefficientwise agreement is equality in `M⟨T₁, …, Tₖ⟩`
   — the elimination rule `MvPowerSeries.ext` cannot supply at module coefficients.
 * `coeff_coe_smul_restrictedMvPowerSeriesSubring`: the scalar action on `A⟨T₁, …, Tₖ⟩` is
@@ -115,6 +119,19 @@ submodule at all, so the subring is the only object it has to identify. The same
 `coeff_coe_smul_restrictedMvPowerSeriesSubring`, which computes an action the source never
 states.
 
+**AINTLIB's mathematics, generalised in statement and rebuilt on this file's API.**
+`restrictedMvPowerSeriesSubmoduleMap_range_eq_ker` is AINTLIB's `muMap_middle_exact`
+(`Adic spaces/TateAlgebra.lean:1855`), Wedhorn's own middle-exactness step, and the argument is
+that one: corestrict `u` to its image, lift the coefficients of a series killed by `p` along the
+corestriction, compose back. Three things differ. The source fixes the row to `Aⁿ → Aᵐ → M` and
+carries Wedhorn's bundle — `[CompleteSpace A] [IsTateRing A] [IsNoetherianRing A]` — so as to
+*derive* strictness of `u` from its own `wedhorn_6_18_open_onto_image`; the row here is between
+arbitrary topological modules with strictness hypothesised, so none of that bundle appears. The
+source works at ring coefficients through its own `restrictedModule` and lifts with
+`restrictedModule_map_surjective`; both come from this file's module-coefficient functor here.
+And the continuity of the action on `↥(range u)`, which the source establishes inline, is
+`Submodule.continuousConstSMul`.
+
 The name `isRestricted_iff` needs care: the port introduced it for the `coeff`-form unfolding
 lemma, which is now `isRestricted_iff_coeff`. The statement the name carries here — unfolding
 through `Filter.ZeroAtFilter` at coefficients asking only for a `0` and a topology — is new.
@@ -172,9 +189,10 @@ arbitrary finite sums of elements in an open additive subgroup remain in the sub
 
 ## References
 
-* [Wedhorn, *Adic Spaces*][wedhorn_adic], (5.6.1) in §5.6.
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], (5.6.1) in §5.6, and Remark 8.29.
 * [AINTLIB](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
-  `projects/AdicSpaces/Adic spaces/RestrictedPowerSeries.lean`.
+  `projects/AdicSpaces/Adic spaces/RestrictedPowerSeries.lean` and, at commit `37bbdaeb9`,
+  `projects/AdicSpaces/Adic spaces/TateAlgebra.lean`.
 -/
 
 public section
@@ -662,6 +680,65 @@ theorem restrictedMvPowerSeriesSubmoduleMap_injective {k : ℕ} {A M N : Type*} 
   restrictedMvPowerSeriesSubmodule_ext fun s ↦ hinj <| by
     rw [← coeff_restrictedMvPowerSeriesSubmoduleMap φ hφ f s,
       ← coeff_restrictedMvPowerSeriesSubmoduleMap φ hφ g s, h]
+
+/-- **`M ↦ M⟨T₁, …, Tₖ⟩` is exact in the middle.** For `A`-linear maps `u : M →ₗ[A] N` and
+`p : N →ₗ[A] P`, each continuous at `0`, with `range u = ker p`, the induced row
+`M⟨T₁, …, Tₖ⟩ → N⟨T₁, …, Tₖ⟩ → P⟨T₁, …, Tₖ⟩` is exact at the middle — provided `u` is **strict**,
+carrying the neighbourhoods of `0` onto neighbourhoods of `0` in its image, and `M` has a
+countable neighbourhood basis at `0`.
+
+This is the middle-exactness step of Wedhorn's Remark 8.29: applied to a presentation
+`Aⁿ →u Aᵐ →p M → 0` it makes the restricted-series row exact at `Aᵐ⟨T₁, …, Tₖ⟩`, which is the
+input the injective half of that remark runs a diagram chase against.
+`restrictedMvPowerSeriesSubmoduleMap_injective` and
+`restrictedMvPowerSeriesSubmoduleMap_surjective` are the same statement at the two ends.
+
+Strictness does not follow from continuity and is not derived here. It is Wedhorn's
+Proposition 6.18(2) that supplies it in the setting Remark 8.29 is stated in — over a complete
+noetherian Tate ring a linear map of finitely generated modules is open onto its image — and that
+derivation needs hypotheses this file does not carry. So strictness is taken as a hypothesis, in
+the filter-inequality form `restrictedMvPowerSeriesSubmoduleMap_surjective` also takes it: a
+caller holding `h : IsOpenMap u.rangeRestrict` passes `map_zero _ ▸ h.nhds_le 0`.
+
+Only `u` need be strict. Nothing is asked of `p` beyond continuity at `0`, and nothing at all of
+`N` or `P` beyond what `N⟨T₁, …, Tₖ⟩` and `P⟨T₁, …, Tₖ⟩` need to exist: exactness at the middle
+lifts the coefficients of a series killed by `p` along `u`, and the countable basis that lifting
+consumes is a property of the source.
+
+Stated as the equality of submodules rather than through Mathlib's `Function.Exact`, whose file
+this one does not import; `LinearMap.exact_iff` converts in either direction where it is wanted. -/
+theorem restrictedMvPowerSeriesSubmoduleMap_range_eq_ker {k : ℕ} {A M N P : Type*} [Semiring A]
+    [AddCommMonoid M] [TopologicalSpace M] [Module A M] [ContinuousAdd M] [ContinuousConstSMul A M]
+    [(nhds (0 : M)).IsCountablyGenerated] [AddCommMonoid N] [TopologicalSpace N] [Module A N]
+    [ContinuousAdd N] [ContinuousConstSMul A N] [AddCommMonoid P] [TopologicalSpace P] [Module A P]
+    [ContinuousAdd P] [ContinuousConstSMul A P] (u : M →ₗ[A] N) (hu : ContinuousAt u 0)
+    (p : N →ₗ[A] P) (hp : ContinuousAt p 0) (hexact : LinearMap.range u = LinearMap.ker p)
+    (hstrict : nhds (0 : LinearMap.range u) ≤ Filter.map u.rangeRestrict (nhds 0)) :
+    LinearMap.range (restrictedMvPowerSeriesSubmoduleMap (k := k) u hu) =
+      LinearMap.ker (restrictedMvPowerSeriesSubmoduleMap (k := k) p hp) := by
+  refine le_antisymm ?_ fun c hc ↦ ?_
+  · rintro _ ⟨b, rfl⟩
+    rw [LinearMap.mem_ker, restrictedMvPowerSeriesSubmoduleMap_eq_zero_iff]
+    intro s
+    rw [coeff_restrictedMvPowerSeriesSubmoduleMap]
+    exact LinearMap.mem_ker.mp (hexact ▸ LinearMap.mem_range_self u _)
+  · rw [LinearMap.mem_ker, restrictedMvPowerSeriesSubmoduleMap_eq_zero_iff] at hc
+    have hcoef : ∀ s, ((c : MvPowerSeries (Fin k) N) : (Fin k →₀ ℕ) → N) s ∈ LinearMap.range u :=
+      fun s ↦ hexact ▸ LinearMap.mem_ker.mpr (hc s)
+    -- The coefficients of `c` lie in `range u`, so `c` is a restricted series over `↥(range u)`
+    -- — restrictedness transfers because the subspace topology is induced. Lift that series
+    -- along the corestriction of `u`, surjective by construction and strict by hypothesis.
+    obtain ⟨b, hb⟩ := restrictedMvPowerSeriesSubmoduleMap_surjective (k := k) u.rangeRestrict
+      (Topology.IsInducing.subtypeVal.continuousAt_iff.mpr hu)
+      (LinearMap.surjective_rangeRestrict u) hstrict
+      ⟨show MvPowerSeries (Fin k) ↥(LinearMap.range u) from fun s ↦ ⟨_, hcoef s⟩,
+        mem_restrictedMvPowerSeriesSubmodule.mpr (isRestricted_iff.mpr
+          (tendsto_subtype_rng.mpr (isRestricted_iff.mp c.2)))⟩
+    -- `u = (range u).subtype ∘ u.rangeRestrict`, so reading `hb` coefficientwise and forgetting
+    -- the membership proof is already the required equality.
+    refine ⟨b, restrictedMvPowerSeriesSubmodule_ext fun s ↦ ?_⟩
+    rw [coeff_restrictedMvPowerSeriesSubmoduleMap]
+    exact congrArg Subtype.val (congrFun (congrArg Subtype.val hb) s)
 
 /-- **`A⟨T₁, …, Tₖ⟩` as a submodule over itself**: at `M = A` the subring and the submodule cut
 out the same series, so they are `A`-linearly isomorphic.


### PR DESCRIPTION
Middle exactness for the restricted-power-series functor. For `A`-linear maps `u : M →ₗ[A] N` and
`p : N →ₗ[A] P`, each continuous at `0`, with `range u = ker p`, the induced row

    M⟨T₁, …, Tₖ⟩ → N⟨T₁, …, Tₖ⟩ → P⟨T₁, …, Tₖ⟩

is exact at the middle — provided `u` is strict, and `M` has a countable neighbourhood basis at `0`.

One theorem, in `TauCeti/RingTheory/Huber/Restricted/PowerSeries.lean`, beside the two it completes:

* `TauCeti.Huber.restrictedMvPowerSeriesSubmoduleMap_range_eq_ker`

### What this closes

`main` already has the functor's behaviour at the two *ends* of an exact row —
`restrictedMvPowerSeriesSubmoduleMap_injective` on the left, `..._surjective` on the right — and
that file's docstring calls them, in terms, "the exactness inputs Remark 8.29 needs at the two
ends". The middle was missing, and it is the step Wedhorn's Remark 8.29 actually turns on: pushing
a presentation `Aⁿ →u Aᵐ →p M → 0` through the functor gives exactness at the ends for formal
reasons, and exactness at `Aᵐ⟨T⟩` only because `u` is open onto its image.

Its consumer is Remark 8.29 proper — injectivity of `M ⊗[A] A⟨T⟩ → M⟨T⟩` — which runs a diagram
chase against this row. `restrictedMvPowerSeriesBaseChange_surjective_of_presentation` (#3994) is
the other half of that chase and is already on `main`.

### What this is not

It is not Remark 8.29, and the docstring says so at length. Wedhorn states the remark over a
**complete noetherian Tate** ring, where Proposition 6.18(2) *derives* strictness of `u` from
finite generation. Here strictness is a hypothesis, in exactly the filter-inequality form
`restrictedMvPowerSeriesSubmoduleMap_surjective` next door already takes it
(`𝓝 0 ≤ Filter.map u.rangeRestrict (𝓝 0)`), so the two compose with no translation step; a caller
holding `h : IsOpenMap u.rangeRestrict` passes `map_zero _ ▸ h.nhds_le 0`.

That is this file's established design rather than a shortcut: its neighbour
`restrictedMvPowerSeriesBaseChange_surjective_of_presentation` is documented as taking "a strict
presentation as a hypothesis and so carries no Tate, noetherian, completeness or module-topology
assumption at all". Discharging strictness in the noetherian module-finite setting is the job of
`isStrictMap_of_isNoetherianRing_of_module_finite` (#4465); assembling the two, with
`continuous_of_module_finite` (#4462), into Wedhorn's own statement is the next brick. This PR
depends on neither and branches off `main`.

Nothing is asked of `p` beyond continuity at `0`, and nothing of `N` or `P` beyond what
`N⟨T₁, …, Tₖ⟩` and `P⟨T₁, …, Tₖ⟩` need in order to exist.

### Provenance

Adapted from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0) at commit `37bbdaeb9`,
`projects/AdicSpaces/Adic spaces/TateAlgebra.lean:1855`, `muMap_middle_exact`. The argument is
that one — corestrict `u` to its image, lift the coefficients of a series killed by `p` along the
corestriction, compose back. Three things differ, and the module docstring's Provenance section
records them: the source fixes the row to `Aⁿ → Aᵐ → M` and carries `[CompleteSpace A]
[IsTateRing A] [IsNoetherianRing A]` in order to derive strictness from its own
`wedhorn_6_18_open_onto_image`; it works at ring coefficients through its own `restrictedModule`
and lifts with `restrictedModule_map_surjective`, where both come from this file's
module-coefficient functor here; and the continuity of the action on `↥(range u)`, established
inline there, is `Submodule.continuousConstSMul` here.

### The one new import

`import TauCeti.Topology.Algebra.Module.Submodule` — private, proof-only; the statement mentions
nothing from it. It supplies `Submodule.continuousAdd` / `Submodule.continuousConstSMul` on
`↥(range u)`, which is what lets `↥(range u)⟨T₁, …, Tₖ⟩` be formed at all. That file's own
docstring already names `TauCeti.Huber.restrictedMvPowerSeriesSubmodule` as the consumer the
instance was written for, so this is the dependency it was added (#3963) to serve.

### Gates

- `lake build` of the changed module and both its direct importers
  (`Restricted.BaseChange`, `WeightedRestrictedSeries.Basic`) — exit 0
- `scripts/lint-style.sh` — exit 0, "all 3356 TauCeti source file(s) have conforming headers"
- `scripts/lint-dot-notation.py` — exit 0, 0 new
- `#print axioms TauCeti.Huber.restrictedMvPowerSeriesSubmoduleMap_range_eq_ker` →
  `[propext, Classical.choice, Quot.sound]`
- 0 sorries. `lake exe axioms` / `module-system` / `lint-env` need a full-library olean set, which
  the module-scoped build policy precludes locally; CI covers them.

Roadmap: AdicSpaces

Target: AdicSpaces README Layer 4.1 step 1 (Remark 8.29) — this is the middle-exactness step
itself, the one that #4462 (continuity) and #4465 (openness) are the inputs to.
