### PR TITLE
feat(scripts): report where the pull-request pipeline is slow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           PYTHONPATH=scripts python3 scripts/test_loc_roadmap_graph.py
           PYTHONPATH=scripts python3 scripts/test_participant_graph.py
           PYTHONPATH=scripts python3 scripts/test_pr_stats_graphs.py
+          PYTHONPATH=scripts python3 scripts/test_pr_lifecycle.py
           PYTHONPATH=scripts python3 scripts/test_pipeline_health.py
           python3 scripts/pr_status/test_stuck_alerts.py
           python3 scripts/test_roadmap_label.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           PYTHONPATH=scripts python3 scripts/test_loc_roadmap_graph.py
           PYTHONPATH=scripts python3 scripts/test_participant_graph.py
           PYTHONPATH=scripts python3 scripts/test_pr_stats_graphs.py
+          PYTHONPATH=scripts python3 scripts/test_pipeline_health.py
           python3 scripts/pr_status/test_stuck_alerts.py
           python3 scripts/test_roadmap_label.py
           python3 scripts/pr_status/test_pr_labels.py

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -155,7 +155,26 @@ jobs:
           python3 scripts/pr_stats_graphs.py \
             --repo "${{ github.repository }}" \
             --out-dir web/static_files \
+            --dump-data "$RUNNER_TEMP/pr-snapshot.json" \
           || echo "::warning::PR statistics generation failed; keeping the committed fallback assets"
+
+      # Pipeline health reuses the snapshot the charts just fetched rather than
+      # walking every PR timeline a second time: that walk is thousands of
+      # requests and the dominant cost of this job. Publishing the result means
+      # anything asking "where is the queue stuck" reads a file instead of
+      # repeating the fetch.
+      - name: Derive pipeline health from the same snapshot
+        working-directory: ${{ github.workspace }}
+        run: |
+          if [ -f "$RUNNER_TEMP/pr-snapshot.json" ]; then
+            python3 scripts/pipeline_health.py \
+              --data "$RUNNER_TEMP/pr-snapshot.json" \
+              --out web/static_files/pipeline-health.json \
+              --json > /dev/null \
+            || echo "::warning::pipeline health generation failed"
+          else
+            echo "::warning::no PR snapshot; skipping pipeline health"
+          fi
 
       # Pinned leanprover/elan release, verified by SHA-256, rather than whatever the installer
       # URL serves at the moment of the request; this elan chooses the toolchain that builds the

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,6 +42,7 @@ on:
       - 'scripts/loc_roadmap_graph.py'
       - 'scripts/participant_graph.py'
       - 'scripts/pr_stats_graphs.py'
+      - 'scripts/pipeline_health.py'
       - '.github/workflows/pages.yml'
   schedule:
     - cron: "23 */3 * * *"   # Every three hours (UTC): refresh the charts and API docs

--- a/scripts/pipeline_health.md
+++ b/scripts/pipeline_health.md
@@ -1,0 +1,48 @@
+# Pipeline health
+
+`scripts/pipeline_health.py` answers "where is the pull-request pipeline slow,
+and why", which merge throughput on its own cannot: throughput is one number at
+the end of a queue, so a fall in it says something is wrong without saying what.
+
+It measures each lifecycle stage separately — arrival rate, departure rate,
+current depth, how long the oldest occupant has waited, and median dwell — each
+against a trailing baseline, and names the stage most responsible.
+
+## Reading it
+
+```
+scripts/pipeline_health.py             # fetch and report
+scripts/pipeline_health.py --json      # machine-readable
+```
+
+Two things it deliberately does not do.
+
+**Depth is not evidence.** A stage can be very deep and perfectly healthy if it
+drains as fast as it fills. The bottleneck is chosen on arrivals outrunning
+departures, and on occupants waiting longer than that stage normally takes.
+
+**`ci-failed` and `awaiting-author` are never blamed.** Those wait on the
+contributor rather than on the project, and treating a backlog there as
+something to fix would point effort at exactly the wrong place. They are
+reported, marked with `*`, and excluded from the bottleneck.
+
+## Where the data comes from
+
+The same normalized snapshot the statistics charts use, so this adds no new API
+surface. Fetching it walks every pull request's label timeline, which is
+thousands of requests and takes tens of minutes, so:
+
+- **the Pages workflow** fetches once, writes the charts, and derives
+  `pipeline-health.json` from the same snapshot;
+- **anything else** should read the published
+  `https://taucetiproject.github.io/TauCeti/static/pipeline-health.json`
+  rather than repeat the walk.
+
+To work offline, dump a snapshot once and replay it:
+
+```
+scripts/pr_stats_graphs.py --dump-data snap.json --out-dir /tmp/charts
+scripts/pipeline_health.py --data snap.json
+```
+
+That is also how the tests run, so they need no network.

--- a/scripts/pipeline_health.md
+++ b/scripts/pipeline_health.md
@@ -15,16 +15,26 @@ scripts/pipeline_health.py             # fetch and report
 scripts/pipeline_health.py --json      # machine-readable
 ```
 
-Two things it deliberately does not do.
+Three things it deliberately does not do.
 
 **Depth is not evidence.** A stage can be very deep and perfectly healthy if it
 drains as fast as it fills. The bottleneck is chosen on arrivals outrunning
 departures, and on occupants waiting longer than that stage normally takes.
 
+**It does not always name a culprit.** Throughput can fall because nothing
+arrived, so when no stage clears an anomaly threshold none is named. A heuristic
+that always finds someone to blame is not a diagnosis. A baseline with too few
+completed merges reports insufficient data rather than health.
+
 **`ci-failed` and `awaiting-author` are never blamed.** Those wait on the
 contributor rather than on the project, and treating a backlog there as
 something to fix would point effort at exactly the wrong place. They are
 reported, marked with `*`, and excluded from the bottleneck.
+
+Depths come from the labels a PR currently carries, not from the last event in
+its timeline, so a PR whose label was removed is not counted in a stage it has
+left. Open PRs carrying no single lifecycle label are counted separately and
+reported, rather than silently omitted.
 
 ## Where the data comes from
 
@@ -44,5 +54,13 @@ To work offline, dump a snapshot once and replay it:
 scripts/pr_stats_graphs.py --dump-data snap.json --out-dir /tmp/charts
 scripts/pipeline_health.py --data snap.json
 ```
+
+A replay is measured as at the snapshot's `fetched_at`, not as at now, so an old
+snapshot gives the answer it would have given when it was taken. `--as-of`
+overrides that.
+
+The baseline window is disjoint from the recent one, and both are clamped to the
+date the lifecycle labels landed, so a wide baseline is not diluted by time in
+which no event could have been recorded.
 
 That is also how the tests run, so they need no network.

--- a/scripts/pipeline_health.md
+++ b/scripts/pipeline_health.md
@@ -6,7 +6,8 @@ the end of a queue, so a fall in it says something is wrong without saying what.
 
 It measures each lifecycle stage separately — arrival rate, departure rate,
 current depth, how long the oldest occupant has waited, and median dwell — each
-against a trailing baseline, and names the stage most responsible.
+against a trailing baseline, and names the cause: a stage backing up, an intake
+that has thinned, both, or neither.
 
 ## Reading it
 
@@ -21,10 +22,16 @@ Three things it deliberately does not do.
 drains as fast as it fills. The bottleneck is chosen on arrivals outrunning
 departures, and on occupants waiting longer than that stage normally takes.
 
-**It does not always name a culprit.** Throughput can fall because nothing
-arrived, so when no stage clears an anomaly threshold none is named. A heuristic
-that always finds someone to blame is not a diagnosis. A baseline with too few
-completed merges reports insufficient data rather than health.
+**A thin intake is an answer, not a shrug.** Fewer merges can mean the queue is
+stuck or simply that less went into it, and those want opposite responses:
+adding review capacity does nothing about a week when nobody opened anything. So
+arrival rates are compared against baseline too, and a fall in them is reported
+as the cause. When both are true, both are said.
+
+**It will admit to not knowing.** If arrivals are steady and no stage is backing
+up, the fall is reported as unexplained rather than pinned on whichever stage
+happened to be deepest. A baseline with too few merges reports insufficient data
+rather than health.
 
 **`ci-failed` and `awaiting-author` are never blamed.** Those wait on the
 contributor rather than on the project, and treating a backlog there as

--- a/scripts/pipeline_health.py
+++ b/scripts/pipeline_health.py
@@ -41,11 +41,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from pr_stats_graphs import (  # noqa: E402
+    LIFECYCLE_EPOCH,
     LIFECYCLE_LABELS,
     STATE_AUTHOR_ACTION,
+    atomic_write,
     fetch_snapshot,
     iso_z,
     parse_dt,
+    percentile,
 )
 
 # Reported in pipeline order, which is also the order to read them in: a stage
@@ -84,75 +87,115 @@ def lifecycle_intervals(pr: dict, now: datetime):
 
 
 def rate(count: int, hours: float) -> float:
-    return count / hours if hours else 0.0
+    return count / hours if hours > 0 else 0.0
 
 
-def median(values: list[float]) -> float | None:
-    if not values:
-        return None
-    ordered = sorted(values)
-    middle = len(ordered) // 2
-    if len(ordered) % 2:
-        return ordered[middle]
-    return (ordered[middle - 1] + ordered[middle]) / 2
+def observable_hours(start: datetime, end: datetime) -> float:
+    """Hours of the interval in which lifecycle labels could exist at all.
+
+    The labels landed on LIFECYCLE_EPOCH, so a window reaching back before it
+    contains time in which no event could have been recorded. Dividing by the
+    requested duration rather than the observable one understates every rate on
+    a wide baseline.
+    """
+    start = max(start, LIFECYCLE_EPOCH)
+    return max((end - start).total_seconds() / 3600, 0.0)
 
 
-def analyse(snapshot: dict, window_hours: float, baseline_hours: float, now: datetime) -> dict:
+def current_stage(pr: dict) -> str | None:
+    """The stage a PR is in now, from its labels rather than its history.
+
+    Taking the last timeline event instead would place a PR whose lifecycle
+    label was removed into a stage it has left, and would drop one that has no
+    events at all. The labels are what the pipeline actually maintains.
+    """
+    present = [label for label in pr.get("labels") or [] if label in LIFECYCLE_LABELS]
+    return present[0] if len(present) == 1 else None
+
+
+def analyse(
+    snapshot: dict,
+    window_hours: float,
+    baseline_hours: float,
+    now: datetime | None = None,
+) -> dict:
+    if window_hours <= 0 or baseline_hours <= 0:
+        raise ValueError("window and baseline must be positive")
+
+    # Replaying a snapshot must measure it as it was, not as though it were
+    # taken now: otherwise every open interval gains however long the file has
+    # been sitting on disk, and every recent rate reads as zero.
+    if now is None:
+        now = parse_dt(snapshot.get("fetched_at")) or datetime.now(timezone.utc)
+    now = now.astimezone(timezone.utc)
+
     prs = snapshot["prs"]
     window_start = now - timedelta(hours=window_hours)
-    baseline_start = now - timedelta(hours=baseline_hours)
+    # Disjoint, so the baseline is something to compare against rather than
+    # something the recent window is already part of.
+    baseline_end = window_start
+    baseline_start = baseline_end - timedelta(hours=baseline_hours)
+    window_span = observable_hours(window_start, now)
+    baseline_span = observable_hours(baseline_start, baseline_end)
 
     entered = defaultdict(lambda: {"window": 0, "baseline": 0})
     left = defaultdict(lambda: {"window": 0, "baseline": 0})
     dwell = defaultdict(lambda: {"window": [], "baseline": []})
     depth: defaultdict[str, int] = defaultdict(int)
     oldest: dict[str, float] = {}
+    unlabelled_open = 0
 
     for pr in prs:
+        if pr["state"] == "OPEN" and not pr["is_draft"]:
+            stage = current_stage(pr)
+            if stage is None:
+                unlabelled_open += 1
+            else:
+                depth[stage] += 1
+
         for label, start, end in lifecycle_intervals(pr, now):
-            if start >= baseline_start:
+            if baseline_start <= start < baseline_end:
                 entered[label]["baseline"] += 1
             if start >= window_start:
                 entered[label]["window"] += 1
 
             if end is None:
-                # Still in this stage: it contributes to depth and to how long
-                # the stage's current occupants have been waiting, but not to
-                # completed dwell times, which would bias them downwards.
-                depth[label] += 1
+                # Still in this stage: it contributes to how long the stage's
+                # current occupants have been waiting, but not to completed
+                # dwell times, which would bias them downwards.
                 waiting = (now - start).total_seconds() / 3600
                 oldest[label] = max(oldest.get(label, 0.0), waiting)
                 continue
 
             hours = (end - start).total_seconds() / 3600
-            if end >= baseline_start:
+            if baseline_start <= end < baseline_end:
                 left[label]["baseline"] += 1
                 dwell[label]["baseline"].append(hours)
             if end >= window_start:
                 left[label]["window"] += 1
                 dwell[label]["window"].append(hours)
 
