### PR TITLE
doc: correct the lint-env advice about stale files

### DIFF
--- a/scripts/lint-env.sh
+++ b/scripts/lint-env.sh
@@ -618,9 +618,10 @@ if [ -s "$TMP/new.txt" ]; then
   echo "— as a deliberate, commented exception — use @[nolint <linter>] plus a"
   echo "'<linter> <declName>' line in $ALLOWLIST (for docString: a baseline entry"
   echo "instead, since the scan ignores @[nolint])."
-  echo "If a flagged declaration is NOT in your diff, your branch likely carries a stale"
-  echo "copy of a file that main has since cleaned up (the CI build overlays your whole"
-  echo "TauCeti/ tree onto current main): merge main into your branch and re-push."
+  echo "If a flagged declaration is NOT in your diff: running this locally, your tree may"
+  echo "carry a stale copy of a file main has since cleaned up, and merging main into your"
+  echo "branch fixes that. In CI it will not be the cause — pr-build compiles your branch"
+  echo "already merged with main — so there it is something your change affected indirectly."
   fail "$(wc -l < "$TMP/new.txt") new violation(s); see the list above"
 fi
 


### PR DESCRIPTION
This PR corrects the advice `scripts/lint-env.sh` prints when it flags a declaration that is not in the author's diff.

It told them their branch likely carried a stale copy of a file main had since cleaned up, because "the CI build overlays your whole TauCeti/ tree onto current main", and to merge main into their branch and re-push. Since https://github.com/TauCetiProject/TauCeti/pull/4571 `fix: build the pull request merged into the base, not the head alone` that is no longer how the build works: `pr-build` merges the pull request into its base and compiles the result, so main's own cleanups are always present and merging main is already done for the author. Following the advice would achieve nothing, and it points away from whatever the real cause is.

It is still accurate for a local run, though, which the script documents (`scripts/lint-env.sh`, `--update`). There the tree is whatever the author has, and a stale file really can be the cause with merging main the fix. So the message now distinguishes the two rather than dropping the advice: local runs keep it, and a CI report says the cause lies elsewhere, most likely something the change affected indirectly.

Message text only; no behaviour changes.

🤖 Prepared with Claude Code