### PR TITLE
feat: the discriminant quadratic module of an even-rank checkerboard lattice

### DIFF
--- a/TauCeti/Algebra/AddCircle.lean
+++ b/TauCeti/Algebra/AddCircle.lean
@@ -20,11 +20,6 @@ in the unit `ℤ`-submodule.
 
 * `AddCircle.coe_eq_zero_iff_mem_one`: vanishing in `AddCircle (1 : ℚ)` is membership in
   `(1 : Submodule ℤ ℚ)`.
-* `AddCircle.coe_eq_zero_of_eq_intCast`: a rational equal to an integer reduces to zero.
-* `AddCircle.zsmul_coe_eq_zero_of_mul_eq_intCast`: a rational whose integer multiple is an
-  integer becomes torsion in `ℚ/ℤ`.
-* `AddCircle.four_zsmul_coe_div_eight_eq_zero_of_even`: the class of `n / 8` is four-torsion
-  when `n` is even.
 -/
 
 public section
@@ -41,26 +36,5 @@ theorem coe_eq_zero_iff_mem_one (q : ℚ) :
   · intro h
     obtain ⟨n, hn⟩ := Submodule.mem_one.mp h
     exact (coe_eq_zero_iff (1 : ℚ)).mpr ⟨n, by simpa using hn⟩
