### PR TITLE
refactor(RootSystem): derive Aut subgroup finiteness from the ambient group

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean
@@ -13,12 +13,13 @@ public import TauCeti.LinearAlgebra.RootSystem.EquivInvariance
 # Permutation actions of Weyl groups
 
 This file proves that the action of the automorphism group of a root system on its root indices is
-faithful.  Consequently, every subgroup of that automorphism group, and in particular the Weyl
-group, is finite when the root index type is finite.  It also records how that action evaluates on
-simple reflections, how it interacts with root negation, and the sign change a reflection induces
-on its own coroot functional.  Alongside it, the weight-space action of the Weyl group is faithful,
-with no spanning hypothesis needed.  More generally, an automorphism transports coroot functionals
-along its action on weights, matching the coroot functional of a root with that of its image.
+faithful.  Consequently that automorphism group is itself finite when the root index type is
+finite, and hence so is every subgroup of it, the Weyl group in particular.  It also records how
+that action evaluates on simple reflections, how it interacts with root negation, and the sign
+change a reflection induces on its own coroot functional.  Alongside it, the weight-space action of
+the Weyl group is faithful, with no spanning hypothesis needed.  More generally, an automorphism
+transports coroot functionals along its action on weights, matching the coroot functional of a root
+with that of its image.
 
 ## Main results
 
@@ -42,8 +43,8 @@ along its action on weights, matching the coroot functional of a root with that 
   reflection by a Weyl-group element gives the reflection in the image root index.
 * `TauCeti.RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal` says orthogonal roots have
   commuting reflections.
-* `TauCeti.RootPairing.finite_subgroup_aut` proves that every subgroup of the automorphism group of
-  a finite root system is finite.
+* `TauCeti.RootPairing.finite_aut` proves that the automorphism group of a finite root system is
+  finite, and `TauCeti.RootPairing.finite_subgroup_aut` deduces the same for every subgroup of it.
 * `TauCeti.RootPairing.finite_weylGroup` is the resulting finiteness theorem for the Weyl group.
 
 ## References
@@ -245,18 +246,6 @@ end weylGroup
 
 variable [Finite ι]
 
-/-- If the roots span, every subgroup of the automorphism group is finite when the root index type
-is finite. -/
-theorem finite_subgroup_aut_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤)
-    (G : Subgroup P.Aut) : Finite G :=
-  Finite.of_injective ((_root_.RootPairing.Equiv.indexHom P).domRestrict G)
-    ((Equiv.indexHom_injective_of_span_eq_top P hspan).comp Subtype.val_injective)
-
-/-- Every subgroup of the automorphism group of a finite root system is finite. -/
-theorem finite_subgroup_aut [P.IsRootSystem] (G : Subgroup P.Aut) : Finite G :=
-  finite_subgroup_aut_of_span_eq_top P
-    (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) G
-
 /-- If the roots span, the automorphism group is finite when the root index type is finite. -/
 theorem finite_aut_of_span_eq_top
     (hspan : Submodule.span R (range P.root) = ⊤) : Finite P.Aut :=
@@ -268,23 +257,16 @@ theorem finite_aut [P.IsRootSystem] : Finite P.Aut :=
   finite_aut_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
 
-/-- If the roots span, every subgroup of the automorphism group has order at most the factorial of
-the number of roots. -/
-theorem card_subgroup_aut_le_factorial_of_span_eq_top
-    (hspan : Submodule.span R (range P.root) = ⊤)
-    (G : Subgroup P.Aut) : Nat.card G ≤ Nat.factorial (Nat.card ι) := by
-  calc
-    Nat.card G ≤ Nat.card (ι ≃ ι) := Nat.card_le_card_of_injective
-      ((_root_.RootPairing.Equiv.indexHom P).domRestrict G)
-        ((Equiv.indexHom_injective_of_span_eq_top P hspan).comp
-          Subtype.val_injective)
-    _ = Nat.factorial (Nat.card ι) := Nat.card_perm
+/-- If the roots span, every subgroup of the automorphism group is finite when the root index type
+is finite. -/
+theorem finite_subgroup_aut_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤)
+    (G : Subgroup P.Aut) : Finite G :=
+  have := finite_aut_of_span_eq_top P hspan
+  Subtype.finite
 
-/-- Every subgroup of the automorphism group of a finite root system has order at most the
-factorial of the number of roots. -/
-theorem card_subgroup_aut_le_factorial [P.IsRootSystem] (G : Subgroup P.Aut) :
-    Nat.card G ≤ Nat.factorial (Nat.card ι) :=
-  card_subgroup_aut_le_factorial_of_span_eq_top P
+/-- Every subgroup of the automorphism group of a finite root system is finite. -/
+theorem finite_subgroup_aut [P.IsRootSystem] (G : Subgroup P.Aut) : Finite G :=
+  finite_subgroup_aut_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) G
 
 /-- If the roots span, the automorphism group has order at most the factorial of the number of
