### PR TITLE
feat: simple roots depend analytically on the coefficients

### DIFF
--- a/TauCeti/Analysis/Polynomial/SimpleRoots.lean
+++ b/TauCeti/Analysis/Polynomial/SimpleRoots.lean
@@ -204,7 +204,7 @@ theorem exists_analyticAt_coeffEquiv_symm {c₀ z : Fin n → 𝕜} (hz : Functi
       (toMonic ((coeffEquiv 𝕜 n).symm c) : 𝕜[X]) = monicOfCoeff c := by
     intro c
     conv_rhs => rw [← Equiv.apply_symm_apply (coeffEquiv 𝕜 n) c]
-    rw [monicOfCoeff_coeffEquiv]
+    rw [TauCeti.monicOfCoeff_coeffEquiv]
   obtain ⟨Ψ, hΨ₀, hΨa, hΨ⟩ :=
     exists_analyticAt_prod_X_sub_C hz (((hmonic c₀).symm.trans (by rw [hc₀])).trans
       (toMonic_ofFn z))

--- a/TauCeti/Analysis/Polynomial/SimpleRoots.lean
+++ b/TauCeti/Analysis/Polynomial/SimpleRoots.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.Analysis.Analytic.Basic
 public import Mathlib.Analysis.RCLike.Basic
-public import TauCeti.RingTheory.Polynomial.SymmetricPower
+public import TauCeti.Analysis.Polynomial.SymmetricPower
 import Mathlib.Analysis.Analytic.Constructions
 import Mathlib.Analysis.Analytic.Linear
 import Mathlib.Analysis.Calculus.Deriv.Inverse
@@ -55,9 +55,6 @@ ordered lift of the (unordered) inverse chart, not analyticity of a preferred ro
 
 * `TauCeti.Polynomial.analyticAt_eval_monicOfCoeff`: the free monic polynomial is analytic in its
   coefficients and its argument jointly.
-* `TauCeti.Polynomial.analyticAt_coeff_prod_X_sub_C`: the coefficients of `∏ i ∈ s, (X - C (v i))`
-  are analytic in the tuple `v` of roots, the analytic counterpart of
-  `TauCeti.Sym.continuous_coeff_prod_X_sub_C`.
 * `TauCeti.Polynomial.exists_analyticAt_isRoot_monicOfCoeff`: **a simple root moves analytically**
   with the coefficients.
 * `TauCeti.Polynomial.exists_analyticAt_monicOfCoeff_eq_prod_X_sub_C`: a monic polynomial with `n`
@@ -65,8 +62,6 @@ ordered lift of the (unordered) inverse chart, not analyticity of a preferred ro
   coefficient tuple.
 * `TauCeti.Sym.exists_analyticAt_coeffEquiv_symm_eq_ofFn`: the same statement read through the
   elementary symmetric chart, as an analytic ordered lift of the inverse chart.
-* `TauCeti.Sym.analyticAt_coeffEquiv_ofFn`: the chart itself is analytic in an ordered
-  presentation of the tuple, being polynomial in it by Vieta's formulas.
 * `TauCeti.Sym.exists_analyticAt_coeffEquiv_ofFn_localInverse`: **the coefficient map of an
   ordered tuple is a local analytic isomorphism** at every tuple of pairwise distinct points, the
   ordered lift being a two-sided local inverse there.
@@ -120,41 +115,6 @@ theorem analyticAt_eval_monicOfCoeff (q : (Fin n → 𝕜) × 𝕜) :
       analyticAt_fst
   simp only [eval_monicOfCoeff]
   exact (hsnd.pow n).add (Finset.univ.analyticAt_fun_sum fun i _ => (hfst i).mul (hsnd.pow _))
-
-/-! ### The coefficients of a product of linear factors -/
-
-/-- The coefficients of `∏ i ∈ s, (X - C (v i))` depend analytically on the tuple `v` of roots.
-
-This is the elementary half of the chart, and the analytic counterpart of
-`TauCeti.Sym.continuous_coeff_prod_X_sub_C`: each coefficient is, up to sign, an elementary
-symmetric function of the roots, so the analyticity of the ring operations is all that is used. -/
-theorem analyticAt_coeff_prod_X_sub_C {ι : Type*} [Fintype ι] (s : Finset ι) (k : ℕ)
-    (v₀ : ι → 𝕜) : AnalyticAt 𝕜 (fun v : ι → 𝕜 => (∏ i ∈ s, (X - C (v i))).coeff k) v₀ := by
-  classical
-  have hproj : ∀ i : ι, AnalyticAt 𝕜 (fun v : ι → 𝕜 => v i) v₀ := fun i =>
-    (ContinuousLinearMap.proj (R := 𝕜) (φ := fun _ : ι => 𝕜) i).analyticAt _
-  induction s using Finset.induction_on generalizing k with
-  | empty =>
-    simp only [Finset.prod_empty]
-    exact analyticAt_const
-  | @insert a s ha ih =>
-    cases k with
-    | zero =>
-      have hpt : (fun v : ι → 𝕜 => (∏ i ∈ insert a s, (X - C (v i))).coeff 0) =
-          fun v => -v a * (∏ i ∈ s, (X - C (v i))).coeff 0 := by
-        funext v
-        rw [Finset.prod_insert ha, mul_coeff_zero]
-        simp
-      rw [hpt]
-      exact (hproj a).neg.mul (ih 0)
-    | succ k =>
-      have hpt : (fun v : ι → 𝕜 => (∏ i ∈ insert a s, (X - C (v i))).coeff (k + 1)) =
-          fun v => (∏ i ∈ s, (X - C (v i))).coeff k
-            - v a * (∏ i ∈ s, (X - C (v i))).coeff (k + 1) := by
-        funext v
-        rw [Finset.prod_insert ha, sub_mul, coeff_sub, coeff_X_mul, coeff_C_mul]
-      rw [hpt]
-      exact (ih k).sub ((hproj a).mul (ih (k + 1)))
 
 end Elementary
 
@@ -238,24 +198,7 @@ end SimpleRoot
 
 end Polynomial
 
-/-! ### The elementary symmetric chart -/
-
 namespace Sym
-
-section Chart
-
-variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsAlgClosed 𝕜] {n : ℕ}
-
-/-- The elementary symmetric chart is analytic in an ordered presentation of the tuple: by Vieta's
-formulas its coordinates are, up to sign, the elementary symmetric polynomials of the ordered
-tuple. -/
-theorem analyticAt_coeffEquiv_ofFn (v₀ : Fin n → 𝕜) :
-    AnalyticAt 𝕜 (fun v : Fin n → 𝕜 => coeffEquiv 𝕜 n (ofFn v)) v₀ := by
-  refine AnalyticAt.pi fun i => ?_
-  simp only [coeffEquiv_ofFn_apply]
-  exact Polynomial.analyticAt_coeff_prod_X_sub_C _ _ _
-
-end Chart
 
 section AlgClosed
 

--- a/TauCeti/Analysis/Polynomial/SimpleRoots.lean
+++ b/TauCeti/Analysis/Polynomial/SimpleRoots.lean
@@ -14,7 +14,6 @@ import Mathlib.Analysis.Calculus.Deriv.Inverse
 import Mathlib.Analysis.Calculus.Deriv.Polynomial
 import Mathlib.Analysis.Calculus.ImplicitContDiff
 import Mathlib.FieldTheory.Separable
-import Mathlib.RingTheory.Polynomial.Vieta
 
 /-!
 # Simple roots depend analytically on the coefficients
@@ -29,59 +28,71 @@ symmetric charts of `Sym^g(Σ)` need in order to be holomorphic.
 ## The argument
 
 The roots are not a polynomial function of the coefficients, so nothing here is formal. The whole
-file rests on one application of the implicit function theorem to the *universal monic polynomial*
+file rests on one application of the implicit function theorem to the *free monic polynomial*
 
 `f (c, z) = z ^ n + ∑ i, c i * z ^ i`,
 
-which is a polynomial in the coefficient tuple `c` and the argument `z` jointly, hence analytic.
-Its partial derivative in `z` at a point `(c₀, z₀)` is the scalar `P'(z₀)`, where `P` is the monic
-polynomial with lower coefficients `c₀`; multiplication by that scalar is an invertible operator
-exactly when `z₀` is a **simple** root of `P`. The implicit function theorem then produces a
-function `ψ` of the coefficients, analytic at `c₀`, with `ψ c₀ = z₀`, whose value stays a root of
-the nearby polynomials: `TauCeti.Sym.exists_analyticAt_isRoot`.
+that is, to `TauCeti.Polynomial.monicOfCoeff`, the specialization of Mathlib's
+`Polynomial.freeMonic` at a concrete coefficient tuple. It is a polynomial in the coefficient tuple
+`c` and the argument `z` jointly, hence analytic. Its partial derivative in `z` at a point
+`(c₀, z₀)` is the scalar `P'(z₀)`, where `P` is the monic polynomial with lower coefficients `c₀`;
+multiplication by that scalar is an invertible operator exactly when `z₀` is a **simple** root of
+`P`. The implicit function theorem then produces a function `ψ` of the coefficients, analytic at
+`c₀`, with `ψ c₀ = z₀`, whose value stays a root of the nearby polynomials:
+`TauCeti.Polynomial.exists_analyticAt_isRoot_monicOfCoeff`.
 
 Applying this at each of the `n` roots of a polynomial whose roots are pairwise distinct, and
 noting that pairwise distinctness persists in a neighbourhood, gives an analytic *ordered*
 parametrization `Ψ` of the whole unordered root tuple:
-`TauCeti.Sym.exists_analyticAt_prod_X_sub_C`. That is the multiplicity-free half of the
-statement "the inverse elementary symmetric chart is holomorphic"; the diagonal, where roots
-collide, is genuinely harder and is not treated here.
+`TauCeti.Polynomial.exists_analyticAt_monicOfCoeff_eq_prod_X_sub_C`. That is the multiplicity-free
+half of the statement "the inverse elementary symmetric chart is holomorphic"; the diagonal, where
+roots collide, is genuinely harder and is not treated here.
 
 Note that no ordering of the roots is canonical: the conclusion is the existence of an analytic
 ordered lift of the (unordered) inverse chart, not analyticity of a preferred root function.
 
 ## Main declarations
 
-* `TauCeti.Sym.analyticAt_eval_monicOfCoeff`: the universal monic polynomial is analytic in its
+* `TauCeti.Polynomial.analyticAt_eval_monicOfCoeff`: the free monic polynomial is analytic in its
   coefficients and its argument jointly.
-* `TauCeti.Sym.exists_analyticAt_isRoot`: **a simple root moves analytically** with the
-  coefficients.
-* `TauCeti.Sym.exists_analyticAt_prod_X_sub_C`: a monic polynomial with `n` distinct roots has an
-  analytic ordered parametrization of its roots on a neighbourhood of its coefficient tuple.
-* `TauCeti.Sym.exists_analyticAt_coeffEquiv_symm`: the same statement read through the elementary
-  symmetric chart, as an analytic ordered lift of the inverse chart.
+* `TauCeti.Polynomial.analyticAt_coeff_prod_X_sub_C`: the coefficients of `∏ i ∈ s, (X - C (v i))`
+  are analytic in the tuple `v` of roots, the analytic counterpart of
+  `TauCeti.Sym.continuous_coeff_prod_X_sub_C`.
+* `TauCeti.Polynomial.exists_analyticAt_isRoot_monicOfCoeff`: **a simple root moves analytically**
+  with the coefficients.
+* `TauCeti.Polynomial.exists_analyticAt_monicOfCoeff_eq_prod_X_sub_C`: a monic polynomial with `n`
+  distinct roots has an analytic ordered parametrization of its roots on a neighbourhood of its
+  coefficient tuple.
+* `TauCeti.Sym.exists_analyticAt_coeffEquiv_symm_eq_ofFn`: the same statement read through the
+  elementary symmetric chart, as an analytic ordered lift of the inverse chart.
 * `TauCeti.Sym.analyticAt_coeffEquiv_ofFn`: the chart itself is analytic in an ordered
   presentation of the tuple, being polynomial in it by Vieta's formulas.
 * `TauCeti.Sym.exists_analyticAt_coeffEquiv_ofFn_localInverse`: **the coefficient map of an
   ordered tuple is a local analytic isomorphism** at every tuple of pairwise distinct points, the
   ordered lift being a two-sided local inverse there.
