### PR TITLE
feat: split central simple algebras over separably closed fields

### DIFF
--- a/TauCeti/Algebra/BrauerGroup/Quaternion.lean
+++ b/TauCeti/Algebra/BrauerGroup/Quaternion.lean
@@ -113,11 +113,11 @@ example : BrauerGroup.baseChange ℝ ℂ (BrauerGroup.mk (CSA.of ℝ ℍ[ℝ])) 
   rw [BrauerGroup.baseChange_eq_one_of_isAlgClosed, MonoidHom.one_apply]
 
 /-- The same class, killed through the splitting field rather than through the triviality of
-`BrauerGroup ℂ`: `TauCeti.Algebra.isSplittingField_of_isAlgClosed` says `ℂ` splits every
+`BrauerGroup ℂ`: `TauCeti.Algebra.isSplittingField_of_isSepClosed` says `ℂ` splits every
 finite-dimensional central simple `ℝ`-algebra, and a split algebra lies in the kernel. -/
 example : BrauerGroup.mk (CSA.of ℝ ℍ[ℝ]) ∈ (BrauerGroup.baseChange ℝ ℂ).ker :=
   (BrauerGroup.mk_mem_ker_baseChange_iff_isSplittingField ℝ ℂ).2
-    (Algebra.isSplittingField_of_isAlgClosed ℝ ℍ[ℝ] ℂ)
+    (Algebra.isSplittingField_of_isSepClosed ℝ ℍ[ℝ] ℂ)
 
 /-- `ℝ` does not split `ℍ[ℝ]`: the class of `ℍ[ℝ]` is not the identity, and by
 `TauCeti.BrauerGroup.mk_eq_one_iff_isSplittingField` those two statements are the same one. -/

--- a/TauCeti/Algebra/BrauerGroup/Trivial.lean
+++ b/TauCeti/Algebra/BrauerGroup/Trivial.lean
@@ -219,13 +219,13 @@ end Opposite
 
 /-- **The Brauer group of an algebraically closed field is trivial.** Every finite-dimensional
 central simple algebra over an algebraically closed field is a matrix algebra over it
-(`TauCeti.Algebra.isSplittingField_of_isAlgClosed`, with the extension taken to be the base field
+(`TauCeti.Algebra.isSplittingField_of_isSepClosed`, with the extension taken to be the base field
 itself), so there is only one Brauer class. -/
 theorem subsingleton_brauerGroup_of_isAlgClosed [IsAlgClosed K] :
     Subsingleton (BrauerGroup.{u, v} K) :=
   ⟨fun x y ↦ Quotient.inductionOn₂ x y fun A B ↦ Quotient.sound <|
-    isBrauerEquivalent_of_isSplittingField K (Algebra.isSplittingField_of_isAlgClosed K A K)
-      (Algebra.isSplittingField_of_isAlgClosed K B K)⟩
+    isBrauerEquivalent_of_isSplittingField K (Algebra.isSplittingField_of_isSepClosed K A K)
+      (Algebra.isSplittingField_of_isSepClosed K B K)⟩
 
 /-- **The Brauer group of a finite field is trivial.** A finite division ring is a field (little
 Wedderburn), so the Wedderburn presentation of a central simple algebra over a finite field is

--- a/TauCeti/Algebra/CentralSimple/Degree.lean
+++ b/TauCeti/Algebra/CentralSimple/Degree.lean
@@ -12,18 +12,18 @@ module
 -- notation and the algebra structure on `L ⊗[K] A`) and `Mathlib.Algebra.Central.Basic`, which is
 -- why neither is imported again here.
 public import TauCeti.Algebra.CentralSimple.TensorProduct
-public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import TauCeti.Algebra.CentralSimple.SeparablyClosed
 -- Non-public: `Nat.sqrt` occurs only in the body of `TauCeti.Algebra.deg`, the dimension
 -- calculations of `Mathlib.LinearAlgebra.Dimension.Constructions` only inside proofs,
