### PR TITLE
feat: define adjoint semisimple group schemes

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Adjoint/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Adjoint/Basic.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Center.Isomorphism
+public import TauCeti.Algebra.AlgebraicGroup.Semisimple.Basic
+
+/-!
+# Adjoint semisimple affine groups in Hopf coordinates
+
+A semisimple affine group over a field is **adjoint** when its scheme-theoretic center is
+trivial.  For a commutative Hopf algebra `H`, closed subgroup schemes are encoded
+contravariantly by Hopf ideals.  Thus the center is trivial precisely when its defining ideal is
+the augmentation ideal, which cuts out the identity subgroup.
+
+This file packages that condition as an isomorphism-invariant property of semisimple finite-type
+commutative Hopf algebras.  Its characteristic pointwise form says that every universally central
+algebra-valued point is the identity.  This criterion quantifies over all commutative value
+algebras; testing only rational points would miss infinitesimal centers such as `mu_p` in
+characteristic `p`.
+
+## Main declarations
+
+* `TauCeti.adjointSemisimpleCommHopfAlgProperty`: adjointness for semisimple finite-type
+  commutative Hopf algebras.
+* `TauCeti.AdjointSemisimpleCommHopfAlgCat`: the corresponding full subcategory.
+* `TauCeti.adjointSemisimpleCommHopfAlgProperty_iff_forall_isCentralPoint_eq_one`: adjointness is
+  equivalent to triviality of every universally central algebra-valued point.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§1.k and 21.4.
+* T. A. Springer, *Linear Algebraic Groups*, §9.6.
+
+This supplies the adjoint-form definition in Layer 6, "Reductive and semisimple groups", of the
+ReductiveGroups roadmap.  Construction of the adjoint quotient and the classification of adjoint
+forms remain downstream.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+variable {k : Type u} [Field k]
+
+/-- The object property selecting adjoint semisimple affine groups in Hopf coordinates.
+
+An object is already semisimple by belonging to `SemisimpleCommHopfAlgCat k`.  Adjointness says
+that its represented center is the identity subgroup, so the center defining ideal is the
+augmentation ideal. -/
+def adjointSemisimpleCommHopfAlgProperty (k : Type u) [Field k] :
+    ObjectProperty (SemisimpleCommHopfAlgCat.{u} k) :=
+  fun H => CommHopfAlgCat.centerDefiningIdeal H.obj.obj = HopfIdeal.augmentation k H.obj.obj
+
+/-- Membership in the adjoint property means that the center defining ideal is the augmentation
+ideal. -/
+@[simp]
+theorem adjointSemisimpleCommHopfAlgProperty_iff
+    (H : SemisimpleCommHopfAlgCat.{u} k) :
+    adjointSemisimpleCommHopfAlgProperty k H ↔
+      CommHopfAlgCat.centerDefiningIdeal H.obj.obj = HopfIdeal.augmentation k H.obj.obj :=
+  Iff.rfl
+
+namespace adjointSemisimpleCommHopfAlgProperty
+
+variable {H : SemisimpleCommHopfAlgCat.{u} k}
+
+/-- The represented center of an adjoint semisimple affine group is cut out by the augmentation
+ideal. -/
+theorem centerDefiningIdeal_eq_augmentation
+    (hH : adjointSemisimpleCommHopfAlgProperty k H) :
+    CommHopfAlgCat.centerDefiningIdeal H.obj.obj = HopfIdeal.augmentation k H.obj.obj :=
+  hH
+
+/-- Every universally central point of an adjoint semisimple affine group is the identity. -/
+theorem isCentralPoint_eq_one
+    (hH : adjointSemisimpleCommHopfAlgProperty k H)
+    (A : CommAlgCat.{u} k)
+    (g : HopfAlgebra.points (R := k) (H := H.obj.obj) A)
+    (hg : HopfAlgebra.IsCentralPoint g) : g = 1 := by
+  apply CommHopfAlgCat.eq_one_of_mem_quotientPointsSubgroup_augmentation H.obj.obj A
+  rw [← hH.centerDefiningIdeal_eq_augmentation,
+    CommHopfAlgCat.mem_centerPointsSubgroup_iff]
+  exact hg
+
+end adjointSemisimpleCommHopfAlgProperty
+
+/-- Triviality of the represented center can be tested on all algebra-valued points. -/
+theorem centerDefiningIdeal_eq_augmentation_iff_forall_isCentralPoint_eq_one
+    (H : _root_.CommHopfAlgCat.{u} k) :
+    CommHopfAlgCat.centerDefiningIdeal H = HopfIdeal.augmentation k H ↔
+      ∀ (A : CommAlgCat.{u} k)
+        (g : HopfAlgebra.points (R := k) (H := H) A),
+        HopfAlgebra.IsCentralPoint g → g = 1 := by
+  constructor
+  · intro h A g hg
+    apply CommHopfAlgCat.eq_one_of_mem_quotientPointsSubgroup_augmentation H A
+    rw [← h, CommHopfAlgCat.mem_centerPointsSubgroup_iff]
+    exact hg
+  · intro h
+    apply le_antisymm
+    · exact HopfIdeal.le_augmentation k H (CommHopfAlgCat.centerDefiningIdeal H)
+    intro x hx
+    let A : CommAlgCat.{u} k :=
+      CommAlgCat.of k (H ⧸ (CommHopfAlgCat.centerDefiningIdeal H).toIdeal)
+    let q : HopfAlgebra.points (R := k) (H := H) A :=
+      toConv (Ideal.Quotient.mkₐ k (CommHopfAlgCat.centerDefiningIdeal H).toIdeal)
+    have hqcentral : HopfAlgebra.IsCentralPoint q := by
+      rw [← CommHopfAlgCat.mem_centerPointsSubgroup_iff]
+      rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
+      intro y hy
+      exact Ideal.Quotient.eq_zero_iff_mem.mpr (HopfIdeal.mem_toIdeal.mpr hy)
+    have hq : q = 1 := h A q hqcentral
+    apply HopfIdeal.mem_toIdeal.mp
+    apply Ideal.Quotient.eq_zero_iff_mem.mp
+    have hxzero : Coalgebra.counit (R := k) x = 0 :=
+      (HopfIdeal.mem_augmentation k H).mp hx
+    calc
+      Ideal.Quotient.mkₐ k (CommHopfAlgCat.centerDefiningIdeal H).toIdeal x =
+          q.ofConv x := rfl
+      _ = (1 : HopfAlgebra.points (R := k) (H := H) A).ofConv x :=
+        congrArg (fun f : HopfAlgebra.points (R := k) (H := H) A => f.ofConv x) hq
+      _ = 0 := by simp [AlgHom.convOne_apply, hxzero]
+
+/-- A semisimple affine group is adjoint exactly when every universally central point over every
+commutative value algebra is the identity. -/
+theorem adjointSemisimpleCommHopfAlgProperty_iff_forall_isCentralPoint_eq_one
+    (H : SemisimpleCommHopfAlgCat.{u} k) :
+    adjointSemisimpleCommHopfAlgProperty k H ↔
+      ∀ (A : CommAlgCat.{u} k)
+        (g : HopfAlgebra.points (R := k) (H := H.obj.obj) A),
+        HopfAlgebra.IsCentralPoint g → g = 1 :=
+  centerDefiningIdeal_eq_augmentation_iff_forall_isCentralPoint_eq_one H.obj.obj
+
+/-- Adjointness of semisimple commutative Hopf algebras is invariant under isomorphism. -/
+instance (k : Type u) [Field k] :
+    (adjointSemisimpleCommHopfAlgProperty k).IsClosedUnderIsomorphisms where
+  of_iso {H K} e hH := by
+    let e₁ : H.obj.obj ≅ K.obj.obj :=
+      { hom := e.hom.hom.hom
+        inv := e.inv.hom.hom
+        hom_inv_id := by simp
+        inv_hom_id := by simp }
+    let f : H.obj.obj →ₐc[k] K.obj.obj := e₁.hom.hom
+    have hf : Function.Surjective f := ConcreteCategory.bijective_of_isIso e₁.hom |>.2
+    apply (adjointSemisimpleCommHopfAlgProperty_iff K).2
+    apply (HopfIdeal.comap_eq_comap_iff_of_surjective e₁.hom.hom hf).mp
+    calc
+      (CommHopfAlgCat.centerDefiningIdeal K.obj.obj).comap e₁.hom.hom hf =
+          CommHopfAlgCat.centerDefiningIdeal H.obj.obj := by
+        simpa only using CommHopfAlgCat.comap_centerDefiningIdeal e₁
+      _ = HopfIdeal.augmentation k H.obj.obj :=
+        (adjointSemisimpleCommHopfAlgProperty_iff H).1 hH
+      _ = (HopfIdeal.augmentation k K.obj.obj).comap e₁.hom.hom hf := by
+        simpa only using (HopfIdeal.comap_augmentation e₁.hom.hom hf).symm
+
+/-- The category of adjoint semisimple finite-type commutative Hopf algebras over a field. -/
+abbrev AdjointSemisimpleCommHopfAlgCat (k : Type u) [Field k] :=
+  (adjointSemisimpleCommHopfAlgProperty k).FullSubcategory
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Adjoint/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Adjoint/Basic.lean
@@ -74,62 +74,17 @@ namespace adjointSemisimpleCommHopfAlgProperty
 
 variable {H : SemisimpleCommHopfAlgCat.{u} k}
 
