### PR TITLE
feat: complete the B₂ special-isogeny square

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.LinearAlgebra.Matrix.SpecialMap
 public import TauCeti.LinearAlgebra.RootSystem.DiagramPermutations
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.B.RankTwo
 
@@ -44,10 +45,14 @@ later lift, together with its action on root subgroups, before the Suzuki--Ree l
 * `TauCeti.DynkinType.b2SpecialIsogenyMatrix_mulVec_root` and
   `TauCeti.DynkinType.b2SpecialIsogenyMatrix_transpose_mulVec_coroot`: the equations on the pinned
   datum.
-* `TauCeti.DynkinType.b2SpecialIsogenyMatrix_mul_self`: the square of the lattice map is
-  multiplication by `2`.
+* `TauCeti.DynkinType.b2SpecialIsogenyMatrix_mul_self` and its transpose counterpart: applying the
+  lattice map twice is multiplication by `2`.
+* `TauCeti.DynkinType.det_b2SpecialIsogenyMatrix`: the map has determinant `-2`, so it is an
+  isogeny and not a lattice automorphism.
 * `TauCeti.DynkinType.b2SpecialIsogenyExponent_mul_exponent`: the two rescaling exponents on an
   orbit multiply to the defining characteristic.
+* `TauCeti.DynkinType.b2SpecialIsogenyExponent_mul_pairing`: the Cartan integers transform by the
+  rule a special isogeny forces.
 
 ## References
 
@@ -205,6 +210,49 @@ theorem b2SpecialIsogenyMatrix_mul_self :
   fin_cases i <;> fin_cases j <;>
     simp [b2SpecialIsogenyMatrix_def, Matrix.mul_apply, Fin.sum_univ_succ]
 
+/-- The square of the cocharacter-lattice special matrix is twice the identity matrix. -/
+theorem b2SpecialIsogenyMatrix_transpose_mul_self :
+    b2SpecialIsogenyMatrixᵀ * b2SpecialIsogenyMatrixᵀ =
+      (2 : ℤ) • (1 : Matrix (Fin 2) (Fin 2) ℤ) := by
+  rw [← Matrix.transpose_mul, b2SpecialIsogenyMatrix_mul_self, Matrix.transpose_smul,
+    Matrix.transpose_one]
+
+/-- Applying the character-lattice special map twice is multiplication by the characteristic
+`2`. -/
+theorem b2SpecialIsogenyMatrix_mulVec_self (x : Fin 2 → ℤ) :
+    b2SpecialIsogenyMatrix *ᵥ (b2SpecialIsogenyMatrix *ᵥ x) = (2 : ℤ) • x := by
+  rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_mul_self, Matrix.smul_mulVec,
+    Matrix.one_mulVec]
+
+/-- Applying the cocharacter-lattice special map twice is multiplication by the characteristic
+`2`. -/
+theorem b2SpecialIsogenyMatrix_transpose_mulVec_self (x : Fin 2 → ℤ) :
+    b2SpecialIsogenyMatrixᵀ *ᵥ (b2SpecialIsogenyMatrixᵀ *ᵥ x) = (2 : ℤ) • x := by
+  rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_transpose_mul_self, Matrix.smul_mulVec,
+    Matrix.one_mulVec]
+
+/-- The square relation for the character-lattice map, as an equality of linear maps. -/
+theorem b2SpecialIsogenyMatrix_mulVecLin_comp_self :
+    b2SpecialIsogenyMatrix.mulVecLin ∘ₗ b2SpecialIsogenyMatrix.mulVecLin =
+      (2 : ℤ) • (LinearMap.id : (Fin 2 → ℤ) →ₗ[ℤ] (Fin 2 → ℤ)) := by
+  rw [← Matrix.mulVecLin_mul, b2SpecialIsogenyMatrix_mul_self]
+  ext x
+  simp
+
+/-- The square relation for the cocharacter-lattice map, as an equality of linear maps. -/
+theorem b2SpecialIsogenyMatrix_transpose_mulVecLin_comp_self :
+    b2SpecialIsogenyMatrixᵀ.mulVecLin ∘ₗ b2SpecialIsogenyMatrixᵀ.mulVecLin =
+      (2 : ℤ) • (LinearMap.id : (Fin 2 → ℤ) →ₗ[ℤ] (Fin 2 → ℤ)) := by
+  rw [← Matrix.mulVecLin_mul, b2SpecialIsogenyMatrix_transpose_mul_self]
+  ext x
+  simp
+
+/-- **The special map is an isogeny and not an automorphism of the character lattice**: its
+determinant is `-2`, of absolute value the characteristic. -/
+@[simp] theorem det_b2SpecialIsogenyMatrix : b2SpecialIsogenyMatrix.det = -2 := by
+  rw [b2SpecialIsogenyMatrix_def, Matrix.det_fin_two_of]
+  ring
+
 /-! ## Length and exponent conventions -/
 
 private theorem b2Length_mul_b2Length_specialIsogenyTableIndex (i : Fin 8) :
