### PR TITLE
feat: define simply connected semisimple group schemes

### DIFF
--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/SimplyConnected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/SimplyConnected.lean
@@ -29,7 +29,7 @@ monomorphism of schemes is an isomorphism. This gives the kernel-free characteri
 
 ## Main declarations
 
-* `TauCeti.simplyConnectedSemisimpleAffineGroupSchemeProperty`: simple connectedness for
+* `TauCeti.simplyConnectedSemisimpleAffineGroupSchemeProperty`: simple connectivity for
   semisimple affine group schemes over a field.
 * `TauCeti.SimplyConnectedSemisimpleAffineGroupSchemeCat`: the corresponding full subcategory.
 * `TauCeti.simplyConnectedSemisimpleAffineGroupSchemeProperty_iff_forall_mono`: a semisimple
@@ -96,7 +96,7 @@ theorem isIso (hG : simplyConnectedSemisimpleAffineGroupSchemeProperty k G)
     (hf : GroupScheme.IsCentralIsogeny ((semisimpleAffineGroupSchemeForget k).map f)) : IsIso f :=
   hG H f hf
 
-/-- Establish simple connectedness by proving that every central isogeny onto the group is an
+/-- Establish simple connectivity by proving that every central isogeny onto the group is an
 isomorphism. -/
 theorem mk
     (hG : ∀ (H : SemisimpleAffineGroupSchemeCat k) (f : H ⟶ G),
@@ -106,7 +106,7 @@ theorem mk
 
 end simplyConnectedSemisimpleAffineGroupSchemeProperty
 
-/-- Simple connectedness of semisimple affine group schemes is invariant under isomorphism. -/
+/-- Simple connectivity of semisimple affine group schemes is invariant under isomorphism. -/
 instance (k : Type u) [Field k] :
     (simplyConnectedSemisimpleAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms where
   of_iso {G K} e hG H f hf := by

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/SimplyConnected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/SimplyConnected.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+import Mathlib.AlgebraicGeometry.Morphisms.FlatMono
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Semisimple
+public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Isomorphism
+
+/-!
+# Simply connected semisimple affine group schemes
+
+A semisimple affine group scheme `G` over a field is **simply connected** when every central
+isogeny `G' ⟶ G` from another semisimple affine group scheme is an isomorphism. Restricting the
+source to semisimple affine group schemes is essential: the ambient category of all group schemes
+also contains nonsmooth finite group schemes, whose structural morphisms to the trivial group are
+central isogenies without being isomorphisms.
+
+The definition is phrased in `SemisimpleAffineGroupSchemeCat`, so smoothness, geometric
+connectedness, affineness, and finite type remain separate structural properties rather than
+being repeated as hypotheses on every source. It is invariant under isomorphism and therefore
+cuts out the full subcategory `SimplyConnectedSemisimpleAffineGroupSchemeCat`.
+
+For a central isogeny, being an isomorphism is equivalent to its underlying scheme morphism being
+monic. Indeed, an isogeny is finite, flat, and surjective; a flat, quasi-compact, surjective
+monomorphism of schemes is an isomorphism. This gives the kernel-free characterization
+`simplyConnectedSemisimpleAffineGroupSchemeProperty_iff_forall_mono`.
+
+## Main declarations
+
+* `TauCeti.simplyConnectedSemisimpleAffineGroupSchemeProperty`: simple connectedness for
+  semisimple affine group schemes over a field.
+* `TauCeti.SimplyConnectedSemisimpleAffineGroupSchemeCat`: the corresponding full subcategory.
+* `TauCeti.simplyConnectedSemisimpleAffineGroupSchemeProperty_iff_forall_mono`: a semisimple
+  affine group scheme is simply connected exactly when every central isogeny onto it has monic
+  underlying scheme morphism.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §21.4.
+* T. A. Springer, *Linear Algebraic Groups*, §9.6.
+
+This is the simply-connected-form target in Layer 6, "Reductive and semisimple groups", of the
+ReductiveGroups roadmap. Central isogenies and semisimple affine group schemes are already
+available; construction and classification of simply connected covers remain downstream.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory AlgebraicGeometry
+
+universe u
+
+variable {k : Type u} [Field k]
+
+/-- The forgetful functor from semisimple affine group schemes to group schemes. -/
+noncomputable abbrev semisimpleAffineGroupSchemeForget (k : Type u) [Field k] :
+    SemisimpleAffineGroupSchemeCat k ⥤ Grp (Over (Spec (CommRingCat.of k))) :=
+  (semisimpleAffineGroupSchemeProperty k).ι ⋙
+    (finiteTypeAffineGroupSchemeProperty (CommRingCat.of k)).ι ⋙
+      (affineGroupSchemeProperty (CommRingCat.of k)).ι
+
+/-- The object property selecting simply connected semisimple affine group schemes over a field.
+
+A semisimple affine group scheme `G` is simply connected when every central isogeny `H ⟶ G`
+in the category of semisimple affine group schemes is an isomorphism. The source is required to
+be semisimple; allowing arbitrary group schemes would incorrectly include nonsmooth finite
+central covers among the maps tested by the definition. -/
+def simplyConnectedSemisimpleAffineGroupSchemeProperty (k : Type u) [Field k] :
+    ObjectProperty (SemisimpleAffineGroupSchemeCat k) :=
+  fun G ↦ ∀ (H : SemisimpleAffineGroupSchemeCat k) (f : H ⟶ G),
+    GroupScheme.IsCentralIsogeny ((semisimpleAffineGroupSchemeForget k).map f) → IsIso f
+
+/-- Membership in the simply connected semisimple affine-group-scheme property means that every
+central isogeny from a semisimple affine group scheme is an isomorphism. -/
+@[simp]
+theorem simplyConnectedSemisimpleAffineGroupSchemeProperty_iff
+    (G : SemisimpleAffineGroupSchemeCat k) :
+    simplyConnectedSemisimpleAffineGroupSchemeProperty k G ↔
+      ∀ (H : SemisimpleAffineGroupSchemeCat k) (f : H ⟶ G),
+        GroupScheme.IsCentralIsogeny
+          ((semisimpleAffineGroupSchemeForget k).map f) → IsIso f :=
+  Iff.rfl
+
+namespace simplyConnectedSemisimpleAffineGroupSchemeProperty
+
+variable {G : SemisimpleAffineGroupSchemeCat k}
+
+/-- Every central isogeny from a semisimple affine group scheme to a simply connected one is an
+isomorphism. -/
+theorem isIso (hG : simplyConnectedSemisimpleAffineGroupSchemeProperty k G)
+    {H : SemisimpleAffineGroupSchemeCat k} (f : H ⟶ G)
+    (hf : GroupScheme.IsCentralIsogeny ((semisimpleAffineGroupSchemeForget k).map f)) : IsIso f :=
+  hG H f hf
+
+/-- Establish simple connectedness by proving that every central isogeny onto the group is an
+isomorphism. -/
+theorem mk
+    (hG : ∀ (H : SemisimpleAffineGroupSchemeCat k) (f : H ⟶ G),
+      GroupScheme.IsCentralIsogeny ((semisimpleAffineGroupSchemeForget k).map f) → IsIso f) :
+    simplyConnectedSemisimpleAffineGroupSchemeProperty k G :=
+  hG
+
+end simplyConnectedSemisimpleAffineGroupSchemeProperty
+
+/-- Simple connectedness of semisimple affine group schemes is invariant under isomorphism. -/
+instance (k : Type u) [Field k] :
+    (simplyConnectedSemisimpleAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms where
+  of_iso {G K} e hG H f hf := by
+    have hcomp : GroupScheme.IsCentralIsogeny
+        ((semisimpleAffineGroupSchemeForget k).map (f ≫ e.inv)) := by
+      rw [Functor.map_comp]
+      exact ((GroupScheme.centralIsogenies k).cancel_right_of_respectsIso
+        ((semisimpleAffineGroupSchemeForget k).map f)
+        ((semisimpleAffineGroupSchemeForget k).map e.inv)).mpr hf
+    let _ : IsIso (f ≫ e.inv) := hG H (f ≫ e.inv) hcomp
+    exact IsIso.of_isIso_comp_right f e.inv
+
+/-- The category of simply connected semisimple affine group schemes over a field. -/
+abbrev SimplyConnectedSemisimpleAffineGroupSchemeCat (k : Type u) [Field k] :=
+  (simplyConnectedSemisimpleAffineGroupSchemeProperty k).FullSubcategory
+
+/-- A central isogeny of semisimple affine group schemes is an isomorphism if its underlying
+scheme morphism is monic.
+
+The isogeny supplies finiteness, flatness, and surjectivity. Finiteness supplies quasi-compactness,
+so the flat-surjective-monomorphism criterion applies to the underlying scheme morphism; the
+successive forgetful functors then reflect the resulting isomorphism. -/
+theorem GroupScheme.IsCentralIsogeny.isIso_of_mono
+    {G H : SemisimpleAffineGroupSchemeCat k} (f : G ⟶ H)
+    (hf : GroupScheme.IsCentralIsogeny ((semisimpleAffineGroupSchemeForget k).map f))
+    [hmono : Mono ((semisimpleAffineGroupSchemeForget k).map f).hom.hom.left] : IsIso f := by
+  let q := (semisimpleAffineGroupSchemeForget k).map f
+  let _ : IsFinite q.hom.hom.left := hf.isFinite
+  let _ : Flat q.hom.hom.left := hf.flat
+  let _ : Surjective q.hom.hom.left := hf.surjective
+  let _ : Mono q.hom.hom.left := hmono
+  let _ : IsIso q.hom.hom.left := Flat.isIso_of_surjective_of_mono q.hom.hom.left
+  let _ : IsIso ((Over.forget (Spec (CommRingCat.of k))).map q.hom.hom) :=
+    inferInstanceAs (IsIso q.hom.hom.left)
+  let _ : IsIso q.hom.hom :=
+    isIso_of_reflects_iso q.hom.hom (Over.forget (Spec (CommRingCat.of k)))
+  let _ : IsIso ((Mon.forget (Over (Spec (CommRingCat.of k)))).map q.hom) :=
+    inferInstanceAs (IsIso q.hom.hom)
+  let _ : IsIso q.hom :=
+    isIso_of_reflects_iso q.hom (Mon.forget (Over (Spec (CommRingCat.of k))))
+  let _ : IsIso ((Grp.forget₂Mon (Over (Spec (CommRingCat.of k)))).map q) :=
+    inferInstanceAs (IsIso q.hom)
+  let _ : IsIso q :=
+    isIso_of_reflects_iso q (Grp.forget₂Mon (Over (Spec (CommRingCat.of k))))
+  let _ : IsIso ((semisimpleAffineGroupSchemeForget k).map f) := inferInstanceAs (IsIso q)
+  exact isIso_of_reflects_iso f (semisimpleAffineGroupSchemeForget k)
+
+/-- A semisimple affine group scheme is simply connected exactly when the underlying scheme map
+of every central isogeny onto it is a monomorphism. -/
+theorem simplyConnectedSemisimpleAffineGroupSchemeProperty_iff_forall_mono
+    (G : SemisimpleAffineGroupSchemeCat k) :
+    simplyConnectedSemisimpleAffineGroupSchemeProperty k G ↔
+      ∀ (H : SemisimpleAffineGroupSchemeCat k) (f : H ⟶ G),
+        GroupScheme.IsCentralIsogeny
+            ((semisimpleAffineGroupSchemeForget k).map f) →
+          Mono
+            ((semisimpleAffineGroupSchemeForget k).map f).hom.hom.left := by
+  constructor
+  · intro hG H f hf
+    let _ : IsIso f := hG H f hf
+    infer_instance
+  · intro hG H f hf
+    let _ : Mono ((semisimpleAffineGroupSchemeForget k).map f).hom.hom.left := hG H f hf
+    exact GroupScheme.IsCentralIsogeny.isIso_of_mono f hf
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/SimplyConnected.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/SimplyConnected.lean
@@ -5,7 +5,6 @@ Authors: Codex
 -/
 module
 
-import Mathlib.AlgebraicGeometry.Morphisms.FlatMono
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Semisimple
 public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Isomorphism
 
@@ -124,37 +123,6 @@ instance (k : Type u) [Field k] :
 abbrev SimplyConnectedSemisimpleAffineGroupSchemeCat (k : Type u) [Field k] :=
   (simplyConnectedSemisimpleAffineGroupSchemeProperty k).FullSubcategory
 
-/-- A central isogeny of semisimple affine group schemes is an isomorphism if its underlying
-scheme morphism is monic.
-
-The isogeny supplies finiteness, flatness, and surjectivity. Finiteness supplies quasi-compactness,
-so the flat-surjective-monomorphism criterion applies to the underlying scheme morphism; the
-successive forgetful functors then reflect the resulting isomorphism. -/
-theorem GroupScheme.IsCentralIsogeny.isIso_of_mono
-    {G H : SemisimpleAffineGroupSchemeCat k} (f : G ⟶ H)
-    (hf : GroupScheme.IsCentralIsogeny ((semisimpleAffineGroupSchemeForget k).map f))
-    [hmono : Mono ((semisimpleAffineGroupSchemeForget k).map f).hom.hom.left] : IsIso f := by
-  let q := (semisimpleAffineGroupSchemeForget k).map f
-  let _ : IsFinite q.hom.hom.left := hf.isFinite
-  let _ : Flat q.hom.hom.left := hf.flat
-  let _ : Surjective q.hom.hom.left := hf.surjective
-  let _ : Mono q.hom.hom.left := hmono
-  let _ : IsIso q.hom.hom.left := Flat.isIso_of_surjective_of_mono q.hom.hom.left
-  let _ : IsIso ((Over.forget (Spec (CommRingCat.of k))).map q.hom.hom) :=
-    inferInstanceAs (IsIso q.hom.hom.left)
-  let _ : IsIso q.hom.hom :=
-    isIso_of_reflects_iso q.hom.hom (Over.forget (Spec (CommRingCat.of k)))
-  let _ : IsIso ((Mon.forget (Over (Spec (CommRingCat.of k)))).map q.hom) :=
-    inferInstanceAs (IsIso q.hom.hom)
-  let _ : IsIso q.hom :=
-    isIso_of_reflects_iso q.hom (Mon.forget (Over (Spec (CommRingCat.of k))))
-  let _ : IsIso ((Grp.forget₂Mon (Over (Spec (CommRingCat.of k)))).map q) :=
-    inferInstanceAs (IsIso q.hom)
-  let _ : IsIso q :=
-    isIso_of_reflects_iso q (Grp.forget₂Mon (Over (Spec (CommRingCat.of k))))
-  let _ : IsIso ((semisimpleAffineGroupSchemeForget k).map f) := inferInstanceAs (IsIso q)
-  exact isIso_of_reflects_iso f (semisimpleAffineGroupSchemeForget k)
-
 /-- A semisimple affine group scheme is simply connected exactly when the underlying scheme map
 of every central isogeny onto it is a monomorphism. -/
 theorem simplyConnectedSemisimpleAffineGroupSchemeProperty_iff_forall_mono
@@ -171,6 +139,7 @@ theorem simplyConnectedSemisimpleAffineGroupSchemeProperty_iff_forall_mono
     infer_instance
   · intro hG H f hf
     let _ : Mono ((semisimpleAffineGroupSchemeForget k).map f).hom.hom.left := hG H f hf
-    exact GroupScheme.IsCentralIsogeny.isIso_of_mono f hf
+    let _ : IsIso ((semisimpleAffineGroupSchemeForget k).map f) := hf.isIsogeny.isIso_of_mono
+    exact isIso_of_reflects_iso f (semisimpleAffineGroupSchemeForget k)
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.AlgebraicGeometry.Morphisms.Finite
-public import Mathlib.AlgebraicGeometry.Morphisms.FlatMono
+public import Mathlib.AlgebraicGeometry.Morphisms.Flat
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.CommGrp_
 public import Mathlib.GroupTheory.Subgroup.Center
 
@@ -36,8 +36,6 @@ central kernel and that every isogeny out of a commutative group scheme is centr
 * `TauCeti.GroupScheme.hasCentralKernel`: the corresponding morphism property.
 * `TauCeti.GroupScheme.isogenies`: the finite, flat, surjective morphism property on group schemes.
 * `TauCeti.GroupScheme.IsIsogeny`: the corresponding predicate on a group-scheme morphism.
-* `TauCeti.GroupScheme.IsIsogeny.isIso_of_mono`: an isogeny whose underlying scheme morphism is
-  monic is an isomorphism.
 * `TauCeti.GroupScheme.centralIsogenies`: the central-isogeny morphism property.
 * `TauCeti.GroupScheme.IsCentralIsogeny`: an isogeny with central kernel.
 * `TauCeti.GroupScheme.isCentralIsogeny_iff_isIsogeny_and_hasCentralKernel`: the predicate-level
@@ -217,24 +215,6 @@ theorem flat {f : G ⟶ H} (hf : IsIsogeny f) : Flat f.hom.hom.left :=
 /-- The underlying scheme morphism of a group-scheme isogeny is surjective. -/
 theorem surjective {f : G ⟶ H} (hf : IsIsogeny f) : Surjective f.hom.hom.left :=
   (isIsogeny_iff f).mp hf |>.2.2
-
-/-- A group-scheme isogeny whose underlying scheme morphism is monic is an isomorphism. -/
-theorem isIso_of_mono {f : G ⟶ H} (hf : IsIsogeny f) [Mono f.hom.hom.left] : IsIso f := by
-  let _ : IsFinite f.hom.hom.left := hf.isFinite
-  let _ : Flat f.hom.hom.left := hf.flat
-  let _ : Surjective f.hom.hom.left := hf.surjective
-  let _ : IsIso f.hom.hom.left := Flat.isIso_of_surjective_of_mono f.hom.hom.left
-  let _ : IsIso ((Over.forget (Spec (CommRingCat.of k))).map f.hom.hom) :=
-    inferInstanceAs (IsIso f.hom.hom.left)
-  let _ : IsIso f.hom.hom :=
-    isIso_of_reflects_iso f.hom.hom (Over.forget (Spec (CommRingCat.of k)))
-  let _ : IsIso ((Mon.forget (Over (Spec (CommRingCat.of k)))).map f.hom) :=
-    inferInstanceAs (IsIso f.hom.hom)
-  let _ : IsIso f.hom :=
-    isIso_of_reflects_iso f.hom (Mon.forget (Over (Spec (CommRingCat.of k))))
-  let _ : IsIso ((Grp.forget₂Mon (Over (Spec (CommRingCat.of k)))).map f) :=
-    inferInstanceAs (IsIso f.hom)
-  exact isIso_of_reflects_iso f (Grp.forget₂Mon (Over (Spec (CommRingCat.of k))))
 
 /-- A composite of group-scheme isogenies is an isogeny. -/
 theorem comp {f : G ⟶ H} {g : H ⟶ K} (hf : IsIsogeny f) (hg : IsIsogeny g) :

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Basic.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.AlgebraicGeometry.Morphisms.Finite
-public import Mathlib.AlgebraicGeometry.Morphisms.Flat
+public import Mathlib.AlgebraicGeometry.Morphisms.FlatMono
 public import Mathlib.CategoryTheory.Monoidal.Cartesian.CommGrp_
 public import Mathlib.GroupTheory.Subgroup.Center
 
@@ -36,6 +36,8 @@ central kernel and that every isogeny out of a commutative group scheme is centr
 * `TauCeti.GroupScheme.hasCentralKernel`: the corresponding morphism property.
 * `TauCeti.GroupScheme.isogenies`: the finite, flat, surjective morphism property on group schemes.
 * `TauCeti.GroupScheme.IsIsogeny`: the corresponding predicate on a group-scheme morphism.
+* `TauCeti.GroupScheme.IsIsogeny.isIso_of_mono`: an isogeny whose underlying scheme morphism is
+  monic is an isomorphism.
 * `TauCeti.GroupScheme.centralIsogenies`: the central-isogeny morphism property.
 * `TauCeti.GroupScheme.IsCentralIsogeny`: an isogeny with central kernel.
 * `TauCeti.GroupScheme.isCentralIsogeny_iff_isIsogeny_and_hasCentralKernel`: the predicate-level
@@ -215,6 +217,24 @@ theorem flat {f : G ⟶ H} (hf : IsIsogeny f) : Flat f.hom.hom.left :=
 /-- The underlying scheme morphism of a group-scheme isogeny is surjective. -/
 theorem surjective {f : G ⟶ H} (hf : IsIsogeny f) : Surjective f.hom.hom.left :=
   (isIsogeny_iff f).mp hf |>.2.2
+
+/-- A group-scheme isogeny whose underlying scheme morphism is monic is an isomorphism. -/
+theorem isIso_of_mono {f : G ⟶ H} (hf : IsIsogeny f) [Mono f.hom.hom.left] : IsIso f := by
+  let _ : IsFinite f.hom.hom.left := hf.isFinite
+  let _ : Flat f.hom.hom.left := hf.flat
+  let _ : Surjective f.hom.hom.left := hf.surjective
+  let _ : IsIso f.hom.hom.left := Flat.isIso_of_surjective_of_mono f.hom.hom.left
+  let _ : IsIso ((Over.forget (Spec (CommRingCat.of k))).map f.hom.hom) :=
+    inferInstanceAs (IsIso f.hom.hom.left)
+  let _ : IsIso f.hom.hom :=
+    isIso_of_reflects_iso f.hom.hom (Over.forget (Spec (CommRingCat.of k)))
+  let _ : IsIso ((Mon.forget (Over (Spec (CommRingCat.of k)))).map f.hom) :=
+    inferInstanceAs (IsIso f.hom.hom)
+  let _ : IsIso f.hom :=
+    isIso_of_reflects_iso f.hom (Mon.forget (Over (Spec (CommRingCat.of k))))
+  let _ : IsIso ((Grp.forget₂Mon (Over (Spec (CommRingCat.of k)))).map f) :=
+    inferInstanceAs (IsIso f.hom)
+  exact isIso_of_reflects_iso f (Grp.forget₂Mon (Over (Spec (CommRingCat.of k))))
 
 /-- A composite of group-scheme isogenies is an isogeny. -/
 theorem comp {f : G ⟶ H} {g : H ⟶ K} (hf : IsIsogeny f) (hg : IsIsogeny g) :

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Isomorphism.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Isomorphism.lean
@@ -5,15 +5,17 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.AlgebraicGeometry.Morphisms.FlatMono
 public import TauCeti.AlgebraicGeometry.GroupScheme.CentralIsogeny.Basic
 
 /-!
 # Central isogenies and isomorphisms
 
-Central isogenies are unchanged by replacing their source or target by an isomorphic group
-scheme. This file proves the corresponding `MorphismProperty.RespectsIso` instance. It also
-records the underlying fact that the all-test-schemes central-kernel condition is invariant under
-pre- and postcomposition with an isomorphism.
+An isogeny with monic underlying scheme morphism is an isomorphism. Central isogenies are also
+unchanged by replacing their source or target by an isomorphic group scheme. This file proves the
+corresponding `MorphismProperty.RespectsIso` instance and records the underlying fact that the
+all-test-schemes central-kernel condition is invariant under pre- and postcomposition with an
+isomorphism.
 
 The proofs stay at the functor-of-points level used by `GroupScheme.HasCentralKernel`. A morphism
 monic in `Over X` induces an injective map on points over every test scheme. On the source this
@@ -30,6 +32,8 @@ pointwise kernel.
   `Over X` preserves and reflects central kernels.
 * `TauCeti.GroupScheme.hasCentralKernel_respectsIso`: having central kernel respects isomorphisms
   of arrows.
+* `TauCeti.GroupScheme.IsIsogeny.isIso_of_mono`: an isogeny whose underlying scheme morphism is
+  monic is an isomorphism.
 * `TauCeti.GroupScheme.centralIsogenies_respectsIso`: central isogenies respect isomorphisms of
   arrows.
 
@@ -104,6 +108,34 @@ instance hasCentralKernel_respectsIso : (hasCentralKernel X).RespectsIso := by
 section Isogeny
 
 variable {k : Type u} [Field k]
+variable {G H : Grp (Over (Spec (CommRingCat.of k)))}
+
+namespace IsIsogeny
+
+/-- A group-scheme isogeny whose underlying scheme morphism is monic is an isomorphism. -/
+theorem isIso_of_mono {f : G ⟶ H} (hf : IsIsogeny f) [Mono f.hom.hom.left] : IsIso f := by
+  let _ : IsFinite f.hom.hom.left := hf.isFinite
+  let _ : Flat f.hom.hom.left := hf.flat
+  let _ : Surjective f.hom.hom.left := hf.surjective
+  let _ : IsIso f.hom.hom.left := Flat.isIso_of_surjective_of_mono f.hom.hom.left
+  -- These forgetful functors are reducible projections on morphisms. The explicit `change`
+  -- steps record each definitional identification before reflecting the isomorphism.
+  let _ : IsIso ((Over.forget (Spec (CommRingCat.of k))).map f.hom.hom) := by
+    change IsIso f.hom.hom.left
+    infer_instance
+  let _ : IsIso f.hom.hom :=
+    isIso_of_reflects_iso f.hom.hom (Over.forget (Spec (CommRingCat.of k)))
+  let _ : IsIso ((Mon.forget (Over (Spec (CommRingCat.of k)))).map f.hom) := by
+    change IsIso f.hom.hom
+    infer_instance
+  let _ : IsIso f.hom :=
+    isIso_of_reflects_iso f.hom (Mon.forget (Over (Spec (CommRingCat.of k))))
+  let _ : IsIso ((Grp.forget₂Mon (Over (Spec (CommRingCat.of k)))).map f) := by
+    change IsIso f.hom
+    infer_instance
+  exact isIso_of_reflects_iso f (Grp.forget₂Mon (Over (Spec (CommRingCat.of k))))
+
+end IsIsogeny
 
 /-- Central isogenies are invariant under pre- and postcomposition with isomorphisms. -/
 instance centralIsogenies_respectsIso : (centralIsogenies k).RespectsIso := by

--- a/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Isomorphism.lean
+++ b/TauCeti/AlgebraicGeometry/GroupScheme/CentralIsogeny/Isomorphism.lean
@@ -117,23 +117,13 @@ theorem isIso_of_mono {f : G ⟶ H} (hf : IsIsogeny f) [Mono f.hom.hom.left] : I
   let _ : IsFinite f.hom.hom.left := hf.isFinite
   let _ : Flat f.hom.hom.left := hf.flat
   let _ : Surjective f.hom.hom.left := hf.surjective
-  let _ : IsIso f.hom.hom.left := Flat.isIso_of_surjective_of_mono f.hom.hom.left
-  -- These forgetful functors are reducible projections on morphisms. The explicit `change`
-  -- steps record each definitional identification before reflecting the isomorphism.
-  let _ : IsIso ((Over.forget (Spec (CommRingCat.of k))).map f.hom.hom) := by
-    change IsIso f.hom.hom.left
-    infer_instance
-  let _ : IsIso f.hom.hom :=
-    isIso_of_reflects_iso f.hom.hom (Over.forget (Spec (CommRingCat.of k)))
-  let _ : IsIso ((Mon.forget (Over (Spec (CommRingCat.of k)))).map f.hom) := by
-    change IsIso f.hom.hom
-    infer_instance
-  let _ : IsIso f.hom :=
-    isIso_of_reflects_iso f.hom (Mon.forget (Over (Spec (CommRingCat.of k))))
-  let _ : IsIso ((Grp.forget₂Mon (Over (Spec (CommRingCat.of k)))).map f) := by
-    change IsIso f.hom
-    infer_instance
-  exact isIso_of_reflects_iso f (Grp.forget₂Mon (Over (Spec (CommRingCat.of k))))
+  apply (isIso_iff_of_reflects_iso f
+    (Grp.forget₂Mon (Over (Spec (CommRingCat.of k))))).mp
+  apply (isIso_iff_of_reflects_iso f.hom
+    (Mon.forget (Over (Spec (CommRingCat.of k))))).mp
+  apply (isIso_iff_of_reflects_iso f.hom.hom
+    (Over.forget (Spec (CommRingCat.of k)))).mp
+  exact Flat.isIso_of_surjective_of_mono f.hom.hom.left
 
 end IsIsogeny
 


### PR DESCRIPTION
This PR defines simply connected semisimple affine group schemes as the objects for which every central isogeny from a semisimple affine group scheme is an isomorphism, packages them as a full subcategory, and proves the equivalent monomorphism criterion for the underlying scheme maps.

It advances the ReductiveGroups roadmap's Layer 6 milestone, “Reductive and semisimple groups,” at the exact target “the simply connected and adjoint forms” by supplying the simply connected group-scheme property on top of the existing semisimple and central-isogeny APIs. Construction of simply connected covers, adjoint forms, and their classification remain after this PR.

The monomorphism criterion reuses Mathlib's `AlgebraicGeometry.Flat.isIso_of_surjective_of_mono` and the standard isomorphism-reflection infrastructure; no Mathlib result is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"simply-connected-semisimple-group-scheme"}-->

🤖 Prepared with Codex
