### PR TITLE
refactor: consolidate Lie isotypic transport

### DIFF
--- a/TauCeti/Algebra/Lie/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/Isotypic.lean
@@ -25,6 +25,11 @@ Mathlib's module-theoretic interface lives in
 
 This is the generic Lie-isotypy interface used by Layer 6 of the Lie highest-weight roadmap and
 its universal-enveloping-algebra dictionary.
+
+## References
+
+* `Mathlib/RingTheory/SimpleModule/Isotypic.lean` (Junyan Xu): the module-theoretic definitions
+  and proof pattern ported here to Lie submodules and Lie-module equivalences.
 -/
 
 public section
@@ -116,7 +121,7 @@ theorem isotypicComponent_le_iff (S : Type*) [AddCommGroup S] [Module R S]
     isotypicComponent R L M S ≤ N ↔
       ∀ P : LieSubmodule R L M, Nonempty (P ≃ₗ⁅R,L⁆ S) → P ≤ N := by
   rw [isotypicComponent_def, sSup_le_iff]
-  rfl
+  simp only [Set.mem_ofPred_eq]
 
 end LieModule
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
@@ -27,11 +27,10 @@ Mathlib's `IsIsotypicOfType`, `IsIsotypic`, and `isotypicComponent` through thos
   actions.
 * `LieModule.isIsotypic_iff_isIsotypic`: pairwise isotypy transport for compatible actions.
 * `LieModule.lieSubmoduleOrderIso_isotypicComponent`: component transport for compatible actions.
-* `LieModule.isIsotypicOfType_iff_isIsotypicOfType_asModule`: fixed-type isotypy transport.
-* `LieModule.isIsotypic_iff_isIsotypic_asModule`: pairwise isotypy transport.
-* `LieModule.lieSubmoduleOrderIsoAsModule_isotypicComponent`: isotypic-component transport.
-* `LieModule.isotypicComponent_eq_top_iff_of_ι_smul` and
-  `LieModule.isotypicComponent_eq_top_iff`: the top-component criterion for an irreducible type.
+* `LieModule.mem_isotypicComponent_iff_mem_isotypicComponent_asModule`: canonical component
+  membership normalization.
+* `LieModule.isotypicComponent_eq_top_iff_of_ι_smul`: the top-component criterion for an
+  irreducible type.
 
 ## Roadmap
 
@@ -174,48 +173,15 @@ attribute [local instance] asModule isScalarTower_asModule
 
 variable {R L M}
 
-/-- Lie-module isotypy of a fixed type is exactly Mathlib's module isotypy for the canonical
-`U(L)`-actions. -/
-theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
-    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S] :
-    IsIsotypicOfType R L M S ↔ _root_.IsIsotypicOfType U M S :=
-  isIsotypicOfType_iff_isIsotypicOfType
-    (asModule_ι_smul R L M) S (asModule_ι_smul R L S)
-
-/-- Lie-module isotypy is exactly Mathlib's module isotypy for the canonical `U(L)`-action. -/
-theorem isIsotypic_iff_isIsotypic_asModule :
-    IsIsotypic R L M ↔ _root_.IsIsotypic U M :=
-  isIsotypic_iff_isIsotypic (asModule_ι_smul R L M)
-
-/-- The canonical submodule dictionary maps the Lie isotypic component to Mathlib's
-`U(L)`-isotypic component. -/
-@[simp]
-theorem lieSubmoduleOrderIsoAsModule_isotypicComponent
-    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S] :
-    lieSubmoduleOrderIsoAsModule R L M (isotypicComponent R L M S) =
-      _root_.isotypicComponent U M S := by
-  rw [lieSubmoduleOrderIsoAsModule_def]
-  exact lieSubmoduleOrderIso_isotypicComponent
-    (asModule_ι_smul R L M) S (asModule_ι_smul R L S)
-
 /-- Membership in the Lie isotypic component is membership in the corresponding canonical
 `U(L)`-isotypic component. -/
