### PR TITLE
feat: compute Laplace transforms

### DIFF
--- a/TauCeti/MeasureTheory/Integral/ExpDecay.lean
+++ b/TauCeti/MeasureTheory/Integral/ExpDecay.lean
@@ -27,6 +27,8 @@ inclusion.
 * `TauCeti.integral_pow_mul_exp_neg_mul_Ioi`: evaluation in terms of a factorial.
 * `TauCeti.integrableOn_exp_mul_Ioi_iff`: `exp (a * ·)` is integrable on `(c, ∞)` exactly when
   `a < 0`.
+* `TauCeti.integrableOn_exp_mul_Iic_iff`: `exp (a * ·)` is integrable on `(-∞, c]` exactly when
+  `0 < a`.
 * `TauCeti.integrable_exp_neg_mul_abs`: `exp (-(a * |·|))` is integrable when `0 < a`.
 -/
 
@@ -102,5 +104,27 @@ theorem integrableOn_exp_mul_Ioi_iff {a c : ℝ} :
   refine ⟨fun h => ?_, fun ha => integrableOn_exp_mul_Ioi ha c⟩
   by_contra hne
   exact not_integrableOn_exp_mul_Ioi (not_lt.mp hne) h
+
+/-- At a nonpositive rate the integrand is bounded below by a positive constant on `(-∞, c]`, a
+set of infinite measure, so it is not integrable there. -/
+private theorem not_integrableOn_exp_mul_Iic {a c : ℝ} (ha : a ≤ 0) :
+    ¬ IntegrableOn (fun x : ℝ => Real.exp (a * x)) (Set.Iic c) := by
+  intro h
+  have hsub : Set.Iic c ⊆ {x : ℝ | Real.exp (a * c) ≤ Real.exp (a * x)} := by
+    intro x hx
+    exact Real.exp_le_exp.2 (mul_le_mul_of_nonpos_left (Set.mem_Iic.mp hx) ha)
+  have h1 : (volume.restrict (Set.Iic c)) (Set.Iic c) < ⊤ :=
+    lt_of_le_of_lt (measure_mono hsub) (h.measure_ge_lt_top (Real.exp_pos (a * c)))
+  rw [Measure.restrict_apply_self, Real.volume_Iic] at h1
+  exact absurd h1 (by simp)
+
+/-- **The exact integrability rate on a left half-line.** `fun x => exp (a * x)` is integrable
+on `(-∞, c]` precisely when the rate is positive. -/
+@[simp]
+theorem integrableOn_exp_mul_Iic_iff {a c : ℝ} :
+    IntegrableOn (fun x : ℝ => Real.exp (a * x)) (Set.Iic c) ↔ 0 < a := by
+  refine ⟨fun h => ?_, fun ha => integrableOn_exp_mul_Iic ha c⟩
+  by_contra hne
+  exact not_integrableOn_exp_mul_Iic (not_lt.mp hne) h
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Integral/ExpDecay.lean
+++ b/TauCeti/MeasureTheory/Integral/ExpDecay.lean
@@ -105,26 +105,15 @@ theorem integrableOn_exp_mul_Ioi_iff {a c : ℝ} :
   by_contra hne
   exact not_integrableOn_exp_mul_Ioi (not_lt.mp hne) h
 
-/-- At a nonpositive rate the integrand is bounded below by a positive constant on `(-∞, c]`, a
-set of infinite measure, so it is not integrable there. -/
-private theorem not_integrableOn_exp_mul_Iic {a c : ℝ} (ha : a ≤ 0) :
-    ¬ IntegrableOn (fun x : ℝ => Real.exp (a * x)) (Set.Iic c) := by
-  intro h
-  have hsub : Set.Iic c ⊆ {x : ℝ | Real.exp (a * c) ≤ Real.exp (a * x)} := by
-    intro x hx
-    exact Real.exp_le_exp.2 (mul_le_mul_of_nonpos_left (Set.mem_Iic.mp hx) ha)
-  have h1 : (volume.restrict (Set.Iic c)) (Set.Iic c) < ⊤ :=
-    lt_of_le_of_lt (measure_mono hsub) (h.measure_ge_lt_top (Real.exp_pos (a * c)))
-  rw [Measure.restrict_apply_self, Real.volume_Iic] at h1
-  exact absurd h1 (by simp)
-
 /-- **The exact integrability rate on a left half-line.** `fun x => exp (a * x)` is integrable
 on `(-∞, c]` precisely when the rate is positive. -/
 @[simp]
 theorem integrableOn_exp_mul_Iic_iff {a c : ℝ} :
     IntegrableOn (fun x : ℝ => Real.exp (a * x)) (Set.Iic c) ↔ 0 < a := by
