### PR TITLE
feat(HeckeRing/GLn): the leading elementary-divisor vector of a Hecke monomial

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/Basic.lean
@@ -23,6 +23,8 @@ here.
 
 ## Main definitions
 
+* `HeckeRing.GLn.heckeGenExponent k` — the exponent vector of the `k`-th generator's diagonal,
+  `0` on the first `n - 1 - k` positions and `1` on the last `k + 1`.
 * `HeckeRing.GLn.heckeGen k` — the `k`-th generator `T(1, …, 1, p, …, p)`, with `k + 1` entries
   equal to `p`.
 * `HeckeRing.GLn.evalHom` — evaluation of `ℤ[X₁, …, Xₙ]` at the generators, into the ambient
@@ -86,6 +88,19 @@ section TGen
 
 variable (p : ℕ) (hp : p.Prime)
 
+/-- The exponent vector of the `k`-th generator's diagonal: `0` on the first `n - 1 - k`
+positions and `1` on the last `k + 1`, so that `heckeGenDiag n p k` is `p` raised to it
+entrywise (`heckeGenDiag_eq_primePowDiag`). -/
+def heckeGenExponent (k : Fin n) : Fin n → ℕ :=
+  fun i ↦ if (i : ℕ) < n - 1 - (k : ℕ) then 0 else 1
+
+/-- Defining equation for the sealed definition `heckeGenExponent`. -/
+@[simp]
+lemma heckeGenExponent_apply (k : Fin n) (i : Fin n) :
+    heckeGenExponent n k i = if (i : ℕ) < n - 1 - (k : ℕ) then 0 else 1 :=
+  -- `(rfl)` rather than `rfl`: see `heckeGenDiag_apply` below.
+  (rfl)
+
 /-- The diagonal for the k-th generator: `(1,...,1,p,...,p)` with `n-1-k` ones
     followed by `k+1` entries of `p`. Here `k : Fin n`, giving `n` generators. -/
 def heckeGenDiag (k : Fin n) : Fin n → ℕ :=
@@ -104,19 +119,18 @@ lemma heckeGenDiag_apply (k : Fin n) (i : Fin n) :
 lemma heckeGenDiag_one_eq_const (p : ℕ) : heckeGenDiag 1 p (0 : Fin 1) = fun _ ↦ p := by
   funext i; simp [heckeGenDiag_apply]
 
-/-- The heckeGen diagonal has p-power entries (each entry is 1 = p^0 or p = p^1). -/
+/-- The heckeGen diagonal has p-power entries (each entry is 1 = p^0 or p = p^1): it is `p`
+raised entrywise to `heckeGenExponent n k`. -/
 lemma heckeGenDiag_eq_primePowDiag (k : Fin n) :
-    heckeGenDiag n p k =
-    primePowDiag n p (fun i ↦ if (i : ℕ) < n - 1 - (k : ℕ) then 0 else 1) := by
+    heckeGenDiag n p k = primePowDiag n p (heckeGenExponent n k) := by
   funext i
-  simp only [heckeGenDiag_apply, primePowDiag_apply]
+  simp only [heckeGenDiag_apply, primePowDiag_apply, heckeGenExponent_apply]
   split_ifs <;> simp
 
 /-- The exponent function for heckeGen is monotone. -/
-lemma heckeGen_exp_monotone (k : Fin n) :
-    Monotone (fun i : Fin n ↦ if (i : ℕ) < n - 1 - (k : ℕ) then 0 else 1) := by
+lemma heckeGenExponent_monotone (k : Fin n) : Monotone (heckeGenExponent n k) := by
   intro i j hij
-  simp only
+  simp only [heckeGenExponent_apply]
   split_ifs <;> omega
 
 variable [NeZero n]
@@ -133,11 +147,10 @@ lemma heckeGen_def (k : Fin n) : heckeGen n p k = diagElem (heckeGenDiag n p k) 
 omit hp in
 /-- Each generator lies in the `p`-local subsemiring `R_p`. -/
 lemma heckeGen_mem_pLocalSubring (k : Fin n) : heckeGen n p k ∈ pLocalSubring n p := by
-  have h_eq : heckeGen n p k =
-      diagElem (primePowDiag n p (fun i ↦ if (i : ℕ) < n - 1 - (k : ℕ) then 0 else 1)) :=
+  have h_eq : heckeGen n p k = diagElem (primePowDiag n p (heckeGenExponent n k)) :=
     congrArg diagElem (heckeGenDiag_eq_primePowDiag n p k)
   rw [h_eq]
