### PR TITLE
feat: embed weight Levi subgroups in parabolics

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Normal.lean
@@ -5,6 +5,7 @@ Authors: Codex
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Levi
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Parabolic
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Unipotent.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Basic
@@ -12,13 +13,18 @@ public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
 
 /-!
-# Normality of weight-unipotent subgroups in weight parabolics
+# Weight Levi and unipotent subgroups inside weight parabolics
 
 For an integer weight `w` on the standard representation, the weight-unipotent subgroup is a
 closed normal subgroup of the corresponding weight parabolic. On coordinate rings, the
 parabolic defining Hopf ideal is contained in the unipotent defining Hopf ideal. Mapping the
 latter into the parabolic coordinate Hopf algebra therefore cuts out the same unipotent group
 scheme, now regarded as a closed subgroup of the parabolic.
+
+The weight Levi is likewise a closed subgroup of the weight parabolic. Its relative defining
+Hopf ideal is the image of the ambient weight-Levi ideal in the parabolic coordinate algebra.
+The resulting quotient spectrum is canonically the already-defined weight-Levi group scheme,
+and its inclusion through the parabolic agrees with the direct inclusion into `GL_N`.
 
 Normality is proved honestly at the scheme level. The functor-of-points criterion for a normal
 Hopf ideal reduces it to conjugation over every commutative value algebra, where it is precisely
@@ -36,6 +42,12 @@ the existing dynamic statement that the weight parabolic normalizes its unipoten
   identification of the relative quotient spectrum with the weight-unipotent group scheme.
 * `TauCeti.GeneralLinear.Dynamic.weightUnipotentToParabolic`: the resulting closed immersion of
   group schemes.
+* `TauCeti.GeneralLinear.Dynamic.weightLeviInParabolicHopfIdeal`: the relative Hopf ideal cutting
+  out the weight Levi inside the weight parabolic.
+* `TauCeti.GeneralLinear.Dynamic.weightLeviInParabolicGroupSchemeIso`: its quotient spectrum is
+  canonically the weight-Levi group scheme.
+* `TauCeti.GeneralLinear.Dynamic.weightLeviToParabolic`: the compatible closed immersion of the
+  weight Levi into the weight parabolic.
 
 ## References
 
@@ -43,8 +55,8 @@ the existing dynamic statement that the weight parabolic normalizes its unipoten
 * J. S. Milne, *Algebraic Groups* (2017), Chapter 13.
 
 This advances the dynamic Levi-decomposition milestone in Layer 7, "Structure theory", of the
-ReductiveGroups roadmap by supplying the scheme-level normality of the represented unipotent
-subgroup in its represented parabolic.
+ReductiveGroups roadmap by supplying both represented factors inside the weight parabolic. The
+relative Levi is the acting factor required by the scheme-level semidirect-product decomposition.
 -/
 
 public section
@@ -74,6 +86,38 @@ theorem weightParabolicDefiningHopfIdeal_le_weightUnipotent (w : Fin N → ℤ) 
   simpa [Matrix.one_apply, hne] using
     sub_one_apply_mem_weightUnipotentRelationSet R w hij.le
 
+/-- The defining Hopf ideal of the weight parabolic is contained in that of the weight Levi.
+Contravariantly, the weight-Levi group scheme is a closed subgroup of the weight-parabolic group
+scheme. -/
+theorem weightParabolicDefiningHopfIdeal_le_weightLevi (w : Fin N → ℤ) :
+    weightParabolicDefiningHopfIdeal R w ≤ weightLeviDefiningHopfIdeal R w := by
+  rw [weightLeviDefiningHopfIdeal_def]
+  exact le_sup_left
+
+/-- The Hopf ideal in the weight-parabolic coordinate algebra which cuts out the weight Levi. -/
+noncomputable def weightLeviInParabolicHopfIdeal (w : Fin N → ℤ) :
+    HopfIdeal R (weightParabolicCoordinateHopfAlgebra R w) :=
+  (weightLeviDefiningHopfIdeal R w).map (weightParabolicCoordinateMap R w).hom
+
+/-- Pulling the relative weight-Levi Hopf ideal back to the ambient general linear coordinate
+algebra recovers the original weight-Levi defining ideal. -/
+@[simp]
+theorem weightLeviInParabolicHopfIdeal_comapOfSurjective (w : Fin N → ℤ) :
+    (weightLeviInParabolicHopfIdeal R w).comapOfSurjective
+        (weightParabolicCoordinateMap R w).hom
+        (weightParabolicCoordinateMap_surjective R w) =
+      weightLeviDefiningHopfIdeal R w := by
+  have hker :
+      HopfIdeal.kerOfSurjective (weightParabolicCoordinateMap R w).hom
+          (weightParabolicCoordinateMap_surjective R w) =
+        weightParabolicDefiningHopfIdeal R w := by
+    ext x
+    rw [HopfIdeal.mem_kerOfSurjective, weightParabolicCoordinateMap_apply,
+      Ideal.Quotient.mkₐ_eq_mk, Ideal.Quotient.eq_zero_iff_mem, HopfIdeal.mem_toIdeal]
+  rw [weightLeviInParabolicHopfIdeal,
+    HopfIdeal.comapOfSurjective_map, hker, sup_eq_left]
+  exact weightParabolicDefiningHopfIdeal_le_weightLevi R w
+
 /-- The Hopf ideal in the weight-parabolic coordinate algebra which cuts out the
 weight-unipotent subgroup. -/
 noncomputable def weightUnipotentInParabolicHopfIdeal (w : Fin N → ℤ) :