-  refine ⟨fun h => ?_, fun ha => integrableOn_exp_mul_Iic ha c⟩
-  by_contra hne
-  exact not_integrableOn_exp_mul_Iic (not_lt.mp hne) h
+  rw [integrableOn_Iic_iff_integrableOn_Iio,
+    ← (Measure.measurePreserving_neg (volume : Measure ℝ)).integrableOn_comp_preimage
+      (Homeomorph.neg ℝ).measurableEmbedding]
+  simpa only [Function.comp_def, neg_preimage, neg_Iio, neg_neg, mul_neg, neg_mul,
+    neg_lt_zero] using (integrableOn_exp_mul_Ioi_iff (a := -a) (c := -c))
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Laplace.lean
+++ b/TauCeti/Probability/Distributions/Laplace.lean
@@ -1,16 +1,21 @@
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Claude
+Authors: Claude, Codex
 -/
 module
 
 public import TauCeti.Probability.Density
 public import Mathlib.Probability.CDF
+public import Mathlib.MeasureTheory.Measure.CharacteristicFunction.Basic
+public import Mathlib.Probability.Moments.Basic
+public import Mathlib.Probability.Moments.IntegrableExpMul
 public import Mathlib.Probability.Moments.Variance
+import TauCeti.Analysis.Fourier.ExpNegAbs
 import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
 import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 import Mathlib.MeasureTheory.Integral.Gamma
+import Mathlib.MeasureTheory.Function.JacobianOneDim
 import Mathlib.MeasureTheory.Measure.Lebesgue.Integral
 
 /-!
@@ -20,7 +25,8 @@ The Laplace law with location `μ` and scale `b` is the two-sided exponential la
 `(2 * b)⁻¹ * exp (-|x - μ| / b)`. This file defines it, proves it is a probability measure for
 `0 < b`, identifies it as a `MeasureTheory.HasPDF` law with that density, and computes the cdf,
 every absolute central moment, the mean, and the variance. The variance is derived from the second
-absolute central moment.
+absolute central moment. It also identifies the exact exponential-integrability domain and computes
+the moment-generating, cumulant-generating, and characteristic functions.
 
 **Boundary.** The scale must be positive for the two-sided exponential formula to normalize to a
 probability density, so both
@@ -44,6 +50,11 @@ hypothesis.
 * `integral_pow_abs_sub_laplaceMeasure` — the absolute central moments are `n ! * b ^ n`;
 * `integral_id_laplaceMeasure` — the mean is `μ`;
 * `variance_id_laplaceMeasure` — the variance is `2 * b ^ 2`;
+* `laplaceMeasure_map_add_const` — translation adds to the location parameter;
+* `integrableExpSet_id_laplaceMeasure` — exponential moments are finite exactly on
+  `(-b⁻¹, b⁻¹)`;
+* `mgf_id_laplaceMeasure`, `cgf_id_laplaceMeasure`, and `charFun_laplaceMeasure` — the three
+  standard transforms;
 * `measurable_laplaceMeasure` — the family is measurable in its two parameters, so it can be used
   as a kernel.
 
@@ -63,11 +74,7 @@ invariance of Lebesgue measure, and the variance is the second absolute central 
 
 ## References
 
-* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 3, the **Laplace** target —
-  the measure and its density for `0 < b`, its vanishing for `b ≤ 0`, the mean `μ`, the variance
-  `2 * b ^ 2` and the cdf — together with the Laplace case of the items 1–4 required of every
-  family in "What every distribution must provide". The exponential-integrability domain, the mgf,
-  the cgf and the characteristic function of that same target are not proved here.
+* Roadmap: `TauCetiRoadmap/StandardDistributions/README.md`, Layer 3, the **Laplace** target.
 * Formal declaration scaffold: `TauCetiRoadmap/StandardDistributions/Suggested.lean`, Layer 3.
 * N. L. Johnson, S. Kotz, N. Balakrishnan, *Continuous Univariate Distributions*, vol. 2, 2nd ed.,
   Wiley (1995), ch. 24.
@@ -487,6 +494,228 @@ theorem variance_id_laplaceMeasure (hb : 0 < b) (μ : ℝ) :
   simp only [sq_abs] at h
   rw [h]
   norm_num
+
+private theorem laplaceMeasure_apply_eq_integral (μ b : ℝ) {s : Set ℝ} (hs : MeasurableSet s) :
+    laplaceMeasure μ b s = ENNReal.ofReal (∫ x in s, laplacePDFReal μ b x) := by
+  rw [laplaceMeasure_eq_withDensity]
+  rw [withDensity_apply _ hs]
+  simp_rw [laplacePDF_eq_ofReal]
+  rw [
+    ← ofReal_integral_eq_lintegral_ofReal (integrable_laplacePDFReal μ).integrableOn
+      (.of_forall fun x ↦ (laplacePDFReal_nonneg μ b x))]
+
+/-- Translating a Laplace distribution adds the translation to its location parameter. -/
+@[simp]
+theorem laplaceMeasure_map_add_const (μ y b : ℝ) :
+    (laplaceMeasure μ b).map (· + y) = laplaceMeasure (μ + y) b := by
+  by_cases hb : 0 < b
+  · let e : ℝ ≃ᵐ ℝ := (Homeomorph.addRight y).symm.toMeasurableEquiv
+    have he' : ∀ x, HasDerivAt e ((fun _ ↦ 1) x) x := fun x ↦ (hasDerivAt_id x).sub_const y
+    -- By construction, `e.symm` is the translation `fun x ↦ x + y`.
+    change (laplaceMeasure μ b).map e.symm = laplaceMeasure (μ + y) b
+    ext s hs
+    rw [laplaceMeasure_eq_withDensity]
+    change (volume.withDensity (fun x ↦ ENNReal.ofReal (laplacePDFReal μ b x))).map e.symm s = _
+    rw [e.withDensity_ofReal_map_symm_apply_eq_integral_abs_deriv_mul' hs he'
+      (.of_forall fun x ↦ laplacePDFReal_nonneg μ b x) (integrable_laplacePDFReal μ),
+      laplaceMeasure_apply_eq_integral (μ + y) b hs]
+    simp only [abs_one, one_mul]
+    congr 2 with x
+    dsimp [e, Homeomorph.addRight]
+    rw [laplacePDFReal_of_pos hb, laplacePDFReal_of_pos hb]
+    congr 3
+    ring_nf
+  · simp [laplaceMeasure_of_nonpos (not_lt.mp hb)]
+
+/-! ### Exponential moments and transforms -/
+
+private lemma laplacePDFReal_mul_exp_eq_left (hb : 0 < b) {y : ℝ} (hy : y ≤ μ) (t : ℝ) :
+    Real.exp (t * y) * laplacePDFReal μ b y =
+      ((2 * b)⁻¹ * Real.exp (-(μ / b))) * Real.exp ((t + b⁻¹) * y) := by
+  rw [laplacePDFReal_eq_left hb hy]
+  calc
+    Real.exp (t * y) * ((2 * b)⁻¹ * Real.exp (-(μ / b)) * Real.exp (b⁻¹ * y)) =
+        ((2 * b)⁻¹ * Real.exp (-(μ / b))) *
+          (Real.exp (b⁻¹ * y) * Real.exp (t * y)) := by ring
+    _ = ((2 * b)⁻¹ * Real.exp (-(μ / b))) * Real.exp ((t + b⁻¹) * y) := by
+      rw [← Real.exp_add]
+      congr 2
+      ring
+
+private lemma laplacePDFReal_mul_exp_eq_right (hb : 0 < b) {y : ℝ} (hy : μ ≤ y) (t : ℝ) :
+    Real.exp (t * y) * laplacePDFReal μ b y =
+      ((2 * b)⁻¹ * Real.exp (μ / b)) * Real.exp ((t - b⁻¹) * y) := by
+  rw [laplacePDFReal_eq_right hb hy]
+  calc
+    Real.exp (t * y) * ((2 * b)⁻¹ * Real.exp (μ / b) * Real.exp (-b⁻¹ * y)) =
+        ((2 * b)⁻¹ * Real.exp (μ / b)) *
+          (Real.exp (-b⁻¹ * y) * Real.exp (t * y)) := by ring
+    _ = ((2 * b)⁻¹ * Real.exp (μ / b)) * Real.exp ((t - b⁻¹) * y) := by
+      rw [← Real.exp_add]
+      congr 2
+      ring
+
+/-- **The exact exponential-integrability threshold for a Laplace law.** For positive scale `b`,
+`exp (t * x)` is integrable exactly when `-b⁻¹ < t < b⁻¹`. -/
+@[simp]
+lemma integrable_exp_mul_laplaceMeasure_iff (hb : 0 < b) (μ t : ℝ) :
+    Integrable (fun x : ℝ => Real.exp (t * x)) (laplaceMeasure μ b) ↔
+      t ∈ Set.Ioo (-b⁻¹) b⁻¹ := by
+  rw [laplaceMeasure_eq_withDensity,
+    integrable_withDensity_iff (measurable_laplacePDF μ b)
+      (ae_of_all _ fun y => ENNReal.ofReal_lt_top)]
+  simp only [toReal_laplacePDF]
+  have hc_left : (2 * b)⁻¹ * Real.exp (-(μ / b)) ≠ 0 :=
+    (mul_pos (inv_pos.mpr (mul_pos (by norm_num) hb)) (Real.exp_pos _)).ne'
+  have hc_right : (2 * b)⁻¹ * Real.exp (μ / b) ≠ 0 :=
+    (mul_pos (inv_pos.mpr (mul_pos (by norm_num) hb)) (Real.exp_pos _)).ne'
+  constructor
+  · intro h
+    have hl := h.integrableOn.congr_fun
+      (fun y hy => laplacePDFReal_mul_exp_eq_left hb hy t) measurableSet_Iic
+    have hr := h.integrableOn.congr_fun
+      (fun y hy => laplacePDFReal_mul_exp_eq_right hb (mem_Ioi.mp hy).le t) measurableSet_Ioi
+    have hl' : IntegrableOn (fun y : ℝ => Real.exp ((t + b⁻¹) * y)) (Iic μ) :=
+      (integrable_const_mul_iff (isUnit_iff_ne_zero.mpr hc_left) _).mp hl
+    have hr' : IntegrableOn (fun y : ℝ => Real.exp ((t - b⁻¹) * y)) (Ioi μ) :=
+      (integrable_const_mul_iff (isUnit_iff_ne_zero.mpr hc_right) _).mp hr
+    exact ⟨by have := integrableOn_exp_mul_Iic_iff.mp hl'; linarith,
+      by have := integrableOn_exp_mul_Ioi_iff.mp hr'; linarith⟩
+  · rintro ⟨ht_lower, ht_upper⟩
+    have hl' : IntegrableOn (fun y : ℝ => Real.exp ((t + b⁻¹) * y)) (Iic μ) :=
+      integrableOn_exp_mul_Iic_iff.mpr (by linarith)
+    have hr' : IntegrableOn (fun y : ℝ => Real.exp ((t - b⁻¹) * y)) (Ioi μ) :=
+      integrableOn_exp_mul_Ioi_iff.mpr (by linarith)
+    have hl : IntegrableOn (fun y : ℝ => Real.exp (t * y) * laplacePDFReal μ b y)
+        (Iic μ) :=
+      IntegrableOn.congr_fun (hl'.const_mul ((2 * b)⁻¹ * Real.exp (-(μ / b))))
+        (fun y hy => (laplacePDFReal_mul_exp_eq_left hb hy t).symm) measurableSet_Iic
+    have hr : IntegrableOn (fun y : ℝ => Real.exp (t * y) * laplacePDFReal μ b y)
+        (Ioi μ) :=
+      IntegrableOn.congr_fun (hr'.const_mul ((2 * b)⁻¹ * Real.exp (μ / b)))
+        (fun y hy => (laplacePDFReal_mul_exp_eq_right hb (mem_Ioi.mp hy).le t).symm)
+        measurableSet_Ioi
+    rw [← integrableOn_univ, ← Iic_union_Ioi (a := μ)]
+    exact hl.union hr
+
+/-- **The exact exponential-integrability domain** of a Laplace law with positive scale `b` is
+`(-b⁻¹, b⁻¹)`. -/
+@[simp]
+theorem integrableExpSet_id_laplaceMeasure (hb : 0 < b) (μ : ℝ) :
+    integrableExpSet id (laplaceMeasure μ b) = Set.Ioo (-b⁻¹) b⁻¹ := by
+  ext t
+  simpa [integrableExpSet] using integrable_exp_mul_laplaceMeasure_iff hb μ t
+
+/-- **The moment-generating function of a Laplace law** with location `μ` and positive scale `b`,
+on its exact finiteness domain. -/
+@[simp]
+theorem mgf_id_laplaceMeasure (hb : 0 < b) (μ : ℝ) {t : ℝ}
+    (ht : t ∈ Set.Ioo (-b⁻¹) b⁻¹) :
+    mgf id (laplaceMeasure μ b) t = Real.exp (μ * t) / (1 - b ^ 2 * t ^ 2) := by
+  have hmeasure : Integrable (fun y : ℝ => Real.exp (t * y)) (laplaceMeasure μ b) :=
+    (integrable_exp_mul_laplaceMeasure_iff hb μ t).2 ht
+  have hint : Integrable
+      (fun y : ℝ => laplacePDFReal μ b y * Real.exp (t * y)) := by
+    rw [laplaceMeasure_eq_withDensity,
+      integrable_withDensity_iff (measurable_laplacePDF μ b)
+        (ae_of_all _ fun y => ENNReal.ofReal_lt_top)] at hmeasure
+    simpa only [toReal_laplacePDF, smul_eq_mul, mul_comm] using hmeasure
+  rw [mgf, laplaceMeasure_eq_withDensity, integral_withDensity_eq_integral_toReal_smul
+    (measurable_laplacePDF μ b) (ae_of_all _ fun y => ENNReal.ofReal_lt_top)]
+  simp only [id_eq, toReal_laplacePDF, smul_eq_mul]
+  rw [← intervalIntegral.integral_Iic_add_Ioi hint.integrableOn hint.integrableOn,
+    setIntegral_congr_fun measurableSet_Iic (fun y hy => by
+      calc
+        laplacePDFReal μ b y * Real.exp (t * y) =
+            Real.exp (t * y) * laplacePDFReal μ b y := mul_comm _ _
+        _ = _ := laplacePDFReal_mul_exp_eq_left hb hy t),
+    setIntegral_congr_fun measurableSet_Ioi (fun y hy => by
+      calc
+        laplacePDFReal μ b y * Real.exp (t * y) =
+            Real.exp (t * y) * laplacePDFReal μ b y := mul_comm _ _
+        _ = _ := laplacePDFReal_mul_exp_eq_right hb (mem_Ioi.mp hy).le t),
+    integral_const_mul, integral_exp_mul_Iic (by linarith [ht.1]) μ,
+    integral_const_mul, integral_exp_mul_Ioi (by linarith [ht.2]) μ]
+  have hb_inv : b * b⁻¹ = 1 := by field_simp
+  have hplus : 0 < 1 + b * t := by
+    nlinarith [mul_pos hb (show 0 < t + b⁻¹ by linarith [ht.1])]
+  have hminus : 0 < 1 - b * t := by
+    nlinarith [mul_pos hb (show 0 < b⁻¹ - t by linarith [ht.2])]
+  have hden : 1 - b ^ 2 * t ^ 2 ≠ 0 := by
+    have : 0 < (1 - b * t) * (1 + b * t) := mul_pos hminus hplus
+    nlinarith
+  have hleft : t + b⁻¹ ≠ 0 := ne_of_gt (by linarith [ht.1])
+  have hright : t - b⁻¹ ≠ 0 := ne_of_lt (by linarith [ht.2])
+  have hplus_ne : b * t + 1 ≠ 0 := by nlinarith
+  have hminus_ne : b * t - 1 ≠ 0 := by nlinarith
+  have hexp_left :
+      Real.exp (-(μ / b)) * Real.exp (μ * (b * t + 1) / b) = Real.exp (μ * t) := by
+    rw [← Real.exp_add]
+    congr 1
+    field_simp
+    ring
+  have hexp_right :
+      Real.exp (μ / b) * Real.exp (μ * (b * t - 1) / b) = Real.exp (μ * t) := by
+    rw [← Real.exp_add]
+    congr 1
+    field_simp
+    ring
+  field_simp
+  rw [hexp_left, mul_assoc (b * t + 1), hexp_right]
+  ring
+
+/-- **The cumulant-generating function of a Laplace law** is the real logarithm of its mgf on
+the exact finiteness domain. -/
+@[simp]
+theorem cgf_id_laplaceMeasure (hb : 0 < b) (μ : ℝ) {t : ℝ}
+    (ht : t ∈ Set.Ioo (-b⁻¹) b⁻¹) :
+    cgf id (laplaceMeasure μ b) t =
+      Real.log (Real.exp (μ * t) / (1 - b ^ 2 * t ^ 2)) := by
+  rw [cgf, mgf_id_laplaceMeasure hb μ ht]
+
+private theorem charFun_laplaceMeasure_zero_loc (hb : 0 < b) (t : ℝ) :
+    charFun (laplaceMeasure 0 b) t = ((1 / (1 + b ^ 2 * t ^ 2) : ℝ) : ℂ) := by
+  have hpair := integral_exp_mul_I_mul_exp_neg_mul_abs (inv_pos.mpr hb) t
+  rw [charFun_apply_real, laplaceMeasure_eq_withDensity,
+    integral_withDensity_eq_integral_toReal_smul (measurable_laplacePDF 0 b)
+      (ae_of_all _ fun x => ENNReal.ofReal_lt_top)]
+  simp_rw [toReal_laplacePDF]
+  calc
+    (∫ x : ℝ, laplacePDFReal 0 b x •
+          Complex.exp ((t : ℂ) * x * Complex.I)) =
+        (((2 * b)⁻¹ : ℝ) : ℂ) *
+          ∫ x : ℝ, Complex.exp ((t : ℂ) * x * Complex.I) *
+            (Real.exp (-(b⁻¹ * |x|)) : ℂ) := by
+      rw [← integral_const_mul]
+      refine integral_congr_ae (.of_forall fun x ↦ ?_)
+      dsimp only
+      rw [Complex.real_smul, laplacePDFReal_of_pos hb]
+      simp only [sub_zero]
+      have hdecay : -|x| / b = -(b⁻¹ * |x|) := by
+        field_simp
+      rw [hdecay, Complex.ofReal_exp]
+      push_cast
+      ring
+    _ = (((2 * b)⁻¹ : ℝ) : ℂ) *
+        ((2 * b⁻¹ / (b⁻¹ ^ 2 + t ^ 2) : ℝ) : ℂ) := by rw [hpair]
+    _ = ((1 / (1 + b ^ 2 * t ^ 2) : ℝ) : ℂ) := by
+      norm_cast
+      have hb0 : b ≠ 0 := hb.ne'
+      have hden : b⁻¹ ^ 2 + t ^ 2 ≠ 0 := by positivity
+      field_simp
+
+/-- **The characteristic function of a Laplace law** with location `μ` and positive scale `b` is
+`exp (i μ t) / (1 + b²t²)`. -/
+@[simp]
+theorem charFun_laplaceMeasure (hb : 0 < b) (μ t : ℝ) :
+    charFun (laplaceMeasure μ b) t =
+      Complex.exp (Complex.I * μ * t) / (1 + b ^ 2 * t ^ 2) := by
+  have hmap := laplaceMeasure_map_add_const 0 μ b
+  simp only [zero_add] at hmap
+  rw [← hmap, charFun_map_add_const, charFun_laplaceMeasure_zero_loc hb]
+  simp only [RCLike.inner_apply, conj_trivial]
+  push_cast
+  ring_nf
 
 /-! ### Measurability in the parameters -/
 

--- a/TauCeti/Probability/Distributions/Laplace.lean
+++ b/TauCeti/Probability/Distributions/Laplace.lean
@@ -511,11 +511,15 @@ theorem laplaceMeasure_map_add_const (μ y b : ℝ) :
   by_cases hb : 0 < b
   · let e : ℝ ≃ᵐ ℝ := (Homeomorph.addRight y).symm.toMeasurableEquiv
     have he' : ∀ x, HasDerivAt e ((fun _ ↦ 1) x) x := fun x ↦ (hasDerivAt_id x).sub_const y
-    -- By construction, `e.symm` is the translation `fun x ↦ x + y`.
-    change (laplaceMeasure μ b).map e.symm = laplaceMeasure (μ + y) b
+    have he_symm : e.symm = (fun x : ℝ ↦ x + y) := by
+      ext x
+      simp [e, Homeomorph.addRight]
+    rw [← he_symm]
     ext s hs
-    rw [laplaceMeasure_eq_withDensity]
-    change (volume.withDensity (fun x ↦ ENNReal.ofReal (laplacePDFReal μ b x))).map e.symm s = _
+    have hpdf : laplacePDF μ b = fun x ↦ ENNReal.ofReal (laplacePDFReal μ b x) := by
+      funext x
+      rw [laplacePDF_eq_ofReal]
+    rw [laplaceMeasure_eq_withDensity, hpdf]
     rw [e.withDensity_ofReal_map_symm_apply_eq_integral_abs_deriv_mul' hs he'
       (.of_forall fun x ↦ laplacePDFReal_nonneg μ b x) (integrable_laplacePDFReal μ),
       laplaceMeasure_apply_eq_integral (μ + y) b hs]


### PR DESCRIPTION
This PR completes the Laplace transform target in `TauCetiRoadmap/StandardDistributions/README.md`, Layer 3, **Laplace**: identify `integrableExpSet id (laplaceMeasure μ b)` exactly as `Set.Ioo (-b⁻¹) b⁻¹` for `0 < b`, compute the mgf `exp (μt) / (1 - b²t²)` and its real-logarithm cgf on that domain, and prove the characteristic function `exp (iμt) / (1 + b²t²)`.

The designated milestone is Layer 3, **new scalar families**, the Laplace family. This is the most effective current step because the measure, density, cdf, moments, and parameter measurability already landed in #4590 while its description explicitly left these four transform results outstanding; completing them closes the family and supplies the law needed by Layer 4's difference-of-independent-exponentials target without overlapping the chi-squared or multivariate-Gaussian work currently in flight. After this PR, the Laplace entry is complete; Layer 3 still needs the log-normal, Weibull, inverse-gamma, Student's t, Fisher's F, negative-binomial, and hypergeometric families before Layer 4 can be completed.

The proof splits exponential integrability over the two half-lines at the location and adds the left-half-line dual of `TauCeti.integrableOn_exp_mul_Ioi_iff` to the existing exponential-decay API. It evaluates the mgf using Mathlib's `integral_exp_mul_Iic` and `integral_exp_mul_Ioi`, proves translation directly at the measure level through Mathlib's one-dimensional with-density change-of-variables theorem, and derives the centered characteristic function from Tau Ceti's existing `integral_exp_mul_I_mul_exp_neg_mul_abs`. No Mathlib source or external formalization is vendored. The formulas follow Johnson, Kotz, and Balakrishnan, *Continuous Univariate Distributions*, volume 2, chapter 24, as cited in the module documentation.

Extend `TauCeti/MeasureTheory/Integral/ExpDecay.lean` by 24 lines and `TauCeti/Probability/Distributions/Laplace.lean` by 236 additions and 7 deletions.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"laplace-transforms"}-->

🤖 Prepared with Codex
