### PR TITLE
feat: add cyclic finite quadratic modules

### DIFF
--- a/TauCeti/Algebra/AddCircle.lean
+++ b/TauCeti/Algebra/AddCircle.lean
@@ -20,6 +20,8 @@ in the unit `ℤ`-submodule.
 
 * `AddCircle.coe_eq_zero_iff_mem_one`: vanishing in `AddCircle (1 : ℚ)` is membership in
   `(1 : Submodule ℤ ℚ)`.
+* `AddCircle.zsmul_coe_eq_zero_iff_mem_one`: the same criterion for an integer multiple of a
+  rational class, which is how the torsion of a discriminant value is checked.
 -/
 
 public section
@@ -36,5 +38,11 @@ theorem coe_eq_zero_iff_mem_one (q : ℚ) :
   · intro h
     obtain ⟨n, hn⟩ := Submodule.mem_one.mp h
     exact (coe_eq_zero_iff (1 : ℚ)).mpr ⟨n, by simpa using hn⟩
+
+/-- An integer multiple of a rational class vanishes in `ℚ/ℤ` exactly when the corresponding
+rational multiple is an integer. -/
+theorem zsmul_coe_eq_zero_iff_mem_one (m : ℤ) (q : ℚ) :
+    m • ((q : ℚ) : AddCircle (1 : ℚ)) = 0 ↔ (m : ℚ) * q ∈ (1 : Submodule ℤ ℚ) := by
+  rw [← coe_zsmul, zsmul_eq_mul, coe_eq_zero_iff_mem_one]
 
 end AddCircle

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -145,8 +145,11 @@ theorem polar_cyclicMap_intCast (k l : ℤ) :
   congr 1
   ring
 
-/-- The standard generator of `cyclicMap` pairs with itself to `2a`. -/
-@[simp]
+/-- The standard generator of `cyclicMap` pairs with itself to `2a`.
+
+This is deliberately not a `simp` lemma: `QuadraticMap.polar_self` and `cyclicMap_one` already
+rewrite the left-hand side, so it is stated only for the `ℤ`-scalar form shared with
+`polar_cyclicMap_intCast`. -/
 theorem polar_cyclicMap_one_one :
     QuadraticMap.polar (cyclicMap n a hquad hpolar) 1 1 = (2 : ℤ) • a := by
   simpa using polar_cyclicMap_intCast n a hquad hpolar 1 1

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -25,8 +25,8 @@ and, for nonzero `n`, packages it as `TauCeti.FiniteQuadraticModule.cyclic`.
 The companion `TauCeti.FiniteQuadraticModule.cyclicIsometryOfGenerator` shows that an additive
 equivalence out of `ZMod n` which matches the quadratic values of the standard generators is
 automatically an isometry.  Together these declarations give the shared presented-module API
-used to identify cyclic discriminant forms, including the `Aₙ`, odd `Dₙ`, `E₆`, and `E₇`
-root lattices.
+used to identify cyclic discriminant forms; the `E₆` and `E₇` root lattices are identified this
+way, and the `Aₙ` and odd `Dₙ` rows are intended to follow.
 
 ## Main declarations
 
@@ -58,17 +58,20 @@ variable (n : ℕ) (a : AddCircle (1 : ℚ))
 
 /-! ## The presenting quadratic map on `ℤ` -/
 
-/-- The bilinear map `(x, y) ↦ xya` on `ℤ`. -/
-private def intBilin : LinearMap.BilinMap ℤ ℤ (AddCircle (1 : ℚ)) :=
-  LinearMap.mk₂ ℤ (fun x y : ℤ ↦ (x * y) • a)
-    (fun x y z ↦ by rw [add_mul, add_smul])
-    (fun r x y ↦ by rw [smul_eq_mul, mul_assoc, mul_smul])
-    (fun x y z ↦ by rw [mul_add, add_smul])
-    (fun r x y ↦ by rw [smul_eq_mul, mul_left_comm, mul_smul])
-
-/-- The quadratic map `x ↦ x²a` on `ℤ`. -/
+/-- The quadratic map `x ↦ x²a` on `ℤ`, as the squaring map followed by multiplication by `a`. -/
 private def intQuadratic : QuadraticMap ℤ ℤ (AddCircle (1 : ℚ)) :=
-  (intBilin a).toQuadraticMap
+  (LinearMap.toSpanSingleton ℤ (AddCircle (1 : ℚ)) a).compQuadraticMap (QuadraticMap.sq (R := ℤ))
+
+private theorem intQuadratic_apply (x : ℤ) : intQuadratic a x = (x * x) • a := by
+  rw [intQuadratic, LinearMap.compQuadraticMap_apply, QuadraticMap.sq_apply,
+    LinearMap.toSpanSingleton_apply]
+
+private theorem polar_intQuadratic (x y : ℤ) :
+    QuadraticMap.polar (intQuadratic a) x y = (2 * (x * y)) • a := by
+  rw [QuadraticMap.polar, intQuadratic_apply, intQuadratic_apply, intQuadratic_apply,
+    ← sub_smul, ← sub_smul]
+  congr 1
+  ring
 
 /-- The two torsion hypotheses put the multiples of `n` in the quadratic radical. -/
 private theorem zmultiples_le_radical_intQuadratic
@@ -77,22 +80,13 @@ private theorem zmultiples_le_radical_intQuadratic
   intro x hx
   obtain ⟨k, rfl⟩ := AddSubgroup.mem_zmultiples_iff.mp hx
   constructor
-  -- The first radical condition unfolds `toQuadraticMap` and `intBilin` to the explicit
-  -- quadratic value of this representative; there is no rewriting lemma for this reduction.
-  · change (((k * (n : ℤ)) * (k * n)) • a) = 0
+  · rw [intQuadratic_apply, smul_eq_mul]
     have hcoeff : (k * (n : ℤ)) * (k * n) = (k * k) * (n * n) := by ring
     rw [hcoeff, mul_smul, hquad, smul_zero]
-  · apply LinearMap.ext
-    intro y
-    -- Unfolding the polar of `toQuadraticMap` exposes the two bilinear evaluations.
-    change QuadraticMap.polar (intQuadratic a) (k • (n : ℤ)) y = 0
-    rw [intQuadratic, LinearMap.BilinMap.polar_toQuadraticMap]
-    simp only [intBilin, LinearMap.mk₂_apply, smul_eq_mul]
-    -- The preceding rewrite exposes the two `intBilin` evaluations, whose integer actions on
-    -- `a` reduce definitionally to these two explicit scalar multiples.
-    change ((k * (n : ℤ) * y) • a) + ((y * (k * n)) • a) = 0
-    rw [← add_smul]
-    have hcoeff : k * (n : ℤ) * y + y * (k * n) = (k * y) * (2 * n) := by ring
+  · refine LinearMap.ext fun y ↦ ?_
+    rw [LinearMap.zero_apply, QuadraticMap.polarBilin_apply_apply, polar_intQuadratic,
+      smul_eq_mul]
+    have hcoeff : 2 * (k * (n : ℤ) * y) = (k * y) * (2 * n) := by ring
     rw [hcoeff, mul_smul, hpolar, smul_zero]
 
 /-- The quotient of `ℤ` by the multiples of `n`, as an integer-linear equivalence with
@@ -134,8 +128,7 @@ theorem cyclicMap_intCast (k : ℤ) :
     cyclicMap n a hquad hpolar (k : ZMod n) = (k * k) • a := by
   unfold cyclicMap
   rw [QuadraticMap.comp_apply, LinearEquiv.coe_coe, intQuotientEquivZMod_symm_intCast,
-    QuadraticMap.lift_mk]
-  simp [intQuadratic, intBilin]
+    QuadraticMap.lift_mk, intQuadratic_apply]
 
 /-- The standard generator of `cyclicMap` has value `a`. -/
 @[simp]
@@ -152,28 +145,30 @@ theorem polar_cyclicMap_intCast (k l : ℤ) :
   congr 1
   ring
 
+/-- The standard generator of `cyclicMap` pairs with itself to `2a`. -/
+@[simp]
+theorem polar_cyclicMap_one_one :
+    QuadraticMap.polar (cyclicMap n a hquad hpolar) 1 1 = (2 : ℤ) • a := by
+  simpa using polar_cyclicMap_intCast n a hquad hpolar 1 1
+
 variable [NeZero n]
 
 /-- **The finite quadratic module on `ZMod n` whose standard generator has value `a`.**
 
 The nonzero-modulus hypothesis is exactly what makes `ZMod n` finite. -/
