### PR TITLE
feat: add covariance matrices of Euclidean laws

### DIFF
--- a/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
@@ -6,25 +6,19 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Probability.Distributions.Gaussian.Multivariate
+public import TauCeti.Probability.Moments.Covariance
 
 /-!
-# Covariance matrices of Euclidean-valued measures
+# The covariance matrix of a multivariate Gaussian
 
-This file packages the coordinate covariances of a measure on a finite-dimensional Euclidean
-space as a matrix. It identifies that matrix with the covariance parameter of Mathlib's
-multivariate Gaussian and connects it to Mathlib's basis-free `covarianceBilin`.
-
-The `MemLp id 2 μ` hypothesis in the comparison theorem is essential. Mathlib deliberately sets
-`covarianceBilin μ` to zero when this hypothesis fails, whereas its scalar `covariance` is
-totalized coordinate by coordinate.
+This file identifies the generic covariance matrix from
+`TauCeti.Probability.Moments.Covariance` with the covariance parameter of Mathlib's multivariate
+Gaussian.
 
 ## Main results
 
-* `TauCeti.covMatrix` is the matrix of coordinate covariances of a measure.
 * `TauCeti.covMatrix_multivariateGaussian` recovers the covariance parameter of a multivariate
   Gaussian law.
-* `TauCeti.covarianceBilin_eq_covMatrix` identifies the matrix and bilinear-form views of
-  covariance when the measure has a finite second moment.
 
 ## References
 
@@ -36,79 +30,22 @@ public section
 
 noncomputable section
 
-open MeasureTheory ProbabilityTheory
-
-open scoped RealInnerProductSpace
+open ProbabilityTheory
 
 namespace TauCeti
 
 variable {ι : Type*}
 
-/-- The covariance matrix of a measure on a finite-dimensional Euclidean space. Its `(i, j)`
-entry is the scalar covariance of the `i`th and `j`th coordinate projections. -/
-def covMatrix (μ : Measure (EuclideanSpace ℝ ι)) : Matrix ι ι ℝ :=
-  fun i j => cov[fun z => z i, fun z => z j; μ]
-
-/-- An entry of `covMatrix` is the covariance of the corresponding coordinate projections. -/
-@[simp]
-theorem covMatrix_apply (μ : Measure (EuclideanSpace ℝ ι)) (i j : ι) :
-    covMatrix μ i j = cov[fun z => z i, fun z => z j; μ] := (rfl)
-
-/-- Covariance matrices are symmetric. -/
-theorem covMatrix_apply_comm (μ : Measure (EuclideanSpace ℝ ι)) (i j : ι) :
-    covMatrix μ i j = covMatrix μ j i := by
-  rw [covMatrix_apply, covMatrix_apply, covariance_comm]
-
-/-- A covariance matrix is Hermitian (equivalently, symmetric over `ℝ`). -/
-theorem covMatrix_isHermitian (μ : Measure (EuclideanSpace ℝ ι)) :
-    (covMatrix μ).IsHermitian := by
-  rw [Matrix.isHermitian_iff_isSymm, Matrix.IsSymm.ext_iff]
-  exact fun i j => covMatrix_apply_comm μ j i
+local instance : DecidableEq ι := Classical.decEq ι
 
 /-- The covariance matrix of a positive-semidefinite multivariate Gaussian is its covariance
 parameter. -/
 @[simp]
-theorem covMatrix_multivariateGaussian [Fintype ι] [DecidableEq ι] (m : EuclideanSpace ℝ ι)
+theorem covMatrix_multivariateGaussian [Fintype ι] (m : EuclideanSpace ℝ ι)
     {S : Matrix ι ι ℝ} (hS : S.PosSemidef) :
     covMatrix (multivariateGaussian m S) = S := by
