### PR TITLE
refactor(RootSystem): name the two Base membership arguments of typeBSimplyConnectedBase

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/Datum.lean
@@ -612,6 +612,87 @@ private lemma typeB_corootOfPair_nonpos_of_sgn_eq_one_of_sgn_eq_neg_one_of_axis_
   · rw [corootOfPair_apply_of_ne hj, hsu, hsv]
     split_ifs <;> omega
 
+/-- Every root of the pinned type `Bₙ` datum is, up to sign, an `ℕ`-combination of the simple
+roots. -/
+private lemma typeB_root_mem_or_neg_mem (k : Fin (2 * n ^ 2)) :
+    (typeBSimplyConnectedRootDatum n).root k ∈
+        AddSubmonoid.closure ((typeBSimplyConnectedRootDatum n).root ''
+          (typeBSimpleSupport n : Set (Fin (2 * n ^ 2)))) ∨
+      -(typeBSimplyConnectedRootDatum n).root k ∈
+        AddSubmonoid.closure ((typeBSimplyConnectedRootDatum n).root ''
+          (typeBSimpleSupport n : Set (Fin (2 * n ^ 2)))) := by
+  rw [image_root_typeBSimpleSupport]
+  obtain ⟨u, v, hroot⟩ : ∃ u v : Fin (2 * n),
+      (typeBSimplyConnectedRootDatum n).root k = rootOfPair u v :=
+    ⟨_, _, by rw [root_typeBSimplyConnectedRootDatum, rootIdx_def]⟩
+  rcases eq_or_ne u v with heq | hne
+  · rw [hroot, ← heq, rootOfPair_self]
+    rcases sgn_eq_one_or_neg_one u with hs | hs
+    · refine Or.inl ?_
+      rw [signedWeight_def, hs, one_smul]
+      exact typeB_weight_mem_closure (le_of_lt (axis_lt u))
+    · refine Or.inr ?_
+      rw [signedWeight_def, hs, neg_one_smul, neg_neg]
+      exact typeB_weight_mem_closure (le_of_lt (axis_lt u))
+  · rw [hroot, rootOfPair_of_ne hne]
+    rcases sgn_eq_one_or_neg_one u with hsu | hsu <;>
+      rcases sgn_eq_one_or_neg_one v with hsv | hsv
+    · exact Or.inl (typeB_signedWeight_add_signedWeight_mem_closure u v hsu hsv)
+    · rcases le_total (axis u) (axis v) with hle | hle
+      · exact Or.inl (typeB_signedWeight_sub_signedWeight_mem_closure u v hsu hsv hle)
+      · refine Or.inr ?_
+        rw [neg_add, ← signedWeight_opp, ← signedWeight_opp, add_comm]
+        exact typeB_signedWeight_sub_signedWeight_mem_closure (opp v) (opp u)
+          (by simp [sgn_opp, hsv])
+          (by simp [sgn_opp, hsu]) (by rwa [axis_opp, axis_opp])
+    · rcases le_total (axis v) (axis u) with hle | hle
+      · rw [add_comm]
+        exact Or.inl (typeB_signedWeight_sub_signedWeight_mem_closure v u hsv hsu hle)
+      · refine Or.inr ?_
+        rw [neg_add, ← signedWeight_opp, ← signedWeight_opp]
+        exact typeB_signedWeight_sub_signedWeight_mem_closure (opp u) (opp v)
+          (by simp [sgn_opp, hsu])
+          (by simp [sgn_opp, hsv]) (by rwa [axis_opp, axis_opp])
+    · refine Or.inr ?_
+      rw [neg_add, ← signedWeight_opp, ← signedWeight_opp]
+      exact typeB_signedWeight_add_signedWeight_mem_closure (opp u) (opp v)
+        (by simp [sgn_opp, hsu])
+        (by simp [sgn_opp, hsv])
+
+/-- Every coroot of the pinned type `Bₙ` datum is, up to sign, an `ℕ`-combination of the simple
+coroots. -/
+private lemma typeB_coroot_mem_or_neg_mem (k : Fin (2 * n ^ 2)) :
+    (typeBSimplyConnectedRootDatum n).coroot k ∈
+        AddSubmonoid.closure ((typeBSimplyConnectedRootDatum n).coroot ''
+          (typeBSimpleSupport n : Set (Fin (2 * n ^ 2)))) ∨
+      -(typeBSimplyConnectedRootDatum n).coroot k ∈
+        AddSubmonoid.closure ((typeBSimplyConnectedRootDatum n).coroot ''
+          (typeBSimpleSupport n : Set (Fin (2 * n ^ 2)))) := by
+  rw [image_coroot_typeBSimpleSupport]
+  obtain ⟨u, v, hcor⟩ : ∃ u v : Fin (2 * n),
+      (typeBSimplyConnectedRootDatum n).coroot k = corootOfPair u v :=
+    ⟨_, _, by rw [coroot_typeBSimplyConnectedRootDatum, corootIdx_def]⟩
+  rw [hcor]
+  rcases sgn_eq_one_or_neg_one u with hsu | hsu <;>
+    rcases sgn_eq_one_or_neg_one v with hsv | hsv
+  · exact Or.inl
+      (typeB_mem_closure_single (typeB_corootOfPair_nonneg_of_sgn_eq_one hsu hsv))
+  · rcases le_total (axis u) (axis v) with hle | hle
+    · exact Or.inl (typeB_mem_closure_single
+        (typeB_corootOfPair_nonneg_of_sgn_eq_one_of_sgn_eq_neg_one_of_axis_le hsu hsv hle))
+    · exact Or.inr (typeB_mem_closure_single fun j =>
+        neg_nonneg.mpr
+          (typeB_corootOfPair_nonpos_of_sgn_eq_one_of_sgn_eq_neg_one_of_axis_le hsu hsv hle j))
+  · rw [corootOfPair_comm]
+    rcases le_total (axis v) (axis u) with hle | hle
+    · exact Or.inl (typeB_mem_closure_single
+        (typeB_corootOfPair_nonneg_of_sgn_eq_one_of_sgn_eq_neg_one_of_axis_le hsv hsu hle))
+    · exact Or.inr (typeB_mem_closure_single fun j =>
+        neg_nonneg.mpr
+          (typeB_corootOfPair_nonpos_of_sgn_eq_one_of_sgn_eq_neg_one_of_axis_le hsv hsu hle j))
+  · exact Or.inr (typeB_mem_closure_single fun j =>
+      neg_nonneg.mpr (typeB_corootOfPair_nonpos_of_sgn_eq_neg_one hsu hsv j))
+
 /-- The Bourbaki-numbered base of the pinned simply connected root datum of type `Bₙ`. Its support
 is the set of the first `n` root indices, carrying the simple roots in Bourbaki order. -/
 def typeBSimplyConnectedBase (n : ℕ) : (typeBSimplyConnectedRootDatum n).Base where
