### PR TITLE
feat(Isogeny): the coordinate pullback of multiplication by n, for n nonzero in the base field

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
+
+/-!
+# The generic point of an affine Weierstrass curve
+
+The coordinate ring `W.CoordinateRing` is `F[X][Y]` modulo the Weierstrass relation, so the
+classes of `X` and `Y` in the function field are a pair satisfying that relation over
+`W.FunctionField`. They are the *generic point*: a point of `W` base-changed to its own function
+field, and the universal one, in that a statement about it specialises to every point of `W`.
+
+The two facts worth having are `equation_genericPoint`, that the pair really is a point, and
+`evalEval_genericPoint`, that evaluating a bivariate polynomial there is the same as reducing it
+modulo the Weierstrass relation. The second is what makes the generic point usable: it turns any
+polynomial expression evaluated at `(X, Y)` into a coordinate-ring element, where that ring's
+own API applies.
+
+## Main definitions
+
+* `WeierstrassCurve.Affine.genericX`, `WeierstrassCurve.Affine.genericY`: the coordinates.
+* `WeierstrassCurve.Affine.functionFieldCurve`: `W` base-changed to `W.FunctionField`.
+
+## Main results
+
+* `WeierstrassCurve.Affine.equation_genericPoint`: the generic point satisfies the equation.
+* `WeierstrassCurve.Affine.nonsingular_genericPoint`: and is nonsingular, on an elliptic curve.
+* `WeierstrassCurve.Affine.evalEval_genericPoint`: evaluation there is reduction.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], II.1.
+-/
+
+public section
+
+open Polynomial
+
+open scoped Polynomial.Bivariate
+
+namespace WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
+
+/-- The generic `x`-coordinate: the class of `X` in the function field. -/
+noncomputable def genericX : W.FunctionField :=
+  algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing X)
+
+/-- The generic `y`-coordinate: the class of `Y` in the function field. -/
+noncomputable def genericY : W.FunctionField :=
+  algebraMap W.CoordinateRing W.FunctionField (AdjoinRoot.root W.polynomial)
+
+/-- **The defining equation of `genericX`.** Under the module system a `def`'s body is sealed
+across the module boundary even inside a `public section`, so a downstream file can unfold it by
+neither `rw` nor `simp only`. This lemma and `genericY_def` are how the two are computed with
+from outside. -/
+theorem genericX_def : W.genericX =
+    algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing X) := (rfl)
+
+/-- **The defining equation of `genericY`.** -/
+theorem genericY_def : W.genericY =
+    algebraMap W.CoordinateRing W.FunctionField (AdjoinRoot.root W.polynomial) := (rfl)
+
+/-- `W` base-changed to its own function field. The generic point is a point of it. -/
+noncomputable abbrev functionFieldCurve : WeierstrassCurve.Affine W.FunctionField :=
+  W.map (algebraMap F W.FunctionField)
+
+/-- The composite `F → W.FunctionField` factors through the coordinate ring. Used to turn
+statements about the base-changed curve into statements about images under
+`algebraMap W.CoordinateRing W.FunctionField`. -/
+theorem algebraMap_functionField_eq_comp :
+    (algebraMap F W.FunctionField : F →+* W.FunctionField) =
+      (algebraMap W.CoordinateRing W.FunctionField).comp (algebraMap F W.CoordinateRing) :=
+  (IsScalarTower.algebraMap_eq F W.CoordinateRing W.FunctionField).symm
+
+/-- **Evaluating at the generic point is reduction modulo the Weierstrass relation.** A bivariate
+polynomial over `F`, pushed to the function field and evaluated at `(genericX, genericY)`, is the
+image of its class in the coordinate ring.
+
+This is the workhorse: it converts any polynomial expression at the generic point into the image
+of a coordinate-ring element, where the ring's own API applies. -/
+theorem evalEval_genericPoint (p : F[X][Y]) :
+    (p.map (mapRingHom (algebraMap F W.FunctionField))).evalEval W.genericX W.genericY =
+      algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W p) := by
+  conv_lhs =>
+    rw [algebraMap_functionField_eq_comp W, ← mapRingHom_comp, ← Polynomial.map_map]
+  set g := algebraMap W.CoordinateRing W.FunctionField
+  set q := Polynomial.map (mapRingHom (algebraMap F W.CoordinateRing)) p with hq
+  -- `genericX` and `genericY` are already of the form `g _`; say so, or the rewrite below
+  -- cannot see its own pattern `evalEval (g _) (g _) (map (mapRingHom g) _)`.
+  change (q.map (mapRingHom g)).evalEval (g _) (g _) = g _
+  rw [Polynomial.map_mapRingHom_evalEval]
+  congr 1
+  rw [hq]
+  rw [← Polynomial.eval₂_eval₂RingHom_apply]
+  have hinner : eval₂RingHom (algebraMap F W.CoordinateRing) (algebraMap F[X] W.CoordinateRing X) =
+      algebraMap F[X] W.CoordinateRing := by
+    ext x
+    · simp [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing]
+    · simp
+  rw [hinner, ← Polynomial.aeval_def]
+  exact AdjoinRoot.aeval_eq p
+
+/-- **The generic point is a point of the curve.** `(X, Y)` satisfies the equation of `W`
+base-changed to the function field, because the Weierstrass polynomial is precisely what the
+coordinate ring quotients out. -/
+theorem equation_genericPoint : W.functionFieldCurve.Equation W.genericX W.genericY := by
+  dsimp only [Equation, functionFieldCurve]
+  rw [map_polynomial, evalEval_genericPoint W W.polynomial, AdjoinRoot.mk_self, map_zero]
+
+/-- The generic point is nonsingular, so it is an affine point of the base-changed curve. -/
+theorem nonsingular_genericPoint [W.IsElliptic] :
+    W.functionFieldCurve.Nonsingular W.genericX W.genericY :=
+  equation_iff_nonsingular.mp (equation_genericPoint W)
+
+end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
@@ -10,10 +10,16 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
 /-!
 # The generic point of an affine Weierstrass curve
 
-The coordinate ring `W.CoordinateRing` is `F[X][Y]` modulo the Weierstrass relation, so the
+The coordinate ring `W.CoordinateRing` is `R[X][Y]` modulo the Weierstrass relation, so the
 classes of `X` and `Y` in the function field are a pair satisfying that relation over
 `W.FunctionField`. They are the *generic point*: a point of `W` base-changed to its own function
-field, and the universal one, in that a statement about it specialises to every point of `W`.
+field.
+
+What is proved here is exactly that — that the pair is a point (`equation_genericPoint`), and
+that evaluating a bivariate polynomial at it is reduction modulo the Weierstrass relation
+(`evalEval_genericPoint`). The word "generic" is the usual geometric one, but no specialisation
+property is established: nothing below says that a statement about this point transfers to the
+points of `W`, and no consumer may rely on that.
 
 The two facts worth having are `equation_genericPoint`, that the pair really is a point, and
 `evalEval_genericPoint`, that evaluating a bivariate polynomial there is the same as reducing it
@@ -45,11 +51,11 @@ open scoped Polynomial.Bivariate
 
 namespace WeierstrassCurve.Affine
 
-variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve.Affine R)
 
 /-- The generic `x`-coordinate: the class of `X` in the function field. -/
 noncomputable def genericX : W.FunctionField :=
-  algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing X)
+  algebraMap W.CoordinateRing W.FunctionField (algebraMap R[X] W.CoordinateRing X)
 
 /-- The generic `y`-coordinate: the class of `Y` in the function field. -/
 noncomputable def genericY : W.FunctionField :=
@@ -60,7 +66,7 @@ across the module boundary even inside a `public section`, so a downstream file 
 neither `rw` nor `simp only`. This lemma and `genericY_def` are how the two are computed with
 from outside. -/
 theorem genericX_def : W.genericX =
-    algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing X) := (rfl)
+    algebraMap W.CoordinateRing W.FunctionField (algebraMap R[X] W.CoordinateRing X) := (rfl)
 
 /-- **The defining equation of `genericY`.** -/
 theorem genericY_def : W.genericY =
@@ -68,29 +74,29 @@ theorem genericY_def : W.genericY =
 
 /-- `W` base-changed to its own function field. The generic point is a point of it. -/
 noncomputable abbrev functionFieldCurve : WeierstrassCurve.Affine W.FunctionField :=
-  W.map (algebraMap F W.FunctionField)
+  W.map (algebraMap R W.FunctionField)
 
-/-- The composite `F → W.FunctionField` factors through the coordinate ring. Used to turn
+/-- The composite `R → W.FunctionField` factors through the coordinate ring. Used to turn
 statements about the base-changed curve into statements about images under
 `algebraMap W.CoordinateRing W.FunctionField`. -/
 theorem algebraMap_functionField_eq_comp :
-    (algebraMap F W.FunctionField : F →+* W.FunctionField) =
-      (algebraMap W.CoordinateRing W.FunctionField).comp (algebraMap F W.CoordinateRing) :=
-  (IsScalarTower.algebraMap_eq F W.CoordinateRing W.FunctionField).symm
+    (algebraMap R W.FunctionField : R →+* W.FunctionField) =
+      (algebraMap W.CoordinateRing W.FunctionField).comp (algebraMap R W.CoordinateRing) :=
+  (IsScalarTower.algebraMap_eq R W.CoordinateRing W.FunctionField).symm
 
 /-- **Evaluating at the generic point is reduction modulo the Weierstrass relation.** A bivariate
-polynomial over `F`, pushed to the function field and evaluated at `(genericX, genericY)`, is the
+polynomial over `R`, pushed to the function field and evaluated at `(genericX, genericY)`, is the
 image of its class in the coordinate ring.
 
 This is the workhorse: it converts any polynomial expression at the generic point into the image
 of a coordinate-ring element, where the ring's own API applies. -/
-theorem evalEval_genericPoint (p : F[X][Y]) :
-    (p.map (mapRingHom (algebraMap F W.FunctionField))).evalEval W.genericX W.genericY =
+theorem evalEval_genericPoint (p : R[X][Y]) :
+    (p.map (mapRingHom (algebraMap R W.FunctionField))).evalEval W.genericX W.genericY =
       algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W p) := by
   conv_lhs =>
     rw [algebraMap_functionField_eq_comp W, ← mapRingHom_comp, ← Polynomial.map_map]
   set g := algebraMap W.CoordinateRing W.FunctionField
-  set q := Polynomial.map (mapRingHom (algebraMap F W.CoordinateRing)) p with hq
+  set q := Polynomial.map (mapRingHom (algebraMap R W.CoordinateRing)) p with hq
   -- `genericX` and `genericY` are already of the form `g _`; say so, or the rewrite below
   -- cannot see its own pattern `evalEval (g _) (g _) (map (mapRingHom g) _)`.
   change (q.map (mapRingHom g)).evalEval (g _) (g _) = g _
@@ -98,10 +104,10 @@ theorem evalEval_genericPoint (p : F[X][Y]) :
   congr 1
   rw [hq]
   rw [← Polynomial.eval₂_eval₂RingHom_apply]
-  have hinner : eval₂RingHom (algebraMap F W.CoordinateRing) (algebraMap F[X] W.CoordinateRing X) =
-      algebraMap F[X] W.CoordinateRing := by
+  have hinner : eval₂RingHom (algebraMap R W.CoordinateRing) (algebraMap R[X] W.CoordinateRing X) =
+      algebraMap R[X] W.CoordinateRing := by
     ext x
-    · simp [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing]
+    · simp [IsScalarTower.algebraMap_apply R R[X] W.CoordinateRing]
     · simp
   rw [hinner, ← Polynomial.aeval_def]
   exact AdjoinRoot.aeval_eq p
@@ -113,9 +119,19 @@ theorem equation_genericPoint : W.functionFieldCurve.Equation W.genericX W.gener
   dsimp only [Equation, functionFieldCurve]
   rw [map_polynomial, evalEval_genericPoint W W.polynomial, AdjoinRoot.mk_self, map_zero]
 