-  ext i j
-  exact covariance_eval_multivariateGaussian hS i j
-
-/-- For a finite measure with finite second moment, the entrywise covariance matrix represents
-Mathlib's basis-free covariance bilinear form. -/
-theorem covarianceBilin_eq_covMatrix [Fintype ι] [DecidableEq ι]
-    (μ : Measure (EuclideanSpace ℝ ι)) [IsFiniteMeasure μ] (hμ : MemLp id 2 μ)
-    (x y : EuclideanSpace ℝ ι) :
-    covarianceBilin μ x y = ⟪x, (covMatrix μ).toEuclideanLin y⟫ := by
-  have hcoord : ∀ i, MemLp (fun z : EuclideanSpace ℝ ι => z i) 2 μ := by
-    intro i
-    simpa only [id_eq, EuclideanSpace.coe_proj] using
-      hμ.continuousLinearMap_comp (𝕜 := ℝ) (EuclideanSpace.proj i)
-  have hpi := covarianceBilin_apply_pi (μ := μ) (X := fun i z => z i) hcoord x y
-  have hfun : (fun z : EuclideanSpace ℝ ι => WithLp.toLp 2 (fun i => z i)) = id := by
-    funext z
-    exact WithLp.toLp_ofLp 2 z
-  rw [hfun, Measure.map_id] at hpi
-  rw [hpi]
-  simp only [PiLp.inner_apply, RCLike.inner_apply, conj_trivial, Matrix.toLpLin_apply,
-    Matrix.mulVec, dotProduct]
-  apply Finset.sum_congr rfl
-  intro i _
-  rw [Finset.sum_mul]
-  apply Finset.sum_congr rfl
-  intro j _
-  rw [covMatrix_apply]
-  ring
-
-/-- The covariance matrix of a finite measure with finite second moment is positive semidefinite. -/
-theorem covMatrix_posSemidef [Fintype ι]
-    (μ : Measure (EuclideanSpace ℝ ι)) [IsFiniteMeasure μ] (hμ : MemLp id 2 μ) :
-    (covMatrix μ).PosSemidef := by
   classical
-  rw [← Matrix.isPositive_toEuclideanLin_iff]
-  refine ⟨Matrix.isSymmetric_toEuclideanLin_iff.mpr (covMatrix_isHermitian μ), fun x => ?_⟩
-  have hnonneg := covarianceBilin_self_nonneg (μ := μ) x
-  rw [covarianceBilin_eq_covMatrix μ hμ x x] at hnonneg
-  simpa only [RCLike.re_to_real, real_inner_comm] using hnonneg
+  ext i j
+  simpa only [covMatrix_apply] using covariance_eval_multivariateGaussian hS i j
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
@@ -36,12 +36,11 @@ namespace TauCeti
 
 variable {ι : Type*}
 
-local instance : DecidableEq ι := Classical.decEq ι
 
 /-- The covariance matrix of a positive-semidefinite multivariate Gaussian is its covariance
 parameter. -/
 @[simp]
-theorem covMatrix_multivariateGaussian [Fintype ι] (m : EuclideanSpace ℝ ι)
+theorem covMatrix_multivariateGaussian [Fintype ι] [DecidableEq ι] (m : EuclideanSpace ℝ ι)
     {S : Matrix ι ι ℝ} (hS : S.PosSemidef) :
     covMatrix (multivariateGaussian m S) = S := by
   classical

