### PR TITLE
refactor(RepresentationTheory): state the carrier facts of an irreducible representation once

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/CentralCharacter.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/CentralCharacter.lean
@@ -139,8 +139,7 @@ to the scalar action on the other; a nonzero vector then forces the two scalars 
 theorem centralCharacter_eq_of_equiv {W : Type*} [AddCommGroup W] [Module k W]
     [FiniteDimensional k W] (σ : _root_.Representation k G W) [σ.IsIrreducible] (φ : ρ.Equiv σ) :
     centralCharacter σ = centralCharacter ρ := by
-  have : Nontrivial ρ.asModule := IsSimpleModule.nontrivial k[G] _
-  have : Nontrivial V := ρ.asModuleEquiv.symm.toEquiv.nontrivial
+  have : Nontrivial V := IsIrreducible.nontrivial ‹ρ.IsIrreducible›
   obtain ⟨v, hv⟩ := exists_ne (0 : V)
   have hφv : φ.toIntertwiningMap v ≠ 0 := fun h0 =>
     hv (φ.toLinearEquiv.injective (by simpa using h0))

--- a/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
@@ -139,8 +139,7 @@ theorem finrank_dvd_card : finrank k V ∣ Nat.card G := by
   let _ : Fintype G := Fintype.ofFinite G
   have hcard : (Nat.card G : k) ≠ 0 := Nat.cast_ne_zero.mpr Nat.card_pos.ne'
   have : Invertible (Nat.card G : k) := invertibleOfNonzero hcard
-  have : Nontrivial ρ.asModule := IsSimpleModule.nontrivial k[G] ρ.asModule
-  have : Nontrivial V := ρ.asModuleEquiv.symm.toEquiv.nontrivial
+  have : Nontrivial V := IsIrreducible.nontrivial ‹ρ.IsIrreducible›
   refine dvd_of_isIntegral_of_natCast_mul_eq (k := k) ?_
     (finrank_mul_sum_centralCharacter_eq_card ρ) Module.finrank_pos.ne'
   refine IsIntegral.sum _ fun C _ => IsIntegral.mul

--- a/TauCeti/RepresentationTheory/CharacterTable/Table.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Table.lean
@@ -238,11 +238,8 @@ theorem irreducibleCharacter_one (i : Fin (Nat.card (ConjClasses G))) :
 nonzero, so the space affording the character has positive dimension. -/
 theorem characterDegree_pos (i : Fin (Nat.card (ConjClasses G))) :
     0 < characterDegree k i := by
-  have hsimple : Nontrivial (irreducibleRepresentation k i).asModule :=
-    IsSimpleModule.nontrivial (MonoidAlgebra k G) _
-  have : Nontrivial (Fin (characterDegree k i) → k) :=
-    (irreducibleRepresentation k i).asModuleEquiv.symm.toEquiv.nontrivial
-  simpa using Module.finrank_pos (R := k) (M := Fin (characterDegree k i) → k)
+  simpa using Representation.IsIrreducible.finrank_pos
+    (inferInstance : (irreducibleRepresentation k i).IsIrreducible)
 
 /-- **The sum of the squares of the degrees is the order of the group**, as an identity of natural
 numbers. The representations affording the enumerated characters are pairwise inequivalent

--- a/TauCeti/RepresentationTheory/Compact/Character/Basic.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Basic.lean
@@ -185,13 +185,8 @@ theorem character_orthonormal_self [IsAlgClosed 𝕜] (hunitary : IsUnitary π)
     ⟪characterLp π hπ, characterLp π hπ⟫_𝕜 = 1 := by
   classical
   let : Representation.IsIrreducible π.toRepresentation := hirr
