### PR TITLE
refactor(Exchangeability): separate array symmetry from its de Finetti consequences

### DIFF
--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Probability.DeFinetti.Theorem
 public import TauCeti.Probability.Exchangeability.Family
 public import TauCeti.Probability.Exchangeability.FullyExchangeable
 public import TauCeti.Probability.Exchangeability.IID
@@ -32,9 +31,9 @@ exchangeability is the invariance a symmetric array can consistently be asked to
 The main theorem here is the first step of the standard route to the Aldous–Hoover representation:
 the **rows of a separately exchangeable array form an exchangeable sequence of random paths**
 (`SeparatelyExchangeable.fullyExchangeable_arrayRow`), so de Finetti's theorem applies to them and
-makes them conditionally i.i.d. (`SeparatelyExchangeable.conditionallyIID_arrayRow`). The value
-space of that sequence is path space `ℕ → α`, which is standard Borel whenever `α` is, so no new
-hypothesis is needed beyond the ones de Finetti already asks of `α`.
+makes them conditionally i.i.d.  That consequence is drawn in `Arrays.DeFinetti`, which is where
+this subtree meets the representation theory; the value space of the sequence is path space
+`ℕ → α`, standard Borel whenever `α` is, so it needs no hypothesis beyond de Finetti's own.
 
 ## Main definitions
 
@@ -59,9 +58,6 @@ hypothesis is needed beyond the ones de Finetti already asks of `α`.
 * `TauCeti.Probability.SeparatelyExchangeable.fullyExchangeable_arrayRow` and
   `TauCeti.Probability.SeparatelyExchangeable.fullyExchangeable_arrayCol` — the rows, and the
   columns, of a separately exchangeable array form fully exchangeable sequences of paths.
-* `TauCeti.Probability.SeparatelyExchangeable.conditionallyIID_arrayRow` — **de Finetti for the
-  rows**: over a nonempty standard Borel state space, the rows of a separately exchangeable array
-  are conditionally i.i.d.
 * `TauCeti.Probability.JointlyExchangeable.fullyExchangeable_arrayDiag` — the diagonal of a jointly
   exchangeable array is a fully exchangeable sequence.
 * `TauCeti.Probability.ExchangeableFamily.separatelyExchangeable` and
