### PR TITLE
feat: the diamond operators are the Hecke operators of the Γ₀(N) cosets

### DIFF
--- a/TauCeti/GroupTheory/DoubleCoset/Normalizer.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/Normalizer.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.DoubleCoset
+
+import Mathlib.Tactic.Group
+
+/-!
+# Double cosets at a normalizing element
+
+A double coset `ΓgΓ` is in general a union of several cosets on either side. When `g`
+normalizes `Γ` it is a *single* coset, and the two sides agree:
+
+`ΓgΓ = Γ(gΓg⁻¹)g = ΓΓg = Γg`.
+
+This file records that collapse, together with the observation that a double coset at a
+normalizing element consists of normalizing elements. Both are used wherever a Hecke double
+coset attached to an element of the normalizer has to be recognised as a single coset — for
+`Γ₁(N) ⊴ Γ₀(N)`, this is what makes the diamond operators double-coset operators.
+
+## Main results
+
+* `DoubleCoset.doubleCoset_eq_rightCoset_of_mem_normalizer`: `ΓgΓ = Γg` for `g` normalizing `Γ`.
+* `DoubleCoset.mem_normalizer_of_mem_doubleCoset`: every element of such a `ΓgΓ` again
+  normalizes `Γ`, so the collapse propagates to any representative of the double coset.
+-/
+
+public section
+
+open MulOpposite
+
+open scoped Pointwise
+
+namespace DoubleCoset
+
+variable {G : Type*} [Group G] {Γ : Subgroup G} {g : G}
+
+/-- **A double coset at a normalizing element is a single right coset.** For `g` in the
+normalizer of `Γ` the two flanking copies of `Γ` merge: the right-hand factor `b` of
+`a * g * b` is absorbed by rewriting `g * b = (g * b * g⁻¹) * g`.
+
+The left-coset form is the same statement, `Γ g Γ = g Γ`, read through `gΓ = Γg`; only the
+right-coset form is stated, because that is the handedness in which Hecke operators decompose
+a double coset. -/
+theorem doubleCoset_eq_rightCoset_of_mem_normalizer (hg : g ∈ Subgroup.normalizer (Γ : Set G)) :
+    doubleCoset g Γ Γ = op g • (Γ : Set G) := by
+  ext x
+  rw [mem_doubleCoset, mem_rightCoset_iff]
+  refine ⟨?_, fun hx ↦ ⟨x * g⁻¹, hx, 1, Γ.one_mem, by simp⟩⟩
+  rintro ⟨a, ha, b, hb, rfl⟩
+  have hconj : g * b * g⁻¹ ∈ Γ := (Subgroup.mem_normalizer_iff.mp hg b).mp hb
+  have hrw : a * g * b * g⁻¹ = a * (g * b * g⁻¹) := by group
+  exact hrw ▸ Γ.mul_mem ha hconj
+
+/-- **A double coset at a normalizing element consists of normalizing elements.** Every
+`a * g * b` with `a, b ∈ Γ` lies in the normalizer of `Γ`, which contains both `Γ` and `g`.
+Consequently `doubleCoset_eq_rightCoset_of_mem_normalizer` applies to *any* representative of
+the double coset, not only to the chosen `g`. -/
+theorem mem_normalizer_of_mem_doubleCoset (hg : g ∈ Subgroup.normalizer (Γ : Set G)) {x : G}
+    (hx : x ∈ doubleCoset g Γ Γ) : x ∈ Subgroup.normalizer (Γ : Set G) := by
+  obtain ⟨a, ha, b, hb, rfl⟩ := mem_doubleCoset.mp hx
+  exact Subgroup.mul_mem _ (Subgroup.mul_mem _ (Subgroup.le_normalizer ha) hg)
+    (Subgroup.le_normalizer hb)
+
+end DoubleCoset

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
@@ -142,7 +142,7 @@ theorem doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets (g : ↥(Gamma0
 /-- **The diamond coset sees exactly the lower-right entry.** Two elements of `Γ₀(N)` give the
 same double coset precisely when they have the same image in `(ZMod N)ˣ`; the forward direction
 uses that `mapGL ℚ` is injective, so a rational coincidence is an integral one. -/
-theorem diamondCosetGamma1_eq_iff {g₁ g₂ : ↥(Gamma0 N)} :
+@[simp] theorem diamondCosetGamma1_eq_iff {g₁ g₂ : ↥(Gamma0 N)} :
     diamondCosetGamma1 N g₁ = diamondCosetGamma1 N g₂ ↔
       (Gamma0Map N).toHomUnits g₁ = (Gamma0Map N).toHomUnits g₂ := by
   rw [← HeckeCoset.toSet_injective.eq_iff, diamondCosetGamma1_toSet, diamondCosetGamma1_toSet,
@@ -224,7 +224,7 @@ private lemma mulMap_diamondCosetGamma1 (p : DecompQuotient ((Gamma1 N).map (map
 There is no structure constant to compute: both decomposition quotients are subsingletons, so
 `multiplicity ≤ 1` is automatic, and every pair of representatives multiplies into the same
 double coset. -/
-theorem single_diamondCosetGamma1_mul_single (R : Type*) [Semiring R] :
+@[simp] theorem single_diamondCosetGamma1_mul_single (R : Type*) [Semiring R] :
     HeckeCosetModule.single R (diamondCosetGamma1 N g₁) 1 *
         HeckeCosetModule.single R (diamondCosetGamma1 N g₂) 1 =
       HeckeCosetModule.single R (diamondCosetGamma1 N (g₁ * g₂)) 1 := by

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
@@ -1,0 +1,297 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.GroupTheory.DoubleCoset.Normalizer
+public import TauCeti.NumberTheory.HeckeRing.Associativity
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.Basic
+public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
+
+import Mathlib.Tactic.Group
+
+/-!
+# The diamond double cosets of the `Γ₁(N)` Hecke ring
+
+The Hecke monoid `Δ₀(N)` asks its elements only to have a *unit* upper-left entry modulo `N`,
+which is what puts all of `Γ₀(N)` inside it (`HeckeRing/GL2/Gamma1/Basic.lean`). This file takes
+the resulting payoff: for `γ ∈ Γ₀(N)` the double coset `Γ₁(N) γ Γ₁(N)` is a basis element of the
+Hecke ring `𝕋 Δ₀(N) Γ₁(N) ℤ`, it is a *single* right coset `Γ₁(N) γ` because `Γ₁(N)` is normal
+in `Γ₀(N)`, it depends only on the lower-right entry `d ∈ (ZMod N)ˣ`, and the resulting map
+
+`⟨·⟩ : (ZMod N)ˣ →* 𝕋 Δ₀(N) Γ₁(N) ℤ`
+
+is an injective monoid homomorphism. So the diamond operators are not an extra structure bolted
+onto the Hecke algebra: they are honest basis elements of it. That the endomorphism of
+`M_k(Γ₁(N))` such a coset induces is the `⟨d⟩` of `ModularForms/DiamondOperators.lean` is the
+companion statement, proved in `ModularForms/HeckeSlash/Diamond.lean`.
+
+## Why the double coset collapses, and what that buys
+
+`Γ₁(N)` is normal in `Γ₀(N)` (`CongruenceSubgroup.Gamma0_normalizes_Gamma1`), so `γ` lies in the
+normalizer of the image of `Γ₁(N)` in `GL₂(ℚ)` and
+`DoubleCoset.doubleCoset_eq_rightCoset_of_mem_normalizer` collapses `Γ₁(N) γ Γ₁(N)` to
+`Γ₁(N) γ`. Two consequences drive everything below.
+
+* The double coset has a **single** right coset, so the slash operator attached to it is a
+  one-term sum. That is the shape `heckeSlashSum` consumes, through the decomposition
+  `doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets` stated at the chosen representative.
+* Its decomposition quotients are subsingletons, so the structure constants of a product of two
+  diamond cosets are at most `1` and `HeckeCosetModule.mul_single_single_of_mulMap_eq` applies:
+  the product of two diamond basis elements is the diamond basis element of the product. No
+  counting is needed, which is exactly what distinguishes the diamonds from the `Tₚ`.
+
+## Main definitions
+
+* `HeckeRing.GL2.diamondCosetGamma1`: the double coset `Γ₁(N) γ Γ₁(N)` of `γ ∈ Γ₀(N)`.
+* `HeckeRing.GL2.diamondHeckeElem` and `HeckeRing.GL2.diamondHeckeElemHom`: the diamond element
+  `⟨d⟩` of the Hecke ring, and the monoid homomorphism `(ZMod N)ˣ →* 𝕋 Δ₀(N) Γ₁(N) ℤ` it forms.
+
+## Main results
+
+* `HeckeRing.GL2.diamondCosetGamma1_toSet` and
+  `HeckeRing.GL2.doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets`: the double coset is
+  the single right coset `Γ₁(N) γ`, in the two spellings the Hecke machinery uses.
+* `HeckeRing.GL2.diamondCosetGamma1_eq_iff`: the coset depends exactly on the lower-right entry.
+* `HeckeRing.GL2.single_diamondCosetGamma1_mul_single`: the basis elements multiply,
+  `[Γ₁(N) γ₁ Γ₁(N)] · [Γ₁(N) γ₂ Γ₁(N)] = [Γ₁(N) γ₁γ₂ Γ₁(N)]`.
+* `HeckeRing.GL2.diamondHeckeElemHom_injective`: the diamonds form a faithful copy of
+  `(ZMod N)ˣ` inside the Hecke ring.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.3.
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.2.
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup CongruenceSubgroup DoubleCoset MulOpposite
+open scoped MatrixGroups Pointwise HeckeCosetModule
+
+namespace HeckeRing.GL2
+
+variable {N : ℕ} [NeZero N]
+
+/-- **The diamond double coset** `Γ₁(N) · γ · Γ₁(N)` of an element `γ ∈ Γ₀(N)`, as an element of
+the basis of the Hecke ring of the pair `(Γ₁(N), Δ₀(N))`.
+
+It is indexed by an element of `Γ₀(N)` rather than by a unit of `ZMod N` because a double coset
+is formed from a matrix; that it depends only on the lower-right entry is
+`diamondCosetGamma1_eq_iff`, and `diamondHeckeElem` is the resulting unit-indexed element. -/
+noncomputable def diamondCosetGamma1 (N : ℕ) [NeZero N] (g : ↥(Gamma0 N)) :
+    HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) :=
+  HeckeCoset.mk _ _ ⟨mapGL ℚ (g : SL(2, ℤ)), mapGL_mem_Delta0 N g⟩
+
+/-- Defining equation for the sealed definition `diamondCosetGamma1`. -/
+lemma diamondCosetGamma1_def (g : ↥(Gamma0 N)) :
+    diamondCosetGamma1 N g = HeckeCoset.mk ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      ⟨mapGL ℚ (g : SL(2, ℤ)), mapGL_mem_Delta0 N g⟩ := (rfl)
+
+/-- The underlying set of a diamond coset is the double coset of `γ`. -/
+lemma diamondCosetGamma1_toSet_eq_doubleCoset (g : ↥(Gamma0 N)) :
+    (diamondCosetGamma1 N g).toSet =
+      doubleCoset (mapGL ℚ (g : SL(2, ℤ))) ((Gamma1 N).map (mapGL ℚ))
+        ((Gamma1 N).map (mapGL ℚ)) :=
+  HeckeCoset.toSet_mk _
+
+/-- **The diamond double coset is a single right coset**, `Γ₁(N) γ Γ₁(N) = Γ₁(N) γ`, since `γ`
+normalizes `Γ₁(N)`. -/
+@[simp] lemma diamondCosetGamma1_toSet (g : ↥(Gamma0 N)) :
+    (diamondCosetGamma1 N g).toSet =
+      op (mapGL ℚ (g : SL(2, ℤ))) • ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) :=
+  (diamondCosetGamma1_toSet_eq_doubleCoset g).trans
+    (doubleCoset_eq_rightCoset_of_mem_normalizer (mapGL_mem_normalizer_Gamma1_map ℚ g))
+
+/-- The chosen representative of a diamond coset lies in the right coset `Γ₁(N) γ`. -/
+lemma rep_diamondCosetGamma1_mem_rightCoset (g : ↥(Gamma0 N)) :
+    ((diamondCosetGamma1 N g).rep : GL (Fin 2) ℚ) ∈
+      op (mapGL ℚ (g : SL(2, ℤ))) • ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) :=
+  diamondCosetGamma1_toSet g ▸ (diamondCosetGamma1 N g).rep_mem
+
+/-- The chosen representative of a diamond coset again normalizes `Γ₁(N)`: it lies in
+`Γ₁(N) γ Γ₁(N)`, all of whose elements do. -/
+lemma rep_diamondCosetGamma1_mem_normalizer (g : ↥(Gamma0 N)) :
+    ((diamondCosetGamma1 N g).rep : GL (Fin 2) ℚ) ∈
+      Subgroup.normalizer (((Gamma1 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+        Set (GL (Fin 2) ℚ)) :=
+  mem_normalizer_of_mem_doubleCoset (mapGL_mem_normalizer_Gamma1_map ℚ g)
+    (diamondCosetGamma1_toSet_eq_doubleCoset g ▸ (diamondCosetGamma1 N g).rep_mem)
+
+/-- The double coset of the chosen representative of `diamondCosetGamma1 N g`, presented as the
+one-term union of right cosets — the shape the slash sum of
+`ModularForms/HeckeSlash/Independence.lean` consumes. -/
+theorem doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets (g : ↥(Gamma0 N)) :
+    doubleCoset ((diamondCosetGamma1 N g).out : GL (Fin 2) ℚ)
+        ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
+      ⋃ _ : Unit, op (mapGL ℚ (g : SL(2, ℤ))) •
+        ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
+  have hout : HeckeCoset.mk ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      (diamondCosetGamma1 N g).out = diamondCosetGamma1 N g := Quotient.out_eq _
+  rw [Set.iUnion_const, HeckeCoset.eq_iff.mp (hout.trans (diamondCosetGamma1_def g))]
+  exact doubleCoset_eq_rightCoset_of_mem_normalizer (mapGL_mem_normalizer_Gamma1_map ℚ g)
+
+/-- **The diamond coset sees exactly the lower-right entry.** Two elements of `Γ₀(N)` give the
+same double coset precisely when they have the same image in `(ZMod N)ˣ`; the forward direction
+uses that `mapGL ℚ` is injective, so a rational coincidence is an integral one. -/
+theorem diamondCosetGamma1_eq_iff {g₁ g₂ : ↥(Gamma0 N)} :
+    diamondCosetGamma1 N g₁ = diamondCosetGamma1 N g₂ ↔
+      (Gamma0Map N).toHomUnits g₁ = (Gamma0Map N).toHomUnits g₂ := by
+  rw [← HeckeCoset.toSet_injective.eq_iff, diamondCosetGamma1_toSet, diamondCosetGamma1_toSet,
+    rightCoset_eq_iff]
+  constructor
+  · intro hmem
+    obtain ⟨σ, hσ, hσeq⟩ := Subgroup.mem_map.mp hmem
+    have hσ' : σ = (g₂ : SL(2, ℤ)) * (g₁ : SL(2, ℤ))⁻¹ :=
+      (mapGL_inj (S := ℚ) _ _).mp (by rw [hσeq, map_mul, map_inv])
+    have hker : (g₂ * g₁⁻¹ : ↥(Gamma0 N)) ∈ Gamma1' N :=
+      (Gamma1_to_Gamma0_mem _).mpr ((Gamma1_mem _ _).mp (by rwa [hσ'] at hσ))
+    have h1 : (Gamma0Map N).toHomUnits (g₂ * g₁⁻¹) = 1 :=
+      Units.ext ((MonoidHom.coe_toHomUnits _ _).trans (Gamma1_mem'.mp hker))
+    rw [map_mul, map_inv, mul_inv_eq_one] at h1
+    exact h1.symm
+  · intro heq
+    refine Subgroup.mem_map.mpr ⟨(g₂ : SL(2, ℤ)) * (g₁ : SL(2, ℤ))⁻¹,
+      mul_inv_mem_Gamma1_of_Gamma0Map_eq g₂ g₁ (congrArg Units.val heq.symm), ?_⟩
+    rw [map_mul, map_inv]
+
+/-- The diamond coset of the identity is the identity double coset `Γ₁(N) · 1 · Γ₁(N)`. -/
+@[simp] theorem diamondCosetGamma1_one : diamondCosetGamma1 N 1 = 1 := by
+  rw [diamondCosetGamma1_def, HeckeCoset.one_def]
+  exact congrArg (HeckeCoset.mk _ _) (Subtype.ext (map_one (mapGL ℚ)))
+
+section Product
+
+variable (g₁ g₂ : ↥(Gamma0 N))
+
+/-- Every value of `HeckeCoset.mulMap` on two diamond cosets is the diamond coset of the
+product: writing each chosen representative as `a · γ` with `a ∈ Γ₁(N)` and pushing the middle
+`Γ₁(N)` factor across `γ₁` — legitimate because `γ₁` normalizes `Γ₁(N)` — leaves
+`Γ₁(N) · γ₁γ₂`. -/
+private lemma mulMap_diamondCosetGamma1 (p : DecompQuotient ((Gamma1 N).map (mapGL ℚ))
+    ((Gamma1 N).map (mapGL ℚ)) ((diamondCosetGamma1 N g₁).rep : GL (Fin 2) ℚ) ×
+      DecompQuotient ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+        ((diamondCosetGamma1 N g₂).rep : GL (Fin 2) ℚ)) :
+    HeckeCoset.mulMap ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+        ((Gamma1 N).map (mapGL ℚ)) (diamondCosetGamma1 N g₁).rep
+        (diamondCosetGamma1 N g₂).rep p = diamondCosetGamma1 N (g₁ * g₂) := by
+  -- name the two representatives as `a γ₁` and `b γ₂`, so that the identity below is an
+  -- identity between short words in six atoms
+  obtain ⟨a, ha, hA⟩ : ∃ a ∈ (Gamma1 N).map (mapGL ℚ),
+      ((diamondCosetGamma1 N g₁).rep : GL (Fin 2) ℚ) = a * mapGL ℚ (g₁ : SL(2, ℤ)) :=
+    ⟨_, (mem_rightCoset_iff _).mp (rep_diamondCosetGamma1_mem_rightCoset g₁),
+      (inv_mul_cancel_right _ _).symm⟩
+  obtain ⟨b, hb, hB⟩ : ∃ b ∈ (Gamma1 N).map (mapGL ℚ),
+      ((diamondCosetGamma1 N g₂).rep : GL (Fin 2) ℚ) = b * mapGL ℚ (g₂ : SL(2, ℤ)) :=
+    ⟨_, (mem_rightCoset_iff _).mp (rep_diamondCosetGamma1_mem_rightCoset g₂),
+      (inv_mul_cancel_right _ _).symm⟩
+  -- the middle `Γ₁(N)` factor, conjugated across `γ₁`
+  have hc : mapGL ℚ (g₁ : SL(2, ℤ)) * ((p.2.out : GL (Fin 2) ℚ) * b) *
+      (mapGL ℚ (g₁ : SL(2, ℤ)))⁻¹ ∈ (Gamma1 N).map (mapGL ℚ) :=
+    (Subgroup.mem_normalizer_iff.mp (mapGL_mem_normalizer_Gamma1_map ℚ g₁) _).mp
+      (Subgroup.mul_mem _ p.2.out.2 hb)
+  have hprod : mapGL ℚ (g₁ : SL(2, ℤ)) * mapGL ℚ (g₂ : SL(2, ℤ)) =
+      mapGL ℚ ((g₁ * g₂ : ↥(Gamma0 N)) : SL(2, ℤ)) := by
+    rw [Subgroup.coe_mul, map_mul]
+  -- the word identity, in six free atoms: quantifying over `u` and `v` keeps `group` away from
+  -- the coset representatives, whose types are large
+  have key₀ : ∀ u v : GL (Fin 2) ℚ, u * (a * mapGL ℚ (g₁ : SL(2, ℤ))) *
+      (v * (b * mapGL ℚ (g₂ : SL(2, ℤ)))) =
+      u * a * (mapGL ℚ (g₁ : SL(2, ℤ)) * (v * b) * (mapGL ℚ (g₁ : SL(2, ℤ)))⁻¹) *
+        (mapGL ℚ (g₁ : SL(2, ℤ)) * mapGL ℚ (g₂ : SL(2, ℤ))) * 1 := fun u v ↦ by group
+  have key := key₀ (p.1.out : GL (Fin 2) ℚ) (p.2.out : GL (Fin 2) ℚ)
+  rw [← hA, ← hB, hprod] at key
+  rw [HeckeCoset.mulMap_eq_mk]
+  refine (HeckeCoset.mk_eq_mk_of_mem (g₂ := ⟨mapGL ℚ ((g₁ * g₂ : ↥(Gamma0 N)) : SL(2, ℤ)),
+    mapGL_mem_Delta0 N (g₁ * g₂)⟩) ?_).trans (diamondCosetGamma1_def (g₁ * g₂)).symm
+  exact mem_doubleCoset.mpr ⟨_, Subgroup.mul_mem _ (Subgroup.mul_mem _ p.1.out.2 ha) hc,
+    1, Subgroup.one_mem _, key⟩
+
+/-- The decomposition quotient of a diamond coset is a subsingleton: its representative
+normalizes `Γ₁(N)`, so the stabilizer `Γ₁(N) ∩ γΓ₁(N)γ⁻¹` is all of `Γ₁(N)`. -/
+private lemma subsingleton_decompQuotient_diamondCosetGamma1 :
+    Subsingleton (DecompQuotient ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      ((diamondCosetGamma1 N g₁).rep : GL (Fin 2) ℚ)) :=
+  subsingleton_decompQuotient
+    (Subgroup.conjAct_pointwise_smul_eq_self (rep_diamondCosetGamma1_mem_normalizer g₁)).ge
+
+/-- **The diamond basis elements multiply**: `[Γ₁(N) γ₁ Γ₁(N)] · [Γ₁(N) γ₂ Γ₁(N)] =
+[Γ₁(N) γ₁γ₂ Γ₁(N)]` in the Hecke ring, over any coefficient semiring.
+
+There is no structure constant to compute: both decomposition quotients are subsingletons, so
+`multiplicity ≤ 1` is automatic, and every pair of representatives multiplies into the same
+double coset. -/
+theorem single_diamondCosetGamma1_mul_single (R : Type*) [Semiring R] :
+    HeckeCosetModule.single R (diamondCosetGamma1 N g₁) 1 *
+        HeckeCosetModule.single R (diamondCosetGamma1 N g₂) 1 =
+      HeckeCosetModule.single R (diamondCosetGamma1 N (g₁ * g₂)) 1 := by
+  classical
+  rw [HeckeCosetModule.mul_def]
+  have := subsingleton_decompQuotient_diamondCosetGamma1 g₁
+  have := subsingleton_decompQuotient_diamondCosetGamma1 g₂
+  refine HeckeCosetModule.mul_single_single_of_mulMap_eq R _ _ _
+    (mulMap_diamondCosetGamma1 g₁ g₂) ?_
+  rw [multiplicity_def, Nat.card_eq_fintype_card]
+  exact Fintype.card_le_one_iff_subsingleton.mpr inferInstance
+
+end Product
+
+/-- The diamond element `⟨d⟩` of the Hecke ring, for `d : (ZMod N)ˣ`: the basis element of the
+double coset of any `Γ₀(N)` matrix with lower-right entry `d`. Such a matrix exists by
+`CongruenceSubgroup.Gamma0Map_toHomUnits_surjective`, and `diamondCosetGamma1_eq_iff` makes the
+choice immaterial — `diamondHeckeElem_eq_single` is the resulting evaluation rule, through which
+every computation goes. -/
+noncomputable def diamondHeckeElem (N : ℕ) [NeZero N] (d : (ZMod N)ˣ) :
+    𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ :=
+  HeckeCosetModule.single ℤ
+    (diamondCosetGamma1 N (Gamma0Map_toHomUnits_surjective d).choose) 1
+
+/-- The diamond element is computed at *any* representative with the right lower-right entry.
+Not `@[simp]`: the representative `g` occurs only in the hypothesis and the right-hand side,
+so `simp` cannot infer it. -/
+theorem diamondHeckeElem_eq_single {d : (ZMod N)ˣ} (g : ↥(Gamma0 N))
+    (hg : (Gamma0Map N).toHomUnits g = d) :
+    diamondHeckeElem N d = HeckeCosetModule.single ℤ (diamondCosetGamma1 N g) 1 :=
+  congrArg (HeckeCosetModule.single ℤ · 1) (diamondCosetGamma1_eq_iff.mpr
+    ((Gamma0Map_toHomUnits_surjective d).choose_spec.trans hg.symm))
+
+/-- **The diamonds inside the Hecke ring.** The map `d ↦ ⟨d⟩` is a monoid homomorphism
+`(ZMod N)ˣ →* 𝕋 Δ₀(N) Γ₁(N) ℤ`: this is the sense in which the diamond operators live in the
+Hecke algebra of the pair `(Γ₁(N), Δ₀(N))` rather than beside it. -/
+noncomputable def diamondHeckeElemHom (N : ℕ) [NeZero N] :
+    (ZMod N)ˣ →* 𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ where
+  toFun := diamondHeckeElem N
+  map_one' := by
+    rw [diamondHeckeElem_eq_single 1 (map_one _), diamondCosetGamma1_one,
+      ← HeckeCosetModule.one_def]
+  map_mul' d₁ d₂ := by
+    obtain ⟨g₁, hg₁⟩ := Gamma0Map_toHomUnits_surjective (N := N) d₁
+    obtain ⟨g₂, hg₂⟩ := Gamma0Map_toHomUnits_surjective (N := N) d₂
+    rw [diamondHeckeElem_eq_single (g₁ * g₂) (by rw [map_mul, hg₁, hg₂]),
+      diamondHeckeElem_eq_single g₁ hg₁, diamondHeckeElem_eq_single g₂ hg₂]
+    exact (single_diamondCosetGamma1_mul_single g₁ g₂ ℤ).symm
+
+@[simp] lemma diamondHeckeElemHom_apply (d : (ZMod N)ˣ) :
+    diamondHeckeElemHom N d = diamondHeckeElem N d := (rfl)
+
+/-- **The diamonds are a faithful copy of `(ZMod N)ˣ` in the Hecke ring.** Distinct units give
+distinct double cosets (`diamondCosetGamma1_eq_iff`), hence distinct basis elements. -/
+theorem diamondHeckeElemHom_injective : Function.Injective (diamondHeckeElemHom N) := by
+  classical
+  intro d₁ d₂ h
+  obtain ⟨g₁, hg₁⟩ := Gamma0Map_toHomUnits_surjective (N := N) d₁
+  obtain ⟨g₂, hg₂⟩ := Gamma0Map_toHomUnits_surjective (N := N) d₂
+  rw [diamondHeckeElemHom_apply, diamondHeckeElemHom_apply,
+    diamondHeckeElem_eq_single g₁ hg₁, diamondHeckeElem_eq_single g₂ hg₂] at h
+  have hval := congrArg (fun f ↦ f (diamondCosetGamma1 N g₁)) h
+  rw [HeckeCosetModule.single_apply, HeckeCosetModule.single_apply, ite_eq_left rfl] at hval
+  rw [← hg₁, ← hg₂, ← diamondCosetGamma1_eq_iff]
+  by_contra hne
+  exact one_ne_zero (hval.trans (ite_eq_right fun hEq ↦ hne hEq.symm))
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
@@ -74,7 +74,7 @@ open scoped MatrixGroups Pointwise HeckeCosetModule
 
 namespace HeckeRing.GL2
 
-variable {N : ℕ} [NeZero N]
+variable {N : ℕ}
 
 /-- **The diamond double coset** `Γ₁(N) · γ · Γ₁(N)` of an element `γ ∈ Γ₀(N)`, as an element of
 the basis of the Hecke ring of the pair `(Γ₁(N), Δ₀(N))`.
@@ -82,7 +82,7 @@ the basis of the Hecke ring of the pair `(Γ₁(N), Δ₀(N))`.
 It is indexed by an element of `Γ₀(N)` rather than by a unit of `ZMod N` because a double coset
 is formed from a matrix; that it depends only on the lower-right entry is
 `diamondCosetGamma1_eq_iff`, and `diamondHeckeElem` is the resulting unit-indexed element. -/
-noncomputable def diamondCosetGamma1 (N : ℕ) [NeZero N] (g : ↥(Gamma0 N)) :
+noncomputable def diamondCosetGamma1 (N : ℕ) (g : ↥(Gamma0 N)) :
     HeckeCoset (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) :=
   HeckeCoset.mk _ _ ⟨mapGL ℚ (g : SL(2, ℤ)), mapGL_mem_Delta0 N g⟩
 
@@ -134,6 +134,11 @@ theorem doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets (g : ↥(Gamma0
   rw [Set.iUnion_const, HeckeCoset.eq_iff.mp (hout.trans (diamondCosetGamma1_def g))]
   exact doubleCoset_eq_rightCoset_of_mem_normalizer (mapGL_mem_normalizer_Gamma1_map ℚ g)
 
+/-- The diamond coset of the identity is the identity double coset `Γ₁(N) · 1 · Γ₁(N)`. -/
+@[simp] theorem diamondCosetGamma1_one : diamondCosetGamma1 N 1 = 1 := by
+  rw [diamondCosetGamma1_def, HeckeCoset.one_def]
+  exact congrArg (HeckeCoset.mk _ _) (Subtype.ext (map_one (mapGL ℚ)))
+
 /-- **The diamond coset sees exactly the lower-right entry.** Two elements of `Γ₀(N)` give the
 same double coset precisely when they have the same image in `(ZMod N)ˣ`; the forward direction
 uses that `mapGL ℚ` is injective, so a rational coincidence is an integral one. -/
@@ -158,14 +163,17 @@ theorem diamondCosetGamma1_eq_iff {g₁ g₂ : ↥(Gamma0 N)} :
       mul_inv_mem_Gamma1_of_Gamma0Map_eq g₂ g₁ (congrArg Units.val heq.symm), ?_⟩
     rw [map_mul, map_inv]
 
-/-- The diamond coset of the identity is the identity double coset `Γ₁(N) · 1 · Γ₁(N)`. -/
-@[simp] theorem diamondCosetGamma1_one : diamondCosetGamma1 N 1 = 1 := by
-  rw [diamondCosetGamma1_def, HeckeCoset.one_def]
-  exact congrArg (HeckeCoset.mk _ _) (Subtype.ext (map_one (mapGL ℚ)))
+/-- The decomposition quotient of a diamond coset is a subsingleton: its representative
+normalizes `Γ₁(N)`, so the stabilizer `Γ₁(N) ∩ γΓ₁(N)γ⁻¹` is all of `Γ₁(N)`. -/
+private lemma subsingleton_decompQuotient_diamondCosetGamma1 (g : ↥(Gamma0 N)) :
+    Subsingleton (DecompQuotient ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      ((diamondCosetGamma1 N g).rep : GL (Fin 2) ℚ)) :=
+  subsingleton_decompQuotient
+    (Subgroup.conjAct_pointwise_smul_eq_self (rep_diamondCosetGamma1_mem_normalizer g)).ge
 
 section Product
 
-variable (g₁ g₂ : ↥(Gamma0 N))
+variable [NeZero N] (g₁ g₂ : ↥(Gamma0 N))
 
 /-- Every value of `HeckeCoset.mulMap` on two diamond cosets is the diamond coset of the
 product: writing each chosen representative as `a · γ` with `a ∈ Γ₁(N)` and pushing the middle
@@ -210,14 +218,6 @@ private lemma mulMap_diamondCosetGamma1 (p : DecompQuotient ((Gamma1 N).map (map
   exact mem_doubleCoset.mpr ⟨_, Subgroup.mul_mem _ (Subgroup.mul_mem _ p.1.out.2 ha) hc,
     1, Subgroup.one_mem _, key⟩
 
-/-- The decomposition quotient of a diamond coset is a subsingleton: its representative
-normalizes `Γ₁(N)`, so the stabilizer `Γ₁(N) ∩ γΓ₁(N)γ⁻¹` is all of `Γ₁(N)`. -/
-private lemma subsingleton_decompQuotient_diamondCosetGamma1 :
-    Subsingleton (DecompQuotient ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
-      ((diamondCosetGamma1 N g₁).rep : GL (Fin 2) ℚ)) :=
-  subsingleton_decompQuotient
-    (Subgroup.conjAct_pointwise_smul_eq_self (rep_diamondCosetGamma1_mem_normalizer g₁)).ge
-
 /-- **The diamond basis elements multiply**: `[Γ₁(N) γ₁ Γ₁(N)] · [Γ₁(N) γ₂ Γ₁(N)] =
 [Γ₁(N) γ₁γ₂ Γ₁(N)]` in the Hecke ring, over any coefficient semiring.
 
@@ -244,7 +244,7 @@ double coset of any `Γ₀(N)` matrix with lower-right entry `d`. Such a matrix 
 `CongruenceSubgroup.Gamma0Map_toHomUnits_surjective`, and `diamondCosetGamma1_eq_iff` makes the
 choice immaterial — `diamondHeckeElem_eq_single` is the resulting evaluation rule, through which
 every computation goes. -/
-noncomputable def diamondHeckeElem (N : ℕ) [NeZero N] (d : (ZMod N)ˣ) :
+noncomputable def diamondHeckeElem (N : ℕ) (d : (ZMod N)ˣ) :
     𝕋 (Delta0 N) ((Gamma1 N).map (mapGL ℚ)) ℤ :=
   HeckeCosetModule.single ℤ
     (diamondCosetGamma1 N (Gamma0Map_toHomUnits_surjective d).choose) 1
@@ -257,6 +257,8 @@ theorem diamondHeckeElem_eq_single {d : (ZMod N)ˣ} (g : ↥(Gamma0 N))
     diamondHeckeElem N d = HeckeCosetModule.single ℤ (diamondCosetGamma1 N g) 1 :=
   congrArg (HeckeCosetModule.single ℤ · 1) (diamondCosetGamma1_eq_iff.mpr
     ((Gamma0Map_toHomUnits_surjective d).choose_spec.trans hg.symm))
+
+variable [NeZero N]
 
 /-- **The diamonds inside the Hecke ring.** The map `d ↦ ⟨d⟩` is a monoid homomorphism
 `(ZMod N)ˣ →* 𝕋 Δ₀(N) Γ₁(N) ℤ`: this is the sense in which the diamond operators live in the

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
@@ -107,14 +107,14 @@ normalizes `Γ₁(N)`. -/
     (doubleCoset_eq_rightCoset_of_mem_normalizer (mapGL_mem_normalizer_Gamma1_map ℚ g))
 
 /-- The chosen representative of a diamond coset lies in the right coset `Γ₁(N) γ`. -/
-lemma rep_diamondCosetGamma1_mem_rightCoset (g : ↥(Gamma0 N)) :
+private lemma rep_diamondCosetGamma1_mem_rightCoset (g : ↥(Gamma0 N)) :
     ((diamondCosetGamma1 N g).rep : GL (Fin 2) ℚ) ∈
       op (mapGL ℚ (g : SL(2, ℤ))) • ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) :=
   diamondCosetGamma1_toSet g ▸ (diamondCosetGamma1 N g).rep_mem
 
 /-- The chosen representative of a diamond coset again normalizes `Γ₁(N)`: it lies in
 `Γ₁(N) γ Γ₁(N)`, all of whose elements do. -/
-lemma rep_diamondCosetGamma1_mem_normalizer (g : ↥(Gamma0 N)) :
+private lemma rep_diamondCosetGamma1_mem_normalizer (g : ↥(Gamma0 N)) :
     ((diamondCosetGamma1 N g).rep : GL (Fin 2) ℚ) ∈
       Subgroup.normalizer (((Gamma1 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
         Set (GL (Fin 2) ℚ)) :=

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean
@@ -5,12 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.GroupTheory.DoubleCoset.Normalizer
 public import TauCeti.NumberTheory.HeckeRing.Associativity
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.Basic
+public import TauCeti.NumberTheory.HeckeRing.Normalizer
 public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
-
-import Mathlib.Tactic.Group
 
 /-!
 # The diamond double cosets of the `Γ₁(N)` Hecke ring
@@ -31,17 +29,17 @@ companion statement, proved in `ModularForms/HeckeSlash/Diamond.lean`.
 ## Why the double coset collapses, and what that buys
 
 `Γ₁(N)` is normal in `Γ₀(N)` (`CongruenceSubgroup.Gamma0_normalizes_Gamma1`), so `γ` lies in the
-normalizer of the image of `Γ₁(N)` in `GL₂(ℚ)` and
-`DoubleCoset.doubleCoset_eq_rightCoset_of_mem_normalizer` collapses `Γ₁(N) γ Γ₁(N)` to
-`Γ₁(N) γ`. Two consequences drive everything below.
+normalizer of the image of `Γ₁(N)` in `GL₂(ℚ)`. Everything below is then an instance of the
+general theory of `HeckeRing/Normalizer.lean`, which collapses a double coset at a normalizing
+element to a single right coset and draws the two consequences that drive this file.
 
 * The double coset has a **single** right coset, so the slash operator attached to it is a
   one-term sum. That is the shape `heckeSlashSum` consumes, through the decomposition
   `doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets` stated at the chosen representative.
 * Its decomposition quotients are subsingletons, so the structure constants of a product of two
-  diamond cosets are at most `1` and `HeckeCosetModule.mul_single_single_of_mulMap_eq` applies:
-  the product of two diamond basis elements is the diamond basis element of the product. No
-  counting is needed, which is exactly what distinguishes the diamonds from the `Tₚ`.
+  diamond cosets are at most `1`: the product of two diamond basis elements is the diamond basis
+  element of the product. No counting is needed, which is exactly what distinguishes the
+  diamonds from the `Tₚ`.
 
 ## Main definitions
 
@@ -51,12 +49,12 @@ normalizer of the image of `Γ₁(N)` in `GL₂(ℚ)` and
 
 ## Main results
 
-* `HeckeRing.GL2.diamondCosetGamma1_toSet` and
+* `HeckeRing.GL2.diamondCosetGamma1_toSet_eq_rightCoset` and
   `HeckeRing.GL2.doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets`: the double coset is
   the single right coset `Γ₁(N) γ`, in the two spellings the Hecke machinery uses.
 * `HeckeRing.GL2.diamondCosetGamma1_eq_iff`: the coset depends exactly on the lower-right entry.
-* `HeckeRing.GL2.single_diamondCosetGamma1_mul_single`: the basis elements multiply,
-  `[Γ₁(N) γ₁ Γ₁(N)] · [Γ₁(N) γ₂ Γ₁(N)] = [Γ₁(N) γ₁γ₂ Γ₁(N)]`.
+* `HeckeRing.GL2.single_diamondCosetGamma1_mul_single_diamondCosetGamma1`: the basis elements
+  multiply, `[Γ₁(N) γ₁ Γ₁(N)] · [Γ₁(N) γ₂ Γ₁(N)] = [Γ₁(N) γ₁γ₂ Γ₁(N)]`.
 * `HeckeRing.GL2.diamondHeckeElemHom_injective`: the diamonds form a faithful copy of
   `(ZMod N)ˣ` inside the Hecke ring.
 
@@ -91,8 +89,10 @@ lemma diamondCosetGamma1_def (g : ↥(Gamma0 N)) :
     diamondCosetGamma1 N g = HeckeCoset.mk ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
       ⟨mapGL ℚ (g : SL(2, ℤ)), mapGL_mem_Delta0 N g⟩ := (rfl)
 
-/-- The underlying set of a diamond coset is the double coset of `γ`. -/
-lemma diamondCosetGamma1_toSet_eq_doubleCoset (g : ↥(Gamma0 N)) :
+/-- The underlying set of a diamond coset is the double coset of `γ`: `HeckeCoset.toSet_mk`
+read at the sealed definition `diamondCosetGamma1`, whose body `simp` cannot unfold on its own.
+The collapsed form is `diamondCosetGamma1_toSet_eq_rightCoset`. -/
+lemma diamondCosetGamma1_toSet (g : ↥(Gamma0 N)) :
     (diamondCosetGamma1 N g).toSet =
       doubleCoset (mapGL ℚ (g : SL(2, ℤ))) ((Gamma1 N).map (mapGL ℚ))
         ((Gamma1 N).map (mapGL ℚ)) :=
@@ -100,26 +100,10 @@ lemma diamondCosetGamma1_toSet_eq_doubleCoset (g : ↥(Gamma0 N)) :
 
 /-- **The diamond double coset is a single right coset**, `Γ₁(N) γ Γ₁(N) = Γ₁(N) γ`, since `γ`
 normalizes `Γ₁(N)`. -/
-@[simp] lemma diamondCosetGamma1_toSet (g : ↥(Gamma0 N)) :
+@[simp] lemma diamondCosetGamma1_toSet_eq_rightCoset (g : ↥(Gamma0 N)) :
     (diamondCosetGamma1 N g).toSet =
       op (mapGL ℚ (g : SL(2, ℤ))) • ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) :=
-  (diamondCosetGamma1_toSet_eq_doubleCoset g).trans
-    (doubleCoset_eq_rightCoset_of_mem_normalizer (mapGL_mem_normalizer_Gamma1_map ℚ g))
-
-/-- The chosen representative of a diamond coset lies in the right coset `Γ₁(N) γ`. -/
-private lemma rep_diamondCosetGamma1_mem_rightCoset (g : ↥(Gamma0 N)) :
-    ((diamondCosetGamma1 N g).rep : GL (Fin 2) ℚ) ∈
-      op (mapGL ℚ (g : SL(2, ℤ))) • ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) :=
-  diamondCosetGamma1_toSet g ▸ (diamondCosetGamma1 N g).rep_mem
-
-/-- The chosen representative of a diamond coset again normalizes `Γ₁(N)`: it lies in
-`Γ₁(N) γ Γ₁(N)`, all of whose elements do. -/
-private lemma rep_diamondCosetGamma1_mem_normalizer (g : ↥(Gamma0 N)) :
-    ((diamondCosetGamma1 N g).rep : GL (Fin 2) ℚ) ∈
-      Subgroup.normalizer (((Gamma1 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
-        Set (GL (Fin 2) ℚ)) :=
-  mem_normalizer_of_mem_doubleCoset (mapGL_mem_normalizer_Gamma1_map ℚ g)
-    (diamondCosetGamma1_toSet_eq_doubleCoset g ▸ (diamondCosetGamma1 N g).rep_mem)
+  HeckeCoset.toSet_mk_eq_rightCoset_of_mem_normalizer (mapGL_mem_normalizer_Gamma1_map ℚ g)
 
 /-- The double coset of the chosen representative of `diamondCosetGamma1 N g`, presented as the
 one-term union of right cosets — the shape the slash sum of
@@ -129,15 +113,16 @@ theorem doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets (g : ↥(Gamma0
         ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ)) =
       ⋃ _ : Unit, op (mapGL ℚ (g : SL(2, ℤ))) •
         ((Gamma1 N).map (mapGL ℚ) : Set (GL (Fin 2) ℚ)) := by
-  have hout : HeckeCoset.mk ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
-      (diamondCosetGamma1 N g).out = diamondCosetGamma1 N g := Quotient.out_eq _
-  rw [Set.iUnion_const, HeckeCoset.eq_iff.mp (hout.trans (diamondCosetGamma1_def g))]
-  exact doubleCoset_eq_rightCoset_of_mem_normalizer (mapGL_mem_normalizer_Gamma1_map ℚ g)
+  rw [Set.iUnion_const]
+  exact HeckeCoset.doubleCoset_out_mk_eq_rightCoset_of_mem_normalizer
+    (mapGL_mem_normalizer_Gamma1_map ℚ g)
 
 /-- The diamond coset of the identity is the identity double coset `Γ₁(N) · 1 · Γ₁(N)`. -/
 @[simp] theorem diamondCosetGamma1_one : diamondCosetGamma1 N 1 = 1 := by
+  have hone : mapGL ℚ ((1 : ↥(Gamma0 N)) : SL(2, ℤ)) = 1 := by
+    rw [Subgroup.coe_one, map_one]
   rw [diamondCosetGamma1_def, HeckeCoset.one_def]
-  exact congrArg (HeckeCoset.mk _ _) (Subtype.ext (map_one (mapGL ℚ)))
+  exact congrArg (HeckeCoset.mk _ _) (Subtype.ext hone)
 
 /-- **The diamond coset sees exactly the lower-right entry.** Two elements of `Γ₀(N)` give the
 same double coset precisely when they have the same image in `(ZMod N)ˣ`; the forward direction
@@ -145,97 +130,47 @@ uses that `mapGL ℚ` is injective, so a rational coincidence is an integral one
 @[simp] theorem diamondCosetGamma1_eq_iff {g₁ g₂ : ↥(Gamma0 N)} :
     diamondCosetGamma1 N g₁ = diamondCosetGamma1 N g₂ ↔
       (Gamma0Map N).toHomUnits g₁ = (Gamma0Map N).toHomUnits g₂ := by
-  rw [← HeckeCoset.toSet_injective.eq_iff, diamondCosetGamma1_toSet, diamondCosetGamma1_toSet,
-    rightCoset_eq_iff]
+  rw [← HeckeCoset.toSet_injective.eq_iff, diamondCosetGamma1_toSet_eq_rightCoset,
+    diamondCosetGamma1_toSet_eq_rightCoset, rightCoset_eq_iff]
   constructor
   · intro hmem
     obtain ⟨σ, hσ, hσeq⟩ := Subgroup.mem_map.mp hmem
     have hσ' : σ = (g₂ : SL(2, ℤ)) * (g₁ : SL(2, ℤ))⁻¹ :=
       (mapGL_inj (S := ℚ) _ _).mp (by rw [hσeq, map_mul, map_inv])
-    have hker : (g₂ * g₁⁻¹ : ↥(Gamma0 N)) ∈ Gamma1' N :=
-      (Gamma1_to_Gamma0_mem _).mpr ((Gamma1_mem _ _).mp (by rwa [hσ'] at hσ))
-    have h1 : (Gamma0Map N).toHomUnits (g₂ * g₁⁻¹) = 1 :=
-      Units.ext ((MonoidHom.coe_toHomUnits _ _).trans (Gamma1_mem'.mp hker))
-    rw [map_mul, map_inv, mul_inv_eq_one] at h1
-    exact h1.symm
+    have heq := (mul_inv_mem_Gamma1_iff_Gamma0Map_eq g₂ g₁).mp (by rwa [hσ'] at hσ)
+    refine Units.ext ?_
+    rw [MonoidHom.coe_toHomUnits, MonoidHom.coe_toHomUnits]
+    exact heq.symm
   · intro heq
     refine Subgroup.mem_map.mpr ⟨(g₂ : SL(2, ℤ)) * (g₁ : SL(2, ℤ))⁻¹,
-      mul_inv_mem_Gamma1_of_Gamma0Map_eq g₂ g₁ (congrArg Units.val heq.symm), ?_⟩
+      (mul_inv_mem_Gamma1_iff_Gamma0Map_eq g₂ g₁).mpr (congrArg Units.val heq.symm), ?_⟩
     rw [map_mul, map_inv]
-
-/-- The decomposition quotient of a diamond coset is a subsingleton: its representative
-normalizes `Γ₁(N)`, so the stabilizer `Γ₁(N) ∩ γΓ₁(N)γ⁻¹` is all of `Γ₁(N)`. -/
-private lemma subsingleton_decompQuotient_diamondCosetGamma1 (g : ↥(Gamma0 N)) :
-    Subsingleton (DecompQuotient ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
-      ((diamondCosetGamma1 N g).rep : GL (Fin 2) ℚ)) :=
-  subsingleton_decompQuotient
-    (Subgroup.conjAct_pointwise_smul_eq_self (rep_diamondCosetGamma1_mem_normalizer g)).ge
 
 section Product
 
 variable [NeZero N] (g₁ g₂ : ↥(Gamma0 N))
 
-/-- Every value of `HeckeCoset.mulMap` on two diamond cosets is the diamond coset of the
-product: writing each chosen representative as `a · γ` with `a ∈ Γ₁(N)` and pushing the middle
-`Γ₁(N)` factor across `γ₁` — legitimate because `γ₁` normalizes `Γ₁(N)` — leaves
-`Γ₁(N) · γ₁γ₂`. -/
-private lemma mulMap_diamondCosetGamma1 (p : DecompQuotient ((Gamma1 N).map (mapGL ℚ))
-    ((Gamma1 N).map (mapGL ℚ)) ((diamondCosetGamma1 N g₁).rep : GL (Fin 2) ℚ) ×
-      DecompQuotient ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
-        ((diamondCosetGamma1 N g₂).rep : GL (Fin 2) ℚ)) :
-    HeckeCoset.mulMap ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
-        ((Gamma1 N).map (mapGL ℚ)) (diamondCosetGamma1 N g₁).rep
-        (diamondCosetGamma1 N g₂).rep p = diamondCosetGamma1 N (g₁ * g₂) := by
-  -- name the two representatives as `a γ₁` and `b γ₂`, so that the identity below is an
-  -- identity between short words in six atoms
-  obtain ⟨a, ha, hA⟩ : ∃ a ∈ (Gamma1 N).map (mapGL ℚ),
-      ((diamondCosetGamma1 N g₁).rep : GL (Fin 2) ℚ) = a * mapGL ℚ (g₁ : SL(2, ℤ)) :=
-    ⟨_, (mem_rightCoset_iff _).mp (rep_diamondCosetGamma1_mem_rightCoset g₁),
-      (inv_mul_cancel_right _ _).symm⟩
-  obtain ⟨b, hb, hB⟩ : ∃ b ∈ (Gamma1 N).map (mapGL ℚ),
-      ((diamondCosetGamma1 N g₂).rep : GL (Fin 2) ℚ) = b * mapGL ℚ (g₂ : SL(2, ℤ)) :=
-    ⟨_, (mem_rightCoset_iff _).mp (rep_diamondCosetGamma1_mem_rightCoset g₂),
-      (inv_mul_cancel_right _ _).symm⟩
-  -- the middle `Γ₁(N)` factor, conjugated across `γ₁`
-  have hc : mapGL ℚ (g₁ : SL(2, ℤ)) * ((p.2.out : GL (Fin 2) ℚ) * b) *
-      (mapGL ℚ (g₁ : SL(2, ℤ)))⁻¹ ∈ (Gamma1 N).map (mapGL ℚ) :=
-    (Subgroup.mem_normalizer_iff.mp (mapGL_mem_normalizer_Gamma1_map ℚ g₁) _).mp
-      (Subgroup.mul_mem _ p.2.out.2 hb)
-  have hprod : mapGL ℚ (g₁ : SL(2, ℤ)) * mapGL ℚ (g₂ : SL(2, ℤ)) =
-      mapGL ℚ ((g₁ * g₂ : ↥(Gamma0 N)) : SL(2, ℤ)) := by
-    rw [Subgroup.coe_mul, map_mul]
-  -- the word identity, in six free atoms: quantifying over `u` and `v` keeps `group` away from
-  -- the coset representatives, whose types are large
-  have key₀ : ∀ u v : GL (Fin 2) ℚ, u * (a * mapGL ℚ (g₁ : SL(2, ℤ))) *
-      (v * (b * mapGL ℚ (g₂ : SL(2, ℤ)))) =
-      u * a * (mapGL ℚ (g₁ : SL(2, ℤ)) * (v * b) * (mapGL ℚ (g₁ : SL(2, ℤ)))⁻¹) *
-        (mapGL ℚ (g₁ : SL(2, ℤ)) * mapGL ℚ (g₂ : SL(2, ℤ))) * 1 := fun u v ↦ by group
-  have key := key₀ (p.1.out : GL (Fin 2) ℚ) (p.2.out : GL (Fin 2) ℚ)
-  rw [← hA, ← hB, hprod] at key
-  rw [HeckeCoset.mulMap_eq_mk]
-  refine (HeckeCoset.mk_eq_mk_of_mem (g₂ := ⟨mapGL ℚ ((g₁ * g₂ : ↥(Gamma0 N)) : SL(2, ℤ)),
-    mapGL_mem_Delta0 N (g₁ * g₂)⟩) ?_).trans (diamondCosetGamma1_def (g₁ * g₂)).symm
-  exact mem_doubleCoset.mpr ⟨_, Subgroup.mul_mem _ (Subgroup.mul_mem _ p.1.out.2 ha) hc,
-    1, Subgroup.one_mem _, key⟩
-
 /-- **The diamond basis elements multiply**: `[Γ₁(N) γ₁ Γ₁(N)] · [Γ₁(N) γ₂ Γ₁(N)] =
 [Γ₁(N) γ₁γ₂ Γ₁(N)]` in the Hecke ring, over any coefficient semiring.
 
-There is no structure constant to compute: both decomposition quotients are subsingletons, so
-`multiplicity ≤ 1` is automatic, and every pair of representatives multiplies into the same
-double coset. -/
-@[simp] theorem single_diamondCosetGamma1_mul_single (R : Type*) [Semiring R] :
+This is `HeckeCosetModule.single_mul_single_of_mem_normalizer` at the two `Γ₀(N)` matrices,
+which normalize `Γ₁(N)`; only the identification of the two products of monoid elements is left
+to do here. -/
+@[simp] theorem single_diamondCosetGamma1_mul_single_diamondCosetGamma1 (R : Type*)
+    [Semiring R] :
     HeckeCosetModule.single R (diamondCosetGamma1 N g₁) 1 *
         HeckeCosetModule.single R (diamondCosetGamma1 N g₂) 1 =
       HeckeCosetModule.single R (diamondCosetGamma1 N (g₁ * g₂)) 1 := by
-  classical
-  rw [HeckeCosetModule.mul_def]
-  have := subsingleton_decompQuotient_diamondCosetGamma1 g₁
-  have := subsingleton_decompQuotient_diamondCosetGamma1 g₂
-  refine HeckeCosetModule.mul_single_single_of_mulMap_eq R _ _ _
-    (mulMap_diamondCosetGamma1 g₁ g₂) ?_
-  rw [multiplicity_def, Nat.card_eq_fintype_card]
-  exact Fintype.card_le_one_iff_subsingleton.mpr inferInstance
+  have hprod : mapGL ℚ (g₁ : SL(2, ℤ)) * mapGL ℚ (g₂ : SL(2, ℤ)) =
+      mapGL ℚ ((g₁ * g₂ : ↥(Gamma0 N)) : SL(2, ℤ)) := by
+    rw [Subgroup.coe_mul, map_mul]
+  have hcoset : HeckeCoset.mk ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      ((⟨mapGL ℚ (g₁ : SL(2, ℤ)), mapGL_mem_Delta0 N g₁⟩ : ↥(Delta0 N)) *
+        ⟨mapGL ℚ (g₂ : SL(2, ℤ)), mapGL_mem_Delta0 N g₂⟩) = diamondCosetGamma1 N (g₁ * g₂) :=
+    congrArg (HeckeCoset.mk _ _) (Subtype.ext hprod)
+  rw [← hcoset]
+  exact HeckeCosetModule.single_mul_single_of_mem_normalizer R
+    (mapGL_mem_normalizer_Gamma1_map ℚ g₁) (mapGL_mem_normalizer_Gamma1_map ℚ g₂)
 
 end Product
 
@@ -274,7 +209,7 @@ noncomputable def diamondHeckeElemHom (N : ℕ) [NeZero N] :
     obtain ⟨g₂, hg₂⟩ := Gamma0Map_toHomUnits_surjective (N := N) d₂
     rw [diamondHeckeElem_eq_single (g₁ * g₂) (by rw [map_mul, hg₁, hg₂]),
       diamondHeckeElem_eq_single g₁ hg₁, diamondHeckeElem_eq_single g₂ hg₂]
-    exact (single_diamondCosetGamma1_mul_single g₁ g₂ ℤ).symm
+    exact (single_diamondCosetGamma1_mul_single_diamondCosetGamma1 g₁ g₂ ℤ).symm
 
 @[simp] lemma diamondHeckeElemHom_apply (d : (ZMod N)ˣ) :
     diamondHeckeElemHom N d = diamondHeckeElem N d := (rfl)

--- a/TauCeti/NumberTheory/HeckeRing/Normalizer.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Normalizer.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.GroupTheory.DoubleCoset.Normalizer
+public import TauCeti.NumberTheory.HeckeRing.Multiplication
+
+import Mathlib.Tactic.Group
+
+/-!
+# Hecke double cosets at a normalizing element
+
+`GroupTheory/DoubleCoset/Normalizer.lean` collapses a double coset `ΓgΓ` to the single right
+coset `Γg` when `g` normalizes `Γ`. This file draws the Hecke-ring consequences, for a Hecke
+triple `(Δ, Γ, Γ)` and an `x : Δ` normalizing `Γ`:
+
+* the underlying set of `HeckeCoset.mk Γ Γ x` is `Γx`, and so is the double coset of its chosen
+  representative — the shape in which the slash sum of a double coset consumes a decomposition;
+* the chosen representative again normalizes `Γ`, so the decomposition quotient
+  `Γ ⧸ (Γ ∩ xΓx⁻¹)` is a subsingleton;
+* consequently the basis elements multiply with no structure constant to count,
+  `[ΓxΓ] · [ΓyΓ] = [Γ(xy)Γ]`, whenever `x` and `y` both normalize `Γ`.
+
+The last statement is what lets a submonoid of the normalizer of `Γ` act on the Hecke ring
+through its basis elements. For `Γ₁(N) ⊴ Γ₀(N)` it is the diamond direction of the `Γ₁(N)`
+Hecke ring, in `HeckeRing/GL2/Gamma1/DiamondCosets.lean`.
+
+## Main results
+
+* `DoubleCoset.subsingleton_decompQuotient_of_mem_normalizer`: the decomposition quotient at a
+  normalizing element is a subsingleton.
+* `HeckeCoset.toSet_mk_eq_rightCoset_of_mem_normalizer` and
+  `HeckeCoset.doubleCoset_out_mk_eq_rightCoset_of_mem_normalizer`: the double coset of a
+  normalizing element is the single right coset `Γx`, at `x` itself and at the chosen
+  representative.
+* `HeckeCosetModule.single_mul_single_of_mem_normalizer`: the product of the basis elements of
+  two normalizing elements is the basis element of their product.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.1.
+-/
+
+public section
+
+open DoubleCoset MulOpposite
+
+open scoped Pointwise
+
+namespace DoubleCoset
+
+variable {G : Type*} [Group G] {Γ : Subgroup G} {g : G}
+
+/-- **The decomposition quotient at a normalizing element is a subsingleton**: the stabilizer
+`Γ ∩ gΓg⁻¹` is all of `Γ`. This is `subsingleton_decompQuotient_of_mem` with membership in `Γ`
+weakened to membership in its normalizer. -/
+lemma subsingleton_decompQuotient_of_mem_normalizer
+    (hg : g ∈ Subgroup.normalizer (Γ : Set G)) : Subsingleton (DecompQuotient Γ Γ g) :=
+  subsingleton_decompQuotient (Subgroup.conjAct_pointwise_smul_eq_self hg).ge
+
+end DoubleCoset
+
+namespace HeckeCoset
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {Γ : Subgroup G} {x y : Δ}
+
+/-- **The double coset of a normalizing element is a single right coset**, `ΓxΓ = Γx`. -/
+lemma toSet_mk_eq_rightCoset_of_mem_normalizer
+    (hx : (x : G) ∈ Subgroup.normalizer (Γ : Set G)) :
+    (mk Γ Γ x).toSet = op (x : G) • (Γ : Set G) :=
+  (toSet_mk x).trans (DoubleCoset.doubleCoset_eq_rightCoset_of_mem_normalizer hx)
+
+/-- The same collapse read at the chosen representative of `HeckeCoset.mk Γ Γ x`, which is the
+shape a decomposition of a double coset into right cosets is stated in. -/
+lemma doubleCoset_out_mk_eq_rightCoset_of_mem_normalizer
+    (hx : (x : G) ∈ Subgroup.normalizer (Γ : Set G)) :
+    DoubleCoset.doubleCoset (((mk Γ Γ x).out : Δ) : G) Γ Γ = op (x : G) • (Γ : Set G) :=
+  (eq_iff.mp (Quotient.out_eq (mk Γ Γ x))).trans
+    (DoubleCoset.doubleCoset_eq_rightCoset_of_mem_normalizer hx)
+
+/-- The chosen representative of `HeckeCoset.mk Γ Γ x` lies in the right coset `Γx`. -/
+lemma rep_mk_mem_rightCoset_of_mem_normalizer
+    (hx : (x : G) ∈ Subgroup.normalizer (Γ : Set G)) :
+    (((mk Γ Γ x).rep : Δ) : G) ∈ op (x : G) • (Γ : Set G) :=
+  toSet_mk_eq_rightCoset_of_mem_normalizer hx ▸ (mk Γ Γ x).rep_mem
+
+/-- The chosen representative of `HeckeCoset.mk Γ Γ x` again normalizes `Γ`: it lies in `ΓxΓ`,
+all of whose elements do. -/
+lemma rep_mk_mem_normalizer_of_mem_normalizer
+    (hx : (x : G) ∈ Subgroup.normalizer (Γ : Set G)) :
+    (((mk Γ Γ x).rep : Δ) : G) ∈ Subgroup.normalizer (Γ : Set G) :=
+  DoubleCoset.mem_normalizer_of_mem_doubleCoset hx (toSet_mk x ▸ (mk Γ Γ x).rep_mem)
+
+/-- **Every value of `HeckeCoset.mulMap` on two normalizing elements is the double coset of
+their product**: writing each chosen representative as `a · x` with `a ∈ Γ` and pushing the
+middle `Γ` factor across `x` — legitimate because `x` normalizes `Γ` — leaves `Γ · xy`. -/
+lemma mulMap_rep_mk_eq_of_mem_normalizer [IsHeckeTriple Δ Γ Γ]
+    (hx : (x : G) ∈ Subgroup.normalizer (Γ : Set G))
+    (hy : (y : G) ∈ Subgroup.normalizer (Γ : Set G))
+    (p : DecompQuotient Γ Γ (((mk Γ Γ x).rep : Δ) : G) ×
+      DecompQuotient Γ Γ (((mk Γ Γ y).rep : Δ) : G)) :
+    mulMap Γ Γ Γ (mk Γ Γ x).rep (mk Γ Γ y).rep p = mk Γ Γ (x * y) := by
+  -- name the two representatives as `a x` and `b y`, so that the identity below is an identity
+  -- between short words in six atoms
+  obtain ⟨a, ha, hA⟩ : ∃ a ∈ Γ, (((mk Γ Γ x).rep : Δ) : G) = a * (x : G) :=
+    ⟨_, (mem_rightCoset_iff _).mp (rep_mk_mem_rightCoset_of_mem_normalizer hx),
+      (inv_mul_cancel_right _ _).symm⟩
+  obtain ⟨b, hb, hB⟩ : ∃ b ∈ Γ, (((mk Γ Γ y).rep : Δ) : G) = b * (y : G) :=
+    ⟨_, (mem_rightCoset_iff _).mp (rep_mk_mem_rightCoset_of_mem_normalizer hy),
+      (inv_mul_cancel_right _ _).symm⟩
+  -- the middle `Γ` factor, conjugated across `x`
+  have hc : (x : G) * ((p.2.out : G) * b) * (x : G)⁻¹ ∈ Γ :=
+    (Subgroup.mem_normalizer_iff.mp hx _).mp (Subgroup.mul_mem _ p.2.out.2 hb)
+  -- the word identity, in six free atoms: quantifying over `u` and `v` keeps `group` away from
+  -- the coset representatives, whose types are large
+  have key₀ : ∀ u v : G, u * (a * (x : G)) * (v * (b * (y : G))) =
+      u * a * ((x : G) * (v * b) * (x : G)⁻¹) * ((x : G) * (y : G)) * 1 := fun u v ↦ by group
+  have key := key₀ (p.1.out : G) (p.2.out : G)
+  rw [← hA, ← hB] at key
+  rw [mulMap_eq_mk]
+  exact mk_eq_mk_of_mem (g₂ := x * y) (DoubleCoset.mem_doubleCoset.mpr
+    ⟨_, Subgroup.mul_mem _ (Subgroup.mul_mem _ p.1.out.2 ha) hc, 1, Subgroup.one_mem _, key⟩)
+
+end HeckeCoset
+
+namespace HeckeCosetModule
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {Γ : Subgroup G} {x y : Δ}
+
+/-- **The basis elements of two normalizing elements multiply**, `[ΓxΓ] · [ΓyΓ] = [Γ(xy)Γ]`,
+over any coefficient semiring.
+
+There is no structure constant to compute: both decomposition quotients are subsingletons, so
+`multiplicity ≤ 1` is automatic, and every pair of representatives multiplies into the same
+double coset. -/
+theorem single_mul_single_of_mem_normalizer [IsHeckeTriple Δ Γ Γ] (R : Type*) [Semiring R]
+    (hx : (x : G) ∈ Subgroup.normalizer (Γ : Set G))
+    (hy : (y : G) ∈ Subgroup.normalizer (Γ : Set G)) :
+    single R (HeckeCoset.mk Γ Γ x) 1 * single R (HeckeCoset.mk Γ Γ y) 1 =
+      single R (HeckeCoset.mk Γ Γ (x * y)) 1 := by
+  classical
+  rw [mul_def]
+  have := DoubleCoset.subsingleton_decompQuotient_of_mem_normalizer
+    (HeckeCoset.rep_mk_mem_normalizer_of_mem_normalizer hx)
+  have := DoubleCoset.subsingleton_decompQuotient_of_mem_normalizer
+    (HeckeCoset.rep_mk_mem_normalizer_of_mem_normalizer hy)
+  refine mul_single_single_of_mulMap_eq R _ _ _
+    (HeckeCoset.mulMap_rep_mk_eq_of_mem_normalizer hx hy) ?_
+  rw [DoubleCoset.multiplicity_def, Nat.card_eq_fintype_card]
+  exact Fintype.card_le_one_iff_subsingleton.mpr inferInstance
+
+end HeckeCosetModule
+
+end

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -190,16 +190,8 @@ theorem mapGL_mem_normalizer_Gamma1_map (S : Type*) [CommRing S] (g : ↥(Gamma0
     mapGL S (g : SL(2, ℤ)) ∈
       Subgroup.normalizer (((Gamma1 N).map (mapGL S) : Subgroup (GL (Fin 2) S)) :
         Set (GL (Fin 2) S)) := by
-  refine Subgroup.mem_normalizer_iff.mpr fun y ↦ ⟨fun hy ↦ ?_, fun hy ↦ ?_⟩
-  · obtain ⟨σ, hσ, rfl⟩ := Subgroup.mem_map.mp hy
-    exact Subgroup.mem_map.mpr ⟨(g : SL(2, ℤ)) * σ * (g : SL(2, ℤ))⁻¹,
-      Gamma0_normalizes_Gamma1 g σ hσ, by simp [map_mul, map_inv]⟩
-  · obtain ⟨σ, hσ, hσy⟩ := Subgroup.mem_map.mp hy
-    refine Subgroup.mem_map.mpr ⟨(g : SL(2, ℤ))⁻¹ * σ * (g : SL(2, ℤ)), ?_, ?_⟩
-    · simpa [inv_inv] using Gamma0_normalizes_Gamma1
-        ⟨(g : SL(2, ℤ))⁻¹, (Gamma0 N).inv_mem g.property⟩ σ hσ
-    · rw [map_mul, map_mul, map_inv, hσy]
-      group
+  exact Subgroup.le_normalizer_map (H := Gamma1 N) (mapGL S)
+    (Subgroup.mem_map.mpr ⟨g, Gamma0_le_normalizer_Gamma1 N g.property, rfl⟩)
 
 /-- `(Gamma1 N).map (mapGL ℝ)` is invariant under conjugation by `Gamma0 N` elements
 in `GL₂(ℝ)`: the pointwise-conjugation form of `mapGL_mem_normalizer_Gamma1_map`. -/

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -17,8 +17,9 @@ import TauCeti.Data.ZMod.Divisibility
 
 Foundational results about the pair `Γ₁(N) ≤ Γ₀(N)` beyond Mathlib's
 `Mathlib.NumberTheory.ModularForms.CongruenceSubgroups`: `Γ₀(N)` normalizes `Γ₁(N)` (also
-after mapping to `GL₂(ℝ)`), the ratio of two `Γ₀(N)`-elements with equal lower-right entry
-lies in `Γ₁(N)`, the lower-right-entry map `Γ₀(N) →* (ZMod N)ˣ` is surjective, and the
+after mapping to `GL₂(S)`, over any commutative ring `S`), the ratio of two `Γ₀(N)`-elements
+with equal lower-right entry lies in `Γ₁(N)`, the lower-right-entry map `Γ₀(N) →* (ZMod N)ˣ`
+is surjective, and the
 location of `-I`: it always lies in `Γ₀(N)`, with lower-right entry the unit `-1`, and it
 lies in `Γ₁(N)` exactly when `N ∣ 2`; and every power of the translation matrix `T` lies in
 `Γ₁(N)`, at every level.  The file then computes the index of `Γ₀` at
@@ -55,8 +56,10 @@ infrastructure independent of the diamond operators.
   `CongruenceSubgroup.Gamma0_le_normalizer_Gamma1`: conjugation by `Γ₀(N)` preserves `Γ₁(N)`.
 * `CongruenceSubgroup.Gamma1_map_le_Gamma0_map`: the inclusion `Γ₁(N) ≤ Γ₀(N)` after mapping to
   `GL₂(ℝ)`.
-* `CongruenceSubgroup.Gamma1_map_inv_conjAct_eq`: `(Gamma1 N).map (mapGL ℝ)` is invariant
-  under conjugation by `Γ₀(N)` elements in `GL₂(ℝ)`.
+* `CongruenceSubgroup.mapGL_mem_normalizer_Gamma1_map` and
+  `CongruenceSubgroup.Gamma1_map_inv_conjAct_eq`: `(Gamma1 N).map (mapGL S)` is invariant
+  under conjugation by `Γ₀(N)` elements in `GL₂(S)`, over any commutative ring `S`, stated as
+  normalizer membership and — over `ℝ` — as a pointwise conjugation.
 * `CongruenceSubgroup.Gamma0Map_toHomUnits_surjective`: every unit of `ZMod N` is the
   lower-right entry of a matrix in `Γ₀(N)` (via strong approximation for `SL₂`).
 * `CongruenceSubgroup.gamma0Twist`: an explicit `Γ₀(N)` element whose lower-right entry is any
@@ -177,25 +180,34 @@ theorem Gamma1_map_le_Gamma0_map (N : ℕ) :
     (Gamma1 N).map (mapGL ℝ) ≤ (Gamma0 N).map (mapGL ℝ) :=
   Subgroup.map_mono (Gamma1_in_Gamma0 N)
 
+/-- **`Γ₀(N)` normalizes `Γ₁(N)` after mapping to `GL₂(S)`**, for any commutative ring `S`.
+This is `Gamma0_normalizes_Gamma1` transported along the monoid homomorphism `mapGL S`: the
+conjugate of an integral witness is again one.
+
+The ring is arbitrary because both rings occur: the slash action of a modular form lives over
+`ℝ`, while the Hecke triples of `Γ₀(N)` and `Γ₁(N)` live over `ℚ`. -/
+theorem mapGL_mem_normalizer_Gamma1_map (S : Type*) [CommRing S] (g : ↥(Gamma0 N)) :
+    mapGL S (g : SL(2, ℤ)) ∈
+      Subgroup.normalizer (((Gamma1 N).map (mapGL S) : Subgroup (GL (Fin 2) S)) :
+        Set (GL (Fin 2) S)) := by
+  refine Subgroup.mem_normalizer_iff.mpr fun y ↦ ⟨fun hy ↦ ?_, fun hy ↦ ?_⟩
+  · obtain ⟨σ, hσ, rfl⟩ := Subgroup.mem_map.mp hy
+    exact Subgroup.mem_map.mpr ⟨(g : SL(2, ℤ)) * σ * (g : SL(2, ℤ))⁻¹,
+      Gamma0_normalizes_Gamma1 g σ hσ, by simp [map_mul, map_inv]⟩
+  · obtain ⟨σ, hσ, hσy⟩ := Subgroup.mem_map.mp hy
+    refine Subgroup.mem_map.mpr ⟨(g : SL(2, ℤ))⁻¹ * σ * (g : SL(2, ℤ)), ?_, ?_⟩
+    · simpa [inv_inv] using Gamma0_normalizes_Gamma1
+        ⟨(g : SL(2, ℤ))⁻¹, (Gamma0 N).inv_mem g.property⟩ σ hσ
+    · rw [map_mul, map_mul, map_inv, hσy]
+      group
+
 /-- `(Gamma1 N).map (mapGL ℝ)` is invariant under conjugation by `Gamma0 N` elements
-in `GL₂(ℝ)`. -/
+in `GL₂(ℝ)`: the pointwise-conjugation form of `mapGL_mem_normalizer_Gamma1_map`. -/
 theorem Gamma1_map_inv_conjAct_eq (g : ↥(Gamma0 N)) :
     ConjAct.toConjAct (mapGL ℝ (g : SL(2, ℤ)))⁻¹ •
-    (Gamma1 N).map (mapGL ℝ) = (Gamma1 N).map (mapGL ℝ) := by
-  ext y
-  simp only [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
-    ConjAct.ofConjAct_toConjAct, map_inv, inv_inv, Subgroup.mem_map]
-  constructor
-  · rintro ⟨σ, hσ, hσy⟩
-    have hmem : (g : SL(2, ℤ))⁻¹ * σ * (g : SL(2, ℤ)) ∈ Gamma1 N := by
-      simpa [inv_inv] using Gamma0_normalizes_Gamma1
-        ⟨(g : SL(2, ℤ))⁻¹, (Gamma0 N).inv_mem g.property⟩ σ hσ
-    exact ⟨_, hmem, by
-      simp only [map_mul, map_inv, hσy]
-      group⟩
-  · rintro ⟨σ, hσ, rfl⟩
-    exact ⟨(g : SL(2, ℤ)) * σ * (g : SL(2, ℤ))⁻¹,
-      Gamma0_normalizes_Gamma1 g σ hσ, by simp [map_mul, map_inv]⟩
+    (Gamma1 N).map (mapGL ℝ) = (Gamma1 N).map (mapGL ℝ) :=
+  Subgroup.conjAct_pointwise_smul_eq_self
+    (Subgroup.inv_mem _ (mapGL_mem_normalizer_Gamma1_map ℝ g))
 
 /-- If two `Γ₀(N)` elements have equal image under `Gamma0Map`, their ratio
 `g₁ · g₂⁻¹` lies in `Γ₁(N)` (as an `SL₂(ℤ)` element). -/

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -211,6 +211,19 @@ lemma mul_inv_mem_Gamma1_of_Gamma0Map_eq (g₁ g₂ : ↥(Gamma0 N))
     exact (MonoidHom.div_mem_ker_iff (Gamma0Map N)).mpr heq
   exact (Gamma1_mem _ _).mpr <| (Gamma1_to_Gamma0_mem _).mp hker
 
+/-- **Two `Γ₀(N)` elements have the same lower-right entry exactly when their ratio lies in
+`Γ₁(N)`.** The `mpr` direction is `mul_inv_mem_Gamma1_of_Gamma0Map_eq`; the converse reads the
+membership back through `Gamma1_mem'`, which says that `Gamma0Map N` is trivial on `Γ₁(N)`. -/
+lemma mul_inv_mem_Gamma1_iff_Gamma0Map_eq (g₁ g₂ : ↥(Gamma0 N)) :
+    ((g₁ : SL(2, ℤ)) * (g₂ : SL(2, ℤ))⁻¹) ∈ Gamma1 N ↔ Gamma0Map N g₁ = Gamma0Map N g₂ := by
+  refine ⟨fun hmem ↦ ?_, mul_inv_mem_Gamma1_of_Gamma0Map_eq g₁ g₂⟩
+  have hcoe : ((g₁ * g₂⁻¹ : ↥(Gamma0 N)) : SL(2, ℤ)) ∈ Gamma1 N := by
+    rwa [Subgroup.coe_mul, Subgroup.coe_inv]
+  have hker : (g₁ * g₂⁻¹ : ↥(Gamma0 N)) ∈ (Gamma0Map N).ker :=
+    Gamma1_mem'.mp ((Gamma1_to_Gamma0_mem _).mpr ((Gamma1_mem _ _).mp hcoe))
+  rw [← div_eq_mul_inv] at hker
+  exact (MonoidHom.div_mem_ker_iff (Gamma0Map N)).mp hker
+
 /-- The diagonal matrix `!![u⁻¹, 0; 0, u]` as an element of `SL₂(ZMod N)`. -/
 private def diagUnit (u : (ZMod N)ˣ) : SpecialLinearGroup (Fin 2) (ZMod N) :=
   ⟨!![(↑u⁻¹ : ZMod N), 0; 0, ↑u], by simp [det_fin_two_of]⟩

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diamond.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diamond.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.DiamondCosets
+public import TauCeti.NumberTheory.ModularForms.DiamondOperators
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Ring
+
+/-!
+# The diamond operators are the Hecke operators of the `Γ₀(N)`-cosets
+
+`ModularForms/DiamondOperators.lean` builds `⟨d⟩` by hand, as slashing by any `Γ₀(N)` matrix
+with lower-right entry `d`, and shows the result is well defined on `M_k(Γ₁(N))` and on
+`S_k(Γ₁(N))`. `HeckeRing/GL2/Gamma1/DiamondCosets.lean` builds, from the same matrix, an
+element of the Hecke ring `𝕋 Δ₀(N) Γ₁(N) ℤ`. This file identifies the two:
+
+`heckeSlashGamma1ModularFormEnd k (diamondCosetGamma1 N γ) = diamondOp k d`,
+
+and the same on cusp forms, and — through the `ℤ`-linear action of the Hecke ring — the
+unit-indexed form `heckeSlashGamma1RingModularFormLinearMap k (diamondHeckeElem N d) =
+diamondOp k d`. So the diamond operators are not a construction parallel to the Hecke
+operators: they are the Hecke operators of the double cosets `Γ₁(N) γ Γ₁(N)` with `γ ∈ Γ₀(N)`,
+and the identification is a theorem rather than a definition.
+
+## Why it is a one-term sum
+
+Slashing by a double coset means summing over its right cosets. A diamond coset has exactly
+one, `Γ₁(N) γ` (`HeckeRing.GL2.doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets`,
+which holds because `Γ₁(N)` is normal in `Γ₀(N)`), so the sum
+`heckeSlashSum k (diamondCosetGamma1 N γ) f` has a single summand `f ∣[k] γ` — and that is the
+defining formula of `⟨d⟩`. The only remaining step is the `ℚ`-to-`ℝ` bridge
+`ModularForm.rat_slash_mapGL`, since the Hecke triples live over `ℚ` and the slash action of a
+modular form over `ℝ`.
+
+Nothing here needs the choice-freeness of `⟨d⟩` to be reproved: both sides are computed at the
+same representative `γ`, and their independence of it is `DiamondOperators.lean`'s
+`coe_diamondOp` on one side and `HeckeRing.GL2.diamondCosetGamma1_eq_iff` on the other.
+
+## Main results
+
+* `HeckeRing.GL2.heckeSlashSum_diamondCosetGamma1`: the slash sum of a diamond coset is the
+  single slash `f ∣[k] γ`, for a form of any of the level-`Γ₁(N)` form classes.
+* `HeckeRing.GL2.heckeSlashGamma1ModularFormEnd_diamondCosetGamma1` and
+  `HeckeRing.GL2.heckeSlashGamma1CuspFormEnd_diamondCosetGamma1`: **the identification**, on
+  `M_k(Γ₁(N))` and on `S_k(Γ₁(N))`.
+* `HeckeRing.GL2.heckeSlashGamma1RingModularFormLinearMap_diamondHeckeElem`: the same statement
+  read on the Hecke ring, at the unit-indexed element `⟨d⟩`.
+* `HeckeRing.GL2.heckeSlashGamma1ModularFormEnd_diamondCosetGamma1_apply_of_mem_modFormCharSpace`
+  and its cusp-form counterpart: on a nebentypus space the diamond coset acts by the scalar
+  `χ(d)`.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005], §5.2.
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.4.
+-/
+
+public section
+
+open Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm
+
+namespace HeckeRing.GL2
+
+variable {N : ℕ} [NeZero N] (k : ℤ) (g : ↥(Gamma0 N))
+
+/-- **The slash sum of a diamond coset is a single slash.** The double coset `Γ₁(N) γ Γ₁(N)`
+decomposes into the one right coset `Γ₁(N) γ`, so the Hecke sum attached to it has one
+summand. -/
+theorem heckeSlashSum_diamondCosetGamma1 {F : Type*} [FunLike F ℍ ℂ]
+    [SlashInvariantFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (f : F) :
+    heckeSlashSum k (diamondCosetGamma1 N g) ⇑f = ⇑f ∣[k] (mapGL ℚ (g : SL(2, ℤ))) := by
+  refine (heckeSlashSum_coe_eq_sum_of_rightCosets k (diamondCosetGamma1 N g)
+    (fun _ : Unit ↦ mapGL ℚ (g : SL(2, ℤ)))
+    (doubleCoset_out_diamondCosetGamma1_eq_iUnion_rightCosets g)
+    (fun _ _ _ ↦ Subsingleton.elim _ _) f).trans ?_
+  simp
+
+/-- **The diamond operator on `M_k(Γ₁(N))` is the Hecke operator of the double coset
+`Γ₁(N) γ Γ₁(N)`.** Both sides are slashing by `γ`; the left-hand side arrives as a one-term
+Hecke sum over `GL₂(ℚ)`, the right-hand side as the definition of `⟨d⟩` over `GL₂(ℝ)`. -/
+@[simp] theorem heckeSlashGamma1ModularFormEnd_diamondCosetGamma1 :
+    heckeSlashGamma1ModularFormEnd k (diamondCosetGamma1 N g) =
+      diamondOp k ((Gamma0Map N).toHomUnits g) :=
+  LinearMap.ext fun f ↦ DFunLike.ext' <| by
+    rw [coe_heckeSlashGamma1ModularFormEnd, heckeSlashSum_diamondCosetGamma1,
+      ModularForm.rat_slash_mapGL, coe_diamondOp k _ g rfl]
+
+/-- **The diamond operator on `S_k(Γ₁(N))` is the Hecke operator of the double coset
+`Γ₁(N) γ Γ₁(N)`.** -/
+@[simp] theorem heckeSlashGamma1CuspFormEnd_diamondCosetGamma1 :
+    heckeSlashGamma1CuspFormEnd k (diamondCosetGamma1 N g) =
+      diamondOpCusp k ((Gamma0Map N).toHomUnits g) :=
+  LinearMap.ext fun f ↦ DFunLike.ext' <| by
+    rw [coe_heckeSlashGamma1CuspFormEnd, heckeSlashSum_diamondCosetGamma1,
+      ModularForm.rat_slash_mapGL, coe_diamondOpCusp k _ g rfl]
+
+/-- **On a nebentypus space the diamond coset acts by the scalar `χ(d)`.** This is the shape
+the character-space action of the Hecke ring consumes: on `M_k(N, χ)` the diamond direction of
+the ring contributes no new operator, only multiplication by `χ(d)`. -/
+theorem heckeSlashGamma1ModularFormEnd_diamondCosetGamma1_apply_of_mem_modFormCharSpace
+    (χ : (ZMod N)ˣ →* ℂˣ) {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ modFormCharSpace k χ) :
+    heckeSlashGamma1ModularFormEnd k (diamondCosetGamma1 N g) f =
+      (↑(χ ((Gamma0Map N).toHomUnits g)) : ℂ) • f := by
+  rw [heckeSlashGamma1ModularFormEnd_diamondCosetGamma1]
+  exact diamondOp_apply_of_mem_modFormCharSpace k χ _ hf
+
+/-- **On a nebentypus cusp-form space the diamond coset acts by the scalar `χ(d)`.** -/
+theorem heckeSlashGamma1CuspFormEnd_diamondCosetGamma1_apply_of_mem_cuspFormCharSpace
+    (χ : (ZMod N)ˣ →* ℂˣ) {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ cuspFormCharSpace k χ) :
+    heckeSlashGamma1CuspFormEnd k (diamondCosetGamma1 N g) f =
+      (↑(χ ((Gamma0Map N).toHomUnits g)) : ℂ) • f := by
+  rw [heckeSlashGamma1CuspFormEnd_diamondCosetGamma1]
+  exact diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ _ hf
+
+/-- **The diamond element of the Hecke ring acts by the diamond operator.** Read through the
+`ℤ`-linear action `heckeSlashGamma1RingModularFormLinearMap` of the Hecke ring on `M_k(Γ₁(N))`,
+the element `⟨d⟩` of `HeckeRing/GL2/Gamma1/DiamondCosets.lean` is the operator `⟨d⟩` of
+`ModularForms/DiamondOperators.lean`. -/
+@[simp] theorem heckeSlashGamma1RingModularFormLinearMap_diamondHeckeElem (d : (ZMod N)ˣ) :
+    heckeSlashGamma1RingModularFormLinearMap k (diamondHeckeElem N d) = diamondOp k d := by
+  obtain ⟨γ, hγ⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
+  rw [diamondHeckeElem_eq_single γ hγ, heckeSlashGamma1RingModularFormLinearMap_single,
+    heckeSlashGamma1ModularFormEnd_diamondCosetGamma1, hγ, one_smul]
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diamond.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diamond.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma1.DiamondCosets
 public import TauCeti.NumberTheory.ModularForms.DiamondOperators
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.CuspRing
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Ring
 
 /-!
@@ -21,9 +22,10 @@ element of the Hecke ring `𝕋 Δ₀(N) Γ₁(N) ℤ`. This file identifies the
 
 and the same on cusp forms, and — through the `ℤ`-linear action of the Hecke ring — the
 unit-indexed form `heckeSlashGamma1RingModularFormLinearMap k (diamondHeckeElem N d) =
-diamondOp k d`. So the diamond operators are not a construction parallel to the Hecke
-operators: they are the Hecke operators of the double cosets `Γ₁(N) γ Γ₁(N)` with `γ ∈ Γ₀(N)`,
-and the identification is a theorem rather than a definition.
+diamondOp k d`, again on both modular and cusp forms. So the diamond operators are not a
+construction parallel to the Hecke operators: they are the Hecke operators of the double cosets
+`Γ₁(N) γ Γ₁(N)` with `γ ∈ Γ₀(N)`, and the identification is a theorem rather than a
+definition.
 
 ## Why it is a one-term sum
 
@@ -46,8 +48,9 @@ same representative `γ`, and their independence of it is `DiamondOperators.lean
 * `HeckeRing.GL2.heckeSlashGamma1ModularFormEnd_diamondCosetGamma1` and
   `HeckeRing.GL2.heckeSlashGamma1CuspFormEnd_diamondCosetGamma1`: **the identification**, on
   `M_k(Γ₁(N))` and on `S_k(Γ₁(N))`.
-* `HeckeRing.GL2.heckeSlashGamma1RingModularFormLinearMap_diamondHeckeElem`: the same statement
-  read on the Hecke ring, at the unit-indexed element `⟨d⟩`.
+* `HeckeRing.GL2.heckeSlashGamma1RingModularFormLinearMap_diamondHeckeElem` and
+  `HeckeRing.GL2.heckeSlashGamma1CuspRingLinearMap_diamondHeckeElem`: the same statement read on
+  the Hecke ring, at the unit-indexed element `⟨d⟩`.
 * `HeckeRing.GL2.heckeSlashGamma1ModularFormEnd_diamondCosetGamma1_apply_of_mem_modFormCharSpace`
   and its cusp-form counterpart: on a nebentypus space the diamond coset acts by the scalar
   `χ(d)`.
@@ -129,6 +132,15 @@ the element `⟨d⟩` of `HeckeRing/GL2/Gamma1/DiamondCosets.lean` is the operat
   obtain ⟨γ, hγ⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
   rw [diamondHeckeElem_eq_single γ hγ, heckeSlashGamma1RingModularFormLinearMap_single,
     heckeSlashGamma1ModularFormEnd_diamondCosetGamma1, hγ, one_smul]
+
+/-- **The diamond element of the Hecke ring acts on cusp forms by the diamond operator**: the
+cusp-form counterpart of `heckeSlashGamma1RingModularFormLinearMap_diamondHeckeElem`, read
+through the `ℤ`-linear action `heckeSlashGamma1CuspRingLinearMap` on `S_k(Γ₁(N))`. -/
+@[simp] theorem heckeSlashGamma1CuspRingLinearMap_diamondHeckeElem (d : (ZMod N)ˣ) :
+    heckeSlashGamma1CuspRingLinearMap k (diamondHeckeElem N d) = diamondOpCusp k d := by
+  obtain ⟨γ, hγ⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
+  rw [diamondHeckeElem_eq_single γ hγ, heckeSlashGamma1CuspRingLinearMap_single,
+    heckeSlashGamma1CuspFormEnd_diamondCosetGamma1, hγ, one_smul]
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diamond.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diamond.lean
@@ -72,7 +72,7 @@ variable {N : ℕ} [NeZero N] (k : ℤ) (g : ↥(Gamma0 N))
 /-- **The slash sum of a diamond coset is a single slash.** The double coset `Γ₁(N) γ Γ₁(N)`
 decomposes into the one right coset `Γ₁(N) γ`, so the Hecke sum attached to it has one
 summand. -/
-theorem heckeSlashSum_diamondCosetGamma1 {F : Type*} [FunLike F ℍ ℂ]
+@[simp] theorem heckeSlashSum_diamondCosetGamma1 {F : Type*} [FunLike F ℍ ℂ]
     [SlashInvariantFormClass F ((Gamma1 N).map (mapGL ℝ)) k] (f : F) :
     heckeSlashSum k (diamondCosetGamma1 N g) ⇑f = ⇑f ∣[k] (mapGL ℚ (g : SL(2, ℤ))) := by
   refine (heckeSlashSum_coe_eq_sum_of_rightCosets k (diamondCosetGamma1 N g)


### PR DESCRIPTION
This PR puts the diamond operators inside the Hecke algebra. For `γ ∈ Γ₀(N)` the double coset `Γ₁(N) γ Γ₁(N)` is a basis element `diamondCosetGamma1 N γ` of the Hecke ring `𝕋 Δ₀(N) Γ₁(N) ℤ`; it collapses to the *single* right coset `Γ₁(N) γ` because `Γ₁(N)` is normal in `Γ₀(N)`, it depends exactly on the lower-right entry `d ∈ (ZMod N)ˣ`, the basis elements multiply (`[Γ₁γ₁Γ₁]·[Γ₁γ₂Γ₁] = [Γ₁γ₁γ₂Γ₁]`), and the resulting `diamondHeckeElemHom : (ZMod N)ˣ →* 𝕋 Δ₀(N) Γ₁(N) ℤ` is injective. The slash operator that coset induces on `M_k(Γ₁(N))` and on `S_k(Γ₁(N))` is then identified with the `⟨d⟩` of `ModularForms/DiamondOperators.lean`, and on a nebentypus space it is multiplication by `χ(d)`.

This is the ModularForms roadmap's Layer 2(b) bullet *"The diamond operators land in the Hecke algebra — in the right ring"*, which asks that in the `Γ₁(N)`-pair ring the diamonds be honest double cosets `Γ₁(N)·γ·Γ₁(N)` for `γ ∈ Γ₀(N)`, and states explicitly that their compatibility with the slash-defined `⟨d⟩` of Layer 0 "is a **theorem** here, not a definition". It serves the layer's **uniform Hecke operators** milestone — one operator `Tₙ` for every `n` together with the ring homomorphism `𝕋 → Module.End ℂ (modFormCharSpace k χ)` — by supplying the diamond half of that ring homomorphism. What remains on the milestone after this PR is the good-prime multiplicativity `TₘTₙ = T_{mn}` for `(m,n) = 1` and the assembly of the ring homomorphism itself, whose `Tₚ` half still needs multiplicativity of the slash action.

The mathematical content is Shimura §3.3 read at the pair `(Γ₁(N), Δ₀(N))` whose monoid `Δ₀(N)` was deliberately cut out with a *unit* upper-left entry precisely so that `Γ₀(N) ≤ Δ₀(N)` (as `HeckeRing/GL2/Gamma1/Basic.lean` already records). Two consequences of normality do all the work: the double coset has one right coset, so its slash sum has one summand `f ∣[k] γ` — which is the defining formula of `⟨d⟩`, up to the `ℚ`-to-`ℝ` bridge `ModularForm.rat_slash_mapGL`; and its decomposition quotients are subsingletons, so `multiplicity ≤ 1` is automatic and `HeckeCosetModule.mul_single_single_of_mulMap_eq` gives the product with no structure constant to count. That is exactly what distinguishes the diamonds from the `Tₚ`.

Three files are added and one is generalised.

* `TauCeti/GroupTheory/DoubleCoset/Normalizer.lean` (69 lines) — the group-theoretic input: `doubleCoset_eq_rightCoset_of_mem_normalizer` (`ΓgΓ = Γg` for `g` normalizing `Γ`) and `mem_normalizer_of_mem_doubleCoset` (so the collapse applies to any representative, in particular to the chosen `HeckeCoset.rep`). It is a new file rather than an addition to `DoubleCoset/Basic.lean`, which is vendored verbatim from mathlib4 PR #41253 and is meant to be deleted when that stack lands.
* `TauCeti/NumberTheory/HeckeRing/GL2/Gamma1/DiamondCosets.lean` (295 lines) — `diamondCosetGamma1`, the two spellings of the right-coset decomposition (at `toSet` and at the chosen representative, the latter being the shape `HeckeSlash/Independence.lean` consumes), `diamondCosetGamma1_eq_iff`, `diamondCosetGamma1_one`, `single_diamondCosetGamma1_mul_single`, and `diamondHeckeElem`/`diamondHeckeElemHom` with `diamondHeckeElemHom_injective`.
* `TauCeti/NumberTheory/ModularForms/HeckeSlash/Diamond.lean` (135 lines) — `heckeSlashSum_diamondCosetGamma1`, the identification on modular and on cusp forms, the `χ(d)` form on the two nebentypus spaces, and `heckeSlashGamma1RingModularFormLinearMap_diamondHeckeElem`, which reads the identification through the existing `ℤ`-linear action of the Hecke ring.
* `TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean` — `Gamma1_map_inv_conjAct_eq` was `ℝ`-only, and its twenty-line proof was the normality argument spelled out again. The general statement `mapGL_mem_normalizer_Gamma1_map (S : Type*) [CommRing S]` is proved once, over any commutative ring, and the `ℝ` statement is derived from it in two lines, keeping its name, signature and every existing use. Both rings are genuinely needed: forms slash over `ℝ`, the Hecke triples live over `ℚ`.

No AINTLIB code is transcribed and nothing is vendored here. AINTLIB's `Gamma1Pair.lean` builds the pair `(Γ₁(N), Δ₁(N))` cut out by `a ≡ 1`, which carries the `Tₚ` alone and deliberately excludes the diamonds; the statements below are about the larger `Δ₀(N)` and are proved from `CongruenceSubgroup.Gamma0_normalizes_Gamma1` and the repository's own double-coset API.

`diamondCosetGamma1` is indexed by an element of `Γ₀(N)` rather than by a unit of `ZMod N` because a double coset is formed from a matrix; the unit-indexed `diamondHeckeElem` is derived from it through `Gamma0Map_toHomUnits_surjective`, mirroring how `DiamondOperators.lean` derives `diamondOp` from `diamondOpAux`, so the two constructions are choice-free in the same way and for the same reason.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"diamondcosetgamma1"}-->

🤖 Prepared with Claude Code
