### PR TITLE
feat: real structures on a complex representation

### DIFF
--- a/TauCeti/LinearAlgebra/Complex/Conjugation.lean
+++ b/TauCeti/LinearAlgebra/Complex/Conjugation.lean
@@ -5,8 +5,11 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.LinearAlgebra.Basis.VectorSpace
 public import Mathlib.LinearAlgebra.Complex.Module
+public import Mathlib.LinearAlgebra.Dimension.Constructions
 public import Mathlib.LinearAlgebra.TensorProduct.Basis
+public import Mathlib.RingTheory.TensorProduct.Basic
 
 /-!
 # The real points of a conjugate-linear involution
@@ -19,36 +22,44 @@ theorem of this file is that `V` is the complexification of that subspace: the c
 `ℂ ⊗[ℝ] realPoints K → V`, `c ⊗ₜ w ↦ c • w`
 
 is a `ℂ`-linear isomorphism.  Conversely a complexification `ℂ ⊗[ℝ] W` carries the conjugation
-`c ⊗ₜ w ↦ conj c ⊗ₜ w`.  So each of the two constructions produces the other — a conjugation on
-`V` yields a presentation of `V` as a complexification, and every such presentation yields a
-conjugation — and in particular `V` admits a conjugation exactly when it is the complexification
-of a real vector space.  That is what makes conjugations the tool for realizing an object over
-`ℝ`.  The two constructions are not set up here as mutually inverse: a presentation carries a
-noncanonical choice of real carrier and isomorphism, which a conjugation does not.
+`c ⊗ₜ w ↦ conj c ⊗ₜ w` (`TauCeti.tmulConj`), whose real points are the image of `W`.  So each of
+the two constructions produces the other: a conjugation on `V` presents `V` as a complexification,
+and a complexification carries a conjugation.  That is what makes conjugations the tool for
+realizing an object over `ℝ`.
+
+The two constructions are not set up here as mutually inverse, and nothing here transports
+`TauCeti.tmulConj` along an isomorphism `ℂ ⊗[ℝ] W ≃ₗ[ℂ] V`: a presentation of `V` as a
+complexification carries a noncanonical choice of real carrier and isomorphism, which a conjugation
+does not.  The equivariant form of that transport is
+`Representation.IsRealForm.exists_isRealStructure`, downstream in
+`TauCeti.RepresentationTheory.RealForm`.
 
 Everything is stated for an arbitrary `V`; no finite-dimensionality is used anywhere.
 
 ## Main definitions
 
 * `TauCeti.realPoints`: the real points of a conjugate-linear map, as a `Submodule ℝ V`.
-* `TauCeti.conjRealPart` and `TauCeti.conjImagPart`: the two real points a vector decomposes into;
-  `TauCeti.conjRealPart_def` and `TauCeti.conjImagPart_def` are their defining formulas.
+* `TauCeti.conjRealPart` and `TauCeti.conjImaginaryPart`: the two real points a vector decomposes
+  into; `TauCeti.conjRealPart_def` and `TauCeti.conjImaginaryPart_def` are their defining formulas.
 * `TauCeti.realPointsLift`: the canonical `ℂ`-linear map `ℂ ⊗[ℝ] realPoints K →ₗ[ℂ] V`.
 * `TauCeti.realPointsEquiv`: that map as a `ℂ`-linear isomorphism, for involutive `K`.
 * `TauCeti.tmulConj`: the conjugation `c ⊗ₜ w ↦ conj c ⊗ₜ w` of a complexification `ℂ ⊗[ℝ] W`.
 
 ## Main statements
 
-* `TauCeti.conjRealPart_add_I_smul_conjImagPart`: the decomposition
-  `v = conjRealPart K v + I • conjImagPart K v`, which makes `TauCeti.realPointsLift` surjective.
+* `TauCeti.conjRealPart_add_I_smul_conjImaginaryPart`: the decomposition
+  `v = conjRealPart K v + I • conjImaginaryPart K v`, which makes `TauCeti.realPointsLift`
+  surjective.
 * `TauCeti.realPointsLift_injective`, `TauCeti.realPointsLift_surjective` and
   `TauCeti.realPointsEquiv`: **a complex vector space is the complexification of the real points of
   any conjugation on it.**
+* `TauCeti.finrank_realPoints`: the real points have the `ℝ`-dimension that `V` has over `ℂ`.
 * `TauCeti.exists_one_tmul_add_I_tmul`: every element of `ℂ ⊗[ℝ] W` is `1 ⊗ₜ w₁ + I ⊗ₜ w₂`; this
   is what makes the lift injective.
-* `TauCeti.tmulConj_involutive`, `TauCeti.tmulConj_tmul` and
-  `TauCeti.mem_realPoints_tmulConj_iff`: the conjugation of a complexification and its real
-  points.
+* `TauCeti.tmulConj_involutive`, `TauCeti.tmulConj_tmul` and `TauCeti.tmulConj_eq_self_iff`: the
+  conjugation of a complexification and its real points.
+* `TauCeti.tmulConj_baseChange`: that conjugation commutes with every base-changed map, which is
+  what makes it equivariant for a base-changed action.
 
 ## Implementation notes
 
