### PR TITLE
feat: package the compact real Spin double cover

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Frobenius/GeneralLinear.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Frobenius/GeneralLinear.lean
@@ -212,9 +212,9 @@ theorem coe_iterateFrobeniusHopfIdealPoints_apply
     iterateFrobenius_def]
 
 /-- A matrix point of a closed subgroup scheme is fixed by the Frobenius endomorphism exactly when
-every one of its entries lies in the Frobenius-fixed subring. Since `TauCeti.mem_fixedSubgroup`
-rewrites membership in `fixedSubgroup (iterateFrobeniusHopfIdealPoints n p k I A)` to the equation
-below, this is the membership criterion for the group of rational points. -/
+every one of its entries lies in the Frobenius-fixed subring. The generic equality-locus
+simplifier rewrites membership in `fixedSubgroup (iterateFrobeniusHopfIdealPoints n p k I A)` to
+the equation below, so this is the membership criterion for the group of rational points. -/
 @[simp]
 theorem iterateFrobeniusHopfIdealPoints_eq_self_iff (x : hopfIdealPointsSubgroup n I A) :
     iterateFrobeniusHopfIdealPoints n p k I A x = x ↔

--- a/TauCeti/Algebra/Group/Subgroup/Ker.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Ker.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Group.Subgroup.Ker
+
+/-!
+# Kernels and equality loci of group homomorphisms
+
+This file supplies the characteristic membership equation for the subgroup equality locus.
+-/
+
+public section
+
+namespace MonoidHom
+
+variable {G M : Type*} [Group G] [Monoid M]
+
+/-- Membership in the equality locus of two group homomorphisms is pointwise equality. -/
+theorem mem_eqLocus {f g : G →* M} {x : G} : x ∈ f.eqLocus g ↔ f x = g x :=
+  Iff.rfl
+
+end MonoidHom

--- a/TauCeti/Algebra/Group/Subgroup/Ker.lean
+++ b/TauCeti/Algebra/Group/Subgroup/Ker.lean
@@ -20,6 +20,7 @@ namespace MonoidHom
 variable {G M : Type*} [Group G] [Monoid M]
 
 /-- Membership in the equality locus of two group homomorphisms is pointwise equality. -/
+@[to_additive (attr := simp)]
 theorem mem_eqLocus {f g : G →* M} {x : G} : x ∈ f.eqLocus g ↔ f x = g x :=
   Iff.rfl
 

--- a/TauCeti/Algebra/Group/Units/Basic.lean
+++ b/TauCeti/Algebra/Group/Units/Basic.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Group.Subgroup.Even
+public import Mathlib.Algebra.Group.Units.Defs
+
+import Mathlib.Algebra.Group.Commute.Units
+
+/-!
+# Squares of units
+
+This file relates squares in a monoid to squares in its group of units.
+
+## Main results
+
+* `TauCeti.isSquare_units_val_iff`: a unit is a square exactly when its underlying monoid element
+  is a square.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A unit is a square exactly when its underlying monoid element is a square. -/
+theorem isSquare_units_val_iff {K : Type*} [Monoid K] {u : Kˣ} :
+    IsSquare (u : K) ↔ IsSquare u := by
+  constructor
+  · rintro ⟨x, hx⟩
+    have hxu : IsUnit x := isUnit_mul_self_iff.mp (hx ▸ u.isUnit)
+    exact ⟨hxu.unit, Units.ext (by simpa using hx)⟩
+  · rintro ⟨v, rfl⟩
+    exact ⟨(v : K), by simp⟩
+
+end TauCeti

--- a/TauCeti/Algebra/Group/Units/Basic.lean
+++ b/TauCeti/Algebra/Group/Units/Basic.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Group.Subgroup.Even
+public import Mathlib.Algebra.Group.Even
 public import Mathlib.Algebra.Group.Units.Defs
 
 import Mathlib.Algebra.Group.Commute.Units
@@ -26,13 +26,13 @@ public section
 namespace TauCeti
 
 /-- A unit is a square exactly when its underlying monoid element is a square. -/
-theorem isSquare_units_val_iff {K : Type*} [Monoid K] {u : Kˣ} :
-    IsSquare (u : K) ↔ IsSquare u := by
+theorem isSquare_units_val_iff {M : Type*} [Monoid M] {u : Mˣ} :
+    IsSquare (u : M) ↔ IsSquare u := by
   constructor
   · rintro ⟨x, hx⟩
     have hxu : IsUnit x := isUnit_mul_self_iff.mp (hx ▸ u.isUnit)
     exact ⟨hxu.unit, Units.ext (by simpa using hx)⟩
   · rintro ⟨v, rfl⟩
-    exact ⟨(v : K), by simp⟩
+    exact ⟨(v : M), by simp⟩
 
 end TauCeti

--- a/TauCeti/Algebra/Group/Units/Basic.lean
+++ b/TauCeti/Algebra/Group/Units/Basic.lean
@@ -26,6 +26,7 @@ public section
 namespace TauCeti
 
 /-- A unit is a square exactly when its underlying monoid element is a square. -/
+@[simp]
 theorem isSquare_units_val_iff {M : Type*} [Monoid M] {u : Mˣ} :
     IsSquare (u : M) ↔ IsSquare u := by
   constructor

--- a/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
+++ b/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
@@ -7,14 +7,10 @@ module
 
 public import Mathlib.Algebra.GroupWithZero.Units.Basic
 public import Mathlib.Algebra.Group.Subgroup.Even
-
-import Mathlib.Algebra.Group.Commute.Units
+public import TauCeti.Algebra.Group.Units.Basic
 
 /-!
-# Units and powers in groups with zero
-
-A unit is a square exactly when its underlying monoid element is a square
-(`TauCeti.isSquare_units_val_iff`).
+# Powers in groups with zero
 
 A product `a ^ i * a⁻¹ ^ (n - i)`, in which the two exponents are natural numbers adding up to
 `n`, is the integer power `a ^ (2 * i - n)`.  Such a product is what a diagonal matrix
@@ -29,16 +25,6 @@ statement for the exponents `i` and `n - i` of `a` and `a⁻¹`.
 public section
 
 namespace TauCeti
-
-/-- A unit is a square exactly when its underlying monoid element is a square. -/
-theorem isSquare_units_val_iff {K : Type*} [Monoid K] {u : Kˣ} :
-    IsSquare (u : K) ↔ IsSquare u := by
-  constructor
-  · rintro ⟨x, hx⟩
-    have hxu : IsUnit x := isUnit_mul_self_iff.mp (hx ▸ u.isUnit)
-    exact ⟨hxu.unit, Units.ext (by simpa using hx)⟩
-  · rintro ⟨v, rfl⟩
-    exact ⟨(v : K), by simp⟩
 
 /-- **A power of `a` times a power of `a⁻¹` is an integer power of `a`**: for `i ≤ n`, the
 exponents `i` and `n - i` combine to `i - (n - i) = 2 * i - n`. -/

--- a/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
+++ b/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.GroupWithZero.Units.Basic
-public import Mathlib.Algebra.Group.Subgroup.Even
 public import TauCeti.Algebra.Group.Units.Basic
 
 /-!

--- a/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
+++ b/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.GroupWithZero.Units.Basic
-public import TauCeti.Algebra.Group.Units.Basic
 
 /-!
 # Powers in groups with zero

--- a/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
+++ b/TauCeti/Algebra/GroupWithZero/Units/Basic.lean
@@ -6,9 +6,15 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.GroupWithZero.Units.Basic
+public import Mathlib.Algebra.Group.Subgroup.Even
+
+import Mathlib.Algebra.Group.Commute.Units
 
 /-!
-# Merging a power of a unit with a power of its inverse
+# Units and powers in groups with zero
+
+A unit is a square exactly when its underlying monoid element is a square
+(`TauCeti.isSquare_units_val_iff`).
 
 A product `a ^ i * a⁻¹ ^ (n - i)`, in which the two exponents are natural numbers adding up to
 `n`, is the integer power `a ^ (2 * i - n)`.  Such a product is what a diagonal matrix
@@ -23,6 +29,16 @@ statement for the exponents `i` and `n - i` of `a` and `a⁻¹`.
 public section
 
 namespace TauCeti
+
+/-- A unit is a square exactly when its underlying monoid element is a square. -/
+theorem isSquare_units_val_iff {K : Type*} [Monoid K] {u : Kˣ} :
+    IsSquare (u : K) ↔ IsSquare u := by
+  constructor
+  · rintro ⟨x, hx⟩
+    have hxu : IsUnit x := isUnit_mul_self_iff.mp (hx ▸ u.isUnit)
+    exact ⟨hxu.unit, Units.ext (by simpa using hx)⟩
+  · rintro ⟨v, rfl⟩
+    exact ⟨(v : K), by simp⟩
 
 /-- **A power of `a` times a power of `a⁻¹` is an integer power of `a`**: for `i ≤ n`, the
 exponents `i` and `n - i` combine to `i - (n - i) = 2 * i - n`. -/

--- a/TauCeti/FieldTheory/SquareClassGroup.lean
+++ b/TauCeti/FieldTheory/SquareClassGroup.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.Algebra.Group.Subgroup.Even
 public import Mathlib.Algebra.Module.ZMod
 public import Mathlib.LinearAlgebra.LinearIndependent.Defs
-public import TauCeti.Algebra.Group.Units.Basic
 
 /-!
 # The square-class group `Kˣ ⧸ (Kˣ)²`

--- a/TauCeti/FieldTheory/SquareClassGroup.lean
+++ b/TauCeti/FieldTheory/SquareClassGroup.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.Group.Subgroup.Even
 public import Mathlib.Algebra.Module.ZMod
 public import Mathlib.LinearAlgebra.LinearIndependent.Defs
 public import TauCeti.Algebra.Group.Units.Basic

--- a/TauCeti/FieldTheory/SquareClassGroup.lean
+++ b/TauCeti/FieldTheory/SquareClassGroup.lean
@@ -5,9 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Group.Subgroup.Even
 public import Mathlib.Algebra.Module.ZMod
 public import Mathlib.LinearAlgebra.LinearIndependent.Defs
+public import TauCeti.Algebra.GroupWithZero.Units.Basic
 
 /-!
 # The square-class group `Kˣ ⧸ (Kˣ)²`
@@ -27,8 +27,6 @@ square. So linear independence of the classes is the **Finset form** of square-c
 * `TauCeti.squareClass`, `TauCeti.squareClassHom`: the class of a unit, as a function and a
   multiplicative homomorphism, with `squareClass_eq_zero_iff` characterising the trivial class as
   the squares.
