### PR TITLE
feat: the Laurent coefficient ring acting on graded K₀

### DIFF
--- a/TauCeti/Algebra/Polynomial/Laurent.lean
+++ b/TauCeti/Algebra/Polynomial/Laurent.lean
@@ -24,15 +24,15 @@ for an arbitrary semiring `A` and is the unique algebra map with the prescribed 
 Consequently `TauCeti.laurentEvalEquiv` identifies the units of `A` with the `R`-algebra maps out of
 `R[T;T⁻¹]`: the Laurent polynomial ring is the free `R`-algebra on one invertible generator.
 
-The module-theoretic use is `TauCeti.laurentTAut`: on any `ℤ[T;T⁻¹]`-module, multiplication by `T`
+The module-theoretic use is `TauCeti.laurentTAut`: on any `R[T;T⁻¹]`-module, multiplication by `T`
 -- written `q` in the graded `K`-theory literature -- is an automorphism of the underlying additive
-group, and that automorphism is what a shift-compatible invariant is compared against.
+monoid, and that automorphism is what a shift-compatible invariant is compared against.
 
 ## Main definitions
 
 * `TauCeti.laurentEval`: evaluation of a Laurent polynomial at a unit of an `R`-algebra.
 * `TauCeti.laurentEvalEquiv`: the units of `A` are the `R`-algebra maps `R[T;T⁻¹] →ₐ[R] A`.
-* `TauCeti.laurentTAut`: multiplication by `T` on a `ℤ[T;T⁻¹]`-module, as an additive
+* `TauCeti.laurentTAut`: multiplication by `T` on an `R[T;T⁻¹]`-module, as an additive
   automorphism.
 
 ## Main results
@@ -136,31 +136,28 @@ end Eval
 
 section TAut
 
-variable (N : Type*) [AddCommGroup N] [Module (LaurentPolynomial ℤ) N]
+variable (R : Type*) [Semiring R] (N : Type*) [AddCommMonoid N]
+  [Module (LaurentPolynomial R) N]
 
-/-- **Multiplication by the variable on a `ℤ[T;T⁻¹]`-module**, as an automorphism of the
-underlying additive group.  In the graded `K`-theory notation the variable is `q`, so this is the
+/-- **Multiplication by the variable on an `R[T;T⁻¹]`-module**, as an automorphism of the
+underlying additive monoid.  In the graded `K`-theory notation the variable is `q`, so this is the
 operator `x ↦ q • x` against which a shift-compatible invariant is compared. -/
 noncomputable def laurentTAut : AddAut N where
-  toFun x := (T 1 : LaurentPolynomial ℤ) • x
-  invFun x := (T (-1) : LaurentPolynomial ℤ) • x
+  toFun x := (T 1 : LaurentPolynomial R) • x
+  invFun x := (T (-1) : LaurentPolynomial R) • x
   left_inv x := by
-    change (T (-1) : LaurentPolynomial ℤ) • (T 1 : LaurentPolynomial ℤ) • x = x
-    rw [smul_smul, ← T_add]
-    simp
+    simp only [smul_smul, ← T_add, neg_add_cancel, T_zero, one_smul]
   right_inv x := by
-    change (T 1 : LaurentPolynomial ℤ) • (T (-1) : LaurentPolynomial ℤ) • x = x
-    rw [smul_smul, ← T_add]
-    simp
+    simp only [smul_smul, ← T_add, add_neg_cancel, T_zero, one_smul]
   map_add' _ _ := smul_add _ _ _
 
 @[simp]
-lemma laurentTAut_apply (x : N) : laurentTAut N x = (T 1 : LaurentPolynomial ℤ) • x :=
+lemma laurentTAut_apply (x : N) : laurentTAut R N x = (T 1 : LaurentPolynomial R) • x :=
   (rfl)
 
 @[simp]
 lemma laurentTAut_symm_apply (x : N) :
-    (laurentTAut N).symm x = (T (-1) : LaurentPolynomial ℤ) • x :=
+    (laurentTAut R N).symm x = (T (-1) : LaurentPolynomial R) • x :=
   (rfl)
 
 end TAut
@@ -170,14 +167,13 @@ section Constants
 variable {N : Type*} [AddCommGroup N] [Module (LaurentPolynomial ℤ) N]
 
 /-- **A constant Laurent polynomial acts by the integer scalar multiplication** of the underlying
-abelian group of a `ℤ[T;T⁻¹]`-module. -/
+abelian group of a `ℤ[T;T⁻¹]`-module.
+
+Not `@[simp]`: `LaurentPolynomial.C a` is not in simp-normal form, because `eq_intCast` rewrites
+the ring homomorphism `C : ℤ →+* ℤ[T;T⁻¹]` to the integer cast; the normal form of the statement
+is Mathlib's own `Int.cast_smul_eq_zsmul`. -/
 lemma laurentC_smul (a : ℤ) (x : N) : (C a : LaurentPolynomial ℤ) • x = a • x := by
   rw [C_eq_algebraMap, ← Int.cast_smul_eq_zsmul (LaurentPolynomial ℤ) a x]
-  congr 1
-
-/-- Integer scalar multiplication on `ℤ[T;T⁻¹]` is multiplication by a constant. -/
-lemma laurent_zsmul_eq_C_mul (a : ℤ) (p : LaurentPolynomial ℤ) : a • p = C a * p := by
-  rw [zsmul_eq_mul]
   congr 1
 
 end Constants

--- a/TauCeti/Algebra/Polynomial/Laurent.lean
+++ b/TauCeti/Algebra/Polynomial/Laurent.lean
@@ -40,7 +40,8 @@ monoid, and that automorphism is what a shift-compatible invariant is compared a
 * `TauCeti.laurentEval_unique`: an algebra map out of `R[T;T⁻¹]` is determined by its value at `T`.
 * `TauCeti.laurentEval_eq_eval₂`: over a commutative target, this evaluation is Mathlib's
   `LaurentPolynomial.eval₂`.
-* `TauCeti.laurentC_smul`: a constant Laurent polynomial acts by integer scalar multiplication.
+* `TauCeti.laurentPolynomialC_smul`: a constant Laurent polynomial acts by integer scalar
+  multiplication.
 
 ## References
 
@@ -67,16 +68,9 @@ targets are endomorphism rings.  The construction is the universal property of t
 noncomputable def laurentEval (u : Aˣ) : R[T;T⁻¹] →ₐ[R] A :=
   AddMonoidAlgebra.lift R A ℤ ((Units.coeHom A).comp (zpowersHom Aˣ u))
 
-/-- The defining formula for evaluation at a unit, as the lift of the integer-power monoid
-homomorphism through the universal property of the group algebra. -/
-lemma laurentEval_def (u : Aˣ) :
-    laurentEval (R := R) u =
-      AddMonoidAlgebra.lift R A ℤ ((Units.coeHom A).comp (zpowersHom Aˣ u)) :=
-  (rfl)
-
 @[simp]
 lemma laurentEval_T (u : Aˣ) (n : ℤ) : laurentEval (R := R) u (T n) = ((u ^ n : Aˣ) : A) := by
-  rw [laurentEval_def]
+  rw [laurentEval]
   simp only [LaurentPolynomial.T, AddMonoidAlgebra.lift_single, one_smul]
   rfl
 
@@ -119,6 +113,7 @@ lemma laurentEvalEquiv_symm_apply (f : R[T;T⁻¹] →ₐ[R] A) :
   (rfl)
 
 /-- Evaluation at a unit is natural in the target algebra. -/
+@[simp]
 theorem comp_laurentEval {B : Type*} [Semiring B] [Algebra R B] (g : A →ₐ[R] B) (u : Aˣ) :
     g.comp (laurentEval u) = laurentEval (Units.map (g : A →* B) u) :=
   laurentEval_unique _ _ <| by simp
@@ -172,7 +167,8 @@ abelian group of a `ℤ[T;T⁻¹]`-module.
 Not `@[simp]`: `LaurentPolynomial.C a` is not in simp-normal form, because `eq_intCast` rewrites
 the ring homomorphism `C : ℤ →+* ℤ[T;T⁻¹]` to the integer cast; the normal form of the statement
 is Mathlib's own `Int.cast_smul_eq_zsmul`. -/
