### PR TITLE
refactor(RootSystem): state the simple-index embeddings with Mathlib's Fin maps

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
@@ -329,20 +329,22 @@ noncomputable def typeDRootEquiv (n : ℕ) (hn : 4 ≤ n) :
 private lemma typeDRootEquiv_apply (hn : 4 ≤ n) (k : Fin (2 * n * (n - 1))) :
     typeDRootEquiv n hn k = typeDRawRoot ((typeDRawFinEquiv n (by omega)).symm k) := rfl
 
+/-- There is room for the first `n` indices in the type `Dₙ` enumeration of `2 * n * (n - 1)`
+roots. -/
+private lemma typeD_le_two_mul_mul (hn : 4 ≤ n) : n ≤ 2 * n * (n - 1) := by
+  have h : n ≤ n * (n - 1) := Nat.le_mul_of_pos_right n (by omega)
+  have h' : n * (n - 1) ≤ 2 * (n * (n - 1)) := Nat.le_mul_of_pos_left _ (by norm_num)
+  simpa [mul_assoc] using h.trans h'
+
 /-- The `i`-th simple root occupies root index `i`. -/
 def typeDSimpleIndex (n : ℕ) (hn : 4 ≤ n) (i : Fin n) : Fin (2 * n * (n - 1)) :=
