### PR TITLE
feat: compare maximal unipotent candidate dimensions

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -39,6 +39,8 @@ needed in Layer 2 of the ReductiveGroups roadmap.
 * `TauCeti.HopfIdeal.ker_quotientCotangentMap`: its kernel is the conormal subspace.
 * `TauCeti.HopfIdeal.finrank_quotientLie_add_finrank_conormal`: the resulting dimension formula.
 * `TauCeti.HopfIdeal.finrank_quotientLie_le`: the resulting closed-subgroup dimension bound.
+* `TauCeti.HopfIdeal.finrank_quotientLie_antitone`: inclusion of closed subgroups cannot increase
+  Lie dimension.
 
 ## References
 
@@ -88,6 +90,14 @@ theorem mem_conormalSubspace_iff (I : HopfIdeal k H)
     exact ⟨y, hy, rfl⟩
   · rintro ⟨y, hy, rfl⟩
     exact ⟨y, hy, rfl⟩
+
+/-- Enlarging the defining Hopf ideal enlarges the conormal space of the corresponding closed
+subgroup at the identity. -/
+theorem conormalSubspace_mono {I J : HopfIdeal k H} (hIJ : I ≤ J) :
+    conormalSubspace I ≤ conormalSubspace J := by
+  rw [conormalSubspace, conormalSubspace]
+  exact Submodule.map_mono (Submodule.restrictScalars_mono k
+    (HopfIdeal.toIdeal_le_toIdeal.mpr hIJ))
 
 /-- The quotient map carries the augmentation ideal of `H` into the augmentation ideal of
 `H/I`. -/
@@ -270,6 +280,23 @@ theorem finrank_quotientLie_le (I : HopfIdeal k H)
       Module.finrank k
         (Derivation k H (Bialgebra.CounitAlgebra k H k)) := by
   have h := finrank_quotientLie_add_finrank_conormal I
+  omega
+
+/-- Lie dimension is antitone in the defining Hopf ideal: if `I ≤ J`, then the closed subgroup
+cut out by `J` is contained in the one cut out by `I`, so its Lie dimension is no larger. -/
+theorem finrank_quotientLie_antitone
+    [FiniteDimensional k (Bialgebra.CotangentSpace k H)] :
+    Antitone fun I : HopfIdeal k H ↦
+      Module.finrank k
+        (Derivation k (H ⧸ I.toIdeal)
+          (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) := by
+  intro I J hIJ
+  dsimp only
+  have hI := finrank_quotientLie_add_finrank_conormal I
+  have hJ := finrank_quotientLie_add_finrank_conormal J
+  have hconormal : Module.finrank k (conormalSubspace I) ≤
+      Module.finrank k (conormalSubspace J) :=
+    Submodule.finrank_mono (conormalSubspace_mono hIJ)
   omega
 
 end Field

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -6,11 +6,9 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.Dual.Lemmas
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Tangent
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Cotangent
 import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
-import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
 import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
 
 /-!
@@ -43,9 +41,6 @@ needed in Layer 2 of the ReductiveGroups roadmap.
 * `TauCeti.HopfIdeal.finrank_quotientLie_le`: the resulting closed-subgroup dimension bound.
 * `TauCeti.HopfIdeal.finrank_quotientLie_antitone`: inclusion of closed subgroups cannot increase
   Lie dimension.
-* `TauCeti.HopfIdeal.derivationCompLieHom_quotientMapOfLe_bijective_of_finrank_eq`: equal Lie
-  dimensions make the tangent map induced by an inclusion of finite-type closed subgroups
-  bijective.
 
 ## References
 
@@ -305,44 +300,6 @@ theorem finrank_quotientLie_antitone
   omega
 
 end Field
-
-section FiniteType
-
-variable [Field k] (H : FiniteTypeCommHopfAlgCat.{u, v} k)
-
-/-- The tangent map induced by an inclusion of finite-type closed subgroups is bijective when
-their Lie algebras have equal dimension. -/
-theorem derivationCompLieHom_quotientMapOfLe_bijective_of_finrank_eq
-    {I J : HopfIdeal k H} (hIJ : I ≤ J)
-    (hfinrank :
-      Module.finrank k
-          (Derivation k (H ⧸ J.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ J.toIdeal) k)) =
-        Module.finrank k
-          (Derivation k (H ⧸ I.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k))) :
-    Function.Bijective
-      (derivationCompLieHom (B := k)
-        (FiniteTypeCommHopfAlgCat.toBialgHom
-          (FiniteTypeCommHopfAlgCat.quotientMapOfLe H hIJ))) := by
-  let : Algebra.FiniteType k (H ⧸ I.toIdeal) :=
-    (FiniteTypeCommHopfAlgCat.quotient H I).property
-  let : Algebra.FiniteType k (H ⧸ J.toIdeal) :=
-    (FiniteTypeCommHopfAlgCat.quotient H J).property
-  let f := FiniteTypeCommHopfAlgCat.toBialgHom
-    (FiniteTypeCommHopfAlgCat.quotientMapOfLe H hIJ)
-  have hinjective : Function.Injective (derivationCompLieHom (B := k) f) := by
-    intro d e hde
-    apply derivationComp_injective_of_surjective f
-      (FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hIJ)
-    simpa only [derivationCompLieHom_apply] using hde
-  refine ⟨hinjective, ?_⟩
-  simpa only [LieHom.coe_toLinearMap] using
-    (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
-      (f := (derivationCompLieHom (B := k) f : _ →ₗ[k] _)) hfinrank).mp
-      (by simpa only [LieHom.coe_toLinearMap] using hinjective)
-
-end FiniteType
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -6,9 +6,11 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.LinearAlgebra.Dual.Lemmas
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Tangent
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Cotangent
 import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
