### PR TITLE
feat: the iterated generator domains of a C₀-semigroup are dense

### DIFF
--- a/TauCeti/Analysis/Normed/Operator/Resolvent/DomainPow.lean
+++ b/TauCeti/Analysis/Normed/Operator/Resolvent/DomainPow.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Normed.Operator.Resolvent.Unbounded
+public import TauCeti.LinearAlgebra.LinearPMap.DomainPow
+
+/-!
+# The resolvent raises the order of an iterated domain
+
+At a point `lambda` of the resolvent set of an unbounded operator `A`, the resolvent
+`R(lambda, A)` is a right inverse of `lambda • I - A`, so `A R(lambda) y = lambda R(lambda) y - y`
+for every `y`. Reading that identity as a recursion turns a single regularity step,
+`R(lambda) y ∈ D(A)`, into the statement that `R(lambda)` maps `D(Aⁿ)` into `D(Aⁿ⁺¹)`; in
+particular `R(lambda)ⁿ` lands in `D(Aⁿ)`.
+
+These are the regularising maps behind the density of the iterated domains `D(Aⁿ)`, since
+`lambdaⁿ R(lambda)ⁿ` converges strongly to the identity for a generator.
+
+## Main results
+
+* `TauCeti.resolvent_mem_domainPow_succ`: `R(lambda)` maps `D(Aⁿ)` into `D(Aⁿ⁺¹)`.
+* `TauCeti.resolvent_pow_mem_domainPow`: `R(lambda)ⁿ` maps `X` into `D(Aⁿ)`.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+variable {A : X →ₗ.[ℝ] X} {lambda : ℝ}
+
+/-- The resolvent raises the order of an iterated domain by one: it maps `D(Aⁿ)` into
+`D(Aⁿ⁺¹)`. -/
+theorem resolvent_mem_domainPow_succ (h : lambda ∈ LinearPMap.resolventSet A) {n : ℕ} {x : X}
+    (hx : x ∈ domainPow A n) :
+    LinearPMap.resolvent A lambda x ∈ domainPow A (n + 1) := by
+  induction n generalizing x with
+  | zero =>
+      rw [zero_add, domainPow_one]
+      exact LinearPMap.resolvent_mem_domain h x
+  | succ n ih =>
+      refine mem_domainPow_succ.mpr ⟨LinearPMap.resolvent_mem_domain h x, ?_⟩
+      rw [LinearPMap.apply_resolvent h x]
+      exact sub_mem (Submodule.smul_mem _ lambda (ih (domainPow_succ_le A n hx))) hx
+
+/-- The `n`-th power of the resolvent regularises every vector to order `n`: it maps `X` into
+`D(Aⁿ)`. -/
+theorem resolvent_pow_mem_domainPow (h : lambda ∈ LinearPMap.resolventSet A) (n : ℕ) (x : X) :
+    (LinearPMap.resolvent A lambda ^ n) x ∈ domainPow A n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      have hstep : (LinearPMap.resolvent A lambda ^ (n + 1)) x
+          = LinearPMap.resolvent A lambda ((LinearPMap.resolvent A lambda ^ n) x) := by
+        rw [pow_succ', mul_apply_eq_comp]
+      rw [hstep]
+      exact resolvent_mem_domainPow_succ h ih
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Analysis/Semigroups/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Generator.lean
@@ -11,6 +11,7 @@ public import TauCeti.Analysis.Semigroups.Generator.Invariance
 public import TauCeti.Analysis.Semigroups.Generator.Closed
 public import TauCeti.Analysis.Semigroups.Generator.Uniqueness
 public import TauCeti.Analysis.Semigroups.Generator.ExponentialShift
+public import TauCeti.Analysis.Semigroups.Generator.IteratedDomain
 
 /-!
 # Infinitesimal generators of strongly continuous semigroups

--- a/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Normed.Operator.Dense
+public import TauCeti.Analysis.Normed.Operator.Resolvent.DomainPow
+public import TauCeti.Analysis.Semigroups.Generator.Invariance
+public import TauCeti.Analysis.Semigroups.Resolvent.Identity
+
+/-!
+# The iterated generator domains of a strongly continuous semigroup are dense
+
+`StronglyContinuousSemigroup.dense_domain` says that the domain `D(A)` of the infinitesimal
+generator is dense. This file proves the same for every iterate: the domain `D(Aⁿ)` of the
+`n`-th iterate of the generator is dense as well, and is preserved by every semigroup operator.
+
+The regularising maps are the powers of the resolvent. `R(lambda)ⁿ` lands in `D(Aⁿ)`
+(`TauCeti.resolvent_pow_mem_domainPow`), and `lambdaⁿ R(lambda)ⁿ` converges strongly to the
+identity as `lambda → ∞`, so every vector is a limit of vectors of `D(Aⁿ)`. The convergence is
+proved here at a general growth exponent: the exponent-zero statement
+`TauCeti.Semigroups.tendsto_smul_resolvent_apply_atTop` asks for `‖R(lambda)‖ ≤ M / lambda`,
+which a semigroup only satisfies once its growth exponent is at most `0`.
+
+## Main results
+
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.realOperator_mem_domainPow`: every `S t`
+  preserves `D(Aⁿ)`.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.tendsto_smul_resolventFun_apply`:
+  `lambda R(lambda) x → x` as `lambda → ∞`.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.dense_domainPow`: `D(Aⁿ)` is dense.
+
+## References
+
+Engel--Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Lemma II.1.3 and
+Theorem II.1.10; Pazy, *Semigroups of Linear Operators and Applications to Partial Differential
+Equations*, Theorem 1.2.7.
+-/
+
+public section
+
+noncomputable section
+
+open Filter
+open scoped NNReal Topology
+
+namespace TauCeti.Semigroups
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
+
+namespace StronglyContinuousSemigroup
+
+variable (S : StronglyContinuousSemigroup X) {omega M : ℝ}
+
+omit [CompleteSpace X] in
+/-- Every semigroup operator preserves each iterated generator domain `D(Aⁿ)`. -/
+theorem realOperator_mem_domainPow {t : ℝ} (ht : 0 ≤ t) {n : ℕ} {x : X}
+    (hx : x ∈ domainPow S.generator n) :
+    S.realOperator t x ∈ domainPow S.generator n := by
+  induction n generalizing x with
+  | zero => simp
+  | succ n ih =>
+      obtain ⟨hxd, hAx⟩ := mem_domainPow_succ.mp hx
+      have hxd' : x ∈ S.domain := by rwa [S.generator_domain] at hxd
+      have hmem : S.realOperator t x ∈ S.generator.domain := by
+        rw [S.generator_domain]
+        exact S.realOperator_mem_domain ht hxd'
+      refine mem_domainPow_succ.mpr ⟨hmem, ?_⟩
+      have hcomm : S.generator ⟨S.realOperator t x, hmem⟩
+          = S.realOperator t (S.generator ⟨x, hxd⟩) :=
+        S.realOperator_generator_map ht ⟨x, hxd'⟩
+      rw [hcomm]
+      exact ih hAx
+
+/-! ## Strong convergence of the scaled resolvents -/
+
+/-- On the generator domain the scaled resolvent differs from the identity by the resolvent of
+`A x`: `lambda R(lambda) x - x = R(lambda) (A x)`. -/
+private theorem smul_resolventFun_sub_self (hb : S.HasGrowthBound omega M) {lambda : ℝ}
+    (hlt : omega < lambda) {x : X} (hxd : x ∈ S.generator.domain) :
+    lambda • S.resolventFun hb lambda x - x = S.resolventFun hb lambda (S.generator ⟨x, hxd⟩) := by
+  have hres : lambda ∈ LinearPMap.resolventSet S.generator := S.mem_resolventSet_generator hb hlt
+  have heq : LinearPMap.resolvent S.generator lambda = S.resolventFun hb lambda := by
+    rw [S.generator_resolvent_eq hb hlt, S.resolventFun_of_lt hb hlt]
+  rw [← heq, LinearPMap.resolvent_apply_comm hres ⟨x, hxd⟩, LinearPMap.apply_resolvent hres x]
+
+/-- Beyond `2 |omega| + 1` the scaled resolvent `lambda R(lambda)` is bounded by `2 M`. The
+factor `2` absorbs the difference between `lambda` and `lambda - omega`. -/
+private theorem norm_smul_resolventFun_le (hb : S.HasGrowthBound omega M) {lambda : ℝ}
+    (hlambda : 2 * |omega| + 1 ≤ lambda) :
+    ‖lambda • S.resolventFun hb lambda‖ ≤ 2 * M := by
+  have hM : (0 : ℝ) ≤ M := zero_le_one.trans hb.one_le
+  have habs : omega ≤ |omega| := le_abs_self omega
+  have habs0 : (0 : ℝ) ≤ |omega| := abs_nonneg omega
+  have hpos : (0 : ℝ) < lambda := by linarith
+  have hlt : omega < lambda := by linarith
+  have hd : (0 : ℝ) < lambda - omega := by linarith
+  have hhalf : lambda ≤ 2 * (lambda - omega) := by linarith
+  rw [norm_smul, Real.norm_eq_abs, abs_of_pos hpos]
+  calc lambda * ‖S.resolventFun hb lambda‖
+      ≤ lambda * (M / (lambda - omega)) := by
+        gcongr
+        exact S.resolventFun_norm_le hb hlt
+    _ ≤ 2 * M := by
+        rw [mul_div_assoc', div_le_iff₀ hd]
+        nlinarith [mul_le_mul_of_nonneg_right hhalf hM]
+
+private theorem tendsto_smul_resolventFun_apply_of_mem (hb : S.HasGrowthBound omega M)
+    {x : X} (hxd : x ∈ S.generator.domain) :
+    Tendsto (fun lambda : ℝ => lambda • S.resolventFun hb lambda x) atTop (nhds x) := by
+  have hbnd : ∀ᶠ lambda : ℝ in atTop, ‖lambda • S.resolventFun hb lambda x - x‖
+      ≤ M / (lambda - omega) * ‖S.generator ⟨x, hxd⟩‖ := by
+    filter_upwards [eventually_gt_atTop omega] with lambda hlt
+    rw [S.smul_resolventFun_sub_self hb hlt hxd]
+    refine ((S.resolventFun hb lambda).le_opNorm _).trans ?_
+    gcongr
+    exact S.resolventFun_norm_le hb hlt
+  have hzero : Tendsto
+      (fun lambda : ℝ => M / (lambda - omega) * ‖S.generator ⟨x, hxd⟩‖) atTop (nhds 0) := by
+    have hshift : Tendsto (fun lambda : ℝ => lambda - omega) atTop atTop := by
+      simpa [sub_eq_add_neg] using tendsto_atTop_add_const_right atTop (-omega) tendsto_id
+    have hdiv : Tendsto (fun lambda : ℝ => M / (lambda - omega)) atTop (nhds 0) :=
+      tendsto_const_nhds.div_atTop hshift
+    simpa using hdiv.mul_const ‖S.generator ⟨x, hxd⟩‖
+  simpa using (squeeze_zero_norm' hbnd hzero).add_const x
+
+/-- **The scaled resolvents converge strongly to the identity.** For a C₀-semigroup with growth
+bound `(omega, M)`, `lambda R(lambda) x → x` as `lambda → ∞`, for every `x`. -/
+theorem tendsto_smul_resolventFun_apply (hb : S.HasGrowthBound omega M) (x : X) :
+    Tendsto (fun lambda : ℝ => lambda • S.resolventFun hb lambda x) atTop (nhds x) := by
+  have hbound : ∀ᶠ lambda : ℝ in atTop, ‖lambda • S.resolventFun hb lambda‖ ≤ 2 * M := by
+    filter_upwards [eventually_ge_atTop (2 * |omega| + 1)] with lambda hlambda
+    exact S.norm_smul_resolventFun_le hb hlambda
+  have htend : ∀ y ∈ (S.generator.domain : Set X),
+      Tendsto (fun lambda : ℝ => (lambda • S.resolventFun hb lambda) y) atTop
+        (nhds ((1 : X →L[ℝ] X) y)) := fun y hy => by
+    simpa using S.tendsto_smul_resolventFun_apply_of_mem hb hy
+  have hdense : Dense (S.generator.domain : Set X) := by
+    rw [S.generator_domain]
+    exact S.dense_domain
+  simpa using ContinuousLinearMap.tendsto_apply_of_dense (𝕜 := ℝ) (l := atTop)
+    (f := fun lambda : ℝ => lambda • S.resolventFun hb lambda) (g := 1) (C := 2 * M)
+    hdense hbound htend x
+
+/-- If `f lambda → x`, then applying the scaled resolvent along the way does not change the
+limit. This is the induction step behind the convergence of `lambdaⁿ R(lambda)ⁿ`. -/
+private theorem tendsto_smul_resolventFun_comp (hb : S.HasGrowthBound omega M) {f : ℝ → X} {x : X}
+    (hf : Tendsto f atTop (nhds x)) :
+    Tendsto (fun lambda : ℝ => lambda • S.resolventFun hb lambda (f lambda)) atTop (nhds x) := by
+  have hsmall : Tendsto
+      (fun lambda : ℝ => (lambda • S.resolventFun hb lambda) (f lambda - x)) atTop (nhds 0) := by
+    have hnorm : Tendsto (fun lambda : ℝ => 2 * M * ‖f lambda - x‖) atTop (nhds 0) := by
+      simpa using (tendsto_iff_norm_sub_tendsto_zero.mp hf).const_mul (2 * M)
+    refine squeeze_zero_norm' ?_ hnorm
+    filter_upwards [eventually_ge_atTop (2 * |omega| + 1)] with lambda hlambda
+    calc ‖(lambda • S.resolventFun hb lambda) (f lambda - x)‖
+        ≤ ‖lambda • S.resolventFun hb lambda‖ * ‖f lambda - x‖ :=
+          ContinuousLinearMap.le_opNorm _ _
+      _ ≤ 2 * M * ‖f lambda - x‖ := by
+          gcongr
+          exact S.norm_smul_resolventFun_le hb hlambda
+  have hsum := hsmall.add (S.tendsto_smul_resolventFun_apply hb x)
+  rw [zero_add] at hsum
+  refine hsum.congr fun lambda => ?_
+  rw [map_sub]
+  simp
+
+/-- **The iterated scaled resolvents converge strongly to the identity**:
+`lambdaⁿ R(lambda)ⁿ x → x` as `lambda → ∞`. -/
+theorem tendsto_pow_smul_resolventFun_pow_apply (hb : S.HasGrowthBound omega M) (n : ℕ) (x : X) :
+    Tendsto (fun lambda : ℝ => (lambda ^ n) • ((S.resolventFun hb lambda ^ n) x)) atTop
+      (nhds x) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      refine (S.tendsto_smul_resolventFun_comp hb ih).congr fun lambda => ?_
+      rw [map_smul, smul_smul, ← pow_succ', pow_succ' (S.resolventFun hb lambda),
+        mul_apply_eq_comp]
+
+/-- Density of `D(Aⁿ)` at a prescribed growth bound; the growth bound is only a device for
+naming the resolvent, and `StronglyContinuousSemigroup.dense_domainPow` drops it. -/
+private theorem dense_domainPow_of (hb : S.HasGrowthBound omega M) (n : ℕ) :
+    Dense (domainPow S.generator n : Set X) := by
+  intro x
+  refine mem_closure_of_tendsto (S.tendsto_pow_smul_resolventFun_pow_apply hb n x) ?_
+  filter_upwards [eventually_gt_atTop omega] with lambda hlt
+  refine Submodule.smul_mem _ _ ?_
+  have heq : S.resolventFun hb lambda = LinearPMap.resolvent S.generator lambda := by
+    rw [S.generator_resolvent_eq hb hlt, S.resolventFun_of_lt hb hlt]
+  rw [heq]
+  exact resolvent_pow_mem_domainPow (S.mem_resolventSet_generator hb hlt) n x
+
+/-- **The iterated generator domains are dense.** For every `n`, the domain `D(Aⁿ)` of the
+`n`-th iterate of the infinitesimal generator of a C₀-semigroup is dense in the whole space.
+
+For `n = 1` this is `StronglyContinuousSemigroup.dense_domain`. -/
+theorem dense_domainPow (n : ℕ) :
+    Dense (domainPow S.generator n : Set X) := by
+  obtain ⟨omega, M, hb⟩ := S.existsGrowthBound
+  exact S.dense_domainPow_of hb n
+
+end StronglyContinuousSemigroup
+
+end TauCeti.Semigroups
+
+end
+
+end

--- a/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
@@ -176,8 +176,7 @@ theorem tendsto_pow_smul_resolventFun_pow_apply (hb : S.HasGrowthBound omega M) 
   | zero => simp
   | succ n ih =>
       refine (S.tendsto_smul_resolventFun_comp hb ih).congr fun lambda => ?_
-      rw [map_smul, smul_smul, ← pow_succ', pow_succ' (S.resolventFun hb lambda),
-        mul_apply_eq_comp]
+      simp only [map_smul, smul_smul, pow_succ', mul_apply_eq_comp]
 
 /-- Density of `D(Aⁿ)` at a prescribed growth bound; the growth bound is only a device for
 naming the resolvent, and `StronglyContinuousSemigroup.dense_domainPow` drops it. -/

--- a/TauCeti/LinearAlgebra/LinearPMap/DomainPow.lean
+++ b/TauCeti/LinearAlgebra/LinearPMap/DomainPow.lean
@@ -28,7 +28,7 @@ differentiable, and where the density of every `D(Aⁿ)` is the standard regular
 
 * `TauCeti.domainPow`: the submodule `D(Aⁿ)`.
 * `TauCeti.mem_domainPow_succ`: the recursive membership criterion defining it.
-* `TauCeti.antitone_domainPow`: `D(Aⁿ)` decreases with `n`.
+* `TauCeti.domainPow_antitone`: `D(Aⁿ)` decreases with `n`.
 * `TauCeti.apply_mem_domainPow`: `A` maps `D(Aⁿ⁺¹)` into `D(Aⁿ)`.
 
 Tau Ceti puts every declaration under `namespace TauCeti`, so a name in the `LinearPMap`
@@ -56,6 +56,7 @@ theorem domainPow_succ (A : E →ₗ.[R] E) (n : ℕ) :
   (rfl)
 
 /-- Membership in `D(Aⁿ⁺¹)`: a vector of `D(A)` whose image under `A` lies in `D(Aⁿ)`. -/
+@[simp]
 theorem mem_domainPow_succ {A : E →ₗ.[R] E} {n : ℕ} {x : E} :
     x ∈ domainPow A (n + 1) ↔ ∃ hx : x ∈ A.domain, A ⟨x, hx⟩ ∈ domainPow A n := by
   rw [domainPow_succ]
@@ -78,12 +79,12 @@ theorem domainPow_succ_le (A : E →ₗ.[R] E) (n : ℕ) : domainPow A (n + 1) �
       obtain ⟨hxd, hAx⟩ := mem_domainPow_succ.mp hx
       exact mem_domainPow_succ.mpr ⟨hxd, ih hAx⟩
 
-theorem antitone_domainPow (A : E →ₗ.[R] E) : Antitone (domainPow A) :=
+theorem domainPow_antitone (A : E →ₗ.[R] E) : Antitone (domainPow A) :=
   antitone_nat_of_succ_le (domainPow_succ_le A)
 
 theorem domainPow_succ_le_domain (A : E →ₗ.[R] E) (n : ℕ) : domainPow A (n + 1) ≤ A.domain := by
   rw [← domainPow_one A]
-  exact antitone_domainPow A (Nat.succ_le_succ (Nat.zero_le n))
+  exact domainPow_antitone A (Nat.succ_le_succ (Nat.zero_le n))
 
 /-- `A` maps `D(Aⁿ⁺¹)` into `D(Aⁿ)`. -/
 theorem apply_mem_domainPow {A : E →ₗ.[R] E} {n : ℕ} {x : E} (hx : x ∈ domainPow A (n + 1)) :

--- a/TauCeti/LinearAlgebra/LinearPMap/DomainPow.lean
+++ b/TauCeti/LinearAlgebra/LinearPMap/DomainPow.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.LinearPMap
+
+/-!
+# Domains of the iterates of a partially defined linear map
+
+A partially defined linear map `A : E →ₗ.[R] E` cannot in general be composed with itself:
+`LinearPMap.comp` asks for `A x ∈ D(A)` at every `x ∈ D(A)`, which is exactly what fails for an
+unbounded operator. What always makes sense is the *domain* of the `n`-th iterate,
+
+`D(A⁰) = E`,  `D(Aⁿ⁺¹) = {x ∈ D(A) | A x ∈ D(Aⁿ)}`,
+
+the largest submodule on which `A` may be applied `n` times in succession. This file defines it
+and develops its elementary structure: it shrinks as `n` grows, `D(A¹)` is `D(A)`, and `A` maps
+`D(Aⁿ⁺¹)` into `D(Aⁿ)`.
+
+The intended consumer is the theory of strongly continuous semigroups, where `D(Aⁿ)` for the
+infinitesimal generator `A` is the space of vectors whose orbit is `n` times continuously
+differentiable, and where the density of every `D(Aⁿ)` is the standard regularisation statement.
+
+## Main declarations
+
+* `TauCeti.domainPow`: the submodule `D(Aⁿ)`.
+* `TauCeti.mem_domainPow_succ`: the recursive membership criterion defining it.
+* `TauCeti.antitone_domainPow`: `D(Aⁿ)` decreases with `n`.
+* `TauCeti.apply_mem_domainPow`: `A` maps `D(Aⁿ⁺¹)` into `D(Aⁿ)`.
+
+Tau Ceti puts every declaration under `namespace TauCeti`, so a name in the `LinearPMap`
+namespace could not be reached by generalized field notation anyway; these therefore live in the
+root `TauCeti` namespace and are written out as `domainPow A n`.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {R E : Type*} [Ring R] [AddCommGroup E] [Module R E]
+
+/-- The domain `D(Aⁿ)` of the `n`-th iterate of a partially defined linear map `A`: the
+submodule of vectors to which `A` may be applied `n` times in succession. -/
+def domainPow (A : E →ₗ.[R] E) : ℕ → Submodule R E
+  | 0 => ⊤
+  | n + 1 => Submodule.map A.domain.subtype ((domainPow A n).comap A.toFun)
+
+@[simp]
+theorem domainPow_zero (A : E →ₗ.[R] E) : domainPow A 0 = ⊤ := (rfl)
+
+theorem domainPow_succ (A : E →ₗ.[R] E) (n : ℕ) :
+    domainPow A (n + 1) = Submodule.map A.domain.subtype ((domainPow A n).comap A.toFun) :=
+  (rfl)
+
+/-- Membership in `D(Aⁿ⁺¹)`: a vector of `D(A)` whose image under `A` lies in `D(Aⁿ)`. -/
+theorem mem_domainPow_succ {A : E →ₗ.[R] E} {n : ℕ} {x : E} :
+    x ∈ domainPow A (n + 1) ↔ ∃ hx : x ∈ A.domain, A ⟨x, hx⟩ ∈ domainPow A n := by
+  rw [domainPow_succ]
+  constructor
+  · rintro ⟨y, hy, rfl⟩
+    exact ⟨y.2, hy⟩
+  · rintro ⟨hx, hAx⟩
+    exact ⟨⟨x, hx⟩, hAx, rfl⟩
+
+@[simp]
+theorem domainPow_one (A : E →ₗ.[R] E) : domainPow A 1 = A.domain := by
+  ext x
+  simp [mem_domainPow_succ]
+
+theorem domainPow_succ_le (A : E →ₗ.[R] E) (n : ℕ) : domainPow A (n + 1) ≤ domainPow A n := by
+  induction n with
+  | zero => rw [domainPow_zero]; exact le_top
+  | succ n ih =>
+      intro x hx
+      obtain ⟨hxd, hAx⟩ := mem_domainPow_succ.mp hx
+      exact mem_domainPow_succ.mpr ⟨hxd, ih hAx⟩
+
+theorem antitone_domainPow (A : E →ₗ.[R] E) : Antitone (domainPow A) :=
+  antitone_nat_of_succ_le (domainPow_succ_le A)
+
+theorem domainPow_succ_le_domain (A : E →ₗ.[R] E) (n : ℕ) : domainPow A (n + 1) ≤ A.domain := by
+  rw [← domainPow_one A]
+  exact antitone_domainPow A (Nat.succ_le_succ (Nat.zero_le n))
+
+/-- `A` maps `D(Aⁿ⁺¹)` into `D(Aⁿ)`. -/
+theorem apply_mem_domainPow {A : E →ₗ.[R] E} {n : ℕ} {x : E} (hx : x ∈ domainPow A (n + 1)) :
+    A ⟨x, domainPow_succ_le_domain A n hx⟩ ∈ domainPow A n :=
+  (mem_domainPow_succ.mp hx).choose_spec
+
+end TauCeti
+
+end

--- a/TauCeti/LinearAlgebra/LinearPMap/DomainPow.lean
+++ b/TauCeti/LinearAlgebra/LinearPMap/DomainPow.lean
@@ -79,6 +79,7 @@ theorem domainPow_succ_le (A : E →ₗ.[R] E) (n : ℕ) : domainPow A (n + 1) �
       obtain ⟨hxd, hAx⟩ := mem_domainPow_succ.mp hx
       exact mem_domainPow_succ.mpr ⟨hxd, ih hAx⟩
 
+/-- The iterated domains `D(Aⁿ)` decrease as the iteration count increases. -/
 theorem domainPow_antitone (A : E →ₗ.[R] E) : Antitone (domainPow A) :=
   antitone_nat_of_succ_le (domainPow_succ_le A)
 


### PR DESCRIPTION
This PR proves that every iterated domain `D(Aⁿ)` of the infinitesimal generator of a strongly continuous semigroup is dense, and that each semigroup operator preserves it. It defines `TauCeti.domainPow A n`, the domain of the `n`-th iterate of a partially defined linear map `A : E →ₗ.[R] E` (an unbounded operator cannot be composed with itself, so `LinearPMap.comp` does not apply and only the iterated *domain* is available), develops its order structure, shows that at a resolvent point `R(lambda)` maps `D(Aⁿ)` into `D(Aⁿ⁺¹)` and hence `R(lambda)ⁿ` maps `X` into `D(Aⁿ)`, proves the strong convergence `lambdaⁿ R(lambda)ⁿ x → x` for a semigroup with growth bound `(omega, M)`, and concludes density.

The roadmap target is `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A, the "API to develop" bullet **Foundational lemmas**: "a **named density-of-`D(A)`** theorem for generated semigroups (density of `D(Aⁿ)` / smooth vectors is a useful secondary target)". The milestone this serves is Part A's **Hille–Yosida generation theorem**, whose surrounding theory the roadmap asks to be developed rather than left as an isolated endpoint: `dense_domain` (the `n = 1` case) has been on `main` since the generator was built and is consumed by the generation theorems, while the stated secondary target `D(Aⁿ)` had no definition at all. Part A's remaining API items after this PR are the bounded-perturbation theorem at a general growth constant `M`, complex analyticity of `lambda ↦ R(lambda, A)` via complexification, and the C₀-group / Stone stretch goal.

New declarations. `TauCeti.domainPow` with `domainPow_zero`, `domainPow_succ`, `mem_domainPow_succ`, `domainPow_one`, `domainPow_succ_le`, `antitone_domainPow`, `domainPow_succ_le_domain`, `apply_mem_domainPow`; `TauCeti.resolvent_mem_domainPow_succ` and `TauCeti.resolvent_pow_mem_domainPow`; and, for a C₀-semigroup, `realOperator_mem_domainPow`, `tendsto_smul_resolventFun_apply`, `tendsto_pow_smul_resolventFun_pow_apply` and `dense_domainPow`.

Files added: `TauCeti/LinearAlgebra/LinearPMap/DomainPow.lean` (95 lines), `TauCeti/Analysis/Normed/Operator/Resolvent/DomainPow.lean` (69 lines), `TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean` (214 lines); `TauCeti/Analysis/Semigroups/Generator.lean` gains the new module in its re-export list.

Two notes on the design. The algebraic `domainPow` is stated for an arbitrary `LinearPMap` over a ring, and the resolvent lemmas only assume `lambda ∈ LinearPMap.resolventSet A`, so neither depends on the semigroup; they live at that level. The strong convergence `lambda R(lambda) x → x` is proved here at a general growth exponent because the existing exponent-zero statement `TauCeti.Semigroups.tendsto_smul_resolvent_apply_atTop` assumes `‖R(lambda, A)‖ ≤ M / lambda`, which a C₀-semigroup satisfies only once its growth exponent is at most `0`; it reuses `TauCeti.ContinuousLinearMap.tendsto_apply_of_dense` for the density step and the existing sharp Hille–Yosida bound `‖R(lambda)‖ ≤ M / (lambda − omega)`.

The mathematics follows Engel–Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Lemma II.1.3 and Theorem II.1.10, and Pazy, *Semigroups of Linear Operators and Applications to Partial Differential Equations*, Theorem 1.2.7; both are cited in the file headers. No Mathlib source was vendored.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"dense-domainpow"}-->

🤖 Prepared with Claude Code
