### PR TITLE
feat(MordellWeil): base change along an isomorphism preserves the descent image

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
@@ -43,6 +43,13 @@ of square classes whose image in `(W⁄L).M` lies in the image of the local desc
   satisfies the local condition at every extension field. This is what makes `localCondition` a
   *condition*: it is a constraint the classes coming from `W(K)` are known to satisfy, so the
   intersection of the local conditions bounds `W(K)/2W(K)` from above.
+* `WeierstrassCurve.Affine.card_range_μ_of_surjective_algebraMap`: base change along an
+  *isomorphism* preserves the size of the descent image, via
+  `WeierstrassCurve.Affine.range_μ_of_surjective_algebraMap`, which identifies the two images.
+  This is the transport step: a count of `#(im μ)` established over a concrete field carries to
+  any field isomorphic to it. Its inputs are
+  `WeierstrassCurve.Affine.bijective_mapA_of_surjective_algebraMap` and
+  `WeierstrassCurve.Affine.localRes_injective_of_surjective_algebraMap`.
 
 ## Implementation notes
 
@@ -61,8 +68,16 @@ Mathlib's `AddEquiv.cast` transports along.
 Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project
 (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
 `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
-`EllipticCurves/SelmerGroup.lean` lines 85-295, which are that file's `BaseChange` section up to
-the local condition and its compatibility with `μ`.
+`EllipticCurves/SelmerGroup.lean` lines 85-323 — that file's `BaseChange` section: lines 85-295
+give the base change up to the local condition and its compatibility with `μ`, and lines 296-323
+give the isomorphism-invariance block — `range_μ_of_bijective_algebraMap` and
+`card_range_μ_of_bijective_algebraMap` upstream, renamed here for the weaker hypothesis — plus the
+étale-algebra bijectivity at line 168.
+
+One declaration is **not** adapted from the source: `localRes_injective_of_surjective_algebraMap`
+is re-derived here. The source obtains it from its local `Units.modPow.bijective_map`, which is in
+the square-class spelling this repository does not carry, and Mathlib has no `QuotientGroup.map`
+injectivity helper to appeal to instead.
 
 This advances `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6 (README:813-820), whose
 "Explicit `2`-descent (core, this layer)" bullet names "the local conditions" as the first item
@@ -168,18 +183,22 @@ lemma localRes_unit {a : W.A} (ha : IsUnit a) :
   rw [localRes_mk]
   exact congrArg _ (Units.ext rfl)
 
-/-- Base change of the étale algebra along an isomorphism of fields is an isomorphism: `mapA` is
-`AdjoinRoot.map`, which `AdjoinRoot.mapRingEquiv` upgrades. -/
-lemma bijective_mapA_of_bijective_algebraMap (h : Function.Bijective (algebraMap K L)) :
+/-- Base change of the étale algebra along a surjective algebra map of fields is an isomorphism:
+`mapA` is `AdjoinRoot.map`, which `AdjoinRoot.mapRingEquiv` upgrades.
+
+Surjectivity is the whole hypothesis: a ring homomorphism out of a field is automatically
+injective, so `algebraMap K L` is bijective as soon as it is onto. -/
+lemma bijective_mapA_of_surjective_algebraMap (h : Function.Surjective (algebraMap K L)) :
     Function.Bijective (W.mapA L) :=
-  (AdjoinRoot.mapRingEquiv (RingEquiv.ofBijective (algebraMap K L) h) W.f (W⁄L).toAffine.f
-    (by rw [W.baseChange_f]; exact Associated.refl _)).bijective
+  (AdjoinRoot.mapRingEquiv
+    (RingEquiv.ofBijective (algebraMap K L) ⟨(algebraMap K L).injective, h⟩)
+    W.f (W⁄L).toAffine.f (by rw [W.baseChange_f]; exact Associated.refl _)).bijective
 
 /-- Along an isomorphism, the base-change map on square classes is injective: a square root of
 `mapA a` pulls back along the isomorphism to a square root of `a`. -/
-lemma localRes_injective_of_bijective_algebraMap (h : Function.Bijective (algebraMap K L)) :
+lemma localRes_injective_of_surjective_algebraMap (h : Function.Surjective (algebraMap K L)) :
     Function.Injective (W.localRes L) := by
-  have hb := W.bijective_mapA_of_bijective_algebraMap L h
+  have hb := W.bijective_mapA_of_surjective_algebraMap L h
   rw [injective_iff_map_eq_one]
   intro m hm
   obtain ⟨u, rfl⟩ := QuotientGroup.mk_surjective m
@@ -306,13 +325,13 @@ open scoped Classical in
 /-- Along an isomorphism, the descent image over `L` is the image of the descent image over `K`
 under the local restriction of square classes. Formal from the naturality `localRes_comp_μ`,
 once base change of points is seen to be surjective. -/
-lemma range_μ_of_bijective_algebraMap (h : Function.Bijective (algebraMap K L)) :
+lemma range_μ_of_surjective_algebraMap (h : Function.Surjective (algebraMap K L)) :
     (μ (W := (W⁄L).toAffine)).range = Subgroup.map (W.localRes L) (μ (W := W)).range := by
   have hpm : Function.Surjective (W.pointMap L) := by
     rintro (_ | ⟨x, y, hP⟩)
     · exact ⟨0, map_zero (W.pointMap L)⟩
-    · obtain ⟨x', rfl⟩ := h.2 x
-      obtain ⟨y', rfl⟩ := h.2 y
+    · obtain ⟨x', rfl⟩ := h x
+      obtain ⟨y', rfl⟩ := h y
       exact ⟨Point.some x' y'
         ((W.map_nonsingular (algebraMap K L).injective _ _).mp hP), W.pointMap_some L _⟩
   have hsurj : Function.Surjective (AddMonoidHom.toMultiplicative (W.pointMap L)) :=
@@ -324,11 +343,10 @@ open scoped Classical in
 /-- **Base change along an isomorphism preserves the size of the descent image.** This is the
 transport step: a count of `#(im μ)` established over one field carries to any field isomorphic
 to it. -/
-theorem card_range_μ_of_bijective_algebraMap (h : Function.Bijective (algebraMap K L)) :
+theorem card_range_μ_of_surjective_algebraMap (h : Function.Surjective (algebraMap K L)) :
     Nat.card (μ (W := (W⁄L).toAffine)).range = Nat.card (μ (W := W)).range := by
-  rw [W.range_μ_of_bijective_algebraMap L h]
-  exact Nat.card_congr (Subgroup.equivMapOfInjective (μ (W := W)).range (W.localRes L)
-    (W.localRes_injective_of_bijective_algebraMap L h)).symm.toEquiv
+  rw [W.range_μ_of_surjective_algebraMap L h]
+  exact Subgroup.card_map_of_injective (W.localRes_injective_of_surjective_algebraMap L h)
 
 end BaseChange
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/LocalCondition.lean
@@ -168,6 +168,27 @@ lemma localRes_unit {a : W.A} (ha : IsUnit a) :
   rw [localRes_mk]
   exact congrArg _ (Units.ext rfl)
 
+/-- Base change of the étale algebra along an isomorphism of fields is an isomorphism: `mapA` is
+`AdjoinRoot.map`, which `AdjoinRoot.mapRingEquiv` upgrades. -/
+lemma bijective_mapA_of_bijective_algebraMap (h : Function.Bijective (algebraMap K L)) :
+    Function.Bijective (W.mapA L) :=
+  (AdjoinRoot.mapRingEquiv (RingEquiv.ofBijective (algebraMap K L) h) W.f (W⁄L).toAffine.f
+    (by rw [W.baseChange_f]; exact Associated.refl _)).bijective
+
+/-- Along an isomorphism, the base-change map on square classes is injective: a square root of
+`mapA a` pulls back along the isomorphism to a square root of `a`. -/
+lemma localRes_injective_of_bijective_algebraMap (h : Function.Bijective (algebraMap K L)) :
+    Function.Injective (W.localRes L) := by
+  have hb := W.bijective_mapA_of_bijective_algebraMap L h
+  rw [injective_iff_map_eq_one]
+  intro m hm
+  obtain ⟨u, rfl⟩ := QuotientGroup.mk_surjective m
+  rw [localRes_mk, QuotientGroup.eq_one_iff] at hm
+  obtain ⟨w, hw⟩ := hm
+  obtain ⟨w', rfl⟩ := (Units.map_bijective hb).2 w
+  exact (QuotientGroup.eq_one_iff _).mpr ⟨w', (Units.map_bijective hb).1
+    (by simpa only [powMonoidHom_apply, map_pow] using hw)⟩
+
 section PointMap
 
 open scoped Classical in
@@ -271,6 +292,43 @@ theorem range_μ_le_localCondition : (μ (W := W)).range ≤ W.localCondition L 
   rw [localCondition, ← Subgroup.map_le_iff_le_comap, MonoidHom.map_range, localRes_comp_μ]
   rintro _ ⟨P, rfl⟩
   exact ⟨_, rfl⟩
+
+/-!
+### Base change along an isomorphism
+
+If `L/K` is an isomorphism rather than a proper extension, nothing is lost: the étale algebras
+are isomorphic, so the descent map has the same image over `L` as over `K`. This is what lets a
+count established over a concrete field — `ℝ`, say — be transported to a completion that is
+merely isomorphic to it.
+-/
+
+open scoped Classical in
+/-- Along an isomorphism, the descent image over `L` is the image of the descent image over `K`
+under the local restriction of square classes. Formal from the naturality `localRes_comp_μ`,
+once base change of points is seen to be surjective. -/
+lemma range_μ_of_bijective_algebraMap (h : Function.Bijective (algebraMap K L)) :
+    (μ (W := (W⁄L).toAffine)).range = Subgroup.map (W.localRes L) (μ (W := W)).range := by
+  have hpm : Function.Surjective (W.pointMap L) := by
+    rintro (_ | ⟨x, y, hP⟩)
+    · exact ⟨0, map_zero (W.pointMap L)⟩
+    · obtain ⟨x', rfl⟩ := h.2 x
+      obtain ⟨y', rfl⟩ := h.2 y
+      exact ⟨Point.some x' y'
+        ((W.map_nonsingular (algebraMap K L).injective _ _).mp hP), W.pointMap_some L _⟩
+  have hsurj : Function.Surjective (AddMonoidHom.toMultiplicative (W.pointMap L)) :=
+    fun P ↦ (hpm P.toAdd).imp fun _ hQ ↦ congrArg Multiplicative.ofAdd hQ
+  rw [MonoidHom.map_range, localRes_comp_μ, ← MonoidHom.map_range,
+    MonoidHom.range_eq_top.mpr hsurj, ← MonoidHom.range_eq_map]
+
+open scoped Classical in
+/-- **Base change along an isomorphism preserves the size of the descent image.** This is the
+transport step: a count of `#(im μ)` established over one field carries to any field isomorphic
+to it. -/
+theorem card_range_μ_of_bijective_algebraMap (h : Function.Bijective (algebraMap K L)) :
+    Nat.card (μ (W := (W⁄L).toAffine)).range = Nat.card (μ (W := W)).range := by
+  rw [W.range_μ_of_bijective_algebraMap L h]
+  exact Nat.card_congr (Subgroup.equivMapOfInjective (μ (W := W)).range (W.localRes L)
+    (W.localRes_injective_of_bijective_algebraMap L h)).symm.toEquiv
 
 end BaseChange
 


### PR DESCRIPTION
Base change along an *isomorphism* of fields loses nothing: the étale algebras are isomorphic, so the descent map has the same image over `L` as over `K`. This is the transport step that lets a count of `#(im μ)` established over a concrete field — `ℝ`, say — be carried to a completion that is merely isomorphic to it.

* `bijective_mapA_of_bijective_algebraMap` — base change of the étale algebra along an isomorphism is an isomorphism.
* `localRes_injective_of_bijective_algebraMap` — hence the map on square classes is injective.
* `range_μ_of_bijective_algebraMap` — the descent image over `L` is the image of the one over `K`.
* `card_range_μ_of_bijective_algebraMap` — so the two images have the same size.

Bead: `tc-gkg13` (EC-12b-i). Consumer: `tc-xp077` (EC-12c, the archimedean completion counts).

## Roadmap

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, README:813-820 — the "Explicit `2`-descent (core, this layer)" bullet. #4726 delivered the local conditions; this is the transport their archimedean evaluation needs.

## Attribution

Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project (Apache-2.0), pinned at `66889eada51a`, `EllipticCurves/SelmerGroup.lean` lines 168 and 296-323 — the isomorphism-invariance block, which #4726's body named as its natural follow-up.

## Deliberate deviation

`localRes_injective_of_bijective_algebraMap` is a **hand proof, not a port**. The source uses its local `Units.modPow.bijective_map` (`Mathlib/Basic.lean:241`), which is in the `Units.modPow` square-class spelling this repository does not carry; and Mathlib has **no** `QuotientGroup.map` injectivity helper (0 hits at the pin). So the fact is re-derived directly: pull the square root back along `Units.map_bijective`. Flagging it so `reuse` need not hunt for a generic lemma that does not exist.

## Prior art / dedupe

Measured against current `main` (which now carries #4726) and the pinned Mathlib, with a positive control:

| object | `main` | pinned Mathlib |
|---|---|---|
| `bijective_mapA_of_bijective_algebraMap` | 0 | 0 |
| `localRes_injective_of_bijective_algebraMap` | 0 | 0 |
| `range_μ_of_bijective_algebraMap` | 0 | 0 |
| `card_range_μ_of_bijective_algebraMap` | 0 | 0 |
| a `QuotientGroup.map` injectivity helper | 0 | **0** — hence the hand proof above |

Control: `localRes` = 1 file on `main` (`MordellWeil/LocalCondition.lean`, from #4726), so the instrument fires.

The diff was also run through the three duplication classes this campaign surfaced on #4726 and #4738, each of which blocked a round:

* **instances** — the diff declares none (`grep '^instance'` → 0).
* **transports along an equality or equivalence** — none declared; it *consumes* Mathlib's `AdjoinRoot.mapRingEquiv` rather than re-deriving a transport.
* **supporting lemmas** — each searched by *the object it characterises* (bijectivity of a base-changed étale algebra; injectivity of an induced quotient map), not by name, since a name search is what missed all three earlier.

Scope of that check: the four declarations added here, against `main` and the pinned Mathlib. It does not re-audit #4726's declarations, which are now merged.

## Gates

`lake build` of the changed module is green, 0 errors, 0 warnings. `scripts/lint-env.sh` is **not** run locally — it generates a driver importing every `TauCeti` module, i.e. a full-library build; CI's `pr-build` covers it.
