### PR TITLE
feat: add negative symplectic Chevalley relations

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/ChevalleyRelations.lean
@@ -165,8 +165,9 @@ theorem commutatorElement_differenceShortRootSubgroupPoints_negativeLongRootSubg
 
 /-- **The negative structure-constant-two Chevalley relation on algebra-valued points of
 `Sp₂ₘ`.** For distinct `i` and `j`, the commutator of the roots `eᵢ-eⱼ` and `-eᵢ-eⱼ` is
-the long-root point `x_{-2eⱼ}(-2ab)`. The inverse and square on the right are convolution
-operations in `𝔾ₐ(A)`, so they negate and double its parameter. -/
+the long-root point `x_{-2eⱼ}(-2ab)`. The inverse and square on the right are the inverse
+and multiplication of `Sp₂ₘ(A)`; since `negativeLongRootSubgroupPoints j` is a group
+homomorphism out of `𝔾ₐ(A)`, they correspond to negating and doubling the parameter. -/
 theorem commutatorElement_differenceShortRootSubgroupPoints_negativeSumShortRootSubgroupPoints
     (hij : i ≠ j)
     (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
@@ -203,14 +204,10 @@ theorem commutatorElement_differenceShortRootSubgroupPoints_negativeSumShortRoot
   calc
     (GLSymplecticFin.negativeLongRootTransvectionUnit j (c + c))⁻¹ =
         GLSymplecticFin.negativeLongRootTransvectionUnit j (-(c + c)) := by
-      apply Subtype.ext
-      change
-        ((GLSymplecticFin.negativeLongRootTransvectionUnit j (c + c) :
-          GLSymplecticFin m A) : GL (Fin (m + m)) A)⁻¹ =
-          (GLSymplecticFin.negativeLongRootTransvectionUnit j (-(c + c)) :
-            GL (Fin (m + m)) A)
-      rw [GLSymplecticFin.coe_negativeLongRootTransvectionUnit,
-        GLSymplecticFin.coe_negativeLongRootTransvectionUnit, transvectionUnit_inv]
+      simpa only [GLSymplecticFin.negativeLongRootTransvectionHom_apply,
+        toAdd_ofAdd, toAdd_inv] using
+        (map_inv (GLSymplecticFin.negativeLongRootTransvectionHom (R := A) j)
+          (Multiplicative.ofAdd (c + c))).symm
     _ = GLSymplecticFin.negativeLongRootTransvectionUnit j
           (-(2 * f.ofConv (SymmetricAlgebra.ι R R 1) *
             g.ofConv (SymmetricAlgebra.ι R R 1))) := by

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/ChevalleyRelations.lean
@@ -11,14 +11,23 @@ public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Chevall
 /-!
 # Chevalley relations for symplectic root subgroups
 
-This file lifts the two multiply-laced rank-two commutator relations from the standard
-symplectic matrices to the functor of points of `Sp₂ₘ`. For distinct `i` and `j`, they are
+This file lifts the four multiply-laced rank-two commutator relations from the standard
+symplectic matrices to the functor of points of `Sp₂ₘ`. For distinct `i` and `j`, they include
 
 ```text
 ⁅x_{eᵢ-eⱼ}(a), x_{2eⱼ}(b)⁆
   = x_{eᵢ+eⱼ}(ab) x_{2eᵢ}(a²b),
 ⁅x_{eᵢ-eⱼ}(a), x_{eᵢ+eⱼ}(b)⁆
   = x_{2eᵢ}(2ab).
+```
+
+The opposite root string gives
+
+```text
+⁅x_{eᵢ-eⱼ}(a), x_{-2eᵢ}(b)⁆
+  = x_{-eᵢ-eⱼ}(-ab) x_{-2eⱼ}(a²b),
+⁅x_{eᵢ-eⱼ}(a), x_{-eᵢ-eⱼ}(b)⁆
+  = x_{-2eⱼ}(-2ab).
 ```
 
 The parameters on the right are expressed using the algebra structure of the value ring. Thus
@@ -122,5 +131,91 @@ theorem commutatorElement_differenceShortRootSubgroupPoints_positiveSumShortRoot
   congr 1
   dsimp only [c]
   ring
+
+/-- **The negative multiply-laced Chevalley relation on algebra-valued points of `Sp₂ₘ`.**
+For distinct `i` and `j`, the commutator of the roots `eᵢ-eⱼ` and `-2eᵢ` is the product
+of the root subgroups for `-eᵢ-eⱼ` and `-2eⱼ`, with parameters `-ab` and `a²b`. -/
+theorem commutatorElement_differenceShortRootSubgroupPoints_negativeLongRootSubgroupPoints
+    (hij : i ≠ j)
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    ⁅shortRootSubgroupPoints .difference hij f, negativeLongRootSubgroupPoints i g⁆ =
+      shortRootSubgroupPoints .negativeSum hij
+          (AdditiveGroup.gaPointParamMul f g)⁻¹ *
+        negativeLongRootSubgroupPoints j
+          (AdditiveGroup.gaPointParamMul f (AdditiveGroup.gaPointParamMul f g)) := by
+  apply (pointsMulEquiv (R := R) (A := A) m).injective
+  rw [map_commutatorElement, map_mul, pointsMulEquiv_shortRootSubgroupPoints,
+    pointsMulEquiv_negativeLongRootSubgroupPoints,
+    pointsMulEquiv_shortRootSubgroupPoints,
+    pointsMulEquiv_negativeLongRootSubgroupPoints]
+  rw [GLSymplecticFin.ShortRootFamily.hom_difference,
+    GLSymplecticFin.differenceShortRootHom_apply,
+    GLSymplecticFin.ShortRootFamily.hom_negativeSum,
+    GLSymplecticFin.negativeSumShortRootHom_apply]
+  rw [AdditiveGroup.toAdd_gaPointsMulEquiv_inv,
+    AdditiveGroup.toAdd_gaPointsMulEquiv]
+  simp only [AdditiveGroup.toAdd_gaPointsMulEquiv,
+    AdditiveGroup.gaPointParamMul_apply_ι]
+  ring_nf
+  exact
+    GLSymplecticFin.commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit
+      hij
+      (f.ofConv (SymmetricAlgebra.ι R R 1))
+      (g.ofConv (SymmetricAlgebra.ι R R 1))
+
+/-- **The negative structure-constant-two Chevalley relation on algebra-valued points of
+`Sp₂ₘ`.** For distinct `i` and `j`, the commutator of the roots `eᵢ-eⱼ` and `-eᵢ-eⱼ` is
+the long-root point `x_{-2eⱼ}(-2ab)`. The inverse and square on the right are convolution
+operations in `𝔾ₐ(A)`, so they negate and double its parameter. -/
+theorem commutatorElement_differenceShortRootSubgroupPoints_negativeSumShortRootSubgroupPoints
+    (hij : i ≠ j)
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    ⁅shortRootSubgroupPoints .difference hij f,
+        shortRootSubgroupPoints .negativeSum hij g⁆ =
+      (negativeLongRootSubgroupPoints j (AdditiveGroup.gaPointParamMul f g) ^ 2)⁻¹ := by
+  apply (pointsMulEquiv (R := R) (A := A) m).injective
+  rw [map_commutatorElement, map_inv, map_pow, pointsMulEquiv_shortRootSubgroupPoints,
+    pointsMulEquiv_shortRootSubgroupPoints,
+    pointsMulEquiv_negativeLongRootSubgroupPoints]
+  rw [GLSymplecticFin.ShortRootFamily.hom_difference,
+    GLSymplecticFin.differenceShortRootHom_apply,
+    GLSymplecticFin.ShortRootFamily.hom_negativeSum,
+    GLSymplecticFin.negativeSumShortRootHom_apply]
+  simp only [AdditiveGroup.toAdd_gaPointsMulEquiv,
+    AdditiveGroup.gaPointParamMul_apply_ι]
+  convert
+    GLSymplecticFin.commutatorElement_differenceShortRootUnit_negativeSumShortRootUnit
+        hij
+        (f.ofConv (SymmetricAlgebra.ι R R 1))
+        (g.ofConv (SymmetricAlgebra.ι R R 1)) using 1
+  rw [pow_two]
+  let c := f.ofConv (SymmetricAlgebra.ι R R 1) *
+    g.ofConv (SymmetricAlgebra.ι R R 1)
+  have hadd :
+      GLSymplecticFin.negativeLongRootTransvectionUnit j c *
+          GLSymplecticFin.negativeLongRootTransvectionUnit j c =
+        GLSymplecticFin.negativeLongRootTransvectionUnit j (c + c) := by
+    simpa only [GLSymplecticFin.negativeLongRootTransvectionHom_apply,
+      toAdd_ofAdd, toAdd_mul] using
+      ((GLSymplecticFin.negativeLongRootTransvectionHom (R := A) j).map_mul
+        (Multiplicative.ofAdd c) (Multiplicative.ofAdd c)).symm
+  rw [hadd]
+  calc
+    (GLSymplecticFin.negativeLongRootTransvectionUnit j (c + c))⁻¹ =
+        GLSymplecticFin.negativeLongRootTransvectionUnit j (-(c + c)) := by
+      apply Subtype.ext
+      change
+        ((GLSymplecticFin.negativeLongRootTransvectionUnit j (c + c) :
+          GLSymplecticFin m A) : GL (Fin (m + m)) A)⁻¹ =
+          (GLSymplecticFin.negativeLongRootTransvectionUnit j (-(c + c)) :
+            GL (Fin (m + m)) A)
+      rw [GLSymplecticFin.coe_negativeLongRootTransvectionUnit,
+        GLSymplecticFin.coe_negativeLongRootTransvectionUnit, transvectionUnit_inv]
+    _ = GLSymplecticFin.negativeLongRootTransvectionUnit j
+          (-(2 * f.ofConv (SymmetricAlgebra.ι R R 1) *
+            g.ofConv (SymmetricAlgebra.ι R R 1))) := by
+      congr 1
+      dsimp only [c]
+      ring
 
 end TauCeti.Symplectic

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/ChevalleyRelations.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/ChevalleyRelations.lean
@@ -184,13 +184,9 @@ theorem commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUn
     ⁅differenceShortRootUnit hij a, negativeLongRootTransvectionUnit i b⁆ =
       negativeSumShortRootUnit hij (-(a * b)) *
         negativeLongRootTransvectionUnit j (a ^ 2 * b) := by
-  apply Subtype.ext
-  change
-    ⁅(differenceShortRootUnit hij a : GL (Fin (m + m)) R),
-        (negativeLongRootTransvectionUnit i b : GL (Fin (m + m)) R)⁆ =
-      (negativeSumShortRootUnit hij (-(a * b)) : GL (Fin (m + m)) R) *
-        negativeLongRootTransvectionUnit j (a ^ 2 * b)
-  rw [coe_differenceShortRootUnit, coe_negativeLongRootTransvectionUnit,
+  apply (GLSymplecticFin m R).subtype_injective
+  rw [map_commutatorElement, map_mul, Subgroup.coe_subtype,
+    coe_differenceShortRootUnit, coe_negativeLongRootTransvectionUnit,
     coe_negativeSumShortRootUnit, coe_negativeLongRootTransvectionUnit]
   let I := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl i)
   let J := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl j)
