### PR TITLE
refactor(Contour): name the truncated integrand's measurability step and reuse it

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -11,6 +11,7 @@ import Mathlib.Analysis.Calculus.Deriv.Add
 import Mathlib.Analysis.Calculus.Deriv.Mul
 public import Mathlib.Analysis.Complex.Basic
 import Mathlib.Topology.Order.Compact
+import TauCeti.Analysis.Contour.Curve.Distance
 
 /-!
 # The Cauchy principal value of a contour integral at a point (Hungerbühler–Wasem)
@@ -52,6 +53,10 @@ versus `MeromorphicOn` (on a set).
   excised integral eventually equals, and its limit `L`, concludes `HasCauchyPVAt` at `L`.
 * `intervalIntegrable_truncated_and_integral_truncated_eq_zero_of_norm_le` — where the curve
   stays within `ε` of the centre, the truncated integrand is integrable and integrates to `0`.
+* `aestronglyMeasurable_truncated` and `intervalIntegrable_truncated_mul_deriv` — the two halves
+  of integrability for a truncated integrand: measurability of the truncation, and domination by
+  `M · ‖deriv γ‖` from a bound off the ball. `intervalIntegrable_pow_inv_mul_deriv_truncated`
+  applies both to the order-`k` polar integrand `c / (z - z₀) ^ k`.
 * `HasCauchyPVAt.intro` — build the predicate from its two clauses; `HasCauchyPVAt.tendsto`,
   `HasCauchyPVAt.eventually_intervalIntegrable` — the clauses as named accessors;
   `HasCauchyPVAt.cauchyPVAt_eq`, `HasCauchyPVAt.unique` — the value and its uniqueness;
@@ -91,6 +96,9 @@ versus `MeromorphicOn` (on a set).
 Migrated and adapted from the AINTLIB `LeanModularForms` project, file
 `ForMathlib/ClassicalCPV.lean`, specialised to the raw-function (`γ : ℝ → ℂ` on `[a, b]`) design of
 the contour-integration roadmap, and strengthened with the truncated-integrability clause.
+`intervalIntegrable_pow_inv_mul_deriv_truncated` comes instead from the same development's
+`cpvIntegrand_higherOrder_intervalIntegrable`, in
+`ForMathlib/HungerbuhlerWasem/MultiCrossingCPV.lean`.
 
 ## References
 
@@ -165,6 +173,27 @@ theorem CauchyPVExistsAt.intro {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} 
     (h : HasCauchyPVAt γ a b f z₀ L) : CauchyPVExistsAt γ a b f z₀ :=
   ⟨L, h⟩
 
+/-- **The `ε`-truncated integrand is a.e.-strongly measurable.** Truncating an a.e.-strongly
+measurable integrand to the parameters lying at distance `> ε` from `z₀` preserves a.e.-strong
+measurability: on `[[a, b]]` the truncation is the indicator of the complement of the closed set
+`{t ∈ [[a, b]] | ‖γ t - z₀‖ ≤ ε}` on which the curve stays near `z₀`. -/
+theorem aestronglyMeasurable_truncated {γ F : ℝ → ℂ} {z₀ : ℂ} {a b ε : ℝ}
+    (hγ_cont : ContinuousOn γ (Set.uIcc a b))
+    (hF : MeasureTheory.AEStronglyMeasurable F (MeasureTheory.volume.restrict (Set.uIoc a b))) :
+    MeasureTheory.AEStronglyMeasurable (fun t => if ‖γ t - z₀‖ > ε then F t else 0)
+      (MeasureTheory.volume.restrict (Set.uIoc a b)) := by
+  have hK_closed : IsClosed {t ∈ Set.uIcc a b | ‖γ t - z₀‖ ≤ ε} :=
+    isClosed_setOfPred_mem_uIcc_norm_sub_le hγ_cont z₀ ε
+  refine (hF.indicator hK_closed.measurableSet.compl).congr ?_
+  filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_uIoc] with t ht
+  by_cases h_far : ‖γ t - z₀‖ > ε
+  · have h_mem : t ∈ {t ∈ Set.uIcc a b | ‖γ t - z₀‖ ≤ ε}ᶜ :=
+      fun hK => absurd hK.2 (not_le.mpr h_far)
+    rw [Set.indicator_of_mem h_mem, ite_eq_left h_far]
+  · have h_notMem : t ∉ {t ∈ Set.uIcc a b | ‖γ t - z₀‖ ≤ ε}ᶜ := fun hKc =>
+      hKc ⟨Set.uIoc_subset_uIcc ht, not_lt.mp h_far⟩
+    rw [Set.indicator_of_notMem h_notMem, ite_eq_right h_far]
+
 /-- **The `ε`-truncated integrand is interval-integrable from a bound off the ball**: whenever
 `f ∘ γ` is bounded by `M` at distance `> ε` from `z₀` and the truncated integrand is
 a.e.-strongly measurable, the truncated integrand is dominated by `M · ‖deriv γ‖`. -/
