### PR TITLE
ci: build the exact pull request head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           python3 scripts/test_workflow_pins.py
           python3 scripts/test_landrun_pin.py
           python3 scripts/test_elan_pin.py
+          python3 scripts/test_attest_pr_config.py
           PYTHONPATH=scripts python3 scripts/test_claims_access.py
           python3 scripts/test_lint_dot_notation.py
           python3 scripts/test_toolchain_tags.py

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,15 +1,14 @@
 name: pr-build
 
-# Builds untrusted PR code in a TRUSTED, base-branch-defined workflow. A PR cannot change what
-# runs here (pull_request_target uses the base definition). The build/audit configuration
-# (lakefile, scripts/, manifest, toolchain) is the TRUSTED base's: we overlay only the PR's
-# `TauCeti/` sources and validated Lake pins onto a base checkout. What is overlaid is the PR
-# MERGED INTO the base, not the PR head on its own, so the sources built are ones git would
-# produce rather than new pins spliced over old sources -- a combination no commit ever had. Lakefiles remain entirely
-# base-trusted; dependency repair PRs carry exact first-known-bad commits only in the manifest.
-# Any PR touching anything outside the allowed paths is routed to a human. PR `TauCeti/` code
-# compiles only under landrun (offline; writes confined to base/.lake; no secrets or token in
-# reach). The `build` commit status on the PR head SHA is the required merge check.
+# Builds the exact immutable PR head in a TRUSTED, base-branch-defined workflow. A PR cannot
+# change what runs here (pull_request_target uses the base definition). Before Lake sees the
+# candidate, the workflow proves that its lakefile is an ordinary file byte-identical to the
+# PR's merge base and that its pins are either inherited unchanged or a validated forward bump.
+# Workflow-pinned audit tooling is mounted separately; candidate scripts are never invoked by
+# the required build. Candidate Lean code runs only under landrun (offline; writes confined to
+# the checkout's .lake; no secrets or token in reach). Scope is a separate policy status, so an
+# old PR keeps its own historical pins and sources rather than being synthetically merged or
+# overlaid onto today's main. The `build` status on the exact head SHA is the required check.
 #
 # The job below is deliberately NOT named `build`: GitHub Actions auto-creates a check-run named
 # after the job, and a check-run named `build` would collide with the required `build` STATUS this
@@ -26,11 +25,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
   # The merge queue tests a batch (one or more PRs combined onto current main) before it lands. We
-  # build the COMBINED merge-group commit and post the `build` status on it so the queue's required
-  # check is satisfied. The merge-group commit's TauCeti/ (all batched PRs) is overlaid onto a
-  # freshly-checked-out TRUSTED base — exactly as for a single PR — so the build config stays
-  # base-trusted and only TauCeti/ code is untrusted, regardless of batch size. A combined diff that
-  # reaches outside TauCeti/ fails the group (the queue then bisects it); see the scope guard.
+  # build the COMBINED merge-group commit exactly as GitHub synthesized it and post the `build`
+  # status on it so the queue's required check is satisfied. A combined diff that reaches outside
+  # TauCeti/ gets a red scope status; the trusted build harness remains independent of that diff.
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -79,15 +76,14 @@ jobs:
           if [ "${{ github.event_name }}" = "merge_group" ]; then
             # Build the COMBINED merge-group commit (current base + ALL batched PRs, squash-merged by
             # GitHub onto the gh-readonly-queue ref), not any single PR — so a batch is tested as a
-            # whole. The combined commit lives in THIS repo; its TauCeti/ is overlaid onto the trusted
-            # base below, and the required `build` status lands on the merge-group commit.
+            # whole. The combined commit lives in THIS repo, is checked out exactly below, and the
+            # required `build` status lands on that merge-group commit.
             REPO='${{ github.repository }}'
             SHA='${{ github.event.merge_group.head_sha }}'
             # Use the IMMUTABLE base SHA the queue synthesized this group on — NOT the mutable `main`
             # tip, which may have advanced since the group was formed. Building the batch's TauCeti/
-            # over a different base would test (and green-light) the wrong trusted config/pins. This
-            # base_sha drives the trusted base checkout, the combined-diff scope compare, and the bump
-            # merge-base below.
+            # as a different commit would test (and green-light) the wrong batch. This base_sha
+            # drives the combined-diff scope compare and forward-bump policy input below.
             BASE_REF='${{ github.event.merge_group.base_sha }}'
             STATUS_SHA='${{ github.event.merge_group.head_sha }}'
             NUM="merge-group"   # not a single PR; scope/diff use the combined base..head diff below
@@ -107,8 +103,8 @@ jobs:
             STATUS_SHA="$SHA"
             AUTHOR=$(gh api "repos/${{ github.repository }}/pulls/$NUM" --jq .user.login)
           fi
-          # Resolve the target branch to a commit ONCE. Everything below -- the trusted config,
-          # the merge the PR is built as, the scope compare -- then refers to the same base,
+          # Resolve the target branch to a commit ONCE. Everything below -- policy validation,
+          # the merge-base attestation, and the scope compare -- then refers to the same base,
           # instead of each step separately racing a branch that moves every few minutes. For
           # merge_group BASE_REF is already the immutable base_sha the queue synthesized on.
           if [ "${{ github.event_name }}" != "merge_group" ]; then
@@ -169,13 +165,13 @@ jobs:
           fi
           echo "changed files:"; echo "$files"
           # The root TauCeti.lean is allowed alongside TauCeti/: it is the (intentionally
-          # empty) library root, normally untouched, but a PR may edit it. It is overlaid
-          # into the sandbox below and the import-boundary guard covers it. Everything else
-          # outside TauCeti/ (scripts/, .github/, arbitrary Lake config) stays trusted-base-only and
-          # routes to a human. The lakefiles are always human-owned and never overlaid automatically.
+          # empty) library root, normally untouched, but a PR may edit it. Everything else
+          # outside TauCeti/ (scripts/, .github/, arbitrary Lake config) routes to a human.
+          # Candidate scripts are never used by the trusted harness, and a changed lakefile is
+          # rejected before Lake executes, independently of this merge-policy status.
           # lake-manifest.json and lean-toolchain are also permitted, but ONLY as a
           # machine-validated forward bump: the "Validate the Lake-pin bump" step below
-          # runs the trusted base scripts/check-bump.sh and routes to a human if it is
+          # runs the workflow-pinned scripts/check-bump.sh and routes to a human if it is
           # anything other than a forward move (mathlib forward on its nominated branch,
           # transitive pins derived from mathlib, toolchain monotonic).
           # Two independent questions: does this reach outside TauCeti/, and does it change the
@@ -185,14 +181,14 @@ jobs:
           # bump-guard status green, asserting a validation that had not happened, to the human
           # being asked to merge exactly that kind of PR by hand.
           if [ -z "$files" ]; then
-            echo "INFRA=1" >> "$GITHUB_ENV"; echo "::warning::no files / unable to list — cannot determine the overlay, routing to human"
+            echo "INFRA=1" >> "$GITHUB_ENV"; echo "::warning::no files / unable to list — cannot determine scope, routing to human"
           else
             if echo "$files" | grep -vqE '^TauCeti/|^TauCeti\.lean$|^lake-manifest\.json$|^lean-toolchain$'; then
