### PR TITLE
feat: orientation independence of the preprojective algebra

### DIFF
--- a/TauCeti/Combinatorics/Quiver/Reorient.lean
+++ b/TauCeti/Combinatorics/Quiver/Reorient.lean
@@ -7,16 +7,14 @@ module
 
 public import Mathlib.Combinatorics.Quiver.Symmetric
 public import Mathlib.Data.Fintype.BigOperators
-public import Mathlib.Data.Fintype.Sum
 public import TauCeti.Combinatorics.Quiver.Prefunctor
 
 /-!
 # Reorienting a quiver
 
-Two quivers with the same underlying graph differ by a choice, for each edge, of which of its two
-directions carries the arrow. This file records such a choice as a `Bool`-valued labelling `σ` of
-the arrows of a quiver `Q` and builds the quiver `TauCeti.Reorient Q σ`, whose arrows are those of
-`Q` with the ones labelled `true` turned around.
+A `Bool`-valued labelling `σ` of the arrows of a quiver `Q` specifies a change of orientation: this
+file builds the quiver `TauCeti.Reorient Q σ`, whose arrows are those of `Q` with the ones labelled
+`true` turned around.
 
 The two doubled quivers `Quiver.Symmetrify (Reorient Q σ)` and `Quiver.Symmetrify Q` carry exactly
 the same arrows, distributed differently between an arrow and its formal reverse. That is the
@@ -29,7 +27,7 @@ identification along which a construction on doubled quivers -- the additive pre
 
 * `TauCeti.Reorient`: the quiver `Q` with the arrows labelled `true` by `σ` turned around.
 * `TauCeti.reorientHomEquiv`: the identification of a hom set of `Reorient Q σ` with the two
-  subtypes of hom sets of `Q` it is built from, together with `TauCeti.reorientHom_induction` the
+  subtypes of hom sets of `Q` it is built from, together with `TauCeti.reorientHom_induction_on` the
   general elimination interface for a reoriented arrow.
 * `TauCeti.reorientSymmetrify` and `TauCeti.reorientSymmetrifyInv`: the two prefunctors between
   the doubled quivers.
@@ -112,13 +110,11 @@ definitionally equal, so this is the identity; naming it keeps the two quiver st
 abbrev reorientVertex (v : Q) : Reorient Q σ := v
 
 /-- The arrow of `Reorient Q σ` carried by an arrow of `Q` which `σ` leaves alone. -/
-@[expose]
 def reorientKeep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) : reorientVertex σ i ⟶ reorientVertex σ j :=
   Sum.inl ⟨a, h⟩
 
 /-- The arrow of `Reorient Q σ` carried by an arrow of `Q` which `σ` turns around: it runs from
 the head of the original arrow to its tail. -/
-@[expose]
 def reorientFlip {i j : Q} (a : j ⟶ i) (h : σ a) : reorientVertex σ i ⟶ reorientVertex σ j :=
   Sum.inr ⟨a, h⟩
 
@@ -126,9 +122,7 @@ def reorientFlip {i j : Q} (a : j ⟶ i) (h : σ a) : reorientVertex σ i ⟶ re
 `Reorient Q σ` are the arrows `i ⟶ j` of `Q` which `σ` leaves alone together with the arrows
 `j ⟶ i` of `Q` which `σ` turns around. This equivalence is the general elimination interface for a
 reoriented hom set, so no consumer needs to unfold `TauCeti.reorientQuiver`;
-`TauCeti.reorientHom_induction` is its tactic form. Exposed, like `TauCeti.reorientKeep` and
-`TauCeti.reorientFlip`, because its own computation lemmas below are proved by `rfl`. -/
-@[expose]
+`TauCeti.reorientHom_induction_on` is its tactic form. -/
 def reorientHomEquiv (i j : Q) :
     (reorientVertex σ i ⟶ reorientVertex σ j) ≃ {a : i ⟶ j // ¬ σ a} ⊕ {a : j ⟶ i // σ a} :=
   Equiv.refl _
@@ -137,31 +131,31 @@ def reorientHomEquiv (i j : Q) :
 @[simp]
 theorem reorientHomEquiv_reorientKeep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
     reorientHomEquiv σ i j (reorientKeep σ a h) = Sum.inl ⟨a, h⟩ :=
-  rfl
+  (rfl)
 
 /-- The elimination equivalence sends an arrow `σ` turns around to the right summand. -/
 @[simp]
 theorem reorientHomEquiv_reorientFlip {i j : Q} (a : j ⟶ i) (h : σ a) :
     reorientHomEquiv σ i j (reorientFlip σ a h) = Sum.inr ⟨a, h⟩ :=
-  rfl
+  (rfl)
 
 /-- The left summand of the elimination equivalence is an arrow `σ` leaves alone. -/
 @[simp]
 theorem reorientHomEquiv_symm_inl {i j : Q} (x : {a : i ⟶ j // ¬ σ a}) :
     (reorientHomEquiv σ i j).symm (Sum.inl x) = reorientKeep σ x.1 x.2 :=
-  rfl
+  (rfl)
 
 /-- The right summand of the elimination equivalence is an arrow `σ` turns around. -/
 @[simp]
 theorem reorientHomEquiv_symm_inr {i j : Q} (y : {a : j ⟶ i // σ a}) :
     (reorientHomEquiv σ i j).symm (Sum.inr y) = reorientFlip σ y.1 y.2 :=
-  rfl
+  (rfl)
 
 /-- **Case analysis on an arrow of a reorientation**: it is either an arrow of `Q` which `σ` leaves
 alone or an arrow of `Q` which `σ` turns around. This is the tactic form of
 `TauCeti.reorientHomEquiv`. -/
 @[elab_as_elim]
-theorem reorientHom_induction {i j : Q}
+theorem reorientHom_induction_on {i j : Q}
     {motive : (reorientVertex σ i ⟶ reorientVertex σ j) → Prop}
     (b : reorientVertex σ i ⟶ reorientVertex σ j)
     (keep : ∀ (a : i ⟶ j) (h : ¬ σ a), motive (reorientKeep σ a h))
@@ -188,7 +182,8 @@ theorem sum_reorientHom {M : Type*} [AddCommMonoid M] [∀ i j : Q, Fintype (i �
 /-- The comparison prefunctor from the doubled reoriented quiver to the doubled quiver. It is the
 identity on vertices; on arrows it forgets which of the four pieces of a hom set of
 `Symmetrify (Reorient Q σ)` an arrow came from and remembers only whether it runs forwards or
-backwards in `Q`. -/
+backwards in `Q`. The body is exposed because the dependent source and target types of its public
+arrow-map equations contain the object map. -/
 @[expose]
 def reorientSymmetrify : Symmetrify (Reorient Q σ) ⥤q Symmetrify Q where
   obj := id
@@ -201,8 +196,8 @@ def reorientSymmetrify : Symmetrify (Reorient Q σ) ⥤q Symmetrify Q where
 
 /-- The inverse comparison: an arrow of the doubled quiver is sorted into one of the four pieces of
 a hom set of `Symmetrify (Reorient Q σ)` according to whether it runs forwards or backwards in `Q`
-and whether `σ` turns it around. Its object map remains exposed because reducing `obj := id` is
-needed to typecheck the dependent source and target types of its public arrow-map equations. -/
+and whether `σ` turns it around. As for `TauCeti.reorientSymmetrify`, exposure is needed for the
+dependent endpoint types of its public arrow-map equations. -/
 @[expose]
 def reorientSymmetrifyInv : Symmetrify Q ⥤q Symmetrify (Reorient Q σ) where
   obj := id
@@ -216,12 +211,12 @@ def reorientSymmetrifyInv : Symmetrify Q ⥤q Symmetrify (Reorient Q σ) where
 /-- The comparison of doubled quivers is the identity on vertices. -/
 @[simp]
 theorem reorientSymmetrify_obj (i : Symmetrify (Reorient Q σ)) :
-    (reorientSymmetrify σ).obj i = i := rfl
+    (reorientSymmetrify σ).obj i = i := (rfl)
 
 /-- The inverse comparison of doubled quivers is the identity on vertices. -/
 @[simp]
 theorem reorientSymmetrifyInv_obj (i : Symmetrify Q) :
-    (reorientSymmetrifyInv σ).obj i = i := rfl
+    (reorientSymmetrifyInv σ).obj i = i := (rfl)
 
 /-- The defining case distinction of the inverse comparison on an arrow of `Q`, stated in terms of
 `TauCeti.reorientKeep` and `TauCeti.reorientFlip`. The two sides are definitionally equal, the
@@ -231,7 +226,7 @@ private theorem reorientSymmetrifyInv_map_of {i j : Q} (a : i ⟶ j) :
     (reorientSymmetrifyInv σ).map (Symmetrify.of.map a) =
       if h : σ a then Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h))
         else Symmetrify.of.map (reorientKeep σ a h) :=
-  rfl
+  (rfl)
 
 /-- The defining case distinction of the inverse comparison on the formal reverse of an arrow of
 `Q`; see `TauCeti.reorientSymmetrifyInv_map_of`. -/
@@ -239,7 +234,7 @@ private theorem reorientSymmetrifyInv_map_reverse_of {i j : Q} (a : i ⟶ j) :
     (reorientSymmetrifyInv σ).map (Quiver.reverse (Symmetrify.of.map a)) =
       if h : σ a then Symmetrify.of.map (reorientFlip σ a h)
         else Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h)) :=
-  rfl
+  (rfl)
 
 /-- The inverse comparison sends an arrow which `σ` leaves alone to the corresponding arrow of the
 reoriented quiver. Deliberately not a `simp` lemma: `Quiver.Symmetrify.of_map` rewrites
@@ -278,7 +273,7 @@ theorem reorientSymmetrifyInv_map_reverse_of_flip {i j : Q} (a : i ⟶ j) (h : �
 theorem reorientSymmetrify_map_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
     (reorientSymmetrify σ).map (Symmetrify.of.map (reorientKeep σ a h)) =
       Symmetrify.of.map a :=
-  rfl
+  (rfl)
 
 /-- The formal reverse of an arrow which `σ` leaves alone stays a formal reverse. Deliberately not
 a `simp` lemma: `Quiver.symmetrify_reverse` rewrites `Quiver.reverse` to `Sum.swap` on the left-hand
@@ -286,21 +281,21 @@ side, and `simpNF` rejects the pair. -/
 theorem reorientSymmetrify_map_reverse_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
     (reorientSymmetrify σ).map (Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h))) =
       Quiver.reverse (Symmetrify.of.map a) :=
-  rfl
+  (rfl)
 
 /-- An arrow of `Q` which `σ` turns around becomes the formal reverse of itself. -/
 @[simp]
 theorem reorientSymmetrify_map_of_flip {i j : Q} (a : j ⟶ i) (h : σ a) :
     (reorientSymmetrify σ).map (Symmetrify.of.map (reorientFlip σ a h)) =
       Quiver.reverse (Symmetrify.of.map a) :=
-  rfl
+  (rfl)
 
 /-- The formal reverse of a turned-around arrow is the arrow itself. Deliberately not a `simp`
 lemma, for the reason recorded on `TauCeti.reorientSymmetrify_map_reverse_of_keep`. -/
 theorem reorientSymmetrify_map_reverse_of_flip {i j : Q} (a : j ⟶ i) (h : σ a) :
     (reorientSymmetrify σ).map (Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h))) =
       Symmetrify.of.map a :=
-  rfl
+  (rfl)
 
 /-- **The two comparisons are inverse**, starting from the reoriented quiver. -/
 theorem reorientSymmetrify_comp_reorientSymmetrifyInv :