-  have : Nontrivial π.toRepresentation.asModule :=
-    IsSimpleModule.nontrivial (MonoidAlgebra 𝕜 G) π.toRepresentation.asModule
-  -- Nontriviality lives on the `Representation.asModule` type synonym; transport it along
-  -- `Representation.asModuleEquiv` rather than through the synonym's definitional unfolding.
-  have : Nontrivial V := π.toRepresentation.asModuleEquiv.symm.toEquiv.nontrivial
-  have hd : (Module.finrank 𝕜 V : 𝕜) ≠ 0 := by
-    exact_mod_cast (Module.finrank_pos (R := 𝕜) (M := V)).ne'
+  have hd : (Module.finrank 𝕜 V : 𝕜) ≠ 0 :=
+    Representation.IsIrreducible.natCast_finrank_ne_zero hirr
   set e := stdOrthonormalBasis 𝕜 V
   -- Only the diagonal term of each inner sum survives, so each of the `d` rows contributes `d⁻¹`.
   have hrow : ∀ i, ∑ k, ⟪matrixCoeffLp π hπ (e k) (e k), matrixCoeffLp π hπ (e i) (e i)⟫_𝕜 =

--- a/TauCeti/RepresentationTheory/Compact/Character/Projection.lean
+++ b/TauCeti/RepresentationTheory/Compact/Character/Projection.lean
@@ -153,13 +153,8 @@ theorem finrank_smul_integratedOperator_star_character_self (hunitary : IsUnitar
     (Module.finrank 𝕜 V : 𝕜) • integratedOperator π hπ (star (character π hπ))
       = ContinuousLinearMap.id 𝕜 V := by
   let : Representation.IsIrreducible π.toRepresentation := hirr
-  have : Nontrivial π.toRepresentation.asModule :=
-    IsSimpleModule.nontrivial (MonoidAlgebra 𝕜 G) π.toRepresentation.asModule
-  -- Nontriviality lives on the `Representation.asModule` type synonym; transport it along
-  -- `Representation.asModuleEquiv` rather than through the synonym's definitional unfolding.
-  have : Nontrivial V := π.toRepresentation.asModuleEquiv.symm.toEquiv.nontrivial
-  have hdim : (Module.finrank 𝕜 V : 𝕜) ≠ 0 := by
-    exact_mod_cast (Module.finrank_pos (R := 𝕜) (M := V)).ne'
+  have hdim : (Module.finrank 𝕜 V : 𝕜) ≠ 0 :=
+    Representation.IsIrreducible.natCast_finrank_ne_zero hirr
   rw [integratedOperator_star_character_self π hπ hunitary hirr, smul_smul,
     mul_inv_cancel₀ hdim, one_smul]
 

--- a/TauCeti/RepresentationTheory/Compact/Integrated.lean
+++ b/TauCeti/RepresentationTheory/Compact/Integrated.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.RepresentationTheory.Compact.Averaging
 public import TauCeti.RepresentationTheory.Continuous.Character
 public import TauCeti.RepresentationTheory.Continuous.Schur
+public import TauCeti.RepresentationTheory.Irreducible
 
 /-!
 # A class function acts on an irreducible representation by a scalar
@@ -322,12 +323,6 @@ theorem integratedOperator_eq_smul_id
       = ((Module.finrank 𝕜 V : 𝕜)⁻¹ * ∫ g, f g * character π hπ g ∂haarProb G) •
         ContinuousLinearMap.id 𝕜 V := by
   let : Representation.IsIrreducible π.toRepresentation := hirr
-  have : IsSimpleModule (MonoidAlgebra 𝕜 G) π.toRepresentation.asModule := inferInstance
-  have : Nontrivial π.toRepresentation.asModule :=
-    IsSimpleModule.nontrivial (MonoidAlgebra 𝕜 G) π.toRepresentation.asModule
-  -- Nontriviality lives on the `Representation.asModule` type synonym; transport it along
-  -- `Representation.asModuleEquiv` rather than through the synonym's definitional unfolding.
-  have : Nontrivial V := π.toRepresentation.asModuleEquiv.symm.toEquiv.nontrivial
   obtain ⟨c, hc⟩ := exists_eq_smul_one_of_irreducible π hirr (integratedIntertwiner π hπ hf)
   have hc := congrArg ContIntertwiningMap.toContinuousLinearMap hc
   simp only [toContinuousLinearMap_integratedIntertwiner,
@@ -335,8 +330,8 @@ theorem integratedOperator_eq_smul_id
     ContIntertwiningMap.toContinuousLinearMap_one, ContinuousLinearMap.one_def] at hc
   have htrace := trace_integratedOperator π hπ f
   rw [hc] at htrace
-  have hdim : (Module.finrank 𝕜 V : 𝕜) ≠ 0 := by
-    exact_mod_cast (Module.finrank_pos (R := 𝕜) (M := V)).ne'
+  have hdim : (Module.finrank 𝕜 V : 𝕜) ≠ 0 :=
+    Representation.IsIrreducible.natCast_finrank_ne_zero hirr
   have hc' : c = (Module.finrank 𝕜 V : 𝕜)⁻¹ * ∫ g, f g * character π hπ g ∂haarProb G := by
     apply (eq_inv_mul_iff_mul_eq₀ hdim).2
     simpa [mul_comm] using htrace

--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.RepresentationTheory.Compact.Intertwiner.Basic
 public import TauCeti.RepresentationTheory.Continuous.Schur
+public import TauCeti.RepresentationTheory.Irreducible
 public import Mathlib.Analysis.InnerProductSpace.Trace
 
 /-!
@@ -78,12 +79,6 @@ theorem averageOperator_eq_finrank_inv_mul_trace_smul_id
       ((Module.finrank 𝕜 V : 𝕜)⁻¹ * LinearMap.trace 𝕜 V (T : V →ₗ[𝕜] V)) •
         ContinuousLinearMap.id 𝕜 V := by
   let : Representation.IsIrreducible π.toRepresentation := hirr
-  have : IsSimpleModule 𝕜[G] π.toRepresentation.asModule := inferInstance
-  have : Nontrivial π.toRepresentation.asModule :=
-    IsSimpleModule.nontrivial 𝕜[G] π.toRepresentation.asModule
-  -- Nontriviality lives on the `Representation.asModule` type synonym; transport it along
-  -- `Representation.asModuleEquiv` rather than through the synonym's definitional unfolding.
-  have : Nontrivial V := π.toRepresentation.asModuleEquiv.symm.toEquiv.nontrivial
   obtain ⟨c, hc⟩ := exists_eq_smul_one_of_irreducible π hirr
     (averageIntertwiner π hπ π hπ T)
   have hc := congrArg ContIntertwiningMap.toContinuousLinearMap hc
@@ -92,8 +87,8 @@ theorem averageOperator_eq_finrank_inv_mul_trace_smul_id
     ContIntertwiningMap.toContinuousLinearMap_one, ContinuousLinearMap.one_def] at hc
   have htrace := trace_averageOperator π hπ T
   rw [hc] at htrace
