### PR TITLE
ci: centralize Lake cache map URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,8 +277,9 @@ jobs:
       # through `$GITHUB_PATH`, or set LD_PRELOAD or BASH_ENV for every later step through
       # `$GITHUB_ENV`. A secret given to any later step of this job is a secret given to code
       # that landed on main, whatever that step does with it. So this job only stages the
-      # artifacts, and publish-lake-cache below, a fresh runner with no checkout, no
-      # workspace and no project code, is the only place the key exists.
+      # artifacts, and publish-lake-cache below, a fresh runner with only a sparse pin/helper
+      # checkout and no project workspace, is the only place the key exists. The helper stays
+      # inert until the key-bearing step has exited.
       - name: Configure the Lake cache staging (no-op unless the S3 endpoints are set)
         id: cachecfg
         env:
@@ -343,8 +344,8 @@ jobs:
           echo "root-package mapping entries: $(wc -l < .lake/outputs.jsonl)"
           lake cache stage .lake/outputs.jsonl "$RUNNER_TEMP/lake-cache-staging"
           # `lake cache put-staged` does not configure the workspace, which is precisely what
-          # keeps project code out of the publish job, so it cannot derive the toolchain and
-          # platform halves of the upload scope. The publish job supplies them from the pin
+          # keeps project build code out of the publisher, so it cannot derive the toolchain and
+          # platform halves of the upload scope. The publisher supplies them from the sparse pin
           # instead, which is right only while the package config keeps the two assumptions
           # below. Check them here, where the workspace does exist: `platformIndependent` is
           # what makes Lake leave the platform out of the scope (put-staged's default), while

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -772,7 +772,8 @@ jobs:
           [ "$state" = "success" ]
 
   # Only an already-audited merge-group commit may publish. The reusable workflow runs on a
-  # fresh runner, checks out only that commit's toolchain pin, and is the sole holder of the key.
+  # fresh runner, sparsely checks out that commit's toolchain pin and key-free confirmation
+  # helper, and is the sole holder of the key. The helper runs only after the key-bearing step.
   publish-merge-group-cache:
     needs: sandboxed-build
     if: ${{ always() && needs.sandboxed-build.result == 'success' && needs.sandboxed-build.outputs.publication-required == 'true' }}

--- a/.github/workflows/publish-lake-cache.yml
+++ b/.github/workflows/publish-lake-cache.yml
@@ -2,9 +2,10 @@ name: publish-lake-cache
 
 # Secret-isolated Lake cache publisher shared by main CI and merge-group CI. The caller may
 # execute arbitrary Lean code while producing the staging artifact, so this workflow treats the
-# entire artifact and every reported value as hostile. It checks out only the toolchain pin at the
-# immutable revision being published; no project or dependency code runs in the job that receives
-# LAKE_CACHE_KEY.
+# entire artifact and every reported value as hostile. It checks out only the toolchain pin and
+# the public-map helper at the immutable revision being published. The helper remains inert until
+# the key-bearing upload step has exited; no project or dependency code runs while LAKE_CACHE_KEY
+# is present.
 
 on:
   workflow_call:
@@ -41,16 +42,20 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     outputs:
-      published: ${{ steps.upload.outputs.published }}
+      published: ${{ steps.result.outputs.published }}
     steps:
-      # Exactly one repository file is admitted to the secret-bearing job. Which toolchain this
-      # job installs decides which `lake` handles the upload key, so the pin is read independently
-      # from the immutable revision rather than trusted from the staging build.
-      - name: Check out the toolchain pin, and nothing else
+      # Exactly two repository files are admitted. Which toolchain this job installs decides
+      # which `lake` handles the upload key, so the pin is read independently from the immutable
+      # revision rather than trusted from the staging build. The Python helper is present only so
+      # a later, key-free step can share the public URL contract with every other cache probe; it
+      # is data, never executed, before or during the secret-bearing upload step.
+      - name: Check out the toolchain pin and key-free confirmation helper
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.revision }}
-          sparse-checkout: lean-toolchain
+          sparse-checkout: |
+            lean-toolchain
+            scripts/lake_cache_probe.py
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
@@ -133,7 +138,7 @@ jobs:
           "$HOME/.elan/bin/elan" toolchain install "$TOOLCHAIN"
           printf 'name=%s\n' "$TOOLCHAIN" >> "$GITHUB_OUTPUT"
 
-      - name: Publish and confirm the revision map is publicly readable
+      - name: Publish the staged Lake cache
         id: upload
         env:
           S3_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
