### PR TITLE
feat(MvPowerSeries): evaluation into a power of an adic ideal

### DIFF
--- a/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
@@ -116,24 +116,6 @@ theorem eval₂_mem_pow (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {
   have hsum := tsum_mem (hI.isClosed_pow k) hval
   rwa [htot.tsum_eq] at hsum
 
-/-- **A series vanishing below total degree `c`, evaluated at arguments of `I ^ j`, takes values
-in `I ^ (c * j)`.** A surviving monomial has degree at least `c`, so it contributes at least `c`
-arguments and therefore a factor from `I ^ (c * j)`. -/
-theorem eval₂_mem_pow_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {j c : ℕ}
-    (hmem : ∀ i, a i ∈ I ^ j) (f : MvPowerSeries σ R)
-    (hcoeff : ∀ d : σ →₀ ℕ, d.degree < c → coeff d f = 0) :
-    eval₂ φ a f ∈ I ^ (c * j) := by
-  classical
-  have htot := hasSum_eval₂ hφ ha f
-  have hval : ∀ d : σ →₀ ℕ, φ (coeff d f) * d.prod (fun s e ↦ a s ^ e) ∈ I ^ (c * j) := by
-    intro d
-    rcases lt_or_ge d.degree c with hlt | hge
-    · rw [hcoeff d hlt, map_zero, zero_mul]
-      exact zero_mem _
-    · exact Ideal.mul_mem_left _ _ (prod_mem_pow_mul hmem hge)
-  have hsum := tsum_mem (hI.isClosed_pow (c * j)) hval
-  rwa [htot.tsum_eq] at hsum
-
 /-- **Small coefficients improve the bound.** If in addition every coefficient of `f` lies in
 `I ^ k`, the two contributions multiply and the value lies in `I ^ (k + c * j)`. -/
 theorem eval₂_mem_pow_add_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {j c k : ℕ}
@@ -152,6 +134,15 @@ theorem eval₂_mem_pow_add_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsA
       exact Ideal.mul_mem_mul (hcoeff d) (prod_mem_pow_mul hmem hge)
   have hsum := tsum_mem (hI.isClosed_pow (k + c * j)) hval
   rwa [htot.tsum_eq] at hsum
+
+/-- **A series vanishing below total degree `c`, evaluated at arguments of `I ^ j`, takes values
+in `I ^ (c * j)`.** This is the `k = 0` case of `eval₂_mem_pow_add_mul`: every coefficient lies in
+`I ^ 0 = ⊤`, so that hypothesis is vacuous and the exponent collapses. -/
+theorem eval₂_mem_pow_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {j c : ℕ}
+    (hmem : ∀ i, a i ∈ I ^ j) (f : MvPowerSeries σ R)
+    (hcoeff : ∀ d : σ →₀ ℕ, d.degree < c → coeff d f = 0) :
+    eval₂ φ a f ∈ I ^ (c * j) := by
+  simpa using eval₂_mem_pow_add_mul (k := 0) hφ ha hI hmem f (fun _ ↦ by simp) hcoeff
 
 end Eval
 

--- a/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
@@ -14,8 +14,9 @@ public import TauCeti.Topology.Algebra.Nonarchimedean.AdicTopology
 Let `S` carry the `I`-adic topology for an ideal `I`, and let `f` be a multivariate power series
 evaluated at a family `a : σ → S` through a continuous coefficient map `φ`. This file bounds the
 value `eval₂ φ a f` by a power of `I`, in the three forms the estimate is used in: the value is
-confined to `I ^ k` as soon as the arguments and the constant term are, and the confinement
-improves when the series vanishes in low total degree or has small coefficients.
+confined to `I ^ k` as soon as the arguments are and `φ` sends the constant term there, and the
+confinement improves when the series vanishes in low total degree or when `φ` sends every
+coefficient into a power of `I`.
 
 All three have the same one-line mechanism. `MvPowerSeries.hasSum_eval₂` writes the value as the
 sum of its monomial values `φ (coeff d f) * ∏ s, a s ^ d s`; each such monomial is checked to lie
@@ -33,12 +34,12 @@ already carried by `HasEval`. Taking `I` to be `IsLocalRing.maximalIdeal S` and 
 
 ## Main results
 
-* `MvPowerSeries.eval₂_mem_pow` : arguments and constant term in `I ^ k` confine the value to
-  `I ^ k`.
+* `MvPowerSeries.eval₂_mem_pow` : arguments in `I ^ k`, and a constant term whose image under
+  `φ` lies in `I ^ k`, confine the value to `I ^ k`.
 * `MvPowerSeries.eval₂_mem_pow_mul` : a series vanishing below total degree `c`, evaluated at
   arguments of `I ^ j`, takes values in `I ^ (c * j)`.
-* `MvPowerSeries.eval₂_mem_pow_add_mul` : if moreover every coefficient lies in `I ^ k`, the
-  value lies in `I ^ (k + c * j)`.
+* `MvPowerSeries.eval₂_mem_pow_add_mul` : if moreover `φ` sends every coefficient into `I ^ k`,
+  the value lies in `I ^ (k + c * j)`.
 
 ## Provenance
 
@@ -95,9 +96,9 @@ variable {S : Type*} [CommRing S] [UniformSpace S] [IsUniformAddGroup S] [Comple
     [T2Space S] [IsTopologicalRing S] [IsLinearTopology S S]
 variable {φ : R →+* S} {a : σ → S} {I : Ideal S}
 
-/-- **The value lies in `I ^ k` when the arguments and the constant term do.** Every monomial of
-positive degree already carries an argument, hence a factor from `I ^ k`; the constant monomial is
-covered by the hypothesis on the constant term. -/
+/-- **The value lies in `I ^ k` when the arguments do and `φ` sends the constant term there.**
+Every monomial of positive degree already carries an argument, hence a factor from `I ^ k`; the
+constant monomial is covered by the hypothesis on the image of the constant term. -/
 theorem eval₂_mem_pow (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {k : ℕ}
     (hmem : ∀ i, a i ∈ I ^ k) (f : MvPowerSeries σ R)
     (hcc : φ (constantCoeff f) ∈ I ^ k) :
@@ -116,8 +117,8 @@ theorem eval₂_mem_pow (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {
   have hsum := tsum_mem (hI.isClosed_pow k) hval
   rwa [htot.tsum_eq] at hsum
 
-/-- **Small coefficients improve the bound.** If in addition every coefficient of `f` lies in
-`I ^ k`, the two contributions multiply and the value lies in `I ^ (k + c * j)`. -/
+/-- **Small coefficient images improve the bound.** If in addition `φ` sends every coefficient of
+`f` into `I ^ k`, the two contributions multiply and the value lies in `I ^ (k + c * j)`. -/
 theorem eval₂_mem_pow_add_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {j c k : ℕ}
     (hmem : ∀ i, a i ∈ I ^ j) (f : MvPowerSeries σ R)
     (hcoeff : ∀ d : σ →₀ ℕ, φ (coeff d f) ∈ I ^ k)
@@ -136,8 +137,8 @@ theorem eval₂_mem_pow_add_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsA
   rwa [htot.tsum_eq] at hsum
 
 /-- **A series vanishing below total degree `c`, evaluated at arguments of `I ^ j`, takes values
-in `I ^ (c * j)`.** This is the `k = 0` case of `eval₂_mem_pow_add_mul`: every coefficient lies in
-`I ^ 0 = ⊤`, so that hypothesis is vacuous and the exponent collapses. -/
+in `I ^ (c * j)`.** This is the `k = 0` case of `eval₂_mem_pow_add_mul`: every coefficient image
+lies in `I ^ 0 = ⊤`, so that hypothesis is vacuous and the exponent collapses. -/
 theorem eval₂_mem_pow_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {j c : ℕ}
     (hmem : ∀ i, a i ∈ I ^ j) (f : MvPowerSeries σ R)
     (hcoeff : ∀ d : σ →₀ ℕ, d.degree < c → coeff d f = 0) :

--- a/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.RingTheory.MvPowerSeries.Evaluation
+public import TauCeti.Topology.Algebra.Nonarchimedean.AdicTopology
+
+/-!
+# Evaluating a multivariate power series into a power of an adic ideal
+
+Let `S` carry the `I`-adic topology for an ideal `I`, and let `f` be a multivariate power series
+evaluated at a family `a : σ → S` through a continuous coefficient map `φ`. This file bounds the
+value `eval₂ φ a f` by a power of `I`, in the three forms the estimate is used in: the value is
+confined to `I ^ k` as soon as the arguments and the constant term are, and the confinement
+improves when the series vanishes in low total degree or has small coefficients.
+
+All three have the same one-line mechanism. `MvPowerSeries.hasSum_eval₂` writes the value as the
+sum of its monomial values `φ (coeff d f) * ∏ s, a s ^ d s`; each such monomial is checked to lie
+in the relevant power of `I`; and the sum of a family inside `I ^ n` stays inside `I ^ n` because
+`I ^ n` is closed (`IsAdic.isClosed_pow`) and `tsum_mem` applies. The three statements differ only
+in which power the monomial estimate produces.
+
+Three hypotheses of the source turn out to be unnecessary. Nothing asks for `I` to be maximal or
+for `S` to be local, only that the topology be `I`-adic, so the results are stated for an
+arbitrary ideal; the coefficient map is an arbitrary continuous `φ : R →+* S` rather than the
+identity, since `MvPowerSeries.hasSum_eval₂` is already stated at that generality; and the index
+type need not be finite, because the summation argument uses only the `Tendsto a cofinite (𝓝 0)`
+already carried by `HasEval`. Taking `I` to be `IsLocalRing.maximalIdeal S` and `φ` to be
+`RingHom.id S` recovers the source statements.
+
+## Main results
+
+* `MvPowerSeries.eval₂_mem_pow` : arguments and constant term in `I ^ k` confine the value to
+  `I ^ k`.
+* `MvPowerSeries.eval₂_mem_pow_mul` : a series vanishing below total degree `c`, evaluated at
+  arguments of `I ^ j`, takes values in `I ^ (c * j)`.
+* `MvPowerSeries.eval₂_mem_pow_add_mul` : if moreover every coefficient lies in `I ^ k`, the
+  value lies in `I ^ (k + c * j)`.
+
+## Provenance
+
+Adapted from Michael Stoll's `EllipticCurves` (`github.com/MichaelStollBayreuth/EllipticCurves`,
+Apache-2.0) at commit `66889eada51ac1eb2a1c98b3c1ba5b0bbe64a8d0`, file
+`EllipticCurves/WeierstrassFormalGroup/Eval.lean`, where these are
+`ChabautyColeman.MvPSeries.eval_mem_maximalIdeal_pow`, `..._pow_mul` and `..._pow_add_mul`. That
+development evaluates through its own `ChabautyColeman.MvPSeries.eval`, which is by definition
+`MvPowerSeries.eval₂ (RingHom.id _)`; the wrapper is dropped here and the statements are made
+directly about Mathlib's `MvPowerSeries.eval₂`, as are the generalisations noted above. The
+monomial estimates and the closed-ideal summation argument are the source's.
+-/
+
+public section
+
+namespace MvPowerSeries
+
+section Monomial
+
+variable {σ : Type*} {S : Type*} [CommRing S] {a : σ → S} {I : Ideal S}
+
+/-- The monomial estimate behind all three results: a product of powers of elements of `I ^ j`
+lies in `I ^ (j * ∑ exponents)`. Stated over an arbitrary `Finset` so that the induction has
+somewhere to run. -/
+private theorem prod_mem_pow_mul_sum {j : ℕ} (hmem : ∀ i, a i ∈ I ^ j) (d : σ →₀ ℕ)
+    (t : Finset σ) : (∏ s ∈ t, a s ^ d s) ∈ I ^ (j * ∑ s ∈ t, d s) := by
+  classical
+  induction t using Finset.induction with
+  | empty => simp
+  | insert s t hs ih =>
+    rw [Finset.prod_insert hs, Finset.sum_insert hs, Nat.mul_add, pow_add]
+    exact Ideal.mul_mem_mul (pow_mul I j (d s) ▸ Ideal.pow_mem_pow (hmem s) (d s)) ih
+
+/-- A monomial of total degree at least `c`, evaluated at arguments of `I ^ j`, lies in
+`I ^ (c * j)`: it carries at least `c` of them. -/
+private theorem prod_mem_pow_mul {j c : ℕ} (hmem : ∀ i, a i ∈ I ^ j) {d : σ →₀ ℕ}
+    (hge : c ≤ d.degree) : d.prod (fun s e ↦ a s ^ e) ∈ I ^ (c * j) := by
+  have hle : c * j ≤ j * d.degree := by
+    calc c * j ≤ d.degree * j := by gcongr
+      _ = j * d.degree := mul_comm _ _
+  have hprod : d.prod (fun s e ↦ a s ^ e) ∈ I ^ (j * d.degree) := by
+    have hdeg : d.degree = ∑ s ∈ d.support, d s := rfl
+    rw [Finsupp.prod, hdeg]
+    exact prod_mem_pow_mul_sum hmem d d.support
+  exact SetLike.le_def.mp (Ideal.pow_le_pow_right hle) hprod
+
+end Monomial
+
+section Eval
+
+variable {σ : Type*}
+variable {R : Type*} [CommRing R] [UniformSpace R] [IsTopologicalSemiring R] [IsUniformAddGroup R]
+variable {S : Type*} [CommRing S] [UniformSpace S] [IsUniformAddGroup S] [CompleteSpace S]
+    [T2Space S] [IsTopologicalRing S] [IsLinearTopology S S]
+variable {φ : R →+* S} {a : σ → S} {I : Ideal S}
+
+/-- **The value lies in `I ^ k` when the arguments and the constant term do.** Every monomial of
+positive degree already carries an argument, hence a factor from `I ^ k`; the constant monomial is
+covered by the hypothesis on the constant term. -/
+theorem eval₂_mem_pow (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {k : ℕ}
+    (hmem : ∀ i, a i ∈ I ^ k) (f : MvPowerSeries σ R)
+    (hcc : φ (constantCoeff f) ∈ I ^ k) :
+    eval₂ φ a f ∈ I ^ k := by
+  classical
+  have htot := hasSum_eval₂ hφ ha f
+  have hval : ∀ d : σ →₀ ℕ, φ (coeff d f) * d.prod (fun s e ↦ a s ^ e) ∈ I ^ k := by
+    intro d
+    rcases eq_or_ne d 0 with rfl | hd
+    · simpa using hcc
+    · obtain ⟨i, hi⟩ := Finsupp.support_nonempty_iff.mpr hd
+      rw [Finsupp.prod, ← Finset.prod_erase_mul _ _ hi]
+      exact Ideal.mul_mem_left _ _ (Ideal.mul_mem_left _ _
+        (Ideal.pow_mem_of_mem _ (hmem i) _
+          (Nat.pos_of_ne_zero (Finsupp.mem_support_iff.mp hi))))
+  have hsum := tsum_mem (hI.isClosed_pow k) hval
+  rwa [htot.tsum_eq] at hsum
+
+/-- **A series vanishing below total degree `c`, evaluated at arguments of `I ^ j`, takes values
+in `I ^ (c * j)`.** A surviving monomial has degree at least `c`, so it contributes at least `c`
+arguments and therefore a factor from `I ^ (c * j)`. -/
+theorem eval₂_mem_pow_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {j c : ℕ}
+    (hmem : ∀ i, a i ∈ I ^ j) (f : MvPowerSeries σ R)
+    (hcoeff : ∀ d : σ →₀ ℕ, d.degree < c → coeff d f = 0) :
+    eval₂ φ a f ∈ I ^ (c * j) := by
+  classical
+  have htot := hasSum_eval₂ hφ ha f
+  have hval : ∀ d : σ →₀ ℕ, φ (coeff d f) * d.prod (fun s e ↦ a s ^ e) ∈ I ^ (c * j) := by
+    intro d
+    rcases lt_or_ge d.degree c with hlt | hge
+    · rw [hcoeff d hlt, map_zero, zero_mul]
+      exact zero_mem _
+    · exact Ideal.mul_mem_left _ _ (prod_mem_pow_mul hmem hge)
+  have hsum := tsum_mem (hI.isClosed_pow (c * j)) hval
+  rwa [htot.tsum_eq] at hsum
+
+/-- **Small coefficients improve the bound.** If in addition every coefficient of `f` lies in
+`I ^ k`, the two contributions multiply and the value lies in `I ^ (k + c * j)`. -/
+theorem eval₂_mem_pow_add_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic I) {j c k : ℕ}
+    (hmem : ∀ i, a i ∈ I ^ j) (f : MvPowerSeries σ R)
+    (hcoeff : ∀ d : σ →₀ ℕ, φ (coeff d f) ∈ I ^ k)
+    (hlow : ∀ d : σ →₀ ℕ, d.degree < c → coeff d f = 0) :
+    eval₂ φ a f ∈ I ^ (k + c * j) := by
+  classical
+  have htot := hasSum_eval₂ hφ ha f
+  have hval : ∀ d : σ →₀ ℕ, φ (coeff d f) * d.prod (fun s e ↦ a s ^ e) ∈ I ^ (k + c * j) := by
+    intro d
+    rcases lt_or_ge d.degree c with hlt | hge
+    · rw [hlow d hlt, map_zero, zero_mul]
+      exact zero_mem _
+    · rw [pow_add]
+      exact Ideal.mul_mem_mul (hcoeff d) (prod_mem_pow_mul hmem hge)
+  have hsum := tsum_mem (hI.isClosed_pow (k + c * j)) hval
+  rwa [htot.tsum_eq] at hsum
+
+end Eval
+
+end MvPowerSeries

--- a/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Topology.Algebra.Nonarchimedean.AdicTopology
+public import Mathlib.Topology.Algebra.OpenSubgroup
+
+/-!
+# Powers of the ideal defining an adic topology
+
+For an ideal `I` of a commutative ring `R`, Mathlib's `Ideal.openAddSubgroup` records that each
+power `I ^ n` is an open additive subgroup **of `R` carried with the topology `I.adicTopology`**.
+A ring is usually met the other way round: it comes with a topology already, and `IsAdic I` is
+the statement that this topology *is* the `I`-adic one. The two results here transport the
+openness across that equation and add the complementary closedness, so that a ring satisfying
+`IsAdic I` may be used directly.
+
+Closedness is the form these are wanted in: an infinite sum all of whose terms lie in `I ^ n`
+again lies in `I ^ n`, because `I ^ n` is closed and `tsum_mem` applies. That is how a power
+series evaluated at arguments of `I ^ n` is confined to `I ^ n`, in
+`TauCeti.RingTheory.MvPowerSeries.Evaluation`.
+
+## Main results
+
+* `IsAdic.isOpen_pow` : in a ring whose topology is `I`-adic, every power of `I` is open.
+* `IsAdic.isClosed_pow` : in a ring whose topology is `I`-adic, every power of `I` is closed —
+  an open additive subgroup of a topological group being closed.
+
+## Provenance
+
+Adapted from Michael Stoll's `EllipticCurves` (`github.com/MichaelStollBayreuth/EllipticCurves`,
+Apache-2.0) at commit `66889eada51ac1eb2a1c98b3c1ba5b0bbe64a8d0`, file
+`EllipticCurves/Mathlib/Chabauty/AdicTopology.lean`, where these appear as `IsAdic.isOpen_pow`
+and `IsAdic.isClosed_pow` among that development's Mathlib-bound material.
+-/
+
+public section
+
+namespace IsAdic
+
+variable {R : Type*} [CommRing R] [TopologicalSpace R] {I : Ideal R}
+
+/-- In a ring whose topology is the `I`-adic one, every power of `I` is open. -/
+theorem isOpen_pow (hI : IsAdic I) (n : ℕ) : IsOpen ((I ^ n : Ideal R) : Set R) := by
+  simp only [IsAdic] at hI
+  subst hI
+  let : TopologicalSpace R := I.adicTopology
+  exact (I.openAddSubgroup n).isOpen'
+
+/-- In a ring whose topology is the `I`-adic one, every power of `I` is closed: it is an open
+additive subgroup, and an open subgroup of a topological group is closed. -/
+theorem isClosed_pow (hI : IsAdic I) (n : ℕ) : IsClosed ((I ^ n : Ideal R) : Set R) := by
+  have hopen := hI.isOpen_pow n
+  simp only [IsAdic] at hI
+  subst hI
+  let : TopologicalSpace R := I.adicTopology
+  have : NonarchimedeanRing R := I.nonarchimedean
+  exact AddSubgroup.isClosed_of_isOpen (I ^ n).toAddSubgroup hopen
+
+end IsAdic


### PR DESCRIPTION
Evaluating a multivariate power series at arguments drawn from a power of an adic ideal keeps the
value in that power. This adds that estimate in the three forms the formal-group development uses,
together with the topological fact it rests on.

## What this adds

`TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean`

* `IsAdic.isOpen_pow`, `IsAdic.isClosed_pow` — in a ring whose topology *is* the `I`-adic one,
  every power of `I` is open, hence closed. Mathlib's `Ideal.openAddSubgroup` gives this for the
  canonical topology `I.adicTopology`; these transport it across the `IsAdic I` equation, which is
  how a ring that merely satisfies `IsAdic I` can use it.

`TauCeti/RingTheory/MvPowerSeries/Evaluation.lean`

* `MvPowerSeries.eval₂_mem_pow` — arguments and constant term in `I ^ k` confine the value to
  `I ^ k`.
* `MvPowerSeries.eval₂_mem_pow_mul` — a series vanishing below total degree `c`, evaluated at
  arguments of `I ^ j`, takes values in `I ^ (c * j)`.
* `MvPowerSeries.eval₂_mem_pow_add_mul` — if moreover every coefficient lies in `I ^ k`, the value
  lies in `I ^ (k + c * j)`.

All three run on one mechanism: `MvPowerSeries.hasSum_eval₂` writes the value as the sum of its
monomial values, each monomial is placed in the relevant power of `I`, and the sum stays there
because `I ^ n` is closed. The monomial estimate common to the last two is factored out as a
single private lemma rather than repeated.

## Two generalisations over the source

The source states these for the maximal ideal of a local ring and for evaluation through the
identity. Neither restriction is used:

* nothing asks for `I` to be maximal or for the ring to be local — only that the topology be
  `I`-adic — so they are stated for an arbitrary ideal;
* the coefficient map is an arbitrary continuous `φ : R →+* S` rather than `RingHom.id`, since
  `MvPowerSeries.hasSum_eval₂` is already stated at that generality.

Taking `I := IsLocalRing.maximalIdeal S` and `φ := RingHom.id S` recovers the source statements.

## Why

This is substrate for milestone (iii) of the formal-group programme — `Ê(𝔪)` as an honest group of
points — which needs exactly this confinement to know that the formal group law and inversion send
`𝔪`-arguments back into `𝔪`, and into deeper powers when the series vanishes to higher order. The
curve-level evaluations that consume it follow separately, on the formal group law itself.

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, Layer 1, lines 572–580:

> **The formal group — four milestones with four different hypothesis sets, not one.** [...]
> (iii) Convergence: over a complete valued field, `Ê(𝔪)` as an honest group of points. [...]
> These cannot share one typeclass bundle, and the existing sorry-free Stoll development
> (provenance) is the port source — refounded on Mathlib's formal-group-law layer, not rebuilt
> from nothing.

No `tauceti-target` marker: this PR authors no roadmap target. It supplies a Mathlib-shaped
prerequisite that the formal-group targets consume, and inventing a target id for it would put a
fabricated identifier in front of the duplicate sweeper.

## Provenance

Adapted from Michael Stoll's `EllipticCurves` (`github.com/MichaelStollBayreuth/EllipticCurves`,
Apache-2.0) at commit `66889eada51ac1eb2a1c98b3c1ba5b0bbe64a8d0` — the port source the roadmap
names for the formal group.

* `EllipticCurves/Mathlib/Chabauty/AdicTopology.lean` — `IsAdic.isOpen_pow`,
  `IsAdic.isClosed_pow`, ported as they stand.
* `EllipticCurves/WeierstrassFormalGroup/Eval.lean` — `ChabautyColeman.MvPSeries.eval_mem_maximalIdeal_pow`,
  `..._pow_mul`, `..._pow_add_mul`, restated as above.

The source evaluates through its own `ChabautyColeman.MvPSeries.eval`, which is by definition
`MvPowerSeries.eval₂ (RingHom.id _)`. That wrapper is dropped and the statements are made directly
about Mathlib's `MvPowerSeries.eval₂`, so no scaffolding is carried over. The monomial estimates
and the closed-ideal summation argument are the source's; the generalisations, the extraction of
the shared monomial lemma, and the documentation are not.


## Gates run

Stated explicitly, because one of them could not be run locally and a silent skip would make
the rest meaningless.

| Gate | Result |
| --- | --- |
| `lake build` of both changed modules, at this head | **pass** — 1663 jobs, exit 0, mathlib pin unchanged across the rebase |
| `scripts/lint-style.sh` | **pass** — exit 0, 3606 source files with conforming headers |
| `scripts/lint-env.sh` | **not run locally** — see below |
| axioms / module-system | CI (`pr-build`) |

`lint-env.sh` is not runnable in a module-scoped worktree: its docstring-scan driver imports the
whole library, so without a full `TauCeti` build it fails on the first missing object file
(`TauCeti/Algebra/AddCircle.olean` here) before reaching any of this PR's code. A full local build
is what the project's build discipline forbids, so this gate is CI-only for a worker who is not
sitting on a fully built tree. It is not being claimed as passed; `pr-build` covers it.

One further note for anyone reading a gate log on this branch: an earlier `lint-style` run exited
non-zero on `TauCeti/RingTheory/DedekindDomain/SInteger/SelmerGroup.lean`, a file this PR does not
touch. That was not a finding — the linter was scanning while a `git rebase` moved the tree under
it. The clean re-run on a stable tree is the one recorded above.