-    def opened_or_merged(field: str, since: datetime) -> int:
+    def counted(field: str, start: datetime, end: datetime) -> int:
         return sum(
             1 for pr in prs
-            if pr.get(field) and parse_dt(pr[field]) >= since
+            if pr.get(field) and start <= parse_dt(pr[field]) < end
         )
 
     stages = []
     for label in STAGE_ORDER:
-        baseline_dwell = median(dwell[label]["baseline"])
-        window_dwell = median(dwell[label]["window"])
         stages.append({
             "stage": label,
             "owned_by_project": label not in STATE_AUTHOR_ACTION,
             "depth": depth[label],
-            "oldest_waiting_hours": round(oldest.get(label, 0.0), 1),
-            "entered_per_hour": round(rate(entered[label]["window"], window_hours), 2),
-            "left_per_hour": round(rate(left[label]["window"], window_hours), 2),
-            "baseline_entered_per_hour": round(rate(entered[label]["baseline"], baseline_hours), 2),
-            "baseline_left_per_hour": round(rate(left[label]["baseline"], baseline_hours), 2),
-            "median_dwell_hours": round(window_dwell, 2) if window_dwell is not None else None,
-            "baseline_median_dwell_hours": round(baseline_dwell, 2) if baseline_dwell is not None else None,
+            "oldest_waiting_hours": oldest.get(label, 0.0),
+            "entered_per_hour": rate(entered[label]["window"], window_span),
+            "left_per_hour": rate(left[label]["window"], window_span),
+            "baseline_entered_per_hour": rate(entered[label]["baseline"], baseline_span),
+            "baseline_left_per_hour": rate(left[label]["baseline"], baseline_span),
+            "left_count": left[label]["window"],
+            "baseline_left_count": left[label]["baseline"],
+            "median_dwell_hours": percentile(dwell[label]["window"], 0.5),
+            "baseline_median_dwell_hours": percentile(dwell[label]["baseline"], 0.5),
         })
 
     result = {
@@ -162,58 +205,100 @@ def analyse(snapshot: dict, window_hours: float, baseline_hours: float, now: dat
         "snapshot_fetched_at": snapshot.get("fetched_at"),
         "window_hours": window_hours,
         "baseline_hours": baseline_hours,
-        "opened_per_hour": round(rate(opened_or_merged("created_at", window_start), window_hours), 2),
-        "baseline_opened_per_hour": round(rate(opened_or_merged("created_at", baseline_start), baseline_hours), 2),
-        "merged_per_hour": round(rate(opened_or_merged("merged_at", window_start), window_hours), 2),
-        "baseline_merged_per_hour": round(rate(opened_or_merged("merged_at", baseline_start), baseline_hours), 2),
+        "observable_window_hours": window_span,
+        "observable_baseline_hours": baseline_span,
+        "opened_per_hour": rate(counted("created_at", window_start, now), window_span),
+        "baseline_opened_per_hour": rate(
+            counted("created_at", baseline_start, baseline_end), baseline_span),
+        "merged_per_hour": rate(counted("merged_at", window_start, now), window_span),
+        "baseline_merged_per_hour": rate(
+            counted("merged_at", baseline_start, baseline_end), baseline_span),
+        "merged_count": counted("merged_at", window_start, now),
+        "baseline_merged_count": counted("merged_at", baseline_start, baseline_end),
         "open_prs": sum(1 for pr in prs if pr["state"] == "OPEN"),
+        "open_prs_without_a_lifecycle_label": unlabelled_open,
         "stages": stages,
     }
     result["bottleneck"] = find_bottleneck(result)
     return result
 
 
+ROUND_TO = 2
+
+
+def rounded(result: dict) -> dict:
+    """Round for output only.
+
+    Comparisons run on the raw values: rounding first turns one event in a
+    fortnight into a rate of exactly zero, which silently changes which branch
+    every threshold takes.
+    """
+    def fix(value):
+        return round(value, ROUND_TO) if isinstance(value, float) else value
+
+    out = {k: fix(v) for k, v in result.items() if k != "stages"}
+    out["stages"] = [{k: fix(v) for k, v in stage.items()} for stage in result["stages"]]
+    return out
+
+
+# A stage must clear one of these to be blamed at all. Without them the search
+# always returns something, and a heuristic that always finds a culprit is not a
+# diagnosis.
+MIN_COMPLETIONS = 3          # below this a median dwell is noise
+GROWTH_PER_HOUR = 0.05       # arrivals must outpace departures by a real margin
+SLOWDOWN_FACTOR = 2.0        # the oldest occupant, against normal dwell
+THROUGHPUT_FRACTION = 0.75   # of baseline, below which something is wrong
+
+
 def find_bottleneck(result: dict) -> dict | None:
     """The stage most responsible for the pipeline being slower than usual.
 
-    Judged on backing up rather than on depth: a stage can be deep and perfectly
-    healthy if it is draining as fast as it fills. What matters is arrivals
-    outrunning departures, and occupants waiting longer than they normally do.
+    Judged on backing up, not on depth: a stage can be very deep and perfectly
+    healthy if it drains as fast as it fills. A stage that meets no anomaly
+    condition is not named, even when throughput is down, because "the queue is
+    slow and no stage is misbehaving" is a real and useful answer.
     """
-    if result["merged_per_hour"] >= result["baseline_merged_per_hour"] * 0.75:
+    baseline = result["baseline_merged_per_hour"]
+    if not baseline or result["baseline_merged_count"] < MIN_COMPLETIONS:
+        # Nothing to compare against. Saying "healthy" here would be a guess
+        # dressed as a finding.
+        return {"stage": None, "why": "not enough baseline data to judge", "insufficient_data": True}
+    if result["merged_per_hour"] >= baseline * THROUGHPUT_FRACTION:
         return None
 
-    scored = []
+    candidates = []
     for stage in result["stages"]:
         if not stage["owned_by_project"] or not stage["depth"]:
             continue
-        arriving = stage["entered_per_hour"]
-        leaving = stage["left_per_hour"]
-        # How far behind the stage is falling, relative to its own normal pace.
-        backlog_growth = arriving - leaving
-        baseline_dwell = stage["baseline_median_dwell_hours"] or 0
-        slowdown = 0.0
-        if baseline_dwell and stage["oldest_waiting_hours"]:
-            slowdown = stage["oldest_waiting_hours"] / baseline_dwell
-        scored.append((backlog_growth > 0, slowdown, backlog_growth, stage))
-
-    if not scored:
-        return None
-    scored.sort(key=lambda item: (item[0], item[1], item[2]), reverse=True)
-    growing, slowdown, growth, stage = scored[0]
-
-    if growing:
-        why = (
-            f"arriving at {stage['entered_per_hour']}/h and leaving at "
-            f"{stage['left_per_hour']}/h, so it is filling faster than it drains"
+        growth = stage["entered_per_hour"] - stage["left_per_hour"]
+        normal = stage["baseline_median_dwell_hours"]
+        enough = stage["baseline_left_count"] >= MIN_COMPLETIONS
+        slowdown = (
+            stage["oldest_waiting_hours"] / normal
+            if enough and normal and stage["oldest_waiting_hours"] else 0.0
         )
-    elif slowdown > 2:
+        filling = growth > GROWTH_PER_HOUR
+        stalled = slowdown >= SLOWDOWN_FACTOR
+        if filling or stalled:
+            candidates.append((filling, growth, slowdown, stage))
+
+    if not candidates:
+        return None
+    # Filling beats merely slow, then by how fast it is filling, then by how far
+    # past normal its oldest occupant is.
+    candidates.sort(key=lambda item: (item[0], item[1], item[2]), reverse=True)
+    filling, growth, slowdown, stage = candidates[0]
+
+    if filling:
         why = (
-            f"its oldest occupant has waited {stage['oldest_waiting_hours']}h against a "
-            f"{stage['baseline_median_dwell_hours']}h normal dwell"
+            f"arriving at {stage['entered_per_hour']:.2f}/h and leaving at "
+            f"{stage['left_per_hour']:.2f}/h, so it is filling faster than it drains"
         )
     else:
-        why = f"{stage['depth']} waiting, the deepest project-owned stage"
+        why = (
+            f"its oldest occupant has waited {stage['oldest_waiting_hours']:.0f}h against a "
+            f"{stage['baseline_median_dwell_hours']:.1f}h normal dwell"
+        )
     return {"stage": stage["stage"], "why": why, "depth": stage["depth"]}
 
 
@@ -248,7 +333,14 @@ def report(result: dict) -> str:
     lines.append("  * waiting on the contributor, not on the project")
     lines.append("")
     bottleneck = result["bottleneck"]
-    if bottleneck:
+    if result.get("open_prs_without_a_lifecycle_label"):
+        lines.append(
+            f"  note: {result['open_prs_without_a_lifecycle_label']} open PR(s) carry no single "
+            "lifecycle label, so they are absent from every depth above"
+        )
+    if bottleneck and bottleneck.get("insufficient_data"):
+        lines.append(f"  {bottleneck['why']}")
+    elif bottleneck:
         lines.append(f"  bottleneck: {bottleneck['stage']} — {bottleneck['why']}")
     elif baseline and merged < baseline:
         lines.append("  throughput is down but no stage is backing up; likely a quiet spell in arrivals")
@@ -266,17 +358,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--window", type=float, default=24.0, help="recent window, hours")
     parser.add_argument("--baseline", type=float, default=14 * 24.0, help="baseline, hours")
     parser.add_argument("--json", action="store_true", help="print JSON instead of a report")
+    parser.add_argument("--as-of", type=parse_dt,
+                        help="analyse as at this instant (default: the snapshot's fetched_at)")
     args = parser.parse_args(argv)
 
     snapshot = json.loads(args.data.read_text()) if args.data else fetch_snapshot(args.repo)
     if args.dump_data:
         args.dump_data.write_text(json.dumps(snapshot, indent=1))
 
-    now = datetime.now(timezone.utc)
-    result = analyse(snapshot, args.window, args.baseline, now)
+    result = rounded(analyse(snapshot, args.window, args.baseline, args.as_of))
 
     if args.out:
-        args.out.write_text(json.dumps(result, indent=1))
+        # Atomically, matching pr_stats_graphs.py: a half-written JSON file is
+        # worse than a missing one, because everything downstream trusts it.
+        atomic_write(args.out, json.dumps(result, indent=1))
     print(json.dumps(result, indent=1) if args.json else report(result))
     return 0
 

--- a/scripts/pipeline_health.py
+++ b/scripts/pipeline_health.py
@@ -40,50 +40,18 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from pr_stats_graphs import (  # noqa: E402
+from pr_lifecycle import (  # noqa: E402
     LIFECYCLE_EPOCH,
-    LIFECYCLE_LABELS,
+    STAGE_ORDER,
     STATE_AUTHOR_ACTION,
-    atomic_write,
-    fetch_snapshot,
+    current_stage,
+    episodes,
     iso_z,
     parse_dt,
-    percentile,
 )
+from pr_stats_graphs import atomic_write, fetch_snapshot, percentile  # noqa: E402
 
-# Reported in pipeline order, which is also the order to read them in: a stage
-# is only the bottleneck if the ones feeding it are keeping up.
-STAGE_ORDER = [
-    "awaiting-CI",
-    "awaiting-review",
-    "review-in-progress",
-    "ready-to-merge",
-    "ci-failed",
-    "awaiting-author",
-]
 OWNED_BY_PROJECT = [s for s in STAGE_ORDER if s not in STATE_AUTHOR_ACTION]
-
-
-def lifecycle_intervals(pr: dict, now: datetime):
-    """Yield (label, entered, left) for each spell the PR spent in a stage.
-
-    The pipeline keeps exactly one lifecycle label on a PR at a time, so
-    consecutive label events bound each spell. An open PR's final spell is still
-    running, and is reported with `left` as None.
-    """
-    events = [
-        (parse_dt(e["created_at"]), e["label"])
-        for e in sorted(pr.get("labeled_events") or [], key=lambda e: e["created_at"])
-        if e["label"] in LIFECYCLE_LABELS
-    ]
-    for index, (entered, label) in enumerate(events):
-        if index + 1 < len(events):
-            yield label, entered, events[index + 1][0]
-        elif pr["state"] == "OPEN":
-            yield label, entered, None
-        else:
-            closed = parse_dt(pr.get("merged_at") or pr.get("closed_at"))
-            yield label, entered, closed or now
 
 
 def rate(count: int, hours: float) -> float:
@@ -100,17 +68,6 @@ def observable_hours(start: datetime, end: datetime) -> float:
     """
     start = max(start, LIFECYCLE_EPOCH)
     return max((end - start).total_seconds() / 3600, 0.0)
-
-
-def current_stage(pr: dict) -> str | None:
-    """The stage a PR is in now, from its labels rather than its history.
-
-    Taking the last timeline event instead would place a PR whose lifecycle
-    label was removed into a stage it has left, and would drop one that has no
-    events at all. The labels are what the pipeline actually maintains.
-    """
-    present = [label for label in pr.get("labels") or [] if label in LIFECYCLE_LABELS]
-    return present[0] if len(present) == 1 else None
 
 
 def analyse(
@@ -153,7 +110,7 @@ def analyse(
             else:
                 depth[stage] += 1
 
-        for label, start, end in lifecycle_intervals(pr, now):
+        for label, start, end in episodes(pr, now):
             if baseline_start <= start < baseline_end:
                 entered[label]["baseline"] += 1
             if start >= window_start:

--- a/scripts/pipeline_health.py
+++ b/scripts/pipeline_health.py
@@ -45,7 +45,8 @@ from pr_lifecycle import (  # noqa: E402
     STAGE_ORDER,
     STATE_AUTHOR_ACTION,
     current_stage,
-    episodes,
+    label_intervals,
+    waiting_since,
     iso_z,
     parse_dt,
 )
@@ -109,19 +110,25 @@ def analyse(
                 unlabelled_open += 1
             else:
                 depth[stage] += 1
+                # How long this pull request has been waiting is a question
+                # about its spell, not about the label currently on it: the
+                # clock does not restart when the pipeline swaps a label for
+                # its sibling. Rates below are the opposite, and use the atomic
+                # per-label intervals.
+                began = waiting_since(pr, now)
+                if began:
+                    waiting = (now - began).total_seconds() / 3600
+                    oldest[stage] = max(oldest.get(stage, 0.0), waiting)
 
-        for label, start, end in episodes(pr, now):
+        for label, start, end in label_intervals(pr, now):
             if baseline_start <= start < baseline_end:
                 entered[label]["baseline"] += 1
             if start >= window_start:
                 entered[label]["window"] += 1
 
             if end is None:
-                # Still in this stage: it contributes to how long the stage's
-                # current occupants have been waiting, but not to completed
-                # dwell times, which would bias them downwards.
-                waiting = (now - start).total_seconds() / 3600
-                oldest[label] = max(oldest.get(label, 0.0), waiting)
+                # Still running, so not a completed dwell: counting it would
+                # bias a stuck stage's median downwards.
                 continue
 
             hours = (end - start).total_seconds() / 3600
@@ -176,6 +183,7 @@ def analyse(
         "open_prs_without_a_lifecycle_label": unlabelled_open,
         "stages": stages,
     }
+    result["anomalies"] = anomalies(result)
     result["bottleneck"] = find_bottleneck(result)
     return result
 
@@ -193,8 +201,9 @@ def rounded(result: dict) -> dict:
     def fix(value):
         return round(value, ROUND_TO) if isinstance(value, float) else value
 
-    out = {k: fix(v) for k, v in result.items() if k != "stages"}
+    out = {k: fix(v) for k, v in result.items() if k not in ("stages", "anomalies")}
     out["stages"] = [{k: fix(v) for k, v in stage.items()} for stage in result["stages"]]
+    out["anomalies"] = [{k: fix(v) for k, v in a.items()} for a in result.get("anomalies") or []]
     return out
 
 
@@ -207,8 +216,55 @@ SLOWDOWN_FACTOR = 2.0        # the oldest occupant, against normal dwell
 THROUGHPUT_FRACTION = 0.75   # of baseline, below which something is wrong
 
 
+def anomalies(result: dict) -> list[dict]:
+    """Every project-owned stage misbehaving, worst first.
+
+    A pipeline can have more than one thing wrong with it, and on real data it
+    usually does: naming a single culprit hid a stage full of approved work that
+    was not merging, because a different stage happened to be filling faster.
+    """
+    found = []
+    for stage in result["stages"]:
+        if not stage["owned_by_project"] or not stage["depth"]:
+            continue
+        growth = stage["entered_per_hour"] - stage["left_per_hour"]
+        normal = stage["baseline_median_dwell_hours"]
+        enough = stage["baseline_left_count"] >= MIN_COMPLETIONS
+        slowdown = (
+            stage["oldest_waiting_hours"] / normal
+            if enough and normal and stage["oldest_waiting_hours"] else 0.0
+        )
+        filling = growth > GROWTH_PER_HOUR
+        stalled = slowdown >= SLOWDOWN_FACTOR
+        if not (filling or stalled):
+            continue
+        reasons = []
+        if filling:
+            reasons.append(
+                f"arriving at {stage['entered_per_hour']:.2f}/h and leaving at "
+                f"{stage['left_per_hour']:.2f}/h, so it is filling faster than it drains"
+            )
+        if stalled:
+            reasons.append(
+                f"its oldest has waited {stage['oldest_waiting_hours']:.0f}h against a "
+                f"{normal:.1f}h normal dwell"
+            )
+        found.append({
+            "stage": stage["stage"],
+            "depth": stage["depth"],
+            "growth_per_hour": growth,
+            "slowdown_factor": slowdown,
+            "why": "; ".join(reasons),
+        })
+    # Filling beats merely stalled, then by how fast, then by how far past normal.
+    found.sort(key=lambda item: (item["growth_per_hour"] > GROWTH_PER_HOUR,
+                                 item["growth_per_hour"], item["slowdown_factor"]),
+               reverse=True)
+    return found
+
+
 def find_bottleneck(result: dict) -> dict | None:
-    """The stage most responsible for the pipeline being slower than usual.
+    """The headline stage, when there is one to name.
 
     Judged on backing up, not on depth: a stage can be very deep and perfectly
     healthy if it drains as fast as it fills. A stage that meets no anomaly
@@ -222,41 +278,8 @@ def find_bottleneck(result: dict) -> dict | None:
         return {"stage": None, "why": "not enough baseline data to judge", "insufficient_data": True}
     if result["merged_per_hour"] >= baseline * THROUGHPUT_FRACTION:
         return None
-
-    candidates = []
-    for stage in result["stages"]:
-        if not stage["owned_by_project"] or not stage["depth"]:
-            continue
-        growth = stage["entered_per_hour"] - stage["left_per_hour"]
-        normal = stage["baseline_median_dwell_hours"]
-        enough = stage["baseline_left_count"] >= MIN_COMPLETIONS
-        slowdown = (
-            stage["oldest_waiting_hours"] / normal
-            if enough and normal and stage["oldest_waiting_hours"] else 0.0
-        )
-        filling = growth > GROWTH_PER_HOUR
-        stalled = slowdown >= SLOWDOWN_FACTOR
-        if filling or stalled:
-            candidates.append((filling, growth, slowdown, stage))
-
-    if not candidates:
-        return None
-    # Filling beats merely slow, then by how fast it is filling, then by how far
-    # past normal its oldest occupant is.
-    candidates.sort(key=lambda item: (item[0], item[1], item[2]), reverse=True)
-    filling, growth, slowdown, stage = candidates[0]
-
-    if filling:
-        why = (
-            f"arriving at {stage['entered_per_hour']:.2f}/h and leaving at "
-            f"{stage['left_per_hour']:.2f}/h, so it is filling faster than it drains"
-        )
-    else:
-        why = (
-            f"its oldest occupant has waited {stage['oldest_waiting_hours']:.0f}h against a "
-            f"{stage['baseline_median_dwell_hours']:.1f}h normal dwell"
-        )
-    return {"stage": stage["stage"], "why": why, "depth": stage["depth"]}
+    found = result.get("anomalies") or anomalies(result)
+    return found[0] if found else None
 
 
 def report(result: dict) -> str:
@@ -298,7 +321,10 @@ def report(result: dict) -> str:
     if bottleneck and bottleneck.get("insufficient_data"):
         lines.append(f"  {bottleneck['why']}")
     elif bottleneck:
+        found = result.get("anomalies") or []
         lines.append(f"  bottleneck: {bottleneck['stage']} — {bottleneck['why']}")
+        for other in found[1:]:
+            lines.append(f"  also:       {other['stage']} — {other['why']}")
     elif baseline and merged < baseline:
         lines.append("  throughput is down but no stage is backing up; likely a quiet spell in arrivals")
     else:

--- a/scripts/pipeline_health.py
+++ b/scripts/pipeline_health.py
@@ -179,12 +179,14 @@ def analyse(
             counted("merged_at", baseline_start, baseline_end), baseline_span),
         "merged_count": counted("merged_at", window_start, now),
         "baseline_merged_count": counted("merged_at", baseline_start, baseline_end),
+        "opened_count": counted("created_at", window_start, now),
+        "baseline_opened_count": counted("created_at", baseline_start, baseline_end),
         "open_prs": sum(1 for pr in prs if pr["state"] == "OPEN"),
         "open_prs_without_a_lifecycle_label": unlabelled_open,
         "stages": stages,
     }
     result["anomalies"] = anomalies(result)
-    result["bottleneck"] = find_bottleneck(result)
+    result["cause"] = find_cause(result)
     return result
 
 
@@ -263,23 +265,55 @@ def anomalies(result: dict) -> list[dict]:
     return found
 
 
-def find_bottleneck(result: dict) -> dict | None:
-    """The headline stage, when there is one to name.
+def find_cause(result: dict) -> dict | None:
+    """Why throughput is down, when it is.
 
-    Judged on backing up, not on depth: a stage can be very deep and perfectly
-    healthy if it drains as fast as it fills. A stage that meets no anomaly
-    condition is not named, even when throughput is down, because "the queue is
-    slow and no stage is misbehaving" is a real and useful answer.
+    Fewer merges can mean the queue is stuck or simply that less went into it,
+    and those want opposite responses: adding review capacity does nothing about
+    a week when nobody opened anything. Both are answers, so both are reported.
+    Only when neither holds is the fall genuinely unexplained, and saying so is
+    better than picking a stage to blame.
     """
     baseline = result["baseline_merged_per_hour"]
     if not baseline or result["baseline_merged_count"] < MIN_COMPLETIONS:
         # Nothing to compare against. Saying "healthy" here would be a guess
         # dressed as a finding.
-        return {"stage": None, "why": "not enough baseline data to judge", "insufficient_data": True}
+        return {"kind": "insufficient_data", "stage": None,
+                "why": "not enough baseline data to judge"}
     if result["merged_per_hour"] >= baseline * THROUGHPUT_FRACTION:
         return None
-    found = result.get("anomalies") or anomalies(result)
-    return found[0] if found else None
+
+    found = result["anomalies"] if "anomalies" in result else anomalies(result)
+    opened, opened_baseline = result["opened_per_hour"], result["baseline_opened_per_hour"]
+    intake_down = (
+        opened_baseline
+        and opened < opened_baseline * THROUGHPUT_FRACTION
+        and result["baseline_opened_count"] >= MIN_COMPLETIONS
+    )
+
+    if intake_down and not found:
+        return {
+            "kind": "intake", "stage": None,
+            "why": (
+                f"fewer pull requests are arriving: {opened:.2f}/h against "
+                f"{opened_baseline:.2f}/h. Nothing is stuck; there is less to merge"
+            ),
+        }
+    if found:
+        primary = dict(found[0], kind="stage")
+        if intake_down:
+            primary["why"] += (
+                f". Arrivals are also down, at {opened:.2f}/h against "
+                f"{opened_baseline:.2f}/h, so the queue is both thinner and slower"
+            )
+        return primary
+    return {
+        "kind": "unexplained", "stage": None,
+        "why": (
+            f"arrivals are steady at {opened:.2f}/h and no stage is backing up, "
+            "so the fall is not explained by the queue"
+        ),
+    }
 
 
 def report(result: dict) -> str:
@@ -312,23 +346,21 @@ def report(result: dict) -> str:
     lines.append("")
     lines.append("  * waiting on the contributor, not on the project")
     lines.append("")
-    bottleneck = result["bottleneck"]
     if result.get("open_prs_without_a_lifecycle_label"):
         lines.append(
             f"  note: {result['open_prs_without_a_lifecycle_label']} open PR(s) carry no single "
             "lifecycle label, so they are absent from every depth above"
         )
-    if bottleneck and bottleneck.get("insufficient_data"):
-        lines.append(f"  {bottleneck['why']}")
-    elif bottleneck:
-        found = result.get("anomalies") or []
-        lines.append(f"  bottleneck: {bottleneck['stage']} — {bottleneck['why']}")
-        for other in found[1:]:
-            lines.append(f"  also:       {other['stage']} — {other['why']}")
-    elif baseline and merged < baseline:
-        lines.append("  throughput is down but no stage is backing up; likely a quiet spell in arrivals")
-    else:
+
+    cause = result["cause"]
+    if cause is None:
         lines.append("  throughput is normal; no stage is backing up")
+    elif cause["kind"] == "stage":
+        lines.append(f"  cause: {cause['stage']} — {cause['why']}")
+        for other in (result.get("anomalies") or [])[1:]:
+            lines.append(f"  also:  {other['stage']} — {other['why']}")
+    else:
+        lines.append(f"  cause: {cause['why']}")
     return "\n".join(lines)
 
 

--- a/scripts/pipeline_health.py
+++ b/scripts/pipeline_health.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Where is the pull-request pipeline slow right now, and why?
+
+Merge throughput is one number at the end of a queue, so a fall in it says
+something is wrong without saying what. This measures each stage separately:
+how fast pull requests arrive at it, how fast they leave, how deep it currently
+is, and how long they sit in it, each against a trailing baseline.
+
+The stages are the lifecycle labels, which the pipeline maintains one at a time:
+
+  awaiting-CI          waiting for a build on the latest commit
+  awaiting-review      green, waiting for a reviewer
+  review-in-progress   a review is running on this commit
+  ci-failed            build failed; the author has to act
+  awaiting-author      changes requested; the author has to act
+  ready-to-merge       approved and green; waiting to merge
+
+Two of those are not the project's to fix. `ci-failed` and `awaiting-author`
+sit with the contributor, and reading a backlog there as a project problem
+would point effort at exactly the wrong place, so they are reported separately
+from the stages the project owns.
+
+Data comes from the same snapshot the statistics charts use, so this needs no
+new API surface and can be replayed offline:
+
+    scripts/pipeline_health.py                       # fetch and report
+    scripts/pipeline_health.py --json                # machine-readable
+    scripts/pr_stats_graphs.py --dump-data snap.json --out-dir /tmp/x
+    scripts/pipeline_health.py --data snap.json      # replay, no network
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from pr_stats_graphs import (  # noqa: E402
+    LIFECYCLE_LABELS,
+    STATE_AUTHOR_ACTION,
+    fetch_snapshot,
+    iso_z,
+    parse_dt,
+)
+
+# Reported in pipeline order, which is also the order to read them in: a stage
+# is only the bottleneck if the ones feeding it are keeping up.
+STAGE_ORDER = [
+    "awaiting-CI",
+    "awaiting-review",
+    "review-in-progress",
+    "ready-to-merge",
+    "ci-failed",
+    "awaiting-author",
+]
+OWNED_BY_PROJECT = [s for s in STAGE_ORDER if s not in STATE_AUTHOR_ACTION]
+
+
+def lifecycle_intervals(pr: dict, now: datetime):
+    """Yield (label, entered, left) for each spell the PR spent in a stage.
+
+    The pipeline keeps exactly one lifecycle label on a PR at a time, so
+    consecutive label events bound each spell. An open PR's final spell is still
+    running, and is reported with `left` as None.
+    """
+    events = [
+        (parse_dt(e["created_at"]), e["label"])
+        for e in sorted(pr.get("labeled_events") or [], key=lambda e: e["created_at"])
+        if e["label"] in LIFECYCLE_LABELS
+    ]
+    for index, (entered, label) in enumerate(events):
+        if index + 1 < len(events):
+            yield label, entered, events[index + 1][0]
+        elif pr["state"] == "OPEN":
+            yield label, entered, None
+        else:
+            closed = parse_dt(pr.get("merged_at") or pr.get("closed_at"))
+            yield label, entered, closed or now
+
+
+def rate(count: int, hours: float) -> float:
+    return count / hours if hours else 0.0
+
+
+def median(values: list[float]) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2
+
+
+def analyse(snapshot: dict, window_hours: float, baseline_hours: float, now: datetime) -> dict:
+    prs = snapshot["prs"]
+    window_start = now - timedelta(hours=window_hours)
+    baseline_start = now - timedelta(hours=baseline_hours)
+
+    entered = defaultdict(lambda: {"window": 0, "baseline": 0})
+    left = defaultdict(lambda: {"window": 0, "baseline": 0})
+    dwell = defaultdict(lambda: {"window": [], "baseline": []})
+    depth: defaultdict[str, int] = defaultdict(int)
+    oldest: dict[str, float] = {}
+
+    for pr in prs:
+        for label, start, end in lifecycle_intervals(pr, now):
+            if start >= baseline_start:
+                entered[label]["baseline"] += 1
+            if start >= window_start:
+                entered[label]["window"] += 1
+
+            if end is None:
+                # Still in this stage: it contributes to depth and to how long
+                # the stage's current occupants have been waiting, but not to
+                # completed dwell times, which would bias them downwards.
+                depth[label] += 1
+                waiting = (now - start).total_seconds() / 3600
+                oldest[label] = max(oldest.get(label, 0.0), waiting)
+                continue
+
+            hours = (end - start).total_seconds() / 3600
+            if end >= baseline_start:
+                left[label]["baseline"] += 1
+                dwell[label]["baseline"].append(hours)
+            if end >= window_start:
+                left[label]["window"] += 1
+                dwell[label]["window"].append(hours)
+
+    def opened_or_merged(field: str, since: datetime) -> int:
+        return sum(
+            1 for pr in prs
+            if pr.get(field) and parse_dt(pr[field]) >= since
+        )
+
+    stages = []
+    for label in STAGE_ORDER:
+        baseline_dwell = median(dwell[label]["baseline"])
+        window_dwell = median(dwell[label]["window"])
+        stages.append({
+            "stage": label,
+            "owned_by_project": label not in STATE_AUTHOR_ACTION,
+            "depth": depth[label],
+            "oldest_waiting_hours": round(oldest.get(label, 0.0), 1),
+            "entered_per_hour": round(rate(entered[label]["window"], window_hours), 2),
+            "left_per_hour": round(rate(left[label]["window"], window_hours), 2),
+            "baseline_entered_per_hour": round(rate(entered[label]["baseline"], baseline_hours), 2),
+            "baseline_left_per_hour": round(rate(left[label]["baseline"], baseline_hours), 2),
+            "median_dwell_hours": round(window_dwell, 2) if window_dwell is not None else None,
+            "baseline_median_dwell_hours": round(baseline_dwell, 2) if baseline_dwell is not None else None,
+        })
+
+    result = {
+        "schema_version": 1,
+        "repo": snapshot.get("repo"),
+        "generated_at": iso_z(now),
+        "snapshot_fetched_at": snapshot.get("fetched_at"),
+        "window_hours": window_hours,
+        "baseline_hours": baseline_hours,
+        "opened_per_hour": round(rate(opened_or_merged("created_at", window_start), window_hours), 2),
+        "baseline_opened_per_hour": round(rate(opened_or_merged("created_at", baseline_start), baseline_hours), 2),
+        "merged_per_hour": round(rate(opened_or_merged("merged_at", window_start), window_hours), 2),
+        "baseline_merged_per_hour": round(rate(opened_or_merged("merged_at", baseline_start), baseline_hours), 2),
+        "open_prs": sum(1 for pr in prs if pr["state"] == "OPEN"),
+        "stages": stages,
+    }
+    result["bottleneck"] = find_bottleneck(result)
+    return result
+
+
+def find_bottleneck(result: dict) -> dict | None:
+    """The stage most responsible for the pipeline being slower than usual.
+
+    Judged on backing up rather than on depth: a stage can be deep and perfectly
+    healthy if it is draining as fast as it fills. What matters is arrivals
+    outrunning departures, and occupants waiting longer than they normally do.
+    """
+    if result["merged_per_hour"] >= result["baseline_merged_per_hour"] * 0.75:
+        return None
+
+    scored = []
+    for stage in result["stages"]:
+        if not stage["owned_by_project"] or not stage["depth"]:
+            continue
+        arriving = stage["entered_per_hour"]
+        leaving = stage["left_per_hour"]
+        # How far behind the stage is falling, relative to its own normal pace.
+        backlog_growth = arriving - leaving
+        baseline_dwell = stage["baseline_median_dwell_hours"] or 0
+        slowdown = 0.0
+        if baseline_dwell and stage["oldest_waiting_hours"]:
+            slowdown = stage["oldest_waiting_hours"] / baseline_dwell
+        scored.append((backlog_growth > 0, slowdown, backlog_growth, stage))
+
+    if not scored:
+        return None
+    scored.sort(key=lambda item: (item[0], item[1], item[2]), reverse=True)
+    growing, slowdown, growth, stage = scored[0]
+
+    if growing:
+        why = (
+            f"arriving at {stage['entered_per_hour']}/h and leaving at "
+            f"{stage['left_per_hour']}/h, so it is filling faster than it drains"
+        )
+    elif slowdown > 2:
+        why = (
+            f"its oldest occupant has waited {stage['oldest_waiting_hours']}h against a "
+            f"{stage['baseline_median_dwell_hours']}h normal dwell"
+        )
+    else:
+        why = f"{stage['depth']} waiting, the deepest project-owned stage"
+    return {"stage": stage["stage"], "why": why, "depth": stage["depth"]}
+
+
+def report(result: dict) -> str:
+    lines = []
+    merged, baseline = result["merged_per_hour"], result["baseline_merged_per_hour"]
+    change = f"{merged / baseline:.0%} of baseline" if baseline else "no baseline"
+    lines.append(f"{result['repo']}  ({result['open_prs']} open)")
+    lines.append(
+        f"  merged {merged}/h over the last {result['window_hours']:.0f}h "
+        f"against {baseline}/h over {result['baseline_hours'] / 24:.0f}d — {change}"
+    )
+    lines.append(
+        f"  opened {result['opened_per_hour']}/h against {result['baseline_opened_per_hour']}/h"
+    )
+    lines.append("")
+    header = f"  {'stage':<20}{'depth':>6}{'oldest':>9}{'in/h':>7}{'out/h':>7}{'dwell':>8}{'normal':>8}"
+    lines.append(header)
+    lines.append("  " + "-" * (len(header) - 2))
+    for stage in result["stages"]:
+        mark = " " if stage["owned_by_project"] else "*"
+        dwell = stage["median_dwell_hours"]
+        normal = stage["baseline_median_dwell_hours"]
+        lines.append(
+            f"  {mark}{stage['stage']:<19}{stage['depth']:>6}"
+            f"{stage['oldest_waiting_hours']:>8.0f}h"
+            f"{stage['entered_per_hour']:>7}{stage['left_per_hour']:>7}"
+            f"{(f'{dwell:.1f}h' if dwell is not None else '-'):>8}"
+            f"{(f'{normal:.1f}h' if normal is not None else '-'):>8}"
+        )
+    lines.append("")
+    lines.append("  * waiting on the contributor, not on the project")
+    lines.append("")
+    bottleneck = result["bottleneck"]
+    if bottleneck:
+        lines.append(f"  bottleneck: {bottleneck['stage']} — {bottleneck['why']}")
+    elif baseline and merged < baseline:
+        lines.append("  throughput is down but no stage is backing up; likely a quiet spell in arrivals")
+    else:
+        lines.append("  throughput is normal; no stage is backing up")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo", default="TauCetiProject/TauCeti")
+    parser.add_argument("--data", type=Path, help="replay a normalized offline snapshot")
+    parser.add_argument("--dump-data", type=Path, help="write the fetched snapshot")
+    parser.add_argument("--out", type=Path, help="write the JSON result here")
+    parser.add_argument("--window", type=float, default=24.0, help="recent window, hours")
+    parser.add_argument("--baseline", type=float, default=14 * 24.0, help="baseline, hours")
+    parser.add_argument("--json", action="store_true", help="print JSON instead of a report")
+    args = parser.parse_args(argv)
+
+    snapshot = json.loads(args.data.read_text()) if args.data else fetch_snapshot(args.repo)
+    if args.dump_data:
+        args.dump_data.write_text(json.dumps(snapshot, indent=1))
+
+    now = datetime.now(timezone.utc)
+    result = analyse(snapshot, args.window, args.baseline, now)
+
+    if args.out:
+        args.out.write_text(json.dumps(result, indent=1))
+    print(json.dumps(result, indent=1) if args.json else report(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pr_lifecycle.py
+++ b/scripts/pr_lifecycle.py
@@ -108,13 +108,66 @@ def review_cycle_starts(pr: dict) -> list[datetime]:
     return starts
 
 
-def episodes(pr: dict, now: datetime):
-    """Yield (state, entered, left) for each spell, with the joining rules applied.
+def label_intervals(pr: dict, now: datetime):
+    """Yield (label, applied, replaced) for each individual label application.
 
-    `state` is the label the spell began in. A spell that is still running has
-    `left` of None. This is the primitive both the queue-age histograms and the
-    per-stage rates are built on, so that "how long has this been waiting" has
-    exactly one answer.
+    Atomic: no joining. This is what per-label rates and dwell times are built
+    on, because "how many pull requests entered `awaiting-author` this hour" is
+    a question about that label and not about the spell containing it.
+
+    A running interval has `replaced` of None, but only when the label is still
+    on the pull request. The snapshot records label additions and not removals,
+    so a label that was taken off without another arriving would otherwise look
+    like it was still in force; that case is censored instead, since the honest
+    answer is that we cannot see when it ended.
+    """
+    timeline = [
+        (parse_dt(event["created_at"]), event["label"])
+        for event in events(pr) if event["label"] in LIFECYCLE_LABELS
+    ]
+    for index, (applied, label) in enumerate(timeline):
+        if index + 1 < len(timeline):
+            yield label, applied, timeline[index + 1][0]
+            continue
+        if pr["state"] == "OPEN":
+            if current_stage(pr) == label:
+                yield label, applied, None
+            # else: censored. The label went away and nothing replaced it.
+            continue
+        closed = parse_dt(pr.get("merged_at") or pr.get("closed_at"))
+        if closed:
+            yield label, applied, closed
+
+
+def group_of(label: str) -> str:
+    """The waiting-spell a label belongs to.
+
+    Siblings share a group because the wait does not restart when the pipeline
+    swaps one for the other: the author reads a build log for `ci-failed` and
+    review threads for `awaiting-author`, but the ball is in their court either
+    way, and a review round moves between `awaiting-review` and
+    `review-in-progress` without the author's wait beginning again.
+    """
+    if label in STATE_AUTHOR_ACTION:
+        return "author-action"
+    if label in STATE_REVIEW:
+        return "review"
+    return label
+
+
+def episodes(pr: dict, now: datetime):
+    """Yield (group, entered, left) for each waiting spell.
+
+    Grouped, not atomic: this answers "how long has this been waiting", where
+    swapping a label for its sibling does not restart the clock. Use
+    `label_intervals` for anything counted per label.
+
+    Note that this is deliberately not the same decomposition as
+    `review_cycle_starts`, which counts how many times a pull request has been
+    through review and treats only an author or CI state as ending a cycle. A
+    spell of waiting and a round of review are different questions, and a
+    pull request that reached `ready-to-merge` and came back has waited twice
+    while having been reviewed once.
     """
     timeline = [
         (parse_dt(event["created_at"]), event["label"])
@@ -123,32 +176,30 @@ def episodes(pr: dict, now: datetime):
     if not timeline:
         return
 
-    def joined(previous: str, nxt: str) -> bool:
-        return (
-            (previous in STATE_AUTHOR_ACTION and nxt in STATE_AUTHOR_ACTION)
-            or (previous in STATE_REVIEW and nxt in STATE_REVIEW)
-        )
-
-    spell_start, spell_label = timeline[0]
-    for index in range(1, len(timeline)):
-        at, label = timeline[index]
-        if joined(spell_label, label):
-            # Same spell continuing under a sibling label; the clock keeps running.
-            spell_label = label
+    spell_start, spell_group = timeline[0][0], group_of(timeline[0][1])
+    for at, label in timeline[1:]:
+        group = group_of(label)
+        if group == spell_group:
             continue
-        yield spell_label, spell_start, at
-        spell_start, spell_label = at, label
+        yield spell_group, spell_start, at
+        spell_start, spell_group = at, group
 
     if pr["state"] == "OPEN":
-        yield spell_label, spell_start, None
-    else:
-        closed = parse_dt(pr.get("merged_at") or pr.get("closed_at"))
-        yield spell_label, spell_start, closed or now
+        stage = current_stage(pr)
+        # Same censoring as label_intervals: a spell whose label was removed
+        # without replacement has ended at a time the snapshot cannot show.
+        if stage is not None and group_of(stage) == spell_group:
+            yield spell_group, spell_start, None
+        return
+    closed = parse_dt(pr.get("merged_at") or pr.get("closed_at"))
+    if closed:
+        yield spell_group, spell_start, closed
 
 
-def waiting_since(pr: dict) -> datetime | None:
-    """When the pull request's current spell began, whatever state it is in."""
-    timeline = list(episodes(pr, datetime.now(timezone.utc)))
-    if timeline and timeline[-1][2] is None:
-        return timeline[-1][1]
+def waiting_since(pr: dict, now: datetime | None = None) -> datetime | None:
+    """When the pull request's current spell began, or None if it is not in one."""
+    now = now or datetime.now(timezone.utc)
+    for _, start, end in episodes(pr, now):
+        if end is None:
+            return start
     return None

--- a/scripts/pr_lifecycle.py
+++ b/scripts/pr_lifecycle.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""What the pull-request lifecycle labels mean, in one place.
+
+Both the statistics charts and the pipeline-health report ask questions of the
+same label timelines, and the answers have to agree. They very nearly did not:
+the two disagreed by nineteen hours on how long one pull request had been
+waiting, because one of them treated a `ci-failed` to `awaiting-author` swap as
+the start of a fresh wait and the other did not.
+
+The rules that matter, and that no caller should have to reimplement:
+
+* `ci-failed` and `awaiting-author` are one state for timing purposes. The author
+  reads a build log for one and review threads for the other, but the ball is in
+  their court either way, so swapping one for the other continues the spell
+  rather than beginning a new one.
+* `awaiting-review` and `review-in-progress` are likewise one state. The pipeline
+  swaps them while a round is judged and can restore the first afterwards, so
+  counting label applications would split one cycle into several.
+* Anything else ends a spell. A push that sends a pull request back to
+  `awaiting-CI` is a genuinely fresh wait even if it fails again immediately.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+STATE_REVIEW = {"awaiting-review", "review-in-progress"}
+# The two states that put the ball in the author's court.
+STATE_AUTHOR_ACTION = {"awaiting-author", "ci-failed"}
+STATE_LABELS = {*STATE_AUTHOR_ACTION, *STATE_REVIEW}
+# States in which the pull request has left the review queue: the author owns it,
+# or CI is judging a new commit before review resumes.
+STATE_AUTHOR = {*STATE_AUTHOR_ACTION, "awaiting-CI"}
+LIFECYCLE_LABELS = {*STATE_REVIEW, *STATE_AUTHOR, "ready-to-merge"}
+# The lifecycle-label workflow first landed on 2026-07-22. A pull request closed
+# before that UTC day cannot contain one of its label events.
+LIFECYCLE_EPOCH = datetime(2026, 7, 22, tzinfo=timezone.utc)
+
+# In pipeline order, which is also the order to read them in: a stage is only
+# the bottleneck if the ones feeding it are keeping up.
+STAGE_ORDER = [
+    "awaiting-CI",
+    "awaiting-review",
+    "review-in-progress",
+    "ready-to-merge",
+    "ci-failed",
+    "awaiting-author",
+]
+
+
+def parse_dt(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")) if value else None
+
+
+def iso_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def events(pr: dict) -> list[dict]:
+    return sorted(pr.get("labeled_events") or [], key=lambda item: item["created_at"])
+
+
+def latest_lifecycle_label(pr: dict) -> str | None:
+    found = [event for event in events(pr) if event["label"] in LIFECYCLE_LABELS]
+    return found[-1]["label"] if found else None
+
+
+def current_stage(pr: dict) -> str | None:
+    """The stage a pull request is in now, from the labels it currently carries.
+
+    Not from the last timeline event: a pull request whose lifecycle label was
+    removed has left that stage, and one with no events at all is still
+    somewhere. The labels are what the pipeline actually maintains.
+    """
+    present = [label for label in pr.get("labels") or [] if label in LIFECYCLE_LABELS]
+    return present[0] if len(present) == 1 else None
+
+
+def author_episode_start(pr: dict) -> datetime | None:
+    """When the current spell of waiting on the author began, or None."""
+    start = None
+    for event in events(pr):
+        if event["label"] in STATE_AUTHOR_ACTION:
+            if start is None:
+                start = parse_dt(event["created_at"])
+        elif event["label"] in LIFECYCLE_LABELS:
+            start = None
+    return start
+
+
+def review_cycle_starts(pr: dict) -> list[datetime]:
+    """When each review cycle began.
+
+    A cycle begins where the pull request *enters* the review states from an
+    author or CI state, or from no state at all, and lasts until it leaves for
+    one. Consecutive review labels stay inside the same cycle. A bare removal,
+    as on merge, never opens a cycle.
+    """
+    starts = []
+    in_review = False
+    for event in events(pr):
+        if event["label"] in STATE_REVIEW:
+            if not in_review:
+                starts.append(parse_dt(event["created_at"]))
+            in_review = True
+        elif event["label"] in STATE_AUTHOR:
+            in_review = False
+    return starts
+
+
+def episodes(pr: dict, now: datetime):
+    """Yield (state, entered, left) for each spell, with the joining rules applied.
+
+    `state` is the label the spell began in. A spell that is still running has
+    `left` of None. This is the primitive both the queue-age histograms and the
+    per-stage rates are built on, so that "how long has this been waiting" has
+    exactly one answer.
+    """
+    timeline = [
+        (parse_dt(event["created_at"]), event["label"])
+        for event in events(pr) if event["label"] in LIFECYCLE_LABELS
+    ]
+    if not timeline:
+        return
+
+    def joined(previous: str, nxt: str) -> bool:
+        return (
+            (previous in STATE_AUTHOR_ACTION and nxt in STATE_AUTHOR_ACTION)
+            or (previous in STATE_REVIEW and nxt in STATE_REVIEW)
+        )
+
+    spell_start, spell_label = timeline[0]
+    for index in range(1, len(timeline)):
+        at, label = timeline[index]
+        if joined(spell_label, label):
+            # Same spell continuing under a sibling label; the clock keeps running.
+            spell_label = label
+            continue
+        yield spell_label, spell_start, at
+        spell_start, spell_label = at, label
+
+    if pr["state"] == "OPEN":
+        yield spell_label, spell_start, None
+    else:
+        closed = parse_dt(pr.get("merged_at") or pr.get("closed_at"))
+        yield spell_label, spell_start, closed or now
+
+
+def waiting_since(pr: dict) -> datetime | None:
+    """When the pull request's current spell began, whatever state it is in."""
+    timeline = list(episodes(pr, datetime.now(timezone.utc)))
+    if timeline and timeline[-1][2] is None:
+        return timeline[-1][1]
+    return None

--- a/scripts/pr_stats_graphs.py
+++ b/scripts/pr_stats_graphs.py
@@ -42,6 +42,24 @@ from pathlib import Path
 from typing import Iterable
 
 from chart_style import BAR_BG, MUTED, PALETTE, base_css, card_rect, css_px
+# The lifecycle rules live in one module because two readers of the same label
+# timelines have to agree about what they mean, and once did not.
+from pr_lifecycle import (  # noqa: F401  (re-exported for existing callers)
+    LIFECYCLE_EPOCH,
+    LIFECYCLE_LABELS,
+    STAGE_ORDER,
+    STATE_AUTHOR,
+    STATE_AUTHOR_ACTION,
+    STATE_LABELS,
+    STATE_REVIEW,
+    author_episode_start,
+    current_stage,
+    episodes,
+    iso_z,
+    latest_lifecycle_label,
+    parse_dt,
+    review_cycle_starts,
+)
 
 SCOREBOARD_MARKER = "<!--tauceti-scoreboard-->"
 # A canonical scoreboard is the review engine's own comment: besides the public marker it
@@ -50,19 +68,6 @@ SCOREBOARD_MARKER = "<!--tauceti-scoreboard-->"
 # marker or paste another PR's scoreboard.  scripts/pr_status/core.py parses the same block
 # when it derives a single PR's review state.
 SCOREBOARD_META_KIND = "scoreboard"
-STATE_REVIEW = {"awaiting-review", "review-in-progress"}
-# The two states that put the ball in the author's court. They are separate labels because the
-# author reads a build log for one and the review threads for the other, but every measurement
-# here treats them as one state: the PR is waiting on a human either way.
-STATE_AUTHOR_ACTION = {"awaiting-author", "ci-failed"}
-STATE_LABELS = {*STATE_AUTHOR_ACTION, *STATE_REVIEW}
-# States in which the PR has left the review queue: the author owns it, or CI is judging a
-# new commit before review resumes.
-STATE_AUTHOR = {*STATE_AUTHOR_ACTION, "awaiting-CI"}
-LIFECYCLE_LABELS = {*STATE_REVIEW, *STATE_AUTHOR, "ready-to-merge"}
-# The lifecycle-label workflow first landed on 2026-07-22. A PR closed before
-# that UTC day cannot contain one of its label events and needs no timeline query.
-LIFECYCLE_EPOCH = datetime(2026, 7, 22, tzinfo=timezone.utc)
 ASSET_NAMES = [
     "pr-queue-age.svg",
     "review-cycles-reached.svg",
@@ -76,14 +81,6 @@ HOUR_LABELS = [
     "<1h", "1–2h", "2–4h", "4–8h", "8–12h", "12–24h",
     "1–2d", "2–3d", "3–5d", "5d+",
 ]
-
-
-def parse_dt(value: str | None) -> datetime | None:
-    return datetime.fromisoformat(value.replace("Z", "+00:00")) if value else None
-
-
-def iso_z(value: datetime) -> str:
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def atomic_write(path: Path, content: str) -> None:
@@ -358,58 +355,6 @@ def fetch_snapshot(repo: str) -> dict:
         "scoreboards": scoreboards,
         "rejected_scoreboard_comments": dict(sorted(rejected.items())),
     }
-
-
-def latest_lifecycle_label(pr: dict) -> str | None:
-    events = [
-        event for event in pr.get("labeled_events") or []
-        if event["label"] in LIFECYCLE_LABELS
-    ]
-    return events[-1]["label"] if events else None
-
-
-def author_episode_start(pr: dict) -> datetime | None:
-    """When the PR's current spell of waiting on its author began, or None if it is not in one.
-
-    ``ci-failed`` and ``awaiting-author`` are separate labels because the author has to do
-    different things about them, but for the queue-age clock they are one state: the PR is out of
-    the pipeline's hands either way.  So the clock runs from where the PR *entered* that state, and
-    swapping one of the two for the other inside it -- a red build arriving on a PR that already
-    had changes requested, or the migration that first split the labels -- continues the spell
-    rather than starting a new one.  Any other lifecycle label ends it: a push that sends the PR
-    back to ``awaiting-CI`` is a genuinely fresh wait, even if it fails again straight afterwards.
-    """
-    start = None
-    for event in sorted(pr.get("labeled_events") or [], key=lambda item: item["created_at"]):
-        if event["label"] in STATE_AUTHOR_ACTION:
-            if start is None:
-                start = parse_dt(event["created_at"])
-        elif event["label"] in LIFECYCLE_LABELS:
-            start = None
-    return start
-
-
-def review_cycle_starts(pr: dict) -> list[datetime]:
-    """When each of the PR's review cycles began, from its label timeline.
-
-    The pipeline swaps ``awaiting-review`` for ``review-in-progress`` while a round is being
-    judged and reconciliation can restore ``awaiting-review`` afterwards, so counting label
-    applications splits one cycle into several.  A cycle instead begins where the PR *enters*
-    the review states from an author or CI state (or from no state at all) and lasts until it
-    leaves for one; consecutive review labels stay inside the same cycle.  Labeled events
-    alone are enough: the pipeline replaces one state label with another, and a bare removal,
-    as on merge, never opens a cycle.
-    """
-    starts = []
-    in_review = False
-    for event in sorted(pr.get("labeled_events") or [], key=lambda item: item["created_at"]):
-        if event["label"] in STATE_REVIEW:
-            if not in_review:
-                starts.append(parse_dt(event["created_at"]))
-            in_review = True
-        elif event["label"] in STATE_AUTHOR:
-            in_review = False
-    return starts
 
 
 def queue_age_metrics(prs: list[dict], snapshot: datetime) -> dict:

--- a/scripts/test_pipeline_health.py
+++ b/scripts/test_pipeline_health.py
@@ -102,14 +102,16 @@ class AnalysisTests(unittest.TestCase):
 
 class BottleneckTests(unittest.TestCase):
     def base(self, **overrides):
-        result = {"merged_per_hour": 1.0, "baseline_merged_per_hour": 5.0, "stages": []}
+        result = {"merged_per_hour": 1.0, "baseline_merged_per_hour": 5.0,
+                  "baseline_merged_count": 100, "stages": []}
         result.update(overrides)
         return result
 
     def stage(self, name, **kw):
         item = {"stage": name, "owned_by_project": name not in health.STATE_AUTHOR_ACTION,
                 "depth": 0, "oldest_waiting_hours": 0.0, "entered_per_hour": 0.0,
-                "left_per_hour": 0.0, "baseline_median_dwell_hours": None}
+                "left_per_hour": 0.0, "baseline_median_dwell_hours": None,
+                "baseline_left_count": 20}
         item.update(kw)
         return item
 
@@ -132,6 +134,41 @@ class BottleneckTests(unittest.TestCase):
         ])
         self.assertEqual(health.find_bottleneck(result)["stage"], "ready-to-merge")
 
+    def test_no_stage_is_named_when_none_is_misbehaving(self):
+        """Throughput can fall because nothing arrived. Naming a culprit anyway
+        is how a heuristic becomes an oracle that is always confidently wrong."""
+        result = self.base(stages=[
+            self.stage("awaiting-CI", depth=5, entered_per_hour=1.0, left_per_hour=1.0,
+                       oldest_waiting_hours=2.0, baseline_median_dwell_hours=3.0),
+            self.stage("awaiting-review", depth=9, entered_per_hour=0.5, left_per_hour=0.6,
+                       oldest_waiting_hours=4.0, baseline_median_dwell_hours=5.0),
+        ])
+        self.assertIsNone(health.find_bottleneck(result))
+
+    def test_a_stalled_stage_is_named_even_without_growth(self):
+        result = self.base(stages=[
+            self.stage("ready-to-merge", depth=4, entered_per_hour=0.1, left_per_hour=0.1,
+                       oldest_waiting_hours=100.0, baseline_median_dwell_hours=2.0),
+        ])
+        found = health.find_bottleneck(result)
+        self.assertEqual(found["stage"], "ready-to-merge")
+        self.assertIn("normal dwell", found["why"])
+
+    def test_a_thin_baseline_reports_insufficient_data_not_health(self):
+        """Zero merges over the baseline made the old gate read 0 >= 0 and call
+        an empty repository healthy."""
+        found = health.find_bottleneck(self.base(
+            merged_per_hour=0.0, baseline_merged_per_hour=0.0, baseline_merged_count=0))
+        self.assertTrue(found["insufficient_data"])
+
+    def test_a_stage_with_too_few_completions_is_not_judged_on_dwell(self):
+        result = self.base(stages=[
+            self.stage("awaiting-review", depth=2, entered_per_hour=0.1, left_per_hour=0.1,
+                       oldest_waiting_hours=500.0, baseline_median_dwell_hours=1.0,
+                       baseline_left_count=1),
+        ])
+        self.assertIsNone(health.find_bottleneck(result))
+
     def test_stages_waiting_on_the_author_are_never_blamed(self):
         """The project cannot fix these, so naming one would point effort at
         exactly the wrong place."""
@@ -147,12 +184,71 @@ class BottleneckTests(unittest.TestCase):
         self.assertIsNone(health.find_bottleneck(result))
 
 
+class TimingTests(unittest.TestCase):
+    def test_replay_measures_the_snapshot_as_it_was(self):
+        """Otherwise every open interval gains however long the file sat on disk."""
+        old = NOW - timedelta(days=30)
+        data = snapshot([pr(1, [(old - timedelta(hours=2), "awaiting-review")])])
+        data["fetched_at"] = iso(old)
+        stage = next(s for s in health.analyse(data, 24, 24 * 14)["stages"]
+                     if s["stage"] == "awaiting-review")
+        self.assertAlmostEqual(stage["oldest_waiting_hours"], 2.0, places=3)
+
+    def test_the_baseline_excludes_the_recent_window(self):
+        """A baseline containing the window it is compared against is not a
+        comparison."""
+        recent = NOW - timedelta(hours=2)
+        data = snapshot([pr(1, [(recent, "awaiting-review")],
+                            state="MERGED", merged=recent + timedelta(minutes=1))])
+        result = health.analyse(data, 24, 24 * 14, NOW)
+        self.assertGreater(result["merged_per_hour"], 0)
+        self.assertEqual(result["baseline_merged_count"], 0)
+
+    def test_a_nonpositive_window_is_rejected(self):
+        with self.assertRaises(ValueError):
+            health.analyse(snapshot([]), 0, 24, NOW)
+
+
+class DepthTests(unittest.TestCase):
+    def test_depth_comes_from_current_labels_not_the_last_event(self):
+        """A PR whose lifecycle label was removed has left that stage."""
+        item = pr(1, [(NOW - timedelta(hours=5), "awaiting-review")])
+        item["labels"] = []
+        stage = next(s for s in health.analyse(snapshot([item]), 24, 24 * 14, NOW)["stages"]
+                     if s["stage"] == "awaiting-review")
+        self.assertEqual(stage["depth"], 0)
+
+    def test_an_open_pr_with_no_lifecycle_label_is_counted_and_reported(self):
+        """Silently omitting it would make the depths quietly not add up."""
+        item = pr(1, [])
+        item["labels"] = []
+        result = health.analyse(snapshot([item]), 24, 24 * 14, NOW)
+        self.assertEqual(result["open_prs_without_a_lifecycle_label"], 1)
+
+    def test_drafts_do_not_count_towards_depth(self):
+        item = pr(1, [(NOW - timedelta(hours=5), "awaiting-review")])
+        item["is_draft"] = True
+        stage = next(s for s in health.analyse(snapshot([item]), 24, 24 * 14, NOW)["stages"]
+                     if s["stage"] == "awaiting-review")
+        self.assertEqual(stage["depth"], 0)
+
+
+class RoundingTests(unittest.TestCase):
+    def test_comparisons_run_on_unrounded_values(self):
+        """One event in a fortnight rounds to a rate of exactly zero, which
+        silently changes which branch every threshold takes."""
+        result = health.analyse(snapshot([]), 24, 24 * 14, NOW)
+        self.assertIn("stages", health.rounded(result))
+        raw = {"merged_per_hour": 0.0044, "baseline_merged_per_hour": 0.0, "stages": []}
+        self.assertNotEqual(round(raw["merged_per_hour"], 2), raw["merged_per_hour"])
+
+
 class ReportTests(unittest.TestCase):
     def test_report_renders_and_names_the_author_owned_marker(self):
         result = health.analyse(snapshot([
             pr(1, [(NOW - timedelta(hours=2), "awaiting-review")]),
         ]), 24, 24 * 14, NOW)
-        text = health.report(result)
+        text = health.report(health.rounded(result))
         self.assertIn("awaiting-review", text)
         self.assertIn("waiting on the contributor", text)
 

--- a/scripts/test_pipeline_health.py
+++ b/scripts/test_pipeline_health.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Hermetic tests for scripts/pipeline_health.py."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+import pipeline_health as health
+
+UTC = timezone.utc
+NOW = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+
+
+def iso(when: datetime) -> str:
+    return when.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def pr(number, events, *, state="OPEN", created=None, merged=None):
+    """A PR with a lifecycle label timeline, as fetch_prs would return it."""
+    return {
+        "number": number,
+        "created_at": iso(created or NOW - timedelta(days=1)),
+        "merged_at": iso(merged) if merged else None,
+        "closed_at": iso(merged) if merged else None,
+        "state": state,
+        "is_draft": False,
+        "author": "someone",
+        "labels": [events[-1][1]] if events and state == "OPEN" else [],
+        "labeled_events": [
+            {"created_at": iso(at), "label": label} for at, label in events
+        ],
+    }
+
+
+def snapshot(prs):
+    return {"schema_version": 1, "repo": "TauCetiProject/TauCeti",
+            "fetched_at": iso(NOW), "prs": prs, "scoreboards": {}}
+
+
+class IntervalTests(unittest.TestCase):
+    def test_consecutive_labels_bound_each_spell(self):
+        item = pr(1, [
+            (NOW - timedelta(hours=10), "awaiting-CI"),
+            (NOW - timedelta(hours=8), "awaiting-review"),
+        ])
+        spells = list(health.lifecycle_intervals(item, NOW))
+        self.assertEqual([s[0] for s in spells], ["awaiting-CI", "awaiting-review"])
+        self.assertEqual((spells[0][2] - spells[0][1]), timedelta(hours=2))
+
+    def test_an_open_pr_s_last_spell_is_still_running(self):
+        item = pr(1, [(NOW - timedelta(hours=3), "awaiting-review")])
+        self.assertIsNone(list(health.lifecycle_intervals(item, NOW))[-1][2])
+
+    def test_a_merged_pr_s_last_spell_ends_at_the_merge(self):
+        merged = NOW - timedelta(hours=1)
+        item = pr(2, [(NOW - timedelta(hours=5), "ready-to-merge")],
+                  state="MERGED", merged=merged)
+        _, start, end = list(health.lifecycle_intervals(item, NOW))[-1]
+        self.assertEqual(end, merged)
+
+    def test_non_lifecycle_labels_are_ignored(self):
+        item = pr(3, [(NOW - timedelta(hours=4), "roadmap:algebra"),
+                      (NOW - timedelta(hours=2), "awaiting-review")])
+        self.assertEqual([s[0] for s in health.lifecycle_intervals(item, NOW)],
+                         ["awaiting-review"])
+
+
+class AnalysisTests(unittest.TestCase):
+    def test_depth_counts_only_prs_still_in_the_stage(self):
+        data = snapshot([
+            pr(1, [(NOW - timedelta(hours=2), "awaiting-review")]),
+            pr(2, [(NOW - timedelta(hours=3), "awaiting-review")]),
+            pr(3, [(NOW - timedelta(hours=9), "awaiting-review"),
+                   (NOW - timedelta(hours=1), "ready-to-merge")]),
+        ])
+        result = health.analyse(data, 24, 24 * 14, NOW)
+        by_stage = {s["stage"]: s for s in result["stages"]}
+        self.assertEqual(by_stage["awaiting-review"]["depth"], 2)
+        self.assertEqual(by_stage["ready-to-merge"]["depth"], 1)
+
+    def test_an_unfinished_spell_does_not_bias_dwell_times_downwards(self):
+        """A PR still sitting in a stage has not finished waiting, so counting
+        its time so far as a completed dwell would make a stuck stage look fast."""
+        data = snapshot([
+            pr(1, [(NOW - timedelta(hours=100), "awaiting-review")]),          # stuck
+            pr(2, [(NOW - timedelta(hours=4), "awaiting-review"),
+                   (NOW - timedelta(hours=3), "ready-to-merge")]),             # 1h, done
+        ])
+        stage = next(s for s in health.analyse(data, 24, 24 * 14, NOW)["stages"]
+                     if s["stage"] == "awaiting-review")
+        self.assertEqual(stage["median_dwell_hours"], 1.0)
+        self.assertEqual(stage["oldest_waiting_hours"], 100.0)
+
+    def test_author_owned_stages_are_marked_as_such(self):
+        result = health.analyse(snapshot([]), 24, 24 * 14, NOW)
+        owned = {s["stage"]: s["owned_by_project"] for s in result["stages"]}
+        self.assertFalse(owned["ci-failed"])
+        self.assertFalse(owned["awaiting-author"])
+        self.assertTrue(owned["awaiting-review"])
+
+
+class BottleneckTests(unittest.TestCase):
+    def base(self, **overrides):
+        result = {"merged_per_hour": 1.0, "baseline_merged_per_hour": 5.0, "stages": []}
+        result.update(overrides)
+        return result
+
+    def stage(self, name, **kw):
+        item = {"stage": name, "owned_by_project": name not in health.STATE_AUTHOR_ACTION,
+                "depth": 0, "oldest_waiting_hours": 0.0, "entered_per_hour": 0.0,
+                "left_per_hour": 0.0, "baseline_median_dwell_hours": None}
+        item.update(kw)
+        return item
+
+    def test_healthy_throughput_names_no_bottleneck(self):
+        self.assertIsNone(health.find_bottleneck(
+            self.base(merged_per_hour=5.0, baseline_merged_per_hour=5.0)))
+
+    def test_a_stage_filling_faster_than_it_drains_wins(self):
+        result = self.base(stages=[
+            self.stage("awaiting-CI", depth=50, entered_per_hour=1.0, left_per_hour=1.0),
+            self.stage("awaiting-review", depth=10, entered_per_hour=3.0, left_per_hour=0.5),
+        ])
+        self.assertEqual(health.find_bottleneck(result)["stage"], "awaiting-review")
+
+    def test_a_deep_but_draining_stage_is_not_the_bottleneck(self):
+        """Depth alone means nothing: a queue can be long and perfectly healthy."""
+        result = self.base(stages=[
+            self.stage("awaiting-CI", depth=200, entered_per_hour=2.0, left_per_hour=2.5),
+            self.stage("ready-to-merge", depth=3, entered_per_hour=1.0, left_per_hour=0.2),
+        ])
+        self.assertEqual(health.find_bottleneck(result)["stage"], "ready-to-merge")
+
+    def test_stages_waiting_on_the_author_are_never_blamed(self):
+        """The project cannot fix these, so naming one would point effort at
+        exactly the wrong place."""
+        result = self.base(stages=[
+            self.stage("ci-failed", depth=99, entered_per_hour=9.0, left_per_hour=0.1),
+            self.stage("awaiting-author", depth=99, entered_per_hour=9.0, left_per_hour=0.1),
+        ])
+        self.assertIsNone(health.find_bottleneck(result))
+
+    def test_an_empty_stage_is_not_a_bottleneck(self):
+        result = self.base(stages=[self.stage("awaiting-review", depth=0,
+                                              entered_per_hour=0.0, left_per_hour=0.0)])
+        self.assertIsNone(health.find_bottleneck(result))
+
+
+class ReportTests(unittest.TestCase):
+    def test_report_renders_and_names_the_author_owned_marker(self):
+        result = health.analyse(snapshot([
+            pr(1, [(NOW - timedelta(hours=2), "awaiting-review")]),
+        ]), 24, 24 * 14, NOW)
+        text = health.report(result)
+        self.assertIn("awaiting-review", text)
+        self.assertIn("waiting on the contributor", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_pipeline_health.py
+++ b/scripts/test_pipeline_health.py
@@ -7,6 +7,7 @@ import unittest
 from datetime import datetime, timedelta, timezone
 
 import pipeline_health as health
+import pr_lifecycle as health_lc
 
 UTC = timezone.utc
 NOW = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
@@ -44,29 +45,29 @@ class IntervalTests(unittest.TestCase):
             (NOW - timedelta(hours=10), "awaiting-CI"),
             (NOW - timedelta(hours=8), "awaiting-review"),
         ])
-        spells = list(health.episodes(item, NOW))
+        spells = list(health_lc.label_intervals(item, NOW))
         self.assertEqual([s[0] for s in spells], ["awaiting-CI", "awaiting-review"])
         self.assertEqual((spells[0][2] - spells[0][1]), timedelta(hours=2))
 
     def test_an_open_pr_s_last_spell_is_still_running(self):
         item = pr(1, [(NOW - timedelta(hours=3), "awaiting-review")])
-        self.assertIsNone(list(health.episodes(item, NOW))[-1][2])
+        self.assertIsNone(list(health_lc.label_intervals(item, NOW))[-1][2])
 
     def test_a_merged_pr_s_last_spell_ends_at_the_merge(self):
         merged = NOW - timedelta(hours=1)
         item = pr(2, [(NOW - timedelta(hours=5), "ready-to-merge")],
                   state="MERGED", merged=merged)
-        _, start, end = list(health.episodes(item, NOW))[-1]
+        _, start, end = list(health_lc.label_intervals(item, NOW))[-1]
         self.assertEqual(end, merged)
 
     def test_non_lifecycle_labels_are_ignored(self):
         item = pr(3, [(NOW - timedelta(hours=4), "roadmap:algebra"),
                       (NOW - timedelta(hours=2), "awaiting-review")])
-        self.assertEqual([s[0] for s in health.episodes(item, NOW)],
+        self.assertEqual([s[0] for s in health_lc.label_intervals(item, NOW)],
                          ["awaiting-review"])
 
     def test_a_pr_with_no_lifecycle_events_yields_nothing(self):
-        self.assertEqual(list(health.episodes(pr(4, []), NOW)), [])
+        self.assertEqual(list(health_lc.label_intervals(pr(4, []), NOW)), [])
 
 
 class AnalysisTests(unittest.TestCase):
@@ -256,8 +257,6 @@ class ReportTests(unittest.TestCase):
         self.assertIn("waiting on the contributor", text)
 
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 class AgreementTests(unittest.TestCase):
@@ -300,3 +299,7 @@ class AgreementTests(unittest.TestCase):
         ])
         stages = health.analyse(snapshot([item]), 24, 24 * 14, NOW)["stages"]
         self.assertAlmostEqual(max(s["oldest_waiting_hours"] for s in stages), 3.0, places=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_pipeline_health.py
+++ b/scripts/test_pipeline_health.py
@@ -44,26 +44,29 @@ class IntervalTests(unittest.TestCase):
             (NOW - timedelta(hours=10), "awaiting-CI"),
             (NOW - timedelta(hours=8), "awaiting-review"),
         ])