-              if echo "$files" | grep -qE '^lakefile\.toml$'; then
+              if echo "$files" | grep -qE '^lakefile\.(toml|lean)$'; then
                 echo "HUMAN_LAKEFILE=1" >> "$GITHUB_ENV"
               fi
               echo "OUT_OF_SCOPE=1" >> "$GITHUB_ENV"
-              echo "::warning::PR changes paths outside TauCeti/ + Lake pins — its TauCeti/ is still sandbox-built against the trusted base (so the build result is visible), but merging needs human review"
+              echo "::warning::PR changes paths outside TauCeti/ + Lake pins — its exact head is still sandbox-built when its Lake config is attested, but merging needs human review"
             fi
           fi
           # Whether THIS pull request changes the Lake pins, asked of the immutable commit this
@@ -299,28 +295,19 @@ jobs:
             echo "$long"
           fi
 
-      - name: Checkout base (trusted)
+      # The current target tip is trusted policy input for forward-bump validation only. It is
+      # never used as the source or configuration tree of an ordinary PR build.
+      - name: Checkout current base policy input (trusted)
         if: ${{ env.INFRA != '1' }}
         uses: actions/checkout@v4
-        # Pin to the trusted base branch explicitly. For merge_group the event default ref is the
-        # untrusted combined commit, so this is what keeps the build config (lakefile, scripts,
-        # manifest, toolchain) base-trusted; only TauCeti/ is overlaid from the merge-group commit.
         with:
-          # The resolved commit rather than the branch name: the config built against is then
-          # the same base the sources below are merged onto, even if main moves mid-run.
           ref: "${{ steps.pr.outputs.base_sha }}"
           path: base
           persist-credentials: false
-          # Enough base history for `lake cache get` to backtrack to a recently-built
-          # ancestor commit (its `--max-revs`) when the exact base tip has no cache
-          # mapping yet. Harmless (just a slightly deeper fetch) when the cache is off.
-          fetch-depth: 100
+          fetch-depth: 1
 
-      # Pin the new build/watchdog scripts to the commit that supplied this
-      # workflow. This matters during first rollout and historical manual
-      # dispatches, where the PR's base predates those scripts. For normal
-      # pull_request_target and merge_group events github.workflow_sha is the
-      # trusted base-defined workflow commit, never the candidate checkout.
+      # This is the commit that supplied the pull_request_target / merge_group workflow. All
+      # executable audit, watchdog, cache, and bump-validation tooling comes from here.
       - name: Checkout workflow-pinned trusted build tooling
         if: ${{ env.INFRA != '1' }}
         uses: actions/checkout@v4
@@ -330,193 +317,85 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Stage workflow-pinned build tooling into the trusted base
+      - name: Checkout the PR merge base (trusted historical configuration)
         if: ${{ env.INFRA != '1' }}
-        run: |
-          set -euo pipefail
-          rm -rf base/scripts/perf
-          cp -a gate/scripts/perf base/scripts/perf
-          cp gate/scripts/sandbox-build.sh base/scripts/sandbox-build.sh
-          cp gate/scripts/lint-env.sh base/scripts/lint-env.sh
-          cp gate/scripts/lint-style.sh base/scripts/lint-style.sh
-          cp gate/scripts/source-modules.sh base/scripts/source-modules.sh
-          cp gate/scripts/HeaderStyle.lean base/scripts/HeaderStyle.lean
-
-      - name: Checkout merge-base config (trusted ancestor — only to scope the PR's pin delta)
-        if: ${{ env.INFRA != '1' && env.BUMP == '1' }}
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.pr.outputs.mergebase }}
           path: mergebase
           persist-credentials: false
+          fetch-depth: 1
 
-      # A merge_group commit is ALREADY the batch merged onto its base by the queue, so it is
-      # taken as-is; only its TauCeti/ is overlaid, exactly as before.
-      - name: Checkout the merge-group commit (untrusted contents, no credentials)
-        if: ${{ env.INFRA != '1' && github.event_name == 'merge_group' }}
+      # Full history is intentional. lake cache get --max-revs=0 walks all available ancestors
+      # until it reaches a published main commit, then Lake's input hashes invalidate only changed
+      # modules and their downstream dependents. The checkout is the immutable event head itself:
+      # no refs/pull/N/merge, no local merge, and no source/config overlay.
+      - name: Checkout the exact candidate head (untrusted contents, no credentials)
+        if: ${{ env.INFRA != '1' }}
         uses: actions/checkout@v4
         with:
           repository: ${{ steps.pr.outputs.repo }}
           ref: ${{ steps.pr.outputs.sha }}
           path: pr
           persist-credentials: false
+          fetch-depth: 0
           allow-unsafe-pr-checkout: true
 
-      # For a pull request there is no such commit, so make one. Start from the same trusted
-      # base commit and merge the PR into it, rather than building the PR head on its own.
-      #
-      # The head alone is the bug this replaces: its TauCeti/ was overlaid onto a base carrying
-      # the target branch's Lake pins, so a branch cut before a Mathlib bump compiled pre-bump
-      # sources against post-bump Mathlib and failed on code it had never touched. On
-      # 2026-08-25 that reddened 39 of the 40 then-failing pull requests at once, all on one
-      # unchanged line of Analysis/Contour/Argument/Principle.lean, and every one needed main
-      # merged into it by hand before it would build again.
-      #
-      # Merging here rather than reading refs/pull/N/merge is deliberate. That ref is mutable
-      # and, when a pull request conflicts, is left pointing at the last clean merge instead of
-      # disappearing -- a stale candidate still names the current head as its second parent, so
-      # it passes the obvious check while carrying a base hundreds of commits old. Using it
-      # safely takes a mergeability poll, a parent check, an ancestry check and a retarget
-      # check, all to re-establish facts that are simply known when the merge is made here from
-      # a base commit resolved above and an immutable head from the event.
-      - name: Check out the base to merge into (deep enough to find a merge base)
-        if: ${{ env.INFRA != '1' && github.event_name != 'merge_group' }}
-        uses: actions/checkout@v4
-        with:
-          ref: "${{ steps.pr.outputs.base_sha }}"
-          path: pr
-          persist-credentials: false
-          # Full history: a merge needs a common ancestor, and old pull requests are further
-          # back than any bounded depth would reach. Measured at 32MB/5s against a build of
-          # roughly twelve minutes.
-          fetch-depth: 0
-
-      - name: Merge the pull request into it (no PR code runs; git only)
-        if: ${{ env.INFRA != '1' && github.event_name != 'merge_group' }}
-        env:
-          NUM: "${{ steps.pr.outputs.num }}"
-          HEAD_SHA: "${{ steps.pr.outputs.sha }}"
-          BASE_SHA: "${{ steps.pr.outputs.base_sha }}"
+      - name: Attest exact-head Lake configuration before executing Lake
+        if: ${{ env.INFRA != '1' }}
         run: |