@@ -60,8 +71,18 @@ would either duplicate it or invert the dependency between `TauCeti.LinearAlgebr
 fields.  For the same reason `TauCeti.realPoints` asks only for the semilinear map: the subspace
 makes sense without involutivity, and only the complexification theorem needs it.
 
+Mathlib's `realPart`/`imaginaryPart` decomposition of a star module over `ℂ` is the same
+mathematics, but it reads the conjugation off the `Star` *instance* on `V`: `selfAdjoint.submodule`
+and `realPart` both ask for `[StarAddMonoid V] [StarModule ℂ V]`, and `StarAddMonoid` already
+carries involutivity.  Here the conjugation is instead a term `K` that `TauCeti.realPoints` and
+`TauCeti.conjRealPart` are indexed by, because one `V` carries many conjugations and
+`TauCeti.realPoints` is wanted before `K` is known to be involutive -- `TauCeti.realPointsLift` is
+injective for every conjugate-linear `K`.  So the instance-borne spelling is not available here,
+and a `TauCeti.Hodge.Conjugation`, or a `Representation.IsRealStructure`, hands its conjugation
+over as a field rather than as an instance.
+
 No definition here exposes its body: `TauCeti.mem_realPoints`, `TauCeti.conjRealPart_def`,
-`TauCeti.conjImagPart_def`, `TauCeti.realPointsLift_tmul`, `TauCeti.realPointsEquiv_tmul`,
+`TauCeti.conjImaginaryPart_def`, `TauCeti.realPointsLift_tmul`, `TauCeti.realPointsEquiv_tmul`,
 `TauCeti.realPointsEquiv_symm_apply` and `TauCeti.tmulConj_tmul` are the characterizations a
 consumer works from.
 
@@ -77,6 +98,8 @@ so `r • v` and `(r : ℂ) • v` are definitionally equal and no scalar tower 
 public section
 
 open scoped TensorProduct
+
+open Module (finrank)
 
 namespace TauCeti
 
@@ -103,11 +126,11 @@ theorem mem_realPoints {K : V →ₛₗ[starRingEnd ℂ] V} {v : V} :
 
 variable {K : V →ₛₗ[starRingEnd ℂ] V}
 
-theorem add_conj_mem_realPoints (hK : Function.Involutive K) (v : V) :
+private theorem add_conj_mem_realPoints (hK : Function.Involutive K) (v : V) :
     v + K v ∈ realPoints K := by
   rw [mem_realPoints, map_add, hK v, add_comm]
 
-theorem I_smul_sub_conj_mem_realPoints (hK : Function.Involutive K) (v : V) :
+private theorem I_smul_conj_sub_mem_realPoints (hK : Function.Involutive K) (v : V) :
     Complex.I • (K v - v) ∈ realPoints K := by
   rw [mem_realPoints, map_smulₛₗ, map_sub, hK v, Complex.conj_I, neg_smul, ← smul_neg, neg_sub]
 
@@ -118,35 +141,50 @@ noncomputable def conjRealPart (v : V) : V := (2⁻¹ : ℝ) • (v + K v)
 
 variable (K) in
 /-- The **imaginary part** of `v` relative to a conjugate-linear map: the vector
-`½ I • (K v - v)`, the coefficient of `I` in `TauCeti.conjRealPart_add_I_smul_conjImagPart`. -/
-noncomputable def conjImagPart (v : V) : V := (2⁻¹ : ℝ) • (Complex.I • (K v - v))
+`½ I • (K v - v)`, the coefficient of `I` in
+`TauCeti.conjRealPart_add_I_smul_conjImaginaryPart`. -/
+noncomputable def conjImaginaryPart (v : V) : V := (2⁻¹ : ℝ) • (Complex.I • (K v - v))
 
 /-- The defining formula for the real part, the body of `TauCeti.conjRealPart` not being exposed. -/
 theorem conjRealPart_def (v : V) : conjRealPart K v = (2⁻¹ : ℝ) • (v + K v) := (rfl)
 
-/-- The defining formula for the imaginary part, the body of `TauCeti.conjImagPart` not being
+/-- The defining formula for the imaginary part, the body of `TauCeti.conjImaginaryPart` not being
 exposed. -/
-theorem conjImagPart_def (v : V) :
-    conjImagPart K v = (2⁻¹ : ℝ) • (Complex.I • (K v - v)) := (rfl)
+theorem conjImaginaryPart_def (v : V) :
+    conjImaginaryPart K v = (2⁻¹ : ℝ) • (Complex.I • (K v - v)) := (rfl)
 
 theorem conjRealPart_mem (hK : Function.Involutive K) (v : V) : conjRealPart K v ∈ realPoints K :=
   Submodule.smul_mem _ _ (add_conj_mem_realPoints hK v)
 
-theorem conjImagPart_mem (hK : Function.Involutive K) (v : V) : conjImagPart K v ∈ realPoints K :=
-  Submodule.smul_mem _ _ (I_smul_sub_conj_mem_realPoints hK v)
+theorem conjImaginaryPart_mem (hK : Function.Involutive K) (v : V) :
+    conjImaginaryPart K v ∈ realPoints K :=
+  Submodule.smul_mem _ _ (I_smul_conj_sub_mem_realPoints hK v)
+
+/-- A real point is its own real part. -/
+@[simp]
+theorem conjRealPart_of_mem {v : V} (hv : v ∈ realPoints K) : conjRealPart K v = v := by
+  rw [mem_realPoints] at hv
+  rw [conjRealPart_def, hv, ← two_smul ℝ v, smul_smul]
+  norm_num
+
+/-- A real point has vanishing imaginary part. -/
+@[simp]
+theorem conjImaginaryPart_of_mem {v : V} (hv : v ∈ realPoints K) : conjImaginaryPart K v = 0 := by
+  rw [mem_realPoints] at hv
+  rw [conjImaginaryPart_def, hv, sub_self, smul_zero, smul_zero]
 
 /-- **The decomposition into real points**: every vector is its real part plus `I` times its
 imaginary part.  Once `K` is involutive both summands lie in `TauCeti.realPoints K`, so this is
 what exhibits `V` as the complexification of that subspace. -/
-theorem conjRealPart_add_I_smul_conjImagPart (v : V) :
-    conjRealPart K v + Complex.I • conjImagPart K v = v := by
+theorem conjRealPart_add_I_smul_conjImaginaryPart (v : V) :
+    conjRealPart K v + Complex.I • conjImaginaryPart K v = v := by
   have hI : Complex.I • (Complex.I • (K v - v)) = v - K v := by
     rw [smul_smul, Complex.I_mul_I, neg_one_smul, neg_sub]
   have hsum : (v + K v) + (v - K v) = (2 : ℝ) • v := by
     rw [two_smul]
     abel
-  rw [conjRealPart_def, conjImagPart_def, smul_comm Complex.I ((2⁻¹ : ℝ)), hI, ← smul_add, hsum,
-    smul_smul]
+  rw [conjRealPart_def, conjImaginaryPart_def, smul_comm Complex.I ((2⁻¹ : ℝ)), hI, ← smul_add,
+    hsum, smul_smul]
   norm_num
 
 /-! ### A complexification splits along `1` and `I` -/
@@ -165,24 +203,24 @@ theorem exists_one_tmul_add_I_tmul {W : Type*} [AddCommGroup W] [Module ℝ W] (
 
 variable (K) in
 /-- The canonical `ℂ`-linear map from the complexification of the real points, `c ⊗ₜ w ↦ c • w`.
+It is `LinearMap.liftBaseChange` applied to the inclusion of the real points.
 `TauCeti.realPointsEquiv` upgrades it to an isomorphism when `K` is involutive. -/
 noncomputable def realPointsLift : ℂ ⊗[ℝ] realPoints K →ₗ[ℂ] V :=
-  TensorProduct.AlgebraTensorModule.lift
-    (LinearMap.toSpanSingleton ℂ (realPoints K →ₗ[ℝ] V) (realPoints K).subtype)
+  (realPoints K).subtype.liftBaseChange ℂ
 
 @[simp]
 theorem realPointsLift_tmul (c : ℂ) (w : realPoints K) :
-    realPointsLift K (c ⊗ₜ[ℝ] w) = c • (w : V) := by
-  simp [realPointsLift]
+    realPointsLift K (c ⊗ₜ[ℝ] w) = c • (w : V) :=
+  (rfl)
 
 /-- The lift is surjective once `K` is involutive: `v` is hit by
-`1 ⊗ₜ conjRealPart K v + I ⊗ₜ conjImagPart K v`. -/
+`1 ⊗ₜ conjRealPart K v + I ⊗ₜ conjImaginaryPart K v`. -/
 theorem realPointsLift_surjective (hK : Function.Involutive K) :
     Function.Surjective (realPointsLift K) := fun v =>
   ⟨1 ⊗ₜ[ℝ] ⟨conjRealPart K v, conjRealPart_mem hK v⟩ +
-      Complex.I ⊗ₜ[ℝ] ⟨conjImagPart K v, conjImagPart_mem hK v⟩, by
+      Complex.I ⊗ₜ[ℝ] ⟨conjImaginaryPart K v, conjImaginaryPart_mem hK v⟩, by
     rw [map_add, realPointsLift_tmul, realPointsLift_tmul, one_smul]
-    exact conjRealPart_add_I_smul_conjImagPart v⟩
+    exact conjRealPart_add_I_smul_conjImaginaryPart v⟩
 
 /-- The lift is injective for **any** conjugate-linear `K`: only its surjectivity uses that `K` is
 involutive. -/
@@ -202,20 +240,19 @@ theorem realPointsLift_injective : Function.Injective (realPointsLift K) := by
       rw [two_smul]
       abel
     rw [hu, hconj, add_zero] at h2
-    have := congrArg (fun x : V => (2 : ℂ)⁻¹ • x) h2
-    simpa [smul_smul] using this.symm
+    -- `(2 : ℂ) • w₁ = 0` forces `w₁ = 0`: `smul_eq_zero` and `2 ≠ 0`.
+    simpa using h2.symm
   have h₂ : (w₂ : V) = 0 := by
     have hI : Complex.I • (w₂ : V) = 0 := by rw [← hu, h₁, zero_add]
-    have := congrArg (fun x : V => Complex.I⁻¹ • x) hI
-    simpa [smul_smul, inv_mul_cancel₀ Complex.I_ne_zero] using this
+    simpa using hI
   rw [Submodule.coe_eq_zero] at h₁ h₂
   rw [h₁, h₂]
   simp
 
 /-- **A complex vector space is the complexification of the real points of any conjugation on
 it.**  The isomorphism is `c ⊗ₜ w ↦ c • w`; surjectivity is the decomposition
-`TauCeti.conjRealPart_add_I_smul_conjImagPart`, and injectivity is that a relation `w₁ + I • w₂ = 0`
-between real points is killed by adding and subtracting its conjugate. -/
+`TauCeti.conjRealPart_add_I_smul_conjImaginaryPart`, and injectivity is that a relation
+`w₁ + I • w₂ = 0` between real points is killed by adding and subtracting its conjugate. -/
 noncomputable def realPointsEquiv (hK : Function.Involutive K) :
     ℂ ⊗[ℝ] realPoints K ≃ₗ[ℂ] V :=
   LinearEquiv.ofBijective (realPointsLift K)
@@ -228,14 +265,22 @@ theorem realPointsEquiv_tmul (hK : Function.Involutive K) (c : ℂ) (w : realPoi
   realPointsLift_tmul c w
 
 /-- The inverse of the isomorphism is the decomposition into real and imaginary parts:
-`v ↦ 1 ⊗ₜ conjRealPart K v + I ⊗ₜ conjImagPart K v`. -/
+`v ↦ 1 ⊗ₜ conjRealPart K v + I ⊗ₜ conjImaginaryPart K v`. -/
 @[simp]
 theorem realPointsEquiv_symm_apply (hK : Function.Involutive K) (v : V) :
     (realPointsEquiv hK).symm v =
       1 ⊗ₜ[ℝ] (⟨conjRealPart K v, conjRealPart_mem hK v⟩ : realPoints K) +
-        Complex.I ⊗ₜ[ℝ] (⟨conjImagPart K v, conjImagPart_mem hK v⟩ : realPoints K) := by
+        Complex.I ⊗ₜ[ℝ] (⟨conjImaginaryPart K v, conjImaginaryPart_mem hK v⟩ : realPoints K) := by
   rw [LinearEquiv.symm_apply_eq, map_add, realPointsEquiv_tmul, realPointsEquiv_tmul, one_smul]
-  exact (conjRealPart_add_I_smul_conjImagPart v).symm
+  exact (conjRealPart_add_I_smul_conjImaginaryPart v).symm
+
+/-- **The real points of a conjugation halve the dimension**: their `ℝ`-dimension is the
+`ℂ`-dimension of `V`, because `V` is their complexification and base change does not change the
+dimension.  No finiteness is assumed: in the infinite-dimensional case both sides are the junk
+value `0`. -/
+theorem finrank_realPoints (hK : Function.Involutive K) :
+    finrank ℝ (realPoints K) = finrank ℂ V := by
+  rw [← (realPointsEquiv hK).finrank_eq, Module.finrank_baseChange]
 
 /-! ### The conjugation of a complexification -/
 
@@ -244,19 +289,20 @@ section Complexification
 variable (W : Type*) [AddCommGroup W] [Module ℝ W]
 
 /-- The **conjugation of a complexification**: `c ⊗ₜ w ↦ conj c ⊗ₜ w`, conjugate-linear because
-conjugation is `ℝ`-linear and multiplicative on `ℂ`.  This is the construction converse to
+conjugation is `ℝ`-linear and multiplicative on `ℂ`.  The underlying `ℝ`-linear map is
+`LinearMap.rTensor W Complex.conjAe.toLinearMap`.  This is the construction converse to
 `TauCeti.realPointsEquiv`: it turns a presentation of a space as a complexification into a
 conjugation on it. -/
 noncomputable def tmulConj : (ℂ ⊗[ℝ] W) →ₛₗ[starRingEnd ℂ] (ℂ ⊗[ℝ] W) where
-  toFun := TensorProduct.lift ((TensorProduct.mk ℝ ℂ W).comp Complex.conjAe.toLinearMap)
+  toFun := LinearMap.rTensor W Complex.conjAe.toLinearMap
   map_add' := map_add _
   map_smul' c u := by
     induction u with
     | zero => simp
     | tmul c' w =>
-      simp only [TensorProduct.smul_tmul', smul_eq_mul, TensorProduct.lift.tmul,
-        LinearMap.coe_comp, Function.comp_apply, AlgEquiv.toLinearMap_apply,
-        Complex.conjAe_coe, TensorProduct.mk_apply, map_mul]
+      rw [TensorProduct.smul_tmul', smul_eq_mul, LinearMap.rTensor_tmul, LinearMap.rTensor_tmul,
+        TensorProduct.smul_tmul', smul_eq_mul]
+      simp only [AlgEquiv.toLinearMap_apply, Complex.conjAe_coe, map_mul]
     | add u₁ u₂ h₁ h₂ => rw [smul_add, map_add, map_add, h₁, h₂, smul_add]
 
 /-- The conjugation of a complexification conjugates the scalar and leaves the vector alone. -/
@@ -265,22 +311,30 @@ theorem tmulConj_tmul (c : ℂ) (w : W) :
     tmulConj W (c ⊗ₜ[ℝ] w) = (starRingEnd ℂ) c ⊗ₜ[ℝ] w :=
   (rfl)
 
-/-- The conjugation of a complexification is involutive, so it is a conjugation in the sense of
-this file. -/
-theorem tmulConj_involutive : Function.Involutive (tmulConj W) := by
-  intro u
+/-- Conjugating twice is the identity, in the applied form `simp` can use.  The proof is an
+induction on the tensor, run off the characterization `TauCeti.tmulConj_tmul` rather than the
+unexposed body. -/
+@[simp]
+theorem tmulConj_tmulConj (u : ℂ ⊗[ℝ] W) : tmulConj W (tmulConj W u) = u := by
   induction u with
   | zero => simp
   | tmul c w => simp
   | add u₁ u₂ h₁ h₂ => rw [map_add, map_add, h₁, h₂]
 
-/-- The real points of the conjugation of a complexification are exactly the image of `W`, that
-is, the elements `1 ⊗ₜ w`. -/
-theorem mem_realPoints_tmulConj_iff (u : ℂ ⊗[ℝ] W) :
-    u ∈ realPoints (tmulConj W) ↔ ∃ w : W, u = 1 ⊗ₜ[ℝ] w := by
+/-- The conjugation of a complexification is involutive, so it is a conjugation in the sense of
+this file. -/
+theorem tmulConj_involutive : Function.Involutive (tmulConj W) :=
+  tmulConj_tmulConj W
+
+/-- The vectors the conjugation of a complexification fixes are exactly the image of `W`, that is,
+the elements `1 ⊗ₜ w`.  Stated on `tmulConj W u = u` rather than on `u ∈ realPoints (tmulConj W)`
+because `TauCeti.mem_realPoints` is the simp normal form of the latter. -/
+@[simp]
+theorem tmulConj_eq_self_iff (u : ℂ ⊗[ℝ] W) :
+    tmulConj W u = u ↔ ∃ w : W, u = 1 ⊗ₜ[ℝ] w := by
   refine ⟨fun hu => ?_, ?_⟩
   · obtain ⟨w₁, w₂, rfl⟩ := exists_one_tmul_add_I_tmul u
-    rw [mem_realPoints, map_add, tmulConj_tmul, tmulConj_tmul, map_one, Complex.conj_I] at hu
+    rw [map_add, tmulConj_tmul, tmulConj_tmul, map_one, Complex.conj_I] at hu
     refine ⟨w₁, ?_⟩
     have hc : -(Complex.I ⊗ₜ[ℝ] w₂) = Complex.I ⊗ₜ[ℝ] w₂ := by
       rw [← TensorProduct.neg_tmul]
@@ -289,12 +343,11 @@ theorem mem_realPoints_tmulConj_iff (u : ℂ ⊗[ℝ] W) :
       rw [two_smul]
       nth_rewrite 1 [← hc]
       abel
-    have h₂ : Complex.I ⊗ₜ[ℝ] w₂ = (0 : ℂ ⊗[ℝ] W) := by
-      have := congrArg (fun x : ℂ ⊗[ℝ] W => (2⁻¹ : ℝ) • x) h
-      simpa [smul_smul] using this
+    -- `(2 : ℝ) • x = 0` forces `x = 0`: `smul_eq_zero` and `2 ≠ 0`.
+    have h₂ : Complex.I ⊗ₜ[ℝ] w₂ = (0 : ℂ ⊗[ℝ] W) := by simpa using h
     rw [h₂, add_zero]
   · rintro ⟨w, rfl⟩
-    rw [mem_realPoints, tmulConj_tmul, map_one]
+    rw [tmulConj_tmul, map_one]
 
 end Complexification
 

--- a/TauCeti/LinearAlgebra/Complex/Conjugation.lean
+++ b/TauCeti/LinearAlgebra/Complex/Conjugation.lean
@@ -1,0 +1,289 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Complex.Module
+public import Mathlib.LinearAlgebra.TensorProduct.Tower
+
+/-!
+# The real points of a conjugate-linear involution
+
+A **conjugation** of a complex vector space `V` is a conjugate-linear map `K : V → V` with
+`K ∘ K = id`, that is, a `starRingEnd ℂ`-semilinear self-map that is involutive.  Its **real
+points** are the vectors it fixes.  They form a real subspace `TauCeti.realPoints K`, and the main
+theorem of this file is that `V` is the complexification of that subspace: the canonical map
+
+`ℂ ⊗[ℝ] realPoints K → V`, `c ⊗ₜ w ↦ c • w`
+
+is a `ℂ`-linear isomorphism.  Conversely a complexification `ℂ ⊗[ℝ] W` carries the conjugation
+`c ⊗ₜ w ↦ conj c ⊗ₜ w`.  So a conjugation on `V` is the same data as a presentation of `V` as the
+complexification of a real vector space, which is what makes conjugations the tool for realizing
+an object over `ℝ`.
+
+Everything is stated for an arbitrary `V`; no finite-dimensionality is used anywhere.
+
+## Main definitions
+
+* `TauCeti.realPoints`: the real points of a conjugate-linear map, as a `Submodule ℝ V`.
+* `TauCeti.conjRealPart` and `TauCeti.conjImagPart`: the two real points a vector decomposes into.
+* `TauCeti.realPointsLift`: the canonical `ℂ`-linear map `ℂ ⊗[ℝ] realPoints K →ₗ[ℂ] V`.
+* `TauCeti.realPointsEquiv`: that map as a `ℂ`-linear isomorphism, for involutive `K`.
+* `TauCeti.tmulConj`: the conjugation `c ⊗ₜ w ↦ conj c ⊗ₜ w` of a complexification `ℂ ⊗[ℝ] W`.
+
+## Main statements
+
+* `TauCeti.conjRealPart_add_I_smul_conjImagPart`: the decomposition
+  `v = conjRealPart K v + I • conjImagPart K v`, which makes `TauCeti.realPointsLift` surjective.
+* `TauCeti.realPointsLift_bijective` and `TauCeti.realPointsEquiv`: **a complex vector space is the
+  complexification of the real points of any conjugation on it.**
+* `TauCeti.exists_one_tmul_add_I_tmul`: every element of `ℂ ⊗[ℝ] W` is `1 ⊗ₜ w₁ + I ⊗ₜ w₂`; this
+  is what makes the lift injective.
+* `TauCeti.tmulConj_involutive`, `TauCeti.tmulConj_tmul` and
+  `TauCeti.mem_realPoints_tmulConj_iff`: the conjugation of a complexification and its real
+  points.
+
+## Implementation notes
+
+A conjugation is carried here as the two unbundled hypotheses `K : V →ₛₗ[starRingEnd ℂ] V` and
+`Function.Involutive K`, rather than as a bundled structure.  `TauCeti.Hodge.Conjugation` already
+bundles exactly this data, but it lives downstream in `TauCeti/Geometry/Hodge/`, so bundling here
+would either duplicate it or invert the dependency between `TauCeti.LinearAlgebra` and
+`TauCeti.Geometry`; a `TauCeti.Hodge.Conjugation` supplies the hypotheses below from its two
+fields.  For the same reason `TauCeti.realPoints` asks only for the semilinear map: the subspace
+makes sense without involutivity, and only the complexification theorem needs it.
+
+The real scalar structure on `V` is Mathlib's `Module.complexToReal`, the one `Module ℂ V` induces,
+so `r • v` and `(r : ℂ) • v` are definitionally equal and no scalar tower hypothesis is carried.
+
+## References
+
+* J.-P. Serre, *Linear Representations of Finite Groups*, GTM 42 (1977), §13.2, where the
+  conjugation attached to an invariant form realizes a representation over `ℝ`.
+-/
+
+@[expose] public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+variable {V : Type*} [AddCommGroup V] [Module ℂ V]
+
+/-! ### The real points of a conjugate-linear map -/
+
+/-- The **real points** of a conjugate-linear map `K : V → V`: the vectors `K` fixes.  They form a
+subspace over `ℝ` but not over `ℂ`, since `K (c • v) = conj c • K v`. -/
+def realPoints (K : V →ₛₗ[starRingEnd ℂ] V) : Submodule ℝ V where
+  carrier := {v | K v = v}
+  add_mem' {v w} hv hw := by
+    change K v = v at hv
+    change K w = w at hw
+    change K (v + w) = v + w
+    rw [map_add, hv, hw]
+  zero_mem' := map_zero K
+  smul_mem' r v hv := by
+    change K v = v at hv
+    change K ((r : ℂ) • v) = (r : ℂ) • v
+    rw [map_smulₛₗ, Complex.conj_ofReal, hv]
+
+@[simp]
+theorem mem_realPoints {K : V →ₛₗ[starRingEnd ℂ] V} {v : V} :
+    v ∈ realPoints K ↔ K v = v :=
+  Iff.rfl
+
+variable {K : V →ₛₗ[starRingEnd ℂ] V}
+
+theorem add_conj_mem_realPoints (hK : Function.Involutive K) (v : V) :
+    v + K v ∈ realPoints K := by
+  rw [mem_realPoints, map_add, hK v, add_comm]
+
+theorem I_smul_sub_conj_mem_realPoints (hK : Function.Involutive K) (v : V) :
+    Complex.I • (K v - v) ∈ realPoints K := by
+  rw [mem_realPoints, map_smulₛₗ, map_sub, hK v, Complex.conj_I, neg_smul, ← smul_neg, neg_sub]
+
+variable (K) in
+/-- The **real part** of `v` relative to a conjugate-linear map: the vector `½ (v + K v)`, a real
+point once `K` is involutive (`TauCeti.conjRealPart_mem`). -/
+noncomputable def conjRealPart (v : V) : V := (2⁻¹ : ℝ) • (v + K v)
+
+variable (K) in
+/-- The **imaginary part** of `v` relative to a conjugate-linear map: the vector
+`½ I • (K v - v)`, the coefficient of `I` in `TauCeti.conjRealPart_add_I_smul_conjImagPart`. -/
+noncomputable def conjImagPart (v : V) : V := (2⁻¹ : ℝ) • (Complex.I • (K v - v))
+
+theorem conjRealPart_mem (hK : Function.Involutive K) (v : V) : conjRealPart K v ∈ realPoints K :=
+  Submodule.smul_mem _ _ (add_conj_mem_realPoints hK v)
+
+theorem conjImagPart_mem (hK : Function.Involutive K) (v : V) : conjImagPart K v ∈ realPoints K :=
+  Submodule.smul_mem _ _ (I_smul_sub_conj_mem_realPoints hK v)
+
+/-- **The decomposition into real points**: every vector is its real part plus `I` times its
+imaginary part.  Once `K` is involutive both summands lie in `TauCeti.realPoints K`, so this is
+what exhibits `V` as the complexification of that subspace. -/
+theorem conjRealPart_add_I_smul_conjImagPart (v : V) :
+    conjRealPart K v + Complex.I • conjImagPart K v = v := by
+  have hI : Complex.I • (Complex.I • (K v - v)) = v - K v := by
+    rw [smul_smul, Complex.I_mul_I, neg_one_smul, neg_sub]
+  have hsum : (v + K v) + (v - K v) = (2 : ℝ) • v := by
+    rw [two_smul]
+    abel
+  rw [conjRealPart, conjImagPart, smul_comm Complex.I ((2⁻¹ : ℝ)), hI, ← smul_add, hsum, smul_smul]
+  norm_num
+
+/-! ### A complexification splits along `1` and `I` -/
+
+/-- **Every element of `ℂ ⊗[ℝ] W` is `1 ⊗ₜ w₁ + I ⊗ₜ w₂`**: writing a complex scalar as
+`x + y * I` with `x, y : ℝ` moves its two real coordinates into the second factor.  This is the
+splitting `ℂ ⊗[ℝ] W ≅ W ⊕ I · W` in the form the injectivity argument below uses it. -/
+theorem exists_one_tmul_add_I_tmul {W : Type*} [AddCommGroup W] [Module ℝ W] (u : ℂ ⊗[ℝ] W) :
+    ∃ w₁ w₂ : W, u = 1 ⊗ₜ[ℝ] w₁ + Complex.I ⊗ₜ[ℝ] w₂ := by
+  induction u with
+  | zero => exact ⟨0, 0, by simp⟩
+  | tmul c w =>
+    refine ⟨c.re • w, c.im • w, ?_⟩
+    rw [← TensorProduct.smul_tmul, ← TensorProduct.smul_tmul, ← TensorProduct.add_tmul]
+    congr 1
+    simp only [Complex.real_smul, mul_one]
+    exact (Complex.re_add_im c).symm
+  | add u₁ u₂ h₁ h₂ =>
+    obtain ⟨a₁, b₁, rfl⟩ := h₁
+    obtain ⟨a₂, b₂, rfl⟩ := h₂
+    exact ⟨a₁ + a₂, b₁ + b₂, by rw [TensorProduct.tmul_add, TensorProduct.tmul_add]; abel⟩
+
+/-! ### The complexification of the real points -/
+
+variable (K) in
+/-- The canonical `ℂ`-linear map from the complexification of the real points, `c ⊗ₜ w ↦ c • w`.
+`TauCeti.realPointsEquiv` upgrades it to an isomorphism when `K` is involutive. -/
+noncomputable def realPointsLift : ℂ ⊗[ℝ] realPoints K →ₗ[ℂ] V :=
+  TensorProduct.AlgebraTensorModule.lift
+    (LinearMap.toSpanSingleton ℂ (realPoints K →ₗ[ℝ] V) (realPoints K).subtype)
+
+@[simp]
+theorem realPointsLift_tmul (c : ℂ) (w : realPoints K) :
+    realPointsLift K (c ⊗ₜ[ℝ] w) = c • (w : V) := by
+  simp [realPointsLift]
+
+theorem realPointsLift_surjective (hK : Function.Involutive K) :
+    Function.Surjective (realPointsLift K) := fun v =>
+  ⟨1 ⊗ₜ[ℝ] ⟨conjRealPart K v, conjRealPart_mem hK v⟩ +
+      Complex.I ⊗ₜ[ℝ] ⟨conjImagPart K v, conjImagPart_mem hK v⟩, by
+    rw [map_add, realPointsLift_tmul, realPointsLift_tmul, one_smul]
+    exact conjRealPart_add_I_smul_conjImagPart v⟩
+
+/-- The lift is injective for **any** conjugate-linear `K`: only the surjectivity below uses that
+`K` is involutive. -/
+theorem realPointsLift_injective : Function.Injective (realPointsLift K) := by
+  rw [injective_iff_map_eq_zero]
+  intro u hu
+  obtain ⟨w₁, w₂, rfl⟩ := exists_one_tmul_add_I_tmul u
+  rw [map_add, realPointsLift_tmul, realPointsLift_tmul, one_smul] at hu
+  -- Applying `K` flips the sign of the `I`-component, so both components vanish.
+  have hconj : (w₁ : V) - Complex.I • (w₂ : V) = 0 := by
+    have h := congrArg K hu
+    rwa [map_add, map_smulₛₗ, Complex.conj_I, neg_smul, ← sub_eq_add_neg, w₁.2, w₂.2,
+      map_zero] at h
+  have h₁ : (w₁ : V) = 0 := by
+    have h2 : ((w₁ : V) + Complex.I • (w₂ : V)) + ((w₁ : V) - Complex.I • (w₂ : V))
+        = (2 : ℂ) • (w₁ : V) := by
+      rw [two_smul]
+      abel
+    rw [hu, hconj, add_zero] at h2
+    have := congrArg (fun x : V => (2 : ℂ)⁻¹ • x) h2
+    simpa [smul_smul] using this.symm
+  have h₂ : (w₂ : V) = 0 := by
+    have hI : Complex.I • (w₂ : V) = 0 := by rw [← hu, h₁, zero_add]
+    have := congrArg (fun x : V => Complex.I⁻¹ • x) hI
+    simpa [smul_smul, inv_mul_cancel₀ Complex.I_ne_zero] using this
+  rw [Submodule.coe_eq_zero] at h₁ h₂
+  rw [h₁, h₂]
+  simp
+
+theorem realPointsLift_bijective (hK : Function.Involutive K) :
+    Function.Bijective (realPointsLift K) :=
+  ⟨realPointsLift_injective, realPointsLift_surjective hK⟩
+
+/-- **A complex vector space is the complexification of the real points of any conjugation on
+it.**  The isomorphism is `c ⊗ₜ w ↦ c • w`; surjectivity is the decomposition
+`TauCeti.conjRealPart_add_I_smul_conjImagPart`, and injectivity is that a relation `w₁ + I • w₂ = 0`
+between real points is killed by adding and subtracting its conjugate. -/
+noncomputable def realPointsEquiv (hK : Function.Involutive K) :
+    ℂ ⊗[ℝ] realPoints K ≃ₗ[ℂ] V :=
+  LinearEquiv.ofBijective (realPointsLift K) (realPointsLift_bijective hK)
+
+@[simp]
+theorem realPointsEquiv_tmul (hK : Function.Involutive K) (c : ℂ) (w : realPoints K) :
+    realPointsEquiv hK (c ⊗ₜ[ℝ] w) = c • (w : V) :=
+  realPointsLift_tmul c w
+
+/-! ### The conjugation of a complexification -/
+
+section Complexification
+
+variable (W : Type*) [AddCommGroup W] [Module ℝ W]
+
+/-- The **conjugation of a complexification**: `c ⊗ₜ w ↦ conj c ⊗ₜ w`, conjugate-linear because
+conjugation is `ℝ`-linear and multiplicative on `ℂ`.  Together with `TauCeti.realPointsEquiv` it
+makes conjugations on `V` and presentations of `V` as a complexification the same data. -/
+noncomputable def tmulConj : (ℂ ⊗[ℝ] W) →ₛₗ[starRingEnd ℂ] (ℂ ⊗[ℝ] W) where
+  toFun := TensorProduct.lift ((TensorProduct.mk ℝ ℂ W).comp Complex.conjAe.toLinearMap)
+  map_add' := map_add _
+  map_smul' c u := by
+    induction u with
+    | zero => simp
+    | tmul c' w =>
+      simp only [TensorProduct.smul_tmul', smul_eq_mul, TensorProduct.lift.tmul,
+        LinearMap.coe_comp, Function.comp_apply, AlgEquiv.toLinearMap_apply,
+        Complex.conjAe_coe, TensorProduct.mk_apply, map_mul]
+    | add u₁ u₂ h₁ h₂ => rw [smul_add, map_add, map_add, h₁, h₂, smul_add]
+
+@[simp]
+theorem tmulConj_tmul (c : ℂ) (w : W) :
+    tmulConj W (c ⊗ₜ[ℝ] w) = (starRingEnd ℂ) c ⊗ₜ[ℝ] w :=
+  rfl
+
+theorem tmulConj_involutive : Function.Involutive (tmulConj W) := by
+  intro u
+  induction u with
+  | zero => simp
+  | tmul c w => simp
+  | add u₁ u₂ h₁ h₂ => rw [map_add, map_add, h₁, h₂]
+
+/-- The real points of the conjugation of a complexification are exactly the image of `W`, that
+is, the elements `1 ⊗ₜ w`. -/
+theorem mem_realPoints_tmulConj_iff (u : ℂ ⊗[ℝ] W) :
+    u ∈ realPoints (tmulConj W) ↔ ∃ w : W, u = 1 ⊗ₜ[ℝ] w := by
+  refine ⟨fun hu => ?_, ?_⟩
+  · obtain ⟨w₁, w₂, rfl⟩ := exists_one_tmul_add_I_tmul u
+    rw [mem_realPoints, map_add, tmulConj_tmul, tmulConj_tmul, map_one, Complex.conj_I] at hu
+    refine ⟨w₁, ?_⟩
+    have hc : -(Complex.I ⊗ₜ[ℝ] w₂) = Complex.I ⊗ₜ[ℝ] w₂ := by
+      rw [← TensorProduct.neg_tmul]
+      exact add_left_cancel hu
+    have h : (2 : ℝ) • (Complex.I ⊗ₜ[ℝ] w₂) = (0 : ℂ ⊗[ℝ] W) := by
+      rw [two_smul]
+      nth_rewrite 1 [← hc]
+      abel
+    have h₂ : Complex.I ⊗ₜ[ℝ] w₂ = (0 : ℂ ⊗[ℝ] W) := by
+      have := congrArg (fun x : ℂ ⊗[ℝ] W => (2⁻¹ : ℝ) • x) h
+      simpa [smul_smul] using this
+    rw [h₂, add_zero]
+  · rintro ⟨w, rfl⟩
+    rw [mem_realPoints, tmulConj_tmul, map_one]
+
+end Complexification
+
+/-- **The conjugation of a complexification commutes with every base-changed map**, because
+`LinearMap.baseChange` leaves the conjugated factor alone. -/
+theorem tmulConj_baseChange {W W' : Type*} [AddCommGroup W] [Module ℝ W] [AddCommGroup W']
+    [Module ℝ W'] (f : W →ₗ[ℝ] W') (u : ℂ ⊗[ℝ] W) :
+    tmulConj W' (f.baseChange ℂ u) = f.baseChange ℂ (tmulConj W u) := by
+  induction u with
+  | zero => simp
+  | tmul c w => simp
+  | add u₁ u₂ h₁ h₂ => rw [map_add, map_add, map_add, map_add, h₁, h₂]
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Complex/Conjugation.lean
+++ b/TauCeti/LinearAlgebra/Complex/Conjugation.lean
@@ -28,7 +28,8 @@ Everything is stated for an arbitrary `V`; no finite-dimensionality is used anyw
 ## Main definitions
 
 * `TauCeti.realPoints`: the real points of a conjugate-linear map, as a `Submodule ℝ V`.
-* `TauCeti.conjRealPart` and `TauCeti.conjImagPart`: the two real points a vector decomposes into.
+* `TauCeti.conjRealPart` and `TauCeti.conjImagPart`: the two real points a vector decomposes into;
+  `TauCeti.conjRealPart_def` and `TauCeti.conjImagPart_def` are their defining formulas.
 * `TauCeti.realPointsLift`: the canonical `ℂ`-linear map `ℂ ⊗[ℝ] realPoints K →ₗ[ℂ] V`.
 * `TauCeti.realPointsEquiv`: that map as a `ℂ`-linear isomorphism, for involutive `K`.
 * `TauCeti.tmulConj`: the conjugation `c ⊗ₜ w ↦ conj c ⊗ₜ w` of a complexification `ℂ ⊗[ℝ] W`.
@@ -37,8 +38,9 @@ Everything is stated for an arbitrary `V`; no finite-dimensionality is used anyw
 
 * `TauCeti.conjRealPart_add_I_smul_conjImagPart`: the decomposition
   `v = conjRealPart K v + I • conjImagPart K v`, which makes `TauCeti.realPointsLift` surjective.
-* `TauCeti.realPointsLift_bijective` and `TauCeti.realPointsEquiv`: **a complex vector space is the
-  complexification of the real points of any conjugation on it.**
+* `TauCeti.realPointsLift_injective`, `TauCeti.realPointsLift_surjective` and
+  `TauCeti.realPointsEquiv`: **a complex vector space is the complexification of the real points of
+  any conjugation on it.**
 * `TauCeti.exists_one_tmul_add_I_tmul`: every element of `ℂ ⊗[ℝ] W` is `1 ⊗ₜ w₁ + I ⊗ₜ w₂`; this
   is what makes the lift injective.
 * `TauCeti.tmulConj_involutive`, `TauCeti.tmulConj_tmul` and
@@ -55,6 +57,10 @@ would either duplicate it or invert the dependency between `TauCeti.LinearAlgebr
 fields.  For the same reason `TauCeti.realPoints` asks only for the semilinear map: the subspace
 makes sense without involutivity, and only the complexification theorem needs it.
 
