### PR TITLE
feat: the geodesic predicate and its second-order chart equation

### DIFF
--- a/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
+++ b/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
@@ -34,8 +34,9 @@ curve need not carry a `HasMFDerivWithinAt` witness for it.
   `(g ∘ γ)' (t) = d g (γ t) (γ' t)` for a function `g` from the manifold to a normed space,
   with `TauCeti.Manifold.hasDerivAt_comp_curve` its unrestricted case.
 * `TauCeti.Manifold.curveVelocityWithin` and `TauCeti.Manifold.curveVelocity`: the velocity of a
-  curve within a parameter set and its unrestricted case, related by
-  `TauCeti.Manifold.curveVelocityWithin_univ`.
+  curve within a parameter set and its unrestricted case, computed by
+  `TauCeti.Manifold.curveVelocityWithin_apply` and `TauCeti.Manifold.curveVelocity_apply` and
+  related by `TauCeti.Manifold.curveVelocityWithin_univ`.
 * `TauCeti.Manifold.hasMFDerivWithinAt_curveVelocityWithin` and
   `TauCeti.Manifold.curveVelocityWithin_eq_of_hasMFDerivWithinAt`: the two directions relating the
   named velocity to a `HasMFDerivWithinAt` witness.
@@ -106,21 +107,32 @@ def curveVelocity (γ : 𝕜 → M) (t : 𝕜) : TangentSpace I (γ t) :=
 theorem curveVelocityWithin_univ : curveVelocityWithin I γ Set.univ = curveVelocity I γ :=
   (rfl)
 
+/-- The velocity within `s` is the derivative within `s` evaluated at the unit tangent vector.
+This restates the definition, whose body is not exposed across the module boundary. -/
+theorem curveVelocityWithin_apply :
+    curveVelocityWithin I γ s t = mfderivWithin 𝓘(𝕜, 𝕜) I γ s t (1 : 𝕜) :=
+  (rfl)
+
 /-- The unrestricted velocity is the unrestricted derivative evaluated at the unit tangent
 vector. -/
 theorem curveVelocity_apply : curveVelocity I γ t = mfderiv 𝓘(𝕜, 𝕜) I γ t (1 : 𝕜) := by
-  rw [curveVelocity, curveVelocityWithin, mfderivWithin_univ]
+  rw [← curveVelocityWithin_univ, curveVelocityWithin_apply, mfderivWithin_univ]
+
+/-- Evaluating the `smulRight` presentation of a velocity at the unit tangent vector returns that
+velocity.  The tangent space of the scalar model is definitionally `𝕜`, but its instances block
+rewriting by `ContinuousLinearMap.smulRight_apply` until that identification is exposed, which is
+what the `change` below does. -/
+private theorem smulRight_one_apply_one {x : M} (v : TangentSpace I x) :
+    ((1 : 𝕜 →L[𝕜] 𝕜).smulRight v) (1 : 𝕜) = v := by
+  change (1 : 𝕜) • v = v
+  rw [one_smul]
 
 /-- A continuous linear map out of the scalar model is determined by its value at `1`; this is the
 shape in which Mathlib's integral-curve API presents the velocity of a curve. -/
 private theorem mfderivWithin_eq_smulRight_curveVelocityWithin (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜) :
-    mfderivWithin 𝓘(𝕜, 𝕜) I γ s t = (1 : 𝕜 →L[𝕜] 𝕜).smulRight (curveVelocityWithin I γ s t) := by
-  ext
-  -- The tangent space of the scalar model is definitionally `𝕜`, but its topology instance blocks
-  -- rewriting by `ContinuousLinearMap.smulRight_apply` until that identification is exposed.
-  change (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜) =
-    (1 : 𝕜) • (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜)
-  rw [one_smul]
+    mfderivWithin 𝓘(𝕜, 𝕜) I γ s t = (1 : 𝕜 →L[𝕜] 𝕜).smulRight (curveVelocityWithin I γ s t) :=
+  -- Reducing to the value at `1` needs `TangentSpace 𝓘(𝕜, 𝕜) t` to unfold to `𝕜`.
+  ContinuousLinearMap.ext_ring (smulRight_one_apply_one _).symm
 
 /-- A curve differentiable within `s` at `t` has `TauCeti.Manifold.curveVelocityWithin` as its
 velocity there. -/
@@ -139,21 +151,28 @@ derivative within the parameter set is unique. -/
 theorem curveVelocityWithin_eq_of_hasMFDerivWithinAt
     (hγ : HasMFDerivWithinAt 𝓘(𝕜, 𝕜) I γ s t ((1 : 𝕜 →L[𝕜] 𝕜).smulRight w))
     (hs : UniqueDiffWithinAt 𝕜 s t) : curveVelocityWithin I γ s t = w := by
