### PR TITLE
feat: the strictness of a morphism of mixed Hodge structures

### DIFF
--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -152,14 +152,9 @@ theorem rationalToComplexLinearEquiv_one_tmul_mem (hℚ : IsBaseChange ℚ ιℚ
   rw [rationalToComplexSubmodule_eq_span]
   exact Submodule.subset_span ⟨x, hx, rfl⟩
 
-/-- Complexification of rational subspaces is monotone. -/
-theorem rationalToComplexSubmodule_mono (hℚ : IsBaseChange ℚ ιℚ)
-    (hℂ : IsBaseChange ℂ ιℂ) :
-    Monotone (rationalToComplexSubmodule hℚ hℂ) := fun _ _ h ↦
-  Submodule.map_mono (Submodule.baseChange_mono ℂ h)
-
 /-- Complexification of rational subspaces reflects inclusions: `ℂ` is faithfully flat over `ℚ`,
 so an inclusion of rational subspaces may be tested on the complexifications. -/
+@[simp]
 theorem rationalToComplexSubmodule_le_iff (hℚ : IsBaseChange ℚ ιℚ)
     (hℂ : IsBaseChange ℂ ιℂ) (W₁ W₂ : Submodule ℚ Vℚ) :
     rationalToComplexSubmodule hℚ hℂ W₁ ≤ rationalToComplexSubmodule hℚ hℂ W₂ ↔ W₁ ≤ W₂ := by
@@ -168,6 +163,12 @@ theorem rationalToComplexSubmodule_le_iff (hℚ : IsBaseChange ℚ ιℚ)
       (f := (rationalToComplexLinearEquiv hℚ hℂ).toLinearMap)
       (rationalToComplexLinearEquiv hℚ hℂ).injective,
     Submodule.baseChange_le_iff]
+
+/-- Complexification of rational subspaces is monotone. -/
+theorem rationalToComplexSubmodule_mono (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) :
+    Monotone (rationalToComplexSubmodule hℚ hℂ) := fun _ _ h ↦
+  (rationalToComplexSubmodule_le_iff hℚ hℂ _ _).2 h
 
 @[simp]
 theorem rationalToComplexSubmodule_bot (hℚ : IsBaseChange ℚ ιℚ)
@@ -181,10 +182,8 @@ over `ℚ`. -/
 theorem rationalToComplexSubmodule_eq_bot_iff (hℚ : IsBaseChange ℚ ιℚ)
     (hℂ : IsBaseChange ℂ ιℂ) (W : Submodule ℚ Vℚ) :
     rationalToComplexSubmodule hℚ hℂ W = ⊥ ↔ W = ⊥ := by
-  rw [rationalToComplexSubmodule, Submodule.map_eq_bot_iff]
-  refine ⟨fun h ↦ Submodule.baseChange_injective (A := ℂ) (by simp [h]), ?_⟩
-  rintro rfl
-  simp
+  rw [← le_bot_iff, ← rationalToComplexSubmodule_bot hℚ hℂ,
+    rationalToComplexSubmodule_le_iff, le_bot_iff]
 
 @[simp]
 theorem rationalToComplexSubmodule_top (hℚ : IsBaseChange ℚ ιℚ)

--- a/TauCeti/Geometry/Hodge/BaseChange.lean
+++ b/TauCeti/Geometry/Hodge/BaseChange.lean
@@ -51,6 +51,8 @@ imposed later as structure data.
   subspaces.
 * `TauCeti.Hodge.rationalToComplexSubmodule_eq_bot_iff`: only the zero subspace has trivial
   complexification.
+* `TauCeti.Hodge.rationalToComplexSubmodule_le_iff`: an inclusion of rational subspaces can be
+  tested on their complexifications.
 
 The design follows the base-change interface specified in the Hodge structures roadmap. Its only
 nontrivial comparison map is Mathlib's
@@ -155,6 +157,17 @@ theorem rationalToComplexSubmodule_mono (hℚ : IsBaseChange ℚ ιℚ)
     (hℂ : IsBaseChange ℂ ιℂ) :
     Monotone (rationalToComplexSubmodule hℚ hℂ) := fun _ _ h ↦
   Submodule.map_mono (Submodule.baseChange_mono ℂ h)
+
+/-- Complexification of rational subspaces reflects inclusions: `ℂ` is faithfully flat over `ℚ`,
+so an inclusion of rational subspaces may be tested on the complexifications. -/
+theorem rationalToComplexSubmodule_le_iff (hℚ : IsBaseChange ℚ ιℚ)
+    (hℂ : IsBaseChange ℂ ιℂ) (W₁ W₂ : Submodule ℚ Vℚ) :
+    rationalToComplexSubmodule hℚ hℂ W₁ ≤ rationalToComplexSubmodule hℚ hℂ W₂ ↔ W₁ ≤ W₂ := by
+  rw [rationalToComplexSubmodule, rationalToComplexSubmodule,
+    Submodule.map_le_map_iff_of_injective
+      (f := (rationalToComplexLinearEquiv hℚ hℂ).toLinearMap)
+      (rationalToComplexLinearEquiv hℚ hℂ).injective,
+    Submodule.baseChange_le_iff]
 
 @[simp]
 theorem rationalToComplexSubmodule_bot (hℚ : IsBaseChange ℚ ιℚ)

--- a/TauCeti/Geometry/Hodge/Mixed/Decomposition.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/Decomposition.lean
@@ -41,10 +41,14 @@ it.
   larger total degree, and what is left has a class in `gr^W_{p+q}` lying both in `H^{p,q}` and in
   the complementary `conj F^{q+1} ⊔ F^{p+1}`, hence vanishing.
 
