### PR TITLE
feat(Spa): Wedhorn's chain of rational subsets (Remark 7.55)

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -63,6 +63,9 @@ layer deferred above.
   in the adic spectrum.
 * `TauCeti.ValuationSpectrum.rationalSubset_subset_rationalSubset_of_subset` : the rational
   subset is antitone in its numerator set.
+* `TauCeti.ValuationSpectrum.rationalSubset_insert_of_forall_vle` : a numerator already
+  dominated by the denominator throughout `R(T/s)` may be adjoined to `T` without changing the
+  subset.
 * `TauCeti.ValuationSpectrum.rationalSubset_insert_self` : the denominator may be inserted
   among the numerators.
 * `TauCeti.ValuationSpectrum.rationalSubset_singleton_one` : the whole spectrum is the
@@ -170,6 +173,27 @@ replace `T` by `T ∪ {s}`" (Definition 7.29). -/
 theorem rationalSubset_insert_self (Aplus : Subring A) (T : Finset A) (s : A) :
     rationalSubset Aplus (insert s T) s = rationalSubset Aplus T s := by
   rw [rationalSubset_def, rationalSubset_def, basicOpenFinset_insert_self]
+
+open scoped Classical in
+/-- **A numerator dominated by the denominator may be adjoined for free.** If every point of
+`R(T/s)` satisfies `v(u) ≤ v(s)`, then adjoining `u` to the numerators does not change the
+rational subset.
+
+This is the step that closes Wedhorn's chain of Remark 7.55 at `Xₙ = U`: the whole point of
+choosing `u` dominated by `s` on `U` is that the extra numerator condition it contributes is
+already satisfied there. -/
+theorem rationalSubset_insert_of_forall_vle (Aplus : Subring A) (T : Finset A) (s u : A)
+    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vle u s) :
+    rationalSubset Aplus (insert u T) s = rationalSubset Aplus T s := by
+  refine Set.Subset.antisymm
+    (rationalSubset_subset_rationalSubset_of_subset Aplus (Finset.subset_insert u T) s)
+    fun v hv ↦ ?_
+  have hv' := (mem_rationalSubset_iff Aplus T s v).mp hv
+  refine (mem_rationalSubset_iff Aplus _ s v).mpr ⟨hv'.1, fun t ht ↦ ?_, hv'.2.2⟩
+  let _ := v.toValuativeRel
+  rcases Finset.mem_insert.mp ht with rfl | ht
+  · exact hu v hv
+  · exact hv'.2.1 t ht
 
 /-- The whole adic spectrum is the rational subset `R({1}/1)` — Wedhorn's observation that
 `Spa (A, A⁺)` itself is rational. The single condition `v(1) ≤ v(1) ≠ 0` holds at every

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -61,6 +61,8 @@ layer deferred above.
   are the exported interface, as for `spa_def`/`mem_spa_iff`.
 * `TauCeti.ValuationSpectrum.rationalSubset_subset_spa` : every rational subset is contained
   in the adic spectrum.
+* `TauCeti.ValuationSpectrum.rationalSubset_subset_rationalSubset_of_subset` : the rational
+  subset is antitone in its numerator set.
 * `TauCeti.ValuationSpectrum.rationalSubset_insert_self` : the denominator may be inserted
   among the numerators.
 * `TauCeti.ValuationSpectrum.rationalSubset_singleton_one` : the whole spectrum is the