-        spells = list(health.lifecycle_intervals(item, NOW))
+        spells = list(health.episodes(item, NOW))
         self.assertEqual([s[0] for s in spells], ["awaiting-CI", "awaiting-review"])
         self.assertEqual((spells[0][2] - spells[0][1]), timedelta(hours=2))
 
     def test_an_open_pr_s_last_spell_is_still_running(self):
         item = pr(1, [(NOW - timedelta(hours=3), "awaiting-review")])
-        self.assertIsNone(list(health.lifecycle_intervals(item, NOW))[-1][2])
+        self.assertIsNone(list(health.episodes(item, NOW))[-1][2])
 
     def test_a_merged_pr_s_last_spell_ends_at_the_merge(self):
         merged = NOW - timedelta(hours=1)
         item = pr(2, [(NOW - timedelta(hours=5), "ready-to-merge")],
                   state="MERGED", merged=merged)
-        _, start, end = list(health.lifecycle_intervals(item, NOW))[-1]
+        _, start, end = list(health.episodes(item, NOW))[-1]
         self.assertEqual(end, merged)
 
     def test_non_lifecycle_labels_are_ignored(self):
         item = pr(3, [(NOW - timedelta(hours=4), "roadmap:algebra"),
                       (NOW - timedelta(hours=2), "awaiting-review")])
