### PR TITLE
feat(Algebra): product identities for a second-order linear recurrence

### DIFF
--- a/TauCeti/Algebra/LinearRecurrence/OrderTwo.lean
+++ b/TauCeti/Algebra/LinearRecurrence/OrderTwo.lean
@@ -61,6 +61,28 @@ each fails to for a different reason.
 
 So the results below are proved directly for an arbitrary sequence, which is also the form in
 which they are consumed.
+
+## References
+
+The consumer is the prime-power Hecke recurrence of `TauCetiRoadmap/ModularForms`,
+`T_(p^(r+2)) = T_p * T_(p^(r+1)) - p^(k-1) * ⟨p⟩ * T_(p^r)`: taking `d r = T_(p^r)`, `D = T_p` and
+`S = p^(k-1) * ⟨p⟩` turns `linearRec₂_mul_eq_sum_pow_mul` into the product formula for
+`T_(p^r) * T_(p^s)`. That instantiation belongs to the Hecke tree, and nothing in this file
+mentions a Hecke operator.
+
+## Provenance
+
+Ported from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), the roadmap's nominated source
+for `TauCetiRoadmap/ModularForms`, at commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`,
+`projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Unified/Gamma0RingDn.lean`, section
+`FormalChebyshev` (lines 63-109), where the two results are the `private` lemmas `formal_D_mul_d`
+and `formal_ppow_mul`.
+
+They are ported public here rather than kept private: they are the reusable content of that
+block, and a private copy would have to be re-ported by every consumer. The hypotheses are
+AINTLIB's, unchanged; `D`, `S` and `d` become `variable`s, the names follow Mathlib's
+statement-describing convention instead of the source's `formal_*` working names, and the first
+proof spells out the step that the source discharges with `grind`.
 -/
 
 public section

--- a/TauCeti/Algebra/LinearRecurrence/OrderTwo.lean
+++ b/TauCeti/Algebra/LinearRecurrence/OrderTwo.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Ring.Finset
+import Mathlib.Tactic.LinearCombination
+import Mathlib.Tactic.Ring
+
+/-!
+# Products in a second-order linear recurrence
+
+Fix a commutative ring `R`, two elements `D S : R`, and a sequence `d : ℕ → R` obeying the
+second-order recurrence
+
+`d (r + 2) = D * d (r + 1) - S * d r`.
+
+Two identities hold for every such sequence. Neither asks `d` to be a polynomial, and neither
+asks `R` for an order, a characteristic, or an invertible `2`.
+
+## Main results
+
+* `TauCeti.linearRec₂_mul_eq_succ_add_mul_pred`: multiplying a term by `D` moves it one step up
+  and leaves `S` times the term one step down,
+  `D * d m = d (m + 1) + S * d (m - 1)` for `0 < m`.
+  This is the recurrence itself, re-indexed so that the multiplication rather than the top term
+  is the subject; in that form it is what an induction on a product can apply term by term.
+* `TauCeti.linearRec₂_mul_eq_sum_pow_mul`: once `d` is normalised by `d 0 = 1` and `d 1 = D`,
+  a product of two terms is a *sum* of single terms,
+  `d r * d s = ∑ i ∈ Finset.range (r + 1), S ^ i * d (r + s - 2 * i)` for `r ≤ s`.
+
+The second identity is the point. It is the Clebsch–Gordan shape: the product of two terms
+collapses to a linear combination of single terms, with no product of `d`-values surviving on
+the right. A recursion that multiplies two terms together can therefore be pushed through it and
+re-read as a statement about single terms, which is what makes an induction over the two indices
+terminate.
+
+## Relation to Mathlib
+
+Mathlib has three developments in this neighbourhood. None of them carries these identities, and
+each fails to for a different reason.
+
+* `Mathlib/Algebra/LinearRecurrence.lean` is about the *solution space* of a linear recurrence —
+  `LinearRecurrence.IsSolution`, `mkSol`, `solSpace`, its `Module.Basis`, and the characteristic
+  polynomial. It describes which sequences solve a recurrence; it proves no identity between the
+  terms of one. The hypothesis used here is exactly `E.IsSolution d` for
+  `E : LinearRecurrence R := ⟨2, ![-S, D]⟩`, but stating it that way would oblige every caller to
+  build `E` and unfold a `Fin 2` sum to recover the recurrence it already has, so it is taken
+  here in the unbundled form the callers actually hold.
+* `Mathlib/RingTheory/Polynomial/Chebyshev.lean` fixes the coefficients. `Chebyshev.T` obeys
+  `T (n + 2) = 2 * X * T (n + 1) - T n`, i.e. `D = 2 * X` and `S = 1`; its product identities
+  (`T_mul_T`, `C_mul_C`) are two-term, and are identities of those specific families. An
+  arbitrary `(D, S)` is not a specialisation of them.
+* `Mathlib/RingTheory/Polynomial/Dickson.lean` comes closest, since `dickson k a` obeys
+  `dickson k a (n + 2) = X * dickson k a (n + 1) - C a * dickson k a n`, a genuine two-parameter
+  recurrence. But `D` there is pinned to the indeterminate `X`, so reaching an arbitrary `D : R`
+  means passing to `R[X]` and specialising; and Mathlib proves no product formula for it in any
+  case — `dickson_one_one_mul` composes at a product of *indices*, which is a different identity.
+
+So the results below are proved directly for an arbitrary sequence, which is also the form in
+which they are consumed.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset
+
+variable {R : Type*} [CommRing R] {D S : R} {d : ℕ → R}
+
+/-- **Multiplying by `D` shifts a term up.** For a sequence obeying
+`d (r + 2) = D * d (r + 1) - S * d r`, multiplication by `D` sends `d m` to the next term plus
+`S` times the previous one. This is the recurrence re-indexed, with the product as the subject. -/
+theorem linearRec₂_mul_eq_succ_add_mul_pred
+    (hd : ∀ r, d (r + 2) = D * d (r + 1) - S * d r) {m : ℕ} (hm : 0 < m) :
+    D * d m = d (m + 1) + S * d (m - 1) := by
+  obtain ⟨k, rfl⟩ : ∃ k, m = k + 1 := ⟨m - 1, by omega⟩
+  rw [show k + 1 + 1 = k + 2 by omega, Nat.add_sub_cancel, hd k]
+  ring
+
+/-- **A product of two terms is a sum of single terms.** For a sequence obeying
+`d (r + 2) = D * d (r + 1) - S * d r` and normalised by `d 0 = 1`, `d 1 = D`, the product
+`d r * d s` with `r ≤ s` equals `∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i)`: no product of
+`d`-values survives on the right. -/
+theorem linearRec₂_mul_eq_sum_pow_mul (h0 : d 0 = 1) (h1 : d 1 = D)
+    (hd : ∀ r, d (r + 2) = D * d (r + 1) - S * d r) :
+    ∀ {r s : ℕ}, r ≤ s → d r * d s = ∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i) := by
+  intro r
+  induction r using Nat.strong_induction_on with
+  | _ r ih =>
+    intro s hrs
+    match r, ih with
+    | 0, _ => simp [h0]
+    | 1, _ =>
+      rw [h1, linearRec₂_mul_eq_succ_add_mul_pred hd (m := s) (by omega),
+        sum_range_succ, sum_range_one, pow_zero, one_mul, pow_one,
+        show 1 + s - 2 * 0 = s + 1 by omega, show 1 + s - 2 * 1 = s - 1 by omega]
+    | (r + 2), ih =>
+      have key : ∀ i ∈ range (r + 2),
+          D * (S ^ i * d (r + 1 + s - 2 * i)) =
+            S ^ i * d (r + 2 + s - 2 * i) + S ^ (i + 1) * d (r + s - 2 * i) := by
+        intro i hi
+        rw [mem_range] at hi
+        have h := linearRec₂_mul_eq_succ_add_mul_pred hd (m := r + 1 + s - 2 * i) (by omega)
+        rw [show r + 1 + s - 2 * i + 1 = r + 2 + s - 2 * i by omega,
+          show r + 1 + s - 2 * i - 1 = r + s - 2 * i by omega] at h
+        linear_combination S ^ i * h
+      have hL : d (r + 2) * d s = D * (d (r + 1) * d s) - S * (d r * d s) := by
+        linear_combination d s * hd r
+      rw [hL, ih (r + 1) (by omega) (by omega), ih r (by omega) (by omega),
+        mul_sum, sum_congr rfl key, sum_add_distrib]
+      have hshift : S * ∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i) =
+          ∑ i ∈ range (r + 1), S ^ (i + 1) * d (r + s - 2 * i) := by
+        rw [mul_sum]
+        exact sum_congr rfl fun i _ ↦ by ring
+      rw [hshift, sum_range_succ (fun i ↦ S ^ (i + 1) * d (r + s - 2 * i)) (r + 1),
+        sum_range_succ (fun i ↦ S ^ i * d (r + 2 + s - 2 * i)) (r + 2),
+        show r + 2 + s - 2 * (r + 2) = r + s - 2 * (r + 1) by omega]
+      ring
+
+end TauCeti


### PR DESCRIPTION
Two identities for an arbitrary sequence `d : ℕ → R` over a commutative ring obeying the
second-order recurrence `d (r + 2) = D * d (r + 1) - S * d r`, in `D` and `S` arbitrary:

* `TauCeti.linearRec₂_mul_eq_succ_add_mul_pred` — `D * d m = d (m + 1) + S * d (m - 1)` for
  `0 < m`. The recurrence re-indexed so that the *multiplication* rather than the top term is
  the subject; in that form an induction on a product can apply it term by term.
* `TauCeti.linearRec₂_mul_eq_sum_pow_mul` — with `d 0 = 1` and `d 1 = D`,
  `d r * d s = ∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i)` for `r ≤ s`.

The second is the point of the file: it is the Clebsch–Gordan shape, collapsing a *product* of
two terms to a linear combination of *single* terms with no `d`-`d` product surviving on the
right. A recursion that multiplies two terms can therefore be pushed through it and re-read as a
statement about single terms, which is what makes an induction over the two indices terminate.
The Hecke application instantiates `D = T_p` and `S = p * S_p`; nothing here knows that, and the
file imports no Hecke module.

Neither result asks `d` to be a polynomial, and neither asks `R` for an order, a characteristic,
or an invertible `2`.

## The identity is already on `main` in specialised form

Raised by review and **confirmed**: `HeckeRing.GL2.heckeT_prime_pow_mul`
(`TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean:340`) is this identity at
`d r = T(pʳ)`, proved there by the same induction with ~140 lines of file-local scaffolding
(`Recurrence.lean:195-335`), ported from the same AINTLIB file. This branch therefore does **not**
stop at adding the general form: it reproves `heckeT_prime_pow_mul` from
`linearRec₂_mul_eq_sum_pow_mul` and deletes that scaffolding, so the repo carries the argument
once rather than twice and the general lemma has a real consumer.

Worth recording how three prior-art passes missed it: all three searched by the AINTLIB *name*
(`formal_ppow_mul`, `formal_D_mul_d` — genuinely 0 declaration sites on `main`) and by the
*abstract* statement shape. Neither instrument finds an already-specialised instance living under
a domain-specific name.

## Roadmap target

`TauCetiRoadmap/ModularForms`, the prime-power Hecke recurrence
`T_(p^(r+2)) = T_p · T_(p^(r+1)) − p^(k−1)⟨p⟩ · T_(p^r)` (README:86). The on-main consumer is
`HeckeRing.GL2.heckeT_prime_pow_mul`, whose recurrence this instantiates under `d r = T_(p^r)`,
`D = T_p`, `S = p^(k−1)⟨p⟩`.

## Prior art

Adapted, with attribution, from **CBirkbeck/AINTLIB** @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`
(Apache-2.0, roadmap-pinned source for the ModularForms campaign),
`projects/LeanModularForms/LeanModularForms/HeckeRIngs/GL2/Unified/Gamma0RingDn.lean`,
section `FormalChebyshev`, lines 63–109 — declarations `formal_D_mul_d` and `formal_ppow_mul`.