--- `AlgebraicClosure` and Mathlib's algebraically closed Wedderburn-Artin theorem likewise, and the
--- complex numbers and the real quaternions only in the worked examples at the end of the file
+-- `AlgebraicClosure` likewise, and the complex numbers and real quaternions only in the worked
+-- examples at the end of the file
 -- (`TauCeti.Algebra.Central.Quaternion` re-exports `Mathlib.Algebra.Quaternion`, hence the `ℍ[·]`
 -- notation there).
 import Mathlib.Data.Nat.Sqrt
 import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
 import Mathlib.LinearAlgebra.Complex.FiniteDimensional
-import Mathlib.RingTheory.SimpleModule.IsAlgClosed
+import TauCeti.Algebra.Central.BaseChange
 import TauCeti.Algebra.Central.Quaternion
 
 /-!
@@ -34,23 +34,19 @@ proves that, and defines the **degree** `TauCeti.Algebra.deg K A` as the square 
 `Module.finrank K A`.
 
 The proof is the base-change one, and it needs no theory of maximal subfields. Let `L / K` be a
-field extension with `L` algebraically closed. Then `L ⊗[K] A` is again simple, because `L` is a
-simple `K`-algebra and `A` is central simple
-(`TauCeti.IsSimpleRing.tensorProduct_of_isCentral_right`); it is finite-dimensional over `L` of the
-same dimension as `A` over `K` (`Module.finrank_baseChange`); so Mathlib's
-`IsSimpleRing.exists_algEquiv_matrix_of_isAlgClosed` writes it as `Matrix (Fin n) (Fin n) L`, whose
-dimension is `n ^ 2`. Only simplicity of the scalar extension is used: the sharper statement that
-`L ⊗[K] A` is central simple *over `L`* is not needed here. It is proved separately, as
-`TauCeti.Algebra.IsCentral.baseChange` in `TauCeti/Algebra/Central/BaseChange.lean`, which this file
-does not import.
+field extension with `L` separably closed. Then `L ⊗[K] A` is again central simple and is
+finite-dimensional over `L` of the same dimension as `A` over `K` (`Module.finrank_baseChange`).
+The separably closed Artin--Wedderburn theorem
+`TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_isSepClosed` writes it as
+`Matrix (Fin n) (Fin n) L`, whose dimension is `n ^ 2`.
 
 Centrality of `A` over `K` is essential rather than decorative: `ℂ` is a simple, finite-dimensional
 `ℝ`-algebra whose dimension `2` is not a perfect square. That negative control is checked at the end
 of the file, alongside the real quaternions as the positive one.
 
-The same argument says that an algebraically closed extension **splits** `A`, in `deg K A` rows and
+The same argument says that a separably closed extension **splits** `A`, in `deg K A` rows and
 columns; that is recorded as
-`TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isAlgClosed`.
+`TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isSepClosed`.
 
 ## Main results
 
@@ -60,7 +56,7 @@ columns; that is recorded as
   `TauCeti.Algebra.deg_sq : deg K A ^ 2 = Module.finrank K A`, its multiplicativity
   `TauCeti.Algebra.deg_tensorProduct` and `TauCeti.Algebra.deg_matrix`, the reading
   `TauCeti.Algebra.deg_eq_mul_deg_of_algEquiv_matrix` off a Wedderburn presentation, and the
-  splitting `TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isAlgClosed` restated with
+  splitting `TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isSepClosed` restated with
   matrix size `deg K A`.
 * `TauCeti.Algebra.finrank_tensorProduct_mulOpposite` and
   `TauCeti.Algebra.deg_tensorProduct_mulOpposite`: the dimension `(Module.finrank K A) ^ 2` and the
@@ -75,7 +71,7 @@ columns; that is recorded as
 dimension it is handed: the value is therefore pinned down for every square-dimensional algebra,
 central simple or not, and `Nat.sqrt` rounds down elsewhere. What central simplicity buys is that
 the dimension *is* a square (`TauCeti.Algebra.deg_sq`), and with it the reading of `deg K A` as the
