### PR TITLE
feat: the discriminant quadratic module of an odd-rank checkerboard lattice

### DIFF
--- a/TauCeti/Algebra/AddCircle.lean
+++ b/TauCeti/Algebra/AddCircle.lean
@@ -20,6 +20,8 @@ in the unit `ℤ`-submodule.
 
 * `AddCircle.coe_eq_zero_iff_mem_one`: vanishing in `AddCircle (1 : ℚ)` is membership in
   `(1 : Submodule ℤ ℚ)`.
+* `AddCircle.zsmul_coe_eq_zero`: an integer multiple of a rational number vanishes in
+  `AddCircle (1 : ℚ)` once that multiple is an integer.
 -/
 
 public section
@@ -36,5 +38,17 @@ theorem coe_eq_zero_iff_mem_one (q : ℚ) :
   · intro h
     obtain ⟨n, hn⟩ := Submodule.mem_one.mp h
     exact (coe_eq_zero_iff (1 : ℚ)).mpr ⟨n, by simpa using hn⟩
+
+/-- The multiple `k • x` of a rational number vanishes in `ℚ/ℤ` as soon as it is the integer `c`.
+
+This is the shape in which the torsion side conditions of the cyclic and Klein four presentations
+of a finite quadratic module arise: the witness `c` is supplied explicitly and the remaining
+arithmetic identity is a computation in `ℚ`. -/
+theorem zsmul_coe_eq_zero {k c : ℤ} {x : ℚ} (h : (k : ℚ) * x = c) :
+    k • ((x : ℚ) : AddCircle (1 : ℚ)) = 0 := by
+  rw [← coe_zsmul, coe_eq_zero_iff_mem_one]
+  refine Submodule.mem_one.mpr ⟨c, ?_⟩
+  rw [zsmul_eq_mul, h]
+  exact eq_intCast (algebraMap ℤ ℚ) c
 
 end AddCircle

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Isomorphisms
+public import Mathlib.Algebra.Algebra.Bilinear
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
 
 /-!
@@ -23,11 +23,12 @@ q(k) = k²a,   b(j, k) = 2jk·a.
 The construction is a quotient, not a formula in `ZMod.val`: the parameter defines the honest
 `ℤ`-bilinear map `(x, y) ↦ xy·a` on `ℤ`, its associated quadratic map `x ↦ x²a` has the kernel of
 the reduction `ℤ → ℤ/m` inside its radical exactly under the two torsion hypotheses, and
-`QuadraticMap.lift` descends it.  The hypotheses are therefore not technical: `m²a = 0` is the
-statement that the quadratic value of the generator is well defined modulo `m`, and `2ma = 0` the
-corresponding statement for the pairing.  Neither implies the other: for `m = 1` and `a = 1/2` the
-second holds and the first fails, while for `m = 2` and `a = 1/4` the first holds and the second
-fails.
+`TauCeti.QuadraticMap.liftOfSurjective` descends it.  The hypotheses are therefore not technical:
+`m²a = 0` is the statement that the quadratic value of the generator is well defined modulo `m`,
+and `2ma = 0` the corresponding statement for the pairing.  Neither implies the other: for `m = 1`
+and `a = 1/2` the second holds (`2a = 0`) and the first fails (`a = 1/2`), while for `m = 3` and
+`a = 1/9` the first holds (`9a = 0`) and the second fails (`6a = 2/3`).  No witness of the latter
+kind has `m = 2`, where the two coefficients `m² = 4` and `2m = 4` agree.
 
 The companion `TauCeti.FiniteQuadraticModule.cyclicIsometryOfGenerator` turns an additive
 equivalence `ℤ/m ≃+ A` matching the single generator value into an isometry onto `A`, which is how
@@ -66,16 +67,12 @@ variable (m : ℕ) (a : AddCircle (1 : ℚ))
 
 /-! ## The presenting quadratic map on `ℤ` -/
 
-/-- The bilinear map `(x, y) ↦ xy·a` on `ℤ`. -/
+/-- The bilinear map `(x, y) ↦ xy·a` on `ℤ`: multiplication followed by the linear map sending
+`1` to `a`. -/
 private def cyclicBilin : LinearMap.BilinMap ℤ ℤ (AddCircle (1 : ℚ)) :=
-  LinearMap.mk₂ ℤ (fun x y : ℤ ↦ (x * y) • a)
-    (fun x y z ↦ by rw [add_mul, add_smul])
-    (fun r x y ↦ by rw [smul_eq_mul, mul_assoc, mul_smul])
-    (fun x y z ↦ by rw [mul_add, add_smul])
-    (fun r x y ↦ by rw [smul_eq_mul, mul_left_comm, mul_smul])
+  (LinearMap.mul ℤ ℤ).compr₂ (LinearMap.toSpanSingleton ℤ (AddCircle (1 : ℚ)) a)
 
-private theorem cyclicBilin_apply (x y : ℤ) : cyclicBilin a x y = (x * y) • a := by
-  rw [cyclicBilin, LinearMap.mk₂_apply]
+private theorem cyclicBilin_apply (x y : ℤ) : cyclicBilin a x y = (x * y) • a := (rfl)
 
 /-- The quadratic map `x ↦ x²a` on `ℤ`. -/
 private def cyclicAux : QuadraticMap ℤ ℤ (AddCircle (1 : ℚ)) :=
@@ -130,19 +127,13 @@ include hq hp
 
 /-- The quadratic map on `ℤ/m` sending the generator `1` to `a`. -/
 noncomputable def cyclicMap : QuadraticMap ℤ (ZMod m) (AddCircle (1 : ℚ)) :=
-  ((cyclicAux a).lift (LinearMap.ker (zmodProj m))
-      (ker_zmodProj_le_radical m a hq hp)).comp
-    ((zmodProj m).quotKerEquivOfSurjective (zmodProj_surjective m)).symm.toLinearMap
+  QuadraticMap.liftOfSurjective (cyclicAux a) (zmodProj m) (zmodProj_surjective m)
+    (ker_zmodProj_le_radical m a hq hp)
 
 /-- The value of `cyclicMap` on the reduction of an integer. -/
 theorem cyclicMap_intCast (k : ℤ) :
     cyclicMap m a hq hp (k : ZMod m) = (k * k) • a := by
-  have hsymm :
-      ((zmodProj m).quotKerEquivOfSurjective (zmodProj_surjective m)).symm (k : ZMod m) =
-        Submodule.Quotient.mk k := by
-    rw [← zmodProj_apply m k, LinearMap.quotKerEquivOfSurjective_symm_apply]
-  rw [cyclicMap, QuadraticMap.comp_apply, LinearEquiv.coe_coe, hsymm, QuadraticMap.lift_mk,
-    cyclicAux_apply]
+  rw [cyclicMap, ← zmodProj_apply m k, QuadraticMap.liftOfSurjective_apply, cyclicAux_apply]
 
 @[simp]
 theorem cyclicMap_one : cyclicMap m a hq hp 1 = a := by
@@ -163,13 +154,8 @@ theorem polar_cyclicMap_one_one :
   simpa using polar_cyclicMap_intCast m a hq hp 1 1
 
 /-- **The finite quadratic module on `ℤ/m` whose generator has value `a`.** -/
