### PR TITLE
feat: prove the Lie functor faithful on connected groups

### DIFF
--- a/TauCeti/Geometry/Lie/Faithfulness.lean
+++ b/TauCeti/Geometry/Lie/Faithfulness.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Lie.Functor
+import TauCeti.Geometry.Lie.Exponential.LocalInverse
+import Mathlib.Topology.Algebra.OpenSubgroup
+
+/-!
+# Faithfulness of the Lie functor on connected groups
+
+A smooth homomorphism out of a connected finite-dimensional real Lie group is determined by its
+induced Lie-algebra homomorphism. Naturality of the Lie-group exponential first gives equality on
+the exponential image. The local inverse to the exponential promotes this to equality near the
+identity, and the equality locus is then an open and closed subgroup of the connected source.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 3, "Injectivity on connected groups".
+
+## Main results
+
+* `lieMap_injective`: a smooth homomorphism out of a connected Lie group is determined by its Lie
+  map.
+-/
+
+public section
+
+noncomputable section
+
+open Filter
+open scoped ContDiff Topology
+
+attribute [local instance] LieGroup.minSmoothnessThree
+attribute [local instance] ContMDiffMul.boundarylessManifold
+
+private theorem monoidHom_eq_of_eventuallyEq_one
+    {G M : Type*} [Group G] [TopologicalSpace G] [SeparatelyContinuousMul G]
+    [PreconnectedSpace G] [Monoid M]
+    (φ ψ : G →* M) (h : φ =ᶠ[𝓝 (1 : G)] ψ) : φ = ψ := by
+  let S := φ.eqLocus ψ
+  have hS : (S : Set G) ∈ 𝓝 (1 : G) := h
+  have hopen : IsOpen (S : Set G) := S.isOpen_of_mem_nhds hS
+  have hclosed : IsClosed (S : Set G) := S.isClosed_of_isOpen hopen
+  have huniv : (S : Set G) = Set.univ :=
+    IsClopen.eq_univ ⟨hclosed, hopen⟩ ⟨1, S.one_mem⟩
+  apply MonoidHom.ext
+  intro g
+  have hg : g ∈ (S : Set G) := by
+    rw [huniv]
+    trivial
+  exact hg
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  {E' : Type*} [NormedAddCommGroup E'] [NormedSpace ℝ E']
+  {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners ℝ E' H'}
+  {G' : Type*} [TopologicalSpace G'] [ChartedSpace H' G'] [Group G']
+
+/-- The Lie map is injective on smooth homomorphisms out of a connected Lie group. -/
+theorem lieMap_injective
+    [LieGroup I ∞ G] [LieGroup I' ∞ G'] [ConnectedSpace G]
+    [FiniteDimensional ℝ E] [FiniteDimensional ℝ E'] :
+    Function.Injective
+      (lieMap : ContMDiffMonoidMorphism I I' ∞ G G' →
+        LeftInvariantDerivation I G →ₗ⁅ℝ⁆ LeftInvariantDerivation I' G') := by
+  intro φ ψ h
+  let _ : IsTopologicalGroup G := topologicalGroup_of_lieGroup I ∞
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
+  have hnear : φ =ᶠ[𝓝 (1 : G)] ψ :=
+    (eventually_lieExp_lieLog (I := I) (G := G)).mono fun g hg => by
+      rw [← hg, map_lieExp, map_lieExp, h]
+  apply DFunLike.coe_injective
+  exact congrArg (fun f : G →* G' => (f : G → G'))
+    (monoidHom_eq_of_eventuallyEq_one φ.toMonoidHom ψ.toMonoidHom hnear)

--- a/TauCeti/Geometry/Lie/Faithfulness.lean
+++ b/TauCeti/Geometry/Lie/Faithfulness.lean
@@ -6,16 +6,16 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Geometry.Lie.Functor
+import TauCeti.Topology.Algebra.Group.Preconnected
 import TauCeti.Geometry.Lie.Exponential.LocalInverse
-import Mathlib.Topology.Algebra.OpenSubgroup
 
 /-!
-# Faithfulness of the Lie functor on connected groups
+# Faithfulness of the Lie functor on preconnected groups
 
-A smooth homomorphism out of a connected finite-dimensional real Lie group is determined by its
+A smooth homomorphism out of a preconnected finite-dimensional real Lie group is determined by its
 induced Lie-algebra homomorphism. Naturality of the Lie-group exponential first gives equality on
 the exponential image. The local inverse to the exponential promotes this to equality near the
-identity, and the equality locus is then an open and closed subgroup of the connected source.
+identity, and the equality locus is then an open and closed subgroup of the preconnected source.
 
 ## References
 
@@ -24,7 +24,7 @@ identity, and the equality locus is then an open and closed subgroup of the conn
 
 ## Main results
 
-* `lieMap_injective`: a smooth homomorphism out of a connected Lie group is determined by its Lie
+* `lieMap_injective`: a smooth homomorphism out of a preconnected Lie group is determined by its Lie
   map.
 -/
 
@@ -38,23 +38,6 @@ open scoped ContDiff Topology
 attribute [local instance] LieGroup.minSmoothnessThree
 attribute [local instance] ContMDiffMul.boundarylessManifold
 
-private theorem monoidHom_eq_of_eventuallyEq_one
-    {G M : Type*} [Group G] [TopologicalSpace G] [SeparatelyContinuousMul G]
-    [PreconnectedSpace G] [Monoid M]
-    (φ ψ : G →* M) (h : φ =ᶠ[𝓝 (1 : G)] ψ) : φ = ψ := by
-  let S := φ.eqLocus ψ
-  have hS : (S : Set G) ∈ 𝓝 (1 : G) := h
-  have hopen : IsOpen (S : Set G) := S.isOpen_of_mem_nhds hS
-  have hclosed : IsClosed (S : Set G) := S.isClosed_of_isOpen hopen
-  have huniv : (S : Set G) = Set.univ :=
-    IsClopen.eq_univ ⟨hclosed, hopen⟩ ⟨1, S.one_mem⟩
-  apply MonoidHom.ext
-  intro g
-  have hg : g ∈ (S : Set G) := by
-    rw [huniv]
-    trivial
-  exact hg
-
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
@@ -62,9 +45,10 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners ℝ E' H'}
   {G' : Type*} [TopologicalSpace G'] [ChartedSpace H' G'] [Group G']
 
-/-- The Lie map is injective on smooth homomorphisms out of a connected Lie group. -/
+/-- The Lie map is injective on smooth homomorphisms out of a preconnected Lie group. -/
+@[grind inj]
 theorem lieMap_injective
-    [LieGroup I ∞ G] [LieGroup I' ∞ G'] [ConnectedSpace G]
+    [LieGroup I ∞ G] [LieGroup I' ∞ G'] [PreconnectedSpace G]
     [FiniteDimensional ℝ E] [FiniteDimensional ℝ E'] :
     Function.Injective
       (lieMap : ContMDiffMonoidMorphism I I' ∞ G G' →
@@ -77,4 +61,4 @@ theorem lieMap_injective
       rw [← hg, map_lieExp, map_lieExp, h]
   apply DFunLike.coe_injective
   exact congrArg (fun f : G →* G' => (f : G → G'))
-    (monoidHom_eq_of_eventuallyEq_one φ.toMonoidHom ψ.toMonoidHom hnear)
+    (MonoidHom.eq_of_eventuallyEq_one hnear)

--- a/TauCeti/Topology/Algebra/Group/Preconnected.lean
+++ b/TauCeti/Topology/Algebra/Group/Preconnected.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.OpenSubgroup
+
+/-!
+# Homomorphisms from preconnected topological groups
+
+This file records a local-to-global principle for monoid homomorphisms from a preconnected
+topological group: two such homomorphisms that agree near the identity agree everywhere.
+-/
+
+public section
+
+open Filter
+open scoped Topology
+
+/-- Two monoid homomorphisms from a preconnected topological group that agree near the identity
+agree everywhere. -/
+theorem MonoidHom.eq_of_eventuallyEq_one
+    {G M : Type*} [Group G] [TopologicalSpace G] [SeparatelyContinuousMul G]
+    [PreconnectedSpace G] [Monoid M]
+    {φ ψ : G →* M} (h : φ =ᶠ[𝓝 (1 : G)] ψ) : φ = ψ := by
+  let S := φ.eqLocus ψ
+  have hS : (S : Set G) ∈ 𝓝 (1 : G) := h
+  have hopen : IsOpen (S : Set G) := S.isOpen_of_mem_nhds hS
+  have hclosed : IsClosed (S : Set G) := S.isClosed_of_isOpen hopen
+  have huniv : (S : Set G) = Set.univ :=
+    IsClopen.eq_univ ⟨hclosed, hopen⟩ ⟨1, S.one_mem⟩
+  apply MonoidHom.ext
+  intro g
+  have hg : g ∈ (S : Set G) := by
+    rw [huniv]
+    trivial
+  exact hg

--- a/TauCeti/Topology/Algebra/Group/Preconnected.lean
+++ b/TauCeti/Topology/Algebra/Group/Preconnected.lean
@@ -26,13 +26,18 @@ theorem MonoidHom.eq_of_eventuallyEq_one
     [PreconnectedSpace G] [Monoid M]
     {φ ψ : G →* M} (h : φ =ᶠ[𝓝 (1 : G)] ψ) : φ = ψ := by
   let S := φ.eqLocus ψ
-  have hS : (S : Set G) ∈ 𝓝 (1 : G) := h
+  have hS : (S : Set G) ∈ 𝓝 (1 : G) := by
+    -- Expose equality-locus membership as the pointwise equality used by the filter statement.
+    change φ =ᶠ[𝓝 (1 : G)] ψ
+    exact h
   have hopen : IsOpen (S : Set G) := S.isOpen_of_mem_nhds hS
   have hclosed : IsClosed (S : Set G) := S.isClosed_of_isOpen hopen
   have huniv : (S : Set G) = Set.univ :=
     IsClopen.eq_univ ⟨hclosed, hopen⟩ ⟨1, S.one_mem⟩
   apply MonoidHom.ext
   intro g
+  -- Expose equality-locus membership as the pointwise equality required by extensionality.
+  change g ∈ S
   have hg : g ∈ (S : Set G) := by
     rw [huniv]
     trivial


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Proves that a smooth homomorphism from a preconnected finite-dimensional real Lie group is determined by its Lie map.

The proof uses exponential naturality and the local inverse of the Lie exponential to obtain equality near the identity, then propagates it across the preconnected source.

## Roadmap target

Completes Deliverable A, Layer 3, “Injectivity on connected groups” in the [LieGroups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md).

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"LieGroups/README.md#injectivity-on-connected-groups"}-->

## Verification

Focused builds, public consumer and `grind` probes, axiom and module-system audits, header/style checks, and the full environment linter pass for the exact aggregate published at `4ed624b2`.

## Scope

Adds a 64-line Lie module with the public faithfulness theorem and a 44-line topology/group module with the public generic local-to-global helper. Integration/existence of homomorphisms remains downstream.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [465c9e7](https://github.com/TauCetiProject/TauCetiReview/commit/465c9e7f030871aa0d5fbc533ada5219e9a96f2c) · local skill review @ [ut-lean-review](https://github.com/utensil/formal-land/tree/11870ae6f95672bc7368474182e7e958866e2e10/lean4/skills/ut-lean-review) fixed: api-design (1), generality (1), proof-quality (1)</sub>