### PR TITLE
feat: T_{p^r} = T_p^r at a prime dividing the level

### DIFF
--- a/TauCeti/Data/Int/LinearCongruence.lean
+++ b/TauCeti/Data/Int/LinearCongruence.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+-- `ZMod.coe_int_isUnit_iff_isCoprime` is used only inside the proof below.
+import Mathlib.Data.ZMod.Units
+import TauCeti.Data.ZMod.Divisibility
+
+/-!
+# Reduced integer solutions to linear congruences
+
+A linear congruence with coefficient coprime to its modulus has a solution in the canonical
+interval of representatives.
+
+## Main results
+
+* `Int.exists_nonneg_lt_and_dvd_mul_sub`: an integer in `[0, m)` solving
+  `a * r ≡ b (mod m)` when `a` is coprime to `m`.
+-/
+
+public section
+
+namespace Int
+
+/-- **A reduced integer solution to a linear congruence.** With `a` coprime to `m` there is an
+`r` in `[0, m)` solving `a * r ≡ b (mod m)`.
+
+This is `ZMod.exists_dvd_sub_val_mul` repackaged from a residue class into its canonical integer
+representative. -/
+lemma exists_nonneg_lt_and_dvd_mul_sub (a b : ℤ) (m : ℕ) (hm_pos : 0 < m)
+    (ham : Int.gcd a m = 1) :
+    ∃ r : ℤ, 0 ≤ r ∧ r < m ∧ (m : ℤ) ∣ a * r - b := by
+  have : NeZero m := ⟨hm_pos.ne'⟩
+  have hunit : IsUnit ((a : ℤ) : ZMod m) := (ZMod.coe_int_isUnit_iff_isCoprime a m).mpr
+    (isCoprime_comm.mp (Int.isCoprime_iff_gcd_eq_one.mpr ham))
+  obtain ⟨r, hr⟩ := ZMod.exists_dvd_sub_val_mul m b a hunit
+  refine ⟨(r.val : ℤ), Int.natCast_nonneg _, by exact_mod_cast r.val_lt, ?_⟩
+  rw [← neg_sub, mul_comm]
+  exact dvd_neg.mpr hr
+
+end Int

--- a/TauCeti/Data/ZMod/Divisibility.lean
+++ b/TauCeti/Data/ZMod/Divisibility.lean
@@ -25,8 +25,6 @@ consumed there and in `HeckeRing/GL2/Gamma1/CoprimeCosets.lean`.
 
 * `ZMod.exists_dvd_sub_val_mul`: the congruence `j b ≡ a (mod n)` has a solution `j : ZMod n`
   whenever `b` is a unit modulo `n`.
-* `Int.exists_nonneg_lt_and_dvd_mul_sub`: the same solution as an integer in `[0, n)` when
-  the coefficient is coprime to `n`.
 -/
 
 public section
@@ -47,23 +45,3 @@ lemma exists_dvd_sub_val_mul (n : ℕ) [NeZero n] (a b : ℤ)
   rw [hunit, mul_one, sub_self]
 
 end ZMod
-
-namespace Int
-
-/-- **A reduced integer solution to a linear congruence.** With `a` coprime to `m` there is an
-`r` in `[0, m)` solving `a * r ≡ b (mod m)`.
-
-This is `ZMod.exists_dvd_sub_val_mul` repackaged from a residue class into its canonical integer
-representative. -/
-lemma exists_nonneg_lt_and_dvd_mul_sub (a b : ℤ) (m : ℕ) (hm_pos : 0 < m)
-    (ham : Int.gcd a m = 1) :
-    ∃ r : ℤ, 0 ≤ r ∧ r < m ∧ (m : ℤ) ∣ a * r - b := by
-  have : NeZero m := ⟨hm_pos.ne'⟩
-  have hunit : IsUnit ((a : ℤ) : ZMod m) := (ZMod.coe_int_isUnit_iff_isCoprime a m).mpr
-    (isCoprime_comm.mp (Int.isCoprime_iff_gcd_eq_one.mpr ham))
-  obtain ⟨r, hr⟩ := ZMod.exists_dvd_sub_val_mul m b a hunit
-  refine ⟨(r.val : ℤ), Int.natCast_nonneg _, by exact_mod_cast r.val_lt, ?_⟩
-  rw [← neg_sub, mul_comm]
-  exact dvd_neg.mpr hr
-
-end Int

--- a/TauCeti/Data/ZMod/Divisibility.lean
+++ b/TauCeti/Data/ZMod/Divisibility.lean
@@ -5,6 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
+import Mathlib.Data.ZMod.Units
 public import Mathlib.Data.ZMod.Basic
 
 /-!
@@ -24,6 +25,8 @@ consumed there and in `HeckeRing/GL2/Gamma1/CoprimeCosets.lean`.
 
 * `ZMod.exists_dvd_sub_val_mul`: the congruence `j b ≡ a (mod n)` has a solution `j : ZMod n`
   whenever `b` is a unit modulo `n`.
+* `Int.exists_nonneg_lt_and_dvd_mul_sub`: the same solution as an integer in `[0, n)` when
+  the coefficient is coprime to `n`.
 -/
 
 public section
@@ -44,3 +47,23 @@ lemma exists_dvd_sub_val_mul (n : ℕ) [NeZero n] (a b : ℤ)
   rw [hunit, mul_one, sub_self]
 
 end ZMod
+
+namespace Int
+
+/-- **A reduced integer solution to a linear congruence.** With `a` coprime to `m` there is an
+`r` in `[0, m)` solving `a * r ≡ b (mod m)`.
+
+This is `ZMod.exists_dvd_sub_val_mul` repackaged from a residue class into its canonical integer
+representative. -/
+lemma exists_nonneg_lt_and_dvd_mul_sub (a b : ℤ) (m : ℕ) (hm_pos : 0 < m)
+    (ham : Int.gcd a m = 1) :
+    ∃ r : ℤ, 0 ≤ r ∧ r < m ∧ (m : ℤ) ∣ a * r - b := by
+  have : NeZero m := ⟨hm_pos.ne'⟩
+  have hunit : IsUnit ((a : ℤ) : ZMod m) := (ZMod.coe_int_isUnit_iff_isCoprime a m).mpr
+    (isCoprime_comm.mp (Int.isCoprime_iff_gcd_eq_one.mpr ham))
+  obtain ⟨r, hr⟩ := ZMod.exists_dvd_sub_val_mul m b a hunit
+  refine ⟨(r.val : ℤ), Int.natCast_nonneg _, by exact_mod_cast r.val_lt, ?_⟩
+  rw [← neg_sub, mul_comm]
+  exact dvd_neg.mpr hr
+
+end Int

--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -184,7 +184,8 @@ lemma upperTriRep_mul_upperTriRep {n m : ℕ} (b' : Fin n) (b : Fin m) :
     upperTriRep n b' * upperTriRep m b = upperTriRep (n * m) (finProdFinEquiv (b', b)) := by
   refine Units.ext ?_
   rw [Units.val_mul, coe_upperTriRep, coe_upperTriRep, coe_upperTriRep, Matrix.mul_fin_two]
