### PR TITLE
feat(MordellWeil): base change of the étale algebra and the local condition of 2-descent

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
@@ -84,6 +84,7 @@ variable {R : Type*} [CommRing R] (W : Affine R)
 /-- Base changing along the identity algebra map returns the curve itself. Stated over a
 commutative ring: it is a formal `map` identity and uses nothing about `R` beyond its ring
 structure. -/
+@[simp]
 lemma baseChange_self : (W⁄R).toAffine = W := by
   -- `WeierstrassCurve.baseChange` (Weierstrass.lean:236) is a plain `def` and Mathlib exposes no
   -- unfolding lemma for it, so this one definitional step cannot be replaced by an API rewrite.
@@ -93,37 +94,47 @@ lemma baseChange_self : (W⁄R).toAffine = W := by
   rw [show algebraMap R R = RingHom.id R from Algebra.algebraMap_self]
   exact W.map_id
 
+section Map
+
+variable {S : Type*} [CommRing S] (σ : R →+* S)
+
+lemma map_f : (W.map σ).toAffine.f = W.f.map σ := by
+  simp only [f, Polynomial.map_add, Polynomial.map_pow, Polynomial.map_mul, Polynomial.map_X,
+    Polynomial.map_C, map_a₂, map_a₄, map_a₆]
+
+lemma eval_map_f (x : R) : (W.map σ).toAffine.f.eval (σ x) = σ (W.f.eval x) := by
+  rw [map_f, Polynomial.eval_map, Polynomial.eval₂_at_apply]
+
+lemma map_fCofactor (x : R) : (W.fCofactor x).map σ = (W.map σ).toAffine.fCofactor (σ x) := by
+  simp only [fCofactor, Polynomial.map_add, Polynomial.map_pow, Polynomial.map_mul,
+    Polynomial.map_X, Polynomial.map_C, map_a₂, map_a₄, map_add, map_mul, map_pow]
+
+end Map
+
+section Algebra
+
+variable (S : Type*) [CommRing S] [Algebra R S]
+
+lemma eval_baseChange_f (x : R) :
+    (W⁄S).toAffine.f.eval (algebraMap R S x) = algebraMap R S (W.f.eval x) :=
+  W.eval_map_f (algebraMap R S) x
+
+lemma baseChange_fCofactor (x : R) :
+    (W.fCofactor x).map (algebraMap R S) = (W⁄S).toAffine.fCofactor (algebraMap R S x) :=
+  W.map_fCofactor (algebraMap R S) x
+
+lemma baseChange_f : (W⁄S).toAffine.f = W.f.map (algebraMap R S) :=
+  W.map_f (algebraMap R S)
+
+end Algebra
+
 end CommRing
 
 variable {K : Type*} [Field K] (W : Affine K)
 
 section BaseChange
 
-variable {L₀ : Type*} [Field L₀] (σ : K →+* L₀)
-
-lemma map_f : (W.map σ).toAffine.f = W.f.map σ := by
-  simp only [f, Polynomial.map_add, Polynomial.map_pow, Polynomial.map_mul, Polynomial.map_X,
-    Polynomial.map_C, map_a₂, map_a₄, map_a₆]
-
-lemma eval_map_f (x : K) : (W.map σ).toAffine.f.eval (σ x) = σ (W.f.eval x) := by
-  rw [map_f, Polynomial.eval_map, Polynomial.eval₂_at_apply]
-
-lemma map_fCofactor (x : K) : (W.fCofactor x).map σ = (W.map σ).toAffine.fCofactor (σ x) := by
-  simp only [fCofactor, Polynomial.map_add, Polynomial.map_pow, Polynomial.map_mul,
-    Polynomial.map_X, Polynomial.map_C, map_a₂, map_a₄, map_add, map_mul, map_pow]
-
 variable (L : Type*) [Field L] [Algebra K L]