+@[simp]
 theorem mem_isotypicComponent_iff_mem_isotypicComponent_asModule
     {S : Type*} [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     {m : M} :
     m ∈ isotypicComponent R L M S ↔ m ∈ _root_.isotypicComponent U M S :=
   mem_isotypicComponent_iff_mem_isotypicComponent
     (asModule_ι_smul R L M) (asModule_ι_smul R L S)
-
-/-- For an irreducible type `S` in a completely reducible Lie module, the isotypic component of
-type `S` is the whole module exactly when the Lie module is isotypic of type `S`. -/
-theorem isotypicComponent_eq_top_iff
-    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
-    [IsIrreducible R L S]
-    [ComplementedLattice (LieSubmodule R L M)] :
-    isotypicComponent R L M S = ⊤ ↔ IsIsotypicOfType R L M S :=
-  isotypicComponent_eq_top_iff_of_ι_smul
-    (asModule_ι_smul R L M) S (asModule_ι_smul R L S)
 
 end Canonical
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
@@ -23,9 +23,10 @@ Mathlib's `IsIsotypicOfType`, `IsIsotypic`, and `isotypicComponent` through thos
 
 ## Main results
 
-* `LieModule.isIsotypicOfType_iff_isIsotypicOfType`: fixed-type isotypy transport for compatible
+* `LieModule.isIsotypicOfType_iff_isIsotypicOfType_of_ι_smul`: fixed-type isotypy transport
+  for compatible actions.
+* `LieModule.isIsotypic_iff_isIsotypic_of_ι_smul`: pairwise isotypy transport for compatible
   actions.
-* `LieModule.isIsotypic_iff_isIsotypic`: pairwise isotypy transport for compatible actions.
 * `LieModule.lieSubmoduleOrderIso_isotypicComponent`: component transport for compatible actions.
 * `LieModule.mem_isotypicComponent_iff_mem_isotypicComponent_asModule`: canonical component
   membership normalization.
@@ -69,7 +70,7 @@ variable {R L M}
 
 /-- Lie-module isotypy of a fixed type is exactly Mathlib's module isotypy for compatible
 `U(L)`-actions. -/
-theorem isIsotypicOfType_iff_isIsotypicOfType
+theorem isIsotypicOfType_iff_isIsotypicOfType_of_ι_smul
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     [Module U S] [IsScalarTower R U S]
@@ -89,7 +90,7 @@ theorem isIsotypicOfType_iff_isIsotypicOfType
       (h (lieSubmoduleOrderIso hM P))
 
 /-- Lie-module isotypy is exactly Mathlib's module isotypy for a compatible `U(L)`-action. -/
-theorem isIsotypic_iff_isIsotypic
+theorem isIsotypic_iff_isIsotypic_of_ι_smul
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆) :
     IsIsotypic R L M ↔ _root_.IsIsotypic U M := by
   rw [isIsotypic_iff]
@@ -101,7 +102,7 @@ theorem isIsotypic_iff_isIsotypic
     let : IsScalarTower R U P := isScalarTower_asModule R L P
     let : IsIrreducible R L P :=
       (isSimpleModule_lieSubmoduleOrderIso_iff hM P).mp hQ
