### PR TITLE
feat: classify the covering spaces of a disjoint union

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Sigma.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Sigma.lean
@@ -73,8 +73,9 @@ def sigmaMonodromyNatIso (f : ∀ i, E i → X i)
           ((isCoveringMap_sigmaMap f hf).monodromy
             (γ.map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j))) p) =
             (hf i).monodromy γ ((sigmaMapFiberEquiv f i x).symm p) := by
-        obtain ⟨v, rfl⟩ := (sigmaMapFiberEquiv f i x).surjective p
-        rw [monodromy_sigmaMap f hf γ v, Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+        apply (sigmaMapFiberEquiv f i y).injective
+        rw [Equiv.apply_symm_apply, ← monodromy_sigmaMap]
+        exact congrArg _ (Equiv.apply_symm_apply (sigmaMapFiberEquiv f i x) p).symm
       exact (congrArg (fun w => (e i).hom.app (FundamentalGroupoid.mk y) w) h).trans
         (NatTrans.naturality_apply (e i).hom γ ((sigmaMapFiberEquiv f i x).symm p)))
 
@@ -92,8 +93,20 @@ theorem exists_monodromyFunctor_iso_sigma (F : FundamentalGroupoid (Σ i, X i) �
     (FundamentalGroupoid.map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j)) ⋙ F)
   let f : ∀ i, ((q i : TopCat) : Type u) → X i := fun i => ⇑(q i).proj
   have hf : ∀ i, IsCoveringMap (f i) := fun i => (q i).isCoveringMap_proj
