### PR TITLE
feat: the graphon partition energy and its Pythagoras increment

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/Basic.lean
@@ -6,6 +6,8 @@ Authors: Claude
 module
 
 public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
+public import Mathlib.MeasureTheory.Integral.Prod
+import Mathlib.MeasureTheory.Measure.FiniteMeasure
 
 /-!
 # Symmetric kernels
@@ -44,6 +46,8 @@ Consequently the algebra below needs no hypothesis on `μ` at all — in particu
 * `AddCommGroup` and `Module ℝ` instances, defined pointwise. The `coe_zero`, `coe_add`, `coe_neg`,
   `coe_sub` and `coe_smul` simp lemmas identify every operation with the corresponding operation on
   `Ω → Ω → ℝ`, so the module structure can be computed entirely by `simp`.
+* `SymmKernel.integrable_uncurry` says that a bounded kernel is integrable on the product of two
+  finite copies of its measure.
 * `comap_apply` evaluates a pullback, and `comap_zero` / `comap_add` / `comap_neg` / `comap_sub` /
   `comap_smul` say that pulling back is linear, so a pullback of a difference of kernels is the
   difference of the pullbacks. `comap_id` and `comap_comap` are the functoriality laws.
@@ -115,6 +119,13 @@ theorem measurable (K : SymmKernel Ω μ) : Measurable (Function.uncurry (K : Ω
 
 /-- A symmetric kernel is uniformly bounded. The constant is not canonical. -/
 theorem exists_bound (K : SymmKernel Ω μ) : ∃ C, ∀ x y, |K x y| ≤ C := K.bdd'
+
+/-- A bounded symmetric kernel is integrable on the product of two finite copies of its measure. -/
+theorem integrable_uncurry (μ : Measure Ω) [IsFiniteMeasure μ] (K : SymmKernel Ω μ) :
+    Integrable (fun p : Ω × Ω => K p.1 p.2) (μ.prod μ) := by
+  obtain ⟨C, hC⟩ := K.exists_bound
+  refine Integrable.of_bound K.measurable.aestronglyMeasurable C (ae_of_all _ fun p => ?_)
+  simpa [Function.uncurry_apply_pair, Real.norm_eq_abs] using hC p.1 p.2
 
 section Algebra
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/CutNorm.lean
@@ -78,13 +78,6 @@ variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω)
 
 namespace SymmKernel
 
-/-- A bounded symmetric kernel is integrable on the product of two finite copies of its measure. -/
-theorem integrable_uncurry [IsFiniteMeasure μ] (K : SymmKernel Ω μ) :
-    Integrable (fun p : Ω × Ω => K p.1 p.2) (μ.prod μ) := by
-  obtain ⟨C, hC⟩ := K.exists_bound
-  refine Integrable.of_bound K.measurable.aestronglyMeasurable C (ae_of_all _ fun p => ?_)
-  simpa [Function.uncurry_apply_pair, Real.norm_eq_abs] using hC p.1 p.2
-
 /-- The integral of a symmetric kernel over the rectangle `S × T`. -/
 noncomputable def rectIntegral (K : SymmKernel Ω μ) (S T : Set Ω) : ℝ :=
   ∫ p in S ×ˢ T, K p.1 p.2 ∂(μ.prod μ)

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -5,7 +5,7 @@ Authors: Claude
 -/
 module
 
-public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
+public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Basic
 public import Mathlib.MeasureTheory.Integral.Prod
 
 /-!
@@ -17,7 +17,7 @@ defines the integrals `l2inner μ K L = ∫ K · L` and `l2sq μ K = ∫ K²` at
 symmetric kernels.  When `μ` is finite, bounded kernels are square-integrable, so these integrals
 are the `L²(μ ⊗ μ)` inner product and its induced norm squared.  The integrability of a single
 kernel over the product carrier is already available as `SymmKernel.integrable_uncurry` from the
-rectangle-integral layer, and everything here is built on it.
+basic kernel layer, and everything here is built on it.
 
 **Why plain integrals and not `Lp`.**  A `SymmKernel` is a strict everywhere-defined
 representative, and the whole point of that convention is that a difference `K - L` is again a

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -6,7 +6,6 @@ Authors: Claude
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Basic
-public import Mathlib.MeasureTheory.Integral.Prod
 
 /-!
 # The `L²` pairing of symmetric kernels

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -14,9 +14,10 @@ The Frieze--Kannan weak regularity argument runs on an `L²(μ ⊗ μ)` potentia
 step graphons of a refinement chain must be compared in `L²` and not only in cut norm.  This file
 defines the integrals `l2inner μ K L = ∫ K · L` and `l2sq μ K = ∫ K²` at the level of strict
 symmetric kernels.  When `μ` is finite, bounded kernels are square-integrable, so these integrals
-are the `L²(μ ⊗ μ)` inner product and its induced norm squared.  The integrability of a single
-kernel over the product carrier is already available as `SymmKernel.integrable_uncurry` from the
-basic kernel layer, and everything here is built on it.
+are the `L²(μ ⊗ μ)` integral pairing and squared seminorm on strict representatives.  They induce
+the genuine inner product and norm squared after quotienting by a.e. equality.  The integrability
+of a single kernel over the product carrier is already available as
+`SymmKernel.integrable_uncurry` from the basic kernel layer, and everything here is built on it.
 
 **Why plain integrals and not `Lp`.**  A `SymmKernel` is a strict everywhere-defined
 representative, and the whole point of that convention is that a difference `K - L` is again a
@@ -33,17 +34,17 @@ the expansion `l2sq_sub` needs no additional side conditions.
 ## Main results
 
 * `TauCeti.DenseGraphLimits.SymmKernel.integrable_mul` is the integrability behind both;
-* `TauCeti.DenseGraphLimits.l2sq_sub` expands the norm squared of a difference — the identity the
-  Pythagoras energy increment is read off from;
-* `TauCeti.DenseGraphLimits.l2sq_le_one_of_abs_le_one` bounds the norm squared of a kernel with
-  values in `[-1, 1]` over a probability carrier.
+* `TauCeti.DenseGraphLimits.l2sq_sub` expands the squared seminorm of a difference — the identity
+  the Pythagoras energy increment is read off from;
+* `TauCeti.DenseGraphLimits.l2sq_le_one_of_abs_le_one` bounds the squared seminorm of a kernel
+  with values in `[-1, 1]` over a probability carrier.
 
 ## References
 
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), §9.2.
 * Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 1/2 — `l2sq` and the analytic energy
   stack.  The `l2sq` signature and the `l2sq_nonneg` proof are taken from
-  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` (Layer 1/2); the inner product `l2inner` and its
+  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` (Layer 1/2); the pairing `l2inner` and its
   bilinear API are developed here.
 -/
 
@@ -77,7 +78,7 @@ theorem integrable_sq [IsFiniteMeasure μ] (K : SymmKernel Ω μ) :
 end SymmKernel
 
 /-- The integral of the product of two symmetric kernels.  For finite `μ`, this is their
-`L²(μ ⊗ μ)` inner product. -/
+`L²(μ ⊗ μ)` integral pairing, which becomes an inner product after quotienting by a.e. equality. -/
 def l2inner (K L : SymmKernel Ω μ) : ℝ := ∫ p, K p.1 p.2 * L p.1 p.2 ∂(μ.prod μ)
 
 /-- The defining equation of `l2inner`. The definition's body is not exposed across module
@@ -85,8 +86,8 @@ boundaries, so this is the unfolding lemma downstream modules should use. -/
 theorem l2inner_def (K L : SymmKernel Ω μ) :
     l2inner μ K L = ∫ p, K p.1 p.2 * L p.1 p.2 ∂(μ.prod μ) := (rfl)
 
-/-- The integral of the square of a symmetric kernel.  For finite `μ`, this is its `L²(μ ⊗ μ)`
-norm squared. -/
+/-- The integral of the square of a symmetric kernel.  For finite `μ`, this is its squared
+`L²(μ ⊗ μ)` seminorm, which becomes a squared norm after quotienting by a.e. equality. -/
 def l2sq (K : SymmKernel Ω μ) : ℝ := ∫ p, K p.1 p.2 ^ 2 ∂(μ.prod μ)
 
 /-- The defining equation of `l2sq`. The definition's body is not exposed across module boundaries,
@@ -94,16 +95,16 @@ so this is the unfolding lemma downstream modules should use. -/
 theorem l2sq_def (K : SymmKernel Ω μ) :
     l2sq μ K = ∫ p, K p.1 p.2 ^ 2 ∂(μ.prod μ) := (rfl)
 
-/-- The `L²` norm squared is the inner product of a kernel with itself. -/
+/-- The squared `L²` seminorm is the integral pairing of a kernel with itself. -/
 theorem l2sq_eq_l2inner_self (K : SymmKernel Ω μ) : l2sq μ K = l2inner μ K K := by
   simp only [l2sq_def, l2inner_def, sq]
 
-/-- The `L²` norm squared is nonnegative: it is the integral of a square. -/
+/-- The squared `L²` seminorm is nonnegative: it is the integral of a square. -/
 theorem l2sq_nonneg (K : SymmKernel Ω μ) : 0 ≤ l2sq μ K := by
   rw [l2sq_def]
   exact integral_nonneg fun _ => sq_nonneg _
 
-/-- The `L²` inner product is symmetric. -/
+/-- The `L²` integral pairing is symmetric. -/
 theorem l2inner_comm (K L : SymmKernel Ω μ) : l2inner μ K L = l2inner μ L K := by
   simp only [l2inner_def, mul_comm]
 
@@ -144,12 +145,12 @@ theorem l2inner_smul_right (c : ℝ) (K L : SymmKernel Ω μ) :
 theorem l2sq_zero : l2sq μ (0 : SymmKernel Ω μ) = 0 := by
   simp [l2sq_def]
 
-/-- The `L²` norm squared is unchanged by negation. -/
+/-- The squared `L²` seminorm is unchanged by negation. -/
 @[simp]
 theorem l2sq_neg (K : SymmKernel Ω μ) : l2sq μ (-K) = l2sq μ K := by
   simp [l2sq_eq_l2inner_self]
 
-/-- Scaling a kernel scales its `L²` norm squared by the square of the scalar. -/
+/-- Scaling a kernel scales its squared `L²` seminorm by the square of the scalar. -/
 @[simp]
 theorem l2sq_smul (c : ℝ) (K : SymmKernel Ω μ) : l2sq μ (c • K) = c ^ 2 * l2sq μ K := by
   rw [l2sq_eq_l2inner_self, l2inner_smul_left, l2inner_smul_right, l2sq_eq_l2inner_self]
@@ -157,34 +158,34 @@ theorem l2sq_smul (c : ℝ) (K : SymmKernel Ω μ) : l2sq μ (c • K) = c ^ 2 *
 
 variable [IsFiniteMeasure μ]
 
-/-- The `L²` inner product is additive in its left argument. -/
+/-- The `L²` integral pairing is additive in its left argument. -/
 @[simp]
 theorem l2inner_add_left (K L M : SymmKernel Ω μ) :
     l2inner μ (K + L) M = l2inner μ K M + l2inner μ L M := by
   simp only [l2inner_def, SymmKernel.coe_add, Pi.add_apply, add_mul]
   exact integral_add (SymmKernel.integrable_mul μ K M) (SymmKernel.integrable_mul μ L M)
 
-/-- The `L²` inner product is additive in its right argument. -/
+/-- The `L²` integral pairing is additive in its right argument. -/
 @[simp]
 theorem l2inner_add_right (K L M : SymmKernel Ω μ) :
     l2inner μ K (L + M) = l2inner μ K L + l2inner μ K M := by
   rw [l2inner_comm, l2inner_add_left, l2inner_comm μ L K, l2inner_comm μ M K]
 
-/-- The `L²` inner product subtracts in its left argument. -/
+/-- The `L²` integral pairing subtracts in its left argument. -/
 @[simp]
 theorem l2inner_sub_left (K L M : SymmKernel Ω μ) :
     l2inner μ (K - L) M = l2inner μ K M - l2inner μ L M := by
   simp only [l2inner_def, SymmKernel.coe_sub, Pi.sub_apply, sub_mul]
   exact integral_sub (SymmKernel.integrable_mul μ K M) (SymmKernel.integrable_mul μ L M)
 
-/-- The `L²` inner product subtracts in its right argument. -/
+/-- The `L²` integral pairing subtracts in its right argument. -/
 @[simp]
 theorem l2inner_sub_right (K L M : SymmKernel Ω μ) :
     l2inner μ K (L - M) = l2inner μ K L - l2inner μ K M := by
   rw [l2inner_comm μ, l2inner_sub_left, l2inner_comm μ M K, l2inner_comm μ L K]
 
