### PR TITLE
refactor(Multiquadratic): name the two side conditions re-proved across the tree

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/Galois/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois/Basic.lean
@@ -25,6 +25,7 @@ The explicit identification of the group with `(ℤ/2)ⁿ` is a separate, later 
 ## Main results
 
 * `TauCeti.Multiquadratic.isSplittingField`: `M` is the splitting field of `∏ᵢ (X² - dᵢ)`.
+* `TauCeti.Multiquadratic.finiteDimensional_adjoin_range`: `M` is finite-dimensional over `K`.
 * `TauCeti.Multiquadratic.isGalois`: `M / K` is Galois (when `2 ≠ 0` in `K`).
 * `TauCeti.Multiquadratic.aut_mul_self_eq_one`: every `σ : M ≃ₐ[K] M` satisfies `σ * σ = 1`.
 * `TauCeti.Multiquadratic.aut_commute`: the automorphism group is commutative.
@@ -172,6 +173,13 @@ theorem isSplittingField (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
     refine le_antisymm le_top ?_
     rw [← Algebra.adjoin_eq_top_of_intermediateField halg (adjoin_gen_eq_top (root := root))]
     exact Algebra.adjoin_mono hsub
+
+/-- A multiquadratic field is finite-dimensional over `K`: it is the splitting field of
+`∏ᵢ (X² - dᵢ)`, a polynomial over `K`. -/
+theorem finiteDimensional_adjoin_range (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i)) :
+    FiniteDimensional K (adjoin K (Set.range root)) :=
+  haveI := isSplittingField hroot
+  IsSplittingField.finiteDimensional _ (definingPolynomial d)
 
 /-- A multiquadratic field over a field in which `2 ≠ 0` is Galois: it is the splitting field of
 `∏ᵢ (X² - dᵢ)` (hence normal), and each generator satisfies a separable quadratic. -/

