### PR TITLE
feat: prove the special linear group reductive

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Reductive.lean
@@ -117,34 +117,18 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
 theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
     (k : Type u) [Field k] (n : Nat) :
     reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) := by
-  rw [reductiveCommHopfAlgProperty_iff]
   let e := coordinateHopfAlgebraFiniteTypeObjIso k n
-  refine ⟨(smoothCommHopfAlgProperty_iff _).mp <|
+  apply reductiveCommHopfAlgProperty_of_geometricFiber_iso k _
+    (finiteTypeCoordinateHopfAlgebra (AlgebraicClosure k) n)
+    ((smoothCommHopfAlgProperty_iff _).mp <|
       (smoothCommHopfAlgProperty k).prop_of_iso e
-        ((smoothCommHopfAlgProperty_iff _).mpr inferInstance),
-    (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e
-      (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n), ?_⟩
-  intro I hI _ hU
-  let K := AlgebraicClosure k
-  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := K)
-    (finiteTypeCoordinateHopfAlgebra k n)
-  let Gbar := finiteTypeCoordinateHopfAlgebra K n
-  let e : Hbar ≅ Gbar := finiteTypeCoordinateHopfAlgebraBaseChangeIso k K n
-  let f : Gbar →ₐc[K] Hbar := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.inv
-  let J : HopfIdeal K Gbar := I.comap f hf.2
-  have hJnormal : J.IsNormal := hI.comap_of_bijective f hf.1 hf.2
-  let qIso : FiniteTypeCommHopfAlgCat.quotient Gbar J ≅
-      FiniteTypeCommHopfAlgCat.quotient Hbar I :=
-    FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm I
-  have hJU : smoothUnipotentCommHopfAlgProperty K
-      (FiniteTypeCommHopfAlgCat.quotient Gbar J) :=
-    (smoothUnipotentCommHopfAlgProperty K).prop_of_iso qIso.symm hU
-  have hJ : J = HopfIdeal.augmentation K Gbar :=
-    eq_augmentation_of_isNormal_of_smoothUnipotent K n J hJnormal hJU
-  rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hf.2,
-    HopfIdeal.comap_augmentation]
-  exact hJ
+        ((smoothCommHopfAlgProperty_iff _).mpr inferInstance))
+    ((geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e
+      (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n))
+    (finiteTypeCoordinateHopfAlgebraBaseChangeIso k (AlgebraicClosure k) n)
+  intro I hI hU
+  exact eq_augmentation_of_isNormal_of_smoothUnipotent
+    (AlgebraicClosure k) n I hI hU
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.lean
@@ -31,6 +31,8 @@ the precise affine-group statement that the geometric fibre is the trivial group
 * `TauCeti.reductiveCommHopfAlgProperty`: reductivity for finite-type commutative Hopf algebras
   over a field.
 * `TauCeti.ReductiveCommHopfAlgCat`: the corresponding full subcategory.
+* `TauCeti.reductiveCommHopfAlgProperty_of_geometricFiber_iso`: establish reductivity using an
+  isomorphic direct model of the geometric fibre.
 * `TauCeti.reductiveCommHopfAlgProperty.eq_augmentation`: every connected normal smooth
   unipotent closed subgroup of a reductive group's geometric fibre is trivial.
 * `TauCeti.reductiveCommHopfAlgProperty.bot_eq_augmentation`: the zero Hopf ideal of a reductive
@@ -97,6 +99,42 @@ instance (k : Type u) [Field k] :
     (reductiveCommHopfAlgProperty k).IsClosedUnderIsomorphisms :=
   inferInstanceAs ((geometricNormalSubgroupFreeCommHopfAlgProperty k
     (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k))).IsClosedUnderIsomorphisms)