@@ -152,7 +157,6 @@ jobs:
               exit 1
             fi
             echo "::notice::$1"
-            echo 'published=false' >> "$GITHUB_OUTPUT"
             exit 0
           }
 
@@ -187,16 +191,28 @@ jobs:
           lake cache put-staged "$STAGING" --service tauceti-r2 \
             --repo TauCetiProject/TauCeti --rev "$REVISION" --toolchain "$ELAN_TOOLCHAIN"
 
-          # Lake maps elan toolchain names to scope directories by replacing `/` with `--` and
-          # `:` with `---`. Confirm the exact bytes just uploaded have propagated to the public
-          # read endpoint before allowing a merge-group build to turn green.
-          TOOLCHAIN_DIR="${ELAN_TOOLCHAIN//\//--}"
-          TOOLCHAIN_DIR="${TOOLCHAIN_DIR//:/---}"
-          PUBLIC_URL="${PUBLIC_REVISION_ENDPOINT%/}/TauCetiProject/TauCeti/tc/$TOOLCHAIN_DIR/$REVISION.jsonl"
+          echo 'uploaded=true' >> "$GITHUB_OUTPUT"
+          echo "::notice::uploaded the Lake cache for $REVISION"
+
+      # This is intentionally a separate step. The shared repository helper did not execute while
+      # LAKE_CACHE_KEY existed in the upload step's environment, and this step receives no secret.
+      # It owns the one public-map URL implementation used by main's probe and toolchain_tags.py,
+      # while --expected preserves the publisher's stronger byte-for-byte confirmation.
+      - name: Confirm the exact revision map on the public endpoint
+        id: confirm
+        if: ${{ steps.upload.outputs.uploaded == 'true' }}
+        env:
+          PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+          ELAN_TOOLCHAIN: ${{ steps.toolchain.outputs.name }}
+          STAGING: ${{ runner.temp }}/lake-cache-staging
+          REVISION: ${{ inputs.revision }}
+        run: |
+          set -euo pipefail
           observed=0
           for attempt in 1 2 3 4 5 6; do
-            if curl --fail --silent --show-error "$PUBLIC_URL" -o "$RUNNER_TEMP/public-outputs.jsonl" \
-                 && cmp "$STAGING/outputs.jsonl" "$RUNNER_TEMP/public-outputs.jsonl"; then
+            if python3 scripts/lake_cache_probe.py --repo TauCetiProject/TauCeti \
+                --expected "$STAGING/outputs.jsonl" \
+                "$PUBLIC_REVISION_ENDPOINT" "$ELAN_TOOLCHAIN" "$REVISION"; then
               observed=1
               break
             fi
@@ -206,3 +222,15 @@ jobs:
           [ "$observed" = 1 ] || { echo "::error::the published revision map did not become publicly readable"; exit 1; }
           echo 'published=true' >> "$GITHUB_OUTPUT"
           echo "::notice::published and confirmed the Lake cache for $REVISION"
+
+      - name: Report whether publication was confirmed
+        id: result
+        if: ${{ always() }}
+        env:
+          CONFIRMED: ${{ steps.confirm.outputs.published }}
+        run: |
+          if [ "$CONFIRMED" = true ]; then
+            echo 'published=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'published=false' >> "$GITHUB_OUTPUT"
+          fi

--- a/scripts/lake_cache_probe.py
+++ b/scripts/lake_cache_probe.py
@@ -23,9 +23,12 @@ REVISION = re.compile(r"\A[0-9a-f]{40}\Z")
 TOOLCHAIN = re.compile(r"\Aleanprover/lean4:[0-9A-Za-z][0-9A-Za-z._+-]*\Z")
 INPUT_HASH = re.compile(r"\A[0-9a-f]{16}\Z")
 ARTIFACT = re.compile(r"\A[0-9a-f]{16}\.ltar\Z")
+REPOSITORY = re.compile(r"\A[0-9A-Za-z_.-]+/[0-9A-Za-z_.-]+\Z")
+DEFAULT_REPOSITORY = "TauCetiProject/TauCeti"
 
 
-def exact_map_url(endpoint: str, toolchain: str, revision: str) -> str:
+def exact_map_url(endpoint: str, toolchain: str, revision: str,
+                  repository: str = DEFAULT_REPOSITORY) -> str:
     """Return the public revision-map URL written by ``lake cache put-staged``."""
     endpoint = endpoint.strip().rstrip("/")
     parsed = urllib.parse.urlsplit(endpoint)
