### PR TITLE
feat(Flat): a flat algebra modulo a universally regular element is flat

### DIFF
--- a/TauCeti/RingTheory/Flat/QuotientRegular.lean
+++ b/TauCeti/RingTheory/Flat/QuotientRegular.lean
@@ -13,16 +13,16 @@ import Mathlib.LinearAlgebra.TensorProduct.RightExactness
 # Flatness of a quotient by a universally regular element
 
 Let `B` be a flat algebra over a commutative ring `R` and `g ∈ B`. If multiplication by `g` on
-`M ⊗[R] B` is injective for every finitely generated `R`-module `M`, then `B ⧸ (g)` is a flat
-`R`-module.
+`R ⧸ I ⊗[R] B` is injective for every finitely generated ideal `I` of `R`, then `B ⧸ (g)` is a
+flat `R`-module.
 
 This is the claim inside Wedhorn's proof of Lemma 8.31(2): for `B = A⟨X⟩` over a complete
 noetherian Tate ring `A`, and `g = f - X` or `g = 1 - f X`, the quotient is flat because
-multiplication by `g` is injective on `M⟨X⟩ = M ⊗[A] A⟨X⟩` for every finitely generated `M`.
-Wedhorn proves the claim with the long exact `Tor` sequence. What the sequence encodes is a
-diagram chase, and that chase is what is carried out here, against Mathlib's ideal criterion
-for flatness: `B ⧸ (g)` is flat once `I ⊗[R] B ⧸ (g) → R ⊗[R] B ⧸ (g)` is injective for every
-finitely generated ideal `I`.
+multiplication by `g` is injective on `M⟨X⟩ = M ⊗[A] A⟨X⟩` for every finitely generated `M` —
+in particular for every `M = A ⧸ I`, which is all the argument uses. Wedhorn proves the claim
+with the long exact `Tor` sequence. What the sequence encodes is a diagram chase, and that chase
+is what is carried out here, against Mathlib's ideal criterion for flatness: `B ⧸ (g)` is flat
+once `I ⊗[R] B ⧸ (g) → R ⊗[R] B ⧸ (g)` is injective for every finitely generated ideal `I`.
 
 ## Main results
 
@@ -30,9 +30,16 @@ finitely generated ideal `I`.
 
 ## Implementation notes
 
-The regularity hypothesis is quantified over modules in the universe of `R`, which is where the
-proof uses it: at `M = R ⧸ I`. It is stated for `M ⊗[R] B` with `M` on the left, matching the
-orientation of Mathlib's `Module.Flat.iff_rTensor_injective`.
+The regularity hypothesis is asked only on `R ⧸ I ⊗[R] B` for finitely generated ideals `I`,
+which is exactly what the chase consumes; a hypothesis on every finitely generated module, as
+Wedhorn states it, specialises to this. It is stated with the coefficient module on the left,
+matching the orientation of Mathlib's `Module.Flat.iff_rTensor_injective`.
+
+The chase, for a finitely generated ideal `I`: an element of `I ⊗ B ⧸ (g)` killed in
+`R ⊗ B ⧸ (g)` lifts to `I ⊗ B`, is there the image of `g` times some `w` in `R ⊗ B`, and
+regularity of `g` on `R ⧸ I ⊗ B` shows that `w` comes from `I ⊗ B`, so the element is `g` times
+an element of `I ⊗ B` and dies in `I ⊗ B ⧸ (g)`. Flatness of `B` enters twice: as exactness of
+`I ⊗ B → R ⊗ B → R ⧸ I ⊗ B`, and as injectivity of `I ⊗ B → R ⊗ B`.
 
 ## References
 
@@ -45,26 +52,19 @@ open TensorProduct
 
 namespace Module.Flat
 
-universe u
-
-variable {R : Type u} {B : Type*} [CommRing R] [CommRing B] [Algebra R B]
+variable {R B : Type*} [CommRing R] [CommRing B] [Algebra R B]
 
 /-- **A flat algebra modulo a universally regular element is flat.** Let `B` be a flat