+
+/-- Establish reductivity by identifying the geometric fibre with a direct model on which normal
+smooth unipotent closed subgroups can be eliminated. This packages the transport of Hopf ideals,
+normality, the quotient property, and the augmentation ideal across the identification. -/
+theorem reductiveCommHopfAlgProperty_of_geometricFiber_iso
+    (k : Type u) [Field k] (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (G : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k))
+    (hsmooth : Algebra.Smooth k H)
+    (hconnected : geometricallyConnectedCommHopfAlgProperty k H.obj)
+    (e : FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H ≅ G)
+    (htrivial : ∀ (I : HopfIdeal (AlgebraicClosure k) G), I.IsNormal →
+      smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.quotient G I) →
+      I = HopfIdeal.augmentation (AlgebraicClosure k) G) :
+    reductiveCommHopfAlgProperty k H := by
+  rw [reductiveCommHopfAlgProperty_iff]
+  refine ⟨hsmooth, hconnected, ?_⟩
+  intro I hI _ hU
+  let f : G →ₐc[AlgebraicClosure k]
+      FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H :=
+    FiniteTypeCommHopfAlgCat.toBialgHom e.inv
+  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.inv
+  let J : HopfIdeal (AlgebraicClosure k) G := I.comap f hf.2
+  have hJnormal : J.IsNormal := hI.comap_of_bijective f hf.1 hf.2
+  let qIso : FiniteTypeCommHopfAlgCat.quotient G J ≅
+      FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) I :=
+    FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm I
+  have hJU : smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient G J) :=
+    (smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)).prop_of_iso qIso.symm hU
+  have hJ : J = HopfIdeal.augmentation (AlgebraicClosure k) G :=
+    htrivial J hJnormal hJU
+  rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hf.2,
+    HopfIdeal.comap_augmentation]
+  exact hJ
 
 /-- The category of reductive finite-type commutative Hopf algebras over a field. -/
 abbrev ReductiveCommHopfAlgCat (k : Type u) [Field k] :=

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/BaseChange.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Basic
+import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
+
+/-!
+# Base change of the special linear group
+
+For a morphism of commutative rings `R → K`, scalar extension of the coordinate Hopf algebra
+of `SLₙ` is canonically the coordinate Hopf algebra constructed directly over `K`.
+
+The proof starts from the corresponding base-change isomorphism for `GLₙ`. It sends the
+base-changed generic determinant to the generic determinant over `K`, and therefore carries the
+base change of the determinant-one Hopf ideal onto the determinant-one Hopf ideal over `K`.
+The result then follows from the general theorem that a Hopf-ideal quotient commutes with base
+change.
+
+## Main declarations
+
+* `TauCeti.SpecialLinear.coordinateHopfAlgebraBaseChangeIso`: base change of the coordinate Hopf
+  algebra of `SLₙ`.
+* `TauCeti.SpecialLinear.finiteTypeCoordinateHopfAlgebraBaseChangeIso`: the finite-type form of
+  the same isomorphism.
+* `TauCeti.SpecialLinear.finiteTypeCoordinateHopfAlgebraBaseChangeIso_hom`: its underlying
+  commutative-Hopf-algebra morphism.
+
+## References
+
+* J. S. Milne, *Basic Theory of Affine Group Schemes*, Chapter IV, §1.8.
+* The Stacks Project, Tags [01JO](https://stacks.math.columbia.edu/tag/01JO) and
+  [022W](https://stacks.math.columbia.edu/tag/022W).
+
+This is the scalar-extension compatibility needed to assemble the `SLₙ` worked example in
+Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti.SpecialLinear
+
+universe u v
+
+variable (R : Type u) (K : Type max u v) [CommRing R] [CommRing K] [Algebra R K]
+variable (n : ℕ)
+
+/-- The general-linear base-change isomorphism sends the scalar extension of the generic
+determinant to the generic determinant over the new base. -/
+private theorem coordinateHopfAlgebraBaseChangeIso_hom_determinantGroupLike :
+    (GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n).hom.hom
+        (1 ⊗ₜ[R]
+          (GeneralLinear.determinantGroupLike R n :
+            GeneralLinear.coordinateHopfAlgebra R n)) =
+      (GeneralLinear.determinantGroupLike K n :
+        GeneralLinear.coordinateHopfAlgebra K n) := by
+  have hdet :
+      MvPolynomial.map (algebraMap R K)
+          (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R)) =
+        Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) K) := by
+    rw [RingHom.map_det]
+    congr 1
+    funext i j
+    simp [Matrix.mvPolynomialX]
+  rw [GeneralLinear.determinantGroupLike_val,
+    GeneralLinear.det_localizedGenericMatrix,
+    GeneralLinear.coordinateHopfAlgebraBaseChangeIso_hom_apply,
+    GeneralLinear.determinantGroupLike_val,
+    GeneralLinear.det_localizedGenericMatrix, hdet, one_smul]
+
+/-- The general-linear base-change isomorphism carries the base-changed determinant-one Hopf
+ideal onto the determinant-one Hopf ideal over the new base. -/
+private theorem map_baseChangeHopfIdeal_definingHopfIdeal :
+    (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (definingHopfIdeal R n)).map
+        (GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n).hom.hom =
+      definingHopfIdeal K n := by
+  have hdet :
+      ((GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n).hom.hom :
+          CommHopfAlgCat.baseChange (K := K)
+              (GeneralLinear.coordinateHopfAlgebra R n) →+*
+            GeneralLinear.coordinateHopfAlgebra K n)
+          (1 ⊗ₜ[R]
+            (GeneralLinear.determinantGroupLike R n :
+              GeneralLinear.coordinateHopfAlgebra R n)) =
+        (GeneralLinear.determinantGroupLike K n :
+          GeneralLinear.coordinateHopfAlgebra K n) :=
+    coordinateHopfAlgebraBaseChangeIso_hom_determinantGroupLike R K n
+  apply HopfIdeal.ext
+  intro x
+  rw [← HopfIdeal.mem_toIdeal, HopfIdeal.map_toIdeal,
+    CommHopfAlgCat.baseChangeHopfIdeal_toIdeal, definingHopfIdeal_toIdeal]
+  rw [Ideal.map_span, Set.image_singleton]
+  rw [Ideal.map_span, Set.image_singleton]
+  rw [
+    Algebra.TensorProduct.includeRight_apply, TensorProduct.tmul_sub, map_sub,
+    ← Algebra.TensorProduct.one_def, map_one,
+    hdet,
+    ← HopfIdeal.mem_toIdeal, definingHopfIdeal_toIdeal]
+
+/-- Pulling the determinant-one Hopf ideal back along the general-linear base-change
+isomorphism recovers its base change. -/
+private theorem comap_definingHopfIdeal_baseChangeIso :
+    (definingHopfIdeal K n).comap
+        (GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n).hom.hom
+        (ConcreteCategory.bijective_of_isIso
+          (GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n).hom).2 =
+      CommHopfAlgCat.baseChangeHopfIdeal (K := K) (definingHopfIdeal R n) := by
+  let e := GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n
+  have he := ConcreteCategory.bijective_of_isIso e.hom
+  rw [← map_baseChangeHopfIdeal_definingHopfIdeal R K n,
+    HopfIdeal.comap_map_of_surjective,
+    (HopfIdeal.kerOfSurjective_eq_bot_iff e.hom.hom he.2).2 he.1, sup_bot_eq]
+
+/-- Base change of the special-linear coordinate Hopf algebra is canonically the
+special-linear coordinate Hopf algebra over the new base. -/
+noncomputable def coordinateHopfAlgebraBaseChangeIso :
+    CommHopfAlgCat.baseChange (K := K) (coordinateHopfAlgebra R n) ≅
+      coordinateHopfAlgebra K n :=
+  (CommHopfAlgCat.quotientBaseChangeIso (K := K) (definingHopfIdeal R n)).symm ≪≫
+    eqToIso (congrArg
+      (CommHopfAlgCat.quotient
+        (CommHopfAlgCat.baseChange (K := K) (GeneralLinear.coordinateHopfAlgebra R n)))
+      (comap_definingHopfIdeal_baseChangeIso R K n).symm) ≪≫
+    CommHopfAlgCat.quotientIsoOfIso
+      (GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n) (definingHopfIdeal K n)
+
+/-- The finite-type coordinate Hopf algebra of `SLₙ` commutes with base change. -/
+noncomputable def finiteTypeCoordinateHopfAlgebraBaseChangeIso :
+    FiniteTypeCommHopfAlgCat.baseChange (K := K) (finiteTypeCoordinateHopfAlgebra R n) ≅
+      finiteTypeCoordinateHopfAlgebra K n :=
+  ObjectProperty.isoMk _ <|
+    eqToIso (congrArg (CommHopfAlgCat.baseChange (K := K))
+      (finiteTypeCoordinateHopfAlgebra_obj R n)) ≪≫
+    coordinateHopfAlgebraBaseChangeIso R K n ≪≫
+    eqToIso (finiteTypeCoordinateHopfAlgebra_obj K n).symm
+
+/-- The underlying commutative-Hopf-algebra morphism of the finite-type base-change isomorphism
+is the coordinate-Hopf-algebra base-change isomorphism, with the object equalities made explicit.
+-/
+@[simp]
+theorem finiteTypeCoordinateHopfAlgebraBaseChangeIso_hom :
+    (finiteTypeCoordinateHopfAlgebraBaseChangeIso R K n).hom.hom =
+      (eqToIso (congrArg (CommHopfAlgCat.baseChange (K := K))
+          (finiteTypeCoordinateHopfAlgebra_obj R n)) ≪≫
+        coordinateHopfAlgebraBaseChangeIso R K n ≪≫
+        eqToIso (finiteTypeCoordinateHopfAlgebra_obj K n).symm).hom := by
+  simp only [finiteTypeCoordinateHopfAlgebraBaseChangeIso,
+    ObjectProperty.isoMk_hom, ObjectProperty.homMk_hom]
+
+end TauCeti.SpecialLinear

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/BaseChange.lean
@@ -119,6 +119,20 @@ private theorem comap_definingHopfIdeal_baseChangeIso :
     HopfIdeal.comap_map_of_surjective,
     (HopfIdeal.kerOfSurjective_eq_bot_iff e.hom.hom he.2).2 he.1, sup_bot_eq]
 