--- a/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Multivariate.lean
@@ -1,0 +1,114 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.Distributions.Gaussian.Multivariate
+
+/-!
+# Covariance matrices of Euclidean-valued measures
+
+This file packages the coordinate covariances of a measure on a finite-dimensional Euclidean
+space as a matrix. It identifies that matrix with the covariance parameter of Mathlib's
+multivariate Gaussian and connects it to Mathlib's basis-free `covarianceBilin`.
+
+The `MemLp id 2 μ` hypothesis in the comparison theorem is essential. Mathlib deliberately sets
+`covarianceBilin μ` to zero when this hypothesis fails, whereas its scalar `covariance` is
+totalized coordinate by coordinate.
+
+## Main results
+
+* `TauCeti.covMatrix` is the matrix of coordinate covariances of a measure.
+* `TauCeti.covMatrix_multivariateGaussian` recovers the covariance parameter of a multivariate
+  Gaussian law.
+* `TauCeti.covarianceBilin_eq_covMatrix` identifies the matrix and bilinear-form views of
+  covariance when the measure has a finite second moment.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 1,
+  **Covariance matrices**.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+open scoped RealInnerProductSpace
+
+namespace TauCeti
+
+variable {ι : Type*}
+
+/-- The covariance matrix of a measure on a finite-dimensional Euclidean space. Its `(i, j)`
+entry is the scalar covariance of the `i`th and `j`th coordinate projections. -/
+def covMatrix (μ : Measure (EuclideanSpace ℝ ι)) : Matrix ι ι ℝ :=
+  fun i j => cov[fun z => z i, fun z => z j; μ]
+
+/-- An entry of `covMatrix` is the covariance of the corresponding coordinate projections. -/
+@[simp]
+theorem covMatrix_apply (μ : Measure (EuclideanSpace ℝ ι)) (i j : ι) :
+    covMatrix μ i j = cov[fun z => z i, fun z => z j; μ] := (rfl)
+
+/-- Covariance matrices are symmetric. -/
+theorem covMatrix_apply_comm (μ : Measure (EuclideanSpace ℝ ι)) (i j : ι) :
+    covMatrix μ i j = covMatrix μ j i := by
+  rw [covMatrix_apply, covMatrix_apply, covariance_comm]
+
+/-- A covariance matrix is Hermitian (equivalently, symmetric over `ℝ`). -/
+theorem covMatrix_isHermitian (μ : Measure (EuclideanSpace ℝ ι)) :
+    (covMatrix μ).IsHermitian := by
+  rw [Matrix.isHermitian_iff_isSymm, Matrix.IsSymm.ext_iff]
+  exact fun i j => covMatrix_apply_comm μ j i
+
+/-- The covariance matrix of a positive-semidefinite multivariate Gaussian is its covariance
+parameter. -/
+@[simp]
+theorem covMatrix_multivariateGaussian [Fintype ι] [DecidableEq ι] (m : EuclideanSpace ℝ ι)
+    {S : Matrix ι ι ℝ} (hS : S.PosSemidef) :
+    covMatrix (multivariateGaussian m S) = S := by
+  ext i j
+  exact covariance_eval_multivariateGaussian hS i j
+
+/-- For a finite measure with finite second moment, the entrywise covariance matrix represents
+Mathlib's basis-free covariance bilinear form. -/
+theorem covarianceBilin_eq_covMatrix [Fintype ι] [DecidableEq ι]
+    (μ : Measure (EuclideanSpace ℝ ι)) [IsFiniteMeasure μ] (hμ : MemLp id 2 μ)
+    (x y : EuclideanSpace ℝ ι) :
+    covarianceBilin μ x y = ⟪x, (covMatrix μ).toEuclideanLin y⟫ := by
+  have hcoord : ∀ i, MemLp (fun z : EuclideanSpace ℝ ι => z i) 2 μ := by
+    intro i
+    simpa only [id_eq, EuclideanSpace.coe_proj] using
+      hμ.continuousLinearMap_comp (𝕜 := ℝ) (EuclideanSpace.proj i)
+  have hpi := covarianceBilin_apply_pi (μ := μ) (X := fun i z => z i) hcoord x y
+  have hfun : (fun z : EuclideanSpace ℝ ι => WithLp.toLp 2 (fun i => z i)) = id := by
+    funext z
+    exact WithLp.toLp_ofLp 2 z
+  rw [hfun, Measure.map_id] at hpi
+  rw [hpi]
+  simp only [PiLp.inner_apply, RCLike.inner_apply, conj_trivial, Matrix.toLpLin_apply,
+    Matrix.mulVec, dotProduct]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [covMatrix_apply]
+  ring
+
+/-- The covariance matrix of a finite measure with finite second moment is positive semidefinite. -/
+theorem covMatrix_posSemidef [Fintype ι]
+    (μ : Measure (EuclideanSpace ℝ ι)) [IsFiniteMeasure μ] (hμ : MemLp id 2 μ) :
+    (covMatrix μ).PosSemidef := by
+  classical
+  rw [← Matrix.isPositive_toEuclideanLin_iff]
+  refine ⟨Matrix.isSymmetric_toEuclideanLin_iff.mpr (covMatrix_isHermitian μ), fun x => ?_⟩
+  have hnonneg := covarianceBilin_self_nonneg (μ := μ) x
+  rw [covarianceBilin_eq_covMatrix μ hμ x x] at hnonneg
+  simpa only [RCLike.re_to_real, real_inner_comm] using hnonneg
+
+end TauCeti

