### PR TITLE
feat: prove normal product containment and normality

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
@@ -35,6 +35,8 @@ coordinate Hopf algebras acts on points by pre-composition.
 * `CommHopfAlgCat.grpObj`: the underlying object of the represented group object.
 * `CommHopfAlgCat.grpObjMap`: the contravariant morphism of represented group objects induced by a
   coordinate Hopf-algebra morphism.
+* `CommHopfAlgCat.whiskerLeft_grpObjMap_unop_hom`: the coordinate description of left whiskering
+  a represented group-object map.
 * `CommHopfAlgCat.grpObjMap_injective`: represented group-object maps determine their coordinate
   Hopf-algebra morphisms.
 
@@ -78,11 +80,19 @@ noncomputable def grpObjMap {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
 theorem grpObjMap_unop {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
     (grpObjMap f).unop = CommAlgCat.ofHom f.hom := (rfl)
 
-/-- The underlying algebra homomorphism of the opposite of `grpObjMap f` is the underlying
+/-- The underlying algebra homomorphism obtained by unopping `grpObjMap f` is the underlying
 algebra homomorphism of `f`. -/
 theorem grpObjMap_unop_hom {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
     (grpObjMap f).unop.hom = f.hom.toAlgHom :=
   congrArg CommAlgCat.Hom.hom (grpObjMap_unop f)
+
+/-- Unopping the left whiskering of a represented group-object map gives the tensor product of
+the identity with its underlying coordinate algebra map. -/
+theorem whiskerLeft_grpObjMap_unop_hom
+    {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
+    (MonoidalCategoryStruct.whiskerLeft (grpObj H) (grpObjMap f)).unop.hom =
+      Algebra.TensorProduct.map (AlgHom.id R H) f.hom.toAlgHom := by
+  simp only [unop_whiskerLeft, CommAlgCat.whiskerLeft_hom, grpObjMap_unop_hom]
 
 /-- Represented group-object maps determine their coordinate Hopf-algebra morphisms. -/
 theorem grpObjMap_injective {H K : _root_.CommHopfAlgCat.{u} R} :

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
@@ -91,8 +91,8 @@ theorem grpObjMap_injective {H K : _root_.CommHopfAlgCat.{u} R} :
   apply _root_.CommHopfAlgCat.hom_ext
   apply BialgHom.ext
   intro x
-  change f.hom.toAlgHom x = g.hom.toAlgHom x
-  simpa only [grpObjMap_unop_hom] using congrArg (fun q ↦ q.unop.hom x) h
+  simpa only [grpObjMap_unop_hom, BialgHom.coe_toAlgHom] using
+    congrArg (fun q ↦ q.unop.hom x) h
 
 /-- The identity coordinate morphism represents the identity group-object morphism. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Basic.lean
@@ -35,6 +35,8 @@ coordinate Hopf algebras acts on points by pre-composition.
 * `CommHopfAlgCat.grpObj`: the underlying object of the represented group object.
 * `CommHopfAlgCat.grpObjMap`: the contravariant morphism of represented group objects induced by a
   coordinate Hopf-algebra morphism.
+* `CommHopfAlgCat.grpObjMap_injective`: represented group-object maps determine their coordinate
+  Hopf-algebra morphisms.
 
 ## References
 
@@ -75,6 +77,22 @@ noncomputable def grpObjMap {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
 @[simp]
 theorem grpObjMap_unop {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
     (grpObjMap f).unop = CommAlgCat.ofHom f.hom := (rfl)
+
+/-- The underlying algebra homomorphism of the opposite of `grpObjMap f` is the underlying
+algebra homomorphism of `f`. -/
+theorem grpObjMap_unop_hom {H K : _root_.CommHopfAlgCat.{u} R} (f : H ⟶ K) :
+    (grpObjMap f).unop.hom = f.hom.toAlgHom :=
+  congrArg CommAlgCat.Hom.hom (grpObjMap_unop f)
+
+/-- Represented group-object maps determine their coordinate Hopf-algebra morphisms. -/
+theorem grpObjMap_injective {H K : _root_.CommHopfAlgCat.{u} R} :
+    Function.Injective (grpObjMap : (H ⟶ K) → (grpObj K ⟶ grpObj H)) := by
+  intro f g h
+  apply _root_.CommHopfAlgCat.hom_ext
+  apply BialgHom.ext
+  intro x
+  change f.hom.toAlgHom x = g.hom.toAlgHom x
+  simpa only [grpObjMap_unop_hom] using congrArg (fun q ↦ q.unop.hom x) h
 
 /-- The identity coordinate morphism represents the identity group-object morphism. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.Conjugation
 
 /-!
 # Yoneda theory for the functor of points
@@ -45,6 +46,8 @@ shrinking part.
   group-Yoneda model to algebra morphisms.
 * `TauCeti.CommHopfAlgCat.grpObjPointsMulEquiv`: generalized points of the represented group
   object are its convolution points.
+* `TauCeti.CommHopfAlgCat.grpObj_conj_unop_hom`: categorical conjugation unops to the coordinate
+  conjugation algebra map.
 * `TauCeti.CommHopfAlgCat.groupYonedaPointsFunctorIso`: the group-valued Yoneda model is
   naturally isomorphic to the existing points functor.
 * `TauCeti.CommHopfAlgCat.pointsFunctor_faithful` and
@@ -66,7 +69,7 @@ Hopf-algebra/cogroup equivalence, `CategoryTheory.yonedaGrp`, and its essential-
 
 public section
 
-open CategoryTheory Opposite WithConv
+open CategoryTheory MonoidalCategory CartesianMonoidalCategory Opposite WithConv
 open scoped CategoryTheory.MonObj
 
 namespace TauCeti
@@ -331,6 +334,28 @@ theorem grpObjPointsMulEquiv_apply (H : _root_.CommHopfAlgCat.{u} R)
     (X : (CommAlgCat.{u} R)ᵒᵖ) (g : X ⟶ grpObj H) :
     grpObjPointsMulEquiv H X g = toConv g.unop.hom := by
   exact HopfAlgebra.pointsHomEquiv_apply H g.unop
+
+/-- Unopping categorical conjugation on the represented group object gives the coordinate
+conjugation algebra map. -/
+theorem grpObj_conj_unop_hom (H : _root_.CommHopfAlgCat.{u} R) :
+    (GrpObj.conj (grpObj H)).unop.hom =
+      HopfAlgebra.conjugationAlgHom (R := R) (H := H) := by
+  apply WithConv.toConv_injective
+  calc
+    WithConv.toConv (GrpObj.conj (grpObj H)).unop.hom =
+        grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (GrpObj.conj (grpObj H)) := by
+      rw [grpObjPointsMulEquiv_apply]
+    _ = grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (fst (grpObj H) (grpObj H)) *
+        grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (snd (grpObj H) (grpObj H)) *
+        (grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (fst (grpObj H) (grpObj H)))⁻¹ := by
+      rw [GrpObj.conj, map_mul, map_mul, map_inv]
+    _ = WithConv.toConv (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) := by
+      rw [grpObjPointsMulEquiv_apply,
+        grpObjPointsMulEquiv_apply H (grpObj H ⊗ grpObj H) (snd (grpObj H) (grpObj H))]
+      simpa only [CommAlgCat.fst_unop_hom, CommAlgCat.snd_unop_hom,
+        Bialgebra.TensorProduct.includeLeft_toAlgHom,
+        Bialgebra.TensorProduct.includeRight_toAlgHom] using
+        (HopfAlgebra.toConv_conjugationAlgHom (R := R) (H := H)).symm
 
 /-- The inverse point equivalence bundles a convolution point as a morphism in the opposite
 category of commutative algebras. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
@@ -32,8 +32,6 @@ The multiplication bridge used here is `TauCeti.CommHopfAlgCat.grpObjPointsMulEq
 
 * `TauCeti.CommHopfAlgCat.quotientGrpObjInclusion_normal_iff`: a Hopf ideal is normal exactly
   when its categorical inclusion is a normal subgroup object.
-* `TauCeti.CommHopfAlgCat.grpObj_conj_unop_hom`: categorical conjugation unops to the coordinate
-  conjugation algebra map.
 
 ## References
 
@@ -58,28 +56,6 @@ namespace TauCeti.CommHopfAlgCat
 universe u
 
 variable {R : Type u} [CommRing R]
-
-/-- Unopping categorical conjugation on the represented group object gives the coordinate
-conjugation algebra map. -/
-theorem grpObj_conj_unop_hom (H : _root_.CommHopfAlgCat.{u} R) :
-    (GrpObj.conj (grpObj H)).unop.hom =
-      HopfAlgebra.conjugationAlgHom (R := R) (H := H) := by
-  apply WithConv.toConv_injective
-  calc
-    WithConv.toConv (GrpObj.conj (grpObj H)).unop.hom =
-        grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (GrpObj.conj (grpObj H)) := by
-      rw [grpObjPointsMulEquiv_apply]
-    _ = grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (fst (grpObj H) (grpObj H)) *
-        grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (snd (grpObj H) (grpObj H)) *
-        (grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (fst (grpObj H) (grpObj H)))⁻¹ := by
-      rw [GrpObj.conj, map_mul, map_mul, map_inv]
-    _ = WithConv.toConv (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) := by
-      rw [grpObjPointsMulEquiv_apply,
-        grpObjPointsMulEquiv_apply H (grpObj H ⊗ grpObj H) (snd (grpObj H) (grpObj H))]
-      simpa only [CommAlgCat.fst_unop_hom, CommAlgCat.snd_unop_hom,
-        Bialgebra.TensorProduct.includeLeft_toAlgHom,
-        Bialgebra.TensorProduct.includeRight_toAlgHom] using
-        (HopfAlgebra.toConv_conjugationAlgHom (R := R) (H := H)).symm
 
 /-- Mapping the range of a categorical quotient inclusion through the generalized-point
 equivalence gives the subgroup cut out by the Hopf ideal. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Categorical.lean
@@ -32,6 +32,8 @@ The multiplication bridge used here is `TauCeti.CommHopfAlgCat.grpObjPointsMulEq
 
 * `TauCeti.CommHopfAlgCat.quotientGrpObjInclusion_normal_iff`: a Hopf ideal is normal exactly
   when its categorical inclusion is a normal subgroup object.
+* `TauCeti.CommHopfAlgCat.grpObj_conj_unop_hom`: categorical conjugation unops to the coordinate
+  conjugation algebra map.
 
 ## References
 
@@ -48,7 +50,7 @@ two normal unipotent-radical candidates.
 
 public section
 
-open CategoryTheory Opposite WithConv
+open CategoryTheory MonoidalCategory CartesianMonoidalCategory Opposite WithConv
 open scoped CategoryTheory.MonObj
 
 namespace TauCeti.CommHopfAlgCat
@@ -56,6 +58,28 @@ namespace TauCeti.CommHopfAlgCat
 universe u
 
 variable {R : Type u} [CommRing R]
+
+/-- Unopping categorical conjugation on the represented group object gives the coordinate
+conjugation algebra map. -/
+theorem grpObj_conj_unop_hom (H : _root_.CommHopfAlgCat.{u} R) :
+    (GrpObj.conj (grpObj H)).unop.hom =
+      HopfAlgebra.conjugationAlgHom (R := R) (H := H) := by
+  apply WithConv.toConv_injective
+  calc
+    WithConv.toConv (GrpObj.conj (grpObj H)).unop.hom =
+        grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (GrpObj.conj (grpObj H)) := by
+      rw [grpObjPointsMulEquiv_apply]
+    _ = grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (fst (grpObj H) (grpObj H)) *
+        grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (snd (grpObj H) (grpObj H)) *
+        (grpObjPointsMulEquiv H (grpObj H ⊗ grpObj H) (fst (grpObj H) (grpObj H)))⁻¹ := by
+      rw [GrpObj.conj, map_mul, map_mul, map_inv]
+    _ = WithConv.toConv (HopfAlgebra.conjugationAlgHom (R := R) (H := H)) := by
+      rw [grpObjPointsMulEquiv_apply,
+        grpObjPointsMulEquiv_apply H (grpObj H ⊗ grpObj H) (snd (grpObj H) (grpObj H))]
+      simpa only [CommAlgCat.fst_unop_hom, CommAlgCat.snd_unop_hom,
+        Bialgebra.TensorProduct.includeLeft_toAlgHom,
+        Bialgebra.TensorProduct.includeRight_toAlgHom] using
+        (HopfAlgebra.toConv_conjugationAlgHom (R := R) (H := H)).symm
 
 /-- Mapping the range of a categorical quotient inclusion through the generalized-point
 equivalence gives the subgroup cut out by the Hopf ideal. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Categorical
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Basic
 public import TauCeti.CategoryTheory.Monoidal.SemidirectProduct.Normal
@@ -69,11 +70,10 @@ an action of affine group objects. -/
 and another closed affine subgroup. Its underlying commutative algebra is
 `(H / I) ⊗[ R ] (H / J)`, and its Hopf structure records conjugation of the second subgroup
 on the first. -/
-@[expose] noncomputable def normalSemidirectProduct
+noncomputable abbrev normalSemidirectProduct
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) : _root_.CommHopfAlgCat.{u} R :=
-  (commHopfAlgCatEquivCogrpCommAlgCat R).inverse.obj
-    (op (quotientNormalConjugation H I J hI).semidirectProduct)
+  (quotientNormalConjugation H I J hI).coordinateHopfAlgebra
 
 /-- The coordinate Hopf-algebra morphism dual to multiplication from the semidirect product of
 a normal closed subgroup and another closed subgroup into the ambient affine group. -/
@@ -128,42 +128,8 @@ theorem grpObjMap_productMapOfNormal
       (GrpObj.Action.normalSemidirectMul i j).hom.hom := by
   apply Quiver.Hom.unop_inj
   apply CommAlgCat.hom_ext
-  rw [show (grpObjMap (productMapOfNormal H I J hI)).unop.hom =
-      (productMapOfNormal H I J hI).hom.toAlgHom by
-    exact congrArg CommAlgCat.Hom.hom (grpObjMap_unop _)]
+  rw [grpObjMap_unop_hom]
   exact productMapOfNormal_hom H I J hI
-
-/-- Normal semidirect multiplication restricts to the first quotient-subgroup inclusion. -/
-theorem quotientNormalConjugation_inl_comp_normalSemidirectMul
-    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
-    (hI : I.IsNormal) :
-    let i := quotientGrpObjInclusion H I
-    let j := quotientGrpObjInclusion H J
-    let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
-    (quotientNormalConjugation H I J hI).inl.hom.hom ≫
-        (GrpObj.Action.normalSemidirectMul i j).hom.hom = i := by
-  have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
-    (quotientGrpObjInclusion_normal_iff H I).2 hI
-  simpa only [quotientNormalConjugation, Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
-    congrArg (fun f ↦ f.hom.hom)
-      (GrpObj.Action.inl_comp_normalSemidirectMul
-        (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J))
-
-/-- Normal semidirect multiplication restricts to the second quotient-subgroup inclusion. -/
-theorem quotientNormalConjugation_inr_comp_normalSemidirectMul
-    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
-    (hI : I.IsNormal) :
-    let i := quotientGrpObjInclusion H I
-    let j := quotientGrpObjInclusion H J
-    let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
-    (quotientNormalConjugation H I J hI).inr.hom.hom ≫
-        (GrpObj.Action.normalSemidirectMul i j).hom.hom = j := by
-  have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
-    (quotientGrpObjInclusion_normal_iff H I).2 hI
-  simpa only [quotientNormalConjugation, Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
-    congrArg (fun f ↦ f.hom.hom)
-      (GrpObj.Action.inr_comp_normalSemidirectMul
-        (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J))
 
 variable {k : Type u} [Field k]
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
@@ -101,6 +101,70 @@ theorem productMapOfNormal_def
           (op (GrpObj.Action.normalSemidirectMul i j)) :=
   (rfl)
 
+/-- The underlying coordinate algebra map of `productMapOfNormal` is the opposite of normal
+semidirect multiplication. -/
+@[simp]
+theorem productMapOfNormal_hom
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) :
+    let i := quotientGrpObjInclusion H I
+    let j := quotientGrpObjInclusion H J
+    let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
+    (productMapOfNormal H I J hI).hom.toAlgHom =
+      (GrpObj.Action.normalSemidirectMul i j).hom.hom.unop.hom := by
+  rw [productMapOfNormal_def]
+  rfl
+
+/-- The represented group-object map of `productMapOfNormal` is normal semidirect
+multiplication. -/
+@[simp]
+theorem grpObjMap_productMapOfNormal
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) :
+    let i := quotientGrpObjInclusion H I
+    let j := quotientGrpObjInclusion H J
+    let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
+    grpObjMap (productMapOfNormal H I J hI) =
+      (GrpObj.Action.normalSemidirectMul i j).hom.hom := by
+  apply Quiver.Hom.unop_inj
+  apply CommAlgCat.hom_ext
+  rw [show (grpObjMap (productMapOfNormal H I J hI)).unop.hom =
+      (productMapOfNormal H I J hI).hom.toAlgHom by
+    exact congrArg CommAlgCat.Hom.hom (grpObjMap_unop _)]
+  exact productMapOfNormal_hom H I J hI
+
+/-- Normal semidirect multiplication restricts to the first quotient-subgroup inclusion. -/
+theorem quotientNormalConjugation_inl_comp_normalSemidirectMul
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) :
+    let i := quotientGrpObjInclusion H I
+    let j := quotientGrpObjInclusion H J
+    let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
+    (quotientNormalConjugation H I J hI).inl.hom.hom ≫
+        (GrpObj.Action.normalSemidirectMul i j).hom.hom = i := by
+  have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
+    (quotientGrpObjInclusion_normal_iff H I).2 hI
+  simpa only [quotientNormalConjugation, Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
+    congrArg (fun f ↦ f.hom.hom)
+      (GrpObj.Action.inl_comp_normalSemidirectMul
+        (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J))
+
+/-- Normal semidirect multiplication restricts to the second quotient-subgroup inclusion. -/
+theorem quotientNormalConjugation_inr_comp_normalSemidirectMul
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) :
+    let i := quotientGrpObjInclusion H I
+    let j := quotientGrpObjInclusion H J
+    let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
+    (quotientNormalConjugation H I J hI).inr.hom.hom ≫
+        (GrpObj.Action.normalSemidirectMul i j).hom.hom = j := by
+  have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
+    (quotientGrpObjInclusion_normal_iff H I).2 hI
+  simpa only [quotientNormalConjugation, Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
+    congrArg (fun f ↦ f.hom.hom)
+      (GrpObj.Action.inr_comp_normalSemidirectMul
+        (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J))
+
 variable {k : Type u} [Field k]
 
 /-- The coordinate Hopf algebra of the scheme-theoretic multiplication image. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
@@ -71,16 +71,59 @@ an action of affine group objects. -/
 and another closed affine subgroup. Its underlying commutative algebra is
 `(H / I) ⊗[ R ] (H / J)`, and its Hopf structure records conjugation of the second subgroup
 on the first. -/
-noncomputable abbrev normalSemidirectProduct
+noncomputable def normalSemidirectProduct
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) : _root_.CommHopfAlgCat.{u} R :=
   (quotientNormalConjugation H I J hI).coordinateHopfAlgebra
 
-/-- The coordinate Hopf-algebra morphism dual to multiplication from the semidirect product of
-a normal closed subgroup and another closed subgroup into the ambient affine group. -/
-noncomputable def productMapOfNormal
+/-- The canonical comparison between the named normal semidirect product and the coordinate
+Hopf algebra supplied by the categorical semidirect-product construction. -/
+noncomputable def normalSemidirectProductIso
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
-    (hI : I.IsNormal) : H ⟶ normalSemidirectProduct H I J hI := by
+    (hI : I.IsNormal) :
+    normalSemidirectProduct H I J hI ≅
+      (quotientNormalConjugation H I J hI).coordinateHopfAlgebra := by
+  rw [normalSemidirectProduct]
+
+/-- The coordinate morphism representing inclusion of the normal factor in the named normal
+semidirect product. -/
+noncomputable def normalSemidirectProductCoordinateInl
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) : normalSemidirectProduct H I J hI ⟶ quotient H I :=
+  (normalSemidirectProductIso H I J hI).hom ≫
+    (quotientNormalConjugation H I J hI).coordinateInl
+
+/-- The coordinate morphism representing inclusion of the acting factor in the named normal
+semidirect product. -/
+noncomputable def normalSemidirectProductCoordinateInr
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) : normalSemidirectProduct H I J hI ⟶ quotient H J :=
+  (normalSemidirectProductIso H I J hI).hom ≫
+    (quotientNormalConjugation H I J hI).coordinateInr
+
+/-- The normal-factor coordinate morphism is transported by the canonical comparison. -/
+theorem normalSemidirectProductCoordinateInl_eq
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) :
+    normalSemidirectProductCoordinateInl H I J hI =
+      (normalSemidirectProductIso H I J hI).hom ≫
+        (quotientNormalConjugation H I J hI).coordinateInl := by
+  rw [normalSemidirectProductCoordinateInl]
+
+/-- The acting-factor coordinate morphism is transported by the canonical comparison. -/
+theorem normalSemidirectProductCoordinateInr_eq
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) :
+    normalSemidirectProductCoordinateInr H I J hI =
+      (normalSemidirectProductIso H I J hI).hom ≫
+        (quotientNormalConjugation H I J hI).coordinateInr := by
+  rw [normalSemidirectProductCoordinateInr]
+
+/-- The coordinate map obtained directly from categorical normal semidirect multiplication. -/
+noncomputable def normalSemidirectMultiplicationCoordinateMap
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) :
+    H ⟶ (quotientNormalConjugation H I J hI).coordinateHopfAlgebra := by
   let i := quotientGrpObjInclusion H I
   let j := quotientGrpObjInclusion H J
   letI : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