+/-- Quotient maps commute with transporting their defining ideal along an equality. -/
+private theorem mkQuotient_comp_eqToIso
+    {I J : HopfIdeal K (CommHopfAlgCat.baseChange (K := K)
+      (GeneralLinear.coordinateHopfAlgebra R n))} (hIJ : I = J) :
+    CommHopfAlgCat.mkQuotient
+          (CommHopfAlgCat.baseChange (K := K) (GeneralLinear.coordinateHopfAlgebra R n)) I ≫
+        (eqToIso (congrArg (CommHopfAlgCat.quotient
+          (CommHopfAlgCat.baseChange (K := K) (GeneralLinear.coordinateHopfAlgebra R n)))
+          hIJ)).hom =
+      CommHopfAlgCat.mkQuotient
+        (CommHopfAlgCat.baseChange (K := K) (GeneralLinear.coordinateHopfAlgebra R n)) J := by
+  subst J
+  simp
+
 /-- Base change of the special-linear coordinate Hopf algebra is canonically the
 special-linear coordinate Hopf algebra over the new base. -/
 noncomputable def coordinateHopfAlgebraBaseChangeIso :
@@ -131,6 +145,31 @@ noncomputable def coordinateHopfAlgebraBaseChangeIso :
       (comap_definingHopfIdeal_baseChangeIso R K n).symm) ≪≫
     CommHopfAlgCat.quotientIsoOfIso
       (GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n) (definingHopfIdeal K n)
