### PR TITLE
fix: render toolchain tag commands as shell

### DIFF
--- a/.github/workflows/toolchain-tags.yml
+++ b/.github/workflows/toolchain-tags.yml
@@ -12,7 +12,8 @@ name: Toolchain tags
 #
 # It posts only when the state has changed since its last message, which it reads from a
 # marker in that message rather than from any stored state. So a run that finds nothing new
-# says nothing, and a message in the topic means something happened.
+# posts nothing new. It may first make a one-time edit to add the missing `shell` language
+# to its own newest old-style command fence, without changing that report's body.
 #
 # It never creates a tag. `--create` is a manual step, because a tag is permanent.
 #

--- a/docs/toolchain-tags.md
+++ b/docs/toolchain-tags.md
@@ -45,7 +45,9 @@ never lower it.
 release becomes taggable or turns out not to be taggable. It runs on a push to `main` that
 changes `lean-toolchain`, waits for `ci.yml` to conclude on that commit, and then posts only
 if the state has changed since its last message. It reads that state from a marker in the
-message, so it stores nothing, and it never creates a tag.
+message, so it stores nothing, and it never creates a tag. Before comparing that marker,
+the bot repairs the missing `shell` language on its own newest old-style command fence;
+that one-time edit leaves the report body unchanged.
 
 The wait matters: the push lands 40 to 70 minutes before the release is taggable, because
 `ci.yml` coalesces bursts of `main` pushes and then takes 20 to 30 minutes, publishing the

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -326,7 +326,7 @@ class PostContent(unittest.TestCase):
 
     def test_it_carries_the_command_and_the_output(self):
         content = tt.post_content(self.ROWS, "0" * 16)
-        self.assertIn("```shell\npython3 scripts/toolchain_tags.py", content)
+        self.assertIn(tt.SHELL_FENCE, content)
         self.assertIn("v4.34.0", content)
         self.assertEqual(content.count("```"), 4, "two fenced blocks")
 
@@ -348,7 +348,8 @@ class PostContent(unittest.TestCase):
         # which no run of that command would produce.
         content = tt.post_content(self.ROWS, "0" * 16)
         command = content.split("```shell\n")[1].split("\n```")[0].strip()
-        self.assertEqual(command, "python3 scripts/toolchain_tags.py --brief")
+        self.assertEqual(command, tt.BRIEF_COMMAND)
+        self.assertEqual(tt.BRIEF_COMMAND, "python3 scripts/toolchain_tags.py --brief")
         shown = content.split("```text")[1].split("```")[0].strip()
         produced = tt.render(self.ROWS, include_policy=False, collapse_old=True).strip()
         self.assertEqual(shown, produced)
@@ -407,14 +408,25 @@ class PostIfChanged(unittest.TestCase):
         self.assertEqual(fake.sent, [])
         self.assertEqual(fake.updated, [])
 
-    def test_it_updates_formatting_when_the_state_is_unchanged(self):
+    def test_it_repairs_the_old_fence_when_the_state_is_unchanged(self):
         digest = tt.state_digest(self.ROWS)
-        old = tt.post_content(self.ROWS, digest).replace("```shell", "```", 1)
+        old = tt.post_content(self.ROWS, digest).replace(tt.SHELL_FENCE, tt.OLD_FENCE, 1)
         fake = FakeZulip([self._message(digest, content=old)])
         self._zulip(fake)
-        self.assertTrue(tt.post_if_changed(self.ROWS))
+        self.assertFalse(tt.post_if_changed(self.ROWS))
         self.assertEqual(fake.sent, [])
         self.assertEqual(fake.updated, [(1, tt.post_content(self.ROWS, digest))])
