### PR TITLE
feat: characterize finite-dimensional highest weight modules

### DIFF
--- a/TauCeti/Algebra/Lie/HighestWeight/FiniteDimensional.lean
+++ b/TauCeti/Algebra/Lie/HighestWeight/FiniteDimensional.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.HighestWeight.Multiplicity
+public import TauCeti.Algebra.Lie.HighestWeight.WeightSupport
+import TauCeti.Algebra.Lie.Submodule.Atom
+
+public section
+
+/-!
+# Finite-dimensionality of dominant irreducible highest weight modules
+
+Let `L` be a finite-dimensional Lie algebra with non-degenerate Killing form over an algebraically
+closed field of characteristic zero. An irreducible highest weight `L`-module is
+finite-dimensional exactly when its highest weight is dominant integral.
+
+The forward implication is the rank-one argument of
+`TauCeti.IsHighestWeightVector.isDominantIntegral`. For the reverse implication, two earlier
+milestones supply the necessary finiteness:
+
+* `TauCeti.finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector` says that a dominant
+  irreducible highest weight module has only finitely many nonzero weight spaces;
+* `TauCeti.finiteDimensional_genWeightSpace_of_isHighestWeightVector_of_lieSpan_eq_top` says that
+  each of those weight spaces is finite-dimensional.
+
+The weight-cone decomposition of a highest weight module says that these spaces span the whole
+module. Their finite supremum is therefore finitely generated, which proves the result without
+assuming finite-dimensionality of the ambient module at any intermediate step.
+
+## Main results
+
+* `TauCeti.finiteDimensional_of_isHighestWeightVector_of_isDominantIntegral`: the difficult
+  implication, from dominance to finite-dimensionality.
+* `TauCeti.finiteDimensional_iff_isDominantIntegral_of_isHighestWeightVector`: the complete
+  finite-dimensionality criterion for an irreducible highest weight module.
+
+## References
+
+This closes the **finite-dimensionality** milestone of Layer 4 of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`. It is the last assembly step in
+the proof that the irreducible highest weight module `L(lam)` is finite-dimensional precisely for
+dominant integral `lam`; applying it to the canonical irreducible quotient of the Verma module
+additionally requires that quotient's highest weight vector to be nonzero.
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §21.2.
+-/
+
+namespace TauCeti
+
+open LieAlgebra LieModule Module
+
+universe u v w
+
+variable {K : Type u} {L : Type v} [Field K] [CharZero K] [IsAlgClosed K] [LieRing L]
+  [LieAlgebra K L] [IsKilling K L] [FiniteDimensional K L]
+  {H : LieSubalgebra K L} [H.IsCartanSubalgebra]
+  {M : Type w} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+  [LieModule.IsIrreducible K L M]
+  {b : (IsKilling.rootSystem H).Base} {lam : Dual K H} {v : M}
+
+/-- **An irreducible highest weight module of dominant integral highest weight is
+finite-dimensional.** Its nonzero weight spaces form a finite family, every member of that family
+is finite-dimensional, and the family spans the module. -/
+theorem finiteDimensional_of_isHighestWeightVector_of_isDominantIntegral
+    (hv : IsHighestWeightVector b lam v) (hlam : IsDominantIntegral b lam) :
+    FiniteDimensional K M := by
+  have hgen : LieSubmodule.lieSpan K L {v} = ⊤ :=
+    lieSpan_singleton_eq_top_of_ne_zero hv.ne_zero
+  have hfinite :
+      {chi : H → K |
+        (genWeightSpace M chi : LieSubmodule K H M).toSubmodule ≠ ⊥}.Finite := by
+    convert finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector hv hlam using 1
+    ext chi
+    simp
+  let _ : Fintype
+      {chi : H → K |
+        (genWeightSpace M chi : LieSubmodule K H M).toSubmodule ≠ ⊥} :=
+    hfinite.fintype
+  have htop :
+      (⨆ chi : {chi : H → K |
+          (genWeightSpace M chi : LieSubmodule K H M).toSubmodule ≠ ⊥},
+        (genWeightSpace M (chi : H → K) : LieSubmodule K H M).toSubmodule) = ⊤ := by
+    calc
+      _ = ⨆ chi : H → K,
+          (genWeightSpace M chi : LieSubmodule K H M).toSubmodule :=
+        iSup_ne_bot_subtype _
+      _ = ⊤ := by
+        apply LieSubmodule.iSup_toSubmodule_eq_top.mpr
+        refine eq_top_iff.mpr ?_
+        rw [←
+          iSup_genWeightSpace_sub_posRootCone_eq_top_of_isHighestWeightVector_of_lieSpan_eq_top
+            hv hgen]
+        exact iSup₂_le fun nu _ ↦
+          le_iSup (fun chi : H → K ↦ genWeightSpace M chi)
+            (((lam - nu : Dual K H) : H → K))
+  apply Module.Finite.of_fg_top
+  rw [← htop]
+  refine Submodule.fg_iSup _ fun chi ↦ ?_
+  exact (Submodule.fg_iff_finiteDimensional _).mpr
+    (finiteDimensional_genWeightSpace_of_isHighestWeightVector_of_lieSpan_eq_top
+      hv hgen (chi : H → K))
+
+/-- **Finite-dimensionality criterion for an irreducible highest weight module.** Such a module is
+finite-dimensional if and only if its highest weight is dominant integral. -/
+theorem finiteDimensional_iff_isDominantIntegral_of_isHighestWeightVector
+    (hv : IsHighestWeightVector b lam v) :
+    FiniteDimensional K M ↔ IsDominantIntegral b lam := by
+  constructor
+  · intro hM
+    let _ := hM
+    exact hv.isDominantIntegral
+  · exact finiteDimensional_of_isHighestWeightVector_of_isDominantIntegral hv
+
+end TauCeti


### PR DESCRIPTION
This PR proves that an irreducible highest weight module over an algebraically closed characteristic-zero field is finite-dimensional if and only if its highest weight is dominant integral. The difficult direction, `TauCeti.finiteDimensional_of_isHighestWeightVector_of_isDominantIntegral`, combines the finite weight support of a dominant irreducible highest weight module with finite-dimensionality of each individual weight space; `TauCeti.finiteDimensional_iff_isDominantIntegral_of_isHighestWeightVector` adds the converse supplied by the rank-one dominance theorem.

The exact target is `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`, Layer 4, milestone “`L(λ)` is finite-dimensional iff `λ` is dominant integral,” specifically its final **Finite-dimensionality** assembly step: each weight space is finite-dimensional and finitely many nonzero weight spaces give `dim L(λ) < ∞`. This is the most effective current step because both hard inputs are now on `main` as `TauCeti.finite_setOf_genWeightSpace_ne_bot_of_isHighestWeightVector` and `TauCeti.finiteDimensional_genWeightSpace_of_isHighestWeightVector_of_lieSpan_eq_top`, while no open PR connects them and the in-flight Weyl complete-reducibility PR starts at Layer 5. After this PR, applying the criterion to the canonical irreducible quotient of every Verma module still requires Layer 3’s missing nonvanishing of the Verma generator; the Layer 4 classification summit then remains to package those quotients and the highest-weight bijection.

The proof restricts the spanning supremum of generalized weight spaces to its nonzero support with Mathlib’s `iSup_ne_bot_subtype`, equips that support with its proved finite type, and applies `Submodule.fg_iSup` to the already-proved finite-dimensional weight spaces. This keeps the ambient module infinite-dimensional until the conclusion and uses irreducibility only to show that the highest weight vector generates. The reverse implication reuses `TauCeti.IsHighestWeightVector.isDominantIntegral`. No Mathlib infrastructure or supplementary snapshot material is vendored or adapted; the mathematical route follows Humphreys, *Introduction to Lie Algebras and Representation Theory*, §21.2, as credited in the module documentation.

Add `TauCeti/Algebra/Lie/HighestWeight/FiniteDimensional.lean` (118 lines); no existing file changes.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"finite-dimensional-iff-dominant-integral"}-->

🤖 Prepared with Codex