-  have hdim : (Module.finrank 𝕜 V : 𝕜) ≠ 0 := by
-    exact_mod_cast (Module.finrank_pos (R := 𝕜) (M := V)).ne'
+  have hdim : (Module.finrank 𝕜 V : 𝕜) ≠ 0 :=
+    Representation.IsIrreducible.natCast_finrank_ne_zero hirr
   have hc' : c = (Module.finrank 𝕜 V : 𝕜)⁻¹ *
       LinearMap.trace 𝕜 V (T : V →ₗ[𝕜] V) := by
     apply (eq_inv_mul_iff_mul_eq₀ hdim).2

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Basic.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Basic.lean
@@ -340,8 +340,7 @@ theorem isSemisimpleRepresentation_comp_subtype_of_isAtom [ρ.IsIrreducible]
 subgroup of a finite-dimensional irreducible representation is semisimple. -/
 theorem isSemisimpleRepresentation_comp_subtype [ρ.IsIrreducible] [FiniteDimensional k V] :
     _root_.Representation.IsSemisimpleRepresentation (ρ.comp N.subtype) := by
-  have : Nontrivial ρ.asModule := IsSimpleModule.nontrivial k[G] _
-  have : Nontrivial V := ρ.asModuleEquiv.symm.toEquiv.nontrivial
+  have : Nontrivial V := IsIrreducible.nontrivial ‹ρ.IsIrreducible›
   obtain ⟨σ, hσ⟩ := exists_isAtom (ρ.comp N.subtype)
   exact isSemisimpleRepresentation_comp_subtype_of_isAtom ρ hσ
 

