### PR TITLE
feat: the spin representation is irreducible in odd dimension

### DIFF
--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -68,16 +68,20 @@ always contains the scalars, so it needs no such hypothesis, and neither does th
 The odd-dimensional case is the opposite of all this, and the last section records it. There the
 even subalgebra is a *single* matrix algebra rather than a product, so the Fock action already
 carries it onto all of `Module.End K S` (`TauCeti.evenSpinAction_surjective`), and the whole
-spinor module — not a half of it — is the irreducible object:
-`TauCeti.isIrreducible_spinRep`. Exterior parity still splits `S` as a vector space, but no
-longer as a representation, which `TauCeti.not_forall_map_spinRep_spinPlus_le` records: `S⁺` is a
-subspace that is neither `⊥` nor everything, so irreducibility alone forbids it from being
-invariant. The `P.line = ⊥` carried by every statement of the even-dimensional half is precisely
-what fails.
+spinor module — not a half of it — is the irreducible object: `TauCeti.isIrreducible_spinRep`.
+As soon as `P.W ≠ ⊥`, exterior parity still splits `S` as a vector space but no longer as a
+representation, which `TauCeti.not_forall_map_spinRep_spinPlus_le` and
+`TauCeti.not_forall_map_spinRep_spinMinus_le` record: neither half is `⊥` or everything, so
+irreducibility alone forbids either from being invariant. The `P.line = ⊥` carried by every
+statement of the even-dimensional half is precisely what fails. Dimension one is the exception:
+there `W = ⊥` and `S = K` is entirely even, so `S⁺ = S` and `S⁻ = 0` are both invariant, for want
+of anything to split.
 
 The two parities are separated by exactly one hypothesis, the surjectivity of
 `TauCeti.evenSpinAction`, and `TauCeti.isIrreducible_spinRep_of_span_of_surjective` is stated
-against it rather than against a dimension, so the dichotomy is visible in the statement.
+against it rather than against a dimension, so the dichotomy is visible in the statement. It fails
+in even dimension except for the zero-dimensional quadratic space, where `S = K` is
+one-dimensional and there is no room for it to fail.
 
 What is not proved here is the odd-dimensional splitting of `CliffordAlgebra Q` into its two
 central summands, for which the results here are the even-dimensional half; it is
@@ -111,8 +115,9 @@ central summands, for which the results here are the even-dimensional half; it i
   the spinor module.
 * `TauCeti.isIrreducible_spinRep`: **the spin representation is irreducible in odd dimension**,
   the type `Bₗ` half of Layer 4.
-* `TauCeti.not_forall_map_spinRep_spinPlus_le`: **in odd dimension the spinor module does not
-  split along exterior parity.**
+* `TauCeti.not_forall_map_spinRep_spinPlus_le` and
+  `TauCeti.not_forall_map_spinRep_spinMinus_le`: **in odd dimension the spinor module does not
+  split along exterior parity**, provided `P.W ≠ ⊥`, which rules out only dimension one.
 
 ## References
 
@@ -150,21 +155,22 @@ private theorem eq_bot_or_eq_top_of_surjective_action {K : Type u} [Field K]
   obtain ⟨a, rfl⟩ := hF g
   exact hg ▸ hN a ⟨s, hs, rfl⟩
 
-private def spinGroupToEven {K : Type u} [Field K]
-    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} :
-    spinGroup Q →* CliffordAlgebra.even Q :=
-  Submonoid.inclusion fun _ hx => spinGroup.mem_even hx
-
 private def spinGroupRepresentation {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
     {M : Type*} [AddCommGroup M] [Module K M]
     (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M) : Representation K (spinGroup Q) M :=
-  F.toMonoidHom.comp spinGroupToEven
+  F.toMonoidHom.comp (spinGroupToEven Q)
+
+private theorem spinGroupRepresentation_apply {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
+    {M : Type*} [AddCommGroup M] [Module K M]
+    (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M) (g : spinGroup Q) :
+    spinGroupRepresentation F g = F (spinGroupToEven Q g) := rfl
 
 private noncomputable def spinGroupAlgebraHom {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} :
     MonoidAlgebra K (spinGroup Q) →ₐ[K] CliffordAlgebra.even Q :=
-  MonoidAlgebra.lift K (CliffordAlgebra.even Q) (spinGroup Q) spinGroupToEven
+  MonoidAlgebra.lift K (CliffordAlgebra.even Q) (spinGroup Q) (spinGroupToEven Q)
 
 private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V]
@@ -176,10 +182,10 @@ private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
   change Function.Surjective (spinGroupAlgebraHom (K := K) (Q := Q)).toLinearMap
   rw [← LinearMap.range_eq_top]
   rw [show (spinGroupAlgebraHom (K := K) (Q := Q)).toLinearMap =
-      (Finsupp.linearCombination K spinGroupToEven).comp
+      (Finsupp.linearCombination K (spinGroupToEven Q)).comp
         (MonoidAlgebra.coeffLinearEquiv K).toLinearMap by
     ext g
-    simp [spinGroupAlgebraHom, spinGroupToEven]]
+    simp [spinGroupAlgebraHom]]
   rw [LinearMap.range_comp_of_range_eq_top _ (LinearEquiv.range _),
     Finsupp.range_linearCombination]
   apply (Submodule.span_range_subtype_eq_top_iff
@@ -504,70 +510,82 @@ variable {K : Type u} [Field K]
 even Clifford subalgebra and that subalgebra already exhausts the endomorphisms of the spinor
 module.
 
-The second hypothesis is exactly what separates the two parities of `finrank K V`. In even
-dimension it fails — the even subalgebra is the *product* of the two half-spin endomorphism
+The second hypothesis is exactly what separates the two parities of `finrank K V`. In *positive*
+even dimension it fails — the even subalgebra is the *product* of the two half-spin endomorphism
 algebras, by `TauCeti.SpinPolarizationData.evenCliffordEquivProdEnd`, and `S` visibly splits — and
-in odd dimension it holds, by `TauCeti.evenSpinAction_surjective`. -/
+in odd dimension it holds, by `TauCeti.evenSpinAction_surjective`. Dimension zero is the exception
+on the even side: there `W = ⊥`, the odd block is zero, `S = K` is one-dimensional and the even
+subalgebra is already all of `Module.End K S`. -/
 theorem isIrreducible_spinRep_of_span_of_surjective
     (hspan : Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) =
       (CliffordAlgebra.even Q).toSubmodule)
     (hsurj : Function.Surjective (evenSpinAction Q P)) : (spinRep Q P).IsIrreducible := by
-  have hEq : spinGroupRepresentation (evenSpinAction Q P) = spinRep Q P := by
-    refine DFunLike.ext _ _ fun g => ?_
-    have hg : spinGroupRepresentation (evenSpinAction Q P) g
-        = evenSpinAction Q P (spinGroupToEven g) := rfl
-    rw [hg, evenSpinAction_apply, spinRep_apply]
-    rfl
+  have hEq : spinGroupRepresentation (evenSpinAction Q P) = spinRep Q P :=
+    DFunLike.ext _ _ fun g => by
+      rw [spinGroupRepresentation_apply, evenSpinAction_spinGroupToEven]
   exact hEq ▸ isIrreducible_spinGroupRepresentation hspan (evenSpinAction Q P) hsurj
+
+/-- A subspace of the spinor module that is neither zero nor everything is not invariant under the
+Spin group once the spin representation is irreducible, since invariance would make it a
+subrepresentation. -/
+private theorem not_forall_map_spinRep_le (hirr : (spinRep Q P).IsIrreducible)
+    {N : Submodule K (ExteriorAlgebra K P.W)} (hbot : N ≠ ⊥) (htop : N ≠ ⊤) :
+    ¬ ∀ g : spinGroup Q, N.map (spinRep Q P g) ≤ N := by
+  intro hinv
+  have _ : (spinRep Q P).IsIrreducible := hirr
+  let σ : Subrepresentation (spinRep Q P) :=
+    { toSubmodule := N
+      apply_mem_toSubmodule := fun g _ hv => hinv g ⟨_, hv, rfl⟩ }
+  rcases IsSimpleOrder.eq_bot_or_eq_top σ with h | h
+  · exact hbot (congrArg Subrepresentation.toSubmodule h)
+  · exact htop (congrArg Subrepresentation.toSubmodule h)
 
 variable [NeZero (2 : K)] [IsSepClosed K] [FiniteDimensional K V]
 
 /-- **The spin representation is irreducible in odd dimension.** For a nondegenerate quadratic
-form on a space of dimension `2 * l + 1` over a separably closed field of characteristic not two,
-the Spin group acts irreducibly on the whole spinor module `S = ⋀·W`, of dimension `2 ^ l`.
+form on a space of odd dimension over a separably closed field of characteristic not two, the Spin
+group acts irreducibly on the whole spinor module `S = ⋀·W`.
 
-This is the type `Bₗ` half of the Layer-4 irreducibility statement, and the exterior parity
-splitting `S = S⁺ ⊕ S⁻` is *not* a splitting of representations here: see
-`TauCeti.not_forall_map_spinRep_spinPlus_le`. The even-dimensional counterpart is the pair
-`TauCeti.isIrreducible_spinPlusSubrep`, `TauCeti.isIrreducible_spinMinusSubrep`, where `S` itself
-is reducible. -/
-theorem isIrreducible_spinRep {l : ℕ} (hQ : Q.Nondegenerate) (hV : finrank K V = 2 * l + 1) :
+This is the type `Bₗ` half of the Layer-4 irreducibility statement. Except in dimension one, where
+`W = ⊥` and `S = K` is entirely even, the exterior parity splitting `S = S⁺ ⊕ S⁻` is *not* a
+splitting of representations here: see `TauCeti.not_forall_map_spinRep_spinPlus_le`. The
+even-dimensional counterpart is the pair `TauCeti.isIrreducible_spinPlusSubrep`,
+`TauCeti.isIrreducible_spinMinusSubrep`, where `S` itself is reducible unless it is the
+zero-dimensional quadratic space. -/
+theorem isIrreducible_spinRep (hQ : Q.Nondegenerate) (hodd : Odd (finrank K V)) :
     (spinRep Q P).IsIrreducible :=
   isIrreducible_spinRep_of_span_of_surjective P
-    (CliffordAlgebra.span_spinGroup_eq_even Q hQ) (evenSpinAction_surjective P hQ hV)
+    (CliffordAlgebra.span_spinGroup_eq_even Q hQ) (evenSpinAction_surjective P hQ hodd)
 
 /-- **In odd dimension the spinor module does not split along exterior parity.** The even part
-`S⁺` is not invariant under the Spin group, so — unlike in even dimension — it is not a
+`S⁺` is not invariant under the Spin group, so — unlike in positive even dimension — it is not a
 subrepresentation of `spinRep`.
 
 Nothing about the anisotropic remainder is computed: the proof is by irreducibility, `S⁺` being
 neither `⊥` (it contains the scalars) nor everything (it misses the nonzero `S⁻`). The hypothesis
