### PR TITLE
feat: identify the GLn diagonal Weyl group

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Datum.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Datum.lean
@@ -102,10 +102,16 @@ This package is constructed directly from the coordinate differences. The theore
 `ofAdd_root_mem_nontrivialAdjointWeights` proves that its roots are adjoint weights; the converse
 classification is `mem_nontrivialAdjointWeights_iff_exists_diagonalRoot` in
 `GeneralLinear.Root.Adjoint`. -/
-@[expose]
 noncomputable def diagonalRootDatum (n : ℕ) :
     RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ) (ULift.{u} (Fin n) → ℤ) :=
   SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))
+
+/-- The diagonal root datum is the coordinate root datum on the universe-lifted indices. -/
+theorem diagonalRootDatum_eq_coordinateRootDatum (n : ℕ) :
+    diagonalRootDatum.{u} n = SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)) :=
+  -- `(rfl)` opts out of exporting the definitional equality, so the definition can remain opaque
+  -- while this theorem provides the downstream rewriting interface.
+  (rfl)
 
 /-- The underlying bilinear map is the split-torus character--cocharacter dot pairing. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Datum.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Datum.lean
@@ -102,16 +102,10 @@ This package is constructed directly from the coordinate differences. The theore
 `ofAdd_root_mem_nontrivialAdjointWeights` proves that its roots are adjoint weights; the converse
 classification is `mem_nontrivialAdjointWeights_iff_exists_diagonalRoot` in
 `GeneralLinear.Root.Adjoint`. -/
+@[expose]
 noncomputable def diagonalRootDatum (n : ℕ) :
     RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ) (ULift.{u} (Fin n) → ℤ) :=
   SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))
-
-/-- The diagonal root datum is the coordinate-difference root datum on the universe-lifted
-matrix coordinates. This characteristic equation lets downstream modules use the generic
-coordinate-root-datum API without unfolding `diagonalRootDatum`. -/
-theorem diagonalRootDatum_eq_coordinateRootDatum (n : ℕ) :
-    diagonalRootDatum n = SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)) :=
-  (rfl)
 
 /-- The underlying bilinear map is the split-torus character--cocharacter dot pairing. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Datum.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Datum.lean
@@ -106,6 +106,13 @@ noncomputable def diagonalRootDatum (n : ℕ) :
     RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ) (ULift.{u} (Fin n) → ℤ) :=
   SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))
 
+/-- The diagonal root datum is the coordinate-difference root datum on the universe-lifted
+matrix coordinates. This characteristic equation lets downstream modules use the generic
+coordinate-root-datum API without unfolding `diagonalRootDatum`. -/
+theorem diagonalRootDatum_eq_coordinateRootDatum (n : ℕ) :
+    diagonalRootDatum n = SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)) :=
+  (rfl)
+
 /-- The underlying bilinear map is the split-torus character--cocharacter dot pairing. -/
 @[simp]
 theorem diagonalRootDatum_toLinearMap (n : ℕ) :

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/WeylGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/WeylGroup.lean
@@ -31,16 +31,15 @@ coordinate root datum describe the same Weyl group of the standard split torus i
   the character lattice.
 * `TauCeti.GeneralLinear.diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap`: a
   transposition matrix maps to the corresponding root reflection.
-* `TauCeti.GeneralLinear.diagonalNormalizer_mul_diagGL_mul_inv`: conjugation by a normalizer
-  element permutes the diagonal coordinates by the same permutation.
 
 ## References
 
 * J. S. Milne, *Algebraic Groups* (2017), Example 19.7 and Section 21.1.
 * J. E. Humphreys, *Linear Algebraic Groups* (1975), Sections 16.1 and 26.3.
 
-This completes the Weyl-group identification for the standard split `GL_n` example in Layer 7,
-"Root datum `(G, T)` with its Weyl group", of the ReductiveGroups roadmap.
+This advances Layer 7, "Root datum `(G, T)` with its Weyl group", of the ReductiveGroups roadmap
+through the group-of-points Weyl group of the standard split maximal torus of `GL_n`; the
+scheme-level identification is not addressed here.
 -/
 
 public section
@@ -53,35 +52,54 @@ noncomputable section
 
 variable {k : Type u} [Field k] [Nontrivial kˣ] {n : ℕ}
 
-/-- Transport a permutation of `Fin n` to the universe-lifted coordinate type used by the
-diagonal root datum. -/
-noncomputable def liftCoordinatePerm (e : Equiv.Perm (Fin n)) :
-    Equiv.Perm (ULift.{u} (Fin n)) :=
-  Equiv.ulift.symm.permCongr e
+private theorem diagonalRootDatum_eq_coordinateRootDatum (n : ℕ) :
+    diagonalRootDatum.{u} n = SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)) := by
+  rw [diagonalRootDatum]
 
-@[simp]
-theorem liftCoordinatePerm_apply (e : Equiv.Perm (Fin n)) (i : Fin n) :
-    liftCoordinatePerm e (ULift.up i) = ULift.up (e i) := by
-  simp [liftCoordinatePerm, Equiv.permCongr_apply]
+/-- Transport between the Weyl groups across the opaque `diagonalRootDatum` wrapper. -/
+noncomputable def diagonalWeylGroupMulEquivCoordinateWeylGroup (n : ℕ) :
+    (diagonalRootDatum.{u} n).weylGroup ≃*
+      (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup := by
+  rw [diagonalRootDatum_eq_coordinateRootDatum]
 
-@[simp]
-theorem liftCoordinatePerm_symm_apply (e : Equiv.Perm (Fin n)) (i : Fin n) :
-    (liftCoordinatePerm e).symm (ULift.up i) = ULift.up (e.symm i) := by
-  apply (liftCoordinatePerm e).injective
-  rw [Equiv.apply_symm_apply, liftCoordinatePerm_apply]
-  exact congrArg ULift.up (e.apply_symm_apply i).symm
+private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_smul_apply
+    (w : (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup)
+    (x : ULift.{u} (Fin n) →₀ ℤ) (a : ULift.{u} (Fin n)) :
+    ((diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm w • x) a =
+      (w • x) a := by
+  have h := diagonalRootDatum_eq_coordinateRootDatum.{u} n
+  cases h
+  rfl
+
+private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_indexEquiv_apply
+    (w : (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup)
+    (p : DiagonalRootIndex n) :
+    ((diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm w).1.indexEquiv p =
+      w.1.indexEquiv p := by
+  have h := diagonalRootDatum_eq_coordinateRootDatum.{u} n
+  cases h
+  rfl
+
+private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_ofIdx
+    (p : DiagonalRootIndex n) :
+    (diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm
+        (RootPairing.weylGroup.ofIdx
+          (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))) p) =
+      RootPairing.weylGroup.ofIdx (diagonalRootDatum.{u} n) p := by
+  have h := diagonalRootDatum_eq_coordinateRootDatum.{u} n
+  cases h
+  rfl
 
 /-- **The normalizer quotient of the diagonal torus is the Weyl group of its coordinate root
 datum.** The intermediate permutation is transported from `Fin n` to the universe-lifted
-coordinate type used by `diagonalRootDatum`. The theorem
-`diagonalRootDatum_eq_coordinateRootDatum` identifies the displayed target with the Weyl group
-of `diagonalRootDatum n`. -/
+coordinate type used by `diagonalRootDatum`. -/
 noncomputable def diagonalNormalizerQuotientMulEquivWeylGroup (k : Type u) [Field k]
     [Nontrivial kˣ] (n : ℕ) :
     Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n) ≃*
-      (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup :=
-  (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n)).trans <|
-    Equiv.ulift.symm.permCongrHom.trans SplitTorus.coordinatePermMulEquivWeylGroup
+      (diagonalRootDatum.{u} n).weylGroup :=
+  ((diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n)).trans <|
+    Equiv.ulift.symm.permCongrHom.trans SplitTorus.coordinatePermMulEquivWeylGroup).trans <|
+      (diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm
 
 /-- On a normalizer representative, the Weyl-group equivalence is the root-datum automorphism
 induced by its coordinate permutation. -/
@@ -90,17 +108,12 @@ theorem diagonalNormalizerQuotientMulEquivWeylGroup_mk
     (g : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k))) :
     diagonalNormalizerQuotientMulEquivWeylGroup k n
         (g : Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n)) =