--- a/TauCeti/NumberTheory/Multiquadratic/Galois/Group.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois/Group.lean
@@ -211,9 +211,7 @@ private theorem signHom_bijective [Finite ι] [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
     Function.Bijective (signHom (K := K) root hroot) := by
-  have := isSplittingField hroot
-  have : FiniteDimensional K (adjoin K (Set.range root)) :=
-    IsSplittingField.finiteDimensional _ (definingPolynomial d)
+  have := finiteDimensional_adjoin_range hroot
   have := isGalois hroot
   let := Fintype.ofFinite ι
   rw [Fintype.bijective_iff_injective_and_card]

--- a/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusFive/ClassNumber.lean
@@ -148,12 +148,8 @@ private theorem minkowski_bound_lt_three
   have hfin : finrank ℚ K = 2 := finrank_rat_eq_two hmin hgen
   have _ : IsTotallyComplex K :=
     isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg hmin (by norm_num)
-  have hreal : InfinitePlace.nrRealPlaces K = 0 :=
-    NumberField.IsTotallyComplex.nrRealPlaces_eq_zero K
-  have hcomplex : InfinitePlace.nrComplexPlaces K = 1 := by
-    have hsignature := InfinitePlace.card_add_two_mul_card_eq_rank K
-    rw [hreal, hfin] at hsignature
-    omega
+  have hcomplex : InfinitePlace.nrComplexPlaces K = 1 :=
+    InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two hfin
   have hdisc := discr_eq_neg_twenty hmin hgen
   have hsqrt : Real.sqrt 20 < 9 / 2 := by
     rw [Real.sqrt_lt' (by norm_num)]

--- a/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MinusTwentyOne/ClassNumber.lean
@@ -83,12 +83,8 @@ private theorem minkowski_bound_lt_six
   have hfin : finrank ℚ K = 2 := finrank_rat_eq_two hmin hgen
   have _ : IsTotallyComplex K :=
     isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg hmin (by norm_num)
-  have hreal : InfinitePlace.nrRealPlaces K = 0 :=
-    NumberField.IsTotallyComplex.nrRealPlaces_eq_zero K
-  have hcomplex : InfinitePlace.nrComplexPlaces K = 1 := by
-    have hsignature := InfinitePlace.card_add_two_mul_card_eq_rank K
-    rw [hreal, hfin] at hsignature
-    omega
+  have hcomplex : InfinitePlace.nrComplexPlaces K = 1 :=
+    InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two hfin
   have hdisc := discr_eq_neg_eighty_four hmin hgen
   have hsqrt : Real.sqrt 84 < 46 / 5 := by
     rw [Real.sqrt_lt' (by norm_num)]

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/TwoRank.lean
@@ -139,12 +139,8 @@ theorem twoRank_eq_ncard_ramifiedPrimes_sub_one
   by_cases hgauss : d = -1
   · subst d
     have hfin : Module.finrank ℚ K = 2 := NumberField.finrank_rat_eq_two hmin hgen
-    have hreal : InfinitePlace.nrRealPlaces K = 0 :=
-      NumberField.IsTotallyComplex.nrRealPlaces_eq_zero K
-    have hcomplex : InfinitePlace.nrComplexPlaces K = 1 := by
-      have hsignature := InfinitePlace.card_add_two_mul_card_eq_rank K
-      rw [hreal, hfin] at hsignature
-      omega
+    have hcomplex : InfinitePlace.nrComplexPlaces K = 1 :=
+      InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two hfin
     have hdisc : NumberField.discr K = -4 := by
       simpa using NumberField.discr_eq_four_mul_of_mod_four_ne_one hmin hgen hsf (by norm_num)
     have hpid : IsPrincipalIdealRing (𝓞 K) := by

--- a/TauCeti/NumberTheory/Multiquadratic/RelativeDegree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/RelativeDegree.lean
@@ -70,9 +70,7 @@ theorem finiteDimensional_top_over_intermediateField [Finite ι]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (F : IntermediateField K (adjoin K (Set.range root))) :
     FiniteDimensional F (adjoin K (Set.range root)) :=
-  haveI := isSplittingField hroot
-  haveI : FiniteDimensional K (adjoin K (Set.range root)) :=
-    Polynomial.IsSplittingField.finiteDimensional _ (definingPolynomial d)
+  haveI := finiteDimensional_adjoin_range hroot
   Module.Finite.of_restrictScalars_finite K F (adjoin K (Set.range root))
 
 /-- **The tower identity `[F : K] · [M : F] = 2ⁿ`.** Under square-class independence, an
@@ -98,9 +96,7 @@ theorem finrank_top_over_intermediateField [Finite ι] [NeZero (2 : K)]
     (F : IntermediateField K (adjoin K (Set.range root))) :
     Module.finrank F (adjoin K (Set.range root))
       = 2 ^ Module.finrank (ZMod 2) (intermediateFieldEquivSubmodule hroot hindep F).ofDual := by
-  have := isSplittingField hroot
-  have : FiniteDimensional K (adjoin K (Set.range root)) :=
-    Polynomial.IsSplittingField.finiteDimensional _ (definingPolynomial d)
+  have := finiteDimensional_adjoin_range hroot
   have hpos : 0 < Module.finrank K F := Module.finrank_pos
   refine Nat.eq_of_mul_eq_mul_left hpos ?_
   rw [finrank_intermediateField_mul_finrank_top hroot hindep F,
@@ -150,9 +146,8 @@ theorem finrank_top_over_adjoin_range_ne [Finite ι] [NeZero (2 : K)]
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
     (htop : adjoin K (Set.range root) = ⊤) (i : ι) :
     Module.finrank (adjoin K (Set.range fun j : {j // j ≠ i} => root j.val)) L = 2 := by
-  have := isSplittingField hroot
   have : FiniteDimensional K (adjoin K (Set.range root)) :=
-    Polynomial.IsSplittingField.finiteDimensional _ (definingPolynomial d)
+    finiteDimensional_adjoin_range hroot
   rw [htop] at this
   have : FiniteDimensional K L :=
     (IntermediateField.topEquiv (F := K) (E := L)).toLinearEquiv.finiteDimensional

--- a/TauCeti/NumberTheory/Multiquadratic/Subfield/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Subfield/Degree.lean
@@ -104,9 +104,7 @@ theorem finrank_mul_card_intermediateFieldEquivSubmodule [Finite ι] [NeZero (2 
     Module.finrank K F
         * Nat.card (intermediateFieldEquivSubmodule hroot hindep F).ofDual
       = 2 ^ Nat.card ι := by
-  have := isSplittingField hroot
-  have : FiniteDimensional K (adjoin K (Set.range root)) :=
-    Polynomial.IsSplittingField.finiteDimensional _ (definingPolynomial d)
+  have := finiteDimensional_adjoin_range hroot
   have := isGalois hroot
   rw [card_intermediateFieldEquivSubmodule_ofDual hroot hindep F,
     IntermediateField.finrank_eq_fixingSubgroup_index (adjoin K (Set.range root)) F,

--- a/TauCeti/NumberTheory/Multiquadratic/Subfield/Lattice.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Subfield/Lattice.lean
@@ -68,9 +68,7 @@ noncomputable def intermediateFieldEquivSubmodule [Finite ι] [NeZero (2 : K)]
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) :
     IntermediateField K (adjoin K (Set.range root)) ≃o
       (Submodule (ZMod 2) (ι → ZMod 2))ᵒᵈ :=
-  haveI := isSplittingField hroot
-  haveI : FiniteDimensional K (adjoin K (Set.range root)) :=
-    Polynomial.IsSplittingField.finiteDimensional _ (definingPolynomial d)
+  haveI := finiteDimensional_adjoin_range hroot
   haveI := isGalois hroot
   IsGalois.intermediateFieldEquivSubgroup.trans
     (OrderIso.dual

--- a/TauCeti/NumberTheory/NumberField/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/NumberField/InfinitePlace.lean
@@ -13,7 +13,7 @@ public import Mathlib.NumberTheory.NumberField.InfinitePlace.TotallyRealComplex
 A field containing an element whose square is a negative rational is totally complex: a real
 embedding would send that element to a real square root of a negative number. A totally complex
 field, having only complex infinite places, is then unramified at every infinite place in any
-extension.
+extension, and in degree `2` it has exactly one such place.
 
 ## Main results
 
@@ -21,6 +21,8 @@ extension.
   complexity.
 * `NumberField.IsUnramifiedAtInfinitePlaces_of_isTotallyComplex`: a totally complex base is
   unramified at all infinite places of any extension.
+* `NumberField.InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two`: a totally complex
+  field of degree `2` — an imaginary quadratic field — has exactly one complex place.
 -/
 
 public section
@@ -57,5 +59,14 @@ lemma IsUnramifiedAtInfinitePlaces_of_isTotallyComplex {k K : Type*} [Field k] [
   isUnramified w := by
     rw [InfinitePlace.isUnramified_iff]
     exact Or.inr (IsTotallyComplex.isComplex _)
+
+/-- **A totally complex field of degree `2` has exactly one complex place.** Such a field
+satisfies `Module.finrank ℚ K = 2 * nrComplexPlaces K`, so degree `2` leaves exactly one
+complex place; with `NumberField.IsTotallyComplex.nrRealPlaces_eq_zero` it is the field's only
+infinite place. This is the imaginary quadratic case. -/
+theorem InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two [IsTotallyComplex K]
+    (hK : Module.finrank ℚ K = 2) : InfinitePlace.nrComplexPlaces K = 1 := by
+  have := NumberField.IsTotallyComplex.finrank (K := K)
+  omega
 
 end NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/InfinitePlace.lean
@@ -17,6 +17,8 @@ For `d < 0`, the imaginary quadratic field `ℚ(√d)` is totally complex: a spe
 ## Main results
 
 * `NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg`.
+* `NumberField.InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two`: an imaginary
+  quadratic field has exactly one complex place.
 -/
 
 public section
@@ -34,5 +36,14 @@ theorem isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg (hmin : minpoly ℤ θ 
     (hd : d < 0) : IsTotallyComplex K :=
   isTotallyComplex_of_sq_ratCast_of_neg (x := (θ : K)) (r := (d : ℚ))
     (coe_gen_sq_ratCast hmin) (by exact_mod_cast hd)
+
+/-- **An imaginary quadratic field has exactly one complex place.** A totally complex field
+satisfies `Module.finrank ℚ K = 2 * nrComplexPlaces K`, so in degree `2` exactly one complex
+place remains; together with `NumberField.IsTotallyComplex.nrRealPlaces_eq_zero` it is the
+field's only infinite place. -/
+theorem InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two [IsTotallyComplex K]
+    (hK : Module.finrank ℚ K = 2) : InfinitePlace.nrComplexPlaces K = 1 := by
+  have := NumberField.IsTotallyComplex.finrank (K := K)
+  omega
 
 end NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/InfinitePlace.lean
@@ -17,8 +17,6 @@ For `d < 0`, the imaginary quadratic field `ℚ(√d)` is totally complex: a spe
 ## Main results
 
 * `NumberField.isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg`.
-* `NumberField.InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two`: an imaginary
-  quadratic field has exactly one complex place.
 -/
 
 public section
@@ -36,14 +34,5 @@ theorem isTotallyComplex_of_minpoly_eq_X_sq_sub_C_of_neg (hmin : minpoly ℤ θ 
     (hd : d < 0) : IsTotallyComplex K :=
   isTotallyComplex_of_sq_ratCast_of_neg (x := (θ : K)) (r := (d : ℚ))
     (coe_gen_sq_ratCast hmin) (by exact_mod_cast hd)
-
-/-- **An imaginary quadratic field has exactly one complex place.** A totally complex field
-satisfies `Module.finrank ℚ K = 2 * nrComplexPlaces K`, so in degree `2` exactly one complex
-place remains; together with `NumberField.IsTotallyComplex.nrRealPlaces_eq_zero` it is the
-field's only infinite place. -/
-theorem InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two [IsTotallyComplex K]
-    (hK : Module.finrank ℚ K = 2) : InfinitePlace.nrComplexPlaces K = 1 := by
-  have := NumberField.IsTotallyComplex.finrank (K := K)
-  omega
 
 end NumberField


### PR DESCRIPTION
Two facts in the multiquadratic tree were each re-proved verbatim as an inline `have` in several
theorems across several files. This names each one once and cites it at every site. No new
mathematics: both statements were already proved on `main`, just anonymously and repeatedly.

Roadmap: Multiquadratic

## The two extractions

**`TauCeti.Multiquadratic.finiteDimensional_adjoin_range`** — a multiquadratic field is
finite-dimensional over `K`, being the splitting field of `∏ᵢ (X² - dᵢ)`. The two-line
`isSplittingField` + `IsSplittingField.finiteDimensional` incantation is replaced at its five
sites: `Galois/Group.lean`, `RelativeDegree.lean` (twice), `Subfield/Degree.lean`,
`Subfield/Lattice.lean`.

**`NumberField.InfinitePlace.nrComplexPlaces_eq_one_of_finrank_eq_two`** — an imaginary quadratic
field has exactly one complex place. This replaces the five-line derivation in
`Quadratic/TwoRank.lean`, `MinusFive/ClassNumber.lean` and `MinusTwentyOne/ClassNumber.lean`.

## Two notes a reviewer will want

**The new complex-place proof does not reproduce the inline one.** Each site derived
`nrComplexPlaces K = 1` from `InfinitePlace.card_add_two_mul_card_eq_rank` by rewriting with
`nrRealPlaces K = 0` and `finrank ℚ K = 2`, then `omega`. Mathlib already packages exactly that
step as `NumberField.IsTotallyComplex.finrank : finrank ℚ K = 2 * nrComplexPlaces K`, so the named
lemma goes through it and is two lines.

**`nrRealPlaces K = 0` is deliberately *not* extracted**, although the dedup sweep flagged it
alongside the other two as a fact repeated at three sites. At each site it was a bare one-line
citation of Mathlib's `IsTotallyComplex.nrRealPlaces_eq_zero`, used only as a rewrite step inside
the `nrComplexPlaces` derivation. Naming it would add a wrapper around a Mathlib lemma, which the
repository forbids. Since the derivation that consumed it is now gone, the `have` disappears from
all three sites anyway — the duplication is removed without a declaration.

## Placement and prior art

The complex-place lemma goes in `NumberField/Quadratic/InfinitePlace.lean`: all three consumers
already import it, and the file's stated subject — "the infinite place of a quadratic field
`ℚ(√d)`", singular — is precisely this statement. Mathlib has no lemma for it: the nearest are
`nrComplexPlaces_eq_zero_of_finrank_eq_one` and `nrComplexPlaces_eq_totient_div_two` (cyclotomic),
and it names it after the former. Nothing in TauCeti proved it either.

## Gates

- `lake build` of the 9 changed modules and their 20 direct importers — `Build completed
  successfully (3686 jobs)`, exit 0, zero warning or error lines.
- `#print axioms` on both new declarations and the ten public theorems whose proofs changed —
  `propext`, `Classical.choice`, `Quot.sound` only.
- `scripts/lint-dot-notation.py` — `0 new`, exit 0.
- Whole-library gates (`lint-env`, `lake exe axioms`, module-system) left to CI, per the
  module-scoped local build policy.
