### PR TITLE
feat: the permutation character of a point stabilizer in the symmetric group

### DIFF
--- a/TauCeti/GroupTheory/DoubleCoset/PointStabilizer.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/PointStabilizer.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.GroupTheory.DoubleCoset.Identity
+public import Mathlib.Algebra.Group.End
+public import Mathlib.GroupTheory.GroupAction.Defs
+public import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.Tactic.Group
+
+/-!
+# The double cosets of a point stabilizer in a symmetric group
+
+Let `α` be a type with at least two elements and let `x₀ : α`.  The stabilizer of `x₀` in
+`Equiv.Perm α` has exactly two double cosets: a permutation either fixes `x₀` or does not, and
+each of the two possibilities is a single class.  Fixing `x₀` is membership in the stabilizer, so
+that case is the identity double coset; and if `σ` and `τ` both move `x₀` then the transposition
+of `σ x₀` and `τ x₀` fixes `x₀` and carries the one onto the other.
+
+## Main statements
+
+* `TauCeti.doubleCoset_rel_stabilizer_of_ne`: the permutations moving `x₀` form a single double
+  coset.
+* `TauCeti.doubleCoset_mk_stabilizer_eq_one_iff`: a double coset of the stabilizer of `x₀` is the
+  identity one exactly when its permutations fix `x₀`.
+* `TauCeti.card_doubleCosetQuotient_stabilizer`: a point stabilizer of a nontrivial `α` has
+  exactly two double cosets in `Equiv.Perm α`.
+
+## Implementation notes
+
+`TauCeti.doubleCoset_rel_stabilizer_of_ne` is stated on the relation `DoubleCoset.setoid` and
+transported to the quotient with `Quotient.sound'`, because `DoubleCoset.Quotient` is a plain
+definition that `rw` will not see through.
+
+The count is proved by hand rather than through `TauCeti.doubleCosetEquivOrbitQuotient`, which
+reads the same two classes as the two orbits of `Equiv.Perm α` on ordered pairs of points: the
+transposition exhibiting the second class is shorter than the transport.
+-/
+
+public section
+
+open MulAction
+
+namespace TauCeti
+
+variable {α : Type*} (x₀ : α)
+
+/-- **The permutations moving `x₀` form a single double coset.**  If `σ` and `τ` both move `x₀`
+then the transposition of `σ x₀` and `τ x₀` fixes `x₀` and carries the one onto the other. -/
+theorem doubleCoset_rel_stabilizer_of_ne {σ τ : Equiv.Perm α} (hσ : σ x₀ ≠ x₀) (hτ : τ x₀ ≠ x₀) :
+    DoubleCoset.setoid (↑(stabilizer (Equiv.Perm α) x₀)) (↑(stabilizer (Equiv.Perm α) x₀)) σ τ :=
+    by
+  classical
+  have hax₀ : Equiv.swap (σ x₀) (τ x₀) x₀ = x₀ :=
+    Equiv.swap_apply_of_ne_of_ne (Ne.symm hσ) (Ne.symm hτ)
+  have hinv : (Equiv.swap (σ x₀) (τ x₀))⁻¹ (τ x₀) = σ x₀ := by
+    rw [Equiv.swap_inv]
+    exact Equiv.swap_apply_right _ _
+  rw [DoubleCoset.rel_iff]
+  refine ⟨Equiv.swap (σ x₀) (τ x₀), mem_stabilizer_iff.mpr hax₀,
+    σ⁻¹ * (Equiv.swap (σ x₀) (τ x₀))⁻¹ * τ, mem_stabilizer_iff.mpr ?_, by group⟩
+  rw [Equiv.Perm.smul_def, Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, hinv,
+    Equiv.Perm.inv_def, Equiv.symm_apply_apply]
+
+/-- A double coset of the stabilizer of `x₀` is the identity one exactly when its permutations fix
+`x₀`.  This is `TauCeti.doubleCosetMk_eq_mk_one_iff_mem` for the stabilizer, whose membership
+condition is fixing `x₀`. -/
+theorem doubleCoset_mk_stabilizer_eq_one_iff {σ : Equiv.Perm α} :
+    DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) σ =
+        DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) 1 ↔
+      σ x₀ = x₀ :=
+  (doubleCosetMk_eq_mk_one_iff_mem _ σ).trans mem_stabilizer_iff
+
+/-- **A point stabilizer has exactly two double cosets.**  The identity double coset is the
+stabilizer itself, and every permutation moving `x₀` lies in the other one; a nontrivial `α`
+supplies such a permutation. -/
+theorem card_doubleCosetQuotient_stabilizer [Nontrivial α] :
+    Nat.card (DoubleCoset.Quotient (↑(stabilizer (Equiv.Perm α) x₀))
+      (↑(stabilizer (Equiv.Perm α) x₀) : Set (Equiv.Perm α))) = 2 := by
+  classical
+  obtain ⟨y, hy⟩ := exists_ne x₀
+  have hswap : Equiv.swap x₀ y x₀ ≠ x₀ := by
+    rw [Equiv.swap_apply_left]
+    exact hy
+  rw [Nat.card_eq_two_iff' (DoubleCoset.mk _ _ 1)]
+  refine ⟨DoubleCoset.mk _ _ (Equiv.swap x₀ y),
+    fun h => hswap ((doubleCoset_mk_stabilizer_eq_one_iff x₀).mp h), fun q hq => ?_⟩
+  induction q using Quotient.inductionOn with
+  | h σ =>
+    exact Quotient.sound' (doubleCoset_rel_stabilizer_of_ne x₀
+      (fun h => hq ((doubleCoset_mk_stabilizer_eq_one_iff x₀).mpr h)) hswap)
+
+end TauCeti

--- a/TauCeti/GroupTheory/DoubleCoset/PointStabilizer.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/PointStabilizer.lean
@@ -56,18 +56,18 @@ theorem doubleCoset_rel_stabilizer_of_ne {σ τ : Equiv.Perm α} (hσ : σ x₀ 
   classical
   have hax₀ : Equiv.swap (σ x₀) (τ x₀) x₀ = x₀ :=
     Equiv.swap_apply_of_ne_of_ne (Ne.symm hσ) (Ne.symm hτ)
-  have hinv : (Equiv.swap (σ x₀) (τ x₀))⁻¹ (τ x₀) = σ x₀ := by
-    rw [Equiv.swap_inv]
-    exact Equiv.swap_apply_right _ _
   rw [DoubleCoset.rel_iff]
   refine ⟨Equiv.swap (σ x₀) (τ x₀), mem_stabilizer_iff.mpr hax₀,
     σ⁻¹ * (Equiv.swap (σ x₀) (τ x₀))⁻¹ * τ, mem_stabilizer_iff.mpr ?_, by group⟩
-  rw [Equiv.Perm.smul_def, Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, hinv,
-    Equiv.Perm.inv_def, Equiv.symm_apply_apply]
+  simp
 
 /-- A double coset of the stabilizer of `x₀` is the identity one exactly when its permutations fix
 `x₀`.  This is `TauCeti.doubleCosetMk_eq_mk_one_iff_mem` for the stabilizer, whose membership
-condition is fixing `x₀`. -/
+condition is fixing `x₀`.
+
+Not a `simp` lemma: `TauCeti.doubleCosetMk_eq_mk_one_iff_mem` and `MulAction.mem_stabilizer_iff`
+are both `simp` lemmas and between them already rewrite this left-hand side to this right-hand
+side, so tagging this specialisation fails the `simpNF` linter with "simp can prove this". -/
 theorem doubleCosetMk_stabilizer_eq_one_iff {σ : Equiv.Perm α} :
     DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) σ =
         DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) 1 ↔

--- a/TauCeti/GroupTheory/DoubleCoset/PointStabilizer.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/PointStabilizer.lean
@@ -24,7 +24,7 @@ of `σ x₀` and `τ x₀` fixes `x₀` and carries the one onto the other.
 
 * `TauCeti.doubleCoset_rel_stabilizer_of_ne`: the permutations moving `x₀` form a single double
   coset.