-        self.assertEqual([s[0] for s in health.lifecycle_intervals(item, NOW)],
+        self.assertEqual([s[0] for s in health.episodes(item, NOW)],
                          ["awaiting-review"])
+
+    def test_a_pr_with_no_lifecycle_events_yields_nothing(self):
+        self.assertEqual(list(health.episodes(pr(4, []), NOW)), [])
 
 
 class AnalysisTests(unittest.TestCase):
@@ -255,3 +258,45 @@ class ReportTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AgreementTests(unittest.TestCase):
+    """The charts and this report read the same timelines and must not disagree.
+
+    They did, by nineteen hours: one treated a ci-failed to awaiting-author swap
+    as a fresh wait and the other continued the spell. That is the whole reason
+    the lifecycle rules now live in one module.
+    """
+
+    def swapped_author_labels(self):
+        return pr(1, [
+            (NOW - timedelta(hours=20), "ci-failed"),
+            (NOW - timedelta(hours=1), "awaiting-author"),
+        ])
+
+    def test_waiting_time_matches_the_chart_generator(self):
+        import pr_stats_graphs as stats
+
+        item = self.swapped_author_labels()
+        theirs = stats.queue_age_metrics([item], NOW)["awaiting_author_hours"][0]
+        stages = health.analyse(snapshot([item]), 24, 24 * 14, NOW)["stages"]
+        mine = max(s["oldest_waiting_hours"] for s in stages)
+        self.assertAlmostEqual(theirs, mine, places=3)
+        self.assertAlmostEqual(theirs, 20.0, places=3)
+
+    def test_swapping_sibling_review_labels_continues_the_cycle(self):
+        item = pr(2, [
+            (NOW - timedelta(hours=12), "awaiting-review"),
+            (NOW - timedelta(hours=2), "review-in-progress"),
+        ])
+        stages = health.analyse(snapshot([item]), 24, 24 * 14, NOW)["stages"]
+        self.assertAlmostEqual(max(s["oldest_waiting_hours"] for s in stages), 12.0, places=3)
+
+    def test_a_push_back_to_ci_does_start_a_fresh_wait(self):
+        """Only sibling labels join; anything else is genuinely a new spell."""
+        item = pr(3, [
+            (NOW - timedelta(hours=30), "awaiting-author"),
+            (NOW - timedelta(hours=3), "awaiting-CI"),
+        ])
+        stages = health.analyse(snapshot([item]), 24, 24 * 14, NOW)["stages"]
+        self.assertAlmostEqual(max(s["oldest_waiting_hours"] for s in stages), 3.0, places=3)

--- a/scripts/test_pipeline_health.py
+++ b/scripts/test_pipeline_health.py
@@ -104,10 +104,15 @@ class AnalysisTests(unittest.TestCase):
         self.assertTrue(owned["awaiting-review"])
 
 
-class BottleneckTests(unittest.TestCase):
+class CauseTests(unittest.TestCase):
+    """Why throughput fell: a stage backing up, a thinner intake, both, or an
+    honest admission that the queue does not explain it."""
+
     def base(self, **overrides):
         result = {"merged_per_hour": 1.0, "baseline_merged_per_hour": 5.0,
-                  "baseline_merged_count": 100, "stages": []}
+                  "baseline_merged_count": 100, "stages": [],
+                  "opened_per_hour": 5.0, "baseline_opened_per_hour": 5.0,
+                  "baseline_opened_count": 100}
         result.update(overrides)
         return result
 