@@ -243,13 +239,9 @@ theorem commutatorElement_differenceShortRootUnit_negativeSumShortRootUnit
     (hij : i ≠ j) (a b : R) :
     ⁅differenceShortRootUnit hij a, negativeSumShortRootUnit hij b⁆ =
       negativeLongRootTransvectionUnit j (-(2 * a * b)) := by
-  apply Subtype.ext
-  change
-    ⁅(differenceShortRootUnit hij a : GL (Fin (m + m)) R),
-        (negativeSumShortRootUnit hij b : GL (Fin (m + m)) R)⁆ =
-      (negativeLongRootTransvectionUnit j (-(2 * a * b)) : GL (Fin (m + m)) R)
-  rw [coe_differenceShortRootUnit, coe_negativeSumShortRootUnit,
-    coe_negativeLongRootTransvectionUnit]
+  apply (GLSymplecticFin m R).subtype_injective
+  rw [map_commutatorElement, Subgroup.coe_subtype, coe_differenceShortRootUnit,
+    coe_negativeSumShortRootUnit, coe_negativeLongRootTransvectionUnit]
   let I := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl i)
   let J := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl j)
   let I' := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inr i)

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/ChevalleyRelations.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/ChevalleyRelations.lean
@@ -20,14 +20,23 @@ matrix parametrizations satisfy
   = x_{eᵢ+eⱼ}(ab) x_{2eᵢ}(a²b).
 ```
 
-The second relation records the non-unit structure constant in the same rank-two system:
+The opposite-root-string analogues are
+
+```text
+⁅x_{eᵢ-eⱼ}(a), x_{-2eᵢ}(b)⁆
+  = x_{-eᵢ-eⱼ}(-ab) x_{-2eⱼ}(a²b),
+⁅x_{eᵢ-eⱼ}(a), x_{-eᵢ-eⱼ}(b)⁆ = x_{-2eⱼ}(-2ab).
+```
+
+The second relation in each root string records its non-unit structure constant; for the
+positive string it is
 
 ```text
 ⁅x_{eᵢ-eⱼ}(a), x_{eᵢ+eⱼ}(b)⁆ = x_{2eᵢ}(2ab).
 ```
 
-These are the two rank-two relations needed to compare the standard symplectic realization with
-the characteristic-two special isogeny of type `B₂/C₂`.
+Together these four identities are the rank-two relations needed to compare the standard
+symplectic realization with the characteristic-two special isogeny of type `B₂/C₂`.
 
 ## References
 
@@ -162,6 +171,124 @@ theorem commutatorElement_differenceShortRootUnit_positiveSumShortRootUnit
       (finSumFinEquiv_inr_ne_inl i i) _ _).eq, mul_inv_cancel_right]
   rw [commutatorElement_mul_left_eq_conj_mul, hBDE, hADE]
   rw [(commute_transvectionUnit hIJ hII' hIJ.symm hII'.symm _ _).eq]
+  simp only [mul_assoc, mul_inv_cancel, mul_one]
+  rw [← transvectionUnit_add]
+  congr 1
+  ring
+
+/-- **The negative multiply-laced Chevalley relation in the standard symplectic group.** The
+commutator of `x_{eᵢ-eⱼ}(a)` and `x_{-2eᵢ}(b)` is the product of the two remaining root
+subgroups in their root string, with parameters `-ab` and `a²b`. -/
+theorem commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit
+    (hij : i ≠ j) (a b : R) :
+    ⁅differenceShortRootUnit hij a, negativeLongRootTransvectionUnit i b⁆ =
+      negativeSumShortRootUnit hij (-(a * b)) *
+        negativeLongRootTransvectionUnit j (a ^ 2 * b) := by
+  apply Subtype.ext
+  change
+    ⁅(differenceShortRootUnit hij a : GL (Fin (m + m)) R),
+        (negativeLongRootTransvectionUnit i b : GL (Fin (m + m)) R)⁆ =
+      (negativeSumShortRootUnit hij (-(a * b)) : GL (Fin (m + m)) R) *
+        negativeLongRootTransvectionUnit j (a ^ 2 * b)
+  rw [coe_differenceShortRootUnit, coe_negativeLongRootTransvectionUnit,
+    coe_negativeSumShortRootUnit, coe_negativeLongRootTransvectionUnit]
+  let I := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl i)
+  let J := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl j)
+  let I' := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inr i)
+  let J' := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inr j)
+  have hIJ : I ≠ J := differenceShortRoot_first_indices_ne hij
+  have hJ'I' : J' ≠ I' := differenceShortRoot_second_indices_ne hij
+  have hI'I : I' ≠ I := finSumFinEquiv_inr_ne_inl i i
+  have hI'J : I' ≠ J := finSumFinEquiv_inr_ne_inl i j
+  have hJ'I : J' ≠ I := finSumFinEquiv_inr_ne_inl j i
+  have hJ'J : J' ≠ J := finSumFinEquiv_inr_ne_inl j j
+  have hBC :
+      ⁅transvectionUnit hJ'I' (-a), transvectionUnit hI'I b⁆ =
+        transvectionUnit hJ'I (-(a * b)) := by
+    rw [commutatorElement_transvectionUnit hJ'I' hI'I hJ'I]
+    congr 1
+    ring
+  have hAC :
+      ⁅transvectionUnit hIJ a, transvectionUnit hI'I b⁆ =
+        transvectionUnit hI'J (-(a * b)) := by
+    rw [commutatorElement_transvectionUnit_reverse hIJ hI'I hI'J]
+    congr 1
+    ring
+  have hAE :
+      ⁅transvectionUnit hIJ a, transvectionUnit hJ'I (-(a * b))⁆ =
+        transvectionUnit hJ'J (a ^ 2 * b) := by
+    rw [commutatorElement_transvectionUnit_reverse hIJ hJ'I hJ'J]
+    congr 1
+    ring
+  rw [commutatorElement_mul_left_eq_conj_mul, hBC, hAC]
+  calc
+    transvectionUnit hIJ a * transvectionUnit hJ'I (-(a * b)) *
+          (transvectionUnit hIJ a)⁻¹ * transvectionUnit hI'J (-(a * b)) =
+        ⁅transvectionUnit hIJ a, transvectionUnit hJ'I (-(a * b))⁆ *
+          transvectionUnit hJ'I (-(a * b)) * transvectionUnit hI'J (-(a * b)) := by
+      rw [← MulAut.conj_apply, conj_eq_commutatorElement_mul]
+    _ = transvectionUnit hJ'J (a ^ 2 * b) * transvectionUnit hJ'I (-(a * b)) *
+          transvectionUnit hI'J (-(a * b)) := by rw [hAE]
+    _ = transvectionUnit hI'J (-(a * b)) * transvectionUnit hJ'I (-(a * b)) *
+          transvectionUnit hJ'J (a ^ 2 * b) := by
+      rw [(commute_transvectionUnit hJ'J hJ'I hJ'J.symm hJ'I.symm _ _).eq,
+        mul_assoc,
+        (commute_transvectionUnit hJ'J hI'J hI'J.symm hJ'J.symm _ _).eq,
+        ← mul_assoc,
+        (commute_transvectionUnit hJ'I hI'J hI'I.symm hJ'J.symm _ _).eq]
+
+/-- **The negative structure-constant-two Chevalley relation in the standard symplectic
+group.** The commutator of `x_{eᵢ-eⱼ}(a)` and `x_{-eᵢ-eⱼ}(b)` is `x_{-2eⱼ}(-2ab)`. -/
+theorem commutatorElement_differenceShortRootUnit_negativeSumShortRootUnit
+    (hij : i ≠ j) (a b : R) :
+    ⁅differenceShortRootUnit hij a, negativeSumShortRootUnit hij b⁆ =
+      negativeLongRootTransvectionUnit j (-(2 * a * b)) := by
+  apply Subtype.ext
+  change
+    ⁅(differenceShortRootUnit hij a : GL (Fin (m + m)) R),
+        (negativeSumShortRootUnit hij b : GL (Fin (m + m)) R)⁆ =
+      (negativeLongRootTransvectionUnit j (-(2 * a * b)) : GL (Fin (m + m)) R)
+  rw [coe_differenceShortRootUnit, coe_negativeSumShortRootUnit,
+    coe_negativeLongRootTransvectionUnit]
+  let I := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl i)
+  let J := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl j)
+  let I' := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inr i)
+  let J' := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inr j)
+  have hIJ : I ≠ J := differenceShortRoot_first_indices_ne hij
+  have hJ'I' : J' ≠ I' := differenceShortRoot_second_indices_ne hij
+  have hI'J : I' ≠ J := finSumFinEquiv_inr_ne_inl i j
+  have hJ'I : J' ≠ I := finSumFinEquiv_inr_ne_inl j i
+  have hJ'J : J' ≠ J := finSumFinEquiv_inr_ne_inl j j
+  have hBC :
+      ⁅transvectionUnit hJ'I' (-a), transvectionUnit hI'J b⁆ =
+        transvectionUnit hJ'J (-(a * b)) := by
+    rw [commutatorElement_transvectionUnit hJ'I' hI'J hJ'J]
+    congr 1
+    ring
+  have hAD :
+      ⁅transvectionUnit hIJ a, transvectionUnit hJ'I b⁆ =
+        transvectionUnit hJ'J (-(a * b)) := by
+    rw [commutatorElement_transvectionUnit_reverse hIJ hJ'I hJ'J]
+    congr 1
+    ring
+  have hBCD :
+      ⁅transvectionUnit hJ'I' (-a),
+          transvectionUnit hI'J b * transvectionUnit hJ'I b⁆ =
+        transvectionUnit hJ'J (-(a * b)) := by
+    rw [commutatorElement_mul_right_eq_mul_conj, hBC,
+      (commute_transvectionUnit hJ'I' hJ'I hJ'I'.symm hJ'I.symm _ _).commutator_eq]
+    simp only [mul_one, mul_assoc, mul_inv_cancel, mul_one]
+  have hACD :
+      ⁅transvectionUnit hIJ a,
+          transvectionUnit hI'J b * transvectionUnit hJ'I b⁆ =
+        transvectionUnit hJ'J (-(a * b)) := by
+    rw [commutatorElement_mul_right_eq_mul_conj,
+      (commute_transvectionUnit hIJ hI'J hI'J.symm hIJ.symm _ _).commutator_eq,
+      one_mul, hAD]
+    rw [(commute_transvectionUnit hI'J hJ'J hJ'J.symm hI'J.symm _ _).eq,
+      mul_inv_cancel_right]
+  rw [commutatorElement_mul_left_eq_conj_mul, hBCD, hACD]
+  rw [(commute_transvectionUnit hIJ hJ'J hJ'J.symm hIJ.symm _ _).eq]
   simp only [mul_assoc, mul_inv_cancel, mul_one]
   rw [← transvectionUnit_add]
   congr 1


### PR DESCRIPTION
This PR completes the negative type-`C₂` root strings for the standard symplectic realization: prove the commutators of `x_{eᵢ-eⱼ}` with `x_{-2eᵢ}` and `x_{-eᵢ-eⱼ}` over every commutative ring, then lift both identities to algebra-valued points of `Sp₂ₘ`.

It advances the ReductiveGroups Layer 9 targets “Root subgroup maps” (including their Chevalley commutator relations) and “Special isogenies in characteristics two and three”, specifically the characteristic-two `B₂/C₂` exceptional isogeny. After this PR, constructing that group-scheme isogeny and proving its prescribed action on long and short root subgroups remain.

Dependency edge: CFSGStatement milestone L2, “Suzuki--Ree Steinberg maps”, consumes the ReductiveGroups Layer 9 characteristic-two `B₂/C₂` special isogeny; these negative root-string relations supply the remaining explicit symplectic commutator checks for that construction.

The proofs reuse Mathlib's special-linear transvection identities through TauCeti's existing general-linear transvection API; no Mathlib implementation is vendored.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"symplectic-negative-b2-chevalley-commutator-relations"}-->

🤖 Prepared with Codex