-
-lemma eval_baseChange_f (x : K) :
-    (W⁄L).toAffine.f.eval (algebraMap K L x) = algebraMap K L (W.f.eval x) :=
-  W.eval_map_f (algebraMap K L) x
-
-lemma baseChange_fCofactor (x : K) :
-    (W.fCofactor x).map (algebraMap K L) = (W⁄L).toAffine.fCofactor (algebraMap K L x) :=
-  W.map_fCofactor (algebraMap K L) x
-
-lemma baseChange_f : (W⁄L).toAffine.f = W.f.map (algebraMap K L) :=
-  W.map_f (algebraMap K L)
 
 /-- The base-change homomorphism `K[X]⧸⟨f⟩ →+* L[X]⧸⟨f⟩` of étale algebras, as an instance of
 `AdjoinRoot.map` (so that its API — `map_of`, `map_root`, `map_comp_map`, `mapRingEquiv` —
@@ -147,11 +158,11 @@ lemma localRes_mk (u : W.Aˣ) :
     W.localRes L (QuotientGroup.mk u) = QuotientGroup.mk (Units.map (W.mapA L).toMonoidHom u) :=
   QuotientGroup.map_mk _ _ _ _ u
 
-/-- The base-change map on square classes, on the class of a unit given as `IsUnit a`.
-
-Deliberately **not** `@[simp]`: the left-hand side is not in simp-normal form, because
-`localRes_mk` rewrites `W.localRes L ↑ha.unit` first, so the attribute could never fire. This
-lemma is for explicit `rw` at the `localRes_μX` call sites below. -/
+/-- The base-change map on square classes, on the class of a unit given as `IsUnit a`. -/
+-- Deliberately NOT `@[simp]`: the left-hand side is not in simp-normal form, because
+-- `localRes_mk` rewrites `W.localRes L ↑ha.unit` first, so the attribute could never fire —
+-- tagging it is what failed the simp-NF lint on this branch. It is for explicit `rw` at the
+-- `localRes_μX` call sites below.
 lemma localRes_unit {a : W.A} (ha : IsUnit a) :
     W.localRes L (ha.unit : W.M) = ((ha.map (W.mapA L)).unit : (W⁄L).toAffine.M) := by
   rw [localRes_mk]
@@ -159,18 +170,19 @@ lemma localRes_unit {a : W.A} (ha : IsUnit a) :
 
 section PointMap
 
-variable [DecidableEq K] [DecidableEq L]
-
+open scoped Classical in
 /-- Transporting an affine point along an equality of curves carries its coordinates unchanged.
 
 The transport itself is Mathlib's `AddEquiv.cast`, which is `Equiv.cast (congrArg _ h)` bundled
 as an `AddEquiv`; this is the one fact about it that mentions `Point.some`, and Mathlib has no
 lemma of that shape because `Point` is not one of its indexed families. -/
-private lemma cast_point_some {W₁ W₂ : Affine K} (h : W₁ = W₂) {x y : K} (hp : W₁.Nonsingular x y) :
+private lemma cast_point_some {W₁ W₂ : Affine K} (h : W₁ = W₂) {x y : K}
+    (hp : W₁.Nonsingular x y) :
     AddEquiv.cast (M := fun W' : Affine K => W'.Point) h (Point.some x y hp) =
       Point.some x y (h ▸ hp) := by
   subst h; rfl
 
+open scoped Classical in
 /-- The base-change homomorphism on points, `W(K) →+ W(L)`: Mathlib's
 `WeierstrassCurve.Affine.Point.map`, aligned with the plain base change `W⁄L` via
 `baseChange_self`. -/
@@ -178,17 +190,17 @@ noncomputable def pointMap : W.Point →+ (W⁄L).toAffine.Point :=
   (Point.map (W' := W) (Algebra.ofId K L)).comp
     (AddEquiv.cast (M := fun W' : Affine K => W'.Point) W.baseChange_self.symm).toAddMonoidHom
 
-/-- The base-change map on an affine point carries its coordinates along `algebraMap K L`.
-
-The type ascription on the nonsingularity proof is load-bearing and cannot be dropped:
-`map_nonsingular` produces it at `W.map (algebraMap K L)`, and although `W⁄L` is a reducible
-abbreviation for exactly that, the elaborator does not unfold it at `instances` transparency,
-so the two printings do not unify without being told the target type. -/
+open scoped Classical in
+/-- The base-change map on an affine point carries its coordinates along `algebraMap K L`. -/
 @[simp]
 lemma pointMap_some {x y : K} (h : W.Nonsingular x y) : W.pointMap L (Point.some x y h) =
       Point.some (W' := (W⁄L).toAffine) (algebraMap K L x) (algebraMap K L y)
         (show (W⁄L).toAffine.Nonsingular (algebraMap K L x) (algebraMap K L y) from
           (W.map_nonsingular (algebraMap K L).injective x y).mpr h) := by
+  -- The type ascription above is load-bearing: `map_nonsingular` produces the nonsingularity
+  -- proof at `W.map (algebraMap K L)`, and although `W⁄L` is a reducible abbreviation for
+  -- exactly that, the elaborator does not unfold it at `instances` transparency, so the two
+  -- identically-printing types do not unify without being told the target.
   rw [pointMap, AddMonoidHom.comp_apply, AddEquiv.coe_toAddMonoidHom, cast_point_some,
     Point.map_some]
   rfl
@@ -235,7 +247,6 @@ theorem localRes_μX (x : K) :
     simp only [mapA_mk, Polynomial.map_sub,
       Polynomial.map_C, Polynomial.map_X]
 
-variable [DecidableEq K]
 
 open scoped Classical in
 /-- Naturality of the descent map under base change: restricting square classes after the

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
@@ -54,7 +54,7 @@ repository has a single spelling of square classes. Accordingly `localRes` is bu
 
 `pointMap` is Mathlib's `WeierstrassCurve.Affine.Point.map` and is not a new construction: the
 only content is the alignment of `W` with `W⁄K`, which `baseChange_self` supplies and
-`Point.congr` transports along.
+Mathlib's `AddEquiv.cast` transports along.
 
 ## Provenance
 
@@ -148,32 +148,31 @@ section PointMap
 
 variable [DecidableEq K] [DecidableEq L]
 
-/-- Transport of points along an equality of Weierstrass curves. -/
-def Point.congr {W₁ W₂ : Affine K} (h : W₁ = W₂) : W₁.Point ≃+ W₂.Point := by
-  subst h; exact AddEquiv.refl _
+/-- Transporting an affine point along an equality of curves carries its coordinates unchanged.
 
-lemma Point.congr_zero {W₁ W₂ : Affine K} (h : W₁ = W₂) :
-    Point.congr h (0 : W₁.Point) = 0 := by subst h; rfl
-
-lemma Point.congr_some {W₁ W₂ : Affine K} (h : W₁ = W₂) {x y : K} (hp : W₁.Nonsingular x y) :
-    Point.congr h (Point.some x y hp) = Point.some x y (h ▸ hp) := by subst h; rfl
+The transport itself is Mathlib's `AddEquiv.cast`, which is `Equiv.cast (congrArg _ h)` bundled
+as an `AddEquiv`; this is the one fact about it that mentions `Point.some`, and Mathlib has no
+lemma of that shape because `Point` is not one of its indexed families. -/
+lemma cast_point_some {W₁ W₂ : Affine K} (h : W₁ = W₂) {x y : K} (hp : W₁.Nonsingular x y) :
+    AddEquiv.cast (M := fun W' : Affine K => W'.Point) h (Point.some x y hp) =
+      Point.some x y (h ▸ hp) := by
+  subst h; rfl
 
 /-- The base-change homomorphism on points, `W(K) →+ W(L)`: Mathlib's
 `WeierstrassCurve.Affine.Point.map`, aligned with the plain base change `W⁄L` via
 `baseChange_self`. -/
 noncomputable def pointMap : W.Point →+ (W⁄L).toAffine.Point :=
   (Point.map (W' := W) (Algebra.ofId K L)).comp
-    (Point.congr (W.baseChange_self).symm).toAddMonoidHom
+    (AddEquiv.cast (M := fun W' : Affine K => W'.Point) W.baseChange_self.symm).toAddMonoidHom
 
 @[simp]
-lemma pointMap_zero : W.pointMap L 0 = 0 := by
-  simp [pointMap, Point.congr_zero]
+lemma pointMap_zero : W.pointMap L 0 = 0 := map_zero _
 
 lemma pointMap_some {x y : K} (h : W.Nonsingular x y) : W.pointMap L (Point.some x y h) =
       Point.some (W' := (W⁄L).toAffine) (algebraMap K L x) (algebraMap K L y)
         (show (W⁄L).toAffine.Nonsingular (algebraMap K L x) (algebraMap K L y) from
           (W.map_nonsingular (algebraMap K L).injective x y).mpr h) := by
-  rw [pointMap, AddMonoidHom.comp_apply, AddEquiv.coe_toAddMonoidHom, Point.congr_some,
+  rw [pointMap, AddMonoidHom.comp_apply, AddEquiv.coe_toAddMonoidHom, cast_point_some,
     Point.map_some]
   rfl
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
@@ -1,0 +1,255 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.XSubT
+
+/-!
+# Base change of the étale algebra, and the local condition of `2`-descent
+
+Let `W : y² = f(x) = x³ + a₂x² + a₄x + a₆` be an elliptic curve in characteristic `≠ 2` normal
+form over a field `K`, with étale algebra `A = K[X]⧸⟨f⟩` and descent map
+`μ : W(K) → M = Aˣ/(Aˣ)²`, as set up in
+`TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean`.
+
+Everything in that construction base-changes along a field extension `L/K` — in the arithmetic
+application `L` is a completion of `K`. This file builds that base change and uses it to define
+the **local condition** at `L`: the subgroup
+
+`W.localCondition L : Subgroup W.M`
+
+of square classes whose image in `(W⁄L).M` lies in the image of the local descent map `μ_L`. The
+`2`-Selmer group of `W` is cut out of `W.M` by these conditions at all completions of `K`, so
+`localCondition` is the object every later descent statement is phrased in.
+
+## Main definitions
+
+* `WeierstrassCurve.Affine.mapA`: the base-change homomorphism `K[X]⧸⟨f⟩ →+* L[X]⧸⟨f⟩` of étale
+  algebras.
+* `WeierstrassCurve.Affine.localRes`: the induced map `W.M →* (W⁄L).M` on square classes.
+* `WeierstrassCurve.Affine.pointMap`: the base-change homomorphism `W(K) →+ W(L)` on points.
+* `WeierstrassCurve.Affine.localCondition`: the local `2`-descent condition at `L`.
+
+## Main statements
+
+* `WeierstrassCurve.Affine.localRes_μX` and `WeierstrassCurve.Affine.localRes_comp_μ`: the
+  descent map is natural under base change — restricting square classes after the global `μ` is
+  applying the local `μ` after the base change of points.
+* `WeierstrassCurve.Affine.range_μ_le_localCondition`: the image of the global descent map
+  satisfies the local condition at every extension field. This is what makes `localCondition` a
+  *condition*: it is a constraint the classes coming from `W(K)` are known to satisfy, so the
+  intersection of the local conditions bounds `W(K)/2W(K)` from above.
+
+## Implementation notes
+
+Square classes are spelled `W.M`, the quotient of `W.Aˣ` by the range of `powMonoidHom 2`,
+following `XSubT.lean`; the source uses a local abbreviation `Units.modPow` for the same group,
+which is not a Mathlib declaration and which TauCeti deliberately does not carry, so that the
+repository has a single spelling of square classes. Accordingly `localRes` is built from
+`QuotientGroup.map` rather than from the source's `Units.modPow.map`.
+
+`pointMap` is Mathlib's `WeierstrassCurve.Affine.Point.map` and is not a new construction: the
+only content is the alignment of `W` with `W⁄K`, which `baseChange_self` supplies and
+`Point.congr` transports along.
+
+## Provenance
+
+Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+`EllipticCurves/SelmerGroup.lean` lines 85-295, which are that file's `BaseChange` section up to
+the local condition and its compatibility with `μ`.
+
+This advances `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6 (README:813-820), whose
+"Explicit `2`-descent (core, this layer)" bullet names "the local conditions" as the first item
+to migrate.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve
+
+namespace Affine
+
+variable {K : Type*} [Field K] (W : Affine K)
+
+section BaseChange
+
+variable {L₀ : Type*} [Field L₀] (σ : K →+* L₀)
+
+lemma map_f : (W.map σ).toAffine.f = W.f.map σ := by
+  simp only [f, Polynomial.map_add, Polynomial.map_pow, Polynomial.map_mul, Polynomial.map_X,
+    Polynomial.map_C, map_a₂, map_a₄, map_a₆]
+
+instance [W.IsCharNeTwoNF] : (W.map σ).IsCharNeTwoNF where
+  a₁ := by simp [map_a₁]
+  a₃ := by simp [map_a₃]
+
+lemma eval_map_f (x : K) : (W.map σ).toAffine.f.eval (σ x) = σ (W.f.eval x) := by
+  rw [map_f, Polynomial.eval_map, Polynomial.eval₂_at_apply]
+
+lemma map_fCofactor (x : K) : (W.fCofactor x).map σ = (W.map σ).toAffine.fCofactor (σ x) := by
+  simp only [fCofactor, Polynomial.map_add, Polynomial.map_pow, Polynomial.map_mul,
+    Polynomial.map_X, Polynomial.map_C, map_a₂, map_a₄, map_add, map_mul, map_pow]
+
+variable (L : Type*) [Field L] [Algebra K L]
+
+instance [W.IsCharNeTwoNF] : (W⁄L).IsCharNeTwoNF :=
+  inferInstanceAs (W.map (algebraMap K L)).IsCharNeTwoNF
+
+lemma eval_baseChange_f (x : K) :
+    (W⁄L).toAffine.f.eval (algebraMap K L x) = algebraMap K L (W.f.eval x) :=
+  W.eval_map_f (algebraMap K L) x
+
+lemma baseChange_fCofactor (x : K) :
+    (W.fCofactor x).map (algebraMap K L) = (W⁄L).toAffine.fCofactor (algebraMap K L x) :=
+  W.map_fCofactor (algebraMap K L) x
+
+lemma baseChange_f : (W⁄L).toAffine.f = W.f.map (algebraMap K L) :=
+  W.map_f (algebraMap K L)
+
+/-- The base-change homomorphism `K[X]⧸⟨f⟩ →+* L[X]⧸⟨f⟩` of étale algebras, as an instance of
+`AdjoinRoot.map` (so that its API — `map_of`, `map_root`, `map_comp_map`, `mapRingEquiv` —
+applies directly). -/
+noncomputable def mapA : W.A →+* (W⁄L).toAffine.A :=
+  AdjoinRoot.map (algebraMap K L) W.f (W⁄L).toAffine.f (W.baseChange_f L).dvd
+
+@[simp]
+lemma mapA_mk (p : K[X]) :
+    W.mapA L (AdjoinRoot.mk W.f p) = AdjoinRoot.mk (W⁄L).toAffine.f (p.map (algebraMap K L)) :=
+  AdjoinRoot.map_mk _ _
+
+/-- The base-change map on square classes of units of the étale algebra. -/
+noncomputable def localRes : W.M →* (W⁄L).toAffine.M :=
+  QuotientGroup.map _ _ (Units.map (W.mapA L).toMonoidHom) <| by
+    rintro _ ⟨u, rfl⟩
+    exact ⟨Units.map (W.mapA L).toMonoidHom u, by simp [powMonoidHom]⟩
+
+@[simp]
+lemma localRes_mk (u : W.Aˣ) :
+    W.localRes L (QuotientGroup.mk u) = QuotientGroup.mk (Units.map (W.mapA L).toMonoidHom u) :=
+  QuotientGroup.map_mk _ _ _ _ u
+
+@[simp]
+lemma localRes_unit {a : W.A} (ha : IsUnit a) :
+    W.localRes L (ha.unit : W.M) = ((ha.map (W.mapA L)).unit : (W⁄L).toAffine.M) := by
+  rw [localRes_mk]
+  exact congrArg _ (Units.ext rfl)
+
+lemma baseChange_self : (W⁄K).toAffine = W := by
+  change W.map (algebraMap K K) = W
+  rw [show algebraMap K K = RingHom.id K from Algebra.algebraMap_self]
+  exact W.map_id
+
+section PointMap
+
+variable [DecidableEq K] [DecidableEq L]
+
+/-- Transport of points along an equality of Weierstrass curves. -/
+def Point.congr {W₁ W₂ : Affine K} (h : W₁ = W₂) : W₁.Point ≃+ W₂.Point := by
+  subst h; exact AddEquiv.refl _
+
+lemma Point.congr_zero {W₁ W₂ : Affine K} (h : W₁ = W₂) :
+    Point.congr h (0 : W₁.Point) = 0 := by subst h; rfl
+
+lemma Point.congr_some {W₁ W₂ : Affine K} (h : W₁ = W₂) {x y : K} (hp : W₁.Nonsingular x y) :
+    Point.congr h (Point.some x y hp) = Point.some x y (h ▸ hp) := by subst h; rfl
+
+/-- The base-change homomorphism on points, `W(K) →+ W(L)`: Mathlib's
+`WeierstrassCurve.Affine.Point.map`, aligned with the plain base change `W⁄L` via
+`baseChange_self`. -/
+noncomputable def pointMap : W.Point →+ (W⁄L).toAffine.Point :=
+  (Point.map (W' := W) (Algebra.ofId K L)).comp
+    (Point.congr (W.baseChange_self).symm).toAddMonoidHom
+
+@[simp]
+lemma pointMap_zero : W.pointMap L 0 = 0 := by
+  simp [pointMap, Point.congr_zero]
+
+lemma pointMap_some {x y : K} (h : W.Nonsingular x y) : W.pointMap L (Point.some x y h) =
+      Point.some (W' := (W⁄L).toAffine) (algebraMap K L x) (algebraMap K L y)
+        (show (W⁄L).toAffine.Nonsingular (algebraMap K L x) (algebraMap K L y) from
+          (W.map_nonsingular (algebraMap K L).injective x y).mpr h) := by
+  rw [pointMap, AddMonoidHom.comp_apply, AddEquiv.coe_toAddMonoidHom, Point.congr_some,
+    Point.map_some]
+  rfl
+
+end PointMap
+
+variable [W.IsElliptic] [W.IsCharNeTwoNF]
+
+instance : (W⁄L).IsElliptic := inferInstanceAs (W.map (algebraMap K L)).IsElliptic
+
+open scoped Classical in
+/-- The local `2`-descent condition at the extension field `L` of `K` (in the applications,
+`L` is a completion of `K`): the subgroup of square classes in the étale algebra of `W`
+whose image over `L` comes from an `L`-point of the curve. -/
+noncomputable def localCondition : Subgroup W.M :=
+  ((μ (W := (W⁄L).toAffine)).range).comap (W.localRes L)
+
+open scoped Classical in
+lemma mem_localCondition_iff {m : W.M} :
+    m ∈ W.localCondition L ↔ W.localRes L m ∈ (μ (W := (W⁄L).toAffine)).range :=
+  Subgroup.mem_comap
+
+open scoped Classical in
+/-- The local restriction map is compatible with the `x - T` maps: the square class of
+`x - T` restricts to that of `σ(x) - T`, and likewise for the modified class at a
+`2`-torsion `x`-coordinate. -/
+theorem localRes_μX (x : K) :
+    W.localRes L (W.μX x) = μX (W := (W⁄L).toAffine) (algebraMap K L x) := by
+  rcases eq_or_ne (W.f.eval x) 0 with hx | hx
+  · have hxL : (W⁄L).toAffine.f.eval (algebraMap K L x) = 0 := by
+      rw [W.eval_baseChange_f, hx, map_zero]
+    rw [μX_of_eval_f_eq_zero hxL, μX_of_eval_f_eq_zero hx, localRes_unit]
+    refine congrArg _ (Units.ext ?_)
+    rw [IsUnit.unit_spec, IsUnit.unit_spec]
+    simp only [mapA_mk, Polynomial.map_add,
+      Polynomial.map_sub, Polynomial.map_C, Polynomial.map_X, W.baseChange_fCofactor]
+  · have hxL : (W⁄L).toAffine.f.eval (algebraMap K L x) ≠ 0 := by
+      rw [W.eval_baseChange_f]
+      exact fun h0 ↦ hx ((map_eq_zero _).mp h0)
+    rw [μX_of_eval_f_ne_zero hxL, μX_of_eval_f_ne_zero hx, localRes_unit]
+    refine congrArg _ (Units.ext ?_)
+    rw [IsUnit.unit_spec, IsUnit.unit_spec]
+    simp only [mapA_mk, Polynomial.map_sub,
+      Polynomial.map_C, Polynomial.map_X]
+
+variable [DecidableEq K]
+
+open scoped Classical in
+/-- Naturality of the descent map under base change: restricting square classes after the
+global `μ` is applying the local `μ` after the base change of points. -/
+theorem localRes_comp_μ : (W.localRes L).comp (μ (W := W)) =
+      (μ (W := (W⁄L).toAffine)).comp (AddMonoidHom.toMultiplicative (W.pointMap L)) := by
+  refine MonoidHom.ext fun P' ↦ ?_
+  obtain ⟨P, rfl⟩ := Multiplicative.ofAdd.surjective P'
+  simp only [MonoidHom.comp_apply, AddMonoidHom.toMultiplicative_apply_apply, toAdd_ofAdd,
+    μ_apply]
+  cases P with
+  | zero =>
+      rw [show (Point.zero : W.Point) = 0 from rfl, μ₀_zero, map_one, W.pointMap_zero L,
+        μ₀_zero (W := (W⁄L).toAffine)]
+  | some x y hP =>
+      rw [μ₀_some, W.pointMap_some L hP, μ₀_some (W := (W⁄L).toAffine), W.localRes_μX L x]
+
+open scoped Classical in
+/-- The image of the global descent map `μ` satisfies the local condition at every extension
+field: this is formal from the naturality `localRes_comp_μ`. -/
+theorem range_μ_le_localCondition : (μ (W := W)).range ≤ W.localCondition L := by
+  rw [localCondition, ← Subgroup.map_le_iff_le_comap, MonoidHom.map_range, localRes_comp_μ]
+  rintro _ ⟨P, rfl⟩
+  exact ⟨_, rfl⟩
+
+end BaseChange
+
+end Affine
+
+end WeierstrassCurve
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
@@ -77,6 +77,24 @@ namespace WeierstrassCurve
 
 namespace Affine
 
+section CommRing
+
+variable {R : Type*} [CommRing R] (W : Affine R)
+
+/-- Base changing along the identity algebra map returns the curve itself. Stated over a
+commutative ring: it is a formal `map` identity and uses nothing about `R` beyond its ring
+structure. -/
+lemma baseChange_self : (W⁄R).toAffine = W := by
+  -- `WeierstrassCurve.baseChange` (Weierstrass.lean:236) is a plain `def` and Mathlib exposes no
+  -- unfolding lemma for it, so this one definitional step cannot be replaced by an API rewrite.
+  -- It must be `change` rather than `show`: the step rewrites the goal rather than restating it,
+  -- which is exactly what `linter.style.show` requires. Everything after it is a named rewrite.
+  change W.map (algebraMap R R) = W
+  rw [show algebraMap R R = RingHom.id R from Algebra.algebraMap_self]
+  exact W.map_id
+
+end CommRing
+
 variable {K : Type*} [Field K] (W : Affine K)
 
 section BaseChange
@@ -139,11 +157,6 @@ lemma localRes_unit {a : W.A} (ha : IsUnit a) :
   rw [localRes_mk]
   exact congrArg _ (Units.ext rfl)
 
-lemma baseChange_self : (W⁄K).toAffine = W := by
-  change W.map (algebraMap K K) = W
-  rw [show algebraMap K K = RingHom.id K from Algebra.algebraMap_self]
-  exact W.map_id
-
 section PointMap
 
 variable [DecidableEq K] [DecidableEq L]
@@ -153,7 +166,7 @@ variable [DecidableEq K] [DecidableEq L]
 The transport itself is Mathlib's `AddEquiv.cast`, which is `Equiv.cast (congrArg _ h)` bundled
 as an `AddEquiv`; this is the one fact about it that mentions `Point.some`, and Mathlib has no
 lemma of that shape because `Point` is not one of its indexed families. -/
-lemma cast_point_some {W₁ W₂ : Affine K} (h : W₁ = W₂) {x y : K} (hp : W₁.Nonsingular x y) :
+private lemma cast_point_some {W₁ W₂ : Affine K} (h : W₁ = W₂) {x y : K} (hp : W₁.Nonsingular x y) :
     AddEquiv.cast (M := fun W' : Affine K => W'.Point) h (Point.some x y hp) =
       Point.some x y (h ▸ hp) := by
   subst h; rfl
@@ -165,9 +178,13 @@ noncomputable def pointMap : W.Point →+ (W⁄L).toAffine.Point :=
   (Point.map (W' := W) (Algebra.ofId K L)).comp
     (AddEquiv.cast (M := fun W' : Affine K => W'.Point) W.baseChange_self.symm).toAddMonoidHom
 
-@[simp]
-lemma pointMap_zero : W.pointMap L 0 = 0 := map_zero _
+/-- The base-change map on an affine point carries its coordinates along `algebraMap K L`.
 
+The type ascription on the nonsingularity proof is load-bearing and cannot be dropped:
+`map_nonsingular` produces it at `W.map (algebraMap K L)`, and although `W⁄L` is a reducible
+abbreviation for exactly that, the elaborator does not unfold it at `instances` transparency,
+so the two printings do not unify without being told the target type. -/
+@[simp]
 lemma pointMap_some {x y : K} (h : W.Nonsingular x y) : W.pointMap L (Point.some x y h) =
       Point.some (W' := (W⁄L).toAffine) (algebraMap K L x) (algebraMap K L y)
         (show (W⁄L).toAffine.Nonsingular (algebraMap K L x) (algebraMap K L y) from
@@ -190,6 +207,7 @@ noncomputable def localCondition : Subgroup W.M :=
   ((μ (W := (W⁄L).toAffine)).range).comap (W.localRes L)
 
 open scoped Classical in
+@[simp]
 lemma mem_localCondition_iff {m : W.M} :
     m ∈ W.localCondition L ↔ W.localRes L m ∈ (μ (W := (W⁄L).toAffine)).range :=
   Subgroup.mem_comap
@@ -230,7 +248,7 @@ theorem localRes_comp_μ : (W.localRes L).comp (μ (W := W)) =
     μ_apply]
   cases P with
   | zero =>
-      rw [show (Point.zero : W.Point) = 0 from rfl, μ₀_zero, map_one, W.pointMap_zero L,
+      rw [← Point.zero_def, μ₀_zero, map_one, map_zero (W.pointMap L),
         μ₀_zero (W := (W⁄L).toAffine)]
   | some x y hP =>
       rw [μ₀_some, W.pointMap_some L hP, μ₀_some (W := (W⁄L).toAffine), W.localRes_μX L x]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.XSubT
+public import TauCeti.AlgebraicGeometry.EllipticCurve.NormalForms
 
 /-!
 # Base change of the étale algebra, and the local condition of `2`-descent
@@ -86,10 +87,6 @@ lemma map_f : (W.map σ).toAffine.f = W.f.map σ := by
   simp only [f, Polynomial.map_add, Polynomial.map_pow, Polynomial.map_mul, Polynomial.map_X,
     Polynomial.map_C, map_a₂, map_a₄, map_a₆]
 
-instance [W.IsCharNeTwoNF] : (W.map σ).IsCharNeTwoNF where
-  a₁ := by simp [map_a₁]
-  a₃ := by simp [map_a₃]
-
 lemma eval_map_f (x : K) : (W.map σ).toAffine.f.eval (σ x) = σ (W.f.eval x) := by
   rw [map_f, Polynomial.eval_map, Polynomial.eval₂_at_apply]
 
@@ -98,9 +95,6 @@ lemma map_fCofactor (x : K) : (W.fCofactor x).map σ = (W.map σ).toAffine.fCofa
     Polynomial.map_X, Polynomial.map_C, map_a₂, map_a₄, map_add, map_mul, map_pow]
 
 variable (L : Type*) [Field L] [Algebra K L]
-
-instance [W.IsCharNeTwoNF] : (W⁄L).IsCharNeTwoNF :=
-  inferInstanceAs (W.map (algebraMap K L)).IsCharNeTwoNF
 
 lemma eval_baseChange_f (x : K) :
     (W⁄L).toAffine.f.eval (algebraMap K L x) = algebraMap K L (W.f.eval x) :=

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
@@ -135,7 +135,11 @@ lemma localRes_mk (u : W.Aˣ) :
     W.localRes L (QuotientGroup.mk u) = QuotientGroup.mk (Units.map (W.mapA L).toMonoidHom u) :=
   QuotientGroup.map_mk _ _ _ _ u
 
-@[simp]
+/-- The base-change map on square classes, on the class of a unit given as `IsUnit a`.
+
+Deliberately **not** `@[simp]`: the left-hand side is not in simp-normal form, because
+`localRes_mk` rewrites `W.localRes L ↑ha.unit` first, so the attribute could never fire. This
+lemma is for explicit `rw` at the `localRes_μX` call sites below. -/
 lemma localRes_unit {a : W.A} (ha : IsUnit a) :
     W.localRes L (ha.unit : W.M) = ((ha.map (W.mapA L)).unit : (W⁄L).toAffine.M) := by
   rw [localRes_mk]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -147,6 +147,25 @@ namespace WeierstrassCurve
 
 namespace Affine
 
+section CommRingCurve
+
+variable {R : Type*} [CommRing R] (W : Affine R)
+
+/-- The polynomial on the right hand side of a Weierstrass equation with `a₁ = a₃ = 0`.
+
+Defined over a commutative ring: it is a polynomial in the coefficients and uses nothing about
+`R` beyond its ring structure. The descent constructions below specialise it to a field. -/
+noncomputable abbrev f : R[X] := X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆
+
+/-- The synthetic cofactor of `f` at `x`, defined for every `x` by the coefficients of synthetic
+division: it satisfies `fCofactor x * (X - C x) = f - C (f.eval x)` (`fCofactor_mul_eq`). It is
+the quotient of `f` by `X - x` exactly when `x` is a root of `f`, which is the case
+`f_eq_mul_of_eval_eq_zero` records. -/
+noncomputable abbrev fCofactor (x : R) : R[X] :=
+  X ^ 2 + C (x + W.a₂) * X + C (x ^ 2 + W.a₂ * x + W.a₄)
+
+end CommRingCurve
+
 variable {K : Type*} [Field K] (W : Affine K)
 
 lemma ringChar_ne_two [W.IsElliptic] [W.IsCharNeTwoNF] : ringChar K ≠ 2 := by
@@ -163,9 +182,6 @@ lemma ringChar_ne_two [W.IsElliptic] [W.IsCharNeTwoNF] : ringChar K ≠ 2 := by
 /-!
 ### The étale algebra `A`
 -/
-
-/-- The polynomial on the right hand side of a Weierstrass equation with `a₁ = a₃ = 0`. -/
-noncomputable abbrev f : K[X] := X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆
 
 lemma natDegree_f : W.f.natDegree = 3 := by
   simp only [f]
@@ -232,13 +248,6 @@ lemma negY_of_isCharNeTwoNF [W.IsCharNeTwoNF] (x y : K) : W.negY x y = -y := by
 lemma y_ne_zero_of_eval_f_ne_zero [W.IsCharNeTwoNF] {x y : K} (h : W.Equation x y)
     (hx : W.f.eval x ≠ 0) : y ≠ 0 :=
   fun h0 ↦ hx <| by simp [(equation_iff_eval_f_eq_sq W x y).mp h, h0]
-
-/-- The synthetic cofactor of `f` at `x`, defined for every `x` by the coefficients of synthetic
-division: it satisfies `fCofactor x * (X - C x) = f - C (f.eval x)` (`fCofactor_mul_eq`). It is
-the quotient of `f` by `X - x` exactly when `x` is a root of `f`, which is the case
-`f_eq_mul_of_eval_eq_zero` records. -/
-noncomputable abbrev fCofactor (x : K) : K[X] :=
-  X ^ 2 + C (x + W.a₂) * X + C (x ^ 2 + W.a₂ * x + W.a₄)
 
 lemma natDegree_fCofactor (x : K) : (W.fCofactor x).natDegree = 2 := by
   simp only [fCofactor]


### PR DESCRIPTION
Base change of the étale algebra along a field extension `L/K`, and the **local condition** of explicit `2`-descent that every later descent rung is stated in terms of.

Building on `MordellWeil/XSubT.lean` (the `x - T` map `μ : W(K) → M = Aˣ/(Aˣ)²`), this adds a new module `MordellWeil/LocalCondition.lean`:

* `mapA : W.A →+* (W⁄L).A` — base change of the étale algebra `K[X]⧸⟨f⟩`, as an instance of `AdjoinRoot.map`;
* `localRes : W.M →* (W⁄L).M` — the induced map on square classes;
* `pointMap : W(K) →+ W(L)` — base change on points;
* `localCondition L : Subgroup W.M` — the classes whose image over `L` comes from an `L`-point;
* `localRes_μX`, `localRes_comp_μ` — naturality of the descent map under base change;
* `range_μ_le_localCondition` — the image of the global `μ` satisfies the local condition at every `L`. This is what makes `localCondition` a *condition*: the intersection over all completions bounds `W(K)/2W(K)` from above.

## Roadmap

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, README:813-820 — the "**Explicit `2`-descent (core, this layer)**" bullet:

> The Stoll development already contains arithmetic `2`-descent: **the local conditions**, the explicit `2`-Selmer group inside the square classes of the étale algebra `K[X]/(f)`, its finiteness, and the theorem converting its cardinality into a **Mordell–Weil rank bound** — none of which needs Layer 7's cohomological framework. Migrate it here as its own lane […]

README:1187-1189 names the same list again ("the local conditions, the étale-algebra `2`-Selmer group, its finiteness, the rank-bound theorem"). "The local conditions" is the first item of that migration, and this PR is it.

## Attribution

Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0), pinned by `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, file `EllipticCurves/SelmerGroup.lean` lines 85-295 — that file's `BaseChange` section up to the local condition and its compatibility with `μ`. The source module carries no `maxHeartbeats` override, so none was stripped and none is added.

## Deliberate deviations from the source

**Square classes are spelled `W.M`, not `Units.modPow`.** `Units.modPow` is a *local abbreviation of Stoll's*, not a Mathlib declaration (checked at the pinned Mathlib `618f225e1ff4`: zero occurrences of `modPow`, against a control of 66 files for `Units.map`). `XSubT.lean` already made the decision to spell square classes as `W.Aˣ ⧸ (powMonoidHom 2).range` "so that TauCeti carries a single spelling of square classes", and this PR follows it. Concretely, `localRes` is built from `QuotientGroup.map` rather than the source's `Units.modPow.map`, and `localRes_unit` is stated against `IsUnit.unit` in that quotient.

**`pointMap` is Mathlib's `Point.map`, not a new construction.** The only content is aligning `W` with `W⁄K`, which `baseChange_self` supplies and `Point.congr` transports along. Mathlib's `WeierstrassCurve.Affine.Point.map` / `Point.baseChange` do the actual work.

## Not in this PR, and why

The rest of the source's `BaseChange` section (lines 296-336) is left for a follow-up, for concrete missing prerequisites rather than for size:

* `norm_mapA`, `normM_localRes` need the norm map `normM` on square classes, which is the source's **Step 5**; `XSubT.lean` deliberately excluded that step ("the two lemmas computing the norm of `x - T` are not part of this file"), and they further need `AdjoinRoot.norm_mk_eq_resultant` and `resultant_map_map`, neither of which is on `main` or in the pinned Mathlib.
* `card_range_μ_of_isAlgClosed` needs `Units.modPow.subsingleton_of_isAlgClosed_of_isIntegral` and `AdjoinRoot.modPowEquivPiFactors`, both source-local and both phrased in the `Units.modPow` spelling this repository does not carry.
* The isomorphism-invariance block (`bijective_mapA_of_bijective_algebraMap`, `range_μ_of_bijective_algebraMap`, `card_range_μ_of_bijective_algebraMap`, `card_ker_nsmul_two_baseChange`) is a self-contained follow-on and is the natural second PR.

## Prior art / dedupe

Re-measured against **both** current `main` and the pinned Mathlib `618f225e1ff4`, with a positive control for every instrument:

| name | `main` | pinned Mathlib | control |
|---|---|---|---|
| `localCondition` | 0 | 0 | `def μX` = 1 on `main` |
| `def localRes` | 0 | 0 | ″ |
| `def mapA` (word-boundary) | 0 | 0 | ″ |
| `def pointMap` (word-boundary) | 0 | 0 | ″ |
| `modPow` | 0 | 0 | `Units.map` = 66 files in Mathlib |

Two near-misses worth recording, both checked and both **not** duplicates:

* An unanchored grep for `mapA` appears to hit ~20 files on `main`; those are all the prefix of `mapAlgHom` (`Tangent/Basic.lean:299` and friends). Nothing on `main` is named `mapA`.
* `pointMap` **is** a live name on `main` — `GroupScheme/CentralIsogeny/Basic.lean:69` — but for a different subject (`f : G ⟶ H` in `Grp (Over X)`, group schemes over a base). This PR's `pointMap` stays inside `WeierstrassCurve.Affine`, so the two never collide.

Searching by *object* rather than by name also turned up Mathlib's `Affine.Point.map` / `Point.baseChange` and `main`'s `Affine/Point/MapAlong.lean`; `pointMap` is built on the former rather than re-deriving it, and `mapAlong` is a plain function on points along a ring hom, not the bundled `→+` base change needed here.

### Correction after review round 1

The sweep above measured the port's *headline objects*. It did not measure the **instances** the
port re-declares in passing, and the `reuse` rubric correctly caught two:
`TauCeti/AlgebraicGeometry/EllipticCurve/NormalForms.lean:41,47` already carries
`isCharNeTwoNF_map` and `isCharNeTwoNF_baseChange`, over any `CommRing` hom rather than a field
extension. Both local copies are deleted and that module is now imported.

They were not shadowing the existing instances — TauCeti's `NormalForms` was not in scope at all:
`XSubT.lean` imports *Mathlib's* `EllipticCurve.NormalForms`, and its three TauCeti imports pull
in only Mathlib modules. That is why the duplication compiled silently rather than clashing, and
why the added `public import` is load-bearing.

`instance : (W⁄L).IsElliptic` was checked and **kept**: Mathlib has `(W.map f).IsElliptic`
(`Weierstrass.lean:448`) but nothing for the `baseChange` spelling, and instance search does not
unfold it — the same reason `NormalForms.lean:47` states its `baseChange` variant separately.

## Namespace

`WeierstrassCurve.Affine`, extending Mathlib's namespace rather than sitting under `TauCeti` — forced by dot notation (`W.f`, `W.A`, `W.M` resolve on the structure's namespace), exactly the precedent `XSubT.lean` and `TauCeti/RingTheory/AdjoinRoot.lean` already set.
