### PR TITLE
feat: compute Ext-Euler forms from projective resolutions

### DIFF
--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Basic.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Basic.lean
@@ -57,6 +57,8 @@ The value is defined by truncating the sum to the degrees below an explicit boun
   either variable, and `TauCeti.IsEulerAdmissible.biprod`,
   `TauCeti.IsEulerAdmissible.biprod'` under binary direct sums; the empty direct sum is covered by
   `TauCeti.IsEulerAdmissible.of_isZero_left` and `TauCeti.IsEulerAdmissible.of_isZero_right`.
+* `TauCeti.IsExtFinite.of_shortExact₃'`: `Ext`-finiteness also passes from the subobject and the
+  middle object of a short exact sequence to its quotient, in the first variable.
 * `TauCeti.IsExtFinite.finiteDimensional_hom`: Hom-finiteness is the degree-zero consequence of
   `Ext`-finiteness, and is kept as a separate predicate.
 * `TauCeti.extEuler_projective`: **projective evaluation**, `χ(P, Y) = dim_k Hom(P, Y)`.
@@ -298,6 +300,24 @@ theorem IsExtFinite.of_shortExact₂' (hS : S.ShortExact) {Y : C} (h₁ : IsExtF
   ⟨fun n ↦ haveI := h₁.finiteDimensional n
     haveI := h₃.finiteDimensional n
     finiteDimensional_of_exact (exact_precompOfLinear k hS Y n)⟩
+
+/-- `Ext`-finiteness passes to the quotient term of a short exact sequence, along the first
+variable: the long exact sequence exhibits `Extⁿ⁺¹(S.X₃, Y)` between `Extⁿ(S.X₁, Y)` and
+`Extⁿ⁺¹(S.X₂, Y)`, and its degree-zero group is a subspace of `Hom(S.X₂, Y)`. -/
+theorem IsExtFinite.of_shortExact₃' (hS : S.ShortExact) {Y : C} (h₁ : IsExtFinite.{w} k S.X₁ Y)
+    (h₂ : IsExtFinite.{w} k S.X₂ Y) : IsExtFinite.{w} k S.X₃ Y := by
+  refine ⟨fun n ↦ ?_⟩
+  match n with
+  | 0 =>
+      have := hS.epi_g
+      have := h₂.finiteDimensional 0
+      refine FiniteDimensional.of_injective
+        (Ext.precompOfLinear (Ext.mk₀ S.g) k Y (zero_add 0)) ?_
+      simpa only [coe_precompOfLinear] using Ext.precomp_mk₀_injective_of_epi Y S.g
+  | n + 1 =>
+      have := h₁.finiteDimensional n
+      have := h₂.finiteDimensional (n + 1)
+      exact finiteDimensional_of_exact (exact_precompOfLinear₃ k hS Y n (n + 1) (Nat.one_add n))
 
 /-- **Extension closure in the second variable** for eventual `Ext`-vanishing: the middle term of
 a short exact sequence inherits the larger of the two outer bounds. -/

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Descent.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Descent.lean
@@ -181,10 +181,7 @@ private theorem truncatedExtEuler_shortExact_correction₁ {S : ShortComplex C} 
     have h := Ext.contravariant_sequence_exact₁' hS Y n (n + 1) (Nat.one_add n)
     rw [ShortComplex.ab_exact_iff_function_exact] at h
     exact h