-/-- The represented center of an adjoint semisimple affine group is cut out by the augmentation
-ideal. -/
-theorem centerDefiningIdeal_eq_augmentation
-    (hH : adjointSemisimpleCommHopfAlgProperty k H) :
-    CommHopfAlgCat.centerDefiningIdeal H.obj.obj = HopfIdeal.augmentation k H.obj.obj :=
-  hH
-
 /-- Every universally central point of an adjoint semisimple affine group is the identity. -/
 theorem isCentralPoint_eq_one
     (hH : adjointSemisimpleCommHopfAlgProperty k H)
     (A : CommAlgCat.{u} k)
     (g : HopfAlgebra.points (R := k) (H := H.obj.obj) A)
     (hg : HopfAlgebra.IsCentralPoint g) : g = 1 := by
-  apply CommHopfAlgCat.eq_one_of_mem_quotientPointsSubgroup_augmentation H.obj.obj A
-  rw [← hH.centerDefiningIdeal_eq_augmentation,
-    CommHopfAlgCat.mem_centerPointsSubgroup_iff]
-  exact hg
+  exact
+    (CommHopfAlgCat.centerDefiningIdeal_eq_augmentation_iff_forall_isCentralPoint_eq_one
+      H.obj.obj).1 hH A g hg
 
 end adjointSemisimpleCommHopfAlgProperty