+No definition here exposes its body: `TauCeti.mem_realPoints`, `TauCeti.conjRealPart_def`,
+`TauCeti.conjImagPart_def`, `TauCeti.realPointsLift_tmul`, `TauCeti.realPointsEquiv_tmul` and
+`TauCeti.tmulConj_tmul` are the characterizations a consumer works from.
+
 The real scalar structure on `V` is Mathlib's `Module.complexToReal`, the one `Module ℂ V` induces,
 so `r • v` and `(r : ℂ) • v` are definitionally equal and no scalar tower hypothesis is carried.
 
@@ -64,7 +70,7 @@ so `r • v` and `(r : ℂ) • v` are definitionally equal and no scalar tower 
   conjugation attached to an invariant form realizes a representation over `ℝ`.
 -/
 
-@[expose] public section
+public section
 
 open scoped TensorProduct
 
@@ -78,21 +84,18 @@ variable {V : Type*} [AddCommGroup V] [Module ℂ V]
 subspace over `ℝ` but not over `ℂ`, since `K (c • v) = conj c • K v`. -/
 def realPoints (K : V →ₛₗ[starRingEnd ℂ] V) : Submodule ℝ V where
   carrier := {v | K v = v}
-  add_mem' {v w} hv hw := by
-    change K v = v at hv
-    change K w = w at hw
-    change K (v + w) = v + w
-    rw [map_add, hv, hw]
+  add_mem' {v w} (hv : K v = v) (hw : K w = w) := by
+    rw [Set.mem_ofPred_eq, map_add, hv, hw]
   zero_mem' := map_zero K