-`P.W ≠ ⊥` rules out only `finrank V = 1`, where `S = K` is entirely even and there is nothing to
-split. In even dimension the same subspace *is* invariant, by `TauCeti.spinPlus_invariant`, whose
-hypothesis `P.line = ⊥` is what an odd-dimensional polarization cannot satisfy. -/
-theorem not_forall_map_spinRep_spinPlus_le {l : ℕ} (hQ : Q.Nondegenerate)
-    (hV : finrank K V = 2 * l + 1) (hW : P.W ≠ ⊥) :
-    ¬ ∀ g : spinGroup Q, (spinPlus Q P).map (spinRep Q P g) ≤ spinPlus Q P := by
-  intro hinv
-  have _ : (spinRep Q P).IsIrreducible := isIrreducible_spinRep P hQ hV
-  -- The invariance makes `S⁺` a subrepresentation, so it is `⊥` or everything.
-  let σ : Subrepresentation (spinRep Q P) :=
-    { toSubmodule := spinPlus Q P
-      apply_mem_toSubmodule := fun g _ hv => hinv g ⟨_, hv, rfl⟩ }
-  have hσ : σ = ⊥ ∨ σ = ⊤ := IsSimpleOrder.eq_bot_or_eq_top σ
-  have hbot : spinPlus Q P ≠ ⊥ := by
-    have := nontrivial_spinPlus P
-    exact fun h => not_nontrivial_iff_subsingleton.2 (h ▸ inferInstance) this
-  have htop : spinPlus Q P ≠ ⊤ := by
-    have hne := nontrivial_spinMinus P hW
-    intro h
-    have : spinMinus Q P = ⊥ := by
-      have := spinPlus_inf_spinMinus (Q := Q) (P := P)
-      rwa [h, top_inf_eq] at this
-    exact not_nontrivial_iff_subsingleton.2 (this ▸ inferInstance) hne
-  rcases hσ with h | h
-  · exact hbot (congrArg Subrepresentation.toSubmodule h)
-  · exact htop (congrArg Subrepresentation.toSubmodule h)
+`P.W ≠ ⊥` is what excludes `finrank V = 1`, where `S = K` is entirely even, `S⁺ = S` is trivially
+invariant and there is nothing to split. In even dimension the same subspace *is* invariant, by
+`TauCeti.spinPlus_invariant`, whose hypothesis `P.line = ⊥` is what an odd-dimensional
+polarization cannot satisfy. -/
+theorem not_forall_map_spinRep_spinPlus_le (hQ : Q.Nondegenerate) (hodd : Odd (finrank K V))
+    (hW : P.W ≠ ⊥) :
+    ¬ ∀ g : spinGroup Q, (spinPlus Q P).map (spinRep Q P g) ≤ spinPlus Q P :=
+  not_forall_map_spinRep_le P (isIrreducible_spinRep P hQ hodd)
+    (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinPlus P))
+    ((isCompl_spinPlus_spinMinus P).symm.disjoint.ne_top_of_ne_bot
+      (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinMinus P hW)))
+
+/-- **In odd dimension the odd half of the spinor module is not invariant either.** The companion
+of `TauCeti.not_forall_map_spinRep_spinPlus_le` for the other parity: `S⁻` is nonzero when
+`P.W ≠ ⊥` and is not everything, `S⁺` containing the scalars, so irreducibility forbids it from
+being a subrepresentation of `spinRep`. -/
+theorem not_forall_map_spinRep_spinMinus_le (hQ : Q.Nondegenerate) (hodd : Odd (finrank K V))
+    (hW : P.W ≠ ⊥) :
+    ¬ ∀ g : spinGroup Q, (spinMinus Q P).map (spinRep Q P g) ≤ spinMinus Q P :=
+  not_forall_map_spinRep_le P (isIrreducible_spinRep P hQ hodd)
+    (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinMinus P hW))
+    ((isCompl_spinPlus_spinMinus P).disjoint.ne_top_of_ne_bot
+      (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinPlus P)))
 
 end Odd
 

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -66,9 +66,9 @@ only the zero-dimensional quadratic space: there `S = K` is entirely even and `S
 always contains the scalars, so it needs no such hypothesis, and neither does the inequivalence.
 
 The odd-dimensional case is the opposite of all this, and the last section records it. There the
-even subalgebra is a *single* matrix algebra rather than a product, so the Fock action already
-carries it onto all of `Module.End K S` (`TauCeti.evenSpinAction_surjective`), and the whole
-spinor module — not a half of it — is the irreducible object: `TauCeti.isIrreducible_spinRep`.
+even subalgebra is a *single* block rather than a product, so the Fock action already carries it
+onto all of `Module.End K S` (`TauCeti.evenSpinAction_surjective`), and the whole spinor module —
+not a half of it — is the irreducible object: `TauCeti.isIrreducible_spinRep`.
 As soon as `P.W ≠ ⊥`, exterior parity still splits `S` as a vector space but no longer as a
 representation, which `TauCeti.not_forall_map_spinRep_spinPlus_le` and
 `TauCeti.not_forall_map_spinRep_spinMinus_le` record: neither half is `⊥` or everything, so
@@ -113,8 +113,9 @@ central summands, for which the results here are the even-dimensional half; it i
 * `TauCeti.isIrreducible_spinRep_of_span_of_surjective`: the spin representation is irreducible
   once the Spin group spans the even subalgebra and that subalgebra exhausts the endomorphisms of
   the spinor module.
-* `TauCeti.isIrreducible_spinRep`: **the spin representation is irreducible in odd dimension**,
-  the type `Bₗ` half of Layer 4.
+* `TauCeti.isIrreducible_spinRep_of_isSquare` and `TauCeti.isIrreducible_spinRep`: **the spin
+  representation is irreducible in odd dimension**, the type `Bₗ` half of Layer 4, under the square
+  normalization and over a separably closed field respectively.
 * `TauCeti.not_forall_map_spinRep_spinPlus_le` and
   `TauCeti.not_forall_map_spinRep_spinMinus_le`: **in odd dimension the spinor module does not
   split along exterior parity**, provided `P.W ≠ ⊥`, which rules out only dimension one.
@@ -167,6 +168,17 @@ private theorem spinGroupRepresentation_apply {K : Type u} [Field K]
     (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M) (g : spinGroup Q) :
     spinGroupRepresentation F g = F (spinGroupToEven Q g) := rfl
 
+/-- The same, with the even element spelled out in the coordinates the half-spin lemmas of
+`TauCeti/RepresentationTheory/Spin/HalfSpin.lean` are stated in. Only the coercion lemma
+`TauCeti.coe_spinGroupToEven` is used, not the definition of the inclusion. -/
+private theorem spinGroupRepresentation_apply_mk {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
+    {M : Type*} [AddCommGroup M] [Module K M]
+    (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M) (g : spinGroup Q) :
+    spinGroupRepresentation F g = F ⟨g, spinGroup.mem_even g.2⟩ := by
+  rw [spinGroupRepresentation_apply]
+  exact congrArg F (Subtype.ext (coe_spinGroupToEven Q g))
+
 private noncomputable def spinGroupAlgebraHom {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} :
     MonoidAlgebra K (spinGroup Q) →ₐ[K] CliffordAlgebra.even Q :=
@@ -188,6 +200,10 @@ private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
     simp [spinGroupAlgebraHom]]
   rw [LinearMap.range_comp_of_range_eq_top _ (LinearEquiv.range _),
     Finsupp.range_linearCombination]
+  rw [show Set.range ⇑(spinGroupToEven Q) =
+      Set.range fun g : spinGroup Q ↦
+        (⟨g, spinGroup.mem_even g.2⟩ : CliffordAlgebra.even Q) from
+    congrArg Set.range (funext fun g ↦ Subtype.ext (coe_spinGroupToEven Q g))]
   apply (Submodule.span_range_subtype_eq_top_iff
     (CliffordAlgebra.even Q).toSubmodule
       (fun g : spinGroup Q ↦ spinGroup.mem_even g.2)).2
@@ -233,7 +249,8 @@ private theorem intertwines_even_of_intertwines_spinGroup {K : Type u} [Field K]
     (x : CliffordAlgebra.even Q) (m : M) : φ (F x m) = G x (φ m) := by
   obtain ⟨a, rfl⟩ := spinGroupAlgebraHom_surjective hspan x
   let φ' : (spinGroupRepresentation F).IntertwiningMap (spinGroupRepresentation G) :=
-    ⟨φ, fun g => LinearMap.ext fun m => hφ g m⟩
+    ⟨φ, fun g => LinearMap.ext fun m => by
+      simpa only [LinearMap.comp_apply, spinGroupRepresentation_apply_mk] using hφ g m⟩
   have h := (Representation.IntertwiningMap.equivLinearMapAsModule
     (spinGroupRepresentation F) (spinGroupRepresentation G) φ').map_smul' a m
   -- The module equivalence is definitionally the identity on carriers. Expose the algebra
@@ -371,6 +388,7 @@ theorem isIrreducible_spinPlusSubrep_of_span
     LinearEquiv.ofEq _ _ (toSubmodule_spinPlusSubrep P hline).symm
   refine Representation.isIrreducible_of_linearEquiv e ?_ hρ
   intro g s
+  rw [spinGroupRepresentation_apply_mk]
   apply Subtype.ext
   exact coe_spinPlusAction_spinGroup_apply P hline g s
 
@@ -389,6 +407,7 @@ theorem isIrreducible_spinMinusSubrep_of_span
     LinearEquiv.ofEq _ _ (toSubmodule_spinMinusSubrep P hline).symm
   refine Representation.isIrreducible_of_linearEquiv e ?_ hρ
   intro g s
+  rw [spinGroupRepresentation_apply_mk]
   apply Subtype.ext
   exact coe_spinMinusAction_spinGroup_apply P hline g s
 
@@ -411,13 +430,17 @@ theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_span
   refine ⟨f, fun x s => intertwines_even_of_intertwines_spinGroup hspan
     (spinPlusAction Q P hline) (spinMinusAction Q P hline) f.toLinearMap ?_ x s⟩
   intro g s
+  rw [← spinGroupRepresentation_apply_mk (spinPlusAction Q P hline) g,
+    ← spinGroupRepresentation_apply_mk (spinMinusAction Q P hline) g]
   have hPlus : ePlus ((spinGroupRepresentation (spinPlusAction Q P hline)) g s) =
       (spinPlusSubrep P hline).toRepresentation g (ePlus s) := by
+    rw [spinGroupRepresentation_apply_mk]
     apply Subtype.ext
     exact coe_spinPlusAction_spinGroup_apply P hline g s
   have hMinus (t : spinMinus Q P) :
       eMinus ((spinGroupRepresentation (spinMinusAction Q P hline)) g t) =
         (spinMinusSubrep P hline).toRepresentation g (eMinus t) := by
+    rw [spinGroupRepresentation_apply_mk]
     apply Subtype.ext
     exact coe_spinMinusAction_spinGroup_apply P hline g t
   have hef (t : spinPlus Q P) : e.toIntertwiningMap (ePlus t) = eMinus (f t) := by
@@ -540,11 +563,28 @@ private theorem not_forall_map_spinRep_le (hirr : (spinRep Q P).IsIrreducible)
   · exact hbot (congrArg Subrepresentation.toSubmodule h)
   · exact htop (congrArg Subrepresentation.toSubmodule h)
 
-variable [NeZero (2 : K)] [IsSepClosed K] [FiniteDimensional K V]
+variable [NeZero (2 : K)] [FiniteDimensional K V]
 
-/-- **The spin representation is irreducible in odd dimension.** For a nondegenerate quadratic
-form on a space of odd dimension over a separably closed field of characteristic not two, the Spin
-group acts irreducibly on the whole spinor module `S = ⋀·W`.
+/-- **The spin representation is irreducible in odd dimension** when anisotropic pairs admit the
+square normalization needed to span the even Clifford algebra.
+
+This is the generality of the even-dimensional `TauCeti.isIrreducible_spinPlusSubrep_of_isSquare`:
+no separably closed field, and no nondegeneracy hypothesis, the polarization data already carrying
+it by `TauCeti.SpinPolarizationData.nondegenerate`. The square normalization is only what lifts a
+product of two reflections to the Spin group, and it is the sole remaining obstruction. -/
+theorem isIrreducible_spinRep_of_isSquare
+    (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
+    (hodd : Odd (finrank K V)) : (spinRep Q P).IsIrreducible := by
+  have _ : Invertible (2 : K) := invertibleOfNonzero (NeZero.ne (2 : K))
+  exact isIrreducible_spinRep_of_span_of_surjective P
+    (CliffordAlgebra.span_spinGroup_eq_even_of_isSquare Q P.nondegenerate hsq)
+    (evenSpinAction_surjective P hodd)
+
+variable [IsSepClosed K]
+
+/-- **The spin representation is irreducible in odd dimension.** For a polarized quadratic space of
+odd dimension over a separably closed field of characteristic not two, the Spin group acts
+irreducibly on the whole spinor module `S = ⋀·W`.
 
 This is the type `Bₗ` half of the Layer-4 irreducibility statement. Except in dimension one, where
 `W = ⊥` and `S = K` is entirely even, the exterior parity splitting `S = S⁺ ⊕ S⁻` is *not* a
@@ -552,10 +592,9 @@ splitting of representations here: see `TauCeti.not_forall_map_spinRep_spinPlus_
 even-dimensional counterpart is the pair `TauCeti.isIrreducible_spinPlusSubrep`,
 `TauCeti.isIrreducible_spinMinusSubrep`, where `S` itself is reducible unless it is the
 zero-dimensional quadratic space. -/
-theorem isIrreducible_spinRep (hQ : Q.Nondegenerate) (hodd : Odd (finrank K V)) :
-    (spinRep Q P).IsIrreducible :=
-  isIrreducible_spinRep_of_span_of_surjective P
-    (CliffordAlgebra.span_spinGroup_eq_even Q hQ) (evenSpinAction_surjective P hQ hodd)
+theorem isIrreducible_spinRep (hodd : Odd (finrank K V)) : (spinRep Q P).IsIrreducible :=
+  isIrreducible_spinRep_of_isSquare P
+    (fun v w _ _ ↦ IsSepClosed.exists_eq_mul_self ((Q v)⁻¹ * (Q w)⁻¹)) hodd
 
 /-- **In odd dimension the spinor module does not split along exterior parity.** The even part
 `S⁺` is not invariant under the Spin group, so — unlike in positive even dimension — it is not a
