### PR TITLE
refactor(EllipticCurve): name the scalar tower of a composite isogeny

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Degree.lean
@@ -182,8 +182,7 @@ theorem degree_comp (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
   let _ := ψ.fieldPullback.toRingHom.toAlgebra
   let _ := (ψ.comp φ).fieldPullback.toRingHom.toAlgebra
   have htower : IsScalarTower W₃.FunctionField W₂.FunctionField W₁.FunctionField :=
-    IsScalarTower.of_algebraMap_eq fun z ↦ by
-      simp [RingHom.algebraMap_toAlgebra, comp_fieldPullback]
+    isScalarTower_fieldPullback ψ φ
   have hφ : ∀ z, algebraMap _ _ z = φ.fieldPullback z :=
     φ.fieldPullback.algebraMap_toAlgebra_apply
   have hψ : ∀ z, algebraMap _ _ z = ψ.fieldPullback z :=

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.lean
@@ -37,6 +37,9 @@ field. `TauCeti.Isogeny.comp` therefore lives here rather than beside `TauCeti.I
   its function-field law and `TauCeti.Isogeny.id_comp`, `TauCeti.Isogeny.comp_id`,
   `TauCeti.Isogeny.comp_assoc` the unit and associativity laws. The pointedness obligation is
   discharged privately when `comp` is defined.
+* `TauCeti.Isogeny.isScalarTower_fieldPullback`: the three pullbacks of a composite make
+  `F(W₃) ⊆ F(W₂) ⊆ F(W₁)` a scalar tower — the shared opening of the multiplicativity-under-
+  composition proofs in `Isogeny/Degree.lean` and `Isogeny/Separability.lean`.
 * `TauCeti.Isogeny.comp_right_injective` and `TauCeti.Isogeny.comp_right_inj`: precomposition
   by a fixed isogeny is injective. Equivalently, a factorisation `ψ = λ.comp φ` through a fixed
   `φ` determines its factor `λ` uniquely — the uniqueness half of factoring an isogeny, reached
@@ -275,6 +278,28 @@ pullbacks. -/
 theorem comp_fieldPullback (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
     (ψ.comp φ).fieldPullback = φ.fieldPullback.comp ψ.fieldPullback :=
   ((ψ.comp φ).fieldPullback_unique _ fun x ↦ by simp).symm
+
+/-- **The pullbacks of a composite isogeny form a scalar tower**: `F(W₃) ⊆ F(W₂) ⊆ F(W₁)`, the
+inclusions being the three function-field pullbacks. This is `comp_fieldPullback` read as a
+statement about algebra structures — the composite's pullback *is* the composite of the two, which
+is exactly the compatibility `IsScalarTower` asks for.
+
+The three `letI`s are part of the statement, because these algebra structures come from `AlgHom`s
+rather than from instances: a consumer installs the same three `let`s and this lemma then applies.
+It is the shared opening of every proof that an invariant is multiplicative under composition —
+`degree_comp`, `separableDegree_comp` and `inseparableDegree_comp` each begin with it. -/
+theorem isScalarTower_fieldPullback (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
+    letI := φ.fieldPullback.toRingHom.toAlgebra
+    letI := ψ.fieldPullback.toRingHom.toAlgebra
+    letI := (ψ.comp φ).fieldPullback.toRingHom.toAlgebra
+    IsScalarTower W₃.FunctionField W₂.FunctionField W₁.FunctionField := by
+  -- the statement's `letI`s fix the *type*, but instance search inside the proof needs them in
+  -- the local instance cache, so install them again here
+  let _ := φ.fieldPullback.toRingHom.toAlgebra
+  let _ := ψ.fieldPullback.toRingHom.toAlgebra
+  let _ := (ψ.comp φ).fieldPullback.toRingHom.toAlgebra
+  exact IsScalarTower.of_algebraMap_eq fun z ↦ by
+    simp [RingHom.algebraMap_toAlgebra, comp_fieldPullback]
 
 /-- The identity isogeny is a left unit for composition. -/
 @[simp]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Separability.lean
@@ -239,8 +239,7 @@ theorem separableDegree_comp (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂) :
   let _ := ψ.fieldPullback.toRingHom.toAlgebra
   let _ := (ψ.comp φ).fieldPullback.toRingHom.toAlgebra
   have : IsScalarTower W₃.FunctionField W₂.FunctionField W₁.FunctionField :=
-    IsScalarTower.of_algebraMap_eq fun z ↦ by
-      simp [RingHom.algebraMap_toAlgebra, comp_fieldPullback]
+    isScalarTower_fieldPullback ψ φ
   have hφ : ∀ z, algebraMap _ _ z = φ.fieldPullback z :=
     φ.fieldPullback.algebraMap_toAlgebra_apply
   have hψ : ∀ z, algebraMap _ _ z = ψ.fieldPullback z :=
@@ -264,8 +263,7 @@ theorem inseparableDegree_comp (ψ : Isogeny W₂ W₃) (φ : Isogeny W₁ W₂)
   let _ := ψ.fieldPullback.toRingHom.toAlgebra
   let _ := (ψ.comp φ).fieldPullback.toRingHom.toAlgebra
   have : IsScalarTower W₃.FunctionField W₂.FunctionField W₁.FunctionField :=
-    IsScalarTower.of_algebraMap_eq fun z ↦ by
-      simp [RingHom.algebraMap_toAlgebra, comp_fieldPullback]
+    isScalarTower_fieldPullback ψ φ
   have hφ : ∀ z, algebraMap _ _ z = φ.fieldPullback z :=
     φ.fieldPullback.algebraMap_toAlgebra_apply
   have hψ : ∀ z, algebraMap _ _ z = ψ.fieldPullback z :=


### PR DESCRIPTION
`TauCeti.Isogeny.degree_comp`, `TauCeti.Isogeny.separableDegree_comp` and
`TauCeti.Isogeny.inseparableDegree_comp` each opened with the *same* three-line proof, verbatim:

```lean
have : IsScalarTower W₃.FunctionField W₂.FunctionField W₁.FunctionField :=
  IsScalarTower.of_algebraMap_eq fun z ↦ by
    simp [RingHom.algebraMap_toAlgebra, comp_fieldPullback]
```

This PR states that fact once and cites it at all three sites.

## Added — `Isogeny/FunctionField.lean`

* `TauCeti.Isogeny.isScalarTower_fieldPullback`: the three function-field pullbacks of a composite
  isogeny make `F(W₃) ⊆ F(W₂) ⊆ F(W₁)` a scalar tower.

It is placed directly after `TauCeti.Isogeny.comp_fieldPullback`, the lemma its proof uses — the
tower is really that lemma read as a statement about algebra structures, since the composite's
pullback *is* the composite of the two, which is exactly the compatibility `IsScalarTower` asks
for. Added to the module docstring's **Main results**.

`FunctionField.lean` is the deepest common ancestor of the three call sites — `Degree.lean`
publicly imports it, and `Separability.lean` publicly imports `Degree.lean` — so **no import
changes anywhere**.

## Re-pointed — 3 sites

| file | theorem | diff |
|---|---|---|
| `Isogeny/Degree.lean` | `degree_comp` | +1 / −2 |
| `Isogeny/Separability.lean` | `separableDegree_comp` | +1 / −2 |
| `Isogeny/Separability.lean` | `inseparableDegree_comp` | +1 / −2 |

## A note on the `letI`s in the statement

These algebra structures come from `AlgHom`s rather than from instances, so they cannot be
hypotheses: the statement installs them itself with three `letI`s, and a consumer that installs
the same three `let`s can then cite the lemma directly. That is exactly what the three call sites
already did, and they are unchanged apart from the citation.

The proof re-installs the same three with `let _`, because the statement's `letI`s fix the *type*
without entering the local instance cache that instance search inside the proof consults. There is
a comment on that line saying so.

## What this deliberately does *not* do

The three sites also share `have hφ`, `have hψ` and `have hc`, each of the shape
`∀ z, algebraMap _ _ z = ….fieldPullback z`. Those are **not** extracted, because each is already
a single application of the existing `AlgHom.algebraMap_toAlgebra_apply`; the `have` only binds a
name and fixes implicit arguments for the later `rw`. Naming them again would add aliases with no
content.

## Verification

`lake build` of the three changed modules and all eight of their direct importers
(`Isogeny.InfinityPlace`, `Isogeny.Factorisation`, `Isogeny.Frobenius`,
`Isogeny.RelativeFrobenius`, and `Isogeny.IntermediateRing.{Basic,Finite,Rank,Dedekind}`) —
2748 jobs, clean. `#print axioms` on the new lemma and on all three re-pointed theorems reports
`[propext, Classical.choice, Quot.sound]` only.

Roadmap: none

A pure refactor: it adds no new mathematics and carries no `tauceti-target` marker. Found by the
2026-08-24 dedup sweep as finding V09.