@@ -88,49 +131,71 @@ noncomputable def productMapOfNormal
     (commHopfAlgCatEquivCogrpCommAlgCat R).inverse.map
       (op (GrpObj.Action.normalSemidirectMul i j))
 
-/-- The product coordinate morphism is the transport of categorical normal semidirect
-multiplication. -/
-theorem productMapOfNormal_def
+/-- The coordinate Hopf-algebra morphism dual to multiplication from the semidirect product of
+a normal closed subgroup and another closed subgroup into the ambient affine group. -/
+noncomputable def productMapOfNormal
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) : H ⟶ normalSemidirectProduct H I J hI :=
+  normalSemidirectMultiplicationCoordinateMap H I J hI ≫
+    (normalSemidirectProductIso H I J hI).inv
+
+/-- After the canonical comparison, the product coordinate morphism is the transport of
+categorical normal semidirect multiplication. -/
+@[reassoc (attr := simp)]
+theorem productMapOfNormal_comp_normalSemidirectProductIso_hom
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
-    let i := quotientGrpObjInclusion H I
-    let j := quotientGrpObjInclusion H J
-    letI : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
-    productMapOfNormal H I J hI =
-      (commHopfAlgCatEquivCogrpCommAlgCat R).unitIso.hom.app H ≫
-        (commHopfAlgCatEquivCogrpCommAlgCat R).inverse.map
-          (op (GrpObj.Action.normalSemidirectMul i j)) :=
-  (rfl)
+    productMapOfNormal H I J hI ≫ (normalSemidirectProductIso H I J hI).hom =
+      normalSemidirectMultiplicationCoordinateMap H I J hI := by
+  rw [productMapOfNormal, Category.assoc, Iso.inv_hom_id, Category.comp_id]
 