@@ -226,6 +274,37 @@ theorem b2SpecialIsogenyExponent_eq_one_or_eq_two (i : Fin (2 * 2 ^ 2)) :
   obtain ⟨j, rfl⟩ := b2Index_bijective.surjective i
   rw [b2SpecialIsogenyExponent_b2Index]
   decide +revert
+
+/-- **The special permutation exchanges long roots with short ones.** -/
+@[simp] theorem b2SpecialIsogenyExponent_indexEquiv_eq_one_iff (i : Fin (2 * 2 ^ 2)) :
+    b2SpecialIsogenyExponent (b2SpecialIsogenyIndexEquiv i) = 1 ↔
+      b2SpecialIsogenyExponent i = 2 := by
+  obtain ⟨j, rfl⟩ := b2Index_bijective.surjective i
+  rw [b2SpecialIsogenyIndexEquiv_b2Index, b2SpecialIsogenyExponent_b2Index,
+    b2SpecialIsogenyExponent_b2Index]
+  decide +revert
+
+/-- **The special permutation sends a short root to a long root.** -/
+@[simp] theorem b2SpecialIsogenyExponent_indexEquiv_eq_two_iff (i : Fin (2 * 2 ^ 2)) :
+    b2SpecialIsogenyExponent (b2SpecialIsogenyIndexEquiv i) = 2 ↔
+      b2SpecialIsogenyExponent i = 1 := by
+  have h := (b2SpecialIsogenyExponent_indexEquiv_eq_one_iff
+    (b2SpecialIsogenyIndexEquiv i)).symm
+  rw [b2SpecialIsogenyIndexEquiv_apply_apply] at h
+  exact h
+
+/-- **The Cartan integers transform by the rule a special isogeny forces.** Writing `α'` for the
+image of a root `α` under the special permutation, pairing the root equation against the coroot
+equation gives `ℓ(α) ⟨α', β'∨⟩ = ℓ(β) ⟨α, β∨⟩`. -/
+theorem b2SpecialIsogenyExponent_mul_pairing (i j : Fin (2 * 2 ^ 2)) :
+    b2SpecialIsogenyExponent i *
+        (typeBSimplyConnectedRootDatum 2).pairing
+          (b2SpecialIsogenyIndexEquiv i) (b2SpecialIsogenyIndexEquiv j) =
+      b2SpecialIsogenyExponent j * (typeBSimplyConnectedRootDatum 2).pairing i j := by
+  rw [← RootPairing.root_coroot_eq_pairing, toLinearMap_typeBSimplyConnectedRootDatum,
+    ← RootPairing.root_coroot_eq_pairing, toLinearMap_typeBSimplyConnectedRootDatum]
+  exact mul_dotProduct_eq_of_mulVec_eq_smul b2SpecialIsogenyMatrix_mulVec_root
+    b2SpecialIsogenyMatrix_transpose_mulVec_coroot i j
 
 private theorem b2SpecialIsogenyExponent_b2Index_simple (i : Fin 2) :
     b2SpecialIsogenyExponent (b2Index (Fin.castLE (by omega) i)) =

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
@@ -218,15 +218,16 @@ theorem b2SpecialIsogenyMatrix_transpose_mul_self :
     Matrix.transpose_one]
 
 /-- Applying the character-lattice special map twice is multiplication by the characteristic
