### PR TITLE
feat: trigonalize the representations of a commutative affine group

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Trigonalizable.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Trigonalizable.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule.Flag.Triangular
+public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
+import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+import TauCeti.Algebra.Coalgebra.Subcomodule.PointSeparation
+import TauCeti.LinearAlgebra.Eigenspace.JointEigenvector.Exists
+
+/-!
+# Trigonalizing the representations of a commutative affine group
+
+Let `H` be a reduced finite-type commutative Hopf algebra over an algebraically closed field `k`.
+If the points of `H` act on a finite-dimensional comodule by pairwise-commuting operators, that
+comodule has a nonzero weight vector: a joint eigenvector of the commuting operators spans a
+point-stable line, and point separation promotes that line to a subcomodule, whose weight is
+automatically a character.
+
+Feeding this into the flag induction of
+`TauCeti.Algebra.Coalgebra.Comodule.Flag.Triangular` trigonalizes every finite-dimensional
+representation of a commutative affine group: over a cocommutative `H` the convolution group of
+points is commutative, so the hypothesis holds for every comodule at once.
+
+This is the base case of the Lie--Kolchin induction, which reduces a connected solvable group to
+its commutative quotient by the derived subgroup. The induction step, which is where connectedness
+enters, is not proved here.
+
+## Main declarations
+
+* `TauCeti.Comodule.hasNonzeroWeightVector_of_pairwise_commute`: commuting point actions produce a
+  weight vector.
+* `TauCeti.Comodule.hasNonzeroWeightVector_of_isCocomm`: every nonzero finite-dimensional
+  representation of a commutative affine group has a weight vector.
+* `TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperTriangular_of_isCocomm`: every
+  finite-dimensional representation of a commutative affine group has an upper-triangular basis
+  with group-like diagonal.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, Theorem 6.3.1, whose commutative case is proved here.
+* A. Borel, *Linear Algebraic Groups*, §10.5.
+
+This advances the "Lie--Kolchin; solvable groups" milestone in Layer 5 of the ReductiveGroups
+roadmap.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.Comodule
+
+open WithConv
+
+universe u v w
+
+noncomputable section
+
+variable {k : Type u} {H : Type v} {M : Type w}
+variable [Field k] [CommRing H] [HopfAlgebra k H]
+variable [AddCommGroup M] [Module k M] [Comodule k H M]
+
+/-- If the base-valued points of a reduced finite-type commutative Hopf algebra over an
+algebraically closed field act on a nonzero finite-dimensional comodule by pairwise-commuting
+operators, then that comodule has a nonzero weight vector. -/
+theorem hasNonzeroWeightVector_of_pairwise_commute
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H]
+    [FiniteDimensional k M] [Nontrivial M]
+    (hcomm : Pairwise fun g h : WithConv (H →ₐ[k] k) ↦
+      Commute (basePointsRepresentation (R := k) (H := H) M g)
+        (basePointsRepresentation (R := k) (H := H) M h)) :
+    HasNonzeroWeightVector k H M := by
+  obtain ⟨chi, p, hrank, hact⟩ :=
+    TauCeti.exists_unitHom_submodule_finrank_eq_one_of_pairwise_commute_of_isAlgClosed
+      (basePointsRepresentation (R := k) (H := H) M) hcomm
+  have hbot : p ≠ ⊥ := by
+    intro h
+    rw [h, finrank_bot] at hrank
+    exact absurd hrank (by norm_num)
+  obtain ⟨v, hvp, hv⟩ := p.ne_bot_iff.mp hbot
+  have hspan : (k ∙ v) = p :=
+    Submodule.eq_of_le_of_finrank_eq ((Submodule.span_singleton_le_iff_mem v p).mpr hvp)
+      ((finrank_span_singleton hv).trans hrank.symm)
+  have hstable : ∀ (g : H →ₐ[k] k) {m : M}, m ∈ p →
+      Comodule.endOfPoint M g ((1 : k) ⊗ₜ[k] m) ∈ p.baseChange k := by
+    intro g m hm
+    have haction := endOfPoint_one_tmul_eq_one_tmul_basePointsRepresentation
+      (R := k) (H := H) (M := M) (toConv g) m
+    rw [ofConv_toConv] at haction
+    rw [endOfPoint_tmul, one_smul, haction]
+    exact Submodule.tmul_mem_baseChange_of_mem _ (hact (toConv g) m hm ▸ p.smul_mem _ hm)
+  exact hasNonzeroWeightVector_of_toSubmodule_eq_span
+    (Subcomodule.ofEndOfPointStable (K := k) p hstable) hv
+    ((Subcomodule.ofEndOfPointStable_toSubmodule (K := k) p hstable).trans hspan.symm)
+
+/-- Every nonzero finite-dimensional representation of a commutative affine group, reduced and of
+finite type over an algebraically closed field, has a nonzero weight vector. -/
+theorem hasNonzeroWeightVector_of_isCocomm
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H] [Coalgebra.IsCocomm k H]
+    [FiniteDimensional k M] [Nontrivial M] :
+    HasNonzeroWeightVector k H M :=
+  hasNonzeroWeightVector_of_pairwise_commute fun g h _ ↦
+    (Commute.all g h).map (basePointsRepresentation (R := k) (H := H) M)
+
+/-- **Every finite-dimensional representation of a commutative affine group is trigonalizable.**
+For a reduced finite-type cocommutative Hopf algebra over an algebraically closed field, every
+finite-dimensional comodule has a basis whose coefficient matrix is upper triangular with
+group-like diagonal entries: the group acts by upper-triangular matrices whose diagonal entries
+are characters. -/
+theorem exists_basis_coefficientMatrix_isUpperTriangular_of_isCocomm
+    [IsAlgClosed k] [Algebra.FiniteType k H] [IsReduced H] [Coalgebra.IsCocomm k H]
+    [FiniteDimensional k M] :
+    ∃ (n : ℕ) (b : Module.Basis (Fin n) k M),
+      (coefficientMatrix (C := H) b).IsUpperTriangular ∧
+        ∀ i, IsGroupLikeElem k (coefficientMatrix (C := H) b i i) :=
+  exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors
+    fun _ _ _ _ _ _ ↦ hasNonzeroWeightVector_of_isCocomm
+
+end
+
+end TauCeti.Comodule

--- a/TauCeti/Algebra/Coalgebra/Comodule/Flag/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Flag/Basic.lean
@@ -11,22 +11,25 @@ public import TauCeti.Algebra.Coalgebra.Subcomodule.Quotient
 public import TauCeti.LinearAlgebra.Matrix.Triangular
 
 /-!
-# Flags of upper-unitriangular comodules
+# Flags of upper-triangular comodules
 
 Let `M` be a finite free comodule with basis `b₀, ..., bₙ₋₁`. Its coefficient matrix is upper
-unitriangular exactly when, for every `i`, the coaction of `bᵢ` is congruent to `bᵢ ⊗ 1` modulo
-the span of the preceding basis vectors. Thus the standard basis flag is comodule-stable and its
-successive one-dimensional factors are trivial.
+triangular with diagonal `c` exactly when, for every `i`, the coaction of `bᵢ` is congruent to
+`bᵢ ⊗ cᵢ` modulo the span of the preceding basis vectors. Thus the standard basis flag is
+comodule-stable and its successive one-dimensional factors have weights `cᵢ`. The unitriangular
+case `c = 1` says those factors are trivial.
 
-This is the flag interface needed for the Kolchin induction in Layer 5, "Unipotent groups", of
-the ReductiveGroups roadmap. Once that induction supplies successive fixed vectors, the criterion
-here produces the upper-unitriangular coefficient matrix used to embed a faithful representation
-into `Uₙ`.
+This is the flag interface needed for the Kolchin inductions in Layer 5, "Unipotent groups", of
+the ReductiveGroups roadmap. Once such an induction supplies successive fixed vectors, the
+criterion here produces the upper-unitriangular coefficient matrix used to embed a faithful
+representation into `Uₙ`.
 
 ## Main declarations
 