-* `TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm`: **the elementary symmetric transition
-  maps are analytic at multiplicity-free points**. A map `φ` of the underlying field induces a map
-  of coefficient tuples, sending the coefficients of a polynomial to those of the polynomial whose
-  roots are the `φ`-images of its roots; it is analytic at every coefficient tuple whose roots are
-  distinct and at which `φ` is analytic.
+* `TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm`: **a coordinate change acts analytically
+  on the elementary symmetric coordinates at multiplicity-free points**. A map `φ` of the
+  underlying field induces a map of coefficient tuples, sending the coefficients of a polynomial to
+  those of the polynomial whose roots are the `φ`-images of its roots; it is analytic at every
+  coefficient tuple whose roots are distinct and at which `φ` is analytic.
 
 Lane F4.1 of the analytic Heegaard Floer roadmap opens with "`Sym^g(Σ)` geometry: smooth complex
 structure (elementary symmetric functions)", after Ozsváth--Szabó
 ([arXiv:math/0101206](https://arxiv.org/abs/math/0101206), §2.1). A holomorphic coordinate on the
-surface identifies a neighbourhood in `Sym^g(Σ)` with an open subset of `Sym^g(ℂ)`; the transition
-map between two such identifications is exactly the induced map on coefficient tuples of
-`TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm`, so that theorem is the holomorphy of the
-transition maps of the elementary symmetric atlas of
-`TauCeti/Geometry/Manifold/SymmetricPower.lean`, away from the diagonal.
+surface identifies a neighbourhood in `Sym^g(Σ)` with an open subset of `Sym^g(ℂ)`
+(`TauCeti.Sym.isOpenEmbedding_coeffEquiv_comp_map`), and
+`TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm` says that changing that coordinate acts
+analytically on the elementary symmetric coordinates of one such patch, at multiplicity-free
+tuples. That is the analytic ingredient for the transition maps of the atlas of
+`TauCeti/Geometry/Manifold/SymmetricPower.lean`, not those transition maps themselves: a chart
+there splits a tuple into the factors lying in `k` disjoint patches, of degrees `m 1, …, m k`, and
+regroups the resulting blocks of coefficients along a bijection `(Σ i, Fin (m i)) ≃ Fin n`.
+Neither that assembly across blocks nor the diagonal, where the points of a tuple collide, is
+treated here.
 
-Everything is stated over an `RCLike` field, so it covers the real as well as the complex case;
-only the statements that mention the chart itself need the field algebraically closed.
+Everything is stated over an `RCLike` field, so it covers the real as well as the complex case,
+except for the elementary polynomial calculus, which needs only a nontrivially normed field; only
+the statements that mention the chart itself need the field algebraically closed.
 -/
 
 public section
@@ -91,14 +102,16 @@ open scoped ContDiff
 
 namespace TauCeti
 
-namespace Sym
+namespace Polynomial
 
-variable {𝕜 : Type*} [RCLike 𝕜] {n : ℕ}
+/-! ### The free monic polynomial -/
 
-/-! ### The universal monic polynomial -/
+section Elementary
 
-/-- The universal monic polynomial of degree `n`, evaluated at a coefficient tuple and an argument,
-is analytic in the two jointly: it is `z ^ n + ∑ i, c i * z ^ i`. -/
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : ℕ}
+
+/-- The free monic polynomial of degree `n`, evaluated at a coefficient tuple and an argument, is
+analytic in the two jointly: it is `z ^ n + ∑ i, c i * z ^ i`. -/
 theorem analyticAt_eval_monicOfCoeff (q : (Fin n → 𝕜) × 𝕜) :
     AnalyticAt 𝕜 (fun p : (Fin n → 𝕜) × 𝕜 => (monicOfCoeff p.1).eval p.2) q := by
   have hsnd : AnalyticAt 𝕜 (fun p : (Fin n → 𝕜) × 𝕜 => p.2) q := analyticAt_snd
@@ -108,17 +121,58 @@ theorem analyticAt_eval_monicOfCoeff (q : (Fin n → 𝕜) × 𝕜) :
   simp only [eval_monicOfCoeff]
   exact (hsnd.pow n).add (Finset.univ.analyticAt_fun_sum fun i _ => (hfst i).mul (hsnd.pow _))
 
+/-! ### The coefficients of a product of linear factors -/
+
+/-- The coefficients of `∏ i ∈ s, (X - C (v i))` depend analytically on the tuple `v` of roots.
+
+This is the elementary half of the chart, and the analytic counterpart of
+`TauCeti.Sym.continuous_coeff_prod_X_sub_C`: each coefficient is, up to sign, an elementary
+symmetric function of the roots, so the analyticity of the ring operations is all that is used. -/
+theorem analyticAt_coeff_prod_X_sub_C {ι : Type*} [Fintype ι] (s : Finset ι) (k : ℕ)
+    (v₀ : ι → 𝕜) : AnalyticAt 𝕜 (fun v : ι → 𝕜 => (∏ i ∈ s, (X - C (v i))).coeff k) v₀ := by
+  classical
+  have hproj : ∀ i : ι, AnalyticAt 𝕜 (fun v : ι → 𝕜 => v i) v₀ := fun i =>
+    (ContinuousLinearMap.proj (R := 𝕜) (φ := fun _ : ι => 𝕜) i).analyticAt _
+  induction s using Finset.induction_on generalizing k with
+  | empty =>
+    simp only [Finset.prod_empty]
+    exact analyticAt_const
+  | @insert a s ha ih =>
+    cases k with
+    | zero =>
+      have hpt : (fun v : ι → 𝕜 => (∏ i ∈ insert a s, (X - C (v i))).coeff 0) =
+          fun v => -v a * (∏ i ∈ s, (X - C (v i))).coeff 0 := by
+        funext v
+        rw [Finset.prod_insert ha, mul_coeff_zero]
+        simp
+      rw [hpt]
+      exact (hproj a).neg.mul (ih 0)
+    | succ k =>
+      have hpt : (fun v : ι → 𝕜 => (∏ i ∈ insert a s, (X - C (v i))).coeff (k + 1)) =
+          fun v => (∏ i ∈ s, (X - C (v i))).coeff k
+            - v a * (∏ i ∈ s, (X - C (v i))).coeff (k + 1) := by
+        funext v
+        rw [Finset.prod_insert ha, sub_mul, coeff_sub, coeff_X_mul, coeff_C_mul]
+      rw [hpt]
+      exact (ih k).sub ((hproj a).mul (ih (k + 1)))
+
+end Elementary
+
 /-! ### A simple root moves analytically -/
+
+section SimpleRoot
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n : ℕ}
 
 /-- **A simple root moves analytically.** If `z₀` is a root of the monic polynomial with lower
 coefficients `c₀` at which the derivative does not vanish, then there is a function `ψ` of the
 coefficients, analytic at `c₀`, with `ψ c₀ = z₀`, whose value at every nearby coefficient tuple is
 a root of the corresponding monic polynomial.
 
-This is the implicit function theorem applied to the universal monic polynomial: its partial
-derivative in the argument is multiplication by `P'(z₀)`, which is invertible exactly under the
-simplicity hypothesis. -/
-theorem exists_analyticAt_isRoot {c₀ : Fin n → 𝕜} {z₀ : 𝕜}
+This is the implicit function theorem applied to the free monic polynomial: its partial derivative
+in the argument is multiplication by `P'(z₀)`, which is invertible exactly under the simplicity
+hypothesis. -/
+theorem exists_analyticAt_isRoot_monicOfCoeff {c₀ : Fin n → 𝕜} {z₀ : 𝕜}
     (hroot : (monicOfCoeff c₀).IsRoot z₀)
     (hsimple : (derivative (monicOfCoeff c₀)).eval z₀ ≠ 0) :
     ∃ ψ : (Fin n → 𝕜) → 𝕜, ψ c₀ = z₀ ∧ AnalyticAt 𝕜 ψ c₀ ∧
@@ -153,64 +207,44 @@ the roots of every nearby monic polynomial.
 
 No ordering of the roots is canonical, so the ordered lift `Ψ` is not unique; what is asserted is
 that some analytic ordering exists near `c₀`. -/
-theorem exists_analyticAt_prod_X_sub_C {c₀ z : Fin n → 𝕜} (hz : Function.Injective z)
-    (hc₀ : monicOfCoeff c₀ = ∏ i, (X - C (z i))) :
+theorem exists_analyticAt_monicOfCoeff_eq_prod_X_sub_C {c₀ z : Fin n → 𝕜}
+    (hz : Function.Injective z) (hc₀ : monicOfCoeff c₀ = ∏ i, (X - C (z i))) :
     ∃ Ψ : (Fin n → 𝕜) → (Fin n → 𝕜), Ψ c₀ = z ∧ AnalyticAt 𝕜 Ψ c₀ ∧
       ∀ᶠ c in 𝓝 c₀, monicOfCoeff c = ∏ i, (X - C (Ψ c i)) := by
   have hroot : ∀ i, (monicOfCoeff c₀).eval (z i) = 0 := by
     intro i
     rw [hc₀, eval_prod]
     exact Finset.prod_eq_zero (Finset.mem_univ i) (by simp)
-  have hsimple : ∀ i, (derivative (monicOfCoeff c₀)).eval (z i) ≠ 0 := by
-    intro i hi
-    obtain ⟨a, b, hab⟩ : IsCoprime (monicOfCoeff c₀) (derivative (monicOfCoeff c₀)) :=
-      hc₀ ▸ separable_prod_X_sub_C_iff.2 hz
-    have := congrArg (Polynomial.eval (z i)) hab
-    simp only [eval_add, eval_mul, eval_one, hroot i, hi, mul_zero, add_zero] at this
-    exact zero_ne_one this
-  choose ψ hψ₀ hψa hψr using fun i => exists_analyticAt_isRoot (hroot i) (hsimple i)
+  have hsep : (monicOfCoeff c₀).Separable := hc₀ ▸ separable_prod_X_sub_C_iff.2 hz
+  have hsimple : ∀ i, (derivative (monicOfCoeff c₀)).eval (z i) ≠ 0 := fun i =>
+    hsep.eval₂_derivative_ne_zero (RingHom.id 𝕜) (hroot i)
+  choose ψ hψ₀ hψa hψr using fun i => exists_analyticAt_isRoot_monicOfCoeff (hroot i) (hsimple i)
   refine ⟨fun c i => ψ i c, funext hψ₀, AnalyticAt.pi hψa, ?_⟩
   have hne : ∀ i j : Fin n, ∀ᶠ c in 𝓝 c₀, i ≠ j → ψ i c ≠ ψ j c := by
     intro i j
     rcases eq_or_ne i j with rfl | hij
     · exact .of_forall fun _ h => absurd rfl h
-    · have hcont : ContinuousAt (fun c => ψ i c - ψ j c) c₀ :=
-        (hψa i).continuousAt.sub (hψa j).continuousAt
-      have h0 : (fun c => ψ i c - ψ j c) c₀ ≠ 0 := by
-        simp only [hψ₀ i, hψ₀ j, ne_eq, sub_eq_zero]
-        exact fun h => hij (hz h)
-      filter_upwards [hcont.eventually_ne h0] with c hc _
-      exact sub_ne_zero.mp hc
+    · filter_upwards [((hψa i).continuousAt.ne_iff_eventually_ne (hψa j).continuousAt).1
+        (by rw [hψ₀ i, hψ₀ j]; exact fun h => hij (hz h))] with c hc _ using hc
   filter_upwards [eventually_all.2 hψr,
     eventually_all.2 fun i => eventually_all.2 fun j => hne i j] with c hcr hcne
   have hcinj : Function.Injective fun i => ψ i c := fun i j hij => by
     by_contra h
     exact hcne i j h hij
-  exact (toMonic_ofFn_eq_of_forall_isRoot (monic_monicOfCoeff c) (natDegree_monicOfCoeff c) hcinj
-    hcr).symm.trans (toMonic_ofFn _)
+  exact (Sym.toMonic_ofFn_eq_of_forall_isRoot (monic_monicOfCoeff c) (natDegree_monicOfCoeff c)
+    hcinj hcr).symm.trans (Sym.toMonic_ofFn _)
+
+end SimpleRoot
+
+end Polynomial
 
 /-! ### The elementary symmetric chart -/
 
-variable [IsAlgClosed 𝕜]
+namespace Sym
 
-/-- The inverse elementary symmetric chart admits an analytic ordered lift at every
-multiplicity-free coefficient tuple: near such a tuple the unordered root tuple is `ofFn` of an
-analytic ordered tuple. -/
-theorem exists_analyticAt_coeffEquiv_symm {c₀ z : Fin n → 𝕜} (hz : Function.Injective z)
-    (hc₀ : (coeffEquiv 𝕜 n).symm c₀ = ofFn z) :
-    ∃ Ψ : (Fin n → 𝕜) → (Fin n → 𝕜), Ψ c₀ = z ∧ AnalyticAt 𝕜 Ψ c₀ ∧
-      ∀ᶠ c in 𝓝 c₀, (coeffEquiv 𝕜 n).symm c = ofFn (Ψ c) := by
-  have hmonic : ∀ c : Fin n → 𝕜,
-      (toMonic ((coeffEquiv 𝕜 n).symm c) : 𝕜[X]) = monicOfCoeff c := by
-    intro c
-    conv_rhs => rw [← Equiv.apply_symm_apply (coeffEquiv 𝕜 n) c]
-    rw [TauCeti.monicOfCoeff_coeffEquiv]
-  obtain ⟨Ψ, hΨ₀, hΨa, hΨ⟩ :=
-    exists_analyticAt_prod_X_sub_C hz (((hmonic c₀).symm.trans (by rw [hc₀])).trans
-      (toMonic_ofFn z))
-  refine ⟨Ψ, hΨ₀, hΨa, ?_⟩
-  filter_upwards [hΨ] with c hc
-  exact toMonic_injective (Subtype.ext (((hmonic c).trans hc).trans (toMonic_ofFn _).symm))
+section Chart
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsAlgClosed 𝕜] {n : ℕ}
 
 /-- The elementary symmetric chart is analytic in an ordered presentation of the tuple: by Vieta's
 formulas its coordinates are, up to sign, the elementary symmetric polynomials of the ordered
@@ -218,19 +252,29 @@ tuple. -/
 theorem analyticAt_coeffEquiv_ofFn (v₀ : Fin n → 𝕜) :
     AnalyticAt 𝕜 (fun v : Fin n → 𝕜 => coeffEquiv 𝕜 n (ofFn v)) v₀ := by
   refine AnalyticAt.pi fun i => ?_
-  have hcoeff : ∀ v : Fin n → 𝕜, coeffEquiv 𝕜 n (ofFn v) i
-      = ∑ t ∈ Finset.univ.powersetCard (n - (i : ℕ)), ∏ j ∈ t, -v j := by
-    intro v
-    have hlin : ∀ j : Fin n, (X - C (v j) : 𝕜[X]) = X + C (-v j) := by
-      intro j
-      rw [map_neg, sub_eq_add_neg]
-    rw [coeffEquiv_ofFn_apply]
-    simp_rw [hlin]
-    rw [Finset.prod_X_add_C_coeff _ _ (by simp)]
-    simp
-  simp only [hcoeff]
-  refine Finset.analyticAt_fun_sum _ fun t _ => Finset.analyticAt_fun_prod _ fun j _ => ?_
-  exact (analyticAt_pi_iff.1 (analyticAt_id (𝕜 := 𝕜) (z := v₀)) j).neg
+  simp only [coeffEquiv_ofFn_apply]
+  exact Polynomial.analyticAt_coeff_prod_X_sub_C _ _ _
+
+end Chart
+
+section AlgClosed
+
+variable {𝕜 : Type*} [RCLike 𝕜] [IsAlgClosed 𝕜] {n : ℕ}
+
+/-- The inverse elementary symmetric chart admits an analytic ordered lift at every
+multiplicity-free coefficient tuple: near such a tuple the unordered root tuple is `ofFn` of an
+analytic ordered tuple. -/
+theorem exists_analyticAt_coeffEquiv_symm_eq_ofFn {c₀ z : Fin n → 𝕜} (hz : Function.Injective z)
+    (hc₀ : (coeffEquiv 𝕜 n).symm c₀ = ofFn z) :
+    ∃ Ψ : (Fin n → 𝕜) → (Fin n → 𝕜), Ψ c₀ = z ∧ AnalyticAt 𝕜 Ψ c₀ ∧
+      ∀ᶠ c in 𝓝 c₀, (coeffEquiv 𝕜 n).symm c = ofFn (Ψ c) := by
+  obtain ⟨Ψ, hΨ₀, hΨa, hΨ⟩ :=
+    Polynomial.exists_analyticAt_monicOfCoeff_eq_prod_X_sub_C hz
+      (((toMonic_coeffEquiv_symm c₀).symm.trans (by rw [hc₀])).trans (toMonic_ofFn z))
+  refine ⟨Ψ, hΨ₀, hΨa, ?_⟩
+  filter_upwards [hΨ] with c hc
+  exact toMonic_injective
+    (Subtype.ext (((toMonic_coeffEquiv_symm c).trans hc).trans (toMonic_ofFn _).symm))
 
 /-- **The coefficient map is a local analytic isomorphism away from the diagonal.** At an ordered
 tuple `z` of pairwise distinct points there is an analytic `Ψ` inverting, on both sides and near
@@ -246,7 +290,7 @@ theorem exists_analyticAt_coeffEquiv_ofFn_localInverse {z : Fin n → 𝕜}
       (∀ᶠ w in 𝓝 z, Ψ (coeffEquiv 𝕜 n (ofFn w)) = w) ∧
       (∀ᶠ c in 𝓝 (coeffEquiv 𝕜 n (ofFn z)), coeffEquiv 𝕜 n (ofFn (Ψ c)) = c) := by
   obtain ⟨Ψ, hΨ₀, hΨa, hΨ⟩ :=