@@ -567,10 +606,9 @@ neither `⊥` (it contains the scalars) nor everything (it misses the nonzero `S
 invariant and there is nothing to split. In even dimension the same subspace *is* invariant, by
 `TauCeti.spinPlus_invariant`, whose hypothesis `P.line = ⊥` is what an odd-dimensional
 polarization cannot satisfy. -/
-theorem not_forall_map_spinRep_spinPlus_le (hQ : Q.Nondegenerate) (hodd : Odd (finrank K V))
-    (hW : P.W ≠ ⊥) :
+theorem not_forall_map_spinRep_spinPlus_le (hodd : Odd (finrank K V)) (hW : P.W ≠ ⊥) :
     ¬ ∀ g : spinGroup Q, (spinPlus Q P).map (spinRep Q P g) ≤ spinPlus Q P :=
-  not_forall_map_spinRep_le P (isIrreducible_spinRep P hQ hodd)
+  not_forall_map_spinRep_le P (isIrreducible_spinRep P hodd)
     (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinPlus P))
     ((isCompl_spinPlus_spinMinus P).symm.disjoint.ne_top_of_ne_bot
       (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinMinus P hW)))
@@ -579,10 +617,9 @@ theorem not_forall_map_spinRep_spinPlus_le (hQ : Q.Nondegenerate) (hodd : Odd (f
 of `TauCeti.not_forall_map_spinRep_spinPlus_le` for the other parity: `S⁻` is nonzero when
 `P.W ≠ ⊥` and is not everything, `S⁺` containing the scalars, so irreducibility forbids it from
 being a subrepresentation of `spinRep`. -/
-theorem not_forall_map_spinRep_spinMinus_le (hQ : Q.Nondegenerate) (hodd : Odd (finrank K V))
-    (hW : P.W ≠ ⊥) :
+theorem not_forall_map_spinRep_spinMinus_le (hodd : Odd (finrank K V)) (hW : P.W ≠ ⊥) :
     ¬ ∀ g : spinGroup Q, (spinMinus Q P).map (spinRep Q P g) ≤ spinMinus Q P :=
-  not_forall_map_spinRep_le P (isIrreducible_spinRep P hQ hodd)
+  not_forall_map_spinRep_le P (isIrreducible_spinRep P hodd)
     (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinMinus P hW))
     ((isCompl_spinPlus_spinMinus P).disjoint.ne_top_of_ne_bot
       (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinPlus P)))

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -577,7 +577,8 @@ theorem isIrreducible_spinRep_of_isSquare
     (hodd : Odd (finrank K V)) : (spinRep Q P).IsIrreducible := by
   have _ : Invertible (2 : K) := invertibleOfNonzero (NeZero.ne (2 : K))
   exact isIrreducible_spinRep_of_span_of_surjective P
-    (CliffordAlgebra.span_spinGroup_eq_even_of_isSquare Q P.nondegenerate hsq)
+    (CliffordAlgebra.span_spinGroup_eq_even_of_isSquare Q
+      (P.nondegenerate ((isUnit_of_invertible (2 : K)).isSMulRegular K)) hsq)
     (evenSpinAction_surjective P hodd)
 
 variable [IsSepClosed K]

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -170,14 +170,14 @@ private theorem spinGroupRepresentation_apply {K : Type u} [Field K]
 
 /-- The same, with the even element spelled out in the coordinates the half-spin lemmas of
 `TauCeti/RepresentationTheory/Spin/HalfSpin.lean` are stated in. Only the coercion lemma
-`TauCeti.coe_spinGroupToEven` is used, not the definition of the inclusion. -/
+`TauCeti.coe_spinGroupToEven_apply` is used, not the definition of the inclusion. -/
 private theorem spinGroupRepresentation_apply_mk {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
     {M : Type*} [AddCommGroup M] [Module K M]
     (F : CliffordAlgebra.even Q →ₐ[K] Module.End K M) (g : spinGroup Q) :
     spinGroupRepresentation F g = F ⟨g, spinGroup.mem_even g.2⟩ := by
   rw [spinGroupRepresentation_apply]
-  exact congrArg F (Subtype.ext (coe_spinGroupToEven Q g))
+  exact congrArg F (Subtype.ext (coe_spinGroupToEven_apply Q g))
 
 private noncomputable def spinGroupAlgebraHom {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} :
@@ -203,7 +203,7 @@ private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
   rw [show Set.range ⇑(spinGroupToEven Q) =
       Set.range fun g : spinGroup Q ↦
         (⟨g, spinGroup.mem_even g.2⟩ : CliffordAlgebra.even Q) from
-    congrArg Set.range (funext fun g ↦ Subtype.ext (coe_spinGroupToEven Q g))]
+    congrArg Set.range (funext fun g ↦ Subtype.ext (coe_spinGroupToEven_apply Q g))]
   apply (Submodule.span_range_subtype_eq_top_iff
     (CliffordAlgebra.even Q).toSubmodule
       (fun g : spinGroup Q ↦ spinGroup.mem_even g.2)).2
@@ -545,7 +545,8 @@ theorem isIrreducible_spinRep_of_span_of_surjective
     (hsurj : Function.Surjective (evenSpinAction Q P)) : (spinRep Q P).IsIrreducible := by
   have hEq : spinGroupRepresentation (evenSpinAction Q P) = spinRep Q P :=
     DFunLike.ext _ _ fun g => by
-      rw [spinGroupRepresentation_apply, evenSpinAction_apply, coe_spinGroupToEven, spinRep_apply]
+      rw [spinGroupRepresentation_apply, evenSpinAction_apply, coe_spinGroupToEven_apply,
+        spinRep_apply]
   exact hEq ▸ isIrreducible_spinGroupRepresentation hspan (evenSpinAction Q P) hsurj
 
 /-- A subspace of the spinor module that is neither zero nor everything is not invariant under the

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -572,7 +572,8 @@ square normalization needed to span the even Clifford algebra.
 This is the generality of the even-dimensional `TauCeti.isIrreducible_spinPlusSubrep_of_isSquare`:
 no separably closed field, and no nondegeneracy hypothesis, the polarization data already carrying
 it by `TauCeti.SpinPolarizationData.nondegenerate`. The square normalization is only what lifts a
-product of two reflections to the Spin group, and it is the sole remaining obstruction. -/
+product of two reflections to the Spin group, and it is the sole remaining hypothesis of this
+argument. -/
 theorem isIrreducible_spinRep_of_isSquare
     (hsq : ∀ v w, Q v ≠ 0 → Q w ≠ 0 → IsSquare ((Q v)⁻¹ * (Q w)⁻¹))
     (hodd : Odd (finrank K V)) : (spinRep Q P).IsIrreducible := by

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -545,7 +545,7 @@ theorem isIrreducible_spinRep_of_span_of_surjective
     (hsurj : Function.Surjective (evenSpinAction Q P)) : (spinRep Q P).IsIrreducible := by
   have hEq : spinGroupRepresentation (evenSpinAction Q P) = spinRep Q P :=
     DFunLike.ext _ _ fun g => by
-      rw [spinGroupRepresentation_apply, evenSpinAction_spinGroupToEven]
+      rw [spinGroupRepresentation_apply, evenSpinAction_apply, coe_spinGroupToEven, spinRep_apply]
   exact hEq ▸ isIrreducible_spinGroupRepresentation hspan (evenSpinAction Q P) hsurj
 
 /-- A subspace of the spinor module that is neither zero nor everything is not invariant under the

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -68,7 +68,7 @@ always contains the scalars, so it needs no such hypothesis, and neither does th
 The odd-dimensional case is the opposite of all this, and the last section records it. There the
 even subalgebra is a *single* block rather than a product, so the Fock action already carries it
 onto all of `Module.End K S` (`TauCeti.evenSpinAction_surjective`), and the whole spinor module —
-not a half of it — is the irreducible object: `TauCeti.isIrreducible_spinRep`.
+not a half of it — is the irreducible object: `TauCeti.spinRep_isIrreducible_of_odd`.
 As soon as `P.W ≠ ⊥`, exterior parity still splits `S` as a vector space but no longer as a
 representation, which `TauCeti.not_forall_map_spinRep_spinPlus_le` and
 `TauCeti.not_forall_map_spinRep_spinMinus_le` record: neither half is `⊥` or everything, so
@@ -113,12 +113,14 @@ central summands, for which the results here are the even-dimensional half; it i
 * `TauCeti.isIrreducible_spinRep_of_span_of_surjective`: the spin representation is irreducible
   once the Spin group spans the even subalgebra and that subalgebra exhausts the endomorphisms of
   the spinor module.
-* `TauCeti.isIrreducible_spinRep_of_isSquare` and `TauCeti.isIrreducible_spinRep`: **the spin
-  representation is irreducible in odd dimension**, the type `Bₗ` half of Layer 4, under the square
-  normalization and over a separably closed field respectively.
-* `TauCeti.not_forall_map_spinRep_spinPlus_le` and
-  `TauCeti.not_forall_map_spinRep_spinMinus_le`: **in odd dimension the spinor module does not
-  split along exterior parity**, provided `P.W ≠ ⊥`, which rules out only dimension one.
+* `TauCeti.isIrreducible_spinRep_of_isSquare` and `TauCeti.spinRep_isIrreducible_of_odd`: **the
+  spin representation is irreducible in odd dimension**, the type `Bₗ` half of Layer 4, under the
+  square normalization and over a separably closed field respectively.
+* `TauCeti.not_forall_map_spinRep_spinPlus_le_of_isIrreducible` and
+  `TauCeti.not_forall_map_spinRep_spinMinus_le_of_isIrreducible`: **an irreducible spinor module
+  does not split along exterior parity**, provided `P.W ≠ ⊥`, which rules out only dimension one;
+  `TauCeti.not_forall_map_spinRep_spinPlus_le` and
+  `TauCeti.not_forall_map_spinRep_spinMinus_le` are their odd-dimensional specializations.
 
 ## References
 
@@ -572,6 +574,34 @@ private theorem not_forall_map_spinRep_le (hirr : (spinRep Q P).IsIrreducible)
   · exact hbot (congrArg Subrepresentation.toSubmodule h)
   · exact htop (congrArg Subrepresentation.toSubmodule h)
 
+/-- **An irreducible spinor module does not split along exterior parity.** The even part `S⁺` is
+not invariant under the Spin group, so it is not a subrepresentation of `spinRep`.
+
+Nothing about the anisotropic remainder is computed: the proof is by irreducibility, `S⁺` being
+neither `⊥` (it contains the scalars) nor everything (it misses the nonzero `S⁻`). The hypothesis
+`P.W ≠ ⊥` is what excludes `finrank K V = 1`, where `S = K` is entirely even, `S⁺ = S` is trivially
+invariant and there is nothing to split. In even dimension the same subspace *is* invariant, by
+`TauCeti.spinPlus_invariant`, and `spinRep` is correspondingly reducible. -/
+theorem not_forall_map_spinRep_spinPlus_le_of_isIrreducible (hirr : (spinRep Q P).IsIrreducible)
+    (hW : P.W ≠ ⊥) :
+    ¬ ∀ g : spinGroup Q, (spinPlus Q P).map (spinRep Q P g) ≤ spinPlus Q P :=
+  not_forall_map_spinRep_le P hirr
+    (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinPlus P))
+    ((isCompl_spinPlus_spinMinus P).symm.disjoint.ne_top_of_ne_bot
+      (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinMinus P hW)))
+
+/-- **The odd half of an irreducible spinor module is not invariant either.** The companion of
+`TauCeti.not_forall_map_spinRep_spinPlus_le_of_isIrreducible` for the other parity: `S⁻` is nonzero
+when `P.W ≠ ⊥` and is not everything, `S⁺` containing the scalars, so irreducibility forbids it
+from being a subrepresentation of `spinRep`. -/
+theorem not_forall_map_spinRep_spinMinus_le_of_isIrreducible (hirr : (spinRep Q P).IsIrreducible)
+    (hW : P.W ≠ ⊥) :
+    ¬ ∀ g : spinGroup Q, (spinMinus Q P).map (spinRep Q P g) ≤ spinMinus Q P :=
+  not_forall_map_spinRep_le P hirr
+    (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinMinus P hW))
+    ((isCompl_spinPlus_spinMinus P).disjoint.ne_top_of_ne_bot
+      (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinPlus P)))
+
 variable [NeZero (2 : K)] [FiniteDimensional K V]
 
 /-- **The spin representation is irreducible in odd dimension** when anisotropic pairs admit the
@@ -594,46 +624,37 @@ theorem isIrreducible_spinRep_of_isSquare
 variable [IsSepClosed K]
 
 /-- **The spin representation is irreducible in odd dimension.** For a polarized quadratic space of
-odd dimension over a separably closed field of characteristic not two, the Spin group acts
+dimension `2 * l + 1` over a separably closed field of characteristic not two, the Spin group acts
 irreducibly on the whole spinor module `S = ⋀·W`.
 
-This is the type `Bₗ` half of the Layer-4 irreducibility statement. Except in dimension one, where
-`W = ⊥` and `S = K` is entirely even, the exterior parity splitting `S = S⁺ ⊕ S⁻` is *not* a
-splitting of representations here: see `TauCeti.not_forall_map_spinRep_spinPlus_le`. The
-even-dimensional counterpart is the pair `TauCeti.isIrreducible_spinPlusSubrep`,
-`TauCeti.isIrreducible_spinMinusSubrep`, where `S` itself is reducible unless it is the
-zero-dimensional quadratic space. -/
-theorem isIrreducible_spinRep (hodd : Odd (finrank K V)) : (spinRep Q P).IsIrreducible :=
+This is the type `Bₗ` half of the Layer-4 irreducibility statement, in the shape the roadmap pins.
+Nondegeneracy of `Q` is not assumed: the polarization data already carries it, by
+`TauCeti.SpinPolarizationData.nondegenerate`. Except in dimension one, where `W = ⊥` and `S = K` is
+entirely even, the exterior parity splitting `S = S⁺ ⊕ S⁻` is *not* a splitting of representations
+here: see `TauCeti.not_forall_map_spinRep_spinPlus_le`. The even-dimensional counterpart is the
+pair `TauCeti.isIrreducible_spinPlusSubrep`, `TauCeti.isIrreducible_spinMinusSubrep`, where `S`
+itself is reducible unless it is the zero-dimensional quadratic space. -/
+theorem spinRep_isIrreducible_of_odd (l : ℕ) (hV : finrank K V = 2 * l + 1) :
+    (spinRep Q P).IsIrreducible :=
   isIrreducible_spinRep_of_isSquare P
-    (fun v w _ _ ↦ IsSepClosed.exists_eq_mul_self ((Q v)⁻¹ * (Q w)⁻¹)) hodd
+    (fun v w _ _ ↦ IsSepClosed.exists_eq_mul_self ((Q v)⁻¹ * (Q w)⁻¹)) ⟨l, hV⟩
 
-/-- **In odd dimension the spinor module does not split along exterior parity.** The even part
-`S⁺` is not invariant under the Spin group, so — unlike in positive even dimension — it is not a
-subrepresentation of `spinRep`.
-
-Nothing about the anisotropic remainder is computed: the proof is by irreducibility, `S⁺` being
-neither `⊥` (it contains the scalars) nor everything (it misses the nonzero `S⁻`). The hypothesis
-`P.W ≠ ⊥` is what excludes `finrank V = 1`, where `S = K` is entirely even, `S⁺ = S` is trivially
-invariant and there is nothing to split. In even dimension the same subspace *is* invariant, by
-`TauCeti.spinPlus_invariant`, whose hypothesis `P.line = ⊥` is what an odd-dimensional
-polarization cannot satisfy. -/
-theorem not_forall_map_spinRep_spinPlus_le (hodd : Odd (finrank K V)) (hW : P.W ≠ ⊥) :
+/-- **In odd dimension the spinor module does not split along exterior parity.** The
+separably closed specialization of
+`TauCeti.not_forall_map_spinRep_spinPlus_le_of_isIrreducible`, where
+`TauCeti.spinRep_isIrreducible_of_odd` supplies the irreducibility. Unlike in positive even
+dimension, `S⁺` is not a subrepresentation of `spinRep`; the hypothesis `P.line = ⊥` carried by
+`TauCeti.spinPlus_invariant` is what an odd-dimensional polarization cannot satisfy. -/
+theorem not_forall_map_spinRep_spinPlus_le (l : ℕ) (hV : finrank K V = 2 * l + 1) (hW : P.W ≠ ⊥) :
     ¬ ∀ g : spinGroup Q, (spinPlus Q P).map (spinRep Q P g) ≤ spinPlus Q P :=
-  not_forall_map_spinRep_le P (isIrreducible_spinRep P hodd)
-    (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinPlus P))
-    ((isCompl_spinPlus_spinMinus P).symm.disjoint.ne_top_of_ne_bot
-      (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinMinus P hW)))
+  not_forall_map_spinRep_spinPlus_le_of_isIrreducible P (spinRep_isIrreducible_of_odd P l hV) hW
 
 /-- **In odd dimension the odd half of the spinor module is not invariant either.** The companion
-of `TauCeti.not_forall_map_spinRep_spinPlus_le` for the other parity: `S⁻` is nonzero when
-`P.W ≠ ⊥` and is not everything, `S⁺` containing the scalars, so irreducibility forbids it from
-being a subrepresentation of `spinRep`. -/
-theorem not_forall_map_spinRep_spinMinus_le (hodd : Odd (finrank K V)) (hW : P.W ≠ ⊥) :
+of `TauCeti.not_forall_map_spinRep_spinPlus_le` for the other parity, the separably closed
+specialization of `TauCeti.not_forall_map_spinRep_spinMinus_le_of_isIrreducible`. -/
+theorem not_forall_map_spinRep_spinMinus_le (l : ℕ) (hV : finrank K V = 2 * l + 1) (hW : P.W ≠ ⊥) :
     ¬ ∀ g : spinGroup Q, (spinMinus Q P).map (spinRep Q P g) ≤ spinMinus Q P :=
-  not_forall_map_spinRep_le P (isIrreducible_spinRep P hodd)
-    (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinMinus P hW))
-    ((isCompl_spinPlus_spinMinus P).disjoint.ne_top_of_ne_bot
-      (Submodule.nontrivial_iff_ne_bot.1 (nontrivial_spinPlus P)))
+  not_forall_map_spinRep_spinMinus_le_of_isIrreducible P (spinRep_isIrreducible_of_odd P l hV) hW
 
 end Odd
 

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.RepresentationTheory.Spin.Structure
+public import TauCeti.RepresentationTheory.Spin.OddStructure
 public import TauCeti.RepresentationTheory.Irreducible
 -- Private: `IsSimpleModule.toSpanSingleton_surjective` is used only inside proofs.
 import Mathlib.RingTheory.SimpleModule.Basic
@@ -65,8 +65,23 @@ theorem is stated with, so no separate parity hypothesis is carried. The lattice
 only the zero-dimensional quadratic space: there `S = K` is entirely even and `S⁻` is zero. `S⁺`
 always contains the scalars, so it needs no such hypothesis, and neither does the inequivalence.
 
+The odd-dimensional case is the opposite of all this, and the last section records it. There the
+even subalgebra is a *single* matrix algebra rather than a product, so the Fock action already
+carries it onto all of `Module.End K S` (`TauCeti.evenSpinAction_surjective`), and the whole
+spinor module — not a half of it — is the irreducible object:
+`TauCeti.isIrreducible_spinRep`. Exterior parity still splits `S` as a vector space, but no
+longer as a representation, which `TauCeti.not_forall_map_spinRep_spinPlus_le` records: `S⁺` is a
+subspace that is neither `⊥` nor everything, so irreducibility alone forbids it from being
+invariant. The `P.line = ⊥` carried by every statement of the even-dimensional half is precisely
+what fails.
+
+The two parities are separated by exactly one hypothesis, the surjectivity of
+`TauCeti.evenSpinAction`, and `TauCeti.isIrreducible_spinRep_of_span_of_surjective` is stated
+against it rather than against a dimension, so the dichotomy is visible in the statement.
+
 What is not proved here is the odd-dimensional splitting of `CliffordAlgebra Q` into its two
-central summands, for which the results here are the even-dimensional half.
+central summands, for which the results here are the even-dimensional half; it is
+`CliffordAlgebra.nonempty_algEquiv_matrix_prod_of_finrank_eq_two_mul_add_one`.
 
 ## Main results
 
@@ -91,13 +106,23 @@ central summands, for which the results here are the even-dimensional half.
 * `TauCeti.isEmpty_equiv_spinPlusSubrep_spinMinusSubrep_of_span`: **the two half-spin group
   representations are inequivalent** under the same spanning hypothesis, with analogous
   corollaries.
+* `TauCeti.isIrreducible_spinRep_of_span_of_surjective`: the spin representation is irreducible
+  once the Spin group spans the even subalgebra and that subalgebra exhausts the endomorphisms of
+  the spinor module.
+* `TauCeti.isIrreducible_spinRep`: **the spin representation is irreducible in odd dimension**,
+  the type `Bₗ` half of Layer 4.
+* `TauCeti.not_forall_map_spinRep_spinPlus_le`: **in odd dimension the spinor module does not
+  split along exterior parity.**
 
 ## References
 
 * W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), §20.1, Lemma 20.9 and
   Proposition 20.15: the Clifford algebra of an even-dimensional space is the endomorphism algebra
   of `⋀·W`, its even subalgebra is the product of the endomorphism algebras of the two halves, and
-  the two half-spin modules are irreducible and inequivalent.
+  the two half-spin modules are irreducible and inequivalent; §20.2 for the odd-dimensional spin
+  representation, which does not split.
+* H. B. Lawson and M.-L. Michelsohn, *Spin Geometry*, Princeton University Press (1989),
+  Chapter I, §5: the complex spinor representations and their irreducibility in both parities.
 * C. Chevalley, *The Algebraic Theory of Spinors* (1954), Chapter II.
 * [Spin-representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
   Layers 1 and 4, "the structure theorem" and "the spin and half-spin representations".
@@ -466,5 +491,84 @@ theorem isEmpty_equiv_spinPlusSubrep_spinMinusSubrep [IsSepClosed K]
     (fun v w _ _ ↦ IsSepClosed.exists_eq_mul_self ((Q v)⁻¹ * (Q w)⁻¹)) hline
 
 end SpinGroup
+
+/-! ### Irreducibility of the spin representation in odd dimension -/
+
+section Odd
+
+variable {K : Type u} [Field K]
+  {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
+  (P : SpinPolarizationData Q)
+
+/-- **The whole spin representation is irreducible** as soon as the Spin group linearly spans the
+even Clifford subalgebra and that subalgebra already exhausts the endomorphisms of the spinor
+module.
+
+The second hypothesis is exactly what separates the two parities of `finrank K V`. In even
+dimension it fails — the even subalgebra is the *product* of the two half-spin endomorphism
+algebras, by `TauCeti.SpinPolarizationData.evenCliffordEquivProdEnd`, and `S` visibly splits — and
+in odd dimension it holds, by `TauCeti.evenSpinAction_surjective`. -/
+theorem isIrreducible_spinRep_of_span_of_surjective
+    (hspan : Submodule.span K (spinGroup Q : Set (CliffordAlgebra Q)) =
+      (CliffordAlgebra.even Q).toSubmodule)
+    (hsurj : Function.Surjective (evenSpinAction Q P)) : (spinRep Q P).IsIrreducible := by
+  have hEq : spinGroupRepresentation (evenSpinAction Q P) = spinRep Q P := by
+    refine DFunLike.ext _ _ fun g => ?_
+    have hg : spinGroupRepresentation (evenSpinAction Q P) g
+        = evenSpinAction Q P (spinGroupToEven g) := rfl
+    rw [hg, evenSpinAction_apply, spinRep_apply]
+    rfl
+  exact hEq ▸ isIrreducible_spinGroupRepresentation hspan (evenSpinAction Q P) hsurj
+
+variable [NeZero (2 : K)] [IsSepClosed K] [FiniteDimensional K V]
+
+/-- **The spin representation is irreducible in odd dimension.** For a nondegenerate quadratic
+form on a space of dimension `2 * l + 1` over a separably closed field of characteristic not two,
+the Spin group acts irreducibly on the whole spinor module `S = ⋀·W`, of dimension `2 ^ l`.
+
+This is the type `Bₗ` half of the Layer-4 irreducibility statement, and the exterior parity
+splitting `S = S⁺ ⊕ S⁻` is *not* a splitting of representations here: see
+`TauCeti.not_forall_map_spinRep_spinPlus_le`. The even-dimensional counterpart is the pair
+`TauCeti.isIrreducible_spinPlusSubrep`, `TauCeti.isIrreducible_spinMinusSubrep`, where `S` itself
+is reducible. -/
+theorem isIrreducible_spinRep {l : ℕ} (hQ : Q.Nondegenerate) (hV : finrank K V = 2 * l + 1) :
+    (spinRep Q P).IsIrreducible :=
+  isIrreducible_spinRep_of_span_of_surjective P
+    (CliffordAlgebra.span_spinGroup_eq_even Q hQ) (evenSpinAction_surjective P hQ hV)
+
+/-- **In odd dimension the spinor module does not split along exterior parity.** The even part
+`S⁺` is not invariant under the Spin group, so — unlike in even dimension — it is not a
+subrepresentation of `spinRep`.
+
+Nothing about the anisotropic remainder is computed: the proof is by irreducibility, `S⁺` being
+neither `⊥` (it contains the scalars) nor everything (it misses the nonzero `S⁻`). The hypothesis
+`P.W ≠ ⊥` rules out only `finrank V = 1`, where `S = K` is entirely even and there is nothing to
+split. In even dimension the same subspace *is* invariant, by `TauCeti.spinPlus_invariant`, whose
+hypothesis `P.line = ⊥` is what an odd-dimensional polarization cannot satisfy. -/
+theorem not_forall_map_spinRep_spinPlus_le {l : ℕ} (hQ : Q.Nondegenerate)
+    (hV : finrank K V = 2 * l + 1) (hW : P.W ≠ ⊥) :
+    ¬ ∀ g : spinGroup Q, (spinPlus Q P).map (spinRep Q P g) ≤ spinPlus Q P := by
+  intro hinv
+  have _ : (spinRep Q P).IsIrreducible := isIrreducible_spinRep P hQ hV
+  -- The invariance makes `S⁺` a subrepresentation, so it is `⊥` or everything.
+  let σ : Subrepresentation (spinRep Q P) :=
+    { toSubmodule := spinPlus Q P
+      apply_mem_toSubmodule := fun g _ hv => hinv g ⟨_, hv, rfl⟩ }
+  have hσ : σ = ⊥ ∨ σ = ⊤ := IsSimpleOrder.eq_bot_or_eq_top σ
+  have hbot : spinPlus Q P ≠ ⊥ := by
+    have := nontrivial_spinPlus P
+    exact fun h => not_nontrivial_iff_subsingleton.2 (h ▸ inferInstance) this
+  have htop : spinPlus Q P ≠ ⊤ := by
+    have hne := nontrivial_spinMinus P hW
+    intro h
+    have : spinMinus Q P = ⊥ := by
+      have := spinPlus_inf_spinMinus (Q := Q) (P := P)
+      rwa [h, top_inf_eq] at this
+    exact not_nontrivial_iff_subsingleton.2 (this ▸ inferInstance) hne
+  rcases hσ with h | h
+  · exact hbot (congrArg Subrepresentation.toSubmodule h)
+  · exact htop (congrArg Subrepresentation.toSubmodule h)
+
+end Odd
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Spin/Irreducible.lean
@@ -184,6 +184,17 @@ private noncomputable def spinGroupAlgebraHom {K : Type u} [Field K]
     MonoidAlgebra K (spinGroup Q) →ₐ[K] CliffordAlgebra.even Q :=
   MonoidAlgebra.lift K (CliffordAlgebra.even Q) (spinGroup Q) (spinGroupToEven Q)
 
+/-- The range of the Spin-group inclusion, with its values spelled out as the subtype elements
+`⟨g, _⟩` that `Submodule.span_range_subtype_eq_top_iff` consumes. As for
+`TauCeti.spinGroupRepresentation_apply_mk`, only the coercion lemma
+`TauCeti.coe_spinGroupToEven_apply` is used, not the definition of the inclusion. -/
+private theorem range_spinGroupToEven {K : Type u} [Field K]
+    {V : Type v} [AddCommGroup V] [Module K V] (Q : QuadraticForm K V) :
+    Set.range ⇑(spinGroupToEven Q) =
+      Set.range fun g : spinGroup Q ↦
+        (⟨g, spinGroup.mem_even g.2⟩ : CliffordAlgebra.even Q) :=
+  congrArg Set.range (funext fun g ↦ Subtype.ext (coe_spinGroupToEven_apply Q g))
+
 private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
     {V : Type v} [AddCommGroup V] [Module K V]
     {Q : QuadraticForm K V}
@@ -200,10 +211,7 @@ private theorem spinGroupAlgebraHom_surjective {K : Type u} [Field K]
     simp [spinGroupAlgebraHom]]
   rw [LinearMap.range_comp_of_range_eq_top _ (LinearEquiv.range _),
     Finsupp.range_linearCombination]
-  rw [show Set.range ⇑(spinGroupToEven Q) =
-      Set.range fun g : spinGroup Q ↦
-        (⟨g, spinGroup.mem_even g.2⟩ : CliffordAlgebra.even Q) from
-    congrArg Set.range (funext fun g ↦ Subtype.ext (coe_spinGroupToEven_apply Q g))]
+  rw [range_spinGroupToEven]
   apply (Submodule.span_range_subtype_eq_top_iff
     (CliffordAlgebra.even Q).toSubmodule
       (fun g : spinGroup Q ↦ spinGroup.mem_even g.2)).2

--- a/TauCeti/RepresentationTheory/Spin/OddStructure.lean
+++ b/TauCeti/RepresentationTheory/Spin/OddStructure.lean
@@ -7,11 +7,14 @@ module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.OddSplitting
 public import TauCeti.RepresentationTheory.Spin.Structure
--- Non-public: the coordinate surjection out of a product, the simplicity of a matrix algebra, and
--- the finite-dimensional injectivity criterion are all used only inside proofs.
+-- Non-public: the coordinate surjection out of a product, the simplicity of a matrix algebra, the
+-- finite-dimensional injectivity criterion, the anisotropic orthogonal basis carrying the volume
+-- element and the centrality of an endomorphism algebra are all used only inside proofs.
 import TauCeti.RingTheory.CentralIdempotent
+import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalBasis
 import Mathlib.RingTheory.SimpleRing.Matrix
 import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+import Mathlib.Algebra.Central.End
 
 /-!
 # The structure theorem for an odd-dimensional Clifford algebra
@@ -50,12 +53,15 @@ and of a basis of the spinor module — so the statements are `Nonempty`, as the
 Once a polarization *is* fixed there is a canonical isomorphism to be had, and the last section
 records it. Only the basis of the spinor module was arbitrary above, so dropping it leaves the
 Fock action itself: `TauCeti.evenSpinAction` is a bijection from `even Q` onto
-`Module.End F (⋀·W)`, because the even subalgebra is simple (being a matrix algebra), so any
-nonzero action of it is faithful, and the two algebras have the same dimension. That statement,
-`TauCeti.SpinPolarizationData.evenCliffordEquivEnd`, is the odd-dimensional companion of the even
-`TauCeti.SpinPolarizationData.cliffordEquivEnd`, one grade down: in even dimension the *whole*
-Clifford algebra is `Module.End F (⋀·W)`, in odd dimension only its even half is, the whole
-algebra being two copies of that half.
+`Module.End F (⋀·W)`. That needs neither the matrix identification nor a separably closed field.
+The whole Fock action is onto (`TauCeti.spinAction_surjective`), and in odd dimension the even
+half already reaches as far: the volume element `ω` is central, so its image commutes with all of
+`Module.End F (⋀·W)` and is a scalar, and `ω` is odd with `ω² = c ≠ 0`, so each generator is
+`ι v = c⁻¹ (ι v * ω) * ω` with `ι v * ω` even. A dimension count then makes the surjection
+injective. That statement, `TauCeti.SpinPolarizationData.evenCliffordEquivEnd`, is the
+odd-dimensional companion of the even `TauCeti.SpinPolarizationData.cliffordEquivEnd`, one grade
+down: in even dimension the *whole* Clifford algebra is `Module.End F (⋀·W)`, in odd dimension
+only its even half is, the whole algebra being two copies of that half.
 
 ## Main results
 
@@ -65,9 +71,9 @@ algebra being two copies of that half.
   theorem in odd dimension**, `CliffordAlgebra Q ≃ₐ[F] M_{2^l}(F) × M_{2^l}(F)`.
 * `CliffordAlgebra.isSimpleRing_even_of_odd_finrank`: **the even subalgebra is a simple ring** in
   odd dimension, unlike the whole algebra.
-* `TauCeti.evenSpinAction_bijective` and `TauCeti.SpinPolarizationData.evenCliffordEquivEnd`:
+* `TauCeti.evenSpinAction_surjective` and `TauCeti.SpinPolarizationData.evenCliffordEquivEnd`:
   **the odd structure theorem in operator form**, that the Fock action identifies `even Q` with
-  `Module.End F (⋀·W)`.
+  `Module.End F (⋀·W)`, over any field of characteristic not two.
 * `TauCeti.SpinPolarizationData.finrank_exteriorAlgebra_W_of_finrank_eq_two_mul_add_one` and
   `TauCeti.SpinPolarizationData.finrank_even_eq_finrank_end_of_odd_finrank`: the dimension
   bookkeeping the operator form rests on.
@@ -212,8 +218,10 @@ end CliffordAlgebra
 /-! ### The odd structure theorem in operator form
 
 The matrix identification above is not canonical: it depends on a basis of the spinor module. The
-Fock action itself is canonical once a polarization is chosen, and the counting above says exactly
-that it identifies the even subalgebra with the operator algebra of the spinor module. -/
+Fock action itself is canonical once a polarization is chosen, and it identifies the even
+subalgebra with the operator algebra of the spinor module directly, over any field of
+characteristic not two: the polarization data carries the nondegeneracy, and the volume element
+does the rest without being normalized to a square root of one. -/
 
 namespace TauCeti
 
@@ -221,55 +229,99 @@ open CliffordAlgebra Module
 
 section OperatorForm
 
-variable {F : Type u} [Field F] [NeZero (2 : F)] [IsSepClosed F]
+variable {F : Type u} [Field F] [NeZero (2 : F)]
   {V : Type v} [AddCommGroup V] [Module F V] [FiniteDimensional F V] {Q : QuadraticForm F V}
-  (P : SpinPolarizationData Q) (hQ : Q.Nondegenerate) (hodd : Odd (finrank F V))
+  (P : SpinPolarizationData Q) (hodd : Odd (finrank F V))
 
-include hQ hodd
+include hodd
 
-/-- **The even Clifford action on the spinor module is faithful in odd dimension.** The even
-subalgebra is simple, and an algebra homomorphism out of a simple ring into a nonzero ring is
-injective. -/
-theorem evenSpinAction_injective : Function.Injective (evenSpinAction Q P) := by
-  have _ : Invertible (2 : F) := invertibleOfNonzero (NeZero.ne (2 : F))
-  have _ : IsSimpleRing ↥(even Q) :=
-    CliffordAlgebra.isSimpleRing_even_of_odd_finrank hQ hodd
-  exact RingHom.injective (evenSpinAction Q P).toRingHom
-
-/-- **The even Clifford action on the spinor module is onto in odd dimension.** It is injective,
-and the two algebras have the same dimension.
+/-- **The even Clifford action on the spinor module is onto in odd dimension.** The whole Fock
+action is onto by `TauCeti.spinAction_surjective`, and in odd dimension the even half already
+reaches everything the odd half does: the volume element `ω` of an orthogonal basis is central,
+odd, and squares to a nonzero scalar, so its image is a scalar operator, and every generator
+factors as `ι v = c⁻¹ (ι v * ω) * ω` with `ι v * ω` even.
 
 This is the sharp form of the odd-dimensional structure theorem: unlike the whole Clifford
 algebra, which needs both spinor modules to act faithfully, the even subalgebra already sees all
-of `Module.End F (⋀·W)`. -/
+of `Module.End F (⋀·W)`. Neither nondegeneracy nor a separably closed field is assumed: the
+polarization data carries the first (`TauCeti.SpinPolarizationData.nondegenerate`) and the
+argument never normalizes `ω`, which is what the second was for. -/
 theorem evenSpinAction_surjective : Function.Surjective (evenSpinAction Q P) := by
+  have _ : Invertible (2 : F) := invertibleOfNonzero (NeZero.ne (2 : F))
+  obtain ⟨l, hl, hlen, hspan, hQl⟩ := P.nondegenerate.exists_list_pairwise_isOrtho
+  set ω : CliffordAlgebra Q := (l.map (ι Q)).prod
+  set c : F := (-1 : F) ^ l.length.choose 2 * (l.map Q).prod
+  have hc : c ≠ 0 := by
+    refine mul_ne_zero (pow_ne_zero _ (neg_ne_zero.mpr one_ne_zero)) (List.prod_ne_zero ?_)
+    rintro hmem
+    obtain ⟨v, hv, hv0⟩ := List.mem_map.mp hmem
+    exact hQl v hv hv0
+  have hsq : ω * ω = algebraMap F (CliffordAlgebra Q) c := prod_map_ι_sq_scalar hl
+  have hωodd : ω ∈ evenOdd Q 1 := prod_map_ι_mem_evenOdd_one_of_odd_length (hlen ▸ hodd)
+  -- The image of the volume element is central, hence a scalar, hence already in the range.
+  have hωrange : spinAction Q P ω ∈ (evenSpinAction Q P).range := by
+    have hcentre : spinAction Q P ω ∈
+        Subalgebra.center F (Module.End F (ExteriorAlgebra F P.W)) := by
+      rw [Subalgebra.mem_center_iff]
+      intro f
+      obtain ⟨x, rfl⟩ := spinAction_surjective P f
+      rw [← map_mul, ← map_mul, Subalgebra.mem_center_iff.1
+        (prod_map_ι_mem_center_of_odd_length hl (hlen ▸ hodd) hspan) x]
+    obtain ⟨a, ha⟩ := (Algebra.IsCentral.mem_center_iff F).1 hcentre
+    exact ha ▸ Subalgebra.algebraMap_mem _ a
+  -- Each generator is an even element times the volume element, up to the scalar `c`.
+  have hgen : ∀ v : V, spinAction Q P (ι Q v) ∈ (evenSpinAction Q P).range := by
+    intro v
+    have hmem : ι Q v * ω ∈ even Q := by
+      rw [← Subalgebra.mem_toSubmodule, even_toSubmodule]
+      have h := SetLike.mul_mem_graded (ι_mem_evenOdd_one Q v) hωodd
+      rwa [show (1 : ZMod 2) + 1 = 0 by decide] at h
+    have hrw : spinAction Q P (ι Q v * ω) * (c⁻¹ • spinAction Q P ω) = spinAction Q P (ι Q v) := by
+      rw [mul_smul_comm, ← map_mul, mul_assoc, hsq, ← Algebra.commutes, ← Algebra.smul_def,
+        map_smul, smul_smul, inv_mul_cancel₀ hc, one_smul]
+    exact hrw ▸ Subalgebra.mul_mem _
+      ((AlgHom.mem_range _).2 ⟨⟨_, hmem⟩, evenSpinAction_apply Q P _⟩)
+      (Subalgebra.smul_mem _ hωrange _)
+  -- The generators generate, so the range of the even action is everything.
+  have hle : Algebra.adjoin F (Set.range (ι Q)) ≤
+      Subalgebra.comap (spinAction Q P) (evenSpinAction Q P).range :=
+    Algebra.adjoin_le (by rintro _ ⟨v, rfl⟩; exact hgen v)
+  intro f
+  obtain ⟨x, rfl⟩ := spinAction_surjective P f
+  exact (AlgHom.mem_range _).1 (hle ((adjoin_range_ι (Q := Q)).ge Algebra.mem_top))
+
+/-- **The even Clifford action on the spinor module is faithful in odd dimension.** It is onto an
+algebra of the same dimension, so it is injective. -/
+theorem evenSpinAction_injective : Function.Injective (evenSpinAction Q P) := by
   have _ : Invertible (2 : F) := invertibleOfNonzero (NeZero.ne (2 : F))
   exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
     (f := (evenSpinAction Q P).toLinearMap)
-    (P.finrank_even_eq_finrank_end_of_odd_finrank hodd)).1
-    (evenSpinAction_injective P hQ hodd)
+    (P.finrank_even_eq_finrank_end_of_odd_finrank hodd)).2
+    (evenSpinAction_surjective P hodd)
 
 /-- **The even Clifford action on the spinor module is bijective in odd dimension**, the
-odd-dimensional counterpart of `TauCeti.spinAction_bijective`. -/
-theorem evenSpinAction_bijective : Function.Bijective (evenSpinAction Q P) :=
-  ⟨evenSpinAction_injective P hQ hodd, evenSpinAction_surjective P hQ hodd⟩
+odd-dimensional counterpart of `TauCeti.spinAction_bijective`. Kept private: it exists so that the
+bijectivity fed to `AlgEquiv.ofBijective` below carries the stated type, which is what lets the
+application lemma rewrite through it. -/
+private theorem evenSpinAction_bijective : Function.Bijective (evenSpinAction Q P) :=
+  ⟨evenSpinAction_injective P hodd, evenSpinAction_surjective P hodd⟩
 
 /-- **The odd structure theorem in operator form**: for a polarized quadratic space of odd
-dimension over a separably closed field of characteristic not two, the Fock action is an
-isomorphism of `F`-algebras from the even Clifford subalgebra onto the endomorphism algebra of the
-spinor module `S = ⋀·W`.
+dimension over a field of characteristic not two, the Fock action is an isomorphism of
+`F`-algebras from the even Clifford subalgebra onto the endomorphism algebra of the spinor module
+`S = ⋀·W`.
 
 This is the odd-dimensional companion of
 `TauCeti.SpinPolarizationData.cliffordEquivEnd`, one grade down: there the *whole* algebra is
 `Module.End F S`, here only its even half is, the whole algebra being two copies of it. -/
 noncomputable def SpinPolarizationData.evenCliffordEquivEnd :
     ↥(even Q) ≃ₐ[F] Module.End F (ExteriorAlgebra F P.W) :=
-  AlgEquiv.ofBijective (evenSpinAction Q P) (evenSpinAction_bijective P hQ hodd)
+  AlgEquiv.ofBijective (evenSpinAction Q P) (evenSpinAction_bijective P hodd)
 
 /-- The operator form of the odd structure theorem is the Fock action itself. -/
 @[simp]
 theorem SpinPolarizationData.evenCliffordEquivEnd_apply (x : ↥(even Q)) :
-    P.evenCliffordEquivEnd hQ hodd x = spinAction Q P x := by
+    P.evenCliffordEquivEnd hodd x = spinAction Q P x := by
   rw [SpinPolarizationData.evenCliffordEquivEnd, AlgEquiv.ofBijective_apply, evenSpinAction_apply]
 
 end OperatorForm

--- a/TauCeti/RepresentationTheory/Spin/OddStructure.lean
+++ b/TauCeti/RepresentationTheory/Spin/OddStructure.lean
@@ -63,14 +63,14 @@ algebra being two copies of that half.
   subalgebra is a matrix algebra** `M_{2^l}(F)` in dimension `2 * l + 1`.
 * `CliffordAlgebra.nonempty_algEquiv_matrix_prod_of_finrank_eq_two_mul_add_one`: **the structure
   theorem in odd dimension**, `CliffordAlgebra Q ≃ₐ[F] M_{2^l}(F) × M_{2^l}(F)`.
-* `CliffordAlgebra.isSimpleRing_even_of_finrank_eq_two_mul_add_one`: **the even subalgebra is a
-  simple ring** in odd dimension, unlike the whole algebra.
+* `CliffordAlgebra.isSimpleRing_even_of_odd_finrank`: **the even subalgebra is a simple ring** in
+  odd dimension, unlike the whole algebra.
 * `TauCeti.evenSpinAction_bijective` and `TauCeti.SpinPolarizationData.evenCliffordEquivEnd`:
   **the odd structure theorem in operator form**, that the Fock action identifies `even Q` with
   `Module.End F (⋀·W)`.
 * `TauCeti.SpinPolarizationData.finrank_exteriorAlgebra_W_of_finrank_eq_two_mul_add_one` and
-  `TauCeti.SpinPolarizationData.finrank_even_eq_finrank_end_of_finrank_eq_two_mul_add_one`: the
-  dimension bookkeeping the operator form rests on.
+  `TauCeti.SpinPolarizationData.finrank_even_eq_finrank_end_of_odd_finrank`: the dimension
+  bookkeeping the operator form rests on.
 
 ## References
 
@@ -106,16 +106,18 @@ theorem finrank_exteriorAlgebra_W_of_finrank_eq_two_mul_add_one {l : ℕ}
   rw [TauCeti.ExteriorAlgebra.finrank_eq_two_pow, P.finrank_W_of_finrank_eq_two_mul_add_one hV]
 
 /-- **The even Clifford subalgebra and the operator algebra of the spinor module have equal
-dimension** in odd dimension: `2 ^ (2 * l + 1 - 1)` on the left, `(2 ^ l) ^ 2` on the right.
+dimension** in odd dimension: writing `finrank F V = 2 * l + 1`, that is `2 ^ (2 * l + 1 - 1)` on
+the left and `(2 ^ l) ^ 2` on the right.
 
 This is the odd-dimensional analogue of
 `TauCeti.SpinPolarizationData.finrank_cliffordAlgebra_eq_finrank_end`, and the shift of one power
 of two is exactly the difference between the two parities: in even dimension the *whole* Clifford
 algebra matches the operator algebra of `⋀·W`, while in odd dimension only its even half does. -/
-theorem finrank_even_eq_finrank_end_of_finrank_eq_two_mul_add_one [Invertible (2 : F)] {l : ℕ}
-    (hV : finrank F V = 2 * l + 1) :
+theorem finrank_even_eq_finrank_end_of_odd_finrank [Invertible (2 : F)]
+    (hodd : Odd (finrank F V)) :
     finrank F ↥(CliffordAlgebra.even Q) =
       finrank F (Module.End F (ExteriorAlgebra F P.W)) := by
+  obtain ⟨l, hV⟩ := hodd
   have _ : Nontrivial V := Module.nontrivial_of_finrank_pos (R := F) (by rw [hV]; omega)
   have hEnd : finrank F (Module.End F (ExteriorAlgebra F P.W)) =
       finrank F (ExteriorAlgebra F P.W) * finrank F (ExteriorAlgebra F P.W) :=
@@ -198,8 +200,9 @@ over a field are simple.
 The whole algebra is not: in odd dimension it is a product of two matrix algebras, so `(1, 0)` is
 a central idempotent other than `0` and `1`. Simplicity of the even half is what forces every
 nonzero action of it to be faithful, and hence — the dimensions agreeing — onto. -/
-theorem isSimpleRing_even_of_finrank_eq_two_mul_add_one {l : ℕ}
-    (hQ : Q.Nondegenerate) (hV : finrank F V = 2 * l + 1) : IsSimpleRing ↥(even Q) := by
+theorem isSimpleRing_even_of_odd_finrank (hQ : Q.Nondegenerate) (hodd : Odd (finrank F V)) :
+    IsSimpleRing ↥(even Q) := by
+  obtain ⟨l, hV⟩ := hodd
   have _ : Nonempty (Fin (2 ^ l)) := ⟨⟨0, Nat.two_pow_pos l⟩⟩
   obtain ⟨e⟩ := nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one hQ hV
   exact IsSimpleRing.of_ringEquiv e.symm.toRingEquiv inferInstance
@@ -220,9 +223,9 @@ section OperatorForm
 
 variable {F : Type u} [Field F] [NeZero (2 : F)] [IsSepClosed F]
   {V : Type v} [AddCommGroup V] [Module F V] [FiniteDimensional F V] {Q : QuadraticForm F V}
-  (P : SpinPolarizationData Q) {l : ℕ} (hQ : Q.Nondegenerate) (hV : finrank F V = 2 * l + 1)
+  (P : SpinPolarizationData Q) (hQ : Q.Nondegenerate) (hodd : Odd (finrank F V))
 
-include hQ hV
+include hQ hodd
 
 /-- **The even Clifford action on the spinor module is faithful in odd dimension.** The even
 subalgebra is simple, and an algebra homomorphism out of a simple ring into a nonzero ring is
@@ -230,7 +233,7 @@ injective. -/
 theorem evenSpinAction_injective : Function.Injective (evenSpinAction Q P) := by
   have _ : Invertible (2 : F) := invertibleOfNonzero (NeZero.ne (2 : F))
   have _ : IsSimpleRing ↥(even Q) :=
-    CliffordAlgebra.isSimpleRing_even_of_finrank_eq_two_mul_add_one hQ hV
+    CliffordAlgebra.isSimpleRing_even_of_odd_finrank hQ hodd
   exact RingHom.injective (evenSpinAction Q P).toRingHom
 
 /-- **The even Clifford action on the spinor module is onto in odd dimension.** It is injective,
@@ -243,15 +246,16 @@ theorem evenSpinAction_surjective : Function.Surjective (evenSpinAction Q P) := 
   have _ : Invertible (2 : F) := invertibleOfNonzero (NeZero.ne (2 : F))
   exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
     (f := (evenSpinAction Q P).toLinearMap)
-    (P.finrank_even_eq_finrank_end_of_finrank_eq_two_mul_add_one hV)).1
-    (evenSpinAction_injective P hQ hV)
+    (P.finrank_even_eq_finrank_end_of_odd_finrank hodd)).1
+    (evenSpinAction_injective P hQ hodd)
 
-/-- **The even Clifford action on the spinor module is bijective in odd dimension.** -/
+/-- **The even Clifford action on the spinor module is bijective in odd dimension**, the
+odd-dimensional counterpart of `TauCeti.spinAction_bijective`. -/
 theorem evenSpinAction_bijective : Function.Bijective (evenSpinAction Q P) :=
-  ⟨evenSpinAction_injective P hQ hV, evenSpinAction_surjective P hQ hV⟩
+  ⟨evenSpinAction_injective P hQ hodd, evenSpinAction_surjective P hQ hodd⟩
 
-/-- **The odd structure theorem in operator form**: for a polarized quadratic space of dimension
-`2 * l + 1` over a separably closed field of characteristic not two, the Fock action is an
+/-- **The odd structure theorem in operator form**: for a polarized quadratic space of odd
+dimension over a separably closed field of characteristic not two, the Fock action is an
 isomorphism of `F`-algebras from the even Clifford subalgebra onto the endomorphism algebra of the
 spinor module `S = ⋀·W`.
 
@@ -260,16 +264,13 @@ This is the odd-dimensional companion of
 `Module.End F S`, here only its even half is, the whole algebra being two copies of it. -/
 noncomputable def SpinPolarizationData.evenCliffordEquivEnd :
     ↥(even Q) ≃ₐ[F] Module.End F (ExteriorAlgebra F P.W) :=
-  AlgEquiv.ofBijective (evenSpinAction Q P) (evenSpinAction_bijective P hQ hV)
+  AlgEquiv.ofBijective (evenSpinAction Q P) (evenSpinAction_bijective P hQ hodd)
 
 /-- The operator form of the odd structure theorem is the Fock action itself. -/
 @[simp]
 theorem SpinPolarizationData.evenCliffordEquivEnd_apply (x : ↥(even Q)) :
-    P.evenCliffordEquivEnd hQ hV x = spinAction Q P x := by
-  rw [SpinPolarizationData.evenCliffordEquivEnd]
-  exact (congrFun
-    (AlgEquiv.coe_ofBijective (evenSpinAction Q P) (evenSpinAction_bijective P hQ hV)) x).trans
-    (evenSpinAction_apply Q P x)
+    P.evenCliffordEquivEnd hQ hodd x = spinAction Q P x := by
+  rw [SpinPolarizationData.evenCliffordEquivEnd, AlgEquiv.ofBijective_apply, evenSpinAction_apply]
 
 end OperatorForm
 

--- a/TauCeti/RepresentationTheory/Spin/OddStructure.lean
+++ b/TauCeti/RepresentationTheory/Spin/OddStructure.lean
@@ -211,6 +211,16 @@ open CliffordAlgebra Module
 
 section OperatorForm
 
+/-- An element squaring to a nonzero scalar is right-invertible, with `c⁻¹ • ω` as the inverse:
+`x * ω * (c⁻¹ • ω) = x`. This is the algebraic content of the factorization
+`ι v = c⁻¹ (ι v * ω) * ω` by which the volume element pulls an odd generator into the even part. -/
+private theorem mul_mul_inv_smul_self_of_mul_self_eq {F : Type*} [Field F] {A : Type*}
+    [Semiring A] [Algebra F A] {ω : A} {c : F} (hc : c ≠ 0)
+    (hsq : ω * ω = algebraMap F A c) (x : A) : x * ω * (c⁻¹ • ω) = x :=
+  calc x * ω * (c⁻¹ • ω) = c⁻¹ • (x * (ω * ω)) := by rw [mul_smul_comm, mul_assoc]
+    _ = c⁻¹ • c • x := by rw [hsq, ← Algebra.commutes, ← Algebra.smul_def]
+    _ = x := inv_smul_smul₀ hc x
+
 variable {F : Type u} [Field F] [NeZero (2 : F)]
   {V : Type v} [AddCommGroup V] [Module F V] [FiniteDimensional F V] {Q : QuadraticForm F V}
   (P : SpinPolarizationData Q) (hodd : Odd (finrank F V))
@@ -240,6 +250,9 @@ theorem evenSpinAction_surjective : Function.Surjective (evenSpinAction Q P) := 
     obtain ⟨v, hv, hv0⟩ := List.mem_map.mp hmem
     exact hQl v hv hv0
   have hsq : ω * ω = algebraMap F (CliffordAlgebra Q) c := prod_map_ι_sq_scalar hl
+  have hsqEnd : spinAction Q P ω * spinAction Q P ω =
+      algebraMap F (Module.End F (ExteriorAlgebra F P.W)) c := by
+    rw [← map_mul, hsq, AlgHom.commutes]
   have hωodd : ω ∈ evenOdd Q 1 := prod_map_ι_mem_evenOdd_one_of_odd_length (hlen ▸ hodd)
   -- The image of the volume element is central, hence a scalar, hence already in the range.
   have hωrange : spinAction Q P ω ∈ (evenSpinAction Q P).range := by
@@ -260,8 +273,8 @@ theorem evenSpinAction_surjective : Function.Surjective (evenSpinAction Q P) := 
       have h := SetLike.mul_mem_graded (ι_mem_evenOdd_one Q v) hωodd
       rwa [CharTwo.add_self_eq_zero] at h
     have hrw : spinAction Q P (ι Q v * ω) * (c⁻¹ • spinAction Q P ω) = spinAction Q P (ι Q v) := by
-      rw [mul_smul_comm, ← map_mul, mul_assoc, hsq, ← Algebra.commutes, ← Algebra.smul_def,
-        map_smul, smul_smul, inv_mul_cancel₀ hc, one_smul]
+      rw [map_mul]
+      exact mul_mul_inv_smul_self_of_mul_self_eq hc hsqEnd _
     exact hrw ▸ Subalgebra.mul_mem _
       ((AlgHom.mem_range _).2 ⟨⟨_, hmem⟩, evenSpinAction_apply Q P _⟩)
       (Subalgebra.smul_mem _ hωrange _)

--- a/TauCeti/RepresentationTheory/Spin/OddStructure.lean
+++ b/TauCeti/RepresentationTheory/Spin/OddStructure.lean
@@ -231,7 +231,8 @@ polarization data carries the first (`TauCeti.SpinPolarizationData.nondegenerate
 argument never normalizes `ω`, which is what the second was for. -/
 theorem evenSpinAction_surjective : Function.Surjective (evenSpinAction Q P) := by
   have _ : Invertible (2 : F) := invertibleOfNonzero (NeZero.ne (2 : F))
-  obtain ⟨l, hl, hlen, hspan, hQl⟩ := P.nondegenerate.exists_list_pairwise_isOrtho
+  obtain ⟨l, hl, hlen, hspan, hQl⟩ :=
+    (P.nondegenerate ((isUnit_of_invertible (2 : F)).isSMulRegular F)).exists_list_pairwise_isOrtho
   set ω : CliffordAlgebra Q := (l.map (ι Q)).prod
   set c : F := (-1 : F) ^ l.length.choose 2 * (l.map Q).prod
   have hc : c ≠ 0 := by

--- a/TauCeti/RepresentationTheory/Spin/OddStructure.lean
+++ b/TauCeti/RepresentationTheory/Spin/OddStructure.lean
@@ -47,12 +47,30 @@ The isomorphisms are not canonical — they depend on a choice of orthogonal bas
 and of a basis of the spinor module — so the statements are `Nonempty`, as the even-dimensional
 `CliffordAlgebra.nonempty_algEquiv_matrix_of_finrank_eq_two_mul` is.
 
+Once a polarization *is* fixed there is a canonical isomorphism to be had, and the last section
+records it. Only the basis of the spinor module was arbitrary above, so dropping it leaves the
+Fock action itself: `TauCeti.evenSpinAction` is a bijection from `even Q` onto
+`Module.End F (⋀·W)`, because the even subalgebra is simple (being a matrix algebra), so any
+nonzero action of it is faithful, and the two algebras have the same dimension. That statement,
+`TauCeti.SpinPolarizationData.evenCliffordEquivEnd`, is the odd-dimensional companion of the even
+`TauCeti.SpinPolarizationData.cliffordEquivEnd`, one grade down: in even dimension the *whole*
+Clifford algebra is `Module.End F (⋀·W)`, in odd dimension only its even half is, the whole
+algebra being two copies of that half.
+
 ## Main results
 
 * `CliffordAlgebra.nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one`: **the even
   subalgebra is a matrix algebra** `M_{2^l}(F)` in dimension `2 * l + 1`.
 * `CliffordAlgebra.nonempty_algEquiv_matrix_prod_of_finrank_eq_two_mul_add_one`: **the structure
   theorem in odd dimension**, `CliffordAlgebra Q ≃ₐ[F] M_{2^l}(F) × M_{2^l}(F)`.
+* `CliffordAlgebra.isSimpleRing_even_of_finrank_eq_two_mul_add_one`: **the even subalgebra is a
+  simple ring** in odd dimension, unlike the whole algebra.
+* `TauCeti.evenSpinAction_bijective` and `TauCeti.SpinPolarizationData.evenCliffordEquivEnd`:
+  **the odd structure theorem in operator form**, that the Fock action identifies `even Q` with
+  `Module.End F (⋀·W)`.
+* `TauCeti.SpinPolarizationData.finrank_exteriorAlgebra_W_of_finrank_eq_two_mul_add_one` and
+  `TauCeti.SpinPolarizationData.finrank_even_eq_finrank_end_of_finrank_eq_two_mul_add_one`: the
+  dimension bookkeeping the operator form rests on.
 
 ## References
 
@@ -69,6 +87,46 @@ public section
 open CliffordAlgebra Module QuadraticMap
 
 universe u v
+
+namespace TauCeti.SpinPolarizationData
+
+/-! ### The dimension count in odd dimension -/
+
+section Dimension
+
+variable {F : Type u} [Field F] {V : Type v} [AddCommGroup V] [Module F V]
+  [FiniteDimensional F V] {Q : QuadraticForm F V} (P : SpinPolarizationData Q)
+
+/-- **The spinor module has dimension `2 ^ l`** when the polarized quadratic space has dimension
+`2 * l + 1`. The isotropic summand has dimension `l` in odd dimension as well as in even
+dimension, the extra dimension being taken up by the anisotropic remainder, so the two parities
+give spinor modules of the same size. -/
+theorem finrank_exteriorAlgebra_W_of_finrank_eq_two_mul_add_one {l : ℕ}
+    (hV : finrank F V = 2 * l + 1) : finrank F (ExteriorAlgebra F P.W) = 2 ^ l := by
+  rw [TauCeti.ExteriorAlgebra.finrank_eq_two_pow, P.finrank_W_of_finrank_eq_two_mul_add_one hV]
+
+/-- **The even Clifford subalgebra and the operator algebra of the spinor module have equal
+dimension** in odd dimension: `2 ^ (2 * l + 1 - 1)` on the left, `(2 ^ l) ^ 2` on the right.
+
+This is the odd-dimensional analogue of
+`TauCeti.SpinPolarizationData.finrank_cliffordAlgebra_eq_finrank_end`, and the shift of one power
+of two is exactly the difference between the two parities: in even dimension the *whole* Clifford
+algebra matches the operator algebra of `⋀·W`, while in odd dimension only its even half does. -/
+theorem finrank_even_eq_finrank_end_of_finrank_eq_two_mul_add_one [Invertible (2 : F)] {l : ℕ}
+    (hV : finrank F V = 2 * l + 1) :
+    finrank F ↥(CliffordAlgebra.even Q) =
+      finrank F (Module.End F (ExteriorAlgebra F P.W)) := by
+  have _ : Nontrivial V := Module.nontrivial_of_finrank_pos (R := F) (by rw [hV]; omega)
+  have hEnd : finrank F (Module.End F (ExteriorAlgebra F P.W)) =
+      finrank F (ExteriorAlgebra F P.W) * finrank F (ExteriorAlgebra F P.W) :=
+    Module.finrank_linearMap F F (ExteriorAlgebra F P.W) (ExteriorAlgebra F P.W)
+  rw [CliffordAlgebra.finrank_even Q, hEnd,
+    P.finrank_exteriorAlgebra_W_of_finrank_eq_two_mul_add_one hV, hV, Nat.add_sub_cancel,
+    two_mul, pow_add]
+
+end Dimension
+
+end TauCeti.SpinPolarizationData
 
 namespace CliffordAlgebra
 
@@ -95,8 +153,8 @@ theorem nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one {l : ℕ}
   have _ : Nontrivial V := Module.nontrivial_of_finrank_pos (R := F) (by rw [hV]; omega)
   -- The Fock action of a polarization, read in a basis of the spinor module.
   set P := SpinPolarizationData.ofNondegenerate Q hQ
-  have hS : finrank F (ExteriorAlgebra F P.W) = 2 ^ l := by
-    rw [TauCeti.ExteriorAlgebra.finrank_eq_two_pow, P.finrank_W_of_finrank_eq_two_mul_add_one hV]
+  have hS : finrank F (ExteriorAlgebra F P.W) = 2 ^ l :=
+    P.finrank_exteriorAlgebra_W_of_finrank_eq_two_mul_add_one hV
   set toMatrix := Algebra.endAlgEquivMatrix F (ExteriorAlgebra F P.W) hS
   set π : CliffordAlgebra Q →ₐ[F] Matrix (Fin (2 ^ l)) (Fin (2 ^ l)) F :=
     (toMatrix : Module.End F (ExteriorAlgebra F P.W) ≃ₐ[F] _).toAlgHom.comp (spinAction Q P)
@@ -132,4 +190,87 @@ theorem nonempty_algEquiv_matrix_prod_of_finrank_eq_two_mul_add_one {l : ℕ}
   obtain ⟨f⟩ := nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one hQ hV
   exact ⟨e.trans (f.prodCongr f)⟩
 
+/-- **The even subalgebra of an odd-dimensional Clifford algebra is a simple ring.** It is a matrix
+algebra over the base field by
+`CliffordAlgebra.nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one`, and matrix algebras
+over a field are simple.
+
+The whole algebra is not: in odd dimension it is a product of two matrix algebras, so `(1, 0)` is
+a central idempotent other than `0` and `1`. Simplicity of the even half is what forces every
+nonzero action of it to be faithful, and hence — the dimensions agreeing — onto. -/
+theorem isSimpleRing_even_of_finrank_eq_two_mul_add_one {l : ℕ}
+    (hQ : Q.Nondegenerate) (hV : finrank F V = 2 * l + 1) : IsSimpleRing ↥(even Q) := by
+  have _ : Nonempty (Fin (2 ^ l)) := ⟨⟨0, Nat.two_pow_pos l⟩⟩
+  obtain ⟨e⟩ := nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one hQ hV
+  exact IsSimpleRing.of_ringEquiv e.symm.toRingEquiv inferInstance
+
 end CliffordAlgebra
+
+/-! ### The odd structure theorem in operator form
+
+The matrix identification above is not canonical: it depends on a basis of the spinor module. The
+Fock action itself is canonical once a polarization is chosen, and the counting above says exactly
+that it identifies the even subalgebra with the operator algebra of the spinor module. -/
+
+namespace TauCeti
+
+open CliffordAlgebra Module
+
+section OperatorForm
+
+variable {F : Type u} [Field F] [NeZero (2 : F)] [IsSepClosed F]
+  {V : Type v} [AddCommGroup V] [Module F V] [FiniteDimensional F V] {Q : QuadraticForm F V}
+  (P : SpinPolarizationData Q) {l : ℕ} (hQ : Q.Nondegenerate) (hV : finrank F V = 2 * l + 1)
+
+include hQ hV
+
+/-- **The even Clifford action on the spinor module is faithful in odd dimension.** The even
+subalgebra is simple, and an algebra homomorphism out of a simple ring into a nonzero ring is
+injective. -/
+theorem evenSpinAction_injective : Function.Injective (evenSpinAction Q P) := by
+  have _ : Invertible (2 : F) := invertibleOfNonzero (NeZero.ne (2 : F))
+  have _ : IsSimpleRing ↥(even Q) :=
+    CliffordAlgebra.isSimpleRing_even_of_finrank_eq_two_mul_add_one hQ hV
+  exact RingHom.injective (evenSpinAction Q P).toRingHom
+
+/-- **The even Clifford action on the spinor module is onto in odd dimension.** It is injective,
+and the two algebras have the same dimension.
+
+This is the sharp form of the odd-dimensional structure theorem: unlike the whole Clifford
+algebra, which needs both spinor modules to act faithfully, the even subalgebra already sees all
+of `Module.End F (⋀·W)`. -/
+theorem evenSpinAction_surjective : Function.Surjective (evenSpinAction Q P) := by
+  have _ : Invertible (2 : F) := invertibleOfNonzero (NeZero.ne (2 : F))
+  exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+    (f := (evenSpinAction Q P).toLinearMap)
+    (P.finrank_even_eq_finrank_end_of_finrank_eq_two_mul_add_one hV)).1
+    (evenSpinAction_injective P hQ hV)
+
+/-- **The even Clifford action on the spinor module is bijective in odd dimension.** -/
+theorem evenSpinAction_bijective : Function.Bijective (evenSpinAction Q P) :=
+  ⟨evenSpinAction_injective P hQ hV, evenSpinAction_surjective P hQ hV⟩
+
+/-- **The odd structure theorem in operator form**: for a polarized quadratic space of dimension
+`2 * l + 1` over a separably closed field of characteristic not two, the Fock action is an
+isomorphism of `F`-algebras from the even Clifford subalgebra onto the endomorphism algebra of the
+spinor module `S = ⋀·W`.
+
+This is the odd-dimensional companion of
+`TauCeti.SpinPolarizationData.cliffordEquivEnd`, one grade down: there the *whole* algebra is
+`Module.End F S`, here only its even half is, the whole algebra being two copies of it. -/
+noncomputable def SpinPolarizationData.evenCliffordEquivEnd :
+    ↥(even Q) ≃ₐ[F] Module.End F (ExteriorAlgebra F P.W) :=
+  AlgEquiv.ofBijective (evenSpinAction Q P) (evenSpinAction_bijective P hQ hV)
+
+/-- The operator form of the odd structure theorem is the Fock action itself. -/
+@[simp]
+theorem SpinPolarizationData.evenCliffordEquivEnd_apply (x : ↥(even Q)) :
+    P.evenCliffordEquivEnd hQ hV x = spinAction Q P x := by
+  rw [SpinPolarizationData.evenCliffordEquivEnd]
+  exact (congrFun
+    (AlgEquiv.coe_ofBijective (evenSpinAction Q P) (evenSpinAction_bijective P hQ hV)) x).trans
+    (evenSpinAction_apply Q P x)
+
+end OperatorForm
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/OddStructure.lean
+++ b/TauCeti/RepresentationTheory/Spin/OddStructure.lean
@@ -69,8 +69,6 @@ only its even half is, the whole algebra being two copies of that half.
   subalgebra is a matrix algebra** `M_{2^l}(F)` in dimension `2 * l + 1`.
 * `CliffordAlgebra.nonempty_algEquiv_matrix_prod_of_finrank_eq_two_mul_add_one`: **the structure
   theorem in odd dimension**, `CliffordAlgebra Q ≃ₐ[F] M_{2^l}(F) × M_{2^l}(F)`.
