### PR TITLE
refactor(Symplectic): prove the transport round-trip laws from Mathlib

### DIFF
--- a/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
+++ b/TauCeti/Geometry/Symplectic/SymplecticTransport.lean
@@ -92,13 +92,17 @@ lemma transport_trans (ω : SymplecticForm V) (e₁ : V ≃ₗ[ℝ] W) (e₂ : W
 
 /-- Transporting forward along `e` and back along `e.symm` returns the original form. -/
 lemma transport_symm_transport (ω : SymplecticForm V) (e : V ≃ₗ[ℝ] W) :
-    (ω.transport e).transport e.symm = ω := by
-  rw [transport_trans, e.self_trans_symm, transport_refl]
+    (ω.transport e).transport e.symm = ω :=
+  toBilinForm_injective <| by
+    rw [transport_toBilinForm, transport_toBilinForm, ← LinearMap.BilinForm.congr_symm,
+      LinearEquiv.symm_apply_apply]
 
 /-- Transporting back along `e.symm` and forward along `e` returns the original form. -/
 lemma transport_transport_symm (ω : SymplecticForm W) (e : V ≃ₗ[ℝ] W) :
-    (ω.transport e.symm).transport e = ω := by
-  rw [transport_trans, e.symm_trans_self, transport_refl]
+    (ω.transport e.symm).transport e = ω :=
+  toBilinForm_injective <| by
+    rw [transport_toBilinForm, transport_toBilinForm, ← LinearMap.BilinForm.congr_symm,
+      LinearEquiv.apply_symm_apply]
 
 /-- `e` is a symplectomorphism onto the transported form: evaluating `ω.transport e` on images
 under `e` recovers `ω`. -/

--- a/TauCeti/Geometry/Symplectic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/Transport.lean
@@ -73,7 +73,7 @@ lemma transport_apply (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) (w : 
 @[simp]
 lemma transport_refl (J : AlmostComplexStructure V) :
     J.transport (LinearEquiv.refl ℝ V) = J :=
-  toLinearMap_injective (by ext v; simp)
+  toLinearMap_injective (LinearEquiv.conj_refl J.toLinearMap)
 
 /-- Transport is functorial: transporting along `e₁` then `e₂` is transporting along their
 composite. -/
@@ -86,13 +86,13 @@ lemma transport_trans (J : AlmostComplexStructure V) (e₁ : V ≃ₗ[ℝ] W) (e
 
 /-- Transporting forward along `e` and back along `e.symm` returns the original structure. -/
 lemma transport_symm_transport (J : AlmostComplexStructure V) (e : V ≃ₗ[ℝ] W) :
-    (J.transport e).transport e.symm = J := by
-  rw [transport_trans, e.self_trans_symm, transport_refl]
+    (J.transport e).transport e.symm = J :=
+  toLinearMap_injective (e.conj_symm_conj J.toLinearMap)
 
 /-- Transporting back along `e.symm` and forward along `e` returns the original structure. -/
 lemma transport_transport_symm (J : AlmostComplexStructure W) (e : V ≃ₗ[ℝ] W) :
-    (J.transport e.symm).transport e = J := by
-  rw [transport_trans, e.symm_trans_self, transport_refl]
+    (J.transport e.symm).transport e = J :=
+  toLinearMap_injective (e.conj_conj_symm J.toLinearMap)
 
 /-- Transport commutes with negation of the almost complex structure. -/
 @[simp]


### PR DESCRIPTION
Four transport round-trip proofs in `TauCeti/Geometry/Symplectic/` were **textually identical
across two files** — the same three-step rewrite, copied once for almost complex structures and
once for symplectic forms:

```lean
rw [transport_trans, e.self_trans_symm, transport_refl]   -- ×2 in Transport.lean
rw [transport_trans, e.symm_trans_self, transport_refl]   -- ×2 in SymplecticTransport.lean
```

Both transports are already *defined* as lifts of a Mathlib operation — `LinearEquiv.conj` for
`AlmostComplexStructure`, `LinearMap.BilinForm.congr` for `SymplecticForm` — and Mathlib already
proves the round-trip laws for both. So each copy is replaced by the corresponding Mathlib lemma,
lifted through the structure's injectivity lemma.

Roadmap: HeegaardFloer

This is cleanup of existing code, so it claims no new roadmap target; `HeegaardFloer/README.md:22`
names `TauCeti/Geometry/Symplectic/` as its analytic lanes, and that is the roadmap chiefly served.

## The change

| lemma | before | after |
|---|---|---|
| `AlmostComplexStructure.transport_symm_transport` | 3-step `rw` | `toLinearMap_injective (e.conj_symm_conj _)` |
| `AlmostComplexStructure.transport_transport_symm` | 3-step `rw` | `toLinearMap_injective (e.conj_conj_symm _)` |
| `SymplecticForm.transport_symm_transport` | 3-step `rw` | `← BilinForm.congr_symm` + `symm_apply_apply` |
| `SymplecticForm.transport_transport_symm` | 3-step `rw` | `← BilinForm.congr_symm` + `apply_symm_apply` |
| `AlmostComplexStructure.transport_refl` | `by ext v; simp` | `toLinearMap_injective (LinearEquiv.conj_refl _)` |

No statement changes, no declarations added or removed, no `simp` attributes touched — every
downstream user sees exactly the same API.

`SymplecticForm.transport_refl` is deliberately **left alone**, so the two `transport_refl`s do
not match. That asymmetry is Mathlib's, not an oversight: `LinearEquiv.conj_refl` applies to an
argument (`(refl).conj f = f`), so it lifts to a term one-liner, whereas
`LinearMap.BilinForm.congr_refl` is an equation between the *equivs* themselves
(`congr (refl) = refl`, `BilinearForm/Hom.lean:214`). Forcing the symplectic side into the same
shape reads worse than the `simp` already there, so it keeps it.

The round-trip laws also stop depending on `transport_trans` and `transport_refl`, which is the
substantive gain beyond the de-duplication: they were being derived *through* the functoriality
lemmas of this file, and are now independent of them.

## Why the finding's proposed generalisation is **not** what this PR does

The dedup finding proposes extracting a shared `transportEquiv : S V ≃ S W` built from
`Equiv.subtypeEquiv`, and re-pointing both sites at it. I did not do that, and the reason is that
the premise does not hold:

* `AlmostComplexStructure` and `SymplecticForm` are **`structure`s, not `Subtype`s**
  (`AlmostComplex.lean:56` and `:343`), so `Equiv.subtypeEquiv` does not apply to either without
  first redefining both — a change to public definitions, to remove ten lines of proof.
* They do not even have the same shape: `AlmostComplexStructure` carries one property
  (`square_neg`), `SymplecticForm` carries two (`isAlt`, `nondegenerate`).
* Their underlying Mathlib operations differ (`LinearEquiv.conj` on an endomorphism versus
  `BilinForm.congr` on a bilinear form), and `SymplecticForm.transport` is `noncomputable` while
  `AlmostComplexStructure.transport` is not.

A shared abstraction over exactly two instances of different shape would cost more than the
duplication it removes. Pointing each site at the Mathlib lemma that already proves it removes the
same duplication with no new API, which is why that is the route taken here — it is also the
"direct one-liners" remedy the finding itself lists alongside the `subtypeEquiv` proposal.

## Prior art

Measured against **mathlib `618f225e1ff4a6b2790a944e01b806b7c68bdc56`** and **TauCeti `main`
`d78ec98699f2c0ff0b9e68d2ed1f7f8125b7912f`**:

* **Mathlib** already has every lemma this PR now calls — `LinearEquiv.conj_refl`,
  `LinearEquiv.conj_symm_conj`, `LinearEquiv.conj_conj_symm`, `LinearMap.BilinForm.congr_symm`.
  Nothing new is proved here; the point is that the repository was re-deriving them.
* **TauCeti `main`**: no other transport-style structure repeats this pattern — the two files in
  this diff are the only sites the sweep found, and both are edited here.

## Gates

Module-scoped, after merging `origin/main`:

* `lake build` of both changed modules **and all six direct importers**
  (`Complex/Line`, `Cotangent/Compatible`, `JHolomorphic/MapOps`, `JHolomorphic/Transport`,
  `Lagrangian/Constructions`, `Prod/Basic`, `Restrict`)
* `scripts/lint-style.sh`
* `scripts/lint-dot-notation.py`
* `#print axioms` on the five touched declarations