@@ -36,11 +39,15 @@ def exact_map_url(endpoint: str, toolchain: str, revision: str) -> str:
         raise ValueError("the revision is not a lowercase 40-character Git object ID")
     if not TOOLCHAIN.fullmatch(toolchain):
         raise ValueError("the toolchain is not a leanprover/lean4 release")
+    if not REPOSITORY.fullmatch(repository):
+        raise ValueError("the repository is not an owner/name pair")
+    if any(component in {".", ".."} for component in repository.split("/")):
+        raise ValueError("the repository contains a relative path component")
 
-    # Lake scopes toolchain-dependent caches by this escaped elan toolchain name.  Keep this in
-    # sync with the confirmation URL in publish-lake-cache.yml.
+    # Lake scopes toolchain-dependent caches by this escaped elan toolchain name.  This function
+    # is the repository's single source for the corresponding public revision-map URL.
     scope = toolchain.replace("/", "--").replace(":", "---")
-    return (f"{endpoint}/TauCetiProject/TauCeti/tc/{scope}/{revision}.jsonl")
+    return f"{endpoint}/{repository}/tc/{scope}/{revision}.jsonl"
 
 
 def valid_map(path: pathlib.Path) -> tuple[bool, str]:
@@ -64,10 +71,12 @@ def valid_map(path: pathlib.Path) -> tuple[bool, str]:
     return True, ""
 
 
-def probe(endpoint: str, toolchain: str, revision: str, runner=None) -> tuple[bool, str, str]:
+def probe(endpoint: str, toolchain: str, revision: str, runner=None,
+          expected: pathlib.Path | None = None,
+          repository: str = DEFAULT_REPOSITORY) -> tuple[bool, str, str]:
     """Return ``(found, url, reason)`` without turning an inconclusive probe into an error."""
     try:
-        url = exact_map_url(endpoint, toolchain, revision)
+        url = exact_map_url(endpoint, toolchain, revision, repository)
     except ValueError as exc:
         return False, "", str(exc)
 
@@ -89,17 +98,29 @@ def probe(endpoint: str, toolchain: str, revision: str, runner=None) -> tuple[bo
             return False, url, f"{reason}: {detail}" if detail else reason
 
         found, reason = valid_map(destination)
+        if found and expected is not None:
+            try:
+                matches = destination.read_bytes() == expected.read_bytes()
+            except OSError as exc:
+                return False, url, f"could not compare the expected Lake map: {exc}"
+            if not matches:
+                return False, url, "the public Lake map does not match the expected bytes"
         return found, url, reason
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPOSITORY,
+                        help=f"GitHub owner/name cache scope (default: {DEFAULT_REPOSITORY})")
+    parser.add_argument("--expected", type=pathlib.Path,
+                        help="require the public map to match this file byte for byte")
     parser.add_argument("endpoint", help="public Lake revision endpoint")
     parser.add_argument("toolchain", help="contents of lean-toolchain")
     parser.add_argument("revision", help="exact Tau Ceti Git revision")
     args = parser.parse_args(argv)
 
-    found, url, reason = probe(args.endpoint, args.toolchain, args.revision)
+    found, url, reason = probe(args.endpoint, args.toolchain, args.revision,
+                               expected=args.expected, repository=args.repo)
     if found:
         print(f"found valid public Lake cache map: {url}")
         return 0

--- a/scripts/test_lake_cache_probe.py
+++ b/scripts/test_lake_cache_probe.py
@@ -4,6 +4,7 @@
 import pathlib
 import subprocess
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -13,6 +14,8 @@ import lake_cache_probe as cache_probe  # noqa: E402
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 CI = ROOT / ".github/workflows/ci.yml"
+PUBLISHER = ROOT / ".github/workflows/publish-lake-cache.yml"
+TOOLCHAIN_TAGS = ROOT / "scripts/toolchain_tags.py"
 SHA = "a" * 40
 TOOLCHAIN = "leanprover/lean4:v4.34.0-rc1"
 ENDPOINT = "https://cache.taucetiproject.org/revisions"
@@ -68,6 +71,28 @@ class ExactMapProbe(unittest.TestCase):
                 self.assertFalse(found)
                 self.assertEqual(url, "")
 
