### PR TITLE
feat: prove the GLn diagonal torus maximal

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/ClosedImmersion.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/ClosedImmersion.lean
@@ -28,6 +28,8 @@ maximal among tori is a separate geometric step in Layer 7 of the ReductiveGroup
   for the standard basis of its character lattice.
 * `TauCeti.GeneralLinear.diagonalTorus_eq_diagonalGroupSchemeHom`: its equivalent description as
   a diagonalizable-group representation.
+* `TauCeti.GeneralLinear.diagonalTorusCoordinateMap_surjective`: the restriction map from the
+  coordinate ring of `GL_n` onto that of the diagonal torus is surjective.
 * `TauCeti.GeneralLinear.isClosedImmersion_diagonalTorus`: the diagonal torus morphism is a
   closed immersion.
 * `TauCeti.GeneralLinear.diagonalTorusClosedSubgroup`: the diagonal torus as a closed subgroup
@@ -95,6 +97,15 @@ theorem diagonalTorus_eq_diagonalGroupSchemeHom :
           SplitTorus.weightCharacter
             (Pi.basisFun ℤ (ULift.{u} (Fin N)) (ULift.up i)) := by
   rw [diagonalTorus_eq_weightTorus, weightTorus_eq_diagonalGroupSchemeHom]
+
+/-- The coordinate morphism restricting functions on `GL_n` to the diagonal torus is
+surjective. -/
+theorem diagonalTorusCoordinateMap_surjective :
+    Function.Surjective (diagonalTorusCoordinateMap (R := R) (N := N)).hom := by
+  rw [diagonalTorusCoordinateMap_eq_weightTorusCoordinateMap]
+  apply weightTorusCoordinateMap_surjective
+  rw [Set.range_comp', ULift.up_surjective.range_eq, Set.image_univ,
+    (Pi.basisFun ℤ (ULift.{u} (Fin N))).span_eq]
 
 /-- **The diagonal split torus is a closed subgroup scheme of `GL_n` over every commutative
 base ring.** -/

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.DiagonalTorus.ClosedImmersion
+public import TauCeti.Algebra.AlgebraicGroup.Hopf.KernelPoints
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Separation
+
+/-!
+# Maximality of the diagonal torus in the general linear group
+
+Over an algebraically closed field, the diagonal torus of `GL_n` is maximal among reduced
+commutative closed subgroup schemes. In Hopf coordinates, its defining ideal is the kernel of
+the surjective restriction morphism from `O(GL_n)` to the Laurent coordinate ring of the split
+torus.
+
+The proof compares algebraically closed points. A reduced commutative closed subgroup containing
+the diagonal torus gives a commutative matrix subgroup containing all invertible diagonal
+matrices. The point-level centralizer calculation says that this subgroup is exactly the diagonal
+torus. Reduced finite-type point separation then upgrades equality of point subgroups to equality
+of their defining Hopf ideals.
+
+This statement is stronger than maximality among tori: every torus is reduced and commutative,
+whereas the competing subgroup below need not itself be a torus or connected.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.diagonalTorusDefiningIdeal`: the Hopf ideal cutting out the diagonal
+  torus in `GL_n`.
+* `TauCeti.GeneralLinear.quotientPointsSubgroup_diagonalTorusDefiningIdeal`: its points are the
+  range of the diagonal-torus point morphism.
+* `TauCeti.GeneralLinear.eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm`: no larger reduced
+  commutative closed subgroup contains the diagonal torus.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Example 12.6 and Section 21.1.
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), Sections 15.3 and 16.1.
+
+This completes the standard `GL_n` maximal-torus example required by Layer 7, "Borel subgroups,
+maximal tori", of the ReductiveGroups roadmap. Together with the existing adjoint root spaces and
+normalizer quotient, it validates the torus used by the packaged `GL_n` root datum and Weyl group.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.GeneralLinear
+
+universe u
+
+noncomputable section
+
+variable (k : Type u) [Field k] (n : ℕ)
+
+/-- The Hopf ideal defining the diagonal torus inside the coordinate Hopf algebra of `GL_n`.
+
+It is the ordinary kernel of the surjective restriction morphism to the split-torus coordinate
+ring, packaged as a Hopf ideal. -/
+noncomputable def diagonalTorusDefiningIdeal :
+    HopfIdeal k (coordinateHopfAlgebra k n) :=
+  HopfIdeal.kerOfSurjective (diagonalTorusCoordinateMap (R := k) (N := n)).hom
+    (diagonalTorusCoordinateMap_surjective k n)
+
+/-- The points cut out by `diagonalTorusDefiningIdeal` are exactly the diagonal-torus points. -/
+theorem quotientPointsSubgroup_diagonalTorusDefiningIdeal (A : CommAlgCat.{u} k) :
+    CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra k n)
+        (diagonalTorusDefiningIdeal k n) A =
+      ((CommHopfAlgCat.mapPointsFunctor
+        (diagonalTorusCoordinateMap (R := k) (N := n))).app A).hom.range := by
+  rw [diagonalTorusDefiningIdeal,
+    HopfIdeal.quotientPointsSubgroup_kerOfSurjective_eq_range]
+  apply congrArg MonoidHom.range
+  apply MonoidHom.ext
+  intro q
+  rw [AlgHom.mapDomain_apply]
+  exact (CommHopfAlgCat.mapPointsFunctor_app_apply
+    (diagonalTorusCoordinateMap (R := k) (N := n)) A q).symm
+
+variable [IsAlgClosed k]
+
+omit [IsAlgClosed k] in
+private theorem isReduced_quotient_diagonalTorusDefiningIdeal :
+    IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n)
+      (diagonalTorusDefiningIdeal k n)) := by
+  let f := (diagonalTorusCoordinateMap (R := k) (N := n)).hom
+  let hf : Function.Surjective f := diagonalTorusCoordinateMap_surjective k n
+  let e := HopfIdeal.kerLiftBialgEquiv f hf
+  exact isReduced_of_injective e.toAlgEquiv.toRingEquiv.toRingHom e.injective
+
+/-- **The diagonal torus of `GL_n` is maximal among reduced commutative closed subgroup
+schemes over an algebraically closed field.**
+
+If `I` cuts out a reduced commutative closed subgroup containing the diagonal torus, then `I` is
+the diagonal-torus defining ideal. Containment is written contravariantly as
+`I ≤ diagonalTorusDefiningIdeal k n`; commutativity is the cocommutativity of the quotient
+coordinate Hopf algebra. -/
+theorem eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm
+    (I : HopfIdeal k (coordinateHopfAlgebra k n))
+    [IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I)]
+    [Coalgebra.IsCocomm k (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I)]
+    (hI : I ≤ diagonalTorusDefiningIdeal k n) :
+    I = diagonalTorusDefiningIdeal k n := by
+  let U := {x : k // x ∈ ({0} : Set k)ᶜ}
+  let _ : Infinite U := (Set.toFinite ({0} : Set k)).infinite_compl.to_subtype
+  let _ : Nontrivial kˣ := ⟨by
+    obtain ⟨x, y, hxy⟩ := exists_pair_ne U
+    refine ⟨Units.mk0 x (by
+        simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using x.property),
+      Units.mk0 y (by
+        simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using y.property), ?_⟩
+    intro h
+    apply hxy
+    apply Subtype.ext
+    exact congrArg Units.val h⟩
+  let H := coordinateHopfAlgebra k n
+  let D := diagonalTorusDefiningIdeal k n
+  let A := CommAlgCat.of k k
+  let GI := CommHopfAlgCat.quotientPointsSubgroup H I A
+  let GD := CommHopfAlgCat.quotientPointsSubgroup H D A
+  let e := pointsMulEquiv (R := k) (A := k) n
+  let P : Subgroup (GL (Fin n) k) := GI.map e.toMonoidHom
+  let _ : IsMulCommutative GI :=
+    CommHopfAlgCat.instIsMulCommutativeQuotientPointsSubgroup
+      (coordinateHopfAlgebra k n) I (CommAlgCat.of k k)
+  let _ : IsMulCommutative P := Subgroup.map_isMulCommutative GI e.toMonoidHom
+  have hDG : GD ≤ GI :=
+    CommHopfAlgCat.quotientPointsSubgroup_le_of_le H hI A
+  have hdiagonalP : TauCeti.diagonalTorus k n ≤ P := by
+    intro m hm
+    obtain ⟨t, rfl⟩ := mem_diagonalTorus_iff_exists_diagGL.mp hm
+    let s : ULift.{u} (Fin n) → kˣ := fun i ↦ t i.down
+    let q : WithConv
+        (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) →ₐ[k] k) :=
+      (SplitTorus.pointsMulEquiv (R := k) (A := k)).symm s
+    let d := diagonalTorusPoints (R := k) (N := n) (A := k) q
+    have hdD : d ∈ GD := by
+      dsimp only [GD, D]
+      rw [quotientPointsSubgroup_diagonalTorusDefiningIdeal]
+      refine ⟨q, ?_⟩
+      exact mapPointsFunctor_diagonalTorusCoordinateMap_app A q
+    refine ⟨d, hDG hdD, ?_⟩
+    calc
+      e.toMonoidHom d = e d := rfl
+      _ = diagGL (diagonalTorusCoordinates (SplitTorus.pointsMulEquiv q)) := by
+        exact pointsMulEquiv_diagonalTorusPoints q
+      _ = diagGL t := by
+        congr 1
+        have hs : SplitTorus.pointsMulEquiv q = s :=
+          MulEquiv.apply_symm_apply (SplitTorus.pointsMulEquiv (R := k) (A := k)) s
+        funext i
+        rw [diagonalTorusCoordinates_apply, hs]
+  have hP : P = TauCeti.diagonalTorus k n :=
+    eq_diagonalTorus_of_le_of_isMulCommutative P hdiagonalP
+  have hpoints : GI = GD := by
+    apply le_antisymm
+    · intro g hg
+      have hegP : e g ∈ P := ⟨g, hg, rfl⟩
+      have hegD : e g ∈ TauCeti.diagonalTorus k n := hP ▸ hegP
+      obtain ⟨t, ht⟩ := mem_diagonalTorus_iff_exists_diagGL.mp hegD
+      let s : ULift.{u} (Fin n) → kˣ := fun i ↦ t i.down
+      let q : WithConv
+          (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) →ₐ[k] k) :=
+        (SplitTorus.pointsMulEquiv (R := k) (A := k)).symm s
+      have hdiag : e (diagonalTorusPoints (R := k) (N := n) (A := k) q) = diagGL t := by
+        calc
+          e (diagonalTorusPoints (R := k) (N := n) (A := k) q) =
+              diagGL (diagonalTorusCoordinates (SplitTorus.pointsMulEquiv q)) := by
+            exact pointsMulEquiv_diagonalTorusPoints q
+          _ = diagGL t := by
+            congr 1
+            have hs : SplitTorus.pointsMulEquiv q = s :=
+              MulEquiv.apply_symm_apply (SplitTorus.pointsMulEquiv (R := k) (A := k)) s
+            funext i
+            rw [diagonalTorusCoordinates_apply, hs]
+      dsimp only [GD, D]
+      rw [quotientPointsSubgroup_diagonalTorusDefiningIdeal]
+      refine ⟨q, ?_⟩
+      apply e.injective
+      rw [mapPointsFunctor_diagonalTorusCoordinateMap_app]
+      exact hdiag.trans ht
+    · exact hDG
+  let _ : IsReduced (CommHopfAlgCat.quotient H D) :=
+    isReduced_quotient_diagonalTorusDefiningIdeal k n
+  exact HopfIdeal.eq_of_quotientPointsSubgroup_eq hpoints
+
+end
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
@@ -161,6 +161,7 @@ theorem eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm
       refine ⟨q, ?_⟩
       exact mapPointsFunctor_diagonalTorusCoordinateMap_app A q
     refine ⟨d, hDG hdD, ?_⟩
+    -- Unfold the `e.toMonoidHom` coercion introduced by `Subgroup.map` to the coercion of `e`.
     change e d = diagGL t
     simpa only [e, d, q, s] using pointsMulEquiv_diagonalTorusPoints_symm k n t
   have hP : P = TauCeti.diagonalTorus k n :=

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Maximal.lean
@@ -83,6 +83,20 @@ theorem quotientPointsSubgroup_diagonalTorusDefiningIdeal (A : CommAlgCat.{u} k)
 
 variable [IsAlgClosed k]
 
+private instance instNontrivialUnitsOfInfiniteField {F : Type*} [Field F] [Infinite F] :
+    Nontrivial Fˣ := by
+  let U := {x : F // x ∈ ({0} : Set F)ᶜ}
+  let _ : Infinite U := (Set.toFinite ({0} : Set F)).infinite_compl.to_subtype
+  obtain ⟨x, y, hxy⟩ := exists_pair_ne U
+  refine ⟨Units.mk0 x (by
+      simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using x.property),
+    Units.mk0 y (by
+      simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using y.property), ?_⟩
+  intro h
+  apply hxy
+  apply Subtype.ext
+  exact congrArg Units.val h
+
 omit [IsAlgClosed k] in
 private theorem isReduced_quotient_diagonalTorusDefiningIdeal :
     IsReduced (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n)
@@ -91,6 +105,21 @@ private theorem isReduced_quotient_diagonalTorusDefiningIdeal :
   let hf : Function.Surjective f := diagonalTorusCoordinateMap_surjective k n
   let e := HopfIdeal.kerLiftBialgEquiv f hf
   exact isReduced_of_injective e.toAlgEquiv.toRingEquiv.toRingHom e.injective
+
+omit [IsAlgClosed k] in
+private theorem pointsMulEquiv_diagonalTorusPoints_symm (t : Fin n → kˣ) :
+    pointsMulEquiv (R := k) (A := k) n
+        (diagonalTorusPoints
+          ((SplitTorus.pointsMulEquiv (R := k) (A := k)).symm
+            (fun i : ULift.{u} (Fin n) ↦ t i.down))) =
+      diagGL t := by
+  rw [pointsMulEquiv_diagonalTorusPoints]
+  congr 1
+  funext i
+  rw [diagonalTorusCoordinates_apply]
+  exact congrFun
+    ((SplitTorus.pointsMulEquiv (R := k) (A := k)).apply_symm_apply
+      (fun j : ULift.{u} (Fin n) ↦ t j.down)) (ULift.up i)
 
 /-- **The diagonal torus of `GL_n` is maximal among reduced commutative closed subgroup
 schemes over an algebraically closed field.**
@@ -105,18 +134,6 @@ theorem eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm
     [Coalgebra.IsCocomm k (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I)]
     (hI : I ≤ diagonalTorusDefiningIdeal k n) :
     I = diagonalTorusDefiningIdeal k n := by
-  let U := {x : k // x ∈ ({0} : Set k)ᶜ}
-  let _ : Infinite U := (Set.toFinite ({0} : Set k)).infinite_compl.to_subtype
-  let _ : Nontrivial kˣ := ⟨by
-    obtain ⟨x, y, hxy⟩ := exists_pair_ne U
-    refine ⟨Units.mk0 x (by
-        simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using x.property),
-      Units.mk0 y (by
-        simpa only [Set.mem_compl_iff, Set.mem_singleton_iff] using y.property), ?_⟩
-    intro h
-    apply hxy
-    apply Subtype.ext
-    exact congrArg Units.val h⟩
   let H := coordinateHopfAlgebra k n
   let D := diagonalTorusDefiningIdeal k n
   let A := CommAlgCat.of k k
@@ -144,16 +161,8 @@ theorem eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm
       refine ⟨q, ?_⟩
       exact mapPointsFunctor_diagonalTorusCoordinateMap_app A q
     refine ⟨d, hDG hdD, ?_⟩
-    calc
-      e.toMonoidHom d = e d := rfl
-      _ = diagGL (diagonalTorusCoordinates (SplitTorus.pointsMulEquiv q)) := by
-        exact pointsMulEquiv_diagonalTorusPoints q
-      _ = diagGL t := by
-        congr 1
-        have hs : SplitTorus.pointsMulEquiv q = s :=
-          MulEquiv.apply_symm_apply (SplitTorus.pointsMulEquiv (R := k) (A := k)) s
-        funext i
-        rw [diagonalTorusCoordinates_apply, hs]
+    change e d = diagGL t
+    simpa only [e, d, q, s] using pointsMulEquiv_diagonalTorusPoints_symm k n t
   have hP : P = TauCeti.diagonalTorus k n :=
     eq_diagonalTorus_of_le_of_isMulCommutative P hdiagonalP
   have hpoints : GI = GD := by
@@ -167,16 +176,7 @@ theorem eq_diagonalTorusDefiningIdeal_of_le_of_isCocomm
           (MonoidAlgebra k (Multiplicative (ULift.{u} (Fin n) →₀ ℤ)) →ₐ[k] k) :=
         (SplitTorus.pointsMulEquiv (R := k) (A := k)).symm s
       have hdiag : e (diagonalTorusPoints (R := k) (N := n) (A := k) q) = diagGL t := by
-        calc
-          e (diagonalTorusPoints (R := k) (N := n) (A := k) q) =
-              diagGL (diagonalTorusCoordinates (SplitTorus.pointsMulEquiv q)) := by
-            exact pointsMulEquiv_diagonalTorusPoints q
-          _ = diagGL t := by
-            congr 1
-            have hs : SplitTorus.pointsMulEquiv q = s :=
-              MulEquiv.apply_symm_apply (SplitTorus.pointsMulEquiv (R := k) (A := k)) s
-            funext i
-            rw [diagonalTorusCoordinates_apply, hs]
+        simpa only [e, q, s] using pointsMulEquiv_diagonalTorusPoints_symm k n t
       dsimp only [GD, D]
       rw [quotientPointsSubgroup_diagonalTorusDefiningIdeal]
       refine ⟨q, ?_⟩

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Torus.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Torus.lean
@@ -42,6 +42,8 @@ No faithfulness is asserted: an arbitrary weight family may have a common kernel
 * `TauCeti.GeneralLinear.weightCharacterMap`: the homomorphism on character lattices.
 * `TauCeti.GeneralLinear.weightTorusCoordinateMap`: the coordinate Hopf-algebra morphism of the
   represented weight torus.
+* `TauCeti.GeneralLinear.weightTorusCoordinateMap_surjective`: spanning weights make the
+  coordinate morphism surjective.
 * `TauCeti.GeneralLinear.weightTorusCoordinateBialgHom`: its direct diagonal-representation form,
   allowing the base ring and torus index to live in different universes.
 * `TauCeti.GeneralLinear.weightTorusBaseChangeCoordinateMap`: that morphism base changed along
@@ -194,6 +196,15 @@ theorem hom_weightTorusCoordinateMap (wt : Fin N → κ → ℤ) :
   apply coordinateHopfAlgebra_bialgHom_ext R N
   intro i j
   rw [weightTorusCoordinateMap_X, weightTorusCoordinateBialgHom_X]
+
+/-- A spanning family of weights makes the weight-torus coordinate morphism surjective. -/
+theorem weightTorusCoordinateMap_surjective (wt : Fin N → κ → ℤ)
+    (hwt : Submodule.span ℤ (Set.range wt) = ⊤) :
+    Function.Surjective (weightTorusCoordinateMap (R := R) wt).hom := by
+  let _ : Fintype κ := Fintype.ofFinite κ
+  rw [hom_weightTorusCoordinateMap, weightTorusCoordinateBialgHom]
+  apply DiagonalizableGroup.surjective_diagonalCoordinateMap
+  exact SplitTorus.closure_range_weightCharacter_eq_top wt hwt
 
 /-- The group-scheme morphism from a split torus to `GL_N` prescribed by a family of weights.
 It factors through the diagonal torus: the `i`-th diagonal entry is the character `wt i`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Hopf/KernelPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Hopf/KernelPoints.lean
@@ -37,6 +37,8 @@ closed-subgroup inclusion assumes the source Hopf algebra `H` is commutative.
   the inverse equivalence with the quotient-points inclusion.
 * `TauCeti.HopfIdeal.quotientPointsHom_quotientKerPointsMulEquiv_apply`: the corresponding
   compatibility for an arbitrary point of the kernel quotient.
+* `TauCeti.HopfIdeal.quotientPointsSubgroup_kerOfSurjective_eq_range`: the subgroup cut out by
+  the kernel consists exactly of points obtained by pre-composition with the morphism.
 
 ## References
 
@@ -169,6 +171,22 @@ theorem quotientPointsHom_quotientKerPointsMulEquiv_apply_apply (f : H →ₐc[R
         (kerOfSurjective f hf) A g).ofConv h =
       (quotientKerPointsMulEquiv f hf A g).ofConv (f h) := by
   rw [quotientPointsHom_quotientKerPointsMulEquiv_apply, AlgHom.mapDomain_apply_apply]
+
+/-- The closed subgroup cut out by the kernel of a surjective Hopf-algebra morphism has, on
+every value algebra, exactly the points obtained by pre-composition with that morphism. -/
+theorem quotientPointsSubgroup_kerOfSurjective_eq_range (f : H →ₐc[R] K)
+    (hf : Function.Surjective f) (A : CommAlgCat.{x} R) :
+    CommHopfAlgCat.quotientPointsSubgroup (_root_.CommHopfAlgCat.of R H)
+        (kerOfSurjective f hf) A =
+      (AlgHom.mapDomain (A := A) f).range := by
+  ext g
+  constructor
+  · rintro ⟨q, rfl⟩
+    exact ⟨quotientKerPointsMulEquiv f hf A q,
+      (quotientPointsHom_quotientKerPointsMulEquiv_apply f hf A q).symm⟩
+  · rintro ⟨q, rfl⟩
+    exact ⟨(quotientKerPointsMulEquiv f hf A).symm q,
+      quotientPointsHom_quotientKerPointsMulEquiv_symm_apply f hf A q⟩
 
 end CommSource
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Separation.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Separation.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Order
+public import TauCeti.RingTheory.FiniteType.PointSeparation
+
+/-!
+# Recovering reduced closed subgroups from geometric points
+
+Let `H` be a commutative Hopf algebra over an algebraically closed field. A Hopf ideal `I`
+cuts out the subgroup of points of `H` that vanish on `I`. If the quotient `H/I` is reduced and
+of finite type, its points separate functions, so this subgroup determines `I`.
+
+The order statement is contravariant: if every point cut out by `J` is also cut out by `I`, then
+`I ≤ J`, provided `H/J` is reduced and of finite type. Applying it in both directions shows that
+two reduced finite-type closed subgroups with the same points have the same defining Hopf ideal.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.le_of_quotientPointsSubgroup_le`: recover an inclusion of Hopf ideals from
+  the reverse inclusion of their algebraically closed point subgroups.
+* `TauCeti.HopfIdeal.eq_of_quotientPointsSubgroup_eq`: reduced finite-type closed subgroups are
+  determined by their algebraically closed points.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Sections 1.d and 2.a.
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, Section 3.2.
+
+This is the point-separation input for the maximal-torus step in Layer 7 of the ReductiveGroups
+roadmap. It allows pointwise centralizer calculations to determine reduced closed subgroup
+schemes.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u v
+
+namespace HopfIdeal
+
+variable {k : Type u} [Field k] [IsAlgClosed k]
+variable {H : _root_.CommHopfAlgCat.{v} k} {I J : HopfIdeal k H}
+
+/-- Recover an inclusion of Hopf ideals from the reverse inclusion of their point subgroups.
+
+Only the quotient by the ideal on the right of the conclusion must be reduced and of finite
+type. Those hypotheses make its `k`-valued points separate functions. -/
+theorem le_of_quotientPointsSubgroup_le
+    [Algebra.FiniteType k (CommHopfAlgCat.quotient H J)]
+    [IsReduced (CommHopfAlgCat.quotient H J)]
+    (hpoints : CommHopfAlgCat.quotientPointsSubgroup H J (CommAlgCat.of k k) ≤
+      CommHopfAlgCat.quotientPointsSubgroup H I (CommAlgCat.of k k)) :
+    I ≤ J := by
+  intro x hx
+  apply HopfIdeal.mem_toIdeal.mp
+  apply Ideal.Quotient.eq_zero_iff_mem.mp
+  apply eq_of_forall_algHom_apply_eq (k := k) (K := k)
+  intro f
+  let g : HopfAlgebra.points (R := k) (H := H) (CommAlgCat.of k k) :=
+    CommHopfAlgCat.quotientPointsHom H J (CommAlgCat.of k k) (toConv f)
+  have hgJ : g ∈ CommHopfAlgCat.quotientPointsSubgroup H J (CommAlgCat.of k k) :=
+    CommHopfAlgCat.quotientPointsHom_mem_quotientPointsSubgroup H J
+      (CommAlgCat.of k k) (toConv f)
+  have hgI := hpoints hgJ
+  rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff] at hgI
+  have hzero :
+      ((CommHopfAlgCat.quotientPointsHom H J (CommAlgCat.of k k) (toConv f)).ofConv) x = 0 :=
+    by simpa only [g] using hgI x hx
+  rw [CommHopfAlgCat.quotientPointsHom_apply_apply] at hzero
+  simpa only [WithConv.ofConv_toConv, map_zero, Ideal.Quotient.mkₐ_eq_mk] using hzero
+
+/-- Two reduced finite-type closed subgroups of an affine group over an algebraically closed
+field have the same defining Hopf ideal when they have the same points. -/
+theorem eq_of_quotientPointsSubgroup_eq
+    [Algebra.FiniteType k (CommHopfAlgCat.quotient H I)]
+    [IsReduced (CommHopfAlgCat.quotient H I)]
+    [Algebra.FiniteType k (CommHopfAlgCat.quotient H J)]
+    [IsReduced (CommHopfAlgCat.quotient H J)]
+    (hpoints : CommHopfAlgCat.quotientPointsSubgroup H I (CommAlgCat.of k k) =
+      CommHopfAlgCat.quotientPointsSubgroup H J (CommAlgCat.of k k)) :
+    I = J := by
+  apply le_antisymm
+  · apply le_of_quotientPointsSubgroup_le
+    rw [hpoints]
+  · apply le_of_quotientPointsSubgroup_le
+    rw [hpoints]
+
+end HopfIdeal
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the standard diagonal torus of `GL_n` over an algebraically closed field is maximal among reduced commutative closed subgroup schemes. It follows the exact Layer 7 target “Borel subgroups, maximal tori” in `TauCetiRoadmap/ReductiveGroups/README.md`, specifically the standard `GL_n` maximal-torus example needed by the packaged root datum and Weyl group.

The proof packages the diagonal torus's defining Hopf ideal, identifies its points through the surjective coordinate restriction, applies the existing point-level centralizer theorem for invertible diagonal matrices, and uses reduced finite-type point separation to recover equality of Hopf ideals. The supporting lemmas also record that the kernel of a surjective Hopf morphism cuts out exactly the range on points and that algebraically closed points determine reduced finite-type Hopf quotients.

This is the most direct remaining step on the `GL_n` branch of the milestone after the diagonal closed immersion, root datum, and normalizer quotient landed. After this PR, the broader Layer 7 milestone still needs the general existence/conjugacy theory for maximal tori and Borel subgroups and its integration with the reductive-group API.

The coordinate-surjectivity proof reuses Tau Ceti's existing `DiagonalizableGroup.surjective_diagonalCoordinateMap`; the scheme-to-points passage reuses Tau Ceti's Hopf-kernel equivalence and finite-type point-separation infrastructure. No external implementation is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"gln-diagonal-torus-maximal"}-->

🤖 Prepared with Codex