-
-/-- A rational number equal to an integer reduces to zero in `ℚ/ℤ`. -/
-theorem coe_eq_zero_of_eq_intCast {q : ℚ} (m : ℤ) (h : q = (m : ℚ)) :
-    (q : AddCircle (1 : ℚ)) = 0 := by
-  rw [coe_eq_zero_iff_mem_one]
-  exact Submodule.mem_one.mpr ⟨m, by simpa using h.symm⟩
-
-/-- A rational whose integer multiple is an integer becomes torsion in `ℚ/ℤ`. -/
-theorem zsmul_coe_eq_zero_of_mul_eq_intCast {q : ℚ} (n m : ℤ)
-    (h : (n : ℚ) * q = (m : ℚ)) : n • (q : AddCircle (1 : ℚ)) = 0 := by
-  rw [← coe_zsmul, zsmul_eq_mul]
-  exact coe_eq_zero_of_eq_intCast m h
-
-/-- The class of `n / 8` in `ℚ/ℤ` is four-torsion when `n` is even. -/
-theorem four_zsmul_coe_div_eight_eq_zero_of_even (n : ℕ) (hn : Even n) :
-    (4 : ℤ) • (((n : ℚ) / 8 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
-  obtain ⟨k, hk⟩ := hn
-  refine zsmul_coe_eq_zero_of_mul_eq_intCast 4 k ?_
-  rw [hk]
-  push_cast
-  ring
 
 end AddCircle

--- a/TauCeti/Algebra/AddCircle.lean
+++ b/TauCeti/Algebra/AddCircle.lean
@@ -20,6 +20,11 @@ in the unit `ℤ`-submodule.
 
 * `AddCircle.coe_eq_zero_iff_mem_one`: vanishing in `AddCircle (1 : ℚ)` is membership in
   `(1 : Submodule ℤ ℚ)`.
+* `AddCircle.coe_eq_zero_of_eq_intCast`: a rational equal to an integer reduces to zero.
+* `AddCircle.zsmul_coe_eq_zero_of_mul_eq_intCast`: a rational whose integer multiple is an
+  integer becomes torsion in `ℚ/ℤ`.
+* `AddCircle.four_zsmul_coe_div_eight_eq_zero_of_even`: the class of `n / 8` is four-torsion
+  when `n` is even.
 -/
 
 public section
@@ -36,5 +41,26 @@ theorem coe_eq_zero_iff_mem_one (q : ℚ) :
   · intro h
     obtain ⟨n, hn⟩ := Submodule.mem_one.mp h
     exact (coe_eq_zero_iff (1 : ℚ)).mpr ⟨n, by simpa using hn⟩
+
+/-- A rational number equal to an integer reduces to zero in `ℚ/ℤ`. -/
+theorem coe_eq_zero_of_eq_intCast {q : ℚ} (m : ℤ) (h : q = (m : ℚ)) :
+    (q : AddCircle (1 : ℚ)) = 0 := by
+  rw [coe_eq_zero_iff_mem_one]
+  exact Submodule.mem_one.mpr ⟨m, by simpa using h.symm⟩
+
+/-- A rational whose integer multiple is an integer becomes torsion in `ℚ/ℤ`. -/
+theorem zsmul_coe_eq_zero_of_mul_eq_intCast {q : ℚ} (n m : ℤ)
+    (h : (n : ℚ) * q = (m : ℚ)) : n • (q : AddCircle (1 : ℚ)) = 0 := by
+  rw [← coe_zsmul, zsmul_eq_mul]
+  exact coe_eq_zero_of_eq_intCast m h
+
+/-- The class of `n / 8` in `ℚ/ℤ` is four-torsion when `n` is even. -/
+theorem four_zsmul_coe_div_eight_eq_zero_of_even (n : ℕ) (hn : Even n) :
+    (4 : ℤ) • (((n : ℚ) / 8 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
+  obtain ⟨k, hk⟩ := hn
+  refine zsmul_coe_eq_zero_of_mul_eq_intCast 4 k ?_
+  rw [hk]
+  push_cast
+  ring
 
 end AddCircle

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
@@ -179,6 +179,7 @@ theorem kleinFourMap_apply_one_one :
   simpa using kleinFourMap_intCast α β γ h₄α h₄β h₂γ 1 1
 
 /-- The two standard generators of `(ℤ/2)²` pair to `γ`. -/
+@[simp]
 theorem polar_kleinFourMap_one_zero_zero_one :
     QuadraticMap.polar (kleinFourMap α β γ h₄α h₄β h₂γ) (1, 0) (0, 1) = γ := by
   rw [QuadraticMap.polar, kleinFourMap_apply_one_zero, kleinFourMap_apply_zero_one]

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
@@ -30,8 +30,11 @@ technical: `4α = 0` is the statement that `q` is well defined on a two-torsion 
 
 The companion `TauCeti.FiniteQuadraticModule.kleinFourIsometryOfGenerators` turns an additive
 equivalence `(ℤ/2)² ≃+ A` matching the three displayed values into an isometry onto `A`, which is
-how a discriminant form of order four and exponent two is identified.  It needs no induction: the
-four elements of `(ℤ/2)²` are checked one by one.
+how a discriminant form of order four and exponent two is identified.
+
+The quotient construction is a rank-two adaptation of the private cyclic construction in
+`TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean`; the two can be unified when that
+construction is promoted to shared API.
 
 ## Main declarations
 
@@ -43,8 +46,9 @@ four elements of `(ℤ/2)²` are checked one by one.
 
 ## References
 
-* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1, where
-  the corresponding two-torsion forms are written `u₁` and `v₁` in the full-norm convention.
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1 for
+  discriminant forms and §1.8, Proposition 1.8.1 for the forms written `u₁` and `v₁` in the
+  full-norm convention.
 * W. Ebeling, *Lattices and Codes*, Chapter 1.
 
 This is part of Layer 3 of `TauCetiRoadmap/IntegralLattices/README.md`.
@@ -75,19 +79,24 @@ private def kleinFourBilin : LinearMap.BilinMap ℤ (ℤ × ℤ) (AddCircle (1 :
     (fun c u v ↦ by
       simp only [Prod.smul_fst, Prod.smul_snd, smul_eq_mul, mul_left_comm, mul_smul, smul_add])
 
+private theorem kleinFourBilin_apply (u v : ℤ × ℤ) :
+    kleinFourBilin α β γ u v =
+      (u.1 * v.1) • α + (u.2 * v.2) • β + (u.1 * v.2) • γ := by
+  rw [kleinFourBilin, LinearMap.mk₂_apply]
+
 /-- The quadratic map `(m, k) ↦ m²α + k²β + mkγ` on `ℤ × ℤ`. -/
 private def kleinFourAux : QuadraticMap ℤ (ℤ × ℤ) (AddCircle (1 : ℚ)) :=
   (kleinFourBilin α β γ).toQuadraticMap
 
 private theorem kleinFourAux_apply (u : ℤ × ℤ) :
-    kleinFourAux α β γ u = (u.1 * u.1) • α + (u.2 * u.2) • β + (u.1 * u.2) • γ := (rfl)
+    kleinFourAux α β γ u = (u.1 * u.1) • α + (u.2 * u.2) • β + (u.1 * u.2) • γ := by
+  rw [kleinFourAux, LinearMap.BilinMap.toQuadraticMap_apply, kleinFourBilin_apply]
 
 private theorem polar_kleinFourAux (u v : ℤ × ℤ) :
     QuadraticMap.polar (kleinFourAux α β γ) u v =
       (2 * (u.1 * v.1)) • α + (2 * (u.2 * v.2)) • β + (u.1 * v.2 + u.2 * v.1) • γ := by
-  have hB : ∀ x y : ℤ × ℤ, kleinFourBilin α β γ x y
-      = (x.1 * y.1) • α + (x.2 * y.2) • β + (x.1 * y.2) • γ := fun _ _ ↦ (rfl)
-  rw [kleinFourAux, LinearMap.BilinMap.polar_toQuadraticMap, hB, hB]
+  rw [kleinFourAux, LinearMap.BilinMap.polar_toQuadraticMap, kleinFourBilin_apply,
+    kleinFourBilin_apply]
   have e₁ : (2 * (u.1 * v.1) : ℤ) = u.1 * v.1 + v.1 * u.1 := by ring
   have e₂ : (2 * (u.2 * v.2) : ℤ) = u.2 * v.2 + v.2 * u.2 := by ring
   have e₃ : (u.1 * v.2 + u.2 * v.1 : ℤ) = u.1 * v.2 + v.1 * u.2 := by ring
@@ -205,33 +214,38 @@ theorem kleinFour_pairing (x y : ZMod 2 × ZMod 2) :
     (kleinFour α β γ h₄α h₄β h₂γ).toFiniteBilinearModule.pairing x y =
       QuadraticMap.polar (kleinFourMap α β γ h₄α h₄β h₂γ) x y := (rfl)
 
-/-- **An additive equivalence from `(ℤ/2)²` matching the three generator values is an isometry.**
+omit h₄α h₄β h₂γ in
+/-- **An additive equivalence from `(ℤ/2)²` matching all three nonzero values is an isometry.**
 
-The four elements of `(ℤ/2)²` are checked one by one, so no hypothesis beyond the three displayed
-values is needed.  The target is stated as a bare quadratic map so that the construction applies
-to a discriminant form before it is packaged as a finite quadratic module. -/
+No hypothesis beyond the three displayed values is needed.  Both forms are stated as bare quadratic
+maps so that the construction applies before either is packaged as a finite quadratic module. -/
 noncomputable def kleinFourIsometryOfGenerators {A : Type*} [AddCommGroup A]
+    (q : QuadraticMap ℤ (ZMod 2 × ZMod 2) (AddCircle (1 : ℚ)))
     (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod 2 × ZMod 2 ≃+ A)
-    (h₁ : r (e (1, 0)) = α) (h₂ : r (e (0, 1)) = β) (h₃ : r (e (1, 1)) = α + β + γ) :
-    (kleinFourMap α β γ h₄α h₄β h₂γ).IsometryEquiv r where
+    (h₁ : r (e (1, 0)) = q (1, 0)) (h₂ : r (e (0, 1)) = q (0, 1))
+    (h₃ : r (e (1, 1)) = q (1, 1)) : q.IsometryEquiv r where
   toLinearEquiv := e.toIntLinearEquiv
   map_app' x := by
     have hcases : ∀ c : ZMod 2, c = 0 ∨ c = 1 := by decide
     obtain ⟨c, d⟩ := x
-    -- Identify the bundled linear equivalence with its underlying additive equivalence.
-    change r (e (c, d)) = kleinFourMap α β γ h₄α h₄β h₂γ (c, d)
+    -- The linear and additive equivalences have definitionally equal coercions, so the named
+    -- reflexive theorem `AddEquiv.coe_toIntLinearEquiv` gives `simp` no rewrite step here.
+    change r (e (c, d)) = q (c, d)
     rcases hcases c with rfl | rfl <;> rcases hcases d with rfl | rfl
     · rw [Prod.mk_zero_zero, map_zero, map_zero, map_zero]
-    · rw [kleinFourMap_apply_zero_one, h₂]
-    · rw [kleinFourMap_apply_one_zero, h₁]
-    · rw [kleinFourMap_apply_one_one, h₃]
+    · exact h₂
+    · exact h₁
+    · exact h₃
 
+omit h₄α h₄β h₂γ in
 @[simp]
 theorem kleinFourIsometryOfGenerators_apply {A : Type*} [AddCommGroup A]
+    (q : QuadraticMap ℤ (ZMod 2 × ZMod 2) (AddCircle (1 : ℚ)))
     (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod 2 × ZMod 2 ≃+ A)
-    (h₁ : r (e (1, 0)) = α) (h₂ : r (e (0, 1)) = β) (h₃ : r (e (1, 1)) = α + β + γ)
+    (h₁ : r (e (1, 0)) = q (1, 0)) (h₂ : r (e (0, 1)) = q (0, 1))
+    (h₃ : r (e (1, 1)) = q (1, 1))
     (x : ZMod 2 × ZMod 2) :
-    kleinFourIsometryOfGenerators α β γ h₄α h₄β h₂γ r e h₁ h₂ h₃ x = e x := (rfl)
+    kleinFourIsometryOfGenerators q r e h₁ h₂ h₃ x = e x := (rfl)
 
 end FiniteQuadraticModule
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
@@ -1,0 +1,237 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Isomorphisms
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
+
+/-!
+# Finite quadratic modules on the Klein four-group
+
+A `ℚ/ℤ`-valued quadratic map on `(ℤ/2)²` is determined by its three values on the nonzero
+elements, and conversely any three values admissible for the two-torsion of the group occur.
+This file makes that presentation available as a construction: given `α β γ : ℚ/ℤ` with
+`4α = 4β = 2γ = 0`, `TauCeti.FiniteQuadraticModule.kleinFour` is the finite quadratic module on
+`ZMod 2 × ZMod 2` with
+
+```text
+q(1, 0) = α,   q(0, 1) = β,   q(1, 1) = α + β + γ,   b((1, 0), (0, 1)) = γ.
+```
+
+The construction is a quotient, not a formula in `ZMod.val`: the parameters define an honest
+`ℤ`-bilinear map on `ℤ × ℤ`, its associated quadratic map `(m, k) ↦ m²α + k²β + mkγ` has the
+kernel of the reduction `ℤ × ℤ → (ℤ/2)²` inside its radical exactly under the three torsion
+hypotheses, and `QuadraticMap.lift` descends it.  The torsion hypotheses are therefore not
+technical: `4α = 0` is the statement that `q` is well defined on a two-torsion generator, and
+`2γ = 0` the corresponding statement for the pairing.
+
+The companion `TauCeti.FiniteQuadraticModule.kleinFourIsometryOfGenerators` turns an additive
+equivalence `(ℤ/2)² ≃+ A` matching the three displayed values into an isometry onto `A`, which is
+how a discriminant form of order four and exponent two is identified.  It needs no induction: the
+four elements of `(ℤ/2)²` are checked one by one.
+
+## Main declarations
+
+* `TauCeti.FiniteQuadraticModule.kleinFourMap`: the quadratic map on `ZMod 2 × ZMod 2` with the
+  displayed generator values.
+* `TauCeti.FiniteQuadraticModule.kleinFour`: the resulting finite quadratic module.
+* `TauCeti.FiniteQuadraticModule.kleinFourIsometryOfGenerators`: an additive equivalence matching
+  the three generator values is an isometry.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1, where
+  the corresponding two-torsion forms are written `u₁` and `v₁` in the full-norm convention.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+
+This is part of Layer 3 of `TauCetiRoadmap/IntegralLattices/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace FiniteQuadraticModule
+
+variable (α β γ : AddCircle (1 : ℚ))
+
+/-! ## The presenting quadratic map on `ℤ × ℤ` -/
+
+/-- The bilinear map `((m, k), (m', k')) ↦ mm'α + kk'β + mk'γ` on `ℤ × ℤ`.  It is not symmetric;
+only its associated quadratic map is used. -/
+private def kleinFourBilin : LinearMap.BilinMap ℤ (ℤ × ℤ) (AddCircle (1 : ℚ)) :=
+  LinearMap.mk₂ ℤ (fun u v ↦ (u.1 * v.1) • α + (u.2 * v.2) • β + (u.1 * v.2) • γ)
+    (fun u u' v ↦ by
+      simp only [Prod.fst_add, Prod.snd_add, add_mul, add_smul]
+      abel)
+    (fun c u v ↦ by
+      simp only [Prod.smul_fst, Prod.smul_snd, smul_eq_mul, mul_assoc, mul_smul, smul_add])
+    (fun u v v' ↦ by
+      simp only [Prod.fst_add, Prod.snd_add, mul_add, add_smul]
+      abel)
+    (fun c u v ↦ by
+      simp only [Prod.smul_fst, Prod.smul_snd, smul_eq_mul, mul_left_comm, mul_smul, smul_add])
+
+/-- The quadratic map `(m, k) ↦ m²α + k²β + mkγ` on `ℤ × ℤ`. -/
+private def kleinFourAux : QuadraticMap ℤ (ℤ × ℤ) (AddCircle (1 : ℚ)) :=
+  (kleinFourBilin α β γ).toQuadraticMap
+
+private theorem kleinFourAux_apply (u : ℤ × ℤ) :
+    kleinFourAux α β γ u = (u.1 * u.1) • α + (u.2 * u.2) • β + (u.1 * u.2) • γ := (rfl)
+
+private theorem polar_kleinFourAux (u v : ℤ × ℤ) :
+    QuadraticMap.polar (kleinFourAux α β γ) u v =
+      (2 * (u.1 * v.1)) • α + (2 * (u.2 * v.2)) • β + (u.1 * v.2 + u.2 * v.1) • γ := by
+  have hB : ∀ x y : ℤ × ℤ, kleinFourBilin α β γ x y
+      = (x.1 * y.1) • α + (x.2 * y.2) • β + (x.1 * y.2) • γ := fun _ _ ↦ (rfl)
+  rw [kleinFourAux, LinearMap.BilinMap.polar_toQuadraticMap, hB, hB]
+  have e₁ : (2 * (u.1 * v.1) : ℤ) = u.1 * v.1 + v.1 * u.1 := by ring
+  have e₂ : (2 * (u.2 * v.2) : ℤ) = u.2 * v.2 + v.2 * u.2 := by ring
+  have e₃ : (u.1 * v.2 + u.2 * v.1 : ℤ) = u.1 * v.2 + v.1 * u.2 := by ring
+  rw [e₁, e₂, e₃, add_smul, add_smul, add_smul]
+  abel
+
+/-! ## Reduction modulo two -/
+
+/-- Coordinatewise reduction `ℤ × ℤ → (ℤ/2)²`. -/
+private def zmodTwoPairProj : (ℤ × ℤ) →ₗ[ℤ] ZMod 2 × ZMod 2 :=
+  LinearMap.prodMap (Int.castAddHom (ZMod 2)).toIntLinearMap
+    (Int.castAddHom (ZMod 2)).toIntLinearMap
+
+private theorem zmodTwoPairProj_apply (m k : ℤ) :
+    zmodTwoPairProj (m, k) = ((m : ZMod 2), (k : ZMod 2)) := (rfl)
+
+private theorem zmodTwoPairProj_surjective : Function.Surjective zmodTwoPairProj := by
+  rintro ⟨x, y⟩
+  obtain ⟨m, rfl⟩ := ZMod.intCast_surjective x
+  obtain ⟨k, rfl⟩ := ZMod.intCast_surjective y
+  exact ⟨(m, k), rfl⟩
+
+private theorem mem_ker_zmodTwoPairProj_iff (u : ℤ × ℤ) :
+    u ∈ LinearMap.ker zmodTwoPairProj ↔ (2 : ℤ) ∣ u.1 ∧ (2 : ℤ) ∣ u.2 := by
+  obtain ⟨m, k⟩ := u
+  rw [LinearMap.mem_ker, zmodTwoPairProj_apply, Prod.ext_iff]
+  simpa using
+    and_congr (ZMod.intCast_zmod_eq_zero_iff_dvd m 2) (ZMod.intCast_zmod_eq_zero_iff_dvd k 2)
+
+/-- Under the three torsion hypotheses the kernel of reduction modulo two lies in the radical,
+which is what lets the quadratic map descend. -/
+private theorem ker_zmodTwoPairProj_le_radical (h₄α : (4 : ℤ) • α = 0) (h₄β : (4 : ℤ) • β = 0)
+    (h₂γ : (2 : ℤ) • γ = 0) :
+    LinearMap.ker zmodTwoPairProj ≤ (kleinFourAux α β γ).radical := by
+  rintro ⟨m, k⟩ hu
+  rw [mem_ker_zmodTwoPairProj_iff] at hu
+  obtain ⟨⟨a, rfl⟩, ⟨b, rfl⟩⟩ := hu
+  have hα : ∀ c : ℤ, (c * 4 : ℤ) • α = 0 := fun c ↦ by rw [mul_smul, h₄α, smul_zero]
+  have hβ : ∀ c : ℤ, (c * 4 : ℤ) • β = 0 := fun c ↦ by rw [mul_smul, h₄β, smul_zero]
+  have hγ : ∀ c : ℤ, (c * 2 : ℤ) • γ = 0 := fun c ↦ by rw [mul_smul, h₂γ, smul_zero]
+  constructor
+  · rw [kleinFourAux_apply]
+    have e₁ : (2 * a * (2 * a) : ℤ) = a * a * 4 := by ring
+    have e₂ : (2 * b * (2 * b) : ℤ) = b * b * 4 := by ring
+    have e₃ : (2 * a * (2 * b) : ℤ) = 2 * a * b * 2 := by ring
+    rw [e₁, e₂, e₃, hα, hβ, hγ, add_zero, add_zero]
+  · refine LinearMap.ext fun v ↦ ?_
+    rw [LinearMap.zero_apply, QuadraticMap.polarBilin_apply_apply, polar_kleinFourAux]
+    have e₁ : (2 * (2 * a * v.1) : ℤ) = a * v.1 * 4 := by ring
+    have e₂ : (2 * (2 * b * v.2) : ℤ) = b * v.2 * 4 := by ring
+    have e₃ : (2 * a * v.2 + 2 * b * v.1 : ℤ) = (a * v.2 + b * v.1) * 2 := by ring
+    rw [e₁, e₂, e₃, hα, hβ, hγ, add_zero, add_zero]
+
+/-! ## The quadratic module -/
+
+variable (h₄α : (4 : ℤ) • α = 0) (h₄β : (4 : ℤ) • β = 0) (h₂γ : (2 : ℤ) • γ = 0)
+
+include h₄α h₄β h₂γ
+
+/-- The quadratic map on `(ℤ/2)²` sending `(1, 0)` to `α`, `(0, 1)` to `β`, and `(1, 1)` to
+`α + β + γ`. -/
+noncomputable def kleinFourMap : QuadraticMap ℤ (ZMod 2 × ZMod 2) (AddCircle (1 : ℚ)) :=
+  ((kleinFourAux α β γ).lift (LinearMap.ker zmodTwoPairProj)
+      (ker_zmodTwoPairProj_le_radical α β γ h₄α h₄β h₂γ)).comp
+    (zmodTwoPairProj.quotKerEquivOfSurjective zmodTwoPairProj_surjective).symm.toLinearMap
+
+/-- The value of `kleinFourMap` on the reduction of a pair of integers. -/
+theorem kleinFourMap_intCast (m k : ℤ) :
+    kleinFourMap α β γ h₄α h₄β h₂γ ((m : ZMod 2), (k : ZMod 2)) =
+      (m * m) • α + (k * k) • β + (m * k) • γ := by
+  have hsymm :
+      (zmodTwoPairProj.quotKerEquivOfSurjective zmodTwoPairProj_surjective).symm
+          ((m : ZMod 2), (k : ZMod 2)) = Submodule.Quotient.mk (m, k) := by
+    rw [← zmodTwoPairProj_apply m k, LinearMap.quotKerEquivOfSurjective_symm_apply]
+  rw [kleinFourMap, QuadraticMap.comp_apply, LinearEquiv.coe_coe, hsymm, QuadraticMap.lift_mk,
+    kleinFourAux_apply]
+
+@[simp]
+theorem kleinFourMap_apply_one_zero : kleinFourMap α β γ h₄α h₄β h₂γ (1, 0) = α := by
+  simpa using kleinFourMap_intCast α β γ h₄α h₄β h₂γ 1 0
+
+@[simp]
+theorem kleinFourMap_apply_zero_one : kleinFourMap α β γ h₄α h₄β h₂γ (0, 1) = β := by
+  simpa using kleinFourMap_intCast α β γ h₄α h₄β h₂γ 0 1
+
+@[simp]
+theorem kleinFourMap_apply_one_one :
+    kleinFourMap α β γ h₄α h₄β h₂γ (1, 1) = α + β + γ := by
+  simpa using kleinFourMap_intCast α β γ h₄α h₄β h₂γ 1 1
+
+/-- The two standard generators of `(ℤ/2)²` pair to `γ`. -/
+theorem polar_kleinFourMap_one_zero_zero_one :
+    QuadraticMap.polar (kleinFourMap α β γ h₄α h₄β h₂γ) (1, 0) (0, 1) = γ := by
+  rw [QuadraticMap.polar, kleinFourMap_apply_one_zero, kleinFourMap_apply_zero_one]
+  rw [Prod.mk_add_mk, add_zero, zero_add, kleinFourMap_apply_one_one]
+  abel
+
+/-- **The finite quadratic module on `(ℤ/2)²` with generator values `α`, `β` and `α + β + γ`.** -/
+@[expose] noncomputable def kleinFour : FiniteQuadraticModule where
+  toFiniteBilinearModule := {
+    carrier := ZMod 2 × ZMod 2
+    pairing := LinearMap.toAddMonoidHom'.comp
+      (kleinFourMap α β γ h₄α h₄β h₂γ).polarBilin.toAddMonoidHom
+    pairing_comm := fun x y ↦ QuadraticMap.polar_comm (kleinFourMap α β γ h₄α h₄β h₂γ) x y }
+  quadratic := kleinFourMap α β γ h₄α h₄β h₂γ
+  polar_eq_pairing' := fun _ _ ↦ (rfl)
+
+@[simp]
+theorem kleinFour_quadratic (x : ZMod 2 × ZMod 2) :
+    (kleinFour α β γ h₄α h₄β h₂γ).quadratic x = kleinFourMap α β γ h₄α h₄β h₂γ x := (rfl)
+
+@[simp]
+theorem kleinFour_pairing (x y : ZMod 2 × ZMod 2) :
+    (kleinFour α β γ h₄α h₄β h₂γ).toFiniteBilinearModule.pairing x y =
+      QuadraticMap.polar (kleinFourMap α β γ h₄α h₄β h₂γ) x y := (rfl)
+
+/-- **An additive equivalence from `(ℤ/2)²` matching the three generator values is an isometry.**
+
+The four elements of `(ℤ/2)²` are checked one by one, so no hypothesis beyond the three displayed
+values is needed.  The target is stated as a bare quadratic map so that the construction applies
+to a discriminant form before it is packaged as a finite quadratic module. -/
+noncomputable def kleinFourIsometryOfGenerators {A : Type*} [AddCommGroup A]
+    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod 2 × ZMod 2 ≃+ A)
+    (h₁ : r (e (1, 0)) = α) (h₂ : r (e (0, 1)) = β) (h₃ : r (e (1, 1)) = α + β + γ) :
+    (kleinFourMap α β γ h₄α h₄β h₂γ).IsometryEquiv r where
+  toLinearEquiv := e.toIntLinearEquiv
+  map_app' x := by
+    have hcases : ∀ c : ZMod 2, c = 0 ∨ c = 1 := by decide
+    obtain ⟨c, d⟩ := x
+    -- Identify the bundled linear equivalence with its underlying additive equivalence.
+    change r (e (c, d)) = kleinFourMap α β γ h₄α h₄β h₂γ (c, d)
+    rcases hcases c with rfl | rfl <;> rcases hcases d with rfl | rfl
+    · rw [Prod.mk_zero_zero, map_zero, map_zero, map_zero]
+    · rw [kleinFourMap_apply_zero_one, h₂]
+    · rw [kleinFourMap_apply_one_zero, h₁]
+    · rw [kleinFourMap_apply_one_one, h₃]
+
+@[simp]
+theorem kleinFourIsometryOfGenerators_apply {A : Type*} [AddCommGroup A]
+    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod 2 × ZMod 2 ≃+ A)
+    (h₁ : r (e (1, 0)) = α) (h₂ : r (e (0, 1)) = β) (h₃ : r (e (1, 1)) = α + β + γ)
+    (x : ZMod 2 × ZMod 2) :
+    kleinFourIsometryOfGenerators α β γ h₄α h₄β h₂γ r e h₁ h₂ h₃ x = e x := (rfl)
+
+end FiniteQuadraticModule
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
@@ -380,11 +380,18 @@ theorem checkerboardVector_mem_dualCarrier :
   simp only [checkerboardVector_apply]
   rcases eq_or_ne i (checkerboardLastIndex n) with h | h <;> simp [h]
 
+omit [NeZero n] in
 /-- The spinor representative lies in the dual lattice. -/
 theorem checkerboardSpinor_mem_dualCarrier :
     checkerboardSpinor n ∈ (checkerboardLattice n).dualCarrier := by
-  rw [mem_checkerboardLattice_dualCarrier_iff]
-  exact ⟨fun i ↦ ⟨0, by simp⟩, 1, by norm_num⟩
+  rw [IntegralLattice.dualCarrier, LinearMap.BilinForm.mem_dualSubmodule]
+  intro x hx
+  obtain ⟨-, m, hm⟩ := (mem_checkerboardLattice_carrier_iff x).mp hx
+  refine Submodule.mem_one.mpr ⟨m, ?_⟩
+  rw [(checkerboardLattice n).isSymm.eq, checkerboardLattice_form_apply]
+  simp only [checkerboardSpinor_apply, ← Finset.sum_mul, hm]
+  ring_nf
+  rfl
 
 /-- The cospinor representative lies in the dual lattice. -/
 theorem checkerboardCospinor_mem_dualCarrier :
@@ -486,6 +493,7 @@ noncomputable def checkerboardVectorClass : (checkerboardLattice n).Discriminant
 noncomputable def checkerboardSpinorClass : (checkerboardLattice n).DiscriminantGroup :=
   Submodule.Quotient.mk ⟨checkerboardSpinor n, checkerboardSpinor_mem_dualCarrier⟩
 
+omit [NeZero n] in
 /-- The spinor class is represented by the Conway--Sloane spinor vector. -/
 theorem checkerboardSpinorClass_def :
     checkerboardSpinorClass n =
@@ -711,6 +719,7 @@ theorem discriminantQuadraticMap_checkerboardVectorClass :
   rw [checkerboardVectorClass, discriminantQuadraticMap_mk,
     checkerboardLattice_form_checkerboardVector_self]
 
+omit [NeZero n] in
 /-- **The spinor class has quadratic value `n / 8`.** -/
 @[simp]
 theorem discriminantQuadraticMap_checkerboardSpinorClass :
@@ -760,6 +769,7 @@ theorem two_zsmul_checkerboardVectorClass : (2 : ℤ) • checkerboardVectorClas
     split_ifs <;> ring
   · simp
 
+omit [NeZero n] in
 /-- **For even `n` the spinor class has order two**: the all-ones vector `2 s` has even
 coordinate sum. -/
 theorem two_zsmul_checkerboardSpinorClass_of_even (hn : Even n) :
@@ -800,6 +810,7 @@ private theorem mem_zmultiples_iff_eq_zero_or_eq_of_two_zsmul_eq_zero
     · exact (AddSubgroup.zmultiples a).zero_mem
     · exact AddSubgroup.mem_zmultiples_iff.mpr ⟨1, by rw [one_zsmul]⟩
 
+omit [NeZero n] in
 /-- For even `n`, the multiples of the spinor class are exactly zero and the spinor class. -/
 theorem mem_zmultiples_checkerboardSpinorClass_iff (hn : Even n)
     (x : (checkerboardLattice n).DiscriminantGroup) :
@@ -948,8 +959,10 @@ theorem discriminantPairing_checkerboardVectorClass_self :
       (checkerboardVectorClass n) = 0 := by
   rw [checkerboardVectorClass, discriminantPairing_mk,
     checkerboardLattice_form_checkerboardVector_self]
-  exact AddCircle.coe_eq_zero_of_eq_intCast 1 (by norm_num)
+  rw [AddCircle.coe_eq_zero_iff]
+  exact ⟨1, by norm_num⟩
 
+omit [NeZero n] in
 /-- **The spinor class has self-pairing `b(s, s) = n / 4`.** -/
 @[simp]
 theorem discriminantPairing_checkerboardSpinorClass_self :
@@ -978,9 +991,20 @@ two spinor classes carry the quarter-integral values `n / 8`. -/
     FiniteQuadraticModule :=
   FiniteQuadraticModule.kleinFour (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
     ((((n : ℚ) / 8 : ℚ)) : AddCircle (1 : ℚ)) (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
-    (AddCircle.zsmul_coe_eq_zero_of_mul_eq_intCast 4 2 (by norm_num))
-    (AddCircle.four_zsmul_coe_div_eight_eq_zero_of_even n hn)
-    (AddCircle.zsmul_coe_eq_zero_of_mul_eq_intCast 2 1 (by norm_num))
+    (by
+      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
+      exact ⟨2, by norm_num⟩)
+    (by
+      obtain ⟨k, hk⟩ := hn
+      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
+      refine ⟨k, ?_⟩
+      rw [hk]
+      push_cast
+      ring_nf
+      norm_cast)
+    (by
+      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
+      exact ⟨1, by norm_num⟩)
 
 omit [NeZero n] in
 /-- The first standard generator has quadratic value `1 / 2`. -/
@@ -988,8 +1012,9 @@ omit [NeZero n] in
 theorem checkerboardStandardQuadraticModule_quadratic_one_zero (hn : Even n) :
     (checkerboardStandardQuadraticModule n hn).quadratic (1, 0) =
       (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) := by
-  change FiniteQuadraticModule.kleinFourMap _ _ _ _ _ _ (1, 0) = _
-  rw [FiniteQuadraticModule.kleinFourMap_apply_one_zero]
+  unfold checkerboardStandardQuadraticModule
+  rw [FiniteQuadraticModule.kleinFour_quadratic,
+    FiniteQuadraticModule.kleinFourMap_apply_one_zero]
 
 omit [NeZero n] in
 /-- The second standard generator has quadratic value `n / 8`. -/
@@ -997,8 +1022,9 @@ omit [NeZero n] in
 theorem checkerboardStandardQuadraticModule_quadratic_zero_one (hn : Even n) :
     (checkerboardStandardQuadraticModule n hn).quadratic (0, 1) =
       (((n : ℚ) / 8 : ℚ) : AddCircle (1 : ℚ)) := by
-  change FiniteQuadraticModule.kleinFourMap _ _ _ _ _ _ (0, 1) = _
-  rw [FiniteQuadraticModule.kleinFourMap_apply_zero_one]
+  unfold checkerboardStandardQuadraticModule
+  rw [FiniteQuadraticModule.kleinFour_quadratic,
+    FiniteQuadraticModule.kleinFourMap_apply_zero_one]
 
 omit [NeZero n] in
 /-- The diagonal standard generator has quadratic value `n / 8`. -/
@@ -1006,9 +1032,13 @@ omit [NeZero n] in
 theorem checkerboardStandardQuadraticModule_quadratic_one_one (hn : Even n) :
     (checkerboardStandardQuadraticModule n hn).quadratic (1, 1) =
       (((n : ℚ) / 8 : ℚ) : AddCircle (1 : ℚ)) := by
-  change FiniteQuadraticModule.kleinFourMap _ _ _ _ _ _ (1, 1) = _
-  rw [FiniteQuadraticModule.kleinFourMap_apply_one_one, add_right_comm, ← AddCircle.coe_add]
-  rw [AddCircle.coe_eq_zero_of_eq_intCast 1 (by norm_num), zero_add]
+  unfold checkerboardStandardQuadraticModule
+  rw [FiniteQuadraticModule.kleinFour_quadratic,
+    FiniteQuadraticModule.kleinFourMap_apply_one_one, add_right_comm, ← AddCircle.coe_add]
+  have hhalf :
+      ((((1 : ℚ) / 2 : ℚ) + (1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 :=
+    (AddCircle.coe_eq_zero_iff (p := (1 : ℚ))).mpr ⟨1, by norm_num⟩
+  rw [hhalf, zero_add]
 
 omit [NeZero n] in
 /-- The two standard generators pair to `1 / 2`. -/
@@ -1016,8 +1046,9 @@ omit [NeZero n] in
 theorem checkerboardStandardQuadraticModule_pairing_one_zero_zero_one (hn : Even n) :
     (checkerboardStandardQuadraticModule n hn).toFiniteBilinearModule.pairing (1, 0) (0, 1) =
       (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) := by
-  change QuadraticMap.polar (FiniteQuadraticModule.kleinFourMap _ _ _ _ _ _) (1, 0) (0, 1) = _
-  rw [FiniteQuadraticModule.polar_kleinFourMap_one_zero_zero_one]
+  unfold checkerboardStandardQuadraticModule
+  rw [FiniteQuadraticModule.kleinFour_pairing,
+    FiniteQuadraticModule.polar_kleinFourMap_one_zero_zero_one]
 
 /-- **The standard model is isometric to the discriminant quadratic module of an even-rank
 checkerboard lattice**, by the identification carrying `(1, 0)` to the vector class and `(0, 1)`
@@ -1044,8 +1075,8 @@ noncomputable def checkerboardDiscriminantQuadraticIsometry (hn : Even n) :
       have hhalf :
           (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) +
               (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
-        rw [← AddCircle.coe_add]
-        exact AddCircle.coe_eq_zero_of_eq_intCast 1 (by norm_num)
+        rw [← AddCircle.coe_add, AddCircle.coe_eq_zero_iff]
+        exact ⟨1, by norm_num⟩
       rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_one,
         discriminantQuadraticMap_checkerboardCospinorClass,
         FiniteQuadraticModule.kleinFourMap_apply_one_one, add_right_comm, hhalf, zero_add])

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
@@ -999,11 +999,15 @@ two spinor classes carry the quarter-integral values `n / 8`. -/
   FiniteQuadraticModule.kleinFour (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
     ((((n : ℚ) / 8 : ℚ)) : AddCircle (1 : ℚ)) (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
     (by
+      -- `change` exposes the quotient-induced ℤ-action as multiplication in ℚ; rewriting
+      -- cannot cross this definitional representation boundary.
       change ((((4 : ℚ) * ((1 : ℚ) / 2)) : ℚ) : AddCircle (1 : ℚ)) = 0
       rw [AddCircle.coe_eq_zero_iff_mem_one]
       exact Submodule.mem_one.mpr ⟨2, by norm_num⟩)
     (four_zsmul_coe_spinorHalfNorm n hn)
     (by
+      -- `change` exposes the quotient-induced ℤ-action as multiplication in ℚ; rewriting
+      -- cannot cross this definitional representation boundary.
       change ((((2 : ℚ) * ((1 : ℚ) / 2)) : ℚ) : AddCircle (1 : ℚ)) = 0
       rw [AddCircle.coe_eq_zero_iff_mem_one]
       exact Submodule.mem_one.mpr ⟨1, by norm_num⟩)
@@ -1030,6 +1034,8 @@ noncomputable def checkerboardDiscriminantQuadraticIsometry (hn : Even n) :
       have hhalf :
           (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) +
               (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
+        -- `change` exposes addition induced by the quotient map as rational addition; rewriting
+        -- cannot cross this definitional representation boundary.
         change ((((1 : ℚ) / 2 + (1 : ℚ) / 2) : ℚ) : AddCircle (1 : ℚ)) = 0
         exact checkerboard_coe_eq_zero 1 (by norm_num)
       rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_one,

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.KleinFour
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Cardinality
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Quadratic
 
@@ -37,6 +38,14 @@ has order four; the form is positive definite, so the Gram determinant in any in
 `2s = v`, and is `(ℤ/2)²` when `n` is even.  The two spinor classes then carry the same quadratic
 value, and their mutual pairing is `b(s, c) = (n - 2) / 4`.
 
+For even `n` the file goes further and identifies the discriminant form itself, not only its group:
+the quadratic values `q(v) = 1 / 2` and `q(s) = q(c) = n / 8` together with the pairing
+`b(v, s) = 1 / 2` present it on `(ℤ/2)²`, and `checkerboardDiscriminantQuadraticIsometry` is an
+isometry of finite quadratic modules from that presented model onto `A_L`.  Group order alone does
+not determine this form: as `n` runs over the even residues modulo eight the model runs through
+Nikulin's `u₁` (for `n ≡ 0`), his `v₁` (for `n ≡ 4`), and the two forms with quarter-integral
+spinor values (for `n ≡ 2 mod 4`).
+
 The representatives are the ones fixed by Conway and Sloane, so that later glue calculations —
 in particular the enlargement of `D₈` to `E₈` — can reuse them without a change of
 representative.
@@ -55,6 +64,8 @@ representative.
   group of an odd-rank checkerboard lattice is `ℤ/4`.
 * `TauCeti.IntegralLattice.zmodTwoProdAddEquivCheckerboardDiscriminantGroup`: the discriminant
   group of an even-rank checkerboard lattice is `(ℤ/2)²`.
+* `TauCeti.IntegralLattice.checkerboardStandardQuadraticModule`: the presented `(ℤ/2)²` model of
+  the discriminant form of an even-rank checkerboard lattice.
 
 ## Main results
 
@@ -70,6 +81,14 @@ representative.
   `n / 8`.
 * `TauCeti.IntegralLattice.discriminantPairing_checkerboardSpinorClass_checkerboardCospinorClass`:
   the mutual pairing `(n - 2) / 4` of the spinor and cospinor classes.
+* `TauCeti.IntegralLattice.discriminantPairing_checkerboardVectorClass_checkerboardSpinorClass`,
+  `discriminantPairing_checkerboardVectorClass_self`,
+  `discriminantPairing_checkerboardSpinorClass_self`: the remaining pairing values `1 / 2`, `0`
+  and `n / 4`.
+* `TauCeti.IntegralLattice.checkerboardDiscriminantQuadraticIsometry`: for even `n`, the presented
+  model is isometric to the discriminant quadratic module.
+* `TauCeti.IntegralLattice.isNondegenerate_checkerboardStandardQuadraticModule`: the presented
+  model is nondegenerate.
 
 ## References
 
@@ -905,6 +924,139 @@ theorem zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_zero_one (hn : Ev
       checkerboardSpinorClass n := by
   rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup, AddEquiv.ofBijective_apply,
     AddMonoidHom.coprod_apply, map_zero, zero_add, checkerboardZModTwoHom_one]
+
+/-! ## The discriminant pairings -/
+
+/-- A rational number which is an integer vanishes in `ℚ/ℤ`. -/
+private theorem checkerboard_coe_eq_zero {q : ℚ} (m : ℤ) (h : q = (m : ℚ)) :
+    ((q : ℚ) : AddCircle (1 : ℚ)) = 0 := by
+  rw [AddCircle.coe_eq_zero_iff_mem_one]
+  exact Submodule.mem_one.mpr ⟨m, by simpa using h.symm⟩
+
+/-- **The vector class is bilinear-isotropic**: the ambient self-pairing `⟨v, v⟩ = 1` is an
+integer, so `b(v, v) = 0`. -/
+@[simp]
+theorem discriminantPairing_checkerboardVectorClass_self :
+    (checkerboardLattice n).discriminantPairing (checkerboardVectorClass n)
+      (checkerboardVectorClass n) = 0 := by
+  rw [checkerboardVectorClass, discriminantPairing_mk,
+    checkerboardLattice_form_checkerboardVector_self]
+  exact checkerboard_coe_eq_zero 1 (by norm_num)
+
+/-- **The spinor class has self-pairing `b(s, s) = n / 4`.** -/
+@[simp]
+theorem discriminantPairing_checkerboardSpinorClass_self :
+    (checkerboardLattice n).discriminantPairing (checkerboardSpinorClass n)
+      (checkerboardSpinorClass n) = (((n : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) := by
+  rw [checkerboardSpinorClass, discriminantPairing_mk,
+    checkerboardLattice_form_checkerboardSpinor_self]
+
+/-- **The vector and spinor classes pair to `1 / 2`.**  This is the value which distinguishes the
+`(ℤ/2)²` discriminant module from the orthogonal sum of two rank-one modules. -/
+@[simp]
+theorem discriminantPairing_checkerboardVectorClass_checkerboardSpinorClass :
+    (checkerboardLattice n).discriminantPairing (checkerboardVectorClass n)
+      (checkerboardSpinorClass n) = (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) := by
+  rw [checkerboardVectorClass, checkerboardSpinorClass, discriminantPairing_mk,
+    checkerboardLattice_form_checkerboardVector_checkerboardSpinor]
+
+/-! ## The discriminant quadratic module of an even-rank checkerboard lattice -/
+
+/-- The class of `1 / 2` in `ℚ/ℤ` doubles to zero. -/
+theorem coe_half_add_coe_half :
+    (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) + (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
+  -- Expand the sum through the quotient map `ℚ → ℚ/ℤ`.
+  change ((((1 : ℚ) / 2 + (1 : ℚ) / 2) : ℚ) : AddCircle (1 : ℚ)) = 0
+  exact checkerboard_coe_eq_zero 1 (by norm_num)
+
+/-- The class of `1 / 2` in `ℚ/ℤ` is two-torsion. -/
+theorem two_zsmul_coe_half :
+    (2 : ℤ) • (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
+  rw [two_zsmul, coe_half_add_coe_half]
+
+/-- The class of `1 / 2` in `ℚ/ℤ` is in particular four-torsion, as the parameters of a
+`(ℤ/2)²` quadratic module must be. -/
+theorem four_zsmul_coe_half :
+    (4 : ℤ) • (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
+  have hfour : (4 : ℤ) = 2 * 2 := by norm_num
+  rw [hfour, mul_smul, two_zsmul_coe_half, smul_zero]
+
+omit [NeZero n] in
+/-- **The spinor half-norm `n / 8` is four-torsion in `ℚ/ℤ` when `n` is even.**  This is exactly
+what makes the discriminant form of an even-rank checkerboard lattice a quadratic module on
+`(ℤ/2)²`. -/
+theorem four_zsmul_coe_spinorHalfNorm (hn : Even n) :
+    (4 : ℤ) • ((((n : ℚ) / 8 : ℚ)) : AddCircle (1 : ℚ)) = 0 := by
+  obtain ⟨k, hk⟩ := hn
+  -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
+  change ((((4 : ℚ) * ((n : ℚ) / 8)) : ℚ) : AddCircle (1 : ℚ)) = 0
+  refine checkerboard_coe_eq_zero (k : ℤ) ?_
+  rw [hk]
+  push_cast
+  ring
+
+/-- The even-rank identification sends the diagonal generator of `(ℤ/2)²` to the cospinor
+class. -/
+@[simp]
+theorem zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_one (hn : Even n) :
+    zmodTwoProdAddEquivCheckerboardDiscriminantGroup n hn (1, 1) =
+      checkerboardCospinorClass n := by
+  have hsplit : ((1 : ZMod 2), (1 : ZMod 2)) =
+      ((1 : ZMod 2), (0 : ZMod 2)) + ((0 : ZMod 2), (1 : ZMod 2)) := by
+    rw [Prod.mk_add_mk, add_zero, zero_add]
+  rw [hsplit, map_add, zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_zero,
+    zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_zero_one,
+    checkerboardVectorClass_add_checkerboardSpinorClass]
+
+/-- **The standard `(ℤ/2)²` model of the even-rank checkerboard discriminant form**: the vector
+class has quadratic value `1 / 2`, either spinor class has `n / 8`, and the vector and spinor
+classes pair to `1 / 2`.
+
+For `n ≡ 0 mod 8` this is Nikulin's `u₁`, for `n ≡ 4 mod 8` it is `v₁`, and for `n ≡ 2 mod 4` the
+two spinor classes carry the quarter-integral values `n / 8`. -/
+@[expose] noncomputable def checkerboardStandardQuadraticModule (hn : Even n) :
+    FiniteQuadraticModule :=
+  FiniteQuadraticModule.kleinFour (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
+    ((((n : ℚ) / 8 : ℚ)) : AddCircle (1 : ℚ)) (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
+    four_zsmul_coe_half (four_zsmul_coe_spinorHalfNorm n hn)
+    two_zsmul_coe_half
+
+/-- **The standard model is isometric to the discriminant quadratic module of an even-rank
+checkerboard lattice**, by the identification carrying `(1, 0)` to the vector class and `(0, 1)`
+to the spinor class.
+
+This is the `Dₙ` row of the ADE table for even `n`: not only is the discriminant group `(ℤ/2)²`,
+its quadratic form is the displayed one. -/
+noncomputable def checkerboardDiscriminantQuadraticIsometry (hn : Even n) :
+    FiniteQuadraticModule.Isometry (checkerboardStandardQuadraticModule n hn)
+      ((checkerboardLattice n).discriminantQuadraticModule (isEven_checkerboardLattice n)) :=
+  FiniteQuadraticModule.kleinFourIsometryOfGenerators _ _ _ _ _ _
+    ((checkerboardLattice n).discriminantQuadraticMap (isEven_checkerboardLattice n))
+    (zmodTwoProdAddEquivCheckerboardDiscriminantGroup n hn)
+    (by
+      rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_zero,
+        discriminantQuadraticMap_checkerboardVectorClass])
+    (by
+      rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_zero_one,
+        discriminantQuadraticMap_checkerboardSpinorClass])
+    (by
+      rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_one,
+        discriminantQuadraticMap_checkerboardCospinorClass, add_right_comm,
+        coe_half_add_coe_half, zero_add])
+
+/-- The even-rank quadratic isometry acts through the discriminant-group equivalence. -/
+@[simp]
+theorem checkerboardDiscriminantQuadraticIsometry_apply (hn : Even n) (x : ZMod 2 × ZMod 2) :
+    checkerboardDiscriminantQuadraticIsometry n hn x =
+      zmodTwoProdAddEquivCheckerboardDiscriminantGroup n hn x :=
+  FiniteQuadraticModule.kleinFourIsometryOfGenerators_apply _ _ _ _ _ _ _ _ _ _ _ x
+
+/-- **The standard `(ℤ/2)²` model is nondegenerate**, since the discriminant form of a
+nondegenerate lattice is. -/
+theorem isNondegenerate_checkerboardStandardQuadraticModule (hn : Even n) :
+    (checkerboardStandardQuadraticModule n hn).IsNondegenerate :=
+  ((checkerboardDiscriminantQuadraticIsometry n hn).isNondegenerate_iff).mpr
+    (isNondegenerate_discriminantQuadraticModule _ _)
 
 end IntegralLattice
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
@@ -951,8 +951,7 @@ theorem discriminantPairing_checkerboardSpinorClass_self :
   rw [checkerboardSpinorClass, discriminantPairing_mk,
     checkerboardLattice_form_checkerboardSpinor_self]
 
-/-- **The vector and spinor classes pair to `1 / 2`.**  This is the value which distinguishes the
-`(ℤ/2)²` discriminant module from the orthogonal sum of two rank-one modules. -/
+/-- **The vector and spinor classes pair to `1 / 2`.** -/
 @[simp]
 theorem discriminantPairing_checkerboardVectorClass_checkerboardSpinorClass :
     (checkerboardLattice n).discriminantPairing (checkerboardVectorClass n)
@@ -961,25 +960,6 @@ theorem discriminantPairing_checkerboardVectorClass_checkerboardSpinorClass :
     checkerboardLattice_form_checkerboardVector_checkerboardSpinor]
 
 /-! ## The discriminant quadratic module of an even-rank checkerboard lattice -/
-
-/-- The class of `1 / 2` in `ℚ/ℤ` doubles to zero. -/
-theorem coe_half_add_coe_half :
-    (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) + (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
-  -- Expand the sum through the quotient map `ℚ → ℚ/ℤ`.
-  change ((((1 : ℚ) / 2 + (1 : ℚ) / 2) : ℚ) : AddCircle (1 : ℚ)) = 0
-  exact checkerboard_coe_eq_zero 1 (by norm_num)
-
-/-- The class of `1 / 2` in `ℚ/ℤ` is two-torsion. -/
-theorem two_zsmul_coe_half :
-    (2 : ℤ) • (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
-  rw [two_zsmul, coe_half_add_coe_half]
-
-/-- The class of `1 / 2` in `ℚ/ℤ` is in particular four-torsion, as the parameters of a
-`(ℤ/2)²` quadratic module must be. -/
-theorem four_zsmul_coe_half :
-    (4 : ℤ) • (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
-  have hfour : (4 : ℤ) = 2 * 2 := by norm_num
-  rw [hfour, mul_smul, two_zsmul_coe_half, smul_zero]
 
 omit [NeZero n] in
 /-- **The spinor half-norm `n / 8` is four-torsion in `ℚ/ℤ` when `n` is even.**  This is exactly
@@ -1018,8 +998,15 @@ two spinor classes carry the quarter-integral values `n / 8`. -/
     FiniteQuadraticModule :=
   FiniteQuadraticModule.kleinFour (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
     ((((n : ℚ) / 8 : ℚ)) : AddCircle (1 : ℚ)) (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
-    four_zsmul_coe_half (four_zsmul_coe_spinorHalfNorm n hn)
-    two_zsmul_coe_half
+    (by
+      change ((((4 : ℚ) * ((1 : ℚ) / 2)) : ℚ) : AddCircle (1 : ℚ)) = 0
+      rw [AddCircle.coe_eq_zero_iff_mem_one]
+      exact Submodule.mem_one.mpr ⟨2, by norm_num⟩)
+    (four_zsmul_coe_spinorHalfNorm n hn)
+    (by
+      change ((((2 : ℚ) * ((1 : ℚ) / 2)) : ℚ) : AddCircle (1 : ℚ)) = 0
+      rw [AddCircle.coe_eq_zero_iff_mem_one]
+      exact Submodule.mem_one.mpr ⟨1, by norm_num⟩)
 
 /-- **The standard model is isometric to the discriminant quadratic module of an even-rank
 checkerboard lattice**, by the identification carrying `(1, 0)` to the vector class and `(0, 1)`
@@ -1040,9 +1027,14 @@ noncomputable def checkerboardDiscriminantQuadraticIsometry (hn : Even n) :
       rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_zero_one,
         discriminantQuadraticMap_checkerboardSpinorClass])
     (by
+      have hhalf :
+          (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) +
+              (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
+        change ((((1 : ℚ) / 2 + (1 : ℚ) / 2) : ℚ) : AddCircle (1 : ℚ)) = 0
+        exact checkerboard_coe_eq_zero 1 (by norm_num)
       rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_one,
         discriminantQuadraticMap_checkerboardCospinorClass, add_right_comm,
-        coe_half_add_coe_half, zero_add])
+        hhalf, zero_add])
 
 /-- The even-rank quadratic isometry acts through the discriminant-group equivalence. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean
@@ -925,13 +925,20 @@ theorem zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_zero_one (hn : Ev
   rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup, AddEquiv.ofBijective_apply,
     AddMonoidHom.coprod_apply, map_zero, zero_add, checkerboardZModTwoHom_one]
 
-/-! ## The discriminant pairings -/
+/-- The even-rank identification sends the diagonal generator of `(ℤ/2)²` to the cospinor
+class. -/
+@[simp]
+theorem zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_one (hn : Even n) :
+    zmodTwoProdAddEquivCheckerboardDiscriminantGroup n hn (1, 1) =
+      checkerboardCospinorClass n := by
+  have hsplit : ((1 : ZMod 2), (1 : ZMod 2)) =
+      ((1 : ZMod 2), (0 : ZMod 2)) + ((0 : ZMod 2), (1 : ZMod 2)) := by
+    rw [Prod.mk_add_mk, add_zero, zero_add]
+  rw [hsplit, map_add, zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_zero,
+    zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_zero_one,
+    checkerboardVectorClass_add_checkerboardSpinorClass]
 
-/-- A rational number which is an integer vanishes in `ℚ/ℤ`. -/
-private theorem checkerboard_coe_eq_zero {q : ℚ} (m : ℤ) (h : q = (m : ℚ)) :
-    ((q : ℚ) : AddCircle (1 : ℚ)) = 0 := by
-  rw [AddCircle.coe_eq_zero_iff_mem_one]
-  exact Submodule.mem_one.mpr ⟨m, by simpa using h.symm⟩
+/-! ## The discriminant pairings -/
 
 /-- **The vector class is bilinear-isotropic**: the ambient self-pairing `⟨v, v⟩ = 1` is an
 integer, so `b(v, v) = 0`. -/
@@ -941,7 +948,7 @@ theorem discriminantPairing_checkerboardVectorClass_self :
       (checkerboardVectorClass n) = 0 := by
   rw [checkerboardVectorClass, discriminantPairing_mk,
     checkerboardLattice_form_checkerboardVector_self]
-  exact checkerboard_coe_eq_zero 1 (by norm_num)
+  exact AddCircle.coe_eq_zero_of_eq_intCast 1 (by norm_num)
 
 /-- **The spinor class has self-pairing `b(s, s) = n / 4`.** -/
 @[simp]
@@ -961,56 +968,56 @@ theorem discriminantPairing_checkerboardVectorClass_checkerboardSpinorClass :
 
 /-! ## The discriminant quadratic module of an even-rank checkerboard lattice -/
 
-omit [NeZero n] in
-/-- **The spinor half-norm `n / 8` is four-torsion in `ℚ/ℤ` when `n` is even.**  This is exactly
-what makes the discriminant form of an even-rank checkerboard lattice a quadratic module on
-`(ℤ/2)²`. -/
-theorem four_zsmul_coe_spinorHalfNorm (hn : Even n) :
-    (4 : ℤ) • ((((n : ℚ) / 8 : ℚ)) : AddCircle (1 : ℚ)) = 0 := by
-  obtain ⟨k, hk⟩ := hn
-  -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
-  change ((((4 : ℚ) * ((n : ℚ) / 8)) : ℚ) : AddCircle (1 : ℚ)) = 0
-  refine checkerboard_coe_eq_zero (k : ℤ) ?_
-  rw [hk]
-  push_cast
-  ring
-
-/-- The even-rank identification sends the diagonal generator of `(ℤ/2)²` to the cospinor
-class. -/
-@[simp]
-theorem zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_one (hn : Even n) :
-    zmodTwoProdAddEquivCheckerboardDiscriminantGroup n hn (1, 1) =
-      checkerboardCospinorClass n := by
-  have hsplit : ((1 : ZMod 2), (1 : ZMod 2)) =
-      ((1 : ZMod 2), (0 : ZMod 2)) + ((0 : ZMod 2), (1 : ZMod 2)) := by
-    rw [Prod.mk_add_mk, add_zero, zero_add]
-  rw [hsplit, map_add, zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_zero,
-    zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_zero_one,
-    checkerboardVectorClass_add_checkerboardSpinorClass]
-
 /-- **The standard `(ℤ/2)²` model of the even-rank checkerboard discriminant form**: the vector
 class has quadratic value `1 / 2`, either spinor class has `n / 8`, and the vector and spinor
 classes pair to `1 / 2`.
 
 For `n ≡ 0 mod 8` this is Nikulin's `u₁`, for `n ≡ 4 mod 8` it is `v₁`, and for `n ≡ 2 mod 4` the
 two spinor classes carry the quarter-integral values `n / 8`. -/
-@[expose] noncomputable def checkerboardStandardQuadraticModule (hn : Even n) :
+@[expose] noncomputable def checkerboardStandardQuadraticModule (n : ℕ) (hn : Even n) :
     FiniteQuadraticModule :=
   FiniteQuadraticModule.kleinFour (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
     ((((n : ℚ) / 8 : ℚ)) : AddCircle (1 : ℚ)) (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ))
-    (by
-      -- `change` exposes the quotient-induced ℤ-action as multiplication in ℚ; rewriting
-      -- cannot cross this definitional representation boundary.
-      change ((((4 : ℚ) * ((1 : ℚ) / 2)) : ℚ) : AddCircle (1 : ℚ)) = 0
-      rw [AddCircle.coe_eq_zero_iff_mem_one]
-      exact Submodule.mem_one.mpr ⟨2, by norm_num⟩)
-    (four_zsmul_coe_spinorHalfNorm n hn)
-    (by
-      -- `change` exposes the quotient-induced ℤ-action as multiplication in ℚ; rewriting
-      -- cannot cross this definitional representation boundary.
-      change ((((2 : ℚ) * ((1 : ℚ) / 2)) : ℚ) : AddCircle (1 : ℚ)) = 0
-      rw [AddCircle.coe_eq_zero_iff_mem_one]
-      exact Submodule.mem_one.mpr ⟨1, by norm_num⟩)
+    (AddCircle.zsmul_coe_eq_zero_of_mul_eq_intCast 4 2 (by norm_num))
+    (AddCircle.four_zsmul_coe_div_eight_eq_zero_of_even n hn)
+    (AddCircle.zsmul_coe_eq_zero_of_mul_eq_intCast 2 1 (by norm_num))
+
+omit [NeZero n] in
+/-- The first standard generator has quadratic value `1 / 2`. -/
+@[simp]
+theorem checkerboardStandardQuadraticModule_quadratic_one_zero (hn : Even n) :
+    (checkerboardStandardQuadraticModule n hn).quadratic (1, 0) =
+      (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) := by
+  change FiniteQuadraticModule.kleinFourMap _ _ _ _ _ _ (1, 0) = _
+  rw [FiniteQuadraticModule.kleinFourMap_apply_one_zero]
+
+omit [NeZero n] in
+/-- The second standard generator has quadratic value `n / 8`. -/
+@[simp]
+theorem checkerboardStandardQuadraticModule_quadratic_zero_one (hn : Even n) :
+    (checkerboardStandardQuadraticModule n hn).quadratic (0, 1) =
+      (((n : ℚ) / 8 : ℚ) : AddCircle (1 : ℚ)) := by
+  change FiniteQuadraticModule.kleinFourMap _ _ _ _ _ _ (0, 1) = _
+  rw [FiniteQuadraticModule.kleinFourMap_apply_zero_one]
+
+omit [NeZero n] in
+/-- The diagonal standard generator has quadratic value `n / 8`. -/
+@[simp]
+theorem checkerboardStandardQuadraticModule_quadratic_one_one (hn : Even n) :
+    (checkerboardStandardQuadraticModule n hn).quadratic (1, 1) =
+      (((n : ℚ) / 8 : ℚ) : AddCircle (1 : ℚ)) := by
+  change FiniteQuadraticModule.kleinFourMap _ _ _ _ _ _ (1, 1) = _
+  rw [FiniteQuadraticModule.kleinFourMap_apply_one_one, add_right_comm, ← AddCircle.coe_add]
+  rw [AddCircle.coe_eq_zero_of_eq_intCast 1 (by norm_num), zero_add]
+
+omit [NeZero n] in
+/-- The two standard generators pair to `1 / 2`. -/
+@[simp]
+theorem checkerboardStandardQuadraticModule_pairing_one_zero_zero_one (hn : Even n) :
+    (checkerboardStandardQuadraticModule n hn).toFiniteBilinearModule.pairing (1, 0) (0, 1) =
+      (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) := by
+  change QuadraticMap.polar (FiniteQuadraticModule.kleinFourMap _ _ _ _ _ _) (1, 0) (0, 1) = _
+  rw [FiniteQuadraticModule.polar_kleinFourMap_one_zero_zero_one]
 
 /-- **The standard model is isometric to the discriminant quadratic module of an even-rank
 checkerboard lattice**, by the identification carrying `(1, 0)` to the vector class and `(0, 1)`
@@ -1021,33 +1028,34 @@ its quadratic form is the displayed one. -/
 noncomputable def checkerboardDiscriminantQuadraticIsometry (hn : Even n) :
     FiniteQuadraticModule.Isometry (checkerboardStandardQuadraticModule n hn)
       ((checkerboardLattice n).discriminantQuadraticModule (isEven_checkerboardLattice n)) :=
-  FiniteQuadraticModule.kleinFourIsometryOfGenerators _ _ _ _ _ _
+  FiniteQuadraticModule.kleinFourIsometryOfGenerators
+    (FiniteQuadraticModule.kleinFourMap _ _ _ _ _ _)
     ((checkerboardLattice n).discriminantQuadraticMap (isEven_checkerboardLattice n))
     (zmodTwoProdAddEquivCheckerboardDiscriminantGroup n hn)
     (by
       rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_zero,
-        discriminantQuadraticMap_checkerboardVectorClass])
+        discriminantQuadraticMap_checkerboardVectorClass,
+        FiniteQuadraticModule.kleinFourMap_apply_one_zero])
     (by
       rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_zero_one,
-        discriminantQuadraticMap_checkerboardSpinorClass])
+        discriminantQuadraticMap_checkerboardSpinorClass,
+        FiniteQuadraticModule.kleinFourMap_apply_zero_one])
     (by
       have hhalf :
           (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) +
               (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) = 0 := by
-        -- `change` exposes addition induced by the quotient map as rational addition; rewriting
-        -- cannot cross this definitional representation boundary.
-        change ((((1 : ℚ) / 2 + (1 : ℚ) / 2) : ℚ) : AddCircle (1 : ℚ)) = 0
-        exact checkerboard_coe_eq_zero 1 (by norm_num)
+        rw [← AddCircle.coe_add]
+        exact AddCircle.coe_eq_zero_of_eq_intCast 1 (by norm_num)
       rw [zmodTwoProdAddEquivCheckerboardDiscriminantGroup_apply_one_one,
-        discriminantQuadraticMap_checkerboardCospinorClass, add_right_comm,
-        hhalf, zero_add])
+        discriminantQuadraticMap_checkerboardCospinorClass,
+        FiniteQuadraticModule.kleinFourMap_apply_one_one, add_right_comm, hhalf, zero_add])
 
 /-- The even-rank quadratic isometry acts through the discriminant-group equivalence. -/
 @[simp]
 theorem checkerboardDiscriminantQuadraticIsometry_apply (hn : Even n) (x : ZMod 2 × ZMod 2) :
     checkerboardDiscriminantQuadraticIsometry n hn x =
       zmodTwoProdAddEquivCheckerboardDiscriminantGroup n hn x :=
-  FiniteQuadraticModule.kleinFourIsometryOfGenerators_apply _ _ _ _ _ _ _ _ _ _ _ x
+  FiniteQuadraticModule.kleinFourIsometryOfGenerators_apply _ _ _ _ _ _ x
 
 /-- **The standard `(ℤ/2)²` model is nondegenerate**, since the discriminant form of a
 nondegenerate lattice is. -/


### PR DESCRIPTION
This PR identifies the discriminant form of the even-rank checkerboard lattice up to isometry, not merely its underlying group. `TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean` already proved that for even `n` the discriminant group of `Dₙ = {x ∈ ℤⁿ | ∑ xᵢ even}` is `(ℤ/2)²` and computed the quadratic values `q(v) = 1/2` and `q(s) = q(c) = n/8`, but it stopped at an `AddEquiv`; the roadmap's convention is explicit that "a module or additive equivalence without the form-preservation equation is not an isometry", and its `Dₙ` row asks to "calculate all pairings needed to identify the finite quadratic module up to isometry". This PR supplies the missing model and the isometry onto it, and records the remaining pairing values `b(v, v) = 0`, `b(s, s) = n/4` and `b(v, s) = 1/2`.

The milestone is Layer 5 of `TauCetiRoadmap/IntegralLattices/README.md`, the ADE table row `` `D_n`, even `n≥4` | `(ℤ/2)²` | vector and the two spinor classes are the three nonzero classes; `q(v)=1/2` and `q(s)=q(c)=n/8` ``, together with the layer's standing requirement that "group order alone is not enough to distinguish the even-`D_n` quadratic forms". After this PR the `Dₙ` even row is closed as an isometry statement; what remains on that row's odd-`n` companion, and on the `A_n` row, is the cyclic `ℤ/(n+1)`- and `ℤ/4`-model analogue, which needs the rank-one presented module currently living as private declarations inside `RootLattice/TypeE.lean` to be promoted to shared API — a prerequisite refactor, so a separate PR.

`TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean` (new, 237 lines) adds the Layer-3 construction the row needs: for `α β γ : ℚ/ℤ` with `4α = 4β = 2γ = 0`, `FiniteQuadraticModule.kleinFour α β γ` is the finite quadratic module on `ZMod 2 × ZMod 2` with `q(1,0) = α`, `q(0,1) = β`, `q(1,1) = α + β + γ` and `b((1,0),(0,1)) = γ`. It is built as an honest quotient rather than a `ZMod.val` formula: the parameters give a `ℤ`-bilinear map on `ℤ × ℤ` whose quadratic map is `(m,k) ↦ m²α + k²β + mkγ`, the three torsion hypotheses are exactly what puts the kernel of `ℤ × ℤ → (ℤ/2)²` inside its radical, and Mathlib's `QuadraticMap.lift` and `LinearMap.quotKerEquivOfSurjective` descend it. `kleinFourIsometryOfGenerators` then turns an additive equivalence matching the three values into an isometry, by checking the four elements one by one; it is stated against a bare quadratic map so that it applies to a discriminant form before that form is packaged as a `FiniteQuadraticModule`.

`TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD.lean` (+152 lines) instantiates this at `α = γ = 1/2`, `β = n/8`, which is admissible exactly because `n` is even, and proves `checkerboardDiscriminantQuadraticIsometry`: the presented model is isometric to `(checkerboardLattice n).discriminantQuadraticModule`, carrying `(1,0)` to the vector class and `(0,1)` to the spinor class. The consistency check that makes this non-vacuous is that the model's own pairing of its two generators, `γ = 1/2`, is the independently computed `b(v, s) = 1/2`, while `q(1,1) = 1/2 + n/8 + 1/2 = n/8` is the independently computed `q(c)`. Nondegeneracy of the model follows by transport. As `n` runs over the even residues modulo eight the model is Nikulin's `u₁` for `n ≡ 0`, his `v₁` for `n ≡ 4`, and the two forms with quarter-integral spinor values for `n ≡ 2 mod 4` — four isometry classes sharing one group, which is the point of the roadmap's warning.

Nothing was vendored from Mathlib. `RootLattice/TypeE.lean` carries a private rank-one analogue of this construction (`cyclicQuadraticMap`, on `ZMod n`); it is not reused here because it is private and, being rank one, does not produce the `(ℤ/2)²` carrier. Unifying the two into a single presented-module API is the refactor named above.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"even-checkerboard-discriminant-quadratic-module"}-->

🤖 Prepared with Claude Code