-`2`. -/
-@[simp] theorem b2SpecialIsogenyMatrix_mulVec_self (x : Fin 2 → ℤ) :
+`2`. This is not a `simp` lemma: on `Fin 2` the simp set unfolds `*ᵥ` entrywise through
+`Matrix.mulVec_fin_two`, so the left-hand side is not in normal form. -/
+theorem b2SpecialIsogenyMatrix_mulVec_self (x : Fin 2 → ℤ) :
     b2SpecialIsogenyMatrix *ᵥ (b2SpecialIsogenyMatrix *ᵥ x) = (2 : ℤ) • x := by
   rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_mul_self, Matrix.smul_mulVec,
     Matrix.one_mulVec]
 
 /-- Applying the cocharacter-lattice special map twice is multiplication by the characteristic
-`2`. -/
-@[simp] theorem b2SpecialIsogenyMatrix_transpose_mulVec_self (x : Fin 2 → ℤ) :
+`2`. As for the character-lattice statement, this is not a `simp` lemma. -/
+theorem b2SpecialIsogenyMatrix_transpose_mulVec_self (x : Fin 2 → ℤ) :
     b2SpecialIsogenyMatrixᵀ *ᵥ (b2SpecialIsogenyMatrixᵀ *ᵥ x) = (2 : ℤ) • x := by
   rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_transpose_mul_self, Matrix.smul_mulVec,
     Matrix.one_mulVec]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
@@ -220,16 +220,32 @@ theorem b2SpecialIsogenyMatrix_transpose_mul_self :
 /-- Applying the character-lattice special map twice is multiplication by the characteristic
 `2`. -/
 @[simp] theorem b2SpecialIsogenyMatrix_mulVec_self (x : Fin 2 → ℤ) :
-    b2SpecialIsogenyMatrix *ᵥ (b2SpecialIsogenyMatrix *ᵥ x) = (2 : ℤ) • x := by
-  rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_mul_self, Matrix.smul_mulVec,
-    Matrix.one_mulVec]
+    ![b2SpecialIsogenyMatrix 0 0 *
+          (b2SpecialIsogenyMatrix 0 0 * x 0 + b2SpecialIsogenyMatrix 0 1 * x 1) +
+        b2SpecialIsogenyMatrix 0 1 *
+          (b2SpecialIsogenyMatrix 1 0 * x 0 + b2SpecialIsogenyMatrix 1 1 * x 1),
+      b2SpecialIsogenyMatrix 1 0 *
+          (b2SpecialIsogenyMatrix 0 0 * x 0 + b2SpecialIsogenyMatrix 0 1 * x 1) +
+        b2SpecialIsogenyMatrix 1 1 *
+          (b2SpecialIsogenyMatrix 1 0 * x 0 + b2SpecialIsogenyMatrix 1 1 * x 1)] =
+      (2 : ℤ) • x := by
+  ext i
+  fin_cases i <;> simp [b2SpecialIsogenyMatrix_def]
 
 /-- Applying the cocharacter-lattice special map twice is multiplication by the characteristic
 `2`. -/
 @[simp] theorem b2SpecialIsogenyMatrix_transpose_mulVec_self (x : Fin 2 → ℤ) :
