### PR TITLE
feat: the CAR module of gl n on its Clifford algebra

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Algebra.Lie.GeneralLinear.TraceForm
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Lie.Representation
 import Mathlib.Algebra.Lie.Classical
+import TauCeti.LinearAlgebra.CliffordAlgebra.Vectors
 
 /-!
 # The quadratic Clifford lift of the general linear Lie algebra
@@ -24,6 +25,9 @@ corresponding Clifford algebra.
 * `TauCeti.glCliffordHom_single`: its formula on matrix units.
 * `TauCeti.glCliffordHom_normalOrdering`: its decomposition into bivectors and the central
   normal-ordering constant.
+* `TauCeti.glCliffordHom_injective`: it is injective once `Fintype.card n` is invertible, which
+  the quadratic part alone is not — the centre of `gl n K` is what the normal-ordering constant
+  separates.
 
 ## References
 
@@ -223,5 +227,71 @@ theorem glCliffordHom_single (i j : n) :
     rw [← hcentral]
     rw [Finset.sum_add_distrib, smul_add]
   · simp [h, Finset.smul_sum]
+
+/-! ### Injectivity -/
+
+/-- A matrix annihilated by the normal-ordered lift is central: the lift acts on Clifford
+generators by the matrix commutator, and the generators are a faithful copy of the matrices. -/
+private theorem commute_of_glCliffordHom_eq_zero {X : Matrix n n K}
+    (hX : glCliffordHom (K := K) (n := n) X = 0) (Y : Matrix n n K) : Commute Y X := by
+  have h : ι (traceQuadraticForm K n) ⁅X, Y⁆ = 0 := by
+    rw [← glCliffordHom_lie_ι, hX, zero_lie]
+  have hXY : ⁅X, Y⁆ = 0 := by rwa [ι_eq_zero_iff] at h
+  rw [Ring.lie_def, sub_eq_zero] at hXY
+  exact hXY.symm
+
+/-- On a central matrix the lift is its normal-ordering constant alone: the adjoint action the
+quadratic part lifts already vanishes there. -/
+private theorem glCliffordHom_eq_algebraMap_of_commute {X : Matrix n n K}
+    (hX : ∀ Y : Matrix n n K, Commute Y X) :
+    glCliffordHom (K := K) (n := n) X =
+      algebraMap K (CliffordAlgebra (traceQuadraticForm K n))
+        ((Fintype.card n / 2 : K) * X.trace) := by
+  have hzero : traceAdjointSO K n X = 0 := by
+    refine Subtype.ext (LinearMap.ext fun Y => ?_)
+    rw [coe_traceAdjointSO, _root_.LieAlgebra.ad_apply, Ring.lie_def, (hX Y).eq, sub_self]
+    rfl
+  rw [glCliffordHom_apply, CliffordAlgebra.quadraticLift_apply, hzero, map_zero,
+    ZeroMemClass.coe_zero, zero_add]
+
+/-- **The normal-ordered lift is injective as soon as `Fintype.card n` is invertible in `K`.**
+The adjoint action of `gl n K` is not faithful — its kernel is the centre, the scalar matrices
+(`TauCeti.ker_traceAdjointSO`) — so the quadratic part alone is not injective; this is the
+reductive-not-semisimple behaviour that distinguishes `gl n K` from a Killing-semisimple Lie
+algebra, where `CliffordAlgebra.adjointCliffordHom_injective` needs no hypothesis. It is the
+normal-ordering constant that repairs it: on the scalar matrix `r • 1` the lift is the scalar
+`(card n) ^ 2 * r / 2`, nonzero exactly when `r` is. The hypothesis is not removable, since in
+characteristic dividing `card n` those scalar matrices are again killed. -/
+theorem glCliffordHom_injective (h : (Fintype.card n : K) ≠ 0) :
+    Function.Injective (glCliffordHom (K := K) (n := n)) := by
+  have key : ∀ X : Matrix n n K, glCliffordHom (K := K) (n := n) X = 0 → X = 0 := by
+    intro X hX
+    have hcomm := commute_of_glCliffordHom_eq_zero hX
+    obtain ⟨r, hr⟩ :=
+      Matrix.mem_range_scalar_iff_commute_single'.mpr fun i j => hcomm (Matrix.single i j 1)
+    have htrace : X.trace = r * Fintype.card n := by
+      rw [← hr]
+      simp [Matrix.scalar_apply, Matrix.trace_diagonal, mul_comm]
+    have hscalar :
+        algebraMap K (CliffordAlgebra (traceQuadraticForm K n))
+          ((Fintype.card n / 2 : K) * X.trace) = 0 := by
+      rw [← glCliffordHom_eq_algebraMap_of_commute hcomm, hX]
+    have hcoef : (Fintype.card n / 2 : K) * X.trace = 0 :=
+      ((ι_eq_algebraMap_iff (traceQuadraticForm K n) 0
+        ((Fintype.card n / 2 : K) * X.trace)).mp (by rw [map_zero, hscalar])).2
+    rw [htrace] at hcoef
+    have hr0 : r = 0 := by
+      rcases mul_eq_zero.mp hcoef with hc | hc
+      · rcases div_eq_zero_iff.mp hc with hc | hc
+        · exact absurd hc h
+        · exact absurd hc (Invertible.ne_zero (2 : K))
+      · rcases mul_eq_zero.mp hc with hc | hc
+        · exact hc
+        · exact absurd hc h
+    rw [← hr, hr0]
+    simp
+  intro X Y hXY
+  have h0 : glCliffordHom (K := K) (n := n) (X - Y) = 0 := by rw [map_sub, hXY, sub_self]
+  exact sub_eq_zero.mp (key _ h0)
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/Fock.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Fock.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.Clifford
+public import TauCeti.Algebra.Lie.OfAssociative
+import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
+
+/-!
+# The CAR module: the Clifford algebra of the trace form of `gl n`, left-regularly
+
+The adjoint action of `gl n K` preserves its trace form, so it lifts to the Clifford algebra of
+that form; adding the normal-ordering constant makes the lift the homomorphism
+`TauCeti.glCliffordHom`, whose value on a matrix unit is `Eᵢⱼ ↦ ½ ∑ₖ dᵢₖ dₖⱼ`. This file installs
+the `gl n K`-module structure that the `gl n` instance of Kostant's isotypy theorem is about: the
+Clifford algebra acted on by **left multiplication** by that lift,
+
+`⁅X, c⁆ = glCliffordHom X * c`.
+
+The carrier is the **fermionic Fock space**: `CliffordAlgebra.equivExterior` identifies it with
+`⋀(gl n K)`, of dimension `2 ^ N²` for `N` the cardinality of `n`
+(`TauCeti.finrank_cliffordAlgebra_traceQuadraticForm`).
+
+This is the trace-form sibling of `CliffordAlgebra.kostantLieRingModule`, the left-regular module
+of the Killing form of a Killing-semisimple Lie algebra, and everything structural is shared with
+it: the same `LieHom.leftRegularRep` builds the action, so the same right multiplications are
+intertwiners (`TauCeti.carRightMul`) and the same left ideals are submodules
+(`TauCeti.carLieSubmoduleOfLeftIdeal`). What is *not* shared is faithfulness. The Killing case is
+faithful outright, because the centre of a Killing-semisimple Lie algebra vanishes; `gl n K` is
+reductive and not semisimple, its centre is the scalar matrices, and the quadratic part of the
+lift therefore has a kernel (`TauCeti.ker_traceAdjointSO`). The normal-ordering constant repairs
+that, but only when `N` is invertible in `K` (`TauCeti.glCliffordHom_injective`), so
+`TauCeti.carLieModule_isFaithful` carries the hypothesis `(Fintype.card n : K) ≠ 0` too.
+
+As in the Killing case the two instances are `scoped`, because the same lift produces a second,
+competing `gl n K`-module structure on the same carrier: the inner derivation action
+`⁅X, c⁆ = ⁅glCliffordHom X, c⁆` of `CliffordAlgebra.cliffordDerivationRep`, which differs from this
+one by a right multiplication (`TauCeti.car_lie_sub_mul`) and is not the isotypic action. Write
+`open scoped TauCeti` to use them.
+
+## Main definitions
+
+* `TauCeti.carLieRingModule` and `TauCeti.carLieModule`: the scoped left-regular
+  `gl n K`-module structure on `CliffordAlgebra (TauCeti.traceQuadraticForm K n)`.
+* `TauCeti.carRightMul`: right multiplication, as an endomorphism of that module.
+* `TauCeti.carLieSubmoduleOfLeftIdeal`: a left ideal, as a Lie submodule.
+
+## Main results
+
+* `TauCeti.car_lie_def`: the defining equation of the action.
+* `TauCeti.car_lie_ι`: its value on a Clifford generator, where the matrix commutator reappears
+  together with a right-multiplication term.
+* `TauCeti.car_lie_sub_mul`: the comparison with the inner derivation action.
+* `TauCeti.carLieModule_isFaithful`: the module is faithful once `Fintype.card n` is invertible,
+  which is exactly `TauCeti.glCliffordHom_injective`.
+* `TauCeti.finrank_cliffordAlgebra_traceQuadraticForm`: the Fock space has dimension `2 ^ N²`.
+
+## References
+
+This implements the "CAR module" target (`carLieRingModule`, `carLieModule`, `car_lie_def`) of the
+`gl_N` worked instance of Layer 9 in
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`.
+
+* D. Panyushev, *On the irreducibility of the Clifford module of a semisimple Lie algebra*,
+  Prop. 2.4 and Ex. 2.5(1).
+* B. Kostant, *Clifford algebra analogue of the Hopf--Koszul--Samelson theorem*, Adv. Math. 125
+  (1997), 275--350.
+-/
+
+public section
+
+namespace TauCeti
+
+open CliffordAlgebra
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+attribute [local instance] Classical.decEq
+
+variable {K n : Type*} [Field K] [Fintype n] [Invertible (2 : K)]
+
+/-- **The CAR module.** The Clifford algebra of the trace form of `gl n K`, acted on by `gl n K`
+through left multiplication by the normal-ordered quadratic lift. Scoped: the inner derivation
+action of `CliffordAlgebra.cliffordDerivationRep` is a competing `gl n K`-module structure on the
+same carrier, so neither may be global. -/
+noncomputable scoped instance carLieRingModule :
+    LieRingModule (Matrix n n K) (CliffordAlgebra (traceQuadraticForm K n)) :=
+  LieRingModule.compLieHom _ (LieHom.leftRegularRep (glCliffordHom (K := K) (n := n)))
+
+/-- The CAR module is a Lie module over the base field. -/
+noncomputable scoped instance carLieModule :
+    LieModule K (Matrix n n K) (CliffordAlgebra (traceQuadraticForm K n)) :=
+  LieModule.compLieHom _ (LieHom.leftRegularRep (glCliffordHom (K := K) (n := n)))
+
+/-- **The defining equation of the CAR module**: `gl n K` acts by left multiplication by the
+normal-ordered quadratic lift. -/
+@[simp, grind =]
+theorem car_lie_def (X : Matrix n n K) (c : CliffordAlgebra (traceQuadraticForm K n)) :
+    ⁅X, c⁆ = glCliffordHom X * c :=
+  LieHom.leftRegularRep_apply _ X c
+
+/-- **The action on a Clifford generator.** The matrix commutator is visible in the CAR module, but
+only up to a right-multiplication term: left multiplication is not the derivation action. Not a
+`simp` lemma: `TauCeti.car_lie_def` already rewrites its left-hand side, so `simp` would never see
+this one in simp-normal form. -/
+@[grind =]
+theorem car_lie_ι (X Y : Matrix n n K) :
+    ⁅X, ι (traceQuadraticForm K n) Y⁆ =
+      ι (traceQuadraticForm K n) ⁅X, Y⁆ +
+        ι (traceQuadraticForm K n) Y * glCliffordHom X := by
+  have h := glCliffordHom_lie_ι (K := K) (n := n) X Y
+  rw [LieRing.of_associative_ring_bracket] at h
+  rw [car_lie_def, ← h, sub_add_cancel]
+
+/-- **The CAR action minus right multiplication is the inner derivation action.** This is the
+precise sense in which the left-regular module and the exterior extension of the adjoint
+representation are different modules on the same carrier; it is the pointwise form of
+`LieHom.ad_apply_eq_leftRegularRep_sub_mulRight` for the normal-ordered quadratic lift. -/
+theorem car_lie_sub_mul (X : Matrix n n K) (c : CliffordAlgebra (traceQuadraticForm K n)) :
+    ⁅X, c⁆ - c * glCliffordHom X = ⁅glCliffordHom X, c⁆ :=
+  (congrArg (fun f : Module.End K (CliffordAlgebra (traceQuadraticForm K n)) ↦ f c)
+    (LieHom.ad_apply_eq_leftRegularRep_sub_mulRight (glCliffordHom (K := K) (n := n)) X)).symm
+
+/-- **Right multiplication is an endomorphism of the CAR module.** Associativity of the Clifford
+algebra says that left and right multiplications commute, so every right multiplication lies in
+the commutant of the action; this is the supply of intertwiners behind the isotypy statement. -/
+noncomputable def carRightMul (d : CliffordAlgebra (traceQuadraticForm K n)) :
+    CliffordAlgebra (traceQuadraticForm K n) →ₗ⁅K, Matrix n n K⁆
+      CliffordAlgebra (traceQuadraticForm K n) where
+  __ := LinearMap.mulRight K d
+  map_lie' {X c} :=
+    (congrArg (fun f : Module.End K (CliffordAlgebra (traceQuadraticForm K n)) ↦ f c)
+      (LieHom.leftRegularRep_comp_mulRight (glCliffordHom (K := K) (n := n)) X d)).symm
+
+@[simp, grind =]
+theorem carRightMul_apply (d c : CliffordAlgebra (traceQuadraticForm K n)) :
+    carRightMul d c = c * d :=
+  (rfl)
+
+/-- **A left ideal of the Clifford algebra is a Lie submodule of the CAR module.** The action is by
+left multiplication, which a left ideal absorbs, so every left ideal is an invariant subspace. -/
+noncomputable def carLieSubmoduleOfLeftIdeal
+    (I : Submodule (CliffordAlgebra (traceQuadraticForm K n))
+      (CliffordAlgebra (traceQuadraticForm K n))) :
+    LieSubmodule K (Matrix n n K) (CliffordAlgebra (traceQuadraticForm K n)) where
+  __ := I.restrictScalars K
+  lie_mem {X _} h := LieHom.leftRegularRep_mem_of_mem (glCliffordHom (K := K) (n := n)) I X h
+
+@[simp, grind =]
+theorem mem_carLieSubmoduleOfLeftIdeal
+    {I : Submodule (CliffordAlgebra (traceQuadraticForm K n))
+      (CliffordAlgebra (traceQuadraticForm K n))}
+    {c : CliffordAlgebra (traceQuadraticForm K n)} :
+    c ∈ carLieSubmoduleOfLeftIdeal I ↔ c ∈ I :=
+  Iff.rfl
+
+/-! ### Faithfulness through the normal-ordering constant -/
+
+/-- **The CAR module is faithful when `N` is invertible in `K`.** Acting on `1` recovers the
+normal-ordered quadratic lift, so faithfulness is exactly its injectivity. -/
+theorem carLieModule_isFaithful (h : (Fintype.card n : K) ≠ 0) :
+    LieModule.IsFaithful K (Matrix n n K) (CliffordAlgebra (traceQuadraticForm K n)) where
+  injective_toEnd _ _ hXY :=
+    (LieHom.leftRegularRep_injective_iff (glCliffordHom (K := K) (n := n))).2
+      (glCliffordHom_injective h) <|
+      LinearMap.ext fun c =>
+        congrArg (fun f : Module.End K (CliffordAlgebra (traceQuadraticForm K n)) ↦ f c) hXY
+
+/-! ### The Fock space -/
+
+variable (K n) in
+/-- **The carrier of the CAR module is the fermionic Fock space `⋀(gl n K)`**, of dimension
+`2 ^ N²`: the Clifford algebra of any quadratic form on a finite free module has rank two to the
+rank of the module, and `gl n K` has rank `N²`. -/
+theorem finrank_cliffordAlgebra_traceQuadraticForm :
+    Module.finrank K (CliffordAlgebra (traceQuadraticForm K n))
+      = 2 ^ (Fintype.card n * Fintype.card n) := by
+  rw [CliffordAlgebra.finrank_eq_two_pow, Module.finrank_matrix, Module.finrank_self, mul_one]
+
+end TauCeti


### PR DESCRIPTION
This PR installs the CAR module of `gl n K`: the Clifford algebra of the trace form, acted on by `gl n K` through **left multiplication** by the normal-ordered quadratic lift `TauCeti.glCliffordHom`, so `⁅X, c⁆ = glCliffordHom X * c`. This is the setting the `gl_N` instance of Kostant's isotypy corollary is stated in, and the trace-form sibling of the Killing-form module `CliffordAlgebra.kostantLieRingModule` that landed in #4419. The new file `TauCeti/Algebra/Lie/GeneralLinear/Fock.lean` (183 lines) supplies the two scoped instances `TauCeti.carLieRingModule` and `TauCeti.carLieModule`, the defining equation `TauCeti.car_lie_def`, the value on a Clifford generator `TauCeti.car_lie_ι` (the matrix commutator, up to a right-multiplication term), the comparison `TauCeti.car_lie_sub_mul` with the competing inner derivation action of `CliffordAlgebra.cliffordDerivationRep`, right multiplication as an intertwiner `TauCeti.carRightMul`, left ideals as Lie submodules `TauCeti.carLieSubmoduleOfLeftIdeal`, faithfulness `TauCeti.carLieModule_isFaithful`, and the dimension `2 ^ N²` of the fermionic Fock space carrier.

The structural half is shared with the Killing case and is built from the same generic device `LieHom.leftRegularRep`, so nothing is reproved; what is genuinely different is faithfulness. A Killing-semisimple Lie algebra has vanishing centre, so `CliffordAlgebra.adjointCliffordHom_injective` needs no hypothesis. `gl n K` is reductive and not semisimple: its centre is the scalar matrices, and the quadratic part of the lift therefore has a kernel (`TauCeti.ker_traceAdjointSO`). It is the normal-ordering constant that separates that centre, sending `r • 1` to the scalar `(card n) ^ 2 * r / 2`, so the new `TauCeti.glCliffordHom_injective` carries the hypothesis `(Fintype.card n : K) ≠ 0` — not removable, since in characteristic dividing `card n` those scalar matrices are killed again — and the module is faithful under the same hypothesis. That injectivity lemma is a fact about the lift, so it is placed beside it in the existing `TauCeti/Algebra/Lie/GeneralLinear/Clifford.lean` (+70 lines, one new non-public import of `TauCeti.LinearAlgebra.CliffordAlgebra.Vectors` for the generator-injectivity facts its proof uses) rather than in the new module; no existing declaration is renamed, moved, or deleted.

The target is `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`, Layer 9, the worked instance "`gl_N` on `M_N(ℂ)` (the CAR algebra)", whose `Suggested.lean` pins exactly `carLieRingModule`, `carLieModule` and `car_lie_def` as "**The CAR module**: `Cliff(M_N)` as a `gl_N`-module under left multiplication by `glCliffordHom` ...; `equivExterior` identifies the carrier with the fermionic Fock space `⋀(M_N)` of dimension `2^{N²}`". The pinned signatures are stated over `ℂ` for `n = Fin N`; the module here is stated over a field `K` with `2` invertible and an arbitrary `Fintype n`, the generality `TauCeti.glCliffordHom` already carries, and specializes to the pinned form. The isotypy theorems `car_isotypic` and `car_multiplicity` that this module is the setting for are not proved here. No Mathlib code is vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"carlieringmodule"}-->

🤖 Prepared with Claude Code