-size of the matrix algebra `A` becomes over an algebraically closed extension. Every lemma here that
+size of the matrix algebra `A` becomes over a separably closed extension. Every lemma here that
 computes a degree is derived from `TauCeti.Algebra.deg_eq_of_finrank_eq_sq`, so a downstream proof
 need never unfold the definition. The two exceptions do not compute a degree and go through
 `Nat.sqrt` directly, because there is no square dimension to feed the characteristic property:
@@ -104,7 +100,7 @@ namespace TauCeti
 
 open scoped TensorProduct
 
-/-! ### Splitting by an algebraically closed extension -/
+/-! ### Splitting by a separably closed extension -/
 
 namespace IsSimpleRing
 
@@ -112,8 +108,8 @@ variable (K : Type*) [Field K] (L : Type*) [Field L] [Algebra K L]
   (A : Type*) [Ring A] [Algebra K A] [Algebra.IsCentral K A] [IsSimpleRing A]
   [FiniteDimensional K A]
 
-/-- **An algebraically closed extension splits a central simple algebra.** If `L / K` is a field
-extension with `L` algebraically closed and `A` is a finite-dimensional central simple `K`-algebra,
+/-- **A separably closed extension splits a central simple algebra.** If `L / K` is a field
+extension with `L` separably closed and `A` is a finite-dimensional central simple `K`-algebra,
 then `L ⊗[K] A` is a full matrix algebra over `L`, and its size `n` records the dimension of `A` as
 `Module.finrank K A = n ^ 2`.
 
@@ -125,12 +121,12 @@ product of two copies of `ℂ`; the shadow of that failure which is checked in t
 This is the private engine of the two public statements it splits into: the matrix size is a perfect
 square root of the dimension (`TauCeti.IsSimpleRing.isSquare_finrank`) and is therefore the degree,
 so the splitting is stated downstream with the size named exactly, by
-`TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isAlgClosed`, rather than existentially
+`TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isSepClosed`, rather than existentially
 quantified. -/
-private theorem exists_algEquiv_matrix_baseChange_of_isAlgClosed [IsAlgClosed L] :
+private theorem exists_algEquiv_matrix_baseChange_of_isSepClosed [IsSepClosed L] :
     ∃ (n : ℕ) (_ : NeZero n), Module.finrank K A = n ^ 2 ∧
       Nonempty (L ⊗[K] A ≃ₐ[L] Matrix (Fin n) (Fin n) L) := by
-  obtain ⟨n, hn, ⟨e⟩⟩ := _root_.IsSimpleRing.exists_algEquiv_matrix_of_isAlgClosed L (L ⊗[K] A)
+  obtain ⟨n, hn, -, ⟨e⟩⟩ := exists_algEquiv_matrix_of_isSepClosed L (L ⊗[K] A)
   refine ⟨n, hn, ?_, ⟨e⟩⟩
   calc Module.finrank K A
       = Module.finrank L (L ⊗[K] A) :=
@@ -144,7 +140,7 @@ Base change to an algebraic closure of `K` splits `A`, and a full matrix algebra
 dimension. Centrality cannot be dropped: `Module.finrank ℝ ℂ = 2`. -/
 theorem isSquare_finrank : IsSquare (Module.finrank K A) := by
   obtain ⟨n, -, hrank, -⟩ :=
-    exists_algEquiv_matrix_baseChange_of_isAlgClosed K (AlgebraicClosure K) A
+    exists_algEquiv_matrix_baseChange_of_isSepClosed K (AlgebraicClosure K) A
   exact ⟨n, by rw [hrank, sq]⟩
 
 end IsSimpleRing
@@ -157,8 +153,8 @@ variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A]
 
 /-- The **degree** of a central simple `K`-algebra `A`: the square root of `Module.finrank K A`,
 which is a perfect square by `TauCeti.IsSimpleRing.isSquare_finrank`. Equivalently, the size of the