-  · intro n
-    have h := Ext.contravariant_sequence_exact₃' hS Y n (n + 1) (Nat.one_add n)
-    rw [ShortComplex.ab_exact_iff_function_exact] at h
-    exact h
+  · exact fun n ↦ exact_precompOfLinear₃ k hS Y n (n + 1) (Nat.one_add n)
 
 /-! ### Additivity on short exact sequences -/
 

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Resolution.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Resolution.lean
@@ -1,0 +1,212 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Homology.EulerCharacteristic.ExtEuler.Descent
+public import TauCeti.CategoryTheory.Exact.Projective
+
+/-!
+# The Ext-Euler characteristic from a finite projective resolution
+
+Let `C` be a `k`-linear abelian category. A finite projective resolution
+
+```text
+0 ⟶ Pₙ ⟶ ⋯ ⟶ P₁ ⟶ P₀ ⟶ X ⟶ 0
+```
+
+computes the Ext-Euler characteristic against `Y` as the alternating Hom dimension
+
+```text
+χ(X, Y) = ∑ i, (-1)ⁱ dimₖ Hom(Pᵢ, Y).
+```
+
+The only finiteness hypothesis needed on the resolution is that every resolving object has a
+finite-dimensional Hom space into `Y`. Projectivity makes its higher `Ext` groups vanish. The
+long exact Ext sequence then proves, from the far end of the resolution towards `X`, both that
+`(X, Y)` is Euler-admissible and that the displayed formula holds.
+
+The auxiliary `of_shortExact₃'` lemmas below are the first-variable two-out-of-three statements
+needed by that induction: for a short exact sequence `X₁ ⟶ X₂ ⟶ X₃`, finiteness and
+eventual vanishing for `(X₁, Y)` and `(X₂, Y)` imply the corresponding property for `(X₃, Y)`.
+
+## Main definitions
+
+* `TauCeti.ExactStructure.FiniteResolution.homEuler`: the alternating Hom dimension of the terms
+  of a finite resolution.
+
+## Main results
+
+* `TauCeti.ExactStructure.FiniteResolution.isEulerAdmissible`: a Hom-finite finite projective
+  resolution makes the resolved pair Euler-admissible.
+* `TauCeti.ExactStructure.FiniteResolution.extEuler_eq_homEuler`: every admissibility witness gives
+  the Ext-Euler characteristic as the alternating Hom dimension of the resolution.
+
+## References
+
+* Charles A. Weibel, *An Introduction to Homological Algebra*, Sections 2.4--2.7, for the long
+  exact Ext sequence and computation of Ext by projective resolutions.
+* Ibrahim Assem, Daniel Simson, and Andrzej Skowroński, *Elements of the Representation Theory of
+  Associative Algebras, Volume 1*, Chapter III, Proposition 3.13, for the resulting Euler-form
+  formula over a finite-dimensional algebra.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Abelian CategoryTheory.Limits
+
+universe w v u t
+
+variable {C : Type u} [Category.{v} C] [Abelian C] {k : Type t} [Field k] [Linear k C]
+  [HasExt.{w} C]
+
+/-! ### Two-out-of-three towards the quotient term -/
+
+variable {S : ShortComplex C} {Y : C}
+
+/-- In the first-variable long exact Ext sequence, Ext-finiteness of the subobject and middle
+object implies Ext-finiteness of the quotient. -/
+theorem IsExtFinite.of_shortExact₃' (hS : S.ShortExact)
+    (h₁ : IsExtFinite.{w} k S.X₁ Y) (h₂ : IsExtFinite.{w} k S.X₂ Y) :
+    IsExtFinite.{w} k S.X₃ Y := by
+  refine ⟨fun n ↦ ?_⟩
+  match n with
+  | 0 =>
+      let _ := hS.epi_g
+      let _ := h₂.finiteDimensional 0
+      exact FiniteDimensional.of_injective
+        (Ext.precompOfLinear (Ext.mk₀ S.g) k Y (zero_add 0))
+        (Ext.precomp_mk₀_injective_of_epi Y S.g)
+  | n + 1 =>
+      let _ := h₁.finiteDimensional n
+      let _ := h₂.finiteDimensional (n + 1)
+      have h := Ext.contravariant_sequence_exact₃' hS Y n (n + 1) (Nat.one_add n)
+      rw [ShortComplex.ab_exact_iff_function_exact] at h
+      -- Mathlib states this through `AddCommGrpCat`; expose the underlying functions so the
+      -- same exactness proof applies to the linear refinements.
+      change Function.Exact (Ext.precomp hS.extClass Y (Nat.one_add n))
+        (Ext.precomp (Ext.mk₀ S.g) Y (zero_add (n + 1))) at h
+      exact finiteDimensional_of_exact
+        (f := Ext.precompOfLinear hS.extClass k Y (Nat.one_add n))
+        (g := Ext.precompOfLinear (Ext.mk₀ S.g) k Y (zero_add (n + 1)))
+        h
+
+/-- In the first-variable long exact Ext sequence, bounds for the subobject and middle object
+give a bound for the quotient. A bound `N₁` for the subobject is shifted by one degree. -/
+theorem IsExtBoundedBy.of_shortExact₃' (hS : S.ShortExact) {N₁ N₂ : ℕ}
+    (h₁ : IsExtBoundedBy.{w} S.X₁ Y N₁) (h₂ : IsExtBoundedBy.{w} S.X₂ Y N₂) :
+    IsExtBoundedBy.{w} S.X₃ Y (max (N₁ + 1) N₂) := by
+  refine ⟨fun {n} hn ↦ ?_⟩
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : n ≠ 0)
+  let _ := h₁.subsingleton (by omega : N₁ ≤ m)
+  let _ := h₂.subsingleton (by omega : N₂ ≤ m + 1)
+  have h := Ext.contravariant_sequence_exact₃' hS Y m (m + 1) (Nat.one_add m)
+  rw [ShortComplex.ab_exact_iff_function_exact] at h
+  -- As above, remove only the concrete-category wrapper from Mathlib's exactness statement.
+  change Function.Exact (Ext.precomp hS.extClass Y (Nat.one_add m))
+    (Ext.precomp (Ext.mk₀ S.g) Y (zero_add (m + 1))) at h
+  exact subsingleton_of_exact
+    (f := Ext.precomp hS.extClass Y (Nat.one_add m))
+    (g := Ext.precomp (Ext.mk₀ S.g) Y (zero_add (m + 1))) h (map_zero _)
+
+/-- Euler-admissibility for the subobject and middle object of a short exact sequence implies
+Euler-admissibility for its quotient, in the first variable. -/
+theorem IsEulerAdmissible.of_shortExact₃' (hS : S.ShortExact)
+    (h₁ : IsEulerAdmissible.{w} k S.X₁ Y) (h₂ : IsEulerAdmissible.{w} k S.X₂ Y) :
+    IsEulerAdmissible.{w} k S.X₃ Y := by
+  obtain ⟨N₁, hN₁⟩ := h₁.isExtBounded.exists_bound
+  obtain ⟨N₂, hN₂⟩ := h₂.isExtBounded.exists_bound
+  exact ⟨h₁.isExtFinite.of_shortExact₃' hS h₂.isExtFinite,
+    (hN₁.of_shortExact₃' hS hN₂).isExtBounded⟩
+
+/-! ### Alternating Hom dimension of a finite resolution -/
+
+namespace ExactStructure.FiniteResolution
+
+variable {P : ObjectProperty C} {X Y : C}
+
+/-- The alternating Hom dimension of a finite resolution against `Y`:
+`dim Hom(P₀,Y) - dim Hom(P₁,Y) + ⋯ + (-1)ⁿ dim Hom(Pₙ,Y)`.
+
+As with `TauCeti.truncatedExtEuler`, this definition is total: `Module.finrank` has its usual
+zero fallback when a Hom space is not finite-dimensional. The theorems below assume Hom-finiteness,
+so every summand there is an actual dimension. -/
+noncomputable def homEuler (k : Type t) [Field k] [Linear k C] (Y : C) :
+    ∀ {X : C}, (ExactStructure.abelian C).FiniteResolution P X → ℤ
+  | X, .base _ => Module.finrank k (X ⟶ Y)
+  | _, .step (Q := Q) _ _ _ _ _ r => Module.finrank k (Q ⟶ Y) - r.homEuler k Y
+
+omit [HasExt.{w} C] in
+/-- A length-zero resolution has Hom-Euler characteristic equal to its Hom dimension. -/
+@[simp]
+theorem homEuler_base (hX : P X) :
+    (base (E := ExactStructure.abelian C) hX).homEuler k Y = Module.finrank k (X ⟶ Y) :=
+  (rfl)
+
+omit [HasExt.{w} C] in
+/-- Prepending a resolving term subtracts the Hom-Euler characteristic of the remaining
+resolution from the Hom dimension of that term. -/
+@[simp]
+theorem homEuler_step {K Q : C} (hQ : P Q) (i : K ⟶ Q) (p : Q ⟶ X) (zero : i ≫ p = 0)
+    (hp : (ExactStructure.abelian C).Conflation (ShortComplex.mk i p zero))
+    (r : (ExactStructure.abelian C).FiniteResolution P K) :
+    (step hQ i p zero hp r).homEuler k Y = Module.finrank k (Q ⟶ Y) - r.homEuler k Y :=
+  (rfl)
+
+/-- A finite resolution by projectives whose Hom spaces into `Y` are finite-dimensional makes
+the resolved pair `(X,Y)` Euler-admissible. -/
+theorem isEulerAdmissible
+    (r : (ExactStructure.abelian C).FiniteResolution P X)
+    (hproj : P ≤ (ExactStructure.abelian C).isProjective)
+    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y)) :
+    IsEulerAdmissible.{w} k X Y := by
+  induction r with
+  | @base X hX =>
+      let _ : Projective X := (ExactStructure.abelian_isProjective_iff X).mp (hproj X hX)
+      let _ := hHom X hX
+      exact isEulerAdmissible_of_projective k X Y
+  | @step K Q X hQ i p zero hp r ih =>
+      let _ : Projective Q := (ExactStructure.abelian_isProjective_iff Q).mp (hproj Q hQ)
+      let _ := hHom Q hQ
+      exact ih.of_shortExact₃' ((ExactStructure.abelian_conflation _).mp hp)
+        (isEulerAdmissible_of_projective k Q Y)
+
+/-- **Finite-projective-resolution formula for the Ext-Euler characteristic.** The value of
+`χ(X,Y)` is the alternating sum of the dimensions of `Hom(Pᵢ,Y)` along any finite `P`-resolution
+of `X`, provided the `P`-objects are projective and those Hom spaces are finite-dimensional. -/
+theorem extEuler_eq_homEuler
+    (r : (ExactStructure.abelian C).FiniteResolution P X)
+    (hproj : P ≤ (ExactStructure.abelian C).isProjective)
+    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y))
+    (h : IsEulerAdmissible.{w} k X Y) :
+    extEuler.{w} k h = r.homEuler k Y := by
+  induction r with
+  | @base X hX =>
+      let _ : Projective X := (ExactStructure.abelian_isProjective_iff X).mp (hproj X hX)
+      exact extEuler_projective k h
+  | @step K Q X hQ i p zero hp r ih =>
+      let _ : Projective Q := (ExactStructure.abelian_isProjective_iff Q).mp (hproj Q hQ)
+      let _ := hHom Q hQ
+      have hK := r.isEulerAdmissible hproj hHom
+      have hQ' := isEulerAdmissible_of_projective k Q Y
+      have hadd := extEuler_shortExact₁ ((ExactStructure.abelian_conflation _).mp hp) Y hK hQ' h
+      have hQeval := extEuler_projective k hQ'
+      rw [homEuler_step, ← ih hK]
+      omega
+
+/-- The alternating Hom dimension is independent of the chosen finite projective resolution. -/
+theorem homEuler_eq_homEuler
+    (r s : (ExactStructure.abelian C).FiniteResolution P X)
+    (hproj : P ≤ (ExactStructure.abelian C).isProjective)
+    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y)) :
+    r.homEuler k Y = s.homEuler k Y := by
+  have h := r.isEulerAdmissible hproj hHom
+  rw [← r.extEuler_eq_homEuler hproj hHom h, ← s.extEuler_eq_homEuler hproj hHom h]
+
+end ExactStructure.FiniteResolution
+
+end TauCeti

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Resolution.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Resolution.lean
@@ -40,12 +40,14 @@ and that the displayed formula holds.
 
 * `TauCeti.ExactStructure.FiniteResolution.hasProjectiveDimensionLT`: a finite resolution by
   projectives bounds the projective dimension of the resolved object by its length.