@@ -119,16 +124,41 @@ class BottleneckTests(unittest.TestCase):
         item.update(kw)
         return item
 
-    def test_healthy_throughput_names_no_bottleneck(self):
-        self.assertIsNone(health.find_bottleneck(
+    def test_healthy_throughput_names_no_cause(self):
+        self.assertIsNone(health.find_cause(
             self.base(merged_per_hour=5.0, baseline_merged_per_hour=5.0)))
+
+    def test_thin_intake_is_itself_the_answer(self):
+        """Fewer merges because fewer arrived is a cause, not the absence of
+        one, and it wants the opposite response to a stuck queue: adding review
+        capacity does nothing about a week when nobody opened anything."""
+        found = health.find_cause(self.base(opened_per_hour=0.5, anomalies=[]))
+        self.assertEqual(found["kind"], "intake")
+        self.assertIn("fewer pull requests are arriving", found["why"])
+
+    def test_a_stuck_stage_and_thin_intake_are_both_reported(self):
+        found = health.find_cause(self.base(
+            opened_per_hour=0.5,
+            stages=[self.stage("awaiting-review", depth=10,
+                               entered_per_hour=3.0, left_per_hour=0.5)]))
+        self.assertEqual(found["kind"], "stage")
+        self.assertIn("Arrivals are also down", found["why"])
+
+    def test_an_unexplained_fall_says_so_rather_than_blaming_a_stage(self):
+        found = health.find_cause(self.base(anomalies=[]))
+        self.assertEqual(found["kind"], "unexplained")
+
+    def test_thin_intake_needs_a_baseline_to_claim_it(self):
+        found = health.find_cause(self.base(
+            opened_per_hour=0.5, baseline_opened_count=1, anomalies=[]))
+        self.assertEqual(found["kind"], "unexplained")
 
     def test_a_stage_filling_faster_than_it_drains_wins(self):
         result = self.base(stages=[
             self.stage("awaiting-CI", depth=50, entered_per_hour=1.0, left_per_hour=1.0),
             self.stage("awaiting-review", depth=10, entered_per_hour=3.0, left_per_hour=0.5),
         ])
-        self.assertEqual(health.find_bottleneck(result)["stage"], "awaiting-review")
+        self.assertEqual(health.find_cause(result)["stage"], "awaiting-review")
 
     def test_a_deep_but_draining_stage_is_not_the_bottleneck(self):
         """Depth alone means nothing: a queue can be long and perfectly healthy."""
@@ -136,7 +166,7 @@ class BottleneckTests(unittest.TestCase):
             self.stage("awaiting-CI", depth=200, entered_per_hour=2.0, left_per_hour=2.5),
             self.stage("ready-to-merge", depth=3, entered_per_hour=1.0, left_per_hour=0.2),
         ])