-* `TauCeti.doubleCoset_mk_stabilizer_eq_one_iff`: a double coset of the stabilizer of `x₀` is the
+* `TauCeti.doubleCosetMk_stabilizer_eq_one_iff`: a double coset of the stabilizer of `x₀` is the
   identity one exactly when its permutations fix `x₀`.
 * `TauCeti.card_doubleCosetQuotient_stabilizer`: a point stabilizer of a nontrivial `α` has
   exactly two double cosets in `Equiv.Perm α`.
@@ -68,7 +68,7 @@ theorem doubleCoset_rel_stabilizer_of_ne {σ τ : Equiv.Perm α} (hσ : σ x₀ 
 /-- A double coset of the stabilizer of `x₀` is the identity one exactly when its permutations fix
 `x₀`.  This is `TauCeti.doubleCosetMk_eq_mk_one_iff_mem` for the stabilizer, whose membership
 condition is fixing `x₀`. -/
-theorem doubleCoset_mk_stabilizer_eq_one_iff {σ : Equiv.Perm α} :
+theorem doubleCosetMk_stabilizer_eq_one_iff {σ : Equiv.Perm α} :
     DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) σ =
         DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) 1 ↔
       σ x₀ = x₀ :=
@@ -87,10 +87,10 @@ theorem card_doubleCosetQuotient_stabilizer [Nontrivial α] :
     exact hy
   rw [Nat.card_eq_two_iff' (DoubleCoset.mk _ _ 1)]
   refine ⟨DoubleCoset.mk _ _ (Equiv.swap x₀ y),
-    fun h => hswap ((doubleCoset_mk_stabilizer_eq_one_iff x₀).mp h), fun q hq => ?_⟩
+    fun h => hswap ((doubleCosetMk_stabilizer_eq_one_iff x₀).mp h), fun q hq => ?_⟩
   induction q using Quotient.inductionOn with
   | h σ =>
     exact Quotient.sound' (doubleCoset_rel_stabilizer_of_ne x₀
-      (fun h => hq ((doubleCoset_mk_stabilizer_eq_one_iff x₀).mpr h)) hswap)
+      (fun h => hq ((doubleCosetMk_stabilizer_eq_one_iff x₀).mpr h)) hswap)
 
 end TauCeti

--- a/TauCeti/GroupTheory/DoubleCoset/PointStabilizer.lean
+++ b/TauCeti/GroupTheory/DoubleCoset/PointStabilizer.lean
@@ -22,8 +22,8 @@ of `σ x₀` and `τ x₀` fixes `x₀` and carries the one onto the other.
 
 ## Main statements
 
-* `TauCeti.doubleCoset_rel_stabilizer_of_ne`: the permutations moving `x₀` form a single double
-  coset.
+* `TauCeti.doubleCoset_rel_stabilizer_of_ne_of_ne`: the permutations moving `x₀` form a single
+  double coset.
 * `TauCeti.doubleCosetMk_stabilizer_eq_one_iff`: a double coset of the stabilizer of `x₀` is the
   identity one exactly when its permutations fix `x₀`.
 * `TauCeti.card_doubleCosetQuotient_stabilizer`: a point stabilizer of a nontrivial `α` has
@@ -31,7 +31,7 @@ of `σ x₀` and `τ x₀` fixes `x₀` and carries the one onto the other.
 
 ## Implementation notes
 
-`TauCeti.doubleCoset_rel_stabilizer_of_ne` is stated on the relation `DoubleCoset.setoid` and
+`TauCeti.doubleCoset_rel_stabilizer_of_ne_of_ne` is stated on the relation `DoubleCoset.setoid` and
 transported to the quotient with `Quotient.sound'`, because `DoubleCoset.Quotient` is a plain
 definition that `rw` will not see through.
 
@@ -50,7 +50,8 @@ variable {α : Type*} (x₀ : α)
 
 /-- **The permutations moving `x₀` form a single double coset.**  If `σ` and `τ` both move `x₀`
 then the transposition of `σ x₀` and `τ x₀` fixes `x₀` and carries the one onto the other. -/
-theorem doubleCoset_rel_stabilizer_of_ne {σ τ : Equiv.Perm α} (hσ : σ x₀ ≠ x₀) (hτ : τ x₀ ≠ x₀) :
+theorem doubleCoset_rel_stabilizer_of_ne_of_ne {σ τ : Equiv.Perm α} (hσ : σ x₀ ≠ x₀)
+    (hτ : τ x₀ ≠ x₀) :
     DoubleCoset.setoid (↑(stabilizer (Equiv.Perm α) x₀)) (↑(stabilizer (Equiv.Perm α) x₀)) σ τ :=
     by
   classical
@@ -90,7 +91,7 @@ theorem card_doubleCosetQuotient_stabilizer [Nontrivial α] :
     fun h => hswap ((doubleCosetMk_stabilizer_eq_one_iff x₀).mp h), fun q hq => ?_⟩
   induction q using Quotient.inductionOn with
   | h σ =>
-    exact Quotient.sound' (doubleCoset_rel_stabilizer_of_ne x₀
+    exact Quotient.sound' (doubleCoset_rel_stabilizer_of_ne_of_ne x₀
       (fun h => hq ((doubleCosetMk_stabilizer_eq_one_iff x₀).mpr h)) hswap)
 
 end TauCeti

--- a/TauCeti/GroupTheory/GroupAction/Transitive.lean
+++ b/TauCeti/GroupTheory/GroupAction/Transitive.lean
@@ -10,10 +10,11 @@ public import Mathlib.GroupTheory.GroupAction.Quotient
 /-!
 # Orbit-stabiliser for a transitive action
 
-Mathlib's orbit-stabiliser theorem `MulAction.orbitEquivQuotientStabilizer` identifies the orbit
-of a point with the coset space of its stabiliser. When the action is transitive there is only
-one orbit, so that identification is between the coset space and the acted-on set itself. This
-file records that specialisation, together with the equivariance that makes it an isomorphism of
+Mathlib's `MulAction.ofQuotientStabilizer` sends the coset of `g` in `G ⧸ stabilizer G b` to
+`g • b`; it is injective by `MulAction.injective_ofQuotientStabilizer`, and its image is the orbit
+of `b`, which is the orbit-stabiliser theorem. When the action is transitive that orbit is all of
+`X`, so the map is a bijection. This file records that specialisation, together with the
+equivariance -- Mathlib's `MulAction.ofQuotientStabilizer_smul` -- that makes it an isomorphism of
 `G`-sets rather than a bare bijection.
 
 ## Main definitions
@@ -43,22 +44,22 @@ namespace TauCeti
 variable (G : Type*) {X : Type*} [Group G] [MulAction G X] [IsPretransitive G X]
 
 /-- **Orbit-stabiliser for a transitive action**: the coset space of the stabiliser of a point is
-the set acted on, the coset of `g` corresponding to `g • b`. -/
+the set acted on, the coset of `g` corresponding to `g • b`.  This is
+`MulAction.ofQuotientStabilizer`, which transitivity makes surjective. -/
 noncomputable def quotientStabilizerEquiv (b : X) : G ⧸ stabilizer G b ≃ X :=
-  (orbitEquivQuotientStabilizer G b).symm.trans
-    ((Equiv.setCongr (orbit_eq_univ G b)).trans (Equiv.Set.univ X))
+  Equiv.ofBijective (ofQuotientStabilizer G b)
+    ⟨injective_ofQuotientStabilizer G b, fun x => by
+      obtain ⟨g, hg⟩ := exists_smul_eq G b x
+      exact ⟨QuotientGroup.mk g, (ofQuotientStabilizer_mk G b g).trans hg⟩⟩
 
 @[simp]
 theorem quotientStabilizerEquiv_mk (b : X) (g : G) :
     quotientStabilizerEquiv G b (QuotientGroup.mk g) = g • b :=
-  (rfl)
+  ofQuotientStabilizer_mk G b g
 
 /-- The identification of the coset space with the set acted on is equivariant. -/
 theorem quotientStabilizerEquiv_smul (b : X) (g : G) (q : G ⧸ stabilizer G b) :
-    quotientStabilizerEquiv G b (g • q) = g • quotientStabilizerEquiv G b q := by
-  induction q using QuotientGroup.induction_on with
-  | H x =>
-    rw [Quotient.smul_mk, quotientStabilizerEquiv_mk, quotientStabilizerEquiv_mk, smul_eq_mul,
-      mul_smul]
+    quotientStabilizerEquiv G b (g • q) = g • quotientStabilizerEquiv G b q :=
+  ofQuotientStabilizer_smul G b g q
 
 end TauCeti