+import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
 import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
 
 /-!
@@ -41,6 +43,9 @@ needed in Layer 2 of the ReductiveGroups roadmap.
 * `TauCeti.HopfIdeal.finrank_quotientLie_le`: the resulting closed-subgroup dimension bound.
 * `TauCeti.HopfIdeal.finrank_quotientLie_antitone`: inclusion of closed subgroups cannot increase
   Lie dimension.
+* `TauCeti.HopfIdeal.derivationCompLieHom_quotientMapOfLe_bijective_of_finrank_eq`: equal Lie
+  dimensions make the tangent map induced by an inclusion of finite-type closed subgroups
+  bijective.
 
 ## References
 
@@ -300,6 +305,44 @@ theorem finrank_quotientLie_antitone
   omega
 
 end Field
+
+section FiniteType
+
+variable [Field k] (H : FiniteTypeCommHopfAlgCat.{u, v} k)
+
+/-- The tangent map induced by an inclusion of finite-type closed subgroups is bijective when
+their Lie algebras have equal dimension. -/
+theorem derivationCompLieHom_quotientMapOfLe_bijective_of_finrank_eq
+    {I J : HopfIdeal k H} (hIJ : I ≤ J)
+    (hfinrank :
+      Module.finrank k
+          (Derivation k (H ⧸ J.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ J.toIdeal) k)) =
+        Module.finrank k
+          (Derivation k (H ⧸ I.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k))) :
+    Function.Bijective
+      (derivationCompLieHom (B := k)
+        (FiniteTypeCommHopfAlgCat.toBialgHom
+          (FiniteTypeCommHopfAlgCat.quotientMapOfLe H hIJ))) := by
+  let : Algebra.FiniteType k (H ⧸ I.toIdeal) :=
+    (FiniteTypeCommHopfAlgCat.quotient H I).property
+  let : Algebra.FiniteType k (H ⧸ J.toIdeal) :=
+    (FiniteTypeCommHopfAlgCat.quotient H J).property
+  let f := FiniteTypeCommHopfAlgCat.toBialgHom
+    (FiniteTypeCommHopfAlgCat.quotientMapOfLe H hIJ)
+  have hinjective : Function.Injective (derivationCompLieHom (B := k) f) := by
+    intro d e hde
+    apply derivationComp_injective_of_surjective f
+      (FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hIJ)
+    simpa only [derivationCompLieHom_apply] using hde
+  refine ⟨hinjective, ?_⟩
+  simpa only [LieHom.coe_toLinearMap] using
+    (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+      (f := (derivationCompLieHom (B := k) f : _ →ₗ[k] _)) hfinrank).mp
+      (by simpa only [LieHom.coe_toLinearMap] using hinjective)
+
+end FiniteType
 
 end HopfIdeal
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -40,6 +40,8 @@ the finite-type coordinate-Hopf-algebra category.
   the quotient by a Hopf ideal kills that ideal.
 * `TauCeti.CommHopfAlgCat.quotientMapOfLe`: the morphism `H ⧸ I ⟶ H ⧸ J` induced by
   `I ≤ J`.
+* `TauCeti.CommHopfAlgCat.quotientMapOfLe_surjective`: quotient-to-quotient coordinate maps are
+  surjective.
 * `TauCeti.CommHopfAlgCat.quotientBotIso`: quotienting by the zero Hopf ideal does not
   change a commutative Hopf algebra.
 * `TauCeti.CommHopfAlgCat.quotientIsoOfSurjective`: a surjective ambient morphism identifies
@@ -418,6 +420,14 @@ lemma quotientMapOfLe_mk (H : _root_.CommHopfAlgCat.{v} R) {I J : HopfIdeal R H}
     (quotientMapOfLe H hIJ).hom (Ideal.Quotient.mkₐ R I.toIdeal h) =
       Ideal.Quotient.mkₐ R J.toIdeal h := by
   rw [quotientMapOfLe, liftQuotient_mk, mkQuotient_apply]
