### PR TITLE
feat: classify real Clifford algebras modulo eight

### DIFF
--- a/TauCeti/Algebra/BrauerGroup/Basic.lean
+++ b/TauCeti/Algebra/BrauerGroup/Basic.lean
@@ -59,7 +59,7 @@ it is Mathlib's Kronecker product of matrix algebras, `Matrix.kroneckerTMulAlgEq
 is indexed by `Fin m × Fin n`, transported along `finProdFinEquiv` to the `Fin (m * n)` indexing
 that `IsBrauerEquivalent` is stated in. Since neither central simplicity nor positivity of the
 sizes enters, it is stated in that generality first, as
-`TauCeti.Matrix.kroneckerTMulFinAlgEquiv`, over any commutative semiring and any two algebras
+`Matrix.kroneckerTMulFinAlgEquiv`, over any commutative semiring and any two algebras
 over it; `TauCeti.CSA.tensorProductMatrixAlgEquiv` is the bundled `CSA` reading that Brauer
 equivalence consumes. Everything about the tensor product below is a consequence of it and of the
 transport `Algebra.TensorProduct.congr`.
@@ -78,7 +78,7 @@ moved. This is not a restriction in practice: `BrauerGroup K` is the interesting
   `TauCeti.CSA.base K` is `K` itself.
 * `TauCeti.CSA.matrix A n` and `TauCeti.CSA.tensorProduct A B`: `Mₙ(A)` and `A ⊗[K] B` as terms
   of `CSA K`. The underlying type of each is the expected one by definition.
-* `TauCeti.Matrix.kroneckerTMulFinAlgEquiv`: matrix absorption
+* `Matrix.kroneckerTMulFinAlgEquiv`: matrix absorption
   `Mₘ(A) ⊗[R] Mₙ(B) ≃ₐ[R] M_{mn}(A ⊗[R] B)` for arbitrary algebras and sizes, and
   `TauCeti.CSA.tensorProductMatrixAlgEquiv`, its bundled `CSA` reading.
 
@@ -185,7 +185,7 @@ variable {K}
 
 /-- **Matrix absorption** for central simple algebras:
 `Mₘ(A) ⊗[K] Mₙ(B) ≃ₐ[K] M_{mn}(A ⊗[K] B)` as an isomorphism of terms of `CSA K`. This is
-`TauCeti.Matrix.kroneckerTMulFinAlgEquiv`, read through the constructors `TauCeti.CSA.matrix` and
+`Matrix.kroneckerTMulFinAlgEquiv`, read through the constructors `TauCeti.CSA.matrix` and
 `TauCeti.CSA.tensorProduct`, whose underlying types are the expected ones by definition. -/
 def CSA.tensorProductMatrixAlgEquiv (A B : CSA.{u, v} K) (m n : ℕ) [NeZero m] [NeZero n] :
     CSA.tensorProduct (CSA.matrix A m) (CSA.matrix B n) ≃ₐ[K]

--- a/TauCeti/Algebra/BrauerGroup/Basic.lean
+++ b/TauCeti/Algebra/BrauerGroup/Basic.lean
@@ -22,13 +22,10 @@ public import Mathlib.Algebra.BrauerGroup.Defs
 -- what bundles `Mₙ(A)` as a term of `CSA K`.
 public import Mathlib.Algebra.Central.Matrix
 public import Mathlib.RingTheory.SimpleRing.Matrix
--- Mathlib's Kronecker product of matrix algebras is the body of
--- `TauCeti.Matrix.kroneckerTMulFinAlgEquiv`, and a compiled definition may not refer to a
--- privately imported one, so this import is public too. It re-exports
--- `Mathlib.Data.Matrix.Composition` and `Mathlib.RingTheory.TensorProduct.Maps`, hence the two
--- further equivalences used in the proofs below, `Matrix.compAlgEquiv` and
--- `Algebra.TensorProduct.congr`, which is why neither is imported again here.
-public import Mathlib.RingTheory.MatrixAlgebra
+-- The finite-index Kronecker equivalence used by the Brauer constructions below. It re-exports
+-- `Mathlib.RingTheory.MatrixAlgebra`, hence `Matrix.compAlgEquiv` and
+-- `Algebra.TensorProduct.congr` are also available here.
+public import TauCeti.LinearAlgebra.Matrix.TensorProduct
 
 /-!
 # Brauer equivalence: bundling central simple algebras, matrices, and the tensor product
@@ -183,19 +180,6 @@ theorem isBrauerEquivalent_matrix_congr {A B : CSA.{u, v} K} (h : IsBrauerEquiva
   ((isBrauerEquivalent_matrix K A m).trans h).trans (isBrauerEquivalent_matrix K B n).symm
 
 /-! ### Matrix absorption -/
-
-/-- **Matrix absorption**: `Mₘ(A) ⊗[R] Mₙ(B) ≃ₐ[R] M_{mn}(A ⊗[R] B)`, over any commutative
-semiring `R` and any two `R`-algebras, in any two sizes.
-
-Neither central simplicity nor positivity of the sizes plays any part, so neither is assumed;
-`TauCeti.CSA.tensorProductMatrixAlgEquiv` is the bundled reading that Brauer equivalence
-consumes. -/
-def Matrix.kroneckerTMulFinAlgEquiv (m n : ℕ) (R : Type*) [CommSemiring R] (A : Type*) [Semiring A]
-    [Algebra R A] (B : Type*) [Semiring B] [Algebra R B] :
-    Matrix (Fin m) (Fin m) A ⊗[R] Matrix (Fin n) (Fin n) B ≃ₐ[R]
-      Matrix (Fin (m * n)) (Fin (m * n)) (A ⊗[R] B) :=
-  (Matrix.kroneckerTMulAlgEquiv (Fin m) (Fin n) R R A B).trans
-    (Matrix.reindexAlgEquiv R _ finProdFinEquiv)
 
 variable {K}
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/BottPeriodicity.lean
@@ -10,7 +10,7 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.SignSwitch
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Prod
 public import Mathlib.RingTheory.MatrixAlgebra
 
-import Mathlib.LinearAlgebra.Matrix.Unique
+import TauCeti.LinearAlgebra.Matrix.TensorProduct
 -- Private: `CliffordAlgebra.prod_map_ι_mul_ι_of_even_length` is used only inside the proof of
 -- `CliffordAlgebra.hyperbolicVolume_anticomm_rightGenerator`.
 import TauCeti.LinearAlgebra.CliffordAlgebra.VolumeElement
@@ -477,8 +477,7 @@ private def tensorMatrixMulEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Al
 
 private def tensorMatrixOneEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A] :
     A ≃ₐ[R] A ⊗[R] Matrix (Fin 1) (Fin 1) R :=
-  ((Matrix.uniqueAlgEquiv (R := R) (A := A) (m := Unit)).symm.trans
-      (Matrix.reindexAlgEquiv R A (Equiv.ofUnique Unit (Fin 1)))).trans
+  (Matrix.finOneAlgEquiv R A).trans
     (matrixEquivTensor (Fin 1) R A)
 
 private noncomputable def realCliffordBottIterEquivImpl (p q : ℕ) : (n : ℕ) →
@@ -557,7 +556,8 @@ theorem realCliffordBottIterEquiv_zero_apply (p q : ℕ)
   -- Expose the zero branch of the private recursive implementation.
   change tensorMatrixOneEquiv ℝ (_root_.CliffordAlgebra (realCliffordForm p q)) x = _
   rw [tensorMatrixOneEquiv, AlgEquiv.trans_apply, matrixEquivTensor_apply,
-    Fintype.sum_prod_type, Fin.sum_univ_one, Fin.sum_univ_one]
+    Fintype.sum_prod_type, Fin.sum_univ_one, Fin.sum_univ_one,
+    Matrix.finOneAlgEquiv_apply]
   -- The unfolded tensor equivalence leaves the unique matrix unit to identify with `1`.
   change x ⊗ₜ[ℝ] Matrix.single 0 0 1 = x ⊗ₜ[ℝ] 1
   congr 1

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
@@ -9,6 +9,8 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.EightPeriodicity
 
 import Mathlib.RingTheory.TensorProduct.Pi
 import Mathlib.LinearAlgebra.Matrix.Unique
+import Mathlib.LinearAlgebra.CliffordAlgebra.Equivs
+import Mathlib.Algebra.Module.Equiv.Basic
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import TauCeti.Algebra.CentralSimple.Quaternion
 import TauCeti.Algebra.CentralSimple.Splitting
@@ -46,24 +48,20 @@ private abbrev C (p q : ℕ) :=
 def realCliffordResidue (p q : ℕ) : ℕ :=
   (q + 8 - p % 8) % 8
 
-private theorem realCliffordResidue_eq_proof (p q : ℕ) :
-    realCliffordResidue p q = (q + 8 - p % 8) % 8 :=
-  rfl
-
 /-- The defining formula for `realCliffordResidue`. -/
-theorem realCliffordResidue_eq (p q : ℕ) :
+theorem realCliffordResidue_def (p q : ℕ) :
     realCliffordResidue p q = (q + 8 - p % 8) % 8 :=
-  realCliffordResidue_eq_proof p q
+  (rfl)
 
 /-- The real Clifford residue is one of the eight table indices. -/
 theorem realCliffordResidue_lt_eight (p q : ℕ) : realCliffordResidue p q < 8 := by
-  rw [realCliffordResidue_eq]
+  rw [realCliffordResidue_def]
   exact Nat.mod_lt _ (by norm_num)
 
 @[simp]
-theorem realCliffordResidue_add_both (p q n : ℕ) :
+theorem realCliffordResidue_add_add_right (p q n : ℕ) :
     realCliffordResidue (p + n) (q + n) = realCliffordResidue p q := by
-  simp only [realCliffordResidue_eq]
+  simp only [realCliffordResidue_def]
   omega
 
 /-- The exact real algebra classification of the standard Clifford algebra of signature `(p,q)`.
@@ -121,16 +119,18 @@ theorem isRealCliffordClassified_iff (p q : ℕ) :
   · exact IsRealCliffordClassified.intro
 
 private noncomputable def realCliffordZeroZeroEquiv :
-    _root_.CliffordAlgebra (realCliffordForm 0 0) ≃ₐ[ℝ] ℝ :=
-  AlgEquiv.ofAlgHom
-    (_root_.CliffordAlgebra.lift (realCliffordForm 0 0)
-      ⟨0, fun v ↦ by
+    _root_.CliffordAlgebra (realCliffordForm 0 0) ≃ₐ[ℝ] ℝ := by
+  letI : Subsingleton (Fin (0 + 0) → ℝ) :=
+    ⟨fun f g ↦ funext fun i ↦ Fin.elim0 i⟩
+  exact (CliffordAlgebra.equivOfIsometry
+    (QuadraticMap.IsometryEquiv.mk
+      (LinearEquiv.ofSubsingleton (Fin (0 + 0) → ℝ) Unit)
+      (by
+        intro v
         have hv : v = 0 := funext fun i ↦ Fin.elim0 i
         subst v
-        simp⟩)
-    (Algebra.ofId ℝ _)
-    (by ext)
-    (by ext v; exact Fin.elim0 v)
+        simp))).trans
+    CliffordAlgebraRing.equiv
 
 private def prodTensorAlgebraEquiv (R A B : Type*) [CommSemiring R]
     [Semiring A] [Semiring B] [Algebra R A] [Algebra R B] :
@@ -223,7 +223,7 @@ private theorem pow_half_sub_add_eight (n d : ℕ) (h : d ≤ n) :
   rw [hdiv, pow_add]
   norm_num
 
-private theorem pow_half_sub_add_both (p q n d : ℕ) (h : d ≤ p + q) :
+private theorem pow_half_sub_add_add_right (p q n d : ℕ) (h : d ≤ p + q) :
     2 ^ ((p + q - d) / 2) * 2 ^ n =
       2 ^ (((p + n) + (q + n) - d) / 2) := by
   rw [← pow_add]
@@ -406,10 +406,10 @@ private theorem realClifford_negativeAxis_classification (q : ℕ) :
         (by simpa only [Nat.reducePow, Nat.zero_add] using
           pow_half_sub_mul_pow n 1 1 (n + 1) (by omega))⟩
 
-private theorem realCliffordClassification_add_both (p q n : ℕ)
+private theorem isRealCliffordClassified_add_add_right (p q n : ℕ)
     (h : IsRealCliffordClassified p q) :
     IsRealCliffordClassified (p + n) (q + n) := by
-  rw [isRealCliffordClassified_iff, realCliffordResidue_add_both]
+  rw [isRealCliffordClassified_iff, realCliffordResidue_add_add_right]
   rw [isRealCliffordClassified_iff] at h
   generalize hr : realCliffordResidue p q = r at h
   have hrlt : r < 8 := by
@@ -419,38 +419,38 @@ private theorem realCliffordClassification_add_both (p q n : ℕ)
   all_goals obtain ⟨e⟩ := h
   · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
       (matrixEquivTensor (Fin (2 ^ n)) ℝ ℝ).symm
-      (pow_half_sub_add_both p q n 0 (by omega))⟩
+      (pow_half_sub_add_add_right p q n 0 (by omega))⟩
   · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
       (matrixEquivTensor (Fin (2 ^ n)) ℝ ℂ).symm
-      (pow_half_sub_add_both p q n 1 (by simp [realCliffordResidue] at hr; omega))⟩
+      (pow_half_sub_add_add_right p q n 1 (by simp [realCliffordResidue] at hr; omega))⟩
   · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
       (matrixEquivTensor (Fin (2 ^ n)) ℝ ℍ[ℝ]).symm
-      (pow_half_sub_add_both p q n 2 (by simp [realCliffordResidue] at hr; omega))⟩
+      (pow_half_sub_add_add_right p q n 2 (by simp [realCliffordResidue] at hr; omega))⟩
   · exact ⟨matrixProdModelTensorEquiv (realCliffordBottIterEquiv p q n) e
       (matrixEquivTensor (Fin (2 ^ n)) ℝ ℍ[ℝ]).symm
-      (pow_half_sub_add_both p q n 3 (by simp [realCliffordResidue] at hr; omega))⟩
+      (pow_half_sub_add_add_right p q n 3 (by simp [realCliffordResidue] at hr; omega))⟩
   · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
       (matrixEquivTensor (Fin (2 ^ n)) ℝ ℍ[ℝ]).symm
-      (pow_half_sub_add_both p q n 2 (by simp [realCliffordResidue] at hr; omega))⟩
+      (pow_half_sub_add_add_right p q n 2 (by simp [realCliffordResidue] at hr; omega))⟩
   · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
       (matrixEquivTensor (Fin (2 ^ n)) ℝ ℂ).symm
-      (pow_half_sub_add_both p q n 1 (by simp [realCliffordResidue] at hr; omega))⟩
+      (pow_half_sub_add_add_right p q n 1 (by simp [realCliffordResidue] at hr; omega))⟩
   · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
       (matrixEquivTensor (Fin (2 ^ n)) ℝ ℝ).symm
-      (pow_half_sub_add_both p q n 0 (by omega))⟩
+      (pow_half_sub_add_add_right p q n 0 (by omega))⟩
   · exact ⟨matrixProdModelTensorEquiv (realCliffordBottIterEquiv p q n) e
       (matrixEquivTensor (Fin (2 ^ n)) ℝ ℝ).symm
-      (pow_half_sub_add_both p q n 1 (by simp [realCliffordResidue] at hr; omega))⟩
+      (pow_half_sub_add_add_right p q n 1 (by simp [realCliffordResidue] at hr; omega))⟩
 
 /-- The real Clifford algebra of every finite signature is the full matrix algebra, complex
 matrix algebra, quaternionic matrix algebra, or split algebra prescribed by `(q - p) mod 8`. -/
 theorem realClifford_classification (p q : ℕ) :
     IsRealCliffordClassified p q := by
   rcases le_total p q with hpq | hqp
-  · have h := realCliffordClassification_add_both 0 (q - p) p
+  · have h := isRealCliffordClassified_add_add_right 0 (q - p) p
       (realClifford_negativeAxis_classification (q - p))
     simpa [Nat.sub_add_cancel hpq] using h
-  · have h := realCliffordClassification_add_both (p - q) 0 q
+  · have h := isRealCliffordClassified_add_add_right (p - q) 0 q
       (realClifford_positiveAxis_classification (p - q))
     simpa [Nat.sub_add_cancel hqp] using h
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
@@ -188,6 +188,11 @@ private def castMatrixProdTargetEquiv {R S A : Type*} [CommSemiring R]
     S ≃ₐ[R] Matrix (Fin n) (Fin n) A × Matrix (Fin n) (Fin n) A :=
   h ▸ e
 
+private theorem pow_half_sub_add_eight (n d : ℕ) (h : d ≤ n) :
+    2 ^ ((n + 8 - d) / 2) = 2 ^ ((n - d) / 2) * 16 := by
+  rw [show (n + 8 - d) / 2 = (n - d) / 2 + 4 by omega, pow_add]
+  norm_num
+
 private noncomputable def realCliffordPositiveZeroEquiv :
     C 0 0 ≃ₐ[ℝ] Matrix (Fin 1) (Fin 1) ℝ :=
   realCliffordZeroZeroEquiv.trans (matrixOneEquiv ℝ ℝ)
@@ -296,69 +301,25 @@ private theorem realClifford_positiveAxis_classification (p : ℕ) :
             tsub_zero, Nat.mod_self, Nat.add_zero, Nat.add_mod_right, Nat.add_one_sub_one,
             Nat.mod_succ, Nat.reduceSub, Nat.reduceMod, Nat.one_mod] at prev ⊢
         all_goals obtain ⟨e⟩ := prev