-matrix algebra that `A` becomes over an algebraically closed extension of `K`
-(`TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isAlgClosed`).
+matrix algebra that `A` becomes over a separably closed extension of `K`
+(`TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isSepClosed`).
 
 This is defined for an arbitrary `K`-algebra. The characteristic property
 `TauCeti.Algebra.deg_eq_of_finrank_eq_sq` fixes the value whenever the dimension is a square, with
@@ -277,15 +273,15 @@ end Algebra
 
 namespace IsSimpleRing
 
-variable (K : Type*) [Field K] (L : Type*) [Field L] [Algebra K L] [IsAlgClosed L]
+variable (K : Type*) [Field K] (L : Type*) [Field L] [Algebra K L]
   (A : Type*) [Ring A] [Algebra K A] [Algebra.IsCentral K A] [IsSimpleRing A]
   [FiniteDimensional K A]
 
-/-- An algebraically closed extension `L / K` splits a finite-dimensional central simple
+/-- A separably closed extension `L / K` splits a finite-dimensional central simple
 `K`-algebra `A` into matrices of size exactly `TauCeti.Algebra.deg K A`. -/
-theorem nonempty_algEquiv_matrix_baseChange_of_isAlgClosed :
+theorem nonempty_algEquiv_matrix_baseChange_of_isSepClosed [IsSepClosed L] :
     Nonempty (L ⊗[K] A ≃ₐ[L] Matrix (Fin (Algebra.deg K A)) (Fin (Algebra.deg K A)) L) := by
-  obtain ⟨n, -, hrank, he⟩ := exists_algEquiv_matrix_baseChange_of_isAlgClosed K L A
+  obtain ⟨n, -, hrank, he⟩ := exists_algEquiv_matrix_baseChange_of_isSepClosed K L A
   rwa [Algebra.deg_eq_of_finrank_eq_sq hrank]
 
 end IsSimpleRing

--- a/TauCeti/Algebra/CentralSimple/Index.lean
+++ b/TauCeti/Algebra/CentralSimple/Index.lean
@@ -241,7 +241,7 @@ theorem isSplittingField_self_iff_index_eq_one :
 /-- Over an algebraically closed field every central simple algebra has index one. -/
 theorem index_eq_one_of_isAlgClosed [IsAlgClosed K] : index K A = 1 :=
   (isSplittingField_self_iff_index_eq_one K A).1
-    (isSplittingField_of_isAlgClosed K A K)
+    (isSplittingField_of_isSepClosed K A K)
 
 /-- Over a finite field every central simple algebra has index one. -/
 theorem index_eq_one_of_finite [Finite K] : index K A = 1 :=

--- a/TauCeti/Algebra/CentralSimple/MaximalSubfield.lean
+++ b/TauCeti/Algebra/CentralSimple/MaximalSubfield.lean
@@ -130,7 +130,7 @@ theorem exists_subalgebra_isField_finrank_eq_deg :
 /-- **A central division algebra is split by a subfield of degree `deg K D`.**
 
 This is the maximal-subfield route to a splitting field: unlike the passage to an algebraic
-closure (`TauCeti.Algebra.isSplittingField_of_isAlgClosed`), it produces a splitting field that is
+closure (`TauCeti.Algebra.isSplittingField_of_isSepClosed`), it produces a splitting field that is
 a *finite* extension of `K`, and one realized inside `D` by the accompanying homomorphism. -/
 theorem exists_isSplittingField_finrank_eq_deg :
     ∃ (L : Type u) (_ : Field L) (_ : Algebra K L) (_ : L →ₐ[K] D),

