### PR TITLE
feat: preserve connectedness and smoothness under normal products

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Properties
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
@@ -121,7 +120,6 @@ theorem productOfNormal (H : CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
       (CommHopfAlgCat.productOfNormal H I J hI) := by
   let A := CommHopfAlgCat.quotientNormalConjugation H I J hI
   apply image (CommHopfAlgCat.productMapOfNormal H I J hI)
-  rw [CommHopfAlgCat.normalSemidirectProduct_eq_coordinateHopfAlgebra]
   exact semidirectProduct (CommHopfAlgCat.quotient H I)
     (CommHopfAlgCat.quotient H J) A hIc hJc
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Properties
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
 public import TauCeti.AlgebraicGeometry.Geometrically.Connected
 
@@ -28,6 +30,9 @@ isomorphism then identifies the result with the spectrum of the tensor product.
   geometrically connected commutative Hopf algebras is geometrically connected.
 * `TauCeti.geometricallyConnectedCommHopfAlgProperty.semidirectProduct`: a semidirect product
   associated to an action of geometrically connected affine groups is geometrically connected.
+* `TauCeti.geometricallyConnectedCommHopfAlgProperty.productOfNormal`: the multiplication image
+  of a normal subgroup and another connected subgroup is geometrically connected when both
+  factors are.
 
 ## References
 
@@ -105,6 +110,20 @@ theorem semidirectProduct (H K : CommHopfAlgCat.{u} k)
   let eL := Algebra.TensorProduct.congr
     A.coordinateAlgEquiv (AlgEquiv.refl : L ≃ₐ[k] L)
   exact (PrimeSpectrum.homeomorphOfRingEquiv eL.toRingEquiv).connectedSpace_iff.mpr (h L)
+
+/-- The scheme-theoretic multiplication image of a normal geometrically connected closed affine
+subgroup and another geometrically connected closed affine subgroup is geometrically connected. -/
+theorem productOfNormal (H : CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
+    (hI : I.IsNormal)
+    (hIc : geometricallyConnectedCommHopfAlgProperty k (CommHopfAlgCat.quotient H I))
+    (hJc : geometricallyConnectedCommHopfAlgProperty k (CommHopfAlgCat.quotient H J)) :
+    geometricallyConnectedCommHopfAlgProperty k
+      (CommHopfAlgCat.productOfNormal H I J hI) := by
+  let A := CommHopfAlgCat.quotientNormalConjugation H I J hI
+  apply image (CommHopfAlgCat.productMapOfNormal H I J hI)
+  rw [CommHopfAlgCat.normalSemidirectProduct_eq_coordinateHopfAlgebra]
+  exact semidirectProduct (CommHopfAlgCat.quotient H I)
+    (CommHopfAlgCat.quotient H J) A hIc hJc
 
 end geometricallyConnectedCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
 import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Properties
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
 public import TauCeti.AlgebraicGeometry.Geometrically.Connected
@@ -121,8 +121,10 @@ theorem productOfNormal (H : CommHopfAlgCat.{u} k) (I J : HopfIdeal k H)
       (CommHopfAlgCat.productOfNormal H I J hI) := by
   let A := CommHopfAlgCat.quotientNormalConjugation H I J hI
   apply image (CommHopfAlgCat.productMapOfNormal H I J hI)
-  exact semidirectProduct (CommHopfAlgCat.quotient H I)
-    (CommHopfAlgCat.quotient H J) A hIc hJc
+  exact (geometricallyConnectedCommHopfAlgProperty k).prop_of_iso
+    (CommHopfAlgCat.normalSemidirectProductIso H I J hI).symm
+    (semidirectProduct (CommHopfAlgCat.quotient H I)
+      (CommHopfAlgCat.quotient H J) A hIc hJc)
 
 end geometricallyConnectedCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Properties
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Properties
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected
 public import TauCeti.AlgebraicGeometry.Geometrically.Connected
 

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/Product.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Properties
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Connected

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Smooth
+
+/-!
+# Smoothness of products of affine groups
+
+The coordinate algebra of a direct or semidirect product of affine groups is the tensor product
+of the two coordinate algebras. Smoothness is preserved by base change and composition, so the
+product is smooth when both factors are. Smoothness then descends to a scheme-theoretic image in
+a finite-type ambient affine group.
+
+## Main declarations
+
+* `TauCeti.smoothCommHopfAlgProperty.semidirectProduct`: a semidirect product of smooth affine
+  groups is smooth.
+* `TauCeti.smoothCommHopfAlgProperty.productOfNormal`: the multiplication image of a normal
+  smooth subgroup and another smooth subgroup is smooth in a finite-type ambient affine group.
+
+This supplies the smoothness part of binary-product closure in Layer 5, "The unipotent radical",
+of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace smoothCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+
+/-- The semidirect product associated to an action of smooth affine groups is smooth. -/
+theorem semidirectProduct (H K : CommHopfAlgCat.{u} k)
+    (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H))
+    (hH : smoothCommHopfAlgProperty k H)
+    (hK : smoothCommHopfAlgProperty k K) :
+    smoothCommHopfAlgProperty k A.coordinateHopfAlgebra := by
+  rw [smoothCommHopfAlgProperty_iff] at hH hK ⊢
+  let _ : Algebra.Smooth k H := hH
+  let _ : Algebra.Smooth k K := hK
+  let _ : Algebra.Smooth H (H ⊗[k] K) := Algebra.Smooth.baseChange k K H
+  let _ : Algebra.Smooth k (H ⊗[k] K) := Algebra.Smooth.comp k H _
+  -- Transport the inferred tensor-product smoothness across the coordinate-algebra equivalence.
+  exact Algebra.Smooth.of_equiv A.coordinateAlgEquiv.symm
+
+/-- The scheme-theoretic multiplication image of a normal smooth closed affine subgroup and
+another smooth closed affine subgroup is smooth when the ambient affine group is finite type. -/
+theorem productOfNormal (H : CommHopfAlgCat.{u} k) [Algebra.FiniteType k H]
+    (I J : HopfIdeal k H) (hI : I.IsNormal)
+    (hIs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H I))
+    (hJs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H J)) :
+    smoothCommHopfAlgProperty k (CommHopfAlgCat.productOfNormal H I J hI) := by
+  let A := CommHopfAlgCat.quotientNormalConjugation H I J hI
+  apply image (CommHopfAlgCat.productMapOfNormal H I J hI)
+  rw [CommHopfAlgCat.normalSemidirectProduct_eq_coordinateHopfAlgebra]
+  exact semidirectProduct (CommHopfAlgCat.quotient H I)
+    (CommHopfAlgCat.quotient H J) A hIs hJs
+
+end smoothCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
@@ -7,7 +7,8 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Smooth
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Smooth
 
 /-!
 # Smoothness of products of affine groups

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Smooth
 
