### PR TITLE
feat(RealEtale): evaluate a real étale algebra at its archimedean places

### DIFF
--- a/TauCeti/RingTheory/Polynomial/RealEtale.lean
+++ b/TauCeti/RingTheory/Polynomial/RealEtale.lean
@@ -16,7 +16,7 @@ public import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
 For a real polynomial `f`, the quotient `ℝ[X]/f` maps to a product of copies of `ℝ`, one for each
 real root of `f`, and copies of `ℂ`, one for each irreducible quadratic factor — the archimedean
 places of the algebra. This file builds that evaluation map and shows it is injective when `f` is
-nonzero and squarefree, which is the point: an element of `ℝ[X]/f` is determined by its values at
+squarefree, which is the point: an element of `ℝ[X]/f` is determined by its values at
 the real roots together with its values at the upper-half-plane roots of the quadratic factors.
 
 Over `ℝ` an irreducible polynomial has degree `1` or `2` (`Irreducible.natDegree_le_two`), so those
@@ -35,7 +35,7 @@ evaluation there identifies `ℝ[X]/p` with `ℂ` (`Polynomial.evalUpperEquiv`).
 ## Main results
 
 * `Polynomial.upperRoot_im_pos` : the chosen root really does lie in the upper half-plane.
-* `Polynomial.etaleEvalHom_injective` : for `f ≠ 0` squarefree, the evaluation map is injective.
+* `Polynomial.etaleEvalHom_injective` : for squarefree `f`, the evaluation map is injective.
 
 ## Provenance
 
@@ -64,34 +64,37 @@ open Complex UniqueFactorizationMonoid
 
 namespace Polynomial
 
-variable {p : ℝ[X]} (hp : Irreducible p) (hd : p.natDegree = 2)
+variable {p : ℝ[X]}
 