--- a/TauCeti/Probability/Moments/Covariance.lean
+++ b/TauCeti/Probability/Moments/Covariance.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Probability.Moments.CovarianceBilin
+
+/-!
+# Covariance matrices of Euclidean-valued measures
+
+This file packages the coordinate covariances of a measure on a finite-dimensional Euclidean
+space as a matrix and connects that matrix to Mathlib's basis-free `covarianceBilin`.
+
+The `MemLp id 2 μ` hypothesis in the comparison theorem is essential. Mathlib deliberately sets
+`covarianceBilin μ` to zero when this hypothesis fails, whereas its scalar `covariance` is
+totalized coordinate by coordinate.
+
+## Main results
+
+* `TauCeti.covMatrix` is the matrix of coordinate covariances of a measure.
+* `TauCeti.covarianceBilin_eq_covMatrix` identifies the matrix and bilinear-form views of
+  covariance when the measure has a finite second moment.
+* `TauCeti.posSemidef_covMatrix` proves that covariance matrices are positive semidefinite under
+  the same moment hypotheses.
+
+## References
+
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 1,
+  **Covariance matrices**.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+open scoped RealInnerProductSpace
+
+namespace TauCeti
+
+variable {ι : Type*}
+
+local instance : DecidableEq ι := Classical.decEq ι
+
+/-- The covariance matrix of a measure on a finite-dimensional Euclidean space. Its `(i, j)`
+entry is the scalar covariance of the `i`th and `j`th coordinate projections. -/
+def covMatrix (μ : Measure (EuclideanSpace ℝ ι)) : Matrix ι ι ℝ :=
+  fun i j => cov[fun z => z i, fun z => z j; μ]
+
+/-- An entry of `covMatrix` is the covariance of the corresponding coordinate projections. -/
+@[simp]
+theorem covMatrix_apply (μ : Measure (EuclideanSpace ℝ ι)) (i j : ι) :
+    covMatrix μ i j = cov[fun z => z i, fun z => z j; μ] := (rfl)
+
+/-- Covariance matrices are symmetric. -/
+theorem covMatrix_apply_comm (μ : Measure (EuclideanSpace ℝ ι)) (i j : ι) :
+    covMatrix μ i j = covMatrix μ j i := by
+  rw [covMatrix_apply, covMatrix_apply, covariance_comm]
+
+/-- A covariance matrix is Hermitian (equivalently, symmetric over `ℝ`). -/
+theorem isHermitian_covMatrix (μ : Measure (EuclideanSpace ℝ ι)) :
+    (covMatrix μ).IsHermitian := by
+  rw [Matrix.isHermitian_iff_isSymm, Matrix.IsSymm.ext_iff]
+  exact fun i j => covMatrix_apply_comm μ j i
+
+/-- For a finite measure with finite second moment, the entrywise covariance matrix represents
+Mathlib's basis-free covariance bilinear form. -/
+theorem covarianceBilin_eq_covMatrix [Fintype ι]
+    (μ : Measure (EuclideanSpace ℝ ι)) [IsFiniteMeasure μ] (hμ : MemLp id 2 μ)
+    (x y : EuclideanSpace ℝ ι) :
+    covarianceBilin μ x y = ⟪x, (covMatrix μ).toEuclideanLin y⟫ := by
+  classical
+  have hcoord : ∀ i, MemLp (fun z : EuclideanSpace ℝ ι => z i) 2 μ := by
+    intro i
+    simpa only [id_eq, EuclideanSpace.coe_proj] using
+      hμ.continuousLinearMap_comp (𝕜 := ℝ) (EuclideanSpace.proj i)
+  have hpi := covarianceBilin_apply_pi (μ := μ) (X := fun i z => z i) hcoord x y
+  have hfun : (fun z : EuclideanSpace ℝ ι => WithLp.toLp 2 (fun i => z i)) = id := by
+    funext z
+    exact WithLp.toLp_ofLp 2 z
+  rw [hfun, Measure.map_id] at hpi
+  rw [hpi]
+  simp only [PiLp.inner_apply, RCLike.inner_apply, conj_trivial, Matrix.toLpLin_apply,
+    Matrix.mulVec, dotProduct]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [covMatrix_apply]
+  ring
+
+/-- The covariance matrix of a finite measure with finite second moment is positive semidefinite. -/
+theorem posSemidef_covMatrix [Fintype ι]
+    (μ : Measure (EuclideanSpace ℝ ι)) [IsFiniteMeasure μ] (hμ : MemLp id 2 μ) :
+    (covMatrix μ).PosSemidef := by
+  classical
+  rw [← Matrix.isPositive_toEuclideanLin_iff]
+  refine ⟨Matrix.isSymmetric_toEuclideanLin_iff.mpr (isHermitian_covMatrix μ), fun x => ?_⟩
+  have hnonneg := covarianceBilin_self_nonneg (μ := μ) x
+  rw [covarianceBilin_eq_covMatrix μ hμ x x] at hnonneg
+  simpa only [RCLike.re_to_real, real_inner_comm] using hnonneg
+
+end TauCeti

