### PR TITLE
feat: equivariance of an exchangeable array's directing measure

### DIFF
--- a/TauCeti/MeasureTheory/Measure/Measurability.lean
+++ b/TauCeti/MeasureTheory/Measure/Measurability.lean
@@ -6,6 +6,7 @@ Authors: Claude
 module
 
 public import Mathlib.MeasureTheory.Measure.GiryMonad
+public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 
 /-!
 # Measurability of measure-valued maps
@@ -17,6 +18,8 @@ of measures.
 
 * `TauCeti.MeasureTheory.measurable_sum_smul_dirac` — a countable mixture of Dirac measures at
   fixed atoms is measurable when each weight is measurable.
+* `TauCeti.MeasureTheory.measurable_probabilityMeasure_map` — pushing forward along a fixed
+  measurable map is measurable on `ProbabilityMeasure`.
 -/
 
 public section
@@ -43,6 +46,13 @@ theorem measurable_sum_smul_dirac {β ι α : Type*} [MeasurableSpace β] [Measu
   refine Measure.measurable_measure.2 fun s hs => ?_
   simp only [Measure.sum_apply _ hs, Measure.smul_apply, smul_eq_mul, Measure.dirac_apply' _ hs]
   exact Measurable.tsum fun i => (hf i).mul_const _
+
+/-- Pushing a probability measure forward along a fixed measurable map is measurable for the Giry
+structure that `ProbabilityMeasure` inherits as a subtype of `Measure`. -/
+theorem measurable_probabilityMeasure_map {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+    {f : α → β} (hf : Measurable f) :
+    Measurable fun P : ProbabilityMeasure α => P.map hf.aemeasurable :=
+  ((Measure.measurable_map f hf).comp measurable_subtype_coe).subtype_mk
 
 end MeasureTheory
 

--- a/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
@@ -1,0 +1,285 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.Arrays.DeFinetti
+public import TauCeti.Probability.Exchangeability.ConditionallyIID.PathDisintegration
+-- Non-public: the closure of the conditional predicate under a coordinatewise map is used only to
+-- produce the directing measure of a reindexed array.
+import TauCeti.Probability.Exchangeability.ConditionallyIID.Map
+-- Non-public: the Giry-measurability of a pushforward is used only inside the proofs below.
+import TauCeti.MeasureTheory.Measure.Measurability
+
+/-!
+# The directing measure of a separately exchangeable array is equivariant
+
+Applying de Finetti to the rows of a separately exchangeable array produces a directing measure
+`ν` on row paths, and `Arrays.MixingLaw` records the symmetry it inherits from the remaining column
+freedom: the *law* of `ν` is invariant under pushing every row path forward by a permutation `τ` of
+the time coordinate. That statement forgets how `ν` is coupled to the array, and the coupling is
+exactly what the next step of the Aldous--Hoover argument has to work with: the column randomness
+of the array is carried by `ν`, not by the conditionally i.i.d. rows, so column symmetry has to be
+available *after* conditioning on `ν`.
+
+This file supplies the coupled statement. For all permutations `σ` of the rows and `τ` of the
+columns,
+
+```text
+Law (ν.map (permReindex τ),  (i, j) ↦ X (σ i, τ j))  =  Law (ν,  (i, j) ↦ X (i, j)).
+```
+
+Row permutations leave the directing measure alone and column permutations push it forward. Taking
+the first marginal recovers the conclusion of
+`SeparatelyExchangeable.mixingLaw_map_permReindex_arrayRow_eq` at a directing measure, and taking
+the second recovers separate exchangeability itself.
+
+Both refinements are genuine. The statement is *conditional-side*: it is false for an arbitrary
+mixing representative, since an independent copy of a directing measure is another mixing
+representative with a different coupling to the array, so it must be read off the joint law rather
+than the mixture identity. And it is *equivariant* rather than invariant: `ν` is almost surely not
+an exchangeable measure — if every row is one common i.i.d. path `Y`, then `ν = δ_Y` — so the
+column permutation cannot simply be dropped.
+
+## Main results
+
+* `TauCeti.Probability.SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq` — the displayed
+  identity;
+* `TauCeti.Probability.SeparatelyExchangeable.jointLaw_arrayRow_rowReindex_eq` and
+  `TauCeti.Probability.SeparatelyExchangeable.jointLaw_arrayRow_colReindex_eq` — its two axes
+  separately;
+* `TauCeti.Probability.SeparatelyExchangeable.exists_directing_arrayRow_jointLaw_equivariant` —
+  de Finetti supplies a directing measure with this symmetry;
+* `TauCeti.Probability.SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq` — the transposed
+  statement for the column directing measure.
+
+## Implementation
+
+Everything is deduced from one general fact, `ConditionallyIIDWith.jointPathLaw_eq_of_pathLaw_eq`:
+a conditionally i.i.d. process determines the joint law of its directing measure and its path
+through the path law alone. The reindexed array has a directing measure for its rows by the two
+closure lemmas `ConditionallyIIDWith.comp_injective` (permute the rows) and
+`ConditionallyIIDWith.map_values` (permute the time coordinate of each row path), and separate
+exchangeability says its row process has the original path law. Transporting the resulting identity
+of joint path laws along a measurable reassembly of the array from its row — or column — process
+gives the array-level statements.
+
+`arrayRow` and `arrayCol` are ordinary definitions rather than reducible abbreviations, so the
+proofs move between a process of paths and the entries of the array through their `@[simp]`
+evaluation lemmas rather than by definitional unfolding.
+
+These results advance the exchangeable-arrays milestone in
+`TauCetiRoadmap/Exchangeability/README.md`, Layer 8.
+
+## References
+
+* D. Aldous, "Representations for partially exchangeable arrays of random variables", *Journal of
+  Multivariate Analysis* 11 (1981), 581–598.
+* O. Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005, Chapter 7.
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable sequences
+rather than exchangeable arrays.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α Ω : Type*} [MeasurableSpace α] [MeasurableSpace Ω]
+  {μ : Measure Ω} {X : ℕ × ℕ → Ω → α} {ν : Ω → ProbabilityMeasure (ℕ → α)}
+
+/-! ### Transporting a joint path law to the array -/
+
+omit [MeasurableSpace α] [MeasurableSpace Ω] in
+/-- The row process of an array, with `arrayRow` eliminated in favour of the entries. `arrayRow` is
+an ordinary definition, so the proofs below normalise with this rather than unfold it. -/
+private theorem arrayRow_eq_entries (X : ℕ × ℕ → Ω → α) :
+    arrayRow X = fun i ω j => X (i, j) ω := by
+  funext i ω j
+  simp
+
+omit [MeasurableSpace α] [MeasurableSpace Ω] in
+/-- The column process of an array, with `arrayCol` eliminated in favour of the entries. -/
+private theorem arrayCol_eq_entries (X : ℕ × ℕ → Ω → α) :
+    arrayCol X = fun j ω i => X (i, j) ω := by
+  funext j ω i
+  simp
+
+/-- Currying an array-shaped path into its rows. -/
+private theorem measurable_rowsOf :
+    Measurable fun x : ℕ × ℕ → α => fun i j => x (i, j) :=
+  measurable_pi_lambda _ fun i => measurable_pi_lambda _ fun j => measurable_pi_apply (i, j)
+
+/-- Currying an array-shaped path into its columns. -/
+private theorem measurable_colsOf :
+    Measurable fun x : ℕ × ℕ → α => fun j i => x (i, j) :=
+  measurable_pi_lambda _ fun j => measurable_pi_lambda _ fun i => measurable_pi_apply (i, j)
+
+/-- Reassembling an array from its columns. -/
+private theorem measurable_uncurrySwap :
+    Measurable fun x : ℕ → ℕ → α => fun p : ℕ × ℕ => x p.2 p.1 :=
+  measurable_pi_lambda _ fun p => (measurable_pi_apply p.1).comp (measurable_pi_apply p.2)
+
+/-- Reassembling the array from its row process turns the joint law of a random measure and the row
+process into the joint law of that random measure and the array. -/
+private theorem map_prod_jointPathLaw_arrayRow (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : Measurable ν) :
+    (jointPathLaw μ (arrayRow X) ν).map (Prod.map id Function.uncurry)
+      = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
+  rw [jointPathLaw_def, AEMeasurable.map_map_of_aemeasurable
+    (measurable_id.prodMap measurable_uncurry).aemeasurable
+    (hν.aemeasurable.prodMk (aemeasurable_pi_lambda _ (aemeasurable_arrayRow hX)))]
+  refine congrArg (Measure.map · _) (funext fun ω => Prod.ext rfl (funext fun p => ?_))
+  simp [Function.uncurry]
+
+/-- Reassembling the array from its column process turns the joint law of a random measure and the
+column process into the joint law of that random measure and the array. -/
+private theorem map_prod_jointPathLaw_arrayCol (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : Measurable ν) :
+    (jointPathLaw μ (arrayCol X) ν).map
+        (Prod.map id fun x : ℕ → ℕ → α => fun p : ℕ × ℕ => x p.2 p.1)
+      = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
+  rw [jointPathLaw_def, AEMeasurable.map_map_of_aemeasurable
+    (measurable_id.prodMap measurable_uncurrySwap).aemeasurable
+    (hν.aemeasurable.prodMk (aemeasurable_pi_lambda _ (aemeasurable_arrayCol hX)))]
+  refine congrArg (Measure.map · _) (funext fun ω => Prod.ext rfl (funext fun p => ?_))
+  simp
+
+/-! ### The row directing measure -/
+
+/-- **Equivariance of the row directing measure, at the level of the row process.** Reindexing the
+rows of a separately exchangeable array by `σ` and the columns by `τ`, and pushing the directing
+measure forward by `τ`, leaves the joint law of the directing measure and the row process
+unchanged. -/
+theorem SeparatelyExchangeable.jointPathLaw_arrayRow_pairReindex_eq [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : ConditionallyIIDWith μ (arrayRow X) ν) (σ τ : Equiv.Perm ℕ) :
+    jointPathLaw μ (arrayRow fun p => X (σ p.1, τ p.2))
+        (fun ω => (ν ω).map (measurable_reindex τ).aemeasurable)
+      = jointPathLaw μ (arrayRow X) ν := by
+  simp only [arrayRow_eq_entries] at hν ⊢
+  exact ((hν.comp_injective σ.injective).map_values
+    (measurable_reindex (α := α) τ)).jointPathLaw_eq_of_pathLaw_eq hν
+    (h.map_comp hX σ τ measurable_rowsOf)
+
+/-- **Equivariance of the row directing measure.** For a separately exchangeable array with row
+directing measure `ν`, the joint law of `ν` and the array is unchanged when the rows are reindexed
+by `σ`, the columns by `τ`, and `ν` is pushed forward by `τ`.
+
+Rows and columns enter differently, and both asymmetries are real: the rows are the coordinates of
+the conditionally i.i.d. process that `ν` directs, so permuting them does not disturb `ν`, while
+the columns are coordinates *inside* each row path, so permuting them acts on `ν`. -/
+theorem SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : ConditionallyIIDWith μ (arrayRow X) ν) (σ τ : Equiv.Perm ℕ) :
+    (μ.map fun ω => ((ν ω).map (measurable_reindex τ).aemeasurable,
+        fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω))
+      = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
+  have hν' : Measurable fun ω => (ν ω).map (measurable_reindex (α := α) τ).aemeasurable :=
+    (TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex τ)).comp
+      hν.measurable_directing
+  rw [← map_prod_jointPathLaw_arrayRow (X := fun p => X (σ p.1, τ p.2)) (fun p => hX _) hν',
+    ← map_prod_jointPathLaw_arrayRow hX hν.measurable_directing,
+    h.jointPathLaw_arrayRow_pairReindex_eq hX hν σ τ]
+
+/-- **Row permutations leave the row directing measure alone.** The rows are the coordinates of the
+process that `ν` directs, so a permutation of them is absorbed by conditional i.i.d.-ness. -/
+theorem SeparatelyExchangeable.jointLaw_arrayRow_rowReindex_eq [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : ConditionallyIIDWith μ (arrayRow X) ν) (σ : Equiv.Perm ℕ) :
+    (μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X (σ p.1, p.2) ω))
+      = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
+  have key : jointPathLaw μ (arrayRow fun p => X (σ p.1, p.2)) ν
+      = jointPathLaw μ (arrayRow X) ν := by
+    simp only [arrayRow_eq_entries] at hν ⊢
+    exact (hν.comp_injective σ.injective).jointPathLaw_eq_of_pathLaw_eq hν
+      (h.map_comp hX σ 1 measurable_rowsOf)
+  rw [← map_prod_jointPathLaw_arrayRow (X := fun p => X (σ p.1, p.2)) (fun p => hX _)
+      hν.measurable_directing,
+    ← map_prod_jointPathLaw_arrayRow hX hν.measurable_directing, key]
+
+/-- **Column permutations push the row directing measure forward.** This is the half of
+`SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq` that carries information about `ν`. -/
+theorem SeparatelyExchangeable.jointLaw_arrayRow_colReindex_eq [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : ConditionallyIIDWith μ (arrayRow X) ν) (τ : Equiv.Perm ℕ) :
+    (μ.map fun ω => ((ν ω).map (measurable_reindex τ).aemeasurable,
+        fun p : ℕ × ℕ => X (p.1, τ p.2) ω))
+      = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) :=
+  h.jointLaw_arrayRow_pairReindex_eq hX hν 1 τ
+
+/-- **De Finetti for the rows, with the inherited joint symmetry.** Over a nonempty standard Borel
+state space a separately exchangeable array has a row directing measure whose joint law with the
+array is equivariant for the two axis permutations.
+
+This refines `SeparatelyExchangeable.exists_directing_arrayRow_mixingLaw_invariant`, whose
+conclusion is the first marginal of this one. -/
+theorem SeparatelyExchangeable.exists_directing_arrayRow_jointLaw_equivariant
+    [StandardBorelSpace α] [Nonempty α] [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    ∃ ν : Ω → ProbabilityMeasure (ℕ → α), ConditionallyIIDWith μ (arrayRow X) ν ∧
+      ∀ σ τ : Equiv.Perm ℕ,
+        (μ.map fun ω => ((ν ω).map (measurable_reindex τ).aemeasurable,
+            fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω))
+          = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
+  obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayRow hX).exists_directing
+  exact ⟨ν, hν, fun σ τ => h.jointLaw_arrayRow_pairReindex_eq hX hν σ τ⟩
+
+/-! ### The column directing measure -/
+
+/-- **Equivariance of the column directing measure, at the level of the column process.** The
+transpose of `SeparatelyExchangeable.jointPathLaw_arrayRow_pairReindex_eq`: now the row permutation
+acts on the directing measure and the column permutation is absorbed. -/
+theorem SeparatelyExchangeable.jointPathLaw_arrayCol_pairReindex_eq [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : ConditionallyIIDWith μ (arrayCol X) ν) (σ τ : Equiv.Perm ℕ) :
+    jointPathLaw μ (arrayCol fun p => X (σ p.1, τ p.2))
+        (fun ω => (ν ω).map (measurable_reindex σ).aemeasurable)
+      = jointPathLaw μ (arrayCol X) ν := by
+  simp only [arrayCol_eq_entries] at hν ⊢
+  exact ((hν.comp_injective τ.injective).map_values
+    (measurable_reindex (α := α) σ)).jointPathLaw_eq_of_pathLaw_eq hν
+    (h.map_comp hX σ τ measurable_colsOf)
+
+/-- **Equivariance of the column directing measure.** The transpose of
+`SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq`. -/
+theorem SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : ConditionallyIIDWith μ (arrayCol X) ν) (σ τ : Equiv.Perm ℕ) :
+    (μ.map fun ω => ((ν ω).map (measurable_reindex σ).aemeasurable,
+        fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω))
+      = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
+  have hν' : Measurable fun ω => (ν ω).map (measurable_reindex (α := α) σ).aemeasurable :=
+    (TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex σ)).comp
+      hν.measurable_directing
+  rw [← map_prod_jointPathLaw_arrayCol (X := fun p => X (σ p.1, τ p.2)) (fun p => hX _) hν',
+    ← map_prod_jointPathLaw_arrayCol hX hν.measurable_directing,
+    h.jointPathLaw_arrayCol_pairReindex_eq hX hν σ τ]
+
+/-- **De Finetti for the columns, with the inherited joint symmetry.** -/
+theorem SeparatelyExchangeable.exists_directing_arrayCol_jointLaw_equivariant
+    [StandardBorelSpace α] [Nonempty α] [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ) :
+    ∃ ν : Ω → ProbabilityMeasure (ℕ → α), ConditionallyIIDWith μ (arrayCol X) ν ∧
+      ∀ σ τ : Equiv.Perm ℕ,
+        (μ.map fun ω => ((ν ω).map (measurable_reindex σ).aemeasurable,
+            fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω))
+          = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
+  obtain ⟨ν, hν⟩ := (h.conditionallyIID_arrayCol hX).exists_directing
+  exact ⟨ν, hν, fun σ τ => h.jointLaw_arrayCol_pairReindex_eq hX hν σ τ⟩
+
+end Probability
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
@@ -53,7 +53,9 @@ column permutation cannot simply be dropped.
 * `TauCeti.Probability.SeparatelyExchangeable.exists_directing_arrayRow_jointLaw_equivariant` —
   de Finetti supplies a directing measure with this symmetry;
 * `TauCeti.Probability.SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq` — the transposed
