### PR TITLE
feat(Huber): A⟨T⟩ is faithfully flat over a complete noetherian Tate ring (Lemma 8.31(1))

### DIFF
--- a/TauCeti/RingTheory/Huber/Restricted/Flat.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/Flat.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Huber.Restricted.BaseChange
+public import Mathlib.RingTheory.Flat.FaithfullyFlat.Algebra
+import TauCeti.RingTheory.Huber.ClosedSubmodule
+import Mathlib.RingTheory.Flat.Tensor
+
+/-!
+# `A⟨T₁, …, Tₖ⟩` is faithfully flat over a complete noetherian Tate ring
+
+Wedhorn's Lemma 8.31(1): for a complete noetherian Tate ring `A`, the ring of restricted power
+series `A⟨T₁, …, Tₖ⟩` is faithfully flat over `A`.
+
+Flatness is Remark 8.29 applied to the ideals of `A`: for an ideal `I`, the comparison maps
+identify `I ⊗[A] A⟨T⟩ → A ⊗[A] A⟨T⟩` with the coefficientwise inclusion `I⟨T⟩ → A⟨T⟩`, which is
+injective, and Mathlib's `Module.Flat.iff_rTensor_injective` asks for nothing more. Faithfulness is
+the prime `{∑ aᵥ Tᵛ ; a₀ ∈ 𝔭}` Wedhorn writes down: the constant coefficient is a ring homomorphism
+`A⟨T⟩ → A` retracting `A → A⟨T⟩`, so every prime of `A` is the contraction of a prime of `A⟨T⟩`,
+and `Module.FaithfullyFlat.of_comap_surjective` concludes.
+
+## Main results
+
+* `TauCeti.Huber.flat_restrictedMvPowerSeriesSubring`: `A⟨T₁, …, Tₖ⟩` is flat over `A`.
+* `TauCeti.Huber.faithfullyFlat_restrictedMvPowerSeriesSubring`: it is faithfully flat.
+
+## Implementation notes
+
+For an ideal `I` of `A`, Remark 8.29 (`restrictedMvPowerSeriesBaseChange_bijective`) is applied to
+`I` with its subspace topology: `I` is closed (`isClosed_of_isNoetherian`), hence complete, hence
+carries the module topology (`IsTateRing.isModuleTopology`). Faithfulness goes through
+`Module.FaithfullyFlat.of_comap_surjective`, with the constant coefficient
+`MvPowerSeries.constantCoeff ∘ restrictedMvPowerSeriesSubringVal` as the ring homomorphism whose
+`comap` sections `Spec (A⟨T⟩) → Spec A`.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Lemma 8.31.
+-/
+
+open Filter Topology
+open scoped Uniformity
+
+public section
+
+namespace TauCeti.Huber
+
+variable {k : ℕ} {A : Type*} [CommRing A] [UniformSpace A] [IsUniformAddGroup A] [CompleteSpace A]
+  [(𝓤 A).IsCountablyGenerated] [T0Space A] [NonarchimedeanRing A] [IsTateRing A]
+  [IsNoetherianRing A]
+
+/-- **`A⟨T₁, …, Tₖ⟩` is flat over a complete noetherian Tate ring** (Wedhorn, Lemma 8.31(1)). -/
+theorem flat_restrictedMvPowerSeriesSubring :
+    Module.Flat A (restrictedMvPowerSeriesSubring k A) := by
+  rw [Module.Flat.iff_rTensor_injective]
+  intro I _
+  -- An ideal of a noetherian complete Tate ring is closed, so with its subspace topology it is a
+  -- finite complete metrisable module, hence carries the module topology and Remark 8.29 applies.
+  have : CompleteSpace I := (isClosed_of_isNoetherian I).completeSpace_coe
+  have : Module.Finite A I := Module.Finite.iff_fg.mpr (IsNoetherian.noetherian I)
+  have : IsModuleTopology A I := IsTateRing.isModuleTopology
+  have hι : ContinuousAt (I.subtype : I → A) 0 := continuous_subtype_val.continuousAt
+  intro x y hxy
+  apply (restrictedMvPowerSeriesBaseChange_bijective (k := k) (A := A) (M := I)).injective
+  apply restrictedMvPowerSeriesSubmoduleMap_injective (k := k) I.subtype hι I.injective_subtype
+  rw [restrictedMvPowerSeriesSubmoduleMap_baseChange,
+    restrictedMvPowerSeriesSubmoduleMap_baseChange]
+  exact congrArg _ hxy
+
+/-- **`A⟨T₁, …, Tₖ⟩` is faithfully flat over a complete noetherian Tate ring** (Wedhorn,
+Lemma 8.31(1)). -/
+theorem faithfullyFlat_restrictedMvPowerSeriesSubring :
+    Module.FaithfullyFlat A (restrictedMvPowerSeriesSubring k A) := by
+  have := flat_restrictedMvPowerSeriesSubring (k := k) (A := A)
+  -- The constant coefficient retracts `algebraMap`, so `comap` along it sections `Spec`.
+  set c : restrictedMvPowerSeriesSubring k A →+* A :=
+    (MvPowerSeries.constantCoeff (σ := Fin k) (R := A)).comp
+      restrictedMvPowerSeriesSubringVal.toRingHom with hc
+  have hsect : c.comp (algebraMap A (restrictedMvPowerSeriesSubring k A)) = RingHom.id A := by
+    ext a
+    simp [hc, MvPowerSeries.algebraMap_apply]
+  refine Module.FaithfullyFlat.of_comap_surjective fun p ↦ ⟨PrimeSpectrum.comap c p, ?_⟩
+  rw [← PrimeSpectrum.comap_comp_apply, hsect, PrimeSpectrum.comap_id]
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Restricted/Flat.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/Flat.lean
@@ -19,7 +19,7 @@ series `A⟨T₁, …, Tₖ⟩` is faithfully flat over `A`.
 Flatness is Remark 8.29 applied to the ideals of `A`: for an ideal `I`, the comparison maps
 identify `I ⊗[A] A⟨T⟩ → A ⊗[A] A⟨T⟩` with the coefficientwise inclusion `I⟨T⟩ → A⟨T⟩`, which is
 injective, and Mathlib's `Module.Flat.iff_rTensor_injective` asks for nothing more. Faithfulness is
