### PR TITLE
feat: the cumulative distribution function of a beta law

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Beta.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Beta.lean
@@ -21,7 +21,7 @@ for `Β` itself — symmetry and the unit step in the first parameter — are re
 
 These are the analytic prerequisites of
 `TauCeti/Analysis/SpecialFunctions/IncompleteBeta.lean`, and
-`TauCeti/Probability/Distributions/Beta.lean` uses the beta integral for its moment formula.
+`TauCeti/Probability/Distributions/Beta/Basic.lean` uses the beta integral for its moment formula.
 
 ## Main results
 

--- a/TauCeti/Probability/Distributions/Beta/Basic.lean
+++ b/TauCeti/Probability/Distributions/Beta/Basic.lean
@@ -21,6 +21,7 @@ moment exists.
 
 ## Main results
 
+* `TauCeti.betaPDFReal_nonneg` — nonnegativity of the density;
 * `TauCeti.integral_pow_betaMeasure` — the natural raw moments as a quotient of Gamma values;
 * `TauCeti.integral_id_betaMeasure` — the mean is `α / (α + β)`;
 * `TauCeti.variance_id_betaMeasure` — the variance is
@@ -45,7 +46,9 @@ namespace TauCeti
 open MeasureTheory ProbabilityTheory Set
 open scoped ENNReal NNReal ProbabilityTheory
 
-private lemma betaPDFReal_nonneg {α β : ℝ} (hα : 0 < α) (hβ : 0 < β) (x : ℝ) :
+/-- For positive shape parameters the beta density is nonnegative: it vanishes off the open unit
+interval, and on it the normalizing constant `ProbabilityTheory.beta α β` is positive. -/
+theorem betaPDFReal_nonneg {α β : ℝ} (hα : 0 < α) (hβ : 0 < β) (x : ℝ) :
     0 ≤ betaPDFReal α β x := by
   rw [betaPDFReal]
   split_ifs with hx