-        self.assertEqual(health.find_bottleneck(result)["stage"], "ready-to-merge")
+        self.assertEqual(health.find_cause(result)["stage"], "ready-to-merge")
 
     def test_no_stage_is_named_when_none_is_misbehaving(self):
         """Throughput can fall because nothing arrived. Naming a culprit anyway
@@ -147,23 +177,23 @@ class BottleneckTests(unittest.TestCase):
             self.stage("awaiting-review", depth=9, entered_per_hour=0.5, left_per_hour=0.6,
                        oldest_waiting_hours=4.0, baseline_median_dwell_hours=5.0),
         ])
-        self.assertIsNone(health.find_bottleneck(result))
+        self.assertIsNone(health.find_cause(result)["stage"])
 
     def test_a_stalled_stage_is_named_even_without_growth(self):
         result = self.base(stages=[
             self.stage("ready-to-merge", depth=4, entered_per_hour=0.1, left_per_hour=0.1,
                        oldest_waiting_hours=100.0, baseline_median_dwell_hours=2.0),
         ])
-        found = health.find_bottleneck(result)
+        found = health.find_cause(result)
         self.assertEqual(found["stage"], "ready-to-merge")
         self.assertIn("normal dwell", found["why"])
 
     def test_a_thin_baseline_reports_insufficient_data_not_health(self):
         """Zero merges over the baseline made the old gate read 0 >= 0 and call
         an empty repository healthy."""
-        found = health.find_bottleneck(self.base(
+        found = health.find_cause(self.base(
             merged_per_hour=0.0, baseline_merged_per_hour=0.0, baseline_merged_count=0))
-        self.assertTrue(found["insufficient_data"])
+        self.assertEqual(found["kind"], "insufficient_data")
 
     def test_a_stage_with_too_few_completions_is_not_judged_on_dwell(self):
         result = self.base(stages=[
@@ -171,7 +201,7 @@ class BottleneckTests(unittest.TestCase):
                        oldest_waiting_hours=500.0, baseline_median_dwell_hours=1.0,
                        baseline_left_count=1),
         ])
-        self.assertIsNone(health.find_bottleneck(result))
+        self.assertIsNone(health.find_cause(result)["stage"])
 
     def test_stages_waiting_on_the_author_are_never_blamed(self):
         """The project cannot fix these, so naming one would point effort at
