### PR TITLE
feat: the full-weight Chevalley carrier of type A

### DIFF
--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -1,0 +1,612 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Lie.Classical
+public import Mathlib.LinearAlgebra.Matrix.Cartan
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ClosedImmersion
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Points
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Relations
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Torus
+public import TauCeti.Algebra.Lie.UniversalEnveloping.MatrixRepresentation
+public import TauCeti.Algebra.Module.Rat
+public import TauCeti.LinearAlgebra.Eigenspace.Binomial
+public import TauCeti.RingTheory.Binomial
+import TauCeti.CategoryTheory.Comma.Over
+
+/-!
+# The full-weight Chevalley carrier of type `A`
+
+Fix `r` and let `sl_{r+1}` act on the standard module `Fin (r+1) → ℚ`. This file feeds that
+representation, its coordinate `ℤ`-lattice and the Bourbaki-numbered Chevalley generators
+
+```text
+e_i = E_{i,i+1},    f_i = E_{i+1,i},    h_i = E_{i,i} - E_{i+1,i+1}
+```
+
+into the Kostant toral-closure construction, and so produces an explicit affine group scheme over
+`ℤ` for every rank: `TauCeti.SlStd.groupScheme`, the smallest closed subgroup scheme of `GL_{r+1}`
+containing the divided-power exponential root subgroups of those generators together with the
+weight torus of the standard lattice.
+
+What distinguishes the standard module from the adjoint one is its weights. The Cartan generator
+`h_i` acts on the coordinate vector at `k` by `δ_{k,i} - δ_{k,i+1}`, so the weights are the `ε_k`,
+and `TauCeti.SlStd.span_range_weight_eq_top` says they generate the *whole* character lattice
+`Fin r → ℤ` of the rank-`r` split torus, whose cocharacter lattice is spanned by the simple
+coroots. That character lattice is the weight lattice `P` of type `A_r`, whereas the weights of the
+adjoint module generate only the root lattice `Q`, of index `r + 1` in it. Consequently the split
+torus of rank `r` is a *closed* subgroup of the carrier built here
+(`TauCeti.SlStd.isClosedImmersion_weightTorus`), which is the property the pinned simply connected
+Chevalley--Demazure group of type `A_r` is asked for and which the adjoint carrier does not have.
+
+The whole ambient Lie algebra used is Mathlib's `LieAlgebra.SpecialLinear.sl`, and the Kostant form
+depends only on the numbered generators above, so every carrier below traces back to explicit
+matrices; no existence or classification theorem is invoked anywhere.
+
+Three things are deliberately not asserted. The carrier is not proved reductive, its torus is not
+proved maximal, and it is not identified with the special linear group scheme; each needs the
+generation and root-datum statements that Layer 9 of the reductive-groups roadmap still owes. Nor
+is any group here claimed to be finite or simple.
+
+## Main definitions
+
+* `TauCeti.SlStd.rootGenerator` and `TauCeti.SlStd.cartanGenerator`: the Bourbaki-numbered
+  Chevalley generators of `sl_{r+1}`, as elements of `LieAlgebra.SpecialLinear.sl`.
+* `TauCeti.SlStd.rep`: the standard representation, extended to the universal enveloping algebra.
+* `TauCeti.SlStd.weight` and `TauCeti.SlStd.rootWeight`: the integral weights of the coordinate
+  vectors and the roots of the numbered generators.
+* `TauCeti.SlStd.lattice` and `TauCeti.SlStd.latticeBasis`: the standard admissible lattice and its
+  coordinate basis.
+* `TauCeti.SlStd.groupScheme`, `TauCeti.SlStd.rootSubgroup`, `TauCeti.SlStd.weightTorus` and
+  `TauCeti.SlStd.points`: the carrier, its pinned generating morphisms, and its matrix points.
+
+## Main results
+
+* `TauCeti.SlStd.lie_cartanGenerator_rootGenerator`: the numbered Cartan generators act on the
+  numbered root generators through the type `A_r` Cartan matrix.
+* `TauCeti.SlStd.rep_kostantForm_mem_lattice`: the Kostant `ℤ`-form preserves the standard lattice,
+  so the lattice is admissible.
+* `TauCeti.SlStd.span_range_weight_eq_top`: the weights of the standard module generate the full
+  character lattice.
+* `TauCeti.SlStd.isClosedImmersion_rootSubgroup` and
+  `TauCeti.SlStd.isClosedImmersion_weightTorus`: the root subgroups and the split torus are closed
+  subgroups of the carrier.
+* `TauCeti.SlStd.torusPoints_conj_rootSubgroupParam` and
+  `TauCeti.SlStd.weightTorus_conj_rootSubgroup`: the pinning equation
+  `t(s) x_k(u) t(s)⁻¹ = x_k(α_k(s) u)`, on points and at the level of group schemes.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 7.1.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, §27, and
+  *Linear Algebraic Groups*, §§26--27, for admissible lattices and the weights that distinguish
+  the simply connected form from the adjoint one.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate I, for the numbering of the type
+  `A` diagram and the index `r + 1` of the root lattice in the weight lattice.
+
+This advances "The Chevalley--Demazure construction", "Pinnings" and "Root subgroup maps" in
+Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, which asks for an explicitly constructed
+split reductive group scheme over `ℤ` realizing a root datum, with a torus and root subgroups as
+data. Its consumer is milestone L0, "pinned ambient groups", of
+`TauCetiRoadmap/CFSGStatement/README.md`, whose recipe is computed in the simply connected form and
+therefore cannot use the adjoint Geck carrier of
+`TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GroupScheme.lean`.
+-/
+
+public section
+
+namespace TauCeti.SlStd
+
+open LieAlgebra.SpecialLinear
+open scoped Matrix TensorProduct
+open scoped CategoryTheory.MonObj
+
+attribute [local instance] TauCeti.moduleNNRat
+
+variable (r : ℕ)
+
+/-- The target coordinate of the numbered raising or lowering generator. -/
+def rootTarget : Fin r ⊕ Fin r → Fin (r + 1)
+  | .inl i => i.castSucc
+  | .inr i => i.succ
+
+/-- The source coordinate of the numbered raising or lowering generator. -/
+def rootSource : Fin r ⊕ Fin r → Fin (r + 1)
+  | .inl i => i.succ
+  | .inr i => i.castSucc
+
+@[simp] theorem rootTarget_inl (i : Fin r) : rootTarget r (.inl i) = i.castSucc := (rfl)
+@[simp] theorem rootTarget_inr (i : Fin r) : rootTarget r (.inr i) = i.succ := (rfl)
+@[simp] theorem rootSource_inl (i : Fin r) : rootSource r (.inl i) = i.succ := (rfl)
+@[simp] theorem rootSource_inr (i : Fin r) : rootSource r (.inr i) = i.castSucc := (rfl)
+
+/-- A numbered root generator moves between two distinct coordinates. -/
+theorem rootTarget_ne_rootSource (k : Fin r ⊕ Fin r) : rootTarget r k ≠ rootSource r k := by
+  cases k with
+  | inl i => exact (Fin.castSucc_lt_succ (i := i)).ne
+  | inr i => exact (Fin.castSucc_lt_succ (i := i)).ne'
+
+/-! ## The pinned Chevalley generators -/
+
+/-- The Bourbaki-numbered raising and lowering generators of `sl_{r+1}`: the matrix unit
+`E_{i, i+1}` at `Sum.inl i` and `E_{i+1, i}` at `Sum.inr i`. -/
+def rootGenerator (k : Fin r ⊕ Fin r) : sl (Fin (r + 1)) ℚ :=
+  single (rootTarget r k) (rootSource r k) (rootTarget_ne_rootSource r k) 1
+
+/-- The Bourbaki-numbered Cartan generators of `sl_{r+1}`: the diagonal matrix
+`E_{i,i} - E_{i+1,i+1}`. -/
+def cartanGenerator (i : Fin r) : sl (Fin (r + 1)) ℚ :=
+  singleSubSingle i.castSucc i.succ 1
+
+@[simp]
+theorem val_rootGenerator (k : Fin r ⊕ Fin r) :
+    (rootGenerator r k : Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) =
+      Matrix.single (rootTarget r k) (rootSource r k) 1 := (rfl)
+
+@[simp]
+theorem val_cartanGenerator (i : Fin r) :
+    (cartanGenerator r i : Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) =
+      Matrix.single i.castSucc i.castSucc 1 - Matrix.single i.succ i.succ 1 := (rfl)
+
+/-! ## The standard representation -/
+
+/-- The standard representation of `sl_{r+1}` on coordinate vectors, extended to the universal
+enveloping algebra. -/
+noncomputable abbrev rep :
+    _root_.UniversalEnvelopingAlgebra ℚ (sl (Fin (r + 1)) ℚ) →ₐ[ℚ]
+      Module.End ℚ (Fin (r + 1) → ℚ) :=
+  LieSubalgebra.matrixRepresentation (sl (Fin (r + 1)) ℚ)
+
+theorem rep_ι_apply (x : sl (Fin (r + 1)) ℚ) (v : Fin (r + 1) → ℚ) :
+    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ x) v =
+      (x : Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) *ᵥ v :=
+  LieSubalgebra.matrixRepresentation_ι_apply _ x v
+
+/-- A numbered root generator reads off one coordinate and writes it into another. -/
+theorem rep_rootGenerator_apply (k : Fin r ⊕ Fin r) (v : Fin (r + 1) → ℚ) :
+    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k)) v =
+      v (rootSource r k) • Pi.single (rootTarget r k) 1 := by
+  rw [rep_ι_apply, val_rootGenerator, Matrix.single_mulVec_eq, one_mul]
+
+/-- A numbered root generator sends the coordinate vector at its source to the one at its
+target. -/
+theorem rep_rootGenerator_single_source (k : Fin r ⊕ Fin r) :
+    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))
+        (Pi.single (rootSource r k) 1) = Pi.single (rootTarget r k) 1 := by
+  rw [rep_rootGenerator_apply, Pi.single_eq_same, one_smul]
+
+/-- Every numbered root generator squares to zero in the standard representation. -/
+theorem rep_rootGenerator_rep_rootGenerator_eq_zero (k : Fin r ⊕ Fin r) (v : Fin (r + 1) → ℚ) :
+    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))
+        (rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k)) v) = 0 := by
+  rw [rep_rootGenerator_apply r k v, map_smul, rep_rootGenerator_apply,
+    Pi.single_eq_of_ne (rootTarget_ne_rootSource r k).symm 1, zero_smul, smul_zero]
+
+/-- Every numbered root generator acts nilpotently. -/
+theorem isNilpotent_rep_rootGenerator (k : Fin r ⊕ Fin r) :
+    IsNilpotent (rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))) := by
+  refine ⟨2, LinearMap.ext fun v => ?_⟩
+  rw [pow_two, Module.End.mul_apply, rep_rootGenerator_rep_rootGenerator_eq_zero,
+    LinearMap.zero_apply]
+
+/-! ## Weights and roots -/
+
+/-- The integral weight of the `k`-th standard coordinate vector on the numbered Cartan
+generators. These are the weights `ε₀, …, ε_r` of the standard module, written in the basis of
+fundamental weights. -/
+def weight (k : Fin (r + 1)) (i : Fin r) : ℤ :=
+  (if k = i.castSucc then 1 else 0) - (if k = i.succ then 1 else 0)
+
+/-- The root of a numbered raising or lowering generator, as an integral character of the
+numbered Cartan generators: the `i`-th row of the type `A` Cartan matrix on a raising generator
+and its negative on a lowering one. -/
+def rootWeight : Fin r ⊕ Fin r → Fin r → ℤ
+  | .inl i => fun j => CartanMatrix.A r i j
+  | .inr i => fun j => -CartanMatrix.A r i j
+
+@[simp] theorem rootWeight_inl (i j : Fin r) :
+    rootWeight r (.inl i) j = CartanMatrix.A r i j := (rfl)
+
+@[simp] theorem rootWeight_inr (i j : Fin r) :
+    rootWeight r (.inr i) j = -CartanMatrix.A r i j := (rfl)
+
+/-- A diagonal matrix unit acts on a standard coordinate vector by the corresponding
+Kronecker delta. -/
+private theorem diagSingle_mulVec (a k : Fin (r + 1)) :
+    Matrix.single a a (1 : ℚ) *ᵥ Pi.single k 1 =
+      (if k = a then (1 : ℚ) else 0) • Pi.single k 1 := by
+  rw [Matrix.single_mulVec_eq, one_mul, Pi.single_apply]
+  by_cases h : k = a
+  · subst h; simp
+  · simp [h, Ne.symm h]
+
+/-- Multiplying a matrix unit on the left by a diagonal one. -/
+private theorem diagSingle_mul_single (a c d : Fin (r + 1)) :
+    Matrix.single a a (1 : ℚ) * Matrix.single c d 1 =
+      (if a = c then (1 : ℚ) else 0) • Matrix.single c d 1 := by
+  by_cases h : a = c
+  · subst h; simp
+  · simp [h]
+
+/-- Multiplying a matrix unit on the right by a diagonal one. -/
+private theorem single_mul_diagSingle (c d b : Fin (r + 1)) :
+    Matrix.single c d (1 : ℚ) * Matrix.single b b 1 =
+      (if d = b then (1 : ℚ) else 0) • Matrix.single c d 1 := by
+  by_cases h : d = b
+  · subst h; simp
+  · simp [h]
+
+/-- Every standard coordinate vector is a Cartan weight vector, of the weight recorded by
+`TauCeti.SlStd.weight`. -/
+theorem isCartanWeightVector_single (k : Fin (r + 1)) :
+    TauCeti.UniversalEnvelopingAlgebra.IsCartanWeightVector (cartanGenerator r) (rep r)
+      (weight r k) (Pi.single k 1) := by
+  refine (TauCeti.UniversalEnvelopingAlgebra.isCartanWeightVector_iff
+    (cartanGenerator r) (rep r)).mpr fun j => ?_
+  rw [rep_ι_apply, val_cartanGenerator, Matrix.sub_mulVec, diagSingle_mulVec,
+    diagSingle_mulVec, ← sub_smul, weight]
+  simp only [Int.cast_sub, apply_ite (fun z : ℤ => (z : ℚ)), Int.cast_one, Int.cast_zero]
+
+/-- The Kronecker coefficient produced by conjugating a numbered root generator by a numbered
+Cartan generator is the corresponding entry of the type `A` Cartan matrix, with a sign for the
+lowering generators. -/
+private theorem cartanCoeff (k : Fin r ⊕ Fin r) (j : Fin r) :
+    ((if j.castSucc = rootTarget r k then (1 : ℤ) else 0) -
+        (if j.succ = rootTarget r k then 1 else 0)) -
+      ((if rootSource r k = j.castSucc then (1 : ℤ) else 0) -
+        (if rootSource r k = j.succ then 1 else 0)) = rootWeight r k j := by
+  cases k with
+  | inl i =>
+      rw [rootTarget_inl, rootSource_inl, rootWeight_inl, CartanMatrix.A]
+      simp only [Matrix.of_apply, Fin.ext_iff, Fin.val_succ, Fin.val_castSucc]
+      split_ifs <;> omega
+  | inr i =>
+      rw [rootTarget_inr, rootSource_inr, rootWeight_inr, CartanMatrix.A]
+      simp only [Matrix.of_apply, Fin.ext_iff, Fin.val_succ, Fin.val_castSucc]
+      split_ifs <;> omega
+
+/-- **The numbered Cartan generators act on the numbered root generators through the type `A`
+Cartan matrix.** This is the relation that makes the split torus of the carrier below act on the
+root subgroup at `k` through the character `TauCeti.SlStd.rootWeight r k`. -/
+theorem lie_cartanGenerator_rootGenerator (k : Fin r ⊕ Fin r) (j : Fin r) :
+    ⁅cartanGenerator r j, rootGenerator r k⁆ =
+      ((rootWeight r k j : ℤ) : ℚ) • rootGenerator r k := by
+  refine Subtype.ext ?_
+  rw [sl_bracket]
+  have hcoe : (((((rootWeight r k j : ℤ) : ℚ) • rootGenerator r k) :
+      sl (Fin (r + 1)) ℚ) : Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) =
+      ((rootWeight r k j : ℤ) : ℚ) •
+        Matrix.single (rootTarget r k) (rootSource r k) (1 : ℚ) := by
+    rw [← val_rootGenerator]
+    rfl
+  rw [hcoe, val_cartanGenerator, val_rootGenerator, Matrix.sub_mul, Matrix.mul_sub,
+    diagSingle_mul_single, diagSingle_mul_single, single_mul_diagSingle, single_mul_diagSingle,
+    ← sub_smul, ← sub_smul, ← sub_smul, ← cartanCoeff r k j]
+  simp only [Int.cast_sub, apply_ite (fun z : ℤ => (z : ℚ)), Int.cast_one, Int.cast_zero]
+
+/-! ## The standard admissible lattice -/
+
+/-- **The standard `ℤ`-lattice of the standard `sl_{r+1}`-module**, spanned by the coordinate
+vectors. -/
+def lattice : Submodule ℤ (Fin (r + 1) → ℚ) :=
+  Submodule.span ℤ (Set.range (Pi.basisFun ℚ (Fin (r + 1))))
+
+/-- A vector lies in the standard lattice exactly when all of its coordinates are integers. -/
+@[simp]
+theorem mem_lattice_iff {v : Fin (r + 1) → ℚ} :
+    v ∈ lattice r ↔ ∀ i, ∃ z : ℤ, (z : ℚ) = v i := by
+  rw [lattice, Module.Basis.mem_span_iff_repr_mem]
+  simp only [Pi.basisFun_repr, algebraMap_int_eq, Int.coe_castRingHom, Set.mem_range]
+
+theorem single_mem_lattice (i : Fin (r + 1)) : Pi.single i (1 : ℚ) ∈ lattice r := by
+  rw [lattice, ← Pi.basisFun_apply]
+  exact Submodule.subset_span (Set.mem_range_self i)
+
+/-- The coordinate basis of the standard lattice.
+
+The carrier subtype and `ℤ`-module structure of a submodule are definitionally equal to those of
+its underlying additive subgroup, so the restricted-scalars basis has the displayed target type. -/
+noncomputable def latticeBasis : Module.Basis (Fin (r + 1)) ℤ (lattice r).toAddSubgroup :=
+  (Pi.basisFun ℚ (Fin (r + 1))).restrictScalars ℤ
+
+@[simp]
+theorem coe_latticeBasis (i : Fin (r + 1)) :
+    ((latticeBasis r i : (lattice r).toAddSubgroup) : Fin (r + 1) → ℚ) = Pi.single i 1 := by
+  unfold latticeBasis lattice
+  rw [Module.Basis.restrictScalars_apply, Pi.basisFun_apply]
+
+/-! ## Stability of the lattice under the Kostant form -/
+
+/-- Every numbered root generator squares to zero in the standard representation. -/
+theorem pow_two_rep_rootGenerator_eq_zero (k : Fin r ⊕ Fin r) :
+    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k)) ^ 2 = 0 := by
+  refine LinearMap.ext fun v => ?_
+  rw [pow_two, Module.End.mul_apply, rep_rootGenerator_rep_rootGenerator_eq_zero,
+    LinearMap.zero_apply]
+
+/-- A numbered root generator carries the standard lattice into itself. -/
+theorem rep_rootGenerator_mem_lattice (k : Fin r ⊕ Fin r) {v : Fin (r + 1) → ℚ}
+    (hv : v ∈ lattice r) :
+    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k)) v ∈ lattice r := by
+  obtain ⟨z, hz⟩ := (mem_lattice_iff r).1 hv (rootSource r k)
+  rw [rep_rootGenerator_apply, ← hz, Int.cast_smul_eq_zsmul]
+  exact zsmul_mem (single_mem_lattice r _) z
+
+/-- **Every divided power of a numbered root generator preserves the standard lattice.** The
+generator squares to zero on the standard module, so only the zeroth and first divided powers are
+nonzero, and both are visibly integral. -/
+theorem rep_dividedPower_rootGenerator_mem_lattice (k : Fin r ⊕ Fin r) (n : ℕ)
+    {v : Fin (r + 1) → ℚ} (hv : v ∈ lattice r) :
+    rep r (Associative.dividedPower n
+        (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))) v ∈ lattice r := by
+  rw [Associative.map_dividedPower]
+  match n with
+  | 0 => rwa [Associative.dividedPower_zero, Module.End.one_apply]
+  | 1 => rw [Associative.dividedPower_one]; exact rep_rootGenerator_mem_lattice r k hv
+  | (n + 2) =>
+      rw [Associative.dividedPower_def,
+        pow_eq_zero_of_le (m := 2) (by omega) (pow_two_rep_rootGenerator_eq_zero r k), smul_zero,
+        LinearMap.zero_apply]
+      exact zero_mem _
+
+/-- **Every Cartan binomial operator preserves the standard lattice.** The coordinate vectors are
+weight vectors with integer weights, so the binomial coefficients act on them by integers. -/
+theorem rep_ringChoose_cartanGenerator_mem_lattice (i : Fin r) (n : ℕ)
+    {v : Fin (r + 1) → ℚ} (hv : v ∈ lattice r) :
+    rep r (Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (cartanGenerator r i)) n) v ∈
+      lattice r := by
+  rw [lattice] at hv ⊢
+  induction hv using Submodule.span_induction with
+  | mem v hv =>
+      obtain ⟨x, rfl⟩ := hv
+      rw [Pi.basisFun_apply, Ring.map_choose]
+      have hweight := (TauCeti.UniversalEnvelopingAlgebra.isCartanWeightVector_iff
+        (cartanGenerator r) (rep r)).1 (isCartanWeightVector_single r x) i
+      rw [ringChoose_end_apply_of_apply_eq_smul hweight n, TauCeti.Ring.choose_intCast,
+        Int.cast_smul_eq_zsmul ℚ]
+      have hx : Pi.single x (1 : ℚ) ∈
+          Submodule.span ℤ (Set.range (Pi.basisFun ℚ (Fin (r + 1)))) := by
+        rw [← Pi.basisFun_apply]
+        exact Submodule.subset_span (Set.mem_range_self x)
+      exact Submodule.smul_mem _ _ hx
+  | zero => rw [map_zero]; exact zero_mem _
+  | add x y _ _ hx hy => rw [map_add]; exact add_mem hx hy
+  | smul z x _ hx => rw [map_zsmul]; exact Submodule.smul_mem _ z hx
+
+/-- **The standard lattice is an admissible lattice**: the Kostant `ℤ`-form presented by the
+numbered Chevalley generators preserves it. -/
+theorem rep_kostantForm_mem_lattice
+    {u : _root_.UniversalEnvelopingAlgebra ℚ (sl (Fin (r + 1)) ℚ)}
+    (hu : u ∈ TauCeti.UniversalEnvelopingAlgebra.kostantForm (rootGenerator r)
+      (cartanGenerator r))
+    {v : Fin (r + 1) → ℚ} (hv : v ∈ lattice r) :
+    rep r u v ∈ lattice r :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantForm_apply_mem (rootGenerator r) (cartanGenerator r)
+    (rep r) (lattice r)
+    (fun k n _ hv => rep_dividedPower_rootGenerator_mem_lattice r k n hv)
+    (fun i n _ hv => rep_ringChoose_cartanGenerator_mem_lattice r i n hv) u hu hv
+
+/-! ## The weights generate the full character lattice -/
+
+/-- The weight of an integral combination of coordinate vectors, as a linear map into the
+character lattice of the split torus of rank `r`. -/
+def weightMap : (Fin (r + 1) → ℤ) →ₗ[ℤ] Fin r → ℤ where
+  toFun x i := x i.castSucc - x i.succ
+  map_add' x y := by funext i; simp only [Pi.add_apply]; ring
+  map_smul' c x := by funext i; simp only [Pi.smul_apply, smul_eq_mul, RingHom.id_apply]; ring
+
+@[simp]
+theorem weightMap_apply (x : Fin (r + 1) → ℤ) (i : Fin r) :
+    weightMap r x i = x i.castSucc - x i.succ := (rfl)
+
+/-- The weight of the `k`-th coordinate vector is the image of its indicator function. -/
+theorem weightMap_single (k : Fin (r + 1)) : weightMap r (Pi.single k 1) = weight r k := by
+  funext i
+  simp only [weightMap_apply, weight, Pi.single_apply]
+  simp only [eq_comm]
+
+/-- **The weight map is surjective**: the differences `x_i - x_{i+1}` realize every integral
+character, by partial summation. -/
+theorem weightMap_surjective : Function.Surjective (weightMap r) := by
+  classical
+  intro y
+  refine ⟨fun j => -∑ n ∈ Finset.range (j : ℕ), (if h : n < r then y ⟨n, h⟩ else 0), ?_⟩
+  funext i
+  have hval : (if h : (i : ℕ) < r then y ⟨(i : ℕ), h⟩ else 0) = y i := by simp
+  rw [weightMap_apply, Fin.val_castSucc, Fin.val_succ, Finset.sum_range_succ, hval]
+  ring
+
+/-- **The weights of the standard module generate the full character lattice.** This is the
+property that separates the standard module from the adjoint one, whose weights are the roots and
+generate the root lattice, of index `r + 1`. It is what makes the rank-`r` split torus a closed
+subgroup of the carrier assembled below. -/
+theorem span_range_weight_eq_top : Submodule.span ℤ (Set.range (weight r)) = ⊤ := by
+  have h1 : ⇑(weightMap r) '' Set.range (fun k : Fin (r + 1) => Pi.single k (1 : ℤ)) =
+      Set.range (weight r) := by
+    rw [← Set.range_comp]
+    exact congrArg Set.range (funext (weightMap_single r))
+  have hbasis : (fun k : Fin (r + 1) => Pi.single k (1 : ℤ)) =
+      ⇑(Pi.basisFun ℤ (Fin (r + 1))) := funext fun k => (Pi.basisFun_apply ℤ _ k).symm
+  have h2 : Submodule.span ℤ (Set.range fun k : Fin (r + 1) => Pi.single k (1 : ℤ)) = ⊤ := by
+    rw [hbasis]
+    exact (Pi.basisFun ℤ (Fin (r + 1))).span_eq
+  rw [← h1, Submodule.span_image, h2, Submodule.map_top,
+    LinearMap.range_eq_top.2 (weightMap_surjective r)]
+
+/-! ## The pinned carrier of type `A_r` -/
+
+section Carrier
+
+open AlgebraicGeometry CategoryTheory
+
+-- Match tensor products to the `ℤ`-algebra structure used by scalar extension.
+attribute [local instance high] Algebra.toModule
+
+/-- Every coordinate basis vector of the standard lattice is a Cartan weight vector. -/
+theorem isCartanWeightVector_latticeBasis (k : Fin (r + 1)) :
+    TauCeti.UniversalEnvelopingAlgebra.IsCartanWeightVector (cartanGenerator r) (rep r)
+      (weight r k)
+      ((latticeBasis r k : (lattice r).toAddSubgroup) : Fin (r + 1) → ℚ) := by
+  rw [coe_latticeBasis]
+  exact isCartanWeightVector_single r k
+
+/-- The Kostant-form stability of the standard lattice, in the shape the Kostant constructions
+consume. -/
+theorem kostantForm_apply_mem_lattice :
+    ∀ u ∈ TauCeti.UniversalEnvelopingAlgebra.kostantForm (rootGenerator r) (cartanGenerator r),
+      ∀ v ∈ (lattice r).toAddSubgroup, rep r u v ∈ (lattice r).toAddSubgroup :=
+  fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv
+
+/-- **The full-weight Chevalley carrier of type `A_r`**: the smallest closed subgroup scheme of
+`GL_{r+1}` over `ℤ` containing the divided-power exponential root subgroups of the numbered
+Chevalley generators of `sl_{r+1}` and the weight torus of the standard lattice. -/
+noncomputable abbrev groupScheme : Grp (Over (Spec (CommRingCat.of ℤ))) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+
+/-- The numbered root subgroup `x_k : 𝔾ₐ → G` of the type `A_r` carrier. -/
+noncomputable abbrev rootSubgroup (k : Fin r ⊕ Fin r) :
+    AdditiveGroup.groupScheme ℤ ⟶ groupScheme r :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k
+
+/-- The split maximal torus `T → G` of the type `A_r` carrier. -/
+noncomputable abbrev weightTorus : SplitTorus.groupScheme ℤ (Fin r) ⟶ groupScheme r :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+
+/-- The `A`-valued points of the type `A_r` carrier, as matrices. -/
+noncomputable abbrev points (A : Type) [CommRing A] :
+    Subgroup (Matrix.GeneralLinearGroup (Fin (r + 1)) A) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A
+
+/-! ## The pinning -/
+
+/-- A numbered root generator carries the coordinate basis vector at its source to the one at its
+target. This is the root step that makes the root subgroup a closed copy of `𝔾ₐ`. -/
+theorem rep_rootGenerator_latticeBasis (k : Fin r ⊕ Fin r) :
+    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))
+        ((latticeBasis r (rootSource r k) : (lattice r).toAddSubgroup) : Fin (r + 1) → ℚ) =
+      (1 : ℤ) • ((latticeBasis r (rootTarget r k) : (lattice r).toAddSubgroup) :
+        Fin (r + 1) → ℚ) := by
+  rw [coe_latticeBasis, coe_latticeBasis, rep_rootGenerator_single_source, one_smul]
+
+theorem rep_rootGenerator_rep_rootGenerator_latticeBasis_eq_zero (k : Fin r ⊕ Fin r) :
+    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))
+        (rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))
+          ((latticeBasis r (rootSource r k) : (lattice r).toAddSubgroup) :
+            Fin (r + 1) → ℚ)) = 0 :=
+  rep_rootGenerator_rep_rootGenerator_eq_zero r k _
+
+/-- The coordinate morphism of a numbered root subgroup is surjective before factoring through
+the carrier. -/
+private theorem representedRootCoordinateMap_surjective (k : Fin r ⊕ Fin r) :
+    Function.Surjective
+      (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+        k (isNilpotent_rep_rootGenerator r k) (latticeBasis r)).hom :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap_surjective _ _ _ _ _ _ _ _
+    isUnit_one (rep_rootGenerator_latticeBasis r k)
+    (rep_rootGenerator_rep_rootGenerator_latticeBasis_eq_zero r k)
+
+/-- **The coordinate morphism of every numbered root subgroup of the type `A_r` carrier is
+surjective.** -/
+theorem rootSubgroupCoordinateMap_surjective (k : Fin r ⊕ Fin r) :
+    Function.Surjective
+      (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k).hom :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap_surjective_of_surjective
+    _ _ _ _ _ _ _ _ k (representedRootCoordinateMap_surjective r k)
+
+/-- **Every numbered root subgroup of the type `A_r` carrier is a closed immersion.** -/
+instance isClosedImmersion_rootSubgroup (k : Fin r ⊕ Fin r) :
+    IsClosedImmersion (rootSubgroup r k).hom.hom.left := by
+  have hdef := TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral_def (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k
+  let e₁ := (eqToHom (AdditiveGroup.groupScheme_def ℤ)).hom.hom.left
+  let c := ((AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).map
+    (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap (rootGenerator r)
+      (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k).op).hom.hom.left
+  have hc : IsClosedImmersion c :=
+    (CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff _).2
+      (rootSubgroupCoordinateMap_surjective r k)
+  have he₁c : IsClosedImmersion (e₁ ≫ c) :=
+    (MorphismProperty.cancel_left_of_respectsIso _ e₁ c).2 hc
+  unfold rootSubgroup
+  rw [hdef]
+  simp only [Grp.comp', Mon.comp_hom', Over.comp_left]
+  exact he₁c
+
+/-- **The split torus of the type `A_r` carrier is a closed immersion.** This is exactly where the
+full-weight property is used: the weights of the standard module generate the whole character
+lattice, so the rank-`r` split torus embeds rather than mapping onto a proper quotient. -/
+instance isClosedImmersion_weightTorus :
+    IsClosedImmersion (weightTorus r).hom.hom.left :=
+  TauCeti.UniversalEnvelopingAlgebra.isClosedImmersion_kostantWeightTorusToToral _ _ _ _ _ _ _ _
+    (span_range_weight_eq_top r)
+
+/-- The parametrized numbered root subgroup on points of a value algebra. -/
+noncomputable abbrev rootSubgroupParam (k : Fin r ⊕ Fin r) (A : CommAlgCat ℤ) :
+    Multiplicative A →* LinearMap.GeneralLinearGroup A (A ⊗[ℤ] (lattice r).toAddSubgroup) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupParam (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r) k
+    (isNilpotent_rep_rootGenerator r k) A
+
+/-- The split weight torus on points of a value algebra. -/
+noncomputable abbrev torusPoints (A : CommAlgCat ℤ) :
+    (Fin r → Aˣ) →* LinearMap.GeneralLinearGroup A (A ⊗[ℤ] (lattice r).toAddSubgroup) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints (lattice r).toAddSubgroup
+    (latticeBasis r) (weight r) A
+
+/-- **The pinning equation of the type `A_r` carrier.** A torus point `s` conjugates the
+root-subgroup element of parameter `u` into the one of parameter `α_k(s) u`, where `α_k` is the
+`k`-th row of the type `A_r` Cartan matrix on a raising generator and its negative on a lowering
+one. -/
+theorem torusPoints_conj_rootSubgroupParam (k : Fin r ⊕ Fin r) (A : CommAlgCat ℤ)
+    (s : Fin r → Aˣ) (u : Multiplicative A) :
+    torusPoints r A s * rootSubgroupParam r k A u * (torusPoints r A s)⁻¹ =
+      rootSubgroupParam r k A
+        (Multiplicative.ofAdd
+          ((TauCeti.torusCharacter s (rootWeight r k) : A) *
+            Multiplicative.toAdd u)) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints_conj_kostantRootSubgroupParam
+    _ _ _ _ _ _ _ (isCartanWeightVector_latticeBasis r)
+    (fun j => lie_cartanGenerator_rootGenerator r k j) _ A s u
+
+/-- **The scheme-level pinning equation of the type `A_r` carrier.** Conjugation by a point of the
+split torus rescales the parameter of a numbered root subgroup by the corresponding root
+character. -/
+theorem weightTorus_conj_rootSubgroup (k : Fin r ⊕ Fin r) (A : Type) [CommRing A]
+    (s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
+      (SplitTorus.groupScheme ℤ (Fin r)).X)
+    (u : A) :
+    (s ≫ (weightTorus r).hom.hom) *
+        ((AdditiveGroup.groupSchemePointMulEquiv A)
+            ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm
+              (Multiplicative.ofAdd u)) ≫
+          (rootSubgroup r k).hom.hom) *
+        (s ≫ (weightTorus r).hom.hom)⁻¹ =
+      (AdditiveGroup.schemePointsMulEquiv A).symm
+          (Multiplicative.ofAdd
+            ((TauCeti.torusCharacter (SplitTorus.schemePointsMulEquiv (R := ℤ) (A := A) s)
+              (rootWeight r k) : A) * u)) ≫
+        (rootSubgroup r k).hom.hom :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral_conj_kostantRootSubgroupToToralParam
+    _ _ _ _ _ _ _ (isCartanWeightVector_latticeBasis r) (isNilpotent_rep_rootGenerator r) A
+    (fun j => lie_cartanGenerator_rootGenerator r k j) s u
+
+end Carrier
+
+end TauCeti.SlStd

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -14,6 +14,7 @@ public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Schem
 public import TauCeti.Algebra.Lie.UniversalEnveloping.MatrixRepresentation
 public import TauCeti.LinearAlgebra.Eigenspace.Binomial
 public import TauCeti.RingTheory.Binomial
+import TauCeti.Algebra.Lie.GeneralLinear.DiagonalCartan
 import TauCeti.CategoryTheory.Comma.Over
 
 /-!
@@ -235,20 +236,6 @@ private theorem diagSingle_mulVec (a k : Fin (r + 1)) :
   · subst h; simp
   · simp [h, Ne.symm h]
 
-/-- The commutator of a difference of two diagonal matrix units with a matrix unit is the
-corresponding Kronecker multiple of that matrix unit. -/
-private theorem commutator_diagSingleSub_single (a b c d : Fin (r + 1)) :
-    (Matrix.single a a (1 : ℚ) - Matrix.single b b 1) * Matrix.single c d 1 -
-        Matrix.single c d 1 * (Matrix.single a a (1 : ℚ) - Matrix.single b b 1) =
-      (((if a = c then (1 : ℚ) else 0) - (if b = c then 1 else 0)) -
-          ((if d = a then (1 : ℚ) else 0) - (if d = b then 1 else 0))) •
-        Matrix.single c d 1 := by
-  ext x y
-  simp only [Matrix.sub_apply, Matrix.mul_apply, Matrix.single_apply, Matrix.smul_apply,
-    smul_eq_mul, ite_and, sub_mul, mul_sub, mul_ite, mul_zero, mul_one, Finset.sum_ite_eq,
-    Finset.mem_univ, ite_true]
-  split_ifs <;> simp_all
-
 /-- Every standard coordinate vector is a Cartan weight vector, of the weight recorded by
 `TauCeti.SlStd.weight`. -/
 theorem isCartanWeightVector_single (k : Fin (r + 1)) :
@@ -291,9 +278,14 @@ theorem lie_cartanGenerator_rootGenerator (k : Fin r ⊕ Fin r) (j : Fin r) :
         Matrix.single (rootTarget r k) (rootSource r k) (1 : ℚ) := by
     rw [← val_rootGenerator]
     rfl
-  rw [sl_bracket, hcoe, val_cartanGenerator, val_rootGenerator,
-    commutator_diagSingleSub_single, ← cartanCoeff r k j]
-  simp only [Int.cast_sub, apply_ite (fun z : ℤ => (z : ℚ)), Int.cast_one, Int.cast_zero]
+  rw [hcoe]
+  change ⁅(cartanGenerator r j).1, (rootGenerator r k).1⁆ = _
+  rw [val_cartanGenerator, val_rootGenerator,
+    lie_single_of_mem_diagonalCartan
+      (sub_mem (single_self_mem_diagonalCartan j.castSucc 1)
+        (single_self_mem_diagonalCartan j.succ 1)), ← cartanCoeff r k j]
+  simp only [Matrix.sub_apply, Matrix.single_apply, and_self, Int.cast_sub,
+    apply_ite (fun z : ℤ => (z : ℚ)), Int.cast_one, Int.cast_zero, eq_comm]
 
 /-! ## The standard admissible lattice -/
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -442,19 +442,13 @@ theorem isCartanWeightVector_latticeBasis (k : Fin (r + 1)) :
   rw [coe_latticeBasis]
   exact isCartanWeightVector_single r k
 
-/-- The Kostant-form stability of the standard lattice, in the shape the Kostant constructions
-consume. -/
-theorem kostantForm_apply_mem_lattice :
-    ∀ u ∈ TauCeti.UniversalEnvelopingAlgebra.kostantForm (rootGenerator r) (cartanGenerator r),
-      ∀ v ∈ (lattice r).toAddSubgroup, rep r u v ∈ (lattice r).toAddSubgroup :=
-  fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv
-
 /-- **The full-weight Chevalley carrier of type `A_r`**: the smallest closed subgroup scheme of
 `GL_{r+1}` over `ℤ` containing the divided-power exponential root subgroups of the numbered
 Chevalley generators of `sl_{r+1}` and the weight torus of the standard lattice. -/
 noncomputable abbrev groupScheme : Grp (Over (Spec (CommRingCat.of ℤ))) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme (rootGenerator r)
-    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
 
 /-- **The canonical closed immersion of the type `A_r` carrier into `GL_{r+1}`**: the carrier is
@@ -462,7 +456,8 @@ by construction a closed subgroup scheme of the general linear group scheme of t
 lattice. -/
 noncomputable def carrierι : groupScheme r ⟶ TauCeti.GeneralLinear.groupScheme ℤ (r + 1) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupSchemeι (rootGenerator r)
-    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
 
 /-- **The type `A_r` carrier is a closed subgroup scheme of `GL_{r+1}`.** -/
@@ -474,14 +469,16 @@ instance isClosedImmersion_carrierι : IsClosedImmersion (carrierι r).hom.hom.l
 noncomputable def rootSubgroup (k : Fin r ⊕ Fin r) :
     AdditiveGroup.groupScheme ℤ ⟶ groupScheme r :=
   TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral (rootGenerator r)
-    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k
 
 /-- The rank-`r` split weight torus `T → G` of the type `A_r` carrier. Maximality is not
 asserted here; see the scope disclaimer in the module documentation. -/
 noncomputable def weightTorus : SplitTorus.groupScheme ℤ (Fin r) ⟶ groupScheme r :=
   TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral (rootGenerator r)
-    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
 
 /-- Including a numbered root subgroup of the type `A_r` carrier into `GL_{r+1}` recovers the
@@ -490,7 +487,8 @@ Kostant root subgroup of the numbered generator. -/
 theorem rootSubgroup_comp_carrierι (k : Fin r ⊕ Fin r) :
     rootSubgroup r k ≫ carrierι r =
       TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroup (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r) k
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
         (isNilpotent_rep_rootGenerator r k) (latticeBasis r) := by
   rw [rootSubgroup, carrierι,
     TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral_comp_ι]
@@ -507,7 +505,8 @@ theorem weightTorus_comp_carrierι :
 noncomputable def points (A : Type) [CommRing A] :
     Subgroup (Matrix.GeneralLinearGroup (Fin (r + 1)) A) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
-    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A
 
 /-- A matrix is a point of the type `A_r` carrier exactly when the associated convolution point
@@ -518,7 +517,8 @@ theorem mem_points_iff (A : Type) [CommRing A]
     g ∈ points r A ↔
       ∀ x ∈ TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal (rootGenerator r)
           (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
-          (kostantForm_apply_mem_lattice r) (isNilpotent_rep_rootGenerator r)
+          (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+          (isNilpotent_rep_rootGenerator r)
           (latticeBasis r) (weight r),
         ((GeneralLinear.pointsMulEquiv (R := ℤ) (r + 1)).symm g).ofConv x = 0 := by
   rw [points]
@@ -536,30 +536,25 @@ theorem rep_rootGenerator_latticeBasis (k : Fin r ⊕ Fin r) :
         Fin (r + 1) → ℚ) := by
   rw [coe_latticeBasis, coe_latticeBasis, rep_rootGenerator_single_source, one_smul]
 
-theorem rep_rootGenerator_rep_rootGenerator_latticeBasis_eq_zero (k : Fin r ⊕ Fin r) :
-    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))
-        (rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))
-          ((latticeBasis r (rootSource r k) : (lattice r).toAddSubgroup) :
-            Fin (r + 1) → ℚ)) = 0 :=
-  rep_rootGenerator_rep_rootGenerator_eq_zero r k _
-
 /-- The coordinate morphism of a numbered root subgroup is surjective before factoring through
 the carrier. -/
 private theorem representedRootCoordinateMap_surjective (k : Fin r ⊕ Fin r) :
     Function.Surjective
       (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
         k (isNilpotent_rep_rootGenerator r k) (latticeBasis r)).hom :=
   TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap_surjective _ _ _ _ _ _ _ _
     isUnit_one (rep_rootGenerator_latticeBasis r k)