-  have hval : ((finProdFinEquiv (b', b) : Fin (n * m)) : ℕ) = (b : ℕ) + m * (b' : ℕ) := rfl
+  have hval : ((finProdFinEquiv (b', b) : Fin (n * m)) : ℕ) = (b : ℕ) + m * (b' : ℕ) :=
+    finProdFinEquiv_apply_val (b', b)
   rw [hval]
   congrm !![?_, ?_; ?_, ?_] <;> push_cast <;> ring1
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/CosetDecomposition.lean
@@ -51,6 +51,8 @@ these representatives are in `GL2/UpperTriangularDelta0.lean`.
   `!![1, b; 0, p]`.
 * `HeckeRing.GL2.upperTriRep_apply_one_zero`: the representatives are upper triangular — the
   hypothesis mathlib's `IsBoundedAtImInfty.slash` asks for.
+* `HeckeRing.GL2.upperTriRep_mul_upperTriRep`: the families at indices `n` and `m` multiply into
+  the family at index `n · m`, along `finProdFinEquiv`.
 * `HeckeRing.GL2.det_upperTriRep_pos`: they have determinant `p > 0`, which is what lets scalars
   pass through a slash by them without the `σ` twist.
 
@@ -168,6 +170,23 @@ noncomputable def upperTriRep (b : Fin p) : GL (Fin 2) ℚ :=
 @[simp] lemma upperTriRep_apply_one_zero (b : Fin p) :
     (↑(upperTriRep p b) : Matrix (Fin 2) (Fin 2) ℚ) 1 0 = 0 :=
   upperTriGL_apply_eq_zero_of_lt (fun i ↦ by fin_cases i <;> simp [b.pos]) _ (by decide)
+
+/-- **The upper-triangular representatives compose.** The product of the representative at
+offset `b'` of index `n` with the one at offset `b` of index `m` is again a representative,
+
+`!![1, b'; 0, n] * !![1, b; 0, m] = !![1, b + m·b'; 0, n·m]`,
+
+at index `n · m` and at the offset `finProdFinEquiv (b', b)`, which is exactly `b + m · b'`.
+
+Since `finProdFinEquiv` is a bijection, the `n · m` representatives are enumerated once each by
+the pairs, which is what makes the slash sums over these families multiply. -/
+lemma upperTriRep_mul_upperTriRep {n m : ℕ} (b' : Fin n) (b : Fin m) :
+    upperTriRep n b' * upperTriRep m b = upperTriRep (n * m) (finProdFinEquiv (b', b)) := by
+  refine Units.ext ?_
+  rw [Units.val_mul, coe_upperTriRep, coe_upperTriRep, coe_upperTriRep, Matrix.mul_fin_two]
+  have hval : ((finProdFinEquiv (b', b) : Fin (n * m)) : ℕ) = (b : ℕ) + m * (b' : ℕ) := rfl
+  rw [hval]
+  congrm !![?_, ?_; ?_, ?_] <;> push_cast <;> ring1
 
 /-- The representatives have positive determinant: `det !![1, b; 0, p] = p > 0`. -/
 lemma det_upperTriRep_pos (b : Fin p) :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/BadPrimeCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/BadPrimeCoset.lean
@@ -7,7 +7,7 @@ module
 
 -- `ZMod.coe_int_isUnit_iff_isCoprime` is used only inside a proof, so this stays private.
 import Mathlib.Data.ZMod.Units
-import TauCeti.Data.ZMod.Divisibility
+import TauCeti.Data.Int.LinearCongruence
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.DoubleCoset
 public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 
@@ -51,8 +51,9 @@ the remaining parameter into a second `Γ₀(N)` factor, which is what makes the
   `dvd_lowerRight_witness`, `shimura_prop_3_33_gen` and `shimura_prop_3_33`.
 
   Five source declarations are deliberately **not** ported. `exists_mod_clearing` is the
-  Bézout step behind `Int.exists_nonneg_lt_and_dvd_mul_sub`, and `ZMod.exists_dvd_sub_val_mul`
-  (`TauCeti/Data/ZMod/Divisibility.lean`) already solves that congruence.
+  Bézout step behind `Int.exists_nonneg_lt_and_dvd_mul_sub`
+  (`TauCeti/Data/Int/LinearCongruence.lean`), which repackages the congruence solver
+  `ZMod.exists_dvd_sub_val_mul`.
   `diagMat_one_mem_Delta0` and `diagMat_mem_Delta0_of_gcd` are already on main as
   `natDiagGL_one_mem_Delta0` and
   `natDiagGL_mem_Delta0_of_coprime`. `fin2_col_scale` exists only to drive the source's

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/BadPrimeCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/BadPrimeCoset.lean
@@ -5,8 +5,10 @@ Authors: Chris Birkbeck, Claude
 -/
 module
 
--- `ZMod.coe_int_isUnit_iff_isCoprime` is used only inside a proof, so this stays private.
+-- `ZMod.coe_int_isUnit_iff_isCoprime` and `ZMod.exists_dvd_sub_val_mul` are used only inside
+-- proofs, so these stay private.
 import Mathlib.Data.ZMod.Units
+import TauCeti.Data.ZMod.Divisibility
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.DoubleCoset
 public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 
@@ -47,11 +49,13 @@ the remaining parameter into a second `Γ₀(N)` factor, which is what makes the
 * Ported from [AINTLIB](https://github.com/CBirkbeck/AINTLIB) commit
   `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck,
   `LeanModularForms/HeckeRIngs/GLn/CongruenceHecke/Props.lean`, declarations
-  `exists_mod_clearing`, `dvd_lowerRight_witness`, `shimura_prop_3_33_gen` and
-  `shimura_prop_3_33`.
+  `dvd_lowerRight_witness`, `shimura_prop_3_33_gen` and `shimura_prop_3_33`.
 
-  Four source declarations are deliberately **not** ported. `diagMat_one_mem_Delta0` and
-  `diagMat_mem_Delta0_of_gcd` are already on main as `natDiagGL_one_mem_Delta0` and
+  Five source declarations are deliberately **not** ported. `exists_mod_clearing` is the
+  Bézout step behind `exists_reduced_shear`, and `ZMod.exists_dvd_sub_val_mul`
+  (`TauCeti/Data/ZMod/Divisibility.lean`) already solves that congruence.
+  `diagMat_one_mem_Delta0` and `diagMat_mem_Delta0_of_gcd` are already on main as
+  `natDiagGL_one_mem_Delta0` and
   `natDiagGL_mem_Delta0_of_coprime`. `fin2_col_scale` exists only to drive the source's
   entrywise `fin_cases`/`linarith` verification of the final matrix identity, which is done
   here by factoring `!![1, r; 0, m]` and reusing `HeckeRing.GLn.mapGL_mul_coe_eq_intMatrix`.
@@ -71,17 +75,6 @@ open Matrix Matrix.SpecialLinearGroup CongruenceSubgroup HeckeRing.GLn
 open scoped MatrixGroups
 
 namespace HeckeRing.GL2
-
-/-- **Bézout, in the shape a row operation needs.** If `a` is coprime to `p` then the residue
-of `c` can be cleared by adding a multiple of `a`: some `t` has `p ∣ t * a + c`.
-
-Stated over `ℤ` with `p : ℕ` because the modulus arrives as a natural determinant. -/
-lemma exists_mod_clearing (a c : ℤ) (p : ℕ) (hap : Int.gcd a p = 1) :
-    ∃ t : ℤ, (p : ℤ) ∣ (t * a + c) := by
-  refine ⟨-c * Int.gcdA a p, ⟨c * Int.gcdB a p, ?_⟩⟩
-  have bez := Int.gcd_eq_gcd_ab a p
-  rw [hap] at bez
-  linear_combination c * bez
 
 /-- **Clearing the upper row clears the lower-right entry too.** For an integral matrix whose
 lower-left entry is `N * c₀` and whose determinant is `m`, with the upper-left entry coprime to
@@ -108,22 +101,20 @@ private lemma dvd_lowerRight_witness (A : Matrix (Fin 2) (Fin 2) ℤ) (N m : ℕ
 /-- **The reduced shear parameter.** With `a` coprime to `m` there is an `r` in `[0, m)`
 solving `a * r ≡ b (mod m)`.
 
-Split out of `exists_unimodular_mul_upperTriangular` below: it is the arithmetic half, and
-isolating it keeps that lemma's matrix bookkeeping readable. -/
+This is `ZMod.exists_dvd_sub_val_mul` repackaged: that lemma returns the solution as a residue
+class, and the two consumers here — the column reduction below and the `Γ₁(N)` offset in
+`Gamma1/UpperTriCosets.lean` — both need it as an integer in `[0, m)`. -/
 lemma exists_reduced_shear (a b : ℤ) (m : ℕ) (hm_pos : 0 < m)
     (ham : Int.gcd a m = 1) :
     ∃ r : ℤ, 0 ≤ r ∧ r < m ∧ (m : ℤ) ∣ a * r - b := by
-  obtain ⟨t_inv, ht⟩ := exists_mod_clearing a (-b) m ham
-  refine ⟨t_inv % (m : ℤ), Int.emod_nonneg _ (by omega), Int.emod_lt_of_pos _ (by omega), ?_⟩
-  -- `t_inv` differs from its residue by a multiple of `m`, so subtracting that multiple of
-  -- `a` from Bézout's combination leaves the divisibility intact.
-  have hquot : t_inv - t_inv % (m : ℤ) = (m : ℤ) * (t_inv / (m : ℤ)) := by
-    linarith [Int.mul_ediv_add_emod t_inv ((m : ℤ))]
-  have hm_tr : (m : ℤ) ∣ (t_inv - t_inv % (m : ℤ)) := hquot ▸ dvd_mul_right _ _
-  have h := dvd_sub ht (dvd_mul_of_dvd_left hm_tr a)
-  have hcollapse : t_inv * a + -b - (t_inv - t_inv % (m : ℤ)) * a
-      = a * (t_inv % (m : ℤ)) - b := by ring
-  rwa [hcollapse] at h
+  have : NeZero m := ⟨hm_pos.ne'⟩
+  have hunit : IsUnit ((a : ℤ) : ZMod m) := (ZMod.coe_int_isUnit_iff_isCoprime a m).mpr
+    (isCoprime_comm.mp (Int.isCoprime_iff_gcd_eq_one.mpr ham))
+  obtain ⟨r, hr⟩ := ZMod.exists_dvd_sub_val_mul m b a hunit
+  refine ⟨(r.val : ℤ), Int.natCast_nonneg _, by exact_mod_cast r.val_lt, ?_⟩
+  -- `hr` divides `b - r * a`; negating and commuting the product is the whole gap
+  rw [← neg_sub, mul_comm]
+  exact dvd_neg.mpr hr
 
 /-- **The determinant of an integral witness.** If `A` represents `g ∈ GL₂(ℚ)` entrywise over
 `ℤ` and `g` has determinant `m`, then `A` has determinant `m` over `ℤ`.

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/BadPrimeCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/BadPrimeCoset.lean
@@ -105,24 +105,24 @@ private lemma dvd_lowerRight_witness (A : Matrix (Fin 2) (Fin 2) ℤ) (N m : ℕ
   exact ((Int.isCoprime_iff_gcd_eq_one.mpr ham).symm).dvd_of_dvd_mul_left
     (h_key ▸ dvd_add (dvd_refl _) (dvd_mul_of_dvd_left hm_ba _))
 
-/-- **The reduced shear parameter.** With `A 0 0` coprime to `m` there is an `r` in `[0, m)`
-clearing the upper row modulo `m`: `m ∣ A 0 0 * r - A 0 1`.
+/-- **The reduced shear parameter.** With `a` coprime to `m` there is an `r` in `[0, m)`
+solving `a * r ≡ b (mod m)`.
 
 Split out of `exists_unimodular_mul_upperTriangular` below: it is the arithmetic half, and
 isolating it keeps that lemma's matrix bookkeeping readable. -/
-private lemma exists_reduced_shear (A : Matrix (Fin 2) (Fin 2) ℤ) (m : ℕ) (hm_pos : 0 < m)
-    (ham : Int.gcd (A 0 0) m = 1) :
-    ∃ r : ℤ, 0 ≤ r ∧ r < m ∧ (m : ℤ) ∣ (A 0 0 * r - A 0 1) := by
-  obtain ⟨t_inv, ht⟩ := exists_mod_clearing (A 0 0) (-A 0 1) m ham
+lemma exists_reduced_shear (a b : ℤ) (m : ℕ) (hm_pos : 0 < m)
+    (ham : Int.gcd a m = 1) :
+    ∃ r : ℤ, 0 ≤ r ∧ r < m ∧ (m : ℤ) ∣ a * r - b := by
+  obtain ⟨t_inv, ht⟩ := exists_mod_clearing a (-b) m ham
   refine ⟨t_inv % (m : ℤ), Int.emod_nonneg _ (by omega), Int.emod_lt_of_pos _ (by omega), ?_⟩
   -- `t_inv` differs from its residue by a multiple of `m`, so subtracting that multiple of
-  -- `A 0 0` from Bézout's combination leaves the divisibility intact.
+  -- `a` from Bézout's combination leaves the divisibility intact.
   have hquot : t_inv - t_inv % (m : ℤ) = (m : ℤ) * (t_inv / (m : ℤ)) := by
     linarith [Int.mul_ediv_add_emod t_inv ((m : ℤ))]
   have hm_tr : (m : ℤ) ∣ (t_inv - t_inv % (m : ℤ)) := hquot ▸ dvd_mul_right _ _
-  have h := dvd_sub ht (dvd_mul_of_dvd_left hm_tr (A 0 0))
-  have hcollapse : t_inv * A 0 0 + -A 0 1 - (t_inv - t_inv % (m : ℤ)) * A 0 0
-      = A 0 0 * (t_inv % (m : ℤ)) - A 0 1 := by ring
+  have h := dvd_sub ht (dvd_mul_of_dvd_left hm_tr a)
+  have hcollapse : t_inv * a + -b - (t_inv - t_inv % (m : ℤ)) * a
+      = a * (t_inv % (m : ℤ)) - b := by ring
   rwa [hcollapse] at h
 
 /-- **The determinant of an integral witness.** If `A` represents `g ∈ GL₂(ℚ)` entrywise over
@@ -179,7 +179,8 @@ lemma exists_unimodular_mul_upperTriangular (N : ℕ) (A : Matrix (Fin 2) (Fin 2
     ∃ (L : Matrix (Fin 2) (Fin 2) ℤ) (r : ℤ), L.det = 1 ∧ (N : ℤ) ∣ L 1 0 ∧ 0 ≤ r ∧ r < m ∧
       A = L * (Matrix.of ![![(1 : ℤ), r], ![0, (m : ℤ)]]) := by
   obtain ⟨c₀, hc₀⟩ := hAN
-  obtain ⟨r, hr_nonneg, hr_lt, hm_ar_b⟩ := exists_reduced_shear A m hm_pos ham
+  obtain ⟨r, hr_nonneg, hr_lt, hm_ar_b⟩ :=
+    exists_reduced_shear (A 0 0) (A 0 1) m hm_pos ham
   obtain ⟨q₂, hq₂⟩ := dvd_lowerRight_witness A N m c₀ r hc₀ hdet ham hm_ar_b
   obtain ⟨q₁, hq₁⟩ := hm_ar_b
   refine ⟨Matrix.of ![![A 0 0, -q₁], ![(N : ℤ) * c₀, q₂]], r, ?_, ?_, hr_nonneg, hr_lt, ?_⟩

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/BadPrimeCoset.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/BadPrimeCoset.lean
@@ -5,8 +5,7 @@ Authors: Chris Birkbeck, Claude
 -/
 module
 
--- `ZMod.coe_int_isUnit_iff_isCoprime` and `ZMod.exists_dvd_sub_val_mul` are used only inside
--- proofs, so these stay private.
+-- `ZMod.coe_int_isUnit_iff_isCoprime` is used only inside a proof, so this stays private.
 import Mathlib.Data.ZMod.Units
 import TauCeti.Data.ZMod.Divisibility
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.DoubleCoset
@@ -52,7 +51,7 @@ the remaining parameter into a second `Γ₀(N)` factor, which is what makes the
   `dvd_lowerRight_witness`, `shimura_prop_3_33_gen` and `shimura_prop_3_33`.
 
   Five source declarations are deliberately **not** ported. `exists_mod_clearing` is the
-  Bézout step behind `exists_reduced_shear`, and `ZMod.exists_dvd_sub_val_mul`
+  Bézout step behind `Int.exists_nonneg_lt_and_dvd_mul_sub`, and `ZMod.exists_dvd_sub_val_mul`
   (`TauCeti/Data/ZMod/Divisibility.lean`) already solves that congruence.
   `diagMat_one_mem_Delta0` and `diagMat_mem_Delta0_of_gcd` are already on main as
   `natDiagGL_one_mem_Delta0` and
@@ -97,24 +96,6 @@ private lemma dvd_lowerRight_witness (A : Matrix (Fin 2) (Fin 2) ℤ) (N m : ℕ
     exact ⟨-w, by linarith⟩
   exact ((Int.isCoprime_iff_gcd_eq_one.mpr ham).symm).dvd_of_dvd_mul_left
     (h_key ▸ dvd_add (dvd_refl _) (dvd_mul_of_dvd_left hm_ba _))
-
-/-- **The reduced shear parameter.** With `a` coprime to `m` there is an `r` in `[0, m)`
-solving `a * r ≡ b (mod m)`.
-
-This is `ZMod.exists_dvd_sub_val_mul` repackaged: that lemma returns the solution as a residue
-class, and the two consumers here — the column reduction below and the `Γ₁(N)` offset in
-`Gamma1/UpperTriCosets.lean` — both need it as an integer in `[0, m)`. -/
-lemma exists_reduced_shear (a b : ℤ) (m : ℕ) (hm_pos : 0 < m)
-    (ham : Int.gcd a m = 1) :
-    ∃ r : ℤ, 0 ≤ r ∧ r < m ∧ (m : ℤ) ∣ a * r - b := by
-  have : NeZero m := ⟨hm_pos.ne'⟩
-  have hunit : IsUnit ((a : ℤ) : ZMod m) := (ZMod.coe_int_isUnit_iff_isCoprime a m).mpr
-    (isCoprime_comm.mp (Int.isCoprime_iff_gcd_eq_one.mpr ham))
-  obtain ⟨r, hr⟩ := ZMod.exists_dvd_sub_val_mul m b a hunit
-  refine ⟨(r.val : ℤ), Int.natCast_nonneg _, by exact_mod_cast r.val_lt, ?_⟩
-  -- `hr` divides `b - r * a`; negating and commuting the product is the whole gap
-  rw [← neg_sub, mul_comm]
-  exact dvd_neg.mpr hr
 
 /-- **The determinant of an integral witness.** If `A` represents `g ∈ GL₂(ℚ)` entrywise over
 `ℤ` and `g` has determinant `m`, then `A` has determinant `m` over `ℤ`.
@@ -171,7 +152,7 @@ lemma exists_unimodular_mul_upperTriangular (N : ℕ) (A : Matrix (Fin 2) (Fin 2
       A = L * (Matrix.of ![![(1 : ℤ), r], ![0, (m : ℤ)]]) := by
   obtain ⟨c₀, hc₀⟩ := hAN
   obtain ⟨r, hr_nonneg, hr_lt, hm_ar_b⟩ :=
-    exists_reduced_shear (A 0 0) (A 0 1) m hm_pos ham
+    Int.exists_nonneg_lt_and_dvd_mul_sub (A 0 0) (A 0 1) m hm_pos ham
   obtain ⟨q₂, hq₂⟩ := dvd_lowerRight_witness A N m c₀ r hc₀ hdet ham hm_ar_b
   obtain ⟨q₁, hq₁⟩ := hm_ar_b
   refine ⟨Matrix.of ![![A 0 0, -q₁], ![(N : ℤ) * c₀, q₂]], r, ?_, ?_, hr_nonneg, hr_lt, ?_⟩

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
@@ -11,20 +11,21 @@ public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.Basic
 public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 
 /-!
-# The double coset `Γ₁(N) · diag(1, p) · Γ₁(N)` at `p ∣ N`
+# The double coset `Γ₁(N) · diag(1, p) · Γ₁(N)` at an index supported on the level
 
 `GL2/CosetDecomposition.lean` supplies the `p` upper-triangular matrices
 `upperTriRep p b = !![1, b; 0, p]`, and `HeckeSlash/UpperTri/` builds an operator on
 `M_k(Γ₁(N))` by slashing against them and summing. Nothing so far says that this family *is* the
 double coset of `diag(1, p)`, and without that the classical operator and the abstract Hecke
-ring's operator are two unrelated objects. This file proves the missing statement, for `p ∣ N`:
+ring's operator are two unrelated objects. This file proves the missing statement, whenever every
+prime factor of `p` divides `N`:
 
 `Γ₁(N) · diag(1, p) · Γ₁(N) = ⋃_{b < p} Γ₁(N) · !![1, b; 0, p]`,
 
 a disjoint union of **right** cosets — the handedness Shimura's slash sum needs
 (`HeckeSlash/Basic.lean`).
 
-## Why `p ∣ N`, and where it enters
+## Why the index must be supported on the level, and where that enters
 
 Only the inclusion `⊆` uses it. An element of the double coset is `γ₁ · diag(1, p) · γ₂`, and
 since the left factor is absorbed by the coset, the content is that `diag(1, p) · γ₂` lies in one
@@ -32,18 +33,25 @@ of the `p` right cosets. Writing `γ₂ = !![a, b; c, d]`, the candidate is
 
 `diag(1, p) · γ₂ = !![a, m; p c, d - c j] · !![1, j; 0, p]`,
 
-which asks for `p ∣ b - a j` — solvable for `j` because `a` is invertible modulo `p`. That is
-where the level enters: `γ₂ ∈ Γ₁(N)` gives `a ≡ 1 (mod N)`, and `p ∣ N` promotes it to
-`a ≡ 1 (mod p)`, so `j ≡ b` works. The new left factor lands back in `Γ₁(N)` because `N ∣ c`
-makes both `p c ≡ 0` and `d - c j ≡ d ≡ 1` modulo `N`.
+which asks for `p ∣ b - a j` — solvable for `j` exactly when `a` is invertible modulo `p`. That
+is where the level enters: `γ₂ ∈ Γ₁(N)` gives `a ≡ 1 (mod N)`, so `a` is coprime to `N`, and the
+hypothesis `p.primeFactors ⊆ N.primeFactors` promotes that to coprimality with `p`. The new left
+factor lands back in `Γ₁(N)` because `N ∣ c` makes both `p c ≡ 0` and `d - c j ≡ d ≡ 1` modulo
+`N`.
 
-⚠ For `p ∤ N` the statement is false: when `p` is prime the double coset then has `p + 1` right
-cosets, the extra one represented by `!![m, n; N, p] · diag(p, 1)` for any `m p − n N = 1`
-(Diamond–Shurman, Proposition 5.2.1). That case is proved in `Gamma1/CoprimeCosets.lean` by
+The hypothesis is `p.primeFactors ⊆ N.primeFactors` rather than `p ∣ N` because the prime powers
+`p = q ^ r` with `q ∣ N` are exactly the indices the bad-prime operators `T_{q^r} = U_q^r` need,
+and they need not divide `N`. Divisibility is the special case, by
+`Nat.primeFactors_mono`.
+
+⚠ When some prime factor of `p` is coprime to `N` the statement is false: for `p` prime and
+`p ∤ N` the double coset has `p + 1` right cosets, the extra one represented by
+`!![m, n; N, p] · diag(p, 1)` for any `m p − n N = 1` (Diamond–Shurman, Proposition 5.2.1). That
+case is proved in `Gamma1/CoprimeCosets.lean` by
 `doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime`.
 
-The reverse inclusion needs no divisibility: `!![1, b; 0, p] = diag(1, p) · Tᵇ` and every power
-of `T = !![1, 1; 0, 1]` lies in `Γ₁(N)`.
+The reverse inclusion needs no hypothesis on the index: `!![1, b; 0, p] = diag(1, p) · Tᵇ` and
+every power of `T = !![1, 1; 0, 1]` lies in `Γ₁(N)`.
 
 ## Main definitions
 
@@ -58,8 +66,8 @@ of `T = !![1, 1; 0, 1]` lies in `Γ₁(N)`.
   reverse inclusion in one line.
 * `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul_of_dvd`: the factorisation
   `diag(1, p) · γ = δ · !![1, j; 0, p]` with `δ ∈ Γ₁(N)`, at any offset `j` with `p ∣ b − a j`;
-  `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul` chooses such an offset from `p ∣ N`, and is
-  the forward inclusion.
+  `HeckeRing.GL2.exists_mem_Gamma1_natDiagGL_mul` chooses such an offset from
+  `p.primeFactors ⊆ N.primeFactors`, and is the forward inclusion.
 * `HeckeRing.GL2.op_upperTriRep_smul_injective`: the `p` right cosets are pairwise distinct,
   so the union is disjoint. Stated for an arbitrary subgroup of `SL₂(ℤ)`, since only
   integrality is used.
@@ -74,13 +82,13 @@ of `T = !![1, 1; 0, 1]` lies in `Γ₁(N)`.
 
 ## Provenance
 
-No code is transcribed. The statement is Diamond–Shurman Proposition 5.2.1 in the case `p ∣ N`,
-proved here directly for this repository's own representative families `natDiagGL` and
-`upperTriRep` rather than for transcribed matrices. The AINTLIB `LeanModularForms` project
-(Chris Birkbeck, Apache-2.0) organises the same case as its `heckeT_p_divN` branch of
-`heckeT_p_all` (`LeanModularForms/HeckeRIngs/GL2/HeckeT_n.lean`), on the operator rather than
-the coset side; the coset statement below is what identifies the two, and is proved from the
-group law here.
+No code is transcribed. The statement generalises Diamond–Shurman Proposition 5.2.1 in the
+bad-prime case, proved here directly for this repository's own representative families
+`natDiagGL` and `upperTriRep`, rather than for transcribed matrices. The AINTLIB
+`LeanModularForms` project (Chris Birkbeck, Apache-2.0) organises the same case as its
+`heckeT_p_divN` branch of `heckeT_p_all`
+(`LeanModularForms/HeckeRIngs/GL2/HeckeT_n.lean`), on the operator rather than the coset side;
+the coset statement below is what identifies the two, and is proved from the group law here.
 
 ## References
 
@@ -197,36 +205,61 @@ lemma exists_mem_Gamma1_natDiagGL_mul_of_dvd (hp : 0 < p) {γ : SL(2, ℤ)} (hγ
     · push_cast; ring1
     · push_cast; ring1
 
-/-- **The forward factorisation at `p ∣ N`.** For `p ∣ N` and `γ ∈ Γ₁(N)`, the product
-`diag(1, p) · γ` lies in one of the `p` right cosets `Γ₁(N) · !![1, j; 0, p]`.
+/-- **The upper-left entry of a level-`N` element is invertible modulo an index supported on the
+level.** If every prime factor of `p` divides `N` and `a ≡ 1 (mod N)`, then `a` is coprime to `p`:
+a common prime factor `q` of `a` and `p` would divide `N`, hence `a - 1`, hence `1`. -/
+private lemma isCoprime_of_primeFactors_subset (hp : 0 < p)
+    (hpN : p.primeFactors ⊆ N.primeFactors) {a : ℤ} (ha : (N : ℤ) ∣ a - 1) :
+    IsCoprime a (p : ℤ) := by
+  have hgcd : Int.gcd a (p : ℤ) = Nat.gcd a.natAbs p := by simp [Int.gcd]
+  rw [Int.isCoprime_iff_gcd_eq_one, hgcd]
+  by_contra hne
+  obtain ⟨q, hq, hqa, hqp⟩ := Nat.Prime.not_coprime_iff_dvd.mp hne
+  obtain ⟨-, hqN, -⟩ := Nat.mem_primeFactors.mp (hpN (Nat.mem_primeFactors.mpr ⟨hq, hqp, hp.ne'⟩))
+  have hqa' : (q : ℤ) ∣ a := Int.dvd_natAbs.mp (Int.natCast_dvd_natCast.mpr hqa)
+  have hq1 : (q : ℕ) ∣ 1 := by
+    have : (q : ℤ) ∣ 1 := by
+      simpa using dvd_sub hqa' ((Int.natCast_dvd_natCast.mpr hqN).trans ha)
+    exact_mod_cast this
+  exact hq.one_lt.ne' (Nat.dvd_one.mp hq1)
 
-The offset is `j ≡ b (mod p)` for `γ = !![a, b; c, d]`, which works because `p ∣ N` makes
-`a ≡ 1 (mod p)`; the factorisation itself is
+/-- **The offset exists whenever the level controls the index.** For `p` with every prime factor
+dividing `N` and for `a ≡ 1 (mod N)`, the congruence `a · j ≡ b (mod p)` has a solution `j < p`,
+because `a` is then invertible modulo `p`.
+
+This is the arithmetic input of the forward inclusion below, isolated from the matrix
+bookkeeping. -/
+private lemma exists_offset_of_primeFactors_subset (hp : 0 < p)
+    (hpN : p.primeFactors ⊆ N.primeFactors) {a b : ℤ} (ha : (N : ℤ) ∣ a - 1) :
+    ∃ j : ℕ, j < p ∧ (p : ℤ) ∣ b - a * j := by
+  have hp' : (0 : ℤ) < p := by exact_mod_cast hp
+  obtain ⟨u, v, huv⟩ := isCoprime_of_primeFactors_subset hp hpN ha
+  have hj0 : (0 : ℤ) ≤ u * b % p := Int.emod_nonneg _ hp'.ne'
+  refine ⟨(u * b % p).toNat, ?_, ⟨b * v + a * (u * b / p), ?_⟩⟩
+  · have := Int.emod_lt_of_pos (u * b) hp'
+    omega
+  · rw [Int.toNat_of_nonneg hj0, Int.emod_def]
+    linear_combination (-b) * huv
+
+/-- **The forward factorisation at an index supported on the level.** If every prime factor of
+`p` divides `N`, then for `γ ∈ Γ₁(N)` the product `diag(1, p) · γ` lies in one of the `p` right
+cosets `Γ₁(N) · !![1, j; 0, p]`.
+
+The offset solves `a j ≡ b (mod p)` for `γ = !![a, b; c, d]`, which
+`exists_offset_of_primeFactors_subset` supplies; the factorisation itself is
 `exists_mem_Gamma1_natDiagGL_mul_of_dvd`. -/
-lemma exists_mem_Gamma1_natDiagGL_mul (hp : 0 < p) (hpN : p ∣ N) {γ : SL(2, ℤ)}
-    (hγ : γ ∈ Gamma1 N) :
+lemma exists_mem_Gamma1_natDiagGL_mul (hp : 0 < p) (hpN : p.primeFactors ⊆ N.primeFactors)
+    {γ : SL(2, ℤ)} (hγ : γ ∈ Gamma1 N) :
     ∃ (j : Fin p) (δ : SL(2, ℤ)), δ ∈ Gamma1 N ∧
       natDiagGL 2 ![1, p] * mapGL ℚ γ = mapGL ℚ δ * upperTriRep p j := by
   obtain ⟨ha, -, -⟩ := (Gamma1_mem N γ).mp hγ
-  have hp' : (0 : ℤ) < p := by exact_mod_cast hp
-  -- the level divisibility, read in `ℤ`
+  -- the level congruence on the upper-left entry, read in `ℤ`
   have haN : (N : ℤ) ∣ γ 0 0 - 1 := by
     refine (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp ?_
     push_cast
     rw [ha, sub_self]
-  -- the offset `j ≡ b (mod p)`, taken opaquely: only its size and its residue matter
-  obtain ⟨j, hjlt, hpj⟩ : ∃ j : ℕ, j < p ∧ (p : ℤ) ∣ γ 0 1 - j := by
-    have hj0 : (0 : ℤ) ≤ γ 0 1 % p := Int.emod_nonneg _ hp'.ne'
-    refine ⟨(γ 0 1 % p).toNat, ?_, ?_⟩
-    · have := Int.emod_lt_of_pos (γ 0 1) hp'
-      omega
-    · rw [Int.toNat_of_nonneg hj0, Int.emod_def]
-      exact ⟨γ 0 1 / p, by ring⟩
-  have hpa : (p : ℤ) ∣ γ 0 0 - 1 := dvd_trans (Int.natCast_dvd_natCast.mpr hpN) haN
-  have hj : (p : ℤ) ∣ γ 0 1 - γ 0 0 * j := by
-    have h : γ 0 1 - γ 0 0 * j = (γ 0 1 - j) - (γ 0 0 - 1) * j := by ring
-    rw [h]
-    exact dvd_sub hpj (Dvd.dvd.mul_right hpa _)
+  obtain ⟨j, hjlt, hj⟩ :=
+    exists_offset_of_primeFactors_subset hp hpN (a := γ 0 0) (b := γ 0 1) haN
   obtain ⟨δ, hδ, heq⟩ := exists_mem_Gamma1_natDiagGL_mul_of_dvd hp hγ hjlt hj
   exact ⟨⟨j, hjlt⟩, δ, hδ, heq⟩
 
@@ -265,14 +298,17 @@ theorem op_upperTriRep_smul_injective {G : Subgroup SL(2, ℤ)} :
   have := Int.eq_zero_of_abs_lt_dvd hdvd habs
   exact Fin.ext (by omega)
 
-/-- **The `Tₚ` double coset at `p ∣ N` is the union of the `p` upper-triangular right cosets.**
-`Γ₁(N) · diag(1, p) · Γ₁(N) = ⋃_{j < p} Γ₁(N) · !![1, j; 0, p]`, Diamond–Shurman's
-Proposition 5.2.1 in the case `p ∣ N`.
+/-- **The `Tₚ` double coset at an index supported on the level is the union of the `p`
+upper-triangular right cosets.**
+`Γ₁(N) · diag(1, p) · Γ₁(N) = ⋃_{j < p} Γ₁(N) · !![1, j; 0, p]`, whenever every prime factor of
+`p` divides `N` — Diamond–Shurman's Proposition 5.2.1 in the bad-prime case, and its extension
+to the prime powers `q ^ r` with `q ∣ N`.
 
-The inclusion `⊇` is `natDiagGL_mul_mapGL_T_zpow` and needs no divisibility; the inclusion `⊆`
-is `exists_mem_Gamma1_natDiagGL_mul` and is where `p ∣ N` enters. That the union is disjoint is
-`op_upperTriRep_smul_injective`. -/
-theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets (hp : 0 < p) (hpN : p ∣ N) :
+The inclusion `⊇` is `natDiagGL_mul_mapGL_T_zpow` and needs no hypothesis on the index; the
+inclusion `⊆` is `exists_mem_Gamma1_natDiagGL_mul` and is where the hypothesis enters. That the
+union is disjoint is `op_upperTriRep_smul_injective`. -/
+theorem doubleCoset_natDiagGL_eq_iUnion_rightCosets (hp : 0 < p)
+    (hpN : p.primeFactors ⊆ N.primeFactors) :
     doubleCoset (natDiagGL 2 ![1, p]) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ j : Fin p, MulOpposite.op (upperTriRep p j) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
@@ -302,7 +338,8 @@ theorem doubleCoset_out_diagCosetGamma1_eq_doubleCoset_natDiagGL :
 /-- The decomposition of `doubleCoset_natDiagGL_eq_iUnion_rightCosets`, read at the chosen
 representative `D.out` of `diagCosetGamma1 N p` — the shape the slash-sum machinery of
 `HeckeSlash/Independence.lean` consumes. -/
-theorem doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets (hp : 0 < p) (hpN : p ∣ N) :
+theorem doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets (hp : 0 < p)
+    (hpN : p.primeFactors ⊆ N.primeFactors) :
     doubleCoset ((diagCosetGamma1 N p).out : GL (Fin 2) ℚ)
         ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ j : Fin p, MulOpposite.op (upperTriRep p j) •

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
@@ -234,22 +234,13 @@ bookkeeping. -/
 private lemma exists_offset_of_primeFactors_subset (hp : 0 < p)
     (hpN : p.primeFactors ⊆ N.primeFactors) {a b : ℤ} (ha : (N : ℤ) ∣ a - 1) :
     ∃ j : ℕ, j < p ∧ (p : ℤ) ∣ b - a * j := by
-  have hp' : (0 : ℤ) < p := by exact_mod_cast hp
   have hgcd : Int.gcd a p = 1 :=
     Int.isCoprime_iff_gcd_eq_one.mp (isCoprime_of_primeFactors_subset hp hpN ha)
-  obtain ⟨u, hu⟩ := exists_mod_clearing a (-b) p hgcd
-  have hj0 : (0 : ℤ) ≤ u % p := Int.emod_nonneg _ hp'.ne'
-  refine ⟨(u % p).toNat, ?_, ?_⟩
-  · have := Int.emod_lt_of_pos u hp'
-    omega
-  · rw [Int.toNat_of_nonneg hj0]
-    have hquot : u - u % (p : ℤ) = (p : ℤ) * (u / (p : ℤ)) := by
-      linarith [Int.mul_ediv_add_emod u (p : ℤ)]
-    have hp_ur : (p : ℤ) ∣ u - u % (p : ℤ) := hquot ▸ dvd_mul_right _ _
-    have hclear := dvd_sub hu (dvd_mul_of_dvd_left hp_ur a)
-    have hcollapse : u * a + -b - (u - u % (p : ℤ)) * a = a * (u % p) - b := by ring
-    rw [hcollapse] at hclear
-    simpa only [neg_sub] using dvd_neg.mpr hclear
+  obtain ⟨r, hr0, hrlt, hr⟩ := exists_reduced_shear a b p hp hgcd
+  refine ⟨r.toNat, ?_, ?_⟩
+  · omega
+  · rw [Int.toNat_of_nonneg hr0]
+    simpa only [neg_sub] using dvd_neg.mpr hr
 
 /-- **The forward factorisation at an index supported on the level.** If every prime factor of
 `p` divides `N`, then for `γ ∈ Γ₁(N)` the product `diag(1, p) · γ` lies in one of the `p` right

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.BadPrimeCoset
 public import TauCeti.NumberTheory.HeckeRing.GL2.CosetDecomposition
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Coset
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.Basic
@@ -33,7 +34,7 @@ of the `p` right cosets. Writing `γ₂ = !![a, b; c, d]`, the candidate is
 
 `diag(1, p) · γ₂ = !![a, m; p c, d - c j] · !![1, j; 0, p]`,
 
-which asks for `p ∣ b - a j` — solvable for `j` exactly when `a` is invertible modulo `p`. That
+which asks for `p ∣ b - a j` — solvable for `j` because `a` is invertible modulo `p`. That
 is where the level enters: `γ₂ ∈ Γ₁(N)` gives `a ≡ 1 (mod N)`, so `a` is coprime to `N`, and the
 hypothesis `p.primeFactors ⊆ N.primeFactors` promotes that to coprimality with `p`. The new left
 factor lands back in `Γ₁(N)` because `N ∣ c` makes both `p c ≡ 0` and `d - c j ≡ d ≡ 1` modulo
@@ -44,8 +45,8 @@ The hypothesis is `p.primeFactors ⊆ N.primeFactors` rather than `p ∣ N` beca
 and they need not divide `N`. Divisibility is the special case, by
 `Nat.primeFactors_mono`.
 
-⚠ When some prime factor of `p` is coprime to `N` the statement is false: for `p` prime and
-`p ∤ N` the double coset has `p + 1` right cosets, the extra one represented by
+Failure is known when `p` is prime and `p ∤ N`: the double coset then has `p + 1` right cosets,
+the extra one represented by
 `!![m, n; N, p] · diag(p, 1)` for any `m p − n N = 1` (Diamond–Shurman, Proposition 5.2.1). That
 case is proved in `Gamma1/CoprimeCosets.lean` by
 `doubleCoset_natDiagGL_eq_iUnion_rightCosets_of_prime`.
@@ -211,17 +212,18 @@ a common prime factor `q` of `a` and `p` would divide `N`, hence `a - 1`, hence 
 private lemma isCoprime_of_primeFactors_subset (hp : 0 < p)
     (hpN : p.primeFactors ⊆ N.primeFactors) {a : ℤ} (ha : (N : ℤ) ∣ a - 1) :
     IsCoprime a (p : ℤ) := by
-  have hgcd : Int.gcd a (p : ℤ) = Nat.gcd a.natAbs p := by simp [Int.gcd]
-  rw [Int.isCoprime_iff_gcd_eq_one, hgcd]
-  by_contra hne
-  obtain ⟨q, hq, hqa, hqp⟩ := Nat.Prime.not_coprime_iff_dvd.mp hne
-  obtain ⟨-, hqN, -⟩ := Nat.mem_primeFactors.mp (hpN (Nat.mem_primeFactors.mpr ⟨hq, hqp, hp.ne'⟩))
-  have hqa' : (q : ℤ) ∣ a := Int.dvd_natAbs.mp (Int.natCast_dvd_natCast.mpr hqa)
-  have hq1 : (q : ℕ) ∣ 1 := by
-    have : (q : ℤ) ∣ 1 := by
-      simpa using dvd_sub hqa' ((Int.natCast_dvd_natCast.mpr hqN).trans ha)
-    exact_mod_cast this
-  exact hq.one_lt.ne' (Nat.dvd_one.mp hq1)
+  obtain ⟨c, hc⟩ := ha
+  have haN : IsCoprime a (N : ℤ) := by
+    have ha_eq : a = 1 + (N : ℤ) * c := by linarith
+    rw [ha_eq]
+    exact isCoprime_one_left.add_mul_left_left c
+  rcases eq_or_ne N 0 with rfl | hN
+  · have hp_empty : p.primeFactors = ∅ := Finset.subset_empty.mp (by simpa using hpN)
+    have hp_one : p = 1 := (Nat.primeFactors_eq_empty.mp hp_empty).resolve_left hp.ne'
+    subst p
+    exact isCoprime_one_right
+  · have hp_dvd : p ∣ N ^ p := (Nat.dvd_pow_self_iff hp.ne' hN).mpr hpN
+    exact (haN.pow_right (n := p)).of_isCoprime_of_dvd_right (by exact_mod_cast hp_dvd)
 
 /-- **The offset exists whenever the level controls the index.** For `p` with every prime factor
 dividing `N` and for `a ≡ 1 (mod N)`, the congruence `a · j ≡ b (mod p)` has a solution `j < p`,
@@ -233,13 +235,21 @@ private lemma exists_offset_of_primeFactors_subset (hp : 0 < p)
     (hpN : p.primeFactors ⊆ N.primeFactors) {a b : ℤ} (ha : (N : ℤ) ∣ a - 1) :
     ∃ j : ℕ, j < p ∧ (p : ℤ) ∣ b - a * j := by
   have hp' : (0 : ℤ) < p := by exact_mod_cast hp
-  obtain ⟨u, v, huv⟩ := isCoprime_of_primeFactors_subset hp hpN ha
-  have hj0 : (0 : ℤ) ≤ u * b % p := Int.emod_nonneg _ hp'.ne'
-  refine ⟨(u * b % p).toNat, ?_, ⟨b * v + a * (u * b / p), ?_⟩⟩
-  · have := Int.emod_lt_of_pos (u * b) hp'
+  have hgcd : Int.gcd a p = 1 :=
+    Int.isCoprime_iff_gcd_eq_one.mp (isCoprime_of_primeFactors_subset hp hpN ha)
+  obtain ⟨u, hu⟩ := exists_mod_clearing a (-b) p hgcd
+  have hj0 : (0 : ℤ) ≤ u % p := Int.emod_nonneg _ hp'.ne'
+  refine ⟨(u % p).toNat, ?_, ?_⟩
+  · have := Int.emod_lt_of_pos u hp'
     omega
-  · rw [Int.toNat_of_nonneg hj0, Int.emod_def]
-    linear_combination (-b) * huv
+  · rw [Int.toNat_of_nonneg hj0]
+    have hquot : u - u % (p : ℤ) = (p : ℤ) * (u / (p : ℤ)) := by
+      linarith [Int.mul_ediv_add_emod u (p : ℤ)]
+    have hp_ur : (p : ℤ) ∣ u - u % (p : ℤ) := hquot ▸ dvd_mul_right _ _
+    have hclear := dvd_sub hu (dvd_mul_of_dvd_left hp_ur a)
+    have hcollapse : u * a + -b - (u - u % (p : ℤ)) * a = a * (u % p) - b := by ring
+    rw [hcollapse] at hclear
+    simpa only [neg_sub] using dvd_neg.mpr hclear
 
 /-- **The forward factorisation at an index supported on the level.** If every prime factor of
 `p` divides `N`, then for `γ ∈ Γ₁(N)` the product `diag(1, p) · γ` lies in one of the `p` right

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.BadPrimeCoset
+import TauCeti.Data.ZMod.Divisibility
 public import TauCeti.NumberTheory.HeckeRing.GL2.CosetDecomposition
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Coset
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.Basic
@@ -236,7 +236,7 @@ private lemma exists_offset_of_primeFactors_subset (hp : 0 < p)
     ∃ j : ℕ, j < p ∧ (p : ℤ) ∣ b - a * j := by
   have hgcd : Int.gcd a p = 1 :=
     Int.isCoprime_iff_gcd_eq_one.mp (isCoprime_of_primeFactors_subset hp hpN ha)
-  obtain ⟨r, hr0, hrlt, hr⟩ := exists_reduced_shear a b p hp hgcd
+  obtain ⟨r, hr0, hrlt, hr⟩ := Int.exists_nonneg_lt_and_dvd_mul_sub a b p hp hgcd
   refine ⟨r.toNat, ?_, ?_⟩
   · omega
   · rw [Int.toNat_of_nonneg hr0]

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/UpperTriCosets.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-import TauCeti.Data.ZMod.Divisibility
+import TauCeti.Data.Int.LinearCongruence
 public import TauCeti.NumberTheory.HeckeRing.GL2.CosetDecomposition
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Coset
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.Basic

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
@@ -5,14 +5,15 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.NumberTheory.ModularForms.HeckeSlash.BadPrime
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Operators
 
 /-!
 # The Hecke operators at an index supported on the level
 
 Call a positive integer `n` *supported on the level* `N` when every prime factor of `n` divides
-`N`, that is `n.primeFactors ⊆ N.primeFactors`. These are exactly the indices at which the
-double coset `Γ₁(N) · diag(1, n) · Γ₁(N)` decomposes into the `n` upper-triangular right cosets
+`N`, that is `n.primeFactors ⊆ N.primeFactors`. These are the indices at which the decomposition
+proved here writes the double coset `Γ₁(N) · diag(1, n) · Γ₁(N)` as `n` upper-triangular right
+cosets
 `Γ₁(N) · !![1, b; 0, n]` — no further coset appears, as it does at a prime `p ∤ N`. The prime
 powers `p ^ r` with `p ∣ N` are supported on the level whether or not they divide it, and they
 are the reason this regime is worth naming: `p ∣ N` alone does not reach `T_{p²}`.
@@ -45,17 +46,14 @@ recurrence of `UpperTri/ModularForm.lean` at every level-supported index.
   `HeckeRing.GL2.coe_heckeTCuspNat_of_primeFactors_subset`: at an index supported on the level,
   `T_n` is the upper-triangular sum.
 * `HeckeRing.GL2.heckeTNat_mul_of_primeFactors_subset` and its cusp-form counterpart:
-  `T_{n m} = T_m ∘ T_n` for two indices supported on the level, with
+  `T_{n m} = T_n ∘ T_m` for two indices supported on the level, with
   `HeckeRing.GL2.commute_heckeTNat_of_primeFactors_subset` recording that such operators
   commute.
-* `HeckeRing.GL2.heckeTNat_congr` and its cusp-form counterpart: transport along an equality of
-  indices, the rewrite the `NeZero` index argument would otherwise block.
-* `HeckeRing.GL2.heckeTNat_pow_of_primeFactors_subset` and
-  `HeckeRing.GL2.heckeTNat_prime_pow`: **`T_{p^r} = T_p ^ r` at `p ∣ N`**, on modular and on
-  cusp forms.
-* `HeckeRing.GL2.heckeSlashUpperTri_slash_mapGL_of_nebentypus_of_primeFactors_subset`: the
-  function-level nebentypus transport, proved by peeling off the least prime factor of the
-  index, and `HeckeRing.GL2.heckeTNat_mem_modFormCharSpace_of_primeFactors_subset` with its
+* `HeckeRing.GL2.heckeTNat_pow_of_primeFactors_subset`: `T_{n^r} = T_n ^ r` at every
+  level-supported index, with its cusp-form counterpart.
+* `HeckeRing.GL2.heckeTNat_pow_of_prime_dvd`: **`T_{p^r} = T_p ^ r` at `p ∣ N`**, with its
+  cusp-form counterpart.
+* `HeckeRing.GL2.heckeTNat_mem_modFormCharSpace_of_primeFactors_subset` with its
   cusp-form counterpart: the operator preserves `M_k(N, χ)` and `S_k(N, χ)`.
 * `HeckeRing.GL2.qExpansion_coeff_heckeTNat_of_primeFactors_subset` and its cusp-form
   counterpart: `aₘ(T_n f) = a_{n m}(f)`.
@@ -106,20 +104,6 @@ theorem coe_heckeTCuspNat_of_primeFactors_subset (n : ℕ) [NeZero n]
   rw [coe_heckeTCuspNat]
   exact heckeSlashSum_diagCosetGamma1 k (Nat.pos_of_ne_zero (NeZero.ne n)) hn f
 
-/-- **Transport `T_n` along an equality of indices.** The `NeZero` side condition is a `Prop`, so
-the two operators are the same object; the lemma exists because rewriting the index *inside*
-`heckeTNat` would leave the instance argument stranded at the old index. -/
-lemma heckeTNat_congr {n m : ℕ} [NeZero n] [NeZero m] (h : n = m) :
-    heckeTNat (N := N) k n = heckeTNat (N := N) k m := by
-  subst h
-  rfl
-
-/-- **Transport the cusp-form `T_n` along an equality of indices.** -/
-lemma heckeTCuspNat_congr {n m : ℕ} [NeZero n] [NeZero m] (h : n = m) :
-    heckeTCuspNat (N := N) k n = heckeTCuspNat (N := N) k m := by
-  subst h
-  rfl
-
 omit [NeZero N] in
 /-- A product of two indices supported on the level is supported on the level. -/
 private lemma primeFactors_mul_subset {n m : ℕ} [NeZero n] [NeZero m]
@@ -128,7 +112,7 @@ private lemma primeFactors_mul_subset {n m : ℕ} [NeZero n] [NeZero m]
   rw [Nat.primeFactors_mul (NeZero.ne n) (NeZero.ne m)]
   exact Finset.union_subset hn hm
 
-/-- **The Hecke operators at indices supported on the level multiply**: `T_{n m} = T_m ∘ T_n`
+/-- **The Hecke operators at indices supported on the level multiply**: `T_{n m} = T_n ∘ T_m`
 on `M_k(Γ₁(N))`.
 
 Both sides are upper-triangular sums, and `upperTriRep_mul_upperTriRep` matches the pairs of
@@ -137,21 +121,23 @@ coprimality statement: `n` and `m` share the level's primes by hypothesis, and t
 holds for `n = m` in particular. -/
 theorem heckeTNat_mul_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
     (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
-    heckeTNat (N := N) k (n * m) = heckeTNat (N := N) k m * heckeTNat (N := N) k n :=
+    heckeTNat (N := N) k (n * m) = heckeTNat (N := N) k n * heckeTNat (N := N) k m :=
   LinearMap.ext fun f ↦ DFunLike.ext' <| by
     rw [coe_heckeTNat_of_primeFactors_subset k _ (primeFactors_mul_subset hn hm),
-      Module.End.mul_apply, coe_heckeTNat_of_primeFactors_subset k m hm,
-      coe_heckeTNat_of_primeFactors_subset k n hn, heckeSlashUpperTri_heckeSlashUpperTri]
+      Module.End.mul_apply, coe_heckeTNat_of_primeFactors_subset k n hn,
+      coe_heckeTNat_of_primeFactors_subset k m hm, heckeSlashUpperTri_heckeSlashUpperTri,
+      mul_comm m n]
 
 /-- **The cusp-form Hecke operators at indices supported on the level multiply**:
-`T_{n m} = T_m ∘ T_n` on `S_k(Γ₁(N))`. -/
+`T_{n m} = T_n ∘ T_m` on `S_k(Γ₁(N))`. -/
 theorem heckeTCuspNat_mul_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
     (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
-    heckeTCuspNat (N := N) k (n * m) = heckeTCuspNat (N := N) k m * heckeTCuspNat (N := N) k n :=
+    heckeTCuspNat (N := N) k (n * m) = heckeTCuspNat (N := N) k n * heckeTCuspNat (N := N) k m :=
   LinearMap.ext fun f ↦ DFunLike.ext' <| by
     rw [coe_heckeTCuspNat_of_primeFactors_subset k _ (primeFactors_mul_subset hn hm),
-      Module.End.mul_apply, coe_heckeTCuspNat_of_primeFactors_subset k m hm,
-      coe_heckeTCuspNat_of_primeFactors_subset k n hn, heckeSlashUpperTri_heckeSlashUpperTri]
+      Module.End.mul_apply, coe_heckeTCuspNat_of_primeFactors_subset k n hn,
+      coe_heckeTCuspNat_of_primeFactors_subset k m hm, heckeSlashUpperTri_heckeSlashUpperTri,
+      mul_comm m n]
 
 /-- **The Hecke operators at indices supported on the level commute.** Both orders compute the
 operator at the product index, and the product of indices is commutative. This is the
@@ -159,17 +145,17 @@ commuting family the simultaneous-diagonalisation arguments consume at the bad p
 theorem commute_heckeTNat_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
     (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
     Commute (heckeTNat (N := N) k n) (heckeTNat (N := N) k m) := by
-  rw [Commute, SemiconjBy, ← heckeTNat_mul_of_primeFactors_subset k hm hn,
-    ← heckeTNat_mul_of_primeFactors_subset k hn hm]
-  exact heckeTNat_congr k (mul_comm m n)
+  rw [Commute, SemiconjBy, ← heckeTNat_mul_of_primeFactors_subset k hn hm,
+    ← heckeTNat_mul_of_primeFactors_subset k hm hn]
+  exact heckeTNat_congr k (mul_comm n m)
 
 /-- **The cusp-form Hecke operators at indices supported on the level commute.** -/
 theorem commute_heckeTCuspNat_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
     (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
     Commute (heckeTCuspNat (N := N) k n) (heckeTCuspNat (N := N) k m) := by
-  rw [Commute, SemiconjBy, ← heckeTCuspNat_mul_of_primeFactors_subset k hm hn,
-    ← heckeTCuspNat_mul_of_primeFactors_subset k hn hm]
-  exact heckeTCuspNat_congr k (mul_comm m n)
+  rw [Commute, SemiconjBy, ← heckeTCuspNat_mul_of_primeFactors_subset k hn hm,
+    ← heckeTCuspNat_mul_of_primeFactors_subset k hm hn]
+  exact heckeTCuspNat_congr k (mul_comm n m)
 
 omit [NeZero N] in
 /-- A power of an index supported on the level is supported on the level. -/
@@ -188,7 +174,7 @@ theorem heckeTNat_pow_of_primeFactors_subset {n : ℕ} [NeZero n]
   | zero => rw [heckeTNat_congr k (pow_zero n), heckeTNat_one, pow_zero]
   | succ r ih =>
       rw [heckeTNat_congr k (pow_succ n r),
-        heckeTNat_mul_of_primeFactors_subset k (primeFactors_pow_subset hn r) hn, ih, pow_succ']
+        heckeTNat_mul_of_primeFactors_subset k (primeFactors_pow_subset hn r) hn, ih, pow_succ]
 
 /-- **`T_{n^r} = T_n ^ r` on cusp forms, at an index supported on the level.** -/
 theorem heckeTCuspNat_pow_of_primeFactors_subset {n : ℕ} [NeZero n]
@@ -199,7 +185,7 @@ theorem heckeTCuspNat_pow_of_primeFactors_subset {n : ℕ} [NeZero n]
   | succ r ih =>
       rw [heckeTCuspNat_congr k (pow_succ n r),
         heckeTCuspNat_mul_of_primeFactors_subset k (primeFactors_pow_subset hn r) hn, ih,
-        pow_succ']
+        pow_succ]
 
 /-- **`T_{p^r} = T_p ^ r` at a prime `p ∣ N`**, on `M_k(Γ₁(N))`.
 
@@ -207,14 +193,14 @@ This is the degenerate case of the prime-power recurrence
 `T_{p^{r+2}} = T_p T_{p^{r+1}} − p^{k−1} ⟨p⟩ T_{p^r}`: the zero-extended diamond `⟨p⟩` vanishes
 at `p ∣ N`, leaving `T_{p^{r+1}} = T_p T_{p^r}`. Read through `heckeUNat_eq_heckeTNat` the
 statement is `T_{p^r} = U_p ^ r`; there is no second operator. -/
-theorem heckeTNat_prime_pow (hp : p.Prime) (hpN : p ∣ N) (r : ℕ) :
+theorem heckeTNat_pow_of_prime_dvd (hp : p.Prime) (hpN : p ∣ N) (r : ℕ) :
     heckeTNat (N := N) k (p ^ r) (_hn := ⟨pow_ne_zero r hp.ne_zero⟩)
       = heckeTNat (N := N) k p (_hn := ⟨hp.ne_zero⟩) ^ r :=
   let _ : NeZero p := ⟨hp.ne_zero⟩
   heckeTNat_pow_of_primeFactors_subset k (Nat.primeFactors_mono hpN (NeZero.ne N)) r
 
 /-- **`T_{p^r} = T_p ^ r` at a prime `p ∣ N`**, on `S_k(Γ₁(N))`. -/
-theorem heckeTCuspNat_prime_pow (hp : p.Prime) (hpN : p ∣ N) (r : ℕ) :
+theorem heckeTCuspNat_pow_of_prime_dvd (hp : p.Prime) (hpN : p ∣ N) (r : ℕ) :
     heckeTCuspNat (N := N) k (p ^ r) (_hn := ⟨pow_ne_zero r hp.ne_zero⟩)
       = heckeTCuspNat (N := N) k p (_hn := ⟨hp.ne_zero⟩) ^ r :=
   let _ : NeZero p := ⟨hp.ne_zero⟩
@@ -223,45 +209,6 @@ theorem heckeTCuspNat_prime_pow (hp : p.Prime) (hpN : p ∣ N) (r : ℕ) :
 section Nebentypus
 
 variable (χ : (ZMod N)ˣ →* ℂˣ)
-
-omit [NeZero N] in
-/-- **The upper-triangular sum preserves the nebentypus at every index supported on the level.**
-If `f` transforms under `Γ₀(N)` by the character `χ`, so does `heckeSlashUpperTri k n f`.
-
-`UpperTri/Invariance.lean` proves this at a divisor `q ∣ N`, where the `Γ₀(N)`-action permutes
-the `q` representatives. That argument does **not** run at `n = q ^ 2`, since `Γ₀(N)` need not lie
-in `Γ₀(q ^ 2)`. Instead the index is peeled apart one prime at a time: `n = (n / q) · q` for `q`
-the least prime factor of `n`, which divides `N` because it divides `n`, and the composition law
-`heckeSlashUpperTri_heckeSlashUpperTri` turns the `n`-term sum into the `q`-term sum of the
-`(n / q)`-term sum. -/
-theorem heckeSlashUpperTri_slash_mapGL_of_nebentypus_of_primeFactors_subset (n : ℕ)
-    (hn0 : n ≠ 0) (hn : n.primeFactors ⊆ N.primeFactors) (γ : ↥(Gamma0 N)) {f : ℍ → ℂ}
-    (hf : ∀ δ : ↥(Gamma0 N), f ∣[k] (mapGL ℚ (δ : SL(2, ℤ)) : GL (Fin 2) ℚ)
-      = (↑(χ ((Gamma0Map N).toHomUnits δ)) : ℂ) • f) :
-    heckeSlashUpperTri k n f ∣[k] (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)
-      = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) • heckeSlashUpperTri k n f := by
-  induction n using Nat.strong_induction_on generalizing γ with
-  | _ n ih =>
-    rcases eq_or_ne n 1 with rfl | hn1
-    · rw [heckeSlashUpperTri_one]
-      exact hf γ
-    · have hq : n.minFac.Prime := Nat.minFac_prime hn1
-      have hqn : n.minFac ∣ n := Nat.minFac_dvd n
-      have hqN : n.minFac ∣ N :=
-        (Nat.mem_primeFactors.mp (hn (Nat.mem_primeFactors.mpr ⟨hq, hqn, hn0⟩))).2.1
-      have hm0 : n / n.minFac ≠ 0 :=
-        (Nat.div_pos (Nat.le_of_dvd (Nat.pos_of_ne_zero hn0) hqn) hq.pos).ne'
-      have hmlt : n / n.minFac < n := Nat.div_lt_self (Nat.pos_of_ne_zero hn0) hq.one_lt
-      have hmn : (n / n.minFac).primeFactors ⊆ N.primeFactors :=
-        (Nat.primeFactors_mono (Nat.div_dvd_of_dvd hqn) hn0).trans hn
-      have _ : NeZero n.minFac := ⟨hq.ne_zero⟩
-      have key : heckeSlashUpperTri k n f
-          = heckeSlashUpperTri k n.minFac (heckeSlashUpperTri k (n / n.minFac) f) := by
-        rw [heckeSlashUpperTri_heckeSlashUpperTri k n.minFac (n / n.minFac) f,
-          Nat.div_mul_cancel hqn]
-      rw [key]
-      exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hqN χ γ
-        fun δ ↦ ih _ hmlt hm0 hmn δ
 
 /-- **`T_n` preserves the nebentypus at every index supported on the level**: it maps
 `M_k(N, χ)` into itself. Not an assumption but a theorem, as the ModularForms roadmap asks of

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
@@ -6,14 +6,15 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Operators
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.QExpansion
 
 /-!
 # The Hecke operators at an index supported on the level
 
 Call a positive integer `n` *supported on the level* `N` when every prime factor of `n` divides
 `N`, that is `n.primeFactors ⊆ N.primeFactors`. These are the indices at which the decomposition
-proved here writes the double coset `Γ₁(N) · diag(1, n) · Γ₁(N)` as `n` upper-triangular right
-cosets
+of `HeckeRing/GL2/Gamma1/UpperTriCosets.lean` writes the double coset
+`Γ₁(N) · diag(1, n) · Γ₁(N)` as `n` upper-triangular right cosets
 `Γ₁(N) · !![1, b; 0, n]` — no further coset appears, as it does at a prime `p ∤ N`. The prime
 powers `p ^ r` with `p ∣ N` are supported on the level whether or not they divide it, and they
 are the reason this regime is worth naming: `p ∣ N` alone does not reach `T_{p²}`.
@@ -29,16 +30,17 @@ the vocabulary of modern papers the operator at `p ∣ N` is `U_p`
 (`heckeUNat`, an alias of `T_p` by `heckeUNat_eq_heckeTNat`), so the same statement reads
 `T_{p^r} = U_p ^ r`; no second operator is introduced.
 
-⚠ This is **not** the multiplicativity `T_m T_n = T_{m n}` for coprime `m`, `n`. That statement
-concerns indices coprime to each other, holds at good primes, and needs the whole coset
-decomposition of `Gamma1/CoprimeCosets.lean`; the one proved here concerns indices *sharing* the
-level's primes and degenerates the prime-power recurrence
+⚠ This does not supply multiplicativity for arbitrary coprime indices: it applies when each
+index is supported on the level, whether or not the two indices are coprime. An index with a
+prime factor outside the level needs the whole coset decomposition of
+`Gamma1/CoprimeCosets.lean`. In the level-supported case the identity degenerates the
+prime-power recurrence
 `T_{p^{r+2}} = T_p T_{p^{r+1}} − p^{k−1}⟨p⟩ T_{p^r}` to `T_{p^r} = T_p ^ r`, the zero-extended
 diamond `⟨p⟩` vanishing at `p ∣ N`.
 
 Two consequences are recorded alongside: `T_n` preserves each nebentypus space `M_k(N, χ)` and
-`S_k(N, χ)` there, and its effect on `q`-expansions is `aₘ(T_n f) = a_{n m}(f)` — the `p ∣ N`
-recurrence of `UpperTri/ModularForm.lean` at every level-supported index.
+`S_k(N, χ)` there, and its effect on `q`-expansions is `aₘ(T_n f) = a_{n m}(f)`, proved from
+the function-level recurrence in `UpperTri/QExpansion.lean`.
 
 ## Main results
 
@@ -51,7 +53,7 @@ recurrence of `UpperTri/ModularForm.lean` at every level-supported index.
   commute.
 * `HeckeRing.GL2.heckeTNat_pow_of_primeFactors_subset`: `T_{n^r} = T_n ^ r` at every
   level-supported index, with its cusp-form counterpart.
-* `HeckeRing.GL2.heckeTNat_pow_of_prime_dvd`: **`T_{p^r} = T_p ^ r` at `p ∣ N`**, with its
+* `HeckeRing.GL2.heckeTNat_pow_of_dvd`: **`T_{p^r} = T_p ^ r` at `p ∣ N`**, with its
   cusp-form counterpart.
 * `HeckeRing.GL2.heckeTNat_mem_modFormCharSpace_of_primeFactors_subset` with its
   cusp-form counterpart: the operator preserves `M_k(N, χ)` and `S_k(N, χ)`.
@@ -117,8 +119,8 @@ on `M_k(Γ₁(N))`.
 
 Both sides are upper-triangular sums, and `upperTriRep_mul_upperTriRep` matches the pairs of
 representatives with the representatives at index `n · m` bijectively. Nothing here is a
-coprimality statement: `n` and `m` share the level's primes by hypothesis, and the identity
-holds for `n = m` in particular. -/
+coprimality statement: each of `n` and `m` is supported on the level, and the identity holds
+whether or not they are coprime (in particular, for `n = m`). -/
 theorem heckeTNat_mul_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
     (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
     heckeTNat (N := N) k (n * m) = heckeTNat (N := N) k n * heckeTNat (N := N) k m :=
@@ -145,7 +147,7 @@ commuting family the simultaneous-diagonalisation arguments consume at the bad p
 theorem commute_heckeTNat_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
     (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
     Commute (heckeTNat (N := N) k n) (heckeTNat (N := N) k m) := by
-  rw [Commute, SemiconjBy, ← heckeTNat_mul_of_primeFactors_subset k hn hm,
+  rw [commute_iff_eq, ← heckeTNat_mul_of_primeFactors_subset k hn hm,
     ← heckeTNat_mul_of_primeFactors_subset k hm hn]
   exact heckeTNat_congr k (mul_comm n m)
 
@@ -153,7 +155,7 @@ theorem commute_heckeTNat_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero 
 theorem commute_heckeTCuspNat_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
     (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
     Commute (heckeTCuspNat (N := N) k n) (heckeTCuspNat (N := N) k m) := by
-  rw [Commute, SemiconjBy, ← heckeTCuspNat_mul_of_primeFactors_subset k hn hm,
+  rw [commute_iff_eq, ← heckeTCuspNat_mul_of_primeFactors_subset k hn hm,
     ← heckeTCuspNat_mul_of_primeFactors_subset k hm hn]
   exact heckeTCuspNat_congr k (mul_comm n m)
 
@@ -187,23 +189,29 @@ theorem heckeTCuspNat_pow_of_primeFactors_subset {n : ℕ} [NeZero n]
         heckeTCuspNat_mul_of_primeFactors_subset k (primeFactors_pow_subset hn r) hn, ih,
         pow_succ]
 
-/-- **`T_{p^r} = T_p ^ r` at a prime `p ∣ N`**, on `M_k(Γ₁(N))`.
+/-- **`T_{p^r} = T_p ^ r` at a divisor `p ∣ N`**, on `M_k(Γ₁(N))`.
 
-This is the degenerate case of the prime-power recurrence
+The roadmap's prime case is the degenerate case of the prime-power recurrence
 `T_{p^{r+2}} = T_p T_{p^{r+1}} − p^{k−1} ⟨p⟩ T_{p^r}`: the zero-extended diamond `⟨p⟩` vanishes
-at `p ∣ N`, leaving `T_{p^{r+1}} = T_p T_{p^r}`. Read through `heckeUNat_eq_heckeTNat` the
-statement is `T_{p^r} = U_p ^ r`; there is no second operator. -/
-theorem heckeTNat_pow_of_prime_dvd (hp : p.Prime) (hpN : p ∣ N) (r : ℕ) :
-    heckeTNat (N := N) k (p ^ r) (_hn := ⟨pow_ne_zero r hp.ne_zero⟩)
-      = heckeTNat (N := N) k p (_hn := ⟨hp.ne_zero⟩) ^ r :=
-  let _ : NeZero p := ⟨hp.ne_zero⟩
+at a prime `p ∣ N`, leaving `T_{p^{r+1}} = T_p T_{p^r}`. In that case, read through
+`heckeUNat_eq_heckeTNat`, the statement is `T_{p^r} = U_p ^ r`; there is no second operator. -/
+theorem heckeTNat_pow_of_dvd (hpN : p ∣ N) (r : ℕ) :
+    heckeTNat (N := N) k (p ^ r)
+        (_hn := ⟨pow_ne_zero r fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩)
+      = heckeTNat (N := N) k p
+          (_hn := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩) ^ r :=
+  let _ : NeZero p :=
+    ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
   heckeTNat_pow_of_primeFactors_subset k (Nat.primeFactors_mono hpN (NeZero.ne N)) r
 
-/-- **`T_{p^r} = T_p ^ r` at a prime `p ∣ N`**, on `S_k(Γ₁(N))`. -/
-theorem heckeTCuspNat_pow_of_prime_dvd (hp : p.Prime) (hpN : p ∣ N) (r : ℕ) :
-    heckeTCuspNat (N := N) k (p ^ r) (_hn := ⟨pow_ne_zero r hp.ne_zero⟩)
-      = heckeTCuspNat (N := N) k p (_hn := ⟨hp.ne_zero⟩) ^ r :=
-  let _ : NeZero p := ⟨hp.ne_zero⟩
+/-- **`T_{p^r} = T_p ^ r` at a divisor `p ∣ N`**, on `S_k(Γ₁(N))`. -/
+theorem heckeTCuspNat_pow_of_dvd (hpN : p ∣ N) (r : ℕ) :
+    heckeTCuspNat (N := N) k (p ^ r)
+        (_hn := ⟨pow_ne_zero r fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩)
+      = heckeTCuspNat (N := N) k p
+          (_hn := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩) ^ r :=
+  let _ : NeZero p :=
+    ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
   heckeTCuspNat_pow_of_primeFactors_subset k (Nat.primeFactors_mono hpN (NeZero.ne N)) r
 
 section Nebentypus

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
@@ -1,0 +1,317 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.BadPrime
+
+/-!
+# The Hecke operators at an index supported on the level
+
+Call a positive integer `n` *supported on the level* `N` when every prime factor of `n` divides
+`N`, that is `n.primeFactors ⊆ N.primeFactors`. These are exactly the indices at which the
+double coset `Γ₁(N) · diag(1, n) · Γ₁(N)` decomposes into the `n` upper-triangular right cosets
+`Γ₁(N) · !![1, b; 0, n]` — no further coset appears, as it does at a prime `p ∤ N`. The prime
+powers `p ^ r` with `p ∣ N` are supported on the level whether or not they divide it, and they
+are the reason this regime is worth naming: `p ∣ N` alone does not reach `T_{p²}`.
+
+Consequently `T_n` is the plain upper-triangular sum there, and — this is the point — these
+operators **multiply**: composing the `m`-term and the `n`-term sums enumerates the `(n·m)`-term
+sum exactly once each, so
+
+`T_n T_m = T_{n m}`  for `n` and `m` supported on the level,
+
+with **`T_{p^r} = T_p ^ r` at `p ∣ N`** as the special case the ModularForms roadmap names. In
+the vocabulary of modern papers the operator at `p ∣ N` is `U_p`
+(`heckeUNat`, an alias of `T_p` by `heckeUNat_eq_heckeTNat`), so the same statement reads
+`T_{p^r} = U_p ^ r`; no second operator is introduced.
+
+⚠ This is **not** the multiplicativity `T_m T_n = T_{m n}` for coprime `m`, `n`. That statement
+concerns indices coprime to each other, holds at good primes, and needs the whole coset
+decomposition of `Gamma1/CoprimeCosets.lean`; the one proved here concerns indices *sharing* the
+level's primes and degenerates the prime-power recurrence
+`T_{p^{r+2}} = T_p T_{p^{r+1}} − p^{k−1}⟨p⟩ T_{p^r}` to `T_{p^r} = T_p ^ r`, the zero-extended
+diamond `⟨p⟩` vanishing at `p ∣ N`.
+
+Two consequences are recorded alongside: `T_n` preserves each nebentypus space `M_k(N, χ)` and
+`S_k(N, χ)` there, and its effect on `q`-expansions is `aₘ(T_n f) = a_{n m}(f)` — the `p ∣ N`
+recurrence of `UpperTri/ModularForm.lean` at every level-supported index.
+
+## Main results
+
+* `HeckeRing.GL2.coe_heckeTNat_of_primeFactors_subset` and
+  `HeckeRing.GL2.coe_heckeTCuspNat_of_primeFactors_subset`: at an index supported on the level,
+  `T_n` is the upper-triangular sum.
+* `HeckeRing.GL2.heckeTNat_mul_of_primeFactors_subset` and its cusp-form counterpart:
+  `T_{n m} = T_m ∘ T_n` for two indices supported on the level, with
+  `HeckeRing.GL2.commute_heckeTNat_of_primeFactors_subset` recording that such operators
+  commute.
+* `HeckeRing.GL2.heckeTNat_congr` and its cusp-form counterpart: transport along an equality of
+  indices, the rewrite the `NeZero` index argument would otherwise block.
+* `HeckeRing.GL2.heckeTNat_pow_of_primeFactors_subset` and
+  `HeckeRing.GL2.heckeTNat_prime_pow`: **`T_{p^r} = T_p ^ r` at `p ∣ N`**, on modular and on
+  cusp forms.
+* `HeckeRing.GL2.heckeSlashUpperTri_slash_mapGL_of_nebentypus_of_primeFactors_subset`: the
+  function-level nebentypus transport, proved by peeling off the least prime factor of the
+  index, and `HeckeRing.GL2.heckeTNat_mem_modFormCharSpace_of_primeFactors_subset` with its
+  cusp-form counterpart: the operator preserves `M_k(N, χ)` and `S_k(N, χ)`.
+* `HeckeRing.GL2.qExpansion_coeff_heckeTNat_of_primeFactors_subset` and its cusp-form
+  counterpart: `aₘ(T_n f) = a_{n m}(f)`.
+
+## Provenance
+
+No code is transcribed. The prime-power statement is the ModularForms roadmap's Layer 2(b)
+milestone, carried in the AINTLIB `LeanModularForms` project (Chris Birkbeck, Apache-2.0) as
+`heckeT_ppow_eq_pow_of_not_coprime` (`LeanModularForms/HeckeRIngs/GL2/MultiplicationTable.lean`);
+there it is a statement about a family of operators assembled prime by prime, while here it
+falls out of the composition law for the coset representatives, which holds at every pair of
+level-supported indices and not only at powers of one prime.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Propositions 5.2.1--5.2.2 and equations (5.3)--(5.4).
+* T. Miyake, *Modular forms*, §4.5, Lemma 4.5.7.
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.5.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm
+
+namespace HeckeRing.GL2
+
+variable {N p : ℕ} [NeZero N] (k : ℤ)
+
+/-- **At an index supported on the level, `T_n` is the upper-triangular sum**
+`∑_{b < n} f ∣[k] !![1, b; 0, n]`. This is the normalisation lemma of
+`UpperTri/DoubleCoset.lean` at every such index, not only at the divisors of `N`. -/
+theorem coe_heckeTNat_of_primeFactors_subset (n : ℕ) [NeZero n]
+    (hn : n.primeFactors ⊆ N.primeFactors)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeTNat (N := N) k n f) = heckeSlashUpperTri k n ⇑f := by
+  rw [coe_heckeTNat]
+  exact heckeSlashSum_diagCosetGamma1 k (Nat.pos_of_ne_zero (NeZero.ne n)) hn f
+
+/-- **At an index supported on the level, the cusp-form `T_n` is the upper-triangular sum.** -/
+theorem coe_heckeTCuspNat_of_primeFactors_subset (n : ℕ) [NeZero n]
+    (hn : n.primeFactors ⊆ N.primeFactors)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(heckeTCuspNat (N := N) k n f) = heckeSlashUpperTri k n ⇑f := by
+  rw [coe_heckeTCuspNat]
+  exact heckeSlashSum_diagCosetGamma1 k (Nat.pos_of_ne_zero (NeZero.ne n)) hn f
+
+/-- **Transport `T_n` along an equality of indices.** The `NeZero` side condition is a `Prop`, so
+the two operators are the same object; the lemma exists because rewriting the index *inside*
+`heckeTNat` would leave the instance argument stranded at the old index. -/
+lemma heckeTNat_congr {n m : ℕ} [NeZero n] [NeZero m] (h : n = m) :
+    heckeTNat (N := N) k n = heckeTNat (N := N) k m := by
+  subst h
+  rfl
+
+/-- **Transport the cusp-form `T_n` along an equality of indices.** -/
+lemma heckeTCuspNat_congr {n m : ℕ} [NeZero n] [NeZero m] (h : n = m) :
+    heckeTCuspNat (N := N) k n = heckeTCuspNat (N := N) k m := by
+  subst h
+  rfl
+
+omit [NeZero N] in
+/-- A product of two indices supported on the level is supported on the level. -/
+private lemma primeFactors_mul_subset {n m : ℕ} [NeZero n] [NeZero m]
+    (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
+    (n * m).primeFactors ⊆ N.primeFactors := by
+  rw [Nat.primeFactors_mul (NeZero.ne n) (NeZero.ne m)]
+  exact Finset.union_subset hn hm
+
+/-- **The Hecke operators at indices supported on the level multiply**: `T_{n m} = T_m ∘ T_n`
+on `M_k(Γ₁(N))`.
+
+Both sides are upper-triangular sums, and `upperTriRep_mul_upperTriRep` matches the pairs of
+representatives with the representatives at index `n · m` bijectively. Nothing here is a
+coprimality statement: `n` and `m` share the level's primes by hypothesis, and the identity
+holds for `n = m` in particular. -/
+theorem heckeTNat_mul_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
+    (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
+    heckeTNat (N := N) k (n * m) = heckeTNat (N := N) k m * heckeTNat (N := N) k n :=
+  LinearMap.ext fun f ↦ DFunLike.ext' <| by
+    rw [coe_heckeTNat_of_primeFactors_subset k _ (primeFactors_mul_subset hn hm),
+      Module.End.mul_apply, coe_heckeTNat_of_primeFactors_subset k m hm,
+      coe_heckeTNat_of_primeFactors_subset k n hn, heckeSlashUpperTri_heckeSlashUpperTri]
+
+/-- **The cusp-form Hecke operators at indices supported on the level multiply**:
+`T_{n m} = T_m ∘ T_n` on `S_k(Γ₁(N))`. -/
+theorem heckeTCuspNat_mul_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
+    (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
+    heckeTCuspNat (N := N) k (n * m) = heckeTCuspNat (N := N) k m * heckeTCuspNat (N := N) k n :=
+  LinearMap.ext fun f ↦ DFunLike.ext' <| by
+    rw [coe_heckeTCuspNat_of_primeFactors_subset k _ (primeFactors_mul_subset hn hm),
+      Module.End.mul_apply, coe_heckeTCuspNat_of_primeFactors_subset k m hm,
+      coe_heckeTCuspNat_of_primeFactors_subset k n hn, heckeSlashUpperTri_heckeSlashUpperTri]
+
+/-- **The Hecke operators at indices supported on the level commute.** Both orders compute the
+operator at the product index, and the product of indices is commutative. This is the
+commuting family the simultaneous-diagonalisation arguments consume at the bad primes. -/
+theorem commute_heckeTNat_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
+    (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
+    Commute (heckeTNat (N := N) k n) (heckeTNat (N := N) k m) := by
+  rw [Commute, SemiconjBy, ← heckeTNat_mul_of_primeFactors_subset k hm hn,
+    ← heckeTNat_mul_of_primeFactors_subset k hn hm]
+  exact heckeTNat_congr k (mul_comm m n)
+
+/-- **The cusp-form Hecke operators at indices supported on the level commute.** -/
+theorem commute_heckeTCuspNat_of_primeFactors_subset {n m : ℕ} [NeZero n] [NeZero m]
+    (hn : n.primeFactors ⊆ N.primeFactors) (hm : m.primeFactors ⊆ N.primeFactors) :
+    Commute (heckeTCuspNat (N := N) k n) (heckeTCuspNat (N := N) k m) := by
+  rw [Commute, SemiconjBy, ← heckeTCuspNat_mul_of_primeFactors_subset k hm hn,
+    ← heckeTCuspNat_mul_of_primeFactors_subset k hn hm]
+  exact heckeTCuspNat_congr k (mul_comm m n)
+
+omit [NeZero N] in
+/-- A power of an index supported on the level is supported on the level. -/
+private lemma primeFactors_pow_subset {n : ℕ} (hn : n.primeFactors ⊆ N.primeFactors) (r : ℕ) :
+    (n ^ r).primeFactors ⊆ N.primeFactors := by
+  rcases Nat.eq_zero_or_pos r with rfl | hr
+  · simp
+  · rw [Nat.primeFactors_pow n hr.ne']
+    exact hn
+
+/-- **`T_{n^r} = T_n ^ r` at an index supported on the level.** -/
+theorem heckeTNat_pow_of_primeFactors_subset {n : ℕ} [NeZero n]
+    (hn : n.primeFactors ⊆ N.primeFactors) (r : ℕ) :
+    heckeTNat (N := N) k (n ^ r) = heckeTNat (N := N) k n ^ r := by
+  induction r with
+  | zero => rw [heckeTNat_congr k (pow_zero n), heckeTNat_one, pow_zero]
+  | succ r ih =>
+      rw [heckeTNat_congr k (pow_succ n r),
+        heckeTNat_mul_of_primeFactors_subset k (primeFactors_pow_subset hn r) hn, ih, pow_succ']
+
+/-- **`T_{n^r} = T_n ^ r` on cusp forms, at an index supported on the level.** -/
+theorem heckeTCuspNat_pow_of_primeFactors_subset {n : ℕ} [NeZero n]
+    (hn : n.primeFactors ⊆ N.primeFactors) (r : ℕ) :
+    heckeTCuspNat (N := N) k (n ^ r) = heckeTCuspNat (N := N) k n ^ r := by
+  induction r with
+  | zero => rw [heckeTCuspNat_congr k (pow_zero n), heckeTCuspNat_one, pow_zero]
+  | succ r ih =>
+      rw [heckeTCuspNat_congr k (pow_succ n r),
+        heckeTCuspNat_mul_of_primeFactors_subset k (primeFactors_pow_subset hn r) hn, ih,
+        pow_succ']
+
+/-- **`T_{p^r} = T_p ^ r` at a prime `p ∣ N`**, on `M_k(Γ₁(N))`.
+
+This is the degenerate case of the prime-power recurrence
+`T_{p^{r+2}} = T_p T_{p^{r+1}} − p^{k−1} ⟨p⟩ T_{p^r}`: the zero-extended diamond `⟨p⟩` vanishes
+at `p ∣ N`, leaving `T_{p^{r+1}} = T_p T_{p^r}`. Read through `heckeUNat_eq_heckeTNat` the
+statement is `T_{p^r} = U_p ^ r`; there is no second operator. -/
+theorem heckeTNat_prime_pow (hp : p.Prime) (hpN : p ∣ N) (r : ℕ) :
+    heckeTNat (N := N) k (p ^ r) (_hn := ⟨pow_ne_zero r hp.ne_zero⟩)
+      = heckeTNat (N := N) k p (_hn := ⟨hp.ne_zero⟩) ^ r :=
+  let _ : NeZero p := ⟨hp.ne_zero⟩
+  heckeTNat_pow_of_primeFactors_subset k (Nat.primeFactors_mono hpN (NeZero.ne N)) r
+
+/-- **`T_{p^r} = T_p ^ r` at a prime `p ∣ N`**, on `S_k(Γ₁(N))`. -/
+theorem heckeTCuspNat_prime_pow (hp : p.Prime) (hpN : p ∣ N) (r : ℕ) :
+    heckeTCuspNat (N := N) k (p ^ r) (_hn := ⟨pow_ne_zero r hp.ne_zero⟩)
+      = heckeTCuspNat (N := N) k p (_hn := ⟨hp.ne_zero⟩) ^ r :=
+  let _ : NeZero p := ⟨hp.ne_zero⟩
+  heckeTCuspNat_pow_of_primeFactors_subset k (Nat.primeFactors_mono hpN (NeZero.ne N)) r
+
+section Nebentypus
+
+variable (χ : (ZMod N)ˣ →* ℂˣ)
+
+omit [NeZero N] in
+/-- **The upper-triangular sum preserves the nebentypus at every index supported on the level.**
+If `f` transforms under `Γ₀(N)` by the character `χ`, so does `heckeSlashUpperTri k n f`.
+
+`UpperTri/Invariance.lean` proves this at a divisor `q ∣ N`, where the `Γ₀(N)`-action permutes
+the `q` representatives. That argument does **not** run at `n = q ^ 2`, since `Γ₀(N)` need not lie
+in `Γ₀(q ^ 2)`. Instead the index is peeled apart one prime at a time: `n = (n / q) · q` for `q`
+the least prime factor of `n`, which divides `N` because it divides `n`, and the composition law
+`heckeSlashUpperTri_heckeSlashUpperTri` turns the `n`-term sum into the `q`-term sum of the
+`(n / q)`-term sum. -/
+theorem heckeSlashUpperTri_slash_mapGL_of_nebentypus_of_primeFactors_subset (n : ℕ)
+    (hn0 : n ≠ 0) (hn : n.primeFactors ⊆ N.primeFactors) (γ : ↥(Gamma0 N)) {f : ℍ → ℂ}
+    (hf : ∀ δ : ↥(Gamma0 N), f ∣[k] (mapGL ℚ (δ : SL(2, ℤ)) : GL (Fin 2) ℚ)
+      = (↑(χ ((Gamma0Map N).toHomUnits δ)) : ℂ) • f) :
+    heckeSlashUpperTri k n f ∣[k] (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)
+      = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) • heckeSlashUpperTri k n f := by
+  induction n using Nat.strong_induction_on generalizing γ with
+  | _ n ih =>
+    rcases eq_or_ne n 1 with rfl | hn1
+    · rw [heckeSlashUpperTri_one]
+      exact hf γ
+    · have hq : n.minFac.Prime := Nat.minFac_prime hn1
+      have hqn : n.minFac ∣ n := Nat.minFac_dvd n
+      have hqN : n.minFac ∣ N :=
+        (Nat.mem_primeFactors.mp (hn (Nat.mem_primeFactors.mpr ⟨hq, hqn, hn0⟩))).2.1
+      have hm0 : n / n.minFac ≠ 0 :=
+        (Nat.div_pos (Nat.le_of_dvd (Nat.pos_of_ne_zero hn0) hqn) hq.pos).ne'
+      have hmlt : n / n.minFac < n := Nat.div_lt_self (Nat.pos_of_ne_zero hn0) hq.one_lt
+      have hmn : (n / n.minFac).primeFactors ⊆ N.primeFactors :=
+        (Nat.primeFactors_mono (Nat.div_dvd_of_dvd hqn) hn0).trans hn
+      have _ : NeZero n.minFac := ⟨hq.ne_zero⟩
+      have key : heckeSlashUpperTri k n f
+          = heckeSlashUpperTri k n.minFac (heckeSlashUpperTri k (n / n.minFac) f) := by
+        rw [heckeSlashUpperTri_heckeSlashUpperTri k n.minFac (n / n.minFac) f,
+          Nat.div_mul_cancel hqn]
+      rw [key]
+      exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hqN χ γ
+        fun δ ↦ ih _ hmlt hm0 hmn δ
+
+/-- **`T_n` preserves the nebentypus at every index supported on the level**: it maps
+`M_k(N, χ)` into itself. Not an assumption but a theorem, as the ModularForms roadmap asks of
+the Hecke action. -/
+theorem heckeTNat_mem_modFormCharSpace_of_primeFactors_subset (n : ℕ) [NeZero n]
+    (hn : n.primeFactors ⊆ N.primeFactors)
+    {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ modFormCharSpace k χ) :
+    heckeTNat (N := N) k n f ∈ modFormCharSpace k χ := by
+  rw [mem_modFormCharSpace_iff_nebentypus] at hf ⊢
+  intro g
+  rw [coe_heckeTNat_of_primeFactors_subset k n hn, ← ModularForm.rat_slash_mapGL]
+  exact heckeSlashUpperTri_slash_mapGL_of_nebentypus_of_primeFactors_subset k χ n
+    (NeZero.ne n) hn g fun δ ↦ by rw [ModularForm.rat_slash_mapGL]; exact hf δ
+
+/-- **`T_n` preserves the nebentypus on cusp forms**: it maps `S_k(N, χ)` into itself, at every
+index supported on the level. -/
+theorem heckeTCuspNat_mem_cuspFormCharSpace_of_primeFactors_subset (n : ℕ) [NeZero n]
+    (hn : n.primeFactors ⊆ N.primeFactors)
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :
+    heckeTCuspNat (N := N) k n f ∈ cuspFormCharSpace k χ := by
+  rw [mem_cuspFormCharSpace_iff_nebentypus] at hf ⊢
+  intro g
+  rw [coe_heckeTCuspNat_of_primeFactors_subset k n hn, ← ModularForm.rat_slash_mapGL]
+  exact heckeSlashUpperTri_slash_mapGL_of_nebentypus_of_primeFactors_subset k χ n
+    (NeZero.ne n) hn g fun δ ↦ by rw [ModularForm.rat_slash_mapGL]; exact hf δ
+
+end Nebentypus
+
+/-- **The `q`-expansion recurrence at an index supported on the level**:
+`aₘ(T_n f) = a_{n m}(f)`. At a prime `p ∣ N` this is the Diamond–Shurman recurrence
+`aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k-1} a_{m/p}(f)` with its second term killed by `χ(p) = 0`;
+at `n = p ^ r` it is the `r`-fold iterate of that. -/
+theorem qExpansion_coeff_heckeTNat_of_primeFactors_subset (n : ℕ) [NeZero n]
+    (hn : n.primeFactors ⊆ N.primeFactors)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
+    (qExpansion 1 (heckeTNat (N := N) k n f)).coeff m = (qExpansion 1 f).coeff (n * m) := by
+  rw [coe_heckeTNat_of_primeFactors_subset k n hn f]
+  exact qExpansion_coeff_heckeSlashUpperTri' k n
+    (by simp [CongruenceSubgroup.strictPeriods_Gamma1]) (Nat.pos_of_ne_zero (NeZero.ne n)) f m
+
+/-- **The `q`-expansion recurrence on cusp forms**: `aₘ(T_n f) = a_{n m}(f)` at an index
+supported on the level. -/
+theorem qExpansion_coeff_heckeTCuspNat_of_primeFactors_subset (n : ℕ) [NeZero n]
+    (hn : n.primeFactors ⊆ N.primeFactors)
+    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
+    (qExpansion 1 (heckeTCuspNat (N := N) k n f)).coeff m = (qExpansion 1 f).coeff (n * m) := by
+  rw [coe_heckeTCuspNat_of_primeFactors_subset k n hn f]
+  exact qExpansion_coeff_heckeSlashUpperTri' k n
+    (by simp [CongruenceSubgroup.strictPeriods_Gamma1]) (Nat.pos_of_ne_zero (NeZero.ne n)) f m
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
@@ -246,7 +246,8 @@ theorem heckeTCuspNat_mem_cuspFormCharSpace_of_primeFactors_subset (n : ℕ) [Ne
 end Nebentypus
 
 /-- **The `q`-expansion recurrence at an index supported on the level**:
-`aₘ(T_n f) = a_{n m}(f)`. At a prime `p ∣ N` this is the Diamond–Shurman recurrence
+`aₘ(T_n f) = a_{n m}(f)`. When `f` lies in a nebentypus-`χ` space, at a prime `p ∣ N`
+this is the Diamond–Shurman recurrence
 `aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k-1} a_{m/p}(f)` with its second term killed by `χ(p) = 0`;
 at `n = p ^ r` it is the `r`-fold iterate of that. -/
 theorem qExpansion_coeff_heckeTNat_of_primeFactors_subset (n : ℕ) [NeZero n]

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Operators.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Operators.lean
@@ -33,6 +33,8 @@ before the multiplicativity and prime-power recurrences are developed.
 ## Main results
 
 * `HeckeRing.GL2.coe_heckeTNat`, `HeckeRing.GL2.coe_heckeTCuspNat`: the underlying slash sums.
+* `HeckeRing.GL2.heckeTNat_congr`, `HeckeRing.GL2.heckeTCuspNat_congr`: transport the index
+  across an equality despite its `NeZero` instance argument.
 * `HeckeRing.GL2.heckeTNat_one`, `HeckeRing.GL2.heckeTCuspNat_one`: `T₁` is the identity.
 * `HeckeRing.GL2.coe_heckeTNat_prime`, `HeckeRing.GL2.coe_heckeTCuspNat_prime`: the classical
   formula for `T_p` at every prime.
@@ -94,6 +96,20 @@ lemma heckeTNat_def (n : ℕ) [NeZero n] :
 lemma heckeTCuspNat_def (n : ℕ) [NeZero n] :
     heckeTCuspNat (N := N) k n = heckeSlashGamma1CuspFormEnd k (diagCosetGamma1 N n) :=
   (rfl)
+
+/-- **Transport `T_n` along an equality of indices.** The `NeZero` side condition is a `Prop`, so
+the two operators are the same object; the lemma exists because rewriting the index *inside*
+`heckeTNat` would leave the instance argument stranded at the old index. -/
+lemma heckeTNat_congr {n m : ℕ} [NeZero n] [NeZero m] (h : n = m) :
+    heckeTNat (N := N) k n = heckeTNat (N := N) k m := by
+  subst h
+  rfl
+
+/-- **Transport the cusp-form `T_n` along an equality of indices.** -/
+lemma heckeTCuspNat_congr {n m : ℕ} [NeZero n] [NeZero m] (h : n = m) :
+    heckeTCuspNat (N := N) k n = heckeTCuspNat (N := N) k m := by
+  subst h
+  rfl
 
 /-- On underlying functions, `T_n` is the slash sum of its defining double coset. -/
 @[simp] lemma coe_heckeTNat (n : ℕ) [NeZero n]

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
@@ -111,7 +111,8 @@ theorem coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime (hp : p.Prim
   · rw [heckeSlashSum_diagCosetGamma1_of_coprime k hp h f, SlashAction.slash_mul,
       slash_mapGL_gamma0Twist_eq_diamondOpNat k h f]
   · have hpN : p ∣ N := hp.dvd_iff_not_coprime.mpr h
-    rw [heckeSlashSum_diagCosetGamma1 k hpN f, diamondOpNat_of_not_coprime k h]
+    rw [heckeSlashSum_diagCosetGamma1 k hp.pos (Nat.primeFactors_mono hpN (NeZero.ne N)) f,
+      diamondOpNat_of_not_coprime k h]
     simp
 
 /-- **The classical `Tₚ` on `S_k(Γ₁(N))`, at every prime** — the same formula, with the
@@ -125,7 +126,8 @@ theorem coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime (hp : p.Prime)
   · rw [heckeSlashSum_diagCosetGamma1_of_coprime k hp h f, SlashAction.slash_mul,
       slash_mapGL_gamma0Twist_eq_diamondOpCuspNat k h f]
   · have hpN : p ∣ N := hp.dvd_iff_not_coprime.mpr h
-    rw [heckeSlashSum_diagCosetGamma1 k hpN f, diamondOpCuspNat_of_not_coprime k h]
+    rw [heckeSlashSum_diagCosetGamma1 k hp.pos (Nat.primeFactors_mono hpN (NeZero.ne N)) f,
+      diamondOpCuspNat_of_not_coprime k h]
     simp
 
 /-- **`Tₚ` on a nebentypus space `M_k(N, χ)`, at a prime `p ∤ N`.** The diamond acts by the

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Prime.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.CoprimeCosets
+public import TauCeti.NumberTheory.ModularForms.DiamondOperators
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.DoubleCoset
 
 /-!

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Recurrence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Recurrence.lean
@@ -31,8 +31,7 @@ and on a nebentypus space `M_k(N, χ)` with `p ∤ N`, where the diamond acts by
 divides the level: `a_{m/p}` is read as an explicit `if p ∣ m`, and at `p ∣ N` the zero-extended
 diamond `⟨p⟩` of `DiamondOperators.lean` vanishes, so the recurrence degenerates to
 `aₘ(Tₚ f) = a_{p m}(f)` — the operator modern papers write `Uₚ`. Following Miyake,
-Diamond–Shurman and Shimura, `Uₚ` is not a second operator, only this case of `Tₚ`; it appears
-here as `qExpansion_coeff_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_dvd_level`.
+Diamond–Shurman and Shimura, `Uₚ` is not a second operator, only this case of `Tₚ`.
 
 The `Nat` division in `a_{m/p}` is guarded by that `if`: without it, `m / p` would silently
 round down at indices `p ∤ m` and name a coefficient the recurrence does not contain.
@@ -46,8 +45,6 @@ round down at indices `p ∤ m` and name a coefficient the recurrence does not c
   `χ(p)` in place of the diamond.
 * `HeckeRing.GL2.qExpansion_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime`: the same
   identity between power series, the diamond term appearing as a `PowerSeries.expand`.
-* `HeckeRing.GL2.qExpansion_coeff_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_dvd_level`:
-  the degenerate `p ∣ N` case, `aₘ(Tₚ f) = a_{p m}(f)`.
 * `HeckeRing.GL2.qExpansion_coeff_one_heckeSlashGamma1ModularFormEnd_diagCosetGamma1`:
   `a₁(Tₚ f) = a_p(f)`, and
   `HeckeRing.GL2.eq_qExpansion_coeff_of_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_eq_smul`:
@@ -216,26 +213,6 @@ theorem qExpansion_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime
     rw [qExpansion_coeff_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime k hp f m,
       map_add, PowerSeries.coeff_mk, map_smul, PowerSeries.coeff_expand, smul_eq_mul]
     split_ifs <;> simp
-
-/-- **The coefficient formula at any divisor of the level**: for `p ∣ N`,
-`aₘ(Tₚ f) = a_{p m}(f)` with no second term. When `p` is prime, this is the operator modern
-papers write `Uₚ`; following Miyake, Diamond–Shurman and Shimura it is not a separate object,
-only the `p ∣ N` case of `Tₚ`. -/
-theorem qExpansion_coeff_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_dvd_level
-    (hpN : p ∣ N) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
-    (qExpansion 1 (heckeSlashGamma1ModularFormEnd k (diagCosetGamma1 N p) f)).coeff m =
-      (qExpansion 1 f).coeff (p * m) := by
-  rw [heckeSlashGamma1ModularFormEnd_diagCosetGamma1 k hpN]
-  exact qExpansion_coeff_heckeSlashUpperTriModularFormEnd k hpN f m
-
-/-- **The coefficient formula at any divisor of the level, on cusp forms**:
-`aₘ(Tₚ f) = a_{p m}(f)` for `p ∣ N`. -/
-theorem qExpansion_coeff_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_dvd_level
-    (hpN : p ∣ N) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
-    (qExpansion 1 (heckeSlashGamma1CuspFormEnd k (diagCosetGamma1 N p) f)).coeff m =
-      (qExpansion 1 f).coeff (p * m) := by
-  rw [heckeSlashGamma1CuspFormEnd_diagCosetGamma1 k hpN]
-  exact qExpansion_coeff_heckeSlashUpperTriCuspFormEnd k hpN f m
 
 /-- **The first coefficient of `Tₚ f` is the `p`-th coefficient of `f`**, at every prime and
 every level: `p ∤ 1`, so the diamond term of the recurrence is absent. This is what turns a

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Recurrence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Recurrence.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Diagonal.QExpansion
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Prime
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.QExpansion
 
 /-!
 # The Fourier-coefficient recurrence for `Tₚ`, at every prime

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/DoubleCoset.lean
@@ -37,16 +37,17 @@ is `HeckeRing/GL2/Gamma1/UpperTriCosets.lean`: at `p ∣ N` the `p` cosets
 those in turns the abstract sum into `heckeSlashUpperTri`, and the two bundled endomorphisms
 then agree because both are that function on the underlying `ℍ → ℂ`.
 
-## Why `p ∣ N` and no primality
+## Why level-supportedness, and the bundled `p ∣ N` case
 
-`p ∣ N` is what makes the `p` upper-triangular representatives exhaust the coset; for `p ∤ N` and
-`p` prime there is one further coset and the identification below is false as stated. No
-primality is needed anywhere: at `p ∣ N` the count is `p` for every `p`, prime or not.
+The condition `p.primeFactors ⊆ N.primeFactors` makes the `p` upper-triangular representatives
+exhaust the coset; for `p ∤ N` and `p` prime there is one further coset and the identification
+below is false as stated. No primality is needed anywhere.
 
 The function-level statement `heckeSlashSum_diagCosetGamma1` is proved under the weaker
 hypothesis the coset decomposition actually uses — every prime factor of `p` divides `N` — since
 the prime powers `q ^ r` with `q ∣ N` satisfy it without dividing `N`. The two bundled operators
-stay at `p ∣ N`, because `heckeSlashUpperTriModularFormEnd` is only constructed there.
+stay at the special case `p ∣ N`, because `heckeSlashUpperTriModularFormEnd` is only constructed
+there.
 
 Following Miyake, Diamond–Shurman and Shimura, no separate `Uₚ` is introduced — this *is* `Tₚ` at
 `p ∣ N`, and the identification proved here is what lets literature stated in either vocabulary be

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/DoubleCoset.lean
@@ -43,6 +43,11 @@ then agree because both are that function on the underlying `ℍ → ℂ`.
 `p` prime there is one further coset and the identification below is false as stated. No
 primality is needed anywhere: at `p ∣ N` the count is `p` for every `p`, prime or not.
 
+The function-level statement `heckeSlashSum_diagCosetGamma1` is proved under the weaker
+hypothesis the coset decomposition actually uses — every prime factor of `p` divides `N` — since
+the prime powers `q ^ r` with `q ∣ N` satisfy it without dividing `N`. The two bundled operators
+stay at `p ∣ N`, because `heckeSlashUpperTriModularFormEnd` is only constructed there.
+
 Following Miyake, Diamond–Shurman and Shimura, no separate `Uₚ` is introduced — this *is* `Tₚ` at
 `p ∣ N`, and the identification proved here is what lets literature stated in either vocabulary be
 consumed.
@@ -50,7 +55,8 @@ consumed.
 ## Main results
 
 * `HeckeRing.GL2.heckeSlashSum_diagCosetGamma1`: on underlying functions, the abstract slash sum
-  of `diagCosetGamma1 N p` is `heckeSlashUpperTri k p`.
+  of `diagCosetGamma1 N p` is `heckeSlashUpperTri k p`, at any index whose prime factors all
+  divide the level — `p ∣ N` is the case the bundled operators below are stated at.
 * `HeckeRing.GL2.heckeSlashGamma1ModularFormEnd_diagCosetGamma1`,
   `HeckeRing.GL2.heckeSlashGamma1CuspFormEnd_diagCosetGamma1`: **the normalisation lemma**, on
   `M_k(Γ₁(N))` and on `S_k(Γ₁(N))`.
@@ -87,15 +93,21 @@ for, which `p ∣ N` and `NeZero N` already supply. -/
 private lemma pos_of_dvd (hpN : p ∣ N) : 0 < p :=
   Nat.pos_of_ne_zero fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))
 
-/-- **The abstract slash sum of `diag(1, p)` is the classical upper-triangular sum**, for
-`p ∣ N`. This is `heckeSlashSum_coe_eq_sum_of_rightCosets` fed with the decomposition of
-`HeckeRing/GL2/Gamma1/UpperTriCosets.lean`; slash-invariance of `f`, the one hypothesis that
-lemma needs, is carried by the form class. -/
-theorem heckeSlashSum_diagCosetGamma1 (hpN : p ∣ N) {F : Type*} [FunLike F ℍ ℂ]
+/-- The prime factors of a divisor of a nonzero level are prime factors of the level: the
+hypothesis the coset decomposition asks for, in the form `p ∣ N` supplies. -/
+private lemma primeFactors_subset_of_dvd (hpN : p ∣ N) : p.primeFactors ⊆ N.primeFactors :=
+  Nat.primeFactors_mono hpN (NeZero.ne N)
+
+/-- **The abstract slash sum of `diag(1, p)` is the classical upper-triangular sum**, at any
+index supported on the level. This is `heckeSlashSum_coe_eq_sum_of_rightCosets` fed with the
+decomposition of `HeckeRing/GL2/Gamma1/UpperTriCosets.lean`; slash-invariance of `f`, the one
+hypothesis that lemma needs, is carried by the form class. -/
+theorem heckeSlashSum_diagCosetGamma1 (hp : 0 < p) (hpN : p.primeFactors ⊆ N.primeFactors)
+    {F : Type*} [FunLike F ℍ ℂ]
     [SlashInvariantFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (f : F) :
     heckeSlashSum k (diagCosetGamma1 N p) ⇑f = heckeSlashUpperTri k p ⇑f :=
   (heckeSlashSum_coe_eq_sum_of_rightCosets k (diagCosetGamma1 N p) (upperTriRep p)
-    (doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets (pos_of_dvd hpN) hpN)
+    (doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets hp hpN)
     op_upperTriRep_smul_injective f).trans (heckeSlashUpperTri_def k p ⇑f).symm
 
 /-- **The normalisation lemma on `M_k(Γ₁(N))`.** For `p ∣ N` the Hecke operator of the double
@@ -107,7 +119,7 @@ theorem heckeSlashGamma1ModularFormEnd_diagCosetGamma1 (hpN : p ∣ N) :
       heckeSlashUpperTriModularFormEnd k hpN :=
   LinearMap.ext fun f ↦ DFunLike.ext' <| by
     rw [coe_heckeSlashGamma1ModularFormEnd, coe_heckeSlashUpperTriModularFormEnd,
-      heckeSlashSum_diagCosetGamma1 k hpN f]
+      heckeSlashSum_diagCosetGamma1 k (pos_of_dvd hpN) (primeFactors_subset_of_dvd hpN) f]
 
 /-- **The normalisation lemma on `S_k(Γ₁(N))`.** -/
 @[simp]
@@ -115,7 +127,7 @@ theorem heckeSlashGamma1CuspFormEnd_diagCosetGamma1 (hpN : p ∣ N) :
     heckeSlashGamma1CuspFormEnd k (diagCosetGamma1 N p) = heckeSlashUpperTriCuspFormEnd k hpN :=
   LinearMap.ext fun f ↦ DFunLike.ext' <| by
     rw [coe_heckeSlashGamma1CuspFormEnd, coe_heckeSlashUpperTriCuspFormEnd,
-      heckeSlashSum_diagCosetGamma1 k hpN f]
+      heckeSlashSum_diagCosetGamma1 k (pos_of_dvd hpN) (primeFactors_subset_of_dvd hpN) f]
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/DoubleCoset.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/DoubleCoset.lean
@@ -23,9 +23,10 @@ This file identifies them, which is the roadmap's flagged *normalisation lemma*:
 
 `heckeSlashGamma1ModularFormEnd k (diagCosetGamma1 N p) = heckeSlashUpperTriModularFormEnd k hpN`,
 
-and likewise on cusp forms. Everything already known about the classical operator — the
-recurrence `aₘ(Tₚ f) = a_{p m}(f)` on `q`-expansions, stability of each nebentypus space —
-transfers to the abstract one by rewriting with these two equalities, which are `simp` lemmas.
+and likewise on cusp forms. These `simp` lemmas provide the normalization bridge between the
+abstract and explicit constructions. Nebentypus preservation and the `q`-expansion recurrence
+for the canonical `heckeTNat` operator are proved at every level-supported index in
+`HeckeSlash/LevelSupported.lean`.
 
 ## How the two are matched
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Invariance.lean
@@ -9,13 +9,13 @@ public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.Sum
 
 /-!
-# The upper-triangular Hecke sum is `Γ₀(N)`-equivariant when `p ∣ N`
+# Equivariance of the upper-triangular Hecke sum at level-supported indices
 
 `UpperTri/Sum.lean` defines `heckeSlashUpperTri k p f = ∑_{b < p} f ∣[k] !![1, b; 0, p]`, and
 `UpperTri/Periodic.lean` shows it preserves invariance under the single matrix `T`. That is far
 short of an operator: to act on `M_k(Γ₁(N))` the sum has to preserve invariance under the whole
-group. This file proves that it does, **provided `p` divides the level** — the case in which the
-factorisation below closes on the `p` upper-triangular representatives.
+group. This file proves the basic case when `p` divides the level, then obtains every index
+supported on the level by composing those basic sums.
 
 ## The permutation
 
@@ -40,8 +40,9 @@ has the *same* `Gamma0Map` value as `γ`; and if `γ ∈ Γ₁(N)` then `γ' ∈
 on `f` is only ever used at matrices congruent to `γ` in the relevant sense, which is what lets
 the nebentypus version below carry a fixed character.
 
-⚠ `p ∣ N` is essential to the equivariance proved here, not a convenience. When `p` is prime and
-`p ∤ N`, the classical double coset has one further left coset, represented by
+⚠ `p ∣ N` is essential to the direct permutation argument, not a convenience. The general
+level-supported theorem below instead composes sums at prime divisors of `N`. When `p` is prime
+and `p ∤ N`, the classical double coset has one further left coset, represented by
 `!![p, 0; 0, 1]` up to a `Γ₀(N)` twist, and the sum over the upper-triangular representatives
 alone is *not* invariant.
 
@@ -60,6 +61,8 @@ alone is *not* invariant.
   function is `Γ₁(N)`-invariant.
 * `HeckeRing.GL2.heckeSlashUpperTri_slash_mapGL_of_nebentypus`: the sum of a function with
   nebentypus `χ` has nebentypus `χ`.
+* `HeckeRing.GL2.heckeSlashUpperTri_slash_mapGL_of_nebentypus_of_primeFactors_subset`: the same
+  conclusion for every index whose prime factors divide `N`.
 
 ## References
 
@@ -217,6 +220,42 @@ theorem heckeSlashUpperTri_slash_mapGL_of_nebentypus (k : ℤ) [NeZero p] (hpN :
   intro δ hδ hd
   have hmap : (Gamma0Map N).toHomUnits ⟨δ, hδ⟩ = (Gamma0Map N).toHomUnits γ := Units.ext hd
   rw [hf ⟨δ, hδ⟩, hmap]
+
+/-- **The upper-triangular sum preserves the nebentypus at every index supported on the level.**
+If `f` transforms under `Γ₀(N)` by the character `χ`, so does `heckeSlashUpperTri k n f`.
+
+The divisor case above does not apply directly at `n = q ^ 2`, since `Γ₀(N)` need not lie in
+`Γ₀(q ^ 2)`. Instead the index is peeled apart one prime at a time, and the composition law for
+upper-triangular sums reduces to the divisor case. -/
+theorem heckeSlashUpperTri_slash_mapGL_of_nebentypus_of_primeFactors_subset (k : ℤ)
+    (χ : (ZMod N)ˣ →* ℂˣ) (n : ℕ) (hn0 : n ≠ 0)
+    (hn : n.primeFactors ⊆ N.primeFactors) (γ : ↥(Gamma0 N)) {f : ℍ → ℂ}
+    (hf : ∀ δ : ↥(Gamma0 N), f ∣[k] (mapGL ℚ (δ : SL(2, ℤ)) : GL (Fin 2) ℚ)
+      = (↑(χ ((Gamma0Map N).toHomUnits δ)) : ℂ) • f) :
+    heckeSlashUpperTri k n f ∣[k] (mapGL ℚ (γ : SL(2, ℤ)) : GL (Fin 2) ℚ)
+      = (↑(χ ((Gamma0Map N).toHomUnits γ)) : ℂ) • heckeSlashUpperTri k n f := by
+  induction n using Nat.strong_induction_on generalizing γ with
+  | _ n ih =>
+    rcases eq_or_ne n 1 with rfl | hn1
+    · rw [heckeSlashUpperTri_one]
+      exact hf γ
+    · have hq : n.minFac.Prime := Nat.minFac_prime hn1
+      have hqn : n.minFac ∣ n := Nat.minFac_dvd n
+      have hqN : n.minFac ∣ N :=
+        (Nat.mem_primeFactors.mp (hn (Nat.mem_primeFactors.mpr ⟨hq, hqn, hn0⟩))).2.1
+      have hm0 : n / n.minFac ≠ 0 :=
+        (Nat.div_pos (Nat.le_of_dvd (Nat.pos_of_ne_zero hn0) hqn) hq.pos).ne'
+      have hmlt : n / n.minFac < n := Nat.div_lt_self (Nat.pos_of_ne_zero hn0) hq.one_lt
+      have hmn : (n / n.minFac).primeFactors ⊆ N.primeFactors :=
+        (Nat.primeFactors_mono (Nat.div_dvd_of_dvd hqn) hn0).trans hn
+      have _ : NeZero n.minFac := ⟨hq.ne_zero⟩
+      have key : heckeSlashUpperTri k n f
+          = heckeSlashUpperTri k n.minFac (heckeSlashUpperTri k (n / n.minFac) f) := by
+        rw [heckeSlashUpperTri_heckeSlashUpperTri k n.minFac (n / n.minFac) f,
+          Nat.div_mul_cancel hqn]
+      rw [key]
+      exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hqN χ γ
+        fun δ ↦ ih _ hmlt hm0 hmn δ
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
@@ -53,9 +53,6 @@ is `ModularForm.rat_slash_mapGL`, from `ModularForms/SlashActionRat.lean`.
 * `HeckeRing.GL2.coe_heckeSlashUpperTriModularFormEnd`,
   `HeckeRing.GL2.coe_heckeSlashUpperTriCuspFormEnd`: both are `heckeSlashUpperTri` on underlying
   functions.
-* `HeckeRing.GL2.heckeSlashUpperTriModularFormEnd_mem_modFormCharSpace`,
-  `HeckeRing.GL2.heckeSlashUpperTriCuspFormEnd_mem_cuspFormCharSpace`: **the operator preserves
-  the nebentypus**.
 * `HeckeRing.GL2.qExpansion_coeff_heckeSlashUpperTriModularFormEnd`,
   `HeckeRing.GL2.qExpansion_coeff_heckeSlashUpperTriCuspFormEnd`: the coefficient at `m` is the
   coefficient of the original form at `p m`.
@@ -161,32 +158,6 @@ noncomputable def heckeSlashUpperTriCuspFormEnd (hpN : p ∣ N) :
 @[simp] lemma coe_heckeSlashUpperTriCuspFormEnd (hpN : p ∣ N)
     (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
     ⇑(heckeSlashUpperTriCuspFormEnd k hpN f) = heckeSlashUpperTri k p f := (rfl)
-
-/-- **The operator preserves the nebentypus**: it maps `M_k(N, χ)` into itself. Not an
-assumption but a theorem: the factorisation of `UpperTri/Invariance.lean` replaces a `Γ₀(N)`
-matrix by one with the same lower-right entry modulo `N`, so the character value is unchanged. -/
-theorem heckeSlashUpperTriModularFormEnd_mem_modFormCharSpace (hpN : p ∣ N)
-    (χ : (ZMod N)ˣ →* ℂˣ) {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k}
-    (hf : f ∈ modFormCharSpace k χ) :
-    heckeSlashUpperTriModularFormEnd k hpN f ∈ modFormCharSpace k χ := by
-  let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
-  rw [mem_modFormCharSpace_iff_nebentypus] at hf ⊢
-  intro g
-  rw [coe_heckeSlashUpperTriModularFormEnd, ← ModularForm.rat_slash_mapGL]
-  exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hpN χ g
-    fun δ ↦ by rw [ModularForm.rat_slash_mapGL]; exact hf δ
-
-/-- **The operator preserves the nebentypus on cusp forms**: it maps `S_k(N, χ)` into itself. -/
-theorem heckeSlashUpperTriCuspFormEnd_mem_cuspFormCharSpace (hpN : p ∣ N)
-    (χ : (ZMod N)ˣ →* ℂˣ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
-    (hf : f ∈ cuspFormCharSpace k χ) :
-    heckeSlashUpperTriCuspFormEnd k hpN f ∈ cuspFormCharSpace k χ := by
-  let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
-  rw [mem_cuspFormCharSpace_iff_nebentypus] at hf ⊢
-  intro g
-  rw [coe_heckeSlashUpperTriCuspFormEnd, ← ModularForm.rat_slash_mapGL]
-  exact heckeSlashUpperTri_slash_mapGL_of_nebentypus k hpN χ g
-    fun δ ↦ by rw [ModularForm.rat_slash_mapGL]; exact hf δ
 
 /-- **The `q`-expansion recurrence**: the coefficient at `m` is `a_{p m}(f)` for `p ∣ N`.
 When `p` is prime, this is the Diamond–Shurman recurrence

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/ModularForm.lean
@@ -5,22 +5,21 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.NumberTheory.ModularForms.DiamondOperators
+import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.Holomorphic
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.Cusps
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.Invariance
-public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.QExpansion
 
 /-!
 # The upper-triangular Hecke operator on `M_k(Γ₁(N))` and `S_k(Γ₁(N))`
 
-The four analytic inputs for `heckeSlashUpperTri` are in place — holomorphy
+The three analytic inputs for `heckeSlashUpperTri` are in place — holomorphy
 (`UpperTri/Holomorphic.lean`), boundedness and vanishing at every cusp (`UpperTri/Cusps.lean`),
-the `q`-expansion (`UpperTri/QExpansion.lean`) — and `UpperTri/Invariance.lean` supplies the
-missing algebraic one: at `p ∣ N` the sum preserves `Γ₁(N)`-invariance. This file assembles them
+and `UpperTri/Invariance.lean` supplies the missing algebraic one: at `p ∣ N` the sum preserves
+`Γ₁(N)`-invariance. This file assembles them
 into the operator itself, a `ℂ`-linear endomorphism of `ModularForm ((Gamma1 N).map (mapGL ℝ)) k`
-and of `CuspForm ((Gamma1 N).map (mapGL ℝ)) k`, and records the two facts that make it usable:
-it preserves each nebentypus space `M_k(N, χ)`, `S_k(N, χ)`, and on `q`-expansions it is
-`aₘ ↦ a_{p m}`.
+and of `CuspForm ((Gamma1 N).map (mapGL ℝ)) k`. Nebentypus preservation and the `q`-expansion
+recurrence for the canonical `heckeTNat` operator are recorded at every level-supported index in
+`HeckeSlash/LevelSupported.lean`.
 
 This is Layer 2(b) of the ModularForms roadmap at a level divisible by `p`. When `p` is prime,
 the classical `Tₚ` for `p ∤ N` needs one further coset representative and is not built here;
@@ -53,10 +52,6 @@ is `ModularForm.rat_slash_mapGL`, from `ModularForms/SlashActionRat.lean`.
 * `HeckeRing.GL2.coe_heckeSlashUpperTriModularFormEnd`,
   `HeckeRing.GL2.coe_heckeSlashUpperTriCuspFormEnd`: both are `heckeSlashUpperTri` on underlying
   functions.
-* `HeckeRing.GL2.qExpansion_coeff_heckeSlashUpperTriModularFormEnd`,
-  `HeckeRing.GL2.qExpansion_coeff_heckeSlashUpperTriCuspFormEnd`: the coefficient at `m` is the
-  coefficient of the original form at `p m`.
-
 ## References
 
 * [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.2–5.3.
@@ -81,12 +76,6 @@ private lemma rat_slash_eq_of_mem_Gamma1 {F : Type*} [FunLike F ℍ ℂ]
     (hδ : δ ∈ Gamma1 N) : (⇑f) ∣[k] (mapGL ℚ δ : GL (Fin 2) ℚ) = ⇑f := by
   rw [ModularForm.rat_slash_mapGL]
   exact SlashInvariantFormClass.slash_action_eq f _ (Subgroup.mem_map_of_mem _ hδ)
-
-/-- The width of `∞` for `Γ₁(N)` is `1`, so all `q`-expansions below are taken at width `1`. -/
-private lemma one_mem_strictPeriods_Gamma1 :
-    (1 : ℝ) ∈ ((Gamma1 N).map (mapGL ℝ)).strictPeriods := by
-  rw [strictPeriods_Gamma1]
-  exact AddSubgroup.mem_zmultiples 1
 
 variable [NeZero N]
 
@@ -158,28 +147,6 @@ noncomputable def heckeSlashUpperTriCuspFormEnd (hpN : p ∣ N) :
 @[simp] lemma coe_heckeSlashUpperTriCuspFormEnd (hpN : p ∣ N)
     (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
     ⇑(heckeSlashUpperTriCuspFormEnd k hpN f) = heckeSlashUpperTri k p f := (rfl)
-
-/-- **The `q`-expansion recurrence**: the coefficient at `m` is `a_{p m}(f)` for `p ∣ N`.
-When `p` is prime, this is the Diamond–Shurman recurrence
-`aₘ(Tₚ f) = a_{m p}(f) + χ(p) p^{k-1} a_{m/p}(f)` in the case that makes the second term vanish,
-`χ(p) = 0`. -/
-theorem qExpansion_coeff_heckeSlashUpperTriModularFormEnd (hpN : p ∣ N)
-    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
-    (qExpansion 1 (heckeSlashUpperTriModularFormEnd k hpN f)).coeff m
-      = (qExpansion 1 f).coeff (p * m) := by
-  rw [coe_heckeSlashUpperTriModularFormEnd]
-  exact qExpansion_coeff_heckeSlashUpperTri' k p one_mem_strictPeriods_Gamma1
-    (Nat.pos_of_ne_zero fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))) f m
-
-/-- **The `q`-expansion recurrence on cusp forms**: the coefficient at `m` is `a_{p m}(f)` for
-`p ∣ N`. -/
-theorem qExpansion_coeff_heckeSlashUpperTriCuspFormEnd (hpN : p ∣ N)
-    (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) (m : ℕ) :
-    (qExpansion 1 (heckeSlashUpperTriCuspFormEnd k hpN f)).coeff m
-      = (qExpansion 1 f).coeff (p * m) := by
-  rw [coe_heckeSlashUpperTriCuspFormEnd]
-  exact qExpansion_coeff_heckeSlashUpperTri' k p one_mem_strictPeriods_Gamma1
-    (Nat.pos_of_ne_zero fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))) f m
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
@@ -35,6 +35,8 @@ the entrywise description of the representatives is not restated.
   its sum.
 * `HeckeRing.GL2.heckeSlashUpperTri_zero`, `heckeSlashUpperTri_add`,
   `heckeSlashUpperTri_smul`: linearity in `f`.
+* `HeckeRing.GL2.heckeSlashUpperTri_heckeSlashUpperTri`: the sums compose, the `p`-term sum of
+  the `n`-term sum being the `(n · p)`-term sum.
 The representatives themselves, and their upper-triangularity and positive determinant, live in
 `HeckeRing/GL2/CosetDecomposition.lean`; this file is only the slash sum built from them.
 
@@ -103,5 +105,34 @@ scalar generality matches `ModularForm.rat_smul_slash_of_det_pos`. -/
   rw [heckeSlashUpperTri_def, heckeSlashUpperTri_def, Finset.smul_sum]
   exact Finset.sum_congr rfl fun b _ ↦
     ModularForm.rat_smul_slash_of_det_pos k (det_upperTriRep_pos p b) f c
+
+/-- **The upper-triangular sums compose**: the `p`-term sum of the `n`-term sum is the
+`(n · p)`-term sum,
+
+`∑_{b < p} (∑_{b' < n} f ∣[k] !![1, b'; 0, n]) ∣[k] !![1, b; 0, p] =
+  ∑_{c < n·p} f ∣[k] !![1, c; 0, n·p]`.
+
+Both sides are sums of slashes of `f` by representatives, and `upperTriRep_mul_upperTriRep`
+matches the index pair `(b', b)` with the offset `finProdFinEquiv (b', b)` of the composite
+family; that map is a bijection, so each composite representative occurs exactly once.
+
+No divisibility, primality or level hypothesis enters: this is an identity of finite sums of
+slashes, valid for every `f : ℍ → ℂ`. -/
+lemma heckeSlashUpperTri_heckeSlashUpperTri (n : ℕ) (f : ℍ → ℂ) :
+    heckeSlashUpperTri k p (heckeSlashUpperTri k n f) = heckeSlashUpperTri k (n * p) f := by
+  have hstep : ∀ b : Fin p, heckeSlashUpperTri k n f ∣[k] upperTriRep p b =
+      ∑ b' : Fin n, f ∣[k] upperTriRep (n * p) (finProdFinEquiv (b', b)) := fun b ↦ by
+    rw [heckeSlashUpperTri_def, SlashAction.sum_slash]
+    exact Finset.sum_congr rfl fun b' _ ↦ by
+      rw [← SlashAction.slash_mul, upperTriRep_mul_upperTriRep]
+  calc heckeSlashUpperTri k p (heckeSlashUpperTri k n f)
+      = ∑ b : Fin p, ∑ b' : Fin n, f ∣[k] upperTriRep (n * p) (finProdFinEquiv (b', b)) := by
+        rw [heckeSlashUpperTri_def]
+        exact Finset.sum_congr rfl fun b _ ↦ hstep b
+    _ = ∑ x : Fin n × Fin p, f ∣[k] upperTriRep (n * p) (finProdFinEquiv x) := by
+        rw [Fintype.sum_prod_type]
+        exact Finset.sum_comm
+    _ = heckeSlashUpperTri k (n * p) f :=
+        Fintype.sum_equiv finProdFinEquiv _ _ fun _ ↦ rfl
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/UpperTri/Sum.lean
@@ -118,7 +118,7 @@ family; that map is a bijection, so each composite representative occurs exactly
 
 No divisibility, primality or level hypothesis enters: this is an identity of finite sums of
 slashes, valid for every `f : ℍ → ℂ`. -/
-lemma heckeSlashUpperTri_heckeSlashUpperTri (n : ℕ) (f : ℍ → ℂ) :
+@[simp] lemma heckeSlashUpperTri_heckeSlashUpperTri (n : ℕ) (f : ℍ → ℂ) :
     heckeSlashUpperTri k p (heckeSlashUpperTri k n f) = heckeSlashUpperTri k (n * p) f := by
   have hstep : ∀ b : Fin p, heckeSlashUpperTri k n f ∣[k] upperTriRep p b =
       ∑ b' : Fin n, f ∣[k] upperTriRep (n * p) (finProdFinEquiv (b', b)) := fun b ↦ by