-  smul_mem' r v hv := by
-    change K v = v at hv
-    change K ((r : ℂ) • v) = (r : ℂ) • v
-    rw [map_smulₛₗ, Complex.conj_ofReal, hv]
+  smul_mem' r v (hv : K v = v) := by
+    -- `Complex.coe_smul` turns the `ℝ`-action of `Module.complexToReal` into the `ℂ`-action, the
+    -- one the semilinearity of `K` speaks about.
+    rw [Set.mem_ofPred_eq, ← Complex.coe_smul r, map_smulₛₗ, Complex.conj_ofReal, hv]
 
 @[simp]
 theorem mem_realPoints {K : V →ₛₗ[starRingEnd ℂ] V} {v : V} :
     v ∈ realPoints K ↔ K v = v :=
-  Iff.rfl
+  (Iff.rfl)
 
 variable {K : V →ₛₗ[starRingEnd ℂ] V}
 
@@ -114,6 +117,14 @@ variable (K) in
 `½ I • (K v - v)`, the coefficient of `I` in `TauCeti.conjRealPart_add_I_smul_conjImagPart`. -/
 noncomputable def conjImagPart (v : V) : V := (2⁻¹ : ℝ) • (Complex.I • (K v - v))
 
+/-- The defining formula for the real part, the body of `TauCeti.conjRealPart` not being exposed. -/
+theorem conjRealPart_def (v : V) : conjRealPart K v = (2⁻¹ : ℝ) • (v + K v) := (rfl)
+
+/-- The defining formula for the imaginary part, the body of `TauCeti.conjImagPart` not being
+exposed. -/
+theorem conjImagPart_def (v : V) :
+    conjImagPart K v = (2⁻¹ : ℝ) • (Complex.I • (K v - v)) := (rfl)
+
 theorem conjRealPart_mem (hK : Function.Involutive K) (v : V) : conjRealPart K v ∈ realPoints K :=
   Submodule.smul_mem _ _ (add_conj_mem_realPoints hK v)
 