-
-/-- Triviality of the represented center can be tested on all algebra-valued points. -/
-theorem centerDefiningIdeal_eq_augmentation_iff_forall_isCentralPoint_eq_one
-    (H : _root_.CommHopfAlgCat.{u} k) :
-    CommHopfAlgCat.centerDefiningIdeal H = HopfIdeal.augmentation k H ↔
-      ∀ (A : CommAlgCat.{u} k)
-        (g : HopfAlgebra.points (R := k) (H := H) A),
-        HopfAlgebra.IsCentralPoint g → g = 1 := by
-  constructor
-  · intro h A g hg
-    apply CommHopfAlgCat.eq_one_of_mem_quotientPointsSubgroup_augmentation H A
-    rw [← h, CommHopfAlgCat.mem_centerPointsSubgroup_iff]
-    exact hg
-  · intro h
-    apply le_antisymm
-    · exact HopfIdeal.le_augmentation k H (CommHopfAlgCat.centerDefiningIdeal H)
-    intro x hx
-    let A : CommAlgCat.{u} k :=
-      CommAlgCat.of k (H ⧸ (CommHopfAlgCat.centerDefiningIdeal H).toIdeal)
-    let q : HopfAlgebra.points (R := k) (H := H) A :=
-      toConv (Ideal.Quotient.mkₐ k (CommHopfAlgCat.centerDefiningIdeal H).toIdeal)
-    have hqcentral : HopfAlgebra.IsCentralPoint q := by
-      rw [← CommHopfAlgCat.mem_centerPointsSubgroup_iff]
-      rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
-      intro y hy
-      exact Ideal.Quotient.eq_zero_iff_mem.mpr (HopfIdeal.mem_toIdeal.mpr hy)
-    have hq : q = 1 := h A q hqcentral
-    apply HopfIdeal.mem_toIdeal.mp
-    apply Ideal.Quotient.eq_zero_iff_mem.mp
-    have hxzero : Coalgebra.counit (R := k) x = 0 :=
-      (HopfIdeal.mem_augmentation k H).mp hx
-    calc
-      Ideal.Quotient.mkₐ k (CommHopfAlgCat.centerDefiningIdeal H).toIdeal x =
-          q.ofConv x := rfl
-      _ = (1 : HopfAlgebra.points (R := k) (H := H) A).ofConv x :=
-        congrArg (fun f : HopfAlgebra.points (R := k) (H := H) A => f.ofConv x) hq
-      _ = 0 := by simp [AlgHom.convOne_apply, hxzero]
 
 /-- A semisimple affine group is adjoint exactly when every universally central point over every
 commutative value algebra is the identity. -/