-  ⟨i, lt_of_lt_of_le i.isLt (by
-    have h : n ≤ n * (n - 1) := Nat.le_mul_of_pos_right n (by omega)
-    have h' : n * (n - 1) ≤ 2 * (n * (n - 1)) :=
-      Nat.le_mul_of_pos_left _ (by norm_num)
-    simpa [mul_assoc] using h.trans h')⟩
+  Fin.castLE (typeD_le_two_mul_mul hn) i
 
 @[simp] lemma typeDSimpleIndex_val (hn : 4 ≤ n) (i : Fin n) :
     (typeDSimpleIndex n hn i : ℕ) = i := (rfl)
 
-lemma typeDSimpleIndex_injective (hn : 4 ≤ n) : Injective (typeDSimpleIndex n hn) := by
-  intro i j h
-  exact Fin.ext (by simpa using congrArg Fin.val h)
+lemma typeDSimpleIndex_injective (hn : 4 ≤ n) : Injective (typeDSimpleIndex n hn) :=
+  Fin.castLE_injective (typeD_le_two_mul_mul hn)
 
 private def typeDSimpleRawIndex (n : ℕ) (hn : 4 ≤ n) (i : Fin n) : TypeDRawIndex n :=
   if h : (i : ℕ) + 1 < n then

--- a/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/ClassicalTypeD.lean
@@ -341,7 +341,8 @@ def typeDSimpleIndex (n : ℕ) (hn : 4 ≤ n) (i : Fin n) : Fin (2 * n * (n - 1)
   Fin.castLE (typeD_le_two_mul_mul hn) i
 
 @[simp] lemma typeDSimpleIndex_val (hn : 4 ≤ n) (i : Fin n) :
-    (typeDSimpleIndex n hn i : ℕ) = i := (rfl)
+    (typeDSimpleIndex n hn i : ℕ) = i := by
+  simp [typeDSimpleIndex]
 
 lemma typeDSimpleIndex_injective (hn : 4 ≤ n) : Injective (typeDSimpleIndex n hn) :=
   Fin.castLE_injective (typeD_le_two_mul_mul hn)

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -395,7 +395,8 @@ theorem pairing_typeASimplyConnectedRootDatum_comm (k l : Fin (n * (n + 1))) :
 def typeASimpleIndex (n : ℕ) (i : Fin n) : Fin (n * (n + 1)) :=
   Fin.castLE (Nat.le_mul_of_pos_right n n.succ_pos) i
 
-@[simp] lemma typeASimpleIndex_val (i : Fin n) : (typeASimpleIndex n i : ℕ) = i := (rfl)
+@[simp] lemma typeASimpleIndex_val (i : Fin n) : (typeASimpleIndex n i : ℕ) = i := by
+  simp [typeASimpleIndex]
 
 lemma typeASimpleIndex_injective : Injective (typeASimpleIndex n) :=
   Fin.castLE_injective (Nat.le_mul_of_pos_right n n.succ_pos)

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/A.lean
@@ -393,15 +393,12 @@ theorem pairing_typeASimplyConnectedRootDatum_comm (k l : Fin (n * (n + 1))) :
 
 /-- The `i`-th simple root of type `Aₙ` sits at root index `i`, the Bourbaki node `i + 1`. -/
 def typeASimpleIndex (n : ℕ) (i : Fin n) : Fin (n * (n + 1)) :=
-  ⟨i, lt_of_lt_of_le i.isLt (Nat.le_mul_of_pos_right n n.succ_pos)⟩
+  Fin.castLE (Nat.le_mul_of_pos_right n n.succ_pos) i
 
 @[simp] lemma typeASimpleIndex_val (i : Fin n) : (typeASimpleIndex n i : ℕ) = i := (rfl)
 
-lemma typeASimpleIndex_injective : Injective (typeASimpleIndex n) := by
-  intro i j h
-  have := congrArg Fin.val h
-  simp only [typeASimpleIndex_val] at this
-  exact Fin.ext this
+lemma typeASimpleIndex_injective : Injective (typeASimpleIndex n) :=
+  Fin.castLE_injective (Nat.le_mul_of_pos_right n n.succ_pos)
 
 private lemma typeAIndexEquiv_symm_typeASimpleIndex (i : Fin n) :
     (typeAIndexEquiv n).symm (typeASimpleIndex n i) =

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
@@ -192,9 +192,12 @@ private lemma corootIdx_injective : Injective (corootIdx : Fin (2 * n) × Fin n 
 
 /-! ## The enumeration of the roots -/
 
+/-- There is room for the first `n` indices in the type `Bₙ` enumeration of `2 * n ^ 2` roots. -/
+private lemma typeB_le_two_mul_sq (n : ℕ) : n ≤ 2 * n ^ 2 :=
+  le_trans (Nat.le_self_pow (by norm_num) n) (Nat.le_mul_of_pos_left (n ^ 2) (by norm_num))
+
 private lemma typeB_lt_two_mul_sq {i : ℕ} (hi : i < n) : i < 2 * n ^ 2 :=
-  lt_of_lt_of_le hi (le_trans (Nat.le_self_pow (by norm_num) n)
-    (Nat.le_mul_of_pos_left (n ^ 2) (by norm_num)))
+  lt_of_lt_of_le hi (typeB_le_two_mul_sq n)
 
 /-- The rotation of the signed basis vectors by `n - 1` steps. Composed with the reversal of the
 offsets it moves the long simple roots to the front of the enumeration. -/
@@ -251,12 +254,12 @@ private def typeBSimplePair (i : Fin n) : Fin (2 * n) × Fin n :=
 
 /-- The `i`-th simple root of type `Bₙ` sits at root index `i`, the Bourbaki node `i + 1`. -/
 def typeBSimpleIndex (n : ℕ) (i : Fin n) : Fin (2 * n ^ 2) :=
-  ⟨i, typeB_lt_two_mul_sq i.isLt⟩
+  Fin.castLE (typeB_le_two_mul_sq n) i
 
 @[simp] lemma typeBSimpleIndex_val (i : Fin n) : (typeBSimpleIndex n i : ℕ) = i := (rfl)
 
-lemma typeBSimpleIndex_injective : Injective (typeBSimpleIndex n) := fun i j h =>
-  Fin.ext (by simpa using congrArg Fin.val h)
+lemma typeBSimpleIndex_injective : Injective (typeBSimpleIndex n) :=
+  Fin.castLE_injective (typeB_le_two_mul_sq n)
 
 private lemma typeBEnum_typeBSimplePair (i : Fin n) :
     typeBEnum n (typeBSimplePair i) = typeBSimpleIndex n i := by

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
@@ -256,7 +256,8 @@ private def typeBSimplePair (i : Fin n) : Fin (2 * n) × Fin n :=
 def typeBSimpleIndex (n : ℕ) (i : Fin n) : Fin (2 * n ^ 2) :=
   Fin.castLE (typeB_le_two_mul_sq n) i
 
-@[simp] lemma typeBSimpleIndex_val (i : Fin n) : (typeBSimpleIndex n i : ℕ) = i := (rfl)
+@[simp] lemma typeBSimpleIndex_val (i : Fin n) : (typeBSimpleIndex n i : ℕ) = i := by
+  simp [typeBSimpleIndex]
 
 lemma typeBSimpleIndex_injective : Injective (typeBSimpleIndex n) :=
   Fin.castLE_injective (typeB_le_two_mul_sq n)

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
@@ -423,17 +423,18 @@ theorem coroot_typeCIndexEquiv_diag (a : Fin n) (s : Bool) :
 
 /-! ## The simple roots and coroots -/
 
+/-- There is room for the first `n` indices in the type `Cₙ` enumeration of `2 * n ^ 2` roots. -/
+private lemma typeC_le_two_mul_sq (n : ℕ) : n ≤ 2 * n ^ 2 :=
+  le_trans (Nat.le_self_pow (by norm_num) n) (Nat.le_mul_of_pos_left (n ^ 2) (by norm_num))
+
 /-- The `i`-th simple root of type `Cₙ` sits at root index `i`, the Bourbaki node `i + 1`. -/
 def typeCSimpleIndex (n : ℕ) (i : Fin n) : Fin (2 * n ^ 2) :=
-  ⟨i, lt_of_lt_of_le i.isLt (by nlinarith [i.isLt, Nat.zero_le (i : ℕ)])⟩
+  Fin.castLE (typeC_le_two_mul_sq n) i
 
 @[simp] lemma typeCSimpleIndex_val (i : Fin n) : (typeCSimpleIndex n i : ℕ) = i := (rfl)
 
-lemma typeCSimpleIndex_injective : Injective (typeCSimpleIndex n) := by
-  intro i j h
-  have := congrArg Fin.val h
-  simp only [typeCSimpleIndex_val] at this
-  exact Fin.ext this
+lemma typeCSimpleIndex_injective : Injective (typeCSimpleIndex n) :=
+  Fin.castLE_injective (typeC_le_two_mul_sq n)
 
 private lemma typeCIndexEquiv_symm_typeCSimpleIndex (i : Fin n) :
     (typeCIndexEquiv n).symm (typeCSimpleIndex n i) = (i, typeCSucc i, false) := by

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Datum.lean
@@ -431,7 +431,8 @@ private lemma typeC_le_two_mul_sq (n : ℕ) : n ≤ 2 * n ^ 2 :=
 def typeCSimpleIndex (n : ℕ) (i : Fin n) : Fin (2 * n ^ 2) :=
   Fin.castLE (typeC_le_two_mul_sq n) i
 
-@[simp] lemma typeCSimpleIndex_val (i : Fin n) : (typeCSimpleIndex n i : ℕ) = i := (rfl)
+@[simp] lemma typeCSimpleIndex_val (i : Fin n) : (typeCSimpleIndex n i : ℕ) = i := by
+  simp [typeCSimpleIndex]
 
 lemma typeCSimpleIndex_injective : Injective (typeCSimpleIndex n) :=
   Fin.castLE_injective (typeC_le_two_mul_sq n)

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/Basic.lean
@@ -117,13 +117,13 @@ def e6Root : Fin 72 ↪ (Fin 6 → ℤ) where
 /-! ## The three blocks of root indices -/
 
 /-- The `i`-th simple root of type `E₆` sits at root index `i`, the Bourbaki node `i + 1`. -/
-def e6SimpleIndex (i : Fin 6) : Fin 72 := ⟨i, by omega⟩
+def e6SimpleIndex (i : Fin 6) : Fin 72 := Fin.castAdd 66 i
 
 /-- The `i`-th positive root of type `E₆` sits at root index `i`. -/
-def e6PositiveIndex (i : Fin 36) : Fin 72 := ⟨i, by omega⟩
+def e6PositiveIndex (i : Fin 36) : Fin 72 := Fin.castAdd 36 i
 
 /-- The negative of the `i`-th positive root of type `E₆` sits at root index `i + 36`. -/
-def e6NegativeIndex (i : Fin 36) : Fin 72 := ⟨i + 36, by omega⟩
+def e6NegativeIndex (i : Fin 36) : Fin 72 := Fin.addNat i 36
 
 @[simp] lemma e6SimpleIndex_val (i : Fin 6) : (e6SimpleIndex i : ℕ) = i := (rfl)
 
@@ -132,7 +132,7 @@ def e6NegativeIndex (i : Fin 36) : Fin 72 := ⟨i + 36, by omega⟩
 @[simp] lemma e6NegativeIndex_val (i : Fin 36) : (e6NegativeIndex i : ℕ) = (i : ℕ) + 36 := (rfl)
 
 lemma e6SimpleIndex_injective : Function.Injective e6SimpleIndex :=
-  fun _ _ h => Fin.ext (by simpa using congrArg Fin.val h)
+  Fin.castAdd_injective 6 66
 
 /-! ## The Cartan matrix as the bridge between the two embeddings -/
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/E6/Basic.lean
@@ -125,11 +125,14 @@ def e6PositiveIndex (i : Fin 36) : Fin 72 := Fin.castAdd 36 i
 /-- The negative of the `i`-th positive root of type `E₆` sits at root index `i + 36`. -/
 def e6NegativeIndex (i : Fin 36) : Fin 72 := Fin.addNat i 36
 
-@[simp] lemma e6SimpleIndex_val (i : Fin 6) : (e6SimpleIndex i : ℕ) = i := (rfl)
+@[simp] lemma e6SimpleIndex_val (i : Fin 6) : (e6SimpleIndex i : ℕ) = i := by
+  simp [e6SimpleIndex]
 
-@[simp] lemma e6PositiveIndex_val (i : Fin 36) : (e6PositiveIndex i : ℕ) = i := (rfl)
+@[simp] lemma e6PositiveIndex_val (i : Fin 36) : (e6PositiveIndex i : ℕ) = i := by
+  simp [e6PositiveIndex]
 
-@[simp] lemma e6NegativeIndex_val (i : Fin 36) : (e6NegativeIndex i : ℕ) = (i : ℕ) + 36 := (rfl)
+@[simp] lemma e6NegativeIndex_val (i : Fin 36) : (e6NegativeIndex i : ℕ) = (i : ℕ) + 36 := by
+  simp [e6NegativeIndex]
 
 lemma e6SimpleIndex_injective : Function.Injective e6SimpleIndex :=
   Fin.castAdd_injective 6 66


### PR DESCRIPTION
Roadmap: ReductiveGroups

The per-type "simple index" embeddings of the simply-connected root data were each built by
hand as an anonymous-constructor `⟨i, _⟩` carrying its own bound proof, and each came with a
hand-rolled injectivity proof that unfolded the `_val` lemma and applied `Fin.ext`. They are
exactly Mathlib's `Fin.castLE` / `Fin.castAdd` / `Fin.addNat`, and `E7`, `E8`, `F4` and `G2`
already state theirs that way. This brings `A`, `B`, `C`, `D` and `E6` into line with them.

| declaration | was | now |
| --- | --- | --- |
| `typeASimpleIndex` | `⟨i, lt_of_lt_of_le i.isLt _⟩` | `Fin.castLE _ i` |
| `typeBSimpleIndex` | `⟨i, typeB_lt_two_mul_sq i.isLt⟩` | `Fin.castLE _ i` |
| `typeCSimpleIndex` | `⟨i, lt_of_lt_of_le i.isLt _⟩` | `Fin.castLE _ i` |
| `typeDSimpleIndex` | `⟨i, lt_of_lt_of_le i.isLt _⟩` | `Fin.castLE _ i` |
| `e6SimpleIndex` | `⟨i, by omega⟩` | `Fin.castAdd 66 i` |
| `e6PositiveIndex` | `⟨i, by omega⟩` | `Fin.castAdd 36 i` |
| `e6NegativeIndex` | `⟨i + 36, by omega⟩` | `Fin.addNat i 36` |

The five `_injective` lemmas become one-line applications of `Fin.castLE_injective` and
`Fin.castAdd_injective` in place of their hand-rolled proofs.

Every statement is unchanged, and each new definition is definitionally equal to the one it
replaces: `Fin.castLE h i`, `Fin.castAdd m i` and `Fin.addNat i m` all reduce to the same
anonymous constructor as before, so the `@[simp]` `_val` lemmas remain true by `rfl` and no
downstream proof needed adjusting.

Found by the 2026-08-24 dedup sweep as finding LG1 (lane `mathlib-watch`, grade 3).