-  statement for the column directing measure.
+  statement for the column directing measure, again with its two axes separately as
+  `TauCeti.Probability.SeparatelyExchangeable.jointLaw_arrayCol_rowReindex_eq` and
+  `TauCeti.Probability.SeparatelyExchangeable.jointLaw_arrayCol_colReindex_eq`.
 
 ## Implementation
 
@@ -128,6 +130,13 @@ private theorem measurable_uncurrySwap :
     Measurable fun x : ℕ → ℕ → α => fun p : ℕ × ℕ => x p.2 p.1 :=
   measurable_pi_lambda _ fun p => (measurable_pi_apply p.1).comp (measurable_pi_apply p.2)
 
+omit [MeasurableSpace Ω] in
+/-- Pushing a probability measure on path space forward by the identity permutation of time does
+nothing. This is what specialises the pair-reindexing laws below to a single axis. -/
+private theorem map_permReindex_one (P : ProbabilityMeasure (ℕ → α)) :
+    P.map (measurable_reindex (α := α) (1 : Equiv.Perm ℕ)).aemeasurable = P :=
+  ProbabilityMeasure.toMeasure_injective (by simp)
+
 /-- Reassembling the array from its row process turns the joint law of a random measure and the row
 process into the joint law of that random measure and the array. -/
 private theorem map_prod_jointPathLaw_arrayRow (hX : ∀ p, AEMeasurable (X p) μ)
