### PR TITLE
feat: represent a recurrent Markov exchangeable process by its excursions

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
+++ b/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
@@ -38,6 +38,8 @@ excursions is nothing but a prescribed finite path.
 
 * `TauCeti.excursion`: the finite word strictly between two consecutive visits to a state.
 * `TauCeti.excursionPrefix`: the list of the first `m` excursions.
+* `TauCeti.pathOfExcursions`: the sequence spelled out by a base state and an infinite sequence of
+  excursions.
 
 ## Main results
 
@@ -49,6 +51,10 @@ excursions is nothing but a prescribed finite path.
 * `TauCeti.visitCount_loopPathAt`: a loop visits its base state once per excursion.
 * `TauCeti.eqOn_loopPathAt_iff_excursionPrefix_eq`: for a path whose relevant return exists, having
   prescribed first excursions is the same as spelling out their loop word.
+* `TauCeti.pathOfExcursions_excursion`: a sequence that starts at a state and returns to it
+  infinitely often is rebuilt from its own excursions.
+* `TauCeti.excursion_pathOfExcursions`: conversely, a sequence spelled out by excursions avoiding
+  the base state has exactly those excursions.
 
 ## References
 
@@ -325,6 +331,143 @@ theorem eqOn_loopPathAt_iff_excursionPrefix_eq {bs : List (List α)} (havoid : �
       simp only [List.length_map, List.length_range]
       omega
     simpa using (List.getElem_of_eq hmaps hi').symm
+
+
+/-! ## The sequence spelled out by an infinite sequence of excursions -/
+
+/-- The sequence spelled out by a base state `a` and an infinite sequence `b` of excursions:
+
+```text
+a, b 0, a, b 1, a, …
+```
+
+Index `i` is read off the loop word of the first `i + 1` excursions, which already runs for at
+least `i + 1` steps, so the reading never falls off its end. -/
+def pathOfExcursions (a : α) (b : ℕ → List α) (i : ℕ) : α :=
+  loopPathAt a ((List.range (i + 1)).map b) i
+
+/-- The defining equation of `TauCeti.pathOfExcursions`. -/
+theorem pathOfExcursions_def (a : α) (b : ℕ → List α) (i : ℕ) :
+    pathOfExcursions a b i = loopPathAt a ((List.range (i + 1)).map b) i :=
+  (rfl)
+
+/-- A longer list of excursions extends a shorter one. -/
+private theorem exists_map_range_append (b : ℕ → List α) {m m' : ℕ} (h : m ≤ m') :
+    ∃ cs, (List.range m').map b = ((List.range m).map b) ++ cs := by
+  induction m' with
+  | zero => exact ⟨[], by rw [Nat.le_zero.1 h]; simp⟩
+  | succ n ih =>
+    rcases Nat.eq_or_lt_of_le h with heq | hlt
+    · exact ⟨[], by rw [← heq]; simp⟩
+    · obtain ⟨cs, hcs⟩ := ih (Nat.lt_succ_iff.1 hlt)
+      exact ⟨cs ++ [b n], by
+        rw [List.range_succ, List.map_append, hcs, List.append_assoc]
+        simp⟩
+
+/-- Below the span of a shorter list of excursions, a longer one spells out the same loop. -/
+private theorem loopPathAt_map_range_eq (a : α) (b : ℕ → List α) {i m m' : ℕ} (hm : m ≤ m')
+    (hi : i ≤ loopSteps ((List.range m).map b)) :
+    loopPathAt a ((List.range m').map b) i = loopPathAt a ((List.range m).map b) i := by
+  obtain ⟨cs, hcs⟩ := exists_map_range_append b hm
+  rw [hcs, loopPathAt_append_of_le _ _ _ hi]
+
+/-- **A sequence spelled out by excursions is read off any long enough loop word.** The definition
+uses the shortest such word; this is the form the reconstruction theorems below need. -/
+theorem pathOfExcursions_eq_loopPathAt (a : α) (b : ℕ → List α) {i n : ℕ}
+    (hi : i ≤ loopSteps ((List.range n).map b)) :
+    pathOfExcursions a b i = loopPathAt a ((List.range n).map b) i := by
+  have hi1 : i ≤ loopSteps ((List.range (i + 1)).map b) := by
+    have hle := length_le_loopSteps ((List.range (i + 1)).map b)
+    simp only [List.length_map, List.length_range] at hle
+    omega
+  rw [pathOfExcursions_def, ← loopPathAt_map_range_eq a b (le_max_left (i + 1) n) hi1,
+    loopPathAt_map_range_eq a b (le_max_right (i + 1) n) hi]
+
+@[simp]
+theorem pathOfExcursions_zero (a : α) (b : ℕ → List α) : pathOfExcursions a b 0 = a := by
+  rw [pathOfExcursions_def, loopPathAt_zero]
+
+/-- Appending one more excursion lengthens the loop by that excursion and the step back to the
+base state. -/
+theorem loopSteps_map_range_succ (b : ℕ → List α) (n : ℕ) :
+    loopSteps ((List.range (n + 1)).map b) =
+      loopSteps ((List.range n).map b) + ((b n).length + 1) := by
+  rw [List.range_succ, List.map_append, loopSteps_append]
+  simp
+
+/-- A sequence spelled out by excursions is back at its base state at the end of every
+excursion. -/
+theorem pathOfExcursions_loopSteps (a : α) (b : ℕ → List α) (n : ℕ) :
+    pathOfExcursions a b (loopSteps ((List.range n).map b)) = a := by
+  rw [pathOfExcursions_eq_loopPathAt a b le_rfl, loopPathAt_loopSteps]
+
+/-- **A sequence spelled out by excursions returns to its base state infinitely often**, whatever
+the excursions are. -/
+theorem infinite_setOf_pathOfExcursions_eq (a : α) (b : ℕ → List α) :
+    {n | pathOfExcursions a b n = a}.Infinite := by
+  have hmono : StrictMono fun n => loopSteps ((List.range n).map b) := by
+    refine strictMono_nat_of_lt_succ fun n => ?_
+    rw [loopSteps_map_range_succ]
+    omega
+  exact Set.infinite_of_injective_forall_mem hmono.injective
+    fun n => pathOfExcursions_loopSteps a b n
+
+/-! ## The two reconstructions -/
+
+/-- **Excursions rebuild the sequence they came from.** A sequence that starts at `a` and returns
+to it infinitely often is spelled out by its own excursions. -/
+theorem pathOfExcursions_excursion (h : {n | x n = a}.Infinite) (h0 : x 0 = a) :
+    pathOfExcursions a (excursion x a) = x := by
+  have hvisit : ∀ n : ℕ, n ≤ visitTime x a n := by
+    intro n
+    induction n with
+    | zero => exact Nat.zero_le _
+    | succ n ih =>
+      exact Nat.succ_le_of_lt
+        (lt_of_le_of_lt ih (visitTime_strictMono_of_infinite h (Nat.lt_succ_self n)))
+  funext i
+  have hpre : (List.range (i + 1)).map (excursion x a) = excursionPrefix x a (i + 1) :=
+    (excursionPrefix_def x a (i + 1)).symm
+  have hsteps : loopSteps (excursionPrefix x a (i + 1)) = visitTime x a (i + 1) :=
+    loopSteps_excursionPrefix_of_infinite_of_zero h h0 (i + 1)
+  have hi : i ≤ loopSteps ((List.range (i + 1)).map (excursion x a)) := by
+    rw [hpre, hsteps]
+    exact le_trans (Nat.le_succ i) (hvisit (i + 1))
+  rw [pathOfExcursions_eq_loopPathAt _ _ hi, hpre]
+  refine ((eqOn_loopPathAt_iff_excursionPrefix_eq
+    (forall_not_mem_excursionPrefix x a (i + 1))
+    (by simpa using exists_visitCount_of_infinite h (i + 1)) h0).mpr (by simp) i ?_).symm
+  rw [hsteps]
+  exact le_trans (Nat.le_succ i) (hvisit (i + 1))
+
+/-- **A sequence spelled out by excursions has exactly those excursions**, provided none of them
+visits the base state. This is the converse of `TauCeti.pathOfExcursions_excursion`, and makes the
+excursion decomposition a bijection between sequences returning to `a` infinitely often and
+sequences of finite words avoiding `a`. -/
+theorem excursionPrefix_pathOfExcursions {b : ℕ → List α} (havoid : ∀ j, a ∉ b j) (n : ℕ) :
+    excursionPrefix (pathOfExcursions a b) a n = (List.range n).map b := by
+  have havoid' : ∀ e ∈ (List.range n).map b, a ∉ e := by
+    intro e he
+    obtain ⟨j, -, rfl⟩ := List.mem_map.1 he
+    exact havoid j
+  have hlen : ((List.range n).map b).length = n := by simp
+  have heq : ∀ i ≤ loopSteps ((List.range n).map b),
+      pathOfExcursions a b i = loopPathAt a ((List.range n).map b) i := fun i hi =>
+    pathOfExcursions_eq_loopPathAt a b hi
+  have hex : ∃ i, pathOfExcursions a b i = a ∧
+      visitCount (pathOfExcursions a b) a i = ((List.range n).map b).length := by
+    refine ⟨loopSteps ((List.range n).map b), pathOfExcursions_loopSteps a b n, ?_⟩
+    rw [visitCount_congr fun i hi => heq i hi.le, visitCount_loopPathAt a havoid', hlen]
+  have hmain := (eqOn_loopPathAt_iff_excursionPrefix_eq havoid' hex
+    (pathOfExcursions_zero a b)).mp heq
+  rwa [hlen] at hmain
+
+/-- **Each excursion of a sequence spelled out by excursions is the corresponding one.** -/
+theorem excursion_pathOfExcursions {b : ℕ → List α} (havoid : ∀ j, a ∉ b j) (j : ℕ) :
+    excursion (pathOfExcursions a b) a j = b j := by
+  have hidx : j < (excursionPrefix (pathOfExcursions a b) a (j + 1)).length := by simp
+  have h := List.getElem_of_eq (excursionPrefix_pathOfExcursions havoid (j + 1)) hidx
+  simpa [getElem_excursionPrefix (Nat.lt_succ_self j)] using h
 
 end TauCeti
 

--- a/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
+++ b/TauCeti/Combinatorics/Enumerative/ExcursionProcess.lean
@@ -346,23 +346,13 @@ least `i + 1` steps, so the reading never falls off its end. -/
 def pathOfExcursions (a : α) (b : ℕ → List α) (i : ℕ) : α :=
   loopPathAt a ((List.range (i + 1)).map b) i
 
-/-- The defining equation of `TauCeti.pathOfExcursions`. -/
-theorem pathOfExcursions_def (a : α) (b : ℕ → List α) (i : ℕ) :
-    pathOfExcursions a b i = loopPathAt a ((List.range (i + 1)).map b) i :=
-  (rfl)
-
 /-- A longer list of excursions extends a shorter one. -/
 private theorem exists_map_range_append (b : ℕ → List α) {m m' : ℕ} (h : m ≤ m') :
     ∃ cs, (List.range m').map b = ((List.range m).map b) ++ cs := by
-  induction m' with
-  | zero => exact ⟨[], by rw [Nat.le_zero.1 h]; simp⟩
-  | succ n ih =>
-    rcases Nat.eq_or_lt_of_le h with heq | hlt
-    · exact ⟨[], by rw [← heq]; simp⟩
-    · obtain ⟨cs, hcs⟩ := ih (Nat.lt_succ_iff.1 hlt)
-      exact ⟨cs ++ [b n], by
-        rw [List.range_succ, List.map_append, hcs, List.append_assoc]
-        simp⟩
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le h
+  refine ⟨(List.range k).map (fun i => b (m + i)), ?_⟩
+  rw [List.range_add, List.map_append, List.map_map]
+  rfl
 
 /-- Below the span of a shorter list of excursions, a longer one spells out the same loop. -/
 private theorem loopPathAt_map_range_eq (a : α) (b : ℕ → List α) {i m m' : ℕ} (hm : m ≤ m')
@@ -380,12 +370,12 @@ theorem pathOfExcursions_eq_loopPathAt (a : α) (b : ℕ → List α) {i n : ℕ
     have hle := length_le_loopSteps ((List.range (i + 1)).map b)
     simp only [List.length_map, List.length_range] at hle
     omega
-  rw [pathOfExcursions_def, ← loopPathAt_map_range_eq a b (le_max_left (i + 1) n) hi1,
+  rw [pathOfExcursions, ← loopPathAt_map_range_eq a b (le_max_left (i + 1) n) hi1,
     loopPathAt_map_range_eq a b (le_max_right (i + 1) n) hi]
 
 @[simp]
 theorem pathOfExcursions_zero (a : α) (b : ℕ → List α) : pathOfExcursions a b 0 = a := by
-  rw [pathOfExcursions_def, loopPathAt_zero]
+  rw [pathOfExcursions, loopPathAt_zero]
 
 /-- Appending one more excursion lengthens the loop by that excursion and the step back to the
 base state. -/
@@ -397,6 +387,7 @@ theorem loopSteps_map_range_succ (b : ℕ → List α) (n : ℕ) :
 
 /-- A sequence spelled out by excursions is back at its base state at the end of every
 excursion. -/
+@[simp]
 theorem pathOfExcursions_loopSteps (a : α) (b : ℕ → List α) (n : ℕ) :
     pathOfExcursions a b (loopSteps ((List.range n).map b)) = a := by
   rw [pathOfExcursions_eq_loopPathAt a b le_rfl, loopPathAt_loopSteps]
@@ -440,16 +431,16 @@ theorem pathOfExcursions_excursion (h : {n | x n = a}.Infinite) (h0 : x 0 = a) :
   rw [hsteps]
   exact le_trans (Nat.le_succ i) (hvisit (i + 1))
 
-/-- **A sequence spelled out by excursions has exactly those excursions**, provided none of them
-visits the base state. This is the converse of `TauCeti.pathOfExcursions_excursion`, and makes the
-excursion decomposition a bijection between sequences returning to `a` infinitely often and
-sequences of finite words avoiding `a`. -/
-theorem excursionPrefix_pathOfExcursions {b : ℕ → List α} (havoid : ∀ j, a ∉ b j) (n : ℕ) :
+/-- **A sequence spelled out by excursions has the prescribed excursion prefix**, provided the
+excursions in that prefix avoid the base state. -/
+@[simp]
+theorem excursionPrefix_pathOfExcursions {b : ℕ → List α} (n : ℕ)
+    (havoid : ∀ j < n, a ∉ b j) :
     excursionPrefix (pathOfExcursions a b) a n = (List.range n).map b := by
   have havoid' : ∀ e ∈ (List.range n).map b, a ∉ e := by
     intro e he
-    obtain ⟨j, -, rfl⟩ := List.mem_map.1 he
-    exact havoid j
+    obtain ⟨j, hj, rfl⟩ := List.mem_map.1 he
+    exact havoid j (List.mem_range.1 hj)
   have hlen : ((List.range n).map b).length = n := by simp
   have heq : ∀ i ≤ loopSteps ((List.range n).map b),
       pathOfExcursions a b i = loopPathAt a ((List.range n).map b) i := fun i hi =>
@@ -462,11 +453,14 @@ theorem excursionPrefix_pathOfExcursions {b : ℕ → List α} (havoid : ∀ j, 
     (pathOfExcursions_zero a b)).mp heq
   rwa [hlen] at hmain
 
-/-- **Each excursion of a sequence spelled out by excursions is the corresponding one.** -/
-theorem excursion_pathOfExcursions {b : ℕ → List α} (havoid : ∀ j, a ∉ b j) (j : ℕ) :
+/-- **Each excursion of a sequence spelled out by excursions is the corresponding one**, provided
+that excursion and its predecessors avoid the base state. -/
+@[simp]
+theorem excursion_pathOfExcursions {b : ℕ → List α} (j : ℕ) (havoid : ∀ k ≤ j, a ∉ b k) :
     excursion (pathOfExcursions a b) a j = b j := by
   have hidx : j < (excursionPrefix (pathOfExcursions a b) a (j + 1)).length := by simp
-  have h := List.getElem_of_eq (excursionPrefix_pathOfExcursions havoid (j + 1)) hidx
+  have h := List.getElem_of_eq
+    (excursionPrefix_pathOfExcursions (j + 1) fun k hk => havoid k (Nat.lt_succ_iff.1 hk)) hidx
   simpa [getElem_excursionPrefix (Nat.lt_succ_self j)] using h
 
 end TauCeti

--- a/TauCeti/Combinatorics/Enumerative/LoopWord.lean
+++ b/TauCeti/Combinatorics/Enumerative/LoopWord.lean
@@ -60,6 +60,7 @@ length `n + 1` as such a word through `List.getD`. Both of those list lemmas liv
   excursions that avoid `a₀`.
 * `TauCeti.loopPath_injOn`: those excursions are unique.
 * `TauCeti.loopPathAt_cons_add`: past its first excursion a loop is the loop of the remaining ones.
+* `TauCeti.loopPathAt_append_of_le`: over the span of its first excursions a loop is their loop.
 * `TauCeti.infinite_setOf_loopPathAt_eq`: read as a function on `ℕ`, a loop returns to its base
   letter infinitely often.
 * `TauCeti.map_range_loopPathAt`: reading that function over the loop's span spells the loop word
@@ -139,6 +140,20 @@ theorem loopSteps_eq_of_perm {bs bs' : List (List α)} (h : bs.Perm bs') :
     loopSteps bs = loopSteps bs' :=
   (h.map _).sum_eq
 
+@[simp]
+theorem loopSteps_append (bs cs : List (List α)) :
+    loopSteps (bs ++ cs) = loopSteps bs + loopSteps cs := by
+  simp [loopSteps]
+
+/-- A loop takes at least one step per excursion, since every excursion is followed by the step
+back to the base letter. -/
+theorem length_le_loopSteps (bs : List (List α)) : bs.length ≤ loopSteps bs := by
+  induction bs with
+  | nil => simp
+  | cons e bs ih =>
+    simp only [List.length_cons, loopSteps_cons]
+    omega
+
 /-- A loop, read as a function on `ℕ`: past its last letter it is padded with the base letter. -/
 def loopPathAt (a₀ : α) (bs : List (List α)) (i : ℕ) : α :=
   (loopPath a₀ bs).getD i a₀
@@ -187,6 +202,26 @@ theorem loopPathAt_eq_of_loopSteps_le (a₀ : α) (bs : List (List α)) {i : ℕ
   rcases eq_or_lt_of_le hi with rfl | hlt
   · exact loopPathAt_loopSteps a₀ bs
   · exact List.getD_eq_default _ _ (by rw [length_loopPath]; omega)
+
+/-- **A loop extends its own initial stretches.** Over the span of `bs`, the loop of `bs ++ cs`
+spells out the loop of `bs`: the two words share the prefix `loopPath a₀ bs`, and at the very end
+of that span both sit at the base letter, where the loop of `cs` starts. -/
+theorem loopPathAt_append_of_le (a₀ : α) (bs cs : List (List α)) {i : ℕ}
+    (hi : i ≤ loopSteps bs) :
+    loopPathAt a₀ (bs ++ cs) i = loopPathAt a₀ bs i := by
+  have hlen : (loopPath a₀ bs).dropLast.length = loopSteps bs := by
+    rw [List.length_dropLast, length_loopPath]
+    omega
+  rcases eq_or_lt_of_le hi with rfl | hlt
+  · refine Eq.trans ?_ (loopPathAt_loopSteps a₀ bs).symm
+    rw [loopPathAt_def, loopPath_append, List.getD_append_right _ _ _ _ hlen.le, hlen,
+      Nat.sub_self]
+    cases cs <;> simp
+  · have hlt' : i < (loopPath a₀ bs).dropLast.length := by omega
+    rw [loopPathAt_def, loopPath_append, List.getD_append _ _ _ _ hlt',
+      List.getD_eq_getElem _ _ hlt', loopPathAt_def,
+      List.getD_eq_getElem _ _ (by rw [length_loopPath]; omega)]
+    simp
 
 /-- **A loop returns to its base letter infinitely often**, since `loopPathAt` pads with that
 letter. This is what lets the excursion decomposition of a loop be read with no side condition. -/

--- a/TauCeti/Probability/Exchangeability/Recurrence/Representation.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Representation.lean
@@ -43,9 +43,10 @@ remaining input of the Diaconis–Freedman representation
 
 * `TauCeti.Probability.measurable_pathOfExcursions`: concatenating excursions is measurable over a
   countable discrete state space.
-* `TauCeti.Probability.Recurrent.pathLaw_eq_map_pathOfExcursions`: the path law of a recurrent
-  process started at `a₀` is the image of its excursion law under concatenation.
-* `TauCeti.Probability.ConditionallyIIDWith.ae_measure_setOf_mem_eq_zero_excursionProcess`: a
+* `TauCeti.Probability.pathLaw_eq_map_pathOfExcursions`: the path law of a process that almost
+  surely starts at and returns infinitely often to `a₀` is the image of its excursion law under
+  concatenation.
+* `TauCeti.Probability.ConditionallyIIDWith.ae_measure_setOf_mem_eq_zero_of_excursionProcess`: a
   directing measure of an excursion process almost surely charges no word through the base state.
 * `TauCeti.Probability.MarkovExchangeable.exists_pathLaw_eq_map_deFinettiBarycenter`: **a recurrent
   Markov exchangeable process is a mixture of processes with i.i.d. excursions.**
@@ -84,7 +85,11 @@ theorem measurable_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
       (fun v : Fin (i + 1) → List α => loopPathAt a₀ (List.ofFn v) i) ∘
         fun (b : ℕ → List α) (j : Fin (i + 1)) => b j.val := by
     funext b
-    rw [Function.comp_apply, pathOfExcursions_def]
+    have hi : i ≤ loopSteps ((List.range (i + 1)).map b) := by
+      have hle := length_le_loopSteps ((List.range (i + 1)).map b)
+      simp only [List.length_map, List.length_range] at hle
+      omega
+    rw [Function.comp_apply, pathOfExcursions_eq_loopPathAt a₀ b hi]
     congr 1
     refine List.ext_getElem (by simp) fun j hj hj' => ?_
     rw [List.getElem_map, List.getElem_range, List.getElem_ofFn]
@@ -95,31 +100,38 @@ theorem measurable_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
 
 variable {μ : Measure Ω} {X : ℕ → Ω → α} {a₀ : α}
 
-/-- **The path law of a recurrent process started at `a₀` is the image of its excursion law.**
-Almost every sample path returns to `a₀` infinitely often, so concatenating its excursions
-recovers it. -/
-theorem Recurrent.pathLaw_eq_map_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
-    (hrec : Recurrent μ X) (hX : ∀ i, AEMeasurable (X i) μ) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
+/-- **The path law of a process returning infinitely often to `a₀` is the image of its excursion
+law.** Almost every sample path starts at and returns infinitely often to `a₀`, so concatenating
+its excursions recovers it. -/
+theorem pathLaw_eq_map_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
+    (hX : ∀ i, AEMeasurable (X i) μ) (hreturns : ∀ᵐ ω ∂μ, {n | X n ω = a₀}.Infinite)
+    (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
     pathLaw μ X = (pathLaw μ (excursionProcess X a₀)).map (pathOfExcursions a₀) := by
   have hΦ : AEMeasurable (fun ω k => excursionProcess X a₀ k ω) μ :=
     aemeasurable_pi_lambda _ fun k => aemeasurable_excursionProcess hX a₀ k
   have hae : (pathOfExcursions a₀ ∘ fun ω k => excursionProcess X a₀ k ω) =ᵐ[μ]
       fun ω i => X i ω := by
-    filter_upwards [h0, hrec.ae_infinite_setOf_eq] with ω hω0 hωinf
-    have hinf : {n | X n ω = a₀}.Infinite := by
-      have h := hωinf 0
-      rwa [hω0] at h
-    simpa [Function.comp_def] using pathOfExcursions_excursion hinf hω0
+    filter_upwards [h0, hreturns] with ω hω0 hωinf
+    simpa [Function.comp_def] using pathOfExcursions_excursion hωinf hω0
   rw [pathLaw_def, pathLaw_def,
     AEMeasurable.map_map_of_aemeasurable (measurable_pathOfExcursions a₀).aemeasurable hΦ,
     Measure.map_congr hae]
+
+/-- **The path law of a recurrent process started at `a₀` is the image of its excursion law.** -/
+theorem Recurrent.pathLaw_eq_map_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
+    (hrec : Recurrent μ X) (hX : ∀ i, AEMeasurable (X i) μ) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
+    pathLaw μ X = (pathLaw μ (excursionProcess X a₀)).map (pathOfExcursions a₀) := by
+  apply TauCeti.Probability.pathLaw_eq_map_pathOfExcursions hX _ h0
+  filter_upwards [h0, hrec.ae_infinite_setOf_eq] with ω hω0 hωinf
+  have h := hωinf 0
+  rwa [hω0] at h
 
 /-! ## Excursion laws avoid the base state -/
 
 /-- **A directing measure of an excursion process charges no word through the base state.** An
 excursion never visits the state it is an excursion from, so almost every mixing representative of
 the excursion process gives the words through `a₀` mass zero. -/
-theorem ConditionallyIIDWith.ae_measure_setOf_mem_eq_zero_excursionProcess
+theorem ConditionallyIIDWith.ae_measure_setOf_mem_eq_zero_of_excursionProcess
     [Countable α] [MeasurableSingletonClass α]
     (hX : ∀ i, AEMeasurable (X i) μ) {ν : Ω → ProbabilityMeasure (List α)}
     (h : ConditionallyIIDWith μ (excursionProcess X a₀) ν) :
@@ -177,7 +189,7 @@ theorem MarkovExchangeable.exists_pathLaw_eq_map_deFinettiBarycenter [IsProbabil
   have hSmeas : MeasurableSet {l : List α | a₀ ∈ l} := MeasurableSet.of_discrete
   refine ⟨μ.map ν, Measure.isProbabilityMeasure_map hν_meas.aemeasurable, ?_, ?_⟩
   · refine (ae_map_iff hν_meas.aemeasurable ?_).2
-      (hν.ae_measure_setOf_mem_eq_zero_excursionProcess h.aemeasurable)
+      (hν.ae_measure_setOf_mem_eq_zero_of_excursionProcess h.aemeasurable)
     exact ((Measure.measurable_coe hSmeas).comp measurable_subtype_coe)
       (measurableSet_singleton (0 : ENNReal))
   · rw [hrec.pathLaw_eq_map_pathOfExcursions h.aemeasurable h0,

--- a/TauCeti/Probability/Exchangeability/Recurrence/Representation.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/Representation.lean
@@ -1,0 +1,192 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.DeFinetti.Barycenter
+public import TauCeti.Probability.Exchangeability.Recurrence.Excursion
+-- Non-public: the mixture form of a path law is used only inside proofs.
+import TauCeti.Probability.Exchangeability.MixedIID.Mixture
+
+/-!
+# A recurrent Markov exchangeable process is a mixture of processes with i.i.d. excursions
+
+A recurrent process that starts at a state `a₀` returns to it infinitely often, so it is spelled
+out by its excursions and by nothing else: reading the excursions off the path and concatenating
+them back are mutually inverse (`TauCeti.pathOfExcursions_excursion` and
+`TauCeti.excursion_pathOfExcursions`). This file turns that bijection into an identity of laws.
+The path law of the process is the image of the path law of its excursion process under
+concatenation (`TauCeti.Probability.Recurrent.pathLaw_eq_map_pathOfExcursions`), and for a
+**Markov exchangeable** process the excursion process is exchangeable, hence conditionally i.i.d.
+The resulting representation is
+
+```text
+pathLaw μ X = (deFinettiBarycenter π).map (pathOfExcursions a₀)
+```
+
+for a probability measure `π` on laws of finite words: draw an excursion law `P` from `π`, draw
+excursions i.i.d. from `P`, and concatenate them
+(`TauCeti.Probability.MarkovExchangeable.exists_pathLaw_eq_map_deFinettiBarycenter`). The mixing
+law is carried on laws of words that almost surely avoid `a₀`
+(`TauCeti.Probability.MarkovExchangeable.exists_pathLaw_eq_map_deFinettiBarycenter`, second
+conjunct), so the concatenated path really has the drawn words as its excursions.
+
+This is Diaconis and Freedman's decomposition step for Markov exchangeability: it exhibits a
+recurrent Markov exchangeable process as a mixture of **regenerative** processes. What it does not
+yet say is that the random excursion law is the excursion law of a Markov chain, which is the
+remaining input of the Diaconis–Freedman representation
+`TauCeti.Probability.MixedMarkovChain`.
+
+## Main results
+
+* `TauCeti.Probability.measurable_pathOfExcursions`: concatenating excursions is measurable over a
+  countable discrete state space.
+* `TauCeti.Probability.Recurrent.pathLaw_eq_map_pathOfExcursions`: the path law of a recurrent
+  process started at `a₀` is the image of its excursion law under concatenation.
+* `TauCeti.Probability.ConditionallyIIDWith.ae_measure_setOf_mem_eq_zero_excursionProcess`: a
+  directing measure of an excursion process almost surely charges no word through the base state.
+* `TauCeti.Probability.MarkovExchangeable.exists_pathLaw_eq_map_deFinettiBarycenter`: **a recurrent
+  Markov exchangeable process is a mixture of processes with i.i.d. excursions.**
+
+## References
+
+* P. Diaconis and D. Freedman, "de Finetti's theorem for Markov chains", *Annals of Probability*
+  8 (1980), 115–130.
+* Roadmap: `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, "Markov exchangeability".
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable rather than
+Markov exchangeable sequences.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-! ## Measurability of the concatenation map -/
+
+/-- **Concatenating a sequence of excursions is measurable.** Each coordinate of the concatenated
+sequence depends on finitely many excursions, and over a countable discrete state space the finite
+words form a countable discrete space, on which every map is measurable. -/
+theorem measurable_pathOfExcursions [Countable α] [MeasurableSingletonClass α] (a₀ : α) :
+    Measurable (pathOfExcursions a₀ : (ℕ → List α) → ℕ → α) := by
+  refine measurable_pi_lambda _ fun i => ?_
+  have hfac : (fun b : ℕ → List α => pathOfExcursions a₀ b i) =
+      (fun v : Fin (i + 1) → List α => loopPathAt a₀ (List.ofFn v) i) ∘
+        fun (b : ℕ → List α) (j : Fin (i + 1)) => b j.val := by
+    funext b
+    rw [Function.comp_apply, pathOfExcursions_def]
+    congr 1
+    refine List.ext_getElem (by simp) fun j hj hj' => ?_
+    rw [List.getElem_map, List.getElem_range, List.getElem_ofFn]
+  rw [hfac]
+  exact Measurable.of_discrete.comp (measurable_pi_lambda _ fun j => measurable_pi_apply _)
+
+/-! ## The path law of a recurrent process -/
+
+variable {μ : Measure Ω} {X : ℕ → Ω → α} {a₀ : α}
+
+/-- **The path law of a recurrent process started at `a₀` is the image of its excursion law.**
+Almost every sample path returns to `a₀` infinitely often, so concatenating its excursions
+recovers it. -/
+theorem Recurrent.pathLaw_eq_map_pathOfExcursions [Countable α] [MeasurableSingletonClass α]
+    (hrec : Recurrent μ X) (hX : ∀ i, AEMeasurable (X i) μ) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
+    pathLaw μ X = (pathLaw μ (excursionProcess X a₀)).map (pathOfExcursions a₀) := by
+  have hΦ : AEMeasurable (fun ω k => excursionProcess X a₀ k ω) μ :=
+    aemeasurable_pi_lambda _ fun k => aemeasurable_excursionProcess hX a₀ k
+  have hae : (pathOfExcursions a₀ ∘ fun ω k => excursionProcess X a₀ k ω) =ᵐ[μ]
+      fun ω i => X i ω := by
+    filter_upwards [h0, hrec.ae_infinite_setOf_eq] with ω hω0 hωinf
+    have hinf : {n | X n ω = a₀}.Infinite := by
+      have h := hωinf 0
+      rwa [hω0] at h
+    simpa [Function.comp_def] using pathOfExcursions_excursion hinf hω0
+  rw [pathLaw_def, pathLaw_def,
+    AEMeasurable.map_map_of_aemeasurable (measurable_pathOfExcursions a₀).aemeasurable hΦ,
+    Measure.map_congr hae]
+
+/-! ## Excursion laws avoid the base state -/
+
+/-- **A directing measure of an excursion process charges no word through the base state.** An
+excursion never visits the state it is an excursion from, so almost every mixing representative of
+the excursion process gives the words through `a₀` mass zero. -/
+theorem ConditionallyIIDWith.ae_measure_setOf_mem_eq_zero_excursionProcess
+    [Countable α] [MeasurableSingletonClass α]
+    (hX : ∀ i, AEMeasurable (X i) μ) {ν : Ω → ProbabilityMeasure (List α)}
+    (h : ConditionallyIIDWith μ (excursionProcess X a₀) ν) :
+    ∀ᵐ ω ∂μ, (ν ω : Measure (List α)) {l : List α | a₀ ∈ l} = 0 := by
+  set S : Set (List α) := {l : List α | a₀ ∈ l} with hS
+  have hSmeas : MeasurableSet S := MeasurableSet.of_discrete
+  have hmix := mixedIIDWith_of_conditionallyIIDWith h
+  have hrect := hmix.blockLaw_univ_pi (fun _ : Fin 1 => (0 : ℕ))
+    (fun i j _ => Subsingleton.elim i j) (fun _ : Fin 1 => S) fun _ => hSmeas
+  -- The block law of a single excursion gives the rectangle no mass: an excursion avoids `a₀`.
+  have hzero : blockLaw μ (excursionProcess X a₀) (fun _ : Fin 1 => (0 : ℕ))
+      (Set.univ.pi fun _ : Fin 1 => S) = 0 := by
+    have hf : AEMeasurable
+        (fun ω => fun _ : Fin 1 => excursionProcess X a₀ 0 ω) μ :=
+      aemeasurable_pi_lambda _ fun _ => aemeasurable_excursionProcess hX a₀ 0
+    rw [blockLaw_def, Measure.map_apply_of_aemeasurable hf
+      (MeasurableSet.univ_pi fun _ => hSmeas)]
+    convert measure_empty (μ := μ)
+    refine Set.eq_empty_of_forall_notMem fun ω hω => ?_
+    have hmem := (Set.mem_univ_pi.1 hω) 0
+    simp only [hS, Set.mem_ofPred_eq, excursionProcess_apply] at hmem
+    exact not_mem_excursion (fun n => X n ω) a₀ 0 hmem
+  rw [hzero] at hrect
+  have hmeasν : Measurable fun ω => (ν ω : Measure (List α)) S :=
+    (Measure.measurable_coe hSmeas).comp
+      (measurable_subtype_coe.comp hmix.measurable_mixingRepresentative)
+  have hint : ∫⁻ ω, (ν ω : Measure (List α)) S ∂μ = 0 := by
+    have hsplit : ∫⁻ ω, (ν ω : Measure (List α)) S ∂μ
+        = ∫⁻ ω, ∏ _i : Fin 1, (ν ω : Measure (List α)) S ∂μ :=
+      lintegral_congr fun ω => by rw [Fin.prod_univ_one]
+    rw [hsplit, ← hrect]
+  filter_upwards [(lintegral_eq_zero_iff hmeasν).1 hint] with ω hω using hω
+
+/-! ## The representation -/
+
+/-- **A recurrent Markov exchangeable process is a mixture of processes with i.i.d. excursions.**
+Its path law is obtained by drawing an excursion law `P` from a mixing law `π`, drawing excursions
+i.i.d. from `P`, and concatenating them. The mixing law is carried on laws that almost surely avoid
+the base state, so the concatenated path has the drawn words as its excursions.
+
+This is the decomposition step of the Diaconis–Freedman representation. Identifying the random
+excursion law with the excursion law of a Markov chain, which upgrades this to
+`TauCeti.Probability.MixedMarkovChain`, is a separate statement. -/
+theorem MarkovExchangeable.exists_pathLaw_eq_map_deFinettiBarycenter [IsProbabilityMeasure μ]
+    (h : MarkovExchangeable μ X) (hrec : Recurrent μ X) (h0 : ∀ᵐ ω ∂μ, X 0 ω = a₀) :
+    ∃ π : Measure (ProbabilityMeasure (List α)), IsProbabilityMeasure π ∧
+      (∀ᵐ P : ProbabilityMeasure (List α) ∂π,
+        (P : Measure (List α)) {l : List α | a₀ ∈ l} = 0) ∧
+      pathLaw μ X = (deFinettiBarycenter π).map (pathOfExcursions a₀) := by
+  let _ : Countable α := h.countable
+  have : MeasurableSingletonClass α := h.measurableSingletonClass
+  obtain ⟨ν, hν⟩ := (h.conditionallyIID_excursionProcess hrec h0).exists_directing
+  have hmix := mixedIIDWith_of_conditionallyIIDWith hν
+  have hν_meas : Measurable ν := hmix.measurable_mixingRepresentative
+  have hSmeas : MeasurableSet {l : List α | a₀ ∈ l} := MeasurableSet.of_discrete
+  refine ⟨μ.map ν, Measure.isProbabilityMeasure_map hν_meas.aemeasurable, ?_, ?_⟩
+  · refine (ae_map_iff hν_meas.aemeasurable ?_).2
+      (hν.ae_measure_setOf_mem_eq_zero_excursionProcess h.aemeasurable)
+    exact ((Measure.measurable_coe hSmeas).comp measurable_subtype_coe)
+      (measurableSet_singleton (0 : ENNReal))
+  · rw [hrec.pathLaw_eq_map_pathOfExcursions h.aemeasurable h0,
+      pathLaw_eq_bind_infinitePi_of_mixedIIDWith hmix, deFinettiBarycenter_def]
+
+end Probability
+
+end TauCeti
+
+end
+
+end


### PR DESCRIPTION
This PR represents the path law of a recurrent Markov exchangeable process as a mixture of processes with i.i.d. excursions, the decomposition step of the Diaconis–Freedman representation. It serves the Exchangeability roadmap's Layer 8 milestone "Markov exchangeability", whose target is the Diaconis–Freedman theorem that a recurrent Markov exchangeable process is a `MixedMarkovChain`. `MarkovExchangeable.exchangeable_excursionProcess` and `MarkovExchangeable.conditionallyIID_excursionProcess` (TauCeti#4376) made the excursions of such a process conditionally i.i.d.; nothing yet translated that into a statement about the process itself, because the concatenation direction of the excursion decomposition was missing. This PR supplies it and draws the conclusion. What remains for the milestone is to identify the random excursion law as the excursion law of a Markov chain — equivalently, row exchangeability of the successor array, which `mixedMarkovChain_of_rowExchangeable_successorProcess` already turns into `MixedMarkovChain`.

`TauCeti.pathOfExcursions a b` spells out the sequence `a, b 0, a, b 1, a, …`, reading index `i` off the loop word of the first `i + 1` excursions — which already runs for at least `i + 1` steps, so the reading never falls off its end. The two reconstructions are `TauCeti.pathOfExcursions_excursion` (a sequence starting at `a` and returning to it infinitely often is spelled out by its own excursions) and `TauCeti.excursion_pathOfExcursions` (conversely, a sequence spelled out by excursions avoiding `a` has exactly those excursions), so the excursion decomposition is a bijection between the two sides. `TauCeti.infinite_setOf_pathOfExcursions_eq` records that a concatenated path always returns to its base state infinitely often. All of this is list combinatorics over the existing `loopPath`/`loopPathAt` API, and it needs two new loop lemmas: `TauCeti.loopSteps_append` and `TauCeti.loopPathAt_append_of_le`, the latter saying that over the span of `bs` the loop of `bs ++ cs` spells out the loop of `bs` — the compatibility that makes the reading of `pathOfExcursions` independent of how many excursions are supplied.

On the measure-theoretic side, `TauCeti.Probability.measurable_pathOfExcursions` factors each coordinate through finitely many excursions and uses that finite words over a countable discrete alphabet are a countable discrete space, via the existing `TauCeti.instDiscreteMeasurableSpaceList`. `TauCeti.Probability.Recurrent.pathLaw_eq_map_pathOfExcursions` then reads the round trip as `pathLaw μ X = (pathLaw μ (excursionProcess X a₀)).map (pathOfExcursions a₀)` for a recurrent process almost surely starting at `a₀`. Combined with de Finetti for the excursion process, `TauCeti.Probability.MarkovExchangeable.exists_pathLaw_eq_map_deFinettiBarycenter` gives

```text
pathLaw μ X = (deFinettiBarycenter π).map (pathOfExcursions a₀)
```

for a probability measure `π` on laws of finite words: draw an excursion law `P` from `π`, draw excursions i.i.d. from `P`, and concatenate them. The statement also carries `π` on laws that almost surely give no mass to words through `a₀` (`TauCeti.Probability.ConditionallyIIDWith.ae_measure_setOf_mem_eq_zero_excursionProcess`, proved from the one-coordinate rectangle identity of the mixing representative), which is what makes the representation exact rather than one-directional: by `excursion_pathOfExcursions` the concatenated path really has the drawn words as its excursions.

The representation is deliberately not called a mixture of Markov chains, and it is not one: an i.i.d.-excursion mixture is a mixture of regenerative processes, and the Markov property of the excursion law is exactly the input still missing.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"markovexchangeable-exists-pathlaw-eq-map-definettibarycenter"}-->

🤖 Prepared with Claude Code