-lemma laurentC_smul (a : ℤ) (x : N) : (C a : LaurentPolynomial ℤ) • x = a • x := by
+lemma laurentPolynomialC_smul (a : ℤ) (x : N) :
+    (C a : LaurentPolynomial ℤ) • x = a • x := by
   rw [C_eq_algebraMap, ← Int.cast_smul_eq_zsmul (LaurentPolynomial ℤ) a x]
   congr 1
 

--- a/TauCeti/Algebra/Polynomial/Laurent.lean
+++ b/TauCeti/Algebra/Polynomial/Laurent.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.MonoidAlgebra.Basic
+public import Mathlib.Algebra.Polynomial.Laurent
+public import Mathlib.Data.Int.Cast.Lemmas
+
+/-!
+# Evaluating a Laurent polynomial at a unit of a not necessarily commutative algebra
+
+Mathlib's `LaurentPolynomial.eval₂` substitutes a unit of a *commutative* semiring into a Laurent
+polynomial.  The Laurent coefficient ring of graded `K`-theory has to act on abelian groups, so it
+has to be substituted into endomorphism rings, which are not commutative.  This file supplies that
+evaluation.
+
+For a unit `u` of an `R`-algebra `A`, `TauCeti.laurentEval u : R[T;T⁻¹] →ₐ[R] A` is the algebra map
+sending `T` to `u` and `T⁻¹` to `u⁻¹`.  It is the algebra map attached by
+`AddMonoidAlgebra.lift` to the monoid homomorphism `n ↦ uⁿ` out of `Multiplicative ℤ`, so it exists
+for an arbitrary semiring `A` and is the unique algebra map with the prescribed value at `T`.
+Consequently `TauCeti.laurentEvalEquiv` identifies the units of `A` with the `R`-algebra maps out of
+`R[T;T⁻¹]`: the Laurent polynomial ring is the free `R`-algebra on one invertible generator.
+
+The module-theoretic use is `TauCeti.laurentTAut`: on any `ℤ[T;T⁻¹]`-module, multiplication by `T`
+-- written `q` in the graded `K`-theory literature -- is an automorphism of the underlying additive
+group, and that automorphism is what a shift-compatible invariant is compared against.
+
+## Main definitions
+
+* `TauCeti.laurentEval`: evaluation of a Laurent polynomial at a unit of an `R`-algebra.
+* `TauCeti.laurentEvalEquiv`: the units of `A` are the `R`-algebra maps `R[T;T⁻¹] →ₐ[R] A`.
+* `TauCeti.laurentTAut`: multiplication by `T` on a `ℤ[T;T⁻¹]`-module, as an additive
+  automorphism.
+
+## Main results
+
+* `TauCeti.laurentEval_unique`: an algebra map out of `R[T;T⁻¹]` is determined by its value at `T`.
+* `TauCeti.laurentEval_eq_eval₂`: over a commutative target, this evaluation is Mathlib's
+  `LaurentPolynomial.eval₂`.
+* `TauCeti.laurentC_smul`: a constant Laurent polynomial acts by integer scalar multiplication.
+
+## References
+
+* `TauCetiRoadmap/GrothendieckEulerForms/README.md`, Layer 6, which fixes `ℤ[q,q⁻¹]`,
+  represented by `LaurentPolynomial ℤ`, as the coefficient ring of the graded theory.
+-/
+
+public section
+
+namespace TauCeti
+
+open LaurentPolynomial
+
+section Eval
+
+variable {R : Type*} [CommSemiring R] {A : Type*} [Semiring A] [Algebra R A]
+
+/-- **Evaluation of a Laurent polynomial at a unit** `u` of an `R`-algebra `A`: the `R`-algebra
+map `R[T;T⁻¹] →ₐ[R] A` sending `T` to `u`, hence `T⁻¹` to `u⁻¹`.
+
+Unlike `LaurentPolynomial.eval₂` this does not ask `A` to be commutative, because the intended
+targets are endomorphism rings.  The construction is the universal property of the group algebra
+`R[ℤ]`: an integer power of a unit is a monoid homomorphism out of `Multiplicative ℤ`. -/
+noncomputable def laurentEval (u : Aˣ) : R[T;T⁻¹] →ₐ[R] A :=
+  AddMonoidAlgebra.lift R A ℤ ((Units.coeHom A).comp (zpowersHom Aˣ u))
+
+/-- The defining formula for evaluation at a unit, as the lift of the integer-power monoid
+homomorphism through the universal property of the group algebra. -/
+lemma laurentEval_def (u : Aˣ) :
+    laurentEval (R := R) u =
+      AddMonoidAlgebra.lift R A ℤ ((Units.coeHom A).comp (zpowersHom Aˣ u)) :=
+  (rfl)
+
+@[simp]
+lemma laurentEval_T (u : Aˣ) (n : ℤ) : laurentEval (R := R) u (T n) = ((u ^ n : Aˣ) : A) := by
+  rw [laurentEval_def]
+  simp only [LaurentPolynomial.T, AddMonoidAlgebra.lift_single, one_smul]
+  rfl
+
+@[simp]
+lemma laurentEval_C (u : Aˣ) (r : R) : laurentEval u (C r) = algebraMap R A r := by
+  rw [C_eq_algebraMap]
+  exact (laurentEval u).commutes r
+
+/-- The generator `T` evaluates to the chosen unit. -/
+lemma laurentEval_T_one (u : Aˣ) : laurentEval (R := R) u (T 1) = (u : A) := by
+  simp
+
+/-- **An `R`-algebra map out of `R[T;T⁻¹]` is determined by its value at `T`.** -/
+theorem laurentEval_unique (u : Aˣ) (f : R[T;T⁻¹] →ₐ[R] A) (hf : f (T 1) = (u : A)) :
+    f = laurentEval u :=
+  (AddMonoidAlgebra.lift R A ℤ).symm.injective <|
+    MonoidHom.ext_mint <| by
+      rw [AddMonoidAlgebra.lift_symm_apply, AddMonoidAlgebra.lift_symm_apply]
+      exact hf.trans (laurentEval_T_one u).symm
+
+/-- **The Laurent polynomial ring is the free `R`-algebra on one invertible generator**: its
+`R`-algebra maps to `A` are exactly the units of `A`, through evaluation at `T`. -/
+noncomputable def laurentEvalEquiv : Aˣ ≃ (R[T;T⁻¹] →ₐ[R] A) where
+  toFun := laurentEval
+  invFun f :=
+    { val := f (T 1)
+      inv := f (T (-1))
+      val_inv := by rw [← map_mul, ← T_add]; simp
+      inv_val := by rw [← map_mul, ← T_add]; simp }
+  left_inv u := Units.ext <| by simp
+  right_inv f := (laurentEval_unique _ f rfl).symm
+
+@[simp]
+lemma laurentEvalEquiv_apply (u : Aˣ) : laurentEvalEquiv (R := R) u = laurentEval u :=
+  (rfl)
+
+@[simp]
+lemma laurentEvalEquiv_symm_apply (f : R[T;T⁻¹] →ₐ[R] A) :
+    ((laurentEvalEquiv.symm f : Aˣ) : A) = f (T 1) :=
+  (rfl)
+
+/-- Evaluation at a unit is natural in the target algebra. -/
+theorem comp_laurentEval {B : Type*} [Semiring B] [Algebra R B] (g : A →ₐ[R] B) (u : Aˣ) :
+    g.comp (laurentEval u) = laurentEval (Units.map (g : A →* B) u) :=
+  laurentEval_unique _ _ <| by simp
+
+/-- **Over a commutative target this is Mathlib's `LaurentPolynomial.eval₂`.**  The two
+constructions are separate only because `LaurentPolynomial.eval₂` is built by localization and so
+needs a commutative codomain. -/
+theorem laurentEval_eq_eval₂ {S : Type*} [CommSemiring S] [Algebra R S] (u : Sˣ)
+    (p : R[T;T⁻¹]) : laurentEval u p = eval₂ (algebraMap R S) u p := by
+  induction p using LaurentPolynomial.induction_on' with
+  | add p q hp hq => simp [hp, hq]
+  | C_mul_T n a => simp
+
+end Eval
+
+section TAut
+
+variable (N : Type*) [AddCommGroup N] [Module (LaurentPolynomial ℤ) N]
+
+/-- **Multiplication by the variable on a `ℤ[T;T⁻¹]`-module**, as an automorphism of the
+underlying additive group.  In the graded `K`-theory notation the variable is `q`, so this is the
+operator `x ↦ q • x` against which a shift-compatible invariant is compared. -/
+noncomputable def laurentTAut : AddAut N where
+  toFun x := (T 1 : LaurentPolynomial ℤ) • x
+  invFun x := (T (-1) : LaurentPolynomial ℤ) • x
+  left_inv x := by
+    change (T (-1) : LaurentPolynomial ℤ) • (T 1 : LaurentPolynomial ℤ) • x = x
+    rw [smul_smul, ← T_add]
+    simp
+  right_inv x := by
+    change (T 1 : LaurentPolynomial ℤ) • (T (-1) : LaurentPolynomial ℤ) • x = x
+    rw [smul_smul, ← T_add]
+    simp
+  map_add' _ _ := smul_add _ _ _
+
+@[simp]
+lemma laurentTAut_apply (x : N) : laurentTAut N x = (T 1 : LaurentPolynomial ℤ) • x :=
+  (rfl)
+
+@[simp]
+lemma laurentTAut_symm_apply (x : N) :
+    (laurentTAut N).symm x = (T (-1) : LaurentPolynomial ℤ) • x :=
+  (rfl)
+
+end TAut
+
+section Constants
+
+variable {N : Type*} [AddCommGroup N] [Module (LaurentPolynomial ℤ) N]
+
+/-- **A constant Laurent polynomial acts by the integer scalar multiplication** of the underlying
+abelian group of a `ℤ[T;T⁻¹]`-module. -/
+lemma laurentC_smul (a : ℤ) (x : N) : (C a : LaurentPolynomial ℤ) • x = a • x := by
+  rw [C_eq_algebraMap, ← Int.cast_smul_eq_zsmul (LaurentPolynomial ℤ) a x]
+  congr 1
+
+/-- Integer scalar multiplication on `ℤ[T;T⁻¹]` is multiplication by a constant. -/
+lemma laurent_zsmul_eq_C_mul (a : ℤ) (p : LaurentPolynomial ℤ) : a • p = C a * p := by
+  rw [zsmul_eq_mul]
+  congr 1
+
+end Constants
+
+end TauCeti

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Laurent.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Laurent.lean
@@ -28,7 +28,7 @@ The universal property `TauCeti.LaurentK0.liftEquiv` is the `ℤ[q,q⁻¹]`-line
 one: for a `ℤ[q,q⁻¹]`-module `N`, the `ℤ[q,q⁻¹]`-linear maps out of `LaurentK0 E` are exactly the
 conflation-additive invariants `a` with `a(M{1}) = q · a(M)`, that is, the shift-compatible
 invariants of `TauCeti.GradedExactStructure.ShiftInvariant` for the automorphism