@@ -191,20 +200,18 @@ theorem SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq [IsFiniteMeasure
     h.jointPathLaw_arrayRow_pairReindex_eq hX hν σ τ]
 
 /-- **Row permutations leave the row directing measure alone.** The rows are the coordinates of the
-process that `ν` directs, so a permutation of them is absorbed by conditional i.i.d.-ness. -/
+process that `ν` directs, so a permutation of them is absorbed by conditional i.i.d.-ness.
+
+This is `SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq` at the identity column
+permutation, whose pushforward of `ν` is the identity. -/
 theorem SeparatelyExchangeable.jointLaw_arrayRow_rowReindex_eq [IsFiniteMeasure μ]
     (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
     (hν : ConditionallyIIDWith μ (arrayRow X) ν) (σ : Equiv.Perm ℕ) :
     (μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X (σ p.1, p.2) ω))
       = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
-  have key : jointPathLaw μ (arrayRow fun p => X (σ p.1, p.2)) ν
-      = jointPathLaw μ (arrayRow X) ν := by
-    simp only [arrayRow_eq_entries] at hν ⊢
-    exact (hν.comp_injective σ.injective).jointPathLaw_eq_of_pathLaw_eq hν
-      (h.map_comp hX σ 1 measurable_rowsOf)
-  rw [← map_prod_jointPathLaw_arrayRow (X := fun p => X (σ p.1, p.2)) (fun p => hX _)
-      hν.measurable_directing,
-    ← map_prod_jointPathLaw_arrayRow hX hν.measurable_directing, key]
+  have key := h.jointLaw_arrayRow_pairReindex_eq hX hν σ 1
+  simp only [map_permReindex_one] at key
+  simpa only [Equiv.Perm.coe_one, id_eq] using key
 
 /-- **Column permutations push the row directing measure forward.** This is the half of
 `SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq` that carries information about `ν`. -/