-        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
-          refine (Algebra.TensorProduct.congr e
-            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
-          have hsize : 2 ^ ((n + 8) / 2) = 2 ^ (n / 2) * 16 := by
-            rw [show (n + 8) / 2 = n / 2 + 4 by omega, pow_add]
-            norm_num
-          exact castMatrixTargetEquiv hsize.symm
+        all_goals
+          refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans
+            ((Algebra.TensorProduct.congr e
+              (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_)⟩
+        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 0 (by omega)).symm
             (matrixTensorMatrixEquiv ℝ ℝ (2 ^ (n / 2)) 16)
-        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
-          refine (Algebra.TensorProduct.congr e
-            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
-          have hsize : 2 ^ ((n + 8 - 1) / 2) = 2 ^ ((n - 1) / 2) * 16 := by
-            rw [show (n + 8 - 1) / 2 = (n - 1) / 2 + 4 by omega, pow_add]
-            norm_num
-          exact castMatrixProdTargetEquiv hsize.symm
+        · exact castMatrixProdTargetEquiv (pow_half_sub_add_eight n 1 (by omega)).symm
             (matrixProdTensorMatrixEquiv ℝ ℝ (2 ^ ((n - 1) / 2)) 16)
-        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
-          refine (Algebra.TensorProduct.congr e
-            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
-          have hsize : 2 ^ ((n + 8) / 2) = 2 ^ (n / 2) * 16 := by
-            rw [show (n + 8) / 2 = n / 2 + 4 by omega, pow_add]
-            norm_num
-          exact castMatrixTargetEquiv hsize.symm
+        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 0 (by omega)).symm
             (matrixTensorMatrixEquiv ℝ ℝ (2 ^ (n / 2)) 16)
-        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
-          refine (Algebra.TensorProduct.congr e
-            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
-          have hsize : 2 ^ ((n + 8 - 1) / 2) = 2 ^ ((n - 1) / 2) * 16 := by
-            rw [show (n + 8 - 1) / 2 = (n - 1) / 2 + 4 by omega, pow_add]
-            norm_num
-          exact castMatrixTargetEquiv hsize.symm
+        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 1 (by omega)).symm
             (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((n - 1) / 2)) 16)
-        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
-          refine (Algebra.TensorProduct.congr e
-            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
-          have hsize : 2 ^ ((n + 8 - 2) / 2) = 2 ^ ((n - 2) / 2) * 16 := by
-            rw [show (n + 8 - 2) / 2 = (n - 2) / 2 + 4 by omega, pow_add]
-            norm_num
-          exact castMatrixTargetEquiv hsize.symm
+        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 2 (by omega)).symm
             (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((n - 2) / 2)) 16)
-        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
-          refine (Algebra.TensorProduct.congr e
-            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
-          have hsize : 2 ^ ((n + 8 - 3) / 2) = 2 ^ ((n - 3) / 2) * 16 := by
-            rw [show (n + 8 - 3) / 2 = (n - 3) / 2 + 4 by omega, pow_add]
-            norm_num
-          exact castMatrixProdTargetEquiv hsize.symm
+        · exact castMatrixProdTargetEquiv (pow_half_sub_add_eight n 3 (by omega)).symm
             (matrixProdTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((n - 3) / 2)) 16)
-        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
-          refine (Algebra.TensorProduct.congr e
-            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
-          have hsize : 2 ^ ((n + 8 - 2) / 2) = 2 ^ ((n - 2) / 2) * 16 := by
-            rw [show (n + 8 - 2) / 2 = (n - 2) / 2 + 4 by omega, pow_add]
-            norm_num
-          exact castMatrixTargetEquiv hsize.symm
+        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 2 (by omega)).symm
             (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((n - 2) / 2)) 16)
-        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
-          refine (Algebra.TensorProduct.congr e
-            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
-          have hsize : 2 ^ ((n + 8 - 1) / 2) = 2 ^ ((n - 1) / 2) * 16 := by
-            rw [show (n + 8 - 1) / 2 = (n - 1) / 2 + 4 by omega, pow_add]
-            norm_num
-          exact castMatrixTargetEquiv hsize.symm
+        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 1 (by omega)).symm
             (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((n - 1) / 2)) 16)
 
 private theorem realClifford_negativeAxis_classification (q : ℕ) :
@@ -376,56 +337,43 @@ private theorem realClifford_negativeAxis_classification (q : ℕ) :
         Nat.reduceAdd, Nat.reduceMod, Nat.add_one_sub_one, Nat.add_succ_sub_one,
         Nat.mod_succ] at prev ⊢
     all_goals obtain ⟨e⟩ := prev
