### PR TITLE
feat: make component groups finite etale

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
@@ -11,16 +11,22 @@ public import TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup.Representa
 # The component group is finite etale
 
 Let `H` be the coordinate Hopf algebra of a finite-type affine group over an algebraically
-closed field. The fppf quotient by the identity component is represented by the constant group
-scheme on the finite group of connected components of `Spec H`. This group scheme is finite and
-etale by the corresponding instances for constant finite group schemes.
+closed field. The existing group-object representation of the fppf quotient by the identity
+component uses the constant group scheme on the finite group of connected components of `Spec H`.
+Here that scheme is named and its affineness, finiteness, and etaleness are recorded explicitly.
+The underlying sheaf of the quotient is also compared with the sheafification of the scheme's
+Yoneda functor of points on affine schemes.
 
 ## Main declarations
 
 * `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupScheme`: the constant group scheme on the
   connected components of `Spec H`.
-* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupFppfSheafIsoComponentGroupSchemePoints`: the
-  component quotient is isomorphic to the sheafified functor of points of that scheme.
+* `TauCeti.FiniteTypeCommHopfAlgCat.isFinite_componentGroupScheme`: the component group scheme
+  is finite.
+* `TauCeti.FiniteTypeCommHopfAlgCat.etale_componentGroupScheme`: the component group scheme is
+  etale.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupFppfSheafIsoSheafifiedSchemePoints`: the
+  underlying component quotient sheaf is isomorphic to the sheafified functor of points.
 
 ## References
 
@@ -31,7 +37,7 @@ This completes the algebraically closed-field case of the finite etale component
 Layer 3, "Identity component `G°` and component group `π₀(G)`", of the ReductiveGroups roadmap.
 -/
 
-public section
+@[expose] public section
 
 open CategoryTheory Opposite
 
@@ -45,46 +51,65 @@ variable {k : Type u} [Field k] [IsAlgClosed k]
 
 /-- The constant group scheme on the connected components of the spectrum of a finite-type
 commutative Hopf algebra over an algebraically closed field. -/
-noncomputable abbrev componentGroupScheme
+noncomputable def componentGroupScheme
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     Grp (Over (Spec (CommRingCat.of k))) :=
   ConstantGroup.groupScheme k (ConnectedComponents (PrimeSpectrum H))
 
-/-- The fppf component quotient is represented by `componentGroupScheme H`: its underlying sheaf
-is isomorphic to the sheafification of the scheme's Yoneda functor of points on affine schemes. -/
-noncomputable def componentGroupFppfSheafIsoComponentGroupSchemePoints
+/-- The component group scheme is the constant group scheme on the connected components. -/
+theorem componentGroupScheme_def (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupScheme H =
+      ConstantGroup.groupScheme k (ConnectedComponents (PrimeSpectrum H)) := by
+  rfl
+
+/-- The component group scheme is affine. -/
+instance isAffine_componentGroupScheme (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    IsAffine (componentGroupScheme H).X.left := by
+  rw [componentGroupScheme_def]
+  infer_instance
+
+/-- The structural morphism of the component group scheme is finite. -/
+instance isFinite_componentGroupScheme (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    IsFinite (componentGroupScheme H).X.hom := by
+  rw [componentGroupScheme_def]
+  infer_instance
+
+/-- The structural morphism of the component group scheme is etale. -/
+instance etale_componentGroupScheme (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Etale (componentGroupScheme H).X.hom := by
+  rw [componentGroupScheme_def]
+  infer_instance
+
+/-- The sheafification of the universe-lifted Yoneda functor of points of the component group
+scheme on the affine fppf site. -/
+noncomputable def componentGroupSchemePointsFppfSheaf
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    (componentGroupFppfSheaf H).X ≅
-      (presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))).obj
-        (((AlgebraicGeometry.algSpec (CommRingCat.of k)).op ⋙
-          yoneda.obj (componentGroupScheme H).X) ⋙
-            CategoryTheory.uliftFunctor.{u + 1, u}) := by
+    Sheaf (CommAlgCat.fppfTopology k) (Type (u + 1)) :=
+  (presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))).obj
+    (((AlgebraicGeometry.algSpec (CommRingCat.of k)).op ⋙
+      yoneda.obj (componentGroupScheme H).X) ⋙
+        CategoryTheory.uliftFunctor.{u + 1, u})
+
+/-- The underlying fppf component quotient sheaf is isomorphic to the sheafification of the
+component group scheme's universe-lifted Yoneda functor of points on affine schemes. -/
+noncomputable def componentGroupFppfSheafIsoSheafifiedSchemePoints
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    (componentGroupFppfSheaf H).X ≅ componentGroupSchemePointsFppfSheaf H := by
   let K := CommHopfAlgCat.of k
     (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))
   let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
