### PR TITLE
feat: the order filtration of a function field at a place

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
@@ -174,6 +174,15 @@ theorem ord_div_zpow {f t : F} (hf : f ≠ 0) (ht : t ≠ 0) (n : ℤ) :
 theorem ord_surjective : Function.Surjective P.ord :=
   Valuation.ord_surjective P.valuation P.valuation_surjective
 
+/-- Every integer is the order of a *nonzero* function: the sharpening of
+`TauCeti.Place.ord_surjective` that the junk value `ord_P 0 = 0` makes necessary, since the
+element `ord_surjective` produces at `0` may itself be `0`. -/
+theorem exists_ne_zero_ord_eq (n : ℤ) : ∃ t : F, t ≠ 0 ∧ P.ord t = n := by
+  obtain ⟨t, ht⟩ := P.ord_surjective n
+  rcases eq_or_ne t 0 with rfl | ht0
+  · exact ⟨1, one_ne_zero, by rw [P.ord_one, ← ht, P.ord_zero]⟩
+  · exact ⟨t, ht0, ht⟩
+
 theorem mem_integers_iff_ord_nonneg {f : F} : f ∈ P.integers ↔ 0 ≤ P.ord f :=
   Valuation.mem_valuationSubring_iff_ord_nonneg P.valuation
 
@@ -364,6 +373,13 @@ noncomputable instance : Algebra k P.integers :=
 
 instance : IsScalarTower k P.integers F :=
   .of_algebraMap_eq fun _ => rfl
+
+/-- A constant, viewed in `𝒪_P` and then back in `F`, is that constant.  The name says
+`constants` rather than `integers` because `TauCeti.Place.coe_algebraMap_integers` is the
+corresponding statement for the algebra map between the valuation rings of two places. -/
+theorem coe_algebraMap_constants (c : k) :
+    ((algebraMap k P.integers c : P.integers) : F) = algebraMap k F c := by
+  rw [IsScalarTower.algebraMap_apply k P.integers F, ValuationSubring.algebraMap_apply]
 
 /-- The residue field `F_P = 𝒪_P / 𝔪_P` of a place (Stichtenoth, Definition 1.1.14). The
 evaluation map `f ↦ f(P)` is `IsLocalRing.residue P.integers`. -/

--- a/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
@@ -377,6 +377,7 @@ instance : IsScalarTower k P.integers F :=
 /-- A constant, viewed in `𝒪_P` and then back in `F`, is that constant.  The name says
 `constants` rather than `integers` because `TauCeti.Place.coe_algebraMap_integers` is the
 corresponding statement for the algebra map between the valuation rings of two places. -/
+@[simp, norm_cast]
 theorem coe_algebraMap_constants (c : k) :
     ((algebraMap k P.integers c : P.integers) : F) = algebraMap k F c := by
   rw [IsScalarTower.algebraMap_apply k P.integers F, ValuationSubring.algebraMap_apply]

--- a/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
@@ -5,16 +5,14 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Dimension.Free
 public import Mathlib.LinearAlgebra.Dimension.RankNullity
-public import Mathlib.LinearAlgebra.Isomorphisms
 public import TauCeti.FieldTheory.FunctionField.Place.Basic
 
 /-!
 # The order filtration of a function field at a place
 
-A place `P` of `F / k` filters `F` by the order of vanishing at `P`: for an integer `a` the
-functions with `ord_P z ≥ a` form a `k`-subspace
+A place `P` of `F / k` filters `F` by the order of vanishing at `P`: for an integer `a`, zero
+together with the nonzero functions satisfying `ord_P z ≥ a` forms the `k`-subspace
 
 `𝔪_P^a = {z ∈ F | v_P z ≤ exp (-a)}`
 
@@ -56,8 +54,8 @@ these local quotients, and so computes `dim_k (A_F(E) / A_F(D)) = deg E - deg D`
 ## Implementation notes
 
 Membership is stated multiplicatively, as `v_P z ≤ exp (-a)`, and never in the additive form
-`ord_P z ≥ a`, which the junk value `ord_P 0 = 0` would get wrong at `a ≤ 0`: the additive
-carrier would not contain `0` at negative `a` and so would not be a subspace.  This is the
+`ord_P z ≥ a`, which the junk value `ord_P 0 = 0` would get wrong at `a > 0`: the additive
+carrier would not contain `0` at positive `a` and so would not be a subspace.  This is the
 convention of `TauCeti.riemannRochSpace` and `TauCeti.adeleFiltration`, of which this filtration
 is the one-place shadow; `TauCeti.Place.mem_filtration_iff_le_ord` is the additive form, guarded
 by `z ≠ 0`.
@@ -87,22 +85,20 @@ variable {k F : Type*} [Field k] [Field F] [Algebra k F]
 
 /-! ### The filtration -/
 
-/-- The subspace `𝔪_P^a = {z ∈ F | ord_P z ≥ a}` of functions vanishing to order at least `a`
+/-- The subspace `𝔪_P^a` whose nonzero elements are the functions satisfying `ord_P z ≥ a`
 at `P`, for `a` an arbitrary integer: for `a ≤ 0` it is the space of functions with a pole of
 order at most `-a` at `P`, and for `a > 0` the `a`-th power of the maximal ideal of `𝒪_P`.
 
 The defining condition is the multiplicative `v_P z ≤ exp (-a)`, which is junk-free at `z = 0`;
 `TauCeti.Place.mem_filtration_iff_le_ord` is the additive form. -/
-noncomputable def filtration (P : Place k F) (a : ℤ) : Submodule k F where
-  __ := P.valuation.leAddSubgroup (WithZero.exp (-a))
-  smul_mem' c z hz := by
-    have hz' : P.valuation z ≤ WithZero.exp (-a) := hz
-    rcases eq_or_ne c 0 with rfl | hc
-    · simp
-    · have hcz : P.valuation (c • z) ≤ WithZero.exp (-a) := by
-        rw [Algebra.smul_def, map_mul, P.isTrivialOn.eq_one c hc, one_mul]
-        exact hz'
-      exact hcz
+noncomputable def filtration (P : Place k F) (a : ℤ) : Submodule k F :=
+  letI : Algebra k P.valuation.integer :=
+    ((algebraMap k F).codRestrict P.valuation.integer fun c ↦ by
+      rcases eq_or_ne c 0 with rfl | hc
+      · simp
+      · exact (P.isTrivialOn.eq_one c hc).le).toAlgebra
+  letI : IsScalarTower k P.valuation.integer F := .of_algebraMap_eq fun _ ↦ rfl
+  (P.valuation.leSubmodule (WithZero.exp (-a))).restrictScalars k
 
 variable (P : Place k F)
 
@@ -113,8 +109,8 @@ theorem mem_filtration_iff {a : ℤ} {z : F} :
   (Iff.rfl)
 
 /-- The additive form of membership in `𝔪_P^a`.  The nonvanishing hypothesis guards the junk
-value `ord_P 0 = 0`: the zero function lies in `𝔪_P^a` for every `a`, including the negative
-ones. -/
+value `ord_P 0 = 0`: the zero function lies in `𝔪_P^a` for every `a`, whereas the inequality
+`a ≤ ord_P 0` fails precisely when `a > 0`. -/
 theorem mem_filtration_iff_le_ord {a : ℤ} {z : F} (hz : z ≠ 0) :
     z ∈ P.filtration a ↔ a ≤ P.ord z := by
   rw [mem_filtration_iff, P.valuation_eq_exp_neg_ord hz, WithZero.exp_le_exp]
@@ -178,6 +174,7 @@ noncomputable def filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
     exact congrArg _
       (Subtype.ext (by push_cast [Algebra.smul_def, coe_algebraMap_constants]; ring))
 
+@[simp]
 theorem filtrationResidue_apply (hs : P.ord s = -a) (hs0 : s ≠ 0) (z : P.filtration a) :
     filtrationResidue hs hs0 z =
       IsLocalRing.residue P.integers