-    exact (isIsotypicOfType_iff_isIsotypicOfType hM P
+    exact (isIsotypicOfType_iff_isIsotypicOfType_of_ι_smul hM P
       (asModule_ι_smul R L P) |>.mp (h P)).of_linearEquiv_type
       (lieSubmoduleLinearEquiv hM P)
   · intro h P hP
@@ -109,7 +110,7 @@ theorem isIsotypic_iff_isIsotypic
     let : IsScalarTower R U P := isScalarTower_asModule R L P
     let : IsSimpleModule U (lieSubmoduleOrderIso hM P) :=
       (isSimpleModule_lieSubmoduleOrderIso_iff hM P).mpr hP
-    exact isIsotypicOfType_iff_isIsotypicOfType hM P
+    exact isIsotypicOfType_iff_isIsotypicOfType_of_ι_smul hM P
       (asModule_ι_smul R L P) |>.mpr
       ((h (lieSubmoduleOrderIso hM P)).of_linearEquiv_type
         (lieSubmoduleLinearEquiv hM P).symm)
@@ -135,7 +136,7 @@ theorem lieSubmoduleOrderIso_isotypicComponent
 
 /-- Membership in the Lie isotypic component is membership in the corresponding isotypic component
 for compatible `U(L)`-actions. -/
-theorem mem_isotypicComponent_iff_mem_isotypicComponent
+theorem mem_isotypicComponent_iff_mem_isotypicComponent_of_ι_smul
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     {S : Type*} [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     [Module U S] [IsScalarTower R U S]
@@ -163,7 +164,7 @@ theorem isotypicComponent_eq_top_iff_of_ι_smul
   rw [← map_eq_top_iff (lieSubmoduleOrderIso hM),
     lieSubmoduleOrderIso_isotypicComponent hM S hS,
     _root_.isotypicComponent_eq_top_iff,
-    isIsotypicOfType_iff_isIsotypicOfType hM S hS]
+    isIsotypicOfType_iff_isIsotypicOfType_of_ι_smul hM S hS]
 
 end Compatible
 
@@ -180,7 +181,7 @@ theorem mem_isotypicComponent_iff_mem_isotypicComponent_asModule
     {S : Type*} [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     {m : M} :
     m ∈ isotypicComponent R L M S ↔ m ∈ _root_.isotypicComponent U M S :=
-  mem_isotypicComponent_iff_mem_isotypicComponent
+  mem_isotypicComponent_iff_mem_isotypicComponent_of_ι_smul
     (asModule_ι_smul R L M) (asModule_ι_smul R L S)
 
 end Canonical

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Isotypic.lean
@@ -13,19 +13,25 @@ public import TauCeti.Algebra.Lie.UniversalEnveloping.Module
 # Isotypic Lie modules through the universal enveloping algebra
 
 This file transports Mathlib's isotypic-module interface across the universal-enveloping-algebra
-dictionary. Semisimplicity enters only in the characterization of an isotypic module by its
-unique component.
+dictionary. For an irreducible target type, semisimplicity enters only in the characterization of
+an isotypic module by its unique component.
 
 The generic equivalence and submodule interfaces live with the rest of the enveloping-algebra
 dictionary in `TauCeti.Algebra.Lie.UniversalEnveloping.Module`. The UEA-independent Lie-level
 predicates and component live in `TauCeti.Algebra.Lie.Isotypic`; this file identifies them with
 Mathlib's `IsIsotypicOfType`, `IsIsotypic`, and `isotypicComponent` through those interfaces.
 
-## Main definitions
+## Main results
 
+* `LieModule.isIsotypicOfType_iff_isIsotypicOfType`: fixed-type isotypy transport for compatible
+  actions.
+* `LieModule.isIsotypic_iff_isIsotypic`: pairwise isotypy transport for compatible actions.
+* `LieModule.lieSubmoduleOrderIso_isotypicComponent`: component transport for compatible actions.
 * `LieModule.isIsotypicOfType_iff_isIsotypicOfType_asModule`: fixed-type isotypy transport.
 * `LieModule.isIsotypic_iff_isIsotypic_asModule`: pairwise isotypy transport.
 * `LieModule.lieSubmoduleOrderIsoAsModule_isotypicComponent`: isotypic-component transport.
+* `LieModule.isotypicComponent_eq_top_iff_of_ι_smul` and
+  `LieModule.isotypicComponent_eq_top_iff`: the top-component criterion for an irreducible type.
 
 ## Roadmap
 
@@ -33,6 +39,11 @@ This is the universal-enveloping-algebra bridge for Layer 6 of the Lie highest-w
 It deliberately stops before highest-weight classification: consumers such as Kostant-form
 modules can state that all irreducible Lie submodules are equivalent without rebuilding ring-level
 isotypic machinery.
+
+## References
+
+* `Mathlib/RingTheory/SimpleModule/Isotypic.lean` (Junyan Xu): the module-theoretic isotypic
+  interface and top-component criterion transported through the enveloping-algebra dictionary.
 -/
 
 public section
@@ -59,7 +70,7 @@ variable {R L M}
 
 /-- Lie-module isotypy of a fixed type is exactly Mathlib's module isotypy for compatible
 `U(L)`-actions. -/
-theorem isIsotypicOfType_iff_isIsotypicOfType_uea
+theorem isIsotypicOfType_iff_isIsotypicOfType
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     [Module U S] [IsScalarTower R U S]
@@ -68,60 +79,41 @@ theorem isIsotypicOfType_iff_isIsotypicOfType_uea
   rw [isIsotypicOfType_iff]
   constructor
   · intro h Q hQ
-    let P := (lieSubmoduleOrderIso hM).symm Q
-    let : Module U P := asModule R L P
-    let : IsScalarTower R U P := isScalarTower_asModule R L P
-    rw [← (lieSubmoduleOrderIso hM).apply_symm_apply Q] at hQ ⊢
-    let : IsSimpleModule U P :=
-      IsSimpleModule.congr (lieSubmoduleLinearEquiv hM P)
+    obtain ⟨P, rfl⟩ := (lieSubmoduleOrderIso hM).surjective Q
     let : IsIrreducible R L P :=
-      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
-    exact (h P).map fun e => (lieSubmoduleLinearEquiv hM P).symm.trans
-      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
-        (asModule_ι_smul R L P) hS e)
+      (isSimpleModule_lieSubmoduleOrderIso_iff hM P).mp hQ
+    exact (nonempty_lieModuleEquiv_iff_nonempty_linearEquiv hM S hS P).mp (h P)
   · intro h P hP
-    let : Module U P := asModule R L P
-    let : IsScalarTower R U P := isScalarTower_asModule R L P
-    let Q := lieSubmoduleOrderIso hM P
-    let : IsSimpleModule U P :=
-      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
-    let : IsSimpleModule U Q :=
-      IsSimpleModule.congr (lieSubmoduleLinearEquiv hM P).symm
-    exact (h Q).map fun e =>
-      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
-        (asModule_ι_smul R L P) hS).symm
-        ((lieSubmoduleLinearEquiv hM P).trans e)
+    let : IsSimpleModule U (lieSubmoduleOrderIso hM P) :=
+      (isSimpleModule_lieSubmoduleOrderIso_iff hM P).mpr hP
+    exact (nonempty_lieModuleEquiv_iff_nonempty_linearEquiv hM S hS P).mpr
+      (h (lieSubmoduleOrderIso hM P))
 
 /-- Lie-module isotypy is exactly Mathlib's module isotypy for a compatible `U(L)`-action. -/
-theorem isIsotypic_iff_isIsotypic_uea
+theorem isIsotypic_iff_isIsotypic
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆) :
     IsIsotypic R L M ↔ _root_.IsIsotypic U M := by
   rw [isIsotypic_iff]
   simp only [_root_.IsIsotypic]
   constructor
   · intro h Q hQ