-* `TauCeti.ExactStructure.FiniteResolution.isExtBoundedBy` and
-  `TauCeti.ExactStructure.FiniteResolution.isExtFinite`: the two halves of Euler-admissibility,
-  with the explicit vanishing bound `r.length + 1`; they are packaged as
-  `TauCeti.ExactStructure.FiniteResolution.isEulerAdmissible`.
-* `TauCeti.ExactStructure.FiniteResolution.extEuler_eq_homEuler`: every admissibility witness gives
-  the Ext-Euler characteristic as the alternating Hom dimension of the resolution.
+* `TauCeti.ExactStructure.FiniteResolution.isExtBoundedBy`: a finite resolution by projectives
+  makes the `Ext` groups vanish from degree `r.length + 1` on.
+* `TauCeti.ExactStructure.FiniteResolution.isExtFinite`: `Ext`-finiteness propagates along a
+  finite resolution from its resolving terms to the resolved object. Together with the previous
+  result it gives `TauCeti.ExactStructure.FiniteResolution.isEulerAdmissible`.
+* `TauCeti.ExactStructure.FiniteResolution.extEuler_eq_homEuler`: the Ext-Euler characteristic of
+  a pair resolved by a Hom-finite finite projective resolution is the alternating Hom dimension of
+  that resolution.
 * `TauCeti.ExactStructure.FiniteResolution.homEuler_eq_homEuler`: any two finite resolutions of
   `X`, along object properties consisting of projectives with finite-dimensional Hom spaces into
   `Y`, have the same alternating Hom dimension.
@@ -132,22 +134,17 @@ theorem isExtBoundedBy (r : (ExactStructure.abelian C).FiniteResolution P X)
   have := r.hasProjectiveDimensionLT hproj
   ⟨fun _ hn ↦ HasProjectiveDimensionLT.subsingleton X (r.length + 1) _ hn Y⟩
 
-/-- The `Ext` groups out of an object with a finite resolution whose `P`-objects are projective
-and have finite-dimensional Hom spaces into `Y` are finite-dimensional. -/
+/-- `Ext`-finiteness propagates along a finite resolution: if every `P`-object has
+finite-dimensional `Ext` groups into `Y`, then so does the resolved object. Projectivity plays no
+role here; the projective case is the one used by
+`TauCeti.ExactStructure.FiniteResolution.isEulerAdmissible`. -/
 theorem isExtFinite (r : (ExactStructure.abelian C).FiniteResolution P X)
-    (hproj : P ≤ (ExactStructure.abelian C).isProjective)
-    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y)) :
+    (hfinite : ∀ Z, P Z → IsExtFinite.{w} k Z Y) :
     IsExtFinite.{w} k X Y := by
   induction r with
-  | @base X hX =>
-      have : Projective X := (ExactStructure.abelian_isProjective_iff X).mp (hproj X hX)
-      have := hHom X hX
-      exact isExtFinite_of_projective k X Y
+  | @base X hX => exact hfinite X hX
   | @step K Q X hQ i p zero hp r ih =>
