### PR TITLE
refactor(RootSystem): name the long-root case of the type B weight reflection

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Model.lean
@@ -677,18 +677,19 @@ private lemma signedWeight_reflMap_of_axis_ne (hax : axis p ≠ axis q) (u : Fin
     signedWeight_dotProduct_of_axis_ne (Ne.symm hax)
   rw [rootOfPair_of_ne h1]
   -- For a long root, split the signed basis vectors into `p`, `q`, their opposites, and the
-  -- complement. The pairing is respectively `1`, `1`, `-1`, `-1`, and `0`.
+  -- complement. In each case `two_mul_dotProduct_corootOfPair` gives twice the pairing with the
+  -- coroot (`hval`), from which the pairing itself is `1`, `1`, `-1`, `-1`, and `0`.
   by_cases c1 : u = p
   · have hval := two_mul_dotProduct_corootOfPair p p q
     rw [signedWeight_dotProduct_self, hpq'] at hval
-    rw [c1, show signedWeight p ⬝ᵥ corootOfPair p q = 1 by omega, reflMap_fst, ite_eq_right h1,
-      signedWeight_opp]
+    have hpair : signedWeight p ⬝ᵥ corootOfPair p q = 1 := by omega
+    rw [c1, hpair, reflMap_fst, ite_eq_right h1, signedWeight_opp]
     module
   by_cases c2 : u = q
   · have hval := two_mul_dotProduct_corootOfPair q p q
     rw [signedWeight_dotProduct_self, hqp] at hval
-    rw [c2, show signedWeight q ⬝ᵥ corootOfPair p q = 1 by omega, reflMap_snd h3,
-      signedWeight_opp]
+    have hpair : signedWeight q ⬝ᵥ corootOfPair p q = 1 := by omega
+    rw [c2, hpair, reflMap_snd h3, signedWeight_opp]
     module
   by_cases c3 : u = opp p
   · have e1 : signedWeight (opp p) ⬝ᵥ signedCoweight p = -2 := by
@@ -697,8 +698,8 @@ private lemma signedWeight_reflMap_of_axis_ne (hax : axis p ≠ axis q) (u : Fin
       rw [signedWeight_opp, neg_dotProduct, hpq', neg_zero]
     have hval := two_mul_dotProduct_corootOfPair (opp p) p q
     rw [e1, e2] at hval
-    rw [c3, show signedWeight (opp p) ⬝ᵥ corootOfPair p q = -1 by omega,
-      reflMap_opp_fst h5, ite_eq_right h1, signedWeight_opp]
+    have hpair : signedWeight (opp p) ⬝ᵥ corootOfPair p q = -1 := by omega
+    rw [c3, hpair, reflMap_opp_fst h5, ite_eq_right h1, signedWeight_opp]
     module
   by_cases c4 : u = opp q
   · have e1 : signedWeight (opp q) ⬝ᵥ signedCoweight p = 0 := by
@@ -707,12 +708,13 @@ private lemma signedWeight_reflMap_of_axis_ne (hax : axis p ≠ axis q) (u : Fin
       rw [signedWeight_opp, neg_dotProduct, signedWeight_dotProduct_self]
     have hval := two_mul_dotProduct_corootOfPair (opp q) p q
     rw [e1, e2] at hval
-    rw [c4, show signedWeight (opp q) ⬝ᵥ corootOfPair p q = -1 by omega,
-      reflMap_opp_snd h7 h8, signedWeight_opp]
+    have hpair : signedWeight (opp q) ⬝ᵥ corootOfPair p q = -1 := by omega
+    rw [c4, hpair, reflMap_opp_snd h7 h8, signedWeight_opp]
     module
   · have hval := two_mul_dotProduct_corootOfPair u p q
     rw [signedWeight_dotProduct_eq_zero c1 c3, signedWeight_dotProduct_eq_zero c2 c4] at hval
-    rw [show signedWeight u ⬝ᵥ corootOfPair p q = 0 by omega, reflMap_of_ne c1 c2 c3 c4]
+    have hpair : signedWeight u ⬝ᵥ corootOfPair p q = 0 := by omega
+    rw [hpair, reflMap_of_ne c1 c2 c3 c4]
     module
 
 /-- **The reflection formula on a single signed basis vector.** -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Model.lean
@@ -667,6 +667,54 @@ lemma isPair_reflMap (h : IsPair p q) {u v : Fin (2 * n)} (huv : IsPair u v) :
     have heq := (reflMap_involutive h).injective hc'
     exact (huv.resolve_left hne) (by rw [heq, axis_opp])
 
+/-- The reflection formula on a single signed basis vector, on a long root. -/
+private lemma signedWeight_reflMap_of_axis_ne (hax : axis p ≠ axis q) (u : Fin (2 * n)) :
+    signedWeight (reflMap p q u) =
+      signedWeight u - (signedWeight u ⬝ᵥ corootOfPair p q) • rootOfPair p q := by
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8⟩ := long_ne hax
+  have hpq' : signedWeight p ⬝ᵥ signedCoweight q = 0 := signedWeight_dotProduct_of_axis_ne hax
+  have hqp : signedWeight q ⬝ᵥ signedCoweight p = 0 :=
+    signedWeight_dotProduct_of_axis_ne (Ne.symm hax)
+  rw [rootOfPair_of_ne h1]
+  -- For a long root, split the signed basis vectors into `p`, `q`, their opposites, and the
+  -- complement. The pairing is respectively `1`, `1`, `-1`, `-1`, and `0`.
+  by_cases c1 : u = p
+  · have hval := two_mul_dotProduct_corootOfPair p p q
+    rw [signedWeight_dotProduct_self, hpq'] at hval
+    rw [c1, show signedWeight p ⬝ᵥ corootOfPair p q = 1 by omega, reflMap_fst, ite_eq_right h1,
+      signedWeight_opp]
+    module
+  by_cases c2 : u = q
+  · have hval := two_mul_dotProduct_corootOfPair q p q
+    rw [signedWeight_dotProduct_self, hqp] at hval
+    rw [c2, show signedWeight q ⬝ᵥ corootOfPair p q = 1 by omega, reflMap_snd h3,
+      signedWeight_opp]
+    module
+  by_cases c3 : u = opp p
+  · have e1 : signedWeight (opp p) ⬝ᵥ signedCoweight p = -2 := by
+      rw [signedWeight_opp, neg_dotProduct, signedWeight_dotProduct_self]
+    have e2 : signedWeight (opp p) ⬝ᵥ signedCoweight q = 0 := by
+      rw [signedWeight_opp, neg_dotProduct, hpq', neg_zero]
+    have hval := two_mul_dotProduct_corootOfPair (opp p) p q
+    rw [e1, e2] at hval
+    rw [c3, show signedWeight (opp p) ⬝ᵥ corootOfPair p q = -1 by omega,
+      reflMap_opp_fst h5, ite_eq_right h1, signedWeight_opp]
+    module
+  by_cases c4 : u = opp q
+  · have e1 : signedWeight (opp q) ⬝ᵥ signedCoweight p = 0 := by
+      rw [signedWeight_opp, neg_dotProduct, hqp, neg_zero]
+    have e2 : signedWeight (opp q) ⬝ᵥ signedCoweight q = -2 := by
+      rw [signedWeight_opp, neg_dotProduct, signedWeight_dotProduct_self]
+    have hval := two_mul_dotProduct_corootOfPair (opp q) p q
+    rw [e1, e2] at hval
+    rw [c4, show signedWeight (opp q) ⬝ᵥ corootOfPair p q = -1 by omega,
+      reflMap_opp_snd h7 h8, signedWeight_opp]
+    module
+  · have hval := two_mul_dotProduct_corootOfPair u p q
+    rw [signedWeight_dotProduct_eq_zero c1 c3, signedWeight_dotProduct_eq_zero c2 c4] at hval
+    rw [show signedWeight u ⬝ᵥ corootOfPair p q = 0 by omega, reflMap_of_ne c1 c2 c3 c4]
+    module
+
 /-- **The reflection formula on a single signed basis vector.** -/
 lemma signedWeight_reflMap (h : IsPair p q) (u : Fin (2 * n)) :
     signedWeight (reflMap p q u) =
@@ -685,50 +733,7 @@ lemma signedWeight_reflMap (h : IsPair p q) (u : Fin (2 * n)) :
         module
       · rw [reflMap_of_ne c1 c1 c2 c2, signedWeight_dotProduct_eq_zero c1 c2]
         module
-  · have hax : axis p ≠ axis q := h.resolve_left hpq
-    obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8⟩ := long_ne hax
-    have hpq' : signedWeight p ⬝ᵥ signedCoweight q = 0 := signedWeight_dotProduct_of_axis_ne hax
-    have hqp : signedWeight q ⬝ᵥ signedCoweight p = 0 :=
-      signedWeight_dotProduct_of_axis_ne (Ne.symm hax)
-    rw [rootOfPair_of_ne h1]
-    -- For a long root, split the signed basis vectors into `p`, `q`, their opposites, and the
-    -- complement. The pairing is respectively `1`, `1`, `-1`, `-1`, and `0`.
-    by_cases c1 : u = p
-    · have hval := two_mul_dotProduct_corootOfPair p p q
-      rw [signedWeight_dotProduct_self, hpq'] at hval
-      rw [c1, show signedWeight p ⬝ᵥ corootOfPair p q = 1 by omega, reflMap_fst, ite_eq_right h1,
-        signedWeight_opp]
-      module
-    by_cases c2 : u = q
-    · have hval := two_mul_dotProduct_corootOfPair q p q
-      rw [signedWeight_dotProduct_self, hqp] at hval
-      rw [c2, show signedWeight q ⬝ᵥ corootOfPair p q = 1 by omega, reflMap_snd h3,
-        signedWeight_opp]
-      module
-    by_cases c3 : u = opp p
-    · have e1 : signedWeight (opp p) ⬝ᵥ signedCoweight p = -2 := by
-        rw [signedWeight_opp, neg_dotProduct, signedWeight_dotProduct_self]
-      have e2 : signedWeight (opp p) ⬝ᵥ signedCoweight q = 0 := by
-        rw [signedWeight_opp, neg_dotProduct, hpq', neg_zero]
-      have hval := two_mul_dotProduct_corootOfPair (opp p) p q
-      rw [e1, e2] at hval
-      rw [c3, show signedWeight (opp p) ⬝ᵥ corootOfPair p q = -1 by omega,
-        reflMap_opp_fst h5, ite_eq_right h1, signedWeight_opp]
-      module
-    by_cases c4 : u = opp q
-    · have e1 : signedWeight (opp q) ⬝ᵥ signedCoweight p = 0 := by
-        rw [signedWeight_opp, neg_dotProduct, hqp, neg_zero]
-      have e2 : signedWeight (opp q) ⬝ᵥ signedCoweight q = -2 := by
-        rw [signedWeight_opp, neg_dotProduct, signedWeight_dotProduct_self]
-      have hval := two_mul_dotProduct_corootOfPair (opp q) p q
-      rw [e1, e2] at hval
-      rw [c4, show signedWeight (opp q) ⬝ᵥ corootOfPair p q = -1 by omega,
-        reflMap_opp_snd h7 h8, signedWeight_opp]
-      module
-    · have hval := two_mul_dotProduct_corootOfPair u p q
-      rw [signedWeight_dotProduct_eq_zero c1 c3, signedWeight_dotProduct_eq_zero c2 c4] at hval
-      rw [show signedWeight u ⬝ᵥ corootOfPair p q = 0 by omega, reflMap_of_ne c1 c2 c3 c4]
-      module
+  · exact signedWeight_reflMap_of_axis_ne (h.resolve_left hpq) u
 
 /-- The reflection formula on the double of a single signed basis vector, on a long root. -/
 private lemma signedCoweight_reflMap_of_axis_ne (hax : axis p ≠ axis q) (u : Fin (2 * n)) :


### PR DESCRIPTION
Name the long-root case of the type B weight reflection formula, so
`signedWeight_reflMap` states its case split instead of also proving one of the
two cases — the twin of #4515, which did the same for `signedCoweight_reflMap`
in this file.

## What moved

`signedWeight_reflMap` was a `rcases eq_or_ne p q` into an 11-line short-root case
and a 44-line long-root case. The long case is now
`signedWeight_reflMap_of_axis_ne`, and the parent delegates to it.

| | before | after |
|---|---|---|
| `signedWeight_reflMap` body | 58 lines | **15 lines** |
| `signedWeight_reflMap_of_axis_ne` | — | 43 lines |

(The helper is one line shorter than the branch it replaces: the branch's opening
`have hax : axis p ≠ axis q := h.resolve_left hpq` is now the hypothesis.)

The public statement of `signedWeight_reflMap` is byte-identical, so its consumers
in `B/Datum.lean` are untouched and this stays a one-file diff.

## Minimal hypotheses, re-derived from the block

The branch ran under `h : IsPair p q` and `hpq : p ≠ q` and used **neither**: it
opened by deriving `hax : axis p ≠ axis q` and every later step went through `hax`.
Reading the body for what it actually consumes:

| used | from | needs `IsPair` / `p ≠ q`? |
|---|---|---|
| `h1 … h8` | `long_ne hax` | no |
| `hpq'`, `hqp` | `signedWeight_dotProduct_of_axis_ne hax` (+ `Ne.symm`) | no |
| `hval` (one per case) | `two_mul_dotProduct_corootOfPair` — no hypothesis at all | no |
| `rootOfPair_of_ne`, `reflMap_{fst,snd,opp_fst,opp_snd,of_ne}` | `long_ne` outputs | no |

So the helper is **strictly more general than the branch it replaces**:
`IsPair p q` together with `p ≠ q` implies `axis p ≠ axis q`, not conversely. The
parent recovers its case with `h.resolve_left hpq`, exactly as `signedCoweight_reflMap`
does two declarations below. Apart from `hax`, the only parameter is the `u` the
statement quantifies.

## Only the long case

The 11-line short-root case stays inline deliberately, as in #4515. Extracting both
would produce a second helper that is scaffolding rather than a named argument — the
parent would become a two-line dispatcher and the reader would have to follow two
hops to find either case.

## Naming and placement

- `signedWeight_reflMap_of_axis_ne` mirrors the merged `signedCoweight_reflMap_of_axis_ne`
  and the file's public `signedWeight_dotProduct_of_axis_ne`.
- `private`, and the hypothesis shape matches `long_ne`, the file's existing private
  helper keyed on exactly `axis p ≠ axis q`.
- Placed directly above the parent's docstring, so the file now reads
  `signedWeight_reflMap_of_axis_ne`, `signedWeight_reflMap`,
  `signedCoweight_reflMap_of_axis_ne`, `signedCoweight_reflMap` — each formula
  preceded by its own long-root case.
- The module docstring's "Main results" names only the public
  `signedWeight_reflMap`, whose statement is unchanged; the addition is private, so
  nothing there needed re-syncing.

## Notes for review

- The proof body is a **verbatim lift** — the only edit is the dedent. The signpost
  comment on the four-way case split moves with the block.
- `obtain ⟨h1, …, h8⟩ := long_ne hax` binds three names (`h2`, `h4`, `h6`) that the
  body does not use. That is unchanged from the code on `main` (and identical in
  `signedCoweight_reflMap_of_axis_ne`), kept so the destructuring stays aligned with
  `long_ne`'s eight-fold statement; narrowing it would make this more than a lift.
- Gate: module-scoped `lake build` of `B.Model` and its sole importer `B.Datum`
  (importer artifacts deleted first and confirmed regenerated), exit 0, zero warnings.

Roadmap: none