--- a/TauCeti/Probability/Moments/Covariance.lean
+++ b/TauCeti/Probability/Moments/Covariance.lean
@@ -43,7 +43,6 @@ namespace TauCeti
 
 variable {ι : Type*}
 
-local instance : DecidableEq ι := Classical.decEq ι
 
 /-- The covariance matrix of a measure on a finite-dimensional Euclidean space. Its `(i, j)`
 entry is the scalar covariance of the `i`th and `j`th coordinate projections. -/
@@ -68,7 +67,7 @@ theorem isHermitian_covMatrix (μ : Measure (EuclideanSpace ℝ ι)) :
 
 /-- For a finite measure with finite second moment, the entrywise covariance matrix represents
 Mathlib's basis-free covariance bilinear form. -/
-theorem covarianceBilin_eq_covMatrix [Fintype ι]
+theorem covarianceBilin_eq_covMatrix [Fintype ι] [DecidableEq ι]
     (μ : Measure (EuclideanSpace ℝ ι)) [IsFiniteMeasure μ] (hμ : MemLp id 2 μ)
     (x y : EuclideanSpace ℝ ι) :
     covarianceBilin μ x y = ⟪x, (covMatrix μ).toEuclideanLin y⟫ := by


### PR DESCRIPTION
This PR defines `TauCeti.covMatrix`, the matrix of coordinate covariances of a measure on `EuclideanSpace ℝ ι`, and completes the missing matrix packaging in Layer 5, item 1, **“Covariance matrices”**, of `TauCetiRoadmap/StandardDistributions/README.md`. It proves the characteristic entry formula and symmetry, bundles symmetry as `Matrix.IsHermitian`, proves positive semidefiniteness under the roadmap’s essential `[IsFiniteMeasure μ]` and `MemLp id 2 μ` hypotheses, identifies Mathlib’s basis-free form by `covarianceBilin μ x y = ⟪x, (covMatrix μ).toEuclideanLin y⟫`, and recovers the covariance parameter of every positive-semidefinite `multivariateGaussian m S`.

The bilinear-form comparison reuses Mathlib’s `ProbabilityTheory.covarianceBilin_apply_pi`: finite-dimensional coordinate projections inherit the global `MemLp` hypothesis through `MemLp.continuousLinearMap_comp`, the Euclidean reconstruction map is the identity, and the remaining equality is the matrix-vector expansion. The Gaussian specialization is exactly Mathlib’s `ProbabilityTheory.covariance_eval_multivariateGaussian` entrywise. The other two clauses of the same roadmap item—integrability of `id` and the Bochner mean—are already supplied canonically at this pin by `ProbabilityTheory.IsGaussian.integrable_id` and `ProbabilityTheory.integral_id_multivariateGaussian`, so no local aliases duplicate them. No Mathlib source or external formalization is vendored.

The designated milestone is Layer 5, **multivariate distributions**, item 1, “Covariance matrices”; after this PR, Layer 5 still needs the multivariate-Gaussian density, affine and quadratic-form laws, conditional laws, multinomial and Dirichlet families, and shared parameter measurability, while item 1 itself is complete.

This is the most effective current step because Layer 2 is complete or in its final open beta-cdf PR, Layer 3’s chi-squared family is already in flight, and `covMatrix` is the common representation required later by both the multinomial and Dirichlet covariance targets without depending on unfinished scalar families.

Add `TauCeti/Probability/Distributions/Gaussian/Multivariate.lean` (114 lines).

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"covmatrix"}-->

🤖 Prepared with Codex
