### PR TITLE
feat: identify GLn diagonal roots with adjoint weights

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Adjoint.lean
@@ -18,9 +18,12 @@ two constructions exactly.
 
 Thus the roots packaged by `GeneralLinear.diagonalRootDatum` are neither merely an abstract
 coordinate model nor just a subset of the adjoint weights: their range is the complete set
-`Derivation.nontrivialAdjointWeights` extracted from the pair `(GL_n, T)`. The induced
-equivalence records the canonical root indexing. The existing adjoint classification then
-identifies each root space with the line spanned by the corresponding matrix unit `E_ij`.
+`Derivation.nontrivialAdjointWeights` for the diagonal-torus morphism. The induced equivalence
+records the canonical root indexing. The existing adjoint classification then identifies each
+root space with the line spanned by the corresponding matrix unit `E_ij`.
+
+This is a worked-example bridge between two concrete constructions. It does not assert that the
+diagonal torus is maximal or construct the general root datum of a reductive pair.
 
 ## Main declarations
 
@@ -36,9 +39,10 @@ identifies each root space with the line spanned by the corresponding matrix uni
 * J. S. Milne, *Algebraic Groups* (2017), Example 19.7 and Section 21.1.
 * J. E. Humphreys, *Linear Algebraic Groups* (1975), Sections 16.1 and 26.3.
 