--- a/TauCeti/Combinatorics/Quiver/Reorient.lean
+++ b/TauCeti/Combinatorics/Quiver/Reorient.lean
@@ -268,8 +268,9 @@ theorem reorientSymmetrifyInv_map_reverse_of_flip {i j : Q} (a : i ⟶ j) (h : �
       Symmetrify.of.map (reorientFlip σ a h) := by
   rw [reorientSymmetrifyInv_map_reverse_of, dite_eq_left h]
 
-/-- An arrow of `Q` which `σ` leaves alone stays an arrow of the doubled quiver. -/
-@[simp]
+/-- An arrow of `Q` which `σ` leaves alone stays an arrow of the doubled quiver. Deliberately not a
+`simp` lemma: `Quiver.Symmetrify.of_map` rewrites `Symmetrify.of.map ...` to `Sum.inl ...` on the
+left-hand side, and `simpNF` rejects it. -/
 theorem reorientSymmetrify_map_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
     (reorientSymmetrify σ).map (Symmetrify.of.map (reorientKeep σ a h)) =
       Symmetrify.of.map a :=
@@ -283,8 +284,8 @@ theorem reorientSymmetrify_map_reverse_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ �
       Quiver.reverse (Symmetrify.of.map a) :=
   (rfl)
 
-/-- An arrow of `Q` which `σ` turns around becomes the formal reverse of itself. -/
-@[simp]
+/-- An arrow of `Q` which `σ` turns around becomes the formal reverse of itself. Deliberately not a
+`simp` lemma, for the reason recorded on `TauCeti.reorientSymmetrify_map_of_keep`. -/
 theorem reorientSymmetrify_map_of_flip {i j : Q} (a : j ⟶ i) (h : σ a) :
     (reorientSymmetrify σ).map (Symmetrify.of.map (reorientFlip σ a h)) =
       Quiver.reverse (Symmetrify.of.map a) :=

--- a/TauCeti/Combinatorics/Quiver/Reorient.lean
+++ b/TauCeti/Combinatorics/Quiver/Reorient.lean
@@ -5,10 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Combinatorics.Quiver.Symmetric
 public import Mathlib.Data.Fintype.BigOperators
 public import Mathlib.Data.Fintype.Sum
 public import TauCeti.Combinatorics.Quiver.Prefunctor
-public import TauCeti.RepresentationTheory.Quiver.Symmetrify
 
 /-!
 # Reorienting a quiver
@@ -173,15 +173,31 @@ theorem reorientSymmetrify_obj (i : Symmetrify (Reorient Q σ)) :
 theorem reorientSymmetrifyInv_obj (i : Symmetrify Q) :
     (reorientSymmetrifyInv σ).obj i = i := rfl
 
+/-- The defining case distinction of the inverse comparison on an arrow of `Q`, stated in terms of
+`TauCeti.reorientKeep` and `TauCeti.reorientFlip`. The two sides are definitionally equal, the
+`if`-branches being the two constructors of the reoriented hom set repackaged; the four public
+equations below are the two instances of each branch. -/
+private theorem reorientSymmetrifyInv_map_of {i j : Q} (a : i ⟶ j) :
+    (reorientSymmetrifyInv σ).map (Symmetrify.of.map a) =
+      if h : σ a then Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h))
+        else Symmetrify.of.map (reorientKeep σ a h) :=
+  rfl
+
+/-- The defining case distinction of the inverse comparison on the formal reverse of an arrow of
+`Q`; see `TauCeti.reorientSymmetrifyInv_map_of`. -/
+private theorem reorientSymmetrifyInv_map_reverse_of {i j : Q} (a : i ⟶ j) :
+    (reorientSymmetrifyInv σ).map (Quiver.reverse (Symmetrify.of.map a)) =
+      if h : σ a then Symmetrify.of.map (reorientFlip σ a h)
+        else Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h)) :=
+  rfl
+
 /-- The inverse comparison sends an arrow which `σ` leaves alone to the corresponding arrow of the
 reoriented quiver. Deliberately not a `simp` lemma: `Quiver.Symmetrify.of_map` rewrites
 `Symmetrify.of.map a` to `Sum.inl a` on the left-hand side, and `simpNF` rejects it. -/
 theorem reorientSymmetrifyInv_map_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
     (reorientSymmetrifyInv σ).map (Symmetrify.of.map a) =
       Symmetrify.of.map (reorientKeep σ a h) := by
-  change (if h' : σ a then Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h'))
-    else Symmetrify.of.map (reorientKeep σ a h')) = Symmetrify.of.map (reorientKeep σ a h)
-  rw [dite_eq_right h]
+  rw [reorientSymmetrifyInv_map_of, dite_eq_right h]
 
 /-- The inverse comparison sends the formal reverse of an arrow which `σ` leaves alone to the
 formal reverse of the corresponding reoriented arrow. Deliberately not a `simp` lemma: simplifying
@@ -189,10 +205,7 @@ formal reversal first would make this a non-normal-form rule. -/
 theorem reorientSymmetrifyInv_map_reverse_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
     (reorientSymmetrifyInv σ).map (Quiver.reverse (Symmetrify.of.map a)) =
       Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h)) := by
-  change (if h' : σ a then Symmetrify.of.map (reorientFlip σ a h')
-    else Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h'))) =
-      Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h))
-  rw [dite_eq_right h]
+  rw [reorientSymmetrifyInv_map_reverse_of, dite_eq_right h]
 
 /-- The inverse comparison sends an arrow which `σ` turns around to the formal reverse of the
 corresponding reoriented arrow. Deliberately not a `simp` lemma, for the reason recorded on
@@ -200,10 +213,7 @@ corresponding reoriented arrow. Deliberately not a `simp` lemma, for the reason 
 theorem reorientSymmetrifyInv_map_of_flip {i j : Q} (a : i ⟶ j) (h : σ a) :
     (reorientSymmetrifyInv σ).map (Symmetrify.of.map a) =
       Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h)) := by
-  change (if h' : σ a then Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h'))
-    else Symmetrify.of.map (reorientKeep σ a h')) =
-      Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h))
-  rw [dite_eq_left h]
+  rw [reorientSymmetrifyInv_map_of, dite_eq_left h]
 
 /-- The inverse comparison sends the formal reverse of an arrow which `σ` turns around to the
 corresponding reoriented arrow. Deliberately not a `simp` lemma, for the reason recorded on
@@ -211,10 +221,7 @@ corresponding reoriented arrow. Deliberately not a `simp` lemma, for the reason 
 theorem reorientSymmetrifyInv_map_reverse_of_flip {i j : Q} (a : i ⟶ j) (h : σ a) :
     (reorientSymmetrifyInv σ).map (Quiver.reverse (Symmetrify.of.map a)) =
       Symmetrify.of.map (reorientFlip σ a h) := by
-  change (if h' : σ a then Symmetrify.of.map (reorientFlip σ a h')
-    else Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h'))) =
-      Symmetrify.of.map (reorientFlip σ a h)
-  rw [dite_eq_left h]
+  rw [reorientSymmetrifyInv_map_reverse_of, dite_eq_left h]
 
 /-- An arrow of `Q` which `σ` leaves alone stays an arrow of the doubled quiver. -/
 @[simp]

--- a/TauCeti/Combinatorics/Quiver/Reorient.lean
+++ b/TauCeti/Combinatorics/Quiver/Reorient.lean
@@ -28,6 +28,9 @@ identification along which a construction on doubled quivers -- the additive pre
 ## Main definitions
 
 * `TauCeti.Reorient`: the quiver `Q` with the arrows labelled `true` by `σ` turned around.
+* `TauCeti.reorientHomEquiv`: the identification of a hom set of `Reorient Q σ` with the two
+  subtypes of hom sets of `Q` it is built from, together with `TauCeti.reorientHom_induction` the
+  general elimination interface for a reoriented arrow.
 * `TauCeti.reorientSymmetrify` and `TauCeti.reorientSymmetrifyInv`: the two prefunctors between
   the doubled quivers.
 
@@ -118,6 +121,53 @@ the head of the original arrow to its tail. -/
 @[expose]
 def reorientFlip {i j : Q} (a : j ⟶ i) (h : σ a) : reorientVertex σ i ⟶ reorientVertex σ j :=
   Sum.inr ⟨a, h⟩