-/-- The generic point is nonsingular, so it is an affine point of the base-changed curve. -/
+section Field
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
+
+/-- The generic point is nonsingular, so it is an affine point of the base-changed curve.
+
+This is the only statement here that needs a field rather than a commutative ring: it goes
+through `equation_iff_nonsingular`, which does. Everything above is stated over `[CommRing R]`,
+which is all `CoordinateRing` and `FunctionField` ask for — both are `abbrev`s at that class. -/
 theorem nonsingular_genericPoint [W.IsElliptic] :
     W.functionFieldCurve.Nonsingular W.genericX W.genericY :=
   equation_iff_nonsingular.mp (equation_genericPoint W)
+
+end Field
 
 end WeierstrassCurve.Affine

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/GenericPoint.lean
@@ -61,10 +61,11 @@ noncomputable def genericX : W.FunctionField :=
 noncomputable def genericY : W.FunctionField :=
   algebraMap W.CoordinateRing W.FunctionField (AdjoinRoot.root W.polynomial)
 
-/-- **The defining equation of `genericX`.** Under the module system a `def`'s body is sealed
-across the module boundary even inside a `public section`, so a downstream file can unfold it by
-neither `rw` nor `simp only`. This lemma and `genericY_def` are how the two are computed with
-from outside. -/
+/-- **The defining equation of `genericX`.** Under the module system a `def`'s body is not
+exposed across the module boundary even inside a `public section`, so a downstream file can
+unfold `genericX` by neither `simp only` — *Invalid simp theorem: Expected a definition with an
+exposed body* — nor `rw`, there being no equation lemma for it to use. This lemma and
+`genericY_def` are how the two are computed with from outside. -/
 theorem genericX_def : W.genericX =
     algebraMap W.CoordinateRing W.FunctionField (algebraMap R[X] W.CoordinateRing X) := (rfl)
 
@@ -76,14 +77,6 @@ theorem genericY_def : W.genericY =
 noncomputable abbrev functionFieldCurve : WeierstrassCurve.Affine W.FunctionField :=
   W.map (algebraMap R W.FunctionField)
 
-/-- The composite `R → W.FunctionField` factors through the coordinate ring. Used to turn
-statements about the base-changed curve into statements about images under
-`algebraMap W.CoordinateRing W.FunctionField`. -/
-theorem algebraMap_functionField_eq_comp :
-    (algebraMap R W.FunctionField : R →+* W.FunctionField) =
-      (algebraMap W.CoordinateRing W.FunctionField).comp (algebraMap R W.CoordinateRing) :=
-  (IsScalarTower.algebraMap_eq R W.CoordinateRing W.FunctionField).symm
-
 /-- **Evaluating at the generic point is reduction modulo the Weierstrass relation.** A bivariate
 polynomial over `R`, pushed to the function field and evaluated at `(genericX, genericY)`, is the
 image of its class in the coordinate ring.
@@ -94,7 +87,8 @@ theorem evalEval_genericPoint (p : R[X][Y]) :
     (p.map (mapRingHom (algebraMap R W.FunctionField))).evalEval W.genericX W.genericY =
       algebraMap W.CoordinateRing W.FunctionField (CoordinateRing.mk W p) := by
   conv_lhs =>
-    rw [algebraMap_functionField_eq_comp W, ← mapRingHom_comp, ← Polynomial.map_map]
+    rw [IsScalarTower.algebraMap_eq R W.CoordinateRing W.FunctionField, ← mapRingHom_comp,
+      ← Polynomial.map_map]
   set g := algebraMap W.CoordinateRing W.FunctionField
   set q := Polynomial.map (mapRingHom (algebraMap R W.CoordinateRing)) p with hq
   -- `genericX` and `genericY` are already of the form `g _`; say so, or the rewrite below

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
@@ -226,11 +226,20 @@ theorem eval₂_mulByIntXHom_polynomial_eq_zero [W.IsElliptic] {n : ℤ}
 
 /-- **`ψₙ` does not vanish at the generic point** when `n` is invertible in `F`.
 