-/-- The expansion of the `L²` norm squared of a difference.  Read backwards with a vanishing cross
-term, this is the Pythagoras identity the energy increment uses. -/
+/-- The expansion of the squared `L²` seminorm of a difference.  Read backwards with a vanishing
+cross term, this is the Pythagoras identity the energy increment uses. -/
 theorem l2sq_sub (K L : SymmKernel Ω μ) :
     l2sq μ (K - L) = l2sq μ K - 2 * l2inner μ K L + l2sq μ L := by
   rw [l2sq_eq_l2inner_self, l2inner_sub_left, l2inner_sub_right, l2inner_sub_right,
@@ -192,7 +193,7 @@ theorem l2sq_sub (K L : SymmKernel Ω μ) :
   ring
 
 omit [IsFiniteMeasure μ] in
-/-- A kernel with values in `[-1, 1]` has `L²` norm squared at most `1` over a probability
+/-- A kernel with values in `[-1, 1]` has squared `L²` seminorm at most `1` over a probability
 carrier. -/
 theorem l2sq_le_one_of_abs_le_one [IsProbabilityMeasure μ] (K : SymmKernel Ω μ)
     (h : ∀ x y, |K x y| ≤ 1) : l2sq μ K ≤ 1 := by

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -153,7 +153,7 @@ theorem l2sq_neg (K : SymmKernel Ω μ) : l2sq μ (-K) = l2sq μ K := by
 /-- Scaling a kernel scales its squared `L²` seminorm by the square of the scalar. -/
 @[simp]
 theorem l2sq_smul (c : ℝ) (K : SymmKernel Ω μ) : l2sq μ (c • K) = c ^ 2 * l2sq μ K := by
-  rw [l2sq_eq_l2inner_self, l2inner_smul_left, l2inner_smul_right, l2sq_eq_l2inner_self]
+  simp only [l2sq_eq_l2inner_self, l2inner_smul_left, l2inner_smul_right]
   ring
 
 variable [IsFiniteMeasure μ]
@@ -188,8 +188,8 @@ theorem l2inner_sub_right (K L M : SymmKernel Ω μ) :
 cross term, this is the Pythagoras identity the energy increment uses. -/
 theorem l2sq_sub (K L : SymmKernel Ω μ) :
     l2sq μ (K - L) = l2sq μ K - 2 * l2inner μ K L + l2sq μ L := by
-  rw [l2sq_eq_l2inner_self, l2inner_sub_left, l2inner_sub_right, l2inner_sub_right,
-    l2inner_comm μ L K, l2sq_eq_l2inner_self μ K, l2sq_eq_l2inner_self μ L]
+  simp only [l2sq_eq_l2inner_self, l2inner_sub_left, l2inner_sub_right]
+  rw [l2inner_comm μ L K]
   ring
 
 omit [IsFiniteMeasure μ] in

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -5,9 +5,8 @@ Authors: Claude
 -/
 module
 
-public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Basic
+public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
 public import Mathlib.MeasureTheory.Integral.Prod
-import Mathlib.MeasureTheory.Measure.FiniteMeasure
 
 /-!
 # The `L²` pairing of symmetric kernels
@@ -16,7 +15,9 @@ The Frieze--Kannan weak regularity argument runs on an `L²(μ ⊗ μ)` potentia
 step graphons of a refinement chain must be compared in `L²` and not only in cut norm.  This file
 defines the integrals `l2inner μ K L = ∫ K · L` and `l2sq μ K = ∫ K²` at the level of strict
 symmetric kernels.  When `μ` is finite, bounded kernels are square-integrable, so these integrals
-are the `L²(μ ⊗ μ)` inner product and its induced norm squared.
+are the `L²(μ ⊗ μ)` inner product and its induced norm squared.  The integrability of a single
+kernel over the product carrier is already available as `SymmKernel.integrable_uncurry` from the
+rectangle-integral layer, and everything here is built on it.
 
 **Why plain integrals and not `Lp`.**  A `SymmKernel` is a strict everywhere-defined
 representative, and the whole point of that convention is that a difference `K - L` is again a
@@ -42,7 +43,9 @@ the expansion `l2sq_sub` needs no additional side conditions.
 
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), §9.2.
 * Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 1/2 — `l2sq` and the analytic energy
-  stack.
+  stack.  The `l2sq` signature and the `l2sq_nonneg` proof are taken from
+  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` (Layer 1/2); the inner product `l2inner` and its
+  bilinear API are developed here.
 -/
 
 public section
@@ -64,13 +67,8 @@ bounded, and the product measure of a finite measure with itself is finite. -/
 theorem integrable_mul [IsFiniteMeasure μ] (K L : SymmKernel Ω μ) :
     Integrable (fun p : Ω × Ω => K p.1 p.2 * L p.1 p.2) (μ.prod μ) := by
   obtain ⟨C, hC⟩ := K.exists_bound
-  obtain ⟨D, hD⟩ := L.exists_bound
-  have hmeas : Measurable fun p : Ω × Ω => K p.1 p.2 * L p.1 p.2 := K.measurable.mul L.measurable
-  refine Integrable.of_bound hmeas.aestronglyMeasurable (C * D) (ae_of_all _ fun p => ?_)
-  have hCp := hC p.1 p.2
-  have hDp := hD p.1 p.2
-  rw [Real.norm_eq_abs, abs_mul]
-  exact mul_le_mul hCp hDp (abs_nonneg _) ((abs_nonneg _).trans hCp)
+  exact (L.integrable_uncurry μ).bdd_mul K.measurable.aestronglyMeasurable
+    (ae_of_all _ fun p => by simpa [Real.norm_eq_abs] using hC p.1 p.2)
 
 /-- A symmetric kernel is square integrable on the product carrier. -/
 theorem integrable_sq [IsFiniteMeasure μ] (K : SymmKernel Ω μ) :
@@ -130,9 +128,33 @@ theorem l2inner_neg_left (K L : SymmKernel Ω μ) : l2inner μ (-K) L = -l2inner
 theorem l2inner_neg_right (K L : SymmKernel Ω μ) : l2inner μ K (-L) = -l2inner μ K L := by
   rw [l2inner_comm, l2inner_neg_left, l2inner_comm μ L K]
 
+/-- Scaling the left argument scales the pairing. -/
+@[simp]
+theorem l2inner_smul_left (c : ℝ) (K L : SymmKernel Ω μ) :
+    l2inner μ (c • K) L = c * l2inner μ K L := by
+  simp only [l2inner_def, SymmKernel.coe_smul, Pi.smul_apply, smul_eq_mul, mul_assoc,
+    integral_const_mul]
+
+/-- Scaling the right argument scales the pairing. -/
+@[simp]
+theorem l2inner_smul_right (c : ℝ) (K L : SymmKernel Ω μ) :
+    l2inner μ K (c • L) = c * l2inner μ K L := by
+  rw [l2inner_comm, l2inner_smul_left, l2inner_comm μ L K]
+
 @[simp]
 theorem l2sq_zero : l2sq μ (0 : SymmKernel Ω μ) = 0 := by
   simp [l2sq_def]
+
+/-- The `L²` norm squared is unchanged by negation. -/
+@[simp]
+theorem l2sq_neg (K : SymmKernel Ω μ) : l2sq μ (-K) = l2sq μ K := by
+  simp [l2sq_eq_l2inner_self]
+
+/-- Scaling a kernel scales its `L²` norm squared by the square of the scalar. -/
+@[simp]
+theorem l2sq_smul (c : ℝ) (K : SymmKernel Ω μ) : l2sq μ (c • K) = c ^ 2 * l2sq μ K := by
+  rw [l2sq_eq_l2inner_self, l2inner_smul_left, l2inner_smul_right, l2sq_eq_l2inner_self]
+  ring
 
 variable [IsFiniteMeasure μ]
 
@@ -179,8 +201,7 @@ theorem l2sq_le_one_of_abs_le_one [IsProbabilityMeasure μ] (K : SymmKernel Ω �
   calc
     (∫ p : Ω × Ω, K p.1 p.2 ^ 2 ∂(μ.prod μ)) ≤ ∫ _p : Ω × Ω, (1 : ℝ) ∂(μ.prod μ) := by
       refine integral_mono (SymmKernel.integrable_sq μ K) (integrable_const 1) fun p => ?_
-      have hp := h p.1 p.2
-      nlinarith [abs_nonneg (K p.1 p.2), sq_abs (K p.1 p.2)]
+      exact (sq_le_one_iff_abs_le_one _).2 (h p.1 p.2)
     _ = 1 := by simp
 
 end DenseGraphLimits

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
+
+/-!
+# The `L²` pairing of symmetric kernels
+
+The Frieze--Kannan weak regularity argument runs on an `L²(μ ⊗ μ)` potential, so the block-average
+step graphons of a refinement chain must be compared in `L²` and not only in cut norm.  This file
+supplies that pairing at the level of strict symmetric kernels: `l2inner` is the `L²(μ ⊗ μ)` inner
+product `∫ K · L` and `l2sq` is the induced norm squared `∫ K²`.
+
+**Why plain integrals and not `Lp`.**  A `SymmKernel` is a strict everywhere-defined
+representative, and the whole point of that convention is that a difference `K - L` is again a
+literal kernel.  Passing through `MeasureTheory.Lp` would replace each kernel by an a.e. class and
+force a.e. bookkeeping into a layer that has no need of it; the a.e. view is taken once, later, on
+the graphon quotient.  Kernels are bounded and the carrier is finite, so the integrals below always
+converge and the expansion `l2sq_sub` needs no side conditions.
+
+## Main definitions
+
+* `TauCeti.DenseGraphLimits.l2inner` is the `L²(μ ⊗ μ)` inner product of two symmetric kernels;
+* `TauCeti.DenseGraphLimits.l2sq` is the `L²(μ ⊗ μ)` norm squared of a symmetric kernel.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.SymmKernel.integrable_mul` is the integrability behind both;
+* `TauCeti.DenseGraphLimits.l2sq_sub` expands the norm squared of a difference — the identity the
+  Pythagoras energy increment is read off from;
+* `TauCeti.DenseGraphLimits.l2sq_le_one_of_abs_le_one` bounds the norm squared of a kernel with
+  values in `[-1, 1]` over a probability carrier.
+
+## References
+
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), §9.2.
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 1/2 — `l2sq` and the analytic energy
+  stack.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω)
+
+namespace SymmKernel
+
+/-- The pointwise product of two symmetric kernels is integrable on the product carrier: both are
+bounded, and the product measure of a finite measure with itself is finite. -/
+theorem integrable_mul [IsFiniteMeasure μ] (K L : SymmKernel Ω μ) :
+    Integrable (fun p : Ω × Ω => K p.1 p.2 * L p.1 p.2) (μ.prod μ) := by
+  obtain ⟨C, hC⟩ := K.exists_bound
+  obtain ⟨D, hD⟩ := L.exists_bound
+  have hmeas : Measurable fun p : Ω × Ω => K p.1 p.2 * L p.1 p.2 := K.measurable.mul L.measurable
+  refine Integrable.of_bound hmeas.aestronglyMeasurable (C * D) (ae_of_all _ fun p => ?_)
+  have hCp := hC p.1 p.2
+  have hDp := hD p.1 p.2
+  rw [Real.norm_eq_abs, abs_mul]
+  exact mul_le_mul hCp hDp (abs_nonneg _) ((abs_nonneg _).trans hCp)
+
+/-- A symmetric kernel is square integrable on the product carrier. -/
+theorem integrable_sq [IsFiniteMeasure μ] (K : SymmKernel Ω μ) :
+    Integrable (fun p : Ω × Ω => K p.1 p.2 ^ 2) (μ.prod μ) := by
+  simpa only [sq] using integrable_mul μ K K
+
+end SymmKernel
+
+/-- The `L²(μ ⊗ μ)` inner product of two symmetric kernels. -/
+def l2inner (K L : SymmKernel Ω μ) : ℝ := ∫ p, K p.1 p.2 * L p.1 p.2 ∂(μ.prod μ)
+
+/-- The defining equation of `l2inner`. The definition's body is not exposed across module
+boundaries, so this is the unfolding lemma downstream modules should use. -/
+theorem l2inner_def (K L : SymmKernel Ω μ) :
+    l2inner μ K L = ∫ p, K p.1 p.2 * L p.1 p.2 ∂(μ.prod μ) := (rfl)
+
+/-- The `L²(μ ⊗ μ)` norm squared of a symmetric kernel. -/
+def l2sq (K : SymmKernel Ω μ) : ℝ := ∫ p, K p.1 p.2 ^ 2 ∂(μ.prod μ)
+
+/-- The defining equation of `l2sq`. The definition's body is not exposed across module boundaries,
+so this is the unfolding lemma downstream modules should use. -/
+theorem l2sq_def (K : SymmKernel Ω μ) :
+    l2sq μ K = ∫ p, K p.1 p.2 ^ 2 ∂(μ.prod μ) := (rfl)
+
+/-- The `L²` norm squared is the inner product of a kernel with itself. -/
+theorem l2sq_eq_l2inner_self (K : SymmKernel Ω μ) : l2sq μ K = l2inner μ K K := by
+  simp only [l2sq_def, l2inner_def, sq]
+
+/-- The `L²` norm squared is nonnegative: it is the integral of a square. -/
+theorem l2sq_nonneg (K : SymmKernel Ω μ) : 0 ≤ l2sq μ K := by
+  rw [l2sq_def]
+  exact integral_nonneg fun _ => sq_nonneg _
+
+/-- The `L²` inner product is symmetric. -/
+theorem l2inner_comm (K L : SymmKernel Ω μ) : l2inner μ K L = l2inner μ L K := by
+  simp only [l2inner_def, mul_comm]
+
+@[simp]
+theorem l2sq_zero : l2sq μ (0 : SymmKernel Ω μ) = 0 := by
+  simp [l2sq_def]
+
+variable [IsFiniteMeasure μ]
+
+/-- The `L²` inner product is additive in its left argument. -/
+theorem l2inner_add_left (K L M : SymmKernel Ω μ) :
+    l2inner μ (K + L) M = l2inner μ K M + l2inner μ L M := by
+  simp only [l2inner_def, SymmKernel.coe_add, Pi.add_apply, add_mul]
+  exact integral_add (SymmKernel.integrable_mul μ K M) (SymmKernel.integrable_mul μ L M)
+
+/-- The `L²` inner product subtracts in its left argument. -/
+theorem l2inner_sub_left (K L M : SymmKernel Ω μ) :
+    l2inner μ (K - L) M = l2inner μ K M - l2inner μ L M := by
+  simp only [l2inner_def, SymmKernel.coe_sub, Pi.sub_apply, sub_mul]
+  exact integral_sub (SymmKernel.integrable_mul μ K M) (SymmKernel.integrable_mul μ L M)
+
+/-- The `L²` inner product subtracts in its right argument. -/
+theorem l2inner_sub_right (K L M : SymmKernel Ω μ) :
+    l2inner μ K (L - M) = l2inner μ K L - l2inner μ K M := by
+  rw [l2inner_comm μ, l2inner_sub_left, l2inner_comm μ M K, l2inner_comm μ L K]
+
+/-- The expansion of the `L²` norm squared of a difference.  Read backwards with a vanishing cross
+term, this is the Pythagoras identity the energy increment uses. -/
+theorem l2sq_sub (K L : SymmKernel Ω μ) :
+    l2sq μ (K - L) = l2sq μ K - 2 * l2inner μ K L + l2sq μ L := by
+  rw [l2sq_eq_l2inner_self, l2inner_sub_left, l2inner_sub_right, l2inner_sub_right,
+    l2inner_comm μ L K, l2sq_eq_l2inner_self μ K, l2sq_eq_l2inner_self μ L]
+  ring
+
+/-- A kernel with values in `[-1, 1]` has `L²` norm squared at most `1` over a probability
+carrier. -/
+theorem l2sq_le_one_of_abs_le_one [IsProbabilityMeasure μ] (K : SymmKernel Ω μ)
+    (h : ∀ x y, |K x y| ≤ 1) : l2sq μ K ≤ 1 := by
+  rw [l2sq_def]
+  calc
+    (∫ p : Ω × Ω, K p.1 p.2 ^ 2 ∂(μ.prod μ)) ≤ ∫ _p : Ω × Ω, (1 : ℝ) ∂(μ.prod μ) := by
+      refine integral_mono (SymmKernel.integrable_sq μ K) (integrable_const 1) fun p => ?_
+      have hp := h p.1 p.2
+      nlinarith [abs_nonneg (K p.1 p.2), sq_abs (K p.1 p.2)]
+    _ = 1 := by simp
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -5,27 +5,30 @@ Authors: Claude
 -/
 module
 