-    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
-      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
-      have hsize : 2 ^ (n / 2) = 2 ^ ((0 + (n + 1 + 1) - 2) / 2) := by
+    all_goals
+      refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans
+        ((Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_)⟩
+    · have hsize : 2 ^ (n / 2) = 2 ^ ((0 + (n + 1 + 1) - 2) / 2) := by
         congr 1
         omega
       exact castMatrixTargetEquiv hsize (realMatrixTensorQuaternionEquiv (2 ^ (n / 2)))
-    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
-      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
-      have hsize : 2 ^ ((n - 1) / 2) = 2 ^ ((0 + (n + 1 + 1) - 3) / 2) := by
+    · have hsize : 2 ^ ((n - 1) / 2) = 2 ^ ((0 + (n + 1 + 1) - 3) / 2) := by
         congr 1
         omega
       exact castMatrixProdTargetEquiv hsize
         (realMatrixProdTensorQuaternionEquiv (2 ^ ((n - 1) / 2)))
-    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
-      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
-      have hsize : 2 ^ (n / 2) = 2 ^ ((0 + (n + 1 + 1) - 2) / 2) := by
+    · have hsize : 2 ^ (n / 2) = 2 ^ ((0 + (n + 1 + 1) - 2) / 2) := by
         congr 1
         omega
       exact castMatrixTargetEquiv hsize (realMatrixTensorQuaternionEquiv (2 ^ (n / 2)))
-    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
-      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
-      have hsize : 2 ^ ((n - 1) / 2) * 2 = 2 ^ ((0 + (n + 1)) / 2) := by
+    · have hsize : 2 ^ ((n - 1) / 2) * 2 = 2 ^ ((0 + (n + 1)) / 2) := by
         rw [show (0 + (n + 1)) / 2 = (n - 1) / 2 + 1 by omega, pow_add]
         norm_num
       exact castMatrixTargetEquiv hsize
         (complexMatrixTensorQuaternionEquiv (2 ^ ((n - 1) / 2)))
-    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
-      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
-      have hsize : 2 ^ ((n - 2) / 2) * 4 = 2 ^ ((0 + (n + 1 + 1)) / 2) := by
+    · have hsize : 2 ^ ((n - 2) / 2) * 4 = 2 ^ ((0 + (n + 1 + 1)) / 2) := by
         rw [show (0 + (n + 1 + 1)) / 2 = (n - 2) / 2 + 2 by omega, pow_add]
         norm_num
       exact castMatrixTargetEquiv hsize
         (quaternionMatrixTensorQuaternionEquiv (2 ^ ((n - 2) / 2)))
-    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
-      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
-      have hsize : 2 ^ ((n - 3) / 2) * 4 = 2 ^ ((0 + (n + 1)) / 2) := by
+    · have hsize : 2 ^ ((n - 3) / 2) * 4 = 2 ^ ((0 + (n + 1)) / 2) := by
         rw [show (0 + (n + 1)) / 2 = (n - 3) / 2 + 2 by omega, pow_add]
         norm_num
       exact castMatrixProdTargetEquiv hsize
         (quaternionMatrixProdTensorQuaternionEquiv (2 ^ ((n - 3) / 2)))
-    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
-      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
-      have hsize : 2 ^ ((n - 2) / 2) * 4 = 2 ^ ((0 + (n + 1 + 1)) / 2) := by
+    · have hsize : 2 ^ ((n - 2) / 2) * 4 = 2 ^ ((0 + (n + 1 + 1)) / 2) := by
         rw [show (0 + (n + 1 + 1)) / 2 = (n - 2) / 2 + 2 by omega, pow_add]
         norm_num
       exact castMatrixTargetEquiv hsize
         (quaternionMatrixTensorQuaternionEquiv (2 ^ ((n - 2) / 2)))
-    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
-      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
-      have hsize : 2 ^ ((n - 1) / 2) * 2 = 2 ^ ((0 + (n + 1)) / 2) := by
+    · have hsize : 2 ^ ((n - 1) / 2) * 2 = 2 ^ ((0 + (n + 1)) / 2) := by
         rw [show (0 + (n + 1)) / 2 = (n - 1) / 2 + 1 by omega, pow_add]
         norm_num
       exact castMatrixTargetEquiv hsize
@@ -442,19 +390,17 @@ private theorem realCliffordClassification_add_both (p q n : ℕ)
     exact Nat.mod_lt _ (by norm_num)
   interval_cases r <;> simp only at h ⊢
   all_goals obtain ⟨e⟩ := h
-  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
-    refine (Algebra.TensorProduct.congr e
-      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
-    have hsize : 2 ^ ((p + q) / 2) * 2 ^ n = 2 ^ (((p + n) + (q + n)) / 2) := by
+  all_goals
+    refine ⟨(realCliffordBottIterEquiv p q n).trans
+      ((Algebra.TensorProduct.congr e
+        (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_)⟩
+  · have hsize : 2 ^ ((p + q) / 2) * 2 ^ n = 2 ^ (((p + n) + (q + n)) / 2) := by
       rw [← pow_add]
       congr 1
       omega
     exact castMatrixTargetEquiv hsize
       (matrixTensorMatrixEquiv ℝ ℝ (2 ^ ((p + q) / 2)) (2 ^ n))
-  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
-    refine (Algebra.TensorProduct.congr e
-      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
-    have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
+  · have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
         2 ^ (((p + n) + (q + n) - 1) / 2) := by
       rw [← pow_add]
       congr 1
@@ -462,10 +408,7 @@ private theorem realCliffordClassification_add_both (p q n : ℕ)
       omega
     exact castMatrixTargetEquiv hsize
       (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((p + q - 1) / 2)) (2 ^ n))
-  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
-    refine (Algebra.TensorProduct.congr e
-      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
-    have hsize : 2 ^ ((p + q - 2) / 2) * 2 ^ n =
+  · have hsize : 2 ^ ((p + q - 2) / 2) * 2 ^ n =
         2 ^ (((p + n) + (q + n) - 2) / 2) := by
       rw [← pow_add]
       congr 1
@@ -473,10 +416,7 @@ private theorem realCliffordClassification_add_both (p q n : ℕ)
       omega
     exact castMatrixTargetEquiv hsize
       (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((p + q - 2) / 2)) (2 ^ n))
-  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
-    refine (Algebra.TensorProduct.congr e
-      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
-    have hsize : 2 ^ ((p + q - 3) / 2) * 2 ^ n =
+  · have hsize : 2 ^ ((p + q - 3) / 2) * 2 ^ n =
         2 ^ (((p + n) + (q + n) - 3) / 2) := by
       rw [← pow_add]
       congr 1
@@ -484,10 +424,7 @@ private theorem realCliffordClassification_add_both (p q n : ℕ)
       omega
     exact castMatrixProdTargetEquiv hsize
       (matrixProdTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((p + q - 3) / 2)) (2 ^ n))
-  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
-    refine (Algebra.TensorProduct.congr e
-      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
-    have hsize : 2 ^ ((p + q - 2) / 2) * 2 ^ n =
+  · have hsize : 2 ^ ((p + q - 2) / 2) * 2 ^ n =
         2 ^ (((p + n) + (q + n) - 2) / 2) := by
       rw [← pow_add]
       congr 1
@@ -495,10 +432,7 @@ private theorem realCliffordClassification_add_both (p q n : ℕ)
       omega
     exact castMatrixTargetEquiv hsize
       (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((p + q - 2) / 2)) (2 ^ n))
-  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
-    refine (Algebra.TensorProduct.congr e
-      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
-    have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
+  · have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
         2 ^ (((p + n) + (q + n) - 1) / 2) := by
       rw [← pow_add]
       congr 1
@@ -506,19 +440,13 @@ private theorem realCliffordClassification_add_both (p q n : ℕ)
       omega
     exact castMatrixTargetEquiv hsize
       (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((p + q - 1) / 2)) (2 ^ n))
-  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
-    refine (Algebra.TensorProduct.congr e
-      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
-    have hsize : 2 ^ ((p + q) / 2) * 2 ^ n = 2 ^ (((p + n) + (q + n)) / 2) := by
+  · have hsize : 2 ^ ((p + q) / 2) * 2 ^ n = 2 ^ (((p + n) + (q + n)) / 2) := by
       rw [← pow_add]
       congr 1
       omega
     exact castMatrixTargetEquiv hsize
       (matrixTensorMatrixEquiv ℝ ℝ (2 ^ ((p + q) / 2)) (2 ^ n))
-  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
-    refine (Algebra.TensorProduct.congr e
-      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
-    have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
+  · have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
         2 ^ (((p + n) + (q + n) - 1) / 2) := by
       rw [← pow_add]
       congr 1

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
@@ -1,0 +1,542 @@
+/-
+Copyright (c) 2026 Tau Ceti Project. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.EightPeriodicity
+
+import Mathlib.RingTheory.TensorProduct.Pi
+import Mathlib.LinearAlgebra.Matrix.Unique
+import Mathlib.Analysis.Complex.Polynomial.Basic
+import TauCeti.Algebra.BrauerGroup.Basic
+import TauCeti.Algebra.CentralSimple.Quaternion
+import TauCeti.Algebra.CentralSimple.Splitting
+
+/-!
+# Classification of real Clifford algebras
+
+The signature recurrences reduce every standard real Clifford algebra to one of eight matrix,
+complex, quaternionic, or split matrix models.
+
+## Main results
+
+* `realCliffordResidue` records `(q - p) mod 8` without integer coercions.
+* `RealCliffordClassification` states the exact algebra in each residue class.
+* `realClifford_classification` proves the classification for every signature.
+
+## References
+
+* C. Chevalley, *The Algebraic Theory of Spinors*.
+* H. B. Lawson and M.-L. Michelsohn, *Spin Geometry*, Chapter I.
+-/
+
+public section
+
+open scoped Matrix Quaternion TensorProduct
+
+namespace TauCeti
+
+private abbrev C (p q : ℕ) :=
+  _root_.CliffordAlgebra (realCliffordForm p q)
+
+/-- The residue `q - p` modulo eight, represented as a natural number in `[0, 8)`. -/
+def realCliffordResidue (p q : ℕ) : ℕ :=
+  (q + 8 - p % 8) % 8
+
+@[simp]
+private theorem realCliffordResidue_add_both (p q n : ℕ) :
+    realCliffordResidue (p + n) (q + n) = realCliffordResidue p q := by
+  simp only [realCliffordResidue]
+  omega
+
+/-- The exact real algebra classification of the standard Clifford algebra of signature `(p,q)`.
+The matrix size is stated uniformly in terms of the total dimension. -/
+def RealCliffordClassification (p q : ℕ) : Prop :=
+  match realCliffordResidue p q with
+  | 0 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ)
+  | 1 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℂ)
+  | 2 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 2) / 2))) (Fin (2 ^ ((p + q - 2) / 2))) ℍ[ℝ])
+  | 3 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 3) / 2))) (Fin (2 ^ ((p + q - 3) / 2))) ℍ[ℝ] ×
+        Matrix (Fin (2 ^ ((p + q - 3) / 2))) (Fin (2 ^ ((p + q - 3) / 2))) ℍ[ℝ])
+  | 4 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 2) / 2))) (Fin (2 ^ ((p + q - 2) / 2))) ℍ[ℝ])
+  | 5 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℂ)
+  | 6 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ)
+  | 7 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ ×
+        Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ)
+  | _ => False
+
+private noncomputable def realCliffordZeroZeroEquiv :
+    _root_.CliffordAlgebra (realCliffordForm 0 0) ≃ₐ[ℝ] ℝ :=
+  AlgEquiv.ofAlgHom
+    (_root_.CliffordAlgebra.lift (realCliffordForm 0 0)
+      ⟨0, fun v ↦ by
+        have hv : v = 0 := funext fun i ↦ Fin.elim0 i
+        subst v
+        simp⟩)
+    (Algebra.ofId ℝ _)
+    (by ext)
+    (by ext v; exact Fin.elim0 v)
+
+private def matrixOneEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A] :
+    A ≃ₐ[R] Matrix (Fin 1) (Fin 1) A :=
+  (Matrix.uniqueAlgEquiv (R := R) (A := A) (m := Unit)).symm.trans
+    (Matrix.reindexAlgEquiv R A (Equiv.ofUnique Unit (Fin 1)))
+
+private def matrixTensorMatrixEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A]
+    (m n : ℕ) :
+    Matrix (Fin m) (Fin m) A ⊗[R] Matrix (Fin n) (Fin n) R ≃ₐ[R]
+      Matrix (Fin (m * n)) (Fin (m * n)) A :=
+  (Matrix.kroneckerTMulFinAlgEquiv m n R A R).trans
+    (Algebra.TensorProduct.rid R R A).mapMatrix
+
+private def prodTensorAlgebraEquiv (R A B : Type*) [CommSemiring R]
+    [Semiring A] [Semiring B] [Algebra R A] [Algebra R B] :
+    (A × A) ⊗[R] B ≃ₐ[R] (A ⊗[R] B) × (A ⊗[R] B) :=
+  (Algebra.TensorProduct.comm R _ _).trans <|
+    (Algebra.TensorProduct.prodRight R R B A A).trans <|
+    AlgEquiv.prodCongr (Algebra.TensorProduct.comm R B A)
+      (Algebra.TensorProduct.comm R B A)
+
+private def matrixProdTensorMatrixEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A]
+    (m n : ℕ) :
+    (Matrix (Fin m) (Fin m) A × Matrix (Fin m) (Fin m) A) ⊗[R]
+        Matrix (Fin n) (Fin n) R ≃ₐ[R]
+      Matrix (Fin (m * n)) (Fin (m * n)) A ×
+        Matrix (Fin (m * n)) (Fin (m * n)) A :=
+  (prodTensorAlgebraEquiv R (Matrix (Fin m) (Fin m) A)
+    (Matrix (Fin n) (Fin n) R)).trans <|
+    AlgEquiv.prodCongr (matrixTensorMatrixEquiv R A m n) (matrixTensorMatrixEquiv R A m n)
+
+private noncomputable def complexTensorQuaternionEquiv :
+    ℂ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℂ := by
+  have hdeg : Algebra.deg ℝ ℍ[ℝ] = 2 :=
+    Algebra.deg_eq_of_finrank_eq_sq (by rw [Quaternion.finrank_eq_four]; norm_num)
+  let e : ℂ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℂ] Matrix (Fin 2) (Fin 2) ℂ :=
+    Classical.choice <| hdeg ▸
+      (Algebra.isSplittingField_of_isSepClosed ℝ ℍ[ℝ] ℂ).nonempty_algEquiv_matrix_deg ..
+  exact e.restrictScalars ℝ
+
+private def matrixTensorAlgebraEquiv (R A B : Type*) [CommSemiring R]
+    [Semiring A] [Semiring B] [Algebra R A] [Algebra R B] (m : ℕ) :
+    Matrix (Fin m) (Fin m) A ⊗[R] B ≃ₐ[R]
+      Matrix (Fin m) (Fin m) (A ⊗[R] B) :=
+  (Algebra.TensorProduct.congr (AlgEquiv.refl : Matrix (Fin m) (Fin m) A ≃ₐ[R] _)
+    (matrixOneEquiv R B)).trans <|
+  (Matrix.kroneckerTMulFinAlgEquiv m 1 R A B).trans <|
+  Matrix.reindexAlgEquiv R _ (finCongr (Nat.mul_one m))
+
+private def flattenMatrixEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A]
+    (m n : ℕ) :
+    Matrix (Fin m) (Fin m) (Matrix (Fin n) (Fin n) A) ≃ₐ[R]
+      Matrix (Fin (m * n)) (Fin (m * n)) A :=
+  (Matrix.compAlgEquiv (Fin m) (Fin n) A R).trans
+    (Matrix.reindexAlgEquiv R A finProdFinEquiv)
+
+private noncomputable def realMatrixTensorQuaternionEquiv (m : ℕ) :
+    Matrix (Fin m) (Fin m) ℝ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
+      Matrix (Fin m) (Fin m) ℍ[ℝ] :=
+  (matrixTensorAlgebraEquiv ℝ ℝ ℍ[ℝ] m).trans
+    (Algebra.TensorProduct.lid ℝ ℍ[ℝ]).mapMatrix
+
+private noncomputable def complexMatrixTensorQuaternionEquiv (m : ℕ) :
+    Matrix (Fin m) (Fin m) ℂ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
+      Matrix (Fin (m * 2)) (Fin (m * 2)) ℂ :=
+  (matrixTensorAlgebraEquiv ℝ ℂ ℍ[ℝ] m).trans <|
+    complexTensorQuaternionEquiv.mapMatrix.trans <| flattenMatrixEquiv ℝ ℂ m 2
+
+private noncomputable def quaternionMatrixTensorQuaternionEquiv (m : ℕ) :
+    Matrix (Fin m) (Fin m) ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
+      Matrix (Fin (m * 4)) (Fin (m * 4)) ℝ :=
+  (matrixTensorAlgebraEquiv ℝ ℍ[ℝ] ℍ[ℝ] m).trans <|
+    Quaternion.tensorSelfAlgEquivMatrix.mapMatrix.trans <| flattenMatrixEquiv ℝ ℝ m 4
+
+private noncomputable def realMatrixProdTensorQuaternionEquiv (m : ℕ) :
+    (Matrix (Fin m) (Fin m) ℝ × Matrix (Fin m) (Fin m) ℝ) ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
+      Matrix (Fin m) (Fin m) ℍ[ℝ] × Matrix (Fin m) (Fin m) ℍ[ℝ] :=
+  (prodTensorAlgebraEquiv ℝ (Matrix (Fin m) (Fin m) ℝ) ℍ[ℝ]).trans <|
+    AlgEquiv.prodCongr (realMatrixTensorQuaternionEquiv m)
+      (realMatrixTensorQuaternionEquiv m)
+
+private noncomputable def quaternionMatrixProdTensorQuaternionEquiv (m : ℕ) :
+    (Matrix (Fin m) (Fin m) ℍ[ℝ] × Matrix (Fin m) (Fin m) ℍ[ℝ]) ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
+      Matrix (Fin (m * 4)) (Fin (m * 4)) ℝ ×
+        Matrix (Fin (m * 4)) (Fin (m * 4)) ℝ :=
+  (prodTensorAlgebraEquiv ℝ (Matrix (Fin m) (Fin m) ℍ[ℝ]) ℍ[ℝ]).trans <|
+    AlgEquiv.prodCongr (quaternionMatrixTensorQuaternionEquiv m)
+      (quaternionMatrixTensorQuaternionEquiv m)
+
+private def castMatrixTargetEquiv {R S A : Type*} [CommSemiring R]
+    [Semiring S] [Semiring A] [Algebra R S] [Algebra R A] {m n : ℕ} (h : m = n)
+    (e : S ≃ₐ[R] Matrix (Fin m) (Fin m) A) :
+    S ≃ₐ[R] Matrix (Fin n) (Fin n) A :=
+  h ▸ e
+
+private def castMatrixProdTargetEquiv {R S A : Type*} [CommSemiring R]
+    [Semiring S] [Semiring A] [Algebra R S] [Algebra R A] {m n : ℕ} (h : m = n)
+    (e : S ≃ₐ[R]
+      Matrix (Fin m) (Fin m) A × Matrix (Fin m) (Fin m) A) :
+    S ≃ₐ[R] Matrix (Fin n) (Fin n) A × Matrix (Fin n) (Fin n) A :=
+  h ▸ e
+
+private noncomputable def realCliffordPositiveZeroEquiv :
+    C 0 0 ≃ₐ[ℝ] Matrix (Fin 1) (Fin 1) ℝ :=
+  realCliffordZeroZeroEquiv.trans (matrixOneEquiv ℝ ℝ)
+
+private noncomputable def realCliffordPositiveOneEquiv :
+    C 1 0 ≃ₐ[ℝ]
+      Matrix (Fin 1) (Fin 1) ℝ × Matrix (Fin 1) (Fin 1) ℝ :=
+  realCliffordOneZeroEquivProd.trans <|
+    AlgEquiv.prodCongr (matrixOneEquiv ℝ ℝ) (matrixOneEquiv ℝ ℝ)
+
+private noncomputable def realCliffordPositiveTwoEquiv :
+    C 2 0 ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
+  (realCliffordSignatureSwitchRecurrenceEquiv 0 0).trans <|
+    (Algebra.TensorProduct.congr realCliffordZeroZeroEquiv
+      (AlgEquiv.refl : Matrix (Fin 2) (Fin 2) ℝ ≃ₐ[ℝ] _)).trans <|
+    Algebra.TensorProduct.lid ℝ _
+
+private noncomputable def realCliffordPositiveThreeEquiv :
+    C 3 0 ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℂ :=
+  (realCliffordSignatureSwitchRecurrenceEquiv 1 0).trans <|
+    (Algebra.TensorProduct.congr realCliffordZeroOneEquivComplex
+      (AlgEquiv.refl : Matrix (Fin 2) (Fin 2) ℝ ≃ₐ[ℝ] _)).trans <|
+    (matrixEquivTensor (Fin 2) ℝ ℂ).symm
+
+private noncomputable def realCliffordPositiveFourEquiv :
+    C 4 0 ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℍ[ℝ] :=
+  (realCliffordSignatureSwitchRecurrenceEquiv 2 0).trans <|
+    (Algebra.TensorProduct.congr realCliffordZeroTwoEquivQuaternion
+      (AlgEquiv.refl : Matrix (Fin 2) (Fin 2) ℝ ≃ₐ[ℝ] _)).trans <|
+    (matrixEquivTensor (Fin 2) ℝ ℍ[ℝ]).symm
+
+private noncomputable def realCliffordZeroThreeEquiv :
+    C 0 3 ≃ₐ[ℝ]
+      Matrix (Fin 1) (Fin 1) ℍ[ℝ] × Matrix (Fin 1) (Fin 1) ℍ[ℝ] :=
+  (realCliffordQuaternionRecurrenceEquiv 0 1).trans <|
+    (Algebra.TensorProduct.congr realCliffordOneZeroEquivProd
+      (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans <|
+    (prodTensorAlgebraEquiv ℝ ℝ ℍ[ℝ]).trans <|
+    AlgEquiv.prodCongr
+      ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
+      ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
+
+private noncomputable def realCliffordPositiveFiveEquiv :
+    C 5 0 ≃ₐ[ℝ]
+      Matrix (Fin 2) (Fin 2) ℍ[ℝ] × Matrix (Fin 2) (Fin 2) ℍ[ℝ] :=
+  (realCliffordSignatureSwitchRecurrenceEquiv 3 0).trans <|
+    (Algebra.TensorProduct.congr realCliffordZeroThreeEquiv
+      (AlgEquiv.refl : Matrix (Fin 2) (Fin 2) ℝ ≃ₐ[ℝ] _)).trans <|
+    matrixProdTensorMatrixEquiv ℝ ℍ[ℝ] 1 2
+
+private noncomputable def realCliffordZeroFourEquiv :
+    C 0 4 ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℍ[ℝ] :=
+  (realCliffordQuaternionRecurrenceEquiv 0 2).trans <|
+    (Algebra.TensorProduct.congr realCliffordPositiveTwoEquiv
+      (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans <|
+    realMatrixTensorQuaternionEquiv 2
+
+private noncomputable def realCliffordPositiveSixEquiv :
+    C 6 0 ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℍ[ℝ] :=
+  (realCliffordSignatureSwitchRecurrenceEquiv 4 0).trans <|
+    (Algebra.TensorProduct.congr realCliffordZeroFourEquiv
+      (AlgEquiv.refl : Matrix (Fin 2) (Fin 2) ℝ ≃ₐ[ℝ] _)).trans <|
+    matrixTensorMatrixEquiv ℝ ℍ[ℝ] 2 2
+
+private noncomputable def realCliffordZeroFiveEquiv :
+    C 0 5 ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℂ :=
+  (realCliffordQuaternionRecurrenceEquiv 0 3).trans <|
+    (Algebra.TensorProduct.congr realCliffordPositiveThreeEquiv
+      (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans <|
+    complexMatrixTensorQuaternionEquiv 2
+
+private noncomputable def realCliffordPositiveSevenEquiv :
+    C 7 0 ≃ₐ[ℝ] Matrix (Fin 8) (Fin 8) ℂ :=
+  (realCliffordSignatureSwitchRecurrenceEquiv 5 0).trans <|
+    (Algebra.TensorProduct.congr realCliffordZeroFiveEquiv
+      (AlgEquiv.refl : Matrix (Fin 2) (Fin 2) ℝ ≃ₐ[ℝ] _)).trans <|
+    matrixTensorMatrixEquiv ℝ ℂ 4 2
+
+private theorem realClifford_positiveAxis_base (p : ℕ) (hp : p < 8) :
+    RealCliffordClassification p 0 := by
+  interval_cases p <;>
+    simp only [RealCliffordClassification, realCliffordResidue, zero_add, Nat.zero_mod,
+      tsub_zero, Nat.mod_self, Nat.add_zero, Nat.reduceDiv, Nat.pow_zero, Nat.one_mod,
+      Nat.add_one_sub_one, Nat.mod_succ, Nat.reduceMod, Nat.reduceSub, Nat.reducePow] <;>
+    first
+    | exact ⟨realCliffordPositiveZeroEquiv⟩
+    | exact ⟨realCliffordPositiveOneEquiv⟩
+    | exact ⟨realCliffordPositiveTwoEquiv⟩
+    | exact ⟨realCliffordPositiveThreeEquiv⟩
+    | exact ⟨realCliffordPositiveFourEquiv⟩
+    | exact ⟨realCliffordPositiveFiveEquiv⟩
+    | exact ⟨realCliffordPositiveSixEquiv⟩
+    | exact ⟨realCliffordPositiveSevenEquiv⟩
+
+private theorem realClifford_positiveAxis_classification (p : ℕ) :
+    RealCliffordClassification p 0 := by
+  induction p using Nat.strong_induction_on with
+  | h p ih =>
+      by_cases hp : p < 8
+      · exact realClifford_positiveAxis_base p hp
+      · obtain ⟨n, rfl⟩ : ∃ n, p = n + 8 := ⟨p - 8, by omega⟩
+        have prev := ih n (by omega)
+        have hmod : n % 8 < 8 := Nat.mod_lt _ (by norm_num)
+        interval_cases hn : n % 8 <;>
+          simp only [RealCliffordClassification, realCliffordResidue, zero_add, hn,
+            tsub_zero, Nat.mod_self, Nat.add_zero, Nat.add_mod_right, Nat.add_one_sub_one,
+            Nat.mod_succ, Nat.reduceSub, Nat.reduceMod, Nat.one_mod] at prev ⊢
+        all_goals obtain ⟨e⟩ := prev
+        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
+          refine (Algebra.TensorProduct.congr e
+            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
+          have hsize : 2 ^ ((n + 8) / 2) = 2 ^ (n / 2) * 16 := by
+            rw [show (n + 8) / 2 = n / 2 + 4 by omega, pow_add]
+            norm_num
+          exact castMatrixTargetEquiv hsize.symm
+            (matrixTensorMatrixEquiv ℝ ℝ (2 ^ (n / 2)) 16)
+        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
+          refine (Algebra.TensorProduct.congr e
+            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
+          have hsize : 2 ^ ((n + 8 - 1) / 2) = 2 ^ ((n - 1) / 2) * 16 := by
+            rw [show (n + 8 - 1) / 2 = (n - 1) / 2 + 4 by omega, pow_add]
+            norm_num
+          exact castMatrixProdTargetEquiv hsize.symm
+            (matrixProdTensorMatrixEquiv ℝ ℝ (2 ^ ((n - 1) / 2)) 16)
+        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
+          refine (Algebra.TensorProduct.congr e
+            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
+          have hsize : 2 ^ ((n + 8) / 2) = 2 ^ (n / 2) * 16 := by
+            rw [show (n + 8) / 2 = n / 2 + 4 by omega, pow_add]
+            norm_num
+          exact castMatrixTargetEquiv hsize.symm
+            (matrixTensorMatrixEquiv ℝ ℝ (2 ^ (n / 2)) 16)
+        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
+          refine (Algebra.TensorProduct.congr e
+            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
+          have hsize : 2 ^ ((n + 8 - 1) / 2) = 2 ^ ((n - 1) / 2) * 16 := by
+            rw [show (n + 8 - 1) / 2 = (n - 1) / 2 + 4 by omega, pow_add]
+            norm_num
+          exact castMatrixTargetEquiv hsize.symm
+            (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((n - 1) / 2)) 16)
+        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
+          refine (Algebra.TensorProduct.congr e
+            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
+          have hsize : 2 ^ ((n + 8 - 2) / 2) = 2 ^ ((n - 2) / 2) * 16 := by
+            rw [show (n + 8 - 2) / 2 = (n - 2) / 2 + 4 by omega, pow_add]
+            norm_num
+          exact castMatrixTargetEquiv hsize.symm
+            (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((n - 2) / 2)) 16)
+        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
+          refine (Algebra.TensorProduct.congr e
+            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
+          have hsize : 2 ^ ((n + 8 - 3) / 2) = 2 ^ ((n - 3) / 2) * 16 := by
+            rw [show (n + 8 - 3) / 2 = (n - 3) / 2 + 4 by omega, pow_add]
+            norm_num
+          exact castMatrixProdTargetEquiv hsize.symm
+            (matrixProdTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((n - 3) / 2)) 16)
+        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
+          refine (Algebra.TensorProduct.congr e
+            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
+          have hsize : 2 ^ ((n + 8 - 2) / 2) = 2 ^ ((n - 2) / 2) * 16 := by
+            rw [show (n + 8 - 2) / 2 = (n - 2) / 2 + 4 by omega, pow_add]
+            norm_num
+          exact castMatrixTargetEquiv hsize.symm
+            (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((n - 2) / 2)) 16)
+        · refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans ?_⟩
+          refine (Algebra.TensorProduct.congr e
+            (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_
+          have hsize : 2 ^ ((n + 8 - 1) / 2) = 2 ^ ((n - 1) / 2) * 16 := by
+            rw [show (n + 8 - 1) / 2 = (n - 1) / 2 + 4 by omega, pow_add]
+            norm_num
+          exact castMatrixTargetEquiv hsize.symm
+            (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((n - 1) / 2)) 16)
+
+private theorem realClifford_negativeAxis_classification (q : ℕ) :
+    RealCliffordClassification 0 q := by
+  rcases q with _ | _ | n
+  · exact realClifford_positiveAxis_classification 0
+  · simp only [RealCliffordClassification, realCliffordResidue, zero_add, Nat.reduceAdd,
+      Nat.zero_mod, tsub_zero, Nat.reduceMod, Nat.add_one_sub_one, Nat.reduceDiv, Nat.pow_zero]
+    exact ⟨realCliffordZeroOneEquivComplex.trans (matrixOneEquiv ℝ ℂ)⟩
+  · have prev := realClifford_positiveAxis_classification n
+    have hmod : n % 8 < 8 := Nat.mod_lt _ (by norm_num)
+    interval_cases hn : n % 8 <;>
+      simp only [RealCliffordClassification, realCliffordResidue, zero_add, hn, tsub_zero,
+        Nat.mod_self, Nat.add_zero, Nat.zero_mod, Nat.add_mod_right, Nat.add_mod, Nat.one_mod,
+        Nat.reduceAdd, Nat.reduceMod, Nat.add_one_sub_one, Nat.add_succ_sub_one,
+        Nat.mod_succ] at prev ⊢
+    all_goals obtain ⟨e⟩ := prev
+    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
+      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
+      have hsize : 2 ^ (n / 2) = 2 ^ ((0 + (n + 1 + 1) - 2) / 2) := by
+        congr 1
+        omega
+      exact castMatrixTargetEquiv hsize (realMatrixTensorQuaternionEquiv (2 ^ (n / 2)))
+    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
+      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
+      have hsize : 2 ^ ((n - 1) / 2) = 2 ^ ((0 + (n + 1 + 1) - 3) / 2) := by
+        congr 1
+        omega
+      exact castMatrixProdTargetEquiv hsize
+        (realMatrixProdTensorQuaternionEquiv (2 ^ ((n - 1) / 2)))
+    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
+      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
+      have hsize : 2 ^ (n / 2) = 2 ^ ((0 + (n + 1 + 1) - 2) / 2) := by
+        congr 1
+        omega
+      exact castMatrixTargetEquiv hsize (realMatrixTensorQuaternionEquiv (2 ^ (n / 2)))
+    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
+      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
+      have hsize : 2 ^ ((n - 1) / 2) * 2 = 2 ^ ((0 + (n + 1)) / 2) := by
+        rw [show (0 + (n + 1)) / 2 = (n - 1) / 2 + 1 by omega, pow_add]
+        norm_num
+      exact castMatrixTargetEquiv hsize
+        (complexMatrixTensorQuaternionEquiv (2 ^ ((n - 1) / 2)))
+    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
+      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
+      have hsize : 2 ^ ((n - 2) / 2) * 4 = 2 ^ ((0 + (n + 1 + 1)) / 2) := by
+        rw [show (0 + (n + 1 + 1)) / 2 = (n - 2) / 2 + 2 by omega, pow_add]
+        norm_num
+      exact castMatrixTargetEquiv hsize
+        (quaternionMatrixTensorQuaternionEquiv (2 ^ ((n - 2) / 2)))
+    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
+      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
+      have hsize : 2 ^ ((n - 3) / 2) * 4 = 2 ^ ((0 + (n + 1)) / 2) := by
+        rw [show (0 + (n + 1)) / 2 = (n - 3) / 2 + 2 by omega, pow_add]
+        norm_num
+      exact castMatrixProdTargetEquiv hsize
+        (quaternionMatrixProdTensorQuaternionEquiv (2 ^ ((n - 3) / 2)))
+    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
+      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
+      have hsize : 2 ^ ((n - 2) / 2) * 4 = 2 ^ ((0 + (n + 1 + 1)) / 2) := by
+        rw [show (0 + (n + 1 + 1)) / 2 = (n - 2) / 2 + 2 by omega, pow_add]
+        norm_num
+      exact castMatrixTargetEquiv hsize
+        (quaternionMatrixTensorQuaternionEquiv (2 ^ ((n - 2) / 2)))
+    · refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans ?_⟩
+      refine (Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_
+      have hsize : 2 ^ ((n - 1) / 2) * 2 = 2 ^ ((0 + (n + 1)) / 2) := by
+        rw [show (0 + (n + 1)) / 2 = (n - 1) / 2 + 1 by omega, pow_add]
+        norm_num
+      exact castMatrixTargetEquiv hsize
+        (complexMatrixTensorQuaternionEquiv (2 ^ ((n - 1) / 2)))
+
+private theorem realCliffordClassification_add_both (p q n : ℕ)
+    (h : RealCliffordClassification p q) :
+    RealCliffordClassification (p + n) (q + n) := by
+  rw [RealCliffordClassification, realCliffordResidue_add_both]
+  rw [RealCliffordClassification] at h
+  generalize hr : realCliffordResidue p q = r at h
+  have hrlt : r < 8 := by
+    rw [← hr]
+    exact Nat.mod_lt _ (by norm_num)
+  interval_cases r <;> simp only at h ⊢
+  all_goals obtain ⟨e⟩ := h
+  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
+    refine (Algebra.TensorProduct.congr e
+      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
+    have hsize : 2 ^ ((p + q) / 2) * 2 ^ n = 2 ^ (((p + n) + (q + n)) / 2) := by
+      rw [← pow_add]
+      congr 1
+      omega
+    exact castMatrixTargetEquiv hsize
+      (matrixTensorMatrixEquiv ℝ ℝ (2 ^ ((p + q) / 2)) (2 ^ n))
+  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
+    refine (Algebra.TensorProduct.congr e
+      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
+    have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
+        2 ^ (((p + n) + (q + n) - 1) / 2) := by
+      rw [← pow_add]
+      congr 1
+      simp [realCliffordResidue] at hr
+      omega
+    exact castMatrixTargetEquiv hsize
+      (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((p + q - 1) / 2)) (2 ^ n))
+  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
+    refine (Algebra.TensorProduct.congr e
+      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
+    have hsize : 2 ^ ((p + q - 2) / 2) * 2 ^ n =
+        2 ^ (((p + n) + (q + n) - 2) / 2) := by
+      rw [← pow_add]
+      congr 1
+      simp [realCliffordResidue] at hr
+      omega
+    exact castMatrixTargetEquiv hsize
+      (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((p + q - 2) / 2)) (2 ^ n))
+  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
+    refine (Algebra.TensorProduct.congr e
+      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
+    have hsize : 2 ^ ((p + q - 3) / 2) * 2 ^ n =
+        2 ^ (((p + n) + (q + n) - 3) / 2) := by
+      rw [← pow_add]
+      congr 1
+      simp [realCliffordResidue] at hr
+      omega
+    exact castMatrixProdTargetEquiv hsize
+      (matrixProdTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((p + q - 3) / 2)) (2 ^ n))
+  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
+    refine (Algebra.TensorProduct.congr e
+      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
+    have hsize : 2 ^ ((p + q - 2) / 2) * 2 ^ n =
+        2 ^ (((p + n) + (q + n) - 2) / 2) := by
+      rw [← pow_add]
+      congr 1
+      simp [realCliffordResidue] at hr
+      omega
+    exact castMatrixTargetEquiv hsize
+      (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((p + q - 2) / 2)) (2 ^ n))
+  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
+    refine (Algebra.TensorProduct.congr e
+      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
+    have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
+        2 ^ (((p + n) + (q + n) - 1) / 2) := by
+      rw [← pow_add]
+      congr 1
+      simp [realCliffordResidue] at hr
+      omega
+    exact castMatrixTargetEquiv hsize
+      (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((p + q - 1) / 2)) (2 ^ n))
+  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
+    refine (Algebra.TensorProduct.congr e
+      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
+    have hsize : 2 ^ ((p + q) / 2) * 2 ^ n = 2 ^ (((p + n) + (q + n)) / 2) := by
+      rw [← pow_add]
+      congr 1
+      omega
+    exact castMatrixTargetEquiv hsize
+      (matrixTensorMatrixEquiv ℝ ℝ (2 ^ ((p + q) / 2)) (2 ^ n))
+  · refine ⟨(realCliffordBottIterEquiv p q n).trans ?_⟩
+    refine (Algebra.TensorProduct.congr e
+      (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_
+    have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
+        2 ^ (((p + n) + (q + n) - 1) / 2) := by
+      rw [← pow_add]
+      congr 1
+      simp [realCliffordResidue] at hr
+      omega
+    exact castMatrixProdTargetEquiv hsize
+      (matrixProdTensorMatrixEquiv ℝ ℝ (2 ^ ((p + q - 1) / 2)) (2 ^ n))
+
+/-- The real Clifford algebra of every finite signature is the full matrix algebra, complex
+matrix algebra, quaternionic matrix algebra, or split algebra prescribed by `(q - p) mod 8`. -/
+theorem realClifford_classification (p q : ℕ) :
+    RealCliffordClassification p q := by
+  rcases le_total p q with hpq | hqp
+  · have h := realCliffordClassification_add_both 0 (q - p) p
+      (realClifford_negativeAxis_classification (q - p))
+    simpa [Nat.sub_add_cancel hpq] using h
+  · have h := realCliffordClassification_add_both (p - q) 0 q
+      (realClifford_positiveAxis_classification (p - q))
+    simpa [Nat.sub_add_cancel hqp] using h
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
@@ -9,8 +9,6 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.EightPeriodicity
 
 import Mathlib.RingTheory.TensorProduct.Pi
 import Mathlib.LinearAlgebra.Matrix.Unique
-import Mathlib.LinearAlgebra.CliffordAlgebra.Equivs
-import Mathlib.Algebra.Module.Equiv.Basic
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import TauCeti.Algebra.CentralSimple.Quaternion
 import TauCeti.Algebra.CentralSimple.Splitting
@@ -48,27 +46,21 @@ private abbrev C (p q : ℕ) :=
 def realCliffordResidue (p q : ℕ) : ℕ :=
   (q + 8 - p % 8) % 8
 
-/-- The defining formula for `realCliffordResidue`. -/
-theorem realCliffordResidue_def (p q : ℕ) :
-    realCliffordResidue p q = (q + 8 - p % 8) % 8 :=
-  (rfl)
-
 /-- The real Clifford residue is one of the eight table indices. -/
 theorem realCliffordResidue_lt_eight (p q : ℕ) : realCliffordResidue p q < 8 := by
-  rw [realCliffordResidue_def]
+  rw [realCliffordResidue]
   exact Nat.mod_lt _ (by norm_num)
 
 @[simp]
 theorem realCliffordResidue_add_add_right (p q n : ℕ) :
     realCliffordResidue (p + n) (q + n) = realCliffordResidue p q := by
-  simp only [realCliffordResidue_def]
+  simp only [realCliffordResidue]
   omega
 
 /-- The exact real algebra classification of the standard Clifford algebra of signature `(p,q)`.
 The matrix size is stated uniformly in terms of the total dimension. -/
-inductive IsRealCliffordClassified (p q : ℕ) : Prop where
-  | intro (classification :
-    match realCliffordResidue p q with
+def IsRealCliffordClassified (p q : ℕ) : Prop :=
+  match realCliffordResidue p q with
   | 0 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
       Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ)
   | 1 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
@@ -87,36 +79,7 @@ inductive IsRealCliffordClassified (p q : ℕ) : Prop where
   | 7 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
       Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ ×
         Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ)
-    | _ => False)
-
-/-- Characterization of the real Clifford classification by the signature residue. -/
-@[simp]
-theorem isRealCliffordClassified_iff (p q : ℕ) :
-    IsRealCliffordClassified p q ↔
-      match realCliffordResidue p q with
-      | 0 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
-          Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ)
-      | 1 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
-          Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℂ)
-      | 2 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
-          Matrix (Fin (2 ^ ((p + q - 2) / 2))) (Fin (2 ^ ((p + q - 2) / 2))) ℍ[ℝ])
-      | 3 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
-          Matrix (Fin (2 ^ ((p + q - 3) / 2))) (Fin (2 ^ ((p + q - 3) / 2))) ℍ[ℝ] ×
-            Matrix (Fin (2 ^ ((p + q - 3) / 2))) (Fin (2 ^ ((p + q - 3) / 2))) ℍ[ℝ])
-      | 4 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
-          Matrix (Fin (2 ^ ((p + q - 2) / 2))) (Fin (2 ^ ((p + q - 2) / 2))) ℍ[ℝ])
-      | 5 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
-          Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℂ)
-      | 6 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
-          Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ)
-      | 7 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
-          Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ ×
-            Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ)
-      | _ => False := by
-  constructor
-  · rintro ⟨classification⟩
-    exact classification
-  · exact IsRealCliffordClassified.intro
+  | _ => False
 
 private noncomputable def realCliffordZeroZeroEquiv :
     _root_.CliffordAlgebra (realCliffordForm 0 0) ≃ₐ[ℝ] ℝ := by
@@ -305,7 +268,7 @@ private noncomputable def realCliffordPositiveSevenEquiv :
 private theorem realClifford_positiveAxis_base (p : ℕ) (hp : p < 8) :
     IsRealCliffordClassified p 0 := by
   interval_cases p <;>
-    simp only [isRealCliffordClassified_iff, realCliffordResidue, zero_add, Nat.zero_mod,
+    simp only [IsRealCliffordClassified, realCliffordResidue, zero_add, Nat.zero_mod,
       tsub_zero, Nat.mod_self, Nat.add_zero, Nat.reduceDiv, Nat.pow_zero, Nat.one_mod,
       Nat.add_one_sub_one, Nat.mod_succ, Nat.reduceMod, Nat.reduceSub, Nat.reducePow] <;>
     first
@@ -329,7 +292,7 @@ private theorem realClifford_positiveAxis_classification (p : ℕ) :
         have hmod : n % 8 < 8 := Nat.mod_lt _ (by norm_num)
         let periodicity := Classical.choice (nonempty_realCliffordEightPeriodicityEquiv n 0)
         interval_cases hn : n % 8 <;>
-          simp only [isRealCliffordClassified_iff, realCliffordResidue, zero_add, hn,
+          simp only [IsRealCliffordClassified, realCliffordResidue, zero_add, hn,
             tsub_zero, Nat.mod_self, Nat.add_zero, Nat.add_mod_right, Nat.add_one_sub_one,
             Nat.mod_succ, Nat.reduceSub, Nat.reduceMod, Nat.one_mod] at prev ⊢
         all_goals obtain ⟨e⟩ := prev
@@ -362,13 +325,13 @@ private theorem realClifford_negativeAxis_classification (q : ℕ) :
     IsRealCliffordClassified 0 q := by
   rcases q with _ | _ | n
   · exact realClifford_positiveAxis_classification 0
-  · simp only [isRealCliffordClassified_iff, realCliffordResidue, zero_add, Nat.reduceAdd,
+  · simp only [IsRealCliffordClassified, realCliffordResidue, zero_add, Nat.reduceAdd,
       Nat.zero_mod, tsub_zero, Nat.reduceMod, Nat.add_one_sub_one, Nat.reduceDiv, Nat.pow_zero]
     exact ⟨realCliffordZeroOneEquivComplex.trans (matrixOneEquiv ℝ ℂ)⟩
   · have prev := realClifford_positiveAxis_classification n
     have hmod : n % 8 < 8 := Nat.mod_lt _ (by norm_num)
     interval_cases hn : n % 8 <;>
-      simp only [isRealCliffordClassified_iff, realCliffordResidue, zero_add, hn, tsub_zero,
+      simp only [IsRealCliffordClassified, realCliffordResidue, zero_add, hn, tsub_zero,
         Nat.mod_self, Nat.add_zero, Nat.zero_mod, Nat.add_mod_right, Nat.add_mod, Nat.one_mod,
         Nat.reduceAdd, Nat.reduceMod, Nat.add_one_sub_one, Nat.add_succ_sub_one,
         Nat.mod_succ] at prev ⊢
@@ -409,8 +372,8 @@ private theorem realClifford_negativeAxis_classification (q : ℕ) :
 private theorem isRealCliffordClassified_add_add_right (p q n : ℕ)
     (h : IsRealCliffordClassified p q) :
     IsRealCliffordClassified (p + n) (q + n) := by
-  rw [isRealCliffordClassified_iff, realCliffordResidue_add_add_right]
-  rw [isRealCliffordClassified_iff] at h
+  rw [IsRealCliffordClassified, realCliffordResidue_add_add_right]
+  rw [IsRealCliffordClassified] at h
   generalize hr : realCliffordResidue p q = r at h
   have hrlt : r < 8 := by
     rw [← hr]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
@@ -10,7 +10,6 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.EightPeriodicity
 import Mathlib.RingTheory.TensorProduct.Pi
 import Mathlib.LinearAlgebra.Matrix.Unique
 import Mathlib.Analysis.Complex.Polynomial.Basic
-import TauCeti.Algebra.BrauerGroup.Basic
 import TauCeti.Algebra.CentralSimple.Quaternion
 import TauCeti.Algebra.CentralSimple.Splitting
 
@@ -23,13 +22,15 @@ complex, quaternionic, or split matrix models.
 ## Main results
 
 * `realCliffordResidue` records `(q - p) mod 8` without integer coercions.
-* `RealCliffordClassification` states the exact algebra in each residue class.
+* `IsRealCliffordClassified` states the exact algebra in each residue class.
 * `realClifford_classification` proves the classification for every signature.
 
 ## References
 
 * C. Chevalley, *The Algebraic Theory of Spinors*.
 * H. B. Lawson and M.-L. Michelsohn, *Spin Geometry*, Chapter I.
+* [TauCeti SpinRepresentations roadmap, Layer 7](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-7-real-clifford-algebras-bott-periodicity-and-spinp-q),
+  the `(q - p) mod 8` classification-table target.
 -/
 
 public section
@@ -45,16 +46,31 @@ private abbrev C (p q : ℕ) :=
 def realCliffordResidue (p q : ℕ) : ℕ :=
   (q + 8 - p % 8) % 8
 
+private theorem realCliffordResidue_eq_proof (p q : ℕ) :
+    realCliffordResidue p q = (q + 8 - p % 8) % 8 :=
+  rfl
+
+/-- The defining formula for `realCliffordResidue`. -/
+theorem realCliffordResidue_eq (p q : ℕ) :
+    realCliffordResidue p q = (q + 8 - p % 8) % 8 :=
+  realCliffordResidue_eq_proof p q
+
+/-- The real Clifford residue is one of the eight table indices. -/
+theorem realCliffordResidue_lt_eight (p q : ℕ) : realCliffordResidue p q < 8 := by
+  rw [realCliffordResidue_eq]
+  exact Nat.mod_lt _ (by norm_num)
+
 @[simp]
-private theorem realCliffordResidue_add_both (p q n : ℕ) :
+theorem realCliffordResidue_add_both (p q n : ℕ) :
     realCliffordResidue (p + n) (q + n) = realCliffordResidue p q := by
-  simp only [realCliffordResidue]
+  simp only [realCliffordResidue_eq]
   omega
 
 /-- The exact real algebra classification of the standard Clifford algebra of signature `(p,q)`.
 The matrix size is stated uniformly in terms of the total dimension. -/
-abbrev RealCliffordClassification (p q : ℕ) : Prop :=
-  match realCliffordResidue p q with
+inductive IsRealCliffordClassified (p q : ℕ) : Prop where
+  | intro (classification :
+    match realCliffordResidue p q with
   | 0 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
       Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ)
   | 1 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
@@ -73,7 +89,36 @@ abbrev RealCliffordClassification (p q : ℕ) : Prop :=
   | 7 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
       Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ ×
         Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ)
-  | _ => False
+    | _ => False)
+
+/-- Characterization of the real Clifford classification by the signature residue. -/
+@[simp]
+theorem isRealCliffordClassified_iff (p q : ℕ) :
+    IsRealCliffordClassified p q ↔
+      match realCliffordResidue p q with
+      | 0 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+          Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ)
+      | 1 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+          Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℂ)
+      | 2 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+          Matrix (Fin (2 ^ ((p + q - 2) / 2))) (Fin (2 ^ ((p + q - 2) / 2))) ℍ[ℝ])
+      | 3 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+          Matrix (Fin (2 ^ ((p + q - 3) / 2))) (Fin (2 ^ ((p + q - 3) / 2))) ℍ[ℝ] ×
+            Matrix (Fin (2 ^ ((p + q - 3) / 2))) (Fin (2 ^ ((p + q - 3) / 2))) ℍ[ℝ])
+      | 4 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+          Matrix (Fin (2 ^ ((p + q - 2) / 2))) (Fin (2 ^ ((p + q - 2) / 2))) ℍ[ℝ])
+      | 5 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+          Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℂ)
+      | 6 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+          Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ)
+      | 7 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+          Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ ×
+            Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ)
+      | _ => False := by
+  constructor
+  · rintro ⟨classification⟩
+    exact classification
+  · exact IsRealCliffordClassified.intro
 
 private noncomputable def realCliffordZeroZeroEquiv :
     _root_.CliffordAlgebra (realCliffordForm 0 0) ≃ₐ[ℝ] ℝ :=