@@ -629,69 +710,8 @@ def typeBSimplyConnectedBase (n : ℕ) : (typeBSimplyConnectedRootDatum n).Base 
         simp
       rw [hcomp]
       exact (Pi.basisFun ℤ (Fin n)).linearIndependent
-  root_mem_or_neg_mem k := by
-    rw [image_root_typeBSimpleSupport]
-    obtain ⟨u, v, hroot⟩ : ∃ u v : Fin (2 * n),
-        (typeBSimplyConnectedRootDatum n).root k = rootOfPair u v :=
-      ⟨_, _, by rw [root_typeBSimplyConnectedRootDatum, rootIdx_def]⟩
-    rcases eq_or_ne u v with heq | hne
-    · rw [hroot, ← heq, rootOfPair_self]
-      rcases sgn_eq_one_or_neg_one u with hs | hs
-      · refine Or.inl ?_
-        rw [signedWeight_def, hs, one_smul]
-        exact typeB_weight_mem_closure (le_of_lt (axis_lt u))
-      · refine Or.inr ?_
-        rw [signedWeight_def, hs, neg_one_smul, neg_neg]
-        exact typeB_weight_mem_closure (le_of_lt (axis_lt u))
-    · rw [hroot, rootOfPair_of_ne hne]
-      rcases sgn_eq_one_or_neg_one u with hsu | hsu <;>
-        rcases sgn_eq_one_or_neg_one v with hsv | hsv
-      · exact Or.inl (typeB_signedWeight_add_signedWeight_mem_closure u v hsu hsv)
-      · rcases le_total (axis u) (axis v) with hle | hle
-        · exact Or.inl (typeB_signedWeight_sub_signedWeight_mem_closure u v hsu hsv hle)
-        · refine Or.inr ?_
-          rw [neg_add, ← signedWeight_opp, ← signedWeight_opp, add_comm]
-          exact typeB_signedWeight_sub_signedWeight_mem_closure (opp v) (opp u)
-            (by simp [sgn_opp, hsv])
-            (by simp [sgn_opp, hsu]) (by rwa [axis_opp, axis_opp])
-      · rcases le_total (axis v) (axis u) with hle | hle
-        · rw [add_comm]
-          exact Or.inl (typeB_signedWeight_sub_signedWeight_mem_closure v u hsv hsu hle)
-        · refine Or.inr ?_
-          rw [neg_add, ← signedWeight_opp, ← signedWeight_opp]
-          exact typeB_signedWeight_sub_signedWeight_mem_closure (opp u) (opp v)
-            (by simp [sgn_opp, hsu])
-            (by simp [sgn_opp, hsv]) (by rwa [axis_opp, axis_opp])
-      · refine Or.inr ?_
-        rw [neg_add, ← signedWeight_opp, ← signedWeight_opp]
-        exact typeB_signedWeight_add_signedWeight_mem_closure (opp u) (opp v)
-          (by simp [sgn_opp, hsu])
-          (by simp [sgn_opp, hsv])
-  coroot_mem_or_neg_mem k := by
-    rw [image_coroot_typeBSimpleSupport]
-    obtain ⟨u, v, hcor⟩ : ∃ u v : Fin (2 * n),
-        (typeBSimplyConnectedRootDatum n).coroot k = corootOfPair u v :=
-      ⟨_, _, by rw [coroot_typeBSimplyConnectedRootDatum, corootIdx_def]⟩
-    rw [hcor]
-    rcases sgn_eq_one_or_neg_one u with hsu | hsu <;>
-      rcases sgn_eq_one_or_neg_one v with hsv | hsv
-    · exact Or.inl
-        (typeB_mem_closure_single (typeB_corootOfPair_nonneg_of_sgn_eq_one hsu hsv))
-    · rcases le_total (axis u) (axis v) with hle | hle
-      · exact Or.inl (typeB_mem_closure_single
-          (typeB_corootOfPair_nonneg_of_sgn_eq_one_of_sgn_eq_neg_one_of_axis_le hsu hsv hle))
-      · exact Or.inr (typeB_mem_closure_single fun j =>
-          neg_nonneg.mpr
-            (typeB_corootOfPair_nonpos_of_sgn_eq_one_of_sgn_eq_neg_one_of_axis_le hsu hsv hle j))
-    · rw [corootOfPair_comm]
-      rcases le_total (axis v) (axis u) with hle | hle
-      · exact Or.inl (typeB_mem_closure_single
-          (typeB_corootOfPair_nonneg_of_sgn_eq_one_of_sgn_eq_neg_one_of_axis_le hsv hsu hle))
-      · exact Or.inr (typeB_mem_closure_single fun j =>
-          neg_nonneg.mpr
-            (typeB_corootOfPair_nonpos_of_sgn_eq_one_of_sgn_eq_neg_one_of_axis_le hsv hsu hle j))
-    · exact Or.inr (typeB_mem_closure_single fun j =>
-        neg_nonneg.mpr (typeB_corootOfPair_nonpos_of_sgn_eq_neg_one hsu hsv j))
+  root_mem_or_neg_mem := typeB_root_mem_or_neg_mem
+  coroot_mem_or_neg_mem := typeB_coroot_mem_or_neg_mem
 
 /-- Membership in the pinned base support is exactly membership among the first `n` root
 indices. -/


