### PR TITLE
feat: preserve unipotence under normal products

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
@@ -85,6 +85,17 @@ noncomputable def normalSemidirectProductIso
       (quotientNormalConjugation H I J hI).coordinateHopfAlgebra := by
   rw [normalSemidirectProduct]
 
+/-- The coordinate algebra of the named normal semidirect product is finite type when the
+coordinate algebras of both factors are finite type. -/
+noncomputable instance normalSemidirectProduct_finiteType
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H)
+    (hI : I.IsNormal) [Algebra.FiniteType R (quotient H I)]
+    [Algebra.FiniteType R (quotient H J)] :
+    Algebra.FiniteType R (normalSemidirectProduct H I J hI) :=
+  Algebra.FiniteType.equiv
+    (GrpObj.Action.coordinateHopfAlgebra_finiteType (quotientNormalConjugation H I J hI))
+    (CommHopfAlgCat.ofIso (normalSemidirectProductIso H I J hI)).toAlgEquiv.symm
+
 /-- The coordinate morphism representing inclusion of the normal factor in the named normal
 semidirect product. -/
 noncomputable def normalSemidirectProductCoordinateInl

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/NormalProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/NormalProduct.lean
@@ -6,13 +6,13 @@ Authors: Codex
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Unipotent
-public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Basic
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Unipotent
 import TauCeti.Algebra.AlgebraicGroup.Unipotent.SemidirectProduct
 import TauCeti.RingTheory.Smooth.GeometricallyReduced
 
 /-!
-# Unipotence of products of unipotent-radical candidates
+# Unipotence of normal products
 
 Let `I` and `J` cut out smooth unipotent closed subgroups of a finite-type affine group, with
 `I` normal. Multiplication is a homomorphism from their conjugation semidirect product into the
@@ -29,10 +29,10 @@ normality of the image are supplied by the normal-product API.
 
 ## Main declarations
 
+* `TauCeti.smoothUnipotentCommHopfAlgProperty.normalSemidirectProduct`: the named normal
+  semidirect product of two smooth unipotent groups is smooth unipotent.
 * `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.productOfNormal`: the multiplication
   image of two smooth unipotent subgroups has geometrically unipotent points.
-* `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate.geometricallyUnipotent_productOfNormal`: the
-  candidate-level form of the result.
 
 ## References
 
@@ -54,6 +54,41 @@ universe u
 
 noncomputable section
 
+namespace smoothUnipotentCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+
+/-- The named normal semidirect product of two smooth unipotent closed subgroups is smooth
+unipotent. -/
+theorem normalSemidirectProduct (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (I J : HopfIdeal k H) (hI : I.IsNormal)
+    (hIu : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I))
+    (hJu : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H J)) :
+    smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.of k
+        (CommHopfAlgCat.normalSemidirectProduct H.obj I J hI)) := by
+  let _ : Algebra.FiniteType k (CommHopfAlgCat.quotient H.obj I) :=
+    (FiniteTypeCommHopfAlgCat.quotient H I).property
+  let _ : Algebra.FiniteType k (CommHopfAlgCat.quotient H.obj J) :=
+    (FiniteTypeCommHopfAlgCat.quotient H J).property
+  let A := CommHopfAlgCat.quotientNormalConjugation H.obj I J hI
+  let _ : Algebra.FiniteType k A.coordinateHopfAlgebra :=
+    GrpObj.Action.coordinateHopfAlgebra_finiteType A
+  have hsource : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.of k A.coordinateHopfAlgebra) :=
+    smoothUnipotentCommHopfAlgProperty.semidirectProduct k
+      (FiniteTypeCommHopfAlgCat.quotient H I)
+      (FiniteTypeCommHopfAlgCat.quotient H J) A hIu hJu
+  let e : FiniteTypeCommHopfAlgCat.of k
+      (CommHopfAlgCat.normalSemidirectProduct H.obj I J hI) ≅
+      FiniteTypeCommHopfAlgCat.of k A.coordinateHopfAlgebra :=
+    ObjectProperty.isoMk _ (CommHopfAlgCat.normalSemidirectProductIso H.obj I J hI)
+  exact (smoothUnipotentCommHopfAlgProperty k).prop_of_iso e.symm hsource
+
+end smoothUnipotentCommHopfAlgProperty
+
 namespace geometricallyUnipotentPointsCommHopfAlgProperty
 
 variable {k : Type u} [Field k]
