### PR TITLE
refactor(Polynomial): state the linear-factor lemma over any commutative ring

### DIFF
--- a/TauCeti/Algebra/Polynomial/LinearFactor.lean
+++ b/TauCeti/Algebra/Polynomial/LinearFactor.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Polynomial.Div
-public import Mathlib.Algebra.Polynomial.Monic
 
 /-!
 # Polynomials of degree at most one with a prescribed root
@@ -36,13 +35,14 @@ public section
 
 namespace Polynomial
 
-variable {R : Type*} [CommRing R] [IsDomain R]
+variable {R : Type*} [CommRing R]
 
 /-- A polynomial of degree at most one with prescribed root `x` is a scalar multiple of
 `X - C x`. -/
 lemma exists_eq_C_mul_X_sub_C_of_natDegree_le_one {p : R[X]} (hdeg : p.natDegree ≤ 1)
     {x : R} (hx : p.IsRoot x) :
     ∃ γ, p = C γ * (X - C x) := by
+  nontriviality R
   obtain ⟨q, rfl⟩ := dvd_iff_isRoot.mpr hx
   rcases eq_or_ne q 0 with rfl | hq
   · exact ⟨0, by simp⟩


### PR DESCRIPTION
`Polynomial.exists_eq_C_mul_X_sub_C_of_natDegree_le_one` (a polynomial of `natDegree ≤ 1` with root
`x` is `C γ * (X - C x)`) was merged in #4448 under `[CommRing R] [IsDomain R]`, with a redundant
`public import Mathlib.Algebra.Polynomial.Monic` beside it. Neither is needed.

### What changes

* The `[IsDomain R]` hypothesis is dropped: the proof never used the absence of zero-divisors, only
  nontriviality (for `natDegree_X_sub_C`), and the statement is vacuous over the trivial ring — so
  the proof now opens with `nontriviality R` and the lemma holds over any commutative ring.
* The direct `Mathlib.Algebra.Polynomial.Monic` import goes: everything the file uses arrives
  through `Mathlib.Algebra.Polynomial.Div`.

Statement otherwise unchanged; its one consumer (`MordellWeil/XSubT.lean`, over a field) is
untouched and rebuilt.

### Why a separate PR

Both edits were requested by review on #4473 (placement, round 1; generality, round 2), and the
same review's scope rubric then blocked #4473 for bundling a generalisation of already-merged
material with the kernel computation. This PR carries the generalisation on its own; #4473 no
longer touches this file.

### Validation

* Module-scoped `lake build` of `TauCeti.Algebra.Polynomial.LinearFactor` and its only importer
  `TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.XSubT` at the current mathlib pin
  (`618f225`) — green, zero `Built Mathlib` lines.
* A `#lint` driver over that built closure with the linter set from `scripts/lint-env.sh` — clean;
  `#print axioms` on the lemma gives `[propext, Classical.choice, Quot.sound]`.
* The whole-library `lint-env`, `axioms` and `module-system` checks run in CI's `pr-build`.

Roadmap: EllipticCurves