-the prime `{∑ aᵥ Tᵛ ; a₀ ∈ 𝔭}` Wedhorn writes down: the constant coefficient is a ring homomorphism
+the prime `{∑ aᵥ Tᵛ | a₀ ∈ 𝔭}` Wedhorn writes down: the constant coefficient is a ring homomorphism
 `A⟨T⟩ → A` retracting `A → A⟨T⟩`, so every prime of `A` is the contraction of a prime of `A⟨T⟩`,
 and `Module.FaithfullyFlat.of_comap_surjective` concludes.
 


### PR DESCRIPTION
Wedhorn's Lemma 8.31(1): for a complete noetherian Tate ring `A`, the ring of restricted power
series `A⟨T₁, …, Tₖ⟩` is faithfully flat over `A`.

## What is added

`TauCeti/RingTheory/Huber/Restricted/Flat.lean` (new):

* `flat_restrictedMvPowerSeriesSubring` — `Module.Flat A (restrictedMvPowerSeriesSubring k A)`.
* `faithfullyFlat_restrictedMvPowerSeriesSubring` — `Module.FaithfullyFlat A (restrictedMvPowerSeriesSubring k A)`.

## The proof, and what it consumes

Flatness is Wedhorn's argument: "Let `i : N ↪ M` be an injective homomorphism of finitely
generated `A`-modules. Then Remark 8.29 implies that `i ⊗ id : N ⊗ A⟨X⟩ → M ⊗ A⟨X⟩` is again
injective." Mathlib's `Module.Flat.iff_rTensor_injective` only asks this for the inclusions
`I ↪ A` of finitely generated ideals, so Remark 8.29 (#4575, merged) is applied to `I` with its
subspace topology — closed by `isClosed_of_isNoetherian` (#4465), hence complete, hence the module
topology by `IsTateRing.isModuleTopology` — and the naturality
`restrictedMvPowerSeriesSubmoduleMap_baseChange` identifies `I ⊗ A⟨T⟩ → A ⊗ A⟨T⟩` with the
coefficientwise inclusion `I⟨T⟩ → A⟨T⟩`, injective by `restrictedMvPowerSeriesSubmoduleMap_injective`.

Faithfulness is Wedhorn's prime: "If `𝔭` is a prime ideal of `A`, then the set of `∑ aᵥ Xᵛ ∈ A⟨X⟩`
such that `a₀ ∈ 𝔭` is a prime ideal `𝔮` of `A⟨X⟩` with `𝔮 ∩ A = 𝔭`." That prime is the contraction
of `𝔭` along the constant coefficient `A⟨T⟩ → A`, a ring homomorphism retracting `A → A⟨T⟩`; so
`Spec A⟨T⟩ → Spec A` is surjective and `Module.FaithfullyFlat.of_comap_surjective` concludes.

## Why this PR stops at 8.31(1)

Lemma 8.31 has two parts. Part (2) — flatness of `A⟨X⟩/(f − X)` and `A⟨X⟩/(1 − fX)` — is a
different argument (regularity of those elements on `M⟨X⟩`, transported through Remark 8.29 into
`Module.Flat.quotient_span_singleton_of_lTensor_mulLeft_injective`, #4644) and follows as its own
PR; it consumes the flatness proved here. One topic per PR.

## Prior art

Mathlib has no restricted power series over Tate rings, hence no statement of this lemma; it
supplies the criteria used (`Module.Flat.iff_rTensor_injective`,
`Module.FaithfullyFlat.of_comap_surjective`, `MvPowerSeries.constantCoeff`). AINTLIB
(`github.com/CBirkbeck/AINTLIB` @ `37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`) has no sorry-free
counterpart: its flatness results are about adic completions (`AdicCompletionFaithfullyFlat.lean`),
`TateAlgebra.lean` states no flatness, and `Wedhorn828.lean` carries 17 `sorry`s. Nothing is ported.

## Verification

`lake build TauCeti.RingTheory.Huber.Restricted.Flat` green with the Mathlib linter set (new module,
no importers, so that is the whole module-scoped closure). `#print axioms` on both theorems reports
`[propext, Classical.choice, Quot.sound]`. Whole-library gates (`lake exe axioms`, `module-system`,
`lint-env`) are left to CI per the no-full-local-build policy. Full `/cleanup` pass on the file.

Roadmap: AdicSpaces
<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-4-1-lemma-8-31-1-faithfully-flat"}-->

Source: Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Lemma 8.31(1): "Let A be a noetherian complete
Tate ring. (1) The ring A⟨X⟩ is faithfully flat over A."

Target: AdicSpaces README Layer 4.1, numbered step 2: "Lemma 8.31: prove that A⟨X⟩ is faithfully
flat over A, and that the quotients A⟨X⟩/(f−X), A⟨X⟩/(1−fX) are flat in the cases used for Laurent
rational subsets." This PR is the first half of that step; the Laurent quotients follow.