-/-- The underlying coordinate algebra map of `productMapOfNormal` is the algebra map obtained by
+/-- The underlying algebra map of the direct categorical coordinate map is obtained by
 unopping normal semidirect multiplication. -/
-theorem productMapOfNormal_hom_toAlgHom
+theorem normalSemidirectMultiplicationCoordinateMap_hom_toAlgHom
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
     let i := quotientGrpObjInclusion H I
     let j := quotientGrpObjInclusion H J
     let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
-    (productMapOfNormal H I J hI).hom.toAlgHom =
+    (normalSemidirectMultiplicationCoordinateMap H I J hI).hom.toAlgHom =
       (GrpObj.Action.normalSemidirectMul i j).hom.hom.unop.hom := by
-  rw [productMapOfNormal_def]
+  rw [normalSemidirectMultiplicationCoordinateMap]
   -- The unit of Mathlib's Hopf/cogroup equivalence is definitionally the identity on the
   -- underlying algebra map, leaving exactly the unop of semidirect multiplication.
   rfl
 
-/-- The represented group-object map of `productMapOfNormal` is normal semidirect
-multiplication. -/
+/-- The represented group-object map of the direct categorical coordinate map is normal
+semidirect multiplication. -/
+theorem grpObjMap_normalSemidirectMultiplicationCoordinateMap
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) :
+    let i := quotientGrpObjInclusion H I
+    let j := quotientGrpObjInclusion H J
+    let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
+    grpObjMap (normalSemidirectMultiplicationCoordinateMap H I J hI) =
+      (GrpObj.Action.normalSemidirectMul i j).hom.hom := by
+  apply Quiver.Hom.unop_inj
+  apply CommAlgCat.hom_ext
+  rw [grpObjMap_unop_hom]
+  exact normalSemidirectMultiplicationCoordinateMap_hom_toAlgHom H I J hI
+
+/-- After the canonical comparison, the represented group-object map of `productMapOfNormal`
+is normal semidirect multiplication. -/
 theorem grpObjMap_productMapOfNormal
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
     let i := quotientGrpObjInclusion H I
     let j := quotientGrpObjInclusion H J
     let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
-    grpObjMap (productMapOfNormal H I J hI) =
+    grpObjMap (normalSemidirectProductIso H I J hI).hom ≫
+      grpObjMap (productMapOfNormal H I J hI) =
       (GrpObj.Action.normalSemidirectMul i j).hom.hom := by
+  rw [← grpObjMap_comp]
+  rw [productMapOfNormal_comp_normalSemidirectProductIso_hom]
   apply Quiver.Hom.unop_inj
   apply CommAlgCat.hom_ext
   rw [grpObjMap_unop_hom]
-  exact productMapOfNormal_hom_toAlgHom H I J hI
+  exact normalSemidirectMultiplicationCoordinateMap_hom_toAlgHom H I J hI
 
 variable {k : Type u} [Field k]
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
@@ -102,7 +102,7 @@ noncomputable def normalSemidirectProductCoordinateInr
     (quotientNormalConjugation H I J hI).coordinateInr
 
 /-- The normal-factor coordinate morphism is transported by the canonical comparison. -/
-theorem normalSemidirectProductCoordinateInl_eq
+theorem normalSemidirectProductCoordinateInl_def
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
     normalSemidirectProductCoordinateInl H I J hI =
@@ -111,7 +111,7 @@ theorem normalSemidirectProductCoordinateInl_eq
   rw [normalSemidirectProductCoordinateInl]
 
 /-- The acting-factor coordinate morphism is transported by the canonical comparison. -/
-theorem normalSemidirectProductCoordinateInr_eq
+theorem normalSemidirectProductCoordinateInr_def
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
     normalSemidirectProductCoordinateInr H I J hI =
@@ -120,7 +120,7 @@ theorem normalSemidirectProductCoordinateInr_eq
   rw [normalSemidirectProductCoordinateInr]
 
 /-- The coordinate map obtained directly from categorical normal semidirect multiplication. -/
-noncomputable def normalSemidirectMultiplicationCoordinateMap
+private noncomputable def normalSemidirectMultiplicationCoordinateMap
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
     H ⟶ (quotientNormalConjugation H I J hI).coordinateHopfAlgebra := by
@@ -141,8 +141,7 @@ noncomputable def productMapOfNormal
 
 /-- After the canonical comparison, the product coordinate morphism is the transport of
 categorical normal semidirect multiplication. -/
-@[reassoc (attr := simp)]
-theorem productMapOfNormal_comp_normalSemidirectProductIso_hom
+private theorem productMapOfNormal_comp_normalSemidirectProductIso_hom
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
     productMapOfNormal H I J hI ≫ (normalSemidirectProductIso H I J hI).hom =
@@ -151,7 +150,7 @@ theorem productMapOfNormal_comp_normalSemidirectProductIso_hom
 
 /-- The underlying algebra map of the direct categorical coordinate map is obtained by
 unopping normal semidirect multiplication. -/
-theorem normalSemidirectMultiplicationCoordinateMap_hom_toAlgHom
+private theorem normalSemidirectMultiplicationCoordinateMap_hom_toAlgHom
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
     let i := quotientGrpObjInclusion H I
@@ -166,7 +165,7 @@ theorem normalSemidirectMultiplicationCoordinateMap_hom_toAlgHom
 
 /-- The represented group-object map of the direct categorical coordinate map is normal
 semidirect multiplication. -/
-theorem grpObjMap_normalSemidirectMultiplicationCoordinateMap
+private theorem grpObjMap_normalSemidirectMultiplicationCoordinateMap
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
     let i := quotientGrpObjInclusion H I
@@ -192,10 +191,7 @@ theorem grpObjMap_productMapOfNormal
       (GrpObj.Action.normalSemidirectMul i j).hom.hom := by
   rw [← grpObjMap_comp]
   rw [productMapOfNormal_comp_normalSemidirectProductIso_hom]
-  apply Quiver.Hom.unop_inj
-  apply CommAlgCat.hom_ext
-  rw [grpObjMap_unop_hom]
-  exact normalSemidirectMultiplicationCoordinateMap_hom_toAlgHom H I J hI
+  exact grpObjMap_normalSemidirectMultiplicationCoordinateMap H I J hI
 
 variable {k : Type u} [Field k]
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
@@ -20,8 +20,9 @@ homomorphism. This file packages the corresponding coordinate Hopf-algebra morph
 the product subgroup as its scheme-theoretic image.
 
 This is the multiplication-image object required by the maximal-dimension construction of the