@@ -71,57 +106,20 @@ theorem productOfNormal (H : FiniteTypeCommHopfAlgCat.{u, u} k)
       (FiniteTypeCommHopfAlgCat.quotient H J)) :
     geometricallyUnipotentPointsCommHopfAlgProperty k
       (CommHopfAlgCat.productOfNormal H.obj I J hI) := by
-  let _ : Algebra.FiniteType k (CommHopfAlgCat.quotient H.obj I) :=
-    (FiniteTypeCommHopfAlgCat.quotient H I).property
-  let _ : Algebra.FiniteType k (CommHopfAlgCat.quotient H.obj J) :=
-    (FiniteTypeCommHopfAlgCat.quotient H J).property
-  let A := CommHopfAlgCat.quotientNormalConjugation H.obj I J hI
-  let N := CommHopfAlgCat.normalSemidirectProduct H.obj I J hI
-  let _ : Algebra.FiniteType k A.coordinateHopfAlgebra :=
-    GrpObj.Action.coordinateHopfAlgebra_finiteType A
-  let _ : Algebra.FiniteType k N :=
-    Algebra.FiniteType.equiv
-      (inferInstanceAs (Algebra.FiniteType k A.coordinateHopfAlgebra))
-      (CommHopfAlgCat.ofIso
-        (CommHopfAlgCat.normalSemidirectProductIso H.obj I J hI)).toAlgEquiv.symm
-  have hsource : smoothUnipotentCommHopfAlgProperty k
-      (FiniteTypeCommHopfAlgCat.of k A.coordinateHopfAlgebra) :=
-    smoothUnipotentCommHopfAlgProperty.semidirectProduct k
-      (FiniteTypeCommHopfAlgCat.quotient H I)
-      (FiniteTypeCommHopfAlgCat.quotient H J) A hIu hJu
-  let e : FiniteTypeCommHopfAlgCat.of k N ≅
-      FiniteTypeCommHopfAlgCat.of k A.coordinateHopfAlgebra :=
-    ObjectProperty.isoMk _ (CommHopfAlgCat.normalSemidirectProductIso H.obj I J hI)
-  have hsourceN : smoothUnipotentCommHopfAlgProperty k
-      (FiniteTypeCommHopfAlgCat.of k N) :=
-    (smoothUnipotentCommHopfAlgProperty k).prop_of_iso e.symm hsource
-  have hsourceN' :=
+  have hsource := smoothUnipotentCommHopfAlgProperty.normalSemidirectProduct
+    H I J hI hIu hJu
+  have hsource' :=
     (smoothUnipotentCommHopfAlgProperty_iff k
-      (FiniteTypeCommHopfAlgCat.of k N)).mp hsourceN
-  let _ : Algebra.Smooth k N := hsourceN'.1
-  let _ : IsReduced N := isReduced_of_smooth_of_field k N
+      (FiniteTypeCommHopfAlgCat.of k
+        (CommHopfAlgCat.normalSemidirectProduct H.obj I J hI))).mp hsource
+  let _ : Algebra.Smooth k (CommHopfAlgCat.normalSemidirectProduct H.obj I J hI) := hsource'.1
+  let _ : IsReduced (CommHopfAlgCat.normalSemidirectProduct H.obj I J hI) :=
+    isReduced_of_smooth_of_field k _
   apply image_of_reduced (CommHopfAlgCat.productMapOfNormal H.obj I J hI)
   rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
-  exact hsourceN'.2
+  exact hsource'.2
 
 end geometricallyUnipotentPointsCommHopfAlgProperty
