### PR TITLE
feat: connected covering spaces are the categorically connected ones

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Connected.lean
@@ -97,8 +97,8 @@ theorem isInitial_iff_isEmpty (p : CoveringSpace X) :
     by_contra hne
     exact hf.elim (nonempty_fiber p (not_isEmpty_iff.mp hne) x₀).some
   · intro h
-    exact ⟨isInitialOfIsInitialObj (fiberActionFunctor x₀)
-      (isInitialActionOfIsEmpty (A := (fiberActionFunctor x₀).obj p) ⟨fun a => h.elim a.1⟩)⟩
+    exact ⟨(isInitialActionOfIsEmpty (A := (fiberActionFunctor x₀).obj p)
+      ⟨fun a => h.elim a.1⟩).isInitialOfObj (fiberActionFunctor x₀) p⟩
 
 /-- **A covering space of `X` is a connected object of `TauCeti.CoveringSpace X` exactly when its
 total space is a connected space.** -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Connected.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.FundamentalGroupAction
+public import TauCeti.CategoryTheory.Action.Connected
+public import TauCeti.CategoryTheory.Galois.Connected
+
+/-!
+# Connected covering spaces are the categorically connected ones
+
+Let `X` be path connected, locally path connected and semilocally simply connected. Covering
+spaces of `X` carry two unrelated-looking notions of connectedness: the topological one, that the
+total space is a `ConnectedSpace`, and the categorical one,
+`CategoryTheory.PreGaloisCategory.IsConnected`, which asks that the cover is not an initial object
+of `TauCeti.CoveringSpace X` and has no nontrivial subobject there. This file proves that they
+agree.
+
+The bridge is the classification of covers by `π₁(X, x₀)`-sets. Categorical connectedness is
+invariant under an equivalence of categories (`TauCeti.isConnected_map_iff`), so it can be read off
+on the other side of `TauCeti.CoveringSpace.fiberActionEquivalence`, where it says exactly that the
+monodromy action on the fibre over `x₀` is transitive and nonempty
+(`TauCeti.isConnected_action_iff_isTransitiveAction`). That in turn is the condition already known
+to characterise connected covers: transitivity of monodromy is
+`TauCeti.ConnectedCoveringSpace.isTransitiveAction_fiberAction`, and conversely a cover realising a
+transitive action is isomorphic to a connected one by
+`TauCeti.ConnectedCoveringSpace.exists_fiberAction_iso`, hence has homeomorphic total space.
+
+The only topology used is path lifting, through `TauCeti.CoveringSpace.nonempty_fiber`: the
+initial objects of `TauCeti.CoveringSpace X` are the covers with empty total space, and to read
+that off the fibre over `x₀` one needs a nonempty cover to have a nonempty fibre. Everything else
+is the transport of a categorical condition along an already-established equivalence. The
+statement is what lets the Galois-theoretic vocabulary — connected objects, and the Galois
+correspondence phrased through them — be used on covering spaces.
+
+## Main declarations
+
+* `TauCeti.CoveringSpace.isTransitiveAction_fiberAction_iff_connectedSpace`: the monodromy action
+  on the fibre over `x₀` is transitive exactly when the total space is connected.
+* `TauCeti.CoveringSpace.isInitial_iff_isEmpty`: a covering space is an initial object exactly
+  when its total space is empty.
+* `TauCeti.CoveringSpace.isConnected_iff_connectedSpace`: **a covering space of `X` is a connected
+  object of `TauCeti.CoveringSpace X` exactly when its total space is a connected space.**
+* `TauCeti.ConnectedCoveringSpace.isConnected_forget_obj`: a connected covering space is a
+  connected object of `TauCeti.CoveringSpace X`.
+
+## References
+
+This is the connectedness dictionary for the alternative lens of Stage 2, item 8 of
+`TauCetiRoadmap/UniversalCovers/README.md`. It consumes the classification of covers by
+`π₁(X, x₀)`-sets and Mathlib's `CategoryTheory.PreGaloisCategory.IsConnected`; no Mathlib proof is
+vendored.
+-/
+
+public section
+noncomputable section
+
+open CategoryTheory Limits Topology
+
+universe u
+
+namespace TauCeti.CoveringSpace
+
+variable {X : TopCat.{u}} (x₀ : X) [PathConnectedSpace X] [LocallyPathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X]
+
+/-- The monodromy action of `π₁(X, x₀)` on the fibre of a covering space over `x₀` is transitive
+exactly when the total space of that cover is connected. -/
+theorem isTransitiveAction_fiberAction_iff_connectedSpace (p : CoveringSpace X) :
+    isTransitiveAction (FundamentalGroup X x₀) ((fiberActionFunctor x₀).obj p) ↔
+      ConnectedSpace (p : TopCat) := by
+  constructor
+  · intro h
+    obtain ⟨q, ⟨e⟩⟩ :=
+      ConnectedCoveringSpace.exists_fiberAction_iso x₀ ((fiberActionFunctor x₀).obj p) h
+    have hq : ConnectedSpace ((totalSpace X).obj ((ConnectedCoveringSpace.forget X).obj q)) :=
+      q.property.2
+    exact (TopCat.homeoOfIso
+      ((totalSpace X).mapIso ((fiberActionFunctor x₀).preimageIso e))).connectedSpace_iff.mp hq
+  · intro h
+    exact ConnectedCoveringSpace.isTransitiveAction_fiberAction x₀
+      (⟨p.obj, ⟨p.property, h⟩⟩ : ConnectedCoveringSpace X)
+
+/-- **A covering space of `X` is an initial object of `TauCeti.CoveringSpace X` exactly when its
+total space is empty.** The empty cover is therefore the initial object, and a cover is
+"non-initial" in the sense of the definition of a connected object exactly when it is nonempty. -/
+theorem isInitial_iff_isEmpty (p : CoveringSpace X) :
+    Nonempty (IsInitial p) ↔ IsEmpty (p : TopCat) := by
+  obtain ⟨x₀⟩ := PathConnectedSpace.nonempty (X := (X : Type u))
+  constructor
+  · rintro ⟨h⟩
+    have hf : IsEmpty (ToType ((fiberActionFunctor x₀).obj p)) :=
+      isEmpty_of_isInitial_action (h.isInitialObj (fiberActionFunctor x₀) p)
+    by_contra hne
+    exact hf.elim (nonempty_fiber p (not_isEmpty_iff.mp hne) x₀).some
+  · intro h
+    exact ⟨isInitialOfIsInitialObj (fiberActionFunctor x₀)
+      (isInitialActionOfIsEmpty (A := (fiberActionFunctor x₀).obj p) ⟨fun a => h.elim a.1⟩)⟩
+
+/-- **A covering space of `X` is a connected object of `TauCeti.CoveringSpace X` exactly when its
+total space is a connected space.** -/
+theorem isConnected_iff_connectedSpace (p : CoveringSpace X) :
+    PreGaloisCategory.IsConnected p ↔ ConnectedSpace (p : TopCat) := by
+  obtain ⟨x₀⟩ := PathConnectedSpace.nonempty (X := (X : Type u))
+  exact ((isConnected_map_iff (fiberActionFunctor x₀) p).symm.trans
+      (isConnected_action_iff_isTransitiveAction _)).trans
+    (isTransitiveAction_fiberAction_iff_connectedSpace x₀ p)
+
+end TauCeti.CoveringSpace
+
+namespace TauCeti.ConnectedCoveringSpace
+
+variable {X : TopCat.{u}} [PathConnectedSpace X] [LocallyPathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X]
+
+/-- A connected covering space is a connected object of `TauCeti.CoveringSpace X`. -/
+theorem isConnected_forget_obj (p : ConnectedCoveringSpace X) :
+    PreGaloisCategory.IsConnected ((forget X).obj p) :=
+  (CoveringSpace.isConnected_iff_connectedSpace ((forget X).obj p)).mpr p.property.2
+
+end TauCeti.ConnectedCoveringSpace
+
+end

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Connected.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Connected.lean
@@ -25,23 +25,21 @@ on the other side of `TauCeti.CoveringSpace.fiberActionEquivalence`, where it sa
 monodromy action on the fibre over `x₀` is transitive and nonempty
 (`TauCeti.isConnected_action_iff_isTransitiveAction`). That in turn is the condition already known
 to characterise connected covers: transitivity of monodromy is
