### PR TITLE
ci: publish merge-group cache before landing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,9 @@ jobs:
           LAKE_NO_CACHE: "true"
         run: lake build
 
-      # Main is the sole publisher. PR and merge-group builds restore these trusted snapshots
-      # but never save, so candidate code cannot populate a cache consumed by later builds.
+      # Main and already-audited merge-group commits publish TauCeti's Lake artifacts through the
+      # same secret-isolated workflow. Ordinary PR heads remain restore-only and cannot populate
+      # a cache consumed by later builds.
       # GitHub cache keys are immutable; an exact restore needs no redundant save, while a
       # prefix restore is extended with the newly downloaded hashes under the exact current key.
       # Pruning is essential: without it, every prefix restore would carry all old pins forward
@@ -358,177 +359,19 @@ jobs:
           # burns CPU on both ends and saves nothing.
           compression-level: 0
 
-  # The only job that ever holds LAKE_CACHE_KEY. It checks out exactly one file and nothing
-  # else, and has no Lake workspace and no dependencies, so no code from this repository, and
-  # none from Mathlib either, runs anywhere in it: `lake cache put-staged` is documented as not
-  # configuring the workspace and therefore not executing arbitrary user code. Everything else
-  # it consumes arrives from the build job, whose every output code that landed on main could
-  # have chosen, so nothing from there is trusted without a check.
+  # Run the secret-bearing upload on a fresh runner through the same hardened publisher used
+  # by merge-group CI. Main publication remains a fallback: merge groups normally publish the
+  # exact commit before landing, while this covers human-owned changes and operational retries.
   publish-lake-cache:
     needs: build
     if: ${{ needs.build.outputs.staged == 'true' }}