-* `TauCeti.Comodule.coefficientMatrix_isUpperUnitriangular_iff`: the quotient-by-preceding-span
-  criterion for an upper-unitriangular coefficient matrix.
+* `TauCeti.Comodule.coefficientMatrix_isUpperTriangular_and_diag_iff`: the
+  quotient-by-preceding-span criterion for an upper-triangular coefficient matrix with prescribed
+  diagonal.
+* `TauCeti.Comodule.coefficientMatrix_isUpperUnitriangular_iff`: its unitriangular special case.
 * `TauCeti.Comodule.flagSubcomodule`: the standard flag of an upper-triangular comodule, bundled as
   subcomodules.
 * `TauCeti.Comodule.quotient_mk_basis_ne_zero`: each successive basis class is nonzero in the
@@ -56,20 +59,21 @@ variable {k : Type u} {H : Type v} {M : Type w} {n : ℕ}
 variable [CommRing k] [AddCommMonoid H] [Module k H] [Coalgebra k H]
 variable [AddCommGroup M] [Module k M] [Comodule k H M]
 
-/-- A coefficient matrix is upper unitriangular exactly when each basis vector is fixed by the
-coaction modulo the span of the preceding basis vectors. -/
-theorem coefficientMatrix_isUpperUnitriangular_iff [One H] (b : Basis (Fin n) k M) :
-    (coefficientMatrix (C := H) b).IsUpperUnitriangular ↔
+/-- A coefficient matrix is upper triangular with prescribed diagonal exactly when each basis
+vector has the prescribed coaction modulo the span of the preceding basis vectors. -/
+theorem coefficientMatrix_isUpperTriangular_and_diag_iff (b : Basis (Fin n) k M) (c : Fin n → H) :
+    ((coefficientMatrix (C := H) b).IsUpperTriangular ∧
+        ∀ i : Fin n, coefficientMatrix (C := H) b i i = c i) ↔
       ∀ i : Fin n,
         TensorProduct.map (b.flag i.castSucc).mkQ (LinearMap.id : H →ₗ[k] H)
             (coact (C := H) (b i)) =
-          Submodule.Quotient.mk (b i) ⊗ₜ[k] (1 : H) := by
+          Submodule.Quotient.mk (b i) ⊗ₜ[k] c i := by
   constructor
-  · intro h i
+  · rintro ⟨htri, hdiag⟩ i
     rw [coact_basis_eq_sum_coefficientMatrix, map_sum]
     classical
     rw [Finset.sum_eq_single i]
-    · simp [h.apply_diag i]
+    · simp [hdiag i]
     · intro j _ hji
       rcases lt_trichotomy j i with hji' | hji' | hij
       · rw [TensorProduct.map_tmul, LinearMap.id_apply]