-public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
+public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Basic
+public import Mathlib.MeasureTheory.Integral.Prod
+import Mathlib.MeasureTheory.Measure.FiniteMeasure
 
 /-!
 # The `L²` pairing of symmetric kernels
 
 The Frieze--Kannan weak regularity argument runs on an `L²(μ ⊗ μ)` potential, so the block-average
 step graphons of a refinement chain must be compared in `L²` and not only in cut norm.  This file
-supplies that pairing at the level of strict symmetric kernels: `l2inner` is the `L²(μ ⊗ μ)` inner
-product `∫ K · L` and `l2sq` is the induced norm squared `∫ K²`.
+defines the integrals `l2inner μ K L = ∫ K · L` and `l2sq μ K = ∫ K²` at the level of strict
+symmetric kernels.  When `μ` is finite, bounded kernels are square-integrable, so these integrals
+are the `L²(μ ⊗ μ)` inner product and its induced norm squared.
 
 **Why plain integrals and not `Lp`.**  A `SymmKernel` is a strict everywhere-defined
 representative, and the whole point of that convention is that a difference `K - L` is again a
 literal kernel.  Passing through `MeasureTheory.Lp` would replace each kernel by an a.e. class and
 force a.e. bookkeeping into a layer that has no need of it; the a.e. view is taken once, later, on
-the graphon quotient.  Kernels are bounded and the carrier is finite, so the integrals below always
-converge and the expansion `l2sq_sub` needs no side conditions.
+the graphon quotient.  Kernels are bounded, so when `μ` is finite the integrals below converge and
+the expansion `l2sq_sub` needs no additional side conditions.
 
 ## Main definitions
 
-* `TauCeti.DenseGraphLimits.l2inner` is the `L²(μ ⊗ μ)` inner product of two symmetric kernels;
-* `TauCeti.DenseGraphLimits.l2sq` is the `L²(μ ⊗ μ)` norm squared of a symmetric kernel.
+* `TauCeti.DenseGraphLimits.l2inner` is the integral of the product of two symmetric kernels;
+* `TauCeti.DenseGraphLimits.l2sq` is the integral of the square of a symmetric kernel.
 
 ## Main results
 
@@ -76,7 +79,8 @@ theorem integrable_sq [IsFiniteMeasure μ] (K : SymmKernel Ω μ) :
 
 end SymmKernel
 
-/-- The `L²(μ ⊗ μ)` inner product of two symmetric kernels. -/
+/-- The integral of the product of two symmetric kernels.  For finite `μ`, this is their
+`L²(μ ⊗ μ)` inner product. -/
 def l2inner (K L : SymmKernel Ω μ) : ℝ := ∫ p, K p.1 p.2 * L p.1 p.2 ∂(μ.prod μ)
 
 /-- The defining equation of `l2inner`. The definition's body is not exposed across module
@@ -84,7 +88,8 @@ boundaries, so this is the unfolding lemma downstream modules should use. -/
 theorem l2inner_def (K L : SymmKernel Ω μ) :
     l2inner μ K L = ∫ p, K p.1 p.2 * L p.1 p.2 ∂(μ.prod μ) := (rfl)
 
-/-- The `L²(μ ⊗ μ)` norm squared of a symmetric kernel. -/
+/-- The integral of the square of a symmetric kernel.  For finite `μ`, this is its `L²(μ ⊗ μ)`
+norm squared. -/
 def l2sq (K : SymmKernel Ω μ) : ℝ := ∫ p, K p.1 p.2 ^ 2 ∂(μ.prod μ)
 
 /-- The defining equation of `l2sq`. The definition's body is not exposed across module boundaries,
@@ -105,6 +110,26 @@ theorem l2sq_nonneg (K : SymmKernel Ω μ) : 0 ≤ l2sq μ K := by
 theorem l2inner_comm (K L : SymmKernel Ω μ) : l2inner μ K L = l2inner μ L K := by
   simp only [l2inner_def, mul_comm]
 
+/-- Pairing the zero kernel on the left with any kernel gives zero. -/
+@[simp]
+theorem l2inner_zero_left (K : SymmKernel Ω μ) : l2inner μ 0 K = 0 := by
+  simp [l2inner_def]
+
+/-- Pairing any kernel with the zero kernel on the right gives zero. -/
+@[simp]
+theorem l2inner_zero_right (K : SymmKernel Ω μ) : l2inner μ K 0 = 0 := by
+  rw [l2inner_comm, l2inner_zero_left]
+
+/-- Negating the left argument negates the pairing. -/
+@[simp]
+theorem l2inner_neg_left (K L : SymmKernel Ω μ) : l2inner μ (-K) L = -l2inner μ K L := by
+  simp only [l2inner_def, SymmKernel.coe_neg, Pi.neg_apply, neg_mul, integral_neg]
+
+/-- Negating the right argument negates the pairing. -/
+@[simp]
+theorem l2inner_neg_right (K L : SymmKernel Ω μ) : l2inner μ K (-L) = -l2inner μ K L := by
+  rw [l2inner_comm, l2inner_neg_left, l2inner_comm μ L K]
+
 @[simp]
 theorem l2sq_zero : l2sq μ (0 : SymmKernel Ω μ) = 0 := by
   simp [l2sq_def]
@@ -116,6 +141,11 @@ theorem l2inner_add_left (K L M : SymmKernel Ω μ) :
     l2inner μ (K + L) M = l2inner μ K M + l2inner μ L M := by
   simp only [l2inner_def, SymmKernel.coe_add, Pi.add_apply, add_mul]
   exact integral_add (SymmKernel.integrable_mul μ K M) (SymmKernel.integrable_mul μ L M)
+
+/-- The `L²` inner product is additive in its right argument. -/
+theorem l2inner_add_right (K L M : SymmKernel Ω μ) :
+    l2inner μ K (L + M) = l2inner μ K L + l2inner μ K M := by
+  rw [l2inner_comm, l2inner_add_left, l2inner_comm μ L K, l2inner_comm μ M K]
 
 /-- The `L²` inner product subtracts in its left argument. -/
 theorem l2inner_sub_left (K L M : SymmKernel Ω μ) :
@@ -136,6 +166,7 @@ theorem l2sq_sub (K L : SymmKernel Ω μ) :
     l2inner_comm μ L K, l2sq_eq_l2inner_self μ K, l2sq_eq_l2inner_self μ L]
   ring
 
+omit [IsFiniteMeasure μ] in
 /-- A kernel with values in `[-1, 1]` has `L²` norm squared at most `1` over a probability
 carrier. -/
 theorem l2sq_le_one_of_abs_le_one [IsProbabilityMeasure μ] (K : SymmKernel Ω μ)

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -137,23 +137,27 @@ theorem l2sq_zero : l2sq μ (0 : SymmKernel Ω μ) = 0 := by
 variable [IsFiniteMeasure μ]
 
 /-- The `L²` inner product is additive in its left argument. -/
+@[simp]
 theorem l2inner_add_left (K L M : SymmKernel Ω μ) :
     l2inner μ (K + L) M = l2inner μ K M + l2inner μ L M := by
   simp only [l2inner_def, SymmKernel.coe_add, Pi.add_apply, add_mul]
   exact integral_add (SymmKernel.integrable_mul μ K M) (SymmKernel.integrable_mul μ L M)
 
 /-- The `L²` inner product is additive in its right argument. -/
+@[simp]
 theorem l2inner_add_right (K L M : SymmKernel Ω μ) :
     l2inner μ K (L + M) = l2inner μ K L + l2inner μ K M := by
   rw [l2inner_comm, l2inner_add_left, l2inner_comm μ L K, l2inner_comm μ M K]
 
 /-- The `L²` inner product subtracts in its left argument. -/
+@[simp]
 theorem l2inner_sub_left (K L M : SymmKernel Ω μ) :
     l2inner μ (K - L) M = l2inner μ K M - l2inner μ L M := by
   simp only [l2inner_def, SymmKernel.coe_sub, Pi.sub_apply, sub_mul]
   exact integral_sub (SymmKernel.integrable_mul μ K M) (SymmKernel.integrable_mul μ L M)
 
 /-- The `L²` inner product subtracts in its right argument. -/
+@[simp]
 theorem l2inner_sub_right (K L M : SymmKernel Ω μ) :
     l2inner μ K (L - M) = l2inner μ K L - l2inner μ K M := by
   rw [l2inner_comm μ, l2inner_sub_left, l2inner_comm μ M K, l2inner_comm μ L K]

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Basic.lean
@@ -28,9 +28,9 @@ measurability immediate and does not choose a distinguished index for each point
 
 ## Main results
 
-* `TauCeti.DenseGraphLimits.iUnion_parts` and `TauCeti.DenseGraphLimits.inter_eq_self_or_empty`
-  are the two covering facts about a `Finpartition` of the carrier that the block constructions
-  and their refinements run on;
+* `TauCeti.Finpartition.iUnion_parts` and
+  `TauCeti.Finpartition.inter_part_eq_self_or_empty_of_le` are the two covering facts about a
+  `Finpartition` of the carrier that the block constructions and their refinements run on;
 * `TauCeti.DenseGraphLimits.stepGraphon_apply` evaluates the graphon on a specified block;
 * `TauCeti.DenseGraphLimits.stepGraphon_inj` says that, for a fixed partition, two step graphons
   are equal exactly when their block values agree;
@@ -53,14 +53,8 @@ open Set
 
 namespace TauCeti
 
-namespace DenseGraphLimits
+namespace Finpartition
 
-variable {Ω : Type*} [MeasurableSpace Ω] {μ : MeasureTheory.Measure Ω}
-  [MeasureTheory.IsProbabilityMeasure μ]
-
-section Parts
-
-omit [MeasurableSpace Ω] in
 /-- The parts of a finite partition of the carrier cover it. -/
 theorem iUnion_parts (P : Finpartition (Set.univ : Set Ω)) :
     ⋃ p : P.parts, (p : Set Ω) = Set.univ := by
@@ -68,10 +62,9 @@ theorem iUnion_parts (P : Finpartition (Set.univ : Set Ω)) :
   obtain ⟨p, hp, hxp⟩ := Set.mem_sUnion.mp (P.isPartition_parts.sUnion_eq_univ ▸ Set.mem_univ x)
   exact Set.mem_iUnion.2 ⟨⟨p, hp⟩, hxp⟩
 
-omit [MeasurableSpace Ω] in
 /-- Under refinement, a part of the finer partition is either contained in a given part of the
 coarser one or disjoint from it. -/
-theorem inter_eq_self_or_empty {P Q : Finpartition (Set.univ : Set Ω)} (href : Q ≤ P)
+theorem inter_part_eq_self_or_empty_of_le {P Q : Finpartition (Set.univ : Set Ω)} (href : Q ≤ P)
     {r : Set Ω} (hr : r ∈ Q.parts) {p : Set Ω} (hp : p ∈ P.parts) :
     r ∩ p = r ∨ r ∩ p = ∅ := by
   obtain ⟨p', hp', hrp'⟩ := href hr
