### PR TITLE
refactor(Comodule): derive the additive-hom lemmas from the bundled hom

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Cat.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Cat.lean
@@ -256,43 +256,37 @@ theorem sum_apply {ι : Type*} {M N : ComoduleCat.{u, v, w} R C} (s : Finset ι)
 /-- Composition in `ComoduleCat` is additive in the left morphism. -/
 @[simp]
 theorem add_comp {M N P : ComoduleCat.{u, v, w} R C} (f g : M ⟶ N) (h : N ⟶ P) :
-    (f + g) ≫ h = f ≫ h + g ≫ h := by
-  ext m
-  exact map_add h.toLinearMap (f m) (g m)
+    (f + g) ≫ h = f ≫ h + g ≫ h :=
+  Comodule.Hom.comp_add h f g
 
 /-- Composition in `ComoduleCat` is additive in the right morphism. -/
 @[simp]
 theorem comp_add {M N P : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) (g h : N ⟶ P) :
-    f ≫ (g + h) = f ≫ g + f ≫ h := by
-  ext m
-  rfl
+    f ≫ (g + h) = f ≫ g + f ≫ h :=
+  Comodule.Hom.add_comp g h f
 
 /-- Composition in `ComoduleCat` is compatible with scalar multiplication in the left
 morphism. -/
 @[simp]
 theorem smul_comp {M N P : ComoduleCat.{u, v, w} R C} (r : R) (f : M ⟶ N) (g : N ⟶ P) :
-    (r • f) ≫ g = r • (f ≫ g) := by
-  ext m
-  exact map_smul g.toLinearMap r (f m)
+    (r • f) ≫ g = r • (f ≫ g) :=
+  Comodule.Hom.comp_smul r g f
 
 /-- Composition in `ComoduleCat` is compatible with scalar multiplication in the right
 morphism. -/
 @[simp]
 theorem comp_smul {M N P : ComoduleCat.{u, v, w} R C} (r : R) (f : M ⟶ N) (g : N ⟶ P) :
-    f ≫ (r • g) = r • (f ≫ g) := by
-  ext m
-  rfl
+    f ≫ (r • g) = r • (f ≫ g) :=
+  Comodule.Hom.smul_comp r g f
 
 /-- Composing the zero morphism on the left gives the zero morphism. -/
-theorem zero_comp {M N P : ComoduleCat.{u, v, w} R C} (f : N ⟶ P) : (0 : M ⟶ N) ≫ f = 0 := by
-  ext m
-  exact map_zero f.toLinearMap
+theorem zero_comp {M N P : ComoduleCat.{u, v, w} R C} (f : N ⟶ P) : (0 : M ⟶ N) ≫ f = 0 :=
+  Comodule.Hom.comp_zero f
 
 /-- Composing the zero morphism on the right gives the zero morphism. -/
 theorem comp_zero {M N P : ComoduleCat.{u, v, w} R C} (f : M ⟶ N) :
-    f ≫ (0 : N ⟶ P) = 0 := by
-  ext m
-  rfl
+    f ≫ (0 : N ⟶ P) = 0 :=
+  Comodule.Hom.zero_comp f
 
 /-- `ComoduleCat` has the standard categorical zero morphisms. -/
 instance hasZeroMorphisms :

--- a/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Hom.lean
@@ -127,38 +127,28 @@ instance instModule : Module R (Hom R C M N) :=
     ext m
     exact LinearMap.congr_fun h m) fun _ _ => smul_toLinearMap _ _
 
-/-- Natural-number scalar multiplication of comodule morphisms is pointwise. -/
-@[simp]
-theorem nsmul_apply (n : ℕ) (f : Hom R C M N) (m : M) : (n • f) m = n • f m := by
-  induction n with
-  | zero =>
-      rw [zero_nsmul, zero_nsmul]
-      rfl
-  | succ n ih =>
-      rw [succ_nsmul, add_apply, ih, succ_nsmul]
-
 /-- Natural-number scalar multiplication of comodule morphisms is natural-number scalar
 multiplication of the underlying linear maps. -/
 @[simp]
-theorem nsmul_toLinearMap (n : ℕ) (f : Hom R C M N) : (n • f).toLinearMap = n • f.toLinearMap := by
-  ext m
-  simp
+theorem nsmul_toLinearMap (n : ℕ) (f : Hom R C M N) : (n • f).toLinearMap = n • f.toLinearMap :=
+  map_nsmul toLinearMapAddMonoidHom n f
 
