### PR TITLE
feat: add the local BCH germ

### DIFF
--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+import Mathlib.Analysis.Analytic.Constructions
+public import Mathlib.Topology.Germ
+public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Inverse
+
+/-!
+# The local Baker--Campbell--Hausdorff map
+
+This file defines the germ at `(0, 0)` represented by
+`logOneAdd (exp x * exp y - 1)` in a complete real normed algebra. Using a
+germ records that this expression is a local logarithm; its values away from
+the origin have no mathematical role.
+
+The exponential of this germ is the product of the two exponentials. Its
+restrictions to either coordinate axis are the identity germ, and its chosen
+representative is analytic at the origin.
+
+## Main declarations
+
+* `NormedSpace.localBCH` and `NormedSpace.localBCH_def`: the local
+  Baker--Campbell--Hausdorff germ and its representative.
+* `NormedSpace.localBCH_sliceLeft` and `NormedSpace.localBCH_sliceRight`: the
+  endpoint equations.
+* `NormedSpace.localBCH_map_exp`: the local exponential equation.
+* `NormedSpace.exists_analyticAt_localBCH_representation`: an analytic
+  representative of the germ.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 3, "Baker--Campbell--Hausdorff".
+-/
+
+public section
+
+open Filter Topology
+
+noncomputable section
+
+namespace NormedSpace
+
+variable (A : Type*) [NormedRing A] [NormedAlgebra ℝ A]
+
+/-- The germ at `(0, 0)` of the local Baker--Campbell--Hausdorff map. -/
+def localBCH : Germ (𝓝 ((0, 0) : A × A)) A :=
+  (fun p : A × A ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1) : A × A → A)
+
+/-- The representative defining the local Baker--Campbell--Hausdorff germ. -/
+theorem localBCH_def :
+    localBCH A =
+      (↑(fun p : A × A ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1)) :
+        Germ (𝓝 ((0, 0) : A × A)) A) :=
+  by simp only [localBCH]
+
+/-- The local Baker--Campbell--Hausdorff germ takes the value zero at the origin. -/
+@[simp]
+theorem localBCH_value : (localBCH A).value = 0 := by
+  simp [localBCH]
+
+variable [CompleteSpace A]
+
+private theorem analyticAt_exp_mul_exp_sub_one :
+    AnalyticAt ℝ (fun p : A × A ↦ exp p.1 * exp p.2 - 1) (0, 0) :=
+  (((exp_analytic (𝕂 := ℝ) 0).comp (x := (0, 0)) analyticAt_fst).mul
+    ((exp_analytic (𝕂 := ℝ) 0).comp (x := (0, 0)) analyticAt_snd)).sub analyticAt_const
+
+/-- Restricting the local Baker--Campbell--Hausdorff germ to the first coordinate axis gives the
+identity germ. -/
+@[simp]
+theorem localBCH_sliceLeft :
+    (localBCH A).sliceLeft = (↑(fun x : A ↦ x) : Germ (𝓝 (0 : A)) A) := by
+  apply Germ.coe_eq.mpr
+  filter_upwards [eventually_logOneAdd_exp_sub_one A] with x hx
+  simpa [localBCH] using hx
+
+/-- Restricting the local Baker--Campbell--Hausdorff germ to the second coordinate axis gives the
+identity germ. -/
+@[simp]
+theorem localBCH_sliceRight :
+    (localBCH A).sliceRight = (↑(fun y : A ↦ y) : Germ (𝓝 (0 : A)) A) := by
+  apply Germ.coe_eq.mpr
+  filter_upwards [eventually_logOneAdd_exp_sub_one A] with y hy
+  simpa [localBCH] using hy
+
+private theorem tendsto_exp_mul_exp_sub_one :
+    Tendsto (fun p : A × A ↦ exp p.1 * exp p.2 - 1)
+      (𝓝 ((0, 0) : A × A)) (𝓝 (0 : A)) := by
+  simpa only [ContinuousAt, exp_zero, mul_one, sub_self] using
+    (analyticAt_exp_mul_exp_sub_one A).continuousAt
+
+/-- Applying exponential to the local Baker--Campbell--Hausdorff germ gives the germ of the product
+of the two exponentials. -/
+@[simp]
+theorem localBCH_map_exp :
+    (localBCH A).map exp =
+      (↑(fun p : A × A ↦ exp p.1 * exp p.2) : Germ (𝓝 ((0, 0) : A × A)) A) := by
+  apply Germ.coe_eq.mpr
+  filter_upwards [(tendsto_exp_mul_exp_sub_one A).eventually
+    (eventually_exp_logOneAdd A)] with p hp
+  simpa [localBCH] using hp
+
+/-- The local Baker--Campbell--Hausdorff germ has a representative analytic at the origin. -/
+theorem exists_analyticAt_localBCH_representation :
+    ∃ f : A × A → A,
+      localBCH A = (↑f : Germ (𝓝 ((0, 0) : A × A)) A) ∧ AnalyticAt ℝ f (0, 0) := by
+  refine ⟨fun p ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1), localBCH_def A, ?_⟩
+  simpa [Function.comp_def] using (analyticAt_logOneAdd (𝕂 := ℝ) (A := A)).comp_of_eq
+    (analyticAt_exp_mul_exp_sub_one A) (by simp)
+
+end NormedSpace

