### PR TITLE
refactor(Lie): prove the dyadic halving step from mulInvariantExp_add_smul

### DIFF
--- a/TauCeti/Geometry/Lie/Exponential/Classification.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Classification.lean
@@ -118,37 +118,22 @@ private theorem eventually_continuousOneParameterLog_eq_two_smul_succ [FiniteDim
     (tendsto_add_atTop_nat 1).eventually hexp
   filter_upwards [hvU, htwoU, hexp, hexpSucc] with n hvn htwon hexpn hexpSuccn
   apply hinj hvn htwon
+  -- `φ` turns the doubled dyadic step into a square, and the exponential turns the square back
+  -- into a doubled Lie-algebra element.
+  have hsmul : (((2 : ℝ) • v (n + 1) : E) : GroupLieAlgebra I G) =
+      (2 : ℝ) • (v (n + 1) : GroupLieAlgebra I G) :=
+    (groupLieAlgebraEquivModelVectorSpace (I := I) (G := G)).symm.map_smul (2 : ℝ) (v (n + 1))
   calc
     mulInvariantExp (I := I) (G := G) (v n : GroupLieAlgebra I G) =
-        φ (Multiplicative.ofAdd (dyadicStep n)) := hexpn
-    _ = φ (Multiplicative.ofAdd
-        (dyadicStep (n + 1) + dyadicStep (n + 1))) := by
-      rw [← dyadicStep_eq_add_succ]
-    _ = φ (Multiplicative.ofAdd (dyadicStep (n + 1))) *
-        φ (Multiplicative.ofAdd (dyadicStep (n + 1))) := by
-      rw [ofAdd_add, map_mul]
-    _ = mulInvariantExp (I := I) (G := G) (v (n + 1) : GroupLieAlgebra I G) *
-        mulInvariantExp (I := I) (G := G) (v (n + 1) : GroupLieAlgebra I G) := by
-      rw [hexpSuccn]
-    _ = mulInvariantExp (I := I) (G := G)
-        (((1 : ℝ) + 1) • (v (n + 1) : GroupLieAlgebra I G)) := by
-      calc
         mulInvariantExp (I := I) (G := G) (v (n + 1) : GroupLieAlgebra I G) *
-              mulInvariantExp (I := I) (G := G) (v (n + 1) : GroupLieAlgebra I G) =
-            mulInvariantExp (I := I) (G := G)
-                ((1 : ℝ) • (v (n + 1) : GroupLieAlgebra I G)) *
-              mulInvariantExp (I := I) (G := G)
-                ((1 : ℝ) • (v (n + 1) : GroupLieAlgebra I G)) := by rw [one_smul]
-        _ = mulInvariantExp (I := I) (G := G)
-            (((1 : ℝ) + 1) • (v (n + 1) : GroupLieAlgebra I G)) :=
-        (mulInvariantExp_add_smul (I := I) (G := G)
-          (v (n + 1) : GroupLieAlgebra I G) (1 : ℝ) (1 : ℝ)).symm
-    _ = mulInvariantExp (I := I) (G := G)
-        (((2 : ℝ) • v (n + 1) : E) : GroupLieAlgebra I G) := by
-      have hsmul : (((2 : ℝ) • v (n + 1) : E) : GroupLieAlgebra I G) =
-          (2 : ℝ) • (v (n + 1) : GroupLieAlgebra I G) :=
-        (groupLieAlgebraEquivModelVectorSpace (I := I) (G := G)).symm.map_smul
-          (2 : ℝ) (v (n + 1))
+          mulInvariantExp (I := I) (G := G) (v (n + 1) : GroupLieAlgebra I G) := by
+      rw [hexpn, hexpSuccn, dyadicStep_eq_add_succ n, ofAdd_add, map_mul]
+    _ = mulInvariantExp (I := I) (G := G) ((1 : ℝ) • (v (n + 1) : GroupLieAlgebra I G)) *
+          mulInvariantExp (I := I) (G := G) ((1 : ℝ) • (v (n + 1) : GroupLieAlgebra I G)) := by
+      rw [one_smul]
+    _ = mulInvariantExp (I := I) (G := G) (((1 : ℝ) + 1) • (v (n + 1) : GroupLieAlgebra I G)) :=
+      (mulInvariantExp_add_smul (I := I) (G := G) (v (n + 1) : GroupLieAlgebra I G) 1 1).symm
+    _ = mulInvariantExp (I := I) (G := G) (((2 : ℝ) • v (n + 1) : E) : GroupLieAlgebra I G) := by
       rw [hsmul]
       norm_num
 


### PR DESCRIPTION
Prove the dyadic halving step of `eventually_continuousOneParameterLog_eq_two_smul_succ`
from the file's own one-parameter-subgroup law, instead of re-deriving that law inline.

## What changed

The proof closed with a 33-line `calc` (with a nested `calc`) showing

```
mulInvariantExp (v n) = mulInvariantExp ((2 : ℝ) • v (n + 1))
```

Read step by step, the chain is: `hexpn`, the dyadic recursion `dyadicStep_eq_add_succ`,
`ofAdd_add` + `map_mul`, `hexpSuccn`, and then — for the last 15 lines — a hand-derivation of
`exp x * exp x = exp ((1 + 1) • x)` from `one_smul` and `mulInvariantExp_add_smul x 1 1`
(an inner `calc` that rewrites each factor as `exp (1 • x)` first). That derivation **is**
`mulInvariantExp_add_smul` read right-to-left (the lemma is already `@[simp]` in
`Exponential/Basic.lean`); the calc was restating it in `v (n + 1)`-specific coordinates.

The chain is now a four-step `calc` in which every step is one of the original's own steps:

1. `exp (v n) = exp (v (n+1)) * exp (v (n+1))` — `hexpn`, `hexpSuccn`,
   `dyadicStep_eq_add_succ`, `ofAdd_add`, `map_mul` (the original's first four steps, one
   rewrite);
2. `… = exp (1 • v (n+1)) * exp (1 • v (n+1))` — `one_smul` (the inner calc's first step);
3. `… = exp ((1 + 1) • v (n+1))` — `mulInvariantExp_add_smul` as a term (the inner calc's
   second step);
4. `… = exp ((2 : ℝ) • v (n+1))` — the original's last step, verbatim (`hsmul` + `norm_num`).

| | before | after |
|---|---|---|
| `eventually_continuousOneParameterLog_eq_two_smul_succ` body | 56 lines | **41 lines** |
| new declarations | — | **none** |

The statement is unchanged; the proof's signpost comment is kept.

## Why a rewrite and not a named helper

The block profile of this proof flags the `calc` as its dominant block, and the obvious move
is to lift it into a helper. But the mathematical content of the block is an existing lemma
of this file's own API, so the improvement is to *use* that lemma, not to add a one-use
restatement of it (that restatement is exactly the shape the reuse rubric asks to inline).

`mulInvariantExp_nsmul` (`exp (m • v) = exp v ^ m`, for `m : ℕ`) was the other candidate;
going through it costs a `((2 : ℕ) : ℝ)` cast rewrite plus `pow_two`, while the
`add_smul` route needs no cast. The `hsmul` coercion identity (`E` vs `GroupLieAlgebra I G`)
stays, exactly as before, because `v` is valued in `E`; it is hoisted out of the last calc
step so the step reads as the numeral normalisation it is. Step 3 has to be a term rather than
a rewrite: the goal's `•` is elaborated at `E` while the lemma's is at `GroupLieAlgebra I G`, and
the two are definitionally but not syntactically equal.

## Gate

Module-scoped `lake build` of `Geometry.Lie.Exponential.Classification` and its sole importer
`Geometry.Lie.Exponential.Circle` (importer artifacts deleted first and confirmed
regenerated), exit 0, zero warnings.

Roadmap: none
