### PR TITLE
feat: make barycentric subdivision realization injective

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Realization.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Realization.lean
@@ -304,6 +304,11 @@ theorem mem_convexHull_carrier (K : AbstractSimplicialComplex ι) (x : Realizati
   rw [carrier_val]
   exact StandardSimplex.mem_convexHull_support ⟨x.1, hx⟩
 
+/-- The barycentric coordinates of a point of the realization are nonnegative. -/
+theorem Realization.nonneg (K : AbstractSimplicialComplex ι) (x : Realization K) (v : ι) :
+    0 ≤ x.1 v :=
+  StandardSimplex.nonneg (σ := (carrier K x).1) ⟨x.1, mem_convexHull_carrier K x⟩ v
+
 /-- The carrier is contained in every finite vertex set whose closed simplex contains the point. -/
 theorem carrier_minimal (K : AbstractSimplicialComplex ι) (x : Realization K) {σ : Finset ι}
     (hx : x.1 ∈ convexHull ℝ (σ.image (fun v => Finsupp.single v (1 : ℝ)) : Set (ι →₀ ℝ))) :

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Injective.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Injective.lean
@@ -1,0 +1,253 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Subdivision.Surjective
+
+/-!
+# Injectivity of the barycentric-subdivision realization map
+
+The canonical realization map sends a face-vertex of the barycentric subdivision to the
+barycenter of that face. This file proves that the map is injective, and hence bijective by the
+surjectivity theorem in `Subdivision.Surjective`.
+
+The key point is positivity. A point of a subdivision simplex is a nonnegative linear combination
+of the barycenters of a chain of faces. The greatest face in the support is exactly the support of
+the resulting point in the original realization. Moreover, that greatest face has a vertex which
+belongs to no smaller face in the chain; evaluating there recovers its coefficient. Removing the
+greatest face and inducting proves uniqueness of all the coefficients.
+
+This is the second bijectivity step in the subdivision-realization milestone in Layer 11 of the
+GeometricTopology roadmap. Continuity of the inverse remains to package the resulting bijection as
+a homeomorphism.
+
+The argument follows the standard uniqueness proof for barycentric subdivision in
+Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2, "Derived Subdivisions".
+
+## Main results
+
+* `AbstractSimplicialComplex.barycentricSubdivisionRealizationMap_injective`: the canonical
+  realization map is one-to-one.
+* `AbstractSimplicialComplex.barycentricSubdivisionRealizationMap_bijective`: the canonical
+  realization map is a bijection.
+-/
+
+public section
+
+noncomputable section
+
+open Finset Set TauCeti TauCeti.SetLike
+
+namespace AbstractSimplicialComplex
+
+variable {ι : Type*}
+
+attribute [local instance] Classical.decEq
+
+/-- A finite nonempty chain in a partial order has a greatest element. -/
+private theorem exists_greatest_of_isChain {α : Type*} [PartialOrder α] (s : Finset α)
+    (hs : s.Nonempty) (hchain : IsChain (· ≤ ·) (s : Set α)) :
+    ∃ a ∈ s, ∀ b ∈ s, b ≤ a := by
+  obtain ⟨a, hmax⟩ := s.exists_maximal hs
+  refine ⟨a, hmax.prop, fun b hb => ?_⟩
+  rcases hchain.total hb hmax.prop with hba | hab
+  · exact hba
+  · exact hmax.le_of_ge hb hab
+
+private theorem barycentricSubdivisionLinearMap_apply (K : AbstractSimplicialComplex ι)
+    (a : Face K →₀ ℝ) (v : ι) :
+    barycentricSubdivisionLinearMap K a v =
+      ∑ σ ∈ a.support, a σ *
+        if v ∈ σ.1 then (σ.1.card : ℝ)⁻¹ else 0 := by
+  conv_lhs => rw [← a.sum_single]
+  simp only [Finsupp.sum]
+  rw [map_sum, Finset.sum_apply']
+  apply Finset.sum_congr rfl
+  intro σ _
+  have hs : Finsupp.single σ (a σ) = a σ • Finsupp.single σ (1 : ℝ) := by
+    rw [Finsupp.smul_single]
+    simp
+  rw [hs, map_smul, Finsupp.smul_apply, barycentricSubdivisionLinearMap_single,
+    faceBarycenter_apply, smul_eq_mul]
+
+/-- The greatest face of a nonnegative chain-supported combination is exactly the coordinate
+support of its image under the barycentric-subdivision linear map. -/
+private theorem support_barycentricSubdivisionLinearMap_eq_greatest
+    (K : AbstractSimplicialComplex ι) {a : Face K →₀ ℝ} (ha : ∀ σ, 0 ≤ a σ)
+    {σ : Face K} (hσ : σ ∈ a.support) (hmax : ∀ τ ∈ a.support, τ ≤ σ) :
+    (barycentricSubdivisionLinearMap K a).support = σ.1 := by
+  ext v
+  simp only [Finsupp.mem_support_iff]
+  constructor
+  · intro hv
+    by_contra hvσ
+    apply hv
+    rw [barycentricSubdivisionLinearMap_apply]
+    apply Finset.sum_eq_zero
+    intro τ hτ
+    have hvτ : v ∉ τ.1 := fun h => hvσ (hmax τ hτ h)
+    simp [hvτ]
+  · intro hvσ
+    have hcard : 0 < (σ.1.card : ℝ)⁻¹ := by
+      have : 0 < σ.1.card := Finset.card_pos.mpr
+        (K.isRelLowerSet_faces.prop_of_mem σ.2)
+      positivity
+    have hapos : 0 < a σ := lt_of_le_of_ne (ha σ) (Finsupp.mem_support_iff.mp hσ).symm
+    apply ne_of_gt
+    rw [barycentricSubdivisionLinearMap_apply]
+    apply Finset.sum_pos'
+    · intro τ hτ
+      exact mul_nonneg (ha τ) (by positivity)
+    · exact ⟨σ, hσ, by simp [hvσ, hapos, hcard]⟩
+
+private theorem exists_mem_greatest_not_mem_of_ne_face (K : AbstractSimplicialComplex ι)
+    {a : Face K →₀ ℝ} (hchain : IsChain (· ≤ ·) (a.support : Set (Face K)))
+    {σ : Face K} (hmax : ∀ τ ∈ a.support, τ ≤ σ) :
+    ∃ v ∈ σ.1, ∀ τ ∈ a.support, v ∈ τ.1 → τ = σ := by
+  by_cases herase : (a.support.erase σ).Nonempty
+  · obtain ⟨τ, hτerase, hτmax⟩ := exists_greatest_of_isChain (a.support.erase σ) herase
+      (hchain.mono (by simp))
+    have hτa : τ ∈ a.support := Finset.mem_of_mem_erase hτerase
+    have hτσ : τ.1 ⊂ σ.1 := (Finset.ssubset_iff_subset_ne).2
+      ⟨hmax τ hτa, fun h => Finset.ne_of_mem_erase hτerase (Subtype.ext h)⟩
+    obtain ⟨v, hvσ, hvτ⟩ := Finset.exists_of_ssubset hτσ
+    refine ⟨v, hvσ, fun ρ hρa hvρ => ?_⟩
+    by_contra hρσ
+    have hρerase : ρ ∈ a.support.erase σ := Finset.mem_erase.2 ⟨hρσ, hρa⟩
+    exact hvτ (hτmax ρ hρerase hvρ)
+  · obtain ⟨v, hvσ⟩ := K.isRelLowerSet_faces.prop_of_mem σ.2
+    refine ⟨v, hvσ, fun τ hτ _ => ?_⟩
+    by_contra hτσ
+    exact herase ⟨τ, Finset.mem_erase.2 ⟨hτσ, hτ⟩⟩
+
+private theorem barycentricSubdivisionLinearMap_apply_eq_of_exposed
+    (K : AbstractSimplicialComplex ι) {a : Face K →₀ ℝ} {σ : Face K} {v : ι}
+    (hσ : σ ∈ a.support) (hvσ : v ∈ σ.1)
+    (hv : ∀ τ ∈ a.support, v ∈ τ.1 → τ = σ) :
+    barycentricSubdivisionLinearMap K a v = a σ * (σ.1.card : ℝ)⁻¹ := by
+  rw [barycentricSubdivisionLinearMap_apply]
+  rw [Finset.sum_eq_single σ]
+  · simp [hvσ]
+  · intro τ hτ hτσ
+    have hvτ : v ∉ τ.1 := fun h => hτσ (hv τ hτ h)
+    simp [hvτ]
+  · exact fun h => (h hσ).elim
+
+private theorem barycentricSubdivisionLinearMap_injective_of_nonneg_of_isChain
+    (K : AbstractSimplicialComplex ι) (a b : Face K →₀ ℝ)
+    (ha : ∀ σ, 0 ≤ a σ) (hb : ∀ σ, 0 ≤ b σ)
+    (hca : IsChain (· ≤ ·) (a.support : Set (Face K)))
+    (hcb : IsChain (· ≤ ·) (b.support : Set (Face K)))
+    (hab : barycentricSubdivisionLinearMap K a = barycentricSubdivisionLinearMap K b) : a = b := by
+  induction hmeasure : a.support.card + b.support.card using Nat.strong_induction_on
+    generalizing a b with
+  | h n ih =>
+      -- A nonzero nonnegative combination has nonempty image support, so the zero cases agree.
+      by_cases ha0 : a = 0
+      · subst a
+        by_cases hb0 : b = 0
+        · exact hb0.symm
+        · exfalso
+          obtain ⟨σ, hσ, hσmax⟩ := exists_greatest_of_isChain b.support
+            (Finsupp.support_nonempty_iff.mpr hb0) hcb
+          have hsupp := support_barycentricSubdivisionLinearMap_eq_greatest K hb hσ hσmax
+          have hzero : barycentricSubdivisionLinearMap K b = 0 := by simpa using hab.symm
+          have hne := K.isRelLowerSet_faces.prop_of_mem σ.2
+          rw [← hsupp, hzero, Finsupp.support_zero] at hne
+          simp at hne
+      · by_cases hb0 : b = 0
+        · subst b
+          exfalso
+          obtain ⟨σ, hσ, hσmax⟩ := exists_greatest_of_isChain a.support
+            (Finsupp.support_nonempty_iff.mpr ha0) hca
+          have hsupp := support_barycentricSubdivisionLinearMap_eq_greatest K ha hσ hσmax
+          have hzero : barycentricSubdivisionLinearMap K a = 0 := by simpa using hab
+          have hne := K.isRelLowerSet_faces.prop_of_mem σ.2
+          rw [← hsupp, hzero, Finsupp.support_zero] at hne
+          simp at hne
+        · obtain ⟨σ, hσa, hσmaxa⟩ := exists_greatest_of_isChain a.support
+            (Finsupp.support_nonempty_iff.mpr ha0) hca
+          obtain ⟨τ, hτb, hτmaxb⟩ := exists_greatest_of_isChain b.support
+            (Finsupp.support_nonempty_iff.mpr hb0) hcb
+          -- The common image support identifies the greatest face in the two chains.
+          have hsuppa := support_barycentricSubdivisionLinearMap_eq_greatest K ha hσa hσmaxa
+          have hsuppb := support_barycentricSubdivisionLinearMap_eq_greatest K hb hτb hτmaxb
+          have hστ : σ = τ := by
+            apply Subtype.ext
+            rw [← hsuppa, hab, hsuppb]
+          subst τ
+          obtain ⟨v, hvσ, hva⟩ :=
+            exists_mem_greatest_not_mem_of_ne_face K hca hσmaxa
+          obtain ⟨w, hwσ, hwb⟩ :=
+            exists_mem_greatest_not_mem_of_ne_face K hcb hτmaxb
+          have hcard : 0 < (σ.1.card : ℝ)⁻¹ := by
+            have : 0 < σ.1.card := Finset.card_pos.mpr
+              (K.isRelLowerSet_faces.prop_of_mem σ.2)
+            positivity
+          have habσ : a σ = b σ := by
+            -- Evaluate at an exposed vertex for each chain to compare the greatest coefficients
+            -- in both directions.
+            have hab_le : b σ * (σ.1.card : ℝ)⁻¹ ≤ a σ * (σ.1.card : ℝ)⁻¹ := by
+              rw [← barycentricSubdivisionLinearMap_apply_eq_of_exposed K hσa hvσ hva, hab]
+              rw [barycentricSubdivisionLinearMap_apply]
+              have hsum := Finset.single_le_sum (s := b.support)
+                (f := fun ρ => b ρ * if v ∈ ρ.1 then (ρ.1.card : ℝ)⁻¹ else 0)
+                (fun ρ _ => mul_nonneg (hb ρ) (by positivity)) hτb
+              simpa [hvσ] using hsum
+            have hba_le : a σ * (σ.1.card : ℝ)⁻¹ ≤ b σ * (σ.1.card : ℝ)⁻¹ := by
+              rw [← barycentricSubdivisionLinearMap_apply_eq_of_exposed K hτb hwσ hwb, ← hab]
+              rw [barycentricSubdivisionLinearMap_apply]
+              have hsum := Finset.single_le_sum (s := a.support)
+                (f := fun ρ => a ρ * if w ∈ ρ.1 then (ρ.1.card : ℝ)⁻¹ else 0)
+                (fun ρ _ => mul_nonneg (ha ρ) (by positivity)) hσa
+              simpa [hwσ] using hsum
+            nlinarith
+          -- Erase the common greatest term and apply the strict induction hypothesis.
+          have hmapErase : barycentricSubdivisionLinearMap K (a.erase σ) =
+              barycentricSubdivisionLinearMap K (b.erase σ) := by
+            rw [Finsupp.erase_eq_sub_single, Finsupp.erase_eq_sub_single, map_sub, map_sub,
+              hab, habσ]
+          have hcardErase : (a.erase σ).support.card + (b.erase σ).support.card < n := by
+            have hcaPos : 0 < a.support.card := Finset.card_pos.mpr
+              (Finsupp.support_nonempty_iff.mpr ha0)
+            have hcbPos : 0 < b.support.card := Finset.card_pos.mpr
+              (Finsupp.support_nonempty_iff.mpr hb0)
+            rw [Finsupp.support_erase, Finsupp.support_erase, Finset.card_erase_of_mem hσa,
+              Finset.card_erase_of_mem hτb, ← hmeasure]
+            omega
+          have herase := ih _ hcardErase (a.erase σ) (b.erase σ)
+            (fun ρ => by by_cases h : ρ = σ <;> simp [h, ha ρ])
+            (fun ρ => by by_cases h : ρ = σ <;> simp [h, hb ρ])
+            (hca.mono (by simp)) (hcb.mono (by simp)) hmapErase rfl
+          rw [← Finsupp.single_add_erase σ a, ← Finsupp.single_add_erase σ b, habσ, herase]
+
+/-- The canonical map from the realization of the barycentric subdivision to the realization of
+the original complex is injective. -/
+theorem barycentricSubdivisionRealizationMap_injective (K : AbstractSimplicialComplex ι) :
+    Function.Injective (barycentricSubdivisionRealizationMap K) := by
+  intro x y hxy
+  apply Subtype.ext
+  apply barycentricSubdivisionLinearMap_injective_of_nonneg_of_isChain K x.1 y.1
+  · intro σ
+    let x' : StandardSimplex (carrier _ x).1 := ⟨x.1, mem_convexHull_carrier _ x⟩
+    exact StandardSimplex.nonneg x' σ
+  · intro σ
+    let y' : StandardSimplex (carrier _ y).1 := ⟨y.1, mem_convexHull_carrier _ y⟩
+    exact StandardSimplex.nonneg y' σ
+  · exact (TauCeti.PreAbstractSimplicialComplex.mem_barycentricSubdivision_iff.mp
+      (support_mem _ x)).2
+  · exact (TauCeti.PreAbstractSimplicialComplex.mem_barycentricSubdivision_iff.mp
+      (support_mem _ y)).2
+  · simpa only [barycentricSubdivisionRealizationMap_val] using congrArg Subtype.val hxy
+
+/-- The canonical map from the realization of the barycentric subdivision to the realization of
+the original complex is bijective. -/
+theorem barycentricSubdivisionRealizationMap_bijective (K : AbstractSimplicialComplex ι) :
+    Function.Bijective (barycentricSubdivisionRealizationMap K) :=
+  ⟨barycentricSubdivisionRealizationMap_injective K,
+    barycentricSubdivisionRealizationMap_surjective K⟩
+
+end AbstractSimplicialComplex

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Injective.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Injective.lean
@@ -47,31 +47,11 @@ variable {ι : Type*}
 
 attribute [local instance] Classical.decEq
 
-/-- A finite nonempty chain in a partial order has a greatest element. -/
-private theorem exists_greatest_of_isChain {α : Type*} [PartialOrder α] (s : Finset α)
-    (hs : s.Nonempty) (hchain : IsChain (· ≤ ·) (s : Set α)) :
-    ∃ a ∈ s, ∀ b ∈ s, b ≤ a := by
-  obtain ⟨a, hmax⟩ := s.exists_maximal hs
-  refine ⟨a, hmax.prop, fun b hb => ?_⟩
-  rcases hchain.total hb hmax.prop with hba | hab
-  · exact hba
-  · exact hmax.le_of_ge hb hab
-
-private theorem barycentricSubdivisionLinearMap_apply (K : AbstractSimplicialComplex ι)
-    (a : Face K →₀ ℝ) (v : ι) :
-    barycentricSubdivisionLinearMap K a v =
-      ∑ σ ∈ a.support, a σ *
-        if v ∈ σ.1 then (σ.1.card : ℝ)⁻¹ else 0 := by
-  conv_lhs => rw [← a.sum_single]
-  simp only [Finsupp.sum]
-  rw [map_sum, Finset.sum_apply']
-  apply Finset.sum_congr rfl
-  intro σ _
-  have hs : Finsupp.single σ (a σ) = a σ • Finsupp.single σ (1 : ℝ) := by
-    rw [Finsupp.smul_single]
-    simp
-  rw [hs, map_smul, Finsupp.smul_apply, barycentricSubdivisionLinearMap_single,
-    faceBarycenter_apply, smul_eq_mul]
+/-- A face is nonempty, so the reciprocal of its cardinality is positive. -/
+private theorem inv_card_pos (K : AbstractSimplicialComplex ι) (σ : Face K) :
+    0 < (σ.1.card : ℝ)⁻¹ := by
+  have : 0 < σ.1.card := Finset.card_pos.mpr (K.isRelLowerSet_faces.prop_of_mem σ.2)
+  positivity
 
 /-- The greatest face of a nonnegative chain-supported combination is exactly the coordinate
 support of its image under the barycentric-subdivision linear map. -/
@@ -91,10 +71,7 @@ private theorem support_barycentricSubdivisionLinearMap_eq_greatest
     have hvτ : v ∉ τ.1 := fun h => hvσ (hmax τ hτ h)
     simp [hvτ]
   · intro hvσ
-    have hcard : 0 < (σ.1.card : ℝ)⁻¹ := by
-      have : 0 < σ.1.card := Finset.card_pos.mpr
-        (K.isRelLowerSet_faces.prop_of_mem σ.2)
-      positivity
+    have hcard : 0 < (σ.1.card : ℝ)⁻¹ := inv_card_pos K σ
     have hapos : 0 < a σ := lt_of_le_of_ne (ha σ) (Finsupp.mem_support_iff.mp hσ).symm
     apply ne_of_gt
     rw [barycentricSubdivisionLinearMap_apply]
@@ -102,6 +79,19 @@ private theorem support_barycentricSubdivisionLinearMap_eq_greatest
     · intro τ hτ
       exact mul_nonneg (ha τ) (by positivity)
     · exact ⟨σ, hσ, by simp [hvσ, hapos, hcard]⟩
+
+/-- A nonzero nonnegative combination supported on a chain of faces has nonzero image. -/
+private theorem barycentricSubdivisionLinearMap_ne_zero (K : AbstractSimplicialComplex ι)
+    {a : Face K →₀ ℝ} (ha : ∀ σ, 0 ≤ a σ)
+    (hchain : IsChain (· ≤ ·) (a.support : Set (Face K))) (ha0 : a ≠ 0) :
+    barycentricSubdivisionLinearMap K a ≠ 0 := by
+  obtain ⟨σ, hσ, hσmax⟩ := exists_greatest_of_isChain a.support
+    (Finsupp.support_nonempty_iff.mpr ha0) hchain
+  intro hzero
+  have hne := K.isRelLowerSet_faces.prop_of_mem σ.2
+  rw [← support_barycentricSubdivisionLinearMap_eq_greatest K ha hσ hσmax, hzero,
+    Finsupp.support_zero] at hne
+  simp at hne
 
 private theorem exists_mem_greatest_not_mem_of_ne_face (K : AbstractSimplicialComplex ι)
     {a : Face K →₀ ℝ} (hchain : IsChain (· ≤ ·) (a.support : Set (Face K)))
@@ -145,29 +135,17 @@ private theorem barycentricSubdivisionLinearMap_injective_of_nonneg_of_isChain
   induction hmeasure : a.support.card + b.support.card using Nat.strong_induction_on
     generalizing a b with
   | h n ih =>
-      -- A nonzero nonnegative combination has nonempty image support, so the zero cases agree.
+      -- A nonzero nonnegative combination has nonzero image, so the zero cases agree.
       by_cases ha0 : a = 0
       · subst a
         by_cases hb0 : b = 0
         · exact hb0.symm
-        · exfalso
-          obtain ⟨σ, hσ, hσmax⟩ := exists_greatest_of_isChain b.support
-            (Finsupp.support_nonempty_iff.mpr hb0) hcb
-          have hsupp := support_barycentricSubdivisionLinearMap_eq_greatest K hb hσ hσmax
-          have hzero : barycentricSubdivisionLinearMap K b = 0 := by simpa using hab.symm
-          have hne := K.isRelLowerSet_faces.prop_of_mem σ.2
-          rw [← hsupp, hzero, Finsupp.support_zero] at hne
-          simp at hne
+        · exact absurd (by simpa using hab.symm)
+            (barycentricSubdivisionLinearMap_ne_zero K hb hcb hb0)
       · by_cases hb0 : b = 0
         · subst b
-          exfalso
-          obtain ⟨σ, hσ, hσmax⟩ := exists_greatest_of_isChain a.support
-            (Finsupp.support_nonempty_iff.mpr ha0) hca
-          have hsupp := support_barycentricSubdivisionLinearMap_eq_greatest K ha hσ hσmax
-          have hzero : barycentricSubdivisionLinearMap K a = 0 := by simpa using hab
-          have hne := K.isRelLowerSet_faces.prop_of_mem σ.2
-          rw [← hsupp, hzero, Finsupp.support_zero] at hne
-          simp at hne
+          exact absurd (by simpa using hab)
+            (barycentricSubdivisionLinearMap_ne_zero K ha hca ha0)
         · obtain ⟨σ, hσa, hσmaxa⟩ := exists_greatest_of_isChain a.support
             (Finsupp.support_nonempty_iff.mpr ha0) hca
           obtain ⟨τ, hτb, hτmaxb⟩ := exists_greatest_of_isChain b.support
@@ -183,10 +161,7 @@ private theorem barycentricSubdivisionLinearMap_injective_of_nonneg_of_isChain
             exists_mem_greatest_not_mem_of_ne_face K hca hσmaxa
           obtain ⟨w, hwσ, hwb⟩ :=
             exists_mem_greatest_not_mem_of_ne_face K hcb hτmaxb
-          have hcard : 0 < (σ.1.card : ℝ)⁻¹ := by
-            have : 0 < σ.1.card := Finset.card_pos.mpr
-              (K.isRelLowerSet_faces.prop_of_mem σ.2)
-            positivity
+          have hcard : 0 < (σ.1.card : ℝ)⁻¹ := inv_card_pos K σ
           have habσ : a σ = b σ := by
             -- Evaluate at an exposed vertex for each chain to compare the greatest coefficients
             -- in both directions.
@@ -231,12 +206,8 @@ theorem barycentricSubdivisionRealizationMap_injective (K : AbstractSimplicialCo
   intro x y hxy
   apply Subtype.ext
   apply barycentricSubdivisionLinearMap_injective_of_nonneg_of_isChain K x.1 y.1
-  · intro σ
-    let x' : StandardSimplex (carrier _ x).1 := ⟨x.1, mem_convexHull_carrier _ x⟩
-    exact StandardSimplex.nonneg x' σ
-  · intro σ
-    let y' : StandardSimplex (carrier _ y).1 := ⟨y.1, mem_convexHull_carrier _ y⟩
-    exact StandardSimplex.nonneg y' σ
+  · exact Realization.nonneg _ x
+  · exact Realization.nonneg _ y
   · exact (TauCeti.PreAbstractSimplicialComplex.mem_barycentricSubdivision_iff.mp
       (support_mem _ x)).2
   · exact (TauCeti.PreAbstractSimplicialComplex.mem_barycentricSubdivision_iff.mp

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Injective.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Injective.lean
@@ -47,6 +47,17 @@ variable {ι : Type*}
 
 attribute [local instance] Classical.decEq
 
+/-- A finite nonempty chain in a partial order has a greatest element. -/
+private theorem exists_greatest_of_isChain {α : Type*} [PartialOrder α] (s : Finset α)
+    (hs : s.Nonempty) (hchain : IsChain (· ≤ ·) (s : Set α)) :
+    ∃ a ∈ s, ∀ b ∈ s, b ≤ a := by
+  classical
+  obtain ⟨a, hmax⟩ := s.exists_maximal hs
+  refine ⟨a, hmax.prop, fun b hb => ?_⟩
+  rcases hchain.total hb hmax.prop with hba | hab
+  · exact hba
+  · exact hmax.le_of_ge hb hab
+
 /-- A face is nonempty, so the reciprocal of its cardinality is positive. -/
 private theorem inv_card_pos (K : AbstractSimplicialComplex ι) (σ : Face K) :
     0 < (σ.1.card : ℝ)⁻¹ := by

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Realization.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Realization.lean
@@ -34,6 +34,10 @@ The construction follows Rourke--Sanderson, *Introduction to Piecewise-Linear To
 
 * `AbstractSimplicialComplex.barycentricSubdivisionRealizationMap_vertex`: a subdivision vertex
   maps to the barycenter of the face it represents.
+* `AbstractSimplicialComplex.barycentricSubdivisionLinearMap_apply`: the coordinates of a linear
+  combination of face barycenters.
+* `AbstractSimplicialComplex.exists_greatest_of_isChain`: a finite nonempty chain in a partial
+  order has a greatest element.
 -/
 
 public section
@@ -49,7 +53,7 @@ variable {ι : Type*}
 attribute [local instance] Classical.decEq
 
 /-- A finite nonempty chain in a partial order has a greatest element. -/
-private theorem exists_greatest_of_isChain {α : Type*} [PartialOrder α] (s : Finset α)
+theorem exists_greatest_of_isChain {α : Type*} [PartialOrder α] (s : Finset α)
     (hs : s.Nonempty) (hchain : IsChain (· ≤ ·) (s : Set α)) :
     ∃ a ∈ s, ∀ b ∈ s, b ≤ a := by
   classical
@@ -70,6 +74,15 @@ theorem barycentricSubdivisionLinearMap_single (K : AbstractSimplicialComplex ι
     (σ : Face K) :
     barycentricSubdivisionLinearMap K (Finsupp.single σ 1) = faceBarycenter K σ := by
   simp [barycentricSubdivisionLinearMap]
+
+/-- The coordinates of a linear combination of face barycenters. -/
+theorem barycentricSubdivisionLinearMap_apply (K : AbstractSimplicialComplex ι)
+    (a : Face K →₀ ℝ) (v : ι) :
+    barycentricSubdivisionLinearMap K a v =
+      ∑ σ ∈ a.support, a σ * if v ∈ σ.1 then (σ.1.card : ℝ)⁻¹ else 0 := by
+  rw [barycentricSubdivisionLinearMap, Finsupp.linearCombination_apply, Finsupp.sum,
+    Finset.sum_apply']
+  simp only [Finsupp.smul_apply, smul_eq_mul, faceBarycenter_apply]
 
 private theorem barycentricSubdivisionLinearMap_mem_closedSimplex
     (K : AbstractSimplicialComplex ι) {ρ : Finset (Face K)} (σ : Face K)

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Realization.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Realization.lean
@@ -36,8 +36,6 @@ The construction follows Rourke--Sanderson, *Introduction to Piecewise-Linear To
   maps to the barycenter of the face it represents.
 * `AbstractSimplicialComplex.barycentricSubdivisionLinearMap_apply`: the coordinates of a linear
   combination of face barycenters.
-* `AbstractSimplicialComplex.exists_greatest_of_isChain`: a finite nonempty chain in a partial
-  order has a greatest element.
 -/
 
 public section
@@ -53,7 +51,7 @@ variable {ι : Type*}
 attribute [local instance] Classical.decEq
 
 /-- A finite nonempty chain in a partial order has a greatest element. -/
-theorem exists_greatest_of_isChain {α : Type*} [PartialOrder α] (s : Finset α)
+private theorem exists_greatest_of_isChain {α : Type*} [PartialOrder α] (s : Finset α)
     (hs : s.Nonempty) (hchain : IsChain (· ≤ ·) (s : Set α)) :
     ∃ a ∈ s, ∀ b ∈ s, b ≤ a := by
   classical

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
@@ -145,8 +145,7 @@ private theorem orderedCoord_succ_le {K : AbstractSimplicialComplex ι} (x : Rea
     exact orderedVertex_antitone x (Fin.mk_le_mk.mpr (Nat.le_succ k))
   · rw [orderedCoord]
     simp only [hks, ↓reduceDIte]
-    let x' : StandardSimplex (carrier K x).1 := ⟨x.1, mem_convexHull_carrier K x⟩
-    exact StandardSimplex.nonneg x' _
+    exact Realization.nonneg K x _
 
 /-- The barycentric coefficient of the `i`th initial face. -/
 private noncomputable def subdivisionWeight {K : AbstractSimplicialComplex ι} (x : Realization K)
@@ -314,11 +313,7 @@ private theorem barycentricSubdivisionLinearMap_subdivisionCoordinates
   rw [subdivisionCoordinates, map_sum]
   apply Finset.sum_congr rfl
   intro i _
-  have hs : Finsupp.single (prefixFace x i) (subdivisionWeight x i) =
-      subdivisionWeight x i • Finsupp.single (prefixFace x i) (1 : ℝ) := by
-    rw [Finsupp.smul_single]
-    simp
-  rw [hs, map_smul, barycentricSubdivisionLinearMap_single]
+  rw [← Finsupp.smul_single_one, map_smul, barycentricSubdivisionLinearMap_single]
 
 private theorem mem_prefixVertices_iff {K : AbstractSimplicialComplex ι} (x : Realization K)
     {v : ι} (hv : v ∈ (carrier K x).1) (i : Fin (carrier K x).1.card) :


### PR DESCRIPTION
This PR proves that the canonical map from the realization of a barycentric subdivision to the original realization is injective, and combines it with the existing surjectivity theorem to obtain bijectivity. It advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 11, milestone “Geometric realization of an abstract simplicial complex,” specifically its subdivision API and the acceptance criterion “Realization round-trips.” The forward continuous map landed before the explicit surjective construction; injectivity is the next missing property and is distinct from the open combinatorial-manifold and reduced-Burau work.

The proof works for nonnegative finitely supported combinations on arbitrary chains of faces. The greatest face of such a combination is exactly the coordinate support of its image. A vertex belonging to that face and to no smaller face then recovers the greatest coefficient; after the two combinations are shown to have the same greatest face and coefficient, erasing it gives a strict induction on the combined support cardinality. Applying this uniqueness theorem to realization points yields `barycentricSubdivisionRealizationMap_injective`, while `barycentricSubdivisionRealizationMap_bijective` joins it to `barycentricSubdivisionRealizationMap_surjective`.

Add `TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Injective.lean` (253 lines). Only the injectivity and bijectivity theorems are public; the chain and coefficient machinery remains private. The argument follows Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2, “Derived Subdivisions,” as credited in the module documentation. No Mathlib infrastructure or external formalization is vendored; the proof reuses `Finsupp` linear combinations, finite-chain maximality, the existing face-barycenter formula, and the realization support API.

After this PR, the milestone still needs continuity of the inverse to package the bijection as a homeomorphism, followed by the standard-simplex-boundary-to-sphere round trip and the Layer 1 PL reconciliation.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"barycentric-subdivision-realization-map-injective"}-->

🤖 Prepared with Codex
