### PR TITLE
ci: skip duplicate main cache publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           python3 scripts/test_elan_pin.py
           python3 scripts/test_attest_pr_config.py
           python3 scripts/test_profile_workflow.py
+          python3 scripts/test_lake_cache_probe.py
           PYTHONPATH=. python3 scripts/perf/test_perf.py
           PYTHONPATH=scripts python3 scripts/test_claims_access.py
           python3 scripts/test_lint_dot_notation.py
@@ -295,9 +296,31 @@ jobs:
             echo "::notice::Lake cache upload not configured, skipping (set the LAKE_CACHE_ARTIFACT_ENDPOINT / LAKE_CACHE_REVISION_ENDPOINT repo variables and the LAKE_CACHE_KEY secret to enable)"
           fi
 
+      # Merge-group CI normally publishes and publicly confirms the exact commit before GitHub
+      # lands it. Avoid packing and transferring the same map again on main when that happened.
+      # This is deliberately fail-open: only a downloaded, structurally valid exact map sets
+      # exists=true. A direct human merge has no map, and any 404, timeout, service error or
+      # malformed response therefore retains the staging/publication fallback below.
+      - name: Probe for this exact cache on the public endpoint
+        id: exact_cache
+        if: ${{ steps.cachecfg.outputs.enabled == 'true' }}
+        env:
+          PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+          REVISION: ${{ github.sha }}
+        run: |
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+          TOOLCHAIN="$(cat lean-toolchain 2>/dev/null || true)"
+          if python3 scripts/lake_cache_probe.py \
+              "$PUBLIC_REVISION_ENDPOINT" "$TOOLCHAIN" "$REVISION"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Exact Lake cache map is already public; skipping duplicate staging and publication"
+          else
+            echo "::notice::Exact Lake cache map is absent or unreadable; retaining main's publication fallback"
+          fi
+
       - name: Stage TauCeti's oleans for the publish job
         id: stage
-        if: ${{ steps.cachecfg.outputs.enabled == 'true' }}
+        if: ${{ steps.cachecfg.outputs.enabled == 'true' && steps.exact_cache.outputs.exists != 'true' }}
         env:
           # Restated at step level, and the same values the restore step sets job-wide when the
           # public endpoints are configured, so staging works either way: with the restore on,