@@ -77,11 +81,11 @@ theorem coefficientMatrix_isUpperUnitriangular_iff [One H] (b : Basis (Fin n) k 
           b.self_mem_flag (Fin.castSucc_lt_castSucc_iff.mpr hji')
         simp [(Submodule.Quotient.mk_eq_zero _).mpr hjflag]
       · exact (hji hji').elim
-      · simp [h.isUpperTriangular hij]
+      · simp [htri hij]
     · simp
   · intro h
     have hcoeff (i j : Fin n) (hji : j ≤ i) :
-        coefficientMatrix (C := H) b i j = if i = j then 1 else 0 := by
+        coefficientMatrix (C := H) b i j = if i = j then c i else 0 := by
       let q := (b.flag j.castSucc).mkQ
       let phi : (M ⧸ b.flag j.castSucc) →ₗ[k] k :=
         (b.flag j.castSucc).liftQ (b.coord i)
@@ -99,14 +103,21 @@ theorem coefficientMatrix_isUpperUnitriangular_iff [One H] (b : Basis (Fin n) k 
       · subst i
         simpa [phi, q, Submodule.liftQ_apply, Basis.coord_apply] using heq
       · simpa [phi, q, Submodule.liftQ_apply, Basis.coord_apply, hij] using heq
-    rw [Matrix.isUpperUnitriangular_def]
-    refine ⟨?_, ?_⟩
-    · intro i j hji
-      have hji' : j < i := by simpa only [id_eq] using hji
+    refine ⟨fun i j hji ↦ ?_, fun i ↦ ?_⟩
+    · have hji' : j < i := by simpa only [id_eq] using hji
       simpa [hji'.ne'] using hcoeff i j hji'.le
-    · intro i
-      rw [hcoeff i i le_rfl]
-      simp
+    · simpa using hcoeff i i le_rfl
+
+/-- A coefficient matrix is upper unitriangular exactly when each basis vector is fixed by the
+coaction modulo the span of the preceding basis vectors. -/
+theorem coefficientMatrix_isUpperUnitriangular_iff [One H] (b : Basis (Fin n) k M) :
+    (coefficientMatrix (C := H) b).IsUpperUnitriangular ↔
+      ∀ i : Fin n,
+        TensorProduct.map (b.flag i.castSucc).mkQ (LinearMap.id : H →ₗ[k] H)
+            (coact (C := H) (b i)) =
+          Submodule.Quotient.mk (b i) ⊗ₜ[k] (1 : H) := by
+  rw [Matrix.isUpperUnitriangular_def]
+  exact coefficientMatrix_isUpperTriangular_and_diag_iff b fun _ ↦ 1
 
 /-- The coaction of a basis vector in a stable initial segment belongs to the tensor product of
 that initial segment with the coalgebra. -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Flag/Extension.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Flag/Extension.lean
@@ -10,21 +10,22 @@ public import TauCeti.Algebra.Coalgebra.Comodule.Flag.Basic
 public import TauCeti.Algebra.Coalgebra.Subcomodule.Induced
 
 /-!
-# Upper-unitriangular comodule structures and extensions
+# Upper-triangular comodule structures and extensions
 
-An extension of upper-unitriangular comodules is again upper unitriangular. More explicitly, let
-`N` be a subcomodule of `M`. A basis of `N` and a basis of `M ⧸ N` combine, using Mathlib's
+An extension of upper-triangular comodules is again upper triangular. More explicitly, let `N` be
+a subcomodule of `M`. A basis of `N` and a basis of `M ⧸ N` combine, using Mathlib's
 `Module.Basis.sumQuot`, into a basis of `M`. If the coefficient matrices on the subcomodule and
-quotient are upper unitriangular, then the combined coefficient matrix is upper unitriangular.
+quotient are upper triangular, then the combined coefficient matrix is upper triangular, and its
+diagonal is the concatenation of theirs; in particular unitriangularity is inherited too.
 
 The coefficient matrix has the expected block form. Its diagonal blocks are the coefficient
 matrices of `N` and `M ⧸ N`, its lower-left block is zero because `N` is stable, and its
 upper-right block records the extension class.
 
-This is the extension step needed by the Kolchin induction in Layer 5, "Unipotent groups", of the
-ReductiveGroups roadmap. A fixed line supplies the first upper-unitriangular block; applying the
-induction hypothesis to the quotient and this file to the resulting extension constructs the
-complete invariant flag.
+This is the extension step needed by the Kolchin inductions in Layer 5, "Unipotent groups", of the
+ReductiveGroups roadmap. A weight line supplies the first diagonal block; applying the induction
+hypothesis to the quotient and this file to the resulting extension constructs the complete
+invariant flag.
 
 ## Main declarations
 
@@ -35,8 +36,10 @@ complete invariant flag.
 * `TauCeti.Comodule.coefficientMatrix_extensionBasis_natAdd_natAdd`: the quotient diagonal block.
 * `TauCeti.Comodule.coefficientMatrix_extensionBasis_natAdd_castAdd`: the vanishing lower-left
   block.
-* `TauCeti.Comodule.coefficientMatrix_extensionBasis_isUpperUnitriangular`: closure of
-  upper-unitriangular comodule structures under extensions.
+* `TauCeti.Comodule.coefficientMatrix_extensionBasis_isUpperTriangular`: closure of
+  upper-triangular comodule structures under extensions.
+* `TauCeti.Comodule.coefficientMatrix_extensionBasis_isUpperUnitriangular`: its unitriangular
+  refinement.
 
 ## References
 
@@ -188,6 +191,42 @@ theorem coefficientMatrix_extensionBasis_natAdd_natAdd
     _ = matrixCoefficient (R := k) (C := C) (bQ.coord i) (bQ j) := by
       rw [N.mkQ_apply, extensionBasis_natAdd_mkQ]
 
+/-- If the induced coefficient matrices on a subcomodule and its quotient are upper triangular,
+then the coefficient matrix on their combined basis is upper triangular. -/
+theorem coefficientMatrix_extensionBasis_isUpperTriangular
+    (N : Subcomodule k C M) (bN : Basis (Fin m) k N)
+    (bQ : Basis (Fin n) k (M ⧸ N.toSubmodule))
+    (hN : (coefficientMatrix (C := C) bN).IsUpperTriangular)
+    (hQ : (coefficientMatrix (C := C) bQ).IsUpperTriangular) :
+    (coefficientMatrix (C := C) (extensionBasis N bN bQ)).IsUpperTriangular := by
+  intro i j hji
+  obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
+  obtain ⟨j, rfl⟩ := finSumFinEquiv.surjective j
+  cases i with
+  | inl i =>
+      cases j with
+      | inl j =>
+          rw [finSumFinEquiv_apply_left, finSumFinEquiv_apply_left,
+            coefficientMatrix_extensionBasis_castAdd_castAdd]
+          simp only [finSumFinEquiv_apply_left] at hji
+          exact hN ((Fin.strictMono_castAdd n).lt_iff_lt.mp hji)
+      | inr j =>
+          rw [finSumFinEquiv_apply_left, finSumFinEquiv_apply_right] at hji
+          -- The two `Fin` embeddings do not simplify through `<`; their underlying indices
+          -- make the impossible cross-block inequality explicit.
+          change m + j.val < i.val at hji
+          omega
+  | inr i =>
+      cases j with
+      | inl j =>
+          rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_left,
+            coefficientMatrix_extensionBasis_natAdd_castAdd]
+      | inr j =>
+          rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_right,
+            coefficientMatrix_extensionBasis_natAdd_natAdd]
+          simp only [finSumFinEquiv_apply_right] at hji
+          exact hQ ((Fin.strictMono_natAdd m).lt_iff_lt.mp hji)
+
 variable [One C]
 
 /-- If the induced coefficient matrices on a subcomodule and its quotient are upper
@@ -199,43 +238,16 @@ theorem coefficientMatrix_extensionBasis_isUpperUnitriangular
     (hQ : (coefficientMatrix (C := C) bQ).IsUpperUnitriangular) :
     (coefficientMatrix (C := C) (extensionBasis N bN bQ)).IsUpperUnitriangular := by
   rw [Matrix.isUpperUnitriangular_def]
-  constructor
-  · intro i j hji
-    obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
-    obtain ⟨j, rfl⟩ := finSumFinEquiv.surjective j
-    cases i with
-    | inl i =>
-        cases j with
-        | inl j =>
-            rw [finSumFinEquiv_apply_left, finSumFinEquiv_apply_left,
-              coefficientMatrix_extensionBasis_castAdd_castAdd]
-            simp only [finSumFinEquiv_apply_left] at hji
-            exact hN.isUpperTriangular ((Fin.strictMono_castAdd n).lt_iff_lt.mp hji)
-        | inr j =>
-            rw [finSumFinEquiv_apply_left, finSumFinEquiv_apply_right] at hji
-            -- The two `Fin` embeddings do not simplify through `<`; their underlying indices
-            -- make the impossible cross-block inequality explicit.
-            change m + j.val < i.val at hji
-            omega
-    | inr i =>
-        cases j with
-        | inl j =>
-            rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_left,
-              coefficientMatrix_extensionBasis_natAdd_castAdd]
-        | inr j =>
-            rw [finSumFinEquiv_apply_right, finSumFinEquiv_apply_right,
-              coefficientMatrix_extensionBasis_natAdd_natAdd]
-            simp only [finSumFinEquiv_apply_right] at hji
-            exact hQ.isUpperTriangular ((Fin.strictMono_natAdd m).lt_iff_lt.mp hji)
-  · intro i
-    obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
-    cases i with
-    | inl i =>
-        rw [finSumFinEquiv_apply_left, coefficientMatrix_extensionBasis_castAdd_castAdd]
-        exact hN.apply_diag i
-    | inr i =>
-        rw [finSumFinEquiv_apply_right, coefficientMatrix_extensionBasis_natAdd_natAdd]
-        exact hQ.apply_diag i
+  refine ⟨coefficientMatrix_extensionBasis_isUpperTriangular N bN bQ hN.isUpperTriangular
+    hQ.isUpperTriangular, fun i ↦ ?_⟩
+  obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
+  cases i with
+  | inl i =>
+      rw [finSumFinEquiv_apply_left, coefficientMatrix_extensionBasis_castAdd_castAdd]
+      exact hN.apply_diag i
+  | inr i =>
+      rw [finSumFinEquiv_apply_right, coefficientMatrix_extensionBasis_natAdd_natAdd]
+      exact hQ.apply_diag i
 
 end
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Flag/Induction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Flag/Induction.lean
@@ -6,18 +6,18 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Coalgebra.Comodule.Fixed
-public import TauCeti.Algebra.Coalgebra.Comodule.Flag.Extension
+public import TauCeti.Algebra.Coalgebra.Comodule.Flag.Triangular
 
 /-!
 # Building upper-unitriangular bases from fixed vectors
 
 Suppose every nonzero finite-dimensional comodule over a coalgebra with a distinguished element
-`1` has a nonzero fixed vector, that is, a vector `v` with coaction `v ↦ v ⊗ 1`. Repeatedly choose
-such a vector and pass to the quotient by its span. Induction on dimension, together with the
-extension basis from `Comodule.Flag.Extension`, gives a basis whose coefficient matrix is upper
-unitriangular.
+`1` has a nonzero fixed vector, that is, a vector `v` with coaction `v ↦ v ⊗ 1`. Then every
+finite-dimensional comodule has a basis whose coefficient matrix is upper unitriangular: this is
+the weight-vector induction of `TauCeti.Algebra.Coalgebra.Comodule.Flag.Triangular` with the
+weights confined to `{1}`.
 
-This is the formal induction step common to the Kolchin arguments in Layer 5 of the
+This is the fixed-vector case of the induction common to the Kolchin arguments in Layer 5 of the
 ReductiveGroups roadmap. Lie–Kolchin supplies eigenlines for solvable groups; for a unipotent
 group every resulting character is trivial, so the lines are fixed. The theorem here turns that
 fixed-vector statement into the complete flag needed to embed a faithful representation into an
@@ -55,8 +55,6 @@ variable {k : Type u} {H : Type v} {M : Type w}
 variable [Field k] [AddCommGroup H] [Module k H] [Coalgebra k H] [One H]
 variable [AddCommGroup M] [Module k M] [Comodule k H M]
 
-attribute [local instance 1100] Module.Free.of_divisionRing Module.Flat.of_free
-
 /-- A comodule has a nonzero fixed vector if some nonzero `v` has coaction `v ⊗ 1`.
 
 For the comodule corresponding to a group representation, this says that the represented group
@@ -80,46 +78,6 @@ theorem hasNonzeroFixedVector_iff_fixedSubcomodule_ne_bot :
   exact ⟨fun ⟨v, hv, hvc⟩ ↦ ⟨v, mem_fixedSubcomodule.mpr hvc, hv⟩,
     fun ⟨v, hvm, hv⟩ ↦ ⟨v, hv, mem_fixedSubcomodule.mp hvm⟩⟩
 
-/-- The span of a fixed vector, bundled as a subcomodule. -/
-private def fixedSpan (v : M)
-    (hv : coact (R := k) (C := H) (M := M) v = v ⊗ₜ[k] (1 : H)) :
-    Subcomodule k H M :=
-  Subcomodule.ofSubmodule (k ∙ v) fun m hm ↦ by
-    obtain ⟨a, rfl⟩ := Submodule.mem_span_singleton.mp hm
-    refine ⟨a •
-      ((⟨v, Submodule.mem_span_singleton_self v⟩ : k ∙ v) ⊗ₜ[k] (1 : H)), ?_⟩
-    simp only [map_smul, TensorProduct.map_tmul, Submodule.coe_subtype,
-      LinearMap.id_coe, id_eq, TensorProduct.smul_tmul', hv]
-
-/-- Every vector in the subcomodule spanned by a fixed vector is fixed. -/
-private theorem fixedSpan_coact [Module.Flat k H] (v : M)
-    (hv : coact (R := k) (C := H) (M := M) v = v ⊗ₜ[k] (1 : H))
-    (x : fixedSpan v hv) :
-    coact (R := k) (C := H) (M := fixedSpan v hv) x = x ⊗ₜ[k] (1 : H) := by
-  apply Module.Flat.rTensor_preserves_injective_linearMap
-    (SMulMemClass.subtype (fixedSpan v hv)) Subtype.val_injective
-  rw [Subcomodule.subtype_rTensor_coact]
-  obtain ⟨a, ha⟩ := Submodule.mem_span_singleton.mp x.2
-  -- After applying the subtype tensor map, expose the ambient vectors on both sides.
-  change coact (R := k) (C := H) (M := M) (x : M) = (x : M) ⊗ₜ[k] (1 : H)
-  rw [← ha, map_smul, hv, TensorProduct.smul_tmul']
-
-omit [One H] in
-/-- A subcomodule and its exposed underlying submodule have the same dimension: both subtype the
-same carrier. -/
-private theorem finrank_toSubmodule (N : Subcomodule k H M) :
-    finrank k N.toSubmodule = finrank k N :=
-  rfl
-
-/-- The subcomodule spanned by a nonzero fixed vector has dimension one. -/
-private theorem fixedSpan_finrank (v : M)
-    (hv : coact (R := k) (C := H) (M := M) v = v ⊗ₜ[k] (1 : H)) (hv₀ : v ≠ 0) :
-    finrank k (fixedSpan v hv) = 1 := by
-  rw [← finrank_toSubmodule]
-  -- Expose the carrier chosen by `fixedSpan`, namely the singleton span.
-  change finrank k (k ∙ v) = 1
-  exact finrank_span_singleton hv₀
-
 /-- If every nonzero finite-dimensional `H`-comodule has a nonzero fixed vector, then every
 finite-dimensional `H`-comodule has a basis with upper-unitriangular coefficient matrix.
 
@@ -132,48 +90,18 @@ theorem exists_basis_coefficientMatrix_isUpperUnitriangular_of_fixed_vectors
       [FiniteDimensional k V] [Nontrivial V], HasNonzeroFixedVector k H V) :
     ∃ (n : ℕ) (b : Basis (Fin n) k M),
       (coefficientMatrix (C := H) b).IsUpperUnitriangular := by
-  generalize hdim : finrank k M = d
-  induction d using Nat.strong_induction_on generalizing M with
-  | h d ih =>
-      by_cases hM : Nontrivial M
-      · let _ : Nontrivial M := hM
-        let _ : Module.Flat k H := Module.Flat.of_free
-        obtain ⟨v, hv, hvcoact⟩ := (hasNonzeroFixedVector_iff (k := k) (H := H) (M := M)).mp
-          (hfixed M)
-        let L : Subcomodule k H M := fixedSpan v hvcoact
-        let _ : AddCommGroup L := Module.addCommMonoidToAddCommGroup k
-        have hLfinrank : finrank k L = 1 := fixedSpan_finrank v hvcoact hv
-        let vL : L := ⟨v, Submodule.mem_span_singleton_self v⟩
-        have hvL : vL ≠ 0 := by
-          intro h
-          exact hv (congrArg Subtype.val h)
-        let bL : Basis (Fin 1) k L :=
-          FiniteDimensional.basisSingleton (Fin 1) hLfinrank vL hvL
-        have hbL_fixed (i : Fin 1) :
-            coact (R := k) (C := H) (M := L) (bL i) = bL i ⊗ₜ[k] (1 : H) :=
-          fixedSpan_coact v hvcoact (bL i)
-        have hbL : (coefficientMatrix (C := H) bL).IsUpperUnitriangular := by
-          rw [coefficientMatrix_isUpperUnitriangular_iff]
-          intro i
-          rw [hbL_fixed i]
-          simp
-        let Q := M ⧸ L.toSubmodule
-        have hQdim : finrank k Q < d := by
-          -- Unfold the local quotient abbreviation so the generic finrank bound applies.
-          change finrank k (M ⧸ L.toSubmodule) < d
-          have hsum := Module.finrank_quotient_add_finrank_le L.toSubmodule
-          have hLto : finrank k L.toSubmodule = 1 := (finrank_toSubmodule L).trans hLfinrank
-          rw [hLto, hdim] at hsum
-          omega
-        obtain ⟨n, bQ, hbQ⟩ := ih (finrank k Q) hQdim (M := Q) rfl
-        exact ⟨1 + n, extensionBasis L bL bQ,
-          coefficientMatrix_extensionBasis_isUpperUnitriangular L bL bQ hbL hbQ⟩
-      · let _ : Subsingleton M := not_nontrivial_iff_subsingleton.mp hM
-        have hzero : finrank k M = 0 := Module.finrank_zero_of_subsingleton
-        let b : Basis (Fin 0) k M := finBasisOfFinrankEq k M hzero
-        refine ⟨0, b, ?_⟩
-        rw [Matrix.isUpperUnitriangular_def]
-        exact ⟨fun i ↦ Fin.elim0 i, fun i ↦ Fin.elim0 i⟩
+  have hweight : ∀ (V : Type w) [AddCommGroup V] [Module k V] [Comodule k H V]
+      [FiniteDimensional k V] [Nontrivial V],
+      ∃ (v : V) (c : H), v ≠ 0 ∧ c ∈ ({1} : Set H) ∧
+        coact (R := k) (C := H) (M := V) v = v ⊗ₜ[k] c := by
+    intro V _ _ _ _ _
+    obtain ⟨v, hv, hvcoact⟩ :=
+      (hasNonzeroFixedVector_iff (k := k) (H := H) (M := V)).mp (hfixed V)
+    exact ⟨v, 1, hv, rfl, hvcoact⟩
+  obtain ⟨n, b, htri, hdiag⟩ :=
+    exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vectors
+      (M := M) ({1} : Set H) hweight
+  exact ⟨n, b, (Matrix.isUpperUnitriangular_def _).mpr ⟨htri, fun i ↦ hdiag i⟩⟩
 
 end
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Flag/Triangular.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Flag/Triangular.lean
@@ -22,14 +22,15 @@ This is the formal induction step behind both Kolchin arguments in Layer 5 of th
 roadmap. Taking `S = {1}` recovers the unitriangular statement used for unipotent groups, where
 Kolchin's theorem supplies genuine fixed vectors; taking `S` to be the set of group-like elements
 gives the triangular statement Lie--Kolchin needs for solvable groups, where only eigenvectors are
-available and the diagonal characters survive in the conclusion.
+available and group-like elements survive on the diagonal. When `C` is the coordinate Hopf algebra
+of an affine group, these group-like elements are its diagonal characters.
 
 ## Main declarations
 
 * `TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vectors`:
   the induction, with the weights confined to a prescribed set.
 * `TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors`: its
-  group-like specialization, an upper-triangular basis whose diagonal coefficients are characters.
+  group-like specialization, with group-like diagonal coefficients.
 
 ## References
 
@@ -50,7 +51,7 @@ universe u v w
 noncomputable section
 
 variable {k : Type u} {C : Type v} {M : Type w}
-variable [Field k] [AddCommGroup C] [Module k C] [Coalgebra k C]
+variable [Field k] [AddCommMonoid C] [Module k C] [Coalgebra k C]
 variable [AddCommGroup M] [Module k M] [Comodule k C M]
 
 attribute [local instance 1100] Module.Free.of_divisionRing Module.Flat.of_free
@@ -65,8 +66,19 @@ private def weightSpan (v : M) (c : C)
     simp only [map_smul, TensorProduct.map_tmul, Submodule.coe_subtype,
       LinearMap.id_coe, id_eq, TensorProduct.smul_tmul', hv]
 
+/-- The carrier module of `weightSpan` is the span used to construct it. -/
+private theorem weightSpan_toSubmodule (v : M) (c : C)
+    (hv : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c) :
+    (weightSpan v c hv).toSubmodule = k ∙ v :=
+  rfl
+
+/-- A bundled subcomodule has the same dimension as its underlying submodule. -/
+private theorem finrank_toSubmodule (N : Subcomodule k C M) :
+    finrank k N.toSubmodule = finrank k N :=
+  rfl
+
 /-- Every vector in the subcomodule spanned by a weight vector has the same weight. -/
-private theorem weightSpan_coact (v : M) (c : C)
+private theorem weightSpan_coact [Module.Flat k C] (v : M) (c : C)
     (hv : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c) (x : weightSpan v c hv) :
     coact (R := k) (C := C) (M := weightSpan v c hv) x = x ⊗ₜ[k] c := by
   apply Module.Flat.rTensor_preserves_injective_linearMap
@@ -79,26 +91,9 @@ private theorem weightSpan_coact (v : M) (c : C)
 /-- The subcomodule spanned by a nonzero weight vector has dimension one. -/
 private theorem weightSpan_finrank (v : M) (c : C)
     (hv : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c) (hv₀ : v ≠ 0) :
-    finrank k (weightSpan v c hv) = 1 :=
-  finrank_span_singleton hv₀
-
-/-- The diagonal of the combined coefficient matrix of an extension consists of the diagonals of
-the subcomodule and quotient blocks. -/
-private theorem coefficientMatrix_extensionBasis_diag_mem
-    {m n : ℕ} (S : Set C) (N : Subcomodule k C M) (bN : Basis (Fin m) k N)
-    (bQ : Basis (Fin n) k (M ⧸ N.toSubmodule))
-    (hN : ∀ i, coefficientMatrix (C := C) bN i i ∈ S)
-    (hQ : ∀ i, coefficientMatrix (C := C) bQ i i ∈ S)
-    (i : Fin (m + n)) :
-    coefficientMatrix (C := C) (extensionBasis N bN bQ) i i ∈ S := by
-  obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
-  cases i with
-  | inl i =>
-      rw [finSumFinEquiv_apply_left, coefficientMatrix_extensionBasis_castAdd_castAdd]
-      exact hN i
-  | inr i =>
-      rw [finSumFinEquiv_apply_right, coefficientMatrix_extensionBasis_natAdd_natAdd]
-      exact hQ i
+    finrank k (weightSpan v c hv) = 1 := by
+  rw [← finrank_toSubmodule, weightSpan_toSubmodule]
+  exact finrank_span_singleton hv₀
 
 /-- If every nonzero finite-dimensional `C`-comodule has a nonzero weight vector whose weight lies
 in `S`, then every finite-dimensional `C`-comodule has a basis whose coefficient matrix is upper
@@ -116,6 +111,7 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vect
     ∃ (n : ℕ) (b : Basis (Fin n) k M),
       (coefficientMatrix (C := C) b).IsUpperTriangular ∧
         ∀ i, coefficientMatrix (C := C) b i i ∈ S := by
+  let _ : AddCommGroup C := Module.addCommMonoidToAddCommGroup k
   generalize hdim : finrank k M = d
   induction d using Nat.strong_induction_on generalizing M with
   | h d ih =>
@@ -143,15 +139,23 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vect
           -- Unfold the local quotient abbreviation so the generic finrank bound applies.
           change finrank k (M ⧸ L.toSubmodule) < d
           have hsum := Module.finrank_quotient_add_finrank_le L.toSubmodule
-          have hLto : finrank k L.toSubmodule = 1 := hLfinrank
+          have hLto : finrank k L.toSubmodule = 1 :=
+            (finrank_toSubmodule L).trans hLfinrank
           rw [hLto, hdim] at hsum
           omega
         obtain ⟨n, bQ, hbQtri, hbQdiag⟩ := ih (finrank k Q) hQdim (M := Q) rfl
         refine ⟨1 + n, extensionBasis L bL bQ,
-          coefficientMatrix_extensionBasis_isUpperTriangular L bL bQ hbL.1 hbQtri,
-          coefficientMatrix_extensionBasis_diag_mem S L bL bQ (fun i ↦ ?_) hbQdiag⟩
-        rw [hbL.2 i]
-        exact hc
+          coefficientMatrix_extensionBasis_isUpperTriangular L bL bQ hbL.1 hbQtri, ?_⟩
+        intro i
+        obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
+        cases i with
+        | inl i =>
+            rw [finSumFinEquiv_apply_left, coefficientMatrix_extensionBasis_castAdd_castAdd,
+              hbL.2 i]
+            exact hc
+        | inr i =>
+            rw [finSumFinEquiv_apply_right, coefficientMatrix_extensionBasis_natAdd_natAdd]
+            exact hbQdiag i
       · let _ : Subsingleton M := not_nontrivial_iff_subsingleton.mp hM
         have hzero : finrank k M = 0 := Module.finrank_zero_of_subsingleton
         let b : Basis (Fin 0) k M := finBasisOfFinrankEq k M hzero
@@ -166,12 +170,12 @@ theorem exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors
       [FiniteDimensional k V] [Nontrivial V], HasNonzeroWeightVector k C V) :
     ∃ (n : ℕ) (b : Basis (Fin n) k M),
       (coefficientMatrix (C := C) b).IsUpperTriangular ∧
-        ∀ i, IsGroupLikeElem k (coefficientMatrix (C := C) b i i) :=
-  exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vectors
+        ∀ i, IsGroupLikeElem k (coefficientMatrix (C := C) b i i) := by
+  exact exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vectors
     {c : C | IsGroupLikeElem k c} fun V _ _ _ _ _ ↦ by
-      obtain ⟨v, c, hv, hc, hvcoact⟩ :=
-        (hasNonzeroWeightVector_iff (k := k) (C := C)).mp (hweight V)
-      exact ⟨v, c, hv, hc, hvcoact⟩
+        obtain ⟨v, c, hv, hc, hvcoact⟩ :=
+          (hasNonzeroWeightVector_iff (k := k) (C := C)).mp (hweight V)
+        exact ⟨v, c, hv, hc, hvcoact⟩
 
 end
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Flag/Triangular.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Flag/Triangular.lean
@@ -1,0 +1,178 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule.Flag.Extension
+public import TauCeti.Algebra.Coalgebra.Comodule.WeightVector
+
+/-!
+# Building upper-triangular bases from weight vectors
+
+Suppose every nonzero finite-dimensional comodule over a coalgebra has a nonzero weight vector
+with weight drawn from a prescribed set `S`, that is, a vector `v` with coaction `v ↦ v ⊗ c` for
+some `c ∈ S`. Repeatedly choose such a vector and pass to the quotient by its span. Induction on
+dimension, together with the extension basis from
+`TauCeti.Algebra.Coalgebra.Comodule.Flag.Extension`, gives a basis whose coefficient matrix is
+upper triangular with diagonal entries in `S`.
+
+This is the formal induction step behind both Kolchin arguments in Layer 5 of the ReductiveGroups
+roadmap. Taking `S = {1}` recovers the unitriangular statement used for unipotent groups, where
+Kolchin's theorem supplies genuine fixed vectors; taking `S` to be the set of group-like elements
+gives the triangular statement Lie--Kolchin needs for solvable groups, where only eigenvectors are
+available and the diagonal characters survive in the conclusion.
+
+## Main declarations
+
+* `TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vectors`:
+  the induction, with the weights confined to a prescribed set.
+* `TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors`: its
+  group-like specialization, an upper-triangular basis whose diagonal coefficients are characters.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §§2.4 and 6.3.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.Comodule
+
+open Module
+
+universe u v w
+
+noncomputable section
+
+variable {k : Type u} {C : Type v} {M : Type w}
+variable [Field k] [AddCommGroup C] [Module k C] [Coalgebra k C]
+variable [AddCommGroup M] [Module k M] [Comodule k C M]
+
+attribute [local instance 1100] Module.Free.of_divisionRing Module.Flat.of_free
+
+/-- The span of a weight vector, bundled as a subcomodule. -/
+private def weightSpan (v : M) (c : C)
+    (hv : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c) :
+    Subcomodule k C M :=
+  Subcomodule.ofSubmodule (k ∙ v) fun m hm ↦ by
+    obtain ⟨a, rfl⟩ := Submodule.mem_span_singleton.mp hm
+    refine ⟨a • ((⟨v, Submodule.mem_span_singleton_self v⟩ : k ∙ v) ⊗ₜ[k] c), ?_⟩
+    simp only [map_smul, TensorProduct.map_tmul, Submodule.coe_subtype,
+      LinearMap.id_coe, id_eq, TensorProduct.smul_tmul', hv]
+
+/-- Every vector in the subcomodule spanned by a weight vector has the same weight. -/
+private theorem weightSpan_coact (v : M) (c : C)
+    (hv : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c) (x : weightSpan v c hv) :
+    coact (R := k) (C := C) (M := weightSpan v c hv) x = x ⊗ₜ[k] c := by
+  apply Module.Flat.rTensor_preserves_injective_linearMap
+    (SMulMemClass.subtype (weightSpan v c hv)) Subtype.val_injective
+  rw [Subcomodule.subtype_rTensor_coact]
+  -- After applying the subtype tensor map, expose the ambient vectors on both sides.
+  change coact (R := k) (C := C) (M := M) (x : M) = (x : M) ⊗ₜ[k] c
+  exact coact_eq_tmul_of_mem_span hv x.2
+
+/-- The subcomodule spanned by a nonzero weight vector has dimension one. -/
+private theorem weightSpan_finrank (v : M) (c : C)
+    (hv : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c) (hv₀ : v ≠ 0) :
+    finrank k (weightSpan v c hv) = 1 :=
+  finrank_span_singleton hv₀
+
+/-- The diagonal of the combined coefficient matrix of an extension consists of the diagonals of
+the subcomodule and quotient blocks. -/
+private theorem coefficientMatrix_extensionBasis_diag_mem
+    {m n : ℕ} (S : Set C) (N : Subcomodule k C M) (bN : Basis (Fin m) k N)
+    (bQ : Basis (Fin n) k (M ⧸ N.toSubmodule))
+    (hN : ∀ i, coefficientMatrix (C := C) bN i i ∈ S)
+    (hQ : ∀ i, coefficientMatrix (C := C) bQ i i ∈ S)
+    (i : Fin (m + n)) :
+    coefficientMatrix (C := C) (extensionBasis N bN bQ) i i ∈ S := by
+  obtain ⟨i, rfl⟩ := finSumFinEquiv.surjective i
+  cases i with
+  | inl i =>
+      rw [finSumFinEquiv_apply_left, coefficientMatrix_extensionBasis_castAdd_castAdd]
+      exact hN i
+  | inr i =>
+      rw [finSumFinEquiv_apply_right, coefficientMatrix_extensionBasis_natAdd_natAdd]
+      exact hQ i
+
+/-- If every nonzero finite-dimensional `C`-comodule has a nonzero weight vector whose weight lies
+in `S`, then every finite-dimensional `C`-comodule has a basis whose coefficient matrix is upper
+triangular with diagonal entries in `S`.
+
+The hypothesis is deliberately uniform in the comodule: the induction applies it to successive
+quotients. The conclusion allows an arbitrary finite index `n`; the exhibited basis itself
+certifies that `n` is the dimension of `M`. -/
+theorem exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vectors
+    (S : Set C) [FiniteDimensional k M]
+    (hweight : ∀ (V : Type w) [AddCommGroup V] [Module k V] [Comodule k C V]
+      [FiniteDimensional k V] [Nontrivial V],
+      ∃ (v : V) (c : C), v ≠ 0 ∧ c ∈ S ∧
+        coact (R := k) (C := C) (M := V) v = v ⊗ₜ[k] c) :
+    ∃ (n : ℕ) (b : Basis (Fin n) k M),
+      (coefficientMatrix (C := C) b).IsUpperTriangular ∧
+        ∀ i, coefficientMatrix (C := C) b i i ∈ S := by
+  generalize hdim : finrank k M = d
+  induction d using Nat.strong_induction_on generalizing M with
+  | h d ih =>
+      by_cases hM : Nontrivial M
+      · let _ : Nontrivial M := hM
+        obtain ⟨v, c, hv, hc, hvcoact⟩ := hweight M
+        let L : Subcomodule k C M := weightSpan v c hvcoact
+        let _ : AddCommGroup L := Module.addCommMonoidToAddCommGroup k
+        have hLfinrank : finrank k L = 1 := weightSpan_finrank v c hvcoact hv
+        let vL : L := ⟨v, Submodule.mem_span_singleton_self v⟩
+        have hvL : vL ≠ 0 := fun h ↦ hv (congrArg Subtype.val h)
+        let bL : Basis (Fin 1) k L :=
+          FiniteDimensional.basisSingleton (Fin 1) hLfinrank vL hvL
+        have hbL_weight (i : Fin 1) :
+            coact (R := k) (C := C) (M := L) (bL i) = bL i ⊗ₜ[k] c :=
+          weightSpan_coact v c hvcoact (bL i)
+        have hbL : (coefficientMatrix (C := C) bL).IsUpperTriangular ∧
+            ∀ i, coefficientMatrix (C := C) bL i i = c := by
+          rw [coefficientMatrix_isUpperTriangular_and_diag_iff bL fun _ ↦ c]
+          intro i
+          rw [hbL_weight i]
+          simp
+        let Q := M ⧸ L.toSubmodule
+        have hQdim : finrank k Q < d := by
+          -- Unfold the local quotient abbreviation so the generic finrank bound applies.
+          change finrank k (M ⧸ L.toSubmodule) < d
+          have hsum := Module.finrank_quotient_add_finrank_le L.toSubmodule
+          have hLto : finrank k L.toSubmodule = 1 := hLfinrank
+          rw [hLto, hdim] at hsum
+          omega
+        obtain ⟨n, bQ, hbQtri, hbQdiag⟩ := ih (finrank k Q) hQdim (M := Q) rfl
+        refine ⟨1 + n, extensionBasis L bL bQ,
+          coefficientMatrix_extensionBasis_isUpperTriangular L bL bQ hbL.1 hbQtri,
+          coefficientMatrix_extensionBasis_diag_mem S L bL bQ (fun i ↦ ?_) hbQdiag⟩
+        rw [hbL.2 i]
+        exact hc
+      · let _ : Subsingleton M := not_nontrivial_iff_subsingleton.mp hM
+        have hzero : finrank k M = 0 := Module.finrank_zero_of_subsingleton
+        let b : Basis (Fin 0) k M := finBasisOfFinrankEq k M hzero
+        exact ⟨0, b, fun i ↦ Fin.elim0 i, fun i ↦ Fin.elim0 i⟩
+
+/-- If every nonzero finite-dimensional `C`-comodule has a nonzero weight vector, then every
+finite-dimensional `C`-comodule has a basis whose coefficient matrix is upper triangular with
+group-like diagonal entries. -/
+theorem exists_basis_coefficientMatrix_isUpperTriangular_of_weight_vectors
+    [FiniteDimensional k M]
+    (hweight : ∀ (V : Type w) [AddCommGroup V] [Module k V] [Comodule k C V]
+      [FiniteDimensional k V] [Nontrivial V], HasNonzeroWeightVector k C V) :
+    ∃ (n : ℕ) (b : Basis (Fin n) k M),
+      (coefficientMatrix (C := C) b).IsUpperTriangular ∧
+        ∀ i, IsGroupLikeElem k (coefficientMatrix (C := C) b i i) :=
+  exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vectors
+    {c : C | IsGroupLikeElem k c} fun V _ _ _ _ _ ↦ by
+      obtain ⟨v, c, hv, hc, hvcoact⟩ :=
+        (hasNonzeroWeightVector_iff (k := k) (C := C)).mp (hweight V)
+      exact ⟨v, c, hv, hc, hvcoact⟩
+
+end
+
+end TauCeti.Comodule

--- a/TauCeti/Algebra/Coalgebra/Comodule/WeightVector.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/WeightVector.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Dual.Lemmas
+public import Mathlib.RingTheory.Coalgebra.GroupLike
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Basic
+
+/-!
+# Weight vectors of a comodule
+
+A **weight vector** of a comodule `M` over a coalgebra `C` is a vector `v` whose coaction is
+`v ↦ v ⊗ c` for a single element `c` of `C`; equivalently, the line it spans is a subcomodule.
+For the representation attached to `M`, this says exactly that every point of the represented
+affine group scales `v`, by the value it takes on `c`.
+
+The weight of a nonzero weight vector is automatically group-like: the counit law forces
+`ε c = 1` and coassociativity forces `Δ c = c ⊗ c`, because a nonzero vector of a vector space is
+detected by a linear functional. So a one-dimensional subcomodule of a comodule over a field is
+the same thing as a character of the represented group, and there is no need to carry
+group-likeness as a hypothesis.
+
+Weight vectors are the eigenvector form of the fixed vectors of
+`TauCeti.Algebra.Coalgebra.Comodule.Fixed`: a fixed vector is a weight vector of weight `1`. They
+are what the Lie--Kolchin argument produces for a connected solvable group, where fixed vectors
+are unavailable, and the flag induction of
+`TauCeti.Algebra.Coalgebra.Comodule.Flag.Triangular` turns them into a complete invariant flag.
+
+## Main declarations
+
+* `TauCeti.Comodule.HasNonzeroWeightVector`: a comodule contains a nonzero weight vector.
+* `TauCeti.Comodule.isGroupLikeElem_of_coact_eq_tmul`: the weight of a nonzero weight vector is
+  group-like.
+* `TauCeti.Comodule.exists_isGroupLikeElem_coact_eq_tmul_of_toSubmodule_eq_span`: a subcomodule
+  spanned by a single nonzero vector exhibits it as a weight vector.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, §§2.4 and 6.3.
+
+This is a Layer 5 ingredient of the ReductiveGroups roadmap, for the "Lie--Kolchin; solvable
+groups" milestone.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.Comodule
+
+universe u v w
+
+noncomputable section
+
+variable {k : Type u} {C : Type v} {M : Type w}
+variable [Field k] [AddCommMonoid C] [Module k C] [Coalgebra k C]
+variable [AddCommGroup M] [Module k M] [Comodule k C M]
+
+/-- A comodule has a nonzero weight vector if some nonzero `v` has coaction `v ⊗ c` for a
+group-like `c`.
+
+For the comodule corresponding to a group representation, this says that the represented group
+acts on the line spanned by `v` through the character `c`. -/
+def HasNonzeroWeightVector (k : Type u) (C : Type v) (M : Type w)
+    [Field k] [AddCommMonoid C] [Module k C] [Coalgebra k C]
+    [AddCommGroup M] [Module k M] [Comodule k C M] : Prop :=
+  ∃ (v : M) (c : C), v ≠ 0 ∧ IsGroupLikeElem k c ∧
+    coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c
+
+/-- The defining characterization of a nonzero weight vector. -/
+@[simp]
+theorem hasNonzeroWeightVector_iff :
+    HasNonzeroWeightVector k C M ↔
+      ∃ (v : M) (c : C), v ≠ 0 ∧ IsGroupLikeElem k c ∧
+        coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c :=
+  Iff.rfl
+
+/-- The weight of a nonzero weight vector is a group-like element. -/
+theorem isGroupLikeElem_of_coact_eq_tmul {v : M} (hv : v ≠ 0) {c : C}
+    (h : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c) :
+    IsGroupLikeElem k c := by
+  obtain ⟨phi, hphi⟩ := Module.Projective.exists_dual_eq_one k hv
+  constructor
+  · have hcounit := lTensor_counit_coact (R := k) (C := C) v
+    rw [h] at hcounit
+    have := congrArg (TensorProduct.rid k M) hcounit
+    simp only [LinearMap.lTensor_tmul, TensorProduct.rid_tmul, one_smul] at this
+    -- `this : Coalgebra.counit c • v = v`; test it against a functional taking `v` to `1`.
+    have hphi' := congrArg phi this
+    simpa [hphi] using hphi'
+  · have hassoc := coassoc_apply (R := k) (C := C) v
+    rw [h] at hassoc
+    simp only [LinearMap.rTensor_tmul, h, TensorProduct.assoc_tmul,
+      LinearMap.lTensor_tmul] at hassoc
+    have hphi' := congrArg
+      (fun z ↦ TensorProduct.lid k (C ⊗[k] C)
+        (TensorProduct.map phi (LinearMap.id : C ⊗[k] C →ₗ[k] C ⊗[k] C) z)) hassoc
+    simpa [hphi] using hphi'.symm
+
+/-- Every vector of a line spanned by a weight vector is a weight vector of the same weight. -/
+theorem coact_eq_tmul_of_mem_span {v : M} {c : C}
+    (h : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c) {x : M} (hx : x ∈ k ∙ v) :
+    coact (R := k) (C := C) (M := M) x = x ⊗ₜ[k] c := by
+  obtain ⟨a, rfl⟩ := Submodule.mem_span_singleton.mp hx
+  rw [map_smul, h, TensorProduct.smul_tmul']
+
+/-- A vector whose coaction lies in the tensor product of the line it spans with the coalgebra is
+a weight vector, and its weight is group-like. -/
+theorem exists_isGroupLikeElem_coact_eq_tmul_of_mem_range {v : M} (hv : v ≠ 0)
+    (h : coact (R := k) (C := C) (M := M) v ∈
+      LinearMap.range (TensorProduct.map (k ∙ v).subtype (LinearMap.id : C →ₗ[k] C))) :
+    ∃ c : C, IsGroupLikeElem k c ∧ coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c := by
+  obtain ⟨phi, hphi⟩ := Module.Projective.exists_dual_eq_one k hv
+  obtain ⟨z, hz⟩ := h
+  set contract : (↥(k ∙ v)) ⊗[k] C →ₗ[k] C :=
+    (TensorProduct.lid k C).toLinearMap ∘ₗ
+      TensorProduct.map (phi ∘ₗ (k ∙ v).subtype) (LinearMap.id : C →ₗ[k] C) with hcontract
+  have key : ∀ w : (↥(k ∙ v)) ⊗[k] C,
+      TensorProduct.map (k ∙ v).subtype (LinearMap.id : C →ₗ[k] C) w = v ⊗ₜ[k] contract w := by
+    intro w
+    induction w with
+    | zero => simp
+    | tmul x c =>
+        have hx : (x : M) = phi (x : M) • v := by
+          obtain ⟨a, ha⟩ := Submodule.mem_span_singleton.mp x.2
+          rw [← ha]
+          simp [hphi]
+        simp only [hcontract, TensorProduct.map_tmul, LinearMap.id_coe, id_eq,
+          LinearMap.coe_comp, Function.comp_apply, Submodule.coe_subtype,
+          LinearEquiv.coe_coe, TensorProduct.lid_tmul]
+        conv_lhs => rw [hx]
+        exact TensorProduct.smul_tmul _ _ _
+    | add x y hx hy => simp [hx, hy, TensorProduct.tmul_add]
+  refine ⟨contract z, ?_, ?_⟩
+  · exact isGroupLikeElem_of_coact_eq_tmul hv (hz ▸ key z)
+  · exact hz ▸ key z
+
+/-- A subcomodule spanned by a single nonzero vector exhibits that vector as a weight vector. -/
+theorem exists_isGroupLikeElem_coact_eq_tmul_of_toSubmodule_eq_span
+    (N : Subcomodule k C M) {v : M} (hv : v ≠ 0) (hN : N.toSubmodule = k ∙ v) :
+    ∃ c : C, IsGroupLikeElem k c ∧ coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c := by
+  refine exists_isGroupLikeElem_coact_eq_tmul_of_mem_range hv ?_
+  have hmem : v ∈ N := by
+    rw [← Subcomodule.mem_toSubmodule, hN]
+    exact Submodule.mem_span_singleton_self v
+  have := N.coact_mem hmem
+  rwa [← N.toSubmodule_carrier, hN] at this
+
+/-- A subcomodule spanned by a single nonzero vector makes the ambient comodule have a nonzero
+weight vector. -/
+theorem hasNonzeroWeightVector_of_toSubmodule_eq_span
+    (N : Subcomodule k C M) {v : M} (hv : v ≠ 0) (hN : N.toSubmodule = k ∙ v) :
+    HasNonzeroWeightVector k C M := by
+  obtain ⟨c, hc, hcoact⟩ :=
+    exists_isGroupLikeElem_coact_eq_tmul_of_toSubmodule_eq_span N hv hN
+  exact ⟨v, c, hv, hc, hcoact⟩
+
+end
+
+end TauCeti.Comodule

--- a/TauCeti/Algebra/Coalgebra/Comodule/WeightVector.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/WeightVector.lean
@@ -14,14 +14,15 @@ public import TauCeti.Algebra.Coalgebra.Subcomodule.Basic
 
 A **weight vector** of a comodule `M` over a coalgebra `C` is a vector `v` whose coaction is
 `v ↦ v ⊗ c` for a single element `c` of `C`; equivalently, the line it spans is a subcomodule.
-For the representation attached to `M`, this says exactly that every point of the represented
-affine group scales `v`, by the value it takes on `c`.
+When `C` is the coordinate Hopf algebra of an affine group, this says that every point of the
+group scales `v`, by the value it takes on `c`.
 
 The weight of a nonzero weight vector is automatically group-like: the counit law forces
 `ε c = 1` and coassociativity forces `Δ c = c ⊗ c`, because a nonzero vector of a vector space is
 detected by a linear functional. So a one-dimensional subcomodule of a comodule over a field is
-the same thing as a character of the represented group, and there is no need to carry
-group-likeness as a hypothesis.
+specified by a group-like element. When `C` is the coordinate Hopf algebra of an affine group,
+that group-like element is a character, so there is no need to carry group-likeness as a
+hypothesis.
 
 Weight vectors are the eigenvector form of the fixed vectors of
 `TauCeti.Algebra.Coalgebra.Comodule.Fixed`: a fixed vector is a weight vector of weight `1`. They
@@ -34,6 +35,7 @@ are unavailable, and the flag induction of
 * `TauCeti.Comodule.HasNonzeroWeightVector`: a comodule contains a nonzero weight vector.
 * `TauCeti.Comodule.isGroupLikeElem_of_coact_eq_tmul`: the weight of a nonzero weight vector is
   group-like.
+* `TauCeti.Comodule.eq_of_coact_eq_tmul`: the weight of a nonzero weight vector is unique.
 * `TauCeti.Comodule.exists_isGroupLikeElem_coact_eq_tmul_of_toSubmodule_eq_span`: a subcomodule
   spanned by a single nonzero vector exhibits it as a weight vector.
 
@@ -63,8 +65,8 @@ variable [AddCommGroup M] [Module k M] [Comodule k C M]
 /-- A comodule has a nonzero weight vector if some nonzero `v` has coaction `v ⊗ c` for a
 group-like `c`.
 
-For the comodule corresponding to a group representation, this says that the represented group
-acts on the line spanned by `v` through the character `c`. -/
+When `C` is the coordinate Hopf algebra of an affine group, this says that the group acts on the
+line spanned by `v` through the character corresponding to `c`. -/
 def HasNonzeroWeightVector (k : Type u) (C : Type v) (M : Type w)
     [Field k] [AddCommMonoid C] [Module k C] [Coalgebra k C]
     [AddCommGroup M] [Module k M] [Comodule k C M] : Prop :=
@@ -100,6 +102,17 @@ theorem isGroupLikeElem_of_coact_eq_tmul {v : M} (hv : v ≠ 0) {c : C}
       (fun z ↦ TensorProduct.lid k (C ⊗[k] C)
         (TensorProduct.map phi (LinearMap.id : C ⊗[k] C →ₗ[k] C ⊗[k] C) z)) hassoc
     simpa [hphi] using hphi'.symm
+
+/-- The weight of a nonzero weight vector is unique. -/
+theorem eq_of_coact_eq_tmul {v : M} (hv : v ≠ 0) {c d : C}
+    (hc : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] c)
+    (hd : coact (R := k) (C := C) (M := M) v = v ⊗ₜ[k] d) : c = d := by
+  obtain ⟨phi, hphi⟩ := Module.Projective.exists_dual_eq_one k hv
+  have h := hc.symm.trans hd
+  have hphi' := congrArg
+    (fun z ↦ TensorProduct.lid k C
+      (TensorProduct.map phi (LinearMap.id : C →ₗ[k] C) z)) h
+  simpa [hphi] using hphi'
 
 /-- Every vector of a line spanned by a weight vector is a weight vector of the same weight. -/
 theorem coact_eq_tmul_of_mem_span {v : M} {c : C}


### PR DESCRIPTION
This PR trigonalizes the finite-dimensional representations of a commutative affine group: for a reduced finite-type cocommutative Hopf algebra `H` over an algebraically closed field, every finite-dimensional `H`-comodule has a basis whose coefficient matrix is upper triangular with group-like diagonal entries (`TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperTriangular_of_isCocomm`). The roadmap target is the Layer 5 milestone "Lie--Kolchin; solvable groups" of `ReductiveGroups/README.md`, whose induction on derived length reduces a connected solvable group to the commutative quotient by its derived subgroup; this PR closes that base case. What remains for the milestone is the induction step — the weight spaces of the derived subgroup are permuted by the ambient group, and connectedness makes that permutation trivial — which is exactly where geometric connectedness enters and is not attempted here.

The mathematics runs as follows. A joint eigenvector of the pairwise-commuting point operators exists over an algebraically closed field, and it spans a line stable under every geometric point; reduced finite-type point separation (`TauCeti.Subcomodule.ofEndOfPointStable`) promotes that line to a subcomodule, and the weight of a one-dimensional subcomodule is automatically group-like — the counit law forces `ε c = 1` and coassociativity forces `Δ c = c ⊗ c`, both read off after testing against a linear functional. Cocommutativity of `H` makes the convolution group of points commutative, so the commuting hypothesis holds for every comodule at once and the flag induction applies to successive quotients.

The flag machinery is generalized rather than duplicated. `Comodule.coefficientMatrix_isUpperTriangular_and_diag_iff` replaces the old unitriangular criterion by an upper-triangular criterion with prescribed diagonal, `Comodule.coefficientMatrix_extensionBasis_isUpperTriangular` factors the triangular half out of the extension theorem, and the new induction `Comodule.exists_basis_coefficientMatrix_isUpperTriangular_diag_mem_of_weight_vectors` confines the weights to an arbitrary set `S`. The existing Kolchin induction `exists_basis_coefficientMatrix_isUpperUnitriangular_of_fixed_vectors` is now derived from it at `S = {1}`, so `Flag/Induction.lean` loses its private `fixedSpan` construction and its copy of the dimension induction; its statement, and every downstream use in `Unipotent/Embedding.lean`, is unchanged.

Files added: `TauCeti/Algebra/Coalgebra/Comodule/WeightVector.lean` (164 lines), `TauCeti/Algebra/Coalgebra/Comodule/Flag/Triangular.lean` (178 lines), `TauCeti/Algebra/AlgebraicGroup/Solvable/Trigonalizable.lean` (126 lines). Files changed: `Flag/Basic.lean`, `Flag/Extension.lean`, `Flag/Induction.lean` (net −51 lines). No Mathlib infrastructure is vendored; the joint-eigenvector input is Tau Ceti's existing `exists_unitHom_submodule_finrank_eq_one_of_pairwise_commute_of_isAlgClosed`, and the mathematical organization follows Springer, *Linear Algebraic Groups*, Theorem 6.3.1, and Borel, *Linear Algebraic Groups*, §10.5, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"commutative-affine-group-trigonalizable"}-->

🤖 Prepared with Claude Code