-      have : Projective Q := (ExactStructure.abelian_isProjective_iff Q).mp (hproj Q hQ)
-      have := hHom Q hQ
-      exact ih.of_shortExact₃' ((ExactStructure.abelian_conflation _).mp hp)
-        (isExtFinite_of_projective k Q Y)
+      exact ih.of_shortExact₃' ((ExactStructure.abelian_conflation _).mp hp) (hfinite Q hQ)
 
 /-- A finite resolution along an object property whose objects are projective and have
 finite-dimensional Hom spaces into `Y` makes the resolved pair `(X,Y)` Euler-admissible. -/
@@ -155,7 +152,11 @@ theorem isEulerAdmissible (r : (ExactStructure.abelian C).FiniteResolution P X)
     (hproj : P ≤ (ExactStructure.abelian C).isProjective)
     (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y)) :
     IsEulerAdmissible.{w} k X Y :=
-  ⟨r.isExtFinite hproj hHom, (r.isExtBoundedBy (Y := Y) hproj).isExtBounded⟩
+  ⟨r.isExtFinite fun Z hZ ↦ by
+      have : Projective Z := (ExactStructure.abelian_isProjective_iff Z).mp (hproj Z hZ)
+      have := hHom Z hZ
+      exact isExtFinite_of_projective k Z Y,
+    (r.isExtBoundedBy (Y := Y) hproj).isExtBounded⟩
 
 /-- **Finite-projective-resolution formula for the Ext-Euler characteristic.** The value of
 `χ(X,Y)` is the alternating sum of the dimensions of `Hom(Pᵢ,Y)` along any finite `P`-resolution
@@ -163,22 +164,22 @@ of `X`, provided the `P`-objects are projective and those Hom spaces are finite-
 theorem extEuler_eq_homEuler
     (r : (ExactStructure.abelian C).FiniteResolution P X)
     (hproj : P ≤ (ExactStructure.abelian C).isProjective)
-    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y))
-    (h : IsEulerAdmissible.{w} k X Y) :
-    extEuler.{w} k h = r.homEuler k Y := by
+    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y)) :
+    extEuler.{w} k (r.isEulerAdmissible hproj hHom) = r.homEuler k Y := by
   induction r with
   | @base X hX =>
       have : Projective X := (ExactStructure.abelian_isProjective_iff X).mp (hproj X hX)
       rw [homEuler_base]
-      exact extEuler_projective k h
+      exact extEuler_projective k _
   | @step K Q X hQ i p zero hp r ih =>
       have : Projective Q := (ExactStructure.abelian_isProjective_iff Q).mp (hproj Q hQ)
       have := hHom Q hQ
-      have hK := r.isEulerAdmissible hproj hHom
       have hQ' := isEulerAdmissible_of_projective k Q Y
-      have hadd := extEuler_shortExact₁ ((ExactStructure.abelian_conflation _).mp hp) Y hK hQ' h
+      have hadd := extEuler_shortExact₁ ((ExactStructure.abelian_conflation _).mp hp) Y
+        (r.isEulerAdmissible hproj hHom) hQ'
+        ((step hQ i p zero hp r).isEulerAdmissible hproj hHom)
       have hQeval := extEuler_projective k hQ'
-      rw [homEuler_step, ← ih hK]
+      rw [homEuler_step, ← ih]
       omega
 
 /-- The alternating Hom dimension is the same along any two finite resolutions of `X` taken along
