### PR TITLE
feat(FormalGroup): the w-equation at an arbitrary parameter, and its uniqueness

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -20,7 +20,7 @@ which determines a unique power series `w(z) ∈ R⟦z⟧` with no terms below `
 constructs that series, proves it satisfies the equation, and proves it is the only series with
 vanishing constant coefficient that does.
 
-The equation is also recorded with its parameter left free, as `WeierstrassCurve.wEquationRhs`,
+The equation is also recorded with its parameter left free, as `WeierstrassCurve.wEquationRHS`,
 and its solution shown unique at any parameter: the formal group obtains the inverse and the
 group law by substitution, and a substituted series solves the equation at the substituted
 parameter rather than at `z`.
@@ -31,7 +31,7 @@ parameter rather than at `z`.
 * `WeierstrassCurve.formalW`: the series `w(z)` itself.
 * `WeierstrassCurve.formalUCoeff`, `WeierstrassCurve.formalU`: the coefficients, and the series
   itself, of `u(z) = w(z) / z ^ 3`.
-* `WeierstrassCurve.wEquationRhs`: the right-hand side of the displayed equation, with both the
+* `WeierstrassCurve.wEquationRHS`: the right-hand side of the displayed equation, with both the
   parameter and the unknown left free.
 
 ## Main results
@@ -42,8 +42,7 @@ parameter rather than at `z`.
   power series with vanishing constant coefficient satisfying that equation equals `w(z)`. The
   two together are the full statement, that `w(z)` is *the* such series.
 * `WeierstrassCurve.eq_of_wEquation`: uniqueness at an arbitrary parameter — two series with
-  vanishing constant coefficient solving the equation at the same parameter are equal. Proved
-  by contraction rather than by coefficients, so it needs a `CommRing`.
+  vanishing constant coefficient solving the equation at the same parameter are equal.
 * `WeierstrassCurve.formalWCoeff_recurrence`: the coefficientwise recurrence — each coefficient
   of `w(z)` above the leading one, from the strictly earlier ones. This is the form to compute
   with; the strong recursion behind `formalWCoeff` is an implementation detail.
@@ -51,7 +50,7 @@ parameter rather than at `z`.
   `WeierstrassCurve.formalWCoeff_eq_zero_of_lt`: the series begins `w(z) = z ^ 3 + ⋯`.
 * `WeierstrassCurve.formalW_eq_X_pow_mul_formalU`: `w(z) = z ^ 3 * u(z)`, where
   `WeierstrassCurve.constantCoeff_formalU` gives `u(0) = 1`. Over a `CommRing` that makes `u(z)`
-  a unit; at the `CommSemiring` generality of that section it does not.
+  a unit; at the `CommSemiring` generality of this file it does not.
 
 ## Scope
 
@@ -68,12 +67,15 @@ by `TauCetiRoadmap/EllipticCurves/README.md` at `dev/hasse-weil @ 513e83879e2f`)
 `HasseWeil/FormalGroup.lean`, declarations `formalW_step`, `formalW_coeff`, `formalW`,
 `formalU_coeff`, the `formalW_coeff_*` lemmas and `formalW_recurrence`.
 
-The uniqueness statement at an arbitrary parameter, and its contraction proof, are adapted from
-Michael Stoll's `EllipticCurves` project (`github.com/MichaelStollBayreuth/EllipticCurves`,
-Apache-2.0, pinned by `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
-`EllipticCurves/WeierstrassFormalGroup/Chord.lean`, declarations `wStepAt`, `wStepAt_contract`
-and `eq_of_wStepAt_fixed`. There the equation is a `def` used only internally; here it is the
-public `wEquationRhs`, so the existing statements in this file are phrased through it too.
+The statement of uniqueness at an arbitrary parameter is adapted from Michael Stoll's
+`EllipticCurves` project (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+`EllipticCurves/WeierstrassFormalGroup/Chord.lean`, declarations `wStepAt` and
+`eq_of_wStepAt_fixed`. There the equation is a `def` used only internally; here it is the public
+`wEquationRHS`, so the existing statements in this file are phrased through it too. The proof is
+not the source's: it argues by contraction for the `z`-adic filtration, which needs subtraction,
+whereas the coefficient induction used here works at the `CommSemiring` generality of the rest of
+this file.
 
 Changes from the source. The source's convolution helpers `conv₂` and `conv₃`, and its
 coefficient and truncation lemmas for them, are stated only for `formalW`, although none of
@@ -229,18 +231,25 @@ at other parameters — substituting a series into `w(z)` solves the equation at
 the parameter is left free. Every occurrence of the unknown is multiplied by `q` or sits in a
 square or a cube, which is what makes the solution unique (`eq_of_wEquation`).
 
-The definition is `@[expose]`d because it is a plain algebraic expression with nothing to keep
-back, and every use of it wants to see the shape. -/
-@[expose] noncomputable def wEquationRhs (W : WeierstrassCurve R) (q v : PowerSeries R) :
+Rewrite with `wEquationRHS_def` rather than unfolding this definition. -/
+noncomputable def wEquationRHS (W : WeierstrassCurve R) (q v : PowerSeries R) :
     PowerSeries R :=
   q ^ 3 + PowerSeries.C W.a₁ * q * v + PowerSeries.C W.a₂ * q ^ 2 * v +
     PowerSeries.C W.a₃ * v ^ 2 + PowerSeries.C W.a₄ * q * v ^ 2 + PowerSeries.C W.a₆ * v ^ 3
 
+/-- The defining formula for `wEquationRHS`. -/
+theorem wEquationRHS_def (W : WeierstrassCurve R) (q v : PowerSeries R) :
+    wEquationRHS W q v =
+      q ^ 3 + PowerSeries.C W.a₁ * q * v + PowerSeries.C W.a₂ * q ^ 2 * v +
+        PowerSeries.C W.a₃ * v ^ 2 + PowerSeries.C W.a₄ * q * v ^ 2 +
+        PowerSeries.C W.a₆ * v ^ 3 :=
+  (rfl)
+
 /-- The `n`-th coefficient of the right-hand side of the `w`-equation, for an arbitrary series
 `w`, expressed through the coefficients of `w` itself. Every occurrence of `w` on the right is
 multiplied by `X` or appears in a square or a cube. -/
-private theorem coeff_wEquationRhs (w : PowerSeries R) (n : ℕ) :
-    PowerSeries.coeff n (wEquationRhs W PowerSeries.X w) =
+private theorem coeff_wEquationRHS (w : PowerSeries R) (n : ℕ) :
+    PowerSeries.coeff n (wEquationRHS W PowerSeries.X w) =
       (if n = 3 then 1 else 0) +
         W.a₁ * (if 1 ≤ n then PowerSeries.coeff (n - 1) w else 0) +
         W.a₂ * (if 2 ≤ n then PowerSeries.coeff (n - 2) w else 0) +
@@ -249,7 +258,7 @@ private theorem coeff_wEquationRhs (w : PowerSeries R) (n : ℕ) :
             PowerSeries.selfConvTwo (fun k => PowerSeries.coeff k w) (n - 1)
           else 0) +
         W.a₆ * PowerSeries.selfConvThree (fun k => PowerSeries.coeff k w) n := by
-  rw [wEquationRhs]
+  rw [wEquationRHS_def]
   -- `PowerSeries.coeff_C_mul` and `PowerSeries.coeff_X_pow_mul'` each need their argument in the
   -- shape `C a * (X ^ d * f)`, so first reassociate the three products and write the bare `X` as
   -- `X ^ 1`. Rewriting `← pow_one` directly is not an option: it would also fire inside `X ^ 3`.
@@ -273,14 +282,14 @@ private theorem coeff_wEquationRhs (w : PowerSeries R) (n : ℕ) :
 from the Weierstrass equation of `W` by the substitution `x = z / w`, `y = -1 / w`. -/
 theorem formalW_wEquation :
     formalW W =
-      wEquationRhs W PowerSeries.X (formalW W) := by
+      wEquationRHS W PowerSeries.X (formalW W) := by
   have hlow : ∀ k, k < 3 → formalWCoeff W k = 0 := fun _ hk => formalWCoeff_eq_zero_of_lt W hk
   have hc2 : ∀ m, m < 6 → PowerSeries.selfConvTwo (formalWCoeff W) m = 0 :=
     fun _ hm => PowerSeries.selfConvTwo_eq_zero hlow hm
   have hc3 : ∀ m, m < 9 → PowerSeries.selfConvThree (formalWCoeff W) m = 0 :=
     fun _ hm => PowerSeries.selfConvThree_eq_zero hlow hm
   ext n
-  rw [coeff_wEquationRhs]
+  rw [coeff_wEquationRHS]
   simp only [coeff_formalW]
   rcases lt_trichotomy n 3 with h | h | h
   · interval_cases n <;> simp [hc2, hc3]
@@ -302,7 +311,7 @@ coefficients to vanish as well, because every occurrence of `w` on its right-han
 multiplied by `X` or sits in a square or a cube. -/
 theorem eq_formalW_of_wEquation (w : PowerSeries R)
     (h0 : PowerSeries.constantCoeff w = 0)
