### PR TITLE
feat: identify the along-curve derivative of a pulled-back vector field

### DIFF
--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Basic.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Basic.lean
@@ -28,8 +28,8 @@ set `s`, so that the construction applies on a closed interval as well as on all
 unrestricted operator is the `s = Set.univ` case, exactly as Mathlib's `fderiv` is the
 `Set.univ` case of `fderivWithin`.  This first part of the along-curve API proves the
 characteristic additive and scalar Leibniz laws, locality in the field and parameter set, and
-naturality under differentiable reparametrization.  A subsequent file will identify the formula
-in an arbitrary fixed chart and compare it with the ambient covariant derivative of a pulled-back
+naturality under differentiable reparametrization.  `AlongCurve/Pullback.lean` identifies the
+formula in an arbitrary fixed chart and with the ambient covariant derivative of a pulled-back
 vector field.
 
 ## Main definitions and results

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Basic.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Basic.lean
@@ -28,9 +28,9 @@ set `s`, so that the construction applies on a closed interval as well as on all
 unrestricted operator is the `s = Set.univ` case, exactly as Mathlib's `fderiv` is the
 `Set.univ` case of `fderivWithin`.  This first part of the along-curve API proves the
 characteristic additive and scalar Leibniz laws, locality in the field and parameter set, and
-naturality under differentiable reparametrization.  `AlongCurve/Pullback.lean` identifies the
-formula in an arbitrary fixed chart and with the ambient covariant derivative of a pulled-back
-vector field.
+naturality under differentiable reparametrization.  For a field pulled back from an ambient vector
+field, `AlongCurve/Pullback.lean` identifies the formula in an arbitrary fixed chart and with the
+ambient covariant derivative.
 
 ## Main definitions and results
 
@@ -92,9 +92,11 @@ variable (cov : _root_.CovariantDerivative I E (fun x : M ↦ TangentSpace I x))
 within the parameter set `s`: `v' + Γ(v, u')`, where `u = extChartAt I x ∘ γ` and
 `v = sectionCoord γ V x` are the coordinate readings of the curve and the field, their
 derivatives are taken within `s`, and `Γ` is the Christoffel map of `cov` in the local frame of
-the fixed basis `Module.finBasis 𝕜 E`.  This is only a candidate for the covariant derivative until
-its chart independence and agreement with an ambient derivative are established.  When the
-coordinate readings are not differentiable within `s` at `t`, `UniqueDiffWithinAt 𝕜 s t` fails,
+the fixed basis `Module.finBasis 𝕜 E`.  Its chart independence and agreement with an ambient
+derivative are established for fields pulled back from ambient vector fields by
+`CovariantDerivative.symmL_alongCurveInChartWithin_pullback`; they remain open here for a general
+section along the curve.  When the coordinate readings are not differentiable within `s` at `t`,
+`UniqueDiffWithinAt 𝕜 s t` fails,
 or `γ` does not stay in `(trivializationAt E (TangentSpace I) x).baseSet` near `t` within `s`, its
 components may carry their junk value `0`. -/
 def alongCurveInChartWithin (s : Set 𝕜) (x : M) (t : 𝕜) : E :=
@@ -113,10 +115,11 @@ theorem alongCurveInChartWithin_apply (s : Set 𝕜) (x : M) (t : 𝕜) :
   (rfl)
 
 /-- The moving-chart candidate for the covariant derivative of `V` along `γ` within the parameter
-set `s`, transported from the model space to `TangentSpace I (γ t)`.  Its identification with a
-chart-independent covariant derivative is deferred; it inherits the junk values of
-`alongCurveInChartWithin`.  The Christoffel map is read in the local frame of the fixed basis
-`Module.finBasis 𝕜 E`. -/
+set `s`, transported from the model space to `TangentSpace I (γ t)`.  Its identification with the
+ambient covariant derivative is established for pulled-back fields by
+`CovariantDerivative.alongCurveWithin_pullback`; it remains open here for a general section along
+the curve.  It inherits the junk values of `alongCurveInChartWithin`.  The Christoffel map is read
+in the local frame of the fixed basis `Module.finBasis 𝕜 E`. -/
 def alongCurveWithin (s : Set 𝕜) (t : 𝕜) : TangentSpace I (γ t) :=
   (trivializationAt E (TangentSpace I) (γ t)).symmL 𝕜 (γ t)
     (alongCurveInChartWithin cov γ V s (γ t) t)

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
@@ -238,6 +238,8 @@ theorem alongCurveWithin_pullback_mfderivWithin {s : Set 𝕜} {t : 𝕜}
       cov X (γ t) (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t (1 : 𝕜)) := by
   refine alongCurveWithin_pullback cov γ X hu (hγ.hasMFDerivWithinAt.congr_mfderiv ?_) hX
   ext