@@ -80,7 +73,12 @@ theorem inter_eq_self_or_empty {P Q : Finpartition (Set.univ : Set Ω)} (href : 
   · refine Or.inr (Set.eq_empty_of_subset_empty fun x hx => ?_)
     exact absurd hx.2 (Set.disjoint_left.mp (P.disjoint hp' hp h) (hrp' hx.1))
 
-end Parts
+end Finpartition
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : MeasureTheory.Measure Ω}
+  [MeasureTheory.IsProbabilityMeasure μ]
 
 section StepValue
 
@@ -90,7 +88,7 @@ omit [MeasurableSpace Ω] in
 /-- Every point of the carrier belongs to one of the parts of a partition of `Set.univ`. -/
 private theorem exists_part (x : Ω) : ∃ p : P.parts, x ∈ (p : Set Ω) := by
   refine Set.mem_iUnion.1 ?_
-  rw [iUnion_parts P]
+  rw [Finpartition.iUnion_parts P]
   exact Set.mem_univ x
 
 /-- The finite rectangle-indicator sum underlying a step graphon. -/

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.Graphon.Basic
 public import Mathlib.Order.Partition.Finpartition
+import Mathlib.Data.Setoid.Partition
 
 /-!
 # Step graphons
@@ -27,6 +28,9 @@ measurability immediate and does not choose a distinguished index for each point
 
 ## Main results
 
+* `TauCeti.DenseGraphLimits.iUnion_parts` and `TauCeti.DenseGraphLimits.inter_eq_self_or_empty`
+  are the two covering facts about a `Finpartition` of the carrier that the block constructions
+  and their refinements run on;
 * `TauCeti.DenseGraphLimits.stepGraphon_apply` evaluates the graphon on a specified block;
 * `TauCeti.DenseGraphLimits.stepGraphon_inj` says that, for a fixed partition, two step graphons
   are equal exactly when their block values agree;
@@ -54,6 +58,30 @@ namespace DenseGraphLimits
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : MeasureTheory.Measure Ω}
   [MeasureTheory.IsProbabilityMeasure μ]
 