--- a/TauCeti/Algebra/CentralSimple/SeparablyClosed.lean
+++ b/TauCeti/Algebra/CentralSimple/SeparablyClosed.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- Public: the central-division-algebra form of Artin--Wedderburn is refined below, and its
+-- hypotheses occur in the exported matrix-presentation theorem.
+public import TauCeti.Algebra.CentralSimple.Wedderburn
+-- `IsSepClosed` occurs throughout the exported signatures.
+public import Mathlib.FieldTheory.IsSepClosed
+-- Non-public: Jacobson--Noether supplies a separable element outside the centre of any
+-- noncommutative finite-dimensional central division algebra.
+import Mathlib.FieldTheory.JacobsonNoether
+
+/-!
+# Central simple algebras over separably closed fields
+
+A finite-dimensional central simple algebra over a separably closed field is a full matrix
+algebra.  This strengthens the algebraically closed case used in the initial splitting-field API
+and is the field-theoretic input for refining an arbitrary finite splitting extension to a finite
+separable one.
+
+The only extra issue over the algebraically closed proof is the coefficient division algebra in
+Artin--Wedderburn.  If a finite-dimensional central division algebra `D` over a separably closed
+field `K` were larger than `K`, the Jacobson--Noether theorem would produce an element of `D`
+outside `K` that is separable over `K`.  Its irreducible minimal polynomial would have degree one,
+because `K` is separably closed, so the element would in fact lie in `K`, a contradiction.
+
+The scalar-extension and splitting consequences live in
+`TauCeti/Algebra/CentralSimple/Degree.lean` and
+`TauCeti/Algebra/CentralSimple/Splitting.lean`, where they replace the former algebraically closed
+special cases.
+
+## Main results
+
+* `TauCeti.baseFieldAlgEquivOfIsSepClosed`: a finite-dimensional central division algebra over a
+  separably closed field is the base field.
+* `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_isSepClosed`: a finite-dimensional central simple
+  algebra over a separably closed field is a full matrix algebra.
+
+## References
+
+This is the separably-closed-field prerequisite for the finite separable splitting extension in
+Layer 6, “Splitting fields, maximal subfields, and the index”, of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md).
+See N. Jacobson, *Basic Algebra II*, 2nd ed., Chapter 15, and P. Gille and T. Szamuely,
+*Central Simple Algebras and Galois Cohomology*, Section 2.2.
+-/
+
+public section
+
+namespace TauCeti
+
+open Polynomial
+
+universe u
+
+/-! ### Central division algebras over a separably closed field -/
+
+section Division
+
+variable (K : Type*) [Field K] [IsSepClosed K]
+variable (D : Type u) [DivisionRing D] [Algebra K D]
+
+/-- An element of a division algebra that is separable over a separably closed base field belongs
+to the image of that base field.
+
+The minimal polynomial is irreducible because the ambient algebra is a division ring.  It is
+separable by hypothesis, hence has degree one over a separably closed field. The degree-one
+calculation adapts Mathlib's `IsSepClosed.algebraMap_surjective` from a field extension to a single
+element of a possibly noncommutative division algebra. -/
+theorem mem_bot_of_isSeparable {x : D} (hx : IsSeparable K x) :
+    x ∈ (⊥ : Subalgebra K D) := by
+  rw [Algebra.mem_bot]
+  refine ⟨-(minpoly K x).coeff 0, ?_⟩
+  have hlead : (minpoly K x).leadingCoeff = 1 := minpoly.monic hx.isIntegral
+  have hdegree : (minpoly K x).degree = 1 :=
+    IsSepClosed.degree_eq_one_of_irreducible K (minpoly.irreducible hx.isIntegral) hx
+  have heval : aeval x (minpoly K x) = 0 := minpoly.aeval K x
+  rw [eq_X_add_C_of_degree_eq_one hdegree, hlead, C_1, one_mul, aeval_add, aeval_X,
+    aeval_C, add_eq_zero_iff_eq_neg] at heval
+  exact (map_neg (algebraMap K D) ((minpoly K x).coeff 0)).trans heval.symm
+
+variable [Algebra.IsCentral K D] [FiniteDimensional K D]
+
+/-- The structure map from a separably closed field onto a finite-dimensional central division
+algebra is surjective.
+
+If its image were proper, Jacobson--Noether would give a separable element outside it, contradicting
+`TauCeti.mem_bot_of_isSeparable`. -/
+theorem algebraMap_surjective_of_isSepClosed : Function.Surjective (algebraMap K D) := by
+  have hbot : (⊥ : Subalgebra K D) = ⊤ := by
+    by_contra hne
+    obtain ⟨x, hx, hsep⟩ := JacobsonNoether.exists_separable_and_not_isCentral' hne
+    exact hx (mem_bot_of_isSeparable K D hsep)
+  intro x
+  apply Algebra.mem_bot.mp
+  rw [hbot]
+  exact Set.mem_univ x
+
+/-- A finite-dimensional central division algebra over a separably closed field is the base field,
+as an equivalence of algebras. -/
+noncomputable def baseFieldAlgEquivOfIsSepClosed : D ≃ₐ[K] K :=
+  (AlgEquiv.ofBijective (Algebra.ofId K D)
+    ⟨RingHom.injective (algebraMap K D), algebraMap_surjective_of_isSepClosed K D⟩).symm
+
+@[simp]
+theorem baseFieldAlgEquivOfIsSepClosed_symm_apply (a : K) :
+    (baseFieldAlgEquivOfIsSepClosed K D).symm a = algebraMap K D a := by
+  rw [baseFieldAlgEquivOfIsSepClosed, AlgEquiv.symm_symm]
+  exact AlgEquiv.ofBijective_apply _ _ a
+
+@[simp]
+theorem algebraMap_baseFieldAlgEquivOfIsSepClosed (x : D) :
+    algebraMap K D (baseFieldAlgEquivOfIsSepClosed K D x) = x := by
+  rw [← baseFieldAlgEquivOfIsSepClosed_symm_apply, AlgEquiv.symm_apply_apply]
+
+/-- A finite-dimensional central division algebra over a separably closed field is
+one-dimensional over that field. -/
+@[simp]
+theorem finrank_eq_one_of_isSepClosed : Module.finrank K D = 1 := by
+  rw [(baseFieldAlgEquivOfIsSepClosed K D).toLinearEquiv.finrank_eq, Module.finrank_self]
+
+end Division
+
+/-! ### Central simple algebras -/
+
+namespace IsSimpleRing
+
+variable (K : Type*) [Field K] [IsSepClosed K]
+variable (A : Type u) [Ring A] [Algebra K A] [Algebra.IsCentral K A] [IsSimpleRing A]
+  [FiniteDimensional K A]
+
+/-- **Artin--Wedderburn over a separably closed field.** A finite-dimensional central simple
+`K`-algebra is a full matrix algebra over `K`. -/
+theorem exists_algEquiv_matrix_of_isSepClosed :
+    ∃ (n : ℕ) (_ : NeZero n), Module.finrank K A = n ^ 2 ∧
+      Nonempty (A ≃ₐ[K] Matrix (Fin n) (Fin n) K) := by
+  obtain ⟨n, hn, D, _, _, _, _, hrank, ⟨e⟩⟩ :=
+    exists_algEquiv_matrix_centralDivisionRing K A
+  refine ⟨n, hn, ?_, ⟨e.trans (AlgEquiv.mapMatrix (baseFieldAlgEquivOfIsSepClosed K D))⟩⟩
+  rw [hrank, finrank_eq_one_of_isSepClosed K D, mul_one]
+
+end IsSimpleRing
+
+end TauCeti