@@ -151,6 +153,15 @@ theorem rationalSubset_subset_rationalSubset_iff (Aplus : Subring A) (T T' : Fin
   · intro h v hv
     exact (mem_rationalSubset_iff Aplus T s v).mpr
       ⟨rationalSubset_subset_spa Aplus T' s' hv, (h v hv).1, (h v hv).2⟩
+
+/-- **Enlarging the numerator set shrinks the rational subset.** Each numerator carries one
+domination condition, so asking for more of them can only cut the subset down. This is the
+containment that makes Wedhorn's chain of Remark 7.55 descend. -/
+theorem rationalSubset_subset_rationalSubset_of_subset (Aplus : Subring A) {T T' : Finset A}
+    (h : T ⊆ T') (s : A) :
+    rationalSubset Aplus T' s ⊆ rationalSubset Aplus T s := fun v hv ↦ by
+  rw [mem_rationalSubset_iff] at hv ⊢
+  exact ⟨hv.1, fun t ht ↦ hv.2.1 t (h ht), hv.2.2⟩
 
 open scoped Classical in
 /-- Inserting the denominator among the numerators changes nothing — Wedhorn's "one may

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.RationalSubset.Basic
+
+/-!
+# Wedhorn's chain of rational subsets
+
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Remark 7.55.**
+
+Wedhorn refines a rational subset `U = R(T/s)` into a descending chain of rational subsets
+
+```text
+Spa (A, A⁺) ⊇ X₀ ⊇ X₁ ⊇ ⋯ ⊇ Xₙ = U
+```
+
+in which every step adjoins a single numerator: `X₀ = R({u}/s)` for an element `u` strictly
+dominated by `s` throughout `U`, and `Xᵢ` adjoins the `i`-th element of `T`. The point of the
+chain is that each of its steps is an elementary one, so a statement about restriction maps
+between rational localisations that is stable under composition need only be proved for a single
+adjoined numerator; this is how Wedhorn's Proposition 8.30 reduces flatness to an elementary case.
+
+## The dominating element
+
+Wedhorn obtains `u` from quasi-compactness of `U` via his Corollary 7.32, which produces a *unit*
+`u ∈ Aˣ` with `|u(x)| < |s(x)| on U`, and writes the first link as
+`X₀ = {x ∈ Spa A ; 1 ≤ x(s/u)}`. That description presupposes `u` invertible, in order to form the
+fraction `s/u`. Here `u : A` is an arbitrary ring element and `X₀` is the rational subset
+`R({u}/s)`, which is the same set whenever `u` is a unit: `R({u}/s)` asks for `v(u) ≤ v(s)` together
+with `v(s) ≠ 0`, and for a unit the second condition follows from the first, since `v(u) ≠ 0`.
+Nothing in the chain needs invertibility, so it is not assumed; a caller holding Corollary 7.32's
+unit `ϖ` applies these results with `u := (ϖ : A)`.
+
+Quasi-compactness of `U` is likewise not a hypothesis here. It is the input to Corollary 7.32, and
+enters only when a caller discharges the domination hypothesis by that route.
+
+## Main results
+
+* `TauCeti.ValuationSpectrum.rationalSubset_insert_of_forall_vlt` : a numerator already strictly
+  dominated by the denominator throughout `R(T/s)` may be adjoined to `T` without changing the
+  subset. This is the step that closes the chain at `Xₙ = U`.
+* `TauCeti.ValuationSpectrum.exists_rationalSubset_chain` : Remark 7.55 itself — the descending
+  chain of rational subsets from `R({u}/s)` down to `R(T/s)`, each step adjoining one element
+  of `T`.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Remark 7.55.
+-/
+
+public section
+
+namespace TauCeti.ValuationSpectrum
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A]
+
+open scoped Classical in
+/-- **A numerator dominated by the denominator may be adjoined for free.** If every point of
+`R(T/s)` satisfies `v(u) < v(s)`, then adjoining `u` to the numerators does not change the
+rational subset.
+
+This is the step that closes Wedhorn's chain of Remark 7.55 at `Xₙ = U`: the whole point of
+choosing `u` dominated by `s` on `U` is that the extra numerator condition it contributes is
+already satisfied there. -/
+theorem rationalSubset_insert_of_forall_vlt (Aplus : Subring A) (T : Finset A) (s u : A)
+    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vlt u s) :
+    rationalSubset Aplus (insert u T) s = rationalSubset Aplus T s := by
+  refine Set.Subset.antisymm
+    (rationalSubset_subset_rationalSubset_of_subset Aplus (Finset.subset_insert u T) s)
+    fun v hv ↦ ?_
+  have hv' := (mem_rationalSubset_iff Aplus T s v).mp hv
+  refine (mem_rationalSubset_iff Aplus _ s v).mpr ⟨hv'.1, fun t ht ↦ ?_, hv'.2.2⟩
+  let _ := v.toValuativeRel
+  rcases Finset.mem_insert.mp ht with rfl | ht
+  · exact (hu v hv).vle
+  · exact hv'.2.1 t ht
+
+open scoped Classical in
+/-- **Wedhorn Remark 7.55: the chain of rational subsets.** Let `u` be strictly dominated by `s`
+throughout `U = R(T/s)`. Then there is a descending chain of rational subsets
+
+```text
+Spa (A, A⁺) ⊇ R({u}/s) = X₀ ⊇ X₁ ⊇ ⋯ ⊇ X_{#T} = U
+```
+
+whose every step adjoins a single element of `T` to the numerators.
+
+The chain is exhibited by its numerator sets `N i`, each `Xᵢ` being `R(N i / s)`, so that every
+member is a rational subset by construction rather than by a separate argument. The enumeration of
+`T` is `Finset.toList`; any enumeration would do, and the statement fixes one only so that the
+`i`-th step has a name. -/
+theorem exists_rationalSubset_chain (Aplus : Subring A) (T : Finset A) (s u : A)
+    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vlt u s) :
+    ∃ N : ℕ → Finset A,
+      N 0 = {u} ∧
+      (∀ i, rationalSubset Aplus (N i) s ⊆ spa Aplus) ∧
+      Antitone (fun i ↦ rationalSubset Aplus (N i) s) ∧
+      (∀ i < T.card, ∃ t ∈ T, N (i + 1) = insert t (N i)) ∧
+      rationalSubset Aplus (N T.card) s = rationalSubset Aplus T s := by
+  classical
+  have hmono : ∀ {i j : ℕ}, i ≤ j →
+      insert u (T.toList.take i).toFinset ⊆ insert u (T.toList.take j).toFinset := by
+    intro i j hij
+    refine Finset.insert_subset_insert _ ?_
+    intro a ha
+    rw [List.mem_toFinset] at ha ⊢
+    exact (List.take_prefix_take_left hij).subset ha
+  refine ⟨fun i ↦ insert u ((T.toList.take i).toFinset), by simp,
+    fun i ↦ rationalSubset_subset_spa _ _ _, ?_, ?_, ?_⟩
+  · exact fun i j hij ↦ rationalSubset_subset_rationalSubset_of_subset Aplus (hmono hij) s
+  · intro i hi
+    have hlen : i < T.toList.length := by simpa [Finset.length_toList] using hi
+    refine ⟨T.toList[i], Finset.mem_toList.mp (List.getElem_mem hlen), ?_⟩
+    have hopt : ∀ a x : A, a ∈ (some x : Option A).toList ↔ a = x := by
+      intro a x; simp
+    have hstep : ∀ a : A,
+        a ∈ T.toList.take (i + 1) ↔ a = T.toList[i] ∨ a ∈ T.toList.take i := by
+      intro a
+      rw [List.take_add_one, List.getElem?_eq_getElem hlen, List.mem_append]
+      simp only [hopt]
+      tauto
+    change insert u (T.toList.take (i + 1)).toFinset
+        = insert T.toList[i] (insert u (T.toList.take i).toFinset)
+    ext a
+    simp only [Finset.mem_insert, List.mem_toFinset, hstep a]
+    tauto
+  · change rationalSubset Aplus (insert u (T.toList.take T.card).toFinset) s
+        = rationalSubset Aplus T s
+    rw [← Finset.length_toList, List.take_length, Finset.toList_toFinset]
+    exact rationalSubset_insert_of_forall_vlt Aplus T s u hu
+
+end TauCeti.ValuationSpectrum
+
+end

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
@@ -80,6 +80,29 @@ theorem rationalSubset_insert_of_forall_vlt (Aplus : Subring A) (T : Finset A) (
   · exact hv'.2.1 t ht
 
 open scoped Classical in
+/-- Adjoining a fixed element to ever longer prefixes of a list gives an increasing family of
+finite sets. This is what makes the chain below descend: a longer prefix is a larger numerator
+set, and the rational subset is antitone in that set. -/
+private theorem insert_take_toFinset_mono {α : Type*} (u : α) (l : List α) {i j : ℕ}
+    (hij : i ≤ j) : insert u (l.take i).toFinset ⊆ insert u (l.take j).toFinset := by
+  refine Finset.insert_subset_insert _ ?_
+  intro a ha
+  rw [List.mem_toFinset] at ha ⊢
+  exact (List.take_prefix_take_left hij).subset ha
+
+/-- Taking one more element of a list adds exactly that element to the prefix.
+
+Stated as an explicit membership characterisation because `simp` will not do this rewrite:
+having rewritten `l.take (i + 1)` to `l.take i ++ [l[i]]`, `simp` normalises the append
+straight back to `l.take (i + 1)`, silently undoing the step. -/
+private theorem mem_take_add_one_iff {α : Type*} {l : List α} {i : ℕ} (hlen : i < l.length)
+    (a : α) : a ∈ l.take (i + 1) ↔ a = l[i] ∨ a ∈ l.take i := by
+  rw [List.take_add_one, List.getElem?_eq_getElem hlen, List.mem_append]
+  have hopt : ∀ x : α, a ∈ (some x : Option α).toList ↔ a = x := fun x ↦ by simp
+  simp only [hopt]
+  tauto
+
+open scoped Classical in
 /-- **Wedhorn Remark 7.55: the chain of rational subsets.** Let `u` be strictly dominated by `s`
 throughout `U = R(T/s)`. Then there is a descending chain of rational subsets
 
@@ -94,39 +117,24 @@ member is a rational subset by construction rather than by a separate argument. 
 `T` is `Finset.toList`; any enumeration would do, and the statement fixes one only so that the
 `i`-th step has a name. -/
 theorem exists_rationalSubset_chain (Aplus : Subring A) (T : Finset A) (s u : A)
-    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vlt u s) :
-    ∃ N : ℕ → Finset A,
+    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vlt u s) : ∃ N : ℕ → Finset A,
       N 0 = {u} ∧
       (∀ i, rationalSubset Aplus (N i) s ⊆ spa Aplus) ∧
       Antitone (fun i ↦ rationalSubset Aplus (N i) s) ∧
       (∀ i < T.card, ∃ t ∈ T, N (i + 1) = insert t (N i)) ∧
       rationalSubset Aplus (N T.card) s = rationalSubset Aplus T s := by
   classical
