### PR TITLE
feat: preserve unipotence under affine group images

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
@@ -7,9 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.FaithfullyFlat
-import Mathlib.LinearAlgebra.Charpoly.ToMatrix
-import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
-import TauCeti.RingTheory.FiniteType.PointSeparation
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Reduced
 
 /-!
 # Unipotence of affine group images
@@ -22,14 +20,11 @@ algebraically closed point of the image lifts to a point of `Spec K`.
 
 There are two ways to descend unipotence from `Spec K` to the image. A faithfully flat inclusion
 lifts every geometric point of the image to the source. More directly, when `K` is reduced and
-finite type, its geometric points separate the coefficients of the characteristic polynomial of
-every representation. The latter argument only needs the canonical inclusion to be injective,
-and hence applies to every scheme-theoretic image of a smooth unipotent affine group.
+finite type, injectivity of the canonical inclusion lets the general reduced descent theorem
+apply to every scheme-theoretic image of a smooth unipotent affine group.
 
 ## Main declaration
 
-* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.of_injective_of_reduced`: geometric
-  unipotence descends along an injective coordinate morphism with reduced finite-type codomain.
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.image_of_reduced`: the image of a
   reduced finite-type geometrically unipotent affine group is geometrically unipotent.
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.image_of_faithfullyFlat`: a
@@ -48,146 +43,15 @@ closure of connected normal smooth unipotent subgroup schemes.
 public section
 
 open CategoryTheory
-open scoped TensorProduct
 
 namespace TauCeti
 
-universe u v w x
+universe u v
 
 namespace geometricallyUnipotentPointsCommHopfAlgProperty
 
 variable {k : Type u} [Field k]
 variable {H K : _root_.CommHopfAlgCat.{v} k}
-
-attribute [local instance 1100] Module.Free.of_divisionRing
-
-private theorem coefficientMatrix_corestrict
-    {C D : Type v} {M : Type w} {ι : Type x}
-    [AddCommMonoid C] [Module k C] [Coalgebra k C]
-    [AddCommMonoid D] [Module k D] [Coalgebra k D]
-    [AddCommMonoid M] [Module k M] [Comodule k C M]
-    (b : Module.Basis ι k M) (f : C →ₗc[k] D) :
-    letI : Comodule k D M := Comodule.Corestrict f
-    Comodule.coefficientMatrix (C := D) b =
-      (Comodule.coefficientMatrix (C := C) b).map f := by
-  let _ : Comodule k D M := Comodule.Corestrict f
-  ext i j
-  rw [Comodule.coefficientMatrix_apply, Matrix.map_apply,
-    Comodule.coefficientMatrix_apply,
-    Comodule.matrixCoefficient_def, Comodule.matrixCoefficient_def,
-    Comodule.corestrict_coact_apply]
-  have h := LinearMap.congr_fun
-    (CoassocSimps.lid_comp_map (b.coord i) f.toLinearMap)
-    (Comodule.coact (R := k) (C := C) (M := M) (b j))
-  rw [TensorProduct.map_map, LinearMap.id_comp, LinearMap.comp_id]
-  -- `lid_comp_map` gives this naturality identity for the underlying linear map.
-  change _ = f.toLinearMap _
-  exact h
-
-/-- Geometric unipotence descends along an injective morphism of coordinate Hopf algebras whose
-codomain is reduced and finite type.
-
-Contravariantly, the morphism represents a schematically dense homomorphism from `Spec K` to
-`Spec H`. For a finite-dimensional `H`-comodule, every geometric point of `Spec K` makes the
-characteristic polynomial of the restricted action equal to `(X - 1) ^ n`. Point separation in
-the reduced algebra `K` gives the same identity for the universal coefficient matrix. Injectivity
-then reflects it to `H`, where evaluation proves that every geometric point of `Spec H` acts
-unipotently. -/
-theorem of_injective_of_reduced (f : H ⟶ K) (hf : Function.Injective f.hom)
-    [Algebra.FiniteType k K] [IsReduced K]
-    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
-    geometricallyUnipotentPointsCommHopfAlgProperty k H := by
-  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hK ⊢
-  intro g
-  rw [HopfAlgebra.isUnipotentPoint_def]
-  intro M
-  let b := Module.Free.chooseBasis k M
-  let C := Comodule.coefficientMatrix (C := H) b
-  let D := C.map f.hom
-  let d := Module.finrank (AlgebraicClosure k) (AlgebraicClosure k ⊗[k] M)
-  let P : Polynomial k := (Polynomial.X - 1) ^ d
-  -- Point separation turns the characteristic polynomial identity at every source point into
-  -- an identity for the universal coefficient matrix over the source coordinate algebra.
-  have hDcharpoly : D.charpoly = P.map (algebraMap k K) := by
-    apply Polynomial.ext
-    intro r
-    apply TauCeti.eq_of_forall_algHom_apply_eq
-      (k := k) (K := AlgebraicClosure k)
-    intro q
-    let _ : Comodule k K M := Comodule.Corestrict f.hom.toCoalgHom
-    let N : FGComoduleCat.{u, v, u} k K := FGComoduleCat.of (R := k) (C := K) M
-    have hq := (HopfAlgebra.isUnipotentPoint_def (WithConv.toConv q)).mp
-      (hK (WithConv.toConv q)) N
-    have hqcharpoly : (Comodule.endOfPoint M q).charpoly =
-        P.map (algebraMap k (AlgebraicClosure k)) := by
-      have hcoe :
-          ((LinearMap.GeneralLinearGroup.ofLinearEquiv
-            (Comodule.pointsAction N (WithConv.toConv q))) : Module.End _ _) =
-              Comodule.endOfPoint M q :=
-        Comodule.pointsAction_toLinearMap N (WithConv.toConv q)
-      rw [← hcoe]
-      have hcharpoly := (LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly _).mp hq
-      have hd : Module.finrank (AlgebraicClosure k)
-          (AlgebraicClosure k ⊗[k] N) = d := rfl
-      rw [hd] at hcharpoly
-      exact hcharpoly.trans (by simp [P])
-    have hmatrix : D.map q =
-        LinearMap.toMatrix (b.baseChange (AlgebraicClosure k))
-          (b.baseChange (AlgebraicClosure k)) (Comodule.endOfPoint N q) := by
-      rw [Comodule.toMatrix_endOfPoint]
-      rw [coefficientMatrix_corestrict b f.hom.toCoalgHom]
-      -- Unfold the local names so `Matrix.map_map` sees the two successive coefficient maps.
-      change (C.map f.hom).map q = _
-      rw [Matrix.map_map]
-      ext i j
-      rfl
-    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint N q)
-      (b.baseChange (AlgebraicClosure k)), ← hmatrix] at hqcharpoly
-    calc
-      q (D.charpoly.coeff r) = (D.charpoly.map q).coeff r := by
-        exact (Polynomial.coeff_map q.toRingHom r).symm
-      _ = (D.map q).charpoly.coeff r :=
-        congrArg (fun p ↦ p.coeff r) (Matrix.charpoly_map D q.toRingHom).symm
-      _ = (P.map (algebraMap k (AlgebraicClosure k))).coeff r :=
-        congrArg (fun p ↦ p.coeff r) hqcharpoly
-      _ = q ((P.map (algebraMap k K)).coeff r) := by
-        rw [Polynomial.coeff_map, Polynomial.coeff_map]
-        exact (q.commutes (P.coeff r)).symm
-  -- Injectivity reflects the universal characteristic polynomial identity to the target.
-  have hCcharpoly : C.charpoly = P.map (algebraMap k H) := by
-    apply Polynomial.map_injective f.hom.toAlgHom.toRingHom hf
-    rw [← Matrix.charpoly_map]
-    -- Expose the local name for the mapped coefficient matrix.
-    change D.charpoly = _
-    rw [hDcharpoly]
-    rw [Polynomial.map_map]
-    congr 1
-    ext x
-    exact (f.hom.toAlgHom.commutes x).symm
-  -- Evaluating the reflected identity proves the required statement at an arbitrary target point.
-  have hgcharpoly :
-      (Comodule.endOfPoint M g.ofConv).charpoly =
-        P.map (algebraMap k (AlgebraicClosure k)) := by
-    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv)
-      (b.baseChange (AlgebraicClosure k)), Comodule.toMatrix_endOfPoint]
-    -- Expose the local name for the target coefficient matrix before applying `charpoly_map`.
-    change (C.map g.ofConv).charpoly = _
-    calc
-      (C.map g.ofConv).charpoly = C.charpoly.map g.ofConv.toRingHom :=
-        Matrix.charpoly_map C g.ofConv.toRingHom
-      _ = _ := by
-        rw [hCcharpoly, Polynomial.map_map]
-        congr 1
-        ext x
-        exact g.ofConv.commutes x
-  apply LinearMap.GeneralLinearGroup.isUnipotent_of_charpoly_eq (n := d)
-  have hcoe :
-      ((LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
-        Module.End _ _) =
-          Comodule.endOfPoint M g.ofConv :=
-    Comodule.pointsAction_toLinearMap M g
-  rw [hcoe]
-  exact hgcharpoly.trans (by simp [P])
 
 /-- The scheme-theoretic image of a reduced finite-type geometrically unipotent affine group is
 geometrically unipotent. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Image/Unipotent.lean
@@ -7,9 +7,12 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.FaithfullyFlat
+import Mathlib.LinearAlgebra.Charpoly.ToMatrix
+import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
+import TauCeti.RingTheory.FiniteType.PointSeparation
 
 /-!
-# Unipotence of faithfully flat affine group images
+# Unipotence of affine group images
 
 For a morphism `f : H ⟶ K` of commutative Hopf algebras, its scheme-theoretic image has coordinate
 algebra
@@ -17,14 +20,18 @@ algebra
 `CommHopfAlgCat.image f ⟶ K` finite type. If this inclusion is faithfully flat, every
 algebraically closed point of the image lifts to a point of `Spec K`.
 
-Unipotence is preserved when a point is precomposed with a Hopf-algebra morphism. It therefore
-descends from `Spec K` to the scheme-theoretic image. This supplies the geometric-point step in
-forming the product of two normal smooth unipotent closed subgroup schemes: after multiplication
-is realized as a faithfully flat morphism onto its image, the image is again geometrically
-unipotent.
+There are two ways to descend unipotence from `Spec K` to the image. A faithfully flat inclusion
+lifts every geometric point of the image to the source. More directly, when `K` is reduced and
+finite type, its geometric points separate the coefficients of the characteristic polynomial of
+every representation. The latter argument only needs the canonical inclusion to be injective,
+and hence applies to every scheme-theoretic image of a smooth unipotent affine group.
 
 ## Main declaration
 
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.of_injective_of_reduced`: geometric
+  unipotence descends along an injective coordinate morphism with reduced finite-type codomain.
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.image_of_reduced`: the image of a
+  reduced finite-type geometrically unipotent affine group is geometrically unipotent.
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.image_of_faithfullyFlat`: a
   faithfully flat finite-type affine group image has only unipotent geometric points when its
   source does.
