### PR TITLE
feat: prove weight-unipotent groups smooth and connected

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Unipotent/Basic.lean
@@ -6,7 +6,7 @@ Authors: Codex
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Basic
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Unipotent
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Unipotent.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Dynamic.Functor
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Naturality
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Basic.lean
@@ -81,7 +81,7 @@ theorem sub_one_apply_mem_weightUnipotentRelationSet (w : Fin N → ℤ) {i j : 
 
 /-- A matrix coordinate on or above the weight-block diagonal is fixed in the quotient by the
 explicit weight-unipotent relation ideal. -/
-theorem quotient_genericMatrix_apply (w : Fin N → ℤ) {i j : Fin N}
+theorem quotient_genericMatrix_apply_of_le (w : Fin N → ℤ) {i j : Fin N}
     (hij : w i ≤ w j) :
     Ideal.Quotient.mkₐ R (Ideal.span (weightUnipotentRelationSet R w))
         ((genericMatrix R N) i j) =
@@ -110,31 +110,31 @@ private theorem sum_quotient_genericMatrix_tmul (w : Fin N → ℤ) {i j : Fin N
   · subst j
     simp only [↓reduceIte]
     rw [Finset.sum_eq_single i]
-    · rw [quotient_genericMatrix_apply R w le_rfl]
+    · rw [quotient_genericMatrix_apply_of_le R w le_rfl]
       simpa only [Matrix.one_apply, ↓reduceIte] using
         (Algebra.TensorProduct.one_def (R := R)
           (A := coordinateHopfAlgebra R N ⧸ Ideal.span (weightUnipotentRelationSet R w))
           (B := coordinateHopfAlgebra R N ⧸ Ideal.span (weightUnipotentRelationSet R w))).symm
     · intro k _ hki
       by_cases hweight : w i ≤ w k
-      · rw [quotient_genericMatrix_apply R w hweight]
+      · rw [quotient_genericMatrix_apply_of_le R w hweight]
         simp [hki.symm]
       · have hkiw : w k ≤ w i := (lt_of_not_ge hweight).le
-        rw [quotient_genericMatrix_apply R w hkiw]
+        rw [quotient_genericMatrix_apply_of_le R w hkiw]
         simp [hki]
     · simp
   · simp only [hij', ↓reduceIte]
     apply Finset.sum_eq_zero
     intro k _
     by_cases hik : w i ≤ w k
-    · rw [quotient_genericMatrix_apply R w hik]
+    · rw [quotient_genericMatrix_apply_of_le R w hik]
       by_cases hEq : i = k
       · subst k
-        rw [quotient_genericMatrix_apply R w hij]
+        rw [quotient_genericMatrix_apply_of_le R w hij]
         simp [hij']
       · simp [hEq]
     · have hkj : w k ≤ w j := (lt_of_not_ge hik).le.trans hij
-      rw [quotient_genericMatrix_apply R w hkj]
+      rw [quotient_genericMatrix_apply_of_le R w hkj]
       have hne : k ≠ j := fun hEq ↦ hik (hEq ▸ hij)
       simp [hne]
 
@@ -237,7 +237,7 @@ private theorem antipode_sub_one_apply_mem (w : Fin N → ℤ) {i j : Fin N}
       Xq a b = (1 : Matrix (Fin N) (Fin N)
         (coordinateHopfAlgebra R N ⧸ J)) a b := by
     intro a b hab
-    exact quotient_genericMatrix_apply R w hab
+    exact quotient_genericMatrix_apply_of_le R w hab
   have hdetXq : IsUnit Xq.det := by
     simp only [Xq, ← AlgHom.mapMatrix_apply, ← AlgHom.map_det]
     exact (isUnit_det_genericMatrix R N).map q

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Basic.lean
@@ -79,7 +79,9 @@ theorem sub_one_apply_mem_weightUnipotentRelationSet (w : Fin N → ℤ) {i j : 
       weightUnipotentRelationSet R w :=
   ⟨i, j, hij, rfl⟩
 
-private theorem quotient_genericMatrix_apply (w : Fin N → ℤ) {i j : Fin N}
+/-- A matrix coordinate on or above the weight-block diagonal is fixed in the quotient by the
+explicit weight-unipotent relation ideal. -/
+theorem quotient_genericMatrix_apply (w : Fin N → ℤ) {i j : Fin N}
     (hij : w i ≤ w j) :
     Ideal.Quotient.mkₐ R (Ideal.span (weightUnipotentRelationSet R w))
         ((genericMatrix R N) i j) =
@@ -279,24 +281,6 @@ theorem weightUnipotentDefiningHopfIdeal_toIdeal (w : Fin N → ℤ) :
     (weightUnipotentDefiningHopfIdeal R w).toIdeal =
       Ideal.span (weightUnipotentRelationSet R w) := by
   rw [weightUnipotentDefiningHopfIdeal, HopfIdeal.ofSpan_toIdeal]
-
-/-- In the weight-unipotent quotient, a matrix coordinate on or above the weight-block
-diagonal is the corresponding entry of the identity matrix. -/
-@[simp]
-theorem weightUnipotentQuotient_mk_genericMatrix_apply (w : Fin N → ℤ) {i j : Fin N}
-    (hij : w i ≤ w j) :
-    Ideal.Quotient.mk (weightUnipotentDefiningHopfIdeal R w).toIdeal
-        ((coordinateHopfAlgebraAlgEquiv R N)
-          ((coordinateRingMap R N) (MvPolynomial.X (i, j)))) =
-      (1 : Matrix (Fin N) (Fin N)
-        (coordinateHopfAlgebra R N ⧸ (weightUnipotentDefiningHopfIdeal R w).toIdeal)) i j := by
-  rw [← genericMatrix_apply (R := R) (n := N) i j,
-    ← Ideal.Quotient.mkₐ_eq_mk (R₁ := R)]
-  apply (Ideal.quotientEquivAlgOfEq R
-    (weightUnipotentDefiningHopfIdeal_toIdeal R w)).injective
-  simpa only [Ideal.Quotient.mkₐ_eq_mk, Ideal.quotientEquivAlgOfEq_mk,
-    Matrix.one_apply, apply_ite, map_one, map_zero] using
-    quotient_genericMatrix_apply R w hij
 
 /-- The coordinate Hopf algebra of the weight-unipotent subgroup attached to `w`. -/
 noncomputable abbrev weightUnipotentCoordinateHopfAlgebra (w : Fin N → ℤ) :

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Basic.lean
@@ -280,6 +280,32 @@ theorem weightUnipotentDefiningHopfIdeal_toIdeal (w : Fin N → ℤ) :
       Ideal.span (weightUnipotentRelationSet R w) := by
   rw [weightUnipotentDefiningHopfIdeal, HopfIdeal.ofSpan_toIdeal]
 
+/-- In the weight-unipotent quotient, a matrix coordinate on or above the weight-block
+diagonal is the corresponding entry of the identity matrix. -/
+@[simp]
+theorem weightUnipotentQuotient_mk_genericMatrix_apply (w : Fin N → ℤ) {i j : Fin N}
+    (hij : w i ≤ w j) :
+    Ideal.Quotient.mk (weightUnipotentDefiningHopfIdeal R w).toIdeal
+        ((coordinateHopfAlgebraAlgEquiv R N)
+          ((coordinateRingMap R N) (MvPolynomial.X (i, j)))) =
+      (1 : Matrix (Fin N) (Fin N)
+        (coordinateHopfAlgebra R N ⧸ (weightUnipotentDefiningHopfIdeal R w).toIdeal)) i j := by
+  rw [← genericMatrix_apply (R := R) (n := N) i j,
+    ← Ideal.Quotient.mkₐ_eq_mk (R₁ := R)]
+  have hrel : (genericMatrix R N) i j -
+      (1 : Matrix (Fin N) (Fin N) (coordinateHopfAlgebra R N)) i j ∈
+        (weightUnipotentDefiningHopfIdeal R w).toIdeal := by
+    rw [weightUnipotentDefiningHopfIdeal_toIdeal]
+    exact Ideal.subset_span (sub_one_apply_mem_weightUnipotentRelationSet R w hij)
+  by_cases hEq : i = j
+  · subst j
+    simp only [Matrix.one_apply, ↓reduceIte]
+    rw [Ideal.Quotient.mkₐ_eq_mk, Ideal.Quotient.mk_eq_one_iff_sub_mem]
+    simpa [Matrix.one_apply] using hrel
+  · simp only [Matrix.one_apply, hEq, ↓reduceIte]
+    rw [Ideal.Quotient.mkₐ_eq_mk, Ideal.Quotient.eq_zero_iff_mem]
+    simpa [Matrix.one_apply, hEq] using hrel
+
 /-- The coordinate Hopf algebra of the weight-unipotent subgroup attached to `w`. -/
 noncomputable abbrev weightUnipotentCoordinateHopfAlgebra (w : Fin N → ℤ) :
     _root_.CommHopfAlgCat.{u} R :=

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Basic.lean
@@ -292,19 +292,11 @@ theorem weightUnipotentQuotient_mk_genericMatrix_apply (w : Fin N → ℤ) {i j 
         (coordinateHopfAlgebra R N ⧸ (weightUnipotentDefiningHopfIdeal R w).toIdeal)) i j := by
   rw [← genericMatrix_apply (R := R) (n := N) i j,
     ← Ideal.Quotient.mkₐ_eq_mk (R₁ := R)]
-  have hrel : (genericMatrix R N) i j -
-      (1 : Matrix (Fin N) (Fin N) (coordinateHopfAlgebra R N)) i j ∈
-        (weightUnipotentDefiningHopfIdeal R w).toIdeal := by
-    rw [weightUnipotentDefiningHopfIdeal_toIdeal]
-    exact Ideal.subset_span (sub_one_apply_mem_weightUnipotentRelationSet R w hij)
-  by_cases hEq : i = j
-  · subst j
-    simp only [Matrix.one_apply, ↓reduceIte]
-    rw [Ideal.Quotient.mkₐ_eq_mk, Ideal.Quotient.mk_eq_one_iff_sub_mem]
-    simpa [Matrix.one_apply] using hrel
-  · simp only [Matrix.one_apply, hEq, ↓reduceIte]
-    rw [Ideal.Quotient.mkₐ_eq_mk, Ideal.Quotient.eq_zero_iff_mem]
-    simpa [Matrix.one_apply, hEq] using hrel
+  apply (Ideal.quotientEquivAlgOfEq R
+    (weightUnipotentDefiningHopfIdeal_toIdeal R w)).injective
+  simpa only [Ideal.Quotient.mkₐ_eq_mk, Ideal.quotientEquivAlgOfEq_mk,
+    Matrix.one_apply, apply_ite, map_one, map_zero] using
+    quotient_genericMatrix_apply R w hij
 
 /-- The coordinate Hopf algebra of the weight-unipotent subgroup attached to `w`. -/
 noncomputable abbrev weightUnipotentCoordinateHopfAlgebra (w : Fin N → ℤ) :

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Geometry.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Geometry.lean
@@ -1,0 +1,337 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.RingTheory.Smooth.Basic
+public import Mathlib.RingTheory.TensorProduct.MvPolynomial
+public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Unipotent.Basic
+
+/-!
+# Geometry of weight-unipotent subgroup schemes
+
+For an integer weight `w i` on each coordinate of `GL_N`, the weight-unipotent subgroup has
+matrix entries fixed to the identity whenever `w i ≤ w j`. The remaining entries, indexed by
+pairs with `w j < w i`, are free polynomial coordinates. This file identifies its coordinate
+algebra with the polynomial algebra on those pairs.
+
+The presentation is obtained directly from the determinant localization defining `GL_N`. The
+generic weight-unipotent matrix is block triangular with identity diagonal blocks, so its
+determinant is one and polynomial evaluation extends across the localization. The defining
+quotient relations then give mutually inverse maps.
+
+The polynomial presentation proves that the represented subgroup is smooth over every
+commutative base ring and geometrically connected over a field. Together with the pointwise
+unipotence theorem, these are the scheme-theoretic properties required of the unipotent factor
+in the dynamic Levi decomposition.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.WeightUnipotentIndex`: the free matrix coordinates `w j < w i`.
+* `TauCeti.GeneralLinear.weightUnipotentCoordinateAlgEquiv`: the polynomial presentation of the
+  weight-unipotent coordinate algebra.
+* `TauCeti.GeneralLinear.instSmoothWeightUnipotentCoordinateHopfAlgebra`: smoothness over the
+  base ring.
+* `geometricallyConnectedCommHopfAlgProperty_weightUnipotentCoordinateHopfAlgebra`: geometric
+  connectedness over a field.
+
+## References
+
+* G. R. Kempf, *Instability in invariant theory*, Annals of Mathematics 108 (1978), §2.
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 13.
+
+This advances the dynamic approach to parabolics and Levi decomposition in Layer 7 of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+noncomputable section
+
+variable (R : Type u) [CommRing R] {N : ℕ}
+
+/-- Pairs indexing the matrix entries not fixed by the weight-unipotent relations. -/
+abbrev WeightUnipotentIndex (w : Fin N → ℤ) :=
+  {ij : Fin N × Fin N // w ij.2 < w ij.1}
+
+/-- The polynomial matrix whose free entries are precisely those strictly below the weight-block
+diagonal, with identity matrices on the diagonal blocks. -/
+def weightUnipotentPolynomialGenericMatrix (w : Fin N → ℤ) :
+    Matrix (Fin N) (Fin N) (MvPolynomial (WeightUnipotentIndex w) R) :=
+  fun i j ↦ if h : w j < w i then MvPolynomial.X ⟨(i, j), h⟩
+    else if i = j then 1 else 0
+
+/-- A free entry of the polynomial weight-unipotent matrix is its corresponding variable. -/
+@[simp]
+theorem weightUnipotentPolynomialGenericMatrix_apply_of_lt (w : Fin N → ℤ)
+    {i j : Fin N} (hij : w j < w i) :
+    weightUnipotentPolynomialGenericMatrix R w i j =
+      MvPolynomial.X (show WeightUnipotentIndex w from ⟨(i, j), hij⟩) := by
+  simp [weightUnipotentPolynomialGenericMatrix, hij]
+
+/-- An entry on or above the weight-block diagonal is the corresponding identity entry. -/
+@[simp]
+theorem weightUnipotentPolynomialGenericMatrix_apply_of_le (w : Fin N → ℤ)
+    {i j : Fin N} (hij : w i ≤ w j) :
+    weightUnipotentPolynomialGenericMatrix R w i j =
+      (1 : Matrix (Fin N) (Fin N) (MvPolynomial (WeightUnipotentIndex w) R)) i j := by
+  simp [weightUnipotentPolynomialGenericMatrix, not_lt.mpr hij, Matrix.one_apply]
+
+/-- The polynomial weight-unipotent matrix is block triangular for the decreasing weight
+filtration. -/
+theorem weightUnipotentPolynomialGenericMatrix_blockTriangular (w : Fin N → ℤ) :
+    (weightUnipotentPolynomialGenericMatrix R w).BlockTriangular
+      (OrderDual.toDual ∘ w) := by
+  intro i j hij
+  have hwiwj : w i < w j := OrderDual.toDual_lt_toDual.mp hij
+  have hne : i ≠ j := fun h ↦ hwiwj.ne (congrArg w h)
+  simpa [Matrix.one_apply, hne] using
+    weightUnipotentPolynomialGenericMatrix_apply_of_le R w hwiwj.le
+
+/-- Every diagonal weight block of the polynomial weight-unipotent matrix is the identity. -/
+private theorem weightUnipotentPolynomialGenericMatrix_toSquareBlock
+    (w : Fin N → ℤ) (a : ℤᵒᵈ) :
+    (weightUnipotentPolynomialGenericMatrix R w).toSquareBlock
+        (OrderDual.toDual ∘ w) a = 1 := by
+  classical
+  apply Matrix.ext
+  intro i j
+  have hweight : w i.1 = w j.1 := by
+    exact congrArg OrderDual.ofDual (i.2.trans j.2.symm)
+  by_cases hij : i = j
+  · subst j
+    simp [Matrix.toSquareBlock_def]
+  · have hij' : i.1 ≠ j.1 := fun h ↦ hij (Subtype.ext h)
+    simp [Matrix.toSquareBlock_def,
+      weightUnipotentPolynomialGenericMatrix_apply_of_le R w hweight.le, hij, hij']
+
+/-- The determinant of the polynomial weight-unipotent matrix is one. -/
+@[simp]
+theorem weightUnipotentPolynomialGenericMatrix_det (w : Fin N → ℤ) :
+    (weightUnipotentPolynomialGenericMatrix R w).det = 1 := by
+  classical
+  rw [(weightUnipotentPolynomialGenericMatrix_blockTriangular R w).det]
+  apply Finset.prod_eq_one
+  intro a _
+  rw [weightUnipotentPolynomialGenericMatrix_toSquareBlock R w a, Matrix.det_one]
+
+/-- Evaluate the matrix-monoid polynomial coordinates at the generic weight-unipotent matrix. -/
+private def weightUnipotentPolynomialEvaluation (w : Fin N → ℤ) :
+    MatrixMonoid.CoordinateRing R N →ₐ[R] MvPolynomial (WeightUnipotentIndex w) R :=
+  MvPolynomial.aeval fun ij ↦ weightUnipotentPolynomialGenericMatrix R w ij.1 ij.2
+
+private theorem weightUnipotentPolynomialEvaluation_determinant (w : Fin N → ℤ) :
+    weightUnipotentPolynomialEvaluation R w
+        (Matrix.det (Matrix.mvPolynomialX (Fin N) (Fin N) R)) = 1 := by
+  rw [weightUnipotentPolynomialEvaluation, AlgHom.map_det,
+    Matrix.mvPolynomialX_mapMatrix_aeval,
+    weightUnipotentPolynomialGenericMatrix_det]
+
+/-- Extend polynomial evaluation across the determinant localization defining `GL_N`. -/
+private def weightUnipotentLocalizedEvaluation (w : Fin N → ℤ) :
+    CoordinateRing R N →ₐ[R] MvPolynomial (WeightUnipotentIndex w) R :=
+  IsLocalization.Away.liftAlgHom
+    (Matrix.det (Matrix.mvPolynomialX (Fin N) (Fin N) R))
+    (by rw [weightUnipotentPolynomialEvaluation_determinant R w]; exact isUnit_one)
+
+private theorem weightUnipotentLocalizedEvaluation_coordinateRingMap
+    (w : Fin N → ℤ) (x : MatrixMonoid.CoordinateRing R N) :
+    weightUnipotentLocalizedEvaluation R w (coordinateRingMap R N x) =
+      weightUnipotentPolynomialEvaluation R w x := by
+  rw [coordinateRingMap_apply]
+  simp [-coordinateRingMap_apply, weightUnipotentLocalizedEvaluation]
+
+/-- Polynomial evaluation extended across the determinant localization and the bundled
+coordinate algebra of `GL_N`. -/
+private def weightUnipotentAmbientToPolynomial (w : Fin N → ℤ) :
+    coordinateHopfAlgebra R N →ₐ[R] MvPolynomial (WeightUnipotentIndex w) R :=
+  (weightUnipotentLocalizedEvaluation R w).comp
+    (coordinateHopfAlgebraAlgEquiv R N).symm.toAlgHom
+
+private theorem weightUnipotentAmbientToPolynomial_genericMatrix_apply
+    (w : Fin N → ℤ) (i j : Fin N) :
+    weightUnipotentAmbientToPolynomial R w ((genericMatrix R N) i j) =
+      weightUnipotentPolynomialGenericMatrix R w i j := by
+  calc
+    _ = weightUnipotentLocalizedEvaluation R w
+        ((coordinateHopfAlgebraAlgEquiv R N).symm
+          (coordinateHopfAlgebraAlgEquiv R N
+            (coordinateRingMap R N (MvPolynomial.X (i, j))))) := by
+      rw [genericMatrix_apply]
+      rfl
+    _ = weightUnipotentLocalizedEvaluation R w
+        (coordinateRingMap R N (MvPolynomial.X (i, j))) :=
+      congrArg (weightUnipotentLocalizedEvaluation R w)
+        ((coordinateHopfAlgebraAlgEquiv R N).symm_apply_apply _)
+    _ = weightUnipotentPolynomialEvaluation R w (MvPolynomial.X (i, j)) :=
+      weightUnipotentLocalizedEvaluation_coordinateRingMap R w _
+    _ = _ := by simp [weightUnipotentPolynomialEvaluation]
+
+private theorem weightUnipotentAmbientToPolynomial_eq_zero
+    (w : Fin N → ℤ) (x : coordinateHopfAlgebra R N)
+    (hx : x ∈ (weightUnipotentDefiningHopfIdeal R w).toIdeal) :
+    weightUnipotentAmbientToPolynomial R w x = 0 := by
+  apply RingHom.mem_ker.mp
+  have hx' : x ∈ Ideal.span (weightUnipotentRelationSet R w) := by
+    simpa only [weightUnipotentDefiningHopfIdeal_toIdeal] using hx
+  refine Ideal.span_le.2 ?_ hx'
+  intro y hy
+  rw [mem_weightUnipotentRelationSet_iff] at hy
+  obtain ⟨i, j, hij, rfl⟩ := hy
+  apply RingHom.mem_ker.mpr
+  rw [map_sub, weightUnipotentAmbientToPolynomial_genericMatrix_apply,
+    weightUnipotentPolynomialGenericMatrix_apply_of_le R w hij]
+  by_cases h : i = j <;> simp [Matrix.one_apply, h]
+
+/-- The quotient coordinate algebra maps to its free polynomial coordinates. -/
+private def weightUnipotentQuotientToPolynomial (w : Fin N → ℤ) :
+    weightUnipotentCoordinateHopfAlgebra R w →ₐ[R]
+      MvPolynomial (WeightUnipotentIndex w) R :=
+  Ideal.Quotient.liftₐ _ (weightUnipotentAmbientToPolynomial R w)
+    (weightUnipotentAmbientToPolynomial_eq_zero R w)
+
+/-- The free polynomial coordinates map back to the corresponding quotient matrix entries. -/
+private def weightUnipotentPolynomialToQuotient (w : Fin N → ℤ) :
+    MvPolynomial (WeightUnipotentIndex w) R →ₐ[R]
+      weightUnipotentCoordinateHopfAlgebra R w :=
+  MvPolynomial.aeval fun ij ↦
+    Ideal.Quotient.mkₐ R (weightUnipotentDefiningHopfIdeal R w).toIdeal
+      ((genericMatrix R N) ij.1.1 ij.1.2)
+
+private theorem weightUnipotentQuotientToPolynomial_mk_genericMatrix_apply
+    (w : Fin N → ℤ) (i j : Fin N) :
+    weightUnipotentQuotientToPolynomial R w
+        (Ideal.Quotient.mkₐ R (weightUnipotentDefiningHopfIdeal R w).toIdeal
+          ((genericMatrix R N) i j)) =
+      weightUnipotentPolynomialGenericMatrix R w i j := by
+  have hcomp := Ideal.Quotient.liftₐ_comp
+    (weightUnipotentDefiningHopfIdeal R w).toIdeal
+    (weightUnipotentAmbientToPolynomial R w)
+    (weightUnipotentAmbientToPolynomial_eq_zero R w)
+  exact (DFunLike.congr_fun hcomp ((genericMatrix R N) i j)).trans
+    (weightUnipotentAmbientToPolynomial_genericMatrix_apply R w i j)
+
+private theorem weightUnipotentQuotientToPolynomial_comp_polynomialToQuotient
+    (w : Fin N → ℤ) :
+    (weightUnipotentQuotientToPolynomial R w).comp
+        (weightUnipotentPolynomialToQuotient R w) = AlgHom.id R _ := by
+  apply MvPolynomial.algHom_ext
+  intro ij
+  rw [AlgHom.comp_apply, weightUnipotentPolynomialToQuotient,
+    MvPolynomial.aeval_X,
+    weightUnipotentQuotientToPolynomial_mk_genericMatrix_apply,
+    weightUnipotentPolynomialGenericMatrix_apply_of_lt R w ij.2,
+    AlgHom.id_apply]
+
+private theorem weightUnipotentPolynomialToQuotient_comp_quotientToPolynomial
+    (w : Fin N → ℤ) :
+    (weightUnipotentPolynomialToQuotient R w).comp
+        (weightUnipotentQuotientToPolynomial R w) = AlgHom.id R _ := by
+  apply AlgHom.ext
+  intro x
+  obtain ⟨y, rfl⟩ := Ideal.Quotient.mkₐ_surjective R
+    (weightUnipotentDefiningHopfIdeal R w).toIdeal x
+  have hcomp :
+      ((weightUnipotentPolynomialToQuotient R w).comp
+        (weightUnipotentQuotientToPolynomial R w)).comp
+          (Ideal.Quotient.mkₐ R (weightUnipotentDefiningHopfIdeal R w).toIdeal) =
+      (AlgHom.id R _).comp
+          (Ideal.Quotient.mkₐ R (weightUnipotentDefiningHopfIdeal R w).toIdeal) := by
+    apply coordinateHopfAlgebra_algHom_ext R N
+    intro i j
+    rw [← genericMatrix_apply]
+    simp only [AlgHom.comp_apply]
+    by_cases hij : w j < w i
+    · rw [
+        weightUnipotentQuotientToPolynomial_mk_genericMatrix_apply,
+        weightUnipotentPolynomialGenericMatrix_apply_of_lt R w hij,
+        weightUnipotentPolynomialToQuotient, MvPolynomial.aeval_X,
+        AlgHom.id_apply]
+    · have hle : w i ≤ w j := not_lt.mp hij
+      rw [weightUnipotentQuotientToPolynomial_mk_genericMatrix_apply,
+        weightUnipotentPolynomialGenericMatrix_apply_of_le R w hle,
+        AlgHom.id_apply, Ideal.Quotient.mkₐ_eq_mk, genericMatrix_apply,
+        weightUnipotentQuotient_mk_genericMatrix_apply R w hle]
+      by_cases h : i = j <;> simp [Matrix.one_apply, h]
+  exact DFunLike.congr_fun hcomp y
+
+/-- The weight-unipotent coordinate algebra is a polynomial algebra on the entries `X_ij` for
+which `w j < w i`. -/
+noncomputable def weightUnipotentCoordinateAlgEquiv (w : Fin N → ℤ) :
+    weightUnipotentCoordinateHopfAlgebra R w ≃ₐ[R]
+      MvPolynomial (WeightUnipotentIndex w) R :=
+  AlgEquiv.ofAlgHom
+    (weightUnipotentQuotientToPolynomial R w)
+    (weightUnipotentPolynomialToQuotient R w)
+    (weightUnipotentQuotientToPolynomial_comp_polynomialToQuotient R w)
+    (weightUnipotentPolynomialToQuotient_comp_quotientToPolynomial R w)
+
+/-- The polynomial presentation sends a quotient generic-matrix entry to the corresponding
+polynomial weight-unipotent matrix entry. -/
+@[simp]
+theorem weightUnipotentCoordinateAlgEquiv_mk_genericMatrix_apply
+    (w : Fin N → ℤ) (i j : Fin N) :
+    weightUnipotentCoordinateAlgEquiv R w
+        (Ideal.Quotient.mk (weightUnipotentDefiningHopfIdeal R w).toIdeal
+          ((coordinateHopfAlgebraAlgEquiv R N)
+            ((coordinateRingMap R N) (MvPolynomial.X (i, j))))) =
+      weightUnipotentPolynomialGenericMatrix R w i j := by
+  rw [← genericMatrix_apply (R := R) (n := N) i j,
+    ← Ideal.Quotient.mkₐ_eq_mk (R₁ := R)]
+  unfold weightUnipotentCoordinateAlgEquiv
+  exact weightUnipotentQuotientToPolynomial_mk_genericMatrix_apply R w i j
+
+/-- The inverse polynomial presentation sends a free variable to its quotient matrix entry. -/
+@[simp]
+theorem weightUnipotentCoordinateAlgEquiv_symm_X
+    (w : Fin N → ℤ) (ij : WeightUnipotentIndex w) :
+    (weightUnipotentCoordinateAlgEquiv R w).symm (MvPolynomial.X ij) =
+      Ideal.Quotient.mkₐ R (weightUnipotentDefiningHopfIdeal R w).toIdeal
+        ((genericMatrix R N) ij.1.1 ij.1.2) := by
+  apply (weightUnipotentCoordinateAlgEquiv R w).injective
+  rw [AlgEquiv.apply_symm_apply, Ideal.Quotient.mkₐ_eq_mk, genericMatrix_apply,
+    weightUnipotentCoordinateAlgEquiv_mk_genericMatrix_apply,
+    weightUnipotentPolynomialGenericMatrix_apply_of_lt R w ij.2]
+
+/-- The weight-unipotent coordinate algebra is smooth over its base ring. -/
+instance instSmoothWeightUnipotentCoordinateHopfAlgebra (w : Fin N → ℤ) :
+    Algebra.Smooth R (weightUnipotentCoordinateHopfAlgebra R w) := by
+  let _ : Algebra.Smooth R (MvPolynomial (WeightUnipotentIndex w) R) :=
+    ⟨inferInstance, inferInstance⟩
+  exact Algebra.Smooth.of_equiv (weightUnipotentCoordinateAlgEquiv R w).symm
+
+/-- Over an integral domain, the weight-unipotent coordinate algebra is an integral domain. -/
+instance instIsDomainWeightUnipotentCoordinateHopfAlgebra
+    [IsDomain R] (w : Fin N → ℤ) :
+    IsDomain (weightUnipotentCoordinateHopfAlgebra R w) :=
+  (weightUnipotentCoordinateAlgEquiv R w).toRingEquiv.isDomain_iff.mpr inferInstance
+
+/-- The weight-unipotent subgroup is geometrically connected over every field. -/
+theorem geometricallyConnectedCommHopfAlgProperty_weightUnipotentCoordinateHopfAlgebra
+    (k : Type u) [Field k] (w : Fin N → ℤ) :
+    geometricallyConnectedCommHopfAlgProperty k
+      (weightUnipotentCoordinateHopfAlgebra k w) := by
+  rw [geometricallyConnectedCommHopfAlgProperty_iff]
+  intro K _ _
+  let e : weightUnipotentCoordinateHopfAlgebra k w ⊗[k] K ≃+*
+      MvPolynomial (WeightUnipotentIndex w) K :=
+    (Algebra.TensorProduct.congr (weightUnipotentCoordinateAlgEquiv k w)
+        (AlgEquiv.refl : K ≃ₐ[k] K)).toRingEquiv.trans <|
+      (Algebra.TensorProduct.comm k
+        (MvPolynomial (WeightUnipotentIndex w) k) K).toRingEquiv.trans <|
+        (MvPolynomial.algebraTensorAlgEquiv k K).toRingEquiv
+  exact (PrimeSpectrum.homeomorphOfRingEquiv e).connectedSpace_iff.mpr inferInstance
+
+end
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Geometry.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Geometry.lean
@@ -76,7 +76,7 @@ def weightUnipotentPolynomialGenericMatrix (w : Fin N → ℤ) :
 theorem weightUnipotentPolynomialGenericMatrix_apply_of_lt (w : Fin N → ℤ)
     {i j : Fin N} (hij : w j < w i) :
     weightUnipotentPolynomialGenericMatrix R w i j =
-      MvPolynomial.X (show WeightUnipotentIndex w from ⟨(i, j), hij⟩) := by
+      MvPolynomial.X ⟨(i, j), hij⟩ := by
   simp [weightUnipotentPolynomialGenericMatrix, hij]
 
 /-- An entry on or above the weight-block diagonal is the corresponding identity entry. -/
@@ -260,9 +260,12 @@ private theorem weightUnipotentPolynomialToQuotient_comp_quotientToPolynomial
     · have hle : w i ≤ w j := not_lt.mp hij
       rw [weightUnipotentQuotientToPolynomial_mk_genericMatrix_apply,
         weightUnipotentPolynomialGenericMatrix_apply_of_le R w hle,
-        AlgHom.id_apply, Ideal.Quotient.mkₐ_eq_mk, genericMatrix_apply,
-        weightUnipotentQuotient_mk_genericMatrix_apply R w hle]
-      by_cases h : i = j <;> simp [Matrix.one_apply, h]
+        AlgHom.id_apply]
+      apply (Ideal.quotientEquivAlgOfEq R
+        (weightUnipotentDefiningHopfIdeal_toIdeal R w)).injective
+      simpa only [weightUnipotentPolynomialToQuotient, Matrix.one_apply, apply_ite,
+        map_one, map_zero, Ideal.Quotient.mkₐ_eq_mk, Ideal.quotientEquivAlgOfEq_mk] using
+        (quotient_genericMatrix_apply R w hle).symm
   exact DFunLike.congr_fun hcomp y
 
 /-- The weight-unipotent coordinate algebra is a polynomial algebra on the entries `X_ij` for

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Geometry.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Unipotent/Geometry.lean
@@ -24,9 +24,9 @@ determinant is one and polynomial evaluation extends across the localization. Th
 quotient relations then give mutually inverse maps.
 
 The polynomial presentation proves that the represented subgroup is smooth over every
-commutative base ring and geometrically connected over a field. Together with the pointwise
-unipotence theorem, these are the scheme-theoretic properties required of the unipotent factor
-in the dynamic Levi decomposition.
+commutative base ring and geometrically connected over a field. A forthcoming pointwise
+unipotence theorem will supply the remaining property required of the unipotent factor in the
+dynamic Levi decomposition.
 
 ## Main declarations
 
@@ -265,7 +265,7 @@ private theorem weightUnipotentPolynomialToQuotient_comp_quotientToPolynomial
         (weightUnipotentDefiningHopfIdeal_toIdeal R w)).injective
       simpa only [weightUnipotentPolynomialToQuotient, Matrix.one_apply, apply_ite,
         map_one, map_zero, Ideal.Quotient.mkₐ_eq_mk, Ideal.quotientEquivAlgOfEq_mk] using
-        (quotient_genericMatrix_apply R w hle).symm
+        (quotient_genericMatrix_apply_of_le R w hle).symm
   exact DFunLike.congr_fun hcomp y
 
 /-- The weight-unipotent coordinate algebra is a polynomial algebra on the entries `X_ij` for
@@ -279,10 +279,19 @@ noncomputable def weightUnipotentCoordinateAlgEquiv (w : Fin N → ℤ) :
     (weightUnipotentQuotientToPolynomial_comp_polynomialToQuotient R w)
     (weightUnipotentPolynomialToQuotient_comp_quotientToPolynomial R w)
 
-/-- The polynomial presentation sends a quotient generic-matrix entry to the corresponding
-polynomial weight-unipotent matrix entry. -/
-@[simp]
+/-- The polynomial presentation sends a canonical quotient generic-matrix entry to the
+corresponding polynomial weight-unipotent matrix entry. -/
 theorem weightUnipotentCoordinateAlgEquiv_mk_genericMatrix_apply
+    (w : Fin N → ℤ) (i j : Fin N) :
+    weightUnipotentCoordinateAlgEquiv R w
+        (Ideal.Quotient.mkₐ R (weightUnipotentDefiningHopfIdeal R w).toIdeal
+          ((genericMatrix R N) i j)) =
+      weightUnipotentPolynomialGenericMatrix R w i j := by
+  unfold weightUnipotentCoordinateAlgEquiv
+  exact weightUnipotentQuotientToPolynomial_mk_genericMatrix_apply R w i j
+
+@[simp]
+private theorem weightUnipotentCoordinateAlgEquiv_mk_apply
     (w : Fin N → ℤ) (i j : Fin N) :
     weightUnipotentCoordinateAlgEquiv R w
         (Ideal.Quotient.mk (weightUnipotentDefiningHopfIdeal R w).toIdeal
@@ -291,8 +300,7 @@ theorem weightUnipotentCoordinateAlgEquiv_mk_genericMatrix_apply
       weightUnipotentPolynomialGenericMatrix R w i j := by
   rw [← genericMatrix_apply (R := R) (n := N) i j,
     ← Ideal.Quotient.mkₐ_eq_mk (R₁ := R)]
-  unfold weightUnipotentCoordinateAlgEquiv
-  exact weightUnipotentQuotientToPolynomial_mk_genericMatrix_apply R w i j
+  exact weightUnipotentCoordinateAlgEquiv_mk_genericMatrix_apply R w i j
 
 /-- The inverse polynomial presentation sends a free variable to its quotient matrix entry. -/
 @[simp]
@@ -302,7 +310,7 @@ theorem weightUnipotentCoordinateAlgEquiv_symm_X
       Ideal.Quotient.mkₐ R (weightUnipotentDefiningHopfIdeal R w).toIdeal
         ((genericMatrix R N) ij.1.1 ij.1.2) := by
   apply (weightUnipotentCoordinateAlgEquiv R w).injective
-  rw [AlgEquiv.apply_symm_apply, Ideal.Quotient.mkₐ_eq_mk, genericMatrix_apply,
+  rw [AlgEquiv.apply_symm_apply,
     weightUnipotentCoordinateAlgEquiv_mk_genericMatrix_apply,
     weightUnipotentPolynomialGenericMatrix_apply_of_lt R w ij.2]
 


### PR DESCRIPTION
This PR proves that every represented weight-unipotent subgroup of `GL_N` has a polynomial coordinate algebra, and uses that presentation to establish smoothness over an arbitrary commutative base ring and geometric connectedness over a field. It targets the ReductiveGroups Layer 7 structure-theory milestone, specifically the roadmap statement to keep the dynamic approach to parabolics, Levi decomposition, and the unipotent radical as a parallel route for downstream `p`-adic representation theory.

The new equivalence identifies the quotient coordinate algebra with `MvPolynomial (WeightUnipotentIndex w) R`, where the variables are exactly the entries with `w j < w i`. Its construction evaluates the generic matrix at the corresponding block-unitriangular polynomial matrix, proves its determinant is one so evaluation extends across the determinant localization, factors through the defining Hopf ideal, and constructs the inverse from the free quotient coordinates. Smoothness then follows by transport from a polynomial algebra, while geometric connectedness follows after arbitrary field extension from the resulting integral-domain presentation.

This is the most effective current step on the milestone because the represented weight-unipotent subgroup already exists on `main`, while pointwise unipotence is covered by the distinct in-flight PR #4587; after this PR, that pointwise result and the in-flight scheme-level normality work in #4614 must land before the represented Levi quotient and semidirect-product isomorphism can be completed and then generalized beyond `GL_N`.

The required prefix-directory normalization is included without a compatibility shim:

| Old module | New module |
| --- | --- |
| `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Unipotent` | `TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Weight.Unipotent.Basic` |

The sole existing in-repository consumer is updated to the new canonical import. The proof reuses Mathlib's block-triangular determinant theorem, determinant-localization lift, ideal-quotient lift, polynomial tensor-product equivalence, and smoothness transport; no Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"weight-unipotent-smooth-connected"}-->

🤖 Prepared with Codex