@@ -139,7 +94,7 @@ theorem adjointSemisimpleCommHopfAlgProperty_iff_forall_isCentralPoint_eq_one
       ∀ (A : CommAlgCat.{u} k)
         (g : HopfAlgebra.points (R := k) (H := H.obj.obj) A),
         HopfAlgebra.IsCentralPoint g → g = 1 :=
-  centerDefiningIdeal_eq_augmentation_iff_forall_isCentralPoint_eq_one H.obj.obj
+  CommHopfAlgCat.centerDefiningIdeal_eq_augmentation_iff_forall_isCentralPoint_eq_one H.obj.obj
 
 /-- Adjointness of semisimple commutative Hopf algebras is invariant under isomorphism. -/
 instance (k : Type u) [Field k] :

--- a/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Basic.lean
@@ -34,6 +34,9 @@ ideal, so the represented closed subgroup is canonical.
 * `TauCeti.CommHopfAlgCat.centerGroupScheme`: the center as a closed affine group scheme.
 * `TauCeti.CommHopfAlgCat.mem_centerPointsSubgroup_iff`: its points are exactly the universally
   central points.
+* `TauCeti.CommHopfAlgCat.centerDefiningIdeal_eq_augmentation_iff_forall_isCentralPoint_eq_one`:
+  the center is trivial exactly when every universally central algebra-valued point is the
+  identity.
 * `TauCeti.CommHopfAlgCat.centerDefiningIdeal_le_iff`: the center contains every central closed
   subgroup scheme.
 
@@ -388,6 +391,41 @@ theorem mem_centerPointsSubgroup_iff (H : _root_.CommHopfAlgCat.{v} k)
     exact h x ((mem_centerDefiningIdeal_iff H).2 hx)
   · intro h x hx
     exact RingHom.mem_ker.mp (h ((mem_centerDefiningIdeal_iff H).1 hx))
+
+/-- Triviality of the represented center can be tested on all algebra-valued points. -/
+theorem centerDefiningIdeal_eq_augmentation_iff_forall_isCentralPoint_eq_one
+    (H : _root_.CommHopfAlgCat.{v} k) :
+    centerDefiningIdeal H = HopfIdeal.augmentation k H ↔
+      ∀ (A : CommAlgCat.{v} k)
+        (g : HopfAlgebra.points (R := k) (H := H) A),
+        HopfAlgebra.IsCentralPoint g → g = 1 := by
+  constructor
+  · intro h A g hg
+    apply eq_one_of_mem_quotientPointsSubgroup_augmentation H A
+    rw [← h, mem_centerPointsSubgroup_iff]
+    exact hg
+  · intro h
+    apply le_antisymm
+    · exact HopfIdeal.le_augmentation k H (centerDefiningIdeal H)
+    intro x hx
+    let A : CommAlgCat.{v} k := CommAlgCat.of k (H ⧸ (centerDefiningIdeal H).toIdeal)
+    let q : HopfAlgebra.points (R := k) (H := H) A :=
+      toConv (Ideal.Quotient.mkₐ k (centerDefiningIdeal H).toIdeal)
+    have hqcentral : HopfAlgebra.IsCentralPoint q := by
+      rw [← mem_centerPointsSubgroup_iff]
+      rw [mem_quotientPointsSubgroup_iff]
+      intro y hy
+      exact Ideal.Quotient.eq_zero_iff_mem.mpr (HopfIdeal.mem_toIdeal.mpr hy)
+    have hq : q = 1 := h A q hqcentral
+    apply HopfIdeal.mem_toIdeal.mp
+    apply Ideal.Quotient.eq_zero_iff_mem.mp
+    have hxzero : Coalgebra.counit (R := k) x = 0 :=
+      (HopfIdeal.mem_augmentation k H).mp hx
+    calc
+      Ideal.Quotient.mkₐ k (centerDefiningIdeal H).toIdeal x = q.ofConv x := rfl
+      _ = (1 : HopfAlgebra.points (R := k) (H := H) A).ofConv x :=
+        congrArg (fun f : HopfAlgebra.points (R := k) (H := H) A => f.ofConv x) hq
+      _ = 0 := by simp [AlgHom.convOne_apply, hxzero]
 
 /-- The represented center agrees with the center previously defined directly on the functor of
 points. -/

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Adjoint.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Adjoint.lean
@@ -74,28 +74,6 @@ theorem adjointSemisimpleAffineGroupSchemeProperty_iff
         ((semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).inverse.obj G).unop :=
   Iff.rfl
 