-What remains of Deligne's theory after this file: the recovery
-`F^p = ⨆_{p' ≥ p} ⨆_{q'} I^{p',q'}` of the Hodge filtration, the conjugation symmetry
-`I^{p,q} ≡ conj I^{q,p}` modulo strictly lower bidegree, and the strictness of a morphism of mixed
-Hodge structures.
+The Hodge filtration is recovered from the bigrading by the same upward induction on the weight:
+a vector of `F^p ∩ W_k` has its class in `gr^W_k` in the `p`-th step of the induced Hodge
+filtration, so — the graded piece being pure — that class is a sum of Hodge components of first
+index at least `p`, each the image of a bigrading piece; correcting the vector by a representative
+of that sum drops it into `F^p ∩ W_{k-1}`.
+
+What remains of Deligne's theory after this file: the conjugation symmetry
+`I^{p,q} ≡ conj I^{q,p}` modulo strictly lower bidegree.
 
 ## Main declarations
 
@@ -59,6 +63,8 @@ Hodge structures.
   independent.
 * `TauCeti.Hodge.MixedHodgeStructure.isInternal_deligneSplittingFamily`: **Deligne's theorem**,
   the bigrading is an internal direct sum.
+* `TauCeti.Hodge.MixedHodgeStructure.F_eq_iSup_deligneSplitting`: the recovery
+  `F^p = ⨆_{p' ≥ p} ⨆_{q'} I^{p',q'}` of the Hodge filtration.
 
 ## References
 
@@ -530,6 +536,93 @@ theorem isInternal_deligneSplittingFamily :
   classical
   exact DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top
     mhs.iSupIndep_deligneSplittingFamily mhs.iSup_deligneSplittingFamily_eq_top