@@ -263,6 +270,28 @@ theorem SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq [IsFiniteMeasure
   rw [← map_prod_jointPathLaw_arrayCol (X := fun p => X (σ p.1, τ p.2)) (fun p => hX _) hν',
     ← map_prod_jointPathLaw_arrayCol hX hν.measurable_directing,
     h.jointPathLaw_arrayCol_pairReindex_eq hX hν σ τ]
+
+/-- **Row permutations push the column directing measure forward.** This is the half of
+`SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq` that carries information about `ν`. -/
+theorem SeparatelyExchangeable.jointLaw_arrayCol_rowReindex_eq [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : ConditionallyIIDWith μ (arrayCol X) ν) (σ : Equiv.Perm ℕ) :
+    (μ.map fun ω => ((ν ω).map (measurable_reindex σ).aemeasurable,
+        fun p : ℕ × ℕ => X (σ p.1, p.2) ω))
+      = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) :=
+  h.jointLaw_arrayCol_pairReindex_eq hX hν σ 1
+
+/-- **Column permutations leave the column directing measure alone.** The columns are the
+coordinates of the process that `ν` directs, so a permutation of them is absorbed by conditional
+i.i.d.-ness. -/
+theorem SeparatelyExchangeable.jointLaw_arrayCol_colReindex_eq [IsFiniteMeasure μ]
+    (h : SeparatelyExchangeable μ X) (hX : ∀ p, AEMeasurable (X p) μ)
+    (hν : ConditionallyIIDWith μ (arrayCol X) ν) (τ : Equiv.Perm ℕ) :
+    (μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X (p.1, τ p.2) ω))
+      = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
+  have key := h.jointLaw_arrayCol_pairReindex_eq hX hν 1 τ
+  simp only [map_permReindex_one] at key
+  simpa only [Equiv.Perm.coe_one, id_eq] using key
 
 /-- **De Finetti for the columns, with the inherited joint symmetry.** -/
 theorem SeparatelyExchangeable.exists_directing_arrayCol_jointLaw_equivariant

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Map.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Map.lean
@@ -87,7 +87,7 @@ theorem ConditionallyIIDWith.map_values {μ : Measure Ω} {X : ι → Ω → α}
       = (μ.map fun ω => (ν ω, fun i : Fin m => X (k i) ω)).map
           (Prod.map (fun Q : ProbabilityMeasure α => Q.map hf.aemeasurable) F) := by
         rw [AEMeasurable.map_map_of_aemeasurable hΦ.aemeasurable hinner]
