### PR TITLE
feat: represent weight-cocharacter Levis

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Dynamic/Functor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Dynamic/Functor.lean
@@ -91,29 +91,23 @@ theorem coe_mapUnipotent_apply (l : H →ₐc[R] LaurentPolynomial R)
 /-- The dynamic parabolic attached to a cocharacter, as a group-valued functor. -/
 -- The object carrier must unfold when downstream modules construct natural transformations.
 @[expose] noncomputable def parabolicFunctor (l : H →ₐc[R] LaurentPolynomial R) :
-    CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
-  obj A := GrpCat.of (parabolic A l)
-  map φ := GrpCat.ofHom (mapParabolic l φ)
-  map_id _ := by ext; rfl
-  map_comp _ _ := by ext; rfl
+    CommAlgCat.{w} R ⥤ GrpCat.{max v w} :=
+  HopfAlgebra.subgroupFunctor (fun A ↦ parabolic A l)
+    (fun φ ↦ mapParabolic l φ) (by intros; rfl) (by intros; rfl)
 
 /-- The dynamic Levi attached to a cocharacter, as a group-valued functor. -/
 -- The object carrier must unfold when downstream modules construct natural transformations.
 @[expose] noncomputable def leviFunctor (l : H →ₐc[R] LaurentPolynomial R) :
-    CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
-  obj A := GrpCat.of (levi A l)
-  map φ := GrpCat.ofHom (mapLevi l φ)
-  map_id _ := by ext; rfl
-  map_comp _ _ := by ext; rfl
+    CommAlgCat.{w} R ⥤ GrpCat.{max v w} :=
+  HopfAlgebra.subgroupFunctor (fun A ↦ levi A l)
+    (fun φ ↦ mapLevi l φ) (by intros; rfl) (by intros; rfl)
 
 /-- The dynamic unipotent subgroup attached to a cocharacter, as a group-valued functor. -/
 -- The object carrier must unfold when downstream modules construct natural transformations.
 @[expose] noncomputable def unipotentFunctor (l : H →ₐc[R] LaurentPolynomial R) :
-    CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
-  obj A := GrpCat.of (unipotent A l)
-  map φ := GrpCat.ofHom (mapUnipotent l φ)
-  map_id _ := by ext; rfl
-  map_comp _ _ := by ext; rfl
+    CommAlgCat.{w} R ⥤ GrpCat.{max v w} :=
+  HopfAlgebra.subgroupFunctor (fun A ↦ unipotent A l)
+    (fun φ ↦ mapUnipotent l φ) (by intros; rfl) (by intros; rfl)
 
 theorem parabolicFunctor_obj (l : H →ₐc[R] LaurentPolynomial R) (A : CommAlgCat.{w} R) :
     (parabolicFunctor l).obj A = GrpCat.of (parabolic A l) :=

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi.lean
@@ -46,6 +46,43 @@ universe u v
 
 variable (R : Type u) [CommRing R] {N : ℕ}
 
+private theorem mapWeightLevi_id (w : Fin N → ℤ) (A : CommAlgCat.{v} R)
+    (g : Cocharacter.levi A (weightCocharacter (R := R) w)) :
+    Cocharacter.mapLevi (weightCocharacter (R := R) w) (𝟙 A) g = g := by
+  change ((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map (𝟙 A)) g = g
+  exact ConcreteCategory.congr_hom
+    ((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map_id A) g
+
+private theorem mapWeightLevi_comp (w : Fin N → ℤ)
+    {A B C : CommAlgCat.{v} R} (φ : A ⟶ B) (ψ : B ⟶ C)
+    (g : Cocharacter.levi A (weightCocharacter (R := R) w)) :
+    Cocharacter.mapLevi (weightCocharacter (R := R) w) (φ ≫ ψ) g =
+      Cocharacter.mapLevi (weightCocharacter (R := R) w) ψ
+        (Cocharacter.mapLevi (weightCocharacter (R := R) w) φ g) := by
+  change ((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map (φ ≫ ψ)) g =
+    (((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map φ ≫
+      (Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map ψ) g)
+  exact ConcreteCategory.congr_hom
+    ((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map_comp φ ψ) g
+
+private theorem mem_weightLeviSubgroup_iff (w : Fin N → ℤ)
+    (A : CommAlgCat.{v} R)
+    (g : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) A) :
+    g ∈ CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
+        (weightLeviDefiningHopfIdeal R w) A ↔
+      g ∈ Cocharacter.levi A (weightCocharacter (R := R) w) :=
+  by
+    rw [GeneralLinear.mem_weightLeviDefiningPointsSubgroup_iff_apply_eq_zero,
+      mem_levi_weightCocharacter_iff]
+
+private theorem coe_mapWeightLevi_apply (w : Fin N → ℤ)
+    {A B : CommAlgCat.{v} R} (φ : A ⟶ B)
+    (g : Cocharacter.levi A (weightCocharacter (R := R) w)) :
+    (Cocharacter.mapLevi (weightCocharacter (R := R) w) φ g :
+      HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) B) =
+      HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R N) φ g :=
+  Cocharacter.coe_mapLevi_apply (weightCocharacter (R := R) w) φ g
+
 section Points
 
 variable {A : Type v} [CommRing A] [Algebra R A]
@@ -57,69 +94,22 @@ theorem mem_weightLeviDefiningPointsSubgroup_iff (w : Fin N → ℤ)
     g ∈ CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
         (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) ↔
       g ∈ Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w) := by
-  rw [GeneralLinear.mem_weightLeviDefiningPointsSubgroup_iff,
+  rw [GeneralLinear.mem_weightLeviDefiningPointsSubgroup_iff_apply_eq_zero,
     mem_levi_weightCocharacter_iff]
 
-/-- Identify the cut-out ambient point subgroup with the dynamic Levi point subgroup. -/
-private noncomputable def weightLeviPointsSubgroupMulEquiv (w : Fin N → ℤ) :
-    CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
-        (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) ≃*
-      Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w) :=
-  MulEquiv.subgroupCongr <| Subgroup.ext fun g ↦
-    mem_weightLeviDefiningPointsSubgroup_iff R w g
-
-private theorem weightLeviPointsSubgroupMulEquiv_natural (w : Fin N → ℤ)
-    {B : CommAlgCat.{v} R} (phi : CommAlgCat.of R A ⟶ B)
-    (g : CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
-      (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A)) :
-    weightLeviPointsSubgroupMulEquiv R w
-        (CommHopfAlgCat.mapQuotientPointsSubgroup (coordinateHopfAlgebra R N)
-          (weightLeviDefiningHopfIdeal R w) phi g) =
-      Cocharacter.mapLevi (weightCocharacter (R := R) w) phi
-        (weightLeviPointsSubgroupMulEquiv R w g) := by
-  apply Subtype.ext
-  calc
-    _ = ((CommHopfAlgCat.mapQuotientPointsSubgroup (coordinateHopfAlgebra R N)
-          (weightLeviDefiningHopfIdeal R w) phi g) :
-        HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) B) :=
-      MulEquiv.subgroupCongr_apply _ _
-    _ = HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R N) phi g :=
-      CommHopfAlgCat.coe_mapQuotientPointsSubgroup_apply _ _ _ _
-    _ = AlgHom.mapValue phi.hom g := rfl
-    _ = AlgHom.mapValue phi.hom
-        ((weightLeviPointsSubgroupMulEquiv R w g :
-            Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
-          HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
-            (CommAlgCat.of R A)) := by
-      congr 1
-    _ = ((Cocharacter.mapLevi (weightCocharacter (R := R) w) phi
-          (weightLeviPointsSubgroupMulEquiv R w g) :
-            Cocharacter.levi B (weightCocharacter (R := R) w)) :
-        HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) B) :=
-      (Cocharacter.coe_mapLevi_apply _ _ _).symm
-
 end Points
-
-/-- The cut-out subgroup functor is naturally the dynamic Levi functor. -/
-private noncomputable def weightLeviSubgroupPointsIso (w : Fin N → ℤ) :
-    CommHopfAlgCat.quotientPointsSubgroupFunctor (R := R) (coordinateHopfAlgebra R N)
-        (weightLeviDefiningHopfIdeal R w) ≅
-      Cocharacter.leviFunctor (weightCocharacter (R := R) w) :=
-  NatIso.ofComponents
-    (fun _ ↦ (weightLeviPointsSubgroupMulEquiv R w).toGrpIso)
-    (by
-      intro A B phi
-      ext g
-      exact weightLeviPointsSubgroupMulEquiv_natural R w phi g)
 
 /-- The weight-Levi coordinate Hopf algebra represents the dynamic Levi functor of the weight
 cocharacter, naturally in the commutative value algebra. -/
 noncomputable def weightLeviPointsIso (w : Fin N → ℤ) :
     HopfAlgebra.pointsFunctor (R := R) (H := weightLeviCoordinateHopfAlgebra R w) ≅
       Cocharacter.leviFunctor (weightCocharacter (R := R) w) :=
