### PR TITLE
feat: relate solvability to the derived subgroup

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Derived.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Derived.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Derived.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
+
+/-!
+# Solvability and the derived closed subgroup
+
+Let `H` be a commutative Hopf algebra. Its derived closed subgroup has coordinate algebra
+`H / CommHopfAlgCat.derivedDefiningIdeal H`. This file proves, over any commutative base and at
+every commutative value algebra, that the point group of `H` is solvable exactly when the point
+group of this derived subgroup is solvable. The geometric-points statement over a field is then an
+immediate specialization.
+
+One implication is closure of solvability under closed subgroups. Conversely, the derived closed
+subgroup contains every pointwise commutator, so the corresponding point-group quotient is
+commutative. Solvability of the derived subgroup and of this commutative quotient then gives
+solvability of the ambient point group by extension closure. No equality between the abstract
+pointwise commutator subgroup and the points of the derived group is needed.
+
+## Main declaration
+
+* `TauCeti.CommHopfAlgCat.isSolvable_points_iff_derived`: over any commutative base and value
+  algebra, the point group is solvable exactly when the derived closed subgroup's point group is.
+* `TauCeti.geometricallySolvablePointsCommHopfAlgProperty_iff_derived`: geometric-point
+  solvability is equivalent to geometric-point solvability of the derived closed subgroup.
+
+## References
+
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+* T. A. Springer, *Linear Algebraic Groups*, Section 2.4.
+
+This advances Layer 5, "Lie--Kolchin; solvable groups", of the ReductiveGroups roadmap. It is the
+derived-subgroup recursion bridge connecting the existing scheme-theoretic derived subgroup to the
+existing geometric-points solvability predicate. The strict-dimension step and the representation
+induction remain separate.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u v w
+
+namespace CommHopfAlgCat
+
+variable {R : Type u} [CommRing R]
+
+/-- The group of points of an affine group is solvable if and only if the group of points of its
+derived closed subgroup is solvable.
+
+The forward implication uses the injection from quotient-coordinate points into ambient points.
+For the reverse implication, their image is a normal solvable subgroup containing the abstract
+commutator subgroup. The ambient point group is therefore an extension of a commutative group by
+a solvable group. This statement holds over an arbitrary commutative base ring and at every
+commutative value algebra. -/
+theorem isSolvable_points_iff_derived (H : _root_.CommHopfAlgCat.{v} R)
+    (A : CommAlgCat.{w} R) :
+    Group.IsSolvable (HopfAlgebra.points (R := R) (H := H) A) ↔
+      Group.IsSolvable
+        (HopfAlgebra.points (R := R)
+          (H := quotient H (derivedDefiningIdeal H)) A) := by
+  let G := HopfAlgebra.points (R := R) (H := H) A
+  let I := derivedDefiningIdeal (R := R) H
+  let D := quotientPointsSubgroup H I A
+  constructor
+  · intro hG
+    let _ : Group.IsSolvable G := hG
+    exact Group.isSolvable_of_isSolvable_injective
+      (f := (quotientPointsHom H I A).hom)
+      (quotientPointsHom_injective H I A)
+  · intro hderived
+    let q := (quotientPointsHom H I A).hom
+    let _ : Group.IsSolvable
+        (HopfAlgebra.points (R := R) (H := quotient H I) A) := hderived
+    have hD : Group.IsSolvable D :=
+      Group.isSolvable_of_surjective q.rangeRestrict_surjective
+    let _ : Group.IsSolvable D := hD
+    let _ : D.Normal := quotientPointsSubgroup_normal H I
+      (isNormal_derivedDefiningIdeal H) A
+    have hcommutator : commutator G ≤ D :=
+      commutator_le_quotientPointsSubgroup_of_le_derivedDefiningIdeal H I le_rfl A
+    have hcommutative : IsMulCommutative (G ⧸ D) :=
+      (Subgroup.Normal.quotient_commutative_iff_commutator_le).mpr hcommutator
+    have hquotient : Group.IsSolvable (G ⧸ D) :=
+      Group.isSolvable_of_comm (isMulCommutative_iff.mp hcommutative)
+    exact (Group.isSolvable_iff_subgroup_quotient D).mpr ⟨hD, hquotient⟩
+
+end CommHopfAlgCat
+
+/-- An affine group has solvable geometric points if and only if its derived closed subgroup does.
+
+The forward implication uses that the derived closed subgroup embeds in the ambient group on
+points. For the reverse implication, its image is a normal solvable subgroup containing the
+abstract commutator subgroup, so the quotient is commutative and hence solvable. -/
+theorem geometricallySolvablePointsCommHopfAlgProperty_iff_derived
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k) :
+    geometricallySolvablePointsCommHopfAlgProperty k H ↔
+      geometricallySolvablePointsCommHopfAlgProperty k
+        (CommHopfAlgCat.quotient H (CommHopfAlgCat.derivedDefiningIdeal H)) := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff,
+    geometricallySolvablePointsCommHopfAlgProperty_iff]
+  exact CommHopfAlgCat.isSolvable_points_iff_derived H
+    (CommAlgCat.of k (AlgebraicClosure k))
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Derived.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Derived.lean
@@ -14,8 +14,8 @@ public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
 Let `H` be a commutative Hopf algebra. Its derived closed subgroup has coordinate algebra
 `H / CommHopfAlgCat.derivedDefiningIdeal H`. This file proves, over any commutative base and at
 every commutative value algebra, that the point group of `H` is solvable exactly when the point