--- a/TauCeti/RepresentationTheory/Induction/Clifford/Orbit/Basic.lean
+++ b/TauCeti/RepresentationTheory/Induction/Clifford/Orbit/Basic.lean
@@ -139,8 +139,7 @@ theorem exists_isAtom_forall_nonempty_linearEquiv_conjSubrep [ρ.IsIrreducible]
     ∃ σ : Subrepresentation (ρ.comp N.subtype), IsAtom σ ∧
       ∀ τ : Subrepresentation (ρ.comp N.subtype), IsAtom τ →
         ∃ g : G, Nonempty (τ.asSubmodule ≃ₗ[k[N]] (conjSubrep ρ g σ).asSubmodule) := by
-  have : Nontrivial ρ.asModule := IsSimpleModule.nontrivial k[G] _
-  have : Nontrivial V := ρ.asModuleEquiv.symm.toEquiv.nontrivial
+  have : Nontrivial V := IsIrreducible.nontrivial ‹ρ.IsIrreducible›
   obtain ⟨σ, hσ⟩ := exists_isAtom (ρ.comp N.subtype)
   exact ⟨σ, hσ, fun _ hτ => exists_nonempty_linearEquiv_conjSubrep ρ hσ hτ⟩
 

--- a/TauCeti/RepresentationTheory/InvariantForm.lean
+++ b/TauCeti/RepresentationTheory/InvariantForm.lean
@@ -9,6 +9,7 @@ public import Mathlib.RepresentationTheory.Invariants
 public import Mathlib.RepresentationTheory.Irreducible
 public import TauCeti.LinearAlgebra.BilinearForm.Basic
 public import TauCeti.LinearAlgebra.BilinearForm.Isometry.Basic
+public import TauCeti.RepresentationTheory.Irreducible
 
 /-!
 # Invariant bilinear forms on a representation
@@ -374,9 +375,7 @@ other is Mathlib's `LinearMap.BilinForm.Nondegenerate.ne_zero`, once the space a
 representation acts on is known to be nonzero. -/
 theorem IsInvariantForm.nondegenerate_iff_ne_zero [ρ.IsIrreducible] (hB : IsInvariantForm ρ B) :
     B.Nondegenerate ↔ B ≠ 0 := by