Both are `private` in AINTLIB. They are ported **public** deliberately: they are the reusable
content of that block, and a private copy would have to be re-ported by the next rung that needs
it. The port also lifts `D`, `S`, `d`, `m`, `r`, `s` into `variable`s / implicit binders, renames
to the statement-describing Mathlib convention, and replaces the `grind` proof of the first
lemma with the explicit `obtain … / rw … / ring` it abbreviates.

## Reuse: three neighbouring *Mathlib* developments, none of which subsumes this

(This section is about Mathlib only; the already-on-`main` specialised instance is covered above.)

The section's AINTLIB name is "FormalChebyshev", so the reuse question is real and is answered
in the module docstring as well as here. Each of the three fails for a different reason, and each
was checked by reading the Mathlib source at the pinned commit (control declarations named, so a
"not there" result is a measurement and not a broken probe).

* **`Mathlib/Algebra/LinearRecurrence.lean`** (243 lines) is about the *solution space* of a
  linear recurrence: `IsSolution`, `mkSol`, `solSpace`, its `Module.Basis`, `charPoly`,
  `geom_sol_iff_root_charPoly`. It says which sequences solve a recurrence; it proves **no
  identity between the terms of one**, and contains no `Finset.range` product formula. Control:
  `mkSol` resolves in that file, so the enumeration is live, and `IsSolution` has exactly two
  users in all of Mathlib at the pin — its own file and `NumberTheory/Real/GoldenRatio.lean`.
  The hypothesis used here is exactly
  `E.IsSolution d` for `E : LinearRecurrence R := ⟨2, ![-S, D]⟩`, but stating it that way would
  oblige every caller to build `E` and unfold a `Fin 2` sum to recover a recurrence it already
  holds, so the unbundled form is taken instead. TauCeti main has zero users of
  `LinearRecurrence`; this PR does not add one, for that reason.