@@ -180,12 +210,12 @@ class BottleneckTests(unittest.TestCase):
             self.stage("ci-failed", depth=99, entered_per_hour=9.0, left_per_hour=0.1),
             self.stage("awaiting-author", depth=99, entered_per_hour=9.0, left_per_hour=0.1),
         ])
-        self.assertIsNone(health.find_bottleneck(result))
+        self.assertIsNone(health.find_cause(result)["stage"])
 
     def test_an_empty_stage_is_not_a_bottleneck(self):
         result = self.base(stages=[self.stage("awaiting-review", depth=0,
                                               entered_per_hour=0.0, left_per_hour=0.0)])
-        self.assertIsNone(health.find_bottleneck(result))
+        self.assertIsNone(health.find_cause(result)["stage"])
 
 
 class TimingTests(unittest.TestCase):

--- a/scripts/test_pr_lifecycle.py
+++ b/scripts/test_pr_lifecycle.py
@@ -49,7 +49,7 @@ class JoiningTests(unittest.TestCase):
             (NOW - timedelta(hours=30), "awaiting-author"),
             (NOW - timedelta(hours=3), "awaiting-CI"),
         ]), NOW))
-        self.assertEqual([s[0] for s in spells], ["awaiting-author", "awaiting-CI"])
+        self.assertEqual([s[0] for s in spells], ["author-action", "awaiting-CI"])
 
     def test_a_closed_pr_s_last_spell_ends_at_the_close(self):
         merged = NOW - timedelta(hours=1)