@@ -130,7 +141,8 @@ theorem conjRealPart_add_I_smul_conjImagPart (v : V) :
   have hsum : (v + K v) + (v - K v) = (2 : ℝ) • v := by
     rw [two_smul]
     abel
-  rw [conjRealPart, conjImagPart, smul_comm Complex.I ((2⁻¹ : ℝ)), hI, ← smul_add, hsum, smul_smul]
+  rw [conjRealPart_def, conjImagPart_def, smul_comm Complex.I ((2⁻¹ : ℝ)), hI, ← smul_add, hsum,
+    smul_smul]
   norm_num
 
 /-! ### A complexification splits along `1` and `I` -/
@@ -174,8 +186,8 @@ theorem realPointsLift_surjective (hK : Function.Involutive K) :
     rw [map_add, realPointsLift_tmul, realPointsLift_tmul, one_smul]
     exact conjRealPart_add_I_smul_conjImagPart v⟩
 
-/-- The lift is injective for **any** conjugate-linear `K`: only the surjectivity below uses that
-`K` is involutive. -/
+/-- The lift is injective for **any** conjugate-linear `K`: only its surjectivity uses that `K` is
+involutive. -/
 theorem realPointsLift_injective : Function.Injective (realPointsLift K) := by
   rw [injective_iff_map_eq_zero]
   intro u hu
@@ -202,17 +214,14 @@ theorem realPointsLift_injective : Function.Injective (realPointsLift K) := by
   rw [h₁, h₂]
   simp
 
-theorem realPointsLift_bijective (hK : Function.Involutive K) :
-    Function.Bijective (realPointsLift K) :=
-  ⟨realPointsLift_injective, realPointsLift_surjective hK⟩
-
 /-- **A complex vector space is the complexification of the real points of any conjugation on
 it.**  The isomorphism is `c ⊗ₜ w ↦ c • w`; surjectivity is the decomposition
 `TauCeti.conjRealPart_add_I_smul_conjImagPart`, and injectivity is that a relation `w₁ + I • w₂ = 0`
 between real points is killed by adding and subtracting its conjugate. -/
 noncomputable def realPointsEquiv (hK : Function.Involutive K) :
     ℂ ⊗[ℝ] realPoints K ≃ₗ[ℂ] V :=
-  LinearEquiv.ofBijective (realPointsLift K) (realPointsLift_bijective hK)
+  LinearEquiv.ofBijective (realPointsLift K)
+    ⟨realPointsLift_injective, realPointsLift_surjective hK⟩
 
 @[simp]
 theorem realPointsEquiv_tmul (hK : Function.Involutive K) (c : ℂ) (w : realPoints K) :
@@ -243,7 +252,7 @@ noncomputable def tmulConj : (ℂ ⊗[ℝ] W) →ₛₗ[starRingEnd ℂ] (ℂ �
 @[simp]
 theorem tmulConj_tmul (c : ℂ) (w : W) :
     tmulConj W (c ⊗ₜ[ℝ] w) = (starRingEnd ℂ) c ⊗ₜ[ℝ] w :=
-  rfl
+  (rfl)
 
 theorem tmulConj_involutive : Function.Involutive (tmulConj W) := by
   intro u

--- a/TauCeti/LinearAlgebra/Complex/Conjugation.lean
+++ b/TauCeti/LinearAlgebra/Complex/Conjugation.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.Complex.Module
-public import Mathlib.LinearAlgebra.TensorProduct.Tower
+public import Mathlib.LinearAlgebra.TensorProduct.Basis
 
 /-!
 # The real points of a conjugate-linear involution
@@ -19,9 +19,12 @@ theorem of this file is that `V` is the complexification of that subspace: the c
 `ℂ ⊗[ℝ] realPoints K → V`, `c ⊗ₜ w ↦ c • w`
 
 is a `ℂ`-linear isomorphism.  Conversely a complexification `ℂ ⊗[ℝ] W` carries the conjugation
-`c ⊗ₜ w ↦ conj c ⊗ₜ w`.  So a conjugation on `V` is the same data as a presentation of `V` as the
-complexification of a real vector space, which is what makes conjugations the tool for realizing
-an object over `ℝ`.
+`c ⊗ₜ w ↦ conj c ⊗ₜ w`.  So each of the two constructions produces the other — a conjugation on
+`V` yields a presentation of `V` as a complexification, and every such presentation yields a
+conjugation — and in particular `V` admits a conjugation exactly when it is the complexification
+of a real vector space.  That is what makes conjugations the tool for realizing an object over
+`ℝ`.  The two constructions are not set up here as mutually inverse: a presentation carries a
+noncanonical choice of real carrier and isomorphism, which a conjugation does not.
 
 Everything is stated for an arbitrary `V`; no finite-dimensionality is used anywhere.
 
@@ -58,8 +61,9 @@ fields.  For the same reason `TauCeti.realPoints` asks only for the semilinear m
 makes sense without involutivity, and only the complexification theorem needs it.
 
 No definition here exposes its body: `TauCeti.mem_realPoints`, `TauCeti.conjRealPart_def`,
-`TauCeti.conjImagPart_def`, `TauCeti.realPointsLift_tmul`, `TauCeti.realPointsEquiv_tmul` and
-`TauCeti.tmulConj_tmul` are the characterizations a consumer works from.
+`TauCeti.conjImagPart_def`, `TauCeti.realPointsLift_tmul`, `TauCeti.realPointsEquiv_tmul`,
+`TauCeti.realPointsEquiv_symm_apply` and `TauCeti.tmulConj_tmul` are the characterizations a
+consumer works from.
 
 The real scalar structure on `V` is Mathlib's `Module.complexToReal`, the one `Module ℂ V` induces,
 so `r • v` and `(r : ℂ) • v` are definitionally equal and no scalar tower hypothesis is carried.
@@ -152,18 +156,10 @@ theorem conjRealPart_add_I_smul_conjImagPart (v : V) :
 splitting `ℂ ⊗[ℝ] W ≅ W ⊕ I · W` in the form the injectivity argument below uses it. -/
 theorem exists_one_tmul_add_I_tmul {W : Type*} [AddCommGroup W] [Module ℝ W] (u : ℂ ⊗[ℝ] W) :
     ∃ w₁ w₂ : W, u = 1 ⊗ₜ[ℝ] w₁ + Complex.I ⊗ₜ[ℝ] w₂ := by
-  induction u with
-  | zero => exact ⟨0, 0, by simp⟩
-  | tmul c w =>
-    refine ⟨c.re • w, c.im • w, ?_⟩
-    rw [← TensorProduct.smul_tmul, ← TensorProduct.smul_tmul, ← TensorProduct.add_tmul]
-    congr 1
-    simp only [Complex.real_smul, mul_one]
-    exact (Complex.re_add_im c).symm
-  | add u₁ u₂ h₁ h₂ =>
-    obtain ⟨a₁, b₁, rfl⟩ := h₁
-    obtain ⟨a₂, b₂, rfl⟩ := h₂
-    exact ⟨a₁ + a₂, b₁ + b₂, by rw [TensorProduct.tmul_add, TensorProduct.tmul_add]; abel⟩
+  obtain ⟨c, hc⟩ := TensorProduct.eq_repr_basis_left Complex.basisOneI u
+  refine ⟨c 0, c 1, ?_⟩
+  rw [← hc, Finsupp.sum_fintype _ _ (by simp), Fin.sum_univ_two, Complex.coe_basisOneI]
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one]
 
 /-! ### The complexification of the real points -/
 