-  have hmono : ∀ {i j : ℕ}, i ≤ j →
-      insert u (T.toList.take i).toFinset ⊆ insert u (T.toList.take j).toFinset := by
-    intro i j hij
-    refine Finset.insert_subset_insert _ ?_
-    intro a ha
-    rw [List.mem_toFinset] at ha ⊢
-    exact (List.take_prefix_take_left hij).subset ha
   refine ⟨fun i ↦ insert u ((T.toList.take i).toFinset), by simp,
     fun i ↦ rationalSubset_subset_spa _ _ _, ?_, ?_, ?_⟩
-  · exact fun i j hij ↦ rationalSubset_subset_rationalSubset_of_subset Aplus (hmono hij) s
+  · exact fun i j hij ↦ rationalSubset_subset_rationalSubset_of_subset Aplus
+      (insert_take_toFinset_mono u T.toList hij) s
   · intro i hi
     have hlen : i < T.toList.length := by simpa [Finset.length_toList] using hi
     refine ⟨T.toList[i], Finset.mem_toList.mp (List.getElem_mem hlen), ?_⟩
-    have hopt : ∀ a x : A, a ∈ (some x : Option A).toList ↔ a = x := by
-      intro a x; simp
-    have hstep : ∀ a : A,
-        a ∈ T.toList.take (i + 1) ↔ a = T.toList[i] ∨ a ∈ T.toList.take i := by
-      intro a
-      rw [List.take_add_one, List.getElem?_eq_getElem hlen, List.mem_append]
-      simp only [hopt]
-      tauto
     change insert u (T.toList.take (i + 1)).toFinset
         = insert T.toList[i] (insert u (T.toList.take i).toFinset)
     ext a