@@ -41,21 +40,23 @@ noncomputable section
 
 namespace smoothCommHopfAlgProperty
 
-variable {k : Type u} [Field k]
+variable {R : Type u} [CommRing R]
 
 /-- The semidirect product associated to an action of smooth affine groups is smooth. -/
-theorem semidirectProduct (H K : CommHopfAlgCat.{u} k)
+theorem semidirectProduct (H K : CommHopfAlgCat.{u} R)
     (A : GrpObj.Action (CommHopfAlgCat.grpObj K) (CommHopfAlgCat.grpObj H))
-    (hH : smoothCommHopfAlgProperty k H)
-    (hK : smoothCommHopfAlgProperty k K) :
-    smoothCommHopfAlgProperty k A.coordinateHopfAlgebra := by
+    (hH : smoothCommHopfAlgProperty R H)
+    (hK : smoothCommHopfAlgProperty R K) :
+    smoothCommHopfAlgProperty R A.coordinateHopfAlgebra := by
   rw [smoothCommHopfAlgProperty_iff] at hH hK ⊢
-  let _ : Algebra.Smooth k H := hH
-  let _ : Algebra.Smooth k K := hK
-  let _ : Algebra.Smooth H (H ⊗[k] K) := Algebra.Smooth.baseChange k K H
-  let _ : Algebra.Smooth k (H ⊗[k] K) := Algebra.Smooth.comp k H _
+  let _ : Algebra.Smooth R H := hH
+  let _ : Algebra.Smooth R K := hK
+  let _ : Algebra.Smooth H (H ⊗[R] K) := Algebra.Smooth.baseChange R K H
+  let _ : Algebra.Smooth R (H ⊗[R] K) := Algebra.Smooth.comp R H _
   -- Transport the inferred tensor-product smoothness across the coordinate-algebra equivalence.
   exact Algebra.Smooth.of_equiv A.coordinateAlgEquiv.symm