-group of this derived subgroup is solvable. The geometric-points statement over a field is then an
-immediate specialization.
+group of any closed subgroup containing the derived subgroup is solvable. The derived-subgroup
+and geometric-points statements are immediate specializations.
 
 One implication is closure of solvability under closed subgroups. Conversely, the derived closed
 subgroup contains every pointwise commutator, so the corresponding point-group quotient is
@@ -23,10 +23,12 @@ commutative. Solvability of the derived subgroup and of this commutative quotien
 solvability of the ambient point group by extension closure. No equality between the abstract
 pointwise commutator subgroup and the points of the derived group is needed.
 
-## Main declaration
+## Main declarations
 
-* `TauCeti.CommHopfAlgCat.isSolvable_points_iff_derived`: over any commutative base and value
-  algebra, the point group is solvable exactly when the derived closed subgroup's point group is.
+* `TauCeti.CommHopfAlgCat.isSolvable_points_iff_of_le_derivedDefiningIdeal`: over any
+  commutative base and value algebra, the point group is solvable exactly when any closed subgroup
+  containing the derived subgroup has a solvable point group.
+* `TauCeti.CommHopfAlgCat.isSolvable_points_iff_derived`: the derived-subgroup specialization.
 * `TauCeti.geometricallySolvablePointsCommHopfAlgProperty_iff_derived`: geometric-point
   solvability is equivalent to geometric-point solvability of the derived closed subgroup.
 
@@ -53,61 +55,91 @@ namespace CommHopfAlgCat
 
 variable {R : Type u} [CommRing R]
 
-/-- The group of points of an affine group is solvable if and only if the group of points of its
-derived closed subgroup is solvable.
-
-The forward implication uses the injection from quotient-coordinate points into ambient points.
-For the reverse implication, their image is a normal solvable subgroup containing the abstract
-commutator subgroup. The ambient point group is therefore an extension of a commutative group by
-a solvable group. This statement holds over an arbitrary commutative base ring and at every
+/-- The point group of a closed subgroup of an affine group is solvable whenever the ambient
+point group is solvable. This holds over an arbitrary commutative base ring and at every
 commutative value algebra. -/