-`TauCeti.ConnectedCoveringSpace.isTransitiveAction_fiberAction`, and conversely a cover realising a
-transitive action is isomorphic to a connected one by
-`TauCeti.ConnectedCoveringSpace.exists_fiberAction_iso`, hence has homeomorphic total space.
+`TauCeti.ConnectedCoveringSpace.isTransitiveAction_fiberAction`, and conversely a cover with
+transitive monodromy has path-connected total space, because path lifting joins every point of the
+total space to a point of the fibre over `x₀` and monodromy joins any two points of that fibre.
+That converse needs no hypothesis on `X` beyond path connectedness, so the dictionary between
+transitive monodromy and a connected total space is established before the classification is
+invoked; only the passage to the categorical statement uses the full standing hypotheses.
 
-The only topology used is path lifting, through `TauCeti.CoveringSpace.nonempty_fiber`: the
-initial objects of `TauCeti.CoveringSpace X` are the covers with empty total space, and to read
-that off the fibre over `x₀` one needs a nonempty cover to have a nonempty fibre. Everything else
-is the transport of a categorical condition along an already-established equivalence. The
-statement is what lets the Galois-theoretic vocabulary — connected objects, and the Galois
-correspondence phrased through them — be used on covering spaces.
+The initial objects of `TauCeti.CoveringSpace X` play no special role here: they are the covers
+with empty total space over any base, which is
+`TauCeti.CoveringSpace.isInitial_iff_isEmpty` in the general covering-space API.
 
 ## Main declarations
 
 * `TauCeti.CoveringSpace.isTransitiveAction_fiberAction_iff_connectedSpace`: the monodromy action
   on the fibre over `x₀` is transitive exactly when the total space is connected.
-* `TauCeti.CoveringSpace.isInitial_iff_isEmpty`: a covering space is an initial object exactly
-  when its total space is empty.
 * `TauCeti.CoveringSpace.isConnected_iff_connectedSpace`: **a covering space of `X` is a connected
   object of `TauCeti.CoveringSpace X` exactly when its total space is a connected space.**
 * `TauCeti.ConnectedCoveringSpace.isConnected_forget_obj`: a connected covering space is a
@@ -65,43 +63,47 @@ universe u
 namespace TauCeti.CoveringSpace
 
 variable {X : TopCat.{u}} (x₀ : X) [PathConnectedSpace X] [LocallyPathConnectedSpace X]
-  [SemilocallySimplyConnectedSpace X]
 
 /-- The monodromy action of `π₁(X, x₀)` on the fibre of a covering space over `x₀` is transitive
-exactly when the total space of that cover is connected. -/
+exactly when the total space of that cover is connected.
+
+This is deliberately not `@[simp]`: `TauCeti.isTransitiveAction_iff` is already a simp lemma, so
+the left-hand side is not in simp normal form and `simpNF` rejects the attribute. -/
 theorem isTransitiveAction_fiberAction_iff_connectedSpace (p : CoveringSpace X) :
     isTransitiveAction (FundamentalGroup X x₀) ((fiberActionFunctor x₀).obj p) ↔
       ConnectedSpace (p : TopCat) := by
   constructor
   · intro h