-  (CommHopfAlgCat.quotientPointsSubgroupNatIso (coordinateHopfAlgebra R N)
-      (weightLeviDefiningHopfIdeal R w)).trans
-    (weightLeviSubgroupPointsIso R w)
+  CommHopfAlgCat.quotientPointsSubgroupRepresentingIso
+    (coordinateHopfAlgebra R N) (weightLeviDefiningHopfIdeal R w)
+    (fun A ↦ Cocharacter.levi A (weightCocharacter (R := R) w))
+    (fun φ ↦ Cocharacter.mapLevi (weightCocharacter (R := R) w) φ)
+    (mapWeightLevi_id R w) (mapWeightLevi_comp R w)
+    (mem_weightLeviSubgroup_iff R w) (coe_mapWeightLevi_apply R w)
 
 /-- The ambient point underlying the represented dynamic-Levi point is induced by the quotient
 coordinate map. -/
@@ -135,15 +125,16 @@ theorem coe_weightLeviPointsIso_hom_app_apply (w : Fin N → ℤ)
       HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) (CommAlgCat.of R A)) =
       CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
         (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) f := by
-  have hcomponent := CommHopfAlgCat.quotientPointsSubgroupNatIso_hom_app_apply
-    (coordinateHopfAlgebra R N) (weightLeviDefiningHopfIdeal R w)
-    (CommAlgCat.of R A) f
   unfold weightLeviPointsIso
-  exact congrArg
-    (fun g => ((weightLeviPointsSubgroupMulEquiv R w g :
-        Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
-      HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) (CommAlgCat.of R A)))
-    hcomponent
+  convert
+    (CommHopfAlgCat.coe_quotientPointsSubgroupRepresentingIso_hom_app_apply
+      (coordinateHopfAlgebra R N) (weightLeviDefiningHopfIdeal R w)
+      (fun B ↦ Cocharacter.levi B (weightCocharacter (R := R) w))
+      (fun φ ↦ Cocharacter.mapLevi (weightCocharacter (R := R) w) φ)
+      (mapWeightLevi_id R w) (mapWeightLevi_comp R w)
+      (mem_weightLeviSubgroup_iff R w) (coe_mapWeightLevi_apply R w)
+      (CommAlgCat.of R A) f) using 1
+  rfl
 
 /-- Applying the quotient inclusion to the inverse representing isomorphism recovers the ambient
 dynamic-Levi point. -/
@@ -154,22 +145,15 @@ theorem quotientPointsHom_weightLeviPointsIso_inv_app_apply (w : Fin N → ℤ)
     CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
         (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A)
         ((weightLeviPointsIso R w).inv.app (CommAlgCat.of R A) g) = g.1 := by