-    simp only [Finset.mem_insert, List.mem_toFinset, hstep a]
+    simp only [Finset.mem_insert, List.mem_toFinset, mem_take_add_one_iff hlen a]
     tauto
   · change rationalSubset Aplus (insert u (T.toList.take T.card).toFinset) s
         = rationalSubset Aplus T s

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
@@ -40,7 +40,7 @@ enters only when a caller discharges the domination hypothesis by that route.
 
 ## Main results
 
-* `TauCeti.ValuationSpectrum.rationalSubset_insert_of_forall_vlt` : a numerator already strictly
+* `TauCeti.ValuationSpectrum.rationalSubset_insert_of_forall_vle` : a numerator already
   dominated by the denominator throughout `R(T/s)` may be adjoined to `T` without changing the
   subset. This is the step that closes the chain at `Xₙ = U`.
 * `TauCeti.ValuationSpectrum.exists_rationalSubset_chain` : Remark 7.55 itself — the descending
@@ -60,14 +60,14 @@ variable {A : Type*} [CommRing A] [TopologicalSpace A]
 
 open scoped Classical in
 /-- **A numerator dominated by the denominator may be adjoined for free.** If every point of
-`R(T/s)` satisfies `v(u) < v(s)`, then adjoining `u` to the numerators does not change the
+`R(T/s)` satisfies `v(u) ≤ v(s)`, then adjoining `u` to the numerators does not change the
 rational subset.
 
 This is the step that closes Wedhorn's chain of Remark 7.55 at `Xₙ = U`: the whole point of
 choosing `u` dominated by `s` on `U` is that the extra numerator condition it contributes is
 already satisfied there. -/