@@ -191,8 +192,7 @@ theorem homEuler_eq_homEuler {P' : ObjectProperty C}
     (hproj' : P' ≤ (ExactStructure.abelian C).isProjective)
     (hHom' : ∀ Z, P' Z → FiniteDimensional k (Z ⟶ Y)) :
     r.homEuler k Y = s.homEuler k Y := by
-  have h := r.isEulerAdmissible hproj hHom
-  rw [← r.extEuler_eq_homEuler hproj hHom h, ← s.extEuler_eq_homEuler hproj' hHom' h]
+  rw [← r.extEuler_eq_homEuler hproj hHom, ← s.extEuler_eq_homEuler hproj' hHom']
 
 end ExactStructure.FiniteResolution
 

--- a/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Resolution.lean
+++ b/TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Resolution.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.CategoryTheory.Abelian.Projective.Dimension
 public import TauCeti.Algebra.Homology.EulerCharacteristic.ExtEuler.Descent
 public import TauCeti.CategoryTheory.Exact.Projective
 
@@ -23,14 +24,12 @@ computes the Ext-Euler characteristic against `Y` as the alternating Hom dimensi
 χ(X, Y) = ∑ i, (-1)ⁱ dimₖ Hom(Pᵢ, Y).
 ```
 
-The only finiteness hypothesis needed on the resolution is that every resolving object has a
-finite-dimensional Hom space into `Y`. Projectivity makes its higher `Ext` groups vanish. The
-long exact Ext sequence then proves, from the far end of the resolution towards `X`, both that
-`(X, Y)` is Euler-admissible and that the displayed formula holds.
-
-The auxiliary `of_shortExact₃'` lemmas below are the first-variable two-out-of-three statements
-needed by that induction: for a short exact sequence `X₁ ⟶ X₂ ⟶ X₃`, finiteness and
-eventual vanishing for `(X₁, Y)` and `(X₂, Y)` imply the corresponding property for `(X₃, Y)`.
+The hypotheses are conditions on the object property `P` along which the resolution is taken:
+every object satisfying `P` is projective and has a finite-dimensional Hom space into `Y`.
+Projectivity makes the higher `Ext` groups of the resolving terms vanish, and bounds the
+projective dimension of `X` by the length of the resolution. The long exact Ext sequence then
+proves, from the far end of the resolution towards `X`, both that `(X, Y)` is Euler-admissible
+and that the displayed formula holds.
 
 ## Main definitions
 
@@ -39,10 +38,17 @@ eventual vanishing for `(X₁, Y)` and `(X₂, Y)` imply the corresponding prope
 
 ## Main results
 
-* `TauCeti.ExactStructure.FiniteResolution.isEulerAdmissible`: a Hom-finite finite projective
-  resolution makes the resolved pair Euler-admissible.
+* `TauCeti.ExactStructure.FiniteResolution.hasProjectiveDimensionLT`: a finite resolution by
+  projectives bounds the projective dimension of the resolved object by its length.
+* `TauCeti.ExactStructure.FiniteResolution.isExtBoundedBy` and
+  `TauCeti.ExactStructure.FiniteResolution.isExtFinite`: the two halves of Euler-admissibility,
+  with the explicit vanishing bound `r.length + 1`; they are packaged as
+  `TauCeti.ExactStructure.FiniteResolution.isEulerAdmissible`.
 * `TauCeti.ExactStructure.FiniteResolution.extEuler_eq_homEuler`: every admissibility witness gives
   the Ext-Euler characteristic as the alternating Hom dimension of the resolution.
+* `TauCeti.ExactStructure.FiniteResolution.homEuler_eq_homEuler`: any two finite resolutions of
+  `X`, along object properties consisting of projectives with finite-dimensional Hom spaces into
+  `Y`, have the same alternating Hom dimension.
 
 ## References
 
@@ -64,70 +70,11 @@ universe w v u t
 variable {C : Type u} [Category.{v} C] [Abelian C] {k : Type t} [Field k] [Linear k C]
   [HasExt.{w} C]
 
-/-! ### Two-out-of-three towards the quotient term -/
-
-variable {S : ShortComplex C} {Y : C}
-
-/-- In the first-variable long exact Ext sequence, Ext-finiteness of the subobject and middle
-object implies Ext-finiteness of the quotient. -/
-theorem IsExtFinite.of_shortExact₃' (hS : S.ShortExact)
-    (h₁ : IsExtFinite.{w} k S.X₁ Y) (h₂ : IsExtFinite.{w} k S.X₂ Y) :
-    IsExtFinite.{w} k S.X₃ Y := by
-  refine ⟨fun n ↦ ?_⟩
-  match n with
-  | 0 =>
-      let _ := hS.epi_g
-      let _ := h₂.finiteDimensional 0
-      exact FiniteDimensional.of_injective
-        (Ext.precompOfLinear (Ext.mk₀ S.g) k Y (zero_add 0))
-        (Ext.precomp_mk₀_injective_of_epi Y S.g)
-  | n + 1 =>
-      let _ := h₁.finiteDimensional n
-      let _ := h₂.finiteDimensional (n + 1)
-      have h := Ext.contravariant_sequence_exact₃' hS Y n (n + 1) (Nat.one_add n)
-      rw [ShortComplex.ab_exact_iff_function_exact] at h
-      -- Mathlib states this through `AddCommGrpCat`; expose the underlying functions so the
-      -- same exactness proof applies to the linear refinements.
-      change Function.Exact (Ext.precomp hS.extClass Y (Nat.one_add n))
-        (Ext.precomp (Ext.mk₀ S.g) Y (zero_add (n + 1))) at h
-      exact finiteDimensional_of_exact
-        (f := Ext.precompOfLinear hS.extClass k Y (Nat.one_add n))
-        (g := Ext.precompOfLinear (Ext.mk₀ S.g) k Y (zero_add (n + 1)))
-        h
-
-/-- In the first-variable long exact Ext sequence, bounds for the subobject and middle object
-give a bound for the quotient. A bound `N₁` for the subobject is shifted by one degree. -/
-theorem IsExtBoundedBy.of_shortExact₃' (hS : S.ShortExact) {N₁ N₂ : ℕ}
-    (h₁ : IsExtBoundedBy.{w} S.X₁ Y N₁) (h₂ : IsExtBoundedBy.{w} S.X₂ Y N₂) :
-    IsExtBoundedBy.{w} S.X₃ Y (max (N₁ + 1) N₂) := by
-  refine ⟨fun {n} hn ↦ ?_⟩
-  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : n ≠ 0)
-  let _ := h₁.subsingleton (by omega : N₁ ≤ m)
-  let _ := h₂.subsingleton (by omega : N₂ ≤ m + 1)
-  have h := Ext.contravariant_sequence_exact₃' hS Y m (m + 1) (Nat.one_add m)
-  rw [ShortComplex.ab_exact_iff_function_exact] at h
-  -- As above, remove only the concrete-category wrapper from Mathlib's exactness statement.
-  change Function.Exact (Ext.precomp hS.extClass Y (Nat.one_add m))
-    (Ext.precomp (Ext.mk₀ S.g) Y (zero_add (m + 1))) at h
-  exact subsingleton_of_exact
-    (f := Ext.precomp hS.extClass Y (Nat.one_add m))
-    (g := Ext.precomp (Ext.mk₀ S.g) Y (zero_add (m + 1))) h (map_zero _)
-
-/-- Euler-admissibility for the subobject and middle object of a short exact sequence implies
-Euler-admissibility for its quotient, in the first variable. -/
-theorem IsEulerAdmissible.of_shortExact₃' (hS : S.ShortExact)
-    (h₁ : IsEulerAdmissible.{w} k S.X₁ Y) (h₂ : IsEulerAdmissible.{w} k S.X₂ Y) :
-    IsEulerAdmissible.{w} k S.X₃ Y := by
-  obtain ⟨N₁, hN₁⟩ := h₁.isExtBounded.exists_bound
-  obtain ⟨N₂, hN₂⟩ := h₂.isExtBounded.exists_bound
-  exact ⟨h₁.isExtFinite.of_shortExact₃' hS h₂.isExtFinite,
-    (hN₁.of_shortExact₃' hS hN₂).isExtBounded⟩
+namespace ExactStructure.FiniteResolution
 
 /-! ### Alternating Hom dimension of a finite resolution -/
 
-namespace ExactStructure.FiniteResolution
-
-variable {P : ObjectProperty C} {X Y : C}
+variable {E : ExactStructure C} {P : ObjectProperty C} {X Y : C}
 
 /-- The alternating Hom dimension of a finite resolution against `Y`:
 `dim Hom(P₀,Y) - dim Hom(P₁,Y) + ⋯ + (-1)ⁿ dim Hom(Pₙ,Y)`.
@@ -135,45 +82,80 @@ variable {P : ObjectProperty C} {X Y : C}
 As with `TauCeti.truncatedExtEuler`, this definition is total: `Module.finrank` has its usual
 zero fallback when a Hom space is not finite-dimensional. The theorems below assume Hom-finiteness,
 so every summand there is an actual dimension. -/
-noncomputable def homEuler (k : Type t) [Field k] [Linear k C] (Y : C) :
-    ∀ {X : C}, (ExactStructure.abelian C).FiniteResolution P X → ℤ
-  | X, .base _ => Module.finrank k (X ⟶ Y)
-  | _, .step (Q := Q) _ _ _ _ _ r => Module.finrank k (Q ⟶ Y) - r.homEuler k Y
+noncomputable def homEuler (k : Type t) [Field k] [Linear k C] (Y : C) {X : C}
+    (r : E.FiniteResolution P X) : ℤ :=
+  r.foldAlternating fun Z _ ↦ (Module.finrank k (Z ⟶ Y) : ℤ)
 
 omit [HasExt.{w} C] in
 /-- A length-zero resolution has Hom-Euler characteristic equal to its Hom dimension. -/
 @[simp]
 theorem homEuler_base (hX : P X) :
-    (base (E := ExactStructure.abelian C) hX).homEuler k Y = Module.finrank k (X ⟶ Y) :=
-  (rfl)
+    (base (E := E) hX).homEuler k Y = Module.finrank k (X ⟶ Y) :=
+  foldAlternating_base _ hX
 
 omit [HasExt.{w} C] in
 /-- Prepending a resolving term subtracts the Hom-Euler characteristic of the remaining
 resolution from the Hom dimension of that term. -/
 @[simp]
 theorem homEuler_step {K Q : C} (hQ : P Q) (i : K ⟶ Q) (p : Q ⟶ X) (zero : i ≫ p = 0)
-    (hp : (ExactStructure.abelian C).Conflation (ShortComplex.mk i p zero))
-    (r : (ExactStructure.abelian C).FiniteResolution P K) :
+    (hp : E.Conflation (ShortComplex.mk i p zero)) (r : E.FiniteResolution P K) :
     (step hQ i p zero hp r).homEuler k Y = Module.finrank k (Q ⟶ Y) - r.homEuler k Y :=
-  (rfl)
+  foldAlternating_step _ hQ i p zero hp r
 
-/-- A finite resolution by projectives whose Hom spaces into `Y` are finite-dimensional makes
-the resolved pair `(X,Y)` Euler-admissible. -/
-theorem isEulerAdmissible
-    (r : (ExactStructure.abelian C).FiniteResolution P X)
-    (hproj : P ≤ (ExactStructure.abelian C).isProjective)
-    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y)) :
-    IsEulerAdmissible.{w} k X Y := by
+/-! ### Euler-admissibility along a projective resolution -/
+
+omit [HasExt.{w} C] in
+/-- A finite resolution by projectives bounds the projective dimension of the resolved object by
+its length: the resolving terms have projective dimension `< 1`, and each conflation of the chain
+raises the bound by one through
+`CategoryTheory.ShortComplex.ShortExact.hasProjectiveDimensionLT_X₃`. -/
+theorem hasProjectiveDimensionLT (r : (ExactStructure.abelian C).FiniteResolution P X)
+    (hproj : P ≤ (ExactStructure.abelian C).isProjective) :
+    HasProjectiveDimensionLT X (r.length + 1) := by
   induction r with
   | @base X hX =>