-* `CliffordAlgebra.isSimpleRing_even_of_odd_finrank`: **the even subalgebra is a simple ring** in
-  odd dimension, unlike the whole algebra.
 * `TauCeti.evenSpinAction_surjective` and `TauCeti.SpinPolarizationData.evenCliffordEquivEnd`:
   **the odd structure theorem in operator form**, that the Fock action identifies `even Q` with
   `Module.End F (⋀·W)`, over any field of characteristic not two.
@@ -198,21 +196,6 @@ theorem nonempty_algEquiv_matrix_prod_of_finrank_eq_two_mul_add_one {l : ℕ}
   obtain ⟨f⟩ := nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one hQ hV
   exact ⟨e.trans (f.prodCongr f)⟩
 
-/-- **The even subalgebra of an odd-dimensional Clifford algebra is a simple ring.** It is a matrix
-algebra over the base field by
-`CliffordAlgebra.nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one`, and matrix algebras
-over a field are simple.
-
-The whole algebra is not: in odd dimension it is a product of two matrix algebras, so `(1, 0)` is
-a central idempotent other than `0` and `1`. Simplicity of the even half is what forces every
-nonzero action of it to be faithful, and hence — the dimensions agreeing — onto. -/
-theorem isSimpleRing_even_of_odd_finrank (hQ : Q.Nondegenerate) (hodd : Odd (finrank F V)) :
-    IsSimpleRing ↥(even Q) := by
-  obtain ⟨l, hV⟩ := hodd
-  have _ : Nonempty (Fin (2 ^ l)) := ⟨⟨0, Nat.two_pow_pos l⟩⟩
-  obtain ⟨e⟩ := nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one hQ hV
-  exact IsSimpleRing.of_ringEquiv e.symm.toRingEquiv inferInstance
-
 end CliffordAlgebra
 
 /-! ### The odd structure theorem in operator form