-  rw [curveVelocityWithin,
+  rw [curveVelocityWithin_apply,
     hγ.mfderivWithin (uniqueMDiffWithinAt_iff_uniqueDiffWithinAt.mpr hs)]
-  change (1 : 𝕜) • w = w
-  rw [one_smul]
+  exact smulRight_one_apply_one w
 
 /-- On a parameter set which is a neighbourhood of `t`, the restricted velocity is the
 unrestricted one. -/
 theorem curveVelocityWithin_of_mem_nhds (hs : s ∈ 𝓝 t) :
     curveVelocityWithin I γ s t = curveVelocity I γ t := by
-  rw [curveVelocityWithin, curveVelocity_apply, mfderivWithin_of_mem_nhds hs]
+  rw [curveVelocityWithin_apply, curveVelocity_apply, mfderivWithin_of_mem_nhds hs]
 
+/-- A constant curve has zero velocity within any parameter set. -/
 @[simp]
 theorem curveVelocityWithin_const (x : M) : curveVelocityWithin I (fun _ : 𝕜 ↦ x) s t = 0 := by
-  rw [curveVelocityWithin, mfderivWithin_const]
-  rfl
+  rw [curveVelocityWithin_apply, mfderivWithin_const]
+  exact zero_apply _
+
+/-- A constant curve has zero velocity.  This is the unrestricted case of
+`TauCeti.Manifold.curveVelocityWithin_const`, which `TauCeti.Manifold.curveVelocityWithin_univ`
+would otherwise keep `simp` from reaching. -/
+@[simp]
+theorem curveVelocity_const (x : M) : curveVelocity I (fun _ : 𝕜 ↦ x) t = 0 := by
+  rw [← curveVelocityWithin_univ, curveVelocityWithin_const]
 
 variable [IsManifold I 1 M]
 

--- a/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
+++ b/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
@@ -24,19 +24,32 @@ through `HasMFDerivWithinAt 𝓘(𝕜, 𝕜) I γ s t ((1 : 𝕜 →L[𝕜] 𝕜
 `TangentSpace 𝓘(𝕜, 𝕜) t` carries no `One` instance and `mfderivWithin ... 1` therefore does not
 elaborate.
 
-## Main results
+The velocity itself is named here: `TauCeti.Manifold.curveVelocityWithin` reads the derivative
+within a parameter set on the unit tangent vector, so that a statement about the velocity of a
+curve need not carry a `HasMFDerivWithinAt` witness for it.
+
+## Main definitions and results
 
 * `TauCeti.Manifold.hasDerivWithinAt_comp_curve`: the chain rule
   `(g ∘ γ)' (t) = d g (γ t) (γ' t)` for a function `g` from the manifold to a normed space,
   with `TauCeti.Manifold.hasDerivAt_comp_curve` its unrestricted case.
+* `TauCeti.Manifold.curveVelocityWithin` and `TauCeti.Manifold.curveVelocity`: the velocity of a
+  curve within a parameter set and its unrestricted case, related by
+  `TauCeti.Manifold.curveVelocityWithin_univ`.
+* `TauCeti.Manifold.hasMFDerivWithinAt_curveVelocityWithin` and
+  `TauCeti.Manifold.curveVelocityWithin_eq_of_hasMFDerivWithinAt`: the two directions relating the
+  named velocity to a `HasMFDerivWithinAt` witness.
 * `TauCeti.Manifold.hasDerivWithinAt_extChartAt_comp_curve`: reading the curve in the chart
   centred at the current point differentiates it to the velocity itself, with
-  `TauCeti.Manifold.hasDerivAt_extChartAt_comp_curve` its unrestricted case.
+  `TauCeti.Manifold.hasDerivAt_extChartAt_comp_curve` its unrestricted case and
+  `TauCeti.Manifold.derivWithin_extChartAt_comp_curve` its form for the named velocity.
 -/
 
 public section
 
 open scoped Manifold Topology
+
+noncomputable section
 
 namespace TauCeti.Manifold
 
@@ -73,6 +86,75 @@ theorem hasDerivAt_comp_curve {g : M → F} (hg : MDifferentiableAt I 𝓘(𝕜,
   rw [← hasDerivWithinAt_univ]
   exact hasDerivWithinAt_comp_curve hg hγ.hasMFDerivWithinAt
 
+/-! ### The velocity of a curve -/
+
+variable (I) in
+/-- The velocity of the curve `γ` at the parameter `t`, taken within the parameter set `s`: the
+value at the unit tangent vector of the manifold derivative of `γ` within `s`.  Where `γ` is not
+differentiable within `s` at `t`, this carries Mathlib's junk value `0`; where the derivative
+within `s` is not unique it need not be the velocity of any parametrization. -/
+def curveVelocityWithin (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜) : TangentSpace I (γ t) :=
+  mfderivWithin 𝓘(𝕜, 𝕜) I γ s t (1 : 𝕜)
+
+variable (I) in
+/-- The velocity of the curve `γ` at the parameter `t`, with unrestricted derivative.  This is the
+`s = Set.univ` case of `TauCeti.Manifold.curveVelocityWithin`. -/
+def curveVelocity (γ : 𝕜 → M) (t : 𝕜) : TangentSpace I (γ t) :=
+  curveVelocityWithin I γ Set.univ t
+
+@[simp]
+theorem curveVelocityWithin_univ : curveVelocityWithin I γ Set.univ = curveVelocity I γ :=
+  (rfl)
+
+/-- The unrestricted velocity is the unrestricted derivative evaluated at the unit tangent
+vector. -/
+theorem curveVelocity_apply : curveVelocity I γ t = mfderiv 𝓘(𝕜, 𝕜) I γ t (1 : 𝕜) := by
+  rw [curveVelocity, curveVelocityWithin, mfderivWithin_univ]
+
+/-- A continuous linear map out of the scalar model is determined by its value at `1`; this is the
+shape in which Mathlib's integral-curve API presents the velocity of a curve. -/
+private theorem mfderivWithin_eq_smulRight_curveVelocityWithin (γ : 𝕜 → M) (s : Set 𝕜) (t : 𝕜) :
+    mfderivWithin 𝓘(𝕜, 𝕜) I γ s t = (1 : 𝕜 →L[𝕜] 𝕜).smulRight (curveVelocityWithin I γ s t) := by
+  ext
+  -- The tangent space of the scalar model is definitionally `𝕜`, but its topology instance blocks
+  -- rewriting by `ContinuousLinearMap.smulRight_apply` until that identification is exposed.
+  change (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜) =
+    (1 : 𝕜) • (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜)
+  rw [one_smul]
+
+/-- A curve differentiable within `s` at `t` has `TauCeti.Manifold.curveVelocityWithin` as its
+velocity there. -/
+theorem hasMFDerivWithinAt_curveVelocityWithin (hγ : MDifferentiableWithinAt 𝓘(𝕜, 𝕜) I γ s t) :
+    HasMFDerivWithinAt 𝓘(𝕜, 𝕜) I γ s t
+      ((1 : 𝕜 →L[𝕜] 𝕜).smulRight (curveVelocityWithin I γ s t)) :=
+  hγ.hasMFDerivWithinAt.congr_mfderiv (mfderivWithin_eq_smulRight_curveVelocityWithin γ s t)
+
+/-- The unrestricted case of `TauCeti.Manifold.hasMFDerivWithinAt_curveVelocityWithin`. -/
+theorem hasMFDerivAt_curveVelocity (hγ : MDifferentiableAt 𝓘(𝕜, 𝕜) I γ t) :
+    HasMFDerivAt 𝓘(𝕜, 𝕜) I γ t ((1 : 𝕜 →L[𝕜] 𝕜).smulRight (curveVelocity I γ t)) :=
+  hasMFDerivWithinAt_univ.mp (hasMFDerivWithinAt_curveVelocityWithin hγ.mdifferentiableWithinAt)
+
+/-- A velocity witnessed by a `HasMFDerivWithinAt` statement is *the* velocity, as soon as the
+derivative within the parameter set is unique. -/
+theorem curveVelocityWithin_eq_of_hasMFDerivWithinAt
+    (hγ : HasMFDerivWithinAt 𝓘(𝕜, 𝕜) I γ s t ((1 : 𝕜 →L[𝕜] 𝕜).smulRight w))
+    (hs : UniqueDiffWithinAt 𝕜 s t) : curveVelocityWithin I γ s t = w := by
+  rw [curveVelocityWithin,
+    hγ.mfderivWithin (uniqueMDiffWithinAt_iff_uniqueDiffWithinAt.mpr hs)]
+  change (1 : 𝕜) • w = w
+  rw [one_smul]
+
+/-- On a parameter set which is a neighbourhood of `t`, the restricted velocity is the
+unrestricted one. -/
+theorem curveVelocityWithin_of_mem_nhds (hs : s ∈ 𝓝 t) :
+    curveVelocityWithin I γ s t = curveVelocity I γ t := by
+  rw [curveVelocityWithin, curveVelocity_apply, mfderivWithin_of_mem_nhds hs]
+
+@[simp]
+theorem curveVelocityWithin_const (x : M) : curveVelocityWithin I (fun _ : 𝕜 ↦ x) s t = 0 := by
+  rw [curveVelocityWithin, mfderivWithin_const]
+  rfl
+
 variable [IsManifold I 1 M]
 
 /-- Reading the curve in the extended chart centred at the *current* point differentiates it to
@@ -93,4 +175,15 @@ theorem hasDerivAt_extChartAt_comp_curve
     HasDerivAt (extChartAt I (γ t) ∘ γ) w t :=
   hasDerivWithinAt_univ.mp (hasDerivWithinAt_extChartAt_comp_curve hγ.hasMFDerivWithinAt)
 
+
+/-- The derivative within `s` of a differentiable curve read in the chart centred at the current
+point is its velocity within `s`. -/
+theorem derivWithin_extChartAt_comp_curve (hγ : MDifferentiableWithinAt 𝓘(𝕜, 𝕜) I γ s t)
+    (hs : UniqueDiffWithinAt 𝕜 s t) :
+    derivWithin (extChartAt I (γ t) ∘ γ) s t = curveVelocityWithin I γ s t :=
+  (hasDerivWithinAt_extChartAt_comp_curve
+    (hasMFDerivWithinAt_curveVelocityWithin hγ)).derivWithin hs
+
 end TauCeti.Manifold
+
+end

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Basic.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Basic.lean
@@ -1,0 +1,266 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.MFDeriv.Curve
+public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.AlongCurve.Pullback
+public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCivita.Existence
+
+/-!
+# Geodesics of a Riemannian manifold
+
+A curve in a Riemannian manifold is a geodesic when its velocity is parallel along it: the
+covariant derivative of the velocity field along the curve, taken for the Levi-Civita connection
+of the manifold's Riemannian bundle instance, vanishes.  This file introduces that predicate,
+carrying the parameter set on which it is asserted, and identifies it with the classical
+second-order geodesic ODE in a chart.
+
+The predicate is stated *within* a parameter set `s`, so that a geodesic segment on a closed
+interval and an all-time geodesic are the same notion at two values of `s`; the all-time
+predicate is the `s = Set.univ` case.  Both the velocity `TauCeti.Manifold.curveVelocityWithin`
+and the along-curve derivative `CovariantDerivative.alongCurveWithin` are then read within `s`,
+and the predicate carries `UniqueDiffOn ℝ s` — satisfied by the nondegenerate intervals and by
+`Set.univ` which the theory uses — because that is what makes those within-derivatives the
+honest ones rather than junk values.
+
+Reading the curve in the extended chart centred at the current point turns the definition into
+the second-order equation
+
+`u'' + Γ_{γ t} (u', u') = 0`,
+
+where `u = extChartAt I (γ t) ∘ γ` and `Γ` is the model-space Christoffel map of the Levi-Civita
+connection.  That is `TauCeti.Manifold.isGeodesicCurveOn_iff_chart`.  Chart-reading the curve at
+its *current* point, rather than in one fixed chart, is what makes this a statement about the
+whole parameter set at once.
+
+## Main definitions and results
+
+* `TauCeti.Manifold.IsGeodesicCurveOn`: the geodesic equation on a parameter set, and
+  `TauCeti.Manifold.IsGeodesicCurve` its all-time case, unfolded by
+  `TauCeti.Manifold.isGeodesicCurve_iff`.
+* `TauCeti.Manifold.IsGeodesicCurveOnFrom`: a geodesic together with its initial data, the point
+  and velocity at parameter `0`.
+* `TauCeti.Manifold.isGeodesicCurveOn_iff_chart`: **the geodesic equation in a chart**, the
+  second-order ODE `u'' + Γ (u', u') = 0`.
+* `TauCeti.Manifold.isGeodesicCurveOn_iff_of_isOpen`: on an open parameter set the equation is
+  the unrestricted one.
+* `TauCeti.Manifold.isGeodesicCurveOn_const`: a constant curve is a geodesic.
+
+## References
+
+* [Geodesics, the exponential map, and the Hopf--Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
+  Layer 1, "`IsGeodesicCurveOn γ s`" and "Initial data".
+* M. P. do Carmo, *Riemannian Geometry*, Birkhäuser, 1992, Ch. 3, §2.
+* J. M. Lee, *Introduction to Riemannian Manifolds*, GTM 176, 2018, Ch. 4.
+-/
+
+public section
+
+open Bundle CovariantDerivative Filter Set
+open scoped Manifold Topology
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 2 M]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+  {γ : ℝ → M} {s : Set ℝ} {t : ℝ}
+
+/-! ### The geodesic equation -/
+
+variable (I γ s) in
+/-- **A geodesic on a parameter set**: a `C²` curve whose velocity within `s` is parallel along
+it for the Levi-Civita connection of the ambient Riemannian bundle instance.
+
+The velocity is `TauCeti.Manifold.curveVelocityWithin` and its derivative along the curve is
+`CovariantDerivative.alongCurveWithin`, both taken within `s`. -/
+structure IsGeodesicCurveOn : Prop where
+  /-- The parameter set has unique derivatives.  Without this the derivatives within `s` are not
+  determined by the curve, and the geodesic equation below does not say what it should. -/
+  uniqueDiffOn : UniqueDiffOn ℝ s
+  /-- A geodesic is `C²` on its parameter set: this is what makes its velocity field
+  differentiable, so that the geodesic equation is an equation between honest derivatives. -/
+  contMDiffOn : ContMDiffOn 𝓘(ℝ, ℝ) I 2 γ s
+  /-- **The geodesic equation**: the velocity field is parallel along the curve. -/
+  alongCurveWithin_curveVelocityWithin_eq_zero : ∀ r ∈ s,
+    alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s r = 0
+
+variable (I γ) in
+/-- **A geodesic**, defined at every real parameter.  This is the `s = Set.univ` case of
+`TauCeti.Manifold.IsGeodesicCurveOn`. -/
+def IsGeodesicCurve : Prop := IsGeodesicCurveOn I γ univ
+
+/-- A geodesic is differentiable on its parameter set. -/
+theorem IsGeodesicCurveOn.mdifferentiableOn (h : IsGeodesicCurveOn I γ s) :
+    MDifferentiableOn 𝓘(ℝ, ℝ) I γ s :=
+  h.contMDiffOn.mdifferentiableOn (by norm_num)
+
+/-- A geodesic is continuous on its parameter set. -/
+theorem IsGeodesicCurveOn.continuousOn (h : IsGeodesicCurveOn I γ s) : ContinuousOn γ s :=
+  h.contMDiffOn.continuousOn
+
+variable (I γ s) in
+/-- **A geodesic with prescribed initial data**: a geodesic on a parameter set containing `0`
+which starts at `p` with velocity `v`.  The two pieces of initial data are packaged as a single
+equality of points of the tangent bundle, which avoids transporting `v` along `γ 0 = p` and is
+the form in which the geodesic flow on `TM` will consume them. -/
+structure IsGeodesicCurveOnFrom (p : M) (v : TangentSpace I p) : Prop where
+  /-- The curve is a geodesic on `s`. -/
+  isGeodesicCurveOn : IsGeodesicCurveOn I γ s
+  /-- The initial parameter belongs to the parameter set. -/
+  zero_mem : (0 : ℝ) ∈ s
+  /-- The curve leaves `p` with velocity `v`. -/
+  initial_eq :
+    TotalSpace.mk' E (γ 0) (curveVelocityWithin I γ s 0) = TotalSpace.mk' E p v
+
+variable {p : M} {v : TangentSpace I p}
+
+/-- A geodesic with initial data starts at the prescribed point. -/
+theorem IsGeodesicCurveOnFrom.base_eq (h : IsGeodesicCurveOnFrom I γ s p v) : γ 0 = p :=
+  congrArg TotalSpace.proj h.initial_eq
+
+/-! ### The geodesic equation in a chart -/
+
+omit [FiniteDimensional ℝ E] [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- Along a curve differentiable within `s`, the coordinate reading of the velocity field in the
+tangent-bundle trivialization centred at `x` is the derivative within `s` of the curve read in the
+extended chart at `x`, at every nearby parameter of `s` at which the curve is still in that
+chart. -/
+theorem sectionCoord_curveVelocityWithin_eventuallyEq {x : M} (hs : UniqueDiffOn ℝ s)
+    (hγ : MDifferentiableOn 𝓘(ℝ, ℝ) I γ s) (ht : t ∈ s)
+    (hx : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) :
+    sectionCoord (F := E) γ (curveVelocityWithin I γ s) x =ᶠ[𝓝[s] t]
+      derivWithin (extChartAt I x ∘ γ) s := by
+  have hbase : ∀ᶠ r in 𝓝[s] t, γ r ∈ (trivializationAt E (TangentSpace I) x).baseSet :=
+    (hγ t ht).continuousWithinAt.preimage_mem_nhdsWithin
+      ((trivializationAt E (TangentSpace I) x).open_baseSet.mem_nhds hx)
+  filter_upwards [hbase, self_mem_nhdsWithin] with r hr hrs
+  rw [sectionCoord_apply, derivWithin_extChartAt_comp γ hr (hs r hrs)
+    (hasMFDerivWithinAt_curveVelocityWithin (hγ r hrs))]
+
+/-- The moving-chart coordinate formula applied to the velocity field is the classical
+second-order expression `u'' + Γ (u', u')`, for `u` the curve read in the extended chart at `x`.
+The chart need not be the one centred at the current point of the curve. -/
+theorem alongCurveInChartWithin_curveVelocityWithin {x : M} (hs : UniqueDiffOn ℝ s)
+    (hγ : MDifferentiableOn 𝓘(ℝ, ℝ) I γ s) (ht : t ∈ s)
+    (hx : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) :
+    alongCurveInChartWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s x t =
+      derivWithin (derivWithin (extChartAt I x ∘ γ) s) s t +
+        christoffelMap (Module.finBasis ℝ E)
+          ((leviCivita I M).isCovariantDerivativeOn
+            (s := (trivializationAt E (TangentSpace I) x).baseSet)) (γ t)
+          (derivWithin (extChartAt I x ∘ γ) s t) (derivWithin (extChartAt I x ∘ γ) s t) := by
+  have hEq := sectionCoord_curveVelocityWithin_eventuallyEq hs hγ ht hx
+  have hpoint : sectionCoord (F := E) γ (curveVelocityWithin I γ s) x t =
+      derivWithin (extChartAt I x ∘ γ) s t := hEq.self_of_nhdsWithin ht
+  rw [alongCurveInChartWithin_apply, hEq.derivWithin_eq hpoint, hpoint]
+
+/-- The along-curve derivative of the velocity field vanishes exactly when the curve read in the
+extended chart at the current point solves the second-order geodesic ODE there.  The moving-chart
+formula is transported by a fibrewise linear equivalence, so vanishing may be tested in the
+chart. -/
+theorem alongCurveWithin_curveVelocityWithin_eq_zero_iff (hs : UniqueDiffOn ℝ s)
+    (hγ : MDifferentiableOn 𝓘(ℝ, ℝ) I γ s) (ht : t ∈ s) :
+    alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s t = 0 ↔
+      derivWithin (derivWithin (extChartAt I (γ t) ∘ γ) s) s t +
+        christoffelMap (Module.finBasis ℝ E)
+          ((leviCivita I M).isCovariantDerivativeOn
+            (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t)
+          (derivWithin (extChartAt I (γ t) ∘ γ) s t)
+          (derivWithin (extChartAt I (γ t) ∘ γ) s t) = 0 := by
+  set e := trivializationAt E (TangentSpace I) (γ t)
+  have hmem : γ t ∈ e.baseSet :=
+    FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t)
+  rw [alongCurveWithin_apply, alongCurveInChartWithin_curveVelocityWithin hs hγ ht hmem]
+  refine ⟨fun h ↦ ?_, fun h ↦ by rw [h, map_zero]⟩
+  have h' := congrArg (e.continuousLinearMapAt ℝ (γ t)) h
+  rwa [e.continuousLinearMapAt_symmL (R := ℝ) hmem, map_zero] at h'
+
+/-- **The geodesic equation in a chart.**  A `C²` curve is a geodesic on a parameter set with
+unique derivatives exactly when, at every parameter of that set, the curve read in the extended
+chart centred at the *current* point solves `u'' + Γ (u', u') = 0`, with `Γ` the model-space
+Christoffel map of the Levi-Civita connection in the tangent-bundle trivialization there. -/
+theorem isGeodesicCurveOn_iff_chart (hs : UniqueDiffOn ℝ s) :
+    IsGeodesicCurveOn I γ s ↔ ContMDiffOn 𝓘(ℝ, ℝ) I 2 γ s ∧ ∀ r ∈ s,
+      derivWithin (derivWithin (extChartAt I (γ r) ∘ γ) s) s r +
+        christoffelMap (Module.finBasis ℝ E)
+          ((leviCivita I M).isCovariantDerivativeOn
+            (s := (trivializationAt E (TangentSpace I) (γ r)).baseSet)) (γ r)
+          (derivWithin (extChartAt I (γ r) ∘ γ) s r)
+          (derivWithin (extChartAt I (γ r) ∘ γ) s r) = 0 := by
+  constructor
+  · intro h
+    exact ⟨h.contMDiffOn, fun r hr ↦ (alongCurveWithin_curveVelocityWithin_eq_zero_iff
+      h.uniqueDiffOn h.mdifferentiableOn hr).mp
+      (h.alongCurveWithin_curveVelocityWithin_eq_zero r hr)⟩
+  · rintro ⟨hc, hchart⟩
+    exact ⟨hs, hc, fun r hr ↦ (alongCurveWithin_curveVelocityWithin_eq_zero_iff hs
+      (hc.mdifferentiableOn (by norm_num)) hr).mpr (hchart r hr)⟩
+
+/-! ### Open parameter sets -/
+
+/-- On an open parameter set, the restricted velocity field and the restricted along-curve
+derivative are the unrestricted ones. -/
+theorem alongCurveWithin_curveVelocityWithin_of_isOpen (hs : IsOpen s) (ht : t ∈ s) :
+    alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s t =
+      alongCurve (leviCivita I M) γ (curveVelocity I γ) t := by
+  have hcongr : ∀ᶠ r in 𝓝[s] t, curveVelocityWithin I γ s r = curveVelocity I γ r := by
+    filter_upwards [self_mem_nhdsWithin] with r hr
+    exact curveVelocityWithin_of_mem_nhds (hs.mem_nhds hr)
+  rw [alongCurveWithin_congr (leviCivita I M) γ (curveVelocityWithin I γ s) hcongr
+      (curveVelocityWithin_of_mem_nhds (hs.mem_nhds ht)),
+    alongCurveWithin_of_mem_nhds (leviCivita I M) γ (curveVelocity I γ) (hs.mem_nhds ht)]
+
+/-- On an open parameter set, the geodesic equation is the unrestricted one. -/
+theorem isGeodesicCurveOn_iff_of_isOpen (hs : IsOpen s) :
+    IsGeodesicCurveOn I γ s ↔ ContMDiffOn 𝓘(ℝ, ℝ) I 2 γ s ∧
+      ∀ r ∈ s, alongCurve (leviCivita I M) γ (curveVelocity I γ) r = 0 := by
+  constructor
+  · intro h
+    exact ⟨h.contMDiffOn, fun r hr ↦ by
+      rw [← alongCurveWithin_curveVelocityWithin_of_isOpen hs hr]
+      exact h.alongCurveWithin_curveVelocityWithin_eq_zero r hr⟩
+  · rintro ⟨hc, hzero⟩
+    exact ⟨hs.uniqueDiffOn, hc, fun r hr ↦ by
+      rw [alongCurveWithin_curveVelocityWithin_of_isOpen hs hr]
+      exact hzero r hr⟩
+
+/-- The all-time geodesic equation, spelled out. -/
+theorem isGeodesicCurve_iff :
+    IsGeodesicCurve I γ ↔ ContMDiff 𝓘(ℝ, ℝ) I 2 γ ∧
+      ∀ t : ℝ, alongCurve (leviCivita I M) γ (curveVelocity I γ) t = 0 := by
+  rw [IsGeodesicCurve, isGeodesicCurveOn_iff_of_isOpen isOpen_univ, contMDiffOn_univ]
+  simp
+
+/-! ### Constant curves -/
+
+/-- **A constant curve is a geodesic.**  Its velocity field is the zero section, which is
+parallel. -/
+theorem isGeodesicCurveOn_const (hs : UniqueDiffOn ℝ s) (x : M) :
+    IsGeodesicCurveOn I (fun _ : ℝ ↦ x) s where
+  uniqueDiffOn := hs
+  contMDiffOn := contMDiffOn_const
+  alongCurveWithin_curveVelocityWithin_eq_zero r _ := by
+    have hzero : curveVelocityWithin I (fun _ : ℝ ↦ x) s =
+        fun r : ℝ ↦ (0 : TangentSpace I ((fun _ : ℝ ↦ x) r)) :=
+      funext fun _ ↦ curveVelocityWithin_const x
+    rw [hzero, alongCurveWithin_zero]
+
+/-- A constant curve is an all-time geodesic. -/
+theorem isGeodesicCurve_const (x : M) : IsGeodesicCurve I (fun _ : ℝ ↦ x) :=
+  isGeodesicCurveOn_const uniqueDiffOn_univ x
+
+end TauCeti.Manifold
+
+end

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Basic.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Basic.lean
@@ -13,18 +13,28 @@ public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LeviCiv
 # Geodesics of a Riemannian manifold
 
 A curve in a Riemannian manifold is a geodesic when its velocity is parallel along it: the
-covariant derivative of the velocity field along the curve, taken for the Levi-Civita connection
-of the manifold's Riemannian bundle instance, vanishes.  This file introduces that predicate,
-carrying the parameter set on which it is asserted, and identifies it with the classical
-second-order geodesic ODE in a chart.
+derivative of the velocity field along the curve, taken for the Levi-Civita connection of the
+manifold's Riemannian bundle instance, vanishes.  This file introduces that predicate, carrying
+the parameter set on which it is asserted, and identifies it with the classical second-order
+geodesic ODE in a chart.
+
+The derivative along the curve is the moving-chart candidate
+`CovariantDerivative.alongCurveWithin`.  That candidate is identified with the ambient covariant
+derivative for fields pulled back from an ambient vector field, by
+`CovariantDerivative.alongCurveWithin_pullback`; the velocity field of a curve is not such a
+pullback, so for it the identification — and with it the chart independence of the predicate —
+remains open, exactly as the definition of the operator records.
 
 The predicate is stated *within* a parameter set `s`, so that a geodesic segment on a closed
 interval and an all-time geodesic are the same notion at two values of `s`; the all-time
 predicate is the `s = Set.univ` case.  Both the velocity `TauCeti.Manifold.curveVelocityWithin`
 and the along-curve derivative `CovariantDerivative.alongCurveWithin` are then read within `s`,
 and the predicate carries `UniqueDiffOn ℝ s` — satisfied by the nondegenerate intervals and by
-`Set.univ` which the theory uses — because that is what makes those within-derivatives the
-honest ones rather than junk values.
+`Set.univ` which the theory uses — because that is the hypothesis under which a derivative within
+`s` is determined by the curve.  Together with the `C²` regularity it is the hypothesis under
+which the equation is intended to be read as one between honest derivatives; that the two of them
+do make the chart reading of the curve twice differentiable within `s` is not yet formalized, so
+the `derivWithin`s below may still carry the junk value `0`.
 
 Reading the curve in the extended chart centred at the current point turns the definition into
 the second-order equation
@@ -34,15 +44,21 @@ the second-order equation
 where `u = extChartAt I (γ t) ∘ γ` and `Γ` is the model-space Christoffel map of the Levi-Civita
 connection.  That is `TauCeti.Manifold.isGeodesicCurveOn_iff_chart`.  Chart-reading the curve at
 its *current* point, rather than in one fixed chart, is what makes this a statement about the
-whole parameter set at once.
+whole parameter set at once.  The bridge lemmas doing the work,
+`TauCeti.Manifold.sectionCoord_curveVelocityWithin_eventuallyEq` and
+`CovariantDerivative.alongCurveWithin_curveVelocityWithin_eq_zero_iff`, hold for an arbitrary
+connection and live with the rest of the along-curve API in
+`TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean`.
 
 ## Main definitions and results
 
 * `TauCeti.Manifold.IsGeodesicCurveOn`: the geodesic equation on a parameter set, and
-  `TauCeti.Manifold.IsGeodesicCurve` its all-time case, unfolded by
+  `TauCeti.Manifold.IsGeodesicCurve` its all-time case, related by
+  `TauCeti.Manifold.isGeodesicCurveOn_univ` and unfolded by
   `TauCeti.Manifold.isGeodesicCurve_iff`.
 * `TauCeti.Manifold.IsGeodesicCurveOnFrom`: a geodesic together with its initial data, the point
-  and velocity at parameter `0`.
+  and velocity at parameter `0`, read off by `TauCeti.Manifold.IsGeodesicCurveOnFrom.base_eq` and
+  `TauCeti.Manifold.IsGeodesicCurveOnFrom.velocity_eq`.
 * `TauCeti.Manifold.isGeodesicCurveOn_iff_chart`: **the geodesic equation in a chart**, the
   second-order ODE `u'' + Γ (u', u') = 0`.
 * `TauCeti.Manifold.isGeodesicCurveOn_iff_of_isOpen`: on an open parameter set the equation is
@@ -59,8 +75,8 @@ whole parameter set at once.
 
 public section
 
-open Bundle CovariantDerivative Filter Set
-open scoped Manifold Topology
+open Bundle CovariantDerivative Set
+open scoped Manifold
 
 noncomputable section
 
@@ -78,19 +94,25 @@ variable
 /-! ### The geodesic equation -/
 
 variable (I γ s) in
-/-- **A geodesic on a parameter set**: a `C²` curve whose velocity within `s` is parallel along
-it for the Levi-Civita connection of the ambient Riemannian bundle instance.
+/-- **A geodesic on a parameter set**: a `C²` curve whose velocity within `s` is annihilated by
+the moving-chart candidate for the derivative along the curve, taken for the Levi-Civita
+connection of the ambient Riemannian bundle instance.
 
-The velocity is `TauCeti.Manifold.curveVelocityWithin` and its derivative along the curve is
-`CovariantDerivative.alongCurveWithin`, both taken within `s`. -/
+The velocity is `TauCeti.Manifold.curveVelocityWithin` and the candidate for its derivative along
+the curve is `CovariantDerivative.alongCurveWithin`, both taken within `s`.  The candidate is
+identified with the ambient covariant derivative only for pulled-back fields, which the velocity
+field is not. -/
 structure IsGeodesicCurveOn : Prop where
   /-- The parameter set has unique derivatives.  Without this the derivatives within `s` are not
   determined by the curve, and the geodesic equation below does not say what it should. -/
   uniqueDiffOn : UniqueDiffOn ℝ s
-  /-- A geodesic is `C²` on its parameter set: this is what makes its velocity field
-  differentiable, so that the geodesic equation is an equation between honest derivatives. -/
+  /-- A geodesic is `C²` on its parameter set: this is the regularity under which the geodesic
+  equation is intended to be an equation between honest derivatives.  That it does make the chart
+  reading of the curve twice differentiable within `s` is not yet formalized, so the equation may
+  still read the junk values of `CovariantDerivative.alongCurveInChartWithin`. -/
   contMDiffOn : ContMDiffOn 𝓘(ℝ, ℝ) I 2 γ s
-  /-- **The geodesic equation**: the velocity field is parallel along the curve. -/
+  /-- **The geodesic equation**: the along-curve candidate annihilates the velocity field at every
+  parameter of `s`. -/
   alongCurveWithin_curveVelocityWithin_eq_zero : ∀ r ∈ s,
     alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s r = 0
 
@@ -98,6 +120,9 @@ variable (I γ) in
 /-- **A geodesic**, defined at every real parameter.  This is the `s = Set.univ` case of
 `TauCeti.Manifold.IsGeodesicCurveOn`. -/
 def IsGeodesicCurve : Prop := IsGeodesicCurveOn I γ univ
+
+/-- Asserting the geodesic equation on the whole parameter space gives the all-time predicate. -/
+theorem isGeodesicCurveOn_univ : IsGeodesicCurveOn I γ univ ↔ IsGeodesicCurve I γ := Iff.rfl
 
 /-- A geodesic is differentiable on its parameter set. -/
 theorem IsGeodesicCurveOn.mdifferentiableOn (h : IsGeodesicCurveOn I γ s) :
@@ -128,64 +153,25 @@ variable {p : M} {v : TangentSpace I p}
 theorem IsGeodesicCurveOnFrom.base_eq (h : IsGeodesicCurveOnFrom I γ s p v) : γ 0 = p :=
   congrArg TotalSpace.proj h.initial_eq
 
+/-- A geodesic with initial data leaves with the prescribed velocity.  The equality is
+heterogeneous because the two sides live in the tangent spaces at `γ 0` and at `p`. -/
+theorem IsGeodesicCurveOnFrom.velocity_heq (h : IsGeodesicCurveOnFrom I γ s p v) :
+    HEq (curveVelocityWithin I γ s 0) v :=
+  (TotalSpace.ext_iff.mp h.initial_eq).2
+
+/-- A geodesic with initial data leaves with the prescribed velocity, transported to
+`TangentSpace I p` along `TauCeti.Manifold.IsGeodesicCurveOnFrom.base_eq`. -/
+theorem IsGeodesicCurveOnFrom.velocity_eq (h : IsGeodesicCurveOnFrom I γ s p v) :
+    cast (congrArg (TangentSpace I) h.base_eq) (curveVelocityWithin I γ s 0) = v :=
+  eq_of_heq ((cast_heq _ _).trans h.velocity_heq)
+
+/-- A geodesic on a parameter set containing `0` is a geodesic with the initial data it has
+there. -/
+theorem IsGeodesicCurveOn.isGeodesicCurveOnFrom (h : IsGeodesicCurveOn I γ s) (h0 : (0 : ℝ) ∈ s) :
+    IsGeodesicCurveOnFrom I γ s (γ 0) (curveVelocityWithin I γ s 0) :=
+  ⟨h, h0, rfl⟩
+
 /-! ### The geodesic equation in a chart -/
-
-omit [FiniteDimensional ℝ E] [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
-  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
-  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
-/-- Along a curve differentiable within `s`, the coordinate reading of the velocity field in the
-tangent-bundle trivialization centred at `x` is the derivative within `s` of the curve read in the
-extended chart at `x`, at every nearby parameter of `s` at which the curve is still in that
-chart. -/
-theorem sectionCoord_curveVelocityWithin_eventuallyEq {x : M} (hs : UniqueDiffOn ℝ s)
-    (hγ : MDifferentiableOn 𝓘(ℝ, ℝ) I γ s) (ht : t ∈ s)
-    (hx : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) :
-    sectionCoord (F := E) γ (curveVelocityWithin I γ s) x =ᶠ[𝓝[s] t]
-      derivWithin (extChartAt I x ∘ γ) s := by
-  have hbase : ∀ᶠ r in 𝓝[s] t, γ r ∈ (trivializationAt E (TangentSpace I) x).baseSet :=
-    (hγ t ht).continuousWithinAt.preimage_mem_nhdsWithin
-      ((trivializationAt E (TangentSpace I) x).open_baseSet.mem_nhds hx)
-  filter_upwards [hbase, self_mem_nhdsWithin] with r hr hrs
-  rw [sectionCoord_apply, derivWithin_extChartAt_comp γ hr (hs r hrs)
-    (hasMFDerivWithinAt_curveVelocityWithin (hγ r hrs))]
-
-/-- The moving-chart coordinate formula applied to the velocity field is the classical
-second-order expression `u'' + Γ (u', u')`, for `u` the curve read in the extended chart at `x`.
-The chart need not be the one centred at the current point of the curve. -/
-theorem alongCurveInChartWithin_curveVelocityWithin {x : M} (hs : UniqueDiffOn ℝ s)
-    (hγ : MDifferentiableOn 𝓘(ℝ, ℝ) I γ s) (ht : t ∈ s)
-    (hx : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) :
-    alongCurveInChartWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s x t =
-      derivWithin (derivWithin (extChartAt I x ∘ γ) s) s t +
-        christoffelMap (Module.finBasis ℝ E)
-          ((leviCivita I M).isCovariantDerivativeOn
-            (s := (trivializationAt E (TangentSpace I) x).baseSet)) (γ t)
-          (derivWithin (extChartAt I x ∘ γ) s t) (derivWithin (extChartAt I x ∘ γ) s t) := by
-  have hEq := sectionCoord_curveVelocityWithin_eventuallyEq hs hγ ht hx
-  have hpoint : sectionCoord (F := E) γ (curveVelocityWithin I γ s) x t =
-      derivWithin (extChartAt I x ∘ γ) s t := hEq.self_of_nhdsWithin ht
-  rw [alongCurveInChartWithin_apply, hEq.derivWithin_eq hpoint, hpoint]
-
-/-- The along-curve derivative of the velocity field vanishes exactly when the curve read in the
-extended chart at the current point solves the second-order geodesic ODE there.  The moving-chart
-formula is transported by a fibrewise linear equivalence, so vanishing may be tested in the
-chart. -/
-theorem alongCurveWithin_curveVelocityWithin_eq_zero_iff (hs : UniqueDiffOn ℝ s)
-    (hγ : MDifferentiableOn 𝓘(ℝ, ℝ) I γ s) (ht : t ∈ s) :
-    alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s t = 0 ↔
-      derivWithin (derivWithin (extChartAt I (γ t) ∘ γ) s) s t +
-        christoffelMap (Module.finBasis ℝ E)
-          ((leviCivita I M).isCovariantDerivativeOn
-            (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t)
-          (derivWithin (extChartAt I (γ t) ∘ γ) s t)
-          (derivWithin (extChartAt I (γ t) ∘ γ) s t) = 0 := by
-  set e := trivializationAt E (TangentSpace I) (γ t)
-  have hmem : γ t ∈ e.baseSet :=
-    FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t)
-  rw [alongCurveWithin_apply, alongCurveInChartWithin_curveVelocityWithin hs hγ ht hmem]
-  refine ⟨fun h ↦ ?_, fun h ↦ by rw [h, map_zero]⟩
-  have h' := congrArg (e.continuousLinearMapAt ℝ (γ t)) h
-  rwa [e.continuousLinearMapAt_symmL (R := ℝ) hmem, map_zero] at h'
 
 /-- **The geodesic equation in a chart.**  A `C²` curve is a geodesic on a parameter set with
 unique derivatives exactly when, at every parameter of that set, the curve read in the extended
@@ -202,25 +188,13 @@ theorem isGeodesicCurveOn_iff_chart (hs : UniqueDiffOn ℝ s) :
   constructor
   · intro h
     exact ⟨h.contMDiffOn, fun r hr ↦ (alongCurveWithin_curveVelocityWithin_eq_zero_iff
-      h.uniqueDiffOn h.mdifferentiableOn hr).mp
+      (leviCivita I M) γ h.uniqueDiffOn h.mdifferentiableOn hr).mp
       (h.alongCurveWithin_curveVelocityWithin_eq_zero r hr)⟩
   · rintro ⟨hc, hchart⟩
-    exact ⟨hs, hc, fun r hr ↦ (alongCurveWithin_curveVelocityWithin_eq_zero_iff hs
-      (hc.mdifferentiableOn (by norm_num)) hr).mpr (hchart r hr)⟩
+    exact ⟨hs, hc, fun r hr ↦ (alongCurveWithin_curveVelocityWithin_eq_zero_iff (leviCivita I M) γ
+      hs (hc.mdifferentiableOn (by norm_num)) hr).mpr (hchart r hr)⟩
 
 /-! ### Open parameter sets -/
-
-/-- On an open parameter set, the restricted velocity field and the restricted along-curve
-derivative are the unrestricted ones. -/
-theorem alongCurveWithin_curveVelocityWithin_of_isOpen (hs : IsOpen s) (ht : t ∈ s) :
-    alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s t =
-      alongCurve (leviCivita I M) γ (curveVelocity I γ) t := by
-  have hcongr : ∀ᶠ r in 𝓝[s] t, curveVelocityWithin I γ s r = curveVelocity I γ r := by
-    filter_upwards [self_mem_nhdsWithin] with r hr
-    exact curveVelocityWithin_of_mem_nhds (hs.mem_nhds hr)
-  rw [alongCurveWithin_congr (leviCivita I M) γ (curveVelocityWithin I γ s) hcongr
-      (curveVelocityWithin_of_mem_nhds (hs.mem_nhds ht)),
-    alongCurveWithin_of_mem_nhds (leviCivita I M) γ (curveVelocity I γ) (hs.mem_nhds ht)]
 
 /-- On an open parameter set, the geodesic equation is the unrestricted one. -/
 theorem isGeodesicCurveOn_iff_of_isOpen (hs : IsOpen s) :
@@ -229,24 +203,24 @@ theorem isGeodesicCurveOn_iff_of_isOpen (hs : IsOpen s) :
   constructor
   · intro h
     exact ⟨h.contMDiffOn, fun r hr ↦ by
-      rw [← alongCurveWithin_curveVelocityWithin_of_isOpen hs hr]
+      rw [← alongCurveWithin_curveVelocityWithin_of_isOpen (leviCivita I M) γ hs hr]
       exact h.alongCurveWithin_curveVelocityWithin_eq_zero r hr⟩
   · rintro ⟨hc, hzero⟩
     exact ⟨hs.uniqueDiffOn, hc, fun r hr ↦ by
-      rw [alongCurveWithin_curveVelocityWithin_of_isOpen hs hr]
+      rw [alongCurveWithin_curveVelocityWithin_of_isOpen (leviCivita I M) γ hs hr]
       exact hzero r hr⟩
 
 /-- The all-time geodesic equation, spelled out. -/
 theorem isGeodesicCurve_iff :
     IsGeodesicCurve I γ ↔ ContMDiff 𝓘(ℝ, ℝ) I 2 γ ∧
       ∀ t : ℝ, alongCurve (leviCivita I M) γ (curveVelocity I γ) t = 0 := by
-  rw [IsGeodesicCurve, isGeodesicCurveOn_iff_of_isOpen isOpen_univ, contMDiffOn_univ]
+  rw [← isGeodesicCurveOn_univ, isGeodesicCurveOn_iff_of_isOpen isOpen_univ, contMDiffOn_univ]
   simp
 
 /-! ### Constant curves -/
 
-/-- **A constant curve is a geodesic.**  Its velocity field is the zero section, which is
-parallel. -/
+/-- **A constant curve is a geodesic.**  Its velocity field is the zero section, which the
+along-curve candidate annihilates. -/
 theorem isGeodesicCurveOn_const (hs : UniqueDiffOn ℝ s) (x : M) :
     IsGeodesicCurveOn I (fun _ : ℝ ↦ x) s where
   uniqueDiffOn := hs

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Basic.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Basic.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Geometry.Manifold.MFDeriv.Curve
 public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.LocalFrame
 public import TauCeti.Geometry.Manifold.VectorBundle.SectionAlongCurve
 public import Mathlib.Analysis.Calculus.Deriv.Add
@@ -52,6 +53,9 @@ ambient covariant derivative.
   reparametrization, with
   `CovariantDerivative.alongCurve_congr` and `CovariantDerivative.alongCurve_comp` their
   unrestricted cases.
+* `CovariantDerivative.alongCurveWithin_curveVelocityWithin_of_isOpen`: on an open parameter set
+  the moving-chart candidate for the velocity field of the curve is the unrestricted one of the
+  unrestricted velocity field.
 
 ## References
 
@@ -309,6 +313,20 @@ theorem alongCurve_congr {W : ∀ t, TangentSpace I (γ t)} {t : 𝕜}
     (h : ∀ᶠ r in 𝓝 t, V r = W r) : alongCurve cov γ V t = alongCurve cov γ W t := by
   rw [← alongCurveWithin_univ, ← alongCurveWithin_univ]
   exact alongCurveWithin_congr cov γ V (by rwa [nhdsWithin_univ]) h.self_of_nhds
+
+/-- On an open parameter set, the moving-chart candidate for the velocity field within that set is
+the unrestricted candidate for the unrestricted velocity field: both the velocity and the
+derivatives along the curve are then the unrestricted ones. -/
+theorem alongCurveWithin_curveVelocityWithin_of_isOpen {s : Set 𝕜} {t : 𝕜} (hs : IsOpen s)
+    (ht : t ∈ s) :
+    alongCurveWithin cov γ (curveVelocityWithin I γ s) s t =
+      alongCurve cov γ (curveVelocity I γ) t := by
+  have hcongr : ∀ᶠ r in 𝓝[s] t, curveVelocityWithin I γ s r = curveVelocity I γ r := by
+    filter_upwards [self_mem_nhdsWithin] with r hr
+    exact curveVelocityWithin_of_mem_nhds (hs.mem_nhds hr)
+  rw [alongCurveWithin_congr cov γ (curveVelocityWithin I γ s) hcongr
+      (curveVelocityWithin_of_mem_nhds (hs.mem_nhds ht)),
+    alongCurveWithin_of_mem_nhds cov γ (curveVelocity I γ) (hs.mem_nhds ht)]
 
 /-- The moving-chart candidate within a parameter set is natural under differentiable
 reparametrization mapping that set into the parameter set of the original curve. The curve and the

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Geometry.Manifold.MFDeriv.Curve
 public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.AlongCurve.Basic
 public import Mathlib.Geometry.Manifold.MFDeriv.Atlas
 
@@ -28,13 +29,22 @@ same tangent vector for every such `x`.
 
 The velocity of the curve is carried by a `HasMFDerivWithinAt` hypothesis, in the
 `ContinuousLinearMap.smulRight 1 w` form used by Mathlib's integral-curve API, so that no junk
-value can leak in; `CovariantDerivative.alongCurveWithin_pullback_mfderivWithin` restates the
-result for the canonical velocity `mfderivWithin 𝓘(𝕜, 𝕜) I γ s t 1`.
+value can leak in; `CovariantDerivative.alongCurveWithin_pullback_curveVelocityWithin` restates the
+result for the canonical velocity `TauCeti.Manifold.curveVelocityWithin`.
+
+The chart computation of this file also specializes to the *velocity field* `t ↦ γ' t` of the
+curve, which is not pulled back from an ambient vector field: reading it in a chart returns the
+derivative of the chart reading of the curve, so the moving-chart formula becomes the classical
+second-order expression `u'' + Γ (u', u')`.  Those lemmas are stated for an arbitrary connection;
+`TauCeti/Geometry/Manifold/Riemannian/Geodesic/Basic.lean` reads the geodesic equation off them
+for the Levi-Civita connection.
 
 ## Main results
 
 * `TauCeti.Manifold.derivWithin_extChartAt_comp`: the derivative of a curve read in the chart at
