### PR TITLE
feat: eliminate normal unipotent subgroups of SLn

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
@@ -5,53 +5,51 @@ Authors: Codex
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.StandardComodule
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.SmoothConnected
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.StandardComodule
 public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
 import TauCeti.Algebra.AlgebraicGroup.Reductive.LinearlyReductive
 import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
+import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Smooth
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
+import TauCeti.RingTheory.Smooth.GeometricallyReduced
 
 /-!
-# The general linear group is reductive
+# Normal unipotent subgroups of the special linear group
 
-The coordinate Hopf algebra of `GL_n` is reductive over every field and in every natural rank.
-The proof uses the geometric definition, so it works in arbitrary characteristic.
+A normal smooth unipotent closed subgroup of `SL_n` over an algebraically closed field is
+trivial. The proof uses the faithful simple standard representation.
 
-First, the determinant localization defining `O(GL_n)` is smooth and geometrically connected.
-For the normal-subgroup condition, work over an algebraically closed field and let `I` cut out a
-normal smooth unipotent closed subgroup. The simple standard `GL_n`-comodule is completely
-reducible, so the general normal-unipotent elimination theorem makes the subgroup act trivially.
-Faithfulness of the standard representation then identifies `I` with the augmentation ideal.
+Smoothness makes the subgroup coordinate ring reduced, while geometric unipotence says that all
+of its points act unipotently. The general normal-invariants theorem then makes the subgroup act
+trivially on every completely reducible ambient representation. The standard representation of
+`SL_n` is simple in positive rank, hence completely reducible, and it is faithful in every rank.
+Faithfulness therefore identifies the subgroup's defining ideal with the augmentation ideal. The
+zero-rank case is handled directly using the zero-dimensional standard representation.
 
-The final theorem transports this argument across the canonical identification
+Geometric connectedness of `SL_n`, and hence the assembly of this theorem into reductivity over an
+arbitrary field, is developed separately.
 
-`AlgebraicClosure k ⊗[k] O(GL_n) ≃ O(GL_n, AlgebraicClosure k)`.
+## Main declaration
 
-## Main declarations
-
-* `TauCeti.GeneralLinear.eq_augmentation_of_isNormal_of_smoothUnipotent`: a normal smooth
-  unipotent closed subgroup of `GL_n` over an algebraically closed field is trivial.
-* `TauCeti.GeneralLinear.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`:
-  **`GL_n` is reductive.**
+* `TauCeti.SpecialLinear.eq_augmentation_of_isNormal_of_smoothUnipotent`: a normal smooth
+  unipotent closed subgroup of `SL_n` over an algebraically closed field is the identity subgroup.
 
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), §§4.a, 5, 19.b, and Chapter 14.
 * T. A. Springer, *Linear Algebraic Groups*, §§2.2 and 2.4.
 
-This gives the reductivity half of the `GL_n` worked example requested alongside Layer 6,
-"Reductive and semisimple groups", of the ReductiveGroups roadmap. The characteristic-zero
-complete-reducibility route remains open.
+This supplies the normal-subgroup elimination step for the `SL_n` worked example in Layer 6,
+"Reductive and semisimple groups", of the ReductiveGroups roadmap.
 -/
 
 public section
 
 open CategoryTheory
 
-namespace TauCeti.GeneralLinear
+namespace TauCeti.SpecialLinear
 
-universe u v
+universe u
 
 noncomputable section
 
@@ -64,7 +62,7 @@ private noncomputable def coordinateHopfAlgebraFiniteTypeObjIso
     coordinateHopfAlgebra R n ≅ (finiteTypeCoordinateHopfAlgebra R n).obj :=
   eqToIso (finiteTypeCoordinateHopfAlgebra_obj R n).symm
 
-/-- A normal smooth unipotent closed subgroup of `GL_n` over an algebraically closed field is
+/-- A normal smooth unipotent closed subgroup of `SL_n` over an algebraically closed field is
 trivial. No positivity hypothesis on `n` is needed. -/
 theorem eq_augmentation_of_isNormal_of_smoothUnipotent
     (k : Type u) [Field k] [IsAlgClosed k] (n : Nat)
@@ -94,6 +92,7 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
       ((geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU'.2)
   let _ : IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) J) :=
     isReduced_of_smooth_of_field k _
+  let _ : IsReduced (coordinateHopfAlgebra k n) := isReduced_of_smooth_of_field k _
   let _ : Comodule k (coordinateHopfAlgebra k n) (Fin n → k) := standardComodule k n
   have hu :=
     geometricallyUnipotentPointsCommHopfAlgProperty.forall_isUnipotentPoint hJunipotent
@@ -113,39 +112,6 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
     HopfIdeal.comap_augmentation]
   exact hJ
 
-/-- **The general linear group is reductive over every field.** -/
-theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
-    (k : Type u) [Field k] (n : Nat) :
-    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) := by
-  rw [reductiveCommHopfAlgProperty_iff]
-  let e := coordinateHopfAlgebraFiniteTypeObjIso k n
-  refine ⟨(smoothCommHopfAlgProperty_iff _).mp <|
-      (smoothCommHopfAlgProperty k).prop_of_iso e
-        ((smoothCommHopfAlgProperty_iff _).mpr inferInstance),
-    (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e
-      (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n), ?_⟩
-  intro I hI _ hU
-  let K := AlgebraicClosure k
-  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := K)
-    (finiteTypeCoordinateHopfAlgebra k n)
-  let Gbar := finiteTypeCoordinateHopfAlgebra K n
-  let e : Hbar ≅ Gbar := finiteTypeCoordinateHopfAlgebraBaseChangeIso k K n
-  let f : Gbar →ₐc[K] Hbar := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.inv
-  let J : HopfIdeal K Gbar := I.comap f hf.2
-  have hJnormal : J.IsNormal := hI.comap_of_bijective f hf.1 hf.2
-  let qIso : FiniteTypeCommHopfAlgCat.quotient Gbar J ≅
-      FiniteTypeCommHopfAlgCat.quotient Hbar I :=
-    FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm I
-  have hJU : smoothUnipotentCommHopfAlgProperty K
-      (FiniteTypeCommHopfAlgCat.quotient Gbar J) :=
-    (smoothUnipotentCommHopfAlgProperty K).prop_of_iso qIso.symm hU
-  have hJ : J = HopfIdeal.augmentation K Gbar :=
-    eq_augmentation_of_isNormal_of_smoothUnipotent K n J hJnormal hJU
-  rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hf.2,
-    HopfIdeal.comap_augmentation]
-  exact hJ
-
 end
 