-`TauCeti.laurentTAut N` of multiplication by `q`.
+`TauCeti.laurentTAut ℤ N` of multiplication by `q`.
 
 ## Main definitions
 
@@ -44,6 +44,7 @@ invariants of `TauCeti.GradedExactStructure.ShiftInvariant` for the automorphism
 * `TauCeti.LaurentK0.T_smul`: `qⁿ · [M] = [M{n}]`, and its generating cases
   `TauCeti.LaurentK0.T_one_smul_of` and `TauCeti.LaurentK0.T_neg_one_smul_of`.
 * `TauCeti.LaurentK0.liftEquiv`: the universal property over the Laurent coefficient ring.
+* `TauCeti.LaurentK0.of_conflation`: the defining relation `[M₂] = [M₁] + [M₃]` of a conflation.
 * `TauCeti.LaurentK0.hom_ext`: a `ℤ[q,q⁻¹]`-linear map out of `LaurentK0 E` is determined by its
   values on object classes.
 
@@ -77,7 +78,6 @@ structure; the grading shift makes it a module over `ℤ[q,q⁻¹]`, with `q` ac
 The type synonym is needed because a `ℤ[q,q⁻¹]`-module structure is determined by an automorphism
 of the group, and `ExactK0 E.toExactStructure` does not mention the grading shift.  Use
 `TauCeti.LaurentK0.ofExactK0` to move between the two views. -/
-@[expose]
 def LaurentK0 (E : GradedExactStructure C) : Type w := ExactK0 E.toExactStructure
 
 namespace LaurentK0
@@ -89,18 +89,15 @@ instance : AddCommGroup (LaurentK0 E) :=
 
 /-- **The graded Grothendieck group is the exact one.**  Moving a class across this equivalence
 changes nothing but which module structure is in scope. -/
-@[expose]
 def ofExactK0 : ExactK0 E.toExactStructure ≃+ LaurentK0 E :=
   AddEquiv.refl _
 
 /-- The grading shift, as a `ℤ`-linear automorphism of the graded Grothendieck group. -/
-@[expose]
 noncomputable def shiftLinearEquiv : LaurentK0 E ≃ₗ[ℤ] LaurentK0 E :=
   { E.shiftEquiv with map_smul' := fun a x => map_zsmul E.shiftEquiv a x }
 
 /-- The grading shift as a unit of the endomorphism ring of the graded Grothendieck group: this is
 the unit at which the Laurent variable is evaluated. -/
-@[expose]
 noncomputable def shiftUnit : (Module.End ℤ (LaurentK0 E))ˣ where
   val := shiftLinearEquiv E
   inv := (shiftLinearEquiv E).symm
@@ -160,6 +157,14 @@ lemma ofExactK0_exactK0_of (X : C) : ofExactK0 E (ExactK0.of X) = of E X :=
 theorem of_congr {X Y : C} (e : X ≅ Y) : of E X = of E Y := by
   rw [← ofExactK0_exactK0_of, ← ofExactK0_exactK0_of, ExactK0.of_congr e]
 
+/-- **The defining relation of graded `K₀`**: the class of the middle term of a conflation is the
+sum of the classes of its outer terms.  The grading plays no role, so this is
+`ExactK0.of_conflation` moved across `TauCeti.LaurentK0.ofExactK0`. -/
+theorem of_conflation {S : ShortComplex C} (hS : E.toExactStructure.Conflation S) :
+    of E S.X₂ = of E S.X₁ + of E S.X₃ := by
+  rw [← ofExactK0_exactK0_of, ExactK0.of_conflation hS, map_add, ofExactK0_exactK0_of,
+    ofExactK0_exactK0_of]
+
 /-- **`q · [M] = [M{1}]`.** -/
 @[simp]
 theorem T_one_smul_of (X : C) :
@@ -175,14 +180,20 @@ theorem T_neg_one_smul_of (X : C) :
     ofExactK0_exactK0_of]
 
 /-- The constants of the Laurent coefficient ring act by the integer scalar multiplication of the
-underlying abelian group. -/
+underlying abelian group.
+
+Not `@[simp]`: `LaurentPolynomial.C a` is not in simp-normal form, see `TauCeti.laurentC_smul`. -/
 lemma C_smul (a : ℤ) (x : LaurentK0 E) :
     (LaurentPolynomial.C a : LaurentPolynomial ℤ) • x = a • x :=
   laurentC_smul a x
 
+/-- **The Laurent action restricts along the constants to the underlying integer action**: an
+integer scalar may be pushed through a Laurent scalar.  This is the content of `C_smul` in the form
+`Module` consumers need, and it is what lets `ℤ`-linear arguments about the underlying group be
+reused verbatim over `ℤ[q,q⁻¹]`. -/
 instance : IsScalarTower ℤ (LaurentPolynomial ℤ) (LaurentK0 E) where
   smul_assoc a p x := by
-    rw [laurent_zsmul_eq_C_mul, mul_smul, C_smul]
+    rw [zsmul_eq_mul, mul_smul, Int.cast_smul_eq_zsmul]
 
 /-- **A `ℤ[q,q⁻¹]`-linear map out of the graded Grothendieck group is determined by its values on
 object classes**, because those classes generate the underlying group. -/
