### PR TITLE
ci(pages): run every six hours rather than three

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,7 +45,14 @@ on:
       - 'scripts/pipeline_health.py'
       - '.github/workflows/pages.yml'
   schedule:
-    - cron: "23 */3 * * *"   # Every three hours (UTC): refresh the charts and API docs
+    # Every six hours (UTC). Not three: a successful run takes a median of 276
+    # minutes, 82% of it the doc-gen4 build, which every scheduled run forces
+    # regardless of the cache. Asking for a new one every three hours therefore
+    # queued runs behind each other, and GitHub discarded the superseded pending
+    # one -- 8 of the last 60 runs were cancelled that way, including the push
+    # that landed the pipeline-health report. Six hours is roughly what the
+    # workflow actually achieves, so the schedule now describes reality.
+    - cron: "23 */6 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR changes the Pages schedule from three hours to six.

A successful run takes a median of 276 minutes and as much as 498, so asking for one every three hours queued them behind each other. Only one run can be pending under the `pages` concurrency group, so a third arrival discarded the waiting one: 8 of the last 60 runs were cancelled that way, including the push that landed the pipeline-health report, which then had to wait for the next scheduled run to publish.

Six hours is roughly what the workflow actually achieves, so the schedule now describes what happens rather than what was hoped for. The site refreshes no more slowly than it already did; it just stops asking for work it cannot start.

**This should be reverted to three hours once #4613 lands and one run confirms the cache hit.** That PR restores TauCeti's oleans before the docs build, which should remove most of the 197-minute source compilation and bring the workflow comfortably under three hours. At that point six hours would halve the site's freshness for no reason. Six is the right cadence for a four-to-eight-hour build and the wrong one for a forty-minute build, so this is deliberately a stopgap rather than a decision.

Roadmap: none

🤖 Prepared with Claude Code