-The hypothesis is on `n` in `F`, not on `n` in `ℤ`: in characteristic `p` it excludes `n = p`,
-where `[p]` is inseparable. That case is true as well — `ΨSq n` is prime to `Φ n`, which has
-positive degree — but the coprimality is not in Mathlib or on `main`, so the results below take
-the non-vanishing as a hypothesis and this lemma discharges it in the case that is available.
-Nothing downstream has to be restated when the general form arrives. -/
+The hypothesis is on `n` in `F`, not on `n` in `ℤ`: in characteristic `p` it excludes `n = p`.
+That case is true too, but it is not reachable from what is currently available. Every
+non-vanishing lemma in Mathlib's division-polynomial development is characteristic-conditional
+in the same way — `preΨ_ne_zero`, `ΨSq_ne_zero`, `Ψ₃_ne_zero`, `preΨ₄_ne_zero` — because each
+is proved from a leading coefficient (`(W.ΨSq n).coeff (n.natAbs ^ 2 - 1) = n ^ 2`), and that
+is exactly what vanishes when `p ∣ n`. The char-free route instead needs
+`IsCoprime (W.Φ n) (W.ΨSq n)` (Silverman, Exercise III.3.7), which is in neither Mathlib nor
+`main`; proving it goes through an algebraically closed base change and belongs beside the
+division polynomials rather than here.
+
+So `mulByIntPullback` takes the non-vanishing as a *hypothesis* rather than deriving it, and
+this lemma discharges that hypothesis in the case that is available. The construction itself
+carries no characteristic restriction, so when the coprimality lands the general case follows
+with nothing here restated — only a second discharge lemma beside this one. -/
 theorem psiFunctionField_ne_zero {n : ℤ} (hn : (n : F) ≠ 0) : psiFunctionField W n ≠ 0 := by
   intro h
   have hΨ : W.ΨSq n ≠ 0 := WeierstrassCurve.ΨSq_ne_zero W hn

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
@@ -1,0 +1,280 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.ZSMul
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Basic
+-- `ΨSq_ne_zero` is used only inside the proof of `psiFunctionField_ne_zero` below, so private.
+import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Degree
+
+/-!
+# The coordinate pullback of multiplication by `n`
+
+`Isogeny/Basic.lean` gives the identity coordinate pullback and `Isogeny/Frobenius.lean` gives
+the Frobenius one. This file gives `[n]`: for `n` with `ψₙ` non-vanishing at the generic point,
+multiplication by `n` pulls back to a map `W.CoordinateRing →ₐ[F] W.FunctionField`.
+
+The construction is the division-polynomial formula read at the *generic* point. The coordinate
+ring `W.CoordinateRing` is `F[X][Y]` modulo the Weierstrass relation, so the pair `(X, Y)` is
+itself a point of `W` over the function field `W.FunctionField` — the generic point. `n` times
+it has coordinates `φₙ / ψₙ²` and `ωₙ / ψₙ³` by the division-polynomial formulas, and sending
+`X` and `Y` there is exactly a coordinate pullback.
+
+## What is not here
+
+The `MapsInfinity` condition, and so `[n]` as an `Isogeny W W`, are not proved here. Neither
+criterion `Isogeny/Basic.lean` offers applies directly: `mapsInfinity_of_pow` wants a fixed
+power of every coordinate function to be pulled back, which is the Frobenius shape and not this
+one, and `mapsInfinity_iff_isEquiv_comap_infinityPlace` wants the induced map of *function
+fields*, which is available only after the pullback below is known injective. That chain —
+injectivity, the function-field map, then the place comparison — is its own topic and its own
+file. Note the order of dependence: `Isogeny/FunctionField.lean` proves transcendence,
+injectivity and the field pullback for *any* isogeny, but each of those consumes
+`mapsInfinity`, so none of them can be used to establish it.
+
+Two facts are the whole content here, and both are about the generic point rather than about
+`n`:
+
+* `equation_genericPoint` — the generic point satisfies the equation of the base-changed curve.
+  This is the affine shadow of `AdjoinRoot.eval₂_root`: the Weierstrass polynomial is what is
+  quotiented out, so it vanishes at the class of `Y`.
+* `eval₂_mulByIntXHom_polynomial_eq_zero` — the pair `(φₙ/ψₙ², ωₙ/ψₙ³)` satisfies it too. This is
+  *not* a polynomial identity to be checked; it holds because `n • P` is a point of the curve
+  whenever `P` is, which is `WeierstrassCurve.zsmul_point_eq_smulEval` at the generic point.
+
+## Main definitions
+
+* `TauCeti.Isogeny.genericX`, `TauCeti.Isogeny.genericY`: the generic point of `W`.
+* `TauCeti.Isogeny.mulByIntX`, `TauCeti.Isogeny.mulByIntY`: the coordinates of `[n]` there.
+* `TauCeti.Isogeny.mulByIntPullback`: the coordinate pullback of `[n]`.
+
+## Main results
+
+* `TauCeti.Isogeny.equation_genericPoint`: the generic point is a point of `W` over the function
+  field.
+* `TauCeti.Isogeny.eval₂_mulByIntXHom_polynomial_eq_zero`: so is `[n]` of it.
+* `TauCeti.Isogeny.psiFunctionField_ne_zero`: `ψₙ` does not vanish there when `n` is invertible
+  in `F`.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.4 and the
+  division-polynomial formulas of Exercise 3.7.
+* Adapted from the AINTLIB `HasseWeil` project (Chris Birkbeck),
+  [`HasseWeil/MulByIntPullback.lean`](https://github.com/CBirkbeck/AINTLIB), Apache-2.0, at commit
+  `513e83879e2f8cbc626eb9e04d660e92be16ccba`, declarations `x_gen`, `y_gen`, `W_KE`,
+  `generic_equation`, `Φ_ff`, `ΨSq_ff`, `ψ_ff`, `ω_ff`, `mulByInt_x`, `mulByInt_y`,
+  `mulByInt_xHom`, `mulByInt_weierstrass` and `mulByInt_coordHom`. The source stops at a
+  `RingHom` out of the coordinate ring and then builds its own function-field pullback,
+  injectivity and transcendence statements by hand; here the ring hom is upgraded to the
+  `AlgHom` that `TauCeti.CoordinatePullback` already asks for, and those three consequences are
+  read off `Isogeny/FunctionField.lean` instead of being reproved.
+-/
+
+public section
+
+open Polynomial WeierstrassCurve
+
+open scoped Polynomial.Bivariate
+
+namespace TauCeti
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
+
+namespace Isogeny
+
+/-- The generic `x`-coordinate: the class of `X` in the function field. -/
+noncomputable def genericX : W.FunctionField :=
+  algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing X)
+
+/-- The generic `y`-coordinate: the class of `Y` in the function field. -/
+noncomputable def genericY : W.FunctionField :=
+  algebraMap W.CoordinateRing W.FunctionField (AdjoinRoot.root W.polynomial)
+
+/-- `W` base-changed to its own function field. The generic point is a point of it. -/
+noncomputable abbrev functionFieldCurve : WeierstrassCurve.Affine W.FunctionField :=
+  W.map (algebraMap F W.FunctionField)
+
+/-- The composite `F → W.FunctionField` factors through the coordinate ring. Used to turn
+statements about the base-changed curve into statements about images under
+`algebraMap W.CoordinateRing W.FunctionField`. -/
+theorem algebraMap_functionField_eq_comp :
+    (algebraMap F W.FunctionField : F →+* W.FunctionField) =
+      (algebraMap W.CoordinateRing W.FunctionField).comp (algebraMap F W.CoordinateRing) :=
+  (IsScalarTower.algebraMap_eq F W.CoordinateRing W.FunctionField).symm
+
+/-- **Evaluating at the generic point is reduction modulo the Weierstrass relation.** A bivariate
+polynomial over `F`, pushed to the function field and evaluated at `(genericX, genericY)`, is the
+image of its class in the coordinate ring.
+
+This is the workhorse: it converts every division-polynomial value at the generic point into the
+image of a coordinate-ring element, where the ring's own API applies. -/
+theorem evalEval_genericPoint (p : F[X][Y]) :
+    (p.map (mapRingHom (algebraMap F W.FunctionField))).evalEval (genericX W) (genericY W) =
+      algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W p) := by
+  conv_lhs =>
+    rw [algebraMap_functionField_eq_comp W, ← mapRingHom_comp, ← Polynomial.map_map]
+  set g := algebraMap W.CoordinateRing W.FunctionField
+  set q := Polynomial.map (mapRingHom (algebraMap F W.CoordinateRing)) p with hq
+  -- `genericX` and `genericY` are already of the form `g _`; say so, or the rewrite below
+  -- cannot see its own pattern `evalEval (g _) (g _) (map (mapRingHom g) _)`.
+  change (q.map (mapRingHom g)).evalEval (g _) (g _) = g _
+  rw [Polynomial.map_mapRingHom_evalEval]
+  congr 1
+  rw [hq]
+  rw [← Polynomial.eval₂_eval₂RingHom_apply]
+  have hinner : eval₂RingHom (algebraMap F W.CoordinateRing) (algebraMap F[X] W.CoordinateRing X) =
+      algebraMap F[X] W.CoordinateRing := by
+    ext x
+    · simp [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing]
+    · simp
+  rw [hinner, ← Polynomial.aeval_def]
+  exact AdjoinRoot.aeval_eq p
+
+/-- **The generic point is a point of the curve.** `(X, Y)` satisfies the equation of `W`
+base-changed to the function field, because the Weierstrass polynomial is precisely what the
+coordinate ring quotients out. -/
+theorem equation_genericPoint : (functionFieldCurve W).Equation (genericX W) (genericY W) := by
+  change (W.map (algebraMap F W.FunctionField)).polynomial.evalEval _ _ = 0
+  rw [Affine.map_polynomial, evalEval_genericPoint W W.polynomial,
+    AdjoinRoot.mk_self, map_zero]
+
+/-- The generic point is nonsingular, so it is an affine point of the base-changed curve. -/
+theorem nonsingular_genericPoint [W.IsElliptic] :
+    (functionFieldCurve W).Nonsingular (genericX W) (genericY W) :=
+  Affine.equation_iff_nonsingular.mp (equation_genericPoint W)
+
+/-- The image of `ψₙ` in the function field. -/
+noncomputable def psiFunctionField (n : ℤ) : W.FunctionField :=
+  algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.ψ n))
+
+/-- The image of `ωₙ` in the function field. -/
+noncomputable def omegaFunctionField (n : ℤ) : W.FunctionField :=
+  algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.ω n))
+
+/-- The image of `φₙ` in the function field. -/
+noncomputable def phiFunctionField (n : ℤ) : W.FunctionField :=
+  algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.φ n))
+
+/-- The `x`-coordinate of `[n]` at the generic point, `φₙ / ψₙ²`. -/
+noncomputable def mulByIntX (n : ℤ) : W.FunctionField :=
+  phiFunctionField W n / psiFunctionField W n ^ 2
+
+/-- The `y`-coordinate of `[n]` at the generic point, `ωₙ / ψₙ³`. -/
+noncomputable def mulByIntY (n : ℤ) : W.FunctionField :=
+  omegaFunctionField W n / psiFunctionField W n ^ 3
+
+/-- The ring hom `F[X] → W.FunctionField` sending `X` to the `x`-coordinate of `[n]`. -/
+noncomputable def mulByIntXHom (n : ℤ) : F[X] →+* W.FunctionField :=
+  eval₂RingHom (algebraMap F W.FunctionField) (mulByIntX W n)
+
+/-- The `Z`-coordinate of the Jacobian triple of `[n]` at the generic point is `ψₙ`. -/
+theorem smulEval_genericPoint_two (n : ℤ) :
+    smulEval (functionFieldCurve W) (genericX W) (genericY W) n 2 = psiFunctionField W n := by
+  change ((W.map (algebraMap F W.FunctionField)).ψ n).evalEval _ _ = _
+  rw [map_ψ, psiFunctionField]
+  exact evalEval_genericPoint W (W.ψ n)
+
+/-- The `X`-coordinate of the Jacobian triple of `[n]` at the generic point is `φₙ`. -/
+theorem smulEval_genericPoint_zero (n : ℤ) :
+    smulEval (functionFieldCurve W) (genericX W) (genericY W) n 0 = phiFunctionField W n := by
+  change ((W.map (algebraMap F W.FunctionField)).φ n).evalEval _ _ = _
+  rw [map_φ, phiFunctionField]
+  exact evalEval_genericPoint W (W.φ n)
+
+/-- The `Y`-coordinate of the Jacobian triple of `[n]` at the generic point is `ωₙ`. -/
+theorem smulEval_genericPoint_one (n : ℤ) :
+    smulEval (functionFieldCurve W) (genericX W) (genericY W) n 1 = omegaFunctionField W n := by
+  change ((W.map (algebraMap F W.FunctionField)).ω n).evalEval _ _ = _
+  rw [map_ω, omegaFunctionField]
+  exact evalEval_genericPoint W (W.ω n)
+
+/-- `ψₙ² = ΨSqₙ` in the function field: the division polynomial's square is the univariate
+`ΨSq`, already known in the coordinate ring as `mk_ψ` followed by `mk_Ψ_sq`. -/
+theorem psiFunctionField_sq (n : ℤ) : psiFunctionField W n ^ 2 =
+      algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (C (W.ΨSq n))) := by
+  rw [psiFunctionField, ← map_pow, Affine.CoordinateRing.mk_ψ, Affine.CoordinateRing.mk_Ψ_sq]
+
+/-- **The generic point of `[n]` satisfies the Weierstrass equation.**
+
+This is the fact that makes `[n]` a coordinate pullback at all, and it is *not* a polynomial
+identity: it holds because `n • P` is again a point of the curve whenever `P` is. Concretely,
+`zsmul_point_eq_smulEval` identifies `n • (generic point)` with the Jacobian class of
+`(φₙ : ωₙ : ψₙ)`, that class is nonsingular because it is a point, and `ψₙ ≠ 0` lets it be read
+in affine coordinates — where it becomes exactly this equation. -/
+theorem eval₂_mulByIntXHom_polynomial_eq_zero [W.IsElliptic] {n : ℤ}
+    (hn : psiFunctionField W n ≠ 0) :
+    eval₂ (mulByIntXHom W n) (mulByIntY W n) W.polynomial = 0 := by
+  have hns := nonsingular_genericPoint W
+  change eval₂ (eval₂RingHom (algebraMap F W.FunctionField) (mulByIntX W n)) _ _ = 0
+  rw [eval₂_eval₂RingHom_apply,
+    show Polynomial.map (mapRingHom (algebraMap F W.FunctionField)) W.polynomial =
+      (functionFieldCurve W).polynomial from (Affine.map_polynomial W _).symm]
+  have hsmul : Jacobian.Nonsingular (functionFieldCurve W).toJacobian
+      (smulEval (functionFieldCurve W) (genericX W) (genericY W) n) := by
+    rw [← Jacobian.nonsingularLift_iff, ← zsmul_point_eq_smulEval _ hns n]
+    exact (n • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns)).nonsingular
+  have hZ : smulEval (functionFieldCurve W) (genericX W) (genericY W) n 2 ≠ 0 := by
+    rw [smulEval_genericPoint_two]; exact hn
+  have hJ := (Jacobian.equation_of_Z_ne_zero hZ).mp hsmul.1
+  rwa [smulEval_genericPoint_zero, smulEval_genericPoint_one, smulEval_genericPoint_two,
+    show phiFunctionField W n / psiFunctionField W n ^ 2 = mulByIntX W n from rfl,
+    show omegaFunctionField W n / psiFunctionField W n ^ 3 = mulByIntY W n from rfl] at hJ
+
+/-- **`ψₙ` does not vanish at the generic point** when `n` is invertible in `F`.
+
+The hypothesis is on `n` in `F`, not on `n` in `ℤ`: in characteristic `p` it excludes `n = p`,
+where `[p]` is inseparable. That case is true as well — `ΨSq n` is prime to `Φ n`, which has
+positive degree — but the coprimality is not in Mathlib or on `main`, so the results below take
+the non-vanishing as a hypothesis and this lemma discharges it in the case that is available.
+Nothing downstream has to be restated when the general form arrives. -/
+theorem psiFunctionField_ne_zero {n : ℤ} (hn : (n : F) ≠ 0) : psiFunctionField W n ≠ 0 := by
+  intro h
+  have hΨ : W.ΨSq n ≠ 0 := WeierstrassCurve.ΨSq_ne_zero W hn
+  refine hΨ ?_
+  have hzero : algebraMap W.CoordinateRing W.FunctionField
+      (Affine.CoordinateRing.mk W (C (W.ΨSq n))) = 0 := by
+    rw [← psiFunctionField_sq, h, zero_pow two_ne_zero]
+  rw [show Affine.CoordinateRing.mk W (C (W.ΨSq n)) =
+    algebraMap F[X] W.CoordinateRing (W.ΨSq n) from rfl] at hzero
+  exact FaithfulSMul.algebraMap_injective F[X] W.CoordinateRing
+    ((FaithfulSMul.algebraMap_injective W.CoordinateRing W.FunctionField
+      (hzero.trans (map_zero _).symm)).trans (map_zero _).symm)
+
+/-- **The coordinate pullback of `[n]`.** The coordinate ring is `F[X]` with a root of the
+Weierstrass polynomial adjoined, so a map out of it is exactly a value for `X` together with a
+value for `Y` satisfying that polynomial — here `φₙ/ψₙ²` and `ωₙ/ψₙ³`, which satisfy it by
+`eval₂_mulByIntXHom_polynomial_eq_zero`.
+
+`AdjoinRoot.lift` produces a ring hom; `CoordinatePullback` asks for an `F`-algebra hom, and the
+two agree because the lift sends a constant to itself. -/
+noncomputable def mulByIntPullback [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    CoordinatePullback W W :=
+  { AdjoinRoot.lift (mulByIntXHom W n) (mulByIntY W n)
+      (eval₂_mulByIntXHom_polynomial_eq_zero W hn) with
+    commutes' := fun r ↦ by
+      rw [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing]
+      simp [mulByIntXHom] }
+
+/-- The pullback of `[n]` sends the class of `X` to `φₙ/ψₙ²`.
+
+Stated with `AdjoinRoot.of`, not `algebraMap F[X] W.CoordinateRing`, because
+`AdjoinRoot.algebraMap_eq` is itself a `simp` lemma: a goal mentioning the class of `X` is
+already normalised this way by the time this fires. -/
+@[simp]
+theorem mulByIntPullback_genericX [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    mulByIntPullback W hn (AdjoinRoot.of W.polynomial X) = mulByIntX W n := by
+  simp [mulByIntPullback, mulByIntXHom]
+
+/-- The pullback of `[n]` sends the class of `Y` to `ωₙ/ψₙ³`. -/
+@[simp]
+theorem mulByIntPullback_genericY [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    mulByIntPullback W hn (AdjoinRoot.root W.polynomial) = mulByIntY W n := by
+  simp [mulByIntPullback]
+
+end Isogeny
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.GenericPoint
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.ZSMul
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Basic
 -- `ΨSq_ne_zero` is used only inside the proof of `psiFunctionField_ne_zero` below, so private.
@@ -48,6 +49,10 @@ file. Note the order of dependence: `Isogeny/FunctionField.lean` proves transcen
 injectivity and the field pullback for *any* isogeny, but each of those consumes
 `mapsInfinity`, so none of them can be used to establish it.
 
+Every definition here is paired with a `_def` equation lemma, because a `def`'s body is sealed
+across the module boundary even inside a `public section`. Without them the file cannot be
+computed with from outside at all.
+
 Two facts are the whole content here, and both are about the generic point rather than about
 `n`:
 
@@ -83,8 +88,10 @@ Two facts are the whole content here, and both are about the generic point rathe
   `mulByInt_xHom`, `mulByInt_weierstrass` and `mulByInt_coordHom`. The source stops at a
   `RingHom` out of the coordinate ring and then builds its own function-field pullback,
   injectivity and transcendence statements by hand; here the ring hom is upgraded to the
-  `AlgHom` that `TauCeti.CoordinatePullback` already asks for, and those three consequences are
-  read off `Isogeny/FunctionField.lean` instead of being reproved.
+  `AlgHom` that `TauCeti.CoordinatePullback` already asks for. The source's function-field
+  pullback, injectivity and transcendence are **not** ported and **not** reproved here: they are
+  deferred until `MapsInfinity` is available, because each of the corresponding general results
+  in `Isogeny/FunctionField.lean` consumes it. See "What is not here".
 -/
 
 public section
@@ -99,114 +106,91 @@ variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
 
 namespace Isogeny
 
-/-- The generic `x`-coordinate: the class of `X` in the function field. -/
-noncomputable def genericX : W.FunctionField :=
-  algebraMap W.CoordinateRing W.FunctionField (algebraMap F[X] W.CoordinateRing X)
-
-/-- The generic `y`-coordinate: the class of `Y` in the function field. -/
-noncomputable def genericY : W.FunctionField :=
-  algebraMap W.CoordinateRing W.FunctionField (AdjoinRoot.root W.polynomial)
-
-/-- `W` base-changed to its own function field. The generic point is a point of it. -/
-noncomputable abbrev functionFieldCurve : WeierstrassCurve.Affine W.FunctionField :=
-  W.map (algebraMap F W.FunctionField)
-
-/-- The composite `F → W.FunctionField` factors through the coordinate ring. Used to turn
-statements about the base-changed curve into statements about images under
-`algebraMap W.CoordinateRing W.FunctionField`. -/
-theorem algebraMap_functionField_eq_comp :
-    (algebraMap F W.FunctionField : F →+* W.FunctionField) =
-      (algebraMap W.CoordinateRing W.FunctionField).comp (algebraMap F W.CoordinateRing) :=
-  (IsScalarTower.algebraMap_eq F W.CoordinateRing W.FunctionField).symm
-
-/-- **Evaluating at the generic point is reduction modulo the Weierstrass relation.** A bivariate
-polynomial over `F`, pushed to the function field and evaluated at `(genericX, genericY)`, is the
-image of its class in the coordinate ring.
-
-This is the workhorse: it converts every division-polynomial value at the generic point into the
-image of a coordinate-ring element, where the ring's own API applies. -/
-theorem evalEval_genericPoint (p : F[X][Y]) :
-    (p.map (mapRingHom (algebraMap F W.FunctionField))).evalEval (genericX W) (genericY W) =
-      algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W p) := by
-  conv_lhs =>
-    rw [algebraMap_functionField_eq_comp W, ← mapRingHom_comp, ← Polynomial.map_map]
-  set g := algebraMap W.CoordinateRing W.FunctionField
-  set q := Polynomial.map (mapRingHom (algebraMap F W.CoordinateRing)) p with hq
-  -- `genericX` and `genericY` are already of the form `g _`; say so, or the rewrite below
-  -- cannot see its own pattern `evalEval (g _) (g _) (map (mapRingHom g) _)`.
-  change (q.map (mapRingHom g)).evalEval (g _) (g _) = g _
-  rw [Polynomial.map_mapRingHom_evalEval]
-  congr 1
-  rw [hq]
-  rw [← Polynomial.eval₂_eval₂RingHom_apply]
-  have hinner : eval₂RingHom (algebraMap F W.CoordinateRing) (algebraMap F[X] W.CoordinateRing X) =
-      algebraMap F[X] W.CoordinateRing := by
-    ext x
-    · simp [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing]
-    · simp
-  rw [hinner, ← Polynomial.aeval_def]
-  exact AdjoinRoot.aeval_eq p
-
-/-- **The generic point is a point of the curve.** `(X, Y)` satisfies the equation of `W`
-base-changed to the function field, because the Weierstrass polynomial is precisely what the
-coordinate ring quotients out. -/
-theorem equation_genericPoint : (functionFieldCurve W).Equation (genericX W) (genericY W) := by
-  change (W.map (algebraMap F W.FunctionField)).polynomial.evalEval _ _ = 0
-  rw [Affine.map_polynomial, evalEval_genericPoint W W.polynomial,
-    AdjoinRoot.mk_self, map_zero]
-
-/-- The generic point is nonsingular, so it is an affine point of the base-changed curve. -/
-theorem nonsingular_genericPoint [W.IsElliptic] :
-    (functionFieldCurve W).Nonsingular (genericX W) (genericY W) :=
-  Affine.equation_iff_nonsingular.mp (equation_genericPoint W)
-
-/-- The image of `ψₙ` in the function field. -/
+/-- The image of the division polynomial `ψₙ` in the function field, i.e. `ψₙ` evaluated at the
+generic point. Its non-vanishing is the hypothesis every construction below carries. -/
 noncomputable def psiFunctionField (n : ℤ) : W.FunctionField :=
   algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.ψ n))
 