-          set -uo pipefail
-          cd pr
-
-          # Run git with NO configuration but this repository's own. Content cannot define a
-          # merge driver or a filter, but it can SELECT one that the runner already has
-          # configured (an installed Git LFS filter being the realistic example), and a
-          # .lfsconfig could then point that at an endpoint of the contributor's choosing.
-          # Neutralising system and global config removes anything for content to select, and
-          # hooksPath is belt and braces: a fetch does not transfer hooks in the first place.
-          export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
-          git config core.hooksPath /dev/null
-          git config core.fsmonitor false
-          # An identity is required even by `merge --no-commit`, which prepares a commit it
-          # then does not write. Set one explicitly rather than inheriting: neutralising the
-          # global and system config above leaves a runner with none at all, and git will not
-          # invent one, so without this every merge fails with "empty ident name".
-          git config user.name "pr-build"
-          git config user.email "pr-build@taucetiproject.invalid"
-
-          # From the canonical repository: refs/pull/N/head is maintained here for forks too,
-          # so no fork is contacted at build time, and the SHA is checked below regardless.
-          if ! git fetch --quiet origin "refs/pull/$NUM/head"; then
+          set -euo pipefail
+          if bash gate/scripts/attest-pr-config.sh \
+               mergebase pr '${{ steps.pr.outputs.sha }}' '${{ github.event_name }}' \
+               "${MERGEBASE_EXACT:-0}" "${BUMP:-0}"; then
+            echo "CONFIG_ATTESTED=1" >> "$GITHUB_ENV"
+            echo "Exact candidate Lake configuration attested against merge base ${{ steps.pr.outputs.mergebase }}."
+          else
+            echo "CONFIG_BAD=1" >> "$GITHUB_ENV"
             echo "INFRA=1" >> "$GITHUB_ENV"
-            echo "::warning::could not fetch the head of PR #$NUM — re-run pr-build"
-            exit 0
+            echo "::warning::candidate Lake configuration failed trusted attestation; refusing to execute it"
           fi
-          got=$(git rev-parse FETCH_HEAD)
-          # The event's head is what gets statused, so it is what must be built.
-          if [ "$got" != "$HEAD_SHA" ]; then
-            echo "INFRA=1" >> "$GITHUB_ENV"
-            echo "::warning::PR #$NUM is at $got, not the $HEAD_SHA this run is for — the run for the new head will build it"
-            exit 0
-          fi
-          # --no-commit: the merged tree is all that is wanted, and not committing means no
-          # identity to configure and nothing to push anywhere.
-          if ! git merge --no-commit --no-ff "$HEAD_SHA" >/tmp/merge.log 2>&1; then
-            # Distinguish a real conflict from a merge that failed for some other reason.
-            # Unmerged index entries are what a content conflict leaves behind; anything else
-            # (a repository error, a disk failure) is infrastructure, and telling an author to
-            # update a branch that merges perfectly well would send a worker off to do a round
-            # of work that cannot help. Read before aborting, which clears the index.
-            unmerged=$(git ls-files --unmerged | wc -l | tr -d " ")
-            sed -n "1,40p" /tmp/merge.log
-            git merge --abort 2>/dev/null || true
-            echo "INFRA=1" >> "$GITHUB_ENV"
-            if [ "$unmerged" != "0" ]; then
-              echo "NEEDS_REBASE=1" >> "$GITHUB_ENV"
-              echo "::warning::PR #$NUM conflicts with the base; update the branch and this builds again"
-            else
-              echo "::warning::could not merge PR #$NUM into the base, and it is not a content conflict — re-run pr-build"
-            fi
-            exit 0
-          fi
-          echo "built as $HEAD_SHA merged into $BASE_SHA"
 
-      # For a Lake-pin PR, validate it is a safe forward bump BEFORE overlaying its
-      # pins or building. The validator and the BASE config it judges against are the
-      # TRUSTED current target tip; mergebase/ only scopes the PR's own pin delta; pr/
-      # is read as text — no PR code runs. An invalid/backward/forked bump sets INFRA=1
-      # → not built, routed to a human. This same inline validation is what the
-      # required `bump-guard` status is posted from in the final step (this job owns
-      # both required statuses; there is no separate bump-guard workflow).
-      - name: Validate the Lake-pin bump (trusted base validator) before building
+      # For a pin-changing candidate, the workflow-pinned validator proves a forward Mathlib and
+      # toolchain move before dependency setup. Unchanged historical pins inherit trust from the
+      # attested merge base and need no comparison with today's main.
+      - name: Validate the Lake-pin bump before building
         if: ${{ env.INFRA != '1' && env.BUMP == '1' }}
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
-          if bash base/scripts/check-bump.sh base mergebase pr; then
-            # Proof the validator ran to completion and passed. The report step requires this
-            # rather than inferring it from the absence of BUMP_BAD: this step is skipped
-            # whenever INFRA is set, and INFRA has several causes that have nothing to do with
-            # the pins, so "not marked bad" and "validated" are different facts.
+          if bash gate/scripts/check-bump.sh base mergebase pr; then
             echo "BUMP_VALIDATED=1" >> "$GITHUB_ENV"
-            echo "Lake-pin bump validated — building with the PR's pins."
+            echo "Lake-pin bump validated — building the exact candidate with its new pins."
           else
             echo "BUMP_BAD=1" >> "$GITHUB_ENV"
             echo "INFRA=1" >> "$GITHUB_ENV"
-            echo "::warning::Lake-pin change is not a validated forward bump — routing to human"
+            echo "::warning::Lake-pin change is not a validated forward bump — refusing to execute it"
           fi
 
-      - name: Overlay PR TauCeti/ and root TauCeti.lean onto the trusted base (reject symlinks)
+      - name: Candidate source shape guard (reject symlinks)
         if: ${{ env.INFRA != '1' }}
         run: |
-          # No symlinks in the untrusted sources (avoid read/write escapes via the build tree).
-          if find pr/TauCeti -type l -print | grep -q .; then
-            echo "::error::symlinks are not allowed under TauCeti/"; exit 1
-          fi
           test -d pr/TauCeti && test ! -L pr/TauCeti
-          rm -rf base/TauCeti
-          cp -a pr/TauCeti base/TauCeti
-          # Overlay the root TauCeti.lean too (a regular file, never a symlink). Only if
-          # the PR actually ships one; otherwise keep the base copy.
-          if [ -e pr/TauCeti.lean ]; then
-            test ! -L pr/TauCeti.lean || { echo "::error::TauCeti.lean must not be a symlink"; exit 1; }
-            cp -a pr/TauCeti.lean base/TauCeti.lean
+          if find pr/TauCeti -type l -print | grep -q .; then
+            echo "::error::symlinks are not allowed under TauCeti/"
+            exit 1
           fi
-          # For a validated forward bump, overlay the PR's Lake pins too, so the build
-          # below actually exercises the new mathlib/toolchain.
-          if [ "${BUMP:-}" = "1" ]; then
-            for f in lake-manifest.json lean-toolchain; do
-              if [ -L "pr/$f" ]; then echo "::error::$f must not be a symlink"; exit 1; fi
-              [ -e "pr/$f" ] && cp -a "pr/$f" "base/$f"
-            done
-          fi
+          test -f pr/TauCeti.lean && test ! -L pr/TauCeti.lean
+
       - name: Import-boundary guard (TauCeti/ and TauCeti.lean ⊬ roadmap/review)
         if: ${{ env.INFRA != '1' }}
         run: |