-  let e₀ : (CommHopfAlgCat.pointsPresheafGrp K).X ≅
-      HopfAlgebra.pointsPresheaf K ⋙ CategoryTheory.uliftFunctor.{u + 1, u} :=
-    eqToIso (CommHopfAlgCat.pointsPresheafGrp_X_eq K) ≪≫
-      eqToIso (CommHopfAlgCat.pointsGroupPresheaf_ulift_forget K)
-  let e₁ : HopfAlgebra.pointsPresheaf K ⋙ CategoryTheory.uliftFunctor.{u + 1, u} ≅
-      CommHopfAlgCat.schemePointsPresheaf K ⋙
-        CategoryTheory.uliftFunctor.{u + 1, u} :=
-    Functor.isoWhiskerRight
-      (CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf K)
-      CategoryTheory.uliftFunctor.{u + 1, u}
   have hScheme : CommHopfAlgCat.schemePointsPresheaf K =
       (AlgebraicGeometry.algSpec (CommRingCat.of k)).op ⋙
         yoneda.obj (componentGroupScheme H).X := by
-    dsimp only [componentGroupScheme]
-    rw [ConstantGroup.groupScheme_def]
-  let e₂ : CommHopfAlgCat.schemePointsPresheaf K ⋙
-        CategoryTheory.uliftFunctor.{u + 1, u} ≅
-      (((AlgebraicGeometry.algSpec (CommRingCat.of k)).op ⋙
-        yoneda.obj (componentGroupScheme H).X) ⋙
-          CategoryTheory.uliftFunctor.{u + 1, u}) :=
+    rw [componentGroupScheme_def, ConstantGroup.groupScheme_def]
+  let e : CommHopfAlgCat.schemePointsPresheaf K ⋙
+      CategoryTheory.uliftFunctor.{u + 1, u} ≅
+        ((AlgebraicGeometry.algSpec (CommRingCat.of k)).op ⋙
+          yoneda.obj (componentGroupScheme H).X) ⋙
+            CategoryTheory.uliftFunctor.{u + 1, u} :=
     Functor.isoWhiskerRight (eqToIso hScheme) CategoryTheory.uliftFunctor.{u + 1, u}
-  exact (Grp.forget _).mapIso (componentGroupFppfGroupObjectIso H) ≪≫
-    eqToIso (CommHopfAlgCat.pointsFppfGroupObject_X_eq K) ≪≫
-      F.mapIso (e₀ ≪≫ e₁ ≪≫ e₂)
+  exact componentGroupFppfSheafIso H ≪≫
+    CommHopfAlgCat.pointsFppfGroupObjectXIsoSchemePointsFppfSheaf K ≪≫
+      F.mapIso e
 
 end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup.Representable