@@ -87,11 +132,6 @@ private noncomputable def realCliffordZeroZeroEquiv :
     (by ext)
     (by ext v; exact Fin.elim0 v)
 
-private def matrixOneEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A] :
-    A ≃ₐ[R] Matrix (Fin 1) (Fin 1) A :=
-  (Matrix.uniqueAlgEquiv (R := R) (A := A) (m := Unit)).symm.trans
-    (Matrix.reindexAlgEquiv R A (Equiv.ofUnique Unit (Fin 1)))
-
 private def prodTensorAlgebraEquiv (R A B : Type*) [CommSemiring R]
     [Semiring A] [Semiring B] [Algebra R A] [Algebra R B] :
     (A × A) ⊗[R] B ≃ₐ[R] (A ⊗[R] B) × (A ⊗[R] B) :=
@@ -99,6 +139,13 @@ private def prodTensorAlgebraEquiv (R A B : Type*) [CommSemiring R]
     (Algebra.TensorProduct.prodRight R R B A A).trans <|
     AlgEquiv.prodCongr (Algebra.TensorProduct.comm R B A)
       (Algebra.TensorProduct.comm R B A)
+
+/-- The canonical one-by-one matrix equivalence, reindexed so its matrix instances agree with
+the standard `Fin 1` instances used by the target type. -/
+private def matrixOneEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A] :
+    A ≃ₐ[R] Matrix (Fin 1) (Fin 1) A :=
+  (Matrix.uniqueAlgEquiv (R := R) (A := A) (m := Unit)).symm.trans
+    (Matrix.reindexAlgEquiv R A (Equiv.ofUnique Unit (Fin 1)))
 
 private noncomputable def complexTensorQuaternionEquiv :
     ℂ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℂ := by