-    let P := (lieSubmoduleOrderIso hM).symm Q
+    obtain ⟨P, rfl⟩ := (lieSubmoduleOrderIso hM).surjective Q
     let : Module U P := asModule R L P
     let : IsScalarTower R U P := isScalarTower_asModule R L P
-    rw [← (lieSubmoduleOrderIso hM).apply_symm_apply Q] at hQ ⊢
-    let : IsSimpleModule U P :=
-      IsSimpleModule.congr (lieSubmoduleLinearEquiv hM P)
     let : IsIrreducible R L P :=
-      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mpr inferInstance
-    exact (isIsotypicOfType_iff_isIsotypicOfType_uea hM P
+      (isSimpleModule_lieSubmoduleOrderIso_iff hM P).mp hQ
+    exact (isIsotypicOfType_iff_isIsotypicOfType hM P
       (asModule_ι_smul R L P) |>.mp (h P)).of_linearEquiv_type
       (lieSubmoduleLinearEquiv hM P)
   · intro h P hP
     let : Module U P := asModule R L P
     let : IsScalarTower R U P := isScalarTower_asModule R L P
-    let Q := lieSubmoduleOrderIso hM P
-    let : IsSimpleModule U P :=
-      (isIrreducible_iff_isSimpleModule (asModule_ι_smul R L P)).mp hP
-    let : IsSimpleModule U Q :=
-      IsSimpleModule.congr (lieSubmoduleLinearEquiv hM P).symm
-    exact isIsotypicOfType_iff_isIsotypicOfType_uea hM P
+    let : IsSimpleModule U (lieSubmoduleOrderIso hM P) :=
+      (isSimpleModule_lieSubmoduleOrderIso_iff hM P).mpr hP
+    exact isIsotypicOfType_iff_isIsotypicOfType hM P
       (asModule_ι_smul R L P) |>.mpr
-      ((h Q).of_linearEquiv_type (lieSubmoduleLinearEquiv hM P).symm)
+      ((h (lieSubmoduleOrderIso hM P)).of_linearEquiv_type
+        (lieSubmoduleLinearEquiv hM P).symm)
 
 /-- A compatible submodule dictionary maps the Lie isotypic component to Mathlib's
 `U(L)`-isotypic component. -/
@@ -137,28 +129,14 @@ theorem lieSubmoduleOrderIso_isotypicComponent
     _root_.isotypicComponent]
   congr 1
   ext Q
-  -- Membership in the inverse-image family expands to the two equivalence types compared below.
-  change Nonempty (((lieSubmoduleOrderIso hM).symm Q) ≃ₗ⁅R,L⁆ S) ↔
-    Nonempty (Q ≃ₗ[U] S)
-  let P := (lieSubmoduleOrderIso hM).symm Q
-  let : Module U P := asModule R L P
-  let : IsScalarTower R U P := isScalarTower_asModule R L P
-  constructor
-  · rintro ⟨e⟩
-    have e' := (lieSubmoduleLinearEquiv hM P).symm.trans
-      (lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
-        (asModule_ι_smul R L P) hS e)
-    exact ⟨(lieSubmoduleOrderIso hM).apply_symm_apply Q ▸ e'⟩
-  · rintro ⟨e⟩
-    have e' : P ≃ₗ[U] S :=
-      (lieSubmoduleLinearEquiv hM P).trans
-        ((lieSubmoduleOrderIso hM).apply_symm_apply Q ▸ e)
-    exact ⟨(lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := P) (N := S)
-      (asModule_ι_smul R L P) hS).symm e'⟩
+  simp only [Set.mem_preimage, Set.mem_ofPred_eq]
+  obtain ⟨P, rfl⟩ := (lieSubmoduleOrderIso hM).surjective Q
+  rw [(lieSubmoduleOrderIso hM).symm_apply_apply]
+  exact nonempty_lieModuleEquiv_iff_nonempty_linearEquiv hM S hS P
 
 /-- Membership in the Lie isotypic component is membership in the corresponding isotypic component
 for compatible `U(L)`-actions. -/
-theorem mem_isotypicComponent_iff_uea
+theorem mem_isotypicComponent_iff_mem_isotypicComponent
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     {S : Type*} [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     [Module U S] [IsScalarTower R U S]
@@ -168,9 +146,10 @@ theorem mem_isotypicComponent_iff_uea
   rw [← mem_lieSubmoduleOrderIso hM,
     lieSubmoduleOrderIso_isotypicComponent hM S hS]
 
-/-- For compatible `U(L)`-actions on a completely reducible Lie module, the isotypic component of
-type `S` is the whole module exactly when the Lie module is isotypic of type `S`. -/
-theorem isotypicComponent_eq_top_iff_uea
+/-- For compatible `U(L)`-actions, an irreducible type `S`, and a completely reducible Lie module,
+the isotypic component of type `S` is the whole module exactly when the Lie module is isotypic of
+type `S`. -/
+theorem isotypicComponent_eq_top_iff_of_ι_smul
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     [Module U S] [IsScalarTower R U S]
@@ -185,7 +164,7 @@ theorem isotypicComponent_eq_top_iff_uea
   rw [← map_eq_top_iff (lieSubmoduleOrderIso hM),
     lieSubmoduleOrderIso_isotypicComponent hM S hS,
     _root_.isotypicComponent_eq_top_iff,
-    isIsotypicOfType_iff_isIsotypicOfType_uea hM S hS]
+    isIsotypicOfType_iff_isIsotypicOfType hM S hS]
 
 end Compatible
 