+
+    def test_it_does_not_rewrite_other_content_when_the_state_is_unchanged(self):
+        digest = tt.state_digest(self.ROWS)
+        older_rows = [dict(row, reason="older wording") for row in self.ROWS]
+        old = tt.post_content(older_rows, digest)
+        self.assertNotEqual(old, tt.post_content(self.ROWS, digest))
+        fake = FakeZulip([self._message(digest, content=old)])
+        self._zulip(fake)
+        self.assertFalse(tt.post_if_changed(self.ROWS))
+        self.assertEqual(fake.sent, [])
+        self.assertEqual(fake.updated, [])
 
     def test_it_posts_when_the_state_changed(self):
         fake = FakeZulip([self._message("0" * 16)])
@@ -422,11 +434,11 @@ class PostIfChanged(unittest.TestCase):
         self.assertTrue(tt.post_if_changed(self.ROWS))
 
     def test_it_corrects_the_old_fence_before_posting_a_new_state(self):
-        old = tt.post_content(self.ROWS, "0" * 16).replace("```shell", "```", 1)
+        old = tt.post_content(self.ROWS, "0" * 16).replace(tt.SHELL_FENCE, tt.OLD_FENCE, 1)
         fake = FakeZulip([self._message("0" * 16, content=old)])
         self._zulip(fake)
         self.assertTrue(tt.post_if_changed(self.ROWS))
-        self.assertEqual(fake.updated, [(1, old.replace("```", "```shell", 1))])
+        self.assertEqual(fake.updated, [(1, old.replace(tt.OLD_FENCE, tt.SHELL_FENCE, 1))])
         self.assertEqual(fake.sent, [tt.post_content(self.ROWS, tt.state_digest(self.ROWS))])
 
     def test_it_ignores_messages_from_other_accounts(self):

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -326,7 +326,7 @@ class PostContent(unittest.TestCase):
 
     def test_it_carries_the_command_and_the_output(self):
         content = tt.post_content(self.ROWS, "0" * 16)
-        self.assertIn("python3 scripts/toolchain_tags.py", content)
+        self.assertIn("```shell\npython3 scripts/toolchain_tags.py", content)
         self.assertIn("v4.34.0", content)
         self.assertEqual(content.count("```"), 4, "two fenced blocks")
 
@@ -347,7 +347,7 @@ class PostContent(unittest.TestCase):
         # command while displaying output with the policy stripped and rows collapsed,
         # which no run of that command would produce.
         content = tt.post_content(self.ROWS, "0" * 16)
-        command = content.split("```")[1].strip()
+        command = content.split("```shell\n")[1].split("\n```")[0].strip()
         self.assertEqual(command, "python3 scripts/toolchain_tags.py --brief")
         shown = content.split("```text")[1].split("```")[0].strip()
         produced = tt.render(self.ROWS, include_policy=False, collapse_old=True).strip()
@@ -359,6 +359,7 @@ class FakeZulip:
         self.messages = list(messages or [])
         self.bot_id = bot_id
         self.sent = []
+        self.updated = []
 
     def my_user_id(self):
         return self.bot_id
@@ -368,6 +369,9 @@ class FakeZulip:
 
     def send_message(self, content):
         self.sent.append(content)
+
+    def update_message(self, message_id, content):
+        self.updated.append((message_id, content))
 
 
 class PostIfChanged(unittest.TestCase):
@@ -385,10 +389,9 @@ class PostIfChanged(unittest.TestCase):
             self.addCleanup(lambda n=name, o=old:
                             os.environ.__setitem__(n, o) if o else os.environ.pop(n, None))
 
-    def _message(self, digest, sender=7):
+    def _message(self, digest, sender=7, content=None):
         return {"id": 1, "sender_id": sender,
-                "content": ("whatever\n"
-                            f"<!--toolchain-tags:v1 {digest}-->")}
+                "content": content or tt.post_content(self.ROWS, digest)}
 
     def test_it_posts_when_nothing_has_been_posted(self):
         fake = FakeZulip()
@@ -402,6 +405,16 @@ class PostIfChanged(unittest.TestCase):
         self._zulip(fake)
         self.assertFalse(tt.post_if_changed(self.ROWS))
         self.assertEqual(fake.sent, [])