@@ -172,7 +219,8 @@ private def matrixProdModelTensorEquiv {R S T A B D : Type*} [CommSemiring R]
 
 private theorem pow_half_sub_add_eight (n d : ℕ) (h : d ≤ n) :
     2 ^ ((n + 8 - d) / 2) = 2 ^ ((n - d) / 2) * 16 := by
-  rw [show (n + 8 - d) / 2 = (n - d) / 2 + 4 by omega, pow_add]
+  have hdiv : (n + 8 - d) / 2 = (n - d) / 2 + 4 := by omega
+  rw [hdiv, pow_add]
   norm_num
 
 private theorem pow_half_sub_add_both (p q n d : ℕ) (h : d ≤ p + q) :
@@ -189,7 +237,8 @@ private theorem pow_half_sub_mul_pow (n d s t : ℕ)
 
 private noncomputable def realCliffordPositiveZeroEquiv :
     C 0 0 ≃ₐ[ℝ] Matrix (Fin 1) (Fin 1) ℝ :=
-  realCliffordZeroZeroEquiv.trans (matrixOneEquiv ℝ ℝ)
+  realCliffordZeroZeroEquiv.trans
+    (matrixOneEquiv ℝ ℝ)
 
 private noncomputable def realCliffordPositiveOneEquiv :
     C 1 0 ≃ₐ[ℝ]
@@ -254,9 +303,9 @@ private noncomputable def realCliffordPositiveSevenEquiv :
     realCliffordZeroFiveEquiv (matrixEquivTensor (Fin 2) ℝ ℂ).symm (by norm_num)
 
 private theorem realClifford_positiveAxis_base (p : ℕ) (hp : p < 8) :
-    RealCliffordClassification p 0 := by
+    IsRealCliffordClassified p 0 := by
   interval_cases p <;>
-    simp only [RealCliffordClassification, realCliffordResidue, zero_add, Nat.zero_mod,
+    simp only [isRealCliffordClassified_iff, realCliffordResidue, zero_add, Nat.zero_mod,
       tsub_zero, Nat.mod_self, Nat.add_zero, Nat.reduceDiv, Nat.pow_zero, Nat.one_mod,
       Nat.add_one_sub_one, Nat.mod_succ, Nat.reduceMod, Nat.reduceSub, Nat.reducePow] <;>
     first
@@ -270,7 +319,7 @@ private theorem realClifford_positiveAxis_base (p : ℕ) (hp : p < 8) :
     | exact ⟨realCliffordPositiveSevenEquiv⟩
 
 private theorem realClifford_positiveAxis_classification (p : ℕ) :
-    RealCliffordClassification p 0 := by
+    IsRealCliffordClassified p 0 := by
   induction p using Nat.strong_induction_on with
   | h p ih =>
       by_cases hp : p < 8
@@ -278,47 +327,48 @@ private theorem realClifford_positiveAxis_classification (p : ℕ) :
       · obtain ⟨n, rfl⟩ : ∃ n, p = n + 8 := ⟨p - 8, by omega⟩
         have prev := ih n (by omega)
         have hmod : n % 8 < 8 := Nat.mod_lt _ (by norm_num)
+        let periodicity := Classical.choice (nonempty_realCliffordEightPeriodicityEquiv n 0)
         interval_cases hn : n % 8 <;>
-          simp only [RealCliffordClassification, realCliffordResidue, zero_add, hn,
+          simp only [isRealCliffordClassified_iff, realCliffordResidue, zero_add, hn,
             tsub_zero, Nat.mod_self, Nat.add_zero, Nat.add_mod_right, Nat.add_one_sub_one,
             Nat.mod_succ, Nat.reduceSub, Nat.reduceMod, Nat.one_mod] at prev ⊢
         all_goals obtain ⟨e⟩ := prev
-        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+        · exact ⟨matrixModelTensorEquiv periodicity e
             (matrixEquivTensor (Fin 16) ℝ ℝ).symm
             (pow_half_sub_add_eight n 0 (by omega)).symm⟩
-        · exact ⟨matrixProdModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+        · exact ⟨matrixProdModelTensorEquiv periodicity e
             (matrixEquivTensor (Fin 16) ℝ ℝ).symm
             (pow_half_sub_add_eight n 1 (by omega)).symm⟩
-        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+        · exact ⟨matrixModelTensorEquiv periodicity e
             (matrixEquivTensor (Fin 16) ℝ ℝ).symm
             (pow_half_sub_add_eight n 0 (by omega)).symm⟩
-        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+        · exact ⟨matrixModelTensorEquiv periodicity e
             (matrixEquivTensor (Fin 16) ℝ ℂ).symm
             (pow_half_sub_add_eight n 1 (by omega)).symm⟩
-        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+        · exact ⟨matrixModelTensorEquiv periodicity e
             (matrixEquivTensor (Fin 16) ℝ ℍ[ℝ]).symm
             (pow_half_sub_add_eight n 2 (by omega)).symm⟩
-        · exact ⟨matrixProdModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+        · exact ⟨matrixProdModelTensorEquiv periodicity e
             (matrixEquivTensor (Fin 16) ℝ ℍ[ℝ]).symm
             (pow_half_sub_add_eight n 3 (by omega)).symm⟩
-        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+        · exact ⟨matrixModelTensorEquiv periodicity e
             (matrixEquivTensor (Fin 16) ℝ ℍ[ℝ]).symm
             (pow_half_sub_add_eight n 2 (by omega)).symm⟩
-        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+        · exact ⟨matrixModelTensorEquiv periodicity e
             (matrixEquivTensor (Fin 16) ℝ ℂ).symm
             (pow_half_sub_add_eight n 1 (by omega)).symm⟩
 
 private theorem realClifford_negativeAxis_classification (q : ℕ) :
-    RealCliffordClassification 0 q := by
+    IsRealCliffordClassified 0 q := by
   rcases q with _ | _ | n
   · exact realClifford_positiveAxis_classification 0
-  · simp only [RealCliffordClassification, realCliffordResidue, zero_add, Nat.reduceAdd,
+  · simp only [isRealCliffordClassified_iff, realCliffordResidue, zero_add, Nat.reduceAdd,
       Nat.zero_mod, tsub_zero, Nat.reduceMod, Nat.add_one_sub_one, Nat.reduceDiv, Nat.pow_zero]
     exact ⟨realCliffordZeroOneEquivComplex.trans (matrixOneEquiv ℝ ℂ)⟩
   · have prev := realClifford_positiveAxis_classification n
     have hmod : n % 8 < 8 := Nat.mod_lt _ (by norm_num)
     interval_cases hn : n % 8 <;>
-      simp only [RealCliffordClassification, realCliffordResidue, zero_add, hn, tsub_zero,
+      simp only [isRealCliffordClassified_iff, realCliffordResidue, zero_add, hn, tsub_zero,
         Nat.mod_self, Nat.add_zero, Nat.zero_mod, Nat.add_mod_right, Nat.add_mod, Nat.one_mod,
         Nat.reduceAdd, Nat.reduceMod, Nat.add_one_sub_one, Nat.add_succ_sub_one,
         Nat.mod_succ] at prev ⊢
@@ -357,10 +407,10 @@ private theorem realClifford_negativeAxis_classification (q : ℕ) :
           pow_half_sub_mul_pow n 1 1 (n + 1) (by omega))⟩
 
 private theorem realCliffordClassification_add_both (p q n : ℕ)
-    (h : RealCliffordClassification p q) :
-    RealCliffordClassification (p + n) (q + n) := by
-  rw [RealCliffordClassification, realCliffordResidue_add_both]
-  rw [RealCliffordClassification] at h
+    (h : IsRealCliffordClassified p q) :
+    IsRealCliffordClassified (p + n) (q + n) := by
+  rw [isRealCliffordClassified_iff, realCliffordResidue_add_both]
+  rw [isRealCliffordClassified_iff] at h
   generalize hr : realCliffordResidue p q = r at h
   have hrlt : r < 8 := by
     rw [← hr]
@@ -395,7 +445,7 @@ private theorem realCliffordClassification_add_both (p q n : ℕ)
 /-- The real Clifford algebra of every finite signature is the full matrix algebra, complex
 matrix algebra, quaternionic matrix algebra, or split algebra prescribed by `(q - p) mod 8`. -/
 theorem realClifford_classification (p q : ℕ) :
-    RealCliffordClassification p q := by
+    IsRealCliffordClassified p q := by
   rcases le_total p q with hpq | hqp
   · have h := realCliffordClassification_add_both 0 (q - p) p
       (realClifford_negativeAxis_classification (q - p))

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
@@ -8,10 +8,10 @@ module
 public import TauCeti.LinearAlgebra.CliffordAlgebra.EightPeriodicity
 
 import Mathlib.RingTheory.TensorProduct.Pi
-import Mathlib.LinearAlgebra.Matrix.Unique
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import TauCeti.Algebra.CentralSimple.Quaternion
 import TauCeti.Algebra.CentralSimple.Splitting
+import TauCeti.LinearAlgebra.Matrix.TensorProduct
 
 /-!
 # Classification of real Clifford algebras
@@ -103,13 +103,6 @@ private def prodTensorAlgebraEquiv (R A B : Type*) [CommSemiring R]
     AlgEquiv.prodCongr (Algebra.TensorProduct.comm R B A)
       (Algebra.TensorProduct.comm R B A)
 
-/-- The canonical one-by-one matrix equivalence, reindexed so its matrix instances agree with
-the standard `Fin 1` instances used by the target type. -/
-private def matrixOneEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A] :
-    A ≃ₐ[R] Matrix (Fin 1) (Fin 1) A :=
-  (Matrix.uniqueAlgEquiv (R := R) (A := A) (m := Unit)).symm.trans
-    (Matrix.reindexAlgEquiv R A (Equiv.ofUnique Unit (Fin 1)))
-
 private noncomputable def complexTensorQuaternionEquiv :
     ℂ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℂ := by
   have hdeg : Algebra.deg ℝ ℍ[ℝ] = 2 :=
@@ -124,7 +117,7 @@ private def matrixTensorAlgebraEquiv (R A B : Type*) [CommSemiring R]
     Matrix (Fin m) (Fin m) A ⊗[R] B ≃ₐ[R]
       Matrix (Fin m) (Fin m) (A ⊗[R] B) :=
   (Algebra.TensorProduct.congr (AlgEquiv.refl : Matrix (Fin m) (Fin m) A ≃ₐ[R] _)
-    (matrixOneEquiv R B)).trans <|
+    (Matrix.finOneAlgEquiv R B)).trans <|
   (Matrix.kroneckerTMulFinAlgEquiv m 1 R A B).trans <|
   Matrix.reindexAlgEquiv R _ (finCongr (Nat.mul_one m))
 
@@ -201,13 +194,13 @@ private theorem pow_half_sub_mul_pow (n d s t : ℕ)
 private noncomputable def realCliffordPositiveZeroEquiv :
     C 0 0 ≃ₐ[ℝ] Matrix (Fin 1) (Fin 1) ℝ :=
   realCliffordZeroZeroEquiv.trans
-    (matrixOneEquiv ℝ ℝ)
+    (Matrix.finOneAlgEquiv ℝ ℝ)
 
 private noncomputable def realCliffordPositiveOneEquiv :
     C 1 0 ≃ₐ[ℝ]
       Matrix (Fin 1) (Fin 1) ℝ × Matrix (Fin 1) (Fin 1) ℝ :=
   realCliffordOneZeroEquivProd.trans <|
-    AlgEquiv.prodCongr (matrixOneEquiv ℝ ℝ) (matrixOneEquiv ℝ ℝ)
+    AlgEquiv.prodCongr (Matrix.finOneAlgEquiv ℝ ℝ) (Matrix.finOneAlgEquiv ℝ ℝ)
 
 private noncomputable def realCliffordPositiveTwoEquiv :
     C 2 0 ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ :=
@@ -235,8 +228,8 @@ private noncomputable def realCliffordZeroThreeEquiv :
       Matrix (Fin 1) (Fin 1) ℍ[ℝ] × Matrix (Fin 1) (Fin 1) ℍ[ℝ] :=
   matrixProdModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 1)
     (realCliffordOneZeroEquivProd.trans <|
-      AlgEquiv.prodCongr (matrixOneEquiv ℝ ℝ) (matrixOneEquiv ℝ ℝ))
-    ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ])) (by norm_num)
+      AlgEquiv.prodCongr (Matrix.finOneAlgEquiv ℝ ℝ) (Matrix.finOneAlgEquiv ℝ ℝ))
+    ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (Matrix.finOneAlgEquiv ℝ ℍ[ℝ])) (by norm_num)
 
 private noncomputable def realCliffordPositiveFiveEquiv :
     C 5 0 ≃ₐ[ℝ]
@@ -248,7 +241,7 @@ private noncomputable def realCliffordZeroFourEquiv :
     C 0 4 ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℍ[ℝ] :=
   matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 2)
     realCliffordPositiveTwoEquiv
-    ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ])) (by norm_num)
+    ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (Matrix.finOneAlgEquiv ℝ ℍ[ℝ])) (by norm_num)
 
 private noncomputable def realCliffordPositiveSixEquiv :
     C 6 0 ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℍ[ℝ] :=
@@ -327,7 +320,7 @@ private theorem realClifford_negativeAxis_classification (q : ℕ) :
   · exact realClifford_positiveAxis_classification 0
   · simp only [IsRealCliffordClassified, realCliffordResidue, zero_add, Nat.reduceAdd,
       Nat.zero_mod, tsub_zero, Nat.reduceMod, Nat.add_one_sub_one, Nat.reduceDiv, Nat.pow_zero]
-    exact ⟨realCliffordZeroOneEquivComplex.trans (matrixOneEquiv ℝ ℂ)⟩
+    exact ⟨realCliffordZeroOneEquivComplex.trans (Matrix.finOneAlgEquiv ℝ ℂ)⟩
   · have prev := realClifford_positiveAxis_classification n
     have hmod : n % 8 < 8 := Nat.mod_lt _ (by norm_num)
     interval_cases hn : n % 8 <;>
@@ -337,15 +330,15 @@ private theorem realClifford_negativeAxis_classification (q : ℕ) :
         Nat.mod_succ] at prev ⊢
     all_goals obtain ⟨e⟩ := prev
     · exact ⟨matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
-        ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
+        ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (Matrix.finOneAlgEquiv ℝ ℍ[ℝ]))
         (by simpa only [Nat.sub_zero, Nat.reducePow, mul_one, Nat.zero_add] using
           pow_half_sub_mul_pow n 0 0 (n + 1 + 1 - 2) (by omega))⟩
     · exact ⟨matrixProdModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
-        ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
+        ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (Matrix.finOneAlgEquiv ℝ ℍ[ℝ]))
         (by simpa only [Nat.reducePow, mul_one, Nat.zero_add] using
           pow_half_sub_mul_pow n 1 0 (n + 1 + 1 - 3) (by omega))⟩
     · exact ⟨matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
-        ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
+        ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (Matrix.finOneAlgEquiv ℝ ℍ[ℝ]))
         (by simpa only [Nat.sub_zero, Nat.reducePow, mul_one, Nat.zero_add] using
           pow_half_sub_mul_pow n 0 0 (n + 1 + 1 - 2) (by omega))⟩
     · exact ⟨matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
@@ -375,9 +368,7 @@ private theorem isRealCliffordClassified_add_add_right (p q n : ℕ)
   rw [IsRealCliffordClassified, realCliffordResidue_add_add_right]
   rw [IsRealCliffordClassified] at h
   generalize hr : realCliffordResidue p q = r at h
-  have hrlt : r < 8 := by
-    rw [← hr]
-    exact Nat.mod_lt _ (by norm_num)
+  have hrlt : r < 8 := hr ▸ realCliffordResidue_lt_eight p q
   interval_cases r <;> simp only at h ⊢
   all_goals obtain ⟨e⟩ := h
   · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
@@ -416,5 +407,63 @@ theorem realClifford_classification (p q : ℕ) :
   · have h := isRealCliffordClassified_add_add_right (p - q) 0 q
       (realClifford_positiveAxis_classification (p - q))
     simpa [Nat.sub_add_cancel hqp] using h