--- a/TauCeti/Algebra/CentralSimple/Splitting.lean
+++ b/TauCeti/Algebra/CentralSimple/Splitting.lean
@@ -6,9 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 -- `TauCeti.Algebra.CentralSimple.Degree` is imported publicly: `TauCeti.Algebra.deg` occurs in the
--- statements below, and it is the algebraically closed base change
--- `TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isAlgClosed` proved there that makes
--- an algebraically closed extension a splitting field. It also re-exports
+-- statements below, and it is the separably closed base change
+-- `TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isSepClosed` proved there that makes
+-- a separably closed extension a splitting field. It also re-exports
 -- `Mathlib.RingTheory.TensorProduct.Basic` (the `⊗[K]` notation and the algebra structure on
 -- `L ⊗[K] A`) and `Mathlib.Algebra.Central.Basic`, which is why neither is imported again here.
 public import TauCeti.Algebra.CentralSimple.Degree
@@ -30,9 +30,9 @@ import TauCeti.Algebra.Central.Quaternion
 
 A field extension `L / K` **splits** a `K`-algebra `A` when the scalar extension `L ⊗[K] A` is a
 full matrix algebra over `L`. This file defines that predicate, `TauCeti.Algebra.IsSplittingField`,
-gives it its basic API, and settles the two cases that need no field theory: an **algebraically
-closed** extension splits every finite-dimensional central simple algebra, and over a **finite**
-base field every central simple algebra is already split by the base field itself.
+gives it its basic API, and settles the two cases that need no additional field theory: a
+**separably closed** extension splits every finite-dimensional central simple algebra, and over a
+**finite** base field every central simple algebra is already split by the base field itself.
 
 The name is qualified because Mathlib's root-namespace `IsSplittingField` is the unrelated
 predicate that a field extension splits a *polynomial*.