+        self.assertEqual(fake.updated, [])
+
+    def test_it_updates_formatting_when_the_state_is_unchanged(self):
+        digest = tt.state_digest(self.ROWS)
+        old = tt.post_content(self.ROWS, digest).replace("```shell", "```", 1)
+        fake = FakeZulip([self._message(digest, content=old)])
+        self._zulip(fake)
+        self.assertTrue(tt.post_if_changed(self.ROWS))
+        self.assertEqual(fake.sent, [])
+        self.assertEqual(fake.updated, [(1, tt.post_content(self.ROWS, digest))])
 
     def test_it_posts_when_the_state_changed(self):
         fake = FakeZulip([self._message("0" * 16)])

--- a/scripts/test_toolchain_tags.py
+++ b/scripts/test_toolchain_tags.py
@@ -421,6 +421,14 @@ class PostIfChanged(unittest.TestCase):
         self._zulip(fake)
         self.assertTrue(tt.post_if_changed(self.ROWS))
 
+    def test_it_corrects_the_old_fence_before_posting_a_new_state(self):
+        old = tt.post_content(self.ROWS, "0" * 16).replace("```shell", "```", 1)
+        fake = FakeZulip([self._message("0" * 16, content=old)])
+        self._zulip(fake)
+        self.assertTrue(tt.post_if_changed(self.ROWS))
+        self.assertEqual(fake.updated, [(1, old.replace("```", "```shell", 1))])
+        self.assertEqual(fake.sent, [tt.post_content(self.ROWS, tt.state_digest(self.ROWS))])
+
     def test_it_ignores_messages_from_other_accounts(self):
         # A human replying in the topic must not be mistaken for the last report.
         digest = tt.state_digest(self.ROWS)

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -497,6 +497,9 @@ def create_tag(row, dry_run=False):
 # --- waiting, and posting to Zulip ------------------------------------------
 
 MARKER_RE = re.compile(r"<!--toolchain-tags:v1 ([0-9a-f]{16})-->\s*\Z")
+BRIEF_COMMAND = "python3 scripts/toolchain_tags.py --brief"
+SHELL_FENCE = f"```shell\n{BRIEF_COMMAND}\n```"
+OLD_FENCE = f"```\n{BRIEF_COMMAND}\n```"
 
 
 def wait_for_ci(sha, timeout_minutes=180, poll_seconds=120, sleep=None):
@@ -546,15 +549,15 @@ def post_content(rows, digest):
     body = render(rows, include_policy=False, collapse_old=True).rstrip()
     # The command shown must be the one that produced what is shown. --brief is exactly
     # this transformation, so someone can paste it and get the same thing back.