+  -- The tangent space of the scalar model is definitionally `𝕜`, but its topology instance blocks
+  -- rewriting by `ContinuousLinearMap.smulRight_apply` until that identification is exposed.
   change (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜) =
     (1 : 𝕜) • (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜)
   rw [one_smul]

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
@@ -1,0 +1,245 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.AlongCurve.Basic
+public import Mathlib.Geometry.Manifold.MFDeriv.Atlas
+
+/-!
+# The along-curve derivative of a pulled-back vector field
+
+`CovariantDerivative.alongCurveWithin` differentiates a tangent field along a curve by the
+moving-chart formula `v' + Γ(v, u')` of
+`TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Basic.lean`, which reads
+the curve and the field in the chart centred at the current point.  This file identifies that
+formula for a field which is *pulled back* from an ambient vector field, `V t = X (γ t)`: there
+the formula returns `∇_{γ'(t)} X`, the ambient covariant derivative of `X` in the direction of the
+velocity of `γ`.  This is the property that pins the along-curve derivative down and makes it
+chart independent on pulled-back fields, and it is what lets a connection-based geodesic equation
+be stated through the along-curve API.
+
+The identification is proved in an arbitrary chart, not only in the moving one: for any `x` whose
+chart contains `γ t`, the coordinate formula computed in the chart at `x` is the reading of
+`∇_{γ'(t)} X` in the tangent-bundle trivialization at `x`.  Transporting back therefore gives the
+same tangent vector for every such `x`.
+
+The velocity of the curve is carried by a `HasMFDerivWithinAt` hypothesis, in the
+`ContinuousLinearMap.smulRight 1 w` form used by Mathlib's integral-curve API, so that no junk
+value can leak in; `CovariantDerivative.alongCurveWithin_pullback_mfderivWithin` restates the
+result for the canonical velocity `mfderivWithin 𝓘(𝕜, 𝕜) I γ s t 1`.
+
+## Main results
+
+* `TauCeti.Manifold.derivWithin_extChartAt_comp`: the derivative of a curve read in the chart at
+  `x` is the reading of its velocity in the tangent-bundle trivialization at `x`.
+* `TauCeti.Manifold.derivWithin_sectionCoord_pullback`: the derivative of the coordinate reading
+  of a pulled-back field is the reading of the flat frame derivative in the direction of the
+  velocity.
+* `CovariantDerivative.alongCurveInChartWithin_pullback`: the coordinate formula in the chart at
+  `x`, for a pulled-back field, is the reading of `∇_{γ'(t)} X`.
+* `CovariantDerivative.alongCurveWithin_pullback` and
+  `CovariantDerivative.alongCurve_pullback`: the along-curve derivative of a pulled-back field is
+  `∇_{γ'(t)} X`, within a parameter set and unrestricted.
+* `CovariantDerivative.symmL_alongCurveInChartWithin_pullback`: on pulled-back fields the
+  coordinate formula is chart independent -- reading it in any chart around `γ t` and transporting
+  back gives the moving-chart value.
+* `CovariantDerivative.alongCurveWithin_pullback_mfderivWithin`: the same identification with the
+  velocity written as `mfderivWithin 𝓘(𝕜, 𝕜) I γ s t 1`.
+
+## References
+
+* [Geodesics, the exponential map, and the Hopf--Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
+  Layer 1, "Covariant derivative along a curve": agreement with the ambient derivative for a
+  pulled-back vector field.
+* M. P. do Carmo, *Riemannian Geometry*, Birkhauser, 1992, Ch. 2, Proposition 2.2(c).
+-/
+
+public section
+
+open Bundle Filter Module Set
+open scoped Manifold Topology
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+variable
+  {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 1 M]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
+
+variable (γ : 𝕜 → M) (X : Π y : M, TangentSpace I y)
+
+omit [CompleteSpace 𝕜] [FiniteDimensional 𝕜 E]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
+/-- The derivative of a curve read in the chart centred at `x`, taken within a parameter set with
+a unique derivative there, is the reading of the velocity of the curve in the tangent-bundle
+trivialization at `x`.  The chart need not be the one centred at the current point of the
+curve. -/
+theorem derivWithin_extChartAt_comp {x : M} {s : Set 𝕜} {t : 𝕜} {w : TangentSpace I (γ t)}
+    (hx : γ t ∈ (chartAt H x).source) (hu : UniqueDiffWithinAt 𝕜 s t)
+    (hγ : HasMFDerivAt[s] γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w)) :
+    derivWithin (extChartAt I x ∘ γ) s t =
+      (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 (γ t) w := by
+  rw [TangentBundle.continuousLinearMapAt_trivializationAt hx]
+  set D := mfderiv% (extChartAt I x) (γ t)
+  have hchart : HasMFDerivAt% (extChartAt I x) (γ t) D :=
+    (mdifferentiableAt_extChartAt hx).hasMFDerivAt
+  -- The chain rule for the chart composed with the curve; the continuous linear maps
+  -- `D ∘L (1.smulRight w)` and `1.smulRight (D w)` agree by linearity of `D`.
+  have hcomp : HasMFDerivAt[s] (extChartAt I x ∘ γ) t
+      (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (D w)) :=
+    (hchart.comp_hasMFDerivWithinAt (hf := hγ)).congr_mfderiv (by
+      ext
+      exact D.map_smul (1 : 𝕜) w)
+  have hderiv : HasDerivWithinAt (extChartAt I x ∘ γ) (D w) s t := hcomp.hasFDerivWithinAt
+  exact hderiv.derivWithin hu
+
+/-- Along a curve, the derivative of the coordinate reading of a pulled-back vector field is the
+reading of the flat frame derivative of that field in the direction of the velocity.  Both
+readings are taken in the tangent-bundle trivialization at `x`, whose base set contains the
+current point of the curve. -/
+theorem derivWithin_sectionCoord_pullback {ι : Type*} [Fintype ι] (b : Basis ι 𝕜 E) {x : M}
+    {s : Set 𝕜} {t : 𝕜} {w : TangentSpace I (γ t)}
+    (hy : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) (hu : UniqueDiffWithinAt 𝕜 s t)
+    (hγ : HasMFDerivAt[s] γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w))
+    (hX : MDiffAt (T% X) (γ t)) :
+    derivWithin (sectionCoord (F := E) γ (fun r ↦ X (γ r)) x) s t =
+      (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 (γ t)
+        (frameCovariantDerivative I b (trivializationAt E (TangentSpace I) x) X (γ t) w) := by
+  set e := trivializationAt E (TangentSpace I) x
+  set σ : ι → M → 𝕜 := fun i ↦ (LinearMap.piApply (e.localFrameCoeff I b i)) X
+  -- The coordinate reading of a section is the sum of its frame coefficients.
+  have hread : ∀ y ∈ e.baseSet, e.continuousLinearMapAt 𝕜 y (X y) = ∑ i, σ i y • b i := by
+    intro y hyb
+    have h : ∀ i, σ i y = b.repr (e.continuousLinearMapAt 𝕜 y (X y)) i := fun i ↦ by
+      have hcoe : σ i y = e.localFrameCoeff I b i y (X y) := (rfl)
+      rw [hcoe, e.localFrameCoeff_eq_coeff (s := X) hyb,
+        Bundle.Trivialization.continuousLinearMapAt_apply_of_mem (R := 𝕜) e hyb]
+    simp only [h]
+    exact (b.sum_repr _).symm
+  -- Each frame coefficient is differentiable along the curve, with the expected derivative.
+  have hcoeff : ∀ i, HasDerivWithinAt (fun r ↦ σ i (γ r)) (d% (σ i) (γ t) w) s t := by
+    intro i
+    have hσ : MDiffAt (σ i) (γ t) := mdifferentiableAt_localFrameCoeff b hy hX i
+    have hcomp : HasMFDerivAt[s] (fun r ↦ σ i (γ r)) t
+        (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (d% (σ i) (γ t) w)) :=
+      (hσ.hasMFDerivAt.comp_hasMFDerivWithinAt (hf := hγ)).congr_mfderiv (by
+        ext
+        exact (d% (σ i) (γ t)).map_smul (1 : 𝕜) w)
+    exact hcomp.hasFDerivWithinAt
+  have hfun : (∑ i : ι, fun r ↦ σ i (γ r) • b i) = fun r ↦ ∑ i, σ i (γ r) • b i := by
+    funext r
+    simp [Finset.sum_apply]
+  have hsum : HasDerivWithinAt (fun r ↦ ∑ i, σ i (γ r) • b i)
+      (∑ i, d% (σ i) (γ t) w • b i) s t :=
+    hfun ▸ HasDerivWithinAt.sum fun i (_ : i ∈ Finset.univ) ↦ (hcoeff i).smul_const (b i)
+  have hbase : ∀ᶠ r in 𝓝[s] t, γ r ∈ e.baseSet :=
+    hγ.1.preimage_mem_nhdsWithin (e.open_baseSet.mem_nhds hy)
+  have hEq : sectionCoord (F := E) γ (fun r ↦ X (γ r)) x =ᶠ[𝓝[s] t]
+      fun r ↦ ∑ i, σ i (γ r) • b i :=
+    hbase.mono fun r hr ↦ by rw [sectionCoord_apply, hread _ hr]
+  have hpoint : sectionCoord (F := E) γ (fun r ↦ X (γ r)) x t =
+      (fun r ↦ ∑ i, σ i (γ r) • b i) t := by
+    rw [sectionCoord_apply, hread _ hy]
+  rw [(hsum.congr_of_eventuallyEq hEq hpoint).derivWithin hu, frameCovariantDerivative_apply,
+    map_sum]
+  refine Finset.sum_congr rfl fun i _ ↦ ?_
+  rw [map_smul]
+  have hframe : e.continuousLinearMapAt 𝕜 (γ t) (e.localFrame b i (γ t)) = b i := by
+    simp [Bundle.Trivialization.continuousLinearMapAt_apply_of_mem, hy,
+      Bundle.Trivialization.localFrame_apply_of_mem_baseSet, Bundle.Trivialization.basisAt]
+  rw [hframe]
+
+end TauCeti.Manifold
+
+namespace CovariantDerivative
+
+open TauCeti.Manifold
+
+variable
+  {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [FiniteDimensional 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 1 M]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
+
+variable (cov : _root_.CovariantDerivative I E (fun y : M ↦ TangentSpace I y))
+  (γ : 𝕜 → M) (X : Π y : M, TangentSpace I y)
+
+/-- The moving-chart coordinate formula, evaluated in the chart at an arbitrary point `x` whose
+base set contains `γ t`, computes the reading of the ambient covariant derivative `∇_{γ'(t)} X`
+in the tangent-bundle trivialization at `x`, whenever the differentiated field is pulled back
+from the vector field `X`. -/
+theorem alongCurveInChartWithin_pullback {x : M} {s : Set 𝕜} {t : 𝕜} {w : TangentSpace I (γ t)}
+    (hy : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) (hu : UniqueDiffWithinAt 𝕜 s t)
+    (hγ : HasMFDerivAt[s] γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w))
+    (hX : MDiffAt (T% X) (γ t)) :
+    alongCurveInChartWithin cov γ (fun r ↦ X (γ r)) s x t =
+      (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 (γ t) (cov X (γ t) w) := by
+  set e := trivializationAt E (TangentSpace I) x
+  set b := Module.finBasis 𝕜 E
+  set hcov := cov.isCovariantDerivativeOn (s := e.baseSet)
+  -- The two summands of the coordinate formula are the readings of the flat frame derivative and
+  -- of the Christoffel form, whose sum is the covariant derivative.
+  rw [alongCurveInChartWithin_apply, derivWithin_sectionCoord_pullback γ X b hy hu hγ hX,
+    derivWithin_extChartAt_comp γ hy hu hγ, christoffelMap_apply b hcov hy, sectionCoord_apply,
+    e.symmL_continuousLinearMapAt (R := 𝕜) hy, e.symmL_continuousLinearMapAt (R := 𝕜) hy,
+    ← map_add, covariantDerivative_eq_add_christoffelForm b hcov hy hX]
+  rfl
+
+/-- **Agreement with the ambient covariant derivative.** The derivative along `γ` of the field
+pulled back from a vector field `X` is `∇_{γ'(t)} X`, the ambient covariant derivative of `X` in
+the direction of the velocity of `γ`. -/
+theorem alongCurveWithin_pullback {s : Set 𝕜} {t : 𝕜} {w : TangentSpace I (γ t)}
+    (hu : UniqueDiffWithinAt 𝕜 s t)
+    (hγ : HasMFDerivAt[s] γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w))
+    (hX : MDiffAt (T% X) (γ t)) :
+    alongCurveWithin cov γ (fun r ↦ X (γ r)) s t = cov X (γ t) w := by
+  have hmem := FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t)
+  rw [alongCurveWithin_apply, alongCurveInChartWithin_pullback cov γ X hmem hu hγ hX,
+    (trivializationAt E (TangentSpace I) (γ t)).symmL_continuousLinearMapAt (R := 𝕜) hmem]
+
+/-- **Chart independence on pulled-back fields.** Reading the coordinate formula in the chart at
+any point `x` whose base set contains `γ t`, and transporting the result back to
+`TangentSpace I (γ t)`, gives the moving-chart value. -/
+theorem symmL_alongCurveInChartWithin_pullback {x : M} {s : Set 𝕜} {t : 𝕜}
+    {w : TangentSpace I (γ t)}
+    (hy : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) (hu : UniqueDiffWithinAt 𝕜 s t)
+    (hγ : HasMFDerivAt[s] γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w))
+    (hX : MDiffAt (T% X) (γ t)) :
+    (trivializationAt E (TangentSpace I) x).symmL 𝕜 (γ t)
+        (alongCurveInChartWithin cov γ (fun r ↦ X (γ r)) s x t) =
+      alongCurveWithin cov γ (fun r ↦ X (γ r)) s t := by
+  rw [alongCurveInChartWithin_pullback cov γ X hy hu hγ hX,
+    (trivializationAt E (TangentSpace I) x).symmL_continuousLinearMapAt (R := 𝕜) hy,
+    alongCurveWithin_pullback cov γ X hu hγ hX]
+
+/-- The unrestricted along-curve derivative of a pulled-back vector field is the ambient covariant
+derivative in the direction of the velocity of the curve. -/
+theorem alongCurve_pullback {t : 𝕜} {w : TangentSpace I (γ t)}
+    (hγ : HasMFDerivAt% γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w))
+    (hX : MDiffAt (T% X) (γ t)) :
+    alongCurve cov γ (fun r ↦ X (γ r)) t = cov X (γ t) w := by
+  rw [← alongCurveWithin_univ]
+  exact alongCurveWithin_pullback cov γ X uniqueDiffWithinAt_univ hγ.hasMFDerivWithinAt hX
+
+/-- Agreement with the ambient covariant derivative, with the velocity of the curve written as the
+canonical `mfderivWithin 𝓘(𝕜, 𝕜) I γ s t 1`. -/
+theorem alongCurveWithin_pullback_mfderivWithin {s : Set 𝕜} {t : 𝕜}
+    (hu : UniqueDiffWithinAt 𝕜 s t) (hγ : MDifferentiableWithinAt 𝓘(𝕜, 𝕜) I γ s t)
+    (hX : MDiffAt (T% X) (γ t)) :
+    alongCurveWithin cov γ (fun r ↦ X (γ r)) s t =
+      cov X (γ t) (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t (1 : 𝕜)) := by
+  refine alongCurveWithin_pullback cov γ X hu (hγ.hasMFDerivWithinAt.congr_mfderiv ?_) hX
+  ext
+  change (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜) =
+    (1 : 𝕜) • (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜)
+  rw [one_smul]
+
+end CovariantDerivative

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
@@ -17,9 +17,9 @@ moving-chart formula `v' + Γ(v, u')` of
 the curve and the field in the chart centred at the current point.  This file identifies that
 formula for a field which is *pulled back* from an ambient vector field, `V t = X (γ t)`: there
 the formula returns `∇_{γ'(t)} X`, the ambient covariant derivative of `X` in the direction of the