-unipotent radical. Establishing its containment of both factors and closure of normality,
-connectedness, smoothness, and unipotence are subsequent steps.
+unipotent radical. Containment of both factors and normality are proved in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties`; connectedness, smoothness,
+and unipotence of the image remain subsequent steps.
 
 ## Main declarations
 
@@ -101,10 +102,9 @@ theorem productMapOfNormal_def
           (op (GrpObj.Action.normalSemidirectMul i j)) :=
   (rfl)
 
-/-- The underlying coordinate algebra map of `productMapOfNormal` is the opposite of normal
-semidirect multiplication. -/
-@[simp]
-theorem productMapOfNormal_hom
+/-- The underlying coordinate algebra map of `productMapOfNormal` is the algebra map obtained by
+unopping normal semidirect multiplication. -/
+theorem productMapOfNormal_hom_toAlgHom
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
     let i := quotientGrpObjInclusion H I
@@ -113,11 +113,12 @@ theorem productMapOfNormal_hom
     (productMapOfNormal H I J hI).hom.toAlgHom =
       (GrpObj.Action.normalSemidirectMul i j).hom.hom.unop.hom := by
   rw [productMapOfNormal_def]
+  -- The unit of Mathlib's Hopf/cogroup equivalence is definitionally the identity on the
+  -- underlying algebra map, leaving exactly the unop of semidirect multiplication.
   rfl
 
 /-- The represented group-object map of `productMapOfNormal` is normal semidirect
 multiplication. -/
-@[simp]
 theorem grpObjMap_productMapOfNormal
     (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
     (hI : I.IsNormal) :
@@ -129,7 +130,7 @@ theorem grpObjMap_productMapOfNormal
   apply Quiver.Hom.unop_inj
   apply CommAlgCat.hom_ext
   rw [grpObjMap_unop_hom]
-  exact productMapOfNormal_hom H I J hI
+  exact productMapOfNormal_hom_toAlgHom H I J hI
 
 variable {k : Type u} [Field k]
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
@@ -58,7 +58,9 @@ universe u
 
 noncomputable section
 
-variable {k : Type u} [Field k]
+section
+
+variable {k : Type u} [CommRing k]
 
 /-- Multiplication from the conjugation semidirect product restricts on its normal factor to the
 closed-subgroup quotient morphism. -/
@@ -73,8 +75,17 @@ theorem productMapOfNormal_comp_coordinateInl
   rw [grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInl]
   rw [grpObjMap_productMapOfNormal]
   rw [← quotientGrpObjInclusion_def]
-  exact GrpObj.Action.inl_hom_comp_normalSemidirectMul_hom
-    (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J)
+  have hrestriction :
+      let A := GrpObj.Action.normalConjugation
+        (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J)
+      A.inl.hom.hom ≫
+          (GrpObj.Action.normalSemidirectMul
+            (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J)).hom.hom =
+        quotientGrpObjInclusion H I := by
+    simpa only [Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
+      congrArg (fun f ↦ f.hom.hom) (GrpObj.Action.inl_comp_normalSemidirectMul
+        (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J))
+  exact hrestriction
 
 /-- Multiplication from the conjugation semidirect product restricts on its acting factor to the
 closed-subgroup quotient morphism. -/
@@ -89,8 +100,21 @@ theorem productMapOfNormal_comp_coordinateInr
   rw [grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInr]
   rw [grpObjMap_productMapOfNormal]
   rw [← quotientGrpObjInclusion_def]
-  exact GrpObj.Action.inr_hom_comp_normalSemidirectMul_hom
-    (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J)
+  have hrestriction :
+      let A := GrpObj.Action.normalConjugation
+        (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J)
+      A.inr.hom.hom ≫
+          (GrpObj.Action.normalSemidirectMul
+            (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J)).hom.hom =
+        quotientGrpObjInclusion H J := by
+    simpa only [Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
+      congrArg (fun f ↦ f.hom.hom) (GrpObj.Action.inr_comp_normalSemidirectMul
+        (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J))
+  exact hrestriction
+
+end
+
+variable {k : Type u} [Field k]
 
 /-- The defining Hopf ideal of the multiplication image lies below the ideal of the normal
 factor. Equivalently, the product image contains that factor as a closed subgroup scheme. -/
@@ -104,8 +128,7 @@ theorem productOfNormal_definingIdeal_le_left
     (HopfIdeal.mem_ker _).mp hx
   have hcomp := congrArg (fun f : H ⟶ quotient H I ↦ f.hom x)
     (productMapOfNormal_comp_coordinateInl H I J hI)
-  change ((quotientNormalConjugation H I J hI).coordinateInl).hom
-      ((productMapOfNormal H I J hI).hom x) = (mkQuotient H I).hom x at hcomp
+  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp, Function.comp_apply] at hcomp
   rw [← hcomp, hx0, map_zero]
 
 /-- The defining Hopf ideal of the multiplication image lies below the ideal of the acting
@@ -120,16 +143,14 @@ theorem productOfNormal_definingIdeal_le_right
     (HopfIdeal.mem_ker _).mp hx
   have hcomp := congrArg (fun f : H ⟶ quotient H J ↦ f.hom x)
     (productMapOfNormal_comp_coordinateInr H I J hI)
-  change ((quotientNormalConjugation H I J hI).coordinateInr).hom
-      ((productMapOfNormal H I J hI).hom x) = (mkQuotient H J).hom x at hcomp
+  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp, Function.comp_apply] at hcomp
   rw [← hcomp, hx0, map_zero]
 
 private theorem whiskerLeft_grpObjMap_unop_hom
     {H K : _root_.CommHopfAlgCat.{u} k} (f : H ⟶ K) :
     (MonoidalCategoryStruct.whiskerLeft (grpObj H) (grpObjMap f)).unop.hom =
       Algebra.TensorProduct.map (AlgHom.id k H) f.hom.toAlgHom := by
-  change Algebra.TensorProduct.map (AlgHom.id k H) (grpObjMap f).unop.hom = _
-  rw [grpObjMap_unop_hom]
+  simp only [unop_whiskerLeft, CommAlgCat.whiskerLeft_hom, grpObjMap_unop_hom]
 
 private theorem grpObj_conj_unop_hom (H : _root_.CommHopfAlgCat.{u} k) :
     (GrpObj.conj (grpObj H)).unop.hom =
@@ -180,6 +201,20 @@ private noncomputable def normalSemidirectConjugationAlgHom
   dsimp only [normalSemidirectProduct]
   exact (GrpObj.Action.normalSemidirectConjugation i j).hom.unop.hom
 
+private theorem normalSemidirectConjugationAlgHom_def
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
+    (hI : I.IsNormal) (hJ : J.IsNormal) :
+    normalSemidirectConjugationAlgHom H I J hI hJ = by
+      let i := quotientGrpObjInclusion H I
+      let j := quotientGrpObjInclusion H J
+      let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
+      let _ : IsMonHom.Normal j := (quotientGrpObjInclusion_normal_iff H J).2 hJ
+      let A := GrpObj.Action.normalConjugation i j
+      let _ := A.semidirectProductGrpObj
+      dsimp only [normalSemidirectProduct]
+      exact (GrpObj.Action.normalSemidirectConjugation i j).hom.unop.hom := by
+  rfl
+
 private theorem productMapOfNormal_conjugation_equivariant
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
     (hI : I.IsNormal) (hJ : J.IsNormal) :
@@ -214,8 +249,7 @@ private theorem productMapOfNormal_conjugation_equivariant
           grpObjMap (productMapOfNormal H I J hI)).unop.hom =
         (normalSemidirectConjugationAlgHom H I J hI hJ).comp
           (productMapOfNormal H I J hI).hom.toAlgHom := by
-    rw [hproduct, productMapOfNormal_hom]
-    dsimp only [normalSemidirectConjugationAlgHom]
+    rw [hproduct, productMapOfNormal_hom, normalSemidirectConjugationAlgHom_def]
     rfl
   exact hleft.symm.trans (hunop.trans hright)
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
@@ -1,0 +1,290 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Image
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
+public import TauCeti.CategoryTheory.Monoidal.SemidirectProduct.Equivariance
+
+/-!
+# Containment and normality of normal-subgroup products
+
+Let `I` and `J` be Hopf ideals of a commutative Hopf algebra `H`. If `I` is normal, multiplication
+from the conjugation semidirect product has a scheme-theoretic image in `Spec H`. This file proves
+that the image contains the closed subgroups cut out by both `I` and `J`. If `J` is normal as well,
+then the product image is normal.
+
+Containment is contravariant: the kernel Hopf ideal of the product coordinate map lies below each
+of `I` and `J`. Normality follows by translating simultaneous-conjugation equivariance of
+semidirect multiplication to coordinate algebras, then applying the general theorem that the
+kernel of an equivariant coordinate morphism is normal.
+
+These are two of the structural inputs needed to prove binary-product closure of connected normal
+smooth unipotent closed subgroups. Connectedness and smooth unipotence of the product image are
+separate steps.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.productMapOfNormal_comp_coordinateInl` and
+  `TauCeti.CommHopfAlgCat.productMapOfNormal_comp_coordinateInr`: multiplication restricts to the
+  two original closed-subgroup inclusions.
+* `TauCeti.CommHopfAlgCat.productOfNormal_definingIdeal_le_left` and
+  `TauCeti.CommHopfAlgCat.productOfNormal_definingIdeal_le_right`: the product image contains both
+  factors.
+* `TauCeti.CommHopfAlgCat.isNormal_productOfNormal_definingIdeal`: the product of two normal
+  closed affine subgroups is normal.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a, 6.a.
+* A. Borel, *Linear Algebraic Groups*, Proposition 14.4.
+
+This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap by proving the
+containment and normality parts of binary-product closure for unipotent-radical candidates.
+-/
+
+public section
+
+open CategoryTheory Opposite
+open scoped CategoryTheory.MonObj TensorProduct
+
+namespace TauCeti.CommHopfAlgCat
+
+universe u
+
+noncomputable section
+
+variable {k : Type u} [Field k]
+
+private theorem grpObjMap_unop_hom
+    {H K : _root_.CommHopfAlgCat.{u} k} (f : H ⟶ K) :
+    (grpObjMap f).unop.hom = f.hom.toAlgHom :=
+  congrArg CommAlgCat.Hom.hom (grpObjMap_unop f)
+
+/-- The coordinate morphism representing inclusion of the normal factor into the conjugation
+semidirect product. -/
+noncomputable def normalSemidirectProductCoordinateInl
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
+    normalSemidirectProduct H I J hI ⟶ quotient H I := by
+  dsimp only [normalSemidirectProduct]
+  exact (quotientNormalConjugation H I J hI).coordinateInl
+
+/-- The coordinate morphism representing inclusion of the acting factor into the conjugation
+semidirect product. -/
+noncomputable def normalSemidirectProductCoordinateInr
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
+    normalSemidirectProduct H I J hI ⟶ quotient H J := by
+  dsimp only [normalSemidirectProduct]
+  exact (quotientNormalConjugation H I J hI).coordinateInr
+
+/-- The represented group-object map of `normalSemidirectProductCoordinateInl` is the canonical
+inclusion of the normal factor. -/
+@[simp]
+theorem grpObjMap_normalSemidirectProductCoordinateInl
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
+    grpObjMap (normalSemidirectProductCoordinateInl H I J hI) =
+      (quotientNormalConjugation H I J hI).inl.hom.hom := by
+  rw [normalSemidirectProductCoordinateInl]
+  exact GrpObj.Action.grpObjMap_coordinateInl _
+
+/-- The represented group-object map of `normalSemidirectProductCoordinateInr` is the canonical
+inclusion of the acting factor. -/
+@[simp]
+theorem grpObjMap_normalSemidirectProductCoordinateInr
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
+    grpObjMap (normalSemidirectProductCoordinateInr H I J hI) =
+      (quotientNormalConjugation H I J hI).inr.hom.hom := by
+  rw [normalSemidirectProductCoordinateInr]
+  exact GrpObj.Action.grpObjMap_coordinateInr _
+
+/-- Multiplication from the conjugation semidirect product restricts on its normal factor to the
+closed-subgroup quotient morphism. -/
+@[reassoc]
+theorem productMapOfNormal_comp_coordinateInl
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
+    productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInl H I J hI =
+      mkQuotient H I := by
+  have hmap : grpObjMap
+      (productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInl H I J hI) =
+      grpObjMap (mkQuotient H I) := by
+    rw [grpObjMap_comp, grpObjMap_normalSemidirectProductCoordinateInl]
+    rw [grpObjMap_productMapOfNormal]
+    rw [← quotientGrpObjInclusion_def]
+    exact quotientNormalConjugation_inl_comp_normalSemidirectMul H I J hI
+  apply _root_.CommHopfAlgCat.hom_ext
+  apply BialgHom.ext
+  intro x
+  change
+    (productMapOfNormal H I J hI ≫
+        normalSemidirectProductCoordinateInl H I J hI).hom.toAlgHom x =
+      (mkQuotient H I).hom.toAlgHom x
+  simpa only [grpObjMap_unop_hom] using congrArg (fun q ↦ q.unop.hom x) hmap
+
+/-- Multiplication from the conjugation semidirect product restricts on its acting factor to the
+closed-subgroup quotient morphism. -/
+@[reassoc]
+theorem productMapOfNormal_comp_coordinateInr
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
+    productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInr H I J hI =
+      mkQuotient H J := by
+  have hmap : grpObjMap
+      (productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInr H I J hI) =
+      grpObjMap (mkQuotient H J) := by
+    rw [grpObjMap_comp, grpObjMap_normalSemidirectProductCoordinateInr]
+    rw [grpObjMap_productMapOfNormal]
+    rw [← quotientGrpObjInclusion_def]
+    exact quotientNormalConjugation_inr_comp_normalSemidirectMul H I J hI
+  apply _root_.CommHopfAlgCat.hom_ext
+  apply BialgHom.ext
+  intro x
+  change
+    (productMapOfNormal H I J hI ≫
+        normalSemidirectProductCoordinateInr H I J hI).hom.toAlgHom x =
+      (mkQuotient H J).hom.toAlgHom x
+  simpa only [grpObjMap_unop_hom] using congrArg (fun q ↦ q.unop.hom x) hmap
+
+/-- The defining Hopf ideal of the multiplication image lies below the ideal of the normal
+factor. Equivalently, the product image contains that factor as a closed subgroup scheme. -/
+theorem productOfNormal_definingIdeal_le_left
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
+    HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤ I := by
+  rw [← HopfIdeal.toIdeal_le_toIdeal]
+  intro x hx
+  rw [← mkQuotient_eq_zero_iff H I x]
+  have hx0 : (productMapOfNormal H I J hI).hom x = 0 :=
+    (HopfIdeal.mem_ker _).mp hx
+  have hcomp := congrArg (fun f : H ⟶ quotient H I ↦ f.hom x)
+    (productMapOfNormal_comp_coordinateInl H I J hI)
+  change (normalSemidirectProductCoordinateInl H I J hI).hom
+      ((productMapOfNormal H I J hI).hom x) = (mkQuotient H I).hom x at hcomp
+  rw [← hcomp, hx0, map_zero]
+
+/-- The defining Hopf ideal of the multiplication image lies below the ideal of the acting
+factor. Equivalently, the product image contains that factor as a closed subgroup scheme. -/
+theorem productOfNormal_definingIdeal_le_right
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
+    HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤ J := by
+  rw [← HopfIdeal.toIdeal_le_toIdeal]
+  intro x hx
+  rw [← mkQuotient_eq_zero_iff H J x]
+  have hx0 : (productMapOfNormal H I J hI).hom x = 0 :=
+    (HopfIdeal.mem_ker _).mp hx
+  have hcomp := congrArg (fun f : H ⟶ quotient H J ↦ f.hom x)
+    (productMapOfNormal_comp_coordinateInr H I J hI)
+  change (normalSemidirectProductCoordinateInr H I J hI).hom
+      ((productMapOfNormal H I J hI).hom x) = (mkQuotient H J).hom x at hcomp
+  rw [← hcomp, hx0, map_zero]
+
+private theorem whiskerLeft_grpObjMap_unop_hom
+    {H K : _root_.CommHopfAlgCat.{u} k} (f : H ⟶ K) :
+    (MonoidalCategoryStruct.whiskerLeft (grpObj H) (grpObjMap f)).unop.hom =
+      Algebra.TensorProduct.map (AlgHom.id k H) f.hom.toAlgHom := by
+  change Algebra.TensorProduct.map (AlgHom.id k H) (grpObjMap f).unop.hom = _
+  rw [grpObjMap_unop_hom]
+
+private theorem grpObj_conj_unop_hom (H : _root_.CommHopfAlgCat.{u} k) :
+    (GrpObj.conj (grpObj H)).unop.hom =
+      HopfAlgebra.conjugationAlgHom (R := k) (H := H) := by
+  have hinv :
+      ((WithConv.toConv
+        (Bialgebra.TensorProduct.includeLeft (R := k) (H₁ := H) (H₂ := H)).toAlgHom)⁻¹).ofConv =
+        (Bialgebra.TensorProduct.includeLeft (R := k) (H₁ := H) (H₂ := H)).toAlgHom.comp
+          (HopfAlgebra.antipodeAlgHom k H) := rfl
+  have hmul :
+      (WithConv.toConv
+          (Bialgebra.TensorProduct.includeLeft (R := k) (H₁ := H) (H₂ := H)).toAlgHom *
+        WithConv.toConv
+          (Bialgebra.TensorProduct.includeRight (R := k) (H₁ := H) (H₂ := H)).toAlgHom).ofConv =
+        (Algebra.TensorProduct.lift
+          (Bialgebra.TensorProduct.includeLeft (R := k) (H₁ := H) (H₂ := H)).toAlgHom
+          (Bialgebra.TensorProduct.includeRight (R := k) (H₁ := H) (H₂ := H)).toAlgHom
+          (fun _ _ ↦ .all _ _)).comp (Bialgebra.comulAlgHom k H) := by
+    ext x
+    exact AlgHom.convMul_apply _ _ x
+  apply WithConv.toConv_injective
+  rw [HopfAlgebra.toConv_conjugationAlgHom]
+  rw [GrpObj.conj, CategoryTheory.Hom.mul_def, CategoryTheory.Hom.mul_def,
+    CategoryTheory.Hom.inv_def]
+  ext x
+  simp only [unop_comp, CommAlgCat.hom_comp, CommAlgCat.lift_unop_hom,
+    CommAlgCat.mul_op_of_unop_hom, CommAlgCat.inv_op_of_unop_hom,
+    CommAlgCat.fst_unop_hom, CommAlgCat.snd_unop_hom,
+    AlgHom.convMul_apply, hinv, hmul, AlgHom.coe_comp, Function.comp_apply]
+  congr 1
+  apply Algebra.TensorProduct.ext'
+  intro a b
+  simp
+
+/-- The coordinate algebra map of simultaneous ambient conjugation on the normal semidirect
+product. -/
+private noncomputable def normalSemidirectConjugationAlgHom
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
+    (hI : I.IsNormal) (hJ : J.IsNormal) :
+    normalSemidirectProduct H I J hI →ₐ[k]
+      (H ⊗[k] normalSemidirectProduct H I J hI) := by
+  let i := quotientGrpObjInclusion H I
+  let j := quotientGrpObjInclusion H J
+  let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
+  let _ : IsMonHom.Normal j := (quotientGrpObjInclusion_normal_iff H J).2 hJ
+  let A := GrpObj.Action.normalConjugation i j
+  let _ := A.semidirectProductGrpObj
+  dsimp only [normalSemidirectProduct]
+  exact (GrpObj.Action.normalSemidirectConjugation i j).hom.unop.hom
+
+private theorem productMapOfNormal_conjugation_equivariant
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
+    (hI : I.IsNormal) (hJ : J.IsNormal) :
+    (Algebra.TensorProduct.map (AlgHom.id k H)
+        (productMapOfNormal H I J hI).hom.toAlgHom).comp
+        (HopfAlgebra.conjugationAlgHom (R := k) (H := H)) =
+      (normalSemidirectConjugationAlgHom H I J hI hJ).comp
+        (productMapOfNormal H I J hI).hom.toAlgHom := by
+  let i := quotientGrpObjInclusion H I
+  let j := quotientGrpObjInclusion H J
+  let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
+  let _ : IsMonHom.Normal j := (quotientGrpObjInclusion_normal_iff H J).2 hJ
+  let A := GrpObj.Action.normalConjugation i j
+  let _ := A.semidirectProductGrpObj
+  have hequiv := GrpObj.Action.normalSemidirectMul_equivariant i j
+  have hproduct : grpObjMap (productMapOfNormal H I J hI) =
+      (GrpObj.Action.normalSemidirectMul i j).hom.hom :=
+    grpObjMap_productMapOfNormal H I J hI
+  rw [← hproduct] at hequiv
+  have hunop := congrArg (fun q ↦ q.unop.hom) hequiv.symm
+  have hleft :
+      (MonoidalCategoryStruct.whiskerLeft (grpObj H)
+          (grpObjMap (productMapOfNormal H I J hI)) ≫
+        GrpObj.conj (grpObj H)).unop.hom =
+        (Algebra.TensorProduct.map (AlgHom.id k H)
+          (productMapOfNormal H I J hI).hom.toAlgHom).comp
+            (HopfAlgebra.conjugationAlgHom (R := k) (H := H)) := by
+    rw [unop_comp, CommAlgCat.hom_comp, whiskerLeft_grpObjMap_unop_hom,
+      grpObj_conj_unop_hom]
+  have hright :
+      ((GrpObj.Action.normalSemidirectConjugation i j).hom ≫
+          grpObjMap (productMapOfNormal H I J hI)).unop.hom =
+        (normalSemidirectConjugationAlgHom H I J hI hJ).comp
+          (productMapOfNormal H I J hI).hom.toAlgHom := by
+    rw [hproduct, productMapOfNormal_hom]
+    dsimp only [normalSemidirectConjugationAlgHom]
+    rfl
+  exact hleft.symm.trans (hunop.trans hright)
+
+/-- If both factors are normal, the Hopf ideal defining their scheme-theoretic multiplication
+image is normal. Thus the product image is a normal closed affine subgroup of the ambient group. -/
+theorem isNormal_productOfNormal_definingIdeal
+    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
+    (hI : I.IsNormal) (hJ : J.IsNormal) :
+    (HopfIdeal.ker (productMapOfNormal H I J hI).hom).IsNormal :=
+  HopfIdeal.isNormal_ker_of_conjugation_equivariant
+    (productMapOfNormal H I J hI).hom
+    (normalSemidirectConjugationAlgHom H I J hI hJ)
+    (productMapOfNormal_conjugation_equivariant H I J hI hJ)
+
+end
+
+end TauCeti.CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
@@ -67,13 +67,15 @@ closed-subgroup quotient morphism. -/
 @[reassoc (attr := simp)]
 theorem productMapOfNormal_comp_coordinateInl
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
-    productMapOfNormal H I J hI ≫ (quotientNormalConjugation H I J hI).coordinateInl =
+    productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInl H I J hI =
       mkQuotient H I := by
   have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
     (quotientGrpObjInclusion_normal_iff H I).2 hI