--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -13,11 +13,9 @@ public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Inverse
 # The local Baker--Campbell--Hausdorff map
 
 This file defines the germ at `(0, 0)` represented by
-`logOneAdd (exp x * exp y - 1)` in a real normed algebra. Using a germ records
+`logOneAdd (exp x * exp y - 1)` in a complete real normed algebra. Using a germ records
 that this expression is a local logarithm; its values away from the origin
-have no mathematical role. The definition, representative equation, and value
-at the origin need only a normed algebra; all subsequent results also assume
-completeness.
+have no mathematical role.
 
 The exponential of this germ is the product of the two exponentials. Its
 restrictions to either coordinate axis are the identity germ, and its chosen
@@ -54,11 +52,12 @@ variable (A : Type*) [NormedRing A] [NormedAlgebra ℝ A]
 
 /-- The germ at `(0, 0)` represented by the local logarithm
 `fun p ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1)` of `exp p.1 * exp p.2`. -/
-def localBCH : Germ (𝓝 ((0, 0) : A × A)) A :=
+def localBCH [hA : CompleteSpace A] : Germ (𝓝 ((0, 0) : A × A)) A :=
+  let _ := hA
   (fun p : A × A ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1) : A × A → A)
 
 /-- `localBCH` is the germ of `fun p ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1)`. -/
-theorem localBCH_def :
+theorem localBCH_def [CompleteSpace A] :
     localBCH A =
       (↑(fun p : A × A ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1)) :
         Germ (𝓝 ((0, 0) : A × A)) A) :=
@@ -66,7 +65,7 @@ theorem localBCH_def :
 
 /-- The local Baker--Campbell--Hausdorff germ takes the value zero at the origin. -/
 @[simp]
-theorem localBCH_value : (localBCH A).value = 0 := by
+theorem localBCH_value [CompleteSpace A] : (localBCH A).value = 0 := by
   simp [localBCH]
 
 variable [CompleteSpace A]

--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -13,9 +13,10 @@ public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Inverse
 # The local Baker--Campbell--Hausdorff map
 
 This file defines the germ at `(0, 0)` represented by
-`logOneAdd (exp x * exp y - 1)` in a complete real normed algebra. Using a
-germ records that this expression is a local logarithm; its values away from
-the origin have no mathematical role.
+`logOneAdd (exp x * exp y - 1)` in a real normed algebra. Using a germ records
+that this expression is a local logarithm; its values away from the origin
+have no mathematical role. Completeness is required only for the axis,
+exponential, and analyticity equations.
 
 The exponential of this germ is the product of the two exponentials. Its
 restrictions to either coordinate axis are the identity germ, and its chosen
@@ -23,13 +24,13 @@ representative is analytic at the origin.
 
 ## Main declarations
 
-* `NormedSpace.localBCH` and `NormedSpace.localBCH_def`: the local
-  Baker--Campbell--Hausdorff germ and its representative.
+* `NormedSpace.localBCH`: the local Baker--Campbell--Hausdorff germ.
+* `NormedSpace.localBCH_def`: its defining representative equation.
 * `NormedSpace.localBCH_sliceLeft` and `NormedSpace.localBCH_sliceRight`: the
   endpoint equations.
 * `NormedSpace.localBCH_map_exp`: the local exponential equation.
-* `NormedSpace.exists_analyticAt_localBCH_representation`: an analytic
-  representative of the germ.
+* `NormedSpace.analyticAt_localBCH_representative`: the defining representative
+  is analytic at the origin.
 
 ## References
 