-@[expose] noncomputable def cyclic : FiniteQuadraticModule where
-  toFiniteBilinearModule := {
-    carrier := ZMod n
-    pairing := LinearMap.toAddMonoidHom'.comp
-      (cyclicMap n a hquad hpolar).polarBilin.toAddMonoidHom
-    pairing_comm := fun x y ↦ QuadraticMap.polar_comm (cyclicMap n a hquad hpolar) x y }
-  quadratic := cyclicMap n a hquad hpolar
-  polar_eq_pairing' := fun _ _ ↦ (rfl)
+@[expose] noncomputable def cyclic : FiniteQuadraticModule :=
+  ofQuadraticMap (ZMod n) (cyclicMap n a hquad hpolar)
 
 @[simp]
 theorem cyclic_quadratic (x : ZMod n) :
-    (cyclic n a hquad hpolar).quadratic x = cyclicMap n a hquad hpolar x := (rfl)
+    (cyclic n a hquad hpolar).quadratic x = cyclicMap n a hquad hpolar x :=
+  ofQuadraticMap_quadratic _ _ x
 
 @[simp]
 theorem cyclic_pairing (x y : ZMod n) :
     (cyclic n a hquad hpolar).toFiniteBilinearModule.pairing x y =
-      QuadraticMap.polar (cyclicMap n a hquad hpolar) x y := (rfl)
+      QuadraticMap.polar (cyclicMap n a hquad hpolar) x y :=
+  ofQuadraticMap_pairing _ _ x y
 
 omit hquad hpolar [NeZero n] in
 /-- **An additive equivalence from `ZMod n` matching the generator values is an isometry.**

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -74,6 +74,8 @@ private theorem zmultiples_le_radical_intQuadratic
   intro x hx
   obtain ⟨k, rfl⟩ := AddSubgroup.mem_zmultiples_iff.mp hx
   constructor
+  -- The first radical condition unfolds `toQuadraticMap` and `intBilin` to the explicit
+  -- quadratic value of this representative; there is no rewriting lemma for this reduction.
   · change (((k * (n : ℤ)) * (k * n)) • a) = 0
     have hcoeff : (k * (n : ℤ)) * (k * n) = (k * k) * (n * n) := by ring
     rw [hcoeff, mul_smul, hquad, smul_zero]
@@ -83,6 +85,8 @@ private theorem zmultiples_le_radical_intQuadratic
     change QuadraticMap.polar (intQuadratic a) (k • (n : ℤ)) y = 0
     rw [intQuadratic, LinearMap.BilinMap.polar_toQuadraticMap]
     simp only [intBilin, LinearMap.mk₂_apply, smul_eq_mul]
+    -- The preceding rewrite exposes the two `intBilin` evaluations, whose integer actions on
+    -- `a` reduce definitionally to these two explicit scalar multiples.
     change ((k * (n : ℤ) * y) • a) + ((y * (k * n)) • a) = 0
     rw [← add_smul]
     have hcoeff : k * (n : ℤ) * y + y * (k * n) = (k * y) * (2 * n) := by ring
@@ -96,6 +100,19 @@ private def intQuotientEquivZMod :
     map_smul' := by
       intro k x
       convert! (Int.quotientZMultiplesNatEquivZMod n).toAddMonoidHom.map_zsmul k x using 1 }
+
+/-- The inverse quotient equivalence sends an integer class to its quotient representative. -/
+private theorem intQuotientEquivZMod_symm_intCast (k : ℤ) :
+    (intQuotientEquivZMod n).symm (k : ZMod n) = Submodule.Quotient.mk k := by
+  apply (intQuotientEquivZMod n).injective
+  rw [LinearEquiv.apply_symm_apply]
+  have hs : (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).symm
+      (QuotientAddGroup.mk k) = QuotientAddGroup.mk k := by
+    apply (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).injective
+    rw [AddEquiv.apply_symm_apply, QuotientAddGroup.quotientAddEquivOfEq_mk]
+  change (k : ZMod n) = Int.quotientZMultiplesNatEquivZMod n (QuotientAddGroup.mk k)
+  rw [Int.quotientZMultiplesNatEquivZMod, AddEquiv.trans_apply, hs]
+  rfl
 
 /-! ## The cyclic quadratic module -/
 
@@ -116,26 +133,12 @@ noncomputable def cyclicMap : QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)) :=
 @[simp]
 theorem cyclicMap_intCast (k : ℤ) :
     cyclicMap n a hquad hpolar (k : ZMod n) = (k * k) • a := by
-  rw [← zsmul_one, (cyclicMap n a hquad hpolar).map_smul]
-  congr 1
   unfold cyclicMap
   rw [QuadraticMap.comp_apply]