### PR DESCRIPTION
Name the two membership arguments inside `typeBSimplyConnectedBase`, so the structure instance
reads as an instance instead of also carrying two case analyses.

## What moved

`typeBSimplyConnectedBase` (the Bourbaki base of the pinned type `Bₙ` simply connected root
datum) proved its two `Base` obligations inline: `root_mem_or_neg_mem` was a 37-line case
analysis on `rootOfPair u v` (equal or distinct indices, then the four sign cases, then the
axis order), and `coroot_mem_or_neg_mem` a 24-line one on `corootOfPair u v`. They are now the
private lemmas `typeB_root_mem_or_neg_mem` and `typeB_coroot_mem_or_neg_mem`, stated exactly as
the fields' types (over `typeBSimpleSupport n` and the datum's `root`/`coroot`), and the
instance assigns them.

| | before | after |
|---|---|---|
| `typeBSimplyConnectedBase` body | 77 lines | **16 lines** |
| `typeB_root_mem_or_neg_mem` | — | 37 lines |
| `typeB_coroot_mem_or_neg_mem` | — | 24 lines |

The public definition and its statement are unchanged; nothing in the file's importers
(`SimplyConnectedRootDatum/Assembly.lean`, `B/RankTwo.lean`) is touched.

## Hypotheses, re-derived from the blocks

Each field's body closes over nothing but its index `k` (the `u v` it works with are obtained
inside from `root_typeBSimplyConnectedRootDatum` / `coroot_typeBSimplyConnectedRootDatum`);
both lemmas take exactly `(k : Fin (2 * n ^ 2))` with the section's `{n : ℕ}`.

## Two lemmas, deliberately

Both fields are substantive arguments and each is used once, so neither lemma is scaffolding
for the other. The alternative of a generic "symmetric pair family is in `C` up to sign" lemma
covering both was considered and declined: it needs two new `_opp` lemmas in `B/Model.lean`
(`rootOfPair_opp`, `corootOfPair_opp`) and a new abstraction — new API in a refactor whose
topic is naming existing arguments.

## Naming and placement

- `typeB_root_mem_or_neg_mem` / `typeB_coroot_mem_or_neg_mem` follow the file's
  `typeB_…_mem_closure` private helpers and the `Base` field names they discharge.
- `private`, directly above the definition's docstring, after the sign lemmas they use.

## Notes for review

- The proof bodies are verbatim lifts (dedent only); the `obtain ⟨u, v, …⟩` openings move with
  their cases.
- Gate: module-scoped `lake build` of `SimplyConnectedRootDatum.B.Datum` and its importers
  `SimplyConnectedRootDatum.Assembly` and `SimplyConnectedRootDatum.B.RankTwo` (importer
  artifacts deleted first and confirmed regenerated), exit 0, zero warnings.

Roadmap: none