@@ -299,13 +282,6 @@ theorem evenSpinAction_injective : Function.Injective (evenSpinAction Q P) := by
     (P.finrank_even_eq_finrank_end_of_odd_finrank hodd)).2
     (evenSpinAction_surjective P hodd)
 
-/-- **The even Clifford action on the spinor module is bijective in odd dimension**, the
-odd-dimensional counterpart of `TauCeti.spinAction_bijective`. Kept private: it exists so that the
-bijectivity fed to `AlgEquiv.ofBijective` below carries the stated type, which is what lets the
-application lemma rewrite through it. -/
-private theorem evenSpinAction_bijective : Function.Bijective (evenSpinAction Q P) :=
-  ⟨evenSpinAction_injective P hodd, evenSpinAction_surjective P hodd⟩
-
 /-- **The odd structure theorem in operator form**: for a polarized quadratic space of odd
 dimension over a field of characteristic not two, the Fock action is an isomorphism of
 `F`-algebras from the even Clifford subalgebra onto the endomorphism algebra of the spinor module
@@ -316,13 +292,14 @@ This is the odd-dimensional companion of
 `Module.End F S`, here only its even half is, the whole algebra being two copies of it. -/
 noncomputable def SpinPolarizationData.evenCliffordEquivEnd :
     ↥(even Q) ≃ₐ[F] Module.End F (ExteriorAlgebra F P.W) :=