-    return (f"```shell\npython3 scripts/toolchain_tags.py --brief\n```\n"
+    return (f"{SHELL_FENCE}\n"
             f"```text\n{body}\n```\n"
             f"<!--toolchain-tags:v1 {digest}-->")
 
 
 def post_if_changed(rows, dry_run=False):
-    """Post when the state changed, or update formatting in the current report.
+    """Repair a legacy command fence, then post when the state changed.
 
-    Returns True if a message was posted or updated."""
+    Returns True only if a new message was posted."""
     digest = state_digest(rows)
     content = post_content(rows, digest)
     if dry_run:
@@ -569,20 +572,15 @@ def post_if_changed(rows, dry_run=False):
     z = zp.Zulip(email, api_key, site)
     zp.check(z)
     message, previous = last_posted_report(z, z.my_user_id())
-    old_fence = "```\npython3 scripts/toolchain_tags.py --brief\n```"
-    shell_fence = "```shell\npython3 scripts/toolchain_tags.py --brief\n```"
-    if message and previous != digest and old_fence in message["content"]:
-        corrected = message["content"].replace(old_fence, shell_fence, 1)
+    # One-time migration for reports posted before the command fence specified `shell`.
+    # It can be removed after the existing old-style report has been repaired.
+    if message and OLD_FENCE in message["content"]:
+        corrected = message["content"].replace(OLD_FENCE, SHELL_FENCE, 1)
         log(f"correcting the shell fence in message {message['id']}")
         z.update_message(message["id"], corrected)
-        message = dict(message, content=corrected)
-    if previous == digest and message["content"] == content:
+    if previous == digest:
         log(f"state unchanged since the last post ({digest}); saying nothing")
         return False
-    if previous == digest:
-        log(f"state unchanged ({digest}), but report formatting changed; updating")
-        z.update_message(message["id"], content)
-        return True
     log(f"state changed ({previous or 'nothing posted yet'} -> {digest}); posting")
     z.send_message(content)
     return True

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -569,6 +569,13 @@ def post_if_changed(rows, dry_run=False):
     z = zp.Zulip(email, api_key, site)
     zp.check(z)
     message, previous = last_posted_report(z, z.my_user_id())
+    old_fence = "```\npython3 scripts/toolchain_tags.py --brief\n```"
+    shell_fence = "```shell\npython3 scripts/toolchain_tags.py --brief\n```"
+    if message and previous != digest and old_fence in message["content"]:
+        corrected = message["content"].replace(old_fence, shell_fence, 1)
+        log(f"correcting the shell fence in message {message['id']}")
+        z.update_message(message["id"], corrected)
+        message = dict(message, content=corrected)
     if previous == digest and message["content"] == content:
         log(f"state unchanged since the last post ({digest}); saying nothing")
         return False

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -523,8 +523,8 @@ def log(message):
     print(message, flush=True)
 
 
-def last_posted_digest(z, bot_id):
-    """The digest carried by this account's newest message in the topic, or None.
+def last_posted_report(z, bot_id):
+    """This account's newest marked message and its digest, or (None, None).
 
     The previous state lives in the topic rather than in a file, so the poster keeps no
     state of its own and a wiped topic simply reposts."""
@@ -537,8 +537,8 @@ def last_posted_digest(z, bot_id):
             continue
         match = MARKER_RE.search(message["content"])
         if match:
-            return match.group(1)
-    return None
+            return message, match.group(1)
+    return None, None
 
 
 def post_content(rows, digest):
@@ -546,14 +546,15 @@ def post_content(rows, digest):
     body = render(rows, include_policy=False, collapse_old=True).rstrip()
     # The command shown must be the one that produced what is shown. --brief is exactly
     # this transformation, so someone can paste it and get the same thing back.
-    return (f"```\npython3 scripts/toolchain_tags.py --brief\n```\n"
+    return (f"```shell\npython3 scripts/toolchain_tags.py --brief\n```\n"
             f"```text\n{body}\n```\n"
             f"<!--toolchain-tags:v1 {digest}-->")
 
 
 def post_if_changed(rows, dry_run=False):
-    """Post the report when the state has changed since the last message. Returns True if
-    a message was posted."""
+    """Post when the state changed, or update formatting in the current report.
+
+    Returns True if a message was posted or updated."""
     digest = state_digest(rows)
     content = post_content(rows, digest)
     if dry_run:
@@ -567,10 +568,14 @@ def post_if_changed(rows, dry_run=False):
         raise RuntimeError("ZULIP_EMAIL / ZULIP_API_KEY are not set")
     z = zp.Zulip(email, api_key, site)
     zp.check(z)
-    previous = last_posted_digest(z, z.my_user_id())
-    if previous == digest:
+    message, previous = last_posted_report(z, z.my_user_id())
+    if previous == digest and message["content"] == content:
         log(f"state unchanged since the last post ({digest}); saying nothing")
         return False
+    if previous == digest:
+        log(f"state unchanged ({digest}), but report formatting changed; updating")
+        z.update_message(message["id"], content)
+        return True
     log(f"state changed ({previous or 'nothing posted yet'} -> {digest}); posting")
     z.send_message(content)
     return True


### PR DESCRIPTION
This PR marks the command block in toolchain-tag Zulip reports as `shell`. On its next run, the bot repairs the old-style fence in its current report before reconciling the latest state, so the linked post is fixed even though the release-state digest has since changed.

Tested with `python3 scripts/test_toolchain_tags.py`.

Roadmap: none

:robot: Prepared with OpenAI Codex