+
+variable {k : Type u} [Field k]
 
 /-- The scheme-theoretic multiplication image of a normal smooth closed affine subgroup and
 another smooth closed affine subgroup is smooth when the ambient affine group is finite type. -/
@@ -66,7 +67,6 @@ theorem productOfNormal (H : CommHopfAlgCat.{u} k) [Algebra.FiniteType k H]
     smoothCommHopfAlgProperty k (CommHopfAlgCat.productOfNormal H I J hI) := by
   let A := CommHopfAlgCat.quotientNormalConjugation H I J hI
   apply image (CommHopfAlgCat.productMapOfNormal H I J hI)
-  rw [CommHopfAlgCat.normalSemidirectProduct_eq_coordinateHopfAlgebra]
   exact semidirectProduct (CommHopfAlgCat.quotient H I)
     (CommHopfAlgCat.quotient H J) A hIs hJs
 

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
 import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Smooth
 
@@ -69,8 +69,10 @@ theorem productOfNormal (H : CommHopfAlgCat.{u} k) [Algebra.FiniteType k H]
     smoothCommHopfAlgProperty k (CommHopfAlgCat.productOfNormal H I J hI) := by
   let A := CommHopfAlgCat.quotientNormalConjugation H I J hI
   apply image (CommHopfAlgCat.productMapOfNormal H I J hI)
-  exact semidirectProduct (CommHopfAlgCat.quotient H I)
-    (CommHopfAlgCat.quotient H J) A hIs hJs
+  exact (smoothCommHopfAlgProperty k).prop_of_iso
+    (CommHopfAlgCat.normalSemidirectProductIso H I J hI).symm
+    (semidirectProduct (CommHopfAlgCat.quotient H I)
+      (CommHopfAlgCat.quotient H J) A hIs hJs)
 
 end smoothCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SemidirectProduct
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Smooth
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product.lean
@@ -84,16 +84,14 @@ theorem smooth_productOfNormal
     (hJ : IsUnipotentRadicalCandidate H J) :
     smoothCommHopfAlgProperty k
       (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) := by
-  let QI := FiniteTypeCommHopfAlgCat.quotient H I
-  let QJ := FiniteTypeCommHopfAlgCat.quotient H J
-  -- Each finite-type quotient wrapper has `.obj` definitionally equal to the corresponding
-  -- `CommHopfAlgCat.quotient` used by `smoothCommHopfAlgProperty.productOfNormal`.
-  have hIs : smoothCommHopfAlgProperty k QI.obj :=
-    (smoothCommHopfAlgProperty_iff QI.obj).mpr
-      ((smoothUnipotentCommHopfAlgProperty_iff k QI).mp hI.smoothUnipotent |>.1)
-  have hJs : smoothCommHopfAlgProperty k QJ.obj :=
-    (smoothCommHopfAlgProperty_iff QJ.obj).mpr
-      ((smoothUnipotentCommHopfAlgProperty_iff k QJ).mp hJ.smoothUnipotent |>.1)
+  have hIs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H.obj I) :=
+    (smoothCommHopfAlgProperty_iff (CommHopfAlgCat.quotient H.obj I)).mpr
+      ((smoothUnipotentCommHopfAlgProperty_iff k
+        (FiniteTypeCommHopfAlgCat.quotient H I)).mp hI.smoothUnipotent |>.1)
+  have hJs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H.obj J) :=
+    (smoothCommHopfAlgProperty_iff (CommHopfAlgCat.quotient H.obj J)).mpr
+      ((smoothUnipotentCommHopfAlgProperty_iff k
+        (FiniteTypeCommHopfAlgCat.quotient H J)).mp hJ.smoothUnipotent |>.1)
   exact smoothCommHopfAlgProperty.productOfNormal H.obj I J hI.isNormal hIs hJs
 
 end HopfIdeal.IsUnipotentRadicalCandidate

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Basic
 import TauCeti.Algebra.AlgebraicGroup.Connected.Product
