### PR TITLE
feat: the composite diagonal element of the Gamma0(N) Hecke ring

### DIFF
--- a/TauCeti/Data/Nat/Factorization/PrimePowerProd.lean
+++ b/TauCeti/Data/Nat/Factorization/PrimePowerProd.lean
@@ -43,7 +43,8 @@ previous paragraph can use it. Only the `Finsupp.prod` comparison needs the full
 ## Main results
 
 * `TauCeti.Nat.primePowerProd_of_one_lt`: the peeling step, as a rewriting rule.
-* `TauCeti.Nat.primePowerProd_prime_pow`: on a prime power the product is a single block.
+* `TauCeti.Nat.primePowerProd_prime_pow`: on a prime power the product is a single block;
+  `TauCeti.Nat.primePowerProd_prime` is the same at a bare prime.
 * `Commute.primePowerProd_right`: an element commuting with every block commutes with the
   ordered product.
 * `TauCeti.Nat.primePowerProd_mul_of_coprime`: multiplicativity on coprime arguments, given
@@ -160,6 +161,14 @@ theorem primePowerProd_prime_pow (f : ℕ → ℕ → M) {p : ℕ} (hp : p.Prime
     primePowerProd f (p ^ v) = f p v := by
   simpa [hp.pow_minFac hv, hp.factorization_self, Nat.div_self (pow_pos hp.pos v)]
     using primePowerProd_of_one_lt f (Nat.one_lt_pow hv hp.one_lt)
+
+/-- At a prime the product is the single block `f p 1`: the case `v = 1` of
+`primePowerProd_prime_pow`, stated separately because a bare prime is not syntactically a
+power, so that lemma cannot fire on it. -/
+@[simp]
+theorem primePowerProd_prime (f : ℕ → ℕ → M) {p : ℕ} (hp : p.Prime) :
+    primePowerProd f p = f p 1 := by
+  simpa using primePowerProd_prime_pow f hp one_ne_zero
 
 end MulOneClass
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Composite.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Composite.lean
@@ -19,8 +19,9 @@ assembled over a prime factorisation is [not] proved here". This file assembles 
 the primes of `n`, least prime first. The assembly is `TauCeti.Nat.primePowerProd` rather than
 `n.factorization.prod`: a `Finsupp.prod` needs a `CommMonoid` instance, and the Hecke ring
 `𝕋 (Δ₀(N)) (Γ₀(N)) ℤ` carries only a `Ring` one — its commutativity is a theorem about the
-Atkin–Lehner anti-involution, not a structure field. The ordered product asks for a `Monoid`
-and so is available now.
+Atkin–Lehner anti-involution, not a structure field. The ordered product asks only for a
+`MulOneClass` — weaker still than a `Monoid`, since its bracketing is fixed and associativity
+never enters — and so is available now.
 
 The block map is `heckeTGeneratorRecGamma0 N` applied directly, with no primality guard. That
 is exactly what `Diagonal/PrimePower.lean` bought by dropping `Nat.Prime p` from the recurrence:
@@ -128,7 +129,10 @@ theorem heckeTCompositeGamma0_prime_pow {p : ℕ} (hp : p.Prime) (v : ℕ) :
   · simp
   · exact TauCeti.Nat.primePowerProd_prime_pow _ hp hv
 
-/-- At a prime the composite is the generator: `T_p` assembled is `T_p`. -/
+/-- At a prime the composite is the generator: `T_p` assembled is `T_p`. Marked `@[simp]`
+alongside `heckeTCompositeGamma0_prime_pow`, which cannot fire here: a bare prime is not
+syntactically a power, so without this lemma a prime input does not reduce to the generator. -/
+@[simp]
 theorem heckeTCompositeGamma0_prime {p : ℕ} (hp : p.Prime) :
     heckeTCompositeGamma0 N p = heckeTGeneratorGamma0 N p := by
   simpa using heckeTCompositeGamma0_prime_pow N hp 1

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Composite.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Composite.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Data.Nat.Factorization.PrimePowerProd
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimePower
+
+/-!
+# The composite diagonal element of the `Γ₀(N)` Hecke ring
+
+`Diagonal/PrimePower.lean` builds the generator `T_p` and the family `T_{p^r}` that the
+Diamond–Shurman recurrence produces, and closes by naming its own gap: "the composite element
+assembled over a prime factorisation is [not] proved here". This file assembles it.
+
+`heckeTCompositeGamma0 N n` multiplies the blocks `heckeTGeneratorRecGamma0 N p (v_p n)` over
+the primes of `n`, least prime first. The assembly is `TauCeti.Nat.primePowerProd` rather than
+`n.factorization.prod`: a `Finsupp.prod` needs a `CommMonoid` instance, and the Hecke ring
+`𝕋 (Δ₀(N)) (Γ₀(N)) ℤ` carries only a `Ring` one — its commutativity is a theorem about the
+Atkin–Lehner anti-involution, not a structure field. The ordered product asks for a `Monoid`
+and so is available now.
+
+The block map is `heckeTGeneratorRecGamma0 N` applied directly, with no primality guard. That
+is exactly what `Diagonal/PrimePower.lean` bought by dropping `Nat.Prime p` from the recurrence:
+the family is total in `p`, so it *is* a block map, and the composite needs no `dite` over
+primality and no junk branch to reason around. The primality of `n.minFac` still does all the
+mathematical work — it is what `heckeTCompositeGamma0_prime_pow` runs on — but it enters as a
+hypothesis of the lemmas rather than as a guard inside the definition.
+
+## What is not here
+
+Coprime multiplicativity `T_{mn} = T_m · T_n` and the per-prime product formula both need the
+Hecke ring of `Γ₀(N)` to be commutative — `TauCeti.Nat.primePowerProd_mul_of_coprime` is stated
+for a `CommMonoid`, and the Chebyshev manipulation behind the product formula for a `CommRing`.
+That commutativity is not on `main` yet, so neither result is stated here. Nothing below is
+blocked by its absence, and `heckeTCompositeGamma0_def` is the hook the multiplicative half
+will instantiate through.
+
+## Main definitions
+
+* `HeckeRing.GL2.heckeTCompositeGamma0`: the composite element assembled over the prime
+  factorisation of `n`.
+
+## Main results
+
+* `HeckeRing.GL2.heckeTCompositeGamma0_prime_pow`: on a prime power the composite is the
+  recurrence family, with no positivity hypothesis.
+* `HeckeRing.GL2.heckeTCompositeGamma0_of_one_lt`: the peeling step, as a rewriting rule.
+* `HeckeRing.GL2.heckeTCompositeGamma0_prime_pow_of_not_coprime`: at a prime sharing a factor
+  with the level the composite degenerates to a power of the generator.
+
+## References
+
+* Diamond–Shurman, *A first course in modular forms*, §5.3 — the multiplicative assembly
+  `T_n = ∏_p T_{p^{v_p(n)}}` this file transcribes to the ring.
+* Ported from [AINTLIB](https://github.com/CBirkbeck/AINTLIB) commit
+  `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck,
+  `projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Unified/Gamma0RingDn.lean`,
+  declarations `heckeRingDn`, `heckeRingDn_ppow` and `heckeRingDn_peel`. The source guards its
+  block map with `if hp : Nat.Prime p then … else 1` because its prime-power family demands a
+  primality proof; this file's does not, so the guard is dropped and
+  `heckeTCompositeGamma0_prime_pow` loses the source's `0 < v` hypothesis with it. The source's
+  peeling combinator `peelProd` is generalised out of the Hecke namespace into
+  `TauCeti.Nat.primePowerProd`, where it belongs — it is combinatorics about `Nat.minFac`, with
+  no Hecke content.
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup HeckeRing.GLn CongruenceSubgroup
+
+open scoped MatrixGroups HeckeCosetModule
+
+namespace HeckeRing.GL2
+
+variable (N : ℕ) [NeZero N]
+
+/-- The composite element of the `Γ₀(N)` Hecke ring attached to `n`: the product of the
+prime-power blocks `heckeTGeneratorRecGamma0 N p (n.factorization p)` over the primes `p ∣ n`,
+taken least prime first. At a prime `p` this is the generator `T_p`, at a prime power `p ^ v`
+the `v`-th term of the Diamond–Shurman recurrence, and at `1` — as at the junk input `0` — the
+identity.
+
+The ordering is an artefact of the weakened typeclass, not of the mathematics: once the Hecke
+ring is known to be commutative the factors commute and the product is
+`n.factorization.prod (heckeTGeneratorRecGamma0 N)` by
+`TauCeti.Nat.primePowerProd_eq_factorization_prod`. -/
+noncomputable def heckeTCompositeGamma0 (n : ℕ) : 𝕋 (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ℤ :=
+  TauCeti.Nat.primePowerProd (heckeTGeneratorRecGamma0 N) n
+
+/-- **The defining equation of the composite**: it *is* the ordered product of the recurrence
+family over the factorisation. The body is sealed, so without this the
+`TauCeti.Nat.primePowerProd` API — in particular the multiplicativity that arrives with
+commutativity — is unreachable for it. -/
+theorem heckeTCompositeGamma0_def (n : ℕ) :
+    heckeTCompositeGamma0 N n = TauCeti.Nat.primePowerProd (heckeTGeneratorRecGamma0 N) n := (rfl)
+
+/-- The junk input: `0` has no factorisation, and the empty product is the identity. -/
+@[simp]
+theorem heckeTCompositeGamma0_zero : heckeTCompositeGamma0 N 0 = 1 :=
+  TauCeti.Nat.primePowerProd_zero _
+
+/-- `T₁ = 1`: the empty product over the empty factorisation. -/
+@[simp]
+theorem heckeTCompositeGamma0_one : heckeTCompositeGamma0 N 1 = 1 :=
+  TauCeti.Nat.primePowerProd_one _
+
+/-- **The peeling step**: for `1 < n` the composite splits off the block at the least prime
+factor of `n`, carrying its whole multiplicity. -/
+theorem heckeTCompositeGamma0_of_one_lt {n : ℕ} (hn : 1 < n) : heckeTCompositeGamma0 N n =
+    heckeTGeneratorRecGamma0 N n.minFac (n.factorization n.minFac) *
+      heckeTCompositeGamma0 N (n / n.minFac ^ n.factorization n.minFac) :=
+  TauCeti.Nat.primePowerProd_of_one_lt _ hn
+
+/-- **On a prime power the composite is the recurrence family**: `T_{p^v}` assembled is
+`T_{p^v}` generated.
+
+No positivity is asked of `v`, unlike the general `TauCeti.Nat.primePowerProd_prime_pow`: at
+`v = 0` both sides are the identity, the left by `heckeTCompositeGamma0_one` and the right by
+`heckeTGeneratorRecGamma0_zero`. That the two junk conventions agree is what lets every
+consumer below drop the hypothesis. -/
+@[simp]
+theorem heckeTCompositeGamma0_prime_pow {p : ℕ} (hp : p.Prime) (v : ℕ) :
+    heckeTCompositeGamma0 N (p ^ v) = heckeTGeneratorRecGamma0 N p v := by
+  rcases eq_or_ne v 0 with rfl | hv
+  · simp
+  · exact TauCeti.Nat.primePowerProd_prime_pow _ hp hv
+
+/-- At a prime the composite is the generator: `T_p` assembled is `T_p`. -/
+theorem heckeTCompositeGamma0_prime {p : ℕ} (hp : p.Prime) :
+    heckeTCompositeGamma0 N p = heckeTGeneratorGamma0 N p := by
+  simpa using heckeTCompositeGamma0_prime_pow N hp 1
+
+/-- When `p` shares a factor with the level the scalar term of the recurrence vanishes and the
+composite degenerates to a power of the generator: `T_{p^v} = T_p^v`. This is the bad-prime
+half of the classical statement, and it is unconditional in `v`. -/
+theorem heckeTCompositeGamma0_prime_pow_of_not_coprime {p : ℕ} (hp : p.Prime)
+    (hpN : ¬Nat.Coprime p N) (v : ℕ) :
+    heckeTCompositeGamma0 N (p ^ v) = heckeTGeneratorGamma0 N p ^ v := by
+  rw [heckeTCompositeGamma0_prime_pow N hp v,
+    heckeTGeneratorRecGamma0_eq_generator_pow_of_not_coprime N hpN]
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Composite.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Composite.lean
@@ -101,20 +101,23 @@ theorem heckeTCompositeGamma0_def (n : ℕ) :
 
 /-- The junk input: `0` has no factorisation, and the empty product is the identity. -/
 @[simp]
-theorem heckeTCompositeGamma0_zero : heckeTCompositeGamma0 N 0 = 1 :=
-  TauCeti.Nat.primePowerProd_zero _
+theorem heckeTCompositeGamma0_zero : heckeTCompositeGamma0 N 0 = 1 := by
+  simpa only [heckeTCompositeGamma0_def] using
+    TauCeti.Nat.primePowerProd_zero (heckeTGeneratorRecGamma0 N)
 
 /-- `T₁ = 1`: the empty product over the empty factorisation. -/
 @[simp]
-theorem heckeTCompositeGamma0_one : heckeTCompositeGamma0 N 1 = 1 :=
-  TauCeti.Nat.primePowerProd_one _
+theorem heckeTCompositeGamma0_one : heckeTCompositeGamma0 N 1 = 1 := by
+  simpa only [heckeTCompositeGamma0_def] using
+    TauCeti.Nat.primePowerProd_one (heckeTGeneratorRecGamma0 N)
 
 /-- **The peeling step**: for `1 < n` the composite splits off the block at the least prime
 factor of `n`, carrying its whole multiplicity. -/
 theorem heckeTCompositeGamma0_of_one_lt {n : ℕ} (hn : 1 < n) : heckeTCompositeGamma0 N n =
     heckeTGeneratorRecGamma0 N n.minFac (n.factorization n.minFac) *
-      heckeTCompositeGamma0 N (n / n.minFac ^ n.factorization n.minFac) :=
-  TauCeti.Nat.primePowerProd_of_one_lt _ hn
+      heckeTCompositeGamma0 N (n / n.minFac ^ n.factorization n.minFac) := by
+  simpa only [heckeTCompositeGamma0_def] using
+    TauCeti.Nat.primePowerProd_of_one_lt (heckeTGeneratorRecGamma0 N) hn
 
 /-- **On a prime power the composite is the recurrence family**: `T_{p^v}` assembled is
 `T_{p^v}` generated.
@@ -128,7 +131,8 @@ theorem heckeTCompositeGamma0_prime_pow {p : ℕ} (hp : p.Prime) (v : ℕ) :
     heckeTCompositeGamma0 N (p ^ v) = heckeTGeneratorRecGamma0 N p v := by
   rcases eq_or_ne v 0 with rfl | hv
   · simp
-  · exact TauCeti.Nat.primePowerProd_prime_pow _ hp hv
+  · simpa only [heckeTCompositeGamma0_def] using
+      TauCeti.Nat.primePowerProd_prime_pow (heckeTGeneratorRecGamma0 N) hp hv
 
 /-- At a prime the composite is the generator: `T_p` assembled is `T_p`. This is
 `TauCeti.Nat.primePowerProd_prime` read through the definition. Marked `@[simp]` alongside

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Composite.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Composite.lean
@@ -19,9 +19,9 @@ assembled over a prime factorisation is [not] proved here". This file assembles 
 the primes of `n`, least prime first. The assembly is `TauCeti.Nat.primePowerProd` rather than
 `n.factorization.prod`: a `Finsupp.prod` needs a `CommMonoid` instance, and the Hecke ring
 `𝕋 (Δ₀(N)) (Γ₀(N)) ℤ` carries only a `Ring` one — its commutativity is a theorem about the
-Atkin–Lehner anti-involution, not a structure field. The ordered product asks only for a
-`MulOneClass` — weaker still than a `Monoid`, since its bracketing is fixed and associativity
-never enters — and so is available now.
+Atkin–Lehner anti-involution, not a structure field. The ordered product asks only for `One`
+and `Mul` — its bracketing is fixed, so neither associativity nor a unit law enters — and so is
+available now.
 
 The block map is `heckeTGeneratorRecGamma0 N` applied directly, with no primality guard. That
 is exactly what `Diagonal/PrimePower.lean` bought by dropping `Nat.Prime p` from the recurrence:
@@ -33,11 +33,12 @@ hypothesis of the lemmas rather than as a guard inside the definition.
 ## What is not here
 
 Coprime multiplicativity `T_{mn} = T_m · T_n` and the per-prime product formula both need the
-Hecke ring of `Γ₀(N)` to be commutative — `TauCeti.Nat.primePowerProd_mul_of_coprime` is stated
-for a `CommMonoid`, and the Chebyshev manipulation behind the product formula for a `CommRing`.
-That commutativity is not on `main` yet, so neither result is stated here. Nothing below is
-blocked by its absence, and `heckeTCompositeGamma0_def` is the hook the multiplicative half
-will instantiate through.
+blocks of the `Γ₀(N)` Hecke ring to commute — `TauCeti.Nat.primePowerProd_mul_of_coprime` is
+stated in a `Monoid`, but under the hypothesis that each block of `n` commutes with the blocks
+of `m` at larger primes, and the Chebyshev manipulation behind the product formula needs a
+`CommRing`. That commutativity is not on `main` yet, so neither result is stated here. Nothing
+below is blocked by its absence, and `heckeTCompositeGamma0_def` is the hook the multiplicative
+half will instantiate through.
 
 ## Main definitions
 
@@ -129,13 +130,15 @@ theorem heckeTCompositeGamma0_prime_pow {p : ℕ} (hp : p.Prime) (v : ℕ) :
   · simp
   · exact TauCeti.Nat.primePowerProd_prime_pow _ hp hv
 
-/-- At a prime the composite is the generator: `T_p` assembled is `T_p`. Marked `@[simp]`
-alongside `heckeTCompositeGamma0_prime_pow`, which cannot fire here: a bare prime is not
-syntactically a power, so without this lemma a prime input does not reduce to the generator. -/
+/-- At a prime the composite is the generator: `T_p` assembled is `T_p`. This is
+`TauCeti.Nat.primePowerProd_prime` read through the definition. Marked `@[simp]` alongside
+`heckeTCompositeGamma0_prime_pow`, which cannot fire here: a bare prime is not syntactically a
+power, so without this lemma a prime input does not reduce to the generator. -/
 @[simp]
 theorem heckeTCompositeGamma0_prime {p : ℕ} (hp : p.Prime) :
     heckeTCompositeGamma0 N p = heckeTGeneratorGamma0 N p := by
-  simpa using heckeTCompositeGamma0_prime_pow N hp 1
+  rw [heckeTCompositeGamma0_def, TauCeti.Nat.primePowerProd_prime _ hp,
+    heckeTGeneratorRecGamma0_one]
 
 /-- When `p` shares a factor with the level the scalar term of the recurrence vanishes and the
 composite degenerates to a power of the generator: `T_{p^v} = T_p^v`. This is the bad-prime


### PR DESCRIPTION
> **Rebased onto `main` after #4496 merged (2026-08-26 03:10Z).** The diff is now this PR's own file, `TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/Composite.lean` (152 lines), plus one lemma added to `TauCeti/Data/Nat/Factorization/PrimePowerProd.lean` at a reviewer's request (`primePowerProd_prime`, review round 2 below). It was a draft while its parent was open, under the no-PR-on-an-unmerged-parent rule, and is ready for review again.

`Diagonal/PrimePower.lean` builds the generator `T_p` and the family `T_{p^r}` the Diamond–Shurman recurrence produces, and closes by naming its own gap:

> Neither the per-prime product formula nor the composite element assembled over a prime factorisation is proved here; this file supplies the generators those need.

This assembles the composite. `heckeTCompositeGamma0 N n` multiplies the blocks `heckeTGeneratorRecGamma0 N p (v_p n)` over the primes of `n`, least prime first.

### Two design points

**The assembly is `TauCeti.Nat.primePowerProd`, not `n.factorization.prod`.** A `Finsupp.prod` needs a `CommMonoid` instance, and `𝕋 (Δ₀(N)) (Γ₀(N)) ℤ` carries only a `Ring` one — commutativity of the `Γ₀(N)` Hecke ring is a theorem about the Atkin–Lehner anti-involution, not a structure field, and it is not on `main` yet. The ordered product asks only `One` and `Mul`, so the composite is definable today.

**The block map is `heckeTGeneratorRecGamma0 N` applied directly, with no primality guard.** That is what `Diagonal/PrimePower.lean` bought by dropping `Nat.Prime p` from the recurrence: the family is total in `p`, so it *is* a block map — no `dite` over primality inside the definition and no junk branch to reason around. Primality of `n.minFac` still does the mathematical work; it enters as a hypothesis of the lemmas instead. One visible payoff: `heckeTCompositeGamma0_prime_pow` holds for **every** `v`, including `v = 0`, where the two junk conventions agree (`_one` on the left, `heckeTGeneratorRecGamma0_zero` on the right) — the AINTLIB source needs `0 < v` there.

### Contents

* `heckeTCompositeGamma0` + `_def`, `_zero`, `_one`
* `heckeTCompositeGamma0_of_one_lt` — the peeling step
* `heckeTCompositeGamma0_prime_pow` — on a prime power it is the recurrence family, unconditional in `v`
* `heckeTCompositeGamma0_prime` — at a prime it is the generator; it reads `primePowerProd_prime` through the definition
* `TauCeti.Nat.primePowerProd_prime` (in `PrimePowerProd.lean`) — at a bare prime the ordered product is the single block `f p 1`; the case `v = 1` of `primePowerProd_prime_pow`, stated separately because a bare prime is not syntactically a power
* `heckeTCompositeGamma0_prime_pow_of_not_coprime` — at a bad prime it degenerates to `T_p ^ v`

### What is deliberately not here

Coprime multiplicativity `T_{mn} = T_m · T_n`, the per-prime product formula, and the general multiplication table all need the `Γ₀(N)` Hecke ring to be commutative — `primePowerProd_mul_of_coprime` is stated in a `Monoid`, but under the hypothesis that each block of `n` commutes with the blocks of `m` at larger primes — for the Hecke blocks that is the same commutativity — and the Chebyshev manipulation needs a `CommRing`. In AINTLIB each of them opens with `letI : CommRing (𝕋 (Gamma0_pair N) ℤ) := instCommRing_Gamma0 N`, and `instCommRing_Gamma0` has no counterpart on `main` (its Atkin–Lehner prerequisite chain is still in flight). None of the results above is blocked by that absence, and `heckeTCompositeGamma0_def` is the hook the multiplicative half will instantiate through, so it ships as a separate follow-up rather than as a `sorry` here.

The source's scalar composite `heckeRingSn` is also left out: its only consumers are those blocked results, and on `main` it is plausibly redundant against `heckeTScalarGamma0` at a composite argument — that file's scalar generator, unlike AINTLIB's, is already defined at every natural number. Settling that redundancy belongs with the multiplicativity PR, not ahead of it.

### Prior art

`peelProd`, `heckeRingDn` and the `heckeT*` composite names were all measured absent from `origin/main` (control: `heckeTGeneratorGamma0` = 1 file). The eight prime-power declarations of the AINTLIB source are **not** re-ported — they are already on `main` as `Diagonal/PrimePower.lean`, generalised, and this file builds on them under their `heckeT*` names.

Ported from [AINTLIB](https://github.com/CBirkbeck/AINTLIB) commit `2baa76f742bdb4fb8ee323fabba41203bd390e08` (Apache-2.0, Chris Birkbeck), `projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Unified/Gamma0RingDn.lean`, declarations `heckeRingDn`, `heckeRingDn_ppow`, `heckeRingDn_peel` (lines 506–527).

### Gates

Re-measured at this head, after the rebase onto `main`, module-scoped (the two changed modules; `Composite.lean` has no in-repository importers and `PrimePowerProd.lean`'s only importer is `Composite.lean`).

* `lake build TauCeti.Data.Nat.Factorization.PrimePowerProd TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Composite` — exit 0, 2242 jobs, no warnings (on `main` at `193f4e076`, after the rebase); re-run for round 3 on the changed module — exit 0, 2242 jobs, no warnings; the scoped `#lint` driver, `#print axioms` (9 declarations), header audit, module-scoped `lint-style` and the scoped dot-notation scan were all re-run on the round-3 head and are clean
* environment linters, scoped: a driver importing both modules, `#lint only simpNF checkType synTaut simpComm unusedArguments defsWithUnderscore docBlame in TauCeti` — 0 errors over the 468 declarations of the imported `TauCeti` closure (which contains both modules) with 7 linters; `simpNF` is the gate for the third overlapping `@[simp]` lemma on `primePowerProd`
* scoped `#print axioms` on all 8 declarations of `Composite.lean` and on `primePowerProd_prime` — `propext`, `Classical.choice`, `Quot.sound` only
* `scripts/lint-style.sh`'s two phases, module-scoped: the header audit (`scripts/HeaderStyle.lean`) on both files — conforming; `lake exe lint-style` on both modules — exit 0, no diagnostics
* `scripts/lint-dot-notation.py --source-root <dir>` on `TauCeti/Data/Nat/Factorization` and on `TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal` — 0 total, 0 new in each (the whole-tree scan exceeds ten minutes at load average 60–70 on this box; the same scoped invocation on `TauCeti/Algebra/AlgebraicGroup/BaseChange`, a directory with grandfathered entries, reports its 2 findings, so the scoped scan does see what it scans)
* `scripts/lint-env.sh` — **NOT RUN**: its driver imports every `TauCeti` module, a full-library build; the scoped `#lint` above covers this diff's declarations and CI `pr-build` covers the rest

### Review round 1 — all four findings addressed

* **api-design**, `PrimePowerProd.lean:113` — `primePowerProd_eq_factorization_prod` no longer
  asks `n ≠ 0`. (This fix now lives on `main`: #4496 made the same change in its own round 1,
  and the rebase takes `main`'s file wholesale.) The equality does hold there (both sides are `1`: the left as the junk value,
  the right because `Nat.factorization 0 = 0` has empty support), and the old docstring already
  said so while keeping the hypothesis anyway. The `n = 0` case is now peeled off *inside* the
  strong induction rather than before it — taking it before would revert `hn` into the motive
  and change `ih`'s type. Downstream payoff, exactly as the finding predicted: with the rewrite
  now unconditional, `primePowerProd_mul_of_coprime` loses both of its zero cases and collapses
  to a single `rw` chain, since `Nat.factorization_mul_of_coprime` needs no nonvanishing either.
* **api-design**, `Composite.lean:134` — `heckeTCompositeGamma0_prime` is now `@[simp]`.
  Verified by probe that it fires (`simp [hp]` closes the characteristic equation) and that
  `heckeTCompositeGamma0_prime_pow` cannot cover the case: a bare prime is not syntactically a
  power, so it made no progress there. Its conditional-`Prime` shape matches the already-`@[simp]`
  `_prime_pow` in the same file — a control probe confirms the two behave identically.
* **documentation**, `Composite.lean:26` — `Monoid` corrected to `MulOneClass`. This was prose
  drift, not a design change: `PrimePowerProd.lean`'s own docstring and this PR body both
  already said `MulOneClass`; only the composite module's docstring had it wrong.
* **scope** — the exact roadmap file, layer and bullet are named under *Roadmap target* above,
  with the dependency path spelled out.

### Review round 2

* **api-design**, `PrimePowerProd.lean:99` — `@[simp] theorem primePowerProd_prime (f) {p} (hp : p.Prime) : primePowerProd f p = f p 1` added, derived from `primePowerProd_prime_pow` at exponent `1`, and `heckeTCompositeGamma0_prime` now reads through it — `heckeTCompositeGamma0_def`, `primePowerProd_prime`, `heckeTGeneratorRecGamma0_one` — instead of re-deriving the prime case from the prime-power one. `PrimePowerProd.lean` now carries three `@[simp]` lemmas whose left-hand sides overlap (`_prime_pow`, `_prime`, and the `CommMonoid` bridge); `simpNF` is the gate that judges that and it passes.
* **generality**, `PrimePowerProd.lean:64` — resolved on `main`: #4496 states the definition and its three equations at `One` plus `Mul` (its round-1 fix), with `MulOneClass` only for `primePowerProd_prime_pow` and now `primePowerProd_prime`.

Prose in `Composite.lean` that had drifted from `main`'s `PrimePowerProd.lean` is corrected: the ordered product asks `One` and `Mul`, not `MulOneClass`; and `primePowerProd_mul_of_coprime` is stated in a `Monoid` under a block-commutation hypothesis, not for a `CommMonoid`. The reason coprime multiplicativity is still deferred is unchanged — the Hecke blocks' commutativity is not on `main` — only its description.

### Review round 3

* **proof-quality**, `Composite.lean:113` — `heckeTCompositeGamma0_zero`, `_one`, `_of_one_lt` and the nonzero branch of `_prime_pow` no longer close by unfolding the wrapper definitionally; each is now `simpa only [heckeTCompositeGamma0_def] using` the corresponding `primePowerProd` theorem, so every consumer of the definition's body goes through `heckeTCompositeGamma0_def` — which is what that lemma is for. `heckeTCompositeGamma0_prime` already did (round 2).

### Roadmap target

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2: Hecke operators and the Hecke algebra** —
bullet **(b) The action on forms**.

That bullet states the theory of `Tₙ` for the `Γ₀(N)` Hecke ring and names its multiplication
table explicitly — `T_sum_mul_coprime`, `T_sum_ppow_recurrence` and the general `T_sum_mul` —
and the layer pins the ring this file works in as AINTLIB's `heckeRingDn : 𝕋 (Gamma0_pair N) ℤ`,
the `Γ₀(N)`-pair ring in which the diamond direction enters through the scalar cosets.

**How this advances it.** Those statements quantify over an arbitrary `n`, so each of them
presupposes that `Tₙ` exists *as an element of that ring* for every `n` — the general `T_sum_mul`
cannot even be stated until it does. `Diagonal/PrimePower.lean` supplied the prime-power blocks
`T_{p^r}`; this PR supplies the assembly `T_n = ∏_p T_{p^{v_p(n)}}` over a prime factorisation
that turns those blocks into `Tₙ` itself. It is the object the layer's multiplication table is
about, and the last piece needed before the coprime and prime-power identities can be stated —
which, as *What is deliberately not here* records, additionally wait on commutativity of the
ring.

Roadmap: ModularForms