+
+/-- The residue-zero case of the real Clifford classification table. -/
+theorem realClifford_classification_of_residue_eq_zero (p q : ℕ)
+    (h : realCliffordResidue p q = 0) :
+    Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ) := by
+  simpa only [IsRealCliffordClassified, h] using realClifford_classification p q
+
+/-- The residue-one case of the real Clifford classification table. -/
+theorem realClifford_classification_of_residue_eq_one (p q : ℕ)
+    (h : realCliffordResidue p q = 1) :
+    Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℂ) := by
+  simpa only [IsRealCliffordClassified, h] using realClifford_classification p q
+
+/-- The residue-two case of the real Clifford classification table. -/
+theorem realClifford_classification_of_residue_eq_two (p q : ℕ)
+    (h : realCliffordResidue p q = 2) :
+    Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 2) / 2))) (Fin (2 ^ ((p + q - 2) / 2))) ℍ[ℝ]) := by
+  simpa only [IsRealCliffordClassified, h] using realClifford_classification p q
+
+/-- The residue-three case of the real Clifford classification table. -/
+theorem realClifford_classification_of_residue_eq_three (p q : ℕ)
+    (h : realCliffordResidue p q = 3) :
+    Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 3) / 2))) (Fin (2 ^ ((p + q - 3) / 2))) ℍ[ℝ] ×
+        Matrix (Fin (2 ^ ((p + q - 3) / 2))) (Fin (2 ^ ((p + q - 3) / 2))) ℍ[ℝ]) := by
+  simpa only [IsRealCliffordClassified, h] using realClifford_classification p q
+
+/-- The residue-four case of the real Clifford classification table. -/
+theorem realClifford_classification_of_residue_eq_four (p q : ℕ)
+    (h : realCliffordResidue p q = 4) :
+    Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 2) / 2))) (Fin (2 ^ ((p + q - 2) / 2))) ℍ[ℝ]) := by
+  simpa only [IsRealCliffordClassified, h] using realClifford_classification p q
+
+/-- The residue-five case of the real Clifford classification table. -/
+theorem realClifford_classification_of_residue_eq_five (p q : ℕ)
+    (h : realCliffordResidue p q = 5) :
+    Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℂ) := by
+  simpa only [IsRealCliffordClassified, h] using realClifford_classification p q
+
+/-- The residue-six case of the real Clifford classification table. -/
+theorem realClifford_classification_of_residue_eq_six (p q : ℕ)
+    (h : realCliffordResidue p q = 6) :
+    Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ) := by
+  simpa only [IsRealCliffordClassified, h] using realClifford_classification p q
+
+/-- The residue-seven case of the real Clifford classification table. -/
+theorem realClifford_classification_of_residue_eq_seven (p q : ℕ)
+    (h : realCliffordResidue p q = 7) :
+    Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
+      Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ ×
+        Matrix (Fin (2 ^ ((p + q - 1) / 2))) (Fin (2 ^ ((p + q - 1) / 2))) ℝ) := by
+  simpa only [IsRealCliffordClassified, h] using realClifford_classification p q
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
@@ -53,7 +53,7 @@ private theorem realCliffordResidue_add_both (p q n : ℕ) :
 
 /-- The exact real algebra classification of the standard Clifford algebra of signature `(p,q)`.
 The matrix size is stated uniformly in terms of the total dimension. -/
-def RealCliffordClassification (p q : ℕ) : Prop :=
+abbrev RealCliffordClassification (p q : ℕ) : Prop :=
   match realCliffordResidue p q with
   | 0 => Nonempty (_root_.CliffordAlgebra (realCliffordForm p q) ≃ₐ[ℝ]
       Matrix (Fin (2 ^ ((p + q) / 2))) (Fin (2 ^ ((p + q) / 2))) ℝ)
@@ -92,13 +92,6 @@ private def matrixOneEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra 
   (Matrix.uniqueAlgEquiv (R := R) (A := A) (m := Unit)).symm.trans
     (Matrix.reindexAlgEquiv R A (Equiv.ofUnique Unit (Fin 1)))
 
-private def matrixTensorMatrixEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A]
-    (m n : ℕ) :
-    Matrix (Fin m) (Fin m) A ⊗[R] Matrix (Fin n) (Fin n) R ≃ₐ[R]
-      Matrix (Fin (m * n)) (Fin (m * n)) A :=
-  (Matrix.kroneckerTMulFinAlgEquiv m n R A R).trans
-    (Algebra.TensorProduct.rid R R A).mapMatrix
-
 private def prodTensorAlgebraEquiv (R A B : Type*) [CommSemiring R]
     [Semiring A] [Semiring B] [Algebra R A] [Algebra R B] :
     (A × A) ⊗[R] B ≃ₐ[R] (A ⊗[R] B) × (A ⊗[R] B) :=
@@ -106,16 +99,6 @@ private def prodTensorAlgebraEquiv (R A B : Type*) [CommSemiring R]
     (Algebra.TensorProduct.prodRight R R B A A).trans <|
     AlgEquiv.prodCongr (Algebra.TensorProduct.comm R B A)
       (Algebra.TensorProduct.comm R B A)
-
-private def matrixProdTensorMatrixEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A]
-    (m n : ℕ) :
-    (Matrix (Fin m) (Fin m) A × Matrix (Fin m) (Fin m) A) ⊗[R]
-        Matrix (Fin n) (Fin n) R ≃ₐ[R]
-      Matrix (Fin (m * n)) (Fin (m * n)) A ×
-        Matrix (Fin (m * n)) (Fin (m * n)) A :=
-  (prodTensorAlgebraEquiv R (Matrix (Fin m) (Fin m) A)
-    (Matrix (Fin n) (Fin n) R)).trans <|
-    AlgEquiv.prodCongr (matrixTensorMatrixEquiv R A m n) (matrixTensorMatrixEquiv R A m n)
 
 private noncomputable def complexTensorQuaternionEquiv :
     ℂ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℂ := by
@@ -142,39 +125,6 @@ private def flattenMatrixEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Alge
   (Matrix.compAlgEquiv (Fin m) (Fin n) A R).trans
     (Matrix.reindexAlgEquiv R A finProdFinEquiv)
 
-private noncomputable def realMatrixTensorQuaternionEquiv (m : ℕ) :
-    Matrix (Fin m) (Fin m) ℝ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
-      Matrix (Fin m) (Fin m) ℍ[ℝ] :=
-  (matrixTensorAlgebraEquiv ℝ ℝ ℍ[ℝ] m).trans
-    (Algebra.TensorProduct.lid ℝ ℍ[ℝ]).mapMatrix
-
-private noncomputable def complexMatrixTensorQuaternionEquiv (m : ℕ) :
-    Matrix (Fin m) (Fin m) ℂ ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
-      Matrix (Fin (m * 2)) (Fin (m * 2)) ℂ :=
-  (matrixTensorAlgebraEquiv ℝ ℂ ℍ[ℝ] m).trans <|
-    complexTensorQuaternionEquiv.mapMatrix.trans <| flattenMatrixEquiv ℝ ℂ m 2
-
-private noncomputable def quaternionMatrixTensorQuaternionEquiv (m : ℕ) :
-    Matrix (Fin m) (Fin m) ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
-      Matrix (Fin (m * 4)) (Fin (m * 4)) ℝ :=
-  (matrixTensorAlgebraEquiv ℝ ℍ[ℝ] ℍ[ℝ] m).trans <|
-    Quaternion.tensorSelfAlgEquivMatrix.mapMatrix.trans <| flattenMatrixEquiv ℝ ℝ m 4
-
-private noncomputable def realMatrixProdTensorQuaternionEquiv (m : ℕ) :
-    (Matrix (Fin m) (Fin m) ℝ × Matrix (Fin m) (Fin m) ℝ) ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
-      Matrix (Fin m) (Fin m) ℍ[ℝ] × Matrix (Fin m) (Fin m) ℍ[ℝ] :=
-  (prodTensorAlgebraEquiv ℝ (Matrix (Fin m) (Fin m) ℝ) ℍ[ℝ]).trans <|
-    AlgEquiv.prodCongr (realMatrixTensorQuaternionEquiv m)
-      (realMatrixTensorQuaternionEquiv m)
-
-private noncomputable def quaternionMatrixProdTensorQuaternionEquiv (m : ℕ) :
-    (Matrix (Fin m) (Fin m) ℍ[ℝ] × Matrix (Fin m) (Fin m) ℍ[ℝ]) ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ]
-      Matrix (Fin (m * 4)) (Fin (m * 4)) ℝ ×
-        Matrix (Fin (m * 4)) (Fin (m * 4)) ℝ :=
-  (prodTensorAlgebraEquiv ℝ (Matrix (Fin m) (Fin m) ℍ[ℝ]) ℍ[ℝ]).trans <|
-    AlgEquiv.prodCongr (quaternionMatrixTensorQuaternionEquiv m)
-      (quaternionMatrixTensorQuaternionEquiv m)
-
 private def castMatrixTargetEquiv {R S A : Type*} [CommSemiring R]
     [Semiring S] [Semiring A] [Algebra R S] [Algebra R A] {m n : ℕ} (h : m = n)
     (e : S ≃ₐ[R] Matrix (Fin m) (Fin m) A) :
@@ -188,10 +138,54 @@ private def castMatrixProdTargetEquiv {R S A : Type*} [CommSemiring R]
     S ≃ₐ[R] Matrix (Fin n) (Fin n) A × Matrix (Fin n) (Fin n) A :=
   h ▸ e
 
+private def matrixTensorByCoefficientEquiv {R A B D : Type*} [CommSemiring R]
+    [Semiring A] [Semiring B] [Semiring D] [Algebra R A] [Algebra R B] [Algebra R D]
+    {n : ℕ} (m : ℕ) (coeff : A ⊗[R] B ≃ₐ[R] Matrix (Fin n) (Fin n) D) :
+    Matrix (Fin m) (Fin m) A ⊗[R] B ≃ₐ[R]
+      Matrix (Fin (m * n)) (Fin (m * n)) D :=
+  (matrixTensorAlgebraEquiv R A B m).trans <|
+    coeff.mapMatrix.trans <| flattenMatrixEquiv R D m n
+
+private def matrixModelTensorEquiv {R S T A B D : Type*} [CommSemiring R]
+    [Semiring S] [Semiring T] [Semiring A] [Semiring B] [Semiring D]
+    [Algebra R S] [Algebra R T] [Algebra R A] [Algebra R B] [Algebra R D]
+    {m n k : ℕ} (step : T ≃ₐ[R] S ⊗[R] B)
+    (model : S ≃ₐ[R] Matrix (Fin m) (Fin m) A)
+    (coeff : A ⊗[R] B ≃ₐ[R] Matrix (Fin n) (Fin n) D) (h : m * n = k) :
+    T ≃ₐ[R] Matrix (Fin k) (Fin k) D :=
+  step.trans <| (Algebra.TensorProduct.congr model (AlgEquiv.refl : B ≃ₐ[R] B)).trans <|
+    castMatrixTargetEquiv h (matrixTensorByCoefficientEquiv m coeff)
+
+private def matrixProdModelTensorEquiv {R S T A B D : Type*} [CommSemiring R]
+    [Semiring S] [Semiring T] [Semiring A] [Semiring B] [Semiring D]
+    [Algebra R S] [Algebra R T] [Algebra R A] [Algebra R B] [Algebra R D]
+    {m n k : ℕ} (step : T ≃ₐ[R] S ⊗[R] B)
+    (model : S ≃ₐ[R]
+      Matrix (Fin m) (Fin m) A × Matrix (Fin m) (Fin m) A)
+    (coeff : A ⊗[R] B ≃ₐ[R] Matrix (Fin n) (Fin n) D) (h : m * n = k) :
+    T ≃ₐ[R] Matrix (Fin k) (Fin k) D × Matrix (Fin k) (Fin k) D :=
+  step.trans <| (Algebra.TensorProduct.congr model (AlgEquiv.refl : B ≃ₐ[R] B)).trans <|
+    (prodTensorAlgebraEquiv R (Matrix (Fin m) (Fin m) A) B).trans <|
+      castMatrixProdTargetEquiv h <|
+        AlgEquiv.prodCongr (matrixTensorByCoefficientEquiv m coeff)
+          (matrixTensorByCoefficientEquiv m coeff)
+
 private theorem pow_half_sub_add_eight (n d : ℕ) (h : d ≤ n) :
     2 ^ ((n + 8 - d) / 2) = 2 ^ ((n - d) / 2) * 16 := by
   rw [show (n + 8 - d) / 2 = (n - d) / 2 + 4 by omega, pow_add]
   norm_num
+
+private theorem pow_half_sub_add_both (p q n d : ℕ) (h : d ≤ p + q) :
+    2 ^ ((p + q - d) / 2) * 2 ^ n =
+      2 ^ (((p + n) + (q + n) - d) / 2) := by
+  rw [← pow_add]
+  congr 1
+  omega
+
+private theorem pow_half_sub_mul_pow (n d s t : ℕ)
+    (h : (n - d) / 2 + s = t / 2) :
+    2 ^ ((n - d) / 2) * 2 ^ s = 2 ^ (t / 2) := by
+  rw [← pow_add, h]
 
 private noncomputable def realCliffordPositiveZeroEquiv :
     C 0 0 ≃ₐ[ℝ] Matrix (Fin 1) (Fin 1) ℝ :=
@@ -227,49 +221,37 @@ private noncomputable def realCliffordPositiveFourEquiv :
 private noncomputable def realCliffordZeroThreeEquiv :
     C 0 3 ≃ₐ[ℝ]
       Matrix (Fin 1) (Fin 1) ℍ[ℝ] × Matrix (Fin 1) (Fin 1) ℍ[ℝ] :=
-  (realCliffordQuaternionRecurrenceEquiv 0 1).trans <|
-    (Algebra.TensorProduct.congr realCliffordOneZeroEquivProd
-      (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans <|
-    (prodTensorAlgebraEquiv ℝ ℝ ℍ[ℝ]).trans <|
-    AlgEquiv.prodCongr
-      ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
-      ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
+  matrixProdModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 1)
+    (realCliffordOneZeroEquivProd.trans <|
+      AlgEquiv.prodCongr (matrixOneEquiv ℝ ℝ) (matrixOneEquiv ℝ ℝ))
+    ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ])) (by norm_num)
 
 private noncomputable def realCliffordPositiveFiveEquiv :
     C 5 0 ≃ₐ[ℝ]
       Matrix (Fin 2) (Fin 2) ℍ[ℝ] × Matrix (Fin 2) (Fin 2) ℍ[ℝ] :=
-  (realCliffordSignatureSwitchRecurrenceEquiv 3 0).trans <|
-    (Algebra.TensorProduct.congr realCliffordZeroThreeEquiv
-      (AlgEquiv.refl : Matrix (Fin 2) (Fin 2) ℝ ≃ₐ[ℝ] _)).trans <|
-    matrixProdTensorMatrixEquiv ℝ ℍ[ℝ] 1 2
+  matrixProdModelTensorEquiv (realCliffordSignatureSwitchRecurrenceEquiv 3 0)
+    realCliffordZeroThreeEquiv (matrixEquivTensor (Fin 2) ℝ ℍ[ℝ]).symm (by norm_num)
 
 private noncomputable def realCliffordZeroFourEquiv :
     C 0 4 ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℍ[ℝ] :=
-  (realCliffordQuaternionRecurrenceEquiv 0 2).trans <|
-    (Algebra.TensorProduct.congr realCliffordPositiveTwoEquiv
-      (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans <|
-    realMatrixTensorQuaternionEquiv 2
+  matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 2)
+    realCliffordPositiveTwoEquiv
+    ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ])) (by norm_num)
 
 private noncomputable def realCliffordPositiveSixEquiv :
     C 6 0 ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℍ[ℝ] :=
-  (realCliffordSignatureSwitchRecurrenceEquiv 4 0).trans <|
-    (Algebra.TensorProduct.congr realCliffordZeroFourEquiv
-      (AlgEquiv.refl : Matrix (Fin 2) (Fin 2) ℝ ≃ₐ[ℝ] _)).trans <|
-    matrixTensorMatrixEquiv ℝ ℍ[ℝ] 2 2
+  matrixModelTensorEquiv (realCliffordSignatureSwitchRecurrenceEquiv 4 0)
+    realCliffordZeroFourEquiv (matrixEquivTensor (Fin 2) ℝ ℍ[ℝ]).symm (by norm_num)
 
 private noncomputable def realCliffordZeroFiveEquiv :
     C 0 5 ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℂ :=
-  (realCliffordQuaternionRecurrenceEquiv 0 3).trans <|
-    (Algebra.TensorProduct.congr realCliffordPositiveThreeEquiv
-      (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans <|
-    complexMatrixTensorQuaternionEquiv 2
+  matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 3)
+    realCliffordPositiveThreeEquiv complexTensorQuaternionEquiv (by norm_num)
 
 private noncomputable def realCliffordPositiveSevenEquiv :
     C 7 0 ≃ₐ[ℝ] Matrix (Fin 8) (Fin 8) ℂ :=
-  (realCliffordSignatureSwitchRecurrenceEquiv 5 0).trans <|
-    (Algebra.TensorProduct.congr realCliffordZeroFiveEquiv
-      (AlgEquiv.refl : Matrix (Fin 2) (Fin 2) ℝ ≃ₐ[ℝ] _)).trans <|
-    matrixTensorMatrixEquiv ℝ ℂ 4 2
+  matrixModelTensorEquiv (realCliffordSignatureSwitchRecurrenceEquiv 5 0)
+    realCliffordZeroFiveEquiv (matrixEquivTensor (Fin 2) ℝ ℂ).symm (by norm_num)
 
 private theorem realClifford_positiveAxis_base (p : ℕ) (hp : p < 8) :
     RealCliffordClassification p 0 := by
@@ -301,26 +283,30 @@ private theorem realClifford_positiveAxis_classification (p : ℕ) :
             tsub_zero, Nat.mod_self, Nat.add_zero, Nat.add_mod_right, Nat.add_one_sub_one,
             Nat.mod_succ, Nat.reduceSub, Nat.reduceMod, Nat.one_mod] at prev ⊢
         all_goals obtain ⟨e⟩ := prev