-          if grep -rIn -E '^[[:space:]]*import[[:space:]]+(TauCetiRoadmap|TauCetiReview)\b' base/TauCeti/ base/TauCeti.lean; then
-            echo "::error::TauCeti/ must not import TauCetiRoadmap or TauCetiReview"; exit 1
+          if grep -rIn -E '^[[:space:]]*import[[:space:]]+(TauCetiRoadmap|TauCetiReview)\b' pr/TauCeti/ pr/TauCeti.lean; then
+            echo "::error::TauCeti/ must not import TauCetiRoadmap or TauCetiReview"
+            exit 1
           fi
 
-      # No-set_option guard. `set_option` is an escape hatch (it can raise maxHeartbeats,
-      # silence linters, bump maxRecDepth, ...), so the overlaid TauCeti/ may not use it. Like
-      # the import guard it is a textual scan that needs no elaboration, so it runs trusted (on
-      # the overlaid base/TauCeti/) outside the landrun sandbox.
       - name: No-set_option guard (TauCeti/ and TauCeti.lean use no set_option)
         if: ${{ env.INFRA != '1' }}
         run: |
-          if grep -rIn '^set_option ' base/TauCeti/ base/TauCeti.lean; then
-            echo "::error::TauCeti/ may not use set_option (it can weaken maxHeartbeats, linters, maxRecDepth, ...); remove it"; exit 1
+          if grep -rIn '^set_option ' pr/TauCeti/ pr/TauCeti.lean; then
+            echo "::error::TauCeti/ may not use set_option (it can weaken maxHeartbeats, linters, maxRecDepth, ...); remove it"
+            exit 1
           fi
 
       # Take elan from a pinned leanprover/elan release verified by SHA-256, not from whatever
@@ -562,9 +441,8 @@ jobs:
           fi
 
       # Restore only Mathlib's compressed, content-addressed `.ltar` download store from a
-      # trusted main publisher. This workflow never writes that GitHub Actions cache. For a
-      # validated pin bump the expressions hash the
-      # already-overlaid files under base/, so an exact new-pin snapshot is preferred. A
+      # trusted main publisher. This workflow never writes that GitHub Actions cache. The keys
+      # hash the exact candidate pins, so an exact historical or new-pin snapshot is preferred. A
       # Mathlib-only bump can fall back to the newest same-toolchain main snapshot; a toolchain
       # bump misses both keys and refetches from Mathlib's server. `lake exe cache get` below
       # remains authoritative and downloads every applicable hash that is still absent. The
@@ -574,14 +452,14 @@ jobs:
         if: ${{ env.INFRA != '1' }}
         uses: ./gate/.github/actions/restore-mathlib-ltars
         with:
-          # The action's default cache directory is outside base/, which is later mounted into
+          # The action's default cache directory is outside pr/, which is later mounted into
           # landrun. Although MATHLIB_CACHE_DIR is job-wide, landrun's explicit `--env` allowlist
           # excludes it and the cache directory is not mounted, so the sandbox never receives it.
-          project-dir: base
+          project-dir: pr
 
       # `lake exe cache get` runs the `cache` exe built from the pinned Mathlib, unsandboxed,
       # with network (to download oleans) but deliberately NO token in env. For a normal PR that
-      # is the trusted base Mathlib. For a validated bump it is the PR's Mathlib pin — which
+      # pin is inherited from its trusted merge base. For a validated bump it is the new pin — which
       # bump-guard proved is a *forward commit on Mathlib's own master* (same repo, never a fork),
       # so the code run here is still trusted Mathlib master under the project's "track master"
       # policy; only the PR's TauCeti/ code stays untrusted and runs solely under landrun below.
@@ -595,11 +473,11 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          if ! ( cd base && lake exe cache get ) 2>&1 | tee "$GITHUB_WORKSPACE/cache-get.log"; then
+          if ! ( cd pr && lake exe cache get ) 2>&1 | tee "$GITHUB_WORKSPACE/cache-get.log"; then
             echo "::warning::lake exe cache get failed; forcing a full refetch"
-            ( cd base && lake exe cache get! ) 2>&1 | tee "$GITHUB_WORKSPACE/cache-get.log"
+            ( cd pr && lake exe cache get! ) 2>&1 | tee "$GITHUB_WORKSPACE/cache-get.log"
           fi
-          mkdir -p base/.lake/tmp
+          mkdir -p pr/.lake/tmp
 
       # Backstop to bump-guard's step 2b, measuring the thing itself rather than a proxy.
       # `lake exe cache get` exits 0 on a PARTIAL hit: it prints one warning and the build
@@ -607,7 +485,7 @@ jobs:
       # in a green build and costs about an hour on every downstream build until the pin
       # moves again, so catch it here (roughly 90 seconds in) rather than after the build.
       #
-      # Only a bump is judged. A normal PR builds against the base pin, which it did not
+      # Only a bump is judged. A normal PR builds against its inherited pin, which it did not
       # choose and cannot fix; failing those would take every PR in the repo down for as
       # long as a bad pin sat on main, which is precisely backwards.
       - name: Require a complete Mathlib cache for a bump
@@ -629,17 +507,21 @@ jobs:
           fi
           echo "Mathlib cache is complete at the bump target."
 
-      # Text-only trusted lint: inspect the overlaid PR sources after Mathlib's source tree is
-      # available. It does not elaborate or execute the untrusted TauCeti code.
+      # Text-only trusted lint: inspect the exact candidate sources after Mathlib's source tree is
+      # available. The workflow-pinned Python does not elaborate or execute candidate code.
       - name: Dot-notation namespace lint (Mathlib type namespaces stay at root)
         if: ${{ env.INFRA != '1' }}
-        run: (cd base && python3 scripts/lint-dot-notation.py)
+        run: |
+          python3 gate/scripts/lint-dot-notation.py \
+            --baseline gate/scripts/lint-dot-notation-baseline.txt \
+            --mathlib-root pr/.lake/packages/mathlib/Mathlib \
+            --source-root pr/TauCeti
 
       # Enable Lake's built-in artifact cache for the build below ONLY when the public read
       # endpoints are configured (repo variables). Until then this is a no-op: LAKE_*
       # stay empty and the landrun build recompiles TauCeti/ from scratch exactly as before.
-      # The cache dir lives under base/.lake/ so the offline landrun build (which mounts
-      # base/.lake rw) can read what the network `lake cache get` step populates. We never
+      # The cache dir lives under pr/.lake/ so the offline landrun build (which mounts
+      # pr/.lake rw) can read what the network `lake cache get` step populates. We never
       # pass the cache *endpoints* into landrun, so the sandboxed build stays offline and
       # can only consult the locally-populated cache.
       - name: Configure the Lake artifact cache (no-op unless the public endpoints are set)