@@ -304,6 +286,21 @@ theorem card_aut_le_factorial [P.IsRootSystem] :
     Nat.card P.Aut ≤ Nat.factorial (Nat.card ι) :=
   card_aut_le_factorial_of_span_eq_top P
     (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P))
+
+/-- If the roots span, every subgroup of the automorphism group has order at most the factorial of
+the number of roots. -/
+theorem card_subgroup_aut_le_factorial_of_span_eq_top
+    (hspan : Submodule.span R (range P.root) = ⊤)
+    (G : Subgroup P.Aut) : Nat.card G ≤ Nat.factorial (Nat.card ι) :=
+  have := finite_aut_of_span_eq_top P hspan
+  G.card_le_card_group.trans (card_aut_le_factorial_of_span_eq_top P hspan)
+
+/-- Every subgroup of the automorphism group of a finite root system has order at most the
+factorial of the number of roots. -/
+theorem card_subgroup_aut_le_factorial [P.IsRootSystem] (G : Subgroup P.Aut) :
+    Nat.card G ≤ Nat.factorial (Nat.card ι) :=
+  card_subgroup_aut_le_factorial_of_span_eq_top P
+    (_root_.RootPairing.IsRootSystem.span_root_eq_top (P := P)) G
 
 /-- If the roots span, the Weyl group is finite when the root index type is finite. -/
 theorem finite_weylGroup_of_span_eq_top (hspan : Submodule.span R (range P.root) = ⊤) :


### PR DESCRIPTION
`TauCeti/LinearAlgebra/RootSystem/Weyl/Group.lean` closes with four finiteness statements about the
automorphism group of a root system, and each of the four proved itself from scratch out of
`Equiv.indexHom_injective_of_span_eq_top`:

| | ambient group | arbitrary subgroup `G` |
|---|---|---|
| finiteness | `finite_aut_of_span_eq_top` | `finite_subgroup_aut_of_span_eq_top` |
| order bound | `card_aut_le_factorial_of_span_eq_top` | `card_subgroup_aut_le_factorial_of_span_eq_top` |

The right-hand column duplicated the left. Both subgroup proofs re-applied the same injectivity
fact, pre-composed with `Subtype.val_injective`, and the order bound duplicated a whole `calc`
ending in `Nat.card_perm`. Nothing in either was about subgroups: a subgroup of a finite group is
finite, and its order is at most the order of the group.

This PR makes the left column the primitive and derives the right one.

* `finite_subgroup_aut_of_span_eq_top` is now `Subtype.finite` under `finite_aut_of_span_eq_top`.
* `card_subgroup_aut_le_factorial_of_span_eq_top` is now `Nat.card_le_card_of_injective` along
  `Subtype.val` composed with `card_aut_le_factorial_of_span_eq_top`.

**All four statements are byte-identical to what is on `main`** — signatures, hypotheses, and
binder names are untouched, so every downstream consumer (`finite_weylGroup_of_span_eq_top`,
`card_weylGroup_le_factorial_of_span_eq_top`, and the four `IsRootSystem` corollaries) is
unaffected. The only reordering is that the two ambient-group theorems now precede the two
subgroup ones, which is what lets the latter cite the former.

### Why this direction

The dedup finding this closes proposed the opposite arrow — deriving the ambient statements by
instantiating the subgroup ones at `⊤` and transporting along `Subgroup.topEquiv`. That also
removes the duplication, but it routes the two headline results (`finite_aut`,
`card_aut_le_factorial`) through a subgroup wrapper they have no need for, and it makes
`Nat.card P.Aut` reachable only via `Nat.card ↥(⊤ : Subgroup P.Aut)`.

The content here is that `P.Aut` embeds in `Equiv.Perm ι`; that is a statement about `P.Aut`, and
the subgroup versions are generic group theory on top of it. Proving the ambient fact once and
letting `Subtype.finite` do the rest keeps the mathematical primitive and the Lean primitive the
same declaration, and needs no `⊤` and no `topEquiv`.

`finite_subgroup_aut_of_span_eq_top` is kept rather than deleted even though it is now one line:
it has two in-repo consumers (`finite_subgroup_aut`, `finite_weylGroup_of_span_eq_top`) and the
module docstring advertises it.

### Prose

The module docstring's opening paragraph said faithfulness makes "every subgroup of that
automorphism group, and in particular the Weyl group" finite — which was accurate but named the
consequence before the fact it follows from. It now says the automorphism group is itself finite
and every subgroup follows, matching the new order of the proofs. The Main-results bullet is
updated to name `finite_aut` as the primitive alongside `finite_subgroup_aut`.

Roadmap: RepresentationTheory

Provenance: no external code adapted and no new mathematics — this is a proof-only restructuring of
declarations already on `main`, closing dedup finding L15 from the 2026-08-24 sweep
(`TauCeti/.mathlib-quality/dedup/findings.jsonl`). `Nat.card_le_card_of_injective`
(`Mathlib/SetTheory/Cardinal/Finite.lean`) and the `Subtype.finite` instance
(`Mathlib/Data/Fintype/EquivFin.lean`) are the only Mathlib facts newly cited.