-      SplitTorus.coordinatePermMulEquivWeylGroup
-        (liftCoordinatePerm (diagonalNormalizerPerm (k := k) (n := n) g)) := by
-  rw [diagonalNormalizerQuotientMulEquivWeylGroup]
-  simp only [MulEquiv.trans_apply, Equiv.permCongrHom_coe]
-  refine congrArg (SplitTorus.coordinatePermMulEquivWeylGroup
-    (σ := ULift.{u} (Fin n))) ?_
-  change Equiv.ulift.symm.permCongr
-      (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n)
-        (g : Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n))) = _
-  rw [diagonalNormalizerQuotientMulEquivPerm_mk]
-  rfl
+      (diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm
+        (SplitTorus.coordinatePermMulEquivWeylGroup
+          (Equiv.ulift.symm.permCongrHom
+            (diagonalNormalizerPerm (k := k) (n := n) g))) := by
+  simp only [diagonalNormalizerQuotientMulEquivWeylGroup, MulEquiv.trans_apply,
+    Equiv.permCongrHom_coe, diagonalNormalizerQuotientMulEquivPerm_mk]
 
 /-- A permutation matrix represents the Weyl element induced by the same coordinate
 permutation, transported to the universe-lifted root coordinates. -/
@@ -109,26 +122,28 @@ theorem diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL
     diagonalNormalizerQuotientMulEquivWeylGroup k n
         (⟨permutationGL (k := k) e, permutationGL_mem_normalizer e⟩ :
           Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k))) =
-      SplitTorus.coordinatePermMulEquivWeylGroup (liftCoordinatePerm e) := by
+      (diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm
+        (SplitTorus.coordinatePermMulEquivWeylGroup
+          (Equiv.ulift.symm.permCongrHom e)) := by
   rw [diagonalNormalizerQuotientMulEquivWeylGroup_mk,
     diagonalNormalizerPerm_permutationGL]
 
-/-- The Weyl element represented by a normalizer class acts on characters by the inverse of the
-associated coordinate permutation. -/
+/-- The Weyl element represented by a normalizer class acts on the character lattice by moving
+each coordinate through its associated permutation; equivalently, its value at a coordinate is
+the original value at the inverse image of that coordinate. -/
 @[simp]
 theorem diagonalNormalizerQuotientMulEquivWeylGroup_smul_apply
     (q : Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n))
-    (x : ULift.{u} (Fin n) →₀ ℤ) (i : Fin n) :
-    (diagonalNormalizerQuotientMulEquivWeylGroup k n q • x) (ULift.up i) =
+    (x : ULift.{u} (Fin n) →₀ ℤ) (a : ULift.{u} (Fin n)) :
+    (diagonalNormalizerQuotientMulEquivWeylGroup k n q • x) a =
       x (ULift.up
-        ((diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q).symm i)) := by
+        ((diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q).symm a.down)) := by
   rw [diagonalNormalizerQuotientMulEquivWeylGroup]
   simp only [MulEquiv.trans_apply, Equiv.permCongrHom_coe,
+    diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_smul_apply,
     SplitTorus.coordinatePermMulEquivWeylGroup_smul_apply]
-  change x ((liftCoordinatePerm
-    (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q)).symm
-      (ULift.up i)) = _
-  rw [liftCoordinatePerm_symm_apply]
+  rw [Equiv.permCongr_def]
+  rfl
 
 /-- The Weyl element represented by a normalizer class applies the associated coordinate
 permutation simultaneously to both entries of a root index. -/
@@ -138,17 +153,12 @@ theorem diagonalNormalizerQuotientMulEquivWeylGroup_indexEquiv_apply
     (p : DiagonalRootIndex n) :
     (diagonalNormalizerQuotientMulEquivWeylGroup k n q).1.indexEquiv p =
       SplitTorus.coordinatePermRootIndex
-        (liftCoordinatePerm
+        (Equiv.ulift.symm.permCongrHom
           (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q)) p := by
   rw [diagonalNormalizerQuotientMulEquivWeylGroup]
+  rw [MulEquiv.trans_apply, MulEquiv.trans_apply,
+    diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_indexEquiv_apply]
   exact SplitTorus.coordinatePermMulEquivWeylGroup_indexEquiv_apply _ _
-
-/-- Transporting a coordinate transposition to lifted coordinates gives the corresponding
-transposition of the lifted coordinates. -/
-theorem liftCoordinatePerm_swap (i j : Fin n) :
-    liftCoordinatePerm (Equiv.swap i j) =
-      Equiv.swap (ULift.up i) (ULift.up j) := by
-  exact Equiv.symm_trans_swap_trans i j Equiv.ulift.symm
 
 /-- A transposition matrix maps to reflection in the corresponding diagonal root. -/
 theorem diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap
@@ -158,22 +168,44 @@ theorem diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap
           permutationGL_mem_normalizer (Equiv.swap i j)⟩ :
           Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k))) =
       RootPairing.weylGroup.ofIdx