-        all_goals
-          refine ⟨(realCliffordEightPeriodicityEquiv n 0).trans
-            ((Algebra.TensorProduct.congr e
-              (AlgEquiv.refl : Matrix (Fin 16) (Fin 16) ℝ ≃ₐ[ℝ] _)).trans ?_)⟩
-        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 0 (by omega)).symm
-            (matrixTensorMatrixEquiv ℝ ℝ (2 ^ (n / 2)) 16)
-        · exact castMatrixProdTargetEquiv (pow_half_sub_add_eight n 1 (by omega)).symm
-            (matrixProdTensorMatrixEquiv ℝ ℝ (2 ^ ((n - 1) / 2)) 16)
-        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 0 (by omega)).symm
-            (matrixTensorMatrixEquiv ℝ ℝ (2 ^ (n / 2)) 16)
-        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 1 (by omega)).symm
-            (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((n - 1) / 2)) 16)
-        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 2 (by omega)).symm
-            (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((n - 2) / 2)) 16)
-        · exact castMatrixProdTargetEquiv (pow_half_sub_add_eight n 3 (by omega)).symm
-            (matrixProdTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((n - 3) / 2)) 16)
-        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 2 (by omega)).symm
-            (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((n - 2) / 2)) 16)
-        · exact castMatrixTargetEquiv (pow_half_sub_add_eight n 1 (by omega)).symm
-            (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((n - 1) / 2)) 16)
+        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+            (matrixEquivTensor (Fin 16) ℝ ℝ).symm
+            (pow_half_sub_add_eight n 0 (by omega)).symm⟩
+        · exact ⟨matrixProdModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+            (matrixEquivTensor (Fin 16) ℝ ℝ).symm
+            (pow_half_sub_add_eight n 1 (by omega)).symm⟩
+        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+            (matrixEquivTensor (Fin 16) ℝ ℝ).symm
+            (pow_half_sub_add_eight n 0 (by omega)).symm⟩
+        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+            (matrixEquivTensor (Fin 16) ℝ ℂ).symm
+            (pow_half_sub_add_eight n 1 (by omega)).symm⟩
+        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+            (matrixEquivTensor (Fin 16) ℝ ℍ[ℝ]).symm
+            (pow_half_sub_add_eight n 2 (by omega)).symm⟩
+        · exact ⟨matrixProdModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+            (matrixEquivTensor (Fin 16) ℝ ℍ[ℝ]).symm
+            (pow_half_sub_add_eight n 3 (by omega)).symm⟩
+        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+            (matrixEquivTensor (Fin 16) ℝ ℍ[ℝ]).symm
+            (pow_half_sub_add_eight n 2 (by omega)).symm⟩
+        · exact ⟨matrixModelTensorEquiv (realCliffordEightPeriodicityEquiv n 0) e
+            (matrixEquivTensor (Fin 16) ℝ ℂ).symm
+            (pow_half_sub_add_eight n 1 (by omega)).symm⟩
 
 private theorem realClifford_negativeAxis_classification (q : ℕ) :
     RealCliffordClassification 0 q := by
@@ -337,47 +323,38 @@ private theorem realClifford_negativeAxis_classification (q : ℕ) :
         Nat.reduceAdd, Nat.reduceMod, Nat.add_one_sub_one, Nat.add_succ_sub_one,
         Nat.mod_succ] at prev ⊢
     all_goals obtain ⟨e⟩ := prev
-    all_goals
-      refine ⟨(realCliffordQuaternionRecurrenceEquiv 0 n).trans
-        ((Algebra.TensorProduct.congr e (AlgEquiv.refl : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ])).trans ?_)⟩
-    · have hsize : 2 ^ (n / 2) = 2 ^ ((0 + (n + 1 + 1) - 2) / 2) := by
-        congr 1
-        omega
-      exact castMatrixTargetEquiv hsize (realMatrixTensorQuaternionEquiv (2 ^ (n / 2)))
-    · have hsize : 2 ^ ((n - 1) / 2) = 2 ^ ((0 + (n + 1 + 1) - 3) / 2) := by
-        congr 1
-        omega
-      exact castMatrixProdTargetEquiv hsize
-        (realMatrixProdTensorQuaternionEquiv (2 ^ ((n - 1) / 2)))
-    · have hsize : 2 ^ (n / 2) = 2 ^ ((0 + (n + 1 + 1) - 2) / 2) := by
-        congr 1
-        omega
-      exact castMatrixTargetEquiv hsize (realMatrixTensorQuaternionEquiv (2 ^ (n / 2)))
-    · have hsize : 2 ^ ((n - 1) / 2) * 2 = 2 ^ ((0 + (n + 1)) / 2) := by
-        rw [show (0 + (n + 1)) / 2 = (n - 1) / 2 + 1 by omega, pow_add]
-        norm_num
-      exact castMatrixTargetEquiv hsize
-        (complexMatrixTensorQuaternionEquiv (2 ^ ((n - 1) / 2)))
-    · have hsize : 2 ^ ((n - 2) / 2) * 4 = 2 ^ ((0 + (n + 1 + 1)) / 2) := by
-        rw [show (0 + (n + 1 + 1)) / 2 = (n - 2) / 2 + 2 by omega, pow_add]
-        norm_num
-      exact castMatrixTargetEquiv hsize
-        (quaternionMatrixTensorQuaternionEquiv (2 ^ ((n - 2) / 2)))
-    · have hsize : 2 ^ ((n - 3) / 2) * 4 = 2 ^ ((0 + (n + 1)) / 2) := by
-        rw [show (0 + (n + 1)) / 2 = (n - 3) / 2 + 2 by omega, pow_add]
-        norm_num
-      exact castMatrixProdTargetEquiv hsize
-        (quaternionMatrixProdTensorQuaternionEquiv (2 ^ ((n - 3) / 2)))
-    · have hsize : 2 ^ ((n - 2) / 2) * 4 = 2 ^ ((0 + (n + 1 + 1)) / 2) := by
-        rw [show (0 + (n + 1 + 1)) / 2 = (n - 2) / 2 + 2 by omega, pow_add]
-        norm_num
-      exact castMatrixTargetEquiv hsize
-        (quaternionMatrixTensorQuaternionEquiv (2 ^ ((n - 2) / 2)))
-    · have hsize : 2 ^ ((n - 1) / 2) * 2 = 2 ^ ((0 + (n + 1)) / 2) := by
-        rw [show (0 + (n + 1)) / 2 = (n - 1) / 2 + 1 by omega, pow_add]
-        norm_num
-      exact castMatrixTargetEquiv hsize
-        (complexMatrixTensorQuaternionEquiv (2 ^ ((n - 1) / 2)))
+    · exact ⟨matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
+        ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
+        (by simpa only [Nat.sub_zero, Nat.reducePow, mul_one, Nat.zero_add] using
+          pow_half_sub_mul_pow n 0 0 (n + 1 + 1 - 2) (by omega))⟩
+    · exact ⟨matrixProdModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
+        ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
+        (by simpa only [Nat.reducePow, mul_one, Nat.zero_add] using
+          pow_half_sub_mul_pow n 1 0 (n + 1 + 1 - 3) (by omega))⟩
+    · exact ⟨matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
+        ((Algebra.TensorProduct.lid ℝ ℍ[ℝ]).trans (matrixOneEquiv ℝ ℍ[ℝ]))
+        (by simpa only [Nat.sub_zero, Nat.reducePow, mul_one, Nat.zero_add] using
+          pow_half_sub_mul_pow n 0 0 (n + 1 + 1 - 2) (by omega))⟩
+    · exact ⟨matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
+        complexTensorQuaternionEquiv
+        (by simpa only [Nat.reducePow, Nat.zero_add] using
+          pow_half_sub_mul_pow n 1 1 (n + 1) (by omega))⟩
+    · exact ⟨matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
+        Quaternion.tensorSelfAlgEquivMatrix
+        (by simpa only [Nat.reducePow, Nat.zero_add] using
+          pow_half_sub_mul_pow n 2 2 (n + 1 + 1) (by omega))⟩
+    · exact ⟨matrixProdModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
+        Quaternion.tensorSelfAlgEquivMatrix
+        (by simpa only [Nat.reducePow, Nat.zero_add] using
+          pow_half_sub_mul_pow n 3 2 (n + 1) (by omega))⟩
+    · exact ⟨matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
+        Quaternion.tensorSelfAlgEquivMatrix
+        (by simpa only [Nat.reducePow, Nat.zero_add] using
+          pow_half_sub_mul_pow n 2 2 (n + 1 + 1) (by omega))⟩
+    · exact ⟨matrixModelTensorEquiv (realCliffordQuaternionRecurrenceEquiv 0 n) e
+        complexTensorQuaternionEquiv
+        (by simpa only [Nat.reducePow, Nat.zero_add] using
+          pow_half_sub_mul_pow n 1 1 (n + 1) (by omega))⟩
 
 private theorem realCliffordClassification_add_both (p q n : ℕ)
     (h : RealCliffordClassification p q) :
@@ -390,70 +367,30 @@ private theorem realCliffordClassification_add_both (p q n : ℕ)
     exact Nat.mod_lt _ (by norm_num)
   interval_cases r <;> simp only at h ⊢
   all_goals obtain ⟨e⟩ := h
-  all_goals
-    refine ⟨(realCliffordBottIterEquiv p q n).trans
-      ((Algebra.TensorProduct.congr e
-        (AlgEquiv.refl : Matrix (Fin (2 ^ n)) (Fin (2 ^ n)) ℝ ≃ₐ[ℝ] _)).trans ?_)⟩
-  · have hsize : 2 ^ ((p + q) / 2) * 2 ^ n = 2 ^ (((p + n) + (q + n)) / 2) := by
-      rw [← pow_add]
-      congr 1
-      omega
-    exact castMatrixTargetEquiv hsize
-      (matrixTensorMatrixEquiv ℝ ℝ (2 ^ ((p + q) / 2)) (2 ^ n))
-  · have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
-        2 ^ (((p + n) + (q + n) - 1) / 2) := by
-      rw [← pow_add]
-      congr 1
-      simp [realCliffordResidue] at hr
-      omega
-    exact castMatrixTargetEquiv hsize
-      (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((p + q - 1) / 2)) (2 ^ n))
-  · have hsize : 2 ^ ((p + q - 2) / 2) * 2 ^ n =
-        2 ^ (((p + n) + (q + n) - 2) / 2) := by
-      rw [← pow_add]
-      congr 1
-      simp [realCliffordResidue] at hr
-      omega
-    exact castMatrixTargetEquiv hsize
-      (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((p + q - 2) / 2)) (2 ^ n))
-  · have hsize : 2 ^ ((p + q - 3) / 2) * 2 ^ n =
-        2 ^ (((p + n) + (q + n) - 3) / 2) := by
-      rw [← pow_add]
-      congr 1
-      simp [realCliffordResidue] at hr
-      omega
-    exact castMatrixProdTargetEquiv hsize
-      (matrixProdTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((p + q - 3) / 2)) (2 ^ n))
-  · have hsize : 2 ^ ((p + q - 2) / 2) * 2 ^ n =
-        2 ^ (((p + n) + (q + n) - 2) / 2) := by
-      rw [← pow_add]
-      congr 1
-      simp [realCliffordResidue] at hr
-      omega
-    exact castMatrixTargetEquiv hsize
-      (matrixTensorMatrixEquiv ℝ ℍ[ℝ] (2 ^ ((p + q - 2) / 2)) (2 ^ n))
-  · have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
-        2 ^ (((p + n) + (q + n) - 1) / 2) := by
-      rw [← pow_add]
-      congr 1
-      simp [realCliffordResidue] at hr
-      omega
-    exact castMatrixTargetEquiv hsize
-      (matrixTensorMatrixEquiv ℝ ℂ (2 ^ ((p + q - 1) / 2)) (2 ^ n))
-  · have hsize : 2 ^ ((p + q) / 2) * 2 ^ n = 2 ^ (((p + n) + (q + n)) / 2) := by
-      rw [← pow_add]
-      congr 1
-      omega
-    exact castMatrixTargetEquiv hsize
-      (matrixTensorMatrixEquiv ℝ ℝ (2 ^ ((p + q) / 2)) (2 ^ n))
-  · have hsize : 2 ^ ((p + q - 1) / 2) * 2 ^ n =
-        2 ^ (((p + n) + (q + n) - 1) / 2) := by
-      rw [← pow_add]
-      congr 1
-      simp [realCliffordResidue] at hr
-      omega
-    exact castMatrixProdTargetEquiv hsize
-      (matrixProdTensorMatrixEquiv ℝ ℝ (2 ^ ((p + q - 1) / 2)) (2 ^ n))
+  · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
+      (matrixEquivTensor (Fin (2 ^ n)) ℝ ℝ).symm
+      (pow_half_sub_add_both p q n 0 (by omega))⟩
+  · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
+      (matrixEquivTensor (Fin (2 ^ n)) ℝ ℂ).symm
+      (pow_half_sub_add_both p q n 1 (by simp [realCliffordResidue] at hr; omega))⟩
+  · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
+      (matrixEquivTensor (Fin (2 ^ n)) ℝ ℍ[ℝ]).symm
+      (pow_half_sub_add_both p q n 2 (by simp [realCliffordResidue] at hr; omega))⟩
+  · exact ⟨matrixProdModelTensorEquiv (realCliffordBottIterEquiv p q n) e
+      (matrixEquivTensor (Fin (2 ^ n)) ℝ ℍ[ℝ]).symm
+      (pow_half_sub_add_both p q n 3 (by simp [realCliffordResidue] at hr; omega))⟩
+  · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
+      (matrixEquivTensor (Fin (2 ^ n)) ℝ ℍ[ℝ]).symm
+      (pow_half_sub_add_both p q n 2 (by simp [realCliffordResidue] at hr; omega))⟩
+  · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
+      (matrixEquivTensor (Fin (2 ^ n)) ℝ ℂ).symm
+      (pow_half_sub_add_both p q n 1 (by simp [realCliffordResidue] at hr; omega))⟩
+  · exact ⟨matrixModelTensorEquiv (realCliffordBottIterEquiv p q n) e
+      (matrixEquivTensor (Fin (2 ^ n)) ℝ ℝ).symm
+      (pow_half_sub_add_both p q n 0 (by omega))⟩
+  · exact ⟨matrixProdModelTensorEquiv (realCliffordBottIterEquiv p q n) e
+      (matrixEquivTensor (Fin (2 ^ n)) ℝ ℝ).symm
+      (pow_half_sub_add_both p q n 1 (by simp [realCliffordResidue] at hr; omega))⟩
 
 /-- The real Clifford algebra of every finite signature is the full matrix algebra, complex
 matrix algebra, quaternionic matrix algebra, or split algebra prescribed by `(q - p) mod 8`. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Classification.lean
@@ -57,6 +57,18 @@ theorem realCliffordResidue_add_add_right (p q n : ℕ) :
   simp only [realCliffordResidue]
   omega
 
+@[simp]
+theorem realCliffordResidue_add_eight_left (p q : ℕ) :
+    realCliffordResidue (p + 8) q = realCliffordResidue p q := by
+  simp only [realCliffordResidue]
+  omega
+
+@[simp]
+theorem realCliffordResidue_add_eight_right (p q : ℕ) :
+    realCliffordResidue p (q + 8) = realCliffordResidue p q := by
+  simp only [realCliffordResidue]
+  omega
+
 /-- The exact real algebra classification of the standard Clifford algebra of signature `(p,q)`.
 The matrix size is stated uniformly in terms of the total dimension. -/
 def IsRealCliffordClassified (p q : ℕ) : Prop :=

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/EightPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/EightPeriodicity.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.NegativePlane
-public import TauCeti.LinearAlgebra.Matrix.TensorProduct
 
 import TauCeti.Algebra.CentralSimple.Quaternion
 
@@ -43,8 +42,8 @@ private abbrev M16 := Matrix (Fin 16) (Fin 16) ℝ
 private def matrixTensorSelf (n : ℕ) :
     Matrix (Fin n) (Fin n) ℝ ⊗[ℝ] Matrix (Fin n) (Fin n) ℝ ≃ₐ[ℝ]
       Matrix (Fin (n * n)) (Fin (n * n)) ℝ :=
-  (Matrix.kroneckerTMulFinAlgEquiv n n ℝ ℝ ℝ).trans
-    (Algebra.TensorProduct.lid ℝ ℝ).mapMatrix
+  (Matrix.kroneckerAlgEquiv (Fin n) (Fin n) ℝ).trans
+    (Matrix.reindexAlgEquiv ℝ ℝ finProdFinEquiv)
 
 private noncomputable def realCliffordEightPeriodicityEquivImpl (p q : ℕ) :
     _root_.CliffordAlgebra (realCliffordForm (p + 8) q) ≃ₐ[ℝ]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/EightPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/EightPeriodicity.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 Tau Ceti Project. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.NegativePlane