-velocity of `γ`.  This is the property that pins the along-curve derivative down and makes it
-chart independent on pulled-back fields, and it is what lets a connection-based geodesic equation
-be stated through the along-curve API.
+velocity of `γ`.  This is do Carmo 2.2(c), one of the properties characterising `D/dt` together
+with the linearity and Leibniz laws of `AlongCurve/Basic.lean`; it also makes the formula chart
+independent on pulled-back fields.
 
 The identification is proved in an arbitrary chart, not only in the moving one: for any `x` whose
 chart contains `γ t`, the coordinate formula computed in the chart at `x` is the reading of
@@ -55,6 +55,10 @@ result for the canonical velocity `mfderivWithin 𝓘(𝕜, 𝕜) I γ s t 1`.
   Layer 1, "Covariant derivative along a curve": agreement with the ambient derivative for a
   pulled-back vector field.
 * M. P. do Carmo, *Riemannian Geometry*, Birkhauser, 1992, Ch. 2, Proposition 2.2(c).
+* The moving-chart operator characterized here was informed by
+  `formalized-sources/DoCarmo/DoCarmoLib/Riemannian/Connection/CovariantDerivativeAlong.lean` in
+  the Apache-2.0 [`frenzymath/Poincare-Conjecture`](https://github.com/frenzymath/Poincare-Conjecture)
+  repository at revision `24f32e4d600878bfaac6bc2f2f9324175571c321`.
 -/
 
 public section
@@ -76,63 +80,76 @@ variable
 variable (γ : 𝕜 → M) (X : Π y : M, TangentSpace I y)
 
 omit [CompleteSpace 𝕜] [FiniteDimensional 𝕜 E]
+  [IsManifold I 1 M]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
+/-- Compose a manifold derivative with a curve of specified velocity, reading the resulting
+one-dimensional manifold derivative as an ordinary derivative. -/
+private theorem hasDerivWithinAt_comp_curve
+    {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] [ContinuousSMul 𝕜 F]
+    {f : M → F} {s : Set 𝕜} {t : 𝕜}
+    {w : TangentSpace I (γ t)} {D : TangentSpace I (γ t) →L[𝕜] F}
+    (hf : HasMFDerivAt I 𝓘(𝕜, F) f (γ t) D)
+    (hγ : HasMFDerivAt[s] γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w)) :
+    HasDerivWithinAt (f ∘ γ) (D w) s t := by
+  have hcomp : HasMFDerivAt[s] (f ∘ γ) t
+      (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (D w)) :=
+    (hf.comp_hasMFDerivWithinAt (hf := hγ)).congr_mfderiv (by
+      ext
+      exact D.map_smul (1 : 𝕜) w)
+  exact hcomp.hasFDerivWithinAt
+
+omit [CompleteSpace 𝕜] [FiniteDimensional 𝕜 E]
   [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
 /-- The derivative of a curve read in the chart centred at `x`, taken within a parameter set with
 a unique derivative there, is the reading of the velocity of the curve in the tangent-bundle
 trivialization at `x`.  The chart need not be the one centred at the current point of the
 curve. -/
 theorem derivWithin_extChartAt_comp {x : M} {s : Set 𝕜} {t : 𝕜} {w : TangentSpace I (γ t)}
-    (hx : γ t ∈ (chartAt H x).source) (hu : UniqueDiffWithinAt 𝕜 s t)
+    (hx : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet)
+    (hu : UniqueDiffWithinAt 𝕜 s t)
     (hγ : HasMFDerivAt[s] γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w)) :
     derivWithin (extChartAt I x ∘ γ) s t =
       (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 (γ t) w := by
-  rw [TangentBundle.continuousLinearMapAt_trivializationAt hx]
+  rw [TangentBundle.continuousLinearMapAt_trivializationAt
+    (by simpa only [TangentBundle.trivializationAt_baseSet] using hx)]
   set D := mfderiv% (extChartAt I x) (γ t)
   have hchart : HasMFDerivAt% (extChartAt I x) (γ t) D :=
     (mdifferentiableAt_extChartAt hx).hasMFDerivAt
-  -- The chain rule for the chart composed with the curve; the continuous linear maps
-  -- `D ∘L (1.smulRight w)` and `1.smulRight (D w)` agree by linearity of `D`.
-  have hcomp : HasMFDerivAt[s] (extChartAt I x ∘ γ) t
-      (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (D w)) :=
-    (hchart.comp_hasMFDerivWithinAt (hf := hγ)).congr_mfderiv (by
-      ext
-      exact D.map_smul (1 : 𝕜) w)
-  have hderiv : HasDerivWithinAt (extChartAt I x ∘ γ) (D w) s t := hcomp.hasFDerivWithinAt
-  exact hderiv.derivWithin hu
+  exact (hasDerivWithinAt_comp_curve γ hchart hγ).derivWithin hu
 
-/-- Along a curve, the derivative of the coordinate reading of a pulled-back vector field is the
-reading of the flat frame derivative of that field in the direction of the velocity.  Both
-readings are taken in the tangent-bundle trivialization at `x`, whose base set contains the
-current point of the curve. -/
-theorem derivWithin_sectionCoord_pullback {ι : Type*} [Fintype ι] (b : Basis ι 𝕜 E) {x : M}
+omit [FiniteDimensional 𝕜 E]
+  [IsManifold I 1 M]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
+/-- Along a curve, the derivative of the coordinate reading of a pulled-back vector-bundle section
+is the reading of its flat frame derivative in the direction of the velocity. -/
+theorem derivWithin_sectionCoord_pullback
+    {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] [FiniteDimensional 𝕜 F]
+    {V : M → Type*} [TopologicalSpace (TotalSpace F V)] [∀ y, AddCommGroup (V y)]
+    [∀ y, Module 𝕜 (V y)] [∀ y, TopologicalSpace (V y)] [FiberBundle F V]
+    [∀ y, IsTopologicalAddGroup (V y)] [∀ y, ContinuousSMul 𝕜 (V y)]
+    [VectorBundle 𝕜 F V] [ContMDiffVectorBundle 1 F V I]
+    {ι : Type*} [Fintype ι] (b : Basis ι 𝕜 F) (Y : Π y : M, V y) {x : M}
     {s : Set 𝕜} {t : 𝕜} {w : TangentSpace I (γ t)}
-    (hy : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) (hu : UniqueDiffWithinAt 𝕜 s t)
+    (hy : γ t ∈ (trivializationAt F V x).baseSet) (hu : UniqueDiffWithinAt 𝕜 s t)
     (hγ : HasMFDerivAt[s] γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w))