-import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Smooth
+import TauCeti.Algebra.AlgebraicGroup.Smooth.Product
 
 /-!
 # Geometric properties of products of unipotent-radical candidates
@@ -20,8 +20,8 @@ is the closed subgroup represented by `CommHopfAlgCat.productOfNormal`.
 
 This file proves two of the geometric properties needed to show that this image is again a
 unipotent-radical candidate. The semidirect-product source is geometrically connected, because
-its underlying scheme is the direct product of the two connected factors, and it is smooth
-unipotent. Geometric connectedness and smoothness then descend to the scheme-theoretic image.
+its underlying scheme is the direct product of the two connected factors, and it is smooth.
+Geometric connectedness and smoothness then descend to the scheme-theoretic image.
 
 Normality and containment of the factors are separate coordinate calculations. Geometric
 unipotence of the image additionally needs faithful flatness of a homomorphism of affine groups
@@ -71,17 +71,12 @@ theorem geometricallyConnected_productOfNormal
     (hJ : IsUnipotentRadicalCandidate H J) :
     geometricallyConnectedCommHopfAlgProperty k
       (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) := by
-  let A := CommHopfAlgCat.quotientNormalConjugation H.obj I J hI.isNormal
-  apply geometricallyConnectedCommHopfAlgProperty.image
-    (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal)
-  exact geometricallyConnectedCommHopfAlgProperty.semidirectProduct
-    (FiniteTypeCommHopfAlgCat.quotient H I).obj
-    (FiniteTypeCommHopfAlgCat.quotient H J).obj A
+  exact geometricallyConnectedCommHopfAlgProperty.productOfNormal H.obj I J hI.isNormal
     hI.geometricallyConnected hJ.geometricallyConnected
 
 /-- The scheme-theoretic multiplication image of two unipotent-radical candidates is smooth.
 
-The conjugation semidirect product is smooth unipotent because both factors are. Its smoothness
+The conjugation semidirect product is smooth because both factors are. Its smoothness
 descends to the scheme-theoretic image inside the finite-type ambient group. This result does not
 assert unipotence of the image. -/
 theorem smooth_productOfNormal
@@ -91,23 +86,15 @@ theorem smooth_productOfNormal
       (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) := by
   let QI := FiniteTypeCommHopfAlgCat.quotient H I
   let QJ := FiniteTypeCommHopfAlgCat.quotient H J