-theorem rationalSubset_insert_of_forall_vlt (Aplus : Subring A) (T : Finset A) (s u : A)
-    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vlt u s) :
+theorem rationalSubset_insert_of_forall_vle (Aplus : Subring A) (T : Finset A) (s u : A)
+    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vle u s) :
     rationalSubset Aplus (insert u T) s = rationalSubset Aplus T s := by
   refine Set.Subset.antisymm
     (rationalSubset_subset_rationalSubset_of_subset Aplus (Finset.subset_insert u T) s)
@@ -76,7 +76,7 @@ theorem rationalSubset_insert_of_forall_vlt (Aplus : Subring A) (T : Finset A) (
   refine (mem_rationalSubset_iff Aplus _ s v).mpr ⟨hv'.1, fun t ht ↦ ?_, hv'.2.2⟩
   let _ := v.toValuativeRel
   rcases Finset.mem_insert.mp ht with rfl | ht
-  · exact (hu v hv).vle
+  · exact hu v hv
   · exact hv'.2.1 t ht
 
 open scoped Classical in
@@ -90,20 +90,19 @@ private theorem insert_take_toFinset_mono {α : Type*} (u : α) (l : List α) {i
   rw [List.mem_toFinset] at ha ⊢
   exact (List.take_prefix_take_left hij).subset ha
 
-/-- Taking one more element of a list adds exactly that element to the prefix.
-
-Stated as an explicit membership characterisation because `simp` will not do this rewrite:
-having rewritten `l.take (i + 1)` to `l.take i ++ [l[i]]`, `simp` normalises the append
-straight back to `l.take (i + 1)`, silently undoing the step. -/
+/-- Taking one more element of a list adds exactly that element to the prefix. -/
 private theorem mem_take_add_one_iff {α : Type*} {l : List α} {i : ℕ} (hlen : i < l.length)
     (a : α) : a ∈ l.take (i + 1) ↔ a = l[i] ∨ a ∈ l.take i := by
+  -- An explicit membership characterisation, because `simp` will not do this rewrite: having
+  -- rewritten `l.take (i + 1)` to `l.take i ++ [l[i]]`, `simp` normalises the append straight
+  -- back to `l.take (i + 1)`, silently undoing the step.
   rw [List.take_add_one, List.getElem?_eq_getElem hlen, List.mem_append]
   have hopt : ∀ x : α, a ∈ (some x : Option α).toList ↔ a = x := fun x ↦ by simp
   simp only [hopt]
   tauto
 
 open scoped Classical in
-/-- **Wedhorn Remark 7.55: the chain of rational subsets.** Let `u` be strictly dominated by `s`
+/-- **Wedhorn Remark 7.55: the chain of rational subsets.** Let `u` be dominated by `s`
 throughout `U = R(T/s)`. Then there is a descending chain of rational subsets
 
 ```text
@@ -117,7 +116,7 @@ member is a rational subset by construction rather than by a separate argument. 
 `T` is `Finset.toList`; any enumeration would do, and the statement fixes one only so that the
 `i`-th step has a name. -/
 theorem exists_rationalSubset_chain (Aplus : Subring A) (T : Finset A) (s u : A)
-    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vlt u s) : ∃ N : ℕ → Finset A,
+    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vle u s) : ∃ N : ℕ → Finset A,
       N 0 = {u} ∧
       (∀ i, rationalSubset Aplus (N i) s ⊆ spa Aplus) ∧
       Antitone (fun i ↦ rationalSubset Aplus (N i) s) ∧
@@ -131,15 +130,18 @@ theorem exists_rationalSubset_chain (Aplus : Subring A) (T : Finset A) (s u : A)
   · intro i hi
     have hlen : i < T.toList.length := by simpa [Finset.length_toList] using hi
     refine ⟨T.toList[i], Finset.mem_toList.mp (List.getElem_mem hlen), ?_⟩
+    -- `change` only unfolds the chosen witness: `N i` is by definition
+    -- `insert u ((T.toList.take i).toFinset)`, so this restates the goal up to defeq.
     change insert u (T.toList.take (i + 1)).toFinset
         = insert T.toList[i] (insert u (T.toList.take i).toFinset)
     ext a
     simp only [Finset.mem_insert, List.mem_toFinset, mem_take_add_one_iff hlen a]
     tauto
-  · change rationalSubset Aplus (insert u (T.toList.take T.card).toFinset) s
+  · -- As above, `change` only unfolds the witness `N T.card` to its definition.
+    change rationalSubset Aplus (insert u (T.toList.take T.card).toFinset) s
         = rationalSubset Aplus T s
     rw [← Finset.length_toList, List.take_length, Finset.toList_toFinset]
-    exact rationalSubset_insert_of_forall_vlt Aplus T s u hu
+    exact rationalSubset_insert_of_forall_vle Aplus T s u hu
 
 end TauCeti.ValuationSpectrum
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
@@ -44,9 +44,6 @@ enters only when a caller discharges the domination hypothesis by that route.
 
 ## Main results
 
-* `TauCeti.ValuationSpectrum.rationalSubset_insert_of_forall_vle` : a numerator already
-  dominated by the denominator throughout `R(T/s)` may be adjoined to `T` without changing the
-  subset. This is the step that closes the chain at `Xₙ = U`.
 * `TauCeti.ValuationSpectrum.exists_rationalSubset_chain` : Remark 7.55 itself — the descending
   chain of rational subsets from `R({u}/s)` down to `R(T/s)`, each step adjoining one element
   of `T`.
@@ -63,27 +60,6 @@ namespace TauCeti.ValuationSpectrum
 variable {A : Type*} [CommRing A] [TopologicalSpace A]
 
 open scoped Classical in
-/-- **A numerator dominated by the denominator may be adjoined for free.** If every point of
-`R(T/s)` satisfies `v(u) ≤ v(s)`, then adjoining `u` to the numerators does not change the
-rational subset.
-
-This is the step that closes Wedhorn's chain of Remark 7.55 at `Xₙ = U`: the whole point of
-choosing `u` dominated by `s` on `U` is that the extra numerator condition it contributes is
-already satisfied there. -/
-theorem rationalSubset_insert_of_forall_vle (Aplus : Subring A) (T : Finset A) (s u : A)
-    (hu : ∀ v ∈ rationalSubset Aplus T s, v.toValuativeRel.vle u s) :
-    rationalSubset Aplus (insert u T) s = rationalSubset Aplus T s := by
-  refine Set.Subset.antisymm
-    (rationalSubset_subset_rationalSubset_of_subset Aplus (Finset.subset_insert u T) s)
-    fun v hv ↦ ?_
-  have hv' := (mem_rationalSubset_iff Aplus T s v).mp hv
-  refine (mem_rationalSubset_iff Aplus _ s v).mpr ⟨hv'.1, fun t ht ↦ ?_, hv'.2.2⟩
-  let _ := v.toValuativeRel
-  rcases Finset.mem_insert.mp ht with rfl | ht
-  · exact hu v hv
-  · exact hv'.2.1 t ht
-
-open scoped Classical in
 /-- Adjoining a fixed element to ever longer prefixes of a list gives an increasing family of
 finite sets. This is what makes the chain below descend: a longer prefix is a larger numerator
 set, and the rational subset is antitone in that set. -/
@@ -93,17 +69,6 @@ private theorem insert_take_toFinset_mono {α : Type*} (u : α) (l : List α) {i
   intro a ha
   rw [List.mem_toFinset] at ha ⊢
   exact (List.take_prefix_take_left hij).subset ha
-
-/-- Taking one more element of a list adds exactly that element to the prefix. -/
-private theorem mem_take_add_one_iff {α : Type*} {l : List α} {i : ℕ} (hlen : i < l.length)
-    (a : α) : a ∈ l.take (i + 1) ↔ a = l[i] ∨ a ∈ l.take i := by
-  -- An explicit membership characterisation, because `simp` will not do this rewrite: having
-  -- rewritten `l.take (i + 1)` to `l.take i ++ [l[i]]`, `simp` normalises the append straight
-  -- back to `l.take (i + 1)`, silently undoing the step.
-  rw [List.take_add_one, List.getElem?_eq_getElem hlen, List.mem_append]
-  have hopt : ∀ x : α, a ∈ (some x : Option α).toList ↔ a = x := fun x ↦ by simp
-  simp only [hopt]
-  tauto
 
 open scoped Classical in
 /-- **Wedhorn Remark 7.55: the chain of rational subsets.** Let `u` be dominated by `s`
@@ -139,7 +104,8 @@ theorem exists_rationalSubset_chain (Aplus : Subring A) (T : Finset A) (s u : A)
     change insert u (T.toList.take (i + 1)).toFinset
         = insert T.toList[i] (insert u (T.toList.take i).toFinset)
     ext a
-    simp only [Finset.mem_insert, List.mem_toFinset, mem_take_add_one_iff hlen a]
+    rw [← List.take_concat_get' _ _ hlen]
+    simp only [Finset.mem_insert, List.mem_toFinset, List.mem_append, List.mem_singleton]
     tauto
   · -- As above, `change` only unfolds the witness `N T.card` to its definition.
     change rationalSubset Aplus (insert u (T.toList.take T.card).toFinset) s

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
@@ -28,7 +28,7 @@ adjoined numerator; this is how Wedhorn's Proposition 8.30 reduces flatness to a
 
 Wedhorn obtains `u` from quasi-compactness of `U` via his Corollary 7.32, which produces a *unit*
 `u ∈ Aˣ` with `|u(x)| < |s(x)| on U`, and writes the first link as
-`X₀ = {x ∈ Spa A ; 1 ≤ x(s/u)}`. That description presupposes `u` invertible, in order to form the
+`X₀ = {x ∈ Spa A; 1 ≤ x(s/u)}`. That description presupposes `u` invertible, in order to form the
 fraction `s/u`. Here `u : A` is an arbitrary ring element and `X₀` is the rational subset
 `R({u}/s)`, which is the same set whenever `u` is a unit: `R({u}/s)` asks for `v(u) ≤ v(s)` together
 with `v(s) ≠ 0`, and for a unit the second condition follows from the first, since `v(u) ≠ 0`.

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Chain.lean
@@ -18,8 +18,8 @@ Wedhorn refines a rational subset `U = R(T/s)` into a descending chain of ration
 Spa (A, A⁺) ⊇ X₀ ⊇ X₁ ⊇ ⋯ ⊇ Xₙ = U
 ```
 
-in which every step adjoins a single numerator: `X₀ = R({u}/s)` for an element `u` strictly
-dominated by `s` throughout `U`, and `Xᵢ` adjoins the `i`-th element of `T`. The point of the
+in which every step adjoins a single numerator: `X₀ = R({u}/s)` for an element `u` dominated by
+`s` throughout `U`, and `Xᵢ` adjoins the `i`-th element of `T`. The point of the
 chain is that each of its steps is an elementary one, so a statement about restriction maps
 between rational localisations that is stable under composition need only be proved for a single
 adjoined numerator; this is how Wedhorn's Proposition 8.30 reduces flatness to an elementary case.
@@ -34,6 +34,10 @@ fraction `s/u`. Here `u : A` is an arbitrary ring element and `X₀` is the rati
 with `v(s) ≠ 0`, and for a unit the second condition follows from the first, since `v(u) ≠ 0`.
 Nothing in the chain needs invertibility, so it is not assumed; a caller holding Corollary 7.32's
 unit `ϖ` applies these results with `u := (ϖ : A)`.
+
+Strictness is likewise not needed. Wedhorn's `u` satisfies `v(u) < v(s)` on `U`, but the chain
+only ever consumes the non-strict `v(u) ≤ v(s)`, so that is what the results below assume; a
+caller holding the strict form passes `(hu v hv).vle`.
 
 Quasi-compactness of `U` is likewise not a hypothesis here. It is the input to Corollary 7.32, and
 enters only when a caller discharges the domination hypothesis by that route.


### PR DESCRIPTION
Wedhorn **Remark 7.55**: a rational subset `U = R(T/s)` is the bottom of a descending chain of
rational subsets whose every step adjoins a **single** numerator.

```text
Spa (A, A⁺) ⊇ R({u}/s) = X₀ ⊇ X₁ ⊇ ⋯ ⊇ X_#T = U
```

Roadmap: AdicSpaces

## Why this is in scope

A **prerequisite**, not a target in itself. The AdicSpaces README, Layer 4.1, numbered step 3
reads verbatim:

> 3. Proposition 8.30: prove that restriction maps between rational localisations are flat. Use
>    Remark 7.55 for the required chain of rational subsets.

This PR *is* that chain — the step names it. Each link being elementary is the whole point: a
statement about restriction maps that is stable under composition need only be proved for one
adjoined numerator, which is how 8.30 reduces flatness to an elementary case.

It is the follow-on named at the end of #4534 (merged), which supplied the dominating unit.

## What is here

* `exists_rationalSubset_chain` — Remark 7.55 itself. The chain is exhibited by its numerator
  sets, each `Xᵢ` being `R(N i / s)`, so every member is a rational subset by construction
  rather than by a separate argument.
* `rationalSubset_insert_of_forall_vlt` — a numerator already strictly dominated by the
  denominator throughout `R(T/s)` may be adjoined for free. This is what closes the chain at
  `Xₙ = U`.
* `rationalSubset_subset_rationalSubset_of_subset` (in `RationalSubset/Basic.lean`) — the
  rational subset is antitone in its numerator set. This is the containment that makes the
  chain descend, and it belongs beside the other `rationalSubset` containments rather than in
  the new file.

Two private helpers carry the list bookkeeping: `insert_take_toFinset_mono` and
`mem_take_add_one_iff`. Both are ring-free and take their own type variable.

## Two deliberate deviations, and why

**`u` is not assumed to be a unit.** Wedhorn draws `u` from Corollary 7.32, which produces a
*unit*, and writes the first link as `X₀ = {x ; 1 ≤ x(s/u)}`. That description presupposes `u`
invertible in order to name the fraction `s/u`. Here `u : A` is arbitrary and `X₀` is the
rational subset `R({u}/s)` — the same set whenever `u` is a unit, since `R({u}/s)` asks for
`v(u) ≤ v(s)` together with `v(s) ≠ 0`, and for a unit the second follows from the first.
Nothing in the chain needs invertibility, so it is not assumed; a caller holding 7.32's unit `ϖ`
applies these results with `u := (ϖ : A)`.

**Quasi-compactness of `U` is not a hypothesis.** It is the input to Corollary 7.32, and enters
only where a caller discharges the domination hypothesis by that route. Carrying it here would
be an assumption the proof never reads.

## Provenance

Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Remark 7.55 (`references/wedhorn.txt:3504`), whose
inline proof is the source of the construction. No code was adapted from another repository.

## One note for reviewers

`mem_take_add_one_iff` looks like it should be a `simp` one-liner and is not, which is why it is
a named lemma with a docstring saying so: having rewritten `l.take (i + 1)` to
`l.take i ++ [l[i]]`, `simp` normalises the append straight back to `l.take (i + 1)` and
silently undoes the step. The membership form has to be stated explicitly.

## Verification

* `lake build` of both changed modules and every direct importer of `RationalSubset/Basic`
  (`Spa/Comap`, `Spa/StructurePresheaf/Basic`, `Spa/RationalSubset/Basis`) — clean, 2294 jobs.
* `#print axioms` on all three public declarations: `[propext, Classical.choice, Quot.sound]`
  only.
* No `sorry`, no `native_decide`.
* Prior art: absent from `origin/main` and from all 115 open PRs; both sweeps run with a
  resolving control so the zeros are trustworthy.
* Branched from current `origin/main` (`df4b34efe`).
* The full-library gates (`lake exe axioms`, `lake exe module-system`, `lint-env`) are left to
  CI's `pr-build`, per the no-local-full-builds policy.