@@ -200,13 +179,13 @@ variable {R L M}
 theorem isIsotypicOfType_iff_isIsotypicOfType_asModule
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S] :
     IsIsotypicOfType R L M S ↔ _root_.IsIsotypicOfType U M S :=
-  isIsotypicOfType_iff_isIsotypicOfType_uea
+  isIsotypicOfType_iff_isIsotypicOfType
     (asModule_ι_smul R L M) S (asModule_ι_smul R L S)
 
 /-- Lie-module isotypy is exactly Mathlib's module isotypy for the canonical `U(L)`-action. -/
 theorem isIsotypic_iff_isIsotypic_asModule :
     IsIsotypic R L M ↔ _root_.IsIsotypic U M :=
-  isIsotypic_iff_isIsotypic_uea (asModule_ι_smul R L M)
+  isIsotypic_iff_isIsotypic (asModule_ι_smul R L M)
 
 /-- The canonical submodule dictionary maps the Lie isotypic component to Mathlib's
 `U(L)`-isotypic component. -/
@@ -221,22 +200,21 @@ theorem lieSubmoduleOrderIsoAsModule_isotypicComponent
 
 /-- Membership in the Lie isotypic component is membership in the corresponding canonical
 `U(L)`-isotypic component. -/
-@[simp]
-theorem mem_isotypicComponent_iff
+theorem mem_isotypicComponent_iff_mem_isotypicComponent_asModule
     {S : Type*} [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     {m : M} :
     m ∈ isotypicComponent R L M S ↔ m ∈ _root_.isotypicComponent U M S :=
-  mem_isotypicComponent_iff_uea
+  mem_isotypicComponent_iff_mem_isotypicComponent
     (asModule_ι_smul R L M) (asModule_ι_smul R L S)
 
-/-- In a completely reducible Lie module, the isotypic component of type `S` is the whole module
-exactly when the Lie module is isotypic of type `S`. -/
+/-- For an irreducible type `S` in a completely reducible Lie module, the isotypic component of
+type `S` is the whole module exactly when the Lie module is isotypic of type `S`. -/
 theorem isotypicComponent_eq_top_iff
     (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
     [IsIrreducible R L S]
     [ComplementedLattice (LieSubmodule R L M)] :
     isotypicComponent R L M S = ⊤ ↔ IsIsotypicOfType R L M S :=
-  isotypicComponent_eq_top_iff_uea
+  isotypicComponent_eq_top_iff_of_ι_smul
     (asModule_ι_smul R L M) S (asModule_ι_smul R L S)
 
 end Canonical

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.SimpleModule.Basic
-public import TauCeti.Algebra.Lie.Basic
+public import TauCeti.Algebra.Lie.Submodule.Atom
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Basic
 
 /-!
@@ -57,8 +57,8 @@ below is named after its counterparts there wherever one exists.
   `R`-linear equivalence between Lie module homomorphisms and `U(L)`-linear maps.
 * `TauCeti.UniversalEnvelopingAlgebra.lieModuleEquivEquivLinearEquiv`: the corresponding
   dictionary from Lie-module equivalences to `U(L)`-linear equivalences.
-* `TauCeti.UniversalEnvelopingAlgebra.lieSubmoduleLinearEquivAsModule`: the identity equivalence
-  between a Lie submodule and its image under the canonical submodule dictionary.
+* `TauCeti.UniversalEnvelopingAlgebra.lieSubmoduleLinearEquiv`: the identity equivalence between a
+  Lie submodule and its image under an arbitrary compatible submodule dictionary.
 
 ## Main results
 
@@ -312,6 +312,16 @@ theorem isIrreducible_iff_isSimpleModule
     IsSimpleOrder (LieSubmodule R L M) ↔ IsSimpleModule U M :=
   (lieSubmoduleOrderIso hcompat).isSimpleOrder_iff.trans (isSimpleModule_iff U M).symm
 
+/-- A Lie submodule is irreducible exactly when its image under a compatible enveloping-algebra
+submodule dictionary is simple. -/
+theorem isSimpleModule_lieSubmoduleOrderIso_iff
+    (hcompat : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (P : LieSubmodule R L M) :
+    IsSimpleModule U (lieSubmoduleOrderIso hcompat P) ↔ LieModule.IsIrreducible R L P :=
+  isSimpleModule_iff_isAtom.trans <|
+    ((lieSubmoduleOrderIso hcompat).isAtom_iff P).trans
+      (TauCeti.isIrreducible_iff_isAtom P).symm
+
 /-- **Complete reducibility is semisimplicity over the enveloping algebra**: every Lie submodule of
 `M` has a complement exactly when `M` is a semisimple `U(L)`-module. -/
 theorem complementedLattice_lieSubmodule_iff_isSemisimpleModule
@@ -399,29 +409,22 @@ section Equiv
 /-- **The enveloping-algebra dictionary for equivalences**: Lie module equivalences are exactly
 `U(L)`-linear equivalences when both actions are compatible with the canonical Lie generators.
 The correspondence is the identity on underlying functions. -/
-noncomputable def lieModuleEquivEquivLinearEquiv
+def lieModuleEquivEquivLinearEquiv
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆) :
     (M ≃ₗ⁅R,L⁆ N) ≃ (M ≃ₗ[U] N) where
-  toFun e := LinearEquiv.ofBijective (lieModuleHomEquiv hM hN e.toLieModuleHom) (by
-    rw [coe_lieModuleHomEquiv]
-    exact ⟨e.injective, e.surjective⟩)
-  invFun e := LieModuleEquiv.ofBijective ((lieModuleHomEquiv hM hN).symm e.toLinearMap)
-    (by
-      rw [coe_lieModuleHomEquiv_symm]
-      exact e.bijective)
-  left_inv e := by
-    apply LieModuleEquiv.ext
-    intro m
-    simp only [LieModuleEquiv.ofBijective_apply, coe_lieModuleHomEquiv_symm,
-      LinearEquiv.coe_toLinearMap, LinearEquiv.ofBijective_apply, coe_lieModuleHomEquiv,
-      LieModuleEquiv.coe_toLieModuleHom]
-  right_inv e := by
-    apply LinearEquiv.ext
-    intro m
-    simp only [LinearEquiv.ofBijective_apply, coe_lieModuleHomEquiv,
-      LieModuleEquiv.coe_toLieModuleHom, LieModuleEquiv.ofBijective_apply,
-      coe_lieModuleHomEquiv_symm, LinearEquiv.coe_toLinearMap]
+  toFun e :=
+    { lieModuleHomEquiv hM hN e.toLieModuleHom with
+      invFun := e.symm
+      left_inv := e.left_inv
+      right_inv := e.right_inv }
+  invFun e :=
+    { (lieModuleHomEquiv hM hN).symm e.toLinearMap with
+      invFun := e.symm
+      left_inv := e.left_inv
+      right_inv := e.right_inv }
+  left_inv _ := rfl
+  right_inv _ := rfl
 
 /-- The forward equivalence dictionary does not change the underlying function. -/
 @[simp]
@@ -430,10 +433,17 @@ theorem coe_lieModuleEquivEquivLinearEquiv
     (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
     (e : M ≃ₗ⁅R,L⁆ N) :
     ⇑(lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := M) (N := N) hM hN e) = ⇑e :=
-  by
-    ext m
-    simp only [lieModuleEquivEquivLinearEquiv, Equiv.coe_fn_mk, LinearEquiv.ofBijective_apply,
-      coe_lieModuleHomEquiv, LieModuleEquiv.coe_toLieModuleHom]
+  (rfl)
+
+/-- The inverse of the forward equivalence dictionary is the original inverse function. -/
+@[simp]
+theorem coe_lieModuleEquivEquivLinearEquiv_apply_symm
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
+    (e : M ≃ₗ⁅R,L⁆ N) :
+    ⇑(lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := M) (N := N) hM hN e).symm =
+      ⇑e.symm :=
+  (rfl)
 
 /-- The inverse equivalence dictionary does not change the underlying function. -/
 @[simp]
@@ -443,17 +453,36 @@ theorem coe_lieModuleEquivEquivLinearEquiv_symm
     (e : M ≃ₗ[U] N) :
     ⇑((lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := M) (N := N) hM hN).symm e) =
       ⇑e :=
