### PR TITLE
feat: the weight support of a dominant irreducible highest weight module is finite

### DIFF
--- a/TauCeti/Algebra/Lie/HighestWeight/WeightSupport.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/WeightSupport.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.HighestWeight.Reflection
+import TauCeti.Algebra.Lie.Submodule.Atom
+public import TauCeti.LinearAlgebra.RootSystem.DominantCone
+
+public section
+
+/-!
+# The weight support of an irreducible highest weight module of dominant integral weight is finite
+
+Let `L` be a finite-dimensional Lie algebra with non-degenerate Killing form over an algebraically
+closed field of characteristic zero, let `H` be a splitting Cartan subalgebra, let `b` be a base of
+its root system, and let `M` be an irreducible `L`-module carrying a highest weight vector of
+dominant integral weight `lam`. This file proves that `M` has only **finitely many** weights.
+
+`M` is not assumed finite-dimensional, and that is the whole point: for the modules `L(lam)` of
+Layer 4 of the highest weight roadmap, finite-dimensionality is the conclusion. Together with
+finite-dimensionality of the individual weight spaces it is what makes `L(lam)` finite-dimensional.
+
+## Main results
+
+* `TauCeti.finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector`: **an irreducible highest
+  weight module of dominant integral weight has finitely many weights.**
+
+## The argument
+
+Three facts about the weights of `M` are already available, none of them needing
+finite-dimensionality:
+
+* they lie in the cone `lam - Q⁺`, by the weight-cone theorem of
+  `TauCeti/Algebra/Lie/HighestWeight/Module.lean`;
+* they take integer values on the simple coroots
+  (`TauCeti.exists_int_apply_coroot_of_genWeightSpace_ne_bot_of_isHighestWeightVector`);
+* they are stable under the simple reflections
+  (`TauCeti.genWeightSpace_rootSystem_reflection_ne_bot`).
+
+`TauCeti.finite_of_forall_reflection_mem_of_sub_mem_posRootCone` turns exactly that combination
+into finiteness, so the work here is to feed the three facts to it and then to remove the linearity
+restriction: a weight of `M` is a priori only a function `H → K`, but every weight of a highest
+weight module is of the form `lam - ν`, hence linear, by
+`TauCeti.exists_sub_eq_of_genWeightSpace_ne_bot_of_isHighestWeightVector_of_lieSpan_eq_top`.
+
+## References
+
+This is the "weight-cone bound" milestone of Layer 4, "the classification of finite-dimensional
+irreducibles", of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §21.2.
+-/
+
+namespace TauCeti
+
+open LieAlgebra LieModule Module
+
+universe u v w
+
+variable {K : Type u} {L : Type v} [Field K] [CharZero K] [IsAlgClosed K] [LieRing L]
+  [LieAlgebra K L] [IsKilling K L] [FiniteDimensional K L]
+  {H : LieSubalgebra K L} [H.IsCartanSubalgebra]
+  {M : Type w} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+  {b : (IsKilling.rootSystem H).Base} {lam : Dual K H} {v : M}
+
+/-- **An irreducible highest weight module of dominant integral weight has finitely many
+weights.** Let `M` be irreducible with a highest weight vector of dominant integral weight `lam`.
+Then only finitely many functions on the Cartan subalgebra have a nonzero weight space in `M`.
+
+`M` is not assumed finite-dimensional. The three inputs — the weight cone `lam - Q⁺`, integrality
+on the simple coroots, and stability under the simple reflections — are exactly the hypotheses of
+`TauCeti.finite_of_forall_reflection_mem_of_sub_mem_posRootCone`, and each of them is available
+for an integrable module. -/
+theorem finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector
+    [LieModule.IsIrreducible K L M] (hv : IsHighestWeightVector b lam v)
+    (hlam : IsDominantIntegral b lam) :
+    {chi : H → K | genWeightSpace M chi ≠ ⊥}.Finite := by
+  have hgen : LieSubmodule.lieSpan K L {v} = ⊤ := lieSpan_singleton_eq_top_of_ne_zero hv.ne_zero
+  have hcoroot' : ∀ (i : H.root) (chi : Dual K H),
+      (IsKilling.rootSystem H).coroot' i chi = chi (IsKilling.coroot (i : Weight K H L)) :=
+    fun _ _ ↦ rfl
+  have hS : {chi : Dual K H | genWeightSpace M ((chi : Dual K H) : H → K) ≠ ⊥}.Finite := by
+    refine finite_of_forall_reflection_mem_of_sub_mem_posRootCone (lam := lam) b
+      (fun chi hchi ↦ ?_) (fun chi hchi i hi ↦ ?_) fun chi hchi i hi ↦ ?_
+    · exact sub_mem_posRootCone_of_genWeightSpace_ne_bot_of_isHighestWeightVector_of_lieSpan_eq_top
+        hv hgen hchi
+    · obtain ⟨m, hm⟩ := exists_int_apply_coroot_of_genWeightSpace_ne_bot_of_isHighestWeightVector
+        hv hlam hi hchi
+      exact ⟨m, by rw [hcoroot' i chi, hm]⟩
+    · exact genWeightSpace_rootSystem_reflection_ne_bot hv hlam hi hchi
+  refine Set.Finite.subset (hS.image fun psi : Dual K H ↦ (psi : H → K)) fun chi hchi ↦ ?_
+  obtain ⟨nu, -, heq⟩ :=
+    exists_sub_eq_of_genWeightSpace_ne_bot_of_isHighestWeightVector_of_lieSpan_eq_top hv hgen hchi
+  exact ⟨lam - nu, by rw [Set.mem_ofPred_eq, heq]; exact hchi, heq⟩
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/HighestWeight/WeightSupport.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/WeightSupport.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Algebra.Lie.HighestWeight.Reflection
 import TauCeti.Algebra.Lie.Submodule.Atom
-public import TauCeti.LinearAlgebra.RootSystem.DominantCone
+import TauCeti.LinearAlgebra.RootSystem.DominantCone
 
 public section
 
@@ -72,16 +72,21 @@ Then only finitely many functions on the Cartan subalgebra have a nonzero weight
 
 `M` is not assumed finite-dimensional. The three inputs — the weight cone `lam - Q⁺`, integrality
 on the simple coroots, and stability under the simple reflections — are exactly the hypotheses of
-`TauCeti.finite_of_forall_reflection_mem_of_sub_mem_posRootCone`, and each of them is available
-for an integrable module. -/
+`TauCeti.finite_of_forall_reflection_mem_of_sub_mem_posRootCone`, and each of them follows from
+`hv`, from dominance integrality of `lam`, and from irreducibility of `M` (used only through the
+resulting fact that `v` generates `M`). -/
 theorem finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector
     [LieModule.IsIrreducible K L M] (hv : IsHighestWeightVector b lam v)
     (hlam : IsDominantIntegral b lam) :
     {chi : H → K | genWeightSpace M chi ≠ ⊥}.Finite := by
   have hgen : LieSubmodule.lieSpan K L {v} = ⊤ := lieSpan_singleton_eq_top_of_ne_zero hv.ne_zero
+  -- The root system of `H` pairs a weight with a coroot by evaluation, so its `coroot'` is
+  -- evaluation at `IsKilling.coroot`; this is the boundary between the two coroot interfaces.
   have hcoroot' : ∀ (i : H.root) (chi : Dual K H),
-      (IsKilling.rootSystem H).coroot' i chi = chi (IsKilling.coroot (i : Weight K H L)) :=
-    fun _ _ ↦ rfl
+      (IsKilling.rootSystem H).coroot' i chi = chi (IsKilling.coroot (i : Weight K H L)) := by
+    intro i chi
+    rw [LinearMap.flip_apply, IsKilling.rootSystem_toLinearMap_apply,
+      IsKilling.rootSystem_coroot_apply]
   have hS : {chi : Dual K H | genWeightSpace M ((chi : Dual K H) : H → K) ≠ ⊥}.Finite := by
     refine finite_of_forall_reflection_mem_of_sub_mem_posRootCone (lam := lam) b
       (fun chi hchi ↦ ?_) (fun chi hchi i hi ↦ ?_) fun chi hchi i hi ↦ ?_

--- a/TauCeti/LinearAlgebra/RootSystem/DominantCone.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/DominantCone.lean
@@ -102,7 +102,7 @@ takes a natural value on `mu`.
 The two hypotheses pull in opposite directions: the first writes `lam - mu` as `∑ j, c j • αⱼ` with
 `c j` natural, and the second bounds the resulting Cartan expression `∑ j, c j ⟨αⱼ, αᵢ^∨⟩` above.
 Positive definiteness of the symmetrized Cartan matrix
-(`TauCeti.IsFiniteType.finite_setOf_forall_sum_mul_le`) leaves only finitely many such `c`. -/
+(`TauCeti.finite_setOf_forall_sum_mul_le`) leaves only finitely many such `c`. -/
 theorem finite_setOf_dominant_sub_mem_posRootCone (lam : M) :
     {mu : M | lam - mu ∈ posRootCone P b ∧
       ∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i mu = (n : R)}.Finite := by
@@ -129,8 +129,9 @@ theorem finite_setOf_dominant_sub_mem_posRootCone (lam : M) :
     simp only [hydef]
     push_cast
     ring
+  obtain ⟨d, hd, hpd⟩ := (isFiniteType_cartanMatrix b).transpose.exists_symmetrizer
   refine Set.Finite.subset
-    (((isFiniteType_cartanMatrix b).transpose.finite_setOf_forall_sum_mul_le y).image
+    ((finite_setOf_forall_sum_mul_le d hd hpd y).image
       fun c : b.support → ℕ ↦ lam - ∑ j : b.support, c j • P.root j) ?_
   rintro mu ⟨hcone, hdom⟩
   obtain ⟨f, hf⟩ := (mem_posRootCone P b).mp hcone

--- a/TauCeti/LinearAlgebra/RootSystem/DominantCone.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/DominantCone.lean
@@ -5,9 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Bounded
+import TauCeti.LinearAlgebra.RootSystem.FiniteType.Bounded
 public import TauCeti.LinearAlgebra.RootSystem.Positive
-public import TauCeti.LinearAlgebra.RootSystem.Weyl.Group
+import TauCeti.LinearAlgebra.RootSystem.Weyl.Group
 
 public section
 

--- a/TauCeti/LinearAlgebra/RootSystem/DominantCone.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/DominantCone.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Bounded
+public import TauCeti.LinearAlgebra.RootSystem.Positive
+public import TauCeti.LinearAlgebra.RootSystem.Weyl.Group
+
+public section
+
+/-!
+# The weight cone below a weight is finite once it is stable under the simple reflections
+
+Fix a base `b` of a finite crystallographic root system `P` and a weight `lam`. The set of weights
+lying **below** `lam`, that is those `mu` with `lam - mu` in the positive root cone `Q⁺`, is
+infinite: it is a whole translated cone. This file proves that two further conditions cut it down
+to a finite set.
+
+* **Dominance.** Only finitely many `mu` below `lam` take a natural value on every simple coroot
+  (`TauCeti.finite_setOf_dominant_sub_mem_posRootCone`). This is the classical statement that a
+  dominant weight below `lam` is bounded, and it comes straight from positive definiteness of the
+  symmetrized Cartan matrix, in the form given in
+  `TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean`.
+* **Stability under the simple reflections.** A set of weights below `lam` on which every simple
+  coroot takes integer values and which is carried into itself by every simple reflection is
+  finite (`TauCeti.finite_of_forall_reflection_mem_of_sub_mem_posRootCone`). Stability replaces
+  dominance: a non-dominant member is raised by a simple reflection to another member strictly
+  closer to `lam`, so it is a Weyl translate of a dominant member, and the Weyl group is finite.
+
+The second statement is the shape the representation theory needs. The weights of an irreducible
+highest weight module of dominant integral highest weight `lam` lie in `lam - Q⁺`, take integer
+values on the simple coroots and are stable under the simple reflections, none of which presupposes
+that the module is finite-dimensional; the theorem below turns those three facts into finiteness of
+the weight support.
+
+## Main results
+
+* `TauCeti.finite_setOf_dominant_sub_mem_posRootCone`: **only finitely many dominant weights lie
+  below a given weight.**
+* `TauCeti.finite_of_forall_reflection_mem_of_sub_mem_posRootCone`: **a set of weights below `lam`,
+  integral on the simple coroots and stable under the simple reflections, is finite.**
+
+## The argument
+
+Writing `lam - mu = ∑ j, c j • αⱼ` with natural coefficients `c j`, the value of `mu` on the simple
+coroot `αᵢ^∨` is `lam (αᵢ^∨) - ∑ j, c j * ⟨αⱼ, αᵢ^∨⟩`. Dominance therefore says that the natural
+vector `c` solves the Cartan inequality of the transposed Cartan matrix, whose solution set is
+finite; the right-hand side of the inequality is manufactured from one member of the set, which is
+why the argument begins by disposing of the empty case.
+
+For the second statement, if `mu` is a member on which `αᵢ^∨` takes a negative value, then
+`sᵢ mu = mu - ⟨mu, αᵢ^∨⟩ αᵢ` is again a member and `lam - sᵢ mu` has strictly smaller height: the
+simple roots are linearly independent, so the coefficient vectors of the two differences agree
+except at `i`, where the coefficient drops by `-⟨mu, αᵢ^∨⟩ ≥ 1`. Induction on that height therefore
+writes every member as a Weyl translate of a dominant member.
+
+## References
+
+This is the root-system content of the "weight-cone bound" milestone of Layer 4, "the
+classification of finite-dimensional irreducibles", of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §13.2 and
+  §21.2.
+-/
+
+namespace TauCeti
+
+open Set
+
+universe u v w x
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  {P : RootPairing ι R M N} [Finite ι] [CharZero R] [IsDomain R]
+  [P.IsRootSystem] [P.IsCrystallographic] (b : P.Base)
+
+omit [Finite ι] [CharZero R] [IsDomain R] [P.IsRootSystem] in
+/-- The value of a simple coroot on a natural combination of the simple roots, as an integer read
+off the Cartan matrix. -/
+private theorem coroot'_sum_nsmul_root (f : ι → ℕ) (i : ι) :
+    P.coroot' i (∑ j ∈ b.support, f j • P.root j)
+      = ((∑ j : b.support, P.pairingIn ℤ j i * (f j : ℤ) : ℤ) : R) := by
+  have hpair : ∀ p q : ι, ((P.pairingIn ℤ p q : ℤ) : R) = P.pairing p q := by
+    intro p q
+    rw [← P.algebraMap_pairingIn ℤ p q]
+    simp
+  rw [map_sum, ← Finset.sum_coe_sort b.support fun j ↦ P.coroot' i (f j • P.root j)]
+  push_cast
+  refine Finset.sum_congr rfl fun j _ ↦ ?_
+  rw [map_nsmul, P.root_coroot'_eq_pairing, nsmul_eq_mul, hpair]
+  ring
+
+/-- **Only finitely many dominant weights lie below a given weight.** For a base `b` of a finite
+crystallographic root system and a weight `lam`, only finitely many `mu` satisfy both that
+`lam - mu` is a nonnegative integer combination of the simple roots and that every simple coroot
+takes a natural value on `mu`.
+
+The two hypotheses pull in opposite directions: the first writes `lam - mu` as `∑ j, c j • αⱼ` with
+`c j` natural, and the second bounds the resulting Cartan expression `∑ j, c j ⟨αⱼ, αᵢ^∨⟩` above.
+Positive definiteness of the symmetrized Cartan matrix
+(`TauCeti.IsFiniteType.finite_setOf_forall_sum_mul_le`) leaves only finitely many such `c`. -/
+theorem finite_setOf_dominant_sub_mem_posRootCone (lam : M) :
+    {mu : M | lam - mu ∈ posRootCone P b ∧
+      ∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i mu = (n : R)}.Finite := by
+  classical
+  set D : Set M := {mu : M | lam - mu ∈ posRootCone P b ∧
+    ∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i mu = (n : R)}
+  rcases D.eq_empty_or_nonempty with hempty | ⟨mu₀, hmu₀⟩
+  · rw [hempty]
+    exact Set.finite_empty
+  -- The right-hand side of the Cartan inequality is read off a chosen member of the set.
+  choose n₀ hn₀ using fun i : b.support ↦ hmu₀.2 i i.2
+  obtain ⟨f₀, hf₀⟩ := (mem_posRootCone P b).mp hmu₀.1
+  set y : b.support → ℤ :=
+    fun i ↦ (n₀ i : ℤ) + ∑ j : b.support, P.pairingIn ℤ j i * (f₀ j : ℤ) with hydef
+  have hlam : ∀ i : b.support, P.coroot' i lam = ((y i : ℤ) : R) := by
+    intro i
+    have h := coroot'_sum_nsmul_root b f₀ i
+    rw [← hf₀, map_sub] at h
+    have hsplit : P.coroot' i lam
+        = P.coroot' i mu₀ + ((∑ j : b.support, P.pairingIn ℤ j i * (f₀ j : ℤ) : ℤ) : R) := by
+      rw [← h]
+      ring
+    rw [hsplit, hn₀ i]
+    simp only [hydef]
+    push_cast
+    ring
+  refine Set.Finite.subset
+    (((isFiniteType_cartanMatrix b).transpose.finite_setOf_forall_sum_mul_le y).image
+      fun c : b.support → ℕ ↦ lam - ∑ j : b.support, c j • P.root j) ?_
+  rintro mu ⟨hcone, hdom⟩
+  obtain ⟨f, hf⟩ := (mem_posRootCone P b).mp hcone
+  choose n hn using fun i : b.support ↦ hdom i i.2
+  refine ⟨fun j : b.support ↦ f j, fun i ↦ ?_, ?_⟩
+  · have h := coroot'_sum_nsmul_root b f i
+    rw [← hf, map_sub, hlam i, hn i] at h
+    have hcast : ((∑ j : b.support, P.pairingIn ℤ j i * (f j : ℤ) : ℤ) : R)
+        = ((y i - n i : ℤ) : R) := by
+      rw [← h]
+      push_cast
+      ring
+    have heqZ := Int.cast_injective (α := R) hcast
+    simp only [Matrix.transpose_apply, RootPairing.Base.cartanMatrixIn_def]
+    rw [heqZ]
+    omega
+  · rw [← Finset.sum_coe_sort b.support fun j ↦ f j • P.root j] at hf
+    dsimp only
+    rw [← hf]
+    abel
+
+/-- **A reflection-stable set of weights below a weight is finite.** Let `S` be a set of weights
+with `lam - mu` in the positive root cone for every `mu ∈ S`, on which every simple coroot takes
+integer values, and which every simple reflection carries into itself. Then `S` is finite.
+
+Stability is what replaces dominance in
+`TauCeti.finite_setOf_dominant_sub_mem_posRootCone`: a member on which some simple coroot is
+negative is moved by the corresponding reflection to a member strictly closer to `lam`, so
+induction on the height of `lam - mu` exhibits every member as a Weyl translate of a dominant
+member, and both the dominant members and the Weyl group are finite. -/
+theorem finite_of_forall_reflection_mem_of_sub_mem_posRootCone {lam : M} {S : Set M}
+    (hcone : ∀ mu ∈ S, lam - mu ∈ posRootCone P b)
+    (hint : ∀ mu ∈ S, ∀ i ∈ b.support, ∃ z : ℤ, P.coroot' i mu = (z : R))
+    (hrefl : ∀ mu ∈ S, ∀ i ∈ b.support, P.reflection i mu ∈ S) :
+    S.Finite := by
+  classical
+  have : Finite P.weylGroup := RootPairing.finite_weylGroup P
+  set D : Set M := {mu : M | lam - mu ∈ posRootCone P b ∧
+    ∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i mu = (n : R)}
+  set T : Set M := ⋃ w : P.weylGroup, (fun x ↦ w • x) '' D with hTdef
+  have hT : T.Finite :=
+    Set.finite_iUnion fun w ↦ (finite_setOf_dominant_sub_mem_posRootCone b lam).image _
+  -- The union of the Weyl translates of the dominant members is reflection stable.
+  have hTrefl : ∀ (i : ι) (x : M), x ∈ T → P.reflection i x ∈ T := by
+    intro i x hx
+    simp only [hTdef, Set.mem_iUnion, Set.mem_image] at hx ⊢
+    obtain ⟨w, v, hv, rfl⟩ := hx
+    refine ⟨RootPairing.weylGroup.ofIdx P i * w, v, hv, ?_⟩
+    rw [mul_smul]
+    simp
+  -- The simple roots are linearly independent, so the coefficients of a member are determined.
+  have hli : LinearIndepOn ℤ P.root (b.support : Set ι) :=
+    b.linearIndepOn_root.restrict_scalars' ℤ
+  have main : ∀ k : ℕ, ∀ mu ∈ S, ∀ f : ι → ℕ,
+      lam - mu = ∑ j ∈ b.support, f j • P.root j → ∑ j ∈ b.support, f j = k → mu ∈ T := by
+    intro k
+    induction k using Nat.strong_induction_on with
+    | _ k ih =>
+      intro mu hmu f hf hsum
+      by_cases hdom : ∀ i ∈ b.support, ∃ n : ℕ, P.coroot' i mu = (n : R)
+      · exact Set.mem_iUnion.mpr ⟨1, mu, ⟨hcone mu hmu, hdom⟩, one_smul _ _⟩
+      push Not at hdom
+      obtain ⟨i, hi, hnotnat⟩ := hdom
+      obtain ⟨z, hz⟩ := hint mu hmu i hi
+      have hzneg : z < 0 := by
+        by_contra hc
+        push Not at hc
+        refine hnotnat z.toNat ?_
+        rw [hz, ← Int.cast_natCast (R := R) z.toNat, Int.toNat_of_nonneg hc]
+      -- Reflecting in `αᵢ` raises `mu`, so it lowers the height of `lam - mu`.
+      have hnu : P.reflection i mu ∈ S := hrefl mu hmu i hi
+      obtain ⟨g, hg⟩ := (mem_posRootCone P b).mp (hcone _ hnu)
+      have hrel : ∑ j ∈ b.support, (g j : ℤ) • P.root j
+          = ∑ j ∈ b.support, (f j : ℤ) • P.root j + z • P.root i := by
+        have h₁ : lam - P.reflection i mu = (lam - mu) + z • P.root i := by
+          rw [P.reflection_apply, hz, Int.cast_smul_eq_zsmul]
+          abel
+        simp only [natCast_zsmul]
+        rw [← hg, h₁, hf]
+      have hcoeff : ∀ j ∈ b.support,
+          ((g j : ℤ) - (f j : ℤ) - (if j = i then z else 0)) = 0 := by
+        refine linearIndepOn_iff'.mp hli b.support _ subset_rfl ?_
+        have hsingle : ∑ j ∈ b.support, (if j = i then z else 0) • P.root j = z • P.root i := by
+          rw [Finset.sum_eq_single i (fun j _ hj ↦ by simp [hj]) fun hni ↦ absurd hi hni]
+          simp
+        simp only [sub_smul]
+        rw [Finset.sum_sub_distrib, Finset.sum_sub_distrib, hsingle, hrel]
+        abel
+      have hgsum : ((∑ j ∈ b.support, g j : ℕ) : ℤ) = ((∑ j ∈ b.support, f j : ℕ) : ℤ) + z := by
+        have hsplit : ∀ j ∈ b.support, (g j : ℤ) = (f j : ℤ) + (if j = i then z else 0) := by
+          intro j hj
+          have := hcoeff j hj
+          omega
+        push_cast
+        rw [Finset.sum_congr rfl hsplit, Finset.sum_add_distrib]
+        congr 1
+        rw [Finset.sum_eq_single i (fun j _ hj ↦ by simp [hj]) fun hni ↦ absurd hi hni]
+        simp
+      have hlt : ∑ j ∈ b.support, g j < k := by omega
+      have hmem := ih _ hlt _ hnu g hg rfl
+      have hback : P.reflection i (P.reflection i mu) = mu := P.reflection_same i mu
+      exact hback ▸ hTrefl i _ hmem
+  refine hT.subset fun mu hmu ↦ ?_
+  obtain ⟨f, hf⟩ := (mem_posRootCone P b).mp (hcone mu hmu)
+  exact main _ mu hmu f hf rfl
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.BilinearForm
+public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Basic
+
+public section
+
+/-!
+# A finite-type Cartan inequality has finitely many natural solutions
+
+Let `A` be an integer matrix of finite type, that is a generalized Cartan matrix carrying a
+positive symmetrizer whose symmetrization is positive definite (`TauCeti.IsFiniteType`). This file
+proves that for every integer vector `y` the system of inequalities
+
+`∑ j, A i j * c j ≤ y i`  (for every index `i`)
+
+has only finitely many solutions `c` in the **nonnegative** integers.
+
+The system is the shape in which dominance bounds a weight from below. A weight `mu` lying under
+`lam` is `lam - ∑ j, c j • αⱼ` for natural numbers `c j`, and its value on the simple coroot
+`αᵢ^∨` is `lam (αᵢ^∨) - ∑ j, c j * ⟨αⱼ, αᵢ^∨⟩`; asking that value to be a natural number is exactly
+the displayed inequality for the transposed Cartan matrix. Finiteness of the solution set is
+therefore finiteness of the set of dominant weights under `lam`, which is how
+`TauCeti/LinearAlgebra/RootSystem/DominantCone.lean` uses it.
+
+## Main results
+
+* `TauCeti.IsFiniteType.finite_setOf_forall_sum_mul_le`: **a finite-type Cartan inequality has
+  finitely many natural solutions.**
+
+## The argument
+
+Everything happens in the rational bilinear form `F u v = u ⬝ᵥ S *ᵥ v` of the symmetrization
+`S i j = d i * A i j`, which is symmetric and positive definite. Positive definiteness makes `S`
+invertible, so every linear functional on `B → ℚ` is `F (·) w` for some `w`; the two functionals
+this file represents that way are `c ↦ ∑ i, d i * y i * c i` and, for each index `k`, the `k`-th
+coordinate.
+
+* Because the entries of `c` are nonnegative and the symmetrizer is positive, the inequalities sum
+  to `F x x ≤ F x z`, where `x` is `c` viewed rationally and `z` represents the first functional.
+  Cauchy-Schwarz for a positive semidefinite symmetric form
+  (`LinearMap.BilinForm.apply_sq_le_of_symm`) turns that into `F x x ≤ F z z`: a bound on the
+  length of `x` that does not depend on `c`.
+* Cauchy-Schwarz applied a second time, against the vector representing the `k`-th coordinate,
+  bounds each `c k` in terms of `F x x`. So the solutions lie in a product of finite intervals.
+
+No compactness, completeness or eigenvalue theory enters; the two applications of Cauchy-Schwarz
+replace them, which is what keeps the argument inside `ℚ`.
+
+## References
+
+This supplies the root-system half of the "weight-cone bound" milestone of Layer 4, "the
+classification of finite-dimensional irreducibles", of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §13.2, Lemma B.
+-/
+
+open scoped Matrix
+
+namespace TauCeti
+
+namespace IsFiniteType
+
+variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
+
+/-- **A finite-type Cartan inequality has finitely many natural solutions.** For a finite-type
+integer matrix `A` and any integer vector `y`, only finitely many vectors `c` of natural numbers
+satisfy `∑ j, A i j * c j ≤ y i` at every index `i`.
+
+Positive definiteness of the symmetrization of `A` is what makes the solution set bounded: the
+inequalities force the length of `c` in the symmetrized form to stay below a bound read off from
+`y` alone. -/
+theorem finite_setOf_forall_sum_mul_le (h : IsFiniteType A) (y : B → ℤ) :
+    {c : B → ℕ | ∀ i, ∑ j, A i j * (c j : ℤ) ≤ y i}.Finite := by
+  classical
+  obtain ⟨d, hd, hpd⟩ := h.exists_symmetrizer
+  set S : Matrix B B ℚ := Matrix.of fun i j ↦ d i * (A i j : ℚ) with hSdef
+  set F : LinearMap.BilinForm ℚ (B → ℚ) := Matrix.toBilin' S with hFdef
+  have hFapply : ∀ u v : B → ℚ, F u v = u ⬝ᵥ S *ᵥ v := fun u v ↦ Matrix.toBilin'_apply' S u v
+  -- The symmetrization is symmetric, being positive definite, and nonnegative on the diagonal.
+  have hST : Sᵀ = S := by
+    ext p q
+    simpa using hpd.isHermitian.apply p q
+  have hnonneg : ∀ u : B → ℚ, 0 ≤ F u u := fun u ↦ by
+    simpa [hFapply] using hpd.posSemidef.dotProduct_mulVec_nonneg u
+  have hsymm : LinearMap.IsSymm F := LinearMap.isSymm_def.mpr fun u v ↦ by
+    rw [RingHom.id_apply, hFapply, hFapply, Matrix.dotProduct_mulVec, ← Matrix.mulVec_transpose,
+      hST]
+    exact dotProduct_comm _ _
+  -- Positive definiteness makes `S` invertible, so every functional is represented by the form.
+  have hsolve : ∀ w : B → ℚ, ∃ z : B → ℚ, S *ᵥ z = w := fun w ↦
+    ⟨S⁻¹ *ᵥ w, by
+      rw [Matrix.mulVec_mulVec, Matrix.mul_nonsing_inv S
+        ((Matrix.isUnit_iff_isUnit_det S).mp hpd.isUnit), Matrix.one_mulVec]⟩
+  obtain ⟨z, hz⟩ := hsolve fun i ↦ d i * (y i : ℚ)
+  have hdual : ∀ k : B, ∃ u : B → ℚ, ∀ x : B → ℚ, F x u = x k := by
+    intro k
+    obtain ⟨u, hu⟩ := hsolve (Pi.single k 1)
+    exact ⟨u, fun x ↦ by rw [hFapply, hu]; simp⟩
+  choose u hu using hdual
+  refine Set.Finite.subset
+    (Set.Finite.pi fun _ : B ↦ Set.finite_Iic ⌈max 1 (F z z * ∑ k, F (u k) (u k))⌉₊)
+    fun c hc ↦ ?_
+  simp only [Set.mem_ofPred_eq] at hc
+  rw [Set.mem_univ_pi]
+  intro k
+  -- Summing the inequalities against the nonnegative vector `c` gives `F x x ≤ F x z`.
+  have hrow : ∀ i, (S *ᵥ fun j ↦ (c j : ℚ)) i = d i * ((∑ j, A i j * (c j : ℤ) : ℤ) : ℚ) := by
+    intro i
+    have hexp : (S *ᵥ fun j ↦ (c j : ℚ)) i = ∑ j, d i * (A i j : ℚ) * (c j : ℚ) := rfl
+    rw [hexp]
+    push_cast
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl fun j _ ↦ by ring
+  have hxz : F (fun j ↦ (c j : ℚ)) z = ∑ i, (c i : ℚ) * (d i * (y i : ℚ)) := by
+    rw [hFapply, hz]
+    rfl
+  have hxx : F (fun j ↦ (c j : ℚ)) (fun j ↦ (c j : ℚ))
+      = ∑ i, (c i : ℚ) * (S *ᵥ fun j ↦ (c j : ℚ)) i := by
+    rw [hFapply]
+    rfl
+  have hle : F (fun j ↦ (c j : ℚ)) (fun j ↦ (c j : ℚ)) ≤ F (fun j ↦ (c j : ℚ)) z := by
+    rw [hxx, hxz]
+    refine Finset.sum_le_sum fun i _ ↦ mul_le_mul_of_nonneg_left ?_ (by positivity)
+    rw [hrow i]
+    exact mul_le_mul_of_nonneg_left (by exact_mod_cast hc i) (hd i).le
+  -- Cauchy-Schwarz turns that into a bound on `F x x` independent of `c`.
+  have hbound : F (fun j ↦ (c j : ℚ)) (fun j ↦ (c j : ℚ)) ≤ F z z := by
+    rcases eq_or_lt_of_le (hnonneg fun j ↦ (c j : ℚ)) with h0 | h0
+    · exact h0 ▸ hnonneg z
+    · refine le_of_mul_le_mul_left ?_ h0
+      refine (mul_self_le_mul_self h0.le hle).trans ?_
+      rw [← pow_two]
+      exact F.apply_sq_le_of_symm hnonneg hsymm _ z
+  -- Cauchy-Schwarz against the `k`-th coordinate vector bounds the `k`-th entry of `c`.
+  have hcoord : (c k : ℚ) ^ 2 ≤ F z z * ∑ k, F (u k) (u k) := by
+    calc (c k : ℚ) ^ 2 = (F (fun j ↦ (c j : ℚ)) (u k)) ^ 2 := by rw [hu k]
+      _ ≤ F (fun j ↦ (c j : ℚ)) (fun j ↦ (c j : ℚ)) * F (u k) (u k) :=
+          F.apply_sq_le_of_symm hnonneg hsymm _ (u k)
+      _ ≤ F z z * ∑ k, F (u k) (u k) := by
+          refine mul_le_mul hbound ?_ (hnonneg (u k)) (hnonneg z)
+          exact Finset.single_le_sum (fun j _ ↦ hnonneg (u j)) (Finset.mem_univ k)
+  have hck : (c k : ℚ) ≤ max 1 (F z z * ∑ k, F (u k) (u k)) := by
+    rcases le_or_gt (c k : ℚ) 1 with hsmall | hlarge
+    · exact hsmall.trans (le_max_left _ _)
+    · have hsq : (c k : ℚ) ≤ (c k : ℚ) ^ 2 := by nlinarith
+      exact (hsq.trans hcoord).trans (le_max_right _ _)
+  rw [Set.mem_Iic, ← Nat.cast_le (α := ℚ)]
+  exact hck.trans (Nat.le_ceil _)
+
+end IsFiniteType
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean
@@ -113,18 +113,16 @@ theorem finite_setOf_forall_sum_mul_le (h : IsFiniteType A) (y : B → ℤ) :
   -- Summing the inequalities against the nonnegative vector `c` gives `F x x ≤ F x z`.
   have hrow : ∀ i, (S *ᵥ fun j ↦ (c j : ℚ)) i = d i * ((∑ j, A i j * (c j : ℤ) : ℤ) : ℚ) := by
     intro i
-    have hexp : (S *ᵥ fun j ↦ (c j : ℚ)) i = ∑ j, d i * (A i j : ℚ) * (c j : ℚ) := rfl
-    rw [hexp]
+    rw [Matrix.mulVec_apply_eq_sum, hSdef]
+    simp only [Matrix.of_apply]
     push_cast
     rw [Finset.mul_sum]
     exact Finset.sum_congr rfl fun j _ ↦ by ring
   have hxz : F (fun j ↦ (c j : ℚ)) z = ∑ i, (c i : ℚ) * (d i * (y i : ℚ)) := by
-    rw [hFapply, hz]
-    rfl
+    rw [hFapply, hz, dotProduct]
   have hxx : F (fun j ↦ (c j : ℚ)) (fun j ↦ (c j : ℚ))
       = ∑ i, (c i : ℚ) * (S *ᵥ fun j ↦ (c j : ℚ)) i := by
-    rw [hFapply]
-    rfl
+    rw [hFapply, dotProduct]
   have hle : F (fun j ↦ (c j : ℚ)) (fun j ↦ (c j : ℚ)) ≤ F (fun j ↦ (c j : ℚ)) z := by
     rw [hxx, hxz]
     refine Finset.sum_le_sum fun i _ ↦ mul_le_mul_of_nonneg_left ?_ (by positivity)

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-import Mathlib.LinearAlgebra.Matrix.BilinearForm
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Basic
 
 public section
@@ -30,8 +29,8 @@ therefore finiteness of the set of dominant weights under `lam`, which is how
 
 ## Main results
 
-* `TauCeti.IsFiniteType.finite_setOf_forall_sum_mul_le`: **a finite-type Cartan inequality has
-  finitely many natural solutions.**
+* `TauCeti.finite_setOf_forall_sum_mul_le`: **an inequality whose matrix has a positive
+  symmetrizer has finitely many natural solutions.**
 
 ## The argument
 
@@ -65,21 +64,20 @@ open scoped Matrix
 
 namespace TauCeti
 
-namespace IsFiniteType
-
 variable {B : Type*} [Fintype B] {A : Matrix B B ℤ}
 
-/-- **A finite-type Cartan inequality has finitely many natural solutions.** For a finite-type
-integer matrix `A` and any integer vector `y`, only finitely many vectors `c` of natural numbers
-satisfy `∑ j, A i j * c j ≤ y i` at every index `i`.
+/-- **A positively symmetrized matrix inequality has finitely many natural solutions.** Let `d` be
+a positive rational vector such that the matrix with entries `d i * A i j` is positive definite.
+For any integer vector `y`, only finitely many vectors `c` of natural numbers satisfy
+`∑ j, A i j * c j ≤ y i` at every index `i`.
 
 Positive definiteness of the symmetrization of `A` is what makes the solution set bounded: the
 inequalities force the length of `c` in the symmetrized form to stay below a bound read off from
 `y` alone. -/
-theorem finite_setOf_forall_sum_mul_le (h : IsFiniteType A) (y : B → ℤ) :
+theorem finite_setOf_forall_sum_mul_le (d : B → ℚ) (hd : ∀ i, 0 < d i)
+    (hpd : (Matrix.of fun i j ↦ d i * (A i j : ℚ)).PosDef) (y : B → ℤ) :
     {c : B → ℕ | ∀ i, ∑ j, A i j * (c j : ℤ) ≤ y i}.Finite := by
   classical
-  obtain ⟨d, hd, hpd⟩ := h.exists_symmetrizer
   set S : Matrix B B ℚ := Matrix.of fun i j ↦ d i * (A i j : ℚ) with hSdef
   set F : LinearMap.BilinForm ℚ (B → ℚ) := Matrix.toBilin' S with hFdef
   have hFapply : ∀ u v : B → ℚ, F u v = u ⬝ᵥ S *ᵥ v := fun u v ↦ Matrix.toBilin'_apply' S u v
@@ -89,21 +87,29 @@ theorem finite_setOf_forall_sum_mul_le (h : IsFiniteType A) (y : B → ℤ) :
     simpa using hpd.isHermitian.apply p q
   have hnonneg : ∀ u : B → ℚ, 0 ≤ F u u := fun u ↦ by
     simpa [hFapply] using hpd.posSemidef.dotProduct_mulVec_nonneg u
-  have hsymm : LinearMap.IsSymm F := LinearMap.isSymm_def.mpr fun u v ↦ by
-    rw [RingHom.id_apply, hFapply, hFapply, Matrix.dotProduct_mulVec, ← Matrix.mulVec_transpose,
-      hST]
+  have hsymmB : F.IsSymm := LinearMap.BilinForm.isSymm_def.mpr fun u v ↦ by
+    rw [hFapply, hFapply, Matrix.dotProduct_mulVec, ← Matrix.mulVec_transpose, hST]
     exact dotProduct_comm _ _
-  -- Positive definiteness makes `S` invertible, so every functional is represented by the form.
-  have hsolve : ∀ w : B → ℚ, ∃ z : B → ℚ, S *ᵥ z = w := fun w ↦
-    ⟨S⁻¹ *ᵥ w, by
-      rw [Matrix.mulVec_mulVec, Matrix.mul_nonsing_inv S
-        ((Matrix.isUnit_iff_isUnit_det S).mp hpd.isUnit), Matrix.one_mulVec]⟩
-  obtain ⟨z, hz⟩ := hsolve fun i ↦ d i * (y i : ℚ)
-  have hdual : ∀ k : B, ∃ u : B → ℚ, ∀ x : B → ℚ, F x u = x k := by
-    intro k
-    obtain ⟨u, hu⟩ := hsolve (Pi.single k 1)
-    exact ⟨u, fun x ↦ by rw [hFapply, hu]; simp⟩
-  choose u hu using hdual
+  have hsymm : LinearMap.IsSymm F := LinearMap.BilinForm.isSymm_iff.mp hsymmB
+  -- Positive definiteness makes the form nondegenerate, so its duality equivalence represents the
+  -- weighted-sum functional and every coordinate functional.
+  have hFnondeg : F.Nondegenerate := by
+    rw [hFdef, Matrix.nondegenerate_toBilin'_iff, Matrix.nondegenerate_iff_det_ne_zero,
+      ← isUnit_iff_ne_zero, ← Matrix.isUnit_iff_isUnit_det]
+    exact hpd.isUnit
+  let weighted : Module.Dual ℚ (B → ℚ) :=
+    ∑ i, (d i * (y i : ℚ)) • LinearMap.proj i
+  let z : B → ℚ := (F.toDual hFnondeg).symm weighted
+  have hz : ∀ x : B → ℚ, F x z = ∑ i, x i * (d i * (y i : ℚ)) := by
+    intro x
+    rw [hsymmB.eq, LinearMap.BilinForm.apply_toDual_symm_apply]
+    simp only [weighted, LinearMap.sum_apply, LinearMap.smul_apply, smul_eq_mul,
+      LinearMap.proj_apply]
+    exact Finset.sum_congr rfl fun i _ ↦ by ring
+  let u : B → B → ℚ := fun k ↦ (F.toDual hFnondeg).symm (LinearMap.proj k)
+  have hu : ∀ (k : B) (x : B → ℚ), F x (u k) = x k := by
+    intro k x
+    rw [hsymmB.eq, LinearMap.BilinForm.apply_toDual_symm_apply, LinearMap.proj_apply]
   refine Set.Finite.subset
     (Set.Finite.pi fun _ : B ↦ Set.finite_Iic ⌈max 1 (F z z * ∑ k, F (u k) (u k))⌉₊)
     fun c hc ↦ ?_
@@ -119,7 +125,7 @@ theorem finite_setOf_forall_sum_mul_le (h : IsFiniteType A) (y : B → ℤ) :
     rw [Finset.mul_sum]
     exact Finset.sum_congr rfl fun j _ ↦ by ring
   have hxz : F (fun j ↦ (c j : ℚ)) z = ∑ i, (c i : ℚ) * (d i * (y i : ℚ)) := by
-    rw [hFapply, hz, dotProduct]
+    exact hz _
   have hxx : F (fun j ↦ (c j : ℚ)) (fun j ↦ (c j : ℚ))
       = ∑ i, (c i : ℚ) * (S *ᵥ fun j ↦ (c j : ℚ)) i := by
     rw [hFapply, dotProduct]
@@ -151,7 +157,5 @@ theorem finite_setOf_forall_sum_mul_le (h : IsFiniteType A) (y : B → ℤ) :
       exact (hsq.trans hcoord).trans (le_max_right _ _)
   rw [Set.mem_Iic, ← Nat.cast_le (α := ℚ)]
   exact hck.trans (Nat.le_ceil _)
-
-end IsFiniteType
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Matrix.BilinearForm
+import Mathlib.LinearAlgebra.Matrix.BilinearForm
 public import TauCeti.LinearAlgebra.RootSystem.FiniteType.Basic
 
 public section


### PR DESCRIPTION
This PR proves that an irreducible highest weight module of dominant integral highest weight has only finitely many weights, with no finiteness assumed of the module. Three facts about such a module are already on `main` and none of them presupposes finite-dimensionality: its weights lie in the cone `lam - Q⁺`, they take integer values on the simple coroots, and they are stable under the simple reflections. `TauCeti.finite_of_forall_reflection_mem_of_sub_mem_posRootCone` turns exactly that combination into finiteness at the level of root systems, and `TauCeti.finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector` feeds the three facts to it; the linearity restriction is removed at the end, since every weight of a highest weight module is `lam - ν` and hence linear.

The milestone is the **weight-cone bound** item of Layer 4, "the classification of finite-dimensional irreducibles", of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`: "The weight support of `L(λ)` is then stable under the whole Weyl group and bounded inside the convex hull of `W·λ` (a finite downward root cone), hence **finite**". This is the most effective current step because it is the half of Layer 4 that no open PR covers: #4464 extends reflection stability from a single simple reflection to the whole Weyl group and #4512 proves finite-dimensionality of the individual weight spaces, and both say in as many words that "the milestone still needs the finite-support deduction from the bounded Weyl orbit", which is what lands here. After this PR, Layer 4 needs only to combine this finite support with the per-weight-space bound to conclude `dim L(λ) < ∞` at dominant integral `λ`, and then to assemble the classification bijection.

The deduction is stated so that only stability under the *simple* reflections is needed, which is what merged #4325 already supplies; full Weyl stability is not an input. Its engine is a new statement about finite-type Cartan matrices in `TauCeti/LinearAlgebra/RootSystem/FiniteType/Bounded.lean` (86 lines of content): for a finite-type integer matrix `A` and any integer vector `y`, only finitely many vectors `c` of natural numbers satisfy `∑ j, A i j * c j ≤ y i` at every index. Writing a weight below `lam` as `lam - ∑ j, c j • αⱼ`, that inequality for the transposed Cartan matrix is exactly dominance, so the solution bound is the classical statement that only finitely many dominant weights lie below `lam` (Humphreys, GTM 9, §13.2, Lemma B). The proof runs entirely inside `ℚ`: positive definiteness of the symmetrized Cartan matrix `TauCeti.isFiniteType_cartanMatrix` makes it invertible, so the linear functional `c ↦ ∑ i, d i * y i * c i` and each coordinate functional are represented by the associated bilinear form, and two applications of Mathlib's Cauchy-Schwarz inequality for positive semidefinite symmetric forms (`LinearMap.BilinForm.apply_sq_le_of_symm`) bound first the length of `c` and then each of its entries. No compactness, completeness or eigenvalue theory is needed, which is what keeps the argument away from `ℝ`.

`TauCeti/LinearAlgebra/RootSystem/DominantCone.lean` (240 lines) carries the two root-system statements. `TauCeti.finite_setOf_dominant_sub_mem_posRootCone` is the dominant case above; the reflection-stable case reduces to it by raising: a member on which some simple coroot is negative is moved by that reflection to another member whose difference from `lam` has strictly smaller height, because the simple roots are linearly independent (`RootPairing.Base.linearIndepOn_root`) so the two coefficient vectors agree away from the reflecting index. Induction on that height writes every member as a Weyl translate of a dominant member, and `TauCeti.RootPairing.finite_weylGroup` closes the argument. `TauCeti/Algebra/Lie/HighestWeight/WeightSupport.lean` (99 lines) is the Lie-algebra corollary.

No Mathlib source and no supplementary snapshot material is vendored or adapted; Mathlib supplies the Cauchy-Schwarz inequality, the positive definite matrix API and the base of a root pairing, all used through their public interfaces. The mathematical route is the one in J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §13.2 and §21.2, as credited in the module documentation.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"weight-cone-bound"}-->

🤖 Prepared with Claude Code