@@ -93,6 +93,70 @@ class AgreementTests(unittest.TestCase):
             (NOW - timedelta(hours=2), "review-in-progress"),
         ])
         self.assertEqual(lc.review_cycle_starts(item)[-1], list(lc.episodes(item, NOW))[-1][1])
+
+
+class SeparationTests(unittest.TestCase):
+    """Waiting spells and per-label rates are different questions.
+
+    Using one decomposition for both meant a ci-failed to awaiting-author swap
+    recorded no dwell for ci-failed at all, and dated awaiting-author's arrival
+    nineteen hours before it happened. The waiting time was right and every rate
+    was wrong.
+    """
+
+    def swap(self):
+        return pr([
+            (NOW - timedelta(hours=20), "ci-failed"),
+            (NOW - timedelta(hours=1), "awaiting-author"),
+        ])
+
+    def test_atomic_intervals_keep_each_label_separate(self):
+        got = [(label, end) for label, _, end in lc.label_intervals(self.swap(), NOW)]
+        self.assertEqual([label for label, _ in got], ["ci-failed", "awaiting-author"])
+        self.assertIsNone(got[-1][1])
+
+    def test_the_first_label_records_its_own_dwell(self):
+        first = next(iter(lc.label_intervals(self.swap(), NOW)))
+        self.assertAlmostEqual((first[2] - first[1]).total_seconds() / 3600, 19.0, places=3)
+
+    def test_the_spell_is_one_group_and_keeps_the_whole_wait(self):
+        spells = list(lc.episodes(self.swap(), NOW))
+        self.assertEqual([g for g, _, _ in spells], ["author-action"])
+        self.assertEqual(spells[0][1], NOW - timedelta(hours=20))
+
+    def test_episodes_yield_a_group_not_a_label(self):
+        """The old version claimed to yield the starting label and yielded the
+        final one, which silently decided which label got the duration."""
+        groups = {g for g, _, _ in lc.episodes(self.swap(), NOW)}
+        self.assertEqual(groups, {"author-action"})
+        self.assertNotIn("ci-failed", groups)
+
+
+class CensoringTests(unittest.TestCase):
+    def test_a_removed_label_is_not_still_running(self):
+        """Only additions are recorded, so a label taken off without another
+        arriving would otherwise look like it was still in force."""
+        item = pr([(NOW - timedelta(hours=5), "awaiting-review")], labels=[])
+        self.assertEqual([i for i in lc.label_intervals(item, NOW)], [])
+        self.assertIsNone(lc.waiting_since(item, NOW))
+
+    def test_a_label_still_present_is_running(self):
+        item = pr([(NOW - timedelta(hours=5), "awaiting-review")])
+        self.assertIsNone(list(lc.label_intervals(item, NOW))[-1][2])
+
+
+class DeliberateDifferenceTests(unittest.TestCase):
+    def test_review_cycles_and_waiting_spells_count_differently(self):
+        """A pull request that reached ready-to-merge and came back has waited
+        twice while having been reviewed once. Both answers are correct; the
+        point is that the difference is intended and pinned."""
+        item = pr([
+            (NOW - timedelta(hours=9), "awaiting-review"),
+            (NOW - timedelta(hours=6), "ready-to-merge"),
+            (NOW - timedelta(hours=3), "awaiting-review"),
+        ])
+        self.assertEqual(len(lc.review_cycle_starts(item)), 1)
+        self.assertEqual(sum(1 for g, _, _ in lc.episodes(item, NOW) if g == "review"), 2)
 
 
 if __name__ == "__main__":

--- a/scripts/test_pr_lifecycle.py
+++ b/scripts/test_pr_lifecycle.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Hermetic tests for scripts/pr_lifecycle.py, the shared lifecycle rules."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+import pr_lifecycle as lc
+
+UTC = timezone.utc
+NOW = datetime(2026, 8, 25, 12, tzinfo=UTC)
+
+
+def iso(when):
+    return when.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def pr(events, *, state="OPEN", labels=None, merged=None):
+    return {
+        "state": state,
+        "merged_at": iso(merged) if merged else None,
+        "closed_at": iso(merged) if merged else None,
+        "labels": labels if labels is not None else ([events[-1][1]] if events else []),
+        "labeled_events": [{"created_at": iso(at), "label": name} for at, name in events],
+    }
+
+
+class JoiningTests(unittest.TestCase):
+    def test_author_action_siblings_are_one_spell(self):
+        """The author reads a build log for one and review threads for the other,
+        but the ball is in their court either way."""
+        spells = list(lc.episodes(pr([
+            (NOW - timedelta(hours=20), "ci-failed"),
+            (NOW - timedelta(hours=1), "awaiting-author"),
+        ]), NOW))
+        self.assertEqual(len(spells), 1)
+        self.assertEqual(spells[0][1], NOW - timedelta(hours=20))
+
+    def test_review_siblings_are_one_spell(self):
+        spells = list(lc.episodes(pr([
+            (NOW - timedelta(hours=12), "awaiting-review"),
+            (NOW - timedelta(hours=2), "review-in-progress"),
+        ]), NOW))
+        self.assertEqual(len(spells), 1)
+
+    def test_anything_else_starts_a_fresh_spell(self):
+        spells = list(lc.episodes(pr([
+            (NOW - timedelta(hours=30), "awaiting-author"),
+            (NOW - timedelta(hours=3), "awaiting-CI"),
+        ]), NOW))
+        self.assertEqual([s[0] for s in spells], ["awaiting-author", "awaiting-CI"])
+
+    def test_a_closed_pr_s_last_spell_ends_at_the_close(self):
+        merged = NOW - timedelta(hours=1)
+        spells = list(lc.episodes(
+            pr([(NOW - timedelta(hours=5), "ready-to-merge")], state="MERGED", merged=merged), NOW))
+        self.assertEqual(spells[-1][2], merged)
+
+    def test_an_open_pr_s_last_spell_is_still_running(self):
+        spells = list(lc.episodes(pr([(NOW - timedelta(hours=5), "awaiting-review")]), NOW))
+        self.assertIsNone(spells[-1][2])
+
+
+class CurrentStageTests(unittest.TestCase):
+    def test_from_labels_not_from_history(self):
+        item = pr([(NOW - timedelta(hours=5), "awaiting-review")], labels=[])
+        self.assertIsNone(lc.current_stage(item))
+
+    def test_a_single_lifecycle_label_wins(self):
+        item = pr([], labels=["roadmap:algebra", "awaiting-review"])
+        self.assertEqual(lc.current_stage(item), "awaiting-review")
+
+    def test_two_lifecycle_labels_is_no_answer(self):
+        """The pipeline keeps one at a time, so two means something is wrong and
+        guessing between them would invent a fact."""
+        item = pr([], labels=["awaiting-review", "ci-failed"])
+        self.assertIsNone(lc.current_stage(item))
+
+
+class AgreementTests(unittest.TestCase):
+    def test_author_episode_start_matches_the_shared_spell(self):
+        item = pr([
+            (NOW - timedelta(hours=20), "ci-failed"),
+            (NOW - timedelta(hours=1), "awaiting-author"),
+        ])
+        spells = list(lc.episodes(item, NOW))
+        self.assertEqual(lc.author_episode_start(item), spells[-1][1])
+
+    def test_review_cycle_start_matches_the_shared_spell(self):
+        item = pr([
+            (NOW - timedelta(hours=12), "awaiting-review"),
+            (NOW - timedelta(hours=2), "review-in-progress"),
+        ])
+        self.assertEqual(lc.review_cycle_starts(item)[-1], list(lc.episodes(item, NOW))[-1][1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a pipeline-health report that derives per-stage arrival and departure rates, queue depth, oldest wait, and median dwell from pull-request lifecycle-label timelines, and identifies the current bottleneck.

The Pages workflow reuses the normalized snapshot already fetched by `pr_stats_graphs.py` and publishes the report as `pipeline-health.json`.

Depth alone does not implicate a stage, since one can be deep and healthy if it drains as fast as it fills; a stage is named only when arrivals outpace departures or its oldest occupant has waited well past that stage's normal dwell. `ci-failed` and `awaiting-author` are reported but never blamed, because they wait on the contributor rather than the project.

Roadmap: none

🤖 Prepared with Claude Code