-  by
-    ext n
-    simp only [lieModuleEquivEquivLinearEquiv, Equiv.coe_fn_symm_mk,
-      LieModuleEquiv.ofBijective_apply, coe_lieModuleHomEquiv_symm,
-      LinearEquiv.coe_toLinearMap]
+  (rfl)
+
+/-- The inverse of the backward equivalence dictionary is the original inverse function. -/
+@[simp]
+theorem coe_lieModuleEquivEquivLinearEquiv_symm_apply_symm
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (hN : ∀ (x : L) (n : N), ι R x • n = ⁅x, n⁆)
+    (e : M ≃ₗ[U] N) :
+    ⇑((lieModuleEquivEquivLinearEquiv (R := R) (L := L) (M := M) (N := N) hM hN).symm e).symm =
+      ⇑e.symm :=
+  (rfl)
 
 end Equiv
 
 end Hom
 
 /-! #### Submodule equivalences -/
+
+/-- A compatible enveloping-algebra action on a Lie submodule agrees, after inclusion, with the
+action on the ambient Lie module. -/
+theorem coe_smul_of_ι_smul
+    [LieModule R L M]
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (P : LieSubmodule R L M) (u : U) (p : P) :
+    letI := asModule R L P
+    ((u • p : P) : M) = u • (p : M) := by
+  let : Module U P := asModule R L P
+  let : IsScalarTower R U P := isScalarTower_asModule R L P
+  exact map_smul_of_map_ι_smul (R := R) (L := L) (M := P) (N := M) P.subtype
+    (fun x p => by rw [asModule_ι_smul R L P, hM]; exact P.incl.map_lie x p) u p
 
 /-- A Lie submodule with its canonical `U(L)`-action is linearly equivalent, by the identity map,
 to its image under an arbitrary compatible enveloping-algebra submodule dictionary. -/