-  let A := CommHopfAlgCat.quotientNormalConjugation H.obj I J hI.isNormal
-  have hsmoothI :=
-    (smoothUnipotentCommHopfAlgProperty_iff k QI).mp hI.smoothUnipotent |>.1
-  have hsmoothJ :=
-    (smoothUnipotentCommHopfAlgProperty_iff k QJ).mp hJ.smoothUnipotent |>.1
-  let smoothI : Algebra.Smooth k QI := hsmoothI
-  let smoothJ : Algebra.Smooth k QJ := hsmoothJ
-  let smoothOverI : Algebra.Smooth QI ((QI : Type u) ⊗[k] (QJ : Type u)) :=
-    @Algebra.Smooth.baseChange k _ QJ QI _ _ _ _ smoothJ
-  let smoothProduct : Algebra.Smooth k ((QI : Type u) ⊗[k] (QJ : Type u)) :=
-    @Algebra.Smooth.comp k _ QI ((QI : Type u) ⊗[k] (QJ : Type u))
-      _ _ _ _ _ _ smoothI smoothOverI
-  have hsourceSmooth : smoothCommHopfAlgProperty k A.coordinateHopfAlgebra :=
-    (smoothCommHopfAlgProperty_iff A.coordinateHopfAlgebra).mpr
-      (Algebra.Smooth.of_equiv A.coordinateAlgEquiv.symm)
-  exact smoothCommHopfAlgProperty.image
-    (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal) hsourceSmooth
+  -- Each finite-type quotient wrapper has `.obj` definitionally equal to the corresponding
+  -- `CommHopfAlgCat.quotient` used by `smoothCommHopfAlgProperty.productOfNormal`.
+  have hIs : smoothCommHopfAlgProperty k QI.obj :=
+    (smoothCommHopfAlgProperty_iff QI.obj).mpr
+      ((smoothUnipotentCommHopfAlgProperty_iff k QI).mp hI.smoothUnipotent |>.1)
+  have hJs : smoothCommHopfAlgProperty k QJ.obj :=
+    (smoothCommHopfAlgProperty_iff QJ.obj).mpr
+      ((smoothUnipotentCommHopfAlgProperty_iff k QJ).mp hJ.smoothUnipotent |>.1)
+  exact smoothCommHopfAlgProperty.productOfNormal H.obj I J hI.isNormal hIs hJs
 
 end HopfIdeal.IsUnipotentRadicalCandidate
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Basic
 import TauCeti.Algebra.AlgebraicGroup.Connected.Product
 import TauCeti.Algebra.AlgebraicGroup.Smooth.Product

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Basic
+import TauCeti.Algebra.AlgebraicGroup.Connected.Product
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Smooth
+
+/-!
+# Geometric properties of products of unipotent-radical candidates
+
+Let `I` and `J` cut out connected normal smooth unipotent closed subgroups of a finite-type
+affine group. Since `I` is normal, multiplication on the two subgroups is a homomorphism after
+their product is equipped with the conjugation semidirect-product law. Its scheme-theoretic image
+is the closed subgroup represented by `CommHopfAlgCat.productOfNormal`.
+
+This file proves two of the geometric properties needed to show that this image is again a
+unipotent-radical candidate. The semidirect-product source is geometrically connected, because
+its underlying scheme is the direct product of the two connected factors, and it is smooth
+unipotent. Geometric connectedness and smoothness then descend to the scheme-theoretic image.
+
+Normality and containment of the factors are separate coordinate calculations. Geometric
+unipotence of the image additionally needs faithful flatness of a homomorphism of affine groups
+onto its scheme-theoretic image; no such hypothesis is hidden in the results below.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate.geometricallyConnected_productOfNormal`:
+  the multiplication image of two candidates is geometrically connected.
+* `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate.smooth_productOfNormal`: the multiplication
+  image of two candidates is smooth.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a, 6.a.
+* A. Borel, *Linear Algebraic Groups*, Proposition 14.4 and Section 11.21.
+
+This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap. It supplies the
+connectedness and smoothness parts of binary-product closure for connected normal smooth
+unipotent closed subgroups.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal.IsUnipotentRadicalCandidate
+
+variable {k : Type u} [Field k]
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
+
+/-- The scheme-theoretic multiplication image of two unipotent-radical candidates is
+geometrically connected.
+
+The conjugation semidirect product has the tensor-product scheme underlying it, so it is
+geometrically connected when both quotient subgroups are. Geometric connectedness then descends
+to its scheme-theoretic image in the ambient group. -/
+theorem geometricallyConnected_productOfNormal
+    (hI : IsUnipotentRadicalCandidate H I)
+    (hJ : IsUnipotentRadicalCandidate H J) :
+    geometricallyConnectedCommHopfAlgProperty k
+      (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) := by
+  let A := CommHopfAlgCat.quotientNormalConjugation H.obj I J hI.isNormal
+  apply geometricallyConnectedCommHopfAlgProperty.image
+    (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal)
+  exact geometricallyConnectedCommHopfAlgProperty.semidirectProduct
+    (FiniteTypeCommHopfAlgCat.quotient H I).obj
+    (FiniteTypeCommHopfAlgCat.quotient H J).obj A
+    hI.geometricallyConnected hJ.geometricallyConnected
+
+/-- The scheme-theoretic multiplication image of two unipotent-radical candidates is smooth.
+
+The conjugation semidirect product is smooth unipotent because both factors are. Its smoothness
+descends to the scheme-theoretic image inside the finite-type ambient group. This result does not
+assert unipotence of the image. -/
+theorem smooth_productOfNormal
+    (hI : IsUnipotentRadicalCandidate H I)
+    (hJ : IsUnipotentRadicalCandidate H J) :
+    smoothCommHopfAlgProperty k
+      (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) := by
+  let QI := FiniteTypeCommHopfAlgCat.quotient H I
+  let QJ := FiniteTypeCommHopfAlgCat.quotient H J
+  let A := CommHopfAlgCat.quotientNormalConjugation H.obj I J hI.isNormal
+  have hsmoothI :=
+    (smoothUnipotentCommHopfAlgProperty_iff k QI).mp hI.smoothUnipotent |>.1
+  have hsmoothJ :=
+    (smoothUnipotentCommHopfAlgProperty_iff k QJ).mp hJ.smoothUnipotent |>.1
+  let smoothI : Algebra.Smooth k QI := hsmoothI
+  let smoothJ : Algebra.Smooth k QJ := hsmoothJ
+  let smoothOverI : Algebra.Smooth QI ((QI : Type u) ⊗[k] (QJ : Type u)) :=
+    @Algebra.Smooth.baseChange k _ QJ QI _ _ _ _ smoothJ
+  let smoothProduct : Algebra.Smooth k ((QI : Type u) ⊗[k] (QJ : Type u)) :=
+    @Algebra.Smooth.comp k _ QI ((QI : Type u) ⊗[k] (QJ : Type u))
+      _ _ _ _ _ _ smoothI smoothOverI
+  have hsourceSmooth : smoothCommHopfAlgProperty k A.coordinateHopfAlgebra :=
+    (smoothCommHopfAlgProperty_iff A.coordinateHopfAlgebra).mpr
+      (Algebra.Smooth.of_equiv A.coordinateAlgEquiv.symm)
+  exact smoothCommHopfAlgProperty.image
+    (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal) hsourceSmooth
+
+end HopfIdeal.IsUnipotentRadicalCandidate
+
+end
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the scheme-theoretic multiplication image of two unipotent-radical candidates is geometrically connected and smooth. The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5 milestone “The unipotent radical `R_u(G)`,” specifically the binary-product closure step for connected normal smooth unipotent closed subgroups. This is the most effective current step because `main` now contains both geometric connectedness and smooth unipotence of the conjugation semidirect-product source, together with descent of connectedness and smoothness to scheme-theoretic images, while the complementary open PR #4579 supplies containment and normality of the same multiplication image.

The new candidate-level theorems compose those general results without unfolding the multiplication-image construction. `geometricallyConnected_productOfNormal` applies connectedness of semidirect products and then connectedness descent to the image. `smooth_productOfNormal` obtains smoothness of the tensor-product coordinate algebra by base change and composition, transports it across the semidirect product’s coordinate-algebra equivalence, and then applies smoothness descent to the image. The second theorem intentionally makes no unipotence claim: proving geometric unipotence of the image still requires the explicit faithfully-flat-onto-image input identified by the existing image API.

After this PR, the Layer 5 binary-product step still needs geometric unipotence of the multiplication image and the containment/normality work in #4579 to land; the milestone then needs the maximal-dimension argument to identify the resulting candidate as the greatest one.

Add `TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product.lean` (116 lines). The implementation reuses Tau Ceti’s semidirect-product connectedness, coordinate-algebra equivalence, and general connected/smooth image theorems; no Mathlib infrastructure is vendored. The mathematical organization follows Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§5.a, 6.a, and Borel, *Linear Algebraic Groups*, Proposition 14.4 and §11.21, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"normal-product-image-connected-smooth"}-->

🤖 Prepared with Codex