+
+/-- The special-linear base-change isomorphism is compatible with the quotient coordinate
+morphisms from the corresponding general-linear coordinate Hopf algebras. -/
+@[simp]
+theorem baseChangeMap_coordinateMap_comp_coordinateHopfAlgebraBaseChangeIso_hom :
+    CommHopfAlgCat.baseChangeMap (K := K) (coordinateMap R n) ≫
+        (coordinateHopfAlgebraBaseChangeIso R K n).hom =
+      (GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n).hom ≫ coordinateMap K n := by
+  let e := GeneralLinear.coordinateHopfAlgebraBaseChangeIso R K n
+  let h := comap_definingHopfIdeal_baseChangeIso R K n
+  have hbase :
+      CommHopfAlgCat.baseChangeMap (K := K) (coordinateMap R n) ≫
+          (CommHopfAlgCat.quotientBaseChangeIso
+            (K := K) (definingHopfIdeal R n)).symm.hom =
+        CommHopfAlgCat.mkQuotient
+          (CommHopfAlgCat.baseChange (K := K)
+            (GeneralLinear.coordinateHopfAlgebra R n))
+          (CommHopfAlgCat.baseChangeHopfIdeal (K := K) (definingHopfIdeal R n)) := by
+    rw [← cancel_mono (CommHopfAlgCat.quotientBaseChangeIso
+      (K := K) (definingHopfIdeal R n)).hom]
+    simp
+  rw [coordinateHopfAlgebraBaseChangeIso, Iso.trans_hom, Iso.trans_hom,
+    ← Category.assoc, hbase, ← Category.assoc,
+    mkQuotient_comp_eqToIso R K n h.symm]
+  exact CommHopfAlgCat.mkQuotient_comp_quotientIsoOfIso_hom e (definingHopfIdeal K n)
 
 /-- The finite-type coordinate Hopf algebra of `SLₙ` commutes with base change. -/
 noncomputable def finiteTypeCoordinateHopfAlgebraBaseChangeIso :

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
@@ -9,38 +9,45 @@ public import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.StandardComodule
 public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
 import TauCeti.Algebra.AlgebraicGroup.Reductive.LinearlyReductive
 import TauCeti.Algebra.AlgebraicGroup.Representation.ClosedSubgroup
