### PR TITLE
feat: prove graphon weak regularity

### DIFF
--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -5,7 +5,9 @@ Authors: Claude
 -/
 module
 
-public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.Basic
+public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
+import Mathlib.Analysis.Convex.Integral
+import Mathlib.Analysis.Convex.SpecificFunctions.Deriv
 
 /-!
 # The `L²` pairing of symmetric kernels
@@ -36,6 +38,8 @@ the expansion `l2sq_sub` needs no additional side conditions.
 * `TauCeti.DenseGraphLimits.SymmKernel.integrable_mul` is the integrability behind both;
 * `TauCeti.DenseGraphLimits.l2sq_sub` expands the squared seminorm of a difference — the identity
   the Pythagoras energy increment is read off from;
+* `TauCeti.DenseGraphLimits.sq_rectIntegral_le_l2sq` is the Cauchy--Schwarz bound that converts a
+  cut-norm witness into an energy increment;
 * `TauCeti.DenseGraphLimits.l2sq_le_one_of_abs_le_one` bounds the squared seminorm of a kernel
   with values in `[-1, 1]` over a probability carrier.
 
@@ -46,6 +50,9 @@ the expansion `l2sq_sub` needs no additional side conditions.
   stack.  The `l2sq` signature and the `l2sq_nonneg` proof are taken from
   `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` (Layer 1/2); the pairing `l2inner` and its
   bilinear API are developed here.
+* The set-integral Cauchy--Schwarz argument follows `Graphon/Regularity.lean` in
+  `cameronfreer/graphon` (Apache 2.0) at commit
+  `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699`.
 -/
 
 public section
@@ -191,6 +198,53 @@ theorem l2sq_sub (K L : SymmKernel Ω μ) :
   simp only [l2sq_eq_l2inner_self, l2inner_sub_left, l2inner_sub_right]
   rw [l2inner_comm μ L K]
   ring
+
+/-- Cauchy--Schwarz for a set integral, in the squared form used by graphon regularity. -/
+private theorem sq_setIntegral_le_measureReal_mul_setIntegral_sq (f : Ω → ℝ) (S : Set Ω)
+    (hf : IntegrableOn f S μ) (hf_sq : IntegrableOn (fun x => f x ^ 2) S μ) :
+    (∫ x in S, f x ∂μ) ^ 2 ≤ μ.real S * ∫ x in S, f x ^ 2 ∂μ := by
+  by_cases hS : μ S = 0
+  · rw [Measure.restrict_eq_zero.mpr hS]
+    simp
+  · have hS_top : μ S ≠ ⊤ := (measure_lt_top μ S).ne
+    have hS_pos : 0 < μ.real S := ENNReal.toReal_pos hS hS_top
+    have hconv : ConvexOn ℝ Set.univ (fun x : ℝ => x ^ 2) :=
+      (Even.strictConvexOn_pow (by norm_num : Even 2) (by norm_num : (2 : ℕ) ≠ 0)).convexOn
+    have hjensen := hconv.map_set_average_le (continuous_pow 2).continuousOn isClosed_univ
+      hS hS_top (ae_of_all _ fun _ => Set.mem_univ _) hf hf_sq
+    rw [setAverage_eq, setAverage_eq] at hjensen
+    simp only [smul_eq_mul, Measure.real] at hjensen
+    have hkey : (μ.real S)⁻¹ ^ 2 * (∫ x in S, f x ∂μ) ^ 2
+        ≤ (μ.real S)⁻¹ * ∫ x in S, f x ^ 2 ∂μ := by
+      calc
+        (μ.real S)⁻¹ ^ 2 * (∫ x in S, f x ∂μ) ^ 2 =
+            ((μ.real S)⁻¹ * ∫ x in S, f x ∂μ) ^ 2 := by ring
+        _ ≤ _ := hjensen
+    calc
+      (∫ x in S, f x ∂μ) ^ 2 =
+          μ.real S ^ 2 * ((μ.real S)⁻¹ ^ 2 * (∫ x in S, f x ∂μ) ^ 2) := by
+            field_simp
+      _ ≤ μ.real S ^ 2 * ((μ.real S)⁻¹ * ∫ x in S, f x ^ 2 ∂μ) :=
+        mul_le_mul_of_nonneg_left hkey (sq_nonneg _)
+      _ = μ.real S * ∫ x in S, f x ^ 2 ∂μ := by field_simp
+
+/-- The square of a kernel's integral over any rectangle is at most its squared `L²` seminorm
+on a probability carrier. -/
+theorem sq_rectIntegral_le_l2sq [IsProbabilityMeasure μ] (K : SymmKernel Ω μ) (S T : Set Ω) :
+    (K.rectIntegral μ S T) ^ 2 ≤ l2sq μ K := by
+  rw [SymmKernel.rectIntegral_def, l2sq_def]
+  calc
+    (∫ p in S ×ˢ T, K p.1 p.2 ∂(μ.prod μ)) ^ 2
+        ≤ (μ.prod μ).real (S ×ˢ T) *
+            ∫ p in S ×ˢ T, K p.1 p.2 ^ 2 ∂(μ.prod μ) :=
+      sq_setIntegral_le_measureReal_mul_setIntegral_sq (μ.prod μ) _ _
+        (K.integrable_uncurry μ).integrableOn (K.integrable_sq μ).integrableOn
+    _ ≤ 1 * ∫ p in S ×ˢ T, K p.1 p.2 ^ 2 ∂(μ.prod μ) := by
+      exact mul_le_mul_of_nonneg_right measureReal_le_one
+        (setIntegral_nonneg_of_ae_restrict (ae_of_all _ fun _ => sq_nonneg _))
+    _ ≤ ∫ p, K p.1 p.2 ^ 2 ∂(μ.prod μ) := by
+      rw [one_mul]
+      exact setIntegral_le_integral (K.integrable_sq μ) (ae_of_all _ fun _ => sq_nonneg _)
 
 omit [IsFiniteMeasure μ] in
 /-- A kernel with values in `[-1, 1]` has squared `L²` seminorm at most `1` over a probability

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -6,7 +6,7 @@ Authors: Claude, Codex
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
-public import TauCeti.MeasureTheory.Integral.Bochner.Basic
+import TauCeti.MeasureTheory.Integral.Bochner.Basic
 
 /-!
 # The `L²` pairing of symmetric kernels
@@ -209,6 +209,7 @@ theorem sq_rectIntegral_le_l2sq [IsProbabilityMeasure μ] (K : SymmKernel Ω μ)
         ≤ (μ.prod μ).real (S ×ˢ T) *
             ∫ p in S ×ˢ T, K p.1 p.2 ^ 2 ∂(μ.prod μ) :=
       MeasureTheory.sq_setIntegral_le_measureReal_mul_setIntegral_sq _ _
+        (measure_ne_top _ _)
         (K.integrable_uncurry μ).integrableOn (K.integrable_sq μ).integrableOn
     _ ≤ 1 * ∫ p in S ×ˢ T, K p.1 p.2 ^ 2 ∂(μ.prod μ) := by
       exact mul_le_mul_of_nonneg_right measureReal_le_one

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -1,13 +1,12 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: Claude, Codex
 -/
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.CutNorm
-import Mathlib.Analysis.Convex.Integral
-import Mathlib.Analysis.Convex.SpecificFunctions.Deriv
+public import TauCeti.MeasureTheory.Integral.Bochner.Basic
 
 /-!
 # The `L²` pairing of symmetric kernels
@@ -199,35 +198,7 @@ theorem l2sq_sub (K L : SymmKernel Ω μ) :
   rw [l2inner_comm μ L K]
   ring
 
-/-- Cauchy--Schwarz for a set integral, in the squared form used by graphon regularity. -/
-private theorem sq_setIntegral_le_measureReal_mul_setIntegral_sq (f : Ω → ℝ) (S : Set Ω)
-    (hf : IntegrableOn f S μ) (hf_sq : IntegrableOn (fun x => f x ^ 2) S μ) :
-    (∫ x in S, f x ∂μ) ^ 2 ≤ μ.real S * ∫ x in S, f x ^ 2 ∂μ := by
-  by_cases hS : μ S = 0
-  · rw [Measure.restrict_eq_zero.mpr hS]
-    simp
-  · have hS_top : μ S ≠ ⊤ := (measure_lt_top μ S).ne
-    have hS_pos : 0 < μ.real S := ENNReal.toReal_pos hS hS_top
-    have hconv : ConvexOn ℝ Set.univ (fun x : ℝ => x ^ 2) :=
-      (Even.strictConvexOn_pow (by norm_num : Even 2) (by norm_num : (2 : ℕ) ≠ 0)).convexOn
-    have hjensen := hconv.map_set_average_le (continuous_pow 2).continuousOn isClosed_univ
-      hS hS_top (ae_of_all _ fun _ => Set.mem_univ _) hf hf_sq
-    rw [setAverage_eq, setAverage_eq] at hjensen
-    simp only [smul_eq_mul, Measure.real] at hjensen
-    have hkey : (μ.real S)⁻¹ ^ 2 * (∫ x in S, f x ∂μ) ^ 2
-        ≤ (μ.real S)⁻¹ * ∫ x in S, f x ^ 2 ∂μ := by
-      calc
-        (μ.real S)⁻¹ ^ 2 * (∫ x in S, f x ∂μ) ^ 2 =
-            ((μ.real S)⁻¹ * ∫ x in S, f x ∂μ) ^ 2 := by ring
-        _ ≤ _ := hjensen
-    calc
-      (∫ x in S, f x ∂μ) ^ 2 =
-          μ.real S ^ 2 * ((μ.real S)⁻¹ ^ 2 * (∫ x in S, f x ∂μ) ^ 2) := by
-            field_simp
-      _ ≤ μ.real S ^ 2 * ((μ.real S)⁻¹ * ∫ x in S, f x ^ 2 ∂μ) :=
-        mul_le_mul_of_nonneg_left hkey (sq_nonneg _)
-      _ = μ.real S * ∫ x in S, f x ^ 2 ∂μ := by field_simp
-
+omit [IsFiniteMeasure μ] in
 /-- The square of a kernel's integral over any rectangle is at most its squared `L²` seminorm
 on a probability carrier. -/
 theorem sq_rectIntegral_le_l2sq [IsProbabilityMeasure μ] (K : SymmKernel Ω μ) (S T : Set Ω) :