@@ -249,12 +260,12 @@ lemma liftAux_of (f : ExactK0 E.toExactStructure →+ N)
 variable (E) in
 /-- **The homomorphism out of graded `K₀` induced by a shift-compatible invariant**, as a map of
 `ℤ[q,q⁻¹]`-modules.  The invariant is compared against multiplication by `q` on the target. -/
-noncomputable def lift (a : GradedExactStructure.ShiftInvariant E (laurentTAut N)) :
+noncomputable def lift (a : GradedExactStructure.ShiftInvariant E (laurentTAut ℤ N)) :
     LaurentK0 E →ₗ[LaurentPolynomial ℤ] N :=
   liftAux a.lift fun x => by simpa using a.lift_shiftEquiv x
 
 @[simp]
-lemma lift_of (a : GradedExactStructure.ShiftInvariant E (laurentTAut N)) (X : C) :
+lemma lift_of (a : GradedExactStructure.ShiftInvariant E (laurentTAut ℤ N)) (X : C) :
     lift E a (of E X) = a.obj X := by
   rw [lift, liftAux_of, GradedExactStructure.ShiftInvariant.lift_of]
 
@@ -266,11 +277,11 @@ the conflation-additive invariants whose value on `M{1}` is `q` times the value 
 This is the Layer 2 universal property of a shift-compatible invariant, with the abstract
 automorphism of the target replaced by the one the coefficient ring supplies. -/
 noncomputable def liftEquiv :
-    GradedExactStructure.ShiftInvariant E (laurentTAut N) ≃
+    GradedExactStructure.ShiftInvariant E (laurentTAut ℤ N) ≃
       (LaurentK0 E →ₗ[LaurentPolynomial ℤ] N) where
   toFun := lift E
   invFun g :=
-    (GradedExactStructure.ShiftInvariant.liftEquiv (laurentTAut N)).symm
+    (GradedExactStructure.ShiftInvariant.liftEquiv (laurentTAut ℤ N)).symm
       ⟨g.toAddMonoidHom.comp (ofExactK0 E).toAddMonoidHom, fun x => by
         simp only [AddMonoidHom.comp_apply, AddEquiv.coe_toAddMonoidHom, laurentTAut_apply,
           LinearMap.toAddMonoidHom_coe]