+import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.BaseChange
+import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Connected
 import TauCeti.Algebra.AlgebraicGroup.SpecialLinear.Smooth
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.Embedding
 import TauCeti.RingTheory.Smooth.GeometricallyReduced
 
 /-!
-# Normal unipotent subgroups of the special linear group
+# The special linear group is reductive
 
-A normal smooth unipotent closed subgroup of `SL_n` over an algebraically closed field is
-trivial. The proof uses the faithful simple standard representation.
+The coordinate Hopf algebra of `SL_n` is reductive over every field and in every natural rank.
+The proof uses the geometric definition, so it works in arbitrary characteristic.
 
-Smoothness makes the subgroup coordinate ring reduced, while geometric unipotence says that all
-of its points act unipotently. The general normal-invariants theorem then makes the subgroup act
-trivially on every completely reducible ambient representation. The standard representation of
-`SL_n` is simple in positive rank, hence completely reducible, and it is faithful in every rank.
-Faithfulness therefore identifies the subgroup's defining ideal with the augmentation ideal. The
-zero-rank case is handled directly using the zero-dimensional standard representation.
+Smoothness and geometric connectedness are established directly for the special-linear
+coordinate algebra. Over an algebraically closed field, smoothness makes a subgroup coordinate
+ring reduced, while geometric unipotence says that all of its points act unipotently. The general
+normal-invariants theorem then makes the subgroup act trivially on every completely reducible
+ambient representation. The standard representation of `SL_n` is simple in positive rank, hence
+completely reducible, and it is faithful in every rank. Faithfulness therefore identifies the
+subgroup's defining ideal with the augmentation ideal. The zero-rank case is handled directly
+using the zero-dimensional standard representation.
 
-Geometric connectedness of `SL_n`, and hence the assembly of this theorem into reductivity over an
-arbitrary field, is developed separately.
+The final theorem transports the normal-subgroup argument across the canonical identification
+
+`AlgebraicClosure k ⊗[k] O(SL_n) ≃ O(SL_n, AlgebraicClosure k)`.
 
 ## Main declaration
 
 * `TauCeti.SpecialLinear.eq_augmentation_of_isNormal_of_smoothUnipotent`: a normal smooth
   unipotent closed subgroup of `SL_n` over an algebraically closed field is the identity subgroup.
+* `TauCeti.SpecialLinear.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`:
+  **`SL_n` is reductive.**
 
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), §§4.a, 5, 19.b, and Chapter 14.
 * T. A. Springer, *Linear Algebraic Groups*, §§2.2 and 2.4.
 
-This supplies the normal-subgroup elimination step for the `SL_n` worked example in Layer 6,
-"Reductive and semisimple groups", of the ReductiveGroups roadmap.
+This completes the `SL_n` worked example in Layer 6, "Reductive and semisimple groups", of the
+ReductiveGroups roadmap.
 -/
 
 public section