-/-- A complex root of an irreducible real quadratic in the open upper half-plane: of the two
-conjugate roots, the one with positive imaginary part. -/
-noncomputable def upperRoot : ℂ :=
+/-- **The root of an irreducible real quadratic in the open upper half-plane**: of the two
+conjugate roots, the one with positive imaginary part. The quadratic hypothesis is part of the
+interface — for a linear `p` the chosen root is real, and the name would be a lie. The
+construction itself does not consume the degree, hence the underscore; it is there to stop the
+declaration being applied where its name does not hold. -/
+noncomputable def upperRoot (hp : Irreducible p) (_hd : p.natDegree = 2) : ℂ :=
   let z := (IsAlgClosed.exists_aeval_eq_zero ℂ p (degree_pos_of_irreducible hp).ne').choose
   if 0 < z.im then z else starRingEnd ℂ z
 
-include hp in
 /-- The chosen root is a root: conjugation preserves vanishing of a real polynomial. -/
-theorem aeval_upperRoot : aeval (upperRoot hp) p = 0 := by
+theorem aeval_upperRoot (hp : Irreducible p) (hd : p.natDegree = 2) :
+    aeval (upperRoot hp hd) p = 0 := by
   have hz := (IsAlgClosed.exists_aeval_eq_zero ℂ p (degree_pos_of_irreducible hp).ne').choose_spec
   rw [upperRoot]
   split_ifs with h
   · exact hz
   · rw [aeval_conj, hz, map_zero]
 
-include hp hd in
 /-- An irreducible real quadratic has no real root, so each of its complex roots is non-real. -/
-theorem im_ne_zero_of_aeval_eq_zero {z : ℂ} (hz : aeval z p = 0) : z.im ≠ 0 := by
+theorem im_ne_zero_of_aeval_eq_zero (hp : Irreducible p) (hd : p.natDegree = 2) {z : ℂ}
+    (hz : aeval z p = 0) : z.im ≠ 0 := by
   intro him
   have hz' : z = algebraMap ℝ ℂ z.re := Complex.ext (by simp) (by simp [him])
   rw [hz', aeval_algebraMap_apply, map_eq_zero] at hz
   exact hp.not_isRoot_of_natDegree_ne_one (by omega) hz
 
-include hp hd in
 /-- The chosen root lies in the open upper half-plane. -/
-theorem upperRoot_im_pos : 0 < (upperRoot hp).im := by
+theorem upperRoot_im_pos (hp : Irreducible p) (hd : p.natDegree = 2) :
+    0 < (upperRoot hp hd).im := by
   have hz := (IsAlgClosed.exists_aeval_eq_zero ℂ p (degree_pos_of_irreducible hp).ne').choose_spec
   have hne := im_ne_zero_of_aeval_eq_zero hp hd hz
   rw [upperRoot]
@@ -101,30 +104,44 @@ theorem upperRoot_im_pos : 0 < (upperRoot hp).im := by
     exact neg_pos.mpr ((not_lt.mp h).lt_of_ne hne)
 
 /-- Evaluation at the upper-half-plane root, as an `ℝ`-algebra hom `ℝ[X]/p → ℂ`. -/
-noncomputable def evalUpperHom : AdjoinRoot p →ₐ[ℝ] ℂ :=
-  AdjoinRoot.liftAlgHom p (Algebra.ofId ℝ ℂ) (upperRoot hp)
-    (by have := aeval_upperRoot hp; simpa [aeval_def] using this)
+noncomputable def evalUpperHom (hp : Irreducible p) (hd : p.natDegree = 2) :
+    AdjoinRoot p →ₐ[ℝ] ℂ :=
+  AdjoinRoot.liftAlgHom p (Algebra.ofId ℝ ℂ) (upperRoot hp hd)
+    (by have := aeval_upperRoot hp hd; simpa [aeval_def] using this)
 
-include hp in
-theorem evalUpperHom_injective : Function.Injective (evalUpperHom hp) :=
+/-- Evaluating a representative: the hom is evaluation of the polynomial at the upper root, so
+consumers never unfold the definition. -/
+@[simp]
+theorem evalUpperHom_mk (hp : Irreducible p) (hd : p.natDegree = 2) (q : ℝ[X]) :
+    evalUpperHom hp hd (AdjoinRoot.mk p q) = aeval (upperRoot hp hd) q := (rfl)
+
+theorem evalUpperHom_injective (hp : Irreducible p) (hd : p.natDegree = 2) :
+    Function.Injective (evalUpperHom hp hd) :=
   have : Fact (Irreducible p) := ⟨hp⟩
-  (evalUpperHom hp).toRingHom.injective
+  (evalUpperHom hp hd).toRingHom.injective
 
 /-- **`ℝ[X]/p ≃ ℂ` for an irreducible real quadratic `p`.** The evaluation hom is injective, and
 a dimension count over `ℝ` makes it surjective. -/
-noncomputable def evalUpperEquiv : AdjoinRoot p ≃ₐ[ℝ] ℂ :=
+noncomputable def evalUpperEquiv (hp : Irreducible p) (hd : p.natDegree = 2) :
+    AdjoinRoot p ≃ₐ[ℝ] ℂ :=
   have : Fact (Irreducible p) := ⟨hp⟩
-  AlgEquiv.ofBijective (evalUpperHom hp) ⟨evalUpperHom_injective hp, by
-    have hsurj : Function.Surjective ⇑(evalUpperHom hp).toLinearMap := by
+  AlgEquiv.ofBijective (evalUpperHom hp hd) ⟨evalUpperHom_injective hp hd, by
+    have hsurj : Function.Surjective ⇑(evalUpperHom hp hd).toLinearMap := by
       -- `AdjoinRoot p` is by definition `ℝ[X] ⧸ span {p}`, but `rw` does not see through that,
       -- so Mathlib's dimension count is ascribed at the `AdjoinRoot` spelling first.
       have hfr : Module.finrank ℝ (AdjoinRoot p) = p.natDegree :=
         finrank_quotient_span_eq_natDegree
       rw [← LinearMap.range_eq_top]
       apply Submodule.eq_top_of_finrank_eq
-      rw [LinearMap.finrank_range_of_inj (evalUpperHom_injective hp), hfr, hd,
+      rw [LinearMap.finrank_range_of_inj (evalUpperHom_injective hp hd), hfr, hd,
         Complex.finrank_real_complex]
     exact hsurj⟩
+
+/-- Evaluating a representative through the isomorphism, for the same reason as
+`evalUpperHom_mk`. -/
+@[simp]
+theorem evalUpperEquiv_mk (hp : Irreducible p) (hd : p.natDegree = 2) (q : ℝ[X]) :
+    evalUpperEquiv hp hd (AdjoinRoot.mk p q) = aeval (upperRoot hp hd) q := (rfl)
 
 /-! ### The evaluation map at all archimedean places -/
 
@@ -135,7 +152,7 @@ degree-2 factor. -/
 noncomputable def etaleTuple (f : ℝ[X]) :
     ({x : ℝ // f.eval x = 0} → ℝ) ×
       ({p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} → ℂ) :=
-  (fun x ↦ (x : ℝ), fun p ↦ upperRoot (irreducible_of_normalized_factor _ p.2.1))
+  (fun x ↦ (x : ℝ), fun p ↦ upperRoot (irreducible_of_normalized_factor _ p.2.1) p.2.2)
 
 /-- The real-root component of `aeval (etaleTuple f) q` is `q.eval x`. -/
 theorem aeval_etaleTuple_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
@@ -153,7 +170,7 @@ theorem aeval_etaleTuple_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
 theorem aeval_etaleTuple_snd (q : ℝ[X])
     (p : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2}) :
     (aeval (etaleTuple f) q).2 p
-      = aeval (upperRoot (irreducible_of_normalized_factor _ p.2.1)) q := by
+      = aeval (upperRoot (irreducible_of_normalized_factor _ p.2.1) p.2.2) q := by
   have h := aeval_algHom_apply
     ((Pi.evalAlgHom ℝ
       (fun _ : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} ↦ ℂ) p).comp
@@ -170,10 +187,10 @@ theorem aeval_etaleTuple : aeval (etaleTuple f) f = 0 := by
     funext p
     rw [Pi.zero_apply, aeval_etaleTuple_snd]
     have hirr := irreducible_of_normalized_factor _ p.2.1
-    have hd : aeval (upperRoot hirr) (p : ℝ[X]) ∣ aeval (upperRoot hirr) f :=
+    have hdvd : aeval (upperRoot hirr p.2.2) (p : ℝ[X]) ∣ aeval (upperRoot hirr p.2.2) f :=
       _root_.map_dvd _ (dvd_of_mem_normalizedFactors p.2.1)
-    rw [aeval_upperRoot] at hd
-    exact zero_dvd_iff.mp hd
+    rw [aeval_upperRoot] at hdvd
+    exact zero_dvd_iff.mp hdvd
   exact Prod.ext h1 h2
 
 /-- **Evaluation at the archimedean places of `ℝ[X]/f`**, as an `ℝ`-algebra hom into the product
@@ -200,15 +217,17 @@ theorem etaleEvalHom_mk_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
 theorem etaleEvalHom_mk_snd (q : ℝ[X])
     (p : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2}) :
     (etaleEvalHom f (AdjoinRoot.mk f q)).2 p
-      = aeval (upperRoot (irreducible_of_normalized_factor _ p.2.1)) q := by
+      = aeval (upperRoot (irreducible_of_normalized_factor _ p.2.1) p.2.2) q := by
   rw [etaleEvalHom_mk, aeval_etaleTuple_snd]
 
-/-- **The evaluation map is injective for `f` nonzero and squarefree.** A class killed at every
+/-- **The evaluation map is injective for squarefree `f`.** A class killed at every
 place is divisible by every irreducible factor of `f`; the factors are pairwise coprime, so their
 product — which is `f` up to a unit — divides it. -/
-theorem etaleEvalHom_injective (hf : f ≠ 0) (hsq : Squarefree f) :
+theorem etaleEvalHom_injective (hsq : Squarefree f) :
     Function.Injective (etaleEvalHom f) := by
   classical
+  -- `Squarefree` already excludes `0` over a domain, so nonvanishing is not a separate hypothesis.
+  have hf : f ≠ 0 := hsq.ne_zero
   have : Finite {p : ℝ[X] // p ∈ normalizedFactors f} :=
     (normalizedFactors f).finite_toSet.to_subtype
   have : Fintype {p : ℝ[X] // p ∈ normalizedFactors f} := Fintype.ofFinite _
@@ -236,10 +255,10 @@ theorem etaleEvalHom_injective (hf : f ≠ 0) (hsq : Squarefree f) :
         have h0 := hirr.natDegree_pos
         have h2 := hirr.natDegree_le_two
         omega
-      have hq : aeval (upperRoot hirr) q = 0 := by
+      have hq : aeval (upperRoot hirr hd2) q = 0 := by
         have h := congrArg (·.2 ⟨(p : ℝ[X]), p.2, hd2⟩) ha
         simpa using h
-      rw [minpoly.eq_of_irreducible_of_monic hirr (aeval_upperRoot hirr) hmon]
+      rw [minpoly.eq_of_irreducible_of_monic hirr (aeval_upperRoot hirr hd2) hmon]
       exact minpoly.dvd ℝ _ hq
   -- The distinct factors are pairwise coprime, so their product divides `q`; and that product is
   -- `f` up to a unit, because squarefreeness makes `normalizedFactors f` duplicate-free.

--- a/TauCeti/RingTheory/Polynomial/RealEtale.lean
+++ b/TauCeti/RingTheory/Polynomial/RealEtale.lean
@@ -21,20 +21,27 @@ the real roots together with its values at the upper-half-plane roots of the qua
 
 Over `ℝ` an irreducible polynomial has degree `1` or `2` (`Irreducible.natDegree_le_two`), so those
 two families exhaust the factors, and a degree-2 factor `p` has two conjugate non-real roots. One
-is singled out by its sign: `Polynomial.upperRoot` is the root in the open upper half-plane, and
-evaluation there identifies `ℝ[X]/p` with `ℂ` (`Polynomial.evalUpperEquiv`).
+is singled out by its sign: `Polynomial.selectedRoot` picks the one with positive imaginary part
+when the two differ, `Polynomial.selectedRoot_im_pos` confirms that it really is in the upper
+half-plane once `p` is quadratic, and evaluation there identifies `ℝ[X]/p` with `ℂ`
+(`Polynomial.evalUpperEquiv`).
 
 ## Main definitions
 
-* `Polynomial.upperRoot` : the root of an irreducible real quadratic with positive imaginary part.
-* `Polynomial.evalUpperHom`, `Polynomial.evalUpperEquiv` : evaluation at that root, as an
-  `ℝ`-algebra hom `ℝ[X]/p → ℂ` and, for a quadratic `p`, an isomorphism.
+* `Polynomial.selectedRoot` : a distinguished complex root of an irreducible real polynomial —
+  the one with positive imaginary part when the two conjugates differ. Defined for every
+  irreducible `p`; the upper-half-plane claim needs `p` quadratic and is
+  `Polynomial.selectedRoot_im_pos`.
+* `Polynomial.evalSelectedHom`, `Polynomial.evalUpperEquiv` : evaluation at that root, as an
+  `ℝ`-algebra hom `ℝ[X]/p → ℂ` for any irreducible `p` and, for a quadratic `p`, an
+  isomorphism.
 * `Polynomial.etaleEvalHom` : the evaluation map
   `ℝ[X]/f → ({x // f.eval x = 0} → ℝ) × ({p ∈ normalizedFactors f // deg p = 2} → ℂ)`.
 
 ## Main results
 
-* `Polynomial.upperRoot_im_pos` : the chosen root really does lie in the upper half-plane.
+* `Polynomial.selectedRoot_im_pos` : for a quadratic, the chosen root really does lie in the
+  upper half-plane.
 * `Polynomial.etaleEvalHom_injective` : for squarefree `f`, the evaluation map is injective.
 
 ## Provenance
@@ -66,20 +73,19 @@ namespace Polynomial
 
 variable {p : ℝ[X]}
 
-/-- **The root of an irreducible real quadratic in the open upper half-plane**: of the two
-conjugate roots, the one with positive imaginary part. The quadratic hypothesis is part of the
-interface — for a linear `p` the chosen root is real, and the name would be a lie. The
-construction itself does not consume the degree, hence the underscore; it is there to stop the
-declaration being applied where its name does not hold. -/
-noncomputable def upperRoot (hp : Irreducible p) (_hd : p.natDegree = 2) : ℂ :=
+/-- **A distinguished complex root of an irreducible real polynomial**: of the two conjugate
+roots, the one with positive imaginary part when they differ. The name deliberately does not
+promise positivity, because for a linear `p` the root is real; that claim is
+`selectedRoot_im_pos`, which asks for the quadratic hypothesis. -/
+noncomputable def selectedRoot (hp : Irreducible p) : ℂ :=
   let z := (IsAlgClosed.exists_aeval_eq_zero ℂ p (degree_pos_of_irreducible hp).ne').choose
   if 0 < z.im then z else starRingEnd ℂ z
 
 /-- The chosen root is a root: conjugation preserves vanishing of a real polynomial. -/
-theorem aeval_upperRoot (hp : Irreducible p) (hd : p.natDegree = 2) :
-    aeval (upperRoot hp hd) p = 0 := by
+@[simp]
+theorem aeval_selectedRoot (hp : Irreducible p) : aeval (selectedRoot hp) p = 0 := by
   have hz := (IsAlgClosed.exists_aeval_eq_zero ℂ p (degree_pos_of_irreducible hp).ne').choose_spec
-  rw [upperRoot]
+  rw [selectedRoot]
   split_ifs with h
   · exact hz
   · rw [aeval_conj, hz, map_zero]
@@ -93,55 +99,56 @@ theorem im_ne_zero_of_aeval_eq_zero (hp : Irreducible p) (hd : p.natDegree = 2) 
   exact hp.not_isRoot_of_natDegree_ne_one (by omega) hz
 
 /-- The chosen root lies in the open upper half-plane. -/
-theorem upperRoot_im_pos (hp : Irreducible p) (hd : p.natDegree = 2) :
-    0 < (upperRoot hp hd).im := by
+theorem selectedRoot_im_pos (hp : Irreducible p) (hd : p.natDegree = 2) :
+    0 < (selectedRoot hp).im := by
   have hz := (IsAlgClosed.exists_aeval_eq_zero ℂ p (degree_pos_of_irreducible hp).ne').choose_spec
   have hne := im_ne_zero_of_aeval_eq_zero hp hd hz
-  rw [upperRoot]
+  rw [selectedRoot]
   split_ifs with h
   · exact h
   · rw [Complex.conj_im]
     exact neg_pos.mpr ((not_lt.mp h).lt_of_ne hne)
 
-/-- Evaluation at the upper-half-plane root, as an `ℝ`-algebra hom `ℝ[X]/p → ℂ`. -/
-noncomputable def evalUpperHom (hp : Irreducible p) (hd : p.natDegree = 2) :
-    AdjoinRoot p →ₐ[ℝ] ℂ :=
-  AdjoinRoot.liftAlgHom p (Algebra.ofId ℝ ℂ) (upperRoot hp hd)
-    (by have := aeval_upperRoot hp hd; simpa [aeval_def] using this)
+/-- Evaluation at the selected root, as an `ℝ`-algebra hom `ℝ[X]/p → ℂ`. For a quadratic `p`
+that root is the upper-half-plane one (`selectedRoot_im_pos`), and the hom is then the
+isomorphism `evalUpperEquiv`. -/
+noncomputable def evalSelectedHom (hp : Irreducible p) : AdjoinRoot p →ₐ[ℝ] ℂ :=
+  AdjoinRoot.liftAlgHom p (Algebra.ofId ℝ ℂ) (selectedRoot hp)
+    (by have := aeval_selectedRoot hp; simpa [aeval_def] using this)
 
-/-- Evaluating a representative: the hom is evaluation of the polynomial at the upper root, so
+/-- Evaluating a representative: the hom is evaluation of the polynomial at the selected root, so
 consumers never unfold the definition. -/
 @[simp]
-theorem evalUpperHom_mk (hp : Irreducible p) (hd : p.natDegree = 2) (q : ℝ[X]) :
-    evalUpperHom hp hd (AdjoinRoot.mk p q) = aeval (upperRoot hp hd) q := (rfl)
+theorem evalSelectedHom_mk (hp : Irreducible p) (q : ℝ[X]) :
+    evalSelectedHom hp (AdjoinRoot.mk p q) = aeval (selectedRoot hp) q := (rfl)
 
-theorem evalUpperHom_injective (hp : Irreducible p) (hd : p.natDegree = 2) :
-    Function.Injective (evalUpperHom hp hd) :=
+theorem evalSelectedHom_injective (hp : Irreducible p) :
+    Function.Injective (evalSelectedHom hp) :=
   have : Fact (Irreducible p) := ⟨hp⟩
-  (evalUpperHom hp hd).toRingHom.injective
+  (evalSelectedHom hp).toRingHom.injective
 
 /-- **`ℝ[X]/p ≃ ℂ` for an irreducible real quadratic `p`.** The evaluation hom is injective, and
 a dimension count over `ℝ` makes it surjective. -/
 noncomputable def evalUpperEquiv (hp : Irreducible p) (hd : p.natDegree = 2) :
     AdjoinRoot p ≃ₐ[ℝ] ℂ :=
   have : Fact (Irreducible p) := ⟨hp⟩
-  AlgEquiv.ofBijective (evalUpperHom hp hd) ⟨evalUpperHom_injective hp hd, by
-    have hsurj : Function.Surjective ⇑(evalUpperHom hp hd).toLinearMap := by
+  AlgEquiv.ofBijective (evalSelectedHom hp) ⟨evalSelectedHom_injective hp, by
+    have hsurj : Function.Surjective ⇑(evalSelectedHom hp).toLinearMap := by
       -- `AdjoinRoot p` is by definition `ℝ[X] ⧸ span {p}`, but `rw` does not see through that,
       -- so Mathlib's dimension count is ascribed at the `AdjoinRoot` spelling first.
       have hfr : Module.finrank ℝ (AdjoinRoot p) = p.natDegree :=
         finrank_quotient_span_eq_natDegree
       rw [← LinearMap.range_eq_top]
       apply Submodule.eq_top_of_finrank_eq
-      rw [LinearMap.finrank_range_of_inj (evalUpperHom_injective hp hd), hfr, hd,
+      rw [LinearMap.finrank_range_of_inj (evalSelectedHom_injective hp), hfr, hd,
         Complex.finrank_real_complex]
     exact hsurj⟩
 
 /-- Evaluating a representative through the isomorphism, for the same reason as
-`evalUpperHom_mk`. -/
+`evalSelectedHom_mk`. -/
 @[simp]
 theorem evalUpperEquiv_mk (hp : Irreducible p) (hd : p.natDegree = 2) (q : ℝ[X]) :
-    evalUpperEquiv hp hd (AdjoinRoot.mk p q) = aeval (upperRoot hp hd) q := (rfl)
+    evalUpperEquiv hp hd (AdjoinRoot.mk p q) = aeval (selectedRoot hp) q := (rfl)
 
 /-! ### The evaluation map at all archimedean places -/
 
@@ -152,9 +159,10 @@ degree-2 factor. -/
 noncomputable def etaleTuple (f : ℝ[X]) :
     ({x : ℝ // f.eval x = 0} → ℝ) ×
       ({p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} → ℂ) :=
-  (fun x ↦ (x : ℝ), fun p ↦ upperRoot (irreducible_of_normalized_factor _ p.2.1) p.2.2)
+  (fun x ↦ (x : ℝ), fun p ↦ selectedRoot (irreducible_of_normalized_factor _ p.2.1))
 
 /-- The real-root component of `aeval (etaleTuple f) q` is `q.eval x`. -/
+@[simp]
 theorem aeval_etaleTuple_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
     (aeval (etaleTuple f) q).1 x = q.eval (x : ℝ) := by
   have h := aeval_algHom_apply
@@ -167,10 +175,11 @@ theorem aeval_etaleTuple_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
   simp [etaleTuple, aeval_def, eval₂_id]
 
 /-- The degree-2-factor component of `aeval (etaleTuple f) q` is the value at the upper root. -/
+@[simp]
 theorem aeval_etaleTuple_snd (q : ℝ[X])
     (p : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2}) :
     (aeval (etaleTuple f) q).2 p
-      = aeval (upperRoot (irreducible_of_normalized_factor _ p.2.1) p.2.2) q := by
+      = aeval (selectedRoot (irreducible_of_normalized_factor _ p.2.1)) q := by
   have h := aeval_algHom_apply
     ((Pi.evalAlgHom ℝ
       (fun _ : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} ↦ ℂ) p).comp
@@ -180,6 +189,7 @@ theorem aeval_etaleTuple_snd (q : ℝ[X])
   rfl
 
 /-- `f` itself vanishes at every evaluation point. -/
+@[simp]
 theorem aeval_etaleTuple : aeval (etaleTuple f) f = 0 := by
   have h1 : (aeval (etaleTuple f) f).1 = 0 := by
     funext x; rw [Pi.zero_apply, aeval_etaleTuple_fst]; exact x.2
@@ -187,9 +197,9 @@ theorem aeval_etaleTuple : aeval (etaleTuple f) f = 0 := by
     funext p
     rw [Pi.zero_apply, aeval_etaleTuple_snd]
     have hirr := irreducible_of_normalized_factor _ p.2.1
-    have hdvd : aeval (upperRoot hirr p.2.2) (p : ℝ[X]) ∣ aeval (upperRoot hirr p.2.2) f :=
+    have hdvd : aeval (selectedRoot hirr) (p : ℝ[X]) ∣ aeval (selectedRoot hirr) f :=
       _root_.map_dvd _ (dvd_of_mem_normalizedFactors p.2.1)
-    rw [aeval_upperRoot] at hdvd
+    rw [aeval_selectedRoot] at hdvd
     exact zero_dvd_iff.mp hdvd
   exact Prod.ext h1 h2
 
@@ -205,19 +215,23 @@ noncomputable def etaleEvalHom (f : ℝ[X]) :
 /-- Definitional: `AdjoinRoot.liftAlgHom_mk` and `Algebra.toRingHom_ofId` are both `rfl`, so
 evaluating a representative is evaluating the polynomial. Parenthesised so that it elaborates
 against the sealed body across the module boundary. -/
+@[simp]
 theorem etaleEvalHom_mk (q : ℝ[X]) :
     etaleEvalHom f (AdjoinRoot.mk f q) = aeval (etaleTuple f) q := (rfl)
 
-@[simp]
+/-- The real-root component on a representative. Deliberately not `@[simp]`: `etaleEvalHom_mk`
+and `aeval_etaleTuple_fst` are simp lemmas that already reach this normal form in two steps, so
+the attribute here would be a rule the simp set can prove. Kept as the one-step `rw` form. -/
 theorem etaleEvalHom_mk_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
     (etaleEvalHom f (AdjoinRoot.mk f q)).1 x = q.eval (x : ℝ) := by
   rw [etaleEvalHom_mk, aeval_etaleTuple_fst]
 
-@[simp]
+/-- The degree-2-factor component on a representative. Not `@[simp]`, for the same reason as
+`etaleEvalHom_mk_fst`. -/
 theorem etaleEvalHom_mk_snd (q : ℝ[X])
     (p : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2}) :
     (etaleEvalHom f (AdjoinRoot.mk f q)).2 p
-      = aeval (upperRoot (irreducible_of_normalized_factor _ p.2.1) p.2.2) q := by
+      = aeval (selectedRoot (irreducible_of_normalized_factor _ p.2.1)) q := by
   rw [etaleEvalHom_mk, aeval_etaleTuple_snd]
 
 /-- **The evaluation map is injective for squarefree `f`.** A class killed at every
@@ -255,10 +269,10 @@ theorem etaleEvalHom_injective (hsq : Squarefree f) :
         have h0 := hirr.natDegree_pos
         have h2 := hirr.natDegree_le_two
         omega
-      have hq : aeval (upperRoot hirr hd2) q = 0 := by
+      have hq : aeval (selectedRoot hirr) q = 0 := by
         have h := congrArg (·.2 ⟨(p : ℝ[X]), p.2, hd2⟩) ha
         simpa using h
-      rw [minpoly.eq_of_irreducible_of_monic hirr (aeval_upperRoot hirr hd2) hmon]
+      rw [minpoly.eq_of_irreducible_of_monic hirr (aeval_selectedRoot hirr) hmon]
       exact minpoly.dvd ℝ _ hq
   -- The distinct factors are pairwise coprime, so their product divides `q`; and that product is
   -- `f` up to a unit, because squarefreeness makes `normalizedFactors f` duplicate-free.

--- a/TauCeti/RingTheory/Polynomial/RealEtale.lean
+++ b/TauCeti/RingTheory/Polynomial/RealEtale.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Algebra.Polynomial.FieldDivision
 public import Mathlib.Analysis.Complex.Polynomial.Basic
 public import Mathlib.RingTheory.AdjoinRoot
-public import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
+public import TauCeti.RingTheory.Polynomial.Factors
 
 /-!
 # Evaluating a real étale algebra at its real and complex places
@@ -36,7 +36,7 @@ half-plane once `p` is quadratic, and evaluation there identifies `ℝ[X]/p` wit
   `ℝ`-algebra hom `ℝ[X]/p → ℂ` for any irreducible `p` and, for a quadratic `p`, an
   isomorphism.
 * `Polynomial.etaleEvalHom` : the evaluation map
-  `ℝ[X]/f → ({x // f.eval x = 0} → ℝ) × ({p ∈ normalizedFactors f // deg p = 2} → ℂ)`.
+  `ℝ[X]/f → ({x // f.eval x = 0} → ℝ) × ({p : f.Factors // deg p = 2} → ℂ)`.
 
 ## Main results
 
@@ -53,12 +53,12 @@ Apache-2.0) at commit `66889eada51ac1eb2a1c98b3c1ba5b0bbe64a8d0`, file
 Two things are spelled differently here, in both cases because Mathlib already has what the
 source provides for itself.
 
-* The source indexes the quadratic factors by its own `Polynomial.Factors` wrapper — a subtype of
-  monic irreducible divisors, introduced there to avoid the `DecidableEq` that `normalizedFactors`
-  carries. Over `ℝ` that motivation does not apply, since `Real.decidableEq` is an instance, so the
-  factors are indexed by membership in `normalizedFactors` directly and the wrapper is not needed.
-  `Polynomial.mem_normalizedFactors_iff` is Mathlib's, and supplies monic, irreducible and divides
-  in one step.
+* The source indexes the quadratic factors by its own `Polynomial.Factors` wrapper — a subtype
+  of monic irreducible divisors. That wrapper is now this repository's, ported by #4730, so the
+  factors are indexed by `f.Factors` here too and its API is reused rather than reproved:
+  `Polynomial.Factors.isCoprime` for pairwise coprimality, `Polynomial.Factors.associated_prod`
+  for the product of the distinct factors, and `Polynomial.Factors.linearEquivRoots` for the
+  correspondence between the linear factors and the roots.
 * The source proves `Module.finrank ℝ (AdjoinRoot p) = p.natDegree` for itself. That is Mathlib's
   `finrank_quotient_span_eq_natDegree`, which is stronger — it needs no `p ≠ 0` — so it is used
   instead. It has to be ascribed at the `AdjoinRoot` spelling before rewriting, since `rw` does not
@@ -67,7 +67,7 @@ source provides for itself.
 
 public section
 
-open Complex UniqueFactorizationMonoid
+open Complex
 
 namespace Polynomial
 
@@ -157,9 +157,8 @@ variable {f : ℝ[X]}
 /-- The tuple of evaluation points: each real root of `f`, and the upper root of each
 degree-2 factor. -/
 noncomputable def etaleTuple (f : ℝ[X]) :
-    ({x : ℝ // f.eval x = 0} → ℝ) ×
-      ({p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} → ℂ) :=
-  (fun x ↦ (x : ℝ), fun p ↦ selectedRoot (irreducible_of_normalized_factor _ p.2.1))
+    ({x : ℝ // f.eval x = 0} → ℝ) × ({p : f.Factors // (p : ℝ[X]).natDegree = 2} → ℂ) :=
+  (fun x ↦ (x : ℝ), fun p ↦ selectedRoot (p : f.Factors).irreducible)
 
 /-- The real-root component of `aeval (etaleTuple f) q` is `q.eval x`. -/
 @[simp]
@@ -172,17 +171,14 @@ theorem aeval_etaleTuple_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
   rw [← h]
   -- `(etaleTuple f).1 x` is by definition the real number `x`, so this is ordinary evaluation.
   change aeval ((etaleTuple f).1 x) q = q.eval (x : ℝ)
-  simp [etaleTuple, aeval_def, eval₂_id]
+  simp [etaleTuple]
 
 /-- The degree-2-factor component of `aeval (etaleTuple f) q` is the value at the upper root. -/
 @[simp]
-theorem aeval_etaleTuple_snd (q : ℝ[X])
-    (p : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2}) :
-    (aeval (etaleTuple f) q).2 p
-      = aeval (selectedRoot (irreducible_of_normalized_factor _ p.2.1)) q := by
+theorem aeval_etaleTuple_snd (q : ℝ[X]) (p : {p : f.Factors // (p : ℝ[X]).natDegree = 2}) :
+    (aeval (etaleTuple f) q).2 p = aeval (selectedRoot (p : f.Factors).irreducible) q := by
   have h := aeval_algHom_apply
-    ((Pi.evalAlgHom ℝ
-      (fun _ : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} ↦ ℂ) p).comp
+    ((Pi.evalAlgHom ℝ (fun _ : {p : f.Factors // (p : ℝ[X]).natDegree = 2} ↦ ℂ) p).comp
       (AlgHom.snd ℝ _ _)) (etaleTuple f) q
   simp only [AlgHom.comp_apply, AlgHom.snd_apply, Pi.evalAlgHom_apply] at h
   rw [← h]
@@ -196,9 +192,9 @@ theorem aeval_etaleTuple : aeval (etaleTuple f) f = 0 := by
   have h2 : (aeval (etaleTuple f) f).2 = 0 := by
     funext p
     rw [Pi.zero_apply, aeval_etaleTuple_snd]
-    have hirr := irreducible_of_normalized_factor _ p.2.1
-    have hdvd : aeval (selectedRoot hirr) (p : ℝ[X]) ∣ aeval (selectedRoot hirr) f :=
-      _root_.map_dvd _ (dvd_of_mem_normalizedFactors p.2.1)
+    have hirr := (p : f.Factors).irreducible
+    have hdvd : aeval (selectedRoot hirr) ((p : f.Factors) : ℝ[X]) ∣ aeval (selectedRoot hirr) f :=
+      _root_.map_dvd _ (p : f.Factors).dvd
     rw [aeval_selectedRoot] at hdvd
     exact zero_dvd_iff.mp hdvd
   exact Prod.ext h1 h2
@@ -207,8 +203,7 @@ theorem aeval_etaleTuple : aeval (etaleTuple f) f = 0 := by
 of the residue fields: `ℝ` at each real root, `ℂ` at each irreducible quadratic factor. -/
 noncomputable def etaleEvalHom (f : ℝ[X]) :
     AdjoinRoot f →ₐ[ℝ]
-      ({x : ℝ // f.eval x = 0} → ℝ) ×
-        ({p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} → ℂ) :=
+      ({x : ℝ // f.eval x = 0} → ℝ) × ({p : f.Factors // (p : ℝ[X]).natDegree = 2} → ℂ) :=
   AdjoinRoot.liftAlgHom f (Algebra.ofId ℝ _) (etaleTuple f) (by
     have := aeval_etaleTuple (f := f); rwa [aeval_def] at this)
 
@@ -228,10 +223,9 @@ theorem etaleEvalHom_mk_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
 
 /-- The degree-2-factor component on a representative. Not `@[simp]`, for the same reason as
 `etaleEvalHom_mk_fst`. -/
-theorem etaleEvalHom_mk_snd (q : ℝ[X])
-    (p : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2}) :
+theorem etaleEvalHom_mk_snd (q : ℝ[X]) (p : {p : f.Factors // (p : ℝ[X]).natDegree = 2}) :
     (etaleEvalHom f (AdjoinRoot.mk f q)).2 p
-      = aeval (selectedRoot (irreducible_of_normalized_factor _ p.2.1)) q := by
+      = aeval (selectedRoot (p : f.Factors).irreducible) q := by
   rw [etaleEvalHom_mk, aeval_etaleTuple_snd]
 
 /-- **The evaluation map is injective for squarefree `f`.** A class killed at every
@@ -242,60 +236,38 @@ theorem etaleEvalHom_injective (hsq : Squarefree f) :
   classical
   -- `Squarefree` already excludes `0` over a domain, so nonvanishing is not a separate hypothesis.
   have hf : f ≠ 0 := hsq.ne_zero
-  have : Finite {p : ℝ[X] // p ∈ normalizedFactors f} :=
-    (normalizedFactors f).finite_toSet.to_subtype
-  have : Fintype {p : ℝ[X] // p ∈ normalizedFactors f} := Fintype.ofFinite _
+  have : Finite f.Factors := Factors.finite hf
+  have : Fintype f.Factors := Fintype.ofFinite _
   rw [injective_iff_map_eq_zero]
   intro a ha
   obtain ⟨q, rfl⟩ := AdjoinRoot.mk_surjective a
   rw [AdjoinRoot.mk_eq_zero]
-  -- Every irreducible factor divides `q`: a linear one because `q` vanishes at its root, a
-  -- quadratic one because `q` vanishes at its upper root, which has it as minimal polynomial.
-  have hfac (p : {p : ℝ[X] // p ∈ normalizedFactors f}) : (p : ℝ[X]) ∣ q := by
-    obtain ⟨hirr, hmon, hdvd⟩ := (Polynomial.mem_normalizedFactors_iff hf).mp p.2
+  -- Every irreducible factor divides `q`: a linear one because `q` vanishes at the root it
+  -- records, a quadratic one because `q` vanishes at its selected root, which has it as minimal
+  -- polynomial.
+  have hfac (p : f.Factors) : (p : ℝ[X]) ∣ q := by
     rcases eq_or_ne (p : ℝ[X]).natDegree 1 with h1 | h1
-    · set x₀ := -(p : ℝ[X]).coeff 0 with hx0
-      have hpx : (p : ℝ[X]) = X - C x₀ := by
-        conv_lhs => rw [hmon.eq_X_add_C h1]
-        rw [hx0, map_neg, sub_neg_eq_add]
-      have hroot : f.eval x₀ = 0 :=
-        eval_eq_zero_of_dvd_of_eval_eq_zero hdvd (by rw [hpx]; simp)
-      have hq : q.eval x₀ = 0 := by
-        have h := congrArg (·.1 ⟨x₀, hroot⟩) ha
-        simpa using h
-      rw [hpx]
+    · -- `Factors.linearEquivRoots` carries the linear factor to the root of `f` it records,
+      -- together with the proof that `f` vanishes there.
+      obtain ⟨x, hx⟩ : ∃ x : {x : ℝ // f.eval x = 0}, (p : ℝ[X]) = X - C (x : ℝ) :=
+        ⟨Factors.linearEquivRoots ⟨p, h1⟩, by
+          conv_lhs => rw [p.monic.eq_X_add_C h1]
+          rw [Factors.linearEquivRoots_apply, map_neg, sub_neg_eq_add]⟩
+      have hq : q.eval (x : ℝ) = 0 := by simpa using congrArg (·.1 x) ha
+      rw [hx]
       exact dvd_iff_isRoot.mpr hq
     · have hd2 : (p : ℝ[X]).natDegree = 2 := by
-        have h0 := hirr.natDegree_pos
-        have h2 := hirr.natDegree_le_two
+        have h0 := p.irreducible.natDegree_pos
+        have h2 := p.irreducible.natDegree_le_two
         omega
-      have hq : aeval (selectedRoot hirr) q = 0 := by
-        have h := congrArg (·.2 ⟨(p : ℝ[X]), p.2, hd2⟩) ha
-        simpa using h
-      rw [minpoly.eq_of_irreducible_of_monic hirr (aeval_selectedRoot hirr) hmon]
+      have hq : aeval (selectedRoot p.irreducible) q = 0 := by
+        simpa using congrArg (·.2 ⟨p, hd2⟩) ha
+      rw [minpoly.eq_of_irreducible_of_monic p.irreducible (aeval_selectedRoot p.irreducible)
+        p.monic]
       exact minpoly.dvd ℝ _ hq
-  -- The distinct factors are pairwise coprime, so their product divides `q`; and that product is
-  -- `f` up to a unit, because squarefreeness makes `normalizedFactors f` duplicate-free.
-  have hcop : ∀ p₁ p₂ : {p : ℝ[X] // p ∈ normalizedFactors f}, p₁ ≠ p₂ →
-      IsCoprime (p₁ : ℝ[X]) (p₂ : ℝ[X]) := by
-    intro p₁ p₂ hne
-    obtain ⟨h₁, hm₁, -⟩ := (Polynomial.mem_normalizedFactors_iff hf).mp p₁.2
-    obtain ⟨h₂, hm₂, -⟩ := (Polynomial.mem_normalizedFactors_iff hf).mp p₂.2
-    refine (Ideal.isCoprime_span_singleton_iff _ _).mp <| Ideal.isCoprime_iff_sup_eq.mpr <|
-      Ideal.IsMaximal.coprime_of_ne (PrincipalIdealRing.isMaximal_of_irreducible h₁)
-        (PrincipalIdealRing.isMaximal_of_irreducible h₂) fun h ↦ hne <| Subtype.ext <|
-      eq_of_monic_of_associated hm₁ hm₂ <| Ideal.span_singleton_eq_span_singleton.mp h
-  have hprod : Associated (∏ p : {p : ℝ[X] // p ∈ normalizedFactors f}, (p : ℝ[X])) f := by
-    have hcoe : ∏ p : {p : ℝ[X] // p ∈ normalizedFactors f}, (p : ℝ[X]) =
-        ∏ p ∈ (normalizedFactors f).toFinset, p := by
-      refine (Fintype.prod_equiv (Equiv.subtypeEquivRight fun p ↦ ?_) _ _ fun x ↦ ?_).trans
-        (Finset.prod_coe_sort _ fun x ↦ x)
-      · exact (Multiset.mem_toFinset).symm
-      · rw [Equiv.subtypeEquivRight_apply]
-    rw [hcoe, Finset.prod_eq_multiset_prod, Multiset.toFinset_val,
-      Multiset.dedup_eq_self.mpr ((squarefree_iff_nodup_normalizedFactors hf).mp hsq),
-      Multiset.map_id']
-    exact prod_normalizedFactors hf
-  exact hprod.symm.dvd.trans (Fintype.prod_dvd_of_coprime (fun _ _ hab ↦ hcop _ _ hab) hfac)
+  -- The distinct factors are pairwise coprime, so their product divides `q`; and squarefreeness
+  -- makes that product `f` up to a unit.
+  exact (Factors.associated_prod hf hsq).symm.dvd.trans
+    (Fintype.prod_dvd_of_coprime (fun _ _ hne ↦ Factors.isCoprime hne) hfac)
 
 end Polynomial

--- a/TauCeti/RingTheory/Polynomial/RealEtale.lean
+++ b/TauCeti/RingTheory/Polynomial/RealEtale.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Algebra.Polynomial.FieldDivision
+public import Mathlib.Analysis.Complex.Polynomial.Basic
+public import Mathlib.RingTheory.AdjoinRoot
+public import Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors
+
+/-!
+# Evaluating a real étale algebra at its real and complex places
+
+For a real polynomial `f`, the quotient `ℝ[X]/f` maps to a product of copies of `ℝ`, one for each
+real root of `f`, and copies of `ℂ`, one for each irreducible quadratic factor — the archimedean
+places of the algebra. This file builds that evaluation map and shows it is injective when `f` is
+nonzero and squarefree, which is the point: an element of `ℝ[X]/f` is determined by its values at
+the real roots together with its values at the upper-half-plane roots of the quadratic factors.
+
+Over `ℝ` an irreducible polynomial has degree `1` or `2` (`Irreducible.natDegree_le_two`), so those
+two families exhaust the factors, and a degree-2 factor `p` has two conjugate non-real roots. One
+is singled out by its sign: `Polynomial.upperRoot` is the root in the open upper half-plane, and
+evaluation there identifies `ℝ[X]/p` with `ℂ` (`Polynomial.evalUpperEquiv`).
+
+## Main definitions
+
+* `Polynomial.upperRoot` : the root of an irreducible real quadratic with positive imaginary part.
+* `Polynomial.evalUpperHom`, `Polynomial.evalUpperEquiv` : evaluation at that root, as an
+  `ℝ`-algebra hom `ℝ[X]/p → ℂ` and, for a quadratic `p`, an isomorphism.
+* `Polynomial.etaleEvalHom` : the evaluation map
+  `ℝ[X]/f → ({x // f.eval x = 0} → ℝ) × ({p ∈ normalizedFactors f // deg p = 2} → ℂ)`.
+
+## Main results
+
+* `Polynomial.upperRoot_im_pos` : the chosen root really does lie in the upper half-plane.
+* `Polynomial.etaleEvalHom_injective` : for `f ≠ 0` squarefree, the evaluation map is injective.
+
+## Provenance
+
+Adapted from Michael Stoll's `EllipticCurves` (`github.com/MichaelStollBayreuth/EllipticCurves`,
+Apache-2.0) at commit `66889eada51ac1eb2a1c98b3c1ba5b0bbe64a8d0`, file
+`EllipticCurves/Mathlib/RealEtale.lean`, the section preceding the square-class decomposition.
+
+Two things are spelled differently here, in both cases because Mathlib already has what the
+source provides for itself.
+
+* The source indexes the quadratic factors by its own `Polynomial.Factors` wrapper — a subtype of
+  monic irreducible divisors, introduced there to avoid the `DecidableEq` that `normalizedFactors`
+  carries. Over `ℝ` that motivation does not apply, since `Real.decidableEq` is an instance, so the
+  factors are indexed by membership in `normalizedFactors` directly and the wrapper is not needed.
+  `Polynomial.mem_normalizedFactors_iff` is Mathlib's, and supplies monic, irreducible and divides
+  in one step.
+* The source proves `Module.finrank ℝ (AdjoinRoot p) = p.natDegree` for itself. That is Mathlib's
+  `finrank_quotient_span_eq_natDegree`, which is stronger — it needs no `p ≠ 0` — so it is used
+  instead. It has to be ascribed at the `AdjoinRoot` spelling before rewriting, since `rw` does not
+  see through the definitional unfolding to `ℝ[X] ⧸ Ideal.span {p}`.
+-/
+
+public section
+
+open Complex UniqueFactorizationMonoid
+
+namespace Polynomial
+
+variable {p : ℝ[X]} (hp : Irreducible p) (hd : p.natDegree = 2)
+
+/-- A complex root of an irreducible real quadratic in the open upper half-plane: of the two
+conjugate roots, the one with positive imaginary part. -/
+noncomputable def upperRoot : ℂ :=
+  let z := (IsAlgClosed.exists_aeval_eq_zero ℂ p (degree_pos_of_irreducible hp).ne').choose
+  if 0 < z.im then z else starRingEnd ℂ z
+
+include hp in
+/-- The chosen root is a root: conjugation preserves vanishing of a real polynomial. -/
+theorem aeval_upperRoot : aeval (upperRoot hp) p = 0 := by
+  have hz := (IsAlgClosed.exists_aeval_eq_zero ℂ p (degree_pos_of_irreducible hp).ne').choose_spec
+  rw [upperRoot]
+  split_ifs with h
+  · exact hz
+  · rw [aeval_conj, hz, map_zero]
+
+include hp hd in
+/-- An irreducible real quadratic has no real root, so each of its complex roots is non-real. -/
+theorem im_ne_zero_of_aeval_eq_zero {z : ℂ} (hz : aeval z p = 0) : z.im ≠ 0 := by
+  intro him
+  have hz' : z = algebraMap ℝ ℂ z.re := Complex.ext (by simp) (by simp [him])
+  rw [hz', aeval_algebraMap_apply, map_eq_zero] at hz
+  exact hp.not_isRoot_of_natDegree_ne_one (by omega) hz
+
+include hp hd in
+/-- The chosen root lies in the open upper half-plane. -/
+theorem upperRoot_im_pos : 0 < (upperRoot hp).im := by
+  have hz := (IsAlgClosed.exists_aeval_eq_zero ℂ p (degree_pos_of_irreducible hp).ne').choose_spec
+  have hne := im_ne_zero_of_aeval_eq_zero hp hd hz
+  rw [upperRoot]
+  split_ifs with h
+  · exact h
+  · rw [Complex.conj_im]
+    exact neg_pos.mpr ((not_lt.mp h).lt_of_ne hne)
+
+/-- Evaluation at the upper-half-plane root, as an `ℝ`-algebra hom `ℝ[X]/p → ℂ`. -/
+noncomputable def evalUpperHom : AdjoinRoot p →ₐ[ℝ] ℂ :=
+  AdjoinRoot.liftAlgHom p (Algebra.ofId ℝ ℂ) (upperRoot hp)
+    (by have := aeval_upperRoot hp; simpa [aeval_def] using this)
+
+include hp in
+theorem evalUpperHom_injective : Function.Injective (evalUpperHom hp) :=
+  have : Fact (Irreducible p) := ⟨hp⟩
+  (evalUpperHom hp).toRingHom.injective
+
+/-- **`ℝ[X]/p ≃ ℂ` for an irreducible real quadratic `p`.** The evaluation hom is injective, and
+a dimension count over `ℝ` makes it surjective. -/
+noncomputable def evalUpperEquiv : AdjoinRoot p ≃ₐ[ℝ] ℂ :=
+  have : Fact (Irreducible p) := ⟨hp⟩
+  AlgEquiv.ofBijective (evalUpperHom hp) ⟨evalUpperHom_injective hp, by
+    have hsurj : Function.Surjective ⇑(evalUpperHom hp).toLinearMap := by
+      -- `AdjoinRoot p` is by definition `ℝ[X] ⧸ span {p}`, but `rw` does not see through that,
+      -- so Mathlib's dimension count is ascribed at the `AdjoinRoot` spelling first.
+      have hfr : Module.finrank ℝ (AdjoinRoot p) = p.natDegree :=
+        finrank_quotient_span_eq_natDegree
+      rw [← LinearMap.range_eq_top]
+      apply Submodule.eq_top_of_finrank_eq
+      rw [LinearMap.finrank_range_of_inj (evalUpperHom_injective hp), hfr, hd,
+        Complex.finrank_real_complex]
+    exact hsurj⟩
+
+/-! ### The evaluation map at all archimedean places -/
+
+variable {f : ℝ[X]}
+
+/-- The tuple of evaluation points: each real root of `f`, and the upper root of each
+degree-2 factor. -/
+noncomputable def etaleTuple (f : ℝ[X]) :
+    ({x : ℝ // f.eval x = 0} → ℝ) ×
+      ({p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} → ℂ) :=
+  (fun x ↦ (x : ℝ), fun p ↦ upperRoot (irreducible_of_normalized_factor _ p.2.1))
+
+/-- The real-root component of `aeval (etaleTuple f) q` is `q.eval x`. -/
+theorem aeval_etaleTuple_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
+    (aeval (etaleTuple f) q).1 x = q.eval (x : ℝ) := by
+  have h := aeval_algHom_apply
+    ((Pi.evalAlgHom ℝ (fun _ : {x : ℝ // f.eval x = 0} ↦ ℝ) x).comp (AlgHom.fst ℝ _ _))
+    (etaleTuple f) q
+  simp only [AlgHom.comp_apply, AlgHom.fst_apply, Pi.evalAlgHom_apply] at h
+  rw [← h]
+  -- `(etaleTuple f).1 x` is by definition the real number `x`, so this is ordinary evaluation.
+  change aeval ((etaleTuple f).1 x) q = q.eval (x : ℝ)
+  simp [etaleTuple, aeval_def, eval₂_id]
+
+/-- The degree-2-factor component of `aeval (etaleTuple f) q` is the value at the upper root. -/
+theorem aeval_etaleTuple_snd (q : ℝ[X])
+    (p : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2}) :
+    (aeval (etaleTuple f) q).2 p
+      = aeval (upperRoot (irreducible_of_normalized_factor _ p.2.1)) q := by
+  have h := aeval_algHom_apply
+    ((Pi.evalAlgHom ℝ
+      (fun _ : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} ↦ ℂ) p).comp
+      (AlgHom.snd ℝ _ _)) (etaleTuple f) q
+  simp only [AlgHom.comp_apply, AlgHom.snd_apply, Pi.evalAlgHom_apply] at h
+  rw [← h]
+  rfl
+
+/-- `f` itself vanishes at every evaluation point. -/
+theorem aeval_etaleTuple : aeval (etaleTuple f) f = 0 := by
+  have h1 : (aeval (etaleTuple f) f).1 = 0 := by
+    funext x; rw [Pi.zero_apply, aeval_etaleTuple_fst]; exact x.2
+  have h2 : (aeval (etaleTuple f) f).2 = 0 := by
+    funext p
+    rw [Pi.zero_apply, aeval_etaleTuple_snd]
+    have hirr := irreducible_of_normalized_factor _ p.2.1
+    have hd : aeval (upperRoot hirr) (p : ℝ[X]) ∣ aeval (upperRoot hirr) f :=
+      _root_.map_dvd _ (dvd_of_mem_normalizedFactors p.2.1)
+    rw [aeval_upperRoot] at hd
+    exact zero_dvd_iff.mp hd
+  exact Prod.ext h1 h2
+
+/-- **Evaluation at the archimedean places of `ℝ[X]/f`**, as an `ℝ`-algebra hom into the product
+of the residue fields: `ℝ` at each real root, `ℂ` at each irreducible quadratic factor. -/
+noncomputable def etaleEvalHom (f : ℝ[X]) :
+    AdjoinRoot f →ₐ[ℝ]
+      ({x : ℝ // f.eval x = 0} → ℝ) ×
+        ({p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2} → ℂ) :=
+  AdjoinRoot.liftAlgHom f (Algebra.ofId ℝ _) (etaleTuple f) (by
+    have := aeval_etaleTuple (f := f); rwa [aeval_def] at this)
+
+/-- Definitional: `AdjoinRoot.liftAlgHom_mk` and `Algebra.toRingHom_ofId` are both `rfl`, so
+evaluating a representative is evaluating the polynomial. Parenthesised so that it elaborates
+against the sealed body across the module boundary. -/
+theorem etaleEvalHom_mk (q : ℝ[X]) :
+    etaleEvalHom f (AdjoinRoot.mk f q) = aeval (etaleTuple f) q := (rfl)
+
+@[simp]
+theorem etaleEvalHom_mk_fst (q : ℝ[X]) (x : {x : ℝ // f.eval x = 0}) :
+    (etaleEvalHom f (AdjoinRoot.mk f q)).1 x = q.eval (x : ℝ) := by
+  rw [etaleEvalHom_mk, aeval_etaleTuple_fst]
+
+@[simp]
+theorem etaleEvalHom_mk_snd (q : ℝ[X])
+    (p : {p : ℝ[X] // p ∈ normalizedFactors f ∧ p.natDegree = 2}) :
+    (etaleEvalHom f (AdjoinRoot.mk f q)).2 p
+      = aeval (upperRoot (irreducible_of_normalized_factor _ p.2.1)) q := by
+  rw [etaleEvalHom_mk, aeval_etaleTuple_snd]
+
+/-- **The evaluation map is injective for `f` nonzero and squarefree.** A class killed at every
+place is divisible by every irreducible factor of `f`; the factors are pairwise coprime, so their
+product — which is `f` up to a unit — divides it. -/
+theorem etaleEvalHom_injective (hf : f ≠ 0) (hsq : Squarefree f) :
+    Function.Injective (etaleEvalHom f) := by
+  classical
+  have : Finite {p : ℝ[X] // p ∈ normalizedFactors f} :=
+    (normalizedFactors f).finite_toSet.to_subtype
+  have : Fintype {p : ℝ[X] // p ∈ normalizedFactors f} := Fintype.ofFinite _
+  rw [injective_iff_map_eq_zero]
+  intro a ha
+  obtain ⟨q, rfl⟩ := AdjoinRoot.mk_surjective a
+  rw [AdjoinRoot.mk_eq_zero]
+  -- Every irreducible factor divides `q`: a linear one because `q` vanishes at its root, a
+  -- quadratic one because `q` vanishes at its upper root, which has it as minimal polynomial.
+  have hfac (p : {p : ℝ[X] // p ∈ normalizedFactors f}) : (p : ℝ[X]) ∣ q := by
+    obtain ⟨hirr, hmon, hdvd⟩ := (Polynomial.mem_normalizedFactors_iff hf).mp p.2
+    rcases eq_or_ne (p : ℝ[X]).natDegree 1 with h1 | h1
+    · set x₀ := -(p : ℝ[X]).coeff 0 with hx0
+      have hpx : (p : ℝ[X]) = X - C x₀ := by
+        conv_lhs => rw [hmon.eq_X_add_C h1]
+        rw [hx0, map_neg, sub_neg_eq_add]
+      have hroot : f.eval x₀ = 0 :=
+        eval_eq_zero_of_dvd_of_eval_eq_zero hdvd (by rw [hpx]; simp)
+      have hq : q.eval x₀ = 0 := by
+        have h := congrArg (·.1 ⟨x₀, hroot⟩) ha
+        simpa using h
+      rw [hpx]
+      exact dvd_iff_isRoot.mpr hq
+    · have hd2 : (p : ℝ[X]).natDegree = 2 := by
+        have h0 := hirr.natDegree_pos
+        have h2 := hirr.natDegree_le_two
+        omega
+      have hq : aeval (upperRoot hirr) q = 0 := by
+        have h := congrArg (·.2 ⟨(p : ℝ[X]), p.2, hd2⟩) ha
+        simpa using h
+      rw [minpoly.eq_of_irreducible_of_monic hirr (aeval_upperRoot hirr) hmon]
+      exact minpoly.dvd ℝ _ hq
+  -- The distinct factors are pairwise coprime, so their product divides `q`; and that product is
+  -- `f` up to a unit, because squarefreeness makes `normalizedFactors f` duplicate-free.
+  have hcop : ∀ p₁ p₂ : {p : ℝ[X] // p ∈ normalizedFactors f}, p₁ ≠ p₂ →
+      IsCoprime (p₁ : ℝ[X]) (p₂ : ℝ[X]) := by
+    intro p₁ p₂ hne
+    obtain ⟨h₁, hm₁, -⟩ := (Polynomial.mem_normalizedFactors_iff hf).mp p₁.2
+    obtain ⟨h₂, hm₂, -⟩ := (Polynomial.mem_normalizedFactors_iff hf).mp p₂.2
+    refine (Ideal.isCoprime_span_singleton_iff _ _).mp <| Ideal.isCoprime_iff_sup_eq.mpr <|
+      Ideal.IsMaximal.coprime_of_ne (PrincipalIdealRing.isMaximal_of_irreducible h₁)
+        (PrincipalIdealRing.isMaximal_of_irreducible h₂) fun h ↦ hne <| Subtype.ext <|
+      eq_of_monic_of_associated hm₁ hm₂ <| Ideal.span_singleton_eq_span_singleton.mp h
+  have hprod : Associated (∏ p : {p : ℝ[X] // p ∈ normalizedFactors f}, (p : ℝ[X])) f := by
+    have hcoe : ∏ p : {p : ℝ[X] // p ∈ normalizedFactors f}, (p : ℝ[X]) =
+        ∏ p ∈ (normalizedFactors f).toFinset, p := by
+      refine (Fintype.prod_equiv (Equiv.subtypeEquivRight fun p ↦ ?_) _ _ fun x ↦ ?_).trans
+        (Finset.prod_coe_sort _ fun x ↦ x)
+      · exact (Multiset.mem_toFinset).symm
+      · rw [Equiv.subtypeEquivRight_apply]
+    rw [hcoe, Finset.prod_eq_multiset_prod, Multiset.toFinset_val,
+      Multiset.dedup_eq_self.mpr ((squarefree_iff_nodup_normalizedFactors hf).mp hsq),
+      Multiset.map_id']
+    exact prod_normalizedFactors hf
+  exact hprod.symm.dvd.trans (Fintype.prod_dvd_of_coprime (fun _ _ hab ↦ hcop _ _ hab) hfac)
+
+end Polynomial

--- a/TauCeti/RingTheory/Polynomial/RealEtale.lean
+++ b/TauCeti/RingTheory/Polynomial/RealEtale.lean
@@ -47,7 +47,7 @@ half-plane once `p` is quadratic, and evaluation there identifies `ℝ[X]/p` wit
 ## Provenance
 
 Adapted from Michael Stoll's `EllipticCurves` (`github.com/MichaelStollBayreuth/EllipticCurves`,
-Apache-2.0) at commit `66889eada51ac1eb2a1c98b3c1ba5b0bbe64a8d0`, file
+Apache-2.0) at commit `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, file
 `EllipticCurves/Mathlib/RealEtale.lean`, the section preceding the square-class decomposition.
 
 Two things are spelled differently here, in both cases because Mathlib already has what the


### PR DESCRIPTION
For a real polynomial `f`, an element of `ℝ[X]/f` is determined by its values at the archimedean
places of that algebra: the real roots of `f`, and one chosen complex root of each irreducible
quadratic factor. This adds that evaluation map and proves it injective for `f` nonzero and
squarefree.

## What this adds

`TauCeti/RingTheory/Polynomial/RealEtale.lean`

* `Polynomial.selectedRoot` — a distinguished complex root of *any* irreducible real `p`: of the
  two conjugate roots, the one with positive imaginary part when they differ. For a quadratic `p`
  that root is in the open upper half-plane, which is `selectedRoot_im_pos`.
* `Polynomial.evalSelectedHom`, `Polynomial.evalUpperEquiv` — evaluation there as an `ℝ`-algebra
  hom `ℝ[X]/p → ℂ` for any irreducible `p`, and for a quadratic `p` an isomorphism, by a dimension
  count over `ℝ`.
* `Polynomial.etaleTuple`, `Polynomial.etaleEvalHom` — the evaluation map
  `ℝ[X]/f → ({x // f.eval x = 0} → ℝ) × ({p : f.Factors // deg p = 2} → ℂ)`,
  with `_mk`, `_mk_fst`, `_mk_snd` computing it on representatives.
* `Polynomial.etaleEvalHom_injective` — injectivity for `f ≠ 0` squarefree: a class killed at
  every place is divisible by every irreducible factor, the factors are pairwise coprime, and
  their product is `f` up to a unit.

Over `ℝ` an irreducible polynomial has degree `1` or `2` (Mathlib's
`Irreducible.natDegree_le_two`), so the two families exhaust the factors.

## Reuse: what is Mathlib's and stays Mathlib's

Two declarations were written for this file and then deleted once the search found them upstream.
Recording both, since each is the kind of near-miss a reader would otherwise re-introduce:

* The factors are indexed by `f.Factors` — this repository's `Polynomial.Factors`, the subtype of
  monic irreducible divisors, ported from the same source by #4730. **An earlier revision of this
  PR said the opposite**, arguing that the wrapper existed only to dodge the `DecidableEq` that
  `normalizedFactors` carries and was therefore unnecessary over `ℝ`. That was true when written
  and false when read: #4730 merged `TauCeti/RingTheory/Polynomial/Factors.lean` about an hour
  before the previous push, which turned the wrapper from the source's private device into shared
  API. The `reuse` finding on `02be0ba` caught it, and this revision reuses
  `Polynomial.Factors.isCoprime`, `Polynomial.Factors.associated_prod` and
  `Polynomial.Factors.linearEquivRoots` rather than reproving them — 28 lines of scaffolding, with
  no result removed. `Mathlib.RingTheory.UniqueFactorizationDomain.NormalizedFactors` and
  `open UniqueFactorizationMonoid` go with it, the file having no remaining reference to
  `normalizedFactors`.
* `Module.finrank ℝ (AdjoinRoot p) = p.natDegree` is Mathlib's `finrank_quotient_span_eq_natDegree`
  (`Mathlib/RingTheory/AdjoinRoot.lean`), and Mathlib's is **stronger** — it needs no `p ≠ 0`,
  where the local version did. It has to be ascribed at the `AdjoinRoot` spelling before
  rewriting, since `rw` does not see through the unfolding to `ℝ[X] ⧸ Ideal.span {p}`; the proof
  says so at the point where it matters.

`Fintype.prod_dvd_of_coprime` and `Irreducible.natDegree_le_two` are likewise taken from Mathlib
rather than reproved.

## Gates run

| Gate | Result |
| --- | --- |
| `lake build` of the changed module | **pass** — `Build completed successfully (2890 jobs)`, mathlib pin unchanged |
| dead-simp-arg deletion test | **2 found and removed** — see below |
| `scripts/lint-style.sh` | **not re-run at this head** — see below; `pr-build` covers it |
| `scripts/lint-env.sh` | **not run whole-library** — module-scoped equivalent run instead, see below |
| axioms / module-system | CI (`pr-build`) |

`lint-env.sh` itself cannot run in a module-scoped worktree: its docstring-scan driver imports the
whole library and fails on the first missing object file before reaching this PR's code, and
building the whole library locally is what the project's build discipline forbids. So the `#lint`
half of it was reproduced against this module alone — a legacy driver importing only
`TauCeti.RingTheory.Polynomial.RealEtale`, running `#lint only <the script's 13 default linters> in
TauCeti`, elaborated with `lake env lean`. Result: **0 errors in 20 declarations with 13 linters**,
the run's completion marker printed. The docstring scan and the whole-library sweep remain
`pr-build`'s.

`lint-style.sh` passed at the previous head. It is **not** claimed at this head: the run was
started, raced a rebase that deleted a file it had already enumerated
(`TauCeti/Analysis/Complex/ContinuousLog.lean`, present on the old base and gone from current
main), and died on that stale entry rather than on anything in this diff. What this head's diff
actually risks was checked directly instead — longest line 99 **characters** (not bytes; the file
is full of `ℝ`/`ℂ`/`→`, and a byte count reads 102 where the limit is on characters), and no
trailing whitespace. The full sweep is `pr-build`'s.

Every non-`simpa` simp call in the file was put through a per-argument deletion test.
`aeval_def` and `eval₂_id` in `aeval_etaleTuple_fst` never fire: the proof is green without either
one, and green without both together (checked jointly as well as singly, since removals interact),
so that call is now `simp [etaleTuple]`. Every other argument — `AlgHom.comp_apply`,
`AlgHom.fst_apply`, `AlgHom.snd_apply`, `Pi.evalAlgHom_apply` in both proofs, `etaleTuple`, and
`him` — was tested and is load-bearing, so all are kept. Sites in the same proof were tested
separately, because a failure at an earlier tactic masks the verdict on a later one in the same
block and reads as a false "dead".

That probe is also what settled the `@[simp]` question below, in both directions: with
`etaleEvalHom_mk_fst`/`_mk_snd` tagged it reports 2 `simpNF` violations naming the exact rewrite
route (`etaleEvalHom_mk` then `aeval_etaleTuple_fst`/`_snd`); untagged, 0.

Roadmap: EllipticCurves

Prerequisite of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, the explicit-2-descent bullet
at lines 813–820:

> **Explicit `2`-descent (core, this layer).** The Stoll development already contains arithmetic
> `2`-descent: the local conditions, the explicit `2`-Selmer group inside the square classes of the
> étale algebra `K[X]/(f)`, its finiteness, and the theorem converting its cardinality into a
> **Mordell–Weil rank bound** [...]

The local condition at a real place is exactly the sign data this evaluation map exposes: the real
places of `K[X]/(f)` are its real roots, the complex places its irreducible quadratic factors, and
injectivity is what makes the resulting sign pattern determine the class. No `tauceti-target`
marker: this PR authors no roadmap target of its own, it supplies a prerequisite the 2-descent
target consumes.

## Provenance

Adapted from Michael Stoll's `EllipticCurves` (`github.com/MichaelStollBayreuth/EllipticCurves`,
Apache-2.0) at commit `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, file
`EllipticCurves/Mathlib/RealEtale.lean` — the section preceding the square-class decomposition, the
roadmap's named port source for this material. The mathematics is the source's; the indexing, the
two Mathlib substitutions above, and the documentation are not. The square-class decomposition that
follows it in that file is deliberately out of scope here and lands separately.




