### PR TITLE
feat(Spa): the converse half of Wedhorn Corollary 7.53, and the iff

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
@@ -61,16 +61,38 @@ theorem exists_mem_spa_supp_eq (Aplus : Subring A) (𝔭 : Ideal A) [𝔭.IsPrim
       (Or.inr ((Ideal.ne_top_iff_one 𝔭).mp ‹𝔭.IsPrime›.ne_top))
   · rw [← suppFun_asIdeal, suppFun_trivialSection]
 
+/-- **The converse half of Wedhorn Corollary 7.53.** If every maximal ideal of `A` is open and
+every point of `Spa(A, A⁺)` is nonzero on some member of `T`, then `T` generates the unit ideal.
+
+Contrapositive of Proposition 7.51: were `T` not to generate, it would lie in a maximal ideal,
+which is open by hypothesis and hence the support of a point — and that point would vanish on
+every member of `T`.
+
+Wedhorn states this for a complete affinoid ring, where every maximal ideal is automatically
+open; the openness hypothesis is what replaces completeness here, matching the generality the
+forward half already has in
+`TauCeti.ValuationSpectrum.mem_rationalSubset_of_span_eq_top_of_mem_spa`. -/
+theorem span_eq_top_of_forall_mem_spa_exists_not_vle_zero (Aplus : Subring A)
+    (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {T : Finset A}
+    (h : ∀ v ∈ spa Aplus, ∃ t ∈ T, ¬ v.toValuativeRel.vle t 0) :
+    Ideal.span (T : Set A) = ⊤ := by
+  by_contra hne
+  obtain ⟨𝔪, h𝔪, hle⟩ := Ideal.exists_le_maximal _ hne
+  obtain ⟨v, hv, rfl⟩ := exists_mem_spa_supp_eq Aplus 𝔪 (hmax 𝔪 h𝔪)
+  obtain ⟨t, ht, hvt⟩ := h v hv
+  exact hvt ((mem_supp_iff v t).mp (hle (Ideal.subset_span ht)))
+
 /-- **Proposition 7.52(2)**: if every maximal ideal of `A` is open and no point of
-`Spa(A, A⁺)` vanishes on `f`, then `f` is a unit — a non-unit lies in a maximal ideal, which is
-the support of a point by Proposition 7.51. -/
+`Spa(A, A⁺)` vanishes on `f`, then `f` is a unit.
+
+This is the singleton case of `span_eq_top_of_forall_mem_spa_exists_not_vle_zero`: the argument
+is the same contrapositive of Proposition 7.51, so it is derived rather than repeated. -/
 theorem isUnit_of_forall_not_vle_zero (Aplus : Subring A)
     (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {f : A}
     (h : ∀ v ∈ spa Aplus, ¬ v.toValuativeRel.vle f 0) : IsUnit f := by
-  by_contra hf
-  obtain ⟨𝔪, h𝔪, hf𝔪⟩ := exists_max_ideal_of_mem_nonunits hf
-  obtain ⟨v, hv, rfl⟩ := exists_mem_spa_supp_eq Aplus 𝔪 (hmax 𝔪 h𝔪)
-  exact h v hv ((mem_supp_iff v f).mp hf𝔪)
+  rw [← Ideal.span_singleton_eq_top]
+  simpa using span_eq_top_of_forall_mem_spa_exists_not_vle_zero Aplus hmax
+    (T := {f}) fun v hv ↦ ⟨f, Finset.mem_singleton_self f, h v hv⟩
 
 end
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
@@ -27,6 +27,9 @@ it is supplied by `Ideal.isOpen_of_isMaximal_of_isOpen_isTopologicallyNilpotent`
   is the support of a point of the adic spectrum.
 * `TauCeti.ValuationSpectrum.isUnit_of_forall_not_vle_zero` : Proposition 7.52(2) — if no point
   of `Spa(A, A⁺)` vanishes on `f`, then `f` is a unit.
+* `TauCeti.ValuationSpectrum.span_eq_top_of_forall_mem_spa_exists_not_vle_zero` : the converse
+  half of Corollary 7.53 — if every point of `Spa(A, A⁺)` is nonzero somewhere on `T`, then `T`
+  generates the unit ideal.
 
 ## Provenance
 
@@ -64,18 +67,15 @@ theorem exists_mem_spa_supp_eq (Aplus : Subring A) (𝔭 : Ideal A) [𝔭.IsPrim
 /-- **The converse half of Wedhorn Corollary 7.53.** If every maximal ideal of `A` is open and
 every point of `Spa(A, A⁺)` is nonzero on some member of `T`, then `T` generates the unit ideal.
 
-Contrapositive of Proposition 7.51: were `T` not to generate, it would lie in a maximal ideal,
-which is open by hypothesis and hence the support of a point — and that point would vanish on
-every member of `T`.
-
 Wedhorn states this for a complete affinoid ring, where every maximal ideal is automatically
 open; the openness hypothesis is what replaces completeness here, matching the generality the
 forward half already has in
-`TauCeti.ValuationSpectrum.mem_rationalSubset_of_span_eq_top_of_mem_spa`. -/
+`TauCeti.ValuationSpectrum.mem_rationalSubset_of_span_eq_top_of_mem_spa`. `T` is an arbitrary
+set: finiteness plays no part, and enters only in the rational-cover corollary. -/
 theorem span_eq_top_of_forall_mem_spa_exists_not_vle_zero (Aplus : Subring A)
-    (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {T : Finset A}
+    (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {T : Set A}
     (h : ∀ v ∈ spa Aplus, ∃ t ∈ T, ¬ v.toValuativeRel.vle t 0) :
-    Ideal.span (T : Set A) = ⊤ := by
+    Ideal.span T = ⊤ := by
   by_contra hne
   obtain ⟨𝔪, h𝔪, hle⟩ := Ideal.exists_le_maximal _ hne
   obtain ⟨v, hv, rfl⟩ := exists_mem_spa_supp_eq Aplus 𝔪 (hmax 𝔪 h𝔪)
@@ -85,14 +85,14 @@ theorem span_eq_top_of_forall_mem_spa_exists_not_vle_zero (Aplus : Subring A)
 /-- **Proposition 7.52(2)**: if every maximal ideal of `A` is open and no point of
 `Spa(A, A⁺)` vanishes on `f`, then `f` is a unit.
 
-This is the singleton case of `span_eq_top_of_forall_mem_spa_exists_not_vle_zero`: the argument
-is the same contrapositive of Proposition 7.51, so it is derived rather than repeated. -/
+Wedhorn states this for a complete affinoid ring; as with the converse above, openness of the
+maximal ideals is what replaces completeness. -/
 theorem isUnit_of_forall_not_vle_zero (Aplus : Subring A)
     (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {f : A}
     (h : ∀ v ∈ spa Aplus, ¬ v.toValuativeRel.vle f 0) : IsUnit f := by
   rw [← Ideal.span_singleton_eq_top]
   simpa using span_eq_top_of_forall_mem_spa_exists_not_vle_zero Aplus hmax
-    (T := {f}) fun v hv ↦ ⟨f, Finset.mem_singleton_self f, h v hv⟩
+    (T := {f}) fun v hv ↦ ⟨f, Set.mem_singleton f, h v hv⟩
 
 end
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -86,6 +86,11 @@ layer deferred above.
 * `TauCeti.ValuationSpectrum.spa_eq_biUnion_rationalSubset_of_span_eq_top` : a finite set
   generating the unit ideal gives a standard rational cover, the forward implication of
   Corollary 7.53.
+* `TauCeti.ValuationSpectrum.span_eq_top_iff_forall_mem_spa_exists_not_vle_zero` : Corollary 7.53
+  in pointwise form — `T` generates the unit ideal exactly when no point vanishes on all of it.
+* `TauCeti.ValuationSpectrum.span_eq_top_iff_spa_eq_biUnion_rationalSubset` : Corollary 7.53 as
+  the roadmap states it — generating the unit ideal is equivalent to the standard family being a
+  cover. Only the `←` directions need the maximal ideals of `A` to be open.
 
 ## References
 
@@ -322,8 +327,23 @@ than this iff, so as not to acquire `hmax` for nothing. -/
 theorem span_eq_top_iff_forall_mem_spa_exists_not_vle_zero (Aplus : Subring A)
     (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {T : Finset A} :
     Ideal.span (T : Set A) = ⊤ ↔ ∀ v ∈ spa Aplus, ∃ t ∈ T, ¬ v.toValuativeRel.vle t 0 := by
-  refine ⟨fun hT v hv ↦ ?_, span_eq_top_of_forall_mem_spa_exists_not_vle_zero Aplus hmax⟩
+  refine ⟨fun hT v hv ↦ ?_,
+    fun h ↦ span_eq_top_of_forall_mem_spa_exists_not_vle_zero Aplus hmax (T := (T : Set A)) h⟩
   obtain ⟨s, hs, hmem⟩ := mem_rationalSubset_of_span_eq_top_of_mem_spa Aplus hT hv
+  exact ⟨s, hs, ((mem_rationalSubset_iff Aplus T s v).mp hmem).2.2⟩
+
+/-- **Wedhorn Corollary 7.53, in the form the roadmap states it.** A finite set `T` generates the
+unit ideal exactly when the standard family `(R(T/t))_{t ∈ T}` covers `Spa(A, A⁺)`.
+
+The `→` direction is `spa_eq_biUnion_rationalSubset_of_span_eq_top` and needs no hypothesis on
+`A`; only `←` uses `hmax`, so a consumer who already has `Ideal.span T = ⊤` should take the cover
+from that lemma directly rather than through this iff. -/
+theorem span_eq_top_iff_spa_eq_biUnion_rationalSubset (Aplus : Subring A)
+    (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {T : Finset A} :
+    Ideal.span (T : Set A) = ⊤ ↔ spa Aplus = ⋃ t ∈ T, rationalSubset Aplus T t := by
+  refine ⟨spa_eq_biUnion_rationalSubset_of_span_eq_top Aplus, fun hcov ↦ ?_⟩
+  refine (span_eq_top_iff_forall_mem_spa_exists_not_vle_zero Aplus hmax).mpr fun v hv ↦ ?_
+  obtain ⟨s, hs, hmem⟩ := Set.mem_iUnion₂.mp (hcov ▸ hv)
   exact ⟨s, hs, ((mem_rationalSubset_iff Aplus T s v).mp hmem).2.2⟩
 
 end TauCeti.ValuationSpectrum

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/RationalSubset/Basic.lean
@@ -7,6 +7,7 @@ module
 
 import TauCeti.RingTheory.Valuation.CofinalIdeal.Greatest
 public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Basic
+public import TauCeti.AlgebraicGeometry.AdicSpace.Spa.Points
 
 /-!
 # Rational subsets of the adic spectrum
@@ -307,6 +308,23 @@ theorem spa_eq_biUnion_rationalSubset_of_span_eq_top (Aplus : Subring A) {T : Fi
     obtain ⟨s, hs, hmem⟩ := mem_rationalSubset_of_span_eq_top_of_mem_spa Aplus hT hv
     exact Set.mem_iUnion₂_of_mem hs hmem
   · exact Set.iUnion₂_subset fun t _ ↦ rationalSubset_subset_spa Aplus T t
+
+/-- **Wedhorn Corollary 7.53.** A finite set `T` generates the unit ideal exactly when no point
+of `Spa(A, A⁺)` vanishes on all of it. Combined with
+`spa_eq_biUnion_rationalSubset_of_span_eq_top`, this is what makes the standard family
+`(R(T/t))_{t ∈ T}` an open *covering* rather than merely a family.
+
+Wedhorn assumes a complete affinoid ring, where every maximal ideal is open. Here that is the
+explicit hypothesis `hmax`, and only the `←` direction uses it: the forward direction is
+`mem_rationalSubset_of_span_eq_top_of_mem_spa`, which holds over an arbitrary commutative ring.
+A consumer who has `Ideal.span T = ⊤` and wants the cover should use that lemma directly rather
+than this iff, so as not to acquire `hmax` for nothing. -/
+theorem span_eq_top_iff_forall_mem_spa_exists_not_vle_zero (Aplus : Subring A)
+    (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {T : Finset A} :
+    Ideal.span (T : Set A) = ⊤ ↔ ∀ v ∈ spa Aplus, ∃ t ∈ T, ¬ v.toValuativeRel.vle t 0 := by
+  refine ⟨fun hT v hv ↦ ?_, span_eq_top_of_forall_mem_spa_exists_not_vle_zero Aplus hmax⟩
+  obtain ⟨s, hs, hmem⟩ := mem_rationalSubset_of_span_eq_top_of_mem_spa Aplus hT hv
+  exact ⟨s, hs, ((mem_rationalSubset_iff Aplus T s v).mp hmem).2.2⟩
 
 end TauCeti.ValuationSpectrum
 


### PR DESCRIPTION
Wedhorn's Corollary 7.53 has only its forward half on `main`. This adds the converse and packages the two as the iff a consumer actually wants: a finite set generates the unit ideal **exactly when** no point of `Spa(A, A⁺)` vanishes on all of it. That is what makes the standard family `(R(T/t))_{t ∈ T}` an open *covering* rather than merely a family.

* `span_eq_top_of_forall_mem_spa_exists_not_vle_zero` (`Spa/Points.lean`) — the missing direction, by contraposition of Proposition 7.51: were `T` not to generate, it would lie in a maximal ideal, which is open by hypothesis and hence the support of a point, and that point would vanish on all of `T`.
* `span_eq_top_iff_forall_mem_spa_exists_not_vle_zero` (`Spa/RationalSubset/Basic.lean`) — Corollary 7.53 itself, with the existing forward lemma supplying `→`.

Bead: `tc-a9ac0`.

## Roadmap

Roadmap: AdicSpaces

`TauCetiRoadmap/AdicSpaces/README.md`, Layer 2.2 "Rational subsets", under "Add the following useful results":

> **Corollary 7.53**: if `T` is a finite subset of a complete Hausdorff affinoid ring, then `T` generates the unit ideal if and only if the standard family `(R(T/t))_{t ∈ T}` covers `Spa(A,A⁺)`.

## Source

T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Corollary 7.53 and its proof. This is an assembly over declarations already on `main`, not a port of foreign Lean.

## Generality: openness in place of completeness

Wedhorn assumes a complete affinoid ring, where every maximal ideal is automatically open. Following what `main` already did for the forward half — whose docstrings say "Generalization of the forward implication of Wedhorn Corollary 7.53" — the converse takes the openness of maximal ideals as an explicit hypothesis instead, so the result holds over an arbitrary commutative ring with a subring `A⁺`.

The two directions do **not** have the same hypotheses, and that asymmetry is deliberate:

* the forward direction needs nothing beyond a commutative ring, and remains available as `mem_rationalSubset_of_span_eq_top_of_mem_spa`;
* only the converse needs `hmax`.

So the iff carries `hmax`, and its docstring tells a consumer holding `Ideal.span T = ⊤` to use the forward lemma directly rather than acquire `hmax` for nothing.

## Reuse: Proposition 7.52(2) is now derived, not repeated

`isUnit_of_forall_not_vle_zero` (Prop 7.52(2)) was proved by exactly this contrapositive for the singleton set. Rather than ship a second copy of that argument, it is now **derived** from the new general statement via `Ideal.span_singleton_eq_top`. Net effect: one proof of the argument where there were about to be two, and the existing theorem's statement is unchanged, so its consumers are untouched.

## Prior art / dedupe

Measured against current `main` and the pinned Mathlib, with a positive control:

| object | `main` | note |
|---|---|---|
| `span_eq_top_of_forall_mem_spa_exists_not_vle_zero` | 0 | the target |
| `span_eq_top_iff_forall_mem_spa_exists_not_vle_zero` | 0 | the target |
| `exists_mem_spa_supp_eq` (Prop 7.51) | 1 | present — consumed, not rebuilt |
| `mem_rationalSubset_of_span_eq_top_of_mem_spa` | 1 | present — supplies `→` |
| `spa_eq_biUnion_rationalSubset_of_span_eq_top` | 2 | present — the cover form |

Control: `rationalSubset` = 13 files on `main`, so the instrument fires.

The diff was also run through the three duplication classes this campaign has surfaced: it declares **no** instances, **no** defs or abbrevs, and uses **no** transport-along-an-equality API. For the supporting-lemma class — searching by the *object* rather than the name — the search found Prop 7.52(2), which is why it is derived above rather than duplicated.

## Gates

`lake build` of both changed modules is green, 0 errors, 0 warnings. `scripts/lint-env.sh` is not run locally: it generates a driver importing every `TauCeti` module, i.e. a full-library build; CI's `pr-build` covers it.