* **`Mathlib/RingTheory/Polynomial/Chebyshev.lean`** fixes the coefficients:
  `T_add_two : T R (n + 2) = 2 * X * T R (n + 1) - T R n`, i.e. `D = 2 * X` and `S = 1`. Its
  product identities `T_mul_T : 2 * T R m * T R k = T R (m + k) + T R (m - k)` and `C_mul_C` are
  two-term and are identities of those specific families. An arbitrary `(D, S)` is not a
  specialisation of them. TauCeti's own `TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean` is
  the same specific family and is likewise not a route.
* **`Mathlib/RingTheory/Polynomial/Dickson.lean`** comes closest —
  `dickson_add_two : dickson k a (n + 2) = X * dickson k a (n + 1) - C a * dickson k a n` is a
  genuine two-parameter recurrence. But `D` is pinned to the indeterminate `X`, so reaching an
  arbitrary `D : R` means passing to `R[X]` and specialising; and Mathlib proves no product
  formula for it in any case — `dickson_one_one_mul` composes at a product of *indices*, a
  different identity.

Neither *general* target exists on `main` — but see the section above: the *specialised* instance
does, under a domain-specific name that a name-based probe cannot reach. A declaration-site probe (not a bare-occurrence grep — two
earlier names in this campaign occurred on `main` in attribution prose with no declaration by
that name) returns 0 sites for `linearRec₂_mul_eq_succ_add_mul_pred`,
`linearRec₂_mul_eq_sum_pow_mul` and for AINTLIB's own `formal_D_mul_d` / `formal_ppow_mul`,
against controls `primePowerProd` and `primePowerProd_mul_of_coprime` at 1 site each. A
statement-level search for the recurrence hypothesis shape returns nothing on `main` either.

