### PR TITLE
refactor(Hodge): bundle the complexification of integral maps

### DIFF
--- a/TauCeti/Geometry/Hodge/Conjugation.lean
+++ b/TauCeti/Geometry/Hodge/Conjugation.lean
@@ -483,11 +483,26 @@ theorem integralMapToComplex_id (h₁ : IsBaseChange ℂ ι₁) :
     integralMapToComplex h₁ ι₁ (LinearMap.id : V₁ →ₗ[ℤ] V₁) = LinearMap.id :=
   h₁.algHom_ext _ _ fun x ↦ by simp
 
+/-- Complexification of integral linear maps, bundled as an additive monoid homomorphism.
+
+Only additivity has to be checked; the zero, negation, subtraction and multiple laws below are
+then `map_zero`, `map_neg`, `map_sub`, `map_nsmul` and `map_zsmul` of this bundled map. -/
+noncomputable def integralMapToComplexAddMonoidHom (h₁ : IsBaseChange ℂ ι₁) (ι₂ : V₂ →ₗ[ℤ] W₂) :
+    (V₁ →ₗ[ℤ] V₂) →+ (W₁ →ₗ[ℂ] W₂) where
+  toFun := integralMapToComplex h₁ ι₂
+  map_zero' := h₁.algHom_ext _ _ fun x ↦ by simp
+  map_add' _ _ := h₁.algHom_ext _ _ fun x ↦ by simp
+
+@[simp]
+theorem integralMapToComplexAddMonoidHom_apply (h₁ : IsBaseChange ℂ ι₁) (ι₂ : V₂ →ₗ[ℤ] W₂)
+    (f : V₁ →ₗ[ℤ] V₂) :
+    integralMapToComplexAddMonoidHom h₁ ι₂ f = integralMapToComplex h₁ ι₂ f := (rfl)
+
 /-- Complexification sends the zero integral map to the zero complex map. -/
 @[simp]
 theorem integralMapToComplex_zero (h₁ : IsBaseChange ℂ ι₁) (ι₂ : V₂ →ₗ[ℤ] W₂) :
     integralMapToComplex h₁ ι₂ (0 : V₁ →ₗ[ℤ] V₂) = 0 :=
-  h₁.algHom_ext _ _ fun x ↦ by simp
+  map_zero (integralMapToComplexAddMonoidHom h₁ ι₂)
 
 /-- Complexification preserves addition of integral linear maps. -/
 @[simp]