@@ -47,11 +48,12 @@ namespace NormedSpace
 
 variable (A : Type*) [NormedRing A] [NormedAlgebra ℝ A]
 
-/-- The germ at `(0, 0)` of the local Baker--Campbell--Hausdorff map. -/
+/-- The germ at `(0, 0)` represented by the local logarithm
+`fun p ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1)` of `exp p.1 * exp p.2`. -/
 def localBCH : Germ (𝓝 ((0, 0) : A × A)) A :=
   (fun p : A × A ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1) : A × A → A)
 
-/-- The representative defining the local Baker--Campbell--Hausdorff germ. -/
+/-- `localBCH` is the germ of `fun p ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1)`. -/
 theorem localBCH_def :
     localBCH A =
       (↑(fun p : A × A ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1)) :
@@ -75,24 +77,24 @@ identity germ. -/
 @[simp]
 theorem localBCH_sliceLeft :
     (localBCH A).sliceLeft = (↑(fun x : A ↦ x) : Germ (𝓝 (0 : A)) A) := by
-  apply Germ.coe_eq.mpr
+  rw [localBCH_def, Germ.sliceLeft_coe, Germ.coe_eq]
   filter_upwards [eventually_logOneAdd_exp_sub_one A] with x hx
-  simpa [localBCH] using hx
+  simpa using hx
 
 /-- Restricting the local Baker--Campbell--Hausdorff germ to the second coordinate axis gives the
 identity germ. -/
 @[simp]
 theorem localBCH_sliceRight :
     (localBCH A).sliceRight = (↑(fun y : A ↦ y) : Germ (𝓝 (0 : A)) A) := by
-  apply Germ.coe_eq.mpr
+  rw [localBCH_def, Germ.sliceRight_coe, Germ.coe_eq]
   filter_upwards [eventually_logOneAdd_exp_sub_one A] with y hy
-  simpa [localBCH] using hy
+  simpa using hy
 
 private theorem tendsto_exp_mul_exp_sub_one :
     Tendsto (fun p : A × A ↦ exp p.1 * exp p.2 - 1)
       (𝓝 ((0, 0) : A × A)) (𝓝 (0 : A)) := by
-  simpa only [ContinuousAt, exp_zero, mul_one, sub_self] using
-    (analyticAt_exp_mul_exp_sub_one A).continuousAt
+  simpa only [exp_zero, mul_one, sub_self] using
+    (analyticAt_exp_mul_exp_sub_one A).continuousAt.tendsto
 
 /-- Applying exponential to the local Baker--Campbell--Hausdorff germ gives the germ of the product
 of the two exponentials. -/
@@ -100,16 +102,14 @@ of the two exponentials. -/
 theorem localBCH_map_exp :
     (localBCH A).map exp =
       (↑(fun p : A × A ↦ exp p.1 * exp p.2) : Germ (𝓝 ((0, 0) : A × A)) A) := by
-  apply Germ.coe_eq.mpr
+  rw [localBCH_def, Germ.map_coe, Germ.coe_eq]
   filter_upwards [(tendsto_exp_mul_exp_sub_one A).eventually
     (eventually_exp_logOneAdd A)] with p hp
-  simpa [localBCH] using hp
+  simpa [Function.comp_def] using hp
 
-/-- The local Baker--Campbell--Hausdorff germ has a representative analytic at the origin. -/
-theorem exists_analyticAt_localBCH_representation :
-    ∃ f : A × A → A,
-      localBCH A = (↑f : Germ (𝓝 ((0, 0) : A × A)) A) ∧ AnalyticAt ℝ f (0, 0) := by
-  refine ⟨fun p ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1), localBCH_def A, ?_⟩
+/-- The representative defining `localBCH` is analytic at the origin. -/
+theorem analyticAt_localBCH_representative :
+    AnalyticAt ℝ (fun p : A × A ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1)) (0, 0) := by
   simpa [Function.comp_def] using (analyticAt_logOneAdd (𝕂 := ℝ) (A := A)).comp_of_eq
     (analyticAt_exp_mul_exp_sub_one A) (by simp)
 

--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -15,8 +15,9 @@ public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Inverse
 This file defines the germ at `(0, 0)` represented by
 `logOneAdd (exp x * exp y - 1)` in a real normed algebra. Using a germ records
 that this expression is a local logarithm; its values away from the origin