-@[expose] noncomputable def cyclic [NeZero m] : FiniteQuadraticModule where
-  toFiniteBilinearModule := {
-    carrier := ZMod m
-    pairing := LinearMap.toAddMonoidHom'.comp (cyclicMap m a hq hp).polarBilin.toAddMonoidHom
-    pairing_comm := fun x y ↦ QuadraticMap.polar_comm (cyclicMap m a hq hp) x y }
-  quadratic := cyclicMap m a hq hp
-  polar_eq_pairing' := fun _ _ ↦ (rfl)
+@[expose] noncomputable def cyclic [NeZero m] : FiniteQuadraticModule :=
+  ofQuadraticMap (cyclicMap m a hq hp)
 
 @[simp]
 theorem cyclic_quadratic [NeZero m] (x : ZMod m) :

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Isomorphisms
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
+
+/-!
+# Cyclic finite quadratic modules
+
+A `ℚ/ℤ`-valued quadratic map on `ℤ/m` is determined by its value on the generator `1`, and a
+value `a` occurs exactly when `m²a = 0` and `2ma = 0`.  This file makes that presentation
+available as a construction: given `a : ℚ/ℤ` satisfying those two torsion conditions,
+`TauCeti.FiniteQuadraticModule.cyclic` is the finite quadratic module on `ZMod m` with
+
+```text
+q(k) = k²a,   b(j, k) = 2jk·a.
+```
+
+The construction is a quotient, not a formula in `ZMod.val`: the parameter defines the honest
+`ℤ`-bilinear map `(x, y) ↦ xy·a` on `ℤ`, its associated quadratic map `x ↦ x²a` has the kernel of
+the reduction `ℤ → ℤ/m` inside its radical exactly under the two torsion hypotheses, and
+`QuadraticMap.lift` descends it.  The hypotheses are therefore not technical: `m²a = 0` is the
+statement that the quadratic value of the generator is well defined modulo `m`, and `2ma = 0` the
+corresponding statement for the pairing.  Neither implies the other: for `m = 1` and `a = 1/2` the
+second holds and the first fails, while for `m = 2` and `a = 1/4` the first holds and the second
+fails.
+
+The companion `TauCeti.FiniteQuadraticModule.cyclicIsometryOfGenerator` turns an additive
+equivalence `ℤ/m ≃+ A` matching the single generator value into an isometry onto `A`, which is how
+a cyclic discriminant form is identified.  It needs no hypothesis beyond that one value, because
+an additive equivalence out of a cyclic group is determined by the image of the generator.
+
+The rank-two analogue, presenting a form on the Klein four-group by its three nonzero values, is
+`TauCeti.FiniteQuadraticModule.kleinFour` in
+`TauCeti.LinearAlgebra.FiniteBilinearModule.KleinFour`.
+
+## Main declarations
+
+* `TauCeti.FiniteQuadraticModule.cyclicMap`: the quadratic map on `ZMod m` whose generator has the
+  prescribed value.
+* `TauCeti.FiniteQuadraticModule.cyclic`: the resulting finite quadratic module.
+* `TauCeti.FiniteQuadraticModule.cyclicIsometryOfGenerator`: an additive equivalence matching the
+  generator value is an isometry.
+
+## References
+
+* V. V. Nikulin, *Integral symmetric bilinear forms and some of their applications*, §1.1 for
+  discriminant forms and §1.8 for the cyclic forms written `q_θ^{(p)}` in the full-norm
+  convention.
+* W. Ebeling, *Lattices and Codes*, Chapter 1.
+
+This is part of Layer 3 of `TauCetiRoadmap/IntegralLattices/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace FiniteQuadraticModule
+
+variable (m : ℕ) (a : AddCircle (1 : ℚ))
+
+/-! ## The presenting quadratic map on `ℤ` -/
+
+/-- The bilinear map `(x, y) ↦ xy·a` on `ℤ`. -/
+private def cyclicBilin : LinearMap.BilinMap ℤ ℤ (AddCircle (1 : ℚ)) :=
+  LinearMap.mk₂ ℤ (fun x y : ℤ ↦ (x * y) • a)
+    (fun x y z ↦ by rw [add_mul, add_smul])
+    (fun r x y ↦ by rw [smul_eq_mul, mul_assoc, mul_smul])
+    (fun x y z ↦ by rw [mul_add, add_smul])
+    (fun r x y ↦ by rw [smul_eq_mul, mul_left_comm, mul_smul])
+
+private theorem cyclicBilin_apply (x y : ℤ) : cyclicBilin a x y = (x * y) • a := by
+  rw [cyclicBilin, LinearMap.mk₂_apply]
+
+/-- The quadratic map `x ↦ x²a` on `ℤ`. -/
+private def cyclicAux : QuadraticMap ℤ ℤ (AddCircle (1 : ℚ)) :=
+  (cyclicBilin a).toQuadraticMap
+
+private theorem cyclicAux_apply (x : ℤ) : cyclicAux a x = (x * x) • a := by
+  rw [cyclicAux, LinearMap.BilinMap.toQuadraticMap_apply, cyclicBilin_apply]
+
+private theorem polar_cyclicAux (x y : ℤ) :
+    QuadraticMap.polar (cyclicAux a) x y = (2 * (x * y)) • a := by
+  rw [cyclicAux, LinearMap.BilinMap.polar_toQuadraticMap, cyclicBilin_apply, cyclicBilin_apply,
+    ← add_smul]
+  congr 1
+  ring
+
+/-! ## Reduction modulo `m` -/
+
+/-- Reduction `ℤ → ℤ/m`. -/
+private def zmodProj : ℤ →ₗ[ℤ] ZMod m :=
+  (Int.castAddHom (ZMod m)).toIntLinearMap
+
+private theorem zmodProj_apply (k : ℤ) : zmodProj m k = (k : ZMod m) := (rfl)
+
+private theorem zmodProj_surjective : Function.Surjective (zmodProj m) :=
+  ZMod.intCast_surjective
+
+private theorem mem_ker_zmodProj_iff (k : ℤ) :
+    k ∈ LinearMap.ker (zmodProj m) ↔ (m : ℤ) ∣ k := by
+  rw [LinearMap.mem_ker, zmodProj_apply, ZMod.intCast_zmod_eq_zero_iff_dvd]
+
+/-- Under the two torsion hypotheses the kernel of reduction modulo `m` lies in the radical,
+which is what lets the quadratic map descend. -/
+private theorem ker_zmodProj_le_radical (hq : ((m : ℤ) * m) • a = 0)
+    (hp : (2 * (m : ℤ)) • a = 0) :
+    LinearMap.ker (zmodProj m) ≤ (cyclicAux a).radical := by
+  intro x hx
+  obtain ⟨k, rfl⟩ := (mem_ker_zmodProj_iff m x).mp hx
+  constructor
+  · rw [cyclicAux_apply]
+    have e : ((m : ℤ) * k * ((m : ℤ) * k)) = (k * k) * ((m : ℤ) * m) := by ring
+    rw [e, mul_smul, hq, smul_zero]
+  · refine LinearMap.ext fun y ↦ ?_
+    rw [LinearMap.zero_apply, QuadraticMap.polarBilin_apply_apply, polar_cyclicAux]
+    have e : (2 * ((m : ℤ) * k * y)) = (k * y) * (2 * (m : ℤ)) := by ring
+    rw [e, mul_smul, hp, smul_zero]
+
+/-! ## The quadratic module -/
+
+variable (hq : ((m : ℤ) * m) • a = 0) (hp : (2 * (m : ℤ)) • a = 0)
+
+include hq hp
+
+/-- The quadratic map on `ℤ/m` sending the generator `1` to `a`. -/
+noncomputable def cyclicMap : QuadraticMap ℤ (ZMod m) (AddCircle (1 : ℚ)) :=
+  ((cyclicAux a).lift (LinearMap.ker (zmodProj m))
+      (ker_zmodProj_le_radical m a hq hp)).comp
+    ((zmodProj m).quotKerEquivOfSurjective (zmodProj_surjective m)).symm.toLinearMap
+
+/-- The value of `cyclicMap` on the reduction of an integer. -/
+theorem cyclicMap_intCast (k : ℤ) :
+    cyclicMap m a hq hp (k : ZMod m) = (k * k) • a := by
+  have hsymm :
+      ((zmodProj m).quotKerEquivOfSurjective (zmodProj_surjective m)).symm (k : ZMod m) =
+        Submodule.Quotient.mk k := by
+    rw [← zmodProj_apply m k, LinearMap.quotKerEquivOfSurjective_symm_apply]
+  rw [cyclicMap, QuadraticMap.comp_apply, LinearEquiv.coe_coe, hsymm, QuadraticMap.lift_mk,
+    cyclicAux_apply]
+
+@[simp]
+theorem cyclicMap_one : cyclicMap m a hq hp 1 = a := by
+  simpa using cyclicMap_intCast m a hq hp 1
+
+/-- The pairing of two reductions of integers. -/
+theorem polar_cyclicMap_intCast (j k : ℤ) :
+    QuadraticMap.polar (cyclicMap m a hq hp) (j : ZMod m) (k : ZMod m) = (2 * (j * k)) • a := by
+  rw [QuadraticMap.polar, ← Int.cast_add, cyclicMap_intCast, cyclicMap_intCast, cyclicMap_intCast]
+  have e : ((j + k) * (j + k) : ℤ) = j * j + (k * k + 2 * (j * k)) := by ring
+  rw [e, add_smul, add_smul]
+  abel
+
+/-- The generator has self-pairing `2a`.  This is not a `simp` lemma: `QuadraticMap.polar_self`
+together with `cyclicMap_one` already rewrites the left-hand side to the right-hand side. -/
+theorem polar_cyclicMap_one_one :
+    QuadraticMap.polar (cyclicMap m a hq hp) 1 1 = (2 : ℤ) • a := by
+  simpa using polar_cyclicMap_intCast m a hq hp 1 1
+
+/-- **The finite quadratic module on `ℤ/m` whose generator has value `a`.** -/
+@[expose] noncomputable def cyclic [NeZero m] : FiniteQuadraticModule where
+  toFiniteBilinearModule := {
+    carrier := ZMod m
+    pairing := LinearMap.toAddMonoidHom'.comp (cyclicMap m a hq hp).polarBilin.toAddMonoidHom
+    pairing_comm := fun x y ↦ QuadraticMap.polar_comm (cyclicMap m a hq hp) x y }
+  quadratic := cyclicMap m a hq hp
+  polar_eq_pairing' := fun _ _ ↦ (rfl)
+
+@[simp]
+theorem cyclic_quadratic [NeZero m] (x : ZMod m) :
+    (cyclic m a hq hp).quadratic x = cyclicMap m a hq hp x := (rfl)
+
+@[simp]
+theorem cyclic_pairing [NeZero m] (x y : ZMod m) :
+    (cyclic m a hq hp).toFiniteBilinearModule.pairing x y =
+      QuadraticMap.polar (cyclicMap m a hq hp) x y := (rfl)
+
+omit hq hp in
+/-- **An additive equivalence from `ℤ/m` matching the generator value is an isometry.**
+
+No hypothesis beyond that single value is needed.  Both forms are stated as bare quadratic maps so
+that the construction applies before either is packaged as a finite quadratic module. -/
+noncomputable def cyclicIsometryOfGenerator {A : Type*} [AddCommGroup A]
+    (q : QuadraticMap ℤ (ZMod m) (AddCircle (1 : ℚ)))
+    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod m ≃+ A)
+    (h : r (e 1) = q 1) : q.IsometryEquiv r where
+  toLinearEquiv := e.toIntLinearEquiv
+  map_app' x := by
+    obtain ⟨k, rfl⟩ := ZMod.intCast_surjective x
+    -- The linear and additive equivalences have definitionally equal coercions, so the named
+    -- reflexive theorem `AddEquiv.coe_toIntLinearEquiv` gives `simp` no rewrite step here.
+    change r (e (k : ZMod m)) = q (k : ZMod m)
+    rw [← zsmul_one, map_zsmul, r.map_smul, q.map_smul, h]
+
+omit hq hp in
+/-- The underlying additive equivalence of `cyclicIsometryOfGenerator` is the given one. -/
+@[simp]
+theorem cyclicIsometryOfGenerator_toAddEquiv {A : Type*} [AddCommGroup A]
+    (q : QuadraticMap ℤ (ZMod m) (AddCircle (1 : ℚ)))
+    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod m ≃+ A)
+    (h : r (e 1) = q 1) :
+    (cyclicIsometryOfGenerator m q r e h).toAddEquiv = e := (rfl)
+
+omit hq hp in
+@[simp]
+theorem cyclicIsometryOfGenerator_apply {A : Type*} [AddCommGroup A]
+    (q : QuadraticMap ℤ (ZMod m) (AddCircle (1 : ℚ)))
+    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod m ≃+ A)
+    (h : r (e 1) = q 1) (x : ZMod m) :
+    cyclicIsometryOfGenerator m q r e h x = e x := (rfl)
+
+end FiniteQuadraticModule
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -23,7 +23,7 @@ q(k) = k²a,   b(j, k) = 2jk·a.
 The construction is a quotient, not a formula in `ZMod.val`: the parameter defines the honest
 `ℤ`-bilinear map `(x, y) ↦ xy·a` on `ℤ`, its associated quadratic map `x ↦ x²a` has the kernel of
 the reduction `ℤ → ℤ/m` inside its radical exactly under the two torsion hypotheses, and
-`TauCeti.QuadraticMap.liftOfSurjective` descends it.  The hypotheses are therefore not technical:
+`QuadraticMap.liftOfSurjective` descends it.  The hypotheses are therefore not technical:
 `m²a = 0` is the statement that the quadratic value of the generator is well defined modulo `m`,
 and `2ma = 0` the corresponding statement for the pairing.  Neither implies the other: for `m = 1`
 and `a = 1/2` the second holds (`2a = 0`) and the first fails (`a = 1/2`), while for `m = 3` and

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean
@@ -147,12 +147,6 @@ theorem polar_cyclicMap_intCast (j k : ℤ) :
   rw [e, add_smul, add_smul]
   abel
 
-/-- The generator has self-pairing `2a`.  This is not a `simp` lemma: `QuadraticMap.polar_self`
-together with `cyclicMap_one` already rewrites the left-hand side to the right-hand side. -/
-theorem polar_cyclicMap_one_one :
-    QuadraticMap.polar (cyclicMap m a hq hp) 1 1 = (2 : ℤ) • a := by
-  simpa using polar_cyclicMap_intCast m a hq hp 1 1
-
 /-- **The finite quadratic module on `ℤ/m` whose generator has value `a`.** -/
 @[expose] noncomputable def cyclic [NeZero m] : FiniteQuadraticModule :=
   ofQuadraticMap (cyclicMap m a hq hp)

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
@@ -32,9 +32,9 @@ The companion `TauCeti.FiniteQuadraticModule.kleinFourIsometryOfGenerators` turn
 equivalence `(ℤ/2)² ≃+ A` matching the three displayed values into an isometry onto `A`, which is
 how a discriminant form of order four and exponent two is identified.
 
-The quotient construction is a rank-two adaptation of the private cyclic construction in
-`TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean`; the two can be unified when that
-construction is promoted to shared API.
+The quotient construction is the rank-two adaptation of the cyclic one in
+`TauCeti.LinearAlgebra.FiniteBilinearModule.Cyclic`, which presents a form on `ℤ/m` by the single
+value of its generator.
 
 ## Main declarations
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
@@ -23,7 +23,7 @@ q(1, 0) = α,   q(0, 1) = β,   q(1, 1) = α + β + γ,   b((1, 0), (0, 1)) = γ
 The construction is a quotient, not a formula in `ZMod.val`: the parameters define an honest
 `ℤ`-bilinear map on `ℤ × ℤ`, its associated quadratic map `(m, k) ↦ m²α + k²β + mkγ` has the
 kernel of the reduction `ℤ × ℤ → (ℤ/2)²` inside its radical exactly under the three torsion
-hypotheses, and `TauCeti.QuadraticMap.liftOfSurjective` descends it.  The torsion hypotheses are
+hypotheses, and `QuadraticMap.liftOfSurjective` descends it.  The torsion hypotheses are
 therefore not technical: `4α = 0` is the statement that `q` is well defined on a two-torsion
 generator, and `2γ = 0` the corresponding statement for the pairing.
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/KleinFour.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Isomorphisms
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.Quadratic
 
 /-!
@@ -24,9 +23,9 @@ q(1, 0) = α,   q(0, 1) = β,   q(1, 1) = α + β + γ,   b((1, 0), (0, 1)) = γ
 The construction is a quotient, not a formula in `ZMod.val`: the parameters define an honest
 `ℤ`-bilinear map on `ℤ × ℤ`, its associated quadratic map `(m, k) ↦ m²α + k²β + mkγ` has the
 kernel of the reduction `ℤ × ℤ → (ℤ/2)²` inside its radical exactly under the three torsion
-hypotheses, and `QuadraticMap.lift` descends it.  The torsion hypotheses are therefore not
-technical: `4α = 0` is the statement that `q` is well defined on a two-torsion generator, and
-`2γ = 0` the corresponding statement for the pairing.
+hypotheses, and `TauCeti.QuadraticMap.liftOfSurjective` descends it.  The torsion hypotheses are
+therefore not technical: `4α = 0` is the statement that `q` is well defined on a two-torsion
+generator, and `2γ = 0` the corresponding statement for the pairing.
 
 The companion `TauCeti.FiniteQuadraticModule.kleinFourIsometryOfGenerators` turns an additive
 equivalence `(ℤ/2)² ≃+ A` matching the three displayed values into an isometry onto `A`, which is
@@ -159,19 +158,14 @@ include h₄α h₄β h₂γ
 /-- The quadratic map on `(ℤ/2)²` sending `(1, 0)` to `α`, `(0, 1)` to `β`, and `(1, 1)` to
 `α + β + γ`. -/
 noncomputable def kleinFourMap : QuadraticMap ℤ (ZMod 2 × ZMod 2) (AddCircle (1 : ℚ)) :=
-  ((kleinFourAux α β γ).lift (LinearMap.ker zmodTwoPairProj)
-      (ker_zmodTwoPairProj_le_radical α β γ h₄α h₄β h₂γ)).comp
-    (zmodTwoPairProj.quotKerEquivOfSurjective zmodTwoPairProj_surjective).symm.toLinearMap
+  QuadraticMap.liftOfSurjective (kleinFourAux α β γ) zmodTwoPairProj zmodTwoPairProj_surjective
+    (ker_zmodTwoPairProj_le_radical α β γ h₄α h₄β h₂γ)
 
 /-- The value of `kleinFourMap` on the reduction of a pair of integers. -/
 theorem kleinFourMap_intCast (m k : ℤ) :
     kleinFourMap α β γ h₄α h₄β h₂γ ((m : ZMod 2), (k : ZMod 2)) =
       (m * m) • α + (k * k) • β + (m * k) • γ := by
-  have hsymm :
-      (zmodTwoPairProj.quotKerEquivOfSurjective zmodTwoPairProj_surjective).symm
-          ((m : ZMod 2), (k : ZMod 2)) = Submodule.Quotient.mk (m, k) := by
-    rw [← zmodTwoPairProj_apply m k, LinearMap.quotKerEquivOfSurjective_symm_apply]
-  rw [kleinFourMap, QuadraticMap.comp_apply, LinearEquiv.coe_coe, hsymm, QuadraticMap.lift_mk,
+  rw [kleinFourMap, ← zmodTwoPairProj_apply m k, QuadraticMap.liftOfSurjective_apply,
     kleinFourAux_apply]
 
 @[simp]
@@ -196,14 +190,8 @@ theorem polar_kleinFourMap_one_zero_zero_one :
   abel
 
 /-- **The finite quadratic module on `(ℤ/2)²` with generator values `α`, `β` and `α + β + γ`.** -/
-@[expose] noncomputable def kleinFour : FiniteQuadraticModule where
-  toFiniteBilinearModule := {
-    carrier := ZMod 2 × ZMod 2
-    pairing := LinearMap.toAddMonoidHom'.comp
-      (kleinFourMap α β γ h₄α h₄β h₂γ).polarBilin.toAddMonoidHom
-    pairing_comm := fun x y ↦ QuadraticMap.polar_comm (kleinFourMap α β γ h₄α h₄β h₂γ) x y }
-  quadratic := kleinFourMap α β γ h₄α h₄β h₂γ
-  polar_eq_pairing' := fun _ _ ↦ (rfl)
+@[expose] noncomputable def kleinFour : FiniteQuadraticModule :=
+  ofQuadraticMap (kleinFourMap α β γ h₄α h₄β h₂γ)
 
 @[simp]
 theorem kleinFour_quadratic (x : ZMod 2 × ZMod 2) :

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.OrthogonalComplement
 public import Mathlib.Algebra.Group.Subgroup.Map
+public import Mathlib.LinearAlgebra.Isomorphisms
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
 public import Mathlib.LinearAlgebra.QuadraticForm.Prod
 
@@ -25,8 +26,12 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
 
 ## Main definitions
 
+* `TauCeti.QuadraticMap.liftOfSurjective`: descent of a quadratic map along a surjection whose
+  kernel lies in the radical.
 * `TauCeti.FiniteQuadraticModule`: a finite abelian group with an `AddCircle (1 : ℚ)`-valued
   quadratic map.
+* `TauCeti.FiniteQuadraticModule.ofQuadraticMap`: the finite quadratic module presented by a
+  quadratic map on a finite abelian group.
 * `TauCeti.FiniteQuadraticModule.toFiniteBilinearModule`: the canonical polar bilinear module.
 * `TauCeti.FiniteQuadraticModule.Hom`: a quadratic-map-preserving additive homomorphism.
 * `TauCeti.FiniteQuadraticModule.Isometry`: a quadratic-map isometric equivalence.
@@ -55,6 +60,32 @@ namespace TauCeti
 
 universe u v
 
+/-! ## Descent of a quadratic map along a surjection -/
+
+namespace QuadraticMap
+
+variable {R M N P : Type*} [CommRing R] [AddCommGroup M] [AddCommGroup N] [AddCommGroup P]
+  [Module R M] [Module R N] [Module R P]
+
+/-- Descend a quadratic map along a surjective linear map whose kernel lies in its radical.
+
+Mathlib's `QuadraticMap.lift` descends along the quotient by a submodule of the radical.  A
+quotient is usually presented instead by a surjection onto a concrete group — reduction modulo `m`
+onto `ZMod m`, say — and this is that formulation. -/
+noncomputable def liftOfSurjective (Q : QuadraticMap R M P) (f : M →ₗ[R] N)
+    (hf : Function.Surjective f) (h : LinearMap.ker f ≤ Q.radical) : QuadraticMap R N P :=
+  (Q.lift (LinearMap.ker f) h).comp (f.quotKerEquivOfSurjective hf).symm.toLinearMap
+
+/-- The descended quadratic map takes the original value on every representative. -/
+@[simp]
+theorem liftOfSurjective_apply (Q : QuadraticMap R M P) (f : M →ₗ[R] N)
+    (hf : Function.Surjective f) (h : LinearMap.ker f ≤ Q.radical) (x : M) :
+    liftOfSurjective Q f hf h (f x) = Q x := by
+  rw [liftOfSurjective, QuadraticMap.comp_apply, LinearEquiv.coe_coe,
+    LinearMap.quotKerEquivOfSurjective_symm_apply, QuadraticMap.lift_mk]
+
+end QuadraticMap
+
 /-- A finite abelian group equipped with a quadratic map to `ℚ/ℤ`.
 
 The associated bilinear pairing is required to be the polar form, so the quadratic map determines
@@ -71,6 +102,31 @@ namespace FiniteQuadraticModule
 /-- A finite quadratic module coerces to its underlying type. -/
 instance : CoeSort FiniteQuadraticModule (Type u) :=
   ⟨fun A ↦ A.toFiniteBilinearModule.carrier⟩
+
+/-- **The finite quadratic module presented by a quadratic map** on a finite abelian group.  The
+pairing is the polar form, which is what the structure demands anyway, so no data beyond the
+quadratic map is needed.
+
+Exposed for the same reason as `quotientOfLeQuadraticRadical`: so that its carrier reduces to the
+given group and maps into or out of it are definable. -/
+@[expose] def ofQuadraticMap {C : Type u} [AddCommGroup C] [Finite C]
+    (q : QuadraticMap ℤ C (AddCircle (1 : ℚ))) : FiniteQuadraticModule where
+  toFiniteBilinearModule := {
+    carrier := C
+    pairing := LinearMap.toAddMonoidHom'.comp q.polarBilin.toAddMonoidHom
+    pairing_comm := fun x y ↦ QuadraticMap.polar_comm q x y }
+  quadratic := q
+  polar_eq_pairing' := fun _ _ ↦ (rfl)
+
+@[simp]
+theorem ofQuadraticMap_quadratic {C : Type u} [AddCommGroup C] [Finite C]
+    (q : QuadraticMap ℤ C (AddCircle (1 : ℚ))) (x : C) :
+    (ofQuadraticMap q).quadratic x = q x := (rfl)
+
+@[simp]
+theorem ofQuadraticMap_pairing {C : Type u} [AddCommGroup C] [Finite C]
+    (q : QuadraticMap ℤ C (AddCircle (1 : ℚ))) (x y : C) :
+    (ofQuadraticMap q).toFiniteBilinearModule.pairing x y = QuadraticMap.polar q x y := (rfl)
 
 variable (A : FiniteQuadraticModule)
 

--- a/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
+++ b/TauCeti/LinearAlgebra/FiniteBilinearModule/Quadratic.lean
@@ -26,7 +26,7 @@ the polar pairing is therefore `B(x, y)` modulo `ℤ`.
 
 ## Main definitions
 
-* `TauCeti.QuadraticMap.liftOfSurjective`: descent of a quadratic map along a surjection whose
+* `QuadraticMap.liftOfSurjective`: descent of a quadratic map along a surjection whose
   kernel lies in the radical.
 * `TauCeti.FiniteQuadraticModule`: a finite abelian group with an `AddCircle (1 : ℚ)`-valued
   quadratic map.
@@ -56,8 +56,6 @@ This is the finite-quadratic-module part of Layer 3 of
 
 public section
 
-namespace TauCeti
-
 universe u v
 
 /-! ## Descent of a quadratic map along a surjection -/
@@ -85,6 +83,8 @@ theorem liftOfSurjective_apply (Q : QuadraticMap R M P) (f : M →ₗ[R] N)
     LinearMap.quotKerEquivOfSurjective_symm_apply, QuadraticMap.lift_mk]
 
 end QuadraticMap
+
+namespace TauCeti
 
 /-- A finite abelian group equipped with a quadratic map to `ℚ/ℤ`.
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
@@ -51,8 +51,8 @@ For odd `n` the single value `q(s) = n / 8` already presents the form, because `
 cyclic group `ℤ/4`: `checkerboardCyclicQuadraticModule` is the cyclic model and
 `checkerboardCyclicQuadraticIsometry` is an isometry from it onto `A_L`.  The model records the
 whole of the odd `Dₙ` table row, since its value at `2` is the vector value `q(v) = 1 / 2` — an