@@ -64,7 +64,7 @@ an arbitrary `K`-algebra, where the degree is not yet meaningful.
 * `TauCeti.Algebra.finrank_eq_sq_of_algEquiv_matrix` and
   `TauCeti.Algebra.IsSplittingField.nonempty_algEquiv_matrix_deg`: the dimension count and, for a
   central simple `A`, the identification of the matrix size with the degree.
-* `TauCeti.Algebra.isSplittingField_of_isAlgClosed`: **an algebraically closed extension splits
+* `TauCeti.Algebra.isSplittingField_of_isSepClosed`: **a separably closed extension splits
   every finite-dimensional central simple algebra**.
 * `TauCeti.Algebra.isSplittingField_self_of_finite`: **over a finite field every central simple
   algebra is split by the base field**, so there is nothing to split.
@@ -91,7 +91,8 @@ be commutative), so it is left to the file that builds it.
 This implements the splitting-field half of the fourth bullet of Layer 6 ("Splitting fields,
 maximal subfields, and the index") of the
 [semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md),
-whose `Suggested.lean` pins `IsSplittingField` and `isSplittingField_of_isAlgClosed`, together with
+whose `Suggested.lean` pins `IsSplittingField`; the stronger separably closed form of its pinned
+algebraically closed splitting theorem is `isSplittingField_of_isSepClosed`, together with
 the splitting half of its "Finite base fields" bullet. See P. Gille, T. Szamuely, *Central Simple
 Algebras and Galois Cohomology*, Section 2.2, and R. S. Pierce, *Associative Algebras*, GTM 88,
 Chapter 13.
@@ -216,15 +217,16 @@ theorem isSplittingField_iff_deg :
   ⟨IsSplittingField.nonempty_algEquiv_matrix_deg K A L,
     fun h ↦ (isSplittingField_iff K A L).2 ⟨deg K A, h⟩⟩
 
-/-- **An algebraically closed extension splits every finite-dimensional central simple algebra.**
+/-- **A separably closed extension splits every finite-dimensional central simple algebra.**
 
-This is the base case of the splitting theory, and it needs no theory of maximal subfields: over an
-algebraically closed field the Wedderburn division algebra collapses, which is exactly
-`TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isAlgClosed`. Every finite-dimensional
-central simple `K`-algebra therefore has a splitting field, namely an algebraic closure of `K`. -/
-theorem isSplittingField_of_isAlgClosed [IsAlgClosed L] : IsSplittingField K A L :=
+This is the base case of the separable splitting theory, and it needs no theory of maximal
+subfields: over a separably closed field the Wedderburn division algebra collapses, which is
+exactly `TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isSepClosed`. Every
+finite-dimensional central simple `K`-algebra therefore has a separable splitting field, namely a
+separable closure of `K`. -/
+theorem isSplittingField_of_isSepClosed [IsSepClosed L] : IsSplittingField K A L :=
   (isSplittingField_iff_deg K A L).2
-    (IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isAlgClosed K L A)
+    (IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isSepClosed K L A)
 
 /-- **Over a finite field every central simple algebra is split by the base field.** A finite
 central division algebra is its own base field (little Wedderburn), so the Wedderburn presentation
@@ -247,16 +249,16 @@ section Examples
 open scoped _root_.Quaternion
 
 /-- **`ℂ` splits the real quaternions.** `ℂ` is algebraically closed, so this is
-`TauCeti.Algebra.isSplittingField_of_isAlgClosed`; all three of `Algebra.IsCentral ℝ ℍ[ℝ]`,
+`TauCeti.Algebra.isSplittingField_of_isSepClosed`; all three of `Algebra.IsCentral ℝ ℍ[ℝ]`,
 `IsSimpleRing ℍ[ℝ]` and `FiniteDimensional ℝ ℍ[ℝ]` are found by instance search. -/
-example : IsSplittingField ℝ ℍ[ℝ] ℂ := isSplittingField_of_isAlgClosed ℝ ℍ[ℝ] ℂ
+example : IsSplittingField ℝ ℍ[ℝ] ℂ := isSplittingField_of_isSepClosed ℝ ℍ[ℝ] ℂ
 
 /-- The splitting of `ℍ[ℝ]` by `ℂ` happens at the degree, so it is
 `ℂ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℂ] Matrix (Fin 2) (Fin 2) ℂ` on the nose. -/
 example : Nonempty (ℂ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℂ] Matrix (Fin 2) (Fin 2) ℂ) := by
   have hdeg : deg ℝ ℍ[ℝ] = 2 :=
     deg_eq_of_finrank_eq_sq (by rw [Quaternion.finrank_eq_four]; norm_num)