+
+/-- **Every arrow of a reorientation is one of the two kinds**: the arrows `i ⟶ j` of
+`Reorient Q σ` are the arrows `i ⟶ j` of `Q` which `σ` leaves alone together with the arrows
+`j ⟶ i` of `Q` which `σ` turns around. This equivalence is the general elimination interface for a
+reoriented hom set, so no consumer needs to unfold `TauCeti.reorientQuiver`;
+`TauCeti.reorientHom_induction` is its tactic form. Exposed, like `TauCeti.reorientKeep` and
+`TauCeti.reorientFlip`, because its own computation lemmas below are proved by `rfl`. -/
+@[expose]
+def reorientHomEquiv (i j : Q) :
+    (reorientVertex σ i ⟶ reorientVertex σ j) ≃ {a : i ⟶ j // ¬ σ a} ⊕ {a : j ⟶ i // σ a} :=
+  Equiv.refl _
+
+/-- The elimination equivalence sends an arrow `σ` leaves alone to the left summand. -/
+@[simp]
+theorem reorientHomEquiv_reorientKeep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
+    reorientHomEquiv σ i j (reorientKeep σ a h) = Sum.inl ⟨a, h⟩ :=
+  rfl
+
+/-- The elimination equivalence sends an arrow `σ` turns around to the right summand. -/
+@[simp]
+theorem reorientHomEquiv_reorientFlip {i j : Q} (a : j ⟶ i) (h : σ a) :
+    reorientHomEquiv σ i j (reorientFlip σ a h) = Sum.inr ⟨a, h⟩ :=
+  rfl
+
+/-- The left summand of the elimination equivalence is an arrow `σ` leaves alone. -/
+@[simp]
+theorem reorientHomEquiv_symm_inl {i j : Q} (x : {a : i ⟶ j // ¬ σ a}) :
+    (reorientHomEquiv σ i j).symm (Sum.inl x) = reorientKeep σ x.1 x.2 :=
+  rfl
+
+/-- The right summand of the elimination equivalence is an arrow `σ` turns around. -/
+@[simp]
+theorem reorientHomEquiv_symm_inr {i j : Q} (y : {a : j ⟶ i // σ a}) :
+    (reorientHomEquiv σ i j).symm (Sum.inr y) = reorientFlip σ y.1 y.2 :=
+  rfl
+
+/-- **Case analysis on an arrow of a reorientation**: it is either an arrow of `Q` which `σ` leaves
+alone or an arrow of `Q` which `σ` turns around. This is the tactic form of
+`TauCeti.reorientHomEquiv`. -/
+@[elab_as_elim]
+theorem reorientHom_induction {i j : Q}
+    {motive : (reorientVertex σ i ⟶ reorientVertex σ j) → Prop}
+    (b : reorientVertex σ i ⟶ reorientVertex σ j)
+    (keep : ∀ (a : i ⟶ j) (h : ¬ σ a), motive (reorientKeep σ a h))
+    (flip : ∀ (a : j ⟶ i) (h : σ a), motive (reorientFlip σ a h)) : motive b := by
+  obtain ⟨a, h⟩ | ⟨a, h⟩ := b
+  exacts [keep a h, flip a h]
 
 /-- A sum over the vertices of a reorientation is a sum over the vertices of `Q`. -/
 theorem sum_reorientVertex {M : Type*} [AddCommMonoid M] [Fintype Q] (f : Reorient Q σ → M) :

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Basic.lean
@@ -116,6 +116,13 @@ keeps the doubled quiver structure from being replaced by that of `Q`. -/
 noncomputable def doubledVertexIdempotent (v : Q) : pathAlgebra k (Symmetrify Q) :=
   @vertexIdempotent k (Symmetrify Q) _ (symmetrifyQuiver Q) (Symmetrify.of.obj v)
 
+/-- The doubled vertex idempotent is the vertex idempotent of the doubled quiver. This is the
+defining equation, exposed for use outside this module. -/
+theorem doubledVertexIdempotent_def (v : Q) :
+    doubledVertexIdempotent k v =
+      @vertexIdempotent k (Symmetrify Q) _ (symmetrifyQuiver Q) (Symmetrify.of.obj v) := by
+  rw [doubledVertexIdempotent]
+
 /-- The **head backtrack** of an arrow `a : i ⟶ j`: the length-two loop of the doubled quiver at
 the head `j` of `a` which traverses the formal reverse `a*` and then `a`. In Tau Ceti's
 later-factor-first convention this is the product `ofArrow a * ofArrow (reverse a)`, which is the

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Gauge.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Gauge.lean
@@ -63,11 +63,10 @@ negates under reversal. The `-` sign in `ρ_ε` is exactly the antisymmetry of t
 
 Reversing the orientation of an arrow of `Q` is here a change of the labelling `ε`, not a change of
 the quiver: the results below establish gauge independence for the labellings of one fixed quiver
-and hence in one fixed doubled path algebra. The doubled quivers attached to two reorientations of
-a common underlying graph are canonically isomorphic, but comparing their algebras additionally
-needs the induced path-algebra isomorphism, which does not exist in this repository and is not
-built here. So the cross-quiver form of orientation independence, which quantifies over two quivers
-with a common underlying graph, is deliberately left unstated by this file.
+and hence in one fixed doubled path algebra. The cross-quiver form of orientation independence,
+which compares the preprojective algebras of two quivers with a common underlying graph, is proved
+in `TauCeti.RepresentationTheory.Quiver.Preprojective.Orientation`; it consumes the gauge
+isomorphism below after identifying the two doubled path algebras.
 
 ## References
 
@@ -75,8 +74,9 @@ This is the gauge clause of Layer 4 of `TauCetiRoadmap/ZigzagPreprojective/READM
 to reverse a chosen arrow by an algebra isomorphism rescaling one of the exchanged arrows by `-1`,
 and then to generalize from signs to an antisymmetric sign function on oriented edges and prove
 independence under the explicit gauge change. This file proves that gauge clause; the cross-quiver
-clause preceding it is not proved here. See Crawley-Boevey, *Quiver algebras, weighted
-projective lines, and the Deligne--Simpson problem*, Section 1.
+clause preceding it is proved in
+`TauCeti.RepresentationTheory.Quiver.Preprojective.Orientation`. See Crawley-Boevey, *Quiver
+algebras, weighted projective lines, and the Deligne--Simpson problem*, Section 1.
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Gauge.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Gauge.lean
@@ -63,9 +63,9 @@ negates under reversal. The `-` sign in `ρ_ε` is exactly the antisymmetry of t
 
 Reversing the orientation of an arrow of `Q` is here a change of the labelling `ε`, not a change of
 the quiver: the results below establish gauge independence for the labellings of one fixed quiver
-and hence in one fixed doubled path algebra. The cross-quiver form of orientation independence,
-which compares the preprojective algebras of two quivers with a common underlying graph, is proved
-in `TauCeti.RepresentationTheory.Quiver.Preprojective.Orientation`; it consumes the gauge
+and hence in one fixed doubled path algebra. The reorientation form of orientation independence,
+which compares `Q` with an explicit `Reorient Q σ`, is proved in
+`TauCeti.RepresentationTheory.Quiver.Preprojective.Orientation`; it consumes the gauge
 isomorphism below after identifying the two doubled path algebras.
 
 ## References

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
@@ -5,9 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Combinatorics.Quiver.Reorient
 public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.Map
 public import TauCeti.RepresentationTheory.Quiver.Preprojective.Gauge
-public import TauCeti.RepresentationTheory.Quiver.Reorient
 
 /-!
 # Orientation independence of the additive preprojective algebra
@@ -66,6 +66,10 @@ obtained from the same proof.
 * `TauCeti.reorientPreprojectiveAlgebraEquiv_preprojectiveMk`: the isomorphism, computed on an
   arbitrary quotient representative, as the doubled-quiver identification followed by the rescaling
   by `-1` of the turned-around arrows.
+* `TauCeti.reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_keep` and its three
+  companions: the isomorphism, computed on each of the four kinds of generator. An arrow `σ` leaves
+  alone and its formal reverse are fixed, a turned-around arrow is carried to a formal reverse, and
+  the formal reverse of a turned-around arrow is carried to the negative of an arrow.
 
 ## Implementation notes
 
@@ -95,15 +99,11 @@ universe u v w
 
 section Sign
 
-variable (k : Type w) {Q : Type u} [Ring k] [Quiver.{v + 1} Q]
+variable (k : Type w) {Q : Type u} [One k] [Neg k] [Quiver.{v + 1} Q]
 
 /-- The sign labelling attached to a reorientation: an arrow which `σ` turns around enters the
 preprojective relator with the opposite sign, and every other arrow keeps its sign. -/
 def reorientSign (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) ⦃i j : Q⦄ (a : i ⟶ j) : k :=
-  if σ a then -1 else 1
-
-/-- The sign labelling, valued in the units of `k`. -/
-def reorientSignUnit (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) ⦃i j : Q⦄ (a : i ⟶ j) : kˣ :=
   if σ a then -1 else 1
 
 /-- A turned-around arrow gets the sign `-1`. -/
@@ -118,6 +118,16 @@ theorem reorientSign_of_false {σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool} {i j 
     (h : ¬ σ a) : reorientSign k σ a = 1 := by
   simp [reorientSign, h]
 
+end Sign
+
+section SignUnit
+
+variable (k : Type w) {Q : Type u} [Ring k] [Quiver.{v + 1} Q]
+
+/-- The sign labelling, valued in the units of `k`. -/
+def reorientSignUnit (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) ⦃i j : Q⦄ (a : i ⟶ j) : kˣ :=
+  if σ a then -1 else 1
+
 /-- The sign labelling takes values in `{1, -1}`, so it is its own inverse. -/
 @[simp]
 theorem reorientSignUnit_inv (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) ⦃i j : Q⦄ (a : i ⟶ j) :
@@ -131,7 +141,7 @@ theorem reorientSign_eq_coe_reorientSignUnit (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) 
   rw [reorientSign, reorientSignUnit]
   split <;> simp
 
-end Sign
+end SignUnit
 
 /-! ### The induced isomorphism of doubled path algebras -/
 
@@ -159,6 +169,13 @@ private theorem reorientDoubledEquiv_ofArrowComp {i j l : Symmetrify (Reorient Q
   rw [reorientDoubledEquiv, mapAlgEquiv_apply, mapAlgHom_ofPath,
     Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp, Prefunctor.mapPath_toPath,
     Prefunctor.mapPath_toPath]
+
+/-- Pushing an arrow of the doubled reoriented quiver along the comparison carries it to the image
+arrow. Deliberately not a `simp` lemma, `TauCeti.PathAlgebra.ofArrow_eq_ofPath` already rewriting
+its left-hand side. -/
+theorem reorientDoubledEquiv_ofArrow {x y : Symmetrify (Reorient Q σ)} (b : x ⟶ y) :
+    reorientDoubledEquiv k σ (ofArrow b) = ofArrow ((reorientSymmetrify σ).map b) := by
+  rw [reorientDoubledEquiv, mapAlgEquiv_apply, mapAlgHom_ofArrow]
 
 /-- An arrow which `σ` leaves alone keeps its head backtrack. -/
 @[simp]
@@ -377,6 +394,72 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk
     reorientPreprojectiveAlgebraEquivGauged_preprojectiveMk,
     preprojectiveAlgebraEquivGauged_symm_gaugedPreprojectiveMk]
   simp only [reorientSignUnit_inv, ← reorientSign_eq_coe_reorientSignUnit]
+
+/-! The four equations below compute the isomorphism on the generators of the reoriented algebra,
+which are the arrows of `Symmetrify (Reorient Q σ)`. They are deliberately not `simp` lemmas,
+`TauCeti.PathAlgebra.ofArrow_eq_ofPath` and `Quiver.Symmetrify.of_map` already rewriting their
+left-hand sides. Each proof isolates the image of the generator in a `have`, whose statement names
+the vertices of `Q` directly where rewriting leaves them spelled `(reorientSymmetrify σ).obj v`;
+those two spellings are definitionally equal, which is what the closing `rfl` uses, but they are
+not syntactically equal, so rewriting further inside the un-normalized form fails. -/
+
+/-- **The isomorphism fixes an arrow which `σ` leaves alone.** -/
+theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_keep {i j : Q} (a : i ⟶ j)
+    (ha : ¬ σ a) :
+    reorientPreprojectiveAlgebraEquiv k σ
+        (preprojectiveMk k (Reorient Q σ) (ofArrow (Symmetrify.of.map (reorientKeep σ a ha))))
+      = preprojectiveMk k Q (ofArrow (Symmetrify.of.map a)) := by
+  have h : reorientDoubledEquiv k σ (ofArrow (Symmetrify.of.map (reorientKeep σ a ha)))
+      = ofArrow (Symmetrify.of.map a) := by
+    rw [reorientDoubledEquiv_ofArrow, reorientSymmetrify_map_of_keep]
+    rfl
+  rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow, doubledLabelling_of,
+    reorientSign_of_false k ha, one_smul]
+
+/-- **The isomorphism fixes the formal reverse of an arrow which `σ` leaves alone.** -/
+theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_reverse_keep {i j : Q}
+    (a : i ⟶ j) (ha : ¬ σ a) :
+    reorientPreprojectiveAlgebraEquiv k σ (preprojectiveMk k (Reorient Q σ)
+        (ofArrow (Quiver.reverse (Symmetrify.of.map (reorientKeep σ a ha)))))
+      = preprojectiveMk k Q (ofArrow (Quiver.reverse (Symmetrify.of.map a))) := by
+  have h : reorientDoubledEquiv k σ
+        (ofArrow (Quiver.reverse (Symmetrify.of.map (reorientKeep σ a ha))))
+      = ofArrow (Quiver.reverse (Symmetrify.of.map a)) := by
+    rw [reorientDoubledEquiv_ofArrow, reorientSymmetrify_map_reverse_of_keep]
+    rfl
+  rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow,
+    doubledLabelling_reverse_of, one_smul]
+
+/-- **The isomorphism exchanges a turned-around arrow with a formal reverse**, without a sign: the
+arrow of `Reorient Q σ` carried by a turned-around arrow `a` of `Q` goes to the formal reverse
+of `a`. -/
+theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_flip {i j : Q} (a : j ⟶ i)
+    (ha : σ a) :
+    reorientPreprojectiveAlgebraEquiv k σ
+        (preprojectiveMk k (Reorient Q σ) (ofArrow (Symmetrify.of.map (reorientFlip σ a ha))))
+      = preprojectiveMk k Q (ofArrow (Quiver.reverse (Symmetrify.of.map a))) := by
+  have h : reorientDoubledEquiv k σ (ofArrow (Symmetrify.of.map (reorientFlip σ a ha)))
+      = ofArrow (Quiver.reverse (Symmetrify.of.map a)) := by
+    rw [reorientDoubledEquiv_ofArrow, reorientSymmetrify_map_of_flip]
+    rfl
+  rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow,
+    doubledLabelling_reverse_of, one_smul]
+
+/-- **The isomorphism negates the formal reverse of a turned-around arrow.** This is the one
+generator carrying the sign which repairs the change of orientation; every other generator above is
+carried to a generator on the nose. -/
+theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_reverse_flip {i j : Q}
+    (a : j ⟶ i) (ha : σ a) :
+    reorientPreprojectiveAlgebraEquiv k σ (preprojectiveMk k (Reorient Q σ)
+        (ofArrow (Quiver.reverse (Symmetrify.of.map (reorientFlip σ a ha)))))
+      = -preprojectiveMk k Q (ofArrow (Symmetrify.of.map a)) := by
+  have h : reorientDoubledEquiv k σ
+        (ofArrow (Quiver.reverse (Symmetrify.of.map (reorientFlip σ a ha))))
+      = ofArrow (Symmetrify.of.map a) := by
+    rw [reorientDoubledEquiv_ofArrow, reorientSymmetrify_map_reverse_of_flip]
+    rfl
+  rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow, doubledLabelling_of,
+    reorientSign_of_true k ha, neg_one_smul, map_neg]
 
 end Independence
 

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
@@ -41,7 +41,7 @@ sign-flipped arrows by `-1` and fixes their formal reverses, gives
 
 Turning around a single arrow is the case of a labelling supported on one arrow; an arbitrary `σ`
 performs an arbitrary composite of such flips in one step, so the isomorphism above compares `Q`
-with the result of any prescribed reorientation of its arrows. Nothing is assumed about the
+with the explicit quiver `Reorient Q σ`. Nothing is assumed about the
 characteristic of `k`: in characteristic two the sign is invisible, and the same statement is
 obtained from the same proof.
 
@@ -84,8 +84,8 @@ what the transposition step of the proof does; the equality does *not* hold hom 
 This is the orientation-independence clause of Layer 4 of
 `TauCetiRoadmap/ZigzagPreprojective/README.md`, which asks to turn around a chosen arrow by an
 algebra isomorphism rescaling one of the exchanged arrows by `-1`, to check that it sends every
-local relation to the corresponding relation, and to compose these maps into independence of all
-orientations of a fixed underlying graph, including in characteristic two. See Crawley-Boevey,
+local relation to the corresponding relation, and to compose these maps into independence under
+every explicit reorientation `Reorient Q σ`, including in characteristic two. See Crawley-Boevey,
 *Quiver algebras, weighted projective lines, and the Deligne--Simpson problem*, Section 1.
 -/
 
@@ -176,6 +176,18 @@ its left-hand side. -/
 theorem reorientDoubledEquiv_ofArrow {x y : Symmetrify (Reorient Q σ)} (b : x ⟶ y) :
     reorientDoubledEquiv k σ (ofArrow b) = ofArrow ((reorientSymmetrify σ).map b) := by
   rw [reorientDoubledEquiv, mapAlgEquiv_apply, mapAlgHom_ofArrow]
+
+/-- The arrow computation for the doubled path-algebra comparison, with its object map normalized
+to the vertices of the reoriented quiver. -/
+theorem reorientDoubledEquiv_ofArrow_normalized {x y : Symmetrify (Reorient Q σ)} (b : x ⟶ y) :
+    reorientDoubledEquiv k σ (ofArrow b) =
+      ofArrow (Quiver.homOfEq ((reorientSymmetrify σ).map b)
+        (reorientSymmetrify_obj σ x :
+          (reorientSymmetrify σ).obj x = (show Symmetrify Q from x))
+        (reorientSymmetrify_obj σ y :
+          (reorientSymmetrify σ).obj y = (show Symmetrify Q from y))) := by
+  rw [reorientDoubledEquiv_ofArrow]
+  exact (ofArrow_homOfEq _ _ _).symm
 
 /-- An arrow which `σ` leaves alone keeps its head backtrack. -/
 @[simp]
@@ -398,10 +410,9 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk
 /-! The four equations below compute the isomorphism on the generators of the reoriented algebra,
 which are the arrows of `Symmetrify (Reorient Q σ)`. They are deliberately not `simp` lemmas,
 `TauCeti.PathAlgebra.ofArrow_eq_ofPath` and `Quiver.Symmetrify.of_map` already rewriting their
-left-hand sides. Each proof isolates the image of the generator in a `have`, whose statement names
-the vertices of `Q` directly where rewriting leaves them spelled `(reorientSymmetrify σ).obj v`;
-those two spellings are definitionally equal, which is what the closing `rfl` uses, but they are
-not syntactically equal, so rewriting further inside the un-normalized form fails. -/
+left-hand sides. Each proof computes the image through
+`TauCeti.reorientDoubledEquiv_ofArrow_normalized`, so the object map is rewritten explicitly rather
+than discharged by definitional equality. -/
 
 /-- **The isomorphism fixes an arrow which `σ` leaves alone.** -/
 theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_keep {i j : Q} (a : i ⟶ j)
@@ -411,8 +422,9 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_keep {i j : Q}
       = preprojectiveMk k Q (ofArrow (Symmetrify.of.map a)) := by
   have h : reorientDoubledEquiv k σ (ofArrow (Symmetrify.of.map (reorientKeep σ a ha)))
       = ofArrow (Symmetrify.of.map a) := by
-    rw [reorientDoubledEquiv_ofArrow, reorientSymmetrify_map_of_keep]
-    rfl
+    rw [reorientDoubledEquiv_ofArrow_normalized]
+    rw [reorientSymmetrify_map_of_keep]
+    exact ofArrow_homOfEq _ _ _
   rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow, doubledLabelling_of,
     reorientSign_of_false k ha, one_smul]
 
@@ -425,8 +437,9 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_reverse_keep {
   have h : reorientDoubledEquiv k σ
         (ofArrow (Quiver.reverse (Symmetrify.of.map (reorientKeep σ a ha))))
       = ofArrow (Quiver.reverse (Symmetrify.of.map a)) := by
-    rw [reorientDoubledEquiv_ofArrow, reorientSymmetrify_map_reverse_of_keep]
-    rfl
+    rw [reorientDoubledEquiv_ofArrow_normalized]
+    rw [reorientSymmetrify_map_reverse_of_keep]
+    exact ofArrow_homOfEq _ _ _
   rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow,
     doubledLabelling_reverse_of, one_smul]
 
@@ -440,8 +453,9 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_flip {i j : Q}
       = preprojectiveMk k Q (ofArrow (Quiver.reverse (Symmetrify.of.map a))) := by
   have h : reorientDoubledEquiv k σ (ofArrow (Symmetrify.of.map (reorientFlip σ a ha)))
       = ofArrow (Quiver.reverse (Symmetrify.of.map a)) := by
-    rw [reorientDoubledEquiv_ofArrow, reorientSymmetrify_map_of_flip]
-    rfl
+    rw [reorientDoubledEquiv_ofArrow_normalized]
+    rw [reorientSymmetrify_map_of_flip]
+    exact ofArrow_homOfEq _ _ _
   rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow,
     doubledLabelling_reverse_of, one_smul]
 
@@ -456,8 +470,9 @@ theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk_ofArrow_reverse_flip {
   have h : reorientDoubledEquiv k σ
         (ofArrow (Quiver.reverse (Symmetrify.of.map (reorientFlip σ a ha))))
       = ofArrow (Symmetrify.of.map a) := by
-    rw [reorientDoubledEquiv_ofArrow, reorientSymmetrify_map_reverse_of_flip]
-    rfl
+    rw [reorientDoubledEquiv_ofArrow_normalized]
+    rw [reorientSymmetrify_map_reverse_of_flip]
+    exact ofArrow_homOfEq _ _ _
   rw [reorientPreprojectiveAlgebraEquiv_preprojectiveMk, h, rescale_ofArrow, doubledLabelling_of,
     reorientSign_of_true k ha, neg_one_smul, map_neg]
 

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
@@ -137,7 +137,7 @@ end Sign
 
 section Doubled
 
-variable (k : Type w) {Q : Type u} [CommRing k] [Quiver.{v + 1} Q] [Finite Q]
+variable (k : Type w) {Q : Type u} [CommSemiring k] [Quiver.{v + 1} Q] [Finite Q]
   (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool)
 
 /-- **The isomorphism of doubled path algebras attached to a reorientation**: the path algebra of
@@ -149,14 +149,24 @@ noncomputable def reorientDoubledEquiv :
     (reorientSymmetrify_comp_reorientSymmetrifyInv σ)
     (reorientSymmetrifyInv_comp_reorientSymmetrify σ)
 
+/-- The doubled path-algebra comparison maps a path of two arrows by mapping each arrow. -/
+private theorem reorientDoubledEquiv_ofArrowComp {i j l : Symmetrify (Reorient Q σ)} (a : i ⟶ j)
+    (b : j ⟶ l) :
+    reorientDoubledEquiv k σ (ofPath ⟨i, l, a.toPath.comp b.toPath⟩) =
+      ofPath ⟨(reorientSymmetrify σ).obj i, (reorientSymmetrify σ).obj l,
+        ((reorientSymmetrify σ).map a).toPath.comp
+          ((reorientSymmetrify σ).map b).toPath⟩ := by
+  rw [reorientDoubledEquiv, mapAlgEquiv_apply, mapAlgHom_ofPath,
+    Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp, Prefunctor.mapPath_toPath,
+    Prefunctor.mapPath_toPath]
+
 /-- An arrow which `σ` leaves alone keeps its head backtrack. -/
 @[simp]
 theorem reorientDoubledEquiv_headBacktrackElem_keep {i j : Q} (a : i ⟶ j) (ha : ¬ σ a) :
     reorientDoubledEquiv k σ (headBacktrackElem k (reorientKeep σ a ha))
       = headBacktrackElem k a := by
-  rw [headBacktrackElem_def, headBacktrackElem_def, reorientDoubledEquiv, mapAlgEquiv_apply,
-    mapAlgHom_ofPath, Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp,
-    Prefunctor.mapPath_toPath, Prefunctor.mapPath_toPath, reorientSymmetrify_map_of_keep,
+  rw [headBacktrackElem_def, headBacktrackElem_def, reorientDoubledEquiv_ofArrowComp,
+    reorientSymmetrify_map_of_keep,
     reorientSymmetrify_map_reverse_of_keep]
   rfl
 
@@ -165,9 +175,8 @@ theorem reorientDoubledEquiv_headBacktrackElem_keep {i j : Q} (a : i ⟶ j) (ha 
 theorem reorientDoubledEquiv_tailBacktrackElem_keep {i j : Q} (a : i ⟶ j) (ha : ¬ σ a) :
     reorientDoubledEquiv k σ (tailBacktrackElem k (reorientKeep σ a ha))
       = tailBacktrackElem k a := by
-  rw [tailBacktrackElem_def, tailBacktrackElem_def, reorientDoubledEquiv, mapAlgEquiv_apply,
-    mapAlgHom_ofPath, Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp,
-    Prefunctor.mapPath_toPath, Prefunctor.mapPath_toPath, reorientSymmetrify_map_of_keep,
+  rw [tailBacktrackElem_def, tailBacktrackElem_def, reorientDoubledEquiv_ofArrowComp,
+    reorientSymmetrify_map_of_keep,
     reorientSymmetrify_map_reverse_of_keep]
   rfl
 
@@ -177,9 +186,8 @@ arrow is the tail backtrack of the original. -/
 theorem reorientDoubledEquiv_headBacktrackElem_flip {i j : Q} (a : j ⟶ i) (ha : σ a) :
     reorientDoubledEquiv k σ (headBacktrackElem k (reorientFlip σ a ha))
       = tailBacktrackElem k a := by
-  rw [headBacktrackElem_def, tailBacktrackElem_def, reorientDoubledEquiv, mapAlgEquiv_apply,
-    mapAlgHom_ofPath, Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp,
-    Prefunctor.mapPath_toPath, Prefunctor.mapPath_toPath, reorientSymmetrify_map_of_flip,
+  rw [headBacktrackElem_def, tailBacktrackElem_def, reorientDoubledEquiv_ofArrowComp,
+    reorientSymmetrify_map_of_flip,
     reorientSymmetrify_map_reverse_of_flip]
   rfl
 
@@ -189,11 +197,26 @@ arrow is the head backtrack of the original. -/
 theorem reorientDoubledEquiv_tailBacktrackElem_flip {i j : Q} (a : j ⟶ i) (ha : σ a) :
     reorientDoubledEquiv k σ (tailBacktrackElem k (reorientFlip σ a ha))
       = headBacktrackElem k a := by
-  rw [tailBacktrackElem_def, headBacktrackElem_def, reorientDoubledEquiv, mapAlgEquiv_apply,
-    mapAlgHom_ofPath, Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp,
-    Prefunctor.mapPath_toPath, Prefunctor.mapPath_toPath, reorientSymmetrify_map_of_flip,
+  rw [tailBacktrackElem_def, headBacktrackElem_def, reorientDoubledEquiv_ofArrowComp,
+    reorientSymmetrify_map_of_flip,
     reorientSymmetrify_map_reverse_of_flip]
   rfl
+
+/-- The comparison of doubled path algebras matches the vertex idempotents. -/
+@[simp]
+theorem reorientDoubledEquiv_doubledVertexIdempotent (v : Q) :
+    reorientDoubledEquiv k σ (doubledVertexIdempotent k (reorientVertex σ v))
+      = doubledVertexIdempotent k v := by
+  rw [doubledVertexIdempotent_def, doubledVertexIdempotent_def, reorientDoubledEquiv,
+    mapAlgEquiv_apply, mapAlgHom_vertexIdempotent]
+  rfl
+
+end Doubled
+
+section DoubledSub
+
+variable (k : Type w) {Q : Type u} [CommRing k] [Quiver.{v + 1} Q] [Finite Q]
+  (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool)
 
 /-- An arrow which `σ` leaves alone contributes its own difference of backtracks. -/
 theorem reorientDoubledEquiv_sub_keep {i j : Q} (a : i ⟶ j) (ha : ¬ σ a) :
@@ -213,16 +236,7 @@ theorem reorientDoubledEquiv_sub_flip {i j : Q} (a : j ⟶ i) (ha : σ a) :
     reorientDoubledEquiv_tailBacktrackElem_flip, reorientSign_of_true k ha, neg_one_smul,
     neg_sub]
 
-/-- The comparison of doubled path algebras matches the vertex idempotents. -/
-@[simp]
-theorem reorientDoubledEquiv_doubledVertexIdempotent (v : Q) :
-    reorientDoubledEquiv k σ (doubledVertexIdempotent k (reorientVertex σ v))
-      = doubledVertexIdempotent k v := by
-  rw [doubledVertexIdempotent_def, doubledVertexIdempotent_def, reorientDoubledEquiv,
-    mapAlgEquiv_apply, mapAlgHom_vertexIdempotent]
-  rfl
-
-end Doubled
+end DoubledSub
 
 /-! ### The relator of a reorientation is a signed relator -/
 

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
@@ -122,7 +122,7 @@ end Sign
 
 section SignUnit
 
-variable (k : Type w) {Q : Type u} [Ring k] [Quiver.{v + 1} Q]
+variable (k : Type w) {Q : Type u} [Monoid k] [HasDistribNeg k] [Quiver.{v + 1} Q]
 
 /-- The sign labelling, valued in the units of `k`. -/
 def reorientSignUnit (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) ⦃i j : Q⦄ (a : i ⟶ j) : kˣ :=

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean
@@ -1,0 +1,369 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.Map
+public import TauCeti.RepresentationTheory.Quiver.Preprojective.Gauge
+public import TauCeti.RepresentationTheory.Quiver.Reorient
+
+/-!
+# Orientation independence of the additive preprojective algebra
+
+The additive preprojective algebra `Π_k(Q)` is built from the *doubled* quiver of `Q`, so it ought
+not to depend on which of the two directions of each edge was chosen as the arrow of `Q`. That
+independence is not a formality: the defining relator
+
+```text
+ρ = ∑_a (a a* - a* a)
+```
+
+pairs each arrow with its formal reverse *with a sign*, and turning an arrow around exchanges the
+two backtracks, hence negates the corresponding summand. This file proves the independence by
+exhibiting the isomorphism which repairs that sign.
+
+Fix a `Bool`-valued labelling `σ` of the arrows of `Q` and let `Reorient Q σ` be the quiver of
+`TauCeti.Reorient`, obtained by turning around exactly the arrows labelled `true`. The two doubled
+quivers are identified by `TauCeti.reorientSymmetrify`, hence the two doubled path algebras by
+`TauCeti.reorientDoubledEquiv`. Under that identification the relator of `Reorient Q σ` becomes the
+*gauged* relator `ρ_ε = ∑_a ε_a (a a* - a* a)` of `Q`, with `ε_a = -1` exactly when `σ` turns `a`
+around
+(`TauCeti.reorientDoubledEquiv_preprojectiveRelator`), and matching the relations one vertex at a
+time (`TauCeti.reorientDoubledEquiv_localPreprojectiveRelator`). Composing with the gauge
+isomorphism of `TauCeti.RepresentationTheory.Quiver.Preprojective.Gauge`, which rescales the
+sign-flipped arrows by `-1` and fixes their formal reverses, gives
+
+```text
+Π_k(Reorient Q σ) ≃ₐ[k] Π_k(Q).
+```
+
+Turning around a single arrow is the case of a labelling supported on one arrow; an arbitrary `σ`
+performs an arbitrary composite of such flips in one step, so the isomorphism above compares `Q`
+with the result of any prescribed reorientation of its arrows. Nothing is assumed about the
+characteristic of `k`: in characteristic two the sign is invisible, and the same statement is
+obtained from the same proof.
+
+## Main definitions
+
+* `TauCeti.reorientSign` and `TauCeti.reorientSignUnit`: the labelling by `-1` on the arrows `σ`
+  turns around and by `1` elsewhere, valued in `k` and in `kˣ`.
+* `TauCeti.reorientDoubledEquiv`: the isomorphism of doubled path algebras induced by the
+  comparison of doubled quivers.
+* `TauCeti.reorientPreprojectiveAlgebraEquivGauged`: the reoriented preprojective algebra,
+  presented by the signed relator of `Q`.
+* `TauCeti.reorientPreprojectiveAlgebraEquiv`: **orientation independence**.
+
+## Main results
+
+* `TauCeti.reorientDoubledEquiv_headBacktrackElem_flip` and
+  `TauCeti.reorientDoubledEquiv_tailBacktrackElem_flip`: turning an arrow around exchanges its two
+  backtracks. This is the sign.
+* `TauCeti.reorientDoubledEquiv_preprojectiveRelator`: the relator of a reorientation is the signed
+  relator of `Q`.
+* `TauCeti.reorientDoubledEquiv_localPreprojectiveRelator`: the same, vertex by vertex.
+* `TauCeti.reorientPreprojectiveAlgebraEquiv_preprojectiveMk`: the isomorphism, computed on an
+  arbitrary quotient representative, as the doubled-quiver identification followed by the rescaling
+  by `-1` of the turned-around arrows.
+
+## Implementation notes
+
+The counting step is `TauCeti.reorientDoubledEquiv_preprojectiveRelator`. A turned-around arrow
+`a : j ⟶ i` of `Q` is an arrow `i ⟶ j` of `Reorient Q σ`, so its contribution to the relator of the
+reorientation sits in the `(i, j)` hom set while its contribution to the signed relator of `Q` sits
+in the `(j, i)` one. The two agree only after the two vertex summations are exchanged, which is
+what the transposition step of the proof does; the equality does *not* hold hom set by hom set.
+
+## References
+
+This is the orientation-independence clause of Layer 4 of
+`TauCetiRoadmap/ZigzagPreprojective/README.md`, which asks to turn around a chosen arrow by an
+algebra isomorphism rescaling one of the exchanged arrows by `-1`, to check that it sends every
+local relation to the corresponding relation, and to compose these maps into independence of all
+orientations of a fixed underlying graph, including in characteristic two. See Crawley-Boevey,
+*Quiver algebras, weighted projective lines, and the Deligne--Simpson problem*, Section 1.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Quiver PathAlgebra
+
+universe u v w
+
+section Sign
+
+variable (k : Type w) {Q : Type u} [Ring k] [Quiver.{v + 1} Q]
+
+/-- The sign labelling attached to a reorientation: an arrow which `σ` turns around enters the
+preprojective relator with the opposite sign, and every other arrow keeps its sign. -/
+def reorientSign (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) ⦃i j : Q⦄ (a : i ⟶ j) : k :=
+  if σ a then -1 else 1
+
+/-- The sign labelling, valued in the units of `k`. -/
+def reorientSignUnit (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) ⦃i j : Q⦄ (a : i ⟶ j) : kˣ :=
+  if σ a then -1 else 1
+
+/-- A turned-around arrow gets the sign `-1`. -/
+@[simp]
+theorem reorientSign_of_true {σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool} {i j : Q} {a : i ⟶ j} (h : σ a) :
+    reorientSign k σ a = -1 := by
+  simp [reorientSign, h]
+
+/-- An arrow `σ` leaves alone keeps the sign `1`. -/
+@[simp]
+theorem reorientSign_of_false {σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool} {i j : Q} {a : i ⟶ j}
+    (h : ¬ σ a) : reorientSign k σ a = 1 := by
+  simp [reorientSign, h]
+
+/-- The sign labelling takes values in `{1, -1}`, so it is its own inverse. -/
+@[simp]
+theorem reorientSignUnit_inv (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) ⦃i j : Q⦄ (a : i ⟶ j) :
+    (reorientSignUnit k σ a)⁻¹ = reorientSignUnit k σ a := by
+  rw [reorientSignUnit]
+  split <;> simp
+
+/-- The sign labelling is the unit-valued one. -/
+theorem reorientSign_eq_coe_reorientSignUnit (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) ⦃i j : Q⦄
+    (a : i ⟶ j) : reorientSign k σ a = ((reorientSignUnit k σ a : kˣ) : k) := by
+  rw [reorientSign, reorientSignUnit]
+  split <;> simp
+
+end Sign
+
+/-! ### The induced isomorphism of doubled path algebras -/
+
+section Doubled
+
+variable (k : Type w) {Q : Type u} [CommRing k] [Quiver.{v + 1} Q] [Finite Q]
+  (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool)
+
+/-- **The isomorphism of doubled path algebras attached to a reorientation**: the path algebra of
+`Symmetrify (Reorient Q σ)` and the path algebra of `Symmetrify Q` are identified along the
+comparison of doubled quivers, which is the identity on vertices. -/
+noncomputable def reorientDoubledEquiv :
+    pathAlgebra k (Symmetrify (Reorient Q σ)) ≃ₐ[k] pathAlgebra k (Symmetrify Q) :=
+  mapAlgEquiv k (reorientSymmetrify σ) (reorientSymmetrifyInv σ)
+    (reorientSymmetrify_comp_reorientSymmetrifyInv σ)
+    (reorientSymmetrifyInv_comp_reorientSymmetrify σ)
+
+/-- An arrow which `σ` leaves alone keeps its head backtrack. -/
+@[simp]
+theorem reorientDoubledEquiv_headBacktrackElem_keep {i j : Q} (a : i ⟶ j) (ha : ¬ σ a) :
+    reorientDoubledEquiv k σ (headBacktrackElem k (reorientKeep σ a ha))
+      = headBacktrackElem k a := by
+  rw [headBacktrackElem_def, headBacktrackElem_def, reorientDoubledEquiv, mapAlgEquiv_apply,
+    mapAlgHom_ofPath, Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp,
+    Prefunctor.mapPath_toPath, Prefunctor.mapPath_toPath, reorientSymmetrify_map_of_keep,
+    reorientSymmetrify_map_reverse_of_keep]
+  rfl
+
+/-- An arrow which `σ` leaves alone keeps its tail backtrack. -/
+@[simp]
+theorem reorientDoubledEquiv_tailBacktrackElem_keep {i j : Q} (a : i ⟶ j) (ha : ¬ σ a) :
+    reorientDoubledEquiv k σ (tailBacktrackElem k (reorientKeep σ a ha))
+      = tailBacktrackElem k a := by
+  rw [tailBacktrackElem_def, tailBacktrackElem_def, reorientDoubledEquiv, mapAlgEquiv_apply,
+    mapAlgHom_ofPath, Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp,
+    Prefunctor.mapPath_toPath, Prefunctor.mapPath_toPath, reorientSymmetrify_map_of_keep,
+    reorientSymmetrify_map_reverse_of_keep]
+  rfl
+
+/-- Turning an arrow around exchanges its two backtracks: the head backtrack of the turned-around
+arrow is the tail backtrack of the original. -/
+@[simp]
+theorem reorientDoubledEquiv_headBacktrackElem_flip {i j : Q} (a : j ⟶ i) (ha : σ a) :
+    reorientDoubledEquiv k σ (headBacktrackElem k (reorientFlip σ a ha))
+      = tailBacktrackElem k a := by
+  rw [headBacktrackElem_def, tailBacktrackElem_def, reorientDoubledEquiv, mapAlgEquiv_apply,
+    mapAlgHom_ofPath, Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp,
+    Prefunctor.mapPath_toPath, Prefunctor.mapPath_toPath, reorientSymmetrify_map_of_flip,
+    reorientSymmetrify_map_reverse_of_flip]
+  rfl
+
+/-- Turning an arrow around exchanges its two backtracks: the tail backtrack of the turned-around
+arrow is the head backtrack of the original. -/
+@[simp]
+theorem reorientDoubledEquiv_tailBacktrackElem_flip {i j : Q} (a : j ⟶ i) (ha : σ a) :
+    reorientDoubledEquiv k σ (tailBacktrackElem k (reorientFlip σ a ha))
+      = headBacktrackElem k a := by
+  rw [tailBacktrackElem_def, headBacktrackElem_def, reorientDoubledEquiv, mapAlgEquiv_apply,
+    mapAlgHom_ofPath, Prefunctor.mapTotalPath_mk, Prefunctor.mapPath_comp,
+    Prefunctor.mapPath_toPath, Prefunctor.mapPath_toPath, reorientSymmetrify_map_of_flip,
+    reorientSymmetrify_map_reverse_of_flip]
+  rfl
+
+/-- An arrow which `σ` leaves alone contributes its own difference of backtracks. -/
+theorem reorientDoubledEquiv_sub_keep {i j : Q} (a : i ⟶ j) (ha : ¬ σ a) :
+    reorientDoubledEquiv k σ (headBacktrackElem k (reorientKeep σ a ha)
+        - tailBacktrackElem k (reorientKeep σ a ha))
+      = reorientSign k σ a • (headBacktrackElem k a - tailBacktrackElem k a) := by
+  rw [map_sub, reorientDoubledEquiv_headBacktrackElem_keep,
+    reorientDoubledEquiv_tailBacktrackElem_keep, reorientSign_of_false k ha, one_smul]
+
+/-- An arrow which `σ` turns around contributes the *negative* of its difference of backtracks:
+turning the arrow around exchanges its head and tail backtracks. -/
+theorem reorientDoubledEquiv_sub_flip {i j : Q} (a : j ⟶ i) (ha : σ a) :
+    reorientDoubledEquiv k σ (headBacktrackElem k (reorientFlip σ a ha)
+        - tailBacktrackElem k (reorientFlip σ a ha))
+      = reorientSign k σ a • (headBacktrackElem k a - tailBacktrackElem k a) := by
+  rw [map_sub, reorientDoubledEquiv_headBacktrackElem_flip,
+    reorientDoubledEquiv_tailBacktrackElem_flip, reorientSign_of_true k ha, neg_one_smul,
+    neg_sub]
+
+/-- The comparison of doubled path algebras matches the vertex idempotents. -/
+@[simp]
+theorem reorientDoubledEquiv_doubledVertexIdempotent (v : Q) :
+    reorientDoubledEquiv k σ (doubledVertexIdempotent k (reorientVertex σ v))
+      = doubledVertexIdempotent k v := by
+  rw [doubledVertexIdempotent_def, doubledVertexIdempotent_def, reorientDoubledEquiv,
+    mapAlgEquiv_apply, mapAlgHom_vertexIdempotent]
+  rfl
+
+end Doubled
+
+/-! ### The relator of a reorientation is a signed relator -/
+
+section Relator
+
+variable (k : Type w) {Q : Type u} [CommRing k] [Quiver.{v + 1} Q] [Fintype Q]
+  [∀ i j : Q, Fintype (i ⟶ j)] (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool)
+
+/-- Summing a function of the arrows of `Q` over the hom sets of a reorientation, with the
+arrows `σ` turns around contributing to the transposed hom set, recovers the sum over the arrows of
+`Q`: transposition is undone by exchanging the two vertex summations. -/
+private theorem sum_split_reorient {M : Type*} [AddCommMonoid M] (F : ∀ ⦃i j : Q⦄, (i ⟶ j) → M) :
+    (∑ i : Q, ∑ j : Q,
+        ((∑ x : {a : i ⟶ j // ¬ σ a}, F x.1) + ∑ y : {a : j ⟶ i // σ a}, F y.1))
+      = ∑ i : Q, ∑ j : Q, ∑ a : (i ⟶ j), F a := by
+  have hswap : (∑ i : Q, ∑ j : Q, ∑ y : {a : j ⟶ i // σ a}, F y.1)
+      = ∑ i : Q, ∑ j : Q, ∑ y : {a : i ⟶ j // σ a}, F y.1 :=
+    Finset.sum_comm
+  calc (∑ i : Q, ∑ j : Q,
+          ((∑ x : {a : i ⟶ j // ¬ σ a}, F x.1) + ∑ y : {a : j ⟶ i // σ a}, F y.1))
+      = (∑ i : Q, ∑ j : Q, ∑ x : {a : i ⟶ j // ¬ σ a}, F x.1)
+          + ∑ i : Q, ∑ j : Q, ∑ y : {a : j ⟶ i // σ a}, F y.1 := by
+        simp only [Finset.sum_add_distrib]
+    _ = (∑ i : Q, ∑ j : Q, ∑ x : {a : i ⟶ j // ¬ σ a}, F x.1)
+          + ∑ i : Q, ∑ j : Q, ∑ y : {a : i ⟶ j // σ a}, F y.1 := by rw [hswap]
+    _ = ∑ i : Q, ∑ j : Q,
+          ((∑ x : {a : i ⟶ j // ¬ σ a}, F x.1) + ∑ y : {a : i ⟶ j // σ a}, F y.1) := by
+        simp only [Finset.sum_add_distrib]
+    _ = ∑ i : Q, ∑ j : Q, ∑ a : (i ⟶ j), F a :=
+        Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by
+          rw [add_comm]
+          exact Fintype.sum_subtype_add_sum_subtype _ _
+
+/-- **The preprojective relator of a reorientation is the signed relator of the original
+quiver.** Under the identification of the two doubled path algebras, the relator
+`∑_a (a a* - a* a)` of `Reorient Q σ` becomes `∑_a ε_a (a a* - a* a)`, where `ε` is `-1` exactly on
+the arrows `σ` turns around. -/
+theorem reorientDoubledEquiv_preprojectiveRelator :
+    reorientDoubledEquiv k σ (preprojectiveRelator k (Reorient Q σ))
+      = gaugedPreprojectiveRelator k (reorientSign k σ) := by
+  have h1 : reorientDoubledEquiv k σ (preprojectiveRelator k (Reorient Q σ))
+      = ∑ i : Q, ∑ j : Q, ∑ α : (reorientVertex σ i ⟶ reorientVertex σ j),
+          reorientDoubledEquiv k σ (headBacktrackElem k α - tailBacktrackElem k α) := by
+    rw [preprojectiveRelator_def]
+    simp only [map_sum]
+    exact sum_reorientVertex σ _
+  have h2 : ∀ i j : Q, ∑ α : (reorientVertex σ i ⟶ reorientVertex σ j),
+      reorientDoubledEquiv k σ (headBacktrackElem k α - tailBacktrackElem k α)
+      = (∑ x : {a : i ⟶ j // ¬ σ a},
+            reorientSign k σ x.1 • (headBacktrackElem k x.1 - tailBacktrackElem k x.1))
+        + ∑ y : {a : j ⟶ i // σ a},
+            reorientSign k σ y.1 • (headBacktrackElem k y.1 - tailBacktrackElem k y.1) := by
+    intro i j
+    rw [sum_reorientHom]
+    exact congrArg₂ _ (Finset.sum_congr rfl fun x _ => reorientDoubledEquiv_sub_keep k σ x.1 x.2)
+      (Finset.sum_congr rfl fun y _ => reorientDoubledEquiv_sub_flip k σ y.1 y.2)
+  rw [h1, gaugedPreprojectiveRelator_def]
+  simp only [h2]
+  exact sum_split_reorient σ
+    (fun _ _ a => reorientSign k σ a • (headBacktrackElem k a - tailBacktrackElem k a))
+
+/-- **The local relations of a reorientation are the local signed relations.** The corner of the
+relator at a vertex `v` of `Reorient Q σ` is carried to the corner at `v` of the signed relator, so
+the identification matches the relations one vertex at a time and not merely their sum. -/
+theorem reorientDoubledEquiv_localPreprojectiveRelator (v : Q) :
+    reorientDoubledEquiv k σ (localPreprojectiveRelator k (reorientVertex σ v))
+      = doubledVertexIdempotent k v * gaugedPreprojectiveRelator k (reorientSign k σ)
+          * doubledVertexIdempotent k v := by
+  rw [← preprojectiveRelator_vertexCorner_eq_localPreprojectiveRelator, map_mul, map_mul,
+    reorientDoubledEquiv_doubledVertexIdempotent, reorientDoubledEquiv_preprojectiveRelator]
+
+end Relator
+
+/-! ### Orientation independence -/
+
+section Independence
+
+variable (k : Type w) {Q : Type u} [CommRing k] [Quiver.{v + 1} Q] [Fintype Q]
+  [∀ i j : Q, Fintype (i ⟶ j)] (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool)
+
+/-- The preprojective algebra of a reorientation, presented by the signed relator of the original
+quiver. -/
+noncomputable def reorientPreprojectiveAlgebraEquivGauged :
+    preprojectiveAlgebra k (Reorient Q σ) ≃ₐ[k]
+      gaugedPreprojectiveAlgebra k (reorientSign k σ) :=
+  AlgEquiv.ofAlgHom
+    (preprojectiveLift ((gaugedPreprojectiveMk k (reorientSign k σ)).comp
+        (reorientDoubledEquiv k σ).toAlgHom)
+      (by
+        simp only [AlgHom.comp_apply, AlgEquiv.coe_toAlgHom,
+          reorientDoubledEquiv_preprojectiveRelator,
+          gaugedPreprojectiveMk_gaugedPreprojectiveRelator]))
+    (gaugedPreprojectiveLift k (reorientSign k σ)
+      ((preprojectiveMk k (Reorient Q σ)).comp (reorientDoubledEquiv k σ).symm.toAlgHom)
+      (by
+        simp only [AlgHom.comp_apply, AlgEquiv.coe_toAlgHom,
+          ← reorientDoubledEquiv_preprojectiveRelator, AlgEquiv.symm_apply_apply,
+          preprojectiveMk_preprojectiveRelator]))
+    (AlgHom.ext fun y => by
+      obtain ⟨x, rfl⟩ := gaugedPreprojectiveMk_surjective k (reorientSign k σ) y
+      simp)
+    (AlgHom.ext fun y => by
+      obtain ⟨x, rfl⟩ := preprojectiveMk_surjective k (Reorient Q σ) y
+      simp)
+
+/-- **Orientation independence of the additive preprojective algebra.** Turning around any set of
+arrows of `Q` gives an isomorphic preprojective algebra: the doubled quivers are identified, and
+the resulting change of sign in the relator is undone by rescaling the turned-around arrows by
+`-1`. No hypothesis on the characteristic is needed. -/
+noncomputable def reorientPreprojectiveAlgebraEquiv :
+    preprojectiveAlgebra k (Reorient Q σ) ≃ₐ[k] preprojectiveAlgebra k Q :=
+  (reorientPreprojectiveAlgebraEquivGauged k σ).trans
+    (preprojectiveAlgebraEquivGauged k (reorientSign k σ) (reorientSignUnit k σ)
+      (reorientSign_eq_coe_reorientSignUnit k σ)).symm
+
+/-- The presentation of the reoriented algebra by the signed relator, computed on an arbitrary
+quotient representative. -/
+@[simp]
+theorem reorientPreprojectiveAlgebraEquivGauged_preprojectiveMk
+    (x : pathAlgebra k (Symmetrify (Reorient Q σ))) :
+    reorientPreprojectiveAlgebraEquivGauged k σ (preprojectiveMk k (Reorient Q σ) x)
+      = gaugedPreprojectiveMk k (reorientSign k σ) (reorientDoubledEquiv k σ x) := by
+  rw [reorientPreprojectiveAlgebraEquivGauged, ← AlgEquiv.coe_toAlgHom,
+    AlgEquiv.toAlgHom_ofAlgHom, preprojectiveLift_preprojectiveMk, AlgHom.comp_apply]
+  rfl
+
+/-- **The orientation-independence isomorphism, computed on generators**: it identifies the two
+doubled path algebras and then rescales, by `-1`, exactly the arrows `σ` turns around, leaving
+every formal reverse alone. This is the explicit map the roadmap asks for, in the form which makes
+the sign visible. -/
+@[simp]
+theorem reorientPreprojectiveAlgebraEquiv_preprojectiveMk
+    (x : pathAlgebra k (Symmetrify (Reorient Q σ))) :
+    reorientPreprojectiveAlgebraEquiv k σ (preprojectiveMk k (Reorient Q σ) x)
+      = preprojectiveMk k Q (rescale (doubledLabelling k fun _ _ a => reorientSign k σ a)
+          (reorientDoubledEquiv k σ x)) := by
+  rw [reorientPreprojectiveAlgebraEquiv, AlgEquiv.trans_apply,
+    reorientPreprojectiveAlgebraEquivGauged_preprojectiveMk,
+    preprojectiveAlgebraEquivGauged_symm_gaugedPreprojectiveMk]
+  simp only [reorientSignUnit_inv, ← reorientSign_eq_coe_reorientSignUnit]
+
+end Independence
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Reorient.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reorient.lean
@@ -174,8 +174,8 @@ theorem reorientSymmetrifyInv_obj (i : Symmetrify Q) :
     (reorientSymmetrifyInv σ).obj i = i := rfl
 
 /-- The inverse comparison sends an arrow which `σ` leaves alone to the corresponding arrow of the
-reoriented quiver. -/
-@[simp]
+reoriented quiver. Deliberately not a `simp` lemma: `Quiver.Symmetrify.of_map` rewrites
+`Symmetrify.of.map a` to `Sum.inl a` on the left-hand side, and `simpNF` rejects it. -/
 theorem reorientSymmetrifyInv_map_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
     (reorientSymmetrifyInv σ).map (Symmetrify.of.map a) =
       Symmetrify.of.map (reorientKeep σ a h) := by
@@ -195,8 +195,8 @@ theorem reorientSymmetrifyInv_map_reverse_of_keep {i j : Q} (a : i ⟶ j) (h : �
   rw [dite_eq_right h]
 
 /-- The inverse comparison sends an arrow which `σ` turns around to the formal reverse of the
-corresponding reoriented arrow. -/
-@[simp]
+corresponding reoriented arrow. Deliberately not a `simp` lemma, for the reason recorded on
+`TauCeti.reorientSymmetrifyInv_map_of_keep`. -/
 theorem reorientSymmetrifyInv_map_of_flip {i j : Q} (a : i ⟶ j) (h : σ a) :
     (reorientSymmetrifyInv σ).map (Symmetrify.of.map a) =
       Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h)) := by

--- a/TauCeti/RepresentationTheory/Quiver/Reorient.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reorient.lean
@@ -151,7 +151,8 @@ def reorientSymmetrify : Symmetrify (Reorient Q σ) ⥤q Symmetrify Q where
 
 /-- The inverse comparison: an arrow of the doubled quiver is sorted into one of the four pieces of
 a hom set of `Symmetrify (Reorient Q σ)` according to whether it runs forwards or backwards in `Q`
-and whether `σ` turns it around. -/
+and whether `σ` turns it around. Its object map remains exposed because reducing `obj := id` is
+needed to typecheck the dependent source and target types of its public arrow-map equations. -/
 @[expose]
 def reorientSymmetrifyInv : Symmetrify Q ⥤q Symmetrify (Reorient Q σ) where
   obj := id
@@ -171,6 +172,49 @@ theorem reorientSymmetrify_obj (i : Symmetrify (Reorient Q σ)) :
 @[simp]
 theorem reorientSymmetrifyInv_obj (i : Symmetrify Q) :
     (reorientSymmetrifyInv σ).obj i = i := rfl
+
+/-- The inverse comparison sends an arrow which `σ` leaves alone to the corresponding arrow of the
+reoriented quiver. -/
+@[simp]
+theorem reorientSymmetrifyInv_map_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
+    (reorientSymmetrifyInv σ).map (Symmetrify.of.map a) =
+      Symmetrify.of.map (reorientKeep σ a h) := by
+  change (if h' : σ a then Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h'))
+    else Symmetrify.of.map (reorientKeep σ a h')) = Symmetrify.of.map (reorientKeep σ a h)
+  rw [dite_eq_right h]
+
+/-- The inverse comparison sends the formal reverse of an arrow which `σ` leaves alone to the
+formal reverse of the corresponding reoriented arrow. Deliberately not a `simp` lemma: simplifying
+formal reversal first would make this a non-normal-form rule. -/
+theorem reorientSymmetrifyInv_map_reverse_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
+    (reorientSymmetrifyInv σ).map (Quiver.reverse (Symmetrify.of.map a)) =
+      Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h)) := by
+  change (if h' : σ a then Symmetrify.of.map (reorientFlip σ a h')
+    else Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h'))) =
+      Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h))
+  rw [dite_eq_right h]
+
+/-- The inverse comparison sends an arrow which `σ` turns around to the formal reverse of the
+corresponding reoriented arrow. -/
+@[simp]
+theorem reorientSymmetrifyInv_map_of_flip {i j : Q} (a : i ⟶ j) (h : σ a) :
+    (reorientSymmetrifyInv σ).map (Symmetrify.of.map a) =
+      Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h)) := by
+  change (if h' : σ a then Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h'))
+    else Symmetrify.of.map (reorientKeep σ a h')) =
+      Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h))
+  rw [dite_eq_left h]
+
+/-- The inverse comparison sends the formal reverse of an arrow which `σ` turns around to the
+corresponding reoriented arrow. Deliberately not a `simp` lemma, for the reason recorded on
+`TauCeti.reorientSymmetrifyInv_map_reverse_of_keep`. -/
+theorem reorientSymmetrifyInv_map_reverse_of_flip {i j : Q} (a : i ⟶ j) (h : σ a) :
+    (reorientSymmetrifyInv σ).map (Quiver.reverse (Symmetrify.of.map a)) =
+      Symmetrify.of.map (reorientFlip σ a h) := by
+  change (if h' : σ a then Symmetrify.of.map (reorientFlip σ a h')
+    else Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h'))) =
+      Symmetrify.of.map (reorientFlip σ a h)
+  rw [dite_eq_left h]
 
 /-- An arrow of `Q` which `σ` leaves alone stays an arrow of the doubled quiver. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Quiver/Reorient.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reorient.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.Fintype.BigOperators
+public import Mathlib.Data.Fintype.Sum
+public import TauCeti.Combinatorics.Quiver.Prefunctor
+public import TauCeti.RepresentationTheory.Quiver.Symmetrify
+
+/-!
+# Reorienting a quiver
+
+Two quivers with the same underlying graph differ by a choice, for each edge, of which of its two
+directions carries the arrow. This file records such a choice as a `Bool`-valued labelling `σ` of
+the arrows of a quiver `Q` and builds the quiver `TauCeti.Reorient Q σ`, whose arrows are those of
+`Q` with the ones labelled `true` turned around.
+
+The two doubled quivers `Quiver.Symmetrify (Reorient Q σ)` and `Quiver.Symmetrify Q` carry exactly
+the same arrows, distributed differently between an arrow and its formal reverse. That is the
+content of `TauCeti.reorientSymmetrify` and `TauCeti.reorientSymmetrifyInv`, mutually inverse
+prefunctors which are the identity on vertices and commute with reversal. They are the
+identification along which a construction on doubled quivers -- the additive preprojective algebra
+-- is compared across a change of orientation.
+
+## Main definitions
+
+* `TauCeti.Reorient`: the quiver `Q` with the arrows labelled `true` by `σ` turned around.
+* `TauCeti.reorientSymmetrify` and `TauCeti.reorientSymmetrifyInv`: the two prefunctors between
+  the doubled quivers.
+
+## Main results
+
+* `TauCeti.reorientSymmetrify_comp_reorientSymmetrifyInv` and
+  `TauCeti.reorientSymmetrifyInv_comp_reorientSymmetrify`: the two prefunctors are inverse, so the
+  two doubled quivers are isomorphic.
+* `TauCeti.reorientSymmetrify_map_reverse`: the comparison commutes with arrow reversal.
+
+## Implementation notes
+
+`Reorient Q σ` is a semireducible type synonym for `Q`, following `Quiver.Symmetrify`: were it
+reducible, instance search would unfold it and replace the reoriented quiver structure by that of
+`Q`. Its arrows `i ⟶ j` are the disjoint union of the arrows `i ⟶ j` of `Q` which `σ` leaves alone
+and the arrows `j ⟶ i` of `Q` which `σ` turns around, so a hom set of the doubled quiver
+`Symmetrify (Reorient Q σ)` splits into four pieces. Sorting an arrow of `Symmetrify Q` into those
+four pieces is what `TauCeti.reorientSymmetrifyInv` does, and it is why that prefunctor, unlike its
+inverse, is defined by a case distinction on the value of `σ`.
+
+Turning around a *single* arrow is the special case where `σ` is supported on one arrow; allowing
+an arbitrary `σ` performs an arbitrary composite of such flips in one step.
+
+## References
+
+This file supplies the doubled-quiver identification which the orientation-independence clause of
+Layer 4 of `TauCetiRoadmap/ZigzagPreprojective/README.md` needs; see Crawley-Boevey, *Quiver
+algebras, weighted projective lines, and the Deligne--Simpson problem*, Section 1.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Quiver
+
+universe u v
+
+variable (Q : Type u) [Quiver.{v + 1} Q]
+
+/-- The quiver obtained from `Q` by turning around exactly the arrows on which the labelling `σ`
+takes the value `true`: an arrow `i ⟶ j` of `Reorient Q σ` is either an arrow `i ⟶ j` of `Q` which
+`σ` leaves alone, or an arrow `j ⟶ i` of `Q` which `σ` turns around. -/
+@[expose]
+def Reorient (_σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) : Type u := Q
+
+variable {Q}
+
+instance reorientQuiver (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) : Quiver.{v + 1} (Reorient Q σ) :=
+  ⟨fun i j : Q => {a : i ⟶ j // ¬ σ a} ⊕ {a : j ⟶ i // σ a}⟩
+
+instance instFiniteReorient (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) [Finite Q] :
+    Finite (Reorient Q σ) :=
+  inferInstanceAs (Finite Q)
+
+instance instFintypeReorient (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) [Fintype Q] :
+    Fintype (Reorient Q σ) :=
+  inferInstanceAs (Fintype Q)
+
+/-- A hom set of a reorientation is a disjoint union of two subtypes of hom sets of `Q`, hence
+finite. The vertices are taken in `Q`; `TauCeti.instFintypeReorientHom` is the instance form, whose
+vertices are taken in `Reorient Q σ` so that instance search can use it. -/
+@[instance_reducible]
+def reorientHomFintype (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool) [∀ i j : Q, Fintype (i ⟶ j)] (i j : Q) :
+    Fintype (@Quiver.Hom (Reorient Q σ) _ i j) :=
+  inferInstanceAs (Fintype ({a : i ⟶ j // ¬ σ a} ⊕ {a : j ⟶ i // σ a}))
+
+instance instFintypeReorientHom (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool)
+    [∀ i j : Q, Fintype (i ⟶ j)] (i j : Reorient Q σ) :
+    Fintype (i ⟶ j) :=
+  reorientHomFintype σ i j
+
+/-! ### Vertices and arrows -/
+
+variable (σ : ∀ ⦃i j : Q⦄, (i ⟶ j) → Bool)
+
+/-- The vertex of `Reorient Q σ` underlying a vertex of `Q`. The two vertex types are
+definitionally equal, so this is the identity; naming it keeps the two quiver structures apart. -/
+abbrev reorientVertex (v : Q) : Reorient Q σ := v
+
+/-- The arrow of `Reorient Q σ` carried by an arrow of `Q` which `σ` leaves alone. -/
+@[expose]
+def reorientKeep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) : reorientVertex σ i ⟶ reorientVertex σ j :=
+  Sum.inl ⟨a, h⟩
+
+/-- The arrow of `Reorient Q σ` carried by an arrow of `Q` which `σ` turns around: it runs from
+the head of the original arrow to its tail. -/
+@[expose]
+def reorientFlip {i j : Q} (a : j ⟶ i) (h : σ a) : reorientVertex σ i ⟶ reorientVertex σ j :=
+  Sum.inr ⟨a, h⟩
+
+/-- A sum over the vertices of a reorientation is a sum over the vertices of `Q`. -/
+theorem sum_reorientVertex {M : Type*} [AddCommMonoid M] [Fintype Q] (f : Reorient Q σ → M) :
+    ∑ v : Reorient Q σ, f v = ∑ v : Q, f (reorientVertex σ v) :=
+  rfl
+
+/-- A sum over a hom set of a reorientation splits into the arrows `σ` leaves alone and the arrows
+`σ` turns around. -/
+theorem sum_reorientHom {M : Type*} [AddCommMonoid M] [∀ i j : Q, Fintype (i ⟶ j)] (i j : Q)
+    (f : (reorientVertex σ i ⟶ reorientVertex σ j) → M) :
+    ∑ α : (reorientVertex σ i ⟶ reorientVertex σ j), f α
+      = (∑ x : {a : i ⟶ j // ¬ σ a}, f (reorientKeep σ x.1 x.2))
+        + ∑ y : {a : j ⟶ i // σ a}, f (reorientFlip σ y.1 y.2) :=
+  Fintype.sum_sum_type _
+
+/-! ### The doubled quivers of two orientations agree -/
+
+/-- The comparison prefunctor from the doubled reoriented quiver to the doubled quiver. It is the
+identity on vertices; on arrows it forgets which of the four pieces of a hom set of
+`Symmetrify (Reorient Q σ)` an arrow came from and remembers only whether it runs forwards or
+backwards in `Q`. -/
+@[expose]
+def reorientSymmetrify : Symmetrify (Reorient Q σ) ⥤q Symmetrify Q where
+  obj := id
+  map := fun {_ _} b =>
+    match b with
+    | Sum.inl (Sum.inl a) => Sum.inl a.1
+    | Sum.inl (Sum.inr a) => Sum.inr a.1
+    | Sum.inr (Sum.inl a) => Sum.inr a.1
+    | Sum.inr (Sum.inr a) => Sum.inl a.1
+
+/-- The inverse comparison: an arrow of the doubled quiver is sorted into one of the four pieces of
+a hom set of `Symmetrify (Reorient Q σ)` according to whether it runs forwards or backwards in `Q`
+and whether `σ` turns it around. -/
+@[expose]
+def reorientSymmetrifyInv : Symmetrify Q ⥤q Symmetrify (Reorient Q σ) where
+  obj := id
+  map := fun {_ _} b =>
+    match b with
+    | Sum.inl a =>
+        if h : σ a then Sum.inr (Sum.inr ⟨a, h⟩) else Sum.inl (Sum.inl ⟨a, h⟩)
+    | Sum.inr a =>
+        if h : σ a then Sum.inl (Sum.inr ⟨a, h⟩) else Sum.inr (Sum.inl ⟨a, h⟩)
+
+/-- The comparison of doubled quivers is the identity on vertices. -/
+@[simp]
+theorem reorientSymmetrify_obj (i : Symmetrify (Reorient Q σ)) :
+    (reorientSymmetrify σ).obj i = i := rfl
+
+/-- The inverse comparison of doubled quivers is the identity on vertices. -/
+@[simp]
+theorem reorientSymmetrifyInv_obj (i : Symmetrify Q) :
+    (reorientSymmetrifyInv σ).obj i = i := rfl
+
+/-- An arrow of `Q` which `σ` leaves alone stays an arrow of the doubled quiver. -/
+@[simp]
+theorem reorientSymmetrify_map_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
+    (reorientSymmetrify σ).map (Symmetrify.of.map (reorientKeep σ a h)) =
+      Symmetrify.of.map a :=
+  rfl
+
+/-- The formal reverse of an arrow which `σ` leaves alone stays a formal reverse. Deliberately not
+a `simp` lemma: `Quiver.symmetrify_reverse` rewrites `Quiver.reverse` to `Sum.swap` on the left-hand
+side, and `simpNF` rejects the pair. -/
+theorem reorientSymmetrify_map_reverse_of_keep {i j : Q} (a : i ⟶ j) (h : ¬ σ a) :
+    (reorientSymmetrify σ).map (Quiver.reverse (Symmetrify.of.map (reorientKeep σ a h))) =
+      Quiver.reverse (Symmetrify.of.map a) :=
+  rfl
+
+/-- An arrow of `Q` which `σ` turns around becomes the formal reverse of itself. -/
+@[simp]
+theorem reorientSymmetrify_map_of_flip {i j : Q} (a : j ⟶ i) (h : σ a) :
+    (reorientSymmetrify σ).map (Symmetrify.of.map (reorientFlip σ a h)) =
+      Quiver.reverse (Symmetrify.of.map a) :=
+  rfl
+
+/-- The formal reverse of a turned-around arrow is the arrow itself. Deliberately not a `simp`
+lemma, for the reason recorded on `TauCeti.reorientSymmetrify_map_reverse_of_keep`. -/
+theorem reorientSymmetrify_map_reverse_of_flip {i j : Q} (a : j ⟶ i) (h : σ a) :
+    (reorientSymmetrify σ).map (Quiver.reverse (Symmetrify.of.map (reorientFlip σ a h))) =
+      Symmetrify.of.map a :=
+  rfl
+
+/-- **The two comparisons are inverse**, starting from the reoriented quiver. -/
+theorem reorientSymmetrify_comp_reorientSymmetrifyInv :
+    (reorientSymmetrify σ).comp (reorientSymmetrifyInv σ) = Prefunctor.id _ := by
+  refine Prefunctor.ext (fun _ => rfl) fun i j b => ?_
+  obtain (⟨a, ha⟩ | ⟨a, ha⟩) | ⟨a, ha⟩ | ⟨a, ha⟩ := b <;>
+    simp [reorientSymmetrify, reorientSymmetrifyInv, ha] <;> rfl
+
+/-- **The two comparisons are inverse**, starting from the original quiver. -/
+theorem reorientSymmetrifyInv_comp_reorientSymmetrify :
+    (reorientSymmetrifyInv σ).comp (reorientSymmetrify σ) = Prefunctor.id _ := by
+  refine Prefunctor.ext (fun _ => rfl) fun i j b => ?_
+  obtain a | a := b <;> by_cases ha : σ a <;>
+    simp [reorientSymmetrify, reorientSymmetrifyInv, ha] <;> rfl
+
+/-- **The comparison of doubled quivers commutes with arrow reversal**, so it identifies the two
+doubled quivers as quivers with an involutive reverse. -/
+theorem reorientSymmetrify_map_reverse {i j : Symmetrify (Reorient Q σ)} (b : i ⟶ j) :
+    (reorientSymmetrify σ).map (Quiver.reverse b) =
+      Quiver.reverse ((reorientSymmetrify σ).map b) := by
+  obtain (⟨a, ha⟩ | ⟨a, ha⟩) | ⟨a, ha⟩ | ⟨a, ha⟩ := b <;> rfl
+
+end TauCeti


### PR DESCRIPTION
This PR proves orientation independence of the additive preprojective algebra. For a finite quiver `Q` over a commutative ring `k` and any `Bool`-valued labelling `σ` of the arrows of `Q`, it builds the quiver `TauCeti.Reorient Q σ` obtained by turning around exactly the arrows labelled `true`, and proves `TauCeti.reorientPreprojectiveAlgebraEquiv : Π_k(Reorient Q σ) ≃ₐ[k] Π_k(Q)`. It advances Layer 4, "additive preprojective algebras and orientation independence", of `TauCetiRoadmap/ZigzagPreprojective/README.md`, at the exact target "Reverse one chosen original arrow and construct the algebra isomorphism which fixes every other doubled arrow and rescales one of the exchanged arrows by `-1`. Prove that it sends every local relation to the corresponding relation. Compose these maps to prove independence of all orientations of a fixed underlying graph, including characteristic two."

This is the most effective current step because the gauge half of that clause already landed in `TauCeti/RepresentationTheory/Quiver/Preprojective/Gauge.lean`, whose implementation notes record that the cross-quiver form was deliberately left unstated for want of the path-algebra isomorphism induced by a quiver isomorphism; `TauCeti/RepresentationTheory/Quiver/PathAlgebra/Map.lean` has since supplied exactly that isomorphism, so the missing piece is the doubled-quiver identification and the sign bookkeeping across it, which is what this PR adds. Nothing here overlaps the three open zigzag PRs (#4554 vertex projectives, #4505 socle and top, #4482 the componentwise algebra), which are all on Layers 1-3 of the zigzag side.

`TauCeti/Combinatorics/Quiver/Reorient.lean` (276 lines) defines `TauCeti.Reorient Q σ`, a type synonym for `Q` whose arrows `i ⟶ j` are the arrows `i ⟶ j` of `Q` which `σ` leaves alone together with the arrows `j ⟶ i` of `Q` which `σ` turns around, with the constructors `reorientKeep` and `reorientFlip`, its finiteness instances, and the mutually inverse prefunctors `reorientSymmetrify` and `reorientSymmetrifyInv` between the two doubled quivers. They are the identity on vertices and commute with arrow reversal (`reorientSymmetrify_map_reverse`), so they identify the two doubled quivers as quivers with an involutive reverse.

`TauCeti/RepresentationTheory/Quiver/Preprojective/Orientation.lean` (466 lines) does the algebra. `reorientDoubledEquiv` is the induced isomorphism of doubled path algebras. Its content is that turning an arrow around exchanges its two backtracks (`reorientDoubledEquiv_headBacktrackElem_flip` and `reorientDoubledEquiv_tailBacktrackElem_flip`), which negates that arrow's summand in the relator; consequently `reorientDoubledEquiv_preprojectiveRelator` identifies the relator of `Reorient Q σ` with the gauged relator of `Q` for the sign labelling `reorientSign`, and `reorientDoubledEquiv_localPreprojectiveRelator` does the same one vertex-corner at a time, which is the roadmap's "sends every local relation to the corresponding relation". Composing with the landed gauge isomorphism gives `reorientPreprojectiveAlgebraEquiv`; `reorientPreprojectiveAlgebraEquiv_preprojectiveMk` computes it on an arbitrary quotient representative as the doubled-quiver identification followed by the rescaling by `-1` of exactly the turned-around arrows, leaving every formal reverse alone, which is the displayed map the roadmap asks for. No characteristic hypothesis appears anywhere, so the characteristic-two case is the same theorem.

The one subtlety, recorded in the implementation notes, is that the identity does not hold hom set by hom set: a turned-around arrow `a : j ⟶ i` of `Q` is an arrow `i ⟶ j` of the reorientation, so its contribution sits in the transposed hom set, and the two sides agree only after the two vertex summations are exchanged. Allowing an arbitrary `σ` rather than a single arrow performs an arbitrary composite of flips in one step, so no separate composition argument is needed.

Two existing files change. `Preprojective/Basic.lean` gains `doubledVertexIdempotent_def`, the missing defining equation of `doubledVertexIdempotent` in the style of the `headBacktrackElem_def` and `tailBacktrackElem_def` already there; the definition is not exposed across modules, so the equation is needed to rewrite with it downstream. `Preprojective/Gauge.lean`'s implementation notes and references are updated: they asserted that the cross-quiver statement is unprovable here and left unstated, which this PR makes false, and they now point at the new module.

No Mathlib material is vendored. The construction reuses Mathlib's `Quiver.Symmetrify`, `Prefunctor`, `Prefunctor.mapPath`, `Fintype.sum_sum_type`, `Fintype.sum_subtype_add_sum_subtype`, `Finset.sum_comm` and `AlgEquiv.ofAlgHom`, together with Tau Ceti's `PathAlgebra.mapAlgEquiv`, preprojective relator and universal property, and the gauge isomorphism. The mathematical organization follows Crawley-Boevey, *Quiver algebras, weighted projective lines, and the Deligne--Simpson problem*, Section 1, as recorded in the module documentation.

After this PR, Layer 4 still needs the opposite-algebra comparison and base change of `Π_k(Q)`, finite-dimensionality and self-injectivity for finite ADE graphs with infinite-dimensionality, Hilbert series and Koszulity for the connected non-Dynkin ones, and the algebraic comparison with the moment-map commutator formula.

Roadmap: ZigzagPreprojective

<!--tauceti-target:v1 {"focus":"ZigzagPreprojective","id":"preprojective-orientation-independence"}-->

🤖 Prepared with Claude Code

