### PR TITLE
feat: identify the maximal candidate conormal

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -234,6 +234,7 @@ theorem ker_quotientCotangentMap (I : HopfIdeal k H) :
 
 /-- A closed subgroup has zero conormal space at the identity exactly when every element of its
 defining ideal vanishes to second order there. -/
+@[simp]
 theorem conormalSubspace_eq_bot_iff_toIdeal_le_sq_augmentationIdeal
     (I : HopfIdeal k H) :
     conormalSubspace I = ⊥ ↔
@@ -254,8 +255,8 @@ theorem conormalSubspace_eq_bot_iff_toIdeal_le_sq_augmentationIdeal
     obtain ⟨x, hx, rfl⟩ := (mem_conormalSubspace_iff I y).1 hy
     let x' : Bialgebra.AugmentationIdeal k H :=
       ⟨x, toIdeal_le_augmentationIdeal I hx⟩
-    change Bialgebra.cotangentMap k H (x' : H) = 0
-    rw [Bialgebra.cotangentMap_augmentation, Ideal.toCotangent_eq_zero]
+    rw [Bialgebra.cotangentMap_augmentation (x := x'), Submodule.mem_bot,
+      Ideal.toCotangent_eq_zero]
     exact hsquare hx
 
 end Ring
@@ -315,7 +316,17 @@ theorem conormalSubspace_ker_eq_bot_of_surjective_of_derivationCompLieHom_surjec
     intro d
     obtain ⟨e, he⟩ := hdf d
     refine ⟨derivationCompLieHom (B := k) (kerLiftBialgHom f hf) e, ?_⟩
-    rw [quotientLieHom_def]
+    -- `quotientLieHom` is not exposed, so rewrite it through its public application lemma.
+    have hquotient :
+        quotientLieHom (B := k) (kerOfSurjective f hf) =
+          derivationCompLieHom (B := k)
+            (Bialgebra.Quotient.mkBialgHom (kerOfSurjective f hf).toIdeal) := by
+      ext d x
+      rw [quotientLieHom_apply_apply, derivationCompLieHom_apply, derivationComp_apply]
+      exact Bialgebra.CounitAlgebra.algEquivSelf_apply
+        k (H ⧸ (kerOfSurjective f hf).toIdeal) k
+        (d (Ideal.Quotient.mkₐ k (kerOfSurjective f hf).toIdeal x))
+    rw [hquotient]
     calc
       derivationCompLieHom (B := k)
           (Bialgebra.Quotient.mkBialgHom (kerOfSurjective f hf).toIdeal)

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -245,8 +245,7 @@ theorem conormalSubspace_eq_bot_iff_toIdeal_le_sq_augmentationIdeal
     rw [hconormal, Submodule.mem_bot] at hxconormal
     let x' : Bialgebra.AugmentationIdeal k H :=
       ⟨x, toIdeal_le_augmentationIdeal I hx⟩
-    change Bialgebra.cotangentMap k H (x' : H) = 0 at hxconormal
-    rw [Bialgebra.cotangentMap_augmentation] at hxconormal
+    rw [Bialgebra.cotangentMap_augmentation (x := x')] at hxconormal
     exact
       ((Bialgebra.AugmentationIdeal k H).toCotangent_eq_zero x').1 hxconormal
   · intro hsquare
@@ -305,7 +304,7 @@ theorem quotientLieHom_surjective_iff_conormalSubspace_eq_bot
 /-- The kernel of a surjective Hopf-algebra morphism has zero conormal space when the
 differential of the morphism is surjective. -/
 theorem conormalSubspace_ker_eq_bot_of_surjective_of_derivationCompLieHom_surjective
-    {K : Type v} [CommRing K] [HopfAlgebra k K] (f : H →ₐc[k] K)
+    {K : Type w} [CommRing K] [HopfAlgebra k K] (f : H →ₐc[k] K)
     (hf : Function.Surjective f)
     (hdf : Function.Surjective (derivationCompLieHom (B := k) f)) :
     conormalSubspace (ker f) = ⊥ := by

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.Dual.Lemmas
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Tangent
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Cotangent
+public import TauCeti.Algebra.HopfAlgebra.Kernel
 import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
 import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
 
@@ -37,6 +38,10 @@ needed in Layer 2 of the ReductiveGroups roadmap.
   gives the differential of the closed-subgroup inclusion.
 * `TauCeti.HopfIdeal.quotientCotangentMap_surjective`: right exactness of the conormal sequence.
 * `TauCeti.HopfIdeal.ker_quotientCotangentMap`: its kernel is the conormal subspace.
+* `TauCeti.HopfIdeal.quotientLieHom_surjective_iff_conormalSubspace_eq_bot`: the
+  closed-subgroup differential is onto exactly when its conormal space vanishes.
+* `TauCeti.HopfIdeal.conormalSubspace_eq_bot_iff_toIdeal_le_sq_augmentationIdeal`: conormal
+  vanishing means that the defining ideal has no linear term at the identity.
 * `TauCeti.HopfIdeal.finrank_quotientLie_add_finrank_conormal`: the resulting dimension formula.
 * `TauCeti.HopfIdeal.finrank_quotientLie_le`: the resulting closed-subgroup dimension bound.
 * `TauCeti.HopfIdeal.finrank_quotientLie_antitone`: inclusion of closed subgroups cannot increase
@@ -227,11 +232,106 @@ theorem ker_quotientCotangentMap (I : HopfIdeal k H) :
     · exact (Bialgebra.cotangentMap_augmentation
         (R := k) (A := H) ⟨x, toIdeal_le_augmentationIdeal I hx'⟩).symm
 
+/-- A closed subgroup has zero conormal space at the identity exactly when every element of its
+defining ideal vanishes to second order there. -/
+theorem conormalSubspace_eq_bot_iff_toIdeal_le_sq_augmentationIdeal
+    (I : HopfIdeal k H) :
+    conormalSubspace I = ⊥ ↔
+      I.toIdeal ≤ Bialgebra.AugmentationIdeal k H ^ 2 := by
+  constructor
+  · intro hconormal x hx
+    have hxconormal : Bialgebra.cotangentMap k H x ∈ conormalSubspace I :=
+      (mem_conormalSubspace_iff I _).2 ⟨x, hx, rfl⟩
+    rw [hconormal, Submodule.mem_bot] at hxconormal
+    let x' : Bialgebra.AugmentationIdeal k H :=
+      ⟨x, toIdeal_le_augmentationIdeal I hx⟩
+    change Bialgebra.cotangentMap k H (x' : H) = 0 at hxconormal
+    rw [Bialgebra.cotangentMap_augmentation] at hxconormal
+    exact
+      ((Bialgebra.AugmentationIdeal k H).toCotangent_eq_zero x').1 hxconormal
+  · intro hsquare
+    apply le_bot_iff.1
+    intro y hy
+    obtain ⟨x, hx, rfl⟩ := (mem_conormalSubspace_iff I y).1 hy
+    let x' : Bialgebra.AugmentationIdeal k H :=
+      ⟨x, toIdeal_le_augmentationIdeal I hx⟩
+    change Bialgebra.cotangentMap k H (x' : H) = 0
+    rw [Bialgebra.cotangentMap_augmentation, Ideal.toCotangent_eq_zero]
+    exact hsquare hx
+
 end Ring
 
 section Field
 
 variable [Field k] [CommRing H] [HopfAlgebra k H]
+
+/-- The differential of a closed-subgroup inclusion is surjective exactly when the subgroup has
+zero conormal space at the identity. Equivalently, the inclusion is an infinitesimal equality at
+the identity. -/
+theorem quotientLieHom_surjective_iff_conormalSubspace_eq_bot
+    (I : HopfIdeal k H) :
+    Function.Surjective (quotientLieHom (B := k) I) ↔
+      conormalSubspace I = ⊥ := by
+  constructor
+  · intro hsurjective
+    rw [← ker_quotientCotangentMap, LinearMap.ker_eq_bot,
+      ← LinearMap.dualMap_surjective_iff]
+    intro f
+    obtain ⟨d, hd⟩ := hsurjective
+      (Derivation.cotangentLinearEquiv (R := k) (A := H) (B := k) f)
+    refine ⟨(Derivation.cotangentLinearEquiv
+      (R := k) (A := H ⧸ I.toIdeal) (B := k)).symm d, ?_⟩
+    apply (Derivation.cotangentLinearEquiv (R := k) (A := H) (B := k)).injective
+    rw [LinearMap.dualMap_apply',
+      ← cotangentLinearEquiv_comp_quotientCotangentMap,
+      (Derivation.cotangentLinearEquiv
+        (R := k) (A := H ⧸ I.toIdeal) (B := k)).apply_symm_apply]
+    exact hd
+  · intro hconormal
+    have hinjective : Function.Injective (quotientCotangentMap I) := by
+      rw [← LinearMap.ker_eq_bot, ker_quotientCotangentMap]
+      exact hconormal
+    have hdual : Function.Surjective (quotientCotangentMap I).dualMap :=
+      LinearMap.dualMap_surjective_of_injective hinjective
+    intro d
+    obtain ⟨f, hf⟩ := hdual
+      ((Derivation.cotangentLinearEquiv (R := k) (A := H) (B := k)).symm d)
+    refine ⟨Derivation.cotangentLinearEquiv
+      (R := k) (A := H ⧸ I.toIdeal) (B := k) f, ?_⟩
+    rw [cotangentLinearEquiv_comp_quotientCotangentMap,
+      ← LinearMap.dualMap_apply', hf,
+      (Derivation.cotangentLinearEquiv (R := k) (A := H) (B := k)).apply_symm_apply]
+
+/-- The kernel of a surjective Hopf-algebra morphism has zero conormal space when the
+differential of the morphism is surjective. -/
+theorem conormalSubspace_ker_eq_bot_of_surjective_of_derivationCompLieHom_surjective
+    {K : Type v} [CommRing K] [HopfAlgebra k K] (f : H →ₐc[k] K)
+    (hf : Function.Surjective f)
+    (hdf : Function.Surjective (derivationCompLieHom (B := k) f)) :
+    conormalSubspace (ker f) = ⊥ := by
+  have hkerOf : conormalSubspace (kerOfSurjective f hf) = ⊥ := by
+    apply
+      (quotientLieHom_surjective_iff_conormalSubspace_eq_bot
+        (kerOfSurjective f hf)).1
+    intro d
+    obtain ⟨e, he⟩ := hdf d
+    refine ⟨derivationCompLieHom (B := k) (kerLiftBialgHom f hf) e, ?_⟩
+    rw [quotientLieHom_def]
+    calc
+      derivationCompLieHom (B := k)
+          (Bialgebra.Quotient.mkBialgHom (kerOfSurjective f hf).toIdeal)
+          (derivationCompLieHom (B := k) (kerLiftBialgHom f hf) e) =
+        ((derivationCompLieHom (B := k)
+            (Bialgebra.Quotient.mkBialgHom (kerOfSurjective f hf).toIdeal)).comp
+          (derivationCompLieHom (B := k) (kerLiftBialgHom f hf))) e := rfl
+      _ = derivationCompLieHom (B := k)
+          ((kerLiftBialgHom f hf).comp
+            (Bialgebra.Quotient.mkBialgHom (kerOfSurjective f hf).toIdeal)) e := by
+        rw [derivationCompLieHom_comp]
+      _ = derivationCompLieHom (B := k) f e := by
+        rw [kerLiftBialgHom_comp_mkBialgHom]
+      _ = d := he
+  simpa only [kerOfSurjective_eq_ker] using hkerOf
 
 /-- In finite dimension, the dimension of the closed subgroup's cotangent space plus its
 conormal dimension is the dimension of the ambient cotangent space. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
@@ -77,6 +77,15 @@ lemma quotientLieHom_apply_apply (I : HopfIdeal R H)
   simp [quotientLieHom]
   rfl
 
+/-- The closed-subgroup differential is precomposition along the quotient morphism. -/
+theorem quotientLieHom_def (I : HopfIdeal R H) :
+    quotientLieHom (B := B) I =
+      derivationCompLieHom (B := B) (Bialgebra.Quotient.mkBialgHom I.toIdeal) := by
+  ext d x
+  rw [quotientLieHom_apply_apply, derivationCompLieHom_apply, derivationComp_apply]
+  exact Bialgebra.CounitAlgebra.algEquivSelf_apply
+    R (H ⧸ I.toIdeal) B (d (Ideal.Quotient.mkₐ R I.toIdeal x))
+
 /-- The differential of a closed-subgroup inclusion is injective. -/
 theorem quotientLieHom_injective (I : HopfIdeal R H) :
     Function.Injective (quotientLieHom (B := B) I) :=

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Tangent.lean
@@ -77,15 +77,6 @@ lemma quotientLieHom_apply_apply (I : HopfIdeal R H)
   simp [quotientLieHom]
   rfl
 
-/-- The closed-subgroup differential is precomposition along the quotient morphism. -/
-theorem quotientLieHom_def (I : HopfIdeal R H) :
-    quotientLieHom (B := B) I =
-      derivationCompLieHom (B := B) (Bialgebra.Quotient.mkBialgHom I.toIdeal) := by
-  ext d x
-  rw [quotientLieHom_apply_apply, derivationCompLieHom_apply, derivationComp_apply]
-  exact Bialgebra.CounitAlgebra.algEquivSelf_apply
-    R (H ⧸ I.toIdeal) B (d (Ideal.Quotient.mkₐ R I.toIdeal x))
-
 /-- The differential of a closed-subgroup inclusion is injective. -/
 theorem quotientLieHom_injective (I : HopfIdeal R H) :
     Function.Injective (quotientLieHom (B := B) I) :=

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -31,6 +31,8 @@ The declarations are in `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate`.
 * `derivationCompLieHom_productOfNormal_bijective_of_maximal`:
   the inclusion of a maximal candidate into its product with another candidate induces a
   bijection on tangent Lie algebras.
+* `conormalSubspace_productOfNormal_le_left_eq_bot_of_maximal`:
+  the relative defining ideal of the maximal candidate in that product has zero conormal space.
 
 ## References
 
@@ -106,6 +108,46 @@ theorem derivationCompLieHom_productOfNormal_bijective_of_maximal
   have hfinrank := hI.finrank_quotientLie_productOfNormal_eq_of_maximal hmax hJ
   exact derivationCompLieHom_bijective_of_surjective_of_finrank_eq _
     (FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hPI) hfinrank.symm
+
+/-- The relative defining ideal of a maximal-dimensional unipotent-radical candidate inside its
+product with any other candidate has zero conormal space at the identity.
+
+Thus the maximal candidate and the product candidate agree to first order. The remaining
+maximality step is global: smoothness and connectedness must upgrade this infinitesimal equality
+to equality of the two closed subgroups. -/
+theorem conormalSubspace_productOfNormal_le_left_eq_bot_of_maximal
+    (hI : IsUnipotentRadicalCandidate H I)
+    (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
+      Module.finrank k
+          (Derivation k (H ⧸ K.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
+        Module.finrank k
+          (Derivation k (H ⧸ I.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
+    (hJ : IsUnipotentRadicalCandidate H J) :
+    HopfIdeal.conormalSubspace
+      (I.map (Bialgebra.Quotient.mkBialgHom
+        (HopfIdeal.ker
+          (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom).toIdeal)) =
+      ⊥ := by
+  let P : HopfIdeal k H :=
+    HopfIdeal.ker (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom
+  let hPI : P ≤ I :=
+    CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal
+  let q := FiniteTypeCommHopfAlgCat.toBialgHom
+    (FiniteTypeCommHopfAlgCat.quotientMapOfLe H hPI)
+  have hq_surjective : Function.Surjective q :=
+    FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hPI
+  have hdq_surjective :
+      Function.Surjective (derivationCompLieHom (B := k) q) :=
+    (hI.derivationCompLieHom_productOfNormal_bijective_of_maximal hmax hJ).2
+  have hconormal : HopfIdeal.conormalSubspace (HopfIdeal.ker q) = ⊥ :=
+    HopfIdeal.conormalSubspace_ker_eq_bot_of_surjective_of_derivationCompLieHom_surjective
+      q hq_surjective hdq_surjective
+  have hker : HopfIdeal.ker q =
+      I.map (Bialgebra.Quotient.mkBialgHom P.toIdeal) :=
+    CommHopfAlgCat.ker_quotientMapOfLe H.obj hPI
+  simpa only [P] using hker ▸ hconormal
 
 end HopfIdeal.IsUnipotentRadicalCandidate
 


### PR DESCRIPTION
This PR identifies the infinitesimal equality forced by maximal Lie dimension in the unipotent-radical construction: the relative defining Hopf ideal of a maximal candidate inside its product with any other candidate has zero conormal space at the identity.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 5, “The unipotent radical `R_u(G)`,” whose milestone is the maximal connected normal unipotent closed subgroup. The preceding merged steps construct a maximal-Lie-dimension candidate, close candidates under binary products, and prove that the inclusion into each product induces a bijection on tangent Lie algebras; this PR turns that tangent statement into the vanishing conormal statement needed by the remaining global argument. This is the most effective current step because the roadmap’s affine quotient representability needed for a direct `UV/U` proof is not yet available, while cotangent duality already supplies a complete first-order reduction.

At the general Hopf-algebra level, add `quotientLieHom_def`, characterize zero conormal space both by surjectivity of the closed-subgroup differential and by containment of the defining ideal in the square of the augmentation ideal, and prove that the kernel of any surjective Hopf morphism with surjective differential has zero conormal space. Specialize this to `IsUnipotentRadicalCandidate.conormalSubspace_productOfNormal_le_left_eq_bot_of_maximal`.

After this PR, the Layer 5 milestone still needs the global step upgrading this infinitesimal equality to equality of the smooth connected closed subgroups, followed by packaging the resulting greatest candidate as the unipotent radical.

The mathematical organization follows Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§6.45–6.46 and §10.a, and Borel, *Linear Algebraic Groups*, §11.21, as credited in the existing module documentation. The proof reuses Mathlib’s dual-map injectivity/surjectivity equivalence and cotangent-space quotient API together with Tau Ceti’s conormal sequence, Hopf-kernel quotient equivalence, and maximal-candidate tangent bijection. No Mathlib source is vendored.

Modify three existing modules under `TauCeti/Algebra/AlgebraicGroup/` by 151 added lines; no module move or new file is needed.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"maximal-unipotent-candidate-zero-conormal"}-->

🤖 Prepared with Codex