-/-- The image of `ωₙ` in the function field. -/
+/-- The image of the division polynomial `ωₙ` in the function field. -/
 noncomputable def omegaFunctionField (n : ℤ) : W.FunctionField :=
   algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.ω n))
 
-/-- The image of `φₙ` in the function field. -/
+/-- The image of the division polynomial `φₙ` in the function field. -/
 noncomputable def phiFunctionField (n : ℤ) : W.FunctionField :=
   algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.φ n))
 
-/-- The `x`-coordinate of `[n]` at the generic point, `φₙ / ψₙ²`. -/
+/-- The rational division-polynomial expression `φₙ / ψₙ²`.
+
+This is the `x`-coordinate of `[n]` at the generic point exactly when `ψₙ` does not vanish
+there; at a zero of `ψₙ` the quotient is junk, since `[n]` sends that point to infinity, which
+has no affine coordinate. Every result about it below therefore carries `ψₙ ≠ 0`. -/
 noncomputable def mulByIntX (n : ℤ) : W.FunctionField :=
   phiFunctionField W n / psiFunctionField W n ^ 2
 
-/-- The `y`-coordinate of `[n]` at the generic point, `ωₙ / ψₙ³`. -/
+/-- The rational division-polynomial expression `ωₙ / ψₙ³`, the `y`-coordinate of `[n]` at the
+generic point under the same proviso as `mulByIntX`: exactly when `ψₙ` does not vanish there. -/
 noncomputable def mulByIntY (n : ℤ) : W.FunctionField :=
   omegaFunctionField W n / psiFunctionField W n ^ 3
 
-/-- The ring hom `F[X] → W.FunctionField` sending `X` to the `x`-coordinate of `[n]`. -/
-noncomputable def mulByIntXHom (n : ℤ) : F[X] →+* W.FunctionField :=
+/-- The ring hom `F[X] → W.FunctionField` sending `X` to the `x`-coordinate of `[n]`.
+
+Private: it exists to feed `AdjoinRoot.lift`, and consumers want `equation_mulByInt` or the
+pullback itself rather than this intermediate. -/
+private noncomputable def mulByIntXHom (n : ℤ) : F[X] →+* W.FunctionField :=
   eval₂RingHom (algebraMap F W.FunctionField) (mulByIntX W n)
 
-/-- The `Z`-coordinate of the Jacobian triple of `[n]` at the generic point is `ψₙ`. -/
+/-- **The defining equation of `psiFunctionField`.** -/
+theorem psiFunctionField_def (n : ℤ) : psiFunctionField W n =
+    algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.ψ n)) := (rfl)
+
+/-- **The defining equation of `omegaFunctionField`.** -/
+theorem omegaFunctionField_def (n : ℤ) : omegaFunctionField W n =
+    algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.ω n)) := (rfl)
+
+/-- **The defining equation of `phiFunctionField`.** -/
+theorem phiFunctionField_def (n : ℤ) : phiFunctionField W n =
+    algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.φ n)) := (rfl)
+
+/-- **The defining equation of `mulByIntX`**: the `x`-coordinate of `[n]` is `φₙ / ψₙ²`. -/
+theorem mulByIntX_def (n : ℤ) :
+    mulByIntX W n = phiFunctionField W n / psiFunctionField W n ^ 2 := (rfl)
+
+/-- **The defining equation of `mulByIntY`**: the `y`-coordinate of `[n]` is `ωₙ / ψₙ³`. -/
+theorem mulByIntY_def (n : ℤ) :
+    mulByIntY W n = omegaFunctionField W n / psiFunctionField W n ^ 3 := (rfl)
+
+/-- **The defining equation of `mulByIntXHom`**. -/
+private theorem mulByIntXHom_def (n : ℤ) :
+    mulByIntXHom W n = eval₂RingHom (algebraMap F W.FunctionField) (mulByIntX W n) := (rfl)
+
+/-- The `Z`-coordinate of the Jacobian triple of `[n]` at the generic point is `ψₙ`.
+
+Not `@[simp]`, and neither are the two below: `smulEval` is an `abbrev`, so `simp` unfolds the
+left-hand side through `Function.comp_apply` and `map_ψ` before these could fire, and `simpNF`
+rejects them. They are `rw`-lemmas for the equation proof, not normal forms. -/
 theorem smulEval_genericPoint_two (n : ℤ) :
-    smulEval (functionFieldCurve W) (genericX W) (genericY W) n 2 = psiFunctionField W n := by
-  change ((W.map (algebraMap F W.FunctionField)).ψ n).evalEval _ _ = _
+    smulEval W.functionFieldCurve W.genericX W.genericY n 2 = psiFunctionField W n := by
+  dsimp only [smulEval, Affine.functionFieldCurve, Function.comp_def]
   rw [map_ψ, psiFunctionField]
-  exact evalEval_genericPoint W (W.ψ n)
+  exact Affine.evalEval_genericPoint W (W.ψ n)
 
 /-- The `X`-coordinate of the Jacobian triple of `[n]` at the generic point is `φₙ`. -/
 theorem smulEval_genericPoint_zero (n : ℤ) :
-    smulEval (functionFieldCurve W) (genericX W) (genericY W) n 0 = phiFunctionField W n := by
-  change ((W.map (algebraMap F W.FunctionField)).φ n).evalEval _ _ = _
+    smulEval W.functionFieldCurve W.genericX W.genericY n 0 = phiFunctionField W n := by
+  dsimp only [smulEval, Affine.functionFieldCurve, Function.comp_def]
   rw [map_φ, phiFunctionField]
-  exact evalEval_genericPoint W (W.φ n)
+  exact Affine.evalEval_genericPoint W (W.φ n)
 
 /-- The `Y`-coordinate of the Jacobian triple of `[n]` at the generic point is `ωₙ`. -/
 theorem smulEval_genericPoint_one (n : ℤ) :
-    smulEval (functionFieldCurve W) (genericX W) (genericY W) n 1 = omegaFunctionField W n := by
-  change ((W.map (algebraMap F W.FunctionField)).ω n).evalEval _ _ = _
+    smulEval W.functionFieldCurve W.genericX W.genericY n 1 = omegaFunctionField W n := by
+  dsimp only [smulEval, Affine.functionFieldCurve, Function.comp_def]
   rw [map_ω, omegaFunctionField]
-  exact evalEval_genericPoint W (W.ω n)
+  exact Affine.evalEval_genericPoint W (W.ω n)
 
 /-- `ψₙ² = ΨSqₙ` in the function field: the division polynomial's square is the univariate
 `ΨSq`, already known in the coordinate ring as `mk_ψ` followed by `mk_Ψ_sq`. -/
+@[simp]
 theorem psiFunctionField_sq (n : ℤ) : psiFunctionField W n ^ 2 =
       algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (C (W.ΨSq n))) := by
   rw [psiFunctionField, ← map_pow, Affine.CoordinateRing.mk_ψ, Affine.CoordinateRing.mk_Ψ_sq]
@@ -218,24 +202,20 @@ identity: it holds because `n • P` is again a point of the curve whenever `P` 
 `zsmul_point_eq_smulEval` identifies `n • (generic point)` with the Jacobian class of
 `(φₙ : ωₙ : ψₙ)`, that class is nonsingular because it is a point, and `ψₙ ≠ 0` lets it be read
 in affine coordinates — where it becomes exactly this equation. -/
-theorem eval₂_mulByIntXHom_polynomial_eq_zero [W.IsElliptic] {n : ℤ}
+private theorem eval₂_mulByIntXHom_polynomial_eq_zero [W.IsElliptic] {n : ℤ}
     (hn : psiFunctionField W n ≠ 0) :
     eval₂ (mulByIntXHom W n) (mulByIntY W n) W.polynomial = 0 := by