@@ -179,6 +175,8 @@ theorem realPointsLift_tmul (c : ℂ) (w : realPoints K) :
     realPointsLift K (c ⊗ₜ[ℝ] w) = c • (w : V) := by
   simp [realPointsLift]
 
+/-- The lift is surjective once `K` is involutive: `v` is hit by
+`1 ⊗ₜ conjRealPart K v + I ⊗ₜ conjImagPart K v`. -/
 theorem realPointsLift_surjective (hK : Function.Involutive K) :
     Function.Surjective (realPointsLift K) := fun v =>
   ⟨1 ⊗ₜ[ℝ] ⟨conjRealPart K v, conjRealPart_mem hK v⟩ +
@@ -223,10 +221,21 @@ noncomputable def realPointsEquiv (hK : Function.Involutive K) :
   LinearEquiv.ofBijective (realPointsLift K)
     ⟨realPointsLift_injective, realPointsLift_surjective hK⟩
 
+/-- The isomorphism sends `c ⊗ₜ w` to `c • w`. -/
 @[simp]
 theorem realPointsEquiv_tmul (hK : Function.Involutive K) (c : ℂ) (w : realPoints K) :
     realPointsEquiv hK (c ⊗ₜ[ℝ] w) = c • (w : V) :=
   realPointsLift_tmul c w
+
+/-- The inverse of the isomorphism is the decomposition into real and imaginary parts:
+`v ↦ 1 ⊗ₜ conjRealPart K v + I ⊗ₜ conjImagPart K v`. -/
+@[simp]
+theorem realPointsEquiv_symm_apply (hK : Function.Involutive K) (v : V) :
+    (realPointsEquiv hK).symm v =
+      1 ⊗ₜ[ℝ] (⟨conjRealPart K v, conjRealPart_mem hK v⟩ : realPoints K) +
+        Complex.I ⊗ₜ[ℝ] (⟨conjImagPart K v, conjImagPart_mem hK v⟩ : realPoints K) := by
+  rw [LinearEquiv.symm_apply_eq, map_add, realPointsEquiv_tmul, realPointsEquiv_tmul, one_smul]
+  exact (conjRealPart_add_I_smul_conjImagPart v).symm
 
 /-! ### The conjugation of a complexification -/
 
@@ -235,8 +244,9 @@ section Complexification
 variable (W : Type*) [AddCommGroup W] [Module ℝ W]
 
 /-- The **conjugation of a complexification**: `c ⊗ₜ w ↦ conj c ⊗ₜ w`, conjugate-linear because
-conjugation is `ℝ`-linear and multiplicative on `ℂ`.  Together with `TauCeti.realPointsEquiv` it
-makes conjugations on `V` and presentations of `V` as a complexification the same data. -/
+conjugation is `ℝ`-linear and multiplicative on `ℂ`.  This is the construction converse to
+`TauCeti.realPointsEquiv`: it turns a presentation of a space as a complexification into a
+conjugation on it. -/
 noncomputable def tmulConj : (ℂ ⊗[ℝ] W) →ₛₗ[starRingEnd ℂ] (ℂ ⊗[ℝ] W) where
   toFun := TensorProduct.lift ((TensorProduct.mk ℝ ℂ W).comp Complex.conjAe.toLinearMap)
   map_add' := map_add _
@@ -249,11 +259,14 @@ noncomputable def tmulConj : (ℂ ⊗[ℝ] W) →ₛₗ[starRingEnd ℂ] (ℂ �
         Complex.conjAe_coe, TensorProduct.mk_apply, map_mul]
     | add u₁ u₂ h₁ h₂ => rw [smul_add, map_add, map_add, h₁, h₂, smul_add]
 
+/-- The conjugation of a complexification conjugates the scalar and leaves the vector alone. -/
 @[simp]
 theorem tmulConj_tmul (c : ℂ) (w : W) :
     tmulConj W (c ⊗ₜ[ℝ] w) = (starRingEnd ℂ) c ⊗ₜ[ℝ] w :=
   (rfl)
 
+/-- The conjugation of a complexification is involutive, so it is a conjugation in the sense of
+this file. -/
 theorem tmulConj_involutive : Function.Involutive (tmulConj W) := by
   intro u
   induction u with

--- a/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/RealForm.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/RealForm.lean
@@ -41,7 +41,12 @@ is not proved here.  It is a strictly stronger statement than the existence of a
 symmetric form supplied by
 `TauCeti.Representation.frobeniusSchurIndicator_eq_one_iff`: passing from the form to a real
 structure needs an invariant Hermitian inner product as well, and the antilinear involution built
-from the two of them, whose fixed points are the real form.  That construction is separate work.
+from the two of them.  The second half of that route is already available:
+`Representation.IsRealStructure` is such an involution, its fixed points are a real form
+(`Representation.IsRealStructure.isRealForm`), and
+`Representation.isRealizableOverReal_iff_exists_isRealStructure` turns one into realizability over
+`ℝ`.  What remains is building the involution itself out of the invariant symmetric and Hermitian
+forms.
 
 ## Main results
 

--- a/TauCeti/RepresentationTheory/RealForm.lean
+++ b/TauCeti/RepresentationTheory/RealForm.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Complex.Module
 public import Mathlib.RepresentationTheory.Character
 public import Mathlib.RingTheory.Finiteness.Descent
 public import TauCeti.LinearAlgebra.Complex.Conjugation
@@ -297,26 +296,30 @@ variable {K : V →ₛₗ[starRingEnd ℂ] V} (h : IsRealStructure ρ K)
 include h
 
 /-- The action preserves the real points of a real structure: that is exactly the commutation
-`K (ρ g v) = ρ g (K v)` read on a fixed vector. -/
-theorem apply_mem_realPoints (g : G) ⦃v : V⦄ (hv : v ∈ realPoints K) :
-    ρ g v ∈ realPoints K := by
-  rw [mem_realPoints] at hv ⊢
-  rw [h.intertwines, hv]
+`K (ρ g v) = ρ g (K v)` read on a fixed vector.  It is stated for the `ℝ`-linear restriction
+`(ρ g).restrictScalars ℝ` of the action, which is the shape `LinearMap.restrict` consumes in
+`Representation.IsRealStructure.rep`. -/
+theorem apply_mem_realPoints (g : G) :
+    ∀ v ∈ realPoints K, ((ρ g).restrictScalars ℝ) v ∈ realPoints K := by
+  intro v hv
+  rw [mem_realPoints] at hv
+  rw [LinearMap.coe_restrictScalars, mem_realPoints, h.intertwines, hv]
 
 /-- **The real representation carried by the real points** of a real structure: each `ρ g`
 restricts to the real points, where only its `ℝ`-linearity survives. -/
-@[expose]
 def rep : Representation ℝ G (realPoints K) where
   toFun g := LinearMap.restrict ((ρ g).restrictScalars ℝ) (h.apply_mem_realPoints g)
   map_one' := LinearMap.ext fun w => Subtype.ext <| by
-    change ρ 1 (w : V) = (w : V)
-    rw [map_one, Module.End.one_apply]
+    simp only [LinearMap.coe_restrict_apply, LinearMap.coe_restrictScalars, map_one,
+      Module.End.one_apply]
   map_mul' g g' := LinearMap.ext fun w => Subtype.ext <| by
-    change ρ (g * g') (w : V) = ρ g (ρ g' (w : V))
-    rw [map_mul, Module.End.mul_apply]
+    simp only [LinearMap.coe_restrict_apply, LinearMap.coe_restrictScalars, map_mul,
+      Module.End.mul_apply]
 
+-- `(rfl)`, not `rfl`: the body of `rep` is not `@[expose]`d, so a bare `rfl` proof would be
+-- rechecked against the exported environment, where the restriction is opaque.
 @[simp]
-theorem coe_rep_apply (g : G) (w : realPoints K) : (h.rep g w : V) = ρ g (w : V) := rfl
+theorem coe_rep_apply (g : G) (w : realPoints K) : (h.rep g w : V) = ρ g (w : V) := (rfl)
 
 /-- **The real points of a real structure are a real form.**  The `ℂ`-linear isomorphism is
 `TauCeti.realPointsEquiv`, which says that `V` is the complexification of the real points, and it
@@ -361,7 +364,7 @@ theorem IsRealForm.exists_isRealStructure (h : IsRealForm ρ σ) :
       exact tmulConj_baseChange (σ g) (e.symm v)
     have hsymm : e.symm (ρ g v) = baseChange ℂ σ g (e.symm v) := by
       rw [e.symm_apply_eq, hφ, e.apply_symm_apply]