--- a/TauCeti/Probability/Distributions/Beta/Cdf.lean
+++ b/TauCeti/Probability/Distributions/Beta/Cdf.lean
@@ -18,7 +18,7 @@ parameters it is the regularized incomplete beta function `TauCeti.regularizedIn
 `I_x(α, β)`.
 
 This is the beta entry of the closed-form cdf target of
-`TauCetiRoadmap/StandardDistributions/README.md`, Layer 2, and the last one that layer asks for.
+`TauCetiRoadmap/StandardDistributions/README.md`, Layer 2.
 
 The identity holds for every real `x`, with no constraint to the unit interval: outside `[0, 1]`
 both sides are constant, because `TauCeti.regularizedIncompleteBeta` clamps its argument there.
@@ -60,10 +60,6 @@ variable {α β x : ℝ}
 
 /-! ### The cdf as an integral of the density -/
 
-/-- The `ℝ≥0∞`-valued beta density is the nonnegative wrapper of its real-valued companion. -/
-private lemma betaPDF_eq_ofReal_betaPDFReal (α β x : ℝ) :
-    betaPDF α β x = ENNReal.ofReal (betaPDFReal α β x) := rfl
-
 /-- The beta density is integrable: it is a nonnegative function whose Lebesgue integral is `1`. -/
 private lemma integrable_betaPDFReal (hα : 0 < α) (hβ : 0 < β) :
     Integrable (betaPDFReal α β) := by
@@ -78,7 +74,7 @@ private lemma cdf_betaMeasure_eq_integral (hα : 0 < α) (hβ : 0 < β) (x : ℝ
     cdf (betaMeasure α β) x = ∫ t in Iic x, betaPDFReal α β t := by
   have hp : IsProbabilityMeasure (betaMeasure α β) := isProbabilityMeasureBeta hα hβ
   rw [cdf_eq_real, betaMeasure, measureReal_def, withDensity_apply _ measurableSet_Iic]
-  simp_rw [betaPDF_eq_ofReal_betaPDFReal]
+  simp only [betaPDF]
   refine (integral_eq_lintegral_of_nonneg_ae (ae_of_all _ (betaPDFReal_nonneg hα hβ)) ?_).symm
   exact (measurable_betaPDFReal α β).aestronglyMeasurable
 
@@ -87,10 +83,8 @@ private lemma cdf_betaMeasure_eq_integral (hα : 0 < α) (hβ : 0 < β) (x : ℝ
 /-- Below the origin the beta density integrates to `0`. -/
 private lemma setIntegral_betaPDFReal_Iic_of_nonpos (α β : ℝ) (hx : x ≤ 0) :
     ∫ t in Iic x, betaPDFReal α β t = 0 := by
-  have h : ∀ t ∈ Iio x, betaPDFReal α β t = 0 := by
-    intro t ht
-    rw [betaPDFReal, ite_eq_right fun ht' => absurd ht'.1 (not_lt.mpr (ht.trans_le hx).le)]
-  rw [integral_Iic_eq_integral_Iio, setIntegral_congr_fun measurableSet_Iio h, integral_zero]
+  exact setIntegral_eq_zero_of_forall_eq_zero fun t ht ↦ by
+    rw [betaPDFReal, ite_eq_right fun ht' ↦ absurd ht'.1 (not_lt.mpr (ht.trans hx))]
 
 /-- On the support the beta density is the beta integrand divided by `Β(α, β)`, so on `[0, 1]` the
 cdf integral is the normalized integral defining `I_x(α, β)`. -/
@@ -107,6 +101,8 @@ private lemma setIntegral_betaPDFReal_Iic_of_mem_Icc (hα : 0 < α) (hβ : 0 < �
   rw [← Iic_union_Ioc_eq_Iic hx₀, setIntegral_union (Iic_disjoint_Ioc le_rfl) measurableSet_Ioc
       hint.integrableOn hint.integrableOn,
     setIntegral_betaPDFReal_Iic_of_nonpos α β le_rfl, zero_add, integral_Ioc_eq_integral_Ioo,
+    -- `hdens` fails at `t = x = 1`: there `betaPDFReal` is zero, but `0 ^ (β - 1)` is
+    -- one when `β = 1`, so drop the endpoint.
     setIntegral_congr_fun measurableSet_Ioo hdens, ← integral_Ioc_eq_integral_Ioo,
     ← intervalIntegral.integral_of_le hx₀, intervalIntegral.integral_const_mul]
   ring

--- a/TauCeti/Probability/Distributions/Beta/Cdf.lean
+++ b/TauCeti/Probability/Distributions/Beta/Cdf.lean
@@ -1,0 +1,192 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.CDF
+public import Mathlib.Probability.HasLaw
+public import TauCeti.Analysis.SpecialFunctions.IncompleteBeta
+public import TauCeti.Probability.Distributions.Beta.Basic
+
+/-!
+# The cumulative distribution function of a beta law
+
+This file computes `ProbabilityTheory.cdf (betaMeasure α β)` in closed form: for positive shape
+parameters it is the regularized incomplete beta function `TauCeti.regularizedIncompleteBeta`,
+`I_x(α, β)`.
+
+This is the beta entry of the closed-form cdf target of
+`TauCetiRoadmap/StandardDistributions/README.md`, Layer 2, and the last one that layer asks for.
+
+The identity holds for every real `x`, with no constraint to the unit interval: outside `[0, 1]`
+both sides are constant, because `TauCeti.regularizedIncompleteBeta` clamps its argument there.
+That agreement at the clamping convention is the reason the roadmap prescribes the totalization
+it does.
+
+The proof splits `Set.Iic x` at the two ends of the support. Below the origin the density
+vanishes, so the cdf is `0`; on `[0, 1]` the cdf integral is exactly the normalized beta integral
+defining `I_x(α, β)`; and above `1` the extra piece contributes nothing, so the value is Euler's
+integral divided by itself, namely `1`.
+
+## Main results
+
+* `TauCeti.cdf_betaMeasure_eq` — the closed-form cdf `I_x(α, β)`;
+* `TauCeti.measureReal_Iic_betaMeasure` — the same in measure form;
+* `TauCeti.measureReal_Ioc_betaMeasure` — the mass of a bounded interval, as a difference of two
+  values of `I_·(α, β)`;
+* `TauCeti.measureReal_Ioi_betaMeasure` — the upper tail `1 - I_x(α, β)`;
+* `TauCeti.continuous_cdf_betaMeasure` — the cdf is continuous, so a beta law has no atoms;
+* `TauCeti.measureReal_le_of_hasLaw_betaMeasure` — the random-variable corollary.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 2, the "Closed-form cdfs and
+  tails" target.
+* *NIST Digital Library of Mathematical Functions*, [§8.17](https://dlmf.nist.gov/8.17).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory Set
+
+namespace TauCeti
+
+variable {α β x : ℝ}
+
+/-! ### The cdf as an integral of the density -/
+
+/-- The beta density is integrable: it is a nonnegative function whose Lebesgue integral is `1`. -/
+private lemma integrable_betaPDFReal (hα : 0 < α) (hβ : 0 < β) :
+    Integrable (betaPDFReal α β) := by
+  refine ⟨(measurable_betaPDFReal α β).aestronglyMeasurable, ?_⟩
+  have h : ∫⁻ y, ENNReal.ofReal (betaPDFReal α β y) = 1 := lintegral_betaPDF_eq_one hα hβ
+  rw [hasFiniteIntegral_iff_ofReal (ae_of_all _ (betaPDFReal_nonneg hα hβ)), h]
+  exact ENNReal.one_lt_top
+
+/-- The cumulative distribution function of a beta law is the integral of its density over a lower
+half-line. This is the beta analogue of `ProbabilityTheory.cdf_gammaMeasure_eq_integral`. -/
+private lemma cdf_betaMeasure_eq_integral (hα : 0 < α) (hβ : 0 < β) (x : ℝ) :
+    cdf (betaMeasure α β) x = ∫ t in Iic x, betaPDFReal α β t := by
+  have hp : IsProbabilityMeasure (betaMeasure α β) := isProbabilityMeasureBeta hα hβ
+  have hpdf : ∀ y : ℝ, betaPDF α β y = ENNReal.ofReal (betaPDFReal α β y) := fun _ => rfl
+  rw [cdf_eq_real, betaMeasure, measureReal_def, withDensity_apply _ measurableSet_Iic]
+  simp_rw [hpdf]
+  refine (integral_eq_lintegral_of_nonneg_ae (ae_of_all _ (betaPDFReal_nonneg hα hβ)) ?_).symm
+  exact (measurable_betaPDFReal α β).aestronglyMeasurable
+
+/-! ### The three ranges of the support -/
+
+/-- Below the origin the beta density integrates to `0`. -/
+private lemma setIntegral_betaPDFReal_Iic_of_nonpos (α β : ℝ) (hx : x ≤ 0) :
+    ∫ t in Iic x, betaPDFReal α β t = 0 := by
+  have h : ∀ t ∈ Iio x, betaPDFReal α β t = 0 := by
+    intro t ht
+    rw [betaPDFReal, ite_eq_right fun ht' => absurd ht'.1 (not_lt.mpr (ht.trans_le hx).le)]
+  rw [integral_Iic_eq_integral_Iio, setIntegral_congr_fun measurableSet_Iio h, integral_zero]
+
+/-- On the support the beta density is the beta integrand divided by `Β(α, β)`, so on `[0, 1]` the
+cdf integral is the normalized integral defining `I_x(α, β)`. -/
+private lemma setIntegral_betaPDFReal_Iic_of_mem_Icc (hα : 0 < α) (hβ : 0 < β) (hx₀ : 0 ≤ x)
+    (hx₁ : x ≤ 1) :
+    ∫ t in Iic x, betaPDFReal α β t =
+      (∫ t in (0 : ℝ)..x, t ^ (α - 1) * (1 - t) ^ (β - 1)) / beta α β := by
+  have hint := integrable_betaPDFReal hα hβ
+  have hdens : ∀ t ∈ Ioo (0 : ℝ) x,
+      betaPDFReal α β t = (1 / beta α β) * (t ^ (α - 1) * (1 - t) ^ (β - 1)) := by
+    intro t ht
+    rw [betaPDFReal, ite_eq_left ⟨ht.1, ht.2.trans_le hx₁⟩]
+    ring
+  rw [← Iic_union_Ioc_eq_Iic hx₀, setIntegral_union (Iic_disjoint_Ioc le_rfl) measurableSet_Ioc
+      hint.integrableOn hint.integrableOn,
+    setIntegral_betaPDFReal_Iic_of_nonpos α β le_rfl, zero_add, integral_Ioc_eq_integral_Ioo,
+    setIntegral_congr_fun measurableSet_Ioo hdens, ← integral_Ioc_eq_integral_Ioo,
+    ← intervalIntegral.integral_of_le hx₀, intervalIntegral.integral_const_mul]
+  ring
+
+/-- Above the support the beta density contributes nothing, so the cdf integral is Euler's beta
+integral divided by `Β(α, β)`, namely `1`. -/
+private lemma setIntegral_betaPDFReal_Iic_of_one_le (hα : 0 < α) (hβ : 0 < β) (hx : 1 ≤ x) :
+    ∫ t in Iic x, betaPDFReal α β t = 1 := by
+  have hint := integrable_betaPDFReal hα hβ
+  have hzero : ∀ t ∈ Ioc (1 : ℝ) x, betaPDFReal α β t = 0 := by
+    intro t ht
+    rw [betaPDFReal, ite_eq_right fun ht' => absurd ht'.2 (not_lt.mpr ht.1.le)]
+  rw [← Iic_union_Ioc_eq_Iic hx, setIntegral_union (Iic_disjoint_Ioc le_rfl) measurableSet_Ioc
+      hint.integrableOn hint.integrableOn,
+    setIntegral_congr_fun measurableSet_Ioc hzero, integral_zero, add_zero,
+    setIntegral_betaPDFReal_Iic_of_mem_Icc hα hβ zero_le_one le_rfl,
+    integral_rpow_mul_one_sub_rpow hα hβ, div_self (beta_pos hα hβ).ne']
+
+/-! ### The closed form -/
+
+/-- The cumulative distribution function of the beta law with positive shape parameters `α` and
+`β` is the regularized incomplete beta function, `I_x(α, β)`.
+
+No constraint on `x` is needed: outside `[0, 1]` both sides are constant, which is exactly the
+clamping convention built into `TauCeti.regularizedIncompleteBeta`. -/
+@[simp]
+theorem cdf_betaMeasure_eq (hα : 0 < α) (hβ : 0 < β) (x : ℝ) :
+    cdf (betaMeasure α β) x = regularizedIncompleteBeta α β x := by
+  rw [cdf_betaMeasure_eq_integral hα hβ]
+  rcases le_or_gt x 0 with hx | hx
+  · rw [setIntegral_betaPDFReal_Iic_of_nonpos α β hx,
+      regularizedIncompleteBeta_eq_zero_of_nonpos hα.ne' β hx]
+  rcases le_or_gt x 1 with hx₁ | hx₁
+  · rw [setIntegral_betaPDFReal_Iic_of_mem_Icc hα hβ hx.le hx₁,
+      regularizedIncompleteBeta_def_of_mem_Icc hα hβ ⟨hx.le, hx₁⟩]
+  · rw [setIntegral_betaPDFReal_Iic_of_one_le hα hβ hx₁.le,
+      regularizedIncompleteBeta_eq_one_of_one_le hα.le hβ hx₁.le]
+
+/-! ### Consequences -/
+
+/-- The mass a beta law assigns to a lower half-line, in measure form. -/
+@[simp]
+theorem measureReal_Iic_betaMeasure (hα : 0 < α) (hβ : 0 < β) (x : ℝ) :
+    (betaMeasure α β).real (Iic x) = regularizedIncompleteBeta α β x := by
+  have hp : IsProbabilityMeasure (betaMeasure α β) := isProbabilityMeasureBeta hα hβ
+  rw [← cdf_eq_real]
+  exact cdf_betaMeasure_eq hα hβ x
+
+/-- The mass a beta law assigns to a bounded interval is the increment of `I_·(α, β)`. -/
+@[simp]
+theorem measureReal_Ioc_betaMeasure (hα : 0 < α) (hβ : 0 < β) {y : ℝ} (hyx : y ≤ x) :
+    (betaMeasure α β).real (Ioc y x) =
+      regularizedIncompleteBeta α β x - regularizedIncompleteBeta α β y := by
+  have hp : IsProbabilityMeasure (betaMeasure α β) := isProbabilityMeasureBeta hα hβ
+  have hunion : (betaMeasure α β).real (Iic y) + (betaMeasure α β).real (Ioc y x) =
+      (betaMeasure α β).real (Iic x) := by
+    rw [← measureReal_union (Iic_disjoint_Ioc le_rfl) measurableSet_Ioc, Iic_union_Ioc_eq_Iic hyx]
+  rw [measureReal_Iic_betaMeasure hα hβ x, measureReal_Iic_betaMeasure hα hβ y] at hunion
+  linarith
+
+/-- The upper tail of a beta law is `1 - I_x(α, β)`. -/
+@[simp]
+theorem measureReal_Ioi_betaMeasure (hα : 0 < α) (hβ : 0 < β) (x : ℝ) :
+    (betaMeasure α β).real (Ioi x) = 1 - regularizedIncompleteBeta α β x := by
+  have hp : IsProbabilityMeasure (betaMeasure α β) := isProbabilityMeasureBeta hα hβ
+  rw [← compl_Iic, measureReal_compl measurableSet_Iic, measureReal_Iic_betaMeasure hα hβ]
+  simp
+
+/-- The cumulative distribution function of a beta law is continuous: `I_·(α, β)` is continuous
+even at the two endpoints of the support, where for `α < 1` or `β < 1` the beta integrand blows
+up. -/
+theorem continuous_cdf_betaMeasure (hα : 0 < α) (hβ : 0 < β) :
+    Continuous (cdf (betaMeasure α β)) := by
+  have h : ⇑(cdf (betaMeasure α β)) = regularizedIncompleteBeta α β :=
+    funext (cdf_betaMeasure_eq hα hβ)
+  rw [h]
+  exact continuous_regularizedIncompleteBeta hα hβ
+
+/-- A random variable with a beta law has the regularized incomplete beta function as its
+cumulative distribution function. -/
+theorem measureReal_le_of_hasLaw_betaMeasure {Ω : Type*} [MeasurableSpace Ω] {P : Measure Ω}
+    {X : Ω → ℝ} (hα : 0 < α) (hβ : 0 < β) (hX : HasLaw X (betaMeasure α β) P) (x : ℝ) :
+    P.real {ω | X ω ≤ x} = regularizedIncompleteBeta α β x := by
+  rw [hX.measureReal_eq (p := fun y : ℝ => y ≤ x) measurableSet_Iic, Set.Iic_def]
+  exact measureReal_Iic_betaMeasure hα hβ x
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Beta/Cdf.lean
+++ b/TauCeti/Probability/Distributions/Beta/Cdf.lean
@@ -44,6 +44,7 @@ integral divided by itself, namely `1`.
 
 * Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 2, the "Closed-form cdfs and
   tails" target.
+* Formal template: `TauCeti/Probability/Distributions/Gamma/Cdf.lean`.
 * *NIST Digital Library of Mathematical Functions*, [§8.17](https://dlmf.nist.gov/8.17).
 -/
 

--- a/TauCeti/Probability/Distributions/Beta/Cdf.lean
+++ b/TauCeti/Probability/Distributions/Beta/Cdf.lean
@@ -60,6 +60,10 @@ variable {α β x : ℝ}
 
 /-! ### The cdf as an integral of the density -/
 
+/-- The `ℝ≥0∞`-valued beta density is the nonnegative wrapper of its real-valued companion. -/
+private lemma betaPDF_eq_ofReal_betaPDFReal (α β x : ℝ) :
+    betaPDF α β x = ENNReal.ofReal (betaPDFReal α β x) := rfl
+
 /-- The beta density is integrable: it is a nonnegative function whose Lebesgue integral is `1`. -/
 private lemma integrable_betaPDFReal (hα : 0 < α) (hβ : 0 < β) :
     Integrable (betaPDFReal α β) := by
@@ -73,9 +77,8 @@ half-line. This is the beta analogue of `ProbabilityTheory.cdf_gammaMeasure_eq_i
 private lemma cdf_betaMeasure_eq_integral (hα : 0 < α) (hβ : 0 < β) (x : ℝ) :
     cdf (betaMeasure α β) x = ∫ t in Iic x, betaPDFReal α β t := by
   have hp : IsProbabilityMeasure (betaMeasure α β) := isProbabilityMeasureBeta hα hβ