+section Parts
+
+omit [MeasurableSpace Ω] in
+/-- The parts of a finite partition of the carrier cover it. -/
+theorem iUnion_parts (P : Finpartition (Set.univ : Set Ω)) :
+    ⋃ p : P.parts, (p : Set Ω) = Set.univ := by
+  refine Set.eq_univ_of_forall fun x => ?_
+  obtain ⟨p, hp, hxp⟩ := Set.mem_sUnion.mp (P.isPartition_parts.sUnion_eq_univ ▸ Set.mem_univ x)
+  exact Set.mem_iUnion.2 ⟨⟨p, hp⟩, hxp⟩
+
+omit [MeasurableSpace Ω] in
+/-- Under refinement, a part of the finer partition is either contained in a given part of the
+coarser one or disjoint from it. -/
+theorem inter_eq_self_or_empty {P Q : Finpartition (Set.univ : Set Ω)} (href : Q ≤ P)
+    {r : Set Ω} (hr : r ∈ Q.parts) {p : Set Ω} (hp : p ∈ P.parts) :
+    r ∩ p = r ∨ r ∩ p = ∅ := by
+  obtain ⟨p', hp', hrp'⟩ := href hr
+  by_cases h : p' = p
+  · exact Or.inl (Set.inter_eq_self_of_subset_left (h ▸ hrp'))
+  · refine Or.inr (Set.eq_empty_of_subset_empty fun x hx => ?_)
+    exact absurd hx.2 (Set.disjoint_left.mp (P.disjoint hp' hp h) (hrp' hx.1))
+
+end Parts
+
 section StepValue
 
 variable (P : Finpartition (Set.univ : Set Ω))
@@ -61,11 +89,9 @@ variable (P : Finpartition (Set.univ : Set Ω))
 omit [MeasurableSpace Ω] in
 /-- Every point of the carrier belongs to one of the parts of a partition of `Set.univ`. -/
 private theorem exists_part (x : Ω) : ∃ p : P.parts, x ∈ (p : Set Ω) := by
-  have hx : x ∈ ⋃₀ (P.parts : Set (Set Ω)) := by
-    rw [← Finset.sup_id_set_eq_sUnion, P.sup_parts]
-    exact Set.mem_univ x
-  obtain ⟨p, hp, hxp⟩ := Set.mem_sUnion.mp hx
-  exact ⟨⟨p, hp⟩, hxp⟩
+  refine Set.mem_iUnion.1 ?_
+  rw [iUnion_parts P]
+  exact Set.mem_univ x
 
 /-- The finite rectangle-indicator sum underlying a step graphon. -/
 private def stepValue (val : P.parts → P.parts → Set.Icc (0 : ℝ) 1) (x y : Ω) : ℝ :=

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Basic.lean
@@ -6,7 +6,7 @@ Authors: Codex
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.Graphon.Basic
-public import Mathlib.Order.Partition.Finpartition
+public import TauCeti.Order.Partition.Finpartition
 import Mathlib.Data.Setoid.Partition
 
 /-!
@@ -28,9 +28,6 @@ measurability immediate and does not choose a distinguished index for each point
 
 ## Main results
 
-* `Finpartition.iUnion_parts` and
-  `Finpartition.inter_part_eq_self_or_empty_of_le` are the two covering facts about a
-  `Finpartition` of the carrier that the block constructions and their refinements run on;
 * `TauCeti.DenseGraphLimits.stepGraphon_apply` evaluates the graphon on a specified block;
 * `TauCeti.DenseGraphLimits.stepGraphon_inj` says that, for a fixed partition, two step graphons
   are equal exactly when their block values agree;
@@ -51,28 +48,6 @@ noncomputable section
 
 open Set
 
-namespace Finpartition
-
-/-- The parts of a finite partition of the carrier cover it. -/
-theorem iUnion_parts (P : Finpartition (Set.univ : Set Ω)) :
-    ⋃ p : P.parts, (p : Set Ω) = Set.univ := by
-  refine Set.eq_univ_of_forall fun x => ?_
-  obtain ⟨p, hp, hxp⟩ := Set.mem_sUnion.mp (P.isPartition_parts.sUnion_eq_univ ▸ Set.mem_univ x)
-  exact Set.mem_iUnion.2 ⟨⟨p, hp⟩, hxp⟩
-
-/-- Under refinement, a part of the finer partition is either contained in a given part of the
-coarser one or disjoint from it. -/
-theorem inter_part_eq_self_or_empty_of_le {P Q : Finpartition (Set.univ : Set Ω)} (href : Q ≤ P)
-    {r : Set Ω} (hr : r ∈ Q.parts) {p : Set Ω} (hp : p ∈ P.parts) :
-    r ∩ p = r ∨ r ∩ p = ∅ := by
-  obtain ⟨p', hp', hrp'⟩ := href hr
-  by_cases h : p' = p
-  · exact Or.inl (Set.inter_eq_self_of_subset_left (h ▸ hrp'))
-  · refine Or.inr (Set.eq_empty_of_subset_empty fun x hx => ?_)
-    exact absurd hx.2 (Set.disjoint_left.mp (P.disjoint hp' hp h) (hrp' hx.1))
-
-end Finpartition
-
 namespace TauCeti
 
 namespace DenseGraphLimits
@@ -87,9 +62,8 @@ variable (P : Finpartition (Set.univ : Set Ω))
 omit [MeasurableSpace Ω] in
 /-- Every point of the carrier belongs to one of the parts of a partition of `Set.univ`. -/
 private theorem exists_part (x : Ω) : ∃ p : P.parts, x ∈ (p : Set Ω) := by
-  refine Set.mem_iUnion.1 ?_
-  rw [Finpartition.iUnion_parts P]
-  exact Set.mem_univ x
+  obtain ⟨p, ⟨hp, hxp⟩, _⟩ := P.isPartition_parts.2 x
+  exact ⟨⟨p, hp⟩, hxp⟩
 
 /-- The finite rectangle-indicator sum underlying a step graphon. -/
 private def stepValue (val : P.parts → P.parts → Set.Icc (0 : ℝ) 1) (x y : Ω) : ℝ :=

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Basic.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Basic.lean
@@ -28,8 +28,8 @@ measurability immediate and does not choose a distinguished index for each point
 
 ## Main results
 
-* `TauCeti.Finpartition.iUnion_parts` and
-  `TauCeti.Finpartition.inter_part_eq_self_or_empty_of_le` are the two covering facts about a
+* `Finpartition.iUnion_parts` and
+  `Finpartition.inter_part_eq_self_or_empty_of_le` are the two covering facts about a
   `Finpartition` of the carrier that the block constructions and their refinements run on;
 * `TauCeti.DenseGraphLimits.stepGraphon_apply` evaluates the graphon on a specified block;
 * `TauCeti.DenseGraphLimits.stepGraphon_inj` says that, for a fixed partition, two step graphons
@@ -50,8 +50,6 @@ public section
 noncomputable section
 
 open Set
-
-namespace TauCeti
 
 namespace Finpartition
 
@@ -74,6 +72,8 @@ theorem inter_part_eq_self_or_empty_of_le {P Q : Finpartition (Set.univ : Set Ω
     exact absurd hx.2 (Set.disjoint_left.mp (P.disjoint hp' hp h) (hrp' hx.1))
 
 end Finpartition
+
+namespace TauCeti
 
 namespace DenseGraphLimits
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -1,0 +1,327 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.L2
+public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Average
+
+/-!
+# The graphon partition energy
+
+The Frieze--Kannan weak regularity argument is a potential argument: refine a measurable finite
+partition as long as the block-average step graphon fails to approximate the graphon in cut norm,
+and bound the number of refinements by the growth of an `L²` potential that is trapped in `[0, 1]`.
+This file builds that potential.
+
+`graphonPartitionEnergy μ P hP W` is the `L²(μ ⊗ μ)` norm squared of the block-average step graphon
+`stepGraphonAvg`, that is of `E[W | P ⊗ P]`.  Its two structural properties are proved here:
+
+* **projection.** The block-average step graphon is the `L²` orthogonal projection of `W` onto the
+  functions constant on the rectangles of `P`, in the concrete form
+  `l2inner_graphon_stepGraphonAvg`; hence the exact defect identity `l2sq_sub_stepGraphonAvg`.
+* **Pythagoras.** Refining the partition increases the energy by exactly the `L²` norm squared of
+  the change in the block-average step graphon (`graphonPartitionEnergy_increment`), so the energy
+  is monotone under refinement.
+
+Both rest on the same block computation: the energy is a finite sum of block contributions
+(`graphonPartitionEnergy_eq_sum`), and a block average over a *refinement* still reproduces the
+coarse block integrals (`stepGraphonAvg_rectIntegral_of_le`).  That last point is where the
+null-cell convention of `stepGraphonAvg` is tested: a part of the finer partition may be null, and
+the convention assigning it the value zero is exactly what keeps its contribution to the coarse
+block integral correct.
+
+This is `‖E[W | P ⊗ P]‖₂²` written entirely in terms of finite block averages; the identification
+with `MeasureTheory.condExp` belongs to the later a.e. layer, and nothing here needs it.  It is also
+distinct from Mathlib's `Finpartition.energy`, which is the finite edge-density energy of a finite
+graph.
+
+## Main definitions
+
+* `TauCeti.DenseGraphLimits.graphonPartitionEnergy` is the graphon partition energy.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le`: block averaging over a refinement
+  preserves the coarse block integrals;
+* `TauCeti.DenseGraphLimits.graphonPartitionEnergy_eq_sum`: the energy as a finite block sum;
+* `TauCeti.DenseGraphLimits.l2sq_sub_stepGraphonAvg`: the defect identity `‖W - E[W|P⊗P]‖₂² =
+  ‖W‖₂² - E(P)`;
+* `TauCeti.DenseGraphLimits.graphonPartitionEnergy_increment`: the `L²`-Pythagoras increment;
+* `TauCeti.DenseGraphLimits.graphonPartitionEnergy_stepGraphonAvg`: averaging twice at the same
+  partition changes nothing;
+* `TauCeti.DenseGraphLimits.graphonPartitionEnergy_mono`,
+  `TauCeti.DenseGraphLimits.graphonPartitionEnergy_nonneg` and
+  `TauCeti.DenseGraphLimits.graphonPartitionEnergy_le_one`: the bounded monotone potential.
+
+## References
+
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), §9.2.
+* A. Frieze and R. Kannan, *Quick approximation to matrices and applications*, Combinatorica 19
+  (1999), 175--220.
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 2 — the analytic energy stack
+  (`graphonPartitionEnergy`, `graphonPartitionEnergy_eq`, the `L²`-Pythagoras increment and its
+  `_mono` / `_nonneg` / `_le_one` corollaries).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*}
+
+section Parts
+
+/-- The parts of a finite partition of the carrier cover it. -/
+private theorem iUnion_parts (R : Finpartition (Set.univ : Set Ω)) :
+    ⋃ r : R.parts, (r : Set Ω) = Set.univ := by
+  refine eq_univ_of_forall fun x => ?_
+  have hx : x ∈ ⋃₀ (R.parts : Set (Set Ω)) := by
+    rw [← Finset.sup_id_set_eq_sUnion, R.sup_parts]
+    exact mem_univ x
+  obtain ⟨r, hr, hxr⟩ := mem_sUnion.mp hx
+  exact mem_iUnion.2 ⟨⟨r, hr⟩, hxr⟩
+
+/-- Under refinement, a part of the finer partition is either contained in a given part of the
+coarser one or disjoint from it. -/
+private theorem inter_eq_self_or_empty {P Q : Finpartition (Set.univ : Set Ω)} (href : Q ≤ P)
+    {r : Set Ω} (hr : r ∈ Q.parts) {p : Set Ω} (hp : p ∈ P.parts) :
+    r ∩ p = r ∨ r ∩ p = ∅ := by
+  obtain ⟨p', hp', hrp'⟩ := href hr
+  by_cases h : p' = p
+  · exact Or.inl (inter_eq_self_of_subset_left (h ▸ hrp'))
+  · refine Or.inr (eq_empty_of_subset_empty fun x hx => ?_)
+    exact absurd hx.2 (disjoint_left.mp (P.disjoint hp' hp h) (hrp' hx.1))
+
+end Parts
+
+variable [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
+
+section Decomposition
+
+omit [IsProbabilityMeasure μ] in
+/-- A finite measurable partition of the carrier cuts a rectangle into finitely many disjoint
+subrectangles, splitting any integral over it into a finite sum. -/
+private theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
+    (hR : ∀ r ∈ R.parts, MeasurableSet r) {S T : Set Ω} (hS : MeasurableSet S)
+    (hT : MeasurableSet T) {f : Ω × Ω → ℝ} (hf : Integrable f (μ.prod μ)) :
+    ∫ z in S ×ˢ T, f z ∂(μ.prod μ)
+      = ∑ rs : R.parts × R.parts,
+          ∫ z in ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T), f z ∂(μ.prod μ) := by
+  have hmeas : ∀ rs : R.parts × R.parts,
+      MeasurableSet (((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T)) := fun rs =>
+    ((hR _ rs.1.property).inter hS).prod ((hR _ rs.2.property).inter hT)
+  have hdisj : Pairwise (Function.onFun Disjoint fun rs : R.parts × R.parts =>
+      ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T)) := by
+    intro rs rs' hne
+    have key : ∀ {u v : R.parts} {A : Set Ω}, u ≠ v →
+        ((u : Set Ω) ∩ A) ∩ ((v : Set Ω) ∩ A) = ∅ := by
+      intro u v A huv
+      refine disjoint_iff_inter_eq_empty.mp ?_
+      exact (R.disjoint u.property v.property fun h => huv (Subtype.ext h)).mono
+        inter_subset_left inter_subset_left
+    simp only [Function.onFun, disjoint_iff_inter_eq_empty, prod_inter_prod, prod_eq_empty_iff]
+    by_cases h1 : rs.1 = rs'.1
+    · refine Or.inr (key ?_)
+      intro h2
+      exact hne (Prod.ext h1 h2)
+    · exact Or.inl (key h1)
+  have hunion : (⋃ rs : R.parts × R.parts, ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T))
+      = S ×ˢ T := by
+    rw [iUnion_prod (fun r : R.parts => (r : Set Ω) ∩ S) fun r : R.parts => (r : Set Ω) ∩ T,
+      ← iUnion_inter, ← iUnion_inter, iUnion_parts R, univ_inter, univ_inter]
+  rw [← hunion, integral_iUnion_fintype hmeas hdisj fun _ => hf.integrableOn]
+
+omit [IsProbabilityMeasure μ] in
+/-- A finite measurable partition of the carrier splits an integral over the whole product carrier
+into a finite sum over its rectangles. -/
+private theorem integral_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
+    (hR : ∀ r ∈ R.parts, MeasurableSet r) {f : Ω × Ω → ℝ} (hf : Integrable f (μ.prod μ)) :
+    ∫ z, f z ∂(μ.prod μ)
+      = ∑ rs : R.parts × R.parts, ∫ z in (rs.1 : Set Ω) ×ˢ (rs.2 : Set Ω), f z ∂(μ.prod μ) := by
+  rw [← setIntegral_univ (μ := μ.prod μ), ← univ_prod_univ,
+    setIntegral_prod_eq_sum_parts μ R hR MeasurableSet.univ MeasurableSet.univ hf]
+  simp
+
+/-- Two kernels with the same integral over every rectangle of a partition `Q` have the same
+integral over every rectangle of any coarser partition `P`. -/
+private theorem rectIntegral_eq_of_le {P Q : Finpartition (Set.univ : Set Ω)}
+    (hP : ∀ p ∈ P.parts, MeasurableSet p) (hQ : ∀ r ∈ Q.parts, MeasurableSet r) (href : Q ≤ P)
+    {K L : SymmKernel Ω μ}
+    (h : ∀ r s : Q.parts, K.rectIntegral μ (r : Set Ω) (s : Set Ω)
+      = L.rectIntegral μ (r : Set Ω) (s : Set Ω)) (p q : P.parts) :
+    K.rectIntegral μ (p : Set Ω) (q : Set Ω) = L.rectIntegral μ (p : Set Ω) (q : Set Ω) := by
+  rw [SymmKernel.rectIntegral_def, SymmKernel.rectIntegral_def,
+    setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
+      (SymmKernel.integrable_uncurry μ K),
+    setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
+      (SymmKernel.integrable_uncurry μ L)]
+  refine Finset.sum_congr rfl fun rs _ => ?_
+  rcases inter_eq_self_or_empty href rs.1.property p.property with h1 | h1
+  · rcases inter_eq_self_or_empty href rs.2.property q.property with h2 | h2
+    · rw [h1, h2]
+      simpa only [SymmKernel.rectIntegral_def] using h rs.1 rs.2
+    · rw [h2]
+      simp
+  · rw [h1]
+    simp
+
+end Decomposition
+
+variable (P Q : Finpartition (Set.univ : Set Ω))
+
+/-- Block averaging over a refinement still reproduces the block integrals of the coarser
+partition.  This is where the null-cell convention of `stepGraphonAvg` is exercised: a null part of
+the finer partition is given the value zero, and contributes zero to the coarse block integral,
+which is exactly what this identity requires. -/
+theorem stepGraphonAvg_rectIntegral_of_le (hP : ∀ p ∈ P.parts, MeasurableSet p)
+    (hQ : ∀ r ∈ Q.parts, MeasurableSet r) (href : Q ≤ P) (W : Graphon Ω μ) (p q : P.parts) :
+    (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ (p : Set Ω) (q : Set Ω)
+      = W.toSymmKernel.rectIntegral μ (p : Set Ω) (q : Set Ω) :=
+  rectIntegral_eq_of_le μ hP hQ href (fun r s => stepGraphonAvg_rectIntegral Q hQ W r s) p q
+
+/-- On a single block, pairing any kernel against the block-average step graphon multiplies the
+block integral of the kernel by the block average of `W`. -/
+private theorem setIntegral_mul_stepGraphonAvg (hP : ∀ p ∈ P.parts, MeasurableSet p)
+    (W : Graphon Ω μ) (K : SymmKernel Ω μ) (p q : P.parts) :
+    ∫ z in (p : Set Ω) ×ˢ (q : Set Ω), K z.1 z.2 * stepGraphonAvg (μ := μ) P hP W z.1 z.2
+        ∂(μ.prod μ)
+      = K.rectIntegral μ (p : Set Ω) (q : Set Ω)
+        * ⨍ z in (p : Set Ω) ×ˢ (q : Set Ω), W z.1 z.2 ∂(μ.prod μ) := by
+  rw [SymmKernel.rectIntegral_def, ← integral_mul_const]
+  refine setIntegral_congr_fun ((hP _ p.property).prod (hP _ q.property)) fun z hz => ?_
+  rw [stepGraphonAvg_apply P hP W hz.1 hz.2]
+
+/-- The `L²` pairing of any kernel with a block-average step graphon is the finite sum of its block
+integrals weighted by the block averages of `W`. -/
+theorem l2inner_stepGraphonAvg_eq_sum (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ)
+    (K : SymmKernel Ω μ) :
+    l2inner μ K (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
+      = ∑ pq : P.parts × P.parts, K.rectIntegral μ (pq.1 : Set Ω) (pq.2 : Set Ω)
+        * ⨍ z in (pq.1 : Set Ω) ×ˢ (pq.2 : Set Ω), W z.1 z.2 ∂(μ.prod μ) := by
+  rw [l2inner_def, integral_eq_sum_parts μ P hP
+    (SymmKernel.integrable_mul μ K (stepGraphonAvg (μ := μ) P hP W).toSymmKernel)]
+  exact Finset.sum_congr rfl fun pq _ => setIntegral_mul_stepGraphonAvg μ P hP W K pq.1 pq.2
+
+/-- The **graphon partition energy** of `W` over a measurable finite partition `P`: the
+`L²(μ ⊗ μ)` norm squared of the block-average step graphon `E[W | P ⊗ P]`.
+
+This is the analytic potential of the Frieze--Kannan weak regularity argument.  It is not Mathlib's
+`Finpartition.energy`, which is the finite edge-density energy of a finite graph. -/
+def graphonPartitionEnergy (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) : ℝ :=
+  l2sq μ (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
+
+/-- The partition energy is the `L²` norm squared of the block-average step graphon.  The
+definition's body is not exposed across module boundaries, so this is the unfolding lemma
+downstream modules should use. -/
+theorem graphonPartitionEnergy_eq (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
+    graphonPartitionEnergy μ P hP W = l2sq μ (stepGraphonAvg (μ := μ) P hP W).toSymmKernel :=
+  (rfl)
+
+/-- The partition energy as a finite sum of block contributions: each block contributes the
+integral of `W` over it times the average of `W` on it. -/
+theorem graphonPartitionEnergy_eq_sum (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
+    graphonPartitionEnergy μ P hP W
+      = ∑ pq : P.parts × P.parts, W.toSymmKernel.rectIntegral μ (pq.1 : Set Ω) (pq.2 : Set Ω)
+        * ⨍ z in (pq.1 : Set Ω) ×ˢ (pq.2 : Set Ω), W z.1 z.2 ∂(μ.prod μ) := by
+  rw [graphonPartitionEnergy_eq, l2sq_eq_l2inner_self, l2inner_stepGraphonAvg_eq_sum]
+  exact Finset.sum_congr rfl fun pq _ => by
+    rw [stepGraphonAvg_rectIntegral P hP W pq.1 pq.2]
+
+/-- The block-average step graphon is the `L²` orthogonal projection of `W`: pairing `W` against it
+already returns the partition energy. -/
+theorem l2inner_graphon_stepGraphonAvg (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
+    l2inner μ W.toSymmKernel (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
+      = graphonPartitionEnergy μ P hP W := by
+  rw [l2inner_stepGraphonAvg_eq_sum, graphonPartitionEnergy_eq_sum]
+
+/-- The defect identity: the `L²` distance from `W` to its block average is the `L²` norm squared of
+`W` minus the partition energy.  This is the form of orthogonality the weak regularity iteration
+uses — a large defect is exactly a large available energy gain. -/
+theorem l2sq_sub_stepGraphonAvg (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
+    l2sq μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel)
+      = l2sq μ W.toSymmKernel - graphonPartitionEnergy μ P hP W := by
+  rw [l2sq_sub, l2inner_graphon_stepGraphonAvg, graphonPartitionEnergy_eq]
+  ring
+
+/-- The partition energy never exceeds the `L²` norm squared of the graphon — Bessel's inequality
+for the block-average projection. -/
+theorem graphonPartitionEnergy_le_l2sq (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
+    graphonPartitionEnergy μ P hP W ≤ l2sq μ W.toSymmKernel := by
+  have h := l2sq_nonneg μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel)
+  rw [l2sq_sub_stepGraphonAvg] at h
+  linarith
+
+/-- Under refinement, the finer block-average step graphon pairs with the coarser one to give
+exactly the coarser energy: the coarse block average is unchanged by the finer averaging. -/
+theorem l2inner_stepGraphonAvg_of_le (hP : ∀ p ∈ P.parts, MeasurableSet p)
+    (hQ : ∀ r ∈ Q.parts, MeasurableSet r) (href : Q ≤ P) (W : Graphon Ω μ) :
+    l2inner μ (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel
+        (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
+      = graphonPartitionEnergy μ P hP W := by
+  rw [l2inner_stepGraphonAvg_eq_sum, graphonPartitionEnergy_eq_sum]
+  exact Finset.sum_congr rfl fun pq _ => by
+    rw [stepGraphonAvg_rectIntegral_of_le μ P Q hP hQ href W pq.1 pq.2]
+
+/-- **The `L²`-Pythagoras energy increment.**  Refining a partition raises the energy by exactly the
+`L²` norm squared of the change in the block-average step graphon.  This is the quantitative driver
+of the Frieze--Kannan iteration.
+
+Mathlib's refinement order has `P ≤ Q` mean that `P` refines `Q`, so `Q ≤ P` is the hypothesis that
+`Q` is the finer partition. -/
+theorem graphonPartitionEnergy_increment (hP : ∀ p ∈ P.parts, MeasurableSet p)
+    (hQ : ∀ r ∈ Q.parts, MeasurableSet r) (href : Q ≤ P) (W : Graphon Ω μ) :
+    graphonPartitionEnergy μ Q hQ W
+      = graphonPartitionEnergy μ P hP W
+        + l2sq μ ((stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel
+          - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel) := by
+  rw [l2sq_sub, l2inner_stepGraphonAvg_of_le μ P Q hP hQ href W, graphonPartitionEnergy_eq μ Q,
+    graphonPartitionEnergy_eq μ P]
+  ring
+
+/-- The partition energy is monotone under refinement — the `≥ 0` corollary of the Pythagoras
+increment. -/
+theorem graphonPartitionEnergy_mono (hP : ∀ p ∈ P.parts, MeasurableSet p)
+    (hQ : ∀ r ∈ Q.parts, MeasurableSet r) (href : Q ≤ P) (W : Graphon Ω μ) :
+    graphonPartitionEnergy μ P hP W ≤ graphonPartitionEnergy μ Q hQ W := by
+  rw [graphonPartitionEnergy_increment μ P Q hP hQ href W]
+  linarith [l2sq_nonneg μ ((stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel
+    - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel)]
+
+/-- The partition energy is nonnegative. -/
+theorem graphonPartitionEnergy_nonneg (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
+    0 ≤ graphonPartitionEnergy μ P hP W := by
+  rw [graphonPartitionEnergy_eq]
+  exact l2sq_nonneg μ _
+
+/-- Block averaging does not change the partition energy at the same partition: the block-average
+step graphon is already constant on the rectangles of `P`, so averaging it again changes nothing.
+This is the projection identity `E(P, E[W|P⊗P]) = E(P, W)`. -/
+@[simp]
+theorem graphonPartitionEnergy_stepGraphonAvg (hP : ∀ p ∈ P.parts, MeasurableSet p)
+    (W : Graphon Ω μ) :
+    graphonPartitionEnergy μ P hP (stepGraphonAvg (μ := μ) P hP W)
+      = graphonPartitionEnergy μ P hP W := by
+  rw [graphonPartitionEnergy_eq, graphonPartitionEnergy_eq, stepGraphonAvg_idem]
+
+/-- The partition energy is at most `1`, because a graphon is `[0, 1]`-valued.  With
+`graphonPartitionEnergy_mono` and `graphonPartitionEnergy_nonneg` this is the bounded monotone
+potential the Frieze--Kannan iteration runs on. -/
+theorem graphonPartitionEnergy_le_one (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
+    graphonPartitionEnergy μ P hP W ≤ 1 := by
+  rw [graphonPartitionEnergy_eq]
+  refine l2sq_le_one_of_abs_le_one μ _ fun x y => ?_
+  rw [Graphon.coe_toSymmKernel, abs_of_nonneg ((stepGraphonAvg (μ := μ) P hP W).nonneg x y)]
+  exact (stepGraphonAvg (μ := μ) P hP W).le_one x y
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.L2
 public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Average
+public import TauCeti.MeasureTheory.Integral.Finpartition
 
 /-!
 # The graphon partition energy
@@ -46,10 +47,6 @@ graph.
 
 ## Main results
 
-* `Finpartition.setIntegral_prod_eq_sum_parts` and
-  `Finpartition.integral_eq_sum_parts`: a measurable finite partition splits an
-  integral over a rectangle, respectively over the whole product carrier, into a finite sum over
-  its subrectangles;
 * `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le`: block averaging over a refinement
   preserves the coarse block integrals;
 * `TauCeti.DenseGraphLimits.l2inner_stepGraphonAvg_eq_sum`: the block computation everything else
@@ -92,55 +89,6 @@ noncomputable section
 
 open MeasureTheory Set
 
-namespace Finpartition
-
-variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω)
-
-/-- A finite measurable partition of the carrier cuts a rectangle into finitely many disjoint
-subrectangles, splitting any integral over it into a finite sum. -/
-theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
-    (hR : ∀ r ∈ R.parts, MeasurableSet r) {S T : Set Ω} (hS : MeasurableSet S)
-    (hT : MeasurableSet T) {f : Ω × Ω → ℝ} (hf : IntegrableOn f (S ×ˢ T) (μ.prod μ)) :
-    ∫ z in S ×ˢ T, f z ∂(μ.prod μ)
-      = ∑ rs : R.parts × R.parts,
-          ∫ z in ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T), f z ∂(μ.prod μ) := by
-  have hmeas : ∀ rs : R.parts × R.parts,
-      MeasurableSet (((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T)) := fun rs =>
-    ((hR _ rs.1.property).inter hS).prod ((hR _ rs.2.property).inter hT)
-  have hdisj : Pairwise (Function.onFun Disjoint fun rs : R.parts × R.parts =>
-      ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T)) := by
-    intro rs rs' hne
-    have key : ∀ {u v : R.parts} {A : Set Ω}, u ≠ v →
-        ((u : Set Ω) ∩ A) ∩ ((v : Set Ω) ∩ A) = ∅ := by
-      intro u v A huv
-      refine disjoint_iff_inter_eq_empty.mp ?_
-      exact (R.disjoint u.property v.property fun h => huv (Subtype.ext h)).mono
-        inter_subset_left inter_subset_left
-    simp only [Function.onFun, disjoint_iff_inter_eq_empty, prod_inter_prod, prod_eq_empty_iff]
-    by_cases h1 : rs.1 = rs'.1
-    · refine Or.inr (key ?_)
-      intro h2
-      exact hne (Prod.ext h1 h2)
-    · exact Or.inl (key h1)
-  have hunion : (⋃ rs : R.parts × R.parts, ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T))
-      = S ×ˢ T := by
-    rw [iUnion_prod (fun r : R.parts => (r : Set Ω) ∩ S) fun r : R.parts => (r : Set Ω) ∩ T,
-      ← iUnion_inter, ← iUnion_inter, Finpartition.iUnion_parts R, univ_inter, univ_inter]
-  rw [← hunion, integral_iUnion_fintype hmeas hdisj fun _ =>
-    hf.mono_set (prod_mono inter_subset_right inter_subset_right)]
-
-/-- A finite measurable partition of the carrier splits an integral over the whole product carrier
-into a finite sum over its rectangles. -/
-theorem integral_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
-    (hR : ∀ r ∈ R.parts, MeasurableSet r) {f : Ω × Ω → ℝ} (hf : Integrable f (μ.prod μ)) :
-    ∫ z, f z ∂(μ.prod μ)
-      = ∑ rs : R.parts × R.parts, ∫ z in (rs.1 : Set Ω) ×ˢ (rs.2 : Set Ω), f z ∂(μ.prod μ) := by
-  rw [← setIntegral_univ (μ := μ.prod μ), ← univ_prod_univ,
-    setIntegral_prod_eq_sum_parts μ R hR MeasurableSet.univ MeasurableSet.univ hf.integrableOn]
-  simp
-
-end Finpartition
-
 namespace TauCeti
 
 namespace DenseGraphLimits
@@ -163,8 +111,9 @@ private theorem rectIntegral_eq_of_le {P Q : Finpartition (Set.univ : Set Ω)}
     Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
       (SymmKernel.integrable_uncurry μ L).integrableOn]
   refine Finset.sum_congr rfl fun rs _ => ?_
-  rcases Finpartition.inter_part_eq_self_or_empty_of_le href rs.1.property p.property with h1 | h1
-  · rcases Finpartition.inter_part_eq_self_or_empty_of_le href rs.2.property q.property with
+  rcases Finpartition.inter_part_eq_self_or_eq_empty_of_le href rs.1.property p.property with
+    h1 | h1
+  · rcases Finpartition.inter_part_eq_self_or_eq_empty_of_le href rs.2.property q.property with
       h2 | h2
     · rw [h1, h2]
       simpa only [SymmKernel.rectIntegral_def] using h rs.1 rs.2

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -46,8 +46,8 @@ graph.
 
 ## Main results
 
-* `TauCeti.Finpartition.setIntegral_prod_eq_sum_parts` and
-  `TauCeti.Finpartition.integral_eq_sum_parts`: a measurable finite partition splits an
+* `Finpartition.setIntegral_prod_eq_sum_parts` and
+  `Finpartition.integral_eq_sum_parts`: a measurable finite partition splits an
   integral over a rectangle, respectively over the whole product carrier, into a finite sum over
   its subrectangles;
 * `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le`: block averaging over a refinement
@@ -91,8 +91,6 @@ public section
 noncomputable section
 
 open MeasureTheory Set
-
-namespace TauCeti
 
 namespace Finpartition
 
@@ -142,6 +140,8 @@ theorem integral_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
   simp
 
 end Finpartition
+
+namespace TauCeti
 
 namespace DenseGraphLimits
 

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -243,9 +243,8 @@ theorem l2inner_graphon_stepGraphonAvg (hP : ∀ p ∈ P.parts, MeasurableSet p)
       = graphonPartitionEnergy μ P hP W := by
   rw [l2inner_stepGraphonAvg_eq_sum, graphonPartitionEnergy_eq_sum]
 
-/-- The defect identity: the `L²` distance from `W` to its block average is the `L²` norm squared of
-`W` minus the partition energy.  This is the form of orthogonality the weak regularity iteration
-uses — a large defect is exactly a large available energy gain. -/
+/-- The defect identity: the `L²` distance from `W` to its block average is the remaining gap
+between the graphon's `L²` norm squared and the current partition energy. -/
 theorem l2sq_sub_stepGraphonAvg (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
     l2sq μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel)
       = l2sq μ W.toSymmKernel - graphonPartitionEnergy μ P hP W := by

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -107,7 +107,7 @@ omit [IsProbabilityMeasure μ] in
 subrectangles, splitting any integral over it into a finite sum. -/
 theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
     (hR : ∀ r ∈ R.parts, MeasurableSet r) {S T : Set Ω} (hS : MeasurableSet S)
-    (hT : MeasurableSet T) {f : Ω × Ω → ℝ} (hf : Integrable f (μ.prod μ)) :
+    (hT : MeasurableSet T) {f : Ω × Ω → ℝ} (hf : IntegrableOn f (S ×ˢ T) (μ.prod μ)) :
     ∫ z in S ×ˢ T, f z ∂(μ.prod μ)
       = ∑ rs : R.parts × R.parts,
           ∫ z in ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T), f z ∂(μ.prod μ) := by
@@ -133,7 +133,8 @@ theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
       = S ×ˢ T := by
     rw [iUnion_prod (fun r : R.parts => (r : Set Ω) ∩ S) fun r : R.parts => (r : Set Ω) ∩ T,
       ← iUnion_inter, ← iUnion_inter, iUnion_parts R, univ_inter, univ_inter]
-  rw [← hunion, integral_iUnion_fintype hmeas hdisj fun _ => hf.integrableOn]
+  rw [← hunion, integral_iUnion_fintype hmeas hdisj fun _ =>
+    hf.mono_set (prod_mono inter_subset_right inter_subset_right)]
 
 omit [IsProbabilityMeasure μ] in
 /-- A finite measurable partition of the carrier splits an integral over the whole product carrier
@@ -143,7 +144,7 @@ theorem integral_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
     ∫ z, f z ∂(μ.prod μ)
       = ∑ rs : R.parts × R.parts, ∫ z in (rs.1 : Set Ω) ×ˢ (rs.2 : Set Ω), f z ∂(μ.prod μ) := by
   rw [← setIntegral_univ (μ := μ.prod μ), ← univ_prod_univ,
-    setIntegral_prod_eq_sum_parts μ R hR MeasurableSet.univ MeasurableSet.univ hf]
+    setIntegral_prod_eq_sum_parts μ R hR MeasurableSet.univ MeasurableSet.univ hf.integrableOn]
   simp
 
 /-- Two kernels with the same integral over every rectangle of a partition `Q` have the same
@@ -156,9 +157,9 @@ private theorem rectIntegral_eq_of_le {P Q : Finpartition (Set.univ : Set Ω)}
     K.rectIntegral μ (p : Set Ω) (q : Set Ω) = L.rectIntegral μ (p : Set Ω) (q : Set Ω) := by
   rw [SymmKernel.rectIntegral_def, SymmKernel.rectIntegral_def,
     setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
-      (SymmKernel.integrable_uncurry μ K),
+      (SymmKernel.integrable_uncurry μ K).integrableOn,
     setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
-      (SymmKernel.integrable_uncurry μ L)]
+      (SymmKernel.integrable_uncurry μ L).integrableOn]
   refine Finset.sum_congr rfl fun rs _ => ?_
   rcases inter_eq_self_or_empty href rs.1.property p.property with h1 | h1
   · rcases inter_eq_self_or_empty href rs.2.property q.property with h2 | h2

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -19,9 +19,9 @@ This file builds that potential.
 `graphonPartitionEnergy μ P hP W` is the `L²(μ ⊗ μ)` norm squared of the block-average step graphon
 `stepGraphonAvg`, that is of `E[W | P ⊗ P]`.  Its two structural properties are proved here:
 
-* **projection.** The block-average step graphon is the `L²` orthogonal projection of `W` onto the
-  functions constant on the rectangles of `P`, in the concrete form
-  `l2inner_graphon_stepGraphonAvg`; hence the exact defect identity `l2sq_sub_stepGraphonAvg`.
+* **projection moment.** Pairing `W` with its block-average step graphon gives the self-pairing of
+  that block average (`l2inner_graphon_stepGraphonAvg`); hence the exact defect identity
+  `l2sq_sub_stepGraphonAvg`.
 * **Pythagoras.** Refining the partition increases the energy by exactly the `L²` norm squared of
   the change in the block-average step graphon (`graphonPartitionEnergy_increment`), so the energy
   is monotone under refinement.
@@ -46,8 +46,8 @@ graph.
 
 ## Main results
 
-* `TauCeti.DenseGraphLimits.setIntegral_prod_eq_sum_parts` and
-  `TauCeti.DenseGraphLimits.integral_eq_sum_parts`: a measurable finite partition splits an
+* `TauCeti.Finpartition.setIntegral_prod_eq_sum_parts` and
+  `TauCeti.Finpartition.integral_eq_sum_parts`: a measurable finite partition splits an
   integral over a rectangle, respectively over the whole product carrier, into a finite sum over
   its subrectangles;
 * `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le`: block averaging over a refinement
@@ -55,11 +55,9 @@ graph.
 * `TauCeti.DenseGraphLimits.l2inner_stepGraphonAvg_eq_sum`: the block computation everything else
   is read off from — pairing any kernel against a block-average step graphon;
 * `TauCeti.DenseGraphLimits.graphonPartitionEnergy_eq_sum`: the energy as a finite block sum;
-* `TauCeti.DenseGraphLimits.l2inner_graphon_stepGraphonAvg`: the block average is the `L²`
-  orthogonal projection of `W`, and
+* `TauCeti.DenseGraphLimits.l2inner_graphon_stepGraphonAvg`: the projection moment identity, and
   `TauCeti.DenseGraphLimits.l2inner_stepGraphonAvg_of_le` is its refinement form;
-* `TauCeti.DenseGraphLimits.graphonPartitionEnergy_le_l2sq`: Bessel's inequality for that
-  projection;
+* `TauCeti.DenseGraphLimits.graphonPartitionEnergy_le_l2sq`: the corresponding Bessel-type bound;
 * `TauCeti.DenseGraphLimits.l2sq_sub_stepGraphonAvg`: the defect identity `‖W - E[W|P⊗P]‖₂² =
   ‖W‖₂² - E(P)`;
 * `TauCeti.DenseGraphLimits.graphonPartitionEnergy_increment`: the `L²`-Pythagoras increment;
@@ -79,7 +77,7 @@ graph.
   `_mono` / `_nonneg` / `_le_one` corollaries).  The signatures of `graphonPartitionEnergy` and of
   its `_eq` / `_increment` / `_mono` / `_nonneg` / `_le_one` companions, together with the
   `_mono` and `_nonneg` proofs, follow `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` (Layer 2);
-  the block computation, the projection identity and the defect identity are developed here.
+  the block computation, the projection moment identity and the defect identity are developed here.
 * The roadmap lists the null-cell `Finpartition` convention — including unchanged weighted energy,
   the scope of `stepGraphonAvg_rectIntegral_of_le` and of the increment — under its
   migration-backed routes, with an independent development in `Graphon/RegularityFinpartition.lean`
@@ -96,13 +94,10 @@ open MeasureTheory Set
 
 namespace TauCeti
 
-namespace DenseGraphLimits
+namespace Finpartition
 
-variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
+variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω)
 
-section Decomposition
-
-omit [IsProbabilityMeasure μ] in
 /-- A finite measurable partition of the carrier cuts a rectangle into finitely many disjoint
 subrectangles, splitting any integral over it into a finite sum. -/
 theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
@@ -132,11 +127,10 @@ theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
   have hunion : (⋃ rs : R.parts × R.parts, ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T))
       = S ×ˢ T := by
     rw [iUnion_prod (fun r : R.parts => (r : Set Ω) ∩ S) fun r : R.parts => (r : Set Ω) ∩ T,
-      ← iUnion_inter, ← iUnion_inter, iUnion_parts R, univ_inter, univ_inter]
+      ← iUnion_inter, ← iUnion_inter, Finpartition.iUnion_parts R, univ_inter, univ_inter]
   rw [← hunion, integral_iUnion_fintype hmeas hdisj fun _ =>
     hf.mono_set (prod_mono inter_subset_right inter_subset_right)]
 
-omit [IsProbabilityMeasure μ] in
 /-- A finite measurable partition of the carrier splits an integral over the whole product carrier
 into a finite sum over its rectangles. -/
 theorem integral_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
@@ -147,6 +141,14 @@ theorem integral_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
     setIntegral_prod_eq_sum_parts μ R hR MeasurableSet.univ MeasurableSet.univ hf.integrableOn]
   simp
 
+end Finpartition
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
+
+section Decomposition
+
 /-- Two kernels with the same integral over every rectangle of a partition `Q` have the same
 integral over every rectangle of any coarser partition `P`. -/
 private theorem rectIntegral_eq_of_le {P Q : Finpartition (Set.univ : Set Ω)}
@@ -156,13 +158,14 @@ private theorem rectIntegral_eq_of_le {P Q : Finpartition (Set.univ : Set Ω)}
       = L.rectIntegral μ (r : Set Ω) (s : Set Ω)) (p q : P.parts) :
     K.rectIntegral μ (p : Set Ω) (q : Set Ω) = L.rectIntegral μ (p : Set Ω) (q : Set Ω) := by
   rw [SymmKernel.rectIntegral_def, SymmKernel.rectIntegral_def,
-    setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
+    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
       (SymmKernel.integrable_uncurry μ K).integrableOn,
-    setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
+    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
       (SymmKernel.integrable_uncurry μ L).integrableOn]
   refine Finset.sum_congr rfl fun rs _ => ?_
-  rcases inter_eq_self_or_empty href rs.1.property p.property with h1 | h1
-  · rcases inter_eq_self_or_empty href rs.2.property q.property with h2 | h2
+  rcases Finpartition.inter_part_eq_self_or_empty_of_le href rs.1.property p.property with h1 | h1
+  · rcases Finpartition.inter_part_eq_self_or_empty_of_le href rs.2.property q.property with
+      h2 | h2
     · rw [h1, h2]
       simpa only [SymmKernel.rectIntegral_def] using h rs.1 rs.2
     · rw [h2]
@@ -203,7 +206,7 @@ theorem l2inner_stepGraphonAvg_eq_sum (hP : ∀ p ∈ P.parts, MeasurableSet p) 
     l2inner μ K (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
       = ∑ pq : P.parts × P.parts, K.rectIntegral μ (pq.1 : Set Ω) (pq.2 : Set Ω)
         * ⨍ z in (pq.1 : Set Ω) ×ˢ (pq.2 : Set Ω), W z.1 z.2 ∂(μ.prod μ) := by
-  rw [l2inner_def, integral_eq_sum_parts μ P hP
+  rw [l2inner_def, Finpartition.integral_eq_sum_parts μ P hP
     (SymmKernel.integrable_mul μ K (stepGraphonAvg (μ := μ) P hP W).toSymmKernel)]
   simp only [Graphon.coe_toSymmKernel]
   exact Finset.sum_congr rfl fun pq _ => setIntegral_mul_stepGraphonAvg μ P hP W K pq.1 pq.2
@@ -233,8 +236,8 @@ theorem graphonPartitionEnergy_eq_sum (hP : ∀ p ∈ P.parts, MeasurableSet p) 
   exact Finset.sum_congr rfl fun pq _ => by
     rw [stepGraphonAvg_rectIntegral P hP W pq.1 pq.2]
 
-/-- The block-average step graphon is the `L²` orthogonal projection of `W`: pairing `W` against it
-already returns the partition energy. -/
+/-- The projection moment identity: pairing `W` against its block average equals the self-pairing
+of that block average, namely the partition energy. -/
 theorem l2inner_graphon_stepGraphonAvg (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
     l2inner μ W.toSymmKernel (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
       = graphonPartitionEnergy μ P hP W := by
@@ -248,8 +251,8 @@ theorem l2sq_sub_stepGraphonAvg (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : G
   rw [l2sq_sub, l2inner_graphon_stepGraphonAvg, graphonPartitionEnergy_eq]
   ring
 
-/-- The partition energy never exceeds the `L²` norm squared of the graphon — Bessel's inequality
-for the block-average projection. -/
+/-- The partition energy never exceeds the `L²` norm squared of the graphon — the Bessel-type
+bound following from the projection moment identity. -/
 theorem graphonPartitionEnergy_le_l2sq (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) :
     graphonPartitionEnergy μ P hP W ≤ l2sq μ W.toSymmKernel := by
   have h := l2sq_nonneg μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel)
@@ -279,8 +282,8 @@ theorem graphonPartitionEnergy_increment (hP : ∀ p ∈ P.parts, MeasurableSet 
       = graphonPartitionEnergy μ P hP W
         + l2sq μ ((stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel
           - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel) := by
-  rw [l2sq_sub, l2inner_stepGraphonAvg_of_le μ P Q hP hQ href W, graphonPartitionEnergy_eq μ Q,
-    graphonPartitionEnergy_eq μ P]
+  simp only [l2sq_sub, l2inner_stepGraphonAvg_of_le μ P Q hP hQ href W,
+    graphonPartitionEnergy_eq]
   ring
 
 /-- The partition energy is monotone under refinement — the `≥ 0` corollary of the Pythagoras
@@ -300,7 +303,7 @@ theorem graphonPartitionEnergy_nonneg (hP : ∀ p ∈ P.parts, MeasurableSet p) 
 
 /-- Block averaging does not change the partition energy at the same partition: the block-average
 step graphon is already constant on the rectangles of `P`, so averaging it again changes nothing.
-This is the projection identity `E(P, E[W|P⊗P]) = E(P, W)`. -/
+This is the idempotence identity `E(P, E[W|P⊗P]) = E(P, W)`. -/
 @[simp]
 theorem graphonPartitionEnergy_stepGraphonAvg (hP : ∀ p ∈ P.parts, MeasurableSet p)
     (W : Graphon Ω μ) :

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -28,10 +28,12 @@ This file builds that potential.
 
 Both rest on the same block computation: the energy is a finite sum of block contributions
 (`graphonPartitionEnergy_eq_sum`), and a block average over a *refinement* still reproduces the
-coarse block integrals (`stepGraphonAvg_rectIntegral_of_le`).  That last point is where the
-null-cell convention of `stepGraphonAvg` is tested: a part of the finer partition may be null, and
-the convention assigning it the value zero is exactly what keeps its contribution to the coarse
-block integral correct.
+coarse block integrals (`stepGraphonAvg_rectIntegral_of_le`).  That last identity needs no
+hypothesis excluding null parts: a null part of the finer partition cuts out a null rectangle,
+which contributes zero to both sides whatever value the step graphon takes there.  The null-cell
+convention of `stepGraphonAvg` is what makes it a well-defined strict `[0, 1]`-valued
+representative at all — it is load-bearing for `stepGraphonAvg_idem` — but it is not what makes
+this identity true.
 
 This is `‖E[W | P ⊗ P]‖₂²` written entirely in terms of finite block averages; the identification
 with `MeasureTheory.condExp` belongs to the later a.e. layer, and nothing here needs it.  It is also
@@ -44,9 +46,20 @@ graph.
 
 ## Main results
 
+* `TauCeti.DenseGraphLimits.setIntegral_prod_eq_sum_parts` and
+  `TauCeti.DenseGraphLimits.integral_eq_sum_parts`: a measurable finite partition splits an
+  integral over a rectangle, respectively over the whole product carrier, into a finite sum over
+  its subrectangles;
 * `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le`: block averaging over a refinement
   preserves the coarse block integrals;
+* `TauCeti.DenseGraphLimits.l2inner_stepGraphonAvg_eq_sum`: the block computation everything else
+  is read off from — pairing any kernel against a block-average step graphon;
 * `TauCeti.DenseGraphLimits.graphonPartitionEnergy_eq_sum`: the energy as a finite block sum;
+* `TauCeti.DenseGraphLimits.l2inner_graphon_stepGraphonAvg`: the block average is the `L²`
+  orthogonal projection of `W`, and
+  `TauCeti.DenseGraphLimits.l2inner_stepGraphonAvg_of_le` is its refinement form;
+* `TauCeti.DenseGraphLimits.graphonPartitionEnergy_le_l2sq`: Bessel's inequality for that
+  projection;
 * `TauCeti.DenseGraphLimits.l2sq_sub_stepGraphonAvg`: the defect identity `‖W - E[W|P⊗P]‖₂² =
   ‖W‖₂² - E(P)`;
 * `TauCeti.DenseGraphLimits.graphonPartitionEnergy_increment`: the `L²`-Pythagoras increment;
@@ -63,7 +76,16 @@ graph.
   (1999), 175--220.
 * Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 2 — the analytic energy stack
   (`graphonPartitionEnergy`, `graphonPartitionEnergy_eq`, the `L²`-Pythagoras increment and its
-  `_mono` / `_nonneg` / `_le_one` corollaries).
+  `_mono` / `_nonneg` / `_le_one` corollaries).  The signatures of `graphonPartitionEnergy` and of
+  its `_eq` / `_increment` / `_mono` / `_nonneg` / `_le_one` companions, together with the
+  `_mono` and `_nonneg` proofs, follow `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` (Layer 2);
+  the block computation, the projection identity and the defect identity are developed here.
+* The roadmap lists the null-cell `Finpartition` convention — including unchanged weighted energy,
+  the scope of `stepGraphonAvg_rectIntegral_of_le` and of the increment — under its
+  migration-backed routes, with an independent development in `Graphon/RegularityFinpartition.lean`
+  in `cameronfreer/graphon` (Apache 2.0) at commit
+  `dfd7ecc9b197d8211842935204bcec6051d57863`.  No material is adapted from that source; the proofs
+  here are the `L²` route through `l2inner_stepGraphonAvg_eq_sum`.
 -/
 
 public section
@@ -76,41 +98,14 @@ namespace TauCeti
 
 namespace DenseGraphLimits
 
-variable {Ω : Type*}
-
-section Parts
-
-/-- The parts of a finite partition of the carrier cover it. -/
-private theorem iUnion_parts (R : Finpartition (Set.univ : Set Ω)) :
-    ⋃ r : R.parts, (r : Set Ω) = Set.univ := by
-  refine eq_univ_of_forall fun x => ?_
-  have hx : x ∈ ⋃₀ (R.parts : Set (Set Ω)) := by
-    rw [← Finset.sup_id_set_eq_sUnion, R.sup_parts]
-    exact mem_univ x
-  obtain ⟨r, hr, hxr⟩ := mem_sUnion.mp hx
-  exact mem_iUnion.2 ⟨⟨r, hr⟩, hxr⟩
-
-/-- Under refinement, a part of the finer partition is either contained in a given part of the
-coarser one or disjoint from it. -/
-private theorem inter_eq_self_or_empty {P Q : Finpartition (Set.univ : Set Ω)} (href : Q ≤ P)
-    {r : Set Ω} (hr : r ∈ Q.parts) {p : Set Ω} (hp : p ∈ P.parts) :
-    r ∩ p = r ∨ r ∩ p = ∅ := by
-  obtain ⟨p', hp', hrp'⟩ := href hr
-  by_cases h : p' = p
-  · exact Or.inl (inter_eq_self_of_subset_left (h ▸ hrp'))
-  · refine Or.inr (eq_empty_of_subset_empty fun x hx => ?_)
-    exact absurd hx.2 (disjoint_left.mp (P.disjoint hp' hp h) (hrp' hx.1))
-
-end Parts
-
-variable [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
+variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
 
 section Decomposition
 
 omit [IsProbabilityMeasure μ] in
 /-- A finite measurable partition of the carrier cuts a rectangle into finitely many disjoint
 subrectangles, splitting any integral over it into a finite sum. -/
-private theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
+theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
     (hR : ∀ r ∈ R.parts, MeasurableSet r) {S T : Set Ω} (hS : MeasurableSet S)
     (hT : MeasurableSet T) {f : Ω × Ω → ℝ} (hf : Integrable f (μ.prod μ)) :
     ∫ z in S ×ˢ T, f z ∂(μ.prod μ)
@@ -143,7 +138,7 @@ private theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set 
 omit [IsProbabilityMeasure μ] in
 /-- A finite measurable partition of the carrier splits an integral over the whole product carrier
 into a finite sum over its rectangles. -/
-private theorem integral_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
+theorem integral_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
     (hR : ∀ r ∈ R.parts, MeasurableSet r) {f : Ω × Ω → ℝ} (hf : Integrable f (μ.prod μ)) :
     ∫ z, f z ∂(μ.prod μ)
       = ∑ rs : R.parts × R.parts, ∫ z in (rs.1 : Set Ω) ×ˢ (rs.2 : Set Ω), f z ∂(μ.prod μ) := by
@@ -179,9 +174,9 @@ end Decomposition
 variable (P Q : Finpartition (Set.univ : Set Ω))
 
 /-- Block averaging over a refinement still reproduces the block integrals of the coarser
-partition.  This is where the null-cell convention of `stepGraphonAvg` is exercised: a null part of
-the finer partition is given the value zero, and contributes zero to the coarse block integral,
-which is exactly what this identity requires. -/
+partition.  No hypothesis excluding null parts is needed: a null part of the finer partition cuts
+out a null rectangle, which contributes zero to both sides whatever value the step graphon takes
+there. -/
 theorem stepGraphonAvg_rectIntegral_of_le (hP : ∀ p ∈ P.parts, MeasurableSet p)
     (hQ : ∀ r ∈ Q.parts, MeasurableSet r) (href : Q ≤ P) (W : Graphon Ω μ) (p q : P.parts) :
     (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ (p : Set Ω) (q : Set Ω)
@@ -209,6 +204,7 @@ theorem l2inner_stepGraphonAvg_eq_sum (hP : ∀ p ∈ P.parts, MeasurableSet p) 
         * ⨍ z in (pq.1 : Set Ω) ×ˢ (pq.2 : Set Ω), W z.1 z.2 ∂(μ.prod μ) := by
   rw [l2inner_def, integral_eq_sum_parts μ P hP
     (SymmKernel.integrable_mul μ K (stepGraphonAvg (μ := μ) P hP W).toSymmKernel)]
+  simp only [Graphon.coe_toSymmKernel]
   exact Finset.sum_congr rfl fun pq _ => setIntegral_mul_stepGraphonAvg μ P hP W K pq.1 pq.2
 
 /-- The **graphon partition energy** of `W` over a measurable finite partition `P`: the

--- a/TauCeti/MeasureTheory/Integral/Finpartition.lean
+++ b/TauCeti/MeasureTheory/Integral/Finpartition.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.Bochner.Set
+public import Mathlib.MeasureTheory.Measure.Prod
+public import TauCeti.Order.Partition.Finpartition
+import Mathlib.Data.Setoid.Partition
+
+/-!
+# Integrals split by finite measurable partitions
+
+A measurable finite partition of a measure space decomposes integrals on the product space into
+finite sums over partition rectangles.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+
+namespace Finpartition
+
+variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω)
+
+/-- A finite measurable partition of the carrier cuts a rectangle into finitely many disjoint
+subrectangles, splitting any integral over it into a finite sum. -/
+theorem setIntegral_prod_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
+    (hR : ∀ r ∈ R.parts, MeasurableSet r) {S T : Set Ω} (hS : MeasurableSet S)
+    (hT : MeasurableSet T) {f : Ω × Ω → ℝ} (hf : IntegrableOn f (S ×ˢ T) (μ.prod μ)) :
+    ∫ z in S ×ˢ T, f z ∂(μ.prod μ)
+      = ∑ rs : R.parts × R.parts,
+          ∫ z in ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T), f z ∂(μ.prod μ) := by
+  have hmeas : ∀ rs : R.parts × R.parts,
+      MeasurableSet (((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T)) := fun rs =>
+    ((hR _ rs.1.property).inter hS).prod ((hR _ rs.2.property).inter hT)
+  have hdisj : Pairwise (Function.onFun Disjoint fun rs : R.parts × R.parts =>
+      ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T)) := by
+    intro rs rs' hne
+    have key : ∀ {u v : R.parts} {A : Set Ω}, u ≠ v →
+        ((u : Set Ω) ∩ A) ∩ ((v : Set Ω) ∩ A) = ∅ := by
+      intro u v A huv
+      refine disjoint_iff_inter_eq_empty.mp ?_
+      exact (R.disjoint u.property v.property fun h => huv (Subtype.ext h)).mono
+        inter_subset_left inter_subset_left
+    simp only [Function.onFun, disjoint_iff_inter_eq_empty, prod_inter_prod, prod_eq_empty_iff]
+    by_cases h1 : rs.1 = rs'.1
+    · refine Or.inr (key ?_)
+      intro h2
+      exact hne (Prod.ext h1 h2)
+    · exact Or.inl (key h1)
+  have hcover : ⋃ r : R.parts, (r : Set Ω) = Set.univ := by
+    refine Set.eq_univ_of_forall fun x => ?_
+    have hx : x ∈ ⋃₀ (R.parts : Set (Set Ω)) := by
+      rw [R.isPartition_parts.sUnion_eq_univ]
+      exact Set.mem_univ x
+    obtain ⟨r, hr, hxr⟩ := Set.mem_sUnion.mp hx
+    exact Set.mem_iUnion.2 ⟨⟨r, hr⟩, hxr⟩
+  have hunion : (⋃ rs : R.parts × R.parts, ((rs.1 : Set Ω) ∩ S) ×ˢ ((rs.2 : Set Ω) ∩ T))
+      = S ×ˢ T := by
+    rw [iUnion_prod (fun r : R.parts => (r : Set Ω) ∩ S) fun r : R.parts => (r : Set Ω) ∩ T,
+      ← iUnion_inter, ← iUnion_inter, hcover, univ_inter, univ_inter]
+  rw [← hunion, integral_iUnion_fintype hmeas hdisj fun _ =>
+    hf.mono_set (prod_mono inter_subset_right inter_subset_right)]
+
+/-- A finite measurable partition of the carrier splits an integral over the whole product carrier
+into a finite sum over its rectangles. -/
+theorem integral_eq_sum_parts (R : Finpartition (Set.univ : Set Ω))
+    (hR : ∀ r ∈ R.parts, MeasurableSet r) {f : Ω × Ω → ℝ} (hf : Integrable f (μ.prod μ)) :
+    ∫ z, f z ∂(μ.prod μ)
+      = ∑ rs : R.parts × R.parts, ∫ z in (rs.1 : Set Ω) ×ˢ (rs.2 : Set Ω), f z ∂(μ.prod μ) := by
+  rw [← setIntegral_univ (μ := μ.prod μ), ← univ_prod_univ,
+    setIntegral_prod_eq_sum_parts μ R hR MeasurableSet.univ MeasurableSet.univ hf.integrableOn]
+  simp
+
+end Finpartition

--- a/TauCeti/Order/Partition/Finpartition.lean
+++ b/TauCeti/Order/Partition/Finpartition.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Order.Partition.Finpartition
+
+/-!
+# Finite partition helpers
+
+This file contains general-purpose facts about refinements of finite partitions.
+-/
+
+public section
+
+namespace Finpartition
+
+variable {Ω : Type*} {u : Set Ω}
+
+/-- Under refinement, a part of the finer partition is either contained in a given part of the
+coarser one or disjoint from it. -/
+theorem inter_part_eq_self_or_eq_empty_of_le {P Q : Finpartition u} (href : Q ≤ P)
+    {r : Set Ω} (hr : r ∈ Q.parts) {p : Set Ω} (hp : p ∈ P.parts) :
+    r ∩ p = r ∨ r ∩ p = ∅ := by
+  obtain ⟨p', hp', hrp'⟩ := href hr
+  by_cases h : p' = p
+  · exact Or.inl (Set.inter_eq_self_of_subset_left (h ▸ hrp'))
+  · refine Or.inr (Set.eq_empty_of_subset_empty fun x hx => ?_)
+    exact absurd hx.2 (Set.disjoint_left.mp (P.disjoint hp' hp h) (hrp' hx.1))
+
+end Finpartition


### PR DESCRIPTION
This PR builds the Layer-2 analytic energy stack of the dense graph limits roadmap: `graphonPartitionEnergy μ P hP W`, the `L²(μ ⊗ μ)` norm squared of the block-average step graphon `E[W | P ⊗ P]`, together with the `L²`-Pythagoras increment under refinement and the bounds that make it the bounded monotone potential the Frieze–Kannan iteration runs on. It serves the roadmap's Layer-2 milestone `weak_regularity_frieze_kannan`, whose required design-validation gate is stated as "before Layer 2 commits to the block-average representation: the null-cell regression lemmas beyond the adapter (Pythagoras, increment, the iteration exponent)". The pinned targets discharged here are `l2sq` / `l2sq_nonneg`, `graphonPartitionEnergy` / `graphonPartitionEnergy_eq`, `graphonPartitionEnergy_increment`, and the `_mono` / `_nonneg` / `_le_one` corollaries. After this PR the only remaining input to that milestone is the iteration itself — turning a cut-norm defect `> ε` into an energy gain bounded below, and running the bounded potential to the complexity bound `4 ^ (⌈1/ε²⌉ + 1)`.

`TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean` (153 lines) supplies the pairing the energy is measured in: `SymmKernel.integrable_mul`, the inner product `l2inner`, the norm squared `l2sq`, the expansion `l2sq_sub`, and `l2sq_le_one_of_abs_le_one`. These are plain integrals of strict kernel representatives rather than `MeasureTheory.Lp` elements, following the roadmap's strict-carrier convention: a difference `K - L` of kernels is a literal kernel, and boundedness plus a finite carrier makes every integral converge, so `l2sq_sub` needs no side conditions and no a.e. bookkeeping enters this layer.

`TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean` (327 lines) is the energy proper. The block computation is `l2inner_stepGraphonAvg_eq_sum`: a measurable finite partition cuts the product carrier into finitely many disjoint rectangles, and pairing any kernel against a block-average step graphon multiplies each block integral by that block's average of `W`. Two consequences follow. Taking `W` itself as the left argument gives `l2inner_graphon_stepGraphonAvg`, the concrete form of the statement that `E[W | P ⊗ P]` is the `L²` orthogonal projection of `W`, hence the defect identity `l2sq_sub_stepGraphonAvg` (`‖W − E[W|P⊗P]‖₂² = ‖W‖₂² − E(P)`) and Bessel's inequality `graphonPartitionEnergy_le_l2sq`. Taking a *finer* partition's block average as the left argument gives `l2inner_stepGraphonAvg_of_le`, and expanding `l2sq_sub` yields `graphonPartitionEnergy_increment`.

The refinement step rests on `stepGraphonAvg_rectIntegral_of_le`: averaging over a refinement `Q ≤ P` still reproduces the block integrals of `P`. This is exactly where the null-cell convention pinned by `stepGraphonAvg` is exercised rather than assumed — a part of the finer partition may be null, Mathlib's set-average convention then gives it the value zero, and the identity holds precisely because a null part contributes nothing to the coarse block integral. No non-null hypothesis is needed anywhere in this file, and the increment therefore holds for arbitrary measurable finite partitions on an arbitrary probability carrier.

`graphonPartitionEnergy` is deliberately not Mathlib's `Finpartition.energy`, which is the finite edge-density energy of a finite graph and is a proof template rather than an input here; `Finpartition` itself, `MeasureTheory.integral_iUnion_fintype` and the set-average API are consumed from Mathlib. No Mathlib source was vendored. `MeasureTheory.condExp` is not used: the identification of `stepGraphonAvg` with a conditional expectation belongs to the later a.e. layer, and nothing proved here needs it.

Roadmap: DenseGraphLimits

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"graphon-partition-energy"}-->

🤖 Prepared with Claude Code
