### PR TITLE
refactor(EllipticCurve): name the integrality core of mapsInfinity_of_one_lt_infinityPlace

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
@@ -181,7 +181,7 @@ variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
 
 /-- Once an `F`-algebra map into the function field of `W₁` sends some element to one with a pole
 at infinity, the affine coordinate of `W₁` is integral over the image of that map. -/
-private theorem isIntegral_X_over_range_of_one_lt_infinityPlace {A : Type*} [CommRing A]
+private theorem isIntegral_X_over_range_of_one_lt_infinityPlace {A : Type*} [CommSemiring A]
     [Algebra F A] (f : A →ₐ[F] W₁.FunctionField) (a : A) (h : 1 < infinityPlace W₁ (f a)) :
     IsIntegral f.range.toSubring (algebraMap F[X] W₁.FunctionField X) :=
   isIntegral_of_forall_valuation_le_one fun v hvle ↦ by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
@@ -179,16 +179,14 @@ namespace CoordinatePullback
 
 variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
 
-/-- Once the pulled-back coordinate of `W₂` has a pole at infinity, the affine coordinate of `W₁`
-is integral over the image of the pulled-back coordinate ring. -/
-private theorem isIntegral_range_X_of_one_lt_infinityPlace
-    (σ : W₂.FunctionField →ₐ[F] W₁.FunctionField)
-    (h : 1 < infinityPlace W₁ (σ (algebraMap F[X] W₂.FunctionField X))) :
-    IsIntegral
-      (σ.comp (IsScalarTower.toAlgHom F W₂.CoordinateRing W₂.FunctionField)).range.toSubring
-      (algebraMap F[X] W₁.FunctionField X) :=
+/-- Once the image of the coordinate of `W₂` under an `F`-algebra map into the function field of
+`W₁` has a pole at infinity, the affine coordinate of `W₁` is integral over the image of that
+map. -/
+private theorem isIntegral_X_over_range_of_one_lt_infinityPlace
+    (f : W₂.CoordinateRing →ₐ[F] W₁.FunctionField)
+    (h : 1 < infinityPlace W₁ (f (algebraMap F[X] W₂.CoordinateRing X))) :
+    IsIntegral f.range.toSubring (algebraMap F[X] W₁.FunctionField X) :=
   isIntegral_of_forall_valuation_le_one fun v hvle ↦ by
-    let f := σ.comp (IsScalarTower.toAlgHom F W₂.CoordinateRing W₂.FunctionField)
     let _ : ValuativeRel W₁.FunctionField := v
     let u := ValuativeRel.valuation W₁.FunctionField
     have hmemV : ∀ c : W₂.CoordinateRing, f c ∈ u.valuationSubring := fun c ↦
@@ -209,10 +207,7 @@ private theorem isIntegral_range_X_of_one_lt_infinityPlace
           ((Valuation.mem_valuationSubring_iff _ _).1
             (hPint ▸ P.mem_integers_iff.2 hle)))
       have hequiv := isEquiv_infinityPlace_of_one_lt (W := W₁) (v := P.valuation) hpole
-      have hσx : σ (algebraMap F[X] W₂.FunctionField X) = f (algebraMap F[X] W₂.CoordinateRing X) :=
-        congrArg σ (IsScalarTower.algebraMap_apply F[X] W₂.CoordinateRing W₂.FunctionField X)
       refine absurd ((Valuation.isEquiv_iff_val_le_one.1 hequiv).1 ?_) (not_le.2 h)
-      rw [hσx]
       exact P.mem_integers_iff.1 (hPint ▸ hmemV _)
 
 /-- **An embedding of function fields under which `x` acquires a pole at infinity maps infinity