+theorem isSolvable_points_quotient (H : _root_.CommHopfAlgCat.{v} R)
+    (I : HopfIdeal R H) (A : CommAlgCat.{w} R) :
+    Group.IsSolvable (HopfAlgebra.points (R := R) (H := H) A) →
+      Group.IsSolvable
+        (HopfAlgebra.points (R := R) (H := quotient H I) A) := by
+  intro hH
+  let _ : Group.IsSolvable (HopfAlgebra.points (R := R) (H := H) A) := hH
+  exact Group.isSolvable_of_isSolvable_injective
+    (f := (quotientPointsHom H I A).hom)
+    (quotientPointsHom_injective H I A)
+
+/-- If a closed subgroup contains the derived subgroup and its point group is solvable, then the
+ambient point group is solvable. This holds over an arbitrary commutative base ring and at every
+commutative value algebra. -/
+theorem isSolvable_points_of_le_derivedDefiningIdeal
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H)
+    (hID : I ≤ derivedDefiningIdeal (R := R) H) (A : CommAlgCat.{w} R) :
+    Group.IsSolvable (HopfAlgebra.points (R := R) (H := quotient H I) A) →
+      Group.IsSolvable (HopfAlgebra.points (R := R) (H := H) A) := by
+  let G := HopfAlgebra.points (R := R) (H := H) A
+  let D := quotientPointsSubgroup H I A
+  intro hsubgroup
+  let q := (quotientPointsHom H I A).hom
+  let _ : Group.IsSolvable
+      (HopfAlgebra.points (R := R) (H := quotient H I) A) := hsubgroup
+  have hD : Group.IsSolvable D :=
+    Group.isSolvable_of_surjective q.rangeRestrict_surjective
+  let _ : D.Normal := quotientPointsSubgroup_normal H I
+    (isNormal_of_le_derivedDefiningIdeal H I hID) A
+  have hcommutative : IsMulCommutative (G ⧸ D) :=
+    isMulCommutative_pointQuotient_of_le_derivedDefiningIdeal H I hID A
+  have hquotient : Group.IsSolvable (G ⧸ D) :=
+    Group.isSolvable_of_comm (isMulCommutative_iff.mp hcommutative)
+  exact (Group.isSolvable_iff_subgroup_quotient D).mpr ⟨hD, hquotient⟩
+
+/-- The point group of an affine group is solvable if and only if the point group of any closed
+subgroup containing its derived subgroup is solvable. This holds over an arbitrary commutative
+base ring and at every commutative value algebra. -/
+theorem isSolvable_points_iff_of_le_derivedDefiningIdeal
+    (H : _root_.CommHopfAlgCat.{v} R) (I : HopfIdeal R H)
+    (hID : I ≤ derivedDefiningIdeal (R := R) H) (A : CommAlgCat.{w} R) :
+    Group.IsSolvable (HopfAlgebra.points (R := R) (H := H) A) ↔
+      Group.IsSolvable
+        (HopfAlgebra.points (R := R) (H := quotient H I) A) :=
+  ⟨isSolvable_points_quotient H I A,
+    isSolvable_points_of_le_derivedDefiningIdeal H I hID A⟩
+
+/-- The group of points of an affine group is solvable if and only if the group of points of its
+derived closed subgroup is solvable, over any commutative base and value algebra. -/
 theorem isSolvable_points_iff_derived (H : _root_.CommHopfAlgCat.{v} R)
     (A : CommAlgCat.{w} R) :
     Group.IsSolvable (HopfAlgebra.points (R := R) (H := H) A) ↔
       Group.IsSolvable
         (HopfAlgebra.points (R := R)
-          (H := quotient H (derivedDefiningIdeal H)) A) := by
-  let G := HopfAlgebra.points (R := R) (H := H) A
-  let I := derivedDefiningIdeal (R := R) H
-  let D := quotientPointsSubgroup H I A
-  constructor
-  · intro hG
-    let _ : Group.IsSolvable G := hG
-    exact Group.isSolvable_of_isSolvable_injective
-      (f := (quotientPointsHom H I A).hom)
-      (quotientPointsHom_injective H I A)
-  · intro hderived
-    let q := (quotientPointsHom H I A).hom
-    let _ : Group.IsSolvable
-        (HopfAlgebra.points (R := R) (H := quotient H I) A) := hderived
-    have hD : Group.IsSolvable D :=
-      Group.isSolvable_of_surjective q.rangeRestrict_surjective
-    let _ : Group.IsSolvable D := hD
-    let _ : D.Normal := quotientPointsSubgroup_normal H I
-      (isNormal_derivedDefiningIdeal H) A
-    have hcommutator : commutator G ≤ D :=
-      commutator_le_quotientPointsSubgroup_of_le_derivedDefiningIdeal H I le_rfl A
-    have hcommutative : IsMulCommutative (G ⧸ D) :=
-      (Subgroup.Normal.quotient_commutative_iff_commutator_le).mpr hcommutator
-    have hquotient : Group.IsSolvable (G ⧸ D) :=
-      Group.isSolvable_of_comm (isMulCommutative_iff.mp hcommutative)
-    exact (Group.isSolvable_iff_subgroup_quotient D).mpr ⟨hD, hquotient⟩
+          (H := quotient H (derivedDefiningIdeal H)) A) :=
+  isSolvable_points_iff_of_le_derivedDefiningIdeal H (derivedDefiningIdeal H) le_rfl A
 
 end CommHopfAlgCat
 