-This completes the root-set identification for the standard split pair `(GL_n, T)` in Layer 7,
-"Root datum of `(G, T)`", of the ReductiveGroups roadmap. Constructing root data for arbitrary
-split reductive groups and identifying their Weyl groups remain separate milestones.
+This supplies the root-set computation for the standard split `GL_n` worked example in Layer 7,
+"Root datum of `(G, T)`", of the ReductiveGroups roadmap. Proving maximality of the diagonal torus,
+constructing root data for arbitrary split reductive pairs, and identifying their Weyl groups
+remain separate milestones.
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Adjoint.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Adjoint.Classification
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Root.Datum
+
+/-!
+# The diagonal root datum and the adjoint roots of the general linear group
+
+For `GL_n` with its diagonal split torus, the coordinate root datum has roots `e_i - e_j`,
+indexed by ordered pairs `i ≠ j`. Independently, the nontrivial weights of the restricted
+adjoint representation have been classified as the same characters. This file identifies the
+two constructions exactly.
+
+Thus the roots packaged by `GeneralLinear.diagonalRootDatum` are neither merely an abstract
+coordinate model nor just a subset of the adjoint weights: their range is the complete set
+`Derivation.nontrivialAdjointWeights` extracted from the pair `(GL_n, T)`. The induced
+equivalence records the canonical root indexing. The existing adjoint classification then
+identifies each root space with the line spanned by the corresponding matrix unit `E_ij`.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.mem_nontrivialAdjointWeights_iff_exists_diagonalRoot`: a character is a
+  nontrivial adjoint weight exactly when it is a root of the diagonal root datum.
+* `TauCeti.GeneralLinear.range_ofAdd_diagonalRootDatum_root_eq_nontrivialAdjointWeights`: the
+  packaged root set equals the adjoint root set.
+* `TauCeti.GeneralLinear.diagonalRootIndexEquivNontrivialAdjointWeights`: the canonical
+  equivalence from root indices to nontrivial adjoint weights.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Example 19.7 and Section 21.1.
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), Sections 16.1 and 26.3.
+
+This completes the root-set identification for the standard split pair `(GL_n, T)` in Layer 7,
+"Root datum of `(G, T)`", of the ReductiveGroups roadmap. Constructing root data for arbitrary
+split reductive groups and identifying their Weyl groups remain separate milestones.
+-/
+
+public section
+
+open Function Set
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+noncomputable section
+
+variable {k : Type u} [Field k] {n : ℕ}
+
+/-- A character of the diagonal torus is a nontrivial adjoint weight exactly when it is the
+multiplicative form of a root in `diagonalRootDatum`. -/
+theorem mem_nontrivialAdjointWeights_iff_exists_diagonalRoot
+    (alpha : Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) :
+    alpha ∈ Derivation.nontrivialAdjointWeights
+        (diagonalTorusCoordinateMap (R := k) (N := n)).hom ↔
+      ∃ p : DiagonalRootIndex n,
+        alpha = Multiplicative.ofAdd
+          ((diagonalRootDatum n : RootDatum _ (ULift.{u} (Fin n) →₀ ℤ) _).root p) := by
+  rw [mem_nontrivialAdjointWeights_diagonalTorus_iff]
+  constructor
+  · rintro ⟨i, j, hij, rfl⟩
+    let p : DiagonalRootIndex n :=
+      ⟨(ULift.up i, ULift.up j), fun h ↦ hij (congrArg ULift.down h)⟩
+    refine ⟨p, ?_⟩
+    rw [diagonalRootDatum_root, ofAdd_diagonalRoot]
+  · rintro ⟨p, rfl⟩
+    refine ⟨p.1.1.down, p.1.2.down, ?_, ?_⟩
+    · intro h
+      exact p.2 (congrArg ULift.up h)
+    · rw [diagonalRootDatum_root, ofAdd_diagonalRoot]
+
+/-- The multiplicative roots of the diagonal coordinate root datum are exactly the nontrivial
+adjoint weights of `GL_n` relative to its diagonal torus. -/
+theorem range_ofAdd_diagonalRootDatum_root_eq_nontrivialAdjointWeights :
+    Set.range (fun p : DiagonalRootIndex n ↦
+        Multiplicative.ofAdd
+          ((diagonalRootDatum n : RootDatum _ (ULift.{u} (Fin n) →₀ ℤ) _).root p)) =
+      Derivation.nontrivialAdjointWeights
+        (diagonalTorusCoordinateMap (R := k) (N := n)).hom := by
+  ext alpha
+  rw [Set.mem_range, mem_nontrivialAdjointWeights_iff_exists_diagonalRoot]
+  exact exists_congr fun p ↦ eq_comm
+
+/-- The root indices of the diagonal coordinate root datum are canonically equivalent to the
+nontrivial adjoint weights of `GL_n` relative to its diagonal torus. -/
+noncomputable def diagonalRootIndexEquivNontrivialAdjointWeights :
+    DiagonalRootIndex n ≃
+      {alpha // alpha ∈ Derivation.nontrivialAdjointWeights
+        (diagonalTorusCoordinateMap (R := k) (N := n)).hom} :=
+  Equiv.ofBijective
+    (fun p ↦ ⟨Multiplicative.ofAdd
+        ((diagonalRootDatum n : RootDatum _ (ULift.{u} (Fin n) →₀ ℤ) _).root p),
+      ofAdd_root_mem_nontrivialAdjointWeights (k := k) p⟩)
+    ⟨fun p q h ↦ (diagonalRootDatum n).root.injective
+        (Multiplicative.ofAdd.injective (congrArg Subtype.val h)),
+      fun ⟨alpha, halpha⟩ ↦ by
+        obtain ⟨p, hp⟩ :=
+          (mem_nontrivialAdjointWeights_iff_exists_diagonalRoot alpha).mp halpha
+        exact ⟨p, Subtype.ext hp.symm⟩⟩
+
+/-- The root-index equivalence sends an index to the multiplicative form of its packaged root. -/
+@[simp]
+theorem diagonalRootIndexEquivNontrivialAdjointWeights_apply (p : DiagonalRootIndex n) :
+    (diagonalRootIndexEquivNontrivialAdjointWeights (k := k) p :
+      Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) =
+      Multiplicative.ofAdd
+        ((diagonalRootDatum n : RootDatum _ (ULift.{u} (Fin n) →₀ ℤ) _).root p) :=
+  (rfl)
+
+end
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Datum.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Datum.lean
@@ -17,9 +17,8 @@ two coordinates indexed by the reflecting root.
 
 The construction supplies the expected coordinate root datum and proves that each of its roots,
 viewed as a multiplicative character, occurs among the nontrivial adjoint weights of `GL_n`.
-Only this inclusion into `Derivation.nontrivialAdjointWeights` is proved here; identifying those
-adjoint weights exhaustively with the packaged root set, and hence identifying this package with
-the full root datum extracted from the pair `(GL_n, T)`, remains to be formalized.
+Only this inclusion into `Derivation.nontrivialAdjointWeights` is proved here; the converse
+identification with the packaged root set is proved in `GeneralLinear.Root.Adjoint`.
 
 The character and cocharacter lattices are the established split-torus coordinate models
 
@@ -101,7 +100,8 @@ theorem coe_diagonalRoot {n : ℕ} (i j : Fin n) :
 
 This package is constructed directly from the coordinate differences. The theorem
 `ofAdd_root_mem_nontrivialAdjointWeights` proves that its roots are adjoint weights; the converse
-classification of all nontrivial adjoint weights is not part of this file. -/
+classification is `mem_nontrivialAdjointWeights_iff_exists_diagonalRoot` in
+`GeneralLinear.Root.Adjoint`. -/
 noncomputable def diagonalRootDatum (n : ℕ) :
     RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ) (ULift.{u} (Fin n) → ℤ) :=
   SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))


### PR DESCRIPTION
This PR identifies the roots of `GeneralLinear.diagonalRootDatum` exactly with the nontrivial adjoint weights of `GLₙ` relative to its diagonal split torus, and packages the resulting canonical equivalence between the root-index type and the extracted adjoint-root set. The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 7, milestone “Root datum `(X*(T), Φ, X_*(T), Φ^∨)` of `(G, T)` with its Weyl group,” specifically the instruction to do the split case first. This is the most effective current step because #4456 now classifies every nontrivial diagonal adjoint weight and #4474 now packages the coordinate root datum, leaving their converse identification as the precise unmet bridge from the constructed datum to roots extracted from the group.

The new membership theorem proves that a diagonal-torus character belongs to `Derivation.nontrivialAdjointWeights` if and only if it is the multiplicative form of a packaged root. Its extensional form identifies the entire root range with the adjoint-weight set, and `diagonalRootIndexEquivNontrivialAdjointWeights` records the canonical indexing without duplicating the existing matrix-unit root-space classification.

After this PR, Layer 7 still needs the corresponding root-datum extraction for an arbitrary split reductive pair, maximal-torus and conjugacy theory, and identification of the resulting Weyl group.

Add `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Adjoint.lean` (118 lines). The argument reuses Tau Ceti’s complete `GLₙ` adjoint-weight classification and diagonal coordinate root datum; no Mathlib infrastructure is vendored. The mathematical identification follows Milne, *Algebraic Groups* (2017), Example 19.7 and §21.1, and Humphreys, *Linear Algebraic Groups* (1975), §§16.1 and 26.3, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"general-linear-diagonal-roots-adjoint-weights"}-->

🤖 Prepared with Codex