-    (hX : MDiffAt (T% X) (γ t)) :
-    derivWithin (sectionCoord (F := E) γ (fun r ↦ X (γ r)) x) s t =
-      (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 (γ t)
-        (frameCovariantDerivative I b (trivializationAt E (TangentSpace I) x) X (γ t) w) := by
-  set e := trivializationAt E (TangentSpace I) x
-  set σ : ι → M → 𝕜 := fun i ↦ (LinearMap.piApply (e.localFrameCoeff I b i)) X
-  -- The coordinate reading of a section is the sum of its frame coefficients.
-  have hread : ∀ y ∈ e.baseSet, e.continuousLinearMapAt 𝕜 y (X y) = ∑ i, σ i y • b i := by
+    (hY : MDiffAt (T% Y) (γ t)) :
+    derivWithin (sectionCoord (F := F) γ (fun r ↦ Y (γ r)) x) s t =
+      (trivializationAt F V x).continuousLinearMapAt 𝕜 (γ t)
+        (frameCovariantDerivative I b (trivializationAt F V x) Y (γ t) w) := by
+  set e := trivializationAt F V x
+  set σ : ι → M → 𝕜 := fun i ↦ (LinearMap.piApply (e.localFrameCoeff I b i)) Y
+  -- Read Mathlib's local-frame expansion through the trivialization.
+  have hread : ∀ y ∈ e.baseSet, e.continuousLinearMapAt 𝕜 y (Y y) = ∑ i, σ i y • b i := by
     intro y hyb
-    have h : ∀ i, σ i y = b.repr (e.continuousLinearMapAt 𝕜 y (X y)) i := fun i ↦ by
-      have hcoe : σ i y = e.localFrameCoeff I b i y (X y) := (rfl)
-      rw [hcoe, e.localFrameCoeff_eq_coeff (s := X) hyb,
-        Bundle.Trivialization.continuousLinearMapAt_apply_of_mem (R := 𝕜) e hyb]
-    simp only [h]
-    exact (b.sum_repr _).symm
+    rw [e.eq_sum_localFrameCoeff_smul (I := I) (b := b) (s := Y) hyb, map_sum]
+    exact Finset.sum_congr rfl fun i _ ↦ by
+      rw [map_smul, continuousLinearMapAt_localFrame b hyb i]
+      simp only [σ, LinearMap.piApply_apply_apply]
   -- Each frame coefficient is differentiable along the curve, with the expected derivative.
   have hcoeff : ∀ i, HasDerivWithinAt (fun r ↦ σ i (γ r)) (d% (σ i) (γ t) w) s t := by
     intro i
-    have hσ : MDiffAt (σ i) (γ t) := mdifferentiableAt_localFrameCoeff b hy hX i
-    have hcomp : HasMFDerivAt[s] (fun r ↦ σ i (γ r)) t
-        (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (d% (σ i) (γ t) w)) :=
-      (hσ.hasMFDerivAt.comp_hasMFDerivWithinAt (hf := hγ)).congr_mfderiv (by
-        ext
-        exact (d% (σ i) (γ t)).map_smul (1 : 𝕜) w)
-    exact hcomp.hasFDerivWithinAt
+    exact hasDerivWithinAt_comp_curve γ
+      (mdifferentiableAt_localFrameCoeff b hy hY i).hasMFDerivAt hγ
   have hfun : (∑ i : ι, fun r ↦ σ i (γ r) • b i) = fun r ↦ ∑ i, σ i (γ r) • b i := by
     funext r
     simp [Finset.sum_apply]
@@ -141,20 +158,17 @@ theorem derivWithin_sectionCoord_pullback {ι : Type*} [Fintype ι] (b : Basis �
     hfun ▸ HasDerivWithinAt.sum fun i (_ : i ∈ Finset.univ) ↦ (hcoeff i).smul_const (b i)
   have hbase : ∀ᶠ r in 𝓝[s] t, γ r ∈ e.baseSet :=
     hγ.1.preimage_mem_nhdsWithin (e.open_baseSet.mem_nhds hy)
-  have hEq : sectionCoord (F := E) γ (fun r ↦ X (γ r)) x =ᶠ[𝓝[s] t]
+  have hEq : sectionCoord (F := F) γ (fun r ↦ Y (γ r)) x =ᶠ[𝓝[s] t]
       fun r ↦ ∑ i, σ i (γ r) • b i :=
     hbase.mono fun r hr ↦ by rw [sectionCoord_apply, hread _ hr]
-  have hpoint : sectionCoord (F := E) γ (fun r ↦ X (γ r)) x t =
+  have hpoint : sectionCoord (F := F) γ (fun r ↦ Y (γ r)) x t =
       (fun r ↦ ∑ i, σ i (γ r) • b i) t := by
     rw [sectionCoord_apply, hread _ hy]
   rw [(hsum.congr_of_eventuallyEq hEq hpoint).derivWithin hu, frameCovariantDerivative_apply,
     map_sum]
   refine Finset.sum_congr rfl fun i _ ↦ ?_
   rw [map_smul]
-  have hframe : e.continuousLinearMapAt 𝕜 (γ t) (e.localFrame b i (γ t)) = b i := by
-    simp [Bundle.Trivialization.continuousLinearMapAt_apply_of_mem, hy,
-      Bundle.Trivialization.localFrame_apply_of_mem_baseSet, Bundle.Trivialization.basisAt]
-  rw [hframe]
+  rw [continuousLinearMapAt_localFrame b hy i]
 
 end TauCeti.Manifold
 
@@ -187,11 +201,11 @@ theorem alongCurveInChartWithin_pullback {x : M} {s : Set 𝕜} {t : 𝕜} {w : 
   set hcov := cov.isCovariantDerivativeOn (s := e.baseSet)
   -- The two summands of the coordinate formula are the readings of the flat frame derivative and
   -- of the Christoffel form, whose sum is the covariant derivative.
-  rw [alongCurveInChartWithin_apply, derivWithin_sectionCoord_pullback γ X b hy hu hγ hX,
+  rw [alongCurveInChartWithin_apply, derivWithin_sectionCoord_pullback γ b X hy hu hγ hX,
     derivWithin_extChartAt_comp γ hy hu hγ, christoffelMap_apply b hcov hy, sectionCoord_apply,
     e.symmL_continuousLinearMapAt (R := 𝕜) hy, e.symmL_continuousLinearMapAt (R := 𝕜) hy,
-    ← map_add, covariantDerivative_eq_add_christoffelForm b hcov hy hX]
-  rfl
+    ← map_add, covariantDerivative_eq_add_christoffelForm b hcov hy hX,
+    add_apply]
 
 /-- **Agreement with the ambient covariant derivative.** The derivative along `γ` of the field
 pulled back from a vector field `X` is `∇_{γ'(t)} X`, the ambient covariant derivative of `X` in

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LocalFrame.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LocalFrame.lean
@@ -49,7 +49,8 @@ derivative, and they give the classical coordinate formula for `∇ σ` along a 
   `TauCeti.Manifold.christoffelForm_localFrame_apply` identifying them with the frame components
   of the Christoffel form.
 * `TauCeti.Manifold.christoffelMap`: the Christoffel form transported to a continuous bilinear map
-  on the model space, with `TauCeti.Manifold.contMDiffOn_christoffelMap` proving its smoothness.
+  on the model space, with `TauCeti.Manifold.christoffelMap_apply` reading it back as the
+  Christoffel form and `TauCeti.Manifold.contMDiffOn_christoffelMap` proving its smoothness.
 * `TauCeti.Manifold.covariantDerivative_apply_localFrame_eq_sum`: the classical coordinate
   formula `(∇_{eᵢ} σ)ᵏ = dσᵏ(eᵢ) + ∑ j, σʲ Γᵏᵢⱼ`.
 
@@ -308,6 +309,22 @@ def christoffelMap [Fintype ι] (hcov : IsCovariantDerivativeOn E cov e.baseSet)
       (e.continuousLinearMap (RingHom.id 𝕜) e))
     ⟨x, christoffelForm b hcov x⟩).2
 
+/-- The model-space Christoffel map is the Christoffel form read in the trivialization: it acts
+on the coordinates of a fibre vector and of a tangent direction, and returns the coordinates of
+the value of the Christoffel form on them. -/
+theorem christoffelMap_apply [Fintype ι] (hcov : IsCovariantDerivativeOn E cov e.baseSet)
+    (hx : x ∈ e.baseSet) (v w : E) :
+    christoffelMap b hcov x v w =
+      e.continuousLinearMapAt 𝕜 x
+        (christoffelForm b hcov x (e.symmL 𝕜 x v) (e.symmL 𝕜 x w)) := by
+  have hxe : x ∈ (e.continuousLinearMap (RingHom.id 𝕜) e).baseSet := by simp [hx]
+  simp only [christoffelMap, Bundle.Trivialization.continuousLinearMap_apply,
+    ContinuousLinearMap.comp_apply]
+  rw [Bundle.Trivialization.continuousLinearMapAt_apply_of_mem
+    (R := 𝕜) (e.continuousLinearMap (RingHom.id 𝕜) e) hxe]
+  simp only [Bundle.Trivialization.continuousLinearMap_apply,
+    ContinuousLinearMap.comp_apply]
+
 /-- The Christoffel symbols of a `C^n` covariant derivative are `C^n` on the base set of the
 trivialization defining the frame. -/
 theorem contMDiffOn_christoffelSymbol {n : ℕ∞ω}
@@ -352,20 +369,12 @@ theorem christoffelMap_apply_basis [Fintype ι]
     christoffelMap b hcov x (b j) (b i) =
       ∑ k, christoffelSymbol I b e cov i j k x • b k := by
   classical
-  simp only [christoffelMap, Bundle.Trivialization.continuousLinearMap_apply,
-    ContinuousLinearMap.comp_apply]
-  rw [e.symmL_apply hx]
-  have hxe : x ∈ (e.continuousLinearMap (RingHom.id 𝕜) e).baseSet := by simp [hx]
-  rw [Bundle.Trivialization.continuousLinearMapAt_apply_of_mem
-    (R := 𝕜) (e.continuousLinearMap (RingHom.id 𝕜) e) hxe]
-  simp only [Bundle.Trivialization.continuousLinearMap_apply,
-    ContinuousLinearMap.comp_apply]
-  rw [e.symmL_apply hx]
-  have hframe (l : ι) : e.symm x (b l) = e.localFrame b l x := by
+  have hframe (l : ι) : e.symmL 𝕜 x (b l) = e.localFrame b l x := by
+    rw [e.symmL_apply hx]
     simp [Bundle.Trivialization.localFrame_apply_of_mem_baseSet,
       Bundle.Trivialization.basisAt, hx]
-  rw [hframe j, hframe i]
-  rw [christoffelForm_localFrame_apply b hcov hx i j]
+  rw [christoffelMap_apply b hcov hx, hframe j, hframe i,
+    christoffelForm_localFrame_apply b hcov hx i j]
   simp [Bundle.Trivialization.continuousLinearMapAt_apply_of_mem, hx,
     Bundle.Trivialization.localFrame_apply_of_mem_baseSet, Bundle.Trivialization.basisAt]
 

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LocalFrame.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/LocalFrame.lean
@@ -369,14 +369,12 @@ theorem christoffelMap_apply_basis [Fintype ι]
     christoffelMap b hcov x (b j) (b i) =
       ∑ k, christoffelSymbol I b e cov i j k x • b k := by
   classical
-  have hframe (l : ι) : e.symmL 𝕜 x (b l) = e.localFrame b l x := by
-    rw [e.symmL_apply hx]
-    simp [Bundle.Trivialization.localFrame_apply_of_mem_baseSet,
-      Bundle.Trivialization.basisAt, hx]
-  rw [christoffelMap_apply b hcov hx, hframe j, hframe i,
+  rw [christoffelMap_apply b hcov hx, symmL_basis_eq_localFrame b hx j,
+    symmL_basis_eq_localFrame b hx i,
     christoffelForm_localFrame_apply b hcov hx i j]
-  simp [Bundle.Trivialization.continuousLinearMapAt_apply_of_mem, hx,
-    Bundle.Trivialization.localFrame_apply_of_mem_baseSet, Bundle.Trivialization.basisAt]
+  rw [map_sum]
+  exact Finset.sum_congr rfl fun k _ ↦ by
+    rw [map_smul, continuousLinearMapAt_localFrame b hx k]
 
 /-- The scalar basis coefficients of the model-space Christoffel map are precisely the
 Christoffel symbols. -/

--- a/TauCeti/Geometry/Manifold/VectorBundle/LocalFrame.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/LocalFrame.lean
@@ -33,6 +33,9 @@ a time.
   `e.basisAt b hx` of the fibre at a point of `e.baseSet`.
 * `TauCeti.Manifold.localFrameCoeff_localFrame`: the same duality, stated for the frame sections
   themselves.
+* `TauCeti.Manifold.symmL_basis_eq_localFrame` and
+  `TauCeti.Manifold.continuousLinearMapAt_localFrame`: a trivialization transports basis vectors
+  to its local frame and reads those frame vectors back as basis vectors.
 * `TauCeti.Manifold.contMDiffOn_hom_of_localFrame`: a section of the bundle of continuous linear
   maps is `C^n` once its evaluations on a local frame of the source bundle are.
 -/
@@ -71,6 +74,20 @@ theorem localFrameCoeff_basisAt [DecidableEq ι] (hx : x ∈ e.baseSet) (i j : �
 theorem localFrameCoeff_localFrame [DecidableEq ι] (hx : x ∈ e.baseSet) (i j : ι) :
     e.localFrameCoeff I b i x (e.localFrame b j x) = if i = j then 1 else 0 := by
   rw [e.localFrame_apply_of_mem_baseSet b hx, localFrameCoeff_basisAt b hx]
+
+/-- The continuous inverse of a trivialization transports a model-fibre basis vector to the
+corresponding local-frame vector. -/
+theorem symmL_basis_eq_localFrame (hx : x ∈ e.baseSet) (i : ι) :
+    e.symmL 𝕜 x (b i) = e.localFrame b i x := by
+  rw [e.symmL_apply hx]
+  simp [Bundle.Trivialization.localFrame_apply_of_mem_baseSet,
+    Bundle.Trivialization.basisAt, hx]
+
+/-- A trivialization reads a vector of its local frame as the corresponding model-fibre basis
+vector. -/
+theorem continuousLinearMapAt_localFrame (hx : x ∈ e.baseSet) (i : ι) :
+    e.continuousLinearMapAt 𝕜 x (e.localFrame b i x) = b i := by
+  rw [← symmL_basis_eq_localFrame b hx i, e.continuousLinearMapAt_symmL hx]
 
 /-! ### Testing a hom-bundle section on a local frame -/
 
@@ -115,10 +132,8 @@ theorem contMDiffOn_hom_of_localFrame (hu : IsOpen u)
     rw [heh, Bundle.Trivialization.continuousLinearMap_apply]
     simp only [ContinuousLinearMap.comp_apply]
     rw [e.symmL_apply (hu' hy).1]
-    have hframe : e.symm y (b j) = e.localFrame b j y := by
-      simp [Bundle.Trivialization.localFrame_apply_of_mem_baseSet,
-        Bundle.Trivialization.basisAt, (hu' hy).1]
-    rw [hframe, Bundle.Trivialization.continuousLinearMapAt_apply_of_mem 𝕜 e' (hu' hy).2]
+    rw [← e.symmL_apply (R := 𝕜) (hu' hy).1, symmL_basis_eq_localFrame b (hu' hy).1,
+      Bundle.Trivialization.continuousLinearMapAt_apply_of_mem 𝕜 e' (hu' hy).2]
   have hcoord (j : ι) : ContMDiffOn I 𝓘(𝕜, F') n (fun y ↦ (eh ⟨y, A y⟩).2 (b j)) u := by
     refine ContMDiffOn.congr ?_ fun y hy ↦ key hy j
     exact (e'.contMDiffOn_section_iff hu (hu'.trans inter_subset_right)).1 (hA j)


### PR DESCRIPTION
This PR identifies the moving-chart along-curve derivative of a *pulled-back* vector field with the ambient covariant derivative: for a tangent field of the form `V t = X (γ t)`, `CovariantDerivative.alongCurveWithin cov γ (fun r ↦ X (γ r)) s t = cov X (γ t) w`, where `w` is the velocity of `γ` at `t`. It proves the identification in an arbitrary chart around `γ t`, not only in the moving one — `alongCurveInChartWithin_pullback` says the coordinate formula computed in the chart at any `x` with `γ t ∈ (chartAt H x).source` is the reading of `∇_{γ'(t)} X` in the tangent-bundle trivialization at `x` — and deduces chart independence on pulled-back fields (`symmL_alongCurveInChartWithin_pullback`), the unrestricted case, and a restatement with the canonical velocity `mfderivWithin 𝓘(𝕜, 𝕜) I γ s t 1`. The velocity is carried by a `HasMFDerivWithinAt` hypothesis in the `ContinuousLinearMap.smulRight 1 w` form that Mathlib's integral-curve API uses, so no junk value can leak into the statements.

This is the Layer 1 milestone "Covariant derivative along a curve" of the HopfRinow roadmap, whose bullet asks for linearity, the Leibniz rule, locality, naturality under reparametrization, "agreement with the ambient derivative for a pulled-back vector field, and the chart formula". PR #4399 built the operator and the first four items and recorded the remaining two as future work in its module docstring; this PR supplies them for pulled-back fields, which is do Carmo, *Riemannian Geometry*, Ch. 2, Proposition 2.2(c), the property that characterises `D/dt` and is what a connection-based geodesic equation is read through. After this PR the milestone still needs the frame expansion of the operator for an *arbitrary* section along the curve — the classical route to chart independence in general, via additivity, the Leibniz rule and this pullback identity applied to the frame sections — and the specialisation to the velocity field defining covariant acceleration; those are the inputs `IsGeodesicCurveOn` and the geodesic spray then consume.

Two supporting changes. `TauCeti.Manifold.christoffelMap_apply` is added next to `christoffelMap` in `CovariantDerivative/LocalFrame.lean`, reading the model-space Christoffel map back as the Christoffel form applied to the untransported vectors; the pre-existing `christoffelMap_apply_basis` is reproved from it, which shortens its proof. And, because the tree may not hold both `AlongCurve.lean` and an `AlongCurve*.lean` sibling, the existing file moves into a directory as it gains one:

| old module | new module |
| --- | --- |
| `TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.AlongCurve` | `TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.AlongCurve.Basic` |

Only imports and the module header change in the moved file, plus one sentence of its docstring which promised this file; no declaration is renamed. No Mathlib source was vendored: `TangentBundle.continuousLinearMapAt_trivializationAt`, `Bundle.Trivialization.localFrameCoeff_eq_coeff` and `mdifferentiableAt_localFrameCoeff` are consumed from the pinned Mathlib, and the moving-chart operator itself is Tau Ceti's.

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"alongcurvewithin-pullback"}-->

🤖 Prepared with Claude Code