-  `x` is the reading of its velocity in the tangent-bundle trivialization at `x`.
+  `x` is the reading of its velocity in the tangent-bundle trivialization at `x`, with
+  `TauCeti.Manifold.sectionCoord_curveVelocityWithin_eventuallyEq` its eventual-equality form for
+  the velocity field.
 * `TauCeti.Manifold.derivWithin_sectionCoord_pullback`: the derivative of the coordinate reading
   of a pulled-back field is the reading of the flat frame derivative in the direction of the
   velocity.
@@ -46,8 +56,12 @@ result for the canonical velocity `mfderivWithin 𝓘(𝕜, 𝕜) I γ s t 1`.
 * `CovariantDerivative.symmL_alongCurveInChartWithin_pullback`: on pulled-back fields the
   coordinate formula is chart independent -- reading it in any chart around `γ t` and transporting
   back gives the moving-chart value.
-* `CovariantDerivative.alongCurveWithin_pullback_mfderivWithin`: the same identification with the
-  velocity written as `mfderivWithin 𝓘(𝕜, 𝕜) I γ s t 1`.
+* `CovariantDerivative.alongCurveWithin_pullback_curveVelocityWithin`: the same identification with
+  the velocity written as `TauCeti.Manifold.curveVelocityWithin`.
+* `CovariantDerivative.alongCurveInChartWithin_curveVelocityWithin`: the coordinate formula for the
+  velocity field of the curve is `u'' + Γ (u', u')`, and
+  `CovariantDerivative.alongCurveWithin_curveVelocityWithin_eq_zero_iff`: it vanishes exactly when
+  that second-order expression does, for the chart centred at the current point.
 
 ## References
 