-namespace adjointSemisimpleAffineGroupSchemeProperty
-
-variable {G : SemisimpleAffineGroupSchemeCat k}
-
-/-- The coordinate Hopf algebra of an adjoint semisimple affine group has trivial represented
-center. -/
-theorem coordinate
-    (hG : adjointSemisimpleAffineGroupSchemeProperty k G) :
-    adjointSemisimpleCommHopfAlgProperty k
-      ((semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).inverse.obj G).unop :=
-  (adjointSemisimpleAffineGroupSchemeProperty_iff G).1 hG
-
-/-- Establish adjointness of a semisimple affine group scheme by proving that its coordinate Hopf
-algebra has trivial represented center. -/
-theorem mk
-    (hG : adjointSemisimpleCommHopfAlgProperty k
-      ((semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).inverse.obj G).unop) :
-    adjointSemisimpleAffineGroupSchemeProperty k G :=
-  (adjointSemisimpleAffineGroupSchemeProperty_iff G).2 hG
-
-end adjointSemisimpleAffineGroupSchemeProperty
-
 /-- Adjointness of semisimple affine group schemes is invariant under isomorphism. -/
 instance (k : Type u) [Field k] :
     (adjointSemisimpleAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms := by
@@ -135,7 +113,18 @@ noncomputable def
         (adjointSemisimpleAffineGroupSchemeProperty k).ι ≅
       (forget₂ (AdjointSemisimpleCommHopfAlgCat.{u} k)
           (SemisimpleCommHopfAlgCat.{u} k)).op ⋙
-        (semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).functor :=
-  Iso.refl _
+        (semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).functor := by
+  let P := adjointSemisimpleCommHopfAlgProperty k
+  let Q := adjointSemisimpleAffineGroupSchemeProperty k
+  let e := semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k
+  let h := adjointSemisimpleAffineGroupSchemeProperty_inverseImage k
+  exact
+    Functor.associator _ _ _ ≪≫
+      Functor.isoWhiskerLeft (ObjectProperty.opEquivalence P).symm.functor
+        (Q.liftCompιIso (P.op.ι ⋙ e.functor) (fun X ↦
+          (congrFun h X.obj).symm.mp X.property)) ≪≫
+      (Functor.associator _ _ _).symm ≪≫
+      Functor.isoWhiskerRight
+        (P.op.liftCompιIso P.ι.op (fun X ↦ X.unop.property)) e.functor
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Adjoint.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Adjoint.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+import TauCeti.CategoryTheory.ObjectProperty
+public import TauCeti.Algebra.AlgebraicGroup.Adjoint.Basic
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Semisimple
+
+/-!
+# Adjoint semisimple affine group schemes
+
+A semisimple affine group scheme over a field is **adjoint** when its scheme-theoretic center is
+trivial.  This file transports the Hopf-coordinate property
+`adjointSemisimpleCommHopfAlgProperty` across the anti-equivalence between semisimple finite-type
+commutative Hopf algebras and semisimple affine group schemes.
+
+The coordinate characterization says that the Hopf ideal defining the center is the augmentation
+ideal defining the identity subgroup.  By
+`adjointSemisimpleCommHopfAlgProperty_iff_forall_isCentralPoint_eq_one`, this is equivalently the
+all-value-algebras statement that every universally central point is the identity.  In
+particular, adjointness here detects infinitesimal centers and is stronger than triviality of the
+center on points over the ground field alone.
+
+## Main declarations
+
+* `TauCeti.adjointSemisimpleAffineGroupSchemeProperty`: adjointness for semisimple affine group
+  schemes over a field.
+* `TauCeti.AdjointSemisimpleAffineGroupSchemeCat`: the corresponding full subcategory.
+* `TauCeti.adjointSemisimpleAffineGroupSchemeProperty_iff`: the coordinate-Hopf
+  characterization.
+* `TauCeti.adjointSemisimpleCommHopfAlgCatOpEquivAdjointSemisimpleAffineGroupSchemeCat`: the
+  restricted anti-equivalence between the coordinate and scheme models.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §§1.k and 21.4.
+* T. A. Springer, *Linear Algebraic Groups*, §9.6.
+
+This completes the definition-level interface for adjoint forms in Layer 6, "Reductive and
+semisimple groups", of the ReductiveGroups roadmap.  Construction of the represented quotient by
+the center, its adjointness, and the classification of adjoint forms remain downstream.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory Opposite
+
+universe u
+
+variable {k : Type u} [Field k]
+
+/-- The object property selecting adjoint semisimple affine group schemes over a field.
+
+It is transported from the condition that the center defining ideal of the coordinate Hopf
+algebra is its augmentation ideal.  The ambient object is already semisimple by belonging to
+`SemisimpleAffineGroupSchemeCat k`. -/
+def adjointSemisimpleAffineGroupSchemeProperty (k : Type u) [Field k] :
+    ObjectProperty (SemisimpleAffineGroupSchemeCat k) :=
+  (adjointSemisimpleCommHopfAlgProperty k).op.inverseImage
+    (semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).inverse
+
+/-- A semisimple affine group scheme is adjoint exactly when its coordinate Hopf algebra has
+center defining ideal equal to the augmentation ideal. -/
+@[simp]
+theorem adjointSemisimpleAffineGroupSchemeProperty_iff
+    (G : SemisimpleAffineGroupSchemeCat k) :
+    adjointSemisimpleAffineGroupSchemeProperty k G ↔
+      adjointSemisimpleCommHopfAlgProperty k
+        ((semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).inverse.obj G).unop :=
+  Iff.rfl
+
+namespace adjointSemisimpleAffineGroupSchemeProperty
+
+variable {G : SemisimpleAffineGroupSchemeCat k}
+
+/-- The coordinate Hopf algebra of an adjoint semisimple affine group has trivial represented
+center. -/
+theorem coordinate
+    (hG : adjointSemisimpleAffineGroupSchemeProperty k G) :
+    adjointSemisimpleCommHopfAlgProperty k
+      ((semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).inverse.obj G).unop :=
+  (adjointSemisimpleAffineGroupSchemeProperty_iff G).1 hG
+
+/-- Establish adjointness of a semisimple affine group scheme by proving that its coordinate Hopf
+algebra has trivial represented center. -/
+theorem mk
+    (hG : adjointSemisimpleCommHopfAlgProperty k
+      ((semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).inverse.obj G).unop) :
+    adjointSemisimpleAffineGroupSchemeProperty k G :=
+  (adjointSemisimpleAffineGroupSchemeProperty_iff G).2 hG
+
+end adjointSemisimpleAffineGroupSchemeProperty
+
+/-- Adjointness of semisimple affine group schemes is invariant under isomorphism. -/
+instance (k : Type u) [Field k] :
+    (adjointSemisimpleAffineGroupSchemeProperty k).IsClosedUnderIsomorphisms := by
+  unfold adjointSemisimpleAffineGroupSchemeProperty
+  infer_instance
+
+/-- The category of adjoint semisimple affine group schemes over a field. -/
+abbrev AdjointSemisimpleAffineGroupSchemeCat (k : Type u) [Field k] :=
+  (adjointSemisimpleAffineGroupSchemeProperty k).FullSubcategory
+
+/-- Pulling adjointness on semisimple affine group schemes back along `Spec` recovers adjointness
+of semisimple commutative Hopf algebras. -/
+theorem adjointSemisimpleAffineGroupSchemeProperty_inverseImage
+    (k : Type u) [Field k] :
+    (adjointSemisimpleAffineGroupSchemeProperty k).inverseImage
+        (semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).functor =
+      (adjointSemisimpleCommHopfAlgProperty k).op := by
+  unfold adjointSemisimpleAffineGroupSchemeProperty
+  exact ObjectProperty.inverseImage_functor_inverseImage_inverse _ _
+
+/-- `Spec` restricts to an anti-equivalence from adjoint semisimple finite-type commutative Hopf
+algebras to adjoint semisimple affine group schemes. -/
+noncomputable def adjointSemisimpleCommHopfAlgCatOpEquivAdjointSemisimpleAffineGroupSchemeCat
+    (k : Type u) [Field k] :
+    (AdjointSemisimpleCommHopfAlgCat.{u} k)ᵒᵖ ≌
+      AdjointSemisimpleAffineGroupSchemeCat k :=
+  (ObjectProperty.opEquivalence (adjointSemisimpleCommHopfAlgProperty k)).symm.trans <|
+    (semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).congrFullSubcategory
+      (adjointSemisimpleAffineGroupSchemeProperty_inverseImage k)
+
+/-- After forgetting adjointness, the restricted anti-equivalence is the existing semisimple
+Hopf/group-scheme anti-equivalence. -/
+noncomputable def
+    adjointSemisimpleCommHopfAlgCatOpEquivAdjointSemisimpleAffineGroupSchemeCat.functorCompιIso
+    (k : Type u) [Field k] :
+    (adjointSemisimpleCommHopfAlgCatOpEquivAdjointSemisimpleAffineGroupSchemeCat k).functor ⋙
+        (adjointSemisimpleAffineGroupSchemeProperty k).ι ≅
+      (forget₂ (AdjointSemisimpleCommHopfAlgCat.{u} k)
+          (SemisimpleCommHopfAlgCat.{u} k)).op ⋙
+        (semisimpleCommHopfAlgCatOpEquivSemisimpleAffineGroupSchemeCat k).functor :=
+  Iso.refl _
+
+end TauCeti


### PR DESCRIPTION
This PR defines adjoint semisimple affine groups in the synchronized coordinate-Hopf and affine-group-scheme models. It targets `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “Reductive and semisimple groups,” specifically “the simply connected and adjoint forms”: a semisimple group is adjoint when its scheme-theoretic center is trivial, expressed contravariantly as `centerDefiningIdeal H = HopfIdeal.augmentation k H`.

This is the most effective current step because the simply connected property has just landed, while the center, semisimplicity, and affine-group/commutative-Hopf anti-equivalence infrastructure needed for the adjoint counterpart are already on `main`. The coordinate API proves isomorphism invariance and characterizes the property by uniqueness of central points over every commutative `k`-algebra, so it detects nonreduced centers as well as ordinary points. The scheme API transports the property, defines the full subcategory, and restricts the existing anti-equivalence to the adjoint subcategories.

The PR adds `TauCeti/Algebra/AlgebraicGroup/Adjoint/Basic.lean` (172 lines) and `TauCeti/AlgebraicGeometry/AffineGroupScheme/Adjoint.lean` (141 lines).

No Mathlib material is vendored. The implementation reuses Mathlib's `CategoryTheory.ObjectProperty` and Tau Ceti's center ideal, augmentation ideal, semisimple subcategories, and affine-group/commutative-Hopf anti-equivalence. The mathematical organization follows the Milne and Springer references cited in the module documentation.

After this PR, Layer 6 still needs the represented quotient by the center and its adjointness, the construction and classification of simply connected covers and adjoint forms, the radical/derived/central structure theory, and the characteristic-zero reductive/linearly-reductive equivalence.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"adjoint-semisimple-affine-group-scheme"}-->

🤖 Prepared with Codex