-/-- Finite sums of comodule morphisms are evaluated pointwise. -/
+/-- Natural-number scalar multiplication of comodule morphisms is pointwise. -/
 @[simp]
-theorem sum_apply {ι : Type*} (s : Finset ι) (f : ι → Hom R C M N) (m : M) :
-    (∑ i ∈ s, f i) m = ∑ i ∈ s, f i m := by
-  classical
-  induction s using Finset.induction_on with
-  | empty => simp
-  | insert i s hi ih => simp [hi, ih]
+theorem nsmul_apply (n : ℕ) (f : Hom R C M N) (m : M) : (n • f) m = n • f m :=
+  (LinearMap.congr_fun (nsmul_toLinearMap n f) m).trans (LinearMap.smul_apply _ _ _)
 
 /-- Finite sums of comodule morphisms are finite sums of the underlying linear maps. -/
 @[simp]
 theorem sum_toLinearMap {ι : Type*} (s : Finset ι) (f : ι → Hom R C M N) :
-    (∑ i ∈ s, f i).toLinearMap = ∑ i ∈ s, (f i).toLinearMap := by
-  ext m
-  simp
+    (∑ i ∈ s, f i).toLinearMap = ∑ i ∈ s, (f i).toLinearMap :=
+  map_sum toLinearMapAddMonoidHom f s
+
+/-- Finite sums of comodule morphisms are evaluated pointwise. -/
+@[simp]
+theorem sum_apply {ι : Type*} (s : Finset ι) (f : ι → Hom R C M N) (m : M) :
+    (∑ i ∈ s, f i) m = ∑ i ∈ s, f i m :=
+  (LinearMap.congr_fun (sum_toLinearMap s f) m).trans (LinearMap.sum_apply _ _ _)
 
 section Comp
 


### PR DESCRIPTION
`Comodule.Hom.toLinearMapAddMonoidHom` is the bundled `Hom R C M N →+ (M →ₗ[R] N)` whose coercion is the action on underlying linear maps. Every lemma saying an additive operation passes to `toLinearMap` is therefore a `map_*` of it, and every pointwise `_apply` lemma follows by `LinearMap.congr_fun`. Four proofs in `Comodule/Hom.lean` re-derived that content instead:

* `nsmul_toLinearMap` and `sum_toLinearMap` were `ext m; simp`; they are `map_nsmul` and `map_sum` of the bundled hom.
* `nsmul_apply` was an induction on `n`, and `sum_apply` a `classical` `Finset.induction_on`; both are one-line consequences of the corresponding `toLinearMap` lemma.

Each `_toLinearMap` lemma now precedes the `_apply` lemma it proves — the order the file already uses for the `zero`/`add`/`smul` group.

In `Comodule/Cat.lean` the six composition lemmas were re-proved by `ext` although `Comodule.Hom` already closes them. The category instance defines `comp f g` as `Comodule.Hom.comp g f` (`Cat.lean:89`), so each categorical lemma **is** the `Hom` lemma with its two arguments swapped — and the names swap with them: `ComoduleCat.add_comp` is `Comodule.Hom.comp_add`, `ComoduleCat.zero_comp` is `Comodule.Hom.comp_zero`, and so on for all six.

No statement changes anywhere, and the `@[simp]` set is unchanged.

### Scope

This is the Comodule half of dedup finding K05. Two things the finding listed need no change, and I left them alone rather than churning them:

* `Comodule/Finite/Preadditive.lean`'s `zero_apply` and `sub_apply` are already `rfl`.
* `ComoduleCat.toLinearMap_nsmul`, `toLinearMap_sum`, `nsmul_apply` and `sum_apply` already delegate to `Comodule.Hom`.

`Comodule.Hom.instAddCommMonoid` is also left as is. Rebuilding it through `Function.Injective.addCommMonoid` would require introducing an `SMul ℕ (Hom R C M N)` instance — an API addition, not a proof dedup, and one that would change the `nsmul` field's definitional behaviour that `nsmul_apply` and downstream files rely on.

The Hodge half of K05 is deliberately not here: it needs a *new* bundled hom for `integralMapToComplex`, which is an API change rather than a proof dedup, so it is a separate topic.

### Verification

`lake build` of both changed modules and all ten direct importers (`Cat`, `MatrixCoefficient.Basic`, `Zero`, `Cofree`, `Corestrict`, `Trivial`, `ScalarExtension`, `Preadditive`, `Product`, `Transport`) is green. `#print axioms` on all ten changed declarations gives `[propext, Quot.sound]`.

Roadmap: ReductiveGroups