+
+/-- A quotient-to-quotient coordinate morphism induced by an inclusion of Hopf ideals is
+surjective. -/
+theorem quotientMapOfLe_surjective (H : _root_.CommHopfAlgCat.{v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    Function.Surjective (quotientMapOfLe H hIJ).hom :=
+  liftQuotient_surjective_of_surjective I (mkQuotient H J)
+    (toIdeal_le_ker_mkQuotient_of_le H hIJ) (mkQuotient_surjective H J)
 
 /-- Composing the quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient morphism for
 `I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean
@@ -42,6 +42,8 @@ the finite-type coordinate-Hopf-algebra category.
   `I ≤ J`.
 * `TauCeti.CommHopfAlgCat.quotientMapOfLe_surjective`: quotient-to-quotient coordinate maps are
   surjective.
+* `TauCeti.FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective`: the finite-type form of
+  quotient-to-quotient surjectivity.
 * `TauCeti.CommHopfAlgCat.quotientBotIso`: quotienting by the zero Hopf ideal does not
   change a commutative Hopf algebra.
 * `TauCeti.CommHopfAlgCat.quotientIsoOfSurjective`: a surjective ambient morphism identifies
@@ -616,6 +618,13 @@ lemma quotientMapOfLe_mk (H : FiniteTypeCommHopfAlgCat.{u, v} R)
     (toBialgHom (quotientMapOfLe H hIJ)) (Ideal.Quotient.mkₐ R I.toIdeal h) =
       Ideal.Quotient.mkₐ R J.toIdeal h :=
   CommHopfAlgCat.quotientMapOfLe_mk H.obj hIJ h
+
+/-- A finite-type quotient-to-quotient coordinate morphism induced by an inclusion of Hopf
+ideals is surjective. -/
+theorem quotientMapOfLe_surjective (H : FiniteTypeCommHopfAlgCat.{u, v} R)
+    {I J : HopfIdeal R H} (hIJ : I ≤ J) :
+    Function.Surjective (toBialgHom (quotientMapOfLe H hIJ)) :=
+  CommHopfAlgCat.quotientMapOfLe_surjective H.obj hIJ
 
 /-- Composing the finite-type quotient map `H ⟶ H ⧸ I` with the quotient-to-quotient
 morphism for `I ≤ J` gives the quotient map `H ⟶ H ⧸ J`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
@@ -79,17 +79,10 @@ lemma quotientLieHom_apply_apply (I : HopfIdeal R H)
 
 /-- The differential of a closed-subgroup inclusion is injective. -/
 theorem quotientLieHom_injective (I : HopfIdeal R H) :
-    Function.Injective (quotientLieHom (B := B) I) := by
-  have hsurjective : Function.Surjective
-      (Bialgebra.Quotient.mkBialgHom (R := R) I.toIdeal) := by
-    intro q
-    obtain ⟨x, hx⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-    exact ⟨x, (Bialgebra.Quotient.mkBialgHom_apply I.toIdeal x).trans
-      ((congrFun (Ideal.Quotient.mkₐ_eq_mk R I.toIdeal) x).symm.trans hx)⟩
-  intro d e hde
-  apply derivationComp_injective_of_surjective (B := B)
-    (Bialgebra.Quotient.mkBialgHom (R := R) I.toIdeal) hsurjective
-  simpa only [quotientLieHom, derivationCompLieHom_apply] using hde
+    Function.Injective (quotientLieHom (B := B) I) :=
+  derivationCompLieHom_injective_of_surjective
+    (Bialgebra.Quotient.mkBialgHom (R := R) I.toIdeal)
+    Ideal.Quotient.mk_surjective
 
 /-- The Lie subalgebra of the ambient tangent Lie algebra cut out by a Hopf ideal.
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
@@ -80,21 +80,16 @@ lemma quotientLieHom_apply_apply (I : HopfIdeal R H)
 /-- The differential of a closed-subgroup inclusion is injective. -/
 theorem quotientLieHom_injective (I : HopfIdeal R H) :
     Function.Injective (quotientLieHom (B := B) I) := by
+  have hsurjective : Function.Surjective
+      (Bialgebra.Quotient.mkBialgHom (R := R) I.toIdeal) := by
+    intro q
+    obtain ⟨x, hx⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
+    exact ⟨x, (Bialgebra.Quotient.mkBialgHom_apply I.toIdeal x).trans
+      ((congrFun (Ideal.Quotient.mkₐ_eq_mk R I.toIdeal) x).symm.trans hx)⟩
   intro d e hde
-  apply Derivation.ext
-  intro q
-  obtain ⟨x, rfl⟩ := Ideal.Quotient.mkₐ_surjective R I.toIdeal q
-  apply (Bialgebra.CounitAlgebra.algEquivSelf R (H ⧸ I.toIdeal) B).injective
-  have hx := congrArg
-    (fun f => Bialgebra.CounitAlgebra.algEquivSelf R H B (f x)) hde
-  simp only [quotientLieHom_apply_apply] at hx
-  rw [Bialgebra.CounitAlgebra.algEquivSelf_apply R H B
-      (Bialgebra.CounitAlgebra.algEquivSelf R (H ⧸ I.toIdeal) B
-        (d (Ideal.Quotient.mkₐ R I.toIdeal x))),
-    Bialgebra.CounitAlgebra.algEquivSelf_apply R H B
-      (Bialgebra.CounitAlgebra.algEquivSelf R (H ⧸ I.toIdeal) B
-        (e (Ideal.Quotient.mkₐ R I.toIdeal x)))] at hx
-  exact hx
+  apply derivationComp_injective_of_surjective (B := B)
+    (Bialgebra.Quotient.mkBialgHom (R := R) I.toIdeal) hsurjective
+  simpa only [quotientLieHom, derivationCompLieHom_apply] using hde
 
 /-- The Lie subalgebra of the ambient tangent Lie algebra cut out by a Hopf ideal.
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -164,6 +164,8 @@ lemma algEquivSelf_derivationComp_apply (φ : A' →ₐc[R] A)
   rw [derivationComp_apply]
   exact
     (Bialgebra.CounitAlgebra.algEquivSelf_apply R A' B
+      -- Both counit algebras are definitionally copies of `B`; this `show` transports
+      -- the value to the indexing expected by the `A'`-side equivalence.
       (show Bialgebra.CounitAlgebra R A' B from
         d ((φ : A' →ₐ[R] A) a))).trans
       (Bialgebra.CounitAlgebra.algEquivSelf_apply R A B

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -22,8 +22,11 @@ therefore comes from those two facts and is not reproved here.
 
 * `TauCeti.derivationComp`: precomposition of counit-valued derivations along a
   bialgebra morphism, as an `R`-linear map — the derivation form of the differential.
-* `TauCeti.derivationComp_apply`, `TauCeti.derivationComp_id`,
-  `TauCeti.derivationComp_comp`: it acts by precomposition, functorially.
+* `TauCeti.derivationComp_apply`, `TauCeti.algEquivSelf_derivationComp_apply`,
+  `TauCeti.derivationComp_id`, `TauCeti.derivationComp_comp`: it acts by precomposition,
+  functorially and compatibly with the counit coefficient identifications.
+* `TauCeti.derivationComp_injective_of_surjective`: precomposition along a surjective
+  bialgebra morphism is injective.
 
 The intertwining with the tangent dictionaries is
 `TauCeti.tangentKerMap_derivationMulEquivTangentKer` in
@@ -149,6 +152,40 @@ lemma derivationComp_apply (φ : A' →ₐc[R] A)
   -- definitional unfolding once, explicitly.
   change derivationCompAux (B := B) φ d a = _
   rw [derivationCompAux_apply]
+
+/-- The derivation differential is literal precomposition after identifying the two counit
+coefficient algebras with the original coefficient algebra. -/
+lemma algEquivSelf_derivationComp_apply (φ : A' →ₐc[R] A)
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A') :
+    Bialgebra.CounitAlgebra.algEquivSelf R A' B
+        (derivationComp (B := B) φ d a) =
+      Bialgebra.CounitAlgebra.algEquivSelf R A B
+        (d ((φ : A' →ₐ[R] A) a)) := by
+  rw [derivationComp_apply]
+  exact
+    (Bialgebra.CounitAlgebra.algEquivSelf_apply R A' B
+      (show Bialgebra.CounitAlgebra R A' B from
+        d ((φ : A' →ₐ[R] A) a))).trans
+      (Bialgebra.CounitAlgebra.algEquivSelf_apply R A B
+        (d ((φ : A' →ₐ[R] A) a))).symm
+
+/-- Precomposition of derivations along a surjective bialgebra morphism is injective. -/
+theorem derivationComp_injective_of_surjective (φ : A' →ₐc[R] A)
+    (hφ : Function.Surjective φ) :
+    Function.Injective (derivationComp (B := B) φ) := by
+  intro d e hde
+  apply Derivation.ext
+  intro a
+  obtain ⟨a', rfl⟩ := hφ a
+  have hvalue := DFunLike.congr_fun hde a'
+  apply (Bialgebra.CounitAlgebra.algEquivSelf R A B).injective
+  calc
+    _ = Bialgebra.CounitAlgebra.algEquivSelf R A' B
+          (derivationComp (B := B) φ d a') :=
+      (algEquivSelf_derivationComp_apply φ d a').symm
+    _ = Bialgebra.CounitAlgebra.algEquivSelf R A' B
+          (derivationComp (B := B) φ e a') := congrArg _ hvalue
+    _ = _ := algEquivSelf_derivationComp_apply φ e a'
 
 /-- Precomposition along the identity is the identity map. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Equivariance.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Equivariance.lean
@@ -49,22 +49,6 @@ variable [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
 variable [CommSemiring A'] [HopfAlgebra R A']
 variable [CommSemiring B] [Algebra R B]
 
-private lemma algEquivSelf_derivationComp_apply (φ : A' →ₐc[R] A)
-    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A') :
-    Bialgebra.CounitAlgebra.algEquivSelf R A' B
-        (derivationComp (B := B) φ d a) =
-      Bialgebra.CounitAlgebra.algEquivSelf R A B
-        (d ((φ : A' →ₐ[R] A) a)) := by
-  rw [derivationComp_apply]
-  exact
-    (Bialgebra.CounitAlgebra.algEquivSelf_apply R A' B
-      -- Both counit algebras are definitionally copies of `B`; this `show` transports
-      -- the value to the indexing expected by the `A'`-side equivalence.
-      (show Bialgebra.CounitAlgebra R A' B from
-        d ((φ : A' →ₐ[R] A) a))).trans
-      (Bialgebra.CounitAlgebra.algEquivSelf_apply R A B
-        (d ((φ : A' →ₐ[R] A) a))).symm
-
 private lemma derivationComp_toLinearMap (φ : A' →ₐc[R] A)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
     (derivationComp (B := B) φ d :

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
@@ -23,6 +23,8 @@ termwise; the algebra half already entered in `derivationComp`, which needs
 
 * `TauCeti.derivationComp_bracket`: the differential preserves the bracket.
 * `TauCeti.derivationCompLieHom`: the differential as a morphism of Lie algebras.
+* `TauCeti.derivationCompLieHom_injective_of_surjective`: a surjective coordinate morphism
+  induces an injective tangent map.
 -/
 
 public section
@@ -156,6 +158,31 @@ lemma derivationCompLieHom_apply (φ : A' →ₐc[R] A)
   -- its definitional unfolding once, explicitly.
   change derivationComp (B := B) φ d = _
   rfl
+
+/-- A surjective morphism of coordinate bialgebras induces an injective map on tangent Lie
+algebras. -/
+theorem derivationCompLieHom_injective_of_surjective (φ : A' →ₐc[R] A)
+    (hφ : Function.Surjective φ) :
+    Function.Injective (derivationCompLieHom (B := B) φ) := by
+  intro d e hde
+  apply Derivation.ext
+  intro a
+  obtain ⟨a', rfl⟩ := hφ a
+  have hvalue := DFunLike.congr_fun hde a'
+  apply (Bialgebra.CounitAlgebra.algEquivSelf R A B).injective
+  calc
+    Bialgebra.CounitAlgebra.algEquivSelf R A B (d (φ a')) =
+        Bialgebra.CounitAlgebra.algEquivSelf R A' B
+          (derivationCompLieHom (B := B) φ d a') := by
+      rw [derivationCompLieHom_apply, derivationComp_apply]
+      exact (Bialgebra.CounitAlgebra.algEquivSelf_apply R A B _).trans
+        (Bialgebra.CounitAlgebra.algEquivSelf_apply R A' B _).symm
+    _ = Bialgebra.CounitAlgebra.algEquivSelf R A' B
+          (derivationCompLieHom (B := B) φ e a') := congrArg _ hvalue
+    _ = Bialgebra.CounitAlgebra.algEquivSelf R A B (e (φ a')) := by
+      rw [derivationCompLieHom_apply, derivationComp_apply]
+      exact (Bialgebra.CounitAlgebra.algEquivSelf_apply R A' B _).trans
+        (Bialgebra.CounitAlgebra.algEquivSelf_apply R A B _).symm
 
 /-- The bundled differential along the identity is the identity Lie morphism. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
@@ -23,8 +23,6 @@ termwise; the algebra half already entered in `derivationComp`, which needs
 
 * `TauCeti.derivationComp_bracket`: the differential preserves the bracket.
 * `TauCeti.derivationCompLieHom`: the differential as a morphism of Lie algebras.
-* `TauCeti.derivationCompLieHom_injective_of_surjective`: a surjective coordinate morphism
-  induces an injective tangent map.
 -/
 
 public section
@@ -130,24 +128,11 @@ noncomputable def derivationCompLieHom (φ : A' →ₐc[R] A) :
   map_smul' b d := by
     ext a
     apply (Bialgebra.CounitAlgebra.algEquivSelf R A' B).injective
-    calc
-      _ = Bialgebra.CounitAlgebra.algEquivSelf R A B
-          ((b • d) ((φ : A' →ₐ[R] A) a)) := by
-        rw [derivationComp_apply]
-        exact (Bialgebra.CounitAlgebra.algEquivSelf_apply R A' B _).trans
-          (Bialgebra.CounitAlgebra.algEquivSelf_apply R A B _).symm
-      _ = b * Bialgebra.CounitAlgebra.algEquivSelf R A B (d ((φ : A' →ₐ[R] A) a)) :=
-        algEquivSelf_derivation_smul_apply (R := R) (A := A) b d _
-      _ = b * Bialgebra.CounitAlgebra.algEquivSelf R A' B
-          (derivationComp (B := B) φ d a) := by
-        congr 1
-        rw [derivationComp_apply]
-        exact (Bialgebra.CounitAlgebra.algEquivSelf_apply R A B _).trans
-          (Bialgebra.CounitAlgebra.algEquivSelf_apply R A' B _).symm
-      _ = _ := by
-        simpa only [RingHom.id_apply] using
-          (algEquivSelf_derivation_smul_apply (R := R) (A := A') b
-            (derivationComp (B := B) φ d) a).symm
+    rw [algEquivSelf_derivationComp_apply,
+      algEquivSelf_derivation_smul_apply,
+      algEquivSelf_derivation_smul_apply,
+      algEquivSelf_derivationComp_apply]
+    simp only [RingHom.id_apply]
   map_lie' := derivationComp_bracket φ _ _
 
 @[simp]
@@ -158,31 +143,6 @@ lemma derivationCompLieHom_apply (φ : A' →ₐc[R] A)
   -- its definitional unfolding once, explicitly.
   change derivationComp (B := B) φ d = _
   rfl
-
-/-- A surjective morphism of coordinate bialgebras induces an injective map on tangent Lie
-algebras. -/
-theorem derivationCompLieHom_injective_of_surjective (φ : A' →ₐc[R] A)
-    (hφ : Function.Surjective φ) :
-    Function.Injective (derivationCompLieHom (B := B) φ) := by
-  intro d e hde
-  apply Derivation.ext
-  intro a
-  obtain ⟨a', rfl⟩ := hφ a
-  have hvalue := DFunLike.congr_fun hde a'
-  apply (Bialgebra.CounitAlgebra.algEquivSelf R A B).injective
-  calc
-    Bialgebra.CounitAlgebra.algEquivSelf R A B (d (φ a')) =
-        Bialgebra.CounitAlgebra.algEquivSelf R A' B
-          (derivationCompLieHom (B := B) φ d a') := by
-      rw [derivationCompLieHom_apply, derivationComp_apply]
-      exact (Bialgebra.CounitAlgebra.algEquivSelf_apply R A B _).trans
-        (Bialgebra.CounitAlgebra.algEquivSelf_apply R A' B _).symm
-    _ = Bialgebra.CounitAlgebra.algEquivSelf R A' B
-          (derivationCompLieHom (B := B) φ e a') := congrArg _ hvalue
-    _ = Bialgebra.CounitAlgebra.algEquivSelf R A B (e (φ a')) := by
-      rw [derivationCompLieHom_apply, derivationComp_apply]
-      exact (Bialgebra.CounitAlgebra.algEquivSelf_apply R A' B _).trans
-        (Bialgebra.CounitAlgebra.algEquivSelf_apply R A B _).symm
 
 /-- The bundled differential along the identity is the identity Lie morphism. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
@@ -5,8 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.LinearAlgebra.Dimension.Finrank
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.DerivationMap
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 
 /-!
 # The differential is a Lie algebra morphism
@@ -23,6 +25,10 @@ termwise; the algebra half already entered in `derivationComp`, which needs
 
 * `TauCeti.derivationComp_bracket`: the differential preserves the bracket.
 * `TauCeti.derivationCompLieHom`: the differential as a morphism of Lie algebras.
+* `TauCeti.derivationCompLieHom_injective_of_surjective`: the differential of a surjective
+  bialgebra morphism is injective.
+* `TauCeti.derivationCompLieHom_bijective_of_surjective_of_finrank_eq`: a surjective
+  bialgebra morphism between equal-dimensional tangent Lie algebras induces a bijection.
 -/
 
 public section
@@ -144,6 +150,14 @@ lemma derivationCompLieHom_apply (φ : A' →ₐc[R] A)
   change derivationComp (B := B) φ d = _
   rfl
 
+/-- The differential of a surjective bialgebra morphism is injective. -/
+theorem derivationCompLieHom_injective_of_surjective (φ : A' →ₐc[R] A)
+    (hφ : Function.Surjective φ) :
+    Function.Injective (derivationCompLieHom (B := B) φ) := by
+  intro d e hde
+  apply derivationComp_injective_of_surjective φ hφ
+  simpa only [derivationCompLieHom_apply] using hde
+
 /-- The bundled differential along the identity is the identity Lie morphism. -/
 @[simp]
 theorem derivationCompLieHom_id :
@@ -164,5 +178,29 @@ theorem derivationCompLieHom_comp {A'' : Type*} [CommRing A''] [Bialgebra R A'']
     LinearMap.coe_comp, Function.comp_apply]
 
 end LieHom
+
+section FiniteDimensional
+
+variable {k A A' : Type*} [Field k] [CommRing A] [Bialgebra k A]
+  [CommRing A'] [Bialgebra k A']
+  [Module.Finite k (Derivation k A (Bialgebra.CounitAlgebra k A k))]
+  [Module.Finite k (Derivation k A' (Bialgebra.CounitAlgebra k A' k))]
+
+/-- A surjective bialgebra morphism between equal-dimensional tangent Lie algebras induces a
+bijection on tangent Lie algebras. -/
+theorem derivationCompLieHom_bijective_of_surjective_of_finrank_eq
+    (φ : A' →ₐc[k] A) (hφ : Function.Surjective φ)
+    (hfinrank :
+      Module.finrank k (Derivation k A (Bialgebra.CounitAlgebra k A k)) =
+        Module.finrank k (Derivation k A' (Bialgebra.CounitAlgebra k A' k))) :
+    Function.Bijective (derivationCompLieHom (B := k) φ) := by
+  have hinjective := derivationCompLieHom_injective_of_surjective (B := k) φ hφ
+  refine ⟨hinjective, ?_⟩
+  simpa only [LieHom.coe_toLinearMap] using
+    (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+      (f := (derivationCompLieHom (B := k) φ : _ →ₗ[k] _)) hfinrank).mp
+      (by simpa only [LieHom.coe_toLinearMap] using hinjective)
+
+end FiniteDimensional
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -24,7 +24,9 @@ algebra and is therefore trivial, proving that `U` contains every candidate.
 
 ## Main declarations
 
-* `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate.finrank_quotientLie_productOfNormal_eq_of_maximal`:
+The declarations are in `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate`.
+
+* `finrank_quotientLie_productOfNormal_eq_of_maximal`:
   multiplying a maximal-dimensional candidate by any candidate preserves its Lie dimension.
 * `derivationCompLieHom_productOfNormal_bijective_of_maximal`:
   the inclusion of a maximal candidate into its product with another candidate induces a
@@ -54,11 +56,7 @@ variable {k : Type u} [Field k]
 variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
 
 /-- Multiplying a maximal-dimensional unipotent-radical candidate by any other candidate does
-not change its Lie dimension.
-
-The product contains the maximal candidate, so antitonicity of Lie dimension in the defining
-Hopf ideal gives one inequality. The product is itself a candidate, so maximality gives the
-other. -/
+not change its Lie dimension. -/
 theorem finrank_quotientLie_productOfNormal_eq_of_maximal
     (hI : IsUnipotentRadicalCandidate H I)
     (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
@@ -88,10 +86,7 @@ theorem finrank_quotientLie_productOfNormal_eq_of_maximal
       (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)
 
 /-- The closed-subgroup inclusion from a maximal-dimensional unipotent-radical candidate into
-its product with another candidate induces a bijection on tangent Lie algebras.
-
-Injectivity is the tangent-space consequence of surjectivity of the coordinate quotient map;
-surjectivity then follows because the source and target have equal finite dimension. -/
+its product with another candidate induces a bijection on tangent Lie algebras. -/
 theorem derivationCompLieHom_productOfNormal_bijective_of_maximal
     (hI : IsUnipotentRadicalCandidate H I)
     (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
@@ -108,15 +103,9 @@ theorem derivationCompLieHom_productOfNormal_bijective_of_maximal
           (FiniteTypeCommHopfAlgCat.quotientMapOfLe H
             (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)))) := by
   let hPI := CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal
-  let f := FiniteTypeCommHopfAlgCat.quotientMapOfLe H hPI
-  have hf : Function.Surjective (FiniteTypeCommHopfAlgCat.toBialgHom f) :=
-    FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hPI
-  have hinjective : Function.Injective
-      (derivationCompLieHom (B := k) (FiniteTypeCommHopfAlgCat.toBialgHom f)) :=
-    derivationCompLieHom_injective_of_surjective (FiniteTypeCommHopfAlgCat.toBialgHom f) hf
   have hfinrank := hI.finrank_quotientLie_productOfNormal_eq_of_maximal hmax hJ
-  refine ⟨hinjective, ?_⟩
-  exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hfinrank.symm).mp hinjective
+  exact HopfIdeal.derivationCompLieHom_quotientMapOfLe_bijective_of_finrank_eq
+    H hPI hfinrank.symm
 
 end HopfIdeal.IsUnipotentRadicalCandidate
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -26,7 +26,7 @@ algebra and is therefore trivial, proving that `U` contains every candidate.
 
 * `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate.finrank_quotientLie_productOfNormal_eq_of_maximal`:
   multiplying a maximal-dimensional candidate by any candidate preserves its Lie dimension.
-* `bijective_derivationCompLieHom_productOfNormal_of_maximal`:
+* `derivationCompLieHom_productOfNormal_bijective_of_maximal`:
   the inclusion of a maximal candidate into its product with another candidate induces a
   bijection on tangent Lie algebras.
 
@@ -92,7 +92,7 @@ its product with another candidate induces a bijection on tangent Lie algebras.
 
 Injectivity is the tangent-space consequence of surjectivity of the coordinate quotient map;
 surjectivity then follows because the source and target have equal finite dimension. -/
-theorem bijective_derivationCompLieHom_productOfNormal_of_maximal
+theorem derivationCompLieHom_productOfNormal_bijective_of_maximal
     (hI : IsUnipotentRadicalCandidate H I)
     (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
       Module.finrank k
@@ -104,13 +104,16 @@ theorem bijective_derivationCompLieHom_productOfNormal_of_maximal
     (hJ : IsUnipotentRadicalCandidate H J) :
     Function.Bijective
       (derivationCompLieHom (B := k)
-        (CommHopfAlgCat.quotientMapOfLe H.obj
-          (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)).hom) := by
+        (FiniteTypeCommHopfAlgCat.toBialgHom
+          (FiniteTypeCommHopfAlgCat.quotientMapOfLe H
+            (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)))) := by
   let hPI := CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal
-  let f := CommHopfAlgCat.quotientMapOfLe H.obj hPI
-  have hf : Function.Surjective f.hom := CommHopfAlgCat.quotientMapOfLe_surjective H.obj hPI
-  have hinjective : Function.Injective (derivationCompLieHom (B := k) f.hom) :=
-    derivationCompLieHom_injective_of_surjective f.hom hf
+  let f := FiniteTypeCommHopfAlgCat.quotientMapOfLe H hPI
+  have hf : Function.Surjective (FiniteTypeCommHopfAlgCat.toBialgHom f) :=
+    FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hPI
+  have hinjective : Function.Injective
+      (derivationCompLieHom (B := k) (FiniteTypeCommHopfAlgCat.toBialgHom f)) :=
+    derivationCompLieHom_injective_of_surjective (FiniteTypeCommHopfAlgCat.toBialgHom f) hf
   have hfinrank := hI.finrank_quotientLie_productOfNormal_eq_of_maximal hmax hJ
   refine ⟨hinjective, ?_⟩
   exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hfinrank.symm).mp hinjective

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Product
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
+import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
+
+/-!
+# Maximal-dimensional unipotent-radical candidates
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over a field. The existing
+maximal-dimension construction chooses a connected normal smooth unipotent closed subgroup `U`
+whose Lie dimension is at least that of every other such subgroup. The existing product theorem
+shows that the scheme-theoretic product `UV` is another candidate containing both `U` and `V`.
+
+This file combines those two inputs. Containment makes Lie dimension monotone, while maximality
+gives the reverse inequality, so `U` and `UV` have equal Lie dimension for every candidate `V`.
+This is the equality needed to show that the connected quotient `UV/U` has zero-dimensional Lie
+algebra and is therefore trivial, proving that `U` contains every candidate.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate.finrank_quotientLie_productOfNormal_eq_of_maximal`:
+  multiplying a maximal-dimensional candidate by any candidate preserves its Lie dimension.
+* `bijective_derivationCompLieHom_productOfNormal_of_maximal`:
+  the inclusion of a maximal candidate into its product with another candidate induces a
+  bijection on tangent Lie algebras.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§6.45--6.46.
+* A. Borel, *Linear Algebraic Groups*, §11.21.
+
+This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap. It is the
+dimension-comparison step between binary-product closure and the zero-dimensional quotient
+argument that makes a maximal candidate the greatest candidate.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal.IsUnipotentRadicalCandidate
+
+variable {k : Type u} [Field k]
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
+
+/-- Multiplying a maximal-dimensional unipotent-radical candidate by any other candidate does
+not change its Lie dimension.
+
+The product contains the maximal candidate, so antitonicity of Lie dimension in the defining
+Hopf ideal gives one inequality. The product is itself a candidate, so maximality gives the
+other. -/
+theorem finrank_quotientLie_productOfNormal_eq_of_maximal
+    (hI : IsUnipotentRadicalCandidate H I)
+    (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
+      Module.finrank k
+          (Derivation k (H ⧸ K.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
+        Module.finrank k
+          (Derivation k (H ⧸ I.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
+    (hJ : IsUnipotentRadicalCandidate H J) :
+    Module.finrank k
+        (Derivation k
+          (H ⧸ (HopfIdeal.ker
+            (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom).toIdeal)
+          (Bialgebra.CounitAlgebra k
+            (H ⧸ (HopfIdeal.ker
+              (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom).toIdeal) k)) =
+      Module.finrank k
+        (Derivation k (H ⧸ I.toIdeal)
+          (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) := by
+  let P : HopfIdeal k H :=
+    HopfIdeal.ker (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom
+  have hP : IsUnipotentRadicalCandidate H P := hI.productOfNormal hJ
+  apply le_antisymm
+  · exact hmax P hP
+  · exact HopfIdeal.finrank_quotientLie_antitone
+      (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)
+
+/-- The closed-subgroup inclusion from a maximal-dimensional unipotent-radical candidate into
+its product with another candidate induces a bijection on tangent Lie algebras.
+
+Injectivity is the tangent-space consequence of surjectivity of the coordinate quotient map;
+surjectivity then follows because the source and target have equal finite dimension. -/
+theorem bijective_derivationCompLieHom_productOfNormal_of_maximal
+    (hI : IsUnipotentRadicalCandidate H I)
+    (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
+      Module.finrank k
+          (Derivation k (H ⧸ K.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
+        Module.finrank k
+          (Derivation k (H ⧸ I.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
+    (hJ : IsUnipotentRadicalCandidate H J) :
+    Function.Bijective
+      (derivationCompLieHom (B := k)
+        (CommHopfAlgCat.quotientMapOfLe H.obj
+          (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)).hom) := by
+  let hPI := CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal
+  let f := CommHopfAlgCat.quotientMapOfLe H.obj hPI
+  have hf : Function.Surjective f.hom := CommHopfAlgCat.quotientMapOfLe_surjective H.obj hPI
+  have hinjective : Function.Injective (derivationCompLieHom (B := k) f.hom) :=
+    derivationCompLieHom_injective_of_surjective f.hom hf
+  have hfinrank := hI.finrank_quotientLie_productOfNormal_eq_of_maximal hmax hJ
+  refine ⟨hinjective, ?_⟩
+  exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hfinrank.symm).mp hinjective
+
+end HopfIdeal.IsUnipotentRadicalCandidate
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Product
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
-import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
 
 /-!
 # Maximal-dimensional unipotent-radical candidates
@@ -104,8 +103,8 @@ theorem derivationCompLieHom_productOfNormal_bijective_of_maximal
             (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)))) := by
   let hPI := CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal
   have hfinrank := hI.finrank_quotientLie_productOfNormal_eq_of_maximal hmax hJ
-  exact HopfIdeal.derivationCompLieHom_quotientMapOfLe_bijective_of_finrank_eq
-    H hPI hfinrank.symm
+  exact derivationCompLieHom_bijective_of_surjective_of_finrank_eq _
+    (FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hPI) hfinrank.symm
 
 end HopfIdeal.IsUnipotentRadicalCandidate
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Product
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
+import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
 
 /-!
 # Maximal-dimensional unipotent-radical candidates


### PR DESCRIPTION
This PR proves that multiplying a maximal-Lie-dimension unipotent-radical candidate by any other candidate preserves its Lie dimension, and strengthens the comparison to show that the resulting closed-subgroup inclusion induces a bijection on tangent Lie algebras.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5, “The unipotent radical `R_u(G)`,” whose milestone is the maximal connected normal unipotent closed subgroup. The milestone’s maximal-dimension construction now has both inputs needed before the quotient step: merged binary-product closure gives another candidate containing the maximal one, while this PR shows that containment has equal Lie dimension and an isomorphism on tangent spaces. This directly connects the maximal candidate chosen by `exists_isUnipotentRadicalCandidate_maximal_finrank_quotientLie` to the product candidate constructed by `IsUnipotentRadicalCandidate.productOfNormal`.

After this PR, it remains to represent and identify the connected normal quotient of the product candidate by the maximal candidate, use the tangent bijection to prove that quotient has zero Lie dimension, apply zero-Lie triviality, and package the resulting greatest candidate as the unipotent radical.

The supporting API is factored at its natural levels. `HopfIdeal.conormalSubspace_mono` and `HopfIdeal.finrank_quotientLie_antitone` live with the conormal sequence. `CommHopfAlgCat.quotientMapOfLe_surjective` and its finite-type form live with quotient maps. `derivationComp_injective_of_surjective` is in `Tangent/DerivationMap.lean`; the previously private `algEquivSelf_derivationComp_apply` was promoted and relocated there so this proof and the Lie differential reuse the same coefficient transport. `derivationCompLieHom_injective_of_surjective` and `derivationCompLieHom_bijective_of_surjective_of_finrank_eq` are in `Tangent/Lie/Map.lean`. The new `Unipotent/Radical/Maximal.lean` module proves `finrank_quotientLie_productOfNormal_eq_of_maximal` and `derivationCompLieHom_productOfNormal_bijective_of_maximal`.

The mathematical organization follows Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§6.45–6.46, and Borel, *Linear Algebraic Groups*, §11.21, as credited in the module documentation. No Mathlib infrastructure is vendored; the proof reuses Mathlib’s quotient surjectivity, submodule-finrank monotonicity, and equal-finrank injective/surjective criterion together with Tau Ceti’s conormal exact sequence and normal-product API.

Files changed:
- `TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean`
- `TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Basic.lean`
- `TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean`
- `TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean`
- `TauCeti/Algebra/AlgebraicGroup/Tangent/Equivariance.lean`
- `TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean`
- `TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean`

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"maximal-unipotent-candidate-product-equal-lie-dimension"}-->

🤖 Prepared with Codex
