### PR TITLE
feat(MordellWeil): the two norms the 2-descent reads its condition off

### DIFF
--- a/TauCeti/Algebra/Polynomial/LinearFactor.lean
+++ b/TauCeti/Algebra/Polynomial/LinearFactor.lean
@@ -8,22 +8,29 @@ module
 public import Mathlib.Algebra.Polynomial.Div
 
 /-!
-# Polynomials of degree at most one with a prescribed root
+# The linear factor `X - C x`, and its reverse
 
-Mathlib's `Polynomial.dvd_iff_isRoot` factors `X - C x` out of any polynomial vanishing at `x`,
-but leaves the cofactor unidentified. When the polynomial has degree at most one the cofactor is
-forced to be a constant, so the polynomial is `C γ * (X - C x)` for a single scalar `γ`. That
+Two facts about linear factors that Mathlib does not carry.
+
+The *reversed* factor `C x - X` — the shape that arises as `x - θ` in `AdjoinRoot f` — has degree
+`1`, like `X - C x` itself, which is the form Mathlib states.
+
+And Mathlib's `Polynomial.dvd_iff_isRoot` factors `X - C x` out of any polynomial vanishing at
+`x`, but leaves the cofactor unidentified. When the polynomial has degree at most one the cofactor
+is forced to be a constant, so the polynomial is `C γ * (X - C x)` for a single scalar `γ`. That
 sharpened form is what is needed to read off the *coefficient* of a linear factor, which
 `Polynomial.eq_X_add_C_of_natDegree_le_one` does not give once a root is prescribed.
 
 ## Main results
 
+* `Polynomial.natDegree_C_sub_X`: the reversed linear factor `C x - X` has degree `1`.
 * `Polynomial.exists_eq_C_mul_X_sub_C_of_natDegree_le_one`: a polynomial of `natDegree ≤ 1` with
   root `x` is `C γ * (X - C x)` for some `γ`.
 
 ## Provenance
 
-Adapted, with the author's proof, from Michael Stoll's `EllipticCurves` project
+`exists_eq_C_mul_X_sub_C_of_natDegree_le_one` is adapted, with the author's proof, from Michael
+Stoll's `EllipticCurves` project
 (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
 `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`), `EllipticCurves/Mathlib/Basic.lean`.
 Its consumer is the `x - T` descent map of
@@ -36,6 +43,11 @@ public section
 namespace Polynomial
 
 variable {R : Type*} [CommRing R]
+
+/-- The reversed linear polynomial `C x - X` has degree `1`, like `X - C x`. -/
+@[simp]
+theorem natDegree_C_sub_X [Nontrivial R] (x : R) : (C x - X).natDegree = 1 := by
+  rw [natDegree_sub, natDegree_X_sub_C]
 
 /-- A polynomial of degree at most one with prescribed root `x` is a scalar multiple of
 `X - C x`. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -17,6 +17,8 @@ public import TauCeti.Algebra.Group.MapMulMulEqOne
 public import TauCeti.Algebra.Polynomial.LinearFactor
 public import TauCeti.RingTheory.AdjoinRoot
 import TauCeti.Algebra.Group.PowMonoidHom
+import TauCeti.RingTheory.Polynomial.Resultant.AdjoinRoot
+import TauCeti.RingTheory.Polynomial.Resultant.Basic
 
 /-!
 # The `x - T` map of an elliptic curve into its étale algebra
@@ -356,6 +358,58 @@ lemma exists_X_sub_C_mul_eq (r s t : K) (hr : r ≠ 0) :
     simp
   refine ⟨s / r - W.a₂, t - W.a₄ * r - s ^ 2 / r + W.a₂ * s,
     -W.a₆ * r - t * s / r + W.a₂ * t, ?_, ?_, ?_⟩ <;> field