-
-namespace HopfIdeal.IsUnipotentRadicalCandidate
-
-variable {k : Type u} [Field k]
-variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
-
-/-- The scheme-theoretic multiplication image of two unipotent-radical candidates has
-geometrically unipotent points. -/
-theorem geometricallyUnipotent_productOfNormal
-    (hI : IsUnipotentRadicalCandidate H I)
-    (hJ : IsUnipotentRadicalCandidate H J) :
-    geometricallyUnipotentPointsCommHopfAlgProperty k
-      (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) :=
-  geometricallyUnipotentPointsCommHopfAlgProperty.productOfNormal H I J hI.isNormal
-    hI.smoothUnipotent hJ.smoothUnipotent
-
-end HopfIdeal.IsUnipotentRadicalCandidate
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product/Unipotent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product/Unipotent.lean
@@ -1,0 +1,128 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Unipotent
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Basic
+import TauCeti.Algebra.AlgebraicGroup.Unipotent.SemidirectProduct
+import TauCeti.RingTheory.Smooth.GeometricallyReduced
+
+/-!
+# Unipotence of products of unipotent-radical candidates
+
+Let `I` and `J` cut out smooth unipotent closed subgroups of a finite-type affine group, with
+`I` normal. Multiplication is a homomorphism from their conjugation semidirect product into the
+ambient group, and `CommHopfAlgCat.productOfNormal` is its scheme-theoretic image.
+
+The semidirect-product source is again smooth unipotent. In particular, its coordinate algebra
+is reduced. The coordinate algebra of the multiplication image embeds in that reduced algebra,
+so every geometric point of the image is unipotent. This avoids any appeal to faithful flatness
+of the source-to-image morphism.
+
+Together with connectedness and smoothness of the multiplication image, this is the remaining
+geometric input for binary-product closure of unipotent-radical candidates. Containment and
+normality of the image are supplied by the normal-product API.
+
+## Main declarations
+
+* `TauCeti.geometricallyUnipotentPointsCommHopfAlgProperty.productOfNormal`: the multiplication
+  image of two smooth unipotent subgroups has geometrically unipotent points.
+* `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate.geometricallyUnipotent_productOfNormal`: the
+  candidate-level form of the result.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a, 6.a.
+* A. Borel, *Linear Algebraic Groups*, Proposition 14.4 and Section 11.21.
+
+This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap by supplying the
+geometric-unipotence part of binary-product closure for connected normal smooth unipotent closed
+subgroups.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace geometricallyUnipotentPointsCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+
+/-- The scheme-theoretic multiplication image of two smooth unipotent closed subgroups has
+geometrically unipotent points when the first subgroup is normal.
+
+The semidirect-product source is smooth unipotent, hence reduced. Unipotence then descends to its
+scheme-theoretic image through the canonical embedding of coordinate algebras. -/
+theorem productOfNormal (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (I J : HopfIdeal k H) (hI : I.IsNormal)
+    (hIu : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I))
+    (hJu : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H J)) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.productOfNormal H.obj I J hI) := by
+  let _ : Algebra.FiniteType k (CommHopfAlgCat.quotient H.obj I) :=
+    (FiniteTypeCommHopfAlgCat.quotient H I).property
+  let _ : Algebra.FiniteType k (CommHopfAlgCat.quotient H.obj J) :=
+    (FiniteTypeCommHopfAlgCat.quotient H J).property
+  let A := CommHopfAlgCat.quotientNormalConjugation H.obj I J hI
+  let N := CommHopfAlgCat.normalSemidirectProduct H.obj I J hI
+  let _ : Algebra.FiniteType k A.coordinateHopfAlgebra :=
+    GrpObj.Action.coordinateHopfAlgebra_finiteType A
+  let _ : Algebra.FiniteType k N :=
+    Algebra.FiniteType.equiv
+      (inferInstanceAs (Algebra.FiniteType k A.coordinateHopfAlgebra))
+      (CommHopfAlgCat.ofIso
+        (CommHopfAlgCat.normalSemidirectProductIso H.obj I J hI)).toAlgEquiv.symm
+  have hsource : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.of k A.coordinateHopfAlgebra) :=
+    smoothUnipotentCommHopfAlgProperty.semidirectProduct k
+      (FiniteTypeCommHopfAlgCat.quotient H I)
+      (FiniteTypeCommHopfAlgCat.quotient H J) A hIu hJu
+  let e : FiniteTypeCommHopfAlgCat.of k N ≅
+      FiniteTypeCommHopfAlgCat.of k A.coordinateHopfAlgebra :=
+    ObjectProperty.isoMk _ (CommHopfAlgCat.normalSemidirectProductIso H.obj I J hI)
+  have hsourceN : smoothUnipotentCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.of k N) :=
+    (smoothUnipotentCommHopfAlgProperty k).prop_of_iso e.symm hsource
+  have hsourceN' :=
+    (smoothUnipotentCommHopfAlgProperty_iff k
+      (FiniteTypeCommHopfAlgCat.of k N)).mp hsourceN
+  let _ : Algebra.Smooth k N := hsourceN'.1
+  let _ : IsReduced N := isReduced_of_smooth_of_field k N
+  apply image_of_reduced (CommHopfAlgCat.productMapOfNormal H.obj I J hI)
+  rw [geometricallyUnipotentPointsCommHopfAlgProperty_iff]
+  exact hsourceN'.2
+
+end geometricallyUnipotentPointsCommHopfAlgProperty
+
+namespace HopfIdeal.IsUnipotentRadicalCandidate
+
+variable {k : Type u} [Field k]
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
+
+/-- The scheme-theoretic multiplication image of two unipotent-radical candidates has
+geometrically unipotent points. -/
+theorem geometricallyUnipotent_productOfNormal
+    (hI : IsUnipotentRadicalCandidate H I)
+    (hJ : IsUnipotentRadicalCandidate H J) :
+    geometricallyUnipotentPointsCommHopfAlgProperty k
+      (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) :=
+  geometricallyUnipotentPointsCommHopfAlgProperty.productOfNormal H I J hI.isNormal
+    hI.smoothUnipotent hJ.smoothUnipotent
+
+end HopfIdeal.IsUnipotentRadicalCandidate
+
+end
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the scheme-theoretic multiplication image of two smooth unipotent closed subgroups is geometrically unipotent when the first subgroup is normal. Apply smooth unipotence of the conjugation semidirect product to make its coordinate algebra reduced, then descend geometric-point unipotence along the canonical embedding of the image coordinate algebra. This avoids assuming faithful flatness of the source-to-image morphism.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5, “The unipotent radical `R_u(G)`,” specifically the binary-product closure step for connected normal smooth unipotent closed subgroups. This is the most effective current step because `CommHopfAlgCat.productOfNormal`, semidirect-product preservation of smooth unipotence, and reduced-image descent of unipotence are all on `main`, while open PR #4588 explicitly leaves geometric unipotence as the one missing geometric property of the multiplication image. The general theorem `geometricallyUnipotentPointsCommHopfAlgProperty.productOfNormal` exposes the reusable image result, and `HopfIdeal.IsUnipotentRadicalCandidate.geometricallyUnipotent_productOfNormal` supplies the candidate-level form.

After this PR, the Layer 5 milestone still needs #4588’s connectedness and smoothness results to land, assembly of normality and the three geometric properties into binary closure of `IsUnipotentRadicalCandidate`, and the maximal-dimension argument showing that the chosen candidate contains every other candidate.

Add `TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Product/Unipotent.lean` (128 lines). The proof reuses `smoothUnipotentCommHopfAlgProperty.semidirectProduct`, `geometricallyUnipotentPointsCommHopfAlgProperty.image_of_reduced`, and the existing normal-product image factorization. No Mathlib source is vendored. The mathematical organization follows Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§5.a, 6.a, and Borel, *Linear Algebraic Groups*, Proposition 14.4 and §11.21, as credited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"normal-product-image-unipotent"}-->

🤖 Prepared with Codex