@@ -462,8 +491,8 @@ noncomputable def lieSubmoduleLinearEquiv
     (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆) (P : LieSubmodule R L M) :
     letI := asModule R L P
     P ≃ₗ[U] lieSubmoduleOrderIso hM P := by
-  letI := asModule R L P
-  letI := isScalarTower_asModule R L P
+  let : Module U P := asModule R L P
+  let : IsScalarTower R U P := isScalarTower_asModule R L P
   exact
     { toFun := fun p => ⟨p, (mem_lieSubmoduleOrderIso hM).mpr p.property⟩
       invFun := fun p => ⟨p, (mem_lieSubmoduleOrderIso hM).mp p.property⟩
@@ -472,8 +501,7 @@ noncomputable def lieSubmoduleLinearEquiv
       map_add' := fun _ _ => rfl
       map_smul' := fun u p => by
         ext
-        exact map_smul_of_map_ι_smul (R := R) (L := L) (M := P) (N := M) P.subtype
-          (fun x p => by rw [asModule_ι_smul R L P, hM]; rfl) u p }
+        exact coe_smul_of_ι_smul hM P u p }
 
 /-- The compatible-action submodule equivalence preserves the underlying ambient element. -/
 @[simp]
@@ -494,6 +522,26 @@ theorem coe_lieSubmoduleLinearEquiv_symm
     ⇑(lieSubmoduleLinearEquiv hM P).symm =
       fun p => ⟨p, (mem_lieSubmoduleOrderIso hM).mp p.property⟩ :=
   (rfl)
+
+/-- Equivalence to a fixed Lie module is the same as linear equivalence from the corresponding
+compatible enveloping-algebra submodule. -/
+theorem nonempty_lieModuleEquiv_iff_nonempty_linearEquiv
+    [LieModule R L M]
+    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
+    (S : Type*) [AddCommGroup S] [Module R S] [LieRingModule L S] [LieModule R L S]
+    [Module U S] [IsScalarTower R U S]
+    (hS : ∀ (x : L) (s : S), ι R x • s = ⁅x, s⁆)
+    (P : LieSubmodule R L M) :
+    Nonempty (P ≃ₗ⁅R,L⁆ S) ↔ Nonempty (lieSubmoduleOrderIso hM P ≃ₗ[U] S) := by
+  let : Module U P := asModule R L P
+  let : IsScalarTower R U P := isScalarTower_asModule R L P
+  constructor
+  · rintro ⟨e⟩
+    exact ⟨(lieSubmoduleLinearEquiv hM P).symm.trans
+      (lieModuleEquivEquivLinearEquiv (asModule_ι_smul R L P) hS e)⟩
+  · rintro ⟨e⟩
+    exact ⟨(lieModuleEquivEquivLinearEquiv (asModule_ι_smul R L P) hS).symm
+      ((lieSubmoduleLinearEquiv hM P).trans e)⟩
 
 end Dictionary
 
@@ -534,35 +582,6 @@ theorem mem_lieSubmoduleOrderIsoAsModule {P : LieSubmodule R L M} {m : M} :
 theorem mem_lieSubmoduleOrderIsoAsModule_symm {Q : Submodule U M} {m : M} :
     m ∈ (lieSubmoduleOrderIsoAsModule R L M).symm Q ↔ m ∈ Q :=
   (Iff.rfl)
-
-/-- The canonical `U(L)`-action on a Lie submodule agrees, after inclusion, with the canonical
-action on the ambient Lie module. -/
-@[simp]
-theorem coe_asModule_smul_lieSubmodule (P : LieSubmodule R L M) (u : U) (p : P) :
-    ((u • p : P) : M) = u • (p : M) := by
-  exact map_smul_of_map_ι_smul (R := R) (L := L) (M := P) (N := M) P.subtype
-    (fun x p => by rw [asModule_ι_smul R L P, asModule_ι_smul R L M]; rfl) u p
-
-/-- A Lie submodule with its canonical `U(L)`-action is linearly equivalent, by the identity map,
-to its image under `lieSubmoduleOrderIsoAsModule`. This is the subtype-level interface for
-transporting module-theoretic properties through the submodule dictionary. -/
-noncomputable def lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
-    P ≃ₗ[U] lieSubmoduleOrderIsoAsModule R L M P :=
-  lieSubmoduleLinearEquiv (asModule_ι_smul R L M) P
-
-/-- The canonical forward submodule equivalence preserves the underlying ambient element. -/
-@[simp]
-theorem coe_lieSubmoduleLinearEquivAsModule (P : LieSubmodule R L M) :
-    ⇑(lieSubmoduleLinearEquivAsModule R L M P) =
-      fun p => ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mpr p.property⟩ :=
-  (rfl)
-
-/-- The canonical inverse submodule equivalence preserves the underlying ambient element. -/
-@[simp]
-theorem coe_lieSubmoduleLinearEquivAsModule_symm (P : LieSubmodule R L M) :
-    ⇑(lieSubmoduleLinearEquivAsModule R L M P).symm =
-      fun p => ⟨p, (mem_lieSubmoduleOrderIsoAsModule R L M).mp p.property⟩ :=
-  (rfl)
 
 end Canonical
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Module.lean
@@ -314,6 +314,7 @@ theorem isIrreducible_iff_isSimpleModule
 
 /-- A Lie submodule is irreducible exactly when its image under a compatible enveloping-algebra
 submodule dictionary is simple. -/