-    change e (tmulConj W (e.symm (ρ g v))) = ρ g (e (tmulConj W (e.symm v)))
+    simp only [LinearMap.coe_mk, AddHom.coe_mk]
     rw [hsymm, hu, hφ]
 
 /-- **Realizability over `ℝ` is the existence of a real structure.**  This is the working form of

--- a/TauCeti/RepresentationTheory/RealForm.lean
+++ b/TauCeti/RepresentationTheory/RealForm.lean
@@ -65,6 +65,8 @@ writes down directly.
   representations from the complexification of `σ` to `ρ`.
 * `Representation.IsRealStructure.isRealForm`: **the real points of a real structure are a real
   form**, and `Representation.IsRealForm.exists_isRealStructure` is the converse.
+* `Representation.IsRealStructure.isRealizableOverReal`: a real structure on a finite-dimensional
+  `ρ` realizes it over `ℝ` in the pinned sense.
 * `Representation.isRealizableOverReal_iff_exists_isRealStructure`: over a finite-dimensional `V`,
   realizability over `ℝ` is exactly the existence of a real structure.
 * `Representation.IsRealStructure.finrank_realPoints`: the real points of a real structure have
@@ -287,7 +289,7 @@ structure IsRealStructure (K : V →ₛₗ[starRingEnd ℂ] V) : Prop where
   /-- The conjugation is an involution. -/
   involutive : Function.Involutive ⇑K
   /-- The conjugation intertwines the action with itself. -/
-  intertwines (g : G) (v : V) : K (ρ g v) = ρ g (K v)
+  isIntertwining (g : G) (v : V) : K (ρ g v) = ρ g (K v)
 
 namespace IsRealStructure
 
@@ -297,24 +299,23 @@ include h
 
 /-- The action preserves the real points of a real structure: that is exactly the commutation
 `K (ρ g v) = ρ g (K v)` read on a fixed vector.  It is stated for the `ℝ`-linear restriction
-`(ρ g).restrictScalars ℝ` of the action, which is the shape `LinearMap.restrict` consumes in
-`Representation.IsRealStructure.rep`. -/
+`(ρ g).restrictScalars ℝ` of the action, which is the shape `Representation.subrepresentation`
+consumes in `Representation.IsRealStructure.rep`. -/
 theorem apply_mem_realPoints (g : G) :
     ∀ v ∈ realPoints K, ((ρ g).restrictScalars ℝ) v ∈ realPoints K := by
   intro v hv
   rw [mem_realPoints] at hv
-  rw [LinearMap.coe_restrictScalars, mem_realPoints, h.intertwines, hv]
+  rw [LinearMap.coe_restrictScalars, mem_realPoints, h.isIntertwining, hv]
 