-  have hpdf : ∀ y : ℝ, betaPDF α β y = ENNReal.ofReal (betaPDFReal α β y) := fun _ => rfl
   rw [cdf_eq_real, betaMeasure, measureReal_def, withDensity_apply _ measurableSet_Iic]
-  simp_rw [hpdf]
+  simp_rw [betaPDF_eq_ofReal_betaPDFReal]
   refine (integral_eq_lintegral_of_nonneg_ae (ae_of_all _ (betaPDFReal_nonneg hα hβ)) ?_).symm
   exact (measurable_betaPDFReal α β).aestronglyMeasurable
 


### PR DESCRIPTION
This PR computes the cumulative distribution function of Mathlib's `betaMeasure` in closed form: for positive shape parameters `α`, `β` and *every* real `x`, `cdf (betaMeasure α β) x = regularizedIncompleteBeta α β x`. This is the beta entry of the "Closed-form cdfs and tails" target of `TauCetiRoadmap/StandardDistributions/README.md`, Layer 2 — the key declaration `cdf_betaMeasure_eq`, which asks for exactly "for valid gamma and beta parameters and every `x`, … `cdf (betaMeasure a b) x = regularizedIncompleteBeta a b x`; the special functions are clamped below the support". It is the last unstarted item of Layer 2: of that layer's eleven key declarations, `lowerIncompleteGamma`, `regularizedGamma`, `regularizedIncompleteBeta`, `Real.erf`, `Real.erfc`, `cdf_gaussianReal_eq`, `cdf_gaussianReal_zero`, `cdf_gammaMeasure_eq` and `binomial_tail_eq_regularizedIncompleteBeta` are already on `main`, and `poissonMeasure_tail_eq_regularizedGamma` is in flight as #4509, so after this PR and that one Layer 2 is complete and Layer 3's new scalar families — whose closed-form cdfs the roadmap's ordering section says "require Layer 2" — are unblocked.