+@[simp]
 theorem isSimpleModule_lieSubmoduleOrderIso_iff
     (hcompat : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
     (P : LieSubmodule R L M) :
@@ -471,19 +472,6 @@ end Hom
 
 /-! #### Submodule equivalences -/
 
-/-- A compatible enveloping-algebra action on a Lie submodule agrees, after inclusion, with the
-action on the ambient Lie module. -/
-theorem coe_smul_of_ι_smul
-    [LieModule R L M]
-    (hM : ∀ (x : L) (m : M), ι R x • m = ⁅x, m⁆)
-    (P : LieSubmodule R L M) (u : U) (p : P) :
-    letI := asModule R L P
-    ((u • p : P) : M) = u • (p : M) := by
-  let : Module U P := asModule R L P
-  let : IsScalarTower R U P := isScalarTower_asModule R L P
-  exact map_smul_of_map_ι_smul (R := R) (L := L) (M := P) (N := M) P.subtype
-    (fun x p => by rw [asModule_ι_smul R L P, hM]; exact P.incl.map_lie x p) u p
-
 /-- A Lie submodule with its canonical `U(L)`-action is linearly equivalent, by the identity map,
 to its image under an arbitrary compatible enveloping-algebra submodule dictionary. -/
 noncomputable def lieSubmoduleLinearEquiv
@@ -501,7 +489,8 @@ noncomputable def lieSubmoduleLinearEquiv
       map_add' := fun _ _ => rfl
       map_smul' := fun u p => by
         ext
-        exact coe_smul_of_ι_smul hM P u p }
+        exact map_smul_of_map_ι_smul (R := R) (L := L) (M := P) (N := M) P.subtype
+          (fun x p => by rw [asModule_ι_smul R L P, hM]; exact P.incl.map_lie x p) u p }
 
 /-- The compatible-action submodule equivalence preserves the underlying ambient element. -/
 @[simp]
@@ -582,6 +571,16 @@ theorem mem_lieSubmoduleOrderIsoAsModule {P : LieSubmodule R L M} {m : M} :
 theorem mem_lieSubmoduleOrderIsoAsModule_symm {Q : Submodule U M} {m : M} :
     m ∈ (lieSubmoduleOrderIsoAsModule R L M).symm Q ↔ m ∈ Q :=
   (Iff.rfl)
+
+/-- The canonical `U(L)`-action on a Lie submodule agrees, after inclusion, with the canonical
+action on the ambient Lie module. -/
+@[simp]
+theorem coe_asModule_smul_lieSubmodule (P : LieSubmodule R L M) (u : U) (p : P) :
+    ((u • p : P) : M) = u • (p : M) := by
+  exact map_smul_of_map_ι_smul (R := R) (L := L) (M := P) (N := M) P.subtype
+    (fun x p => by
+      rw [asModule_ι_smul R L P, asModule_ι_smul R L M]
+      exact P.incl.map_lie x p) u p
 
 end Canonical
 


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Consolidates the Lie/UEA isotypic transport added in #4368.

- Factors compatible-action irreducibility and equivalence transport into reusable dictionary lemmas.
- Constructs the dictionary equivalences with their actual inverses and exposes both directions.
- Replaces repeated instance transfer and carrier-level proofs with the submodule order isomorphism.
- Removes unused canonical specializations and aligns names with the existing `asModule` convention.
- Corrects documentation and Mathlib attribution.

## Why this is a follow-up

#4368 merged before its separately validated repair entered the public branch. No later commit changed the affected files, and no open PR collides with this maintenance slice.

## Verification

Focused 1,738-job and full 9,256-job builds, 74,855-declaration axiom audit, 3,364-module audit, lint, public consumer probes, and full aggregate `2+1` pass at `042acf5108667e0e44ab484cd5a81aed57f6a3b5`.

## Scope

Refactors already-merged Lie-isotypy infrastructure without adding mathematical scope. Compatible-action results remain generic; canonical specializations remain only where consumed. Obsolete names have no repository consumers and are removed without aliases.