-equality which holds in `ℚ/ℤ` exactly because `n` is odd — and its generator self-pairing is
-`b(s, s) = n / 4`.
+equality which holds in `ℚ/ℤ` exactly because `n` is odd, and `2` is carried to `v` by
+`checkerboardCyclicQuadraticIsometry_two` — and its generator self-pairing is `b(s, s) = n / 4`.
 
 The representatives are the ones fixed by Conway and Sloane, so that later glue calculations —
 in particular the enlargement of `D₈` to `E₈` — can reuse them without a change of
@@ -841,9 +841,9 @@ omit [NeZero n] in
 /-- **For odd `n` the vector class is twice the spinor class**, so the discriminant group is
 cyclic of order four. -/
 theorem two_zsmul_checkerboardSpinorClass_of_odd (hn : Odd n) :
-    letI : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+    letI : NeZero n := NeZero.of_pos hn.pos
     (2 : ℤ) • checkerboardSpinorClass n = checkerboardVectorClass n := by
-  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  let _ : NeZero n := NeZero.of_pos hn.pos
   obtain ⟨k, hk⟩ := hn
   rw [← sub_eq_zero, checkerboardSpinorClass, checkerboardVectorClass, ← Submodule.Quotient.mk_smul,
     ← Submodule.Quotient.mk_sub, discriminantGroup_mk_eq_zero_iff, checkerboardLattice_carrier]