--- a/TauCeti/GroupTheory/GroupAction/Transitive.lean
+++ b/TauCeti/GroupTheory/GroupAction/Transitive.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.GroupAction.Quotient
+
+/-!
+# Orbit-stabiliser for a transitive action
+
+Mathlib's orbit-stabiliser theorem `MulAction.orbitEquivQuotientStabilizer` identifies the orbit
+of a point with the coset space of its stabiliser. When the action is transitive there is only
+one orbit, so that identification is between the coset space and the acted-on set itself. This
+file records that specialisation, together with the equivariance that makes it an isomorphism of
+`G`-sets rather than a bare bijection.
+
+## Main definitions
+
+* `TauCeti.quotientStabilizerEquiv`: for a transitive action of `G` on `X` and a point `b : X`,
+  the equivalence `G ⧸ stabilizer G b ≃ X` sending the coset of `g` to `g • b`.
+
+## Main results
+
+* `TauCeti.quotientStabilizerEquiv_mk`: its value on a coset, and
+  `TauCeti.quotientStabilizerEquiv_smul`: its equivariance.
+
+## Implementation notes
+
+The equivalence is unbundled -- an `Equiv` of types together with a separate equivariance lemma --
+because that is the shape the constructions consuming it take their argument in, for instance
+`TauCeti.ofMulActionEquivCongr`, which builds the induced equivalence of permutation
+representations.
+-/
+
+public section
+
+open MulAction
+
+namespace TauCeti
+
+variable (G : Type*) {X : Type*} [Group G] [MulAction G X] [IsPretransitive G X]
+
+/-- **Orbit-stabiliser for a transitive action**: the coset space of the stabiliser of a point is
+the set acted on, the coset of `g` corresponding to `g • b`. -/
+noncomputable def quotientStabilizerEquiv (b : X) : G ⧸ stabilizer G b ≃ X :=
+  (orbitEquivQuotientStabilizer G b).symm.trans
+    ((Equiv.setCongr (orbit_eq_univ G b)).trans (Equiv.Set.univ X))
+
+@[simp]
+theorem quotientStabilizerEquiv_mk (b : X) (g : G) :
+    quotientStabilizerEquiv G b (QuotientGroup.mk g) = g • b :=
+  (rfl)
+
+/-- The identification of the coset space with the set acted on is equivariant. -/
+theorem quotientStabilizerEquiv_smul (b : X) (g : G) (q : G ⧸ stabilizer G b) :
+    quotientStabilizerEquiv G b (g • q) = g • quotientStabilizerEquiv G b q := by
+  induction q using QuotientGroup.induction_on with
+  | H x =>
+    rw [Quotient.smul_mk, quotientStabilizerEquiv_mk, quotientStabilizerEquiv_mk, smul_eq_mul,
+      mul_smul]
+
+end TauCeti

--- a/TauCeti/GroupTheory/GroupAction/Transitive.lean
+++ b/TauCeti/GroupTheory/GroupAction/Transitive.lean
@@ -52,12 +52,15 @@ noncomputable def quotientStabilizerEquiv (b : X) : G ⧸ stabilizer G b ≃ X :
       obtain ⟨g, hg⟩ := exists_smul_eq G b x
       exact ⟨QuotientGroup.mk g, (ofQuotientStabilizer_mk G b g).trans hg⟩⟩
 
+/-- The computation rule for `TauCeti.quotientStabilizerEquiv`: on the coset represented by `g` it
+takes the value `g • b`. -/
 @[simp]
 theorem quotientStabilizerEquiv_mk (b : X) (g : G) :
     quotientStabilizerEquiv G b (QuotientGroup.mk g) = g • b :=
   ofQuotientStabilizer_mk G b g
 
 /-- The identification of the coset space with the set acted on is equivariant. -/
+@[simp]
 theorem quotientStabilizerEquiv_smul (b : X) (g : G) (q : G ⧸ stabilizer G b) :
     quotientStabilizerEquiv G b (g • q) = g • quotientStabilizerEquiv G b q :=
   ofQuotientStabilizer_smul G b g q

--- a/TauCeti/RepresentationTheory/Induction/PointStabilizer.lean
+++ b/TauCeti/RepresentationTheory/Induction/PointStabilizer.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.GroupTheory.DoubleCoset.PointStabilizer
 public import TauCeti.GroupTheory.GroupAction.Transitive
 public import TauCeti.RepresentationTheory.Induction.DoubleCosetPairing
 public import TauCeti.RepresentationTheory.Rep.OfMulAction
@@ -21,47 +22,51 @@ computes the invariant the permutation representation is pinned down by: the dou
 stabilizer, of which there are exactly two, and hence the self-pairing of the induced character.
 
 The two double cosets are the source of everything else.  A permutation either fixes `x₀` or does
-not, and each of the two possibilities is a single double coset: a permutation moving `x₀` to `y`
-and one moving it to `y'` differ by the transposition of `y` and `y'`, which fixes `x₀`.  So
-`⟨Ind 1, Ind 1⟩ = 2`, and the permutation representation has exactly two constituents, each with
-multiplicity one: the trivial representation on the invariant line, and the standard
-representation of `TauCeti.RepresentationTheory.Symmetric.Standard`, whose irreducibility is
-proved there.
+not, and each of the two possibilities is a single double coset, by
+`TauCeti.card_doubleCosetQuotient_stabilizer`.  So `⟨Ind 1, Ind 1⟩ = 2` whenever `|Equiv.Perm α|`
+is invertible in `k`, and the permutation representation then has exactly two constituents, each
+with multiplicity one.  When moreover `(|α| : k) ≠ 0` those two constituents are named: the
+trivial representation on the invariant line, split off by
+`TauCeti.isCompl_invariantLine_augmentationSubrepresentation`, and the standard representation of
+`TauCeti.RepresentationTheory.Symmetric.Standard`, which is irreducible under that same
+hypothesis.  In the excluded characteristics the character identity
+`TauCeti.char_ind_trivial_stabilizer_eq_one_add_char_standardRepresentation` still holds, but the
+invariant line lies inside the standard representation instead of complementing it, so there is no
+such splitting.
 
 ## Main definitions
 
 * `TauCeti.indTrivialStabilizerEquiv` and `TauCeti.indTrivialStabilizerIso`: inducing the trivial
   representation of the stabilizer of `x₀` gives the permutation representation on `α`, as an
-  equivalence of representations and as an isomorphism in `Rep k (Equiv.Perm α)`.
+  equivalence of representations and as an isomorphism in `Rep k (Equiv.Perm α)`.  Both are read
+  on generators by `TauCeti.indTrivialStabilizerEquiv_apply_mk` and
+  `TauCeti.indTrivialStabilizerIso_hom_hom_mk`.
 
 ## Main statements
 
-* `TauCeti.card_doubleCosetQuotient_stabilizer`: the stabilizer of a point of a nontrivial `α` has
-  exactly two double cosets in `Equiv.Perm α`.
 * `TauCeti.char_ind_trivial_stabilizer`: the character of the induced trivial representation at `σ`
   is the number of points fixed by `σ`, and `TauCeti.finrank_ind_trivial_stabilizer` says the
   representation has dimension `|α|`.
-* `TauCeti.characterPairing_ind_trivial_stabilizer`: its self-pairing is `2`, the number of double
-  cosets.
+* `TauCeti.characterPairing_ind_trivial_stabilizer`: for `|Equiv.Perm α|` invertible in `k`, its
+  self-pairing is `2`, the number of double cosets.
 * `TauCeti.char_ind_trivial_stabilizer_eq_one_add_char_standardRepresentation`: the induced
-  character is the trivial character plus the character of the standard representation.
+  character is the trivial character plus the character of the standard representation.  This is
+  an identity of characters and holds in every characteristic; it is a decomposition of
+  representations only under the hypotheses of
+  `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`.
 * `TauCeti.card_doubleCosetQuotient_stabilizer_fin_four`,
   `TauCeti.finrank_ind_trivial_stabilizer_fin_four`,
   `TauCeti.finrank_augmentationSubrepresentation_fin_four` and
   `TauCeti.isIrreducible_standardRepresentation_fin_four`: the `S₄` instance -- two double cosets,