+
+import TauCeti.Algebra.CentralSimple.Quaternion
+
+/-!
+# Eight-step periodicity for real Clifford algebras
+
+The matrix and quaternion recurrences combine to identify adding eight positive generators with
+tensoring by sixteen-by-sixteen real matrices.
+
+## Main result
+
+* `realCliffordEightPeriodicityEquiv` gives the eight-step equivalence for every real signature.
+
+## References
+
+* H. B. Lawson and M.-L. Michelsohn, *Spin Geometry*, Chapter I.
+* [TauCeti SpinRepresentations roadmap, Layer 7](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-7-real-clifford-algebras-bott-periodicity-and-spinp-q)
+-/
+
+public section
+
+open scoped Matrix Quaternion TensorProduct
+
+namespace TauCeti
+
+private abbrev C (p q : ℕ) :=
+  _root_.CliffordAlgebra (realCliffordForm p q)
+
+private abbrev M2 := Matrix (Fin 2) (Fin 2) ℝ
+private abbrev M4 := Matrix (Fin 4) (Fin 4) ℝ
+private abbrev M16 := Matrix (Fin 16) (Fin 16) ℝ
+
+private def matrixTensorSelf (n : ℕ) :
+    Matrix (Fin n) (Fin n) ℝ ⊗[ℝ] Matrix (Fin n) (Fin n) ℝ ≃ₐ[ℝ]
+      Matrix (Fin (n * n)) (Fin (n * n)) ℝ :=
+  (Matrix.kroneckerAlgEquiv (Fin n) (Fin n) ℝ).trans
+    (Matrix.reindexAlgEquiv ℝ ℝ finProdFinEquiv)
+
+/-- Eight-step periodicity for standard real Clifford algebras. -/
+noncomputable def realCliffordEightPeriodicityEquiv (p q : ℕ) :
+    _root_.CliffordAlgebra (realCliffordForm (p + 8) q) ≃ₐ[ℝ]
+      _root_.CliffordAlgebra (realCliffordForm p q) ⊗[ℝ]
+        Matrix (Fin 16) (Fin 16) ℝ := by
+  letI : Semiring (ℍ[ℝ] ⊗[ℝ] M2) := Algebra.TensorProduct.instSemiring
+  letI : Algebra ℝ (ℍ[ℝ] ⊗[ℝ] M2) := Algebra.TensorProduct.instAlgebra
+  letI : Semiring (M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2)) := Algebra.TensorProduct.instSemiring
+  letI : Algebra ℝ (M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2)) := Algebra.TensorProduct.instAlgebra
+  letI : Semiring (ℍ[ℝ] ⊗[ℝ] (M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2))) :=
+    Algebra.TensorProduct.instSemiring
+  letI : Algebra ℝ (ℍ[ℝ] ⊗[ℝ] (M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2))) :=
+    Algebra.TensorProduct.instAlgebra
+  letI : Semiring (C p q ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] (M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2)))) :=
+    Algebra.TensorProduct.instSemiring
+  letI : Algebra ℝ (C p q ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] (M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2)))) :=
+    Algebra.TensorProduct.instAlgebra
+  let chain : C (p + 8) q ≃ₐ[ℝ]
+      C p q ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] (M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2))) :=
+    (realCliffordSignatureSwitchRecurrenceEquiv (p + 6) q).trans <|
+      (Algebra.TensorProduct.congr (realCliffordFourNegativeRecurrenceEquiv q (p + 2))
+        (AlgEquiv.refl : M2 ≃ₐ[ℝ] M2)).trans <|
+      (Algebra.TensorProduct.assoc ℝ ℝ ℝ (C q (p + 2) ⊗[ℝ] M2) ℍ[ℝ] M2).trans <|
+      (Algebra.TensorProduct.assoc ℝ ℝ ℝ (C q (p + 2)) M2
+        (ℍ[ℝ] ⊗[ℝ] M2)).trans <|
+      (Algebra.TensorProduct.congr (realCliffordQuaternionRecurrenceEquiv q p)
+        (AlgEquiv.refl : M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2) ≃ₐ[ℝ]
+          M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2))).trans <|
+      Algebra.TensorProduct.assoc ℝ ℝ ℝ (C p q) ℍ[ℝ]
+        (M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2))
+  let normalize :
+      C p q ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] (M2 ⊗[ℝ] (ℍ[ℝ] ⊗[ℝ] M2))) ≃ₐ[ℝ]
+        C p q ⊗[ℝ] M16 :=
+    Algebra.TensorProduct.congr (AlgEquiv.refl : C p q ≃ₐ[ℝ] C p q) <|
+      (Algebra.TensorProduct.leftComm ℝ ℍ[ℝ] M2 (ℍ[ℝ] ⊗[ℝ] M2)).trans <|
+      (Algebra.TensorProduct.congr (AlgEquiv.refl : M2 ≃ₐ[ℝ] M2)
+        (Algebra.TensorProduct.assoc ℝ ℝ ℝ ℍ[ℝ] ℍ[ℝ] M2).symm).trans <|
+      (Algebra.TensorProduct.congr (AlgEquiv.refl : M2 ≃ₐ[ℝ] M2)
+        (Algebra.TensorProduct.congr Quaternion.tensorSelfAlgEquivMatrix
+          (AlgEquiv.refl : M2 ≃ₐ[ℝ] M2))).trans <|
+      (Algebra.TensorProduct.leftComm ℝ M2 M4 M2).trans <|
+      (Algebra.TensorProduct.congr (AlgEquiv.refl : M4 ≃ₐ[ℝ] M4)
+        (matrixTensorSelf 2)).trans (matrixTensorSelf 4)
+  exact chain.trans normalize
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/EightPeriodicity.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/EightPeriodicity.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.LinearAlgebra.CliffordAlgebra.NegativePlane
+public import TauCeti.LinearAlgebra.Matrix.TensorProduct
 
 import TauCeti.Algebra.CentralSimple.Quaternion
 
@@ -17,7 +18,8 @@ tensoring by sixteen-by-sixteen real matrices.
 
 ## Main result
 
-* `realCliffordEightPeriodicityEquiv` gives the eight-step equivalence for every real signature.
+* `nonempty_realCliffordEightPeriodicityEquiv` gives the eight-step equivalence for every real
+  signature.
 
 ## References
 
@@ -41,11 +43,10 @@ private abbrev M16 := Matrix (Fin 16) (Fin 16) ℝ
 private def matrixTensorSelf (n : ℕ) :
     Matrix (Fin n) (Fin n) ℝ ⊗[ℝ] Matrix (Fin n) (Fin n) ℝ ≃ₐ[ℝ]
       Matrix (Fin (n * n)) (Fin (n * n)) ℝ :=
-  (Matrix.kroneckerAlgEquiv (Fin n) (Fin n) ℝ).trans
-    (Matrix.reindexAlgEquiv ℝ ℝ finProdFinEquiv)
+  (Matrix.kroneckerTMulFinAlgEquiv n n ℝ ℝ ℝ).trans
+    (Algebra.TensorProduct.lid ℝ ℝ).mapMatrix
 
-/-- Eight-step periodicity for standard real Clifford algebras. -/
-noncomputable def realCliffordEightPeriodicityEquiv (p q : ℕ) :
+private noncomputable def realCliffordEightPeriodicityEquivImpl (p q : ℕ) :
     _root_.CliffordAlgebra (realCliffordForm (p + 8) q) ≃ₐ[ℝ]
       _root_.CliffordAlgebra (realCliffordForm p q) ⊗[ℝ]
         Matrix (Fin 16) (Fin 16) ℝ := by
@@ -88,5 +89,12 @@ noncomputable def realCliffordEightPeriodicityEquiv (p q : ℕ) :
       (Algebra.TensorProduct.congr (AlgEquiv.refl : M4 ≃ₐ[ℝ] M4)
         (matrixTensorSelf 2)).trans (matrixTensorSelf 4)
   exact chain.trans normalize
+
+/-- Eight-step periodicity for standard real Clifford algebras. -/
+theorem nonempty_realCliffordEightPeriodicityEquiv (p q : ℕ) :
+    Nonempty (_root_.CliffordAlgebra (realCliffordForm (p + 8) q) ≃ₐ[ℝ]
+      _root_.CliffordAlgebra (realCliffordForm p q) ⊗[ℝ]
+        Matrix (Fin 16) (Fin 16) ℝ) :=
+  ⟨realCliffordEightPeriodicityEquivImpl p q⟩
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
@@ -16,7 +16,7 @@ matrix algebras.
 
 ## Main result
 
-* `TauCeti.Matrix.kroneckerTMulFinAlgEquiv`: matrix absorption
+* `Matrix.kroneckerTMulFinAlgEquiv`: matrix absorption
   `M_m(A) ⊗[R] M_n(B) ≃ₐ[R] M_(mn)(A ⊗[R] B)`.
 -/
 
@@ -24,11 +24,11 @@ public section
 
 open scoped Kronecker TensorProduct
 
-namespace TauCeti
+namespace Matrix
 
 /-- **Matrix absorption**: `M_m(A) ⊗[R] M_n(B) ≃ₐ[R] M_(mn)(A ⊗[R] B)`, over any commutative
 semiring `R` and any two `R`-algebras, in any two sizes. -/
-def Matrix.kroneckerTMulFinAlgEquiv (m n : ℕ) (R : Type*) [CommSemiring R] (A : Type*) [Semiring A]
+def kroneckerTMulFinAlgEquiv (m n : ℕ) (R : Type*) [CommSemiring R] (A : Type*) [Semiring A]
     [Algebra R A] (B : Type*) [Semiring B] [Algebra R B] :
     Matrix (Fin m) (Fin m) A ⊗[R] Matrix (Fin n) (Fin n) B ≃ₐ[R]
       Matrix (Fin (m * n)) (Fin (m * n)) (A ⊗[R] B) :=
@@ -38,7 +38,7 @@ def Matrix.kroneckerTMulFinAlgEquiv (m n : ℕ) (R : Type*) [CommSemiring R] (A 
 /-- The finite-index matrix absorption equivalence sends a pure tensor to the reindexed
 Kronecker tensor product. -/
 @[simp]
-theorem Matrix.kroneckerTMulFinAlgEquiv_tmul (m n : ℕ) (R : Type*) [CommSemiring R]
+theorem kroneckerTMulFinAlgEquiv_tmul (m n : ℕ) (R : Type*) [CommSemiring R]
     (A : Type*) [Semiring A] [Algebra R A] (B : Type*) [Semiring B] [Algebra R B]
     (a : Matrix (Fin m) (Fin m) A) (b : Matrix (Fin n) (Fin n) B) :
     Matrix.kroneckerTMulFinAlgEquiv m n R A B (a ⊗ₜ[R] b) =
@@ -48,7 +48,7 @@ theorem Matrix.kroneckerTMulFinAlgEquiv_tmul (m n : ℕ) (R : Type*) [CommSemiri
 /-- The inverse finite-index matrix absorption equivalence sends a matrix unit at paired finite
 indices with a pure-tensor coefficient to the tensor of the two corresponding matrix units. -/
 @[simp]
-theorem Matrix.kroneckerTMulFinAlgEquiv_symm_single_tmul (m n : ℕ) (R : Type*)
+theorem kroneckerTMulFinAlgEquiv_symm_single_tmul (m n : ℕ) (R : Type*)
     [CommSemiring R] (A : Type*) [Semiring A] [Algebra R A] (B : Type*) [Semiring B]
     [Algebra R B] (ia ja : Fin m) (ib jb : Fin n) (a : A) (b : B) :
     (Matrix.kroneckerTMulFinAlgEquiv m n R A B).symm
@@ -58,4 +58,4 @@ theorem Matrix.kroneckerTMulFinAlgEquiv_symm_single_tmul (m n : ℕ) (R : Type*)
   rw [Matrix.kroneckerTMulFinAlgEquiv_tmul, Matrix.single_kroneckerTMul_single]
   simp
 
-end TauCeti
+end Matrix

--- a/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.RingTheory.MatrixAlgebra
 public import Mathlib.LinearAlgebra.Matrix.Reindex
+public import Mathlib.LinearAlgebra.Matrix.Unique
 
 /-!
 # Tensor products of matrix algebras
@@ -16,6 +17,7 @@ matrix algebras.
 
 ## Main result
 
+* `Matrix.finOneAlgEquiv`: the canonical equivalence `A ≃ₐ[R] M₁(A)` using `Fin 1` indices.
 * `Matrix.kroneckerTMulFinAlgEquiv`: matrix absorption
   `M_m(A) ⊗[R] M_n(B) ≃ₐ[R] M_(mn)(A ⊗[R] B)`.
 -/
@@ -25,6 +27,24 @@ public section
 open scoped Kronecker TensorProduct
 
 namespace Matrix
+
+/-- The canonical one-by-one matrix equivalence with `Fin 1` indices. -/
+def finOneAlgEquiv (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A] :
+    A ≃ₐ[R] Matrix (Fin 1) (Fin 1) A :=
+  (Matrix.uniqueAlgEquiv (R := R) (A := A) (m := Unit)).symm.trans
+    (Matrix.reindexAlgEquiv R A (Equiv.ofUnique Unit (Fin 1)))
+
+/-- The one-by-one matrix equivalence sends a scalar to the constant one-by-one matrix. -/
+@[simp]
+theorem finOneAlgEquiv_apply (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A]
+    (a : A) (i j : Fin 1) : Matrix.finOneAlgEquiv R A a i j = a := by
+  simp [finOneAlgEquiv]
+
+/-- The inverse one-by-one matrix equivalence extracts the unique entry. -/
+@[simp]
+theorem finOneAlgEquiv_symm_apply (R A : Type*) [CommSemiring R] [Semiring A] [Algebra R A]
+    (M : Matrix (Fin 1) (Fin 1) A) : (Matrix.finOneAlgEquiv R A).symm M = M 0 0 := by
+  simp [finOneAlgEquiv]
 
 /-- **Matrix absorption**: `M_m(A) ⊗[R] M_n(B) ≃ₐ[R] M_(mn)(A ⊗[R] B)`, over any commutative
 semiring `R` and any two `R`-algebras, in any two sizes. -/

--- a/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
@@ -43,7 +43,9 @@ theorem kroneckerTMulFinAlgEquiv_tmul (m n : ℕ) (R : Type*) [CommSemiring R]
     (a : Matrix (Fin m) (Fin m) A) (b : Matrix (Fin n) (Fin n) B) :
     Matrix.kroneckerTMulFinAlgEquiv m n R A B (a ⊗ₜ[R] b) =
       Matrix.reindex finProdFinEquiv finProdFinEquiv (a ⊗ₖₜ b) := by
-  rfl
+  simp only [kroneckerTMulFinAlgEquiv, AlgEquiv.trans_apply,
+    Matrix.kroneckerTMulAlgEquiv_apply, kroneckerTMulLinearEquiv_tmul,
+    Matrix.coe_reindexAlgEquiv]
 
 /-- The inverse finite-index matrix absorption equivalence sends a matrix unit at paired finite
 indices with a pure-tensor coefficient to the tensor of the two corresponding matrix units. -/

--- a/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
@@ -22,7 +22,7 @@ matrix algebras.
 
 public section
 
-open scoped TensorProduct
+open scoped Kronecker TensorProduct
 
 namespace TauCeti
 
@@ -34,5 +34,28 @@ def Matrix.kroneckerTMulFinAlgEquiv (m n : ℕ) (R : Type*) [CommSemiring R] (A 
       Matrix (Fin (m * n)) (Fin (m * n)) (A ⊗[R] B) :=
   (Matrix.kroneckerTMulAlgEquiv (Fin m) (Fin n) R R A B).trans
     (Matrix.reindexAlgEquiv R _ finProdFinEquiv)
+
+/-- The finite-index matrix absorption equivalence sends a pure tensor to the reindexed
+Kronecker tensor product. -/
+@[simp]
+theorem Matrix.kroneckerTMulFinAlgEquiv_tmul (m n : ℕ) (R : Type*) [CommSemiring R]
+    (A : Type*) [Semiring A] [Algebra R A] (B : Type*) [Semiring B] [Algebra R B]
+    (a : Matrix (Fin m) (Fin m) A) (b : Matrix (Fin n) (Fin n) B) :
+    Matrix.kroneckerTMulFinAlgEquiv m n R A B (a ⊗ₜ[R] b) =
+      Matrix.reindex finProdFinEquiv finProdFinEquiv (a ⊗ₖₜ b) := by
+  rfl
+
+/-- The inverse finite-index matrix absorption equivalence sends a matrix unit at paired finite
+indices with a pure-tensor coefficient to the tensor of the two corresponding matrix units. -/
+@[simp]
+theorem Matrix.kroneckerTMulFinAlgEquiv_symm_single_tmul (m n : ℕ) (R : Type*)
+    [CommSemiring R] (A : Type*) [Semiring A] [Algebra R A] (B : Type*) [Semiring B]
+    [Algebra R B] (ia ja : Fin m) (ib jb : Fin n) (a : A) (b : B) :
+    (Matrix.kroneckerTMulFinAlgEquiv m n R A B).symm
+        (Matrix.single (finProdFinEquiv (ia, ib)) (finProdFinEquiv (ja, jb)) (a ⊗ₜ[R] b)) =
+      Matrix.single ia ja a ⊗ₜ[R] Matrix.single ib jb b := by
+  rw [AlgEquiv.symm_apply_eq]
+  rw [Matrix.kroneckerTMulFinAlgEquiv_tmul, Matrix.single_kroneckerTMul_single]
+  simp
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
+++ b/TauCeti/LinearAlgebra/Matrix/TensorProduct.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.MatrixAlgebra
+public import Mathlib.LinearAlgebra.Matrix.Reindex
+
+/-!
+# Tensor products of matrix algebras
+
+This file records the finite-index form of the Kronecker equivalence for tensor products of
+matrix algebras.
+
+## Main result
+
+* `TauCeti.Matrix.kroneckerTMulFinAlgEquiv`: matrix absorption
+  `M_m(A) ⊗[R] M_n(B) ≃ₐ[R] M_(mn)(A ⊗[R] B)`.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+/-- **Matrix absorption**: `M_m(A) ⊗[R] M_n(B) ≃ₐ[R] M_(mn)(A ⊗[R] B)`, over any commutative
+semiring `R` and any two `R`-algebras, in any two sizes. -/
+def Matrix.kroneckerTMulFinAlgEquiv (m n : ℕ) (R : Type*) [CommSemiring R] (A : Type*) [Semiring A]
+    [Algebra R A] (B : Type*) [Semiring B] [Algebra R B] :
+    Matrix (Fin m) (Fin m) A ⊗[R] Matrix (Fin n) (Fin n) B ≃ₐ[R]
+      Matrix (Fin (m * n)) (Fin (m * n)) (A ⊗[R] B) :=
+  (Matrix.kroneckerTMulAlgEquiv (Fin m) (Fin n) R R A B).trans
+    (Matrix.reindexAlgEquiv R _ finProdFinEquiv)
+
+end TauCeti


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Classifies the standard real Clifford algebras by signature modulo eight.

- Combines the public real recurrence theorems into an eight-step equivalence.\n- Exposes residue invariance under an eight-step shift of either signature index.
- States the exact matrix, complex, quaternionic, and split cases.
- Proves the table for every pair of signature indices.
- Exposes direct elimination theorems for each residue case.

## Roadmap target

Completes the algebraic classification in [SpinRepresentations Layer 7](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-7-real-clifford-algebras-bott-periodicity-and-spinp-q).

The required Layer 1 structure theorem is merged in [#4287](https://github.com/TauCetiProject/TauCeti/pull/4287). The Layer 2 compact real double-cover package is open in [#4705](https://github.com/TauCetiProject/TauCeti/pull/4705).

## Verification

Focused and full `--iofail` builds, the allowed-axiom and module audits, environment\/style\/dot-notation lints, bare-`simp` periodicity consumers, and fresh contract-first plus structure-first 13-rubric aggregate reviews pass at exact head `287eedd820e2f3d50927c00eefebd20812780625` and tree `4da34eab1cb551e29269b3761d33e4abd4aa1d61`.

## Scale and generality

Adds 674 lines and removes 27 across five files, covering every standard real signature while keeping generic matrix transport in its natural owner.

## Scope

- **Consumes:** the Bott, signature-switch, quaternion, and four-negative real Clifford recurrences.
- **Provides:** eight-step periodicity, the exact mod-eight classification table, and direct residue-specific table cases.
- **Fits:** completes the algebraic part of Layer 7 used by later real Spin structure theory.
- **Boundary:** real Pin/Spin groups and connectivity remain downstream.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [98e9b07](https://github.com/TauCetiProject/TauCetiReview/commit/98e9b073b76e65285fa72d4b8e0a61e272a78fd8) · current-head API repair @ `287eedd8`</sub>