@@ -102,6 +146,39 @@ theorem weightUnipotentInParabolicHopfIdeal_comapOfSurjective (w : Fin N → ℤ
 section Points
 
 variable {A : Type v} [CommRing A] [Algebra R A]
+
+/-- A parabolic point belongs to the subgroup cut out by the relative Levi Hopf ideal exactly
+when its ambient general linear point belongs to the weight-Levi subgroup. -/
+@[simp]
+theorem mem_weightLeviInParabolicPointsSubgroup_iff (w : Fin N → ℤ)
+    (f : HopfAlgebra.points (R := R) (H := weightParabolicCoordinateHopfAlgebra R w)
+      (CommAlgCat.of R A)) :
+    f ∈ CommHopfAlgCat.quotientPointsSubgroup
+        (weightParabolicCoordinateHopfAlgebra R w)
+        (weightLeviInParabolicHopfIdeal R w) (CommAlgCat.of R A) ↔
+      CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
+          (weightParabolicDefiningHopfIdeal R w) (CommAlgCat.of R A) f ∈
+        CommHopfAlgCat.quotientPointsSubgroup (coordinateHopfAlgebra R N)
+          (weightLeviDefiningHopfIdeal R w) (CommAlgCat.of R A) := by
+  rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff,
+    CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
+  constructor
+  · intro hf x hx
+    have hqx := hf ((weightParabolicCoordinateMap R w).hom x)
+      (HopfIdeal.mem_map_of_mem (weightParabolicCoordinateMap R w).hom hx)
+    rw [weightParabolicCoordinateMap_apply] at hqx
+    rw [CommHopfAlgCat.quotientPointsHom_apply_apply]
+    exact hqx
+  · intro hf y hy
+    rw [weightLeviInParabolicHopfIdeal] at hy
+    obtain ⟨x, hx, hxy⟩ :=
+      (HopfIdeal.mem_map_iff_of_surjective
+        (weightParabolicCoordinateMap_surjective R w)).mp hy
+    subst y
+    have hx0 := hf x hx
+    rw [CommHopfAlgCat.quotientPointsHom_apply_apply] at hx0
+    rw [weightParabolicCoordinateMap_apply]
+    exact hx0
 
 /-- A parabolic point belongs to the subgroup cut out by the relative unipotent Hopf ideal
 exactly when its ambient general linear point belongs to the weight-unipotent subgroup. -/
@@ -169,6 +246,81 @@ private theorem mkQuotient_comp_eqToIso {H : _root_.CommHopfAlgCat.{u} R}
       CommHopfAlgCat.mkQuotient H J := by
   subst J
   simp
+
+/-- The quotient-coordinate isomorphism underlying the identification of the relative
+weight-Levi quotient spectrum. -/
+private noncomputable def weightLeviInParabolicCoordinateIso (w : Fin N → ℤ) :
+    weightLeviCoordinateHopfAlgebra R w ≅
+      CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+        (weightLeviInParabolicHopfIdeal R w) :=
+  eqToIso (congrArg (CommHopfAlgCat.quotient (coordinateHopfAlgebra R N))
+      (weightLeviInParabolicHopfIdeal_comapOfSurjective R w).symm) ≪≫
+    CommHopfAlgCat.quotientIsoOfSurjective
+      (weightParabolicCoordinateMap R w)
+      (weightParabolicCoordinateMap_surjective R w)
+      (weightLeviInParabolicHopfIdeal R w)
+
+/-- The relative quotient spectrum cut out inside the weight parabolic is canonically
+isomorphic to the weight-Levi group scheme. -/
+noncomputable def weightLeviInParabolicGroupSchemeIso (w : Fin N → ℤ) :
+    CommHopfAlgCat.quotientSpec (weightParabolicCoordinateHopfAlgebra R w)
+        (weightLeviInParabolicHopfIdeal R w) ≅
+      weightLeviGroupScheme R w :=
+  (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).mapIso
+    (weightLeviInParabolicCoordinateIso R w).op
+
+/-- The closed immersion of the weight-Levi group scheme into the weight-parabolic group scheme
+induced by inclusion of their defining Hopf ideals. -/
+noncomputable def weightLeviToParabolic (w : Fin N → ℤ) :
+    weightLeviGroupScheme R w ⟶ weightParabolicGroupScheme R w :=
+  CommHopfAlgCat.quotientSpecMapOfLe (coordinateHopfAlgebra R N)
+    (weightParabolicDefiningHopfIdeal_le_weightLevi R w)
+
+/-- The weight-Levi-to-parabolic morphism is a closed immersion. -/
+instance isClosedImmersion_weightLeviToParabolic (w : Fin N → ℤ) :
+    IsClosedImmersion (weightLeviToParabolic R w).hom.hom.left := by
+  rw [weightLeviToParabolic]
+  infer_instance
+
+/-- Including the weight-Levi group scheme through the weight parabolic agrees with its direct
+inclusion into the general linear group scheme. -/
+@[simp]
+theorem weightLeviToParabolic_comp_inclusion (w : Fin N → ℤ) :
+    weightLeviToParabolic R w ≫ weightParabolicInclusion R w =
+      weightLeviInclusion R w := by
+  rw [weightLeviToParabolic, weightParabolicInclusion_def,
+    weightLeviInclusion_def, ← Category.assoc,
+    CommHopfAlgCat.quotientSpecMapOfLe_comp_quotientSpecι]
+
+/-- Under the canonical identification with the weight-Levi group scheme, the relative
+quotient-spectrum inclusion is `weightLeviToParabolic`. -/
+@[simp]
+theorem weightLeviInParabolicGroupSchemeIso_hom_comp_weightLeviToParabolic
+    (w : Fin N → ℤ) :
+    (weightLeviInParabolicGroupSchemeIso R w).hom ≫ weightLeviToParabolic R w =
+      CommHopfAlgCat.quotientSpecι (weightParabolicCoordinateHopfAlgebra R w)
+        (weightLeviInParabolicHopfIdeal R w) := by
+  rw [weightLeviInParabolicGroupSchemeIso, weightLeviToParabolic,
+    CommHopfAlgCat.quotientSpecMapOfLe_def, CommHopfAlgCat.quotientSpecι_def,
+    Functor.mapIso_hom, Iso.op_hom,
+    ← (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map_comp, ← op_comp]
+  congr 2
+  let q := weightParabolicCoordinateMap R w
+  let hq := weightParabolicCoordinateMap_surjective R w
+  let _ : Epi q := ConcreteCategory.epi_of_surjective q hq
+  rw [← cancel_epi q]
+  have hq_def : weightParabolicCoordinateMap R w =
+      CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra R N)
+        (weightParabolicDefiningHopfIdeal R w) := by
+    ext x
+    rw [weightParabolicCoordinateMap_apply, CommHopfAlgCat.mkQuotient_apply]
+  dsimp only [q]
+  rw [hq_def, ← Category.assoc,
+    CommHopfAlgCat.mkQuotient_comp_quotientMapOfLe]
+  rw [weightLeviInParabolicCoordinateIso, Iso.trans_hom, ← Category.assoc,
+    mkQuotient_comp_eqToIso (R := R)
+      (weightLeviInParabolicHopfIdeal_comapOfSurjective R w).symm,
+    CommHopfAlgCat.mkQuotient_comp_quotientIsoOfSurjective_hom, hq_def]
 
 /-- The quotient-coordinate isomorphism underlying the identification of the relative
 weight-unipotent quotient spectrum. -/


### PR DESCRIPTION
This PR constructs the weight Levi as a closed subgroup of its represented weight parabolic: map the ambient Levi defining Hopf ideal into the parabolic coordinate algebra, identify its pullback and algebra-valued points, canonically identify the resulting quotient spectrum with the existing weight-Levi group scheme, and prove that inclusion through the parabolic agrees with the direct inclusion into `GL_N`. It advances the exact `TauCetiRoadmap/ReductiveGroups/README.md` Layer 7 target “parabolic subgroups and Levi decomposition,” following the roadmap’s dynamic approach to parabolics, Levi subgroups, and unipotent radicals.

The designated milestone is the functorial dynamic Levi decomposition. This is the most effective current step because the pointwise semidirect-product equivalence and its naturality are on `main`, as are representations of the parabolic, Levi, and unipotent functors and the relative normal unipotent subgroup, while no open PR supplies the relative Levi ideal required as the acting factor by `CommHopfAlgCat.normalSemidirectProduct`. After this PR, the milestone still needs the coordinate Hopf-algebra isomorphism from that represented semidirect product to the weight parabolic, followed by passage from diagonal weight cocharacters of `GL_N` to general cocharacters and affine group schemes.

The implementation extends `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Normal.lean` by 155 additions and 3 documentation/import-order deletions (401 lines total). It reuses `HopfIdeal.comapOfSurjective_map`, `CommHopfAlgCat.quotientIsoOfSurjective`, and `CommHopfAlgCat.quotientSpecMapOfLe`; no Mathlib source or external formalization is vendored. Its mathematical organization follows Kempf, *Instability in invariant theory*, §2, and Milne, *Algebraic Groups* (2017), Chapter 13, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"weight-levi-in-parabolic"}-->

🤖 Prepared with Codex