-    b2SpecialIsogenyMatrixᵀ *ᵥ (b2SpecialIsogenyMatrixᵀ *ᵥ x) = (2 : ℤ) • x := by
-  rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_transpose_mul_self, Matrix.smul_mulVec,
-    Matrix.one_mulVec]
+    ![b2SpecialIsogenyMatrix 0 0 *
+          (b2SpecialIsogenyMatrix 0 0 * x 0 + b2SpecialIsogenyMatrix 1 0 * x 1) +
+        b2SpecialIsogenyMatrix 1 0 *
+          (b2SpecialIsogenyMatrix 0 1 * x 0 + b2SpecialIsogenyMatrix 1 1 * x 1),
+      b2SpecialIsogenyMatrix 0 1 *
+          (b2SpecialIsogenyMatrix 0 0 * x 0 + b2SpecialIsogenyMatrix 1 0 * x 1) +
+        b2SpecialIsogenyMatrix 1 1 *
+          (b2SpecialIsogenyMatrix 0 1 * x 0 + b2SpecialIsogenyMatrix 1 1 * x 1)] =
+      (2 : ℤ) • x := by
+  ext i
+  fin_cases i <;> simp [b2SpecialIsogenyMatrix_def]
 
 /-- The square relation for the character-lattice map, as an equality of linear maps. -/
 theorem b2SpecialIsogenyMatrix_mulVecLin_comp_self :

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.Matrix.SpecialMap
+import TauCeti.LinearAlgebra.Matrix.SpecialMap
 public import TauCeti.LinearAlgebra.RootSystem.DiagramPermutations
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.B.RankTwo
 
@@ -220,32 +220,16 @@ theorem b2SpecialIsogenyMatrix_transpose_mul_self :
 /-- Applying the character-lattice special map twice is multiplication by the characteristic
 `2`. -/
 @[simp] theorem b2SpecialIsogenyMatrix_mulVec_self (x : Fin 2 → ℤ) :
-    ![b2SpecialIsogenyMatrix 0 0 *
-          (b2SpecialIsogenyMatrix 0 0 * x 0 + b2SpecialIsogenyMatrix 0 1 * x 1) +
-        b2SpecialIsogenyMatrix 0 1 *
-          (b2SpecialIsogenyMatrix 1 0 * x 0 + b2SpecialIsogenyMatrix 1 1 * x 1),
-      b2SpecialIsogenyMatrix 1 0 *
-          (b2SpecialIsogenyMatrix 0 0 * x 0 + b2SpecialIsogenyMatrix 0 1 * x 1) +
-        b2SpecialIsogenyMatrix 1 1 *
-          (b2SpecialIsogenyMatrix 1 0 * x 0 + b2SpecialIsogenyMatrix 1 1 * x 1)] =
-      (2 : ℤ) • x := by
-  ext i
-  fin_cases i <;> simp [b2SpecialIsogenyMatrix_def]
+    b2SpecialIsogenyMatrix *ᵥ (b2SpecialIsogenyMatrix *ᵥ x) = (2 : ℤ) • x := by
+  rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_mul_self, Matrix.smul_mulVec,
+    Matrix.one_mulVec]
 
 /-- Applying the cocharacter-lattice special map twice is multiplication by the characteristic
 `2`. -/
 @[simp] theorem b2SpecialIsogenyMatrix_transpose_mulVec_self (x : Fin 2 → ℤ) :
-    ![b2SpecialIsogenyMatrix 0 0 *
-          (b2SpecialIsogenyMatrix 0 0 * x 0 + b2SpecialIsogenyMatrix 1 0 * x 1) +
-        b2SpecialIsogenyMatrix 1 0 *
-          (b2SpecialIsogenyMatrix 0 1 * x 0 + b2SpecialIsogenyMatrix 1 1 * x 1),
-      b2SpecialIsogenyMatrix 0 1 *
-          (b2SpecialIsogenyMatrix 0 0 * x 0 + b2SpecialIsogenyMatrix 1 0 * x 1) +
-        b2SpecialIsogenyMatrix 1 1 *
-          (b2SpecialIsogenyMatrix 0 1 * x 0 + b2SpecialIsogenyMatrix 1 1 * x 1)] =
-      (2 : ℤ) • x := by
-  ext i
-  fin_cases i <;> simp [b2SpecialIsogenyMatrix_def]
+    b2SpecialIsogenyMatrixᵀ *ᵥ (b2SpecialIsogenyMatrixᵀ *ᵥ x) = (2 : ℤ) • x := by
+  rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_transpose_mul_self, Matrix.smul_mulVec,
+    Matrix.one_mulVec]
 
 /-- The square relation for the character-lattice map, as an equality of linear maps. -/
 theorem b2SpecialIsogenyMatrix_mulVecLin_comp_self :

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean
@@ -219,14 +219,14 @@ theorem b2SpecialIsogenyMatrix_transpose_mul_self :
 
 /-- Applying the character-lattice special map twice is multiplication by the characteristic
 `2`. -/