-    (hw : w = wEquationRhs W PowerSeries.X w) :
+    (hw : w = wEquationRHS W PowerSeries.X w) :
     w = formalW W := by
   rw [← PowerSeries.coeff_zero_eq_constantCoeff_apply] at h0
   -- Degrees `1` and `2` are forced, so the induction below can still start from degree `3`.
@@ -310,7 +319,7 @@ theorem eq_formalW_of_wEquation (w : PowerSeries R)
     intro k hk; interval_cases k; exact h0
   have h1 : PowerSeries.coeff 1 w = 0 := by
     have hL := congrArg (PowerSeries.coeff 1) hw
-    rw [coeff_wEquationRhs,
+    rw [coeff_wEquationRHS,
       PowerSeries.selfConvTwo_eq_zero hv0 (show (1 : ℕ) < 2 * 1 by omega),
       PowerSeries.selfConvTwo_eq_zero hv0 (show (1 : ℕ) - 1 < 2 * 1 by omega),
       PowerSeries.selfConvThree_eq_zero hv0 (show (1 : ℕ) < 3 * 1 by omega)] at hL
@@ -319,7 +328,7 @@ theorem eq_formalW_of_wEquation (w : PowerSeries R)
     intro k hk; interval_cases k; exacts [h0, h1]
   have h2 : PowerSeries.coeff 2 w = 0 := by
     have hL := congrArg (PowerSeries.coeff 2) hw
-    rw [coeff_wEquationRhs,
+    rw [coeff_wEquationRHS,
       PowerSeries.selfConvTwo_eq_zero hv1 (show (2 : ℕ) < 2 * 2 by omega),
       PowerSeries.selfConvTwo_eq_zero hv1 (show (2 : ℕ) - 1 < 2 * 2 by omega),
       PowerSeries.selfConvThree_eq_zero hv1 (show (2 : ℕ) < 3 * 2 by omega)] at hL
@@ -333,7 +342,7 @@ theorem eq_formalW_of_wEquation (w : PowerSeries R)
   ext n
   -- The equation determines each coefficient from the strictly earlier ones, so this is a
   -- strong induction: at index `n` the right-hand side involves `w` only below `n`, by
-  -- `coeff_wEquationRhs` together with `PowerSeries.selfConvTwo_congr` and
+  -- `coeff_wEquationRHS` together with `PowerSeries.selfConvTwo_congr` and
   -- `PowerSeries.selfConvThree_congr`.
   induction n using Nat.strong_induction_on with
   | _ n ih =>
@@ -341,11 +350,11 @@ theorem eq_formalW_of_wEquation (w : PowerSeries R)
     · rw [hlow n h, coeff_formalW, formalWCoeff_eq_zero_of_lt W h]
     · subst h
       have hL := congrArg (PowerSeries.coeff 3) hw
-      rw [coeff_wEquationRhs] at hL
+      rw [coeff_wEquationRHS] at hL
       rw [hL, coeff_formalW, formalWCoeff_three]
       simp [hlow 1 (by omega), hlow 2 (by omega), hc2, hc3]
     · have hL := congrArg (PowerSeries.coeff n) hw
-      rw [coeff_wEquationRhs] at hL
+      rw [coeff_wEquationRHS] at hL
       have hw0 : (fun k => PowerSeries.coeff k w) 0 = 0 := hlow 0 (by omega)
       have hf0 : (fun k => formalWCoeff W k) 0 = 0 := formalWCoeff_zero W
       have hagree : ∀ m, m < n → PowerSeries.coeff m w = formalWCoeff W m := fun m hm => by
@@ -367,71 +376,69 @@ theorem eq_formalW_of_wEquation (w : PowerSeries R)
 `z`. The formal group needs the same statement at an arbitrary parameter series, because the
 inverse and the group law are obtained by substituting one series into another, and such a
 substitution solves the equation at the substituted parameter rather than at `z`.
-
-The argument is different from the one above: instead of computing coefficients, it shows the
-right-hand side is a contraction for the `z`-adic filtration, so two solutions agree to every
-order. That needs subtraction, hence a `CommRing` here rather than a `CommSemiring`.
 -/
 
-section CommRing
+/-- Multiplying by a series with vanishing constant coefficient makes the `n`-th coefficient of
+the product depend only on the coefficients of the other factor strictly below `n`: the term
+that would use the `n`-th one carries the vanishing constant coefficient. -/
+private theorem coeff_mul_congr {q v v' : PowerSeries R}
+    (hq : PowerSeries.constantCoeff q = 0) {n : ℕ}
+    (h : ∀ m, m < n → PowerSeries.coeff m v = PowerSeries.coeff m v') :
+    PowerSeries.coeff n (q * v) = PowerSeries.coeff n (q * v') := by
+  have hq0 : PowerSeries.coeff 0 q = 0 := by
+    rwa [PowerSeries.coeff_zero_eq_constantCoeff_apply]
+  rw [PowerSeries.coeff_mul, PowerSeries.coeff_mul]
+  refine Finset.sum_congr rfl fun p hp => ?_
+  rw [Finset.mem_antidiagonal] at hp
+  rcases Nat.eq_zero_or_pos p.1 with h1 | h1
+  · rw [h1, hq0, zero_mul, zero_mul]
+  · rw [h p.2 (by omega)]
 
-variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
-
-/-- The right-hand side of the `w`-equation contracts: two candidates at the same parameter that
-agree to order `k` have images agreeing to order `k + 1`. Every occurrence of the unknown on the
-right is multiplied by the parameter or sits in a square or a cube, and each of those is
-divisible by one more power of `z` than the difference it is built from. -/
-private theorem X_pow_succ_dvd_wEquationRhs_sub {q u v : PowerSeries R}
-    (hq : (PowerSeries.X : PowerSeries R) ∣ q) (hu : (PowerSeries.X : PowerSeries R) ∣ u)
-    (hv : (PowerSeries.X : PowerSeries R) ∣ v) {k : ℕ}
-    (h : (PowerSeries.X : PowerSeries R) ^ k ∣ u - v) :
-    (PowerSeries.X : PowerSeries R) ^ (k + 1) ∣ wEquationRhs W q u - wEquationRhs W q v := by
-  have hsq : (PowerSeries.X : PowerSeries R) ^ (k + 1) ∣ u ^ 2 - v ^ 2 := by
-    have huv : u ^ 2 - v ^ 2 = (u + v) * (u - v) := by ring
-    rw [huv, pow_succ, mul_comm ((PowerSeries.X : PowerSeries R) ^ k)]
-    exact mul_dvd_mul (dvd_add hu hv) h
-  have hcb : (PowerSeries.X : PowerSeries R) ^ (k + 1) ∣ u ^ 3 - v ^ 3 := by
-    have huv : u ^ 3 - v ^ 3 = (u ^ 2 + u * v + v ^ 2) * (u - v) := by ring
-    rw [huv, pow_succ, mul_comm ((PowerSeries.X : PowerSeries R) ^ k)]
-    refine mul_dvd_mul (dvd_add (dvd_add ?_ (hu.mul_right v)) ?_) h
-    · rw [pow_two]; exact hu.mul_right u
-    · rw [pow_two]; exact hv.mul_right v
-  have hpar : (PowerSeries.X : PowerSeries R) ^ (k + 1) ∣ q * (u - v) := by
-    rw [pow_succ, mul_comm ((PowerSeries.X : PowerSeries R) ^ k)]
-    exact mul_dvd_mul hq h
-  have hsplit : wEquationRhs W q u - wEquationRhs W q v =
-      PowerSeries.C W.a₁ * (q * (u - v)) + PowerSeries.C W.a₂ * q * (q * (u - v)) +
-        PowerSeries.C W.a₃ * (u ^ 2 - v ^ 2) + PowerSeries.C W.a₄ * q * (u ^ 2 - v ^ 2) +
-        PowerSeries.C W.a₆ * (u ^ 3 - v ^ 3) := by
-    simp only [wEquationRhs]
-    ring
-  rw [hsplit]
-  exact dvd_add (dvd_add (dvd_add (dvd_add (hpar.mul_left _) (hpar.mul_left _))
-    (hsq.mul_left _)) (hsq.mul_left _)) (hcb.mul_left _)
+/-- The `n`-th coefficient of the right-hand side of the `w`-equation depends only on the
+coefficients of the unknown strictly below `n`. This is the whole content of uniqueness: every
+occurrence of the unknown is multiplied by the parameter, which has vanishing constant
+coefficient, or sits in a square or a cube of a series with vanishing constant coefficient. -/
+private theorem coeff_wEquationRHS_congr {q v v' : PowerSeries R}
+    (hq : PowerSeries.constantCoeff q = 0) (hv : PowerSeries.constantCoeff v = 0)
+    (hv' : PowerSeries.constantCoeff v' = 0) {n : ℕ}
+    (h : ∀ m, m < n → PowerSeries.coeff m v = PowerSeries.coeff m v') :
+    PowerSeries.coeff n (wEquationRHS W q v) = PowerSeries.coeff n (wEquationRHS W q v') := by
+  have hv0 : (fun k => PowerSeries.coeff k v) 0 = 0 := by
+    simpa using hv
+  have hv'0 : (fun k => PowerSeries.coeff k v') 0 = 0 := by
+    simpa using hv'
+  have hsq : ∀ m, m ≤ n → PowerSeries.coeff m (v ^ 2) = PowerSeries.coeff m (v' ^ 2) := by
+    intro m hm
+    rw [PowerSeries.coeff_pow_two_eq_selfConvTwo, PowerSeries.coeff_pow_two_eq_selfConvTwo]
+    exact PowerSeries.selfConvTwo_congr hv0 hv'0 fun k hk => h k (by omega)
+  have hcb : PowerSeries.coeff n (v ^ 3) = PowerSeries.coeff n (v' ^ 3) := by
+    rw [PowerSeries.coeff_pow_three_eq_selfConvThree,
+      PowerSeries.coeff_pow_three_eq_selfConvThree]
+    exact PowerSeries.selfConvThree_congr hv0 hv'0 h
+  have hq2 : PowerSeries.constantCoeff (q ^ 2) = 0 := by
+    rw [map_pow, hq]
+    simp
+  rw [wEquationRHS_def, wEquationRHS_def]
+  simp only [map_add, mul_assoc, PowerSeries.coeff_C_mul]
+  rw [coeff_mul_congr hq h, coeff_mul_congr hq2 h, hsq n le_rfl,
+    coeff_mul_congr hq fun m hm => hsq m hm.le, hcb]
 
 /-- **Uniqueness of the solution of the `w`-equation, at an arbitrary parameter.** Two power
 series with vanishing constant coefficient that satisfy the `w`-equation at the same parameter
 series are equal.
 
-`eq_formalW_of_wEquation` is the case `q = z`, where the solution is `formalW W`; it is proved
-separately because it holds already over a `CommSemiring`, which this does not. -/
+`eq_formalW_of_wEquation` is the case `q = z`, where the solution is moreover identified as
+`formalW W`. -/
 theorem eq_of_wEquation {q v v' : PowerSeries R} (hq : PowerSeries.constantCoeff q = 0)
     (hv : PowerSeries.constantCoeff v = 0) (hv' : PowerSeries.constantCoeff v' = 0)
-    (h : v = wEquationRhs W q v) (h' : v' = wEquationRhs W q v') : v = v' := by
-  rw [← PowerSeries.X_dvd_iff] at hq hv hv'
-  -- The two solutions agree to every order, because each step of the equation gains a power
-  -- of `z` on the difference.
-  have key : ∀ k : ℕ, (PowerSeries.X : PowerSeries R) ^ k ∣ v - v' := by
-    intro k
-    induction k with
-    | zero => simp
-    | succ k ih =>
-      have hstep := X_pow_succ_dvd_wEquationRhs_sub W hq hv hv' ih
-      rwa [← h, ← h'] at hstep
+    (h : v = wEquationRHS W q v) (h' : v' = wEquationRHS W q v') : v = v' := by
   ext n
-  have hn := PowerSeries.X_pow_dvd_iff.mp (key (n + 1)) n (by omega)
-  rwa [map_sub, sub_eq_zero] at hn
-
-end CommRing
+  -- Each coefficient is determined by the strictly earlier ones, by `coeff_wEquationRHS_congr`.
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    have hL := congrArg (PowerSeries.coeff n) h
+    have hR := congrArg (PowerSeries.coeff n) h'
+    rw [hL, hR]
+    exact coeff_wEquationRHS_congr W hq hv hv' ih
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -47,7 +47,8 @@ equation at the substituted parameter rather than at `z`.
   that parameter are equal.
 * `WeierstrassCurve.subst_wEquationRHS` and `WeierstrassCurve.subst_formalW_wEquation`:
   substituting a series `q` into the equation gives the equation at `q`, so `w(q)` solves it
-  there. With `eq_of_wEquation` this is what identifies substituted solutions.
+  there. When moreover `constantCoeff q = 0`, `eq_subst_formalW_of_wEquation` combines this with
+  `eq_of_wEquation` to identify `w(q)` as the only such solution.
 * `WeierstrassCurve.formalWCoeff_recurrence`: the coefficientwise recurrence — each coefficient
   of `w(z)` above the leading one, from the strictly earlier ones. This is the form to compute
   with; the strong recursion behind `formalWCoeff` is an implementation detail.
@@ -55,7 +56,7 @@ equation at the substituted parameter rather than at `z`.
   `WeierstrassCurve.formalWCoeff_eq_zero_of_lt`: the series begins `w(z) = z ^ 3 + ⋯`.
 * `WeierstrassCurve.formalW_eq_X_pow_mul_formalU`: `w(z) = z ^ 3 * u(z)`, where
   `WeierstrassCurve.constantCoeff_formalU` gives `u(0) = 1`. Over a `CommRing` that makes `u(z)`
-  a unit; at the `CommSemiring` generality of this file it does not.
+  a unit; at the `CommSemiring` generality of that section it does not.
 
 ## Scope
 
@@ -78,27 +79,30 @@ The statement of uniqueness at an arbitrary parameter is adapted from Michael St
 `EllipticCurves/WeierstrassFormalGroup/Chord.lean`, declarations `wStepAt` and
 `eq_of_wStepAt_fixed`. There the equation is a `def` used only internally; here it is the public
 `wEquationRHS`, so the existing statements in this file are phrased through it too. The proof is
-not the source's: it argues by contraction for the `z`-adic filtration, which needs subtraction,
-whereas the coefficient induction used here works at the `CommSemiring` generality of the rest of
-this file.
+not Stoll's: that argues by contraction for the `z`-adic filtration, which needs subtraction,
+whereas the coefficient induction used here works at the `CommSemiring` generality of everything
+in this file except the substitution lemmas, which are `CommRing` only because Mathlib's
+`PowerSeries.subst` is.
 
-Changes from the source. The source's convolution helpers `conv₂` and `conv₃`, and its
+Changes from the AINTLIB source. Its convolution helpers `conv₂` and `conv₃`, and its
 coefficient and truncation lemmas for them, are stated only for `formalW`, although none of
 those proofs uses anything about that series. Generalised to an arbitrary series — and to a
 `Semiring`, which is all they need — they are not elliptic-curve material at all, and live in
 `TauCeti.RingTheory.PowerSeries.SelfConvolution`, which this file imports and which carries
 their attribution.
 
-The source works over a commutative ring. Nothing here needs additive inverses — the equation,
-the recursion and both halves of IV.1.1(a) use only sums and products — so everything is stated
-over a `CommSemiring`.
+The AINTLIB source works over a commutative ring. Nothing there needs additive inverses — the
+equation, the recursion and both halves of IV.1.1(a) use only sums and products — so everything
+here is stated over a `CommSemiring`, with the single exception of the substitution lemmas, which
+need Mathlib's `PowerSeries.subst` and so a `CommRing`.
 
-The source does **not** prove uniqueness: its closing note records that the factoring step is
-blocked by a `PowerSeries` typeclass gap (`RightDistribClass` and `IsRightCancelAdd` failing to
-synthesize), and names coefficient induction as the untried alternative. That is the route
-`eq_formalW_of_wEquation` takes here, so this file proves a result the source leaves open.
+The AINTLIB source does **not** prove uniqueness: its closing note records that the factoring
+step is blocked by a `PowerSeries` typeclass gap (`RightDistribClass` and `IsRightCancelAdd`
+failing to synthesize), and names coefficient induction as the untried alternative. That is the
+route `eq_formalW_of_wEquation` takes here. Stoll's project does prove uniqueness, by the
+contraction route recorded above rather than by the coefficient induction used here.
 
-The source's own generic formal-group scaffolding (`FormalGroupLaw`,
+The AINTLIB source's own generic formal-group scaffolding (`FormalGroupLaw`,
 `bmul`, `binv`, `bpow`, `bcomp`) is deliberately not ported: it predates and duplicates Mathlib's
 `Mathlib/RingTheory/FormalGroup/Basic.lean`.
 
@@ -237,13 +241,23 @@ the parameter is left free. Every occurrence of the unknown is multiplied by `q`
 square or a cube, which is what makes the solution unique (`eq_of_wEquation`).
 
 Rewrite with `wEquationRHS_def` rather than unfolding this definition. -/
-noncomputable def wEquationRHS (W : WeierstrassCurve R) (q v : PowerSeries R) :
-    PowerSeries R :=
-  q ^ 3 + PowerSeries.C W.a₁ * q * v + PowerSeries.C W.a₂ * q ^ 2 * v +
-    PowerSeries.C W.a₃ * v ^ 2 + PowerSeries.C W.a₄ * q * v ^ 2 + PowerSeries.C W.a₆ * v ^ 3
+noncomputable def wEquationRHS {A : Type*} [CommSemiring A] [Algebra R A]
+    (W : WeierstrassCurve R) (q v : A) : A :=
+  q ^ 3 + algebraMap R A W.a₁ * q * v + algebraMap R A W.a₂ * q ^ 2 * v +
+    algebraMap R A W.a₃ * v ^ 2 + algebraMap R A W.a₄ * q * v ^ 2 + algebraMap R A W.a₆ * v ^ 3
 
 /-- The defining formula for `wEquationRHS`. -/
-theorem wEquationRHS_def (W : WeierstrassCurve R) (q v : PowerSeries R) :
+theorem wEquationRHS_def {A : Type*} [CommSemiring A] [Algebra R A] (W : WeierstrassCurve R)
+    (q v : A) :
+    wEquationRHS W q v =
+      q ^ 3 + algebraMap R A W.a₁ * q * v + algebraMap R A W.a₂ * q ^ 2 * v +
+        algebraMap R A W.a₃ * v ^ 2 + algebraMap R A W.a₄ * q * v ^ 2 +
+        algebraMap R A W.a₆ * v ^ 3 :=
+  (rfl)
+
+/-- The `w`-equation in `R⟦z⟧` itself, where the structure map is `PowerSeries.C`. This is the
+spelling the coefficient lemmas below match against. -/
+theorem wEquationRHS_powerSeries (W : WeierstrassCurve R) (q v : PowerSeries R) :
     wEquationRHS W q v =
       q ^ 3 + PowerSeries.C W.a₁ * q * v + PowerSeries.C W.a₂ * q ^ 2 * v +
         PowerSeries.C W.a₃ * v ^ 2 + PowerSeries.C W.a₄ * q * v ^ 2 +
@@ -263,7 +277,7 @@ private theorem coeff_wEquationRHS (w : PowerSeries R) (n : ℕ) :
             PowerSeries.selfConvTwo (fun k => PowerSeries.coeff k w) (n - 1)
           else 0) +
         W.a₆ * PowerSeries.selfConvThree (fun k => PowerSeries.coeff k w) n := by
-  rw [wEquationRHS_def]
+  rw [wEquationRHS_powerSeries]
   -- `PowerSeries.coeff_C_mul` and `PowerSeries.coeff_X_pow_mul'` each need their argument in the
   -- shape `C a * (X ^ d * f)`, so first reassociate the three products and write the bare `X` as
   -- `X ^ 1`. Rewriting `← pow_one` directly is not an option: it would also fire inside `X ^ 3`.
@@ -317,22 +331,6 @@ makes the equation determine its solution: it is what forces the `n`-th coeffici
 right-hand side to depend only on the earlier coefficients of the unknown.
 -/
 
-/-- Multiplying by a series with vanishing constant coefficient makes the `n`-th coefficient of
-the product depend only on the coefficients of the other factor strictly below `n`: the term
-that would use the `n`-th one carries the vanishing constant coefficient. -/
-private theorem coeff_mul_congr {q v v' : PowerSeries R}
-    (hq : PowerSeries.constantCoeff q = 0) {n : ℕ}
-    (h : ∀ m, m < n → PowerSeries.coeff m v = PowerSeries.coeff m v') :
-    PowerSeries.coeff n (q * v) = PowerSeries.coeff n (q * v') := by
-  have hq0 : PowerSeries.coeff 0 q = 0 := by
-    rwa [PowerSeries.coeff_zero_eq_constantCoeff_apply]
-  rw [PowerSeries.coeff_mul, PowerSeries.coeff_mul]
-  refine Finset.sum_congr rfl fun p hp => ?_
-  rw [Finset.mem_antidiagonal] at hp
-  rcases Nat.eq_zero_or_pos p.1 with h1 | h1
-  · rw [h1, hq0, zero_mul, zero_mul]
-  · rw [h p.2 (by omega)]
-
 /-- The `n`-th coefficient of the right-hand side of the `w`-equation depends only on the
 coefficients of the unknown strictly below `n`. This is the whole content of uniqueness: every
 occurrence of the unknown is multiplied by the parameter, which has vanishing constant
@@ -357,10 +355,10 @@ private theorem coeff_wEquationRHS_congr {q v v' : PowerSeries R}
   have hq2 : PowerSeries.constantCoeff (q ^ 2) = 0 := by
     rw [map_pow, hq]
     simp
-  rw [wEquationRHS_def, wEquationRHS_def]
+  rw [wEquationRHS_powerSeries, wEquationRHS_powerSeries]
   simp only [map_add, mul_assoc, PowerSeries.coeff_C_mul]
-  rw [coeff_mul_congr hq h, coeff_mul_congr hq2 h, hsq n le_rfl,
-    coeff_mul_congr hq fun m hm => hsq m hm.le, hcb]
+  rw [PowerSeries.coeff_mul_congr hq h, PowerSeries.coeff_mul_congr hq2 h, hsq n le_rfl,
+    PowerSeries.coeff_mul_congr hq fun m hm => hsq m hm.le, hcb]
 
 /-- **Uniqueness of the solution of the `w`-equation.** Two power series with vanishing constant
 coefficient that satisfy the `w`-equation at the same parameter series `q` are equal, provided
@@ -399,36 +397,53 @@ theorem eq_formalW_of_wEquation (w : PowerSeries R)
 
 /-! ### Substituting into the equation
 
-Substituting a series `q` into the `w`-equation at the parameter `z` gives the equation at the
-parameter `q`. With `eq_of_wEquation` this is what identifies a substituted solution, and it is
-how the formal group's inverse and group law are recognised.
+Substituting a series into the `w`-equation gives the equation at the substituted parameters. The
+`w`-equation makes sense in any commutative `R`-algebra, and substitution is an `R`-algebra map, so
+this is just the statement that `wEquationRHS` is built from `+`, `*`, `^` and the structure map.
+
+With `constantCoeff q = 0` — strictly stronger than `PowerSeries.HasSubst q`, which asks only that
+the constant coefficient be nilpotent — this combines with `eq_of_wEquation` to identify the
+substituted solution, which is `eq_subst_formalW_of_wEquation`.
 
 Mathlib's `PowerSeries.subst` is defined only over a `CommRing`, so this section is stated there;
-the uniqueness theorem above needs no such hypothesis and keeps the `CommSemiring` of the rest of
-this file.
+everything above needs no such hypothesis and keeps the `CommSemiring` of the rest of this file.
 -/
 
 section CommRing
 
 variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
 
-/-- Substitution passes through the `w`-equation, carrying the parameter with it: substituting
-`q` into the right-hand side at parameter `z` gives the right-hand side at parameter `q`. -/
-theorem subst_wEquationRHS {q : PowerSeries R} (hq : PowerSeries.HasSubst q) (v : PowerSeries R) :
-    PowerSeries.subst q (wEquationRHS W PowerSeries.X v) =
-      wEquationRHS W q (PowerSeries.subst q v) := by
-  simp only [wEquationRHS_def, PowerSeries.subst_add hq, PowerSeries.subst_mul hq,
-    PowerSeries.subst_pow hq, PowerSeries.subst_C, PowerSeries.subst_X hq]
-  rfl
+/-- Substitution passes through the `w`-equation, carrying both the parameter and the unknown with
+it. Both sides are read in the target algebra, which is why `wEquationRHS` is stated for an
+arbitrary `R`-algebra: substituting a one-variable series into it lands in `MvPowerSeries τ S`. -/
+theorem subst_wEquationRHS {τ S : Type*} [CommRing S] [Algebra R S] {a : MvPowerSeries τ S}
+    (ha : PowerSeries.HasSubst a) (q v : PowerSeries R) :
+    PowerSeries.subst a (wEquationRHS W q v) =
+      wEquationRHS W (PowerSeries.subst a q) (PowerSeries.subst a v) := by
+  rw [wEquationRHS_def, wEquationRHS_def, ← PowerSeries.coe_substAlgHom ha]
+  simp only [map_add, map_mul, map_pow, AlgHom.commutes]
 
-/-- The `w`-expansion composed with a substitutable series `q` solves the `w`-equation at the
-parameter `q`. This is the hypothesis `eq_of_wEquation` consumes: any other series with vanishing
-constant coefficient solving the equation at `q` is equal to `w(q)`. -/
-theorem subst_formalW_wEquation {q : PowerSeries R} (hq : PowerSeries.HasSubst q) :
-    PowerSeries.subst q (formalW W) =
-      wEquationRHS W q (PowerSeries.subst q (formalW W)) := by
+/-- The `w`-expansion composed with a substitutable series `a` solves the `w`-equation at `a`. -/
+theorem subst_formalW_wEquation {τ S : Type*} [CommRing S] [Algebra R S] {a : MvPowerSeries τ S}
+    (ha : PowerSeries.HasSubst a) :
+    PowerSeries.subst a (formalW W) = wEquationRHS W a (PowerSeries.subst a (formalW W)) := by
   conv_lhs => rw [formalW_wEquation W]
-  exact subst_wEquationRHS W hq (formalW W)
+  rw [subst_wEquationRHS W ha, PowerSeries.subst_X ha]
+
+/-- **The substituted `w`-expansion is the unique solution at the substituted parameter.** For a
+parameter `q` with vanishing constant coefficient, any series with vanishing constant coefficient
+solving the `w`-equation at `q` is `w(q)`.
+
+This is the composite the formal group consumes: `subst_formalW_wEquation` supplies a solution and
+`eq_of_wEquation` says there is only one. Note the hypothesis is `constantCoeff q = 0` rather than
+`PowerSeries.HasSubst q`; the latter asks only for a nilpotent constant coefficient, which is not
+enough for uniqueness. -/
+theorem eq_subst_formalW_of_wEquation {q v : PowerSeries R}
+    (hq : PowerSeries.constantCoeff q = 0) (hv : PowerSeries.constantCoeff v = 0)
+    (h : v = wEquationRHS W q v) : v = PowerSeries.subst q (formalW W) := by
+  have ha : PowerSeries.HasSubst q := PowerSeries.HasSubst.of_constantCoeff_zero' hq
+  refine eq_of_wEquation W hq hv ?_ h (subst_formalW_wEquation W ha)
+  exact PowerSeries.constantCoeff_subst_eq_zero hq (formalW W) (constantCoeff_formalW W)
 
 end CommRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -20,12 +20,19 @@ which determines a unique power series `w(z) ∈ R⟦z⟧` with no terms below `
 constructs that series, proves it satisfies the equation, and proves it is the only series with
 vanishing constant coefficient that does.
 
+The equation is also recorded with its parameter left free, as `WeierstrassCurve.wEquationRhs`,
+and its solution shown unique at any parameter: the formal group obtains the inverse and the
+group law by substitution, and a substituted series solves the equation at the substituted
+parameter rather than at `z`.
+
 ## Main definitions
 
 * `WeierstrassCurve.formalWCoeff`: the coefficients of `w(z)`, by strong recursion.
 * `WeierstrassCurve.formalW`: the series `w(z)` itself.
 * `WeierstrassCurve.formalUCoeff`, `WeierstrassCurve.formalU`: the coefficients, and the series
   itself, of `u(z) = w(z) / z ^ 3`.
+* `WeierstrassCurve.wEquationRhs`: the right-hand side of the displayed equation, with both the
+  parameter and the unknown left free.
 
 ## Main results
 
@@ -34,6 +41,9 @@ vanishing constant coefficient that does.
 * `WeierstrassCurve.eq_formalW_of_wEquation`: **Silverman AEC IV.1.1(a), uniqueness** — any
   power series with vanishing constant coefficient satisfying that equation equals `w(z)`. The
   two together are the full statement, that `w(z)` is *the* such series.
+* `WeierstrassCurve.eq_of_wEquation`: uniqueness at an arbitrary parameter — two series with
+  vanishing constant coefficient solving the equation at the same parameter are equal. Proved
+  by contraction rather than by coefficients, so it needs a `CommRing`.
 * `WeierstrassCurve.formalWCoeff_recurrence`: the coefficientwise recurrence — each coefficient
   of `w(z)` above the leading one, from the strictly earlier ones. This is the form to compute
   with; the strong recursion behind `formalWCoeff` is an implementation detail.
@@ -41,7 +51,7 @@ vanishing constant coefficient that does.
   `WeierstrassCurve.formalWCoeff_eq_zero_of_lt`: the series begins `w(z) = z ^ 3 + ⋯`.
 * `WeierstrassCurve.formalW_eq_X_pow_mul_formalU`: `w(z) = z ^ 3 * u(z)`, where
   `WeierstrassCurve.constantCoeff_formalU` gives `u(0) = 1`. Over a `CommRing` that makes `u(z)`
-  a unit; at the `CommSemiring` generality of this file it does not.
+  a unit; at the `CommSemiring` generality of that section it does not.
 
 ## Scope
 
@@ -57,6 +67,13 @@ Adapted from the AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Ap
 by `TauCetiRoadmap/EllipticCurves/README.md` at `dev/hasse-weil @ 513e83879e2f`),
 `HasseWeil/FormalGroup.lean`, declarations `formalW_step`, `formalW_coeff`, `formalW`,
 `formalU_coeff`, the `formalW_coeff_*` lemmas and `formalW_recurrence`.
+
+The uniqueness statement at an arbitrary parameter, and its contraction proof, are adapted from
+Michael Stoll's `EllipticCurves` project (`github.com/MichaelStollBayreuth/EllipticCurves`,
+Apache-2.0, pinned by `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+`EllipticCurves/WeierstrassFormalGroup/Chord.lean`, declarations `wStepAt`, `wStepAt_contract`
+and `eq_of_wStepAt_fixed`. There the equation is a `def` used only internally; here it is the
+public `wEquationRhs`, so the existing statements in this file are phrased through it too.
 
 Changes from the source. The source's convolution helpers `conv₂` and `conv₃`, and its
 coefficient and truncation lemmas for them, are stated only for `formalW`, although none of
@@ -200,17 +217,30 @@ theorem formalW_eq_X_pow_mul_formalU : formalW W = PowerSeries.X ^ 3 * formalU W
   · rw [coeff_formalU, formalUCoeff_apply, Nat.sub_add_cancel h]
   · exact formalWCoeff_eq_zero_of_lt W (by omega)
 
+/-! ### The `w`-equation -/
+
+/-- The right-hand side of the `w`-equation, with the parameter series `q` in place of `z` and
+the unknown `v` in place of `w`:
+
+`q ^ 3 + a₁ q v + a₂ q ^ 2 v + a₃ v ^ 2 + a₄ q v ^ 2 + a₆ v ^ 3`.
+
+The `w`-expansion is the solution at the parameter `q = z`, but the formal group needs solutions
+at other parameters — substituting a series into `w(z)` solves the equation at that series — so
+the parameter is left free. Every occurrence of the unknown is multiplied by `q` or sits in a
+square or a cube, which is what makes the solution unique (`eq_of_wEquation`).
+
+The definition is `@[expose]`d because it is a plain algebraic expression with nothing to keep
+back, and every use of it wants to see the shape. -/
+@[expose] noncomputable def wEquationRhs (W : WeierstrassCurve R) (q v : PowerSeries R) :
+    PowerSeries R :=
+  q ^ 3 + PowerSeries.C W.a₁ * q * v + PowerSeries.C W.a₂ * q ^ 2 * v +
+    PowerSeries.C W.a₃ * v ^ 2 + PowerSeries.C W.a₄ * q * v ^ 2 + PowerSeries.C W.a₆ * v ^ 3
+
 /-- The `n`-th coefficient of the right-hand side of the `w`-equation, for an arbitrary series
 `w`, expressed through the coefficients of `w` itself. Every occurrence of `w` on the right is
 multiplied by `X` or appears in a square or a cube. -/
 private theorem coeff_wEquationRhs (w : PowerSeries R) (n : ℕ) :
-    PowerSeries.coeff n
-      (PowerSeries.X ^ 3 +
-        PowerSeries.C W.a₁ * PowerSeries.X * w +
-        PowerSeries.C W.a₂ * PowerSeries.X ^ 2 * w +
-        PowerSeries.C W.a₃ * w ^ 2 +
-        PowerSeries.C W.a₄ * PowerSeries.X * w ^ 2 +
-        PowerSeries.C W.a₆ * w ^ 3) =
+    PowerSeries.coeff n (wEquationRhs W PowerSeries.X w) =
       (if n = 3 then 1 else 0) +
         W.a₁ * (if 1 ≤ n then PowerSeries.coeff (n - 1) w else 0) +
         W.a₂ * (if 2 ≤ n then PowerSeries.coeff (n - 2) w else 0) +
@@ -219,6 +249,7 @@ private theorem coeff_wEquationRhs (w : PowerSeries R) (n : ℕ) :
             PowerSeries.selfConvTwo (fun k => PowerSeries.coeff k w) (n - 1)
           else 0) +
         W.a₆ * PowerSeries.selfConvThree (fun k => PowerSeries.coeff k w) n := by
+  rw [wEquationRhs]
   -- `PowerSeries.coeff_C_mul` and `PowerSeries.coeff_X_pow_mul'` each need their argument in the
   -- shape `C a * (X ^ d * f)`, so first reassociate the three products and write the bare `X` as
   -- `X ^ 1`. Rewriting `← pow_one` directly is not an option: it would also fire inside `X ^ 3`.
@@ -242,12 +273,7 @@ private theorem coeff_wEquationRhs (w : PowerSeries R) (n : ℕ) :
 from the Weierstrass equation of `W` by the substitution `x = z / w`, `y = -1 / w`. -/
 theorem formalW_wEquation :
     formalW W =
-      PowerSeries.X ^ 3 +
-        PowerSeries.C W.a₁ * PowerSeries.X * formalW W +
-        PowerSeries.C W.a₂ * PowerSeries.X ^ 2 * formalW W +
-        PowerSeries.C W.a₃ * formalW W ^ 2 +
-        PowerSeries.C W.a₄ * PowerSeries.X * formalW W ^ 2 +
-        PowerSeries.C W.a₆ * formalW W ^ 3 := by
+      wEquationRhs W PowerSeries.X (formalW W) := by
   have hlow : ∀ k, k < 3 → formalWCoeff W k = 0 := fun _ hk => formalWCoeff_eq_zero_of_lt W hk
   have hc2 : ∀ m, m < 6 → PowerSeries.selfConvTwo (formalWCoeff W) m = 0 :=
     fun _ hm => PowerSeries.selfConvTwo_eq_zero hlow hm
@@ -276,13 +302,7 @@ coefficients to vanish as well, because every occurrence of `w` on its right-han
 multiplied by `X` or sits in a square or a cube. -/
 theorem eq_formalW_of_wEquation (w : PowerSeries R)
     (h0 : PowerSeries.constantCoeff w = 0)
-    (hw : w =
-      PowerSeries.X ^ 3 +
-        PowerSeries.C W.a₁ * PowerSeries.X * w +
-        PowerSeries.C W.a₂ * PowerSeries.X ^ 2 * w +
-        PowerSeries.C W.a₃ * w ^ 2 +
-        PowerSeries.C W.a₄ * PowerSeries.X * w ^ 2 +
-        PowerSeries.C W.a₆ * w ^ 3) :
+    (hw : w = wEquationRhs W PowerSeries.X w) :
     w = formalW W := by
   rw [← PowerSeries.coeff_zero_eq_constantCoeff_apply] at h0
   -- Degrees `1` and `2` are forced, so the induction below can still start from degree `3`.
@@ -340,5 +360,78 @@ theorem eq_formalW_of_wEquation (w : PowerSeries R)
         hagree (n - 1) (by omega), hagree (n - 2) (by omega)]
       simp only [h2', h3, h4, ite_true, ite_false]
       ring
+
+/-! ### Uniqueness at an arbitrary parameter
+
+`eq_formalW_of_wEquation` above identifies the solution of the `w`-equation at the parameter
+`z`. The formal group needs the same statement at an arbitrary parameter series, because the
+inverse and the group law are obtained by substituting one series into another, and such a
+substitution solves the equation at the substituted parameter rather than at `z`.
+
+The argument is different from the one above: instead of computing coefficients, it shows the
+right-hand side is a contraction for the `z`-adic filtration, so two solutions agree to every
+order. That needs subtraction, hence a `CommRing` here rather than a `CommSemiring`.
+-/
+
+section CommRing
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+/-- The right-hand side of the `w`-equation contracts: two candidates at the same parameter that
+agree to order `k` have images agreeing to order `k + 1`. Every occurrence of the unknown on the
+right is multiplied by the parameter or sits in a square or a cube, and each of those is
+divisible by one more power of `z` than the difference it is built from. -/
+private theorem X_pow_succ_dvd_wEquationRhs_sub {q u v : PowerSeries R}
+    (hq : (PowerSeries.X : PowerSeries R) ∣ q) (hu : (PowerSeries.X : PowerSeries R) ∣ u)
+    (hv : (PowerSeries.X : PowerSeries R) ∣ v) {k : ℕ}
+    (h : (PowerSeries.X : PowerSeries R) ^ k ∣ u - v) :
+    (PowerSeries.X : PowerSeries R) ^ (k + 1) ∣ wEquationRhs W q u - wEquationRhs W q v := by
+  have hsq : (PowerSeries.X : PowerSeries R) ^ (k + 1) ∣ u ^ 2 - v ^ 2 := by
+    have huv : u ^ 2 - v ^ 2 = (u + v) * (u - v) := by ring
+    rw [huv, pow_succ, mul_comm ((PowerSeries.X : PowerSeries R) ^ k)]
+    exact mul_dvd_mul (dvd_add hu hv) h
+  have hcb : (PowerSeries.X : PowerSeries R) ^ (k + 1) ∣ u ^ 3 - v ^ 3 := by
+    have huv : u ^ 3 - v ^ 3 = (u ^ 2 + u * v + v ^ 2) * (u - v) := by ring
+    rw [huv, pow_succ, mul_comm ((PowerSeries.X : PowerSeries R) ^ k)]
+    refine mul_dvd_mul (dvd_add (dvd_add ?_ (hu.mul_right v)) ?_) h
+    · rw [pow_two]; exact hu.mul_right u
+    · rw [pow_two]; exact hv.mul_right v
+  have hpar : (PowerSeries.X : PowerSeries R) ^ (k + 1) ∣ q * (u - v) := by
+    rw [pow_succ, mul_comm ((PowerSeries.X : PowerSeries R) ^ k)]
+    exact mul_dvd_mul hq h
+  have hsplit : wEquationRhs W q u - wEquationRhs W q v =
+      PowerSeries.C W.a₁ * (q * (u - v)) + PowerSeries.C W.a₂ * q * (q * (u - v)) +
+        PowerSeries.C W.a₃ * (u ^ 2 - v ^ 2) + PowerSeries.C W.a₄ * q * (u ^ 2 - v ^ 2) +
+        PowerSeries.C W.a₆ * (u ^ 3 - v ^ 3) := by
+    simp only [wEquationRhs]
+    ring
+  rw [hsplit]
+  exact dvd_add (dvd_add (dvd_add (dvd_add (hpar.mul_left _) (hpar.mul_left _))
+    (hsq.mul_left _)) (hsq.mul_left _)) (hcb.mul_left _)
+
+/-- **Uniqueness of the solution of the `w`-equation, at an arbitrary parameter.** Two power
+series with vanishing constant coefficient that satisfy the `w`-equation at the same parameter
+series are equal.
+
+`eq_formalW_of_wEquation` is the case `q = z`, where the solution is `formalW W`; it is proved
+separately because it holds already over a `CommSemiring`, which this does not. -/
+theorem eq_of_wEquation {q v v' : PowerSeries R} (hq : PowerSeries.constantCoeff q = 0)
+    (hv : PowerSeries.constantCoeff v = 0) (hv' : PowerSeries.constantCoeff v' = 0)
+    (h : v = wEquationRhs W q v) (h' : v' = wEquationRhs W q v') : v = v' := by
+  rw [← PowerSeries.X_dvd_iff] at hq hv hv'
+  -- The two solutions agree to every order, because each step of the equation gains a power
+  -- of `z` on the difference.
+  have key : ∀ k : ℕ, (PowerSeries.X : PowerSeries R) ^ k ∣ v - v' := by
+    intro k
+    induction k with
+    | zero => simp
+    | succ k ih =>
+      have hstep := X_pow_succ_dvd_wEquationRhs_sub W hq hv hv' ih
+      rwa [← h, ← h'] at hstep
+  ext n
+  have hn := PowerSeries.X_pow_dvd_iff.mp (key (n + 1)) n (by omega)
+  rwa [map_sub, sub_eq_zero] at hn
+
+end CommRing
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Weierstrass
+public import Mathlib.RingTheory.PowerSeries.Substitution
 public import TauCeti.RingTheory.PowerSeries.SelfConvolution
 
 /-!
@@ -21,9 +22,9 @@ constructs that series, proves it satisfies the equation, and proves it is the o
 vanishing constant coefficient that does.
 
 The equation is also recorded with its parameter left free, as `WeierstrassCurve.wEquationRHS`,
-and its solution shown unique at any parameter: the formal group obtains the inverse and the
-group law by substitution, and a substituted series solves the equation at the substituted
-parameter rather than at `z`.
+and its solution shown unique at every parameter with vanishing constant coefficient: the formal
+group obtains the inverse and the group law by substitution, and a substituted series solves the
+equation at the substituted parameter rather than at `z`.
 
 ## Main definitions
 
@@ -41,8 +42,12 @@ parameter rather than at `z`.
 * `WeierstrassCurve.eq_formalW_of_wEquation`: **Silverman AEC IV.1.1(a), uniqueness** — any
   power series with vanishing constant coefficient satisfying that equation equals `w(z)`. The
   two together are the full statement, that `w(z)` is *the* such series.
-* `WeierstrassCurve.eq_of_wEquation`: uniqueness at an arbitrary parameter — two series with
-  vanishing constant coefficient solving the equation at the same parameter are equal.
+* `WeierstrassCurve.eq_of_wEquation`: uniqueness at any parameter that itself has vanishing
+  constant coefficient — two series with vanishing constant coefficient solving the equation at
+  that parameter are equal.
+* `WeierstrassCurve.subst_wEquationRHS` and `WeierstrassCurve.subst_formalW_wEquation`:
+  substituting a series `q` into the equation gives the equation at `q`, so `w(q)` solves it
+  there. With `eq_of_wEquation` this is what identifies substituted solutions.
 * `WeierstrassCurve.formalWCoeff_recurrence`: the coefficientwise recurrence — each coefficient
   of `w(z)` above the leading one, from the strictly earlier ones. This is the form to compute
   with; the strong recursion behind `formalWCoeff` is an implementation detail.
@@ -302,80 +307,14 @@ theorem formalW_wEquation :
     simp only [h2, h3, h4, ite_true, ite_false]
     ring
 
-/-- **Silverman AEC IV.1.1(a), uniqueness.** A power series with vanishing constant coefficient
-that satisfies the `w`-equation is `formalW W`. Together with `formalW_wEquation` this is the
-full statement of Silverman AEC IV.1.1(a): `formalW W` is *the* such series.
+/-! ### Uniqueness at a parameter with vanishing constant coefficient
 
-Only `constantCoeff w = 0` is assumed: the equation at degrees `1` and `2` then forces those two
-coefficients to vanish as well, because every occurrence of `w` on its right-hand side is
-multiplied by `X` or sits in a square or a cube. -/
-theorem eq_formalW_of_wEquation (w : PowerSeries R)
-    (h0 : PowerSeries.constantCoeff w = 0)
-    (hw : w = wEquationRHS W PowerSeries.X w) :
-    w = formalW W := by
-  rw [← PowerSeries.coeff_zero_eq_constantCoeff_apply] at h0
-  -- Degrees `1` and `2` are forced, so the induction below can still start from degree `3`.
-  have hv0 : ∀ k, k < 1 → PowerSeries.coeff k w = 0 := by
-    intro k hk; interval_cases k; exact h0
-  have h1 : PowerSeries.coeff 1 w = 0 := by
-    have hL := congrArg (PowerSeries.coeff 1) hw
-    rw [coeff_wEquationRHS,
-      PowerSeries.selfConvTwo_eq_zero hv0 (show (1 : ℕ) < 2 * 1 by omega),
-      PowerSeries.selfConvTwo_eq_zero hv0 (show (1 : ℕ) - 1 < 2 * 1 by omega),
-      PowerSeries.selfConvThree_eq_zero hv0 (show (1 : ℕ) < 3 * 1 by omega)] at hL
-    simpa [h0] using hL
-  have hv1 : ∀ k, k < 2 → PowerSeries.coeff k w = 0 := by
-    intro k hk; interval_cases k; exacts [h0, h1]
-  have h2 : PowerSeries.coeff 2 w = 0 := by
-    have hL := congrArg (PowerSeries.coeff 2) hw
-    rw [coeff_wEquationRHS,
-      PowerSeries.selfConvTwo_eq_zero hv1 (show (2 : ℕ) < 2 * 2 by omega),
-      PowerSeries.selfConvTwo_eq_zero hv1 (show (2 : ℕ) - 1 < 2 * 2 by omega),
-      PowerSeries.selfConvThree_eq_zero hv1 (show (2 : ℕ) < 3 * 2 by omega)] at hL
-    simpa [h0, h1] using hL
-  have hlow : ∀ k, k < 3 → PowerSeries.coeff k w = 0 := by
-    intro k hk; interval_cases k; exacts [h0, h1, h2]
-  have hc2 : ∀ m, m < 6 → PowerSeries.selfConvTwo (fun k => PowerSeries.coeff k w) m = 0 :=
-    fun _ hm => PowerSeries.selfConvTwo_eq_zero hlow hm
-  have hc3 : ∀ m, m < 9 → PowerSeries.selfConvThree (fun k => PowerSeries.coeff k w) m = 0 :=
-    fun _ hm => PowerSeries.selfConvThree_eq_zero hlow hm
-  ext n
-  -- The equation determines each coefficient from the strictly earlier ones, so this is a
-  -- strong induction: at index `n` the right-hand side involves `w` only below `n`, by
-  -- `coeff_wEquationRHS` together with `PowerSeries.selfConvTwo_congr` and
-  -- `PowerSeries.selfConvThree_congr`.
-  induction n using Nat.strong_induction_on with
-  | _ n ih =>
-    rcases lt_trichotomy n 3 with h | h | h
-    · rw [hlow n h, coeff_formalW, formalWCoeff_eq_zero_of_lt W h]
-    · subst h
-      have hL := congrArg (PowerSeries.coeff 3) hw
-      rw [coeff_wEquationRHS] at hL
-      rw [hL, coeff_formalW, formalWCoeff_three]
-      simp [hlow 1 (by omega), hlow 2 (by omega), hc2, hc3]
-    · have hL := congrArg (PowerSeries.coeff n) hw
-      rw [coeff_wEquationRHS] at hL
-      have hw0 : (fun k => PowerSeries.coeff k w) 0 = 0 := hlow 0 (by omega)
-      have hf0 : (fun k => formalWCoeff W k) 0 = 0 := formalWCoeff_zero W
-      have hagree : ∀ m, m < n → PowerSeries.coeff m w = formalWCoeff W m := fun m hm => by
-        rw [ih m hm, coeff_formalW]
-      have h2' : ¬ n = 3 := by omega
-      have h3 : 1 ≤ n := by omega
-      have h4 : 2 ≤ n := by omega
-      rw [hL, coeff_formalW, formalWCoeff_recurrence W h,
-        PowerSeries.selfConvTwo_congr hw0 hf0 hagree,
-        PowerSeries.selfConvTwo_congr (n := n - 1) hw0 hf0 (fun m hm => hagree m (by omega)),
-        PowerSeries.selfConvThree_congr hw0 hf0 hagree,
-        hagree (n - 1) (by omega), hagree (n - 2) (by omega)]
-      simp only [h2', h3, h4, ite_true, ite_false]
-      ring
-
-/-! ### Uniqueness at an arbitrary parameter
-
-`eq_formalW_of_wEquation` above identifies the solution of the `w`-equation at the parameter
-`z`. The formal group needs the same statement at an arbitrary parameter series, because the
-inverse and the group law are obtained by substituting one series into another, and such a
-substitution solves the equation at the substituted parameter rather than at `z`.
+The formal group needs uniqueness not only at the parameter `z` but at any parameter series
+with vanishing constant coefficient, because the inverse and the group law are obtained by
+substituting one series into another, and such a substitution solves the equation at the
+substituted parameter rather than at `z`. Vanishing of the constant coefficient is exactly what
+makes the equation determine its solution: it is what forces the `n`-th coefficient of the
+right-hand side to depend only on the earlier coefficients of the unknown.
 -/
 
 /-- Multiplying by a series with vanishing constant coefficient makes the `n`-th coefficient of
@@ -423,9 +362,13 @@ private theorem coeff_wEquationRHS_congr {q v v' : PowerSeries R}
   rw [coeff_mul_congr hq h, coeff_mul_congr hq2 h, hsq n le_rfl,
     coeff_mul_congr hq fun m hm => hsq m hm.le, hcb]
 
-/-- **Uniqueness of the solution of the `w`-equation, at an arbitrary parameter.** Two power
-series with vanishing constant coefficient that satisfy the `w`-equation at the same parameter
-series are equal.
+/-- **Uniqueness of the solution of the `w`-equation.** Two power series with vanishing constant
+coefficient that satisfy the `w`-equation at the same parameter series `q` are equal, provided
+`q` too has vanishing constant coefficient.
+
+The hypothesis on `q` is what drives the induction: it is exactly what makes the `n`-th
+coefficient of the right-hand side depend only on the coefficients of the unknown strictly below
+`n`, so that the equation determines its solution one coefficient at a time.
 
 `eq_formalW_of_wEquation` is the case `q = z`, where the solution is moreover identified as
 `formalW W`. -/
@@ -440,5 +383,53 @@ theorem eq_of_wEquation {q v v' : PowerSeries R} (hq : PowerSeries.constantCoeff
     have hR := congrArg (PowerSeries.coeff n) h'
     rw [hL, hR]
     exact coeff_wEquationRHS_congr W hq hv hv' ih
+
+/-- **Silverman AEC IV.1.1(a), uniqueness.** A power series with vanishing constant coefficient
+that satisfies the `w`-equation is `formalW W`. Together with `formalW_wEquation` this is the
+full statement of Silverman AEC IV.1.1(a): `formalW W` is *the* such series.
+
+Only `constantCoeff w = 0` is assumed: the equation at degrees `1` and `2` then forces those two
+coefficients to vanish as well, because every occurrence of `w` on its right-hand side is
+multiplied by `X` or sits in a square or a cube. -/
+theorem eq_formalW_of_wEquation (w : PowerSeries R)
+    (h0 : PowerSeries.constantCoeff w = 0)
+    (hw : w = wEquationRHS W PowerSeries.X w) :
+    w = formalW W :=
+  eq_of_wEquation W (by simp) h0 (by simp) hw (formalW_wEquation W)
+
+/-! ### Substituting into the equation
+
+Substituting a series `q` into the `w`-equation at the parameter `z` gives the equation at the
+parameter `q`. With `eq_of_wEquation` this is what identifies a substituted solution, and it is
+how the formal group's inverse and group law are recognised.
+
+Mathlib's `PowerSeries.subst` is defined only over a `CommRing`, so this section is stated there;
+the uniqueness theorem above needs no such hypothesis and keeps the `CommSemiring` of the rest of
+this file.
+-/
+
+section CommRing
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+/-- Substitution passes through the `w`-equation, carrying the parameter with it: substituting
+`q` into the right-hand side at parameter `z` gives the right-hand side at parameter `q`. -/
+theorem subst_wEquationRHS {q : PowerSeries R} (hq : PowerSeries.HasSubst q) (v : PowerSeries R) :
+    PowerSeries.subst q (wEquationRHS W PowerSeries.X v) =
+      wEquationRHS W q (PowerSeries.subst q v) := by
+  simp only [wEquationRHS_def, PowerSeries.subst_add hq, PowerSeries.subst_mul hq,
+    PowerSeries.subst_pow hq, PowerSeries.subst_C, PowerSeries.subst_X hq]
+  rfl
+
+/-- The `w`-expansion composed with a substitutable series `q` solves the `w`-equation at the
+parameter `q`. This is the hypothesis `eq_of_wEquation` consumes: any other series with vanishing
+constant coefficient solving the equation at `q` is equal to `w(q)`. -/
+theorem subst_formalW_wEquation {q : PowerSeries R} (hq : PowerSeries.HasSubst q) :
+    PowerSeries.subst q (formalW W) =
+      wEquationRHS W q (PowerSeries.subst q (formalW W)) := by
+  conv_lhs => rw [formalW_wEquation W]
+  exact subst_wEquationRHS W hq (formalW W)
+
+end CommRing
 
 end WeierstrassCurve

--- a/TauCeti/RingTheory/PowerSeries/SelfConvolution.lean
+++ b/TauCeti/RingTheory/PowerSeries/SelfConvolution.lean
@@ -36,6 +36,8 @@ defined through these convolutions well founded.
 * `PowerSeries.coeff_pow_two_eq_selfConvTwo`,
   `PowerSeries.coeff_pow_three_eq_selfConvThree`: those sums do compute the coefficients of
   `w ^ 2` and `w ^ 3`.
+* `PowerSeries.coeff_mul_congr`: the `n`-th coefficient of `q * v`, for `q` with vanishing
+  constant coefficient, depends only on the coefficients of `v` strictly below `n`.
 * `PowerSeries.selfConvTwo_congr_le`, `PowerSeries.selfConvThree_congr_le`: the convolution at
   `m` depends only on the values of the function on `[0, m]`. No hypothesis is needed.
 * `PowerSeries.selfConvTwo_congr`, `PowerSeries.selfConvThree_congr`: for a function vanishing at
@@ -84,6 +86,20 @@ def selfConvThree (f : ℕ → R) (n : ℕ) : R :=
 theorem selfConvThree_def (f : ℕ → R) (n : ℕ) :
     selfConvThree f n = ∑ i ∈ range (n + 1), ∑ j ∈ range (n - i + 1), f i * f j * f (n - i - j) :=
   (rfl)
+
+/-- Multiplying by a series with vanishing constant coefficient makes the `n`-th coefficient of
+the product depend only on the coefficients of the other factor strictly below `n`: the term that
+would use the `n`-th one carries the vanishing constant coefficient. -/
+theorem coeff_mul_congr {q v v' : PowerSeries R} (hq : constantCoeff q = 0) {n : ℕ}
+    (h : ∀ m, m < n → coeff m v = coeff m v') : coeff n (q * v) = coeff n (q * v') := by
+  have hq0 : coeff 0 q = 0 := by
+    rwa [coeff_zero_eq_constantCoeff_apply]
+  rw [coeff_mul, coeff_mul]
+  refine Finset.sum_congr rfl fun p hp => ?_
+  rw [Finset.mem_antidiagonal] at hp
+  rcases Nat.eq_zero_or_pos p.1 with h1 | h1
+  · rw [h1, hq0, zero_mul, zero_mul]
+  · rw [h p.2 (by omega)]
 
 /-- `selfConvTwo` computes the coefficients of a square. -/
 theorem coeff_pow_two_eq_selfConvTwo (w : PowerSeries R) (n : ℕ) :


### PR DESCRIPTION
#4604 landed the `w`-expansion together with **Silverman AEC IV.1.1(a)**: `formalW W` satisfies
the `w`-equation, and it is the only series with vanishing constant coefficient that does. That
uniqueness is stated at the parameter `z`, and this PR generalises it to an arbitrary parameter.

## Roadmap target

`TauCetiRoadmap/EllipticCurves/README.md`, heading **`### Layer 1: isogenies, the dual, the
invariant differential, and formal groups (AEC II.2, III.4–6, IV)`** (`:386`), bullet **“The
formal group — four milestones with four different hypothesis sets, not one.”** (`:572`),
**milestone (i)** (`:573-574`):

> (i) The elliptic formal group *law* `Ê` over the coefficient ring, from expanding the group
> law at `O` (AEC IV.1), as an instance of Mathlib's `RingTheory/FormalGroup`; `[m]` on `Ê`.

**The dependency chain from that target to this PR is one step.** Milestone (i) needs the group
law `F(z₁, z₂) = ι(z₃(z₁, z₂))`, hence the formal inverse `ι(z) = -z / (1 - a₁z - a₃w(z))`. The
identity that computes `ι` — that substituting `ι` into `w` gives `-w/u`, the `w`-coordinate of
the negative of a point — is proved by appealing to uniqueness of the solution of the
`w`-equation **at the parameter `ι`**. #4604 proves uniqueness only at the parameter `z`
(`eq_formalW_of_wEquation`), which does not apply. `eq_of_wEquation` is exactly the missing
input, and the inverse cannot be built without it.

## Why the general statement is needed

The formal group builds its inverse `ι(z)` and its group law `F(z₁, z₂)` by **substitution**, and
a substituted series solves the `w`-equation *at the substituted parameter*, not at `z`. The
identity that computes `w ∘ ι` — the `w`-coordinate of the negative of a point — is exactly an
appeal to uniqueness at `q = ι`. `eq_formalW_of_wEquation` is the case `q = z` and does not
apply, so the formal-group work is blocked on this lemma. It is the gate I hit preparing the
next rung over #4728.

## What lands

* `wEquationRhs W q v` — the right-hand side of the equation with **both** the parameter `q` and
  the unknown `v` left free:
  `q ^ 3 + a₁ q v + a₂ q ^ 2 v + a₃ v ^ 2 + a₄ q v ^ 2 + a₆ v ^ 3`.
* `eq_of_wEquation` — two series with vanishing constant coefficient that solve the equation at
  the same parameter `q` are equal, provided `q` too has vanishing constant coefficient. That
  hypothesis is what drives the induction, and the docs no longer say "any parameter" without it.
* `eq_formalW_of_wEquation` is now **derived** from it in one line, and #4604's separate
  coefficient induction for the `q = z` case is deleted — it was the same argument twice.
* `subst_wEquationRHS` and `subst_formalW_wEquation` — substituting into the equation carries
  both parameters with it, so `w(a)` solves the equation at `a`.
* `eq_subst_formalW_of_wEquation` — the composite the formal group actually consumes: for
  `constantCoeff q = 0`, any series with vanishing constant coefficient solving the equation at
  `q` **is** `w(q)`. `HasSubst q` alone is not enough for this (it asks only that the constant
  coefficient be nilpotent), which is why the corollary is stated and exposed rather than left to
  each consumer to re-derive.
* The three existing spellings of the equation — in `coeff_wEquationRhs`, `formalW_wEquation`
  and `eq_formalW_of_wEquation` — are restated through the new definition, so the expression
  appears once instead of four times. No proof of theirs changed; the statements are the same
  propositions, now named.

## Design notes

**The whole file stays at `CommSemiring`.** Uniqueness needs no subtraction: the `n`-th
coefficient of the right-hand side depends only on the coefficients of the unknown strictly below
`n`, because every occurrence of the unknown is multiplied by `q` — which has vanishing constant
coefficient — or sits in a square or a cube of a series that does. That is `coeff_mul_congr` and
`coeff_wEquationRHS_congr`, and `eq_of_wEquation` is then a strong induction on the coefficient
index. The squares and cubes reuse `selfConvTwo_congr` / `selfConvThree_congr`, which #4604 had
already stated for exactly this purpose.

**One uniqueness proof, not two.** `eq_formalW_of_wEquation` keeps its statement — it identifies
the solution at `q = z` as `formalW W`, which the general theorem does not — but it is now proved
by applying `eq_of_wEquation` to `w` and `formalW W`, and #4604's coefficient induction for it is
gone. The net effect on the file is 81 lines removed against 72 added.

**The substitution half needs a `CommRing`, the uniqueness half does not.** Mathlib's
`PowerSeries.subst` is defined only over a `CommRing`, so the substitution lemmas sit in their own
section; `eq_of_wEquation` and everything before it stay at the `CommSemiring` of the rest of the
file.

**`wEquationRHS` is valued in an arbitrary commutative `R`-algebra.** It is built from `+`, `*`,
`^` and the structure map, so nothing ties it to `R⟦z⟧`, and the group law it is aimed at lives in
`MvPowerSeries (Fin 2) R` rather than in one variable. Writing `algebraMap R A W.a₁` costs nothing
at `A = R⟦z⟧`, where `algebraMap R R⟦X⟧` is `PowerSeries.C` by `rfl`: the coefficient lemmas,
`formalW_wEquation` and `eq_of_wEquation` are untouched by the generalisation. It is what lets
`subst_wEquationRHS` be stated for `a : MvPowerSeries τ S` over any `[Algebra R S]`, matching the
generality of Mathlib's own `subst_add` / `subst_mul` / `subst_pow`.

**No definition body is exposed.** `wEquationRHS` is opaque and `wEquationRHS_def` states its
formula; `coeff_wEquationRHS` and the congruence proofs rewrite with that lemma.

## Prior art

Checked by statement at the pinned Mathlib. Mathlib has no Weierstrass `w`-equation at all —
`Mathlib/AlgebraicGeometry/EllipticCurve/` has no formal-group material, with the elliptic tree
itself resolving as the control — so there is nothing upstream to reuse here. Within TauCeti the
only other spelling of this equation is the inline one in `WExpansion.lean`, which this PR
replaces. No other open PR touches `FormalGroup/` except #4728, which adds `Chord.lean` and does
not use any declaration changed here, so the two are independent.

## Provenance

Adapted from Michael Stoll's `EllipticCurves` project
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
`EllipticCurves/WeierstrassFormalGroup/Chord.lean` — declarations `wStepAt`,
`wStepAt_contract`, `eq_of_wStepAt_fixed`.

**Changes from the source.** There the equation is a private `def` used only inside the file and
the uniqueness lemma is private too; here the equation is the public `wEquationRHS` and the
existing statements in `WExpansion.lean` are phrased through it, which is what keeps the file
with a single spelling of the equation. The source states its hypotheses as `X ∣ ·`; they are
`constantCoeff · = 0` here, matching the surrounding file.

**The proof is not the source's.** Stoll argues by contraction for the `z`-adic filtration, which
subtracts and so would force a `CommRing`. The proof here is a coefficient induction, which keeps
the result at the `CommSemiring` generality of the rest of the file. Only the statement is
adapted.

Roadmap: EllipticCurves
