### PR TITLE
feat: compose extensions of places in towers

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean
@@ -118,6 +118,12 @@ at `P` (Stichtenoth, Definition 3.1.5). -/
 noncomputable def ramificationIdx : ℕ :=
   Valuation.ordIndex (P'.valuation.comap (algebraMap F F'))
 
+omit [Algebra.IsIntegral F F'] in
+/-- The ramification index is the order index of the restricted valuation. -/
+lemma ramificationIdx_def :
+    ramificationIdx F P' = Valuation.ordIndex (P'.valuation.comap (algebraMap F F')) := by
+  rw [ramificationIdx]
+
 /-- The ramification index of a restricted place is positive. -/
 theorem ramificationIdx_pos : 0 < ramificationIdx F P' :=
   Nat.pos_of_ne_zero (ordIndex_comap_ne_zero F P')

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Tower.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Tower.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.FunctionField.Place.Extension.Basic
+
+/-!
+# Towers of extensions of places
+
+Restriction of places is functorial through a tower of algebraic field extensions. The
+ramification index and relative residue degree are multiplicative in the same tower. These are
+the tower statements in Stichtenoth, *Algebraic Function Fields and Codes*, Proposition 3.1.6.
+
+The constants are allowed to grow with the function fields. Thus the setup contains parallel
+towers `k₀ → k₁ → k₂` and `F₀ → F₁ → F₂`, with each `Fᵢ` an algebra over `kᵢ` and the
+expected commuting scalar towers. No function-field, finite-dimensionality, separability, or
+perfectness hypothesis is needed: restriction uses only integrality of the field extensions,
+and the degree identity is the ordinary finrank tower formula for the residue fields.
+
+## Main results
+
+* `TauCeti.Place.restrict_restrict`: restricting first to `F₁` and then to `F₀` agrees with
+  restricting directly to `F₀`.
+* `TauCeti.Place.ramificationIdx_restrict_mul`: ramification indices multiply in a tower.
+* `TauCeti.Place.relativeDegree_restrict_mul`: relative residue degrees multiply in a tower.
+
+## Roadmap
+
+`TauCetiRoadmap/AlgebraicCurves/README.md`, Layer 6, "Setup": multiplicativity in towers for
+extensions of places (Stichtenoth, Proposition 3.1.6). The restriction identity is also the
+functoriality required by `TauCetiRoadmap/EllipticCurves/README.md`, Layer 0, `inducedPlace`,
+and by Layer 1's construction of the dual isogeny.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Proposition 3.1.6.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Place
+
+universe u₀ u₁ u₂ v₀ v₁ v₂
+
+variable {k₀ : Type u₀} {k₁ : Type u₁} {k₂ : Type u₂}
+variable {F₀ : Type v₀} {F₁ : Type v₁} {F₂ : Type v₂}
+variable [Field k₀] [Field k₁] [Field k₂] [Field F₀] [Field F₁] [Field F₂]
+variable [Algebra k₀ k₁] [Algebra k₁ k₂] [Algebra k₀ k₂]
+variable [Algebra F₀ F₁] [Algebra F₁ F₂] [Algebra F₀ F₂] [IsScalarTower F₀ F₁ F₂]
+variable [Algebra k₀ F₀] [Algebra k₁ F₁] [Algebra k₂ F₂]
+variable [Algebra k₀ F₁] [Algebra k₁ F₂] [Algebra k₀ F₂]
+variable [IsScalarTower k₀ k₁ F₁] [IsScalarTower k₁ k₂ F₂]
+variable [IsScalarTower k₀ F₀ F₁] [IsScalarTower k₁ F₁ F₂]
+variable [IsScalarTower k₀ k₂ F₂] [IsScalarTower k₀ F₀ F₂]
+variable [Algebra.IsIntegral F₀ F₁] [Algebra.IsIntegral F₁ F₂]
+variable [Algebra.IsIntegral F₀ F₂]
+
+/-- **Restriction of places is functorial in a tower**: restricting a place of `F₂ / k₂`
+first to `F₁ / k₁` and then to `F₀ / k₀` gives its direct restriction to `F₀ / k₀`.
+
+This is the normalized-place form of transitivity of valuation restriction. -/
+@[simp]
+theorem restrict_restrict (P : Place k₂ F₂) :
+    (P.restrict k₁ F₁).restrict k₀ F₀ = P.restrict k₀ F₀ := by
+  rw [restrict_eq_iff_integers_le]
+  intro x hx
+  rw [mem_integers_restrict_iff]
+  rw [← IsScalarTower.algebraMap_apply F₀ F₁ F₂]
+  exact (mem_integers_restrict_iff k₀ F₀ P x).mp hx
+
+omit [Algebra.IsIntegral F₀ F₂] in
+/-- **Ramification indices are multiplicative in towers** (Stichtenoth, Proposition 3.1.6):
+`e(P₂ / P₀) = e(P₂ / P₁) e(P₁ / P₀)` for the restrictions `P₁` and `P₀` of `P₂`. -/
+theorem ramificationIdx_restrict_mul (P : Place k₂ F₂) :
+    P.ramificationIdx F₀ =
+      P.ramificationIdx F₁ * (P.restrict k₁ F₁).ramificationIdx F₀ := by
+  rw [ramificationIdx_def, ramificationIdx_def, ramificationIdx_def]
+  apply Valuation.ordIndex_eq_mul_of_forall_ord_eq _ _
+    (e := Valuation.ordIndex (P.valuation.comap (algebraMap F₁ F₂)))
+  · rw [← ramificationIdx_def]
+    exact ramificationIdx_pos F₁ P
+  · rw [← ramificationIdx_def]
+    exact Nat.ne_of_gt (ramificationIdx_pos F₀ (P.restrict k₁ F₁))
+  intro x
+  have hP (y : F₂) : Valuation.ord P.valuation y = P.ord y := by
+    rw [Valuation.ord_def, P.ord_def]
+  have hP₁ (y : F₁) : Valuation.ord (P.restrict k₁ F₁).valuation y =
+      (P.restrict k₁ F₁).ord y := by
+    rw [Valuation.ord_def, (P.restrict k₁ F₁).ord_def]
+  rw [Valuation.ord_comap, Valuation.ord_comap,
+    IsScalarTower.algebraMap_apply F₀ F₁ F₂, hP, hP₁, ord_algebraMap_restrict k₁ F₁ P,
+    ramificationIdx_def]
+
+/-- **Relative residue degrees are multiplicative in towers** (Stichtenoth, Proposition 3.1.6):
+`f(P₂ / P₀) = f(P₂ / P₁) f(P₁ / P₀)` for the restrictions `P₁` and `P₀` of `P₂`. -/
+theorem relativeDegree_restrict_mul (P : Place k₂ F₂) :
+    P.relativeDegree k₀ F₀ =
+      P.relativeDegree k₁ F₁ * (P.restrict k₁ F₁).relativeDegree k₀ F₀ := by
+  rw [relativeDegree_def, relativeDegree_def, relativeDegree_def]
+  let _ : Algebra ((P.restrict k₁ F₁).restrict k₀ F₀).integers P.integers :=
+    ((algebraMap (P.restrict k₁ F₁).integers P.integers).comp
+      (algebraMap ((P.restrict k₁ F₁).restrict k₀ F₀).integers
+        (P.restrict k₁ F₁).integers)).toAlgebra
+  let _ : IsLocalHom
+      (algebraMap ((P.restrict k₁ F₁).restrict k₀ F₀).integers P.integers) :=
+    RingHom.isLocalHom_comp _ _
+  let _ : IsScalarTower ((P.restrict k₁ F₁).restrict k₀ F₀).integers
+      (P.restrict k₁ F₁).integers P.integers :=
+    IsScalarTower.of_algebraMap_eq fun _ ↦ rfl
+  have hfinrank : Module.finrank (P.restrict k₀ F₀).ResidueField P.ResidueField =
+      Module.finrank ((P.restrict k₁ F₁).restrict k₀ F₀).ResidueField P.ResidueField := by
+    let h := restrict_restrict (k₀ := k₀) (F₀ := F₀) (k₁ := k₁) (F₁ := F₁) P
+    let e : (P.restrict k₀ F₀).ResidueField ≃+*
+        ((P.restrict k₁ F₁).restrict k₀ F₀).ResidueField :=
+      RingEquiv.cast (R := fun Q : Place k₀ F₀ ↦ Q.ResidueField) h.symm
+    refine Algebra.finrank_eq_of_equiv_equiv e (RingEquiv.refl P.ResidueField) ?_
+    ext x
+    obtain ⟨x, rfl⟩ := IsLocalRing.residue_surjective x
+    let y : ((P.restrict k₁ F₁).restrict k₀ F₀).integers :=
+      ⟨x, by rw [h]; exact x.2⟩
+    have cast_residue (Q : Place k₀ F₀) (hQ : Q = P.restrict k₀ F₀)
+        (x : (P.restrict k₀ F₀).integers) (y : Q.integers) (hy : (y : F₀) = x) :
+        RingEquiv.cast (R := fun R : Place k₀ F₀ ↦ R.ResidueField) hQ.symm
+            (IsLocalRing.residue (P.restrict k₀ F₀).integers x) =
+          IsLocalRing.residue Q.integers y := by
+      subst Q
+      have hxy : y = x := Subtype.ext hy
+      subst y
+      rfl
+    change (algebraMap ((P.restrict k₁ F₁).restrict k₀ F₀).ResidueField P.ResidueField)
+        (e (IsLocalRing.residue (P.restrict k₀ F₀).integers x)) =
+      algebraMap (P.restrict k₀ F₀).ResidueField P.ResidueField
+        (IsLocalRing.residue (P.restrict k₀ F₀).integers x)
+    rw [cast_residue _ h x y rfl]
+    simp only [IsLocalRing.ResidueField.algebraMap_residue]
+    apply congrArg (IsLocalRing.residue P.integers)
+    apply Subtype.ext
+    simp only [coe_algebraMap_integers, IsScalarTower.algebraMap_apply F₀ F₁ F₂]
+    rfl
+  rw [hfinrank]
+  simpa only [mul_comm] using
+    (Module.finrank_mul_finrank
+      ((P.restrict k₁ F₁).restrict k₀ F₀).ResidueField
+      (P.restrict k₁ F₁).ResidueField P.ResidueField).symm
+
+end Place
+
+end TauCeti
+
+end

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Tower.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Tower.lean
@@ -59,7 +59,6 @@ variable [IsScalarTower k₀ k₁ F₁] [IsScalarTower k₁ k₂ F₂]
 variable [IsScalarTower k₀ F₀ F₁] [IsScalarTower k₁ F₁ F₂]
 variable [IsScalarTower k₀ k₂ F₂] [IsScalarTower k₀ F₀ F₂]
 variable [Algebra.IsIntegral F₀ F₁] [Algebra.IsIntegral F₁ F₂]
-variable [Algebra.IsIntegral F₀ F₂]
 
 /-- **Restriction of places is functorial in a tower**: restricting a place of `F₂ / k₂`
 first to `F₁ / k₁` and then to `F₀ / k₀` gives its direct restriction to `F₀ / k₀`.
@@ -67,14 +66,16 @@ first to `F₁ / k₁` and then to `F₀ / k₀` gives its direct restriction to
 This is the normalized-place form of transitivity of valuation restriction. -/
 @[simp]
 theorem restrict_restrict (P : Place k₂ F₂) :
-    (P.restrict k₁ F₁).restrict k₀ F₀ = P.restrict k₀ F₀ := by
+    (P.restrict k₁ F₁).restrict k₀ F₀ =
+      @restrict k₀ k₂ F₀ F₂ _ _ _ _ _ _ _ _ _ _ _ P
+        (Algebra.IsIntegral.trans F₁) := by
+  let _ : Algebra.IsIntegral F₀ F₂ := Algebra.IsIntegral.trans F₁
   rw [restrict_eq_iff_integers_le]
   intro x hx
   rw [mem_integers_restrict_iff]
   rw [← IsScalarTower.algebraMap_apply F₀ F₁ F₂]
   exact (mem_integers_restrict_iff k₀ F₀ P x).mp hx
 
-omit [Algebra.IsIntegral F₀ F₂] in
 /-- **Ramification indices are multiplicative in towers** (Stichtenoth, Proposition 3.1.6):
 `e(P₂ / P₀) = e(P₂ / P₁) e(P₁ / P₀)` for the restrictions `P₁` and `P₀` of `P₂`. -/
 theorem ramificationIdx_restrict_mul (P : Place k₂ F₂) :
@@ -100,8 +101,10 @@ theorem ramificationIdx_restrict_mul (P : Place k₂ F₂) :
 /-- **Relative residue degrees are multiplicative in towers** (Stichtenoth, Proposition 3.1.6):
 `f(P₂ / P₀) = f(P₂ / P₁) f(P₁ / P₀)` for the restrictions `P₁` and `P₀` of `P₂`. -/
 theorem relativeDegree_restrict_mul (P : Place k₂ F₂) :
-    P.relativeDegree k₀ F₀ =
+    @relativeDegree k₀ k₂ F₀ F₂ _ _ _ _ _ _ _ _ _ _ _ P
+        (Algebra.IsIntegral.trans F₁) =
       P.relativeDegree k₁ F₁ * (P.restrict k₁ F₁).relativeDegree k₀ F₀ := by
+  let _ : Algebra.IsIntegral F₀ F₂ := Algebra.IsIntegral.trans F₁
   rw [relativeDegree_def, relativeDegree_def, relativeDegree_def]
   let _ : Algebra ((P.restrict k₁ F₁).restrict k₀ F₀).integers P.integers :=
     ((algebraMap (P.restrict k₁ F₁).integers P.integers).comp
@@ -133,6 +136,9 @@ theorem relativeDegree_restrict_mul (P : Place k₂ F₂) :
       have hxy : y = x := Subtype.ext hy
       subst y
       rfl
+    -- The direct residue-field algebra synthesized by `finrank_eq_of_equiv_equiv` and the
+    -- locally defined composite algebra have definitionally equal maps, but no named equality
+    -- relates the two structures for rewriting; `change` exposes that definitional equality.
     change (algebraMap ((P.restrict k₁ F₁).restrict k₀ F₀).ResidueField P.ResidueField)
         (e (IsLocalRing.residue (P.restrict k₀ F₀).integers x)) =
       algebraMap (P.restrict k₀ F₀).ResidueField P.ResidueField

--- a/TauCeti/RingTheory/Valuation/Discrete/Normalize.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Normalize.lean
@@ -28,6 +28,8 @@ extension.
 ## Main results
 
 * `Valuation.ordIndex_dvd_ord`: every order attained by `v` is a multiple of the index.
+* `Valuation.ordIndex_eq_mul_of_forall_ord_eq`: indices multiply when one order function is a
+  positive integral multiple of another.
 * `Valuation.ord_normalization_mul_ordIndex`: the order function of `v` is the index times the
   order function of its normalization — the defining relation between the two.
 * `Valuation.isEquiv_normalization`: a valuation is equivalent to its normalization; in
@@ -229,6 +231,45 @@ theorem normalization_surjective (hv : ordIndex v ≠ 0) :
     refine ⟨t ^ (-n), ?_⟩
     rw [normalization_apply v (zpow_ne_zero _ ht0), ord_zpow, ht,
       Int.mul_ediv_cancel _ he, neg_neg]
+
+/-- If the order function of a nontrivial valuation is a positive integral multiple of the
+order function of another, then their indices differ by the same factor. -/
+theorem ordIndex_eq_mul_of_forall_ord_eq (w : _root_.Valuation F ℤᵐ⁰) {e : ℕ} (he : 0 < e)
+    (hw : ordIndex w ≠ 0) (hord : ∀ f : F, ord v f = e * ord w f) :
+    ordIndex v = e * ordIndex w := by
+  obtain ⟨f, hf⟩ := ord_surjective (normalization w) (normalization_surjective w hw) 1
+  have hwf : ord w f = (ordIndex w : ℤ) := by
+    rw [← ord_normalization_mul_ordIndex w f, hf, one_mul]
+  have hvf : ord v f = (e * ordIndex w : ℕ) := by
+    rw [hord, hwf]
+    norm_cast
+  have hprodPos : 0 < e * ordIndex w := Nat.mul_pos he (Nat.pos_of_ne_zero hw)
+  have hle := ordIndex_le v hprodPos hvf
+  have hv : ordIndex v ≠ 0 := by
+    exact Nat.ne_of_gt (ordIndex_pos v (by rw [hvf]; exact_mod_cast hprodPos.ne'))
+  obtain ⟨g, hg⟩ := exists_ord_eq_ordIndex v hv
+  have hwordPos : 0 < ord w g := by
+    have := hord g
+    rw [hg] at this
+    have he' : (0 : ℤ) < e := by exact_mod_cast he
+    have hv' : (0 : ℤ) < ordIndex v := by exact_mod_cast Nat.pos_of_ne_zero hv
+    nlinarith
+  have hwordEq : ord w g = (ord w g).toNat := by omega
+  have hwle := ordIndex_le w (n := (ord w g).toNat) (by omega) hwordEq
+  have hge : e * ordIndex w ≤ ordIndex v := by
+    have hordg := hord g
+    rw [hg] at hordg
+    have hwle' : (ordIndex w : ℤ) ≤ ord w g := by
+      calc
+        (ordIndex w : ℤ) ≤ ((ord w g).toNat : ℕ) := by exact_mod_cast hwle
+        _ = ord w g := by omega
+    have he' : (0 : ℤ) ≤ e := by positivity
+    have : (e * ordIndex w : ℕ) ≤ ordIndex v := by
+      exact_mod_cast (calc
+        (e : ℤ) * ordIndex w ≤ (e : ℤ) * ord w g := mul_le_mul_of_nonneg_left hwle' he'
+        _ = (ordIndex v : ℤ) := hordg.symm)
+    exact this
+  omega
 
 /-- Normalization preserves triviality on a base ring. -/
 theorem IsTrivialOn.normalization {A : Type*} [CommRing A] [Algebra A F]

--- a/TauCeti/RingTheory/Valuation/Discrete/Order.lean
+++ b/TauCeti/RingTheory/Valuation/Discrete/Order.lean
@@ -34,6 +34,12 @@ noncomputable def ord (v : _root_.Valuation F ℤᵐ⁰) (f : F) : ℤ :=
 theorem ord_def (v : _root_.Valuation F ℤᵐ⁰) (f : F) : ord v f = -WithZero.log (v f) :=
   (rfl)
 
+/-- The order function commutes with restriction along a ring homomorphism. -/
+@[simp]
+theorem ord_comap {K : Type*} [Field K] (v : _root_.Valuation F ℤᵐ⁰) (f : K →+* F)
+    (x : K) : ord (v.comap f) x = ord v (f x) := by
+  rw [ord_def, ord_def, _root_.Valuation.comap_apply]
+
 /-- Translation between the multiplicative valuation and its additive order. -/
 theorem valuation_eq_exp_neg_ord (v : _root_.Valuation F ℤᵐ⁰) {f : F} (hf : f ≠ 0) :
     v f = WithZero.exp (-ord v f) := by


### PR DESCRIPTION
This PR establishes functorial restriction of places and multiplicativity of ramification indices and relative residue degrees in towers of integral field extensions. It targets AlgebraicCurves Layer 6, Setup, “multiplicativity in towers (Stichtenoth, Proposition 3.1.6),” by proving the restriction, `e`, and `f` tower laws without function-field, finiteness, separability, or perfectness assumptions.

The AlgebraicCurves milestone is the place-extension setup preceding the fundamental inequality and identity. After this PR, that setup still needs the roadmap's characterization `f < ∞` iff the residue-field extension is finite before the fundamental inequality is assembled.

This is an upstream prerequisite switch from the designated EllipticCurves roadmap: EllipticCurves Layer 0's `inducedPlace` functoriality consumes `Place.restrict_restrict`, and Layer 1's dual-isogeny construction consumes the same composition law for induced places. AlgebraicCurves owns the generic extension-of-places theory that supplies it.

The proof factors the ramification statement through a reusable valuation theorem saying order indices scale with order functions. The residue-degree statement uses Mathlib's induced residue-field algebras, `Algebra.finrank_eq_of_equiv_equiv`, and `Module.finrank_mul_finrank`, with an explicit transport showing that direct and iterated restriction induce the same bottom residue field and compatible scalar action.

Roadmap: AlgebraicCurves

Consumer roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"place-restriction-tower"}-->

The cache fetch, full build, and axiom audit pass locally.

🤖 Prepared with Codex