@@ -80,25 +94,6 @@ variable
 variable (γ : 𝕜 → M) (X : Π y : M, TangentSpace I y)
 
 omit [CompleteSpace 𝕜] [FiniteDimensional 𝕜 E]
-  [IsManifold I 1 M]
-  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
-/-- Compose a manifold derivative with a curve of specified velocity, reading the resulting
-one-dimensional manifold derivative as an ordinary derivative. -/
-private theorem hasDerivWithinAt_comp_curve
-    {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] [ContinuousSMul 𝕜 F]
-    {f : M → F} {s : Set 𝕜} {t : 𝕜}
-    {w : TangentSpace I (γ t)} {D : TangentSpace I (γ t) →L[𝕜] F}
-    (hf : HasMFDerivAt I 𝓘(𝕜, F) f (γ t) D)
-    (hγ : HasMFDerivAt[s] γ t (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) w)) :
-    HasDerivWithinAt (f ∘ γ) (D w) s t := by
-  have hcomp : HasMFDerivAt[s] (f ∘ γ) t
-      (ContinuousLinearMap.smulRight (1 : 𝕜 →L[𝕜] 𝕜) (D w)) :=
-    (hf.comp_hasMFDerivWithinAt (hf := hγ)).congr_mfderiv (by
-      ext
-      exact D.map_smul (1 : 𝕜) w)
-  exact hcomp.hasFDerivWithinAt
-
-omit [CompleteSpace 𝕜] [FiniteDimensional 𝕜 E]
   [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
 /-- The derivative of a curve read in the chart centred at `x`, taken within a parameter set with
 a unique derivative there, is the reading of the velocity of the curve in the tangent-bundle
@@ -112,10 +107,25 @@ theorem derivWithin_extChartAt_comp {x : M} {s : Set 𝕜} {t : 𝕜} {w : Tange
       (trivializationAt E (TangentSpace I) x).continuousLinearMapAt 𝕜 (γ t) w := by
   rw [TangentBundle.continuousLinearMapAt_trivializationAt
     (by simpa only [TangentBundle.trivializationAt_baseSet] using hx)]
-  set D := mfderiv% (extChartAt I x) (γ t)
-  have hchart : HasMFDerivAt% (extChartAt I x) (γ t) D :=
-    (mdifferentiableAt_extChartAt hx).hasMFDerivAt
-  exact (hasDerivWithinAt_comp_curve γ hchart hγ).derivWithin hu
+  exact (hasDerivWithinAt_comp_curve (mdifferentiableAt_extChartAt hx) hγ).derivWithin hu
+
+omit [CompleteSpace 𝕜] [FiniteDimensional 𝕜 E]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
+/-- Along a curve differentiable within `s`, the coordinate reading of the velocity field in the
+tangent-bundle trivialization centred at `x` is the derivative within `s` of the curve read in the
+extended chart at `x`, at every nearby parameter of `s` at which the curve is still in that
+chart. -/
+theorem sectionCoord_curveVelocityWithin_eventuallyEq {x : M} {s : Set 𝕜} {t : 𝕜}
+    (hs : UniqueDiffOn 𝕜 s) (hγ : MDifferentiableOn 𝓘(𝕜, 𝕜) I γ s) (ht : t ∈ s)
+    (hx : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) :
+    sectionCoord (F := E) γ (curveVelocityWithin I γ s) x =ᶠ[𝓝[s] t]
+      derivWithin (extChartAt I x ∘ γ) s := by
+  have hbase : ∀ᶠ r in 𝓝[s] t, γ r ∈ (trivializationAt E (TangentSpace I) x).baseSet :=
+    (hγ t ht).continuousWithinAt.preimage_mem_nhdsWithin
+      ((trivializationAt E (TangentSpace I) x).open_baseSet.mem_nhds hx)
+  filter_upwards [hbase, self_mem_nhdsWithin] with r hr hrs
+  rw [sectionCoord_apply, derivWithin_extChartAt_comp γ hr (hs r hrs)
+    (hasMFDerivWithinAt_curveVelocityWithin (hγ r hrs))]
 
 omit [FiniteDimensional 𝕜 E]
   [IsManifold I 1 M]
@@ -146,10 +156,8 @@ theorem derivWithin_sectionCoord_pullback
       rw [map_smul, continuousLinearMapAt_localFrame b hyb i]
       simp only [σ, LinearMap.piApply_apply_apply]
   -- Each frame coefficient is differentiable along the curve, with the expected derivative.
-  have hcoeff : ∀ i, HasDerivWithinAt (fun r ↦ σ i (γ r)) (d% (σ i) (γ t) w) s t := by
-    intro i
-    exact hasDerivWithinAt_comp_curve γ
-      (mdifferentiableAt_localFrameCoeff b hy hY i).hasMFDerivAt hγ
+  have hcoeff : ∀ i, HasDerivWithinAt (fun r ↦ σ i (γ r)) (d% (σ i) (γ t) w) s t := fun i ↦
+    hasDerivWithinAt_comp_curve (mdifferentiableAt_localFrameCoeff b hy hY i) hγ
   have hfun : (∑ i : ι, fun r ↦ σ i (γ r) • b i) = fun r ↦ ∑ i, σ i (γ r) • b i := by
     funext r
     simp [Finset.sum_apply]
@@ -244,18 +252,52 @@ theorem alongCurve_pullback {t : 𝕜} {w : TangentSpace I (γ t)}
   exact alongCurveWithin_pullback cov γ X uniqueDiffWithinAt_univ hγ.hasMFDerivWithinAt hX
 
 /-- Agreement with the ambient covariant derivative, with the velocity of the curve written as the
-canonical `mfderivWithin 𝓘(𝕜, 𝕜) I γ s t 1`. -/
-theorem alongCurveWithin_pullback_mfderivWithin {s : Set 𝕜} {t : 𝕜}
+canonical `TauCeti.Manifold.curveVelocityWithin`. -/
+theorem alongCurveWithin_pullback_curveVelocityWithin {s : Set 𝕜} {t : 𝕜}
     (hu : UniqueDiffWithinAt 𝕜 s t) (hγ : MDifferentiableWithinAt 𝓘(𝕜, 𝕜) I γ s t)
     (hX : MDiffAt (T% X) (γ t)) :
-    alongCurveWithin cov γ (fun r ↦ X (γ r)) s t =
-      cov X (γ t) (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t (1 : 𝕜)) := by
-  refine alongCurveWithin_pullback cov γ X hu (hγ.hasMFDerivWithinAt.congr_mfderiv ?_) hX
-  ext
-  -- The tangent space of the scalar model is definitionally `𝕜`, but its topology instance blocks
-  -- rewriting by `ContinuousLinearMap.smulRight_apply` until that identification is exposed.
-  change (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜) =
-    (1 : 𝕜) • (mfderivWithin 𝓘(𝕜, 𝕜) I γ s t) (1 : 𝕜)
-  rw [one_smul]
+    alongCurveWithin cov γ (fun r ↦ X (γ r)) s t = cov X (γ t) (curveVelocityWithin I γ s t) :=
+  alongCurveWithin_pullback cov γ X hu (hasMFDerivWithinAt_curveVelocityWithin hγ) hX
+
+/-! ### The velocity field of the curve -/
+
+/-- The moving-chart coordinate formula applied to the velocity field of the curve is the classical
+second-order expression `u'' + Γ (u', u')`, for `u` the curve read in the extended chart at `x`.
+The chart need not be the one centred at the current point of the curve. -/
+theorem alongCurveInChartWithin_curveVelocityWithin {x : M} {s : Set 𝕜} {t : 𝕜}
+    (hs : UniqueDiffOn 𝕜 s) (hγ : MDifferentiableOn 𝓘(𝕜, 𝕜) I γ s) (ht : t ∈ s)
+    (hx : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) :
+    alongCurveInChartWithin cov γ (curveVelocityWithin I γ s) s x t =
+      derivWithin (derivWithin (extChartAt I x ∘ γ) s) s t +
+        christoffelMap (Module.finBasis 𝕜 E)
+          (cov.isCovariantDerivativeOn
+            (s := (trivializationAt E (TangentSpace I) x).baseSet)) (γ t)
+          (derivWithin (extChartAt I x ∘ γ) s t) (derivWithin (extChartAt I x ∘ γ) s t) := by
+  have hEq := sectionCoord_curveVelocityWithin_eventuallyEq γ hs hγ ht hx
+  have hpoint : sectionCoord (F := E) γ (curveVelocityWithin I γ s) x t =
+      derivWithin (extChartAt I x ∘ γ) s t := hEq.self_of_nhdsWithin ht
+  rw [alongCurveInChartWithin_apply, hEq.derivWithin_eq hpoint, hpoint]
+
+/-- The moving-chart candidate for the derivative of the velocity field along the curve vanishes
+exactly when the curve read in the extended chart at the current point solves the second-order
+equation `u'' + Γ (u', u') = 0` there. -/
+theorem alongCurveWithin_curveVelocityWithin_eq_zero_iff {s : Set 𝕜} {t : 𝕜}
+    (hs : UniqueDiffOn 𝕜 s) (hγ : MDifferentiableOn 𝓘(𝕜, 𝕜) I γ s) (ht : t ∈ s) :
+    alongCurveWithin cov γ (curveVelocityWithin I γ s) s t = 0 ↔
+      derivWithin (derivWithin (extChartAt I (γ t) ∘ γ) s) s t +
+        christoffelMap (Module.finBasis 𝕜 E)
+          (cov.isCovariantDerivativeOn
+            (s := (trivializationAt E (TangentSpace I) (γ t)).baseSet)) (γ t)
+          (derivWithin (extChartAt I (γ t) ∘ γ) s t)
+          (derivWithin (extChartAt I (γ t) ∘ γ) s t) = 0 := by
+  set e := trivializationAt E (TangentSpace I) (γ t)
+  have hmem : γ t ∈ e.baseSet :=
+    FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t)
+  rw [alongCurveWithin_apply, alongCurveInChartWithin_curveVelocityWithin cov γ hs hγ ht hmem]
+  refine ⟨fun h ↦ ?_, fun h ↦ by rw [h, map_zero]⟩
+  -- The coordinate formula is transported by a fibrewise linear equivalence, so its vanishing is
+  -- equivalent to the vanishing of its reading in the chart.
+  have h' := congrArg (e.continuousLinearMapAt 𝕜 (γ t)) h
+  rwa [e.continuousLinearMapAt_symmL (R := 𝕜) hmem, map_zero] at h'
 
 end CovariantDerivative


### PR DESCRIPTION
This PR defines the interval-aware geodesic predicate `TauCeti.Manifold.IsGeodesicCurveOn I γ s` and proves it equivalent to the classical second-order geodesic ODE in a chart. A curve is a geodesic on the parameter set `s` when `s` has unique derivatives, the curve is `C²` on `s`, and the covariant derivative along the curve of its velocity field — both taken within `s`, using the already-merged moving-chart operator `CovariantDerivative.alongCurveWithin` and the Levi-Civita connection `CovariantDerivative.leviCivita` of the ambient Riemannian bundle instance — vanishes at every parameter of `s`. Reading the curve in the extended chart centred at its *current* point turns this into `u'' + Γ_{γ t}(u', u') = 0`, which is `TauCeti.Manifold.isGeodesicCurveOn_iff_chart`; the substance is the bridge lemma `TauCeti.Manifold.sectionCoord_curveVelocityWithin_eventuallyEq`, which identifies the trivialization reading of the velocity field with the derivative within `s` of the chart reading of the curve, so that the first summand of the moving-chart formula becomes an honest second derivative. Also included: the all-time specialization `IsGeodesicCurve` with its unrestricted form, the form of the equation on an open parameter set (where the within-derivatives are the unrestricted ones), the initial-data predicate `IsGeodesicCurveOnFrom` packaging the base point and initial velocity as one equality in the tangent bundle, and the fact that constant curves are geodesics.

Two files: `TauCeti/Geometry/Manifold/Riemannian/Geodesic/Basic.lean` is new (265 lines); `TauCeti/Geometry/Manifold/MFDeriv/Curve.lean` gains 95 lines naming the velocity of a curve, `TauCeti.Manifold.curveVelocityWithin I γ s t = mfderivWithin 𝓘(ℝ, ℝ) I γ s t 1`, with its unrestricted case and the two lemmas relating it to Mathlib's `HasMFDerivWithinAt` presentation of a velocity. That file is the natural home: it already develops derivatives along a curve in a manifold, and the new definition is what lets the geodesic equation be stated without carrying a `HasMFDerivWithinAt` witness for the velocity everywhere.

Roadmap target: the HopfRinow roadmap's Layer 1 bullets "`IsGeodesicCurveOn γ s`" (which asks for exactly this predicate on a `UniqueDiffOn ℝ s` parameter set, with the velocity defined by applying `mfderivWithin 𝓘(ℝ, ℝ) I γ s t` to the unit tangent vector, and for the chart form to be proved equivalent to the connection-based definition) and "Initial data". The milestone served is Layer 1's geodesic spray and local existence: the roadmap's Ordering section puts the along-curve derivative before the spray, and the spray milestone is stated as "integral curves of `S` are exactly the velocity lifts of curves satisfying the covariant geodesic equation", which needs this predicate to be expressible. Its Levi-Civita and along-curve prerequisites landed in #4260, #3913, #4329, #4399 and #4555; nothing in flight covers the geodesic predicate. What remains after this PR, before the spray, is second-order regularity of the chart reading of a `C²` curve — needed for restriction to a subinterval and for affine reparametrization — and then the construction of the spray on `TM` and its identification with this equation.

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"isgeodesiccurveon"}-->

🤖 Prepared with Claude Code