-    runs-on: ubuntu-latest
-    # No GITHUB_TOKEN scopes at all: downloading an artifact from the same run uses the
-    # Actions runtime token, and nothing else here talks to the GitHub API.
-    permissions: {}
-    steps:
-      # Exactly one file, and deliberately not the one the build job reported. Which toolchain
-      # this job installs and runs decides which `lake` binary handles the key, so it must come
-      # from the repository rather than from a job that executed code which landed on main:
-      # that job can rewrite lean-toolchain on disk, or poison a later step through $GITHUB_ENV
-      # and $GITHUB_PATH, so anything it reports is attacker-chosen. lean-toolchain itself is a
-      # Lake pin: bump-guard only lets it move forward along leanprover/lean4 releases without a
-      # human, and the build job above already installed and ran whatever it names, so reading
-      # it here adds no trust that main's build did not already extend.
-      - name: Check out the toolchain pin, and nothing else
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: lean-toolchain
-          sparse-checkout-cone-mode: false
-
-      - name: Download the staged oleans
-        uses: actions/download-artifact@v4
-        with:
-          name: lake-cache-staging
-          path: ${{ runner.temp }}/lake-cache-staging
-
-      - name: Check the staged tree before pointing Lake at it
-        env:
-          STAGING: ${{ runner.temp }}/lake-cache-staging
-        run: |
-          # `lake cache put-staged` uploads `<staging dir>/<name>` for every artifact the
-          # mappings file names, and it parses a name as "<hash>.<everything after the first
-          # dot>" without checking that the join stays inside the staging directory. The job
-          # that produced this tree ran code that landed on main, so both the names and the
-          # tree are attacker-chosen: a name such as `0.art/../../../proc/self/environ` would
-          # otherwise have Lake read this job's environment, the key included, and PUT it
-          # into a publicly readable bucket. Artifact names are flat `<hash>.<ext>` files, so
-          # require exactly that, and require the tree to be a flat directory of regular files
-          # so no name can resolve through a symlink either.
-          if find "$STAGING" -mindepth 2 -print -quit | grep -q .; then
-            echo "::error::the staged tree is nested; expected a flat directory of artifacts"
-            exit 1
-          fi
-          if find "$STAGING" -mindepth 1 ! -type f -print -quit | grep -q .; then
-            echo "::error::the staged tree holds an entry that is not a regular file"
-            exit 1
-          fi
-          python3 - "$STAGING/outputs.jsonl" <<'PY'
-          import json, re, sys
-
-          # A Lake artifact name: a content hash, then dot-separated extension components.
-          NAME = re.compile(r"\A[0-9A-Za-z]+(\.[0-9A-Za-z]+)*\Z")
-
-          def check(value, lineno):
-              """Reject any string that is not a plain artifact name.
-
-              Lake reads artifact descriptors out of arbitrarily nested JSON, so recurse
-              over everything and hold every string to the same shape rather than trying
-              to predict which positions become file names.
-              """
-              if isinstance(value, str):
-                  if not NAME.match(value):
-                      sys.exit(f"::error::{path} line {lineno}: {value!r} is not a plain artifact name")
-              elif isinstance(value, list):
-                  for item in value:
-                      check(item, lineno)
-              elif isinstance(value, dict):
-                  for key, item in value.items():
-                      check(key, lineno)
-                      check(item, lineno)
-
-          path = sys.argv[1]
-          with open(path, encoding="utf-8") as handle:
-              for lineno, line in enumerate(handle, start=1):
-                  # The first line carries the map's schema version, not an artifact name.
-                  if lineno > 1:
-                      check(json.loads(line), lineno)
-          PY
-
-      - name: Install elan (pinned + checksum) and the pinned toolchain
-        id: toolchain
-        env:
-          ELAN_SHA256: df0b2b3a439961ffcbb3985214365ffe40f49bc871df04dff268c7d8e21ca8b2
-          ELAN_VER: v4.2.3
-          REPORTED: ${{ needs.build.outputs.reported-toolchain }}
-        run: |
-          TOOLCHAIN="$(cat lean-toolchain)"
-          # Refuse anything that is not a leanprover/lean4 release name. `elan toolchain
-          # install owner/repo:tag` fetches from that repository's releases, so an unconstrained
-          # name would choose which `lake` binary later handles the key. bump-guard enforces the
-          # same shape on the pin; this repeats it rather than relying on it.
-          case "$TOOLCHAIN" in
-            leanprover/lean4:[A-Za-z0-9]*) ;;
-            *) echo "::error::lean-toolchain names '$TOOLCHAIN', which is not a leanprover/lean4 release"; exit 1 ;;
-          esac
-          # The upload scope must be the toolchain the artifacts were actually built with. The
-          # pin is what the build job's elan resolved, so the two agree unless something moved
-          # underneath the build; say so rather than publish under a scope pr-build never reads.
-          if [ "$TOOLCHAIN" != "$REPORTED" ]; then
-            echo "::error::the build job built with '$REPORTED' but lean-toolchain pins '$TOOLCHAIN'"
-            exit 1
-          fi
-          # elan comes from a pinned leanprover/elan release verified by SHA-256, not from
-          # whatever the installer URL serves at the moment of the request. The next step hands
-          # LAKE_CACHE_KEY to a `lake` this elan selected, so an installer nothing here fixes
-          # would have moved the toolchain check above rather than closed it: constrain the
-          # toolchain NAME but not the elan that resolves it, and the choice just relocates.
-          # What this does not do is fix the bytes of the Lean release elan then downloads.
-          # `lean-toolchain` pins that release's name, not its contents, and elan offers no hook
-          # to verify the archive, so leanprover's release channel stays in this job's trust
-          # base exactly as it is in every other job here. Closing that would mean fetching and
-          # unpacking the release ourselves, or a verification hook from upstream; see
-          # https://github.com/TauCetiProject/TauCeti/issues/3725 for why the latter is the
-          # better bargain.
-          # scripts/test_elan_pin.py keeps the copies of the pin honest.
-          curl -sSL -H "Accept: application/octet-stream" \
-            "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz
-          echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -
-          tar -xzf elan.tar.gz elan-init
-          ./elan-init -y --default-toolchain none
-          rm -f elan.tar.gz elan-init
-          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
-          "$HOME/.elan/bin/elan" toolchain install "$TOOLCHAIN"
-          printf 'name=%s\n' "$TOOLCHAIN" >> "$GITHUB_OUTPUT"
-
-      - name: Publish the staged oleans to the Lake cache
-        env:
-          # Passed under non-LAKE_ names so Lake never sees the deprecated endpoint
-          # environment variables; we hand it the endpoints through a `--service` config.
-          S3_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
-          S3_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
-          LAKE_CACHE_KEY_RAW: ${{ secrets.LAKE_CACHE_KEY }}
-          # The pinned toolchain, read from the repository above. Lake takes ELAN_TOOLCHAIN as
-          # its `Env.toolchain`, which is also the string it scopes uploads by, and elan's `lake`
-          # shim takes it as which toolchain to run.
-          ELAN_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}
-          STAGING: ${{ runner.temp }}/lake-cache-staging
-        run: |
-          if [ -z "$LAKE_CACHE_KEY_RAW" ]; then
-            echo "::notice::the LAKE_CACHE_KEY secret is not set; the staged oleans were not published"
-            exit 0
-          fi
-          # curl --user wants "<ACCESS_KEY_ID>:<SECRET>"; trim trailing whitespace and mask it
-          # so it never lands in the log. The trim is bash parameter expansion rather than a
-          # pipe through `sed`, so no external program sits between the secret and Lake.
-          KEY="$LAKE_CACHE_KEY_RAW"
-          KEY="${KEY%"${KEY##*[![:space:]]}"}"
-          echo "::add-mask::$KEY"; export LAKE_CACHE_KEY="$KEY"
-          # Define the authenticated S3 service in a Lake system config and select it with
-          # `--service` (the env-var form of endpoint config is deprecated).
-          CFG="$RUNNER_TEMP/lake-cache.toml"
-          cat > "$CFG" <<TOML
-          cache.defaultUploadService = "tauceti-r2"
-          [[cache.service]]
-          name = "tauceti-r2"
-          kind = "s3"
-          artifactEndpoint = "$S3_ARTIFACT_ENDPOINT"
-          revisionEndpoint = "$S3_REVISION_ENDPOINT"
-          TOML
-          export LAKE_CONFIG="$CFG"
-          # `--rev` names the commit the build job built, since there is no working tree to
-          # detect it from. That option, `--toolchain`, and the deliberately absent
-          # `--platform` reproduce byte for byte the scope `lake cache put` derived from the
-          # workspace, and so the scope pr-build's `lake cache get --service ... --repo` reads.
-          lake cache put-staged "$STAGING" --service tauceti-r2 \
-            --repo TauCetiProject/TauCeti --rev "$GITHUB_SHA" --toolchain "$ELAN_TOOLCHAIN"
+    permissions:
+      contents: read
+    uses: ./.github/workflows/publish-lake-cache.yml
+    with:
+      revision: ${{ github.sha }}
+      artifact-name: lake-cache-staging
+      reported-toolchain: ${{ needs.build.outputs.reported-toolchain }}
+      publication-required: false
+    secrets:
+      LAKE_CACHE_KEY: ${{ secrets.LAKE_CACHE_KEY }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -50,6 +50,12 @@ jobs:
   # `build` commit STATUS posted in the final step, not this job's auto-created check-run.
   sandboxed-build:
     runs-on: ubuntu-24.04
+    outputs:
+      status-sha: ${{ steps.pr.outputs.status_sha }}
+      build-state: ${{ steps.report.outputs.build-state }}
+      build-description: ${{ steps.report.outputs.build-description }}
+      publication-required: ${{ steps.report.outputs.publication-required }}
+      reported-toolchain: ${{ steps.cache_stage.outputs.toolchain }}
     env:
       LANDRUN_SHA256: 645178e3239cd33760560834e50efea0864183a2a8a82faf199760dffee6dd71
       LANDRUN_VER: v0.1.14
@@ -61,6 +67,9 @@ jobs:
       LAKE_ARTIFACT_CACHE: ""
       LAKE_RESTORE_ARTIFACTS: ""
       LAKE_CACHE_DIR: ""
+      # Enabled only for a merge-group commit when the upload service is configured. The
+      # sandbox then stages the fully audited root-package outputs for the isolated publisher.
+      STAGE_LAKE_CACHE: ""
     steps:
       # --- Trusted setup: no PR code runs until the landrun build phase ---
       - name: Resolve PR head
@@ -553,8 +562,8 @@ jobs:
           fi
 
       # Restore only Mathlib's compressed, content-addressed `.ltar` download store from a
-      # trusted main publisher. This workflow is restore-only: neither fork PRs nor merge-group
-      # candidates can publish cache contents. For a validated pin bump the expressions hash the
+      # trusted main publisher. This workflow never writes that GitHub Actions cache. For a
+      # validated pin bump the expressions hash the
       # already-overlaid files under base/, so an exact new-pin snapshot is preferred. A
       # Mathlib-only bump can fall back to the newest same-toolchain main snapshot; a toolchain
       # bump misses both keys and refetches from Mathlib's server. `lake exe cache get` below
@@ -638,6 +647,8 @@ jobs:
         env:
           PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+          S3_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
+          S3_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
         run: |
           if [ -n "$PUBLIC_ARTIFACT_ENDPOINT" ] && [ -n "$PUBLIC_REVISION_ENDPOINT" ]; then
             {
@@ -649,6 +660,17 @@ jobs:
             echo "::notice::Lake artifact cache enabled — will fetch TauCeti's oleans and build incrementally"
           else
             echo "::notice::Lake artifact cache not configured — building TauCeti/ from scratch (set the LAKE_CACHE_*_PUBLIC repo variables to enable)"
+          fi
+          # A merge-group head is the commit GitHub will land. Stage its outputs after every
+          # sandboxed audit so the required build can wait for publication. A changed lakefile
+          # is deliberately excluded at this layer: this workflow still builds against trusted
+          # base config until the exact-head change lands, so its outputs would not describe the
+          # candidate revision's configuration.
+          if [ "${{ github.event_name }}" = "merge_group" ] \
+             && [ "${HUMAN_LAKEFILE:-}" != "1" ] \
+             && [ -n "$S3_ARTIFACT_ENDPOINT" ] && [ -n "$S3_REVISION_ENDPOINT" ]; then
+            echo "STAGE_LAKE_CACHE=1" >> "$GITHUB_ENV"
+            echo "::notice::merge-group outputs will be staged for pre-landing publication"
           fi
 
       # Restore TauCeti's own root-package oleans from the public Lake cache. The fetch logic
@@ -696,10 +718,35 @@ jobs:
             --rox "$PWD/base" --rw "$PWD/base/.lake" \
             --env PATH --env HOME --env CI \
             --env LAKE_NO_CACHE --env LAKE_ARTIFACT_CACHE --env LAKE_RESTORE_ARTIFACTS --env LAKE_CACHE_DIR \
-            --env WATCHDOG_TOOLCHAIN \
+            --env WATCHDOG_TOOLCHAIN --env STAGE_LAKE_CACHE \
             -- bash -euxo pipefail -c 'cd base && exec bash scripts/sandbox-build.sh'
 
+      - name: Prepare merge-group cache artifact metadata
+        id: cache_stage
+        if: ${{ github.event_name == 'merge_group' && env.STAGE_LAKE_CACHE == '1' && steps.build.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          test -s base/.lake/cache-staging/outputs.jsonl
+          TOOLCHAIN="$(cat base/lean-toolchain)"
+          case "$TOOLCHAIN" in
+            leanprover/lean4:[A-Za-z0-9]*) ;;
+            *) echo "::error::invalid toolchain pin '$TOOLCHAIN'"; exit 1 ;;
+          esac
+          printf 'toolchain=%s\n' "$TOOLCHAIN" >> "$GITHUB_OUTPUT"
+          echo 'staged=true' >> "$GITHUB_OUTPUT"
+
+      - name: Hand the merge-group oleans to the isolated publisher
+        if: ${{ steps.cache_stage.outputs.staged == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: lake-cache-staging-${{ steps.pr.outputs.status_sha }}
+          path: base/.lake/cache-staging
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
       - name: Report build and bump-guard statuses to the PR head commit
+        id: report
         if: always()
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
@@ -797,7 +844,20 @@ jobs:
           else
             state=failure; desc="sandboxed build, audit, or simp-NF lint failed"
           fi
-          post_status build "$state" "$desc"
+          {
+            echo "build-state=$state"
+            echo "build-description=$desc"
+            if [ "${{ github.event_name }}" = "merge_group" ] && [ "${STAGE_LAKE_CACHE:-}" = "1" ]; then
+              echo 'publication-required=true'
+            else
+              echo 'publication-required=false'
+            fi
+          } >> "$GITHUB_OUTPUT"
+          # PR heads are reported immediately. A merge-group head is reported by the finalizer
+          # job below, after its exact revision map has reached the public cache endpoint.
+          if [ "${{ github.event_name }}" != "merge_group" ]; then
+            post_status build "$state" "$desc"
+          fi
 
           # scope: the merge-policy verdict, posted as its OWN status so a policy issue never hides the
           # build result (the bug this split fixes — an out-of-scope PR used to post its "human review"
@@ -833,3 +893,70 @@ jobs:
             exit 1
           fi
           [ "$state" = "success" ]
+
+  # Only an already-audited merge-group commit may publish. The reusable workflow runs on a
+  # fresh runner, checks out only that commit's toolchain pin, and is the sole holder of the key.
+  publish-merge-group-cache:
+    needs: sandboxed-build
+    if: ${{ always() && needs.sandboxed-build.result == 'success' && needs.sandboxed-build.outputs.publication-required == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/publish-lake-cache.yml
+    with:
+      revision: ${{ needs.sandboxed-build.outputs.status-sha }}
+      artifact-name: lake-cache-staging-${{ needs.sandboxed-build.outputs.status-sha }}
+      reported-toolchain: ${{ needs.sandboxed-build.outputs.reported-toolchain }}
+      publication-required: true
+    secrets:
+      LAKE_CACHE_KEY: ${{ secrets.LAKE_CACHE_KEY }}
+
+  # The merge queue's required `build` status is posted only here. In a configured installation,
+  # green therefore means both that the combined commit passed every sandboxed audit and that a
+  # fresh checkout can fetch its exact output map from the public cache before GitHub lands it.
+  finalize-merge-group-build:
+    needs: [sandboxed-build, publish-merge-group-cache]
+    if: ${{ always() && github.event_name == 'merge_group' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      STATUS_SHA: ${{ needs.sandboxed-build.outputs.status-sha }}
+      BUILD_JOB_RESULT: ${{ needs.sandboxed-build.result }}
+      BUILD_STATE: ${{ needs.sandboxed-build.outputs.build-state }}
+      BUILD_DESCRIPTION: ${{ needs.sandboxed-build.outputs.build-description }}
+      PUBLICATION_REQUIRED: ${{ needs.sandboxed-build.outputs.publication-required }}
+      PUBLISH_JOB_RESULT: ${{ needs.publish-merge-group-cache.result }}
+      PUBLISHED: ${{ needs.publish-merge-group-cache.outputs.published }}
+    steps:
+      - name: Post the terminal merge-group build status
+        run: |
+          set -uo pipefail
+          if [ "$BUILD_JOB_RESULT" != "success" ] || [ "$BUILD_STATE" != "success" ]; then
+            state=failure
+            description="${BUILD_DESCRIPTION:-sandboxed merge-group build did not complete}"
+          elif [ "$PUBLICATION_REQUIRED" = "true" ] \
+               && { [ "$PUBLISH_JOB_RESULT" != "success" ] || [ "$PUBLISHED" != "true" ]; }; then
+            state=failure
+            description="build passed, but its exact Lake cache was not published"
+          elif [ "$PUBLICATION_REQUIRED" = "true" ]; then
+            state=success
+            description="sandboxed build passed; exact revision cache is public"
+          else
+            state=success
+            description="sandboxed build passed (cache upload is not configured)"
+          fi
+
+          posted=0
+          for attempt in 1 2 3; do
+            if gh api -X POST "repos/${{ github.repository }}/statuses/$STATUS_SHA" \
+                 -f state="$state" -f context=build -f description="$description" \
+                 -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"; then
+              posted=1
+              break
+            fi
+            echo "::warning::posting the build status failed (attempt $attempt/3)"
+            [ "$attempt" = 3 ] || sleep $((attempt * 5))
+          done
+          [ "$posted" = 1 ] || { echo "::error::could not post the merge-group build status"; exit 1; }
+          [ "$state" = success ]

--- a/.github/workflows/publish-lake-cache.yml
+++ b/.github/workflows/publish-lake-cache.yml
@@ -1,0 +1,208 @@
+name: publish-lake-cache
+
+# Secret-isolated Lake cache publisher shared by main CI and merge-group CI. The caller may
+# execute arbitrary Lean code while producing the staging artifact, so this workflow treats the
+# entire artifact and every reported value as hostile. It checks out only the toolchain pin at the
+# immutable revision being published; no project or dependency code runs in the job that receives
+# LAKE_CACHE_KEY.
+
+on:
+  workflow_call:
+    inputs:
+      revision:
+        description: Immutable TauCeti revision whose output map is being published
+        required: true
+        type: string
+      artifact-name:
+        description: Name of the staging artifact produced by the caller
+        required: true
+        type: string
+      reported-toolchain:
+        description: Toolchain used by the staging build (cross-checked against the revision)
+        required: true
+        type: string
+      publication-required:
+        description: Fail rather than skip if cache upload configuration is absent
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      published:
+        description: Whether the revision map was uploaded and observed on the public endpoint
+        value: ${{ jobs.publish.outputs.published }}
+    secrets:
+      LAKE_CACHE_KEY:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.upload.outputs.published }}
+    steps:
+      # Exactly one repository file is admitted to the secret-bearing job. Which toolchain this
+      # job installs decides which `lake` handles the upload key, so the pin is read independently
+      # from the immutable revision rather than trusted from the staging build.
+      - name: Check out the toolchain pin, and nothing else
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.revision }}
+          sparse-checkout: lean-toolchain
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Download the staged oleans
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ runner.temp }}/lake-cache-staging
+
+      - name: Check the staged tree before pointing Lake at it
+        env:
+          STAGING: ${{ runner.temp }}/lake-cache-staging
+        run: |
+          set -euo pipefail
+          # `lake cache put-staged` joins artifact names from outputs.jsonl to STAGING. The
+          # producer ran arbitrary Lean code, so reject nesting, symlinks, path components, and
+          # every other name that could make Lake read outside this flat data-only directory.
+          if find "$STAGING" -mindepth 2 -print -quit | grep -q .; then
+            echo "::error::the staged tree is nested; expected a flat directory of artifacts"
+            exit 1
+          fi
+          if find "$STAGING" -mindepth 1 ! -type f -print -quit | grep -q .; then
+            echo "::error::the staged tree holds an entry that is not a regular file"
+            exit 1
+          fi
+          python3 - "$STAGING/outputs.jsonl" <<'PY'
+          import json, re, sys
+
+          NAME = re.compile(r"\A[0-9A-Za-z]+(\.[0-9A-Za-z]+)*\Z")
+
+          def check(value, lineno):
+              if isinstance(value, str):
+                  if not NAME.match(value):
+                      sys.exit(
+                          f"::error::{path} line {lineno}: {value!r} is not a plain artifact name"
+                      )
+              elif isinstance(value, list):
+                  for item in value:
+                      check(item, lineno)
+              elif isinstance(value, dict):
+                  for key, item in value.items():
+                      check(key, lineno)
+                      check(item, lineno)
+
+          path = sys.argv[1]
+          with open(path, encoding="utf-8") as handle:
+              lines = 0
+              for lineno, line in enumerate(handle, start=1):
+                  lines = lineno
+                  if lineno > 1:
+                      check(json.loads(line), lineno)
+          if lines < 2:
+              sys.exit(f"::error::{path} contains no root-package output mappings")
+          PY
+
+      - name: Install elan (pinned + checksum) and the pinned toolchain
+        id: toolchain
+        env:
+          ELAN_SHA256: df0b2b3a439961ffcbb3985214365ffe40f49bc871df04dff268c7d8e21ca8b2
+          ELAN_VER: v4.2.3
+          REPORTED: ${{ inputs.reported-toolchain }}
+        run: |
+          set -euo pipefail
+          TOOLCHAIN="$(cat lean-toolchain)"
+          case "$TOOLCHAIN" in
+            leanprover/lean4:[A-Za-z0-9]*) ;;
+            *) echo "::error::lean-toolchain names '$TOOLCHAIN', which is not a leanprover/lean4 release"; exit 1 ;;
+          esac
+          if [ "$TOOLCHAIN" != "$REPORTED" ]; then
+            echo "::error::the staging build used '$REPORTED' but the revision pins '$TOOLCHAIN'"
+            exit 1
+          fi
+          curl -sSL -H "Accept: application/octet-stream" \
+            "https://github.com/leanprover/elan/releases/download/${ELAN_VER}/elan-x86_64-unknown-linux-gnu.tar.gz" -o elan.tar.gz
+          echo "${ELAN_SHA256}  elan.tar.gz" | sha256sum -c -
+          tar -xzf elan.tar.gz elan-init
+          ./elan-init -y --default-toolchain none
+          rm -f elan.tar.gz elan-init
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" toolchain install "$TOOLCHAIN"
+          printf 'name=%s\n' "$TOOLCHAIN" >> "$GITHUB_OUTPUT"
+
+      - name: Publish and confirm the revision map is publicly readable
+        id: upload
+        env:
+          S3_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
+          S3_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
+          PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+          LAKE_CACHE_KEY_RAW: ${{ secrets.LAKE_CACHE_KEY }}
+          ELAN_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}
+          STAGING: ${{ runner.temp }}/lake-cache-staging
+          REVISION: ${{ inputs.revision }}
+          PUBLICATION_REQUIRED: ${{ inputs.publication-required }}
+        run: |
+          set -euo pipefail
+          skip_or_fail() {
+            if [ "$PUBLICATION_REQUIRED" = true ]; then
+              echo "::error::$1"
+              exit 1
+            fi
+            echo "::notice::$1"
+            echo 'published=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          case "$REVISION" in
+            *[!0-9a-f]*|'') echo "::error::revision is not a lowercase hexadecimal Git object ID"; exit 1 ;;
+          esac
+          [ "${#REVISION}" = 40 ] || { echo "::error::revision is not a 40-character Git object ID"; exit 1; }
+          [ -n "$S3_ARTIFACT_ENDPOINT" ] && [ -n "$S3_REVISION_ENDPOINT" ] \
+            || skip_or_fail 'the Lake cache upload endpoints are not configured'
+          [ -n "$PUBLIC_REVISION_ENDPOINT" ] \
+            || skip_or_fail 'the public Lake revision endpoint is not configured'
+          [ -n "$LAKE_CACHE_KEY_RAW" ] \
+            || skip_or_fail 'the LAKE_CACHE_KEY secret is not configured'
+
+          KEY="$LAKE_CACHE_KEY_RAW"
+          KEY="${KEY%"${KEY##*[![:space:]]}"}"
+          [ -n "$KEY" ] || skip_or_fail 'the LAKE_CACHE_KEY secret is empty after trimming'
+          echo "::add-mask::$KEY"
+          export LAKE_CACHE_KEY="$KEY"
+
+          CFG="$RUNNER_TEMP/lake-cache.toml"
+          cat > "$CFG" <<TOML
+          cache.defaultUploadService = "tauceti-r2"
+          [[cache.service]]
+          name = "tauceti-r2"
+          kind = "s3"
+          artifactEndpoint = "$S3_ARTIFACT_ENDPOINT"
+          revisionEndpoint = "$S3_REVISION_ENDPOINT"
+          TOML
+          export LAKE_CONFIG="$CFG"
+
+          lake cache put-staged "$STAGING" --service tauceti-r2 \
+            --repo TauCetiProject/TauCeti --rev "$REVISION" --toolchain "$ELAN_TOOLCHAIN"
+
+          # Lake maps elan toolchain names to scope directories by replacing `/` with `--` and
+          # `:` with `---`. Confirm the exact bytes just uploaded have propagated to the public
+          # read endpoint before allowing a merge-group build to turn green.
+          TOOLCHAIN_DIR="${ELAN_TOOLCHAIN//\//--}"
+          TOOLCHAIN_DIR="${TOOLCHAIN_DIR//:/---}"
+          PUBLIC_URL="${PUBLIC_REVISION_ENDPOINT%/}/TauCetiProject/TauCeti/tc/$TOOLCHAIN_DIR/$REVISION.jsonl"
+          observed=0
+          for attempt in 1 2 3 4 5 6; do
+            if curl --fail --silent --show-error "$PUBLIC_URL" -o "$RUNNER_TEMP/public-outputs.jsonl" \
+                 && cmp "$STAGING/outputs.jsonl" "$RUNNER_TEMP/public-outputs.jsonl"; then
+              observed=1
+              break
+            fi
+            echo "::warning::published revision map is not publicly readable yet (attempt $attempt/6)"
+            [ "$attempt" = 6 ] || sleep 10
+          done
+          [ "$observed" = 1 ] || { echo "::error::the published revision map did not become publicly readable"; exit 1; }
+          echo 'published=true' >> "$GITHUB_OUTPUT"
+          echo "::notice::published and confirmed the Lake cache for $REVISION"

--- a/scripts/sandbox-build.sh
+++ b/scripts/sandbox-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # sandbox-build.sh — the offline, landrun-sandboxed build + audits + environment lint of
-# the overlaid TauCeti/ sources, factored out of .github/workflows/pr-build.yml.
+# the candidate TauCeti sources, factored out of .github/workflows/pr-build.yml.
 #
 # pr-build.yml invokes this inside landrun with a fixed, comment-free one-liner
 # (`cd base && exec bash scripts/sandbox-build.sh`), so the workflow's `bash -c` payload
@@ -59,3 +59,28 @@ bash scripts/lint-env.sh
 # Mathlib's copyright/Authors checks (excluding the deliberately empty root), and generates the
 # text-linter import root under .lake/ without relying on TauCeti.lean's imports.
 bash scripts/lint-style.sh
+
+# A merge-group commit that passes every audit is the exact commit GitHub will land. Pack its
+# root-package outputs while still inside landrun, after the final operation that executes
+# candidate code. The host uploads only this data-only staging tree to a fresh, secret-isolated
+# publisher job. Ordinary PRs and installations without upload endpoints leave this disabled.
+if [ "${STAGE_LAKE_CACHE:-}" = "1" ]; then
+  if ! grep -Eq '^[[:space:]]*platformIndependent[[:space:]]*=[[:space:]]*true' lakefile.toml; then
+    echo "lakefile.toml no longer sets platformIndependent = true" >&2
+    exit 1
+  fi
+  if grep -Eq '^[[:space:]]*(fixedToolchain|bootstrap)[[:space:]]*=[[:space:]]*true' lakefile.toml; then
+    echo "lakefile.toml changes the toolchain cache scope" >&2
+    exit 1
+  fi
+
+  export LAKE_ARTIFACT_CACHE=true
+  export LAKE_RESTORE_ARTIFACTS=true
+  export LAKE_NO_CACHE=true
+  export LAKE_CACHE_DIR="$PWD/.lake/cache"
+  lake build >/dev/null
+  lake build --no-build -o .lake/outputs.jsonl
+  echo "root-package mapping entries: $(wc -l < .lake/outputs.jsonl)"
+  rm -rf .lake/cache-staging
+  lake cache stage .lake/outputs.jsonl .lake/cache-staging
+fi


### PR DESCRIPTION
This PR makes the merge queue publish and publicly verify the complete Lake artifact map for its exact combined commit before posting a green build status. Main CI uses the same secret-isolated publisher as a fallback, so the upload key never enters the code-producing job. This is the first of three stacked infrastructure PRs.

Validated on the complete stack with workflow parsing, the infrastructure policy suites, lake build --iofail, and the axiom, module-system, header-style, and environment-lint audits.

Roadmap: none

:robot: Prepared with OpenAI Codex