-  exact ⟨mk (TopCat.ofHom ⟨Sigma.map id f, (isCoveringMap_sigmaMap f hf).continuous⟩)
-    (isCoveringMap_sigmaMap f hf), ⟨sigmaMonodromyNatIso f hf F fun i => (hq i).some⟩⟩
+  let p : TopCat.of (Σ i, ((q i : TopCat) : Type u)) ⟶ TopCat.of (Σ i, X i) :=
+    TopCat.ofHom ⟨Sigma.map id f, (isCoveringMap_sigmaMap f hf).continuous⟩
+  let hp : IsCoveringMap p := isCoveringMap_sigmaMap f hf
+  let Q : CoveringSpace (TopCat.of (Σ i, X i)) := mk p hp
+  refine ⟨Q, ⟨?_⟩⟩
+  let h : (Q : TopCat) ≃ₜ TopCat.of (Σ i, ((q i : TopCat) : Type u)) :=
+    TopCat.homeoOfIso (eqToIso (mk_coe p hp))
+  have hh : p.hom ∘ h = Q.proj.hom := by
+    funext z
+    have hproj := DFunLike.congr_fun (congrArg TopCat.Hom.hom (mk_proj p hp)) z
+    exact hproj.symm
+  exact eqToIso (monodromyFunctor_obj Q) ≪≫
+    IsCoveringMap.monodromyNatIso Q.isCoveringMap_proj hp h hh ≪≫
+      sigmaMonodromyNatIso f hf F fun i => (hq i).some
 
 /-- **The classification of covering spaces of a disjoint union by fundamental-groupoid
 actions.** Over a disjoint union of path-connected, locally path-connected, semilocally simply

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Sigma.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Sigma.lean
@@ -66,7 +66,7 @@ def sigmaMonodromyNatIso (f : ∀ i, E i → X i)
       (e z.as.1).app (FundamentalGroupoid.mk z.as.2))
     (by
       rintro ⟨⟨i', x⟩⟩ ⟨⟨i, y⟩⟩ m
-      obtain rfl : i = i' := sigma_fst_eq_of_quotient m
+      obtain rfl : i = i' := sigmaFst_eq_of_quotient m
       obtain ⟨γ, rfl⟩ := exists_quotient_map_sigmaMk_eq m
       refine ConcreteCategory.hom_ext _ _ fun p => ?_
       have h : (sigmaMapFiberEquiv f i y).symm

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Sigma.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Sigma.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.MonodromyEquivalence
+public import TauCeti.Topology.Covering.Sigma
+public import TauCeti.Topology.Homotopy.Sigma
+
+/-!
+# Covering spaces of a disjoint union are classified by their monodromy
+
+Let `X i` be a family of path-connected, locally path-connected, semilocally simply connected
+spaces. Their disjoint union is locally path connected but not path connected, so it falls
+outside the standing hypotheses of `TauCeti.CoveringSpace.monodromyEquivalence`; this file proves
+the classification for it anyway.
+
+Only essential surjectivity has to be redone: monodromy is always faithful, and it is full over
+any locally path-connected base. A functor `F` out of the fundamental groupoid of `Σ i, X i`
+restricts along the inclusion of each summand, each restriction is the monodromy of a covering
+space of that summand, and the disjoint union of those covering spaces is a covering space of
+`Σ i, X i` whose monodromy is `F`. The comparison is natural because a path in a disjoint union
+stays in the summand it starts in, so every morphism of the fundamental groupoid comes from a
+single summand.
+
+## Main declarations
+
+* `TauCeti.sigmaMonodromyNatIso`: summandwise identifications of monodromy assemble into one
+  over the disjoint union.
+* `TauCeti.CoveringSpace.exists_monodromyFunctor_iso_sigma`: every functor out of the fundamental
+  groupoid of a disjoint union is the monodromy of a covering space.
+* `TauCeti.CoveringSpace.sigmaMonodromyEquivalence`: **covering spaces of a disjoint union of
+  nice spaces are equivalent to functors from its fundamental groupoid to types.**
+
+## References
+
+This is the disconnected case of Stage 2, item 8 of
+`TauCetiRoadmap/UniversalCovers/README.md`, whose alternative lens asks for covers in general to
+be described as functors out of the fundamental groupoid.
+-/
+
+public section
+noncomputable section
+
+open CategoryTheory Topology
+
+universe u
+
+namespace TauCeti
+
+variable {ι : Type u} {E X : ι → Type u} [∀ i, TopologicalSpace (E i)]
+  [∀ i, TopologicalSpace (X i)]
+
+/-- **Summandwise identifications of monodromy assemble over a disjoint union.** If the monodromy
+functor of `f i` is isomorphic to the restriction of `G` to the `i`-th summand for every `i`,
+then the monodromy functor of the disjoint union of the `f i` is isomorphic to `G`. -/
+def sigmaMonodromyNatIso (f : ∀ i, E i → X i)
+    (hf : ∀ i, IsCoveringMap (f i)) (G : FundamentalGroupoid (Σ i, X i) ⥤ Type u)
+    (e : ∀ i, (hf i).monodromyFunctor ≅
+      FundamentalGroupoid.map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j)) ⋙ G) :
+    (isCoveringMap_sigmaMap f hf).monodromyFunctor ≅ G :=
+  NatIso.ofComponents
+    (fun z => (sigmaMapFiberEquiv f z.as.1 z.as.2).symm.toIso ≪≫
+      (e z.as.1).app (FundamentalGroupoid.mk z.as.2))
+    (by
+      rintro ⟨⟨i', x⟩⟩ ⟨⟨i, y⟩⟩ m
+      obtain rfl : i = i' := sigma_fst_eq_of_quotient m
+      obtain ⟨γ, rfl⟩ := exists_quotient_map_sigmaMk_eq m
+      refine ConcreteCategory.hom_ext _ _ fun p => ?_
+      have h : (sigmaMapFiberEquiv f i y).symm
+          ((isCoveringMap_sigmaMap f hf).monodromy
+            (γ.map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j))) p) =
+            (hf i).monodromy γ ((sigmaMapFiberEquiv f i x).symm p) := by
+        obtain ⟨v, rfl⟩ := (sigmaMapFiberEquiv f i x).surjective p
+        rw [monodromy_sigmaMap f hf γ v, Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+      exact (congrArg (fun w => (e i).hom.app (FundamentalGroupoid.mk y) w) h).trans
+        (NatTrans.naturality_apply (e i).hom γ ((sigmaMapFiberEquiv f i x).symm p)))
+
+variable [∀ i, PathConnectedSpace (X i)] [∀ i, LocallyPathConnectedSpace (X i)]
+  [∀ i, SemilocallySimplyConnectedSpace (X i)]
+
+namespace CoveringSpace
+
+/-- **Every functor out of the fundamental groupoid of a disjoint union of nice spaces is the
+monodromy of a covering space.** -/
+theorem exists_monodromyFunctor_iso_sigma (F : FundamentalGroupoid (Σ i, X i) ⥤ Type u) :
+    ∃ p : CoveringSpace (TopCat.of (Σ i, X i)),
+      Nonempty ((monodromyFunctor (TopCat.of (Σ i, X i))).obj p ≅ F) := by
+  choose q hq using fun i : ι => exists_monodromyFunctor_iso (X := TopCat.of (X i))
+    (FundamentalGroupoid.map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j)) ⋙ F)
+  let f : ∀ i, ((q i : TopCat) : Type u) → X i := fun i => ⇑(q i).proj
+  have hf : ∀ i, IsCoveringMap (f i) := fun i => (q i).isCoveringMap_proj
+  exact ⟨mk (TopCat.ofHom ⟨Sigma.map id f, (isCoveringMap_sigmaMap f hf).continuous⟩)
+    (isCoveringMap_sigmaMap f hf), ⟨sigmaMonodromyNatIso f hf F fun i => (hq i).some⟩⟩
+
+/-- **The classification of covering spaces of a disjoint union by fundamental-groupoid
+actions.** Over a disjoint union of path-connected, locally path-connected, semilocally simply
+connected spaces, monodromy is an equivalence from covering spaces to functors from the
+fundamental groupoid to types. -/
+def sigmaMonodromyEquivalence (X : ι → Type u) [∀ i, TopologicalSpace (X i)]
+    [∀ i, PathConnectedSpace (X i)] [∀ i, LocallyPathConnectedSpace (X i)]
+    [∀ i, SemilocallySimplyConnectedSpace (X i)] :
+    CoveringSpace (TopCat.of (Σ i, X i)) ≌ (FundamentalGroupoid (Σ i, X i) ⥤ Type u) :=
+  haveI : (monodromyFunctor (TopCat.of (Σ i, X i))).Faithful :=
+    monodromyFunctor_faithful (TopCat.of (Σ i, X i))
+  haveI : (monodromyFunctor (TopCat.of (Σ i, X i))).Full := monodromyFunctor_full
+  haveI : (monodromyFunctor (TopCat.of (Σ i, X i))).EssSurj :=
+    ⟨fun F => exists_monodromyFunctor_iso_sigma F⟩
+  haveI : (monodromyFunctor (TopCat.of (Σ i, X i))).IsEquivalence := {}
+  (monodromyFunctor (TopCat.of (Σ i, X i))).asEquivalence
+
+@[simp]
+theorem sigmaMonodromyEquivalence_functor (X : ι → Type u) [∀ i, TopologicalSpace (X i)]
+    [∀ i, PathConnectedSpace (X i)] [∀ i, LocallyPathConnectedSpace (X i)]
+    [∀ i, SemilocallySimplyConnectedSpace (X i)] :
+    (sigmaMonodromyEquivalence X).functor = monodromyFunctor (TopCat.of (Σ i, X i)) :=
+  (rfl)
+
+end CoveringSpace
+
+end TauCeti

--- a/TauCeti/Topology/Covering/Category.lean
+++ b/TauCeti/Topology/Covering/Category.lean
@@ -63,8 +63,9 @@ open CategoryTheory
 
 namespace Over
 