-have no mathematical role. Completeness is required only for the axis,
-exponential, and analyticity equations.
+have no mathematical role. The definition, representative equation, and value
+at the origin need only a normed algebra; all subsequent results also assume
+completeness.
 
 The exponential of this germ is the product of the two exponentials. Its
 restrictions to either coordinate axis are the identity germ, and its chosen
@@ -31,6 +32,9 @@ representative is analytic at the origin.
 * `NormedSpace.localBCH_map_exp`: the local exponential equation.
 * `NormedSpace.analyticAt_localBCH_representative`: the defining representative
   is analytic at the origin.
+* `NormedSpace.localBCH_tendsto`: the germ tends to zero at the origin.
+* `NormedSpace.eq_localBCH_of_tendsto_of_map_exp_eq`: uniqueness among germs
+  tending to zero with the same exponential image.
 
 ## References
 
@@ -112,5 +116,27 @@ theorem analyticAt_localBCH_representative :
     AnalyticAt ℝ (fun p : A × A ↦ logOneAdd ℝ A (exp p.1 * exp p.2 - 1)) (0, 0) := by
   simpa [Function.comp_def] using (analyticAt_logOneAdd (𝕂 := ℝ) (A := A)).comp_of_eq
     (analyticAt_exp_mul_exp_sub_one A) (by simp)
+
+/-- The local Baker--Campbell--Hausdorff germ tends to zero at the origin. -/
+theorem localBCH_tendsto : (localBCH A).Tendsto (𝓝 0) := by
+  rw [localBCH_def, Germ.coe_tendsto]
+  simpa only [exp_zero, mul_one, sub_self, logOneAdd_zero] using
+    (analyticAt_localBCH_representative A).continuousAt.tendsto
+
+/-- A germ tending to zero with the same exponential image as `localBCH` equals `localBCH`. -/
+theorem eq_localBCH_of_tendsto_of_map_exp_eq (f : Germ (𝓝 ((0, 0) : A × A)) A)
+    (hf : f.Tendsto (𝓝 0)) (hmap : f.map exp = (localBCH A).map exp) : f = localBCH A := by
+  induction f using Germ.inductionOn with
+  | _ g =>
+      rw [Germ.coe_tendsto] at hf
+      rw [localBCH_def, Germ.coe_eq]
+      have hmap' :
+          (fun p : A × A => exp (g p)) =ᶠ[𝓝 ((0, 0) : A × A)]
+            (fun p => exp p.1 * exp p.2) := by
+        rw [Germ.map_coe, localBCH_map_exp, Germ.coe_eq] at hmap
+        simpa only [Function.comp_def] using hmap
+      filter_upwards [hf.eventually (eventually_logOneAdd_exp_sub_one A), hmap'] with p hp hmap_p
+      rw [← hmap_p]
+      exact hp.symm
 
 end NormedSpace


### PR DESCRIPTION
Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"LieGroups/Suggested.lean#bch"}-->

## Summary

Adds the local Baker–Campbell–Hausdorff germ in a complete real normed algebra.

- Defines the germ represented by `logOneAdd (exp x * exp y - 1)` near the origin.
- Proves its two axis equations and its exponential equation.
- Proves that the defining representative is analytic and that the germ tends to zero.
- Characterizes it as the unique germ tending to zero with the same exponential image.

## Roadmap target

Advances [LieGroups Layer 3: Baker–Campbell–Hausdorff](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-3-the-lie-functor-and-baker-campbell-hausdorff).

## Verification

Focused and 9,571-job full builds, 81,317-declaration axiom audit, 3,657-module audit, environment and style lint, consumers, proof golf, and fresh full contract-first plus structure-first aggregate reviews pass at `fe5c0784398b4cf46fb9df83666e1a2b0badf5fe`.

## Scale and generality

Adds one 141-line file over complete real normed algebras.

## Scope

- **Consumes:** the merged local `logOneAdd` inverse equations and Mathlib germs.
- **Provides:** the local BCH germ, its representative, endpoint and exponential equations, analyticity of the defining representative, convergence to zero, and uniqueness among small germs with the same exponential image.
- **Fits:** supplies the locally characterized logarithm needed for the Layer 3 BCH construction.
- **Boundary:** an explicit pointwise domain, the commutator expansion, functoriality, and transport to abstract Lie groups remain downstream.

<sub>🤖 GPT-5.6 Sol high · [rubrics](https://github.com/TauCetiProject/TauCetiReview/commit/98e9b073b76e65285fa72d4b8e0a61e272a78fd8) · local review fixed: correctness (1)</sub>