-  exact diagElem_primePowDiag_mem_pLocalSubring n p _ (heckeGen_exp_monotone n k)
+  exact diagElem_primePowDiag_mem_pLocalSubring n p _ (heckeGenExponent_monotone n k)
 
 omit hp
 

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/LeadingExponent.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/LeadingExponent.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GLn.PolynomialRing.Basic
+
+/-!
+# The leading elementary-divisor vector of a Hecke monomial
+
+Towards **Shimura's Theorem 3.20** at general `n`: the `p`-local Hecke ring `pLocalSubring` is
+the polynomial ring `ℤ[X₁, …, Xₙ]` on the diagonal prime cosets `heckeGen k = T(1, …, 1, p, …, p)`.
+The injectivity half is a leading-term argument. Multiplying double cosets multiplies their
+elementary divisors "up to lower terms", so the monomial `∏ k, heckeGen k ^ e k` has a
+distinguished term, the diagonal coset whose elementary divisors are the products of those of the
+factors, and the argument is that this leading term determines the exponent vector `e`.
+
+This file is the combinatorial half of that argument: the exponent vector `leadingExponent e` of
+that distinguished diagonal — entry `i` counts, with multiplicity `e k`, the generators whose
+diagonal carries `p` in position `i`, which are the `k` with `n - 1 - i ≤ k` — together with the
+properties the leading-term argument consumes, above all that the exponents are recovered from it.
+
+## Main definitions
+
+* `HeckeRing.GLn.leadingExponent`: the exponent vector of the leading elementary-divisor diagonal
+  of the Hecke monomial with exponents `e`, as the suffix sums `i ↦ ∑ k ≥ n - 1 - i, e k`.
+
+## Main results
+
+* `HeckeRing.GLn.leadingExponent_injective`: **the exponents of a Hecke monomial are recovered
+  from its leading elementary-divisor vector.** Position `n - 1 - k` is the suffix sum
+  `∑ k' ≥ k, e k'` (`HeckeRing.GLn.leadingExponent_rev`), so consecutive entries differ by one
+  exponent.
+* `HeckeRing.GLn.isDvdChain_primePowDiag_leadingExponent`: the vector is monotone
+  (`HeckeRing.GLn.monotone_leadingExponent`), so the leading diagonal `T(p ^ leadingExponent e)`
+  is a divisibility chain — for `0 < p` a canonical diagonal, by `primePowDiag_pos`.
+* `HeckeRing.GLn.primePowDiag_leadingExponent_single`: on the generator `X k` the leading
+  diagonal is `heckeGenDiag k` itself; `HeckeRing.GLn.leadingExponent_add` and `primePowDiag_add`
+  then give the leading diagonal of a product of monomials as the product of theirs.
+* `HeckeRing.GLn.sum_leadingExponent`: the weight `∑ k, (k + 1) * e k` of the leading diagonal,
+  the `p`-adic valuation of its determinant.
+
+## Implementation notes
+
+The other half of the leading-term argument — that the leading coset occurs in the monomial with
+coefficient `1` and every other coset of its support lies below it — is the triangular expansion,
+and is not proved here. At `n = 1, 2` Theorem 3.20 is `PolynomialRing/Injective.lean`, by direct
+computation; `leadingExponent_fin_two` is the sanity check that at `n = 2` this vector is
+`![e 1, e 0 + e 1]`, the exponent pattern of the leading coset `T(p ^ e 1, p ^ (e 0 + e 1))` of
+that computation (which is not rerouted through it).
+
+This is original work filling the general-`n` gap the roadmap records: the AINTLIB source
+(`LeanModularForms/HeckeRIngs/GLn/PolynomialRing.lean`) proves Theorem 3.20 at `n = 1, 2` only and
+has no general-`n` leading-term device.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.2, Theorem 3.20.
+-/
+
+public section
+
+open Finset
+
+namespace HeckeRing.GLn
+
+variable {n : ℕ}
+
+/-- The exponent vector of the leading elementary-divisor diagonal of the Hecke monomial
+`∏ k, heckeGen k ^ e k`: entry `i` counts, with multiplicity `e k`, the generators `heckeGen k`
+whose diagonal `heckeGenDiag k` carries `p` in position `i` — those with `n - 1 - i ≤ k`, i.e.
+`Fin.rev i ≤ k` — so it is the suffix sum of `e` from `Fin.rev i`. -/
+def leadingExponent (e : Fin n → ℕ) : Fin n → ℕ :=
+  fun i ↦ ∑ k ∈ Ici (Fin.rev i), e k
+
+/-- Defining equation for the sealed definition `leadingExponent`. -/
+lemma leadingExponent_apply (e : Fin n → ℕ) (i : Fin n) :
+    leadingExponent e i = ∑ k ∈ Ici (Fin.rev i), e k :=
+  (rfl)
+
+/-- The empty monomial has the trivial leading diagonal. -/
+@[simp]
+lemma leadingExponent_zero : leadingExponent (0 : Fin n → ℕ) = 0 := by
+  ext i
+  simp [leadingExponent_apply]
+
+/-- The leading exponent vector is additive; with `primePowDiag_add` this says the leading
+diagonal of a product of monomials is the entrywise product of their leading diagonals. -/
+lemma leadingExponent_add (e f : Fin n → ℕ) :
+    leadingExponent (e + f) = leadingExponent e + leadingExponent f := by
+  ext i
+  simp [leadingExponent_apply, Finset.sum_add_distrib]
+
+/-- Read from the last position backwards, the leading exponent vector is the suffix sums of the
+exponents: position `n - 1 - k` sees exactly the generators `k' ≥ k`. -/
+lemma leadingExponent_rev (e : Fin n → ℕ) (k : Fin n) :
+    leadingExponent e (Fin.rev k) = ∑ k' ∈ Ici k, e k' := by
+  rw [leadingExponent_apply, Fin.rev_rev]
+
+/-- On a single generator, the leading exponent vector is that generator's own `p`-exponent
+pattern: `0` on the first `n - 1 - k` positions and `1` on the last `k + 1`. -/
+lemma leadingExponent_single (k : Fin n) : leadingExponent (Pi.single k 1) =
+    fun i : Fin n ↦ if (i : ℕ) < n - 1 - (k : ℕ) then 0 else 1 := by
+  ext i
+  rw [leadingExponent_apply, Finset.sum_pi_single']
+  simp only [Finset.mem_Ici, Fin.le_iff_val_le_val, Fin.val_rev]
+  split_ifs <;> omega
+
+/-- The leading diagonal of the generator `heckeGen k` is its defining diagonal `heckeGenDiag k`. -/
+lemma primePowDiag_leadingExponent_single (p : ℕ) (k : Fin n) :
+    primePowDiag n p (leadingExponent (Pi.single k 1)) = heckeGenDiag n p k := by
+  rw [leadingExponent_single, heckeGenDiag_eq_primePowDiag]
+
+/-- The leading exponent vector is monotone: a later position sees every generator an earlier one
+does. -/
+lemma monotone_leadingExponent (e : Fin n → ℕ) : Monotone (leadingExponent e) := fun _ _ hij ↦
+  Finset.sum_le_sum_of_subset (Finset.Ici_subset_Ici.2 (Fin.rev_le_rev.2 hij))
+
+/-- The leading diagonal `T(p ^ leadingExponent e)` is a divisibility chain; together with
+`primePowDiag_pos`, for `0 < p` it is a canonical diagonal coset. -/
+lemma isDvdChain_primePowDiag_leadingExponent (p : ℕ) (e : Fin n → ℕ) :
+    IsDvdChain (primePowDiag n p (leadingExponent e)) :=
+  isDvdChain_primePowDiag n p _ (monotone_leadingExponent e)
+
+/-- A vector on `Fin n` is determined by its suffix sums: each entry is the difference of two
+consecutive ones, the last suffix sum being the last entry itself. -/
+private lemma sum_Ici_injective :
+    Function.Injective fun (e : Fin n → ℕ) (k : Fin n) ↦ ∑ k' ∈ Ici k, e k' := by
+  intro e f h
+  funext k
+  have hk := congr_fun h k
+  simp only at hk
+  rw [← Finset.add_sum_Ioi_eq_sum_Ici, ← Finset.add_sum_Ioi_eq_sum_Ici] at hk
+  cases n with
+  | zero => exact k.elim0
+  | succ m =>
+    cases k using Fin.lastCases with
+    | last =>
+      have hIoi : Ioi (Fin.last m) = ∅ := Finset.Ioi_eq_empty.2 fun x _ ↦ Fin.le_last x
+      simpa [hIoi] using hk
+    | cast j =>
+      have hIoi : Ioi (Fin.castSucc j) = Ici j.succ := by
+        ext x
+        simp [Fin.castSucc_lt_iff_succ_le]
+      have hs := congr_fun h j.succ
+      simp only at hs
+      rw [hIoi, hs] at hk
+      omega
+
+/-- **The exponents are recovered from the leading elementary-divisor vector.** Its entries are
+the suffix sums of the exponents, and suffix sums determine a vector. -/
+lemma leadingExponent_injective : Function.Injective (leadingExponent (n := n)) := by
+  intro e f h
+  refine sum_Ici_injective (funext fun k ↦ ?_)
+  simpa only [leadingExponent_rev] using congr_fun h (Fin.rev k)
+
+/-- The weight of the leading diagonal: the total of the leading exponent vector is
+`∑ k, (k + 1) * e k`, the generator `heckeGen k` contributing `k + 1` for each of its `e k`
+factors. This is the `p`-adic valuation of the determinant of the leading diagonal. -/
+lemma sum_leadingExponent (e : Fin n → ℕ) :
+    ∑ i, leadingExponent e i = ∑ k : Fin n, ((k : ℕ) + 1) * e k := by
+  rw [← Equiv.sum_comp Fin.revPerm (leadingExponent e)]
+  simp only [Fin.revPerm_apply, leadingExponent_rev]
+  rw [Finset.sum_comm' (t' := Finset.univ) (s' := fun k ↦ Iic k) (by simp)]
+  simp [Fin.card_Iic]
+
+/-- Sanity check at `n = 2`: the leading diagonal of `X₀ ^ e 0 * X₁ ^ e 1 = T(1,p) ^ e 0 *
+T(p,p) ^ e 1` is `T(p ^ e 1, p ^ (e 0 + e 1))`, as in `PolynomialRing/Injective.lean`. -/
+lemma leadingExponent_fin_two (e : Fin 2 → ℕ) : leadingExponent e = ![e 1, e 0 + e 1] := by
+  ext i
+  fin_cases i <;>
+    simp [leadingExponent_apply, ← Finset.filter_le_eq_Ici, Finset.sum_filter, Fin.sum_univ_two]
+
+end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/LeadingExponent.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/LeadingExponent.lean
@@ -40,13 +40,14 @@ the exponents is `Fin.accumulate_injective`, and the explicit inverse is `Fin.in
   from its leading elementary-divisor vector** — `Fin.accumulate_injective` transported along
   `Fin.rev`.
 * `HeckeRing.GLn.isDvdChain_primePowDiag_leadingExponent`: the vector is monotone
-  (`HeckeRing.GLn.monotone_leadingExponent`), so the leading diagonal `T(p ^ leadingExponent e)`
+  (`HeckeRing.GLn.leadingExponent_monotone`), so the leading diagonal `T(p ^ leadingExponent e)`
   is a divisibility chain — for `0 < p` a canonical diagonal, by `primePowDiag_pos`.
 * `HeckeRing.GLn.primePowDiag_leadingExponent_single`: on the generator `X k` the leading
   diagonal is `heckeGenDiag k` itself; `HeckeRing.GLn.leadingExponent_add` and `primePowDiag_add`
   then give the leading diagonal of a product of monomials as the product of theirs.
-* `HeckeRing.GLn.sum_leadingExponent`: the weight `∑ k, (k + 1) * e k` of the leading diagonal,
-  the `p`-adic valuation of its determinant.
+* `HeckeRing.GLn.sum_leadingExponent`: the weight `∑ k, (k + 1) * e k` of the leading diagonal —
+  the exponent of its determinant `p ^ ∑ i, leadingExponent e i`, which is that determinant's
+  `p`-adic valuation once `p` is prime.
 
 ## Implementation notes
 
@@ -100,6 +101,7 @@ lemma leadingExponent_zero : leadingExponent (0 : Fin n → ℕ) = 0 := by
 
 /-- The leading exponent vector is additive; with `primePowDiag_add` this says the leading
 diagonal of a product of monomials is the entrywise product of their leading diagonals. -/
+@[simp]
 lemma leadingExponent_add (e f : Fin n → ℕ) :
     leadingExponent (e + f) = leadingExponent e + leadingExponent f := by
   ext i
@@ -111,12 +113,13 @@ lemma leadingExponent_rev (e : Fin n → ℕ) (k : Fin n) :
     leadingExponent e (Fin.rev k) = ∑ k' ∈ Ici k, e k' := by
   rw [leadingExponent_eq_sum_Ici, Fin.rev_rev]
 
-/-- On a single generator, the leading exponent vector is that generator's own `p`-exponent
-pattern: `0` on the first `n - 1 - k` positions and `1` on the last `k + 1`. -/
-lemma leadingExponent_single (k : Fin n) : leadingExponent (Pi.single k 1) =
-    fun i : Fin n ↦ if (i : ℕ) < n - 1 - (k : ℕ) then 0 else 1 := by
+/-- On a single generator, the leading exponent vector is that generator's own exponent vector
+`heckeGenExponent n k`. -/
+@[simp]
+lemma leadingExponent_single (k : Fin n) :
+    leadingExponent (Pi.single k 1) = heckeGenExponent n k := by
   ext i
-  rw [leadingExponent_eq_sum_Ici, Finset.sum_pi_single']
+  rw [leadingExponent_eq_sum_Ici, Finset.sum_pi_single', heckeGenExponent_apply]
   simp only [Finset.mem_Ici, Fin.le_iff_val_le_val, Fin.val_rev]
   split_ifs <;> omega
 
@@ -127,7 +130,7 @@ lemma primePowDiag_leadingExponent_single (p : ℕ) (k : Fin n) :
 
 /-- The leading exponent vector is monotone: a later position sees every generator an earlier one
 does. -/
-lemma monotone_leadingExponent (e : Fin n → ℕ) : Monotone (leadingExponent e) := by
+lemma leadingExponent_monotone (e : Fin n → ℕ) : Monotone (leadingExponent e) := by
   intro i j hij
   rw [leadingExponent_eq_sum_Ici, leadingExponent_eq_sum_Ici]
   exact Finset.sum_le_sum_of_subset (Finset.Ici_subset_Ici.2 (Fin.rev_le_rev.2 hij))
@@ -136,7 +139,7 @@ lemma monotone_leadingExponent (e : Fin n → ℕ) : Monotone (leadingExponent e
 `primePowDiag_pos`, for `0 < p` it is a canonical diagonal coset. -/
 lemma isDvdChain_primePowDiag_leadingExponent (p : ℕ) (e : Fin n → ℕ) :
     IsDvdChain (primePowDiag n p (leadingExponent e)) :=
-  isDvdChain_primePowDiag n p _ (monotone_leadingExponent e)
+  isDvdChain_primePowDiag n p _ (leadingExponent_monotone e)
 
 /-- **The exponents are recovered from the leading elementary-divisor vector.** Its entries are
 the suffix sums of the exponents, and suffix sums determine a vector
@@ -148,7 +151,9 @@ lemma leadingExponent_injective : Function.Injective (leadingExponent (n := n)) 
 
 /-- The weight of the leading diagonal: the total of the leading exponent vector is
 `∑ k, (k + 1) * e k`, the generator `heckeGen k` contributing `k + 1` for each of its `e k`
-factors. This is the `p`-adic valuation of the determinant of the leading diagonal. -/
+factors. It is the exponent of the determinant `∏ i, primePowDiag n p (leadingExponent e) i`,
+which is `p ^ ∑ i, leadingExponent e i`; once `p` is prime that exponent is the determinant's
+`p`-adic valuation. -/
 lemma sum_leadingExponent (e : Fin n → ℕ) :
     ∑ i, leadingExponent e i = ∑ k : Fin n, ((k : ℕ) + 1) * e k := by
   rw [← Equiv.sum_comp Fin.revPerm (leadingExponent e)]

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/LeadingExponent.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/LeadingExponent.lean
@@ -5,6 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
+public import Mathlib.RingTheory.MvPolynomial.Symmetric.FundamentalTheorem
 public import TauCeti.NumberTheory.HeckeRing.GLn.PolynomialRing.Basic
 
 /-!
@@ -22,17 +23,22 @@ that distinguished diagonal — entry `i` counts, with multiplicity `e k`, the g
 diagonal carries `p` in position `i`, which are the `k` with `n - 1 - i ≤ k` — together with the
 properties the leading-term argument consumes, above all that the exponents are recovered from it.
 
+The vector is the suffix sums of `e` read from the last position backwards, and suffix sums are
+Mathlib's `Fin.accumulate`, the device of the fundamental theorem of symmetric polynomials (the same
+leading-term argument, for the elementary symmetric polynomials): `leadingExponent e` is
+`Fin.accumulate n n e` precomposed with `Fin.rev`, so its additivity is `map_add`, the recovery of
+the exponents is `Fin.accumulate_injective`, and the explicit inverse is `Fin.invAccumulate`.
+
 ## Main definitions
 
 * `HeckeRing.GLn.leadingExponent`: the exponent vector of the leading elementary-divisor diagonal
-  of the Hecke monomial with exponents `e`, as the suffix sums `i ↦ ∑ k ≥ n - 1 - i, e k`.
+  of the Hecke monomial with exponents `e`, the suffix sums `i ↦ ∑ k ≥ n - 1 - i, e k`.
 
 ## Main results
 
 * `HeckeRing.GLn.leadingExponent_injective`: **the exponents of a Hecke monomial are recovered
-  from its leading elementary-divisor vector.** Position `n - 1 - k` is the suffix sum
-  `∑ k' ≥ k, e k'` (`HeckeRing.GLn.leadingExponent_rev`), so consecutive entries differ by one
-  exponent.
+  from its leading elementary-divisor vector** — `Fin.accumulate_injective` transported along
+  `Fin.rev`.
 * `HeckeRing.GLn.isDvdChain_primePowDiag_leadingExponent`: the vector is monotone
   (`HeckeRing.GLn.monotone_leadingExponent`), so the leading diagonal `T(p ^ leadingExponent e)`
   is a divisibility chain — for `0 < p` a canonical diagonal, by `primePowDiag_pos`.
@@ -47,9 +53,8 @@ properties the leading-term argument consumes, above all that the exponents are 
 The other half of the leading-term argument — that the leading coset occurs in the monomial with
 coefficient `1` and every other coset of its support lies below it — is the triangular expansion,
 and is not proved here. At `n = 1, 2` Theorem 3.20 is `PolynomialRing/Injective.lean`, by direct
-computation; `leadingExponent_fin_two` is the sanity check that at `n = 2` this vector is
-`![e 1, e 0 + e 1]`, the exponent pattern of the leading coset `T(p ^ e 1, p ^ (e 0 + e 1))` of
-that computation (which is not rerouted through it).
+computation with the leading coset `T(p ^ e 1, p ^ (e 0 + e 1))` written out; that computation is
+not rerouted through this vector.
 
 This is original work filling the general-`n` gap the roadmap records: the AINTLIB source
 (`LeanModularForms/HeckeRIngs/GLn/PolynomialRing.lean`) proves Theorem 3.20 at `n = 1, 2` only and
@@ -72,40 +77,46 @@ variable {n : ℕ}
 /-- The exponent vector of the leading elementary-divisor diagonal of the Hecke monomial
 `∏ k, heckeGen k ^ e k`: entry `i` counts, with multiplicity `e k`, the generators `heckeGen k`
 whose diagonal `heckeGenDiag k` carries `p` in position `i` — those with `n - 1 - i ≤ k`, i.e.
-`Fin.rev i ≤ k` — so it is the suffix sum of `e` from `Fin.rev i`. -/
+`Fin.rev i ≤ k` — so it is the suffix sum `Fin.accumulate n n e` of `e` at `Fin.rev i`. -/
 def leadingExponent (e : Fin n → ℕ) : Fin n → ℕ :=
-  fun i ↦ ∑ k ∈ Ici (Fin.rev i), e k
+  fun i ↦ Fin.accumulate n n e (Fin.rev i)
 
 /-- Defining equation for the sealed definition `leadingExponent`. -/
 lemma leadingExponent_apply (e : Fin n → ℕ) (i : Fin n) :
-    leadingExponent e i = ∑ k ∈ Ici (Fin.rev i), e k :=
+    leadingExponent e i = Fin.accumulate n n e (Fin.rev i) :=
   (rfl)
+
+/-- The leading exponent vector as a sum over an interval: position `i` sees the generators
+`k ≥ Fin.rev i`. -/
+lemma leadingExponent_eq_sum_Ici (e : Fin n → ℕ) (i : Fin n) :
+    leadingExponent e i = ∑ k ∈ Ici (Fin.rev i), e k := by
+  simp only [leadingExponent_apply, Fin.accumulate_apply, Fin.val_fin_le, Finset.filter_le_eq_Ici]
 
 /-- The empty monomial has the trivial leading diagonal. -/
 @[simp]
 lemma leadingExponent_zero : leadingExponent (0 : Fin n → ℕ) = 0 := by
   ext i
-  simp [leadingExponent_apply]
+  simp only [leadingExponent_apply, map_zero, Pi.zero_apply]
 
 /-- The leading exponent vector is additive; with `primePowDiag_add` this says the leading
 diagonal of a product of monomials is the entrywise product of their leading diagonals. -/
 lemma leadingExponent_add (e f : Fin n → ℕ) :
     leadingExponent (e + f) = leadingExponent e + leadingExponent f := by
   ext i
-  simp [leadingExponent_apply, Finset.sum_add_distrib]
+  simp only [leadingExponent_apply, map_add, Pi.add_apply]
 
 /-- Read from the last position backwards, the leading exponent vector is the suffix sums of the
 exponents: position `n - 1 - k` sees exactly the generators `k' ≥ k`. -/
 lemma leadingExponent_rev (e : Fin n → ℕ) (k : Fin n) :
     leadingExponent e (Fin.rev k) = ∑ k' ∈ Ici k, e k' := by
-  rw [leadingExponent_apply, Fin.rev_rev]
+  rw [leadingExponent_eq_sum_Ici, Fin.rev_rev]
 
 /-- On a single generator, the leading exponent vector is that generator's own `p`-exponent
 pattern: `0` on the first `n - 1 - k` positions and `1` on the last `k + 1`. -/
 lemma leadingExponent_single (k : Fin n) : leadingExponent (Pi.single k 1) =
     fun i : Fin n ↦ if (i : ℕ) < n - 1 - (k : ℕ) then 0 else 1 := by
   ext i
-  rw [leadingExponent_apply, Finset.sum_pi_single']
+  rw [leadingExponent_eq_sum_Ici, Finset.sum_pi_single']
   simp only [Finset.mem_Ici, Fin.le_iff_val_le_val, Fin.val_rev]
   split_ifs <;> omega
 
@@ -116,8 +127,10 @@ lemma primePowDiag_leadingExponent_single (p : ℕ) (k : Fin n) :
 
 /-- The leading exponent vector is monotone: a later position sees every generator an earlier one
 does. -/
-lemma monotone_leadingExponent (e : Fin n → ℕ) : Monotone (leadingExponent e) := fun _ _ hij ↦
-  Finset.sum_le_sum_of_subset (Finset.Ici_subset_Ici.2 (Fin.rev_le_rev.2 hij))
+lemma monotone_leadingExponent (e : Fin n → ℕ) : Monotone (leadingExponent e) := by
+  intro i j hij
+  rw [leadingExponent_eq_sum_Ici, leadingExponent_eq_sum_Ici]
+  exact Finset.sum_le_sum_of_subset (Finset.Ici_subset_Ici.2 (Fin.rev_le_rev.2 hij))
 
 /-- The leading diagonal `T(p ^ leadingExponent e)` is a divisibility chain; together with
 `primePowDiag_pos`, for `0 < p` it is a canonical diagonal coset. -/
@@ -125,37 +138,13 @@ lemma isDvdChain_primePowDiag_leadingExponent (p : ℕ) (e : Fin n → ℕ) :
     IsDvdChain (primePowDiag n p (leadingExponent e)) :=
   isDvdChain_primePowDiag n p _ (monotone_leadingExponent e)
 
-/-- A vector on `Fin n` is determined by its suffix sums: each entry is the difference of two
-consecutive ones, the last suffix sum being the last entry itself. -/
-private lemma sum_Ici_injective :
-    Function.Injective fun (e : Fin n → ℕ) (k : Fin n) ↦ ∑ k' ∈ Ici k, e k' := by
-  intro e f h
-  funext k
-  have hk := congr_fun h k
-  simp only at hk
-  rw [← Finset.add_sum_Ioi_eq_sum_Ici, ← Finset.add_sum_Ioi_eq_sum_Ici] at hk
-  cases n with
-  | zero => exact k.elim0
-  | succ m =>
-    cases k using Fin.lastCases with
-    | last =>
-      have hIoi : Ioi (Fin.last m) = ∅ := Finset.Ioi_eq_empty.2 fun x _ ↦ Fin.le_last x
-      simpa [hIoi] using hk
-    | cast j =>
-      have hIoi : Ioi (Fin.castSucc j) = Ici j.succ := by
-        ext x
-        simp [Fin.castSucc_lt_iff_succ_le]
-      have hs := congr_fun h j.succ
-      simp only at hs
-      rw [hIoi, hs] at hk
-      omega
-
 /-- **The exponents are recovered from the leading elementary-divisor vector.** Its entries are
-the suffix sums of the exponents, and suffix sums determine a vector. -/
+the suffix sums of the exponents, and suffix sums determine a vector
+(`Fin.accumulate_injective`; the inverse is `Fin.invAccumulate`, the consecutive differences). -/
 lemma leadingExponent_injective : Function.Injective (leadingExponent (n := n)) := by
   intro e f h
-  refine sum_Ici_injective (funext fun k ↦ ?_)
-  simpa only [leadingExponent_rev] using congr_fun h (Fin.rev k)
+  refine Fin.accumulate_injective le_rfl (funext fun k ↦ ?_)
+  simpa only [leadingExponent_apply, Fin.rev_rev] using congr_fun h (Fin.rev k)
 
 /-- The weight of the leading diagonal: the total of the leading exponent vector is
 `∑ k, (k + 1) * e k`, the generator `heckeGen k` contributing `k + 1` for each of its `e k`
@@ -166,12 +155,5 @@ lemma sum_leadingExponent (e : Fin n → ℕ) :
   simp only [Fin.revPerm_apply, leadingExponent_rev]
   rw [Finset.sum_comm' (t' := Finset.univ) (s' := fun k ↦ Iic k) (by simp)]
   simp [Fin.card_Iic]
-
-/-- Sanity check at `n = 2`: the leading diagonal of `X₀ ^ e 0 * X₁ ^ e 1 = T(1,p) ^ e 0 *
-T(p,p) ^ e 1` is `T(p ^ e 1, p ^ (e 0 + e 1))`, as in `PolynomialRing/Injective.lean`. -/
-lemma leadingExponent_fin_two (e : Fin 2 → ℕ) : leadingExponent e = ![e 1, e 0 + e 1] := by
-  ext i
-  fin_cases i <;>
-    simp [leadingExponent_apply, ← Finset.filter_le_eq_Ici, Finset.sum_filter, Fin.sum_univ_two]
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/LeadingExponent.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PolynomialRing/LeadingExponent.lean
@@ -26,13 +26,19 @@ properties the leading-term argument consumes, above all that the exponents are 
 The vector is the suffix sums of `e` read from the last position backwards, and suffix sums are
 Mathlib's `Fin.accumulate`, the device of the fundamental theorem of symmetric polynomials (the same
 leading-term argument, for the elementary symmetric polynomials): `leadingExponent e` is
-`Fin.accumulate n n e` precomposed with `Fin.rev`, so its additivity is `map_add`, the recovery of
-the exponents is `Fin.accumulate_injective`, and the explicit inverse is `Fin.invAccumulate`.
+`Fin.accumulate n n e` precomposed with `Fin.rev`, the recovery of the exponents is
+`Fin.accumulate_injective`, and the explicit inverse is `Fin.invAccumulate`.
+
+Multiplying Hecke monomials adds their exponent vectors, so `leadingExponent` is bundled as an
+`AddMonoidHom`, as `Fin.accumulate` itself is. Its `map_zero`, `map_add`, `map_sum` and `map_nsmul`
+are then the generic ones: a product over a finite family of monomials, or a monomial raised to a
+power, needs no lemma of its own here.
 
 ## Main definitions
 
 * `HeckeRing.GLn.leadingExponent`: the exponent vector of the leading elementary-divisor diagonal
-  of the Hecke monomial with exponents `e`, the suffix sums `i ↦ ∑ k ≥ n - 1 - i, e k`.
+  of the Hecke monomial with exponents `e`, the suffix sums `i ↦ ∑ k ≥ n - 1 - i, e k`, as an
+  additive homomorphism `(Fin n → ℕ) →+ (Fin n → ℕ)`.
 
 ## Main results
 
@@ -43,8 +49,8 @@ the exponents is `Fin.accumulate_injective`, and the explicit inverse is `Fin.in
   (`HeckeRing.GLn.leadingExponent_monotone`), so the leading diagonal `T(p ^ leadingExponent e)`
   is a divisibility chain — for `0 < p` a canonical diagonal, by `primePowDiag_pos`.
 * `HeckeRing.GLn.primePowDiag_leadingExponent_single`: on the generator `X k` the leading
-  diagonal is `heckeGenDiag k` itself; `HeckeRing.GLn.leadingExponent_add` and `primePowDiag_add`
-  then give the leading diagonal of a product of monomials as the product of theirs.
+  diagonal is `heckeGenDiag k` itself; `map_add` and `primePowDiag_add` then give the leading
+  diagonal of a product of monomials as the product of theirs.
 * `HeckeRing.GLn.sum_leadingExponent`: the weight `∑ k, (k + 1) * e k` of the leading diagonal —
   the exponent of its determinant `p ^ ∑ i, leadingExponent e i`, which is that determinant's
   `p`-adic valuation once `p` is prime.
@@ -78,9 +84,14 @@ variable {n : ℕ}
 /-- The exponent vector of the leading elementary-divisor diagonal of the Hecke monomial
 `∏ k, heckeGen k ^ e k`: entry `i` counts, with multiplicity `e k`, the generators `heckeGen k`
 whose diagonal `heckeGenDiag k` carries `p` in position `i` — those with `n - 1 - i ≤ k`, i.e.
-`Fin.rev i ≤ k` — so it is the suffix sum `Fin.accumulate n n e` of `e` at `Fin.rev i`. -/
-def leadingExponent (e : Fin n → ℕ) : Fin n → ℕ :=
-  fun i ↦ Fin.accumulate n n e (Fin.rev i)
+`Fin.rev i ≤ k` — so it is the suffix sum `Fin.accumulate n n e` of `e` at `Fin.rev i`.
+
+Additive, because multiplying Hecke monomials adds their exponents; bundled, so that `map_zero`,
+`map_add`, `map_sum` and `map_nsmul` are available generically. -/
+def leadingExponent : (Fin n → ℕ) →+ (Fin n → ℕ) where
+  toFun e i := Fin.accumulate n n e (Fin.rev i)
+  map_zero' := by ext i; simp only [map_zero, Pi.zero_apply]
+  map_add' e f := by ext i; simp only [map_add, Pi.add_apply]
 
 /-- Defining equation for the sealed definition `leadingExponent`. -/
 lemma leadingExponent_apply (e : Fin n → ℕ) (i : Fin n) :
@@ -92,20 +103,6 @@ lemma leadingExponent_apply (e : Fin n → ℕ) (i : Fin n) :
 lemma leadingExponent_eq_sum_Ici (e : Fin n → ℕ) (i : Fin n) :
     leadingExponent e i = ∑ k ∈ Ici (Fin.rev i), e k := by
   simp only [leadingExponent_apply, Fin.accumulate_apply, Fin.val_fin_le, Finset.filter_le_eq_Ici]
-
-/-- The empty monomial has the trivial leading diagonal. -/
-@[simp]
-lemma leadingExponent_zero : leadingExponent (0 : Fin n → ℕ) = 0 := by
-  ext i
-  simp only [leadingExponent_apply, map_zero, Pi.zero_apply]
-
-/-- The leading exponent vector is additive; with `primePowDiag_add` this says the leading
-diagonal of a product of monomials is the entrywise product of their leading diagonals. -/
-@[simp]
-lemma leadingExponent_add (e f : Fin n → ℕ) :
-    leadingExponent (e + f) = leadingExponent e + leadingExponent f := by
-  ext i
-  simp only [leadingExponent_apply, map_add, Pi.add_apply]
 
 /-- Read from the last position backwards, the leading exponent vector is the suffix sums of the
 exponents: position `n - 1 - k` sees exactly the generators `k' ≥ k`. -/

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PrimeDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PrimeDecomposition.lean
@@ -77,6 +77,7 @@ lemma primePowDiag_pos (p : ℕ) (hp : 0 < p) (e : Fin n → ℕ) :
   fun _ ↦ pow_pos hp _
 
 /-- The `p`-power diagonal turns a sum of exponent vectors into the entrywise product. -/
+@[simp]
 lemma primePowDiag_add (p : ℕ) (e f : Fin n → ℕ) :
     primePowDiag n p (e + f) = primePowDiag n p e * primePowDiag n p f := by
   ext i

--- a/TauCeti/NumberTheory/HeckeRing/GLn/PrimeDecomposition.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/PrimeDecomposition.lean
@@ -76,6 +76,12 @@ lemma primePowDiag_pos (p : ℕ) (hp : 0 < p) (e : Fin n → ℕ) :
     ∀ i, 0 < primePowDiag n p e i :=
   fun _ ↦ pow_pos hp _
 
+/-- The `p`-power diagonal turns a sum of exponent vectors into the entrywise product. -/
+lemma primePowDiag_add (p : ℕ) (e f : Fin n → ℕ) :
+    primePowDiag n p (e + f) = primePowDiag n p e * primePowDiag n p f := by
+  ext i
+  simp [pow_add]
+
 /-- Monotone exponents give a divisibility chain of `p`-power diagonals. -/
 lemma isDvdChain_primePowDiag (p : ℕ) (e : Fin n → ℕ) (hmono : Monotone e) :
     IsDvdChain (primePowDiag n p e) :=


### PR DESCRIPTION
Shimura's Theorem 3.20 — the `p`-local Hecke ring `pLocalSubring n p` is the polynomial ring
`ℤ[X₁, …, Xₙ]` on the diagonal prime cosets `heckeGen k = T(1, …, 1, p, …, p)` — is on `main`
for `n = 1, 2` (`GLn/PolynomialRing/Injective.lean`). The roadmap records that general `n` needs
a leading-term argument with named steps, the last of which is *recovery of the generator
exponents from the leading elementary-divisor vector*. This PR is that step, together with the
combinatorics of the vector it is about.

**What the leading vector is.** Multiplying double cosets multiplies elementary divisors "up to
lower terms", so the monomial `∏ k, heckeGen k ^ e k` has a distinguished term: the diagonal
whose `p`-exponent in position `i` counts, with multiplicity `e k`, the generators whose
diagonal carries `p` there — those with `n - 1 - i ≤ k`. So `leadingExponent e` is the suffix sum
`i ↦ ∑ k ∈ Ici (Fin.rev i), e k`, and the leading diagonal is `primePowDiag n p (leadingExponent e)`.
Suffix sums on `Fin n` are Mathlib's `Fin.accumulate` — the device of the fundamental theorem of
symmetric polynomials, i.e. the same leading-term argument for the elementary symmetric
polynomials — so the definition is `Fin.accumulate n n e` precomposed with `Fin.rev`, and the file
reuses that bundled `AddMonoidHom` rather than re-deriving it.

**What is proved about it** (`GLn/PolynomialRing/LeadingExponent.lean`, new file, 159 lines):

* `leadingExponent_injective` — **the named step.** Position `n - 1 - k` of the vector is the
  suffix sum `∑ k' ≥ k, e k'` (`leadingExponent_rev`, one `Fin.rev_rev`), and suffix sums
  determine a vector: `Fin.accumulate_injective le_rfl`, transported along `Fin.rev`. The explicit
  inverse — consecutive differences — is Mathlib's `Fin.invAccumulate`.
* `monotone_leadingExponent` / `isDvdChain_primePowDiag_leadingExponent` — the leading diagonal
  is a divisibility chain, hence (with `primePowDiag_pos`, for `0 < p`) a canonical diagonal coset
  (`CanonicalDiagonal`), which is what lets `eq_of_diagCoset_eq` compare leading cosets.
* `leadingExponent_add` / `leadingExponent_zero` — `map_add` / `map_zero` of `Fin.accumulate`;
  with the new general `primePowDiag_add`
  (`GLn/PrimeDecomposition.lean`, beside `primePowDiag`: the `p`-power diagonal turns sums of
  exponent vectors into entrywise products) this is the multiplication of leading diagonals under
  products of monomials.
* `primePowDiag_leadingExponent_single` — on a generator `X k` the leading diagonal is
  `heckeGenDiag n p k` itself, via the existing `heckeGenDiag_eq_primePowDiag`.
* `sum_leadingExponent` — the weight `∑ k, (k + 1) * e k`, the `p`-adic valuation of the
  determinant of the leading diagonal (reindex by `Fin.revPerm`, swap the sums, `Fin.card_Iic`):
  the quantity the well-founded weight-then-dominance order of the roadmap's other named step is
  built on.

**What is not here.** The triangular expansion itself — that the leading coset occurs in the
monomial with coefficient `1` and every other coset of its support lies strictly below it — is
the roadmap's other named step and is not claimed. This file is the combinatorial substrate it
will consume; it adds no new predicate, only a definition and theorems about it, and it does not
touch the `n = 1, 2` proofs. Two follow-ups surfaced in review and deliberately left out of this
PR to keep it to one topic: naming the generator exponent pattern `fun i ↦ if i < n - 1 - k then
0 else 1` once in `PolynomialRing/Basic.lean` (it is spelled out there twice and once here), and
rerouting `Injective.lean`'s written-out `n = 2` leading coset `T(p ^ e 1, p ^ (e 0 + e 1))`
through this vector once the general-`n` argument needs it.

**Scope.** TauCetiRoadmap `ModularForms/README.md`, "Layer 2: Hecke operators and the Hecke
algebra", item (a): Theorem 3.20 "proved for `n = 2`; at general `n` two named steps remain, and
they must contain: uniqueness of the leading double coset in the triangular expansion …,
well-foundedness of the weight-then-dominance order, and recovery of the generator exponents from
the leading elementary-divisor vector". Layer 0 and the `GL_n` block this builds on
(`GLn/Basic`, `DiagonalCosets`, `PrimeDecomposition`, `PolynomialRing/Basic`) are all on `main`;
nothing is stacked.

**Provenance.** Original work: the AINTLIB source
(`CBirkbeck/AINTLIB @ aa99cd4f9c7358363c4f0384c1b81451365bc955`, Apache-2.0,
`projects/LeanModularForms/LeanModularForms/HeckeRIngs/GLn/PolynomialRing.lean`) proves
Theorem 3.20 at `n = 1, 2` only and carries no general-`n` leading-term device (its only
general-`n` combinatorial notion is the weight `ppowWeight`); Mathlib has no Hecke-specific
counterpart; the suffix-sum device itself is Mathlib's `Fin.accumulate` (reused: definition,
`map_zero`/`map_add`, `Fin.accumulate_injective`), and the weight identity uses `Finset.sum_comm'`
and `Fin.card_Iic`. Reference: Shimura, *Introduction to the arithmetic theory of automorphic
functions*, §3.2, Theorem 3.20.

Roadmap: ModularForms
<!--tauceti-target:v1 {"focus":"ModularForms","id":"layer2-gln-theorem-3-20-exponent-recovery"}-->
Provenance: original work; source sweep of CBirkbeck/AINTLIB @ aa99cd4f9c7358363c4f0384c1b81451365bc955 (Apache-2.0), LeanModularForms/HeckeRIngs/GLn/PolynomialRing.lean — no general-n leading-term device; Shimura §3.2 Thm 3.20.