-/-- An affine group has solvable geometric points if and only if its derived closed subgroup does.
+/-- An affine group has solvable geometric points if and only if any closed subgroup containing
+its derived subgroup does. This is the point-group result specialized to algebraic-closure-valued
+points. -/
+theorem geometricallySolvablePointsCommHopfAlgProperty_iff_of_le_derivedDefiningIdeal
+    (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k) (I : HopfIdeal k H)
+    (hID : I ≤ CommHopfAlgCat.derivedDefiningIdeal H) :
+    geometricallySolvablePointsCommHopfAlgProperty k H ↔
+      geometricallySolvablePointsCommHopfAlgProperty k
+        (CommHopfAlgCat.quotient H I) := by
+  rw [geometricallySolvablePointsCommHopfAlgProperty_iff,
+    geometricallySolvablePointsCommHopfAlgProperty_iff]
+  exact CommHopfAlgCat.isSolvable_points_iff_of_le_derivedDefiningIdeal H I hID
+    (CommAlgCat.of k (AlgebraicClosure k))
 
-The forward implication uses that the derived closed subgroup embeds in the ambient group on
-points. For the reverse implication, its image is a normal solvable subgroup containing the
-abstract commutator subgroup, so the quotient is commutative and hence solvable. -/
+/-- An affine group has solvable geometric points if and only if its derived closed subgroup does.
+This is `CommHopfAlgCat.isSolvable_points_iff_derived` specialized to
+algebraic-closure-valued points. -/
 theorem geometricallySolvablePointsCommHopfAlgProperty_iff_derived
     (k : Type u) [Field k] (H : CommHopfAlgCat.{v} k) :
     geometricallySolvablePointsCommHopfAlgProperty k H ↔
       geometricallySolvablePointsCommHopfAlgProperty k
-        (CommHopfAlgCat.quotient H (CommHopfAlgCat.derivedDefiningIdeal H)) := by
-  rw [geometricallySolvablePointsCommHopfAlgProperty_iff,
-    geometricallySolvablePointsCommHopfAlgProperty_iff]
-  exact CommHopfAlgCat.isSolvable_points_iff_derived H
-    (CommAlgCat.of k (AlgebraicClosure k))
+        (CommHopfAlgCat.quotient H (CommHopfAlgCat.derivedDefiningIdeal H)) :=
+  geometricallySolvablePointsCommHopfAlgProperty_iff_of_le_derivedDefiningIdeal
+    k H (CommHopfAlgCat.derivedDefiningIdeal H) le_rfl
 
 end TauCeti


### PR DESCRIPTION
This PR proves that the point group of a commutative Hopf algebra is solvable exactly when the point group of its scheme-theoretic derived closed subgroup is solvable, first over an arbitrary commutative base ring and value algebra and then for the geometric-points predicate over a field. It advances the exact `TauCetiRoadmap/ReductiveGroups/README.md` Layer 5 milestone “Lie–Kolchin; solvable groups” by connecting the existing solvability predicate to the existing derived-subgroup construction, and it consumes Layer 6’s named `G_der` target rather than introducing a parallel derived object.

The reverse implication uses the represented derived subgroup’s normal image inside the ambient point group. That image contains the abstract commutator subgroup by `CommHopfAlgCat.commutator_le_quotientPointsSubgroup_of_le_derivedDefiningIdeal`, so its quotient is commutative; extension closure then recovers solvability of the ambient group. The forward implication is closed-subgroup inheritance through the injective quotient-points map. This deliberately does not assert equality between the abstract commutator subgroup and the rational points of its scheme-theoretic closure.

The milestone’s commutative trigonalization and scheme-theoretic derived subgroup are already on `main`, while the open unipotent-radical PRs concern a separate maximal-dimension construction. This is therefore the most effective unclaimed bridge toward the general Lie–Kolchin recursion. After this PR, the milestone still needs the strict-decrease result for the derived subgroup of a noncommutative connected solvable group and the resulting invariant-line and flag induction.

Add `TauCeti/Algebra/AlgebraicGroup/Solvable/Derived.lean` (113 lines). No Mathlib source or external formalization is vendored; the module credits Jantzen, *Representations of Algebraic Groups*, I.2, and Springer, *Linear Algebraic Groups*, §2.4.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geometric-solvability-derived-subgroup"}-->

🤖 Prepared with Codex