-  have hns := nonsingular_genericPoint W
-  change eval₂ (eval₂RingHom (algebraMap F W.FunctionField) (mulByIntX W n)) _ _ = 0
-  rw [eval₂_eval₂RingHom_apply,
-    show Polynomial.map (mapRingHom (algebraMap F W.FunctionField)) W.polynomial =
-      (functionFieldCurve W).polynomial from (Affine.map_polynomial W _).symm]
-  have hsmul : Jacobian.Nonsingular (functionFieldCurve W).toJacobian
-      (smulEval (functionFieldCurve W) (genericX W) (genericY W) n) := by
+  have hns := W.nonsingular_genericPoint
+  rw [mulByIntXHom_def, eval₂_eval₂RingHom_apply, ← Affine.map_polynomial W _]
+  have hsmul : Jacobian.Nonsingular W.functionFieldCurve.toJacobian
+      (smulEval W.functionFieldCurve W.genericX W.genericY n) := by
     rw [← Jacobian.nonsingularLift_iff, ← zsmul_point_eq_smulEval _ hns n]
     exact (n • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns)).nonsingular
-  have hZ : smulEval (functionFieldCurve W) (genericX W) (genericY W) n 2 ≠ 0 := by
+  have hZ : smulEval W.functionFieldCurve W.genericX W.genericY n 2 ≠ 0 := by
     rw [smulEval_genericPoint_two]; exact hn
   have hJ := (Jacobian.equation_of_Z_ne_zero hZ).mp hsmul.1
   rwa [smulEval_genericPoint_zero, smulEval_genericPoint_one, smulEval_genericPoint_two,
-    show phiFunctionField W n / psiFunctionField W n ^ 2 = mulByIntX W n from rfl,
-    show omegaFunctionField W n / psiFunctionField W n ^ 3 = mulByIntY W n from rfl] at hJ
+    ← mulByIntX_def, ← mulByIntY_def] at hJ
 
 /-- **`ψₙ` does not vanish at the generic point** when `n` is invertible in `F`.
 
@@ -260,8 +240,7 @@ theorem psiFunctionField_ne_zero {n : ℤ} (hn : (n : F) ≠ 0) : psiFunctionFie
   have hzero : algebraMap W.CoordinateRing W.FunctionField
       (Affine.CoordinateRing.mk W (C (W.ΨSq n))) = 0 := by
     rw [← psiFunctionField_sq, h, zero_pow two_ne_zero]
-  rw [show Affine.CoordinateRing.mk W (C (W.ΨSq n)) =
-    algebraMap F[X] W.CoordinateRing (W.ΨSq n) from rfl] at hzero
+  rw [AdjoinRoot.mk_C] at hzero
   exact FaithfulSMul.algebraMap_injective F[X] W.CoordinateRing
     ((FaithfulSMul.algebraMap_injective W.CoordinateRing W.FunctionField
       (hzero.trans (map_zero _).symm)).trans (map_zero _).symm)
@@ -274,15 +253,34 @@ value for `Y` satisfying that polynomial — here `φₙ/ψₙ²` and `ωₙ/ψ�
 `AdjoinRoot.lift` produces a ring hom; `CoordinatePullback` asks for an `F`-algebra hom, and the
 two agree because the lift sends a constant to itself.
 
-Defined only for `n` invertible in `F`. In characteristic `p` this does not give `[p]`; the
-obstruction is `psiFunctionField_ne_zero`, and the file header says what closing it needs. -/
-noncomputable def mulByIntPullback [W.IsElliptic] {n : ℤ} (hnF : (n : F) ≠ 0) :
+The hypothesis is the weakest one the construction uses: `ψₙ` must not vanish at the generic
+point, which is what makes `φₙ/ψₙ²` and `ωₙ/ψₙ³` defined. It is *proved* only for `n` invertible
+in `F` — see `mulByIntPullbackOfInvertible`, and the file header for the characteristic-`p`
+gap. -/
+noncomputable def mulByIntPullback [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
     CoordinatePullback W W :=
   { AdjoinRoot.lift (mulByIntXHom W n) (mulByIntY W n)
-      (eval₂_mulByIntXHom_polynomial_eq_zero W (psiFunctionField_ne_zero W hnF)) with
+      (eval₂_mulByIntXHom_polynomial_eq_zero W hn) with
     commutes' := fun r ↦ by
       rw [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing]
       simp [mulByIntXHom] }
+
+/-- **The coordinate pullback of `[n]` for `n` invertible in `F`**, the case in which the
+non-vanishing hypothesis of `mulByIntPullback` is available: `psiFunctionField_ne_zero`
+discharges it. This is the specialisation to use unless you can supply `ψₙ ≠ 0` yourself.
+
+In characteristic `p` this does not give `[p]`; the file header says what closing that needs. -/
+noncomputable abbrev mulByIntPullbackOfInvertible [W.IsElliptic] {n : ℤ} (hnF : (n : F) ≠ 0) :
+    CoordinatePullback W W :=
+  mulByIntPullback W (psiFunctionField_ne_zero W hnF)
+
+/-- **The coordinates of `[n]` satisfy the equation of `W` over its function field.** The
+`Equation` form of the fact behind `mulByIntPullback`, stated for consumers so they need not go
+through the `eval₂` intermediate. -/
+theorem equation_mulByInt [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    W.functionFieldCurve.Equation (mulByIntX W n) (mulByIntY W n) := by
+  have := eval₂_mulByIntXHom_polynomial_eq_zero W hn
+  rwa [mulByIntXHom_def, eval₂_eval₂RingHom_apply, ← Affine.map_polynomial W _] at this
 
 /-- The pullback of `[n]` sends the class of `X` to `φₙ/ψₙ²`.
 
@@ -290,14 +288,14 @@ Stated with `AdjoinRoot.of`, not `algebraMap F[X] W.CoordinateRing`, because
 `AdjoinRoot.algebraMap_eq` is itself a `simp` lemma: a goal mentioning the class of `X` is
 already normalised this way by the time this fires. -/
 @[simp]
-theorem mulByIntPullback_genericX [W.IsElliptic] {n : ℤ} (hnF : (n : F) ≠ 0) :
-    mulByIntPullback W hnF (AdjoinRoot.of W.polynomial X) = mulByIntX W n := by
+theorem mulByIntPullback_X [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    mulByIntPullback W hn (AdjoinRoot.of W.polynomial X) = mulByIntX W n := by
   simp [mulByIntPullback, mulByIntXHom]
 
 /-- The pullback of `[n]` sends the class of `Y` to `ωₙ/ψₙ³`. -/
 @[simp]
-theorem mulByIntPullback_genericY [W.IsElliptic] {n : ℤ} (hnF : (n : F) ≠ 0) :
-    mulByIntPullback W hnF (AdjoinRoot.root W.polynomial) = mulByIntY W n := by
+theorem mulByIntPullback_Y [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    mulByIntPullback W hn (AdjoinRoot.root W.polynomial) = mulByIntY W n := by
   simp [mulByIntPullback]
 
 end Isogeny

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
@@ -11,11 +11,14 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Basic
 import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Degree
 
 /-!
-# The coordinate pullback of multiplication by `n`
+# The coordinate pullback of multiplication by `n`, for `n` invertible in the base field
 
 `Isogeny/Basic.lean` gives the identity coordinate pullback and `Isogeny/Frobenius.lean` gives
-the Frobenius one. This file gives `[n]`: for `n` with `ψₙ` non-vanishing at the generic point,
-multiplication by `n` pulls back to a map `W.CoordinateRing →ₐ[F] W.FunctionField`.
+the Frobenius one. This file gives `[n]`, for `n` invertible in `F`: multiplication by such an
+`n` pulls back to a map `W.CoordinateRing →ₐ[F] W.FunctionField`.
+
+**The hypothesis is `(n : F) ≠ 0`, not `n ≠ 0`**, so in characteristic `p` this file does not
+construct `[p]`. That is a genuine limitation and not a convention: see "What is not here".
 
 The construction is the division-polynomial formula read at the *generic* point. The coordinate
 ring `W.CoordinateRing` is `F[X][Y]` modulo the Weierstrass relation, so the pair `(X, Y)` is
@@ -24,6 +27,16 @@ it has coordinates `φₙ / ψₙ²` and `ωₙ / ψₙ³` by the division-polyn
 `X` and `Y` there is exactly a coordinate pullback.
 
 ## What is not here
+
+`[p]` in characteristic `p`. Everything below asks that `n` be invertible in `F`, because the
+non-vanishing of `ψₙ` at the generic point is derived from `Mathlib.ΨSq_ne_zero`, which reads
+the degree off the leading coefficient `n ^ 2` — exactly what vanishes when `p ∣ n`. Every
+non-vanishing lemma in Mathlib's division-polynomial development is conditional in the same way
+(`preΨ_ne_zero`, `ΨSq_ne_zero`, `Ψ₃_ne_zero`, `preΨ₄_ne_zero`). The characteristic-free route
+needs `IsCoprime (W.Φ n) (W.ΨSq n)` (Silverman, Exercise III.3.7), which is in neither Mathlib
+nor `main` and which belongs beside the division polynomials rather than here. When it lands,
+`mulByIntPullback` generalises by weakening its hypothesis to `n ≠ 0`; no statement below
+changes shape.
 
 The `MapsInfinity` condition, and so `[n]` as an `Isogeny W W`, are not proved here. Neither
 criterion `Isogeny/Basic.lean` offers applies directly: `mapsInfinity_of_pow` wants a fixed
@@ -259,11 +272,14 @@ value for `Y` satisfying that polynomial — here `φₙ/ψₙ²` and `ωₙ/ψ�
 `eval₂_mulByIntXHom_polynomial_eq_zero`.
 
 `AdjoinRoot.lift` produces a ring hom; `CoordinatePullback` asks for an `F`-algebra hom, and the