@@ -237,7 +208,7 @@ theorem sq_rectIntegral_le_l2sq [IsProbabilityMeasure μ] (K : SymmKernel Ω μ)
     (∫ p in S ×ˢ T, K p.1 p.2 ∂(μ.prod μ)) ^ 2
         ≤ (μ.prod μ).real (S ×ˢ T) *
             ∫ p in S ×ˢ T, K p.1 p.2 ^ 2 ∂(μ.prod μ) :=
-      sq_setIntegral_le_measureReal_mul_setIntegral_sq (μ.prod μ) _ _
+      MeasureTheory.sq_setIntegral_le_measureReal_mul_setIntegral_sq _ _
         (K.integrable_uncurry μ).integrableOn (K.integrable_sq μ).integrableOn
     _ ≤ 1 * ∫ p in S ×ˢ T, K p.1 p.2 ^ 2 ∂(μ.prod μ) := by
       exact mul_le_mul_of_nonneg_right measureReal_le_one

--- a/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/Kernel/L2.lean
@@ -37,8 +37,8 @@ the expansion `l2sq_sub` needs no additional side conditions.
 * `TauCeti.DenseGraphLimits.SymmKernel.integrable_mul` is the integrability behind both;
 * `TauCeti.DenseGraphLimits.l2sq_sub` expands the squared seminorm of a difference — the identity
   the Pythagoras energy increment is read off from;
-* `TauCeti.DenseGraphLimits.sq_rectIntegral_le_l2sq` is the Cauchy--Schwarz bound that converts a
-  cut-norm witness into an energy increment;
+* `TauCeti.DenseGraphLimits.sq_rectIntegral_le_measureReal_mul_l2sq` is the finite-measure
+  rectangle Cauchy--Schwarz bound, and `sq_rectIntegral_le_l2sq` is its probability specialization;
 * `TauCeti.DenseGraphLimits.l2sq_le_one_of_abs_le_one` bounds the squared seminorm of a kernel
   with values in `[-1, 1]` over a probability carrier.
 
@@ -198,11 +198,10 @@ theorem l2sq_sub (K L : SymmKernel Ω μ) :
   rw [l2inner_comm μ L K]
   ring
 
-omit [IsFiniteMeasure μ] in
-/-- The square of a kernel's integral over any rectangle is at most its squared `L²` seminorm
-on a probability carrier. -/
-theorem sq_rectIntegral_le_l2sq [IsProbabilityMeasure μ] (K : SymmKernel Ω μ) (S T : Set Ω) :
-    (K.rectIntegral μ S T) ^ 2 ≤ l2sq μ K := by
+/-- The square of a kernel's integral over a rectangle is at most the rectangle's measure times
+the kernel's squared `L²` seminorm. -/
+theorem sq_rectIntegral_le_measureReal_mul_l2sq (K : SymmKernel Ω μ) (S T : Set Ω) :
+    (K.rectIntegral μ S T) ^ 2 ≤ (μ.prod μ).real (S ×ˢ T) * l2sq μ K := by
   rw [SymmKernel.rectIntegral_def, l2sq_def]
   calc
     (∫ p in S ×ˢ T, K p.1 p.2 ∂(μ.prod μ)) ^ 2
@@ -211,12 +210,23 @@ theorem sq_rectIntegral_le_l2sq [IsProbabilityMeasure μ] (K : SymmKernel Ω μ)
       MeasureTheory.sq_setIntegral_le_measureReal_mul_setIntegral_sq _ _
         (measure_ne_top _ _)
         (K.integrable_uncurry μ).integrableOn (K.integrable_sq μ).integrableOn
-    _ ≤ 1 * ∫ p in S ×ˢ T, K p.1 p.2 ^ 2 ∂(μ.prod μ) := by
-      exact mul_le_mul_of_nonneg_right measureReal_le_one
-        (setIntegral_nonneg_of_ae_restrict (ae_of_all _ fun _ => sq_nonneg _))
-    _ ≤ ∫ p, K p.1 p.2 ^ 2 ∂(μ.prod μ) := by
-      rw [one_mul]
-      exact setIntegral_le_integral (K.integrable_sq μ) (ae_of_all _ fun _ => sq_nonneg _)
+    _ ≤ (μ.prod μ).real (S ×ˢ T) * ∫ p, K p.1 p.2 ^ 2 ∂(μ.prod μ) := by
+      exact mul_le_mul_of_nonneg_left
+        (setIntegral_le_integral (K.integrable_sq μ) (ae_of_all _ fun _ => sq_nonneg _))
+        measureReal_nonneg
+
+omit [IsFiniteMeasure μ] in
+/-- The square of a kernel's integral over any rectangle is at most its squared `L²` seminorm
+on a probability carrier. -/
+theorem sq_rectIntegral_le_l2sq [IsProbabilityMeasure μ] (K : SymmKernel Ω μ) (S T : Set Ω) :
+    (K.rectIntegral μ S T) ^ 2 ≤ l2sq μ K := by
+  calc
+    (K.rectIntegral μ S T) ^ 2
+        ≤ (μ.prod μ).real (S ×ˢ T) * l2sq μ K :=
+      sq_rectIntegral_le_measureReal_mul_l2sq μ K S T
+    _ ≤ 1 * l2sq μ K :=
+      mul_le_mul_of_nonneg_right measureReal_le_one (l2sq_nonneg μ K)
+    _ = l2sq μ K := one_mul _
 
 omit [IsFiniteMeasure μ] in
 /-- A kernel with values in `[-1, 1]` has squared `L²` seminorm at most `1` over a probability

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -49,6 +49,8 @@ graph.
 
 * `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le`: block averaging over a refinement
   preserves the coarse block integrals;
+* `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le_left_right`: the corresponding
+  statement when the two rectangle sides come from different coarser partitions;
 * `TauCeti.DenseGraphLimits.l2inner_stepGraphonAvg_eq_sum`: the block computation everything else
   is read off from — pairing any kernel against a block-average step graphon;
 * `TauCeti.DenseGraphLimits.graphonPartitionEnergy_eq_sum`: the energy as a finite block sum;
@@ -98,22 +100,23 @@ variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasu
 section Decomposition
 
 /-- Two kernels with the same integral over every rectangle of a partition `Q` have the same
-integral over every rectangle of any coarser partition `P`. -/
-private theorem rectIntegral_eq_of_le {P Q : Finpartition (Set.univ : Set Ω)}
-    (hP : ∀ p ∈ P.parts, MeasurableSet p) (hQ : ∀ r ∈ Q.parts, MeasurableSet r) (href : Q ≤ P)
+integral over a rectangle whose sides are parts of two partitions coarser than `Q`. -/
+theorem rectIntegral_eq_of_le_left_right {P R Q : Finpartition (Set.univ : Set Ω)}
+    (hP : ∀ p ∈ P.parts, MeasurableSet p) (hR : ∀ r ∈ R.parts, MeasurableSet r)
+    (hQ : ∀ q ∈ Q.parts, MeasurableSet q) (hQP : Q ≤ P) (hQR : Q ≤ R)
     {K L : SymmKernel Ω μ}
     (h : ∀ r s : Q.parts, K.rectIntegral μ (r : Set Ω) (s : Set Ω)
-      = L.rectIntegral μ (r : Set Ω) (s : Set Ω)) (p q : P.parts) :
-    K.rectIntegral μ (p : Set Ω) (q : Set Ω) = L.rectIntegral μ (p : Set Ω) (q : Set Ω) := by
+      = L.rectIntegral μ (r : Set Ω) (s : Set Ω)) (p : P.parts) (r : R.parts) :
+    K.rectIntegral μ (p : Set Ω) (r : Set Ω) = L.rectIntegral μ (p : Set Ω) (r : Set Ω) := by
   rw [SymmKernel.rectIntegral_def, SymmKernel.rectIntegral_def,
-    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
+    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hR _ r.property)
       (SymmKernel.integrable_uncurry μ K).integrableOn,
-    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hP _ q.property)
+    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hR _ r.property)
       (SymmKernel.integrable_uncurry μ L).integrableOn]
   refine Finset.sum_congr rfl fun rs _ => ?_
-  rcases Finpartition.inter_part_eq_self_or_eq_empty_of_le href rs.1.property p.property with
+  rcases Finpartition.inter_part_eq_self_or_eq_empty_of_le hQP rs.1.property p.property with
     h1 | h1