+
+/-!
+# The component group is finite etale
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over an algebraically
+closed field. The fppf quotient by the identity component is represented by the constant group
+scheme on the finite group of connected components of `Spec H`. This file names that canonical
+representing group scheme and records that its structural morphism is finite and etale.
+
+No smoothness hypothesis on `H` is needed over an algebraically closed field. The representer is
+constant, and constant finite group schemes are finite etale over any commutative base ring. The
+existing isomorphism `componentGroupFppfGroupObjectIso` identifies its fppf points with the
+component quotient, compatibly with the quotient projection.
+
+## Main declarations
+
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupScheme`: the canonical group scheme
+  representing the component quotient.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupRepresentation`: the representation
+  isomorphism from the fppf component quotient to the named coordinate model.
+* `TauCeti.FiniteTypeCommHopfAlgCat.isFinite_componentGroupScheme`: its structural morphism is
+  finite.
+* `TauCeti.FiniteTypeCommHopfAlgCat.etale_componentGroupScheme`: its structural morphism is
+  etale.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 2.37 and Section 5.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Sections 6.7 and 14.
+
+This completes the algebraically closed-field case of the finite etale component-group target in
+Layer 3, "Identity component `G°` and component group `π₀(G)`", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory Opposite
+
+namespace TauCeti.FiniteTypeCommHopfAlgCat
+
+open AlgebraicGeometry
+
+universe u
+
+variable {k : Type u} [Field k] [IsAlgClosed k]
+
+/-- The coordinate Hopf algebra of the component group of a finite-type affine group over an
+algebraically closed field.
+
+It is the function Hopf algebra on the finite group of connected components of the prime
+spectrum. -/
+noncomputable def componentGroupCoordinateHopfAlgebra
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) : CommHopfAlgCat.{u} k :=
+  CommHopfAlgCat.of k
+    (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))
+
+/-- The component-group coordinate Hopf algebra is the function Hopf algebra on the connected
+components. -/
+theorem componentGroupCoordinateHopfAlgebra_def
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupCoordinateHopfAlgebra H =
+      CommHopfAlgCat.of k
+        (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) := by
+  rfl
+
+/-- The finite constant group scheme representing the component quotient of a finite-type
+affine group over an algebraically closed field. -/
+noncomputable def componentGroupScheme
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Grp (Over (Spec (CommRingCat.of k))) :=
+  ConstantGroup.groupScheme k (ConnectedComponents (PrimeSpectrum H))
+
+/-- The component group scheme is relative spectrum applied to its coordinate Hopf algebra. -/
+theorem componentGroupScheme_def (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupScheme H =
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).obj
+        (op (componentGroupCoordinateHopfAlgebra H)) := by
+  simpa only [componentGroupScheme, componentGroupCoordinateHopfAlgebra] using
+    ConstantGroup.groupScheme_def k (ConnectedComponents (PrimeSpectrum H))
+
+/-- The scheme underlying the component group is the spectrum of the function algebra on the
+connected components. -/
+@[simp]
+theorem componentGroupScheme_X_left (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    (componentGroupScheme H).X.left =
+      Spec (CommRingCat.of
+        (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))) := by
+  exact ConstantGroup.groupScheme_X_left k (ConnectedComponents (PrimeSpectrum H))
+
+/-- The structural morphism of the component group is induced by the scalar inclusion into its
+function algebra. -/
+@[simp]
+theorem componentGroupScheme_X_hom (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    (componentGroupScheme H).X.hom =
+      eqToHom (componentGroupScheme_X_left H) ≫
+        Spec.map (CommRingCat.ofHom
+          (algebraMap k
+            (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))))) := by
+  exact ConstantGroup.groupScheme_X_hom k (ConnectedComponents (PrimeSpectrum H))
+
+/-- The fppf component quotient is represented by the group scheme with the named component-group
+coordinate Hopf algebra. -/
+noncomputable def componentGroupRepresentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupFppfSheaf H ≅
+      CommHopfAlgCat.pointsFppfGroupObject (componentGroupCoordinateHopfAlgebra H) :=
+  componentGroupFppfGroupObjectIso H ≪≫
+    eqToIso (congrArg CommHopfAlgCat.pointsFppfGroupObject
+      (componentGroupCoordinateHopfAlgebra_def H).symm)
+
+/-- Under the named representation, the component quotient projection is the sheafified
+component-coordinate morphism, followed only by the equality identifying the named coordinate
+algebra. -/
+theorem componentGroupFppfProjection_comp_componentGroupRepresentation_hom
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    componentGroupFppfProjection H ≫ (componentGroupRepresentation H).hom =
+      componentCoordinateFppfGroupObjectHom H ≫
+        eqToHom (congrArg CommHopfAlgCat.pointsFppfGroupObject
+          (componentGroupCoordinateHopfAlgebra_def H).symm) := by
+  rw [componentGroupRepresentation, Iso.trans_hom, ← Category.assoc,
+    componentGroupFppfProjection_comp_componentGroupFppfGroupObjectIso_hom]
+  rfl
+
+/-- The component group scheme is affine. -/
+instance isAffine_componentGroupScheme (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    IsAffine (componentGroupScheme H).X.left := by
+  unfold componentGroupScheme
+  infer_instance
+
+/-- The structural morphism of the component group scheme is finite. -/
+instance isFinite_componentGroupScheme (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    IsFinite (componentGroupScheme H).X.hom := by
+  unfold componentGroupScheme
+  infer_instance
+
+/-- The structural morphism of the component group scheme is etale. -/
+instance etale_componentGroupScheme (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Etale (componentGroupScheme H).X.hom := by
+  unfold componentGroupScheme
+  infer_instance
+
+end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
@@ -62,14 +62,10 @@ noncomputable def componentGroupFppfSheafIsoComponentGroupSchemePoints
   let K := CommHopfAlgCat.of k
     (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))
   let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
-  have hPoints :
-      HopfAlgebra.pointsGroupPresheaf K ⋙ GrpCat.uliftFunctor.{u + 1, u} ⋙
-          forget GrpCat.{u + 1} =
-        HopfAlgebra.pointsPresheaf K ⋙ CategoryTheory.uliftFunctor.{u + 1, u} := by
-    rfl
   let e₀ : (CommHopfAlgCat.pointsPresheafGrp K).X ≅
       HopfAlgebra.pointsPresheaf K ⋙ CategoryTheory.uliftFunctor.{u + 1, u} :=
-    eqToIso (CommHopfAlgCat.pointsPresheafGrp_X_eq K) ≪≫ eqToIso hPoints
+    eqToIso (CommHopfAlgCat.pointsPresheafGrp_X_eq K) ≪≫
+      eqToIso (CommHopfAlgCat.pointsGroupPresheaf_ulift_forget K)
   let e₁ : HopfAlgebra.pointsPresheaf K ⋙ CategoryTheory.uliftFunctor.{u + 1, u} ≅
       CommHopfAlgCat.schemePointsPresheaf K ⋙
         CategoryTheory.uliftFunctor.{u + 1, u} :=

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
@@ -12,24 +12,15 @@ public import TauCeti.Algebra.AlgebraicGroup.Connected.ComponentGroup.Representa
 
 Let `H` be the coordinate Hopf algebra of a finite-type affine group over an algebraically
 closed field. The fppf quotient by the identity component is represented by the constant group
-scheme on the finite group of connected components of `Spec H`. This file names that canonical
-representing group scheme and records that its structural morphism is finite and etale.
-
-No smoothness hypothesis on `H` is needed over an algebraically closed field. The representer is
-constant, and constant finite group schemes are finite etale over any commutative base ring. The
-existing isomorphism `componentGroupFppfGroupObjectIso` identifies its fppf points with the
-component quotient, compatibly with the quotient projection.
+scheme on the finite group of connected components of `Spec H`. This group scheme is finite and
+etale by the corresponding instances for constant finite group schemes.
 
 ## Main declarations
 
-* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupScheme`: the canonical group scheme
-  representing the component quotient.
-* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupRepresentation`: the representation
-  isomorphism from the fppf component quotient to the named coordinate model.
-* `TauCeti.FiniteTypeCommHopfAlgCat.isFinite_componentGroupScheme`: its structural morphism is
-  finite.
-* `TauCeti.FiniteTypeCommHopfAlgCat.etale_componentGroupScheme`: its structural morphism is
-  etale.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupScheme`: the constant group scheme on the
+  connected components of `Spec H`.
+* `TauCeti.FiniteTypeCommHopfAlgCat.componentGroupFppfSheafIsoComponentGroupSchemePoints`: the
+  component quotient is isomorphic to the sheafified functor of points of that scheme.
 
 ## References
 
@@ -52,99 +43,52 @@ universe u
 
 variable {k : Type u} [Field k] [IsAlgClosed k]
 
-/-- The coordinate Hopf algebra of the component group of a finite-type affine group over an
-algebraically closed field.
-
-It is the function Hopf algebra on the finite group of connected components of the prime
-spectrum. -/
-noncomputable def componentGroupCoordinateHopfAlgebra
-    (H : FiniteTypeCommHopfAlgCat.{u, u} k) : CommHopfAlgCat.{u} k :=
-  CommHopfAlgCat.of k
-    (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))
-
-/-- The component-group coordinate Hopf algebra is the function Hopf algebra on the connected
-components. -/
-theorem componentGroupCoordinateHopfAlgebra_def
-    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    componentGroupCoordinateHopfAlgebra H =
-      CommHopfAlgCat.of k
-        (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))) := by
-  rfl
-
-/-- The finite constant group scheme representing the component quotient of a finite-type
-affine group over an algebraically closed field. -/
-noncomputable def componentGroupScheme
+/-- The constant group scheme on the connected components of the spectrum of a finite-type
+commutative Hopf algebra over an algebraically closed field. -/
+noncomputable abbrev componentGroupScheme
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
     Grp (Over (Spec (CommRingCat.of k))) :=
   ConstantGroup.groupScheme k (ConnectedComponents (PrimeSpectrum H))
 
-/-- The component group scheme is relative spectrum applied to its coordinate Hopf algebra. -/
-theorem componentGroupScheme_def (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    componentGroupScheme H =
-      (AlgebraicGeometry.hopfSpec (CommRingCat.of k)).obj
-        (op (componentGroupCoordinateHopfAlgebra H)) := by
-  simpa only [componentGroupScheme, componentGroupCoordinateHopfAlgebra] using
-    ConstantGroup.groupScheme_def k (ConnectedComponents (PrimeSpectrum H))
-
-/-- The scheme underlying the component group is the spectrum of the function algebra on the
-connected components. -/
-@[simp]
-theorem componentGroupScheme_X_left (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    (componentGroupScheme H).X.left =
-      Spec (CommRingCat.of
-        (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))) := by
-  exact ConstantGroup.groupScheme_X_left k (ConnectedComponents (PrimeSpectrum H))
-
-/-- The structural morphism of the component group is induced by the scalar inclusion into its
-function algebra. -/
-@[simp]
-theorem componentGroupScheme_X_hom (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    (componentGroupScheme H).X.hom =
-      eqToHom (componentGroupScheme_X_left H) ≫
-        Spec.map (CommRingCat.ofHom
-          (algebraMap k
-            (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H))))) := by
-  exact ConstantGroup.groupScheme_X_hom k (ConnectedComponents (PrimeSpectrum H))
-
-/-- The fppf component quotient is represented by the group scheme with the named component-group
-coordinate Hopf algebra. -/
-noncomputable def componentGroupRepresentation
+/-- The fppf component quotient is represented by `componentGroupScheme H`: its underlying sheaf
+is isomorphic to the sheafification of the scheme's Yoneda functor of points on affine schemes. -/
+noncomputable def componentGroupFppfSheafIsoComponentGroupSchemePoints
     (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    componentGroupFppfSheaf H ≅
-      CommHopfAlgCat.pointsFppfGroupObject (componentGroupCoordinateHopfAlgebra H) :=
-  componentGroupFppfGroupObjectIso H ≪≫
-    eqToIso (congrArg CommHopfAlgCat.pointsFppfGroupObject
-      (componentGroupCoordinateHopfAlgebra_def H).symm)
-
-/-- Under the named representation, the component quotient projection is the sheafified
-component-coordinate morphism, followed only by the equality identifying the named coordinate
-algebra. -/
-theorem componentGroupFppfProjection_comp_componentGroupRepresentation_hom
-    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    componentGroupFppfProjection H ≫ (componentGroupRepresentation H).hom =
-      componentCoordinateFppfGroupObjectHom H ≫
-        eqToHom (congrArg CommHopfAlgCat.pointsFppfGroupObject
-          (componentGroupCoordinateHopfAlgebra_def H).symm) := by
-  rw [componentGroupRepresentation, Iso.trans_hom, ← Category.assoc,
-    componentGroupFppfProjection_comp_componentGroupFppfGroupObjectIso_hom]
-  rfl
-
-/-- The component group scheme is affine. -/
-instance isAffine_componentGroupScheme (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    IsAffine (componentGroupScheme H).X.left := by
-  unfold componentGroupScheme
-  infer_instance
-
-/-- The structural morphism of the component group scheme is finite. -/
-instance isFinite_componentGroupScheme (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    IsFinite (componentGroupScheme H).X.hom := by
-  unfold componentGroupScheme
-  infer_instance
-
-/-- The structural morphism of the component group scheme is etale. -/
-instance etale_componentGroupScheme (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    Etale (componentGroupScheme H).X.hom := by
-  unfold componentGroupScheme
-  infer_instance
+    (componentGroupFppfSheaf H).X ≅
+      (presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))).obj
+        (((AlgebraicGeometry.algSpec (CommRingCat.of k)).op ⋙
+          yoneda.obj (componentGroupScheme H).X) ⋙
+            CategoryTheory.uliftFunctor.{u + 1, u}) := by
+  let K := CommHopfAlgCat.of k
+    (ConstantGroup.coordinateRing k (ConnectedComponents (PrimeSpectrum H)))
+  let F := presheafToSheaf (CommAlgCat.fppfTopology k) (Type (u + 1))
+  have hPoints :
+      HopfAlgebra.pointsGroupPresheaf K ⋙ GrpCat.uliftFunctor.{u + 1, u} ⋙
+          forget GrpCat.{u + 1} =
+        HopfAlgebra.pointsPresheaf K ⋙ CategoryTheory.uliftFunctor.{u + 1, u} := by
+    rfl
+  let e₀ : (CommHopfAlgCat.pointsPresheafGrp K).X ≅
+      HopfAlgebra.pointsPresheaf K ⋙ CategoryTheory.uliftFunctor.{u + 1, u} :=
+    eqToIso (CommHopfAlgCat.pointsPresheafGrp_X_eq K) ≪≫ eqToIso hPoints
+  let e₁ : HopfAlgebra.pointsPresheaf K ⋙ CategoryTheory.uliftFunctor.{u + 1, u} ≅
+      CommHopfAlgCat.schemePointsPresheaf K ⋙
+        CategoryTheory.uliftFunctor.{u + 1, u} :=
+    Functor.isoWhiskerRight
+      (CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf K)
+      CategoryTheory.uliftFunctor.{u + 1, u}
+  have hScheme : CommHopfAlgCat.schemePointsPresheaf K =
+      (AlgebraicGeometry.algSpec (CommRingCat.of k)).op ⋙
+        yoneda.obj (componentGroupScheme H).X := by
+    dsimp only [componentGroupScheme]
+    rw [ConstantGroup.groupScheme_def]
+  let e₂ : CommHopfAlgCat.schemePointsPresheaf K ⋙
+        CategoryTheory.uliftFunctor.{u + 1, u} ≅
+      (((AlgebraicGeometry.algSpec (CommRingCat.of k)).op ⋙
+        yoneda.obj (componentGroupScheme H).X) ⋙
+          CategoryTheory.uliftFunctor.{u + 1, u}) :=
+    Functor.isoWhiskerRight (eqToIso hScheme) CategoryTheory.uliftFunctor.{u + 1, u}
+  exact (Grp.forget _).mapIso (componentGroupFppfGroupObjectIso H) ≪≫
+    eqToIso (CommHopfAlgCat.pointsFppfGroupObject_X_eq K) ≪≫
+      F.mapIso (e₀ ≪≫ e₁ ≪≫ e₂)
 
 end TauCeti.FiniteTypeCommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/FiniteEtale.lean
@@ -37,7 +37,7 @@ This completes the algebraically closed-field case of the finite etale component
 Layer 3, "Identity component `G°` and component group `π₀(G)`", of the ReductiveGroups roadmap.
 -/
 
-@[expose] public section
+public section
 
 open CategoryTheory Opposite
 

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
@@ -115,6 +115,14 @@ theorem groupFunctorGrpIso_hom {C : Type u} [Category.{v} C]
     (groupFunctorGrpIso e).hom = groupFunctorGrpMap e.hom := by
   rw [groupFunctorGrpIso.eq_1]
 
+/-- Forgetting the universe lift of the group-valued points presheaf agrees with universe-lifting
+its underlying type-valued points presheaf. -/
+theorem pointsGroupPresheaf_ulift_forget (H : _root_.CommHopfAlgCat.{u} R) :
+    HopfAlgebra.pointsGroupPresheaf H ⋙ GrpCat.uliftFunctor.{u + 1, u} ⋙
+        forget GrpCat.{u + 1} =
+      HopfAlgebra.pointsPresheaf H ⋙ CategoryTheory.uliftFunctor.{u + 1, u} := by
+  rfl
+
 /-- The convolution-points presheaf as a group object in type-valued presheaves, with values
 lifted to the universe in which the affine-site sheafification lives. -/
 noncomputable def pointsPresheafGrp (H : _root_.CommHopfAlgCat.{u} R) :

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/GroupObject.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.CategoryTheory.Monoidal.Internal.Types.Grp
 public import Mathlib.CategoryTheory.Sites.LeftExact
 public import Mathlib.Algebra.Category.Grp.Ulift
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SchemePoints
 public import TauCeti.Algebra.AlgebraicGroup.Fppf.Basic
 
 /-!
@@ -26,9 +27,19 @@ the ReductiveGroups roadmap.
 open CategoryTheory Opposite
 open scoped CategoryTheory.MonObj
 
-namespace TauCeti.CommHopfAlgCat
-
 universe u v
+
+namespace GrpCat
+
+/-- Forgetting a universe-lifted group agrees with universe-lifting its underlying type. -/
+theorem uliftFunctor_comp_forget_eq_forget_comp_uliftFunctor :
+    uliftFunctor.{u + 1, u} ⋙ forget GrpCat.{u + 1} =
+      forget GrpCat.{u} ⋙ CategoryTheory.uliftFunctor.{u + 1, u} := by
+  rfl
+
+end GrpCat
+
+namespace TauCeti.CommHopfAlgCat
 
 variable {R : Type u} [CommRing R]
 
@@ -117,10 +128,12 @@ theorem groupFunctorGrpIso_hom {C : Type u} [Category.{v} C]
 
 /-- Forgetting the universe lift of the group-valued points presheaf agrees with universe-lifting
 its underlying type-valued points presheaf. -/
-theorem pointsGroupPresheaf_ulift_forget (H : _root_.CommHopfAlgCat.{u} R) :
+theorem pointsGroupPresheaf_ulift_forget_eq_pointsPresheaf_ulift
+    (H : _root_.CommHopfAlgCat.{u} R) :
     HopfAlgebra.pointsGroupPresheaf H ⋙ GrpCat.uliftFunctor.{u + 1, u} ⋙
         forget GrpCat.{u + 1} =
       HopfAlgebra.pointsPresheaf H ⋙ CategoryTheory.uliftFunctor.{u + 1, u} := by
+  rw [GrpCat.uliftFunctor_comp_forget_eq_forget_comp_uliftFunctor]
   rfl
 
 /-- The convolution-points presheaf as a group object in type-valued presheaves, with values
@@ -129,6 +142,26 @@ noncomputable def pointsPresheafGrp (H : _root_.CommHopfAlgCat.{u} R) :
     Grp (((CommAlgCat.{u} R)ᵒᵖ)ᵒᵖ ⥤ Type (u + 1)) :=
   groupFunctorGrp
     (HopfAlgebra.pointsGroupPresheaf H ⋙ GrpCat.uliftFunctor.{u + 1, u})
+
+/-- The carrier of the points presheaf group object is the universe lift of the underlying
+group-valued points presheaf. -/
+theorem pointsPresheafGrp_X_eq (H : _root_.CommHopfAlgCat.{u} R) :
+    (pointsPresheafGrp H).X =
+      HopfAlgebra.pointsGroupPresheaf H ⋙ GrpCat.uliftFunctor.{u + 1, u} ⋙
+        forget GrpCat.{u + 1} := by
+  rfl
+
+/-- The carrier of the group-valued points presheaf is naturally isomorphic to the universe lift
+of the scheme-valued points presheaf. -/
+noncomputable def pointsPresheafGrpXIsoSchemePointsPresheaf
+    (H : _root_.CommHopfAlgCat.{u} R) :
+    (pointsPresheafGrp H).X ≅
+      schemePointsPresheaf H ⋙ CategoryTheory.uliftFunctor.{u + 1, u} :=
+  eqToIso (pointsPresheafGrp_X_eq H) ≪≫
+    eqToIso (pointsGroupPresheaf_ulift_forget_eq_pointsPresheaf_ulift H) ≪≫
+      Functor.isoWhiskerRight
+        (pointsPresheafIsoSchemePointsPresheaf H)
+        CategoryTheory.uliftFunctor.{u + 1, u}
 
 /-- The fppf sheaf of points, regarded as a group object in type-valued sheaves.
 
@@ -141,6 +174,30 @@ noncomputable def pointsFppfGroupObject (H : _root_.CommHopfAlgCat.{u} R) :
     Functor.Monoidal.ofChosenFiniteProducts _
   exact (presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))).mapGrp.obj
     (pointsPresheafGrp H)
+
+/-- The carrier of the fppf points group object is the sheafification of the carrier of its
+presheaf group object. -/
+theorem pointsFppfGroupObject_X_eq
+    (H : _root_.CommHopfAlgCat.{u} R) :
+    (pointsFppfGroupObject H).X =
+      (presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))).obj
+        (pointsPresheafGrp H).X := by
+  rfl
+
+/-- The fppf sheafification of the universe-lifted scheme-valued points presheaf. -/
+noncomputable def schemePointsFppfSheaf (H : _root_.CommHopfAlgCat.{u} R) :
+    Sheaf (CommAlgCat.fppfTopology R) (Type (u + 1)) :=
+  (presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))).obj
+    (schemePointsPresheaf H ⋙ CategoryTheory.uliftFunctor.{u + 1, u})
+
+/-- The carrier of the fppf points group object is naturally isomorphic to the sheafification of
+the universe-lifted scheme-valued points presheaf. -/
+noncomputable def pointsFppfGroupObjectXIsoSchemePointsFppfSheaf
+    (H : _root_.CommHopfAlgCat.{u} R) :
+    (pointsFppfGroupObject H).X ≅ schemePointsFppfSheaf H :=
+  eqToIso (pointsFppfGroupObject_X_eq H) ≪≫
+    (presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))).mapIso
+      (pointsPresheafGrpXIsoSchemePointsPresheaf H)
 
 /-- The underlying sheaf of `pointsFppfGroupObject` is canonically the universe lift of the
 existing group-valued points sheaf `HopfAlgebra.pointsFppfSheaf`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.lean
@@ -93,14 +93,6 @@ noncomputable def pointwiseQuotientPresheafGrpProjection
   groupFunctorGrpMap <| Functor.whiskerRight
     (pointwiseQuotientPresheafProjection H I hI) GrpCat.uliftFunctor.{u + 1, u}
 
-/-- The carrier of the points presheaf group object is the universe lift of the underlying
-group-valued points presheaf. -/
-theorem pointsPresheafGrp_X_eq (H : _root_.CommHopfAlgCat.{u} R) :
-    (pointsPresheafGrp H).X =
-      HopfAlgebra.pointsGroupPresheaf H ⋙ GrpCat.uliftFunctor.{u + 1, u} ⋙
-        forget GrpCat.{u + 1} := by
-  rfl
-
 /-- The carrier of the pointwise quotient presheaf group object is the universe lift of the
 underlying group-valued quotient presheaf. -/
 theorem pointwiseQuotientPresheafGrp_X_eq
@@ -168,15 +160,6 @@ noncomputable def fppfQuotientProjection (H : _root_.CommHopfAlgCat.{u} R)
     Functor.Monoidal.ofChosenFiniteProducts _
   exact (presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))).mapGrp.map
     (pointwiseQuotientPresheafGrpProjection H I hI)
-
-/-- The carrier of the fppf points group object is the sheafification of the carrier of its
-presheaf group object. -/
-theorem pointsFppfGroupObject_X_eq
-    (H : _root_.CommHopfAlgCat.{u} R) :
-    (pointsFppfGroupObject H).X =
-      (presheafToSheaf (CommAlgCat.fppfTopology R) (Type (u + 1))).obj
-        (pointsPresheafGrp H).X := by
-  rfl
 
 /-- The carrier of the fppf quotient group object is the sheafification of the pointwise
 quotient presheaf's carrier. -/


### PR DESCRIPTION
This PR names the constant group scheme on the connected components of `Spec H` and proves that the fppf component quotient is isomorphic to the sheafification of its Yoneda functor of points on affine schemes.

The scheme name is an `abbrev` of `ConstantGroup.groupScheme`, so the existing affineness, finiteness, and etaleness instances apply directly. The representability comparison composes the existing `componentGroupFppfGroupObjectIso` with `CommHopfAlgCat.pointsPresheafIsoSchemePointsPresheaf`; it adds the explicit scheme-points connection requested by review without duplicating the constant-group API.

This completes the algebraically closed-field case of the Layer 3 finite-etale component-group target. Descent to perfect fields or other suitable hypotheses remains future work.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"component-group-finite-etale"}-->

🤖 Prepared with Codex