### PR TITLE
feat: the product rule for weak derivatives and multiplication by a cutoff

### DIFF
--- a/TauCeti/Analysis/Sobolev/Leibniz.lean
+++ b/TauCeti/Analysis/Sobolev/Leibniz.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Sobolev.WeakDeriv
+
+/-!
+# The product rule for weak derivatives
+
+A weak derivative is additive and commutes with scalars
+(`TauCeti.HasWeakLineDerivOn.add`, `TauCeti.HasWeakLineDerivOn.const_smul`), but Lane A of the PDE
+roadmap needs one more algebraic rule before it can localize: multiplication by a *variable*
+smooth factor.  This file proves it.  For a smooth `ψ : E → ℝ` and a weakly differentiable `u`,
+
+`∂_v (ψ u) = ψ ∂_v u + (∂_v ψ) u`
+
+on `Ω`, in the weak sense of `TauCeti.HasWeakLineDerivOn`.
+
+The proof is the one-line distributional computation.  Testing `ψ u` against `∂_v φ` is the same
+as testing `u` against `ψ ∂_v φ = ∂_v (ψ φ) − (∂_v ψ) φ`, and `ψ φ` is again a test function on
+`Ω`, because multiplying by a smooth function neither enlarges a support nor destroys smoothness.
+So the defining identity for `u` applies to it, and the leftover term `(∂_v ψ) φ` is the second
+summand of the Leibniz formula.  No smoothness of `u` is used, and no boundary hypothesis on `Ω`:
+`ψ φ` is compactly supported *inside* `Ω`, so no boundary term appears.
+
+Smoothness of `ψ` is more than the identity needs — `C¹` would do — but it is what makes `ψ φ` a
+member of Mathlib's `TestFunction` type, whose smoothness order is `∞`, and it is what every
+intended application supplies (cutoffs are built from `ContDiffBump`).
+
+## Why this is the localization tool
+
+`ψ` will be a cutoff.  Multiplying by one is how a global statement about `W^{k,p}(Ω)` is reduced
+to a local one: it is the first step of the Meyers–Serrin `H = W` density theorem and of the
+extension operator (Lane A.2 and A.6 of `TauCetiRoadmap/PDE/README.md`), and it is what turns an
+interior estimate into an estimate on a compactly contained subdomain (Lane E.20).  The second
+summand `(∂_v ψ) u` is exactly the error such an argument has to absorb, so having it with an
+explicit, non-asymptotic formula is the point.
+
+## Main declarations
+
+* `TauCeti.HasWeakLineDerivOn.contDiff_smul`: the Leibniz rule in a direction `v`.
+* `TauCeti.HasWeakFDerivOn.contDiff_smul`: its Fréchet form, with the rank-one correction
+  `(fderiv ℝ ψ x).smulRight (u x)`.
+* `TauCeti.HasWeakFDerivOn.contDiff_smul_gradient`: the form consumed by `TauCeti.W1p`, where a
+  weak derivative of a scalar function is recorded by its Riesz representative and the rule reads
+  `∇(ψ u) = ψ ∇u + u ∇ψ`.
+
+## References
+
+L. C. Evans, *Partial Differential Equations*, §5.2.3, Theorem 1(iv).
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory TopologicalSpace
+open scoped ContDiff Distributions
+
+section General
+
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  [NormedAddCommGroup F] [NormedSpace ℝ F] [MeasurableSpace E] [OpensMeasurableSpace E]
+  [LocallyCompactSpace E] {Ω : Opens E} {v : E} {μ : Measure E} {u u' : E → F} {ψ : E → ℝ}
+
+omit [MeasurableSpace E] [OpensMeasurableSpace E] [LocallyCompactSpace E] in
+/-- A directional derivative of a smooth function is smooth. -/
+private theorem contDiff_fderiv_apply (hψ : ContDiff ℝ ∞ ψ) (v : E) :
+    ContDiff ℝ ∞ fun x => fderiv ℝ ψ x v :=
+  (hψ.fderiv_right (by simp)).clm_apply contDiff_const
+
+/-- **The Leibniz rule for weak directional derivatives.** If `u'` is a weak derivative of `u` in
+the direction `v` on `Ω` and `ψ` is smooth, then `ψ u` is weakly differentiable in the direction
+`v` on `Ω`, with derivative `ψ u' + (∂_v ψ) u`.
+
+Nothing is assumed about `Ω` beyond openness: the test function `ψ φ` used in the proof is still
+compactly supported inside `Ω`, so the boundary term of the classical integration by parts is
+absent here just as it is in the definition. -/
+theorem HasWeakLineDerivOn.contDiff_smul (h : HasWeakLineDerivOn μ Ω u u' v)
+    (hψ : ContDiff ℝ ∞ ψ) :
+    HasWeakLineDerivOn μ Ω (fun x => ψ x • u x)
+      (fun x => ψ x • u' x + fderiv ℝ ψ x v • u x) v := by
+  have hΩ : IsLocallyClosed (Ω : Set E) := Ω.isOpen.isLocallyClosed
+  have hdψ : ContDiff ℝ ∞ fun x => fderiv ℝ ψ x v := contDiff_fderiv_apply hψ v
+  have hu : LocallyIntegrableOn (fun x => ψ x • u x) Ω μ :=
+    h.locallyIntegrableOn.continuousOn_smul hΩ hψ.continuous.continuousOn
+  have hu' : LocallyIntegrableOn (fun x => ψ x • u' x + fderiv ℝ ψ x v • u x) Ω μ :=
+    (h.locallyIntegrableOn_deriv.continuousOn_smul hΩ hψ.continuous.continuousOn).add
+      (h.locallyIntegrableOn.continuousOn_smul hΩ hdψ.continuous.continuousOn)
+  rw [hasWeakLineDerivOn_iff_testFunction]
+  refine ⟨h.completeSpace, hu, hu', fun φ => ?_⟩
+  -- `ψ φ` and `(∂_v ψ) φ` are test functions on `Ω`: smoothness is preserved by products and
+  -- the support only shrinks.
+  obtain ⟨Φ, hΦ⟩ : ∃ Φ : 𝓓(Ω, ℝ), (Φ : E → ℝ) = ψ * (φ : E → ℝ) :=
+    ⟨⟨ψ * (φ : E → ℝ), hψ.mul φ.contDiff, φ.hasCompactSupport.mul_left,
+      tsupport_mul_subset_right.trans φ.tsupport_subset⟩, rfl⟩
+  obtain ⟨Ψ, hΨ⟩ :
+      ∃ Ψ : 𝓓(Ω, ℝ), (Ψ : E → ℝ) = (fun x => fderiv ℝ ψ x v) * (φ : E → ℝ) :=
+    ⟨⟨(fun x => fderiv ℝ ψ x v) * (φ : E → ℝ), hdψ.mul φ.contDiff,
+      φ.hasCompactSupport.mul_left,
+      tsupport_mul_subset_right.trans φ.tsupport_subset⟩, rfl⟩
+  have hint1 : Integrable (fun x => lineDeriv ℝ (Φ : E → ℝ) x v • u x) μ :=
+    integrable_lineDeriv_smul_of_locallyIntegrableOn h.locallyIntegrableOn Φ v
+  have hint2 : Integrable (fun x => (Ψ : E → ℝ) x • u x) μ :=
+    integrable_smul_of_locallyIntegrableOn h.locallyIntegrableOn Ψ
+  have hint3 : Integrable (fun x => (Φ : E → ℝ) x • u' x) μ :=
+    integrable_smul_of_locallyIntegrableOn h.locallyIntegrableOn_deriv Φ
+  -- The classical product rule for the smooth factors.
+  have hlineΦ : ∀ x, lineDeriv ℝ (Φ : E → ℝ) x v
+      = ψ x * lineDeriv ℝ (φ : E → ℝ) x v + (Ψ : E → ℝ) x := by
+    intro x
+    have hdψx : DifferentiableAt ℝ ψ x := (hψ.differentiable (by simp)) x
+    have hdφx : DifferentiableAt ℝ (φ : E → ℝ) x := (φ.contDiff.differentiable (by simp)) x
+    have hmul : DifferentiableAt ℝ (ψ * (φ : E → ℝ)) x := hdψx.mul hdφx
+    rw [hΦ, hΨ, hmul.lineDeriv_eq_fderiv, hdφx.lineDeriv_eq_fderiv, fderiv_mul hdψx hdφx]
+    simp only [add_apply, FunLike.coe_smul, Pi.smul_apply, Pi.mul_apply, smul_eq_mul]
+    ring
+  have hsplit : ∫ x, (φ : E → ℝ) x • (ψ x • u' x + fderiv ℝ ψ x v • u x) ∂μ
+      = ∫ x, (Φ : E → ℝ) x • u' x ∂μ + ∫ x, (Ψ : E → ℝ) x • u x ∂μ := by
+    rw [← integral_add hint3 hint2]
+    refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+    simp only [hΦ, hΨ, Pi.mul_apply, smul_add, smul_smul, mul_comm]
+  calc ∫ x, lineDeriv ℝ (φ : E → ℝ) x v • (ψ x • u x) ∂μ
+      = ∫ x, (lineDeriv ℝ (Φ : E → ℝ) x v • u x - (Ψ : E → ℝ) x • u x) ∂μ := by
+        refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+        simp only [hlineΦ x, add_smul, add_sub_cancel_right, smul_smul, mul_comm]
+    _ = ∫ x, lineDeriv ℝ (Φ : E → ℝ) x v • u x ∂μ - ∫ x, (Ψ : E → ℝ) x • u x ∂μ :=
+        integral_sub hint1 hint2
+    _ = -∫ x, (Φ : E → ℝ) x • u' x ∂μ - ∫ x, (Ψ : E → ℝ) x • u x ∂μ := by
+        rw [h.integral_lineDeriv_smul_eq_neg_integral_smul Φ]
+    _ = -∫ x, (φ : E → ℝ) x • (ψ x • u' x + fderiv ℝ ψ x v • u x) ∂μ := by
+        rw [hsplit]; abel
+
+/-- **The Leibniz rule for weak Fréchet derivatives**: `D(ψ u) = ψ Du + u ⊗ Dψ`, the correction
+being the rank-one map `v ↦ (Dψ v) u`. -/
+theorem HasWeakFDerivOn.contDiff_smul {U : E → E →L[ℝ] F} (h : HasWeakFDerivOn μ Ω u U)
+    (hψ : ContDiff ℝ ∞ ψ) :
+    HasWeakFDerivOn μ Ω (fun x => ψ x • u x)
+      (fun x => ψ x • U x + (fderiv ℝ ψ x).smulRight (u x)) := by
+  rw [hasWeakFDerivOn_iff]
+  intro v
+  have hv := (h.hasWeakLineDerivOn v).contDiff_smul hψ
+  convert hv using 2 with x
+  simp
+
+end General
+
+section InnerProduct
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [MeasurableSpace E]
+  [OpensMeasurableSpace E] [FiniteDimensional ℝ E] {Ω : Opens E} {μ : Measure E}
+  {a ψ : E → ℝ} {g : E → E}
+
+open scoped Gradient
+
+/-- **The Leibniz rule in gradient form**: `∇(ψ a) = ψ ∇a + a ∇ψ`.
+
+This is the shape `TauCeti.W1p` stores a weak derivative in — a scalar function together with the
+Riesz representative of its weak Fréchet derivative — so it is the form a multiplication operator
+on the Sobolev space consumes. -/
+theorem HasWeakFDerivOn.contDiff_smul_gradient
+    (h : HasWeakFDerivOn μ Ω a fun x => innerSL ℝ (g x)) (hψ : ContDiff ℝ ∞ ψ) :
+    HasWeakFDerivOn μ Ω (fun x => ψ x • a x)
+      (fun x => innerSL ℝ (ψ x • g x + a x • ∇ ψ x)) := by
+  have hv := h.contDiff_smul hψ
+  convert hv using 2 with x
+  ext w
+  simp [inner_gradient_left (𝕜 := ℝ) (f := ψ) (x := x), mul_comm]
+
+end InnerProduct
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p/Multiplication.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Multiplication.lean
@@ -36,9 +36,8 @@ into an estimate on a compactly contained subdomain.  Having it as a *bounded op
 than as a pointwise membership statement, is what lets those arguments range over a family of
 cutoffs while keeping uniform control of the resulting Sobolev norms.
 
-The factor `2` in `‖ψ u‖ ≤ 2 M ‖u‖` is not optimal — the sharp constant for the Euclidean jet norm
-used here is `√2 M` — but it is explicit, and it is the only shape the downstream localization
-arguments need.
+The factor `2` in `‖ψ u‖ ≤ 2 M ‖u‖` is explicit, and it is the only shape the downstream
+localization arguments need.
 
 ## Main declarations
 

--- a/TauCeti/Analysis/Sobolev/W1p/Multiplication.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Multiplication.lean
@@ -21,11 +21,11 @@ constant `M`, then
 is a continuous linear operator on `W^{1,p}(Ω)` of norm at most `2 M`, with value component `ψ u`
 and gradient component `ψ ∇u + u ∇ψ`.
 
-Boundedness of `ψ` *and* of `∇ψ` is what the statement needs, and neither is automatic: for
-`ψ x = exp ‖x‖²` on `Ω = ℝⁿ` the product `ψ u` leaves every `Lᵖ` class.  Both bounds are therefore
-carried explicitly, through a single constant `M`, so that the operator norm is visible rather
-than hidden behind an unquantified `∃ C`; that is the convention the PDE roadmap asks for.  A
-cutoff built from `ContDiffBump` satisfies them, which is the intended use.
+Boundedness of `ψ` *and* of `∇ψ` on `Ω` is what the statement needs, and neither is automatic: for
+`ψ x = exp ‖x‖²` on `Ω = ℝⁿ`, multiplication by `ψ` need not preserve `Lᵖ`.  Both bounds are
+therefore carried explicitly, through a single constant `M`, so that the operator norm is visible
+rather than hidden behind an unquantified `∃ C`; that is the convention the PDE roadmap asks for.
+A cutoff built from `ContDiffBump` satisfies them, which is the intended use.
 
 ## The operator and the milestone
 
@@ -72,7 +72,7 @@ variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpa
 omit [MeasurableSpace E] [BorelSpace E] in
 /-- The gradient of a smooth function is the Riesz representative of its Fréchet derivative, hence
 continuous.  This is what makes the product below measurable. -/
-theorem continuous_gradient (hpsi : ContDiff ℝ ∞ psi) : Continuous (∇ psi) := by
+theorem ContDiff.continuous_gradient (hpsi : ContDiff ℝ ∞ psi) : Continuous (∇ psi) := by
   have heq : ∇ psi = fun x => (InnerProductSpace.toDual ℝ E).symm (fderiv ℝ psi x) := by
     funext x
     exact (hasFDerivAt_iff_hasGradientAt.1
@@ -82,66 +82,71 @@ theorem continuous_gradient (hpsi : ContDiff ℝ ∞ psi) : Continuous (∇ psi)
 
 omit [FiniteDimensional ℝ E] in
 /-- The value component `ψ u` of the product is `Lᵖ`, because `ψ` is bounded. -/
-theorem W1p.memLp_smul_value (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (u : W1p mu Omega p) :
+theorem W1p.memLp_smul_value (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (u : W1p mu Omega p) :
     MemLp (fun x => psi x • W1p.value u x) p (mu.restrict Omega) := by
-  have hM : (0 : ℝ) ≤ M := (abs_nonneg _).trans (hpsiM 0)
   refine MemLp.of_le ((Lp.memLp (W1p.value u)).const_mul M) ?_ ?_
   · exact hpsi.continuous.aestronglyMeasurable.smul (Lp.aestronglyMeasurable _)
-  · filter_upwards with x
+  · filter_upwards [ae_restrict_mem Omega.isOpen.measurableSet] with x hx
     rw [smul_eq_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_mul, abs_mul, abs_of_nonneg hM]
-    exact mul_le_mul_of_nonneg_right (hpsiM x) (abs_nonneg _)
+    exact mul_le_mul_of_nonneg_right (hpsiM x hx) (abs_nonneg _)
 
 /-- The gradient component `ψ ∇u + u ∇ψ` of the product is `Lᵖ`, because `ψ` and `∇ψ` are
 bounded. -/
-theorem W1p.memLp_smul_gradient (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+theorem W1p.memLp_smul_gradient (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M)
+    (u : W1p mu Omega p) :
     MemLp (fun x => psi x • W1p.gradient u x + W1p.value u x • ∇ psi x) p (mu.restrict Omega) := by
-  have hM : (0 : ℝ) ≤ M := (abs_nonneg _).trans (hpsiM 0)
   refine MemLp.add ?_ ?_
   · refine MemLp.of_le ((Lp.memLp (W1p.gradient u)).const_smul M) ?_ ?_
     · exact hpsi.continuous.aestronglyMeasurable.smul (Lp.aestronglyMeasurable _)
-    · filter_upwards with x
+    · filter_upwards [ae_restrict_mem Omega.isOpen.measurableSet] with x hx
       rw [norm_smul, Pi.smul_apply, norm_smul, Real.norm_eq_abs, Real.norm_eq_abs,
         abs_of_nonneg hM]
-      exact mul_le_mul_of_nonneg_right (hpsiM x) (norm_nonneg _)
+      exact mul_le_mul_of_nonneg_right (hpsiM x hx) (norm_nonneg _)
   · refine MemLp.of_le ((Lp.memLp (W1p.value u)).const_mul M) ?_ ?_
-    · exact (Lp.aestronglyMeasurable _).smul (continuous_gradient hpsi).aestronglyMeasurable
-    · filter_upwards with x
+    · exact (Lp.aestronglyMeasurable _).smul
+        (ContDiff.continuous_gradient hpsi).aestronglyMeasurable
+    · filter_upwards [ae_restrict_mem Omega.isOpen.measurableSet] with x hx
       rw [norm_smul, Real.norm_eq_abs, Real.norm_eq_abs, abs_mul, abs_of_nonneg hM, mul_comm M]
-      exact mul_le_mul_of_nonneg_left (hgradM x) (abs_nonneg _)
+      exact mul_le_mul_of_nonneg_left (hgradM x hx) (abs_nonneg _)
 
 /-! ### The product -/
 
-/-- **Multiplication by a smooth cutoff.**  If `ψ` is smooth with `|ψ| ≤ M` and `‖∇ψ‖ ≤ M`, the
-product `ψ u` of `ψ` with a Sobolev function `u ∈ W^{1,p}(Ω)` is again in `W^{1,p}(Ω)`; its weak
-gradient is `ψ ∇u + u ∇ψ` by the Leibniz rule. -/
+/-- **Multiplication by a smooth cutoff.**  If `ψ` is smooth with `|ψ| ≤ M` and `‖∇ψ‖ ≤ M` on
+`Ω`, the product `ψ u` of `ψ` with a Sobolev function `u ∈ W^{1,p}(Ω)` is again in `W^{1,p}(Ω)`;
+its weak gradient is `ψ ∇u + u ∇ψ` by the Leibniz rule. -/
 def W1p.contDiffSMul (psi : E → ℝ) (hpsi : ContDiff ℝ ∞ psi) {M : ℝ}
-    (hpsiM : ∀ x, |psi x| ≤ M) (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+    (hM : 0 ≤ M) (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M)
+    (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
     W1p mu Omega p :=
-  W1p.mk ((W1p.memLp_smul_value hpsi hpsiM u).toLp _)
-    ((W1p.memLp_smul_gradient hpsi hpsiM hgradM u).toLp _)
+  W1p.mk ((W1p.memLp_smul_value hpsi hM hpsiM u).toLp _)
+    ((W1p.memLp_smul_gradient hpsi hM hpsiM hgradM u).toLp _)
     (by
-      have hv := (W1p.memLp_smul_value (mu := mu) (Omega := Omega) (p := p) hpsi hpsiM u).coeFn_toLp
+      have hv := (W1p.memLp_smul_value (mu := mu) (Omega := Omega) (p := p)
+        hpsi hM hpsiM u).coeFn_toLp
       have hg := (W1p.memLp_smul_gradient (mu := mu) (Omega := Omega) (p := p)
-        hpsi hpsiM hgradM u).coeFn_toLp
+        hpsi hM hpsiM hgradM u).coeFn_toLp
       refine (((W1p.hasWeakFDerivOn u).contDiff_smul_gradient hpsi).congr_ae
         hv.symm).congr_ae_deriv (hg.mono fun x hx => ?_)
       simp only [hx])
 
 /-- The value component of `ψ u` is `ψ u`. -/
-theorem W1p.value_contDiffSMul_ae (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+theorem W1p.value_contDiffSMul_ae (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M)
+    (u : W1p mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
-      W1p.value (W1p.contDiffSMul psi hpsi hpsiM hgradM u) x = psi x • W1p.value u x := by
+      W1p.value (W1p.contDiffSMul psi hpsi hM hpsiM hgradM u) x
+        = psi x • W1p.value u x := by
   rw [W1p.contDiffSMul, W1p.value_mk]
   exact MemLp.coeFn_toLp _
 
 /-- **The Leibniz rule in `W^{1,p}(Ω)`**: the weak gradient of `ψ u` is `ψ ∇u + u ∇ψ`. -/
-theorem W1p.gradient_contDiffSMul_ae (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+theorem W1p.gradient_contDiffSMul_ae (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M)
+    (u : W1p mu Omega p) :
     ∀ᵐ x ∂mu.restrict Omega,
-      W1p.gradient (W1p.contDiffSMul psi hpsi hpsiM hgradM u) x
+      W1p.gradient (W1p.contDiffSMul psi hpsi hM hpsiM hgradM u) x
         = psi x • W1p.gradient u x + W1p.value u x • ∇ psi x := by
   rw [W1p.contDiffSMul, W1p.gradient_mk]
   exact MemLp.coeFn_toLp _
@@ -149,37 +154,40 @@ theorem W1p.gradient_contDiffSMul_ae (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ 
 /-! ### Linearity and boundedness -/
 
 /-- Multiplication by `ψ` is additive. -/
-theorem W1p.contDiffSMul_add (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u v : W1p mu Omega p) :
-    W1p.contDiffSMul psi hpsi hpsiM hgradM (u + v)
-      = W1p.contDiffSMul psi hpsi hpsiM hgradM u + W1p.contDiffSMul psi hpsi hpsiM hgradM v := by
+theorem W1p.contDiffSMul_add (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M)
+    (u v : W1p mu Omega p) :
+    W1p.contDiffSMul psi hpsi hM hpsiM hgradM (u + v)
+      = W1p.contDiffSMul psi hpsi hM hpsiM hgradM u
+        + W1p.contDiffSMul psi hpsi hM hpsiM hgradM v := by
   have hvalue : ∀ w z : W1p mu Omega p, W1p.value (w + z) = W1p.value w + W1p.value z := by
     intro w z
     rw [← W1p.valueL_apply, map_add, W1p.valueL_apply, W1p.valueL_apply]
   refine W1p.ext_value (Lp.ext ?_)
   rw [hvalue]
-  filter_upwards [W1p.value_contDiffSMul_ae hpsi hpsiM hgradM (u + v),
-    W1p.value_contDiffSMul_ae hpsi hpsiM hgradM u,
-    W1p.value_contDiffSMul_ae hpsi hpsiM hgradM v,
-    Lp.coeFn_add (W1p.value (W1p.contDiffSMul psi hpsi hpsiM hgradM u))
-      (W1p.value (W1p.contDiffSMul psi hpsi hpsiM hgradM v)),
+  filter_upwards [W1p.value_contDiffSMul_ae hpsi hM hpsiM hgradM (u + v),
+    W1p.value_contDiffSMul_ae hpsi hM hpsiM hgradM u,
+    W1p.value_contDiffSMul_ae hpsi hM hpsiM hgradM v,
+    Lp.coeFn_add (W1p.value (W1p.contDiffSMul psi hpsi hM hpsiM hgradM u))
+      (W1p.value (W1p.contDiffSMul psi hpsi hM hpsiM hgradM v)),
     Lp.coeFn_add (W1p.value u) (W1p.value v)] with x h h₁ h₂ hadd hadd'
   simp only [h, h₁, h₂, hadd, hadd', hvalue u v, Pi.add_apply, smul_eq_mul]
   ring
 
 /-- Multiplication by `ψ` commutes with scalars. -/
-theorem W1p.contDiffSMul_smul (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (c : ℝ) (u : W1p mu Omega p) :
-    W1p.contDiffSMul psi hpsi hpsiM hgradM (c • u)
-      = c • W1p.contDiffSMul psi hpsi hpsiM hgradM u := by
+theorem W1p.contDiffSMul_smul (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M)
+    (c : ℝ) (u : W1p mu Omega p) :
+    W1p.contDiffSMul psi hpsi hM hpsiM hgradM (c • u)
+      = c • W1p.contDiffSMul psi hpsi hM hpsiM hgradM u := by
   have hvalue : ∀ (a : ℝ) (w : W1p mu Omega p), W1p.value (a • w) = a • W1p.value w := by
     intro a w
     rw [← W1p.valueL_apply, map_smul, W1p.valueL_apply]
   refine W1p.ext_value (Lp.ext ?_)
   rw [hvalue]
-  filter_upwards [W1p.value_contDiffSMul_ae hpsi hpsiM hgradM (c • u),
-    W1p.value_contDiffSMul_ae hpsi hpsiM hgradM u,
-    Lp.coeFn_smul c (W1p.value (W1p.contDiffSMul psi hpsi hpsiM hgradM u)),
+  filter_upwards [W1p.value_contDiffSMul_ae hpsi hM hpsiM hgradM (c • u),
+    W1p.value_contDiffSMul_ae hpsi hM hpsiM hgradM u,
+    Lp.coeFn_smul c (W1p.value (W1p.contDiffSMul psi hpsi hM hpsiM hgradM u)),
     Lp.coeFn_smul c (W1p.value u)] with x h h₁ hsmul hsmul'
   simp only [h, h₁, hsmul, hsmul', hvalue c u, Pi.smul_apply, smul_eq_mul]
   ring
@@ -198,30 +206,31 @@ private theorem norm_sq_coe_ae (w : W1p mu Omega p) :
 most `2 M`, where `M` bounds both `|ψ|` and `‖∇ψ‖`.  The two bounds enter separately: `M` scales
 the value and the `ψ ∇u` half of the gradient, while the second `M` pays for the Leibniz error
 `u ∇ψ`, which is why a bound on `ψ` alone cannot suffice. -/
-theorem W1p.norm_contDiffSMul_le (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
-    ‖W1p.contDiffSMul psi hpsi hpsiM hgradM u‖ ≤ 2 * M * ‖u‖ := by
-  have hM : (0 : ℝ) ≤ M := (abs_nonneg _).trans (hpsiM 0)
-  have hle : ‖(W1p.contDiffSMul psi hpsi hpsiM hgradM u : Sobolev1JetLp mu Omega p)‖
+theorem W1p.norm_contDiffSMul_le (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M)
+    (u : W1p mu Omega p) :
+    ‖W1p.contDiffSMul psi hpsi hM hpsiM hgradM u‖ ≤ 2 * M * ‖u‖ := by
+  have hle : ‖(W1p.contDiffSMul psi hpsi hM hpsiM hgradM u : Sobolev1JetLp mu Omega p)‖
       ≤ ‖(2 * M) • (u : Sobolev1JetLp mu Omega p)‖ := by
     refine Lp.norm_le_norm_of_ae_le ?_
-    filter_upwards [norm_sq_coe_ae (W1p.contDiffSMul psi hpsi hpsiM hgradM u),
-      norm_sq_coe_ae u, W1p.value_contDiffSMul_ae hpsi hpsiM hgradM u,
-      W1p.gradient_contDiffSMul_ae hpsi hpsiM hgradM u,
-      Lp.coeFn_smul (2 * M) (u : Sobolev1JetLp mu Omega p)] with x hsq hsq' hv hg hsmul
+    filter_upwards [norm_sq_coe_ae (W1p.contDiffSMul psi hpsi hM hpsiM hgradM u),
+      norm_sq_coe_ae u, W1p.value_contDiffSMul_ae hpsi hM hpsiM hgradM u,
+      W1p.gradient_contDiffSMul_ae hpsi hM hpsiM hgradM u,
+      Lp.coeFn_smul (2 * M) (u : Sobolev1JetLp mu Omega p),
+      ae_restrict_mem Omega.isOpen.measurableSet] with x hsq hsq' hv hg hsmul hx
     have ha : (0 : ℝ) ≤ ‖W1p.value u x‖ := norm_nonneg _
     have hb : (0 : ℝ) ≤ ‖W1p.gradient u x‖ := norm_nonneg _
     have h₁ : ‖psi x • W1p.value u x‖ ≤ M * ‖W1p.value u x‖ := by
       rw [norm_smul, Real.norm_eq_abs]
-      exact mul_le_mul_of_nonneg_right (hpsiM x) ha
+      exact mul_le_mul_of_nonneg_right (hpsiM x hx) ha
     have h₂ : ‖psi x • W1p.gradient u x + W1p.value u x • ∇ psi x‖
         ≤ M * ‖W1p.gradient u x‖ + ‖W1p.value u x‖ * M := by
       refine (norm_add_le _ _).trans (add_le_add ?_ ?_)
       · rw [norm_smul, Real.norm_eq_abs]
-        exact mul_le_mul_of_nonneg_right (hpsiM x) hb
+        exact mul_le_mul_of_nonneg_right (hpsiM x hx) hb
       · rw [norm_smul]
-        exact mul_le_mul_of_nonneg_left (hgradM x) (norm_nonneg _)
-    have hsqle : ‖(W1p.contDiffSMul psi hpsi hpsiM hgradM u : Sobolev1JetLp mu Omega p) x‖ ^ 2
+        exact mul_le_mul_of_nonneg_left (hgradM x hx) (norm_nonneg _)
+    have hsqle : ‖(W1p.contDiffSMul psi hpsi hM hpsiM hgradM u : Sobolev1JetLp mu Omega p) x‖ ^ 2
         ≤ (2 * M * ‖(u : Sobolev1JetLp mu Omega p) x‖) ^ 2 := by
       rw [hsq, hv, hg, mul_pow, hsq']
       have hs₁ := pow_le_pow_left₀ (norm_nonneg _) h₁ 2
@@ -233,7 +242,7 @@ theorem W1p.norm_contDiffSMul_le (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |
     rw [Real.sqrt_sq (norm_nonneg _), Real.sqrt_sq hBnn] at hfinal
     rw [hsmul, Pi.smul_apply, norm_smul, Real.norm_eq_abs, abs_of_nonneg (by positivity)]
     exact hfinal
-  calc ‖W1p.contDiffSMul psi hpsi hpsiM hgradM u‖
+  calc ‖W1p.contDiffSMul psi hpsi hM hpsiM hgradM u‖
       ≤ ‖(2 * M) • (u : Sobolev1JetLp mu Omega p)‖ := hle
     _ = 2 * M * ‖u‖ := by
         rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg (by positivity : (0:ℝ) ≤ 2 * M)]
@@ -242,32 +251,37 @@ theorem W1p.norm_contDiffSMul_le (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |
 /-- **Multiplication by a smooth cutoff, as a continuous linear operator** on `W^{1,p}(Ω)`, of
 norm at most `2 M`. -/
 def W1p.contDiffSMulL (psi : E → ℝ) (hpsi : ContDiff ℝ ∞ psi) {M : ℝ}
-    (hpsiM : ∀ x, |psi x| ≤ M) (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) :
+    (hM : 0 ≤ M) (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M)
+    (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M) :
     W1p mu Omega p →L[ℝ] W1p mu Omega p :=
   LinearMap.mkContinuous
-    { toFun := W1p.contDiffSMul psi hpsi hpsiM hgradM
-      map_add' := W1p.contDiffSMul_add hpsi hpsiM hgradM
-      map_smul' := W1p.contDiffSMul_smul hpsi hpsiM hgradM }
-    (2 * M) (W1p.norm_contDiffSMul_le hpsi hpsiM hgradM)
+    { toFun := W1p.contDiffSMul psi hpsi hM hpsiM hgradM
+      map_add' := W1p.contDiffSMul_add hpsi hM hpsiM hgradM
+      map_smul' := W1p.contDiffSMul_smul hpsi hM hpsiM hgradM }
+    (2 * M) (W1p.norm_contDiffSMul_le hpsi hM hpsiM hgradM)
 
 @[simp]
-theorem W1p.contDiffSMulL_apply (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
-    W1p.contDiffSMulL psi hpsi hpsiM hgradM u = W1p.contDiffSMul psi hpsi hpsiM hgradM u :=
+theorem W1p.contDiffSMulL_apply (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M)
+    (u : W1p mu Omega p) :
+    W1p.contDiffSMulL psi hpsi hM hpsiM hgradM u
+      = W1p.contDiffSMul psi hpsi hM hpsiM hgradM u :=
   (rfl)
 
 /-! ### The zero-boundary subspace is preserved -/
 
 /-- Multiplying a test function by a smooth `ψ` gives the test function `ψ φ`, whichever of the
 two orders — multiply then embed, or embed then multiply — is used. -/
-theorem W1p.contDiffSMul_ofTestFunctionₗ (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (phi Phi : 𝓓(Omega, ℝ))
+theorem W1p.contDiffSMul_ofTestFunctionₗ (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M)
+    (phi Phi : 𝓓(Omega, ℝ))
     (hPhi : (Phi : E → ℝ) = psi * (phi : E → ℝ)) :
-    W1p.contDiffSMul psi hpsi hpsiM hgradM (W1p.ofTestFunctionₗ mu Omega p phi)
+    W1p.contDiffSMul psi hpsi hM hpsiM hgradM (W1p.ofTestFunctionₗ mu Omega p phi)
       = W1p.ofTestFunctionₗ mu Omega p Phi := by
   refine W1p.ext_value (Lp.ext ?_)
   rw [W1p.value_ofTestFunctionₗ]
-  filter_upwards [W1p.value_contDiffSMul_ae hpsi hpsiM hgradM (W1p.ofTestFunctionₗ mu Omega p phi),
+  filter_upwards [W1p.value_contDiffSMul_ae hpsi hM hpsiM hgradM
+      (W1p.ofTestFunctionₗ mu Omega p phi),
     testFunctionLp_apply_ae (mu := mu) p phi, testFunctionLp_apply_ae (mu := mu) p Phi]
     with x h h₁ h₂
   rw [h, W1p.value_ofTestFunctionₗ, h₁, h₂, hPhi, Pi.mul_apply, smul_eq_mul]
@@ -276,30 +290,32 @@ theorem W1p.contDiffSMul_ofTestFunctionₗ (hpsi : ContDiff ℝ ∞ psi) (hpsiM 
 test function supported in `Ω`, the operator maps the generating test-function jets back into
 `W^{1,p}_0(Ω)`, and continuity extends that to their closure.  This is the form the localization
 arguments of Lane A use, because a cutoff must not create a boundary trace. -/
-theorem W1p.contDiffSMul_mem_w1p0Submodule (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) {u : W1p mu Omega p} (hu : u ∈ w1p0Submodule mu Omega p) :
-    W1p.contDiffSMul psi hpsi hpsiM hgradM u ∈ w1p0Submodule mu Omega p := by
-  have hclosed : IsClosed (W1p.contDiffSMulL psi hpsi hpsiM hgradM ⁻¹'
+theorem W1p.contDiffSMul_mem_w1p0Submodule (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M)
+    {u : W1p mu Omega p} (hu : u ∈ w1p0Submodule mu Omega p) :
+    W1p.contDiffSMul psi hpsi hM hpsiM hgradM u ∈ w1p0Submodule mu Omega p := by
+  have hclosed : IsClosed (W1p.contDiffSMulL psi hpsi hM hpsiM hgradM ⁻¹'
       (w1p0Submodule mu Omega p : Set (W1p mu Omega p))) :=
     (w1p0Submodule mu Omega p).isClosed.preimage
-      (W1p.contDiffSMulL psi hpsi hpsiM hgradM).continuous
+      (W1p.contDiffSMulL psi hpsi hM hpsiM hgradM).continuous
   have htest : ∀ phi : 𝓓(Omega, ℝ), W1p.ofTestFunctionₗ mu Omega p phi ∈
-      W1p.contDiffSMulL psi hpsi hpsiM hgradM ⁻¹'
+      W1p.contDiffSMulL psi hpsi hM hpsiM hgradM ⁻¹'
         (w1p0Submodule mu Omega p : Set (W1p mu Omega p)) := by
     intro phi
     obtain ⟨Phi, hPhi⟩ : ∃ Phi : 𝓓(Omega, ℝ), (Phi : E → ℝ) = psi * (phi : E → ℝ) :=
       ⟨⟨psi * (phi : E → ℝ), hpsi.mul phi.contDiff, phi.hasCompactSupport.mul_left,
         tsupport_mul_subset_right.trans phi.tsupport_subset⟩, rfl⟩
     simp only [Set.mem_preimage, SetLike.mem_coe, W1p.contDiffSMulL_apply,
-      W1p.contDiffSMul_ofTestFunctionₗ hpsi hpsiM hgradM phi Phi hPhi]
+      W1p.contDiffSMul_ofTestFunctionₗ hpsi hM hpsiM hgradM phi Phi hPhi]
     exact W1p.ofTestFunctionₗ_mem_w1p0Submodule Phi
   have := w1p0Submodule_subset_of_isClosed hclosed htest hu
   simpa using this
 
 /-- The operator norm of multiplication by `ψ` is at most `2 M`. -/
-theorem W1p.norm_contDiffSMulL_le (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
-    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) :
-    ‖W1p.contDiffSMulL (mu := mu) (Omega := Omega) (p := p) psi hpsi hpsiM hgradM‖ ≤ 2 * M :=
-  LinearMap.mkContinuous_norm_le _ (by linarith [(abs_nonneg (psi 0)).trans (hpsiM 0)]) _
+theorem W1p.norm_contDiffSMulL_le (hpsi : ContDiff ℝ ∞ psi) (hM : 0 ≤ M)
+    (hpsiM : ∀ x ∈ Omega, |psi x| ≤ M) (hgradM : ∀ x ∈ Omega, ‖∇ psi x‖ ≤ M) :
+    ‖W1p.contDiffSMulL (mu := mu) (Omega := Omega) (p := p)
+      psi hpsi hM hpsiM hgradM‖ ≤ 2 * M :=
+  LinearMap.mkContinuous_norm_le _ (by positivity) _
 
 end TauCeti

--- a/TauCeti/Analysis/Sobolev/W1p/Multiplication.lean
+++ b/TauCeti/Analysis/Sobolev/W1p/Multiplication.lean
@@ -1,0 +1,306 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Sobolev.Leibniz
+public import TauCeti.Analysis.Sobolev.W1p.Zero
+
+/-!
+# Multiplication by a smooth cutoff on `W^{1,p}(Ω)`
+
+The Leibniz rule of `TauCeti/Analysis/Sobolev/Leibniz.lean` says that `ψ u` is weakly
+differentiable whenever `u` is and `ψ` is smooth.  This file upgrades that from a statement about
+weak derivatives to a statement about the Sobolev space itself: if `ψ` and `∇ψ` are bounded by a
+constant `M`, then
+
+`u ↦ ψ u`
+
+is a continuous linear operator on `W^{1,p}(Ω)` of norm at most `2 M`, with value component `ψ u`
+and gradient component `ψ ∇u + u ∇ψ`.
+
+Boundedness of `ψ` *and* of `∇ψ` is what the statement needs, and neither is automatic: for
+`ψ x = exp ‖x‖²` on `Ω = ℝⁿ` the product `ψ u` leaves every `Lᵖ` class.  Both bounds are therefore
+carried explicitly, through a single constant `M`, so that the operator norm is visible rather
+than hidden behind an unquantified `∃ C`; that is the convention the PDE roadmap asks for.  A
+cutoff built from `ContDiffBump` satisfies them, which is the intended use.
+
+## The operator and the milestone
+
+Multiplication by a cutoff is the localization device of Lane A of
+`TauCetiRoadmap/PDE/README.md`: it is the first step of the Meyers--Serrin `H = W` density theorem
+and of the extension operator (Lane A.2 and A.6), and it is what converts an interior estimate
+into an estimate on a compactly contained subdomain.  Having it as a *bounded operator*, rather
+than as a pointwise membership statement, is what lets those arguments range over a family of
+cutoffs while keeping uniform control of the resulting Sobolev norms.
+
+The factor `2` in `‖ψ u‖ ≤ 2 M ‖u‖` is not optimal — the sharp constant for the Euclidean jet norm
+used here is `√2 M` — but it is explicit, and it is the only shape the downstream localization
+arguments need.
+
+## Main declarations
+
+* `TauCeti.W1p.contDiffSMul`: the product `ψ u`, as an element of `W^{1,p}(Ω)`.
+* `TauCeti.W1p.value_contDiffSMul_ae` and `TauCeti.W1p.gradient_contDiffSMul_ae`: its two
+  components, `ψ u` and `ψ ∇u + u ∇ψ`.
+* `TauCeti.W1p.norm_contDiffSMul_le`: the bound `‖ψ u‖ ≤ 2 M ‖u‖`.
+* `TauCeti.W1p.contDiffSMulL`: the same map, bundled as a continuous linear operator.
+* `TauCeti.W1p.contDiffSMul_mem_w1p0Submodule`: it preserves `W^{1,p}_0(Ω)`, the closure of
+  `C_c^∞(Ω)`.
+
+## References
+
+L. C. Evans, *Partial Differential Equations*, §5.2.3, Theorem 1(iv) and §5.3.3.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open MeasureTheory Set TopologicalSpace
+open scoped ContDiff Distributions ENNReal Gradient InnerProductSpace
+
+variable {E : Type*} [MeasurableSpace E] [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+  [FiniteDimensional ℝ E] [BorelSpace E] {mu : Measure E} [mu.IsAddHaarMeasure]
+  {Omega : Opens E} {p : ENNReal} [Fact (1 ≤ p)] {psi : E → ℝ} {M : ℝ}
+
+/-! ### The two `Lᵖ` components -/
+
+omit [MeasurableSpace E] [BorelSpace E] in
+/-- The gradient of a smooth function is the Riesz representative of its Fréchet derivative, hence
+continuous.  This is what makes the product below measurable. -/
+theorem continuous_gradient (hpsi : ContDiff ℝ ∞ psi) : Continuous (∇ psi) := by
+  have heq : ∇ psi = fun x => (InnerProductSpace.toDual ℝ E).symm (fderiv ℝ psi x) := by
+    funext x
+    exact (hasFDerivAt_iff_hasGradientAt.1
+      ((hpsi.differentiable (by simp)) x).hasFDerivAt).gradient
+  rw [heq]
+  exact (InnerProductSpace.toDual ℝ E).symm.continuous.comp (hpsi.continuous_fderiv (by simp))
+
+omit [FiniteDimensional ℝ E] in
+/-- The value component `ψ u` of the product is `Lᵖ`, because `ψ` is bounded. -/
+theorem W1p.memLp_smul_value (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (u : W1p mu Omega p) :
+    MemLp (fun x => psi x • W1p.value u x) p (mu.restrict Omega) := by
+  have hM : (0 : ℝ) ≤ M := (abs_nonneg _).trans (hpsiM 0)
+  refine MemLp.of_le ((Lp.memLp (W1p.value u)).const_mul M) ?_ ?_
+  · exact hpsi.continuous.aestronglyMeasurable.smul (Lp.aestronglyMeasurable _)
+  · filter_upwards with x
+    rw [smul_eq_mul, Real.norm_eq_abs, Real.norm_eq_abs, abs_mul, abs_mul, abs_of_nonneg hM]
+    exact mul_le_mul_of_nonneg_right (hpsiM x) (abs_nonneg _)
+
+/-- The gradient component `ψ ∇u + u ∇ψ` of the product is `Lᵖ`, because `ψ` and `∇ψ` are
+bounded. -/
+theorem W1p.memLp_smul_gradient (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+    MemLp (fun x => psi x • W1p.gradient u x + W1p.value u x • ∇ psi x) p (mu.restrict Omega) := by
+  have hM : (0 : ℝ) ≤ M := (abs_nonneg _).trans (hpsiM 0)
+  refine MemLp.add ?_ ?_
+  · refine MemLp.of_le ((Lp.memLp (W1p.gradient u)).const_smul M) ?_ ?_
+    · exact hpsi.continuous.aestronglyMeasurable.smul (Lp.aestronglyMeasurable _)
+    · filter_upwards with x
+      rw [norm_smul, Pi.smul_apply, norm_smul, Real.norm_eq_abs, Real.norm_eq_abs,
+        abs_of_nonneg hM]
+      exact mul_le_mul_of_nonneg_right (hpsiM x) (norm_nonneg _)
+  · refine MemLp.of_le ((Lp.memLp (W1p.value u)).const_mul M) ?_ ?_
+    · exact (Lp.aestronglyMeasurable _).smul (continuous_gradient hpsi).aestronglyMeasurable
+    · filter_upwards with x
+      rw [norm_smul, Real.norm_eq_abs, Real.norm_eq_abs, abs_mul, abs_of_nonneg hM, mul_comm M]
+      exact mul_le_mul_of_nonneg_left (hgradM x) (abs_nonneg _)
+
+/-! ### The product -/
+
+/-- **Multiplication by a smooth cutoff.**  If `ψ` is smooth with `|ψ| ≤ M` and `‖∇ψ‖ ≤ M`, the
+product `ψ u` of `ψ` with a Sobolev function `u ∈ W^{1,p}(Ω)` is again in `W^{1,p}(Ω)`; its weak
+gradient is `ψ ∇u + u ∇ψ` by the Leibniz rule. -/
+def W1p.contDiffSMul (psi : E → ℝ) (hpsi : ContDiff ℝ ∞ psi) {M : ℝ}
+    (hpsiM : ∀ x, |psi x| ≤ M) (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+    W1p mu Omega p :=
+  W1p.mk ((W1p.memLp_smul_value hpsi hpsiM u).toLp _)
+    ((W1p.memLp_smul_gradient hpsi hpsiM hgradM u).toLp _)
+    (by
+      have hv := (W1p.memLp_smul_value (mu := mu) (Omega := Omega) (p := p) hpsi hpsiM u).coeFn_toLp
+      have hg := (W1p.memLp_smul_gradient (mu := mu) (Omega := Omega) (p := p)
+        hpsi hpsiM hgradM u).coeFn_toLp
+      refine (((W1p.hasWeakFDerivOn u).contDiff_smul_gradient hpsi).congr_ae
+        hv.symm).congr_ae_deriv (hg.mono fun x hx => ?_)
+      simp only [hx])
+
+/-- The value component of `ψ u` is `ψ u`. -/
+theorem W1p.value_contDiffSMul_ae (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+    ∀ᵐ x ∂mu.restrict Omega,
+      W1p.value (W1p.contDiffSMul psi hpsi hpsiM hgradM u) x = psi x • W1p.value u x := by
+  rw [W1p.contDiffSMul, W1p.value_mk]
+  exact MemLp.coeFn_toLp _
+
+/-- **The Leibniz rule in `W^{1,p}(Ω)`**: the weak gradient of `ψ u` is `ψ ∇u + u ∇ψ`. -/
+theorem W1p.gradient_contDiffSMul_ae (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+    ∀ᵐ x ∂mu.restrict Omega,
+      W1p.gradient (W1p.contDiffSMul psi hpsi hpsiM hgradM u) x
+        = psi x • W1p.gradient u x + W1p.value u x • ∇ psi x := by
+  rw [W1p.contDiffSMul, W1p.gradient_mk]
+  exact MemLp.coeFn_toLp _
+
+/-! ### Linearity and boundedness -/
+
+/-- Multiplication by `ψ` is additive. -/
+theorem W1p.contDiffSMul_add (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u v : W1p mu Omega p) :
+    W1p.contDiffSMul psi hpsi hpsiM hgradM (u + v)
+      = W1p.contDiffSMul psi hpsi hpsiM hgradM u + W1p.contDiffSMul psi hpsi hpsiM hgradM v := by
+  have hvalue : ∀ w z : W1p mu Omega p, W1p.value (w + z) = W1p.value w + W1p.value z := by
+    intro w z
+    rw [← W1p.valueL_apply, map_add, W1p.valueL_apply, W1p.valueL_apply]
+  refine W1p.ext_value (Lp.ext ?_)
+  rw [hvalue]
+  filter_upwards [W1p.value_contDiffSMul_ae hpsi hpsiM hgradM (u + v),
+    W1p.value_contDiffSMul_ae hpsi hpsiM hgradM u,
+    W1p.value_contDiffSMul_ae hpsi hpsiM hgradM v,
+    Lp.coeFn_add (W1p.value (W1p.contDiffSMul psi hpsi hpsiM hgradM u))
+      (W1p.value (W1p.contDiffSMul psi hpsi hpsiM hgradM v)),
+    Lp.coeFn_add (W1p.value u) (W1p.value v)] with x h h₁ h₂ hadd hadd'
+  simp only [h, h₁, h₂, hadd, hadd', hvalue u v, Pi.add_apply, smul_eq_mul]
+  ring
+
+/-- Multiplication by `ψ` commutes with scalars. -/
+theorem W1p.contDiffSMul_smul (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (c : ℝ) (u : W1p mu Omega p) :
+    W1p.contDiffSMul psi hpsi hpsiM hgradM (c • u)
+      = c • W1p.contDiffSMul psi hpsi hpsiM hgradM u := by
+  have hvalue : ∀ (a : ℝ) (w : W1p mu Omega p), W1p.value (a • w) = a • W1p.value w := by
+    intro a w
+    rw [← W1p.valueL_apply, map_smul, W1p.valueL_apply]
+  refine W1p.ext_value (Lp.ext ?_)
+  rw [hvalue]
+  filter_upwards [W1p.value_contDiffSMul_ae hpsi hpsiM hgradM (c • u),
+    W1p.value_contDiffSMul_ae hpsi hpsiM hgradM u,
+    Lp.coeFn_smul c (W1p.value (W1p.contDiffSMul psi hpsi hpsiM hgradM u)),
+    Lp.coeFn_smul c (W1p.value u)] with x h h₁ hsmul hsmul'
+  simp only [h, h₁, hsmul, hsmul', hvalue c u, Pi.smul_apply, smul_eq_mul]
+  ring
+
+omit [FiniteDimensional ℝ E] in
+/-- The squared Euclidean jet norm splits into the value and gradient contributions. -/
+private theorem norm_sq_coe_ae (w : W1p mu Omega p) :
+    ∀ᵐ x ∂mu.restrict Omega,
+      ‖(w : Sobolev1JetLp mu Omega p) x‖ ^ 2
+        = ‖W1p.value w x‖ ^ 2 + ‖W1p.gradient w x‖ ^ 2 := by
+  filter_upwards [W1p.value_apply_ae w, W1p.gradient_apply_ae w] with x hv hg
+  rw [hv, hg]
+  exact WithLp.prod_norm_sq_eq_of_L2 _
+
+/-- **The operator bound.**  Multiplication by `ψ` increases the `W^{1,p}` norm by a factor of at
+most `2 M`, where `M` bounds both `|ψ|` and `‖∇ψ‖`.  The two bounds enter separately: `M` scales
+the value and the `ψ ∇u` half of the gradient, while the second `M` pays for the Leibniz error
+`u ∇ψ`, which is why a bound on `ψ` alone cannot suffice. -/
+theorem W1p.norm_contDiffSMul_le (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+    ‖W1p.contDiffSMul psi hpsi hpsiM hgradM u‖ ≤ 2 * M * ‖u‖ := by
+  have hM : (0 : ℝ) ≤ M := (abs_nonneg _).trans (hpsiM 0)
+  have hle : ‖(W1p.contDiffSMul psi hpsi hpsiM hgradM u : Sobolev1JetLp mu Omega p)‖
+      ≤ ‖(2 * M) • (u : Sobolev1JetLp mu Omega p)‖ := by
+    refine Lp.norm_le_norm_of_ae_le ?_
+    filter_upwards [norm_sq_coe_ae (W1p.contDiffSMul psi hpsi hpsiM hgradM u),
+      norm_sq_coe_ae u, W1p.value_contDiffSMul_ae hpsi hpsiM hgradM u,
+      W1p.gradient_contDiffSMul_ae hpsi hpsiM hgradM u,
+      Lp.coeFn_smul (2 * M) (u : Sobolev1JetLp mu Omega p)] with x hsq hsq' hv hg hsmul
+    have ha : (0 : ℝ) ≤ ‖W1p.value u x‖ := norm_nonneg _
+    have hb : (0 : ℝ) ≤ ‖W1p.gradient u x‖ := norm_nonneg _
+    have h₁ : ‖psi x • W1p.value u x‖ ≤ M * ‖W1p.value u x‖ := by
+      rw [norm_smul, Real.norm_eq_abs]
+      exact mul_le_mul_of_nonneg_right (hpsiM x) ha
+    have h₂ : ‖psi x • W1p.gradient u x + W1p.value u x • ∇ psi x‖
+        ≤ M * ‖W1p.gradient u x‖ + ‖W1p.value u x‖ * M := by
+      refine (norm_add_le _ _).trans (add_le_add ?_ ?_)
+      · rw [norm_smul, Real.norm_eq_abs]
+        exact mul_le_mul_of_nonneg_right (hpsiM x) hb
+      · rw [norm_smul]
+        exact mul_le_mul_of_nonneg_left (hgradM x) (norm_nonneg _)
+    have hsqle : ‖(W1p.contDiffSMul psi hpsi hpsiM hgradM u : Sobolev1JetLp mu Omega p) x‖ ^ 2
+        ≤ (2 * M * ‖(u : Sobolev1JetLp mu Omega p) x‖) ^ 2 := by
+      rw [hsq, hv, hg, mul_pow, hsq']
+      have hs₁ := pow_le_pow_left₀ (norm_nonneg _) h₁ 2
+      have hs₂ := pow_le_pow_left₀ (norm_nonneg _) h₂ 2
+      nlinarith [sq_nonneg (‖W1p.value u x‖ - ‖W1p.gradient u x‖), sq_nonneg M,
+        mul_nonneg ha hb, mul_nonneg (mul_nonneg hM hM) (mul_nonneg ha hb)]
+    have hBnn : (0 : ℝ) ≤ 2 * M * ‖(u : Sobolev1JetLp mu Omega p) x‖ := by positivity
+    have hfinal := Real.sqrt_le_sqrt hsqle
+    rw [Real.sqrt_sq (norm_nonneg _), Real.sqrt_sq hBnn] at hfinal
+    rw [hsmul, Pi.smul_apply, norm_smul, Real.norm_eq_abs, abs_of_nonneg (by positivity)]
+    exact hfinal
+  calc ‖W1p.contDiffSMul psi hpsi hpsiM hgradM u‖
+      ≤ ‖(2 * M) • (u : Sobolev1JetLp mu Omega p)‖ := hle
+    _ = 2 * M * ‖u‖ := by
+        rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg (by positivity : (0:ℝ) ≤ 2 * M)]
+        rfl
+
+/-- **Multiplication by a smooth cutoff, as a continuous linear operator** on `W^{1,p}(Ω)`, of
+norm at most `2 M`. -/
+def W1p.contDiffSMulL (psi : E → ℝ) (hpsi : ContDiff ℝ ∞ psi) {M : ℝ}
+    (hpsiM : ∀ x, |psi x| ≤ M) (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) :
+    W1p mu Omega p →L[ℝ] W1p mu Omega p :=
+  LinearMap.mkContinuous
+    { toFun := W1p.contDiffSMul psi hpsi hpsiM hgradM
+      map_add' := W1p.contDiffSMul_add hpsi hpsiM hgradM
+      map_smul' := W1p.contDiffSMul_smul hpsi hpsiM hgradM }
+    (2 * M) (W1p.norm_contDiffSMul_le hpsi hpsiM hgradM)
+
+@[simp]
+theorem W1p.contDiffSMulL_apply (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (u : W1p mu Omega p) :
+    W1p.contDiffSMulL psi hpsi hpsiM hgradM u = W1p.contDiffSMul psi hpsi hpsiM hgradM u :=
+  (rfl)
+
+/-! ### The zero-boundary subspace is preserved -/
+
+/-- Multiplying a test function by a smooth `ψ` gives the test function `ψ φ`, whichever of the
+two orders — multiply then embed, or embed then multiply — is used. -/
+theorem W1p.contDiffSMul_ofTestFunctionₗ (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) (phi Phi : 𝓓(Omega, ℝ))
+    (hPhi : (Phi : E → ℝ) = psi * (phi : E → ℝ)) :
+    W1p.contDiffSMul psi hpsi hpsiM hgradM (W1p.ofTestFunctionₗ mu Omega p phi)
+      = W1p.ofTestFunctionₗ mu Omega p Phi := by
+  refine W1p.ext_value (Lp.ext ?_)
+  rw [W1p.value_ofTestFunctionₗ]
+  filter_upwards [W1p.value_contDiffSMul_ae hpsi hpsiM hgradM (W1p.ofTestFunctionₗ mu Omega p phi),
+    testFunctionLp_apply_ae (mu := mu) p phi, testFunctionLp_apply_ae (mu := mu) p Phi]
+    with x h h₁ h₂
+  rw [h, W1p.value_ofTestFunctionₗ, h₁, h₂, hPhi, Pi.mul_apply, smul_eq_mul]
+
+/-- **`W^{1,p}_0(Ω)` is stable under multiplication by a smooth cutoff.**  Since `ψ φ` is again a
+test function supported in `Ω`, the operator maps the generating test-function jets back into
+`W^{1,p}_0(Ω)`, and continuity extends that to their closure.  This is the form the localization
+arguments of Lane A use, because a cutoff must not create a boundary trace. -/
+theorem W1p.contDiffSMul_mem_w1p0Submodule (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) {u : W1p mu Omega p} (hu : u ∈ w1p0Submodule mu Omega p) :
+    W1p.contDiffSMul psi hpsi hpsiM hgradM u ∈ w1p0Submodule mu Omega p := by
+  have hclosed : IsClosed (W1p.contDiffSMulL psi hpsi hpsiM hgradM ⁻¹'
+      (w1p0Submodule mu Omega p : Set (W1p mu Omega p))) :=
+    (w1p0Submodule mu Omega p).isClosed.preimage
+      (W1p.contDiffSMulL psi hpsi hpsiM hgradM).continuous
+  have htest : ∀ phi : 𝓓(Omega, ℝ), W1p.ofTestFunctionₗ mu Omega p phi ∈
+      W1p.contDiffSMulL psi hpsi hpsiM hgradM ⁻¹'
+        (w1p0Submodule mu Omega p : Set (W1p mu Omega p)) := by
+    intro phi
+    obtain ⟨Phi, hPhi⟩ : ∃ Phi : 𝓓(Omega, ℝ), (Phi : E → ℝ) = psi * (phi : E → ℝ) :=
+      ⟨⟨psi * (phi : E → ℝ), hpsi.mul phi.contDiff, phi.hasCompactSupport.mul_left,
+        tsupport_mul_subset_right.trans phi.tsupport_subset⟩, rfl⟩
+    simp only [Set.mem_preimage, SetLike.mem_coe, W1p.contDiffSMulL_apply,
+      W1p.contDiffSMul_ofTestFunctionₗ hpsi hpsiM hgradM phi Phi hPhi]
+    exact W1p.ofTestFunctionₗ_mem_w1p0Submodule Phi
+  have := w1p0Submodule_subset_of_isClosed hclosed htest hu
+  simpa using this
+
+/-- The operator norm of multiplication by `ψ` is at most `2 M`. -/
+theorem W1p.norm_contDiffSMulL_le (hpsi : ContDiff ℝ ∞ psi) (hpsiM : ∀ x, |psi x| ≤ M)
+    (hgradM : ∀ x, ‖∇ psi x‖ ≤ M) :
+    ‖W1p.contDiffSMulL (mu := mu) (Omega := Omega) (p := p) psi hpsi hpsiM hgradM‖ ≤ 2 * M :=
+  LinearMap.mkContinuous_norm_le _ (by linarith [(abs_nonneg (psi 0)).trans (hpsiM 0)]) _
+
+end TauCeti


### PR DESCRIPTION
This PR proves the **Leibniz product rule for weak derivatives** on an open set `Ω`, and uses it to build **multiplication by a smooth cutoff as a continuous linear operator on `W^{1,p}(Ω)`**. For a smooth `ψ : E → ℝ` and a weakly differentiable `u`, the rule is `∂_v(ψ u) = ψ ∂_v u + (∂_v ψ) u`, and it is proved by the distributional computation: testing `ψ u` against `∂_v φ` is testing `u` against `ψ ∂_v φ = ∂_v(ψ φ) − (∂_v ψ) φ`, where `ψ φ` is again a test function on `Ω` because multiplying by a smooth function neither enlarges a support nor destroys smoothness. No boundary hypothesis on `Ω` is used and none is needed: `ψ φ` is still compactly supported *inside* `Ω`, so no boundary term appears.

The roadmap target is Lane A of `TauCetiRoadmap/PDE/README.md`. The milestone it serves is Lane A.2, "Density and `W^{k,p}_0`" — Meyers–Serrin `H = W` — whose first step is exactly truncation by a cutoff, and Lane A.6's extension operator, which localizes the same way; the roadmap's inventory lists both under "the embedding/trace/compactness package". Neither `TauCeti/Analysis/Sobolev/WeakDeriv.lean` nor `W1p/Basic.lean` had any product rule: they supply `add`, `neg`, `const_smul` and `congr_ae`, which suffice for a linear theory but not for localizing one. What remains after this PR for Lane A.2 is the analytic half — that mollification converges in `Lᵖ`, which is in neither Mathlib nor this repository — together with the partition of unity that assembles the local approximations.

The Rellich–Kondrachov clause of Lane A.6, which would otherwise be the next step, is already covered by open PR #4595 (Fréchet–Kolmogorov) and its stated follow-up, so it is deliberately not touched here.

`TauCeti/Analysis/Sobolev/Leibniz.lean` (175 lines) proves the rule in three forms: `TauCeti.HasWeakLineDerivOn.contDiff_smul` in a direction `v`; `TauCeti.HasWeakFDerivOn.contDiff_smul`, whose correction term is the rank-one map `(fderiv ℝ ψ x).smulRight (u x)`; and `TauCeti.HasWeakFDerivOn.contDiff_smul_gradient`, the gradient form `∇(ψ a) = ψ ∇a + a ∇ψ` in which `TauCeti.W1p` records a weak derivative. Smoothness of `ψ` is more than the identity needs — `C¹` would do — but it is what makes `ψ φ` a member of Mathlib's `TestFunction` type, whose smoothness order is `∞`, and it is what the intended cutoffs supply. The proof reuses the repository's own `TauCeti.integrable_smul_of_locallyIntegrableOn` and `TauCeti.integrable_lineDeriv_smul_of_locallyIntegrableOn` for the integrability side conditions and Mathlib's `LocallyIntegrableOn.continuousOn_smul`, `DifferentiableAt.lineDeriv_eq_fderiv`, `fderiv_mul`, `HasCompactSupport.mul_left` and `tsupport_mul_subset_right`. No Mathlib source was vendored.

`TauCeti/Analysis/Sobolev/W1p/Multiplication.lean` (306 lines) turns the rule into an operator. Boundedness of `ψ` *and* of `∇ψ` is what the Sobolev statement needs and neither is automatic — for `ψ x = exp ‖x‖²` on `Ω = ℝⁿ` the product `ψ u` leaves every `Lᵖ` class — so both bounds are carried explicitly, through a single constant `M`, and the operator norm is stated rather than hidden behind an unquantified `∃ C`, as the roadmap's standing-hypotheses section asks. `TauCeti.W1p.contDiffSMul` is the product, with `TauCeti.W1p.value_contDiffSMul_ae` and `TauCeti.W1p.gradient_contDiffSMul_ae` identifying its two components as `ψ u` and `ψ ∇u + u ∇ψ`; `TauCeti.W1p.norm_contDiffSMul_le` gives `‖ψ u‖ ≤ 2 M ‖u‖`, and `TauCeti.W1p.contDiffSMulL` bundles the map as a continuous linear operator of norm at most `2 M`. The constant `2` is explicit, and it is the only shape the downstream localization arguments need. Finally `TauCeti.W1p.contDiffSMul_mem_w1p0Submodule` records that the operator preserves `W^{1,p}_0(Ω)`: `ψ φ` is again a test function supported in `Ω`, so the generating jets go back into the subspace, and continuity extends that to their closure through the repository's `TauCeti.w1p0Submodule_subset_of_isClosed`. That last statement is what makes the operator usable as a cutoff, since a cutoff must not create a boundary trace.

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"leibniz-product-rule-weak-derivatives"}-->

🤖 Prepared with Claude Code