-end TauCeti.GeneralLinear
+end TauCeti.SpecialLinear

--- a/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean
@@ -43,6 +43,9 @@ milestone in Layer 6 of the ReductiveGroups roadmap.
 * `TauCeti.Comodule.IsCompletelyReducible.of_exists_isCompl` and
   `TauCeti.Comodule.IsCompletelyReducible.exists_isCompl`: construct and use complete
   reducibility through complementary subcomodules.
+* `TauCeti.Comodule.isCompletelyReducible_of_subsingleton` and
+  `TauCeti.Comodule.isCompletelyReducible_of_isSimpleOrder`: subsingleton and simple comodules
+  are completely reducible.
 * `TauCeti.Comodule.fixedSubcomodule_eq_top_of_isCompletelyReducible_of_forall_exists_fixed` and
   `TauCeti.Comodule.coact_eq_tmul_one_of_isCompletelyReducible_of_forall_exists_fixed`: a
   completely reducible comodule all of whose nonzero subcomodules contain nonzero fixed vectors
@@ -110,6 +113,33 @@ theorem IsCompletelyReducible.exists_isCompl (h : IsCompletelyReducible k C V)
     (W : Subcomodule k C V) :
     ∃ Q : Subcomodule k C V, IsCompl W.toSubmodule Q.toSubmodule :=
   h W
+
+/-- A comodule on a subsingleton module is completely reducible. -/
+theorem isCompletelyReducible_of_subsingleton [Subsingleton V] :
+    IsCompletelyReducible k C V := by
+  apply IsCompletelyReducible.of_exists_isCompl
+  intro W
+  have hW : W = ⊥ := by
+    ext m
+    constructor
+    · intro _
+      rw [Subcomodule.mem_bot]
+      exact Subsingleton.elim _ _
+    · intro hm
+      exact (Subcomodule.mem_bot.mp hm) ▸ zero_mem W
+  refine ⟨⊤, ?_⟩
+  simpa [hW] using (isCompl_bot_top : IsCompl (⊥ : Submodule k V) ⊤)
+
+/-- A comodule with no subcomodules except `⊥` and `⊤` is completely reducible. -/
+theorem isCompletelyReducible_of_isSimpleOrder
+    [IsSimpleOrder (Subcomodule k C V)] : IsCompletelyReducible k C V := by
+  apply IsCompletelyReducible.of_exists_isCompl
+  intro W
+  exact (eq_bot_or_eq_top W).elim
+    (fun h ↦ ⟨⊤, by
+      simpa [h] using (isCompl_bot_top : IsCompl (⊥ : Submodule k V) ⊤)⟩)
+    (fun h ↦ ⟨⊥, by
+      simpa [h] using (isCompl_top_bot : IsCompl (⊤ : Submodule k V) ⊥)⟩)
 
 /-- If `V` is completely reducible and every nonzero subcomodule of `V` contains a nonzero fixed
 vector, then the fixed subcomodule is everything.


### PR DESCRIPTION
This PR proves that every normal smooth unipotent closed subgroup of `SL_n` over an algebraically closed field is trivial, identifying its defining Hopf ideal with the augmentation ideal in every natural rank. It advances the exact `TauCetiRoadmap/ReductiveGroups/README.md` Layer 6 milestone “Reductive and semisimple groups,” specifically the worked-example instruction to prove `SL_n` reductive using the geometric unipotent-radical definition.

The proof applies the existing normal-invariants theorem to the faithful standard `SL_n` comodule. In positive rank that comodule is simple and therefore completely reducible; rank zero is handled by the subsingleton module. Smoothness makes the subgroup coordinate ring reduced, geometric unipotence supplies unipotence of its algebraically closed points, and triviality of the restricted coaction plus faithfulness forces the Hopf ideal to be the augmentation ideal.

This is the most effective current step because the faithful simple standard comodule and smoothness of `SL_n` are on `main`, while open PR #4416 independently supplies geometric connectedness and explicitly leaves normal-unipotent subgroup elimination as the remaining mathematical ingredient. After this PR, the worked example needs #4416 to land and the subgroup-elimination theorem here to be transported across the standard base-change isomorphism and assembled with smoothness and connectedness into `reductiveCommHopfAlgProperty`.

Add `TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean` (117 lines). Also factor the generic facts that subsingleton and simple comodules are completely reducible into `TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.lean`, and make the existing `GL_n` proof consume them, removing 21 lines of duplicated complement arguments. The new `SL_n` proof reuses Tau Ceti’s normal-invariants, geometric point-separation, faithful-representation, and unipotent-point APIs. No Mathlib infrastructure is vendored.

The mathematical argument follows J. S. Milne, *Algebraic Groups* (2017), §§4.a, 5, 19.b and Chapter 14, and T. A. Springer, *Linear Algebraic Groups*, §§2.2 and 2.4, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-linear-normal-unipotent-subgroup-trivial"}-->

🤖 Prepared with Codex