@@ -375,26 +371,6 @@ theorem JointlyExchangeable.exchangeable_arrayDiag {μ : Measure Ω} {X : ℕ ×
   FullyExchangeable.exchangeable (h.fullyExchangeable_arrayDiag hX) fun i => hX (i, i)
 
 /-! ## De Finetti for the rows -/
-
-/-- **De Finetti's theorem for the rows of a separately exchangeable array.** Over a nonempty
-standard Borel state space `α`, the rows of a separately exchangeable array are conditionally
-i.i.d. as random elements of path space `ℕ → α`.
-
-This is the first step of the standard route to the Aldous–Hoover representation. Path space is
-standard Borel because `α` is (`StandardBorelSpace.pi_countable`), so the hypotheses are exactly
-de Finetti's. -/
-theorem SeparatelyExchangeable.conditionallyIID_arrayRow [StandardBorelSpace α] [Nonempty α]
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
-    ConditionallyIID μ (arrayRow X) :=
-  deFinetti (aemeasurable_arrayRow hX) (h.exchangeable_arrayRow hX)
-
-/-- **De Finetti's theorem for the columns of a separately exchangeable array.** -/
-theorem SeparatelyExchangeable.conditionallyIID_arrayCol [StandardBorelSpace α] [Nonempty α]
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
-    ConditionallyIID μ (arrayCol X) :=
-  deFinetti (aemeasurable_arrayCol hX) (h.exchangeable_arrayCol hX)
 
 /-! ## The two symmetries are distinct -/
 

--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -370,8 +370,6 @@ theorem JointlyExchangeable.exchangeable_arrayDiag {μ : Measure Ω} {X : ℕ ×
     Exchangeable μ (arrayDiag X) :=
   FullyExchangeable.exchangeable (h.fullyExchangeable_arrayDiag hX) fun i => hX (i, i)
 
-/-! ## De Finetti for the rows -/
-
 /-! ## The two symmetries are distinct -/
 
 /-- The deterministic diagonal-indicator array over a sample space `S`: its `(i, j)` entry is

--- a/TauCeti/Probability/Exchangeability/Arrays/Block.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Block.lean
@@ -58,9 +58,6 @@ coordinates of each such pair agree.
   the chosen pair of index maps;
 * `TauCeti.Probability.JointlyExchangeable.map_arrayBlockPair_eq` — the corresponding canonical-law
   theorem for the pair-valued block;
-* `TauCeti.Probability.JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock` and
-  `TauCeti.Probability.JointlyExchangeable.conditionallyIID_arrayRow_arrayBlockPair` — de Finetti
-  for the rows of a block of a jointly exchangeable array.
 
 ## References
 
@@ -323,29 +320,6 @@ theorem JointlyExchangeable.map_arrayBlockPair_eq [IsFiniteMeasure μ] {e' f' : 
     (fun _ _ _ _ x _ hu hv =>
       Prod.ext (congrArg x (Prod.ext hu hv)) (congrArg x (Prod.ext hv hu)))
     h hX he hf hd he' hf' hd'
-
-/-! ## De Finetti for the rows of a block -/
-
-/-- **De Finetti's theorem for the rows of a block of a jointly exchangeable array.** Over a
-nonempty standard Borel state space, the rows of a block along injections with disjoint ranges are
-conditionally i.i.d. as random elements of path space. -/
-theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock [StandardBorelSpace α] [Nonempty α]
-    [IsFiniteMeasure μ] (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
-    (he : Function.Injective e) (hf : Function.Injective f)
-    (hd : Disjoint (Set.range e) (Set.range f)) :
-    ConditionallyIID μ (arrayRow (arrayBlock X e f)) :=
-  (h.separatelyExchangeable_arrayBlock hX he hf hd).conditionallyIID_arrayRow
-    (aemeasurable_arrayBlock hX)
-
-/-- **De Finetti's theorem for the rows of a block of pairs.** The conclusion simultaneously
-describes both orientations of the selected rectangular cross-block. -/
-theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlockPair [StandardBorelSpace α]
-    [Nonempty α] [IsFiniteMeasure μ] (h : JointlyExchangeable μ X)
-    (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f)
-    (hd : Disjoint (Set.range e) (Set.range f)) :
-    ConditionallyIID μ (arrayRow (arrayBlockPair X e f)) :=
-  (h.separatelyExchangeable_arrayBlockPair hX he hf hd).conditionallyIID_arrayRow
-    (aemeasurable_arrayBlockPair hX)
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
@@ -7,7 +7,7 @@ module
 
 -- Public: the array symmetry and the inherited invariance of the row mixing law are the
 -- hypothesis and the conclusion of the representation.
-public import TauCeti.Probability.Exchangeability.Arrays.MixingLaw
+public import TauCeti.Probability.Exchangeability.Arrays.DeFinetti
 -- Public: the coding map and the barycenter identity it satisfies appear in every statement.
 public import TauCeti.Probability.DeFinetti.Coding
 -- Non-public: the mixture form of a row path law is used only inside proofs.

--- a/TauCeti/Probability/Exchangeability/Arrays/DeFinetti.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/DeFinetti.lean
@@ -17,12 +17,16 @@ state space, the rows and columns of a separately exchangeable array are conditi
 are the rows of a block of a jointly exchangeable one, and the directing measures produced this way
 inherit the symmetry of the array.
 
-**This is the only file in the array subtree that reaches the de Finetti summit.** `Arrays.Basic`
-carries the symmetry predicates and their elementary theory, `Arrays.Block` the combinatorics of
-blocks, and `Arrays.MixingLaw` the results that hold of *any* supplied mixing representative. Each
-of those is now independent of `DeFinetti.Theorem`, so a file needing only array symmetry — for
-instance `Arrays.AldousHoover`, which uses four declarations from `Arrays.Basic` — no longer
-depends transitively on the whole representation theory.
+**This is the array subtree's only direct import of the de Finetti summit.** `Arrays.Coding`
+reaches `DeFinetti.Theorem` too, transitively through this module, which is as it should be: the
+coding representation is a de Finetti consequence. What changed is that the dependency now arrives
+through the one file whose subject it is.
+
+`Arrays.Basic` carries the symmetry predicates and their elementary theory, `Arrays.Block` the
+combinatorics of blocks, and `Arrays.MixingLaw` the results that hold of *any* supplied mixing
+representative. Each of those is now independent of `DeFinetti.Theorem`, so a file needing only
+array symmetry — for instance `Arrays.AldousHoover`, which uses four declarations from
+`Arrays.Basic` — no longer depends on the representation theory at all.
 
 The layering is therefore
 

--- a/TauCeti/Probability/Exchangeability/Arrays/DeFinetti.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/DeFinetti.lean
@@ -1,0 +1,126 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.Arrays.Block
+public import TauCeti.Probability.Exchangeability.Arrays.MixingLaw
+public import TauCeti.Probability.DeFinetti.Theorem
+
+/-!
+# De Finetti's theorem for exchangeable arrays
+
+The consequences of de Finetti's theorem for the array symmetries: over a nonempty standard Borel
+state space, the rows and columns of a separately exchangeable array are conditionally i.i.d., as
+are the rows of a block of a jointly exchangeable one, and the directing measures produced this way
+inherit the symmetry of the array.
+
+**This is the only file in the array subtree that reaches the de Finetti summit.** `Arrays.Basic`
+carries the symmetry predicates and their elementary theory, `Arrays.Block` the combinatorics of
+blocks, and `Arrays.MixingLaw` the results that hold of *any* supplied mixing representative. Each
+of those is now independent of `DeFinetti.Theorem`, so a file needing only array symmetry — for
+instance `Arrays.AldousHoover`, which uses four declarations from `Arrays.Basic` — no longer
+depends transitively on the whole representation theory.
+
+The layering is therefore
+
+```text
+array symmetry  →  consequences of a supplied mixture  →  de Finetti supplies one  →  coding
+```
+
+## Main results
+
+* `SeparatelyExchangeable.conditionallyIID_arrayRow` and `…_arrayCol` — de Finetti for the rows and
+  columns;
+* `JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock` and `…_arrayBlockPair` — de Finetti
+  for the rows of a block;
+* `SeparatelyExchangeable.exists_directing_arrayRow_mixingLaw_invariant` and `…_arrayCol…` — a
+  directing measure whose law inherits the array's symmetry.
+-/
+
+public section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α Ω : Type*} [MeasurableSpace α] [MeasurableSpace Ω] {μ : Measure Ω}
+  {X : ℕ × ℕ → Ω → α} {e f : ℕ → ℕ}
+
+/-- **De Finetti's theorem for the rows of a separately exchangeable array.** Over a nonempty
+standard Borel state space `α`, the rows of a separately exchangeable array are conditionally
+i.i.d. as random elements of path space `ℕ → α`.
+
+This is the first step of the standard route to the Aldous–Hoover representation. Path space is
+standard Borel because `α` is (`StandardBorelSpace.pi_countable`), so the hypotheses are exactly
+de Finetti's. -/
+theorem SeparatelyExchangeable.conditionallyIID_arrayRow [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    ConditionallyIID μ (arrayRow X) :=
+  deFinetti (aemeasurable_arrayRow hX) (h.exchangeable_arrayRow hX)
+
+/-- **De Finetti's theorem for the columns of a separately exchangeable array.** -/
+theorem SeparatelyExchangeable.conditionallyIID_arrayCol [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    ConditionallyIID μ (arrayCol X) :=
+  deFinetti (aemeasurable_arrayCol hX) (h.exchangeable_arrayCol hX)
+
+
+/-- **De Finetti's theorem for the rows of a block of a jointly exchangeable array.** Over a
+nonempty standard Borel state space, the rows of a block along injections with disjoint ranges are
+conditionally i.i.d. as random elements of path space. -/
+theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock [StandardBorelSpace α] [Nonempty α]
+    [IsFiniteMeasure μ] (h : JointlyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f)) :
+    ConditionallyIID μ (arrayRow (arrayBlock X e f)) :=
+  (h.separatelyExchangeable_arrayBlock hX he hf hd).conditionallyIID_arrayRow
+    (aemeasurable_arrayBlock hX)
+
+/-- **De Finetti's theorem for the rows of a block of pairs.** The conclusion simultaneously
+describes both orientations of the selected rectangular cross-block. -/
+theorem JointlyExchangeable.conditionallyIID_arrayRow_arrayBlockPair [StandardBorelSpace α]
+    [Nonempty α] [IsFiniteMeasure μ] (h : JointlyExchangeable μ X)
+    (hX : ∀ p, AEMeasurable (X p) μ) (he : Function.Injective e) (hf : Function.Injective f)
+    (hd : Disjoint (Set.range e) (Set.range f)) :
+    ConditionallyIID μ (arrayRow (arrayBlockPair X e f)) :=
+  (h.separatelyExchangeable_arrayBlockPair hX he hf hd).conditionallyIID_arrayRow
+    (aemeasurable_arrayBlockPair hX)
+
+
+/-- **De Finetti for the rows, with the inherited mixing-law symmetry.** A separately
+exchangeable array has a directing measure for its row process whose law is invariant under every
+permutation of the path coordinates. -/
+theorem SeparatelyExchangeable.exists_directing_arrayRow_mixingLaw_invariant
+    [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    ∃ ν : Ω → ProbabilityMeasure (ℕ → α), ConditionallyIIDWith μ (arrayRow X) ν ∧
+      ∀ τ : Equiv.Perm ℕ,
+        μ.map (fun ω ↦ (ν ω).map (measurable_reindex τ).aemeasurable) = μ.map ν := by
+  obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayRow hX).exists_directing
+  exact ⟨ν, hν, fun τ ↦
+    h.mixingLaw_map_permReindex_arrayRow_eq (mixedIIDWith_of_conditionallyIIDWith hν) τ⟩
+
+/-- **De Finetti for the columns, with the inherited mixing-law symmetry.** -/
+theorem SeparatelyExchangeable.exists_directing_arrayCol_mixingLaw_invariant
+    [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    ∃ ν : Ω → ProbabilityMeasure (ℕ → α), ConditionallyIIDWith μ (arrayCol X) ν ∧
+      ∀ σ : Equiv.Perm ℕ,
+        μ.map (fun ω ↦ (ν ω).map (measurable_reindex σ).aemeasurable) = μ.map ν := by
+  obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayCol hX).exists_directing
+  exact ⟨ν, hν, fun σ ↦
+    h.mixingLaw_map_permReindex_arrayCol_eq (mixedIIDWith_of_conditionallyIIDWith hν) σ⟩
+
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
@@ -43,9 +43,9 @@ of the Aldous–Hoover milestone in `TauCetiRoadmap/Exchangeability/README.md`, 
 * `SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq` — the row mixing law is invariant
   under coordinate permutations;
 * `SeparatelyExchangeable.mixingLaw_map_permReindex_arrayCol_eq` — the symmetric column statement;
-* `SeparatelyExchangeable.exists_directing_arrayRow_mixingLaw_invariant` and
-  `SeparatelyExchangeable.exists_directing_arrayCol_mixingLaw_invariant` — directing-measure
-  versions supplied by de Finetti.
+
+Every result here holds of *any* supplied mixing representative; the existential versions, in which
+de Finetti produces one, are in `Arrays.DeFinetti`.
 
 ## References
 
@@ -173,32 +173,6 @@ theorem SeparatelyExchangeable.mixingLaw_map_permReindex_arrayCol_eq
     μ.map (fun ω ↦ (ν ω).map (measurable_reindex σ).aemeasurable) = μ.map ν :=
   mixingLaw_map_permReindex_arrayCol_eq_of_row_invariant
     (separatelyExchangeable_iff.mp h σ 1) hν
-
-/-- **De Finetti for the rows, with the inherited mixing-law symmetry.** A separately
-exchangeable array has a directing measure for its row process whose law is invariant under every
-permutation of the path coordinates. -/
-theorem SeparatelyExchangeable.exists_directing_arrayRow_mixingLaw_invariant
-    [StandardBorelSpace α] [Nonempty α]
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
-    ∃ ν : Ω → ProbabilityMeasure (ℕ → α), ConditionallyIIDWith μ (arrayRow X) ν ∧
-      ∀ τ : Equiv.Perm ℕ,
-        μ.map (fun ω ↦ (ν ω).map (measurable_reindex τ).aemeasurable) = μ.map ν := by
-  obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayRow hX).exists_directing
-  exact ⟨ν, hν, fun τ ↦
-    h.mixingLaw_map_permReindex_arrayRow_eq (mixedIIDWith_of_conditionallyIIDWith hν) τ⟩
-
-/-- **De Finetti for the columns, with the inherited mixing-law symmetry.** -/
-theorem SeparatelyExchangeable.exists_directing_arrayCol_mixingLaw_invariant
-    [StandardBorelSpace α] [Nonempty α]
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
-    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
-    ∃ ν : Ω → ProbabilityMeasure (ℕ → α), ConditionallyIIDWith μ (arrayCol X) ν ∧
-      ∀ σ : Equiv.Perm ℕ,
-        μ.map (fun ω ↦ (ν ω).map (measurable_reindex σ).aemeasurable) = μ.map ν := by
-  obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayCol hX).exists_directing
-  exact ⟨ν, hν, fun σ ↦
-    h.mixingLaw_map_permReindex_arrayCol_eq (mixedIIDWith_of_conditionallyIIDWith hν) σ⟩
 
 end Probability
 


### PR DESCRIPTION
`Arrays/Basic.lean` — reindexing, rows and columns, the two symmetry predicates, their law read-offs — publicly imported `TauCeti.Probability.DeFinetti.Theorem`, for two terminal corollaries at the very end of the file. Everything downstream of the array foundations inherited the whole representation theory to get the definition of `SeparatelyExchangeable`.

This PR moves the six de Finetti-dependent declarations into a new `Arrays/DeFinetti.lean`. **No new mathematics, no renames, no forwarding modules or aliases** — the declarations move unchanged, with their docstrings.

| from | moved |
|---|---|
| `Arrays/Basic.lean` | `SeparatelyExchangeable.conditionallyIID_arrayRow`, `…_arrayCol` |
| `Arrays/Block.lean` | `JointlyExchangeable.conditionallyIID_arrayRow_arrayBlock`, `…_arrayBlockPair` |
| `Arrays/MixingLaw.lean` | `SeparatelyExchangeable.exists_directing_array{Row,Col}_mixingLaw_invariant` |

## The closure reduction

Whether each array module still reaches `DeFinetti.Theorem`, transitively:

| module | before | after |
|---|---|---|
| `Basic` | yes | **no** |
| `Block` | yes | **no** |
| `MixingLaw` | yes | **no** |
| `AldousHoover` | yes | **no** |
| `Dissociated` | yes | **no** |
| `Coding` | yes | yes |
| `DeFinetti` (new) | — | yes |

Five of the seven modules now stop at the array foundations. `AldousHoover.lean` is the sharpest case: it uses exactly four declarations from `Arrays/Basic` — the two symmetry predicates and their two `_iff` lemmas — and mentions nothing from the representation theory at all, yet reached the summit purely because those definitions share a file with two corollaries that need it. The same held for `Dissociated.lean`.

## The resulting layering

```text
array symmetry  →  consequences of a supplied mixture  →  de Finetti supplies one  →  coding
   Basic, Block            MixingLaw                        DeFinetti                Coding
```

`MixingLaw.lean` becomes witness-level only: every result there now holds of *any* supplied mixing representative, and the existential versions, where de Finetti produces one, sit in the new module. `Block.lean` becomes purely combinatorial. Its module docstring says so.

`Arrays/Coding.lean` is the only consumer of the moved declarations and imports the new module in their place.

## Docstrings

The three source files' headers referenced the moved declarations in six places. Rather than delete every mention, the motivating sentence in `Basic.lean` is kept and repointed — the fact that de Finetti applies to the rows is *why* the row/column machinery exists, so removing it would lose the reason the file is shaped the way it is — while the Main-results bullets for the moved declarations are dropped, since those results are no longer in those files.

No `Arrays.lean` facade is added: it has no demonstrated consumer, and the deliberate exclusion of the heavier array theory from the core `Exchangeability.lean` facade remains sensible.

## Roadmap

Roadmap: Exchangeability

A dependency-boundary reorganization of existing code. No roadmap target is claimed and no new mathematics is added.

🤖 Directed by Cameron Freer, drafted by Opus 5