-  let f := (weightLeviPointsIso R w).inv.app (CommAlgCat.of R A) g
-  calc
-    CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
-        (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) f =
-      (((eqToHom (Cocharacter.leviFunctor_obj
-          (weightCocharacter (R := R) w) (CommAlgCat.of R A)))
-        ((weightLeviPointsIso R w).hom.app (CommAlgCat.of R A) f) :
-          Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
-          HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
-            (CommAlgCat.of R A)) :=
-      (coe_weightLeviPointsIso_hom_app_apply R w f).symm
-    _ = g.1 := by
-      have hinv := CategoryTheory.Iso.inv_hom_id_apply
-        ((weightLeviPointsIso R w).app (CommAlgCat.of R A))
-        (eqToHom (Cocharacter.leviFunctor_obj
-          (weightCocharacter (R := R) w) (CommAlgCat.of R A)).symm g)
-      exact congrArg Subtype.val hinv
+  unfold weightLeviPointsIso
+  convert
+    (CommHopfAlgCat.quotientPointsHom_quotientPointsSubgroupRepresentingIso_inv_app_apply
+      (coordinateHopfAlgebra R N) (weightLeviDefiningHopfIdeal R w)
+      (fun B ↦ Cocharacter.levi B (weightCocharacter (R := R) w))
+      (fun φ ↦ Cocharacter.mapLevi (weightCocharacter (R := R) w) φ)
+      (mapWeightLevi_id R w) (mapWeightLevi_comp R w)
+      (mem_weightLeviSubgroup_iff R w) (coe_mapWeightLevi_apply R w)
+      (CommAlgCat.of R A) g) using 1
+  rfl
 
 end TauCeti.GeneralLinear.Dynamic

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi.lean
@@ -49,9 +49,9 @@ variable (R : Type u) [CommRing R] {N : ℕ}
 private theorem mapWeightLevi_id (w : Fin N → ℤ) (A : CommAlgCat.{v} R)
     (g : Cocharacter.levi A (weightCocharacter (R := R) w)) :
     Cocharacter.mapLevi (weightCocharacter (R := R) w) (𝟙 A) g = g := by
-  change ((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map (𝟙 A)) g = g
-  exact ConcreteCategory.congr_hom
-    ((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map_id A) g
+  apply Subtype.ext
+  rw [Cocharacter.coe_mapLevi_apply, CommAlgCat.hom_id,
+    AlgHom.mapValue_id, MonoidHom.id_apply]
 
 private theorem mapWeightLevi_comp (w : Fin N → ℤ)
     {A B C : CommAlgCat.{v} R} (φ : A ⟶ B) (ψ : B ⟶ C)
@@ -59,11 +59,10 @@ private theorem mapWeightLevi_comp (w : Fin N → ℤ)
     Cocharacter.mapLevi (weightCocharacter (R := R) w) (φ ≫ ψ) g =
       Cocharacter.mapLevi (weightCocharacter (R := R) w) ψ
         (Cocharacter.mapLevi (weightCocharacter (R := R) w) φ g) := by
-  change ((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map (φ ≫ ψ)) g =
-    (((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map φ ≫
-      (Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map ψ) g)
-  exact ConcreteCategory.congr_hom
-    ((Cocharacter.leviFunctor (weightCocharacter (R := R) w)).map_comp φ ψ) g
+  apply Subtype.ext
+  rw [Cocharacter.coe_mapLevi_apply, Cocharacter.coe_mapLevi_apply,
+    Cocharacter.coe_mapLevi_apply, CommAlgCat.hom_comp,
+    AlgHom.mapValue_comp, MonoidHom.comp_apply]
 
 private theorem mem_weightLeviSubgroup_iff (w : Fin N → ℤ)
     (A : CommAlgCat.{v} R)

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Basic
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Levi
+public import TauCeti.Algebra.AlgebraicGroup.Dynamic.Functor
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Naturality
+
+/-!
+# Representability of dynamic weight Levis
+
+The weight-Levi subgroup scheme of `GL_N` represents the dynamic Levi attached to the
+cocharacter `t ↦ diag(t ^ w i)`. On points, both descriptions say exactly that the `(i,j)`
+entry vanishes whenever `w i ≠ w j`.
+
+The construction and its naturality follow the representing interface for the weight parabolic
+in `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Parabolic`, with the Levi cut out
+as the intersection of the two opposite weight parabolics.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.Dynamic.mem_weightLeviDefiningPointsSubgroup_iff`: membership in the
+  Hopf-ideal cut-out agrees with dynamic-Levi membership.
+* `TauCeti.GeneralLinear.Dynamic.weightLeviPointsIso`: the natural representing isomorphism.
+
+## References
+
+* G. R. Kempf, *Instability in invariant theory*, Annals of Mathematics 108 (1978), §2.
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 13.
+
+This completes representability of the weight-cocharacter Levi in the dynamic route of Layer 7,
+"Structure theory", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.GeneralLinear.Dynamic
+
+universe u v
+
+variable (R : Type u) [CommRing R] {N : ℕ}
+
+section Points
+
+variable {A : Type v} [CommRing A] [Algebra R A]
+
+/-- The Hopf-ideal cut-out is exactly the dynamic Levi of the weight cocharacter. -/
+theorem mem_weightLeviDefiningPointsSubgroup_iff (w : Fin N → ℤ)
+    (g : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
+      (CommAlgCat.of R A)) :
+    g ∈ CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
+        (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) ↔
+      g ∈ Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w) := by
+  rw [GeneralLinear.mem_weightLeviDefiningPointsSubgroup_iff,
+    mem_levi_weightCocharacter_iff]
+
+/-- Identify the cut-out ambient point subgroup with the dynamic Levi point subgroup. -/
+private noncomputable def weightLeviPointsSubgroupMulEquiv (w : Fin N → ℤ) :
+    CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
+        (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) ≃*
+      Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w) :=
+  MulEquiv.subgroupCongr <| Subgroup.ext fun g ↦
+    mem_weightLeviDefiningPointsSubgroup_iff R w g
+
+private theorem weightLeviPointsSubgroupMulEquiv_natural (w : Fin N → ℤ)
+    {B : CommAlgCat.{v} R} (phi : CommAlgCat.of R A ⟶ B)
+    (g : CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
+      (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A)) :
+    weightLeviPointsSubgroupMulEquiv R w
+        (CommHopfAlgCat.mapQuotientPointsSubgroup (coordinateHopfAlgebra R N)
+          (weightLeviDefiningHopfIdeal R w) phi g) =
+      Cocharacter.mapLevi (weightCocharacter (R := R) w) phi
+        (weightLeviPointsSubgroupMulEquiv R w g) := by
+  apply Subtype.ext
+  calc
+    _ = ((CommHopfAlgCat.mapQuotientPointsSubgroup (coordinateHopfAlgebra R N)
+          (weightLeviDefiningHopfIdeal R w) phi g) :
+        HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) B) :=
+      MulEquiv.subgroupCongr_apply _ _
+    _ = HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R N) phi g :=
+      CommHopfAlgCat.coe_mapQuotientPointsSubgroup_apply _ _ _ _
+    _ = AlgHom.mapValue phi.hom g := rfl
+    _ = AlgHom.mapValue phi.hom
+        ((weightLeviPointsSubgroupMulEquiv R w g :
+            Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
+          HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
+            (CommAlgCat.of R A)) := by
+      congr 1
+    _ = ((Cocharacter.mapLevi (weightCocharacter (R := R) w) phi
+          (weightLeviPointsSubgroupMulEquiv R w g) :
+            Cocharacter.levi B (weightCocharacter (R := R) w)) :
+        HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) B) :=
+      (Cocharacter.coe_mapLevi_apply _ _ _).symm
+
+end Points
+
+/-- The cut-out subgroup functor is naturally the dynamic Levi functor. -/
+private noncomputable def weightLeviSubgroupPointsIso (w : Fin N → ℤ) :
+    CommHopfAlgCat.quotientPointsSubgroupFunctor (R := R) (coordinateHopfAlgebra R N)
+        (weightLeviDefiningHopfIdeal R w) ≅
+      Cocharacter.leviFunctor (weightCocharacter (R := R) w) :=
+  NatIso.ofComponents
+    (fun _ ↦ (weightLeviPointsSubgroupMulEquiv R w).toGrpIso)
+    (by
+      intro A B phi
+      ext g
+      exact weightLeviPointsSubgroupMulEquiv_natural R w phi g)
+
+/-- The weight-Levi coordinate Hopf algebra represents the dynamic Levi functor of the weight
+cocharacter, naturally in the commutative value algebra. -/
+noncomputable def weightLeviPointsIso (w : Fin N → ℤ) :
+    HopfAlgebra.pointsFunctor (R := R) (H := weightLeviCoordinateHopfAlgebra R w) ≅
+      Cocharacter.leviFunctor (weightCocharacter (R := R) w) :=
+  (CommHopfAlgCat.quotientPointsSubgroupNatIso (coordinateHopfAlgebra R N)
+      (weightLeviDefiningHopfIdeal R w)).trans
+    (weightLeviSubgroupPointsIso R w)
+
+/-- The ambient point underlying the represented dynamic-Levi point is induced by the quotient
+coordinate map. -/
+@[simp]
+theorem coe_weightLeviPointsIso_hom_app_apply (w : Fin N → ℤ)
+    {A : Type v} [CommRing A] [Algebra R A]
+    (f : HopfAlgebra.points
+      (R := R) (H := weightLeviCoordinateHopfAlgebra R w) (CommAlgCat.of R A)) :
+    (((eqToHom (Cocharacter.leviFunctor_obj
+        (weightCocharacter (R := R) w) (CommAlgCat.of R A)))
+      ((weightLeviPointsIso R w).hom.app (CommAlgCat.of R A) f) :
+        Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
+      HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) (CommAlgCat.of R A)) =
+      CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
+        (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) f := by
+  have hcomponent := CommHopfAlgCat.quotientPointsSubgroupNatIso_hom_app_apply
+    (coordinateHopfAlgebra R N) (weightLeviDefiningHopfIdeal R w)
+    (CommAlgCat.of R A) f
+  unfold weightLeviPointsIso
+  exact congrArg
+    (fun g => ((weightLeviPointsSubgroupMulEquiv R w g :
+        Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
+      HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) (CommAlgCat.of R A)))
+    hcomponent
+
+/-- Applying the quotient inclusion to the inverse representing isomorphism recovers the ambient
+dynamic-Levi point. -/
+@[simp]
+theorem quotientPointsHom_weightLeviPointsIso_inv_app_apply (w : Fin N → ℤ)
+    {A : Type v} [CommRing A] [Algebra R A]
+    (g : Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
+    CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
+        (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A)
+        ((weightLeviPointsIso R w).inv.app (CommAlgCat.of R A) g) = g.1 := by
+  let f := (weightLeviPointsIso R w).inv.app (CommAlgCat.of R A) g
+  calc
+    CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
+        (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) f =
+      (((eqToHom (Cocharacter.leviFunctor_obj
+          (weightCocharacter (R := R) w) (CommAlgCat.of R A)))
+        ((weightLeviPointsIso R w).hom.app (CommAlgCat.of R A) f) :
+          Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
+          HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
+            (CommAlgCat.of R A)) :=
+      (coe_weightLeviPointsIso_hom_app_apply R w f).symm
+    _ = g.1 := by
+      have hinv := CategoryTheory.Iso.inv_hom_id_apply
+        ((weightLeviPointsIso R w).app (CommAlgCat.of R A))
+        (eqToHom (Cocharacter.leviFunctor_obj
+          (weightCocharacter (R := R) w) (CommAlgCat.of R A)).symm g)
+      exact congrArg Subtype.val hinv
+
+end TauCeti.GeneralLinear.Dynamic

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Parabolic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Parabolic.lean
@@ -43,6 +43,42 @@ universe u v
 
 variable (R : Type u) [CommRing R] {N : ℕ}
 
+private theorem mapWeightParabolic_id (w : Fin N → ℤ) (A : CommAlgCat.{v} R)
+    (g : Cocharacter.parabolic A (weightCocharacter (R := R) w)) :
+    Cocharacter.mapParabolic (weightCocharacter (R := R) w) (𝟙 A) g = g := by
+  change ((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map (𝟙 A)) g = g
+  exact ConcreteCategory.congr_hom
+    ((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map_id A) g
+
+private theorem mapWeightParabolic_comp (w : Fin N → ℤ)
+    {A B C : CommAlgCat.{v} R} (φ : A ⟶ B) (ψ : B ⟶ C)
+    (g : Cocharacter.parabolic A (weightCocharacter (R := R) w)) :
+    Cocharacter.mapParabolic (weightCocharacter (R := R) w) (φ ≫ ψ) g =
+      Cocharacter.mapParabolic (weightCocharacter (R := R) w) ψ
+        (Cocharacter.mapParabolic (weightCocharacter (R := R) w) φ g) := by
+  change ((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map (φ ≫ ψ)) g =
+    (((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map φ ≫
+      (Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map ψ) g)
+  exact ConcreteCategory.congr_hom
+    ((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map_comp φ ψ) g
+
+private theorem mem_weightParabolicSubgroup_iff (w : Fin N → ℤ)
+    (A : CommAlgCat.{v} R)
+    (g : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) A) :
+    g ∈ CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
+        (weightParabolicDefiningHopfIdeal R w) A ↔
+      g ∈ Cocharacter.parabolic A (weightCocharacter (R := R) w) := by
+  rw [mem_weightParabolicDefiningPointsSubgroup_iff_blockTriangular,
+    mem_parabolic_weightCocharacter_iff]
+
+private theorem coe_mapWeightParabolic_apply (w : Fin N → ℤ)
+    {A B : CommAlgCat.{v} R} (φ : A ⟶ B)
+    (g : Cocharacter.parabolic A (weightCocharacter (R := R) w)) :
+    (Cocharacter.mapParabolic (weightCocharacter (R := R) w) φ g :
+      HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) B) =
+      HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R N) φ g :=
+  Cocharacter.coe_mapParabolic_apply (weightCocharacter (R := R) w) φ g
+
 section Points
 
 variable {A : Type v} [CommRing A] [Algebra R A]
@@ -57,66 +93,19 @@ theorem mem_weightParabolicDefiningPointsSubgroup_iff (w : Fin N → ℤ)
   rw [mem_weightParabolicDefiningPointsSubgroup_iff_blockTriangular,
     mem_parabolic_weightCocharacter_iff]
 
-/-- Identify the cut-out ambient point subgroup with the dynamic parabolic point subgroup. -/
-private noncomputable def weightParabolicPointsSubgroupMulEquiv (w : Fin N → ℤ) :
-    CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
-        (weightParabolicDefiningHopfIdeal R w) (CommAlgCat.of R A) ≃*
-      Cocharacter.parabolic (CommAlgCat.of R A) (weightCocharacter (R := R) w) :=
-  MulEquiv.subgroupCongr <| Subgroup.ext fun g ↦
-    mem_weightParabolicDefiningPointsSubgroup_iff R w g
-
-private theorem weightParabolicPointsSubgroupMulEquiv_natural (w : Fin N → ℤ)
-    {B : CommAlgCat.{v} R} (phi : CommAlgCat.of R A ⟶ B)
-    (g : CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
-      (weightParabolicDefiningHopfIdeal R w) (CommAlgCat.of R A)) :
-    weightParabolicPointsSubgroupMulEquiv R w
-        (CommHopfAlgCat.mapQuotientPointsSubgroup (coordinateHopfAlgebra R N)
-          (weightParabolicDefiningHopfIdeal R w) phi g) =
-      Cocharacter.mapParabolic (weightCocharacter (R := R) w) phi
-        (weightParabolicPointsSubgroupMulEquiv R w g) := by
-  apply Subtype.ext
-  calc
-    _ = ((CommHopfAlgCat.mapQuotientPointsSubgroup (coordinateHopfAlgebra R N)
-          (weightParabolicDefiningHopfIdeal R w) phi g) :
-        HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) B) :=
-      MulEquiv.subgroupCongr_apply _ _
-    _ = HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R N) phi g :=
-      CommHopfAlgCat.coe_mapQuotientPointsSubgroup_apply _ _ _ _
-    _ = AlgHom.mapValue phi.hom g := rfl
-    _ = AlgHom.mapValue phi.hom
-        ((weightParabolicPointsSubgroupMulEquiv R w g :
-            Cocharacter.parabolic (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
-          HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
-            (CommAlgCat.of R A)) := by
-      congr 1
-    _ = ((Cocharacter.mapParabolic (weightCocharacter (R := R) w) phi
-          (weightParabolicPointsSubgroupMulEquiv R w g) :
-            Cocharacter.parabolic B (weightCocharacter (R := R) w)) :
-        HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) B) :=
-      (Cocharacter.coe_mapParabolic_apply _ _ _).symm
-
 end Points
-
-/-- The cut-out subgroup functor is naturally the dynamic parabolic functor. -/
-private noncomputable def weightParabolicSubgroupPointsIso (w : Fin N → ℤ) :
-    CommHopfAlgCat.quotientPointsSubgroupFunctor (R := R) (coordinateHopfAlgebra R N)
-        (weightParabolicDefiningHopfIdeal R w) ≅
-      Cocharacter.parabolicFunctor (weightCocharacter (R := R) w) :=
-  NatIso.ofComponents
-    (fun _ ↦ (weightParabolicPointsSubgroupMulEquiv R w).toGrpIso)
-    (by
-      intro A B phi
-      ext g
-      exact weightParabolicPointsSubgroupMulEquiv_natural R w phi g)
 
 /-- The weight-parabolic coordinate Hopf algebra represents the dynamic parabolic functor of the
 weight cocharacter, naturally in the commutative value algebra. -/
 noncomputable def weightParabolicPointsIso (w : Fin N → ℤ) :
     HopfAlgebra.pointsFunctor (R := R) (H := weightParabolicCoordinateHopfAlgebra R w) ≅
       Cocharacter.parabolicFunctor (weightCocharacter (R := R) w) :=
-  (CommHopfAlgCat.quotientPointsSubgroupNatIso (coordinateHopfAlgebra R N)
-      (weightParabolicDefiningHopfIdeal R w)).trans
-    (weightParabolicSubgroupPointsIso R w)
+  CommHopfAlgCat.quotientPointsSubgroupRepresentingIso
+    (coordinateHopfAlgebra R N) (weightParabolicDefiningHopfIdeal R w)
+    (fun A ↦ Cocharacter.parabolic A (weightCocharacter (R := R) w))
+    (fun φ ↦ Cocharacter.mapParabolic (weightCocharacter (R := R) w) φ)
+    (mapWeightParabolic_id R w) (mapWeightParabolic_comp R w)
+    (mem_weightParabolicSubgroup_iff R w) (coe_mapWeightParabolic_apply R w)
 
 /-- The ambient point underlying the represented dynamic-parabolic point is induced by the
 quotient coordinate map. -/
@@ -132,15 +121,16 @@ theorem coe_weightParabolicPointsIso_hom_app_apply (w : Fin N → ℤ)
       HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) (CommAlgCat.of R A)) =
       CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
         (weightParabolicDefiningHopfIdeal R w) (CommAlgCat.of R A) f := by
-  have hcomponent := CommHopfAlgCat.quotientPointsSubgroupNatIso_hom_app_apply
-    (coordinateHopfAlgebra R N) (weightParabolicDefiningHopfIdeal R w)
-    (CommAlgCat.of R A) f
   unfold weightParabolicPointsIso
-  exact congrArg
-    (fun g => ((weightParabolicPointsSubgroupMulEquiv R w g :
-        Cocharacter.parabolic (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
-      HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) (CommAlgCat.of R A)))
-    hcomponent
+  convert
+    (CommHopfAlgCat.coe_quotientPointsSubgroupRepresentingIso_hom_app_apply
+      (coordinateHopfAlgebra R N) (weightParabolicDefiningHopfIdeal R w)
+      (fun B ↦ Cocharacter.parabolic B (weightCocharacter (R := R) w))
+      (fun φ ↦ Cocharacter.mapParabolic (weightCocharacter (R := R) w) φ)
+      (mapWeightParabolic_id R w) (mapWeightParabolic_comp R w)
+      (mem_weightParabolicSubgroup_iff R w) (coe_mapWeightParabolic_apply R w)
+      (CommAlgCat.of R A) f) using 1
+  rfl
 
 /-- Applying the quotient inclusion to the inverse representing isomorphism recovers the ambient
 dynamic-parabolic point. -/
@@ -151,22 +141,15 @@ theorem quotientPointsHom_weightParabolicPointsIso_inv_app_apply (w : Fin N → 
     CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
         (weightParabolicDefiningHopfIdeal R w) (CommAlgCat.of R A)
         ((weightParabolicPointsIso R w).inv.app (CommAlgCat.of R A) g) = g.1 := by
-  let f := (weightParabolicPointsIso R w).inv.app (CommAlgCat.of R A) g
-  calc
-    CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
-        (weightParabolicDefiningHopfIdeal R w) (CommAlgCat.of R A) f =
-      (((eqToHom (Cocharacter.parabolicFunctor_obj
-          (weightCocharacter (R := R) w) (CommAlgCat.of R A)))
-        ((weightParabolicPointsIso R w).hom.app (CommAlgCat.of R A) f) :
-          Cocharacter.parabolic (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
-          HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
-            (CommAlgCat.of R A)) :=
-      (coe_weightParabolicPointsIso_hom_app_apply R w f).symm
-    _ = g.1 := by
-      have hinv := CategoryTheory.Iso.inv_hom_id_apply
-        ((weightParabolicPointsIso R w).app (CommAlgCat.of R A))
-        (eqToHom (Cocharacter.parabolicFunctor_obj
-          (weightCocharacter (R := R) w) (CommAlgCat.of R A)).symm g)
-      exact congrArg Subtype.val hinv
+  unfold weightParabolicPointsIso
+  convert
+    (CommHopfAlgCat.quotientPointsHom_quotientPointsSubgroupRepresentingIso_inv_app_apply
+      (coordinateHopfAlgebra R N) (weightParabolicDefiningHopfIdeal R w)
+      (fun B ↦ Cocharacter.parabolic B (weightCocharacter (R := R) w))
+      (fun φ ↦ Cocharacter.mapParabolic (weightCocharacter (R := R) w) φ)
+      (mapWeightParabolic_id R w) (mapWeightParabolic_comp R w)
+      (mem_weightParabolicSubgroup_iff R w) (coe_mapWeightParabolic_apply R w)
+      (CommAlgCat.of R A) g) using 1
+  rfl
 
 end TauCeti.GeneralLinear.Dynamic

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Parabolic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Parabolic.lean
@@ -46,9 +46,9 @@ variable (R : Type u) [CommRing R] {N : ℕ}
 private theorem mapWeightParabolic_id (w : Fin N → ℤ) (A : CommAlgCat.{v} R)
     (g : Cocharacter.parabolic A (weightCocharacter (R := R) w)) :
     Cocharacter.mapParabolic (weightCocharacter (R := R) w) (𝟙 A) g = g := by
-  change ((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map (𝟙 A)) g = g
-  exact ConcreteCategory.congr_hom
-    ((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map_id A) g
+  apply Subtype.ext
+  rw [Cocharacter.coe_mapParabolic_apply, CommAlgCat.hom_id,
+    AlgHom.mapValue_id, MonoidHom.id_apply]
 
 private theorem mapWeightParabolic_comp (w : Fin N → ℤ)
     {A B C : CommAlgCat.{v} R} (φ : A ⟶ B) (ψ : B ⟶ C)
@@ -56,11 +56,10 @@ private theorem mapWeightParabolic_comp (w : Fin N → ℤ)
     Cocharacter.mapParabolic (weightCocharacter (R := R) w) (φ ≫ ψ) g =
       Cocharacter.mapParabolic (weightCocharacter (R := R) w) ψ
         (Cocharacter.mapParabolic (weightCocharacter (R := R) w) φ g) := by
-  change ((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map (φ ≫ ψ)) g =
-    (((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map φ ≫
-      (Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map ψ) g)
-  exact ConcreteCategory.congr_hom
-    ((Cocharacter.parabolicFunctor (weightCocharacter (R := R) w)).map_comp φ ψ) g
+  apply Subtype.ext
+  rw [Cocharacter.coe_mapParabolic_apply, Cocharacter.coe_mapParabolic_apply,
+    Cocharacter.coe_mapParabolic_apply, CommAlgCat.hom_comp,
+    AlgHom.mapValue_comp, MonoidHom.comp_apply]
 
 private theorem mem_weightParabolicSubgroup_iff (w : Fin N → ℤ)
     (A : CommAlgCat.{v} R)

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -7,7 +7,9 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SchemePoints
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.FunctorOfPoints
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
+import TauCeti.CategoryTheory.Comma.Over
 
 /-!
 # The general linear group scheme
@@ -36,6 +38,8 @@ lie in the same universe, so this file uses that same-universe setting.
 ## Main declarations
 
 * `TauCeti.GeneralLinear.groupScheme`: the general linear group scheme over `Spec R`.
+* `TauCeti.GeneralLinear.hopfIdealInclusion`: the generic closed immersion into `GL_n`
+  cut out by a Hopf ideal.
 * `TauCeti.GeneralLinear.groupSchemeSpecIso`: its canonical raw-coordinate presentation.
 * `TauCeti.GeneralLinear.groupSchemeMulSourceIso`: the tensor-coordinate presentation of the
   multiplication source.
@@ -98,6 +102,45 @@ lemma groupScheme_def :
   unfold groupScheme
   rfl
 
+/-- The closed subgroup inclusion into `GL_n` cut out by a Hopf ideal of its coordinate
+algebra. -/
+noncomputable def hopfIdealInclusion
+    (I : HopfIdeal R (coordinateHopfAlgebra R n)) :
+    CommHopfAlgCat.quotientSpec (coordinateHopfAlgebra R n) I ⟶ groupScheme R n :=
+  CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R n) I ≫
+    (eqToIso (groupScheme_def R n).symm).hom
+
+/-- A Hopf-ideal inclusion is the quotient-spectrum inclusion followed by the named
+identification with `GL_n`. -/
+theorem hopfIdealInclusion_def (I : HopfIdeal R (coordinateHopfAlgebra R n)) :
+    hopfIdealInclusion R n I =
+      CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R n) I ≫
+        (eqToIso (groupScheme_def R n).symm).hom := by
+  rw [hopfIdealInclusion]
+
+/-- Every subgroup of `GL_n` cut out by a Hopf ideal is closed. -/
+instance isClosedImmersion_hopfIdealInclusion
+    (I : HopfIdeal R (coordinateHopfAlgebra R n)) :
+    IsClosedImmersion (hopfIdealInclusion R n I).hom.hom.left := by
+  let c := (CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R n) I).hom.hom.left
+  let e := ((eqToIso (groupScheme_def R n).symm).hom).hom.hom.left
+  have hc : IsClosedImmersion c := by infer_instance
+  have hce : IsClosedImmersion (c ≫ e) :=
+    (MorphismProperty.cancel_right_of_respectsIso _ c e).2 hc
+  rw [hopfIdealInclusion_def]
+  simpa only [Grp.comp', Mon.comp_hom', Over.comp_left] using hce
+
+/-- A subgroup of `GL_n` cut out by a Hopf ideal is locally of finite type over the base. -/
+instance locallyOfFiniteType_hopfIdealQuotientSpec
+    (I : HopfIdeal R (coordinateHopfAlgebra R n)) :
+    LocallyOfFiniteType
+      (CommHopfAlgCat.quotientSpec (coordinateHopfAlgebra R n) I).X.hom :=
+  FiniteTypeCommHopfAlgCat.locallyOfFiniteType_quotientSpec
+    (⟨coordinateHopfAlgebra R n,
+      inferInstanceAs (Algebra.FiniteType R (coordinateHopfAlgebra R n))⟩ :
+      FiniteTypeCommHopfAlgCat R)
+    I
+
 /-- The scheme underlying the general linear group scheme is the spectrum of its bundled
 coordinate Hopf algebra. -/
 lemma groupScheme_X_left :
@@ -144,6 +187,8 @@ lemma groupScheme_X_hom :
       ext r
       exact (coordinateHopfAlgebraAlgEquiv R n).commutes r |>.symm
 
+/-- The tensor square of the raw coordinate ring is identified with the tensor square of the
+bundled coordinate Hopf algebra. -/
 private noncomputable def coordinateTensorAlgEquiv :
     CoordinateRing R n ⊗[R] CoordinateRing R n ≃ₐ[R]
       coordinateHopfAlgebra R n ⊗[R] coordinateHopfAlgebra R n :=

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Parabolic
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Order
+import TauCeti.CategoryTheory.Comma.Over
+
+/-!
+# Weight-Levi subgroup schemes of the general linear group
+
+An integer weight `w i` on each coordinate of `GL_N` decomposes the standard representation into
+its weight spaces. The corresponding Levi subgroup consists of the invertible matrices preserving
+every weight space, so its `(i,j)` entry vanishes whenever `w i ≠ w j`.
+
+This file represents that subgroup over an arbitrary commutative base ring. Its defining Hopf
+ideal is the join of the weight-parabolic ideals for `w` and `-w`: intersecting the two opposite
+block-triangular subgroups leaves precisely the block-diagonal Levi. This construction reuses the
+weight-parabolic Hopf-ideal and closed-subgroup API rather than repeating its comultiplication and
+antipode calculations.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.weightLeviDefiningHopfIdeal`: the join of the two opposite
+  weight-parabolic ideals.
+* `TauCeti.GeneralLinear.weightLeviGroupScheme`: the resulting finite-type closed subgroup
+  scheme of `GL_N`.
+* `TauCeti.GeneralLinear.mem_weightLeviDefiningPointsSubgroup_iff`: its algebra-valued points are
+  exactly the matrices preserving every weight space.
+
+## References
+
+* G. R. Kempf, *Instability in invariant theory*, Annals of Mathematics 108 (1978), §2.
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 13.
+
+This advances the dynamic-parabolic route in Layer 7, "Structure theory", of the ReductiveGroups
+roadmap by constructing the scheme-level Levi attached to a weight cocharacter.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+variable (R : Type u) [CommRing R] {N : ℕ}
+
+/-- The Hopf ideal cutting out the matrices preserving every weight space. It is the join of the
+weight-parabolic ideals for the two opposite filtrations. -/
+noncomputable def weightLeviDefiningHopfIdeal (w : Fin N → ℤ) :
+    HopfIdeal R (coordinateHopfAlgebra R N) :=
+  weightParabolicDefiningHopfIdeal R w ⊔ weightParabolicDefiningHopfIdeal R (-w)
+
+/-- The underlying ideal of the weight Levi is the sum of the two opposite
+weight-parabolic ideals. -/
+@[simp]
+theorem weightLeviDefiningHopfIdeal_toIdeal (w : Fin N → ℤ) :
+    (weightLeviDefiningHopfIdeal R w).toIdeal =
+      (weightParabolicDefiningHopfIdeal R w).toIdeal ⊔
+        (weightParabolicDefiningHopfIdeal R (-w)).toIdeal := by
+  rw [weightLeviDefiningHopfIdeal, HopfIdeal.sup_toIdeal]
+
+/-- The coordinate Hopf algebra of the weight Levi attached to `w`. -/
+noncomputable abbrev weightLeviCoordinateHopfAlgebra (w : Fin N → ℤ) :
+    _root_.CommHopfAlgCat.{u} R :=
+  CommHopfAlgCat.quotient (coordinateHopfAlgebra R N)
+    (weightLeviDefiningHopfIdeal R w)
+
+/-- The affine group scheme represented by the weight-Levi coordinate Hopf algebra. -/
+noncomputable abbrev weightLeviGroupScheme (w : Fin N → ℤ) :=
+  CommHopfAlgCat.quotientSpec (coordinateHopfAlgebra R N)
+    (weightLeviDefiningHopfIdeal R w)
+
+/-- The closed immersion from the weight Levi into the named general linear group scheme. -/
+noncomputable def weightLeviInclusion (w : Fin N → ℤ) :
+    weightLeviGroupScheme R w ⟶ groupScheme R N :=
+  CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
+      (weightLeviDefiningHopfIdeal R w) ≫
+    (eqToIso (groupScheme_def R N).symm).hom
+
+/-- The weight-Levi inclusion is the quotient-spectrum inclusion followed by the named
+identification with `GL_N`. -/
+theorem weightLeviInclusion_def (w : Fin N → ℤ) :
+    weightLeviInclusion R w =
+      CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
+          (weightLeviDefiningHopfIdeal R w) ≫
+        (eqToIso (groupScheme_def R N).symm).hom := by
+  rw [weightLeviInclusion]
+
+private theorem weightLeviInclusion_hom_left (w : Fin N → ℤ) :
+    (weightLeviInclusion R w).hom.hom.left =
+      (CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
+          (weightLeviDefiningHopfIdeal R w)).hom.hom.left ≫
+        ((eqToIso (groupScheme_def R N).symm).hom).hom.hom.left := by
+  rw [weightLeviInclusion_def]
+  rfl
+
+/-- The weight-Levi inclusion into `GL_N` is a closed immersion. -/
+instance isClosedImmersion_weightLeviInclusion (w : Fin N → ℤ) :
+    IsClosedImmersion (weightLeviInclusion R w).hom.hom.left := by
+  let c := (CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
+    (weightLeviDefiningHopfIdeal R w)).hom.hom.left
+  let e := ((eqToIso (groupScheme_def R N).symm).hom).hom.hom.left
+  have hc : IsClosedImmersion c := by infer_instance
+  have hce : IsClosedImmersion (c ≫ e) :=
+    (MorphismProperty.cancel_right_of_respectsIso _ c e).2 hc
+  rw [weightLeviInclusion_hom_left]
+  exact hce
+
+/-- The weight-Levi group scheme is locally of finite type over the base. -/
+instance locallyOfFiniteType_weightLeviGroupScheme (w : Fin N → ℤ) :
+    LocallyOfFiniteType (weightLeviGroupScheme R w).X.hom :=
+  FiniteTypeCommHopfAlgCat.locallyOfFiniteType_quotientSpec
+    (⟨coordinateHopfAlgebra R N,
+      inferInstanceAs (Algebra.FiniteType R (coordinateHopfAlgebra R N))⟩ :
+      FiniteTypeCommHopfAlgCat R)
+    (weightLeviDefiningHopfIdeal R w)
+
+/-- The subgroup cut out by the weight-Levi ideal consists exactly of matrices preserving every
+weight space: entries between distinct weights vanish. -/
+@[simp]
+theorem mem_weightLeviDefiningPointsSubgroup_iff (w : Fin N → ℤ)
+    {A : Type*} [CommRing A] [Algebra R A]
+    (g : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
+      (CommAlgCat.of R A)) :
+    g ∈ CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
+        (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) ↔
+      ∀ i j, w i ≠ w j →
+        (pointsMulEquiv N g : Matrix (Fin N) (Fin N) A) i j = 0 := by
+  rw [weightLeviDefiningHopfIdeal,
+    CommHopfAlgCat.quotientPointsSubgroup_sup, Subgroup.mem_inf,
+    mem_weightParabolicDefiningPointsSubgroup_iff_blockTriangular,
+    mem_weightParabolicDefiningPointsSubgroup_iff_blockTriangular]
+  simp only [Matrix.BlockTriangular, Function.comp_apply, OrderDual.toDual_lt_toDual,
+    Pi.neg_apply, neg_lt_neg_iff]
+  constructor
+  · rintro ⟨hupper, hlower⟩ i j hij
+    rcases lt_or_gt_of_ne hij with hij | hji
+    · exact hupper hij
+    · exact hlower hji
+  · intro h
+    exact ⟨fun i j hij ↦ h i j hij.ne, fun i j hji ↦ h i j hji.ne'⟩
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi.lean
@@ -60,6 +60,12 @@ noncomputable def weightLeviDefiningHopfIdeal (w : Fin N → ℤ) :
     HopfIdeal R (coordinateHopfAlgebra R N) :=
   weightParabolicDefiningHopfIdeal R w ⊔ weightParabolicDefiningHopfIdeal R (-w)
 
+/-- The weight-Levi ideal is the join of the ideals for the two opposite weight parabolics. -/
+theorem weightLeviDefiningHopfIdeal_def (w : Fin N → ℤ) :
+    weightLeviDefiningHopfIdeal R w =
+      weightParabolicDefiningHopfIdeal R w ⊔ weightParabolicDefiningHopfIdeal R (-w) := by
+  rw [weightLeviDefiningHopfIdeal]
+
 /-- The coordinate Hopf algebra of the weight Levi attached to `w`. -/
 noncomputable abbrev weightLeviCoordinateHopfAlgebra (w : Fin N → ℤ) :
     _root_.CommHopfAlgCat.{u} R :=
@@ -107,7 +113,7 @@ theorem mem_weightLeviDefiningPointsSubgroup_iff_apply_eq_zero (w : Fin N → �
         (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) ↔
       ∀ i j, w i ≠ w j →
         (pointsMulEquiv N g : Matrix (Fin N) (Fin N) A) i j = 0 := by
-  rw [weightLeviDefiningHopfIdeal,
+  rw [weightLeviDefiningHopfIdeal_def,
     CommHopfAlgCat.quotientPointsSubgroup_sup, Subgroup.mem_inf,
     mem_weightParabolicDefiningPointsSubgroup_iff_blockTriangular,
     mem_weightParabolicDefiningPointsSubgroup_iff_blockTriangular]

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi.lean
@@ -28,13 +28,17 @@ antipode calculations.
   weight-parabolic ideals.
 * `TauCeti.GeneralLinear.weightLeviGroupScheme`: the resulting finite-type closed subgroup
   scheme of `GL_N`.
-* `TauCeti.GeneralLinear.mem_weightLeviDefiningPointsSubgroup_iff`: its algebra-valued points are
-  exactly the matrices preserving every weight space.
+* `TauCeti.GeneralLinear.mem_weightLeviDefiningPointsSubgroup_iff_apply_eq_zero`: its
+  algebra-valued points are exactly the matrices preserving every weight space.
 
 ## References
 
 * G. R. Kempf, *Instability in invariant theory*, Annals of Mathematics 108 (1978), §2.
 * J. S. Milne, *Algebraic Groups* (2017), Chapter 13.
+* The closed-subgroup packaging specializes the generic construction abstracted from
+  `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Parabolic`, which in turn adapts
+  `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Borel` and
+  `TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic`.
 
 This advances the dynamic-parabolic route in Layer 7, "Structure theory", of the ReductiveGroups
 roadmap by constructing the scheme-level Levi attached to a weight cocharacter.
@@ -56,15 +60,6 @@ noncomputable def weightLeviDefiningHopfIdeal (w : Fin N → ℤ) :
     HopfIdeal R (coordinateHopfAlgebra R N) :=
   weightParabolicDefiningHopfIdeal R w ⊔ weightParabolicDefiningHopfIdeal R (-w)
 
-/-- The underlying ideal of the weight Levi is the sum of the two opposite
-weight-parabolic ideals. -/
-@[simp]
-theorem weightLeviDefiningHopfIdeal_toIdeal (w : Fin N → ℤ) :
-    (weightLeviDefiningHopfIdeal R w).toIdeal =
-      (weightParabolicDefiningHopfIdeal R w).toIdeal ⊔
-        (weightParabolicDefiningHopfIdeal R (-w)).toIdeal := by
-  rw [weightLeviDefiningHopfIdeal, HopfIdeal.sup_toIdeal]
-
 /-- The coordinate Hopf algebra of the weight Levi attached to `w`. -/
 noncomputable abbrev weightLeviCoordinateHopfAlgebra (w : Fin N → ℤ) :
     _root_.CommHopfAlgCat.{u} R :=
@@ -79,9 +74,7 @@ noncomputable abbrev weightLeviGroupScheme (w : Fin N → ℤ) :=
 /-- The closed immersion from the weight Levi into the named general linear group scheme. -/
 noncomputable def weightLeviInclusion (w : Fin N → ℤ) :
     weightLeviGroupScheme R w ⟶ groupScheme R N :=
-  CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
-      (weightLeviDefiningHopfIdeal R w) ≫
-    (eqToIso (groupScheme_def R N).symm).hom
+  hopfIdealInclusion R N (weightLeviDefiningHopfIdeal R w)
 
 /-- The weight-Levi inclusion is the quotient-spectrum inclusion followed by the named
 identification with `GL_N`. -/
@@ -90,41 +83,23 @@ theorem weightLeviInclusion_def (w : Fin N → ℤ) :
       CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
           (weightLeviDefiningHopfIdeal R w) ≫
         (eqToIso (groupScheme_def R N).symm).hom := by
-  rw [weightLeviInclusion]
-
-private theorem weightLeviInclusion_hom_left (w : Fin N → ℤ) :
-    (weightLeviInclusion R w).hom.hom.left =
-      (CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
-          (weightLeviDefiningHopfIdeal R w)).hom.hom.left ≫
-        ((eqToIso (groupScheme_def R N).symm).hom).hom.hom.left := by
-  rw [weightLeviInclusion_def]
-  rfl
+  rw [weightLeviInclusion, hopfIdealInclusion_def]
 
 /-- The weight-Levi inclusion into `GL_N` is a closed immersion. -/
 instance isClosedImmersion_weightLeviInclusion (w : Fin N → ℤ) :
     IsClosedImmersion (weightLeviInclusion R w).hom.hom.left := by
-  let c := (CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
-    (weightLeviDefiningHopfIdeal R w)).hom.hom.left
-  let e := ((eqToIso (groupScheme_def R N).symm).hom).hom.hom.left
-  have hc : IsClosedImmersion c := by infer_instance
-  have hce : IsClosedImmersion (c ≫ e) :=
-    (MorphismProperty.cancel_right_of_respectsIso _ c e).2 hc
-  rw [weightLeviInclusion_hom_left]
-  exact hce
+  rw [weightLeviInclusion]
+  infer_instance
 
 /-- The weight-Levi group scheme is locally of finite type over the base. -/
 instance locallyOfFiniteType_weightLeviGroupScheme (w : Fin N → ℤ) :
-    LocallyOfFiniteType (weightLeviGroupScheme R w).X.hom :=
-  FiniteTypeCommHopfAlgCat.locallyOfFiniteType_quotientSpec
-    (⟨coordinateHopfAlgebra R N,
-      inferInstanceAs (Algebra.FiniteType R (coordinateHopfAlgebra R N))⟩ :
-      FiniteTypeCommHopfAlgCat R)
-    (weightLeviDefiningHopfIdeal R w)
+    LocallyOfFiniteType (weightLeviGroupScheme R w).X.hom := by
+  infer_instance
 
 /-- The subgroup cut out by the weight-Levi ideal consists exactly of matrices preserving every
 weight space: entries between distinct weights vanish. -/
 @[simp]
-theorem mem_weightLeviDefiningPointsSubgroup_iff (w : Fin N → ℤ)
+theorem mem_weightLeviDefiningPointsSubgroup_iff_apply_eq_zero (w : Fin N → ℤ)
     {A : Type*} [CommRing A] [Algebra R A]
     (g : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
       (CommAlgCat.of R A)) :

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Parabolic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Parabolic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Scheme
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
 public import Mathlib.LinearAlgebra.Matrix.Block
 import TauCeti.CategoryTheory.Comma.Over
@@ -202,9 +201,7 @@ noncomputable abbrev weightParabolicGroupScheme (w : Fin N → ℤ) :=
 /-- The closed immersion from the weight parabolic into the named general linear group scheme. -/
 noncomputable def weightParabolicInclusion (w : Fin N → ℤ) :
     weightParabolicGroupScheme R w ⟶ groupScheme R N :=
-  CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
-      (weightParabolicDefiningHopfIdeal R w) ≫
-    (eqToIso (groupScheme_def R N).symm).hom
+  hopfIdealInclusion R N (weightParabolicDefiningHopfIdeal R w)
 
 /-- The weight-parabolic inclusion is the quotient-spectrum inclusion followed by the named
 identification with `GL_N`. -/
@@ -213,7 +210,7 @@ theorem weightParabolicInclusion_def (w : Fin N → ℤ) :
       CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
           (weightParabolicDefiningHopfIdeal R w) ≫
         (eqToIso (groupScheme_def R N).symm).hom := by
-  rw [weightParabolicInclusion]
+  rw [weightParabolicInclusion, hopfIdealInclusion_def]
 
 /-- The coordinate morphism recovered from the weight-parabolic inclusion is the quotient
 coordinate map. -/
@@ -231,25 +228,11 @@ theorem weightParabolicInclusion_coordinateMap (w : Fin N → ℤ) :
   rw [weightParabolicCoordinateMap]
   simp
 
-private theorem weightParabolicInclusion_hom_left (w : Fin N → ℤ) :
-    (weightParabolicInclusion R w).hom.hom.left =
-      (CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
-          (weightParabolicDefiningHopfIdeal R w)).hom.hom.left ≫
-        ((eqToIso (groupScheme_def R N).symm).hom).hom.hom.left := by
-  rw [weightParabolicInclusion_def]
-  rfl
-
 /-- The weight-parabolic inclusion into `GL_N` is a closed immersion. -/
 instance isClosedImmersion_weightParabolicInclusion (w : Fin N → ℤ) :
     IsClosedImmersion (weightParabolicInclusion R w).hom.hom.left := by
-  let c := (CommHopfAlgCat.quotientSpecι (coordinateHopfAlgebra R N)
-    (weightParabolicDefiningHopfIdeal R w)).hom.hom.left
-  let e := ((eqToIso (groupScheme_def R N).symm).hom).hom.hom.left
-  have hc : IsClosedImmersion c := by infer_instance
-  have hce : IsClosedImmersion (c ≫ e) :=
-    (MorphismProperty.cancel_right_of_respectsIso _ c e).2 hc
-  rw [weightParabolicInclusion_hom_left]
-  exact hce
+  rw [weightParabolicInclusion]
+  infer_instance
 
 /-- The weight-parabolic coordinate Hopf algebra with its finite-type property. -/
 noncomputable def weightParabolicFiniteTypeCoordinateHopfAlgebra (w : Fin N → ℤ) :
@@ -266,12 +249,8 @@ theorem weightParabolicFiniteTypeCoordinateHopfAlgebra_obj (w : Fin N → ℤ) :
 
 /-- The weight-parabolic group scheme is locally of finite type over the base. -/
 instance locallyOfFiniteType_weightParabolicGroupScheme (w : Fin N → ℤ) :
-    LocallyOfFiniteType (weightParabolicGroupScheme R w).X.hom :=
-  FiniteTypeCommHopfAlgCat.locallyOfFiniteType_quotientSpec
-    (⟨coordinateHopfAlgebra R N,
-      inferInstanceAs (Algebra.FiniteType R (coordinateHopfAlgebra R N))⟩ :
-      FiniteTypeCommHopfAlgCat R)
-    (weightParabolicDefiningHopfIdeal R w)
+    LocallyOfFiniteType (weightParabolicGroupScheme R w).X.hom := by
+  infer_instance
 
 /-- The subgroup cut out by the weight-parabolic ideal consists exactly of block-triangular
 ambient points. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
@@ -286,6 +286,129 @@ lemma quotientPointsSubgroupNatIso_inv_app_apply (H : _root_.CommHopfAlgCat.{v} 
       liftQuotientPoint H I A g ((mem_quotientPointsSubgroup_iff H I A g).mp g.property) := by
   exact quotientPointsSubgroupIso_inv_apply H I A g
 
+section SubgroupRepresentability
+
+variable (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H)
+variable (S : (A : CommAlgCat.{w} R) →
+  Subgroup (HopfAlgebra.points (R := R) (H := H) A))
+variable (mapS : {A B : CommAlgCat.{w} R} → (A ⟶ B) → S A →* S B)
+variable (mapS_id : ∀ (A : CommAlgCat.{w} R) (g : S A), mapS (𝟙 A) g = g)
+variable (mapS_comp : ∀ {A B C : CommAlgCat.{w} R} (φ : A ⟶ B) (ψ : B ⟶ C)
+  (g : S A), mapS (φ ≫ ψ) g = mapS ψ (mapS φ g))
+variable (hS : ∀ (A : CommAlgCat.{w} R)
+  (g : HopfAlgebra.points (R := R) (H := H) A),
+  g ∈ quotientPointsSubgroup H I A ↔ g ∈ S A)
+variable (hmapS : ∀ {A B : CommAlgCat.{w} R} (φ : A ⟶ B) (g : S A),
+  (mapS φ g : HopfAlgebra.points (R := R) (H := H) B) =
+    HopfAlgebra.mapPoints (H := H) φ g)
+
+/-- Pointwise identification of a Hopf-ideal cut-out with a subgroup family having the same
+membership predicate. -/
+private noncomputable def quotientPointsSubgroupMulEquiv (A : CommAlgCat.{w} R) :
+    quotientPointsSubgroup H I A ≃* S A :=
+  MulEquiv.subgroupCongr <| Subgroup.ext fun g ↦ hS A g
+
+include hmapS in
+private theorem quotientPointsSubgroupMulEquiv_natural
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) (g : quotientPointsSubgroup H I A) :
+    quotientPointsSubgroupMulEquiv H I S hS B
+        (mapQuotientPointsSubgroup H I φ g) =
+      mapS φ (quotientPointsSubgroupMulEquiv H I S hS A g) := by
+  apply Subtype.ext
+  calc
+    _ = (mapQuotientPointsSubgroup H I φ g :
+        HopfAlgebra.points (R := R) (H := H) B) :=
+      MulEquiv.subgroupCongr_apply _ _
+    _ = HopfAlgebra.mapPoints (H := H) φ g :=
+      coe_mapQuotientPointsSubgroup_apply H I φ g
+    _ = HopfAlgebra.mapPoints (H := H) φ
+        (quotientPointsSubgroupMulEquiv H I S hS A g) := by
+      exact congrArg (HopfAlgebra.mapPoints (H := H) φ)
+        (MulEquiv.subgroupCongr_apply _ g).symm
+    _ = (mapS φ (quotientPointsSubgroupMulEquiv H I S hS A g) :
+        HopfAlgebra.points (R := R) (H := H) B) :=
+      (hmapS φ _).symm
+
+include hS hmapS
+/-- The Hopf-ideal cut-out subgroup functor is naturally isomorphic to any stable subgroup
+family with the same pointwise membership condition. -/
+noncomputable def quotientPointsSubgroupFunctorIso :
+    quotientPointsSubgroupFunctor (R := R) H I ≅
+      HopfAlgebra.subgroupFunctor S mapS mapS_id mapS_comp :=
+  NatIso.ofComponents
+    (fun A ↦ (quotientPointsSubgroupMulEquiv H I S hS A).toGrpIso)
+    (by
+      intro A B φ
+      apply GrpCat.hom_ext
+      apply MonoidHom.ext
+      intro g
+      exact quotientPointsSubgroupMulEquiv_natural H I S mapS hS hmapS φ g)
+
+/-- A Hopf quotient represents any value-algebra-stable family of ambient point subgroups
+whose membership condition agrees with vanishing on the Hopf ideal. -/
+@[expose] noncomputable def quotientPointsSubgroupRepresentingIso :
+    HopfAlgebra.pointsFunctor (R := R) (H := quotient H I) ≅
+      HopfAlgebra.subgroupFunctor S mapS mapS_id mapS_comp :=
+  (quotientPointsSubgroupNatIso H I).trans
+    (quotientPointsSubgroupFunctorIso H I S mapS mapS_id mapS_comp hS hmapS)
+
+/-- The represented subgroup point underlying a quotient point is induced by the quotient
+coordinate map. -/
+@[simp]
+theorem coe_quotientPointsSubgroupRepresentingIso_hom_app_apply
+    (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := quotient H I) A) :
+    ((CategoryTheory.ConcreteCategory.hom
+      (X := HopfAlgebra.pointsFunctor (R := R) (H := quotient H I) |>.obj A)
+      (Y := GrpCat.of (S A))
+      ((quotientPointsSubgroupRepresentingIso
+        H I S mapS mapS_id mapS_comp hS hmapS).hom.app A) f : S A) :
+          HopfAlgebra.points (R := R) (H := H) A) =
+      quotientPointsHom H I A f := by
+  have hcomponent := quotientPointsSubgroupNatIso_hom_app_apply H I A f
+  unfold quotientPointsSubgroupRepresentingIso
+  exact congrArg
+    (fun g ↦ ((quotientPointsSubgroupMulEquiv H I S hS A g : S A) :
+      HopfAlgebra.points (R := R) (H := H) A))
+    hcomponent
+
+/-- Applying the quotient inclusion to the inverse representing isomorphism recovers the
+ambient subgroup point. -/
+@[simp]
+theorem quotientPointsHom_quotientPointsSubgroupRepresentingIso_inv_app_apply
+    (A : CommAlgCat.{w} R) (g : S A) :
+    quotientPointsHom H I A
+        (CategoryTheory.ConcreteCategory.hom
+          (X := GrpCat.of (S A))
+          (Y := HopfAlgebra.pointsFunctor (R := R) (H := quotient H I) |>.obj A)
+          ((quotientPointsSubgroupRepresentingIso
+            H I S mapS mapS_id mapS_comp hS hmapS).inv.app A) g) =
+      g.1 := by
+  let f :=
+    CategoryTheory.ConcreteCategory.hom
+      (X := GrpCat.of (S A))
+      (Y := HopfAlgebra.pointsFunctor (R := R) (H := quotient H I) |>.obj A)
+      ((quotientPointsSubgroupRepresentingIso
+        H I S mapS mapS_id mapS_comp hS hmapS).inv.app A) g
+  calc
+    quotientPointsHom H I A f =
+        ((CategoryTheory.ConcreteCategory.hom
+          (X := HopfAlgebra.pointsFunctor (R := R) (H := quotient H I) |>.obj A)
+          (Y := GrpCat.of (S A))
+          ((quotientPointsSubgroupRepresentingIso
+            H I S mapS mapS_id mapS_comp hS hmapS).hom.app A) f : S A) :
+              HopfAlgebra.points (R := R) (H := H) A) :=
+      (coe_quotientPointsSubgroupRepresentingIso_hom_app_apply
+        H I S mapS mapS_id mapS_comp hS hmapS A f).symm
+    _ = g.1 := by
+      have hinv := CategoryTheory.Iso.inv_hom_id_apply
+        ((quotientPointsSubgroupRepresentingIso
+          H I S mapS mapS_id mapS_comp hS hmapS).app A)
+        g
+      exact congrArg Subtype.val hinv
+
+end SubgroupRepresentability
+
 /-- The image of a quotient point under the subgroup functor is its mapped quotient point,
 viewed inside the cut-out subgroup. -/
 lemma quotientPointsSubgroupFunctor_map_quotientPointsHom

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Naturality.lean
@@ -346,7 +346,7 @@ noncomputable def quotientPointsSubgroupFunctorIso :
 
 /-- A Hopf quotient represents any value-algebra-stable family of ambient point subgroups
 whose membership condition agrees with vanishing on the Hopf ideal. -/
-@[expose] noncomputable def quotientPointsSubgroupRepresentingIso :
+noncomputable def quotientPointsSubgroupRepresentingIso :
     HopfAlgebra.pointsFunctor (R := R) (H := quotient H I) ≅
       HopfAlgebra.subgroupFunctor S mapS mapS_id mapS_comp :=
   (quotientPointsSubgroupNatIso H I).trans

--- a/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.lean
@@ -27,6 +27,8 @@ functor of points has values `A ↦ (H →ₐ[R] A)` and group law given by conv
 * `HopfAlgebra.mapPoints`: the group homomorphism induced by post-composition in the value
   algebra.
 * `HopfAlgebra.pointsFunctor`: the functor `CommAlgCat R ⥤ GrpCat`.
+* `HopfAlgebra.subgroupFunctor`: a functor assembled from point subgroups stable under
+  change of value algebra.
 
 ## References
 
@@ -129,6 +131,52 @@ lemma pointsFunctor_map_apply_apply {A B : CommAlgCat.{w} R} (φ : A ⟶ B)
     (f : WithConv (H →ₐ[R] A)) (h : H) :
     (((pointsFunctor (H := H)).map φ f : WithConv (H →ₐ[R] B)).ofConv) h =
       φ.hom (f.ofConv h) :=
+  rfl
+
+/-- A family of subgroups of the functor of points, equipped with compatible maps between
+value algebras, as a group-valued functor. -/
+@[expose] noncomputable def subgroupFunctor
+    (S : (A : CommAlgCat.{w} R) → Subgroup (points (H := H) A))
+    (map : {A B : CommAlgCat.{w} R} → (A ⟶ B) → S A →* S B)
+    (map_id : ∀ (A : CommAlgCat.{w} R) (g : S A), map (𝟙 A) g = g)
+    (map_comp : ∀ {A B C : CommAlgCat.{w} R} (φ : A ⟶ B) (ψ : B ⟶ C) (g : S A),
+      map (φ ≫ ψ) g = map ψ (map φ g)) :
+    CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
+  obj A := GrpCat.of (S A)
+  map φ := GrpCat.ofHom (map φ)
+  map_id A := by
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    exact map_id A g
+  map_comp φ ψ := by
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro g
+    exact map_comp φ ψ g
+
+/-- The object part of a point-subgroup functor is the specified subgroup. -/
+@[simp]
+lemma subgroupFunctor_obj
+    (S : (A : CommAlgCat.{w} R) → Subgroup (points (H := H) A))
+    (map : {A B : CommAlgCat.{w} R} → (A ⟶ B) → S A →* S B)
+    (map_id : ∀ (A : CommAlgCat.{w} R) (g : S A), map (𝟙 A) g = g)
+    (map_comp : ∀ {A B C : CommAlgCat.{w} R} (φ : A ⟶ B) (ψ : B ⟶ C) (g : S A),
+      map (φ ≫ ψ) g = map ψ (map φ g))
+    (A : CommAlgCat.{w} R) :
+    (subgroupFunctor (H := H) S map map_id map_comp).obj A = GrpCat.of (S A) :=
+  rfl
+
+/-- The map part of a point-subgroup functor is the specified restricted point map. -/
+@[simp]
+lemma subgroupFunctor_map
+    (S : (A : CommAlgCat.{w} R) → Subgroup (points (H := H) A))
+    (map : {A B : CommAlgCat.{w} R} → (A ⟶ B) → S A →* S B)
+    (map_id : ∀ (A : CommAlgCat.{w} R) (g : S A), map (𝟙 A) g = g)
+    (map_comp : ∀ {A B C : CommAlgCat.{w} R} (φ : A ⟶ B) (ψ : B ⟶ C) (g : S A),
+      map (φ ≫ ψ) g = map ψ (map φ g))
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    (subgroupFunctor (H := H) S map map_id map_comp).map φ = GrpCat.ofHom (map φ) :=
   rfl
 
 end HopfAlgebra


### PR DESCRIPTION
This PR represents the dynamic Levi attached to every integer weight cocharacter of `GL_N` over an arbitrary commutative base ring. Define its Hopf ideal as the join of the already-established weight-parabolic ideals for `w` and `-w`, package the quotient as a finite-type closed subgroup scheme of `GL_N`, prove that its algebra-valued points are exactly the invertible matrices whose entries between distinct weight spaces vanish, and identify its points functor naturally with `Cocharacter.leviFunctor (weightCocharacter w)`.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 7, “Borel subgroups, maximal tori, and their conjugacy; parabolic subgroups and Levi decomposition,” together with its instruction to keep the dynamic approach to parabolic/Levi/unipotent subgroups as a parallel route. The milestone is scheme-level representability of the dynamic parabolic and Levi for weight cocharacters. After this PR, the milestone still needs general representability of the dynamic unipotent subgroup and promotion of the pointwise Levi decomposition to the represented subgroup schemes before the broader parabolic structure and conjugacy results can proceed.

This is the most effective current step because `weightParabolicGroupScheme` and its natural dynamic representing isomorphism are already on `main`, as is the pointwise characterization `mem_levi_weightCocharacter_iff`; this PR joins those two completed sides without depending on the in-flight unipotent-radical work or duplicating the open `GL_N` root-datum work.

The construction reuses `HopfIdeal.sup_toIdeal`, `CommHopfAlgCat.quotientPointsSubgroup_sup`, the generic quotient-spectrum closed immersion and finite-type APIs, and `CommHopfAlgCat.quotientPointsSubgroupNatIso`. Its naturality interface follows the established organization of `GeneralLinear.Dynamic.Weight.Parabolic`. No Mathlib infrastructure is vendored. The mathematical description follows Kempf, *Instability in invariant theory*, §2, and Milne, *Algebraic Groups*, Chapter 13, as recorded in both module docstrings.

Add `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi.lean` (149 lines) and `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi.lean` (175 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"weight-cocharacter-levi-representability"}-->

🤖 Prepared with Codex