@@ -187,6 +216,31 @@ theorem intervalIntegrable_truncated_mul_deriv {γ : ℝ → ℂ} {f : ℂ → �
       _ ≤ ‖M * ‖deriv γ t‖‖ := le_abs_self _
   · rw [ite_eq_right h_far, norm_zero]
     positivity
+
+/-- The `ε`-truncated order-`k` polar integrand is interval-integrable: off the `ε`-ball it is
+dominated by `(‖c‖ / ε ^ k) · ‖deriv γ‖`. -/
+theorem intervalIntegrable_pow_inv_mul_deriv_truncated {γ : ℝ → ℂ} {z₀ : ℂ} {a b : ℝ}
+    (c : ℂ) (k : ℕ) (hγ_cont : ContinuousOn γ (Set.uIcc a b))
+    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
+    {ε : ℝ} (hε : 0 < ε) :
+    IntervalIntegrable
+      (fun t => if ‖γ t - z₀‖ > ε then c / (γ t - z₀) ^ k * deriv γ t else 0)
+      MeasureTheory.volume a b := by
+  have hγ_aem : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)) :=
+    ((hγ_cont.aestronglyMeasurable
+      (by rw [← Set.Icc_min_max]; exact measurableSet_Icc)).mono_measure
+      (MeasureTheory.Measure.restrict_mono Set.uIoc_subset_uIcc le_rfl)).aemeasurable
+  have h_polar_aem : AEMeasurable (fun t => c / (γ t - z₀) ^ k)
+      (MeasureTheory.volume.restrict (Set.uIoc a b)) :=
+    (((hγ_aem.sub_const z₀).pow_const k).inv.const_mul c).congr
+      (Eventually.of_forall fun t => (div_eq_mul_inv c _).symm)
+  refine intervalIntegrable_truncated_mul_deriv (f := fun z => c / (z - z₀) ^ k)
+    (M := ‖c‖ / ε ^ k) hderiv_int
+    (aestronglyMeasurable_truncated hγ_cont ((h_polar_aem.mul
+      (intervalIntegrable_iff.mp hderiv_int).aestronglyMeasurable.aemeasurable
+      ).aestronglyMeasurable)) fun t h_far => ?_
+  rw [norm_div, norm_pow]
+  gcongr
 
 /-- **Off the truncation the integrand is a logarithmic derivative.** Where the curve stays
 further than `ε` from the centre `z₀`, the `ε`-truncated winding integrand agrees with the

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -11,7 +11,6 @@ import Mathlib.Analysis.Calculus.Deriv.Add
 import Mathlib.Analysis.Calculus.Deriv.Mul
 public import Mathlib.Analysis.Complex.Basic
 import Mathlib.Topology.Order.Compact
-import TauCeti.Analysis.Contour.Curve.Distance
 
 /-!
 # The Cauchy principal value of a contour integral at a point (Hungerbühler–Wasem)
@@ -56,7 +55,8 @@ versus `MeromorphicOn` (on a set).
 * `aestronglyMeasurable_truncated` and `intervalIntegrable_truncated_mul_deriv` — the two halves
   of integrability for a truncated integrand: measurability of the truncation, and domination by
   `M · ‖deriv γ‖` from a bound off the ball. `intervalIntegrable_pow_inv_mul_deriv_truncated`
-  applies both to the order-`k` polar integrand `c / (z - z₀) ^ k`.
+  applies both to the order-`k` polar integrand `c / (z - z₀) ^ k`, and
+  `intervalIntegrable_inv_sub_truncated` is its simple-pole case `c = 1`, `k = 1`.
 * `HasCauchyPVAt.intro` — build the predicate from its two clauses; `HasCauchyPVAt.tendsto`,
   `HasCauchyPVAt.eventually_intervalIntegrable` — the clauses as named accessors;
   `HasCauchyPVAt.cauchyPVAt_eq`, `HasCauchyPVAt.unique` — the value and its uniqueness;
@@ -98,7 +98,9 @@ Migrated and adapted from the AINTLIB `LeanModularForms` project, file
 the contour-integration roadmap, and strengthened with the truncated-integrability clause.
 `intervalIntegrable_pow_inv_mul_deriv_truncated` comes instead from the same development's
 `cpvIntegrand_higherOrder_intervalIntegrable`, in
-`ForMathlib/HungerbuhlerWasem/MultiCrossingCPV.lean`.
+`ForMathlib/HungerbuhlerWasem/MultiCrossingCPV.lean`, and its simple-pole case
+`intervalIntegrable_inv_sub_truncated` from `cpvIntegrand_inv_intervalIntegrable` in that
+development's `LocalCutoffs.lean`.
 
 ## References
 