-  a `4`-dimensional induced representation, and a `3`-dimensional irreducible complement.
+  a `4`-dimensional induced representation, and a `3`-dimensional complement, irreducible when
+  `4 ≠ 0` in `k`.
 
 ## Implementation notes
 
-The double-coset statements are proved on the relation `DoubleCoset.setoid` first and transported
-to the quotient with `Quotient.sound'` and `Quotient.exact'`, because `DoubleCoset.Quotient` is a
-plain definition that `rw` will not see through. They are proved by hand rather than through
-`TauCeti.doubleCosetEquivOrbitQuotient`, which reads the same two classes as the two orbits of
-`Equiv.Perm α` on ordered pairs of points: the transposition exhibiting the second class is
-shorter than the transport.
-
-The identification of the coset space with `α` is
-`TauCeti.quotientStabilizerEquiv`, in `TauCeti.GroupTheory.GroupAction.Transitive`.
+The two double cosets of the point stabilizer are counted in
+`TauCeti.GroupTheory.DoubleCoset.PointStabilizer`, which is pure group theory, and the
+identification of the coset space with `α` is `TauCeti.quotientStabilizerEquiv`, in
+`TauCeti.GroupTheory.GroupAction.Transitive`.
 
 The coefficient field and the acted-on set share a universe in the `Rep`-level isomorphism, since
 that compares two objects of one category; the `Representation`-level statements, which is where
@@ -89,84 +94,11 @@ open ClassFunction
 
 universe u v
 