-`R`-algebra and `g ∈ B`. If `id ⊗ (g • ·) : M ⊗[R] B → M ⊗[R] B` is injective for every finitely
-generated `R`-module `M`, then `B ⧸ (g)` is a flat `R`-module.
-
-This is the `Tor`-sequence step of Wedhorn's Lemma 8.31(2), as a diagram chase against
-`Module.Flat.iff_rTensor_injective`: for an ideal `I`, an element of `I ⊗ B ⧸ (g)` killed in
-`R ⊗ B ⧸ (g)` lifts to `I ⊗ B`, is there the image of `g` times something in `R ⊗ B`, and
-regularity of `g` on `R ⧸ I ⊗ B` shows that something comes from `I ⊗ B`, so the element is
-`g` times an element of `I ⊗ B` and dies in `I ⊗ B ⧸ (g)`. Flatness of `B` enters twice: as
-exactness of `I ⊗ B → R ⊗ B → R ⧸ I ⊗ B`, and as injectivity of `I ⊗ B → R ⊗ B`. -/
+`R`-algebra and `g ∈ B`. If `id ⊗ (g • ·) : R ⧸ I ⊗[R] B → R ⧸ I ⊗[R] B` is injective for every
+finitely generated ideal `I`, then `B ⧸ (g)` is a flat `R`-module. This is the `Tor`-sequence
+step of Wedhorn's Lemma 8.31(2); a consumer holding injectivity for every finitely generated
+module, as Wedhorn states it, passes it at `M = R ⧸ I`. -/
 theorem quotient_span_singleton_of_lTensor_mulLeft_injective [Flat R B] (g : B)
-    (hg : ∀ (M : Type u) [AddCommGroup M] [Module R M] [Module.Finite R M],
-      Function.Injective (LinearMap.lTensor M (LinearMap.mulLeft R g))) :
+    (hg : ∀ ⦃I : Ideal R⦄, I.FG →
+      Function.Injective (LinearMap.lTensor (R ⧸ I) (LinearMap.mulLeft R g))) :
     Flat R (B ⧸ Ideal.span {g}) := by
   rw [iff_rTensor_injective]
-  intro I _
+  intro I hI
   set v : B →ₗ[R] B := LinearMap.mulLeft R g with hv
   set π : B →ₗ[R] B ⧸ Ideal.span {g} := (Ideal.Quotient.mkₐ R (Ideal.span {g})).toLinearMap
     with hπ
@@ -91,7 +91,7 @@ theorem quotient_span_singleton_of_lTensor_mulLeft_injective [Flat R B] (g : B)
       LinearMap.comp_apply, hw, ← LinearMap.comp_apply, ← LinearMap.rTensor_comp, hqι,
       LinearMap.rTensor_zero, LinearMap.zero_apply]
   obtain ⟨z₀, hz₀⟩ := ((rTensor_exact B (LinearMap.exact_subtype_mkQ I)) _).mp
-    ((injective_iff_map_eq_zero _).mp (hg (R ⧸ I)) _ h2)
+    ((injective_iff_map_eq_zero _).mp (hg hI) _ h2)
   -- Flatness of `B` makes `I ⊗ B → R ⊗ B` injective, so `z' = g • z₀`.
   have h4 : LinearMap.lTensor I v z₀ = z' :=
     rTensor_preserves_injective_linearMap I.subtype Subtype.val_injective <| by