-  · rcases Finpartition.inter_part_eq_self_or_eq_empty_of_le href rs.2.property q.property with
+  · rcases Finpartition.inter_part_eq_self_or_eq_empty_of_le hQR rs.2.property r.property with
       h2 | h2
     · rw [h1, h2]
       simpa only [SymmKernel.rectIntegral_def] using h rs.1 rs.2
@@ -134,7 +137,20 @@ theorem stepGraphonAvg_rectIntegral_of_le (hP : ∀ p ∈ P.parts, MeasurableSet
     (hQ : ∀ r ∈ Q.parts, MeasurableSet r) (href : Q ≤ P) (W : Graphon Ω μ) (p q : P.parts) :
     (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ (p : Set Ω) (q : Set Ω)
       = W.toSymmKernel.rectIntegral μ (p : Set Ω) (q : Set Ω) :=
-  rectIntegral_eq_of_le μ hP hQ href (fun r s => stepGraphonAvg_rectIntegral Q hQ W r s) p q
+  rectIntegral_eq_of_le_left_right μ hP hP hQ href href
+    (fun r s => stepGraphonAvg_rectIntegral Q hQ W r s) p q
+
+/-- Block averaging over `Q` reproduces the integral over any rectangle whose two sides are parts
+of (possibly different) measurable partitions coarser than `Q`. -/
+theorem stepGraphonAvg_rectIntegral_of_le_left_right
+    {P R Q : Finpartition (Set.univ : Set Ω)}
+    (hP : ∀ p ∈ P.parts, MeasurableSet p) (hR : ∀ r ∈ R.parts, MeasurableSet r)
+    (hQ : ∀ q ∈ Q.parts, MeasurableSet q) (hQP : Q ≤ P) (hQR : Q ≤ R)
+    (W : Graphon Ω μ) (p : P.parts) (r : R.parts) :
+    (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ (p : Set Ω) (r : Set Ω)
+      = W.toSymmKernel.rectIntegral μ (p : Set Ω) (r : Set Ω) :=
+  rectIntegral_eq_of_le_left_right μ hP hR hQ hQP hQR
+    (fun q q' => stepGraphonAvg_rectIntegral Q hQ W q q') p r
 
 /-- On a single block, pairing any kernel against the block-average step graphon multiplies the
 block integral of the kernel by the block average of `W`. -/

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Combinatorics.DenseGraphLimits.Kernel.L2
 public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Average
 public import TauCeti.MeasureTheory.Integral.Finpartition
+import TauCeti.MeasureTheory.MeasurableSpace.Finpartition
 
 /-!
 # The graphon partition energy
@@ -29,7 +30,7 @@ This file builds that potential.
 
 Both rest on the same block computation: the energy is a finite sum of block contributions
 (`graphonPartitionEnergy_eq_sum`), and a block average over a *refinement* still reproduces the
-coarse block integrals (`stepGraphonAvg_rectIntegral_of_le`).  That last identity needs no
+coarse block integrals (`stepGraphonAvg_rectIntegral_of_le_of_le`).  That last identity needs no
 hypothesis excluding null parts: a null part of the finer partition cuts out a null rectangle,
 which contributes zero to both sides whatever value the step graphon takes there.  The null-cell
 convention of `stepGraphonAvg` is what makes it a well-defined strict `[0, 1]`-valued
@@ -47,8 +48,9 @@ graph.
 
 ## Main results
 
-* `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le`: block averaging over a refinement
-  preserves rectangle integrals whose sides come from possibly different coarser partitions;
+* `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le_of_le`: block averaging over a
+  refinement preserves rectangle integrals whose sides come from possibly different coarser
+  partitions;
 * `TauCeti.DenseGraphLimits.l2inner_stepGraphonAvg_eq_sum`: the block computation everything else
   is read off from — pairing any kernel against a block-average step graphon;
 * `TauCeti.DenseGraphLimits.graphonPartitionEnergy_eq_sum`: the energy as a finite block sum;
@@ -76,7 +78,7 @@ graph.
   `_mono` and `_nonneg` proofs, follow `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` (Layer 2);
   the block computation, the projection moment identity and the defect identity are developed here.
 * The roadmap lists the null-cell `Finpartition` convention — including unchanged weighted energy,
-  the scope of `stepGraphonAvg_rectIntegral_of_le` and of the increment — under its
+  the scope of `stepGraphonAvg_rectIntegral_of_le_of_le` and of the increment — under its
   migration-backed routes, with an independent development in `Graphon/RegularityFinpartition.lean`
   in `cameronfreer/graphon` (Apache 2.0) at commit
   `dfd7ecc9b197d8211842935204bcec6051d57863`.  No material is adapted from that source; the proofs
@@ -100,13 +102,16 @@ section Decomposition
 /-- Two kernels with the same integral over every rectangle of a partition `Q` have the same
 integral over a rectangle whose sides are parts of two partitions coarser than `Q`. -/
 private theorem rectIntegral_eq_of_le_left_right {P R Q : Finpartition (Set.univ : Set Ω)}
-    (p : P.parts) (r : R.parts) (hp : MeasurableSet (p : Set Ω))
-    (hr : MeasurableSet (r : Set Ω))
-    (hQ : ∀ q ∈ Q.parts, MeasurableSet q) (hQP : Q ≤ P) (hQR : Q ≤ R)
+    (p : P.parts) (r : R.parts) (hQ : ∀ q ∈ Q.parts, MeasurableSet q)
+    (hQP : Q ≤ P) (hQR : Q ≤ R)
     {K L : SymmKernel Ω μ}
     (h : ∀ r s : Q.parts, K.rectIntegral μ (r : Set Ω) (s : Set Ω)
       = L.rectIntegral μ (r : Set Ω) (s : Set Ω)) :
     K.rectIntegral μ (p : Set Ω) (r : Set Ω) = L.rectIntegral μ (p : Set Ω) (r : Set Ω) := by
+  have hp : MeasurableSet (p : Set Ω) :=
+    Finpartition.measurableSet_of_mem_of_le hQ hQP p.property
+  have hr : MeasurableSet (r : Set Ω) :=
+    Finpartition.measurableSet_of_mem_of_le hQ hQR r.property
   rw [SymmKernel.rectIntegral_def, SymmKernel.rectIntegral_def,
     Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ hp hr
       (SymmKernel.integrable_uncurry μ K).integrableOn,
@@ -128,14 +133,14 @@ end Decomposition
 
 /-- Block averaging over `Q` reproduces the integral over any rectangle whose two sides are parts
 of (possibly different) measurable partitions coarser than `Q`. -/
-theorem stepGraphonAvg_rectIntegral_of_le {P R Q : Finpartition (Set.univ : Set Ω)}
-    (p : P.parts) (r : R.parts) (hp : MeasurableSet (p : Set Ω))
-    (hr : MeasurableSet (r : Set Ω))
-    (hQ : ∀ q ∈ Q.parts, MeasurableSet q) (hQP : Q ≤ P) (hQR : Q ≤ R)
+@[simp]
+theorem stepGraphonAvg_rectIntegral_of_le_of_le {P R Q : Finpartition (Set.univ : Set Ω)}
+    (p : P.parts) (r : R.parts) (hQ : ∀ q ∈ Q.parts, MeasurableSet q)
+    (hQP : Q ≤ P) (hQR : Q ≤ R)
     (W : Graphon Ω μ) :
     (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ (p : Set Ω) (r : Set Ω)
       = W.toSymmKernel.rectIntegral μ (p : Set Ω) (r : Set Ω) :=
-  rectIntegral_eq_of_le_left_right μ p r hp hr hQ hQP hQR
+  rectIntegral_eq_of_le_left_right μ p r hQ hQP hQR
     (fun q q' => stepGraphonAvg_rectIntegral Q hQ W q q')
 
 variable (P Q : Finpartition (Set.univ : Set Ω))
@@ -221,8 +226,7 @@ theorem l2inner_stepGraphonAvg_of_le (hP : ∀ p ∈ P.parts, MeasurableSet p)
       = graphonPartitionEnergy μ P hP W := by
   rw [l2inner_stepGraphonAvg_eq_sum, graphonPartitionEnergy_eq_sum]
   exact Finset.sum_congr rfl fun pq _ => by
-    rw [stepGraphonAvg_rectIntegral_of_le μ pq.1 pq.2 (hP _ pq.1.property)
-      (hP _ pq.2.property) hQ href href W]
+    rw [stepGraphonAvg_rectIntegral_of_le_of_le μ pq.1 pq.2 hQ href href W]
 
 /-- **The `L²`-Pythagoras energy increment.**  Refining a partition raises the energy by exactly the
 `L²` norm squared of the change in the block-average step graphon.  This is the quantitative driver

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -100,16 +100,17 @@ section Decomposition
 /-- Two kernels with the same integral over every rectangle of a partition `Q` have the same
 integral over a rectangle whose sides are parts of two partitions coarser than `Q`. -/
 private theorem rectIntegral_eq_of_le_left_right {P R Q : Finpartition (Set.univ : Set Ω)}
-    (hP : ∀ p ∈ P.parts, MeasurableSet p) (hR : ∀ r ∈ R.parts, MeasurableSet r)
+    (p : P.parts) (r : R.parts) (hp : MeasurableSet (p : Set Ω))
+    (hr : MeasurableSet (r : Set Ω))
     (hQ : ∀ q ∈ Q.parts, MeasurableSet q) (hQP : Q ≤ P) (hQR : Q ≤ R)
     {K L : SymmKernel Ω μ}
     (h : ∀ r s : Q.parts, K.rectIntegral μ (r : Set Ω) (s : Set Ω)
-      = L.rectIntegral μ (r : Set Ω) (s : Set Ω)) (p : P.parts) (r : R.parts) :
+      = L.rectIntegral μ (r : Set Ω) (s : Set Ω)) :
     K.rectIntegral μ (p : Set Ω) (r : Set Ω) = L.rectIntegral μ (p : Set Ω) (r : Set Ω) := by
   rw [SymmKernel.rectIntegral_def, SymmKernel.rectIntegral_def,
-    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hR _ r.property)
+    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ hp hr
       (SymmKernel.integrable_uncurry μ K).integrableOn,
-    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ (hP _ p.property) (hR _ r.property)
+    Finpartition.setIntegral_prod_eq_sum_parts μ Q hQ hp hr
       (SymmKernel.integrable_uncurry μ L).integrableOn]
   refine Finset.sum_congr rfl fun rs _ => ?_
   rcases Finpartition.inter_part_eq_self_or_eq_empty_of_le hQP rs.1.property p.property with
@@ -128,13 +129,14 @@ end Decomposition
 /-- Block averaging over `Q` reproduces the integral over any rectangle whose two sides are parts
 of (possibly different) measurable partitions coarser than `Q`. -/
 theorem stepGraphonAvg_rectIntegral_of_le {P R Q : Finpartition (Set.univ : Set Ω)}
-    (hP : ∀ p ∈ P.parts, MeasurableSet p) (hR : ∀ r ∈ R.parts, MeasurableSet r)
+    (p : P.parts) (r : R.parts) (hp : MeasurableSet (p : Set Ω))
+    (hr : MeasurableSet (r : Set Ω))
     (hQ : ∀ q ∈ Q.parts, MeasurableSet q) (hQP : Q ≤ P) (hQR : Q ≤ R)
-    (W : Graphon Ω μ) (p : P.parts) (r : R.parts) :
+    (W : Graphon Ω μ) :
     (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ (p : Set Ω) (r : Set Ω)
       = W.toSymmKernel.rectIntegral μ (p : Set Ω) (r : Set Ω) :=
-  rectIntegral_eq_of_le_left_right μ hP hR hQ hQP hQR
-    (fun q q' => stepGraphonAvg_rectIntegral Q hQ W q q') p r
+  rectIntegral_eq_of_le_left_right μ p r hp hr hQ hQP hQR
+    (fun q q' => stepGraphonAvg_rectIntegral Q hQ W q q')
 
 variable (P Q : Finpartition (Set.univ : Set Ω))
 
@@ -219,7 +221,8 @@ theorem l2inner_stepGraphonAvg_of_le (hP : ∀ p ∈ P.parts, MeasurableSet p)
       = graphonPartitionEnergy μ P hP W := by
   rw [l2inner_stepGraphonAvg_eq_sum, graphonPartitionEnergy_eq_sum]
   exact Finset.sum_congr rfl fun pq _ => by
-    rw [stepGraphonAvg_rectIntegral_of_le μ hP hP hQ href href W pq.1 pq.2]
+    rw [stepGraphonAvg_rectIntegral_of_le μ pq.1 pq.2 (hP _ pq.1.property)
+      (hP _ pq.2.property) hQ href href W]
 
 /-- **The `L²`-Pythagoras energy increment.**  Refining a partition raises the energy by exactly the
 `L²` norm squared of the change in the block-average step graphon.  This is the quantitative driver

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Energy.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: Claude, Codex
 -/
 module
 
@@ -48,9 +48,7 @@ graph.
 ## Main results
 
 * `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le`: block averaging over a refinement
-  preserves the coarse block integrals;
-* `TauCeti.DenseGraphLimits.stepGraphonAvg_rectIntegral_of_le_left_right`: the corresponding
-  statement when the two rectangle sides come from different coarser partitions;
+  preserves rectangle integrals whose sides come from possibly different coarser partitions;
 * `TauCeti.DenseGraphLimits.l2inner_stepGraphonAvg_eq_sum`: the block computation everything else
   is read off from — pairing any kernel against a block-average step graphon;
 * `TauCeti.DenseGraphLimits.graphonPartitionEnergy_eq_sum`: the energy as a finite block sum;
@@ -101,7 +99,7 @@ section Decomposition
 
 /-- Two kernels with the same integral over every rectangle of a partition `Q` have the same
 integral over a rectangle whose sides are parts of two partitions coarser than `Q`. -/
-theorem rectIntegral_eq_of_le_left_right {P R Q : Finpartition (Set.univ : Set Ω)}
+private theorem rectIntegral_eq_of_le_left_right {P R Q : Finpartition (Set.univ : Set Ω)}
     (hP : ∀ p ∈ P.parts, MeasurableSet p) (hR : ∀ r ∈ R.parts, MeasurableSet r)
     (hQ : ∀ q ∈ Q.parts, MeasurableSet q) (hQP : Q ≤ P) (hQR : Q ≤ R)
     {K L : SymmKernel Ω μ}
@@ -127,23 +125,9 @@ theorem rectIntegral_eq_of_le_left_right {P R Q : Finpartition (Set.univ : Set �
 
 end Decomposition
 
-variable (P Q : Finpartition (Set.univ : Set Ω))
-
-/-- Block averaging over a refinement still reproduces the block integrals of the coarser
-partition.  No hypothesis excluding null parts is needed: a null part of the finer partition cuts
-out a null rectangle, which contributes zero to both sides whatever value the step graphon takes
-there. -/
-theorem stepGraphonAvg_rectIntegral_of_le (hP : ∀ p ∈ P.parts, MeasurableSet p)
-    (hQ : ∀ r ∈ Q.parts, MeasurableSet r) (href : Q ≤ P) (W : Graphon Ω μ) (p q : P.parts) :
-    (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ (p : Set Ω) (q : Set Ω)
-      = W.toSymmKernel.rectIntegral μ (p : Set Ω) (q : Set Ω) :=
-  rectIntegral_eq_of_le_left_right μ hP hP hQ href href
-    (fun r s => stepGraphonAvg_rectIntegral Q hQ W r s) p q
-
 /-- Block averaging over `Q` reproduces the integral over any rectangle whose two sides are parts
 of (possibly different) measurable partitions coarser than `Q`. -/
-theorem stepGraphonAvg_rectIntegral_of_le_left_right
-    {P R Q : Finpartition (Set.univ : Set Ω)}
+theorem stepGraphonAvg_rectIntegral_of_le {P R Q : Finpartition (Set.univ : Set Ω)}
     (hP : ∀ p ∈ P.parts, MeasurableSet p) (hR : ∀ r ∈ R.parts, MeasurableSet r)
     (hQ : ∀ q ∈ Q.parts, MeasurableSet q) (hQP : Q ≤ P) (hQR : Q ≤ R)
     (W : Graphon Ω μ) (p : P.parts) (r : R.parts) :
@@ -151,6 +135,8 @@ theorem stepGraphonAvg_rectIntegral_of_le_left_right
       = W.toSymmKernel.rectIntegral μ (p : Set Ω) (r : Set Ω) :=
   rectIntegral_eq_of_le_left_right μ hP hR hQ hQP hQR
     (fun q q' => stepGraphonAvg_rectIntegral Q hQ W q q') p r
+
+variable (P Q : Finpartition (Set.univ : Set Ω))
 
 /-- On a single block, pairing any kernel against the block-average step graphon multiplies the
 block integral of the kernel by the block average of `W`. -/
@@ -233,7 +219,7 @@ theorem l2inner_stepGraphonAvg_of_le (hP : ∀ p ∈ P.parts, MeasurableSet p)
       = graphonPartitionEnergy μ P hP W := by
   rw [l2inner_stepGraphonAvg_eq_sum, graphonPartitionEnergy_eq_sum]
   exact Finset.sum_congr rfl fun pq _ => by
-    rw [stepGraphonAvg_rectIntegral_of_le μ P Q hP hQ href W pq.1 pq.2]
+    rw [stepGraphonAvg_rectIntegral_of_le μ hP hP hQ href href W pq.1 pq.2]
 
 /-- **The `L²`-Pythagoras energy increment.**  Refining a partition raises the energy by exactly the
 `L²` norm squared of the change in the block-average step graphon.  This is the quantitative driver

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Regularity.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Regularity.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Energy
+
+/-!
+# Frieze--Kannan weak regularity for graphons
+
+This file proves the weak regularity lemma for strict graphons.  Starting from the indiscrete
+finite partition, a cut-norm witness for the current block-average defect cuts every part along
+two measurable sets.  The common refinement has at most four times as many parts, while the
+Pythagoras identity for `graphonPartitionEnergy` and Cauchy--Schwarz show that its energy rises by
+at least `ε²`.  Since the energy stays in `[0, 1]`, the process stops after at most
+`⌈1 / ε²⌉ + 1` steps.
+
+Null parts need no special case: `Finpartition.bipartition` omits empty sets but retains nonempty
+null sets, and `stepGraphonAvg` uses Mathlib's zero set-average convention on their rectangles.
+
+## Main results
+
+* `TauCeti.DenseGraphLimits.exists_refinement_energy_add_sq_le` is the quantitative refinement
+  step: a bad cut-norm approximation yields an energy gain of at least `ε²` while multiplying the
+  number of parts by at most four;
+* `TauCeti.DenseGraphLimits.weak_regularity_frieze_kannan` is the roadmap's Layer-2 weak
+  regularity theorem, with complexity `4 ^ (Nat.ceil (1 / ε ^ 2) + 1)`.
+
+## References
+
+* A. Frieze and R. Kannan, *Quick approximation to matrices and applications*, Combinatorica 19
+  (1999), 175--220.
+* L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), §9.2.
+* Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 2 —
+  `weak_regularity_frieze_kannan` and its null-cell/energy-increment validation gate.
+* The refinement-and-energy iteration follows `Graphon/Regularity.lean` in
+  `cameronfreer/graphon` (Apache 2.0) at commit
+  `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699`, adapted here to Mathlib `Finpartition`, strict
+  block-average graphons, and the Pythagoras energy API.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+
+namespace TauCeti
+
+namespace DenseGraphLimits
+
+variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω) [IsProbabilityMeasure μ]
+
+/-- A cut-norm defect larger than `ε` produces a measurable common refinement with at most four
+times as many parts and graphon partition energy at least `ε²` larger. -/
+theorem exists_refinement_energy_add_sq_le (P : Finpartition (Set.univ : Set Ω))
+    (hP : ∀ p ∈ P.parts, MeasurableSet p) (W : Graphon Ω μ) {ε : ℝ} (hε : 0 < ε)
+    (hbad : ε < cutNorm μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel)) :
+    ∃ (Q : Finpartition (Set.univ : Set Ω)) (hQ : ∀ q ∈ Q.parts, MeasurableSet q),
+      Q ≤ P ∧ Q.parts.card ≤ 4 * P.parts.card ∧
+        graphonPartitionEnergy μ P hP W + ε ^ 2 ≤ graphonPartitionEnergy μ Q hQ W := by
+  let D := W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
+  obtain ⟨S, T, hS, hT, hrect⟩ := exists_lt_abs_rectIntegral μ D hbad
+  have hS_ne : S ≠ ∅ := by
+    intro h
+    subst S
+    simp only [SymmKernel.rectIntegral_empty_left, abs_zero] at hrect
+    linarith
+  have hT_ne : T ≠ ∅ := by
+    intro h
+    subst T
+    simp only [SymmKernel.rectIntegral_empty_right, abs_zero] at hrect
+    linarith
+  let PS := Finpartition.bipartition S
+  let PT := Finpartition.bipartition T
+  let Q := (P ⊓ PS) ⊓ PT
+  have hPS : ∀ p ∈ PS.parts, MeasurableSet p := fun _ hp =>
+    Finpartition.measurableSet_of_mem_bipartition hS hp
+  have hPT : ∀ p ∈ PT.parts, MeasurableSet p := fun _ hp =>
+    Finpartition.measurableSet_of_mem_bipartition hT hp
+  have hPPS : ∀ q ∈ (P ⊓ PS).parts, MeasurableSet q := fun _ hq =>
+    Finpartition.measurableSet_of_mem_inf hP hPS hq
+  have hQ : ∀ q ∈ Q.parts, MeasurableSet q := fun _ hq =>
+    Finpartition.measurableSet_of_mem_inf hPPS hPT hq
+  have hQP : Q ≤ P := le_trans inf_le_left inf_le_left
+  have hQS : Q ≤ PS := le_trans inf_le_left inf_le_right
+  have hQT : Q ≤ PT := inf_le_right
+  have hcard : Q.parts.card ≤ 4 * P.parts.card := by
+    calc
+      Q.parts.card ≤ (P ⊓ PS).parts.card * PT.parts.card :=
+        Finpartition.card_parts_inf_le_mul _ _
+      _ ≤ (P.parts.card * PS.parts.card) * PT.parts.card :=
+        Nat.mul_le_mul_right _ (Finpartition.card_parts_inf_le_mul P PS)
+      _ ≤ (P.parts.card * 2) * 2 := Nat.mul_le_mul
+        (Nat.mul_le_mul_left _ (Finpartition.card_parts_bipartition_le S))
+        (Finpartition.card_parts_bipartition_le T)
+      _ = 4 * P.parts.card := by omega
+  let pS : PS.parts := ⟨S, Finpartition.mem_bipartition_of_ne_empty hS_ne⟩
+  let pT : PT.parts := ⟨T, Finpartition.mem_bipartition_of_ne_empty hT_ne⟩
+  have havg :
+      (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ S T =
+        W.toSymmKernel.rectIntegral μ S T := by
+    simpa [pS, pT] using stepGraphonAvg_rectIntegral_of_le_left_right μ hPS hPT hQ
+      hQS hQT W pS pT
+  let L := (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel -
+    (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
+  have hLrect : L.rectIntegral μ S T = D.rectIntegral μ S T := by
+    simp only [L, D, SymmKernel.rectIntegral_sub, havg]
+  have hsq : ε ^ 2 ≤ (D.rectIntegral μ S T) ^ 2 := by
+    have : ε ^ 2 < |D.rectIntegral μ S T| ^ 2 :=
+      sq_lt_sq' (by linarith [abs_nonneg (D.rectIntegral μ S T)]) hrect
+    simpa only [sq_abs] using this.le
+  have hgain : ε ^ 2 ≤ l2sq μ L := by
+    rw [← hLrect] at hsq
+    exact hsq.trans (sq_rectIntegral_le_l2sq μ L S T)
+  refine ⟨Q, hQ, hQP, hcard, ?_⟩
+  rw [graphonPartitionEnergy_increment μ P Q hP hQ hQP W]
+  simpa only [L, add_comm] using add_le_add_left hgain (graphonPartitionEnergy μ P hP W)
+
+/-- **Frieze--Kannan weak regularity.** Every graphon has a measurable block-average step graphon
+within `ε` in cut norm, on a partition with at most `4 ^ (⌈1 / ε²⌉ + 1)` parts. -/
+theorem weak_regularity_frieze_kannan (W : Graphon Ω μ) {ε : ℝ} (hε : 0 < ε) :
+    ∃ (P : Finpartition (Set.univ : Set Ω)) (hP : ∀ p ∈ P.parts, MeasurableSet p),
+      P.parts.card ≤ 4 ^ (Nat.ceil (1 / ε ^ 2) + 1) ∧
+      cutNorm μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel) ≤ ε := by
+  let N := Nat.ceil (1 / ε ^ 2) + 1
+  let δ := ε ^ 2
+  suffices hiter : ∀ n : ℕ, n ≤ N →
+      ∀ (P : Finpartition (Set.univ : Set Ω)) (hP : ∀ p ∈ P.parts, MeasurableSet p),
+        P.parts.card ≤ 4 ^ (N - n) →
+        ∃ (Q : Finpartition (Set.univ : Set Ω)) (hQ : ∀ q ∈ Q.parts, MeasurableSet q),
+          Q.parts.card ≤ 4 ^ N ∧
+            (cutNorm μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel) ≤ ε ∨
+              graphonPartitionEnergy μ P hP W + (n : ℝ) * δ ≤
+                graphonPartitionEnergy μ Q hQ W) by
+    let P₀ : Finpartition (Set.univ : Set Ω) := ⊤
+    have hP₀ : ∀ p ∈ P₀.parts, MeasurableSet p := by
+      intro p hp
+      have : p = Set.univ := Finset.mem_singleton.mp
+        (Finpartition.parts_top_subset (Set.univ : Set Ω) hp)
+      subst p
+      exact MeasurableSet.univ
+    have hP₀_card : P₀.parts.card ≤ 4 ^ (N - N) := by
+      rw [Nat.sub_self, pow_zero]
+      exact Finset.card_le_one.mpr (Finpartition.parts_top_subsingleton _)
+    obtain ⟨Q, hQ, hQcard, hgood | henergy⟩ := hiter N le_rfl P₀ hP₀ hP₀_card
+    · exact ⟨Q, hQ, by simpa [N] using hQcard, hgood⟩
+    · have hQenergy := graphonPartitionEnergy_le_one μ Q hQ W
+      have hP₀energy := graphonPartitionEnergy_nonneg μ P₀ hP₀ W
+      have hN : 1 < (N : ℝ) * δ := by
+        have hceil : 1 / ε ^ 2 ≤ (Nat.ceil (1 / ε ^ 2) : ℕ) := Nat.le_ceil _
+        dsimp only [N, δ]
+        push_cast
+        have hεsq : 0 < ε ^ 2 := sq_pos_of_pos hε
+        calc
+          1 = (1 / ε ^ 2) * ε ^ 2 := by field_simp
+          _ < ((Nat.ceil (1 / ε ^ 2) : ℕ) + 1 : ℝ) * ε ^ 2 := by nlinarith
+      linarith
+  intro n hn
+  induction n with
+  | zero =>
+      intro P hP hPcard
+      exact ⟨P, hP, by simpa using hPcard, Or.inr (by simp)⟩
+  | succ n ih =>
+      intro P hP hPcard
+      by_cases hgood :
+          cutNorm μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel) ≤ ε
+      · refine ⟨P, hP, ?_, Or.inl hgood⟩
+        exact hPcard.trans (Nat.pow_le_pow_right (by omega) (Nat.sub_le N (n + 1)))
+      · push Not at hgood
+        obtain ⟨Q, hQ, _, hQcard_step, hQenergy⟩ :=
+          exists_refinement_energy_add_sq_le μ P hP W hε hgood
+        have hQcard : Q.parts.card ≤ 4 ^ (N - n) := by
+          have hsub : N - n = (N - (n + 1)) + 1 := by omega
+          calc
+            Q.parts.card ≤ 4 * P.parts.card := hQcard_step
+            _ ≤ 4 * 4 ^ (N - (n + 1)) := Nat.mul_le_mul_left 4 hPcard
+            _ = 4 ^ ((N - (n + 1)) + 1) := by ring
+            _ = 4 ^ (N - n) := by rw [hsub]
+        obtain ⟨R, hR, hRcard, hRgood | hRenergy⟩ := ih (by omega) Q hQ hQcard
+        · exact ⟨R, hR, hRcard, Or.inl hRgood⟩
+        · refine ⟨R, hR, hRcard, Or.inr ?_⟩
+          dsimp only [δ] at hQenergy hRenergy ⊢
+          push_cast
+          nlinarith
+
+end DenseGraphLimits
+
+end TauCeti

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Regularity.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Regularity.lean
@@ -6,6 +6,7 @@ Authors: Codex
 module
 
 public import TauCeti.Combinatorics.DenseGraphLimits.StepGraphon.Energy
+import TauCeti.MeasureTheory.MeasurableSpace.Finpartition
 
 /-!
 # Frieze--Kannan weak regularity for graphons
@@ -104,7 +105,7 @@ theorem exists_refinement_energy_add_sq_le (P : Finpartition (Set.univ : Set Ω)
   have havg :
       (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ S T =
         W.toSymmKernel.rectIntegral μ S T := by
-    simpa [pS, pT] using stepGraphonAvg_rectIntegral_of_le μ pS pT hS hT hQ
+    simpa [pS, pT] using stepGraphonAvg_rectIntegral_of_le_of_le μ pS pT hQ
       hQS hQT W
   let L := (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel -
     (stepGraphonAvg (μ := μ) P hP W).toSymmKernel

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Regularity.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Regularity.lean
@@ -104,8 +104,8 @@ theorem exists_refinement_energy_add_sq_le (P : Finpartition (Set.univ : Set Ω)
   have havg :
       (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ S T =
         W.toSymmKernel.rectIntegral μ S T := by
-    simpa [pS, pT] using stepGraphonAvg_rectIntegral_of_le μ hPS hPT hQ
-      hQS hQT W pS pT
+    simpa [pS, pT] using stepGraphonAvg_rectIntegral_of_le μ pS pT hS hT hQ
+      hQS hQT W
   let L := (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel -
     (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
   have hLrect : L.rectIntegral μ S T = D.rectIntegral μ S T := by

--- a/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Regularity.lean
+++ b/TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Regularity.lean
@@ -34,7 +34,9 @@ null sets, and `stepGraphonAvg` uses Mathlib's zero set-average convention on th
   (1999), 175--220.
 * L. Lovász, *Large Networks and Graph Limits*, AMS Colloquium Publications 60 (2012), §9.2.
 * Roadmap: `TauCetiRoadmap/DenseGraphLimits/README.md`, Layer 2 —
-  `weak_regularity_frieze_kannan` and its null-cell/energy-increment validation gate.
+  `weak_regularity_frieze_kannan` and its null-cell/energy-increment validation gate.  The theorem
+  signature and its `4 ^ (Nat.ceil (1 / ε ^ 2) + 1)` bound are taken from
+  `TauCetiRoadmap/DenseGraphLimits/Suggested.lean` (Layer 2).
 * The refinement-and-energy iteration follows `Graphon/Regularity.lean` in
   `cameronfreer/graphon` (Apache 2.0) at commit
   `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699`, adapted here to Mathlib `Finpartition`, strict
@@ -97,12 +99,12 @@ theorem exists_refinement_energy_add_sq_le (P : Finpartition (Set.univ : Set Ω)
         (Nat.mul_le_mul_left _ (Finpartition.card_parts_bipartition_le S))
         (Finpartition.card_parts_bipartition_le T)
       _ = 4 * P.parts.card := by omega
-  let pS : PS.parts := ⟨S, Finpartition.mem_bipartition_of_ne_empty hS_ne⟩
-  let pT : PT.parts := ⟨T, Finpartition.mem_bipartition_of_ne_empty hT_ne⟩
+  let pS : PS.parts := ⟨S, Finpartition.mem_bipartition_of_ne_bot hS_ne⟩
+  let pT : PT.parts := ⟨T, Finpartition.mem_bipartition_of_ne_bot hT_ne⟩
   have havg :
       (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel.rectIntegral μ S T =
         W.toSymmKernel.rectIntegral μ S T := by
-    simpa [pS, pT] using stepGraphonAvg_rectIntegral_of_le_left_right μ hPS hPT hQ
+    simpa [pS, pT] using stepGraphonAvg_rectIntegral_of_le μ hPS hPT hQ
       hQS hQT W pS pT
   let L := (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel -
     (stepGraphonAvg (μ := μ) P hP W).toSymmKernel
@@ -127,6 +129,8 @@ theorem weak_regularity_frieze_kannan (W : Graphon Ω μ) {ε : ℝ} (hε : 0 < 
       cutNorm μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel) ≤ ε := by
   let N := Nat.ceil (1 / ε ^ 2) + 1
   let δ := ε ^ 2
+  -- Iteration invariant: after `n` allowed refinements, either the approximation is good or the
+  -- energy has grown by `n * δ`, while the starting part budget is `4 ^ (N - n)`.
   suffices hiter : ∀ n : ℕ, n ≤ N →
       ∀ (P : Finpartition (Set.univ : Set Ω)) (hP : ∀ p ∈ P.parts, MeasurableSet p),
         P.parts.card ≤ 4 ^ (N - n) →
@@ -135,6 +139,7 @@ theorem weak_regularity_frieze_kannan (W : Graphon Ω μ) {ε : ℝ} (hε : 0 < 
             (cutNorm μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) Q hQ W).toSymmKernel) ≤ ε ∨
               graphonPartitionEnergy μ P hP W + (n : ℝ) * δ ≤
                 graphonPartitionEnergy μ Q hQ W) by
+    -- Instantiate the invariant at the indiscrete partition and rule out the energy-growth branch.
     let P₀ : Finpartition (Set.univ : Set Ω) := ⊤
     have hP₀ : ∀ p ∈ P₀.parts, MeasurableSet p := by
       intro p hp
@@ -161,9 +166,12 @@ theorem weak_regularity_frieze_kannan (W : Graphon Ω μ) {ε : ℝ} (hε : 0 < 
   intro n hn
   induction n with
   | zero =>
+      -- Base case: keep the current partition; the required energy gain is zero.
       intro P hP hPcard
       exact ⟨P, hP, by simpa using hPcard, Or.inr (by simp)⟩
   | succ n ih =>
+      -- Refinement step: stop if already good, otherwise gain `δ` and apply the induction
+      -- hypothesis to the refined partition with the remaining part budget.
       intro P hP hPcard
       by_cases hgood :
           cutNorm μ (W.toSymmKernel - (stepGraphonAvg (μ := μ) P hP W).toSymmKernel) ≤ ε

--- a/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
@@ -49,16 +49,15 @@ namespace TauCeti
 
 namespace MeasureTheory
 
-/-- Cauchy--Schwarz for a real-valued set integral, in squared form. -/
+/-- Cauchy--Schwarz for a real-valued set integral over a set of finite measure, in squared form. -/
 theorem sq_setIntegral_le_measureReal_mul_setIntegral_sq {Ω : Type*} [MeasurableSpace Ω]
-    {μ : Measure Ω} [IsFiniteMeasure μ] (f : Ω → ℝ) (S : Set Ω) (hf : IntegrableOn f S μ)
-    (hf_sq : IntegrableOn (fun x => f x ^ 2) S μ) :
+    {μ : Measure Ω} (f : Ω → ℝ) (S : Set Ω) (hS_top : μ S ≠ ⊤)
+    (hf : IntegrableOn f S μ) (hf_sq : IntegrableOn (fun x => f x ^ 2) S μ) :
     (∫ x in S, f x ∂μ) ^ 2 ≤ μ.real S * ∫ x in S, f x ^ 2 ∂μ := by
   by_cases hS : μ S = 0
   · rw [Measure.restrict_eq_zero.mpr hS]
     simp
-  · have hS_top : μ S ≠ ⊤ := (measure_lt_top μ S).ne
-    have hS_pos : 0 < μ.real S := ENNReal.toReal_pos hS hS_top
+  · have hS_pos : 0 < μ.real S := ENNReal.toReal_pos hS hS_top
     have hconv : ConvexOn ℝ Set.univ (fun x : ℝ => x ^ 2) :=
       Even.convexOn_pow (by norm_num : Even 2)
     have hjensen := hconv.map_set_average_le (continuous_pow 2).continuousOn isClosed_univ

--- a/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
+++ b/TauCeti/MeasureTheory/Integral/Bochner/Basic.lean
@@ -5,7 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.MeasureTheory.Integral.Bochner.Basic
+public import Mathlib.MeasureTheory.Integral.Bochner.Set
+import Mathlib.Analysis.Convex.Integral
+import Mathlib.Analysis.Convex.Mul
 
 /-!
 # Additional lemmas for the Bochner integral
@@ -17,6 +19,11 @@ extended-nonnegative Lebesgue integrals.
 
 * `ofReal_integral_le_lintegral_ofReal` bounds the positive part of a real-valued
   function's integral by the integral of its pointwise positive part.
+
+## Set integrals
+
+* `sq_setIntegral_le_measureReal_mul_setIntegral_sq` is Cauchy--Schwarz for a real-valued set
+  integral, in squared form.
 
 ## `L¹` convergence
 
@@ -41,6 +48,36 @@ open scoped ENNReal Topology
 namespace TauCeti
 
 namespace MeasureTheory
+
+/-- Cauchy--Schwarz for a real-valued set integral, in squared form. -/
+theorem sq_setIntegral_le_measureReal_mul_setIntegral_sq {Ω : Type*} [MeasurableSpace Ω]
+    {μ : Measure Ω} [IsFiniteMeasure μ] (f : Ω → ℝ) (S : Set Ω) (hf : IntegrableOn f S μ)
+    (hf_sq : IntegrableOn (fun x => f x ^ 2) S μ) :
+    (∫ x in S, f x ∂μ) ^ 2 ≤ μ.real S * ∫ x in S, f x ^ 2 ∂μ := by
+  by_cases hS : μ S = 0
+  · rw [Measure.restrict_eq_zero.mpr hS]
+    simp
+  · have hS_top : μ S ≠ ⊤ := (measure_lt_top μ S).ne
+    have hS_pos : 0 < μ.real S := ENNReal.toReal_pos hS hS_top
+    have hconv : ConvexOn ℝ Set.univ (fun x : ℝ => x ^ 2) :=
+      Even.convexOn_pow (by norm_num : Even 2)
+    have hjensen := hconv.map_set_average_le (continuous_pow 2).continuousOn isClosed_univ
+      hS hS_top (ae_of_all _ fun _ => Set.mem_univ _) hf hf_sq
+    rw [setAverage_eq, setAverage_eq] at hjensen
+    simp only [smul_eq_mul] at hjensen
+    have hkey : (μ.real S)⁻¹ ^ 2 * (∫ x in S, f x ∂μ) ^ 2
+        ≤ (μ.real S)⁻¹ * ∫ x in S, f x ^ 2 ∂μ := by
+      calc
+        (μ.real S)⁻¹ ^ 2 * (∫ x in S, f x ∂μ) ^ 2 =
+            ((μ.real S)⁻¹ * ∫ x in S, f x ∂μ) ^ 2 := by ring
+        _ ≤ _ := hjensen
+    calc
+      (∫ x in S, f x ∂μ) ^ 2 =
+          μ.real S ^ 2 * ((μ.real S)⁻¹ ^ 2 * (∫ x in S, f x ∂μ) ^ 2) := by
+            field_simp
+      _ ≤ μ.real S ^ 2 * ((μ.real S)⁻¹ * ∫ x in S, f x ^ 2 ∂μ) :=
+        mul_le_mul_of_nonneg_left hkey (sq_nonneg _)
+      _ = μ.real S * ∫ x in S, f x ^ 2 ∂μ := by field_simp
 
 /-- The positive part of the integral of a real-valued function is at most the integral of its
 pointwise positive part. No integrability or pointwise sign assumption on `f` is needed. -/

--- a/TauCeti/MeasureTheory/Integral/Finpartition.lean
+++ b/TauCeti/MeasureTheory/Integral/Finpartition.lean
@@ -14,7 +14,8 @@ import Mathlib.Data.Setoid.Partition
 # Integrals split by finite measurable partitions
 
 A measurable finite partition of a measure space decomposes integrals on the product space into
-finite sums over partition rectangles.
+finite sums over partition rectangles.  This file also records that measurable bipartitions and
+common refinements have measurable parts.
 -/
 
 public section
@@ -26,6 +27,23 @@ open MeasureTheory Set
 namespace Finpartition
 
 variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω)
+
+/-- Every part of a bipartition along a measurable set is measurable. -/
+theorem measurableSet_of_mem_bipartition {s p : Set Ω} (hs : MeasurableSet s)
+    (hp : p ∈ (bipartition s).parts) : MeasurableSet p := by
+  rw [parts_bipartition, Finset.mem_erase, Finset.mem_insert, Finset.mem_singleton] at hp
+  rcases hp.2 with rfl | rfl
+  · exact hs
+  · exact hs.compl
+
+/-- The common refinement of two measurable finite partitions is measurable. -/
+theorem measurableSet_of_mem_inf {u : Set Ω} {P Q : Finpartition u}
+    (hP : ∀ p ∈ P.parts, MeasurableSet p) (hQ : ∀ q ∈ Q.parts, MeasurableSet q)
+    {r : Set Ω} (hr : r ∈ (P ⊓ Q).parts) : MeasurableSet r := by
+  rw [Finpartition.parts_inf, Finset.mem_erase, Finset.mem_image] at hr
+  obtain ⟨_, pq, hpq, rfl⟩ := hr
+  rw [Finset.mem_product] at hpq
+  exact (hP pq.1 hpq.1).inter (hQ pq.2 hpq.2)
 
 /-- A finite measurable partition of the carrier cuts a rectangle into finitely many disjoint
 subrectangles, splitting any integral over it into a finite sum. -/

--- a/TauCeti/MeasureTheory/Integral/Finpartition.lean
+++ b/TauCeti/MeasureTheory/Integral/Finpartition.lean
@@ -14,8 +14,7 @@ import Mathlib.Data.Setoid.Partition
 # Integrals split by finite measurable partitions
 
 A measurable finite partition of a measure space decomposes integrals on the product space into
-finite sums over partition rectangles.  This file also records that measurable bipartitions and
-common refinements have measurable parts.
+finite sums over partition rectangles.
 -/
 
 public section
@@ -27,23 +26,6 @@ open MeasureTheory Set
 namespace Finpartition
 
 variable {Ω : Type*} [MeasurableSpace Ω] (μ : Measure Ω)
-
-/-- Every part of a bipartition along a measurable set is measurable. -/
-theorem measurableSet_of_mem_bipartition {s p : Set Ω} (hs : MeasurableSet s)
-    (hp : p ∈ (bipartition s).parts) : MeasurableSet p := by
-  rw [parts_bipartition, Finset.mem_erase, Finset.mem_insert, Finset.mem_singleton] at hp
-  rcases hp.2 with rfl | rfl
-  · exact hs
-  · exact hs.compl
-
-/-- The common refinement of two measurable finite partitions is measurable. -/
-theorem measurableSet_of_mem_inf {u : Set Ω} {P Q : Finpartition u}
-    (hP : ∀ p ∈ P.parts, MeasurableSet p) (hQ : ∀ q ∈ Q.parts, MeasurableSet q)
-    {r : Set Ω} (hr : r ∈ (P ⊓ Q).parts) : MeasurableSet r := by
-  rw [Finpartition.parts_inf, Finset.mem_erase, Finset.mem_image] at hr
-  obtain ⟨_, pq, hpq, rfl⟩ := hr
-  rw [Finset.mem_product] at hpq
-  exact (hP pq.1 hpq.1).inter (hQ pq.2 hpq.2)
 
 /-- A finite measurable partition of the carrier cuts a rectangle into finitely many disjoint
 subrectangles, splitting any integral over it into a finite sum. -/

--- a/TauCeti/MeasureTheory/MeasurableSpace/Finpartition.lean
+++ b/TauCeti/MeasureTheory/MeasurableSpace/Finpartition.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.MeasureTheory.MeasurableSpace.Basic
+public import TauCeti.Order.Partition.Finpartition
+
+/-!
+# Measurable finite partitions
+
+This file records elementary ways to construct measurable finite partitions and shows that
+measurability passes from a finer finite partition to a coarser one.
+-/
+
+public section
+
+open Set
+
+namespace Finpartition
+
+variable {Ω : Type*} [MeasurableSpace Ω]
+
+/-- Every part of a bipartition along a measurable set is measurable. -/
+theorem measurableSet_of_mem_bipartition {s p : Set Ω} (hs : MeasurableSet s)
+    (hp : p ∈ (bipartition s).parts) : MeasurableSet p := by
+  rw [parts_bipartition, Finset.mem_erase, Finset.mem_insert, Finset.mem_singleton] at hp
+  rcases hp.2 with rfl | rfl
+  · exact hs
+  · exact hs.compl
+
+/-- The common refinement of two measurable finite partitions is measurable. -/
+theorem measurableSet_of_mem_inf {u : Set Ω} {P Q : Finpartition u}
+    (hP : ∀ p ∈ P.parts, MeasurableSet p) (hQ : ∀ q ∈ Q.parts, MeasurableSet q)
+    {r : Set Ω} (hr : r ∈ (P ⊓ Q).parts) : MeasurableSet r := by
+  rw [Finpartition.parts_inf, Finset.mem_erase, Finset.mem_image] at hr
+  obtain ⟨_, pq, hpq, rfl⟩ := hr
+  rw [Finset.mem_product] at hpq
+  exact (hP pq.1 hpq.1).inter (hQ pq.2 hpq.2)
+
+/-- A part of a finite partition is measurable when it is a union of parts of a measurable
+refinement. -/
+theorem measurableSet_of_mem_of_le {u : Set Ω} {P Q : Finpartition u}
+    (hQ : ∀ q ∈ Q.parts, MeasurableSet q) (href : Q ≤ P) {p : Set Ω} (hp : p ∈ P.parts) :
+    MeasurableSet p := by
+  classical
+  let parts := Q.parts.filter fun q => q ⊆ p
+  have hp_eq : p = ⋃₀ (parts : Set (Set Ω)) := by
+    ext x
+    constructor
+    · intro hx
+      have hx_parts : x ∈ ⋃₀ (Q.parts : Set (Set Ω)) := by
+        rw [← Finset.sup_id_set_eq_sUnion, Q.sup_parts]
+        exact P.le hp hx
+      obtain ⟨q, hq, hxq⟩ := Set.mem_sUnion.1 hx_parts
+      obtain ⟨p', hp', hqp'⟩ := href hq
+      have hp'p : p' = p := P.disjoint.elim hp' hp <|
+        Set.not_disjoint_iff.2 ⟨x, hqp' hxq, hx⟩
+      exact Set.mem_sUnion.2 ⟨q, Finset.mem_filter.2 ⟨hq, hp'p ▸ hqp'⟩, hxq⟩
+    · intro hx
+      obtain ⟨q, hq, hxq⟩ := Set.mem_sUnion.1 hx
+      exact (Finset.mem_filter.1 hq).2 hxq
+  rw [hp_eq]
+  exact parts.finite_toSet.measurableSet_sUnion fun q hq =>
+    hQ q (Finset.mem_filter.1 hq).1
+
+end Finpartition

--- a/TauCeti/Order/Partition/Finpartition.lean
+++ b/TauCeti/Order/Partition/Finpartition.lean
@@ -10,7 +10,9 @@ public import Mathlib.Order.Partition.Finpartition
 /-!
 # Finite partition helpers
 
-This file contains general-purpose facts about refinements of finite partitions.
+This file contains general-purpose constructions and facts about finite partitions: the partition
+of a set into a chosen subset and its complement, cardinality bounds for common refinements, and
+the behavior of intersections of parts under refinement.
 -/
 
 public section
@@ -18,6 +20,34 @@ public section
 namespace Finpartition
 
 variable {Ω : Type*} {u : Set Ω}
+
+/-- The finite partition of the whole space into a set and its complement, omitting either part
+when it is empty. -/
+noncomputable def bipartition (s : Set Ω) : Finpartition (Set.univ : Set Ω) :=
+  (Finpartition.ofPairwiseDisjoint {s, sᶜ} (by
+    simp [Set.pairwiseDisjoint_insert, disjoint_compl_right])).copy (by simp)
+
+@[simp]
+theorem parts_bipartition (s : Set Ω) :
+    (bipartition s).parts = ({s, sᶜ} : Finset (Set Ω)).erase ∅ :=
+  by simp [bipartition]
+
+/-- A bipartition has at most two parts. -/
+theorem card_parts_bipartition_le (s : Set Ω) : (bipartition s).parts.card ≤ 2 := by
+  rw [parts_bipartition]
+  exact Finset.card_erase_le.trans (Finset.card_insert_le _ _ |>.trans_eq (by simp))
+
+/-- A nonempty set is one of the two parts of its bipartition. -/
+theorem mem_bipartition_of_ne_empty {s : Set Ω} (hs : s ≠ ∅) :
+    s ∈ (bipartition s).parts := by
+  simp [parts_bipartition, hs]
+
+/-- The number of parts in a common refinement is at most the product of the two part counts. -/
+theorem card_parts_inf_le_mul (P Q : Finpartition u) :
+    (P ⊓ Q).parts.card ≤ P.parts.card * Q.parts.card := by
+  rw [Finpartition.parts_inf]
+  exact Finset.card_erase_le.trans
+    (Finset.card_image_le.trans_eq (Finset.card_product _ _))
 
 /-- Under refinement, a part of the finer partition is either contained in a given part of the
 coarser one or disjoint from it. -/

--- a/TauCeti/Order/Partition/Finpartition.lean
+++ b/TauCeti/Order/Partition/Finpartition.lean
@@ -11,43 +11,47 @@ public import Mathlib.Order.Partition.Finpartition
 # Finite partition helpers
 
 This file contains general-purpose constructions and facts about finite partitions: the partition
-of a set into a chosen subset and its complement, cardinality bounds for common refinements, and
-the behavior of intersections of parts under refinement.
+of the top element into an element and its complement, cardinality bounds for common refinements,
+and the behavior of intersections of parts under refinement.
 -/
 
 public section
 
 namespace Finpartition
 
-variable {Ω : Type*} {u : Set Ω}
-
-/-- The finite partition of the whole space into a set and its complement, omitting either part
-when it is empty. -/
-noncomputable def bipartition (s : Set Ω) : Finpartition (Set.univ : Set Ω) :=
+/-- The finite partition of the top element into an element and its complement, omitting either
+part when it is bottom. -/
+noncomputable def bipartition {α : Type*} [BooleanAlgebra α] [DecidableEq α] (s : α) :
+    Finpartition (⊤ : α) :=
   (Finpartition.ofPairwiseDisjoint {s, sᶜ} (by
     simp [Set.pairwiseDisjoint_insert, disjoint_compl_right])).copy (by simp)
 
 @[simp]
-theorem parts_bipartition (s : Set Ω) :
-    (bipartition s).parts = ({s, sᶜ} : Finset (Set Ω)).erase ∅ :=
+theorem parts_bipartition {α : Type*} [BooleanAlgebra α] [DecidableEq α] (s : α) :
+    (bipartition s).parts = ({s, sᶜ} : Finset α).erase ⊥ :=
   by simp [bipartition]
 
 /-- A bipartition has at most two parts. -/
-theorem card_parts_bipartition_le (s : Set Ω) : (bipartition s).parts.card ≤ 2 := by
+theorem card_parts_bipartition_le {α : Type*} [BooleanAlgebra α] [DecidableEq α] (s : α) :
+    (bipartition s).parts.card ≤ 2 := by
   rw [parts_bipartition]
   exact Finset.card_erase_le.trans (Finset.card_insert_le _ _ |>.trans_eq (by simp))
 
-/-- A nonempty set is one of the two parts of its bipartition. -/
-theorem mem_bipartition_of_ne_empty {s : Set Ω} (hs : s ≠ ∅) :
+/-- A non-bottom element is a part of its bipartition. -/
+theorem mem_bipartition_of_ne_bot {α : Type*} [BooleanAlgebra α] [DecidableEq α] {s : α}
+    (hs : s ≠ ⊥) :
     s ∈ (bipartition s).parts := by
   simp [parts_bipartition, hs]
 
 /-- The number of parts in a common refinement is at most the product of the two part counts. -/
-theorem card_parts_inf_le_mul (P Q : Finpartition u) :
+theorem card_parts_inf_le_mul {α : Type*} [DistribLattice α] [OrderBot α] [DecidableEq α]
+    {a : α} (P Q : Finpartition a) :
     (P ⊓ Q).parts.card ≤ P.parts.card * Q.parts.card := by
   rw [Finpartition.parts_inf]
   exact Finset.card_erase_le.trans
     (Finset.card_image_le.trans_eq (Finset.card_product _ _))
+
+variable {Ω : Type*} {u : Set Ω}
 
 /-- Under refinement, a part of the finer partition is either contained in a given part of the
 coarser one or disjoint from it. -/


### PR DESCRIPTION
This PR proves the DenseGraphLimits roadmap's Layer 2 milestone `weak_regularity_frieze_kannan` (`TauCetiRoadmap/DenseGraphLimits/README.md`, "Layer 2 — counting, regularity, total boundedness"): for every `ε > 0`, construct a measurable `Finpartition` with at most `4 ^ (Nat.ceil (1 / ε ^ 2) + 1)` parts whose block-average step graphon is within `ε` in cut norm. After this PR, Layer 2 still needs hom-density descent to `GraphonSpace`, density of step graphons in cut distance, and total boundedness; the Frieze–Kannan milestone itself is complete.

The quantitative step takes measurable sets witnessing a bad cut-norm rectangle, refines the current partition by both bipartitions, proves the part count grows by at most four, and preserves the witness integral through the finer block average. A squared set-integral Cauchy–Schwarz bound and the existing exact Pythagoras identity then force an energy gain of at least `ε²`. Iterating from the indiscrete partition must stop because `graphonPartitionEnergy` lies in `[0, 1]`; the resulting proof gives the roadmap's pinned baseline exponent without an assumed termination principle, positivity shortcut, or non-null-part hypothesis.

Add `TauCeti/Combinatorics/DenseGraphLimits/StepGraphon/Regularity.lean` (191 lines) and make focused supporting extensions in the existing canonical modules for finite partitions, measurable partition integrals, kernel L² estimates, and block-average energy (322 additions and 13 deletions total). The proof follows the refinement-and-energy route in Frieze–Kannan (1999), Lovász, *Large Networks and Graph Limits*, §9.2, and `Graphon/Regularity.lean` from `cameronfreer/graphon` at commit `6eccca5bbe5c9df46d7129bf59575b8b9b1d6699` (Apache 2.0), as credited in the module documentation. No Mathlib infrastructure is vendored.

Roadmap: DenseGraphLimits

<!--tauceti-target:v1 {"focus":"DenseGraphLimits","id":"weak-regularity-frieze-kannan"}-->

🤖 Prepared with Codex
