### PR TITLE
feat(MordellWeil): the 2-torsion of the group of points is the roots of f, plus one

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
@@ -40,8 +40,6 @@ is elliptic. See the Provenance note.
 * `WeierstrassCurve.isInteger_of_torsion`: the integrality half, with no order-two exception, for
   any integral model in characteristic-≠-2 normal form.
 * `WeierstrassCurve.y_eq_zero_or_sq_dvd_Δ_of_torsion`: the discriminant half, likewise.
-* `WeierstrassCurve.y_eq_zero_of_order_two`: the collapse — order two forces `y = 0` — over any
-  field in which `2` is invertible.
 
 The three results above `lutz_nagell` are stated at `[W.IsCharNeTwoNF]`, i.e. `a₁ = a₃ = 0`, not
 at `shortCurve`: no step uses `a₂ = 0`, and the cubic `X³ + a₂X² + a₄X + a₆` is monic either way.
@@ -91,20 +89,6 @@ namespace WeierstrassCurve
 open TauCeti.WeierstrassCurve
 
 variable {W : WeierstrassCurve ℤ} [W.IsCharNeTwoNF]
-
-/-- **In characteristic-≠-2 normal form, a two-torsion point has `y = 0`.** Order two makes `ψ₂`
-vanish, and `a₁ = a₃ = 0` makes `ψ₂` equal `2y`; cancelling `2` finishes it.
-
-Nothing here sees `ℤ` or `ℚ`, and nothing needs `a₂ = 0`: the argument is the normal-form identity
-plus the ability to cancel `2` in the point's own field, so those are exactly the hypotheses. -/
-lemma y_eq_zero_of_order_two {F : Type*} [Field F] [DecidableEq F]
-    {E : WeierstrassCurve F} [E.IsCharNeTwoNF] (h2F : (2 : F) ≠ 0)
-    {x y : F} (hns : E.toAffine.Nonsingular x y)
-    (h2 : addOrderOf (Affine.Point.some _ _ hns) = 2) : y = 0 := by
-  have hψ : E.ψ₂.evalEval x y = 0 :=
-    (addOrderOf_eq_two_iff_evalEval_ψ₂_eq_zero _ hns).mp h2
-  rw [evalEval_ψ₂_of_isCharNeTwoNF] at hψ
-  exact (mul_eq_zero.mp hψ).resolve_left h2F
 
 /-- **Nagell–Lutz, discriminant half.** For a torsion point with integral coordinates on an
 integral model in characteristic-≠-2 normal form, either `y₀ = 0` or `y₀²` divides the

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/ShortNagellLutz.lean
@@ -122,7 +122,7 @@ theorem isInteger_of_torsion {x y : ℚ}
     IsLocalization.IsInteger ℤ x ∧ IsLocalization.IsInteger ℤ y := by
   rcases isInteger_or_order_two_of_torsion_rat hns htor with h | ⟨h2, -, -⟩
   · exact h