@@ -652,7 +534,7 @@ jobs:
         run: |
           if [ -n "$PUBLIC_ARTIFACT_ENDPOINT" ] && [ -n "$PUBLIC_REVISION_ENDPOINT" ]; then
             {
-              echo "LAKE_CACHE_DIR=$PWD/base/.lake/cache"
+              echo "LAKE_CACHE_DIR=$PWD/pr/.lake/cache"
               echo "LAKE_ARTIFACT_CACHE=true"
               echo "LAKE_RESTORE_ARTIFACTS=true"
               echo "TAUCETI_CACHE_ENABLED=1"
@@ -661,13 +543,9 @@ jobs:
           else
             echo "::notice::Lake artifact cache not configured — building TauCeti/ from scratch (set the LAKE_CACHE_*_PUBLIC repo variables to enable)"
           fi
-          # A merge-group head is the commit GitHub will land. Stage its outputs after every
-          # sandboxed audit so the required build can wait for publication. A changed lakefile
-          # is deliberately excluded at this layer: this workflow still builds against trusted
-          # base config until the exact-head change lands, so its outputs would not describe the
-          # candidate revision's configuration.
+          # A merge-group head is the exact commit GitHub will land. Stage its outputs after every
+          # sandboxed audit so the required build can wait for publication.
           if [ "${{ github.event_name }}" = "merge_group" ] \
-             && [ "${HUMAN_LAKEFILE:-}" != "1" ] \
              && [ -n "$S3_ARTIFACT_ENDPOINT" ] && [ -n "$S3_REVISION_ENDPOINT" ]; then
             echo "STAGE_LAKE_CACHE=1" >> "$GITHUB_ENV"
             echo "::notice::merge-group outputs will be staged for pre-landing publication"
@@ -684,19 +562,20 @@ jobs:
           # environment variables; the script hands it the endpoints through a `--service` config.
           PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
           PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
-        run: bash gate/scripts/lake-cache-get.sh base
+          LAKE_CACHE_MAX_REVS: "0"
+        run: bash gate/scripts/lake-cache-get.sh pr
 
       - name: Prepare trusted read-only Lean watchdog toolchain
         if: ${{ env.INFRA != '1' }}
         run: |
           set -euo pipefail
           export PATH="$HOME/.elan/bin:$PATH"
-          real_lean=$(cd base && elan which lean)
+          real_lean=$(cd pr && elan which lean)
           watchdog="$RUNNER_TEMP/lean-watchdog-toolchain"
-          bash base/scripts/perf/prepare-watchdog-toolchain.sh "$watchdog" "$real_lean"
+          bash gate/scripts/perf/prepare-watchdog-toolchain.sh "$watchdog" "$real_lean"
           echo "WATCHDOG_TOOLCHAIN=$watchdog" >> "$GITHUB_ENV"
 
-      - name: Build (trusted config + overlaid TauCeti/) under landrun, offline
+      - name: Build exact candidate under landrun with workflow-pinned audits, offline
         id: build
         if: ${{ env.INFRA != '1' }}
         env:
@@ -707,27 +586,30 @@ jobs:
           LAKE_NO_CACHE: "true"
         run: |
           export PATH="$HOME/.local/bin:$HOME/.elan/bin:$PATH"
-          # The sandboxed build/audit/lint body lives in the TRUSTED base script
-          # scripts/sandbox-build.sh (scripts/ routes to a human, so a PR cannot edit it
-          # here). Keeping the landrun `bash -c` payload a fixed, comment-free one-liner
+          # The sandboxed build/audit/lint body comes from the separately mounted, workflow-pinned
+          # gate checkout; candidate scripts are never invoked. Keeping the landrun bash payload
+          # a fixed, comment-free one-liner
           # is deliberate: a comment's apostrophe once closed this single-quoted string
           # early and reddened every PR build (#694). All prose now lives in the script.
+          export TAUCETI_PROJECT_ROOT="$PWD/pr"
+          export TAUCETI_TRUSTED_SCRIPTS="$PWD/gate/scripts"
           landrun --rox /usr --rox /etc \
             --rw /dev/null --rox /dev/zero --rox /dev/urandom --rox /dev/random \
             --rox "$HOME/.elan" --rox "$WATCHDOG_TOOLCHAIN" \
-            --rox "$PWD/base" --rw "$PWD/base/.lake" \
+            --rox "$PWD/pr" --rw "$PWD/pr/.lake" --rox "$PWD/gate" \
             --env PATH --env HOME --env CI \
             --env LAKE_NO_CACHE --env LAKE_ARTIFACT_CACHE --env LAKE_RESTORE_ARTIFACTS --env LAKE_CACHE_DIR \
             --env WATCHDOG_TOOLCHAIN --env STAGE_LAKE_CACHE \
-            -- bash -euxo pipefail -c 'cd base && exec bash scripts/sandbox-build.sh'
+            --env TAUCETI_PROJECT_ROOT --env TAUCETI_TRUSTED_SCRIPTS \
+            -- bash -euxo pipefail -c 'cd pr && exec bash ../gate/scripts/sandbox-build.sh'
 
       - name: Prepare merge-group cache artifact metadata
         id: cache_stage
         if: ${{ github.event_name == 'merge_group' && env.STAGE_LAKE_CACHE == '1' && steps.build.outcome == 'success' }}
         run: |
           set -euo pipefail
-          test -s base/.lake/cache-staging/outputs.jsonl
-          TOOLCHAIN="$(cat base/lean-toolchain)"
+          test -s pr/.lake/cache-staging/outputs.jsonl
+          TOOLCHAIN="$(cat pr/lean-toolchain)"
           case "$TOOLCHAIN" in
             leanprover/lean4:[A-Za-z0-9]*) ;;
             *) echo "::error::invalid toolchain pin '$TOOLCHAIN'"; exit 1 ;;
@@ -740,7 +622,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: lake-cache-staging-${{ steps.pr.outputs.status_sha }}
-          path: base/.lake/cache-staging
+          path: pr/.lake/cache-staging
           if-no-files-found: error
           retention-days: 1
           compression-level: 0
@@ -797,7 +679,7 @@ jobs:
             return 0
           }
 
-          # bump-guard: this job already ran the trusted base scripts/check-bump.sh inline
+          # bump-guard: this job already ran the workflow-pinned scripts/check-bump.sh inline
           # (the "Validate the Lake-pin bump" step), so we post the required `bump-guard`
           # status from its result here rather than from a separate workflow. BUMP_BAD is set
           # only when a manifest/toolchain change failed that validator; anything else (no pin
@@ -819,28 +701,25 @@ jobs:
             # pull request that its pin state was unknown when it is perfectly well known.
             bg_state=failure; bg_desc="could not determine whether the Lake pins changed — re-run pr-build"
           elif [ "${{ env.HUMAN_LAKEFILE }}" = "1" ]; then
-            bg_state=success; bg_desc="lakefile not auto-validated; trusted base config built — human merge required"
+            bg_state=success; bg_desc="lakefile is human-owned; pin policy passed, but candidate config was not executed"
           else
             bg_state=success; bg_desc="validated forward Lake pin bump (or no pin change)"
           fi
           post_status bump-guard "$bg_state" "$bg_desc"
 
-          # build: the real sandboxed-build result ONLY — never a policy verdict. The build now runs even
-          # for an out-of-scope PR (its TauCeti/ is overlaid onto the trusted base and built), so a red
-          # `build` always means the code did not compile or an audit/lint failed, and fix-ci can trust
-          # it. It is reported as not-run only when we genuinely could not build: an indeterminate file
-          # list (INFRA), an unvalidated pin bump (BUMP_BAD — the overlay would need the PR's pins), or a
-          # diff guard that failed closed (TOO_LARGE / DIFF_UNKNOWN both exit before the build). Those
-          # post a failure so this required check still blocks merge; the reason lives in `scope` below.
-          if [ "${{ env.NEEDS_REBASE }}" = "1" ]; then
-            state=failure; desc="conflicts with the base — update the branch, then this builds again"
-          elif [ "$head_moved" = 1 ]; then
+          # build: the exact immutable candidate result, independent of merge-policy scope. An
+          # out-of-scope scripts/.github change still receives a useful build because all harness
+          # code is workflow-pinned. A lakefile edit or invalid pin is never executed and therefore
+          # reports a required failure rather than pretending that a different configuration built.
+          if [ "$head_moved" = 1 ]; then
             state=failure; desc="the pull request changed during this build — the run for its current state statuses it"