@@ -229,8 +224,11 @@ theorem mapsInfinity_of_one_lt_infinityPlace (σ : W₂.FunctionField →ₐ[F] 
     rw [mem_integralClosure_iff]
     have hf : Function.Injective f :=
       σ.injective.comp (IsFractionRing.injective W₂.CoordinateRing W₂.FunctionField)
+    have hfX : f (algebraMap F[X] W₂.CoordinateRing X) = σ (algebraMap F[X] W₂.FunctionField X) :=
+      (congrArg σ (IsScalarTower.algebraMap_apply F[X] W₂.CoordinateRing W₂.FunctionField X)).symm
     let e := (AlgEquiv.ofInjective f hf).toRingEquiv
-    exact (e.isIntegral_iff (by rfl) _).2 (isIntegral_range_X_of_one_lt_infinityPlace σ h)
+    exact (e.isIntegral_iff (by rfl) _).2
+      (isIntegral_X_over_range_of_one_lt_infinityPlace f (by rw [hfX]; exact h))
   -- Every polynomial in that coordinate is then integral, so `F[X]` acts on the integral closure.
   have hmemq : ∀ q : F[X], algebraMap F[X] W₁.FunctionField q ∈ C := by
     intro q

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
@@ -179,17 +179,15 @@ namespace CoordinatePullback
 
 variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
 
-/-- Once the image of the coordinate of `W₂` under an `F`-algebra map into the function field of
-`W₁` has a pole at infinity, the affine coordinate of `W₁` is integral over the image of that
-map. -/
-private theorem isIntegral_X_over_range_of_one_lt_infinityPlace
-    (f : W₂.CoordinateRing →ₐ[F] W₁.FunctionField)
-    (h : 1 < infinityPlace W₁ (f (algebraMap F[X] W₂.CoordinateRing X))) :
+/-- Once an `F`-algebra map into the function field of `W₁` sends some element to one with a pole
+at infinity, the affine coordinate of `W₁` is integral over the image of that map. -/
+private theorem isIntegral_X_over_range_of_one_lt_infinityPlace {A : Type*} [CommRing A]
+    [Algebra F A] (f : A →ₐ[F] W₁.FunctionField) (a : A) (h : 1 < infinityPlace W₁ (f a)) :
     IsIntegral f.range.toSubring (algebraMap F[X] W₁.FunctionField X) :=
   isIntegral_of_forall_valuation_le_one fun v hvle ↦ by
     let _ : ValuativeRel W₁.FunctionField := v
     let u := ValuativeRel.valuation W₁.FunctionField
-    have hmemV : ∀ c : W₂.CoordinateRing, f c ∈ u.valuationSubring := fun c ↦
+    have hmemV : ∀ c : A, f c ∈ u.valuationSubring := fun c ↦
       (Valuation.mem_valuationSubring_iff _ _).2
         ((Valuation.vle_one_iff u).1 (hvle (f c) ⟨c, rfl⟩))
     have hFV : ∀ c : F, algebraMap F W₁.FunctionField c ∈ u.valuationSubring := fun c ↦ by
@@ -228,7 +226,7 @@ theorem mapsInfinity_of_one_lt_infinityPlace (σ : W₂.FunctionField →ₐ[F] 
       (congrArg σ (IsScalarTower.algebraMap_apply F[X] W₂.CoordinateRing W₂.FunctionField X)).symm
     let e := (AlgEquiv.ofInjective f hf).toRingEquiv
     exact (e.isIntegral_iff (by rfl) _).2
-      (isIntegral_X_over_range_of_one_lt_infinityPlace f (by rw [hfX]; exact h))
+      (isIntegral_X_over_range_of_one_lt_infinityPlace f _ (by rw [hfX]; exact h))
   -- Every polynomial in that coordinate is then integral, so `F[X]` acts on the integral closure.
   have hmemq : ∀ q : F[X], algebraMap F[X] W₁.FunctionField q ∈ C := by
     intro q

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/InfinityPlace.lean
@@ -179,6 +179,42 @@ namespace CoordinatePullback
 
 variable {F : Type*} [Field F] {W₁ W₂ : WeierstrassCurve.Affine F}
 
+/-- Once the pulled-back coordinate of `W₂` has a pole at infinity, the affine coordinate of `W₁`
+is integral over the image of the pulled-back coordinate ring. -/
+private theorem isIntegral_range_X_of_one_lt_infinityPlace
+    (σ : W₂.FunctionField →ₐ[F] W₁.FunctionField)
+    (h : 1 < infinityPlace W₁ (σ (algebraMap F[X] W₂.FunctionField X))) :
+    IsIntegral
+      (σ.comp (IsScalarTower.toAlgHom F W₂.CoordinateRing W₂.FunctionField)).range.toSubring
+      (algebraMap F[X] W₁.FunctionField X) :=
+  isIntegral_of_forall_valuation_le_one fun v hvle ↦ by
+    let f := σ.comp (IsScalarTower.toAlgHom F W₂.CoordinateRing W₂.FunctionField)
+    let _ : ValuativeRel W₁.FunctionField := v
+    let u := ValuativeRel.valuation W₁.FunctionField
+    have hmemV : ∀ c : W₂.CoordinateRing, f c ∈ u.valuationSubring := fun c ↦
+      (Valuation.mem_valuationSubring_iff _ _).2
+        ((Valuation.vle_one_iff u).1 (hvle (f c) ⟨c, rfl⟩))
+    have hFV : ∀ c : F, algebraMap F W₁.FunctionField c ∈ u.valuationSubring := fun c ↦ by
+      rw [← f.commutes]
+      exact hmemV _
+    by_cases hu : u.valuationSubring = ⊤
+    · exact (Valuation.vle_one_iff u).2
+        ((Valuation.mem_valuationSubring_iff _ _).1 (hu ▸ trivial))
+    · set P := Place.ofValuationSubring W₁.isFunctionField hFV hu
+      have hPint : P.integers = u.valuationSubring :=
+        Place.integers_ofValuationSubring _ hFV hu
+      by_contra hx
+      have hpole : 1 < P.valuation (algebraMap F[X] W₁.FunctionField X) :=
+        not_le.1 fun hle ↦ hx ((Valuation.vle_one_iff u).2
+          ((Valuation.mem_valuationSubring_iff _ _).1
+            (hPint ▸ P.mem_integers_iff.2 hle)))
+      have hequiv := isEquiv_infinityPlace_of_one_lt (W := W₁) (v := P.valuation) hpole
+      have hσx : σ (algebraMap F[X] W₂.FunctionField X) = f (algebraMap F[X] W₂.CoordinateRing X) :=
+        congrArg σ (IsScalarTower.algebraMap_apply F[X] W₂.CoordinateRing W₂.FunctionField X)
+      refine absurd ((Valuation.isEquiv_iff_val_le_one.1 hequiv).1 ?_) (not_le.2 h)
+      rw [hσx]
+      exact P.mem_integers_iff.1 (hPint ▸ hmemV _)
+
 /-- **An embedding of function fields under which `x` acquires a pole at infinity maps infinity
 to infinity.** -/
 theorem mapsInfinity_of_one_lt_infinityPlace (σ : W₂.FunctionField →ₐ[F] W₁.FunctionField)
@@ -187,46 +223,14 @@ theorem mapsInfinity_of_one_lt_infinityPlace (σ : W₂.FunctionField →ₐ[F] 
   rw [mapsInfinity_iff]
   let f := σ.comp (IsScalarTower.toAlgHom F W₂.CoordinateRing W₂.FunctionField)
   let _ := f.toRingHom.toAlgebra
-  have hcoord : ∀ c : W₂.CoordinateRing,
-      algebraMap W₂.CoordinateRing W₁.FunctionField c = σ (algebraMap _ _ c) := fun _ ↦ rfl
   set C := integralClosure W₂.CoordinateRing W₁.FunctionField
   -- The affine coordinate of `W₁` is integral over the pulled-back coordinate ring.
   have hx₁ : algebraMap F[X] W₁.FunctionField X ∈ C := by
     rw [mem_integralClosure_iff]
-    let B := f.range.toSubring
     have hf : Function.Injective f :=
       σ.injective.comp (IsFractionRing.injective W₂.CoordinateRing W₂.FunctionField)
-    have hxB : IsIntegral B (algebraMap F[X] W₁.FunctionField X) :=
-      isIntegral_of_forall_valuation_le_one fun v hvle ↦ by
-        let _ : ValuativeRel W₁.FunctionField := v
-        let u := ValuativeRel.valuation W₁.FunctionField
-        have hmemV : ∀ c : W₂.CoordinateRing, f c ∈ u.valuationSubring := fun c ↦
-          (Valuation.mem_valuationSubring_iff _ _).2
-            ((Valuation.vle_one_iff u).1 (hvle (f c) ⟨c, rfl⟩))
-        have hFV : ∀ c : F, algebraMap F W₁.FunctionField c ∈ u.valuationSubring := fun c ↦ by
-          rw [← f.commutes]
-          exact hmemV _
-        by_cases hu : u.valuationSubring = ⊤
-        · exact (Valuation.vle_one_iff u).2
-            ((Valuation.mem_valuationSubring_iff _ _).1 (hu ▸ trivial))
-        · set P := Place.ofValuationSubring W₁.isFunctionField hFV hu
-          have hPint : P.integers = u.valuationSubring :=
-            Place.integers_ofValuationSubring _ hFV hu
-          by_contra hx
-          have hpole : 1 < P.valuation (algebraMap F[X] W₁.FunctionField X) :=
-            not_le.1 fun hle ↦ hx ((Valuation.vle_one_iff u).2
-              ((Valuation.mem_valuationSubring_iff _ _).1
-                (hPint ▸ P.mem_integers_iff.2 hle)))
-          have hequiv := isEquiv_infinityPlace_of_one_lt (W := W₁) (v := P.valuation) hpole
-          have hσx : σ (algebraMap F[X] W₂.FunctionField X) =
-              algebraMap W₂.CoordinateRing W₁.FunctionField
-                (algebraMap F[X] W₂.CoordinateRing X) := by
-            rw [hcoord, ← IsScalarTower.algebraMap_apply F[X] W₂.CoordinateRing W₂.FunctionField]
-          refine absurd ((Valuation.isEquiv_iff_val_le_one.1 hequiv).1 ?_) (not_le.2 h)
-          rw [hσx]
-          exact P.mem_integers_iff.1 (hPint ▸ hmemV _)
     let e := (AlgEquiv.ofInjective f hf).toRingEquiv
-    exact (e.isIntegral_iff (by rfl) _).2 hxB
+    exact (e.isIntegral_iff (by rfl) _).2 (isIntegral_range_X_of_one_lt_infinityPlace σ h)
   -- Every polynomial in that coordinate is then integral, so `F[X]` acts on the integral closure.
   have hmemq : ∀ q : F[X], algebraMap F[X] W₁.FunctionField q ∈ C := by
     intro q


### PR DESCRIPTION
Name the valuation-theoretic core of `mapsInfinity_of_one_lt_infinityPlace`: the statement that
the affine coordinate of `W₁` is integral over the image of an `F`-algebra map
`A →ₐ[F] W₁.FunctionField` once that map sends some element of `A` to an element with a pole at
infinity.

## What moved

`mapsInfinity_of_one_lt_infinityPlace` proved `MapsInfinity` by building the integral closure
`C` of the pulled-back coordinate ring and showing `x₁ ∈ C`. The heart of that membership — an
`isIntegral_of_forall_valuation_le_one` argument that runs through every valuation of
`W₁.FunctionField` and, for the non-trivial ones, through the place at infinity — was the
27-line `hxB` block nested two `have`s deep. It is now
`isIntegral_X_over_range_of_one_lt_infinityPlace`, and the parent applies it (to the composite
`f := σ.comp (IsScalarTower.toAlgHom F W₂.CoordinateRing W₂.FunctionField)`) through the
`AlgEquiv.ofInjective` transport exactly as before.

| | before | after |
|---|---|---|
| `mapsInfinity_of_one_lt_infinityPlace` body | 62 lines | **31 lines** |
| `isIntegral_X_over_range_of_one_lt_infinityPlace` | — | 24 lines |

The public statement of `mapsInfinity_of_one_lt_infinityPlace` is byte-identical; its consumer
(`Isogeny/InfinityPlace.lean`, the `mapsInfinity_iff_isEquiv_comap_infinityPlace` proof) and
importer (`Isogeny/Factorisation.lean`) are untouched.

## Hypotheses, re-derived from the block

The block ran under a local `Algebra W₂.CoordinateRing W₁.FunctionField` instance
(`f.toRingHom.toAlgebra`), a `let`-bound `f`, and the embedding `σ`. Reading it for what it
consumes:

| used | from | needs `σ`? needs the local instance? |
|---|---|---|
| `hvle`, `v` | binder of `isIntegral_of_forall_valuation_le_one` | no / no |
| `hmemV`, `hFV` | `f` and `hvle` (`f.commutes` for the constants) | no / no |
| `P`, `hPint`, `hpole`, `hequiv` | `Place.ofValuationSubring`, `isEquiv_infinityPlace_of_one_lt` | no / no |
| the final contradiction | `h`, which only mentions `σ (algebraMap F[X] W₂.FunctionField X)` = `f (algebraMap F[X] W₂.CoordinateRing X)` | **only through `f`** |

So the helper is stated for an arbitrary commutative `F`-algebra `A` (a `CommSemiring`: the
proof never subtracts in `A`), an `F`-algebra map
`f : A →ₐ[F] W₁.FunctionField` and an element `a : A` with `1 < infinityPlace W₁ (f a)`, over
`f.range.toSubring` — no second curve, no embedding of function fields, no `letI`-in-statement
(the `F`-algebra structure is the floor: `f.commutes` is what makes the place trivial on `F`).
The parent instantiates `A := W₂.CoordinateRing`, `f` the composite and `a` the coordinate, with
the one-line scalar-tower identity `hfX` relating `f a` to `σ`'s value; the now-unused `hcoord`
and local `B` are gone from the parent.

## Naming and placement

- `isIntegral_X_over_range_of_one_lt_infinityPlace`: `IsIntegral f.range.toSubring
  (algebraMap F[X] _ X)` under `1 < infinityPlace W₁ (f a)`, element first, following
  `IsIntegral`-conclusion naming and the file's `…_of_one_lt_infinityPlace` /
  `one_lt_infinityPlace_X` names.
- `private`: it is the parent's argument, stated on the parent's objects; placed directly above
  the parent's docstring in the same `CoordinatePullback` section.

## Notes for review

- Apart from generalising the parameters from `σ` to `(A, f, a)` (which deletes the `hσx`
  bridge the first version carried) the proof body is a verbatim lift; the `by_cases hu` on triviality of
  the valuation and the `by_contra` are unchanged.
- Gate: module-scoped `lake build` of `EllipticCurve.Isogeny.InfinityPlace` and its sole
  importer `EllipticCurve.Isogeny.Factorisation` (importer artifacts deleted first and confirmed
  regenerated), exit 0, zero warnings.

Roadmap: none