### PR DESCRIPTION
This PR proves `T_{p^r} = T_p ^ r` at a prime `p ∣ N`, the Layer 2(b) milestone the
ModularForms roadmap states as "Similarly `T_{p^r} = Tₚ^r` at `p ∣ N` (AINTLIB
`heckeT_ppow_eq_pow_of_not_coprime`), the degenerate case of the prime-power recurrence once
`⟨p⟩ = 0`". It serves the roadmap's **uniform Hecke operators** milestone — one operator `Tₙ`
for every `n`, with `Uₚ` only an alias at `p ∣ N` — whose remaining pieces are the good-prime
multiplicativity `TₘTₙ = T_{mn}` for `(m,n) = 1` and the Hecke-ring homomorphism onto the
character spaces. Those two are what is left of the milestone after this PR; the bad-prime side
is now closed.

The obstruction was that `main` only knew the coset decomposition
`Γ₁(N)·diag(1,p)·Γ₁(N) = ⨆_{b<p} Γ₁(N)·!![1,b;0,p]` for `p ∣ N`, and `p²` does not divide `N` in
general, so `T_{p²}` was out of reach. The right hypothesis is not divisibility but
`p.primeFactors ⊆ N.primeFactors`: the forward inclusion needs only that the upper-left entry
`a ≡ 1 (mod N)` of a `Γ₁(N)` element is invertible modulo the index, and that follows from
coprimality with `N` as soon as the index's primes are the level's. So
`exists_mem_Gamma1_natDiagGL_mul`, `doubleCoset_natDiagGL_eq_iUnion_rightCosets` and
`doubleCoset_out_diagCosetGamma1_eq_iUnion_rightCosets` in
`HeckeRing/GL2/Gamma1/UpperTriCosets.lean` are generalised in place, the offset now coming from
a Bézout solution of `a·j ≡ b (mod p)` rather than from `j ≡ b`; `heckeSlashSum_diagCosetGamma1`
follows suit, and its two bundled `p ∣ N` corollaries pass `Nat.primeFactors_mono`. The
prime-power indices `q^r` with `q ∣ N` satisfy the new hypothesis without dividing `N`, which is
the whole point.