-    exists_analyticAt_coeffEquiv_symm hz (Equiv.symm_apply_apply (coeffEquiv 𝕜 n) (ofFn z))
+    exists_analyticAt_coeffEquiv_symm_eq_ofFn hz (Equiv.symm_apply_apply (coeffEquiv 𝕜 n) (ofFn z))
   have hσ : ContinuousAt (fun w : Fin n → 𝕜 => coeffEquiv 𝕜 n (ofFn w)) z :=
     (analyticAt_coeffEquiv_ofFn z).continuousAt
   refine ⟨Ψ, hΨ₀, hΨa, ?_, ?_⟩
@@ -267,14 +311,8 @@ theorem exists_analyticAt_coeffEquiv_ofFn_localInverse {z : Fin n → 𝕜}
       · have hΨi : ContinuousAt (fun w : Fin n → 𝕜 => Ψ (coeffEquiv 𝕜 n (ofFn w)) i) z :=
           ContinuousAt.comp' (f := fun w : Fin n → 𝕜 => coeffEquiv 𝕜 n (ofFn w))
             (analyticAt_pi_iff.1 hΨa i).continuousAt hσ
-        have hcont : ContinuousAt (fun w => Ψ (coeffEquiv 𝕜 n (ofFn w)) i - w j) z :=
-          hΨi.sub (continuousAt_apply j z)
-        have h0 : (fun w => Ψ (coeffEquiv 𝕜 n (ofFn w)) i - w j) z ≠ 0 := by
-          simp only [ne_eq, sub_eq_zero]
-          rw [hΨ₀]
-          exact fun h => hij (hz h)
-        filter_upwards [hcont.eventually_ne h0] with w hw _
-        exact sub_ne_zero.mp hw
+        filter_upwards [(hΨi.ne_iff_eventually_ne (continuousAt_apply j z)).1
+          (by rw [hΨ₀]; exact fun h => hij (hz h))] with w hw _ using hw
     filter_upwards [hmem, eventually_all.2 fun i => eventually_all.2 fun j => hne i j] with
       w hw hwne
     refine funext fun i => ?_
@@ -285,20 +323,22 @@ theorem exists_analyticAt_coeffEquiv_ofFn_localInverse {z : Fin n → 𝕜}
   · filter_upwards [hΨ] with c hc
     rw [← hc, Equiv.apply_symm_apply]
 
-/-- **The elementary symmetric transition maps are analytic away from the diagonal.** A map `φ` of
-the field induces a map of coefficient tuples, taking the coefficients of a monic polynomial to
-those of the monic polynomial whose roots are the `φ`-images of its roots. That induced map is
-analytic at every coefficient tuple whose roots are pairwise distinct and at each of which `φ` is
-analytic.
+/-- **A coordinate change acts analytically on the elementary symmetric coordinates away from the
+diagonal.** A map `φ` of the field induces a map of coefficient tuples, taking the coefficients of
+a monic polynomial to those of the monic polynomial whose roots are the `φ`-images of its roots.
+That induced map is analytic at every coefficient tuple whose roots are pairwise distinct and at
+each of which `φ` is analytic.
 
-Read on `Sym^g(Σ)`, this is the holomorphy of the transition maps of the elementary symmetric
-atlas at the multiplicity-free points: `φ` is the change of holomorphic coordinate on the
-surface. -/
+Read on `Sym^g(Σ)`, `φ` is a change of holomorphic coordinate on the surface, so this is the
+analytic ingredient, at multiplicity-free tuples, for the holomorphy of the transition maps of the
+elementary symmetric atlas of `TauCeti/Geometry/Manifold/SymmetricPower.lean`: it treats one
+coordinate patch (`TauCeti.Sym.isOpenEmbedding_coeffEquiv_comp_map`), and assembling the patches a
+chart there decomposes a tuple into is not done. -/
 theorem analyticAt_coeffEquiv_map_coeffEquiv_symm {φ : 𝕜 → 𝕜} {c₀ z : Fin n → 𝕜}
     (hz : Function.Injective z) (hc₀ : (coeffEquiv 𝕜 n).symm c₀ = ofFn z)
     (hφ : ∀ i, AnalyticAt 𝕜 φ (z i)) :
     AnalyticAt 𝕜 (fun c => coeffEquiv 𝕜 n (_root_.Sym.map φ ((coeffEquiv 𝕜 n).symm c))) c₀ := by
-  obtain ⟨Ψ, hΨ₀, hΨa, hΨ⟩ := exists_analyticAt_coeffEquiv_symm hz hc₀
+  obtain ⟨Ψ, hΨ₀, hΨa, hΨ⟩ := exists_analyticAt_coeffEquiv_symm_eq_ofFn hz hc₀
   have hcomp : AnalyticAt 𝕜 (fun c => fun i => φ (Ψ c i)) c₀ := by
     refine AnalyticAt.pi fun i => ?_
     have hi : AnalyticAt 𝕜 (fun c => Ψ c i) c₀ := analyticAt_pi_iff.1 hΨa i