@@ -495,14 +510,14 @@ theorem integralMapToComplex_add (h₁ : IsBaseChange ℂ ι₁) (ι₂ : V₂ �
     (f g : V₁ →ₗ[ℤ] V₂) :
     integralMapToComplex h₁ ι₂ (f + g) =
       integralMapToComplex h₁ ι₂ f + integralMapToComplex h₁ ι₂ g :=
-  h₁.algHom_ext _ _ fun x ↦ by simp
+  map_add (integralMapToComplexAddMonoidHom h₁ ι₂) f g
 
 /-- Complexification preserves negation of integral linear maps. -/
 @[simp]
 theorem integralMapToComplex_neg (h₁ : IsBaseChange ℂ ι₁) (ι₂ : V₂ →ₗ[ℤ] W₂)
     (f : V₁ →ₗ[ℤ] V₂) :
     integralMapToComplex h₁ ι₂ (-f) = -integralMapToComplex h₁ ι₂ f :=
-  h₁.algHom_ext _ _ fun x ↦ by simp
+  map_neg (integralMapToComplexAddMonoidHom h₁ ι₂) f
 
 /-- Complexification preserves subtraction of integral linear maps. -/
 @[simp]
@@ -510,21 +525,21 @@ theorem integralMapToComplex_sub (h₁ : IsBaseChange ℂ ι₁) (ι₂ : V₂ �
     (f g : V₁ →ₗ[ℤ] V₂) :
     integralMapToComplex h₁ ι₂ (f - g) =
       integralMapToComplex h₁ ι₂ f - integralMapToComplex h₁ ι₂ g :=
-  h₁.algHom_ext _ _ fun x ↦ by simp
+  map_sub (integralMapToComplexAddMonoidHom h₁ ι₂) f g
 
 /-- Complexification preserves natural-number multiples of integral linear maps. -/
 @[simp]
 theorem integralMapToComplex_nsmul (h₁ : IsBaseChange ℂ ι₁) (ι₂ : V₂ →ₗ[ℤ] W₂) (k : ℕ)
     (f : V₁ →ₗ[ℤ] V₂) :
     integralMapToComplex h₁ ι₂ (k • f) = k • integralMapToComplex h₁ ι₂ f :=
-  h₁.algHom_ext _ _ fun x ↦ by simp
+  map_nsmul (integralMapToComplexAddMonoidHom h₁ ι₂) k f
 
 /-- Complexification preserves integer multiples of integral linear maps. -/
 @[simp]
 theorem integralMapToComplex_zsmul (h₁ : IsBaseChange ℂ ι₁) (ι₂ : V₂ →ₗ[ℤ] W₂) (k : ℤ)
     (f : V₁ →ₗ[ℤ] V₂) :
     integralMapToComplex h₁ ι₂ (k • f) = k • integralMapToComplex h₁ ι₂ f :=
-  h₁.algHom_ext _ _ fun x ↦ by simp
+  map_zsmul (integralMapToComplexAddMonoidHom h₁ ι₂) k f
 
 /-- Complexification preserves composition of integral linear maps. -/
 theorem integralMapToComplex_comp (h₁ : IsBaseChange ℂ ι₁) (h₂ : IsBaseChange ℂ ι₂)

--- a/TauCeti/Geometry/Hodge/Morphism.lean
+++ b/TauCeti/Geometry/Hodge/Morphism.lean
@@ -291,40 +291,34 @@ theorem zsmul_toIntLinearMap (k : ℤ) (f : Hom source target) :
 /-- The zero Hodge morphism acts as zero on complex vectors. -/
 @[simp]
 theorem zero_apply (x : W₁) : (0 : Hom source target) x = 0 := by
-  simp only [toLinearMap, zero_toIntLinearMap,
-    integralMapToComplex_zero, LinearMap.zero_apply]
+  simp [toLinearMap]
 
 /-- Addition of Hodge morphisms is pointwise addition on complex vectors. -/
 @[simp]
 theorem add_apply (f g : Hom source target) (x : W₁) : (f + g) x = f x + g x := by
-  simp only [toLinearMap, add_toIntLinearMap,
-    integralMapToComplex_add, LinearMap.add_apply]
+  simp [toLinearMap]
 
 /-- Negation of Hodge morphisms is pointwise negation on complex vectors. -/
 @[simp]
 theorem neg_apply (f : Hom source target) (x : W₁) : (-f) x = -f x := by
-  simp only [toLinearMap, neg_toIntLinearMap,
-    integralMapToComplex_neg, LinearMap.neg_apply]
+  simp [toLinearMap]
 
 /-- Subtraction of Hodge morphisms is pointwise subtraction on complex vectors. -/
 @[simp]
 theorem sub_apply (f g : Hom source target) (x : W₁) : (f - g) x = f x - g x := by
-  simp only [toLinearMap, sub_toIntLinearMap,
-    integralMapToComplex_sub, LinearMap.sub_apply]
+  simp [toLinearMap]
 
 /-- Natural-number multiples of Hodge morphisms are evaluated pointwise on complex vectors. -/
 @[simp]
 theorem nsmul_apply (k : ℕ) (f : Hom source target) (x : W₁) :
     (k • f) x = k • f x := by
-  simp only [toLinearMap, nsmul_toIntLinearMap,
-    integralMapToComplex_nsmul, LinearMap.smul_apply]
+  simp [toLinearMap]
 
 /-- Integer multiples of Hodge morphisms are evaluated pointwise on complex vectors. -/
 @[simp]
 theorem zsmul_apply (k : ℤ) (f : Hom source target) (x : W₁) :
     (k • f) x = k • f x := by
-  simp only [toLinearMap, zsmul_toIntLinearMap,
-    integralMapToComplex_zsmul, LinearMap.smul_apply]
+  simp [toLinearMap]
 
 /-- Composition is additive in the morphism applied second. -/
 @[simp]


### PR DESCRIPTION
`integralMapToComplex h₁ ι₂` is additive, and its zero, addition, negation, subtraction, `ℕ`-multiple and `ℤ`-multiple laws were six separate theorems carrying the same proof — `h₁.algHom_ext _ _ fun x ↦ by simp` — written out each time.

Bundling it as `integralMapToComplexAddMonoidHom : (V₁ →ₗ[ℤ] V₂) →+ (W₁ →ₗ[ℂ] W₂)` leaves only additivity to check. The six laws then become `map_zero`, `map_add`, `map_neg`, `map_sub`, `map_nsmul` and `map_zsmul` of that map. Statements are unchanged and all six keep `@[simp]`.

Because those six are `@[simp]`, as are the `_toIntLinearMap` lemmas beside them, the six `Hom` evaluation lemmas in `Morphism.lean` no longer need their explicit four-lemma `simp only` chains and close with `simp [toLinearMap]`.

### Scope

This is the Hodge half of dedup finding K05; the Comodule half landed as #4647.

I deliberately did **not** bundle `Hom.toLinearMap` itself. Mirroring #4647 there would have meant three new public declarations (`toIntLinearMapAddMonoidHom`, `toLinearMapAddMonoidHom`, and a bridging `apply` lemma) to replace six already-short two-line proofs, and it fought the module system: with `integralMapToComplex`'s body sealed, `toLinearMapAddMonoidHom f` does not reduce to `f.toLinearMap`, so each evaluation lemma needed an extra bridging rewrite. Bundling pays when the duplicated proofs are *identical*, as in `Conjugation.lean`; here they were merely similar, and the collapse to `simp [toLinearMap]` gets the same reduction with no new API.

### Verification

`lake build` green on both changed modules and all five direct importers (`WeilOperator`, `BaseChange`, `Tate.Twist`, `Mixed.Morphism`, `Structure`) — 2163 jobs. `#print axioms` on the new bundled hom and on representative rewritten lemmas gives `[propext, Classical.choice, Quot.sound]`.

Roadmap: HodgeStructures