### PR TITLE
feat: evaluate exit-window principal values

### DIFF
--- a/TauCeti/Analysis/Contour/Crossing/ExitWindow.lean
+++ b/TauCeti/Analysis/Contour/Crossing/ExitWindow.lean
@@ -8,6 +8,9 @@ module
 public import TauCeti.Analysis.Contour.Crossing.CapAngle
 public import TauCeti.Analysis.Contour.Crossing.FiniteExcision
 public import TauCeti.Analysis.Contour.ExitTime
+public import TauCeti.Analysis.Contour.PwC1ImmersionOn
+import TauCeti.Analysis.Contour.InvSubCPVExistence
+import TauCeti.Analysis.Contour.PerWindow.CPV
 
 /-!
 # Equal-radius cap windows at crossings
@@ -24,10 +27,11 @@ joins the original curve.  `exitCapWindows` applies the construction to the sort
 finite crossing set; crossings separated by more than twice the ambient half-width
 (`2 * δ < |t - t'|`) produce nonoverlapping, hence pairwise disjoint, cap windows.
 
-This is the geometric window construction in Proposition 2.2.  The principal-value calculation on
-the generally asymmetric exit-time interval is separate: once that value is supplied,
-`windingNumber_sub_cap_exitCapWindow_eq_crossingAngle_div_two_pi` identifies the local loop with
-its crossing angle.
+This is the window construction and local analytic calculation in Proposition 2.2.
+`exists_radius_hasCauchyPVAt_exitCapWindow` evaluates the principal value on each generally
+asymmetric exit-time interval, and
+`windingNumber_sub_cap_exitCapWindow_eq_crossingAngle_div_two_pi` then identifies the local loop
+with its crossing angle.
 
 ## Main definitions
 
@@ -41,6 +45,8 @@ its crossing angle.
   endpoints.
 * `TauCeti.Contour.pairwise_disjoint_interval_exitCapWindows` -- the finite windows are pairwise
   disjoint, in the shape `Crossing.FiniteExcision` consumes.
+* `TauCeti.Contour.exists_radius_hasCauchyPVAt_exitCapWindow` -- sufficiently small exit-time
+  windows have the boundary-argument principal value.
 * `TauCeti.Contour.windingNumber_sub_cap_exitCapWindow_eq_crossingAngle_div_two_pi` -- the exact
   local angle contribution, once the principal value on the asymmetric exit-time window is
   supplied alongside the standing continuity, tangent, and radius hypotheses.
@@ -382,6 +388,76 @@ theorem exists_common_exitCapWindows_radius {γ : ℝ → ℂ} {s : ℂ} {T : Fi
       exact (hT ⟨t, ht⟩).elim
     · intro t ht
       exact (hT ⟨t, ht⟩).elim
+
+/-- **The Cauchy principal value on an exit-time window.**  Around an interior crossing of a
+piecewise-`C¹` immersion, there is an ambient radius `R` and nonzero one-sided tangent limits such
+that every smaller ambient window containing no other crossing has the following property.  For
+each positive spatial exit radius reached on both sides, the Cauchy-kernel principal value on the
+generally asymmetric interval between the two first exits is
+
+`i * (arg (-L_L / (γ(lower) - s)) + arg ((γ(upper) - s) / L_R))`.
+
+The real logarithmic term vanishes because both exit chords have the same norm.  This is the
+analytic input that `windingNumber_sub_cap_exitCapWindow_eq_crossingAngle_div_two_pi` consumes in
+Hungerbühler--Wasem Proposition 2.2. -/
+theorem exists_radius_hasCauchyPVAt_exitCapWindow {γ : ℝ → ℂ} {s : ℂ} {a b t₀ : ℝ}
+    (h_imm : IsPwC1ImmersionOn γ a b) (hab : a < b) (ht₀ : t₀ ∈ Ioo a b)
+    (h_at : γ t₀ = s) :
+    ∃ R > 0, ∃ L_R L_L : ℂ, L_R ≠ 0 ∧ L_L ≠ 0 ∧
+      Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R) ∧ Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L) ∧
+      ∀ δ : ℝ, 0 < δ → δ ≤ R → a < t₀ - δ → t₀ + δ ≤ b →
+      (∀ t ∈ Icc (t₀ - δ) (t₀ + δ), γ t = s → t = t₀) →
+      ∀ ε : ℝ, 0 < ε → ε ≤ ‖γ (t₀ - δ) - s‖ → ε ≤ ‖γ (t₀ + δ) - s‖ →
+      HasCauchyPVAt γ (exitCapWindow γ s t₀ δ ε L_R L_L).lower
+        (exitCapWindow γ s t₀ δ ε L_R L_L).upper (fun z ↦ (z - s)⁻¹) s
+        (((((-L_L) / (γ (exitCapWindow γ s t₀ δ ε L_R L_L).lower - s)).arg +
+          ((γ (exitCapWindow γ s t₀ δ ε L_R L_L).upper - s) / L_R).arg : ℝ) : ℂ) *
+            Complex.I) := by
+  obtain ⟨R, hR, L_R, L_L, hL_R, hL_L, h_R, h_L, hspec⟩ :=
+    exists_radius_perWindow_tendsto_log_norm_add_arg h_imm hab ht₀ h_at
+  refine ⟨R, hR, L_R, L_L, hL_R, hL_L, h_R, h_L, ?_⟩
+  intro δ hδ hδR ha hb h_unique ε hε hεL hεR
+  let W := exitCapWindow γ s t₀ δ ε L_R L_L
+  have hγ : ContinuousOn γ (Icc (t₀ - δ) (t₀ + δ)) :=
+    h_imm.continuousOn.mono (by
+      rw [uIcc_of_le hab.le]
+      exact Icc_subset_Icc ha.le hb)
+  have hγL : ContinuousOn γ (Icc (t₀ - δ) t₀) :=
+    hγ.mono (Icc_subset_Icc le_rfl (by linarith))
+  have hγR : ContinuousOn γ (Icc t₀ (t₀ + δ)) :=
+    hγ.mono (Icc_subset_Icc (by linarith) le_rfl)
+  have hlt : W.lower < t₀ := exitCapWindow_lower_lt hδ hε h_at hγL hεL
+  have htu : t₀ < W.upper := lt_exitCapWindow_upper hδ hε h_at hγR hεR
+  have hlower_mem := firstExitTimeLeft_mem_Icc hδ.le hεL
+  have hupper_mem := firstExitTimeRight_mem_Icc hδ.le hεR
+  have hnormL : ‖γ W.lower - s‖ = ε :=
+    norm_sub_exitCapWindow_lower_eq hδ hε h_at hγL hεL
+  have hnormR : ‖γ W.upper - s‖ = ε :=
+    norm_sub_exitCapWindow_upper_eq hδ hε h_at hγR hεR
+  have hW_lower : t₀ - δ ≤ W.lower := by
+    dsimp [W]
+    rw [exitCapWindow_lower]
+    exact hlower_mem.1
+  have hW_upper : W.upper ≤ t₀ + δ := by
+    dsimp [W]
+    rw [exitCapWindow_upper]
+    exact hupper_mem.2
+  have htend := hspec W.lower W.upper
+    (by linarith) hlt htu (by linarith) (ha.trans_le hW_lower) (hW_upper.trans hb)
+    (fun t ht heq => h_unique t
+      ⟨hW_lower.trans ht.1, ht.2.trans hW_upper⟩ heq)
+  refine HasCauchyPVAt.intro ?_ ?_
+  · filter_upwards [self_mem_nhdsWithin] with η hη
+    exact intervalIntegrable_inv_sub_truncated
+      (h_imm.continuousOn.mono (by
+        rw [uIcc_of_le hab.le, uIcc_of_le (hlt.le.trans htu.le)]
+        exact Icc_subset_Icc (by linarith [ha, hlower_mem.1])
+          (hupper_mem.2.trans hb)))
+      (h_imm.isPiecewiseC1On.intervalIntegrable_deriv.mono_set (by
+        rw [uIcc_of_le (hlt.le.trans htu.le), uIcc_of_le hab.le]
+        exact Icc_subset_Icc (by linarith [ha, hlower_mem.1]) (hupper_mem.2.trans hb))) hη
+  · rw [hnormR, hnormL] at htend
+    simpa only [W, sub_self, Complex.ofReal_zero, zero_add] using htend
 
 /-- **The exact local angle contribution of one exit-time cap window.**  The winding number of
 the curve over the window minus that of its cap is `crossingAngle γ t₀ / 2π`.  Beyond the

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -83,8 +83,9 @@ private theorem exists_one_sided_tangents {γ : ℝ → ℂ} {a b t₀ : ℝ}
 there is a radius `R > 0` and the crossing's nonzero one-sided tangent limits `L_R`, `L_L` of
 `deriv γ` (from the right and left respectively — `hL_tend_R`, `hL_tend_L` pin them down, so a
 caller can compute with the value below rather than treat `L_R`, `L_L` as opaque), such that at