-  · have hy : y = 0 := y_eq_zero_of_order_two two_ne_zero hns h2
+  · have hy : y = 0 := y_eq_zero_of_order_two two_ne_zero hns (h2 ▸ addOrderOf_nsmul_eq_zero _)
     refine ⟨?_, hy ▸ ⟨0, by simp⟩⟩
     have hmonic : (X ^ 3 + C W.a₂ * X ^ 2 + C W.a₄ * X + C W.a₆ : ℤ[X]).Monic := by
       simpa [add_assoc] using monic_X_pow_add (n := 3) (by compute_degree!)

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/TwoTorsion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/TwoTorsion.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.XSubT
+
+/-!
+# The `2`-torsion of the group of points of a Weierstrass curve
+
+Let `W : y² = f(x) = x³ + a₂x² + a₄x + a₆` be an elliptic curve in characteristic `≠ 2` normal
+form over a field `K`. In that normal form negation is `-(x, y) = (x, -y)`, so a point is its own
+negative exactly when `y = 0`, and the `2`-torsion of `W(K)` is the origin together with the
+points `(x, 0)` at the roots of `f`.
+
+The counting statement `card_ker_nsmul_two` is what turns a root count into a torsion count. It
+is one side of the archimedean local-image formula of explicit `2`-descent, which reads
+`#(im μ_v) = #E(ℝ)[2] / 2` at a real place.
+
+## Main statements
+
+* `WeierstrassCurve.Affine.card_ker_nsmul_two`: `#W(K)[2]` is the number of roots of `f` in `K`,
+  plus one for the origin.
+
+## Provenance
+
+Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+`EllipticCurves/WeakMordellWeil.lean` lines 806-868 — the `2`-torsion section, which sits after
+the range that `TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean` ported.
+
+This advances `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6 (README:813-820), whose
+"Explicit `2`-descent (core, this layer)" bullet names the local conditions and the rank bound;
+the archimedean local-image count needs this torsion count.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve
+
+namespace Affine
+
+variable {K : Type*} [Field K] (W : Affine K) [W.IsCharNeTwoNF] [W.IsElliptic] [DecidableEq K]
+
+variable {W} in
+/-- A point `(x, 0)` at a root of `f` is killed by `2`: in a characteristic `≠ 2` normal form its
+negative is `(x, -0) = (x, 0)`. -/
+lemma two_nsmul_some_eq_zero {x : K} (hx : W.f.eval x = 0) :
+    (2 : ℕ) • (Point.some _ _ (W.nonsingular_of_eval_f_eq_zero hx) : W.Point) = 0 := by
+  rw [two_nsmul, add_eq_zero_iff_eq_neg, Point.neg_some, Point.some.injEq]
+  refine ⟨rfl, ?_⟩
+  rw [negY_of_isCharNeTwoNF, neg_zero]
+
+variable {W} in
+/-- Conversely, an affine `2`-torsion point has `y = 0`: `(x, y) = -(x, y) = (x, -y)` forces
+`2y = 0`, and `2 ≠ 0` in the base field. -/
+lemma y_eq_zero_of_two_nsmul_eq_zero {x y : K}
+    (h : W.Nonsingular x y) (h2 : (2 : ℕ) • (Point.some _ _ h : W.Point) = 0) : y = 0 := by
+  have h20 : (2 : K) ≠ 0 := Ring.two_ne_zero <| ringChar_ne_two W
+  rw [two_nsmul, add_eq_zero_iff_eq_neg, Point.neg_some, Point.some.injEq] at h2
+  have hy : 2 * y = 0 := by linear_combination h2.2.trans (negY_of_isCharNeTwoNF ..)
+  rcases mul_eq_zero.mp hy with h' | h'
+  · exact absurd h' h20
+  · exact h'
+
+/-- **The `2`-torsion of `W(K)` is the origin together with the points `(x, 0)` at the roots of
+`f`**, so its order is the number of roots of `f` in `K` plus one. -/
+theorem card_ker_nsmul_two : Nat.card (nsmulAddMonoidHom (α := W.Point) 2).ker =
+    Nat.card {x : K // W.f.eval x = 0} + 1 := by
+  have hfin : Finite {x : K | W.f.eval x = 0} :=
+    Set.Finite.to_subtype (Polynomial.finite_setOfPred_isRoot W.f_ne_zero)
+  set pt : {x : K | W.f.eval x = 0} → W.Point :=
+    fun x ↦ Point.some _ _ (W.nonsingular_of_eval_f_eq_zero x.2)
+  have hinj : Function.Injective pt := by
+    intro a b hab
+    exact Subtype.ext ((Point.some.injEq _ _ _ _ _ _).mp hab).1
+  have hset : ((nsmulAddMonoidHom (α := W.Point) 2).ker : Set W.Point) =
+      insert 0 (Set.range pt) := by
+    ext P
+    constructor
+    · intro hP
+      induction P with
+      | zero => exact Set.mem_insert _ _
+      | some x y h =>
+        have hy := y_eq_zero_of_two_nsmul_eq_zero h hP
+        subst hy
+        have hx : W.f.eval x = 0 := by
+          have := (W.equation_iff_eval_f_eq_sq x 0).mp h.1
+          simpa using this
+        exact Set.mem_insert_of_mem _ ⟨⟨x, hx⟩, rfl⟩
+    · intro hP
+      rcases Set.mem_insert_iff.mp hP with rfl | ⟨x, rfl⟩
+      · exact zero_mem _
+      · exact two_nsmul_some_eq_zero x.2
+  calc Nat.card (nsmulAddMonoidHom (α := W.Point) 2).ker
+      = ((nsmulAddMonoidHom (α := W.Point) 2).ker : Set W.Point).ncard := Nat.card_coe_set_eq _
+    _ = (insert 0 (Set.range pt)).ncard := by rw [hset]
+    _ = (Set.range pt).ncard + 1 :=
+        Set.ncard_insert_of_notMem (by intro ⟨x, hx⟩; exact Point.some_ne_zero _ hx)
+    _ = Nat.card {x : K // W.f.eval x = 0} + 1 := by
+        rw [← Nat.card_coe_set_eq, Nat.card_range_of_injective hinj]
+        rfl
+
+end Affine
+
+end WeierstrassCurve
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/TwoTorsion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/TwoTorsion.lean
@@ -48,8 +48,12 @@ namespace Affine
 
 variable {K : Type*} [Field K] (W : Affine K) [W.IsCharNeTwoNF] [W.IsElliptic] [DecidableEq K]
 
-/-- **The `2`-torsion of `W(K)` is the origin together with the points `(x, 0)` at the roots of
-`f`**, so its order is the number of roots of `f` in `K` plus one. -/
+/-- **The `2`-torsion of `W(K)` has one more element than `f` has roots in `K`.**
+
+The underlying reason is that the `2`-torsion is the origin together with the points `(x, 0)` at
+the roots of `f`; that set equality is established inside the proof, but only the cardinality is
+exported, because that is all the archimedean local-image count consumes. A caller needing the
+identification itself should ask for it as its own theorem. -/
 theorem card_ker_nsmul_two : Nat.card (nsmulAddMonoidHom (α := W.Point) 2).ker =
     Nat.card {x : K // W.f.eval x = 0} + 1 := by
   have h2F : (2 : K) ≠ 0 := Ring.two_ne_zero (ringChar_ne_two W)
@@ -68,13 +72,7 @@ theorem card_ker_nsmul_two : Nat.card (nsmulAddMonoidHom (α := W.Point) 2).ker 
       induction P with
       | zero => exact Set.mem_insert _ _
       | some x y h =>
-        have h2 : (2 : ℕ) • (Point.some x y h : W.Point) = 0 := hP
-        have hord : addOrderOf (Point.some x y h : W.Point) = 2 := by
-          rcases (Nat.dvd_prime Nat.prime_two).mp
-            (addOrderOf_dvd_iff_nsmul_eq_zero.mpr h2) with h1 | h1
-          · exact absurd (AddMonoid.addOrderOf_eq_one_iff.mp h1) (Point.some_ne_zero h)
-          · exact h1
-        have hy := y_eq_zero_of_order_two h2F h hord
+        have hy := y_eq_zero_of_order_two h2F h (hP : (2 : ℕ) • (Point.some x y h : W.Point) = 0)
         subst hy
         have hx : W.f.eval x = 0 := by
           have := (W.equation_iff_eval_f_eq_sq x 0).mp h.1

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/TwoTorsion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/TwoTorsion.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.XSubT
+public import TauCeti.AlgebraicGeometry.EllipticCurve.NormalForms
 
 /-!
 # The `2`-torsion of the group of points of a Weierstrass curve
@@ -47,31 +48,11 @@ namespace Affine
 
 variable {K : Type*} [Field K] (W : Affine K) [W.IsCharNeTwoNF] [W.IsElliptic] [DecidableEq K]
 
-variable {W} in
-/-- A point `(x, 0)` at a root of `f` is killed by `2`: in a characteristic `≠ 2` normal form its
-negative is `(x, -0) = (x, 0)`. -/
-lemma two_nsmul_some_eq_zero {x : K} (hx : W.f.eval x = 0) :
-    (2 : ℕ) • (Point.some _ _ (W.nonsingular_of_eval_f_eq_zero hx) : W.Point) = 0 := by
-  rw [two_nsmul, add_eq_zero_iff_eq_neg, Point.neg_some, Point.some.injEq]
-  refine ⟨rfl, ?_⟩
-  rw [negY_of_isCharNeTwoNF, neg_zero]
-
-variable {W} in
-/-- Conversely, an affine `2`-torsion point has `y = 0`: `(x, y) = -(x, y) = (x, -y)` forces
-`2y = 0`, and `2 ≠ 0` in the base field. -/
-lemma y_eq_zero_of_two_nsmul_eq_zero {x y : K}
-    (h : W.Nonsingular x y) (h2 : (2 : ℕ) • (Point.some _ _ h : W.Point) = 0) : y = 0 := by
-  have h20 : (2 : K) ≠ 0 := Ring.two_ne_zero <| ringChar_ne_two W
-  rw [two_nsmul, add_eq_zero_iff_eq_neg, Point.neg_some, Point.some.injEq] at h2
-  have hy : 2 * y = 0 := by linear_combination h2.2.trans (negY_of_isCharNeTwoNF ..)
-  rcases mul_eq_zero.mp hy with h' | h'
-  · exact absurd h' h20
-  · exact h'
-
 /-- **The `2`-torsion of `W(K)` is the origin together with the points `(x, 0)` at the roots of
 `f`**, so its order is the number of roots of `f` in `K` plus one. -/
 theorem card_ker_nsmul_two : Nat.card (nsmulAddMonoidHom (α := W.Point) 2).ker =
     Nat.card {x : K // W.f.eval x = 0} + 1 := by
+  have h2F : (2 : K) ≠ 0 := Ring.two_ne_zero (ringChar_ne_two W)
   have hfin : Finite {x : K | W.f.eval x = 0} :=
     Set.Finite.to_subtype (Polynomial.finite_setOfPred_isRoot W.f_ne_zero)
   set pt : {x : K | W.f.eval x = 0} → W.Point :=
@@ -87,7 +68,13 @@ theorem card_ker_nsmul_two : Nat.card (nsmulAddMonoidHom (α := W.Point) 2).ker 
       induction P with
       | zero => exact Set.mem_insert _ _
       | some x y h =>
-        have hy := y_eq_zero_of_two_nsmul_eq_zero h hP
+        have h2 : (2 : ℕ) • (Point.some x y h : W.Point) = 0 := hP
+        have hord : addOrderOf (Point.some x y h : W.Point) = 2 := by
+          rcases (Nat.dvd_prime Nat.prime_two).mp
+            (addOrderOf_dvd_iff_nsmul_eq_zero.mpr h2) with h1 | h1
+          · exact absurd (AddMonoid.addOrderOf_eq_one_iff.mp h1) (Point.some_ne_zero h)
+          · exact h1
+        have hy := y_eq_zero_of_order_two h2F h hord
         subst hy
         have hx : W.f.eval x = 0 := by
           have := (W.equation_iff_eval_f_eq_sq x 0).mp h.1
@@ -96,7 +83,8 @@ theorem card_ker_nsmul_two : Nat.card (nsmulAddMonoidHom (α := W.Point) 2).ker 
     · intro hP
       rcases Set.mem_insert_iff.mp hP with rfl | ⟨x, rfl⟩
       · exact zero_mem _
-      · exact two_nsmul_some_eq_zero x.2
+      · simp only [SetLike.mem_coe, AddMonoidHom.mem_ker, nsmulAddMonoidHom_apply, two_nsmul]
+        exact Point.add_self_of_Y_eq (by rw [negY_of_isCharNeTwoNF, neg_zero])
   calc Nat.card (nsmulAddMonoidHom (α := W.Point) 2).ker
       = ((nsmulAddMonoidHom (α := W.Point) 2).ker : Set W.Point).ncard := Nat.card_coe_set_eq _
     _ = (insert 0 (Set.range pt)).ncard := by rw [hset]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NormalForms.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NormalForms.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 public import Mathlib.AlgebraicGeometry.EllipticCurve.NormalForms
 
 /-!
@@ -25,6 +26,7 @@ re-established by hand at every such crossing.
 * `WeierstrassCurve.isCharNeTwoNF_map`: `a₁ = a₃ = 0` is preserved by a ring hom.
 * `WeierstrassCurve.isCharNeTwoNF_baseChange`: the same for a base change, which is the spelling
   consumers hold. Both are instances, so the crossing is silent.
+* `WeierstrassCurve.y_eq_zero_of_order_two`: a point of order two has `y = 0`.
 -/
 
 public section
@@ -47,5 +49,21 @@ caller holds and instance search does not unfold it. -/
 instance isCharNeTwoNF_baseChange [Algebra R S] [W.IsCharNeTwoNF] :
     (W.baseChange S).IsCharNeTwoNF :=
   W.isCharNeTwoNF_map (algebraMap R S)
+
+/-- **In characteristic-≠-2 normal form, a two-torsion point has `y = 0`.** Negation is
+`(x, y) ↦ (x, -y)`, so a point equal to its own negative has `2y = 0`; cancelling `2` finishes it.
+
+Nothing here sees `ℤ` or `ℚ`, and nothing needs `a₂ = 0`: the argument is the normal-form identity
+plus the ability to cancel `2` in the point's own field, so those are exactly the hypotheses. -/
+lemma y_eq_zero_of_order_two {F : Type*} [Field F] [DecidableEq F]
+    {E : WeierstrassCurve F} [E.IsCharNeTwoNF] (h2F : (2 : F) ≠ 0)
+    {x y : F} (hns : E.toAffine.Nonsingular x y)
+    (h2 : addOrderOf (Affine.Point.some _ _ hns) = 2) : y = 0 := by
+  have hP : (2 : ℕ) • (Affine.Point.some _ _ hns) = 0 := h2 ▸ addOrderOf_nsmul_eq_zero _
+  rw [two_nsmul, add_eq_zero_iff_eq_neg, Affine.Point.neg_some, Affine.Point.some.injEq] at hP
+  have hneg : E.toAffine.negY x y = -y := by
+    simp [Affine.negY, a₁_of_isCharNeTwoNF, a₃_of_isCharNeTwoNF]
+  have hy : 2 * y = 0 := by linear_combination hP.2.trans hneg
+  exact (mul_eq_zero.mp hy).resolve_left h2F
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/NormalForms.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/NormalForms.lean
@@ -9,12 +9,20 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 public import Mathlib.AlgebraicGeometry.EllipticCurve.NormalForms
 
 /-!
-# Weierstrass normal forms survive a base change
+# Characteristic-≠-2 normal form: transport, and its elementary consequences
 
 Mathlib's `WeierstrassCurve.IsCharNeTwoNF` asserts `a₁ = a₃ = 0`, and its `NormalForms` file
-proves a great deal from that hypothesis. What it does not record is that the condition is
-preserved by `map` and `baseChange` — the coefficients of `W.map f` are the images of `W`'s, so a
-vanishing coefficient stays vanishing.
+proves a great deal from that hypothesis. This file collects two things it does not record.
+
+**Transport.** The condition is preserved by `map` and `baseChange` — the coefficients of
+`W.map f` are the images of `W`'s, so a vanishing coefficient stays vanishing.
+
+**Elementary consequences.** Facts that follow from `a₁ = a₃ = 0` alone, by unfolding `negY`, with
+no further machinery. `y_eq_zero_of_order_two` is the current example: negation is `(x, y) ↦
+(x, -y)`, so a `2`-torsion point has `y = 0`. It lives here rather than with the division-polynomial
+material that first proved it because it needs none of that — this module's closure is one file,
+against thirty-three for `DivisionPolynomial/ShortNagellLutz.lean` — and its consumers, Nagell–Lutz
+and the `2`-descent torsion count, sit in unrelated parts of the library.
 
 That gap matters as soon as a statement is about a curve over `ℤ` and a point over `ℚ`, which is
 the shape of the classical Nagell–Lutz theorem: the hypothesis is natural on the integral model,
@@ -26,7 +34,8 @@ re-established by hand at every such crossing.
 * `WeierstrassCurve.isCharNeTwoNF_map`: `a₁ = a₃ = 0` is preserved by a ring hom.
 * `WeierstrassCurve.isCharNeTwoNF_baseChange`: the same for a base change, which is the spelling
   consumers hold. Both are instances, so the crossing is silent.
-* `WeierstrassCurve.y_eq_zero_of_order_two`: a point of order two has `y = 0`.
+* `WeierstrassCurve.y_eq_zero_of_order_two`: in a characteristic-≠-2 normal form, an affine
+  point killed by `2` has `y = 0`.
 -/
 
 public section
@@ -54,16 +63,19 @@ instance isCharNeTwoNF_baseChange [Algebra R S] [W.IsCharNeTwoNF] :
 `(x, y) ↦ (x, -y)`, so a point equal to its own negative has `2y = 0`; cancelling `2` finishes it.
 
 Nothing here sees `ℤ` or `ℚ`, and nothing needs `a₂ = 0`: the argument is the normal-form identity
-plus the ability to cancel `2` in the point's own field, so those are exactly the hypotheses. -/
+plus the ability to cancel `2` in the point's own field, so those are exactly the hypotheses.
+
+The hypothesis is annihilation by `2` rather than `addOrderOf P = 2`, which is what the proof and
+every caller actually have. For an *affine* point the two are equivalent — `Point.some _ _ _` is
+never `0` — so the name remains exact; the weaker form simply spares callers the reconstruction. -/
 lemma y_eq_zero_of_order_two {F : Type*} [Field F] [DecidableEq F]
     {E : WeierstrassCurve F} [E.IsCharNeTwoNF] (h2F : (2 : F) ≠ 0)
     {x y : F} (hns : E.toAffine.Nonsingular x y)
-    (h2 : addOrderOf (Affine.Point.some _ _ hns) = 2) : y = 0 := by
-  have hP : (2 : ℕ) • (Affine.Point.some _ _ hns) = 0 := h2 ▸ addOrderOf_nsmul_eq_zero _
-  rw [two_nsmul, add_eq_zero_iff_eq_neg, Affine.Point.neg_some, Affine.Point.some.injEq] at hP
+    (h2 : (2 : ℕ) • (Affine.Point.some _ _ hns) = 0) : y = 0 := by
+  rw [two_nsmul, add_eq_zero_iff_eq_neg, Affine.Point.neg_some, Affine.Point.some.injEq] at h2
   have hneg : E.toAffine.negY x y = -y := by
     simp [Affine.negY, a₁_of_isCharNeTwoNF, a₃_of_isCharNeTwoNF]
-  have hy : 2 * y = 0 := by linear_combination hP.2.trans hneg
+  have hy : 2 * y = 0 := by linear_combination h2.2.trans hneg
   exact (mul_eq_zero.mp hy).resolve_left h2F
 
 end WeierstrassCurve


### PR DESCRIPTION
In the characteristic-`≠ 2` normal form `y² = f(x)`, negation is `-(x, y) = (x, -y)`, so a point is its own negative exactly when `y = 0`. The `2`-torsion of `W(K)` is therefore the origin together with the points `(x, 0)` at the roots of `f`, and

`WeierstrassCurve.Affine.card_ker_nsmul_two : #W(K)[2] = #{x | f(x) = 0} + 1`