@@ -226,6 +223,15 @@ noncomputable def filtrationQuotientEquivResidueField (hs : P.ord s = -a) (hs0 :
       P.ResidueField :=
   (Submodule.quotEquivOfEq _ _ (ker_filtrationResidue hs hs0).symm).trans
     ((filtrationResidue hs hs0).quotKerEquivOfSurjective (surjective_filtrationResidue hs hs0))
+
+/-- The quotient equivalence evaluates the residue of `s * z` on a representative `z`. -/
+@[simp]
+theorem filtrationQuotientEquivResidueField_apply_mk (hs : P.ord s = -a) (hs0 : s ≠ 0)
+    (z : P.filtration a) :
+    filtrationQuotientEquivResidueField hs hs0 (Submodule.Quotient.mk z) =
+      IsLocalRing.residue P.integers
+        ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs hs0 z.2⟩ := by
+  simp [filtrationQuotientEquivResidueField]
 
 end Residue
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
@@ -1,0 +1,335 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Dimension.Free
+public import Mathlib.LinearAlgebra.Dimension.RankNullity
+public import Mathlib.LinearAlgebra.Isomorphisms
+public import TauCeti.FieldTheory.FunctionField.Place.Basic
+
+/-!
+# The order filtration of a function field at a place
+
+A place `P` of `F / k` filters `F` by the order of vanishing at `P`: for an integer `a` the
+functions with `ord_P z ≥ a` form a `k`-subspace
+
+`𝔪_P^a = {z ∈ F | v_P z ≤ exp (-a)}`
+
+of `F`, decreasing in `a`, equal to the valuation ring `𝒪_P` at `a = 0` and to the maximal ideal
+`𝔪_P` at `a = 1`.  For negative `a` it is the fractional ideal of functions with a pole of order
+at most `-a`, so the whole filtration lives inside `F` and no completion is taken.
+
+This file constructs that filtration and computes its successive quotients.  Multiplication by a
+function of order `-a` identifies `𝔪_P^a / 𝔪_P^(a + 1)` with the residue field `F_P`
+(`TauCeti.Place.filtrationQuotientEquivResidueField`), and iterating this along the tower gives
+the dimension formula
+
+`dim_k (𝔪_P^a / 𝔪_P^b) = (b - a) · deg P`  for  `a ≤ b`
+
+(`TauCeti.Place.finrank_quotient_filtration`).  This is the local half of the local-to-global
+engine of Stichtenoth's Section I.5: the global half identifies the quotient `A_F(E) / A_F(D)`
+of two members of the divisor filtration of the repartition space with a finite direct sum of
+these local quotients, and so computes `dim_k (A_F(E) / A_F(D)) = deg E - deg D`.
+
+## Main definitions
+
+* `TauCeti.Place.filtration`: the subspace `𝔪_P^a ⊆ F`.
+* `TauCeti.Place.filtrationResidue`: for `s` of order `-a`, the `k`-linear evaluation
+  `𝔪_P^a → F_P`, `z ↦ (s · z)(P)`.
+* `TauCeti.Place.filtrationQuotientEquivResidueField`: the induced isomorphism
+  `𝔪_P^a / 𝔪_P^(a + 1) ≃ₗ[k] F_P`.
+
+## Main results
+
+* `TauCeti.Place.rank_quotient_filtration_succ`: one step of the filtration has the rank of the
+  residue field.
+* `TauCeti.Place.finrank_quotient_filtration_add` and
+  `TauCeti.Place.finrank_quotient_filtration`: `dim_k (𝔪_P^a / 𝔪_P^b) = (b - a) · deg P`, in the
+  form indexed by `b = a + n` with `n : ℕ` and in the integer form.
+* `TauCeti.Place.finiteDimensional_quotient_filtration`: those quotients are finite-dimensional
+  as soon as the residue field is, which for a function field is
+  `TauCeti.Place.finiteDimensional_residueField`.
+
+## Implementation notes
+
+Membership is stated multiplicatively, as `v_P z ≤ exp (-a)`, and never in the additive form
+`ord_P z ≥ a`, which the junk value `ord_P 0 = 0` would get wrong at `a ≤ 0`: the additive
+carrier would not contain `0` at negative `a` and so would not be a subspace.  This is the
+convention of `TauCeti.riemannRochSpace` and `TauCeti.adeleFiltration`, of which this filtration
+is the one-place shadow; `TauCeti.Place.mem_filtration_iff_le_ord` is the additive form, guarded
+by `z ≠ 0`.
+
+The relative quotients are spelled `↥(P.filtration a) ⧸ (P.filtration b).submoduleOf
+(P.filtration a)`, using Mathlib's `Submodule.submoduleOf` for the trace of the smaller subspace
+on the larger one.  The dimension formula is proved first as a statement about
+`Module.rank`, where it needs no finiteness hypothesis at all, and then transported to
+`Module.finrank` through `Cardinal.toNat_mul`; it therefore holds unconditionally, both sides
+being zero when the residue field is infinite-dimensional over `k`.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Sections I.1 and I.5.
+-/
+
+public section
+
+open scoped WithZero
+
+namespace TauCeti
+
+namespace Place
+
+variable {k F : Type*} [Field k] [Field F] [Algebra k F]
+
+/-! ### The filtration -/
+
+/-- The subspace `𝔪_P^a = {z ∈ F | ord_P z ≥ a}` of functions vanishing to order at least `a`
+at `P`, for `a` an arbitrary integer: for `a ≤ 0` it is the space of functions with a pole of
+order at most `-a` at `P`, and for `a > 0` the `a`-th power of the maximal ideal of `𝒪_P`.
+
+The defining condition is the multiplicative `v_P z ≤ exp (-a)`, which is junk-free at `z = 0`;
+`TauCeti.Place.mem_filtration_iff_le_ord` is the additive form. -/
+noncomputable def filtration (P : Place k F) (a : ℤ) : Submodule k F where
+  __ := P.valuation.leAddSubgroup (WithZero.exp (-a))
+  smul_mem' c z hz := by
+    have hz' : P.valuation z ≤ WithZero.exp (-a) := hz
+    rcases eq_or_ne c 0 with rfl | hc
+    · simp
+    · have hcz : P.valuation (c • z) ≤ WithZero.exp (-a) := by
+        rw [Algebra.smul_def, map_mul, P.isTrivialOn.eq_one c hc, one_mul]
+        exact hz'
+      exact hcz
+
+variable (P : Place k F)
+
+/-- Membership in `𝔪_P^a`, unfolded. -/
+@[simp]
+theorem mem_filtration_iff {a : ℤ} {z : F} :
+    z ∈ P.filtration a ↔ P.valuation z ≤ WithZero.exp (-a) :=
+  (Iff.rfl)
+
+/-- The additive form of membership in `𝔪_P^a`.  The nonvanishing hypothesis guards the junk
+value `ord_P 0 = 0`: the zero function lies in `𝔪_P^a` for every `a`, including the negative
+ones. -/
+theorem mem_filtration_iff_le_ord {a : ℤ} {z : F} (hz : z ≠ 0) :
+    z ∈ P.filtration a ↔ a ≤ P.ord z := by
+  rw [mem_filtration_iff, P.valuation_eq_exp_neg_ord hz, WithZero.exp_le_exp]
+  omega
+
+/-- `𝔪_P^0` is the valuation ring of `P`. -/
+theorem mem_filtration_zero_iff {z : F} : z ∈ P.filtration 0 ↔ z ∈ P.integers := by
+  simp [mem_integers_iff]
+
+/-- `𝔪_P^1` is the maximal ideal of `𝒪_P`. -/
+theorem mem_filtration_one_iff {z : F} (hz : z ≠ 0) :
+    z ∈ P.filtration 1 ↔ P.valuation z < 1 := by
+  rw [P.mem_filtration_iff_le_ord hz, P.valuation_lt_one_iff_ord_pos hz]
+  omega
+
+/-- The filtration decreases: vanishing to higher order is a stronger condition. -/
+theorem filtration_antitone : Antitone P.filtration := fun a b hab z hz ↦
+  hz.trans (WithZero.exp_le_exp.mpr (by omega))
+
+/-- A function of order at least `a` and one of order at least `b` have a product of order at
+least `a + b`. -/
+theorem mul_mem_filtration {a b : ℤ} {z w : F} (hz : z ∈ P.filtration a)
+    (hw : w ∈ P.filtration b) : z * w ∈ P.filtration (a + b) := by
+  have hz' : P.valuation z ≤ WithZero.exp (-a) := hz
+  have hw' : P.valuation w ≤ WithZero.exp (-b) := hw
+  rw [mem_filtration_iff, map_mul, neg_add, WithZero.exp_add]
+  exact mul_le_mul' hz' hw'
+
+/-- A nonzero function lies in the step of the filtration cut out by its own order. -/
+theorem mem_filtration_ord {z : F} (hz : z ≠ 0) : z ∈ P.filtration (P.ord z) :=
+  (P.mem_filtration_iff_le_ord hz).mpr le_rfl
+
+/-! ### The successive quotients -/
+
+section Residue
+
+variable {P} {a : ℤ} {s : F}
+
+/-- Multiplying a function of order at least `a` by one of order `-a` lands in the valuation
+ring: the integrality behind the evaluation map `TauCeti.Place.filtrationResidue`. -/
+theorem mul_mem_integers_of_mem_filtration (hs : P.ord s = -a) (hs0 : s ≠ 0) {z : F}
+    (hz : z ∈ P.filtration a) : s * z ∈ P.integers := by
+  rcases eq_or_ne z 0 with rfl | hz0
+  · simp
+  · rw [P.mem_integers_iff_ord_nonneg, P.ord_mul hs0 hz0, hs]
+    have := (P.mem_filtration_iff_le_ord hz0).mp hz
+    omega
+
+/-- Evaluation of `s · z` at `P`, for a fixed function `s` of order `-a`: a `k`-linear map from
+`𝔪_P^a` to the residue field `F_P`, whose kernel is `𝔪_P^(a + 1)` and which is surjective.  It
+is the local form of the evaluation map in Stichtenoth's proof of Lemma 1.4.8. -/
+noncomputable def filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
+    P.filtration a →ₗ[k] P.ResidueField where
+  toFun z := IsScalarTower.toAlgHom k P.integers P.ResidueField
+    ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs hs0 z.2⟩
+  map_add' z w := by
+    rw [← map_add]
+    exact congrArg _ (Subtype.ext (by push_cast; ring))
+  map_smul' c z := by
+    rw [RingHom.id_apply, ← map_smul]
+    exact congrArg _
+      (Subtype.ext (by push_cast [Algebra.smul_def, coe_algebraMap_constants]; ring))
+
+theorem filtrationResidue_apply (hs : P.ord s = -a) (hs0 : s ≠ 0) (z : P.filtration a) :
+    filtrationResidue hs hs0 z =
+      IsLocalRing.residue P.integers
+        ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs hs0 z.2⟩ :=
+  (rfl)
+
+/-- The evaluation `z ↦ (s · z)(P)` kills exactly the next step of the filtration. -/
+theorem ker_filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
+    LinearMap.ker (filtrationResidue hs hs0) =
+      (P.filtration (a + 1)).submoduleOf (P.filtration a) := by
+  have hmem : ∀ z : P.filtration a,
+      z ∈ (P.filtration (a + 1)).submoduleOf (P.filtration a) ↔
+        (z : F) ∈ P.filtration (a + 1) := fun _ ↦ Iff.rfl
+  ext z
+  rw [LinearMap.mem_ker, hmem, filtrationResidue_apply]
+  rcases eq_or_ne (z : F) 0 with hz0 | hz0
+  · have h0 : (⟨s * (z : F), mul_mem_integers_of_mem_filtration hs hs0 z.2⟩ : P.integers) = 0 :=
+      Subtype.ext (by simp [hz0])
+    rw [h0, map_zero, hz0]
+    simp
+  · rw [P.residue_eq_zero_iff_ord_pos (mul_ne_zero hs0 hz0), P.ord_mul hs0 hz0, hs,
+      P.mem_filtration_iff_le_ord hz0]
+    omega
+
+/-- Every residue is attained: `z ↦ (s · z)(P)` maps `𝔪_P^a` onto the residue field. -/
+theorem surjective_filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
+    Function.Surjective (filtrationResidue hs hs0) := by
+  intro ξ
+  obtain ⟨u, rfl⟩ := IsLocalRing.residue_surjective (R := P.integers) ξ
+  have hu : s⁻¹ * (u : F) ∈ P.filtration a := by
+    rcases eq_or_ne (u : F) 0 with hu0 | hu0
+    · simp [hu0]
+    · rw [P.mem_filtration_iff_le_ord (mul_ne_zero (inv_ne_zero hs0) hu0),
+        P.ord_mul (inv_ne_zero hs0) hu0, P.ord_inv, hs]
+      have := P.mem_integers_iff_ord_nonneg.mp u.2
+      omega
+  refine ⟨⟨s⁻¹ * (u : F), hu⟩, ?_⟩
+  rw [filtrationResidue_apply]
+  exact congrArg _ (Subtype.ext (by field_simp))
+
+/-- **The local quotient of the order filtration.**  Multiplication by a function `s` of order
+`-a`, followed by evaluation at `P`, identifies `𝔪_P^a / 𝔪_P^(a + 1)` with the residue field
+`F_P` as `k`-vector spaces. -/
+noncomputable def filtrationQuotientEquivResidueField (hs : P.ord s = -a) (hs0 : s ≠ 0) :
+    (↥(P.filtration a) ⧸ (P.filtration (a + 1)).submoduleOf (P.filtration a)) ≃ₗ[k]
+      P.ResidueField :=
+  (Submodule.quotEquivOfEq _ _ (ker_filtrationResidue hs hs0).symm).trans
+    ((filtrationResidue hs hs0).quotKerEquivOfSurjective (surjective_filtrationResidue hs hs0))
+
+end Residue
+
+/-- One step of the order filtration has the rank of the residue field. -/
+theorem rank_quotient_filtration_succ (a : ℤ) :
+    Module.rank k (↥(P.filtration a) ⧸ (P.filtration (a + 1)).submoduleOf (P.filtration a)) =
+      Module.rank k P.ResidueField := by
+  obtain ⟨s, hs0, hs⟩ := P.exists_ne_zero_ord_eq (-a)
+  exact (filtrationQuotientEquivResidueField hs hs0).rank_eq
+
+/-- Rank is additive along a tower `p ≤ q ≤ r` of subspaces: the relative quotients of the two
+steps add up to the relative quotient of the composite.  This is Noether's third isomorphism
+theorem together with rank–nullity, and is what turns the one-step computation
+`TauCeti.Place.rank_quotient_filtration_succ` into the dimension formula below. -/
+private lemma rank_quotient_submoduleOf_tower {M : Type*} [AddCommGroup M] [Module k M]
+    {p q r : Submodule k M} (hpq : p ≤ q) (hqr : q ≤ r) :
+    Module.rank k (↥r ⧸ p.submoduleOf r) =
+      Module.rank k (↥q ⧸ p.submoduleOf q) + Module.rank k (↥r ⧸ q.submoduleOf r) := by
+  have hAB : p.submoduleOf r ≤ q.submoduleOf r := Submodule.comap_mono hpq
+  set A := p.submoduleOf r with hA
+  set f : ↥q →ₗ[k] (↥r ⧸ A) := A.mkQ ∘ₗ Submodule.inclusion hqr with hf
+  have hker : LinearMap.ker f = p.submoduleOf q := by
+    ext z
+    simp [hf, hA, Submodule.submoduleOf, Submodule.inclusion]
+  have hrange : LinearMap.range f = (q.submoduleOf r).map A.mkQ := by
+    rw [hf, LinearMap.range_comp, Submodule.range_inclusion]
+    rfl
+  have e₁ : (↥q ⧸ p.submoduleOf q) ≃ₗ[k] ↥((q.submoduleOf r).map A.mkQ) :=
+    (Submodule.quotEquivOfEq _ _ hker.symm).trans
+      ((f.quotKerEquivRange).trans (LinearEquiv.ofEq _ _ hrange))
+  have e₂ : ((↥r ⧸ A) ⧸ (q.submoduleOf r).map A.mkQ) ≃ₗ[k] (↥r ⧸ q.submoduleOf r) :=
+    Submodule.quotientQuotientEquivQuotient A (q.submoduleOf r) hAB
+  have key := Submodule.rank_quotient_add_rank ((q.submoduleOf r).map A.mkQ)
+  rw [e₂.rank_eq, ← e₁.rank_eq] at key
+  rw [← key, add_comm]
+
+/-- Transport of a relative rank along an equality of indices, which lets the induction below
+step from `a + (n + 1 : ℕ)` to `(a + n) + 1` without rewriting inside a quotient type. -/
+private lemma rank_quotient_filtration_congr (P : Place k F) {a b b' : ℤ} (h : b = b') :
+    Module.rank k (↥(P.filtration a) ⧸ (P.filtration b).submoduleOf (P.filtration a)) =
+      Module.rank k (↥(P.filtration a) ⧸ (P.filtration b').submoduleOf (P.filtration a)) := by
+  subst h
+  rfl
+
+/-- **The dimension of a local quotient of the order filtration**, in the form indexed by a
+natural number of steps: `dim_k (𝔪_P^a / 𝔪_P^(a + n)) = n · deg P`, at the level of ranks and so
+without any finiteness hypothesis on the residue field. -/
+theorem rank_quotient_filtration_add (a : ℤ) (n : ℕ) :
+    Module.rank k (↥(P.filtration a) ⧸ (P.filtration (a + n)).submoduleOf (P.filtration a)) =
+      n * Module.rank k P.ResidueField := by
+  induction n with
+  | zero =>
+    have : (P.filtration a).submoduleOf (P.filtration a) = ⊤ := Submodule.submoduleOf_self _
+    simp [this]
+  | succ n ih =>
+    have hcast : a + ((n + 1 : ℕ) : ℤ) = a + n + 1 := by push_cast; ring
+    have hpq : P.filtration (a + n + 1) ≤ P.filtration (a + n) := P.filtration_antitone (by omega)
+    have hqr : P.filtration (a + n) ≤ P.filtration a := P.filtration_antitone (by omega)
+    rw [rank_quotient_filtration_congr P hcast, rank_quotient_submoduleOf_tower hpq hqr,
+      rank_quotient_filtration_succ, ih]
+    push_cast
+    ring
+
+/-- **The dimension of a local quotient of the order filtration** (Stichtenoth, Section I.5): the
+`k`-dimension of `𝔪_P^a / 𝔪_P^(a + n)` is `n · deg P`.
+
+Both sides are junk — zero — when the residue field is infinite-dimensional over `k`, so no
+finiteness hypothesis is needed; for a function field the residue field is always
+finite-dimensional (`TauCeti.Place.finiteDimensional_residueField`). -/
+theorem finrank_quotient_filtration_add (a : ℤ) (n : ℕ) :
+    Module.finrank k (↥(P.filtration a) ⧸ (P.filtration (a + n)).submoduleOf (P.filtration a)) =
+      n * P.degree := by
+  rw [Module.finrank, rank_quotient_filtration_add, Cardinal.toNat_mul, Cardinal.toNat_natCast,
+    degree_eq_finrank, Module.finrank]
+
+/-- **The dimension of a local quotient of the order filtration**, in integer form: for `a ≤ b`,
+`dim_k (𝔪_P^a / 𝔪_P^b) = (b - a) · deg P`.  This is the local input of the local-to-global
+engine computing `dim_k (A_F(E) / A_F(D)) = deg E - deg D` for the divisor filtration of the
+repartition space. -/
+theorem finrank_quotient_filtration {a b : ℤ} (hab : a ≤ b) :
+    (Module.finrank k (↥(P.filtration a) ⧸ (P.filtration b).submoduleOf (P.filtration a)) : ℤ) =
+      (b - a) * P.degree := by
+  obtain ⟨n, rfl⟩ : ∃ n : ℕ, b = a + n := ⟨(b - a).toNat, by omega⟩
+  rw [finrank_quotient_filtration_add]
+  push_cast
+  ring
+
+/-- The local quotients of the order filtration are finite-dimensional as soon as the residue
+field is, which for a function field is `TauCeti.Place.finiteDimensional_residueField`.  No
+order relation between `a` and `b` is needed: for `b ≤ a` the quotient is trivial. -/
+theorem finiteDimensional_quotient_filtration [Module.Finite k P.ResidueField] (a b : ℤ) :
+    FiniteDimensional k
+      (↥(P.filtration a) ⧸ (P.filtration b).submoduleOf (P.filtration a)) := by
+  rcases le_or_gt a b with hab | hab
+  · obtain ⟨n, rfl⟩ : ∃ n : ℕ, b = a + n := ⟨(b - a).toNat, by omega⟩
+    refine Module.rank_lt_aleph0_iff.mp ?_
+    rw [rank_quotient_filtration_add]
+    exact Cardinal.mul_lt_aleph0 Cardinal.natCast_lt_aleph0
+      (Module.rank_lt_aleph0_iff.mpr ‹Module.Finite k P.ResidueField›)
+  · have : (P.filtration b).submoduleOf (P.filtration a) = ⊤ :=
+      Submodule.submoduleOf_eq_top.mpr (P.filtration_antitone hab.le)
+    rw [this]
+    infer_instance
+
+end Place
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
@@ -169,10 +169,10 @@ theorem mul_mem_integers_of_mem_filtration (hs : P.ord s = -a) {z : F}
 `𝔪_P^a` to the residue field `F_P`, whose kernel is `𝔪_P^(a + 1)` and which is surjective.  It
 is the local form of the evaluation map in Stichtenoth's proof of Lemma 1.4.8.
 
-The nonvanishing hypothesis on `s` is not needed to define the map, but scopes it to the range
-where it is the intended one: `TauCeti.Place.ker_filtrationResidue` and
-`TauCeti.Place.filtrationResidue_surjective` both fail at `s = 0`. -/
-noncomputable def filtrationResidue (hs : P.ord s = -a) (_hs0 : s ≠ 0) :
+Defining the map needs nothing beyond `hs`; it is only its kernel and its surjectivity
+(`TauCeti.Place.ker_filtrationResidue`, `TauCeti.Place.filtrationResidue_surjective`) that fail
+at `s = 0`, so those carry the nonvanishing hypothesis. -/
+noncomputable def filtrationResidue (hs : P.ord s = -a) :
     P.filtration a →ₗ[k] P.ResidueField where
   toFun z := IsScalarTower.toAlgHom k P.integers P.ResidueField
     ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs z.2⟩
@@ -184,14 +184,14 @@ noncomputable def filtrationResidue (hs : P.ord s = -a) (_hs0 : s ≠ 0) :
     exact congrArg _ (Subtype.ext (by push_cast [Algebra.smul_def]; ring))
 
 @[simp]
-theorem filtrationResidue_apply (hs : P.ord s = -a) (hs0 : s ≠ 0) (z : P.filtration a) :
-    filtrationResidue hs hs0 z =
+theorem filtrationResidue_apply (hs : P.ord s = -a) (z : P.filtration a) :
+    filtrationResidue hs z =
       IsLocalRing.residue P.integers ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs z.2⟩ :=
   (rfl)
 
 /-- The evaluation `z ↦ (s · z)(P)` vanishes exactly on the next step of the filtration. -/
 theorem filtrationResidue_eq_zero_iff (hs : P.ord s = -a) (hs0 : s ≠ 0) (z : P.filtration a) :
-    filtrationResidue hs hs0 z = 0 ↔ (z : F) ∈ P.filtration (a + 1) := by
+    filtrationResidue hs z = 0 ↔ (z : F) ∈ P.filtration (a + 1) := by
   rw [filtrationResidue_apply]
   rcases eq_or_ne (z : F) 0 with hz0 | hz0
   · have h0 : (⟨s * (z : F), mul_mem_integers_of_mem_filtration hs z.2⟩ : P.integers) = 0 :=
@@ -204,17 +204,17 @@ theorem filtrationResidue_eq_zero_iff (hs : P.ord s = -a) (hs0 : s ≠ 0) (z : P
 
 /-- The evaluation `z ↦ (s · z)(P)` kills exactly the next step of the filtration. -/
 theorem ker_filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
-    LinearMap.ker (filtrationResidue hs hs0) =
+    LinearMap.ker (filtrationResidue hs) =
       (P.filtration (a + 1)).submoduleOf (P.filtration a) := by
   have hmem : ∀ w : P.filtration a,
       w ∈ (P.filtration (a + 1)).submoduleOf (P.filtration a) ↔ (w : F) ∈ P.filtration (a + 1) :=
     fun _ ↦ Submodule.mem_comap
   ext z
-  rw [LinearMap.mem_ker, hmem, filtrationResidue_eq_zero_iff]
+  rw [LinearMap.mem_ker, hmem, filtrationResidue_eq_zero_iff hs hs0]
 
 /-- Every residue is attained: `z ↦ (s · z)(P)` maps `𝔪_P^a` onto the residue field. -/
 theorem filtrationResidue_surjective (hs : P.ord s = -a) (hs0 : s ≠ 0) :
-    Function.Surjective (filtrationResidue hs hs0) := by
+    Function.Surjective (filtrationResidue hs) := by
   intro ξ
   obtain ⟨u, rfl⟩ := IsLocalRing.residue_surjective (R := P.integers) ξ
   have hu : s⁻¹ * (u : F) ∈ P.filtration a := by
@@ -235,7 +235,7 @@ noncomputable def filtrationQuotientEquivResidueField (hs : P.ord s = -a) (hs0 :
     (↥(P.filtration a) ⧸ (P.filtration (a + 1)).submoduleOf (P.filtration a)) ≃ₗ[k]
       P.ResidueField :=
   (Submodule.quotEquivOfEq _ _ (ker_filtrationResidue hs hs0).symm).trans
-    ((filtrationResidue hs hs0).quotKerEquivOfSurjective (filtrationResidue_surjective hs hs0))
+    ((filtrationResidue hs).quotKerEquivOfSurjective (filtrationResidue_surjective hs hs0))
 
 /-- The quotient equivalence evaluates the residue of `s * z` on a representative `z`. -/
 @[simp]

--- a/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
@@ -54,7 +54,7 @@ these local quotients, and so computes `dim_k (A_F(E) / A_F(D)) = deg E - deg D`
 
 ## Implementation notes
 
-Membership is stated multiplicatively, as `v_P z ≤ exp (-a)`, and never in the additive form
+Membership is stated multiplicatively, as `v_P z ≤ exp (-a)`, and not in the unguarded additive form
 `ord_P z ≥ a`, which the junk value `ord_P 0 = 0` would get wrong at `a > 0`: the additive
 carrier would not contain `0` at positive `a` and so would not be a subspace.  This is the
 convention of `TauCeti.riemannRochSpace` and `TauCeti.adeleFiltration`, of which this filtration

--- a/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Filtration.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Dimension.RankNullity
 public import TauCeti.FieldTheory.FunctionField.Place.Basic
+public import TauCeti.LinearAlgebra.Dimension.Tower
 
 /-!
 # The order filtration of a function field at a place
@@ -16,9 +16,10 @@ together with the nonzero functions satisfying `ord_P z ≥ a` forms the `k`-sub
 
 `𝔪_P^a = {z ∈ F | v_P z ≤ exp (-a)}`
 
-of `F`, decreasing in `a`, equal to the valuation ring `𝒪_P` at `a = 0` and to the maximal ideal
-`𝔪_P` at `a = 1`.  For negative `a` it is the fractional ideal of functions with a pole of order
-at most `-a`, so the whole filtration lives inside `F` and no completion is taken.
+of `F`, decreasing in `a`.  At `a = 0` its membership condition is `v_P z ≤ 1`, that of the
+valuation ring `𝒪_P`, and at `a = 1` it is `v_P z < 1`, that of the maximal ideal `𝔪_P` of `𝒪_P`.
+For negative `a` it is the fractional ideal of functions with a pole of order at most `-a`, so the
+whole filtration lives inside `F` and no completion is taken.
 
 This file constructs that filtration and computes its successive quotients.  Multiplication by a
 function of order `-a` identifies `𝔪_P^a / 𝔪_P^(a + 1)` with the residue field `F_P`
@@ -42,7 +43,7 @@ these local quotients, and so computes `dim_k (A_F(E) / A_F(D)) = deg E - deg D`
 
 ## Main results
 
-* `TauCeti.Place.rank_quotient_filtration_succ`: one step of the filtration has the rank of the
+* `TauCeti.Place.rank_quotient_filtration_add_one`: one step of the filtration has the rank of the
   residue field.
 * `TauCeti.Place.finrank_quotient_filtration_add` and
   `TauCeti.Place.finrank_quotient_filtration`: `dim_k (𝔪_P^a / 𝔪_P^b) = (b - a) · deg P`, in the
@@ -93,10 +94,8 @@ The defining condition is the multiplicative `v_P z ≤ exp (-a)`, which is junk
 `TauCeti.Place.mem_filtration_iff_le_ord` is the additive form. -/
 noncomputable def filtration (P : Place k F) (a : ℤ) : Submodule k F :=
   letI : Algebra k P.valuation.integer :=
-    ((algebraMap k F).codRestrict P.valuation.integer fun c ↦ by
-      rcases eq_or_ne c 0 with rfl | hc
-      · simp
-      · exact (P.isTrivialOn.eq_one c hc).le).toAlgebra
+    ((algebraMap k F).codRestrict P.valuation.integer
+      (Valuation.IsTrivialOn.valuation_algebraMap_le_one P.valuation)).toAlgebra
   letI : IsScalarTower k P.valuation.integer F := .of_algebraMap_eq fun _ ↦ rfl
   (P.valuation.leSubmodule (WithZero.exp (-a))).restrictScalars k
 
@@ -120,28 +119,33 @@ theorem mem_filtration_iff_le_ord {a : ℤ} {z : F} (hz : z ≠ 0) :
 theorem mem_filtration_zero_iff {z : F} : z ∈ P.filtration 0 ↔ z ∈ P.integers := by
   simp [mem_integers_iff]
 
-/-- `𝔪_P^1` is the maximal ideal of `𝒪_P`. -/
-theorem mem_filtration_one_iff {z : F} (hz : z ≠ 0) :
-    z ∈ P.filtration 1 ↔ P.valuation z < 1 := by
-  rw [P.mem_filtration_iff_le_ord hz, P.valuation_lt_one_iff_ord_pos hz]
-  omega
+/-- Membership in `𝔪_P^1` is the maximal-ideal condition `v_P z < 1`
+(`TauCeti.Place.mem_maximalIdeal_iff_valuation_lt_one`): `𝔪_P^1` is the maximal ideal of `𝒪_P`,
+seen inside `F`. -/
+theorem mem_filtration_one_iff {z : F} : z ∈ P.filtration 1 ↔ P.valuation z < 1 := by
+  rcases eq_or_ne z 0 with rfl | hz
+  · simp
+  · rw [P.mem_filtration_iff_le_ord hz, P.valuation_lt_one_iff_ord_pos hz]
+    omega
 
 /-- The filtration decreases: vanishing to higher order is a stronger condition. -/
 theorem filtration_antitone : Antitone P.filtration := fun a b hab z hz ↦
-  hz.trans (WithZero.exp_le_exp.mpr (by omega))
+  P.mem_filtration_iff.mpr
+    ((P.mem_filtration_iff.mp hz).trans (WithZero.exp_le_exp.mpr (by omega)))
 
 /-- A function of order at least `a` and one of order at least `b` have a product of order at
 least `a + b`. -/
 theorem mul_mem_filtration {a b : ℤ} {z w : F} (hz : z ∈ P.filtration a)
     (hw : w ∈ P.filtration b) : z * w ∈ P.filtration (a + b) := by
-  have hz' : P.valuation z ≤ WithZero.exp (-a) := hz
-  have hw' : P.valuation w ≤ WithZero.exp (-b) := hw
   rw [mem_filtration_iff, map_mul, neg_add, WithZero.exp_add]
-  exact mul_le_mul' hz' hw'
+  exact mul_le_mul' (P.mem_filtration_iff.mp hz) (P.mem_filtration_iff.mp hw)
 
-/-- A nonzero function lies in the step of the filtration cut out by its own order. -/
-theorem mem_filtration_ord {z : F} (hz : z ≠ 0) : z ∈ P.filtration (P.ord z) :=
-  (P.mem_filtration_iff_le_ord hz).mpr le_rfl
+/-- A function lies in the step of the filtration cut out by its own order.  At `z = 0` this
+reads `0 ∈ 𝔪_P^0`, the junk value `ord_P 0 = 0` doing no harm. -/
+theorem mem_filtration_ord (z : F) : z ∈ P.filtration (P.ord z) := by
+  rcases eq_or_ne z 0 with rfl | hz
+  · simp
+  · exact (P.mem_filtration_iff_le_ord hz).mpr le_rfl
 
 /-! ### The successive quotients -/
 
@@ -151,47 +155,46 @@ variable {P} {a : ℤ} {s : F}
 
 /-- Multiplying a function of order at least `a` by one of order `-a` lands in the valuation
 ring: the integrality behind the evaluation map `TauCeti.Place.filtrationResidue`. -/
-theorem mul_mem_integers_of_mem_filtration (hs : P.ord s = -a) (hs0 : s ≠ 0) {z : F}
+theorem mul_mem_integers_of_mem_filtration (hs : P.ord s = -a) {z : F}
     (hz : z ∈ P.filtration a) : s * z ∈ P.integers := by
+  rcases eq_or_ne s 0 with rfl | hs0
+  · simp
   rcases eq_or_ne z 0 with rfl | hz0
   · simp
-  · rw [P.mem_integers_iff_ord_nonneg, P.ord_mul hs0 hz0, hs]
-    have := (P.mem_filtration_iff_le_ord hz0).mp hz
-    omega
+  rw [P.mem_integers_iff_ord_nonneg, P.ord_mul hs0 hz0, hs]
+  have := (P.mem_filtration_iff_le_ord hz0).mp hz
+  omega
 
 /-- Evaluation of `s · z` at `P`, for a fixed function `s` of order `-a`: a `k`-linear map from
 `𝔪_P^a` to the residue field `F_P`, whose kernel is `𝔪_P^(a + 1)` and which is surjective.  It
-is the local form of the evaluation map in Stichtenoth's proof of Lemma 1.4.8. -/
-noncomputable def filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
+is the local form of the evaluation map in Stichtenoth's proof of Lemma 1.4.8.
+
+The nonvanishing hypothesis on `s` is not needed to define the map, but scopes it to the range
+where it is the intended one: `TauCeti.Place.ker_filtrationResidue` and
+`TauCeti.Place.filtrationResidue_surjective` both fail at `s = 0`. -/
+noncomputable def filtrationResidue (hs : P.ord s = -a) (_hs0 : s ≠ 0) :
     P.filtration a →ₗ[k] P.ResidueField where
   toFun z := IsScalarTower.toAlgHom k P.integers P.ResidueField
-    ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs hs0 z.2⟩
+    ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs z.2⟩
   map_add' z w := by
     rw [← map_add]
     exact congrArg _ (Subtype.ext (by push_cast; ring))
   map_smul' c z := by
     rw [RingHom.id_apply, ← map_smul]
-    exact congrArg _
-      (Subtype.ext (by push_cast [Algebra.smul_def, coe_algebraMap_constants]; ring))
+    exact congrArg _ (Subtype.ext (by push_cast [Algebra.smul_def]; ring))
 
 @[simp]
 theorem filtrationResidue_apply (hs : P.ord s = -a) (hs0 : s ≠ 0) (z : P.filtration a) :
     filtrationResidue hs hs0 z =
-      IsLocalRing.residue P.integers
-        ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs hs0 z.2⟩ :=
+      IsLocalRing.residue P.integers ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs z.2⟩ :=
   (rfl)
 
-/-- The evaluation `z ↦ (s · z)(P)` kills exactly the next step of the filtration. -/
-theorem ker_filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
-    LinearMap.ker (filtrationResidue hs hs0) =
-      (P.filtration (a + 1)).submoduleOf (P.filtration a) := by
-  have hmem : ∀ z : P.filtration a,
-      z ∈ (P.filtration (a + 1)).submoduleOf (P.filtration a) ↔
-        (z : F) ∈ P.filtration (a + 1) := fun _ ↦ Iff.rfl
-  ext z
-  rw [LinearMap.mem_ker, hmem, filtrationResidue_apply]
+/-- The evaluation `z ↦ (s · z)(P)` vanishes exactly on the next step of the filtration. -/
+theorem filtrationResidue_eq_zero_iff (hs : P.ord s = -a) (hs0 : s ≠ 0) (z : P.filtration a) :
+    filtrationResidue hs hs0 z = 0 ↔ (z : F) ∈ P.filtration (a + 1) := by
+  rw [filtrationResidue_apply]
   rcases eq_or_ne (z : F) 0 with hz0 | hz0
-  · have h0 : (⟨s * (z : F), mul_mem_integers_of_mem_filtration hs hs0 z.2⟩ : P.integers) = 0 :=
+  · have h0 : (⟨s * (z : F), mul_mem_integers_of_mem_filtration hs z.2⟩ : P.integers) = 0 :=
       Subtype.ext (by simp [hz0])
     rw [h0, map_zero, hz0]
     simp
@@ -199,8 +202,18 @@ theorem ker_filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
       P.mem_filtration_iff_le_ord hz0]
     omega
 
+/-- The evaluation `z ↦ (s · z)(P)` kills exactly the next step of the filtration. -/
+theorem ker_filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
+    LinearMap.ker (filtrationResidue hs hs0) =
+      (P.filtration (a + 1)).submoduleOf (P.filtration a) := by
+  have hmem : ∀ w : P.filtration a,
+      w ∈ (P.filtration (a + 1)).submoduleOf (P.filtration a) ↔ (w : F) ∈ P.filtration (a + 1) :=
+    fun _ ↦ Submodule.mem_comap
+  ext z
+  rw [LinearMap.mem_ker, hmem, filtrationResidue_eq_zero_iff]
+
 /-- Every residue is attained: `z ↦ (s · z)(P)` maps `𝔪_P^a` onto the residue field. -/
-theorem surjective_filtrationResidue (hs : P.ord s = -a) (hs0 : s ≠ 0) :
+theorem filtrationResidue_surjective (hs : P.ord s = -a) (hs0 : s ≠ 0) :
     Function.Surjective (filtrationResidue hs hs0) := by
   intro ξ
   obtain ⟨u, rfl⟩ := IsLocalRing.residue_surjective (R := P.integers) ξ
@@ -222,51 +235,24 @@ noncomputable def filtrationQuotientEquivResidueField (hs : P.ord s = -a) (hs0 :
     (↥(P.filtration a) ⧸ (P.filtration (a + 1)).submoduleOf (P.filtration a)) ≃ₗ[k]
       P.ResidueField :=
   (Submodule.quotEquivOfEq _ _ (ker_filtrationResidue hs hs0).symm).trans
-    ((filtrationResidue hs hs0).quotKerEquivOfSurjective (surjective_filtrationResidue hs hs0))
+    ((filtrationResidue hs hs0).quotKerEquivOfSurjective (filtrationResidue_surjective hs hs0))
 
 /-- The quotient equivalence evaluates the residue of `s * z` on a representative `z`. -/
 @[simp]
 theorem filtrationQuotientEquivResidueField_apply_mk (hs : P.ord s = -a) (hs0 : s ≠ 0)
     (z : P.filtration a) :
     filtrationQuotientEquivResidueField hs hs0 (Submodule.Quotient.mk z) =
-      IsLocalRing.residue P.integers
-        ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs hs0 z.2⟩ := by
+      IsLocalRing.residue P.integers ⟨s * (z : F), mul_mem_integers_of_mem_filtration hs z.2⟩ := by
   simp [filtrationQuotientEquivResidueField]
 
 end Residue
 
 /-- One step of the order filtration has the rank of the residue field. -/
-theorem rank_quotient_filtration_succ (a : ℤ) :
+theorem rank_quotient_filtration_add_one (a : ℤ) :
     Module.rank k (↥(P.filtration a) ⧸ (P.filtration (a + 1)).submoduleOf (P.filtration a)) =
       Module.rank k P.ResidueField := by
   obtain ⟨s, hs0, hs⟩ := P.exists_ne_zero_ord_eq (-a)
   exact (filtrationQuotientEquivResidueField hs hs0).rank_eq
-
-/-- Rank is additive along a tower `p ≤ q ≤ r` of subspaces: the relative quotients of the two
-steps add up to the relative quotient of the composite.  This is Noether's third isomorphism
-theorem together with rank–nullity, and is what turns the one-step computation
-`TauCeti.Place.rank_quotient_filtration_succ` into the dimension formula below. -/
-private lemma rank_quotient_submoduleOf_tower {M : Type*} [AddCommGroup M] [Module k M]
-    {p q r : Submodule k M} (hpq : p ≤ q) (hqr : q ≤ r) :
-    Module.rank k (↥r ⧸ p.submoduleOf r) =
-      Module.rank k (↥q ⧸ p.submoduleOf q) + Module.rank k (↥r ⧸ q.submoduleOf r) := by
-  have hAB : p.submoduleOf r ≤ q.submoduleOf r := Submodule.comap_mono hpq
-  set A := p.submoduleOf r with hA
-  set f : ↥q →ₗ[k] (↥r ⧸ A) := A.mkQ ∘ₗ Submodule.inclusion hqr with hf
-  have hker : LinearMap.ker f = p.submoduleOf q := by
-    ext z
-    simp [hf, hA, Submodule.submoduleOf, Submodule.inclusion]
-  have hrange : LinearMap.range f = (q.submoduleOf r).map A.mkQ := by
-    rw [hf, LinearMap.range_comp, Submodule.range_inclusion]
-    rfl
-  have e₁ : (↥q ⧸ p.submoduleOf q) ≃ₗ[k] ↥((q.submoduleOf r).map A.mkQ) :=
-    (Submodule.quotEquivOfEq _ _ hker.symm).trans
-      ((f.quotKerEquivRange).trans (LinearEquiv.ofEq _ _ hrange))
-  have e₂ : ((↥r ⧸ A) ⧸ (q.submoduleOf r).map A.mkQ) ≃ₗ[k] (↥r ⧸ q.submoduleOf r) :=
-    Submodule.quotientQuotientEquivQuotient A (q.submoduleOf r) hAB
-  have key := Submodule.rank_quotient_add_rank ((q.submoduleOf r).map A.mkQ)
-  rw [e₂.rank_eq, ← e₁.rank_eq] at key
-  rw [← key, add_comm]
 
 /-- Transport of a relative rank along an equality of indices, which lets the induction below
 step from `a + (n + 1 : ℕ)` to `(a + n) + 1` without rewriting inside a quotient type. -/
@@ -291,7 +277,7 @@ theorem rank_quotient_filtration_add (a : ℤ) (n : ℕ) :
     have hpq : P.filtration (a + n + 1) ≤ P.filtration (a + n) := P.filtration_antitone (by omega)
     have hqr : P.filtration (a + n) ≤ P.filtration a := P.filtration_antitone (by omega)
     rw [rank_quotient_filtration_congr P hcast, rank_quotient_submoduleOf_tower hpq hqr,
-      rank_quotient_filtration_succ, ih]
+      rank_quotient_filtration_add_one, ih]
     push_cast
     ring
 

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/Basic.lean
@@ -11,6 +11,7 @@ public import Mathlib.RingTheory.Finiteness.Finsupp
 public import TauCeti.FieldTheory.FunctionField.ConstantField
 public import TauCeti.FieldTheory.FunctionField.Divisor.Basic
 public import TauCeti.FieldTheory.FunctionField.Place.Existence
+public import TauCeti.FieldTheory.FunctionField.Place.Filtration
 
 /-!
 # Riemann–Roch spaces
@@ -177,66 +178,56 @@ private lemma le_add_ofPoint (D : Divisor k F) (P : Place k F) :
   le_add_of_nonneg_right
     (WeilDivisor.isEffective_iff_zero_le.mp (WeilDivisor.isEffective_ofPoint P))
 
-private lemma mul_mem_integers (ht : P.ord t = D.coeff P + 1) (ht0 : t ≠ 0) {x : F}
-    (hx : x ∈ riemannRochSpace (D + WeilDivisor.ofPoint P)) : t * x ∈ P.integers := by
-  rcases eq_or_ne x 0 with rfl | hx0
-  · simp
-  · rw [P.mem_integers_iff_ord_nonneg, P.ord_mul ht0 hx0, ht]
-    have h := (mem_riemannRochSpace_iff_neg_le_ord hx0).mp hx P
-    rw [WeilDivisor.coeff_add, WeilDivisor.coeff_ofPoint_self] at h
-    omega
+/-- `L(D)` bounds the pole at any single place: it sits inside the step `𝔪_P^(-D P)` of the
+order filtration at `P`. -/
+private lemma riemannRochSpace_le_filtration (D : Divisor k F) (P : Place k F) :
+    riemannRochSpace D ≤ P.filtration (-D.coeff P) := fun f hf ↦ by
+  rw [Place.mem_filtration_iff, neg_neg]
+  exact mem_riemannRochSpace_iff.mp hf P
+
+/-- The special case of `TauCeti.riemannRochSpace_le_filtration` used to build
+`TauCeti.residueEval`, with the coefficient of `D + P` at `P` computed. -/
+private lemma riemannRochSpace_add_ofPoint_le_filtration (D : Divisor k F) (P : Place k F) :
+    riemannRochSpace (D + WeilDivisor.ofPoint P) ≤ P.filtration (-(D.coeff P + 1)) := by
+  have h := riemannRochSpace_le_filtration (D + WeilDivisor.ofPoint P) P
+  rwa [WeilDivisor.coeff_add, WeilDivisor.coeff_ofPoint_self] at h
+
+/-- Inside `L(D + P)`, belonging to `L(D)` is a condition at `P` alone: away from `P` the two
+divisors agree, so only the pole order at `P` can differ. -/
+private lemma mem_riemannRochSpace_iff_mem_filtration {x : F}
+    (hx : x ∈ riemannRochSpace (D + WeilDivisor.ofPoint P)) :
+    x ∈ riemannRochSpace D ↔ x ∈ P.filtration (-D.coeff P) := by
+  refine ⟨fun h ↦ riemannRochSpace_le_filtration D P h, fun h ↦ ?_⟩
+  rw [Place.mem_filtration_iff, neg_neg] at h
+  rw [mem_riemannRochSpace_iff]
+  intro Q
+  rcases eq_or_ne Q P with rfl | hQ
+  · exact h
+  · have hQ' := mem_riemannRochSpace_iff.mp hx Q
+    rwa [WeilDivisor.coeff_add, WeilDivisor.coeff_ofPoint_of_ne hQ, add_zero] at hQ'
 
 /-- The evaluation map of Stichtenoth's proof of Lemma 1.4.8: for `t` of order `D P + 1` at `P`,
-the map `x ↦ (t · x)(P)` sends `L(D + P)` to the residue field of `P`, and its kernel is
-`L(D)`. -/
+the map `x ↦ (t · x)(P)` sends `L(D + P)` to the residue field of `P`, and its kernel is `L(D)`.
+It is the local map `TauCeti.Place.filtrationResidue` restricted along
+`L(D + P) ≤ 𝔪_P^(-(D P + 1))`. -/
 private noncomputable def residueEval (D : Divisor k F) (P : Place k F) {t : F}
     (ht : P.ord t = D.coeff P + 1) (ht0 : t ≠ 0) :
-    riemannRochSpace (D + WeilDivisor.ofPoint P) →ₗ[k] P.ResidueField where
-  toFun x := IsScalarTower.toAlgHom k P.integers P.ResidueField
-    ⟨t * (x : F), mul_mem_integers ht ht0 x.2⟩
-  map_add' x y := by
-    rw [← map_add]
-    exact congrArg _ (Subtype.ext (by push_cast; ring))
-  map_smul' c x := by
-    rw [RingHom.id_apply, ← map_smul]
-    exact congrArg _
-      (Subtype.ext (by push_cast [Algebra.smul_def, Place.coe_algebraMap_constants]; ring))
-
-private lemma residueEval_apply (ht : P.ord t = D.coeff P + 1) (ht0 : t ≠ 0)
-    (x : riemannRochSpace (D + WeilDivisor.ofPoint P)) :
-    residueEval D P ht ht0 x =
-      IsLocalRing.residue P.integers ⟨t * (x : F), mul_mem_integers ht ht0 x.2⟩ := (rfl)
-
-private lemma mem_riemannRochSpace_iff_residueEval_eq_zero (ht : P.ord t = D.coeff P + 1)
-    (ht0 : t ≠ 0) (x : riemannRochSpace (D + WeilDivisor.ofPoint P)) :
-    (x : F) ∈ riemannRochSpace D ↔ residueEval D P ht ht0 x = 0 := by
-  rcases eq_or_ne (x : F) 0 with hx0 | hx0
-  · have hx : x = 0 := Subtype.ext hx0
-    simp [hx]
-  · have hres : residueEval D P ht ht0 x = 0 ↔ 0 < P.ord (t * (x : F)) := by
-      rw [residueEval_apply]
-      exact P.residue_eq_zero_iff_ord_pos (f := ⟨t * (x : F), mul_mem_integers ht ht0 x.2⟩)
-        (mul_ne_zero ht0 hx0)
-    rw [hres, P.ord_mul ht0 hx0, ht, mem_riemannRochSpace_iff_neg_le_ord hx0]
-    constructor
-    · intro h
-      have := h P
-      omega
-    · intro h Q
-      rcases eq_or_ne Q P with rfl | hQ
-      · omega
-      · have hQ' := (mem_riemannRochSpace_iff_neg_le_ord hx0).mp x.2 Q
-        rwa [WeilDivisor.coeff_add, WeilDivisor.coeff_ofPoint_of_ne hQ, add_zero] at hQ'
+    riemannRochSpace (D + WeilDivisor.ofPoint P) →ₗ[k] P.ResidueField :=
+  (Place.filtrationResidue (a := -(D.coeff P + 1)) (by rw [neg_neg]; exact ht) ht0).comp
+    (Submodule.inclusion (riemannRochSpace_add_ofPoint_le_filtration D P))
 
 /-- The kernel of `TauCeti.residueEval` is `L(D)`, sitting inside `L(D + P)` as the comap of the
 inclusion `TauCeti.riemannRochSpace_mono`.  This is the structural heart of Stichtenoth's proof of
-Lemma 1.4.8. -/
+Lemma 1.4.8, and here it is `TauCeti.Place.ker_filtrationResidue` read inside `L(D + P)`. -/
 private lemma ker_residueEval (ht : P.ord t = D.coeff P + 1) (ht0 : t ≠ 0) :
     LinearMap.ker (residueEval D P ht ht0) =
       Submodule.comap (riemannRochSpace (D + WeilDivisor.ofPoint P)).subtype
         (riemannRochSpace D) := by
+  have hidx : -(D.coeff P + 1) + 1 = -D.coeff P := by ring
   ext x
-  exact (mem_riemannRochSpace_iff_residueEval_eq_zero ht ht0 x).symm
+  rw [LinearMap.mem_ker, residueEval, LinearMap.comp_apply,
+    Place.filtrationResidue_eq_zero_iff, Submodule.coe_inclusion, hidx, Submodule.mem_comap,
+    Submodule.subtype_apply, mem_riemannRochSpace_iff_mem_filtration x.2]
 
 /-- Stichtenoth's proof of Lemma 1.4.8 in its one-place form, carrying both conclusions the two
 public statements below project out of: `L(D + P)` stays finite-dimensional, and its dimension

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/Basic.lean
@@ -177,10 +177,6 @@ private lemma le_add_ofPoint (D : Divisor k F) (P : Place k F) :
   le_add_of_nonneg_right
     (WeilDivisor.isEffective_iff_zero_le.mp (WeilDivisor.isEffective_ofPoint P))
 
-private lemma coe_algebraMap_integers (P : Place k F) (c : k) :
-    ((algebraMap k P.integers c : P.integers) : F) = algebraMap k F c := by
-  rw [IsScalarTower.algebraMap_apply k P.integers F, ValuationSubring.algebraMap_apply]
-
 private lemma mul_mem_integers (ht : P.ord t = D.coeff P + 1) (ht0 : t ≠ 0) {x : F}
     (hx : x ∈ riemannRochSpace (D + WeilDivisor.ofPoint P)) : t * x ∈ P.integers := by
   rcases eq_or_ne x 0 with rfl | hx0
@@ -204,7 +200,7 @@ private noncomputable def residueEval (D : Divisor k F) (P : Place k F) {t : F}
   map_smul' c x := by
     rw [RingHom.id_apply, ← map_smul]
     exact congrArg _
-      (Subtype.ext (by push_cast [Algebra.smul_def, coe_algebraMap_integers]; ring))
+      (Subtype.ext (by push_cast [Algebra.smul_def, Place.coe_algebraMap_constants]; ring))
 
 private lemma residueEval_apply (ht : P.ord t = D.coeff P + 1) (ht0 : t ≠ 0)
     (x : riemannRochSpace (D + WeilDivisor.ofPoint P)) :
@@ -252,11 +248,7 @@ private lemma finiteDimensional_and_finrank_add_ofPoint_le (hF : IsFunctionField
       Module.finrank k (riemannRochSpace (D + WeilDivisor.ofPoint P)) ≤
         Module.finrank k (riemannRochSpace D) + P.degree := by
   have : FiniteDimensional k P.ResidueField := Place.finiteDimensional_residueField P hF
-  obtain ⟨t, ht0, ht⟩ : ∃ t : F, t ≠ 0 ∧ P.ord t = D.coeff P + 1 := by
-    obtain ⟨t, ht⟩ := P.ord_surjective (D.coeff P + 1)
-    rcases eq_or_ne t 0 with rfl | ht0
-    · exact ⟨1, one_ne_zero, by rw [P.ord_one, ← ht, P.ord_zero]⟩
-    · exact ⟨t, ht0, ht⟩
+  obtain ⟨t, ht0, ht⟩ := P.exists_ne_zero_ord_eq (D.coeff P + 1)
   have hle : riemannRochSpace D ≤ riemannRochSpace (D + WeilDivisor.ofPoint P) :=
     riemannRochSpace_mono (le_add_ofPoint D P)
   have hkerfin : FiniteDimensional k (LinearMap.ker (residueEval D P ht ht0)) := by

--- a/TauCeti/FieldTheory/FunctionField/RiemannRoch/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/RiemannRoch/Basic.lean
@@ -211,23 +211,23 @@ the map `x ↦ (t · x)(P)` sends `L(D + P)` to the residue field of `P`, and it
 It is the local map `TauCeti.Place.filtrationResidue` restricted along
 `L(D + P) ≤ 𝔪_P^(-(D P + 1))`. -/
 private noncomputable def residueEval (D : Divisor k F) (P : Place k F) {t : F}
-    (ht : P.ord t = D.coeff P + 1) (ht0 : t ≠ 0) :
+    (ht : P.ord t = D.coeff P + 1) :
     riemannRochSpace (D + WeilDivisor.ofPoint P) →ₗ[k] P.ResidueField :=
-  (Place.filtrationResidue (a := -(D.coeff P + 1)) (by rw [neg_neg]; exact ht) ht0).comp
+  (Place.filtrationResidue (a := -(D.coeff P + 1)) (by rw [neg_neg]; exact ht)).comp
     (Submodule.inclusion (riemannRochSpace_add_ofPoint_le_filtration D P))
 
 /-- The kernel of `TauCeti.residueEval` is `L(D)`, sitting inside `L(D + P)` as the comap of the
 inclusion `TauCeti.riemannRochSpace_mono`.  This is the structural heart of Stichtenoth's proof of
 Lemma 1.4.8, and here it is `TauCeti.Place.ker_filtrationResidue` read inside `L(D + P)`. -/
 private lemma ker_residueEval (ht : P.ord t = D.coeff P + 1) (ht0 : t ≠ 0) :
-    LinearMap.ker (residueEval D P ht ht0) =
+    LinearMap.ker (residueEval D P ht) =
       Submodule.comap (riemannRochSpace (D + WeilDivisor.ofPoint P)).subtype
         (riemannRochSpace D) := by
   have hidx : -(D.coeff P + 1) + 1 = -D.coeff P := by ring
   ext x
   rw [LinearMap.mem_ker, residueEval, LinearMap.comp_apply,
-    Place.filtrationResidue_eq_zero_iff, Submodule.coe_inclusion, hidx, Submodule.mem_comap,
-    Submodule.subtype_apply, mem_riemannRochSpace_iff_mem_filtration x.2]
+    Place.filtrationResidue_eq_zero_iff _ ht0, Submodule.coe_inclusion, hidx,
+    Submodule.mem_comap, Submodule.subtype_apply, mem_riemannRochSpace_iff_mem_filtration x.2]
 
 /-- Stichtenoth's proof of Lemma 1.4.8 in its one-place form, carrying both conclusions the two
 public statements below project out of: `L(D + P)` stays finite-dimensional, and its dimension
@@ -242,24 +242,24 @@ private lemma finiteDimensional_and_finrank_add_ofPoint_le (hF : IsFunctionField
   obtain ⟨t, ht0, ht⟩ := P.exists_ne_zero_ord_eq (D.coeff P + 1)
   have hle : riemannRochSpace D ≤ riemannRochSpace (D + WeilDivisor.ofPoint P) :=
     riemannRochSpace_mono (le_add_ofPoint D P)
-  have hkerfin : FiniteDimensional k (LinearMap.ker (residueEval D P ht ht0)) := by
-    rw [ker_residueEval]
+  have hkerfin : FiniteDimensional k (LinearMap.ker (residueEval D P ht)) := by
+    rw [ker_residueEval ht ht0]
     exact Module.Finite.equiv (Submodule.comapSubtypeEquivOfLe hle).symm
-  have hkerrank : Module.finrank k (LinearMap.ker (residueEval D P ht ht0)) =
+  have hkerrank : Module.finrank k (LinearMap.ker (residueEval D P ht)) =
       Module.finrank k (riemannRochSpace D) := by
-    rw [ker_residueEval]
+    rw [ker_residueEval ht ht0]
     exact (Submodule.comapSubtypeEquivOfLe hle).finrank_eq
   have hquotfin : FiniteDimensional k
-      (riemannRochSpace (D + WeilDivisor.ofPoint P) ⧸ LinearMap.ker (residueEval D P ht ht0)) :=
-    Module.Finite.equiv (LinearMap.quotKerEquivRange (residueEval D P ht ht0)).symm
+      (riemannRochSpace (D + WeilDivisor.ofPoint P) ⧸ LinearMap.ker (residueEval D P ht)) :=
+    Module.Finite.equiv (LinearMap.quotKerEquivRange (residueEval D P ht)).symm
   have hfin : FiniteDimensional k (riemannRochSpace (D + WeilDivisor.ofPoint P)) :=
-    Module.Finite.of_submodule_quotient (LinearMap.ker (residueEval D P ht ht0))
+    Module.Finite.of_submodule_quotient (LinearMap.ker (residueEval D P ht))
   refine ⟨hfin, ?_⟩
-  have hquot := Submodule.finrank_quotient_add_finrank (LinearMap.ker (residueEval D P ht ht0))
+  have hquot := Submodule.finrank_quotient_add_finrank (LinearMap.ker (residueEval D P ht))
   have hrange : Module.finrank k
-      (riemannRochSpace (D + WeilDivisor.ofPoint P) ⧸ LinearMap.ker (residueEval D P ht ht0)) ≤
+      (riemannRochSpace (D + WeilDivisor.ofPoint P) ⧸ LinearMap.ker (residueEval D P ht)) ≤
         P.degree := by
-    rw [(LinearMap.quotKerEquivRange (residueEval D P ht ht0)).finrank_eq, Place.degree_eq_finrank]
+    rw [(LinearMap.quotKerEquivRange (residueEval D P ht)).finrank_eq, Place.degree_eq_finrank]
     exact Submodule.finrank_le _
   omega
 

--- a/TauCeti/LinearAlgebra/Dimension/Tower.lean
+++ b/TauCeti/LinearAlgebra/Dimension/Tower.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Dimension.RankNullity
+public import Mathlib.LinearAlgebra.Isomorphisms
+
+/-!
+# Rank is additive along a tower of submodules
+
+For submodules `p ≤ q ≤ r` of a module `M`, the relative quotient `r / p` is filtered by `q / p`,
+and `TauCeti.rank_quotient_submoduleOf_tower` records that its rank is the sum of the ranks of the
+two steps.  Relative quotients are spelled with `Submodule.submoduleOf`, so that `q / p` means
+`↥q ⧸ p.submoduleOf q`.
+
+The proof is Noether's third isomorphism theorem (`Submodule.quotientQuotientEquivQuotient`)
+together with rank–nullity, which is why the base ring is asked only for `HasRankNullity`.
+-/
+
+public section
+
+universe u v
+
+namespace TauCeti
+
+/-- Rank is additive along a tower `p ≤ q ≤ r` of submodules: the relative quotients of the two
+steps add up to the relative quotient of the composite.  This is Noether's third isomorphism
+theorem together with rank–nullity. -/
+theorem rank_quotient_submoduleOf_tower {R : Type v} {M : Type u} [Ring R] [AddCommGroup M]
+    [Module R M] [HasRankNullity.{u} R] {p q r : Submodule R M} (hpq : p ≤ q) (hqr : q ≤ r) :
+    Module.rank R (↥r ⧸ p.submoduleOf r) =
+      Module.rank R (↥q ⧸ p.submoduleOf q) + Module.rank R (↥r ⧸ q.submoduleOf r) := by
+  have hAB : p.submoduleOf r ≤ q.submoduleOf r := Submodule.comap_mono hpq
+  set A := p.submoduleOf r with hA
+  set f : ↥q →ₗ[R] (↥r ⧸ A) := A.mkQ ∘ₗ Submodule.inclusion hqr with hf
+  have hker : LinearMap.ker f = p.submoduleOf q := by
+    ext z
+    simp [hf, hA, Submodule.submoduleOf, Submodule.inclusion]
+  have hrange : LinearMap.range f = (q.submoduleOf r).map A.mkQ := by
+    rw [hf, LinearMap.range_comp, Submodule.range_inclusion]
+    rfl
+  have e₁ : (↥q ⧸ p.submoduleOf q) ≃ₗ[R] ↥((q.submoduleOf r).map A.mkQ) :=
+    (Submodule.quotEquivOfEq _ _ hker.symm).trans
+      ((f.quotKerEquivRange).trans (LinearEquiv.ofEq _ _ hrange))
+  have e₂ : ((↥r ⧸ A) ⧸ (q.submoduleOf r).map A.mkQ) ≃ₗ[R] (↥r ⧸ q.submoduleOf r) :=
+    Submodule.quotientQuotientEquivQuotient A (q.submoduleOf r) hAB
+  have key := Submodule.rank_quotient_add_rank ((q.submoduleOf r).map A.mkQ)
+  rw [e₂.rank_eq, ← e₁.rank_eq] at key
+  rw [← key, add_comm]
+
+end TauCeti


### PR DESCRIPTION
This PR constructs the filtration of an algebraic function field `F / k` by order of vanishing at a place `P` and computes its successive quotients, closing the first item of the **local-to-global quotient engine** of the AlgebraicCurves roadmap's Layer 4 (Stichtenoth I.5), which asks in so many words: "for each place `P` and integers `a ≤ b`, use a uniformizer filtration of the DVR to prove `dim_k (𝔪_P^a / 𝔪_P^b) = (b-a) * deg P` (with fractional powers interpreted inside `F`)". `TauCeti.Place.filtration P a` is the `k`-subspace of `F` whose nonzero elements satisfy `ord_P z ≥ a` (with zero adjoined) — a fractional ideal for `a < 0`, so nothing is completed and the whole filtration lives inside `F`; `TauCeti.Place.filtrationQuotientEquivResidueField` identifies `𝔪_P^a / 𝔪_P^(a+1)` with the residue field `F_P` by multiplying by a function of order `-a` and evaluating at `P`; and rank additivity along the tower turns that into `TauCeti.Place.finrank_quotient_filtration`, `dim_k (𝔪_P^a / 𝔪_P^b) = (b - a) · deg P` for `a ≤ b`, together with the finite-dimensionality of those quotients.

The dimension formula is proved first for `Module.rank`, where it needs no finiteness hypothesis at all, and only then transported to `Module.finrank` through `Cardinal.toNat_mul`, so the `finrank` statement is unconditional: both sides are zero when the residue field is infinite-dimensional over `k`. Membership is stated multiplicatively, `v_P z ≤ exp (-a)`, matching `riemannRochSpace` and `adeleFiltration`, because the unguarded additive form `ord_P z ≥ a` is not a subspace at `a > 0` thanks to the junk value `ord_P 0 = 0`; `mem_filtration_iff_le_ord` is the guarded additive form. The subspace is built on Mathlib's `Valuation.leSubmodule`, the relative quotients on `Submodule.submoduleOf`, and the tower additivity on `Submodule.quotientQuotientEquivQuotient` plus `Submodule.rank_quotient_add_rank`; no Mathlib code is vendored.

Two small cleanups ride along, both consumed here: `Place.exists_ne_zero_ord_eq` (every integer is the order of a *nonzero* function — the junk-value-aware sharpening of `ord_surjective`) and `Place.coe_algebraMap_constants` replace the ad-hoc copies that were inlined and `private` in `RiemannRoch/Basic.lean`, which now uses the shared lemmas. The name is `coe_algebraMap_constants` rather than `coe_algebraMap_integers` because the latter is already taken, in the same namespace, by the statement about the algebra map between the valuation rings of two places.

What remains of this milestone after this PR: the global half — identify `A_F(E) / A_F(D)` for `D ≤ E` with the finite direct sum over `supp (E - D)` of these local quotients, giving `dim_k (A_F(E) / A_F(D)) = deg E - deg D` — and then the exact sequence relating `L(E)/L(D)` to it, the index of specialty `i(D) = dim_k (A_F ⧸ (A_F(D) + F))` (Thm. 1.5.4), and Weil differentials.

CFSGStatement, this round's preferred roadmap, has no milestone I can advance: `ClassificationStatement`, `simpleRootSubgroup` and `SplitReductive` still grep to 0 in `TauCeti/`, `AmbientGroup` appears only in two docstrings, and L0–L4 plus A0 all wait on ReductiveGroups Layer 9, which had 14 open pull requests covering every one of its bullets. AlgebraicCurves had none open.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"place-finrank-quotient-filtration"}-->

🤖 Prepared with Claude Code