@@ -33,24 +40,162 @@ unipotent.
 
 * A. Borel, *Linear Algebraic Groups*, Proposition 14.4, for the unipotent-radical application.
 
-This is the image specialization of the algebraically-closed-point bridge for Layer 5, "The
-unipotent radical", of the ReductiveGroups roadmap. The separate theorem that a homomorphism of
-affine groups is faithfully flat onto its scheme-theoretic image remains the input that discharges
-the hypothesis below.
+This is the image-unipotence step for Layer 5, "The unipotent radical", of the ReductiveGroups
+roadmap. In particular, it supplies the remaining geometric-unipotence input in the binary-product
+closure of connected normal smooth unipotent subgroup schemes.
 -/
 
 public section
 
 open CategoryTheory
+open scoped TensorProduct
 
 namespace TauCeti
 
-universe u v
+universe u v w x
 
 namespace geometricallyUnipotentPointsCommHopfAlgProperty
 
 variable {k : Type u} [Field k]
 variable {H K : _root_.CommHopfAlgCat.{v} k}
+
+attribute [local instance 1100] Module.Free.of_divisionRing
+
+private theorem coefficientMatrix_corestrict
+    {C D : Type v} {M : Type w} {ι : Type x}
+    [AddCommMonoid C] [Module k C] [Coalgebra k C]
+    [AddCommMonoid D] [Module k D] [Coalgebra k D]
+    [AddCommMonoid M] [Module k M] [Comodule k C M]
+    (b : Module.Basis ι k M) (f : C →ₗc[k] D) :
+    letI : Comodule k D M := Comodule.Corestrict f
+    Comodule.coefficientMatrix (C := D) b =
+      (Comodule.coefficientMatrix (C := C) b).map f := by
+  let _ : Comodule k D M := Comodule.Corestrict f
+  ext i j
+  rw [Comodule.coefficientMatrix_apply, Matrix.map_apply,
+    Comodule.coefficientMatrix_apply,
+    Comodule.matrixCoefficient_def, Comodule.matrixCoefficient_def,
+    Comodule.corestrict_coact_apply]
+  have h := LinearMap.congr_fun
+    (CoassocSimps.lid_comp_map (b.coord i) f.toLinearMap)
+    (Comodule.coact (R := k) (C := C) (M := M) (b j))
+  rw [TensorProduct.map_map, LinearMap.id_comp, LinearMap.comp_id]
+  -- `lid_comp_map` gives this naturality identity for the underlying linear map.
+  change _ = f.toLinearMap _
+  exact h
+
+/-- Geometric unipotence descends along an injective morphism of coordinate Hopf algebras whose
+codomain is reduced and finite type.
+
+Contravariantly, the morphism represents a schematically dense homomorphism from `Spec K` to
+`Spec H`. For a finite-dimensional `H`-comodule, every geometric point of `Spec K` makes the
+characteristic polynomial of the restricted action equal to `(X - 1) ^ n`. Point separation in
+the reduced algebra `K` gives the same identity for the universal coefficient matrix. Injectivity
+then reflects it to `H`, where evaluation proves that every geometric point of `Spec H` acts
+unipotently. -/
+theorem of_injective_of_reduced (f : H ⟶ K) (hf : Function.Injective f.hom)
+    [Algebra.FiniteType k K] [IsReduced K]
+    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k H := by
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hK ⊢
+  intro g
+  rw [HopfAlgebra.isUnipotentPoint_def]
+  intro M
+  let b := Module.Free.chooseBasis k M
+  let C := Comodule.coefficientMatrix (C := H) b
+  let D := C.map f.hom
+  let d := Module.finrank (AlgebraicClosure k) (AlgebraicClosure k ⊗[k] M)
+  let P : Polynomial k := (Polynomial.X - 1) ^ d
+  -- Point separation turns the characteristic polynomial identity at every source point into
+  -- an identity for the universal coefficient matrix over the source coordinate algebra.
+  have hDcharpoly : D.charpoly = P.map (algebraMap k K) := by
+    apply Polynomial.ext
+    intro r
+    apply TauCeti.eq_of_forall_algHom_apply_eq
+      (k := k) (K := AlgebraicClosure k)
+    intro q
+    let _ : Comodule k K M := Comodule.Corestrict f.hom.toCoalgHom
+    let N : FGComoduleCat.{u, v, u} k K := FGComoduleCat.of (R := k) (C := K) M
+    have hq := (HopfAlgebra.isUnipotentPoint_def (WithConv.toConv q)).mp
+      (hK (WithConv.toConv q)) N
+    have hqcharpoly : (Comodule.endOfPoint M q).charpoly =
+        P.map (algebraMap k (AlgebraicClosure k)) := by
+      have hcoe :
+          ((LinearMap.GeneralLinearGroup.ofLinearEquiv
+            (Comodule.pointsAction N (WithConv.toConv q))) : Module.End _ _) =
+              Comodule.endOfPoint M q :=
+        Comodule.pointsAction_toLinearMap N (WithConv.toConv q)
+      rw [← hcoe]
+      have hcharpoly := (LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly _).mp hq
+      have hd : Module.finrank (AlgebraicClosure k)
+          (AlgebraicClosure k ⊗[k] N) = d := rfl
+      rw [hd] at hcharpoly
+      exact hcharpoly.trans (by simp [P])
+    have hmatrix : D.map q =
+        LinearMap.toMatrix (b.baseChange (AlgebraicClosure k))
+          (b.baseChange (AlgebraicClosure k)) (Comodule.endOfPoint N q) := by
+      rw [Comodule.toMatrix_endOfPoint]
+      rw [coefficientMatrix_corestrict b f.hom.toCoalgHom]
+      -- Unfold the local names so `Matrix.map_map` sees the two successive coefficient maps.
+      change (C.map f.hom).map q = _
+      rw [Matrix.map_map]
+      ext i j
+      rfl
+    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint N q)
+      (b.baseChange (AlgebraicClosure k)), ← hmatrix] at hqcharpoly
+    calc
+      q (D.charpoly.coeff r) = (D.charpoly.map q).coeff r := by
+        exact (Polynomial.coeff_map q.toRingHom r).symm
+      _ = (D.map q).charpoly.coeff r :=
+        congrArg (fun p ↦ p.coeff r) (Matrix.charpoly_map D q.toRingHom).symm
+      _ = (P.map (algebraMap k (AlgebraicClosure k))).coeff r :=
+        congrArg (fun p ↦ p.coeff r) hqcharpoly
+      _ = q ((P.map (algebraMap k K)).coeff r) := by
+        rw [Polynomial.coeff_map, Polynomial.coeff_map]
+        exact (q.commutes (P.coeff r)).symm
+  -- Injectivity reflects the universal characteristic polynomial identity to the target.
+  have hCcharpoly : C.charpoly = P.map (algebraMap k H) := by
+    apply Polynomial.map_injective f.hom.toAlgHom.toRingHom hf
+    rw [← Matrix.charpoly_map]
+    -- Expose the local name for the mapped coefficient matrix.
+    change D.charpoly = _
+    rw [hDcharpoly]
+    rw [Polynomial.map_map]
+    congr 1
+    ext x
+    exact (f.hom.toAlgHom.commutes x).symm
+  -- Evaluating the reflected identity proves the required statement at an arbitrary target point.
+  have hgcharpoly :
+      (Comodule.endOfPoint M g.ofConv).charpoly =
+        P.map (algebraMap k (AlgebraicClosure k)) := by
+    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv)
+      (b.baseChange (AlgebraicClosure k)), Comodule.toMatrix_endOfPoint]
+    -- Expose the local name for the target coefficient matrix before applying `charpoly_map`.
+    change (C.map g.ofConv).charpoly = _
+    calc
+      (C.map g.ofConv).charpoly = C.charpoly.map g.ofConv.toRingHom :=
+        Matrix.charpoly_map C g.ofConv.toRingHom
+      _ = _ := by
+        rw [hCcharpoly, Polynomial.map_map]
+        congr 1
+        ext x
+        exact g.ofConv.commutes x
+  apply LinearMap.GeneralLinearGroup.isUnipotent_of_charpoly_eq (n := d)
+  have hcoe :
+      ((LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+        Module.End _ _) =
+          Comodule.endOfPoint M g.ofConv :=
+    Comodule.pointsAction_toLinearMap M g
+  rw [hcoe]
+  exact hgcharpoly.trans (by simp [P])
+
+/-- The scheme-theoretic image of a reduced finite-type geometrically unipotent affine group is
+geometrically unipotent. -/
+theorem image_of_reduced (f : H ⟶ K) [Algebra.FiniteType k K] [IsReduced K]
+    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k (CommHopfAlgCat.image f) :=
+  of_injective_of_reduced (CommHopfAlgCat.imageι f)
+    (CommHopfAlgCat.imageι_injective f) hK
 
 /-- The scheme-theoretic image of a finite-type geometrically unipotent affine group is
 geometrically unipotent when the source-to-image morphism is faithfully flat.

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Reduced.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+import Mathlib.LinearAlgebra.Charpoly.ToMatrix
+import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.PointAction
+import TauCeti.RingTheory.FiniteType.PointSeparation
+
+/-!
+# Unipotence under injective morphisms into reduced Hopf algebras
+
+An injective morphism `H ⟶ K` of coordinate Hopf algebras represents a schematically dense
+homomorphism `Spec K ⟶ Spec H`. When `K` is reduced and finite type, its geometric points separate
+elements. Applying this to the coefficients of the characteristic polynomial of every
+representation shows that geometric unipotence descends from `K` to `H`.
+
+## Main declaration
+
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.of_injective_of_reduced`: geometric
+  unipotence descends along an injective coordinate morphism with reduced finite-type codomain.
+
+## References
+
+* A. Borel, *Linear Algebraic Groups*, Proposition 14.4, for the unipotent-radical application.
+
+This supplies the reduced-source descent input for Layer 5, "The unipotent radical", of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u v
+
+namespace geometricallyUnipotentPointsCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+variable {H K : _root_.CommHopfAlgCat.{v} k}
+
+attribute [local instance 1100] Module.Free.of_divisionRing
+
+/-- Geometric unipotence descends along an injective morphism of coordinate Hopf algebras whose
+codomain is reduced and finite type.
+
+Contravariantly, the morphism represents a schematically dense homomorphism from `Spec K` to
+`Spec H`. For a finite-dimensional `H`-comodule, every geometric point of `Spec K` makes the
+characteristic polynomial of the restricted action equal to `(X - 1) ^ n`. Point separation in
+the reduced algebra `K` gives the same identity for the universal coefficient matrix. Injectivity
+then reflects it to `H`, where evaluation proves that every geometric point of `Spec H` acts
+unipotently. -/
+theorem of_injective_of_reduced (f : H ⟶ K) (hf : Function.Injective f.hom)
+    [Algebra.FiniteType k K] [IsReduced K]
+    (hK : geometricallyUnipotentPointsCommHopfAlgProperty k K) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k H := by
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff] at hK ⊢
+  intro g
+  rw [HopfAlgebra.isUnipotentPoint_def]
+  intro M
+  let b := Module.Free.chooseBasis k M
+  let C := Comodule.coefficientMatrix (C := H) b
+  let D := C.map f.hom
+  let d := Module.finrank (AlgebraicClosure k) (AlgebraicClosure k ⊗[k] M)
+  let P : Polynomial k := (Polynomial.X - 1) ^ d
+  -- Point separation turns the characteristic polynomial identity at every source point into
+  -- an identity for the universal coefficient matrix over the source coordinate algebra.
+  have hDcharpoly : D.charpoly = P.map (algebraMap k K) := by
+    apply Polynomial.ext
+    intro r
+    apply TauCeti.eq_of_forall_algHom_apply_eq
+      (k := k) (K := AlgebraicClosure k)
+    intro q
+    let _ : Comodule k K M := Comodule.Corestrict f.hom.toCoalgHom
+    let N : FGComoduleCat.{u, v, u} k K := FGComoduleCat.of (R := k) (C := K) M
+    have hq := (HopfAlgebra.isUnipotentPoint_def (WithConv.toConv q)).mp
+      (hK (WithConv.toConv q)) N
+    have hqcharpoly : (Comodule.endOfPoint M q).charpoly =
+        P.map (algebraMap k (AlgebraicClosure k)) := by
+      have hcoe :
+          ((LinearMap.GeneralLinearGroup.ofLinearEquiv
+            (Comodule.pointsAction N (WithConv.toConv q))) : Module.End _ _) =
+              Comodule.endOfPoint M q :=
+        Comodule.pointsAction_toLinearMap N (WithConv.toConv q)
+      rw [← hcoe]
+      have hcharpoly := (LinearMap.GeneralLinearGroup.isUnipotent_iff_charpoly _).mp hq
+      let e : N ≃ₗ[k] M := LinearEquiv.refl k M
+      have hd : Module.finrank (AlgebraicClosure k)
+          (AlgebraicClosure k ⊗[k] N) = d :=
+        LinearEquiv.finrank_eq (e.baseChange k (AlgebraicClosure k) N M)
+      rw [hd] at hcharpoly
+      exact hcharpoly.trans (by simp [P])
+    have hmatrix : D.map q =
+        LinearMap.toMatrix (b.baseChange (AlgebraicClosure k))
+          (b.baseChange (AlgebraicClosure k)) (Comodule.endOfPoint N q) := by
+      rw [Comodule.toMatrix_endOfPoint]
+      rw [Comodule.coefficientMatrix_corestrict b f.hom.toCoalgHom]
+      -- Unfold the local names so `Matrix.map_map` sees the two successive coefficient maps.
+      change (C.map f.hom).map q = _
+      rw [Matrix.map_map]
+      ext i j
+      rfl
+    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint N q)
+      (b.baseChange (AlgebraicClosure k)), ← hmatrix] at hqcharpoly
+    calc
+      q (D.charpoly.coeff r) = (D.charpoly.map q).coeff r := by
+        exact (Polynomial.coeff_map q.toRingHom r).symm
+      _ = (D.map q).charpoly.coeff r :=
+        congrArg (fun p ↦ p.coeff r) (Matrix.charpoly_map D q.toRingHom).symm
+      _ = (P.map (algebraMap k (AlgebraicClosure k))).coeff r :=
+        congrArg (fun p ↦ p.coeff r) hqcharpoly
+      _ = q ((P.map (algebraMap k K)).coeff r) := by
+        rw [Polynomial.coeff_map, Polynomial.coeff_map]
+        exact (q.commutes (P.coeff r)).symm
+  -- Injectivity reflects the universal characteristic polynomial identity to the target.
+  have hCcharpoly : C.charpoly = P.map (algebraMap k H) := by
+    apply Polynomial.map_injective f.hom.toAlgHom.toRingHom hf
+    rw [← Matrix.charpoly_map]
+    -- Expose the local name for the mapped coefficient matrix.
+    change D.charpoly = _
+    rw [hDcharpoly]
+    rw [Polynomial.map_map]
+    congr 1
+    ext x
+    exact (f.hom.toAlgHom.commutes x).symm
+  -- Evaluating the reflected identity proves the required statement at an arbitrary target point.
+  have hgcharpoly :
+      (Comodule.endOfPoint M g.ofConv).charpoly =
+        P.map (algebraMap k (AlgebraicClosure k)) := by
+    rw [← LinearMap.charpoly_toMatrix (Comodule.endOfPoint M g.ofConv)
+      (b.baseChange (AlgebraicClosure k)), Comodule.toMatrix_endOfPoint]
+    -- Expose the local name for the target coefficient matrix before applying `charpoly_map`.
+    change (C.map g.ofConv).charpoly = _
+    calc
+      (C.map g.ofConv).charpoly = C.charpoly.map g.ofConv.toRingHom :=
+        Matrix.charpoly_map C g.ofConv.toRingHom
+      _ = _ := by
+        rw [hCcharpoly, Polynomial.map_map]
+        congr 1
+        ext x
+        exact g.ofConv.commutes x
+  apply LinearMap.GeneralLinearGroup.isUnipotent_of_charpoly_eq (n := d)
+  have hcoe :
+      ((LinearMap.GeneralLinearGroup.ofLinearEquiv (Comodule.pointsAction M g)) :
+        Module.End _ _) =
+          Comodule.endOfPoint M g.ofConv :=
+    Comodule.pointsAction_toLinearMap M g
+  rw [hcoe]
+  exact hgcharpoly.trans (by simp [P])
+
+end geometricallyUnipotentPointsCommHopfAlgProperty
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Matrix.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Matrix.lean
@@ -5,8 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import Mathlib.RingTheory.Coalgebra.CoassocSimps
 public import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 public import Mathlib.RingTheory.HopfAlgebra.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule.Corestrict
 public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.Comul
 
 /-!
@@ -24,6 +26,8 @@ therefore a unit.
 ## Main declarations
 
 * `TauCeti.Comodule.coefficientMatrix`: the matrix of basis matrix coefficients.
+* `TauCeti.Comodule.coefficientMatrix_corestrict`: corestriction maps every coefficient entry
+  along the coalgebra morphism.
 * `TauCeti.Comodule.coact_basis_eq_sum_coefficientMatrix`: the coaction of a basis vector is the
   corresponding column of the coefficient matrix.
 * `TauCeti.Comodule.comul_coefficientMatrix_eq_sum` and
@@ -72,6 +76,25 @@ theorem coefficientMatrix_apply (b : Basis ι R M) (i j : ι) :
     coefficientMatrix (C := C) b i j =
       matrixCoefficient (R := R) (C := C) (b.coord i) (b j) := by
   rw [coefficientMatrix]
+
+variable {D : Type*} [AddCommMonoid D] [Module R D] [Coalgebra R D]
+
+/-- Corestricting a comodule along a coalgebra morphism maps that morphism over every entry of
+the coefficient matrix. -/
+@[simp]
+theorem coefficientMatrix_corestrict (b : Basis ι R M) (f : C →ₗc[R] D) :
+    letI : Comodule R D M := Corestrict f
+    coefficientMatrix (C := D) b = (coefficientMatrix (C := C) b).map f := by
+  let _ : Comodule R D M := Corestrict f
+  ext i j
+  rw [coefficientMatrix_apply, Matrix.map_apply, coefficientMatrix_apply,
+    matrixCoefficient_def, matrixCoefficient_def, corestrict_coact_apply]
+  have h := LinearMap.congr_fun
+    (CoassocSimps.lid_comp_map (b.coord i) f.toLinearMap)
+    (coact (R := R) (C := C) (M := M) (b j))
+  rw [TensorProduct.map_map, LinearMap.id_comp, LinearMap.comp_id]
+  change _ = f.toLinearMap _
+  exact h
 
 /-- The counit of a coefficient entry is the corresponding identity-matrix entry. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Matrix.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Matrix.lean
@@ -93,7 +93,6 @@ theorem coefficientMatrix_corestrict (b : Basis ι R M) (f : C →ₗc[R] D) :
     (CoassocSimps.lid_comp_map (b.coord i) f.toLinearMap)
     (coact (R := R) (C := C) (M := M) (b j))
   rw [TensorProduct.map_map, LinearMap.id_comp, LinearMap.comp_id]
-  change _ = f.toLinearMap _
   exact h
 
 /-- The counit of a coefficient entry is the corresponding identity-matrix entry. -/


### PR DESCRIPTION
This PR proves that geometric unipotence descends along an injective morphism of coordinate Hopf algebras when the codomain is reduced and finite type, and specializes the result to every scheme-theoretic image with such a source. It advances the `ReductiveGroups/README.md` Layer 5 milestone “The unipotent radical R_u(G),” specifically the prerequisite that the product of two connected normal smooth unipotent subgroup schemes is again unipotent.

For a finite-dimensional comodule, the proof compares its coefficient matrix before and after corestriction. Unipotence at every geometric source point makes the characteristic polynomial `(X - 1) ^ n`; point separation for a reduced finite-type algebra promotes this pointwise equality to the universal matrix, and injectivity reflects it to the image coordinate algebra. Applying the theorem to the canonical injective `imageι` supplies the geometric-unipotence part of the normal-product construction without requiring a faithfully-flat image theorem. The existing faithfully-flat result remains as the complementary route for nonreduced sources.

This is the missing geometric input alongside the normality and containment work in #4579 and the connectedness and smoothness work in #4588. After this PR, the binary-product prerequisite still needs those pieces assembled, after which maximal Lie dimension can show that the existing radical candidate contains every candidate and finish the Layer 5 construction.

The mathematical application follows Borel, *Linear Algebraic Groups*, Proposition 14.4; the proof itself reuses Mathlib's characteristic-polynomial API and Tau Ceti's comodule point-action and reduced finite-type point-separation infrastructure.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geometrically-unipotent-image-reduced-source"}-->

🤖 Prepared with Codex
