### PR TITLE
feat: complete symplectic sum-long root strings

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/ChevalleyRelations.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/ChevalleyRelations.lean
@@ -11,7 +11,7 @@ public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.Chevall
 /-!
 # Chevalley relations for symplectic root subgroups
 
-This file lifts the four multiply-laced rank-two commutator relations from the standard
+This file lifts the six multiply-laced rank-two commutator relations from the standard
 symplectic matrices to the functor of points of `Sp₂ₘ`. For distinct `i` and `j`, they include
 
 ```text
@@ -28,6 +28,15 @@ The opposite root string gives
   = x_{-eᵢ-eⱼ}(-ab) x_{-2eⱼ}(a²b),
 ⁅x_{eᵢ-eⱼ}(a), x_{-eᵢ-eⱼ}(b)⁆
   = x_{-2eⱼ}(-2ab).
+```
+
+The two complementary strings starting from the sum-root families are
+
+```text
+⁅x_{eᵢ+eⱼ}(a), x_{-2eⱼ}(b)⁆
+  = x_{eᵢ-eⱼ}(ab) x_{2eᵢ}(-a²b),
+⁅x_{-eᵢ-eⱼ}(a), x_{2eⱼ}(b)⁆
+  = x_{eⱼ-eᵢ}(-ab) x_{-2eᵢ}(-a²b).
 ```
 
 The parameters on the right are expressed using the algebra structure of the value ring. Thus
@@ -214,5 +223,68 @@ theorem commutatorElement_differenceShortRootSubgroupPoints_negativeSumShortRoot
       congr 1
       dsimp only [c]
       ring
+
+/-- **The complementary positive-sum multiply-laced relation on algebra-valued points of
+`Sp₂ₘ`.** The inverse long-root point on the right represents the parameter `-a²b`. -/
+theorem commutatorElement_positiveSumShortRootSubgroupPoints_negativeLongRootSubgroupPoints
+    (hij : i ≠ j)
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    ⁅shortRootSubgroupPoints .positiveSum hij f, negativeLongRootSubgroupPoints j g⁆ =
+      shortRootSubgroupPoints .difference hij (AdditiveGroup.gaPointParamMul f g) *
+        positiveLongRootSubgroupPoints i
+          (AdditiveGroup.gaPointParamMul f (AdditiveGroup.gaPointParamMul f g))⁻¹ := by
+  apply (pointsMulEquiv (R := R) (A := A) m).injective
+  rw [map_commutatorElement, map_mul,
+    pointsMulEquiv_shortRootSubgroupPoints,
+    pointsMulEquiv_negativeLongRootSubgroupPoints,
+    pointsMulEquiv_shortRootSubgroupPoints,
+    pointsMulEquiv_positiveLongRootSubgroupPoints]
+  rw [GLSymplecticFin.ShortRootFamily.hom_positiveSum,
+    GLSymplecticFin.positiveSumShortRootHom_apply,
+    GLSymplecticFin.ShortRootFamily.hom_difference,
+    GLSymplecticFin.differenceShortRootHom_apply]
+  rw [AdditiveGroup.toAdd_gaPointsMulEquiv_inv,
+    AdditiveGroup.toAdd_gaPointsMulEquiv]
+  simp only [AdditiveGroup.toAdd_gaPointsMulEquiv,
+    AdditiveGroup.gaPointParamMul_apply_ι]
+  ring_nf
+  exact
+    GLSymplecticFin.commutatorElement_positiveSumShortRootUnit_negativeLongRootTransvectionUnit
+      hij
+      (f.ofConv (SymmetricAlgebra.ι R R 1))
+      (g.ofConv (SymmetricAlgebra.ι R R 1))
+
+/-- **The complementary negative-sum multiply-laced relation on algebra-valued points of
+`Sp₂ₘ`.** Both inverses on the right encode the negative parameters in the additive source
+group. -/
+theorem commutatorElement_negativeSumShortRootSubgroupPoints_positiveLongRootSubgroupPoints
+    (hij : i ≠ j)
+    (f g : WithConv (AdditiveGroup.coordinateHopfAlgebra R →ₐ[R] A)) :
+    ⁅shortRootSubgroupPoints .negativeSum hij f, positiveLongRootSubgroupPoints j g⁆ =
+      shortRootSubgroupPoints .difference hij.symm
+          (AdditiveGroup.gaPointParamMul f g)⁻¹ *
+        negativeLongRootSubgroupPoints i
+          (AdditiveGroup.gaPointParamMul f (AdditiveGroup.gaPointParamMul f g))⁻¹ := by
+  apply (pointsMulEquiv (R := R) (A := A) m).injective
+  rw [map_commutatorElement, map_mul,
+    pointsMulEquiv_shortRootSubgroupPoints,
+    pointsMulEquiv_positiveLongRootSubgroupPoints,
+    pointsMulEquiv_shortRootSubgroupPoints,
+    pointsMulEquiv_negativeLongRootSubgroupPoints]
+  rw [GLSymplecticFin.ShortRootFamily.hom_negativeSum,
+    GLSymplecticFin.negativeSumShortRootHom_apply,
+    GLSymplecticFin.ShortRootFamily.hom_difference,
+    GLSymplecticFin.differenceShortRootHom_apply]
+  rw [AdditiveGroup.toAdd_gaPointsMulEquiv_inv,
+    AdditiveGroup.toAdd_gaPointsMulEquiv_inv,
+    AdditiveGroup.toAdd_gaPointsMulEquiv]
+  simp only [AdditiveGroup.toAdd_gaPointsMulEquiv,
+    AdditiveGroup.gaPointParamMul_apply_ι]
+  ring_nf
+  exact
+    GLSymplecticFin.commutatorElement_negativeSumShortRootUnit_positiveLongRootTransvectionUnit
+      hij
+      (f.ofConv (SymmetricAlgebra.ι R R 1))
+      (g.ofConv (SymmetricAlgebra.ι R R 1))
 
 end TauCeti.Symplectic

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/ChevalleyRelations.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/ChevalleyRelations.lean
@@ -38,6 +38,18 @@ positive string it is
 Together these four identities are the rank-two relations needed to compare the standard
 symplectic realization with the characteristic-two special isogeny of type `B₂/C₂`.
 