--- a/scripts/lake_cache_probe.py
+++ b/scripts/lake_cache_probe.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Probe for one exact, publicly readable Tau Ceti Lake cache map.
+
+Exit successfully only when the map for the requested Git revision and Lean toolchain can be
+downloaded from the anonymous read endpoint and has the JSON-lines shape Lake publishes.  Every
+other result is deliberately a miss: main CI uses a miss to retain its staging/publication
+fallback for direct human merges and for transient cache-service failures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.parse
+
+
+REVISION = re.compile(r"\A[0-9a-f]{40}\Z")
+TOOLCHAIN = re.compile(r"\Aleanprover/lean4:[0-9A-Za-z][0-9A-Za-z._+-]*\Z")
+INPUT_HASH = re.compile(r"\A[0-9a-f]{16}\Z")
+ARTIFACT = re.compile(r"\A[0-9a-f]{16}\.ltar\Z")
+
+
+def exact_map_url(endpoint: str, toolchain: str, revision: str) -> str:
+    """Return the public revision-map URL written by ``lake cache put-staged``."""
+    endpoint = endpoint.strip().rstrip("/")
+    parsed = urllib.parse.urlsplit(endpoint)
+    if (parsed.scheme != "https" or not parsed.netloc or parsed.username is not None
+            or parsed.password is not None or parsed.query or parsed.fragment):
+        raise ValueError("the public revision endpoint is not a plain HTTPS URL")
+    if not REVISION.fullmatch(revision):
+        raise ValueError("the revision is not a lowercase 40-character Git object ID")
+    if not TOOLCHAIN.fullmatch(toolchain):
+        raise ValueError("the toolchain is not a leanprover/lean4 release")
+
+    # Lake scopes toolchain-dependent caches by this escaped elan toolchain name.  Keep this in
+    # sync with the confirmation URL in publish-lake-cache.yml.
+    scope = toolchain.replace("/", "--").replace(":", "---")
+    return (f"{endpoint}/TauCetiProject/TauCeti/tc/{scope}/{revision}.jsonl")
+
+
+def valid_map(path: pathlib.Path) -> tuple[bool, str]:
+    """Check enough of Lake's JSONL map shape to reject empty/error responses."""
+    try:
+        lines = 0
+        with path.open(encoding="utf-8") as handle:
+            for lines, line in enumerate(handle, start=1):
+                value = json.loads(line)
+                if lines == 1:
+                    if not isinstance(value, str) or not value:
+                        return False, "the public response has no Lake map-version header"
+                elif (not isinstance(value, list) or len(value) != 2
+                      or not isinstance(value[0], str) or not INPUT_HASH.fullmatch(value[0])
+                      or not isinstance(value[1], str) or not ARTIFACT.fullmatch(value[1])):
+                    return False, f"the public response line {lines} is not a Lake output mapping"
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        return False, f"the public response is not valid JSONL: {exc}"
+    if lines < 2:
+        return False, "the public response contains no root-package output mappings"
+    return True, ""
+
+
+def probe(endpoint: str, toolchain: str, revision: str, runner=None) -> tuple[bool, str, str]:
+    """Return ``(found, url, reason)`` without turning an inconclusive probe into an error."""
+    try:
+        url = exact_map_url(endpoint, toolchain, revision)
+    except ValueError as exc:
+        return False, "", str(exc)
+
+    runner = runner or subprocess.run
+    with tempfile.TemporaryDirectory(prefix="tauceti-cache-probe-") as directory:
+        destination = pathlib.Path(directory) / "outputs.jsonl"
+        try:
+            result = runner(
+                ["curl", "--fail", "--silent", "--show-error", "--max-time", "30",
+                 "--output", str(destination), url],
+                capture_output=True,
+                text=True,
+            )
+        except OSError as exc:
+            return False, url, f"could not run curl: {exc}"
+        if result.returncode != 0:
+            detail = (result.stderr or "").strip()
+            reason = f"curl exited {result.returncode}"
+            return False, url, f"{reason}: {detail}" if detail else reason
+
+        found, reason = valid_map(destination)
+        return found, url, reason
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("endpoint", help="public Lake revision endpoint")
+    parser.add_argument("toolchain", help="contents of lean-toolchain")
+    parser.add_argument("revision", help="exact Tau Ceti Git revision")
+    args = parser.parse_args(argv)
+
+    found, url, reason = probe(args.endpoint, args.toolchain, args.revision)
+    if found:
+        print(f"found valid public Lake cache map: {url}")
+        return 0
+    print(f"no usable exact public Lake cache map: {reason}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_lake_cache_probe.py
+++ b/scripts/test_lake_cache_probe.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Regression tests for main's exact public Lake cache-map probe."""
+
+import pathlib
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import lake_cache_probe as cache_probe  # noqa: E402
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+CI = ROOT / ".github/workflows/ci.yml"
+SHA = "a" * 40
+TOOLCHAIN = "leanprover/lean4:v4.34.0-rc1"
+ENDPOINT = "https://cache.taucetiproject.org/revisions"
+
+
+def response(body: str, returncode: int = 0, stderr: str = ""):
+    """A curl runner that writes ``body`` to the command's requested output path."""
+    def run(command, **_kwargs):
+        pathlib.Path(command[command.index("--output") + 1]).write_text(body)
+        return subprocess.CompletedProcess(command, returncode, "", stderr)
+
+    return run
+
+
+class ExactMapProbe(unittest.TestCase):
+    def test_url_is_the_exact_lake_toolchain_and_revision_scope(self):
+        url = cache_probe.exact_map_url(ENDPOINT + "/", TOOLCHAIN, SHA)
+        self.assertEqual(
+            url,
+            ENDPOINT + "/TauCetiProject/TauCeti/tc/"
+            "leanprover--lean4---v4.34.0-rc1/" + SHA + ".jsonl",
+        )
+
+    def test_only_a_downloaded_valid_map_is_a_hit(self):
+        found, _url, reason = cache_probe.probe(
+            ENDPOINT, TOOLCHAIN, SHA,
+            response('"2026-03-17"\n["44b76000326a96d8","40b5fb725e1abfb8.ltar"]\n'),
+        )
+        self.assertTrue(found, reason)
+
+    def test_a_curl_failure_is_an_inconclusive_miss(self):
+        found, _url, reason = cache_probe.probe(
+            ENDPOINT, TOOLCHAIN, SHA, response("", 22, "HTTP 404"),
+        )
+        self.assertFalse(found)
+        self.assertIn("curl exited 22", reason)
+
+    def test_an_error_page_or_empty_map_is_a_miss(self):
+        for body in ("upstream error\n", '"2026-03-17"\n',
+                     '{"error":"upstream"}\n{"detail":"unavailable"}\n'):
+            with self.subTest(body=body):
+                found, _url, _reason = cache_probe.probe(
+                    ENDPOINT, TOOLCHAIN, SHA, response(body),
+                )
+                self.assertFalse(found)
+
+    def test_untrusted_path_components_cannot_enter_the_url(self):
+        for toolchain, revision in (("../../secret", SHA), (TOOLCHAIN, "../" + SHA)):
+            with self.subTest(toolchain=toolchain, revision=revision):
+                found, url, _reason = cache_probe.probe(
+                    ENDPOINT, toolchain, revision, response(""),
+                )
+                self.assertFalse(found)
+                self.assertEqual(url, "")
+
+
+def step(workflow: str, name: str) -> str:
+    marker = f"      - name: {name}\n"
+    start = workflow.index(marker)
+    end = workflow.find("\n      - name:", start + len(marker))
+    return workflow[start:end if end >= 0 else None]
+
+
+class MainWorkflowFallback(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = CI.read_text()
+
+    def test_probe_defaults_to_publish_and_uses_the_public_exact_identity(self):
+        block = step(self.workflow, "Probe for this exact cache on the public endpoint")
+        self.assertIn("id: exact_cache", block)
+        self.assertIn("steps.cachecfg.outputs.enabled == 'true'", block)
+        self.assertIn("vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC", block)
+        self.assertIn("REVISION: ${{ github.sha }}", block)
+        self.assertIn("python3 scripts/lake_cache_probe.py", block)
+        self.assertLess(block.index('echo "exists=false"'),
+                        block.index("python3 scripts/lake_cache_probe.py"))
+        self.assertLess(block.index("python3 scripts/lake_cache_probe.py"),
+                        block.index('echo "exists=true"'))
+
+    def test_only_a_probe_hit_suppresses_the_existing_staging_fallback(self):
+        block = step(self.workflow, "Stage TauCeti's oleans for the publish job")
+        self.assertIn("steps.cachecfg.outputs.enabled == 'true'", block)
+        self.assertIn("steps.exact_cache.outputs.exists != 'true'", block)
+        self.assertIn('echo "staged=true"', block)
+        self.assertIn("if: ${{ needs.build.outputs.staged == 'true' }}", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR skips main's duplicate Lake cache staging and publication when the exact commit/toolchain revision map is already readable on the public cache. The probe validates the downloaded Lake JSONL map and fails open, so direct human merges, 404s, malformed responses, and service failures retain the existing publication fallback. The new regression tests and the full infrastructure-policy test suite pass locally, including live hit/miss probes against the public endpoint.

Roadmap: none

:robot: Prepared with OpenAI Codex