+
+/-!
+### The two norms the descent needs
+
+`AdjoinRoot.norm_mk_eq_resultant` turns a norm on `W.A` into a resultant of `f`, and Mathlib's
+resultant algebra then evaluates it. The two values below are the ones the norm condition on the
+image of the descent map is read off from: the norm of `x - T`, and — at a root of `f`, where
+`x - T` is not a unit and the corrected representative `x - T + fCofactor x` is used instead —
+the norm of that corrected representative, which is a square.
+-/
+
+/-- **The norm of `x - T` is `f x`.** -/
+theorem norm_mk_C_sub_X (x : K) :
+    Algebra.norm K (AdjoinRoot.mk W.f (C x - X)) = W.f.eval x := by
+  have hd : (C x - X).natDegree = 1 := by compute_degree!
+  rw [AdjoinRoot.norm_mk_eq_resultant W.monic_f, hd, resultant_C_sub_X _ _ _ le_rfl]
+
+/-- **At a root of `f` the norm of the corrected representative is a square.** If `x` is a root
+of `f` then `x - T + fCofactor x` — the element `μX` uses on that branch, and the one representing
+`f' θ` there — has norm `(f' x) ²`. The factorization `f = fCofactor x * (X - C x)` splits the
+resultant into two factors, each equal to `(fCofactor x).eval x = f' x`. -/
+theorem norm_mk_C_sub_X_add_fCofactor {x : K} (hx : W.f.eval x = 0) :
+    Algebra.norm K (AdjoinRoot.mk W.f (C x - X + W.fCofactor x))
+      = (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
+  have hq : (W.fCofactor x).natDegree = 2 := W.natDegree_fCofactor x
+  have hqx : (W.fCofactor x).eval x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ :=
+    W.eval_fCofactor_self x
+  have hp : (C x - X + W.fCofactor x).natDegree = 2 := by
+    simp only [fCofactor]
+    compute_degree!
+  have hpx : (C x - X + W.fCofactor x).eval x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ := by
+    rw [eval_add, ← hqx]
+    simp
+  rw [AdjoinRoot.norm_mk_eq_resultant W.monic_f, hp, W.natDegree_f]
+  conv_lhs => rw [W.f_eq_mul_of_eval_eq_zero hx]
+  rw [show (3 : ℕ) = (W.fCofactor x).natDegree + (X - C x).natDegree by
+        rw [hq, natDegree_X_sub_C],
+    resultant_mul_left _ _ _ 2 hp.le, hq, natDegree_X_sub_C]
+  -- the factor coming from `X - C x` is the value at `x`
+  rw [show (X - C x) = (X - C x) ^ 1 by rw [pow_one],
+    resultant_X_sub_C_pow_left _ _ _ _ hp.le, pow_one, hpx]
+  -- the factor coming from `fCofactor x` is a resultant against `C x - X`, since
+  -- `fCofactor x` is monic of degree `2` and the added multiple of it drops out
+  have hres : (W.fCofactor x).resultant (C x - X) 2 2 = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ := by
+    have h := resultant_add_right_deg (W.fCofactor x) (C x - X) 2 1 1 (by compute_degree!)
+    simp only [show (1 : ℕ) + 1 = 2 from rfl, pow_one] at h
+    rw [h, show (W.fCofactor x).coeff 2 = 1 by
+        rw [← hq]; exact (W.monic_fCofactor x).coeff_natDegree,
+      one_mul, resultant_C_sub_X _ _ _ hq.le, hqx]
+  rw [show C x - X + W.fCofactor x = (C x - X) + W.fCofactor x * 1 by ring,
+    resultant_add_mul_right (W.fCofactor x) (C x - X) 1 2 2 (by simp) hq.le, hres]
+  ring
 
 /-- The étale algebra associated to the cofactor of `f`. -/
 abbrev A' (x : K) : Type _ := AdjoinRoot (W.fCofactor x)

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -18,7 +18,6 @@ public import TauCeti.Algebra.Polynomial.LinearFactor
 public import TauCeti.RingTheory.AdjoinRoot
 import TauCeti.Algebra.Group.PowMonoidHom
 import TauCeti.RingTheory.Polynomial.Resultant.AdjoinRoot
-import TauCeti.RingTheory.Polynomial.Resultant.Basic
 
 /-!
 # The `x - T` map of an elliptic curve into its étale algebra
@@ -377,7 +376,9 @@ condition needs, the norm of `x - T` itself on the branch where that is already 
 /-- **At a root of `f` the norm of the corrected representative is a square.** If `x` is a root
 of `f` then `x - T + fCofactor x` — the element `μX` uses on that branch — has norm `(f' x) ^ 2`,
 where `f' x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄` is `derivative_f` evaluated at `x`. Being a square
-is what makes its class in `W.M` trivial. -/
+makes that *norm* trivial in the square classes of `K`, which is the condition Step 5 puts on the
+image of `μ`. It does not make the class of `x - T + fCofactor x` itself trivial in `W.M`: that
+would say the element is a square in `W.Aˣ`, which is a different and stronger statement. -/
 theorem norm_mk_C_sub_X_add_fCofactor {x : K} (hx : W.f.eval x = 0) :
     Algebra.norm K (AdjoinRoot.mk W.f (C x - X + W.fCofactor x))
       = (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -59,6 +59,9 @@ what makes the corrected element a unit. Both branches are packaged in `μX`, an
   kernel is exhibited as `2 • P` by solving the identity of `exists_eq_two_smul_iff` from a square
   root of `x - T`, in two cases according to whether the `x`-coordinate is a root of `f`; the
   point-wise statement is `WeierstrassCurve.Affine.eq_two_smul_of_μ_eq_one`.
+* `WeierstrassCurve.Affine.norm_mk_C_sub_X_add_fCofactor`: at a root of `f`, the corrected
+  representative `x - T + fCofactor x` has norm `(f' x) ^ 2`. This is the value the norm condition
+  on the image of the descent map is read off from at the `2`-torsion.
 
 `WeierstrassCurve.Affine.A` is the étale algebra and `WeierstrassCurve.Affine.M` its group of
 square classes of units; `M` is spelled as a quotient of `W.Aˣ` by the range of Mathlib's
@@ -87,10 +90,10 @@ Two changes were made against the source. Stoll defines the square classes throu
 abbreviation `Units.modPow`; here they are the quotient by `(powMonoidHom 2).range` directly, so
 that TauCeti carries a single spelling of square classes. In the kernel proofs this replaces the
 source's `Units.modPow.unit_eq_one_iff` step by `TauCeti.mk_eq_one_iff_exists_pow`, which says
-the same thing about this spelling, for any commutative monoid. The two norm computations
-`norm_mk_C_sub_X` and `norm_mk_C_sub_X_add_fCofactor` are the source's Step 5 opening,
-`WeakMordellWeil.lean` lines 277-313, with the goal-reshaping `show` terms of the second replaced
-by named local facts; the rest of that step, the induced norm map on square classes, is not here.
+the same thing about this spelling, for any commutative monoid. `norm_mk_C_sub_X_add_fCofactor`
+is the source's Step 5 opening, `WeakMordellWeil.lean` lines 284-313, specialised here from the
+general `AdjoinRoot.norm_mk_C_sub_X_add`, which carries that attribution; the rest of that step,
+the induced norm map on square classes, is not here.
 
 This advances `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6 (README:790-838), whose
 description of this route is "the `x - θ` map into the étale algebra `A = K[X]/(f)`".
@@ -361,67 +364,25 @@ lemma exists_X_sub_C_mul_eq (r s t : K) (hr : r ≠ 0) :
     -W.a₆ * r - t * s / r + W.a₂ * t, ?_, ?_, ?_⟩ <;> field
 
 /-!
-### The two norms the descent needs
+### The norm at the `2`-torsion
 
-`AdjoinRoot.norm_mk_eq_resultant` turns a norm on `W.A` into a resultant of `f`, and Mathlib's
-resultant algebra then evaluates it. The two values below are the ones the norm condition on the
-image of the descent map is read off from: the norm of `x - T`, and — at a root of `f`, where
-`x - T` is not a unit and the corrected representative `x - T + fCofactor x` is used instead —
-the norm of that corrected representative, which is a square.
-
-Both are adapted from Michael Stoll's `EllipticCurves`
-(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
-`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
-`EllipticCurves/WeakMordellWeil.lean` lines 277-313, which open that file's Step 5. The statements
-and the arguments are the author's; the second proof's goal-reshaping `show` terms are replaced
-here by named local facts.
+At a root `x` of `f` the descent map uses the corrected representative `x - T + fCofactor x`, and
+the norm condition on the image of the map is read off from its norm, which is a square. The
+computation is `AdjoinRoot.norm_mk_C_sub_X_add`, stated there for any monic polynomial split off
+a linear factor; here it is specialised to `f = fCofactor x * (X - C x)`. The other value the
+condition needs, the norm of `x - T` itself on the branch where that is already a unit, is
+`AdjoinRoot.norm_mk_C_sub_X W.monic_f x`.
 -/
 
-/-- **The norm of `x - T` is `f x`.** -/
-theorem norm_mk_C_sub_X (x : K) :
-    Algebra.norm K (AdjoinRoot.mk W.f (C x - X)) = W.f.eval x := by
-  have hd : (C x - X).natDegree = 1 := by compute_degree!
-  rw [AdjoinRoot.norm_mk_eq_resultant W.monic_f, hd, resultant_C_sub_X _ _ _ le_rfl]
-
 /-- **At a root of `f` the norm of the corrected representative is a square.** If `x` is a root
-of `f` then `x - T + fCofactor x` — the element `μX` uses on that branch — has norm `(f' x) ^ 2`.
-The factorization `f = fCofactor x * (X - C x)` splits the resultant into two factors, each equal
-to `(fCofactor x).eval x = f' x`. -/
+of `f` then `x - T + fCofactor x` — the element `μX` uses on that branch — has norm `(f' x) ^ 2`,
+where `f' x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄` is `derivative_f` evaluated at `x`. Being a square
+is what makes its class in `W.M` trivial. -/
 theorem norm_mk_C_sub_X_add_fCofactor {x : K} (hx : W.f.eval x = 0) :
     Algebra.norm K (AdjoinRoot.mk W.f (C x - X + W.fCofactor x))
       = (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
-  have hq : (W.fCofactor x).natDegree = 2 := W.natDegree_fCofactor x
-  have hqx : (W.fCofactor x).eval x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ :=
-    W.eval_fCofactor_self x
-  have hp : (C x - X + W.fCofactor x).natDegree = 2 := by
-    simp only [fCofactor]
-    compute_degree!
-  have hpx : (C x - X + W.fCofactor x).eval x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ := by
-    rw [eval_add, ← hqx]
-    simp
-  -- `natDegree f = 3` written as the sum of the degrees of the two factors, which is the shape
-  -- `resultant_mul_left` splits
-  have hdeg : (W.fCofactor x).natDegree + (X - C x : K[X]).natDegree = 3 := by
-    rw [hq, natDegree_X_sub_C]
-  -- `fCofactor x` is monic of degree `2`
-  have hlead : (W.fCofactor x).coeff 2 = 1 := by
-    rw [← hq]
-    exact (W.monic_fCofactor x).coeff_natDegree
-  -- the corrected representative is `C x - X` plus a multiple of `fCofactor x`
-  have hmul : C x - X + W.fCofactor x = (C x - X) + W.fCofactor x * 1 := by ring
-  rw [AdjoinRoot.norm_mk_eq_resultant W.monic_f, hp, W.natDegree_f]
-  conv_lhs => rw [W.f_eq_mul_of_eval_eq_zero hx]
-  rw [← hdeg, resultant_mul_left _ _ _ 2 hp.le, hq, natDegree_X_sub_C]
-  -- the factor coming from `X - C x` is the value at `x`
-  rw [← pow_one (X - C x : K[X]), resultant_X_sub_C_pow_left _ _ _ _ hp.le, pow_one, hpx]
-  -- the factor coming from `fCofactor x` is a resultant against `C x - X`, since
-  -- `fCofactor x` is monic of degree `2` and the added multiple of it drops out
-  have hres : (W.fCofactor x).resultant (C x - X) 2 2 = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ := by
-    have h := resultant_add_right_deg (W.fCofactor x) (C x - X) 2 1 1 (by compute_degree!)
-    simp only [one_add_one_eq_two, pow_one] at h
-    rw [h, hlead, one_mul, resultant_C_sub_X _ _ _ hq.le, hqx]
-  rw [hmul, resultant_add_mul_right (W.fCofactor x) (C x - X) 1 2 2 (by simp) hq.le, hres]
-  ring
+  rw [AdjoinRoot.norm_mk_C_sub_X_add (W.monic_fCofactor x) (W.natDegree_fCofactor x).ge
+    (W.f_eq_mul_of_eval_eq_zero hx), W.eval_fCofactor_self]
 
 /-- The étale algebra associated to the cofactor of `f`. -/
 abbrev A' (x : K) : Type _ := AdjoinRoot (W.fCofactor x)
@@ -948,8 +909,7 @@ private lemma eq_two_smul_of_μ_eq_one_of_ne (hμ : (μ <| .ofAdd <| .some x y h
       (W.degree_lt_degree_f (by compute_degree!))
       (W.degree_lt_degree_f (by compute_degree!))] at hz
     apply_fun natDegree at hz
-    have hd : (C x - X).natDegree = 1 := by compute_degree!
-    rw [natDegree_pow, hd] at hz
+    rw [natDegree_pow, natDegree_C_sub_X] at hz
     lia
   obtain ⟨ξ, l, m, H⟩ := W.exists_X_sub_C_mul_eq r s t hr
   rw [← map_mul] at H
@@ -980,8 +940,7 @@ private lemma eq_two_smul_of_μ_eq_one_of_eq (hμ : (μ <| .ofAdd <| .some x y h
         (W.degree_lt_degree_fCofactor x (by compute_degree!))
         (W.degree_lt_degree_fCofactor x (by compute_degree!))] at hz'
     apply_fun natDegree at hz'
-    have hd : (C x - X).natDegree = 1 := by compute_degree!
-    rw [natDegree_pow, hd] at hz'
+    rw [natDegree_pow, natDegree_C_sub_X] at hz'
     lia
   rw [← map_pow, AdjoinRoot.mk_eq_mk] at hz'
   exact ⟨-s / r, 1 / r, -x / r, AdjoinRoot.mk_eq_mk.mpr (W.f_dvd_of_fCofactor_dvd hx hr₀ hz')⟩

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -87,9 +87,10 @@ Two changes were made against the source. Stoll defines the square classes throu
 abbreviation `Units.modPow`; here they are the quotient by `(powMonoidHom 2).range` directly, so
 that TauCeti carries a single spelling of square classes. In the kernel proofs this replaces the
 source's `Units.modPow.unit_eq_one_iff` step by `TauCeti.mk_eq_one_iff_exists_pow`, which says
-the same thing about this spelling, for any commutative monoid. And the two lemmas computing the
-norm of `x - T` are not part of this file: they belong to the source's Step 5, which the
-finiteness result does not use.
+the same thing about this spelling, for any commutative monoid. The two norm computations
+`norm_mk_C_sub_X` and `norm_mk_C_sub_X_add_fCofactor` are the source's Step 5 opening,
+`WeakMordellWeil.lean` lines 277-313, with the goal-reshaping `show` terms of the second replaced
+by named local facts; the rest of that step, the induced norm map on square classes, is not here.
 
 This advances `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6 (README:790-838), whose
 description of this route is "the `x - θ` map into the étale algebra `A = K[X]/(f)`".
@@ -367,6 +368,13 @@ resultant algebra then evaluates it. The two values below are the ones the norm 
 image of the descent map is read off from: the norm of `x - T`, and — at a root of `f`, where
 `x - T` is not a unit and the corrected representative `x - T + fCofactor x` is used instead —
 the norm of that corrected representative, which is a square.
+
+Both are adapted from Michael Stoll's `EllipticCurves`
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+`EllipticCurves/WeakMordellWeil.lean` lines 277-313, which open that file's Step 5. The statements
+and the arguments are the author's; the second proof's goal-reshaping `show` terms are replaced
+here by named local facts.
 -/
 
 /-- **The norm of `x - T` is `f x`.** -/
@@ -376,9 +384,9 @@ theorem norm_mk_C_sub_X (x : K) :
   rw [AdjoinRoot.norm_mk_eq_resultant W.monic_f, hd, resultant_C_sub_X _ _ _ le_rfl]
 
 /-- **At a root of `f` the norm of the corrected representative is a square.** If `x` is a root
-of `f` then `x - T + fCofactor x` — the element `μX` uses on that branch, and the one representing
-`f' θ` there — has norm `(f' x) ²`. The factorization `f = fCofactor x * (X - C x)` splits the
-resultant into two factors, each equal to `(fCofactor x).eval x = f' x`. -/
+of `f` then `x - T + fCofactor x` — the element `μX` uses on that branch — has norm `(f' x) ^ 2`.
+The factorization `f = fCofactor x * (X - C x)` splits the resultant into two factors, each equal
+to `(fCofactor x).eval x = f' x`. -/
 theorem norm_mk_C_sub_X_add_fCofactor {x : K} (hx : W.f.eval x = 0) :
     Algebra.norm K (AdjoinRoot.mk W.f (C x - X + W.fCofactor x))
       = (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
@@ -391,24 +399,28 @@ theorem norm_mk_C_sub_X_add_fCofactor {x : K} (hx : W.f.eval x = 0) :
   have hpx : (C x - X + W.fCofactor x).eval x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ := by
     rw [eval_add, ← hqx]
     simp
+  -- `natDegree f = 3` written as the sum of the degrees of the two factors, which is the shape
+  -- `resultant_mul_left` splits
+  have hdeg : (W.fCofactor x).natDegree + (X - C x : K[X]).natDegree = 3 := by
+    rw [hq, natDegree_X_sub_C]
+  -- `fCofactor x` is monic of degree `2`
+  have hlead : (W.fCofactor x).coeff 2 = 1 := by
+    rw [← hq]
+    exact (W.monic_fCofactor x).coeff_natDegree
+  -- the corrected representative is `C x - X` plus a multiple of `fCofactor x`
+  have hmul : C x - X + W.fCofactor x = (C x - X) + W.fCofactor x * 1 := by ring
   rw [AdjoinRoot.norm_mk_eq_resultant W.monic_f, hp, W.natDegree_f]
   conv_lhs => rw [W.f_eq_mul_of_eval_eq_zero hx]
-  rw [show (3 : ℕ) = (W.fCofactor x).natDegree + (X - C x).natDegree by
-        rw [hq, natDegree_X_sub_C],
-    resultant_mul_left _ _ _ 2 hp.le, hq, natDegree_X_sub_C]
+  rw [← hdeg, resultant_mul_left _ _ _ 2 hp.le, hq, natDegree_X_sub_C]
   -- the factor coming from `X - C x` is the value at `x`
-  rw [show (X - C x) = (X - C x) ^ 1 by rw [pow_one],
-    resultant_X_sub_C_pow_left _ _ _ _ hp.le, pow_one, hpx]
+  rw [← pow_one (X - C x : K[X]), resultant_X_sub_C_pow_left _ _ _ _ hp.le, pow_one, hpx]
   -- the factor coming from `fCofactor x` is a resultant against `C x - X`, since
   -- `fCofactor x` is monic of degree `2` and the added multiple of it drops out
   have hres : (W.fCofactor x).resultant (C x - X) 2 2 = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄ := by
     have h := resultant_add_right_deg (W.fCofactor x) (C x - X) 2 1 1 (by compute_degree!)
-    simp only [show (1 : ℕ) + 1 = 2 from rfl, pow_one] at h
-    rw [h, show (W.fCofactor x).coeff 2 = 1 by
-        rw [← hq]; exact (W.monic_fCofactor x).coeff_natDegree,
-      one_mul, resultant_C_sub_X _ _ _ hq.le, hqx]
-  rw [show C x - X + W.fCofactor x = (C x - X) + W.fCofactor x * 1 by ring,
-    resultant_add_mul_right (W.fCofactor x) (C x - X) 1 2 2 (by simp) hq.le, hres]
+    simp only [one_add_one_eq_two, pow_one] at h
+    rw [h, hlead, one_mul, resultant_C_sub_X _ _ _ hq.le, hqx]
+  rw [hmul, resultant_add_mul_right (W.fCofactor x) (C x - X) 1 2 2 (by simp) hq.le, hres]
   ring
 
 /-- The étale algebra associated to the cofactor of `f`. -/

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -382,8 +382,8 @@ would say the element is a square in `W.Aˣ`, which is a different and stronger 
 theorem norm_mk_C_sub_X_add_fCofactor {x : K} (hx : W.f.eval x = 0) :
     Algebra.norm K (AdjoinRoot.mk W.f (C x - X + W.fCofactor x))
       = (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
-  rw [AdjoinRoot.norm_mk_C_sub_X_add (W.monic_fCofactor x) (W.natDegree_fCofactor x).ge
-    (W.f_eq_mul_of_eval_eq_zero hx), W.eval_fCofactor_self]
+  rw [AdjoinRoot.norm_mk_C_sub_X_add (W.monic_fCofactor x) (W.f_eq_mul_of_eval_eq_zero hx),
+    W.eval_fCofactor_self]
 
 /-- The étale algebra associated to the cofactor of `f`. -/
 abbrev A' (x : K) : Type _ := AdjoinRoot (W.fCofactor x)

--- a/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
@@ -308,17 +308,38 @@ theorem norm_mk_C_sub_X (hg : g.Monic) (x : R) :
   rw [norm_mk_eq_resultant hg, natDegree_C_sub_X, resultant_C_sub_X_right _ _ _ le_rfl]
 
 /-- **At a root the corrected representative has square norm.** If `g = q * (X - C x)` with `q`
-monic of degree at least `2`, then `x - θ` is a zero divisor in `AdjoinRoot g`, and the corrected
-representative `x - θ + q θ` that replaces it has norm `(q.eval x) ^ 2`.
+monic, then `x - θ` is a zero divisor in `AdjoinRoot g`, and the corrected representative
+`x - θ + q θ` that replaces it has norm `(q.eval x) ^ 2`.
 
-The factorization splits the resultant into two factors, each equal to `q.eval x`: against
-`X - C x` the corrected representative is evaluated at `x`, and against `q` the added multiple of
-`q` drops out, leaving a resultant with `C x - X`. -/
-theorem norm_mk_C_sub_X_add {q : R[X]} {x : R} (hq : q.Monic) (hd : 2 ≤ q.natDegree)
-    (hgq : g = q * (X - C x)) :
+For `2 ≤ q.natDegree` the factorization splits the resultant into two factors, each equal to
+`q.eval x`: against `X - C x` the corrected representative is evaluated at `x`, and against `q`
+the added multiple of `q` drops out, leaving a resultant with `C x - X`. Below that degree the
+resultant bookkeeping does not apply and the representative is a scalar instead: at
+`q.natDegree = 1` the `X` terms cancel and it is `C (q.eval x)` in an algebra of rank `2`, and at
+`q.natDegree = 0` it is `1`, as is `q.eval x`. -/
+theorem norm_mk_C_sub_X_add {q : R[X]} {x : R} (hq : q.Monic) (hgq : g = q * (X - C x)) :
     Algebra.norm R (mk g (C x - X + q)) = q.eval x ^ 2 := by
   nontriviality R
   have hg : g.Monic := by rw [hgq]; exact hq.mul (monic_X_sub_C x)
+  have hgd : g.natDegree = q.natDegree + 1 := by
+    rw [hgq, hq.natDegree_mul (monic_X_sub_C x), natDegree_X_sub_C]
+  rcases lt_or_ge q.natDegree 2 with hsmall | hd
+  · -- below degree `2` the representative is a scalar, and the resultant argument does not run
+    have hqd : q.natDegree = 0 ∨ q.natDegree = 1 := by lia
+    rcases hqd with hqd | hqd
+    · -- `q = 1`, so `C x - X + q` is `1` modulo `g`
+      have hq1 : q = 1 := eq_one_of_monic_natDegree_zero hq hqd
+      have hrep : C x - X + q = -g + 1 := by rw [hgq, hq1]; ring
+      rw [hrep, hq1]
+      simp
+    · -- `q = X + C (q.coeff 0)`, so the `X` terms cancel and the representative is a constant
+      have hconst : C x - X + q = C (q.eval x) := by
+        rw [hq.eq_X_add_C hqd, eval_add, eval_X, eval_C, C_add]
+        ring
+      rw [hconst, mk_C, ← algebraMap_eq,
+        Algebra.norm_algebraMap_of_basis (powerBasis' hg).basis, Fintype.card_fin]
+      congr 1
+      simp [powerBasis', hgd, hqd]
   have hp : (C x - X + q).natDegree = q.natDegree :=
     natDegree_add_eq_right_of_natDegree_lt (by rw [natDegree_C_sub_X]; lia)
   have hpx : (C x - X + q).eval x = q.eval x := by simp

--- a/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
@@ -9,6 +9,7 @@ public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.RingTheory.AdjoinRoot
 public import Mathlib.RingTheory.Norm.Basic
 public import Mathlib.RingTheory.Polynomial.Resultant.Basic
+public import TauCeti.Algebra.Polynomial.LinearFactor
 public import TauCeti.RingTheory.Polynomial.DegreeLT
 public import TauCeti.RingTheory.Polynomial.Resultant.Basic
 

--- a/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
@@ -10,6 +10,7 @@ public import Mathlib.RingTheory.AdjoinRoot
 public import Mathlib.RingTheory.Norm.Basic
 public import Mathlib.RingTheory.Polynomial.Resultant.Basic
 public import TauCeti.RingTheory.Polynomial.DegreeLT
+public import TauCeti.RingTheory.Polynomial.Resultant.Basic
 
 /-!
 # The norm on `AdjoinRoot g` is a resultant
@@ -45,6 +46,9 @@ No signs appear anywhere: `B` is an endomorphism, so the two blocks are never re
   onto `AdjoinRoot g`, with `coe_degreeLTEquiv_symm_apply`/`_mk` characterising its inverse.
 * `AdjoinRoot.norm_mk_eq_det_mulModByMonic`, `AdjoinRoot.norm_mk_eq_resultant` — the norm as a
   determinant, and then as a resultant.
+* `AdjoinRoot.norm_mk_C_sub_X`, `AdjoinRoot.norm_mk_C_sub_X_add` — the two values that resultant
+  algebra reads off it: the norm of `x - θ`, and, when `g` has `x` as a root, the norm of the
+  corrected representative `x - θ + q θ` that replaces it.
 
 ## Provenance
 
@@ -56,6 +60,11 @@ targets Lean `v4.32.0` and predates parts of Mathlib's current API, so this is a
 rather than a copy: `degreeLTEquiv` is built from Mathlib's `AdjoinRoot.modByMonicHom` instead of
 from a bijectivity argument, and the source's `Monic.resultant_one_right` is replaced by
 Mathlib's `Polynomial.resultant_one_right`.
+
+`norm_mk_C_sub_X` and `norm_mk_C_sub_X_add` come from the same repository at the same commit,
+`EllipticCurves/WeakMordellWeil.lean` lines 277-313, where they are stated for the polynomial of
+an elliptic curve. Their proofs use no curve input beyond monicity and the factorization, so they
+are stated here at that level instead.
 -/
 
 public section
@@ -289,5 +298,39 @@ theorem norm_mk_eq_resultant (hg : g.Monic) (p : R[X]) :
     ← LinearMap.det_toMatrix b₁, resultant, ← toMatrix_sylvesterMap' g p le_rfl le_rfl, key,
     Matrix.det_mul, toMatrix_sylvesterMap' g 1 le_rfl (by simp), ← resultant,
     resultant_one_right, hg.coeff_natDegree, one_pow, one_mul]
+
+/-- **The norm of `x - θ` is `g x`.** Here `θ` is the image of `X` in `AdjoinRoot g`, so
+`mk g (C x - X)` is `x - θ`. -/
+theorem norm_mk_C_sub_X (hg : g.Monic) (x : R) :
+    Algebra.norm R (mk g (C x - X)) = g.eval x := by
+  nontriviality R
+  rw [norm_mk_eq_resultant hg, natDegree_C_sub_X, resultant_C_sub_X_right _ _ _ le_rfl]
+
+/-- **At a root the corrected representative has square norm.** If `g = q * (X - C x)` with `q`
+monic of degree at least `2`, then `x - θ` is a zero divisor in `AdjoinRoot g`, and the corrected
+representative `x - θ + q θ` that replaces it has norm `(q.eval x) ^ 2`.
+
+The factorization splits the resultant into two factors, each equal to `q.eval x`: against
+`X - C x` the corrected representative is evaluated at `x`, and against `q` the added multiple of
+`q` drops out, leaving a resultant with `C x - X`. -/
+theorem norm_mk_C_sub_X_add {q : R[X]} {x : R} (hq : q.Monic) (hd : 2 ≤ q.natDegree)
+    (hgq : g = q * (X - C x)) :
+    Algebra.norm R (mk g (C x - X + q)) = q.eval x ^ 2 := by
+  nontriviality R
+  have hg : g.Monic := by rw [hgq]; exact hq.mul (monic_X_sub_C x)
+  have hp : (C x - X + q).natDegree = q.natDegree :=
+    natDegree_add_eq_right_of_natDegree_lt (by rw [natDegree_C_sub_X]; lia)
+  have hpx : (C x - X + q).eval x = q.eval x := by simp
+  have hmul : C x - X + q = (C x - X) + q * 1 := by ring
+  have hres : q.resultant (C x - X) q.natDegree q.natDegree = q.eval x := by
+    have hk : 1 + (q.natDegree - 1) = q.natDegree := by lia
+    have h := resultant_add_right_deg q (C x - X) q.natDegree 1 (q.natDegree - 1)
+      (natDegree_C_sub_X x).le
+    rw [hk] at h
+    rw [h, hq.coeff_natDegree, one_pow, one_mul, resultant_C_sub_X_right _ _ _ le_rfl]
+  rw [norm_mk_eq_resultant hg, hp, hgq, hq.natDegree_mul (monic_X_sub_C x),
+    resultant_mul_left _ _ _ _ hp.le, natDegree_X_sub_C, resultant_X_sub_C_left _ _ _ hp.le, hpx,
+    hmul, resultant_add_mul_right q (C x - X) 1 q.natDegree q.natDegree (by simp) le_rfl, hres]
+  ring
 
 end AdjoinRoot

--- a/TauCeti/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Basic.lean
@@ -8,20 +8,18 @@ module
 public import Mathlib.RingTheory.Polynomial.Resultant.Basic
 
 /-!
-# The reversed linear factor `C x - X`
+# The resultant against a reversed linear factor
 
 Mathlib evaluates the resultant against the linear polynomial `X - C x` on either side
-(`Polynomial.resultant_X_sub_C_left`, `Polynomial.resultant_X_sub_C_right`). This file records
-the two facts about the *reversed* polynomial `C x - X`, which is the shape that arises as
-`x - θ` in `AdjoinRoot f`: its degree, and its resultant on the right.
+(`Polynomial.resultant_X_sub_C_left`, `Polynomial.resultant_X_sub_C_right`). This file records the
+companion for the *reversed* polynomial `C x - X`, which is the shape that arises as `x - θ` in
+`AdjoinRoot f`: the answer is `f.eval x`, with **no sign**.
 
-The resultant is `f.eval x`, with **no sign** — that absence is the point. `C x - X` is
-`C (-1) * (X - C x)`, which contributes `(-1) ^ m`, and `resultant_X_sub_C_right` contributes
-another `(-1) ^ m`, so the two cancel.
+That absence is the point. `C x - X` is `C (-1) * (X - C x)`, which contributes `(-1) ^ m`, and
+`resultant_X_sub_C_right` contributes another `(-1) ^ m`, so the two cancel.
 
 ## Main results
 
-* `Polynomial.natDegree_C_sub_X`
 * `Polynomial.resultant_C_sub_X_right`
 
 ## Provenance
@@ -37,11 +35,6 @@ public section
 namespace Polynomial
 
 variable {R : Type*} [CommRing R]
-
-/-- The reversed linear polynomial `C x - X` has degree `1`, like `X - C x`. -/
-@[simp]
-theorem natDegree_C_sub_X [Nontrivial R] (x : R) : (C x - X).natDegree = 1 := by
-  rw [natDegree_sub, natDegree_X_sub_C]
 
 /-- The resultant of `f` with the reversed linear polynomial `C x - X` is `f.eval x`. Note the
 absence of a sign: `C x - X` is `-(X - C x)`, and the two signs cancel. -/

--- a/TauCeti/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Basic.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Polynomial.Resultant.Basic
+
+/-!
+# The resultant against a reversed linear factor
+
+Mathlib evaluates the resultant against a power of `X - C x`
+(`Polynomial.resultant_X_sub_C_pow_right`). This file records the companion for the *reversed*
+linear polynomial `C x - X`, which is the shape that arises as `x - θ` in `AdjoinRoot f`: the
+answer is `f.eval x`, with **no sign**. The absence of a sign is the point — `C x - X` is
+`-(X - C x)`, which contributes `(-1) ^ m`, and `resultant_X_sub_C_pow_right` contributes another
+`(-1) ^ m`, so the two cancel.
+
+## Main results
+
+* `Polynomial.resultant_C_sub_X`
+
+## Provenance
+
+Adapted from Michael Stoll's `EllipticCurves`
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0) at commit
+`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, `EllipticCurves/Mathlib/Basic.lean` line 615, where
+it is a Mathlib-bound prerequisite of the explicit `2`-descent.
+-/
+
+public section
+
+namespace Polynomial
+
+variable {R : Type*} [CommRing R]
+
+/-- The resultant of `f` with the linear polynomial `C x - X` is `f.eval x`. Note the absence of
+a sign: `C x - X` is `-(X - C x)`, and the two signs cancel. -/
+theorem resultant_C_sub_X (f : R[X]) (x : R) (m : ℕ) (hm : f.natDegree ≤ m) :
+    f.resultant (C x - X) m 1 = f.eval x := by
+  have h : f.resultant (X - C x) m 1 = (-1) ^ m * f.eval x := by
+    have := resultant_X_sub_C_pow_right f x m 1 hm
+    rwa [pow_one, mul_one, pow_one] at this
+  rw [show C x - X = C (-1 : R) * (X - C x) by simp, resultant_C_mul_right, h,
+    ← mul_assoc, ← pow_add, ← two_mul, pow_mul, neg_one_sq, one_pow, one_mul]
+
+end Polynomial

--- a/TauCeti/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Basic.lean
@@ -42,7 +42,9 @@ theorem resultant_C_sub_X (f : R[X]) (x : R) (m : ℕ) (hm : f.natDegree ≤ m) 
   have h : f.resultant (X - C x) m 1 = (-1) ^ m * f.eval x := by
     have := resultant_X_sub_C_pow_right f x m 1 hm
     rwa [pow_one, mul_one, pow_one] at this
-  rw [show C x - X = C (-1 : R) * (X - C x) by simp, resultant_C_mul_right, h,
-    ← mul_assoc, ← pow_add, ← two_mul, pow_mul, neg_one_sq, one_pow, one_mul]
+  -- `C x - X` is `X - C x` scaled by the constant `-1`
+  have hneg : C x - X = C (-1 : R) * (X - C x) := by simp
+  rw [hneg, resultant_C_mul_right, h, ← mul_assoc, ← pow_add, ← two_mul, pow_mul, neg_one_sq,
+    one_pow, one_mul]
 
 end Polynomial

--- a/TauCeti/RingTheory/Polynomial/Resultant/Basic.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/Basic.lean
@@ -8,18 +8,21 @@ module
 public import Mathlib.RingTheory.Polynomial.Resultant.Basic
 
 /-!
-# The resultant against a reversed linear factor
+# The reversed linear factor `C x - X`
 
-Mathlib evaluates the resultant against a power of `X - C x`
-(`Polynomial.resultant_X_sub_C_pow_right`). This file records the companion for the *reversed*
-linear polynomial `C x - X`, which is the shape that arises as `x - θ` in `AdjoinRoot f`: the
-answer is `f.eval x`, with **no sign**. The absence of a sign is the point — `C x - X` is
-`-(X - C x)`, which contributes `(-1) ^ m`, and `resultant_X_sub_C_pow_right` contributes another
-`(-1) ^ m`, so the two cancel.
+Mathlib evaluates the resultant against the linear polynomial `X - C x` on either side
+(`Polynomial.resultant_X_sub_C_left`, `Polynomial.resultant_X_sub_C_right`). This file records
+the two facts about the *reversed* polynomial `C x - X`, which is the shape that arises as
+`x - θ` in `AdjoinRoot f`: its degree, and its resultant on the right.
+
+The resultant is `f.eval x`, with **no sign** — that absence is the point. `C x - X` is
+`C (-1) * (X - C x)`, which contributes `(-1) ^ m`, and `resultant_X_sub_C_right` contributes
+another `(-1) ^ m`, so the two cancel.
 
 ## Main results
 
-* `Polynomial.resultant_C_sub_X`
+* `Polynomial.natDegree_C_sub_X`
+* `Polynomial.resultant_C_sub_X_right`
 
 ## Provenance
 
@@ -35,16 +38,19 @@ namespace Polynomial
 
 variable {R : Type*} [CommRing R]
 
-/-- The resultant of `f` with the linear polynomial `C x - X` is `f.eval x`. Note the absence of
-a sign: `C x - X` is `-(X - C x)`, and the two signs cancel. -/
-theorem resultant_C_sub_X (f : R[X]) (x : R) (m : ℕ) (hm : f.natDegree ≤ m) :
+/-- The reversed linear polynomial `C x - X` has degree `1`, like `X - C x`. -/
+@[simp]
+theorem natDegree_C_sub_X [Nontrivial R] (x : R) : (C x - X).natDegree = 1 := by
+  rw [natDegree_sub, natDegree_X_sub_C]
+
+/-- The resultant of `f` with the reversed linear polynomial `C x - X` is `f.eval x`. Note the
+absence of a sign: `C x - X` is `-(X - C x)`, and the two signs cancel. -/
+@[simp]
+theorem resultant_C_sub_X_right (f : R[X]) (x : R) (m : ℕ) (hm : f.natDegree ≤ m) :
     f.resultant (C x - X) m 1 = f.eval x := by
-  have h : f.resultant (X - C x) m 1 = (-1) ^ m * f.eval x := by
-    have := resultant_X_sub_C_pow_right f x m 1 hm
-    rwa [pow_one, mul_one, pow_one] at this
   -- `C x - X` is `X - C x` scaled by the constant `-1`
   have hneg : C x - X = C (-1 : R) * (X - C x) := by simp
-  rw [hneg, resultant_C_mul_right, h, ← mul_assoc, ← pow_add, ← two_mul, pow_mul, neg_one_sq,
-    one_pow, one_mul]
+  rw [hneg, resultant_C_mul_right, resultant_X_sub_C_right f m x hm, ← mul_assoc, ← pow_add,
+    ← two_mul, pow_mul, neg_one_sq, one_pow, one_mul]
 
 end Polynomial


### PR DESCRIPTION
Roadmap: EllipticCurves

Step 5 of the weak Mordell–Weil descent reads its condition off two norms in the étale algebra
`W.A = K[X]/(f)`. Both are computed here — at the level they live at, which is a monic polynomial
and a linear factor, not an elliptic curve.

```
AdjoinRoot.norm_mk_C_sub_X (hg : g.Monic) (x : R) :
    Algebra.norm R (mk g (C x - X)) = g.eval x

AdjoinRoot.norm_mk_C_sub_X_add (hq : q.Monic) (hd : 2 ≤ q.natDegree) (hgq : g = q * (X - C x)) :
    Algebra.norm R (mk g (C x - X + q)) = q.eval x ^ 2
```

The second is the `2`-torsion branch. Where `x` is a root of `f`, `x - T` is *not* a unit and the
descent map `μX` uses the corrected representative `x - T + fCofactor x` instead (already on
`main`, `MordellWeil/XSubT.lean`). Its norm is the square of `f' x` — which is what makes its
square class trivial, and hence what the norm condition on `im μ` will be read off from. The curve
statement is now the two-line specialisation `WeierstrassCurve.Affine.norm_mk_C_sub_X_add_fCofactor`
along `f = fCofactor x * (X - C x)`; the norm of `x - T` on the other branch is
`AdjoinRoot.norm_mk_C_sub_X W.monic_f x` directly, with no curve-level copy.

**Roadmap warrant.** `TauCetiRoadmap` `EllipticCurves/README.md`:813-820, bullet **"Explicit
`2`-descent (core, this layer)"**:

> The Stoll development already contains arithmetic `2`-descent: the local conditions, the
> explicit `2`-Selmer group inside the square classes of the étale algebra `K[X]/(f)`, its
> finiteness, and the theorem converting its cardinality into a **Mordell–Weil rank bound** …
> Migrate it here as its own lane, with the existing `y² = x³ − x + 1` rank computation as the
> early acceptance test.

### The argument

Both norms are instances of `AdjoinRoot.norm_mk_eq_resultant` — the norm of `mk g p` for monic `g`
is the resultant of `g` and `p` — followed by Mathlib's resultant algebra. In the second, the
factorisation `g = q * (X - C x)` splits the resultant into two factors via `resultant_mul_left`,
and each evaluates to `q.eval x`: the `X - C x` factor through `resultant_X_sub_C_left`, and the
`q` factor through `resultant_add_mul_right` (the added multiple of `q` drops out) followed by
`resultant_add_right_deg` and monicity.

Supporting them, a new `TauCeti/RingTheory/Polynomial/Resultant/Basic.lean` records the two facts
about the **reversed** linear factor `C x - X` that Mathlib does not have: its degree, and its
resultant on the right. Mathlib has `X - C x` on both sides; the reversed form is the one that
arises as `x - θ`, and it carries **no sign** — `C x - X` contributes `(-1) ^ m` and
`resultant_X_sub_C_right` contributes another, and they cancel. Both are `@[simp]`, as all four
Mathlib siblings are — measured rather than assumed: with each tag suppressed, `simp` makes no
progress on that lemma's own statement, so neither is a lemma the simp set already had. And
`natDegree_C_sub_X` replaces all three separate `compute_degree!` copies of that fact in
`XSubT.lean`.

### Prior art

`resultant_C_sub_X_right` and `natDegree_C_sub_X` came back absent from the pinned Mathlib —
`loogle` finds nothing of the shape `natDegree (C a - p)`, and the `C x - X` orientation appears
nowhere in `Mathlib/RingTheory/Polynomial/Resultant/Basic.lean`, which states all four `X - C x`
variants. `norm_mk_C_sub_X`, `norm_mk_C_sub_X_add` and `normM` are absent from `main`. Everything
the proofs use is Mathlib and is used rather than re-derived: `resultant_X_sub_C_left`,
`resultant_X_sub_C_right`, `resultant_mul_left`, `resultant_add_right_deg`,
`resultant_add_mul_right`, `resultant_C_mul_right`, `natDegree_sub`,
`natDegree_add_eq_right_of_natDegree_lt`, `Monic.natDegree_mul`, `Monic.coeff_natDegree`.

### Not stacked

Every parent has merged: #4448 (EC-4, the `x - T` map) at 18:02Z, #4473 (EC-5, `ker μ = 2E(K)`)
at 04:01Z, and #4651 (EC-6a, `AdjoinRoot.norm_mk_eq_resultant`) at 08:51Z. This bases on `main`
outright. It is also the first in-repo consumer of `norm_mk_eq_resultant`, which #4651 landed
with none.

`normM` and `range_μ_le_ker_normM` — the norm map on square classes itself — are the remaining
half of Step 5 and follow in a separate PR, since they need an adaptation of Stoll's
`Units.modPow` to the quotient-by-`(powMonoidHom 2).range` form `main` uses.

### Note for the queue

This touches the same paragraph of the `XSubT.lean` module docstring as #4729, which rewrites the
sentence next to the one edited here. The two are otherwise disjoint, and whichever lands second
takes an ordinary rebase.