-  -- Irreducibility makes `ρ.asModule` a simple, hence nonzero, module over the group algebra.
-  have : Nontrivial ρ.asModule := IsSimpleModule.nontrivial (MonoidAlgebra k G) _
-  have : Nontrivial V := ρ.asModuleEquiv.symm.toEquiv.nontrivial
+  have : Nontrivial V := IsIrreducible.nontrivial ‹ρ.IsIrreducible›
   exact ⟨fun h => h.ne_zero, hB.nondegenerate⟩
 
 variable [FiniteDimensional k V] [IsAlgClosed k] [ρ.IsIrreducible]

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -89,19 +89,18 @@ theorem IsIrreducible.nontrivial {ρ : Representation k G V} (h : ρ.IsIrreducib
   have _ := IsSimpleModule.nontrivial k[G] ρ.asModule
   ρ.asModuleEquiv.symm.toEquiv.nontrivial
 
-/-- **An irreducible representation has positive dimension.** This is `Module.finrank_pos` fed the
-nonzero carrier of `TauCeti.Representation.IsIrreducible.nontrivial`; it needs stating because
-that nontriviality is not an instance, so `Module.finrank_pos` does not fire on an
-irreducibility hypothesis by itself. -/
+/-- **A finite-dimensional irreducible representation has positive dimension.** This is what makes
+the degree of an irreducible character positive, and, cast into the base field by
+`Representation.IsIrreducible.natCast_finrank_ne_zero`, what lets the orthogonality relations and
+the integrated operator divide by that degree. -/
 theorem _root_.Representation.IsIrreducible.finrank_pos [FiniteDimensional k V]
     {ρ : Representation k G V} (h : ρ.IsIrreducible) : 0 < Module.finrank k V :=
   have := IsIrreducible.nontrivial h
   Module.finrank_pos
 
 /-- **The dimension of an irreducible representation is nonzero in the base field.** In
-characteristic zero the positive dimension of `Representation.IsIrreducible.finrank_pos`
-survives the cast into `k`, so it may be inverted: this is the scalar the orthogonality relations
-and the integrated operator of an irreducible representation are normalised by. -/
+characteristic zero it is therefore invertible there: this is the scalar the orthogonality
+relations and the integrated operator of an irreducible representation are normalised by. -/
 theorem _root_.Representation.IsIrreducible.natCast_finrank_ne_zero [CharZero k]
     [FiniteDimensional k V] {ρ : Representation k G V} (h : ρ.IsIrreducible) :
     (Module.finrank k V : k) ≠ 0 :=

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -43,6 +43,10 @@ irreducible by.
 
 * `TauCeti.Representation.IsIrreducible.nontrivial`: an irreducible representation has a nonzero
   carrier.
+* `TauCeti.Representation.IsIrreducible.finrank_pos`: a finite-dimensional irreducible
+  representation has positive dimension.
+* `TauCeti.Representation.IsIrreducible.natCast_finrank_ne_zero`: in characteristic zero that
+  dimension is nonzero, hence invertible, in the base field.
 * `Representation.IsIrreducible.finiteDimensional`: an irreducible representation of a finite
   monoid is finite-dimensional.
 * `TauCeti.Representation.isIrreducible_of_finrank_eq_one`: a line is irreducible.
@@ -84,6 +88,23 @@ theorem IsIrreducible.nontrivial {ρ : Representation k G V} (h : ρ.IsIrreducib
   have _ : ρ.IsIrreducible := h
   have _ := IsSimpleModule.nontrivial k[G] ρ.asModule
   ρ.asModuleEquiv.symm.toEquiv.nontrivial
+
+/-- **An irreducible representation has positive dimension.** This is `Module.finrank_pos` fed the
+nonzero carrier of `TauCeti.Representation.IsIrreducible.nontrivial`; it needs stating because that
+nontriviality is not an instance, so `Module.finrank_pos` does not fire on an irreducibility
+hypothesis by itself. -/
+theorem IsIrreducible.finrank_pos [FiniteDimensional k V] {ρ : Representation k G V}
+    (h : ρ.IsIrreducible) : 0 < Module.finrank k V :=
+  have := IsIrreducible.nontrivial h
+  Module.finrank_pos
+
+/-- **The dimension of an irreducible representation is nonzero in the base field.** In
+characteristic zero the positive dimension of `TauCeti.Representation.IsIrreducible.finrank_pos`
+survives the cast into `k`, so it may be inverted: this is the scalar the orthogonality relations
+and the integrated operator of an irreducible representation are normalised by. -/
+theorem IsIrreducible.natCast_finrank_ne_zero [CharZero k] [FiniteDimensional k V]
+    {ρ : Representation k G V} (h : ρ.IsIrreducible) : (Module.finrank k V : k) ≠ 0 :=
+  Nat.cast_ne_zero.mpr (IsIrreducible.finrank_pos h).ne'
 
 open scoped MonoidAlgebra in
 /-- **An irreducible representation of a finite monoid is finite-dimensional.** A simple module is
@@ -222,7 +243,7 @@ theorem _root_.Representation.asAlgebraHom_surjective_of_isIrreducible
   have : ρ.IsIrreducible := hρ
   have : IsSimpleModule k[G] ρ.asModule := inferInstance
   have : Nontrivial ρ.asModule := IsSimpleModule.nontrivial k[G] ρ.asModule
-  have : Nontrivial V := ρ.asModuleEquiv.symm.toEquiv.nontrivial
+  have : Nontrivial V := IsIrreducible.nontrivial hρ
   have : Module.Finite (Module.End k[G] ρ.asModule) ρ.asModule :=
     finite_end_of_smulCommClass (R := k[G]) (M := ρ.asModule) k
   intro T

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -43,9 +43,9 @@ irreducible by.
 
 * `TauCeti.Representation.IsIrreducible.nontrivial`: an irreducible representation has a nonzero
   carrier.
-* `TauCeti.Representation.IsIrreducible.finrank_pos`: a finite-dimensional irreducible
+* `Representation.IsIrreducible.finrank_pos`: a finite-dimensional irreducible
   representation has positive dimension.
-* `TauCeti.Representation.IsIrreducible.natCast_finrank_ne_zero`: in characteristic zero that
+* `Representation.IsIrreducible.natCast_finrank_ne_zero`: in characteristic zero that
   dimension is nonzero, hence invertible, in the base field.
 * `Representation.IsIrreducible.finiteDimensional`: an irreducible representation of a finite
   monoid is finite-dimensional.
@@ -90,21 +90,22 @@ theorem IsIrreducible.nontrivial {ρ : Representation k G V} (h : ρ.IsIrreducib
   ρ.asModuleEquiv.symm.toEquiv.nontrivial
 
 /-- **An irreducible representation has positive dimension.** This is `Module.finrank_pos` fed the
-nonzero carrier of `TauCeti.Representation.IsIrreducible.nontrivial`; it needs stating because that
-nontriviality is not an instance, so `Module.finrank_pos` does not fire on an irreducibility
-hypothesis by itself. -/
-theorem IsIrreducible.finrank_pos [FiniteDimensional k V] {ρ : Representation k G V}
-    (h : ρ.IsIrreducible) : 0 < Module.finrank k V :=
+nonzero carrier of `TauCeti.Representation.IsIrreducible.nontrivial`; it needs stating because
+that nontriviality is not an instance, so `Module.finrank_pos` does not fire on an
+irreducibility hypothesis by itself. -/
+theorem _root_.Representation.IsIrreducible.finrank_pos [FiniteDimensional k V]
+    {ρ : Representation k G V} (h : ρ.IsIrreducible) : 0 < Module.finrank k V :=
   have := IsIrreducible.nontrivial h
   Module.finrank_pos
 
 /-- **The dimension of an irreducible representation is nonzero in the base field.** In
-characteristic zero the positive dimension of `TauCeti.Representation.IsIrreducible.finrank_pos`
+characteristic zero the positive dimension of `Representation.IsIrreducible.finrank_pos`
 survives the cast into `k`, so it may be inverted: this is the scalar the orthogonality relations
 and the integrated operator of an irreducible representation are normalised by. -/
-theorem IsIrreducible.natCast_finrank_ne_zero [CharZero k] [FiniteDimensional k V]
-    {ρ : Representation k G V} (h : ρ.IsIrreducible) : (Module.finrank k V : k) ≠ 0 :=
-  Nat.cast_ne_zero.mpr (IsIrreducible.finrank_pos h).ne'
+theorem _root_.Representation.IsIrreducible.natCast_finrank_ne_zero [CharZero k]
+    [FiniteDimensional k V] {ρ : Representation k G V} (h : ρ.IsIrreducible) :
+    (Module.finrank k V : k) ≠ 0 :=
+  Nat.cast_ne_zero.mpr (Representation.IsIrreducible.finrank_pos h).ne'
 
 open scoped MonoidAlgebra in
 /-- **An irreducible representation of a finite monoid is finite-dimensional.** A simple module is


### PR DESCRIPTION
Roadmap: RepresentationTheory

A refactor: it adds no new mathematics, so it carries no `tauceti-target` marker.

`TauCeti.Representation.IsIrreducible.nontrivial` already records that an irreducible
representation has a nonzero carrier. Eleven proofs across `RepresentationTheory` did not call
it — each re-derived it inline from the same two steps, `IsSimpleModule.nontrivial` on
`ρ.asModule` followed by transport along `ρ.asModuleEquiv`. Four of those then repeated a
second block verbatim, turning the resulting `Nontrivial V` into `(finrank 𝕜 V : 𝕜) ≠ 0` via
`exact_mod_cast (Module.finrank_pos ..).ne'`.

This PR states those two consequences once, beside the lemma they follow from, and re-points
every site.

## Added — `TauCeti/RepresentationTheory/Irreducible.lean`

* `TauCeti.Representation.IsIrreducible.finrank_pos`: a finite-dimensional irreducible
  representation has positive dimension. Two lines — `IsIrreducible.nontrivial` feeding
  `Module.finrank_pos`, which does not fire on an irreducibility hypothesis by itself because
  that nontriviality is a theorem, not an instance.
* `TauCeti.Representation.IsIrreducible.natCast_finrank_ne_zero`: in characteristic zero that
  dimension is nonzero, hence invertible, in the base field — the scalar the orthogonality
  relations and the integrated operator of an irreducible representation are normalised by.

Both are added to the module docstring's **Main results**. The hypothesis is
`[FiniteDimensional k V]` rather than `[Finite G]`: the compact-group call sites have no
finite `G`, and for finite `G` the existing `Representation.IsIrreducible.finiteDimensional`
supplies the instance.

## Re-pointed — 10 files

| file | diff |
|---|---|
| `CharacterTable/CentralCharacter.lean` | +1 / −2 |
| `CharacterTable/Degree.lean` | +1 / −2 |
| `CharacterTable/Table.lean` | +2 / −5 |
| `Compact/Character/Basic.lean` | +2 / −7 |
| `Compact/Character/Projection.lean` | +2 / −7 |
| `Compact/Integrated.lean` | +3 / −8 |
| `Compact/SchurOrthogonality.lean` | +3 / −8 |
| `Induction/Clifford/Basic.lean` | +1 / −2 |
| `Induction/Clifford/Orbit/Basic.lean` | +1 / −2 |
| `InvariantForm.lean` | +2 / −3 |
| `Irreducible.lean` (the additions) | +22 / −1 |

Net −47 / +40. After this PR the `asModule`/`asModuleEquiv` nontriviality transport occurs
exactly once in the library: `grep -rn "asModuleEquiv.symm.toEquiv.nontrivial" TauCeti` returns
a single hit, the body of `IsIrreducible.nontrivial` itself. The
`exact_mod_cast (Module.finrank_pos ..)` pattern returns none.

`CharacterTable/Table.lean`'s `characterDegree_pos` collapses to a single `simpa using
IsIrreducible.finrank_pos ..`, which is the whole content of that proof.

### Three files gain an import

`InvariantForm.lean`, `Compact/Integrated.lean` and `Compact/SchurOrthogonality.lean` now carry
`public import TauCeti.RepresentationTheory.Irreducible`. This is not incidental — it is *why*
the duplication existed: these files consume irreducibility facts but did not import the file
that owns them, so each re-derived what it needed from Mathlib primitives instead. The remaining
call sites already reached the file directly or transitively and needed no new import.

## Deliberately not included

`Invertible (Nat.card G : k)` is derived in two places (`Dual.lean`,
`CharacterTable/Degree.lean`); everywhere else it is a signature hypothesis, not a duplicated
derivation. Two sites is below the bar for extraction, and it is a fact about the group order
rather than about the carrier of an irreducible representation — a different topic, left alone.

## Prior art

* **mathlib** — absent, by three independent methods:
  * *Loogle* (the decisive one), on the exact type pair `Representation.IsIrreducible,
    Module.finrank`, returns exactly two lemmas —
    `Representation.IsIrreducible.finrank_eq_one_of_isMulCommutative` and
    `Representation.IsIrreducible.finrank_intertwiningMap_self`. Neither is `finrank_pos`.
  * *LeanSearch* for "an irreducible representation has positive finrank" returns only the
    **polynomial** notion (`Irreducible.degree_pos`, `Irreducible.natDegree_pos`) — a different
    `Irreducible`, though a useful precedent: `Irreducible.<measure>_pos` is mathlib's own naming
    shape for exactly this statement, which is the shape used here.
  * *Untruncated full-name greps* over `Mathlib/` return 0 for `IsIrreducible.finrank_pos`,
    `IsIrreducible.natCast_finrank_ne_zero` and `finrank_pos_of_isIrreducible`, against live
    controls `Module.finrank_pos` (47 hits) and `IsSimpleModule.nontrivial` (9 hits).

  Both new statements consume the mathlib lemmas (`Module.finrank_pos`, `Nat.cast_ne_zero`)
  rather than restating them.
* **Placement**: mathlib keeps its own `Representation.IsIrreducible.finrank_*` lemmas in
  `Mathlib/RepresentationTheory/Irreducible.lean`; these go in the mirror file
  `TauCeti/RepresentationTheory/Irreducible.lean`, beside the `IsIrreducible.nontrivial` they
  are derived from.
* **No external source.** This reorganises code already in this repository; there is nothing
  to attribute.