-    obtain ⟨q, ⟨e⟩⟩ :=
-      ConnectedCoveringSpace.exists_fiberAction_iso x₀ ((fiberActionFunctor x₀).obj p) h
-    have hq : ConnectedSpace ((totalSpace X).obj ((ConnectedCoveringSpace.forget X).obj q)) :=
-      q.property.2
-    exact (TopCat.homeoOfIso
-      ((totalSpace X).mapIso ((fiberActionFunctor x₀).preimageIso e))).connectedSpace_iff.mp hq
+    obtain ⟨htrans, ⟨e₀⟩⟩ := (isTransitiveAction_iff _).mp h
+    have hjoin {a b : (p : TopCat)} (q : Path.Homotopic.Quotient a b) : Joined a b := by
+      induction q using Path.Homotopic.Quotient.ind with
+      | mk γ => exact ⟨γ⟩
+    -- Path lifting joins every point of the total space to a point of the fibre over `x₀`.
+    have key (e : (p : TopCat)) : ∃ f : ⇑p.proj ⁻¹' {x₀}, Joined e (f : (p : TopCat)) :=
+      ⟨_, hjoin (p.isCoveringMap_proj.liftPathQuotient
+        (Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath (p.proj e) x₀)) ⟨e, rfl⟩)⟩
+    -- Transitivity of the monodromy action joins any two points of that fibre.
+    have hfib (f f' : ⇑p.proj ⁻¹' {x₀}) : Joined (f : (p : TopCat)) (f' : (p : TopCat)) := by
+      obtain ⟨g, hg⟩ := htrans.exists_smul_eq f f'
+      have hg' : (p.isCoveringMap_proj.monodromy g.toPath f : (p : TopCat)) = f' :=
+        congrArg Subtype.val hg
+      have := hjoin (p.isCoveringMap_proj.liftPathQuotient g.toPath f)
+      rwa [hg'] at this
+    have : PathConnectedSpace (p : TopCat) := by
+      refine ⟨⟨(e₀ : ⇑p.proj ⁻¹' {x₀}).1⟩, fun a b => ?_⟩
+      obtain ⟨f, hf⟩ := key a
+      obtain ⟨f', hf'⟩ := key b
+      exact (hf.trans (hfib f f')).trans hf'.symm
+    infer_instance
   · intro h
     exact ConnectedCoveringSpace.isTransitiveAction_fiberAction x₀
       (⟨p.obj, ⟨p.property, h⟩⟩ : ConnectedCoveringSpace X)
 
-/-- **A covering space of `X` is an initial object of `TauCeti.CoveringSpace X` exactly when its
-total space is empty.** The empty cover is therefore the initial object, and a cover is
-"non-initial" in the sense of the definition of a connected object exactly when it is nonempty. -/
-theorem isInitial_iff_isEmpty (p : CoveringSpace X) :
-    Nonempty (IsInitial p) ↔ IsEmpty (p : TopCat) := by
-  obtain ⟨x₀⟩ := PathConnectedSpace.nonempty (X := (X : Type u))
-  constructor
-  · rintro ⟨h⟩
-    have hf : IsEmpty (ToType ((fiberActionFunctor x₀).obj p)) :=
-      isEmpty_of_isInitial_action (h.isInitialObj (fiberActionFunctor x₀) p)
-    by_contra hne
-    exact hf.elim (nonempty_fiber p (not_isEmpty_iff.mp hne) x₀).some
-  · intro h
-    exact ⟨(isInitialActionOfIsEmpty (A := (fiberActionFunctor x₀).obj p)
-      ⟨fun a => h.elim a.1⟩).isInitialOfObj (fiberActionFunctor x₀) p⟩
+variable [SemilocallySimplyConnectedSpace X]
 
 /-- **A covering space of `X` is a connected object of `TauCeti.CoveringSpace X` exactly when its
 total space is a connected space.** -/
+@[simp]
 theorem isConnected_iff_connectedSpace (p : CoveringSpace X) :
     PreGaloisCategory.IsConnected p ↔ ConnectedSpace (p : TopCat) := by
   obtain ⟨x₀⟩ := PathConnectedSpace.nonempty (X := (X : Type u))

--- a/TauCeti/CategoryTheory/Action/Connected.lean
+++ b/TauCeti/CategoryTheory/Action/Connected.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.Action.Limits
+public import Mathlib.CategoryTheory.Galois.Basic
+public import TauCeti.CategoryTheory.Action.Transitive
+
+/-!
+# Connected `G`-sets are the transitive ones
+
+An object of a category is *connected* in the sense of
+`CategoryTheory.PreGaloisCategory.IsConnected` when it is not initial and admits no nontrivial
+subobject. This file identifies that condition for `G`-sets: an object of `Action (Type u) G` is
+connected exactly when it is nonempty and `G` acts transitively on it, which is
+`TauCeti.isTransitiveAction`.
+
+Mathlib proves the same statement for *finite* `G`-sets in
+`CategoryTheory.Action.isConnected_iff_transitive`, but that proof runs through the fibre functor
+of the Galois category `Action FintypeCat G`, machinery unavailable here: `Action (Type u) G` has
+objects with infinite underlying type and is not a Galois category. The argument is instead run
+directly, over the two facts about the forgetful functor `Action (Type u) G ⥤ Type u` that replace
+it: it preserves and reflects monomorphisms, because it preserves and reflects finite limits, and a
+`G`-set is initial exactly when its underlying type is empty.
+
+## Main declarations
+
+* `TauCeti.isInitialActionOfIsEmpty` and `TauCeti.isEmpty_of_isInitial_action`: a `G`-set is
+  initial exactly when its underlying type is empty.
+* `TauCeti.mono_action_iff_injective`: a map of `G`-sets is a monomorphism exactly when it is
+  injective.
+* `TauCeti.isConnected_action_iff_isTransitiveAction`: **a `G`-set is connected exactly when it is
+  transitive.**
+-/
+
+public section
+noncomputable section
+
+universe u v
+
+namespace TauCeti
+
+open CategoryTheory Limits
+
+variable {G : Type v} [Monoid G]
+
+/-- A `G`-set whose underlying type is empty is an initial object. -/
+def isInitialActionOfIsEmpty {A : Action (Type u) G} (h : IsEmpty (ToType A)) : IsInitial A :=
+  IsInitial.ofUniqueHom (fun _ => ⟨↾(fun a => h.elim a), fun _ => by ext a; exact h.elim a⟩)
+    fun _ _ => Action.hom_ext _ _ (by ext a; exact h.elim a)
+
+/-- A `G`-set that is an initial object has empty underlying type. -/
+theorem isEmpty_of_isInitial_action {A : Action (Type u) G} (h : IsInitial A) :
+    IsEmpty (ToType A) :=
+  Function.isEmpty (β := PEmpty.{u + 1}) (h.to ⟨PEmpty.{u + 1}, 1⟩).hom
+
+/-- A `G`-set fails to be an initial object exactly when its underlying type is nonempty. -/
+theorem nonempty_iff_not_isInitial_action (A : Action (Type u) G) :
+    Nonempty (ToType A) ↔ (IsInitial A → False) :=
+  ⟨fun h hi => (isEmpty_of_isInitial_action hi).elim h.some,
+    fun h => not_isEmpty_iff.mp fun he => h (isInitialActionOfIsEmpty he)⟩
+
+/-- A map of `G`-sets is a monomorphism exactly when the underlying map of types is injective.
+Both directions come from the forgetful functor to types, which preserves and reflects finite
+limits and hence monomorphisms. -/
+theorem mono_action_iff_injective {A B : Action (Type u) G} (f : A ⟶ B) :
+    Mono f ↔ Function.Injective f.hom := by
+  constructor
+  · intro _
+    have hf : Mono ((Action.forget (Type u) G).map f) := (Action.forget (Type u) G).map_mono f
+    exact (CategoryTheory.mono_iff_injective f.hom).mp hf
+  · intro hf
+    have hm : Mono ((Action.forget (Type u) G).map f) :=
+      (CategoryTheory.mono_iff_injective f.hom).mpr hf
+    exact (Action.forget (Type u) G).mono_of_mono_map hm
+
+/-- **A `G`-set is connected exactly when it is transitive**, that is, exactly when its underlying
+type is nonempty and `G` acts transitively on it. -/
+theorem isConnected_action_iff_isTransitiveAction (A : Action (Type u) G) :
+    PreGaloisCategory.IsConnected A ↔ isTransitiveAction G A := by
+  constructor
+  · intro hA
+    refine (isTransitiveAction_iff A).mpr
+      ⟨⟨fun x y => ?_⟩, (nonempty_iff_not_isInitial_action A).mpr hA.notInitial⟩
+    -- The orbit of `x` is a subobject of `A` with nonempty underlying type, hence all of `A`.
+    let T : Action (Type u) G := Action.ofMulAction G (MulAction.orbit G x)
+    let i : T ⟶ A := ⟨↾Subtype.val, fun _ => rfl⟩
+    have _ : Mono i := (mono_action_iff_injective i).mpr Subtype.val_injective
+    have hne : IsInitial T → False := fun h =>
+      (isEmpty_of_isInitial_action h).elim ⟨x, MulAction.mem_orbit_self x⟩
+    have _ : IsIso i := hA.noTrivialComponent T i hne
+    have hiso : IsIso i.hom := inferInstanceAs (IsIso ((Action.forget (Type u) G).map i))
+    obtain ⟨⟨y', ⟨g, hg⟩⟩, hy⟩ :=
+      ((CategoryTheory.isIso_iff_bijective i.hom).mp hiso).surjective y
+    exact ⟨g, hg.trans hy⟩
+  · intro hA
+    obtain ⟨htrans, hne⟩ := (isTransitiveAction_iff A).mp hA
+    refine ⟨fun h => (nonempty_iff_not_isInitial_action A).mp hne h, fun Y i hm hni => ?_⟩
+    have _ : Mono i := hm
+    obtain ⟨y₀⟩ := (nonempty_iff_not_isInitial_action Y).mpr hni
+    have hbij : Function.Bijective i.hom := by
+      refine ⟨(mono_action_iff_injective i).mp hm, fun a => ?_⟩
+      obtain ⟨g, hg⟩ := htrans.exists_smul_eq (i.hom y₀) a
+      refine ⟨g • y₀, ?_⟩
+      rw [← hg, smul_eq_ρ_apply, smul_eq_ρ_apply]
+      simpa using ConcreteCategory.congr_hom (i.comm g) y₀
+    have _ : IsIso i.hom := (CategoryTheory.isIso_iff_bijective i.hom).mpr hbij
+    infer_instance
+
+end TauCeti
+
+end

--- a/TauCeti/CategoryTheory/Action/Connected.lean
+++ b/TauCeti/CategoryTheory/Action/Connected.lean
@@ -67,15 +67,8 @@ theorem nonempty_iff_not_isInitial_action (A : Action (Type u) G) :
 Both directions come from the forgetful functor to types, which preserves and reflects finite
 limits and hence monomorphisms. -/
 theorem mono_action_iff_injective {A B : Action (Type u) G} (f : A ⟶ B) :
-    Mono f ↔ Function.Injective f.hom := by
-  constructor
-  · intro _
-    have hf : Mono ((Action.forget (Type u) G).map f) := (Action.forget (Type u) G).map_mono f
-    exact (CategoryTheory.mono_iff_injective f.hom).mp hf
-  · intro hf
-    have hm : Mono ((Action.forget (Type u) G).map f) :=
-      (CategoryTheory.mono_iff_injective f.hom).mpr hf
-    exact (Action.forget (Type u) G).mono_of_mono_map hm
+    Mono f ↔ Function.Injective f.hom :=
+  ((Action.forget (Type u) G).mono_map_iff_mono f).symm.trans (mono_iff_injective _)
 
 /-- **A `G`-set is connected exactly when it is transitive**, that is, exactly when its underlying
 type is nonempty and `G` acts transitively on it. -/

--- a/TauCeti/CategoryTheory/Action/Connected.lean
+++ b/TauCeti/CategoryTheory/Action/Connected.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.CategoryTheory.Action.Limits
 public import Mathlib.CategoryTheory.Galois.Basic
+public import Mathlib.CategoryTheory.Limits.Shapes.ConcreteCategory
 public import TauCeti.CategoryTheory.Action.Transitive
 
 /-!
@@ -23,13 +24,16 @@ Mathlib proves the same statement for *finite* `G`-sets in
 of the Galois category `Action FintypeCat G`, machinery unavailable here: `Action (Type u) G` has
 objects with infinite underlying type and is not a Galois category. The argument is instead run
 directly, over the two facts about the forgetful functor `Action (Type u) G ⥤ Type u` that replace
-it: it preserves and reflects monomorphisms, because it preserves and reflects finite limits, and a
-`G`-set is initial exactly when its underlying type is empty.
+it: it preserves and reflects monomorphisms, and a `G`-set is initial exactly when its underlying
+type is empty.
+
+Both facts are Mathlib's, once the concrete-category forgetful functor of `Action (Type u) G` is
+known to preserve and reflect the empty colimit; that is what the two instances below record, and
+with them `CategoryTheory.Concrete.initial_iff_empty_of_preserves_of_reflects` applies verbatim to
+`G`-sets.
 
 ## Main declarations
 
-* `TauCeti.isInitialActionOfIsEmpty` and `TauCeti.isEmpty_of_isInitial_action`: a `G`-set is
-  initial exactly when its underlying type is empty.
 * `TauCeti.mono_action_iff_injective`: a map of `G`-sets is a monomorphism exactly when it is
   injective.
 * `TauCeti.isConnected_action_iff_isTransitiveAction`: **a `G`-set is connected exactly when it is
@@ -47,43 +51,48 @@ open CategoryTheory Limits
 
 variable {G : Type v} [Monoid G]
 
-/-- A `G`-set whose underlying type is empty is an initial object. -/
-def isInitialActionOfIsEmpty {A : Action (Type u) G} (h : IsEmpty (ToType A)) : IsInitial A :=
-  IsInitial.ofUniqueHom (fun _ => ⟨↾(fun a => h.elim a), fun _ => by ext a; exact h.elim a⟩)
-    fun _ _ => Action.hom_ext _ _ (by ext a; exact h.elim a)
+/-- The concrete-category forgetful functor of `Action (Type u) G` preserves initial objects: it
+is the composite of `Action.forget`, which preserves all colimits of shape `Discrete PEmpty`, with
+the forgetful functor of `Type u`. -/
+instance preservesColimit_empty_forget_action :
+    PreservesColimit (Functor.empty.{0} (Action (Type u) G)) (forget (Action (Type u) G)) := by
+  change PreservesColimit _ (Action.forget (Type u) G ⋙ forget (Type u))
+  infer_instance
 
-/-- A `G`-set that is an initial object has empty underlying type. -/
-theorem isEmpty_of_isInitial_action {A : Action (Type u) G} (h : IsInitial A) :
-    IsEmpty (ToType A) :=
-  Function.isEmpty (β := PEmpty.{u + 1}) (h.to ⟨PEmpty.{u + 1}, 1⟩).hom
-
-/-- A `G`-set fails to be an initial object exactly when its underlying type is nonempty. -/
-theorem nonempty_iff_not_isInitial_action (A : Action (Type u) G) :
-    Nonempty (ToType A) ↔ (IsInitial A → False) :=
-  ⟨fun h hi => (isEmpty_of_isInitial_action hi).elim h.some,
-    fun h => not_isEmpty_iff.mp fun he => h (isInitialActionOfIsEmpty he)⟩
+/-- The concrete-category forgetful functor of `Action (Type u) G` reflects initial objects. -/
+instance reflectsColimit_empty_forget_action :
+    ReflectsColimit (Functor.empty.{0} (Action (Type u) G)) (forget (Action (Type u) G)) := by
+  change ReflectsColimit _ (Action.forget (Type u) G ⋙ forget (Type u))
+  infer_instance
 
 /-- A map of `G`-sets is a monomorphism exactly when the underlying map of types is injective.
 Both directions come from the forgetful functor to types, which preserves and reflects finite
 limits and hence monomorphisms. -/
+@[simp]
 theorem mono_action_iff_injective {A B : Action (Type u) G} (f : A ⟶ B) :
     Mono f ↔ Function.Injective f.hom :=
   ((Action.forget (Type u) G).mono_map_iff_mono f).symm.trans (mono_iff_injective _)
 
 /-- **A `G`-set is connected exactly when it is transitive**, that is, exactly when its underlying
 type is nonempty and `G` acts transitively on it. -/
+@[simp]
 theorem isConnected_action_iff_isTransitiveAction (A : Action (Type u) G) :
     PreGaloisCategory.IsConnected A ↔ isTransitiveAction G A := by
+  have hinit (B : Action (Type u) G) : Nonempty (ToType B) ↔ (IsInitial B → False) := by
+    constructor
+    · exact fun h hi =>
+        ((Concrete.initial_iff_empty_of_preserves_of_reflects B).mp ⟨hi⟩).elim h.some
+    · exact fun h => not_isEmpty_iff.mp fun he =>
+        h ((Concrete.initial_iff_empty_of_preserves_of_reflects B).mpr he).some
   constructor
   · intro hA
-    refine (isTransitiveAction_iff A).mpr
-      ⟨⟨fun x y => ?_⟩, (nonempty_iff_not_isInitial_action A).mpr hA.notInitial⟩
+    refine (isTransitiveAction_iff A).mpr ⟨⟨fun x y => ?_⟩, (hinit A).mpr hA.notInitial⟩
     -- The orbit of `x` is a subobject of `A` with nonempty underlying type, hence all of `A`.
     let T : Action (Type u) G := Action.ofMulAction G (MulAction.orbit G x)
     let i : T ⟶ A := ⟨↾Subtype.val, fun _ => rfl⟩
     have _ : Mono i := (mono_action_iff_injective i).mpr Subtype.val_injective
-    have hne : IsInitial T → False := fun h =>
-      (isEmpty_of_isInitial_action h).elim ⟨x, MulAction.mem_orbit_self x⟩
+    have hne : IsInitial T → False :=
+      (hinit T).mp ⟨⟨x, MulAction.mem_orbit_self x⟩⟩
     have _ : IsIso i := hA.noTrivialComponent T i hne
     have hiso : IsIso i.hom := inferInstanceAs (IsIso ((Action.forget (Type u) G).map i))
     obtain ⟨⟨y', ⟨g, hg⟩⟩, hy⟩ :=
@@ -91,9 +100,9 @@ theorem isConnected_action_iff_isTransitiveAction (A : Action (Type u) G) :
     exact ⟨g, hg.trans hy⟩
   · intro hA
     obtain ⟨htrans, hne⟩ := (isTransitiveAction_iff A).mp hA
-    refine ⟨fun h => (nonempty_iff_not_isInitial_action A).mp hne h, fun Y i hm hni => ?_⟩
+    refine ⟨fun h => (hinit A).mp hne h, fun Y i hm hni => ?_⟩
     have _ : Mono i := hm
-    obtain ⟨y₀⟩ := (nonempty_iff_not_isInitial_action Y).mpr hni
+    obtain ⟨y₀⟩ := (hinit Y).mpr hni
     have hbij : Function.Bijective i.hom := by
       refine ⟨(mono_action_iff_injective i).mp hm, fun a => ?_⟩
       obtain ⟨g, hg⟩ := htrans.exists_smul_eq (i.hom y₀) a

--- a/TauCeti/CategoryTheory/Galois/Connected.lean
+++ b/TauCeti/CategoryTheory/Galois/Connected.lean
@@ -25,7 +25,6 @@ whose objects are not finite sets.
 ## Main declarations
 
 * `TauCeti.isConnected_of_iso`: an object isomorphic to a connected object is connected.
-* `TauCeti.isInitialOfIsInitialObj`: an equivalence reflects initial objects.
 * `TauCeti.isConnected_map`: an equivalence carries connected objects to connected objects.
 * `TauCeti.isConnected_map_iff`: connectedness of `F.obj A` is equivalent to connectedness of `A`.
 -/
@@ -69,14 +68,10 @@ private def unitIsoApp (A : C) : A ≅ F.inv.obj (F.obj A) :=
 private def counitIsoApp (B : D) : F.obj (F.inv.obj B) ≅ B :=
   F.asEquivalence.counitIso.app B
 
-/-- An equivalence of categories reflects initial objects. -/
-def isInitialOfIsInitialObj {A : C} (h : IsInitial (F.obj A)) : IsInitial A :=
-  IsInitial.ofIso (h.isInitialObj F.inv (F.obj A)) (unitIsoApp F A).symm
-
 /-- An equivalence of categories carries connected objects to connected objects. -/
 theorem isConnected_map (A : C) [PreGaloisCategory.IsConnected A] :
     PreGaloisCategory.IsConnected (F.obj A) where
-  notInitial h := PreGaloisCategory.IsConnected.notInitial (isInitialOfIsInitialObj F h)
+  notInitial h := PreGaloisCategory.IsConnected.notInitial (h.isInitialOfObj F A)
   noTrivialComponent Y i hm hni := by
     have _ : Mono i := hm
     have _ : Mono (F.inv.map i) := F.inv.map_mono i

--- a/TauCeti/CategoryTheory/Galois/Connected.lean
+++ b/TauCeti/CategoryTheory/Galois/Connected.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.CategoryTheory.Galois.Basic
+
+/-!
+# Connected objects are invariant under equivalence
+
+`CategoryTheory.PreGaloisCategory.IsConnected` is defined by conditions on initial objects,
+monomorphisms and isomorphisms alone, and an equivalence of categories preserves and reflects all
+three. This file records the resulting transport statements: connectedness is invariant under
+isomorphism inside a category, and an equivalence `F : C ⥤ D` makes `F.obj A` connected exactly
+when `A` is.
+
+None of this needs the Galois axioms. Mathlib states connectedness for an object of an arbitrary
+category and only later restricts to `PreGaloisCategory`, and that arbitrary generality is what is
+used here; in particular the statements apply to a category that is merely *equivalent* to a
+Galois category, which is how a connectedness criterion is transported to a concrete category
+whose objects are not finite sets.
+
+## Main declarations
+
+* `TauCeti.isConnected_of_iso`: an object isomorphic to a connected object is connected.
+* `TauCeti.isInitialOfIsInitialObj`: an equivalence reflects initial objects.
+* `TauCeti.isConnected_map`: an equivalence carries connected objects to connected objects.
+* `TauCeti.isConnected_map_iff`: connectedness of `F.obj A` is equivalent to connectedness of `A`.
+-/
+
+public section
+noncomputable section
+
+universe v₁ v₂ u₁ u₂
+
+namespace TauCeti
+
+open CategoryTheory Limits
+
+variable {C : Type u₁} [Category.{v₁} C] {D : Type u₂} [Category.{v₂} D]
+
+/-- An object isomorphic to a connected object is connected. -/
+theorem isConnected_of_iso {A B : C} (e : A ≅ B) [PreGaloisCategory.IsConnected A] :
+    PreGaloisCategory.IsConnected B where
+  notInitial h := PreGaloisCategory.IsConnected.notInitial (h.ofIso e.symm)
+  noTrivialComponent Y i hm hni := by
+    have _ : Mono i := hm
+    have _ : Mono (i ≫ e.inv) := mono_comp _ _
+    have h : IsIso (i ≫ e.inv) :=
+      PreGaloisCategory.IsConnected.noTrivialComponent Y (i ≫ e.inv) hni
+    have hi : i = (i ≫ e.inv) ≫ e.hom := by simp
+    rw [hi]
+    infer_instance
+
+variable (F : C ⥤ D) [F.IsEquivalence]
+
+-- The two isomorphisms below are the components of the unit and counit of `F.asEquivalence`,
+-- restated with `𝟭` and `⋙` already evaluated. Without that, unification has to see through the
+-- identity and composite functors to match `IsInitial`, `IsConnected` and `Iso` arguments against
+-- the objects they are about, and fails.
+
+/-- The unit isomorphism of an equivalence, at an object. -/
+private def unitIsoApp (A : C) : A ≅ F.inv.obj (F.obj A) :=
+  F.asEquivalence.unitIso.app A
+
+/-- The counit isomorphism of an equivalence, at an object. -/
+private def counitIsoApp (B : D) : F.obj (F.inv.obj B) ≅ B :=
+  F.asEquivalence.counitIso.app B
+
+/-- An equivalence of categories reflects initial objects. -/
+def isInitialOfIsInitialObj {A : C} (h : IsInitial (F.obj A)) : IsInitial A :=
+  IsInitial.ofIso (h.isInitialObj F.inv (F.obj A)) (unitIsoApp F A).symm
+
+/-- An equivalence of categories carries connected objects to connected objects. -/
+theorem isConnected_map (A : C) [PreGaloisCategory.IsConnected A] :
+    PreGaloisCategory.IsConnected (F.obj A) where
+  notInitial h := PreGaloisCategory.IsConnected.notInitial (isInitialOfIsInitialObj F h)
+  noTrivialComponent Y i hm hni := by
+    have _ : Mono i := hm
+    have _ : Mono (F.inv.map i) := F.inv.map_mono i
+    have _ : PreGaloisCategory.IsConnected (F.inv.obj (F.obj A)) :=
+      isConnected_of_iso (unitIsoApp F A)
+    have hni' : IsInitial (F.inv.obj Y) → False := fun h =>
+      hni (IsInitial.ofIso (h.isInitialObj F (F.inv.obj Y)) (counitIsoApp F Y))
+    have _ : IsIso (F.inv.map i) :=
+      PreGaloisCategory.IsConnected.noTrivialComponent _ _ hni'
+    exact isIso_of_reflects_iso i F.inv
+
+/-- **Connectedness transports along an equivalence of categories**: for an equivalence
+`F : C ⥤ D`, an object `A` of `C` is connected exactly when `F.obj A` is. -/
+theorem isConnected_map_iff (A : C) :
+    PreGaloisCategory.IsConnected (F.obj A) ↔ PreGaloisCategory.IsConnected A := by
+  refine ⟨fun h => ?_, fun _ => isConnected_map F A⟩
+  have _ : PreGaloisCategory.IsConnected (F.inv.obj (F.obj A)) := isConnected_map F.inv (F.obj A)
+  exact isConnected_of_iso (unitIsoApp F A).symm
+
+end TauCeti
+
+end

--- a/TauCeti/CategoryTheory/Galois/Connected.lean
+++ b/TauCeti/CategoryTheory/Galois/Connected.lean
@@ -85,6 +85,7 @@ theorem isConnected_map (A : C) [PreGaloisCategory.IsConnected A] :
 
 /-- **Connectedness transports along an equivalence of categories**: for an equivalence
 `F : C ⥤ D`, an object `A` of `C` is connected exactly when `F.obj A` is. -/
+@[simp]
 theorem isConnected_map_iff (A : C) :
     PreGaloisCategory.IsConnected (F.obj A) ↔ PreGaloisCategory.IsConnected A := by
   refine ⟨fun h => ?_, fun _ => isConnected_map F A⟩

--- a/TauCeti/Topology/Covering/Category.lean
+++ b/TauCeti/Topology/Covering/Category.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.CategoryTheory.Limits.Shapes.IsTerminal
 public import Mathlib.CategoryTheory.ObjectProperty.FullSubcategory
 public import Mathlib.Topology.Category.TopCat.Basic
 public import Mathlib.Topology.Covering.Basic
@@ -33,6 +34,8 @@ fundamental-group actions.
 * `TauCeti.CoveringSpace.totalSpace`: the functor taking a cover to its total space.
 * `TauCeti.CoveringSpace.isIso_iff_isHomeomorph_hom_left`: a map of covers is an isomorphism
   exactly when its map of total spaces is a homeomorphism.
+* `TauCeti.CoveringSpace.isInitial_iff_isEmpty`: a cover is an initial object exactly when its
+  total space is empty.
 * `TauCeti.ConnectedCoveringSpace X`: connected covering spaces over `X`.
 * `TauCeti.ConnectedCoveringSpace.mk`, `proj`, `homMk`, `isoMk`: the connected-cover constructor
   API.
@@ -197,6 +200,23 @@ homeomorphism. -/
 theorem isIso_iff_isHomeomorph_hom_left {p q : CoveringSpace X} (f : p ⟶ q) :
     IsIso f ↔ IsHomeomorph f.hom.left := by
   rw [← ObjectProperty.isIso_hom_iff, Over.isIso_iff_isHomeomorph_left]
+
+/-- **A covering space of `X` is an initial object of `TauCeti.CoveringSpace X` exactly when its
+total space is empty.** The empty space covers `X` — vacuously, by
+`IsCoveringMap.of_isEmpty` — and is the initial object, so a cover is "non-initial" exactly when
+it is nonempty. No hypothesis on `X` is needed. -/
+@[simp]
+theorem isInitial_iff_isEmpty (p : CoveringSpace X) :
+    Nonempty (Limits.IsInitial p) ↔ IsEmpty (p : TopCat) := by
+  constructor
+  · rintro ⟨h⟩
+    exact Function.isEmpty (β := PEmpty.{u + 1})
+      (h.to (mk (E := TopCat.of PEmpty.{u + 1})
+        (TopCat.ofHom ⟨PEmpty.elim, by fun_prop⟩) (IsCoveringMap.of_isEmpty _))).hom.left.hom
+  · intro h
+    exact ⟨Limits.IsInitial.ofUniqueHom
+      (fun q => homMk (TopCat.ofHom ⟨fun e => h.elim e, by fun_prop⟩) (by ext e; exact h.elim e))
+      (fun q f => by ext e; exact h.elim e)⟩
 
 end CoveringSpace
 

--- a/TauCeti/Topology/Covering/Monodromy/Transitive.lean
+++ b/TauCeti/Topology/Covering/Monodromy/Transitive.lean
@@ -30,9 +30,8 @@ monodromy an equivalence onto the actions, which is proved in
 * `TauCeti.FundamentalGroupoidAction.isFiberwiseTransitive`: fibrewise pretransitive with
   nonempty fibres.
 * `TauCeti.TransitiveFundamentalGroupoidAction`: the corresponding full subcategory.
-* `TauCeti.CoveringSpace.nonempty_fiber`: over a path-connected base every fibre of a cover with
-  nonempty total space is nonempty, and `TauCeti.ConnectedCoveringSpace.nonempty_fiber`: in
-  particular every fibre of a connected cover is nonempty.
+* `TauCeti.ConnectedCoveringSpace.nonempty_fiber`: over a path-connected base every fibre of a
+  connected cover is nonempty.
 * `TauCeti.ConnectedCoveringSpace.transitiveMonodromyFunctor`: monodromy of connected covers,
   valued in fibrewise transitive actions.
 
@@ -138,29 +137,17 @@ def fullyFaithfulForget (X : TopCat.{u}) : (forget X).FullyFaithful :=
 
 end TransitiveFundamentalGroupoidAction
 
-namespace CoveringSpace
-
-variable {X : TopCat.{u}}
-
-/-- Over a path-connected base, a covering space with nonempty total space has every fibre
-nonempty: a chosen point of the total space is carried into the fibre by monodromy along any
-path. -/
-theorem nonempty_fiber [PathConnectedSpace X] (p : CoveringSpace X)
-    (hp : Nonempty (p : TopCat)) (x : X) : Nonempty (⇑p.proj ⁻¹' {x}) := by
-  obtain ⟨e⟩ := hp
-  exact ⟨p.isCoveringMap_proj.monodromy
-    (Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath (p.proj e) x)) ⟨e, rfl⟩⟩
-
-end CoveringSpace
-
 namespace ConnectedCoveringSpace
 
 variable {X : TopCat.{u}}
 
-/-- Over a path-connected base, every fibre of a connected covering space is nonempty. -/
+/-- Over a path-connected base, every fibre of a connected covering space is nonempty: a chosen
+point of the total space is carried into the fibre by monodromy along any path. -/
 theorem nonempty_fiber [PathConnectedSpace X] (p : ConnectedCoveringSpace X) (x : X) :
-    Nonempty (⇑p.proj ⁻¹' {x}) :=
-  CoveringSpace.nonempty_fiber ((forget X).obj p) (inferInstance : Nonempty (p : TopCat)) x
+    Nonempty (⇑p.proj ⁻¹' {x}) := by
+  obtain ⟨e⟩ := (inferInstance : Nonempty (p : TopCat))
+  exact ⟨p.isCoveringMap_proj.monodromy
+    (Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath (p.proj e) x)) ⟨e, rfl⟩⟩
 
 /-- The ordinary monodromy functor of a connected cover over a path-connected base is transitive
 on every fibre. -/

--- a/TauCeti/Topology/Covering/Monodromy/Transitive.lean
+++ b/TauCeti/Topology/Covering/Monodromy/Transitive.lean
@@ -30,8 +30,9 @@ monodromy an equivalence onto the actions, which is proved in
 * `TauCeti.FundamentalGroupoidAction.isFiberwiseTransitive`: fibrewise pretransitive with
   nonempty fibres.
 * `TauCeti.TransitiveFundamentalGroupoidAction`: the corresponding full subcategory.
-* `TauCeti.ConnectedCoveringSpace.nonempty_fiber`: over a path-connected base every fibre of a
-  connected cover is nonempty.
+* `TauCeti.CoveringSpace.nonempty_fiber`: over a path-connected base every fibre of a cover with
+  nonempty total space is nonempty, and `TauCeti.ConnectedCoveringSpace.nonempty_fiber`: in
+  particular every fibre of a connected cover is nonempty.
 * `TauCeti.ConnectedCoveringSpace.transitiveMonodromyFunctor`: monodromy of connected covers,
   valued in fibrewise transitive actions.
 
@@ -137,17 +138,29 @@ def fullyFaithfulForget (X : TopCat.{u}) : (forget X).FullyFaithful :=
 
 end TransitiveFundamentalGroupoidAction
 
+namespace CoveringSpace
+
+variable {X : TopCat.{u}}
+
+/-- Over a path-connected base, a covering space with nonempty total space has every fibre
+nonempty: a chosen point of the total space is carried into the fibre by monodromy along any
+path. -/
+theorem nonempty_fiber [PathConnectedSpace X] (p : CoveringSpace X)
+    (hp : Nonempty (p : TopCat)) (x : X) : Nonempty (⇑p.proj ⁻¹' {x}) := by
+  obtain ⟨e⟩ := hp
+  exact ⟨p.isCoveringMap_proj.monodromy
+    (Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath (p.proj e) x)) ⟨e, rfl⟩⟩
+
+end CoveringSpace
+
 namespace ConnectedCoveringSpace
 
 variable {X : TopCat.{u}}
 
-/-- Over a path-connected base, every fibre of a connected covering space is nonempty: a chosen
-point of the total space is carried into the fibre by monodromy along any path. -/
+/-- Over a path-connected base, every fibre of a connected covering space is nonempty. -/
 theorem nonempty_fiber [PathConnectedSpace X] (p : ConnectedCoveringSpace X) (x : X) :
-    Nonempty (⇑p.proj ⁻¹' {x}) := by
-  obtain ⟨e⟩ := (inferInstance : Nonempty (p : TopCat))
-  exact ⟨p.isCoveringMap_proj.monodromy
-    (Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath (p.proj e) x)) ⟨e, rfl⟩⟩
+    Nonempty (⇑p.proj ⁻¹' {x}) :=
+  CoveringSpace.nonempty_fiber ((forget X).obj p) (inferInstance : Nonempty (p : TopCat)) x
 
 /-- The ordinary monodromy functor of a connected cover over a path-connected base is transitive
 on every fibre. -/


### PR DESCRIPTION
This PR proves that the two notions of connectedness a covering space carries agree: for `X` path connected, locally path connected and semilocally simply connected, an object `p` of `TauCeti.CoveringSpace X` is connected in the sense of `CategoryTheory.PreGaloisCategory.IsConnected` — not an initial object, and with no nontrivial subobject — exactly when its total space is a `ConnectedSpace`. This is the connectedness dictionary that the *Alternative lens* bullet of Stage 2, item 8 of `TauCetiRoadmap/UniversalCovers/README.md` ("phrase the classification of connected covers via transitive `π₁(X)`-sets / the monodromy functor, `Galois/IsFundamentalgroup`") still lacks: `main` already classifies connected covers by transitive `π₁(X, x₀)`-sets (`TauCeti.ConnectedCoveringSpace.transitiveFiberActionEquivalence`) and all covers by `π₁(X, x₀)`-sets (`TauCeti.CoveringSpace.fiberActionEquivalence`), but nothing connected the topological hypothesis `ConnectedSpace` carried by `TauCeti.ConnectedCoveringSpace` to the categorical condition that the Galois-theoretic vocabulary is stated in.

The proof is transport along the classification, in three steps, each of which is a genuinely missing piece rather than a restatement.

First, `TauCeti.isConnected_map_iff` in `TauCeti/CategoryTheory/Galois/Connected.lean`: `PreGaloisCategory.IsConnected` is defined by conditions on initial objects, monomorphisms and isomorphisms alone, all of which an equivalence preserves and reflects, so `F.obj A` is connected exactly when `A` is. Mathlib states connectedness in an arbitrary category but never records that it transports, and `TauCeti.isConnected_of_iso` — invariance under an isomorphism inside one category — is missing there too.

Second, `TauCeti.isConnected_action_iff_isTransitiveAction` in `TauCeti/CategoryTheory/Action/Connected.lean`: an object of `Action (Type u) G` is connected exactly when it is a transitive `G`-set in the sense of `TauCeti.isTransitiveAction`. Mathlib proves this for *finite* `G`-sets (`CategoryTheory.Action.isConnected_iff_transitive`), but through the fibre functor of the Galois category `Action FintypeCat G`, which does not exist here: `Action (Type u) G` has objects with infinite underlying type and is not a Galois category. The argument is run directly instead, over the two replacements the forgetful functor supplies — monomorphisms of `G`-sets are the injective maps, and a `G`-set is initial exactly when its underlying type is empty. Both are Mathlib's own generic concrete-category lemmas; what was missing was the instances that let them see `Action (Type u) G`, so the file registers `PreservesColimit`/`ReflectsColimit` of the empty diagram along `forget (Action (Type u) G)` and then uses `CategoryTheory.Concrete.initial_iff_empty_of_preserves_of_reflects` verbatim.

Third, the topological side, `TauCeti.CoveringSpace.isTransitiveAction_fiberAction_iff_connectedSpace`: over a path-connected, locally path-connected base, the monodromy action on the fibre over `x₀` is transitive exactly when the total space is connected. The forward direction is proved directly from path lifting — every point of the total space is joined by a lifted path to a point of the fibre over `x₀`, and transitivity of monodromy joins any two points of that fibre, so the total space is path connected — which is why this step needs no semilocal simple connectedness and is established before the classification is invoked.

The initial half of the definition is spelled out as well, and belongs to the general covering-space API rather than to the classification: `TauCeti.CoveringSpace.isInitial_iff_isEmpty` in `TauCeti/Topology/Covering/Category.lean` says the initial objects of `TauCeti.CoveringSpace X` are exactly the covers with empty total space, over **any** base `X`. The empty space covers `X` vacuously (`IsCoveringMap.of_isEmpty`) and is the initial object; a cover admits a map to it only if it is itself empty.

Files added: `TauCeti/CategoryTheory/Galois/Connected.lean` (97), `TauCeti/CategoryTheory/Action/Connected.lean` (117), `TauCeti/AlgebraicTopology/UniversalCover/Classification/Connected.lean` (128); `TauCeti/Topology/Covering/Category.lean` gains `isInitial_iff_isEmpty` (+20 lines, no declaration removed or renamed). That is the only change to an existing file.

No Mathlib proof is vendored. The development consumes Mathlib's `CategoryTheory.PreGaloisCategory.IsConnected`, `CategoryTheory.Action` and its limit API, Mathlib's covering-space path lifting and monodromy, and Tau Ceti's own classification of covers by `π₁(X, x₀)`-sets, which rests on the based-path universal cover adapted from Kim Morrison's [mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292).

What remains on Stage 2, item 8 after this PR is the Galois-category structure itself — that the finite covers of a nice base form a Galois category with the fibre over `x₀` as fibre functor — which is in flight as #4531 and is independent of this PR: it builds the structure on `TauCeti.FiniteCoveringSpace`, while the dictionary proved here is about all covers and is what will identify the connected objects there with `TauCeti.ConnectedCoveringSpace`. Beyond item 8, the roadmap's standing-hypotheses section still excludes rather than handles covers of a base that is not path connected.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"coveringspace-isconnected-iff-connectedspace"}-->

🤖 Prepared with Claude Code