-two agree because the lift sends a constant to itself. -/
-noncomputable def mulByIntPullback [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+two agree because the lift sends a constant to itself.
+
+Defined only for `n` invertible in `F`. In characteristic `p` this does not give `[p]`; the
+obstruction is `psiFunctionField_ne_zero`, and the file header says what closing it needs. -/
+noncomputable def mulByIntPullback [W.IsElliptic] {n : ℤ} (hnF : (n : F) ≠ 0) :
     CoordinatePullback W W :=
   { AdjoinRoot.lift (mulByIntXHom W n) (mulByIntY W n)
-      (eval₂_mulByIntXHom_polynomial_eq_zero W hn) with
+      (eval₂_mulByIntXHom_polynomial_eq_zero W (psiFunctionField_ne_zero W hnF)) with
     commutes' := fun r ↦ by
       rw [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing]
       simp [mulByIntXHom] }
@@ -274,14 +290,14 @@ Stated with `AdjoinRoot.of`, not `algebraMap F[X] W.CoordinateRing`, because
 `AdjoinRoot.algebraMap_eq` is itself a `simp` lemma: a goal mentioning the class of `X` is
 already normalised this way by the time this fires. -/
 @[simp]
-theorem mulByIntPullback_genericX [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
-    mulByIntPullback W hn (AdjoinRoot.of W.polynomial X) = mulByIntX W n := by
+theorem mulByIntPullback_genericX [W.IsElliptic] {n : ℤ} (hnF : (n : F) ≠ 0) :
+    mulByIntPullback W hnF (AdjoinRoot.of W.polynomial X) = mulByIntX W n := by
   simp [mulByIntPullback, mulByIntXHom]
 
 /-- The pullback of `[n]` sends the class of `Y` to `ωₙ/ψₙ³`. -/
 @[simp]
-theorem mulByIntPullback_genericY [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
-    mulByIntPullback W hn (AdjoinRoot.root W.polynomial) = mulByIntY W n := by
+theorem mulByIntPullback_genericY [W.IsElliptic] {n : ℤ} (hnF : (n : F) ≠ 0) :
+    mulByIntPullback W hnF (AdjoinRoot.root W.polynomial) = mulByIntY W n := by
   simp [mulByIntPullback]
 
 end Isogeny

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
@@ -53,29 +53,34 @@ Every definition here is paired with a `_def` equation lemma, because a `def`'s 
 across the module boundary even inside a `public section`. Without them the file cannot be
 computed with from outside at all.
 
-Two facts are the whole content here, and both are about the generic point rather than about
-`n`:
+One fact is the whole content here: `equation_mulByInt`, that the pair `(φₙ/ψₙ², ωₙ/ψₙ³)`
+satisfies the equation of the base-changed curve. It is *not* a polynomial identity to be
+checked; it holds because `n • P` is a point of the curve whenever `P` is, which is
+`WeierstrassCurve.zsmul_point_eq_smulEval` at the generic point.
 
-* `equation_genericPoint` — the generic point satisfies the equation of the base-changed curve.
-  This is the affine shadow of `AdjoinRoot.eval₂_root`: the Weierstrass polynomial is what is
-  quotiented out, so it vanishes at the class of `Y`.
-* `eval₂_mulByIntXHom_polynomial_eq_zero` — the pair `(φₙ/ψₙ², ωₙ/ψₙ³)` satisfies it too. This is
-  *not* a polynomial identity to be checked; it holds because `n • P` is a point of the curve
-  whenever `P` is, which is `WeierstrassCurve.zsmul_point_eq_smulEval` at the generic point.
+That the generic point is itself a point of the curve — the other half of the argument — lives
+in `Affine/FunctionField/GenericPoint.lean` as `WeierstrassCurve.Affine.equation_genericPoint`,
+since it is about `W` and not about `[n]`.
 
 ## Main definitions
 
-* `TauCeti.Isogeny.genericX`, `TauCeti.Isogeny.genericY`: the generic point of `W`.
-* `TauCeti.Isogeny.mulByIntX`, `TauCeti.Isogeny.mulByIntY`: the coordinates of `[n]` there.
-* `TauCeti.Isogeny.mulByIntPullback`: the coordinate pullback of `[n]`.
+* `TauCeti.Isogeny.mulByIntX`, `TauCeti.Isogeny.mulByIntY`: the rational expressions
+  `φₙ/ψₙ²` and `ωₙ/ψₙ³`, the coordinates of `[n]` at the generic point where `ψₙ ≠ 0`.
+* `TauCeti.Isogeny.mulByIntPullback`: the coordinate pullback of `[n]`, given `ψₙ ≠ 0`.
+* `TauCeti.Isogeny.mulByIntPullbackOfInvertible`: its specialisation to `n` invertible in `F`,
+  where that hypothesis is discharged.
+
+The generic point itself (`genericX`, `genericY`, `functionFieldCurve`) is not defined here; it
+is `WeierstrassCurve.Affine`'s, in `Affine/FunctionField/GenericPoint.lean`.
 
 ## Main results
 
-* `TauCeti.Isogeny.equation_genericPoint`: the generic point is a point of `W` over the function
-  field.
-* `TauCeti.Isogeny.eval₂_mulByIntXHom_polynomial_eq_zero`: so is `[n]` of it.
-* `TauCeti.Isogeny.psiFunctionField_ne_zero`: `ψₙ` does not vanish there when `n` is invertible
-  in `F`.
+* `TauCeti.Isogeny.equation_mulByInt`: the coordinates of `[n]` satisfy the equation of `W` over
+  its function field.
+* `TauCeti.Isogeny.psiFunctionField_ne_zero`: `ψₙ` does not vanish at the generic point when `n`
+  is invertible in `F`, which is what discharges the hypothesis above.
+* `TauCeti.Isogeny.mulByIntPullback_X`, `TauCeti.Isogeny.mulByIntPullback_Y`: the values of the
+  pullback on the two coordinates.
 
 ## References
 
@@ -248,7 +253,7 @@ theorem psiFunctionField_ne_zero {n : ℤ} (hn : (n : F) ≠ 0) : psiFunctionFie
 /-- **The coordinate pullback of `[n]`.** The coordinate ring is `F[X]` with a root of the
 Weierstrass polynomial adjoined, so a map out of it is exactly a value for `X` together with a
 value for `Y` satisfying that polynomial — here `φₙ/ψₙ²` and `ωₙ/ψₙ³`, which satisfy it by
-`eval₂_mulByIntXHom_polynomial_eq_zero`.
+`equation_mulByInt`.
 
 `AdjoinRoot.lift` produces a ring hom; `CoordinatePullback` asks for an `F`-algebra hom, and the
 two agree because the lift sends a constant to itself.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
@@ -173,21 +173,21 @@ private theorem mulByIntXHom_def (n : ℤ) :
 Not `@[simp]`, and neither are the two below: `smulEval` is an `abbrev`, so `simp` unfolds the
 left-hand side through `Function.comp_apply` and `map_ψ` before these could fire, and `simpNF`
 rejects them. They are `rw`-lemmas for the equation proof, not normal forms. -/
-theorem smulEval_genericPoint_two (n : ℤ) :
+theorem smulEval_genericPoint_Z (n : ℤ) :
     smulEval W.functionFieldCurve W.genericX W.genericY n 2 = psiFunctionField W n := by
   dsimp only [smulEval, Affine.functionFieldCurve, Function.comp_def]
   rw [map_ψ, psiFunctionField]
   exact Affine.evalEval_genericPoint W (W.ψ n)
 
 /-- The `X`-coordinate of the Jacobian triple of `[n]` at the generic point is `φₙ`. -/
-theorem smulEval_genericPoint_zero (n : ℤ) :
+theorem smulEval_genericPoint_X (n : ℤ) :
     smulEval W.functionFieldCurve W.genericX W.genericY n 0 = phiFunctionField W n := by
   dsimp only [smulEval, Affine.functionFieldCurve, Function.comp_def]
   rw [map_φ, phiFunctionField]
   exact Affine.evalEval_genericPoint W (W.φ n)
 
 /-- The `Y`-coordinate of the Jacobian triple of `[n]` at the generic point is `ωₙ`. -/
-theorem smulEval_genericPoint_one (n : ℤ) :
+theorem smulEval_genericPoint_Y (n : ℤ) :
     smulEval W.functionFieldCurve W.genericX W.genericY n 1 = omegaFunctionField W n := by
   dsimp only [smulEval, Affine.functionFieldCurve, Function.comp_def]
   rw [map_ω, omegaFunctionField]
@@ -217,9 +217,9 @@ private theorem eval₂_mulByIntXHom_polynomial_eq_zero [W.IsElliptic] {n : ℤ}
     rw [← Jacobian.nonsingularLift_iff, ← zsmul_point_eq_smulEval _ hns n]
     exact (n • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns)).nonsingular
   have hZ : smulEval W.functionFieldCurve W.genericX W.genericY n 2 ≠ 0 := by
-    rw [smulEval_genericPoint_two]; exact hn
+    rw [smulEval_genericPoint_Z]; exact hn
   have hJ := (Jacobian.equation_of_Z_ne_zero hZ).mp hsmul.1
-  rwa [smulEval_genericPoint_zero, smulEval_genericPoint_one, smulEval_genericPoint_two,
+  rwa [smulEval_genericPoint_X, smulEval_genericPoint_Y, smulEval_genericPoint_Z,
     ← mulByIntX_def, ← mulByIntY_def] at hJ
 
 /-- **`ψₙ` does not vanish at the generic point** when `n` is invertible in `F`.

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/MulByInt.lean
@@ -12,14 +12,19 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.Isogeny.Basic
 import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Degree
 
 /-!
-# The coordinate pullback of multiplication by `n`, for `n` invertible in the base field
+# The coordinate pullback of multiplication by `n`, for `n` nonzero in the base field
 
 `Isogeny/Basic.lean` gives the identity coordinate pullback and `Isogeny/Frobenius.lean` gives
-the Frobenius one. This file gives `[n]`, for `n` invertible in `F`: multiplication by such an
-`n` pulls back to a map `W.CoordinateRing →ₐ[F] W.FunctionField`.
+the Frobenius one. This file gives `[n]`: multiplication by `n` pulls back to a map
+`W.CoordinateRing →ₐ[F] W.FunctionField` wherever `ψₙ` does not vanish at the generic point.
 
-**The hypothesis is `(n : F) ≠ 0`, not `n ≠ 0`**, so in characteristic `p` this file does not
-construct `[p]`. That is a genuine limitation and not a convention: see "What is not here".
+**That non-vanishing is proved here only for `(n : F) ≠ 0`, not for `n ≠ 0`**, so in
+characteristic `p` this file does not construct `[p]`. That is a genuine limitation and not a
+convention: see "What is not here". The restriction is confined to two declarations —
+`psiFunctionField_ne_zero`, which supplies the non-vanishing, and `mulByIntPullbackOfNeZero`,
+the specialisation that consumes it. `mulByIntPullback` itself, and everything it is built
+from, carry no hypothesis on the characteristic: they ask for `psiFunctionField W n ≠ 0`
+directly.
 
 The construction is the division-polynomial formula read at the *generic* point. The coordinate
 ring `W.CoordinateRing` is `F[X][Y]` modulo the Weierstrass relation, so the pair `(X, Y)` is
@@ -29,15 +34,16 @@ it has coordinates `φₙ / ψₙ²` and `ωₙ / ψₙ³` by the division-polyn
 
 ## What is not here
 
-`[p]` in characteristic `p`. Everything below asks that `n` be invertible in `F`, because the
-non-vanishing of `ψₙ` at the generic point is derived from `Mathlib.ΨSq_ne_zero`, which reads
-the degree off the leading coefficient `n ^ 2` — exactly what vanishes when `p ∣ n`. Every
-non-vanishing lemma in Mathlib's division-polynomial development is conditional in the same way
-(`preΨ_ne_zero`, `ΨSq_ne_zero`, `Ψ₃_ne_zero`, `preΨ₄_ne_zero`). The characteristic-free route
-needs `IsCoprime (W.Φ n) (W.ΨSq n)` (Silverman, Exercise III.3.7), which is in neither Mathlib
-nor `main` and which belongs beside the division polynomials rather than here. When it lands,
-`mulByIntPullback` generalises by weakening its hypothesis to `n ≠ 0`; no statement below
-changes shape.
+`[p]` in characteristic `p`. Not because the construction excludes it — `mulByIntPullback` asks
+only that `ψₙ` not vanish at the generic point — but because the one proof of that
+non-vanishing available here, `psiFunctionField_ne_zero`, goes through `Mathlib.ΨSq_ne_zero`,
+which reads the degree off the leading coefficient `n ^ 2`: exactly what vanishes when `p ∣ n`.
+Every non-vanishing lemma in Mathlib's division-polynomial development is conditional in the
+same way (`preΨ_ne_zero`, `ΨSq_ne_zero`, `Ψ₃_ne_zero`, `preΨ₄_ne_zero`). The
+characteristic-free route needs `IsCoprime (W.Φ n) (W.ΨSq n)` (Silverman, Exercise III.3.7),
+which is in neither Mathlib nor `main` and which belongs beside the division polynomials rather
+than here. When it lands it enters as a second discharge lemma beside
+`psiFunctionField_ne_zero`; no definition or statement below changes shape.
 
 The `MapsInfinity` condition, and so `[n]` as an `Isogeny W W`, are not proved here. Neither
 criterion `Isogeny/Basic.lean` offers applies directly: `mapsInfinity_of_pow` wants a fixed
@@ -49,9 +55,10 @@ file. Note the order of dependence: `Isogeny/FunctionField.lean` proves transcen
 injectivity and the field pullback for *any* isogeny, but each of those consumes
 `mapsInfinity`, so none of them can be used to establish it.
 
-Every definition here is paired with a `_def` equation lemma, because a `def`'s body is sealed
-across the module boundary even inside a `public section`. Without them the file cannot be
-computed with from outside at all.
+Every definition here is paired with a `_def` equation lemma, because a `def`'s body is not
+exposed across the module boundary even inside a `public section`: a downstream
+`simp only [mulByIntX]` is rejected with *Expected a definition with an exposed body*. Without
+them the file cannot be computed with from outside at all.
 
 One fact is the whole content here: `equation_mulByInt`, that the pair `(φₙ/ψₙ², ωₙ/ψₙ³)`
 satisfies the equation of the base-changed curve. It is *not* a polynomial identity to be
@@ -67,8 +74,8 @@ since it is about `W` and not about `[n]`.
 * `TauCeti.Isogeny.mulByIntX`, `TauCeti.Isogeny.mulByIntY`: the rational expressions
   `φₙ/ψₙ²` and `ωₙ/ψₙ³`, the coordinates of `[n]` at the generic point where `ψₙ ≠ 0`.
 * `TauCeti.Isogeny.mulByIntPullback`: the coordinate pullback of `[n]`, given `ψₙ ≠ 0`.
-* `TauCeti.Isogeny.mulByIntPullbackOfInvertible`: its specialisation to `n` invertible in `F`,
-  where that hypothesis is discharged.
+* `TauCeti.Isogeny.mulByIntPullbackOfNeZero`: its specialisation to `(n : F) ≠ 0`, where that
+  hypothesis is discharged.
 
 The generic point itself (`genericX`, `genericY`, `functionFieldCurve`) is not defined here; it
 is `WeierstrassCurve.Affine`'s, in `Affine/FunctionField/GenericPoint.lean`.
@@ -77,10 +84,11 @@ is `WeierstrassCurve.Affine`'s, in `Affine/FunctionField/GenericPoint.lean`.
 
 * `TauCeti.Isogeny.equation_mulByInt`: the coordinates of `[n]` satisfy the equation of `W` over
   its function field.
-* `TauCeti.Isogeny.psiFunctionField_ne_zero`: `ψₙ` does not vanish at the generic point when `n`
-  is invertible in `F`, which is what discharges the hypothesis above.
-* `TauCeti.Isogeny.mulByIntPullback_X`, `TauCeti.Isogeny.mulByIntPullback_Y`: the values of the
-  pullback on the two coordinates.
+* `TauCeti.Isogeny.psiFunctionField_ne_zero`: `ψₙ` does not vanish at the generic point when
+  `(n : F) ≠ 0`, which is what discharges the hypothesis above.
+* `TauCeti.Isogeny.mulByIntPullback_mk`: the pullback of an arbitrary class, as evaluation of a
+  bivariate polynomial at `(φₙ/ψₙ², ωₙ/ψₙ³)`, with `TauCeti.Isogeny.mulByIntPullback_X` and
+  `TauCeti.Isogeny.mulByIntPullback_Y` its values on the two coordinates.
 
 ## References
 
@@ -137,13 +145,6 @@ generic point under the same proviso as `mulByIntX`: exactly when `ψₙ` does n
 noncomputable def mulByIntY (n : ℤ) : W.FunctionField :=
   omegaFunctionField W n / psiFunctionField W n ^ 3
 
-/-- The ring hom `F[X] → W.FunctionField` sending `X` to the `x`-coordinate of `[n]`.
-
-Private: it exists to feed `AdjoinRoot.lift`, and consumers want `equation_mulByInt` or the
-pullback itself rather than this intermediate. -/
-private noncomputable def mulByIntXHom (n : ℤ) : F[X] →+* W.FunctionField :=
-  eval₂RingHom (algebraMap F W.FunctionField) (mulByIntX W n)
-
 /-- **The defining equation of `psiFunctionField`.** -/
 theorem psiFunctionField_def (n : ℤ) : psiFunctionField W n =
     algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (W.ψ n)) := (rfl)
@@ -164,30 +165,27 @@ theorem mulByIntX_def (n : ℤ) :
 theorem mulByIntY_def (n : ℤ) :
     mulByIntY W n = omegaFunctionField W n / psiFunctionField W n ^ 3 := (rfl)
 
-/-- **The defining equation of `mulByIntXHom`**. -/
-private theorem mulByIntXHom_def (n : ℤ) :
-    mulByIntXHom W n = eval₂RingHom (algebraMap F W.FunctionField) (mulByIntX W n) := (rfl)
-
 /-- The `Z`-coordinate of the Jacobian triple of `[n]` at the generic point is `ψₙ`.
 
-Not `@[simp]`, and neither are the two below: `smulEval` is an `abbrev`, so `simp` unfolds the
-left-hand side through `Function.comp_apply` and `map_ψ` before these could fire, and `simpNF`
-rejects them. They are `rw`-lemmas for the equation proof, not normal forms. -/
-theorem smulEval_genericPoint_Z (n : ℤ) :
+Private, like the two below: all three are `rw`-lemmas for `equation_mulByInt`, which is the
+public statement of what they add up to. They are not `@[simp]` either — `smulEval` is an
+`abbrev`, so `simp` unfolds the left-hand side through `Function.comp_apply` and `map_ψ` before
+these could fire, and `simpNF` rejects them. -/
+private theorem smulEval_genericPoint_Z (n : ℤ) :
     smulEval W.functionFieldCurve W.genericX W.genericY n 2 = psiFunctionField W n := by
   dsimp only [smulEval, Affine.functionFieldCurve, Function.comp_def]
   rw [map_ψ, psiFunctionField]
   exact Affine.evalEval_genericPoint W (W.ψ n)
 
 /-- The `X`-coordinate of the Jacobian triple of `[n]` at the generic point is `φₙ`. -/
-theorem smulEval_genericPoint_X (n : ℤ) :
+private theorem smulEval_genericPoint_X (n : ℤ) :
     smulEval W.functionFieldCurve W.genericX W.genericY n 0 = phiFunctionField W n := by
   dsimp only [smulEval, Affine.functionFieldCurve, Function.comp_def]
   rw [map_φ, phiFunctionField]
   exact Affine.evalEval_genericPoint W (W.φ n)
 
 /-- The `Y`-coordinate of the Jacobian triple of `[n]` at the generic point is `ωₙ`. -/
-theorem smulEval_genericPoint_Y (n : ℤ) :
+private theorem smulEval_genericPoint_Y (n : ℤ) :
     smulEval W.functionFieldCurve W.genericX W.genericY n 1 = omegaFunctionField W n := by
   dsimp only [smulEval, Affine.functionFieldCurve, Function.comp_def]
   rw [map_ω, omegaFunctionField]
@@ -200,18 +198,16 @@ theorem psiFunctionField_sq (n : ℤ) : psiFunctionField W n ^ 2 =
       algebraMap W.CoordinateRing W.FunctionField (Affine.CoordinateRing.mk W (C (W.ΨSq n))) := by
   rw [psiFunctionField, ← map_pow, Affine.CoordinateRing.mk_ψ, Affine.CoordinateRing.mk_Ψ_sq]
 
-/-- **The generic point of `[n]` satisfies the Weierstrass equation.**
+/-- **The coordinates of `[n]` satisfy the equation of `W` over its function field.**
 
 This is the fact that makes `[n]` a coordinate pullback at all, and it is *not* a polynomial
 identity: it holds because `n • P` is again a point of the curve whenever `P` is. Concretely,
 `zsmul_point_eq_smulEval` identifies `n • (generic point)` with the Jacobian class of
 `(φₙ : ωₙ : ψₙ)`, that class is nonsingular because it is a point, and `ψₙ ≠ 0` lets it be read
 in affine coordinates — where it becomes exactly this equation. -/
-private theorem eval₂_mulByIntXHom_polynomial_eq_zero [W.IsElliptic] {n : ℤ}
-    (hn : psiFunctionField W n ≠ 0) :
-    eval₂ (mulByIntXHom W n) (mulByIntY W n) W.polynomial = 0 := by
+theorem equation_mulByInt [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
+    W.functionFieldCurve.Equation (mulByIntX W n) (mulByIntY W n) := by
   have hns := W.nonsingular_genericPoint
-  rw [mulByIntXHom_def, eval₂_eval₂RingHom_apply, ← Affine.map_polynomial W _]
   have hsmul : Jacobian.Nonsingular W.functionFieldCurve.toJacobian
       (smulEval W.functionFieldCurve W.genericX W.genericY n) := by
     rw [← Jacobian.nonsingularLift_iff, ← zsmul_point_eq_smulEval _ hns n]
@@ -222,7 +218,7 @@ private theorem eval₂_mulByIntXHom_polynomial_eq_zero [W.IsElliptic] {n : ℤ}
   rwa [smulEval_genericPoint_X, smulEval_genericPoint_Y, smulEval_genericPoint_Z,
     ← mulByIntX_def, ← mulByIntY_def] at hJ
 
-/-- **`ψₙ` does not vanish at the generic point** when `n` is invertible in `F`.
+/-- **`ψₙ` does not vanish at the generic point** when the image of `n` in `F` is nonzero.
 
 The hypothesis is on `n` in `F`, not on `n` in `ℤ`: in characteristic `p` it excludes `n = p`.
 That case is true too, but it is not reachable from what is currently available. Every
@@ -255,37 +251,47 @@ Weierstrass polynomial adjoined, so a map out of it is exactly a value for `X` t
 value for `Y` satisfying that polynomial — here `φₙ/ψₙ²` and `ωₙ/ψₙ³`, which satisfy it by
 `equation_mulByInt`.
 
-`AdjoinRoot.lift` produces a ring hom; `CoordinatePullback` asks for an `F`-algebra hom, and the
-two agree because the lift sends a constant to itself.
+`CoordinatePullback` asks for an `F`-algebra hom, which is what `AdjoinRoot.liftAlgHom` produces
+from the `F`-algebra map `F[X] → W.FunctionField` sending `X` to `φₙ/ψₙ²`.
 
 The hypothesis is the weakest one the construction uses: `ψₙ` must not vanish at the generic
-point, which is what makes `φₙ/ψₙ²` and `ωₙ/ψₙ³` defined. It is *proved* only for `n` invertible
-in `F` — see `mulByIntPullbackOfInvertible`, and the file header for the characteristic-`p`
-gap. -/
+point, which is what makes `φₙ/ψₙ²` and `ωₙ/ψₙ³` defined. It is *proved* only for `(n : F) ≠ 0`
+— see `mulByIntPullbackOfNeZero`, and the file header for the characteristic-`p` gap. -/
 noncomputable def mulByIntPullback [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
     CoordinatePullback W W :=
-  { AdjoinRoot.lift (mulByIntXHom W n) (mulByIntY W n)
-      (eval₂_mulByIntXHom_polynomial_eq_zero W hn) with
-    commutes' := fun r ↦ by
-      rw [IsScalarTower.algebraMap_apply F F[X] W.CoordinateRing]
-      simp [mulByIntXHom] }
+  AdjoinRoot.liftAlgHom W.polynomial (aeval (mulByIntX W n)) (mulByIntY W n) <| by
+    -- `liftAlgHom` wants the equation in `eval₂` form against the coerced `aeval`, and
+    -- `equation_mulByInt` is the same fact with the base change written out.
+    have hcoe : ((aeval (mulByIntX W n) : F[X] →ₐ[F] W.FunctionField) :
+        F[X] →+* W.FunctionField) =
+        eval₂RingHom (algebraMap F W.FunctionField) (mulByIntX W n) :=
+      RingHom.ext fun _ ↦ rfl
+    have h := equation_mulByInt W hn
+    dsimp only [Affine.Equation, Affine.functionFieldCurve] at h
+    rw [Affine.map_polynomial, ← eval₂_eval₂RingHom_apply] at h
+    rw [hcoe]
+    exact h
 
-/-- **The coordinate pullback of `[n]` for `n` invertible in `F`**, the case in which the
-non-vanishing hypothesis of `mulByIntPullback` is available: `psiFunctionField_ne_zero`
-discharges it. This is the specialisation to use unless you can supply `ψₙ ≠ 0` yourself.
+/-- **The coordinate pullback of `[n]` when `(n : F) ≠ 0`**, the case in which the non-vanishing
+hypothesis of `mulByIntPullback` is available: `psiFunctionField_ne_zero` discharges it. This is
+the specialisation to use unless you can supply `ψₙ ≠ 0` yourself.
 
-In characteristic `p` this does not give `[p]`; the file header says what closing that needs. -/
-noncomputable abbrev mulByIntPullbackOfInvertible [W.IsElliptic] {n : ℤ} (hnF : (n : F) ≠ 0) :
+The hypothesis is on the image of `n` in `F`, not on `n` in `ℤ`, so in characteristic `p` this
+does not give `[p]`; the file header says what closing that needs. -/
+noncomputable abbrev mulByIntPullbackOfNeZero [W.IsElliptic] {n : ℤ} (hnF : (n : F) ≠ 0) :
     CoordinatePullback W W :=
   mulByIntPullback W (psiFunctionField_ne_zero W hnF)
 
-/-- **The coordinates of `[n]` satisfy the equation of `W` over its function field.** The
-`Equation` form of the fact behind `mulByIntPullback`, stated for consumers so they need not go
-through the `eval₂` intermediate. -/
-theorem equation_mulByInt [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
-    W.functionFieldCurve.Equation (mulByIntX W n) (mulByIntY W n) := by
-  have := eval₂_mulByIntXHom_polynomial_eq_zero W hn
-  rwa [mulByIntXHom_def, eval₂_eval₂RingHom_apply, ← Affine.map_polynomial W _] at this
+/-- **The pullback of `[n]` on an arbitrary class**: the class of a bivariate polynomial `p` goes
+to `p` evaluated at `(φₙ/ψₙ², ωₙ/ψₙ³)` over the function field. This is the general evaluation
+rule; `mulByIntPullback_X` and `mulByIntPullback_Y` are its two special cases. -/
+@[simp]
+theorem mulByIntPullback_mk [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) (p : F[X][Y]) :
+    mulByIntPullback W hn (Affine.CoordinateRing.mk W p) =
+      (p.map (mapRingHom (algebraMap F W.FunctionField))).evalEval (mulByIntX W n)
+        (mulByIntY W n) := by
+  rw [mulByIntPullback, AdjoinRoot.liftAlgHom_mk]
+  exact eval₂_eval₂RingHom_apply (algebraMap F W.FunctionField) _ _ p
 
 /-- The pullback of `[n]` sends the class of `X` to `φₙ/ψₙ²`.
 
@@ -295,13 +301,13 @@ already normalised this way by the time this fires. -/
 @[simp]
 theorem mulByIntPullback_X [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
     mulByIntPullback W hn (AdjoinRoot.of W.polynomial X) = mulByIntX W n := by
-  simp [mulByIntPullback, mulByIntXHom]
+  rw [mulByIntPullback, AdjoinRoot.liftAlgHom_of, aeval_X]
 
 /-- The pullback of `[n]` sends the class of `Y` to `ωₙ/ψₙ³`. -/
 @[simp]
 theorem mulByIntPullback_Y [W.IsElliptic] {n : ℤ} (hn : psiFunctionField W n ≠ 0) :
     mulByIntPullback W hn (AdjoinRoot.root W.polynomial) = mulByIntY W n := by
-  simp [mulByIntPullback]
+  rw [mulByIntPullback, AdjoinRoot.liftAlgHom_root]
 
 end Isogeny
 


### PR DESCRIPTION
Roadmap: EllipticCurves

Tracking bead: `tc-36qts` (HW-13), PR A of two.

Target: `EllipticCurves/README.md:414-425`, Layer 1 — "`[n] : Hom(E,E)` defined for every `n`,
the division-polynomial identity `x ∘ [n] = φ_n / ψ_n²` proved afterwards as a theorem"
(`:419`). `Isogeny/Basic.lean` has the identity coordinate pullback and `Isogeny/Frobenius.lean`
the Frobenius one; `[n]` is the missing third, and nothing on `main` connects the division
polynomials to the isogeny API at all.

This PR builds the coordinate pullback of `[n]`. Packaging it as an `Isogeny` needs
`MapsInfinity`, which is a separate argument on separate machinery — see "Why this PR stops
where it does" below.

### What it adds

* `genericX`, `genericY` — the generic point of `W`, and `equation_genericPoint`: it is a point
  of `W` base-changed to `W.FunctionField`.
* `evalEval_genericPoint` — evaluating a bivariate polynomial at the generic point is reduction
  modulo the Weierstrass relation. This is the workhorse: it turns every division-polynomial
  value at the generic point into a coordinate-ring element.
* `psiFunctionField`, `omegaFunctionField`, `phiFunctionField`, `mulByIntX`, `mulByIntY` — the
  `[n]` coordinates `φₙ/ψₙ²` and `ωₙ/ψₙ³`.
* `equation_mulByInt` — those coordinates satisfy the Weierstrass equation of `W` base-changed
  to its function field.
* `psiFunctionField_ne_zero` — `ψₙ` does not vanish at the generic point when `(n : F) ≠ 0`.
* `mulByIntPullback` — the resulting `CoordinatePullback W W`, characterised by the `@[simp]`
  evaluation rule `mulByIntPullback_mk` on an arbitrary class and by its two coordinate values
  `mulByIntPullback_X` and `mulByIntPullback_Y`; `mulByIntPullbackOfNeZero` is the
  specialisation in which `psiFunctionField_ne_zero` discharges the hypothesis.

### The one fact that is not bookkeeping

`equation_mulByInt` is not a polynomial identity to be checked. It holds because `n • P` is
again a point of the curve whenever `P` is: `zsmul_point_eq_smulEval`
(`DivisionPolynomial/ZSMul.lean:1012`, already general in `W` and in the field) identifies
`n • (generic point)` with the Jacobian class of `(φₙ : ωₙ : ψₙ)`, that class is nonsingular
because it is a point, and `ψₙ ≠ 0` lets it be read in affine coordinates — where it becomes
exactly the equation `AdjoinRoot.liftAlgHom` wants.

### Reuse

The `[n]` generic-point coordinates are **not** re-derived: `main` already has them as
`DivisionPolynomial/ZSMul.lean`'s `smulX`/`smulY` over the universal curve (`smulX_def :345`,
`smulY_def :349`), and the division polynomials `φ`, `ψ`, `ω` are general in `W` already —
Mathlib's `DivisionPolynomial/Basic.lean` for `preΨ`/`ΨSq` and `main`'s `Omega.lean` for `ω`.
So this file consumes them rather than restating them, and the universal curve does not appear
in the construction at all.

Searched Mathlib → TauCeti `main` → AINTLIB → this lane's open PRs, by name and by statement,
controls resolving (`frobeniusIsogeny` = 6 files, `genericPoint` = 4, `smulX` = 1,
`Transcendental` = 9). Confirmed absent: `Isogeny/Basic.lean` contains exactly
`CoordinatePullback`, `MapsInfinity`, `id` and `Isogeny` — no `[n]` — and
`smulX`/`smulField`/`smulEval` occur in **no** `Isogeny/` file, so nothing joined the two halves.

### Why this PR stops where it does

`MapsInfinity` — and so `[n] : Isogeny W W` — is deliberately left to a follow-up, because
neither criterion `main` offers applies here yet:

* `mapsInfinity_of_pow` (`Isogeny/Basic.lean:73`) wants a fixed power of every coordinate
  function to be pulled back. That is the Frobenius shape (`Frobenius.lean:96`); `[n]*` does not
  hit powers.
* `mapsInfinity_iff_isEquiv_comap_infinityPlace` (`Isogeny/InfinityPlace.lean:253`) wants the
  induced map of *function fields*, which exists only once the pullback below is known
  injective.

So the follow-up is a chain — injectivity, the function-field map, the place comparison — and it
is its own topic. Worth stating explicitly, because it looks like it should be free:
`Isogeny/FunctionField.lean` proves transcendence (`:128`), pullback injectivity (`:155`) and
the field pullback (`:183`) for *any* isogeny, but each consumes `mapsInfinity`
(`transcendental_pullback_X`'s body applies `φ.mapsInfinity` directly), so none of them can be
used to establish it.

### A characteristic caveat, stated rather than hidden

`psiFunctionField_ne_zero` assumes `(n : F) ≠ 0`, not merely `n ≠ 0`. In characteristic `p` that
excludes `n = p`. The stronger statement is true — `ΨSq n` is prime to `Φ n`, which has positive
degree — but that coprimality is in neither Mathlib nor `main`: re-measured at the pin,
`IsCoprime` occurs **0 times** in `Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/`
(control: `ΨSq_ne_zero` resolves there), and on `main` the only `IsCoprime` under
`TauCeti/AlgebraicGeometry/EllipticCurve/` is `MordellWeil/XSubT.lean:416`, about ideals
(control: 55 `IsCoprime` lines repo-wide).

So the restriction is kept out of the construction: `mulByIntPullback` takes the non-vanishing
as a **hypothesis**, and it is `psiFunctionField_ne_zero` — one lemma — that carries the
characteristic condition, with `mulByIntPullbackOfNeZero` the specialisation that consumes it.
When the coprimality lands it enters as a second discharge lemma beside that one; no definition
or statement in either file changes shape.

### Attribution

Adapted from [AINTLIB](https://github.com/CBirkbeck/AINTLIB) `dev/hasse-weil` at commit
`513e83879e2f8cbc626eb9e04d660e92be16ccba` (Apache-2.0, Chris Birkbeck),
`projects/HasseWeil/HasseWeil/MulByIntPullback.lean`: `x_gen`, `y_gen`, `W_KE`,
`generic_equation`, `Φ_ff`, `ΨSq_ff`, `ψ_ff`, `ω_ff`, `mulByInt_x`, `mulByInt_y`,
`mulByInt_xHom`, `mulByInt_weierstrass`, `mulByInt_coordHom`.

Two deliberate departures from the source, both recorded in the file:

1. The source stops at a `RingHom` out of the coordinate ring; `TauCeti.CoordinatePullback` is
   an `→ₐ[F]`, so the lift is upgraded to an algebra hom here — the port bundles *more* than the
   source, not less. The upgrade is Mathlib's `AdjoinRoot.liftAlgHom` rather than a hand-built
   `AlgHom`, so no `commutes'` obligation is reproved.
2. The source's non-vanishing routes through `isCoprime_Φ_ΨSq` in its own
   `Auxiliary.DivisionPolynomial`. That module is not ported (it is presumptively subsumed by
   `main`'s `DivisionPolynomial/` from the FLT/Stoll port), and the coprimality is absent from
   both Mathlib and `main`, so the hypothesis-plus-discharge shape above is used instead.

The source's `Curves.*`/`SmoothPlaneCurve` wrapper does not appear; this builds on
`WeierstrassCurve.Affine` directly. `maxHeartbeats`: none in the source module, none added.

### Gates

Run in `.claude/worktrees/ec-xsubt`. **Rebased onto `main` for this round**, so the branch now
carries main's mathlib pin `653c36f0`; the previous head sat on the pre-bump `618f225e`.

* `lake build` of both changed modules (`…Affine.FunctionField.GenericPoint` and
  `…Isogeny.MulByInt`) — exit 0, 0 errors, 0 warnings. Nothing on `main` imports either module,
  so those two are the whole local build scope.
* `bash scripts/lint-style.sh` — exit 0.
* `/cleanup` on both changed files: no `λ`, `$`, `push_neg`, `set_option`, `haveI`/`letI` or
  `sorry`; every declaration, private ones included, carries a docstring; 314 + 131 lines, max
  width 98 and 99 codepoints.

**Measured at `618f225e`, not at the post-rebase pin — stated rather than implied.** Re-running
the module build and the environment linters at `653c36f0` needs the whole TauCeti olean set
rebuilt; `lake exe cache get` restored mathlib's 8330 cached artifacts and lake still went to
source on `Mathlib.*`, which is a full local build and is prohibited on this machine. So
**CI is the authority for the new pin** — and it has answered: `sandboxed-build` is green at
`7e52a38` against `653c36f0`. The environment linters (including `simpNF` on the new `@[simp]`
lemma) are judged there rather than here.

On that `@[simp]` lemma, since it is the one thing a linter would newly object to:
`mulByIntPullback_mk`'s left-hand side is the class `Affine.CoordinateRing.mk W p` of a general
bivariate `p`, which does not overlap `mulByIntPullback_X`/`_Y` — those are keyed on
`AdjoinRoot.of … X` and `AdjoinRoot.root`, the forms `AdjoinRoot.mk_C` normalises *to*. An
earlier round did fire here: `simpNF` rejected `mulByIntPullback_genericX`'s left-hand side
because `AdjoinRoot.algebraMap_eq` normalises `algebraMap F[X] W.CoordinateRing X` to
`AdjoinRoot.of W.polynomial X`.

Two new files, `TauCeti/` only.