-  have he : (intQuotientEquivZMod n).symm 1 = Submodule.Quotient.mk (1 : ℤ) := by
-    apply (intQuotientEquivZMod n).injective
-    rw [LinearEquiv.apply_symm_apply]
-    have hs : (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).symm
-        (QuotientAddGroup.mk 1) = QuotientAddGroup.mk 1 := by
-      apply (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).injective
-      rw [AddEquiv.apply_symm_apply, QuotientAddGroup.quotientAddEquivOfEq_mk]
-    -- Expose the composition defining the quotient-to-`ZMod` equivalence.
-    change (1 : ZMod n) = Int.quotientZMultiplesNatEquivZMod n (QuotientAddGroup.mk 1)
-    rw [Int.quotientZMultiplesNatEquivZMod, AddEquiv.trans_apply, hs]
-    change (1 : ZMod n) = ((1 : ℤ) : ZMod n)
-    simp
   -- Expose the lifted quadratic map at the quotient representative.
   change (intQuadratic a).lift (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule _
-    ((intQuotientEquivZMod n).symm 1) = a
-  rw [he, QuadraticMap.lift_mk]
+    ((intQuotientEquivZMod n).symm (k : ZMod n)) = (k * k) • a
+  rw [intQuotientEquivZMod_symm_intCast, QuadraticMap.lift_mk]
   simp [intQuadratic, intBilin]
 
 /-- The standard generator of `cyclicMap` has value `a`. -/

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
+import Mathlib.Data.ZMod.QuotientGroup
+
+/-!
+# Finite quadratic modules on cyclic groups
+
+A `ℚ/ℤ`-valued quadratic map on `ZMod n` is determined by its value `a` on the standard
+generator.  Conversely, a value `a : ℚ/ℤ` defines such a map when
+
+```text
+n²a = 0,   2na = 0.
+```
+
+Indeed, the quadratic map `k ↦ k²a` on `ℤ` descends modulo `n` exactly when translation by `n`
+does not change its values or its polar form.  This file carries out that quotient construction
+and, for nonzero `n`, packages it as `TauCeti.FiniteQuadraticModule.cyclic`.
+
+The companion `TauCeti.FiniteQuadraticModule.cyclicIsometryOfGenerator` shows that an additive
+equivalence out of `ZMod n` which matches the quadratic values of the standard generators is
+automatically an isometry.  Together these declarations give the shared presented-module API
+used to identify cyclic discriminant forms, including the `Aₙ`, odd `Dₙ`, `E₆`, and `E₇`
+root lattices.
+
+## Main declarations
+
+* `TauCeti.FiniteQuadraticModule.cyclicMap`: the quadratic map on `ZMod n` with generator value
+  `a`.
+* `TauCeti.FiniteQuadraticModule.cyclic`: the resulting finite quadratic module.
+* `TauCeti.FiniteQuadraticModule.cyclicIsometryOfGenerator`: an additive equivalence matching
+  generator values is an isometry.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+
+This supplies the cyclic presented modules needed by Layer 5 of
+`TauCetiRoadmap/IntegralLattices/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace FiniteQuadraticModule
+
+variable (n : ℕ) (a : AddCircle (1 : ℚ))
+
+/-! ## The presenting quadratic map on `ℤ` -/
+
+/-- The bilinear map `(x, y) ↦ xya` on `ℤ`. -/
+private def intBilin : LinearMap.BilinMap ℤ ℤ (AddCircle (1 : ℚ)) :=
+  LinearMap.mk₂ ℤ (fun x y : ℤ ↦ (x * y) • a)
+    (fun x y z ↦ by rw [add_mul, add_smul])
+    (fun r x y ↦ by rw [smul_eq_mul, mul_assoc, mul_smul])
+    (fun x y z ↦ by rw [mul_add, add_smul])
+    (fun r x y ↦ by rw [smul_eq_mul, mul_left_comm, mul_smul])
+
+/-- The quadratic map `x ↦ x²a` on `ℤ`. -/
+private def intQuadratic : QuadraticMap ℤ ℤ (AddCircle (1 : ℚ)) :=
+  (intBilin a).toQuadraticMap
+
+/-- The two torsion hypotheses put the multiples of `n` in the quadratic radical. -/
+private theorem zmultiples_le_radical_intQuadratic
+    (hquad : ((n : ℤ) * n) • a = 0) (hpolar : (2 * (n : ℤ)) • a = 0) :
+    (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule ≤ (intQuadratic a).radical := by
+  intro x hx
+  obtain ⟨k, rfl⟩ := AddSubgroup.mem_zmultiples_iff.mp hx
+  constructor
+  · change (((k * (n : ℤ)) * (k * n)) • a) = 0
+    have hcoeff : (k * (n : ℤ)) * (k * n) = (k * k) * (n * n) := by ring
+    rw [hcoeff, mul_smul, hquad, smul_zero]
+  · apply LinearMap.ext
+    intro y
+    -- Unfolding the polar of `toQuadraticMap` exposes the two bilinear evaluations.
+    change QuadraticMap.polar (intQuadratic a) (k • (n : ℤ)) y = 0
+    rw [intQuadratic, LinearMap.BilinMap.polar_toQuadraticMap]
+    simp only [intBilin, LinearMap.mk₂_apply, smul_eq_mul]
+    change ((k * (n : ℤ) * y) • a) + ((y * (k * n)) • a) = 0
+    rw [← add_smul]
+    have hcoeff : k * (n : ℤ) * y + y * (k * n) = (k * y) * (2 * n) := by ring
+    rw [hcoeff, mul_smul, hpolar, smul_zero]
+
+/-- The quotient of `ℤ` by the multiples of `n`, as an integer-linear equivalence with
+`ZMod n`. -/
+private def intQuotientEquivZMod :
+    (ℤ ⧸ (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule) ≃ₗ[ℤ] ZMod n :=
+  { Int.quotientZMultiplesNatEquivZMod n with
+    map_smul' := by
+      intro k x
+      convert! (Int.quotientZMultiplesNatEquivZMod n).toAddMonoidHom.map_zsmul k x using 1 }
+
+/-! ## The cyclic quadratic module -/
+
+variable (hquad : ((n : ℤ) * n) • a = 0) (hpolar : (2 * (n : ℤ)) • a = 0)
+
+include hquad hpolar
+
+/-- The quadratic map on `ZMod n` whose standard generator has value `a`.
+
+The hypotheses `n²a = 0` and `2na = 0` say respectively that the proposed quadratic values and
+polar pairing are well defined modulo `n`. -/
+noncomputable def cyclicMap : QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)) :=
+  ((intQuadratic a).lift (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule
+      (zmultiples_le_radical_intQuadratic n a hquad hpolar)).comp
+    (intQuotientEquivZMod n).symm.toLinearMap
+
+/-- The value of `cyclicMap` on the reduction of an integer. -/
+@[simp]
+theorem cyclicMap_intCast (k : ℤ) :
+    cyclicMap n a hquad hpolar (k : ZMod n) = (k * k) • a := by
+  rw [← zsmul_one, (cyclicMap n a hquad hpolar).map_smul]
+  congr 1
+  unfold cyclicMap
+  rw [QuadraticMap.comp_apply]
+  have he : (intQuotientEquivZMod n).symm 1 = Submodule.Quotient.mk (1 : ℤ) := by
+    apply (intQuotientEquivZMod n).injective
+    rw [LinearEquiv.apply_symm_apply]
+    have hs : (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).symm
+        (QuotientAddGroup.mk 1) = QuotientAddGroup.mk 1 := by
+      apply (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).injective
+      rw [AddEquiv.apply_symm_apply, QuotientAddGroup.quotientAddEquivOfEq_mk]
+    -- Expose the composition defining the quotient-to-`ZMod` equivalence.
+    change (1 : ZMod n) = Int.quotientZMultiplesNatEquivZMod n (QuotientAddGroup.mk 1)
+    rw [Int.quotientZMultiplesNatEquivZMod, AddEquiv.trans_apply, hs]
+    change (1 : ZMod n) = ((1 : ℤ) : ZMod n)
+    simp
+  -- Expose the lifted quadratic map at the quotient representative.
+  change (intQuadratic a).lift (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule _
+    ((intQuotientEquivZMod n).symm 1) = a
+  rw [he, QuadraticMap.lift_mk]
+  simp [intQuadratic, intBilin]
+
+/-- The standard generator of `cyclicMap` has value `a`. -/
+@[simp]
+theorem cyclicMap_one : cyclicMap n a hquad hpolar 1 = a := by
+  simpa using cyclicMap_intCast n a hquad hpolar 1
+
+/-- The polar pairing of two integer classes is `2kla`. -/
+@[simp]
+theorem polar_cyclicMap_intCast (k l : ℤ) :
+    QuadraticMap.polar (cyclicMap n a hquad hpolar) (k : ZMod n) (l : ZMod n) =
+      (2 * (k * l)) • a := by
+  rw [QuadraticMap.polar, ← Int.cast_add, cyclicMap_intCast, cyclicMap_intCast,
+    cyclicMap_intCast, ← sub_smul, ← sub_smul]
+  congr 1
+  ring
+
+variable [NeZero n]
+
+/-- **The finite quadratic module on `ZMod n` whose standard generator has value `a`.**
+
+The nonzero-modulus hypothesis is exactly what makes `ZMod n` finite. -/
+@[expose] noncomputable def cyclic : FiniteQuadraticModule where
+  toFiniteBilinearModule := {
+    carrier := ZMod n
+    pairing := LinearMap.toAddMonoidHom'.comp
+      (cyclicMap n a hquad hpolar).polarBilin.toAddMonoidHom
+    pairing_comm := fun x y ↦ QuadraticMap.polar_comm (cyclicMap n a hquad hpolar) x y }
+  quadratic := cyclicMap n a hquad hpolar
+  polar_eq_pairing' := fun _ _ ↦ (rfl)
+
+@[simp]
+theorem cyclic_quadratic (x : ZMod n) :
+    (cyclic n a hquad hpolar).quadratic x = cyclicMap n a hquad hpolar x := (rfl)
+
+@[simp]
+theorem cyclic_pairing (x y : ZMod n) :
+    (cyclic n a hquad hpolar).toFiniteBilinearModule.pairing x y =
+      QuadraticMap.polar (cyclicMap n a hquad hpolar) x y := (rfl)
+
+omit hquad hpolar [NeZero n] in
+/-- **An additive equivalence from `ZMod n` matching the generator values is an isometry.**
+
+Both forms are stated as bare quadratic maps so that the construction applies before either is
+packaged as a finite quadratic module. -/
+noncomputable def cyclicIsometryOfGenerator {A : Type*} [AddCommGroup A]
+    (q : QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)))
+    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod n ≃+ A)
+    (he : r (e 1) = q 1) : q.IsometryEquiv r where
+  toLinearEquiv := e.toIntLinearEquiv
+  map_app' x := by
+    obtain ⟨k, rfl⟩ := ZMod.intCast_surjective x
+    -- Identify the bundled linear equivalence with its underlying additive equivalence.
+    change r (e (k : ZMod n)) = q (k : ZMod n)
+    rw [← zsmul_one, map_zsmul, r.map_smul, q.map_smul, he]
+
+omit hquad hpolar [NeZero n] in
+@[simp]
+theorem cyclicIsometryOfGenerator_toAddEquiv {A : Type*} [AddCommGroup A]
+    (q : QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)))
+    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod n ≃+ A)
+    (he : r (e 1) = q 1) :
+    (cyclicIsometryOfGenerator n q r e he).toAddEquiv = e := (rfl)
+
+omit hquad hpolar [NeZero n] in
+@[simp]
+theorem cyclicIsometryOfGenerator_apply {A : Type*} [AddCommGroup A]
+    (q : QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)))
+    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod n ≃+ A)
+    (he : r (e 1) = q 1) (x : ZMod n) :
+    cyclicIsometryOfGenerator n q r e he x = e x := (rfl)
+
+end FiniteQuadraticModule
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -40,6 +40,9 @@ root lattices.
 
 * V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1.
 * W. Ebeling, *Lattices and Codes*, Chapter 1.
+* The quotient construction and the generator-isometry argument below are promoted, essentially
+  unchanged, from the private `E₆`/`E₇` scaffolding formerly in
+  `TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean`.
 
 This supplies the cyclic presented modules needed by Layer 5 of
 `TauCetiRoadmap/IntegralLattices/README.md`.
@@ -96,23 +99,19 @@ private theorem zmultiples_le_radical_intQuadratic
 `ZMod n`. -/
 private def intQuotientEquivZMod :
     (ℤ ⧸ (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule) ≃ₗ[ℤ] ZMod n :=
-  { Int.quotientZMultiplesNatEquivZMod n with
-    map_smul' := by
-      intro k x
-      convert! (Int.quotientZMultiplesNatEquivZMod n).toAddMonoidHom.map_zsmul k x using 1 }
+  (Int.quotientZMultiplesNatEquivZMod n).toIntLinearEquiv
+
+/-- The quotient equivalence sends the class of an integer to its reduction.
+
+This is the sole point at which the construction of `Int.quotientZMultiplesNatEquivZMod` is used:
+it is a kernel lift, so it computes on quotient representatives. -/
+private theorem intQuotientEquivZMod_mk (k : ℤ) :
+    intQuotientEquivZMod n (Submodule.Quotient.mk k) = (k : ZMod n) := rfl
 
 /-- The inverse quotient equivalence sends an integer class to its quotient representative. -/
 private theorem intQuotientEquivZMod_symm_intCast (k : ℤ) :
     (intQuotientEquivZMod n).symm (k : ZMod n) = Submodule.Quotient.mk k := by
-  apply (intQuotientEquivZMod n).injective
-  rw [LinearEquiv.apply_symm_apply]
-  have hs : (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).symm
-      (QuotientAddGroup.mk k) = QuotientAddGroup.mk k := by
-    apply (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).injective
-    rw [AddEquiv.apply_symm_apply, QuotientAddGroup.quotientAddEquivOfEq_mk]
-  change (k : ZMod n) = Int.quotientZMultiplesNatEquivZMod n (QuotientAddGroup.mk k)
-  rw [Int.quotientZMultiplesNatEquivZMod, AddEquiv.trans_apply, hs]
-  rfl
+  rw [← intQuotientEquivZMod_mk, LinearEquiv.symm_apply_apply]
 
 /-! ## The cyclic quadratic module -/
 
@@ -134,11 +133,8 @@ noncomputable def cyclicMap : QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)) :=
 theorem cyclicMap_intCast (k : ℤ) :
     cyclicMap n a hquad hpolar (k : ZMod n) = (k * k) • a := by
   unfold cyclicMap
-  rw [QuadraticMap.comp_apply]
-  -- Expose the lifted quadratic map at the quotient representative.
-  change (intQuadratic a).lift (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule _
-    ((intQuotientEquivZMod n).symm (k : ZMod n)) = (k * k) • a
-  rw [intQuotientEquivZMod_symm_intCast, QuadraticMap.lift_mk]
+  rw [QuadraticMap.comp_apply, LinearEquiv.coe_coe, intQuotientEquivZMod_symm_intCast,
+    QuadraticMap.lift_mk]
   simp [intQuadratic, intBilin]
 
 /-- The standard generator of `cyclicMap` has value `a`. -/
@@ -191,8 +187,7 @@ noncomputable def cyclicIsometryOfGenerator {A : Type*} [AddCommGroup A]
   toLinearEquiv := e.toIntLinearEquiv
   map_app' x := by
     obtain ⟨k, rfl⟩ := ZMod.intCast_surjective x
-    -- Identify the bundled linear equivalence with its underlying additive equivalence.
-    change r (e (k : ZMod n)) = q (k : ZMod n)
+    simp only [LinearMap.toFun_eq_coe, LinearEquiv.coe_coe, AddEquiv.coe_toIntLinearEquiv]
     rw [← zsmul_one, map_zsmul, r.map_smul, q.map_smul, he]
 
 omit hquad hpolar [NeZero n] in

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -145,15 +145,6 @@ theorem polar_cyclicMap_intCast (k l : ℤ) :
   congr 1
   ring
 
-/-- The standard generator of `cyclicMap` pairs with itself to `2a`.
-
-This is deliberately not a `simp` lemma: `QuadraticMap.polar_self` and `cyclicMap_one` already
-rewrite the left-hand side, so it is stated only for the `ℤ`-scalar form shared with
-`polar_cyclicMap_intCast`. -/
-theorem polar_cyclicMap_one_one :
-    QuadraticMap.polar (cyclicMap n a hquad hpolar) 1 1 = (2 : ℤ) • a := by
-  simpa using polar_cyclicMap_intCast n a hquad hpolar 1 1
-
 variable [NeZero n]
 
 /-- **The finite quadratic module on `ZMod n` whose standard generator has value `a`.**

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
@@ -32,9 +32,8 @@ The companion `TauCeti.FiniteQuadraticModule.kleinFourIsometryOfGenerators` turn
 equivalence `(ℤ/2)² ≃+ A` matching the three displayed values into an isometry onto `A`, which is
 how a discriminant form of order four and exponent two is identified.
 
-The quotient construction is a rank-two adaptation of the private cyclic construction in
-`TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean`; the two can be unified when that
-construction is promoted to shared API.
+This is the rank-two companion to `TauCeti.FiniteQuadraticModule.cyclic`, which carries out the
+same quotient construction for a cyclic carrier.
 
 ## Main declarations
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
@@ -195,23 +195,19 @@ theorem polar_kleinFourMap_one_zero_zero_one :
   abel
 
 /-- **The finite quadratic module on `(ℤ/2)²` with generator values `α`, `β` and `α + β + γ`.** -/
-@[expose] noncomputable def kleinFour : FiniteQuadraticModule where
-  toFiniteBilinearModule := {
-    carrier := ZMod 2 × ZMod 2
-    pairing := LinearMap.toAddMonoidHom'.comp
-      (kleinFourMap α β γ h₄α h₄β h₂γ).polarBilin.toAddMonoidHom
-    pairing_comm := fun x y ↦ QuadraticMap.polar_comm (kleinFourMap α β γ h₄α h₄β h₂γ) x y }
-  quadratic := kleinFourMap α β γ h₄α h₄β h₂γ
-  polar_eq_pairing' := fun _ _ ↦ (rfl)
+@[expose] noncomputable def kleinFour : FiniteQuadraticModule :=
+  ofQuadraticMap (ZMod 2 × ZMod 2) (kleinFourMap α β γ h₄α h₄β h₂γ)
 
 @[simp]
 theorem kleinFour_quadratic (x : ZMod 2 × ZMod 2) :
-    (kleinFour α β γ h₄α h₄β h₂γ).quadratic x = kleinFourMap α β γ h₄α h₄β h₂γ x := (rfl)
+    (kleinFour α β γ h₄α h₄β h₂γ).quadratic x = kleinFourMap α β γ h₄α h₄β h₂γ x :=
+  ofQuadraticMap_quadratic _ _ x
 
 @[simp]
 theorem kleinFour_pairing (x y : ZMod 2 × ZMod 2) :
     (kleinFour α β γ h₄α h₄β h₂γ).toFiniteBilinearModule.pairing x y =
-      QuadraticMap.polar (kleinFourMap α β γ h₄α h₄β h₂γ) x y := (rfl)
+      QuadraticMap.polar (kleinFourMap α β γ h₄α h₄β h₂γ) x y :=
+  ofQuadraticMap_pairing _ _ x y
 
 omit h₄α h₄β h₂γ in
 /-- **An additive equivalence from `(ℤ/2)²` matching all three nonzero values is an isometry.**

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -28,6 +28,8 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
 * `TauCeti.FiniteQuadraticModule`: a finite abelian group with an `AddCircle (1 : ℚ)`-valued
   quadratic map.
 * `TauCeti.FiniteQuadraticModule.toFiniteBilinearModule`: the canonical polar bilinear module.
+* `TauCeti.FiniteQuadraticModule.ofQuadraticMap`: the finite quadratic module presented by a
+  quadratic map on a finite abelian group.
 * `TauCeti.FiniteQuadraticModule.Hom`: a quadratic-map-preserving additive homomorphism.
 * `TauCeti.FiniteQuadraticModule.Isometry`: a quadratic-map isometric equivalence.
 * `TauCeti.FiniteQuadraticModule.IsIsotropic`: quadratic isotropy of an additive subgroup.
@@ -86,6 +88,33 @@ theorem toFiniteBilinearModule_toBilin :
   ext x y
   rw [FiniteBilinearModule.toBilin_apply, QuadraticMap.polarBilin_apply_apply,
     A.polar_eq_pairing]
+
+/-! ## Presentation by a quadratic map -/
+
+/-- The finite quadratic module presented by a `ℚ/ℤ`-valued quadratic map on a finite abelian
+group.
+
+The stored pairing is the polar form of `q`, which is the only choice the structure allows.  This
+is the packaging shared by the presented modules, such as
+`TauCeti.FiniteQuadraticModule.cyclic` and `TauCeti.FiniteQuadraticModule.kleinFour`. -/
+@[expose] def ofQuadraticMap (M : Type u) [AddCommGroup M] [Finite M]
+    (q : QuadraticMap ℤ M (AddCircle (1 : ℚ))) : FiniteQuadraticModule where
+  toFiniteBilinearModule := {
+    carrier := M
+    pairing := LinearMap.toAddMonoidHom'.comp q.polarBilin.toAddMonoidHom
+    pairing_comm := fun x y ↦ QuadraticMap.polar_comm q x y }
+  quadratic := q
+  polar_eq_pairing' := fun _ _ ↦ (rfl)
+
+@[simp]
+theorem ofQuadraticMap_quadratic (M : Type u) [AddCommGroup M] [Finite M]
+    (q : QuadraticMap ℤ M (AddCircle (1 : ℚ))) (x : M) :
+    (ofQuadraticMap M q).quadratic x = q x := (rfl)
+
+@[simp]
+theorem ofQuadraticMap_pairing (M : Type u) [AddCommGroup M] [Finite M]
+    (q : QuadraticMap ℤ M (AddCircle (1 : ℚ))) (x y : M) :
+    (ofQuadraticMap M q).toFiniteBilinearModule.pairing x y = QuadraticMap.polar q x y := (rfl)
 
 /-- A finite quadratic module is nondegenerate when its polar pairing is nondegenerate. -/
 abbrev IsNondegenerate : Prop := A.toFiniteBilinearModule.IsNondegenerate

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -319,16 +319,16 @@ theorem discriminantPairing_typeE₆MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- The type-`E₆` generator value `2/3` satisfies the quadratic-value descent condition. -/
-theorem typeE₆QuadraticValue_sq_torsion :
+/-- Nine times the type-`E₆` quadratic value `2/3` vanishes in `ℚ/ℤ`. -/
+theorem nine_zsmul_typeE₆QuadraticValue_eq_zero :
     (9 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
   -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
   change ((((9 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
   rw [QuotientAddGroup.eq_zero_iff]
   exact ⟨6, by norm_num⟩
 
-/-- The type-`E₆` generator value `2/3` satisfies the polar-pairing descent condition. -/
-theorem typeE₆QuadraticValue_polar_torsion :
+/-- Six times the type-`E₆` quadratic value `2/3` vanishes in `ℚ/ℤ`. -/
+theorem six_zsmul_typeE₆QuadraticValue_eq_zero :
     (6 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
   -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
   change ((((6 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
@@ -339,12 +339,12 @@ theorem typeE₆QuadraticValue_polar_torsion :
 noncomputable def typeE₆StandardQuadraticMap :
     QuadraticMap ℤ (ZMod 3) (AddCircle (1 : ℚ)) :=
   FiniteQuadraticModule.cyclicMap 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
-    typeE₆QuadraticValue_sq_torsion typeE₆QuadraticValue_polar_torsion
+    nine_zsmul_typeE₆QuadraticValue_eq_zero six_zsmul_typeE₆QuadraticValue_eq_zero
 
 /-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`. -/
 @[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
-    typeE₆QuadraticValue_sq_torsion typeE₆QuadraticValue_polar_torsion
+    nine_zsmul_typeE₆QuadraticValue_eq_zero six_zsmul_typeE₆QuadraticValue_eq_zero
 
 /-- The generator of the standard type-`E₆` quadratic map has value `2/3`. -/
 @[simp]
@@ -608,8 +608,8 @@ theorem discriminantPairing_typeE₇MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- The type-`E₇` generator value `3/4` satisfies both cyclic descent conditions. -/
-theorem typeE₇QuadraticValue_torsion :
+/-- Four times the type-`E₇` quadratic value `3/4` vanishes in `ℚ/ℤ`. -/
+theorem four_zsmul_typeE₇QuadraticValue_eq_zero :
     (4 : ℤ) • ((((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
   -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
   change ((((4 : ℚ) * (3 / 4)) : ℚ) : AddCircle (1 : ℚ)) = 0
@@ -620,12 +620,12 @@ theorem typeE₇QuadraticValue_torsion :
 noncomputable def typeE₇StandardQuadraticMap :
     QuadraticMap ℤ (ZMod 2) (AddCircle (1 : ℚ)) :=
   FiniteQuadraticModule.cyclicMap 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
-    typeE₇QuadraticValue_torsion typeE₇QuadraticValue_torsion
+    four_zsmul_typeE₇QuadraticValue_eq_zero four_zsmul_typeE₇QuadraticValue_eq_zero
 
 /-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`. -/
 @[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
-    typeE₇QuadraticValue_torsion typeE₇QuadraticValue_torsion
+    four_zsmul_typeE₇QuadraticValue_eq_zero four_zsmul_typeE₇QuadraticValue_eq_zero
 
 /-- The generator of the standard type-`E₇` quadratic map has value `3/4`. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -319,35 +319,23 @@ theorem discriminantPairing_typeE₆MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- Nine times `2/3`, the type-`E₆` discriminant quadratic value, vanishes in `ℚ/ℤ`. -/
-private theorem nine_zsmul_two_div_three_eq_zero :
-    (9 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
-  rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
-  exact Submodule.mem_one.mpr ⟨6, by norm_num⟩
-
-/-- Six times `2/3`, the type-`E₆` discriminant quadratic value, vanishes in `ℚ/ℤ`. -/
-private theorem six_zsmul_two_div_three_eq_zero :
-    (6 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
-  rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
-  exact Submodule.mem_one.mpr ⟨4, by norm_num⟩
-
-/-- The quadratic map on `ZMod 3` whose generator has value `2/3`. -/
-noncomputable def typeE₆StandardQuadraticMap :
-    QuadraticMap ℤ (ZMod 3) (AddCircle (1 : ℚ)) :=
-  FiniteQuadraticModule.cyclicMap 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
-    nine_zsmul_two_div_three_eq_zero six_zsmul_two_div_three_eq_zero
-
 /-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`.
 
-The two descent hypotheses are discharged inline rather than by named lemmas: they are numeric
-torsion facts of no independent interest, and this definition is `@[expose]`d, so its body must
-mention only public declarations. -/
+The two descent hypotheses are the numeric torsion facts `9 • (2/3) = 0` and `6 • (2/3) = 0` in
+`ℚ/ℤ`; they are discharged inline because they have no independent interest and this definition
+is `@[expose]`d, so its body may mention only public declarations. -/
 @[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
     (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
         exact Submodule.mem_one.mpr ⟨6, by norm_num⟩)
     (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
         exact Submodule.mem_one.mpr ⟨4, by norm_num⟩)
+
+/-- The quadratic map on `ZMod 3` whose generator has value `2/3`, namely the one carried by
+`typeE₆StandardQuadraticModule`. -/
+noncomputable def typeE₆StandardQuadraticMap :
+    QuadraticMap ℤ (ZMod 3) (AddCircle (1 : ℚ)) :=
+  typeE₆StandardQuadraticModule.quadratic
 
 /-- The generator of the standard type-`E₆` quadratic map has value `2/3`. -/
 @[simp]
@@ -611,28 +599,22 @@ theorem discriminantPairing_typeE₇MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- Four times `3/4`, the type-`E₇` discriminant quadratic value, vanishes in `ℚ/ℤ`. -/
-private theorem four_zsmul_three_div_four_eq_zero :
-    (4 : ℤ) • ((((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
-  rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
-  exact Submodule.mem_one.mpr ⟨3, by norm_num⟩
-
-/-- The quadratic map on `ZMod 2` whose generator has value `3/4`. -/
-noncomputable def typeE₇StandardQuadraticMap :
-    QuadraticMap ℤ (ZMod 2) (AddCircle (1 : ℚ)) :=
-  FiniteQuadraticModule.cyclicMap 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
-    four_zsmul_three_div_four_eq_zero four_zsmul_three_div_four_eq_zero
-
 /-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`.
 
-As for `typeE₆StandardQuadraticModule`, the descent hypotheses are discharged inline because this
-definition is `@[expose]`d. -/
+Both descent hypotheses are the numeric torsion fact `4 • (3/4) = 0` in `ℚ/ℤ`, discharged inline
+as for `typeE₆StandardQuadraticModule`. -/
 @[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
     (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
         exact Submodule.mem_one.mpr ⟨3, by norm_num⟩)
     (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
         exact Submodule.mem_one.mpr ⟨3, by norm_num⟩)
+
+/-- The quadratic map on `ZMod 2` whose generator has value `3/4`, namely the one carried by
+`typeE₇StandardQuadraticModule`. -/
+noncomputable def typeE₇StandardQuadraticMap :
+    QuadraticMap ℤ (ZMod 2) (AddCircle (1 : ℚ)) :=
+  typeE₇StandardQuadraticModule.quadratic
 
 /-- The generator of the standard type-`E₇` quadratic map has value `3/4`. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -319,32 +319,35 @@ theorem discriminantPairing_typeE₆MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- Nine times the type-`E₆` quadratic value `2/3` vanishes in `ℚ/ℤ`. -/
-theorem nine_zsmul_typeE₆QuadraticValue_eq_zero :
+/-- Nine times `2/3`, the type-`E₆` discriminant quadratic value, vanishes in `ℚ/ℤ`. -/
+private theorem nine_zsmul_two_div_three_eq_zero :
     (9 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
-  -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
-  change ((((9 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
-  rw [QuotientAddGroup.eq_zero_iff]
-  exact ⟨6, by norm_num⟩
+  rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
+  exact Submodule.mem_one.mpr ⟨6, by norm_num⟩
 
-/-- Six times the type-`E₆` quadratic value `2/3` vanishes in `ℚ/ℤ`. -/
-theorem six_zsmul_typeE₆QuadraticValue_eq_zero :
+/-- Six times `2/3`, the type-`E₆` discriminant quadratic value, vanishes in `ℚ/ℤ`. -/
+private theorem six_zsmul_two_div_three_eq_zero :
     (6 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
-  -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
-  change ((((6 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
-  rw [QuotientAddGroup.eq_zero_iff]
-  exact ⟨4, by norm_num⟩
+  rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
+  exact Submodule.mem_one.mpr ⟨4, by norm_num⟩
 
 /-- The quadratic map on `ZMod 3` whose generator has value `2/3`. -/
 noncomputable def typeE₆StandardQuadraticMap :
     QuadraticMap ℤ (ZMod 3) (AddCircle (1 : ℚ)) :=
   FiniteQuadraticModule.cyclicMap 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
-    nine_zsmul_typeE₆QuadraticValue_eq_zero six_zsmul_typeE₆QuadraticValue_eq_zero
+    nine_zsmul_two_div_three_eq_zero six_zsmul_two_div_three_eq_zero
 
-/-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`. -/
+/-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`.
+
+The two descent hypotheses are discharged inline rather than by named lemmas: they are numeric
+torsion facts of no independent interest, and this definition is `@[expose]`d, so its body must
+mention only public declarations. -/
 @[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
-    nine_zsmul_typeE₆QuadraticValue_eq_zero six_zsmul_typeE₆QuadraticValue_eq_zero
+    (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
+        exact Submodule.mem_one.mpr ⟨6, by norm_num⟩)
+    (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
+        exact Submodule.mem_one.mpr ⟨4, by norm_num⟩)
 
 /-- The generator of the standard type-`E₆` quadratic map has value `2/3`. -/
 @[simp]
@@ -608,24 +611,28 @@ theorem discriminantPairing_typeE₇MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- Four times the type-`E₇` quadratic value `3/4` vanishes in `ℚ/ℤ`. -/
-theorem four_zsmul_typeE₇QuadraticValue_eq_zero :
+/-- Four times `3/4`, the type-`E₇` discriminant quadratic value, vanishes in `ℚ/ℤ`. -/
+private theorem four_zsmul_three_div_four_eq_zero :
     (4 : ℤ) • ((((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
-  -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
-  change ((((4 : ℚ) * (3 / 4)) : ℚ) : AddCircle (1 : ℚ)) = 0
-  rw [QuotientAddGroup.eq_zero_iff]
-  exact ⟨3, by norm_num⟩
+  rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
+  exact Submodule.mem_one.mpr ⟨3, by norm_num⟩
 
 /-- The quadratic map on `ZMod 2` whose generator has value `3/4`. -/
 noncomputable def typeE₇StandardQuadraticMap :
     QuadraticMap ℤ (ZMod 2) (AddCircle (1 : ℚ)) :=
   FiniteQuadraticModule.cyclicMap 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
-    four_zsmul_typeE₇QuadraticValue_eq_zero four_zsmul_typeE₇QuadraticValue_eq_zero
+    four_zsmul_three_div_four_eq_zero four_zsmul_three_div_four_eq_zero
 
-/-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`. -/
+/-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`.
+
+As for `typeE₆StandardQuadraticModule`, the descent hypotheses are discharged inline because this
+definition is `@[expose]`d. -/
 @[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
-    four_zsmul_typeE₇QuadraticValue_eq_zero four_zsmul_typeE₇QuadraticValue_eq_zero
+    (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
+        exact Submodule.mem_one.mpr ⟨3, by norm_num⟩)
+    (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
+        exact Submodule.mem_one.mpr ⟨3, by norm_num⟩)
 
 /-- The generator of the standard type-`E₇` quadratic map has value `3/4`. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -7,11 +7,11 @@ module
 
 public import Mathlib.GroupTheory.SpecificGroups.Cyclic
 public import Mathlib.LinearAlgebra.Matrix.Cartan
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Cyclic
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Cardinality
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Quadratic
 public import TauCeti.LinearAlgebra.IntegralLattice.StandardCoordinates
 public import TauCeti.LinearAlgebra.IntegralLattice.Unimodular
-import Mathlib.Data.ZMod.QuotientGroup
 
 /-!
 # The exceptional root lattices `E₆`, `E₇`, `E₈` and their discriminant forms
@@ -88,90 +88,6 @@ namespace TauCeti
 namespace IntegralLattice
 
 open Finset
-
-/- Cyclic quadratic-module construction used below. -/
-
-private def intBilin (a : AddCircle (1 : ℚ)) : LinearMap.BilinMap ℤ ℤ (AddCircle (1 : ℚ)) :=
-  LinearMap.mk₂ ℤ (fun x y : ℤ ↦ (x * y) • a)
-    (fun x y z ↦ by rw [add_mul, add_smul])
-    (fun r x y ↦ by rw [smul_eq_mul, mul_assoc, mul_smul])
-    (fun x y z ↦ by rw [mul_add, add_smul])
-    (fun r x y ↦ by rw [smul_eq_mul, mul_left_comm, mul_smul])
-
-private def intQuadratic (a : AddCircle (1 : ℚ)) : QuadraticMap ℤ ℤ (AddCircle (1 : ℚ)) :=
-  (intBilin a).toQuadraticMap
-
-private theorem zmultiples_le_radical_intQuadratic (n : ℕ) (a : AddCircle (1 : ℚ))
-    (hq : ((n : ℤ) * n) • a = 0) (hp : (2 * (n : ℤ)) • a = 0) :
-    (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule ≤ (intQuadratic a).radical := by
-  intro x hx
-  obtain ⟨k, rfl⟩ := AddSubgroup.mem_zmultiples_iff.mp hx
-  constructor
-  -- Evaluate the quadratic map on this explicit generator multiple.
-  · change (((k * (n : ℤ)) * (k * n)) • a) = 0
-    have hcoeff : (k * (n : ℤ)) * (k * n) = (k * k) * (n * n) := by ring
-    rw [hcoeff, mul_smul, hq, smul_zero]
-  · apply LinearMap.ext
-    intro y
-    -- The second radical condition is the vanishing of the polar map.
-    change QuadraticMap.polar (intQuadratic a) (k • (n : ℤ)) y = 0
-    rw [intQuadratic, LinearMap.BilinMap.polar_toQuadraticMap]
-    simp only [intBilin, LinearMap.mk₂_apply, smul_eq_mul]
-    -- Expose the two evaluations of the underlying integer bilinear map.
-    change ((k * (n : ℤ) * y) • a) + ((y * (k * n)) • a) = 0
-    rw [← add_smul]
-    have hcoeff : k * (n : ℤ) * y + y * (k * n) = (k * y) * (2 * n) := by ring
-    rw [hcoeff, mul_smul, hp, smul_zero]
-
-private def intQuotientEquivZMod (n : ℕ) :
-    (ℤ ⧸ (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule) ≃ₗ[ℤ] ZMod n :=
-  { Int.quotientZMultiplesNatEquivZMod n with
-    map_smul' := by
-      intro k x
-      convert! (Int.quotientZMultiplesNatEquivZMod n).toAddMonoidHom.map_zsmul k x using 1 }
-
-private def cyclicQuadraticMap (n : ℕ) (a : AddCircle (1 : ℚ))
-    (hq : ((n : ℤ) * n) • a = 0) (hp : (2 * (n : ℤ)) • a = 0) :
-    QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)) :=
-  ((intQuadratic a).lift (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule
-      (zmultiples_le_radical_intQuadratic n a hq hp)).comp
-      (intQuotientEquivZMod n).symm.toLinearMap
-
-private theorem cyclicQuadraticMap_one (n : ℕ) (a : AddCircle (1 : ℚ))
-    (hq : ((n : ℤ) * n) • a = 0) (hp : (2 * (n : ℤ)) • a = 0) :
-    cyclicQuadraticMap n a hq hp 1 = a := by
-  unfold cyclicQuadraticMap
-  rw [QuadraticMap.comp_apply]
-  have he : (intQuotientEquivZMod n).symm 1 = Submodule.Quotient.mk (1 : ℤ) := by
-    apply (intQuotientEquivZMod n).injective
-    rw [LinearEquiv.apply_symm_apply]
-    have hs : (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).symm
-        (QuotientAddGroup.mk 1) = QuotientAddGroup.mk 1 := by
-      apply (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).injective
-      rw [AddEquiv.apply_symm_apply, QuotientAddGroup.quotientAddEquivOfEq_mk]
-    -- Expose the composition defining the quotient-to-`ZMod` equivalence.
-    change (1 : ZMod n) = Int.quotientZMultiplesNatEquivZMod n (QuotientAddGroup.mk 1)
-    rw [Int.quotientZMultiplesNatEquivZMod, AddEquiv.trans_apply, hs]
-    -- The generator of `ZMod n` is definitionally the image of the integer generator.
-    change (1 : ZMod n) = ((1 : ℤ) : ZMod n)
-    simp
-  -- Expose the lifted quadratic map at the quotient representative.
-  change (intQuadratic a).lift (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule _
-    ((intQuotientEquivZMod n).symm 1) = a
-  rw [he, QuadraticMap.lift_mk]
-  simp [intQuadratic, intBilin]
-
-private noncomputable def quadraticMapIsometryOfGenerator (n : ℕ)
-    {A : Type*} [AddCommGroup A]
-    (q : QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)))
-    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod n ≃+ A)
-    (he : r (e 1) = q 1) : q.IsometryEquiv r where
-  toLinearEquiv := e.toIntLinearEquiv
-  map_app' x := by
-    obtain ⟨k, rfl⟩ := ZMod.intCast_surjective x
-    -- Identify the bundled linear equivalence with its underlying additive equivalence.
-    change r (e (k : ZMod n)) = q (k : ZMod n)
-    rw [← zsmul_one, map_zsmul, r.map_smul, q.map_smul, he]
 
 /-! ## The root lattice of type `E₆` -/
 
@@ -403,14 +319,16 @@ theorem discriminantPairing_typeE₆MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-private theorem typeE₆QuadraticValue_sq_torsion :
+/-- The type-`E₆` generator value `2/3` satisfies the quadratic-value descent condition. -/
+theorem typeE₆QuadraticValue_sq_torsion :
     (9 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
   -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
   change ((((9 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
   rw [QuotientAddGroup.eq_zero_iff]
   exact ⟨6, by norm_num⟩
 
-private theorem typeE₆QuadraticValue_polar_torsion :
+/-- The type-`E₆` generator value `2/3` satisfies the polar-pairing descent condition. -/
+theorem typeE₆QuadraticValue_polar_torsion :
     (6 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
   -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
   change ((((6 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
@@ -420,31 +338,27 @@ private theorem typeE₆QuadraticValue_polar_torsion :
 /-- The quadratic map on `ZMod 3` whose generator has value `2/3`. -/
 noncomputable def typeE₆StandardQuadraticMap :
     QuadraticMap ℤ (ZMod 3) (AddCircle (1 : ℚ)) :=
-  cyclicQuadraticMap 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
+  FiniteQuadraticModule.cyclicMap 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
     typeE₆QuadraticValue_sq_torsion typeE₆QuadraticValue_polar_torsion
 
 /-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`. -/
-@[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule where
-  toFiniteBilinearModule := {
-    carrier := ZMod 3
-    pairing := LinearMap.toAddMonoidHom'.comp typeE₆StandardQuadraticMap.polarBilin.toAddMonoidHom
-    pairing_comm := fun x y ↦ QuadraticMap.polar_comm typeE₆StandardQuadraticMap x y }
-  quadratic := typeE₆StandardQuadraticMap
-  polar_eq_pairing' := fun _ _ ↦ rfl
+@[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule :=
+  FiniteQuadraticModule.cyclic 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
+    typeE₆QuadraticValue_sq_torsion typeE₆QuadraticValue_polar_torsion
 
 /-- The generator of the standard type-`E₆` quadratic map has value `2/3`. -/
 @[simp]
 theorem typeE₆StandardQuadraticMap_one :
     typeE₆StandardQuadraticMap 1 =
       (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ)) :=
-  cyclicQuadraticMap_one 3 _ _ _
+  FiniteQuadraticModule.cyclicMap_one 3 _ _ _
 
 /-- The standard cyclic quadratic module of type `E₆` is isometric to the discriminant
 quadratic module of the `E₆` root lattice. -/
 noncomputable def typeE₆DiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry typeE₆StandardQuadraticModule
       (typeE₆RootLattice.discriminantQuadraticModule isEven_typeE₆RootLattice) :=
-  quadraticMapIsometryOfGenerator 3 typeE₆StandardQuadraticMap
+  FiniteQuadraticModule.cyclicIsometryOfGenerator 3 typeE₆StandardQuadraticMap
     (typeE₆RootLattice.discriminantQuadraticMap isEven_typeE₆RootLattice)
     typeE₆DiscriminantGroupEquiv (by
       rw [typeE₆DiscriminantGroupEquiv_apply_one,
@@ -455,14 +369,14 @@ noncomputable def typeE₆DiscriminantQuadraticIsometry :
 theorem typeE₆DiscriminantQuadraticIsometry_toAddEquiv :
     typeE₆DiscriminantQuadraticIsometry.toAddEquiv = typeE₆DiscriminantGroupEquiv := by
   rw [typeE₆DiscriminantQuadraticIsometry]
-  rfl
+  exact FiniteQuadraticModule.cyclicIsometryOfGenerator_toAddEquiv _ _ _ _ _
 
 /-- The type-`E₆` quadratic isometry acts through the discriminant-group equivalence. -/
 @[simp]
 theorem typeE₆DiscriminantQuadraticIsometry_apply (x : ZMod 3) :
     typeE₆DiscriminantQuadraticIsometry x = typeE₆DiscriminantGroupEquiv x := by
   rw [typeE₆DiscriminantQuadraticIsometry]
-  rfl
+  exact FiniteQuadraticModule.cyclicIsometryOfGenerator_apply _ _ _ _ _ x
 
 /-! ## The root lattice of type `E₇` -/
 
@@ -694,7 +608,8 @@ theorem discriminantPairing_typeE₇MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-private theorem typeE₇QuadraticValue_torsion :
+/-- The type-`E₇` generator value `3/4` satisfies both cyclic descent conditions. -/
+theorem typeE₇QuadraticValue_torsion :
     (4 : ℤ) • ((((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
   -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
   change ((((4 : ℚ) * (3 / 4)) : ℚ) : AddCircle (1 : ℚ)) = 0
@@ -704,31 +619,27 @@ private theorem typeE₇QuadraticValue_torsion :
 /-- The quadratic map on `ZMod 2` whose generator has value `3/4`. -/
 noncomputable def typeE₇StandardQuadraticMap :
     QuadraticMap ℤ (ZMod 2) (AddCircle (1 : ℚ)) :=
-  cyclicQuadraticMap 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
+  FiniteQuadraticModule.cyclicMap 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
     typeE₇QuadraticValue_torsion typeE₇QuadraticValue_torsion
 
 /-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`. -/
-@[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule where
-  toFiniteBilinearModule := {
-    carrier := ZMod 2
-    pairing := LinearMap.toAddMonoidHom'.comp typeE₇StandardQuadraticMap.polarBilin.toAddMonoidHom
-    pairing_comm := fun x y ↦ QuadraticMap.polar_comm typeE₇StandardQuadraticMap x y }
-  quadratic := typeE₇StandardQuadraticMap
-  polar_eq_pairing' := fun _ _ ↦ rfl
+@[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule :=
+  FiniteQuadraticModule.cyclic 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
+    typeE₇QuadraticValue_torsion typeE₇QuadraticValue_torsion
 
 /-- The generator of the standard type-`E₇` quadratic map has value `3/4`. -/
 @[simp]
 theorem typeE₇StandardQuadraticMap_one :
     typeE₇StandardQuadraticMap 1 =
       (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) :=
-  cyclicQuadraticMap_one 2 _ _ _
+  FiniteQuadraticModule.cyclicMap_one 2 _ _ _
 
 /-- The standard cyclic quadratic module of type `E₇` is isometric to the discriminant
 quadratic module of the `E₇` root lattice. -/
 noncomputable def typeE₇DiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry typeE₇StandardQuadraticModule
       (typeE₇RootLattice.discriminantQuadraticModule isEven_typeE₇RootLattice) :=
-  quadraticMapIsometryOfGenerator 2 typeE₇StandardQuadraticMap
+  FiniteQuadraticModule.cyclicIsometryOfGenerator 2 typeE₇StandardQuadraticMap
     (typeE₇RootLattice.discriminantQuadraticMap isEven_typeE₇RootLattice)
     typeE₇DiscriminantGroupEquiv (by
       rw [typeE₇DiscriminantGroupEquiv_apply_one,
@@ -739,14 +650,14 @@ noncomputable def typeE₇DiscriminantQuadraticIsometry :
 theorem typeE₇DiscriminantQuadraticIsometry_toAddEquiv :
     typeE₇DiscriminantQuadraticIsometry.toAddEquiv = typeE₇DiscriminantGroupEquiv := by
   rw [typeE₇DiscriminantQuadraticIsometry]
-  rfl
+  exact FiniteQuadraticModule.cyclicIsometryOfGenerator_toAddEquiv _ _ _ _ _
 
 /-- The type-`E₇` quadratic isometry acts through the discriminant-group equivalence. -/
 @[simp]
 theorem typeE₇DiscriminantQuadraticIsometry_apply (x : ZMod 2) :
     typeE₇DiscriminantQuadraticIsometry x = typeE₇DiscriminantGroupEquiv x := by
   rw [typeE₇DiscriminantQuadraticIsometry]
-  rfl
+  exact FiniteQuadraticModule.cyclicIsometryOfGenerator_apply _ _ _ _ _ x
 
 /-! ## The root lattice of type `E₈` -/
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -319,11 +319,8 @@ theorem discriminantPairing_typeE₆MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`.
-
-The two descent hypotheses are the numeric torsion facts `9 • (2/3) = 0` and `6 • (2/3) = 0` in
-`ℚ/ℤ`; they are discharged inline because they have no independent interest and this definition
-is `@[expose]`d, so its body may mention only public declarations. -/
+/-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`, whose generator has
+quadratic value `2/3`. -/
 @[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
     (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
@@ -599,10 +596,8 @@ theorem discriminantPairing_typeE₇MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`.
-
-Both descent hypotheses are the numeric torsion fact `4 • (3/4) = 0` in `ℚ/ℤ`, discharged inline
-as for `typeE₆StandardQuadraticModule`. -/
+/-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`, whose generator has
+quadratic value `3/4`. -/
 @[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
     (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -328,29 +328,25 @@ quadratic value `2/3`. -/
     (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
         exact Submodule.mem_one.mpr ⟨4, by norm_num⟩)
 
-/-- The quadratic map on `ZMod 3` whose generator has value `2/3`, namely the one carried by
-`typeE₆StandardQuadraticModule`. -/
-noncomputable def typeE₆StandardQuadraticMap :
-    QuadraticMap ℤ (ZMod 3) (AddCircle (1 : ℚ)) :=
-  typeE₆StandardQuadraticModule.quadratic
-
-/-- The generator of the standard type-`E₆` quadratic map has value `2/3`. -/
+/-- The generator of the standard type-`E₆` quadratic module has value `2/3`. -/
 @[simp]
-theorem typeE₆StandardQuadraticMap_one :
-    typeE₆StandardQuadraticMap 1 =
-      (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ)) :=
-  FiniteQuadraticModule.cyclicMap_one 3 _ _ _
+theorem typeE₆StandardQuadraticModule_quadratic_one :
+    typeE₆StandardQuadraticModule.quadratic (1 : ZMod 3) =
+      (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ)) := by
+  unfold typeE₆StandardQuadraticModule
+  rw [FiniteQuadraticModule.cyclic_quadratic, FiniteQuadraticModule.cyclicMap_one]
 
 /-- The standard cyclic quadratic module of type `E₆` is isometric to the discriminant
 quadratic module of the `E₆` root lattice. -/
 noncomputable def typeE₆DiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry typeE₆StandardQuadraticModule
       (typeE₆RootLattice.discriminantQuadraticModule isEven_typeE₆RootLattice) :=
-  FiniteQuadraticModule.cyclicIsometryOfGenerator 3 typeE₆StandardQuadraticMap
+  FiniteQuadraticModule.cyclicIsometryOfGenerator 3 typeE₆StandardQuadraticModule.quadratic
     (typeE₆RootLattice.discriminantQuadraticMap isEven_typeE₆RootLattice)
     typeE₆DiscriminantGroupEquiv (by
       rw [typeE₆DiscriminantGroupEquiv_apply_one,
-        discriminantQuadraticMap_typeE₆MinusculeWeightClass, typeE₆StandardQuadraticMap_one])
+        discriminantQuadraticMap_typeE₆MinusculeWeightClass]
+      exact typeE₆StandardQuadraticModule_quadratic_one.symm)
 
 /-- The underlying additive equivalence of the type-`E₆` quadratic isometry. -/
 @[simp]
@@ -605,29 +601,25 @@ quadratic value `3/4`. -/
     (by rw [AddCircle.zsmul_coe_eq_zero_iff_mem_one]
         exact Submodule.mem_one.mpr ⟨3, by norm_num⟩)
 
-/-- The quadratic map on `ZMod 2` whose generator has value `3/4`, namely the one carried by
-`typeE₇StandardQuadraticModule`. -/
-noncomputable def typeE₇StandardQuadraticMap :
-    QuadraticMap ℤ (ZMod 2) (AddCircle (1 : ℚ)) :=
-  typeE₇StandardQuadraticModule.quadratic
-
-/-- The generator of the standard type-`E₇` quadratic map has value `3/4`. -/
+/-- The generator of the standard type-`E₇` quadratic module has value `3/4`. -/
 @[simp]
-theorem typeE₇StandardQuadraticMap_one :
-    typeE₇StandardQuadraticMap 1 =
-      (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) :=
-  FiniteQuadraticModule.cyclicMap_one 2 _ _ _
+theorem typeE₇StandardQuadraticModule_quadratic_one :
+    typeE₇StandardQuadraticModule.quadratic (1 : ZMod 2) =
+      (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) := by
+  unfold typeE₇StandardQuadraticModule
+  rw [FiniteQuadraticModule.cyclic_quadratic, FiniteQuadraticModule.cyclicMap_one]
 
 /-- The standard cyclic quadratic module of type `E₇` is isometric to the discriminant
 quadratic module of the `E₇` root lattice. -/
 noncomputable def typeE₇DiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry typeE₇StandardQuadraticModule
       (typeE₇RootLattice.discriminantQuadraticModule isEven_typeE₇RootLattice) :=
-  FiniteQuadraticModule.cyclicIsometryOfGenerator 2 typeE₇StandardQuadraticMap
+  FiniteQuadraticModule.cyclicIsometryOfGenerator 2 typeE₇StandardQuadraticModule.quadratic
     (typeE₇RootLattice.discriminantQuadraticMap isEven_typeE₇RootLattice)
     typeE₇DiscriminantGroupEquiv (by
       rw [typeE₇DiscriminantGroupEquiv_apply_one,
-        discriminantQuadraticMap_typeE₇MinusculeWeightClass, typeE₇StandardQuadraticMap_one])
+        discriminantQuadraticMap_typeE₇MinusculeWeightClass]
+      exact typeE₇StandardQuadraticModule_quadratic_one.symm)
 
 /-- The underlying additive equivalence of the type-`E₇` quadratic isometry. -/
 @[simp]


### PR DESCRIPTION
This PR promotes the cyclic `ℚ/ℤ`-valued quadratic-module construction from private `E₆`/`E₇` scaffolding into the shared finite-quadratic-module API. Define `cyclicMap` on `ZMod n` by `q(k) = k²a` under the exact descent conditions `n²a = 0` and `2na = 0`, compute its polar pairing, package it as `FiniteQuadraticModule.cyclic` for nonzero `n`, and prove that an additive equivalence matching generator values is automatically a quadratic isometry. Migrate the existing `E₆` and `E₇` models to this API and update the companion Klein-four documentation.

Target: `TauCetiRoadmap/IntegralLattices/README.md`, Layer 5 “ADE root lattices,” specifically the milestone requiring every ADE row's finite quadratic module to be identified up to isometry. The `Aₙ` and odd-`Dₙ` rows already have cyclic discriminant-group equivalences and generator values on `main`, while merged PR #4665 explicitly identifies promotion of the private TypeE cyclic construction as their prerequisite.

This is the most effective unblocked critical-path step because the general discriminant-form layers, exceptional rows, even `Dₙ`, and `D₈⁺` glue are complete, while the separate odd-lattice bilinear comparison is currently covered by open PR #3805. After this PR, Layer 5 still needs the `Aₙ` and odd-`Dₙ` standard cyclic modules instantiated and their existing discriminant-group equivalences upgraded to quadratic isometries.

Add `TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean` (213 lines), remove the duplicate private construction from `TypeE.lean`, and update `KleinFour.lean`. No Mathlib code is vendored; the construction reuses Mathlib's `QuadraticMap.lift`, integer quotient equivalence for `ZMod`, and `ZMod.intCast_surjective`.

Roadmap: IntegralLattices

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"cyclic-finite-quadratic-module"}-->

🤖 Prepared with Codex
