### PR TITLE
refactor: name the per-monomial step of the G₂ divided-power recurrence

### DIFF
--- a/TauCeti/RingTheory/DividedPowers/RootString/G2.lean
+++ b/TauCeti/RingTheory/DividedPowers/RootString/G2.lean
@@ -375,6 +375,63 @@ private theorem sum_g2Monomial_shift {n k : ℕ} {P Q : (ℕ × ℕ × ℕ × �
     (fun _ hq => hright _ (mem_filter_g2SeriesIndex.mp hq))
     (fun _ _ => rfl)
 
+-- `mul_dividedPower_quintuple` in the coordinates the series is indexed by: `g2Monomial n p`
+-- pins the exponent of `y` to `n` minus the weighted degree of `p`, so each of the four releases
+-- lands on a genuine `g2Monomial` only after the arithmetic of its own shift is discharged. The
+-- quadruple is arbitrary: the step this names never used its membership in `g2SeriesIndex n k`.
+private theorem mul_g2Monomial (hxy : x * y = y * x + z) (hxz : x * z = z * x + 2 • w)
+    (hxw : x * w = w * x + 3 • v) (hwz : w * z = z * w + 3 • s) (hxv : Commute x v)
+    (hxs : Commute x s) (hyz : Commute y z) (hwv : Commute w v) (hzs : Commute z s)
+    (hws : Commute w s) (hvs : Commute v s) (n : ℕ) (p : ℕ × ℕ × ℕ × ℕ) :
+    x * g2Monomial y z w v s n p =
+      g2Monomial y z w v s n p * x +
+        (if 0 < n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2 then
+          (p.1 + 1) • g2Monomial y z w v s n (p.1 + 1, p.2.1, p.2.2.1, p.2.2.2) else 0) +
+        (if 0 < p.1 then
+          (2 * (p.2.1 + 1)) •
+            g2Monomial y z w v s n (p.1 - 1, p.2.1 + 1, p.2.2.1, p.2.2.2) else 0) +
+        (if 1 < p.1 then
+          (3 * (p.2.2.2 + 1)) •
+            g2Monomial y z w v s n (p.1 - 2, p.2.1, p.2.2.1, p.2.2.2 + 1) else 0) +
+        (if 0 < p.2.1 then
+          (3 * (p.2.2.1 + 1)) •
+            g2Monomial y z w v s n (p.1, p.2.1 - 1, p.2.2.1 + 1, p.2.2.2) else 0) := by
+  obtain ⟨b, c, d, e⟩ := p
+  have hA : n - (b + 1) - c - d - 2 * e = n - b - c - d - 2 * e - 1 := by omega
+  have hB : 0 < b → n - (b - 1) - (c + 1) - d - 2 * e = n - b - c - d - 2 * e := by omega
+  have hC : 1 < b → n - (b - 2) - c - d - 2 * (e + 1) = n - b - c - d - 2 * e := by omega
+  have hD : 0 < c → n - b - (c - 1) - (d + 1) - 2 * e = n - b - c - d - 2 * e := by omega
+  have eqB : (if 0 < b then (2 * (c + 1)) •
+        (dividedPower (n - (b - 1) - (c + 1) - d - 2 * e) y * (dividedPower (b - 1) z *
+          (dividedPower (c + 1) w * (dividedPower d v * dividedPower e s)))) else 0) =
+      (if 0 < b then (2 * (c + 1)) •
+        (dividedPower (n - b - c - d - 2 * e) y * (dividedPower (b - 1) z *
+          (dividedPower (c + 1) w * (dividedPower d v * dividedPower e s)))) else 0) := by
+    split_ifs with h
+    · rw [hB h]
+    · rfl
+  have eqC : (if 1 < b then (3 * (e + 1)) •
+        (dividedPower (n - (b - 2) - c - d - 2 * (e + 1)) y * (dividedPower (b - 2) z *
+          (dividedPower c w * (dividedPower d v * dividedPower (e + 1) s)))) else 0) =
+      (if 1 < b then (3 * (e + 1)) •
+        (dividedPower (n - b - c - d - 2 * e) y * (dividedPower (b - 2) z *
+          (dividedPower c w * (dividedPower d v * dividedPower (e + 1) s)))) else 0) := by
+    split_ifs with h
+    · rw [hC h]
+    · rfl
+  have eqD : (if 0 < c then (3 * (d + 1)) •
+        (dividedPower (n - b - (c - 1) - (d + 1) - 2 * e) y * (dividedPower b z *
+          (dividedPower (c - 1) w * (dividedPower (d + 1) v * dividedPower e s)))) else 0) =
+      (if 0 < c then (3 * (d + 1)) •
+        (dividedPower (n - b - c - d - 2 * e) y * (dividedPower b z *
+          (dividedPower (c - 1) w * (dividedPower (d + 1) v * dividedPower e s)))) else 0) := by
+    split_ifs with h
+    · rw [hD h]
+    · rfl
+  simp only [g2Monomial]
+  rw [mul_dividedPower_quintuple hxy hxz hxw hwz hxv hxs hyz hwv hzs hws hvs
+    (n - b - c - d - 2 * e) b c d e, hA, eqB, eqC, eqD]
+
 -- The defining recurrence of the sequence: it is what `dividedPower_mul_of_ad_dividedPower_series`
 -- consumes. Each summand of `g2Series n (k + 1)` is reached in four ways, with coefficients
 -- `b`, `2c`, `3d`, and `3e`, which add up to `k + 1`.
@@ -385,55 +442,6 @@ private theorem mul_g2Series (hxy : x * y = y * x + z) (hxz : x * z = z * x + 2 
     x * g2Series y z w v s n k =
       g2Series y z w v s n k * x + (k + 1) • g2Series y z w v s n (k + 1) := by
   classical
-  have hterm : ∀ p ∈ g2SeriesIndex n k,
-      x * g2Monomial y z w v s n p =
-        g2Monomial y z w v s n p * x +
-          (if 0 < n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2 then
-            (p.1 + 1) • g2Monomial y z w v s n (p.1 + 1, p.2.1, p.2.2.1, p.2.2.2) else 0) +
-          (if 0 < p.1 then
-            (2 * (p.2.1 + 1)) •
-              g2Monomial y z w v s n (p.1 - 1, p.2.1 + 1, p.2.2.1, p.2.2.2) else 0) +
-          (if 1 < p.1 then
-            (3 * (p.2.2.2 + 1)) •
-              g2Monomial y z w v s n (p.1 - 2, p.2.1, p.2.2.1, p.2.2.2 + 1) else 0) +
-          (if 0 < p.2.1 then
-            (3 * (p.2.2.1 + 1)) •
-              g2Monomial y z w v s n (p.1, p.2.1 - 1, p.2.2.1 + 1, p.2.2.2) else 0) := by
-    rintro ⟨b, c, d, e⟩ _
-    have hA : n - (b + 1) - c - d - 2 * e = n - b - c - d - 2 * e - 1 := by omega
-    have hB : 0 < b → n - (b - 1) - (c + 1) - d - 2 * e = n - b - c - d - 2 * e := by omega
-    have hC : 1 < b → n - (b - 2) - c - d - 2 * (e + 1) = n - b - c - d - 2 * e := by omega
-    have hD : 0 < c → n - b - (c - 1) - (d + 1) - 2 * e = n - b - c - d - 2 * e := by omega
-    have eqB : (if 0 < b then (2 * (c + 1)) •
-          (dividedPower (n - (b - 1) - (c + 1) - d - 2 * e) y * (dividedPower (b - 1) z *
-            (dividedPower (c + 1) w * (dividedPower d v * dividedPower e s)))) else 0) =
-        (if 0 < b then (2 * (c + 1)) •
-          (dividedPower (n - b - c - d - 2 * e) y * (dividedPower (b - 1) z *
-            (dividedPower (c + 1) w * (dividedPower d v * dividedPower e s)))) else 0) := by
-      split_ifs with h
-      · rw [hB h]
-      · rfl
-    have eqC : (if 1 < b then (3 * (e + 1)) •
-          (dividedPower (n - (b - 2) - c - d - 2 * (e + 1)) y * (dividedPower (b - 2) z *
-            (dividedPower c w * (dividedPower d v * dividedPower (e + 1) s)))) else 0) =
-        (if 1 < b then (3 * (e + 1)) •
-          (dividedPower (n - b - c - d - 2 * e) y * (dividedPower (b - 2) z *
-            (dividedPower c w * (dividedPower d v * dividedPower (e + 1) s)))) else 0) := by
-      split_ifs with h
-      · rw [hC h]
-      · rfl
-    have eqD : (if 0 < c then (3 * (d + 1)) •
-          (dividedPower (n - b - (c - 1) - (d + 1) - 2 * e) y * (dividedPower b z *
-            (dividedPower (c - 1) w * (dividedPower (d + 1) v * dividedPower e s)))) else 0) =
-        (if 0 < c then (3 * (d + 1)) •
-          (dividedPower (n - b - c - d - 2 * e) y * (dividedPower b z *
-            (dividedPower (c - 1) w * (dividedPower (d + 1) v * dividedPower e s)))) else 0) := by
-      split_ifs with h
-      · rw [hD h]
-      · rfl
-    simp only [g2Monomial]
-    rw [mul_dividedPower_quintuple hxy hxz hxw hwz hxv hxs hyz hwv hzs hws hvs
-      (n - b - c - d - 2 * e) b c d e, hA, eqB, eqC, eqD]
   -- The four reindexings that identify the released families with the summands of the next term.
   have hshiftA : ∑ p ∈ {p ∈ g2SeriesIndex n k | 0 < n - p.1 - p.2.1 - p.2.2.1 - 2 * p.2.2.2},
         (p.1 + 1) • g2Monomial y z w v s n (p.1 + 1, p.2.1, p.2.2.1, p.2.2.2) =
@@ -510,7 +518,9 @@ private theorem mul_g2Series (hxy : x * y = y * x + z) (hxz : x * z = z * x + 2 
     congr 1
     have := (mem_g2SeriesIndex.mp hq).2
     omega
-  rw [g2Series, Finset.mul_sum, Finset.sum_mul, Finset.sum_congr rfl hterm]
+  rw [g2Series, Finset.mul_sum, Finset.sum_mul,
+    Finset.sum_congr rfl fun p _ =>
+      mul_g2Monomial hxy hxz hxw hwz hxv hxs hyz hwv hzs hws hvs n p]
   simp only [Finset.sum_add_distrib, ← Finset.sum_filter]
   rw [hshiftA, hshiftB, hshiftC, hshiftD, add_assoc, add_assoc, add_assoc, ← add_assoc _ _
     (∑ q ∈ {q ∈ g2SeriesIndex n (k + 1) | 0 < q.2.2.1}, (3 * q.2.2.1) • g2Monomial y z w v s n q),


### PR DESCRIPTION
`mul_g2Series` proves the defining recurrence of the type-`G₂` divided-power series: moving `x`
across `g2Series y z w v s n k` lengthens it into `(k + 1) • g2Series y z w v s n (k + 1)`. Its
proof was 132 lines, and by far the longest step was an anonymous `have hterm` block that never
mentions the series at all — it is the rule for moving `x` across **one** normal-ordered monomial.
Name it.

## The lemma

**`mul_g2Monomial`**: for an arbitrary quadruple `p : ℕ × ℕ × ℕ × ℕ`,

```text
x * g2Monomial y z w v s n p = g2Monomial y z w v s n p * x + (four guarded releases)
```

where each release lengthens the monomial in one coordinate and carries the coefficient recorded
there, guarded by the condition under which that release is available.

### The membership hypothesis was never used

Inside `mul_g2Series` the block is stated as `∀ p ∈ g2SeriesIndex n k, …`, but its proof opens
`rintro ⟨b, c, d, e⟩ _` — it **discards the membership outright**. So the rule holds for any
quadruple, and the helper needs neither `k` nor `g2SeriesIndex`. That is the content of the block,
recovered by reading the block rather than the context it sat in.

### Stated over the quadruple, not over four naturals

`mul_g2Monomial` takes `(n : ℕ) (p : ℕ × ℕ × ℕ × ℕ)` rather than `(n b c d e : ℕ)`, matching the
way `g2Monomial` is itself indexed and the way the parent consumes it. This is what makes the
extraction a decomposition rather than a halving: with four separate naturals the parent would
have to *keep* the 14-line `have hterm` statement in order to feed `Finset.sum_congr rfl hterm`,
so only the 31-line proof half would leave and the parent would still be ~103 lines. Stated over
`p`, the `have` disappears entirely and the call site inlines to

```text
Finset.sum_congr rfl fun p _ => mul_g2Monomial hxy hxz hxw hwz hxv hxs hyz hwv hzs hws hvs n p
```

### Hypotheses re-derived from the body

All eleven commutation hypotheses are genuinely used: the body forwards exactly them to its single
`mul_dividedPower_quintuple` call. Beyond `n` and `p` nothing else is taken, and nothing is
inherited from the section `variable` line except `[Semiring A] [Algebra ℚ A]`, which `dividedPower`
requires. No parameter is carried that the body does not consume.

## What moved, measured

| | before | after |
|---|---|---|
| `mul_g2Series` body | 132 | **85** |
| its largest contiguous block | 49 (37% of body) | **19** (22%) |
| private helpers added | — | **1** (body 35, largest block 9) |

Diff is +60/−50 in one file. No public declaration changes: `mul_g2Monomial` is `private`, beside
the `private` siblings it sits among, so the module's `## Main results` list — which names only the
three public results — needs no re-sync.

## Why one helper and not two

The parent is left at 85 lines, so it is fair to ask for another cut. The measurement says there
is nothing left to lift: **after this extraction `mul_g2Series` contains no block of 25 lines or
more — its largest is 19.** What remains is the four reindexings (each already a four-line
`refine sum_g2Monomial_shift …` delegating to the existing helper immediately above it) and
`hcombine`, which collects the four released families and checks their coefficients sum to `k + 1`.

`hcombine` is the only remaining candidate and it should stay inline: its proof is four
`Finset.sum_filter_of_ne` rewrites followed by an `omega`, and lifting it would restate a Mathlib
lemma in local clothing. That is precisely the finding that cost the sibling PR #4442 a round —
its *second* helper was flagged by both `reuse` and `generality` as a restatement of
`Finset.sum_filter_of_ne`. One extraction here, on purpose.

## Gate

`lake build` of the changed module and its sole direct importer
(`TauCeti.RingTheory.Nilpotent.RootString.G2`). A private-only change does not by itself force an
importer rebuild, so rather than trust the exit code the importer's `.olean` was **deleted before
the build** and confirmed regenerated with a new mtime — the dependency edge is live and the green
is real.

The branch was gated once before `main` took the mathlib bump to `618f225`, then merged up and
**re-gated against the new pin** (`lake exe cache get`, then the same two modules): exit 0, 1480
jobs, zero warnings, with the whole dependency chain — `Algebra.Ring.Commutator`,
`DividedPowers.Associative`, `NormalOrdering`, `Nilpotent.Exp`, `RootString.Basic` — really
re-elaborated. The merge also brings in #4536, which changed that same importer, so the green
covers the two together.

One more signature worth recording: the module's `.olean` is byte-identical before and after this
change. That is not a stale build — this is a module-system file, so `.olean` carries only the
public interface while `.olean.private` (2.2 MB here) carries the rest, and all the private-side
artifacts were rewritten. An unchanged `.olean` is positive evidence that nothing public moved.

`lake exe axioms`, `lake exe module-system` and `lint-env` each need a full-library build and are
left to CI `pr-build`. No pin change of my own; one file touched.

Roadmap: ReductiveGroups