-every window radius `ρ ≤ R` whose window lies inside `[a, b]` and contains no other crossing, the
-truncated window integral of the Cauchy kernel converges to that explicit log-norm-plus-argument
+every window `[l, u] ⊆ [t₀ - R, t₀ + R]` that lies inside `[a, b]` and contains no other crossing,
+the truncated window integral of the Cauchy kernel converges to that explicit
+log-norm-plus-argument
 value (the value `perWindow_truncated_integral_tendsto` supplies), rather than to a merely
 existentially-bound limit. A consumer that only needs existence of the limit (not its value) can
 take the displayed value itself as the existential witness, so no separate existence-only wrapper
@@ -94,12 +95,12 @@ theorem exists_radius_perWindow_tendsto_log_norm_add_arg
     (h_imm : IsPwC1ImmersionOn γ a b) (hab : a < b) (ht₀ : t₀ ∈ Ioo a b) (h_at : γ t₀ = s) :
     ∃ R > 0, ∃ L_R L_L : ℂ, L_R ≠ 0 ∧ L_L ≠ 0 ∧
       Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R) ∧ Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L) ∧
-      ∀ ρ : ℝ, 0 < ρ → ρ ≤ R → a < t₀ - ρ → t₀ + ρ ≤ b →
-      (∀ t ∈ Icc (t₀ - ρ) (t₀ + ρ), γ t = s → t = t₀) →
-      Tendsto (fun ε : ℝ => ∫ u in (t₀ - ρ)..(t₀ + ρ),
-        if ‖γ u - s‖ > ε then (γ u - s)⁻¹ * deriv γ u else 0) (𝓝[>] (0 : ℝ))
-        (𝓝 (((Real.log ‖γ (t₀ + ρ) - s‖ - Real.log ‖γ (t₀ - ρ) - s‖ : ℝ) : ℂ) +
-          ((((-L_L) / (γ (t₀ - ρ) - s)).arg + ((γ (t₀ + ρ) - s) / L_R).arg : ℝ) : ℂ) *
+      ∀ l u : ℝ, t₀ - R ≤ l → l < t₀ → t₀ < u → u ≤ t₀ + R → a < l → u ≤ b →
+      (∀ t ∈ Icc l u, γ t = s → t = t₀) →
+      Tendsto (fun ε : ℝ => ∫ v in l..u,
+        if ‖γ v - s‖ > ε then (γ v - s)⁻¹ * deriv γ v else 0) (𝓝[>] (0 : ℝ))
+        (𝓝 (((Real.log ‖γ u - s‖ - Real.log ‖γ l - s‖ : ℝ) : ℂ) +
+          ((((-L_L) / (γ l - s)).arg + ((γ u - s) / L_R).arg : ℝ) : ℂ) *
             Complex.I)) := by
   obtain ⟨L_R, L_L, hL_R, hL_L, h_tend_R, h_tend_L, h_dR, h_dL⟩ :=
     exists_one_sided_tangents h_imm hab ht₀
@@ -109,8 +110,8 @@ theorem exists_radius_perWindow_tendsto_log_norm_add_arg
   have ht₀' : t₀ ∈ Ioo (min a b) (max a b) := by
     rwa [min_eq_left hab.le, max_eq_right hab.le]
   refine ⟨R, hR_pos, L_R, L_L, hL_R, hL_L, h_tend_R, h_tend_L,
-    fun ρ hρ_pos hρ_le h_lo h_hi h_unique =>
-    perWindow_truncated_integral_tendsto hρ_pos h_at
+    fun l u hRl hlt htu huR h_lo h_hi h_unique =>
+    perWindow_truncated_integral_tendsto hlt htu h_at
       (h_imm.continuousOn.mono (by
         rw [uIcc_of_le hab.le]
         exact Icc_subset_Icc (by linarith) h_hi))
@@ -122,12 +123,15 @@ theorem exists_radius_perWindow_tendsto_log_norm_add_arg
         rw [min_eq_left hab.le, max_eq_right hab.le]
         exact ⟨by linarith [ht.1.1], by linarith [ht.1.2]⟩, ht.2⟩)
       (h_imm.isPiecewiseC1On.intervalIntegrable_deriv.mono_set (by
-        rw [uIcc_of_le (by linarith : t₀ - ρ ≤ t₀ + ρ), uIcc_of_le hab.le]
+        rw [uIcc_of_le (hlt.le.trans htu.le), uIcc_of_le hab.le]
         exact Icc_subset_Icc (by linarith) h_hi))
       h_unique
-      (fun a' b' h1 h2 h3 => hc_R a' b' h1 h2 (h3.trans (by linarith)))
-      (fun b' h1 h2 => hc_L (t₀ - ρ) b' (by linarith) h1 h2)
-      (hc_plus ρ hρ_pos hρ_le) (hc_minus ρ hρ_pos hρ_le)⟩
+      (fun a' b' h1 h2 h3 => hc_R a' b' h1 h2 (h3.trans huR))
+      (fun b' h1 h2 => hc_L l b' hRl h1 h2)
+      (by simpa only [show t₀ + (u - t₀) = u by ring] using
+        hc_plus (u - t₀) (sub_pos.mpr htu) (by linarith))
+      (by simpa only [show t₀ - (t₀ - l) = l by ring] using
+        hc_minus (t₀ - l) (sub_pos.mpr hlt) (by linarith))⟩
 
 /-- **Existence of the Cauchy-kernel principal value along a piecewise-`C¹` immersion**: if
 every parameter of `[a, b]` where `γ` meets `s` is interior, the single-point Cauchy principal
@@ -165,8 +169,10 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
     (fun t ht => by linarith [(h_endpts t ht).2])
     (fun t ht t' ht' hne => (h_pair t ht t' ht' hne).le)
     h_int_tr
-    (fun t₀ ht₀ => ⟨_, h_spec t₀ ht₀ ρ hρ_pos (hρ_le_R t₀ ht₀)
-      (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
+    (fun t₀ ht₀ => ⟨_, h_spec t₀ ht₀ (t₀ - ρ) (t₀ + ρ)
+      (by linarith [hρ_le_R t₀ ht₀]) (by linarith [hρ_pos]) (by linarith [hρ_pos])
+      (by linarith [hρ_le_R t₀ ht₀]) (by linarith [(h_endpts t₀ ht₀).1])
+      (by linarith [(h_endpts t₀ ht₀).2])
       fun t ht h_eq => eq_of_mem_window_of_eq_of_lt_of_two_mul_lt (h_endpts t₀ ht₀)
         (h_pair t₀ ht₀) h_complete ht h_eq⟩)
     (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -110,8 +110,10 @@ theorem exists_radius_perWindow_tendsto_log_norm_add_arg
   have ht₀' : t₀ ∈ Ioo (min a b) (max a b) := by
     rwa [min_eq_left hab.le, max_eq_right hab.le]
   refine ⟨R, hR_pos, L_R, L_L, hL_R, hL_L, h_tend_R, h_tend_L,
-    fun l u hRl hlt htu huR h_lo h_hi h_unique =>
-    perWindow_truncated_integral_tendsto hlt htu h_at
+    fun l u hRl hlt htu huR h_lo h_hi h_unique => ?_⟩
+  have h_endpoint_R : t₀ + (u - t₀) = u := by ring
+  have h_endpoint_L : t₀ - (t₀ - l) = l := by ring
+  exact perWindow_truncated_integral_tendsto hlt htu h_at
       (h_imm.continuousOn.mono (by
         rw [uIcc_of_le hab.le]
         exact Icc_subset_Icc (by linarith) h_hi))
@@ -128,10 +130,10 @@ theorem exists_radius_perWindow_tendsto_log_norm_add_arg
       h_unique
       (fun a' b' h1 h2 h3 => hc_R a' b' h1 h2 (h3.trans huR))
       (fun b' h1 h2 => hc_L l b' hRl h1 h2)
-      (by simpa only [show t₀ + (u - t₀) = u by ring] using
+      (by simpa only [h_endpoint_R] using
         hc_plus (u - t₀) (sub_pos.mpr htu) (by linarith))
-      (by simpa only [show t₀ - (t₀ - l) = l by ring] using
-        hc_minus (t₀ - l) (sub_pos.mpr hlt) (by linarith))⟩
+      (by simpa only [h_endpoint_L] using
+        hc_minus (t₀ - l) (sub_pos.mpr hlt) (by linarith))
 
 /-- **Existence of the Cauchy-kernel principal value along a piecewise-`C¹` immersion**: if
 every parameter of `[a, b]` where `γ` meets `s` is interior, the single-point Cauchy principal

--- a/TauCeti/Analysis/Contour/PerWindow/CPV.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/CPV.lean
@@ -20,7 +20,7 @@ import Mathlib.Analysis.SpecialFunctions.Complex.Log
 /-!
 # The per-window principal value at a simple pole
 
-At a transverse crossing `γ t₀ = s` with unique crossing on the window `[t₀ - r, t₀ + r]`, the
+At a transverse crossing `γ t₀ = s` with unique crossing on a window `[l, u]`, the
 `ε`-truncated integral of the simple-pole integrand `(γ t - s)⁻¹ * deriv γ t` over the window
 converges as `ε → 0⁺` (`perWindow_truncated_integral_tendsto`). The window integral
 splits at the exit times (`exists_exit_times_truncated_integral_split`); each side integral is
@@ -28,7 +28,7 @@ the logarithm of a chord quotient by the logarithmic fundamental theorem of calc
 `log ε` real parts of the two sides cancel — both exit radii are exactly `ε` — and the argument
 parts converge by the annular argument limits, so the whole expression tends to
 
-  `(log ‖γ (t₀ + r) - s‖ - log ‖γ (t₀ - r) - s‖) + (arg_R + arg_L) · I`.
+  `(log ‖γ u - s‖ - log ‖γ l - s‖) + (arg_R + arg_L) · I`.
 
 The slit-plane hypotheses are taken as inputs rather than derived internally — the caller fixes
 the window radius once (for multi-crossing aggregation each crossing supplies a threshold
@@ -213,35 +213,36 @@ crossing of `s` in the window occurs at `t₀` (at most one crossing; existence 
 the anchored slit-plane chord quotients on each side, and the window-split identity for the
 `ε`-truncated simple-pole integrand, the truncated window integral equals the log-norm difference
 of the window endpoints plus the two boundary chord arguments times `I`. -/
-private theorem perWindow_truncated_integral_eq_log_form {γ : ℝ → ℂ} {s : ℂ} {t₀ r ε : ℝ}
-    {P : Set ℝ} {τl τr : ℝ} (hP : P.Countable) (hγ_cont : ContinuousOn γ (Icc (t₀ - r) (t₀ + r)))
-    (hγ_diffP : ∀ t ∈ Ioo (t₀ - r) (t₀ + r) \ P, DifferentiableAt ℝ γ t)
-    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume (t₀ - r) (t₀ + r))
-    (h_unique : ∀ t ∈ Icc (t₀ - r) (t₀ + r), γ t = s → t = t₀)
-    (h_slit_R : ∀ a b, t₀ < a → a ≤ b → b ≤ t₀ + r → (γ b - s) / (γ a - s) ∈ Complex.slitPlane)
-    (h_slit_L : ∀ b, t₀ - r ≤ b → b < t₀ → (γ b - s) / (γ (t₀ - r) - s) ∈ Complex.slitPlane)
-    (hτL : τl ∈ Ioo (t₀ - r) t₀) (hτR : τr ∈ Ioo t₀ (t₀ + r))
+private theorem perWindow_truncated_integral_eq_log_form {γ : ℝ → ℂ} {s : ℂ} {l t₀ u ε : ℝ}
+    {P : Set ℝ} {τl τr : ℝ} (hP : P.Countable) (hγ_cont : ContinuousOn γ (Icc l u))
+    (hγ_diffP : ∀ t ∈ Ioo l u \ P, DifferentiableAt ℝ γ t)
+    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume l u)
+    (h_unique : ∀ t ∈ Icc l u, γ t = s → t = t₀)
+    (h_slit_R : ∀ a b, t₀ < a → a ≤ b → b ≤ u → (γ b - s) / (γ a - s) ∈ Complex.slitPlane)
+    (h_slit_L : ∀ b, l ≤ b → b < t₀ → (γ b - s) / (γ l - s) ∈ Complex.slitPlane)
+    (hτL : τl ∈ Ioo l t₀) (hτR : τr ∈ Ioo t₀ u)
     (hradL : ‖γ τl - s‖ = ε) (hradR : ‖γ τr - s‖ = ε) (hε : 0 < ε)
-    (hsplit : ∫ u in (t₀ - r)..(t₀ + r), (if ‖γ u - s‖ > ε then (γ u - s)⁻¹ * deriv γ u else 0) =
-      (∫ u in (t₀ - r)..τl, (γ u - s)⁻¹ * deriv γ u) +
-      (∫ u in τr..(t₀ + r), (γ u - s)⁻¹ * deriv γ u)) :
-    ∫ t in (t₀ - r)..(t₀ + r),
+    (hsplit : ∫ v in l..u, (if ‖γ v - s‖ > ε then (γ v - s)⁻¹ * deriv γ v else 0) =
+      (∫ v in l..τl, (γ v - s)⁻¹ * deriv γ v) +
+      (∫ v in τr..u, (γ v - s)⁻¹ * deriv γ v)) :
+    ∫ t in l..u,
         (if ‖γ t - s‖ > ε then (γ t - s)⁻¹ * deriv γ t else 0) =
-      ((Real.log ‖γ (t₀ + r) - s‖ - Real.log ‖γ (t₀ - r) - s‖ : ℝ) : ℂ) +
-        ((((γ τl - s) / (γ (t₀ - r) - s)).arg +
-          ((γ (t₀ + r) - s) / (γ τr - s)).arg : ℝ) : ℂ) * Complex.I := by
-  have hr_pos : 0 < r := by linarith [hτL.1, hτL.2]
-  have h_ne_plus : γ (t₀ + r) - s ≠ 0 := sub_ne_zero.mpr fun h_eq =>
-    absurd (h_unique _ (right_mem_Icc.mpr (by linarith)) h_eq) (by linarith)
-  have h_ne_minus : γ (t₀ - r) - s ≠ 0 := sub_ne_zero.mpr fun h_eq =>
-    absurd (h_unique _ (left_mem_Icc.mpr (by linarith)) h_eq) (by linarith)
+      ((Real.log ‖γ u - s‖ - Real.log ‖γ l - s‖ : ℝ) : ℂ) +
+        ((((γ τl - s) / (γ l - s)).arg +
+          ((γ u - s) / (γ τr - s)).arg : ℝ) : ℂ) * Complex.I := by
+  have hlt : l < t₀ := hτL.1.trans hτL.2
+  have htu : t₀ < u := hτR.1.trans hτR.2
+  have h_ne_plus : γ u - s ≠ 0 := sub_ne_zero.mpr fun h_eq =>
+    absurd (h_unique _ (right_mem_Icc.mpr (hlt.le.trans htu.le)) h_eq) htu.ne'
+  have h_ne_minus : γ l - s ≠ 0 := sub_ne_zero.mpr fun h_eq =>
+    absurd (h_unique _ (left_mem_Icc.mpr (hlt.le.trans htu.le)) h_eq) hlt.ne
   have h_ne_L : γ τl - s ≠ 0 := by
     rw [← norm_pos_iff, hradL]
     exact hε
   have h_ne_R : γ τr - s ≠ 0 := by
     rw [← norm_pos_iff, hradR]
     exact hε
-  have h_win : t₀ - r ≤ t₀ + r := by linarith [hτL.1, hτL.2, hτR.1, hτR.2]
+  have h_win : l ≤ u := hlt.le.trans htu.le
   rw [hsplit,
     integral_inv_sub_mul_deriv_eq_log_window hτL.1.le hP
       (hγ_cont.mono (Icc_subset_Icc le_rfl (by linarith [hτL.2])))
@@ -270,25 +271,25 @@ with unique crossing on the window, non-zero one-sided derivative limits, and th
 inputs at the window radius, the `ε`-truncated window integral of `(γ t - s)⁻¹ * deriv γ t`
 converges as `ε → 0⁺` to the log-norm difference of the window boundary plus the two boundary
 arguments. -/
-theorem perWindow_truncated_integral_tendsto {γ : ℝ → ℂ} {s : ℂ} {t₀ r : ℝ}
-    {L_R L_L : ℂ} {P : Set ℝ} (hr_pos : 0 < r) (h_at : γ t₀ = s)
-    (hγ_cont : ContinuousOn γ (Icc (t₀ - r) (t₀ + r)))
+theorem perWindow_truncated_integral_tendsto {γ : ℝ → ℂ} {s : ℂ} {l t₀ u : ℝ}
+    {L_R L_L : ℂ} {P : Set ℝ} (hlt : l < t₀) (htu : t₀ < u) (h_at : γ t₀ = s)
+    (hγ_cont : ContinuousOn γ (Icc l u))
     (h_tendsto_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
     (h_tendsto_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
     (h_diff_R : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t)
     (h_diff_L : ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t) (hP : P.Countable)
-    (hγ_diffP : ∀ t ∈ Ioo (t₀ - r) (t₀ + r) \ P, DifferentiableAt ℝ γ t)
-    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume (t₀ - r) (t₀ + r))
-    (h_unique : ∀ t ∈ Icc (t₀ - r) (t₀ + r), γ t = s → t = t₀)
-    (h_slit_R : ∀ a b, t₀ < a → a ≤ b → b ≤ t₀ + r → (γ b - s) / (γ a - s) ∈ Complex.slitPlane)
-    (h_slit_L : ∀ b, t₀ - r ≤ b → b < t₀ → (γ b - s) / (γ (t₀ - r) - s) ∈ Complex.slitPlane)
-    (h_slit_plus : (γ (t₀ + r) - s) / L_R ∈ Complex.slitPlane)
-    (h_slit_minus : (-L_L) / (γ (t₀ - r) - s) ∈ Complex.slitPlane) :
-    Tendsto (fun ε : ℝ => ∫ t in (t₀ - r)..(t₀ + r),
+    (hγ_diffP : ∀ t ∈ Ioo l u \ P, DifferentiableAt ℝ γ t)
+    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume l u)
+    (h_unique : ∀ t ∈ Icc l u, γ t = s → t = t₀)
+    (h_slit_R : ∀ a b, t₀ < a → a ≤ b → b ≤ u → (γ b - s) / (γ a - s) ∈ Complex.slitPlane)
+    (h_slit_L : ∀ b, l ≤ b → b < t₀ → (γ b - s) / (γ l - s) ∈ Complex.slitPlane)
+    (h_slit_plus : (γ u - s) / L_R ∈ Complex.slitPlane)
+    (h_slit_minus : (-L_L) / (γ l - s) ∈ Complex.slitPlane) :
+    Tendsto (fun ε : ℝ => ∫ t in l..u,
         if ‖γ t - s‖ > ε then (γ t - s)⁻¹ * deriv γ t else 0)
       (𝓝[>] (0 : ℝ))
-      (𝓝 (((Real.log ‖γ (t₀ + r) - s‖ - Real.log ‖γ (t₀ - r) - s‖ : ℝ) : ℂ) +
-        ((((-L_L) / (γ (t₀ - r) - s)).arg + ((γ (t₀ + r) - s) / L_R).arg : ℝ) : ℂ) *
+      (𝓝 (((Real.log ‖γ u - s‖ - Real.log ‖γ l - s‖ : ℝ) : ℂ) +
+        ((((-L_L) / (γ l - s)).arg + ((γ u - s) / L_R).arg : ℝ) : ℂ) *
           Complex.I)) := by
   classical
   have hL_R : L_R ≠ 0 := fun h0 => by
@@ -300,7 +301,7 @@ theorem perWindow_truncated_integral_tendsto {γ : ℝ → ℂ} {s : ℂ} {t₀ 
   have hγ_at : ContinuousAt γ t₀ :=
     hγ_cont.continuousAt (Icc_mem_nhds (by linarith) (by linarith))
   obtain ⟨τL, τR, h_toL, h_toR, h_radL, h_radR, h_memL, h_memR, h_split⟩ :=
-    exists_exit_times_truncated_integral_split hr_pos h_at hγ_cont hL_R hL_L
+    exists_exit_times_truncated_integral_split hlt htu h_at hγ_cont hL_R hL_L
       h_tendsto_R h_tendsto_L h_diff_R h_diff_L h_unique (fun z => (z - s)⁻¹)
       (fun ε hε a b ha hab hb => intervalIntegrable_inv_sub_truncated
         (hγ_cont.mono (by
@@ -309,24 +310,30 @@ theorem perWindow_truncated_integral_tendsto {γ : ℝ → ℂ} {s : ℂ} {t₀ 
         (hderiv_int.mono_set (by
           rw [uIcc_of_le hab, uIcc_of_le (by linarith)]
           exact Icc_subset_Icc (by linarith) (by linarith))) hε)
-  have h_argR := arg_annular_quotient_exitTime_tendsto_right hγ_at h_diff_R
-    h_tendsto_R h_at h_slit_plus h_toR
-  have h_argL := arg_annular_quotient_exitTime_tendsto_left hγ_at h_diff_L
-    h_tendsto_L h_at h_slit_minus h_toL
-  have h_ev : (fun ε : ℝ => ∫ t in (t₀ - r)..(t₀ + r),
+  have h_argR : Tendsto (fun ε : ℝ => Complex.arg ((γ u - s) / (γ (τR ε) - s)))
+      (𝓝[>] (0 : ℝ)) (𝓝 ((γ u - s) / L_R).arg) := by
+    simpa only [show t₀ + (u - t₀) = u by ring] using
+      arg_annular_quotient_exitTime_tendsto_right (r := u - t₀) hγ_at h_diff_R
+        h_tendsto_R h_at (by simpa only [show t₀ + (u - t₀) = u by ring] using h_slit_plus) h_toR
+  have h_argL : Tendsto (fun ε : ℝ => Complex.arg ((γ (τL ε) - s) / (γ l - s)))
+      (𝓝[>] (0 : ℝ)) (𝓝 ((-L_L) / (γ l - s)).arg) := by
+    simpa only [show t₀ - (t₀ - l) = l by ring] using
+      arg_annular_quotient_exitTime_tendsto_left (r := t₀ - l) hγ_at h_diff_L
+        h_tendsto_L h_at (by simpa only [show t₀ - (t₀ - l) = l by ring] using h_slit_minus) h_toL
+  have h_ev : (fun ε : ℝ => ∫ t in l..u,
       if ‖γ t - s‖ > ε then (γ t - s)⁻¹ * deriv γ t else 0) =ᶠ[𝓝[>] (0 : ℝ)]
-      fun ε => ((Real.log ‖γ (t₀ + r) - s‖ - Real.log ‖γ (t₀ - r) - s‖ : ℝ) : ℂ) +
-        ((((γ (τL ε) - s) / (γ (t₀ - r) - s)).arg +
-          ((γ (t₀ + r) - s) / (γ (τR ε) - s)).arg : ℝ) : ℂ) * Complex.I := by
+      fun ε => ((Real.log ‖γ u - s‖ - Real.log ‖γ l - s‖ : ℝ) : ℂ) +
+        ((((γ (τL ε) - s) / (γ l - s)).arg +
+          ((γ u - s) / (γ (τR ε) - s)).arg : ℝ) : ℂ) * Complex.I := by
     filter_upwards [h_split, h_memL, h_memR, h_radL, h_radR, self_mem_nhdsWithin]
       with ε hsplit hτL hτR hradL hradR hε_pos
     exact perWindow_truncated_integral_eq_log_form hP hγ_cont hγ_diffP hderiv_int
       h_unique h_slit_R h_slit_L hτL hτR hradL hradR hε_pos hsplit
   refine Tendsto.congr' h_ev.symm (tendsto_const_nhds.add ?_)
   have h_sum : Tendsto (fun ε : ℝ =>
-      ((γ (τL ε) - s) / (γ (t₀ - r) - s)).arg +
-        ((γ (t₀ + r) - s) / (γ (τR ε) - s)).arg) (𝓝[>] (0 : ℝ))
-      (𝓝 (((-L_L) / (γ (t₀ - r) - s)).arg + ((γ (t₀ + r) - s) / L_R).arg)) :=
+      ((γ (τL ε) - s) / (γ l - s)).arg +
+        ((γ u - s) / (γ (τR ε) - s)).arg) (𝓝[>] (0 : ℝ))
+      (𝓝 (((-L_L) / (γ l - s)).arg + ((γ u - s) / L_R).arg)) :=
     h_argL.add h_argR
   exact ((Complex.continuous_ofReal.tendsto _).comp h_sum).mul tendsto_const_nhds
 

--- a/TauCeti/Analysis/Contour/PerWindow/CPV.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/CPV.lean
@@ -310,16 +310,18 @@ theorem perWindow_truncated_integral_tendsto {γ : ℝ → ℂ} {s : ℂ} {l t�
         (hderiv_int.mono_set (by
           rw [uIcc_of_le hab, uIcc_of_le (by linarith)]
           exact Icc_subset_Icc (by linarith) (by linarith))) hε)
+  have h_endpoint_R : t₀ + (u - t₀) = u := by ring
+  have h_endpoint_L : t₀ - (t₀ - l) = l := by ring
   have h_argR : Tendsto (fun ε : ℝ => Complex.arg ((γ u - s) / (γ (τR ε) - s)))
       (𝓝[>] (0 : ℝ)) (𝓝 ((γ u - s) / L_R).arg) := by
-    simpa only [show t₀ + (u - t₀) = u by ring] using
+    simpa only [h_endpoint_R] using
       arg_annular_quotient_exitTime_tendsto_right (r := u - t₀) hγ_at h_diff_R
-        h_tendsto_R h_at (by simpa only [show t₀ + (u - t₀) = u by ring] using h_slit_plus) h_toR
+        h_tendsto_R h_at (by simpa only [h_endpoint_R] using h_slit_plus) h_toR
   have h_argL : Tendsto (fun ε : ℝ => Complex.arg ((γ (τL ε) - s) / (γ l - s)))
       (𝓝[>] (0 : ℝ)) (𝓝 ((-L_L) / (γ l - s)).arg) := by
-    simpa only [show t₀ - (t₀ - l) = l by ring] using
+    simpa only [h_endpoint_L] using
       arg_annular_quotient_exitTime_tendsto_left (r := t₀ - l) hγ_at h_diff_L
-        h_tendsto_L h_at (by simpa only [show t₀ - (t₀ - l) = l by ring] using h_slit_minus) h_toL
+        h_tendsto_L h_at (by simpa only [h_endpoint_L] using h_slit_minus) h_toL
   have h_ev : (fun ε : ℝ => ∫ t in l..u,
       if ‖γ t - s‖ > ε then (γ t - s)⁻¹ * deriv γ t else 0) =ᶠ[𝓝[>] (0 : ℝ)]
       fun ε => ((Real.log ‖γ u - s‖ - Real.log ‖γ l - s‖ : ℝ) : ℂ) +

--- a/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
@@ -230,7 +230,7 @@ theorem perWindow_higherOrder_truncated_integral_tendsto {γ : ℝ → ℂ} {s :
   have h_deriv_L : HasDerivWithinAt γ L_L (Iio t_i) t_i :=
     TauCeti.hasDerivWithinAt_Iio_of_tendsto_deriv hγ_at h_diff_L h_tendsto_L
   obtain ⟨τL, τR, h_toL, h_toR, h_radL, h_radR, h_memL, h_memR, h_split⟩ :=
-    exists_exit_times_truncated_integral_split hr_pos h_at hγ_cont hL_R hL_L
+    exists_exit_times_truncated_integral_split (by linarith) (by linarith) h_at hγ_cont hL_R hL_L
       h_tendsto_R h_tendsto_L h_diff_R h_diff_L h_unique (fun z => c / (z - s) ^ k)
       (fun ε hε a b ha hab hb => intervalIntegrable_pow_inv_mul_deriv_truncated c k
         (hγ_cont.mono (by rw [uIcc_of_le hab]; exact Icc_subset_Icc ha hb))

--- a/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
@@ -240,8 +240,9 @@ theorem IsPwC1ImmersionOn.exp_two_pi_I_mul_windingNumber_eq_exp_sum_crossingAngl
       refine ⟨((Real.log ‖γ (t₀ + ρ) - s‖ - Real.log ‖γ (t₀ - ρ) - s‖ : ℝ) : ℂ) +
         ((((-L_L t₀) / (γ (t₀ - ρ) - s)).arg + ((γ (t₀ + ρ) - s) / L_R t₀).arg : ℝ) : ℂ) *
           Complex.I, ?_, ?_⟩
-      · refine hasCauchyPVAt_iff.mpr ⟨?_, h_spec t₀ ht₀ ρ hρ_pos (hρ_le_R t₀ ht₀) hlo hhi
-          (h_unique t₀ ht₀)⟩
+      · refine hasCauchyPVAt_iff.mpr ⟨?_, h_spec t₀ ht₀ (t₀ - ρ) (t₀ + ρ)
+          (by linarith [hρ_le_R t₀ ht₀]) (by linarith [hρ_pos]) (by linarith [hρ_pos])
+          (by linarith [hρ_le_R t₀ ht₀]) hlo hhi (h_unique t₀ ht₀)⟩
         exact Filter.eventually_iff_exists_mem.mpr ⟨Ioi 0, self_mem_nhdsWithin,
           fun ε hε => intervalIntegrable_inv_sub_truncated hpc.continuousOn
             hpc.intervalIntegrable_deriv hε⟩

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral/OnCurve.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral/OnCurve.lean
@@ -389,8 +389,10 @@ private theorem isBounded_intervalIntegrable_cauchyPV_of_interior_crossings
     (fun t ht => ⟨((Real.log ‖γ (t + ρ) - s‖ - Real.log ‖γ (t - ρ) - s‖ : ℝ) : ℂ) +
         ((((-L_L t) / (γ (t - ρ) - s)).arg + ((γ (t + ρ) - s) / L_R t).arg : ℝ) : ℂ) * Complex.I,
       by simp,
-      h_spec t ht ρ hρ_pos (hρ_le_R t ht) (by linarith [(h_endpts t ht).1])
-        (by linarith [(h_endpts t ht).2]) (h_unique t ht)⟩)
+      h_spec t ht (t - ρ) (t + ρ) (by linarith [hρ_le_R t ht])
+        (by linarith [hρ_pos]) (by linarith [hρ_pos]) (by linarith [hρ_le_R t ht])
+        (by linarith [(h_endpts t ht).1]) (by linarith [(h_endpts t ht).2])
+        (h_unique t ht)⟩)
     ⟨hm_pos, hm⟩
   -- The integral identity: the imaginary part is the ordinary integral of the real integrand.
   -- Reuses the upstream principal-value/real-integrand bridge directly, rather than re-deriving

--- a/TauCeti/Analysis/Contour/WindowSplitting.lean
+++ b/TauCeti/Analysis/Contour/WindowSplitting.lean
@@ -10,18 +10,19 @@ public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
 import TauCeti.Analysis.Contour.Crossing.Monotonicity
 import TauCeti.Analysis.Contour.Crossing.Windows
+import TauCeti.Analysis.Contour.Curve.Distance
 import TauCeti.Analysis.Contour.ExitTime
 
 /-!
 # Window splitting of the truncated integral at a crossing
 
 At a transverse crossing `γ t₀ = s` — non-zero one-sided derivative limits, unique crossing on
-the window `[t₀ - r, t₀ + r]` — there are exit-time functions `τL, τR` converging to `t₀` from
-each side with exit radius exactly `ε`, such that for every integrand `g` with integrable
+the window `[l, u]` with `l < t₀ < u` — there are exit-time functions `τL`, `τR` converging to
+`t₀` from each side with exit radius exactly `ε`, such that for every integrand `g` with integrable
 `ε`-truncation the truncated integral over the window eventually splits into the two *plain*
 side integrals:
 
-  `∫ (t₀-r)..(t₀+r), truncated = ∫ (t₀-r)..(τL ε), g (γ u) γ'(u) + ∫ (τR ε)..(t₀+r), g (γ u) γ'(u)`.
+  `∫ l..u, truncated = ∫ l..(τL ε), g (γ v) γ'(v) + ∫ (τR ε)..u, g (γ v) γ'(v)`.
 
 The middle piece `[τL ε, τR ε]` is annihilated — there the curve is inside the `ε`-ball, by
 strict monotonicity of the distance profile up to the exit times — and on the side pieces the
@@ -135,12 +136,12 @@ point with radius `ε`, the curve stays at distance `> ε` almost everywhere —
 inside the antitone window, and at least `m > ε` beyond it — so the `ε`-truncated integral equals
 the plain one. -/
 private theorem integral_truncated_eq_of_left_exit {γ : ℝ → ℂ} {g : ℂ → ℂ} {s : ℂ}
-    {t₀ ρ r m ε cₗ : ℝ} (h_lb : t₀ - r ≤ cₗ) (hcₗ : cₗ ∈ Ioo (t₀ - ρ) t₀)
+    {t₀ ρ l m ε cₗ : ℝ} (h_lb : l ≤ cₗ) (hcₗ : cₗ ∈ Ioo (t₀ - ρ) t₀)
     (hεₗ : ‖γ cₗ - s‖ = ε) (hεm : ε < m)
     (hanti : StrictAntiOn (fun t => ‖γ t - s‖) (Icc (t₀ - ρ) t₀))
-    (h_far : ∀ t ∈ Icc (t₀ - r) (t₀ - ρ), m ≤ ‖γ t - s‖) :
-    ∫ u in (t₀ - r)..cₗ, (if ‖γ u - s‖ > ε then g (γ u) * deriv γ u else 0) =
-      ∫ u in (t₀ - r)..cₗ, g (γ u) * deriv γ u := by
+    (h_far : ∀ t ∈ Icc l (t₀ - ρ), m ≤ ‖γ t - s‖) :
+    ∫ u in l..cₗ, (if ‖γ u - s‖ > ε then g (γ u) * deriv γ u else 0) =
+      ∫ u in l..cₗ, g (γ u) * deriv γ u := by
   refine integral_truncated_eq_of_ae_gt h_lb ?_
   filter_upwards [MeasureTheory.compl_mem_ae_iff.mpr
     (MeasureTheory.measure_singleton cₗ)] with t h_ne ht
@@ -156,12 +157,12 @@ point with radius `ε`, the curve stays at distance `> ε` almost everywhere —
 inside the monotone window, and at least `m > ε` beyond it — so the `ε`-truncated integral equals
 the plain one. -/
 private theorem integral_truncated_eq_of_right_exit {γ : ℝ → ℂ} {g : ℂ → ℂ} {s : ℂ}
-    {t₀ ρ r m ε cᵣ : ℝ} (h_ub : cᵣ ≤ t₀ + r) (hcᵣ : cᵣ ∈ Ioo t₀ (t₀ + ρ))
+    {t₀ ρ u m ε cᵣ : ℝ} (h_ub : cᵣ ≤ u) (hcᵣ : cᵣ ∈ Ioo t₀ (t₀ + ρ))
     (hεᵣ : ‖γ cᵣ - s‖ = ε) (hεm : ε < m)
     (hmono : StrictMonoOn (fun t => ‖γ t - s‖) (Icc t₀ (t₀ + ρ)))
-    (h_far : ∀ t ∈ Icc (t₀ + ρ) (t₀ + r), m ≤ ‖γ t - s‖) :
-    ∫ u in cᵣ..(t₀ + r), (if ‖γ u - s‖ > ε then g (γ u) * deriv γ u else 0) =
-      ∫ u in cᵣ..(t₀ + r), g (γ u) * deriv γ u := by
+    (h_far : ∀ t ∈ Icc (t₀ + ρ) u, m ≤ ‖γ t - s‖) :
+    ∫ v in cᵣ..u, (if ‖γ v - s‖ > ε then g (γ v) * deriv γ v else 0) =
+      ∫ v in cᵣ..u, g (γ v) * deriv γ v := by
   refine integral_truncated_eq_of_ae_gt h_ub (Eventually.of_forall fun t ht => ?_)
   rcases le_or_gt t (t₀ + ρ) with h_le | h_gt
   · have h_bd : ‖γ cᵣ - s‖ < ‖γ t - s‖ :=
@@ -172,26 +173,26 @@ private theorem integral_truncated_eq_of_right_exit {γ : ℝ → ℂ} {g : ℂ 
 /-- **The window integral splits at a pair of exit points.** With the norm strictly monotone off
 `t₀` on the window of radius `ρ`, exit points `cₗ`, `cᵣ` on either side at radius exactly `ε`, and
 the norm bounded below by `m > ε` outside that window, the `ε`-truncated integral over
-`[t₀ - r, t₀ + r]` is the sum of the two plain side integrals up to the exit points. -/
+`[l, u]` is the sum of the two plain side integrals up to the exit points. -/
 private theorem integral_truncated_eq_add_of_exit_points {γ : ℝ → ℂ} {g : ℂ → ℂ} {s : ℂ}
-    {t₀ ρ r m ε cₗ cᵣ : ℝ} (h_lb : t₀ - r ≤ cₗ) (h_ub : cᵣ ≤ t₀ + r)
+    {t₀ ρ l u m ε cₗ cᵣ : ℝ} (h_lb : l ≤ cₗ) (h_ub : cᵣ ≤ u)
     (hmono : StrictMonoOn (fun t => ‖γ t - s‖) (Icc t₀ (t₀ + ρ)))
     (hanti : StrictAntiOn (fun t => ‖γ t - s‖) (Icc (t₀ - ρ) t₀))
-    (h_far_L : ∀ t ∈ Icc (t₀ - r) (t₀ - ρ), m ≤ ‖γ t - s‖)
-    (h_far_R : ∀ t ∈ Icc (t₀ + ρ) (t₀ + r), m ≤ ‖γ t - s‖)
+    (h_far_L : ∀ t ∈ Icc l (t₀ - ρ), m ≤ ‖γ t - s‖)
+    (h_far_R : ∀ t ∈ Icc (t₀ + ρ) u, m ≤ ‖γ t - s‖)
     (hcₗ : cₗ ∈ Ioo (t₀ - ρ) t₀) (hcᵣ : cᵣ ∈ Ioo t₀ (t₀ + ρ))
     (hεₗ : ‖γ cₗ - s‖ = ε) (hεᵣ : ‖γ cᵣ - s‖ = ε) (hεm : ε < m)
     (h_int_left : IntervalIntegrable
       (fun t => if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0)
-      MeasureTheory.volume (t₀ - r) cₗ)
+      MeasureTheory.volume l cₗ)
     (h_int_mid : IntervalIntegrable
       (fun t => if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0) MeasureTheory.volume cₗ cᵣ)
     (h_int_right : IntervalIntegrable
       (fun t => if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0)
-      MeasureTheory.volume cᵣ (t₀ + r)) :
-    ∫ u in (t₀ - r)..(t₀ + r), (if ‖γ u - s‖ > ε then g (γ u) * deriv γ u else 0) =
-      (∫ u in (t₀ - r)..cₗ, g (γ u) * deriv γ u) +
-        (∫ u in cᵣ..(t₀ + r), g (γ u) * deriv γ u) := by
+      MeasureTheory.volume cᵣ u) :
+    ∫ v in l..u, (if ‖γ v - s‖ > ε then g (γ v) * deriv γ v else 0) =
+      (∫ v in l..cₗ, g (γ v) * deriv γ v) +
+        (∫ v in cᵣ..u, g (γ v) * deriv γ v) := by
   rw [← intervalIntegral.integral_add_adjacent_intervals
       (h_int_left.trans h_int_mid) h_int_right,
     ← intervalIntegral.integral_add_adjacent_intervals h_int_left h_int_mid,
@@ -201,20 +202,20 @@ private theorem integral_truncated_eq_add_of_exit_points {γ : ℝ → ℂ} {g :
     integral_truncated_eq_of_right_exit h_ub hcᵣ hεᵣ hεm hmono h_far_R]
 
 /-- **Shared window-splitting core.** At a transverse crossing `γ t₀ = s` (non-zero one-sided
-derivative limits `L_R`, `L_L`, unique crossing on the window `[t₀ - r, t₀ + r]`), there are
+derivative limits `L_R`, `L_L`, unique crossing on the window `[l, u]`), there are
 exit-time functions `τL, τR` tending to `t₀` one-sidedly with exit radius exactly `ε`, such
 that for every integrand `g` with interval-integrable `ε`-truncations on the window, the
 truncated integral over the window eventually equals the sum of the two plain side integrals
 up to the exit times. -/
-theorem exists_exit_times_truncated_integral_split {γ : ℝ → ℂ} {s : ℂ} {t₀ r : ℝ}
-    {L_R L_L : ℂ} (hr_pos : 0 < r) (h_at : γ t₀ = s)
-    (hγ_cont : ContinuousOn γ (Icc (t₀ - r) (t₀ + r))) (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
+theorem exists_exit_times_truncated_integral_split {γ : ℝ → ℂ} {s : ℂ} {l t₀ u : ℝ}
+    {L_R L_L : ℂ} (hlt : l < t₀) (htu : t₀ < u) (h_at : γ t₀ = s)
+    (hγ_cont : ContinuousOn γ (Icc l u)) (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
     (h_tendsto_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
     (h_tendsto_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
     (h_diff_R : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t)
     (h_diff_L : ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t)
-    (h_unique : ∀ t ∈ Icc (t₀ - r) (t₀ + r), γ t = s → t = t₀) (g : ℂ → ℂ)
-    (h_int : ∀ ε : ℝ, 0 < ε → ∀ a b : ℝ, t₀ - r ≤ a → a ≤ b → b ≤ t₀ + r →
+    (h_unique : ∀ t ∈ Icc l u, γ t = s → t = t₀) (g : ℂ → ℂ)
+    (h_int : ∀ ε : ℝ, 0 < ε → ∀ a b : ℝ, l ≤ a → a ≤ b → b ≤ u →
       IntervalIntegrable (fun t => if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0)
         MeasureTheory.volume a b) :
     ∃ τL τR : ℝ → ℝ,
@@ -222,21 +223,30 @@ theorem exists_exit_times_truncated_integral_split {γ : ℝ → ℂ} {s : ℂ} 
       Tendsto τR (𝓝[>] (0 : ℝ)) (𝓝[>] t₀) ∧
       (∀ᶠ ε in 𝓝[>] (0 : ℝ), ‖γ (τL ε) - s‖ = ε) ∧
       (∀ᶠ ε in 𝓝[>] (0 : ℝ), ‖γ (τR ε) - s‖ = ε) ∧
-      (∀ᶠ ε in 𝓝[>] (0 : ℝ), τL ε ∈ Ioo (t₀ - r) t₀) ∧
-      (∀ᶠ ε in 𝓝[>] (0 : ℝ), τR ε ∈ Ioo t₀ (t₀ + r)) ∧
+      (∀ᶠ ε in 𝓝[>] (0 : ℝ), τL ε ∈ Ioo l t₀) ∧
+      (∀ᶠ ε in 𝓝[>] (0 : ℝ), τR ε ∈ Ioo t₀ u) ∧
       (∀ᶠ ε in 𝓝[>] (0 : ℝ),
-        ∫ u in (t₀ - r)..(t₀ + r),
-            (if ‖γ u - s‖ > ε then g (γ u) * deriv γ u else 0) =
-          (∫ u in (t₀ - r)..(τL ε), g (γ u) * deriv γ u) +
-          (∫ u in (τR ε)..(t₀ + r), g (γ u) * deriv γ u)) := by
+        ∫ v in l..u, (if ‖γ v - s‖ > ε then g (γ v) * deriv γ v else 0) =
+          (∫ v in l..(τL ε), g (γ v) * deriv γ v) +
+          (∫ v in (τR ε)..u, g (γ v) * deriv γ v)) := by
   classical
+  let r := min (t₀ - l) (u - t₀)
+  have hr_pos : 0 < r := lt_min (sub_pos.mpr hlt) (sub_pos.mpr htu)
+  have hlr : l ≤ t₀ - r := by
+    dsimp [r]
+    linarith [min_le_left (t₀ - l) (u - t₀)]
+  have hru : t₀ + r ≤ u := by
+    dsimp [r]
+    linarith [min_le_right (t₀ - l) (u - t₀)]
+  have hγ_cont' : ContinuousOn γ (Icc (t₀ - r) (t₀ + r)) :=
+    hγ_cont.mono (Icc_subset_Icc hlr hru)
   obtain ⟨ρ, hρ_pos, hρ_le_r, hmono, hanti, h_leave_R, h_leave_L⟩ :=
-    exists_monotone_leave_radius hr_pos h_at hγ_cont hL_R hL_L h_tendsto_R h_tendsto_L
+    exists_monotone_leave_radius hr_pos h_at hγ_cont' hL_R hL_L h_tendsto_R h_tendsto_L
       h_diff_R h_diff_L
   have hγ_cont_R : ContinuousOn γ (Icc t₀ (t₀ + ρ)) :=
-    hγ_cont.mono (Icc_subset_Icc (by linarith) (by linarith))
+    hγ_cont.mono (Icc_subset_Icc hlt.le (by linarith [hρ_le_r, hru]))
   have hγ_cont_L : ContinuousOn γ (Icc (t₀ - ρ) t₀) :=
-    hγ_cont.mono (Icc_subset_Icc (by linarith) (by linarith))
+    hγ_cont.mono (Icc_subset_Icc (by linarith [hρ_le_r, hlr]) htu.le)
   set τL := firstExitTimeLeft γ t₀ ρ s with hτL_def
   set τR := firstExitTimeRight γ t₀ ρ s with hτR_def
   have h_toL : Tendsto τL (𝓝[>] (0 : ℝ)) (𝓝[<] t₀) :=
@@ -254,18 +264,34 @@ theorem exists_exit_times_truncated_integral_split {γ : ℝ → ℂ} {s : ℂ} 
   refine ⟨τL, τR, h_toL, h_toR, h_radL, h_radR,
     h_memL.mono fun ε hε => ⟨by linarith [hε.1], hε.2⟩,
     h_memR.mono fun ε hε => ⟨hε.1, by linarith [hε.2]⟩, ?_⟩
-  obtain ⟨m, hm_pos, h_far_L, h_far_R⟩ :=
-    exists_window_dist_lower_bound hγ_cont h_unique hρ_pos hρ_le_r
+  obtain ⟨mL, hmL_pos, h_far_L⟩ := exists_curve_dist_lower_bound
+    (a := l) (b := t₀ - ρ) (w := s)
+    (hγ_cont.mono (by rw [uIcc_of_le (by linarith)]; exact Icc_subset_Icc le_rfl (by linarith)))
+    (fun t ht h_eq => by
+      rw [uIcc_of_le (by linarith)] at ht
+      have ht_eq := h_unique t ⟨ht.1, by linarith [ht.2, hρ_pos, htu]⟩ h_eq
+      linarith [ht.2])
+  obtain ⟨mR, hmR_pos, h_far_R⟩ := exists_curve_dist_lower_bound
+    (a := t₀ + ρ) (b := u) (w := s)
+    (hγ_cont.mono (by rw [uIcc_of_le (by linarith)]; exact Icc_subset_Icc (by linarith) le_rfl))
+    (fun t ht h_eq => by
+      rw [uIcc_of_le (by linarith)] at ht
+      have ht_eq := h_unique t ⟨by linarith [ht.1, hρ_pos, hlt], ht.2⟩ h_eq
+      linarith [ht.1])
+  let m := min mL mR
+  have hm_pos : 0 < m := lt_min hmL_pos hmR_pos
   filter_upwards [h_radL, h_radR, h_memL, h_memR, Ioo_mem_nhdsGT hm_pos]
     with ε hεL hεR hτL hτR hεm
-  have h_lb : t₀ - r ≤ τL ε := by linarith [hτL.1]
+  have h_lb : l ≤ τL ε := by linarith [hτL.1, hρ_le_r, hlr]
   have h_mid_le : τL ε ≤ τR ε := by linarith [hτL.2, hτR.1]
-  have h_ub : τR ε ≤ t₀ + r := by linarith [hτR.2]
-  exact integral_truncated_eq_add_of_exit_points h_lb h_ub hmono hanti h_far_L h_far_R
+  have h_ub : τR ε ≤ u := by linarith [hτR.2, hρ_le_r, hru]
+  exact integral_truncated_eq_add_of_exit_points h_lb h_ub hmono hanti
+    (fun t ht => (min_le_left mL mR).trans (h_far_L t (by rwa [uIcc_of_le (by linarith)])))
+    (fun t ht => (min_le_right mL mR).trans (h_far_R t (by rwa [uIcc_of_le (by linarith)])))
     hτL hτR hεL hεR hεm.2
-    (h_int ε hεm.1 (t₀ - r) (τL ε) le_rfl h_lb (by linarith [hτL.2]))
+    (h_int ε hεm.1 l (τL ε) le_rfl h_lb (by linarith [hτL.2, htu]))
     (h_int ε hεm.1 (τL ε) (τR ε) h_lb h_mid_le h_ub)
-    (h_int ε hεm.1 (τR ε) (t₀ + r) (h_lb.trans h_mid_le) h_ub le_rfl)
+    (h_int ε hεm.1 (τR ε) u (h_lb.trans h_mid_le) h_ub le_rfl)
 
 end TauCeti.Contour
 


### PR DESCRIPTION
This PR generalizes Tau Ceti's per-window splitting and logarithmic principal-value calculation from symmetric parameter windows to arbitrary intervals `l < t₀ < u`, then evaluates the Cauchy principal value on the canonical equal-radius first-exit cap window. The new `exists_radius_hasCauchyPVAt_exitCapWindow` theorem exposes the one-sided tangent limits and proves the exact boundary-argument value; the equal first-exit radii cancel the real logarithmic term.

The exact `ContourIntegration/README.md` target is the Layer 1 milestone “Hungerbühler–Wasem Proposition 2.2 (finite crossings and winding decomposition),” specifically its remaining analytic principal-value evaluation on generally asymmetric exit-time windows. This consumes the equal-radius window construction from #4426 and supplies the local analytic input needed by the finite-window accounting in #4413.

After this PR, the milestone still needs the final specialization of #4413's conditional finite-window decomposition to the canonical exit windows and the sum of their local angle contributions.

The proof reuses Tau Ceti's existing first-exit-time, slit-plane logarithm, compact distance-bound, and Cauchy principal-value APIs. No Mathlib source is copied or vendored. The mathematical attribution remains N. Hungerbühler and M. Wasem, *Non-integer valued winding numbers and a generalized Residue Theorem*, Proposition 2.2.

Roadmap: ContourIntegration

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"exit-window-cauchy-principal-value"}-->

🤖 Prepared with Codex