-theorem b2SpecialIsogenyMatrix_mulVec_self (x : Fin 2 → ℤ) :
+@[simp] theorem b2SpecialIsogenyMatrix_mulVec_self (x : Fin 2 → ℤ) :
     b2SpecialIsogenyMatrix *ᵥ (b2SpecialIsogenyMatrix *ᵥ x) = (2 : ℤ) • x := by
   rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_mul_self, Matrix.smul_mulVec,
     Matrix.one_mulVec]
 
 /-- Applying the cocharacter-lattice special map twice is multiplication by the characteristic
 `2`. -/
-theorem b2SpecialIsogenyMatrix_transpose_mulVec_self (x : Fin 2 → ℤ) :
+@[simp] theorem b2SpecialIsogenyMatrix_transpose_mulVec_self (x : Fin 2 → ℤ) :
     b2SpecialIsogenyMatrixᵀ *ᵥ (b2SpecialIsogenyMatrixᵀ *ᵥ x) = (2 : ℤ) • x := by
   rw [Matrix.mulVec_mulVec, b2SpecialIsogenyMatrix_transpose_mul_self, Matrix.smul_mulVec,
     Matrix.one_mulVec]


### PR DESCRIPTION
This PR completes the pinned `B₂` special lattice map's square interface: proves the transpose square and the pointwise and linear-map square relations, computes determinant `-2`, shows that the root permutation exchanges the two exponent values, and derives the Cartan-pairing compatibility forced by the root and coroot equations.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, “Special isogenies in characteristics two and three,” specifically the characteristic-two `B₂/C₂` exceptional isogeny with square equal to Frobenius and prescribed action on long and short root subgroups. The designated consumer milestone is `CFSGStatement` L2, “Suzuki--Ree Steinberg maps.”

This is the most effective distinct step because the explicit `B₂` root table and special matrix are on `main`, while open PR #3893 supplies the generic root-pairing isogeny framework and bundles only the `G₂` and `F₄` maps. This PR supplies the remaining `B₂` determinant and square equations in the same canonical API shape without copying that in-flight framework.

The dependency edge is: `CFSGStatement` milestone L2 consumes the `ReductiveGroups` Layer 9 characteristic-two `B₂/C₂` special group-scheme isogeny; its root-datum square proof consumes `b2SpecialIsogenyMatrix_mulVecLin_comp_self`, `b2SpecialIsogenyMatrix_transpose_mulVecLin_comp_self`, `det_b2SpecialIsogenyMatrix`, and `b2SpecialIsogenyExponent_mul_exponent` supplied here.

After this PR, the Layer 9 target still needs the `B₂` root map bundled through the generic isogeny API once #3893 lands, followed by its lift to the pinned group scheme and the proof of its action on root subgroups before CFSGStatement L2 can close.

Extend `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpecialMap.lean` by 81 insertions and 2 deletions. The public surface follows the established neighboring `F₄` special-map interface and reuses Mathlib's matrix transpose, multiplication, determinant, and linear-map APIs together with Tau Ceti's generic `mul_dotProduct_eq_of_mulVec_eq_smul`; no Mathlib source is vendored. The mathematical conventions and proof organization follow the Steinberg and Carter references already credited in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"b2-special-isogeny-square"}-->

🤖 Prepared with Codex