No hypothesis on `x` is needed, because `TauCeti.regularizedIncompleteBeta` clamps its argument to `[0, 1]`: below the origin both sides are `0` and above `1` both sides are `1`. The proof splits `Set.Iic x` at the two ends of the support. Below the origin the density vanishes on `Set.Iio x`, so the cdf integral is `0`; on `[0, 1]` the cdf integral is, after `MeasureTheory.integral_Ioc_eq_integral_Ioo` dodges the endpoint at which `betaPDFReal` switches branch, exactly the normalized beta integral that defines `I_x(α, β)`; and above `1` the extra piece `Set.Ioc 1 x` contributes nothing, so the value is Euler's beta integral divided by `ProbabilityTheory.beta α β`, namely `1`. The three ranges match the three defining branches of `regularizedIncompleteBeta`, so no case is discharged twice.

Alongside the closed form the file records the measure-level restatements the roadmap's `HasLaw` convention asks for: `measureReal_Iic_betaMeasure`, the bounded-interval mass `measureReal_Ioc_betaMeasure` as an increment of `I_·(α, β)`, the upper tail `measureReal_Ioi_betaMeasure`, the continuity of the cdf, and the random-variable corollary `measureReal_le_of_hasLaw_betaMeasure`. This is the same shape as the gamma entry of the same target, `TauCeti/Probability/Distributions/Gamma/Cdf.lean` (#4415).