+The complementary long-root strings, starting from the sum roots, are
+
+```text
+⁅x_{eᵢ+eⱼ}(a), x_{-2eⱼ}(b)⁆
+  = x_{eᵢ-eⱼ}(ab) x_{2eᵢ}(-a²b),
+⁅x_{-eᵢ-eⱼ}(a), x_{2eⱼ}(b)⁆
+  = x_{eⱼ-eᵢ}(-ab) x_{-2eᵢ}(-a²b).
+```
+
+Thus every interaction between a long root and a nonopposite short root in the rank-two
+subsystem is available without changing coordinates.
+
 ## References
 
 * R. W. Carter, *Simple Groups of Lie Type* (1972), §5.2 and §11.3.
@@ -285,5 +297,118 @@ theorem commutatorElement_differenceShortRootUnit_negativeSumShortRootUnit
   rw [← transvectionUnit_add]
   congr 1
   ring
+
+/-- **The complementary positive-sum multiply-laced Chevalley relation.** The commutator of
+`x_{eᵢ+eⱼ}(a)` and `x_{-2eⱼ}(b)` is the product of the root subgroups for `eᵢ-eⱼ`
+and `2eᵢ`, with parameters `ab` and `-a²b`. -/
+theorem commutatorElement_positiveSumShortRootUnit_negativeLongRootTransvectionUnit
+    (hij : i ≠ j) (a b : R) :
+    ⁅positiveSumShortRootUnit hij a, negativeLongRootTransvectionUnit j b⁆ =
+      differenceShortRootUnit hij (a * b) *
+        positiveLongRootTransvectionUnit i (-(a ^ 2 * b)) := by
+  apply (GLSymplecticFin m R).subtype_injective
+  rw [map_commutatorElement, map_mul, Subgroup.coe_subtype,
+    coe_positiveSumShortRootUnit, coe_negativeLongRootTransvectionUnit,
+    coe_differenceShortRootUnit, coe_positiveLongRootTransvectionUnit]
+  let I := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl i)
+  let J := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl j)
+  let I' := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inr i)
+  let J' := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inr j)
+  have hIJ : I ≠ J := differenceShortRoot_first_indices_ne hij
+  have hJ'I' : J' ≠ I' := differenceShortRoot_second_indices_ne hij
+  have hIJ' : I ≠ J' := finSumFinEquiv_inl_ne_inr i j
+  have hJI' : J ≠ I' := finSumFinEquiv_inl_ne_inr j i
+  have hJ'J : J' ≠ J := finSumFinEquiv_inr_ne_inl j j
+  have hII' : I ≠ I' := finSumFinEquiv_inl_ne_inr i i
+  have hBC :
+      ⁅transvectionUnit hJI' a, transvectionUnit hJ'J b⁆ =
+        transvectionUnit hJ'I' (-(a * b)) := by
+    rw [commutatorElement_transvectionUnit_reverse hJI' hJ'J hJ'I']
+    congr 1
+    ring
+  have hAC :
+      ⁅transvectionUnit hIJ' a, transvectionUnit hJ'J b⁆ =
+        transvectionUnit hIJ (a * b) :=
+    commutatorElement_transvectionUnit hIJ' hJ'J hIJ a b
+  have hAE :
+      ⁅transvectionUnit hIJ' a, transvectionUnit hJ'I' (-(a * b))⁆ =
+        transvectionUnit hII' (-(a ^ 2 * b)) := by
+    rw [commutatorElement_transvectionUnit hIJ' hJ'I' hII']
+    congr 1
+    ring
+  rw [commutatorElement_mul_left_eq_conj_mul, hBC, hAC]
+  calc
+    transvectionUnit hIJ' a * transvectionUnit hJ'I' (-(a * b)) *
+          (transvectionUnit hIJ' a)⁻¹ * transvectionUnit hIJ (a * b) =
+        ⁅transvectionUnit hIJ' a, transvectionUnit hJ'I' (-(a * b))⁆ *
+          transvectionUnit hJ'I' (-(a * b)) * transvectionUnit hIJ (a * b) := by
+      rw [← MulAut.conj_apply, conj_eq_commutatorElement_mul]
+    _ = transvectionUnit hII' (-(a ^ 2 * b)) *
+          transvectionUnit hJ'I' (-(a * b)) * transvectionUnit hIJ (a * b) := by
+      rw [hAE]
+    _ = transvectionUnit hIJ (a * b) * transvectionUnit hJ'I' (-(a * b)) *
+          transvectionUnit hII' (-(a ^ 2 * b)) := by
+      rw [(commute_transvectionUnit hII' hJ'I' hJ'I'.symm hII'.symm _ _).eq,
+        mul_assoc,
+        (commute_transvectionUnit hII' hIJ hII'.symm hIJ.symm _ _).eq,
+        ← mul_assoc,
+        (commute_transvectionUnit hJ'I' hIJ hII'.symm hJ'J.symm _ _).eq]
+
+/-- **The complementary negative-sum multiply-laced Chevalley relation.** The commutator of
+`x_{-eᵢ-eⱼ}(a)` and `x_{2eⱼ}(b)` is the product of the root subgroups for `eⱼ-eᵢ`
+and `-2eᵢ`, both with the signs forced by the chosen parametrizations. -/
+theorem commutatorElement_negativeSumShortRootUnit_positiveLongRootTransvectionUnit
+    (hij : i ≠ j) (a b : R) :
+    ⁅negativeSumShortRootUnit hij a, positiveLongRootTransvectionUnit j b⁆ =
+      differenceShortRootUnit hij.symm (-(a * b)) *
+        negativeLongRootTransvectionUnit i (-(a ^ 2 * b)) := by
+  apply (GLSymplecticFin m R).subtype_injective
+  rw [map_commutatorElement, map_mul, Subgroup.coe_subtype,
+    coe_negativeSumShortRootUnit, coe_positiveLongRootTransvectionUnit,
+    coe_differenceShortRootUnit, coe_negativeLongRootTransvectionUnit]
+  simp only [neg_neg]
+  let I := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl i)
+  let J := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inl j)
+  let I' := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inr i)
+  let J' := (finSumFinEquiv : Fin m ⊕ Fin m ≃ Fin (m + m)) (Sum.inr j)
+  have hJI : J ≠ I := differenceShortRoot_first_indices_ne hij.symm
+  have hI'J' : I' ≠ J' := differenceShortRoot_second_indices_ne hij.symm
+  have hI'J : I' ≠ J := finSumFinEquiv_inr_ne_inl i j
+  have hJ'I : J' ≠ I := finSumFinEquiv_inr_ne_inl j i
+  have hJJ' : J ≠ J' := finSumFinEquiv_inl_ne_inr j j
+  have hI'I : I' ≠ I := finSumFinEquiv_inr_ne_inl i i
+  have hBC :
+      ⁅transvectionUnit hJ'I a, transvectionUnit hJJ' b⁆ =
+        transvectionUnit hJI (-(a * b)) := by
+    rw [commutatorElement_transvectionUnit_reverse hJ'I hJJ' hJI]
+    congr 1
+    ring
+  have hAC :
+      ⁅transvectionUnit hI'J a, transvectionUnit hJJ' b⁆ =
+        transvectionUnit hI'J' (a * b) :=
+    commutatorElement_transvectionUnit hI'J hJJ' hI'J' a b
+  have hAE :
+      ⁅transvectionUnit hI'J a, transvectionUnit hJI (-(a * b))⁆ =
+        transvectionUnit hI'I (-(a ^ 2 * b)) := by
+    rw [commutatorElement_transvectionUnit hI'J hJI hI'I]
+    congr 1
+    ring
+  rw [commutatorElement_mul_left_eq_conj_mul, hBC, hAC]
+  calc
+    transvectionUnit hI'J a * transvectionUnit hJI (-(a * b)) *
+          (transvectionUnit hI'J a)⁻¹ * transvectionUnit hI'J' (a * b) =
+        ⁅transvectionUnit hI'J a, transvectionUnit hJI (-(a * b))⁆ *
+          transvectionUnit hJI (-(a * b)) * transvectionUnit hI'J' (a * b) := by
+      rw [← MulAut.conj_apply, conj_eq_commutatorElement_mul]
+    _ = transvectionUnit hI'I (-(a ^ 2 * b)) *
+          transvectionUnit hJI (-(a * b)) * transvectionUnit hI'J' (a * b) := by
+      rw [hAE]
+    _ = transvectionUnit hJI (-(a * b)) * transvectionUnit hI'J' (a * b) *
+          transvectionUnit hI'I (-(a ^ 2 * b)) := by
+      rw [(commute_transvectionUnit hI'I hJI hJI.symm hI'I.symm _ _).eq,
+        mul_assoc,
+        (commute_transvectionUnit hI'I hI'J' hI'I.symm hI'J'.symm _ _).eq,
+        ← mul_assoc,
+        (commute_transvectionUnit hJI hI'J' hI'I.symm hJJ'.symm _ _).eq]
 
 end TauCeti.GLSymplecticFin

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/ChevalleyRelations.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/ChevalleyRelations.lean
@@ -298,6 +298,45 @@ theorem commutatorElement_differenceShortRootUnit_negativeSumShortRootUnit
   congr 1
   ring
 
+private theorem commutatorElement_transvectionUnit_pair_chain
+    {n : Type*} [Fintype n] [DecidableEq n] {p q r t : n}
+    (hpr : p ≠ r) (hqt : q ≠ t) (hrq : r ≠ q) (hrt : r ≠ t) (hpq : p ≠ q)
+    (hpt : p ≠ t) (a b : R) :
+    ⁅transvectionUnit hpr a * transvectionUnit hqt a, transvectionUnit hrq b⁆ =
+      transvectionUnit hpq (a * b) * transvectionUnit hrt (-(a * b)) *
+        transvectionUnit hpt (-(a ^ 2 * b)) := by
+  have hBC :
+      ⁅transvectionUnit hqt a, transvectionUnit hrq b⁆ =
+        transvectionUnit hrt (-(a * b)) := by
+    rw [commutatorElement_transvectionUnit_reverse hqt hrq hrt]
+    congr 1
+    ring
+  have hAC :
+      ⁅transvectionUnit hpr a, transvectionUnit hrq b⁆ =
+        transvectionUnit hpq (a * b) :=
+    commutatorElement_transvectionUnit hpr hrq hpq a b
+  have hAE :
+      ⁅transvectionUnit hpr a, transvectionUnit hrt (-(a * b))⁆ =
+        transvectionUnit hpt (-(a ^ 2 * b)) := by
+    rw [commutatorElement_transvectionUnit hpr hrt hpt]
+    congr 1
+    ring
+  rw [commutatorElement_mul_left_eq_conj_mul, hBC, hAC]
+  calc
+    transvectionUnit hpr a * transvectionUnit hrt (-(a * b)) *
+          (transvectionUnit hpr a)⁻¹ * transvectionUnit hpq (a * b) =
+        ⁅transvectionUnit hpr a, transvectionUnit hrt (-(a * b))⁆ *
+          transvectionUnit hrt (-(a * b)) * transvectionUnit hpq (a * b) := by
+      rw [← MulAut.conj_apply, conj_eq_commutatorElement_mul]
+    _ = transvectionUnit hpt (-(a ^ 2 * b)) * transvectionUnit hrt (-(a * b)) *
+          transvectionUnit hpq (a * b) := by
+      rw [hAE]
+    _ = transvectionUnit hpq (a * b) * transvectionUnit hrt (-(a * b)) *
+          transvectionUnit hpt (-(a ^ 2 * b)) := by
+      rw [(commute_transvectionUnit hpt hrt hrt.symm hpt.symm _ _).eq, mul_assoc,
+        (commute_transvectionUnit hpt hpq hpt.symm hpq.symm _ _).eq, ← mul_assoc,
+        (commute_transvectionUnit hrt hpq hpt.symm hrq.symm _ _).eq]
+
 /-- **The complementary positive-sum multiply-laced Chevalley relation.** The commutator of
 `x_{eᵢ+eⱼ}(a)` and `x_{-2eⱼ}(b)` is the product of the root subgroups for `eᵢ-eⱼ`
 and `2eᵢ`, with parameters `ab` and `-a²b`. -/
@@ -320,39 +359,7 @@ theorem commutatorElement_positiveSumShortRootUnit_negativeLongRootTransvectionU
   have hJI' : J ≠ I' := finSumFinEquiv_inl_ne_inr j i
   have hJ'J : J' ≠ J := finSumFinEquiv_inr_ne_inl j j
   have hII' : I ≠ I' := finSumFinEquiv_inl_ne_inr i i
-  have hBC :
-      ⁅transvectionUnit hJI' a, transvectionUnit hJ'J b⁆ =
-        transvectionUnit hJ'I' (-(a * b)) := by
-    rw [commutatorElement_transvectionUnit_reverse hJI' hJ'J hJ'I']
-    congr 1
-    ring
-  have hAC :
-      ⁅transvectionUnit hIJ' a, transvectionUnit hJ'J b⁆ =
-        transvectionUnit hIJ (a * b) :=
-    commutatorElement_transvectionUnit hIJ' hJ'J hIJ a b
-  have hAE :
-      ⁅transvectionUnit hIJ' a, transvectionUnit hJ'I' (-(a * b))⁆ =
-        transvectionUnit hII' (-(a ^ 2 * b)) := by
-    rw [commutatorElement_transvectionUnit hIJ' hJ'I' hII']
-    congr 1
-    ring
-  rw [commutatorElement_mul_left_eq_conj_mul, hBC, hAC]
-  calc
-    transvectionUnit hIJ' a * transvectionUnit hJ'I' (-(a * b)) *
-          (transvectionUnit hIJ' a)⁻¹ * transvectionUnit hIJ (a * b) =
-        ⁅transvectionUnit hIJ' a, transvectionUnit hJ'I' (-(a * b))⁆ *
-          transvectionUnit hJ'I' (-(a * b)) * transvectionUnit hIJ (a * b) := by
-      rw [← MulAut.conj_apply, conj_eq_commutatorElement_mul]
-    _ = transvectionUnit hII' (-(a ^ 2 * b)) *
-          transvectionUnit hJ'I' (-(a * b)) * transvectionUnit hIJ (a * b) := by
-      rw [hAE]
-    _ = transvectionUnit hIJ (a * b) * transvectionUnit hJ'I' (-(a * b)) *
-          transvectionUnit hII' (-(a ^ 2 * b)) := by
-      rw [(commute_transvectionUnit hII' hJ'I' hJ'I'.symm hII'.symm _ _).eq,
-        mul_assoc,
-        (commute_transvectionUnit hII' hIJ hII'.symm hIJ.symm _ _).eq,
-        ← mul_assoc,
-        (commute_transvectionUnit hJ'I' hIJ hII'.symm hJ'J.symm _ _).eq]
+  exact commutatorElement_transvectionUnit_pair_chain hIJ' hJI' hJ'J hJ'I' hIJ hII' a b
 
 /-- **The complementary negative-sum multiply-laced Chevalley relation.** The commutator of
 `x_{-eᵢ-eⱼ}(a)` and `x_{2eⱼ}(b)` is the product of the root subgroups for `eⱼ-eᵢ`
@@ -377,38 +384,7 @@ theorem commutatorElement_negativeSumShortRootUnit_positiveLongRootTransvectionU
   have hJ'I : J' ≠ I := finSumFinEquiv_inr_ne_inl j i
   have hJJ' : J ≠ J' := finSumFinEquiv_inl_ne_inr j j
   have hI'I : I' ≠ I := finSumFinEquiv_inr_ne_inl i i
-  have hBC :
-      ⁅transvectionUnit hJ'I a, transvectionUnit hJJ' b⁆ =
-        transvectionUnit hJI (-(a * b)) := by
-    rw [commutatorElement_transvectionUnit_reverse hJ'I hJJ' hJI]
-    congr 1
-    ring
-  have hAC :
-      ⁅transvectionUnit hI'J a, transvectionUnit hJJ' b⁆ =
-        transvectionUnit hI'J' (a * b) :=
-    commutatorElement_transvectionUnit hI'J hJJ' hI'J' a b
-  have hAE :
-      ⁅transvectionUnit hI'J a, transvectionUnit hJI (-(a * b))⁆ =
-        transvectionUnit hI'I (-(a ^ 2 * b)) := by
-    rw [commutatorElement_transvectionUnit hI'J hJI hI'I]
-    congr 1
-    ring
-  rw [commutatorElement_mul_left_eq_conj_mul, hBC, hAC]
-  calc
-    transvectionUnit hI'J a * transvectionUnit hJI (-(a * b)) *
-          (transvectionUnit hI'J a)⁻¹ * transvectionUnit hI'J' (a * b) =
-        ⁅transvectionUnit hI'J a, transvectionUnit hJI (-(a * b))⁆ *
-          transvectionUnit hJI (-(a * b)) * transvectionUnit hI'J' (a * b) := by
-      rw [← MulAut.conj_apply, conj_eq_commutatorElement_mul]
-    _ = transvectionUnit hI'I (-(a ^ 2 * b)) *
-          transvectionUnit hJI (-(a * b)) * transvectionUnit hI'J' (a * b) := by
-      rw [hAE]
-    _ = transvectionUnit hJI (-(a * b)) * transvectionUnit hI'J' (a * b) *
-          transvectionUnit hI'I (-(a ^ 2 * b)) := by
-      rw [(commute_transvectionUnit hI'I hJI hJI.symm hI'I.symm _ _).eq,
-        mul_assoc,
-        (commute_transvectionUnit hI'I hI'J' hI'I.symm hI'J'.symm _ _).eq,
-        ← mul_assoc,
-        (commute_transvectionUnit hJI hI'J' hI'I.symm hJJ'.symm _ _).eq]
+  rw [commutatorElement_transvectionUnit_pair_chain hI'J hJ'I hJJ' hJI hI'J' hI'I]
+  rw [(commute_transvectionUnit hJI hI'J' hI'I.symm hJJ'.symm (-(a * b)) (a * b)).eq]
 
 end TauCeti.GLSymplecticFin


### PR DESCRIPTION
This PR proves the two complementary sum-root/long-root Chevalley commutator identities in the standard symplectic group and lifts them to algebra-valued points of `Sp₂ₘ`: `[x_{eᵢ+eⱼ}(a), x_{-2eⱼ}(b)] = x_{eᵢ-eⱼ}(ab) x_{2eᵢ}(-a²b)` and its negative-root analogue.

It advances the ReductiveGroups Layer 9 **Root subgroup maps** milestone, specifically the target requiring Chevalley commutator relations for the explicit root subgroup maps, and supplies the remaining long/nonopposite-short interactions in the standard `C₂` realization used to check the characteristic-two special isogeny.

After this PR, Layer 9 still needs the compatible pinned `B₂`/`C₂` group-scheme carrier and the exceptional isogeny itself, including its long/short root-subgroup action and square-Frobenius theorem.

Dependency edge: CFSGStatement milestone L2, **Suzuki--Ree Steinberg maps**, consumes ReductiveGroups Layer 9's `B₂`/`C₂` special isogeny; these explicit `C₂` root-subgroup equations provide the commutator compatibility needed by that construction.

The proofs reuse Tau Ceti's general-linear transvection commutator API and existing symplectic root-subgroup parametrizations; no Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"symplectic-opposite-sum-long-commutator-relations"}-->

🤖 Prepared with Codex
