### PR TITLE
feat: preserve multivariate Gaussians under affine maps

### DIFF
--- a/TauCeti/Probability/Distributions/Gaussian/Affine.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Affine.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Distributions.Gaussian.Multivariate
+
+import Mathlib.Probability.Distributions.Gaussian.CharFun
+import Mathlib.Probability.Distributions.Gaussian.Fernique
+
+/-!
+# Affine images of multivariate Gaussian measures
+
+This file proves that a multivariate Gaussian measure is carried by a rectangular affine map to
+the multivariate Gaussian with the transformed mean and covariance.  Rectangular matrices are
+allowed, so the result applies both to embeddings and to possibly singular projections.
+
+## Main result
+
+* `TauCeti.map_affine_multivariateGaussian`: the affine pushforward formula for a multivariate
+  Gaussian measure.
+
+## References
+
+* M. L. Eaton, *Multivariate Statistics: A Vector Space Approach*.
+* `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 3, **Affine maps of Gaussian
+  laws**.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+open scoped MatrixOrder RealInnerProductSpace
+
+namespace TauCeti
+
+variable {ι κ : Type*} [Fintype ι] [Fintype κ] [DecidableEq ι] [DecidableEq κ]
+
+/-- The image of a multivariate Gaussian under a rectangular affine map is the multivariate
+Gaussian with the corresponding transformed mean and covariance. -/
+theorem map_affine_multivariateGaussian (m : EuclideanSpace ℝ ι) {S : Matrix ι ι ℝ}
+    (hS : S.PosSemidef) (L : Matrix κ ι ℝ) (c : EuclideanSpace ℝ κ) :
+    (multivariateGaussian m S).map (fun x => L.toEuclideanLin x + c) =
+      multivariateGaussian (L.toEuclideanLin m + c) (L * S * L.transpose) := by
+  let T : EuclideanSpace ℝ ι →L[ℝ] EuclideanSpace ℝ κ :=
+    L.toEuclideanLin.toContinuousLinearMap
+  -- Separate the linear image from the translation so that Mathlib's covariance rules apply.
+  have h_map :
+      (multivariateGaussian m S).map (fun x => L.toEuclideanLin x + c) =
+        ((multivariateGaussian m S).map T).map (fun y => y + c) := by
+    rw [Measure.map_map]
+    · rfl
+    · fun_prop
+    · fun_prop
+  rw [h_map]
+  -- Gaussian measures are determined by their mean and covariance bilinear form.
+  apply IsGaussian.ext
+  · rw [integral_map]
+    · simp only [id_eq]
+      rw [integral_id_multivariateGaussian]
+      calc
+        ∫ x, x + c ∂(multivariateGaussian m S).map T =
+            (∫ x, x ∂(multivariateGaussian m S).map T) +
+              ∫ _x, c ∂(multivariateGaussian m S).map T :=
+          integral_add IsGaussian.integrable_id (integrable_const c)
+        _ = T m + c := by
+          rw [T.integral_id_map IsGaussian.integrable_id, integral_id_multivariateGaussian,
+            integral_const]
+          simp
+        _ = L.toEuclideanLin m + c := rfl
+    · fun_prop
+    · fun_prop
+  · rw [show (fun y : EuclideanSpace ℝ κ => y + c) = (fun y => c + y) by
+      funext y
+      exact add_comm y c]
+    rw [covarianceBilin_map_const_add]
+    ext x y
+    -- Over `ℝ`, conjugate transpose is ordinary transpose; this also proves positivity of the
+    -- transformed covariance without any rank hypothesis on the rectangular matrix.
+    have hLstar : L.conjTranspose = L.transpose := by
+      ext i j
+      simp
+    have hLS : (L * S * L.transpose).PosSemidef := by
+      rw [← hLstar]
+      exact hS.mul_mul_conjTranspose_same L
+    have hTadj : T.adjoint = L.transpose.toEuclideanLin.toContinuousLinearMap := by
+      rw [← LinearMap.adjoint_toContinuousLinearMap]
+      congr 1
+      rw [← Matrix.toEuclideanLin_conjTranspose_eq_adjoint, hLstar]
+    rw [covarianceBilin_map IsGaussian.memLp_two_id,
+      covarianceBilin_multivariateGaussian hS,
+      covarianceBilin_multivariateGaussian hLS, hTadj]
+    simp only [LinearMap.coe_toContinuousLinearMap']
+    have h_apply (z : EuclideanSpace ℝ κ) :
+        (L.transpose.toEuclideanLin z).ofLp = Matrix.mulVec L.transpose z.ofLp := rfl
+    rw [h_apply, h_apply, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
+    nth_rw 2 [Matrix.dotProduct_mulVec]
+    rw [← Matrix.mulVec_transpose]
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Affine.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Affine.lean
@@ -42,6 +42,7 @@ variable {ι κ : Type*} [Fintype ι] [Fintype κ] [DecidableEq ι] [DecidableEq
 
 /-- The image of a multivariate Gaussian under a rectangular affine map is the multivariate
 Gaussian with the corresponding transformed mean and covariance. -/
+@[simp]
 theorem map_affine_multivariateGaussian (m : EuclideanSpace ℝ ι) {S : Matrix ι ι ℝ}
     (hS : S.PosSemidef) (L : Matrix κ ι ℝ) (c : EuclideanSpace ℝ κ) :
     (multivariateGaussian m S).map (fun x => L.toEuclideanLin x + c) =
@@ -53,7 +54,9 @@ theorem map_affine_multivariateGaussian (m : EuclideanSpace ℝ ι) {S : Matrix 
       (multivariateGaussian m S).map (fun x => L.toEuclideanLin x + c) =
         ((multivariateGaussian m S).map T).map (fun y => y + c) := by
     rw [Measure.map_map]
-    · rfl
+    · refine congrArg (fun f => (multivariateGaussian m S).map f) ?_
+      funext x
+      simp only [T, Function.comp_apply, LinearMap.coe_toContinuousLinearMap']
     · fun_prop
     · fun_prop
   rw [h_map]
@@ -71,12 +74,15 @@ theorem map_affine_multivariateGaussian (m : EuclideanSpace ℝ ι) {S : Matrix 
           rw [T.integral_id_map IsGaussian.integrable_id, integral_id_multivariateGaussian,
             integral_const]
           simp
-        _ = L.toEuclideanLin m + c := rfl
+        _ = L.toEuclideanLin m + c := by
+          simp only [T, LinearMap.coe_toContinuousLinearMap']
     · fun_prop
     · fun_prop
-  · rw [show (fun y : EuclideanSpace ℝ κ => y + c) = (fun y => c + y) by
+  · -- The covariance API states translation with the constant on the left.
+    have h_translate : (fun y : EuclideanSpace ℝ κ => y + c) = fun y => c + y := by
       funext y
-      exact add_comm y c]
+      exact add_comm y c
+    rw [h_translate]
     rw [covarianceBilin_map_const_add]
     ext x y
     -- Over `ℝ`, conjugate transpose is ordinary transpose; this also proves positivity of the
@@ -96,7 +102,9 @@ theorem map_affine_multivariateGaussian (m : EuclideanSpace ℝ ι) {S : Matrix 
       covarianceBilin_multivariateGaussian hLS, hTadj]
     simp only [LinearMap.coe_toContinuousLinearMap']
     have h_apply (z : EuclideanSpace ℝ κ) :
-        (L.transpose.toEuclideanLin z).ofLp = Matrix.mulVec L.transpose z.ofLp := rfl
+        (L.transpose.toEuclideanLin z).ofLp = Matrix.mulVec L.transpose z.ofLp := by
+      simpa only [Matrix.toLin'_apply] using
+        Matrix.ofLp_toLpLin (p := 2) (q := 2) L.transpose z
     rw [h_apply, h_apply, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
     nth_rw 2 [Matrix.dotProduct_mulVec]
     rw [← Matrix.mulVec_transpose]

--- a/TauCeti/Probability/Distributions/Gaussian/Affine.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Affine.lean
@@ -106,7 +106,12 @@ theorem map_affine_multivariateGaussian (m : EuclideanSpace ℝ ι) {S : Matrix 
       simpa only [Matrix.toLin'_apply] using
         Matrix.ofLp_toLpLin (p := 2) (q := 2) L.transpose z
     rw [h_apply, h_apply, ← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
-    nth_rw 2 [Matrix.dotProduct_mulVec]
-    rw [← Matrix.mulVec_transpose]
+    calc
+      L.transpose.mulVec x.ofLp ⬝ᵥ S.mulVec (L.transpose.mulVec y.ofLp) =
+          Matrix.vecMul x.ofLp L ⬝ᵥ S.mulVec (L.transpose.mulVec y.ofLp) := by
+        rw [Matrix.mulVec_transpose]
+      _ = x.ofLp ⬝ᵥ L.mulVec (S.mulVec (L.transpose.mulVec y.ofLp)) :=
+        (Matrix.dotProduct_mulVec x.ofLp L
+          (S.mulVec (L.transpose.mulVec y.ofLp))).symm
 
 end TauCeti


### PR DESCRIPTION
This PR proves that applying any rectangular affine map `x ↦ Lx + c` to a positive-semidefinite multivariate Gaussian produces the multivariate Gaussian with mean `Lm + c` and covariance `L S Lᵀ`. Keep `L` rectangular and impose no rank hypothesis, so the theorem covers embeddings and singular projections as well as automorphisms.

The exact roadmap target is `TauCetiRoadmap/StandardDistributions/README.md`, Layer 5, item 3, **Affine maps of Gaussian laws**, whose key declaration is `map_affine_multivariateGaussian`. This is the next effective unclaimed step in that milestone because Layer 5's covariance-matrix item is complete, the affine formula is a prerequisite for Gaussian projections and the Gaussian-Gram congruence formulas in Layer 6, and no open PR covers it. After this PR, item 3 still needs the directional mgf and its exact exponential-integrability domain, coordinate-marginal packaging, and the separate Gaussian quadratic-form transform.

The assigned IntegralLattices roadmap had no viable independent step on current `main`: its remaining advertised critical-path work is already claimed by #4755, #4758, and #3805 or depends directly on those PRs, so this PR falls back to StandardDistributions.

Add `TauCeti/Probability/Distributions/Gaussian/Affine.lean` (104 lines). The proof uses Mathlib's characterization of Gaussian measures by their mean and covariance, its covariance rules for linear maps and translations, and the positive-semidefinite congruence theorem; it then reduces the rectangular covariance calculation to Mathlib's matrix-vector associativity and transpose identities. No Mathlib source or external formalization is vendored. The mathematical reference is M. L. Eaton, *Multivariate Statistics: A Vector Space Approach*.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"map-affine-multivariategaussian"}-->

🤖 Prepared with Codex
