### PR TITLE
ci(pages): run the olean restore from the repository root

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -263,6 +263,13 @@ jobs:
 
       - name: Restore TauCeti's oleans from the public artifact cache
         if: ${{ steps.docs-plan.outputs.build == 'true' && env.TAUCETI_CACHE_ENABLED == '1' }}
+        # The job's default working directory is web/; this script lives at the root.
+        working-directory: ${{ github.workspace }}
+        # A cache is an optimisation and must not be able to break the deploy. The script
+        # already treats a miss as non-fatal and falls back to compiling from scratch;
+        # this extends that to the script failing outright, which is how a mistake here
+        # cost a whole run.
+        continue-on-error: true
         env:
           PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}


### PR DESCRIPTION
This PR fixes the olean restore step, which failed on its first run.

The job defaults to `working-directory: web`, and every step needing the repository root sets `working-directory: ${{ github.workspace }}` explicitly. The restore step did not, so it looked for `scripts/lake-cache-get.sh` under `web/`, exited 127, and took the whole run down with it before the docs build was reached.

The step is now also `continue-on-error`. A cache is an optimisation and should not be able to break the deploy: `lake-cache-get.sh` already treats a miss as non-fatal and falls back to compiling from scratch, and that intent should survive the script failing outright, which is exactly what happened here.

Roadmap: none

🤖 Prepared with Claude Code