+          elif [ "${{ env.CONFIG_BAD }}" = "1" ]; then
+            state=failure; desc="build not run — candidate Lake configuration failed trusted attestation"
           elif [ "${{ env.BUMP_BAD }}" = "1" ] || [ "${{ env.INFRA }}" = "1" ] \
              || [ "${{ env.TOO_LARGE }}" = "1" ] || [ "${{ env.DIFF_UNKNOWN }}" = "1" ]; then
             state=failure; desc="build not run — see the scope check"
           elif [ "${{ steps.build.outcome }}" = "success" ]; then
-            state=success; desc="sandboxed build, audits, and simp-NF lint passed (trusted config)"
+            state=success; desc="exact-head sandboxed build and workflow-pinned audits passed"
           else
             state=failure; desc="sandboxed build, audit, or simp-NF lint failed"
           fi
@@ -871,10 +750,8 @@ jobs:
             sc_state=failure; sc_desc="changes outside TauCeti/ — human review + merge required"
           elif [ "${{ env.BUMP_BAD }}" = "1" ]; then
             sc_state=failure; sc_desc="Lake pin change failed the trusted bump validator"
-          elif [ "${{ env.NEEDS_REBASE }}" = "1" ]; then
-            sc_state=failure; sc_desc="conflicts with the base — update the branch (no human merge needed)"
           elif [ "${{ env.INFRA }}" = "1" ]; then
-            sc_state=failure; sc_desc="could not determine the changed files — human review + merge required"
+            sc_state=failure; sc_desc="trusted scope/config checks did not complete — see the run; human review may be required"
           elif [ "${{ env.TOO_LARGE }}" = "1" ]; then
             sc_state=failure; sc_desc="diff exceeds 2000 added/removed lines or 2000 files — split into smaller PRs to keep review manageable"
           elif [ "${{ env.DIFF_UNKNOWN }}" = "1" ]; then

--- a/scripts/attest-pr-config.sh
+++ b/scripts/attest-pr-config.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Attest an exact PR checkout before any command executes its Lake configuration.
+#
+# Usage:
+#   attest-pr-config.sh <merge-base-dir> <candidate-dir> <head-sha> \
+#     <event-name> <merge-base-exact:0|1> <pins-changed:0|1>
+#
+# The lakefile must be inherited byte-for-byte from the merge base. The two pins must be
+# ordinary files, and their observed local delta must agree with the immutable GitHub tree check
+# performed by pr-build.yml. A changed pin is authorized only after this script returns; the
+# separate workflow-pinned check-bump.sh then validates it as a forward move before Lake runs.
+set -euo pipefail
+
+MERGE_BASE="${1:?merge-base directory is required}"
+CANDIDATE="${2:?candidate directory is required}"
+EXPECTED_SHA="${3:?expected head SHA is required}"
+EVENT_NAME="${4:?event name is required}"
+MERGEBASE_EXACT="${5:-0}"
+PINS_CHANGED="${6:-0}"
+
+fail() {
+  echo "::error::config-attestation: $*" >&2
+  exit 1
+}
+
+case "$EXPECTED_SHA" in
+  ''|*[!0-9a-f]*) fail "expected head is not a lowercase hexadecimal object ID" ;;
+esac
+[ "${#EXPECTED_SHA}" = 40 ] || fail "expected head is not a 40-character object ID"
+[ "$EVENT_NAME" = "merge_group" ] || [ "$MERGEBASE_EXACT" = "1" ] \
+  || fail "the PR merge base was not resolved exactly"
+case "$PINS_CHANGED" in
+  0|1) ;;
+  *) fail "pins-changed must be 0 or 1" ;;
+esac
+
+GOT="$(git -C "$CANDIDATE" rev-parse HEAD 2>/dev/null)" \
+  || fail "candidate is not a readable Git checkout"
+[ "$GOT" = "$EXPECTED_SHA" ] \
+  || fail "candidate resolved to $GOT instead of immutable event head $EXPECTED_SHA"
+
+ordinary_file() {
+  [ -f "$1" ] && [ ! -L "$1" ]
+}
+
+# Lake accepts either spelling. Preserve both presence and bytes from the trusted ancestor so a
+# candidate cannot switch which configuration Lake loads.
+for FILE in lakefile.toml lakefile.lean; do
+  MB="$MERGE_BASE/$FILE"
+  HEAD="$CANDIDATE/$FILE"
+  if [ -e "$MB" ] || [ -L "$MB" ]; then
+    ordinary_file "$MB" || fail "$FILE is not an ordinary file at the merge base"
+    ordinary_file "$HEAD" || fail "$FILE is missing or not an ordinary file at the candidate head"
+    cmp -s "$MB" "$HEAD" || fail "$FILE differs from the PR merge base"
+  elif [ -e "$HEAD" ] || [ -L "$HEAD" ]; then
+    fail "$FILE was introduced by the candidate"
+  fi
+done
+ordinary_file "$CANDIDATE/lakefile.toml" \
+  || fail "this repository requires an ordinary lakefile.toml"
+
+LOCAL_PIN_DELTA=0
+for FILE in lake-manifest.json lean-toolchain; do
+  ordinary_file "$MERGE_BASE/$FILE" || fail "$FILE is not an ordinary merge-base pin"
+  ordinary_file "$CANDIDATE/$FILE" || fail "$FILE is not an ordinary candidate pin"
+  cmp -s "$MERGE_BASE/$FILE" "$CANDIDATE/$FILE" || LOCAL_PIN_DELTA=1
+done
+[ "$LOCAL_PIN_DELTA" = "$PINS_CHANGED" ] \
+  || fail "the local pin delta disagrees with the immutable GitHub tree check"
+
+echo "config-attestation: exact candidate config is safe to validate/build"

--- a/scripts/check-bump.sh
+++ b/scripts/check-bump.sh
@@ -34,8 +34,9 @@
 #
 # where each dir holds the repo's lean-toolchain, lake-manifest.json, lakefile.toml
 # (and optionally lakefile.lean). base_dir is the CURRENT target-branch tip — the
-# trusted config the PR actually builds and merges against, and what a genuine bump is
-# validated against. merge_base_dir is the PR's merge-base with the target branch, used
+# trusted forward-progress policy anchor a genuine bump is validated against. The exact-head
+# build uses the candidate config after separately attesting its lakefile to the merge base.
+# merge_base_dir is the PR's merge-base with the target branch, used
 # only to decide whether the PR changed these files at all (so a PR that is merely
 # behind the tip is not judged as if it had edited them). Exit 0 = safe forward bump
 # (or no pin change); exit 1 = not auto-mergeable (route to a human). Reasons printed.