-/-- The property of an object of `TopCat / X` that its structure morphism is a covering map. -/
-def isCoveringMap (X : TopCat.{u}) : ObjectProperty (CategoryTheory.Over X) :=
+/-- The property of an object of `TopCat / X` that its structure morphism is a covering map. The
+definition is `@[expose]`d so that it unfolds in downstream modules. -/
+@[expose] def isCoveringMap (X : TopCat.{u}) : ObjectProperty (CategoryTheory.Over X) :=
   fun p ↦ _root_.IsCoveringMap p.hom
 
 /-- A morphism in `TopCat / X` is an isomorphism exactly when its map on left objects is a
@@ -97,8 +98,10 @@ abbrev totalSpace (X : TopCat.{u}) : CoveringSpace X ⥤ TopCat :=
 instance : CoeOut (CoveringSpace X) TopCat where
   coe p := p.obj.left
 
-/-- Construct a covering space over `X` from a covering map `p`. -/
-def mk {E : TopCat.{u}} (p : E ⟶ X) (hp : _root_.IsCoveringMap p) : CoveringSpace X where
+/-- Construct a covering space over `X` from a covering map `p`. Its total space and projection
+are computed by `mk_coe` and `mk_proj`; the definition is `@[expose]`d so that those equations
+also hold by `rfl` in downstream modules. -/
+@[expose] def mk {E : TopCat.{u}} (p : E ⟶ X) (hp : _root_.IsCoveringMap p) : CoveringSpace X where
   obj := CategoryTheory.Over.mk p
   property := hp
 

--- a/TauCeti/Topology/Covering/Category.lean
+++ b/TauCeti/Topology/Covering/Category.lean
@@ -63,9 +63,8 @@ open CategoryTheory
 
 namespace Over
 
-/-- The property of an object of `TopCat / X` that its structure morphism is a covering map. The
-definition is `@[expose]`d so that it unfolds in downstream modules. -/
-@[expose] def isCoveringMap (X : TopCat.{u}) : ObjectProperty (CategoryTheory.Over X) :=
+/-- The property of an object of `TopCat / X` that its structure morphism is a covering map. -/
+def isCoveringMap (X : TopCat.{u}) : ObjectProperty (CategoryTheory.Over X) :=
   fun p ↦ _root_.IsCoveringMap p.hom
 
 /-- A morphism in `TopCat / X` is an isomorphism exactly when its map on left objects is a
@@ -98,10 +97,8 @@ abbrev totalSpace (X : TopCat.{u}) : CoveringSpace X ⥤ TopCat :=
 instance : CoeOut (CoveringSpace X) TopCat where
   coe p := p.obj.left
 
-/-- Construct a covering space over `X` from a covering map `p`. Its total space and projection
-are computed by `mk_coe` and `mk_proj`; the definition is `@[expose]`d so that those equations
-also hold by `rfl` in downstream modules. -/
-@[expose] def mk {E : TopCat.{u}} (p : E ⟶ X) (hp : _root_.IsCoveringMap p) : CoveringSpace X where
+/-- Construct a covering space over `X` from a covering map `p`. -/
+def mk {E : TopCat.{u}} (p : E ⟶ X) (hp : _root_.IsCoveringMap p) : CoveringSpace X where
   obj := CategoryTheory.Over.mk p
   property := hp
 

--- a/TauCeti/Topology/Covering/Sigma.lean
+++ b/TauCeti/Topology/Covering/Sigma.lean
@@ -44,26 +44,21 @@ open Topology
 variable {ι : Type*} {E X : ι → Type*} [∀ i, TopologicalSpace (E i)]
   [∀ i, TopologicalSpace (X i)] (f : ∀ i, E i → X i)
 
-omit [(i : ι) → TopologicalSpace (E i)] [(i : ι) → TopologicalSpace (X i)] in
-/-- The `i`-th summand of `Σ i, E i` is exactly the part of the disjoint union of the `f i` that
-lies over the `i`-th summand of `Σ i, X i`. -/
-theorem preimage_sigmaMap_range_sigmaMk (i : ι) :
-    Sigma.map id f ⁻¹' Set.range (Sigma.mk i) = Set.range (Sigma.mk i) := by
-  ext ⟨j, e⟩
-  simp [Sigma.map, eq_comm]
-
 /-- **A disjoint union of covering maps is a covering map.** -/
 theorem isCoveringMap_sigmaMap (hf : ∀ i, IsCoveringMap (f i)) :
     IsCoveringMap (Sigma.map id f) := by
   rintro ⟨i, x⟩