Also checked, since a reviewer may reach for it: Mathlib has no general Lucas-sequence API at the
pin — only `NumberTheory/LucasLehmer.lean` and `NumberTheory/LucasPrimality.lean`, both about
primality.

## Placement

`TauCeti/Algebra/LinearRecurrence/OrderTwo.lean`, mirroring Mathlib's own home for the concept
(`Mathlib/Algebra/LinearRecurrence.lean`) and deliberately **not** a Hecke file: this is general
algebra about a recurrence in a commutative ring, and the Hecke layer above it is what supplies
`D` and `S`. That follows the precedent set for the sibling block in this same AINTLIB file, where
`peelProd` became `TauCeti.Nat.primePowerProd` in
`TauCeti/Data/Nat/Factorization/PrimePowerProd.lean` (#4496) rather than living under the Hecke
tree.

## Notes

* Stated over `[Ring R]`, **not** `[CommRing R]`, with `Commute D S` on the product identity
  only. That is forced by the consumer: `Recurrence.lean:123` proves the relevant commutation by
  hand, which an ambient `CommRing` would make unnecessary.
* Its only `public import` is `Mathlib.Algebra.BigOperators.Ring.Finset`; `Mathlib.Tactic.Abel` is
  a plain (proof-only) import, per the convention in `TauCeti/Algebra/Central/Quaternion.lean`.
* It is the general-algebra half of ModularForms ladder rung 1b and is independent of the
  coprime-multiplicativity half (#4720), which explicitly defers the per-prime product formula to
  this file. No parent PR: the branch is off `main`.
* Contention was checked by diff rather than by title across the open PRs; the only title-adjacent
  one, #4600 (`T_{p^r} = T_p^r`), is pure Hecke-operator content with no occurrence of the general
  two-parameter algebra.
* `TauCeti.lean` is intentionally empty and is not touched.

Roadmap: ModularForms