--- a/scripts/lake-cache-get.sh
+++ b/scripts/lake-cache-get.sh
@@ -12,9 +12,10 @@
 #
 # Anonymous GETs from the PUBLIC read host (a different host than the S3 API endpoint the
 # trusted upload uses). Looks up the root-package oleans for the checkout's revision --
-# backtracking up to --max-revs ancestors, and unpacks them into $LAKE_CACHE_DIR. This is
-# trusted, publisher-built data: no token is in reach and no PR code runs (lakefile.toml is
-# declarative and base-trusted). Mathlib's oleans are NOT here; they come from
+# backtracking up to LAKE_CACHE_MAX_REVS ancestors (default 100; 0 means the complete available
+# history), and unpacks them into $LAKE_CACHE_DIR. This is trusted, publisher-built data: no token
+# is in reach and no PR code runs (the caller attests the declarative lakefile first). Mathlib's
+# oleans are NOT here; they come from
 # `lake exe cache get`.
 #
 # A TOTAL miss is non-fatal: the build just recompiles from scratch, as when the cache is off.
@@ -30,6 +31,10 @@ set -euo pipefail
 PROJECT_DIR="${1:?usage: lake-cache-get.sh <project-dir>}"
 : "${PUBLIC_ARTIFACT_ENDPOINT:?PUBLIC_ARTIFACT_ENDPOINT is required}"
 : "${PUBLIC_REVISION_ENDPOINT:?PUBLIC_REVISION_ENDPOINT is required}"
+LAKE_CACHE_MAX_REVS="${LAKE_CACHE_MAX_REVS:-100}"
+case "$LAKE_CACHE_MAX_REVS" in
+  ''|*[!0-9]*) echo "::error::LAKE_CACHE_MAX_REVS must be a natural number"; exit 1 ;;
+esac
 
 # Define the public read service in a Lake system config and select it with `--service`
 # (the env-var form of endpoint config is deprecated). Anonymous GETs, so no key here.
@@ -74,7 +79,7 @@ for attempt in $(seq 1 $ATTEMPTS); do
   LOG="${RUNNER_TEMP:-/tmp}/cache-get-$attempt.log"
   rc=0
   ( cd "$PROJECT_DIR" && LAKE_CONFIG="$CFG" lake cache get --service tauceti-public \
-      --repo TauCetiProject/TauCeti ) > "$LOG" 2>&1 || rc=$?
+      --repo TauCetiProject/TauCeti --max-revs="$LAKE_CACHE_MAX_REVS" ) > "$LOG" 2>&1 || rc=$?
   cat "$LOG"
   if [ "$rc" = 0 ]; then clean=1; break; fi
   if grep -qE "$MISS_RE" "$LOG"; then break; fi

--- a/scripts/lint-env.sh
+++ b/scripts/lint-env.sh
@@ -177,9 +177,11 @@
 #   scripts/lint-env.sh --update   # rewrite the baseline from the current state
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
-BASELINE="scripts/lint-baseline.txt"
-ALLOWLIST="scripts/lint-nolints-allowlist.txt"
+PROJECT_ROOT="${TAUCETI_PROJECT_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+TRUSTED_SCRIPTS="${TAUCETI_TRUSTED_SCRIPTS:-$PROJECT_ROOT/scripts}"
+cd "$PROJECT_ROOT"
+BASELINE="$TRUSTED_SCRIPTS/lint-baseline.txt"
+ALLOWLIST="$TRUSTED_SCRIPTS/lint-nolints-allowlist.txt"
 UPDATE=0
 [ "${1:-}" = "--update" ] && UPDATE=1
 
@@ -235,7 +237,7 @@ LINTERS="checkType defsWithUnderscore deprecatedNoSince impossibleInstance nonCl
 LINTERS_LEAN=$(printf '"%s", ' $LINTERS | sed 's/, $//')
 
 MODULE_IMPORT_LIST="$TMP/modules.txt"
-. scripts/source-modules.sh
+. "$TRUSTED_SCRIPTS/source-modules.sh"
 tauceti_source_modules "$TMP/source-files" "$MODULE_IMPORT_LIST"
 mods=$(wc -l < "$MODULE_IMPORT_LIST")
 [ "${mods:-0}" -gt 0 ] || fail "found no TauCeti/*.lean modules — the lint is miswired"

--- a/scripts/lint-style.sh
+++ b/scripts/lint-style.sh
@@ -8,12 +8,16 @@
 # drift apart.
 set -euo pipefail
 
+PROJECT_ROOT="${TAUCETI_PROJECT_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+TRUSTED_SCRIPTS="${TAUCETI_TRUSTED_SCRIPTS:-$PROJECT_ROOT/scripts}"
+cd "$PROJECT_ROOT"
+
 lint_src="$(mktemp -d "$PWD/.lake/lint-style-src.XXXXXX")"
 trap 'rm -rf "$lint_src"' EXIT
 lint_module="$lint_src/TauCetiLint/All.lean"
 mkdir -p "$(dirname "$lint_module")"
 
-. scripts/source-modules.sh
+. "$TRUSTED_SCRIPTS/source-modules.sh"
 tauceti_source_modules "$lint_src/files" "$lint_src/modules"
 mapfile -d '' files < "$lint_src/files"
 printf 'import TauCeti\n' > "$lint_module"
@@ -28,7 +32,7 @@ fi
 # Use the validated discovery list for the copyright/Authors audit. Keep going after a header
 # failure so contributors also see Mathlib's text-style diagnostics in the same CI round.
 status=0
-if ! lake env lean --run scripts/HeaderStyle.lean "${files[@]}"; then
+if ! lake env lean --run "$TRUSTED_SCRIPTS/HeaderStyle.lean" "${files[@]}"; then
   status=1
 fi
 

--- a/scripts/sandbox-build.sh
+++ b/scripts/sandbox-build.sh
@@ -2,35 +2,36 @@
 # sandbox-build.sh — the offline, landrun-sandboxed build + audits + environment lint of
 # the candidate TauCeti sources, factored out of .github/workflows/pr-build.yml.
 #
-# pr-build.yml invokes this inside landrun with a fixed, comment-free one-liner
-# (`cd base && exec bash scripts/sandbox-build.sh`), so the workflow's `bash -c` payload
+# pr-build.yml invokes this workflow-pinned copy inside landrun with a fixed, comment-free
+# one-liner, so the workflow's `bash -c` payload
 # can no longer be broken by an apostrophe or a stray quote in a comment: all the prose
 # and its punctuation live here, in a file the shell reads as a script rather than as a
 # single-quoted `-c` argument. (A comment reading "Mathlib's default" once closed that
 # single-quoted argument early and reddened every PR build; see #694.)
 #
-# This is a TRUSTED base copy. Only the PR's TauCeti/ is overlaid into the sandbox;
-# scripts/ is not, and a PR that edits scripts/ is routed to a human by the scope guard —
-# so this script cannot be swapped out to escape the sandbox, even though it elaborates
-# the PR's (untrusted) TauCeti/ code, which is the whole reason it runs under landrun.
+# This is a TRUSTED workflow-pinned copy mounted separately from the exact candidate checkout.
+# Candidate scripts are never invoked by the required build, even when a human-owned
+# infrastructure PR changes them.
 #
-# cwd on entry is the trusted `base` checkout, with the PR's TauCeti/ already overlaid.
+# cwd on entry is the exact immutable candidate checkout.
 set -euxo pipefail
 
 export TMPDIR="$PWD/.lake/tmp"