With the decomposition in hand the multiplication law is a computation with the representatives:
`!![1,b';0,n] * !![1,b;0,p] = !![1, b + p·b'; 0, n·p]`, and `finProdFinEquiv` matches the index
pairs with the offsets of the composite family bijectively
(`upperTriRep_mul_upperTriRep` in `HeckeRing/GL2/CosetDecomposition.lean`,
`heckeSlashUpperTri_heckeSlashUpperTri` in `HeckeSlash/UpperTri/Sum.lean` — no level or primality
hypothesis in either). The new module
`TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean` (317 lines) turns that into
Hecke-operator statements: `T_n` is the upper-triangular sum at every index supported on the
level, `T_{n m} = T_m ∘ T_n` there, those operators `Commute`, `T_{n^r} = T_n ^ r`, and the named
`heckeTNat_prime_pow` / `heckeTCuspNat_prime_pow`. Read through the existing
`heckeUNat_eq_heckeTNat` the last statement is `T_{p^r} = U_p ^ r`; no second operator is
introduced, per the roadmap's convention.

Two consequences come with it. `T_n` **preserves the nebentypus** at every level-supported index
— `heckeTNat_mem_modFormCharSpace_of_primeFactors_subset` and its cusp-form counterpart, the
proof obligation the roadmap flags with "the action must preserve cuspidality and the
nebentypus; prove that, don't assume it". `main` had this only at `p ∣ N`, where the `Γ₀(N)`
action permutes the `p` representatives; that argument does not run at `p²`, since `Γ₀(N)` need
not lie in `Γ₀(p²)`, so the index is instead peeled apart one prime at a time by strong
induction on `n` through the composition law. And the `q`-expansion recurrence
`aₘ(T_n f) = a_{n m}(f)` extends from the divisors of `N` to every level-supported index.

`heckeTNat_congr` and its cusp counterpart transport `T_n` along an equality of indices; they
exist because the `NeZero` index argument makes an ordinary `rw` of the index inside `heckeTNat`
produce an ill-typed motive.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"hecket-ppow-eq-pow-of-not-coprime"}-->

🤖 Prepared with Claude Code