@@ -175,24 +177,22 @@ theorem CauchyPVExistsAt.intro {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} 
 
 /-- **The `ε`-truncated integrand is a.e.-strongly measurable.** Truncating an a.e.-strongly
 measurable integrand to the parameters lying at distance `> ε` from `z₀` preserves a.e.-strong
-measurability: on `[[a, b]]` the truncation is the indicator of the complement of the closed set
-`{t ∈ [[a, b]] | ‖γ t - z₀‖ ≤ ε}` on which the curve stays near `z₀`. -/
+measurability: the truncation is the indicator of `{t | ε < ‖γ t - z₀‖}`, which is
+null-measurable as soon as `γ` is.
+
+The hypothesis on `γ` is a.e.-measurability rather than continuity, which is all the statement
+needs and is what lets the continuous-curve and merely-measurable-curve callers share it. -/
 theorem aestronglyMeasurable_truncated {γ F : ℝ → ℂ} {z₀ : ℂ} {a b ε : ℝ}
-    (hγ_cont : ContinuousOn γ (Set.uIcc a b))
+    (hγ : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)))
     (hF : MeasureTheory.AEStronglyMeasurable F (MeasureTheory.volume.restrict (Set.uIoc a b))) :
     MeasureTheory.AEStronglyMeasurable (fun t => if ‖γ t - z₀‖ > ε then F t else 0)
       (MeasureTheory.volume.restrict (Set.uIoc a b)) := by
-  have hK_closed : IsClosed {t ∈ Set.uIcc a b | ‖γ t - z₀‖ ≤ ε} :=
-    isClosed_setOfPred_mem_uIcc_norm_sub_le hγ_cont z₀ ε
-  refine (hF.indicator hK_closed.measurableSet.compl).congr ?_
-  filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_uIoc] with t ht
-  by_cases h_far : ‖γ t - z₀‖ > ε
-  · have h_mem : t ∈ {t ∈ Set.uIcc a b | ‖γ t - z₀‖ ≤ ε}ᶜ :=
-      fun hK => absurd hK.2 (not_le.mpr h_far)
-    rw [Set.indicator_of_mem h_mem, ite_eq_left h_far]
-  · have h_notMem : t ∉ {t ∈ Set.uIcc a b | ‖γ t - z₀‖ ≤ ε}ᶜ := fun hKc =>
-      hKc ⟨Set.uIoc_subset_uIcc ht, not_lt.mp h_far⟩
-    rw [Set.indicator_of_notMem h_notMem, ite_eq_right h_far]
+  have h : (fun t => if ‖γ t - z₀‖ > ε then F t else 0)
+      = {t | ε < ‖γ t - z₀‖}.indicator F := by
+    funext t
+    simp [Set.indicator_apply]
+  rw [h]
+  exact hF.indicator₀ (nullMeasurableSet_lt aemeasurable_const ((hγ.sub_const z₀).norm))
 
 /-- **The `ε`-truncated integrand is interval-integrable from a bound off the ball**: whenever
 `f ∘ γ` is bounded by `M` at distance `> ε` from `z₀` and the truncated integrand is
@@ -227,20 +227,31 @@ theorem intervalIntegrable_pow_inv_mul_deriv_truncated {γ : ℝ → ℂ} {z₀ 
       (fun t => if ‖γ t - z₀‖ > ε then c / (γ t - z₀) ^ k * deriv γ t else 0)
       MeasureTheory.volume a b := by
   have hγ_aem : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)) :=
-    ((hγ_cont.aestronglyMeasurable
-      (by rw [← Set.Icc_min_max]; exact measurableSet_Icc)).mono_measure
-      (MeasureTheory.Measure.restrict_mono Set.uIoc_subset_uIcc le_rfl)).aemeasurable
+    (hγ_cont.mono Set.uIoc_subset_uIcc).aemeasurable measurableSet_uIoc
   have h_polar_aem : AEMeasurable (fun t => c / (γ t - z₀) ^ k)
       (MeasureTheory.volume.restrict (Set.uIoc a b)) :=
     (((hγ_aem.sub_const z₀).pow_const k).inv.const_mul c).congr
       (Eventually.of_forall fun t => (div_eq_mul_inv c _).symm)
   refine intervalIntegrable_truncated_mul_deriv (f := fun z => c / (z - z₀) ^ k)
     (M := ‖c‖ / ε ^ k) hderiv_int