-  AlgEquiv.ofBijective (evenSpinAction Q P) (evenSpinAction_bijective P hodd)
+  AlgEquiv.ofBijective (evenSpinAction Q P)
+    ⟨evenSpinAction_injective P hodd, evenSpinAction_surjective P hodd⟩
 
 /-- The operator form of the odd structure theorem is the Fock action itself. -/
 @[simp]
 theorem SpinPolarizationData.evenCliffordEquivEnd_apply (x : ↥(even Q)) :
-    P.evenCliffordEquivEnd hodd x = spinAction Q P x := by
-  rw [SpinPolarizationData.evenCliffordEquivEnd, AlgEquiv.ofBijective_apply, evenSpinAction_apply]
+    P.evenCliffordEquivEnd hodd x = spinAction Q P x :=
+  (congrFun (AlgEquiv.coe_ofBijective _ _) x).trans (evenSpinAction_apply Q P x)
 
 end OperatorForm
 

--- a/TauCeti/RepresentationTheory/Spin/OddStructure.lean
+++ b/TauCeti/RepresentationTheory/Spin/OddStructure.lean
@@ -8,13 +8,12 @@ module
 public import TauCeti.LinearAlgebra.CliffordAlgebra.OddSplitting
 public import TauCeti.RepresentationTheory.Spin.Structure
 -- Non-public: the coordinate surjection out of a product, the simplicity of a matrix algebra, the
--- finite-dimensional injectivity criterion, the anisotropic orthogonal basis carrying the volume
--- element and the centrality of an endomorphism algebra are all used only inside proofs.
+-- finite-dimensional injectivity criterion and the anisotropic orthogonal basis carrying the
+-- volume element are all used only inside proofs.
 import TauCeti.RingTheory.CentralIdempotent
 import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalBasis
 import Mathlib.RingTheory.SimpleRing.Matrix
 import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
-import Mathlib.Algebra.Central.End
 
 /-!
 # The structure theorem for an odd-dimensional Clifford algebra