@@ -876,7 +876,7 @@ omit [NeZero n] in
 spinor class. -/
 noncomputable def zmodFourAddEquivCheckerboardDiscriminantGroup (hn : Odd n) :
     ZMod 4 ≃+ (checkerboardLattice n).DiscriminantGroup := by
-  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  let _ : NeZero n := NeZero.of_pos hn.pos
   exact
     zmodAddEquivOfGenerator (g := checkerboardSpinorClass n)
       (fun x ↦ by
@@ -897,9 +897,9 @@ omit [NeZero n] in
 /-- The odd-rank identification sends the generator `1` of `ℤ/4` to the spinor class. -/
 @[simp]
 theorem zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one (hn : Odd n) :
-    letI : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+    letI : NeZero n := NeZero.of_pos hn.pos
     zmodFourAddEquivCheckerboardDiscriminantGroup n hn 1 = checkerboardSpinorClass n := by
-  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  let _ : NeZero n := NeZero.of_pos hn.pos
   rw [zmodFourAddEquivCheckerboardDiscriminantGroup]
   exact zmodAddEquivOfGenerator_apply_one _ _
 
@@ -1185,28 +1185,27 @@ This is the `Dₙ` row of the ADE table for odd `n`: not only is the discriminan
 quadratic form is the displayed one.  A single generator value suffices here, in contrast to the
 three values needed in the even-rank case. -/
 noncomputable def checkerboardCyclicQuadraticIsometry (hn : Odd n) :
-    letI : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+    letI : NeZero n := NeZero.of_pos hn.pos
     FiniteQuadraticModule.Isometry (checkerboardCyclicQuadraticModule n)
-      ((checkerboardLattice n).discriminantQuadraticModule (isEven_checkerboardLattice n)) := by
-  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
-  exact
-    FiniteQuadraticModule.cyclicIsometryOfGenerator 4
-      (FiniteQuadraticModule.cyclicMap 4 _ _ _)
-      ((checkerboardLattice n).discriminantQuadraticMap (isEven_checkerboardLattice n))
-      (zmodFourAddEquivCheckerboardDiscriminantGroup n hn)
-      (by
-        rw [zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one,
-          discriminantQuadraticMap_checkerboardSpinorClass,
-          FiniteQuadraticModule.cyclicMap_one])
+      ((checkerboardLattice n).discriminantQuadraticModule (isEven_checkerboardLattice n)) :=
+  letI : NeZero n := NeZero.of_pos hn.pos
+  FiniteQuadraticModule.cyclicIsometryOfGenerator 4
+    (FiniteQuadraticModule.cyclicMap 4 _ _ _)
+    ((checkerboardLattice n).discriminantQuadraticMap (isEven_checkerboardLattice n))
+    (zmodFourAddEquivCheckerboardDiscriminantGroup n hn)
+    (by
+      rw [zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one,
+        discriminantQuadraticMap_checkerboardSpinorClass,
+        FiniteQuadraticModule.cyclicMap_one])
 
 omit [NeZero n] in
 /-- The odd-rank quadratic isometry acts through the discriminant-group equivalence. -/
 @[simp]
 theorem checkerboardCyclicQuadraticIsometry_apply (hn : Odd n) (x : ZMod 4) :
-    letI : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+    letI : NeZero n := NeZero.of_pos hn.pos
     checkerboardCyclicQuadraticIsometry n hn x =
       zmodFourAddEquivCheckerboardDiscriminantGroup n hn x := by
-  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  let _ : NeZero n := NeZero.of_pos hn.pos
   exact FiniteQuadraticModule.cyclicIsometryOfGenerator_apply 4 _ _ _ _ x
 
 omit [NeZero n] in
@@ -1214,18 +1213,34 @@ omit [NeZero n] in
 not a `simp` lemma: `checkerboardCyclicQuadraticIsometry_apply` already rewrites the left-hand side
 into the shape settled by `zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one`. -/
 theorem checkerboardCyclicQuadraticIsometry_one (hn : Odd n) :
-    letI : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+    letI : NeZero n := NeZero.of_pos hn.pos
     checkerboardCyclicQuadraticIsometry n hn (1 : ZMod 4) = checkerboardSpinorClass n := by
-  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  let _ : NeZero n := NeZero.of_pos hn.pos
   rw [checkerboardCyclicQuadraticIsometry_apply,
     zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one]
+
+omit [NeZero n] in
+/-- **The odd-rank quadratic isometry carries the element `2` of `ℤ/4` to the vector class.**
+Together with `checkerboardCyclicQuadraticModule_quadratic_two` this reads the vector value
+`q(v) = 1 / 2` of the table row off the model.  This is not a `simp` lemma, for the same reason as
+`checkerboardCyclicQuadraticIsometry_one`. -/
+theorem checkerboardCyclicQuadraticIsometry_two (hn : Odd n) :
+    letI : NeZero n := NeZero.of_pos hn.pos
+    checkerboardCyclicQuadraticIsometry n hn (2 : ZMod 4) = checkerboardVectorClass n := by
+  let _ : NeZero n := NeZero.of_pos hn.pos
+  have h2 : (2 : ℤ) • (1 : ZMod 4) = (2 : ZMod 4) := by
+    rw [zsmul_eq_mul, mul_one]
+    norm_num
+  rw [checkerboardCyclicQuadraticIsometry_apply, ← h2, map_zsmul,
+    zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one,
+    two_zsmul_checkerboardSpinorClass_of_odd n hn]
 
 omit [NeZero n] in
 /-- **The cyclic `ℤ/4` model is nondegenerate**, since the discriminant form of a nondegenerate
 lattice is. -/
 theorem isNondegenerate_checkerboardCyclicQuadraticModule (hn : Odd n) :
     (checkerboardCyclicQuadraticModule n).IsNondegenerate := by
-  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  let _ : NeZero n := NeZero.of_pos hn.pos
   exact ((checkerboardCyclicQuadraticIsometry n hn).isNondegenerate_iff).mpr
     (isNondegenerate_discriminantQuadraticModule _ _)
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Cyclic
 public import TauCeti.LinearAlgebra.FiniteBilinearModule.KleinFour
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Cardinality
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Quadratic
@@ -38,13 +39,20 @@ has order four; the form is positive definite, so the Gram determinant in any in
 `2s = v`, and is `(ℤ/2)²` when `n` is even.  The two spinor classes then carry the same quadratic
 value, and their mutual pairing is `b(s, c) = (n - 2) / 4`.
 
-For even `n` the file goes further and identifies the discriminant form itself, not only its group:
-the quadratic values `q(v) = 1 / 2` and `q(s) = q(c) = n / 8` together with the pairing
+The file goes further and identifies the discriminant form itself, not only its group.  For even
+`n` the quadratic values `q(v) = 1 / 2` and `q(s) = q(c) = n / 8` together with the pairing
 `b(v, s) = 1 / 2` present it on `(ℤ/2)²`, and `checkerboardDiscriminantQuadraticIsometry` is an
 isometry of finite quadratic modules from that presented model onto `A_L`.  Group order alone does
 not determine this form: as `n` runs over the even residues modulo eight the model runs through
 Nikulin's `u₁` (for `n ≡ 0`), his `v₁` (for `n ≡ 4`), and the two forms with quarter-integral
 spinor values (for `n ≡ 2 mod 4`).
+
+For odd `n` the single value `q(s) = n / 8` already presents the form, because `s` generates the
+cyclic group `ℤ/4`: `checkerboardCyclicQuadraticModule` is the cyclic model and
+`checkerboardCyclicQuadraticIsometry` is an isometry from it onto `A_L`.  The model records the
+whole of the odd `Dₙ` table row, since its value at `2` is the vector value `q(v) = 1 / 2` — an
+equality which holds in `ℚ/ℤ` exactly because `n` is odd — and its generator self-pairing is
+`b(s, s) = n / 4`.
 
 The representatives are the ones fixed by Conway and Sloane, so that later glue calculations —
 in particular the enlargement of `D₈` to `E₈` — can reuse them without a change of
@@ -68,6 +76,8 @@ representative.  The identification of this coordinate model with the *root* lat
   group of an even-rank checkerboard lattice is `(ℤ/2)²`.
 * `TauCeti.IntegralLattice.checkerboardStandardQuadraticModule`: the presented `(ℤ/2)²` model of
   the discriminant form of an even-rank checkerboard lattice.
+* `TauCeti.IntegralLattice.checkerboardCyclicQuadraticModule`: the presented `ℤ/4` model of the
+  discriminant form of an odd-rank checkerboard lattice.
 
 ## Main results
 
@@ -89,8 +99,10 @@ representative.  The identification of this coordinate model with the *root* lat
   and `n / 4`.
 * `TauCeti.IntegralLattice.checkerboardDiscriminantQuadraticIsometry`: for even `n`, the presented
   model is isometric to the discriminant quadratic module.
-* `TauCeti.IntegralLattice.isNondegenerate_checkerboardStandardQuadraticModule`: the presented
-  model is nondegenerate.
+* `TauCeti.IntegralLattice.checkerboardCyclicQuadraticIsometry`: for odd `n`, the cyclic model is
+  isometric to the discriminant quadratic module.
+* `TauCeti.IntegralLattice.isNondegenerate_checkerboardStandardQuadraticModule` and
+  `isNondegenerate_checkerboardCyclicQuadraticModule`: the presented models are nondegenerate.
 
 ## References
 
@@ -1099,6 +1111,122 @@ nondegenerate lattice is. -/
 theorem isNondegenerate_checkerboardStandardQuadraticModule (hn : Even n) :
     (checkerboardStandardQuadraticModule n hn).IsNondegenerate :=
   ((checkerboardDiscriminantQuadraticIsometry n hn).isNondegenerate_iff).mpr
+    (isNondegenerate_discriminantQuadraticModule _ _)
+
+/-! ## The discriminant quadratic module of an odd-rank checkerboard lattice -/
+
+/-- **The cyclic `ℤ/4` model of the odd-rank checkerboard discriminant form**: the generator has
+quadratic value `n / 8`.
+
+The two torsion conditions demanded by the cyclic construction are `16 · (n / 8) = 2n` and
+`8 · (n / 8) = n`, both integers, so the model is defined for every `n`; it is the discriminant
+form of the checkerboard lattice exactly when `n` is odd, since only then does the spinor class
+generate. -/
+@[expose] noncomputable def checkerboardCyclicQuadraticModule (n : ℕ) : FiniteQuadraticModule :=
+  FiniteQuadraticModule.cyclic 4 (((n : ℚ) / 8 : ℚ) : AddCircle (1 : ℚ))
+    (by
+      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
+      refine ⟨2 * n, ?_⟩
+      rw [zsmul_eq_mul, zsmul_eq_mul]
+      push_cast
+      ring)
+    (by
+      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
+      refine ⟨n, ?_⟩
+      rw [zsmul_eq_mul, zsmul_eq_mul]
+      push_cast
+      ring)
+
+omit [NeZero n] in
+/-- The generator of the cyclic model has quadratic value `n / 8`. -/
+@[simp]
+theorem checkerboardCyclicQuadraticModule_quadratic_one :
+    (checkerboardCyclicQuadraticModule n).quadratic (1 : ZMod 4) =
+      (((n : ℚ) / 8 : ℚ) : AddCircle (1 : ℚ)) := by
+  unfold checkerboardCyclicQuadraticModule
+  rw [FiniteQuadraticModule.cyclic_quadratic, FiniteQuadraticModule.cyclicMap_one]
+
+omit [NeZero n] in
+/-- **The double of the generator carries the vector value `1 / 2`**, for odd `n`.  The underlying
+computation is `4 · (n / 8) = n / 2`, which is `1 / 2` in `ℚ/ℤ` exactly when `n` is odd. -/
+@[simp]
+theorem checkerboardCyclicQuadraticModule_quadratic_two (hn : Odd n) :
+    (checkerboardCyclicQuadraticModule n).quadratic (2 : ZMod 4) =
+      (((1 : ℚ) / 2 : ℚ) : AddCircle (1 : ℚ)) := by
+  obtain ⟨k, rfl⟩ := hn
+  have htwo : (2 : ZMod 4) = (((2 : ℤ)) : ZMod 4) := by norm_num
+  unfold checkerboardCyclicQuadraticModule
+  rw [FiniteQuadraticModule.cyclic_quadratic, htwo, FiniteQuadraticModule.cyclicMap_intCast,
+    ← AddCircle.coe_zsmul, ← sub_eq_zero, ← AddCircle.coe_sub, AddCircle.coe_eq_zero_iff]
+  refine ⟨k, ?_⟩
+  rw [zsmul_eq_mul, zsmul_eq_mul]
+  push_cast
+  ring
+
+omit [NeZero n] in
+/-- The generator of the cyclic model has self-pairing `n / 4`. -/
+@[simp]
+theorem checkerboardCyclicQuadraticModule_pairing_one_one :
+    (checkerboardCyclicQuadraticModule n).toFiniteBilinearModule.pairing
+        (1 : ZMod 4) (1 : ZMod 4) = (((n : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) := by
+  unfold checkerboardCyclicQuadraticModule
+  rw [FiniteQuadraticModule.cyclic_pairing, FiniteQuadraticModule.polar_cyclicMap_one_one,
+    ← AddCircle.coe_zsmul]
+  congr 1
+  rw [zsmul_eq_mul]
+  push_cast
+  ring
+
+omit [NeZero n] in
+/-- **The cyclic model is isometric to the discriminant quadratic module of an odd-rank
+checkerboard lattice**, by the identification carrying `1` to the spinor class.
+
+This is the `Dₙ` row of the ADE table for odd `n`: not only is the discriminant group `ℤ/4`, its
+quadratic form is the displayed one.  A single generator value suffices here, in contrast to the
+three values needed in the even-rank case. -/
+noncomputable def checkerboardCyclicQuadraticIsometry (hn : Odd n) :
+    letI : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+    FiniteQuadraticModule.Isometry (checkerboardCyclicQuadraticModule n)
+      ((checkerboardLattice n).discriminantQuadraticModule (isEven_checkerboardLattice n)) := by
+  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  exact
+    FiniteQuadraticModule.cyclicIsometryOfGenerator 4
+      (FiniteQuadraticModule.cyclicMap 4 _ _ _)
+      ((checkerboardLattice n).discriminantQuadraticMap (isEven_checkerboardLattice n))
+      (zmodFourAddEquivCheckerboardDiscriminantGroup n hn)
+      (by
+        rw [zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one,
+          discriminantQuadraticMap_checkerboardSpinorClass,
+          FiniteQuadraticModule.cyclicMap_one])
+
+omit [NeZero n] in
+/-- The odd-rank quadratic isometry acts through the discriminant-group equivalence. -/
+@[simp]
+theorem checkerboardCyclicQuadraticIsometry_apply (hn : Odd n) (x : ZMod 4) :
+    letI : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+    checkerboardCyclicQuadraticIsometry n hn x =
+      zmodFourAddEquivCheckerboardDiscriminantGroup n hn x := by
+  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  exact FiniteQuadraticModule.cyclicIsometryOfGenerator_apply 4 _ _ _ _ x
+
+omit [NeZero n] in
+/-- The odd-rank quadratic isometry carries the generator of `ℤ/4` to the spinor class.  This is
+not a `simp` lemma: `checkerboardCyclicQuadraticIsometry_apply` already rewrites the left-hand side
+into the shape settled by `zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one`. -/
+theorem checkerboardCyclicQuadraticIsometry_one (hn : Odd n) :
+    letI : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+    checkerboardCyclicQuadraticIsometry n hn (1 : ZMod 4) = checkerboardSpinorClass n := by
+  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  rw [checkerboardCyclicQuadraticIsometry_apply,
+    zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one]
+
+omit [NeZero n] in
+/-- **The cyclic `ℤ/4` model is nondegenerate**, since the discriminant form of a nondegenerate
+lattice is. -/
+theorem isNondegenerate_checkerboardCyclicQuadraticModule (hn : Odd n) :
+    (checkerboardCyclicQuadraticModule n).IsNondegenerate := by
+  let _ : NeZero n := ⟨by obtain ⟨k, hk⟩ := hn; omega⟩
+  exact ((checkerboardCyclicQuadraticIsometry n hn).isNondegenerate_iff).mpr
     (isNondegenerate_discriminantQuadraticModule _ _)
 
 end IntegralLattice

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
@@ -1124,18 +1124,8 @@ form of the checkerboard lattice exactly when `n` is odd, since only then does t
 generate. -/
 @[expose] noncomputable def checkerboardCyclicQuadraticModule (n : ℕ) : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 4 (((n : ℚ) / 8 : ℚ) : AddCircle (1 : ℚ))
-    (by
-      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
-      refine ⟨2 * n, ?_⟩
-      rw [zsmul_eq_mul, zsmul_eq_mul]
-      push_cast
-      ring)
-    (by
-      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
-      refine ⟨n, ?_⟩
-      rw [zsmul_eq_mul, zsmul_eq_mul]
-      push_cast
-      ring)
+    (AddCircle.zsmul_coe_eq_zero (c := 2 * n) (by push_cast; ring))
+    (AddCircle.zsmul_coe_eq_zero (c := n) (by push_cast; ring))
 
 omit [NeZero n] in
 /-- The generator of the cyclic model has quadratic value `n / 8`. -/

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeD/Basic.lean
@@ -1170,10 +1170,10 @@ theorem checkerboardCyclicQuadraticModule_pairing_one_one :
     (checkerboardCyclicQuadraticModule n).toFiniteBilinearModule.pairing
         (1 : ZMod 4) (1 : ZMod 4) = (((n : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) := by
   unfold checkerboardCyclicQuadraticModule
-  rw [FiniteQuadraticModule.cyclic_pairing, FiniteQuadraticModule.polar_cyclicMap_one_one,
-    ← AddCircle.coe_zsmul]
+  rw [FiniteQuadraticModule.cyclic_pairing, QuadraticMap.polar_self,
+    FiniteQuadraticModule.cyclicMap_one, ← AddCircle.coe_nsmul]
   congr 1
-  rw [zsmul_eq_mul]
+  rw [nsmul_eq_mul]
   push_cast
   ring
 
@@ -1209,9 +1209,7 @@ theorem checkerboardCyclicQuadraticIsometry_apply (hn : Odd n) (x : ZMod 4) :
   exact FiniteQuadraticModule.cyclicIsometryOfGenerator_apply 4 _ _ _ _ x
 
 omit [NeZero n] in
-/-- The odd-rank quadratic isometry carries the generator of `ℤ/4` to the spinor class.  This is
-not a `simp` lemma: `checkerboardCyclicQuadraticIsometry_apply` already rewrites the left-hand side
-into the shape settled by `zmodFourAddEquivCheckerboardDiscriminantGroup_apply_one`. -/
+/-- The odd-rank quadratic isometry carries the generator of `ℤ/4` to the spinor class. -/
 theorem checkerboardCyclicQuadraticIsometry_one (hn : Odd n) :
     letI : NeZero n := NeZero.of_pos hn.pos
     checkerboardCyclicQuadraticIsometry n hn (1 : ZMod 4) = checkerboardSpinorClass n := by
@@ -1222,8 +1220,7 @@ theorem checkerboardCyclicQuadraticIsometry_one (hn : Odd n) :
 omit [NeZero n] in
 /-- **The odd-rank quadratic isometry carries the element `2` of `ℤ/4` to the vector class.**
 Together with `checkerboardCyclicQuadraticModule_quadratic_two` this reads the vector value
-`q(v) = 1 / 2` of the table row off the model.  This is not a `simp` lemma, for the same reason as
-`checkerboardCyclicQuadraticIsometry_one`. -/
+`q(v) = 1 / 2` of the table row off the model. -/
 theorem checkerboardCyclicQuadraticIsometry_two (hn : Odd n) :
     letI : NeZero n := NeZero.of_pos hn.pos
     checkerboardCyclicQuadraticIsometry n hn (2 : ZMod 4) = checkerboardVectorClass n := by

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -5,13 +5,12 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.GroupTheory.SpecificGroups.Cyclic
 public import Mathlib.LinearAlgebra.Matrix.Cartan
+public import TauCeti.LinearAlgebra.FiniteBilinearModule.Cyclic
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Cardinality
 public import TauCeti.LinearAlgebra.IntegralLattice.Discriminant.Quadratic
 public import TauCeti.LinearAlgebra.IntegralLattice.StandardCoordinates
 public import TauCeti.LinearAlgebra.IntegralLattice.Unimodular
-import Mathlib.Data.ZMod.QuotientGroup
 
 /-!
 # The exceptional root lattices `E₆`, `E₇`, `E₈` and their discriminant forms
@@ -45,6 +44,10 @@ second coordinate `3/2` of `ϖ₇` and the order `2` settles type `E₇`.
 
 The half-norm convention is the one fixed by the integral-lattices roadmap: `q_L(x) = ⟨x,x⟩ / 2`
 in `ℚ/ℤ`.  Nikulin's full-norm values for these rows are `4/3` and `3/2`.
+
+Both cyclic discriminant forms are presented through
+`TauCeti.FiniteQuadraticModule.cyclic`, which builds the form on `ℤ/m` whose generator carries a
+prescribed value; only the two torsion conditions on that value are checked here.
 
 The Cartan matrices, their symmetry and their determinants are Mathlib's, in Bourbaki's numbering:
 the branch node of the diagram is `α₄`, and `α₂` is the short arm.
@@ -88,90 +91,6 @@ namespace TauCeti
 namespace IntegralLattice
 
 open Finset
-
-/- Cyclic quadratic-module construction used below. -/
-
-private def intBilin (a : AddCircle (1 : ℚ)) : LinearMap.BilinMap ℤ ℤ (AddCircle (1 : ℚ)) :=
-  LinearMap.mk₂ ℤ (fun x y : ℤ ↦ (x * y) • a)
-    (fun x y z ↦ by rw [add_mul, add_smul])
-    (fun r x y ↦ by rw [smul_eq_mul, mul_assoc, mul_smul])
-    (fun x y z ↦ by rw [mul_add, add_smul])
-    (fun r x y ↦ by rw [smul_eq_mul, mul_left_comm, mul_smul])
-
-private def intQuadratic (a : AddCircle (1 : ℚ)) : QuadraticMap ℤ ℤ (AddCircle (1 : ℚ)) :=
-  (intBilin a).toQuadraticMap
-
-private theorem zmultiples_le_radical_intQuadratic (n : ℕ) (a : AddCircle (1 : ℚ))
-    (hq : ((n : ℤ) * n) • a = 0) (hp : (2 * (n : ℤ)) • a = 0) :
-    (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule ≤ (intQuadratic a).radical := by
-  intro x hx
-  obtain ⟨k, rfl⟩ := AddSubgroup.mem_zmultiples_iff.mp hx
-  constructor
-  -- Evaluate the quadratic map on this explicit generator multiple.
-  · change (((k * (n : ℤ)) * (k * n)) • a) = 0
-    have hcoeff : (k * (n : ℤ)) * (k * n) = (k * k) * (n * n) := by ring
-    rw [hcoeff, mul_smul, hq, smul_zero]
-  · apply LinearMap.ext
-    intro y
-    -- The second radical condition is the vanishing of the polar map.
-    change QuadraticMap.polar (intQuadratic a) (k • (n : ℤ)) y = 0
-    rw [intQuadratic, LinearMap.BilinMap.polar_toQuadraticMap]
-    simp only [intBilin, LinearMap.mk₂_apply, smul_eq_mul]
-    -- Expose the two evaluations of the underlying integer bilinear map.
-    change ((k * (n : ℤ) * y) • a) + ((y * (k * n)) • a) = 0
-    rw [← add_smul]
-    have hcoeff : k * (n : ℤ) * y + y * (k * n) = (k * y) * (2 * n) := by ring
-    rw [hcoeff, mul_smul, hp, smul_zero]
-
-private def intQuotientEquivZMod (n : ℕ) :
-    (ℤ ⧸ (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule) ≃ₗ[ℤ] ZMod n :=
-  { Int.quotientZMultiplesNatEquivZMod n with
-    map_smul' := by
-      intro k x
-      convert! (Int.quotientZMultiplesNatEquivZMod n).toAddMonoidHom.map_zsmul k x using 1 }
-
-private def cyclicQuadraticMap (n : ℕ) (a : AddCircle (1 : ℚ))
-    (hq : ((n : ℤ) * n) • a = 0) (hp : (2 * (n : ℤ)) • a = 0) :
-    QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)) :=
-  ((intQuadratic a).lift (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule
-      (zmultiples_le_radical_intQuadratic n a hq hp)).comp
-      (intQuotientEquivZMod n).symm.toLinearMap
-
-private theorem cyclicQuadraticMap_one (n : ℕ) (a : AddCircle (1 : ℚ))
-    (hq : ((n : ℤ) * n) • a = 0) (hp : (2 * (n : ℤ)) • a = 0) :
-    cyclicQuadraticMap n a hq hp 1 = a := by
-  unfold cyclicQuadraticMap
-  rw [QuadraticMap.comp_apply]
-  have he : (intQuotientEquivZMod n).symm 1 = Submodule.Quotient.mk (1 : ℤ) := by
-    apply (intQuotientEquivZMod n).injective
-    rw [LinearEquiv.apply_symm_apply]
-    have hs : (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).symm
-        (QuotientAddGroup.mk 1) = QuotientAddGroup.mk 1 := by
-      apply (QuotientAddGroup.quotientAddEquivOfEq (ZMod.ker_intCastAddHom n)).injective
-      rw [AddEquiv.apply_symm_apply, QuotientAddGroup.quotientAddEquivOfEq_mk]
-    -- Expose the composition defining the quotient-to-`ZMod` equivalence.
-    change (1 : ZMod n) = Int.quotientZMultiplesNatEquivZMod n (QuotientAddGroup.mk 1)
-    rw [Int.quotientZMultiplesNatEquivZMod, AddEquiv.trans_apply, hs]
-    -- The generator of `ZMod n` is definitionally the image of the integer generator.
-    change (1 : ZMod n) = ((1 : ℤ) : ZMod n)
-    simp
-  -- Expose the lifted quadratic map at the quotient representative.
-  change (intQuadratic a).lift (AddSubgroup.zmultiples (n : ℤ)).toIntSubmodule _
-    ((intQuotientEquivZMod n).symm 1) = a
-  rw [he, QuadraticMap.lift_mk]
-  simp [intQuadratic, intBilin]
-
-private noncomputable def quadraticMapIsometryOfGenerator (n : ℕ)
-    {A : Type*} [AddCommGroup A]
-    (q : QuadraticMap ℤ (ZMod n) (AddCircle (1 : ℚ)))
-    (r : QuadraticMap ℤ A (AddCircle (1 : ℚ))) (e : ZMod n ≃+ A)
-    (he : r (e 1) = q 1) : q.IsometryEquiv r where
-  toLinearEquiv := e.toIntLinearEquiv
-  map_app' x := by
-    obtain ⟨k, rfl⟩ := ZMod.intCast_surjective x
-    -- Identify the bundled linear equivalence with its underlying additive equivalence.
-    change r (e (k : ZMod n)) = q (k : ZMod n)
-    rw [← zsmul_one, map_zsmul, r.map_smul, q.map_smul, he]
 
 /-! ## The root lattice of type `E₆` -/
 
@@ -403,14 +322,17 @@ theorem discriminantPairing_typeE₆MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-private theorem typeE₆QuadraticValue_sq_torsion :
+/-- The type-`E₆` generator value `2/3` is killed by `9`, so it is a legitimate quadratic value
+on `ℤ/3`. -/
+theorem typeE₆QuadraticValue_sq_torsion :
     (9 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
   -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
   change ((((9 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
   rw [QuotientAddGroup.eq_zero_iff]
   exact ⟨6, by norm_num⟩
 
-private theorem typeE₆QuadraticValue_polar_torsion :
+/-- The type-`E₆` generator value `2/3` is killed by `6`, so its polar form descends to `ℤ/3`. -/
+theorem typeE₆QuadraticValue_polar_torsion :
     (6 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
   -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
   change ((((6 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
@@ -420,31 +342,27 @@ private theorem typeE₆QuadraticValue_polar_torsion :
 /-- The quadratic map on `ZMod 3` whose generator has value `2/3`. -/
 noncomputable def typeE₆StandardQuadraticMap :
     QuadraticMap ℤ (ZMod 3) (AddCircle (1 : ℚ)) :=
-  cyclicQuadraticMap 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
+  FiniteQuadraticModule.cyclicMap 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
     typeE₆QuadraticValue_sq_torsion typeE₆QuadraticValue_polar_torsion
 
 /-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`. -/
-@[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule where
-  toFiniteBilinearModule := {
-    carrier := ZMod 3
-    pairing := LinearMap.toAddMonoidHom'.comp typeE₆StandardQuadraticMap.polarBilin.toAddMonoidHom
-    pairing_comm := fun x y ↦ QuadraticMap.polar_comm typeE₆StandardQuadraticMap x y }
-  quadratic := typeE₆StandardQuadraticMap
-  polar_eq_pairing' := fun _ _ ↦ rfl
+@[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule :=
+  FiniteQuadraticModule.cyclic 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
+    typeE₆QuadraticValue_sq_torsion typeE₆QuadraticValue_polar_torsion
 
 /-- The generator of the standard type-`E₆` quadratic map has value `2/3`. -/
 @[simp]
 theorem typeE₆StandardQuadraticMap_one :
     typeE₆StandardQuadraticMap 1 =
       (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ)) :=
-  cyclicQuadraticMap_one 3 _ _ _
+  FiniteQuadraticModule.cyclicMap_one 3 _ _ _
 
 /-- The standard cyclic quadratic module of type `E₆` is isometric to the discriminant
 quadratic module of the `E₆` root lattice. -/
 noncomputable def typeE₆DiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry typeE₆StandardQuadraticModule
       (typeE₆RootLattice.discriminantQuadraticModule isEven_typeE₆RootLattice) :=
-  quadraticMapIsometryOfGenerator 3 typeE₆StandardQuadraticMap
+  FiniteQuadraticModule.cyclicIsometryOfGenerator 3 typeE₆StandardQuadraticMap
     (typeE₆RootLattice.discriminantQuadraticMap isEven_typeE₆RootLattice)
     typeE₆DiscriminantGroupEquiv (by
       rw [typeE₆DiscriminantGroupEquiv_apply_one,
@@ -453,16 +371,14 @@ noncomputable def typeE₆DiscriminantQuadraticIsometry :
 /-- The underlying additive equivalence of the type-`E₆` quadratic isometry. -/
 @[simp]
 theorem typeE₆DiscriminantQuadraticIsometry_toAddEquiv :
-    typeE₆DiscriminantQuadraticIsometry.toAddEquiv = typeE₆DiscriminantGroupEquiv := by
-  rw [typeE₆DiscriminantQuadraticIsometry]
-  rfl
+    typeE₆DiscriminantQuadraticIsometry.toAddEquiv = typeE₆DiscriminantGroupEquiv :=
+  FiniteQuadraticModule.cyclicIsometryOfGenerator_toAddEquiv 3 _ _ _ _
 
 /-- The type-`E₆` quadratic isometry acts through the discriminant-group equivalence. -/
 @[simp]
 theorem typeE₆DiscriminantQuadraticIsometry_apply (x : ZMod 3) :
-    typeE₆DiscriminantQuadraticIsometry x = typeE₆DiscriminantGroupEquiv x := by
-  rw [typeE₆DiscriminantQuadraticIsometry]
-  rfl
+    typeE₆DiscriminantQuadraticIsometry x = typeE₆DiscriminantGroupEquiv x :=
+  FiniteQuadraticModule.cyclicIsometryOfGenerator_apply 3 _ _ _ _ x
 
 /-! ## The root lattice of type `E₇` -/
 
@@ -694,7 +610,9 @@ theorem discriminantPairing_typeE₇MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-private theorem typeE₇QuadraticValue_torsion :
+/-- The type-`E₇` generator value `3/4` is killed by `4`, which is both the square and the twice
+condition for `ℤ/2`. -/
+theorem typeE₇QuadraticValue_torsion :
     (4 : ℤ) • ((((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
   -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
   change ((((4 : ℚ) * (3 / 4)) : ℚ) : AddCircle (1 : ℚ)) = 0
@@ -704,31 +622,27 @@ private theorem typeE₇QuadraticValue_torsion :
 /-- The quadratic map on `ZMod 2` whose generator has value `3/4`. -/
 noncomputable def typeE₇StandardQuadraticMap :
     QuadraticMap ℤ (ZMod 2) (AddCircle (1 : ℚ)) :=
-  cyclicQuadraticMap 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
+  FiniteQuadraticModule.cyclicMap 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
     typeE₇QuadraticValue_torsion typeE₇QuadraticValue_torsion
 
 /-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`. -/
-@[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule where
-  toFiniteBilinearModule := {
-    carrier := ZMod 2
-    pairing := LinearMap.toAddMonoidHom'.comp typeE₇StandardQuadraticMap.polarBilin.toAddMonoidHom
-    pairing_comm := fun x y ↦ QuadraticMap.polar_comm typeE₇StandardQuadraticMap x y }
-  quadratic := typeE₇StandardQuadraticMap
-  polar_eq_pairing' := fun _ _ ↦ rfl
+@[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule :=
+  FiniteQuadraticModule.cyclic 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
+    typeE₇QuadraticValue_torsion typeE₇QuadraticValue_torsion
 
 /-- The generator of the standard type-`E₇` quadratic map has value `3/4`. -/
 @[simp]
 theorem typeE₇StandardQuadraticMap_one :
     typeE₇StandardQuadraticMap 1 =
       (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) :=
-  cyclicQuadraticMap_one 2 _ _ _
+  FiniteQuadraticModule.cyclicMap_one 2 _ _ _
 
 /-- The standard cyclic quadratic module of type `E₇` is isometric to the discriminant
 quadratic module of the `E₇` root lattice. -/
 noncomputable def typeE₇DiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry typeE₇StandardQuadraticModule
       (typeE₇RootLattice.discriminantQuadraticModule isEven_typeE₇RootLattice) :=
-  quadraticMapIsometryOfGenerator 2 typeE₇StandardQuadraticMap
+  FiniteQuadraticModule.cyclicIsometryOfGenerator 2 typeE₇StandardQuadraticMap
     (typeE₇RootLattice.discriminantQuadraticMap isEven_typeE₇RootLattice)
     typeE₇DiscriminantGroupEquiv (by
       rw [typeE₇DiscriminantGroupEquiv_apply_one,
@@ -737,16 +651,14 @@ noncomputable def typeE₇DiscriminantQuadraticIsometry :
 /-- The underlying additive equivalence of the type-`E₇` quadratic isometry. -/
 @[simp]
 theorem typeE₇DiscriminantQuadraticIsometry_toAddEquiv :
-    typeE₇DiscriminantQuadraticIsometry.toAddEquiv = typeE₇DiscriminantGroupEquiv := by
-  rw [typeE₇DiscriminantQuadraticIsometry]
-  rfl
+    typeE₇DiscriminantQuadraticIsometry.toAddEquiv = typeE₇DiscriminantGroupEquiv :=
+  FiniteQuadraticModule.cyclicIsometryOfGenerator_toAddEquiv 2 _ _ _ _
 
 /-- The type-`E₇` quadratic isometry acts through the discriminant-group equivalence. -/
 @[simp]
 theorem typeE₇DiscriminantQuadraticIsometry_apply (x : ZMod 2) :
-    typeE₇DiscriminantQuadraticIsometry x = typeE₇DiscriminantGroupEquiv x := by
-  rw [typeE₇DiscriminantQuadraticIsometry]
-  rfl
+    typeE₇DiscriminantQuadraticIsometry x = typeE₇DiscriminantGroupEquiv x :=
+  FiniteQuadraticModule.cyclicIsometryOfGenerator_apply 2 _ _ _ _ x
 
 /-! ## The root lattice of type `E₈` -/
 

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -322,51 +322,44 @@ theorem discriminantPairing_typeE₆MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- The type-`E₆` generator value `2/3` is killed by `9`, so it is a legitimate quadratic value
-on `ℤ/3`. -/
-theorem typeE₆QuadraticValue_sq_torsion :
-    (9 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
-  -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
-  change ((((9 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
-  rw [QuotientAddGroup.eq_zero_iff]
-  exact ⟨6, by norm_num⟩
-
-/-- The type-`E₆` generator value `2/3` is killed by `6`, so its polar form descends to `ℤ/3`. -/
-theorem typeE₆QuadraticValue_polar_torsion :
-    (6 : ℤ) • ((((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
-  -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
-  change ((((6 : ℚ) * (2 / 3)) : ℚ) : AddCircle (1 : ℚ)) = 0
-  rw [QuotientAddGroup.eq_zero_iff]
-  exact ⟨4, by norm_num⟩
-
-/-- The quadratic map on `ZMod 3` whose generator has value `2/3`. -/
-noncomputable def typeE₆StandardQuadraticMap :
-    QuadraticMap ℤ (ZMod 3) (AddCircle (1 : ℚ)) :=
-  FiniteQuadraticModule.cyclicMap 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
-    typeE₆QuadraticValue_sq_torsion typeE₆QuadraticValue_polar_torsion
-
-/-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`. -/
+/-- The standard cyclic quadratic module of type `E₆`, on `ZMod 3`: the generator carries the
+discriminant value `2/3` of the minuscule weight.  The two torsion conditions demanded by the
+cyclic construction are `9 · (2/3) = 6` and `6 · (2/3) = 4`, both integers. -/
 @[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
-    typeE₆QuadraticValue_sq_torsion typeE₆QuadraticValue_polar_torsion
+    (by
+      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
+      refine ⟨6, ?_⟩
+      rw [zsmul_eq_mul, zsmul_eq_mul]
+      push_cast
+      ring)
+    (by
+      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
+      refine ⟨4, ?_⟩
+      rw [zsmul_eq_mul, zsmul_eq_mul]
+      push_cast
+      ring)
 
-/-- The generator of the standard type-`E₆` quadratic map has value `2/3`. -/
+/-- The generator of the standard type-`E₆` quadratic module has value `2/3`. -/
 @[simp]
-theorem typeE₆StandardQuadraticMap_one :
-    typeE₆StandardQuadraticMap 1 =
-      (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ)) :=
-  FiniteQuadraticModule.cyclicMap_one 3 _ _ _
+theorem typeE₆StandardQuadraticModule_quadratic_one :
+    typeE₆StandardQuadraticModule.quadratic (1 : ZMod 3) =
+      (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ)) := by
+  unfold typeE₆StandardQuadraticModule
+  rw [FiniteQuadraticModule.cyclic_quadratic, FiniteQuadraticModule.cyclicMap_one]
 
 /-- The standard cyclic quadratic module of type `E₆` is isometric to the discriminant
 quadratic module of the `E₆` root lattice. -/
 noncomputable def typeE₆DiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry typeE₆StandardQuadraticModule
       (typeE₆RootLattice.discriminantQuadraticModule isEven_typeE₆RootLattice) :=
-  FiniteQuadraticModule.cyclicIsometryOfGenerator 3 typeE₆StandardQuadraticMap
+  FiniteQuadraticModule.cyclicIsometryOfGenerator 3
+    (FiniteQuadraticModule.cyclicMap 3 _ _ _)
     (typeE₆RootLattice.discriminantQuadraticMap isEven_typeE₆RootLattice)
     typeE₆DiscriminantGroupEquiv (by
       rw [typeE₆DiscriminantGroupEquiv_apply_one,
-        discriminantQuadraticMap_typeE₆MinusculeWeightClass, typeE₆StandardQuadraticMap_one])
+        discriminantQuadraticMap_typeE₆MinusculeWeightClass,
+        FiniteQuadraticModule.cyclicMap_one])
 
 /-- The underlying additive equivalence of the type-`E₆` quadratic isometry. -/
 @[simp]
@@ -610,43 +603,44 @@ theorem discriminantPairing_typeE₇MinusculeWeightClass :
     AddCircle.coe_eq_zero_iff_mem_one]
   exact Submodule.mem_one.mpr ⟨1, by norm_num⟩
 
-/-- The type-`E₇` generator value `3/4` is killed by `4`, which is both the square and the twice
-condition for `ℤ/2`. -/
-theorem typeE₇QuadraticValue_torsion :
-    (4 : ℤ) • ((((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))) = 0 := by
-  -- Expand the integer action through the quotient map `ℚ → ℚ/ℤ`.
-  change ((((4 : ℚ) * (3 / 4)) : ℚ) : AddCircle (1 : ℚ)) = 0
-  rw [QuotientAddGroup.eq_zero_iff]
-  exact ⟨3, by norm_num⟩
-
-/-- The quadratic map on `ZMod 2` whose generator has value `3/4`. -/
-noncomputable def typeE₇StandardQuadraticMap :
-    QuadraticMap ℤ (ZMod 2) (AddCircle (1 : ℚ)) :=
-  FiniteQuadraticModule.cyclicMap 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
-    typeE₇QuadraticValue_torsion typeE₇QuadraticValue_torsion
-
-/-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`. -/
+/-- The standard cyclic quadratic module of type `E₇`, on `ZMod 2`: the generator carries the
+discriminant value `3/4` of the minuscule weight.  Here `4` is at once the square and the twice
+condition demanded by the cyclic construction, and `4 · (3/4) = 3` is an integer. -/
 @[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
-    typeE₇QuadraticValue_torsion typeE₇QuadraticValue_torsion
+    (by
+      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
+      refine ⟨3, ?_⟩
+      rw [zsmul_eq_mul, zsmul_eq_mul]
+      push_cast
+      ring)
+    (by
+      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
+      refine ⟨3, ?_⟩
+      rw [zsmul_eq_mul, zsmul_eq_mul]
+      push_cast
+      ring)
 
-/-- The generator of the standard type-`E₇` quadratic map has value `3/4`. -/
+/-- The generator of the standard type-`E₇` quadratic module has value `3/4`. -/
 @[simp]
-theorem typeE₇StandardQuadraticMap_one :
-    typeE₇StandardQuadraticMap 1 =
-      (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) :=
-  FiniteQuadraticModule.cyclicMap_one 2 _ _ _
+theorem typeE₇StandardQuadraticModule_quadratic_one :
+    typeE₇StandardQuadraticModule.quadratic (1 : ZMod 2) =
+      (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) := by
+  unfold typeE₇StandardQuadraticModule
+  rw [FiniteQuadraticModule.cyclic_quadratic, FiniteQuadraticModule.cyclicMap_one]
 
 /-- The standard cyclic quadratic module of type `E₇` is isometric to the discriminant
 quadratic module of the `E₇` root lattice. -/
 noncomputable def typeE₇DiscriminantQuadraticIsometry :
     FiniteQuadraticModule.Isometry typeE₇StandardQuadraticModule
       (typeE₇RootLattice.discriminantQuadraticModule isEven_typeE₇RootLattice) :=
-  FiniteQuadraticModule.cyclicIsometryOfGenerator 2 typeE₇StandardQuadraticMap
+  FiniteQuadraticModule.cyclicIsometryOfGenerator 2
+    (FiniteQuadraticModule.cyclicMap 2 _ _ _)
     (typeE₇RootLattice.discriminantQuadraticMap isEven_typeE₇RootLattice)
     typeE₇DiscriminantGroupEquiv (by
       rw [typeE₇DiscriminantGroupEquiv_apply_one,
-        discriminantQuadraticMap_typeE₇MinusculeWeightClass, typeE₇StandardQuadraticMap_one])
+        discriminantQuadraticMap_typeE₇MinusculeWeightClass,
+        FiniteQuadraticModule.cyclicMap_one])
 
 /-- The underlying additive equivalence of the type-`E₇` quadratic isometry. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
+++ b/TauCeti/LinearAlgebra/IntegralLattice/RootLattice/TypeE.lean
@@ -327,18 +327,8 @@ discriminant value `2/3` of the minuscule weight.  The two torsion conditions de
 cyclic construction are `9 · (2/3) = 6` and `6 · (2/3) = 4`, both integers. -/
 @[expose] noncomputable def typeE₆StandardQuadraticModule : FiniteQuadraticModule :=
   FiniteQuadraticModule.cyclic 3 (((2 : ℚ) / 3 : ℚ) : AddCircle (1 : ℚ))
-    (by
-      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
-      refine ⟨6, ?_⟩
-      rw [zsmul_eq_mul, zsmul_eq_mul]
-      push_cast
-      ring)
-    (by
-      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
-      refine ⟨4, ?_⟩
-      rw [zsmul_eq_mul, zsmul_eq_mul]
-      push_cast
-      ring)
+    (AddCircle.zsmul_coe_eq_zero (c := 6) (by push_cast; ring))
+    (AddCircle.zsmul_coe_eq_zero (c := 4) (by push_cast; ring))
 
 /-- The generator of the standard type-`E₆` quadratic module has value `2/3`. -/
 @[simp]
@@ -607,19 +597,10 @@ theorem discriminantPairing_typeE₇MinusculeWeightClass :
 discriminant value `3/4` of the minuscule weight.  Here `4` is at once the square and the twice
 condition demanded by the cyclic construction, and `4 · (3/4) = 3` is an integer. -/
 @[expose] noncomputable def typeE₇StandardQuadraticModule : FiniteQuadraticModule :=
-  FiniteQuadraticModule.cyclic 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ))
-    (by
-      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
-      refine ⟨3, ?_⟩
-      rw [zsmul_eq_mul, zsmul_eq_mul]
-      push_cast
-      ring)
-    (by
-      rw [← AddCircle.coe_zsmul, AddCircle.coe_eq_zero_iff]
-      refine ⟨3, ?_⟩
-      rw [zsmul_eq_mul, zsmul_eq_mul]
-      push_cast
-      ring)
+  -- both conditions read `4 · (3/4) = 3`, so one proof term serves twice
+  have h : (4 : ℤ) • (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) = 0 :=
+    AddCircle.zsmul_coe_eq_zero (c := 3) (by push_cast; ring)
+  FiniteQuadraticModule.cyclic 2 (((3 : ℚ) / 4 : ℚ) : AddCircle (1 : ℚ)) h h
 
 /-- The generator of the standard type-`E₇` quadratic module has value `3/4`. -/
 @[simp]


### PR DESCRIPTION
This PR identifies the discriminant quadratic form of an odd-rank checkerboard lattice, completing the odd `Dₙ` row of the ADE table in Layer 5 of the integral-lattices roadmap. The table demands, for odd `n ≥ 5`, that the discriminant group be `ℤ/4` with either spinor class as generator, that `q(s) = n/8`, and that the vector class be `2s` with `q(v) = 1/2`. The group `ℤ/4` and the three quadratic values were already in `RootLattice/TypeD/Basic.lean`; what was missing is the roadmap's actual acceptance criterion for a table row — "calculate all pairings needed to identify the finite quadratic module up to isometry, and verify nondegeneracy". `checkerboardCyclicQuadraticModule` is the presented `ℤ/4` model, `checkerboardCyclicQuadraticIsometry` is an isometry of finite quadratic modules from it onto `A_L`, and `isNondegenerate_checkerboardCyclicQuadraticModule` discharges nondegeneracy. The even-rank row got exactly this treatment in #4665; this is its odd-rank counterpart, and a single generator value suffices where three were needed there.

<!--tauceti-target:v1 {"focus":"IntegralLattices","id":"discriminant-quadratic-module-odd-rank-checkerboard-lattice"}-->

Presenting a form on a cyclic group needs a construction that the repository already had twice over, once privately. `TauCeti/LinearAlgebra/FiniteBilinearModule/Cyclic.lean` (new, 219 lines) supplies it as Layer 3 API: `cyclicMap` is the `ℚ/ℤ`-valued quadratic map on `ℤ/m` whose generator has a prescribed value `a`, built by descending the honest bilinear map `(x, y) ↦ xy·a` on `ℤ` along `QuadraticMap.lift`, with the kernel of reduction shown to lie in the radical exactly under `m²a = 0` and `2ma = 0`; `cyclic` packages it as a `FiniteQuadraticModule`; and `cyclicIsometryOfGenerator` turns an additive equivalence `ℤ/m ≃+ A` matching that one value into an isometry, no further hypothesis needed. The two torsion conditions are independent: `m = 1`, `a = 1/2` satisfies the pairing condition but not the square one, and `m = 3`, `a = 1/9` satisfies the square condition but not the pairing one. The module docstring records both, and notes that `m = 2` cannot separate them because there `m² = 2m = 4`. This is the cyclic sibling of `FiniteBilinearModule/KleinFour.lean`, whose docstring said in as many words that the private cyclic construction in `RootLattice/TypeE.lean` "can be unified when that construction is promoted to shared API"; that private block (84 lines: `intBilin`, `intQuadratic`, `zmultiples_le_radical_intQuadratic`, `intQuotientEquivZMod`, `cyclicQuadraticMap`, `quadraticMapIsometryOfGenerator`) is deleted here and the `E₆` and `E₇` discriminant forms now consume the shared construction, so the repository has one cyclic presentation rather than two. No Mathlib source was vendored; the reduction-modulo-`m` quotient uses Mathlib's `LinearMap.quotKerEquivOfSurjective` and `QuadraticMap.lift` directly, in place of TypeE's `Int.quotientZMultiplesNatEquivZMod` detour, and the now-unused `Mathlib.Data.ZMod.QuotientGroup` and `Mathlib.GroupTheory.SpecificGroups.Cyclic` imports are dropped from that file.

The model is stated for every `n`, since both torsion conditions — `16·(n/8) = 2n` and `8·(n/8) = n` — are integers regardless of parity; it is the discriminant form precisely when `n` is odd, because only then does the spinor class generate. Its value at `2` is `n/2`, which equals the vector value `1/2` in `ℚ/ℤ` exactly because `n` is odd, so `checkerboardCyclicQuadraticModule_quadratic_two` records the second half of the table row as an honest computation rather than a restatement; the generator self-pairing `b(s, s) = n/4` matches `discriminantPairing_checkerboardSpinorClass_self`, and `checkerboardCyclicQuadraticIsometry_one` names the spinor class as the image of the generator.

After this PR, the ADE table's remaining packaging is the `Aₙ` row and the rank-one lattice `⟨2m⟩`, whose discriminant forms are recorded only as a group equivalence plus a generator value and can now be presented through the same `cyclic` construction; the `Dₙ` rows, `E₆`, `E₇`, `E₈`, and the `D₈ ⊂ E₈` glue isometry are formalized.

Roadmap: IntegralLattices

🤖 Prepared with Claude Code