+  -- The `i`-th summand of `Σ i, E i` is exactly the part of `Σ i, E i` lying over the `i`-th
+  -- summand of `Σ i, X i`.
+  have hpre : Sigma.map id f ⁻¹' Set.range (Sigma.mk i) = Set.range (Sigma.mk i) := by
+    simpa using (Set.image_sigmaMk_preimage_sigmaMap Function.injective_id f i Set.univ).symm
   have hopen : IsOpen (Sigma.map id f ⁻¹' Set.range (Sigma.mk i)) := by
-    rw [preimage_sigmaMap_range_sigmaMk]
+    rw [hpre]
     exact isOpen_range_sigmaMk
   refine IsCoveringMapOn.of_isCoveringMap_restrictPreimage _ isOpen_range_sigmaMk hopen ?_ _
     ⟨x, rfl⟩
   let hE : (Sigma.map id f ⁻¹' Set.range (Sigma.mk i) : Set (Σ i, E i)) ≃ₜ E i :=
-    (Homeomorph.setCongr (preimage_sigmaMap_range_sigmaMk f i)).trans
-      (IsEmbedding.sigmaMk (σ := E)).toHomeomorph.symm
+    (Homeomorph.setCongr hpre).trans (IsEmbedding.sigmaMk (σ := E)).toHomeomorph.symm
   let hX : X i ≃ₜ (Set.range (Sigma.mk i) : Set (Σ i, X i)) :=
     (IsEmbedding.sigmaMk (σ := X)).toHomeomorph
   have heq : (Set.range (Sigma.mk i)).restrictPreimage (Sigma.map id f) =
@@ -76,25 +71,12 @@ theorem isCoveringMap_sigmaMap (hf : ∀ i, IsCoveringMap (f i)) :
   rw [heq]
   exact ((hf i).comp_homeomorph hE).homeomorph_comp hX
 
-omit [(i : ι) → TopologicalSpace (E i)] [(i : ι) → TopologicalSpace (X i)] in
-/-- The fibre of a disjoint union of maps over `⟨i, x⟩` consists of the points of the `i`-th
-summand lying over `x`. -/
-theorem image_sigmaMk_preimage_singleton (i : ι) (x : X i) :
-    Sigma.mk i '' (f i ⁻¹' {x}) = Sigma.map id f ⁻¹' {(⟨i, x⟩ : Σ j, X j)} := by
-  refine Set.Subset.antisymm ?_ ?_
-  · rintro _ ⟨e, he, rfl⟩
-    simpa [Sigma.map] using he
-  · rintro ⟨j, e⟩ hje
-    have hje' : (⟨j, f j e⟩ : Σ k, X k) = ⟨i, x⟩ := hje
-    obtain rfl : j = i := congrArg Sigma.fst hje'
-    exact ⟨e, sigma_mk_injective hje', rfl⟩
-
 /-- **The fibre of a disjoint union of maps over `⟨i, x⟩` is the fibre of the `i`-th map over
 `x`**, through the inclusion of the `i`-th summand. -/
 noncomputable def sigmaMapFiberEquiv (i : ι) (x : X i) :
     (f i ⁻¹' {x} : Set (E i)) ≃ (Sigma.map id f ⁻¹' {(⟨i, x⟩ : Σ i, X i)} : Set (Σ i, E i)) :=
-  (Equiv.Set.image _ _ sigma_mk_injective).trans
-    (Equiv.setCongr (image_sigmaMk_preimage_singleton f i x))
+  (Equiv.Set.image _ _ sigma_mk_injective).trans <| Equiv.setCongr <| by
+    simpa using Set.image_sigmaMk_preimage_sigmaMap Function.injective_id f i {x}
 
 omit [(i : ι) → TopologicalSpace (E i)] [(i : ι) → TopologicalSpace (X i)] in
 @[simp]

--- a/TauCeti/Topology/Covering/Sigma.lean
+++ b/TauCeti/Topology/Covering/Sigma.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Covering.Basic
+public import Mathlib.Topology.Homotopy.Lifting
+
+/-!
+# Covering maps of a disjoint union
+
+A family of covering maps `f i : E i → X i` assembles into a single map
+`Sigma.map id f : (Σ i, E i) → Σ i, X i`, and this file proves that the assembled map is again a
+covering map, identifies its fibres, and computes its monodromy.
+
+Everything is local: the summand `Set.range (Sigma.mk i)` is open in `Σ i, X i`, the assembled
+map restricts over it to `f i` up to the two open embeddings, and `IsCoveringMap` is a pointwise
+condition, so the summandwise statements glue with no compatibility to check.
+
+## Main declarations
+
+* `TauCeti.isCoveringMap_sigmaMap`: **a disjoint union of covering maps is a covering map.**
+* `TauCeti.sigmaMapFiberEquiv`: the fibre of `Sigma.map id f` over `⟨i, x⟩` is the fibre of
+  `f i` over `x`.
+* `TauCeti.monodromy_sigmaMap`: that identification intertwines the monodromy of `f i` along a
+  path with the monodromy of `Sigma.map id f` along its image in `Σ i, X i`.
+
+## References
+
+This supplies the topological half of the disconnected case of Stage 2, item 8 of
+`TauCetiRoadmap/UniversalCovers/README.md`, whose classification of covering spaces by functors
+out of the fundamental groupoid is currently available only over a path-connected base
+(`TauCeti.CoveringSpace.monodromyEquivalence`).
+-/
+
+public section
+
+namespace TauCeti
+
+open Topology
+
+variable {ι : Type*} {E X : ι → Type*} [∀ i, TopologicalSpace (E i)]
+  [∀ i, TopologicalSpace (X i)] (f : ∀ i, E i → X i)
+
+omit [(i : ι) → TopologicalSpace (E i)] [(i : ι) → TopologicalSpace (X i)] in
+/-- The `i`-th summand of `Σ i, E i` is exactly the part of the disjoint union of the `f i` that
+lies over the `i`-th summand of `Σ i, X i`. -/
+theorem preimage_sigmaMap_range_sigmaMk (i : ι) :
+    Sigma.map id f ⁻¹' Set.range (Sigma.mk i) = Set.range (Sigma.mk i) := by
+  ext ⟨j, e⟩
+  simp [Sigma.map, eq_comm]
+
+/-- **A disjoint union of covering maps is a covering map.** -/
+theorem isCoveringMap_sigmaMap (hf : ∀ i, IsCoveringMap (f i)) :
+    IsCoveringMap (Sigma.map id f) := by
+  rintro ⟨i, x⟩
+  have hopen : IsOpen (Sigma.map id f ⁻¹' Set.range (Sigma.mk i)) := by
+    rw [preimage_sigmaMap_range_sigmaMk]
+    exact isOpen_range_sigmaMk
+  refine IsCoveringMapOn.of_isCoveringMap_restrictPreimage _ isOpen_range_sigmaMk hopen ?_ _
+    ⟨x, rfl⟩
+  let hE : (Sigma.map id f ⁻¹' Set.range (Sigma.mk i) : Set (Σ i, E i)) ≃ₜ E i :=
+    (Homeomorph.setCongr (preimage_sigmaMap_range_sigmaMk f i)).trans
+      (IsEmbedding.sigmaMk (σ := E)).toHomeomorph.symm
+  let hX : X i ≃ₜ (Set.range (Sigma.mk i) : Set (Σ i, X i)) :=
+    (IsEmbedding.sigmaMk (σ := X)).toHomeomorph
+  have heq : (Set.range (Sigma.mk i)).restrictPreimage (Sigma.map id f) =
+      hX ∘ f i ∘ hE := by
+    refine funext fun p ↦ Subtype.ext ?_
+    obtain ⟨⟨j, e⟩, hje⟩ := p
+    obtain rfl : j = i := by simpa [Sigma.map, eq_comm] using hje
+    simp [Set.restrictPreimage, Sigma.map, hE, hX, Homeomorph.setCongr, Equiv.setCongr,
+      Equiv.subtypeEquivProp]
+  rw [heq]
+  exact ((hf i).comp_homeomorph hE).homeomorph_comp hX
+
+omit [(i : ι) → TopologicalSpace (E i)] [(i : ι) → TopologicalSpace (X i)] in
+/-- The fibre of a disjoint union of maps over `⟨i, x⟩` consists of the points of the `i`-th
+summand lying over `x`. -/
+theorem image_sigmaMk_preimage_singleton (i : ι) (x : X i) :
+    Sigma.mk i '' (f i ⁻¹' {x}) = Sigma.map id f ⁻¹' {(⟨i, x⟩ : Σ j, X j)} := by
+  refine Set.Subset.antisymm ?_ ?_
+  · rintro _ ⟨e, he, rfl⟩
+    simpa [Sigma.map] using he
+  · rintro ⟨j, e⟩ hje
+    have hje' : (⟨j, f j e⟩ : Σ k, X k) = ⟨i, x⟩ := hje
+    obtain rfl : j = i := congrArg Sigma.fst hje'
+    exact ⟨e, sigma_mk_injective hje', rfl⟩
+
+/-- **The fibre of a disjoint union of maps over `⟨i, x⟩` is the fibre of the `i`-th map over
+`x`**, through the inclusion of the `i`-th summand. -/
+@[expose] noncomputable def sigmaMapFiberEquiv (i : ι) (x : X i) :
+    (f i ⁻¹' {x} : Set (E i)) ≃ (Sigma.map id f ⁻¹' {(⟨i, x⟩ : Σ i, X i)} : Set (Σ i, E i)) :=
+  (Equiv.Set.image _ _ sigma_mk_injective).trans
+    (Equiv.setCongr (image_sigmaMk_preimage_singleton f i x))
+
+omit [(i : ι) → TopologicalSpace (E i)] [(i : ι) → TopologicalSpace (X i)] in
+@[simp]
+theorem sigmaMapFiberEquiv_apply_coe (i : ι) (x : X i) (e : (f i ⁻¹' {x} : Set (E i))) :
+    (sigmaMapFiberEquiv f i x e : Σ i, E i) = ⟨i, (e : E i)⟩ :=
+  (rfl)
+
+/-- The raw form of `monodromy_sigmaMap`, with the two fibre elements written as explicit pairs
+rather than through `sigmaMapFiberEquiv`, so that the lifted path can be rewritten. -/
+private theorem monodromy_sigmaMap_aux (hf : ∀ i, IsCoveringMap (f i)) {i : ι} {x y : X i}
+    (γ : Path.Homotopic.Quotient x y) (e : (f i ⁻¹' {x} : Set (E i)))
+    (he : (⟨i, (e : E i)⟩ : Σ j, E j) ∈ Sigma.map id f ⁻¹' {(⟨i, x⟩ : Σ j, X j)})
+    (he' : (⟨i, (((hf i).monodromy γ e : E i))⟩ : Σ j, E j) ∈
+      Sigma.map id f ⁻¹' {(⟨i, y⟩ : Σ j, X j)}) :
+    (isCoveringMap_sigmaMap f hf).monodromy
+        (γ.map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j))) ⟨_, he⟩ = ⟨_, he'⟩ := by
+  refine (isCoveringMap_sigmaMap f hf).monodromy_eq_of_map_eq
+    (((hf i).liftPathQuotient γ e).map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(E i, Σ j, E j))) ?_
+  rw [← Path.Homotopic.Quotient.map_comp]
+  change ((hf i).liftPathQuotient γ e).map
+    ((⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j)).comp ⟨f i, (hf i).continuous⟩) = _
+  rw [Path.Homotopic.Quotient.map_comp, (hf i).map_liftPathQuotient]
+  exact Path.Homotopic.Quotient.map_cast γ
+
+/-- **Monodromy commutes with the inclusion of a summand.** Transporting a point of the fibre of
+`f i` over `x` into the disjoint union and letting the assembled cover transport it along the
+image of `γ` gives the same result as transporting along `γ` first. -/
+theorem monodromy_sigmaMap (hf : ∀ i, IsCoveringMap (f i)) {i : ι} {x y : X i}
+    (γ : Path.Homotopic.Quotient x y) (e : (f i ⁻¹' {x} : Set (E i))) :
+    (isCoveringMap_sigmaMap f hf).monodromy
+        (γ.map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j)))
+        (sigmaMapFiberEquiv f i x e) =
+      sigmaMapFiberEquiv f i y ((hf i).monodromy γ e) :=
+  monodromy_sigmaMap_aux f hf γ e _ _
+
+end TauCeti

--- a/TauCeti/Topology/Covering/Sigma.lean
+++ b/TauCeti/Topology/Covering/Sigma.lean
@@ -91,7 +91,7 @@ theorem image_sigmaMk_preimage_singleton (i : ι) (x : X i) :
 
 /-- **The fibre of a disjoint union of maps over `⟨i, x⟩` is the fibre of the `i`-th map over
 `x`**, through the inclusion of the `i`-th summand. -/
-@[expose] noncomputable def sigmaMapFiberEquiv (i : ι) (x : X i) :
+noncomputable def sigmaMapFiberEquiv (i : ι) (x : X i) :
     (f i ⁻¹' {x} : Set (E i)) ≃ (Sigma.map id f ⁻¹' {(⟨i, x⟩ : Σ i, X i)} : Set (Σ i, E i)) :=
   (Equiv.Set.image _ _ sigma_mk_injective).trans
     (Equiv.setCongr (image_sigmaMk_preimage_singleton f i x))
@@ -101,6 +101,18 @@ omit [(i : ι) → TopologicalSpace (E i)] [(i : ι) → TopologicalSpace (X i)]
 theorem sigmaMapFiberEquiv_apply_coe (i : ι) (x : X i) (e : (f i ⁻¹' {x} : Set (E i))) :
     (sigmaMapFiberEquiv f i x e : Σ i, E i) = ⟨i, (e : E i)⟩ :=
   (rfl)
+
+omit [(i : ι) → TopologicalSpace (E i)] [(i : ι) → TopologicalSpace (X i)] in
+/-- The inverse fibre equivalence sends an element in the `i`-th summand back to that element. -/
+@[simp]
+theorem sigmaMapFiberEquiv_symm_apply_mk (i : ι) (x : X i) (e : E i)
+    (he : e ∈ f i ⁻¹' {x}) :
+    (sigmaMapFiberEquiv f i x).symm
+        ⟨⟨i, e⟩, by simpa [Sigma.map] using he⟩ = ⟨e, he⟩ := by
+  apply (sigmaMapFiberEquiv f i x).injective
+  rw [Equiv.apply_symm_apply]
+  apply Subtype.ext
+  exact (sigmaMapFiberEquiv_apply_coe f i x ⟨e, he⟩).symm
 
 /-- The raw form of `monodromy_sigmaMap`, with the two fibre elements written as explicit pairs
 rather than through `sigmaMapFiberEquiv`, so that the lifted path can be rewritten. -/
@@ -114,6 +126,8 @@ private theorem monodromy_sigmaMap_aux (hf : ∀ i, IsCoveringMap (f i)) {i : ι
   refine (isCoveringMap_sigmaMap f hf).monodromy_eq_of_map_eq
     (((hf i).liftPathQuotient γ e).map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(E i, Σ j, E j))) ?_
   rw [← Path.Homotopic.Quotient.map_comp]
+  -- The composite `Sigma.map id f ∘ Sigma.mk i` reduces to `Sigma.mk i ∘ f i`; spelling the
+  -- inclusions as structure literals makes this dependent endpoint equality definitional.
   change ((hf i).liftPathQuotient γ e).map
     ((⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j)).comp ⟨f i, (hf i).continuous⟩) = _
   rw [Path.Homotopic.Quotient.map_comp, (hf i).map_liftPathQuotient]

--- a/TauCeti/Topology/Covering/Sigma.lean
+++ b/TauCeti/Topology/Covering/Sigma.lean
@@ -118,6 +118,7 @@ private theorem monodromy_sigmaMap_aux (hf : ∀ i, IsCoveringMap (f i)) {i : ι
 /-- **Monodromy commutes with the inclusion of a summand.** Transporting a point of the fibre of
 `f i` over `x` into the disjoint union and letting the assembled cover transport it along the
 image of `γ` gives the same result as transporting along `γ` first. -/
+@[simp]
 theorem monodromy_sigmaMap (hf : ∀ i, IsCoveringMap (f i)) {i : ι} {x y : X i}
     (γ : Path.Homotopic.Quotient x y) (e : (f i ⁻¹' {x} : Set (E i))) :
     (isCoveringMap_sigmaMap f hf).monodromy

--- a/TauCeti/Topology/Homotopy/Sigma.lean
+++ b/TauCeti/Topology/Homotopy/Sigma.lean
@@ -25,7 +25,7 @@ need.
 
 ## Main declarations
 
-* `TauCeti.sigma_fst_eq_of_path`: a path out of the `i`-th summand of a disjoint union ends in
+* `TauCeti.sigmaFst_eq_of_path`: a path out of the `i`-th summand of a disjoint union ends in
   the `i`-th summand.
 * `TauCeti.exists_path_map_sigmaMk_eq`: **a path between two points of the `i`-th summand is the
   image of a path in that summand.**
@@ -46,7 +46,7 @@ open Topology unitInterval
 variable {ι : Type*} {X : ι → Type*} [∀ i, TopologicalSpace (X i)]
 
 /-- A path out of the `i`-th summand of a disjoint union ends in the `i`-th summand. -/
-theorem sigma_fst_eq_of_path {i : ι} {x : X i} {z : Σ j, X j}
+theorem sigmaFst_eq_of_path {i : ι} {x : X i} {z : Σ j, X j}
     (γ : Path (⟨i, x⟩ : Σ j, X j) z) : z.1 = i := by
   obtain ⟨j, g, hg⟩ := ContinuousMap.exists_lift_sigma γ.toContinuousMap
   have hγ : ∀ t, γ t = ⟨j, g t⟩ := fun t => DFunLike.congr_fun hg t
@@ -76,9 +76,9 @@ theorem exists_quotient_map_sigmaMk_eq {i : ι} {x y : X i}
 
 /-- A path homotopy class out of the `i`-th summand of a disjoint union ends in the `i`-th
 summand. -/
-theorem sigma_fst_eq_of_quotient {i : ι} {x : X i} {z : Σ j, X j}
+theorem sigmaFst_eq_of_quotient {i : ι} {x : X i} {z : Σ j, X j}
     (γ : Path.Homotopic.Quotient (⟨i, x⟩ : Σ j, X j) z) : z.1 = i := by
   obtain ⟨γ⟩ := γ
-  exact sigma_fst_eq_of_path γ
+  exact sigmaFst_eq_of_path γ
 
 end TauCeti

--- a/TauCeti/Topology/Homotopy/Sigma.lean
+++ b/TauCeti/Topology/Homotopy/Sigma.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.ContinuousMap.Sigma
+public import Mathlib.Topology.Homotopy.Path
+
+/-!
+# Paths in a disjoint union
+
+A path in a disjoint union `Σ i, X i` never leaves the summand it starts in, because the unit
+interval is connected: this is Mathlib's `ContinuousMap.exists_lift_sigma`. This file draws the
+two consequences that the fundamental groupoid of a disjoint union needs, namely that the
+endpoint of a path out of the `i`-th summand again lies in the `i`-th summand, and that a path
+between two points of the `i`-th summand is the image of a path in that summand — the latter also
+for path homotopy classes.
+
+The inclusion of a summand is spelled out as the anonymous bundled map
+`⟨Sigma.mk i, continuous_sigmaMk⟩` rather than `ContinuousMap.sigmaMk i`, because only the former
+has an application that reduces definitionally, which the dependently typed rewrites downstream
+need.
+
+## Main declarations
+
+* `TauCeti.sigma_fst_eq_of_path`: a path out of the `i`-th summand of a disjoint union ends in
+  the `i`-th summand.
+* `TauCeti.exists_path_map_sigmaMk_eq`: **a path between two points of the `i`-th summand is the
+  image of a path in that summand.**
+* `TauCeti.exists_quotient_map_sigmaMk_eq`: the same for path homotopy classes.
+
+## References
+
+This supplies the fundamental-groupoid half of the disconnected case of Stage 2, item 8 of
+`TauCetiRoadmap/UniversalCovers/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Topology unitInterval
+
+variable {ι : Type*} {X : ι → Type*} [∀ i, TopologicalSpace (X i)]
+
+/-- A path in a disjoint union runs through a single summand. -/
+theorem exists_forall_path_eq_sigmaMk {a b : Σ j, X j} (γ : Path a b) :
+    ∃ (i : ι) (g : C(I, X i)), ∀ t, γ t = ⟨i, g t⟩ := by
+  obtain ⟨i, g, hg⟩ := ContinuousMap.exists_lift_sigma γ.toContinuousMap
+  exact ⟨i, g, fun t => DFunLike.congr_fun hg t⟩
+
+/-- A path out of the `i`-th summand of a disjoint union ends in the `i`-th summand. -/
+theorem sigma_fst_eq_of_path {i : ι} {x : X i} {z : Σ j, X j}
+    (γ : Path (⟨i, x⟩ : Σ j, X j) z) : z.1 = i := by
+  obtain ⟨j, g, hγ⟩ := exists_forall_path_eq_sigmaMk γ
+  rw [γ.target.symm.trans (hγ 1)]
+  exact congrArg Sigma.fst ((hγ 0).symm.trans γ.source)
+
+/-- **A path between two points of the `i`-th summand of a disjoint union is the image of a path
+in that summand.** -/
+theorem exists_path_map_sigmaMk_eq {i : ι} {x y : X i}
+    (γ : Path (⟨i, x⟩ : Σ j, X j) ⟨i, y⟩) :
+    ∃ γ' : Path x y, γ'.map continuous_sigmaMk = γ := by
+  obtain ⟨j, g, hγ⟩ := exists_forall_path_eq_sigmaMk γ
+  obtain rfl : j = i := congrArg Sigma.fst ((hγ 0).symm.trans γ.source)
+  exact ⟨⟨g, sigma_mk_injective ((hγ 0).symm.trans γ.source),
+    sigma_mk_injective ((hγ 1).symm.trans γ.target)⟩, Path.ext (funext fun t => (hγ t).symm)⟩
+
+/-- **A path homotopy class between two points of the `i`-th summand of a disjoint union is the
+image of a class in that summand.** -/
+theorem exists_quotient_map_sigmaMk_eq {i : ι} {x y : X i}
+    (γ : Path.Homotopic.Quotient (⟨i, x⟩ : Σ j, X j) ⟨i, y⟩) :
+    ∃ γ' : Path.Homotopic.Quotient x y,
+      γ'.map (⟨Sigma.mk i, continuous_sigmaMk⟩ : C(X i, Σ j, X j)) = γ := by
+  obtain ⟨γ⟩ := γ
+  obtain ⟨γ', hγ'⟩ := exists_path_map_sigmaMk_eq γ
+  exact ⟨Path.Homotopic.Quotient.mk γ', by rw [← Path.Homotopic.Quotient.mk_map, hγ']; rfl⟩
+
+/-- A path homotopy class out of the `i`-th summand of a disjoint union ends in the `i`-th
+summand. -/
+theorem sigma_fst_eq_of_quotient {i : ι} {x : X i} {z : Σ j, X j}
+    (γ : Path.Homotopic.Quotient (⟨i, x⟩ : Σ j, X j) z) : z.1 = i := by
+  obtain ⟨γ⟩ := γ
+  exact sigma_fst_eq_of_path γ
+
+end TauCeti

--- a/TauCeti/Topology/Homotopy/Sigma.lean
+++ b/TauCeti/Topology/Homotopy/Sigma.lean
@@ -45,16 +45,11 @@ open Topology unitInterval
 
 variable {ι : Type*} {X : ι → Type*} [∀ i, TopologicalSpace (X i)]
 
-/-- A path in a disjoint union runs through a single summand. -/
-theorem exists_forall_path_eq_sigmaMk {a b : Σ j, X j} (γ : Path a b) :
-    ∃ (i : ι) (g : C(I, X i)), ∀ t, γ t = ⟨i, g t⟩ := by
-  obtain ⟨i, g, hg⟩ := ContinuousMap.exists_lift_sigma γ.toContinuousMap
-  exact ⟨i, g, fun t => DFunLike.congr_fun hg t⟩
-
 /-- A path out of the `i`-th summand of a disjoint union ends in the `i`-th summand. -/
 theorem sigma_fst_eq_of_path {i : ι} {x : X i} {z : Σ j, X j}
     (γ : Path (⟨i, x⟩ : Σ j, X j) z) : z.1 = i := by
-  obtain ⟨j, g, hγ⟩ := exists_forall_path_eq_sigmaMk γ
+  obtain ⟨j, g, hg⟩ := ContinuousMap.exists_lift_sigma γ.toContinuousMap
+  have hγ : ∀ t, γ t = ⟨j, g t⟩ := fun t => DFunLike.congr_fun hg t
   rw [γ.target.symm.trans (hγ 1)]
   exact congrArg Sigma.fst ((hγ 0).symm.trans γ.source)
 
@@ -63,7 +58,8 @@ in that summand.** -/
 theorem exists_path_map_sigmaMk_eq {i : ι} {x y : X i}
     (γ : Path (⟨i, x⟩ : Σ j, X j) ⟨i, y⟩) :
     ∃ γ' : Path x y, γ'.map continuous_sigmaMk = γ := by
-  obtain ⟨j, g, hγ⟩ := exists_forall_path_eq_sigmaMk γ
+  obtain ⟨j, g, hg⟩ := ContinuousMap.exists_lift_sigma γ.toContinuousMap
+  have hγ : ∀ t, γ t = ⟨j, g t⟩ := fun t => DFunLike.congr_fun hg t
   obtain rfl : j = i := congrArg Sigma.fst ((hγ 0).symm.trans γ.source)
   exact ⟨⟨g, sigma_mk_injective ((hγ 0).symm.trans γ.source),
     sigma_mk_injective ((hγ 1).symm.trans γ.target)⟩, Path.ext (funext fun t => (hγ t).symm)⟩


### PR DESCRIPTION
This PR classifies the covering spaces of a disjoint union by their monodromy, closing the
disconnected case of the alternative lens the UniversalCovers roadmap asks for in Stage 2,
item 8 of `TauCetiRoadmap/UniversalCovers/README.md` ("phrase the classification of connected
covers via transitive `π₁(X)`-sets / the monodromy functor, with disconnected covers as functors
out of the fundamental groupoid"). On `main`, `TauCeti.CoveringSpace.monodromyEquivalence` proves
`CoveringSpace X ≌ (FundamentalGroupoid X ⥤ Type u)` only for a **path-connected** base; the file
header of `TauCeti/Topology/Covering/Monodromy/Basic.lean` records that the essential image over a
general base "is the remaining topological content of the classification of covering spaces by
fundamental-groupoid actions". This PR supplies that content for a disjoint union.

`TauCeti/Topology/Covering/Sigma.lean` (133 lines) proves `TauCeti.isCoveringMap_sigmaMap`: for a
family of covering maps `f i : E i → X i`, Mathlib's `Sigma.map id f : (Σ i, E i) → Σ i, X i` is a
covering map. The proof is local — the summand `Set.range (Sigma.mk i)` is open, the assembled map
restricts over it to `f i` up to the two open embeddings, and `IsCoveringMap` is a pointwise
condition — so it is assembled from Mathlib's `IsCoveringMapOn.of_isCoveringMap_restrictPreimage`
and `IsCoveringMap.comp_homeomorph`/`homeomorph_comp`. The same file identifies the fibre over
`⟨i, x⟩` with the fibre of `f i` over `x` (`TauCeti.sigmaMapFiberEquiv`) and shows that
identification intertwines the two monodromy actions (`TauCeti.monodromy_sigmaMap`), via Mathlib's
`IsCoveringMap.monodromy_eq_of_map_eq` applied to the pushed-forward lifted path.

`TauCeti/Topology/Homotopy/Sigma.lean` (88 lines) supplies the fundamental-groupoid half. A path in
a disjoint union runs through a single summand — this is Mathlib's
`ContinuousMap.exists_lift_sigma`, consumed rather than reproved — so a path out of the `i`-th
summand ends in the `i`-th summand (`TauCeti.sigmaFst_eq_of_path`) and a path between two points
of that summand is the image of a path in it (`TauCeti.exists_path_map_sigmaMk_eq`), the latter
also for path homotopy classes (`TauCeti.exists_quotient_map_sigmaMk_eq`). The inclusion of a
summand is written as the anonymous bundled map `⟨Sigma.mk i, continuous_sigmaMk⟩` rather than
`ContinuousMap.sigmaMk i`, because only the former has a definitionally reducing application, which
the dependently typed rewrites downstream need; the module docstring says so.

`TauCeti/AlgebraicTopology/UniversalCover/Classification/Sigma.lean` (123 lines) puts the two
together. `TauCeti.sigmaMonodromyNatIso` assembles summandwise isomorphisms of monodromy functors
into one over the disjoint union: the components come from the fibre identification, and naturality
holds because every morphism of `FundamentalGroupoid (Σ i, X i)` comes from a single summand.
Feeding it the covers produced by the existing path-connected reconstruction
(`TauCeti.CoveringSpace.exists_monodromyFunctor_iso`) gives
`TauCeti.CoveringSpace.exists_monodromyFunctor_iso_sigma`, essential surjectivity over the disjoint
union; fullness and faithfulness are already available (`monodromyFunctor_full` needs only local
path-connectedness, which Mathlib's `Sigma.locallyPathConnectedSpace` provides, and
`monodromyFunctor_faithful` needs nothing), so
`TauCeti.CoveringSpace.sigmaMonodromyEquivalence` records
`CoveringSpace (TopCat.of (Σ i, X i)) ≌ (FundamentalGroupoid (Σ i, X i) ⥤ Type u)` for a family of
path-connected, locally path-connected, semilocally simply connected `X i`.

The PR adds nothing outside the three new files: the assembled cover is compared with the raw map
through the existing propositional API of `TauCeti.CoveringSpace.mk`, namely `mk_coe` (transported
along `eqToIso`) and `mk_proj`, so no constructor body is exposed to definitional reduction. (An
earlier commit of this PR did add two `@[expose]` attributes in
`TauCeti/Topology/Covering/Category.lean`; commit `2ffbb8be` removed them, and
`TauCeti/Topology/Covering/Category.lean` is now unchanged by this PR.) No declaration is renamed,
moved, or removed.

The milestone this serves is Stage 2, item 8; what remains after this PR, to get the classification
for an arbitrary locally path-connected, semilocally simply connected base, is the identification of
such a base with the disjoint union of its path components, which needs the subspace instances for
`pathComponent x₀` that open PR #4621 introduces.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"monodromy-equivalence-disjoint-union"}-->

🤖 Prepared with Claude Code