-/-! ### The double cosets of a point stabilizer
-
-A permutation either fixes `x₀` or does not, and each of the two possibilities is a single double
-coset of the stabilizer. -/
-
-section DoubleCosets
-
-variable {α : Type v} (x₀ : α)
-
-/-- A permutation is related to the identity by the double-coset relation of the stabilizer of `x₀`
-exactly when it fixes `x₀`. -/
-theorem doubleCoset_rel_stabilizer_one_iff {σ : Equiv.Perm α} :
-    DoubleCoset.setoid (↑(stabilizer (Equiv.Perm α) x₀)) (↑(stabilizer (Equiv.Perm α) x₀)) σ 1 ↔
-      σ x₀ = x₀ := by
-  rw [DoubleCoset.rel_iff]
-  constructor
-  · rintro ⟨a, ha, b, hb, hab⟩
-    have hax₀ : a x₀ = x₀ := mem_stabilizer_iff.mp ha
-    have hbx₀ : b x₀ = x₀ := mem_stabilizer_iff.mp hb
-    have happ := Equiv.Perm.ext_iff.mp hab.symm x₀
-    rw [Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, hbx₀, Equiv.Perm.one_apply] at happ
-    exact a.injective (happ.trans hax₀.symm)
-  · intro hσ
-    exact ⟨σ⁻¹, (stabilizer (Equiv.Perm α) x₀).inv_mem (mem_stabilizer_iff.mpr hσ), 1,
-      (stabilizer (Equiv.Perm α) x₀).one_mem, by group⟩
-
-/-- **The permutations moving `x₀` form a single double coset.**  If `σ` and `τ` both move `x₀`
-then the transposition of `σ x₀` and `τ x₀` fixes `x₀` and carries the one onto the other. -/
-theorem doubleCoset_rel_stabilizer_of_ne {σ τ : Equiv.Perm α} (hσ : σ x₀ ≠ x₀) (hτ : τ x₀ ≠ x₀) :
-    DoubleCoset.setoid (↑(stabilizer (Equiv.Perm α) x₀)) (↑(stabilizer (Equiv.Perm α) x₀)) σ τ :=
-    by
-  classical
-  have hax₀ : Equiv.swap (σ x₀) (τ x₀) x₀ = x₀ :=
-    Equiv.swap_apply_of_ne_of_ne (Ne.symm hσ) (Ne.symm hτ)
-  have hinv : (Equiv.swap (σ x₀) (τ x₀))⁻¹ (τ x₀) = σ x₀ := by
-    rw [Equiv.swap_inv]
-    exact Equiv.swap_apply_right _ _
-  rw [DoubleCoset.rel_iff]
-  refine ⟨Equiv.swap (σ x₀) (τ x₀), mem_stabilizer_iff.mpr hax₀,
-    σ⁻¹ * (Equiv.swap (σ x₀) (τ x₀))⁻¹ * τ, mem_stabilizer_iff.mpr ?_, by group⟩
-  rw [Equiv.Perm.smul_def, Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, hinv,
-    Equiv.Perm.inv_def, Equiv.symm_apply_apply]
-
-/-- A double coset of the stabilizer of `x₀` is the identity one exactly when its permutations fix
-`x₀`. -/
-theorem doubleCoset_mk_stabilizer_eq_one_iff {σ : Equiv.Perm α} :
-    DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) σ =
-        DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) 1 ↔
-      σ x₀ = x₀ :=
-  ⟨fun h => (doubleCoset_rel_stabilizer_one_iff x₀).mp (Quotient.exact' h),
-    fun h => Quotient.sound' ((doubleCoset_rel_stabilizer_one_iff x₀).mpr h)⟩
-
-/-- **A point stabilizer has exactly two double cosets.**  The identity double coset is the
-stabilizer itself, and every permutation moving `x₀` lies in the other one; a nontrivial `α`
-supplies such a permutation. -/
-theorem card_doubleCosetQuotient_stabilizer [Nontrivial α] :
-    Nat.card (DoubleCoset.Quotient (↑(stabilizer (Equiv.Perm α) x₀))
-      (↑(stabilizer (Equiv.Perm α) x₀) : Set (Equiv.Perm α))) = 2 := by
-  classical
-  obtain ⟨y, hy⟩ := exists_ne x₀
-  have hswap : Equiv.swap x₀ y x₀ ≠ x₀ := by
-    rw [Equiv.swap_apply_left]
-    exact hy
-  rw [Nat.card_eq_two_iff' (DoubleCoset.mk _ _ 1)]
-  refine ⟨DoubleCoset.mk _ _ (Equiv.swap x₀ y),
-    fun h => hswap ((doubleCoset_mk_stabilizer_eq_one_iff x₀).mp h), fun q hq => ?_⟩
-  induction q using Quotient.inductionOn with
-  | h σ =>
-    exact Quotient.sound' (doubleCoset_rel_stabilizer_of_ne x₀
-      (fun h => hq ((doubleCoset_mk_stabilizer_eq_one_iff x₀).mpr h)) hswap)
-
-end DoubleCosets
-
 /-! ### The induced representation is the permutation representation on the points -/
 
-section Induced
+section Equivalence
 
-variable (k : Type u) [Field k] {α : Type v} (x₀ : α)
+variable (k : Type u) [CommRing k] {α : Type v} (x₀ : α)
 
 /-- **Inducing the trivial representation of a point stabilizer.**  Because `Equiv.Perm α` acts
 transitively on `α`, inducing the trivial representation of the stabilizer of `x₀` gives the
@@ -179,13 +111,31 @@ noncomputable def indTrivialStabilizerEquiv :
     (ofMulActionEquivCongr k (quotientStabilizerEquiv (Equiv.Perm α) x₀)
       (quotientStabilizerEquiv_smul (Equiv.Perm α) x₀))
 
+/-- The generator computation rule for `TauCeti.indTrivialStabilizerEquiv`: the generator carried
+by `σ` goes to the basis vector of the point `σ⁻¹ x₀`.  Not a `simp` lemma, for the reason
+`TauCeti.indTrivialEquiv_apply_mk` is not: `simp` unfolds the reducible
+`Representation.IndV.mk`. -/
+theorem indTrivialStabilizerEquiv_apply_mk (σ : Equiv.Perm α) (a : k) :
+    indTrivialStabilizerEquiv k x₀
+        (Representation.IndV.mk (stabilizer (Equiv.Perm α) x₀).subtype
+          (Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k) σ a) =
+      MonoidAlgebra.single (σ⁻¹ x₀) a := by
+  rw [indTrivialStabilizerEquiv, Representation.Equiv.trans_apply, indTrivialEquiv_apply_mk,
+    ofMulActionEquivCongr_apply_single, quotientStabilizerEquiv_mk, Equiv.Perm.smul_def]
+
+end Equivalence
+
+section Induced
+
+variable (k : Type u) [Field k] {α : Type v} (x₀ : α)
+
 /-- **The permutation character.**  The character at `σ` of the trivial representation of the
 stabilizer of `x₀` induced up to `Equiv.Perm α` is the number of points of `α` fixed by `σ`. -/
 theorem char_ind_trivial_stabilizer [Finite α] (σ : Equiv.Perm α) :
     ((Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k).ind
         (stabilizer (Equiv.Perm α) x₀).subtype).character σ = Nat.card {x : α // σ x = x} := by
   rw [Representation.char_iso (indTrivialStabilizerEquiv k x₀), char_ofMulAction]
-  rfl
+  simp only [Equiv.Perm.smul_def]
 
 /-- The induced representation has dimension the number of points. -/
 theorem finrank_ind_trivial_stabilizer [Fintype α] :
@@ -209,11 +159,14 @@ theorem characterPairing_ind_trivial_stabilizer [Fintype α] [DecidableEq α] [N
     card_doubleCosetQuotient_stabilizer x₀]
   norm_num
 
-/-- **The permutation representation is the trivial one plus the standard one**, read on
-characters.  Together with `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`, which
-splits the invariant line off the permutation representation, and
-`TauCeti.isIrreducible_standardRepresentation`, which says the remaining constituent is
-irreducible, this is the decomposition `Ind_H^G 1 ≅ trivial ⊕ standard`. -/
+/-- **The permutation character is the trivial character plus the standard one.**  This is an
+identity of characters, and it needs no hypothesis on the characteristic of `k`.  It becomes the
+decomposition `Ind_H^G 1 ≅ trivial ⊕ standard` when `(Fintype.card α : k) ≠ 0`: that is the
+hypothesis under which `TauCeti.isCompl_invariantLine_augmentationSubrepresentation` splits the
+invariant line off the permutation representation and
+`TauCeti.isIrreducible_standardRepresentation` makes the remaining constituent irreducible.  When
+`(Fintype.card α : k) = 0` and `3 ≤ |α|` the invariant line instead lies inside the standard
+representation, and there is no such splitting. -/
 theorem char_ind_trivial_stabilizer_eq_one_add_char_standardRepresentation [Finite α]
     [Nonempty α] (σ : Equiv.Perm α) :
     ((Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k).ind
@@ -239,9 +192,17 @@ noncomputable def indTrivialStabilizerIso :
     Rep.ind (stabilizer (Equiv.Perm α) x₀).subtype
         (Rep.trivial k (stabilizer (Equiv.Perm α) x₀) k) ≅
       Rep.ofMulAction k (Equiv.Perm α) α :=
-  indTrivialIso k (stabilizer (Equiv.Perm α) x₀) ≪≫
-    ofMulActionIsoCongr k (quotientStabilizerEquiv (Equiv.Perm α) x₀)
-      (quotientStabilizerEquiv_smul (Equiv.Perm α) x₀)
+  Rep.mkIso (indTrivialStabilizerEquiv k x₀)
+
+/-- The generator computation rule for `TauCeti.indTrivialStabilizerIso`: it is
+`TauCeti.indTrivialStabilizerEquiv_apply_mk` read in `Rep k (Equiv.Perm α)`. -/
+theorem indTrivialStabilizerIso_hom_hom_mk (σ : Equiv.Perm α) (a : k) :
+    (indTrivialStabilizerIso k x₀).hom.hom
+        (Representation.IndV.mk (stabilizer (Equiv.Perm α) x₀).subtype
+          (Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k) σ a) =
+      MonoidAlgebra.single (σ⁻¹ x₀) a := by
+  rw [indTrivialStabilizerIso, Rep.mkIso_hom_hom_apply]
+  exact indTrivialStabilizerEquiv_apply_mk k x₀ σ a
 
 end RepIso
 
@@ -249,7 +210,8 @@ end RepIso
 
 `G = S₄` with `H` the stabilizer of a point is the worked example: the induced trivial
 representation is the natural permutation representation on four points, there are two double
-cosets, and the representation splits as the trivial one plus a three-dimensional irreducible. -/
+cosets, and over a field in which `4 ≠ 0` the representation splits as the trivial one plus a
+three-dimensional irreducible. -/
 
 section SymmetricFour
 

--- a/TauCeti/RepresentationTheory/Induction/PointStabilizer.lean
+++ b/TauCeti/RepresentationTheory/Induction/PointStabilizer.lean
@@ -1,0 +1,286 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.GroupTheory.GroupAction.Transitive
+public import TauCeti.RepresentationTheory.Induction.DoubleCosetPairing
+public import TauCeti.RepresentationTheory.Rep.OfMulAction
+public import TauCeti.RepresentationTheory.Symmetric.Standard
+
+/-!
+# Inducing the trivial representation from a point stabilizer
+
+Let `α` be a finite set and let `x₀ : α`.  The symmetric group `Equiv.Perm α` acts transitively on
+`α`, so the coset space of the stabilizer of `x₀` is `α` itself, and inducing the trivial
+representation of that stabilizer produces the permutation representation of `Equiv.Perm α` on
+`α`.  This file makes that identification, reads off its character as the fixed-point count, and
+computes the invariant the permutation representation is pinned down by: the double cosets of the
+stabilizer, of which there are exactly two, and hence the self-pairing of the induced character.
+
+The two double cosets are the source of everything else.  A permutation either fixes `x₀` or does
+not, and each of the two possibilities is a single double coset: a permutation moving `x₀` to `y`
+and one moving it to `y'` differ by the transposition of `y` and `y'`, which fixes `x₀`.  So
+`⟨Ind 1, Ind 1⟩ = 2`, and the permutation representation has exactly two constituents, each with
+multiplicity one: the trivial representation on the invariant line, and the standard
+representation of `TauCeti.RepresentationTheory.Symmetric.Standard`, whose irreducibility is
+proved there.
+
+## Main definitions
+
+* `TauCeti.indTrivialStabilizerEquiv` and `TauCeti.indTrivialStabilizerIso`: inducing the trivial
+  representation of the stabilizer of `x₀` gives the permutation representation on `α`, as an
+  equivalence of representations and as an isomorphism in `Rep k (Equiv.Perm α)`.
+
+## Main statements
+
+* `TauCeti.card_doubleCosetQuotient_stabilizer`: the stabilizer of a point of a nontrivial `α` has
+  exactly two double cosets in `Equiv.Perm α`.
+* `TauCeti.char_ind_trivial_stabilizer`: the character of the induced trivial representation at `σ`
+  is the number of points fixed by `σ`, and `TauCeti.finrank_ind_trivial_stabilizer` says the
+  representation has dimension `|α|`.
+* `TauCeti.characterPairing_ind_trivial_stabilizer`: its self-pairing is `2`, the number of double
+  cosets.
+* `TauCeti.char_ind_trivial_stabilizer_eq_one_add_char_standardRepresentation`: the induced
+  character is the trivial character plus the character of the standard representation.
+* `TauCeti.card_doubleCosetQuotient_stabilizer_fin_four`,
+  `TauCeti.finrank_ind_trivial_stabilizer_fin_four`,
+  `TauCeti.finrank_augmentationSubrepresentation_fin_four` and
+  `TauCeti.isIrreducible_standardRepresentation_fin_four`: the `S₄` instance -- two double cosets,
+  a `4`-dimensional induced representation, and a `3`-dimensional irreducible complement.
+
+## Implementation notes
+
+The double-coset statements are proved on the relation `DoubleCoset.setoid` first and transported
+to the quotient with `Quotient.sound'` and `Quotient.exact'`, because `DoubleCoset.Quotient` is a
+plain definition that `rw` will not see through. They are proved by hand rather than through
+`TauCeti.doubleCosetEquivOrbitQuotient`, which reads the same two classes as the two orbits of
+`Equiv.Perm α` on ordered pairs of points: the transposition exhibiting the second class is
+shorter than the transport.
+
+The identification of the coset space with `α` is
+`TauCeti.quotientStabilizerEquiv`, in `TauCeti.GroupTheory.GroupAction.Transitive`.
+
+The coefficient field and the acted-on set share a universe in the `Rep`-level isomorphism, since
+that compares two objects of one category; the `Representation`-level statements, which is where
+the characters are computed, carry no such constraint.
+
+## References
+
+This is the "Permutation characters and fixed points" worked example of
+`TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`: "For `G = S₄` and `H` a point
+stabilizer `S₃`, `Ind_H^G(trivial)` is the natural permutation representation on `4` points; its
+character at `g` is the number of fixed points of `g`, and `⟨Ind_H^G 1, Ind_H^G 1⟩ = #(H \ G / H) =
+2`, the two double cosets being the diagonal and off-diagonal `H`-orbits on the four points, so it
+splits as `trivial ⊕ (standard 3-dimensional)`."
+
+* J.-P. Serre, *Linear Representations of Finite Groups*, §2.3 and §7.3.
+-/
+
+public section
+
+open MulAction
+
+namespace TauCeti
+
+open ClassFunction
+
+universe u v
+
+/-! ### The double cosets of a point stabilizer
+
+A permutation either fixes `x₀` or does not, and each of the two possibilities is a single double
+coset of the stabilizer. -/
+
+section DoubleCosets
+
+variable {α : Type v} (x₀ : α)
+
+/-- A permutation is related to the identity by the double-coset relation of the stabilizer of `x₀`
+exactly when it fixes `x₀`. -/
+theorem doubleCoset_rel_stabilizer_one_iff {σ : Equiv.Perm α} :
+    DoubleCoset.setoid (↑(stabilizer (Equiv.Perm α) x₀)) (↑(stabilizer (Equiv.Perm α) x₀)) σ 1 ↔
+      σ x₀ = x₀ := by
+  rw [DoubleCoset.rel_iff]
+  constructor
+  · rintro ⟨a, ha, b, hb, hab⟩
+    have hax₀ : a x₀ = x₀ := mem_stabilizer_iff.mp ha
+    have hbx₀ : b x₀ = x₀ := mem_stabilizer_iff.mp hb
+    have happ := Equiv.Perm.ext_iff.mp hab.symm x₀
+    rw [Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, hbx₀, Equiv.Perm.one_apply] at happ
+    exact a.injective (happ.trans hax₀.symm)
+  · intro hσ
+    exact ⟨σ⁻¹, (stabilizer (Equiv.Perm α) x₀).inv_mem (mem_stabilizer_iff.mpr hσ), 1,
+      (stabilizer (Equiv.Perm α) x₀).one_mem, by group⟩
+
+/-- **The permutations moving `x₀` form a single double coset.**  If `σ` and `τ` both move `x₀`
+then the transposition of `σ x₀` and `τ x₀` fixes `x₀` and carries the one onto the other. -/
+theorem doubleCoset_rel_stabilizer_of_ne {σ τ : Equiv.Perm α} (hσ : σ x₀ ≠ x₀) (hτ : τ x₀ ≠ x₀) :
+    DoubleCoset.setoid (↑(stabilizer (Equiv.Perm α) x₀)) (↑(stabilizer (Equiv.Perm α) x₀)) σ τ :=
+    by
+  classical
+  have hax₀ : Equiv.swap (σ x₀) (τ x₀) x₀ = x₀ :=
+    Equiv.swap_apply_of_ne_of_ne (Ne.symm hσ) (Ne.symm hτ)
+  have hinv : (Equiv.swap (σ x₀) (τ x₀))⁻¹ (τ x₀) = σ x₀ := by
+    rw [Equiv.swap_inv]
+    exact Equiv.swap_apply_right _ _
+  rw [DoubleCoset.rel_iff]
+  refine ⟨Equiv.swap (σ x₀) (τ x₀), mem_stabilizer_iff.mpr hax₀,
+    σ⁻¹ * (Equiv.swap (σ x₀) (τ x₀))⁻¹ * τ, mem_stabilizer_iff.mpr ?_, by group⟩
+  rw [Equiv.Perm.smul_def, Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, hinv,
+    Equiv.Perm.inv_def, Equiv.symm_apply_apply]
+
+/-- A double coset of the stabilizer of `x₀` is the identity one exactly when its permutations fix
+`x₀`. -/
+theorem doubleCoset_mk_stabilizer_eq_one_iff {σ : Equiv.Perm α} :
+    DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) σ =
+        DoubleCoset.mk (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) 1 ↔
+      σ x₀ = x₀ :=
+  ⟨fun h => (doubleCoset_rel_stabilizer_one_iff x₀).mp (Quotient.exact' h),
+    fun h => Quotient.sound' ((doubleCoset_rel_stabilizer_one_iff x₀).mpr h)⟩
+
+/-- **A point stabilizer has exactly two double cosets.**  The identity double coset is the
+stabilizer itself, and every permutation moving `x₀` lies in the other one; a nontrivial `α`
+supplies such a permutation. -/
+theorem card_doubleCosetQuotient_stabilizer [Nontrivial α] :
+    Nat.card (DoubleCoset.Quotient (↑(stabilizer (Equiv.Perm α) x₀))
+      (↑(stabilizer (Equiv.Perm α) x₀) : Set (Equiv.Perm α))) = 2 := by
+  classical
+  obtain ⟨y, hy⟩ := exists_ne x₀
+  have hswap : Equiv.swap x₀ y x₀ ≠ x₀ := by
+    rw [Equiv.swap_apply_left]
+    exact hy
+  rw [Nat.card_eq_two_iff' (DoubleCoset.mk _ _ 1)]
+  refine ⟨DoubleCoset.mk _ _ (Equiv.swap x₀ y),
+    fun h => hswap ((doubleCoset_mk_stabilizer_eq_one_iff x₀).mp h), fun q hq => ?_⟩
+  induction q using Quotient.inductionOn with
+  | h σ =>
+    exact Quotient.sound' (doubleCoset_rel_stabilizer_of_ne x₀
+      (fun h => hq ((doubleCoset_mk_stabilizer_eq_one_iff x₀).mpr h)) hswap)
+
+end DoubleCosets
+
+/-! ### The induced representation is the permutation representation on the points -/
+
+section Induced
+
+variable (k : Type u) [Field k] {α : Type v} (x₀ : α)
+
+/-- **Inducing the trivial representation of a point stabilizer.**  Because `Equiv.Perm α` acts
+transitively on `α`, inducing the trivial representation of the stabilizer of `x₀` gives the
+permutation representation of `Equiv.Perm α` on `α` itself. -/
+noncomputable def indTrivialStabilizerEquiv :
+    ((Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k).ind
+        (stabilizer (Equiv.Perm α) x₀).subtype).Equiv
+      (Representation.ofMulAction k (Equiv.Perm α) α) :=
+  (indTrivialEquiv k (stabilizer (Equiv.Perm α) x₀)).trans
+    (ofMulActionEquivCongr k (quotientStabilizerEquiv (Equiv.Perm α) x₀)
+      (quotientStabilizerEquiv_smul (Equiv.Perm α) x₀))
+
+/-- **The permutation character.**  The character at `σ` of the trivial representation of the
+stabilizer of `x₀` induced up to `Equiv.Perm α` is the number of points of `α` fixed by `σ`. -/
+theorem char_ind_trivial_stabilizer [Finite α] (σ : Equiv.Perm α) :
+    ((Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k).ind
+        (stabilizer (Equiv.Perm α) x₀).subtype).character σ = Nat.card {x : α // σ x = x} := by
+  rw [Representation.char_iso (indTrivialStabilizerEquiv k x₀), char_ofMulAction]
+  rfl
+
+/-- The induced representation has dimension the number of points. -/
+theorem finrank_ind_trivial_stabilizer [Fintype α] :
+    Module.finrank k (Representation.IndV (stabilizer (Equiv.Perm α) x₀).subtype
+        (Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k)) = Fintype.card α := by
+  rw [(indTrivialStabilizerEquiv k x₀).toLinearEquiv.finrank_eq,
+    Module.finrank_eq_card_basis (MonoidAlgebra.basis α k)]
+
+/-- **The self-pairing of the permutation character is `2`**, the number of double cosets of the
+point stabilizer.  So the permutation representation has exactly two irreducible constituents, each
+occurring once. -/
+theorem characterPairing_ind_trivial_stabilizer [Fintype α] [DecidableEq α] [Nontrivial α]
+    (hG : IsUnit (Nat.card (Equiv.Perm α) : k)) :
+    characterPairing
+        (ofCharacter ((Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k).ind
+          (stabilizer (Equiv.Perm α) x₀).subtype))
+        (ofCharacter ((Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k).ind
+          (stabilizer (Equiv.Perm α) x₀).subtype)) = 2 := by
+  rw [characterPairing_ind_trivial_eq_card_doubleCosetQuotient k
+    (stabilizer (Equiv.Perm α) x₀) (stabilizer (Equiv.Perm α) x₀) hG,
+    card_doubleCosetQuotient_stabilizer x₀]
+  norm_num
+
+/-- **The permutation representation is the trivial one plus the standard one**, read on
+characters.  Together with `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`, which
+splits the invariant line off the permutation representation, and
+`TauCeti.isIrreducible_standardRepresentation`, which says the remaining constituent is
+irreducible, this is the decomposition `Ind_H^G 1 ≅ trivial ⊕ standard`. -/
+theorem char_ind_trivial_stabilizer_eq_one_add_char_standardRepresentation [Finite α]
+    [Nonempty α] (σ : Equiv.Perm α) :
+    ((Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k).ind
+        (stabilizer (Equiv.Perm α) x₀).subtype).character σ =
+      1 + (standardRepresentation k α).character σ := by
+  rw [char_standardRepresentation σ, char_ofMulAction, char_ind_trivial_stabilizer k x₀]
+  simp only [Equiv.Perm.smul_def]
+  ring
+
+end Induced
+
+/-! ### The `Rep`-level form
+
+Objects of `Rep k G` live over one universe, so the isomorphism form of the identification
+constrains the coefficient ring and the acted-on set to share a universe. -/
+
+section RepIso
+
+variable (k : Type u) [CommRing k] {α : Type u} (x₀ : α)
+
+/-- **Inducing the trivial representation of a point stabilizer**, in `Rep k (Equiv.Perm α)`. -/
+noncomputable def indTrivialStabilizerIso :
+    Rep.ind (stabilizer (Equiv.Perm α) x₀).subtype
+        (Rep.trivial k (stabilizer (Equiv.Perm α) x₀) k) ≅
+      Rep.ofMulAction k (Equiv.Perm α) α :=
+  indTrivialIso k (stabilizer (Equiv.Perm α) x₀) ≪≫
+    ofMulActionIsoCongr k (quotientStabilizerEquiv (Equiv.Perm α) x₀)
+      (quotientStabilizerEquiv_smul (Equiv.Perm α) x₀)
+
+end RepIso
+
+/-! ### The `S₄` instance
+
+`G = S₄` with `H` the stabilizer of a point is the worked example: the induced trivial
+representation is the natural permutation representation on four points, there are two double
+cosets, and the representation splits as the trivial one plus a three-dimensional irreducible. -/
+
+section SymmetricFour
+
+variable (k : Type u) [Field k] (x₀ : Fin 4)
+
+/-- The stabilizer of a point of `Fin 4` has two double cosets in `S₄`: the two orbits of `S₄` on
+ordered pairs of points, the diagonal and the off-diagonal one. -/
+theorem card_doubleCosetQuotient_stabilizer_fin_four :
+    Nat.card (DoubleCoset.Quotient (↑(stabilizer (Equiv.Perm (Fin 4)) x₀))
+      (↑(stabilizer (Equiv.Perm (Fin 4)) x₀) : Set (Equiv.Perm (Fin 4)))) = 2 :=
+  card_doubleCosetQuotient_stabilizer x₀
+
+/-- `Ind_{S₃}^{S₄} 1` is four-dimensional: it is the permutation representation on four points. -/
+theorem finrank_ind_trivial_stabilizer_fin_four :
+    Module.finrank k (Representation.IndV (stabilizer (Equiv.Perm (Fin 4)) x₀).subtype
+        (Representation.trivial k (stabilizer (Equiv.Perm (Fin 4)) x₀) k)) = 4 := by
+  rw [finrank_ind_trivial_stabilizer k x₀]
+  simp
+
+/-- The complementary constituent of `Ind_{S₃}^{S₄} 1` is three-dimensional. -/
+theorem finrank_augmentationSubrepresentation_fin_four :
+    Module.finrank k
+        (augmentationSubrepresentation k (Equiv.Perm (Fin 4)) (Fin 4)).toSubmodule = 3 := by
+  simp
+
+/-- The standard representation of `S₄` is irreducible over a field in which `4` is nonzero, so
+`Ind_{S₃}^{S₄} 1` really is the trivial representation plus a three-dimensional irreducible. -/
+theorem isIrreducible_standardRepresentation_fin_four (h : (4 : k) ≠ 0) :
+    (standardRepresentation k (Fin 4)).IsIrreducible :=
+  isIrreducible_standardRepresentation (by simp) (Or.inr (by simpa using h))
+
+end SymmetricFour
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/PointStabilizer.lean
+++ b/TauCeti/RepresentationTheory/Induction/PointStabilizer.lean
@@ -130,7 +130,11 @@ section Induced
 variable (k : Type u) [Field k] {α : Type v} (x₀ : α)
 
 /-- **The permutation character.**  The character at `σ` of the trivial representation of the
-stabilizer of `x₀` induced up to `Equiv.Perm α` is the number of points of `α` fixed by `σ`. -/
+stabilizer of `x₀` induced up to `Equiv.Perm α` is the number of points of `α` fixed by `σ`.
+
+Not a `simp` lemma: the general `TauCeti.char_ind_trivial` is one, and it already rewrites this
+left-hand side -- to the number of fixed *cosets* -- so tagging this specialisation fails the
+`simpNF` linter. -/
 theorem char_ind_trivial_stabilizer [Finite α] (σ : Equiv.Perm α) :
     ((Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k).ind
         (stabilizer (Equiv.Perm α) x₀).subtype).character σ = Nat.card {x : α // σ x = x} := by
@@ -168,10 +172,11 @@ invariant line off the permutation representation and
 `(Fintype.card α : k) = 0` and `3 ≤ |α|` the invariant line instead lies inside the standard
 representation, and there is no such splitting. -/
 theorem char_ind_trivial_stabilizer_eq_one_add_char_standardRepresentation [Finite α]
-    [Nonempty α] (σ : Equiv.Perm α) :
+    (σ : Equiv.Perm α) :
     ((Representation.trivial k (stabilizer (Equiv.Perm α) x₀) k).ind
         (stabilizer (Equiv.Perm α) x₀).subtype).character σ =
       1 + (standardRepresentation k α).character σ := by
+  have : Nonempty α := ⟨x₀⟩
   rw [char_standardRepresentation σ, char_ofMulAction, char_ind_trivial_stabilizer k x₀]
   simp only [Equiv.Perm.smul_def]
   ring

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -47,6 +47,8 @@ produces all the others, and those differences span.
 * `TauCeti.isAtom_augmentationSubrepresentation`: the standard subrepresentation is an atom of the
   lattice of subrepresentations of `k[α]`, and
   `TauCeti.isIrreducible_standardRepresentation`: hence it is irreducible.
+* `TauCeti.char_standardRepresentation`: its character is the character of `k[α]` less `1`, the
+  trivial constituent the standard representation omits.
 
 The two remaining halves of the picture hold for an arbitrary permutation representation and are
 proved there, in `TauCeti.RepresentationTheory.Augmentation`: that `k[α]` is the direct sum of the
@@ -137,6 +139,21 @@ theorem coe_standardRepresentation_apply (g : Equiv.Perm α)
   (rfl)
 
 end Defn
+
+section Character
+
+variable {k : Type*} [Field k] {α : Type*} [Finite α] [Nonempty α]
+
+/-- **The character of the standard representation** is the character of the permutation
+representation `k[α]` less `1`.  The subtracted `1` is the trivial constituent, and no hypothesis
+on `|α|` in `k` is needed: it is the trace of a projection onto a line transverse to the standard
+subrepresentation, which exists whether or not the *invariant* line is one. -/
+theorem char_standardRepresentation (g : Equiv.Perm α) :
+    (standardRepresentation k α).character g =
+      (Representation.ofMulAction k (Equiv.Perm α) α).character g - 1 :=
+  character_augmentationSubrepresentation g
+
+end Character
 
 section WeakScalars
 

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -48,7 +48,7 @@ produces all the others, and those differences span.
   lattice of subrepresentations of `k[α]`, and
   `TauCeti.isIrreducible_standardRepresentation`: hence it is irreducible.
 * `TauCeti.char_standardRepresentation`: its character is the character of `k[α]` less `1`, the
-  trivial constituent the standard representation omits.
+  `1` being the character of the trivial quotient of `k[α]` by the standard subrepresentation.
 
 The two remaining halves of the picture hold for an arbitrary permutation representation and are
 proved there, in `TauCeti.RepresentationTheory.Augmentation`: that `k[α]` is the direct sum of the
@@ -145,9 +145,14 @@ section Character
 variable {k : Type*} [Field k] {α : Type*} [Finite α] [Nonempty α]
 
 /-- **The character of the standard representation** is the character of the permutation
-representation `k[α]` less `1`.  The subtracted `1` is the trivial constituent, and no hypothesis
-on `|α|` in `k` is needed: it is the trace of a projection onto a line transverse to the standard
-subrepresentation, which exists whether or not the *invariant* line is one. -/
+representation `k[α]` less `1`.  The subtracted `1` is the character of the trivial quotient of
+`k[α]` by the standard subrepresentation, and no hypothesis on `|α|` in `k` is needed: it is the
+trace on a line transverse to the standard subrepresentation, which exists whether or not the
+*invariant* line is one.  Only when `(Fintype.card α : k) ≠ 0` is that quotient realised inside
+`k[α]` as the invariant line, splitting a trivial constituent off the standard representation;
+when `(Fintype.card α : k) = 0` and `3 ≤ |α|` the invariant line lies *inside* the standard
+subrepresentation instead. -/
+@[simp]
 theorem char_standardRepresentation (g : Equiv.Perm α) :
     (standardRepresentation k α).character g =
       (Representation.ofMulAction k (Equiv.Perm α) α).character g - 1 :=

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -145,12 +145,13 @@ section Character
 variable {k : Type*} [Field k] {α : Type*} [Finite α] [Nonempty α]
 
 /-- **The character of the standard representation** is the character of the permutation
-representation `k[α]` less `1`.  The subtracted `1` is the character of the trivial quotient of
-`k[α]` by the standard subrepresentation, and no hypothesis on `|α|` in `k` is needed: it is the
-trace on a line transverse to the standard subrepresentation, which exists whether or not the
-*invariant* line is one.  Only when `(Fintype.card α : k) ≠ 0` is that quotient realised inside
-`k[α]` as the invariant line, splitting a trivial constituent off the standard representation;
-when `(Fintype.card α : k) = 0` and `3 ≤ |α|` the invariant line lies *inside* the standard
+representation `k[α]` less `1`.  The subtracted `1` is the character of the one-dimensional
+quotient of `k[α]` by the standard subrepresentation, which is trivial in every characteristic --
+the quotient map is the augmentation `k[α] → k` -- so no hypothesis on `|α|` in `k` is needed.
+Only when
+`(Fintype.card α : k) ≠ 0` is that quotient realised inside `k[α]`, as the invariant line
+complementing the standard subrepresentation and splitting a trivial constituent off it; when
+`(Fintype.card α : k) = 0` and `3 ≤ |α|` the invariant line lies *inside* the standard
 subrepresentation instead. -/
 @[simp]
 theorem char_standardRepresentation (g : Equiv.Perm α) :


### PR DESCRIPTION
This PR builds the "Permutation characters and fixed points" worked example of the induction and restriction roadmap: inducing the trivial representation of a point stabilizer in the symmetric group gives the natural permutation representation on the points, its character counts fixed points, and its self-pairing is the number of double cosets, which is `2`. It cites `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, "Worked examples (acceptance criteria)", the bullet **Permutation characters and fixed points**: "For `G = S₄` and `H` a point stabilizer `S₃`, `Ind_H^G(trivial)` is the natural permutation representation on `4` points; its character at `g` is the number of fixed points of `g`, and `⟨Ind_H^G 1, Ind_H^G 1⟩ = #(H \ G / H) = 2`, the two double cosets being the diagonal and off-diagonal `H`-orbits on the four points, so it splits as `trivial ⊕ (standard 3-dimensional)`." The Layer 2 machinery it consumes — `TauCeti.indTrivialEquiv`, `TauCeti.char_ofMulAction` and `TauCeti.characterPairing_ind_trivial_eq_card_doubleCosetQuotient` — is already in the repository, stated for a general subgroup; the example is what remained.

Three pieces land. `TauCeti/GroupTheory/GroupAction/Transitive.lean` is new and specialises Mathlib's orbit-stabiliser theorem to a transitive action: `TauCeti.quotientStabilizerEquiv` identifies `G ⧸ stabilizer G b` with `X` itself, with `TauCeti.quotientStabilizerEquiv_smul` the equivariance that makes it an isomorphism of `G`-sets. It is unbundled — an `Equiv` plus an equivariance lemma — because that is the shape `TauCeti.ofMulActionEquivCongr` takes its argument in. `TauCeti/RepresentationTheory/Symmetric/Standard.lean` gains `TauCeti.char_standardRepresentation`, the character of the standard representation as the permutation character less `1`; it belongs beside the definition, whose body is not exposed. `TauCeti/RepresentationTheory/Induction/PointStabilizer.lean` is new and is the example: `TauCeti.indTrivialStabilizerEquiv` and its `Rep`-level form `TauCeti.indTrivialStabilizerIso` identify `Ind_H^G 1` with the permutation representation on the points, `TauCeti.char_ind_trivial_stabilizer` reads its character off as the fixed-point count, `TauCeti.finrank_ind_trivial_stabilizer` gives its dimension, and `TauCeti.char_ind_trivial_stabilizer_eq_one_add_char_standardRepresentation` is the splitting `trivial ⊕ standard` on characters.

The quantitative half is the double-coset count. `TauCeti.card_doubleCosetQuotient_stabilizer` says a point stabilizer in `Equiv.Perm α` has exactly two double cosets whenever `α` is nontrivial, and it is proved by hand rather than transported through `TauCeti.doubleCosetEquivOrbitQuotient`: a permutation either fixes `x₀` or does not, the first case is the identity double coset, and if `σ` and `τ` both move `x₀` then the transposition of `σ x₀` and `τ x₀` fixes `x₀` and carries the one class onto the other, which is shorter than reading the two classes as the two orbits of `Equiv.Perm α` on ordered pairs of points. Feeding it the general pairing theorem gives `TauCeti.characterPairing_ind_trivial_stabilizer`, `⟨Ind 1, Ind 1⟩ = 2`, so the permutation representation has exactly two irreducible constituents, each with multiplicity one. The `S₄` instance closes the acceptance criterion: two double cosets, a `4`-dimensional induced representation, a `3`-dimensional complement, and — over a field where `4 ≠ 0` — its irreducibility, from `TauCeti.isIrreducible_standardRepresentation`.

The double-coset statements are proved on `DoubleCoset.setoid` first and transported to the quotient with `Quotient.sound'` and `Quotient.exact'`, since `DoubleCoset.Quotient` is a plain definition that `rw` will not see through; that is recorded in the module docstring. The `Rep`-level isomorphism constrains the coefficient ring and the acted-on set to one universe, because it compares two objects of one category, while the `Representation`-level statements — where every character is computed — carry no such constraint. No Mathlib infrastructure was vendored: `MulAction.orbitEquivQuotientStabilizer`, `MulAction.orbit_eq_univ`, `DoubleCoset.rel_iff`, `Nat.card_eq_two_iff'` and `Equiv.swap_apply_of_ne_of_ne` are consumed as they stand. `lake build`, `lake exe axioms`, `scripts/lint-env.sh`, `scripts/lint-style.sh` and `scripts/lint-dot-notation.py` all pass locally.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"permutation-characters-and-fixed-points"}-->

🤖 Prepared with Claude Code