-  exact hdeg ▸ (isSplittingField_of_isAlgClosed ℝ ℍ[ℝ] ℂ).nonempty_algEquiv_matrix_deg ..
+  exact hdeg ▸ (isSplittingField_of_isSepClosed ℝ ℍ[ℝ] ℂ).nonempty_algEquiv_matrix_deg ..
 
 /-- **`ℝ` does not split the real quaternions**, so a central simple algebra need not be split by
 its own base field and the notion is not vacuous. A splitting over `ℝ` would make `ℍ[ℝ]` a matrix


### PR DESCRIPTION
This PR proves that every finite-dimensional central simple algebra over a separably closed field is a full matrix algebra, and makes every separably closed extension a splitting field for every finite-dimensional central simple algebra. It advances `TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md`, Layer 6, milestone “Splitting fields, maximal subfields, and the index”, specifically the promised refinement from a finite splitting extension to a finite separable one. After this PR, the milestone still needs descent of the splitting over a separable closure to a finite separable subextension.

The division-algebra step consumes Mathlib's Jacobson–Noether theorem: a proper finite-dimensional central division algebra contains a separable element outside the base field, while separable irreducible polynomials over a separably closed field have degree one. `baseFieldAlgEquivOfIsSepClosed` packages the resulting collapse, `IsSimpleRing.exists_algEquiv_matrix_of_isSepClosed` feeds it through Artin–Wedderburn, and the degree and splitting-field APIs carry the result through scalar extension.

This replaces the strictly weaker algebraically closed splitting declarations and updates every in-repository consumer; no compatibility aliases remain. The elementwise degree-one calculation is adapted from Mathlib's `IsSepClosed.algebraMap_surjective`, and the noncommutative input is Mathlib's `JacobsonNoether.exists_separable_and_not_isCentral'` (Mathlib is Apache-2.0 licensed).

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"is-splitting-field-of-is-sep-closed"}-->

🤖 Prepared with Codex