+        found, url, _reason = cache_probe.probe(
+            ENDPOINT, TOOLCHAIN, SHA, response(""), repository="../TauCeti",
+        )
+        self.assertFalse(found)
+        self.assertEqual(url, "")
+
+    def test_expected_map_must_match_the_public_bytes(self):
+        body = '"2026-03-17"\n["44b76000326a96d8","40b5fb725e1abfb8.ltar"]\n'
+        with tempfile.TemporaryDirectory() as directory:
+            expected = pathlib.Path(directory) / "outputs.jsonl"
+            expected.write_text(body)
+            found, _url, reason = cache_probe.probe(
+                ENDPOINT, TOOLCHAIN, SHA, response(body), expected=expected,
+            )
+            self.assertTrue(found, reason)
+            expected.write_text(body.replace("40b5", "ffff"))
+            found, _url, reason = cache_probe.probe(
+                ENDPOINT, TOOLCHAIN, SHA, response(body), expected=expected,
+            )
+            self.assertFalse(found)
+            self.assertIn("does not match", reason)
+
 
 def step(workflow: str, name: str) -> str:
     marker = f"      - name: {name}\n"
@@ -99,6 +124,41 @@ class MainWorkflowFallback(unittest.TestCase):
         self.assertIn("steps.exact_cache.outputs.exists != 'true'", block)
         self.assertIn('echo "staged=true"', block)
         self.assertIn("if: ${{ needs.build.outputs.staged == 'true' }}", self.workflow)
+
+
+class SharedPublicationContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.publisher = PUBLISHER.read_text()
+
+    def test_publisher_uses_the_shared_helper_not_a_shell_url_copy(self):
+        confirm = step(self.publisher, "Confirm the exact revision map on the public endpoint")
+        self.assertIn("python3 scripts/lake_cache_probe.py", confirm)
+        self.assertIn('--expected "$STAGING/outputs.jsonl"', confirm)
+        self.assertNotIn("TOOLCHAIN_DIR=", self.publisher)
+        self.assertNotIn("PUBLIC_URL=", self.publisher)
+
+    def test_shared_helper_runs_only_after_the_key_bearing_step(self):
+        checkout = step(
+            self.publisher, "Check out the toolchain pin and key-free confirmation helper",
+        )
+        upload = step(self.publisher, "Publish the staged Lake cache")
+        confirm = step(self.publisher, "Confirm the exact revision map on the public endpoint")
+        self.assertIn("scripts/lake_cache_probe.py", checkout)
+        self.assertIn("LAKE_CACHE_KEY_RAW", upload)
+        self.assertNotIn("lake_cache_probe.py", upload)
+        self.assertNotIn("LAKE_CACHE_KEY", confirm)
+        result = step(self.publisher, "Report whether publication was confirmed")
+        self.assertIn("steps.confirm.outputs.published", result)
+        self.assertIn("published=false", result)
+        self.assertLess(self.publisher.index("- name: Publish the staged Lake cache"),
+                        self.publisher.index("- name: Confirm the exact revision map"))
+
+    def test_toolchain_tag_audit_uses_the_same_url_function(self):
+        source = TOOLCHAIN_TAGS.read_text()
+        probe = source[source.index("def cache_published"):source.index("def mathlib_releases")]
+        self.assertIn("exact_map_url(", probe)
+        self.assertNotIn('.replace("/", "--")', probe)
 
 
 if __name__ == "__main__":

--- a/scripts/toolchain_tags.py
+++ b/scripts/toolchain_tags.py
@@ -74,6 +74,8 @@ import subprocess
 import sys
 import time
 
+from lake_cache_probe import exact_map_url
+
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "pr_status"))
 import zulip as zp  # noqa: E402
 
@@ -221,8 +223,7 @@ def cache_published(toolchain, sha):
     host answers python's default user agent with 403 while answering curl with 200, so a
     urllib probe reports every commit as uncached and the whole report becomes noise.
     Found by running the tool, not by reading it."""
-    scope = toolchain.replace("/", "--").replace(":", "---")
-    url = f"{REVISIONS}/{REPO}/tc/{scope}/{sha}.jsonl"
+    url = exact_map_url(REVISIONS, toolchain, sha, REPO)
     out = subprocess.run(["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
                           "--max-time", "30", url], capture_output=True, text=True)
     if out.returncode != 0:


### PR DESCRIPTION
This PR follows up #4767's reuse review by making `scripts/lake_cache_probe.py` the single constructor for public Lake revision-map URLs. `toolchain_tags.py` and the publisher now share that helper; the publisher executes repository code only in a post-upload step without `LAKE_CACHE_KEY`, while `--expected` preserves its byte-for-byte public confirmation. The full infrastructure-policy suite and live shared-helper/public-map probes pass locally.

Roadmap: none

:robot: Prepared with OpenAI Codex