-        rfl
+        exact congrArg (μ.map ·) (funext fun ω => by simp [hF, Prod.map])
     _ = (μ.bind fun ω => (Measure.dirac (ν ω)).prod
           (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure).map
           (Prod.map (fun Q : ProbabilityMeasure α => Q.map hf.aemeasurable) F) := by

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Map.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Map.lean
@@ -7,25 +7,39 @@ module
 
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic
 import TauCeti.MeasureTheory.Measure.GiryMonad
+-- Non-public: the Giry-measurability of a pushforward is used only inside the proofs below.
+import TauCeti.MeasureTheory.Measure.Measurability
 
 /-!
-# Transferring conditional i.i.d.-ness along the path map
+# Maps of conditionally i.i.d. families
 
-The canonical process on path space carries `ConditionallyIID` back to the original process.
+Two ways of moving `ConditionallyIID` along a map. Applying a measurable map to the *values* of
+every coordinate gives another conditionally i.i.d. family, whose directing measure is the
+pushforward of the original one; and the canonical process on path space carries
+`ConditionallyIID` back to the original process.
 
 ## Main results
 
+* `ConditionallyIIDWith.map_values` — the coordinatewise value pushforward, at a named directing
+  measure, together with its existential corollary `ConditionallyIID.map_values`.
 * `ConditionallyIIDWith.of_pathLaw` — the transfer at a named directing measure, identifying the
   transferred witness as `ν ∘ (ω ↦ fun i => X i ω)`.
 * `conditionallyIID_of_conditionallyIID_pathLaw` — its existential corollary.
 
 ## Implementation
 
-This is the conditional counterpart of `mixedIID_of_mixedIID_pathLaw`, and the roadmap refers to it
-as `conditionallyIID_transfer`. Both sides of the disintegration identity move along the path map
-`φ ω = fun i => X i ω`: the joint law by `Measure.map_map`, and the mixture by `bind_map`. The
-directing measure transfers as `ν ∘ φ`.
+These are the conditional counterparts of `MixedIIDWith.map_values` and
+`mixedIID_of_mixedIID_pathLaw`; the roadmap refers to the second as `conditionallyIID_transfer`,
+and asks for the first as the closure of each symmetry class under a coordinatewise pushforward
+(`TauCetiRoadmap/Exchangeability/README.md`, Layer 0). Where the mixture predicate needs only the
+block identity to move, the conditional predicate carries the directing measure along as a
+coordinate of a joint law, so `map_values` transports the *whole* disintegration identity along
+`(Q, x) ↦ (Q.map f, f ∘ x)`. That map splits as a product, which is what lets
+`Measure.map_prod_map` reduce the mixture side to `Measure.map_dirac'` on the tag and
+`Measure.pi_map_pi` on the sampled block.
 
+Both sides of the path-law transfer move along the path map `φ ω = fun i => X i ω`: the joint law
+by `Measure.map_map`, and the mixture by `bind_map`. The directing measure transfers as `ν ∘ φ`.
 Its purpose is to remove `[StandardBorelSpace Ω]` from statements proved on path space, which is
 standard Borel whenever the state space is.
 -/
@@ -40,7 +54,65 @@ namespace TauCeti
 
 namespace Probability
 
-variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+variable {Ω α β ι : Type*} [MeasurableSpace Ω] [MeasurableSpace α] [MeasurableSpace β]
+
+/-- **Conditional i.i.d.-ness is preserved by a coordinatewise measurable map of the value
+space**, at a named directing measure: if `X` is conditionally i.i.d. with directing measure `ν`,
+then `fun i ω => f (X i ω)` is conditionally i.i.d. with directing measure the pushforward
+`fun ω => (ν ω).map f`.
+
+Unlike its mixture counterpart `MixedIIDWith.map_values`, this moves the joint law of the directing
+measure and a block, so the transported map acts on the tag as well: it is
+`(Q, x) ↦ (Q.map f, f ∘ x)`. -/
+theorem ConditionallyIIDWith.map_values {μ : Measure Ω} {X : ι → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
+    {f : α → β} (hf : Measurable f) :
+    ConditionallyIIDWith μ (fun i ω => f (X i ω)) fun ω => (ν ω).map hf.aemeasurable := by
+  have hmapQ : Measurable fun Q : ProbabilityMeasure α => Q.map hf.aemeasurable :=
+    TauCeti.MeasureTheory.measurable_probabilityMeasure_map hf
+  refine ConditionallyIIDWith.intro (hmapQ.comp h.measurable_directing) fun m k hk => ?_
+  set F : (Fin m → α) → Fin m → β := fun x i => f (x i) with hF
+  have hFmeas : Measurable F := measurable_pi_lambda _ fun i => hf.comp (measurable_pi_apply i)
+  have hΦ : Measurable
+      (Prod.map (fun Q : ProbabilityMeasure α => Q.map hf.aemeasurable) F) :=
+    hmapQ.prodMap hFmeas
+  have hinner : AEMeasurable (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) μ :=
+    h.measurable_directing.aemeasurable.prodMk
+      (aemeasurable_pi_lambda _ fun i => h.aemeasurable (k i))
+  have hK : AEMeasurable (fun ω =>
+      (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) μ :=
+    (TauCeti.MeasureTheory.measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure ν
+      h.measurable_directing).aemeasurable
+  calc μ.map (fun ω => ((ν ω).map hf.aemeasurable, fun i : Fin m => f (X (k i) ω)))
+      = (μ.map fun ω => (ν ω, fun i : Fin m => X (k i) ω)).map
+          (Prod.map (fun Q : ProbabilityMeasure α => Q.map hf.aemeasurable) F) := by
+        rw [AEMeasurable.map_map_of_aemeasurable hΦ.aemeasurable hinner]
+        rfl
+    _ = (μ.bind fun ω => (Measure.dirac (ν ω)).prod
+          (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure).map
+          (Prod.map (fun Q : ProbabilityMeasure α => Q.map hf.aemeasurable) F) := by
+        rw [h.jointLaw_eq_disintegration k hk]
+    _ = μ.bind fun ω => ((Measure.dirac (ν ω)).prod
+          (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure).map
+          (Prod.map (fun Q : ProbabilityMeasure α => Q.map hf.aemeasurable) F) :=
+        TauCeti.MeasureTheory.map_bind hK hΦ
+    _ = μ.bind fun ω => (Measure.dirac ((ν ω).map hf.aemeasurable)).prod
+          (ProbabilityMeasure.pi fun _ : Fin m => (ν ω).map hf.aemeasurable).toMeasure := by
+        refine congrArg (μ.bind ·) (funext fun ω => ?_)
+        have : IsProbabilityMeasure ((ν ω : Measure α).map f) :=
+          (ν ω : Measure α).isProbabilityMeasure_map hf.aemeasurable
+        simp only [ProbabilityMeasure.toMeasure_pi, ProbabilityMeasure.toMeasure_map]
+        rw [← Measure.map_dirac' hmapQ (ν ω),
+          ← Measure.pi_map_pi (f := fun _ : Fin m => f) fun _ => hf.aemeasurable]
+        exact (Measure.map_prod_map _ _ hmapQ hFmeas).symm
+
+/-- **Conditional i.i.d.-ness is preserved by a coordinatewise measurable map of the value
+space.** -/
+theorem ConditionallyIID.map_values {μ : Measure Ω} {X : ι → Ω → α}
+    (h : ConditionallyIID μ X) {f : α → β} (hf : Measurable f) :
+    ConditionallyIID μ fun i ω => f (X i ω) :=
+  let ⟨_, hν⟩ := h.exists_directing
+  ConditionallyIID.of_directing (hν.map_values hf)
 
 /-- **Path-law transfer, at a named directing measure.** If the coordinate process is conditionally
 i.i.d. under the path law of `X` with directing measure `ν`, then `X` is conditionally i.i.d. with

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/PathDisintegration.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/PathDisintegration.lean
@@ -7,6 +7,9 @@ module
 
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Construct
 public import TauCeti.Probability.Exchangeability.JointPathLaw
+-- Non-public: mixing-law uniqueness is used only inside the proof of
+-- `ConditionallyIIDWith.jointPathLaw_eq_of_pathLaw_eq`.
+import TauCeti.Probability.Exchangeability.MixedIID.Mixture
 import TauCeti.MeasureTheory.Measure.GiryMonad
 
 /-!
@@ -19,6 +22,8 @@ measure together with the entire process is the disintegration `∫ δ_{ν ω} �
 ## Main results
 
 * `TauCeti.Probability.ConditionallyIIDWith.jointPathLaw_eq_iidMixtureLaw`
+* `TauCeti.Probability.ConditionallyIIDWith.jointPathLaw_eq_of_pathLaw_eq` — the joint law depends
+  on the process only through its path law.
 
 ## Implementation
 
@@ -107,6 +112,27 @@ theorem ConditionallyIIDWith.jointPathLaw_eq_iidMixtureLaw [IsFiniteMeasure μ]
   rw [← hF, TauCeti.MeasureTheory.bind_map h.measurable_directing.aemeasurable
     hker.aemeasurable]
   rfl
+
+/-- **The joint law of a directing measure and a path is a function of the path law.** Two
+conditionally i.i.d. processes with the same path law — on possibly different sample spaces — have
+directing measures jointly distributed with the path in the same way.
+
+This is the conditional-side companion of `mixedIID_mixingLaw_eq_of_pathLaw_eq`, and is strictly
+stronger than it: the mixing law is the first marginal of the joint law. It fails for a mere
+mixing representative, whose coupling with the path is not determined — an independent copy of a
+directing measure witnesses `MixedIIDWith` with a different joint law.
+
+The proof is the full-path disintegration read twice: each joint law is the canonical two-stage
+law `iidMixtureLaw` of its mixing law, and equal path laws give equal mixing laws. -/
+theorem ConditionallyIIDWith.jointPathLaw_eq_of_pathLaw_eq {Ω' : Type*} [MeasurableSpace Ω']
+    [IsFiniteMeasure μ] {μ' : Measure Ω'} [IsFiniteMeasure μ'] {Y : ℕ → Ω' → α}
+    {ν' : Ω' → ProbabilityMeasure α}
+    (h : ConditionallyIIDWith μ X ν) (h' : ConditionallyIIDWith μ' Y ν')
+    (hpath : pathLaw μ X = pathLaw μ' Y) :
+    jointPathLaw μ X ν = jointPathLaw μ' Y ν' := by
+  rw [h.jointPathLaw_eq_iidMixtureLaw, h'.jointPathLaw_eq_iidMixtureLaw,
+    mixedIID_mixingLaw_eq_of_pathLaw_eq (mixedIIDWith_of_conditionallyIIDWith h)
+      (mixedIIDWith_of_conditionallyIIDWith h') hpath]
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/MixedIID/Map.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Map.lean
@@ -8,6 +8,8 @@ module
 public import TauCeti.Probability.Exchangeability.MixedIID.Basic
 -- Non-public: `map_bind` is used only inside the proof below.
 import TauCeti.MeasureTheory.Measure.GiryMonad
+-- Non-public: the Giry-measurability of a pushforward is used only inside the proof below.
+import TauCeti.MeasureTheory.Measure.Measurability
 
 /-!
 # Coordinatewise maps of mixed i.i.d. families
@@ -57,9 +59,8 @@ theorem MixedIIDWith.map_values {μ : Measure Ω} {X : ι → Ω → α}
     MixedIIDWith μ (fun i ω => f (X i ω)) fun ω => (ν ω).map hf.aemeasurable := by
   refine MixedIIDWith.intro ?_ ?_
   · -- The pushforward mixing representative is measurable in the Giry structure.
-    have hν : Measurable fun ω => (ν ω : Measure α) :=
-      measurable_subtype_coe.comp h.measurable_mixingRepresentative
-    exact ((Measure.measurable_map f hf).comp hν).subtype_mk
+    exact (TauCeti.MeasureTheory.measurable_probabilityMeasure_map hf).comp
+      h.measurable_mixingRepresentative
   · intro m k hk
     have hXk : ∀ i : Fin m, AEMeasurable (X (k i)) μ := fun i => h.aemeasurable (k i)
     have hFmeas : Measurable fun x : Fin m → α => fun i => f (x i) :=

--- a/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
@@ -27,6 +27,7 @@ written in the `Measure.bind` idiom.
 
 * `pathLaw_eq_bind_infinitePi_of_mixedIIDWith` — the representation, for an arbitrary mixing
   representative.
+* `mixedIID_mixingLaw_eq_of_pathLaw_eq` — the mixing law is a function of the path law alone.
 * `mixedIID_mixingLaw_unique` — the mixing law `μ.map ν` is determined by the process.
 * `MixedIID.existsUnique_mixingLaw` — a mixed i.i.d. process under a probability law has a unique
   probability mixing law in the infinite-product representation.
@@ -103,6 +104,26 @@ theorem pathLaw_eq_bind_infinitePi_of_mixedIIDWith {μ : Measure Ω} [IsFiniteMe
         rw [TauCeti.MeasureTheory.bind_map hν hfin]
         rfl
 
+/-- **The mixing law is a function of the path law.** Two mixed i.i.d. processes with the same path
+law — on possibly different sample spaces — have mixing representatives with the same law.
+
+This is the sharp form of mixing-law uniqueness: the mixture representation writes the path law as
+`π.bind (P ↦ P^{⊗ℕ})` for `π = μ.map ν`, and that assignment is injective
+(`Measure.ext_of_bind_infinitePi_eq`), so the path law already determines `π`. Comparing two
+witnesses for one and the same process (`mixedIID_mixingLaw_unique`) is the special case
+`hpath = rfl`. -/
+theorem mixedIID_mixingLaw_eq_of_pathLaw_eq {Ω' : Type*} [MeasurableSpace Ω']
+    {μ : Measure Ω} [IsFiniteMeasure μ] {μ' : Measure Ω'} [IsFiniteMeasure μ']
+    {X : ℕ → Ω → α} {Y : ℕ → Ω' → α}
+    {ν : Ω → ProbabilityMeasure α} {ν' : Ω' → ProbabilityMeasure α}
+    (h : MixedIIDWith μ X ν) (h' : MixedIIDWith μ' Y ν')
+    (hpath : pathLaw μ X = pathLaw μ' Y) :
+    μ.map ν = μ'.map ν' := by
+  have : IsFiniteMeasure (μ.map ν) := Measure.isFiniteMeasure_map _ _
+  refine TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq ?_
+  rw [← pathLaw_eq_bind_infinitePi_of_mixedIIDWith h,
+    ← pathLaw_eq_bind_infinitePi_of_mixedIIDWith h', hpath]
+
 /-- **Uniqueness of the mixing law.** Two mixing representatives for the same process induce the
 same law on `ProbabilityMeasure α`.
 
@@ -121,11 +142,8 @@ measures, and the proof goes through for any finite `μ`. -/
 theorem mixedIID_mixingLaw_unique {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
     {ν ν' : Ω → ProbabilityMeasure α}
     (h : MixedIIDWith μ X ν) (h' : MixedIIDWith μ X ν') :
-    μ.map ν = μ.map ν' := by
-  have : IsFiniteMeasure (μ.map ν) := Measure.isFiniteMeasure_map _ _
-  refine TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq ?_
-  rw [← pathLaw_eq_bind_infinitePi_of_mixedIIDWith h,
-    ← pathLaw_eq_bind_infinitePi_of_mixedIIDWith h']
+    μ.map ν = μ.map ν' :=
+  mixedIID_mixingLaw_eq_of_pathLaw_eq h h' rfl
 
 /-- **Existence and uniqueness of the mixing law.** A mixed i.i.d. process under a probability
 law has a unique probability measure `π` on `ProbabilityMeasure α` such that its path law is


### PR DESCRIPTION
This PR upgrades the symmetry that the row directing measure of a separately exchangeable array inherits from the array's column freedom, moving it from the level of the directing measure's *law* to the level of its *joint law with the array*. `Arrays/MixingLaw.lean` currently records that `μ.map (ω ↦ (ν ω).map (permReindex τ)) = μ.map ν`; that statement forgets how `ν` is coupled to the array, and the coupling is what the next step of the Aldous–Hoover argument needs, since the column randomness of the array is carried by `ν` rather than by the conditionally i.i.d. rows. The new `SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq` states, for all permutations `σ` of the rows and `τ` of the columns, that `Law (ν.map (permReindex τ), (i, j) ↦ X (σ i, τ j)) = Law (ν, (i, j) ↦ X (i, j))`: row permutations leave the directing measure alone, and column permutations push it forward. Its first marginal recovers the existing mixing-law statement at a directing measure and its second marginal recovers separate exchangeability, so both refinements are genuine, and both are needed — the identity fails for a mere mixing representative, an independent copy of a directing measure being another one with a different coupling, and `ν` is almost surely not an exchangeable measure, so the column permutation cannot simply be dropped.

The exact roadmap target is the Layer 8 milestone "exchangeable arrays and the Aldous–Hoover representation" of `TauCetiRoadmap/Exchangeability/README.md`, whose separately exchangeable branch already has the first-level coding representation `SeparatelyExchangeable.exists_arrayLaw_eq_map_unitIntervalCoding` (`Arrays/Coding.lean`) writing `X (i, j) =ᵈ f P (ϑ i) j`. What remains after this PR is Aldous's second level: resolving the coded row into per-column and per-cell randomness, which is what the coupled column symmetry supplied here is the input to; the array-symmetry milestone as a whole then still needs the transfer of that resolution back to the whole array.

`TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean` is new (285 lines) and carries the array statements: the row-process-level identity `SeparatelyExchangeable.jointPathLaw_arrayRow_pairReindex_eq`, the array-level `…jointLaw_arrayRow_pairReindex_eq` with its two axes split off as `…jointLaw_arrayRow_rowReindex_eq` and `…jointLaw_arrayRow_colReindex_eq`, the existential form `SeparatelyExchangeable.exists_directing_arrayRow_jointLaw_equivariant` in which de Finetti supplies the directing measure, and the transposed statements for the column directing measure. Since `arrayRow` and `arrayCol` are ordinary definitions rather than reducible abbreviations, the proofs normalise them away through their `@[simp]` evaluation lemmas instead of unfolding.

Three supporting general results are added along the way, each of independent use. `mixedIID_mixingLaw_eq_of_pathLaw_eq` (`MixedIID/Mixture.lean`) says the mixing law is a function of the path law alone, on possibly different sample spaces; the existing `mixedIID_mixingLaw_unique`, which the roadmap names as a Layer 6 milestone, becomes its `rfl` special case. `ConditionallyIIDWith.jointPathLaw_eq_of_pathLaw_eq` (`ConditionallyIID/PathDisintegration.lean`) is its conditional-side companion and the engine of this PR: reading the full-path disintegration twice shows equal path laws force equal joint laws of the directing measure and the path. `ConditionallyIIDWith.map_values` and `ConditionallyIID.map_values` (`ConditionallyIID/Map.lean`) close the conditional predicate under a coordinatewise measurable map of the value space, the conditional counterpart of the existing `MixedIIDWith.map_values` and the last member of the Layer 0 closure family the roadmap asks for; unlike the mixture version it has to transport the whole disintegration identity along `(Q, x) ↦ (Q.map f, f ∘ x)`. Finally `TauCeti.MeasureTheory.measurable_probabilityMeasure_map` (`MeasureTheory/Measure/Measurability.lean`) names the Giry-measurability of a fixed pushforward on `ProbabilityMeasure`, which `MixedIIDWith.map_values` had been building inline and now reuses.

No Mathlib infrastructure is vendored; the proofs consume Mathlib's `Measure.map_prod_map`, `Measure.map_dirac'` and `Measure.pi_map_pi` directly. No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable sequences rather than exchangeable arrays. The mathematics follows Aldous, "Representations for partially exchangeable arrays of random variables" (1981), and Kallenberg, *Probabilistic Symmetries and Invariance Principles* (2005), Chapter 7, both already cited in the array modules.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"arrayrow-directing-measure-joint-equivariance"}-->

🤖 Prepared with Claude Code