@@ -259,7 +258,7 @@ theorem evenSpinAction_surjective : Function.Surjective (evenSpinAction Q P) := 
     have hmem : ι Q v * ω ∈ even Q := by
       rw [← Subalgebra.mem_toSubmodule, even_toSubmodule]
       have h := SetLike.mul_mem_graded (ι_mem_evenOdd_one Q v) hωodd
-      rwa [show (1 : ZMod 2) + 1 = 0 by decide] at h
+      rwa [CharTwo.add_self_eq_zero] at h
     have hrw : spinAction Q P (ι Q v * ω) * (c⁻¹ • spinAction Q P ω) = spinAction Q P (ι Q v) := by
       rw [mul_smul_comm, ← map_mul, mul_assoc, hsq, ← Algebra.commutes, ← Algebra.smul_def,
         map_smul, smul_smul, inv_mul_cancel₀ hc, one_smul]

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
@@ -197,11 +197,10 @@ as `2` is a regular scalar and the base ring is reduced.
 A vector orthogonal to everything lies in the remainder, where the polar form is `2 Q` and `Q` is
 the square of the injective coordinate `SpinPolarizationData.lineCoordinate`; both hypotheses are
 needed to run that back — cancelling the `2` only asks it to be regular, not invertible, and the
-square only has to vanish for a square-zero scalar, which is all a reduced ring is asked for. Over a
-reduced ring with regular `2` this specializes to
-`TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot`, which needs neither hypothesis but
-covers only the case of no remainder; it is what makes nondegeneracy redundant as a hypothesis
-alongside polarization data. -/
+square only has to vanish for a square-zero scalar, which is all a reduced ring is asked for. When
+the remainder vanishes the same conclusion is available with neither hypothesis, from the separate
+`TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot`; this theorem is what makes
+nondegeneracy redundant as a hypothesis alongside polarization data in general. -/
 theorem nondegenerate {K : Type u} [CommRing K] [IsReduced K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
     (P : SpinPolarizationData Q) (h2 : IsSMulRegular K (2 : K)) : Q.Nondegenerate := by

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
@@ -40,6 +40,10 @@ giving `dim W = l` both in dimension `2l` (type `Dₗ`) and in dimension `2l + 1
   `TauCeti.SpinPolarizationData.finrank_line_eq_one_of_finrank_eq_two_mul_add_one` are its
   odd-dimensional consequences: the isotropic summand again has dimension `l`, and the remainder
   is exactly a line.
+* `TauCeti.SpinPolarizationData.nondegenerate` and
+  `TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot`: a polarized quadratic form is
+  nondegenerate, away from characteristic two in general and unconditionally when there is no
+  remainder.
 
 ## References
 
@@ -138,46 +142,80 @@ theorem pairing_separatingRight {K : Type u} [CommRing K] {V : Type v}
   ext x
   simp only [P.pairingEquiv_apply, hy x, map_zero, LinearMap.zero_apply]
 
-/-- A polarization without an orthogonal remainder has nondegenerate quadratic form. -/
-theorem nondegenerate_of_line_eq_bot {K : Type u} [CommRing K] {V : Type v}
+/-- **A vector orthogonal to the whole space lies in the orthogonal remainder.** The polar pairing
+separates each isotropic summand from the other, and the remainder is orthogonal to both, so the
+two isotropic coordinates of such a vector vanish and only its remainder coordinate survives. -/
+private theorem mem_line_of_polarBilin_eq_zero {K : Type u} [CommRing K] {V : Type v}
     [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
-    (P : SpinPolarizationData Q) (hline : P.line = ⊥) : Q.Nondegenerate := by
-  have hker : Q.polarBilin.ker = ⊥ := by
-    rw [LinearMap.ker_eq_bot']
-    intro v hv
-    let x := (P.decompositionEquiv.symm v).1.1
-    let y := (P.decompositionEquiv.symm v).1.2
-    let z := (P.decompositionEquiv.symm v).2
-    have hz : z = 0 := by
-      apply Subtype.ext
-      simpa [hline] using z.property
-    have hdecomp : (x : V) + (y : V) + (z : V) = v := by
-      rw [← P.decompositionEquiv_apply]
-      exact P.decompositionEquiv.apply_symm_apply v
-    have hWW (a b : P.W) : QuadraticMap.polar Q (a : V) b = 0 := by
-      simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W, sub_self]
-    have hW'W' (a b : P.W') : QuadraticMap.polar Q (a : V) b = 0 := by
-      simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W', sub_self]
-    have hx : x = 0 := by
-      apply P.pairing_separatingLeft
-      intro b
-      have h := LinearMap.congr_fun hv (b : V)
-      simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
-        QuadraticMap.polar_add_left, hW'W', P.line_orthogonal_W', LinearMap.zero_apply,
-        add_zero] using h
-    have hy : y = 0 := by
-      apply P.pairing_separatingRight
-      intro a
-      have h := LinearMap.congr_fun hv (a : V)
-      simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
-        QuadraticMap.polar_add_left, hWW, P.line_orthogonal_W, LinearMap.zero_apply,
-        add_zero, zero_add, QuadraticMap.polar_comm Q y a] using h
-    rw [← hdecomp, hx, hy, hz]
-    simp
+    (P : SpinPolarizationData Q) {v : V} (hv : Q.polarBilin v = 0) : v ∈ P.line := by
+  let x := (P.decompositionEquiv.symm v).1.1
+  let y := (P.decompositionEquiv.symm v).1.2
+  let z := (P.decompositionEquiv.symm v).2
+  have hdecomp : (x : V) + (y : V) + (z : V) = v := by
+    rw [← P.decompositionEquiv_apply]
+    exact P.decompositionEquiv.apply_symm_apply v
+  have hWW (a b : P.W) : QuadraticMap.polar Q (a : V) b = 0 := by
+    simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W, sub_self]
+  have hW'W' (a b : P.W') : QuadraticMap.polar Q (a : V) b = 0 := by
+    simp only [QuadraticMap.polar, ← Submodule.coe_add, P.isotropic_W', sub_self]
+  have hx : x = 0 := by
+    apply P.pairing_separatingLeft
+    intro b
+    have h := LinearMap.congr_fun hv (b : V)
+    simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
+      QuadraticMap.polar_add_left, hW'W', P.line_orthogonal_W', LinearMap.zero_apply,
+      add_zero] using h
+  have hy : y = 0 := by
+    apply P.pairing_separatingRight
+    intro a
+    have h := LinearMap.congr_fun hv (a : V)
+    simpa only [QuadraticMap.polarBilin_apply_apply, ← hdecomp,
+      QuadraticMap.polar_add_left, hWW, P.line_orthogonal_W, LinearMap.zero_apply,
+      add_zero, zero_add, QuadraticMap.polar_comm Q y a] using h
+  rw [← hdecomp, hx, hy]
+  simp
+
+/-- A quadratic form whose polar form has trivial kernel is nondegenerate. -/
+private theorem nondegenerate_of_ker_polarBilin_eq_bot {K : Type u} [CommRing K] {V : Type v}
+    [AddCommGroup V] [Module K V] {Q : QuadraticForm K V} (hker : Q.polarBilin.ker = ⊥) :
+    Q.Nondegenerate := by
   refine ⟨le_antisymm (Q.radical_le_ker_polarBilin.trans hker.le) bot_le, ?_⟩
   rw [hker]
   nontriviality K
   simp only [rank_subsingleton', zero_le]
+
+/-- A polarization without an orthogonal remainder has nondegenerate quadratic form. -/
+theorem nondegenerate_of_line_eq_bot {K : Type u} [CommRing K] {V : Type v}
+    [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
+    (P : SpinPolarizationData Q) (hline : P.line = ⊥) : Q.Nondegenerate := by
+  refine nondegenerate_of_ker_polarBilin_eq_bot (LinearMap.ker_eq_bot'.2 fun v hv => ?_)
+  simpa [hline] using P.mem_line_of_polarBilin_eq_zero hv
+
+/-- **A polarization has nondegenerate quadratic form**, whatever its orthogonal remainder, as soon
+as `2` is invertible and the base ring has no zero divisors.
+
+A vector orthogonal to everything lies in the remainder, where the polar form is `2 Q` and `Q` is
+the square of the injective coordinate `SpinPolarizationData.lineCoordinate`; both hypotheses are
+needed to run that back. This subsumes `TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot`
+away from characteristic two, and it is what makes nondegeneracy redundant as a hypothesis
+alongside polarization data. -/
+theorem nondegenerate {K : Type u} [CommRing K] [NoZeroDivisors K] [Invertible (2 : K)]
+    {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
+    (P : SpinPolarizationData Q) : Q.Nondegenerate := by
+  refine nondegenerate_of_ker_polarBilin_eq_bot (LinearMap.ker_eq_bot'.2 fun v hv => ?_)
+  let z : P.line := ⟨v, P.mem_line_of_polarBilin_eq_zero hv⟩
+  have hQz : Q v = 0 := by
+    have h : (2 : K) * Q v = 0 := by
+      simpa only [QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_self,
+        LinearMap.zero_apply, nsmul_eq_mul, Nat.cast_ofNat] using LinearMap.congr_fun hv v
+    rw [← invOf_mul_cancel_left (2 : K) (Q v), h, mul_zero]
+  have hcoord : P.lineCoordinate z = 0 := by
+    have h : P.lineCoordinate z * P.lineCoordinate z = 0 := by
+      rw [P.lineCoordinate_sq]
+      exact hQz
+    exact (mul_self_eq_zero.1 h)
+  exact congrArg Subtype.val (P.lineCoordinate_injective (by simpa using hcoord) :
+    z = (0 : P.line))
 
 section Dimension
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
@@ -42,8 +42,8 @@ giving `dim W = l` both in dimension `2l` (type `Dₗ`) and in dimension `2l + 1
   is exactly a line.
 * `TauCeti.SpinPolarizationData.nondegenerate` and
   `TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot`: a polarized quadratic form is
-  nondegenerate, away from characteristic two in general and unconditionally when there is no
-  remainder.
+  nondegenerate, as soon as `2` is a regular scalar of a reduced ring in general and
+  unconditionally when there is no remainder.
 
 ## References
 
@@ -192,24 +192,24 @@ theorem nondegenerate_of_line_eq_bot {K : Type u} [CommRing K] {V : Type v}
   simpa [hline] using P.mem_line_of_polarBilin_eq_zero hv
 
 /-- **A polarization has nondegenerate quadratic form**, whatever its orthogonal remainder, as soon
-as `2` is invertible and the base ring is reduced.
+as `2` is a regular scalar and the base ring is reduced.
 
 A vector orthogonal to everything lies in the remainder, where the polar form is `2 Q` and `Q` is
 the square of the injective coordinate `SpinPolarizationData.lineCoordinate`; both hypotheses are
-needed to run that back — the square only has to vanish for a square-zero scalar, which is all a
-reduced ring is asked for. This subsumes
-`TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot` away from characteristic two, and it
-is what makes nondegeneracy redundant as a hypothesis alongside polarization data. -/
-theorem nondegenerate {K : Type u} [CommRing K] [IsReduced K] [Invertible (2 : K)]
+needed to run that back — cancelling the `2` only asks it to be regular, not invertible, and the
+square only has to vanish for a square-zero scalar, which is all a reduced ring is asked for. This
+subsumes `TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot` away from characteristic two,
+and it is what makes nondegeneracy redundant as a hypothesis alongside polarization data. -/
+theorem nondegenerate {K : Type u} [CommRing K] [IsReduced K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
-    (P : SpinPolarizationData Q) : Q.Nondegenerate := by
+    (P : SpinPolarizationData Q) (h2 : IsSMulRegular K (2 : K)) : Q.Nondegenerate := by
   refine nondegenerate_of_ker_polarBilin_eq_bot (LinearMap.ker_eq_bot'.2 fun v hv => ?_)
   let z : P.line := ⟨v, P.mem_line_of_polarBilin_eq_zero hv⟩
   have hQz : Q v = 0 := by
-    have h : (2 : K) * Q v = 0 := by
-      simpa only [QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_self,
-        LinearMap.zero_apply, nsmul_eq_mul, Nat.cast_ofNat] using LinearMap.congr_fun hv v
-    rw [← invOf_mul_cancel_left (2 : K) (Q v), h, mul_zero]
+    refine h2.right_eq_zero_of_smul ?_
+    simpa only [QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_self,
+      LinearMap.zero_apply, nsmul_eq_mul, Nat.cast_ofNat, smul_eq_mul] using
+      LinearMap.congr_fun hv v
   have hcoord : P.lineCoordinate z = 0 := by
     have h : P.lineCoordinate z ^ 2 = 0 := by
       rw [pow_two, P.lineCoordinate_sq]

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
@@ -197,9 +197,11 @@ as `2` is a regular scalar and the base ring is reduced.
 A vector orthogonal to everything lies in the remainder, where the polar form is `2 Q` and `Q` is
 the square of the injective coordinate `SpinPolarizationData.lineCoordinate`; both hypotheses are
 needed to run that back — cancelling the `2` only asks it to be regular, not invertible, and the
-square only has to vanish for a square-zero scalar, which is all a reduced ring is asked for. This
-subsumes `TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot` away from characteristic two,
-and it is what makes nondegeneracy redundant as a hypothesis alongside polarization data. -/
+square only has to vanish for a square-zero scalar, which is all a reduced ring is asked for. Over a
+reduced ring with regular `2` this specializes to
+`TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot`, which needs neither hypothesis but
+covers only the case of no remainder; it is what makes nondegeneracy redundant as a hypothesis
+alongside polarization data. -/
 theorem nondegenerate {K : Type u} [CommRing K] [IsReduced K]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
     (P : SpinPolarizationData Q) (h2 : IsSMulRegular K (2 : K)) : Q.Nondegenerate := by

--- a/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/Basic.lean
@@ -192,14 +192,15 @@ theorem nondegenerate_of_line_eq_bot {K : Type u} [CommRing K] {V : Type v}
   simpa [hline] using P.mem_line_of_polarBilin_eq_zero hv
 
 /-- **A polarization has nondegenerate quadratic form**, whatever its orthogonal remainder, as soon
-as `2` is invertible and the base ring has no zero divisors.
+as `2` is invertible and the base ring is reduced.
 
 A vector orthogonal to everything lies in the remainder, where the polar form is `2 Q` and `Q` is
 the square of the injective coordinate `SpinPolarizationData.lineCoordinate`; both hypotheses are
-needed to run that back. This subsumes `TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot`
-away from characteristic two, and it is what makes nondegeneracy redundant as a hypothesis
-alongside polarization data. -/
-theorem nondegenerate {K : Type u} [CommRing K] [NoZeroDivisors K] [Invertible (2 : K)]
+needed to run that back — the square only has to vanish for a square-zero scalar, which is all a
+reduced ring is asked for. This subsumes
+`TauCeti.SpinPolarizationData.nondegenerate_of_line_eq_bot` away from characteristic two, and it
+is what makes nondegeneracy redundant as a hypothesis alongside polarization data. -/
+theorem nondegenerate {K : Type u} [CommRing K] [IsReduced K] [Invertible (2 : K)]
     {V : Type v} [AddCommGroup V] [Module K V] {Q : QuadraticForm K V}
     (P : SpinPolarizationData Q) : Q.Nondegenerate := by
   refine nondegenerate_of_ker_polarBilin_eq_bot (LinearMap.ker_eq_bot'.2 fun v hv => ?_)
@@ -210,10 +211,10 @@ theorem nondegenerate {K : Type u} [CommRing K] [NoZeroDivisors K] [Invertible (
         LinearMap.zero_apply, nsmul_eq_mul, Nat.cast_ofNat] using LinearMap.congr_fun hv v
     rw [← invOf_mul_cancel_left (2 : K) (Q v), h, mul_zero]
   have hcoord : P.lineCoordinate z = 0 := by
-    have h : P.lineCoordinate z * P.lineCoordinate z = 0 := by
-      rw [P.lineCoordinate_sq]
+    have h : P.lineCoordinate z ^ 2 = 0 := by
+      rw [pow_two, P.lineCoordinate_sq]
       exact hQz
-    exact (mul_self_eq_zero.1 h)
+    exact eq_zero_of_pow_eq_zero h
   exact congrArg Subtype.val (P.lineCoordinate_injective (by simpa using hcoord) :
     z = (0 : P.line))
 

--- a/TauCeti/RepresentationTheory/Spin/Representation.lean
+++ b/TauCeti/RepresentationTheory/Spin/Representation.lean
@@ -14,14 +14,21 @@ import TauCeti.LinearAlgebra.ExteriorAlgebra.End
 /-!
 # The Spin-group representation on the exterior model
 
-This file restricts the Fock action of a Clifford algebra to its Spin group and proves, when the
-first isotropic summand is finite free, that the underlying Clifford action generates every
-endomorphism of the exterior model.
+This file restricts the Fock action of a Clifford algebra to its Spin group and to its even
+subalgebra, and proves, when the first isotropic summand is finite free, that the underlying
+Clifford action generates every endomorphism of the exterior model.
+
+The Spin group lies inside the even subalgebra (`spinGroup.mem_even`), so the Spin representation
+factors through the even Clifford action `TauCeti.evenSpinAction`; how much of the endomorphism
+algebra that restricted action reaches is exactly what distinguishes the two parities of the
+ambient dimension. In even dimension it splits off the two half-spin blocks, in odd dimension it
+is still everything.
 
 ## Main definitions and results
 
 * `TauCeti.spinRep` and `TauCeti.pinRep` are the representations of `spinGroup Q` and `pinGroup Q`
   on the exterior model.
+* `TauCeti.evenSpinAction` is the Fock action restricted to the even Clifford subalgebra.
 * `TauCeti.spinAction_surjective` identifies the Fock action as onto the full endomorphism algebra
   when the first isotropic summand is finite free.
 
@@ -64,6 +71,22 @@ noncomputable def pinRep (Q : QuadraticForm K V) (P : SpinPolarizationData Q) :
 theorem pinRep_apply (Q : QuadraticForm K V) (P : SpinPolarizationData Q) (g : pinGroup Q) :
     pinRep Q P g = spinAction Q P g := by
   simp [pinRep]
+
+/-- **The action of the even Clifford subalgebra on the spinor module** `S = ⋀·W`, the Fock action
+restricted along the inclusion of `CliffordAlgebra.even Q`.
+
+This is the algebra through which the Spin representation acts, `spinGroup Q` being contained in
+the even subalgebra; the half-spin actions of `TauCeti.spinPlusAction` and
+`TauCeti.spinMinusAction` are its two blocks in even dimension. -/
+noncomputable def evenSpinAction (Q : QuadraticForm K V) (P : SpinPolarizationData Q) :
+    CliffordAlgebra.even Q →ₐ[K] Module.End K (ExteriorAlgebra K P.W) :=
+  (spinAction Q P).comp (CliffordAlgebra.even Q).val
+
+/-- An even Clifford element acts on the spinor module by the Fock action. -/
+@[simp]
+theorem evenSpinAction_apply (Q : QuadraticForm K V) (P : SpinPolarizationData Q)
+    (x : CliffordAlgebra.even Q) : evenSpinAction Q P x = spinAction Q P x :=
+  (rfl)
 
 /-- When the first isotropic summand is finite free, the Fock action of a Clifford algebra on its
 exterior model is onto the full endomorphism algebra. -/

--- a/TauCeti/RepresentationTheory/Spin/Representation.lean
+++ b/TauCeti/RepresentationTheory/Spin/Representation.lean
@@ -33,7 +33,7 @@ one-dimensional, the odd block is zero and the even action is again onto.
 * `TauCeti.spinGroupToEven` is the inclusion of the Spin group into the even Clifford subalgebra
   and `TauCeti.evenSpinAction` is the Fock action restricted to that subalgebra, through which the
   Spin representation factors by `TauCeti.evenSpinAction_apply` and
-  `TauCeti.coe_spinGroupToEven`.
+  `TauCeti.coe_spinGroupToEven_apply`.
 * `TauCeti.spinAction_surjective` identifies the Fock action as onto the full endomorphism algebra
   when the first isotropic summand is finite free.
 
@@ -84,7 +84,7 @@ def spinGroupToEven (Q : QuadraticForm K V) : spinGroup Q →* CliffordAlgebra.e
 
 /-- A Spin-group element sits in the even subalgebra as itself. -/
 @[simp]
-theorem coe_spinGroupToEven (Q : QuadraticForm K V) (g : spinGroup Q) :
+theorem coe_spinGroupToEven_apply (Q : QuadraticForm K V) (g : spinGroup Q) :
     (spinGroupToEven Q g : CliffordAlgebra Q) = g :=
   (rfl)
 

--- a/TauCeti/RepresentationTheory/Spin/Representation.lean
+++ b/TauCeti/RepresentationTheory/Spin/Representation.lean
@@ -78,11 +78,7 @@ theorem pinRep_apply (Q : QuadraticForm K V) (P : SpinPolarizationData Q) (g : p
   simp [pinRep]
 
 /-- **The inclusion of the Spin group into the even Clifford subalgebra**, the Spin group
-consisting of even elements by `spinGroup.mem_even`.
-
-`@[expose]`, because the inclusion carries no data beyond the membership proof and proofs about
-the restricted actions read a Spin-group element as the even element `⟨↑g, _⟩` it is. -/
-@[expose]
+consisting of even elements by `spinGroup.mem_even`. -/
 def spinGroupToEven (Q : QuadraticForm K V) : spinGroup Q →* CliffordAlgebra.even Q :=
   Submonoid.inclusion fun _ hx => spinGroup.mem_even hx
 
@@ -90,7 +86,7 @@ def spinGroupToEven (Q : QuadraticForm K V) : spinGroup Q →* CliffordAlgebra.e
 @[simp]
 theorem coe_spinGroupToEven (Q : QuadraticForm K V) (g : spinGroup Q) :
     (spinGroupToEven Q g : CliffordAlgebra Q) = g :=
-  rfl
+  (rfl)
 
 /-- **The action of the even Clifford subalgebra on the spinor module** `S = ⋀·W`, the Fock action
 restricted along the inclusion of `CliffordAlgebra.even Q`.

--- a/TauCeti/RepresentationTheory/Spin/Representation.lean
+++ b/TauCeti/RepresentationTheory/Spin/Representation.lean
@@ -20,12 +20,11 @@ Clifford action generates every endomorphism of the exterior model.
 
 The Spin group lies inside the even subalgebra (`spinGroup.mem_even`), so the Spin representation
 factors through the even Clifford action `TauCeti.evenSpinAction` along the inclusion
-`TauCeti.spinGroupToEven`, which is `TauCeti.evenSpinAction_spinGroupToEven`. How much of the
-endomorphism algebra that restricted action reaches is exactly what distinguishes the two parities
-of the ambient dimension: in *positive* even dimension it splits off the two half-spin blocks,
-while in odd dimension it is still everything. Dimension zero is the degenerate exception to the
-even description, `W` being `⊥` there, so that `S = K` is one-dimensional, the odd block is zero
-and the even action is again onto.
+`TauCeti.spinGroupToEven`. How much of the endomorphism algebra that restricted action reaches is
+exactly what distinguishes the two parities of the ambient dimension: in *positive* even dimension
+it splits off the two half-spin blocks, while in odd dimension it is still everything. Dimension
+zero is the degenerate exception to the even description, `W` being `⊥` there, so that `S = K` is
+one-dimensional, the odd block is zero and the even action is again onto.
 
 ## Main definitions and results
 
@@ -33,7 +32,8 @@ and the even action is again onto.
   on the exterior model.
 * `TauCeti.spinGroupToEven` is the inclusion of the Spin group into the even Clifford subalgebra
   and `TauCeti.evenSpinAction` is the Fock action restricted to that subalgebra, through which the
-  Spin representation factors by `TauCeti.evenSpinAction_spinGroupToEven`.
+  Spin representation factors by `TauCeti.evenSpinAction_apply` and
+  `TauCeti.coe_spinGroupToEven`.
 * `TauCeti.spinAction_surjective` identifies the Fock action as onto the full endomorphism algebra
   when the first isotropic summand is finite free.
 
@@ -103,12 +103,6 @@ noncomputable def evenSpinAction (Q : QuadraticForm K V) (P : SpinPolarizationDa
 theorem evenSpinAction_apply (Q : QuadraticForm K V) (P : SpinPolarizationData Q)
     (x : CliffordAlgebra.even Q) : evenSpinAction Q P x = spinAction Q P x :=
   (rfl)
-
-/-- **The Spin representation factors through the even Clifford action**: a Spin-group element acts
-as the even Clifford element it is. -/
-theorem evenSpinAction_spinGroupToEven (Q : QuadraticForm K V) (P : SpinPolarizationData Q)
-    (g : spinGroup Q) : evenSpinAction Q P (spinGroupToEven Q g) = spinRep Q P g := by
-  rw [evenSpinAction_apply, coe_spinGroupToEven, spinRep_apply]
 
 /-- When the first isotropic summand is finite free, the Fock action of a Clifford algebra on its
 exterior model is onto the full endomorphism algebra. -/

--- a/TauCeti/RepresentationTheory/Spin/Representation.lean
+++ b/TauCeti/RepresentationTheory/Spin/Representation.lean
@@ -19,16 +19,21 @@ subalgebra, and proves, when the first isotropic summand is finite free, that th
 Clifford action generates every endomorphism of the exterior model.
 
 The Spin group lies inside the even subalgebra (`spinGroup.mem_even`), so the Spin representation
-factors through the even Clifford action `TauCeti.evenSpinAction`; how much of the endomorphism
-algebra that restricted action reaches is exactly what distinguishes the two parities of the
-ambient dimension. In even dimension it splits off the two half-spin blocks, in odd dimension it
-is still everything.
+factors through the even Clifford action `TauCeti.evenSpinAction` along the inclusion
+`TauCeti.spinGroupToEven`, which is `TauCeti.evenSpinAction_spinGroupToEven`. How much of the
+endomorphism algebra that restricted action reaches is exactly what distinguishes the two parities
+of the ambient dimension: in *positive* even dimension it splits off the two half-spin blocks,
+while in odd dimension it is still everything. Dimension zero is the degenerate exception to the
+even description, `W` being `⊥` there, so that `S = K` is one-dimensional, the odd block is zero
+and the even action is again onto.
 
 ## Main definitions and results
 
 * `TauCeti.spinRep` and `TauCeti.pinRep` are the representations of `spinGroup Q` and `pinGroup Q`
   on the exterior model.
-* `TauCeti.evenSpinAction` is the Fock action restricted to the even Clifford subalgebra.
+* `TauCeti.spinGroupToEven` is the inclusion of the Spin group into the even Clifford subalgebra
+  and `TauCeti.evenSpinAction` is the Fock action restricted to that subalgebra, through which the
+  Spin representation factors by `TauCeti.evenSpinAction_spinGroupToEven`.
 * `TauCeti.spinAction_surjective` identifies the Fock action as onto the full endomorphism algebra
   when the first isotropic summand is finite free.
 
@@ -72,6 +77,21 @@ theorem pinRep_apply (Q : QuadraticForm K V) (P : SpinPolarizationData Q) (g : p
     pinRep Q P g = spinAction Q P g := by
   simp [pinRep]
 
+/-- **The inclusion of the Spin group into the even Clifford subalgebra**, the Spin group
+consisting of even elements by `spinGroup.mem_even`.
+
+`@[expose]`, because the inclusion carries no data beyond the membership proof and proofs about
+the restricted actions read a Spin-group element as the even element `⟨↑g, _⟩` it is. -/
+@[expose]
+def spinGroupToEven (Q : QuadraticForm K V) : spinGroup Q →* CliffordAlgebra.even Q :=
+  Submonoid.inclusion fun _ hx => spinGroup.mem_even hx
+
+/-- A Spin-group element sits in the even subalgebra as itself. -/
+@[simp]
+theorem coe_spinGroupToEven (Q : QuadraticForm K V) (g : spinGroup Q) :
+    (spinGroupToEven Q g : CliffordAlgebra Q) = g :=
+  rfl
+
 /-- **The action of the even Clifford subalgebra on the spinor module** `S = ⋀·W`, the Fock action
 restricted along the inclusion of `CliffordAlgebra.even Q`.
 
@@ -87,6 +107,12 @@ noncomputable def evenSpinAction (Q : QuadraticForm K V) (P : SpinPolarizationDa
 theorem evenSpinAction_apply (Q : QuadraticForm K V) (P : SpinPolarizationData Q)
     (x : CliffordAlgebra.even Q) : evenSpinAction Q P x = spinAction Q P x :=
   (rfl)
+
+/-- **The Spin representation factors through the even Clifford action**: a Spin-group element acts
+as the even Clifford element it is. -/
+theorem evenSpinAction_spinGroupToEven (Q : QuadraticForm K V) (P : SpinPolarizationData Q)
+    (g : spinGroup Q) : evenSpinAction Q P (spinGroupToEven Q g) = spinRep Q P g := by
+  rw [evenSpinAction_apply, coe_spinGroupToEven, spinRep_apply]
 
 /-- When the first isotropic summand is finite free, the Fock action of a Clifford algebra on its
 exterior model is onto the full endomorphism algebra. -/


### PR DESCRIPTION
This PR proves that the spin representation is irreducible in odd dimension, the type `Bₗ` half of the Layer 4 irreducibility statement of `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md` ("Layer 4: the spin and half-spin representations", the **Irreducibility** bullet: "`spinRep` is irreducible in odd dimension, and `spinPlus`, `spinMinus` are irreducible and inequivalent in even dimension"), pinned in that roadmap's `Suggested.lean` as `spinRep_isIrreducible_of_odd`. The even-dimensional half already stands in `TauCeti/RepresentationTheory/Spin/Irreducible.lean`; the odd half did not, because the object it needs — the even Clifford subalgebra acting onto all of `Module.End K S` — was not available. The roadmap's own account of the odd case ("`S` is irreducible and does not split") is also discharged: exterior parity is shown not to split `S` as a representation.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"spinrep-isirreducible-of-odd"}-->

The route is the odd structure theorem restated in operator form. Given a polarization `P`, the Fock action `TauCeti.evenSpinAction` out of `even Q` into `Module.End F (⋀·W)` is a bijection over **any** field of characteristic not two: the volume element `ω` of an orthogonal basis is central, so its image commutes with the whole of `Module.End F (⋀·W)` — the full Fock action being onto — and is therefore a scalar; `ω` is odd with `ω² = c ≠ 0`, so each generator is `ι v = c⁻¹ (ι v * ω) * ω` with `ι v * ω` even, and the even half already reaches everything; the dimension count `2 ^ (2 * l)` on both sides makes the surjection injective. That gives `TauCeti.SpinPolarizationData.evenCliffordEquivEnd`, the canonical (polarization-dependent, basis-free) odd companion of the even `cliffordEquivEnd`, one grade down: in even dimension the whole Clifford algebra is `Module.End F S`, in odd dimension only its even half is. Combined with `CliffordAlgebra.span_spinGroup_eq_even`, the Spin group then exhausts the endomorphisms of `S`, which is irreducibility.

Neither nondegeneracy nor separable closure is assumed anywhere in that: `TauCeti.SpinPolarizationData.nondegenerate` derives nondegeneracy from the polarization data itself away from characteristic two, and `ω` is never normalized to a square root of one, which is what separable closure was for. `TauCeti.isIrreducible_spinRep_of_isSquare` is the resulting generality layer, in the shape of the even-dimensional `isIrreducible_spinPlusSubrep_of_isSquare`; the separably closed `TauCeti.isIrreducible_spinRep` is its corollary.

`TauCeti.isIrreducible_spinRep_of_span_of_surjective` is stated against the surjectivity of `evenSpinAction` rather than against a dimension, because that single hypothesis is exactly what separates the two parities: in even dimension it fails, `even Q` being the *product* of the two half-spin endomorphism algebras, which is why `S` splits there. `TauCeti.not_forall_map_spinRep_spinPlus_le` records the contrast concretely — `S⁺` is neither zero nor everything when `P.W ≠ ⊥`, so irreducibility forbids it from being invariant. No mechanism claim about the anisotropic line is made or needed; the argument is purely by irreducibility.

The changes land in the existing files whose module docstrings already cover them: `evenSpinAction` beside `spinRep` and `pinRep` in `Spin/Representation.lean`, the nondegeneracy of a polarization in `Spin/Polarization/Basic.lean`, the odd-dimension dimension count and the operator form in `Spin/OddStructure.lean`, and the irreducibility statements in `Spin/Irreducible.lean`. Two lines of the existing proof of `nonempty_algEquiv_even_matrix_of_finrank_eq_two_mul_add_one` are replaced by the now-named `finrank_exteriorAlgebra_W_of_finrank_eq_two_mul_add_one` it was computing inline. No Mathlib infrastructure was vendored.

`lake build`, `lake exe axioms` (76034 declarations, allowlist only) and `scripts/lint-style.sh` are green, and a targeted `#lint only simpNF unusedArguments explicitVarsOfIff in TauCeti` over the touched modules reports nothing new.

Roadmap: RepresentationTheory

🤖 Prepared with Claude Code