-      let _ : Projective X := (ExactStructure.abelian_isProjective_iff X).mp (hproj X hX)
-      let _ := hHom X hX
-      exact isEulerAdmissible_of_projective k X Y
+      have : Projective X := (ExactStructure.abelian_isProjective_iff X).mp (hproj X hX)
+      exact hasProjectiveDimensionLT_of_ge X 1 _ (by omega)
   | @step K Q X hQ i p zero hp r ih =>
-      let _ : Projective Q := (ExactStructure.abelian_isProjective_iff Q).mp (hproj Q hQ)
-      let _ := hHom Q hQ
+      have : Projective Q := (ExactStructure.abelian_isProjective_iff Q).mp (hproj Q hQ)
+      have hQ' : HasProjectiveDimensionLT Q (r.length + 1 + 1) :=
+        hasProjectiveDimensionLT_of_ge Q 1 _ (by omega)
+      rw [length_step]
+      exact ((ExactStructure.abelian_conflation _).mp hp).hasProjectiveDimensionLT_X₃
+        (r.length + 1) ih hQ'
+
+/-- The `Ext` groups out of an object with a finite projective resolution vanish from degree
+`r.length + 1` on. Only projectivity of the `P`-objects is used; no Hom-finiteness is needed. -/
+theorem isExtBoundedBy (r : (ExactStructure.abelian C).FiniteResolution P X)
+    (hproj : P ≤ (ExactStructure.abelian C).isProjective) :
+    IsExtBoundedBy.{w} X Y (r.length + 1) :=
+  have := r.hasProjectiveDimensionLT hproj
+  ⟨fun _ hn ↦ HasProjectiveDimensionLT.subsingleton X (r.length + 1) _ hn Y⟩
+
+/-- The `Ext` groups out of an object with a finite resolution whose `P`-objects are projective
+and have finite-dimensional Hom spaces into `Y` are finite-dimensional. -/
+theorem isExtFinite (r : (ExactStructure.abelian C).FiniteResolution P X)
+    (hproj : P ≤ (ExactStructure.abelian C).isProjective)
+    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y)) :
+    IsExtFinite.{w} k X Y := by
+  induction r with
+  | @base X hX =>
+      have : Projective X := (ExactStructure.abelian_isProjective_iff X).mp (hproj X hX)
+      have := hHom X hX
+      exact isExtFinite_of_projective k X Y
+  | @step K Q X hQ i p zero hp r ih =>
+      have : Projective Q := (ExactStructure.abelian_isProjective_iff Q).mp (hproj Q hQ)
+      have := hHom Q hQ
       exact ih.of_shortExact₃' ((ExactStructure.abelian_conflation _).mp hp)
-        (isEulerAdmissible_of_projective k Q Y)
+        (isExtFinite_of_projective k Q Y)
+
+/-- A finite resolution along an object property whose objects are projective and have
+finite-dimensional Hom spaces into `Y` makes the resolved pair `(X,Y)` Euler-admissible. -/
+theorem isEulerAdmissible (r : (ExactStructure.abelian C).FiniteResolution P X)
+    (hproj : P ≤ (ExactStructure.abelian C).isProjective)
+    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y)) :
+    IsEulerAdmissible.{w} k X Y :=
+  ⟨r.isExtFinite hproj hHom, (r.isExtBoundedBy (Y := Y) hproj).isExtBounded⟩
 
 /-- **Finite-projective-resolution formula for the Ext-Euler characteristic.** The value of
 `χ(X,Y)` is the alternating sum of the dimensions of `Hom(Pᵢ,Y)` along any finite `P`-resolution