-        (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)))
-        (⟨(ULift.up i, ULift.up j), fun h ↦ hij (ULift.up_injective h)⟩ :
+        (diagonalRootDatum.{u} n)
+        (⟨(ULift.up i, ULift.up j), fun h ↦ hij (congrArg ULift.down h)⟩ :
           DiagonalRootIndex n) := by
-  rw [diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL,
-    liftCoordinatePerm_swap,
-    SplitTorus.coordinatePermMulEquivWeylGroup_swap]
+  have hijLift : (ULift.up i : ULift.{u} (Fin n)) ≠ ULift.up j :=
+    fun h ↦ hij (congrArg ULift.down h)
+  have hlift :
+      (Equiv.ulift.{u, 0}.symm : Fin n ≃ ULift.{u} (Fin n)).permCongr
+          (Equiv.swap i j) =
+        Equiv.swap (ULift.up i) (ULift.up j) := by
+    rw [Equiv.permCongr_def, Equiv.symm_trans_swap_trans]
+    simp
+  rw [diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL]
+  calc
+    (diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm
+          (SplitTorus.coordinatePermMulEquivWeylGroup
+            (Equiv.ulift.symm.permCongrHom (Equiv.swap i j))) =
+        (diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm
+          (SplitTorus.coordinatePermMulEquivWeylGroup
+            (Equiv.swap (ULift.up i) (ULift.up j))) :=
+      congrArg ((diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm ∘
+        SplitTorus.coordinatePermMulEquivWeylGroup) hlift
+    _ = (diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm
+        (RootPairing.weylGroup.ofIdx
+          (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)))
+          (⟨(ULift.up i, ULift.up j), hijLift⟩ : DiagonalRootIndex n)) := by
+      congr 1
+      exact SplitTorus.coordinatePermMulEquivWeylGroup_swap _ _ _
+    _ = _ := diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_ofIdx _
 
 /-- Conversely, the reflection in `e_i - e_j` corresponds to the normalizer class of the
 transposition matrix swapping the two coordinate lines. -/
 @[simp]
-theorem diagonalNormalizerQuotientMulEquivWeylGroup_symm_reflection
+theorem diagonalNormalizerQuotientMulEquivWeylGroup_symm_ofIdx
     (i j : Fin n) (hij : i ≠ j) :
     (diagonalNormalizerQuotientMulEquivWeylGroup k n).symm
         (RootPairing.weylGroup.ofIdx
-          (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)))
-          (⟨(ULift.up i, ULift.up j), fun h ↦ hij (ULift.up_injective h)⟩ :
+          (diagonalRootDatum.{u} n)
+          (⟨(ULift.up i, ULift.up j), fun h ↦ hij (congrArg ULift.down h)⟩ :
             DiagonalRootIndex n)) =
       (⟨permutationGL (k := k) (Equiv.swap i j),
         permutationGL_mem_normalizer (Equiv.swap i j)⟩ :
@@ -181,47 +213,6 @@ theorem diagonalNormalizerQuotientMulEquivWeylGroup_symm_reflection
   apply (diagonalNormalizerQuotientMulEquivWeylGroup k n).injective
   rw [MulEquiv.apply_symm_apply,
     diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap]
-
-private theorem diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL
-    (g : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k)))
-    (d : Fin n → kˣ) (e : Equiv.Perm (Fin n))
-    (h : (g : GL (Fin n) k) = diagGL d * permutationGL (k := k) e) :
-    diagonalNormalizerPerm (k := k) (n := n) g = e := by
-  let gd : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k)) :=
-    ⟨diagGL d, Subgroup.le_normalizer
-      (mem_diagonalTorus_iff_exists_diagGL.mpr ⟨d, rfl⟩)⟩
-  let ge : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k)) :=
-    ⟨permutationGL (k := k) e, permutationGL_mem_normalizer e⟩
-  have hg : g = gd * ge := Subtype.ext h
-  have hgd : diagonalNormalizerPerm (k := k) (n := n) gd = 1 :=
-    (diagonalNormalizerPerm_eq_one_iff gd).mpr
-      (mem_diagonalTorus_iff_exists_diagGL.mpr ⟨d, rfl⟩)
-  rw [hg, map_mul, hgd, one_mul]
-  exact diagonalNormalizerPerm_permutationGL e
-
-/-- **Conjugation by a diagonal-normalizer element permutes the diagonal coordinates by the same
-permutation that its Weyl class induces on the root datum.** -/
-theorem diagonalNormalizer_mul_diagGL_mul_inv
-    (g : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k)))
-    (t : Fin n → kˣ) :
-    (g : GL (Fin n) k) * diagGL t * (g : GL (Fin n) k)⁻¹ =
-      diagGL (fun i ↦ t ((diagonalNormalizerPerm (k := k) (n := n) g).symm i)) := by
-  obtain ⟨d, e, hge⟩ := mem_normalizer_diagonalTorus_iff_exists.mp g.property
-  have he := diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL g d e hge
-  rw [he, hge]
-  calc
-    (diagGL d * permutationGL (k := k) e) * diagGL t *
-          (diagGL d * permutationGL (k := k) e)⁻¹ =
-        diagGL d *
-          (permutationGL (k := k) e * diagGL t *
-            (permutationGL (k := k) e)⁻¹) * (diagGL d)⁻¹ := by group
-    _ = diagGL d * diagGL (fun i ↦ t (e⁻¹ i)) * (diagGL d)⁻¹ := by
-      rw [permutationGL_mul_diagGL_mul_inv]
-    _ = diagGL (fun i ↦ t (e⁻¹ i)) := by
-      have hcomm : Commute (diagGL d) (diagGL (fun i ↦ t (e⁻¹ i))) := by
-        exact (Commute.all d (fun i ↦ t (e⁻¹ i))).map diagGL
-      rw [hcomm.eq]
-      simp
 
 end
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/WeylGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/WeylGroup.lean
@@ -1,0 +1,228 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Root.Datum
+public import TauCeti.Algebra.AlgebraicGroup.SplitTorus.RootDatum.WeylGroup
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal.Normalizer
+
+/-!
+# The Weyl group of the diagonal torus in the general linear group
+
+For a field `k` with a nontrivial unit group, the normalizer quotient of the diagonal torus in
+`GL_n(k)` is the permutation group of the coordinate lines. Independently, the Weyl group of the
+diagonal coordinate root datum is the permutation group of its universe-lifted coordinates. This
+file identifies those two groups and proves that the identification gives the same actions on the
+character lattice and on the roots.
+
+Concretely, the class of a normalizing matrix `g` maps to the root-datum automorphism attached to
+`diagonalNormalizerPerm g`. The class of a permutation matrix for the transposition `(i j)` maps
+to reflection in the root `e_i - e_j`. Thus the group-of-points normalizer computation and the
+coordinate root datum describe the same Weyl group of the standard split torus in `GL_n`.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.diagonalNormalizerQuotientMulEquivWeylGroup`: the canonical equivalence
+  from the diagonal normalizer quotient to the Weyl group of `diagonalRootDatum`.
+* `TauCeti.GeneralLinear.diagonalNormalizerQuotientMulEquivWeylGroup_smul_apply`: its action on
+  the character lattice.
+* `TauCeti.GeneralLinear.diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap`: a
+  transposition matrix maps to the corresponding root reflection.
+* `TauCeti.GeneralLinear.diagonalNormalizer_mul_diagGL_mul_inv`: conjugation by a normalizer
+  element permutes the diagonal coordinates by the same permutation.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Example 19.7 and Section 21.1.
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), Sections 16.1 and 26.3.
+
+This completes the Weyl-group identification for the standard split `GL_n` example in Layer 7,
+"Root datum `(G, T)` with its Weyl group", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+noncomputable section
+
+variable {k : Type u} [Field k] [Nontrivial kˣ] {n : ℕ}
+
+/-- Transport a permutation of `Fin n` to the universe-lifted coordinate type used by the
+diagonal root datum. -/
+noncomputable def liftCoordinatePerm (e : Equiv.Perm (Fin n)) :
+    Equiv.Perm (ULift.{u} (Fin n)) :=
+  Equiv.ulift.symm.permCongr e
+
+@[simp]
+theorem liftCoordinatePerm_apply (e : Equiv.Perm (Fin n)) (i : Fin n) :
+    liftCoordinatePerm e (ULift.up i) = ULift.up (e i) := by
+  simp [liftCoordinatePerm, Equiv.permCongr_apply]
+
+@[simp]
+theorem liftCoordinatePerm_symm_apply (e : Equiv.Perm (Fin n)) (i : Fin n) :
+    (liftCoordinatePerm e).symm (ULift.up i) = ULift.up (e.symm i) := by
+  apply (liftCoordinatePerm e).injective
+  rw [Equiv.apply_symm_apply, liftCoordinatePerm_apply]
+  exact congrArg ULift.up (e.apply_symm_apply i).symm
+
+/-- **The normalizer quotient of the diagonal torus is the Weyl group of its coordinate root
+datum.** The intermediate permutation is transported from `Fin n` to the universe-lifted
+coordinate type used by `diagonalRootDatum`. The theorem
+`diagonalRootDatum_eq_coordinateRootDatum` identifies the displayed target with the Weyl group
+of `diagonalRootDatum n`. -/
+noncomputable def diagonalNormalizerQuotientMulEquivWeylGroup (k : Type u) [Field k]
+    [Nontrivial kˣ] (n : ℕ) :
+    Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n) ≃*
+      (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup :=
+  (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n)).trans <|
+    Equiv.ulift.symm.permCongrHom.trans SplitTorus.coordinatePermMulEquivWeylGroup
+
+/-- On a normalizer representative, the Weyl-group equivalence is the root-datum automorphism
+induced by its coordinate permutation. -/
+@[simp]
+theorem diagonalNormalizerQuotientMulEquivWeylGroup_mk
+    (g : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k))) :
+    diagonalNormalizerQuotientMulEquivWeylGroup k n
+        (g : Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n)) =
+      SplitTorus.coordinatePermMulEquivWeylGroup
+        (liftCoordinatePerm (diagonalNormalizerPerm (k := k) (n := n) g)) := by
+  rw [diagonalNormalizerQuotientMulEquivWeylGroup]
+  simp only [MulEquiv.trans_apply, Equiv.permCongrHom_coe]
+  refine congrArg (SplitTorus.coordinatePermMulEquivWeylGroup
+    (σ := ULift.{u} (Fin n))) ?_
+  change Equiv.ulift.symm.permCongr
+      (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n)
+        (g : Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n))) = _
+  rw [diagonalNormalizerQuotientMulEquivPerm_mk]
+  rfl
+
+/-- A permutation matrix represents the Weyl element induced by the same coordinate
+permutation, transported to the universe-lifted root coordinates. -/
+theorem diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL
+    (e : Equiv.Perm (Fin n)) :
+    diagonalNormalizerQuotientMulEquivWeylGroup k n
+        (⟨permutationGL (k := k) e, permutationGL_mem_normalizer e⟩ :
+          Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k))) =
+      SplitTorus.coordinatePermMulEquivWeylGroup (liftCoordinatePerm e) := by
+  rw [diagonalNormalizerQuotientMulEquivWeylGroup_mk,
+    diagonalNormalizerPerm_permutationGL]
+
+/-- The Weyl element represented by a normalizer class acts on characters by the inverse of the
+associated coordinate permutation. -/
+@[simp]
+theorem diagonalNormalizerQuotientMulEquivWeylGroup_smul_apply
+    (q : Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n))
+    (x : ULift.{u} (Fin n) →₀ ℤ) (i : Fin n) :
+    (diagonalNormalizerQuotientMulEquivWeylGroup k n q • x) (ULift.up i) =
+      x (ULift.up
+        ((diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q).symm i)) := by
+  rw [diagonalNormalizerQuotientMulEquivWeylGroup]
+  simp only [MulEquiv.trans_apply, Equiv.permCongrHom_coe,
+    SplitTorus.coordinatePermMulEquivWeylGroup_smul_apply]
+  change x ((liftCoordinatePerm
+    (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q)).symm
+      (ULift.up i)) = _
+  rw [liftCoordinatePerm_symm_apply]
+
+/-- The Weyl element represented by a normalizer class applies the associated coordinate
+permutation simultaneously to both entries of a root index. -/
+@[simp]
+theorem diagonalNormalizerQuotientMulEquivWeylGroup_indexEquiv_apply
+    (q : Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n))
+    (p : DiagonalRootIndex n) :
+    (diagonalNormalizerQuotientMulEquivWeylGroup k n q).1.indexEquiv p =
+      SplitTorus.coordinatePermRootIndex
+        (liftCoordinatePerm
+          (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q)) p := by
+  rw [diagonalNormalizerQuotientMulEquivWeylGroup]
+  exact SplitTorus.coordinatePermMulEquivWeylGroup_indexEquiv_apply _ _
+
+/-- Transporting a coordinate transposition to lifted coordinates gives the corresponding
+transposition of the lifted coordinates. -/
+theorem liftCoordinatePerm_swap (i j : Fin n) :
+    liftCoordinatePerm (Equiv.swap i j) =
+      Equiv.swap (ULift.up i) (ULift.up j) := by
+  exact Equiv.symm_trans_swap_trans i j Equiv.ulift.symm
+
+/-- A transposition matrix maps to reflection in the corresponding diagonal root. -/
+theorem diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap
+    (i j : Fin n) (hij : i ≠ j) :
+    diagonalNormalizerQuotientMulEquivWeylGroup k n
+        (⟨permutationGL (k := k) (Equiv.swap i j),
+          permutationGL_mem_normalizer (Equiv.swap i j)⟩ :
+          Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k))) =
+      RootPairing.weylGroup.ofIdx
+        (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)))
+        (⟨(ULift.up i, ULift.up j), fun h ↦ hij (ULift.up_injective h)⟩ :
+          DiagonalRootIndex n) := by
+  rw [diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL,
+    liftCoordinatePerm_swap,
+    SplitTorus.coordinatePermMulEquivWeylGroup_swap]
+
+/-- Conversely, the reflection in `e_i - e_j` corresponds to the normalizer class of the
+transposition matrix swapping the two coordinate lines. -/
+@[simp]
+theorem diagonalNormalizerQuotientMulEquivWeylGroup_symm_reflection
+    (i j : Fin n) (hij : i ≠ j) :
+    (diagonalNormalizerQuotientMulEquivWeylGroup k n).symm
+        (RootPairing.weylGroup.ofIdx
+          (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)))
+          (⟨(ULift.up i, ULift.up j), fun h ↦ hij (ULift.up_injective h)⟩ :
+            DiagonalRootIndex n)) =
+      (⟨permutationGL (k := k) (Equiv.swap i j),
+        permutationGL_mem_normalizer (Equiv.swap i j)⟩ :
+        Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k))) := by
+  apply (diagonalNormalizerQuotientMulEquivWeylGroup k n).injective
+  rw [MulEquiv.apply_symm_apply,
+    diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap]
+
+private theorem diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL
+    (g : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k)))
+    (d : Fin n → kˣ) (e : Equiv.Perm (Fin n))
+    (h : (g : GL (Fin n) k) = diagGL d * permutationGL (k := k) e) :
+    diagonalNormalizerPerm (k := k) (n := n) g = e := by
+  let gd : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k)) :=
+    ⟨diagGL d, Subgroup.le_normalizer
+      (mem_diagonalTorus_iff_exists_diagGL.mpr ⟨d, rfl⟩)⟩
+  let ge : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k)) :=
+    ⟨permutationGL (k := k) e, permutationGL_mem_normalizer e⟩
+  have hg : g = gd * ge := Subtype.ext h
+  have hgd : diagonalNormalizerPerm (k := k) (n := n) gd = 1 :=
+    (diagonalNormalizerPerm_eq_one_iff gd).mpr
+      (mem_diagonalTorus_iff_exists_diagGL.mpr ⟨d, rfl⟩)
+  rw [hg, map_mul, hgd, one_mul]
+  exact diagonalNormalizerPerm_permutationGL e
+
+/-- **Conjugation by a diagonal-normalizer element permutes the diagonal coordinates by the same
+permutation that its Weyl class induces on the root datum.** -/
+theorem diagonalNormalizer_mul_diagGL_mul_inv
+    (g : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k)))
+    (t : Fin n → kˣ) :
+    (g : GL (Fin n) k) * diagGL t * (g : GL (Fin n) k)⁻¹ =
+      diagGL (fun i ↦ t ((diagonalNormalizerPerm (k := k) (n := n) g).symm i)) := by
+  obtain ⟨d, e, hge⟩ := mem_normalizer_diagonalTorus_iff_exists.mp g.property
+  have he := diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL g d e hge
+  rw [he, hge]
+  calc
+    (diagGL d * permutationGL (k := k) e) * diagGL t *
+          (diagGL d * permutationGL (k := k) e)⁻¹ =
+        diagGL d *
+          (permutationGL (k := k) e * diagGL t *
+            (permutationGL (k := k) e)⁻¹) * (diagGL d)⁻¹ := by group
+    _ = diagGL d * diagGL (fun i ↦ t (e⁻¹ i)) * (diagGL d)⁻¹ := by
+      rw [permutationGL_mul_diagGL_mul_inv]
+    _ = diagGL (fun i ↦ t (e⁻¹ i)) := by
+      have hcomm : Commute (diagGL d) (diagGL (fun i ↦ t (e⁻¹ i))) := by
+        exact (Commute.all d (fun i ↦ t (e⁻¹ i))).map diagGL
+      rw [hcomm.eq]
+      simp
+
+end
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/WeylGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/WeylGroup.lean
@@ -52,43 +52,64 @@ noncomputable section
 
 variable {k : Type u} [Field k] [Nontrivial kˣ] {n : ℕ}
 
-private theorem diagonalRootDatum_eq_coordinateRootDatum (n : ℕ) :
-    diagonalRootDatum.{u} n = SplitTorus.coordinateRootDatum (ULift.{u} (Fin n)) := by
-  rw [diagonalRootDatum]
+/-- Transport Weyl groups along an equality of root data. -/
+private noncomputable def weylGroupMulEquivOfEq
+    (D E : RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ)
+      (ULift.{u} (Fin n) → ℤ)) (h : D = E) : D.weylGroup ≃* E.weylGroup := by
+  subst E
+  exact MulEquiv.refl _
+
+private theorem weylGroupMulEquivOfEq_symm_smul_apply
+    (D E : RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ)
+      (ULift.{u} (Fin n) → ℤ)) (h : D = E) (w : E.weylGroup)
+    (x : ULift.{u} (Fin n) →₀ ℤ) (a : ULift.{u} (Fin n)) :
+    ((weylGroupMulEquivOfEq D E h).symm w • x) a = (w • x) a := by
+  subst E
+  rfl
+
+private theorem weylGroupMulEquivOfEq_symm_indexEquiv_apply
+    (D E : RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ)
+      (ULift.{u} (Fin n) → ℤ)) (h : D = E) (w : E.weylGroup)
+    (p : DiagonalRootIndex n) :
+    ((weylGroupMulEquivOfEq D E h).symm w).1.indexEquiv p = w.1.indexEquiv p := by
+  subst E
+  rfl
+
+private theorem weylGroupMulEquivOfEq_symm_ofIdx
+    (D E : RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ)
+      (ULift.{u} (Fin n) → ℤ)) (h : D = E) (p : DiagonalRootIndex n) :
+    (weylGroupMulEquivOfEq D E h).symm (RootPairing.weylGroup.ofIdx E p) =
+      RootPairing.weylGroup.ofIdx D p := by
+  subst E
+  rfl
 
 /-- Transport between the Weyl groups across the opaque `diagonalRootDatum` wrapper. -/
 noncomputable def diagonalWeylGroupMulEquivCoordinateWeylGroup (n : ℕ) :
     (diagonalRootDatum.{u} n).weylGroup ≃*
-      (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup := by
-  rw [diagonalRootDatum_eq_coordinateRootDatum]
+      (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup :=
+  weylGroupMulEquivOfEq _ _ (diagonalRootDatum_eq_coordinateRootDatum n)
 
 private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_smul_apply
     (w : (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup)
     (x : ULift.{u} (Fin n) →₀ ℤ) (a : ULift.{u} (Fin n)) :
     ((diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm w • x) a =
-      (w • x) a := by
-  have h := diagonalRootDatum_eq_coordinateRootDatum.{u} n
-  cases h
-  rfl
+      (w • x) a :=
+  weylGroupMulEquivOfEq_symm_smul_apply _ _ _ w x a
 
 private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_indexEquiv_apply
     (w : (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup)
     (p : DiagonalRootIndex n) :
     ((diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm w).1.indexEquiv p =
-      w.1.indexEquiv p := by
-  have h := diagonalRootDatum_eq_coordinateRootDatum.{u} n
-  cases h
-  rfl
+      w.1.indexEquiv p :=
+  weylGroupMulEquivOfEq_symm_indexEquiv_apply _ _ _ w p
 
 private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_ofIdx
     (p : DiagonalRootIndex n) :
     (diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm
         (RootPairing.weylGroup.ofIdx
           (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))) p) =
-      RootPairing.weylGroup.ofIdx (diagonalRootDatum.{u} n) p := by
-  have h := diagonalRootDatum_eq_coordinateRootDatum.{u} n
-  cases h
-  rfl
+      RootPairing.weylGroup.ofIdx (diagonalRootDatum.{u} n) p :=
+  weylGroupMulEquivOfEq_symm_ofIdx _ _ _ p
 
 /-- **The normalizer quotient of the diagonal torus is the Weyl group of its coordinate root
 datum.** The intermediate permutation is transported from `Fin n` to the universe-lifted

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/WeylGroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/WeylGroup.lean
@@ -46,11 +46,11 @@ public section
 
 namespace TauCeti.GeneralLinear
 
-universe u
+universe u v
 
 noncomputable section
 
-variable {k : Type u} [Field k] [Nontrivial kˣ] {n : ℕ}
+variable {k : Type v} [Field k] [Nontrivial kˣ] {n : ℕ}
 
 /-- Transport Weyl groups along an equality of root data. -/
 private noncomputable def weylGroupMulEquivOfEq
@@ -64,6 +64,22 @@ private theorem weylGroupMulEquivOfEq_symm_smul_apply
       (ULift.{u} (Fin n) → ℤ)) (h : D = E) (w : E.weylGroup)
     (x : ULift.{u} (Fin n) →₀ ℤ) (a : ULift.{u} (Fin n)) :
     ((weylGroupMulEquivOfEq D E h).symm w • x) a = (w • x) a := by
+  subst E
+  rfl
+
+private theorem weylGroupMulEquivOfEq_symm_weightMap_apply
+    (D E : RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ)
+      (ULift.{u} (Fin n) → ℤ)) (h : D = E) (w : E.weylGroup)
+    (x : ULift.{u} (Fin n) →₀ ℤ) :
+    ((weylGroupMulEquivOfEq D E h).symm w).1.weightMap x = w.1.weightMap x := by
+  subst E
+  rfl
+
+private theorem weylGroupMulEquivOfEq_symm_coweightMap_apply
+    (D E : RootDatum (DiagonalRootIndex n) (ULift.{u} (Fin n) →₀ ℤ)
+      (ULift.{u} (Fin n) → ℤ)) (h : D = E) (w : E.weylGroup)
+    (x : ULift.{u} (Fin n) → ℤ) (a : ULift.{u} (Fin n)) :
+    ((weylGroupMulEquivOfEq D E h).symm w).1.coweightMap x a = w.1.coweightMap x a := by
   subst E
   rfl
 
@@ -96,6 +112,20 @@ private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_smul_apply
       (w • x) a :=
   weylGroupMulEquivOfEq_symm_smul_apply _ _ _ w x a
 
+private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_weightMap_apply
+    (w : (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup)
+    (x : ULift.{u} (Fin n) →₀ ℤ) :
+    ((diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm w).1.weightMap x =
+      w.1.weightMap x :=
+  weylGroupMulEquivOfEq_symm_weightMap_apply _ _ _ w x
+
+private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_coweightMap_apply
+    (w : (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup)
+    (x : ULift.{u} (Fin n) → ℤ) (a : ULift.{u} (Fin n)) :
+    ((diagonalWeylGroupMulEquivCoordinateWeylGroup.{u} n).symm w).1.coweightMap x a =
+      w.1.coweightMap x a :=
+  weylGroupMulEquivOfEq_symm_coweightMap_apply _ _ _ w x a
+
 private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_indexEquiv_apply
     (w : (SplitTorus.coordinateRootDatum (ULift.{u} (Fin n))).weylGroup)
     (p : DiagonalRootIndex n) :
@@ -114,7 +144,7 @@ private theorem diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_ofIdx
 /-- **The normalizer quotient of the diagonal torus is the Weyl group of its coordinate root
 datum.** The intermediate permutation is transported from `Fin n` to the universe-lifted
 coordinate type used by `diagonalRootDatum`. -/
-noncomputable def diagonalNormalizerQuotientMulEquivWeylGroup (k : Type u) [Field k]
+noncomputable def diagonalNormalizerQuotientMulEquivWeylGroup (k : Type v) [Field k]
     [Nontrivial kˣ] (n : ℕ) :
     Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n) ≃*
       (diagonalRootDatum.{u} n).weylGroup :=
@@ -124,7 +154,6 @@ noncomputable def diagonalNormalizerQuotientMulEquivWeylGroup (k : Type u) [Fiel
 
 /-- On a normalizer representative, the Weyl-group equivalence is the root-datum automorphism
 induced by its coordinate permutation. -/
-@[simp]
 theorem diagonalNormalizerQuotientMulEquivWeylGroup_mk
     (g : Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k))) :
     diagonalNormalizerQuotientMulEquivWeylGroup k n
@@ -138,6 +167,7 @@ theorem diagonalNormalizerQuotientMulEquivWeylGroup_mk
 
 /-- A permutation matrix represents the Weyl element induced by the same coordinate
 permutation, transported to the universe-lifted root coordinates. -/
+@[simp low]
 theorem diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL
     (e : Equiv.Perm (Fin n)) :
     diagonalNormalizerQuotientMulEquivWeylGroup k n
@@ -163,8 +193,40 @@ theorem diagonalNormalizerQuotientMulEquivWeylGroup_smul_apply
   simp only [MulEquiv.trans_apply, Equiv.permCongrHom_coe,
     diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_smul_apply,
     SplitTorus.coordinatePermMulEquivWeylGroup_smul_apply]
-  rw [Equiv.permCongr_def]
-  rfl
+  apply congrArg x
+  rw [Equiv.symm_apply_eq, Equiv.permCongr_apply]
+  simp only [Equiv.symm_symm, Equiv.ulift_apply, Equiv.ulift_symm_apply,
+    Equiv.apply_symm_apply, ULift.up_down]
+
+/-- The underlying root-datum automorphism moves character coordinates by the associated
+permutation. -/
+@[simp]
+theorem diagonalNormalizerQuotientMulEquivWeylGroup_weightMap_apply
+    (q : Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n))
+    (x : ULift.{u} (Fin n) →₀ ℤ) :
+    (diagonalNormalizerQuotientMulEquivWeylGroup k n q).1.weightMap x =
+      Finsupp.domLCongr (R := ℤ)
+        (Equiv.ulift.symm.permCongrHom
+          (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q)) x := by
+  rw [diagonalNormalizerQuotientMulEquivWeylGroup]
+  rw [MulEquiv.trans_apply,
+    diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_weightMap_apply]
+  exact SplitTorus.coordinatePermMulEquivWeylGroup_weightMap_apply _ _
+
+/-- The underlying root-datum automorphism acts contravariantly on cocharacters through the
+associated coordinate permutation. -/
+@[simp]
+theorem diagonalNormalizerQuotientMulEquivWeylGroup_coweightMap_apply
+    (q : Subgroup.normalizerQuotient (TauCeti.diagonalTorus k n))
+    (x : ULift.{u} (Fin n) → ℤ) (a : ULift.{u} (Fin n)) :
+    (diagonalNormalizerQuotientMulEquivWeylGroup k n q).1.coweightMap x a =
+      x (ULift.up
+        (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q a.down)) := by
+  rw [diagonalNormalizerQuotientMulEquivWeylGroup]
+  simp only [MulEquiv.trans_apply, Equiv.permCongrHom_coe,
+    diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_coweightMap_apply,
+    SplitTorus.coordinatePermMulEquivWeylGroup_coweightMap_apply,
+    Equiv.permCongr_apply, Equiv.symm_symm, Equiv.ulift_apply, Equiv.ulift_symm_apply]
 
 /-- The Weyl element represented by a normalizer class applies the associated coordinate
 permutation simultaneously to both entries of a root index. -/
@@ -177,11 +239,12 @@ theorem diagonalNormalizerQuotientMulEquivWeylGroup_indexEquiv_apply
         (Equiv.ulift.symm.permCongrHom
           (diagonalNormalizerQuotientMulEquivPerm (k := k) (n := n) q)) p := by
   rw [diagonalNormalizerQuotientMulEquivWeylGroup]
-  rw [MulEquiv.trans_apply, MulEquiv.trans_apply,
-    diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_indexEquiv_apply]
+  rw [MulEquiv.trans_apply, MulEquiv.trans_apply]
+  rw [diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_indexEquiv_apply]
   exact SplitTorus.coordinatePermMulEquivWeylGroup_indexEquiv_apply _ _
 
 /-- A transposition matrix maps to reflection in the corresponding diagonal root. -/
+@[simp high]
 theorem diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap
     (i j : Fin n) (hij : i ≠ j) :
     diagonalNormalizerQuotientMulEquivWeylGroup k n
@@ -218,22 +281,21 @@ theorem diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap
       exact SplitTorus.coordinatePermMulEquivWeylGroup_swap _ _ _
     _ = _ := diagonalWeylGroupMulEquivCoordinateWeylGroup_symm_ofIdx _
 
-/-- Conversely, the reflection in `e_i - e_j` corresponds to the normalizer class of the
-transposition matrix swapping the two coordinate lines. -/
+/-- Conversely, a diagonal-root reflection corresponds to the normalizer class of the
+transposition matrix swapping its two coordinate lines. -/
 @[simp]
 theorem diagonalNormalizerQuotientMulEquivWeylGroup_symm_ofIdx
-    (i j : Fin n) (hij : i ≠ j) :
+    (p : DiagonalRootIndex n) :
     (diagonalNormalizerQuotientMulEquivWeylGroup k n).symm
-        (RootPairing.weylGroup.ofIdx
-          (diagonalRootDatum.{u} n)
-          (⟨(ULift.up i, ULift.up j), fun h ↦ hij (congrArg ULift.down h)⟩ :
-            DiagonalRootIndex n)) =
-      (⟨permutationGL (k := k) (Equiv.swap i j),
-        permutationGL_mem_normalizer (Equiv.swap i j)⟩ :
+        (RootPairing.weylGroup.ofIdx (diagonalRootDatum.{u} n) p) =
+      (⟨permutationGL (k := k) (Equiv.swap p.1.1.down p.1.2.down),
+        permutationGL_mem_normalizer (Equiv.swap p.1.1.down p.1.2.down)⟩ :
         Subgroup.normalizer (TauCeti.diagonalTorus k n : Set (GL (Fin n) k))) := by
+  rcases p with ⟨⟨⟨i⟩, ⟨j⟩⟩, hij⟩
+  have hij' : i ≠ j := fun h ↦ hij (congrArg ULift.up h)
   apply (diagonalNormalizerQuotientMulEquivWeylGroup k n).injective
   rw [MulEquiv.apply_symm_apply,
-    diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap]
+    diagonalNormalizerQuotientMulEquivWeylGroup_permutationGL_swap i j hij']
 
 end
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Normalizer.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Normalizer.lean
@@ -27,6 +27,8 @@ Weyl group of the corresponding coordinate root datum with the same permutation 
 * `TauCeti.mem_normalizer_diagonalTorus_iff_exists`: normalizing matrices are precisely products
   of a diagonal matrix and a permutation matrix.
 * `TauCeti.diagonalNormalizerPerm`: the permutation homomorphism from the normalizer.
+* `TauCeti.diagonalNormalizer_mul_diagGL_mul_inv`: conjugation by a normalizer element relabels
+  diagonal coordinates by its coordinate permutation.
 * `TauCeti.diagonalNormalizerQuotientMulEquivPerm`: the normalizer quotient is the symmetric
   group.
 
@@ -437,23 +439,53 @@ noncomputable def diagonalNormalizerPerm :
   map_one' := diagonalNormalizerPermFun_one
   map_mul' := diagonalNormalizerPermFun_mul
 
+/-- A monomial factorization of a diagonal-normalizer element has the coordinate permutation
+selected by `diagonalNormalizerPerm`. -/
+theorem diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL
+    (g : Subgroup.normalizer (diagonalTorus k n : Set (GL (Fin n) k)))
+    (d : Fin n → kˣ) (σ : Equiv.Perm (Fin n))
+    (h : (g : GL (Fin n) k) = diagGL d * permutationGL (k := k) σ) :
+    diagonalNormalizerPerm (k := k) (n := n) g = σ := by
+  apply permutation_eq_of_diagGL_mul_permutationGL_eq (k := k)
+  exact (diagonalNormalizer_factor g).symm.trans h
+
 /-- The coordinate permutation induced by a permutation matrix is the original permutation. -/
 @[simp]
 theorem diagonalNormalizerPerm_permutationGL (σ : Equiv.Perm (Fin n)) :
     diagonalNormalizerPerm (k := k) (n := n)
         ⟨permutationGL (k := k) σ, permutationGL_mem_normalizer σ⟩ = σ := by
-  -- Unfold only the homomorphism's value so uniqueness can identify its chosen factor.
-  change diagonalNormalizerPermFun
-    ⟨permutationGL (k := k) σ, permutationGL_mem_normalizer σ⟩ = σ
   have hone : permutationGL (k := k) σ =
       diagGL (fun _ ↦ (1 : kˣ)) * permutationGL (k := k) σ := by
     -- Present the trivial diagonal factor as the image of the identity.
     change permutationGL (k := k) σ =
       diagGL (1 : Fin n → kˣ) * permutationGL (k := k) σ
     rw [map_one, one_mul]
-  apply permutation_eq_of_diagGL_mul_permutationGL_eq (k := k)
-  exact (diagonalNormalizer_factor
-    ⟨permutationGL (k := k) σ, permutationGL_mem_normalizer σ⟩).symm.trans hone
+  exact diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL _ _ σ hone
+
+/-- Conjugation by a diagonal-normalizer element relabels the diagonal entries by its coordinate
+permutation: the entry at `i` becomes the original entry at the inverse image of `i`. -/
+@[simp]
+theorem diagonalNormalizer_mul_diagGL_mul_inv
+    (g : Subgroup.normalizer (diagonalTorus k n : Set (GL (Fin n) k)))
+    (t : Fin n → kˣ) :
+    (g : GL (Fin n) k) * diagGL t * (g : GL (Fin n) k)⁻¹ =
+      diagGL (fun i ↦ t ((diagonalNormalizerPerm (k := k) (n := n) g).symm i)) := by
+  obtain ⟨d, σ, hg⟩ := mem_normalizer_diagonalTorus_iff_exists.mp g.property
+  have hσ := diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL g d σ hg
+  rw [hσ, hg]
+  calc
+    (diagGL d * permutationGL (k := k) σ) * diagGL t *
+          (diagGL d * permutationGL (k := k) σ)⁻¹ =
+        diagGL d *
+          (permutationGL (k := k) σ * diagGL t *
+            (permutationGL (k := k) σ)⁻¹) * (diagGL d)⁻¹ := by group
+    _ = diagGL d * diagGL (fun i ↦ t (σ⁻¹ i)) * (diagGL d)⁻¹ := by
+      rw [permutationGL_mul_diagGL_mul_inv]
+    _ = diagGL (fun i ↦ t (σ⁻¹ i)) := by
+      have hcomm : Commute (diagGL d) (diagGL (fun i ↦ t (σ⁻¹ i))) :=
+        (Commute.all d (fun i ↦ t (σ⁻¹ i))).map diagGL
+      rw [hcomm.eq]
+      simp
 
 /-- Every coordinate permutation is induced by a permutation matrix in the normalizer. -/
 theorem diagonalNormalizerPerm_surjective :
@@ -479,13 +511,10 @@ theorem diagonalNormalizerPerm_eq_one_iff
       ⟨diagonalNormalizerDiag g, hfactor.symm⟩
   · intro hg
     obtain ⟨d, hd⟩ := mem_diagonalTorus_iff_exists_diagGL.mp hg
-    -- Compare the chosen factorization with the factorization having identity permutation.
-    change diagonalNormalizerPermFun g = 1
     have hone : (g : GL (Fin n) k) =
         diagGL d * permutationGL (k := k) 1 := by
       rw [map_one, mul_one, hd]
-    apply permutation_eq_of_diagGL_mul_permutationGL_eq (k := k)
-    exact (diagonalNormalizer_factor g).symm.trans hone
+    exact diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL g d 1 hone
 
 /-- The normalizer of the diagonal torus modulo the torus is canonically the symmetric group. -/
 noncomputable def diagonalNormalizerQuotientMulEquivPerm :


### PR DESCRIPTION
This PR identifies the group-of-points quotient of the diagonal-torus normalizer in `GL_n(k)` with the Weyl group of the diagonal coordinate root datum, and proves compatibility with character and root-index actions, transposition reflections, and conjugation of diagonal matrices.

The exact ReductiveGroups roadmap target is Layer 7, “Root datum `(X*(T), Φ, X_*(T), Φ^∨)` of `(G, T)` with its Weyl group,” specifically its split-first stage. The designated milestone is the standard split `GL_n` example: this PR connects the already-computed diagonal normalizer quotient to the already-computed coordinate root-datum Weyl group instead of recomputing either through a parallel API. After this PR, the milestone still needs the scheme-level maximal-torus interface and the extraction of root data for arbitrary split reductive groups before proceeding to absolute and relative non-split theory.

The new equivalence composes `diagonalNormalizerQuotientMulEquivPerm`, `Equiv.permCongrHom`, and `SplitTorus.coordinatePermMulEquivWeylGroup`. Its characteristic theorems calculate normalizer representatives, permutation matrices, the action on characters and roots, both directions of the transposition/reflection correspondence, and conjugation on diagonal matrices. The small `diagonalRootDatum_eq_coordinateRootDatum` theorem exposes the defining equation of the existing opaque `diagonalRootDatum` so downstream code can use the generic coordinate-root-datum API. No Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"general-linear-normalizer-quotient-weyl-group"}-->

🤖 Prepared with Codex