@@ -304,6 +315,7 @@ lemma map_of (h : GradedConflationExact E E' F) (X : C) :
   rw [map, liftAux_of, AddMonoidHom.comp_apply, ExactK0.map_of, AddEquiv.coe_toAddMonoidHom,
     ofExactK0_exactK0_of]
 
+/-- **The identity functor induces the identity map** of graded Grothendieck groups. -/
 @[simp]
 theorem map_id : map (GradedConflationExact.id E) = LinearMap.id :=
   hom_ext E fun X => by simp
@@ -311,6 +323,8 @@ theorem map_id : map (GradedConflationExact.id E) = LinearMap.id :=
 variable {K : Type u''} [Category.{v''} K] [Preadditive K] [HasZeroObject K]
   [HasBinaryBiproducts K] [EssentiallySmall.{w''} K]
 
+/-- **`LaurentK0.map` is functorial**: a composite of graded conflation-exact functors induces the
+composite `ℤ[q,q⁻¹]`-linear map. -/
 theorem map_comp {E'' : GradedExactStructure K} {H : D ⥤ K} [H.Additive]
     (h : GradedConflationExact E E' F) (h' : GradedConflationExact E' E'' H) :
     map (h.comp h') = (map h').comp (map h) :=

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Laurent.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Laurent.lean
@@ -1,0 +1,356 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Polynomial.Laurent
+public import TauCeti.CategoryTheory.GrothendieckGroup.Graded
+
+/-!
+# The Laurent coefficient ring acting on the graded Grothendieck group
+
+The grading shift `{1}` of a graded exact category acts on its exact Grothendieck group by the
+automorphism `TauCeti.GradedExactStructure.shiftEquiv`, and iterating it gives the `ℤ`-action
+`TauCeti.GradedExactStructure.shiftZPow`.  Repackaging that `ℤ`-action as a module structure over
+`ℤ[q,q⁻¹] = LaurentPolynomial ℤ` is what turns graded `K₀` into the lattice on which a `q`-Euler
+form can live.
+
+`TauCeti.LaurentK0 E` is the graded Grothendieck group of a graded exact category `E` carrying that
+module structure.  It is a type synonym for `TauCeti.ExactK0 E.toExactStructure`, moved across by
+the additive equivalence `TauCeti.LaurentK0.ofExactK0`: no new group is constructed, and no
+relation is added.  The synonym exists only because the module structure depends on the grading
+shift, which the underlying exact structure does not remember.  The defining property is
+`TauCeti.LaurentK0.T_smul`, the normalization `[M{n}] = qⁿ [M]` of the roadmap.
+
+The universal property `TauCeti.LaurentK0.liftEquiv` is the `ℤ[q,q⁻¹]`-linear form of the graded
+one: for a `ℤ[q,q⁻¹]`-module `N`, the `ℤ[q,q⁻¹]`-linear maps out of `LaurentK0 E` are exactly the
+conflation-additive invariants `a` with `a(M{1}) = q · a(M)`, that is, the shift-compatible
+invariants of `TauCeti.GradedExactStructure.ShiftInvariant` for the automorphism
+`TauCeti.laurentTAut N` of multiplication by `q`.
+
+## Main definitions
+
+* `TauCeti.LaurentK0`: the graded exact Grothendieck group as a `ℤ[q,q⁻¹]`-module.
+* `TauCeti.LaurentK0.ofExactK0`: the additive equivalence with the underlying exact `K₀`.
+* `TauCeti.LaurentK0.of`: the class `[M]` of an object.
+* `TauCeti.LaurentK0.lift`: the `ℤ[q,q⁻¹]`-linear map induced by a shift-compatible invariant.
+* `TauCeti.LaurentK0.map`: the `ℤ[q,q⁻¹]`-linear map induced by a graded conflation-exact functor.
+* `TauCeti.LaurentK0.mapEquiv`: the isomorphism induced by a graded exact equivalence.
+
+## Main results
+
+* `TauCeti.LaurentK0.T_smul`: `qⁿ · [M] = [M{n}]`, and its generating cases
+  `TauCeti.LaurentK0.T_one_smul_of` and `TauCeti.LaurentK0.T_neg_one_smul_of`.
+* `TauCeti.LaurentK0.liftEquiv`: the universal property over the Laurent coefficient ring.
+* `TauCeti.LaurentK0.hom_ext`: a `ℤ[q,q⁻¹]`-linear map out of `LaurentK0 E` is determined by its
+  values on object classes.
+
+## References
+
+* Zsuzsanna Dancso and Anthony Licata, "Koszul algebras and flow lattices", *Journal of
+  Combinatorial Theory, Series A* 185 (2022), Section 2.2, Definition 2.3, where the graded
+  Grothendieck group is presented as a `ℤ[q,q⁻¹]`-module with `[M{1}] = q[M]`.
+* `TauCetiRoadmap/GrothendieckEulerForms/README.md`, Layer 6, first bullet: "For a graded exact
+  category from Layer 2, construct the `R`-module structure on its graded `K₀` and prove
+  `[M{n}] = qⁿ[M]` for every `n : ℤ`, in particular `[M{1}] = q[M]`.  State the universal property
+  for additive invariants equipped with a compatible invertible shift action."
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+open LaurentPolynomial hiding C
+
+universe w w' w'' v v' v'' u u' u''
+
+variable {C : Type u} [Category.{v} C] [Preadditive C] [HasZeroObject C] [HasBinaryBiproducts C]
+  [EssentiallySmall.{w} C]
+
+/-- **The graded Grothendieck group of a graded exact category, over the Laurent coefficient
+ring.**  The underlying additive group is the exact Grothendieck group of the underlying exact
+structure; the grading shift makes it a module over `ℤ[q,q⁻¹]`, with `q` acting as `[M] ↦ [M{1}]`.
+
+The type synonym is needed because a `ℤ[q,q⁻¹]`-module structure is determined by an automorphism
+of the group, and `ExactK0 E.toExactStructure` does not mention the grading shift.  Use
+`TauCeti.LaurentK0.ofExactK0` to move between the two views. -/
+@[expose]
+def LaurentK0 (E : GradedExactStructure C) : Type w := ExactK0 E.toExactStructure
+
+namespace LaurentK0
+
+variable (E : GradedExactStructure C)
+
+instance : AddCommGroup (LaurentK0 E) :=
+  inferInstanceAs (AddCommGroup (ExactK0 E.toExactStructure))
+
+/-- **The graded Grothendieck group is the exact one.**  Moving a class across this equivalence
+changes nothing but which module structure is in scope. -/
+@[expose]
+def ofExactK0 : ExactK0 E.toExactStructure ≃+ LaurentK0 E :=
+  AddEquiv.refl _
+
+/-- The grading shift, as a `ℤ`-linear automorphism of the graded Grothendieck group. -/
+@[expose]
+noncomputable def shiftLinearEquiv : LaurentK0 E ≃ₗ[ℤ] LaurentK0 E :=
+  { E.shiftEquiv with map_smul' := fun a x => map_zsmul E.shiftEquiv a x }
+
+/-- The grading shift as a unit of the endomorphism ring of the graded Grothendieck group: this is
+the unit at which the Laurent variable is evaluated. -/
+@[expose]
+noncomputable def shiftUnit : (Module.End ℤ (LaurentK0 E))ˣ where
+  val := shiftLinearEquiv E
+  inv := (shiftLinearEquiv E).symm
+  val_inv := LinearMap.ext fun x => (shiftLinearEquiv E).apply_symm_apply x
+  inv_val := LinearMap.ext fun x => (shiftLinearEquiv E).symm_apply_apply x
+
+/-- **The Laurent coefficient ring acts on the graded Grothendieck group**, the variable acting
+by the grading shift. -/
+noncomputable instance : Module (LaurentPolynomial ℤ) (LaurentK0 E) :=
+  Module.compHom (LaurentK0 E) (laurentEval (shiftUnit E)).toRingHom
+
+/-- The Laurent action is evaluation of the polynomial at the grading shift. -/
+lemma smul_def (p : LaurentPolynomial ℤ) (x : LaurentK0 E) :
+    p • x = laurentEval (shiftUnit E) p x :=
+  (rfl)
+
+lemma shiftUnit_apply (x : ExactK0 E.toExactStructure) :
+    (shiftUnit E : Module.End ℤ (LaurentK0 E)) (ofExactK0 E x) = ofExactK0 E (E.shiftEquiv x) :=
+  (rfl)
+
+lemma shiftUnit_inv_apply (x : ExactK0 E.toExactStructure) :
+    (↑(shiftUnit E)⁻¹ : Module.End ℤ (LaurentK0 E)) (ofExactK0 E x) =
+      ofExactK0 E (E.shiftEquiv.symm x) :=
+  (rfl)
+
+lemma shiftUnit_zpow_apply (n : ℤ) (x : ExactK0 E.toExactStructure) :
+    (↑(shiftUnit E ^ n) : Module.End ℤ (LaurentK0 E)) (ofExactK0 E x) =
+      ofExactK0 E (E.shiftZPow n x) := by
+  induction n using Int.induction_on with
+  | zero => simp
+  | succ k ih =>
+      rw [GradedExactStructure.shiftZPow_add_one_apply, ← shiftUnit_apply, ← ih,
+        ← Module.End.mul_apply, ← Units.val_mul, ← zpow_one_add, add_comm 1 (k : ℤ)]
+  | pred k ih =>
+      rw [GradedExactStructure.shiftZPow_sub_one_apply, ← shiftUnit_inv_apply, ← ih,
+        ← Module.End.mul_apply, ← Units.val_mul, ← zpow_neg_one, ← zpow_add]
+      have h : (-1 : ℤ) + (-(k : ℤ)) = -(k : ℤ) - 1 := by ring
+      rw [h]
+
+/-- **`qⁿ · [M] = [M{n}]`**: the Laurent variable acts on the graded Grothendieck group by the
+grading shift, and its `n`-th power by the `n`-fold shift.  This is the normalization fixed by the
+roadmap, and it determines the module structure. -/
+@[simp]
+theorem T_smul (n : ℤ) (x : ExactK0 E.toExactStructure) :
+    (T n : LaurentPolynomial ℤ) • ofExactK0 E x = ofExactK0 E (E.shiftZPow n x) := by
+  rw [smul_def, laurentEval_T, shiftUnit_zpow_apply]
+
+/-- The class `[M]` of an object in the graded Grothendieck group. -/
+noncomputable def of (X : C) : LaurentK0 E :=
+  ofExactK0 E (ExactK0.of X)
+
+@[simp]
+lemma ofExactK0_exactK0_of (X : C) : ofExactK0 E (ExactK0.of X) = of E X :=
+  (rfl)
+
+/-- Isomorphic objects have the same class. -/
+theorem of_congr {X Y : C} (e : X ≅ Y) : of E X = of E Y := by
+  rw [← ofExactK0_exactK0_of, ← ofExactK0_exactK0_of, ExactK0.of_congr e]
+
+/-- **`q · [M] = [M{1}]`.** -/
+@[simp]
+theorem T_one_smul_of (X : C) :
+    (T 1 : LaurentPolynomial ℤ) • of E X = of E (E.shift.functor.obj X) := by
+  rw [← ofExactK0_exactK0_of, T_smul, GradedExactStructure.shiftZPow_one_apply_of,
+    ofExactK0_exactK0_of]
+
+/-- **`q⁻¹ · [M] = [M{-1}]`.** -/
+@[simp]
+theorem T_neg_one_smul_of (X : C) :
+    (T (-1) : LaurentPolynomial ℤ) • of E X = of E (E.shift.inverse.obj X) := by
+  rw [← ofExactK0_exactK0_of, T_smul, GradedExactStructure.shiftZPow_neg_one_apply_of,
+    ofExactK0_exactK0_of]
+
+/-- The constants of the Laurent coefficient ring act by the integer scalar multiplication of the
+underlying abelian group. -/
+lemma C_smul (a : ℤ) (x : LaurentK0 E) :
+    (LaurentPolynomial.C a : LaurentPolynomial ℤ) • x = a • x :=
+  laurentC_smul a x
+
+instance : IsScalarTower ℤ (LaurentPolynomial ℤ) (LaurentK0 E) where
+  smul_assoc a p x := by
+    rw [laurent_zsmul_eq_C_mul, mul_smul, C_smul]
+
+/-- **A `ℤ[q,q⁻¹]`-linear map out of the graded Grothendieck group is determined by its values on
+object classes**, because those classes generate the underlying group. -/
+theorem hom_ext {N : Type*} [AddCommGroup N] [Module (LaurentPolynomial ℤ) N]
+    {f g : LaurentK0 E →ₗ[LaurentPolynomial ℤ] N} (h : ∀ X : C, f (of E X) = g (of E X)) :
+    f = g := by
+  refine LinearMap.ext fun x => ?_
+  have key : f.toAddMonoidHom.comp (ofExactK0 E).toAddMonoidHom =
+      g.toAddMonoidHom.comp (ofExactK0 E).toAddMonoidHom :=
+    ExactK0.hom_ext fun X => by simpa using h X
+  simpa using DFunLike.congr_fun key ((ofExactK0 E).symm x)
+
+section UniversalProperty
+
+variable {E}
+variable {N : Type*} [AddCommGroup N] [Module (LaurentPolynomial ℤ) N]
+
+/-- An additive map out of the exact Grothendieck group which turns the grading shift into
+multiplication by `q` turns the whole `ℤ`-action into multiplication by `qⁿ`. -/
+theorem apply_shiftZPow (f : ExactK0 E.toExactStructure →+ N)
+    (hf : ∀ x, f (E.shiftEquiv x) = (T 1 : LaurentPolynomial ℤ) • f x) (n : ℤ)
+    (x : ExactK0 E.toExactStructure) :
+    f (E.shiftZPow n x) = (T n : LaurentPolynomial ℤ) • f x := by
+  have hsymm : ∀ y, f (E.shiftEquiv.symm y) = (T (-1) : LaurentPolynomial ℤ) • f y := fun y => by
+    have hy := hf (E.shiftEquiv.symm y)
+    rw [AddEquiv.apply_symm_apply] at hy
+    rw [hy, smul_smul, ← T_add]
+    simp
+  induction n using Int.induction_on with
+  | zero => simp
+  | succ k ih =>
+      rw [GradedExactStructure.shiftZPow_add_one_apply, hf, ih, smul_smul, ← T_add,
+        add_comm 1 (k : ℤ)]
+  | pred k ih =>
+      rw [GradedExactStructure.shiftZPow_sub_one_apply, hsymm, ih, smul_smul, ← T_add]
+      have h : (-1 : ℤ) + (-(k : ℤ)) = -(k : ℤ) - 1 := by ring
+      rw [h]
+
+/-- The `ℤ[q,q⁻¹]`-linear map out of the graded Grothendieck group determined by a
+shift-compatible additive map on the underlying exact one. -/
+noncomputable def liftAux (f : ExactK0 E.toExactStructure →+ N)
+    (hf : ∀ x, f (E.shiftEquiv x) = (T 1 : LaurentPolynomial ℤ) • f x) :
+    LaurentK0 E →ₗ[LaurentPolynomial ℤ] N where
+  toFun x := f ((ofExactK0 E).symm x)
+  map_add' x y := by simp
+  map_smul' p x := by
+    simp only [RingHom.id_apply]
+    obtain ⟨z, rfl⟩ : ∃ z, ofExactK0 E z = x := ⟨(ofExactK0 E).symm x, by simp⟩
+    simp only [AddEquiv.symm_apply_apply]
+    induction p using LaurentPolynomial.induction_on' with
+    | add p q hp hq =>
+        rw [add_smul, map_add, map_add, hp, hq, add_smul]
+    | C_mul_T n a =>
+        rw [mul_smul, T_smul, laurentC_smul, ← map_zsmul (ofExactK0 E),
+          AddEquiv.symm_apply_apply, map_zsmul f, apply_shiftZPow f hf, mul_smul,
+          laurentC_smul]
+
+@[simp]
+lemma liftAux_of (f : ExactK0 E.toExactStructure →+ N)
+    (hf : ∀ x, f (E.shiftEquiv x) = (T 1 : LaurentPolynomial ℤ) • f x) (X : C) :
+    liftAux f hf (of E X) = f (ExactK0.of X) :=
+  (rfl)
+
+variable (E) in
+/-- **The homomorphism out of graded `K₀` induced by a shift-compatible invariant**, as a map of
+`ℤ[q,q⁻¹]`-modules.  The invariant is compared against multiplication by `q` on the target. -/
+noncomputable def lift (a : GradedExactStructure.ShiftInvariant E (laurentTAut N)) :
+    LaurentK0 E →ₗ[LaurentPolynomial ℤ] N :=
+  liftAux a.lift fun x => by simpa using a.lift_shiftEquiv x
+
+@[simp]
+lemma lift_of (a : GradedExactStructure.ShiftInvariant E (laurentTAut N)) (X : C) :
+    lift E a (of E X) = a.obj X := by
+  rw [lift, liftAux_of, GradedExactStructure.ShiftInvariant.lift_of]
+
+variable (E) in
+/-- **The universal property of graded `K₀` over the Laurent coefficient ring.**  For a
+`ℤ[q,q⁻¹]`-module `N`, the `ℤ[q,q⁻¹]`-linear maps out of `LaurentK0 E` correspond bijectively to
+the conflation-additive invariants whose value on `M{1}` is `q` times the value on `M`.
+
+This is the Layer 2 universal property of a shift-compatible invariant, with the abstract
+automorphism of the target replaced by the one the coefficient ring supplies. -/
+noncomputable def liftEquiv :
+    GradedExactStructure.ShiftInvariant E (laurentTAut N) ≃
+      (LaurentK0 E →ₗ[LaurentPolynomial ℤ] N) where
+  toFun := lift E
+  invFun g :=
+    (GradedExactStructure.ShiftInvariant.liftEquiv (laurentTAut N)).symm
+      ⟨g.toAddMonoidHom.comp (ofExactK0 E).toAddMonoidHom, fun x => by
+        simp only [AddMonoidHom.comp_apply, AddEquiv.coe_toAddMonoidHom, laurentTAut_apply,
+          LinearMap.toAddMonoidHom_coe]
+        conv_rhs => rw [← map_smul g, T_smul]
+        simp⟩
+  left_inv a := by
+    ext X
+    simp
+  right_inv g := by
+    refine hom_ext E fun X => ?_
+    simp [lift]
+
+end UniversalProperty
+
+section Functoriality
+
+variable {D : Type u'} [Category.{v'} D] [Preadditive D] [HasZeroObject D]
+  [HasBinaryBiproducts D] [EssentiallySmall.{w'} D]
+variable {E} {E' : GradedExactStructure D} {F : C ⥤ D} [F.Additive]
+
+/-- **A graded conflation-exact functor induces a `ℤ[q,q⁻¹]`-linear map** of graded Grothendieck
+groups: the shift-equivariance proved in the `ℤ`-graded layer is exactly `q`-linearity. -/
+noncomputable def map (h : GradedConflationExact E E' F) :
+    LaurentK0 E →ₗ[LaurentPolynomial ℤ] LaurentK0 E' :=
+  liftAux ((ofExactK0 E').toAddMonoidHom.comp (ExactK0.map F h.isConflationExact)) fun x => by
+    simp [GradedExactStructure.map_shiftEquiv h]
+
+@[simp]
+lemma map_of (h : GradedConflationExact E E' F) (X : C) :
+    map h (of E X) = of E' (F.obj X) := by
+  rw [map, liftAux_of, AddMonoidHom.comp_apply, ExactK0.map_of, AddEquiv.coe_toAddMonoidHom,
+    ofExactK0_exactK0_of]
+
+@[simp]
+theorem map_id : map (GradedConflationExact.id E) = LinearMap.id :=
+  hom_ext E fun X => by simp
+
+variable {K : Type u''} [Category.{v''} K] [Preadditive K] [HasZeroObject K]
+  [HasBinaryBiproducts K] [EssentiallySmall.{w''} K]
+
+theorem map_comp {E'' : GradedExactStructure K} {H : D ⥤ K} [H.Additive]
+    (h : GradedConflationExact E E' F) (h' : GradedConflationExact E' E'' H) :
+    map (h.comp h') = (map h').comp (map h) :=
+  hom_ext E fun X => by simp
+
+end Functoriality
+
+section Invariance
+
+variable {D : Type u'} [Category.{v'} D] [Preadditive D] [HasZeroObject D]
+  [HasBinaryBiproducts D] [EssentiallySmall.{w'} D]
+variable {E} {E' : GradedExactStructure D}
+
+/-- **A graded exact equivalence induces an isomorphism of `ℤ[q,q⁻¹]`-modules.**  Graded `K₀` over
+the Laurent coefficient ring is therefore an invariant of the graded exact category, not of a
+presentation of it. -/
+noncomputable def mapEquiv (h : GradedExactEquiv E E') :
+    LaurentK0 E ≃ₗ[LaurentPolynomial ℤ] LaurentK0 E' :=
+  LinearEquiv.ofLinearMap (map h.toGradedConflationExact) (map h.symm.toGradedConflationExact)
+    (hom_ext E' fun X => by
+      simp only [LinearMap.comp_apply, map_of, GradedExactEquiv.symm_equiv,
+        Equivalence.symm_functor, LinearMap.id_coe, id_eq]
+      exact of_congr E' (h.equiv.counitIso.app X))
+    (hom_ext E fun X => by
+      simp only [LinearMap.comp_apply, map_of, GradedExactEquiv.symm_equiv,
+        Equivalence.symm_functor, LinearMap.id_coe, id_eq]
+      exact of_congr E (h.equiv.unitIso.app X).symm)
+
+@[simp]
+lemma mapEquiv_of (h : GradedExactEquiv E E') (X : C) :
+    mapEquiv h (of E X) = of E' (h.equiv.functor.obj X) := by
+  simp [mapEquiv, LinearEquiv.ofLinearMap]
+
+@[simp]
+lemma mapEquiv_symm_of (h : GradedExactEquiv E E') (X : D) :
+    (mapEquiv h).symm (of E' X) = of E (h.equiv.inverse.obj X) := by
+  simp [mapEquiv, LinearEquiv.ofLinearMap, GradedExactEquiv.symm_equiv]
+
+end Invariance
+
+end LaurentK0
+
+end TauCeti

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Laurent.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Laurent.lean
@@ -93,12 +93,13 @@ def ofExactK0 : ExactK0 E.toExactStructure ≃+ LaurentK0 E :=
   AddEquiv.refl _
 
 /-- The grading shift, as a `ℤ`-linear automorphism of the graded Grothendieck group. -/
-noncomputable def shiftLinearEquiv : LaurentK0 E ≃ₗ[ℤ] LaurentK0 E :=
-  { E.shiftEquiv with map_smul' := fun a x => map_zsmul E.shiftEquiv a x }
+private noncomputable def shiftLinearEquiv : LaurentK0 E ≃ₗ[ℤ] LaurentK0 E :=
+  let shiftAddEquiv := (ofExactK0 E).symm.trans (E.shiftEquiv.trans (ofExactK0 E))
+  { shiftAddEquiv with map_smul' := fun a x => map_zsmul shiftAddEquiv a x }
 
 /-- The grading shift as a unit of the endomorphism ring of the graded Grothendieck group: this is
 the unit at which the Laurent variable is evaluated. -/
-noncomputable def shiftUnit : (Module.End ℤ (LaurentK0 E))ˣ where
+private noncomputable def shiftUnit : (Module.End ℤ (LaurentK0 E))ˣ where
   val := shiftLinearEquiv E
   inv := (shiftLinearEquiv E).symm
   val_inv := LinearMap.ext fun x => (shiftLinearEquiv E).apply_symm_apply x
@@ -107,23 +108,32 @@ noncomputable def shiftUnit : (Module.End ℤ (LaurentK0 E))ˣ where
 /-- **The Laurent coefficient ring acts on the graded Grothendieck group**, the variable acting
 by the grading shift. -/
 noncomputable instance : Module (LaurentPolynomial ℤ) (LaurentK0 E) :=
-  Module.compHom (LaurentK0 E) (laurentEval (shiftUnit E)).toRingHom
+  let shiftAddEquiv := (ofExactK0 E).symm.trans (E.shiftEquiv.trans (ofExactK0 E))
+  let shiftLinearEquiv : LaurentK0 E ≃ₗ[ℤ] LaurentK0 E :=
+    { shiftAddEquiv with map_smul' := fun a x => map_zsmul shiftAddEquiv a x }
+  Module.compHom (LaurentK0 E)
+    (laurentEval
+      ({ val := shiftLinearEquiv
+         inv := shiftLinearEquiv.symm
+         val_inv := LinearMap.ext fun x => shiftLinearEquiv.apply_symm_apply x
+         inv_val := LinearMap.ext fun x => shiftLinearEquiv.symm_apply_apply x } :
+        (Module.End ℤ (LaurentK0 E))ˣ)).toRingHom
 
 /-- The Laurent action is evaluation of the polynomial at the grading shift. -/
-lemma smul_def (p : LaurentPolynomial ℤ) (x : LaurentK0 E) :
+private lemma smul_def (p : LaurentPolynomial ℤ) (x : LaurentK0 E) :
     p • x = laurentEval (shiftUnit E) p x :=
   (rfl)
 
-lemma shiftUnit_apply (x : ExactK0 E.toExactStructure) :
+private lemma shiftUnit_apply (x : ExactK0 E.toExactStructure) :
     (shiftUnit E : Module.End ℤ (LaurentK0 E)) (ofExactK0 E x) = ofExactK0 E (E.shiftEquiv x) :=
   (rfl)
 
-lemma shiftUnit_inv_apply (x : ExactK0 E.toExactStructure) :
+private lemma shiftUnit_inv_apply (x : ExactK0 E.toExactStructure) :
     (↑(shiftUnit E)⁻¹ : Module.End ℤ (LaurentK0 E)) (ofExactK0 E x) =
       ofExactK0 E (E.shiftEquiv.symm x) :=
   (rfl)
 
-lemma shiftUnit_zpow_apply (n : ℤ) (x : ExactK0 E.toExactStructure) :
+private lemma shiftUnit_zpow_apply (n : ℤ) (x : ExactK0 E.toExactStructure) :
     (↑(shiftUnit E ^ n) : Module.End ℤ (LaurentK0 E)) (ofExactK0 E x) =
       ofExactK0 E (E.shiftZPow n x) := by
   induction n using Int.induction_on with
@@ -179,18 +189,10 @@ theorem T_neg_one_smul_of (X : C) :
   rw [← ofExactK0_exactK0_of, T_smul, GradedExactStructure.shiftZPow_neg_one_apply_of,
     ofExactK0_exactK0_of]
 
-/-- The constants of the Laurent coefficient ring act by the integer scalar multiplication of the
-underlying abelian group.
-
-Not `@[simp]`: `LaurentPolynomial.C a` is not in simp-normal form, see `TauCeti.laurentC_smul`. -/
-lemma C_smul (a : ℤ) (x : LaurentK0 E) :
-    (LaurentPolynomial.C a : LaurentPolynomial ℤ) • x = a • x :=
-  laurentC_smul a x
-
 /-- **The Laurent action restricts along the constants to the underlying integer action**: an
-integer scalar may be pushed through a Laurent scalar.  This is the content of `C_smul` in the form
-`Module` consumers need, and it is what lets `ℤ`-linear arguments about the underlying group be
-reused verbatim over `ℤ[q,q⁻¹]`. -/
+integer scalar may be pushed through a Laurent scalar.  This is the content of
+`TauCeti.laurentC_smul` in the form `Module` consumers need, and it is what lets `ℤ`-linear
+arguments about the underlying group be reused verbatim over `ℤ[q,q⁻¹]`. -/
 instance : IsScalarTower ℤ (LaurentPolynomial ℤ) (LaurentK0 E) where
   smul_assoc a p x := by
     rw [zsmul_eq_mul, mul_smul, Int.cast_smul_eq_zsmul]
@@ -234,7 +236,7 @@ theorem apply_shiftZPow (f : ExactK0 E.toExactStructure →+ N)
 
 /-- The `ℤ[q,q⁻¹]`-linear map out of the graded Grothendieck group determined by a
 shift-compatible additive map on the underlying exact one. -/
-noncomputable def liftAux (f : ExactK0 E.toExactStructure →+ N)
+private noncomputable def liftAux (f : ExactK0 E.toExactStructure →+ N)
     (hf : ∀ x, f (E.shiftEquiv x) = (T 1 : LaurentPolynomial ℤ) • f x) :
     LaurentK0 E →ₗ[LaurentPolynomial ℤ] N where
   toFun x := f ((ofExactK0 E).symm x)
@@ -252,7 +254,7 @@ noncomputable def liftAux (f : ExactK0 E.toExactStructure →+ N)
           laurentC_smul]
 
 @[simp]
-lemma liftAux_of (f : ExactK0 E.toExactStructure →+ N)
+private lemma liftAux_of (f : ExactK0 E.toExactStructure →+ N)
     (hf : ∀ x, f (E.shiftEquiv x) = (T 1 : LaurentPolynomial ℤ) • f x) (X : C) :
     liftAux f hf (of E X) = f (ExactK0.of X) :=
   (rfl)

--- a/TauCeti/CategoryTheory/GrothendieckGroup/Laurent.lean
+++ b/TauCeti/CategoryTheory/GrothendieckGroup/Laurent.lean
@@ -191,8 +191,8 @@ theorem T_neg_one_smul_of (X : C) :
 
 /-- **The Laurent action restricts along the constants to the underlying integer action**: an
 integer scalar may be pushed through a Laurent scalar.  This is the content of
-`TauCeti.laurentC_smul` in the form `Module` consumers need, and it is what lets `ℤ`-linear
-arguments about the underlying group be reused verbatim over `ℤ[q,q⁻¹]`. -/
+`TauCeti.laurentPolynomialC_smul` in the form `Module` consumers need, and it is what lets
+`ℤ`-linear arguments about the underlying group be reused verbatim over `ℤ[q,q⁻¹]`. -/
 instance : IsScalarTower ℤ (LaurentPolynomial ℤ) (LaurentK0 E) where
   smul_assoc a p x := by
     rw [zsmul_eq_mul, mul_smul, Int.cast_smul_eq_zsmul]
@@ -215,7 +215,7 @@ variable {N : Type*} [AddCommGroup N] [Module (LaurentPolynomial ℤ) N]
 
 /-- An additive map out of the exact Grothendieck group which turns the grading shift into
 multiplication by `q` turns the whole `ℤ`-action into multiplication by `qⁿ`. -/
-theorem apply_shiftZPow (f : ExactK0 E.toExactStructure →+ N)
+theorem map_shiftZPow (f : ExactK0 E.toExactStructure →+ N)
     (hf : ∀ x, f (E.shiftEquiv x) = (T 1 : LaurentPolynomial ℤ) • f x) (n : ℤ)
     (x : ExactK0 E.toExactStructure) :
     f (E.shiftZPow n x) = (T n : LaurentPolynomial ℤ) • f x := by
@@ -249,9 +249,9 @@ private noncomputable def liftAux (f : ExactK0 E.toExactStructure →+ N)
     | add p q hp hq =>
         rw [add_smul, map_add, map_add, hp, hq, add_smul]
     | C_mul_T n a =>
-        rw [mul_smul, T_smul, laurentC_smul, ← map_zsmul (ofExactK0 E),
-          AddEquiv.symm_apply_apply, map_zsmul f, apply_shiftZPow f hf, mul_smul,
-          laurentC_smul]
+        rw [mul_smul, T_smul, laurentPolynomialC_smul, ← map_zsmul (ofExactK0 E),
+          AddEquiv.symm_apply_apply, map_zsmul f, map_shiftZPow f hf, mul_smul,
+          laurentPolynomialC_smul]
 
 @[simp]
 private lemma liftAux_of (f : ExactK0 E.toExactStructure →+ N)
@@ -327,6 +327,7 @@ variable {K : Type u''} [Category.{v''} K] [Preadditive K] [HasZeroObject K]
 
 /-- **`LaurentK0.map` is functorial**: a composite of graded conflation-exact functors induces the
 composite `ℤ[q,q⁻¹]`-linear map. -/
+@[simp]
 theorem map_comp {E'' : GradedExactStructure K} {H : D ⥤ K} [H.Additive]
     (h : GradedConflationExact E E' F) (h' : GradedConflationExact E' E'' H) :
     map (h.comp h') = (map h').comp (map h) :=


### PR DESCRIPTION
This PR gives the graded Grothendieck group of a graded exact category its module structure over the Laurent coefficient ring `ℤ[q,q⁻¹] = LaurentPolynomial ℤ`, and proves the normalization `[M{n}] = qⁿ [M]` that fixes it. `TauCeti.LaurentK0 E` is a type synonym for `TauCeti.ExactK0 E.toExactStructure` — moved across by the additive equivalence `TauCeti.LaurentK0.ofExactK0`, so no new group is built and no relation is added — carrying the `ℤ[q,q⁻¹]`-action in which `q` acts by the grading shift. The synonym is unavoidable because a `ℤ[q,q⁻¹]`-module structure on an abelian group is exactly a choice of automorphism of it, and `ExactK0 E.toExactStructure` does not remember the shift. The defining theorem is `TauCeti.LaurentK0.T_smul : qⁿ • [x] = [x{n}]`, stated against the `ℤ`-action `TauCeti.GradedExactStructure.shiftZPow` that landed with the graded Layer 2 files, together with its generating cases `T_one_smul_of` (`q · [M] = [M{1}]`) and `T_neg_one_smul_of`, and the constant action `C_smul`. On top of that the file proves `TauCeti.LaurentK0.hom_ext` (a `ℤ[q,q⁻¹]`-linear map out of graded `K₀` is determined by the classes of objects), the universal property `TauCeti.LaurentK0.liftEquiv` — for a `ℤ[q,q⁻¹]`-module `N`, the `ℤ[q,q⁻¹]`-linear maps `LaurentK0 E →ₗ N` are exactly the conflation-additive invariants `a` with `a(M{1}) = q · a(M)`, that is the existing `GradedExactStructure.ShiftInvariant` taken against the automorphism "multiply by `q`" — and functoriality: `TauCeti.LaurentK0.map` for a graded conflation-exact functor with its identity and composition laws, and `TauCeti.LaurentK0.mapEquiv`, the `ℤ[q,q⁻¹]`-linear isomorphism induced by a graded exact equivalence.

The milestone is Layer 6 of the Grothendieck-groups roadmap, "Laurent coefficients, q-Euler forms, and specialization", and this PR is its first bullet verbatim: "For a graded exact category from Layer 2, construct the `R`-module structure on its graded `K₀` and prove `[M{n}] = qⁿ[M]` for every `n : ℤ`, in particular `[M{1}] = q[M]`. State the universal property for additive invariants equipped with a compatible invertible shift action." That bullet is the one Layer 6 opens with, and the landed graded file `TauCeti/CategoryTheory/GrothendieckGroup/Graded.lean` explicitly defers "the Laurent-module repackaging of this action, in which it becomes multiplication by `qⁿ`" to it, so nothing else in Layer 6 is reachable first: the `q`-Euler form, the graded Gram and Cartan matrices and the specializations all live over this coefficient ring. What remains in Layer 6 after this PR is the finite-Laurent-support graded dimension `qdim`, the sesquilinear `q`-Euler form `χ_q` and its descent to graded `K₀`, the graded Cartan and Gram matrices, and the `q = 1` / `q = -1` base changes together with the forget-the-grading comparison; the specialization bullet in particular asks for degeneracy examples built from a `q`-Euler form, which does not exist yet.

The supporting file supplies the piece of Mathlib-shaped algebra the construction needs and Mathlib does not have. `LaurentPolynomial.eval₂` substitutes a unit into a Laurent polynomial but requires a *commutative* codomain, because it is built through `IsLocalization.lift`; the codomain here is an endomorphism ring, which is not commutative. `TauCeti.laurentEval u : R[T;T⁻¹] →ₐ[R] A`, for a unit `u` of an arbitrary `R`-algebra `A`, is the algebra map attached by `AddMonoidAlgebra.lift` to the integer-power monoid homomorphism `Multiplicative ℤ →* A`. It comes with `laurentEval_unique` (an algebra map out of `R[T;T⁻¹]` is determined by its value at `T`), the resulting universal property `TauCeti.laurentEvalEquiv : Aˣ ≃ (R[T;T⁻¹] →ₐ[R] A)` exhibiting `R[T;T⁻¹]` as the free `R`-algebra on one invertible generator, naturality in the target, and `TauCeti.laurentEval_eq_eval₂`, the theorem that over a commutative target it *is* Mathlib's `eval₂` — so the two constructions are pinned to each other rather than left to drift. `TauCeti.laurentTAut` is multiplication by the variable on a `ℤ[T;T⁻¹]`-module, as an additive automorphism; it is what the shift-compatible invariant of the universal property is compared against.

Two files are added. `TauCeti/Algebra/Polynomial/Laurent.lean` (185 lines) holds the evaluation-at-a-unit material, beside Mathlib's own `Mathlib/Algebra/Polynomial/Laurent.lean` in the tree and with no dependency on category theory. `TauCeti/CategoryTheory/GrothendieckGroup/Laurent.lean` (356 lines) holds `LaurentK0`, alongside the `Split.lean`, `Exact.lean`, `Abelian.lean`, `Triangulated.lean` and `Graded.lean` of the same presentation engine, which is where the roadmap's suggested home `TauCeti/CategoryTheory/GrothendieckGroup/` puts the categorical Grothendieck groups. Nothing existing is changed. Only the exact case is treated, because a graded exact category is what Layer 6's bullet names and what `TauCeti.GradedExactStructure` bundles; the graded split and abelian groups are the special cases `GradedExactStructure.split` and `GradedExactStructure.abelian` of it, whereas the split and abelian shift actions in `Graded.lean` are parameterised by a bare autoequivalence that the type of `SplitK0 C` does not mention, so they admit no instance of this shape. No Mathlib infrastructure was vendored: the group-algebra universal property is `AddMonoidAlgebra.lift`, the transport of scalars is `Module.compHom` through `LinearMap.applyModule`, and the Laurent induction is `LaurentPolynomial.induction_on'`.

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"shift-module-structure-graded-k0"}-->

🤖 Prepared with Claude Code