-* `TauCeti.isSquare_units_val_iff`: a unit is a square exactly when its underlying field element
-  is a square.
 * `TauCeti.linearIndependent_squareClass_iff`: the classes of `d : ι → Kˣ` are `ZMod 2`-linearly
   independent iff no nonempty subset product is a square.
 -/
@@ -58,15 +56,6 @@ def squareClass (u : Kˣ) : SquareClassGroup K :=
 multiplicative form of the additive square-class group. -/
 def squareClassHom : Kˣ →* Multiplicative (SquareClassGroup K) :=
   (QuotientAddGroup.mk' (Subgroup.square Kˣ).toAddSubgroup).toMultiplicativeRight
-
-/-- A unit is a square exactly when its underlying field element is a square. -/
-theorem isSquare_units_val_iff {u : Kˣ} : IsSquare (u : K) ↔ IsSquare u := by
-  constructor
-  · rintro ⟨x, hx⟩
-    have hx0 : x ≠ 0 := fun h => u.ne_zero (by rw [hx, h, mul_zero])
-    exact ⟨Units.mk0 x hx0, Units.ext (by simpa using hx)⟩
-  · rintro ⟨v, rfl⟩
-    exact ⟨(v : K), by simp⟩
 
 @[simp]
 theorem squareClassHom_apply (u : Kˣ) :

--- a/TauCeti/FieldTheory/SquareClassGroup.lean
+++ b/TauCeti/FieldTheory/SquareClassGroup.lean
@@ -27,6 +27,8 @@ square. So linear independence of the classes is the **Finset form** of square-c
 * `TauCeti.squareClass`, `TauCeti.squareClassHom`: the class of a unit, as a function and a
   multiplicative homomorphism, with `squareClass_eq_zero_iff` characterising the trivial class as
   the squares.
+* `TauCeti.isSquare_units_val_iff`: a unit is a square exactly when its underlying field element
+  is a square.
 * `TauCeti.linearIndependent_squareClass_iff`: the classes of `d : ι → Kˣ` are `ZMod 2`-linearly
   independent iff no nonempty subset product is a square.
 -/
@@ -56,6 +58,15 @@ def squareClass (u : Kˣ) : SquareClassGroup K :=
 multiplicative form of the additive square-class group. -/
 def squareClassHom : Kˣ →* Multiplicative (SquareClassGroup K) :=
   (QuotientAddGroup.mk' (Subgroup.square Kˣ).toAddSubgroup).toMultiplicativeRight
+
+/-- A unit is a square exactly when its underlying field element is a square. -/
+theorem isSquare_units_val_iff {u : Kˣ} : IsSquare (u : K) ↔ IsSquare u := by
+  constructor
+  · rintro ⟨x, hx⟩
+    have hx0 : x ≠ 0 := fun h => u.ne_zero (by rw [hx, h, mul_zero])
+    exact ⟨Units.mk0 x hx0, Units.ext (by simpa using hx)⟩
+  · rintro ⟨v, rfl⟩
+    exact ⟨(v : K), by simp⟩
 
 @[simp]
 theorem squareClassHom_apply (u : Kˣ) :

--- a/TauCeti/FieldTheory/SquareClassGroup.lean
+++ b/TauCeti/FieldTheory/SquareClassGroup.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Algebra.Module.ZMod
 public import Mathlib.LinearAlgebra.LinearIndependent.Defs
-public import TauCeti.Algebra.GroupWithZero.Units.Basic
+public import TauCeti.Algebra.Group.Units.Basic
 
 /-!
 # The square-class group `Kˣ ⧸ (Kˣ)²`

--- a/TauCeti/GroupTheory/FixedSubgroup.lean
+++ b/TauCeti/GroupTheory/FixedSubgroup.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.Algebra.Group.Subgroup.Map
 public import Mathlib.Algebra.Group.End
 public import Mathlib.Algebra.Group.Equiv.Basic
-public import Mathlib.Algebra.Group.Subgroup.Ker
+public import TauCeti.Algebra.Group.Subgroup.Ker
 public import Mathlib.Dynamics.FixedPoints.Defs
 
 /-!

--- a/TauCeti/GroupTheory/FixedSubgroup.lean
+++ b/TauCeti/GroupTheory/FixedSubgroup.lean
@@ -68,7 +68,6 @@ variable {G : Type*} [Group G]
 /-- The subgroup of points fixed by an endomorphism of a group, `F.eqLocus (MonoidHom.id G)`. -/
 abbrev fixedSubgroup (F : G →* G) : Subgroup G := F.eqLocus (MonoidHom.id G)
 
-@[simp]
 theorem mem_fixedSubgroup {F : G →* G} {x : G} : x ∈ fixedSubgroup F ↔ F x = x := Iff.rfl
 
 /-- Only the identity fixes every point. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -24,6 +24,8 @@ coordinates and `-1` in the last `q`, written as a `QuadraticMap.weightedSumSqua
 sign vector `TauCeti.realCliffordWeight p q`. It is nondegenerate
 (`TauCeti.nondegenerate_realCliffordForm`), and its Clifford algebra has dimension `2 ^ (p + q)`
 (`TauCeti.finrank_cliffordAlgebra_realCliffordForm`).
+The compact form `realCliffordForm n 0` is positive definite
+(`TauCeti.posDef_realCliffordForm_zero`).
 Negating the form swaps the two signature indices through
 `TauCeti.realCliffordFormNegIsometry`; its coordinate action is given by
 `TauCeti.realCliffordFormNegIsometry_pos_of_neg` and
@@ -148,6 +150,26 @@ theorem nondegenerate_realCliffordForm (p q : ℕ) : (realCliffordForm p q).Nond
   intro v hv
   funext j
   exact Pi.mem_spanSubset_iff.1 hv j (realCliffordWeight_ne_zero p q j)
+
+/-- The standard signature form with no negative coordinates is positive definite. -/
+theorem posDef_realCliffordForm_zero (n : ℕ) : (realCliffordForm n 0).PosDef := by
+  intro v hv
+  rw [realCliffordForm_apply]
+  simp only [Nat.add_zero]
+  have hsum : (∑ i : Fin n, realCliffordWeight n 0 i * (v i * v i)) =
+      ∑ i, v i * v i := by
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [realCliffordWeight_of_lt i.isLt, one_mul]
+  rw [hsum]
+  refine (Fintype.sum_pos_iff_of_nonneg fun i => mul_self_nonneg (v i)).2 ?_
+  rw [Pi.lt_def]
+  constructor
+  · intro i
+    exact mul_self_nonneg (v i)
+  · rw [Function.ne_iff] at hv
+    obtain ⟨i, hi⟩ := hv
+    exact ⟨i, mul_self_pos.2 hi⟩
 
 /-- The real Clifford algebra of signature `(p, q)` has dimension `2 ^ (p + q)`, as every Clifford
 algebra of a space of that dimension does. This is the count that forces the surjections built

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -6,8 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Equivs
-import Mathlib.Algebra.Order.Star.Real
-import Mathlib.LinearAlgebra.Matrix.DotProduct
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
 
@@ -157,8 +155,13 @@ theorem nondegenerate_realCliffordForm (p q : ℕ) : (realCliffordForm p q).Nond
 theorem posDef_realCliffordForm_zero (n : ℕ) : (realCliffordForm n 0).PosDef := by
   intro v hv
   rw [realCliffordForm_apply]
-  simpa [realCliffordWeight, dotProduct] using
-    (Matrix.dotProduct_star_self_pos_iff (v := v)).2 hv
+  refine Finset.sum_pos' (fun i _ ↦ ?_) ?_
+  · rw [realCliffordWeight_of_lt (by omega), one_mul]
+    exact mul_self_nonneg (v i)
+  · obtain ⟨i, hi⟩ := Function.ne_iff.mp hv
+    refine ⟨i, Finset.mem_univ i, ?_⟩
+    rw [realCliffordWeight_of_lt (by omega), one_mul]
+    exact mul_self_pos.mpr hi
 
 /-- The real Clifford algebra of signature `(p, q)` has dimension `2 ^ (p + q)`, as every Clifford
 algebra of a space of that dimension does. This is the count that forces the surjections built

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/RealForm.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Equivs
+import Mathlib.Algebra.Order.Star.Real
+import Mathlib.LinearAlgebra.Matrix.DotProduct
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
 
@@ -155,21 +157,8 @@ theorem nondegenerate_realCliffordForm (p q : ℕ) : (realCliffordForm p q).Nond
 theorem posDef_realCliffordForm_zero (n : ℕ) : (realCliffordForm n 0).PosDef := by
   intro v hv
   rw [realCliffordForm_apply]
-  simp only [Nat.add_zero]
-  have hsum : (∑ i : Fin n, realCliffordWeight n 0 i * (v i * v i)) =
-      ∑ i, v i * v i := by
-    apply Finset.sum_congr rfl
-    intro i _
-    rw [realCliffordWeight_of_lt i.isLt, one_mul]
-  rw [hsum]
-  refine (Fintype.sum_pos_iff_of_nonneg fun i => mul_self_nonneg (v i)).2 ?_
-  rw [Pi.lt_def]
-  constructor
-  · intro i
-    exact mul_self_nonneg (v i)
-  · rw [Function.ne_iff] at hv
-    obtain ⟨i, hi⟩ := hv
-    exact ⟨i, mul_self_pos.2 hi⟩
+  simpa [realCliffordWeight, dotProduct] using
+    (Matrix.dotProduct_star_self_pos_iff (v := v)).2 hv
 
 /-- The real Clifford algebra of signature `(p, q)` has dimension `2 ^ (p + q)`, as every Clifford
 algebra of a space of that dimension does. This is the count that forces the surjections built

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real.lean
@@ -27,9 +27,9 @@ separate.
   spinor norm with the determinant square-class map for a positive-definite real form.
 * `CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_posDef` proves surjectivity for any
   finite-dimensional positive-definite real form.
-* `CliffordAlgebra.spinPQ` and `CliffordAlgebra.spinN` name the real and compact Spin groups.
-* `CliffordAlgebra.spinNDoubleCover` packages the compact real Spin double cover in positive
-  dimension.
+* `CliffordAlgebra.realCliffordSpinGroup` names the real Spin groups by signature.
+* `CliffordAlgebra.realCliffordSpinGroupZero` names the compact real Spin group.
+* `CliffordAlgebra.realCliffordSpinDoubleCoverZero` packages its double cover in positive dimension.
 
 ## References
 
@@ -50,66 +50,53 @@ universe u
 
 variable {V : Type u} [AddCommGroup V] [Module ℝ V]
 
-private theorem posDef_unit_isSquare (Q : QuadraticForm ℝ V) (hQ : Q.PosDef) (v : V)
-    [Invertible (Q v)] : IsSquare (unitOfInvertible (Q v)) := by
-  have hvQ : Q v ≠ 0 := Invertible.ne_zero _
-  have hv : v ≠ 0 := by
-    intro hv
-    subst v
-    simp at hvQ
-  rw [← isSquare_units_val_iff, val_unitOfInvertible, Real.isSquare_iff]
-  exact (hQ v hv).le
-
 variable [FiniteDimensional ℝ V]
 
 /-- On a finite-dimensional positive-definite real quadratic space, the orthogonal spinor norm is
 the square class of the determinant. -/
 theorem orthogonalSpinorNorm_eq_detSquareClass_of_posDef
     (Q : QuadraticForm ℝ V) (hQ : Q.PosDef) :
-    orthogonalSpinorNorm Q hQ.anisotropic.nondegenerate = orthogonalDetSquareClass Q := by
-  exact orthogonalSpinorNorm_eq_detSquareClass_of_isSquare Q hQ.anisotropic.nondegenerate
-    (posDef_unit_isSquare Q hQ)
+    orthogonalSpinorNorm Q hQ.anisotropic.nondegenerate =
+      QuadraticMap.orthogonalDetSquareClass Q := by
+  exact orthogonalSpinorNorm_eq_detSquareClass_of_isSquare_apply Q hQ.anisotropic.nondegenerate
+    fun v => Real.isSquare_iff.2 (hQ.nonneg v)
 
 /-- The Spin action of a finite-dimensional positive-definite real quadratic space is onto its
 special orthogonal group. -/
 theorem spinToSpecialOrthogonal_surjective_of_posDef
     (Q : QuadraticForm ℝ V) (hQ : Q.PosDef) :
     Function.Surjective (spinToSpecialOrthogonal Q) := by
-  exact spinToSpecialOrthogonal_surjective_of_unit_isSquare Q hQ.anisotropic.nondegenerate
-    (posDef_unit_isSquare Q hQ)
+  exact spinToSpecialOrthogonal_surjective_of_isSquare_apply Q hQ.anisotropic.nondegenerate
+    fun v => Real.isSquare_iff.2 (hQ.nonneg v)
 
 /-- The real Spin group of signature `(p, q)`. -/
-abbrev spinPQ (p q : ℕ) := spinGroup (realCliffordForm p q)
+abbrev realCliffordSpinGroup (p q : ℕ) := spinGroup (realCliffordForm p q)
 
 /-- The compact real Spin group `Spin(n)`. -/
-abbrev spinN (n : ℕ) := spinPQ n 0
+abbrev realCliffordSpinGroupZero (n : ℕ) := realCliffordSpinGroup n 0
 
 /-- The algebraic double cover from `Spin(n)` to the special orthogonal group in positive
 dimension. -/
-noncomputable def spinNDoubleCover (n : ℕ) (hn : 0 < n) :
-    GroupExtension (Multiplicative (ZMod 2)) (spinN n)
-      (QuadraticMap.specialOrthogonalGroup (realCliffordForm n 0)) := by
-  let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
-  exact spinDoubleCoverOfSurjective (realCliffordForm n 0)
+noncomputable def realCliffordSpinDoubleCoverZero (n : ℕ) [NeZero n] :
+    GroupExtension (Multiplicative (ZMod 2)) (realCliffordSpinGroupZero n)
+      (QuadraticMap.specialOrthogonalGroup (realCliffordForm n 0)) :=
+  spinDoubleCoverOfSurjective (realCliffordForm n 0)
     (nondegenerate_realCliffordForm n 0)
     (spinToSpecialOrthogonal_surjective_of_posDef _ (posDef_realCliffordForm_zero n))
 
 /-- The inclusion in the compact real Spin double cover sends the generator to the distinguished
 element `-1` of the Spin group. -/
 @[simp]
-theorem spinNDoubleCover_inl_ofAdd_one (n : ℕ) (hn : 0 < n) :
-    let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
-    (spinNDoubleCover n hn).inl (Multiplicative.ofAdd 1) =
+theorem realCliffordSpinDoubleCoverZero_inl_ofAdd_one (n : ℕ) [NeZero n] :
+    (realCliffordSpinDoubleCoverZero n).inl (Multiplicative.ofAdd 1) =
       spinGroup.negOne (realCliffordForm n 0) (nondegenerate_realCliffordForm n 0).ne_zero := by
-  let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
-  rw [spinNDoubleCover, spinDoubleCoverOfSurjective_inl_ofAdd_one]
+  rw [realCliffordSpinDoubleCoverZero, spinDoubleCoverOfSurjective_inl_ofAdd_one]
 
 /-- The projection in the compact real Spin double cover is the Spin action. -/
 @[simp]
-theorem spinNDoubleCover_rightHom (n : ℕ) (hn : 0 < n) :
-    (spinNDoubleCover n hn).rightHom =
+theorem realCliffordSpinDoubleCoverZero_rightHom (n : ℕ) [NeZero n] :
+    (realCliffordSpinDoubleCoverZero n).rightHom =
       spinToSpecialOrthogonal (realCliffordForm n 0) := by
-  let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
-  rw [spinNDoubleCover, spinDoubleCoverOfSurjective_rightHom]
+  rw [realCliffordSpinDoubleCoverZero, spinDoubleCoverOfSurjective_rightHom]
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.RealForm
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.DoubleCover
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpinorNorm
+import Mathlib.Analysis.Real.Sqrt
+
+/-!
+# Compact real Spin groups
+
+For a positive-definite real quadratic form, every nonzero norm is a square. The spinor norm on
+the orthogonal group therefore agrees with the determinant modulo squares. Its restriction to the
+special orthogonal group is trivial, so the Spin action is surjective.
+
+This file applies that argument to the positive-definite signature form `realCliffordForm n 0` and
+packages its Spin double cover. Topology, connectedness, and the universal-cover theorem remain
+separate.
+
+## Main definitions and results
+
+* `CliffordAlgebra.orthogonalSpinorNorm_eq_detSquareClass_of_posDef` identifies it with the
+  orthogonal spinor norm for a positive-definite real form.
+* `CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_posDef` proves surjectivity for any
+  finite-dimensional positive-definite real form.
+* `CliffordAlgebra.spinPQ` and `CliffordAlgebra.spinN` name the real and compact Spin groups.
+* `CliffordAlgebra.spinNDoubleCover` packages the compact real Spin double cover in positive
+  dimension.
+
+## References
+
+This advances the real Spin-group part of Layer 7 in
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. See H. B. Lawson and
+M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+-/
+
+public section
+
+open QuadraticMap
+
+namespace CliffordAlgebra
+
+open TauCeti
+
+universe u
+
+variable {V : Type u} [AddCommGroup V] [Module ℝ V]
+
+private theorem posDef_unit_isSquare (Q : QuadraticForm ℝ V) (hQ : Q.PosDef) (v : V)
+    [Invertible (Q v)] : IsSquare (unitOfInvertible (Q v)) := by
+  have hvQ : Q v ≠ 0 := Invertible.ne_zero _
+  have hv : v ≠ 0 := by
+    intro hv
+    subst v
+    simp at hvQ
+  have hpos := hQ v hv
+  let u : ℝˣ := Units.mk0 (Real.sqrt (Q v)) (Real.sqrt_ne_zero'.2 hpos)
+  refine ⟨u, ?_⟩
+  apply Units.ext
+  dsimp only [u]
+  simpa only [val_unitOfInvertible, Units.val_mul, Units.val_mk0, pow_two] using
+    (Real.sq_sqrt hpos.le).symm
+
+variable [FiniteDimensional ℝ V]
+
+/-- On a finite-dimensional positive-definite real quadratic space, the orthogonal spinor norm is
+the square class of the determinant. -/
+theorem orthogonalSpinorNorm_eq_detSquareClass_of_posDef
+    (Q : QuadraticForm ℝ V) (hQ : Q.PosDef) :
+    orthogonalSpinorNorm Q hQ.nondegenerate = orthogonalDetSquareClass Q := by
+  let f : QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup ℝ) :=
+    orthogonalSpinorNorm Q hQ.nondegenerate
+  let g : QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup ℝ) :=
+    orthogonalDetSquareClass Q
+  let H : Subgroup (QuadraticMap.orthogonalGroup Q) :=
+    @MonoidHom.eqLocus (QuadraticMap.orthogonalGroup Q) _
+      (Multiplicative (SquareClassGroup ℝ)) _ f g
+  have hH : H = ⊤ := QuadraticMap.subgroup_eq_top_of_reflection_mem
+    Q hQ.nondegenerate H fun v _ => by
+      change orthogonalSpinorNorm Q hQ.nondegenerate
+          (QuadraticMap.reflectionOrthogonal Q v) =
+        orthogonalDetSquareClass Q (QuadraticMap.reflectionOrthogonal Q v)
+      rw [orthogonalSpinorNorm_reflectionOrthogonal, orthogonalDetSquareClass_apply]
+      rw [QuadraticMap.coe_reflectionOrthogonal, QuadraticMap.det_reflection]
+      have hsquare : squareClassHom (unitOfInvertible (Q v)) = 1 := by
+        rw [squareClassHom_apply]
+        simpa only [ofAdd_zero] using congrArg Multiplicative.ofAdd
+          ((squareClass_eq_zero_iff _).2 (posDef_unit_isSquare Q hQ v))
+      rw [show -(unitOfInvertible (Q v)) = (-1 : ℝˣ) * unitOfInvertible (Q v) by
+          apply Units.ext
+          simp]
+      rw [map_mul, hsquare]
+      exact mul_one (squareClassHom (-1 : ℝˣ))
+  apply MonoidHom.ext
+  intro x
+  have hx : x ∈ H := by rw [hH]; trivial
+  exact hx
+
+/-- The Spin action of a finite-dimensional positive-definite real quadratic space is onto its
+special orthogonal group. -/
+theorem spinToSpecialOrthogonal_surjective_of_posDef
+    (Q : QuadraticForm ℝ V) (hQ : Q.PosDef) :
+    Function.Surjective (spinToSpecialOrthogonal Q) := by
+  rw [← MonoidHom.range_eq_top]
+  rw [range_spinToSpecialOrthogonal_eq_ker_spinorNorm Q hQ.nondegenerate]
+  rw [Subgroup.eq_top_iff']
+  intro g
+  rw [MonoidHom.mem_ker, spinorNorm_apply,
+    orthogonalSpinorNorm_eq_detSquareClass_of_posDef Q hQ]
+  rw [orthogonalDetSquareClass_apply]
+  have hgdet := (QuadraticMap.mem_specialOrthogonalGroup_iff.mp g.2).2
+  have hgdet' : LinearEquiv.det
+      ((Subgroup.inclusion (QuadraticMap.specialOrthogonalGroup_le_orthogonalGroup Q) g :
+        QuadraticMap.orthogonalGroup Q) : V ≃ₗ[ℝ] V) = 1 := by
+    rw [show ((Subgroup.inclusion
+      (QuadraticMap.specialOrthogonalGroup_le_orthogonalGroup Q) g :
+        QuadraticMap.orthogonalGroup Q) : V ≃ₗ[ℝ] V) = (g : V ≃ₗ[ℝ] V) by
+      apply LinearEquiv.ext
+      intro v
+      rfl]
+    exact hgdet
+  rw [hgdet', map_one]
+
+/-- The real Spin group of signature `(p, q)`. -/
+abbrev spinPQ (p q : ℕ) := spinGroup (realCliffordForm p q)
+
+/-- The compact real Spin group `Spin(n)`. -/
+abbrev spinN (n : ℕ) := spinPQ n 0
+
+/-- The algebraic double cover from `Spin(n)` to the special orthogonal group in positive
+dimension. -/
+noncomputable def spinNDoubleCover (n : ℕ) (hn : 0 < n) :
+    GroupExtension (Multiplicative (ZMod 2)) (spinN n)
+      (QuadraticMap.specialOrthogonalGroup (realCliffordForm n 0)) := by
+  let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
+  exact spinDoubleCoverOfSurjective (realCliffordForm n 0)
+    (nondegenerate_realCliffordForm n 0)
+    (spinToSpecialOrthogonal_surjective_of_posDef _ (posDef_realCliffordForm_zero n))
+
+/-- The inclusion in the compact real Spin double cover sends the generator to the Clifford
+scalar `-1`. -/
+@[simp]
+theorem spinNDoubleCover_inl_ofAdd_one (n : ℕ) (hn : 0 < n) :
+    (((spinNDoubleCover n hn).inl (Multiplicative.ofAdd 1) : spinN n) :
+      CliffordAlgebra (realCliffordForm n 0)) = -1 := by
+  let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
+  rw [spinNDoubleCover, spinDoubleCoverOfSurjective_inl_ofAdd_one,
+    spinGroup.coe_negOne]
+
+/-- The projection in the compact real Spin double cover is the Spin action. -/
+@[simp]
+theorem spinNDoubleCover_rightHom (n : ℕ) (hn : 0 < n) :
+    (spinNDoubleCover n hn).rightHom =
+      spinToSpecialOrthogonal (realCliffordForm n 0) := by
+  let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
+  rw [spinNDoubleCover, spinDoubleCoverOfSurjective_rightHom]
+
+end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real.lean
@@ -23,8 +23,8 @@ separate.
 
 ## Main definitions and results
 
-* `CliffordAlgebra.orthogonalSpinorNorm_eq_detSquareClass_of_posDef` identifies it with the
-  orthogonal spinor norm for a positive-definite real form.
+* `CliffordAlgebra.orthogonalSpinorNorm_eq_detSquareClass_of_posDef` identifies the orthogonal
+  spinor norm with the determinant square-class map for a positive-definite real form.
 * `CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_posDef` proves surjectivity for any
   finite-dimensional positive-definite real form.
 * `CliffordAlgebra.spinPQ` and `CliffordAlgebra.spinN` name the real and compact Spin groups.
@@ -57,13 +57,8 @@ private theorem posDef_unit_isSquare (Q : QuadraticForm ℝ V) (hQ : Q.PosDef) (
     intro hv
     subst v
     simp at hvQ
-  have hpos := hQ v hv
-  let u : ℝˣ := Units.mk0 (Real.sqrt (Q v)) (Real.sqrt_ne_zero'.2 hpos)
-  refine ⟨u, ?_⟩
-  apply Units.ext
-  dsimp only [u]
-  simpa only [val_unitOfInvertible, Units.val_mul, Units.val_mk0, pow_two] using
-    (Real.sq_sqrt hpos.le).symm
+  rw [← isSquare_units_val_iff, val_unitOfInvertible, Real.isSquare_iff]
+  exact (hQ v hv).le
 
 variable [FiniteDimensional ℝ V]
 
@@ -71,59 +66,17 @@ variable [FiniteDimensional ℝ V]
 the square class of the determinant. -/
 theorem orthogonalSpinorNorm_eq_detSquareClass_of_posDef
     (Q : QuadraticForm ℝ V) (hQ : Q.PosDef) :
-    orthogonalSpinorNorm Q hQ.nondegenerate = orthogonalDetSquareClass Q := by
-  let f : QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup ℝ) :=
-    orthogonalSpinorNorm Q hQ.nondegenerate
-  let g : QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup ℝ) :=
-    orthogonalDetSquareClass Q
-  let H : Subgroup (QuadraticMap.orthogonalGroup Q) :=
-    @MonoidHom.eqLocus (QuadraticMap.orthogonalGroup Q) _
-      (Multiplicative (SquareClassGroup ℝ)) _ f g
-  have hH : H = ⊤ := QuadraticMap.subgroup_eq_top_of_reflection_mem
-    Q hQ.nondegenerate H fun v _ => by
-      change orthogonalSpinorNorm Q hQ.nondegenerate
-          (QuadraticMap.reflectionOrthogonal Q v) =
-        orthogonalDetSquareClass Q (QuadraticMap.reflectionOrthogonal Q v)
-      rw [orthogonalSpinorNorm_reflectionOrthogonal, orthogonalDetSquareClass_apply]
-      rw [QuadraticMap.coe_reflectionOrthogonal, QuadraticMap.det_reflection]
-      have hsquare : squareClassHom (unitOfInvertible (Q v)) = 1 := by
-        rw [squareClassHom_apply]
-        simpa only [ofAdd_zero] using congrArg Multiplicative.ofAdd
-          ((squareClass_eq_zero_iff _).2 (posDef_unit_isSquare Q hQ v))
-      rw [show -(unitOfInvertible (Q v)) = (-1 : ℝˣ) * unitOfInvertible (Q v) by
-          apply Units.ext
-          simp]
-      rw [map_mul, hsquare]
-      exact mul_one (squareClassHom (-1 : ℝˣ))
-  apply MonoidHom.ext
-  intro x
-  have hx : x ∈ H := by rw [hH]; trivial
-  exact hx
+    orthogonalSpinorNorm Q hQ.anisotropic.nondegenerate = orthogonalDetSquareClass Q := by
+  exact orthogonalSpinorNorm_eq_detSquareClass_of_isSquare Q hQ.anisotropic.nondegenerate
+    (posDef_unit_isSquare Q hQ)
 
 /-- The Spin action of a finite-dimensional positive-definite real quadratic space is onto its
 special orthogonal group. -/
 theorem spinToSpecialOrthogonal_surjective_of_posDef
     (Q : QuadraticForm ℝ V) (hQ : Q.PosDef) :
     Function.Surjective (spinToSpecialOrthogonal Q) := by
-  rw [← MonoidHom.range_eq_top]
-  rw [range_spinToSpecialOrthogonal_eq_ker_spinorNorm Q hQ.nondegenerate]
-  rw [Subgroup.eq_top_iff']
-  intro g
-  rw [MonoidHom.mem_ker, spinorNorm_apply,
-    orthogonalSpinorNorm_eq_detSquareClass_of_posDef Q hQ]
-  rw [orthogonalDetSquareClass_apply]
-  have hgdet := (QuadraticMap.mem_specialOrthogonalGroup_iff.mp g.2).2
-  have hgdet' : LinearEquiv.det
-      ((Subgroup.inclusion (QuadraticMap.specialOrthogonalGroup_le_orthogonalGroup Q) g :
-        QuadraticMap.orthogonalGroup Q) : V ≃ₗ[ℝ] V) = 1 := by
-    rw [show ((Subgroup.inclusion
-      (QuadraticMap.specialOrthogonalGroup_le_orthogonalGroup Q) g :
-        QuadraticMap.orthogonalGroup Q) : V ≃ₗ[ℝ] V) = (g : V ≃ₗ[ℝ] V) by
-      apply LinearEquiv.ext
-      intro v
-      rfl]
-    exact hgdet
-  rw [hgdet', map_one]
+  exact spinToSpecialOrthogonal_surjective_of_unit_isSquare Q hQ.anisotropic.nondegenerate
+    (posDef_unit_isSquare Q hQ)
 
 /-- The real Spin group of signature `(p, q)`. -/
 abbrev spinPQ (p q : ℕ) := spinGroup (realCliffordForm p q)
@@ -141,15 +94,25 @@ noncomputable def spinNDoubleCover (n : ℕ) (hn : 0 < n) :
     (nondegenerate_realCliffordForm n 0)
     (spinToSpecialOrthogonal_surjective_of_posDef _ (posDef_realCliffordForm_zero n))
 
-/-- The inclusion in the compact real Spin double cover sends the generator to the Clifford
-scalar `-1`. -/
+/-- The compact real Spin double cover is the generic construction applied to positive-definite
+surjectivity. -/
+theorem spinNDoubleCover_def (n : ℕ) (hn : 0 < n) :
+    spinNDoubleCover n hn =
+      let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
+      spinDoubleCoverOfSurjective (realCliffordForm n 0)
+        (nondegenerate_realCliffordForm n 0)
+        (spinToSpecialOrthogonal_surjective_of_posDef _ (posDef_realCliffordForm_zero n)) :=
+  (rfl)
+
+/-- The inclusion in the compact real Spin double cover sends the generator to the distinguished
+element `-1` of the Spin group. -/
 @[simp]
 theorem spinNDoubleCover_inl_ofAdd_one (n : ℕ) (hn : 0 < n) :
-    (((spinNDoubleCover n hn).inl (Multiplicative.ofAdd 1) : spinN n) :
-      CliffordAlgebra (realCliffordForm n 0)) = -1 := by
+    let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
+    (spinNDoubleCover n hn).inl (Multiplicative.ofAdd 1) =
+      spinGroup.negOne (realCliffordForm n 0) (nondegenerate_realCliffordForm n 0).ne_zero := by
   let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
-  rw [spinNDoubleCover, spinDoubleCoverOfSurjective_inl_ofAdd_one,
-    spinGroup.coe_negOne]
+  rw [spinNDoubleCover_def, spinDoubleCoverOfSurjective_inl_ofAdd_one]
 
 /-- The projection in the compact real Spin double cover is the Spin action. -/
 @[simp]
@@ -157,6 +120,6 @@ theorem spinNDoubleCover_rightHom (n : ℕ) (hn : 0 < n) :
     (spinNDoubleCover n hn).rightHom =
       spinToSpecialOrthogonal (realCliffordForm n 0) := by
   let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
-  rw [spinNDoubleCover, spinDoubleCoverOfSurjective_rightHom]
+  rw [spinNDoubleCover_def, spinDoubleCoverOfSurjective_rightHom]
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/Real.lean
@@ -94,16 +94,6 @@ noncomputable def spinNDoubleCover (n : ℕ) (hn : 0 < n) :
     (nondegenerate_realCliffordForm n 0)
     (spinToSpecialOrthogonal_surjective_of_posDef _ (posDef_realCliffordForm_zero n))
 
-/-- The compact real Spin double cover is the generic construction applied to positive-definite
-surjectivity. -/
-theorem spinNDoubleCover_def (n : ℕ) (hn : 0 < n) :
-    spinNDoubleCover n hn =
-      let _ : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
-      spinDoubleCoverOfSurjective (realCliffordForm n 0)
-        (nondegenerate_realCliffordForm n 0)
-        (spinToSpecialOrthogonal_surjective_of_posDef _ (posDef_realCliffordForm_zero n)) :=
-  (rfl)
-
 /-- The inclusion in the compact real Spin double cover sends the generator to the distinguished
 element `-1` of the Spin group. -/
 @[simp]
@@ -112,7 +102,7 @@ theorem spinNDoubleCover_inl_ofAdd_one (n : ℕ) (hn : 0 < n) :
     (spinNDoubleCover n hn).inl (Multiplicative.ofAdd 1) =
       spinGroup.negOne (realCliffordForm n 0) (nondegenerate_realCliffordForm n 0).ne_zero := by
   let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
-  rw [spinNDoubleCover_def, spinDoubleCoverOfSurjective_inl_ofAdd_one]
+  rw [spinNDoubleCover, spinDoubleCoverOfSurjective_inl_ofAdd_one]
 
 /-- The projection in the compact real Spin double cover is the Spin action. -/
 @[simp]
@@ -120,6 +110,6 @@ theorem spinNDoubleCover_rightHom (n : ℕ) (hn : 0 < n) :
     (spinNDoubleCover n hn).rightHom =
       spinToSpecialOrthogonal (realCliffordForm n 0) := by
   let : Nonempty (Fin n) := Fin.pos_iff_nonempty.mp hn
-  rw [spinNDoubleCover_def, spinDoubleCoverOfSurjective_rightHom]
+  rw [spinNDoubleCover, spinDoubleCoverOfSurjective_rightHom]
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
@@ -45,13 +45,14 @@ namespace CliffordAlgebra
 
 open TauCeti
 
-universe u v
+universe u v w
 
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
   [FiniteDimensional K V] [Invertible (2 : K)]
 
 /-- The determinant of an orthogonal transformation, reduced modulo squares. -/
-noncomputable def orthogonalDetSquareClass (Q : QuadraticForm K V) :
+noncomputable def orthogonalDetSquareClass {N : Type w} [AddCommMonoid N] [Module K N]
+    (Q : QuadraticMap K V N) :
     QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
   squareClassHom.comp <|
     LinearEquiv.det.comp (QuadraticMap.orthogonalGroup Q).subtype
@@ -59,7 +60,8 @@ noncomputable def orthogonalDetSquareClass (Q : QuadraticForm K V) :
 omit [FiniteDimensional K V] [Invertible (2 : K)] in
 /-- The determinant square-class map evaluates by taking the determinant modulo squares. -/
 @[simp]
-theorem orthogonalDetSquareClass_apply (Q : QuadraticForm K V)
+theorem orthogonalDetSquareClass_apply {N : Type w} [AddCommMonoid N] [Module K N]
+    (Q : QuadraticMap K V N)
     (g : QuadraticMap.orthogonalGroup Q) :
     orthogonalDetSquareClass Q g = squareClassHom (LinearEquiv.det (g : V ≃ₗ[K] V)) :=
   by

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
@@ -22,6 +22,7 @@ Spin group.
 
 ## Main results
 
+* `CliffordAlgebra.orthogonalDetSquareClass`: the determinant modulo squares on `O(Q)`.
 * `CliffordAlgebra.orthogonalSpinorNorm`: the square-class-valued spinor norm on `O(Q)`.
 * `CliffordAlgebra.spinorNorm`: its restriction to `SO(Q)`.
 * `CliffordAlgebra.range_spinToSpecialOrthogonal_eq_ker_spinorNorm`: the Spin image is
@@ -44,6 +45,22 @@ universe u v
 
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
   [FiniteDimensional K V] [Invertible (2 : K)]
+
+/-- The determinant of an orthogonal transformation, reduced modulo squares. -/
+noncomputable def orthogonalDetSquareClass (Q : QuadraticForm K V) :
+    QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
+  squareClassHom.comp <|
+    LinearEquiv.det.comp (QuadraticMap.orthogonalGroup Q).subtype
+
+omit [FiniteDimensional K V] [Invertible (2 : K)] in
+/-- The determinant square-class map evaluates by taking the determinant modulo squares. -/
+@[simp]
+theorem orthogonalDetSquareClass_apply (Q : QuadraticForm K V)
+    (g : QuadraticMap.orthogonalGroup Q) :
+    orthogonalDetSquareClass Q g = squareClassHom (LinearEquiv.det (g : V ≃ₗ[K] V)) :=
+  by
+    rw [orthogonalDetSquareClass]
+    simp only [MonoidHom.comp_apply, Subgroup.coe_subtype]
 
 private theorem lipschitzToOrthogonal_surjective_of_invertible
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
@@ -5,10 +5,11 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.FieldTheory.SquareClassGroup
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Lipschitz.Norm
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpecialOrthogonal
+public import TauCeti.LinearAlgebra.QuadraticForm.DetSquareClass
 public import TauCeti.LinearAlgebra.QuadraticForm.Radical
+import TauCeti.Algebra.Group.Subgroup.Ker
 import TauCeti.LinearAlgebra.CliffordAlgebra.CartanDieudonne
 import TauCeti.LinearAlgebra.CliffordAlgebra.Basic
 
@@ -22,12 +23,11 @@ Spin group.
 
 ## Main results
 
-* `CliffordAlgebra.orthogonalDetSquareClass`: the determinant modulo squares on `O(Q)`.
 * `CliffordAlgebra.orthogonalSpinorNorm`: the square-class-valued spinor norm on `O(Q)`.
 * `CliffordAlgebra.spinorNorm`: its restriction to `SO(Q)`.
-* `CliffordAlgebra.orthogonalSpinorNorm_eq_detSquareClass_of_isSquare`: when every nonzero value
+* `CliffordAlgebra.orthogonalSpinorNorm_eq_detSquareClass_of_isSquare_apply`: when every value
   of the form is a square, the orthogonal spinor norm is the determinant square class.
-* `CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_unit_isSquare`: the same square-value
+* `CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_isSquare_apply`: the same square-value
   hypothesis makes the Spin action surjective.
 * `CliffordAlgebra.range_spinToSpecialOrthogonal_eq_ker_spinorNorm`: the Spin image is
   the kernel of the spinor norm.
@@ -49,24 +49,6 @@ universe u v w
 
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
   [FiniteDimensional K V] [Invertible (2 : K)]
-
-/-- The determinant of an orthogonal transformation, reduced modulo squares. -/
-noncomputable def orthogonalDetSquareClass {N : Type w} [AddCommMonoid N] [Module K N]
-    (Q : QuadraticMap K V N) :
-    QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
-  squareClassHom.comp <|
-    LinearEquiv.det.comp (QuadraticMap.orthogonalGroup Q).subtype
-
-omit [FiniteDimensional K V] [Invertible (2 : K)] in
-/-- The determinant square-class map evaluates by taking the determinant modulo squares. -/
-@[simp]
-theorem orthogonalDetSquareClass_apply {N : Type w} [AddCommMonoid N] [Module K N]
-    (Q : QuadraticMap K V N)
-    (g : QuadraticMap.orthogonalGroup Q) :
-    orthogonalDetSquareClass Q g = squareClassHom (LinearEquiv.det (g : V ≃ₗ[K] V)) :=
-  by
-    rw [orthogonalDetSquareClass]
-    simp only [MonoidHom.comp_apply, Subgroup.coe_subtype]
 
 private theorem lipschitzToOrthogonal_surjective_of_invertible
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
@@ -188,34 +170,41 @@ theorem orthogonalSpinorNorm_reflectionOrthogonal (Q : QuadraticForm K V)
   rw [← lipschitzToOrthogonal_unitι Q v, orthogonalSpinorNorm_lipschitzToOrthogonal,
     lipschitzNorm_unitι]
 
-/-- If every nonzero value of a finite-dimensional nondegenerate quadratic form is a square, its
-orthogonal spinor norm is the square class of the determinant. -/
-theorem orthogonalSpinorNorm_eq_detSquareClass_of_isSquare
+/-- If every value of a finite-dimensional nondegenerate quadratic form is a square, its
+orthogonal spinor norm is the square class of the determinant. This differs from
+`spinToSpecialOrthogonal_surjective_of_isSquare`, which assumes that `-⅟(Q v)` is a square. -/
+theorem orthogonalSpinorNorm_eq_detSquareClass_of_isSquare_apply
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
-    (hsq : ∀ v [Invertible (Q v)], IsSquare (unitOfInvertible (Q v))) :
-    orthogonalSpinorNorm Q hQ = orthogonalDetSquareClass Q := by
-  let f : QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
-    orthogonalSpinorNorm Q hQ
-  let g : QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
-    orthogonalDetSquareClass Q
-  let H : Subgroup (QuadraticMap.orthogonalGroup Q) :=
-    @MonoidHom.eqLocus (QuadraticMap.orthogonalGroup Q) _
-      (Multiplicative (SquareClassGroup K)) _ f g
-  have hH : H = ⊤ := QuadraticMap.subgroup_eq_top_of_reflection_mem Q hQ H fun v _ => by
-    refine MonoidHom.mem_eqLocusM.mpr ?_
-    dsimp only [f, g]
-    rw [orthogonalSpinorNorm_reflectionOrthogonal, orthogonalDetSquareClass_apply]
+    (hsq : ∀ v, IsSquare (Q v)) :
+    orthogonalSpinorNorm Q hQ = QuadraticMap.orthogonalDetSquareClass Q := by
+  have hH : @MonoidHom.eqLocus (QuadraticMap.orthogonalGroup Q) _
+      (Multiplicative (SquareClassGroup K)) _ (orthogonalSpinorNorm Q hQ)
+      (QuadraticMap.orthogonalDetSquareClass Q) = ⊤ :=
+      QuadraticMap.subgroup_eq_top_of_reflection_mem Q hQ
+        (@MonoidHom.eqLocus (QuadraticMap.orthogonalGroup Q) _
+          (Multiplicative (SquareClassGroup K)) _ (orthogonalSpinorNorm Q hQ)
+          (QuadraticMap.orthogonalDetSquareClass Q)) fun v _ => by
+    rw [MonoidHom.mem_eqLocus]
+    rw [orthogonalSpinorNorm_reflectionOrthogonal,
+      QuadraticMap.orthogonalDetSquareClass_apply]
     rw [QuadraticMap.coe_reflectionOrthogonal, QuadraticMap.det_reflection]
+    have hsquareUnit : IsSquare (unitOfInvertible (Q v)) := by
+      apply isSquare_units_val_iff.mp
+      simpa only [val_unitOfInvertible] using hsq v
     have hsquare : squareClassHom (unitOfInvertible (Q v)) = 1 := by
-      rw [squareClassHom_apply]
-      simpa only [ofAdd_zero] using congrArg Multiplicative.ofAdd
-        ((squareClass_eq_zero_iff _).2 (hsq v))
+      simpa using hsquareUnit
     rw [neg_eq_neg_one_mul, map_mul, hsquare]
     exact mul_one (squareClassHom (-1 : Kˣ))
   apply MonoidHom.ext
   intro x
-  have hx : x ∈ H := by rw [hH]; trivial
-  exact MonoidHom.mem_eqLocusM.mp hx
+  have hx : x ∈ @MonoidHom.eqLocus (QuadraticMap.orthogonalGroup Q) _
+      (Multiplicative (SquareClassGroup K)) _ (orthogonalSpinorNorm Q hQ)
+      (QuadraticMap.orthogonalDetSquareClass Q) := by
+    rw [hH]
+    exact Subgroup.mem_top x
+  exact (MonoidHom.mem_eqLocus (G := QuadraticMap.orthogonalGroup Q)
+    (M := Multiplicative (SquareClassGroup K)) (f := orthogonalSpinorNorm Q hQ)
+    (g := QuadraticMap.orthogonalDetSquareClass Q)).mp hx
 
 /-- The spinor norm on `SO(Q)`, obtained by restricting the orthogonal spinor norm. -/
 noncomputable def spinorNorm (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
@@ -369,19 +358,20 @@ theorem range_spinToSpecialOrthogonal_eq_ker_spinorNorm
     rw [coe_spinToOrthogonal_apply] at hv
     exact hv
 
-/-- If every nonzero value of a finite-dimensional nondegenerate quadratic form is a square, the
-Spin action on its special orthogonal group is surjective. -/
-theorem spinToSpecialOrthogonal_surjective_of_unit_isSquare
+/-- If every value of a finite-dimensional nondegenerate quadratic form is a square, the Spin
+action on its special orthogonal group is surjective. This differs from
+`spinToSpecialOrthogonal_surjective_of_isSquare`, which assumes that `-⅟(Q v)` is a square. -/
+theorem spinToSpecialOrthogonal_surjective_of_isSquare_apply
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
-    (hsq : ∀ v [Invertible (Q v)], IsSquare (unitOfInvertible (Q v))) :
+    (hsq : ∀ v, IsSquare (Q v)) :
     Function.Surjective (spinToSpecialOrthogonal Q) := by
   rw [← MonoidHom.range_eq_top]
   rw [range_spinToSpecialOrthogonal_eq_ker_spinorNorm Q hQ]
   rw [Subgroup.eq_top_iff']
   intro g
   rw [MonoidHom.mem_ker, spinorNorm_apply,
-    orthogonalSpinorNorm_eq_detSquareClass_of_isSquare Q hQ hsq]
-  rw [orthogonalDetSquareClass_apply]
+    orthogonalSpinorNorm_eq_detSquareClass_of_isSquare_apply Q hQ hsq]
+  rw [QuadraticMap.orthogonalDetSquareClass_apply]
   have hgdet := (QuadraticMap.mem_specialOrthogonalGroup_iff.mp g.2).2
   have hgdet' : LinearEquiv.det
       ((Subgroup.inclusion (QuadraticMap.specialOrthogonalGroup_le_orthogonalGroup Q) g :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
@@ -9,6 +9,7 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.Lipschitz.Norm
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpecialOrthogonal
 public import TauCeti.LinearAlgebra.QuadraticForm.DetSquareClass
 public import TauCeti.LinearAlgebra.QuadraticForm.Radical
+import TauCeti.Algebra.Group.Units.Basic
 import TauCeti.Algebra.Group.Subgroup.Ker
 import TauCeti.LinearAlgebra.CliffordAlgebra.CartanDieudonne
 import TauCeti.LinearAlgebra.CliffordAlgebra.Basic

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpinorNorm.lean
@@ -25,6 +25,10 @@ Spin group.
 * `CliffordAlgebra.orthogonalDetSquareClass`: the determinant modulo squares on `O(Q)`.
 * `CliffordAlgebra.orthogonalSpinorNorm`: the square-class-valued spinor norm on `O(Q)`.
 * `CliffordAlgebra.spinorNorm`: its restriction to `SO(Q)`.
+* `CliffordAlgebra.orthogonalSpinorNorm_eq_detSquareClass_of_isSquare`: when every nonzero value
+  of the form is a square, the orthogonal spinor norm is the determinant square class.
+* `CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_unit_isSquare`: the same square-value
+  hypothesis makes the Spin action surjective.
 * `CliffordAlgebra.range_spinToSpecialOrthogonal_eq_ker_spinorNorm`: the Spin image is
   the kernel of the spinor norm.
 
@@ -182,6 +186,35 @@ theorem orthogonalSpinorNorm_reflectionOrthogonal (Q : QuadraticForm K V)
   rw [← lipschitzToOrthogonal_unitι Q v, orthogonalSpinorNorm_lipschitzToOrthogonal,
     lipschitzNorm_unitι]
 
+/-- If every nonzero value of a finite-dimensional nondegenerate quadratic form is a square, its
+orthogonal spinor norm is the square class of the determinant. -/
+theorem orthogonalSpinorNorm_eq_detSquareClass_of_isSquare
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (hsq : ∀ v [Invertible (Q v)], IsSquare (unitOfInvertible (Q v))) :
+    orthogonalSpinorNorm Q hQ = orthogonalDetSquareClass Q := by
+  let f : QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
+    orthogonalSpinorNorm Q hQ
+  let g : QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
+    orthogonalDetSquareClass Q
+  let H : Subgroup (QuadraticMap.orthogonalGroup Q) :=
+    @MonoidHom.eqLocus (QuadraticMap.orthogonalGroup Q) _
+      (Multiplicative (SquareClassGroup K)) _ f g
+  have hH : H = ⊤ := QuadraticMap.subgroup_eq_top_of_reflection_mem Q hQ H fun v _ => by
+    refine MonoidHom.mem_eqLocusM.mpr ?_
+    dsimp only [f, g]
+    rw [orthogonalSpinorNorm_reflectionOrthogonal, orthogonalDetSquareClass_apply]
+    rw [QuadraticMap.coe_reflectionOrthogonal, QuadraticMap.det_reflection]
+    have hsquare : squareClassHom (unitOfInvertible (Q v)) = 1 := by
+      rw [squareClassHom_apply]
+      simpa only [ofAdd_zero] using congrArg Multiplicative.ofAdd
+        ((squareClass_eq_zero_iff _).2 (hsq v))
+    rw [neg_eq_neg_one_mul, map_mul, hsquare]
+    exact mul_one (squareClassHom (-1 : Kˣ))
+  apply MonoidHom.ext
+  intro x
+  have hx : x ∈ H := by rw [hH]; trivial
+  exact MonoidHom.mem_eqLocusM.mp hx
+
 /-- The spinor norm on `SO(Q)`, obtained by restricting the orthogonal spinor norm. -/
 noncomputable def spinorNorm (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     QuadraticMap.specialOrthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
@@ -333,5 +366,25 @@ theorem range_spinToSpecialOrthogonal_eq_ker_spinorNorm
     have hv := congrArg (fun z : QuadraticMap.orthogonalGroup Q => ((z : V ≃ₗ[K] V) v)) horth
     rw [coe_spinToOrthogonal_apply] at hv
     exact hv
+
+/-- If every nonzero value of a finite-dimensional nondegenerate quadratic form is a square, the
+Spin action on its special orthogonal group is surjective. -/
+theorem spinToSpecialOrthogonal_surjective_of_unit_isSquare
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
+    (hsq : ∀ v [Invertible (Q v)], IsSquare (unitOfInvertible (Q v))) :
+    Function.Surjective (spinToSpecialOrthogonal Q) := by
+  rw [← MonoidHom.range_eq_top]
+  rw [range_spinToSpecialOrthogonal_eq_ker_spinorNorm Q hQ]
+  rw [Subgroup.eq_top_iff']
+  intro g
+  rw [MonoidHom.mem_ker, spinorNorm_apply,
+    orthogonalSpinorNorm_eq_detSquareClass_of_isSquare Q hQ hsq]
+  rw [orthogonalDetSquareClass_apply]
+  have hgdet := (QuadraticMap.mem_specialOrthogonalGroup_iff.mp g.2).2
+  have hgdet' : LinearEquiv.det
+      ((Subgroup.inclusion (QuadraticMap.specialOrthogonalGroup_le_orthogonalGroup Q) g :
+        QuadraticMap.orthogonalGroup Q) : V ≃ₗ[K] V) = 1 := by
+    simpa only [Subgroup.coe_inclusion] using hgdet
+  rw [hgdet', map_one]
 
 end CliffordAlgebra

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Frobenius.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Frobenius.lean
@@ -57,8 +57,8 @@ variable (p : ℕ) {A : Type*} [CommRing A] [ExpChar A p]
 of its entries lies in the Frobenius-fixed subring.
 
 Stated as the equation `Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g = g` rather than
-as membership in `TauCeti.fixedSubgroup`, because `TauCeti.mem_fixedSubgroup` is a `simp` lemma
-that rewrites such a membership to this equation; this is the form `simp` reaches, matching
+as membership in `TauCeti.fixedSubgroup`, because the generic equality-locus simplifier rewrites
+such a membership to this equation; this is the form `simp` reaches, matching
 `TauCeti.Bialgebra.iterateFrobeniusPoints_eq_self_iff`. -/
 @[simp]
 theorem map_iterateFrobenius_eq_self_iff (k : ℕ) (g : Matrix.GeneralLinearGroup ι A) :

--- a/TauCeti/LinearAlgebra/QuadraticForm/DetSquareClass.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/DetSquareClass.lean
@@ -32,26 +32,14 @@ universe u v w
 
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
 
-private noncomputable def finiteLinearEquivDet [FiniteDimensional K V] :
-    (V ≃ₗ[K] V) →* Kˣ :=
-  (Units.map (LinearMap.detAux (Trunc.mk (Module.finBasis K V)))).comp
-    (LinearMap.GeneralLinearGroup.generalLinearEquiv K V).symm.toMonoidHom
-
-private theorem finiteLinearEquivDet_apply [FiniteDimensional K V] (g : V ≃ₗ[K] V) :
-    finiteLinearEquivDet g = LinearEquiv.det g := by
-  apply Units.ext
-  simp only [finiteLinearEquivDet, MonoidHom.comp_apply, Units.coe_map, LinearEquiv.coe_det]
-  rw [LinearMap.detAux_def' (Module.finBasis K V),
-    ← LinearMap.det_toMatrix (Module.finBasis K V)]
-  rfl
-
 /-- The determinant of an orthogonal transformation, reduced modulo squares. -/
 noncomputable def orthogonalDetSquareClass {N : Type w} [AddCommMonoid N] [Module K N]
     [FiniteDimensional K V]
     (Q : QuadraticMap K V N) :
     TauCeti.QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
+  let _ := Module.finBasis K V
   squareClassHom.comp <|
-    finiteLinearEquivDet.comp (TauCeti.QuadraticMap.orthogonalGroup Q).subtype
+    LinearEquiv.det.comp (TauCeti.QuadraticMap.orthogonalGroup Q).subtype
 
 /-- The determinant square-class map evaluates by taking the determinant modulo squares. -/
 @[simp]
@@ -60,6 +48,6 @@ theorem orthogonalDetSquareClass_apply {N : Type w} [AddCommMonoid N] [Module K 
     (Q : QuadraticMap K V N) (g : TauCeti.QuadraticMap.orthogonalGroup Q) :
     orthogonalDetSquareClass Q g = squareClassHom (LinearEquiv.det (g : V ≃ₗ[K] V)) := by
   rw [orthogonalDetSquareClass]
-  simp only [MonoidHom.comp_apply, Subgroup.coe_subtype, finiteLinearEquivDet_apply]
+  rfl
 
 end QuadraticMap

--- a/TauCeti/LinearAlgebra/QuadraticForm/DetSquareClass.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/DetSquareClass.lean
@@ -11,9 +11,9 @@ public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
 /-!
 # Determinant square classes of orthogonal transformations
 
-The determinant of an orthogonal transformation is a unit. Reducing that unit modulo squares gives
-a homomorphism from the orthogonal group to the square-class group. This construction only uses the
-orthogonal group and does not require a finite-dimensionality or characteristic assumption.
+The determinant of an orthogonal transformation of a finite-dimensional space is a unit. Reducing
+that unit modulo squares gives a homomorphism from the orthogonal group to the square-class group.
+This construction only uses the orthogonal group and does not require a characteristic assumption.
 
 ## Main definitions and results
 
@@ -32,19 +32,34 @@ universe u v w
 
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
 
+private noncomputable def finiteLinearEquivDet [FiniteDimensional K V] :
+    (V ≃ₗ[K] V) →* Kˣ :=
+  (Units.map (LinearMap.detAux (Trunc.mk (Module.finBasis K V)))).comp
+    (LinearMap.GeneralLinearGroup.generalLinearEquiv K V).symm.toMonoidHom
+
+private theorem finiteLinearEquivDet_apply [FiniteDimensional K V] (g : V ≃ₗ[K] V) :
+    finiteLinearEquivDet g = LinearEquiv.det g := by
+  apply Units.ext
+  simp only [finiteLinearEquivDet, MonoidHom.comp_apply, Units.coe_map, LinearEquiv.coe_det]
+  rw [LinearMap.detAux_def' (Module.finBasis K V),
+    ← LinearMap.det_toMatrix (Module.finBasis K V)]
+  rfl
+
 /-- The determinant of an orthogonal transformation, reduced modulo squares. -/
 noncomputable def orthogonalDetSquareClass {N : Type w} [AddCommMonoid N] [Module K N]
+    [FiniteDimensional K V]
     (Q : QuadraticMap K V N) :
     TauCeti.QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
   squareClassHom.comp <|
-    LinearEquiv.det.comp (TauCeti.QuadraticMap.orthogonalGroup Q).subtype
+    finiteLinearEquivDet.comp (TauCeti.QuadraticMap.orthogonalGroup Q).subtype
 
 /-- The determinant square-class map evaluates by taking the determinant modulo squares. -/
 @[simp]
 theorem orthogonalDetSquareClass_apply {N : Type w} [AddCommMonoid N] [Module K N]
+    [FiniteDimensional K V]
     (Q : QuadraticMap K V N) (g : TauCeti.QuadraticMap.orthogonalGroup Q) :
     orthogonalDetSquareClass Q g = squareClassHom (LinearEquiv.det (g : V ≃ₗ[K] V)) := by
   rw [orthogonalDetSquareClass]
-  simp only [MonoidHom.comp_apply, Subgroup.coe_subtype]
+  simp only [MonoidHom.comp_apply, Subgroup.coe_subtype, finiteLinearEquivDet_apply]
 
 end QuadraticMap

--- a/TauCeti/LinearAlgebra/QuadraticForm/DetSquareClass.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/DetSquareClass.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.FieldTheory.SquareClassGroup
+public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
+
+/-!
+# Determinant square classes of orthogonal transformations
+
+The determinant of an orthogonal transformation is a unit. Reducing that unit modulo squares gives
+a homomorphism from the orthogonal group to the square-class group. This construction only uses the
+orthogonal group and does not require a finite-dimensionality or characteristic assumption.
+
+## Main definitions and results
+
+* `QuadraticMap.orthogonalDetSquareClass`: the determinant modulo squares on `O(Q)`.
+* `QuadraticMap.orthogonalDetSquareClass_apply`: its value on an orthogonal
+  transformation.
+-/
+
+public section
+
+open TauCeti
+
+namespace QuadraticMap
+
+universe u v w
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+
+/-- The determinant of an orthogonal transformation, reduced modulo squares. -/
+noncomputable def orthogonalDetSquareClass {N : Type w} [AddCommMonoid N] [Module K N]
+    (Q : QuadraticMap K V N) :
+    TauCeti.QuadraticMap.orthogonalGroup Q →* Multiplicative (SquareClassGroup K) :=
+  squareClassHom.comp <|
+    LinearEquiv.det.comp (TauCeti.QuadraticMap.orthogonalGroup Q).subtype
+
+/-- The determinant square-class map evaluates by taking the determinant modulo squares. -/
+@[simp]
+theorem orthogonalDetSquareClass_apply {N : Type w} [AddCommMonoid N] [Module K N]
+    (Q : QuadraticMap K V N) (g : TauCeti.QuadraticMap.orthogonalGroup Q) :
+    orthogonalDetSquareClass Q g = squareClassHom (LinearEquiv.det (g : V ≃ₗ[K] V)) := by
+  rw [orthogonalDetSquareClass]
+  simp only [MonoidHom.comp_apply, Subgroup.coe_subtype]
+
+end QuadraticMap

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -25,7 +25,7 @@ its polar form is `2 • B`, and nondegeneracy passes from `B` to it as soon as 
 * `QuadraticMap.radical_prod`: the radical of an orthogonal product is the product of the radicals.
 * `QuadraticMap.Nondegenerate.ne_zero`: a nondegenerate quadratic form on a nontrivial module is
   nonzero.
-* `QuadraticMap.Anisotropic.nondegenerate`: an anisotropic quadratic form is nondegenerate when
+* `QuadraticMap.Anisotropic.nondegenerate`: an anisotropic quadratic map is nondegenerate when
   `2` is invertible.
 * `LinearMap.BilinMap.polarBilin_toQuadraticMap_of_flip`: the polar form of the quadratic form of a
   symmetric bilinear form `B` is `2 • B`.
@@ -85,11 +85,12 @@ end QuadraticMap.Nondegenerate
 
 namespace QuadraticMap.Anisotropic
 
-variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+variable {R M P : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+  [AddCommGroup P] [Module R P]
   [Invertible (2 : R)]
 
-/-- An anisotropic quadratic form is nondegenerate when `2` is invertible. -/
-theorem nondegenerate {Q : QuadraticForm R M} (hQ : Q.Anisotropic) : Q.Nondegenerate := by
+/-- An anisotropic quadratic map is nondegenerate when `2` is invertible. -/
+theorem nondegenerate {Q : QuadraticMap R M P} (hQ : Q.Anisotropic) : Q.Nondegenerate := by
   rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, Submodule.eq_bot_iff]
   intro v hv
   exact hQ v (QuadraticMap.mem_radical_iff'.mp hv).1

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -25,6 +25,7 @@ its polar form is `2 • B`, and nondegeneracy passes from `B` to it as soon as 
 * `QuadraticMap.radical_prod`: the radical of an orthogonal product is the product of the radicals.
 * `QuadraticMap.Nondegenerate.ne_zero`: a nondegenerate quadratic form on a nontrivial module is
   nonzero.
+* `QuadraticMap.Anisotropic.radical_eq_bot`: an anisotropic quadratic map has trivial radical.
 * `QuadraticMap.Anisotropic.nondegenerate`: an anisotropic quadratic map is nondegenerate when
   `2` is invertible.
 * `LinearMap.BilinMap.polarBilin_toQuadraticMap_of_flip`: the polar form of the quadratic form of a
@@ -87,13 +88,17 @@ namespace QuadraticMap.Anisotropic
 
 variable {R M P : Type*} [CommRing R] [AddCommGroup M] [Module R M]
   [AddCommGroup P] [Module R P]
-  [Invertible (2 : R)]
 
-/-- An anisotropic quadratic map is nondegenerate when `2` is invertible. -/
-theorem nondegenerate {Q : QuadraticMap R M P} (hQ : Q.Anisotropic) : Q.Nondegenerate := by
-  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, Submodule.eq_bot_iff]
+/-- An anisotropic quadratic map has trivial radical. -/
+theorem radical_eq_bot {Q : QuadraticMap R M P} (hQ : Q.Anisotropic) : Q.radical = ⊥ := by
+  rw [Submodule.eq_bot_iff]
   intro v hv
   exact hQ v (QuadraticMap.mem_radical_iff'.mp hv).1
+
+/-- An anisotropic quadratic map is nondegenerate when `2` is invertible. -/
+theorem nondegenerate [Invertible (2 : R)] {Q : QuadraticMap R M P}
+    (hQ : Q.Anisotropic) : Q.Nondegenerate :=
+  QuadraticMap.nondegenerate_iff_radical_eq_bot.mpr hQ.radical_eq_bot
 
 end QuadraticMap.Anisotropic
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -25,7 +25,7 @@ its polar form is `2 • B`, and nondegeneracy passes from `B` to it as soon as 
 * `QuadraticMap.radical_prod`: the radical of an orthogonal product is the product of the radicals.
 * `QuadraticMap.Nondegenerate.ne_zero`: a nondegenerate quadratic form on a nontrivial module is
   nonzero.
-* `QuadraticMap.PosDef.nondegenerate`: a positive-definite quadratic form is nondegenerate when
+* `QuadraticMap.Anisotropic.nondegenerate`: an anisotropic quadratic form is nondegenerate when
   `2` is invertible.
 * `LinearMap.BilinMap.polarBilin_toQuadraticMap_of_flip`: the polar form of the quadratic form of a
   symmetric bilinear form `B` is `2 • B`.
@@ -83,18 +83,18 @@ theorem ne_zero [Nontrivial M] {Q : QuadraticForm R M} (hQ : Q.Nondegenerate) : 
 
 end QuadraticMap.Nondegenerate
 
-namespace QuadraticMap.PosDef
+namespace QuadraticMap.Anisotropic
 
-variable {R M : Type*} [CommRing R] [PartialOrder R] [AddCommGroup M] [Module R M]
+variable {R M : Type*} [CommRing R] [AddCommGroup M] [Module R M]
   [Invertible (2 : R)]
 
-/-- A positive-definite quadratic form is nondegenerate when `2` is invertible. -/
-theorem nondegenerate {Q : QuadraticForm R M} (hQ : Q.PosDef) : Q.Nondegenerate := by
+/-- An anisotropic quadratic form is nondegenerate when `2` is invertible. -/
+theorem nondegenerate {Q : QuadraticForm R M} (hQ : Q.Anisotropic) : Q.Nondegenerate := by
   rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, Submodule.eq_bot_iff]
   intro v hv
-  exact hQ.anisotropic v (QuadraticMap.mem_radical_iff'.mp hv).1
+  exact hQ v (QuadraticMap.mem_radical_iff'.mp hv).1
 
-end QuadraticMap.PosDef
+end QuadraticMap.Anisotropic
 
 namespace LinearMap
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Radical.lean
@@ -25,6 +25,8 @@ its polar form is `2 • B`, and nondegeneracy passes from `B` to it as soon as 
 * `QuadraticMap.radical_prod`: the radical of an orthogonal product is the product of the radicals.
 * `QuadraticMap.Nondegenerate.ne_zero`: a nondegenerate quadratic form on a nontrivial module is
   nonzero.
+* `QuadraticMap.PosDef.nondegenerate`: a positive-definite quadratic form is nondegenerate when
+  `2` is invertible.
 * `LinearMap.BilinMap.polarBilin_toQuadraticMap_of_flip`: the polar form of the quadratic form of a
   symmetric bilinear form `B` is `2 • B`.
 * `LinearMap.BilinForm.radical_toQuadraticMap`: the radical of the quadratic form of a symmetric
@@ -80,6 +82,19 @@ theorem ne_zero [Nontrivial M] {Q : QuadraticForm R M} (hQ : Q.Nondegenerate) : 
   rwa [hQ.radical_eq_bot, Submodule.mem_bot] at hm
 
 end QuadraticMap.Nondegenerate
+
+namespace QuadraticMap.PosDef
+
+variable {R M : Type*} [CommRing R] [PartialOrder R] [AddCommGroup M] [Module R M]
+  [Invertible (2 : R)]
+
+/-- A positive-definite quadratic form is nondegenerate when `2` is invertible. -/
+theorem nondegenerate {Q : QuadraticForm R M} (hQ : Q.PosDef) : Q.Nondegenerate := by
+  rw [QuadraticMap.nondegenerate_iff_radical_eq_bot, Submodule.eq_bot_iff]
+  intro v hv
+  exact hQ.anisotropic v (QuadraticMap.mem_radical_iff'.mp hv).1
+
+end QuadraticMap.PosDef
 
 namespace LinearMap
 

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -370,9 +370,7 @@ theorem posDef_iff_sigNeg_eq_zero_and_radical_eq_bot (Q : _root_.QuadraticForm K
   constructor
   · intro hQ
     refine ⟨(forall_nonneg_iff_sigNeg_eq_zero Q).mp hQ.nonneg, ?_⟩
-    rw [Submodule.eq_bot_iff]
-    intro x hx
-    exact hQ.anisotropic x (QuadraticMap.mem_radical_iff'.mp hx).1
+    exact QuadraticMap.nondegenerate_iff_radical_eq_bot.mp hQ.anisotropic.nondegenerate
   · rintro ⟨hneg, hrad⟩
     obtain ⟨W, hWrank, hWpos⟩ := exists_finrank_eq_sigPos_and_posDef Q
     have hsig := sigPos_add_sigNeg_add_radical (Q := Q)

--- a/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Signature.lean
@@ -370,7 +370,7 @@ theorem posDef_iff_sigNeg_eq_zero_and_radical_eq_bot (Q : _root_.QuadraticForm K
   constructor
   · intro hQ
     refine ⟨(forall_nonneg_iff_sigNeg_eq_zero Q).mp hQ.nonneg, ?_⟩
-    exact QuadraticMap.nondegenerate_iff_radical_eq_bot.mp hQ.anisotropic.nondegenerate
+    exact QuadraticMap.Anisotropic.radical_eq_bot hQ.anisotropic
   · rintro ⟨hneg, hrad⟩
     obtain ⟨W, hWrank, hWpos⟩ := exists_finrank_eq_sigPos_and_posDef Q
     have hsig := sigPos_add_sigNeg_add_radical (Q := Q)

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass/Independence.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass/Independence.lean
@@ -34,15 +34,6 @@ namespace TauCeti.Multiquadratic
 
 variable {K : Type*} [Field K] {L : Type*} [Field L] [Algebra K L]
 
-/-- A unit is a square iff its underlying field element is. -/
-private theorem isSquare_units_val_iff {u : Kˣ} : IsSquare (u : K) ↔ IsSquare u := by
-  constructor
-  · rintro ⟨x, hx⟩
-    have hx0 : x ≠ 0 := fun h => u.ne_zero (by rw [hx, h, mul_zero])
-    exact ⟨Units.mk0 x hx0, Units.ext (by simpa using hx)⟩
-  · rintro ⟨v, rfl⟩
-    exact ⟨(v : K), by simp⟩
-
 /-- **The multiquadratic degree theorem, restated via linear independence.** If the square classes
 of the radicands `d : ι → Kˣ` are `ZMod 2`-linearly independent, then the field generated over `K`
 by their square roots `root i` has degree `2^|ι|`. This is `finrank_adjoin_range` consuming the

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass/Independence.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass/Independence.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.NumberTheory.Multiquadratic.Degree
 public import TauCeti.FieldTheory.SquareClassGroup
+import TauCeti.Algebra.Group.Units.Basic
 
 /-!
 # Square-class independence as `ZMod 2`-linear independence


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Packages the algebraic double cover for the compact real Spin group.

- Places determinant modulo squares at the finite-dimensional quadratic-form boundary and identifies the spinor norm with it under a field-generic square-value hypothesis.
- Proves the Spin action is onto the special orthogonal group for positive-definite real forms.
- Defines `realCliffordSpinGroup`, `realCliffordSpinGroupZero`, and `realCliffordSpinDoubleCoverZero`, with generator and projection equations.

## Roadmap target

Advances [SpinRepresentations Layer 7](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-7-real-clifford-algebras-bott-periodicity-and-spinp-q).

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#realCliffordSpinGroup"}-->

## Verification

Focused and full builds, allowed-axiom and module audits, environment/header/style/dot-notation lints, five direct and aggregate consumers, and fresh contract-first and structure-first 13-rubric aggregate reviews pass at exact head `5cb78d7b` and tree `7b25918f`.

## Scale and generality

Changes thirteen files by +330/-22. The unit-square bridge works over monoids; anisotropic radical triviality is arbitrary-codomain and characteristic-free, with nondegeneracy as its invertible-two corollary. The determinant square-class map is a standalone finite-dimensional quadratic-form API over a field and has no invertible-two assumption. Spinor-norm comparison and surjectivity are finite-dimensional field results under nondegeneracy and the direct hypothesis `∀ v, IsSquare (Q v)`. The compact real extension assumes positive dimension through `[NeZero n]`.

## Scope

- **Consumes:** square-class, orthogonal-group, spinor-norm, reflection-generation, Spin-image, and double-cover APIs.
- **Provides:** canonical unit-square and equality-locus bridges, characteristic-free anisotropic radical triviality, finite-dimensional determinant square classes, real Spin groups, surjectivity, and the compact double cover.
- **Fits:** supplies the algebraic Layer 7 boundary required by later connectivity and universal-cover results.
- **Boundary:** topology, connectedness, simple connectedness, and indefinite components remain downstream.

<sub>[rubrics](https://github.com/TauCetiProject/TauCetiReview/commit/98e9b073b76e65285fa72d4b8e0a61e272a78fd8) · fresh paired 13-rubric aggregate reviews pass · fixed: correctness, reuse, API design, generality, placement, naming, documentation, proof quality</sub>