@@ -186,11 +168,12 @@ theorem extEuler_eq_homEuler
     extEuler.{w} k h = r.homEuler k Y := by
   induction r with
   | @base X hX =>
-      let _ : Projective X := (ExactStructure.abelian_isProjective_iff X).mp (hproj X hX)
+      have : Projective X := (ExactStructure.abelian_isProjective_iff X).mp (hproj X hX)
+      rw [homEuler_base]
       exact extEuler_projective k h
   | @step K Q X hQ i p zero hp r ih =>
-      let _ : Projective Q := (ExactStructure.abelian_isProjective_iff Q).mp (hproj Q hQ)
-      let _ := hHom Q hQ
+      have : Projective Q := (ExactStructure.abelian_isProjective_iff Q).mp (hproj Q hQ)
+      have := hHom Q hQ
       have hK := r.isEulerAdmissible hproj hHom
       have hQ' := isEulerAdmissible_of_projective k Q Y
       have hadd := extEuler_shortExact₁ ((ExactStructure.abelian_conflation _).mp hp) Y hK hQ' h
@@ -198,14 +181,18 @@ theorem extEuler_eq_homEuler
       rw [homEuler_step, ← ih hK]
       omega
 
-/-- The alternating Hom dimension is independent of the chosen finite projective resolution. -/
-theorem homEuler_eq_homEuler
-    (r s : (ExactStructure.abelian C).FiniteResolution P X)
+/-- The alternating Hom dimension is the same along any two finite resolutions of `X` taken along
+object properties whose objects are projective and have finite-dimensional Hom spaces into `Y`. -/
+theorem homEuler_eq_homEuler {P' : ObjectProperty C}
+    (r : (ExactStructure.abelian C).FiniteResolution P X)
+    (s : (ExactStructure.abelian C).FiniteResolution P' X)
     (hproj : P ≤ (ExactStructure.abelian C).isProjective)
-    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y)) :
+    (hHom : ∀ Z, P Z → FiniteDimensional k (Z ⟶ Y))
+    (hproj' : P' ≤ (ExactStructure.abelian C).isProjective)
+    (hHom' : ∀ Z, P' Z → FiniteDimensional k (Z ⟶ Y)) :
     r.homEuler k Y = s.homEuler k Y := by
   have h := r.isEulerAdmissible hproj hHom
-  rw [← r.extEuler_eq_homEuler hproj hHom h, ← s.extEuler_eq_homEuler hproj hHom h]
+  rw [← r.extEuler_eq_homEuler hproj hHom h, ← s.extEuler_eq_homEuler hproj' hHom' h]
 
 end ExactStructure.FiniteResolution
 

--- a/TauCeti/Algebra/Homology/Ext/Basic.lean
+++ b/TauCeti/Algebra/Homology/Ext/Basic.lean
@@ -20,7 +20,9 @@ This file collects general `Ext` API that Mathlib does not state in this form:
   `Function.Exact` statements about the composition maps: `TauCeti.exact_postcomp` and
   `TauCeti.exact_precomp` for `CategoryTheory.Abelian.Ext.postcomp` and
   `CategoryTheory.Abelian.Ext.precomp`, and `TauCeti.exact_postcompOfLinear` and
-  `TauCeti.exact_precompOfLinear` for their `R`-linear forms.
+  `TauCeti.exact_precompOfLinear` for their `R`-linear forms; `TauCeti.exact_precomp₃` and
+  `TauCeti.exact_precompOfLinear₃` are the same repackaging one step further along the
+  contravariant sequence, where the incoming map is precomposition with the extension class.
 
 The exactness statements are `CategoryTheory.Abelian.Ext.covariant_sequence_exact₂` and
 `CategoryTheory.Abelian.Ext.contravariant_sequence_exact₂` with the vanishing of the composite