@@ -310,6 +350,8 @@ theorem analyticAt_coeffEquiv_map_coeffEquiv_symm {φ : 𝕜 → 𝕜} {c₀ z :
   filter_upwards [hΨ] with c hc
   rw [hc, map_ofFn]
   rfl
+
+end AlgClosed
 
 end Sym
 

--- a/TauCeti/Analysis/Polynomial/SimpleRoots.lean
+++ b/TauCeti/Analysis/Polynomial/SimpleRoots.lean
@@ -1,0 +1,316 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Analytic.Basic
+public import Mathlib.Analysis.RCLike.Basic
+public import TauCeti.RingTheory.Polynomial.SymmetricPower
+import Mathlib.Analysis.Analytic.Constructions
+import Mathlib.Analysis.Analytic.Linear
+import Mathlib.Analysis.Calculus.Deriv.Inverse
+import Mathlib.Analysis.Calculus.Deriv.Polynomial
+import Mathlib.Analysis.Calculus.ImplicitContDiff
+import Mathlib.FieldTheory.Separable
+import Mathlib.RingTheory.Polynomial.Vieta
+
+/-!
+# Simple roots depend analytically on the coefficients
+
+`TauCeti.Sym.coeffEquiv` presents the `n`-th symmetric power of an algebraically closed field as
+the affine space `Fin n → K` of coefficient tuples, and
+`TauCeti/Analysis/Polynomial/SymmetricPower.lean` proves that presentation a *homeomorphism*: the
+roots of a monic polynomial depend continuously on its coefficients. This file upgrades continuity
+to **analyticity** wherever the roots are simple, which is the analytic input that the elementary
+symmetric charts of `Sym^g(Σ)` need in order to be holomorphic.
+
+## The argument
+
+The roots are not a polynomial function of the coefficients, so nothing here is formal. The whole
+file rests on one application of the implicit function theorem to the *universal monic polynomial*
+
+`f (c, z) = z ^ n + ∑ i, c i * z ^ i`,
+
+which is a polynomial in the coefficient tuple `c` and the argument `z` jointly, hence analytic.
+Its partial derivative in `z` at a point `(c₀, z₀)` is the scalar `P'(z₀)`, where `P` is the monic
+polynomial with lower coefficients `c₀`; multiplication by that scalar is an invertible operator
+exactly when `z₀` is a **simple** root of `P`. The implicit function theorem then produces a
+function `ψ` of the coefficients, analytic at `c₀`, with `ψ c₀ = z₀`, whose value stays a root of
+the nearby polynomials: `TauCeti.Sym.exists_analyticAt_isRoot`.
+
+Applying this at each of the `n` roots of a polynomial whose roots are pairwise distinct, and
+noting that pairwise distinctness persists in a neighbourhood, gives an analytic *ordered*
+parametrization `Ψ` of the whole unordered root tuple:
+`TauCeti.Sym.exists_analyticAt_prod_X_sub_C`. That is the multiplicity-free half of the
+statement "the inverse elementary symmetric chart is holomorphic"; the diagonal, where roots
+collide, is genuinely harder and is not treated here.
+
+Note that no ordering of the roots is canonical: the conclusion is the existence of an analytic
+ordered lift of the (unordered) inverse chart, not analyticity of a preferred root function.
+
+## Main declarations
+
+* `TauCeti.Sym.analyticAt_eval_monicOfCoeff`: the universal monic polynomial is analytic in its
+  coefficients and its argument jointly.
+* `TauCeti.Sym.exists_analyticAt_isRoot`: **a simple root moves analytically** with the
+  coefficients.
+* `TauCeti.Sym.exists_analyticAt_prod_X_sub_C`: a monic polynomial with `n` distinct roots has an
+  analytic ordered parametrization of its roots on a neighbourhood of its coefficient tuple.
+* `TauCeti.Sym.exists_analyticAt_coeffEquiv_symm`: the same statement read through the elementary
+  symmetric chart, as an analytic ordered lift of the inverse chart.
+* `TauCeti.Sym.analyticAt_coeffEquiv_ofFn`: the chart itself is analytic in an ordered
+  presentation of the tuple, being polynomial in it by Vieta's formulas.
+* `TauCeti.Sym.exists_analyticAt_coeffEquiv_ofFn_localInverse`: **the coefficient map of an
+  ordered tuple is a local analytic isomorphism** at every tuple of pairwise distinct points, the
+  ordered lift being a two-sided local inverse there.
+* `TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm`: **the elementary symmetric transition
+  maps are analytic at multiplicity-free points**. A map `φ` of the underlying field induces a map
+  of coefficient tuples, sending the coefficients of a polynomial to those of the polynomial whose
+  roots are the `φ`-images of its roots; it is analytic at every coefficient tuple whose roots are
+  distinct and at which `φ` is analytic.
+
+Lane F4.1 of the analytic Heegaard Floer roadmap opens with "`Sym^g(Σ)` geometry: smooth complex
+structure (elementary symmetric functions)", after Ozsváth--Szabó
+([arXiv:math/0101206](https://arxiv.org/abs/math/0101206), §2.1). A holomorphic coordinate on the
+surface identifies a neighbourhood in `Sym^g(Σ)` with an open subset of `Sym^g(ℂ)`; the transition
+map between two such identifications is exactly the induced map on coefficient tuples of
+`TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm`, so that theorem is the holomorphy of the
+transition maps of the elementary symmetric atlas of
+`TauCeti/Geometry/Manifold/SymmetricPower.lean`, away from the diagonal.
+
+Everything is stated over an `RCLike` field, so it covers the real as well as the complex case;
+only the statements that mention the chart itself need the field algebraically closed.
+-/
+
+public section
+
+open Filter Polynomial Topology
+open scoped ContDiff
+
+namespace TauCeti
+
+namespace Sym
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n : ℕ}
+
+/-! ### The universal monic polynomial -/
+
+/-- The universal monic polynomial of degree `n`, evaluated at a coefficient tuple and an argument,
+is analytic in the two jointly: it is `z ^ n + ∑ i, c i * z ^ i`. -/
+theorem analyticAt_eval_monicOfCoeff (q : (Fin n → 𝕜) × 𝕜) :
+    AnalyticAt 𝕜 (fun p : (Fin n → 𝕜) × 𝕜 => (monicOfCoeff p.1).eval p.2) q := by
+  have hsnd : AnalyticAt 𝕜 (fun p : (Fin n → 𝕜) × 𝕜 => p.2) q := analyticAt_snd
+  have hfst : ∀ i : Fin n, AnalyticAt 𝕜 (fun p : (Fin n → 𝕜) × 𝕜 => p.1 i) q := fun i =>
+    ((ContinuousLinearMap.proj (R := 𝕜) (φ := fun _ : Fin n => 𝕜) i).analyticAt _).comp
+      analyticAt_fst
+  simp only [eval_monicOfCoeff]
+  exact (hsnd.pow n).add (Finset.univ.analyticAt_fun_sum fun i _ => (hfst i).mul (hsnd.pow _))
+
+/-! ### A simple root moves analytically -/
+
+/-- **A simple root moves analytically.** If `z₀` is a root of the monic polynomial with lower
+coefficients `c₀` at which the derivative does not vanish, then there is a function `ψ` of the
+coefficients, analytic at `c₀`, with `ψ c₀ = z₀`, whose value at every nearby coefficient tuple is
+a root of the corresponding monic polynomial.
+
+This is the implicit function theorem applied to the universal monic polynomial: its partial
+derivative in the argument is multiplication by `P'(z₀)`, which is invertible exactly under the
+simplicity hypothesis. -/
+theorem exists_analyticAt_isRoot {c₀ : Fin n → 𝕜} {z₀ : 𝕜}
+    (hroot : (monicOfCoeff c₀).IsRoot z₀)
+    (hsimple : (derivative (monicOfCoeff c₀)).eval z₀ ≠ 0) :
+    ∃ ψ : (Fin n → 𝕜) → 𝕜, ψ c₀ = z₀ ∧ AnalyticAt 𝕜 ψ c₀ ∧
+      ∀ᶠ c in 𝓝 c₀, (monicOfCoeff c).IsRoot (ψ c) := by
+  set f : (Fin n → 𝕜) × 𝕜 → 𝕜 := fun p => (monicOfCoeff p.1).eval p.2
+  have cdf : ContDiffAt 𝕜 ω f (c₀, z₀) := (analyticAt_eval_monicOfCoeff _).contDiffAt
+  set e : 𝕜 ≃L[𝕜] 𝕜 := ContinuousLinearEquiv.unitsEquivAut 𝕜 (Units.mk0 _ hsimple)
+  have hpartial : HasFDerivAt (fun z : 𝕜 => f (c₀, z)) (e : 𝕜 →L[𝕜] 𝕜) z₀ :=
+    ((monicOfCoeff c₀).hasDerivAt z₀).hasFDerivAt_equiv hsimple
+  have hdiff : HasFDerivAt f (fderiv 𝕜 f (c₀, z₀)) (c₀, z₀) :=
+    (cdf.differentiableAt (by simp)).hasFDerivAt
+  have hinr : HasFDerivAt (fun z : 𝕜 => ((c₀ : Fin n → 𝕜), z))
+      (ContinuousLinearMap.inr 𝕜 (Fin n → 𝕜) 𝕜) z₀ :=
+    (hasFDerivAt_const c₀ z₀).prodMk (hasFDerivAt_id z₀)
+  have hcomp : fderiv 𝕜 f (c₀, z₀) ∘L ContinuousLinearMap.inr 𝕜 (Fin n → 𝕜) 𝕜
+      = (e : 𝕜 →L[𝕜] 𝕜) := (hdiff.comp z₀ hinr).unique hpartial
+  have if₂ : (fderiv 𝕜 f (c₀, z₀) ∘L ContinuousLinearMap.inr 𝕜 (Fin n → 𝕜) 𝕜).IsInvertible := by
+    rw [hcomp]
+    exact ⟨e, rfl⟩
+  refine ⟨cdf.implicitFunction (by simp) if₂, cdf.implicitFunction_apply_self _ if₂,
+    (cdf.contDiffAt_implicitFunction _ if₂).analyticAt, ?_⟩
+  filter_upwards [cdf.eventually_apply_implicitFunction (by simp) if₂] with c hc
+  have h₀ : f (c₀, z₀) = 0 := hroot
+  exact hc.trans h₀
+
+/-! ### An analytic ordered parametrization of a multiplicity-free root tuple -/
+
+/-- **The roots of a monic polynomial with distinct roots move analytically.** If the monic
+polynomial with lower coefficients `c₀` is `∏ i, (X - z i)` for a tuple `z` of pairwise distinct
+points, then there is a tuple-valued function `Ψ`, analytic at `c₀`, with `Ψ c₀ = z`, which orders
+the roots of every nearby monic polynomial.
+
+No ordering of the roots is canonical, so the ordered lift `Ψ` is not unique; what is asserted is
+that some analytic ordering exists near `c₀`. -/
+theorem exists_analyticAt_prod_X_sub_C {c₀ z : Fin n → 𝕜} (hz : Function.Injective z)
+    (hc₀ : monicOfCoeff c₀ = ∏ i, (X - C (z i))) :
+    ∃ Ψ : (Fin n → 𝕜) → (Fin n → 𝕜), Ψ c₀ = z ∧ AnalyticAt 𝕜 Ψ c₀ ∧
+      ∀ᶠ c in 𝓝 c₀, monicOfCoeff c = ∏ i, (X - C (Ψ c i)) := by
+  have hroot : ∀ i, (monicOfCoeff c₀).eval (z i) = 0 := by
+    intro i
+    rw [hc₀, eval_prod]
+    exact Finset.prod_eq_zero (Finset.mem_univ i) (by simp)
+  have hsimple : ∀ i, (derivative (monicOfCoeff c₀)).eval (z i) ≠ 0 := by
+    intro i hi
+    obtain ⟨a, b, hab⟩ : IsCoprime (monicOfCoeff c₀) (derivative (monicOfCoeff c₀)) :=
+      hc₀ ▸ separable_prod_X_sub_C_iff.2 hz
+    have := congrArg (Polynomial.eval (z i)) hab
+    simp only [eval_add, eval_mul, eval_one, hroot i, hi, mul_zero, add_zero] at this
+    exact zero_ne_one this
+  choose ψ hψ₀ hψa hψr using fun i => exists_analyticAt_isRoot (hroot i) (hsimple i)
+  refine ⟨fun c i => ψ i c, funext hψ₀, AnalyticAt.pi hψa, ?_⟩
+  have hne : ∀ i j : Fin n, ∀ᶠ c in 𝓝 c₀, i ≠ j → ψ i c ≠ ψ j c := by
+    intro i j
+    rcases eq_or_ne i j with rfl | hij
+    · exact .of_forall fun _ h => absurd rfl h
+    · have hcont : ContinuousAt (fun c => ψ i c - ψ j c) c₀ :=
+        (hψa i).continuousAt.sub (hψa j).continuousAt
+      have h0 : (fun c => ψ i c - ψ j c) c₀ ≠ 0 := by
+        simp only [hψ₀ i, hψ₀ j, ne_eq, sub_eq_zero]
+        exact fun h => hij (hz h)
+      filter_upwards [hcont.eventually_ne h0] with c hc _
+      exact sub_ne_zero.mp hc
+  filter_upwards [eventually_all.2 hψr,
+    eventually_all.2 fun i => eventually_all.2 fun j => hne i j] with c hcr hcne
+  have hcinj : Function.Injective fun i => ψ i c := fun i j hij => by
+    by_contra h
+    exact hcne i j h hij
+  exact (toMonic_ofFn_eq_of_forall_isRoot (monic_monicOfCoeff c) (natDegree_monicOfCoeff c) hcinj
+    hcr).symm.trans (toMonic_ofFn _)
+
+/-! ### The elementary symmetric chart -/
+
+variable [IsAlgClosed 𝕜]
+
+/-- The inverse elementary symmetric chart admits an analytic ordered lift at every
+multiplicity-free coefficient tuple: near such a tuple the unordered root tuple is `ofFn` of an
+analytic ordered tuple. -/
+theorem exists_analyticAt_coeffEquiv_symm {c₀ z : Fin n → 𝕜} (hz : Function.Injective z)
+    (hc₀ : (coeffEquiv 𝕜 n).symm c₀ = ofFn z) :
+    ∃ Ψ : (Fin n → 𝕜) → (Fin n → 𝕜), Ψ c₀ = z ∧ AnalyticAt 𝕜 Ψ c₀ ∧
+      ∀ᶠ c in 𝓝 c₀, (coeffEquiv 𝕜 n).symm c = ofFn (Ψ c) := by
+  have hmonic : ∀ c : Fin n → 𝕜,
+      (toMonic ((coeffEquiv 𝕜 n).symm c) : 𝕜[X]) = monicOfCoeff c := by
+    intro c
+    conv_rhs => rw [← Equiv.apply_symm_apply (coeffEquiv 𝕜 n) c]
+    rw [monicOfCoeff_coeffEquiv]
+  obtain ⟨Ψ, hΨ₀, hΨa, hΨ⟩ :=
+    exists_analyticAt_prod_X_sub_C hz (((hmonic c₀).symm.trans (by rw [hc₀])).trans
+      (toMonic_ofFn z))
+  refine ⟨Ψ, hΨ₀, hΨa, ?_⟩
+  filter_upwards [hΨ] with c hc
+  exact toMonic_injective (Subtype.ext (((hmonic c).trans hc).trans (toMonic_ofFn _).symm))
+
+/-- The elementary symmetric chart is analytic in an ordered presentation of the tuple: by Vieta's
+formulas its coordinates are, up to sign, the elementary symmetric polynomials of the ordered
+tuple. -/
+theorem analyticAt_coeffEquiv_ofFn (v₀ : Fin n → 𝕜) :
+    AnalyticAt 𝕜 (fun v : Fin n → 𝕜 => coeffEquiv 𝕜 n (ofFn v)) v₀ := by
+  refine AnalyticAt.pi fun i => ?_
+  have hcoeff : ∀ v : Fin n → 𝕜, coeffEquiv 𝕜 n (ofFn v) i
+      = ∑ t ∈ Finset.univ.powersetCard (n - (i : ℕ)), ∏ j ∈ t, -v j := by
+    intro v
+    have hlin : ∀ j : Fin n, (X - C (v j) : 𝕜[X]) = X + C (-v j) := by
+      intro j
+      rw [map_neg, sub_eq_add_neg]
+    rw [coeffEquiv_ofFn_apply]
+    simp_rw [hlin]
+    rw [Finset.prod_X_add_C_coeff _ _ (by simp)]
+    simp
+  simp only [hcoeff]
+  refine Finset.analyticAt_fun_sum _ fun t _ => Finset.analyticAt_fun_prod _ fun j _ => ?_
+  exact (analyticAt_pi_iff.1 (analyticAt_id (𝕜 := 𝕜) (z := v₀)) j).neg
+
+/-- **The coefficient map is a local analytic isomorphism away from the diagonal.** At an ordered
+tuple `z` of pairwise distinct points there is an analytic `Ψ` inverting, on both sides and near
+`z`, the map that reads off the elementary symmetric coordinates of an ordered tuple.
+
+The left inverse property is what pins the *ordering* down: a nearby polynomial has the same roots
+as its ordered lift up to a permutation, and the permutation is forced to be the identity because
+each `Ψ i` stays near `z i` while the `z i` are distinct. -/
+theorem exists_analyticAt_coeffEquiv_ofFn_localInverse {z : Fin n → 𝕜}
+    (hz : Function.Injective z) :
+    ∃ Ψ : (Fin n → 𝕜) → (Fin n → 𝕜), Ψ (coeffEquiv 𝕜 n (ofFn z)) = z ∧
+      AnalyticAt 𝕜 Ψ (coeffEquiv 𝕜 n (ofFn z)) ∧
+      (∀ᶠ w in 𝓝 z, Ψ (coeffEquiv 𝕜 n (ofFn w)) = w) ∧
+      (∀ᶠ c in 𝓝 (coeffEquiv 𝕜 n (ofFn z)), coeffEquiv 𝕜 n (ofFn (Ψ c)) = c) := by
+  obtain ⟨Ψ, hΨ₀, hΨa, hΨ⟩ :=
+    exists_analyticAt_coeffEquiv_symm hz (Equiv.symm_apply_apply (coeffEquiv 𝕜 n) (ofFn z))
+  have hσ : ContinuousAt (fun w : Fin n → 𝕜 => coeffEquiv 𝕜 n (ofFn w)) z :=
+    (analyticAt_coeffEquiv_ofFn z).continuousAt
+  refine ⟨Ψ, hΨ₀, hΨa, ?_, ?_⟩
+  · -- Each `Ψ i` of a nearby coefficient tuple is one of the nearby roots, and proximity to the
+    -- distinct `z i` forces it to be the `i`-th one.
+    have hmem : ∀ᶠ w in 𝓝 z, ∀ i, ∃ j, w j = Ψ (coeffEquiv 𝕜 n (ofFn w)) i := by
+      filter_upwards [hσ.eventually hΨ] with w hw i
+      rw [Equiv.symm_apply_apply] at hw
+      have hmem : Ψ (coeffEquiv 𝕜 n (ofFn w)) i ∈ ofFn (Ψ (coeffEquiv 𝕜 n (ofFn w))) :=
+        mem_ofFn.2 ⟨i, rfl⟩
+      rw [← hw] at hmem
+      exact mem_ofFn.1 hmem
+    have hne : ∀ i j : Fin n,
+        ∀ᶠ w in 𝓝 z, i ≠ j → Ψ (coeffEquiv 𝕜 n (ofFn w)) i ≠ w j := by
+      intro i j
+      rcases eq_or_ne i j with rfl | hij
+      · exact .of_forall fun _ h => absurd rfl h
+      · have hΨi : ContinuousAt (fun w : Fin n → 𝕜 => Ψ (coeffEquiv 𝕜 n (ofFn w)) i) z :=
+          ContinuousAt.comp' (f := fun w : Fin n → 𝕜 => coeffEquiv 𝕜 n (ofFn w))
+            (analyticAt_pi_iff.1 hΨa i).continuousAt hσ
+        have hcont : ContinuousAt (fun w => Ψ (coeffEquiv 𝕜 n (ofFn w)) i - w j) z :=
+          hΨi.sub (continuousAt_apply j z)
+        have h0 : (fun w => Ψ (coeffEquiv 𝕜 n (ofFn w)) i - w j) z ≠ 0 := by
+          simp only [ne_eq, sub_eq_zero]
+          rw [hΨ₀]
+          exact fun h => hij (hz h)
+        filter_upwards [hcont.eventually_ne h0] with w hw _
+        exact sub_ne_zero.mp hw
+    filter_upwards [hmem, eventually_all.2 fun i => eventually_all.2 fun j => hne i j] with
+      w hw hwne
+    refine funext fun i => ?_
+    obtain ⟨j, hj⟩ := hw i
+    rcases eq_or_ne i j with rfl | hij
+    · exact hj.symm
+    · exact absurd hj.symm (hwne i j hij)
+  · filter_upwards [hΨ] with c hc
+    rw [← hc, Equiv.apply_symm_apply]
+
+/-- **The elementary symmetric transition maps are analytic away from the diagonal.** A map `φ` of
+the field induces a map of coefficient tuples, taking the coefficients of a monic polynomial to
+those of the monic polynomial whose roots are the `φ`-images of its roots. That induced map is
+analytic at every coefficient tuple whose roots are pairwise distinct and at each of which `φ` is
+analytic.
+
+Read on `Sym^g(Σ)`, this is the holomorphy of the transition maps of the elementary symmetric
+atlas at the multiplicity-free points: `φ` is the change of holomorphic coordinate on the
+surface. -/
+theorem analyticAt_coeffEquiv_map_coeffEquiv_symm {φ : 𝕜 → 𝕜} {c₀ z : Fin n → 𝕜}
+    (hz : Function.Injective z) (hc₀ : (coeffEquiv 𝕜 n).symm c₀ = ofFn z)
+    (hφ : ∀ i, AnalyticAt 𝕜 φ (z i)) :
+    AnalyticAt 𝕜 (fun c => coeffEquiv 𝕜 n (_root_.Sym.map φ ((coeffEquiv 𝕜 n).symm c))) c₀ := by
+  obtain ⟨Ψ, hΨ₀, hΨa, hΨ⟩ := exists_analyticAt_coeffEquiv_symm hz hc₀
+  have hcomp : AnalyticAt 𝕜 (fun c => fun i => φ (Ψ c i)) c₀ := by
+    refine AnalyticAt.pi fun i => ?_
+    have hi : AnalyticAt 𝕜 (fun c => Ψ c i) c₀ := analyticAt_pi_iff.1 hΨa i
+    have hφ' : AnalyticAt 𝕜 φ (Ψ c₀ i) := by
+      rw [hΨ₀]
+      exact hφ i
+    exact AnalyticAt.comp (f := fun c => Ψ c i) hφ' hi
+  refine AnalyticAt.congr ((analyticAt_coeffEquiv_ofFn _).comp hcomp) ?_
+  filter_upwards [hΨ] with c hc
+  rw [hc, map_ofFn]
+  rfl
+
+end Sym
+
+end TauCeti

--- a/TauCeti/Analysis/Polynomial/SymmetricPower.lean
+++ b/TauCeti/Analysis/Polynomial/SymmetricPower.lean
@@ -48,8 +48,10 @@ structure (elementary symmetric functions)", after Ozsváth--Szabó
 ([arXiv:math/0101206](https://arxiv.org/abs/math/0101206), §2.1): a holomorphic coordinate on the
 surface identifies a neighbourhood in `Sym^g(Σ)` with an open subset of `Sym^g(ℂ)`, and the chart
 below is what makes that a chart on a topological manifold; the charted structure is assembled
-from it in `TauCeti/Geometry/Manifold/SymmetricPower.lean`. The complex structure itself, and the
-totally real tori `T_α`, `T_β`, are separate later steps.
+from it in `TauCeti/Geometry/Manifold/SymmetricPower.lean`. Away from the diagonal the continuity
+proved here is upgraded to analyticity in
+`TauCeti/Analysis/Polynomial/SimpleRoots.lean`. The complex structure itself, and the totally real
+tori `T_α`, `T_β`, are separate later steps.
 -/
 
 public section

--- a/TauCeti/Analysis/Polynomial/SymmetricPower.lean
+++ b/TauCeti/Analysis/Polynomial/SymmetricPower.lean
@@ -56,9 +56,11 @@ tori `T_α`, `T_β`, are separate later steps.
 
 public section
 
-namespace TauCeti
-
+-- `Polynomial` is opened outside `namespace TauCeti` so that it names Mathlib's namespace rather
+-- than `TauCeti.Polynomial`, which the import above populates.
 open Filter Polynomial Topology
+
+namespace TauCeti
 
 namespace Sym
 

--- a/TauCeti/Analysis/Polynomial/SymmetricPower.lean
+++ b/TauCeti/Analysis/Polynomial/SymmetricPower.lean
@@ -7,9 +7,12 @@ module
 
 public import Mathlib.Analysis.Normed.Group.Bounded
 public import Mathlib.Analysis.Polynomial.CauchyBound
+public import Mathlib.Analysis.Analytic.Basic
 public import Mathlib.Topology.Algebra.Polynomial
 public import TauCeti.RingTheory.Polynomial.SymmetricPower
 public import TauCeti.Topology.Sym.Disjoint
+import Mathlib.Analysis.Analytic.Constructions
+import Mathlib.Analysis.Analytic.Linear
 
 /-!
 # The elementary symmetric chart is a homeomorphism
@@ -33,6 +36,9 @@ Both halves are elementary, but neither is formal:
 
 * `TauCeti.Sym.continuous_coeffEquiv_comp_ofFn`: the coefficients depend continuously on an
   ordered tuple of roots.
+* `TauCeti.Polynomial.analyticAt_coeff_prod_X_sub_C` and
+  `TauCeti.Sym.analyticAt_coeffEquiv_ofFn`: the same forward coefficient map is analytic over any
+  nontrivially normed field.
 * `TauCeti.Sym.norm_le_norm_coeffEquiv_ofFn_add_one`: Cauchy's bound on the symmetric power, that
   an ordered tuple is bounded by one more than the norm of its coefficient tuple.
 * `TauCeti.Sym.isProperMap_coeffEquiv_comp_ofFn`: consequently the coefficient map
@@ -62,7 +68,69 @@ open Filter Polynomial Topology
 
 namespace TauCeti
 
+namespace Polynomial
+
+/-! ### Analyticity of the coefficients -/
+
+section Analyticity
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+
+/-- The coefficients of `∏ i ∈ s, (X - C (v i))` depend analytically on the tuple `v` of roots.
+
+This is the elementary half of the chart, and the analytic counterpart of
+`TauCeti.Sym.continuous_coeff_prod_X_sub_C`: each coefficient is, up to sign, an elementary
+symmetric function of the roots, so the analyticity of the ring operations is all that is used. -/
+theorem analyticAt_coeff_prod_X_sub_C {ι : Type*} [Fintype ι] (s : Finset ι) (k : ℕ)
+    (v₀ : ι → 𝕜) : AnalyticAt 𝕜 (fun v : ι → 𝕜 => (∏ i ∈ s, (X - C (v i))).coeff k) v₀ := by
+  classical
+  have hproj : ∀ i : ι, AnalyticAt 𝕜 (fun v : ι → 𝕜 => v i) v₀ := fun i =>
+    (ContinuousLinearMap.proj (R := 𝕜) (φ := fun _ : ι => 𝕜) i).analyticAt _
+  induction s using Finset.induction_on generalizing k with
+  | empty =>
+    simp only [Finset.prod_empty]
+    exact analyticAt_const
+  | @insert a s ha ih =>
+    cases k with
+    | zero =>
+      have hpt : (fun v : ι → 𝕜 => (∏ i ∈ insert a s, (X - C (v i))).coeff 0) =
+          fun v => -v a * (∏ i ∈ s, (X - C (v i))).coeff 0 := by
+        funext v
+        rw [Finset.prod_insert ha, mul_coeff_zero]
+        simp
+      rw [hpt]
+      exact (hproj a).neg.mul (ih 0)
+    | succ k =>
+      have hpt : (fun v : ι → 𝕜 => (∏ i ∈ insert a s, (X - C (v i))).coeff (k + 1)) =
+          fun v => (∏ i ∈ s, (X - C (v i))).coeff k
+            - v a * (∏ i ∈ s, (X - C (v i))).coeff (k + 1) := by
+        funext v
+        rw [Finset.prod_insert ha, sub_mul, coeff_sub, coeff_X_mul, coeff_C_mul]
+      rw [hpt]
+      exact (ih k).sub ((hproj a).mul (ih (k + 1)))
+
+end Analyticity
+
+end Polynomial
+
 namespace Sym
+
+/-! ### Analyticity of the coefficients -/
+
+section Analyticity
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsAlgClosed 𝕜] {n : ℕ}
+
+/-- The elementary symmetric chart is analytic in an ordered presentation of the tuple: by Vieta's
+formulas its coordinates are, up to sign, the elementary symmetric polynomials of the ordered
+tuple. -/
+theorem analyticAt_coeffEquiv_ofFn (v₀ : Fin n → 𝕜) :
+    AnalyticAt 𝕜 (fun v : Fin n → 𝕜 => coeffEquiv 𝕜 n (ofFn v)) v₀ := by
+  refine AnalyticAt.pi fun i => ?_
+  simp only [coeffEquiv_ofFn_apply]
+  exact Polynomial.analyticAt_coeff_prod_X_sub_C _ _ _
+
+end Analyticity
 
 /-! ### Continuity of the coefficients -/
 

--- a/TauCeti/Geometry/Manifold/SymmetricPower.lean
+++ b/TauCeti/Geometry/Manifold/SymmetricPower.lean
@@ -37,10 +37,12 @@ The charts so obtained depend on choices — of the separating neighbourhoods, a
 bijection — so the atlas below is a choice of one chart per point, exactly as much as a charted
 structure asks for. Upgrading it to a *complex* manifold, by exhibiting an atlas whose transition
 maps are holomorphic, is the next step of Lane F4.1 and is not done here; so are the totally real
-tori `T_α`, `T_β`. The multiplicity-free half of that transition-map holomorphy —
+tori `T_α`, `T_β`. What is available towards that holomorphy is the analytic ingredient for a
+single coordinate patch at a multiplicity-free coefficient tuple,
 `TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm` in
-`TauCeti/Analysis/Polynomial/SimpleRoots.lean` — is available, but the diagonal, where the points
-of a tuple collide, is not.
+`TauCeti/Analysis/Polynomial/SimpleRoots.lean`; assembling it across the blocks that a chart below
+splits a tuple into, along the regrouping `e`, is not done, and neither is the case of colliding
+points — which is where the degree-`m i` elementary symmetric coordinates genuinely appear.
 
 ## Main declarations
 

--- a/TauCeti/Geometry/Manifold/SymmetricPower.lean
+++ b/TauCeti/Geometry/Manifold/SymmetricPower.lean
@@ -37,7 +37,10 @@ The charts so obtained depend on choices — of the separating neighbourhoods, a
 bijection — so the atlas below is a choice of one chart per point, exactly as much as a charted
 structure asks for. Upgrading it to a *complex* manifold, by exhibiting an atlas whose transition
 maps are holomorphic, is the next step of Lane F4.1 and is not done here; so are the totally real
-tori `T_α`, `T_β`.
+tori `T_α`, `T_β`. The multiplicity-free half of that transition-map holomorphy —
+`TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm` in
+`TauCeti/Analysis/Polynomial/SimpleRoots.lean` — is available, but the diagonal, where the points
+of a tuple collide, is not.
 
 ## Main declarations
 

--- a/TauCeti/RingTheory/Polynomial/MonicOfCoeff.lean
+++ b/TauCeti/RingTheory/Polynomial/MonicOfCoeff.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Polynomial.Degree.Operations
+public import Mathlib.Algebra.Polynomial.Eval.Defs
+public import Mathlib.Algebra.Polynomial.Monic
+
+/-!
+# The monic polynomial with prescribed lower coefficients
+
+A monic polynomial of degree `n` is exactly its `n` lower coefficients: the leading term is forced
+to be `X ^ n`. This file names the resulting polynomial `TauCeti.Polynomial.monicOfCoeff c` for a
+tuple `c : Fin n → R`, and records that reading the coefficients back off is inverse to it.
+
+The point of naming it is that it is the object against which analytic dependence on the
+coefficients is stated: `TauCeti/Analysis/Polynomial/SimpleRoots.lean` differentiates
+`(c, z) ↦ (monicOfCoeff c).eval z` in `c` and `z` jointly, so the lower coefficients must appear as
+a *free* tuple rather than as the data of a polynomial subtype.
+
+## Main declarations
+
+* `TauCeti.Polynomial.monicOfCoeff`: the monic polynomial `X ^ n + ∑ i, c i * X ^ i` of degree `n`
+  whose `n` lower coefficients are `c`.
+* `TauCeti.Polynomial.monic_monicOfCoeff`, `TauCeti.Polynomial.natDegree_monicOfCoeff`,
+  `TauCeti.Polynomial.eval_monicOfCoeff`: its monicity, its degree and its values.
+* `TauCeti.Polynomial.coeff_monicOfCoeff` and `TauCeti.Polynomial.monicOfCoeff_coeff`: the
+  coefficients are read back off, and every monic polynomial of degree `n` arises this way, so the
+  two constructions are mutually inverse.
+
+Mathlib writes the same polynomial in the same shape one universe up: `Polynomial.freeMonic R n`,
+in `Mathlib/RingTheory/Polynomial/UniversalFactorizationRing.lean`, is
+`X ^ n + ∑ i, monomial i (MvPolynomial.X i)` over `MvPolynomial (Fin n) R`, of which
+`monicOfCoeff c` is the specialization at `c`. Mathlib also has the same correspondence in bundled
+form, as the composite of `Polynomial.monicEquivDegreeLT` with `Polynomial.degreeLTEquiv`;
+`monicOfCoeff c` is by definition the image of `c` under the inverse of that composite, with the
+degree-`< n` and monic subtypes unbundled away and without the `Nontrivial R` that
+`monicEquivDegreeLT` carries. `TauCeti.Sym.coeffEquiv` is built from the bundled form, and
+`TauCeti.Sym.toMonic_coeffEquiv_symm` identifies its inverse with `monicOfCoeff`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Polynomial
+
+namespace Polynomial
+
+section OfCoeff
+
+variable {R : Type*} [CommSemiring R] {n : ℕ}
+
+/-- The monic polynomial of degree `n` whose `n` lower coefficients are `c`, that is, the
+specialization of Mathlib's `Polynomial.freeMonic` at the coefficient tuple `c`. It is the inverse
+of the coefficient-reading half of `TauCeti.Sym.coeffEquiv`, and is the natural object to state
+analytic dependence on the coefficients against: `TauCeti.Sym.coeffEquiv_symm_apply` describes the
+inverse chart as its root multiset. -/
+@[expose]
+noncomputable def monicOfCoeff (c : Fin n → R) : R[X] :=
+  X ^ n + ∑ i : Fin n, monomial (i : ℕ) (c i)
+
+/-- The lower part of `TauCeti.Polynomial.monicOfCoeff` has degree less than `n`, which is where its
+monicity and its degree come from. -/
+private theorem degree_sum_monomial_lt (c : Fin n → R) :
+    degree (∑ i : Fin n, monomial (i : ℕ) (c i)) < n := by
+  simpa only [C_mul_X_pow_eq_monomial] using degree_sum_fin_lt c
+
+/-- The polynomial attached to a coefficient tuple is monic: its lower part has degree `< n`, so the
+term `X ^ n` leads. -/
+@[simp]
+theorem monic_monicOfCoeff (c : Fin n → R) : (monicOfCoeff c).Monic :=
+  monic_X_pow_add (degree_sum_monomial_lt c)
+
+/-- The prescribed coefficients are read back off: this is the defining property of
+`TauCeti.Polynomial.monicOfCoeff`. -/
+@[simp]
+theorem coeff_monicOfCoeff (c : Fin n → R) (i : Fin n) : (monicOfCoeff c).coeff (i : ℕ) = c i := by
+  have hne : (i : ℕ) ≠ n := i.2.ne
+  simp [monicOfCoeff, coeff_X_pow, coeff_monomial, hne, Fin.val_eq_val]
+
+/-- Evaluating the monic polynomial attached to a coefficient tuple: the leading power plus the
+prescribed lower part. -/
+theorem eval_monicOfCoeff (c : Fin n → R) (z : R) :
+    (monicOfCoeff c).eval z = z ^ n + ∑ i : Fin n, c i * z ^ (i : ℕ) := by
+  simp [monicOfCoeff, eval_finsetSum]
+
+variable [Nontrivial R]
+
+/-- The polynomial attached to a tuple of `n` coefficients has degree exactly `n`, the degree of its
+leading term `X ^ n`. -/
+@[simp]
+theorem natDegree_monicOfCoeff (c : Fin n → R) : (monicOfCoeff c).natDegree = n := by
+  have hlt : degree (∑ i : Fin n, monomial (i : ℕ) (c i)) < degree (X ^ n : R[X]) := by
+    rw [degree_X_pow]
+    exact degree_sum_monomial_lt c
+  rw [monicOfCoeff, natDegree_add_eq_left_of_degree_lt hlt, natDegree_X_pow]
+
+/-- Every monic polynomial of degree `n` is the monic polynomial attached to its own lower
+coefficients: together with `TauCeti.Polynomial.coeff_monicOfCoeff` this identifies the monic
+polynomials of degree `n` with the coefficient tuples. -/
+theorem monicOfCoeff_coeff {p : R[X]} (hp : p.Monic) (hdeg : p.natDegree = n) :
+    monicOfCoeff (fun i : Fin n => p.coeff (i : ℕ)) = p := by
+  refine Polynomial.ext fun k => ?_
+  rcases lt_trichotomy k n with hk | hk | hk
+  · exact coeff_monicOfCoeff _ ⟨k, hk⟩
+  · have hlead : (monicOfCoeff fun i : Fin n => p.coeff (i : ℕ)).coeff n = 1 := by
+      simpa [natDegree_monicOfCoeff] using
+        (monic_monicOfCoeff fun i : Fin n => p.coeff (i : ℕ)).coeff_natDegree
+    rw [hk, hlead, ← hdeg, hp.coeff_natDegree]
+  · rw [coeff_eq_zero_of_natDegree_lt (by rwa [natDegree_monicOfCoeff]),
+      coeff_eq_zero_of_natDegree_lt (by rwa [hdeg])]
+
+end OfCoeff
+
+end Polynomial
+
+end TauCeti

--- a/TauCeti/RingTheory/Polynomial/MonicOfCoeff.lean
+++ b/TauCeti/RingTheory/Polynomial/MonicOfCoeff.lean
@@ -59,7 +59,6 @@ specialization of Mathlib's `Polynomial.freeMonic` at the coefficient tuple `c`.
 of the coefficient-reading half of `TauCeti.Sym.coeffEquiv`, and is the natural object to state
 analytic dependence on the coefficients against: `TauCeti.Sym.coeffEquiv_symm_apply` describes the
 inverse chart as its root multiset. -/
-@[expose]
 noncomputable def monicOfCoeff (c : Fin n → R) : R[X] :=
   X ^ n + ∑ i : Fin n, monomial (i : ℕ) (c i)
 

--- a/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
+++ b/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
@@ -9,6 +9,7 @@ public import Mathlib.RingTheory.Polynomial.Basic
 public import Mathlib.RingTheory.Polynomial.Vieta
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
 public import TauCeti.Data.Sym.Basic
+public import TauCeti.RingTheory.Polynomial.MonicOfCoeff
 import Mathlib.Data.Fin.VecNotation
 
 /-!
@@ -43,14 +44,9 @@ are separate later steps.
   an integral domain the tuple is recovered from the polynomial as its root multiset, and
   `TauCeti.Sym.toMonic_ofFn_eq_of_forall_isRoot`, that a monic polynomial of degree `n` with `n`
   distinct roots is the monic polynomial of the unordered tuple of those roots.
-* `TauCeti.Polynomial.monicOfCoeff`: the monic polynomial of degree `n` with prescribed lower
-  coefficients — the specialization of Mathlib's `Polynomial.freeMonic` at a concrete coefficient
-  tuple. `TauCeti.Polynomial.coeff_monicOfCoeff` reads those coefficients back and
-  `TauCeti.Polynomial.monicOfCoeff_coeff` recognises every monic polynomial of degree `n` as one of
-  them, so the two are inverse; `TauCeti.Polynomial.monic_monicOfCoeff`,
-  `TauCeti.Polynomial.natDegree_monicOfCoeff` and `TauCeti.Polynomial.eval_monicOfCoeff` record its
-  monicity, degree and values. It inverts the chart by `Sym.monicOfCoeff_coeffEquiv` and
-  `TauCeti.Sym.toMonic_coeffEquiv_symm`.
+* `TauCeti.Sym.toMonic_coeffEquiv_symm`: the inverse chart, read as a polynomial rather than as a
+  root multiset, is `TauCeti.Polynomial.monicOfCoeff`, the monic polynomial with prescribed lower
+  coefficients of `TauCeti/RingTheory/Polynomial/MonicOfCoeff.lean`.
 * `TauCeti.Sym.monicEquiv`: over an algebraically closed field, taking roots with multiplicity
   inverts `toMonic`, so `Sym K n` is equivalent to the monic polynomials of degree `n`.
 * `TauCeti.Sym.coeffEquiv`: the resulting chart `Sym K n ≃ (Fin n → K)`, with
@@ -74,85 +70,13 @@ equivalence between monic polynomials of degree `n` and polynomials of degree `<
 Mathlib's (`Multiset.prod_X_sub_C_coeff`,
 `Polynomial.prod_multiset_X_sub_C_of_monic_of_roots_card_eq`, `Polynomial.ofMultiset`,
 `Polynomial.monicEquivDegreeLT`); nothing is vendored here.
-
-Most declarations about symmetric powers below live in `TauCeti.Sym`. The dot-notation extension
-`Sym.monicOfCoeff_coeffEquiv` lives in Mathlib's root `Sym` namespace, while the one piece of the
-file that mentions no symmetric power, the `TauCeti.Polynomial.monicOfCoeff` API, lives in
-`TauCeti.Polynomial`.
 -/
 
 public section
 
-namespace TauCeti
-
 open Multiset Polynomial
 
-/-! ### The monic polynomial with prescribed lower coefficients -/
-
-namespace Polynomial
-
-section OfCoeff
-
-variable {R : Type*} [CommSemiring R] {n : ℕ}
-
-/-- The monic polynomial of degree `n` whose `n` lower coefficients are `c`, that is, the
-specialization of Mathlib's `Polynomial.freeMonic` at the coefficient tuple `c`. It is the inverse
-of the coefficient-reading half of `TauCeti.Sym.coeffEquiv`, and is the natural object to state
-analytic dependence on the coefficients against: `TauCeti.Sym.coeffEquiv_symm_apply` describes the
-inverse chart as its root multiset. -/
-noncomputable def monicOfCoeff (c : Fin n → R) : R[X] :=
-  X ^ n + ∑ i : Fin n, monomial (i : ℕ) (c i)
-
-/-- The lower part of `TauCeti.Polynomial.monicOfCoeff` has degree less than `n`, which is where its
-monicity and its degree come from. -/
-private theorem degree_sum_monomial_lt (c : Fin n → R) :
-    degree (∑ i : Fin n, monomial (i : ℕ) (c i)) < n := by
-  simpa only [C_mul_X_pow_eq_monomial] using degree_sum_fin_lt c
-
-@[simp]
-theorem monic_monicOfCoeff (c : Fin n → R) : (monicOfCoeff c).Monic :=
-  monic_X_pow_add (degree_sum_monomial_lt c)
-
-/-- The prescribed coefficients are read back off: this is the defining property of
-`TauCeti.Polynomial.monicOfCoeff`. -/
-@[simp]
-theorem coeff_monicOfCoeff (c : Fin n → R) (i : Fin n) : (monicOfCoeff c).coeff (i : ℕ) = c i := by
-  have hne : (i : ℕ) ≠ n := i.2.ne
-  simp [monicOfCoeff, coeff_X_pow, coeff_monomial, hne, Fin.val_eq_val]
-
-/-- Evaluating the monic polynomial attached to a coefficient tuple: the leading power plus the
-prescribed lower part. -/
-theorem eval_monicOfCoeff (c : Fin n → R) (z : R) :
-    (monicOfCoeff c).eval z = z ^ n + ∑ i : Fin n, c i * z ^ (i : ℕ) := by
-  simp [monicOfCoeff, eval_finsetSum]
-
-variable [Nontrivial R]
-
-@[simp]
-theorem natDegree_monicOfCoeff (c : Fin n → R) : (monicOfCoeff c).natDegree = n := by
-  have hlt : degree (∑ i : Fin n, monomial (i : ℕ) (c i)) < degree (X ^ n : R[X]) := by
-    rw [degree_X_pow]
-    exact degree_sum_monomial_lt c
-  rw [monicOfCoeff, natDegree_add_eq_left_of_degree_lt hlt, natDegree_X_pow]
-
-/-- Every monic polynomial of degree `n` is the monic polynomial attached to its own lower
-coefficients: together with `TauCeti.Polynomial.coeff_monicOfCoeff` this identifies the monic
-polynomials of degree `n` with the coefficient tuples. -/
-theorem monicOfCoeff_coeff {p : R[X]} (hp : p.Monic) (hdeg : p.natDegree = n) :
-    monicOfCoeff (fun i : Fin n => p.coeff (i : ℕ)) = p := by
-  refine Polynomial.ext fun k => ?_
-  rcases lt_trichotomy k n with hk | hk | hk
-  · exact coeff_monicOfCoeff _ ⟨k, hk⟩
-  · have hlead : (monicOfCoeff fun i : Fin n => p.coeff (i : ℕ)).coeff n = 1 := by
-      simpa [natDegree_monicOfCoeff] using
-        (monic_monicOfCoeff fun i : Fin n => p.coeff (i : ℕ)).coeff_natDegree
-    rw [hk, hlead, ← hdeg, hp.coeff_natDegree]
-  · rw [coeff_eq_zero_of_natDegree_lt (by rwa [natDegree_monicOfCoeff]),
-      coeff_eq_zero_of_natDegree_lt (by rwa [hdeg])]
-
-end OfCoeff
-
-end Polynomial
+namespace TauCeti
 
 namespace Sym
 
@@ -396,52 +320,16 @@ theorem coeffEquiv_symm_apply (f : Fin n → K) : (((coeffEquiv K n).symm f : Sy
     coe_monicEquivDegreeLT_symm_apply, coe_degreeLTEquiv_toEquiv_symm_apply]
   rfl
 
-end AlgClosed
-
-end Sym
-
-end TauCeti
-
-namespace Sym
-
-variable {K : Type*} [Field K] [IsAlgClosed K] {n : ℕ}
-
-/-- The chart and `TauCeti.Polynomial.monicOfCoeff` are inverse: the monic polynomial rebuilt from
-the coordinates of a tuple is the monic polynomial of that tuple. -/
-@[simp]
-theorem monicOfCoeff_coeffEquiv (s : Sym K n) :
-    TauCeti.Polynomial.monicOfCoeff (TauCeti.Sym.coeffEquiv K n s) =
-      (TauCeti.Sym.toMonic s : _root_.Polynomial K) := by
-  have hroots :
-      (TauCeti.Polynomial.monicOfCoeff (TauCeti.Sym.coeffEquiv K n s)).roots =
-        (s : Multiset K) := by
-    rw [← TauCeti.Sym.coeffEquiv_symm_apply, Equiv.symm_apply_apply]
-  rw [TauCeti.Sym.coe_toMonic, _root_.Polynomial.ofMultiset_apply, ← hroots]
-  exact (_root_.Polynomial.prod_multiset_X_sub_C_of_monic_of_roots_card_eq
-    (TauCeti.Polynomial.monic_monicOfCoeff _)
-    (by rw [hroots, Sym.card_coe, TauCeti.Polynomial.natDegree_monicOfCoeff])).symm
-
-end Sym
-
-namespace TauCeti
-
-open Multiset
-
-namespace Sym
-
-section AlgClosed
-
-variable {K : Type*} [Field K] [IsAlgClosed K] {n : ℕ}
-
 /-- The inverse chart, read as a polynomial rather than as a root multiset, is
-`TauCeti.Polynomial.monicOfCoeff`: this is the `symm` companion of
-`Sym.monicOfCoeff_coeffEquiv`. -/
+`TauCeti.Polynomial.monicOfCoeff`: the monic polynomial of the tuple with prescribed coordinates is
+the monic polynomial with those lower coefficients. Equivalently, the chart itself reads off the
+lower coefficients of `TauCeti.Sym.toMonic`, which is `TauCeti.Sym.coeffEquiv_apply_eq_coeff`. -/
 @[simp]
 theorem toMonic_coeffEquiv_symm (c : Fin n → K) :
-    (toMonic ((coeffEquiv K n).symm c) : _root_.Polynomial K) =
-      TauCeti.Polynomial.monicOfCoeff c := by
-  conv_rhs => rw [← Equiv.apply_symm_apply (coeffEquiv K n) c]
-  rw [_root_.Sym.monicOfCoeff_coeffEquiv]
+    (toMonic ((coeffEquiv K n).symm c) : K[X]) = Polynomial.monicOfCoeff c := by
+  rw [coe_toMonic, coeffEquiv_symm_apply, ofMultiset_apply]
+  exact prod_multiset_X_sub_C_of_monic_of_roots_card_eq (Polynomial.monic_monicOfCoeff c)
+    (splits_iff_card_roots.mp (IsAlgClosed.splits _))
 
 /-- In degree one the chart is negation: the single coordinate of a one-point tuple is minus that
 point. -/

--- a/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
+++ b/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
@@ -49,7 +49,7 @@ are separate later steps.
   `TauCeti.Polynomial.monicOfCoeff_coeff` recognises every monic polynomial of degree `n` as one of
   them, so the two are inverse; `TauCeti.Polynomial.monic_monicOfCoeff`,
   `TauCeti.Polynomial.natDegree_monicOfCoeff` and `TauCeti.Polynomial.eval_monicOfCoeff` record its
-  monicity, degree and values. It inverts the chart by `TauCeti.Sym.monicOfCoeff_coeffEquiv` and
+  monicity, degree and values. It inverts the chart by `Sym.monicOfCoeff_coeffEquiv` and
   `TauCeti.Sym.toMonic_coeffEquiv_symm`.
 * `TauCeti.Sym.monicEquiv`: over an algebraically closed field, taking roots with multiplicity
   inverts `toMonic`, so `Sym K n` is equivalent to the monic polynomials of degree `n`.
@@ -75,9 +75,10 @@ Mathlib's (`Multiset.prod_X_sub_C_coeff`,
 `Polynomial.prod_multiset_X_sub_C_of_monic_of_roots_card_eq`, `Polynomial.ofMultiset`,
 `Polynomial.monicEquivDegreeLT`); nothing is vendored here.
 
-Because the ambient type `Sym` is Mathlib's, the declarations about it below live in `TauCeti.Sym`
-and are applied by name rather than by dot notation. The one piece of the file that mentions no
-symmetric power, the `TauCeti.Polynomial.monicOfCoeff` API, lives in `TauCeti.Polynomial` instead.
+Most declarations about symmetric powers below live in `TauCeti.Sym`. The dot-notation extension
+`Sym.monicOfCoeff_coeffEquiv` lives in Mathlib's root `Sym` namespace, while the one piece of the
+file that mentions no symmetric power, the `TauCeti.Polynomial.monicOfCoeff` API, lives in
+`TauCeti.Polynomial`.
 -/
 
 public section
@@ -395,25 +396,52 @@ theorem coeffEquiv_symm_apply (f : Fin n → K) : (((coeffEquiv K n).symm f : Sy
     coe_monicEquivDegreeLT_symm_apply, coe_degreeLTEquiv_toEquiv_symm_apply]
   rfl
 
+end AlgClosed
+
+end Sym
+
+end TauCeti
+
+namespace Sym
+
+variable {K : Type*} [Field K] [IsAlgClosed K] {n : ℕ}
+
 /-- The chart and `TauCeti.Polynomial.monicOfCoeff` are inverse: the monic polynomial rebuilt from
 the coordinates of a tuple is the monic polynomial of that tuple. -/
 @[simp]
 theorem monicOfCoeff_coeffEquiv (s : Sym K n) :
-    Polynomial.monicOfCoeff (coeffEquiv K n s) = (toMonic s : K[X]) := by
-  have hroots : (Polynomial.monicOfCoeff (coeffEquiv K n s)).roots = (s : Multiset K) := by
-    rw [← coeffEquiv_symm_apply, Equiv.symm_apply_apply]
-  rw [coe_toMonic, ofMultiset_apply, ← hroots]
-  exact (prod_multiset_X_sub_C_of_monic_of_roots_card_eq (Polynomial.monic_monicOfCoeff _)
-    (by rw [hroots, Sym.card_coe, Polynomial.natDegree_monicOfCoeff])).symm
+    TauCeti.Polynomial.monicOfCoeff (TauCeti.Sym.coeffEquiv K n s) =
+      (TauCeti.Sym.toMonic s : _root_.Polynomial K) := by
+  have hroots :
+      (TauCeti.Polynomial.monicOfCoeff (TauCeti.Sym.coeffEquiv K n s)).roots =
+        (s : Multiset K) := by
+    rw [← TauCeti.Sym.coeffEquiv_symm_apply, Equiv.symm_apply_apply]
+  rw [TauCeti.Sym.coe_toMonic, _root_.Polynomial.ofMultiset_apply, ← hroots]
+  exact (_root_.Polynomial.prod_multiset_X_sub_C_of_monic_of_roots_card_eq
+    (TauCeti.Polynomial.monic_monicOfCoeff _)
+    (by rw [hroots, Sym.card_coe, TauCeti.Polynomial.natDegree_monicOfCoeff])).symm
+
+end Sym
+
+namespace TauCeti
+
+open Multiset
+
+namespace Sym
+
+section AlgClosed
+
+variable {K : Type*} [Field K] [IsAlgClosed K] {n : ℕ}
 
 /-- The inverse chart, read as a polynomial rather than as a root multiset, is
 `TauCeti.Polynomial.monicOfCoeff`: this is the `symm` companion of
-`TauCeti.Sym.monicOfCoeff_coeffEquiv`. -/
+`Sym.monicOfCoeff_coeffEquiv`. -/
 @[simp]
 theorem toMonic_coeffEquiv_symm (c : Fin n → K) :
-    (toMonic ((coeffEquiv K n).symm c) : K[X]) = Polynomial.monicOfCoeff c := by
+    (toMonic ((coeffEquiv K n).symm c) : _root_.Polynomial K) =
+      TauCeti.Polynomial.monicOfCoeff c := by
   conv_rhs => rw [← Equiv.apply_symm_apply (coeffEquiv K n) c]
-  rw [monicOfCoeff_coeffEquiv]
+  rw [_root_.Sym.monicOfCoeff_coeffEquiv]
 
 /-- In degree one the chart is negation: the single coordinate of a one-point tuple is minus that
 point. -/

--- a/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
+++ b/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
@@ -43,10 +43,14 @@ are separate later steps.
   an integral domain the tuple is recovered from the polynomial as its root multiset, and
   `TauCeti.Sym.toMonic_ofFn_eq_of_forall_isRoot`, that a monic polynomial of degree `n` with `n`
   distinct roots is the monic polynomial of the unordered tuple of those roots.
-* `TauCeti.Sym.monicOfCoeff`: the monic polynomial of degree `n` with prescribed lower
-  coefficients, with `TauCeti.Sym.monic_monicOfCoeff`, `TauCeti.Sym.natDegree_monicOfCoeff` and
-  `TauCeti.Sym.eval_monicOfCoeff`; it inverts the chart by
-  `TauCeti.monicOfCoeff_coeffEquiv`.
+* `TauCeti.Polynomial.monicOfCoeff`: the monic polynomial of degree `n` with prescribed lower
+  coefficients — the specialization of Mathlib's `Polynomial.freeMonic` at a concrete coefficient
+  tuple. `TauCeti.Polynomial.coeff_monicOfCoeff` reads those coefficients back and
+  `TauCeti.Polynomial.monicOfCoeff_coeff` recognises every monic polynomial of degree `n` as one of
+  them, so the two are inverse; `TauCeti.Polynomial.monic_monicOfCoeff`,
+  `TauCeti.Polynomial.natDegree_monicOfCoeff` and `TauCeti.Polynomial.eval_monicOfCoeff` record its
+  monicity, degree and values. It inverts the chart by `TauCeti.Sym.monicOfCoeff_coeffEquiv` and
+  `TauCeti.Sym.toMonic_coeffEquiv_symm`.
 * `TauCeti.Sym.monicEquiv`: over an algebraically closed field, taking roots with multiplicity
   inverts `toMonic`, so `Sym K n` is equivalent to the monic polynomials of degree `n`.
 * `TauCeti.Sym.coeffEquiv`: the resulting chart `Sym K n ≃ (Fin n → K)`, with
@@ -71,8 +75,9 @@ Mathlib's (`Multiset.prod_X_sub_C_coeff`,
 `Polynomial.prod_multiset_X_sub_C_of_monic_of_roots_card_eq`, `Polynomial.ofMultiset`,
 `Polynomial.monicEquivDegreeLT`); nothing is vendored here.
 
-Because the ambient type `Sym` is Mathlib's, the declarations below live in `TauCeti.Sym` and are
-applied by name rather than by dot notation.
+Because the ambient type `Sym` is Mathlib's, the declarations about it below live in `TauCeti.Sym`
+and are applied by name rather than by dot notation. The one piece of the file that mentions no
+symmetric power, the `TauCeti.Polynomial.monicOfCoeff` API, lives in `TauCeti.Polynomial` instead.
 -/
 
 public section
@@ -80,6 +85,73 @@ public section
 namespace TauCeti
 
 open Multiset Polynomial
+
+/-! ### The monic polynomial with prescribed lower coefficients -/
+
+namespace Polynomial
+
+section OfCoeff
+
+variable {R : Type*} [CommSemiring R] {n : ℕ}
+
+/-- The monic polynomial of degree `n` whose `n` lower coefficients are `c`, that is, the
+specialization of Mathlib's `Polynomial.freeMonic` at the coefficient tuple `c`. It is the inverse
+of the coefficient-reading half of `TauCeti.Sym.coeffEquiv`, and is the natural object to state
+analytic dependence on the coefficients against: `TauCeti.Sym.coeffEquiv_symm_apply` describes the
+inverse chart as its root multiset. -/
+noncomputable def monicOfCoeff (c : Fin n → R) : R[X] :=
+  X ^ n + ∑ i : Fin n, monomial (i : ℕ) (c i)
+
+/-- The lower part of `TauCeti.Polynomial.monicOfCoeff` has degree less than `n`, which is where its
+monicity and its degree come from. -/
+private theorem degree_sum_monomial_lt (c : Fin n → R) :
+    degree (∑ i : Fin n, monomial (i : ℕ) (c i)) < n := by
+  simpa only [C_mul_X_pow_eq_monomial] using degree_sum_fin_lt c
+
+@[simp]
+theorem monic_monicOfCoeff (c : Fin n → R) : (monicOfCoeff c).Monic :=
+  monic_X_pow_add (degree_sum_monomial_lt c)
+
+/-- The prescribed coefficients are read back off: this is the defining property of
+`TauCeti.Polynomial.monicOfCoeff`. -/
+@[simp]
+theorem coeff_monicOfCoeff (c : Fin n → R) (i : Fin n) : (monicOfCoeff c).coeff (i : ℕ) = c i := by
+  have hne : (i : ℕ) ≠ n := i.2.ne
+  simp [monicOfCoeff, coeff_X_pow, coeff_monomial, hne, Fin.val_eq_val]
+
+/-- Evaluating the monic polynomial attached to a coefficient tuple: the leading power plus the
+prescribed lower part. -/
+theorem eval_monicOfCoeff (c : Fin n → R) (z : R) :
+    (monicOfCoeff c).eval z = z ^ n + ∑ i : Fin n, c i * z ^ (i : ℕ) := by
+  simp [monicOfCoeff, eval_finsetSum]
+
+variable [Nontrivial R]
+
+@[simp]
+theorem natDegree_monicOfCoeff (c : Fin n → R) : (monicOfCoeff c).natDegree = n := by
+  have hlt : degree (∑ i : Fin n, monomial (i : ℕ) (c i)) < degree (X ^ n : R[X]) := by
+    rw [degree_X_pow]
+    exact degree_sum_monomial_lt c
+  rw [monicOfCoeff, natDegree_add_eq_left_of_degree_lt hlt, natDegree_X_pow]
+
+/-- Every monic polynomial of degree `n` is the monic polynomial attached to its own lower
+coefficients: together with `TauCeti.Polynomial.coeff_monicOfCoeff` this identifies the monic
+polynomials of degree `n` with the coefficient tuples. -/
+theorem monicOfCoeff_coeff {p : R[X]} (hp : p.Monic) (hdeg : p.natDegree = n) :
+    monicOfCoeff (fun i : Fin n => p.coeff (i : ℕ)) = p := by
+  refine Polynomial.ext fun k => ?_
+  rcases lt_trichotomy k n with hk | hk | hk
+  · exact coeff_monicOfCoeff _ ⟨k, hk⟩
+  · have hlead : (monicOfCoeff fun i : Fin n => p.coeff (i : ℕ)).coeff n = 1 := by
+      simpa [natDegree_monicOfCoeff] using
+        (monic_monicOfCoeff fun i : Fin n => p.coeff (i : ℕ)).coeff_natDegree
+    rw [hk, hlead, ← hdeg, hp.coeff_natDegree]
+  · rw [coeff_eq_zero_of_natDegree_lt (by rwa [natDegree_monicOfCoeff]),
+      coeff_eq_zero_of_natDegree_lt (by rwa [hdeg])]
+
+end OfCoeff
+
+end Polynomial
 
 namespace Sym
 
@@ -253,47 +325,6 @@ private theorem coe_monicEquivDegreeLT_symm_apply (p : degreeLT K n) :
 
 end Components
 
-/-! ### The monic polynomial with prescribed lower coefficients -/
-
-section OfCoeff
-
-variable {K : Type*} [Field K] {n : ℕ}
-
-/-- The monic polynomial of degree `n` whose `n` lower coefficients are `c`. It is the inverse of
-the coefficient-reading half of `TauCeti.Sym.coeffEquiv`, and is the natural object to state
-analytic dependence on the coefficients against: `TauCeti.Sym.coeffEquiv_symm_apply` describes the
-inverse chart as its root multiset. -/
-noncomputable def monicOfCoeff (c : Fin n → K) : K[X] :=
-  X ^ n + ∑ i : Fin n, monomial (i : ℕ) (c i)
-
-/-- `TauCeti.Sym.monicOfCoeff` is the polynomial underlying the inverse of the composite
-`Polynomial.monicEquivDegreeLT`-`Polynomial.degreeLTEquiv`, which is where its monicity and its
-degree come from. -/
-private theorem monicOfCoeff_eq_coe (c : Fin n → K) :
-    monicOfCoeff c =
-      (((monicEquivDegreeLT n).symm ((degreeLTEquiv K n).toEquiv.symm c) :
-        { p : K[X] // p.Monic ∧ p.natDegree = n }) : K[X]) := by
-  rw [coe_monicEquivDegreeLT_symm_apply, coe_degreeLTEquiv_toEquiv_symm_apply]
-  rfl
-
-@[simp]
-theorem monic_monicOfCoeff (c : Fin n → K) : (monicOfCoeff c).Monic := by
-  rw [monicOfCoeff_eq_coe]
-  exact ((monicEquivDegreeLT n).symm _).2.1
-
-@[simp]
-theorem natDegree_monicOfCoeff (c : Fin n → K) : (monicOfCoeff c).natDegree = n := by
-  rw [monicOfCoeff_eq_coe]
-  exact ((monicEquivDegreeLT n).symm _).2.2
-
-/-- Evaluating the monic polynomial attached to a coefficient tuple: the leading power plus the
-prescribed lower part. -/
-theorem eval_monicOfCoeff (c : Fin n → K) (z : K) :
-    (monicOfCoeff c).eval z = z ^ n + ∑ i : Fin n, c i * z ^ (i : ℕ) := by
-  simp [monicOfCoeff, eval_finsetSum]
-
-end OfCoeff
-
 section AlgClosed
 
 variable (K : Type*) [Field K] [IsAlgClosed K] (n : ℕ)
@@ -359,29 +390,30 @@ theorem coeffEquiv_ofFn_apply (f : Fin n → K) (i : Fin n) :
 determines. -/
 @[simp]
 theorem coeffEquiv_symm_apply (f : Fin n → K) : (((coeffEquiv K n).symm f : Sym K n) : Multiset K) =
-      (monicOfCoeff f).roots := by
+      (Polynomial.monicOfCoeff f).roots := by
   rw [coeffEquiv, Equiv.symm_trans_apply, Equiv.symm_trans_apply, coe_monicEquiv_symm_apply,
     coe_monicEquivDegreeLT_symm_apply, coe_degreeLTEquiv_toEquiv_symm_apply]
   rfl
 
-end AlgClosed
-
-end Sym
-
-variable {K : Type*} [Field K] [IsAlgClosed K] {n : ℕ}
-
-/-- The chart and `TauCeti.Sym.monicOfCoeff` are inverse: the monic polynomial rebuilt from the
-coordinates of a tuple is the monic polynomial of that tuple. -/
+/-- The chart and `TauCeti.Polynomial.monicOfCoeff` are inverse: the monic polynomial rebuilt from
+the coordinates of a tuple is the monic polynomial of that tuple. -/
 @[simp]
 theorem monicOfCoeff_coeffEquiv (s : Sym K n) :
-    Sym.monicOfCoeff (Sym.coeffEquiv K n s) = (Sym.toMonic s : K[X]) := by
-  have hroots : (Sym.monicOfCoeff (Sym.coeffEquiv K n s)).roots = (s : Multiset K) := by
-    rw [← Sym.coeffEquiv_symm_apply, Equiv.symm_apply_apply]
-  rw [Sym.coe_toMonic, ofMultiset_apply, ← hroots]
-  exact (prod_multiset_X_sub_C_of_monic_of_roots_card_eq (Sym.monic_monicOfCoeff _)
-    (by rw [hroots, Sym.card_coe, Sym.natDegree_monicOfCoeff])).symm
+    Polynomial.monicOfCoeff (coeffEquiv K n s) = (toMonic s : K[X]) := by
+  have hroots : (Polynomial.monicOfCoeff (coeffEquiv K n s)).roots = (s : Multiset K) := by
+    rw [← coeffEquiv_symm_apply, Equiv.symm_apply_apply]
+  rw [coe_toMonic, ofMultiset_apply, ← hroots]
+  exact (prod_multiset_X_sub_C_of_monic_of_roots_card_eq (Polynomial.monic_monicOfCoeff _)
+    (by rw [hroots, Sym.card_coe, Polynomial.natDegree_monicOfCoeff])).symm
 
-namespace Sym
+/-- The inverse chart, read as a polynomial rather than as a root multiset, is
+`TauCeti.Polynomial.monicOfCoeff`: this is the `symm` companion of
+`TauCeti.Sym.monicOfCoeff_coeffEquiv`. -/
+@[simp]
+theorem toMonic_coeffEquiv_symm (c : Fin n → K) :
+    (toMonic ((coeffEquiv K n).symm c) : K[X]) = Polynomial.monicOfCoeff c := by
+  conv_rhs => rw [← Equiv.apply_symm_apply (coeffEquiv K n) c]
+  rw [monicOfCoeff_coeffEquiv]
 
 /-- In degree one the chart is negation: the single coordinate of a one-point tuple is minus that
 point. -/
@@ -396,6 +428,8 @@ theorem coeffEquiv_two_apply {s : Sym K 2} {a b : K} (hs : (s : Multiset K) = {a
     coeffEquiv K 2 s = ![a * b, -(a + b)] := by
   ext i
   fin_cases i <;> rw [coeffEquiv_apply, hs] <;> simp
+
+end AlgClosed
 
 end Sym
 

--- a/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
+++ b/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
@@ -311,15 +311,6 @@ theorem coeffEquiv_ofFn_apply (f : Fin n → K) (i : Fin n) :
     coeffEquiv K n (ofFn f) i = (∏ j, (X - C (f j))).coeff i := by
   rw [coeffEquiv_apply_eq_coeff, toMonic_ofFn]
 
-/-- The inverse chart sends a coefficient tuple to the root multiset of the monic polynomial it
-determines. -/
-@[simp]
-theorem coeffEquiv_symm_apply (f : Fin n → K) : (((coeffEquiv K n).symm f : Sym K n) : Multiset K) =
-      (Polynomial.monicOfCoeff f).roots := by
-  rw [coeffEquiv, Equiv.symm_trans_apply, Equiv.symm_trans_apply, coe_monicEquiv_symm_apply,
-    coe_monicEquivDegreeLT_symm_apply, coe_degreeLTEquiv_toEquiv_symm_apply]
-  rfl
-
 /-- The inverse chart, read as a polynomial rather than as a root multiset, is
 `TauCeti.Polynomial.monicOfCoeff`: the monic polynomial of the tuple with prescribed coordinates is
 the monic polynomial with those lower coefficients. Equivalently, the chart itself reads off the
@@ -327,9 +318,17 @@ lower coefficients of `TauCeti.Sym.toMonic`, which is `TauCeti.Sym.coeffEquiv_ap
 @[simp]
 theorem toMonic_coeffEquiv_symm (c : Fin n → K) :
     (toMonic ((coeffEquiv K n).symm c) : K[X]) = Polynomial.monicOfCoeff c := by
-  rw [coe_toMonic, coeffEquiv_symm_apply, ofMultiset_apply]
-  exact prod_multiset_X_sub_C_of_monic_of_roots_card_eq (Polynomial.monic_monicOfCoeff c)
-    (splits_iff_card_roots.mp (IsAlgClosed.splits _))
+  symm
+  simpa only [← coeffEquiv_apply_eq_coeff, Equiv.apply_symm_apply] using
+    Polynomial.monicOfCoeff_coeff (monic_toMonic ((coeffEquiv K n).symm c))
+      (natDegree_toMonic (s := (coeffEquiv K n).symm c))
+
+/-- The inverse chart sends a coefficient tuple to the root multiset of the monic polynomial it
+determines. -/
+@[simp]
+theorem coeffEquiv_symm_apply (f : Fin n → K) : (((coeffEquiv K n).symm f : Sym K n) : Multiset K) =
+      (Polynomial.monicOfCoeff f).roots := by
+  rw [← roots_toMonic ((coeffEquiv K n).symm f), toMonic_coeffEquiv_symm]
 
 /-- In degree one the chart is negation: the single coordinate of a one-point tuple is minus that
 point. -/

--- a/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
+++ b/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
@@ -46,7 +46,7 @@ are separate later steps.
 * `TauCeti.Sym.monicOfCoeff`: the monic polynomial of degree `n` with prescribed lower
   coefficients, with `TauCeti.Sym.monic_monicOfCoeff`, `TauCeti.Sym.natDegree_monicOfCoeff` and
   `TauCeti.Sym.eval_monicOfCoeff`; it inverts the chart by
-  `TauCeti.Sym.monicOfCoeff_coeffEquiv`.
+  `TauCeti.monicOfCoeff_coeffEquiv`.
 * `TauCeti.Sym.monicEquiv`: over an algebraically closed field, taking roots with multiplicity
   inverts `toMonic`, so `Sym K n` is equivalent to the monic polynomials of degree `n`.
 * `TauCeti.Sym.coeffEquiv`: the resulting chart `Sym K n ≃ (Fin n → K)`, with
@@ -364,16 +364,24 @@ theorem coeffEquiv_symm_apply (f : Fin n → K) : (((coeffEquiv K n).symm f : Sy
     coe_monicEquivDegreeLT_symm_apply, coe_degreeLTEquiv_toEquiv_symm_apply]
   rfl
 
+end AlgClosed
+
+end Sym
+
+variable {K : Type*} [Field K] [IsAlgClosed K] {n : ℕ}
+
 /-- The chart and `TauCeti.Sym.monicOfCoeff` are inverse: the monic polynomial rebuilt from the
 coordinates of a tuple is the monic polynomial of that tuple. -/
 @[simp]
 theorem monicOfCoeff_coeffEquiv (s : Sym K n) :
-    monicOfCoeff (coeffEquiv K n s) = (toMonic s : K[X]) := by
-  have hroots : (monicOfCoeff (coeffEquiv K n s)).roots = (s : Multiset K) := by
-    rw [← coeffEquiv_symm_apply, Equiv.symm_apply_apply]
-  rw [coe_toMonic, ofMultiset_apply, ← hroots]
-  exact (prod_multiset_X_sub_C_of_monic_of_roots_card_eq (monic_monicOfCoeff _)
-    (by rw [hroots, Sym.card_coe, natDegree_monicOfCoeff])).symm
+    Sym.monicOfCoeff (Sym.coeffEquiv K n s) = (Sym.toMonic s : K[X]) := by
+  have hroots : (Sym.monicOfCoeff (Sym.coeffEquiv K n s)).roots = (s : Multiset K) := by
+    rw [← Sym.coeffEquiv_symm_apply, Equiv.symm_apply_apply]
+  rw [Sym.coe_toMonic, ofMultiset_apply, ← hroots]
+  exact (prod_multiset_X_sub_C_of_monic_of_roots_card_eq (Sym.monic_monicOfCoeff _)
+    (by rw [hroots, Sym.card_coe, Sym.natDegree_monicOfCoeff])).symm
+
+namespace Sym
 
 /-- In degree one the chart is negation: the single coordinate of a one-point tuple is minus that
 point. -/
@@ -388,8 +396,6 @@ theorem coeffEquiv_two_apply {s : Sym K 2} {a b : K} (hs : (s : Multiset K) = {a
     coeffEquiv K 2 s = ![a * b, -(a + b)] := by
   ext i
   fin_cases i <;> rw [coeffEquiv_apply, hs] <;> simp
-
-end AlgClosed
 
 end Sym
 

--- a/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
+++ b/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
@@ -40,7 +40,13 @@ are separate later steps.
   map is multiplicative in the tuple, so adjoining a point multiplies by a linear factor and a
   constant tuple gives a pure power.
 * `TauCeti.Sym.roots_toMonic`, `TauCeti.Sym.toMonic_injective`, `TauCeti.Sym.mem_iff_isRoot`: over
-  an integral domain the tuple is recovered from the polynomial as its root multiset.
+  an integral domain the tuple is recovered from the polynomial as its root multiset, and
+  `TauCeti.Sym.toMonic_ofFn_eq_of_forall_isRoot`, that a monic polynomial of degree `n` with `n`
+  distinct roots is the monic polynomial of the unordered tuple of those roots.
+* `TauCeti.Sym.monicOfCoeff`: the monic polynomial of degree `n` with prescribed lower
+  coefficients, with `TauCeti.Sym.monic_monicOfCoeff`, `TauCeti.Sym.natDegree_monicOfCoeff` and
+  `TauCeti.Sym.eval_monicOfCoeff`; it inverts the chart by
+  `TauCeti.Sym.monicOfCoeff_coeffEquiv`.
 * `TauCeti.Sym.monicEquiv`: over an algebraically closed field, taking roots with multiplicity
   inverts `toMonic`, so `Sym K n` is equivalent to the monic polynomials of degree `n`.
 * `TauCeti.Sym.coeffEquiv`: the resulting chart `Sym K n ≃ (Fin n → K)`, with
@@ -191,6 +197,22 @@ theorem mem_iff_isRoot {a : R} {s : Sym R n} :
     a ∈ (s : Multiset R) ↔ (toMonic s : R[X]).IsRoot a := by
   rw [← roots_toMonic s, mem_roots (monic_toMonic s).ne_zero]
 
+/-- A monic polynomial of degree `n` with `n` pairwise distinct roots is the monic polynomial of
+the unordered tuple of those roots: a full set of simple roots pins the polynomial down. -/
+theorem toMonic_ofFn_eq_of_forall_isRoot {p : R[X]} (hp : p.Monic) (hdeg : p.natDegree = n)
+    {w : Fin n → R} (hw : Function.Injective w) (hroot : ∀ i, (p : R[X]).IsRoot (w i)) :
+    (toMonic (ofFn w) : R[X]) = p := by
+  have hle : (ofFn w : Multiset R) ≤ p.roots := by
+    refine (Multiset.le_iff_subset (by rw [coe_ofFn]; simpa using List.nodup_ofFn.2 hw)).2
+      fun a ha => ?_
+    obtain ⟨i, rfl⟩ := mem_ofFn.1 (by simpa using ha)
+    exact (mem_roots' (p := p)).2 ⟨hp.ne_zero, hroot i⟩
+  have hcard : Multiset.card (ofFn w : Multiset R) = n := Sym.card_coe
+  have hroots : (ofFn w : Multiset R) = p.roots :=
+    Multiset.eq_of_le_of_card_le hle (by rw [hcard, ← hdeg]; exact p.card_roots')
+  rw [coe_toMonic, ofMultiset_apply, hroots]
+  exact prod_multiset_X_sub_C_of_monic_of_roots_card_eq hp (by rw [← hroots, hcard, hdeg])
+
 end Domain
 
 end Basic
@@ -230,6 +252,47 @@ private theorem coe_monicEquivDegreeLT_symm_apply (p : degreeLT K n) :
   rfl
 
 end Components
+
+/-! ### The monic polynomial with prescribed lower coefficients -/
+
+section OfCoeff
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-- The monic polynomial of degree `n` whose `n` lower coefficients are `c`. It is the inverse of
+the coefficient-reading half of `TauCeti.Sym.coeffEquiv`, and is the natural object to state
+analytic dependence on the coefficients against: `TauCeti.Sym.coeffEquiv_symm_apply` describes the
+inverse chart as its root multiset. -/
+noncomputable def monicOfCoeff (c : Fin n → K) : K[X] :=
+  X ^ n + ∑ i : Fin n, monomial (i : ℕ) (c i)
+
+/-- `TauCeti.Sym.monicOfCoeff` is the polynomial underlying the inverse of the composite
+`Polynomial.monicEquivDegreeLT`-`Polynomial.degreeLTEquiv`, which is where its monicity and its
+degree come from. -/
+private theorem monicOfCoeff_eq_coe (c : Fin n → K) :
+    monicOfCoeff c =
+      (((monicEquivDegreeLT n).symm ((degreeLTEquiv K n).toEquiv.symm c) :
+        { p : K[X] // p.Monic ∧ p.natDegree = n }) : K[X]) := by
+  rw [coe_monicEquivDegreeLT_symm_apply, coe_degreeLTEquiv_toEquiv_symm_apply]
+  rfl
+
+@[simp]
+theorem monic_monicOfCoeff (c : Fin n → K) : (monicOfCoeff c).Monic := by
+  rw [monicOfCoeff_eq_coe]
+  exact ((monicEquivDegreeLT n).symm _).2.1
+
+@[simp]
+theorem natDegree_monicOfCoeff (c : Fin n → K) : (monicOfCoeff c).natDegree = n := by
+  rw [monicOfCoeff_eq_coe]
+  exact ((monicEquivDegreeLT n).symm _).2.2
+
+/-- Evaluating the monic polynomial attached to a coefficient tuple: the leading power plus the
+prescribed lower part. -/
+theorem eval_monicOfCoeff (c : Fin n → K) (z : K) :
+    (monicOfCoeff c).eval z = z ^ n + ∑ i : Fin n, c i * z ^ (i : ℕ) := by
+  simp [monicOfCoeff, eval_finsetSum]
+
+end OfCoeff
 
 section AlgClosed
 
@@ -296,9 +359,21 @@ theorem coeffEquiv_ofFn_apply (f : Fin n → K) (i : Fin n) :
 determines. -/
 @[simp]
 theorem coeffEquiv_symm_apply (f : Fin n → K) : (((coeffEquiv K n).symm f : Sym K n) : Multiset K) =
-      (X ^ n + ∑ i : Fin n, monomial (i : ℕ) (f i)).roots := by
+      (monicOfCoeff f).roots := by
   rw [coeffEquiv, Equiv.symm_trans_apply, Equiv.symm_trans_apply, coe_monicEquiv_symm_apply,
     coe_monicEquivDegreeLT_symm_apply, coe_degreeLTEquiv_toEquiv_symm_apply]
+  rfl
+
+/-- The chart and `TauCeti.Sym.monicOfCoeff` are inverse: the monic polynomial rebuilt from the
+coordinates of a tuple is the monic polynomial of that tuple. -/
+@[simp]
+theorem monicOfCoeff_coeffEquiv (s : Sym K n) :
+    monicOfCoeff (coeffEquiv K n s) = (toMonic s : K[X]) := by
+  have hroots : (monicOfCoeff (coeffEquiv K n s)).roots = (s : Multiset K) := by
+    rw [← coeffEquiv_symm_apply, Equiv.symm_apply_apply]
+  rw [coe_toMonic, ofMultiset_apply, ← hroots]
+  exact (prod_multiset_X_sub_C_of_monic_of_roots_card_eq (monic_monicOfCoeff _)
+    (by rw [hroots, Sym.card_coe, natDegree_monicOfCoeff])).symm
 
 /-- In degree one the chart is negation: the single coordinate of a one-point tuple is minus that
 point. -/


### PR DESCRIPTION
This PR upgrades the elementary symmetric presentation of a symmetric power from a homeomorphism to an *analytic* one away from the diagonal. It proves that a simple root of a monic polynomial depends analytically on the polynomial's coefficients, deduces from that an analytic ordered parametrization of the whole root tuple of a polynomial whose roots are pairwise distinct, and concludes that the transition maps of the elementary symmetric atlas are analytic at every multiplicity-free coefficient tuple.

The target is the first clause of Lane F4.1 of the analytic Heegaard Floer roadmap, "`Sym^g(Σ)` geometry: smooth complex structure (elementary symmetric functions)", after Ozsváth–Szabó ([arXiv:math/0101206](https://arxiv.org/abs/math/0101206), §2.1); the milestone it serves is the roadmap's v3 end goal, `HF̂(Y)` over 𝔽₂ via holomorphic disks in `Sym^g(Σ)`, which needs `Sym^g(Σ)` to be a complex manifold before a single holomorphic disk can be spoken of. `TauCeti/Geometry/Manifold/SymmetricPower.lean` already charts `Sym^g(Σ)` as a topological manifold by the elementary symmetric functions and names the holomorphy of the resulting transition maps as the next step; this PR supplies exactly that holomorphy on the multiplicity-free locus. What remains for the first clause after this PR is the diagonal — the transition maps at tuples with repeated points, where the implicit function theorem no longer applies — after which the charted space can be upgraded to a complex manifold and the totally real tori `T_α`, `T_β` defined.

Everything rests on a single application of Mathlib's implicit function theorem to the universal monic polynomial `f (c, z) = z ^ n + ∑ i, c i * z ^ i`, which is polynomial in the coefficient tuple and the argument jointly, hence analytic. Its partial derivative in the argument at `(c₀, z₀)` is multiplication by `P'(z₀)`, which is an invertible operator exactly when `z₀` is a simple root, so the theorem yields a root function analytic in the coefficients (`TauCeti.Sym.exists_analyticAt_isRoot`). Applying that at each of `n` pairwise distinct roots, and noting that distinctness persists in a neighbourhood, gives an analytic ordered lift `Ψ` of the unordered root tuple (`TauCeti.Sym.exists_analyticAt_prod_X_sub_C`, then `TauCeti.Sym.exists_analyticAt_coeffEquiv_symm` read through the chart). Since Vieta's formulas make the chart itself polynomial in an ordered presentation of the tuple (`TauCeti.Sym.analyticAt_coeffEquiv_ofFn`), the lift is a two-sided local inverse of the coefficient map (`TauCeti.Sym.exists_analyticAt_coeffEquiv_ofFn_localInverse`), and the induced map on coefficient tuples of any map analytic at the roots is analytic (`TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm`) — that last statement being the transition-map holomorphy the roadmap asks for. Nothing is vendored from Mathlib; the results used are its implicit function theorem, its analyticity calculus, and Vieta's formulas.

The statements are made over an `RCLike` field, so they cover the real as well as the complex case; only the ones that mention the chart, which lives over an algebraically closed field, specialise further. No ordering of the roots is canonical, so what is proved is the existence of an analytic *ordered lift* of the inverse chart near a multiplicity-free point, not analyticity of a preferred root function.

Files:

* `TauCeti/Analysis/Polynomial/SimpleRoots.lean` (new): the analysis described above.
* `TauCeti/RingTheory/Polynomial/SymmetricPower.lean`: adds `TauCeti.Sym.monicOfCoeff`, the monic polynomial of degree `n` with prescribed lower coefficients, with its monicity, degree and evaluation, and the fact that it inverts the chart; adds `TauCeti.Sym.toMonic_ofFn_eq_of_forall_isRoot`, that a monic polynomial of degree `n` with `n` distinct roots is the monic polynomial of the unordered tuple of those roots; and restates the existing `coeffEquiv_symm_apply` through the new definition.
* `TauCeti/Analysis/Polynomial/SymmetricPower.lean` and `TauCeti/Geometry/Manifold/SymmetricPower.lean`: docstring pointers to the new file, from the two places that record what is still missing for a complex structure.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"simple-roots-depend-analytically-on-coefficients"}-->

🤖 Prepared with Claude Code