Mathlib supplies no `cdf_betaMeasure_eq_integral` — the analogue it has for `gammaMeasure`, `expMeasure` and `paretoMeasure` — so this PR proves it as a private lemma; the closed form is strictly stronger under the same hypotheses, so it is not published as separate API. The one existing declaration that changes status is `TauCeti.betaPDFReal_nonneg`, promoted from `private` to a documented public theorem because the new file needs it; Mathlib has `betaPDFReal_pos` only on the open unit interval, and re-proving the nonnegativity in the new file would duplicate it.

Because `TauCeti/Probability/Distributions/Beta.lean` and the new `Beta/Cdf.lean` would otherwise be two flat `Beta*` siblings, the family gets a directory in this PR, following the same move already made for `Gamma`, `Binomial` and `Poisson`:

| old module | new module |
| --- | --- |
| `TauCeti.Probability.Distributions.Beta` | `TauCeti.Probability.Distributions.Beta.Basic` |

No TauCeti module imported the old path, so the move touches only the module header and one docstring cross-reference in `TauCeti/Analysis/SpecialFunctions/Beta.lean`; no declaration is renamed.

Files: `TauCeti/Probability/Distributions/Beta/Cdf.lean` (192 lines, new), `TauCeti/Probability/Distributions/Beta/Basic.lean` (moved, 5 lines changed), `TauCeti/Analysis/SpecialFunctions/Beta.lean` (1 line changed).

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"cdf-betameasure-eq"}-->

🤖 Prepared with Claude Code