@@ -108,6 +115,39 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
   have hJ : J = HopfIdeal.augmentation k (coordinateHopfAlgebra k n) :=
     Comodule.eq_augmentation_of_isFaithful_of_quotient_coact_eq_tmul_one J
       (isFaithful_standardComodule k n) htrivial
+  rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hf.2,
+    HopfIdeal.comap_augmentation]
+  exact hJ
+
+/-- **The special linear group is reductive over every field.** -/
+theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
+    (k : Type u) [Field k] (n : Nat) :
+    reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) := by
+  rw [reductiveCommHopfAlgProperty_iff]
+  let e₀ := coordinateHopfAlgebraFiniteTypeObjIso k n
+  refine ⟨(smoothCommHopfAlgProperty_iff _).mp <|
+      (smoothCommHopfAlgProperty k).prop_of_iso e₀
+        ((smoothCommHopfAlgProperty_iff _).mpr inferInstance),
+    (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e₀
+      (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n), ?_⟩
+  intro I hI _ hU
+  let K := AlgebraicClosure k
+  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := K)
+    (finiteTypeCoordinateHopfAlgebra k n)
+  let Gbar := finiteTypeCoordinateHopfAlgebra K n
+  let e : Hbar ≅ Gbar := finiteTypeCoordinateHopfAlgebraBaseChangeIso k K n
+  let f : Gbar →ₐc[K] Hbar := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
+  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.inv
+  let J : HopfIdeal K Gbar := I.comap f hf.2
+  have hJnormal : J.IsNormal := hI.comap_of_bijective f hf.1 hf.2
+  let qIso : FiniteTypeCommHopfAlgCat.quotient Gbar J ≅
+      FiniteTypeCommHopfAlgCat.quotient Hbar I :=
+    FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm I
+  have hJU : smoothUnipotentCommHopfAlgProperty K
+      (FiniteTypeCommHopfAlgCat.quotient Gbar J) :=
+    (smoothUnipotentCommHopfAlgProperty K).prop_of_iso qIso.symm hU
+  have hJ : J = HopfIdeal.augmentation K Gbar :=
+    eq_augmentation_of_isNormal_of_smoothUnipotent K n J hJnormal hJU
   rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hf.2,
     HopfIdeal.comap_augmentation]
   exact hJ

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean
@@ -34,6 +34,10 @@ The final theorem transports the normal-subgroup argument across the canonical i
 
 `AlgebraicClosure k ⊗[k] O(SL_n) ≃ O(SL_n, AlgebraicClosure k)`.
 
+Its final reductivity assembly is adapted from
+`TauCeti.GeneralLinear.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra`, with the
+common geometric-fibre transport factored through the generic reductivity API.
+
 ## Main declaration
 
 * `TauCeti.SpecialLinear.eq_augmentation_of_isNormal_of_smoothUnipotent`: a normal smooth
@@ -123,34 +127,18 @@ theorem eq_augmentation_of_isNormal_of_smoothUnipotent
 theorem reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra
     (k : Type u) [Field k] (n : Nat) :
     reductiveCommHopfAlgProperty k (finiteTypeCoordinateHopfAlgebra k n) := by
-  rw [reductiveCommHopfAlgProperty_iff]
   let e₀ := coordinateHopfAlgebraFiniteTypeObjIso k n