-/-- **The real representation carried by the real points** of a real structure: each `ρ g`
-restricts to the real points, where only its `ℝ`-linearity survives. -/
-def rep : Representation ℝ G (realPoints K) where
-  toFun g := LinearMap.restrict ((ρ g).restrictScalars ℝ) (h.apply_mem_realPoints g)
-  map_one' := LinearMap.ext fun w => Subtype.ext <| by
-    simp only [LinearMap.coe_restrict_apply, LinearMap.coe_restrictScalars, map_one,
-      Module.End.one_apply]
-  map_mul' g g' := LinearMap.ext fun w => Subtype.ext <| by
-    simp only [LinearMap.coe_restrict_apply, LinearMap.coe_restrictScalars, map_mul,
-      Module.End.mul_apply]
+/-- **The real representation carried by the real points** of a real structure: reading `ρ` with
+only its `ℝ`-linearity, the real points are an invariant subspace, and
+`Representation.subrepresentation` restricts the action to them. -/
+def rep : Representation ℝ G (realPoints K) :=
+  Representation.subrepresentation
+    { toFun := fun g => (ρ g).restrictScalars ℝ
+      map_one' := LinearMap.ext fun _ => by simp
+      map_mul' := fun _ _ => LinearMap.ext fun _ => by simp }
+    (realPoints K) h.apply_mem_realPoints
 
 -- `(rfl)`, not `rfl`: the body of `rep` is not `@[expose]`d, so a bare `rfl` proof would be
 -- rechecked against the exported environment, where the restriction is opaque.
@@ -334,10 +335,11 @@ theorem isRealizableOverReal [FiniteDimensional ℂ V] : IsRealizableOverReal ρ
   h.isRealForm.isRealizableOverReal
 
 /-- The real points of a real structure have the `ℝ`-dimension that `V` has over `ℂ`; with
-`TauCeti.finrank_real_eq_two_mul_finrank_complex` this says they halve the real dimension of `V`.
-No finiteness is assumed: in the infinite-dimensional case both sides are the junk value `0`. -/
+Mathlib's `finrank_real_of_complex` this says they halve the real dimension of `V`.  Equivariance
+plays no part, so this is the conjugation-level `TauCeti.finrank_realPoints` read on a real
+structure. -/
 theorem finrank_realPoints : finrank ℝ (realPoints K) = finrank ℂ V :=
-  h.isRealForm.finrank_eq
+  TauCeti.finrank_realPoints h.involutive
 
 end IsRealStructure
 
@@ -351,12 +353,10 @@ theorem IsRealForm.exists_isRealStructure (h : IsRealForm ρ σ) :
   set e : (ℂ ⊗[ℝ] W) ≃ₗ[ℂ] V := φ.toLinearEquiv with he
   have hφ : ∀ (g : G) (u : ℂ ⊗[ℝ] W), e (baseChange ℂ σ g u) = ρ g (e u) := fun g u => by
     simpa [he, Equiv.toLinearEquiv_apply] using φ.isIntertwining (g := g) (v := u)
-  refine ⟨{ toFun := fun v => e (tmulConj W (e.symm v))
-            map_add' := fun v v' => by simp
-            map_smul' := fun c v => by simp }, ?_, ?_⟩
+  -- The witness is a composition of semilinear maps; `LinearMap.comp` supplies its map laws.
+  refine ⟨e.toLinearMap ∘ₛₗ (tmulConj W ∘ₛₗ e.symm.toLinearMap), ?_, ?_⟩
   · intro v
-    have hinv : tmulConj W (tmulConj W (e.symm v)) = e.symm v := tmulConj_involutive W (e.symm v)
-    simp [hinv]
+    simp
   · intro g v
     have hu : tmulConj W (baseChange ℂ σ g (e.symm v))
         = baseChange ℂ σ g (tmulConj W (e.symm v)) := by
@@ -364,7 +364,7 @@ theorem IsRealForm.exists_isRealStructure (h : IsRealForm ρ σ) :
       exact tmulConj_baseChange (σ g) (e.symm v)
     have hsymm : e.symm (ρ g v) = baseChange ℂ σ g (e.symm v) := by
       rw [e.symm_apply_eq, hφ, e.apply_symm_apply]
-    simp only [LinearMap.coe_mk, AddHom.coe_mk]
+    simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe]
     rw [hsymm, hu, hφ]
 
 /-- **Realizability over `ℝ` is the existence of a real structure.**  This is the working form of

--- a/TauCeti/RepresentationTheory/RealForm.lean
+++ b/TauCeti/RepresentationTheory/RealForm.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.Complex.Module
 public import Mathlib.RepresentationTheory.Character
 public import Mathlib.RingTheory.Finiteness.Descent
+public import TauCeti.LinearAlgebra.Complex.Conjugation
 public import TauCeti.RepresentationTheory.InvariantForm.BaseChange
 
 /-!
@@ -38,16 +39,37 @@ consumes them -- `Representation.frobeniusSchurIndicator_eq_one_of_isRealizableO
 `TauCeti.RepresentationTheory.CharacterTable.FrobeniusSchur.RealForm` -- asks for a finite group
 only where it sums over the group.
 
+A real form is a statement about an auxiliary carrier `W`; the equivalent statement *inside* `V` is
+a **real structure**, a conjugation `K` of `V` -- a conjugate-linear involution -- commuting with
+the action.  Its real points `TauCeti.realPoints K` carry a real representation whose
+complexification is `ρ` (`Representation.IsRealStructure.isRealForm`), and conversely a real form
+transports the conjugation `c ⊗ₜ w ↦ conj c ⊗ₜ w` of `ℂ ⊗[ℝ] W` to `V`
+(`Representation.IsRealForm.exists_isRealStructure`).  So the two notions agree
+(`Representation.isRealizableOverReal_iff_exists_isRealStructure`).  This is the form in which
+realizability is *produced*: the route to it for an irreducible representation with
+Frobenius-Schur indicator `1` is to build the conjugation out of an invariant symmetric bilinear
+form and an invariant Hermitian inner product, and a real form on a carrier is not something one
+writes down directly.
+
 ## Main definitions
 
 * `Representation.IsRealForm`: `σ` is a real form of `ρ`.
 * `Representation.IsRealizableOverReal`: `ρ` admits a real form on a carrier pinned by the
   dimension of `V`.
+* `Representation.IsRealStructure`: `K` is a real structure on `ρ`, that is, a conjugation of `V`
+  commuting with the action.
+* `Representation.IsRealStructure.rep`: the real representation it induces on the real points.
 
 ## Main results
 
 * `Representation.isRealForm_iff_nonempty_equiv`: a real form is exactly an equivalence of
   representations from the complexification of `σ` to `ρ`.
+* `Representation.IsRealStructure.isRealForm`: **the real points of a real structure are a real
+  form**, and `Representation.IsRealForm.exists_isRealStructure` is the converse.
+* `Representation.isRealizableOverReal_iff_exists_isRealStructure`: over a finite-dimensional `V`,
+  realizability over `ℝ` is exactly the existence of a real structure.
+* `Representation.IsRealStructure.finrank_realPoints`: the real points of a real structure have
+  `ℝ`-dimension `finrank ℂ V`.
 * `Representation.IsRealForm.char_eq`: the character of a representation with a real
   form is the character of that real form, in particular real-valued
   (`Representation.IsRealForm.conj_char`).
@@ -251,5 +273,104 @@ theorem IsRealForm.isRealizableOverReal [FiniteDimensional ℂ V] (h : IsRealFor
   simp only [MonoidHom.coe_mk, OneHom.coe_mk, LinearEquiv.trans_apply,
     LinearEquiv.baseChange_tmul, LinearEquiv.conj_apply_apply, LinearEquiv.symm_apply_apply]
   exact he g (f.symm x)
+
+/-! ### Real structures -/
+
+variable (ρ) in
+/-- A **real structure** on a complex representation: a conjugation of the underlying space -- a
+conjugate-linear involution `K` -- that commutes with the action.  This is the intrinsic form of
+`Representation.IsRealForm`, phrased inside `V` instead of on an auxiliary real carrier, and it is
+the form in which realizability over `ℝ` is produced.
+
+The conjugation is carried unbundled, matching `Representation.IsInvariantForm`; the two fields are
+exactly the data of a `TauCeti.Hodge.Conjugation` together with equivariance. -/
+structure IsRealStructure (K : V →ₛₗ[starRingEnd ℂ] V) : Prop where
+  /-- The conjugation is an involution. -/
+  involutive : Function.Involutive ⇑K
+  /-- The conjugation intertwines the action with itself. -/
+  intertwines (g : G) (v : V) : K (ρ g v) = ρ g (K v)
+
+namespace IsRealStructure
+
+variable {K : V →ₛₗ[starRingEnd ℂ] V} (h : IsRealStructure ρ K)
+
+include h
+
+/-- The action preserves the real points of a real structure: that is exactly the commutation
+`K (ρ g v) = ρ g (K v)` read on a fixed vector. -/
+theorem apply_mem_realPoints (g : G) ⦃v : V⦄ (hv : v ∈ realPoints K) :
+    ρ g v ∈ realPoints K := by
+  rw [mem_realPoints] at hv ⊢
+  rw [h.intertwines, hv]
+
+/-- **The real representation carried by the real points** of a real structure: each `ρ g`
+restricts to the real points, where only its `ℝ`-linearity survives. -/
+@[expose]
+def rep : Representation ℝ G (realPoints K) where
+  toFun g := LinearMap.restrict ((ρ g).restrictScalars ℝ) (h.apply_mem_realPoints g)
+  map_one' := LinearMap.ext fun w => Subtype.ext <| by
+    change ρ 1 (w : V) = (w : V)
+    rw [map_one, Module.End.one_apply]
+  map_mul' g g' := LinearMap.ext fun w => Subtype.ext <| by
+    change ρ (g * g') (w : V) = ρ g (ρ g' (w : V))
+    rw [map_mul, Module.End.mul_apply]
+
+@[simp]
+theorem coe_rep_apply (g : G) (w : realPoints K) : (h.rep g w : V) = ρ g (w : V) := rfl
+
+/-- **The real points of a real structure are a real form.**  The `ℂ`-linear isomorphism is
+`TauCeti.realPointsEquiv`, which says that `V` is the complexification of the real points, and it
+intertwines the two actions because `ρ g` acts on a real point by its restriction. -/
+theorem isRealForm : IsRealForm ρ h.rep :=
+  ⟨realPointsEquiv h.involutive, fun g w => by
+    rw [realPointsEquiv_tmul, realPointsEquiv_tmul, one_smul, one_smul, coe_rep_apply]⟩
+
+/-- **A real structure realizes `ρ` over `ℝ`** in the pinned sense, once `V` is
+finite-dimensional. -/
+theorem isRealizableOverReal [FiniteDimensional ℂ V] : IsRealizableOverReal ρ :=
+  h.isRealForm.isRealizableOverReal
+
+/-- The real points of a real structure have the `ℝ`-dimension that `V` has over `ℂ`; with
+`TauCeti.finrank_real_eq_two_mul_finrank_complex` this says they halve the real dimension of `V`.
+No finiteness is assumed: in the infinite-dimensional case both sides are the junk value `0`. -/
+theorem finrank_realPoints : finrank ℝ (realPoints K) = finrank ℂ V :=
+  h.isRealForm.finrank_eq
+
+end IsRealStructure
+
+/-- **A real form produces a real structure.**  Transport the conjugation `c ⊗ₜ w ↦ conj c ⊗ₜ w` of
+the complexification (`TauCeti.tmulConj`) along the isomorphism `ℂ ⊗[ℝ] W ≃ₗ[ℂ] V`.  It commutes
+with the action because the action on the complexification is `1 ⊗ σ g`, which leaves the first
+tensor factor -- the one being conjugated -- alone. -/
+theorem IsRealForm.exists_isRealStructure (h : IsRealForm ρ σ) :
+    ∃ K : V →ₛₗ[starRingEnd ℂ] V, IsRealStructure ρ K := by
+  obtain ⟨φ⟩ := isRealForm_iff_nonempty_equiv.mp h
+  set e : (ℂ ⊗[ℝ] W) ≃ₗ[ℂ] V := φ.toLinearEquiv with he
+  have hφ : ∀ (g : G) (u : ℂ ⊗[ℝ] W), e (baseChange ℂ σ g u) = ρ g (e u) := fun g u => by
+    simpa [he, Equiv.toLinearEquiv_apply] using φ.isIntertwining (g := g) (v := u)
+  refine ⟨{ toFun := fun v => e (tmulConj W (e.symm v))
+            map_add' := fun v v' => by simp
+            map_smul' := fun c v => by simp }, ?_, ?_⟩
+  · intro v
+    have hinv : tmulConj W (tmulConj W (e.symm v)) = e.symm v := tmulConj_involutive W (e.symm v)
+    simp [hinv]
+  · intro g v
+    have hu : tmulConj W (baseChange ℂ σ g (e.symm v))
+        = baseChange ℂ σ g (tmulConj W (e.symm v)) := by
+      rw [baseChange_apply]
+      exact tmulConj_baseChange (σ g) (e.symm v)
+    have hsymm : e.symm (ρ g v) = baseChange ℂ σ g (e.symm v) := by
+      rw [e.symm_apply_eq, hφ, e.apply_symm_apply]
+    change e (tmulConj W (e.symm (ρ g v))) = ρ g (e (tmulConj W (e.symm v)))
+    rw [hsymm, hu, hφ]
+
+/-- **Realizability over `ℝ` is the existence of a real structure.**  This is the working form of
+realizability: the two implications are `Representation.IsRealStructure.isRealizableOverReal` and
+`Representation.IsRealForm.exists_isRealStructure` applied to a real form on the pinned carrier. -/
+theorem isRealizableOverReal_iff_exists_isRealStructure [FiniteDimensional ℂ V] :
+    IsRealizableOverReal ρ ↔ ∃ K : V →ₛₗ[starRingEnd ℂ] V, IsRealStructure ρ K := by
+  refine ⟨fun h => ?_, fun ⟨_, hK⟩ => hK.isRealizableOverReal⟩
+  obtain ⟨_, hσ⟩ := h
+  exact hσ.exists_isRealStructure
 
 end Representation


### PR DESCRIPTION
This PR adds **real structures** on a complex representation and proves that they are the same thing as real forms. A real form of `ρ : Representation ℂ G V` is a statement about an auxiliary real carrier `W` together with an isomorphism `ℂ ⊗[ℝ] W ≃ₗ[ℂ] V`; the equivalent statement *inside* `V` is a conjugation of `V` — a conjugate-linear involution `K` — commuting with the action. That intrinsic form is the one realizability over `ℝ` is actually *produced* in, and `TauCeti/RepresentationTheory/RealForm.lean` currently records its absence in prose: the converse of `Representation.frobeniusSchurIndicator_eq_one_of_isRealizableOverReal` "needs an invariant Hermitian inner product as well, and the antilinear involution built from the two of them, whose fixed points are the real form. That construction is separate work." This PR builds the second half of that sentence, so that the remaining work on the Frobenius-Schur converse is exactly producing the involution from the two forms.

The target is Layer 7 of `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, the item "**Realizability over `ℝ` (a separate, stronger target)**", which says that realizing `ρ` over `ℝ` means constructing a `Representation ℝ G W` whose scalar extension to `ℂ` recovers `ρ`, "typically via a compatible Hermitian form / anti-linear equivariant involution", and pins `IsRealForm` and `frobeniusSchurIndicatorRep_eq_one_realizable` as targets. This is the anti-linear-equivariant-involution half of that route, and a prerequisite that target needs; the roadmap's `IsRealForm` predicate and `Representation.IsRealizableOverReal` are already in the repository and are consumed here rather than restated.

`TauCeti/LinearAlgebra/Complex/Conjugation.lean` (new, 289 lines) is the linear-algebra half, with no group in sight: `TauCeti.realPoints K`, the real subspace a conjugate-linear map fixes; `TauCeti.conjRealPart` and `TauCeti.conjImagPart` with the decomposition `v = conjRealPart K v + I • conjImagPart K v`; `TauCeti.realPointsLift` and `TauCeti.realPointsEquiv`, the theorem that a complex vector space is the complexification of the real points of any conjugation on it (surjectivity from the decomposition, injectivity from adding and subtracting the conjugate of a relation `w₁ + I • w₂ = 0`, which needs no involutivity); `TauCeti.exists_one_tmul_add_I_tmul`, the splitting of `ℂ ⊗[ℝ] W` along `1` and `I`; and `TauCeti.tmulConj`, the conjugation `c ⊗ₜ w ↦ conj c ⊗ₜ w` of a complexification with its real points and its commutation with base-changed maps. Nothing here assumes finite-dimensionality.

`TauCeti/RepresentationTheory/RealForm.lean` (+121 lines) adds the representation-theoretic half to the file that already owns the topic: `Representation.IsRealStructure ρ K`, the real representation `Representation.IsRealStructure.rep` carried by the real points, `Representation.IsRealStructure.isRealForm` that this is a real form, `Representation.IsRealForm.exists_isRealStructure` for the converse (transport `tmulConj` along the isomorphism; it intertwines because the action on a complexification leaves the conjugated tensor factor alone), and `Representation.isRealizableOverReal_iff_exists_isRealStructure`, which makes the two notions interchangeable over a finite-dimensional `V`. `Representation.IsRealStructure.finrank_realPoints` records that the real points have `ℝ`-dimension `finrank ℂ V`.

The conjugation is carried as the two unbundled hypotheses `K : V →ₛₗ[starRingEnd ℂ] V` and `Function.Involutive K` rather than as a new bundled structure, because `TauCeti.Hodge.Conjugation` already bundles exactly that data; it lives downstream in `TauCeti/Geometry/Hodge/`, so bundling in `TauCeti/LinearAlgebra/` would either duplicate it or invert the dependency, and a `Hodge.Conjugation` supplies the hypotheses from its two fields. The predicate `Representation.IsRealStructure` on an unbundled semilinear map matches the shape of the existing `Representation.IsInvariantForm`. Mathlib's `Module.complexToReal` supplies the real scalar structure, so no scalar-tower hypothesis is carried. No Mathlib source was vendored.

`lake build` and `lake exe axioms` are green (75725 declarations audited, allowlist only), as are `scripts/lint-style.sh`, `scripts/lint-dot-notation.py` (0 new) and `#lint` on both modules.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"isrealstructure"}-->

🤖 Prepared with Claude Code