+  rw [normalSemidirectProductCoordinateInl_eq, ← Category.assoc,
+    productMapOfNormal_comp_normalSemidirectProductIso_hom]
   apply grpObjMap_injective
   rw [grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInl]
-  rw [grpObjMap_productMapOfNormal]
+  rw [grpObjMap_normalSemidirectMultiplicationCoordinateMap]
   rw [← quotientGrpObjInclusion_def]
   have hrestriction :
       let A := GrpObj.Action.normalConjugation
@@ -92,13 +94,15 @@ closed-subgroup quotient morphism. -/
 @[reassoc (attr := simp)]
 theorem productMapOfNormal_comp_coordinateInr
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
-    productMapOfNormal H I J hI ≫ (quotientNormalConjugation H I J hI).coordinateInr =
+    productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInr H I J hI =
       mkQuotient H J := by
   have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
     (quotientGrpObjInclusion_normal_iff H I).2 hI
+  rw [normalSemidirectProductCoordinateInr_eq, ← Category.assoc,
+    productMapOfNormal_comp_normalSemidirectProductIso_hom]
   apply grpObjMap_injective
   rw [grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInr]
-  rw [grpObjMap_productMapOfNormal]
+  rw [grpObjMap_normalSemidirectMultiplicationCoordinateMap]
   rw [← quotientGrpObjInclusion_def]
   have hrestriction :
       let A := GrpObj.Action.normalConjugation
@@ -123,7 +127,7 @@ theorem ker_productMapOfNormal_le_left
     HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤ I := by
   calc
     HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤
-        HopfIdeal.ker ((quotientNormalConjugation H I J hI).coordinateInl.hom.comp
+        HopfIdeal.ker ((normalSemidirectProductCoordinateInl H I J hI).hom.comp
           (productMapOfNormal H I J hI).hom) :=
       HopfIdeal.ker_le_ker_comp _ _
     _ = HopfIdeal.ker (mkQuotient H I).hom := by
@@ -138,7 +142,7 @@ theorem ker_productMapOfNormal_le_right
     HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤ J := by
   calc
     HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤
-        HopfIdeal.ker ((quotientNormalConjugation H I J hI).coordinateInr.hom.comp
+        HopfIdeal.ker ((normalSemidirectProductCoordinateInr H I J hI).hom.comp
           (productMapOfNormal H I J hI).hom) :=
       HopfIdeal.ker_le_ker_comp _ _
     _ = HopfIdeal.ker (mkQuotient H J).hom := by
@@ -151,8 +155,8 @@ product. -/
 private noncomputable def normalSemidirectConjugationAlgHom
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
     (hI : I.IsNormal) (hJ : J.IsNormal) :
-    normalSemidirectProduct H I J hI →ₐ[k]
-      (H ⊗[k] normalSemidirectProduct H I J hI) :=
+    (quotientNormalConjugation H I J hI).coordinateHopfAlgebra →ₐ[k]
+      (H ⊗[k] (quotientNormalConjugation H I J hI).coordinateHopfAlgebra) :=
   let i := quotientGrpObjInclusion H I
   let j := quotientGrpObjInclusion H J
   let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
@@ -165,10 +169,12 @@ private theorem productMapOfNormal_conjugation_equivariant
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
     (hI : I.IsNormal) (hJ : J.IsNormal) :
     (Algebra.TensorProduct.map (AlgHom.id k H)
-        (productMapOfNormal H I J hI).hom.toAlgHom).comp
+        ((productMapOfNormal H I J hI ≫
+          (normalSemidirectProductIso H I J hI).hom).hom.toAlgHom)).comp
         (HopfAlgebra.conjugationAlgHom (R := k) (H := H)) =
       (normalSemidirectConjugationAlgHom H I J hI hJ).comp
-        (productMapOfNormal H I J hI).hom.toAlgHom := by
+        ((productMapOfNormal H I J hI ≫
+          (normalSemidirectProductIso H I J hI).hom).hom.toAlgHom) := by
   let i := quotientGrpObjInclusion H I
   let j := quotientGrpObjInclusion H J
   let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
@@ -176,26 +182,34 @@ private theorem productMapOfNormal_conjugation_equivariant
   let A := GrpObj.Action.normalConjugation i j
   let _ := A.semidirectProductGrpObj
   have hequiv := GrpObj.Action.normalSemidirectMul_equivariant i j
-  have hproduct : grpObjMap (productMapOfNormal H I J hI) =
+  have hproduct : grpObjMap (productMapOfNormal H I J hI ≫
+      (normalSemidirectProductIso H I J hI).hom) =
       (GrpObj.Action.normalSemidirectMul i j).hom.hom :=
-    grpObjMap_productMapOfNormal H I J hI
+    by
+      rw [grpObjMap_comp]
+      exact grpObjMap_productMapOfNormal H I J hI
   rw [← hproduct] at hequiv
   have hunop := congrArg (fun q ↦ q.unop.hom) hequiv.symm
   have hleft :
       (MonoidalCategoryStruct.whiskerLeft (grpObj H)
-          (grpObjMap (productMapOfNormal H I J hI)) ≫
+          (grpObjMap (productMapOfNormal H I J hI ≫
+            (normalSemidirectProductIso H I J hI).hom)) ≫
         GrpObj.conj (grpObj H)).unop.hom =
         (Algebra.TensorProduct.map (AlgHom.id k H)
-          (productMapOfNormal H I J hI).hom.toAlgHom).comp
+          ((productMapOfNormal H I J hI ≫
+            (normalSemidirectProductIso H I J hI).hom).hom.toAlgHom)).comp
             (HopfAlgebra.conjugationAlgHom (R := k) (H := H)) := by
     rw [unop_comp, CommAlgCat.hom_comp, whiskerLeft_grpObjMap_unop_hom,
       grpObj_conj_unop_hom]
   have hright :
       ((GrpObj.Action.normalSemidirectConjugation i j).hom ≫
-          grpObjMap (productMapOfNormal H I J hI)).unop.hom =
+          grpObjMap (productMapOfNormal H I J hI ≫
+            (normalSemidirectProductIso H I J hI).hom)).unop.hom =
         (normalSemidirectConjugationAlgHom H I J hI hJ).comp
-          (productMapOfNormal H I J hI).hom.toAlgHom := by
-    rw [hproduct, productMapOfNormal_hom_toAlgHom]
+          ((productMapOfNormal H I J hI ≫
+            (normalSemidirectProductIso H I J hI).hom).hom.toAlgHom) := by
+    rw [hproduct, productMapOfNormal_comp_normalSemidirectProductIso_hom,
+      normalSemidirectMultiplicationCoordinateMap_hom_toAlgHom]
     -- Expanding the local action instances identifies the named coordinate map with the unop of
     -- categorical semidirect conjugation, and composition in the opposite category reverses.
     rfl
@@ -206,11 +220,26 @@ image is normal. Thus the product image is a normal closed affine subgroup of th
 theorem isNormal_ker_productMapOfNormal
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
     (hI : I.IsNormal) (hJ : J.IsNormal) :
-    (HopfIdeal.ker (productMapOfNormal H I J hI).hom).IsNormal :=
-  HopfIdeal.isNormal_ker_of_conjugation_equivariant
-    (productMapOfNormal H I J hI).hom
-    (normalSemidirectConjugationAlgHom H I J hI hJ)
-    (productMapOfNormal_conjugation_equivariant H I J hI hJ)
+    (HopfIdeal.ker (productMapOfNormal H I J hI).hom).IsNormal := by
+  let e := normalSemidirectProductIso H I J hI
+  let f := productMapOfNormal H I J hI
+  have hnormal : (HopfIdeal.ker (f ≫ e.hom).hom).IsNormal :=
+    HopfIdeal.isNormal_ker_of_conjugation_equivariant
+      (f ≫ e.hom).hom
+      (normalSemidirectConjugationAlgHom H I J hI hJ)
+      (productMapOfNormal_conjugation_equivariant H I J hI hJ)
+  have hker : HopfIdeal.ker f.hom = HopfIdeal.ker (f ≫ e.hom).hom := by
+    apply HopfIdeal.ext
+    intro x
+    rw [HopfIdeal.mem_ker, HopfIdeal.mem_ker]
+    constructor
+    · intro hx
+      simp [hx]
+    · intro hx
+      have hinv := congrArg (fun y ↦ e.inv.hom y) hx
+      simpa using hinv
+  rw [hker]
+  exact hnormal
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
@@ -71,11 +71,10 @@ theorem productMapOfNormal_comp_coordinateInl
       mkQuotient H I := by
   have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
     (quotientGrpObjInclusion_normal_iff H I).2 hI
-  rw [normalSemidirectProductCoordinateInl_eq, ← Category.assoc,
-    productMapOfNormal_comp_normalSemidirectProductIso_hom]
+  rw [normalSemidirectProductCoordinateInl_def, ← Category.assoc]
   apply grpObjMap_injective
-  rw [grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInl]
-  rw [grpObjMap_normalSemidirectMultiplicationCoordinateMap]
+  rw [grpObjMap_comp, grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInl,
+    grpObjMap_productMapOfNormal]
   rw [← quotientGrpObjInclusion_def]
   have hrestriction :
       let A := GrpObj.Action.normalConjugation
@@ -98,11 +97,10 @@ theorem productMapOfNormal_comp_coordinateInr
       mkQuotient H J := by
   have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
     (quotientGrpObjInclusion_normal_iff H I).2 hI
-  rw [normalSemidirectProductCoordinateInr_eq, ← Category.assoc,
-    productMapOfNormal_comp_normalSemidirectProductIso_hom]
+  rw [normalSemidirectProductCoordinateInr_def, ← Category.assoc]
   apply grpObjMap_injective
-  rw [grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInr]
-  rw [grpObjMap_normalSemidirectMultiplicationCoordinateMap]
+  rw [grpObjMap_comp, grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInr,
+    grpObjMap_productMapOfNormal]
   rw [← quotientGrpObjInclusion_def]
   have hrestriction :
       let A := GrpObj.Action.normalConjugation
@@ -208,8 +206,9 @@ private theorem productMapOfNormal_conjugation_equivariant
         (normalSemidirectConjugationAlgHom H I J hI hJ).comp
           ((productMapOfNormal H I J hI ≫
             (normalSemidirectProductIso H I J hI).hom).hom.toAlgHom) := by
-    rw [hproduct, productMapOfNormal_comp_normalSemidirectProductIso_hom,
-      normalSemidirectMultiplicationCoordinateMap_hom_toAlgHom]
+    have hproductHom := congrArg (fun q ↦ q.unop.hom) hproduct
+    rw [grpObjMap_unop_hom] at hproductHom
+    rw [hproduct, hproductHom]
     -- Expanding the local action instances identifies the named coordinate map with the unop of
     -- categorical semidirect conjugation, and composition in the opposite category reverses.
     rfl

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
@@ -32,10 +32,10 @@ separate steps.
 * `TauCeti.CommHopfAlgCat.productMapOfNormal_comp_coordinateInl` and
   `TauCeti.CommHopfAlgCat.productMapOfNormal_comp_coordinateInr`: multiplication restricts to the
   two original closed-subgroup inclusions.
-* `TauCeti.CommHopfAlgCat.productOfNormal_definingIdeal_le_left` and
-  `TauCeti.CommHopfAlgCat.productOfNormal_definingIdeal_le_right`: the product image contains both
+* `TauCeti.CommHopfAlgCat.ker_productMapOfNormal_le_left` and
+  `TauCeti.CommHopfAlgCat.ker_productMapOfNormal_le_right`: the product image contains both
   factors.
-* `TauCeti.CommHopfAlgCat.isNormal_productOfNormal_definingIdeal`: the product of two normal
+* `TauCeti.CommHopfAlgCat.isNormal_ker_productMapOfNormal`: the product of two normal
   closed affine subgroups is normal.
 
 ## References
@@ -64,7 +64,7 @@ variable {k : Type u} [CommRing k]
 
 /-- Multiplication from the conjugation semidirect product restricts on its normal factor to the
 closed-subgroup quotient morphism. -/
-@[reassoc]
+@[reassoc (attr := simp)]
 theorem productMapOfNormal_comp_coordinateInl
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
     productMapOfNormal H I J hI ≫ (quotientNormalConjugation H I J hI).coordinateInl =
@@ -89,7 +89,7 @@ theorem productMapOfNormal_comp_coordinateInl
 
 /-- Multiplication from the conjugation semidirect product restricts on its acting factor to the
 closed-subgroup quotient morphism. -/
-@[reassoc]
+@[reassoc (attr := simp)]
 theorem productMapOfNormal_comp_coordinateInr
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
     productMapOfNormal H I J hI ≫ (quotientNormalConjugation H I J hI).coordinateInr =
@@ -118,72 +118,33 @@ variable {k : Type u} [Field k]
 
 /-- The defining Hopf ideal of the multiplication image lies below the ideal of the normal
 factor. Equivalently, the product image contains that factor as a closed subgroup scheme. -/
-theorem productOfNormal_definingIdeal_le_left
+theorem ker_productMapOfNormal_le_left
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
     HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤ I := by
-  rw [← HopfIdeal.toIdeal_le_toIdeal]
-  intro x hx
-  rw [← mkQuotient_eq_zero_iff H I x]
-  have hx0 : (productMapOfNormal H I J hI).hom x = 0 :=
-    (HopfIdeal.mem_ker _).mp hx
-  have hcomp := congrArg (fun f : H ⟶ quotient H I ↦ f.hom x)
-    (productMapOfNormal_comp_coordinateInl H I J hI)
-  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp, Function.comp_apply] at hcomp
-  rw [← hcomp, hx0, map_zero]
+  calc
+    HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤
+        HopfIdeal.ker ((quotientNormalConjugation H I J hI).coordinateInl.hom.comp
+          (productMapOfNormal H I J hI).hom) :=
+      HopfIdeal.ker_le_ker_comp _ _
+    _ = HopfIdeal.ker (mkQuotient H I).hom := by
+      rw [← _root_.CommHopfAlgCat.hom_comp,
+        productMapOfNormal_comp_coordinateInl]
+    _ = I := HopfIdeal.ker_mkBialgHom I
 
 /-- The defining Hopf ideal of the multiplication image lies below the ideal of the acting
 factor. Equivalently, the product image contains that factor as a closed subgroup scheme. -/
-theorem productOfNormal_definingIdeal_le_right
+theorem ker_productMapOfNormal_le_right
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
     HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤ J := by
-  rw [← HopfIdeal.toIdeal_le_toIdeal]
-  intro x hx
-  rw [← mkQuotient_eq_zero_iff H J x]
-  have hx0 : (productMapOfNormal H I J hI).hom x = 0 :=
-    (HopfIdeal.mem_ker _).mp hx
-  have hcomp := congrArg (fun f : H ⟶ quotient H J ↦ f.hom x)
-    (productMapOfNormal_comp_coordinateInr H I J hI)
-  simp only [_root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp, Function.comp_apply] at hcomp
-  rw [← hcomp, hx0, map_zero]
-
-private theorem whiskerLeft_grpObjMap_unop_hom
-    {H K : _root_.CommHopfAlgCat.{u} k} (f : H ⟶ K) :
-    (MonoidalCategoryStruct.whiskerLeft (grpObj H) (grpObjMap f)).unop.hom =
-      Algebra.TensorProduct.map (AlgHom.id k H) f.hom.toAlgHom := by
-  simp only [unop_whiskerLeft, CommAlgCat.whiskerLeft_hom, grpObjMap_unop_hom]
-
-private theorem grpObj_conj_unop_hom (H : _root_.CommHopfAlgCat.{u} k) :
-    (GrpObj.conj (grpObj H)).unop.hom =
-      HopfAlgebra.conjugationAlgHom (R := k) (H := H) := by
-  have hinv :
-      ((WithConv.toConv
-        (Bialgebra.TensorProduct.includeLeft (R := k) (H₁ := H) (H₂ := H)).toAlgHom)⁻¹).ofConv =
-        (Bialgebra.TensorProduct.includeLeft (R := k) (H₁ := H) (H₂ := H)).toAlgHom.comp
-          (HopfAlgebra.antipodeAlgHom k H) := rfl
-  have hmul :
-      (WithConv.toConv
-          (Bialgebra.TensorProduct.includeLeft (R := k) (H₁ := H) (H₂ := H)).toAlgHom *
-        WithConv.toConv
-          (Bialgebra.TensorProduct.includeRight (R := k) (H₁ := H) (H₂ := H)).toAlgHom).ofConv =
-        (Algebra.TensorProduct.lift
-          (Bialgebra.TensorProduct.includeLeft (R := k) (H₁ := H) (H₂ := H)).toAlgHom
-          (Bialgebra.TensorProduct.includeRight (R := k) (H₁ := H) (H₂ := H)).toAlgHom
-          (fun _ _ ↦ .all _ _)).comp (Bialgebra.comulAlgHom k H) := by
-    ext x
-    exact AlgHom.convMul_apply _ _ x
-  apply WithConv.toConv_injective
-  rw [HopfAlgebra.toConv_conjugationAlgHom]
-  rw [GrpObj.conj, CategoryTheory.Hom.mul_def, CategoryTheory.Hom.mul_def,
-    CategoryTheory.Hom.inv_def]
-  ext x
-  simp only [unop_comp, CommAlgCat.hom_comp, CommAlgCat.lift_unop_hom,
-    CommAlgCat.mul_op_of_unop_hom, CommAlgCat.inv_op_of_unop_hom,
-    CommAlgCat.fst_unop_hom, CommAlgCat.snd_unop_hom,
-    AlgHom.convMul_apply, hinv, hmul, AlgHom.coe_comp, Function.comp_apply]
-  congr 1
-  apply Algebra.TensorProduct.ext'
-  intro a b
-  simp
+  calc
+    HopfIdeal.ker (productMapOfNormal H I J hI).hom ≤
+        HopfIdeal.ker ((quotientNormalConjugation H I J hI).coordinateInr.hom.comp
+          (productMapOfNormal H I J hI).hom) :=
+      HopfIdeal.ker_le_ker_comp _ _
+    _ = HopfIdeal.ker (mkQuotient H J).hom := by
+      rw [← _root_.CommHopfAlgCat.hom_comp,
+        productMapOfNormal_comp_coordinateInr]
+    _ = J := HopfIdeal.ker_mkBialgHom J
 
 /-- The coordinate algebra map of simultaneous ambient conjugation on the normal semidirect
 product. -/
@@ -191,29 +152,14 @@ private noncomputable def normalSemidirectConjugationAlgHom
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
     (hI : I.IsNormal) (hJ : J.IsNormal) :
     normalSemidirectProduct H I J hI →ₐ[k]
-      (H ⊗[k] normalSemidirectProduct H I J hI) := by
+      (H ⊗[k] normalSemidirectProduct H I J hI) :=
   let i := quotientGrpObjInclusion H I
   let j := quotientGrpObjInclusion H J
   let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
   let _ : IsMonHom.Normal j := (quotientGrpObjInclusion_normal_iff H J).2 hJ
   let A := GrpObj.Action.normalConjugation i j
   let _ := A.semidirectProductGrpObj
-  dsimp only [normalSemidirectProduct]
-  exact (GrpObj.Action.normalSemidirectConjugation i j).hom.unop.hom
-
-private theorem normalSemidirectConjugationAlgHom_def
-    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
-    (hI : I.IsNormal) (hJ : J.IsNormal) :
-    normalSemidirectConjugationAlgHom H I J hI hJ = by
-      let i := quotientGrpObjInclusion H I
-      let j := quotientGrpObjInclusion H J
-      let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
-      let _ : IsMonHom.Normal j := (quotientGrpObjInclusion_normal_iff H J).2 hJ
-      let A := GrpObj.Action.normalConjugation i j
-      let _ := A.semidirectProductGrpObj
-      dsimp only [normalSemidirectProduct]
-      exact (GrpObj.Action.normalSemidirectConjugation i j).hom.unop.hom := by
-  rfl
+  (GrpObj.Action.normalSemidirectConjugation i j).hom.unop.hom
 
 private theorem productMapOfNormal_conjugation_equivariant
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
@@ -249,13 +195,15 @@ private theorem productMapOfNormal_conjugation_equivariant
           grpObjMap (productMapOfNormal H I J hI)).unop.hom =
         (normalSemidirectConjugationAlgHom H I J hI hJ).comp
           (productMapOfNormal H I J hI).hom.toAlgHom := by
-    rw [hproduct, productMapOfNormal_hom, normalSemidirectConjugationAlgHom_def]
+    rw [hproduct, productMapOfNormal_hom_toAlgHom]
+    -- Expanding the local action instances identifies the named coordinate map with the unop of
+    -- categorical semidirect conjugation, and composition in the opposite category reverses.
     rfl
   exact hleft.symm.trans (hunop.trans hright)
 
 /-- If both factors are normal, the Hopf ideal defining their scheme-theoretic multiplication
 image is normal. Thus the product image is a normal closed affine subgroup of the ambient group. -/
-theorem isNormal_productOfNormal_definingIdeal
+theorem isNormal_ker_productMapOfNormal
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
     (hI : I.IsNormal) (hJ : J.IsNormal) :
     (HopfIdeal.ker (productMapOfNormal H I J hI).hom).IsNormal :=

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Properties.lean
@@ -60,92 +60,37 @@ noncomputable section
 
 variable {k : Type u} [Field k]
 