-  refine ⟨(smoothCommHopfAlgProperty_iff _).mp <|
+  apply reductiveCommHopfAlgProperty_of_geometricFiber_iso k _
+    (finiteTypeCoordinateHopfAlgebra (AlgebraicClosure k) n)
+    ((smoothCommHopfAlgProperty_iff _).mp <|
       (smoothCommHopfAlgProperty k).prop_of_iso e₀
-        ((smoothCommHopfAlgProperty_iff _).mpr inferInstance),
-    (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e₀
-      (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n), ?_⟩
-  intro I hI _ hU
-  let K := AlgebraicClosure k
-  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := K)
-    (finiteTypeCoordinateHopfAlgebra k n)
-  let Gbar := finiteTypeCoordinateHopfAlgebra K n
-  let e : Hbar ≅ Gbar := finiteTypeCoordinateHopfAlgebraBaseChangeIso k K n
-  let f : Gbar →ₐc[K] Hbar := FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-  have hf : Function.Bijective f := ConcreteCategory.bijective_of_isIso e.inv
-  let J : HopfIdeal K Gbar := I.comap f hf.2
-  have hJnormal : J.IsNormal := hI.comap_of_bijective f hf.1 hf.2
-  let qIso : FiniteTypeCommHopfAlgCat.quotient Gbar J ≅
-      FiniteTypeCommHopfAlgCat.quotient Hbar I :=
-    FiniteTypeCommHopfAlgCat.quotientIsoOfIso e.symm I
-  have hJU : smoothUnipotentCommHopfAlgProperty K
-      (FiniteTypeCommHopfAlgCat.quotient Gbar J) :=
-    (smoothUnipotentCommHopfAlgProperty K).prop_of_iso qIso.symm hU
-  have hJ : J = HopfIdeal.augmentation K Gbar :=
-    eq_augmentation_of_isNormal_of_smoothUnipotent K n J hJnormal hJU
-  rw [← HopfIdeal.comap_eq_comap_iff_of_surjective f hf.2,
-    HopfIdeal.comap_augmentation]
-  exact hJ
+        ((smoothCommHopfAlgProperty_iff _).mpr inferInstance))
+    ((geometricallyConnectedCommHopfAlgProperty k).prop_of_iso e₀
+      (geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra k n))
+    (finiteTypeCoordinateHopfAlgebraBaseChangeIso k (AlgebraicClosure k) n)
+  intro I hI hU
+  exact eq_augmentation_of_isNormal_of_smoothUnipotent
+    (AlgebraicClosure k) n I hI hU
 
 end
 


### PR DESCRIPTION
This PR proves that the finite-type coordinate Hopf algebra of `SLₙ` is reductive over every field and in every natural rank, completing the worked-example instruction in `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “Reductive and semisimple groups”: prove the classical groups reductive via the geometric unipotent-radical definition. This is the most effective current step because smoothness (#4398), geometric connectedness (#4416), and elimination of normal smooth unipotent closed subgroups over an algebraically closed field (#4527) have all just landed, leaving their scalar-extension transport and final assembly as the exact unmet conclusion.

The new base-change module identifies `K ⊗[R] O(SLₙ)` with `O(SLₙ,K)`. It reuses the canonical base-change isomorphism for `GLₙ`, proves that it sends the scalar-extended generic determinant to the generic determinant over `K`, identifies the transported determinant-one Hopf ideal, and then applies Tau Ceti’s general theorem that Hopf-ideal quotients commute with base change. The finite-type packaging exposes the isomorphism consumed by reductivity.

The final theorem combines the existing smoothness and geometric-connectedness results with the algebraically closed subgroup-elimination theorem. A normal smooth unipotent subgroup of the geometric fibre is transported to the directly constructed special-linear coordinate algebra over `AlgebraicClosure k`, shown trivial there, and transported back by the augmentation-ideal compatibility of Hopf-ideal pullback.

After this PR, the `SLₙ` worked example is complete; Layer 6 still needs the characteristic-zero comparison between reductivity and linear reductivity, the radical/centre/derived-group and central-isogeny structure theory, and reductivity proofs for the remaining classical worked examples.

Add `TauCeti/Algebra/AlgebraicGroup/SpecialLinear/BaseChange.lean` (158 lines) and extend `TauCeti/Algebra/AlgebraicGroup/SpecialLinear/Reductive.lean` to state the completed result. The construction follows Milne, *Basic Theory of Affine Group Schemes*, Chapter IV §1.8, the Stacks Project Tags 01JO and 022W, Milne, *Algebraic Groups* (2017), and Springer, *Linear Algebraic Groups*, as credited in the module documentation. No Mathlib implementation is vendored; the proof consumes Mathlib’s tensor-product and ideal-map APIs together with Tau Ceti’s general-linear base change, Hopf-ideal base change, quotient transport, smoothness, connectedness, and normal-invariants infrastructure.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"special-linear-is-reductive"}-->

🤖 Prepared with Codex