-    (aestronglyMeasurable_truncated hγ_cont ((h_polar_aem.mul
+    (aestronglyMeasurable_truncated hγ_aem ((h_polar_aem.mul
       (intervalIntegrable_iff.mp hderiv_int).aestronglyMeasurable.aemeasurable
       ).aestronglyMeasurable)) fun t h_far => ?_
   rw [norm_div, norm_pow]
   gcongr
+
+/-- The `ε`-truncated simple-pole integrand is interval-integrable: the simple pole is the
+order-`1` polar term with coefficient `1`, so this is
+`intervalIntegrable_pow_inv_mul_deriv_truncated` at `c = 1`, `k = 1`, where the domination bound
+reads `(1/ε) · ‖deriv γ‖`. -/
+theorem intervalIntegrable_inv_sub_truncated {γ : ℝ → ℂ} {z₀ : ℂ} {a b : ℝ}
+    (hγ_cont : ContinuousOn γ (Set.uIcc a b))
+    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
+    {ε : ℝ} (hε : 0 < ε) :
+    IntervalIntegrable (fun t => if ‖γ t - z₀‖ > ε then (γ t - z₀)⁻¹ * deriv γ t else 0)
+      MeasureTheory.volume a b := by
+  simpa using
+    intervalIntegrable_pow_inv_mul_deriv_truncated (z₀ := z₀) 1 1 hγ_cont hderiv_int hε
 
 /-- **Off the truncation the integrand is a logarithmic derivative.** Where the curve stays
 further than `ε` from the centre `z₀`, the `ε`-truncated winding integrand agrees with the

--- a/TauCeti/Analysis/Contour/Crossing/ExitWindow.lean
+++ b/TauCeti/Analysis/Contour/Crossing/ExitWindow.lean
@@ -10,7 +10,7 @@ public import TauCeti.Analysis.Contour.Crossing.FiniteExcision
 public import TauCeti.Analysis.Contour.ExitTime
 public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 import TauCeti.Analysis.Contour.InvSubCPVExistence
-import TauCeti.Analysis.Contour.PerWindow.CPV
+import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
 
 /-!
 # Equal-radius cap windows at crossings

--- a/TauCeti/Analysis/Contour/ModelSector/Corner.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/Corner.lean
@@ -216,10 +216,9 @@ theorem hasCauchyPVAt_inv_sub_twoRayCorner {z₀ u v : ℂ} (huv : ‖u‖ = ‖
         refine MeasureTheory.AEStronglyMeasurable.congr
           (f := fun t : ℝ => if ‖twoRayCorner z₀ u v t - z₀‖ > ε then
             (twoRayCorner z₀ u v t - z₀)⁻¹ * (if t < 0 then -u else v) else 0) ?_ ?_
-        · refine (Measurable.ite ?_ ?_ measurable_const).aestronglyMeasurable
-          · exact measurableSet_lt measurable_const
-              (((measurable_twoRayCorner z₀ u v).sub measurable_const).norm)
-          · exact (((measurable_twoRayCorner z₀ u v).sub measurable_const).inv).mul hstep
+        · exact aestronglyMeasurable_truncated (measurable_twoRayCorner z₀ u v).aemeasurable
+            ((((measurable_twoRayCorner z₀ u v).sub measurable_const).inv).mul
+              hstep).aestronglyMeasurable
         · filter_upwards [deriv_twoRayCorner_ae z₀ u v R] with s hs
           rw [hs]
       · intro s hs

--- a/TauCeti/Analysis/Contour/PerWindow/CPV.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/CPV.lean
@@ -41,16 +41,17 @@ externally by the window-boundary radii.
 * `Contour.perWindow_truncated_integral_tendsto` — the truncated window integral of the
   simple-pole integrand converges as `ε → 0⁺`, to the log-norm difference of the window
   boundary plus the boundary arguments.
-* `Contour.intervalIntegrable_inv_sub_truncated` — the truncated simple-pole integrand is
-  interval-integrable at every truncation level `ε > 0`.
 
 ## Provenance
 
 Migrated from `perCrossing_window_integral_tendsto_exact` and its supporting lemmas
-(`annular_log_diff_of_window`, `right/left_annular_log_diff_local`, `log_div_re_im_decomp`,
-`cpvIntegrand_inv_intervalIntegrable`) of `LocalCutoffs.lean` in the AINTLIB `LeanModularForms`
-development, restated for a raw curve on its crossing window. See N. Hungerbühler, M. Wasem,
-*Non-integer valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
+(`annular_log_diff_of_window`, `right/left_annular_log_diff_local`, `log_div_re_im_decomp`) of
+`LocalCutoffs.lean` in the AINTLIB `LeanModularForms` development, restated for a raw curve on
+its crossing window. The truncated-integrability lemma migrated alongside them,
+`cpvIntegrand_inv_intervalIntegrable`, lives with the rest of the truncation API in
+`Contour.Cauchy.PrincipalValue.Basic` as `intervalIntegrable_inv_sub_truncated`.
+See N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+Theorem*, arXiv:1808.00997, §3.
 -/
 
 public section
@@ -60,19 +61,6 @@ noncomputable section
 namespace TauCeti.Contour
 
 open Filter MeasureTheory Set Topology
-
-/-- The `ε`-truncated simple-pole integrand is interval-integrable: the simple pole is the
-order-`1` polar term with coefficient `1`, so this is
-`intervalIntegrable_pow_inv_mul_deriv_truncated` at `c = 1`, `k = 1`, where the domination bound
-reads `(1/ε) · ‖deriv γ‖`. -/
-theorem intervalIntegrable_inv_sub_truncated {γ : ℝ → ℂ} {s : ℂ} {a b : ℝ}
-    (hγ_cont : ContinuousOn γ (uIcc a b))
-    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
-    {ε : ℝ} (hε : 0 < ε) :
-    IntervalIntegrable (fun t => if ‖γ t - s‖ > ε then (γ t - s)⁻¹ * deriv γ t else 0)
-      MeasureTheory.volume a b := by
-  simpa using
-    intervalIntegrable_pow_inv_mul_deriv_truncated (z₀ := s) 1 1 hγ_cont hderiv_int hε
 
 /-- The winding integral is the log of the chord quotient on an ordered pole-free interval
 with the chord quotients anchored at the left endpoint in the slit plane: the `Icc`-hypothesis

--- a/TauCeti/Analysis/Contour/PerWindow/CPV.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/CPV.lean
@@ -9,7 +9,7 @@ public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import TauCeti.Analysis.Calculus.OneSidedDerivLimit
-import TauCeti.Analysis.Contour.Curve.Distance
+import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
 import TauCeti.Analysis.Contour.Chord.QuotientAsymptotics
 import TauCeti.Analysis.Contour.LogDerivFTC
 import TauCeti.Analysis.Contour.Winding.Number.Basic
@@ -61,50 +61,18 @@ namespace TauCeti.Contour
 
 open Filter MeasureTheory Set Topology
 
-/-- The `ε`-truncated simple-pole integrand is interval-integrable: off the `ε`-ball the
-integrand is dominated by `(1/ε) · ‖deriv γ‖`. -/
+/-- The `ε`-truncated simple-pole integrand is interval-integrable: the simple pole is the
+order-`1` polar term with coefficient `1`, so this is
+`intervalIntegrable_pow_inv_mul_deriv_truncated` at `c = 1`, `k = 1`, where the domination bound
+reads `(1/ε) · ‖deriv γ‖`. -/
 theorem intervalIntegrable_inv_sub_truncated {γ : ℝ → ℂ} {s : ℂ} {a b : ℝ}
     (hγ_cont : ContinuousOn γ (uIcc a b))
     (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
     {ε : ℝ} (hε : 0 < ε) :
     IntervalIntegrable (fun t => if ‖γ t - s‖ > ε then (γ t - s)⁻¹ * deriv γ t else 0)
       MeasureTheory.volume a b := by
-  have hK_closed : IsClosed {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε} :=
-    isClosed_setOfPred_mem_uIcc_norm_sub_le hγ_cont s ε
-  have h_inv_aesm : AEStronglyMeasurable (fun t => (γ t - s)⁻¹ * deriv γ t)
-      (MeasureTheory.volume.restrict (Set.uIoc a b)) := by
-    have hγ_aem : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)) :=
-      ((hγ_cont.aestronglyMeasurable (by rw [← Icc_min_max]; exact measurableSet_Icc)
-        ).mono_measure (Measure.restrict_mono Set.uIoc_subset_uIcc le_rfl)).aemeasurable
-    exact (((hγ_aem.sub_const s).inv).mul
-      (intervalIntegrable_iff.mp hderiv_int).aestronglyMeasurable.aemeasurable
-      ).aestronglyMeasurable
-  have h_aesm : AEStronglyMeasurable
-      (fun t => if ‖γ t - s‖ > ε then (γ t - s)⁻¹ * deriv γ t else 0)
-      (MeasureTheory.volume.restrict (Set.uIoc a b)) := by
-    refine (h_inv_aesm.indicator hK_closed.measurableSet.compl).congr ?_
-    filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_uIoc] with t ht
-    by_cases h_far : ‖γ t - s‖ > ε
-    · have h_mem : t ∈ {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε}ᶜ :=
-        fun hK => absurd hK.2 (not_le.mpr h_far)
-      rw [Set.indicator_of_mem h_mem, ite_eq_left h_far]
-    · have h_notMem : t ∉ {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε}ᶜ := fun hKc =>
-        hKc ⟨Set.uIoc_subset_uIcc ht, not_lt.mp h_far⟩
-      rw [Set.indicator_of_notMem h_notMem, ite_eq_right h_far]
-  refine ((hderiv_int.norm.const_mul (1 / ε)).mono_fun h_aesm ?_)
-  refine Eventually.of_forall fun t => ?_
-  -- β-reduce the two sides of the a.e. bound
-  change ‖if ‖γ t - s‖ > ε then (γ t - s)⁻¹ * deriv γ t else 0‖ ≤ ‖1 / ε * ‖deriv γ t‖‖
-  by_cases h_far : ‖γ t - s‖ > ε
-  · rw [ite_eq_left h_far, norm_mul, norm_inv]
-    calc ‖γ t - s‖⁻¹ * ‖deriv γ t‖
-        ≤ (1 / ε) * ‖deriv γ t‖ := by
-          rw [inv_eq_one_div]
-          exact mul_le_mul_of_nonneg_right
-            (one_div_le_one_div_of_le hε h_far.le) (norm_nonneg _)
-      _ ≤ ‖1 / ε * ‖deriv γ t‖‖ := le_abs_self _
-  · rw [ite_eq_right h_far, norm_zero]
-    positivity
+  simpa using
+    intervalIntegrable_pow_inv_mul_deriv_truncated (z₀ := s) 1 1 hγ_cont hderiv_int hε
 
 /-- The winding integral is the log of the chord quotient on an ordered pole-free interval
 with the chord quotients anchored at the left endpoint in the slit plane: the `Icc`-hypothesis

--- a/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
@@ -11,7 +11,6 @@ public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import TauCeti.Analysis.Contour.PiecewiseC1On
 public import TauCeti.Analysis.Contour.RegularityConditions
 import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
-import TauCeti.Analysis.Contour.Curve.Distance
 import TauCeti.Analysis.Calculus.OneSidedDerivLimit
 import TauCeti.Analysis.Contour.HigherOrder.Asymptotics
 import TauCeti.Analysis.Contour.SectorCancellation
@@ -48,16 +47,17 @@ coefficient in a residue theorem.
   order-`k` polar term along the curve, on an interval avoiding the pole.
 * `Contour.integral_pow_inv_mul_deriv_eq_zero_of_closed` — the same term integrates to zero
   around a *closed* piecewise-`C¹` curve missing the pole, the endpoint difference cancelling.
-* `Contour.intervalIntegrable_pow_inv_mul_deriv_truncated` — the truncated order-`k` polar
-  integrand is interval-integrable at every truncation level `ε > 0`.
 
 ## Provenance
 
 Migrated from `perCrossing_higherOrder_window_integral_tendsto_corner` and its supporting
-lemmas (`pow_inv_mul_deriv_intervalIntegrable`, `cpvIntegrand_higherOrder_intervalIntegrable`,
-`antiderivPow_FTC_on_avoiding`) of `MultiCrossingCPV.lean` in the AINTLIB `LeanModularForms`
-development, restated for a raw curve on its crossing window. See N. Hungerbühler, M. Wasem,
-*Non-integer valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, §3.
+lemmas (`pow_inv_mul_deriv_intervalIntegrable`, `antiderivPow_FTC_on_avoiding`) of
+`MultiCrossingCPV.lean` in the AINTLIB `LeanModularForms` development, restated for a raw curve
+on its crossing window. The truncated-integrability lemma migrated alongside them,
+`cpvIntegrand_higherOrder_intervalIntegrable`, lives with the rest of the truncation API in
+`Contour.Cauchy.PrincipalValue.Basic` as `intervalIntegrable_pow_inv_mul_deriv_truncated`.
+See N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+Theorem*, arXiv:1808.00997, §3.
 -/
 
 public section
@@ -80,46 +80,6 @@ private theorem intervalIntegrable_pow_inv_mul_deriv {γ : ℝ → ℂ} {s : ℂ
   rw [uIcc_of_le hlu]
   exact continuousOn_const.div ((hγ_cont.sub continuousOn_const).pow k)
     fun t ht => pow_ne_zero k (sub_ne_zero.mpr (h_ne t ht))
-
-/-- The `ε`-truncated order-`k` polar integrand is interval-integrable: off the `ε`-ball it is
-dominated by `(‖c‖ / ε^k) · ‖deriv γ‖`. -/
-theorem intervalIntegrable_pow_inv_mul_deriv_truncated {γ : ℝ → ℂ} {s : ℂ} {a b : ℝ}
-    (c : ℂ) (k : ℕ) (hγ_cont : ContinuousOn γ (uIcc a b))
-    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
-    {ε : ℝ} (hε : 0 < ε) :
-    IntervalIntegrable
-      (fun t => if ‖γ t - s‖ > ε then c / (γ t - s) ^ k * deriv γ t else 0)
-      MeasureTheory.volume a b := by
-  have hK_closed : IsClosed {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε} :=
-    isClosed_setOfPred_mem_uIcc_norm_sub_le hγ_cont s ε
-  have h_fn_aesm : AEStronglyMeasurable (fun t => c / (γ t - s) ^ k * deriv γ t)
-      (MeasureTheory.volume.restrict (Set.uIoc a b)) := by
-    have hγ_aem : AEMeasurable γ (MeasureTheory.volume.restrict (Set.uIoc a b)) :=
-      ((hγ_cont.aestronglyMeasurable (by rw [← Icc_min_max]; exact measurableSet_Icc)
-        ).mono_measure (Measure.restrict_mono Set.uIoc_subset_uIcc le_rfl)).aemeasurable
-    have h1 : AEMeasurable (fun t => c / (γ t - s) ^ k)
-        (MeasureTheory.volume.restrict (Set.uIoc a b)) :=
-      (((hγ_aem.sub_const s).pow_const k).inv.const_mul c).congr
-        (Eventually.of_forall fun t => (div_eq_mul_inv c _).symm)
-    exact (h1.mul
-      (intervalIntegrable_iff.mp hderiv_int).aestronglyMeasurable.aemeasurable
-      ).aestronglyMeasurable
-  have h_aesm : AEStronglyMeasurable
-      (fun t => if ‖γ t - s‖ > ε then c / (γ t - s) ^ k * deriv γ t else 0)
-      (MeasureTheory.volume.restrict (Set.uIoc a b)) := by
-    refine (h_fn_aesm.indicator hK_closed.measurableSet.compl).congr ?_
-    filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_uIoc] with t ht
-    by_cases h_far : ‖γ t - s‖ > ε
-    · have h_mem : t ∈ {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε}ᶜ :=
-        fun hK => absurd hK.2 (not_le.mpr h_far)
-      rw [Set.indicator_of_mem h_mem, ite_eq_left h_far]
-    · have h_notMem : t ∉ {t ∈ uIcc a b | ‖γ t - s‖ ≤ ε}ᶜ := fun hKc =>
-        hKc ⟨Set.uIoc_subset_uIcc ht, not_lt.mp h_far⟩
-      rw [Set.indicator_of_notMem h_notMem, ite_eq_right h_far]
-  refine intervalIntegrable_truncated_mul_deriv (f := fun z => c / (z - s) ^ k)
-    (M := ‖c‖ / ε ^ k) hderiv_int h_aesm fun t h_far => ?_
-  rw [norm_div, norm_pow]
-  gcongr
 
 /-- The fundamental theorem of calculus for the order-`k` polar term along the curve, on an
 interval avoiding the pole: the integral is the boundary difference of the antiderivative

--- a/TauCeti/Analysis/Contour/PolarPart/Decomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPart/Decomposition.lean
@@ -321,21 +321,16 @@ theorem intervalIntegrable_polarPart_mul_deriv_truncated (decomp : PolarPartDeco
       MeasureTheory.volume a b := by
   classical
   set M : ℝ := ∑ k : Fin (decomp.order s), ‖decomp.coeff s k‖ / ε ^ (k.val + 1) with hM_def
-  have h_meas : Measurable (fun t =>
-      if ‖γ t - (s : ℂ)‖ > ε then decomp.polarPart s (γ t) * deriv γ t else 0) := by
-    have hA : MeasurableSet {t : ℝ | ε < ‖γ t - (s : ℂ)‖} :=
-      measurableSet_lt measurable_const ((hγ_meas.sub_const _).norm)
-    refine Measurable.ite hA ?_ measurable_const
-    have h_polar : Measurable fun t => decomp.polarPart s (γ t) := by
-      have h_eq : (fun t => decomp.polarPart s (γ t)) = fun t =>
-          ∑ k : Fin (decomp.order s), decomp.coeff s k / (γ t - (s : ℂ)) ^ (k.val + 1) :=
-        funext fun t => decomp.polarPart_eq s (γ t)
-      rw [h_eq]
-      exact Finset.measurable_sum _ fun k _ =>
-        (((hγ_meas.sub_const _).pow_const _).const_div _)
-    exact h_polar.mul (measurable_deriv _)
-  refine intervalIntegrable_truncated_mul_deriv (f := decomp.polarPart s) (M := M)
-    hderiv_int h_meas.aestronglyMeasurable fun t h_far => ?_
+  have h_polar : Measurable fun t => decomp.polarPart s (γ t) := by
+    have h_eq : (fun t => decomp.polarPart s (γ t)) = fun t =>
+        ∑ k : Fin (decomp.order s), decomp.coeff s k / (γ t - (s : ℂ)) ^ (k.val + 1) :=
+      funext fun t => decomp.polarPart_eq s (γ t)
+    rw [h_eq]
+    exact Finset.measurable_sum _ fun k _ =>
+      (((hγ_meas.sub_const _).pow_const _).const_div _)
+  refine intervalIntegrable_truncated_mul_deriv (f := decomp.polarPart s) (M := M) hderiv_int
+    (aestronglyMeasurable_truncated hγ_meas.aemeasurable
+      (h_polar.mul (measurable_deriv _)).aestronglyMeasurable) fun t h_far => ?_
   rw [decomp.polarPart_eq s (γ t), hM_def]
   refine (norm_sum_le _ _).trans (Finset.sum_le_sum fun k _ => ?_)
   rw [norm_div, norm_pow]

--- a/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingAngleSum.lean
@@ -12,6 +12,7 @@ public import TauCeti.Analysis.Contour.Winding.Number.Basic
 import TauCeti.Analysis.Contour.Argument.Lift
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.InvSubCPVExistence
+import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
 import TauCeti.Analysis.Contour.PerWindow.CPV
 import TauCeti.Analysis.Contour.Winding.EndpointRatio
 

--- a/TauCeti/Analysis/Contour/Winding/Number/Segment/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Segment/Basic.lean
@@ -80,9 +80,7 @@ private theorem hasCauchyPVAt_inv_sub_ofReal (R : ℝ) :
       (f := fun z : ℂ => (z - 0)⁻¹) (z₀ := 0) (M := ε⁻¹) ?_ ?_ ?_
     · simp [Complex.ofRealCLM.deriv, Complex.ofRealCLM_apply]
     · simp only [Complex.ofRealCLM.deriv, Complex.ofRealCLM_apply]
-      refine (Measurable.ite ?_ ?_ measurable_const).aestronglyMeasurable
-      · exact measurableSet_lt measurable_const (by fun_prop)
-      · fun_prop
+      exact aestronglyMeasurable_truncated (by fun_prop) (by fun_prop)
     · intro t ht
       rw [norm_inv]
       gcongr

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral/OnCurve.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral/OnCurve.lean
@@ -13,7 +13,7 @@ import TauCeti.Analysis.Contour.Crossing.Finiteness
 import TauCeti.Analysis.Contour.Crossing.PVAggregation
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.InvSubCPVExistence
-import TauCeti.Analysis.Contour.PerWindow.CPV
+import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
 public import TauCeti.Analysis.Contour.Winding.LipschitzBoundedIntegrand
 import TauCeti.Analysis.Contour.Winding.SegmentSum
 import TauCeti.Analysis.Contour.Winding.PrincipalValueRealIntegral


### PR DESCRIPTION
Roadmap: ContourIntegration

The ε-truncated contour integrand's interval-integrability was being argued from scratch in five
places. This names the shared step once and points every site at it.

`intervalIntegrable_truncated_mul_deriv` (in `Cauchy/PrincipalValue/Basic.lean`) already packages
the *domination* half of truncated integrability, but every caller had to supply the
*measurability* half itself — and five of them wrote out the same argument:
`PerWindow/CPV.lean`, `PerWindow/HigherOrder.lean`, `PolarPart/Decomposition.lean`,
`ModelSector/Corner.lean` and `Winding/Number/Segment/Basic.lean`. On top of that, a simple pole
is just the order-`k` polar term at `c = 1`, `k = 1`, so two of those five were the same theorem
twice.

* **`Contour.aestronglyMeasurable_truncated`** (new) — truncating an a.e.-strongly-measurable
  integrand to the parameters at distance `> ε` from `z₀` keeps it a.e.-strongly measurable. It
  is stated from `AEMeasurable γ`, not from continuity: the content is measure-theoretic, and the
  weaker hypothesis is what lets the merely-measurable-curve sites share it. Two lines, over
  `AEStronglyMeasurable.indicator₀` and `nullMeasurableSet_lt`.
* **`intervalIntegrable_pow_inv_mul_deriv_truncated` moves** from `PerWindow/HigherOrder.lean`
  into the principal-value file, reproved as measurability + domination. It was stated in the
  per-window file "for its own sake"; it is a fact about the truncation, not about the window
  limit.
* **`intervalIntegrable_inv_sub_truncated` follows it**, as the `c = 1`, `k = 1` instance. It now
  depends on no per-window theory, and two of its consumers (`Crossing/ExitWindow.lean`,
  `Winding/RealIntegral/OnCurve.lean`) were importing the whole window development for it and
  nothing else; they now import the principal-value file directly.
* **Three further copies collapse**: `PolarPart/Decomposition.lean`, `ModelSector/Corner.lean`
  and `Winding/Number/Segment/Basic.lean` each hand-rolled the `Measurable.ite` /
  `measurableSet_lt` plumbing and now call the named lemma.

No statement changes for consumers: every call site passes positionally, so the binder renames
`{s : ℂ} → {z₀ : ℂ}` (adopted for consistency with every other declaration in the file the two
lemmas move into) are invisible. All three module docstrings track the moves, including the
AINTLIB provenance for `cpvIntegrand_higherOrder_intervalIntegrable` and
`cpvIntegrand_inv_intervalIntegrable`, which follow the lemmas they attribute. `Curve/Distance`
is no longer imported anywhere it is unused.

Net −8 lines across 8 files, with five hand-rolled measurability arguments replaced by one named
lemma and one duplicate theorem removed outright.

Found by the 2026-08-24 dedup sweep as finding P04; the three extra sites and the
measure-theoretic hypothesis came from round 1 review (reuse, generality, placement).