-private theorem grpObjMap_unop_hom
-    {H K : _root_.CommHopfAlgCat.{u} k} (f : H ⟶ K) :
-    (grpObjMap f).unop.hom = f.hom.toAlgHom :=
-  congrArg CommAlgCat.Hom.hom (grpObjMap_unop f)
-
-/-- The coordinate morphism representing inclusion of the normal factor into the conjugation
-semidirect product. -/
-noncomputable def normalSemidirectProductCoordinateInl
-    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
-    normalSemidirectProduct H I J hI ⟶ quotient H I := by
-  dsimp only [normalSemidirectProduct]
-  exact (quotientNormalConjugation H I J hI).coordinateInl
-
-/-- The coordinate morphism representing inclusion of the acting factor into the conjugation
-semidirect product. -/
-noncomputable def normalSemidirectProductCoordinateInr
-    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
-    normalSemidirectProduct H I J hI ⟶ quotient H J := by
-  dsimp only [normalSemidirectProduct]
-  exact (quotientNormalConjugation H I J hI).coordinateInr
-
-/-- The represented group-object map of `normalSemidirectProductCoordinateInl` is the canonical
-inclusion of the normal factor. -/
-@[simp]
-theorem grpObjMap_normalSemidirectProductCoordinateInl
-    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
-    grpObjMap (normalSemidirectProductCoordinateInl H I J hI) =
-      (quotientNormalConjugation H I J hI).inl.hom.hom := by
-  rw [normalSemidirectProductCoordinateInl]
-  exact GrpObj.Action.grpObjMap_coordinateInl _
-
-/-- The represented group-object map of `normalSemidirectProductCoordinateInr` is the canonical
-inclusion of the acting factor. -/
-@[simp]
-theorem grpObjMap_normalSemidirectProductCoordinateInr
-    (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
-    grpObjMap (normalSemidirectProductCoordinateInr H I J hI) =
-      (quotientNormalConjugation H I J hI).inr.hom.hom := by
-  rw [normalSemidirectProductCoordinateInr]
-  exact GrpObj.Action.grpObjMap_coordinateInr _
-
 /-- Multiplication from the conjugation semidirect product restricts on its normal factor to the
 closed-subgroup quotient morphism. -/
 @[reassoc]
 theorem productMapOfNormal_comp_coordinateInl
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
-    productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInl H I J hI =
+    productMapOfNormal H I J hI ≫ (quotientNormalConjugation H I J hI).coordinateInl =
       mkQuotient H I := by
-  have hmap : grpObjMap
-      (productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInl H I J hI) =
-      grpObjMap (mkQuotient H I) := by
-    rw [grpObjMap_comp, grpObjMap_normalSemidirectProductCoordinateInl]
-    rw [grpObjMap_productMapOfNormal]
-    rw [← quotientGrpObjInclusion_def]
-    exact quotientNormalConjugation_inl_comp_normalSemidirectMul H I J hI
-  apply _root_.CommHopfAlgCat.hom_ext
-  apply BialgHom.ext
-  intro x
-  change
-    (productMapOfNormal H I J hI ≫
-        normalSemidirectProductCoordinateInl H I J hI).hom.toAlgHom x =
-      (mkQuotient H I).hom.toAlgHom x
-  simpa only [grpObjMap_unop_hom] using congrArg (fun q ↦ q.unop.hom x) hmap
+  have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
+    (quotientGrpObjInclusion_normal_iff H I).2 hI
+  apply grpObjMap_injective
+  rw [grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInl]
+  rw [grpObjMap_productMapOfNormal]
+  rw [← quotientGrpObjInclusion_def]
+  exact GrpObj.Action.inl_hom_comp_normalSemidirectMul_hom
+    (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J)
 
 /-- Multiplication from the conjugation semidirect product restricts on its acting factor to the
 closed-subgroup quotient morphism. -/
 @[reassoc]
 theorem productMapOfNormal_comp_coordinateInr
     (H : _root_.CommHopfAlgCat.{u} k) (I J : HopfIdeal k H) (hI : I.IsNormal) :
-    productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInr H I J hI =
+    productMapOfNormal H I J hI ≫ (quotientNormalConjugation H I J hI).coordinateInr =
       mkQuotient H J := by
-  have hmap : grpObjMap
-      (productMapOfNormal H I J hI ≫ normalSemidirectProductCoordinateInr H I J hI) =
-      grpObjMap (mkQuotient H J) := by
-    rw [grpObjMap_comp, grpObjMap_normalSemidirectProductCoordinateInr]
-    rw [grpObjMap_productMapOfNormal]
-    rw [← quotientGrpObjInclusion_def]
-    exact quotientNormalConjugation_inr_comp_normalSemidirectMul H I J hI
-  apply _root_.CommHopfAlgCat.hom_ext
-  apply BialgHom.ext
-  intro x
-  change
-    (productMapOfNormal H I J hI ≫
-        normalSemidirectProductCoordinateInr H I J hI).hom.toAlgHom x =
-      (mkQuotient H J).hom.toAlgHom x
-  simpa only [grpObjMap_unop_hom] using congrArg (fun q ↦ q.unop.hom x) hmap
+  have _ : IsMonHom.Normal (quotientGrpObjInclusion H I) :=
+    (quotientGrpObjInclusion_normal_iff H I).2 hI
+  apply grpObjMap_injective
+  rw [grpObjMap_comp, GrpObj.Action.grpObjMap_coordinateInr]
+  rw [grpObjMap_productMapOfNormal]
+  rw [← quotientGrpObjInclusion_def]
+  exact GrpObj.Action.inr_hom_comp_normalSemidirectMul_hom
+    (quotientGrpObjInclusion H I) (quotientGrpObjInclusion H J)
 
 /-- The defining Hopf ideal of the multiplication image lies below the ideal of the normal
 factor. Equivalently, the product image contains that factor as a closed subgroup scheme. -/
@@ -159,7 +104,7 @@ theorem productOfNormal_definingIdeal_le_left
     (HopfIdeal.mem_ker _).mp hx
   have hcomp := congrArg (fun f : H ⟶ quotient H I ↦ f.hom x)
     (productMapOfNormal_comp_coordinateInl H I J hI)
-  change (normalSemidirectProductCoordinateInl H I J hI).hom
+  change ((quotientNormalConjugation H I J hI).coordinateInl).hom
       ((productMapOfNormal H I J hI).hom x) = (mkQuotient H I).hom x at hcomp
   rw [← hcomp, hx0, map_zero]
 
@@ -175,7 +120,7 @@ theorem productOfNormal_definingIdeal_le_right
     (HopfIdeal.mem_ker _).mp hx
   have hcomp := congrArg (fun f : H ⟶ quotient H J ↦ f.hom x)
     (productMapOfNormal_comp_coordinateInr H I J hI)
-  change (normalSemidirectProductCoordinateInr H I J hI).hom
+  change ((quotientNormalConjugation H I J hI).coordinateInr).hom
       ((productMapOfNormal H I J hI).hom x) = (mkQuotient H J).hom x at hcomp
   rw [← hcomp, hx0, map_zero]
 

--- a/TauCeti/Algebra/HopfAlgebra/Kernel.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Kernel.lean
@@ -30,6 +30,7 @@ dictionary.
 * `TauCeti.HopfIdeal.kerOfSurjective`: the Hopf ideal given by the kernel of a surjective bialgebra
   morphism.
 * `TauCeti.HopfIdeal.ker`: the kernel Hopf ideal of an arbitrary bialgebra morphism over a field.
+* `TauCeti.HopfIdeal.ker_le_ker_comp`: a Hopf kernel grows under postcomposition.
 * `TauCeti.HopfIdeal.kerOfSurjective_eq_ker`: comparison of the two constructions over a field.
 * `TauCeti.HopfIdeal.kerOfSurjective_toIdeal` and
   `TauCeti.HopfIdeal.mem_kerOfSurjective`: its characteristic API.
@@ -54,7 +55,7 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-universe u v w
+universe u v w x
 
 namespace HopfIdeal
 
@@ -286,6 +287,13 @@ theorem ker_toIdeal (f : H →ₐc[k] K) :
 @[simp]
 theorem mem_ker (f : H →ₐc[k] K) {x : H} : x ∈ ker f ↔ f x = 0 :=
   mem_ofKerComul f _
+
+/-- The kernel Hopf ideal of a morphism is contained in the kernel after postcomposition. -/
+theorem ker_le_ker_comp {L : Type x} [Ring L] [HopfAlgebra k L]
+    (f : H →ₐc[k] K) (g : K →ₐc[k] L) : ker f ≤ ker (g.comp f) := by
+  intro h hh
+  rw [mem_ker] at hh ⊢
+  rw [BialgHom.comp_apply, hh, map_zero]
 
 /-- Over a field, the kernel constructed for a surjective morphism agrees with the canonical
 kernel, which does not require the surjectivity hypothesis. -/

--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
@@ -28,9 +28,6 @@ binary-product map used in the maximal-dimension construction of the unipotent r
 * `TauCeti.GrpObj.Action.normalConjugation`: conjugation along a map into the ambient group.
 * `TauCeti.GrpObj.Action.normalSemidirectMul`: multiplication from the resulting semidirect
   product into the ambient group.
-* `TauCeti.GrpObj.Action.inl_hom_comp_normalSemidirectMul_hom` and
-  `TauCeti.GrpObj.Action.inr_hom_comp_normalSemidirectMul_hom`: the corresponding identities on
-  underlying morphisms.
 
 ## References
 
@@ -214,23 +211,5 @@ theorem inr_comp_normalSemidirectMul
   rw [← Category.assoc, hleft, MonObj.one_comp]
   rw [← Category.assoc, hright, Category.id_comp]
   exact one_mul j
-
-/-- On underlying morphisms, normal semidirect multiplication restricts to the normal subgroup
-map on the first canonical factor. -/
-theorem inl_hom_comp_normalSemidirectMul_hom
-    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j] :
-    let A := normalConjugation i j
-    A.inl.hom.hom ≫ (normalSemidirectMul i j).hom.hom = i := by
-  simpa only [Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
-    congrArg (fun f ↦ f.hom.hom) (inl_comp_normalSemidirectMul i j)
-
-/-- On underlying morphisms, normal semidirect multiplication restricts to the second ambient
-map on the second canonical factor. -/
-theorem inr_hom_comp_normalSemidirectMul_hom
-    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j] :
-    let A := normalConjugation i j
-    A.inr.hom.hom ≫ (normalSemidirectMul i j).hom.hom = j := by
-  simpa only [Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
-    congrArg (fun f ↦ f.hom.hom) (inr_comp_normalSemidirectMul i j)
 
 end TauCeti.GrpObj.Action

--- a/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
+++ b/TauCeti/CategoryTheory/Monoidal/SemidirectProduct/Normal.lean
@@ -28,6 +28,9 @@ binary-product map used in the maximal-dimension construction of the unipotent r
 * `TauCeti.GrpObj.Action.normalConjugation`: conjugation along a map into the ambient group.
 * `TauCeti.GrpObj.Action.normalSemidirectMul`: multiplication from the resulting semidirect
   product into the ambient group.
+* `TauCeti.GrpObj.Action.inl_hom_comp_normalSemidirectMul_hom` and
+  `TauCeti.GrpObj.Action.inr_hom_comp_normalSemidirectMul_hom`: the corresponding identities on
+  underlying morphisms.
 
 ## References
 
@@ -211,5 +214,23 @@ theorem inr_comp_normalSemidirectMul
   rw [← Category.assoc, hleft, MonObj.one_comp]
   rw [← Category.assoc, hright, Category.id_comp]
   exact one_mul j
+
+/-- On underlying morphisms, normal semidirect multiplication restricts to the normal subgroup
+map on the first canonical factor. -/
+theorem inl_hom_comp_normalSemidirectMul_hom
+    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j] :
+    let A := normalConjugation i j
+    A.inl.hom.hom ≫ (normalSemidirectMul i j).hom.hom = i := by
+  simpa only [Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
+    congrArg (fun f ↦ f.hom.hom) (inl_comp_normalSemidirectMul i j)
+
+/-- On underlying morphisms, normal semidirect multiplication restricts to the second ambient
+map on the second canonical factor. -/
+theorem inr_hom_comp_normalSemidirectMul_hom
+    (i : N ⟶ G) [IsMonHom.Normal i] (j : H ⟶ G) [IsMonHom j] :
+    let A := normalConjugation i j
+    A.inr.hom.hom ≫ (normalSemidirectMul i j).hom.hom = j := by
+  simpa only [Grp.comp_hom_hom, Grp.ofHom_hom_hom] using
+    congrArg (fun f ↦ f.hom.hom) (inr_comp_normalSemidirectMul i j)
 
 end TauCeti.GrpObj.Action


### PR DESCRIPTION
This PR proves that the scheme-theoretic multiplication image of a normal closed affine subgroup and another closed affine subgroup contains both factors, and proves that the image is normal when both factors are normal. It translates the categorical semidirect-product identities into coordinate Hopf-algebra equations, obtains the two contravariant kernel-ideal inequalities, and applies conjugation equivariance to the image kernel.

The exact roadmap target is ReductiveGroups Layer 5, “The unipotent radical `R_u(G)` (the hard core, SGA3/Borel level): the maximal connected normal unipotent closed subgroup.” This supplies the containment and normality part of the binary-product closure needed by the maximality construction.

After this PR, connectedness of the multiplication image, preservation of smooth unipotence by the scheme-theoretic image, and the maximal-dimension/greatest-subgroup construction remain for this milestone.

The proof reuses Tau Ceti's normal semidirect multiplication and simultaneous-conjugation equivariance, together with its general normal-image-kernel theorem. No Mathlib implementation is vendored; the coordinate translation uses Mathlib's commutative-Hopf-algebra/cogroup equivalence, tensor-product maps, and convolution API.

The repository's prefix-directory rule requires this module move:

| Old module | New module |
| --- | --- |
| `TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product` | `TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic` |

The new results live in `TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties`; no forwarding import or compatibility alias is retained.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"normal-product-image-containment-normality"}-->

🤖 Prepared with Codex