--- a/TauCeti/RingTheory/Flat/QuotientRegular.lean
+++ b/TauCeti/RingTheory/Flat/QuotientRegular.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Flat.Tensor
+public import Mathlib.RingTheory.Ideal.Quotient.Operations
+import Mathlib.LinearAlgebra.TensorProduct.RightExactness
+
+/-!
+# Flatness of a quotient by a universally regular element
+
+Let `B` be a flat algebra over a commutative ring `R` and `g ∈ B`. If multiplication by `g` on
+`M ⊗[R] B` is injective for every finitely generated `R`-module `M`, then `B ⧸ (g)` is a flat
+`R`-module.
+
+This is the claim inside Wedhorn's proof of Lemma 8.31(2): for `B = A⟨X⟩` over a complete
+noetherian Tate ring `A`, and `g = f - X` or `g = 1 - f X`, the quotient is flat because
+multiplication by `g` is injective on `M⟨X⟩ = M ⊗[A] A⟨X⟩` for every finitely generated `M`.
+Wedhorn proves the claim with the long exact `Tor` sequence. What the sequence encodes is a
+diagram chase, and that chase is what is carried out here, against Mathlib's ideal criterion
+for flatness: `B ⧸ (g)` is flat once `I ⊗[R] B ⧸ (g) → R ⊗[R] B ⧸ (g)` is injective for every
+finitely generated ideal `I`.
+
+## Main results
+
+* `Module.Flat.quotient_span_singleton_of_lTensor_mulLeft_injective`: the statement above.
+
+## Implementation notes
+
+The regularity hypothesis is quantified over modules in the universe of `R`, which is where the
+proof uses it: at `M = R ⧸ I`. It is stated for `M ⊗[R] B` with `M` on the left, matching the
+orientation of Mathlib's `Module.Flat.iff_rTensor_injective`.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Lemma 8.31.
+-/
+
+public section
+
+open TensorProduct
+
+namespace Module.Flat
+
+universe u
+
+variable {R : Type u} {B : Type*} [CommRing R] [CommRing B] [Algebra R B]
+
+/-- **A flat algebra modulo a universally regular element is flat.** Let `B` be a flat
+`R`-algebra and `g ∈ B`. If `id ⊗ (g • ·) : M ⊗[R] B → M ⊗[R] B` is injective for every finitely
+generated `R`-module `M`, then `B ⧸ (g)` is a flat `R`-module.
+
+This is the `Tor`-sequence step of Wedhorn's Lemma 8.31(2), as a diagram chase against
+`Module.Flat.iff_rTensor_injective`: for an ideal `I`, an element of `I ⊗ B ⧸ (g)` killed by
+`R ⊗ B ⧸ (g)` lifts to `I ⊗ B`, is there the image of `g` times something in `R ⊗ B`, and
+regularity of `g` on `R ⧸ I ⊗ B` shows that something comes from `I ⊗ B`, so the element is
+`g` times an element of `I ⊗ B` and dies in `I ⊗ B ⧸ (g)`. Flatness of `B` enters twice, as
+injectivity of `I ⊗ B → R ⊗ B`. -/
+theorem quotient_span_singleton_of_lTensor_mulLeft_injective [Flat R B] (g : B)
+    (hg : ∀ (M : Type u) [AddCommGroup M] [Module R M] [Module.Finite R M],
+      Function.Injective (LinearMap.lTensor M (LinearMap.mulLeft R g))) :
+    Flat R (B ⧸ Ideal.span {g}) := by
+  rw [iff_rTensor_injective]
+  intro I _
+  set v : B →ₗ[R] B := LinearMap.mulLeft R g with hv
+  set π : B →ₗ[R] B ⧸ Ideal.span {g} := (Ideal.Quotient.mkₐ R (Ideal.span {g})).toLinearMap
+    with hπ
+  have hexact : Function.Exact v π := fun y ↦ by
+    simp only [hπ, AlgHom.toLinearMap_apply, Ideal.Quotient.mkₐ_eq_mk,
+      Ideal.Quotient.eq_zero_iff_mem, Ideal.mem_span_singleton', Set.mem_range, hv,
+      LinearMap.mulLeft_apply]
+    exact ⟨fun ⟨a, ha⟩ ↦ ⟨a, by rw [mul_comm]; exact ha⟩,
+      fun ⟨a, ha⟩ ↦ ⟨a, by rw [mul_comm]; exact ha⟩⟩
+  have hπv : π ∘ₗ v = 0 := LinearMap.ext fun x ↦ hexact.apply_apply_eq_zero x
+  have hqι : I.mkQ ∘ₗ I.subtype = 0 :=
+    LinearMap.ext fun x ↦ (Submodule.Quotient.mk_eq_zero I).mpr x.2
+  rw [injective_iff_map_eq_zero]
+  intro z hz
+  obtain ⟨z', rfl⟩ := LinearMap.lTensor_surjective I (g := π) Ideal.Quotient.mk_surjective z
+  -- `rTensor B I.subtype z'` is killed by `lTensor R π`, so it is `g` times some `w`.
+  have h1 : LinearMap.lTensor R π (LinearMap.rTensor B I.subtype z') = 0 := by
+    rwa [← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor, ← LinearMap.rTensor_comp_lTensor,
+      LinearMap.comp_apply]
+  obtain ⟨w, hw⟩ := ((lTensor_exact R hexact) _).mp h1
+  -- The image of `w` in `R ⧸ I ⊗ B` is killed by `g`, hence zero, so `w` comes from `I ⊗ B`.
+  have h2 : LinearMap.lTensor (R ⧸ I) v (LinearMap.rTensor B I.mkQ w) = 0 := by
+    rw [← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor, ← LinearMap.rTensor_comp_lTensor,
+      LinearMap.comp_apply, hw, ← LinearMap.comp_apply, ← LinearMap.rTensor_comp, hqι,
+      LinearMap.rTensor_zero, LinearMap.zero_apply]
+  obtain ⟨z₀, hz₀⟩ := ((rTensor_exact B (LinearMap.exact_subtype_mkQ I)) _).mp
+    ((injective_iff_map_eq_zero _).mp (hg (R ⧸ I)) _ h2)
+  -- Flatness of `B` makes `I ⊗ B → R ⊗ B` injective, so `z' = g • z₀`.
+  have h4 : LinearMap.lTensor I v z₀ = z' :=
+    rTensor_preserves_injective_linearMap I.subtype Subtype.val_injective <| by
+      rw [← LinearMap.comp_apply, LinearMap.rTensor_comp_lTensor, ← LinearMap.lTensor_comp_rTensor,
+        LinearMap.comp_apply, hz₀, hw]
+  rw [← h4, ← LinearMap.comp_apply, ← LinearMap.lTensor_comp, hπv, LinearMap.lTensor_zero,
+    LinearMap.zero_apply]
+
+end Module.Flat

--- a/TauCeti/RingTheory/Flat/QuotientRegular.lean
+++ b/TauCeti/RingTheory/Flat/QuotientRegular.lean
@@ -54,11 +54,11 @@ variable {R : Type u} {B : Type*} [CommRing R] [CommRing B] [Algebra R B]
 generated `R`-module `M`, then `B ⧸ (g)` is a flat `R`-module.
 
 This is the `Tor`-sequence step of Wedhorn's Lemma 8.31(2), as a diagram chase against
-`Module.Flat.iff_rTensor_injective`: for an ideal `I`, an element of `I ⊗ B ⧸ (g)` killed by
+`Module.Flat.iff_rTensor_injective`: for an ideal `I`, an element of `I ⊗ B ⧸ (g)` killed in
 `R ⊗ B ⧸ (g)` lifts to `I ⊗ B`, is there the image of `g` times something in `R ⊗ B`, and
 regularity of `g` on `R ⧸ I ⊗ B` shows that something comes from `I ⊗ B`, so the element is
-`g` times an element of `I ⊗ B` and dies in `I ⊗ B ⧸ (g)`. Flatness of `B` enters twice, as
-injectivity of `I ⊗ B → R ⊗ B`. -/
+`g` times an element of `I ⊗ B` and dies in `I ⊗ B ⧸ (g)`. Flatness of `B` enters twice: as
+exactness of `I ⊗ B → R ⊗ B → R ⧸ I ⊗ B`, and as injectivity of `I ⊗ B → R ⊗ B`. -/
 theorem quotient_span_singleton_of_lTensor_mulLeft_injective [Flat R B] (g : B)
     (hg : ∀ (M : Type u) [AddCommGroup M] [Module R M] [Module.Finite R M],
       Function.Injective (LinearMap.lTensor M (LinearMap.mulLeft R g))) :


### PR DESCRIPTION
The algebraic core of Wedhorn's Lemma 8.31(2), stated for any flat algebra: if `B` is a flat
`R`-algebra and `g ∈ B` acts injectively on `R ⧸ I ⊗[R] B` for every finitely generated ideal `I`
of `R`, then `B ⧸ (g)` is a flat `R`-module.

## What is added

`TauCeti/RingTheory/Flat/QuotientRegular.lean` (new):

* `Module.Flat.quotient_span_singleton_of_lTensor_mulLeft_injective` — the statement above.

## Why this is its own PR

Wedhorn's proof of 8.31(2) opens with exactly this claim ("Let `g ∈ A⟨X⟩` and assume that for every
finitely generated `A`-module `M` the multiplication `w_g : M⟨X⟩ → M⟨X⟩` is injective. Then
`B := A⟨X⟩/(g)` is flat over `A`") and proves it with the long exact `Tor` sequence. Once `M⟨X⟩`
is read as `M ⊗[A] A⟨X⟩` (Remark 8.29, #4575), nothing about restricted power series remains: the
claim is a statement about a flat algebra and an element of it. Splitting it out keeps the
8.31 PR to what is specific to `A⟨X⟩` — the regularity of `f − X` and `1 − f X`, and faithfulness
— and gives the adic lane a PR that does not stack on the unmerged #4575.

## The proof

Mathlib has no `Tor` long exact sequence in a form a flatness argument can consume, but the
sequence only encodes a diagram chase, and Mathlib's ideal criterion
`Module.Flat.iff_rTensor_injective` is where that chase terminates. For a finitely generated
ideal `I`, an element of `I ⊗ B ⧸ (g)` killed in `R ⊗ B ⧸ (g)` is lifted to `I ⊗ B`
(`LinearMap.lTensor_surjective`), shown there to be `g` times an element `w` of `R ⊗ B`
(`Module.Flat.lTensor_exact` for the row `B →(g·) B → B ⧸ (g)`), and the image of `w` in
`R ⧸ I ⊗ B` is killed by `g`, hence is zero by the regularity hypothesis at `M = R ⧸ I`, so `w`
comes from `I ⊗ B` (`Module.Flat.rTensor_exact` for `I → R → R ⧸ I`). Flatness of `B`
(`Module.Flat.rTensor_preserves_injective_linearMap`) then identifies the lift as `g` times an
element of `I ⊗ B`, which dies in `I ⊗ B ⧸ (g)`. Every square used is one of
`LinearMap.lTensor_comp_rTensor` / `rTensor_comp_lTensor`.

The regularity hypothesis is asked only where the chase spends it — on `R ⧸ I ⊗ B` for finitely
generated ideals `I`. Wedhorn's hypothesis, injectivity on `M ⊗ B` for every finitely generated
`M`, specialises to it at `M = R ⧸ I`, so the consumer in Lemma 8.31 passes it directly; no
universal-module corollary is needed.

## Review history

Round 1 (`generality`): the hypothesis quantified over every finitely generated module while the
proof used only `R ⧸ I` — weakened to the ideal form above. Round 1 (`documentation`): the proof
narrative moved out of the theorem docstring into the module's implementation notes.

## Prior art

Mathlib: `Module.Flat.iff_rTensor_injective`, `Module.Flat.lTensor_exact`/`rTensor_exact`,
`rTensor_preserves_injective_linearMap` (all used); `RingTheory/Regular/Flat.lean` (regular
sequences under flat base change) and `IsSMulRegular.of_flat` are about the transfer of
regularity, not about flatness of the quotient; no statement of this lemma was found by
Lean-Finder, LeanSearch, Loogle (`Module.Flat _ (_ ⧸ Ideal.span _)`: no hits), grep of
`RingTheory/Flat/` for `span {`, or a compiled `exact?` probe (with a self-control). AINTLIB
(`github.com/CBirkbeck/AINTLIB` @ `37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`) has no sorry-free
8.31: `Wedhorn828.lean` carries 17 `sorry`s and `TateAlgebra.lean` states no flatness result.
Nothing is ported; the development is this repository's own.

## Verification

`lake build TauCeti.RingTheory.Flat.QuotientRegular` green with the Mathlib linter set (new
module, no importers, so that is the whole module-scoped closure). `#print axioms` on the theorem
reports `[propext, Classical.choice, Quot.sound]`. Whole-library gates (`lake exe axioms`,
`module-system`, `lint-env`) are left to CI per the no-full-local-build policy. Full `/cleanup`
pass on the file.

Roadmap: AdicSpaces
<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-4-1-lemma-8-31-flat-quotient-regular-element"}-->

Target: AdicSpaces README Layer 4.1, numbered step 2: "Lemma 8.31: prove that A⟨X⟩ is faithfully
flat over A, and that the quotients A⟨X⟩/(f−X), A⟨X⟩/(1−fX) are flat in the cases used for Laurent
rational subsets." This PR supplies the prerequisite that step's second half consumes; the
`A⟨X⟩`-specific half follows once #4575 (Remark 8.29) merges.