+TRUSTED_SCRIPTS="${TAUCETI_TRUSTED_SCRIPTS:?trusted script directory is required}"
+test -d "$TRUSTED_SCRIPTS"
 
 # Lake normally invokes Lean directly. Route every compiler process through a
 # trusted wall-clock watchdog instead. This script and the wrapper are the
-# trusted base copies; the PR can overlay only TauCeti/, and landrun does not
-# pass timeout-control variables, so PR code cannot raise or disable the 300s
+# workflow-pinned copies, and landrun does not pass timeout-control variables,
+# so candidate code cannot raise or disable the 300s
 # deadline. The wrapper and Lean both remain inside the same landrun sandbox.
 test -n "${WATCHDOG_TOOLCHAIN:-}"
 test -x "$WATCHDOG_TOOLCHAIN/bin/lean"
 export LAKE_OVERRIDE_LEAN=true
 export LEAN="$WATCHDOG_TOOLCHAIN/bin/lean"
 
-# Build the overlaid TauCeti/ against the trusted base config. landrun keeps this
-# offline and confines writes to base/.lake.
+# Build the exact candidate against its attested Lake config. landrun keeps this offline and
+# confines writes to the candidate's .lake directory.
 #
 # --iofail requires a SILENT build, the way Mathlib does (its CI runs `lake build --iofail`): it is
 # `--fail-level=info`, so the build fails if any module logs an `info:` (or warning/error) — a stray
@@ -41,11 +42,11 @@ lake build --iofail
 # Axiom audit: inspect the built environment and reject any axiom outside
 # {propext, Classical.choice, Quot.sound} — catching sorry, native_decide, and
 # home-rolled axioms, including ones reaching in through imports.
-lake exe axioms
+lake env "$WATCHDOG_TOOLCHAIN/bin/lean" --run "$TRUSTED_SCRIPTS/Axioms.lean"
 
 # Module-system audit: every TauCeti/ module must opt into the Lean module system
 # (read from each compiled module's isModule flag, not a textual grep).
-lake exe module-system
+lake env "$WATCHDOG_TOOLCHAIN/bin/lean" --run "$TRUSTED_SCRIPTS/ModuleSystem.lean"
 
 # Environment lint: Mathlib's default `#lint` set minus docBlame, plus a
 # module-system-reliable docstring scan, compared against the grandfathered baseline in
@@ -53,12 +54,12 @@ lake exe module-system
 # (scripts/lint-nolints-allowlist.txt) are trusted base copies, and its report parsing
 # is fail-closed (see the SECURITY MODEL in the script). Fails on new violations or
 # unaccounted nolints; fixed baseline entries print a ratchet reminder only.
-bash scripts/lint-env.sh
+bash "$TRUSTED_SCRIPTS/lint-env.sh"
 
 # Source style lint. The trusted wrapper uses the shared validated TauCeti/ module list, applies
 # Mathlib's copyright/Authors checks (excluding the deliberately empty root), and generates the
 # text-linter import root under .lake/ without relying on TauCeti.lean's imports.
-bash scripts/lint-style.sh
+bash "$TRUSTED_SCRIPTS/lint-style.sh"
 
 # A merge-group commit that passes every audit is the exact commit GitHub will land. Pack its
 # root-package outputs while still inside landrun, after the final operation that executes

--- a/scripts/test_attest_pr_config.py
+++ b/scripts/test_attest_pr_config.py
@@ -1,0 +1,97 @@
+"""Tests for the exact-head Lake-configuration attestation."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "attest-pr-config.sh"
+
+
+class ConfigAttestation(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp.name)
+        self.mergebase = self.root / "mergebase"
+        self.candidate = self.root / "candidate"
+        self.mergebase.mkdir()
+        self.candidate.mkdir()
+        for directory in (self.mergebase, self.candidate):
+            (directory / "lakefile.toml").write_text('name = "TauCeti"\n')
+            (directory / "lake-manifest.json").write_text('{"packages": []}\n')
+            (directory / "lean-toolchain").write_text("leanprover/lean4:v4.34.0-rc1\n")
+        subprocess.run(["git", "init", "-q"], cwd=self.candidate, check=True)
+        subprocess.run(["git", "add", "."], cwd=self.candidate, check=True)
+        subprocess.run(
+            ["git", "-c", "user.name=test", "-c", "user.email=test@example.com", "commit", "-qm", "fixture"],
+            cwd=self.candidate,
+            check=True,
+        )
+        self.sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=self.candidate, text=True
+        ).strip()
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def run_attestation(
+        self, *, event: str = "pull_request_target", exact: str = "1", pins: str = "0"
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "bash",
+                str(SCRIPT),
+                str(self.mergebase),
+                str(self.candidate),
+                self.sha,
+                event,
+                exact,
+                pins,
+            ],
+            text=True,
+            capture_output=True,
+        )
+
+    def test_unchanged_config_passes(self) -> None:
+        self.assertEqual(self.run_attestation().returncode, 0)
+
+    def test_lakefile_change_fails(self) -> None:
+        (self.candidate / "lakefile.toml").write_text('name = "Other"\n')
+        self.assertNotEqual(self.run_attestation().returncode, 0)
+
+    def test_introduced_lakefile_lean_fails(self) -> None:
+        (self.candidate / "lakefile.lean").write_text("import Lake\n")
+        self.assertNotEqual(self.run_attestation().returncode, 0)
+
+    def test_symlinked_lakefile_fails(self) -> None:
+        (self.candidate / "lakefile.toml").unlink()
+        (self.candidate / "lakefile.toml").symlink_to("lean-toolchain")
+        self.assertNotEqual(self.run_attestation().returncode, 0)
+
+    def test_pin_delta_must_match_tree_attestation(self) -> None:
+        (self.candidate / "lean-toolchain").write_text("leanprover/lean4:v4.34.0\n")
+        self.assertNotEqual(self.run_attestation(pins="0").returncode, 0)
+        self.assertEqual(self.run_attestation(pins="1").returncode, 0)
+
+    def test_unresolved_merge_base_fails_for_pr_but_not_group(self) -> None:
+        self.assertNotEqual(self.run_attestation(exact="0").returncode, 0)
+        self.assertEqual(
+            self.run_attestation(event="merge_group", exact="0").returncode,
+            0,
+        )
+
+    def test_wrong_head_fails(self) -> None:
+        original = self.sha
+        self.sha = "0" * 40
+        try:
+            self.assertNotEqual(self.run_attestation().returncode, 0)
+        finally:
+            self.sha = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR removes the synthetic merge/source-overlay path from required PR CI and builds the exact immutable PR head with its historical configuration. A workflow-pinned harness attests unchanged lakefiles, validates autonomous forward pin bumps, searches the complete cache ancestry, and runs trusted audits without invoking candidate scripts.

Depends on #4667.

Validated locally on the complete stack with workflow parsing, configuration-attestation and infrastructure policy tests, lake build --iofail, and the full audit/lint suite. Branch-pinned GitHub runs on #4668 and #4669 also passed the exact-head workflow; cache lookup skipped uncached tip commits, restored the first cached main ancestor, and completed all sandboxed audits.

Roadmap: none

:robot: Prepared with OpenAI Codex