+
+/-! ### The recovery of the Hodge filtration -/
+
+/-- The image of the bigrading piece `I^{p,q}` in the graded piece of its total degree, with the
+total degree presented as an equation.
+
+Deligne's theory constantly matches a bidegree against a weight index, and the graded piece the
+image lands in occurs in the *type* of that image; naming the weight index separately keeps those
+matches out of dependent rewriting. -/
+theorem map_deligneSplitting_eq_piece_of_add_eq {p q k : ℤ} (hk : p + q = k) :
+    ((mhs.deligneSplitting p q).submoduleOf (mhs.WC k)).map
+        ((mhs.WC (k - 1)).submoduleOf (mhs.WC k)).mkQ =
+      (mhs.complexGradedHodgeStructure k).piece p := by
+  subst hk
+  exact mhs.map_deligneSplitting_eq_piece p q
+
+/-- Every bigrading piece whose first index is at least `p` lies in `F^p`. -/
+theorem iSup_deligneSplitting_le_F (p : ℤ) :
+    (⨆ (rs : ℤ × ℤ) (_ : p ≤ rs.1), mhs.deligneSplitting rs.1 rs.2) ≤ mhs.F p :=
+  iSup₂_le fun rs hrs ↦ (mhs.deligneSplitting_le_F rs.1 rs.2).trans (mhs.F_antitone hrs)
+
+/-- The inductive step recovering the Hodge filtration: if the bigrading pieces of first index at
+least `p` already exhaust `F^p ∩ W_{k-1}`, they exhaust `F^p ∩ W_k`.
+
+The class in `gr^W_k` of a vector of `F^p ∩ W_k` lies in the `p`-th step of the induced Hodge
+filtration, hence — the graded piece being pure — in the sum of its Hodge components of first
+index at least `p`. Each of those components is the image of a bigrading piece, so the class has a
+representative among the bigrading pieces of first index at least `p`; subtracting it leaves a
+vector of `F^p ∩ W_{k-1}`. -/
+private theorem F_inf_WC_le_of_F_inf_WC_sub_one_le {p k : ℤ}
+    (ih : mhs.F p ⊓ mhs.WC (k - 1) ≤
+      ⨆ (rs : ℤ × ℤ) (_ : p ≤ rs.1), mhs.deligneSplitting rs.1 rs.2) :
+    mhs.F p ⊓ mhs.WC k ≤
+      ⨆ (rs : ℤ × ℤ) (_ : p ≤ rs.1), mhs.deligneSplitting rs.1 rs.2 := by
+  rintro x ⟨hxF, hxW⟩
+  have hmk : Submodule.Quotient.mk (⟨x, hxW⟩ : mhs.WC k) ∈
+      (mhs.complexGradedHodgeStructure k).F p :=
+    mhs.mk_mem_complexGradedHodgeStructure_F k p ⟨x, hxW⟩ hxF
+  rw [(mhs.complexGradedHodgeStructure k).F_eq_iSup_piece p] at hmk
+  have hpiece : ∀ r : ℤ, (mhs.complexGradedHodgeStructure k).piece r =
+      ((mhs.deligneSplitting r (k - r)).submoduleOf (mhs.WC k)).map
+        ((mhs.WC (k - 1)).submoduleOf (mhs.WC k)).mkQ :=
+    fun r ↦ (mhs.map_deligneSplitting_eq_piece_of_add_eq (by ring)).symm
+  simp only [hpiece, ← Submodule.map_iSup] at hmk
+  obtain ⟨y, hy, hxy⟩ := hmk
+  have hle : (⨆ r : ℤ, ⨆ (_ : p ≤ r), (mhs.deligneSplitting r (k - r)).submoduleOf (mhs.WC k)) ≤
+      (⨆ (rs : ℤ × ℤ) (_ : p ≤ rs.1), mhs.deligneSplitting rs.1 rs.2).comap
+        (mhs.WC k).subtype := by
+    refine iSup₂_le fun r hr ↦ ?_
+    simp only [Submodule.submoduleOf]
+    exact Submodule.comap_mono (le_iSup_of_le (r, k - r) (le_iSup_of_le hr le_rfl))
+  have hyG : (y : Vℂ) ∈
+      ⨆ (rs : ℤ × ℤ) (_ : p ≤ rs.1), mhs.deligneSplitting rs.1 rs.2 := hle hy
+  have hdiff : (y : Vℂ) - x ∈ mhs.WC (k - 1) := by
+    rw [Submodule.mkQ_apply] at hxy
+    exact (weightGradedComplex_mk_eq_mk_iff mhs.WC k y ⟨x, hxW⟩).1 hxy
+  have hxy' : x - (y : Vℂ) ∈ mhs.F p ⊓ mhs.WC (k - 1) :=
+    Submodule.mem_inf.2 ⟨Submodule.sub_mem _ hxF (mhs.iSup_deligneSplitting_le_F p hyG), by
+      simpa only [neg_sub] using Submodule.neg_mem _ hdiff⟩
+  have hsplit : x = x - (y : Vℂ) + (y : Vℂ) := by abel
+  rw [hsplit]
+  exact Submodule.add_mem _ (ih hxy') hyG
+
+/-- **Deligne's bigrading recovers the Hodge filtration**: the Hodge step `F^p` is the supremum of
+the bigrading pieces whose first index is at least `p`.
+
+One inclusion is `I^{p',q'} ≤ F^{p'} ≤ F^p`. The other is an induction upwards on the weight
+filtration, starting from a step where it vanishes: the class in `gr^W_k` of a vector of
+`F^p ∩ W_k` is a sum of Hodge components of first index at least `p`, each the image of a
+bigrading piece, so correcting the vector by a representative of that sum drops it into
+`F^p ∩ W_{k-1}`. -/
+theorem F_eq_iSup_deligneSplitting (p : ℤ) :
+    mhs.F p = ⨆ (rs : ℤ × ℤ) (_ : p ≤ rs.1), mhs.deligneSplitting rs.1 rs.2 := by
+  refine le_antisymm ?_ (mhs.iSup_deligneSplitting_le_F p)
+  obtain ⟨k₀, hk₀⟩ := mhs.WC_bot
+  obtain ⟨k₁, hk₁⟩ := mhs.WC_top
+  have key : ∀ m : ℤ, k₀ ≤ m → mhs.F p ⊓ mhs.WC m ≤
+      ⨆ (rs : ℤ × ℤ) (_ : p ≤ rs.1), mhs.deligneSplitting rs.1 rs.2 := by
+    refine Int.leInduction (by rw [hk₀, inf_bot_eq]; exact bot_le) ?_
+    intro m _ ih
+    exact mhs.F_inf_WC_le_of_F_inf_WC_sub_one_le (by simpa using ih)
+  have htop : mhs.WC (max k₀ k₁) = ⊤ := by
+    refine top_unique ?_
+    rw [← hk₁]
+    exact mhs.WC_monotone (le_max_right k₀ k₁)
+  intro x hx
+  exact key (max k₀ k₁) (le_max_left _ _) ⟨hx, by rw [htop]; trivial⟩
 
 end MixedHodgeStructure
 

--- a/TauCeti/Geometry/Hodge/Mixed/Decomposition.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/Decomposition.lean
@@ -302,19 +302,6 @@ theorem map_deligneSplitting_eq_piece (p q : ℤ) :
   · have hW := (mhs.WC_eq_iSup_deligneSplitting (p + q - 1)).le
     simpa only [add_sub_cancel_left] using mhs.piece_le_map_deligneSplitting hW p
 
-/-- The image of `I^{p,q}` in `gr^W_k` is the pure Hodge component `H^{p,q}` of that graded
-piece, for a total degree `k = p + q` supplied as a hypothesis.
-
-Deligne's theory constantly matches a bidegree against a weight index, and the graded piece the
-image lands in occurs in the *type* of that image; naming the weight index separately keeps those
-matches out of dependent rewriting. -/
-private theorem map_deligneSplitting_eq_piece_of_add_eq {p q k : ℤ} (hk : p + q = k) :
-    ((mhs.deligneSplitting p q).submoduleOf (mhs.WC k)).map
-        ((mhs.WC (k - 1)).submoduleOf (mhs.WC k)).mkQ =
-      (mhs.complexGradedHodgeStructure k).piece p := by
-  subst hk
-  exact mhs.map_deligneSplitting_eq_piece p q
-
 /-- **Deligne's bigrading spans**: the supremum of all the pieces `I^{p,q}` is the whole complex
 vector space. -/
 theorem iSup_deligneSplittingFamily_eq_top :
@@ -578,7 +565,11 @@ private theorem F_inf_WC_le_of_F_inf_WC_sub_one_le {p k : ℤ}
   have hpiece : ∀ r : ℤ, (mhs.complexGradedHodgeStructure k).piece r =
       ((mhs.deligneSplitting r (k - r)).submoduleOf (mhs.WC k)).map
         ((mhs.WC (k - 1)).submoduleOf (mhs.WC k)).mkQ :=
-    fun r ↦ (mhs.map_deligneSplitting_eq_piece_of_add_eq (by ring)).symm
+    fun r ↦ by
+      have hk : r + (k - r) = k := by omega
+      rw [← hk]
+      simpa only [add_sub_cancel_left] using
+        (mhs.map_deligneSplitting_eq_piece r (k - r)).symm
   simp only [hpiece, ← Submodule.map_iSup] at hmk
   obtain ⟨y, hy, hxy⟩ := hmk
   have hle : (⨆ r : ℤ, ⨆ (_ : p ≤ r), (mhs.deligneSplitting r (k - r)).submoduleOf (mhs.WC k)) ≤

--- a/TauCeti/Geometry/Hodge/Mixed/Decomposition.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/Decomposition.lean
@@ -302,6 +302,19 @@ theorem map_deligneSplitting_eq_piece (p q : ℤ) :
   · have hW := (mhs.WC_eq_iSup_deligneSplitting (p + q - 1)).le
     simpa only [add_sub_cancel_left] using mhs.piece_le_map_deligneSplitting hW p
 
+/-- The image of `I^{p,q}` in `gr^W_k` is the pure Hodge component `H^{p,q}` of that graded
+piece, for a total degree `k = p + q` supplied as a hypothesis.
+
+Deligne's theory constantly matches a bidegree against a weight index, and the graded piece the
+image lands in occurs in the *type* of that image; naming the weight index separately keeps those
+matches out of dependent rewriting. -/
+private theorem map_deligneSplitting_eq_piece_of_add_eq {p q k : ℤ} (hk : p + q = k) :
+    ((mhs.deligneSplitting p q).submoduleOf (mhs.WC k)).map
+        ((mhs.WC (k - 1)).submoduleOf (mhs.WC k)).mkQ =
+      (mhs.complexGradedHodgeStructure k).piece p := by
+  subst hk
+  exact mhs.map_deligneSplitting_eq_piece p q
+
 /-- **Deligne's bigrading spans**: the supremum of all the pieces `I^{p,q}` is the whole complex
 vector space. -/
 theorem iSup_deligneSplittingFamily_eq_top :
@@ -539,21 +552,8 @@ theorem isInternal_deligneSplittingFamily :
 
 /-! ### The recovery of the Hodge filtration -/
 
-/-- The image of the bigrading piece `I^{p,q}` in the graded piece of its total degree, with the
-total degree presented as an equation.
-
-Deligne's theory constantly matches a bidegree against a weight index, and the graded piece the
-image lands in occurs in the *type* of that image; naming the weight index separately keeps those
-matches out of dependent rewriting. -/
-theorem map_deligneSplitting_eq_piece_of_add_eq {p q k : ℤ} (hk : p + q = k) :
-    ((mhs.deligneSplitting p q).submoduleOf (mhs.WC k)).map
-        ((mhs.WC (k - 1)).submoduleOf (mhs.WC k)).mkQ =
-      (mhs.complexGradedHodgeStructure k).piece p := by
-  subst hk
-  exact mhs.map_deligneSplitting_eq_piece p q
-
 /-- Every bigrading piece whose first index is at least `p` lies in `F^p`. -/
-theorem iSup_deligneSplitting_le_F (p : ℤ) :
+private theorem iSup_deligneSplitting_of_le_le_F (p : ℤ) :
     (⨆ (rs : ℤ × ℤ) (_ : p ≤ rs.1), mhs.deligneSplitting rs.1 rs.2) ≤ mhs.F p :=
   iSup₂_le fun rs hrs ↦ (mhs.deligneSplitting_le_F rs.1 rs.2).trans (mhs.F_antitone hrs)
 
@@ -593,7 +593,8 @@ private theorem F_inf_WC_le_of_F_inf_WC_sub_one_le {p k : ℤ}
     rw [Submodule.mkQ_apply] at hxy
     exact (weightGradedComplex_mk_eq_mk_iff mhs.WC k y ⟨x, hxW⟩).1 hxy
   have hxy' : x - (y : Vℂ) ∈ mhs.F p ⊓ mhs.WC (k - 1) :=
-    Submodule.mem_inf.2 ⟨Submodule.sub_mem _ hxF (mhs.iSup_deligneSplitting_le_F p hyG), by
+    Submodule.mem_inf.2
+      ⟨Submodule.sub_mem _ hxF (mhs.iSup_deligneSplitting_of_le_le_F p hyG), by
       simpa only [neg_sub] using Submodule.neg_mem _ hdiff⟩
   have hsplit : x = x - (y : Vℂ) + (y : Vℂ) := by abel
   rw [hsplit]
@@ -609,7 +610,7 @@ bigrading piece, so correcting the vector by a representative of that sum drops 
 `F^p ∩ W_{k-1}`. -/
 theorem F_eq_iSup_deligneSplitting (p : ℤ) :
     mhs.F p = ⨆ (rs : ℤ × ℤ) (_ : p ≤ rs.1), mhs.deligneSplitting rs.1 rs.2 := by
-  refine le_antisymm ?_ (mhs.iSup_deligneSplitting_le_F p)
+  refine le_antisymm ?_ (mhs.iSup_deligneSplitting_of_le_le_F p)
   obtain ⟨k₀, hk₀⟩ := mhs.WC_bot
   obtain ⟨k₁, hk₁⟩ := mhs.WC_top
   have key : ∀ m : ℤ, k₀ ≤ m → mhs.F p ⊓ mhs.WC m ≤

--- a/TauCeti/Geometry/Hodge/Mixed/DeligneSplitting.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/DeligneSplitting.lean
@@ -36,9 +36,8 @@ formula itself:
 That `⨁_{p,q} I^{p,q}` is the whole space, and the recovery `W_k = ⨆_{p+q ≤ k} I^{p,q}` of the
 weight filtration, are proved in `TauCeti/Geometry/Hodge/Mixed/Decomposition.lean`, which needs
 the pure Hodge structure carried by the graded pieces and so cannot be part of this file. What
-remains of Deligne's theorem after that module is the recovery `F^p = ⨆_{p' ≥ p} ⨆_{q'} I^{p',q'}`
-of the Hodge filtration and the conjugation symmetry `I^{p,q} ≡ conj I^{q,p}` modulo lower
-bidegree.
+remains of Deligne's theorem after that module is the conjugation symmetry
+`I^{p,q} ≡ conj I^{q,p}` modulo lower bidegree.
 
 ## Main declarations
 

--- a/TauCeti/Geometry/Hodge/Mixed/Strictness.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/Strictness.lean
@@ -105,7 +105,7 @@ vector of the source's `F^p`.
 The two filtration steps are the sums of the bigrading pieces of first index at least `p`, and `f`
 respects the bigrading, so a preimage may be truncated to its components of first index at least
 `p` without changing its image. -/
-theorem range_inf_F_eq_map_F (f : Hom source target) (p : ℤ) :
+@[simp] theorem range_inf_F_eq_map_F (f : Hom source target) (p : ℤ) :
     LinearMap.range f.toLinearMap ⊓ target.F p = (source.F p).map f.toLinearMap := by
   simpa only [deligneSplittingFamily_apply, ← target.F_eq_iSup_deligneSplitting p,
     ← source.F_eq_iSup_deligneSplitting p] using
@@ -113,7 +113,7 @@ theorem range_inf_F_eq_map_F (f : Hom source target) (p : ℤ) :
 
 /-- **Strictness of a morphism of mixed Hodge structures for the complexified weight
 filtration.** -/
-theorem range_inf_WC_eq_map_WC (f : Hom source target) (k : ℤ) :
+@[simp] theorem range_inf_WC_eq_map_WC (f : Hom source target) (k : ℤ) :
     LinearMap.range f.toLinearMap ⊓ target.WC k = (source.WC k).map f.toLinearMap := by
   simpa only [deligneSplittingFamily_apply, ← target.WC_eq_iSup_deligneSplitting k,
     ← source.WC_eq_iSup_deligneSplitting k] using
@@ -126,7 +126,7 @@ vector of the source's `W_k`.
 The weight filtration is rational, so this is the form the milestone takes; it descends from the
 complex statement because complexification of rational subspaces reflects inclusions. Only the
 inclusion `(A ∩ B)_ℂ ≤ A_ℂ ∩ B_ℂ` is used, which is monotonicity. -/
-theorem range_inf_WQ_eq_map_WQ (f : Hom source target) (k : ℤ) :
+@[simp] theorem range_inf_WQ_eq_map_WQ (f : Hom source target) (k : ℤ) :
     LinearMap.range f.toRatLinearMap ⊓ target.WQ k = (source.WQ k).map f.toRatLinearMap := by
   refine le_antisymm ?_ (le_inf LinearMap.map_le_range (f.map_WQ_le k))
   rw [← rationalToComplexSubmodule_le_iff h'ℚ h'ℂ]

--- a/TauCeti/Geometry/Hodge/Mixed/Strictness.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/Strictness.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Hodge.Mixed.Decomposition
+
+/-!
+# Strictness of a morphism of mixed Hodge structures
+
+A morphism of mixed Hodge structures is **strict**: an element of the target that lies in a step
+of a filtration *and* in the image of the morphism is already the image of an element of the
+corresponding step of the source. Filtration-preserving maps are not strict in general — this is
+the theorem that makes the category of mixed Hodge structures abelian — and the proof is Deligne's
+bigrading.
+
+Both filtrations are recovered from the bigrading `I^{p,q}`
+(`TauCeti.Hodge.MixedHodgeStructure.WC_eq_iSup_deligneSplitting` and
+`TauCeti.Hodge.MixedHodgeStructure.F_eq_iSup_deligneSplitting`) as suprema of the pieces over a set
+of bidegrees, a morphism carries `I^{p,q}` into `I^{p,q}`
+(`TauCeti.Hodge.MixedHodgeStructure.Hom.map_deligneSplitting_le`), and the pieces of the target are
+independent. Strictness for both filtrations at once is then the lattice statement that in a
+family `B ≤ A` with `A` independent, the sum of the `B` over *all* indices meets the sum of the `A`
+over a set `S` of indices in exactly the sum of the `B` over `S`: an element of the intersection
+has no component of the target's bigrading outside `S`, so the source element producing it may be
+truncated to its own components in `S`.
+
+The weight filtration is a rational datum, and its strictness is stated rationally. It descends
+from the complex statement because `ℂ` is faithfully flat over `ℚ`, so an inclusion of rational
+subspaces can be tested after complexification
+(`TauCeti.Hodge.rationalToComplexSubmodule_le_iff`); only the trivial half of the compatibility of
+complexification with intersections is needed.
+
+## Main declarations
+
+* `TauCeti.Hodge.MixedHodgeStructure.Hom.range_inf_F_eq_map_F`: **strictness for the Hodge
+  filtration**, `im f ∩ F'^p = f(F^p)`.
+* `TauCeti.Hodge.MixedHodgeStructure.Hom.range_inf_WQ_eq_map_WQ`: **strictness for the weight
+  filtration**, `im f ∩ W'_k = f(W_k)`, rationally.
+* `TauCeti.Hodge.MixedHodgeStructure.Hom.range_inf_WC_eq_map_WC`: the complexification of the
+  latter.
+
+## References
+
+Deligne, *Théorie de Hodge II*, 1.2.10 and 2.3.5; Peters–Steenbrink, *Mixed Hodge Structures*,
+Theorem 3.13. This is the milestone of Layer L2 of the Hodge structures roadmap.
+-/
+
+public section
+
+namespace TauCeti.Hodge
+
+universe u v w u' v' w'
+
+/-- **A subfamily of an independent family truncates a dominated sum.** If `B i ≤ A i` for every
+`i` and the `A i` are independent, then the total sum of the `B` meets the partial sum of the `A`
+over the indices satisfying `P` in exactly the partial sum of the `B` over those indices.
+
+This is the lattice content of strictness: `A` is the target's bigrading, `B` the image of the
+source's bigrading, and `P` cuts out the bidegrees of a filtration step. -/
+private theorem iSup_inf_iSup_of_le {R : Type*} {N : Type*} {ι : Type*} [Ring R] [AddCommGroup N]
+    [Module R N] {A B : ι → Submodule R N} (hA : iSupIndep A) (hB : ∀ i, B i ≤ A i)
+    (P : ι → Prop) :
+    (⨆ (i) (_ : P i), A i) ⊓ ⨆ i, B i = ⨆ (i) (_ : P i), B i := by
+  have hle : (⨆ (i) (_ : P i), B i) ≤ ⨆ (i) (_ : P i), A i := iSup₂_mono fun i _ ↦ hB i
+  have hdisj : Disjoint (⨆ (i) (_ : P i), A i) (⨆ (i) (_ : ¬ P i), B i) := by
+    have h₀ : Disjoint (⨆ (i) (_ : P i), A i) (⨆ (i) (_ : ¬ P i), A i) := by
+      simpa only [Set.mem_ofPred_eq] using
+        hA.disjoint_biSup_biSup (s := {i | P i}) (t := {i | ¬ P i})
+          (Set.disjoint_left.2 fun i hi hi' ↦ hi' hi)
+    exact h₀.mono_right (iSup₂_mono fun i _ ↦ hB i)
+  rw [iSup_split B P, inf_comm, sup_inf_assoc_of_le _ hle, inf_comm, hdisj.eq_bot, sup_bot_eq]
+
+namespace MixedHodgeStructure.Hom
+
+variable {Vℤ : Type u} {Vℚ : Type v} {Vℂ : Type w}
+variable {V'ℤ : Type u'} {V'ℚ : Type v'} {V'ℂ : Type w'}
+variable [AddCommGroup Vℤ] [AddCommGroup Vℚ] [Module ℚ Vℚ] [AddCommGroup Vℂ] [Module ℂ Vℂ]
+variable [AddCommGroup V'ℤ] [AddCommGroup V'ℚ] [Module ℚ V'ℚ] [AddCommGroup V'ℂ] [Module ℂ V'ℂ]
+variable {ιℚ : Vℤ →ₗ[ℤ] Vℚ} {ιℂ : Vℤ →ₗ[ℤ] Vℂ} {ι'ℚ : V'ℤ →ₗ[ℤ] V'ℚ} {ι'ℂ : V'ℤ →ₗ[ℤ] V'ℂ}
+variable {hℚ : IsBaseChange ℚ ιℚ} {hℂ : IsBaseChange ℂ ιℂ}
+variable {h'ℚ : IsBaseChange ℚ ι'ℚ} {h'ℂ : IsBaseChange ℂ ι'ℂ}
+variable {source : MixedHodgeStructure hℚ hℂ} {target : MixedHodgeStructure h'ℚ h'ℂ}
+
+/-! ### The image of a morphism, bigraded -/
+
+/-- The image of a morphism of mixed Hodge structures is the sum of the images of the bigrading
+pieces of its source: the bigrading of the source spans. -/
+theorem range_eq_iSup_map_deligneSplittingFamily (f : Hom source target) :
+    LinearMap.range f.toLinearMap =
+      ⨆ pq : ℤ × ℤ, (source.deligneSplittingFamily pq).map f.toLinearMap := by
+  rw [← Submodule.map_iSup, source.iSup_deligneSplittingFamily_eq_top, Submodule.map_top]
+
+/-- **Strictness against a set of bidegrees.** The image of a morphism meets the sum of the
+target's bigrading pieces over the bidegrees satisfying `P` in exactly the image of the
+corresponding sum for the source.
+
+Both filtrations of a mixed Hodge structure are sums of bigrading pieces over such a set, so this
+single statement carries every strictness assertion below. -/
+private theorem range_inf_iSup_deligneSplittingFamily (f : Hom source target)
+    (P : ℤ × ℤ → Prop) :
+    LinearMap.range f.toLinearMap ⊓ ⨆ (pq) (_ : P pq), target.deligneSplittingFamily pq =
+      (⨆ (pq) (_ : P pq), source.deligneSplittingFamily pq).map f.toLinearMap := by
+  rw [f.range_eq_iSup_map_deligneSplittingFamily, inf_comm,
+    iSup_inf_iSup_of_le (A := target.deligneSplittingFamily)
+      (B := fun pq ↦ (source.deligneSplittingFamily pq).map f.toLinearMap)
+      target.iSupIndep_deligneSplittingFamily
+      (fun pq ↦ by
+        simpa only [deligneSplittingFamily_apply] using
+          f.map_deligneSplitting_le pq.1 pq.2) P]
+  simp only [Submodule.map_iSup]
+
+/-! ### Strictness -/
+
+/-- **Strictness of a morphism of mixed Hodge structures for the Hodge filtration.** A complex
+vector lying both in the image of `f` and in the target's Hodge step `F^p` is the image of a
+vector of the source's `F^p`.
+
+The two filtration steps are the sums of the bigrading pieces of first index at least `p`, and `f`
+respects the bigrading, so a preimage may be truncated to its components of first index at least
+`p` without changing its image. -/
+theorem range_inf_F_eq_map_F (f : Hom source target) (p : ℤ) :
+    LinearMap.range f.toLinearMap ⊓ target.F p = (source.F p).map f.toLinearMap := by
+  simpa only [deligneSplittingFamily_apply, ← target.F_eq_iSup_deligneSplitting p,
+    ← source.F_eq_iSup_deligneSplitting p] using
+    f.range_inf_iSup_deligneSplittingFamily fun pq ↦ p ≤ pq.1
+
+/-- **Strictness of a morphism of mixed Hodge structures for the complexified weight
+filtration.** -/
+theorem range_inf_WC_eq_map_WC (f : Hom source target) (k : ℤ) :
+    LinearMap.range f.toLinearMap ⊓ target.WC k = (source.WC k).map f.toLinearMap := by
+  simpa only [deligneSplittingFamily_apply, ← target.WC_eq_iSup_deligneSplitting k,
+    ← source.WC_eq_iSup_deligneSplitting k] using
+    f.range_inf_iSup_deligneSplittingFamily fun pq ↦ pq.1 + pq.2 ≤ k
+
+/-- **Strictness of a morphism of mixed Hodge structures for the weight filtration.** A rational
+vector lying both in the image of `f` and in the target's weight step `W_k` is the image of a
+vector of the source's `W_k`.
+
+The weight filtration is rational, so this is the form the milestone takes; it descends from the
+complex statement because complexification of rational subspaces reflects inclusions. Only the
+inclusion `(A ∩ B)_ℂ ≤ A_ℂ ∩ B_ℂ` is used, which is monotonicity. -/
+theorem range_inf_WQ_eq_map_WQ (f : Hom source target) (k : ℤ) :
+    LinearMap.range f.toRatLinearMap ⊓ target.WQ k = (source.WQ k).map f.toRatLinearMap := by
+  refine le_antisymm ?_ (le_inf LinearMap.map_le_range (f.map_WQ_le k))
+  rw [← rationalToComplexSubmodule_le_iff h'ℚ h'ℂ]
+  have hrange : rationalToComplexSubmodule h'ℚ h'ℂ (LinearMap.range f.toRatLinearMap) =
+      LinearMap.range f.toLinearMap := by
+    rw [← Submodule.map_top f.toRatLinearMap, ← map_rationalToComplexSubmodule hℚ hℂ h'ℚ h'ℂ,
+      rationalToComplexSubmodule_top, Submodule.map_top, toLinearMap_def]
+  have hmap : rationalToComplexSubmodule h'ℚ h'ℂ ((source.WQ k).map f.toRatLinearMap) =
+      (source.WC k).map f.toLinearMap := by
+    rw [← map_rationalToComplexSubmodule hℚ hℂ h'ℚ h'ℂ, WC_def, toLinearMap_def]
+  rw [hmap, ← f.range_inf_WC_eq_map_WC k, WC_def, ← hrange]
+  exact le_inf (rationalToComplexSubmodule_mono h'ℚ h'ℂ inf_le_left)
+    (rationalToComplexSubmodule_mono h'ℚ h'ℂ inf_le_right)
+
+end MixedHodgeStructure.Hom
+
+end TauCeti.Hodge

--- a/TauCeti/Geometry/Hodge/Mixed/Strictness.lean
+++ b/TauCeti/Geometry/Hodge/Mixed/Strictness.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Geometry.Hodge.Mixed.Decomposition
+public import TauCeti.Order.CompactlyGenerated
 
 /-!
 # Strictness of a morphism of mixed Hodge structures
@@ -35,6 +36,8 @@ complexification with intersections is needed.
 
 ## Main declarations
 
+* `TauCeti.Hodge.MixedHodgeStructure.Hom.range_inf_iSup_deligneSplittingFamily_eq_map_iSup`:
+  strictness against an arbitrary set of bidegrees.
 * `TauCeti.Hodge.MixedHodgeStructure.Hom.range_inf_F_eq_map_F`: **strictness for the Hodge
   filtration**, `im f ∩ F'^p = f(F^p)`.
 * `TauCeti.Hodge.MixedHodgeStructure.Hom.range_inf_WQ_eq_map_WQ`: **strictness for the weight
@@ -53,25 +56,6 @@ public section
 namespace TauCeti.Hodge
 
 universe u v w u' v' w'
-
-/-- **A subfamily of an independent family truncates a dominated sum.** If `B i ≤ A i` for every
-`i` and the `A i` are independent, then the total sum of the `B` meets the partial sum of the `A`
-over the indices satisfying `P` in exactly the partial sum of the `B` over those indices.
-
-This is the lattice content of strictness: `A` is the target's bigrading, `B` the image of the
-source's bigrading, and `P` cuts out the bidegrees of a filtration step. -/
-private theorem iSup_inf_iSup_of_le {R : Type*} {N : Type*} {ι : Type*} [Ring R] [AddCommGroup N]
-    [Module R N] {A B : ι → Submodule R N} (hA : iSupIndep A) (hB : ∀ i, B i ≤ A i)
-    (P : ι → Prop) :
-    (⨆ (i) (_ : P i), A i) ⊓ ⨆ i, B i = ⨆ (i) (_ : P i), B i := by
-  have hle : (⨆ (i) (_ : P i), B i) ≤ ⨆ (i) (_ : P i), A i := iSup₂_mono fun i _ ↦ hB i
-  have hdisj : Disjoint (⨆ (i) (_ : P i), A i) (⨆ (i) (_ : ¬ P i), B i) := by
-    have h₀ : Disjoint (⨆ (i) (_ : P i), A i) (⨆ (i) (_ : ¬ P i), A i) := by
-      simpa only [Set.mem_ofPred_eq] using
-        hA.disjoint_biSup_biSup (s := {i | P i}) (t := {i | ¬ P i})
-          (Set.disjoint_left.2 fun i hi hi' ↦ hi' hi)
-    exact h₀.mono_right (iSup₂_mono fun i _ ↦ hB i)
-  rw [iSup_split B P, inf_comm, sup_inf_assoc_of_le _ hle, inf_comm, hdisj.eq_bot, sup_bot_eq]
 
 namespace MixedHodgeStructure.Hom
 
@@ -99,12 +83,12 @@ corresponding sum for the source.
 
 Both filtrations of a mixed Hodge structure are sums of bigrading pieces over such a set, so this
 single statement carries every strictness assertion below. -/
-private theorem range_inf_iSup_deligneSplittingFamily (f : Hom source target)
+theorem range_inf_iSup_deligneSplittingFamily_eq_map_iSup (f : Hom source target)
     (P : ℤ × ℤ → Prop) :
     LinearMap.range f.toLinearMap ⊓ ⨆ (pq) (_ : P pq), target.deligneSplittingFamily pq =
       (⨆ (pq) (_ : P pq), source.deligneSplittingFamily pq).map f.toLinearMap := by
   rw [f.range_eq_iSup_map_deligneSplittingFamily, inf_comm,
-    iSup_inf_iSup_of_le (A := target.deligneSplittingFamily)
+    TauCeti.iSupIndep.iSup₂_inf_iSup_eq_iSup₂ (A := target.deligneSplittingFamily)
       (B := fun pq ↦ (source.deligneSplittingFamily pq).map f.toLinearMap)
       target.iSupIndep_deligneSplittingFamily
       (fun pq ↦ by
@@ -125,7 +109,7 @@ theorem range_inf_F_eq_map_F (f : Hom source target) (p : ℤ) :
     LinearMap.range f.toLinearMap ⊓ target.F p = (source.F p).map f.toLinearMap := by
   simpa only [deligneSplittingFamily_apply, ← target.F_eq_iSup_deligneSplitting p,
     ← source.F_eq_iSup_deligneSplitting p] using
-    f.range_inf_iSup_deligneSplittingFamily fun pq ↦ p ≤ pq.1
+    f.range_inf_iSup_deligneSplittingFamily_eq_map_iSup fun pq ↦ p ≤ pq.1
 
 /-- **Strictness of a morphism of mixed Hodge structures for the complexified weight
 filtration.** -/
@@ -133,7 +117,7 @@ theorem range_inf_WC_eq_map_WC (f : Hom source target) (k : ℤ) :
     LinearMap.range f.toLinearMap ⊓ target.WC k = (source.WC k).map f.toLinearMap := by
   simpa only [deligneSplittingFamily_apply, ← target.WC_eq_iSup_deligneSplitting k,
     ← source.WC_eq_iSup_deligneSplitting k] using
-    f.range_inf_iSup_deligneSplittingFamily fun pq ↦ pq.1 + pq.2 ≤ k
+    f.range_inf_iSup_deligneSplittingFamily_eq_map_iSup fun pq ↦ pq.1 + pq.2 ≤ k
 
 /-- **Strictness of a morphism of mixed Hodge structures for the weight filtration.** A rational
 vector lying both in the image of `f` and in the target's weight step `W_k` is the image of a

--- a/TauCeti/Order/CompactlyGenerated.lean
+++ b/TauCeti/Order/CompactlyGenerated.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Order.CompactlyGenerated.Basic
+
+/-!
+# Independent families in compactly generated modular lattices
+
+This file records lattice consequences of independence that use compact generation to pass from
+finite joins to arbitrary suprema.
+
+## Main declarations
+
+* `TauCeti.iSupIndep.iSup₂_inf_iSup_eq_iSup₂`: a partial supremum of an independent family
+  meets the total supremum of a pointwise dominated family in its corresponding partial supremum.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **A subfamily of an independent family truncates a dominated supremum.** If `B i ≤ A i` for
+every `i` and the `A i` are independent, then the total supremum of the `B` meets the partial
+supremum of the `A` over the indices satisfying `P` in exactly the partial supremum of the `B` over
+those indices. -/
+theorem iSupIndep.iSup₂_inf_iSup_eq_iSup₂ {α ι : Type*} [CompleteLattice α]
+    [IsModularLattice α] [IsCompactlyGenerated α] {A B : ι → α}
+    (hA : iSupIndep A) (hB : ∀ i, B i ≤ A i) (P : ι → Prop) :
+    (⨆ (i) (_ : P i), A i) ⊓ ⨆ i, B i = ⨆ (i) (_ : P i), B i := by
+  have hle : (⨆ (i) (_ : P i), B i) ≤ ⨆ (i) (_ : P i), A i := iSup₂_mono fun i _ ↦ hB i
+  have hdisj : Disjoint (⨆ (i) (_ : P i), A i) (⨆ (i) (_ : ¬ P i), B i) := by
+    have h₀ : Disjoint (⨆ (i) (_ : P i), A i) (⨆ (i) (_ : ¬ P i), A i) := by
+      simpa only [Set.mem_ofPred_eq] using
+        hA.disjoint_biSup_biSup (s := {i | P i}) (t := {i | ¬ P i})
+          (Set.disjoint_left.2 fun i hi hi' ↦ hi' hi)
+    exact h₀.mono_right (iSup₂_mono fun i _ ↦ hB i)
+  rw [iSup_split B P, inf_comm, sup_inf_assoc_of_le _ hle, inf_comm, hdisj.eq_bot, sup_bot_eq]
+
+end TauCeti


### PR DESCRIPTION
This PR proves the milestone of Layer **L2** of the `HodgeStructures` roadmap: a morphism of mixed Hodge structures is **strict** for both filtrations. It adds the missing input — the recovery of the Hodge filtration from Deligne's bigrading, `F^p = ⨆_{p' ≥ p} ⨆_{q'} I^{p',q'}` — and then deduces strictness for `F` (complex), for the complexified weight filtration `W_ℂ`, and for the weight filtration `W_ℚ` in the rational form the roadmap states it in: `im f ∩ W'_{ℚ,k} = f(W_{ℚ,k})` and `im f ∩ F'^p = f(F^p)`.

The roadmap's L2 milestone reads: "a morphism of MHS — a single rational map `fQ`, complex action the derived `fC` — is **strict** for both filtrations: `range fQ ⊓ W'_{ℚ,k} = fQ(W_{ℚ,k})` (and its complexification) and `range fC ⊓ F'^p = fC(F^p)`", with the discharge routed through Deligne's canonical `(p,q)`-bigrading. That bigrading was built in PR #4312 and shown to be an internal direct sum, with the weight recovery `W_k = ⨆_{p+q ≤ k} I^{p,q}`, in PR #4653; the module docstring of `Mixed/Decomposition.lean` named exactly the recovery of `F` and strictness as what remained. After this PR the only item left on the roadmap's L2 list is the conjugation symmetry `I^{p,q} ≡ conj I^{q,p}` modulo strictly lower bidegree, plus the `MHS.Hom` category's abelian packaging that strictness now makes available.

The recovery of `F` runs the same upward induction on the weight filtration that the recovery of `W` used. A vector of `F^p ∩ W_k` has its class in `gr^W_k` inside the `p`-th step of the induced Hodge filtration; the graded piece is pure, so that class is a sum of Hodge components of first index at least `p`, and each such component is the image of a bigrading piece. Correcting the vector by a representative of that sum leaves a vector of `F^p ∩ W_{k-1}`, and the induction starts where the weight filtration vanishes.

Strictness is then one lattice statement applied twice. Both filtrations are suprema of bigrading pieces over a set `S` of bidegrees; a morphism carries `I^{p,q}` into `I^{p,q}`, and the target's pieces are independent. So if `B i ≤ A i` pointwise with `A` independent, `(⨆_{i ∈ S} A i) ⊓ ⨆_i B i = ⨆_{i ∈ S} B i` — an element of the image lying in the filtration step has no target component outside `S`, so the source element producing it may be truncated to its own components in `S`. This is Mathlib's `iSupIndep.disjoint_biSup_biSup` together with modularity of the submodule lattice. The rational statement descends from the complex one because `ℂ` is faithfully flat over `ℚ`: only monotonicity of complexification and the new order-reflection lemma `rationalToComplexSubmodule_le_iff` (`Submodule.baseChange_le_iff` transported along the tower equivalence) are needed, not the compatibility of complexification with intersections.

Files: `TauCeti/Geometry/Hodge/Mixed/Strictness.lean` is new (156 lines); `TauCeti/Geometry/Hodge/Mixed/Decomposition.lean` gains the `F`-recovery section and `TauCeti/Geometry/Hodge/BaseChange.lean` the order-reflection lemma. No Mathlib source was vendored.

Roadmap: HodgeStructures

<!--tauceti-target:v1 {"focus":"HodgeStructures","id":"strictness-of-a-morphism-of-mixed-hodge-structures"}-->

🤖 Prepared with Claude Code