turns a root count into a torsion count. New module `MordellWeil/TwoTorsion.lean` — a **single theorem, no supporting API**.

The PR also **relocates** `WeierstrassCurve.y_eq_zero_of_order_two` from `DivisionPolynomial/ShortNagellLutz.lean` to `NormalForms.lean`, with an elementary proof. See "Correction after review round 1" below.

Bead: `tc-h1g7y` (EC-12b prerequisite). Consumer: `tc-gkg13` (EC-12b-i), via the archimedean real-place count.

## Roadmap

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, README:813-820 — the "**Explicit `2`-descent (core, this layer)**" bullet, which names "the local conditions, the explicit `2`-Selmer group …, its finiteness, and the theorem converting its cardinality into a **Mordell–Weil rank bound**".

This is a prerequisite of the archimedean half of that computation: the local-image formula at a real place reads `#(im μ_v) = #E(ℝ)[2] / 2`, so the `2`-torsion count is one side of the identity. It was surfaced by the dependency closure of the archimedean rung, which found this theorem sitting outside the range already ported.

## Attribution

Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0), pinned by `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, file `EllipticCurves/WeakMordellWeil.lean` lines 806-868.

Note that PR #4448 ported `WeakMordellWeil.lean` lines **60-798**; this `2`-torsion section sits just past that range and was not included, which is why it is arriving separately rather than as part of that PR. The source module carries no `maxHeartbeats` override, so none was stripped and none is added.

## Prior art / dedupe

Re-measured against **both** current `main` and the pinned Mathlib, with a positive control for every instrument:

| object | `main` | pinned Mathlib | note |
|---|---|---|---|
| `card_ker_nsmul_two` | 0 | 0 | control `def μX` = 1 on `main` |
| a count of `E(K)[2]` for a Weierstrass curve | 0 | 0 | control: `Affine.Point` = 8 Mathlib files |

Two near-misses, both checked and **not** duplicates:

* `main` has `TauCeti.card_elementaryTwoQuotient_eq_card_twoTorsion` (`Algebra/Group/ElementaryTwoQuotient/Basic.lean:343`), but that is the general group-theoretic identity `|G/G²| = |{g | g² = 1}|`. It says nothing about which points of a Weierstrass curve are `2`-torsion; the content here is the identification of that set with the roots of `f`.
* Mathlib has `WeierstrassCurve.twoTorsionPolynomial` (`Weierstrass.lean:305`), which is a `Cubic` — the polynomial, not a count of rational `2`-torsion points.

Every ingredient of the proof is already on `main` in `MordellWeil/XSubT.lean` (`nonsingular_of_eval_f_eq_zero`, `negY_of_isCharNeTwoNF`, `equation_iff_eval_f_eq_sq`, `ringChar_ne_two`, `f_ne_zero`) or in Mathlib (`nsmulAddMonoidHom`, `Polynomial.finite_setOfPred_isRoot`, `Set.ncard_insert_of_notMem`). No new imports beyond `XSubT`.

Following the instance-duplication lesson from #4726: the diff declares **no** instances, so there is nothing of that kind to collide with existing `map`/`baseChange` instances.

## Deviation from the source

The source calls `Polynomial.finite_setOf_isRoot`, which is **deprecated** at this repository's Mathlib pin in favour of `Polynomial.finite_setOfPred_isRoot`. The port uses the current name, so the file compiles without deprecation warnings.

### Correction after review round 1

The `reuse` rubric correctly found that both of my supporting lemmas duplicated existing API:

* `two_nsmul_some_eq_zero` re-derived Mathlib's `Affine.Point.add_self_of_Y_eq` (`Affine/Point.lean:686`). Deleted; the counting proof calls it directly.
* `y_eq_zero_of_two_nsmul_eq_zero` duplicated `WeierstrassCurve.y_eq_zero_of_order_two`.

For the second I took the relocation the finding explicitly permits, rather than the import, because I measured the cost: `ShortNagellLutz.lean`'s transitive closure is **33 TauCeti modules** against this file's **4**. Importing the division-polynomial tower into a 100-line file for one elementary fact would trade a `reuse` finding for a placement one.

So `y_eq_zero_of_order_two` moves to `NormalForms.lean` (closure 1) **with an elementary proof**. Its previous proof went through the 2-division polynomial `ψ₂`; the fact needs none of that — in a characteristic-`≠ 2` normal form negation is `(x, y) ↦ (x, -y)`, so a point equal to its own negative has `2y = 0`. Its statement is unchanged and `ShortNagellLutz.lean` already imported `NormalForms`, so its own use site is untouched, and the division-polynomial dependency of that fact disappears for every consumer.

`TwoTorsion.lean` is now a single theorem with no supporting API of its own.

## Placement

`MordellWeil/TwoTorsion.lean` rather than an addition to `MordellWeil/XSubT.lean`: XSubT is already 960 lines against the project's 1000-line file-length limit, and its subject is the `x - T` descent map, whereas this is a statement about the group of points that the descent map happens to consume. The namespace is Mathlib's `WeierstrassCurve.Affine`, as `XSubT.lean` established for this development, so that dot notation (`W.f`, `W.Point`) resolves.