@@ -150,5 +152,23 @@ theorem exact_precompOfLinear (R : Type t) [CommRing R] [Linear R C] (hS : S.Sho
       (Ext.precompOfLinear (Ext.mk₀ S.f) R Y (zero_add n)) := by
   simp only [coe_precompOfLinear]
   exact exact_precomp hS Y n
+
+/-- Exactness of `Extⁿ⁰(S.X₁, Y) → Extⁿ¹(S.X₃, Y) → Extⁿ¹(S.X₂, Y)` at the middle term, for a
+short exact sequence `S` and `n₁ = 1 + n₀`. The first map is precomposition with the extension
+class of `S`. This is `CategoryTheory.Abelian.Ext.contravariant_sequence_exact₃'` with its
+`AddCommGrpCat` wrapper removed. -/
+theorem exact_precomp₃ (hS : S.ShortExact) (Y : C) (n₀ n₁ : ℕ) (h : 1 + n₀ = n₁) :
+    Function.Exact (Ext.precomp hS.extClass Y h)
+      (Ext.precomp (Ext.mk₀ S.g) Y (zero_add n₁)) :=
+  (ShortComplex.ab_exact_iff_function_exact _).1
+    (Ext.contravariant_sequence_exact₃' hS Y n₀ n₁ h)
+
+/-- The `R`-linear form of `TauCeti.exact_precomp₃`. -/
+theorem exact_precompOfLinear₃ (R : Type t) [CommRing R] [Linear R C] (hS : S.ShortExact) (Y : C)
+    (n₀ n₁ : ℕ) (h : 1 + n₀ = n₁) :
+    Function.Exact (Ext.precompOfLinear hS.extClass R Y h)
+      (Ext.precompOfLinear (Ext.mk₀ S.g) R Y (zero_add n₁)) := by
+  simp only [coe_precompOfLinear]
+  exact exact_precomp₃ hS Y n₀ n₁ h
 
 end TauCeti

--- a/TauCeti/CategoryTheory/Exact/Resolution.lean
+++ b/TauCeti/CategoryTheory/Exact/Resolution.lean
@@ -35,6 +35,9 @@ property, before any projectivity hypothesis is available.
 
 * `TauCeti.ExactStructure.FiniteResolution E P X`: a finite `P`-resolution of `X`, as data.
 * `TauCeti.ExactStructure.FiniteResolution.length`: the number of conflations in the chain.
+* `TauCeti.ExactStructure.FiniteResolution.foldAlternating`: the alternating fold of a function on
+  the objects satisfying `P` along a resolution, the common shape of the Euler-type invariants of
+  a resolution.
 * `TauCeti.ExactStructure.FiniteResolution.syzygy` and
   `TauCeti.ExactStructure.FiniteResolution.truncate`: the `n`-th syzygy of a resolution, and the
   resolution of it obtained by discarding the first `n` conflations.
@@ -144,6 +147,25 @@ def length : ∀ {X : C}, FiniteResolution E P X → ℕ
 @[simp] theorem length_step {K Q X : C} (hQ : P Q) (i : K ⟶ Q) (p : Q ⟶ X) (zero : i ≫ p = 0)
     (hp : E.Conflation (ShortComplex.mk i p zero)) (r : FiniteResolution E P K) :
     (step hQ i p zero hp r).length = r.length + 1 := (rfl)
+
+/-- The alternating fold of `f` along a resolution: `f Q₀ - f Q₁ + ⋯ + (-1)ⁿ f Kₙ`, where `f`
+assigns an element of an additive group to every object satisfying `P`.
+
+This is the common shape of the Euler-type invariants of a finite resolution;
+`TauCeti.ExactStructure.FiniteResolution.homEuler` is the alternating Hom dimension obtained
+from it. -/
+def foldAlternating {A : Type*} [AddGroup A] (f : ∀ Z : C, P Z → A) :
+    ∀ {X : C}, FiniteResolution E P X → A
+  | _, .base hX => f _ hX
+  | _, .step (Q := Q) hQ _ _ _ _ r => f Q hQ - foldAlternating f r
+
+@[simp] theorem foldAlternating_base {A : Type*} [AddGroup A] (f : ∀ Z : C, P Z → A) {X : C}
+    (hX : P X) : (base (E := E) hX).foldAlternating f = f X hX := (rfl)
+
+@[simp] theorem foldAlternating_step {A : Type*} [AddGroup A] (f : ∀ Z : C, P Z → A) {K Q X : C}
+    (hQ : P Q) (i : K ⟶ Q) (p : Q ⟶ X) (zero : i ≫ p = 0)
+    (hp : E.Conflation (ShortComplex.mk i p zero)) (r : FiniteResolution E P K) :
+    (step hQ i p zero hp r).foldAlternating f = f Q hQ - r.foldAlternating f := (rfl)
 
 /-- The `n`-th syzygy of a resolution of `X`: the object resolved by what is left after
 discarding the first `n` conflations. It is `X` itself for `n = 0`, and it stabilises at the


### PR DESCRIPTION
This PR computes the Ext–Euler characteristic from any finite Hom-finite projective resolution: define its alternating Hom dimension, prove that such a resolution makes the resolved pair Euler-admissible, and identify `χ(X,Y)` with that alternating sum independently of the chosen resolution. It advances `TauCetiRoadmap/GrothendieckEulerForms/README.md`, Layer 5, milestone “Projectives and resolutions,” specifically the target “under finite projective resolutions, compute `χ(M,N)` from the alternating Hom complex.”

The proof supplies rather than assumes the finiteness bridge needed by the induction. `ExactStructure.FiniteResolution.hasProjectiveDimensionLT` propagates Mathlib’s `ShortComplex.ShortExact.hasProjectiveDimensionLT_X₃` along the chain, so a finite resolution by projectives bounds the projective dimension of `X` by its length; `FiniteResolution.isExtBoundedBy` reads off the explicit vanishing bound `r.length + 1` from it. On the finiteness side, the new `IsExtFinite.of_shortExact₃'` — stated in `ExtEuler/Basic.lean` next to the `of_shortExact₂'` family — uses the first-variable long exact Ext sequence to pass Ext-finiteness from the subobject and middle object to the quotient, and `FiniteResolution.isExtFinite` propagates it along the resolution. `isEulerAdmissible` packages the two halves. `FiniteResolution.extEuler_eq_homEuler` then applies the landed short-exact additivity theorem at each step, while projective evaluation replaces each projective Ext–Euler value by its Hom dimension; `homEuler_eq_homEuler` records the resulting independence of the finite projective resolution, for resolutions along two possibly different object properties.

`homEuler` itself is the alternating Hom dimension of the resolving terms. It is defined from the new shared combinator `ExactStructure.FiniteResolution.foldAlternating` in `TauCeti/CategoryTheory/Exact/Resolution.lean` — the alternating fold of a function on the `P`-objects along a resolution — so it is available for an arbitrary exact structure and adds no new copy of that recursion. Two small supporting additions repackage Mathlib exactness the way this repo already does elsewhere: `TauCeti.exact_precomp₃` and `TauCeti.exact_precompOfLinear₃` in `TauCeti/Algebra/Homology/Ext/Basic.lean` strip the `AddCommGrpCat` wrapper off `Ext.contravariant_sequence_exact₃'`, replacing an inline copy in `ExtEuler/Descent.lean` as well.

This is the most effective current step because Layers 0–3 and the object-level Ext–Euler value, additivity, and K₀ descent are on `main`, while the module Cartan map is separately in flight in #4537. The formula here is the general categorical bridge that the next Layer 5 matrix comparison will apply to the Cartan bases without overlapping that module-specific PR. After this PR, the milestone still needs the inverse/transposed Cartan-matrix identification in finite projective/simple bases and its quiver specialization; the graded Ext analogue remains part of the graded Layer 5 path.

The argument follows Weibel, *An Introduction to Homological Algebra*, §§2.4–2.7, and Assem–Simson–Skowroński, *Elements of the Representation Theory of Associative Algebras*, Volume I, Chapter III, Proposition 3.13, both cited in the module documentation. It reuses Mathlib’s `Ext.contravariant_sequence_exact₃'`, `Ext.precomp_mk₀_injective_of_epi`, `ShortComplex.ShortExact.hasProjectiveDimensionLT_X₃` and projective Ext-vanishing, together with Tau Ceti’s finite-resolution, exact-structure, and Ext–Euler additivity APIs. No Mathlib source or external formalization is vendored.

Add `TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Resolution.lean`; extend `TauCeti/Algebra/Homology/Ext/Basic.lean`, `TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Basic.lean` and `TauCeti/CategoryTheory/Exact/Resolution.lean`, and simplify one proof in `TauCeti/Algebra/Homology/EulerCharacteristic/ExtEuler/Descent.lean`.

Roadmap: GrothendieckEulerForms

<!--tauceti-target:v1 {"focus":"GrothendieckEulerForms","id":"ext-euler-finite-projective-resolution"}-->

🤖 Prepared with Codex