-    (rep_rootGenerator_rep_rootGenerator_latticeBasis_eq_zero r k)
+    (rep_rootGenerator_rep_rootGenerator_eq_zero r k _)
 
 /-- **The coordinate morphism of every numbered root subgroup of the type `A_r` carrier is
 surjective.** -/
 theorem rootSubgroupCoordinateMap_surjective (k : Fin r ⊕ Fin r) :
     Function.Surjective
       (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
         (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k).hom :=
   TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap_surjective_of_surjective
     _ _ _ _ _ _ _ _ k (representedRootCoordinateMap_surjective r k)
@@ -568,12 +563,14 @@ theorem rootSubgroupCoordinateMap_surjective (k : Fin r ⊕ Fin r) :
 instance isClosedImmersion_rootSubgroup (k : Fin r ⊕ Fin r) :
     IsClosedImmersion (rootSubgroup r k).hom.hom.left := by
   have hdef := TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral_def (rootGenerator r)
-    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k
   let e₁ := (eqToHom (AdditiveGroup.groupScheme_def ℤ)).hom.hom.left
   let c := ((AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).map
     (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap (rootGenerator r)
-      (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+      (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
       (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k).op).hom.hom.left
   have hc : IsClosedImmersion c :=
     (CommHopfAlgCat.isClosedImmersion_hopfSpec_map_iff _).2
@@ -597,7 +594,8 @@ instance isClosedImmersion_weightTorus :
 noncomputable def rootSubgroupParam (k : Fin r ⊕ Fin r) (A : CommAlgCat ℤ) :
     Multiplicative A →* LinearMap.GeneralLinearGroup A (A ⊗[ℤ] (lattice r).toAddSubgroup) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupParam (rootGenerator r)
-    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r) k
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
     (isNilpotent_rep_rootGenerator r k) A
 
 /-- The split weight torus on points of a value algebra. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -12,7 +12,6 @@ public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Schem
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Relations
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Torus
 public import TauCeti.Algebra.Lie.UniversalEnveloping.MatrixRepresentation
-public import TauCeti.Algebra.Module.Rat
 public import TauCeti.LinearAlgebra.Eigenspace.Binomial
 public import TauCeti.RingTheory.Binomial
 import TauCeti.CategoryTheory.Comma.Over
@@ -56,8 +55,8 @@ is any group here claimed to be finite or simple.
 * `TauCeti.SlStd.rootGenerator` and `TauCeti.SlStd.cartanGenerator`: the Bourbaki-numbered
   Chevalley generators of `sl_{r+1}`, as elements of `LieAlgebra.SpecialLinear.sl`.
 * `TauCeti.SlStd.rep`: the standard representation, extended to the universal enveloping algebra.
-* `TauCeti.SlStd.weight` and `TauCeti.SlStd.rootWeight`: the integral weights of the coordinate
-  vectors and the roots of the numbered generators.
+* `TauCeti.SlStd.weight` and `TauCeti.SlStd.rootGeneratorWeight`: the integral weights of the
+  coordinate vectors and the roots of the numbered generators.
 * `TauCeti.SlStd.lattice` and `TauCeti.SlStd.latticeBasis`: the standard admissible lattice and its
   coordinate basis.
 * `TauCeti.SlStd.groupScheme`, `TauCeti.SlStd.rootSubgroup`, `TauCeti.SlStd.weightTorus` and
@@ -76,7 +75,8 @@ is any group here claimed to be finite or simple.
   subgroups of the carrier.
 * `TauCeti.SlStd.torusPoints_conj_rootSubgroupParam` and
   `TauCeti.SlStd.weightTorus_conj_rootSubgroup`: the pinning equation
-  `t(s) x_k(u) t(s)⁻¹ = x_k(α_k(s) u)`, on points and at the level of group schemes.
+  `t(s) x_k(u) t(s)⁻¹ = x_k(α_k(s) u)`, on matrix points and on `A`-valued scheme points
+  after corestriction to the carrier.
 
 ## References
 
@@ -214,15 +214,15 @@ def weight (k : Fin (r + 1)) (i : Fin r) : ℤ :=
 /-- The root of a numbered raising or lowering generator, as an integral character of the
 numbered Cartan generators: the `i`-th row of the type `A` Cartan matrix on a raising generator
 and its negative on a lowering one. -/
-def rootWeight : Fin r ⊕ Fin r → Fin r → ℤ
+def rootGeneratorWeight : Fin r ⊕ Fin r → Fin r → ℤ
   | .inl i => fun j => CartanMatrix.A r i j
   | .inr i => fun j => -CartanMatrix.A r i j
 
-@[simp] theorem rootWeight_inl (i j : Fin r) :
-    rootWeight r (.inl i) j = CartanMatrix.A r i j := (rfl)
+@[simp] theorem rootGeneratorWeight_inl (i j : Fin r) :
+    rootGeneratorWeight r (.inl i) j = CartanMatrix.A r i j := (rfl)
 
-@[simp] theorem rootWeight_inr (i j : Fin r) :
-    rootWeight r (.inr i) j = -CartanMatrix.A r i j := (rfl)
+@[simp] theorem rootGeneratorWeight_inr (i j : Fin r) :
+    rootGeneratorWeight r (.inr i) j = -CartanMatrix.A r i j := (rfl)
 
 /-- A diagonal matrix unit acts on a standard coordinate vector by the corresponding
 Kronecker delta. -/
@@ -266,27 +266,27 @@ private theorem cartanCoeff (k : Fin r ⊕ Fin r) (j : Fin r) :
     ((if j.castSucc = rootTarget r k then (1 : ℤ) else 0) -
         (if j.succ = rootTarget r k then 1 else 0)) -
       ((if rootSource r k = j.castSucc then (1 : ℤ) else 0) -
-        (if rootSource r k = j.succ then 1 else 0)) = rootWeight r k j := by
+        (if rootSource r k = j.succ then 1 else 0)) = rootGeneratorWeight r k j := by
   cases k with
   | inl i =>
-      rw [rootTarget_inl, rootSource_inl, rootWeight_inl, CartanMatrix.A]
+      rw [rootTarget_inl, rootSource_inl, rootGeneratorWeight_inl, CartanMatrix.A]
       simp only [Matrix.of_apply, Fin.ext_iff, Fin.val_succ, Fin.val_castSucc]
       split_ifs <;> omega
   | inr i =>
-      rw [rootTarget_inr, rootSource_inr, rootWeight_inr, CartanMatrix.A]
+      rw [rootTarget_inr, rootSource_inr, rootGeneratorWeight_inr, CartanMatrix.A]
       simp only [Matrix.of_apply, Fin.ext_iff, Fin.val_succ, Fin.val_castSucc]
       split_ifs <;> omega
 
 /-- **The numbered Cartan generators act on the numbered root generators through the type `A`
 Cartan matrix.** This is the relation that makes the split torus of the carrier below act on the
-root subgroup at `k` through the character `TauCeti.SlStd.rootWeight r k`. -/
+root subgroup at `k` through the character `TauCeti.SlStd.rootGeneratorWeight r k`. -/
 theorem lie_cartanGenerator_rootGenerator (k : Fin r ⊕ Fin r) (j : Fin r) :
     ⁅cartanGenerator r j, rootGenerator r k⁆ =
-      ((rootWeight r k j : ℤ) : ℚ) • rootGenerator r k := by
+      ((rootGeneratorWeight r k j : ℤ) : ℚ) • rootGenerator r k := by
   refine Subtype.ext ?_
-  have hcoe : (((((rootWeight r k j : ℤ) : ℚ) • rootGenerator r k) :
+  have hcoe : (((((rootGeneratorWeight r k j : ℤ) : ℚ) • rootGenerator r k) :
       sl (Fin (r + 1)) ℚ) : Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) =
-      ((rootWeight r k j : ℤ) : ℚ) •
+      ((rootGeneratorWeight r k j : ℤ) : ℚ) •
         Matrix.single (rootTarget r k) (rootSource r k) (1 : ℚ) := by
     rw [← val_rootGenerator]
     rfl
@@ -516,6 +516,21 @@ theorem points_def (A : Type) [CommRing A] :
         (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A := by
   rw [points]
 
+/-- A matrix is a point of the type `A_r` carrier exactly when the associated convolution point
+kills its toral defining Hopf ideal. -/
+@[simp]
+theorem mem_points_iff (A : Type) [CommRing A]
+    (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+    g ∈ points r A ↔
+      ∀ x ∈ TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal (rootGenerator r)
+          (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+          (kostantForm_apply_mem_lattice r) (isNilpotent_rep_rootGenerator r)
+          (latticeBasis r) (weight r),
+        ((GeneralLinear.pointsMulEquiv (R := ℤ) (r + 1)).symm g).ofConv x = 0 := by
+  rw [points_def]
+  exact TauCeti.UniversalEnvelopingAlgebra.mem_kostantToralPointsSubgroup_iff
+    _ _ _ _ _ _ _ _ A g
+
 /-! ## The pinning -/
 
 /-- A numbered root generator carries the coordinate basis vector at its source to the one at its
@@ -623,15 +638,15 @@ theorem torusPoints_conj_rootSubgroupParam (k : Fin r ⊕ Fin r) (A : CommAlgCat
     torusPoints r A s * rootSubgroupParam r k A u * (torusPoints r A s)⁻¹ =
       rootSubgroupParam r k A
         (Multiplicative.ofAdd
-          ((TauCeti.torusCharacter s (rootWeight r k) : A) *
+          ((TauCeti.torusCharacter s (rootGeneratorWeight r k) : A) *
             Multiplicative.toAdd u)) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints_conj_kostantRootSubgroupParam
     _ _ _ _ _ _ _ (isCartanWeightVector_latticeBasis r)
     (fun j => lie_cartanGenerator_rootGenerator r k j) _ A s u
 
-/-- **The scheme-level pinning equation of the type `A_r` carrier.** Conjugation by a point of the
-split torus rescales the parameter of a numbered root subgroup by the corresponding root
-character. -/
+/-- **The pinning equation on `A`-valued scheme points of the type `A_r` carrier.** After
+corestriction to the carrier, conjugation by a split-torus point rescales the parameter of a
+numbered root subgroup by the corresponding root character. -/
 theorem weightTorus_conj_rootSubgroup (k : Fin r ⊕ Fin r) (A : Type) [CommRing A]
     (s : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶
       (SplitTorus.groupScheme ℤ (Fin r)).X)
@@ -645,7 +660,7 @@ theorem weightTorus_conj_rootSubgroup (k : Fin r ⊕ Fin r) (A : Type) [CommRing
       (AdditiveGroup.schemePointsMulEquiv A).symm
           (Multiplicative.ofAdd
             ((TauCeti.torusCharacter (SplitTorus.schemePointsMulEquiv (R := ℤ) (A := A) s)
-              (rootWeight r k) : A) * u)) ≫
+              (rootGeneratorWeight r k) : A) * u)) ≫
         (rootSubgroup r k).hom.hom :=
   TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral_conj_kostantRootSubgroupToToralParam
     _ _ _ _ _ _ _ (isCartanWeightVector_latticeBasis r) (isNilpotent_rep_rootGenerator r) A

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -271,6 +271,7 @@ root subgroup at `k` through the character `TauCeti.SlStd.rootGeneratorWeight r 
 theorem lie_cartanGenerator_rootGenerator (k : Fin r ⊕ Fin r) (j : Fin r) :
     ⁅cartanGenerator r j, rootGenerator r k⁆ =
       ((rootGeneratorWeight r k j : ℤ) : ℚ) • rootGenerator r k := by
+  let _ : LieRing (Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) := LieRing.ofAssociativeRing
   refine Subtype.ext ?_
   have hcoe : (((((rootGeneratorWeight r k j : ℤ) : ℚ) • rootGenerator r k) :
       sl (Fin (r + 1)) ℚ) : Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) =
@@ -278,8 +279,7 @@ theorem lie_cartanGenerator_rootGenerator (k : Fin r ⊕ Fin r) (j : Fin r) :
         Matrix.single (rootTarget r k) (rootSource r k) (1 : ℚ) := by
     rw [← val_rootGenerator]
     rfl
-  rw [hcoe]
-  change ⁅(cartanGenerator r j).1, (rootGenerator r k).1⁆ = _
+  rw [LieSubalgebra.coe_bracket, hcoe]
   rw [val_cartanGenerator, val_rootGenerator,
     lie_single_of_mem_diagonalCartan
       (sub_mem (single_self_mem_diagonalCartan j.castSucc 1)

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -179,19 +179,25 @@ theorem rep_rootGenerator_single_source (k : Fin r ⊕ Fin r) :
         (Pi.single (rootSource r k) 1) = Pi.single (rootTarget r k) 1 := by
   rw [rep_rootGenerator_apply, Pi.single_eq_same, one_smul]
 
-/-- Every numbered root generator squares to zero in the standard representation. -/
+/-- Applying a numbered root generator twice to a vector gives zero: it writes into a coordinate
+it does not read from. -/
 theorem rep_rootGenerator_rep_rootGenerator_eq_zero (k : Fin r ⊕ Fin r) (v : Fin (r + 1) → ℚ) :
     rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))
         (rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k)) v) = 0 := by
   rw [rep_rootGenerator_apply r k v, map_smul, rep_rootGenerator_apply,
     Pi.single_eq_of_ne (rootTarget_ne_rootSource r k).symm 1, zero_smul, smul_zero]
 
-/-- Every numbered root generator acts nilpotently. -/
-theorem isNilpotent_rep_rootGenerator (k : Fin r ⊕ Fin r) :
-    IsNilpotent (rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))) := by
-  refine ⟨2, LinearMap.ext fun v => ?_⟩
+/-- **Every numbered root generator squares to zero in the standard representation.** -/
+theorem pow_two_rep_rootGenerator_eq_zero (k : Fin r ⊕ Fin r) :
+    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k)) ^ 2 = 0 := by
+  refine LinearMap.ext fun v => ?_
   rw [pow_two, Module.End.mul_apply, rep_rootGenerator_rep_rootGenerator_eq_zero,
     LinearMap.zero_apply]
+
+/-- Every numbered root generator acts nilpotently. -/
+theorem isNilpotent_rep_rootGenerator (k : Fin r ⊕ Fin r) :
+    IsNilpotent (rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))) :=
+  ⟨2, pow_two_rep_rootGenerator_eq_zero r k⟩
 
 /-! ## Weights and roots -/
 
@@ -224,21 +230,19 @@ private theorem diagSingle_mulVec (a k : Fin (r + 1)) :
   · subst h; simp
   · simp [h, Ne.symm h]
 
-/-- Multiplying a matrix unit on the left by a diagonal one. -/
-private theorem diagSingle_mul_single (a c d : Fin (r + 1)) :
-    Matrix.single a a (1 : ℚ) * Matrix.single c d 1 =
-      (if a = c then (1 : ℚ) else 0) • Matrix.single c d 1 := by
-  by_cases h : a = c
-  · subst h; simp
-  · simp [h]
-
-/-- Multiplying a matrix unit on the right by a diagonal one. -/
-private theorem single_mul_diagSingle (c d b : Fin (r + 1)) :
-    Matrix.single c d (1 : ℚ) * Matrix.single b b 1 =
-      (if d = b then (1 : ℚ) else 0) • Matrix.single c d 1 := by
-  by_cases h : d = b
-  · subst h; simp
-  · simp [h]
+/-- The commutator of a difference of two diagonal matrix units with a matrix unit is the
+corresponding Kronecker multiple of that matrix unit. -/
+private theorem commutator_diagSingleSub_single (a b c d : Fin (r + 1)) :
+    (Matrix.single a a (1 : ℚ) - Matrix.single b b 1) * Matrix.single c d 1 -
+        Matrix.single c d 1 * (Matrix.single a a (1 : ℚ) - Matrix.single b b 1) =
+      (((if a = c then (1 : ℚ) else 0) - (if b = c then 1 else 0)) -
+          ((if d = a then (1 : ℚ) else 0) - (if d = b then 1 else 0))) •
+        Matrix.single c d 1 := by
+  ext x y
+  simp only [Matrix.sub_apply, Matrix.mul_apply, Matrix.single_apply, Matrix.smul_apply,
+    smul_eq_mul, ite_and, sub_mul, mul_sub, mul_ite, mul_zero, mul_one, Finset.sum_ite_eq,
+    Finset.mem_univ, ite_true]
+  split_ifs <;> simp_all
 
 /-- Every standard coordinate vector is a Cartan weight vector, of the weight recorded by
 `TauCeti.SlStd.weight`. -/
@@ -276,16 +280,14 @@ theorem lie_cartanGenerator_rootGenerator (k : Fin r ⊕ Fin r) (j : Fin r) :
     ⁅cartanGenerator r j, rootGenerator r k⁆ =
       ((rootWeight r k j : ℤ) : ℚ) • rootGenerator r k := by
   refine Subtype.ext ?_
-  rw [sl_bracket]
   have hcoe : (((((rootWeight r k j : ℤ) : ℚ) • rootGenerator r k) :
       sl (Fin (r + 1)) ℚ) : Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) =
       ((rootWeight r k j : ℤ) : ℚ) •
         Matrix.single (rootTarget r k) (rootSource r k) (1 : ℚ) := by
     rw [← val_rootGenerator]
     rfl
-  rw [hcoe, val_cartanGenerator, val_rootGenerator, Matrix.sub_mul, Matrix.mul_sub,
-    diagSingle_mul_single, diagSingle_mul_single, single_mul_diagSingle, single_mul_diagSingle,
-    ← sub_smul, ← sub_smul, ← sub_smul, ← cartanCoeff r k j]
+  rw [sl_bracket, hcoe, val_cartanGenerator, val_rootGenerator,
+    commutator_diagSingleSub_single, ← cartanCoeff r k j]
   simp only [Int.cast_sub, apply_ite (fun z : ℤ => (z : ℚ)), Int.cast_one, Int.cast_zero]
 
 /-! ## The standard admissible lattice -/
@@ -320,13 +322,6 @@ theorem coe_latticeBasis (i : Fin (r + 1)) :
   rw [Module.Basis.restrictScalars_apply, Pi.basisFun_apply]
 
 /-! ## Stability of the lattice under the Kostant form -/
-
-/-- Every numbered root generator squares to zero in the standard representation. -/
-theorem pow_two_rep_rootGenerator_eq_zero (k : Fin r ⊕ Fin r) :
-    rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k)) ^ 2 = 0 := by
-  refine LinearMap.ext fun v => ?_
-  rw [pow_two, Module.End.mul_apply, rep_rootGenerator_rep_rootGenerator_eq_zero,
-    LinearMap.zero_apply]
 
 /-- A numbered root generator carries the standard lattice into itself. -/
 theorem rep_rootGenerator_mem_lattice (k : Fin r ⊕ Fin r) {v : Fin (r + 1) → ℚ}
@@ -476,7 +471,8 @@ noncomputable abbrev rootSubgroup (k : Fin r ⊕ Fin r) :
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k
 
-/-- The split maximal torus `T → G` of the type `A_r` carrier. -/
+/-- The rank-`r` split weight torus `T → G` of the type `A_r` carrier. Maximality is not
+asserted here; see the scope disclaimer in the module documentation. -/
 noncomputable abbrev weightTorus : SplitTorus.groupScheme ℤ (Fin r) ⟶ groupScheme r :=
   TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -59,8 +59,9 @@ is any group here claimed to be finite or simple.
   coordinate vectors and the roots of the numbered generators.
 * `TauCeti.SlStd.lattice` and `TauCeti.SlStd.latticeBasis`: the standard admissible lattice and its
   coordinate basis.
-* `TauCeti.SlStd.groupScheme`, `TauCeti.SlStd.rootSubgroup`, `TauCeti.SlStd.weightTorus` and
-  `TauCeti.SlStd.points`: the carrier, its pinned generating morphisms, and its matrix points.
+* `TauCeti.SlStd.groupScheme`, `TauCeti.SlStd.carrierι`, `TauCeti.SlStd.rootSubgroup`,
+  `TauCeti.SlStd.weightTorus` and `TauCeti.SlStd.points`: the carrier, its closed immersion into
+  `GL_{r+1}`, its pinned generating morphisms, and its matrix points.
 
 ## Main results
 
@@ -468,6 +469,28 @@ noncomputable abbrev groupScheme : Grp (Over (Spec (CommRingCat.of ℤ))) :=
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
 
+/-- **The canonical closed immersion of the type `A_r` carrier into `GL_{r+1}`**: the carrier is
+by construction a closed subgroup scheme of the general linear group scheme of the standard
+lattice. -/
+noncomputable def carrierι : groupScheme r ⟶ TauCeti.GeneralLinear.groupScheme ℤ (r + 1) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupSchemeι (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+
+/-- The inclusion of the type `A_r` carrier into `GL_{r+1}` is the inclusion of the Kostant toral
+closure of the standard lattice. -/
+theorem carrierι_def :
+    carrierι r =
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupSchemeι (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) := by
+  rw [carrierι]
+
+/-- **The type `A_r` carrier is a closed subgroup scheme of `GL_{r+1}`.** -/
+instance isClosedImmersion_carrierι : IsClosedImmersion (carrierι r).hom.hom.left := by
+  rw [carrierι]
+  infer_instance
+
 /-- The numbered root subgroup `x_k : 𝔾ₐ → G` of the type `A_r` carrier. -/
 noncomputable def rootSubgroup (k : Fin r ⊕ Fin r) :
     AdditiveGroup.groupScheme ℤ ⟶ groupScheme r :=
@@ -499,6 +522,25 @@ theorem weightTorus_def :
         (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
         (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) := by
   rw [weightTorus]
+
+/-- Including a numbered root subgroup of the type `A_r` carrier into `GL_{r+1}` recovers the
+Kostant root subgroup of the numbered generator. -/
+@[simp]
+theorem rootSubgroup_comp_carrierι (k : Fin r ⊕ Fin r) :
+    rootSubgroup r k ≫ carrierι r =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroup (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r) k
+        (isNilpotent_rep_rootGenerator r k) (latticeBasis r) := by
+  rw [rootSubgroup, carrierι,
+    TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral_comp_ι]
+
+/-- Including the split torus of the type `A_r` carrier into `GL_{r+1}` recovers the weight torus
+of the weights of the standard module. -/
+@[simp]
+theorem weightTorus_comp_carrierι :
+    weightTorus r ≫ carrierι r = TauCeti.GeneralLinear.weightTorus (R := ℤ) (weight r) := by
+  rw [weightTorus, carrierι,
+    TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral_comp_ι]
 
 /-- The `A`-valued points of the type `A_r` carrier, as matrices. -/
 noncomputable def points (A : Type) [CommRing A] :

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -156,10 +156,14 @@ theorem val_cartanGenerator (i : Fin r) :
 
 /-- The standard representation of `sl_{r+1}` on coordinate vectors, extended to the universal
 enveloping algebra. -/
-noncomputable abbrev rep :
+noncomputable def rep :
     _root_.UniversalEnvelopingAlgebra ℚ (sl (Fin (r + 1)) ℚ) →ₐ[ℚ]
       Module.End ℚ (Fin (r + 1) → ℚ) :=
   LieSubalgebra.matrixRepresentation (sl (Fin (r + 1)) ℚ)
+
+/-- The standard representation is the defining matrix representation of `sl_{r+1}`. -/
+theorem rep_def : rep r = LieSubalgebra.matrixRepresentation (sl (Fin (r + 1)) ℚ) := by
+  rw [rep]
 
 theorem rep_ι_apply (x : sl (Fin (r + 1)) ℚ) (v : Fin (r + 1) → ℚ) :
     rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ x) v =
@@ -465,25 +469,52 @@ noncomputable abbrev groupScheme : Grp (Over (Spec (CommRingCat.of ℤ))) :=
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
 
 /-- The numbered root subgroup `x_k : 𝔾ₐ → G` of the type `A_r` carrier. -/
-noncomputable abbrev rootSubgroup (k : Fin r ⊕ Fin r) :
+noncomputable def rootSubgroup (k : Fin r ⊕ Fin r) :
     AdditiveGroup.groupScheme ℤ ⟶ groupScheme r :=
   TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k
 
+/-- The numbered root subgroup of the type `A_r` carrier is the Kostant root subgroup of the
+numbered generator, corestricted to the toral closure. -/
+theorem rootSubgroup_def (k : Fin r ⊕ Fin r) :
+    rootSubgroup r k =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k := by
+  rw [rootSubgroup]
+
 /-- The rank-`r` split weight torus `T → G` of the type `A_r` carrier. Maximality is not
 asserted here; see the scope disclaimer in the module documentation. -/
-noncomputable abbrev weightTorus : SplitTorus.groupScheme ℤ (Fin r) ⟶ groupScheme r :=
+noncomputable def weightTorus : SplitTorus.groupScheme ℤ (Fin r) ⟶ groupScheme r :=
   TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
 
+/-- The split torus of the type `A_r` carrier is the Kostant weight torus of the standard
+lattice, corestricted to the toral closure. -/
+theorem weightTorus_def :
+    weightTorus r =
+      TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) := by
+  rw [weightTorus]
+
 /-- The `A`-valued points of the type `A_r` carrier, as matrices. -/
-noncomputable abbrev points (A : Type) [CommRing A] :
+noncomputable def points (A : Type) [CommRing A] :
     Subgroup (Matrix.GeneralLinearGroup (Fin (r + 1)) A) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A
+
+/-- The matrix points of the type `A_r` carrier are the Kostant toral points of the standard
+lattice. -/
+theorem points_def (A : Type) [CommRing A] :
+    points r A =
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A := by
+  rw [points]
 
 /-! ## The pinning -/
 
@@ -554,17 +585,34 @@ instance isClosedImmersion_weightTorus :
     (span_range_weight_eq_top r)
 
 /-- The parametrized numbered root subgroup on points of a value algebra. -/
-noncomputable abbrev rootSubgroupParam (k : Fin r ⊕ Fin r) (A : CommAlgCat ℤ) :
+noncomputable def rootSubgroupParam (k : Fin r ⊕ Fin r) (A : CommAlgCat ℤ) :
     Multiplicative A →* LinearMap.GeneralLinearGroup A (A ⊗[ℤ] (lattice r).toAddSubgroup) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupParam (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r) k
     (isNilpotent_rep_rootGenerator r k) A
 
+/-- The parametrized numbered root subgroup is the Kostant divided-power exponential of the
+numbered generator. -/
+theorem rootSubgroupParam_def (k : Fin r ⊕ Fin r) (A : CommAlgCat ℤ) :
+    rootSubgroupParam r k A =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupParam (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r) k
+        (isNilpotent_rep_rootGenerator r k) A := by
+  rw [rootSubgroupParam]
+
 /-- The split weight torus on points of a value algebra. -/
-noncomputable abbrev torusPoints (A : CommAlgCat ℤ) :
+noncomputable def torusPoints (A : CommAlgCat ℤ) :
     (Fin r → Aˣ) →* LinearMap.GeneralLinearGroup A (A ⊗[ℤ] (lattice r).toAddSubgroup) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints (lattice r).toAddSubgroup
     (latticeBasis r) (weight r) A
+
+/-- The split weight torus on points is the Kostant torus of the standard lattice, taken in the
+coordinate basis and the weights of the coordinate vectors. -/
+theorem torusPoints_def (A : CommAlgCat ℤ) :
+    torusPoints r A =
+      TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints (lattice r).toAddSubgroup
+        (latticeBasis r) (weight r) A := by
+  rw [torusPoints]
 
 /-- **The pinning equation of the type `A_r` carrier.** A torus point `s` conjugates the
 root-subgroup element of parameter `u` into the one of parameter `α_k(s) u`, where `α_k` is the

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -273,8 +273,7 @@ theorem lie_cartanGenerator_rootGenerator (k : Fin r ⊕ Fin r) (j : Fin r) :
       sl (Fin (r + 1)) ℚ) : Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) =
       ((rootGeneratorWeight r k j : ℤ) : ℚ) •
         Matrix.single (rootTarget r k) (rootSource r k) (1 : ℚ) := by
-    rw [← val_rootGenerator]
-    rfl
+    rw [SetLike.val_smul, val_rootGenerator]
   rw [LieSubalgebra.coe_bracket, hcoe]
   rw [val_cartanGenerator, val_rootGenerator,
     lie_single_of_mem_diagonalCartan

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -382,24 +382,25 @@ theorem rep_kostantForm_mem_lattice
 
 /-- The weight of an integral combination of coordinate vectors, as a linear map into the
 character lattice of the split torus of rank `r`. -/
-def weightMap : (Fin (r + 1) → ℤ) →ₗ[ℤ] Fin r → ℤ where
+private def weightMap : (Fin (r + 1) → ℤ) →ₗ[ℤ] Fin r → ℤ where
   toFun x i := x i.castSucc - x i.succ
   map_add' x y := by funext i; simp only [Pi.add_apply]; ring
   map_smul' c x := by funext i; simp only [Pi.smul_apply, smul_eq_mul, RingHom.id_apply]; ring
 
 @[simp]
-theorem weightMap_apply (x : Fin (r + 1) → ℤ) (i : Fin r) :
+private theorem weightMap_apply (x : Fin (r + 1) → ℤ) (i : Fin r) :
     weightMap r x i = x i.castSucc - x i.succ := (rfl)
 
 /-- The weight of the `k`-th coordinate vector is the image of its indicator function. -/
-theorem weightMap_single (k : Fin (r + 1)) : weightMap r (Pi.single k 1) = weight r k := by
+private theorem weightMap_single (k : Fin (r + 1)) :
+    weightMap r (Pi.single k 1) = weight r k := by
   funext i
   simp only [weightMap_apply, weight, Pi.single_apply]
   simp only [eq_comm]
 
 /-- **The weight map is surjective**: the differences `x_i - x_{i+1}` realize every integral
 character, by partial summation. -/
-theorem weightMap_surjective : Function.Surjective (weightMap r) := by
+private theorem weightMap_surjective : Function.Surjective (weightMap r) := by
   classical
   intro y
   refine ⟨fun j => -∑ n ∈ Finset.range (j : ℕ), (if h : n < r then y ⟨n, h⟩ else 0), ?_⟩

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean
@@ -163,10 +163,6 @@ noncomputable def rep :
       Module.End ℚ (Fin (r + 1) → ℚ) :=
   LieSubalgebra.matrixRepresentation (sl (Fin (r + 1)) ℚ)
 
-/-- The standard representation is the defining matrix representation of `sl_{r+1}`. -/
-theorem rep_def : rep r = LieSubalgebra.matrixRepresentation (sl (Fin (r + 1)) ℚ) := by
-  rw [rep]
-
 theorem rep_ι_apply (x : sl (Fin (r + 1)) ℚ) (v : Fin (r + 1) → ℚ) :
     rep r (_root_.UniversalEnvelopingAlgebra.ι ℚ x) v =
       (x : Matrix (Fin (r + 1)) (Fin (r + 1)) ℚ) *ᵥ v :=
@@ -469,15 +465,6 @@ noncomputable def carrierι : groupScheme r ⟶ TauCeti.GeneralLinear.groupSchem
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
 
-/-- The inclusion of the type `A_r` carrier into `GL_{r+1}` is the inclusion of the Kostant toral
-closure of the standard lattice. -/
-theorem carrierι_def :
-    carrierι r =
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupSchemeι (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
-        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) := by
-  rw [carrierι]
-
 /-- **The type `A_r` carrier is a closed subgroup scheme of `GL_{r+1}`.** -/
 instance isClosedImmersion_carrierι : IsClosedImmersion (carrierι r).hom.hom.left := by
   rw [carrierι]
@@ -490,30 +477,12 @@ noncomputable def rootSubgroup (k : Fin r ⊕ Fin r) :
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k
 
-/-- The numbered root subgroup of the type `A_r` carrier is the Kostant root subgroup of the
-numbered generator, corestricted to the toral closure. -/
-theorem rootSubgroup_def (k : Fin r ⊕ Fin r) :
-    rootSubgroup r k =
-      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
-        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k := by
-  rw [rootSubgroup]
-
 /-- The rank-`r` split weight torus `T → G` of the type `A_r` carrier. Maximality is not
 asserted here; see the scope disclaimer in the module documentation. -/
 noncomputable def weightTorus : SplitTorus.groupScheme ℤ (Fin r) ⟶ groupScheme r :=
   TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
-
-/-- The split torus of the type `A_r` carrier is the Kostant weight torus of the standard
-lattice, corestricted to the toral closure. -/
-theorem weightTorus_def :
-    weightTorus r =
-      TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
-        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) := by
-  rw [weightTorus]
 
 /-- Including a numbered root subgroup of the type `A_r` carrier into `GL_{r+1}` recovers the
 Kostant root subgroup of the numbered generator. -/
@@ -541,15 +510,6 @@ noncomputable def points (A : Type) [CommRing A] :
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A
 
-/-- The matrix points of the type `A_r` carrier are the Kostant toral points of the standard
-lattice. -/
-theorem points_def (A : Type) [CommRing A] :
-    points r A =
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r)
-        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A := by
-  rw [points]
-
 /-- A matrix is a point of the type `A_r` carrier exactly when the associated convolution point
 kills its toral defining Hopf ideal. -/
 @[simp]
@@ -561,7 +521,7 @@ theorem mem_points_iff (A : Type) [CommRing A]
           (kostantForm_apply_mem_lattice r) (isNilpotent_rep_rootGenerator r)
           (latticeBasis r) (weight r),
         ((GeneralLinear.pointsMulEquiv (R := ℤ) (r + 1)).symm g).ofConv x = 0 := by
-  rw [points_def]
+  rw [points]
   exact TauCeti.UniversalEnvelopingAlgebra.mem_kostantToralPointsSubgroup_iff
     _ _ _ _ _ _ _ _ A g
 
@@ -640,28 +600,11 @@ noncomputable def rootSubgroupParam (k : Fin r ⊕ Fin r) (A : CommAlgCat ℤ) :
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r) k
     (isNilpotent_rep_rootGenerator r k) A
 
-/-- The parametrized numbered root subgroup is the Kostant divided-power exponential of the
-numbered generator. -/
-theorem rootSubgroupParam_def (k : Fin r ⊕ Fin r) (A : CommAlgCat ℤ) :
-    rootSubgroupParam r k A =
-      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupParam (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup (kostantForm_apply_mem_lattice r) k
-        (isNilpotent_rep_rootGenerator r k) A := by
-  rw [rootSubgroupParam]
-
 /-- The split weight torus on points of a value algebra. -/
 noncomputable def torusPoints (A : CommAlgCat ℤ) :
     (Fin r → Aˣ) →* LinearMap.GeneralLinearGroup A (A ⊗[ℤ] (lattice r).toAddSubgroup) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints (lattice r).toAddSubgroup
     (latticeBasis r) (weight r) A
-
-/-- The split weight torus on points is the Kostant torus of the standard lattice, taken in the
-coordinate basis and the weights of the coordinate vectors. -/
-theorem torusPoints_def (A : CommAlgCat ℤ) :
-    torusPoints r A =
-      TauCeti.UniversalEnvelopingAlgebra.kostantTorusPoints (lattice r).toAddSubgroup
-        (latticeBasis r) (weight r) A := by
-  rw [torusPoints]
 
 /-- **The pinning equation of the type `A_r` carrier.** A torus point `s` conjugates the
 root-subgroup element of parameter `u` into the one of parameter `α_k(s) u`, where `α_k` is the


### PR DESCRIPTION
This PR constructs the pinned Chevalley--Demazure carrier of type `A_r` from the standard module of `sl_{r+1}`: it records the Bourbaki-numbered Chevalley generators `e_i = E_{i,i+1}`, `f_i = E_{i+1,i}` and `h_i = E_{i,i} - E_{i+1,i+1}` inside Mathlib's `LieAlgebra.SpecialLinear.sl`, proves that the coordinate `ℤ`-lattice of the standard module is admissible (the Kostant `ℤ`-form preserves it), feeds that data into the Kostant toral-closure construction, and proves the two properties a pinning asks for: every numbered root subgroup is a closed immersion, and so is the rank-`r` split torus. The last of these is the point of the PR, and it rests on `TauCeti.SlStd.span_range_weight_eq_top`: the weights of the standard module generate the *whole* character lattice `Fin r → ℤ` of the torus whose cocharacter lattice is spanned by the simple coroots, that is, the weight lattice `P` of type `A_r`. The pinning equation `t(s) x_k(u) t(s)⁻¹ = x_k(α_k(s) u)` is proved on points and at the level of group schemes, with `α_k` the row of `CartanMatrix.A r` on a raising generator and its negative on a lowering one.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, "The Chevalley--Demazure construction" — "for each root datum, an explicitly constructed split reductive group scheme over `ℤ` realizing it, via a Chevalley basis and the Kostant `ℤ`-form of the enveloping algebra" — together with the "Pinnings" and "Root subgroup maps" targets of the same layer. Nothing here is selected by `Classical.choose`: every carrier traces back to the explicit matrix units above.

The consumer is milestone L0, "pinned ambient groups", of `TauCetiRoadmap/CFSGStatement/README.md`, whose `ValidLieTypeIndex.AmbientGroup` needs the *simply connected* pinned group — the README computes its exclusions in `SL₂` and `SU₃`, "not `PSL₂(3)` and `PSU₃(2)`, which would give different and wrong answers here". The existing Geck carrier `TauCeti.DynkinType.geckGroupScheme` cannot supply that: its module is the adjoint one, so its weights generate only the root lattice, of index `r + 1` in `P` for type `A_r`, and its own module documentation records that L0 "needs instead an admissible lattice whose weights generate the full weight lattice". That is exactly what this PR supplies for the type `A` family, which carries the `A_n(q)` and `²A_n(q)` branches of the CFSG list. The dependency edge was made concrete by TauCeti#4471, the attempt at L0 whose correctness review blocked precisely on the adjoint carrier.

This is the most effective available step because the generic Kostant toral-closure machinery, its closed-immersion criteria and the spanning-weights torus criterion are all on `main`, and the only full-weight instance so far is rank one (open PR TauCeti#4485, `TauCeti.Sl2Std.rankOneGroupScheme`, built from the abstract `sl₂` standard module `V(1)`), whose own description names "analogous full-weight admissible lattices in higher rank" as what Layer 9 still needs. This PR is that higher-rank instance, built along a different route — Mathlib's matrix `sl n R` and its matrix-unit generators rather than the abstract `Sl2Std` weight-string module — and it is uniform in `r` rather than a per-rank table.

After this PR, Layer 9 still needs full-weight admissible lattices for the remaining families (the spin modules for `B` and `D`, the standard symplectic module for `C`, the minuscule modules for `E₆` and `E₇`; `E₈`, `F₄` and `G₂` are already full-weight in the adjoint carrier), the compatible Borel, root subgroups for the nonsimple roots, and the root-datum statements that identify a carrier as split reductive, before CFSGStatement L0 can define `ValidLieTypeIndex.AmbientGroup` uniformly.

Three things are deliberately not asserted, and the module documentation says so: the carrier is not proved reductive, its torus is not proved maximal, and it is not identified with the special linear group scheme. No group here is claimed finite or simple.

The implementation adds `TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier.lean` (611 lines). No Mathlib source or external formalization is vendored: it consumes Mathlib's `LieAlgebra.SpecialLinear.sl` with its `single` and `singleSubSingle` elementary generators, `CartanMatrix.A`, `Matrix.single_mulVec_eq` and `Pi.basisFun`, and Tau Ceti's `LieSubalgebra.matrixRepresentation`, `kostantForm_apply_mem`, `ringChoose_end_apply_of_apply_eq_smul`, `kostantToralGroupScheme` with its root-subgroup and weight-torus closed-immersion criteria, and `kostantTorusPoints_conj_kostantRootSubgroupParam`. The mathematical organization follows Humphreys, *Introduction to Lie Algebras and Representation Theory* §27 and *Linear Algebraic Groups* §§26--27, Carter, *Simple Groups of Lie Type* §§4.4 and 7.1, Jantzen, *Representations of Algebraic Groups* II.1, and Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate I, as credited in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-a-full-weight-chevalley-carrier"}-->

🤖 Prepared with Claude Code
