### PR TITLE
feat: make subdivision realization a homeomorphism

### DIFF
--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Homeomorph.lean
@@ -178,7 +178,7 @@ private theorem continuous_chamberMap {K : AbstractSimplicialComplex ι} (σ : F
     (fun x k => chamberOrderedCoord σ e x k)
     (fun x _ hk => chamberOrderedCoord_succ_le σ e x hk)
     (sum_chamberOrderedCoord σ e) (chamberOrderedCoord_card σ e)
-    (continuous_chamberOrderedCoord σ e)
+    (fun k _ => continuous_chamberOrderedCoord σ e k)
 
 private theorem barycentricSubdivisionRealizationMap_chamberMap
     {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ)

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Homeomorph.lean
@@ -1,0 +1,561 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Intervals
+public import TauCeti.AlgebraicTopology.SimplicialComplex.Subdivision.Injective
+
+/-!
+# The realization homeomorphism for barycentric subdivision
+
+The canonical map from the realization of the barycentric subdivision of a simplicial complex to
+the realization of the original complex is a homeomorphism. The forward map sends a face-vertex to
+the barycenter of that face and extends affinely over subdivision simplices.
+
+Continuity of the inverse is proved simplex by simplex, using the weak topology on realizations.
+Each original simplex is covered by the finitely many closed chambers obtained by ordering its
+barycentric coordinates. On one chamber the inverse has a fixed affine formula: consecutive
+coordinate differences are the coefficients of the nested initial faces in that order. These
+formulas are continuous and agree on chamber intersections because the forward map is injective.
+
+This completes the subdivision part of the geometric-realization milestone in Layer 11 of the
+GeometricTopology roadmap. The construction follows Rourke--Sanderson, *Introduction to
+Piecewise-Linear Topology*, Chapter 2, "Derived Subdivisions".
+
+## Main definition
+
+* `AbstractSimplicialComplex.barycentricSubdivisionRealizationHomeomorph`: the canonical
+  homeomorphism from the realization of the barycentric subdivision to the original realization.
+-/
+
+public section
+
+noncomputable section
+
+open Finset Set TauCeti TauCeti.SetLike
+
+namespace AbstractSimplicialComplex
+
+variable {ι : Type*}
+
+attribute [local instance] Classical.decEq
+
+private abbrev VertexOrder {K : AbstractSimplicialComplex ι} (σ : Face K) :=
+  Fin σ.1.card ≃ {v // v ∈ σ.1}
+
+/-- The closed chamber in which the coordinates occur in decreasing order along `e`. -/
+private def orderChamber {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) : Set (StandardSimplex σ.1) :=
+  {x | Antitone fun i => x.1 (e i).1}
+
+private theorem isClosed_orderChamber {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) : IsClosed (orderChamber σ e) := by
+  -- Expand antitonicity as an intersection of closed coordinate inequalities.
+  rw [show orderChamber σ e =
+      ⋂ i, ⋂ j, ⋂ (_ : i ≤ j), {x | x.1 (e j).1 ≤ x.1 (e i).1} by
+    ext x
+    simp [orderChamber, Antitone]]
+  apply isClosed_iInter
+  intro i
+  apply isClosed_iInter
+  intro j
+  apply isClosed_iInter
+  intro _
+  exact isClosed_le
+    ((continuous_apply (e j).1).comp continuous_induced_dom)
+    ((continuous_apply (e i).1).comp continuous_induced_dom)
+
+@[instance_reducible]
+private noncomputable def vertexLinearOrder {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (x : StandardSimplex σ.1) : LinearOrder {v // v ∈ σ.1} :=
+  LinearOrder.lift'
+    (fun v => toLex (OrderDual.toDual (x.1 v.1), Fintype.equivFin _ v))
+    (fun _ _ h => (Fintype.equivFin _).injective
+      (congrArg (fun z => (ofLex z).2) h))
+
+/-- Order the vertices of a simplex by decreasing coordinate, breaking ties arbitrarily. -/
+private noncomputable def decreasingVertexOrder {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (x : StandardSimplex σ.1) : VertexOrder σ :=
+  let _ := vertexLinearOrder σ x
+  (Fintype.orderIsoFinOfCardEq _ (by simp)).toEquiv
+
+private theorem mem_orderChamber_decreasingVertexOrder {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (x : StandardSimplex σ.1) :
+    x ∈ orderChamber σ (decreasingVertexOrder σ x) := by
+  let _ := vertexLinearOrder σ x
+  intro i j hij
+  have h := (Fintype.orderIsoFinOfCardEq
+    {v // v ∈ σ.1} (by simp)).monotone hij
+  -- Expose the lexicographic order installed by `vertexLinearOrder` to read its first coordinate.
+  change toLex (OrderDual.toDual (x.1 (decreasingVertexOrder σ x i).1),
+      Fintype.equivFin {v // v ∈ σ.1} (decreasingVertexOrder σ x i)) ≤
+    toLex (OrderDual.toDual (x.1 (decreasingVertexOrder σ x j).1),
+      Fintype.equivFin {v // v ∈ σ.1} (decreasingVertexOrder σ x j)) at h
+  rw [Prod.Lex.le_iff] at h
+  rcases h with h | h
+  · exact h.le
+  · exact h.1.le
+
+private theorem iUnion_orderChamber {K : AbstractSimplicialComplex ι} (σ : Face K) :
+    ⋃ e : VertexOrder σ, orderChamber σ e = Set.univ := by
+  rw [eq_univ_iff_forall]
+  intro x
+  exact Set.mem_iUnion.2
+    ⟨decreasingVertexOrder σ x, mem_orderChamber_decreasingVertexOrder σ x⟩
+
+/-- The first `i + 1` vertices in a fixed ordering of a face. -/
+private def orderedPrefixVertices {K : AbstractSimplicialComplex ι} {σ : Face K}
+    (e : VertexOrder σ) (i : Fin σ.1.card) : Finset ι :=
+  (Finset.Iic i).image fun j => (e j).1
+
+private theorem orderedPrefixVertices_nonempty {K : AbstractSimplicialComplex ι} {σ : Face K}
+    (e : VertexOrder σ) (i : Fin σ.1.card) : (orderedPrefixVertices e i).Nonempty := by
+  exact ⟨(e i).1, Finset.mem_image.2 ⟨i, Finset.mem_Iic.2 le_rfl, rfl⟩⟩
+
+private theorem orderedPrefixVertices_subset {K : AbstractSimplicialComplex ι} {σ : Face K}
+    (e : VertexOrder σ) (i : Fin σ.1.card) : orderedPrefixVertices e i ⊆ σ.1 := by
+  intro v hv
+  obtain ⟨j, -, rfl⟩ := Finset.mem_image.1 hv
+  exact (e j).2
+
+private noncomputable def orderedPrefixFace {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (i : Fin σ.1.card) : Face K :=
+  ⟨orderedPrefixVertices e i, K.isRelLowerSet_faces.mem_of_le σ.2
+    (orderedPrefixVertices_subset e i) (orderedPrefixVertices_nonempty e i)⟩
+
+private theorem orderedPrefixFace_mono {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) {i j : Fin σ.1.card} (hij : i ≤ j) :
+    orderedPrefixFace σ e i ≤ orderedPrefixFace σ e j := by
+  intro v hv
+  obtain ⟨k, hki, rfl⟩ := Finset.mem_image.1 hv
+  exact Finset.mem_image.2
+    ⟨k, Finset.mem_Iic.2 ((Finset.mem_Iic.1 hki).trans hij), rfl⟩
+
+private theorem card_orderedPrefixFace {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (i : Fin σ.1.card) :
+    (orderedPrefixFace σ e i).1.card = i.1 + 1 := by
+  -- Forget the face-membership proof before counting the underlying initial segment.
+  change (orderedPrefixVertices e i).card = i.1 + 1
+  rw [orderedPrefixVertices, Finset.card_image_iff.mpr]
+  · exact Fin.card_Iic i
+  · exact fun _ _ _ _ h => e.injective (Subtype.ext h)
+
+/-- The chain of initial faces determined by a vertex ordering. -/
+private noncomputable def orderedSubdivisionFaces {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) : Finset (Face K) :=
+  Finset.univ.image (orderedPrefixFace σ e)
+
+private theorem orderedSubdivisionFaces_nonempty {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) : (orderedSubdivisionFaces σ e).Nonempty := by
+  have hσ : 0 < σ.1.card := Finset.card_pos.mpr
+    (K.isRelLowerSet_faces.prop_of_mem σ.2)
+  let i : Fin σ.1.card := ⟨0, hσ⟩
+  exact ⟨orderedPrefixFace σ e i,
+    Finset.mem_image.2 ⟨i, Finset.mem_univ _, rfl⟩⟩
+
+private theorem orderedSubdivisionFaces_mem {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) :
+    orderedSubdivisionFaces σ e ∈ TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
+      K.toPreAbstractSimplicialComplex := by
+  rw [TauCeti.PreAbstractSimplicialComplex.mem_barycentricSubdivision_iff]
+  refine ⟨orderedSubdivisionFaces_nonempty σ e, ?_⟩
+  intro ρ hρ τ hτ _
+  obtain ⟨i, -, rfl⟩ := Finset.mem_image.1 hρ
+  obtain ⟨j, -, rfl⟩ := Finset.mem_image.1 hτ
+  exact (le_total i j).imp (orderedPrefixFace_mono σ e) (orderedPrefixFace_mono σ e)
+
+private noncomputable def orderedSubdivisionFace {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) :
+    Face (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
+      K.toPreAbstractSimplicialComplex) :=
+  ⟨orderedSubdivisionFaces σ e, orderedSubdivisionFaces_mem σ e⟩
+
+/-- Extend the ordered coordinates by zero after the last vertex. -/
+private noncomputable def chamberOrderedCoord {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) (k : ℕ) : ℝ :=
+  if h : k < σ.1.card then x.1.1 (e ⟨k, h⟩).1 else 0
+
+private theorem chamberOrderedCoord_of_lt {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) {k : ℕ} (hk : k < σ.1.card) :
+    chamberOrderedCoord σ e x k = x.1.1 (e ⟨k, hk⟩).1 := by
+  rw [chamberOrderedCoord]
+  split
+  · congr
+  · contradiction
+
+private theorem chamberOrderedCoord_card {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) :
+    chamberOrderedCoord σ e x σ.1.card = 0 := by
+  simp [chamberOrderedCoord]
+
+private theorem continuous_chamberOrderedCoord {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (k : ℕ) :
+    Continuous (fun x : orderChamber σ e => chamberOrderedCoord σ e x k) := by
+  unfold chamberOrderedCoord
+  split
+  · have hcoe : Continuous (fun y : StandardSimplex σ.1 => (y.1 : ι → ℝ)) :=
+      continuous_induced_dom
+    exact ((continuous_apply _).comp hcoe).comp continuous_subtype_val
+  · exact continuous_const
+
+private theorem chamberOrderedCoord_succ_le {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) {k : ℕ} (hk : k < σ.1.card) :
+    chamberOrderedCoord σ e x (k + 1) ≤ chamberOrderedCoord σ e x k := by
+  rw [chamberOrderedCoord_of_lt σ e x hk]
+  by_cases hks : k + 1 < σ.1.card
+  · rw [chamberOrderedCoord_of_lt σ e x hks]
+    exact x.2 (Fin.mk_le_mk.mpr (Nat.le_succ k))
+  · rw [chamberOrderedCoord]
+    simp only [hks, ↓reduceDIte]
+    exact StandardSimplex.nonneg x.1 _
+
+/-- The coefficient of the `i`th initial face in one ordered chamber. -/
+private noncomputable def chamberWeight {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) (i : Fin σ.1.card) : ℝ :=
+  (i.1 + 1 : ℝ) *
+    (chamberOrderedCoord σ e x i.1 - chamberOrderedCoord σ e x (i.1 + 1))
+
+private theorem chamberWeight_nonneg {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) (i : Fin σ.1.card) :
+    0 ≤ chamberWeight σ e x i := by
+  exact mul_nonneg (by positivity)
+    (sub_nonneg.2 (chamberOrderedCoord_succ_le σ e x i.2))
+
+private theorem continuous_chamberWeight {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (i : Fin σ.1.card) :
+    Continuous (fun x : orderChamber σ e => chamberWeight σ e x i) :=
+  continuous_const.mul
+    ((continuous_chamberOrderedCoord σ e i.1).sub
+      (continuous_chamberOrderedCoord σ e (i.1 + 1)))
+
+/-- Summation by parts for the coefficients in an ordered chamber. -/
+private theorem sum_range_succ_mul_sub (f : ℕ → ℝ) (n : ℕ) :
+    ∑ i ∈ Finset.range n, (i + 1 : ℝ) * (f i - f (i + 1)) =
+      ∑ i ∈ Finset.range n, f i - (n : ℝ) * f n := by
+  apply Finset.sum_range_induction
+  · simp
+  · intro k _
+    rw [Finset.sum_range_succ]
+    push_cast
+    ring
+
+private theorem sum_range_ite_le_sub (f : ℕ → ℝ) {j n : ℕ} (hjn : j < n) :
+    ∑ i ∈ Finset.range n, (if j ≤ i then f i - f (i + 1) else 0) = f j - f n := by
+  rw [← Finset.sum_filter]
+  have hfilter : (Finset.range n).filter (j ≤ ·) = Finset.Ico j n := by
+    ext i
+    simp [and_comm]
+  rw [hfilter]
+  calc
+    ∑ i ∈ Finset.Ico j n, (f i - f (i + 1)) =
+        -∑ i ∈ Finset.Ico j n, (f (i + 1) - f i) := by
+      rw [← Finset.sum_neg_distrib]
+      apply Finset.sum_congr rfl
+      intro i _
+      ring
+    _ = -(f n - f j) := by rw [Finset.sum_Ico_sub f hjn.le]
+    _ = f j - f n := by ring
+
+private theorem sum_chamberOrderedCoord {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) :
+    ∑ k ∈ Finset.range σ.1.card, chamberOrderedCoord σ e x k = 1 := by
+  rw [← Fin.sum_univ_eq_sum_range]
+  calc
+    ∑ i : Fin σ.1.card, chamberOrderedCoord σ e x i =
+        ∑ i : Fin σ.1.card, x.1.1 (e i).1 := by
+      apply Finset.sum_congr rfl
+      intro i _
+      exact chamberOrderedCoord_of_lt σ e x i.2
+    _ = ∑ v : {v // v ∈ σ.1}, x.1.1 v.1 := by
+      exact Fintype.sum_equiv e _ _ fun _ => rfl
+    _ = ∑ v ∈ σ.1, x.1.1 v := Finset.sum_attach _ _
+    _ = 1 := by
+      rw [← Finsupp.sum_of_support_subset x.1.1 (StandardSimplex.support_subset x.1)
+        (fun _ r => r) (by simp)]
+      exact StandardSimplex.sum_eq_one x.1
+
+private theorem sum_chamberWeight {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) :
+    ∑ i, chamberWeight σ e x i = 1 := by
+  calc
+    ∑ i, chamberWeight σ e x i =
+        ∑ i ∈ Finset.range σ.1.card,
+          (i + 1 : ℝ) * (chamberOrderedCoord σ e x i -
+            chamberOrderedCoord σ e x (i + 1)) := by
+      rw [← Fin.sum_univ_eq_sum_range]
+      apply Finset.sum_congr rfl
+      intro i _
+      rfl
+    _ = 1 := by
+      rw [sum_range_succ_mul_sub, chamberOrderedCoord_card, mul_zero, sub_zero,
+        sum_chamberOrderedCoord]
+
+/-- The subdivision coordinates defined by a fixed vertex ordering. -/
+private noncomputable def chamberCoordinates {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) : Face K →₀ ℝ :=
+  ∑ i : Fin σ.1.card,
+    Finsupp.single (orderedPrefixFace σ e i) (chamberWeight σ e x i)
+
+private theorem chamberCoordinates_nonneg {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) (ρ : Face K) :
+    0 ≤ chamberCoordinates σ e x ρ := by
+  rw [chamberCoordinates]
+  -- Evaluation is the additive homomorphism needed to move through the finite sum of `Finsupp`s.
+  change 0 ≤ Finsupp.applyAddHom ρ
+    (∑ i : Fin σ.1.card,
+      Finsupp.single (orderedPrefixFace σ e i) (chamberWeight σ e x i))
+  rw [map_sum]
+  apply Finset.sum_nonneg
+  intro i _
+  by_cases h : orderedPrefixFace σ e i = ρ
+  · simp [h, chamberWeight_nonneg]
+  · simp [h]
+
+private theorem chamberCoordinates_sum {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) :
+    (chamberCoordinates σ e x).sum (fun _ r => r) = 1 := by
+  rw [chamberCoordinates]
+  rw [← Finsupp.sum_finsetSum_index (fun _ => rfl) (fun _ _ _ => rfl)]
+  simp only [Finsupp.sum_single_index]
+  exact sum_chamberWeight σ e x
+
+private theorem chamberCoordinates_support {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) :
+    (chamberCoordinates σ e x).support ⊆ orderedSubdivisionFaces σ e := by
+  intro ρ hρ
+  by_contra hnot
+  have hne : ∀ i : Fin σ.1.card, orderedPrefixFace σ e i ≠ ρ := by
+    intro i hi
+    apply hnot
+    exact Finset.mem_image.2 ⟨i, Finset.mem_univ _, hi⟩
+  have hz : chamberCoordinates σ e x ρ = 0 := by
+    simp [chamberCoordinates, hne]
+  exact (Finsupp.mem_support_iff.mp hρ) hz
+
+private theorem chamberCoordinates_mem {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) :
+    chamberCoordinates σ e x ∈
+      convexHull ℝ ((fun ρ => Finsupp.single ρ (1 : ℝ)) ''
+        (orderedSubdivisionFaces σ e : Set (Face K))) := by
+  rw [mem_standardSimplex_iff]
+  exact ⟨chamberCoordinates_nonneg σ e x, chamberCoordinates_sum σ e x,
+    chamberCoordinates_support σ e x⟩
+
+private noncomputable def chamberStandardSimplex {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) (x : orderChamber σ e) :
+    StandardSimplex (orderedSubdivisionFaces σ e) :=
+  ⟨chamberCoordinates σ e x, by simpa using chamberCoordinates_mem σ e x⟩
+
+private theorem continuous_chamberStandardSimplex {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) : Continuous (chamberStandardSimplex σ e) := by
+  apply continuous_induced_rng.mpr
+  apply continuous_pi
+  intro ρ
+  have hformula :
+      (fun x : orderChamber σ e => (chamberStandardSimplex σ e x : Face K → ℝ) ρ) =
+        fun x => ∑ i : Fin σ.1.card,
+          if orderedPrefixFace σ e i = ρ then chamberWeight σ e x i else 0 := by
+    funext x
+    -- Expose the coordinate function carried by the target simplex subtype.
+    rw [show (chamberStandardSimplex σ e x : Face K →₀ ℝ) =
+      chamberCoordinates σ e x by rfl]
+    rw [chamberCoordinates]
+    rw [Finset.sum_apply']
+    apply Finset.sum_congr rfl
+    intro i _
+    simp [Finsupp.single_apply, eq_comm]
+  -- The induced topology on the target simplex is defined through its coordinate function.
+  change Continuous (fun x : orderChamber σ e =>
+    (chamberStandardSimplex σ e x : Face K → ℝ) ρ)
+  rw [hformula]
+  apply continuous_finsetSum
+  intro i _
+  by_cases h : orderedPrefixFace σ e i = ρ
+  · simp only [h, ↓reduceIte]
+    exact continuous_chamberWeight σ e i
+  · simp only [h, ↓reduceIte]
+    exact continuous_const
+
+/-- The chamber formula, included into the whole subdivision realization. -/
+private noncomputable def chamberMap {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) :
+    Realization (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
+      K.toPreAbstractSimplicialComplex) :=
+  faceInclusion _ (orderedSubdivisionFace σ e) (chamberStandardSimplex σ e x)
+
+private theorem continuous_chamberMap {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) : Continuous (chamberMap σ e) :=
+  (continuous_faceInclusion _ (orderedSubdivisionFace σ e)).comp
+    (continuous_chamberStandardSimplex σ e)
+
+private theorem mem_orderedPrefixVertices_iff {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) {v : ι} (hv : v ∈ σ.1) (i : Fin σ.1.card) :
+    v ∈ orderedPrefixVertices e i ↔ e.symm ⟨v, hv⟩ ≤ i := by
+  constructor
+  · intro h
+    obtain ⟨j, hj, hjv⟩ := Finset.mem_image.1 h
+    have heq : j = e.symm ⟨v, hv⟩ := by
+      apply e.injective
+      apply Subtype.ext
+      rw [hjv, e.apply_symm_apply]
+    rw [← heq]
+    exact Finset.mem_Iic.1 hj
+  · intro h
+    exact Finset.mem_image.2
+      ⟨e.symm ⟨v, hv⟩, Finset.mem_Iic.2 h, by simp⟩
+
+private theorem chamberWeight_mul_card_prefix_inv {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) (x : orderChamber σ e) (i : Fin σ.1.card) :
+    chamberWeight σ e x i * ((orderedPrefixFace σ e i).1.card : ℝ)⁻¹ =
+      chamberOrderedCoord σ e x i.1 - chamberOrderedCoord σ e x (i.1 + 1) := by
+  rw [chamberWeight, card_orderedPrefixFace]
+  have hne : (i.1 + 1 : ℝ) ≠ 0 := by positivity
+  field_simp
+  norm_num [Nat.cast_add, Nat.cast_one]
+  ring
+
+private theorem barycentricSubdivisionLinearMap_chamberCoordinates
+    {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ)
+    (x : orderChamber σ e) :
+    barycentricSubdivisionLinearMap K (chamberCoordinates σ e x) =
+      ∑ i : Fin σ.1.card,
+        chamberWeight σ e x i • faceBarycenter K (orderedPrefixFace σ e i) := by
+  rw [chamberCoordinates, map_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [← Finsupp.smul_single_one, map_smul, barycentricSubdivisionLinearMap_single]
+
+private theorem barycentricSubdivisionLinearMap_chamberCoordinates_apply_of_mem
+    {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ)
+    (x : orderChamber σ e) {v : ι} (hv : v ∈ σ.1) :
+    barycentricSubdivisionLinearMap K (chamberCoordinates σ e x) v = x.1.1 v := by
+  rw [barycentricSubdivisionLinearMap_chamberCoordinates]
+  simp only [Finset.sum_apply', Finsupp.smul_apply, smul_eq_mul, faceBarycenter_apply]
+  let j : Fin σ.1.card := e.symm ⟨v, hv⟩
+  calc
+    ∑ i : Fin σ.1.card,
+        chamberWeight σ e x i *
+          (if v ∈ (orderedPrefixFace σ e i).1 then
+            ((orderedPrefixFace σ e i).1.card : ℝ)⁻¹ else 0) =
+        ∑ i : Fin σ.1.card,
+          if j ≤ i then chamberOrderedCoord σ e x i.1 -
+            chamberOrderedCoord σ e x (i.1 + 1) else 0 := by
+      apply Finset.sum_congr rfl
+      intro i _
+      by_cases hji : j ≤ i
+      · have hmem : v ∈ (orderedPrefixFace σ e i).1 :=
+          (mem_orderedPrefixVertices_iff σ e hv i).2 hji
+        simp only [hmem, hji, ↓reduceIte]
+        exact chamberWeight_mul_card_prefix_inv σ e x i
+      · have hmem : v ∉ (orderedPrefixFace σ e i).1 := fun h =>
+          hji ((mem_orderedPrefixVertices_iff σ e hv i).1 h)
+        simp [hmem, hji]
+    _ = ∑ i ∈ Finset.range σ.1.card,
+          if j.1 ≤ i then chamberOrderedCoord σ e x i -
+            chamberOrderedCoord σ e x (i + 1) else 0 := by
+      rw [← Fin.sum_univ_eq_sum_range]
+      apply Finset.sum_congr rfl
+      intro i _
+      rfl
+    _ = chamberOrderedCoord σ e x j.1 - chamberOrderedCoord σ e x σ.1.card :=
+      sum_range_ite_le_sub (chamberOrderedCoord σ e x) j.2
+    _ = x.1.1 v := by
+      rw [chamberOrderedCoord_card, sub_zero, chamberOrderedCoord_of_lt σ e x j.2]
+      exact congrArg (fun w : {v // v ∈ σ.1} => x.1.1 w.1)
+        (e.apply_symm_apply ⟨v, hv⟩)
+
+private theorem barycentricSubdivisionLinearMap_chamberCoordinates_apply_of_notMem
+    {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ)
+    (x : orderChamber σ e) {v : ι} (hv : v ∉ σ.1) :
+    barycentricSubdivisionLinearMap K (chamberCoordinates σ e x) v = x.1.1 v := by
+  rw [barycentricSubdivisionLinearMap_chamberCoordinates]
+  simp only [Finset.sum_apply', Finsupp.smul_apply, smul_eq_mul, faceBarycenter_apply]
+  have hprefix : ∀ i : Fin σ.1.card, v ∉ (orderedPrefixFace σ e i).1 :=
+    fun i hvi => hv (orderedPrefixVertices_subset e i hvi)
+  simp only [hprefix, ↓reduceIte, mul_zero, Finset.sum_const_zero]
+  exact (Finsupp.notMem_support_iff.mp
+    (fun hsupport => hv (StandardSimplex.support_subset x.1 hsupport))).symm
+
+private theorem chamberMap_val {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (x : orderChamber σ e) :
+    (chamberMap σ e x : Face K →₀ ℝ) = chamberCoordinates σ e x := by
+  exact faceInclusion_val _ (orderedSubdivisionFace σ e) (chamberStandardSimplex σ e x)
+
+private theorem barycentricSubdivisionRealizationMap_chamberMap
+    {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ)
+    (x : orderChamber σ e) :
+    barycentricSubdivisionRealizationMap K (chamberMap σ e x) = faceInclusion K σ x.1 := by
+  apply Subtype.ext
+  ext v
+  rw [barycentricSubdivisionRealizationMap_val, chamberMap_val, faceInclusion_val]
+  by_cases hv : v ∈ σ.1
+  · exact barycentricSubdivisionLinearMap_chamberCoordinates_apply_of_mem σ e x hv
+  · exact barycentricSubdivisionLinearMap_chamberCoordinates_apply_of_notMem σ e x hv
+
+private theorem continuousOn_iUnion_finset_of_isClosed {α β κ : Type*}
+    [TopologicalSpace α] [TopologicalSpace β] {f : α → β} (s : Finset κ) (u : κ → Set α)
+    (hu : ∀ i ∈ s, IsClosed (u i)) (hf : ∀ i ∈ s, ContinuousOn f (u i)) :
+    ContinuousOn f (⋃ i ∈ s, u i) := by
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert i s hi ih =>
+      rw [Finset.set_biUnion_insert]
+      exact (hf i (Finset.mem_insert_self i s)).union_of_isClosed
+        (ih (fun j hj => hu j (Finset.mem_insert_of_mem hj))
+          (fun j hj => hf j (Finset.mem_insert_of_mem hj)))
+        (hu i (Finset.mem_insert_self i s))
+        (isClosed_biUnion_finset fun j hj => hu j (Finset.mem_insert_of_mem hj))
+
+private theorem continuous_inverse_barycentricSubdivisionRealizationMap
+    (K : AbstractSimplicialComplex ι) :
+    let e := Equiv.ofBijective (barycentricSubdivisionRealizationMap K)
+      (barycentricSubdivisionRealizationMap_bijective K)
+    Continuous e.symm := by
+  let e := Equiv.ofBijective (barycentricSubdivisionRealizationMap K)
+    (barycentricSubdivisionRealizationMap_bijective K)
+  apply continuous_iff_faceInclusion.2
+  intro σ
+  rw [← continuousOn_univ, ← iUnion_orderChamber σ]
+  have hpiece : ∀ o : VertexOrder σ,
+      ContinuousOn (e.symm ∘ faceInclusion K σ) (orderChamber σ o) := by
+    intro o
+    rw [continuousOn_iff_continuous_domRestrict]
+    have heq : (orderChamber σ o).domRestrict (e.symm ∘ faceInclusion K σ) =
+        chamberMap σ o := by
+      funext x
+      exact e.symm_apply_eq.2 (by
+        simpa only [e, Equiv.ofBijective_apply] using
+          (barycentricSubdivisionRealizationMap_chamberMap σ o x).symm)
+    rw [heq]
+    exact continuous_chamberMap σ o
+  let _ : Fintype (VertexOrder σ) := Fintype.ofFinite (VertexOrder σ)
+  simpa only [Finset.mem_univ, Set.iUnion_true] using
+    continuousOn_iUnion_finset_of_isClosed
+      (Finset.univ : Finset (VertexOrder σ)) (orderChamber σ)
+      (fun o _ => isClosed_orderChamber σ o) (fun o _ => hpiece o)
+
+/-- The canonical homeomorphism from the realization of the barycentric subdivision of `K` to
+the realization of `K`. It sends every face-vertex to the barycenter of that face. -/
+noncomputable def barycentricSubdivisionRealizationHomeomorph
+    (K : AbstractSimplicialComplex ι) :
+    Realization (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
+      K.toPreAbstractSimplicialComplex) ≃ₜ Realization K where
+  toEquiv := Equiv.ofBijective (barycentricSubdivisionRealizationMap K)
+    (barycentricSubdivisionRealizationMap_bijective K)
+  continuous_toFun := continuous_barycentricSubdivisionRealizationMap K
+  continuous_invFun := continuous_inverse_barycentricSubdivisionRealizationMap K
+
+/-- The subdivision realization homeomorphism has the canonical affine map as its forward map. -/
+@[simp]
+theorem barycentricSubdivisionRealizationHomeomorph_apply
+    (K : AbstractSimplicialComplex ι)
+    (x : Realization (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
+      K.toPreAbstractSimplicialComplex)) :
+    barycentricSubdivisionRealizationHomeomorph K x =
+      barycentricSubdivisionRealizationMap K x :=
+  (rfl)
+
+end AbstractSimplicialComplex

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Homeomorph.lean
@@ -44,7 +44,7 @@ variable {ι : Type*}
 attribute [local instance] Classical.decEq
 
 private abbrev VertexOrder {K : AbstractSimplicialComplex ι} (σ : Face K) :=
-  Fin σ.1.card ≃ {v // v ∈ σ.1}
+  BarycentricSubdivision.VertexOrder σ
 
 /-- The closed chamber in which the coordinates occur in decreasing order along `e`. -/
 private def orderChamber {K : AbstractSimplicialComplex ι} (σ : Face K)
@@ -106,73 +106,6 @@ private theorem iUnion_orderChamber {K : AbstractSimplicialComplex ι} (σ : Fac
   exact Set.mem_iUnion.2
     ⟨decreasingVertexOrder σ x, mem_orderChamber_decreasingVertexOrder σ x⟩
 
-/-- The first `i + 1` vertices in a fixed ordering of a face. -/
-private def orderedPrefixVertices {K : AbstractSimplicialComplex ι} {σ : Face K}
-    (e : VertexOrder σ) (i : Fin σ.1.card) : Finset ι :=
-  (Finset.Iic i).image fun j => (e j).1
-
-private theorem orderedPrefixVertices_nonempty {K : AbstractSimplicialComplex ι} {σ : Face K}
-    (e : VertexOrder σ) (i : Fin σ.1.card) : (orderedPrefixVertices e i).Nonempty := by
-  exact ⟨(e i).1, Finset.mem_image.2 ⟨i, Finset.mem_Iic.2 le_rfl, rfl⟩⟩
-
-private theorem orderedPrefixVertices_subset {K : AbstractSimplicialComplex ι} {σ : Face K}
-    (e : VertexOrder σ) (i : Fin σ.1.card) : orderedPrefixVertices e i ⊆ σ.1 := by
-  intro v hv
-  obtain ⟨j, -, rfl⟩ := Finset.mem_image.1 hv
-  exact (e j).2
-
-private noncomputable def orderedPrefixFace {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (i : Fin σ.1.card) : Face K :=
-  ⟨orderedPrefixVertices e i, K.isRelLowerSet_faces.mem_of_le σ.2
-    (orderedPrefixVertices_subset e i) (orderedPrefixVertices_nonempty e i)⟩
-
-private theorem orderedPrefixFace_mono {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) {i j : Fin σ.1.card} (hij : i ≤ j) :
-    orderedPrefixFace σ e i ≤ orderedPrefixFace σ e j := by
-  intro v hv
-  obtain ⟨k, hki, rfl⟩ := Finset.mem_image.1 hv
-  exact Finset.mem_image.2
-    ⟨k, Finset.mem_Iic.2 ((Finset.mem_Iic.1 hki).trans hij), rfl⟩
-
-private theorem card_orderedPrefixFace {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (i : Fin σ.1.card) :
-    (orderedPrefixFace σ e i).1.card = i.1 + 1 := by
-  -- Forget the face-membership proof before counting the underlying initial segment.
-  change (orderedPrefixVertices e i).card = i.1 + 1
-  rw [orderedPrefixVertices, Finset.card_image_iff.mpr]
-  · exact Fin.card_Iic i
-  · exact fun _ _ _ _ h => e.injective (Subtype.ext h)
-
-/-- The chain of initial faces determined by a vertex ordering. -/
-private noncomputable def orderedSubdivisionFaces {K : AbstractSimplicialComplex ι}
-    (σ : Face K) (e : VertexOrder σ) : Finset (Face K) :=
-  Finset.univ.image (orderedPrefixFace σ e)
-
-private theorem orderedSubdivisionFaces_nonempty {K : AbstractSimplicialComplex ι}
-    (σ : Face K) (e : VertexOrder σ) : (orderedSubdivisionFaces σ e).Nonempty := by
-  have hσ : 0 < σ.1.card := Finset.card_pos.mpr
-    (K.isRelLowerSet_faces.prop_of_mem σ.2)
-  let i : Fin σ.1.card := ⟨0, hσ⟩
-  exact ⟨orderedPrefixFace σ e i,
-    Finset.mem_image.2 ⟨i, Finset.mem_univ _, rfl⟩⟩
-
-private theorem orderedSubdivisionFaces_mem {K : AbstractSimplicialComplex ι}
-    (σ : Face K) (e : VertexOrder σ) :
-    orderedSubdivisionFaces σ e ∈ TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
-      K.toPreAbstractSimplicialComplex := by
-  rw [TauCeti.PreAbstractSimplicialComplex.mem_barycentricSubdivision_iff]
-  refine ⟨orderedSubdivisionFaces_nonempty σ e, ?_⟩
-  intro ρ hρ τ hτ _
-  obtain ⟨i, -, rfl⟩ := Finset.mem_image.1 hρ
-  obtain ⟨j, -, rfl⟩ := Finset.mem_image.1 hτ
-  exact (le_total i j).imp (orderedPrefixFace_mono σ e) (orderedPrefixFace_mono σ e)
-
-private noncomputable def orderedSubdivisionFace {K : AbstractSimplicialComplex ι}
-    (σ : Face K) (e : VertexOrder σ) :
-    Face (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
-      K.toPreAbstractSimplicialComplex) :=
-  ⟨orderedSubdivisionFaces σ e, orderedSubdivisionFaces_mem σ e⟩
-
 /-- Extend the ordered coordinates by zero after the last vertex. -/
 private noncomputable def chamberOrderedCoord {K : AbstractSimplicialComplex ι} (σ : Face K)
     (e : VertexOrder σ) (x : orderChamber σ e) (k : ℕ) : ℝ :=
@@ -212,53 +145,6 @@ private theorem chamberOrderedCoord_succ_le {K : AbstractSimplicialComplex ι} (
     simp only [hks, ↓reduceDIte]
     exact StandardSimplex.nonneg x.1 _
 
-/-- The coefficient of the `i`th initial face in one ordered chamber. -/
-private noncomputable def chamberWeight {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (x : orderChamber σ e) (i : Fin σ.1.card) : ℝ :=
-  (i.1 + 1 : ℝ) *
-    (chamberOrderedCoord σ e x i.1 - chamberOrderedCoord σ e x (i.1 + 1))
-
-private theorem chamberWeight_nonneg {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (x : orderChamber σ e) (i : Fin σ.1.card) :
-    0 ≤ chamberWeight σ e x i := by
-  exact mul_nonneg (by positivity)
-    (sub_nonneg.2 (chamberOrderedCoord_succ_le σ e x i.2))
-
-private theorem continuous_chamberWeight {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (i : Fin σ.1.card) :
-    Continuous (fun x : orderChamber σ e => chamberWeight σ e x i) :=
-  continuous_const.mul
-    ((continuous_chamberOrderedCoord σ e i.1).sub
-      (continuous_chamberOrderedCoord σ e (i.1 + 1)))
-
-/-- Summation by parts for the coefficients in an ordered chamber. -/
-private theorem sum_range_succ_mul_sub (f : ℕ → ℝ) (n : ℕ) :
-    ∑ i ∈ Finset.range n, (i + 1 : ℝ) * (f i - f (i + 1)) =
-      ∑ i ∈ Finset.range n, f i - (n : ℝ) * f n := by
-  apply Finset.sum_range_induction
-  · simp
-  · intro k _
-    rw [Finset.sum_range_succ]
-    push_cast
-    ring
-
-private theorem sum_range_ite_le_sub (f : ℕ → ℝ) {j n : ℕ} (hjn : j < n) :
-    ∑ i ∈ Finset.range n, (if j ≤ i then f i - f (i + 1) else 0) = f j - f n := by
-  rw [← Finset.sum_filter]
-  have hfilter : (Finset.range n).filter (j ≤ ·) = Finset.Ico j n := by
-    ext i
-    simp [and_comm]
-  rw [hfilter]
-  calc
-    ∑ i ∈ Finset.Ico j n, (f i - f (i + 1)) =
-        -∑ i ∈ Finset.Ico j n, (f (i + 1) - f i) := by
-      rw [← Finset.sum_neg_distrib]
-      apply Finset.sum_congr rfl
-      intro i _
-      ring
-    _ = -(f n - f j) := by rw [Finset.sum_Ico_sub f hjn.le]
-    _ = f j - f n := by ring
-
 private theorem sum_chamberOrderedCoord {K : AbstractSimplicialComplex ι} (σ : Face K)
     (e : VertexOrder σ) (x : orderChamber σ e) :
     ∑ k ∈ Finset.range σ.1.card, chamberOrderedCoord σ e x k = 1 := by
@@ -277,223 +163,31 @@ private theorem sum_chamberOrderedCoord {K : AbstractSimplicialComplex ι} (σ :
         (fun _ r => r) (by simp)]
       exact StandardSimplex.sum_eq_one x.1
 
-private theorem sum_chamberWeight {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (x : orderChamber σ e) :
-    ∑ i, chamberWeight σ e x i = 1 := by
-  calc
-    ∑ i, chamberWeight σ e x i =
-        ∑ i ∈ Finset.range σ.1.card,
-          (i + 1 : ℝ) * (chamberOrderedCoord σ e x i -
-            chamberOrderedCoord σ e x (i + 1)) := by
-      rw [← Fin.sum_univ_eq_sum_range]
-      apply Finset.sum_congr rfl
-      intro i _
-      rfl
-    _ = 1 := by
-      rw [sum_range_succ_mul_sub, chamberOrderedCoord_card, mul_zero, sub_zero,
-        sum_chamberOrderedCoord]
-
-/-- The subdivision coordinates defined by a fixed vertex ordering. -/
-private noncomputable def chamberCoordinates {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (x : orderChamber σ e) : Face K →₀ ℝ :=
-  ∑ i : Fin σ.1.card,
-    Finsupp.single (orderedPrefixFace σ e i) (chamberWeight σ e x i)
-
-private theorem chamberCoordinates_nonneg {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (x : orderChamber σ e) (ρ : Face K) :
-    0 ≤ chamberCoordinates σ e x ρ := by
-  rw [chamberCoordinates]
-  -- Evaluation is the additive homomorphism needed to move through the finite sum of `Finsupp`s.
-  change 0 ≤ Finsupp.applyAddHom ρ
-    (∑ i : Fin σ.1.card,
-      Finsupp.single (orderedPrefixFace σ e i) (chamberWeight σ e x i))
-  rw [map_sum]
-  apply Finset.sum_nonneg
-  intro i _
-  by_cases h : orderedPrefixFace σ e i = ρ
-  · simp [h, chamberWeight_nonneg]
-  · simp [h]
-
-private theorem chamberCoordinates_sum {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (x : orderChamber σ e) :
-    (chamberCoordinates σ e x).sum (fun _ r => r) = 1 := by
-  rw [chamberCoordinates]
-  rw [← Finsupp.sum_finsetSum_index (fun _ => rfl) (fun _ _ _ => rfl)]
-  simp only [Finsupp.sum_single_index]
-  exact sum_chamberWeight σ e x
-
-private theorem chamberCoordinates_support {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (x : orderChamber σ e) :
-    (chamberCoordinates σ e x).support ⊆ orderedSubdivisionFaces σ e := by
-  intro ρ hρ
-  by_contra hnot
-  have hne : ∀ i : Fin σ.1.card, orderedPrefixFace σ e i ≠ ρ := by
-    intro i hi
-    apply hnot
-    exact Finset.mem_image.2 ⟨i, Finset.mem_univ _, hi⟩
-  have hz : chamberCoordinates σ e x ρ = 0 := by
-    simp [chamberCoordinates, hne]
-  exact (Finsupp.mem_support_iff.mp hρ) hz
-
-private theorem chamberCoordinates_mem {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (x : orderChamber σ e) :
-    chamberCoordinates σ e x ∈
-      convexHull ℝ ((fun ρ => Finsupp.single ρ (1 : ℝ)) ''
-        (orderedSubdivisionFaces σ e : Set (Face K))) := by
-  rw [mem_standardSimplex_iff]
-  exact ⟨chamberCoordinates_nonneg σ e x, chamberCoordinates_sum σ e x,
-    chamberCoordinates_support σ e x⟩
-
-private noncomputable def chamberStandardSimplex {K : AbstractSimplicialComplex ι}
-    (σ : Face K) (e : VertexOrder σ) (x : orderChamber σ e) :
-    StandardSimplex (orderedSubdivisionFaces σ e) :=
-  ⟨chamberCoordinates σ e x, by simpa using chamberCoordinates_mem σ e x⟩
-
-private theorem continuous_chamberStandardSimplex {K : AbstractSimplicialComplex ι}
-    (σ : Face K) (e : VertexOrder σ) : Continuous (chamberStandardSimplex σ e) := by
-  apply continuous_induced_rng.mpr
-  apply continuous_pi
-  intro ρ
-  have hformula :
-      (fun x : orderChamber σ e => (chamberStandardSimplex σ e x : Face K → ℝ) ρ) =
-        fun x => ∑ i : Fin σ.1.card,
-          if orderedPrefixFace σ e i = ρ then chamberWeight σ e x i else 0 := by
-    funext x
-    -- Expose the coordinate function carried by the target simplex subtype.
-    rw [show (chamberStandardSimplex σ e x : Face K →₀ ℝ) =
-      chamberCoordinates σ e x by rfl]
-    rw [chamberCoordinates]
-    rw [Finset.sum_apply']
-    apply Finset.sum_congr rfl
-    intro i _
-    simp [Finsupp.single_apply, eq_comm]
-  -- The induced topology on the target simplex is defined through its coordinate function.
-  change Continuous (fun x : orderChamber σ e =>
-    (chamberStandardSimplex σ e x : Face K → ℝ) ρ)
-  rw [hformula]
-  apply continuous_finsetSum
-  intro i _
-  by_cases h : orderedPrefixFace σ e i = ρ
-  · simp only [h, ↓reduceIte]
-    exact continuous_chamberWeight σ e i
-  · simp only [h, ↓reduceIte]
-    exact continuous_const
-
 /-- The chamber formula, included into the whole subdivision realization. -/
 private noncomputable def chamberMap {K : AbstractSimplicialComplex ι} (σ : Face K)
     (e : VertexOrder σ) (x : orderChamber σ e) :
     Realization (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
       K.toPreAbstractSimplicialComplex) :=
-  faceInclusion _ (orderedSubdivisionFace σ e) (chamberStandardSimplex σ e x)
+  BarycentricSubdivision.orderedSubdivisionPoint σ e (chamberOrderedCoord σ e x)
+    (chamberOrderedCoord_succ_le σ e x) (sum_chamberOrderedCoord σ e x)
+    (chamberOrderedCoord_card σ e x)
 
 private theorem continuous_chamberMap {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) : Continuous (chamberMap σ e) :=
-  (continuous_faceInclusion _ (orderedSubdivisionFace σ e)).comp
-    (continuous_chamberStandardSimplex σ e)
-
-private theorem mem_orderedPrefixVertices_iff {K : AbstractSimplicialComplex ι}
-    (σ : Face K) (e : VertexOrder σ) {v : ι} (hv : v ∈ σ.1) (i : Fin σ.1.card) :
-    v ∈ orderedPrefixVertices e i ↔ e.symm ⟨v, hv⟩ ≤ i := by
-  constructor
-  · intro h
-    obtain ⟨j, hj, hjv⟩ := Finset.mem_image.1 h
-    have heq : j = e.symm ⟨v, hv⟩ := by
-      apply e.injective
-      apply Subtype.ext
-      rw [hjv, e.apply_symm_apply]
-    rw [← heq]
-    exact Finset.mem_Iic.1 hj
-  · intro h
-    exact Finset.mem_image.2
-      ⟨e.symm ⟨v, hv⟩, Finset.mem_Iic.2 h, by simp⟩
-
-private theorem chamberWeight_mul_card_prefix_inv {K : AbstractSimplicialComplex ι}
-    (σ : Face K) (e : VertexOrder σ) (x : orderChamber σ e) (i : Fin σ.1.card) :
-    chamberWeight σ e x i * ((orderedPrefixFace σ e i).1.card : ℝ)⁻¹ =
-      chamberOrderedCoord σ e x i.1 - chamberOrderedCoord σ e x (i.1 + 1) := by
-  rw [chamberWeight, card_orderedPrefixFace]
-  have hne : (i.1 + 1 : ℝ) ≠ 0 := by positivity
-  field_simp
-  norm_num [Nat.cast_add, Nat.cast_one]
-  ring
-
-private theorem barycentricSubdivisionLinearMap_chamberCoordinates
-    {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ)
-    (x : orderChamber σ e) :
-    barycentricSubdivisionLinearMap K (chamberCoordinates σ e x) =
-      ∑ i : Fin σ.1.card,
-        chamberWeight σ e x i • faceBarycenter K (orderedPrefixFace σ e i) := by
-  rw [chamberCoordinates, map_sum]
-  apply Finset.sum_congr rfl
-  intro i _
-  rw [← Finsupp.smul_single_one, map_smul, barycentricSubdivisionLinearMap_single]
-
-private theorem barycentricSubdivisionLinearMap_chamberCoordinates_apply_of_mem
-    {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ)
-    (x : orderChamber σ e) {v : ι} (hv : v ∈ σ.1) :
-    barycentricSubdivisionLinearMap K (chamberCoordinates σ e x) v = x.1.1 v := by
-  rw [barycentricSubdivisionLinearMap_chamberCoordinates]
-  simp only [Finset.sum_apply', Finsupp.smul_apply, smul_eq_mul, faceBarycenter_apply]
-  let j : Fin σ.1.card := e.symm ⟨v, hv⟩
-  calc
-    ∑ i : Fin σ.1.card,
-        chamberWeight σ e x i *
-          (if v ∈ (orderedPrefixFace σ e i).1 then
-            ((orderedPrefixFace σ e i).1.card : ℝ)⁻¹ else 0) =
-        ∑ i : Fin σ.1.card,
-          if j ≤ i then chamberOrderedCoord σ e x i.1 -
-            chamberOrderedCoord σ e x (i.1 + 1) else 0 := by
-      apply Finset.sum_congr rfl
-      intro i _
-      by_cases hji : j ≤ i
-      · have hmem : v ∈ (orderedPrefixFace σ e i).1 :=
-          (mem_orderedPrefixVertices_iff σ e hv i).2 hji
-        simp only [hmem, hji, ↓reduceIte]
-        exact chamberWeight_mul_card_prefix_inv σ e x i
-      · have hmem : v ∉ (orderedPrefixFace σ e i).1 := fun h =>
-          hji ((mem_orderedPrefixVertices_iff σ e hv i).1 h)
-        simp [hmem, hji]
-    _ = ∑ i ∈ Finset.range σ.1.card,
-          if j.1 ≤ i then chamberOrderedCoord σ e x i -
-            chamberOrderedCoord σ e x (i + 1) else 0 := by
-      rw [← Fin.sum_univ_eq_sum_range]
-      apply Finset.sum_congr rfl
-      intro i _
-      rfl
-    _ = chamberOrderedCoord σ e x j.1 - chamberOrderedCoord σ e x σ.1.card :=
-      sum_range_ite_le_sub (chamberOrderedCoord σ e x) j.2
-    _ = x.1.1 v := by
-      rw [chamberOrderedCoord_card, sub_zero, chamberOrderedCoord_of_lt σ e x j.2]
-      exact congrArg (fun w : {v // v ∈ σ.1} => x.1.1 w.1)
-        (e.apply_symm_apply ⟨v, hv⟩)
-
-private theorem barycentricSubdivisionLinearMap_chamberCoordinates_apply_of_notMem
-    {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ)
-    (x : orderChamber σ e) {v : ι} (hv : v ∉ σ.1) :
-    barycentricSubdivisionLinearMap K (chamberCoordinates σ e x) v = x.1.1 v := by
-  rw [barycentricSubdivisionLinearMap_chamberCoordinates]
-  simp only [Finset.sum_apply', Finsupp.smul_apply, smul_eq_mul, faceBarycenter_apply]
-  have hprefix : ∀ i : Fin σ.1.card, v ∉ (orderedPrefixFace σ e i).1 :=
-    fun i hvi => hv (orderedPrefixVertices_subset e i hvi)
-  simp only [hprefix, ↓reduceIte, mul_zero, Finset.sum_const_zero]
-  exact (Finsupp.notMem_support_iff.mp
-    (fun hsupport => hv (StandardSimplex.support_subset x.1 hsupport))).symm
-
-private theorem chamberMap_val {K : AbstractSimplicialComplex ι} (σ : Face K)
-    (e : VertexOrder σ) (x : orderChamber σ e) :
-    (chamberMap σ e x : Face K →₀ ℝ) = chamberCoordinates σ e x := by
-  exact faceInclusion_val _ (orderedSubdivisionFace σ e) (chamberStandardSimplex σ e x)
+    (e : VertexOrder σ) : Continuous (chamberMap σ e) := by
+  exact BarycentricSubdivision.continuous_orderedSubdivisionPoint σ e
+    (fun x k => chamberOrderedCoord σ e x k)
+    (fun x _ hk => chamberOrderedCoord_succ_le σ e x hk)
+    (sum_chamberOrderedCoord σ e) (chamberOrderedCoord_card σ e)
+    (continuous_chamberOrderedCoord σ e)
 
 private theorem barycentricSubdivisionRealizationMap_chamberMap
     {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ)
     (x : orderChamber σ e) :
     barycentricSubdivisionRealizationMap K (chamberMap σ e x) = faceInclusion K σ x.1 := by
-  apply Subtype.ext
-  ext v
-  rw [barycentricSubdivisionRealizationMap_val, chamberMap_val, faceInclusion_val]
-  by_cases hv : v ∈ σ.1
-  · exact barycentricSubdivisionLinearMap_chamberCoordinates_apply_of_mem σ e x hv
-  · exact barycentricSubdivisionLinearMap_chamberCoordinates_apply_of_notMem σ e x hv
+  exact BarycentricSubdivision.barycentricSubdivisionRealizationMap_orderedSubdivisionPoint
+    σ e (chamberOrderedCoord σ e x) (chamberOrderedCoord_succ_le σ e x)
+    (sum_chamberOrderedCoord σ e x) (chamberOrderedCoord_card σ e x) x.1
+    (fun i => chamberOrderedCoord_of_lt σ e x i.2)
 
 private theorem continuousOn_iUnion_finset_of_isClosed {α β κ : Type*}
     [TopologicalSpace α] [TopologicalSpace β] {f : α → β} (s : Finset κ) (u : κ → Set α)

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Homeomorph.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.BigOperators.Intervals
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Subdivision.Injective
 
 /-!
@@ -17,9 +16,10 @@ the barycenter of that face and extends affinely over subdivision simplices.
 
 Continuity of the inverse is proved simplex by simplex, using the weak topology on realizations.
 Each original simplex is covered by the finitely many closed chambers obtained by ordering its
-barycentric coordinates. On one chamber the inverse has a fixed affine formula: consecutive
-coordinate differences are the coefficients of the nested initial faces in that order. These
-formulas are continuous and agree on chamber intersections because the forward map is injective.
+barycentric coordinates. On one chamber the inverse has a fixed affine formula: cardinality-scaled
+consecutive coordinate differences are the coefficients of the nested initial faces in that order.
+These formulas are continuous and agree on chamber intersections because the forward map is
+injective.
 
 This completes the subdivision part of the geometric-realization milestone in Layer 11 of the
 GeometricTopology roadmap. The construction follows Rourke--Sanderson, *Introduction to

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Injective.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Injective.lean
@@ -21,8 +21,8 @@ belongs to no smaller face in the chain; evaluating there recovers its coefficie
 greatest face and inducting proves uniqueness of all the coefficients.
 
 This is the second bijectivity step in the subdivision-realization milestone in Layer 11 of the
-GeometricTopology roadmap. Continuity of the inverse remains to package the resulting bijection as
-a homeomorphism.
+GeometricTopology roadmap. `Subdivision.Homeomorph` proves continuity of the inverse and packages
+the resulting bijection as a homeomorphism.
 
 The argument follows the standard uniqueness proof for barycentric subdivision in
 Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2, "Derived Subdivisions".

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Realization.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Realization.lean
@@ -19,8 +19,8 @@ face in that chain. The affine extension therefore lands in the realization of `
 
 This file constructs that canonical continuous map. It is the forward map in the homeomorphism
 between the realizations of a complex and its barycentric subdivision required by Layer 11 of the
-GeometricTopology roadmap. Proving that it is a homeomorphism requires the inverse obtained by
-sorting the barycentric coordinates of a point, and is left to the next step.
+GeometricTopology roadmap. The inverse is constructed and proved continuous in
+`Subdivision.Homeomorph`.
 
 The construction follows Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2,
 "Derived Subdivisions".

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import Mathlib.Algebra.BigOperators.Intervals
 public import TauCeti.AlgebraicTopology.SimplicialComplex.Subdivision.Realization
 
 /-!
@@ -120,7 +121,7 @@ private def orderedWeight (c : ℕ → ℝ) (i : ℕ) : ℝ :=
   (i + 1 : ℝ) * (c i - c (i + 1))
 
 /-- Summation by parts for consecutive coordinate differences. -/
-theorem sum_range_succ_mul_sub (f : ℕ → ℝ) (n : ℕ) :
+private theorem sum_range_succ_mul_sub (f : ℕ → ℝ) (n : ℕ) :
     ∑ i ∈ Finset.range n, (i + 1 : ℝ) * (f i - f (i + 1)) =
       ∑ i ∈ Finset.range n, f i - (n : ℝ) * f n := by
   induction n with
@@ -131,25 +132,15 @@ theorem sum_range_succ_mul_sub (f : ℕ → ℝ) (n : ℕ) :
       ring
 
 /-- The tail of a telescoping sum of consecutive differences. -/
-theorem sum_range_ite_le_sub (f : ℕ → ℝ) {j n : ℕ} (hjn : j < n) :
+private theorem sum_range_ite_le_sub (f : ℕ → ℝ) {j n : ℕ} (hjn : j < n) :
     ∑ i ∈ Finset.range n, (if j ≤ i then f i - f (i + 1) else 0) = f j - f n := by
-  induction n with
-  | zero => omega
-  | succ n ih =>
-      rw [Finset.sum_range_succ]
-      by_cases hj : j = n
-      · subst j
-        have hz : ∑ i ∈ Finset.range n, (if n ≤ i then f i - f (i + 1) else 0) = 0 := by
-          apply Finset.sum_eq_zero
-          intro i hi
-          simp only [Finset.mem_range] at hi
-          simp [Nat.not_le_of_lt hi]
-        rw [hz]
-        simp
-      · have hjn' : j < n := by omega
-        rw [ih hjn']
-        simp only [hjn'.le, ↓reduceIte]
-        ring
+  rw [← Finset.sum_filter]
+  have hfilter : (Finset.range n).filter (j ≤ ·) = Finset.Ico j n := by
+    ext i
+    simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_Ico]
+    omega
+  rw [hfilter]
+  simpa only [neg_sub_neg] using Finset.sum_Ico_sub (fun k => -f k) hjn.le
 
 /-- The barycentric-subdivision coordinates associated to an ordered coordinate sequence. -/
 private noncomputable def orderedCoordinates {K : AbstractSimplicialComplex ι} (σ : Face K)
@@ -176,6 +167,7 @@ private theorem orderedCoordinates_nonneg {K : AbstractSimplicialComplex ι} (σ
     (e : VertexOrder σ) (c : ℕ → ℝ) (hc : ∀ {k}, k < σ.1.card → c (k + 1) ≤ c k)
     (ρ : Face K) : 0 ≤ orderedCoordinates σ e c ρ := by
   rw [orderedCoordinates]
+  -- Expose evaluation of the finite `Finsupp` sum so nonnegativity reduces coordinatewise.
   change 0 ≤ Finsupp.applyAddHom ρ
     (∑ i : Fin σ.1.card, Finsupp.single (orderedPrefixFace σ e i) (orderedWeight c i))
   rw [map_sum]
@@ -330,6 +322,8 @@ theorem continuous_orderedSubdivisionPoint {K : AbstractSimplicialComplex ι} {�
   apply continuous_induced_rng.mpr
   apply continuous_pi
   intro ρ
+  -- The realization and simplex topologies are induced from the ambient coordinate function;
+  -- expose that coordinate, then expand the finite `Finsupp.single` sum pointwise.
   change Continuous (fun a => orderedCoordinates σ e (c a) ρ)
   rw [show (fun a => orderedCoordinates σ e (c a) ρ) = fun a =>
       ∑ i : Fin σ.1.card,

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
@@ -17,8 +17,8 @@ take the nested initial segments in that order, and express the point as a conve
 their barycenters.
 
 This is the first bijectivity step in the subdivision-realization milestone in Layer 11 of the
-geometric topology roadmap. Injectivity and continuity of the inverse remain separate steps toward
-the homeomorphism between a complex and its barycentric subdivision.
+geometric topology roadmap. `Subdivision.Injective` proves injectivity, and
+`Subdivision.Homeomorph` proves continuity of the inverse.
 
 The construction follows Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2,
 "Derived Subdivisions".

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
@@ -41,6 +41,314 @@ variable {ι : Type*}
 
 attribute [local instance] Classical.decEq
 
+namespace BarycentricSubdivision
+
+/-- A numbering of the vertices of a face. -/
+abbrev VertexOrder {K : AbstractSimplicialComplex ι} (σ : Face K) :=
+  Fin σ.1.card ≃ {v // v ∈ σ.1}
+
+/-- The first `i + 1` vertices in a fixed ordering of a face. -/
+private def orderedPrefixVertices {K : AbstractSimplicialComplex ι} {σ : Face K}
+    (e : VertexOrder σ) (i : Fin σ.1.card) : Finset ι :=
+  (Finset.Iic i).image fun j => (e j).1
+
+private theorem orderedPrefixVertices_nonempty {K : AbstractSimplicialComplex ι} {σ : Face K}
+    (e : VertexOrder σ) (i : Fin σ.1.card) : (orderedPrefixVertices e i).Nonempty := by
+  exact ⟨(e i).1, Finset.mem_image.2 ⟨i, Finset.mem_Iic.2 le_rfl, rfl⟩⟩
+
+private theorem orderedPrefixVertices_subset {K : AbstractSimplicialComplex ι} {σ : Face K}
+    (e : VertexOrder σ) (i : Fin σ.1.card) : orderedPrefixVertices e i ⊆ σ.1 := by
+  intro v hv
+  obtain ⟨j, -, rfl⟩ := Finset.mem_image.1 hv
+  exact (e j).2
+
+/-- The face on the first `i + 1` vertices in a fixed ordering. -/
+private noncomputable def orderedPrefixFace {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (i : Fin σ.1.card) : Face K :=
+  ⟨orderedPrefixVertices e i, K.isRelLowerSet_faces.mem_of_le σ.2
+    (orderedPrefixVertices_subset e i) (orderedPrefixVertices_nonempty e i)⟩
+
+private theorem orderedPrefixFace_mono {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) {i j : Fin σ.1.card} (hij : i ≤ j) :
+    orderedPrefixFace σ e i ≤ orderedPrefixFace σ e j := by
+  intro v hv
+  obtain ⟨k, hki, rfl⟩ := Finset.mem_image.1 hv
+  exact Finset.mem_image.2
+    ⟨k, Finset.mem_Iic.2 ((Finset.mem_Iic.1 hki).trans hij), rfl⟩
+
+private theorem card_orderedPrefixFace {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (i : Fin σ.1.card) :
+    (orderedPrefixFace σ e i).1.card = i.1 + 1 := by
+  change (orderedPrefixVertices e i).card = i.1 + 1
+  rw [orderedPrefixVertices, Finset.card_image_iff.mpr]
+  · exact Fin.card_Iic i
+  · exact fun _ _ _ _ h => e.injective (Subtype.ext h)
+
+/-- The chain of initial faces determined by a vertex ordering. -/
+private noncomputable def orderedSubdivisionFaces {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) : Finset (Face K) :=
+  Finset.univ.image (orderedPrefixFace σ e)
+
+private theorem orderedSubdivisionFaces_nonempty {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) : (orderedSubdivisionFaces σ e).Nonempty := by
+  have hσ : 0 < σ.1.card := Finset.card_pos.mpr
+    (K.isRelLowerSet_faces.prop_of_mem σ.2)
+  let i : Fin σ.1.card := ⟨0, hσ⟩
+  exact ⟨orderedPrefixFace σ e i,
+    Finset.mem_image.2 ⟨i, Finset.mem_univ _, rfl⟩⟩
+
+private theorem orderedSubdivisionFaces_mem {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) :
+    orderedSubdivisionFaces σ e ∈ TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
+      K.toPreAbstractSimplicialComplex := by
+  rw [TauCeti.PreAbstractSimplicialComplex.mem_barycentricSubdivision_iff]
+  refine ⟨orderedSubdivisionFaces_nonempty σ e, ?_⟩
+  intro ρ hρ τ hτ _
+  obtain ⟨i, -, rfl⟩ := Finset.mem_image.1 hρ
+  obtain ⟨j, -, rfl⟩ := Finset.mem_image.1 hτ
+  exact (le_total i j).imp (orderedPrefixFace_mono σ e) (orderedPrefixFace_mono σ e)
+
+/-- The simplex of the barycentric subdivision determined by a vertex ordering. -/
+private noncomputable def orderedSubdivisionFace {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) :
+    Face (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
+      K.toPreAbstractSimplicialComplex) :=
+  ⟨orderedSubdivisionFaces σ e, orderedSubdivisionFaces_mem σ e⟩
+
+/-- The coefficient of the `i`th initial face for a sequence of ordered coordinates. -/
+private def orderedWeight (c : ℕ → ℝ) (i : ℕ) : ℝ :=
+  (i + 1 : ℝ) * (c i - c (i + 1))
+
+/-- Summation by parts for consecutive coordinate differences. -/
+theorem sum_range_succ_mul_sub (f : ℕ → ℝ) (n : ℕ) :
+    ∑ i ∈ Finset.range n, (i + 1 : ℝ) * (f i - f (i + 1)) =
+      ∑ i ∈ Finset.range n, f i - (n : ℝ) * f n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Finset.sum_range_succ, Finset.sum_range_succ, ih]
+      push_cast
+      ring
+
+/-- The tail of a telescoping sum of consecutive differences. -/
+theorem sum_range_ite_le_sub (f : ℕ → ℝ) {j n : ℕ} (hjn : j < n) :
+    ∑ i ∈ Finset.range n, (if j ≤ i then f i - f (i + 1) else 0) = f j - f n := by
+  induction n with
+  | zero => omega
+  | succ n ih =>
+      rw [Finset.sum_range_succ]
+      by_cases hj : j = n
+      · subst j
+        have hz : ∑ i ∈ Finset.range n, (if n ≤ i then f i - f (i + 1) else 0) = 0 := by
+          apply Finset.sum_eq_zero
+          intro i hi
+          simp only [Finset.mem_range] at hi
+          simp [Nat.not_le_of_lt hi]
+        rw [hz]
+        simp
+      · have hjn' : j < n := by omega
+        rw [ih hjn']
+        simp only [hjn'.le, ↓reduceIte]
+        ring
+
+/-- The barycentric-subdivision coordinates associated to an ordered coordinate sequence. -/
+private noncomputable def orderedCoordinates {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (c : ℕ → ℝ) : Face K →₀ ℝ :=
+  ∑ i : Fin σ.1.card, Finsupp.single (orderedPrefixFace σ e i) (orderedWeight c i)
+
+private theorem orderedWeight_nonneg (c : ℕ → ℝ) {n : ℕ}
+    (hc : ∀ {k}, k < n → c (k + 1) ≤ c k) (i : Fin n) : 0 ≤ orderedWeight c i := by
+  exact mul_nonneg (by positivity) (sub_nonneg.2 (hc i.2))
+
+private theorem sum_orderedWeight (c : ℕ → ℝ) (n : ℕ)
+    (hsum : ∑ k ∈ Finset.range n, c k = 1) (hcard : c n = 0) :
+    ∑ i : Fin n, orderedWeight c i = 1 := by
+  calc
+    ∑ i : Fin n, orderedWeight c i =
+        ∑ i ∈ Finset.range n, (i + 1 : ℝ) * (c i - c (i + 1)) := by
+      rw [← Fin.sum_univ_eq_sum_range]
+      apply Finset.sum_congr rfl
+      intro i _
+      rfl
+    _ = 1 := by rw [sum_range_succ_mul_sub, hsum, hcard, mul_zero, sub_zero]
+
+private theorem orderedCoordinates_nonneg {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (c : ℕ → ℝ) (hc : ∀ {k}, k < σ.1.card → c (k + 1) ≤ c k)
+    (ρ : Face K) : 0 ≤ orderedCoordinates σ e c ρ := by
+  rw [orderedCoordinates]
+  change 0 ≤ Finsupp.applyAddHom ρ
+    (∑ i : Fin σ.1.card, Finsupp.single (orderedPrefixFace σ e i) (orderedWeight c i))
+  rw [map_sum]
+  apply Finset.sum_nonneg
+  intro i _
+  by_cases h : orderedPrefixFace σ e i = ρ
+  · simp [h, orderedWeight_nonneg c hc]
+  · simp [h]
+
+private theorem orderedCoordinates_sum {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (c : ℕ → ℝ) (hsum : ∑ k ∈ Finset.range σ.1.card, c k = 1)
+    (hcard : c σ.1.card = 0) : (orderedCoordinates σ e c).sum (fun _ r => r) = 1 := by
+  rw [orderedCoordinates, ← Finsupp.sum_finsetSum_index (fun _ => rfl) (fun _ _ _ => rfl)]
+  simp only [Finsupp.sum_single_index]
+  exact sum_orderedWeight c σ.1.card hsum hcard
+
+private theorem orderedCoordinates_support {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (c : ℕ → ℝ) :
+    (orderedCoordinates σ e c).support ⊆ orderedSubdivisionFaces σ e := by
+  intro ρ hρ
+  by_contra hnot
+  have hne : ∀ i : Fin σ.1.card, orderedPrefixFace σ e i ≠ ρ := by
+    intro i hi
+    apply hnot
+    exact Finset.mem_image.2 ⟨i, Finset.mem_univ _, hi⟩
+  have hz : orderedCoordinates σ e c ρ = 0 := by simp [orderedCoordinates, hne]
+  exact (Finsupp.mem_support_iff.mp hρ) hz
+
+private theorem orderedCoordinates_mem {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (c : ℕ → ℝ) (hc : ∀ {k}, k < σ.1.card → c (k + 1) ≤ c k)
+    (hsum : ∑ k ∈ Finset.range σ.1.card, c k = 1) (hcard : c σ.1.card = 0) :
+    orderedCoordinates σ e c ∈ convexHull ℝ ((fun ρ => Finsupp.single ρ (1 : ℝ)) ''
+      (orderedSubdivisionFaces σ e : Set (Face K))) := by
+  rw [mem_standardSimplex_iff]
+  exact ⟨orderedCoordinates_nonneg σ e c hc, orderedCoordinates_sum σ e c hsum hcard,
+    orderedCoordinates_support σ e c⟩
+
+private noncomputable def orderedStandardSimplex {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) (c : ℕ → ℝ)
+    (hc : ∀ {k}, k < σ.1.card → c (k + 1) ≤ c k)
+    (hsum : ∑ k ∈ Finset.range σ.1.card, c k = 1) (hcard : c σ.1.card = 0) :
+    StandardSimplex (orderedSubdivisionFaces σ e) :=
+  ⟨orderedCoordinates σ e c, by simpa using orderedCoordinates_mem σ e c hc hsum hcard⟩
+
+/-- The point of the barycentric subdivision determined by a face, an ordering of its vertices,
+and a decreasing sequence of barycentric coordinates. -/
+noncomputable def orderedSubdivisionPoint {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (c : ℕ → ℝ) (hc : ∀ {k}, k < σ.1.card → c (k + 1) ≤ c k)
+    (hsum : ∑ k ∈ Finset.range σ.1.card, c k = 1) (hcard : c σ.1.card = 0) :
+    Realization (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
+      K.toPreAbstractSimplicialComplex) :=
+  faceInclusion _ (orderedSubdivisionFace σ e)
+    (orderedStandardSimplex σ e c hc hsum hcard)
+
+private theorem orderedSubdivisionPoint_val {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (c : ℕ → ℝ) (hc : ∀ {k}, k < σ.1.card → c (k + 1) ≤ c k)
+    (hsum : ∑ k ∈ Finset.range σ.1.card, c k = 1) (hcard : c σ.1.card = 0) :
+    (orderedSubdivisionPoint σ e c hc hsum hcard : Face K →₀ ℝ) =
+      orderedCoordinates σ e c := by
+  exact faceInclusion_val _ (orderedSubdivisionFace σ e)
+    (orderedStandardSimplex σ e c hc hsum hcard)
+
+private theorem mem_orderedPrefixVertices_iff {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) {v : ι} (hv : v ∈ σ.1) (i : Fin σ.1.card) :
+    v ∈ orderedPrefixVertices e i ↔ e.symm ⟨v, hv⟩ ≤ i := by
+  constructor
+  · intro h
+    obtain ⟨j, hj, hjv⟩ := Finset.mem_image.1 h
+    have heq : j = e.symm ⟨v, hv⟩ := by
+      apply e.injective
+      apply Subtype.ext
+      rw [hjv, e.apply_symm_apply]
+    rw [← heq]
+    exact Finset.mem_Iic.1 hj
+  · intro h
+    exact Finset.mem_image.2
+      ⟨e.symm ⟨v, hv⟩, Finset.mem_Iic.2 h, by simp⟩
+
+private theorem orderedWeight_mul_card_prefix_inv {K : AbstractSimplicialComplex ι}
+    (σ : Face K) (e : VertexOrder σ) (c : ℕ → ℝ) (i : Fin σ.1.card) :
+    orderedWeight c i * ((orderedPrefixFace σ e i).1.card : ℝ)⁻¹ = c i.1 - c (i.1 + 1) := by
+  rw [orderedWeight, card_orderedPrefixFace]
+  have hne : (i.1 + 1 : ℝ) ≠ 0 := by positivity
+  field_simp
+  norm_num [Nat.cast_add, Nat.cast_one]
+  ring
+
+private theorem barycentricSubdivisionLinearMap_orderedCoordinates
+    {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ) (c : ℕ → ℝ) :
+    barycentricSubdivisionLinearMap K (orderedCoordinates σ e c) =
+      ∑ i : Fin σ.1.card, orderedWeight c i • faceBarycenter K (orderedPrefixFace σ e i) := by
+  rw [orderedCoordinates, map_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [← Finsupp.smul_single_one, map_smul, barycentricSubdivisionLinearMap_single]
+
+/-- The shared ordered-coordinate construction maps back to the original simplex point. -/
+theorem barycentricSubdivisionRealizationMap_orderedSubdivisionPoint
+    {K : AbstractSimplicialComplex ι} (σ : Face K) (e : VertexOrder σ) (c : ℕ → ℝ)
+    (hc : ∀ {k}, k < σ.1.card → c (k + 1) ≤ c k)
+    (hsum : ∑ k ∈ Finset.range σ.1.card, c k = 1) (hcard : c σ.1.card = 0)
+    (x : StandardSimplex σ.1) (hcoord : ∀ i : Fin σ.1.card, c i.1 = x.1 (e i).1) :
+    barycentricSubdivisionRealizationMap K (orderedSubdivisionPoint σ e c hc hsum hcard) =
+      faceInclusion K σ x := by
+  apply Subtype.ext
+  ext v
+  rw [barycentricSubdivisionRealizationMap_val, orderedSubdivisionPoint_val, faceInclusion_val]
+  rw [barycentricSubdivisionLinearMap_orderedCoordinates]
+  simp only [Finset.sum_apply', Finsupp.smul_apply, smul_eq_mul, faceBarycenter_apply]
+  by_cases hv : v ∈ σ.1
+  · let j : Fin σ.1.card := e.symm ⟨v, hv⟩
+    calc
+      ∑ i : Fin σ.1.card, orderedWeight c i *
+          (if v ∈ (orderedPrefixFace σ e i).1 then
+            ((orderedPrefixFace σ e i).1.card : ℝ)⁻¹ else 0) =
+          ∑ i : Fin σ.1.card, if j ≤ i then c i.1 - c (i.1 + 1) else 0 := by
+        apply Finset.sum_congr rfl
+        intro i _
+        by_cases hji : j ≤ i
+        · have hmem : v ∈ (orderedPrefixFace σ e i).1 :=
+            (mem_orderedPrefixVertices_iff σ e hv i).2 hji
+          simp only [hmem, hji, ↓reduceIte]
+          exact orderedWeight_mul_card_prefix_inv σ e c i
+        · have hmem : v ∉ (orderedPrefixFace σ e i).1 := fun h =>
+            hji ((mem_orderedPrefixVertices_iff σ e hv i).1 h)
+          simp [hmem, hji]
+      _ = ∑ i ∈ Finset.range σ.1.card,
+            if j.1 ≤ i then c i - c (i + 1) else 0 := by
+        rw [← Fin.sum_univ_eq_sum_range]
+        apply Finset.sum_congr rfl
+        intro i _
+        rfl
+      _ = c j.1 - c σ.1.card := sum_range_ite_le_sub c j.2
+      _ = x.1 v := by
+        rw [hcard, sub_zero, hcoord j]
+        exact congrArg (fun w : {v // v ∈ σ.1} => x.1 w.1) (e.apply_symm_apply ⟨v, hv⟩)
+  · have hprefix : ∀ i : Fin σ.1.card, v ∉ (orderedPrefixFace σ e i).1 :=
+      fun i hvi => hv (orderedPrefixVertices_subset e i hvi)
+    simp only [hprefix, ↓reduceIte, mul_zero, Finset.sum_const_zero]
+    exact (Finsupp.notMem_support_iff.mp
+      (fun hsupport => hv (StandardSimplex.support_subset x hsupport))).symm
+
+/-- The shared ordered-coordinate construction is continuous when all its coordinates are. -/
+theorem continuous_orderedSubdivisionPoint {K : AbstractSimplicialComplex ι} {α : Type*}
+    [TopologicalSpace α] (σ : Face K) (e : VertexOrder σ) (c : α → ℕ → ℝ)
+    (hc : ∀ a {k}, k < σ.1.card → c a (k + 1) ≤ c a k)
+    (hsum : ∀ a, ∑ k ∈ Finset.range σ.1.card, c a k = 1)
+    (hcard : ∀ a, c a σ.1.card = 0)
+    (hcontinuous : ∀ k, Continuous fun a => c a k) :
+    Continuous fun a => orderedSubdivisionPoint σ e (c a) (hc a) (hsum a) (hcard a) := by
+  apply (continuous_faceInclusion _ (orderedSubdivisionFace σ e)).comp
+  apply continuous_induced_rng.mpr
+  apply continuous_pi
+  intro ρ
+  change Continuous (fun a => orderedCoordinates σ e (c a) ρ)
+  rw [show (fun a => orderedCoordinates σ e (c a) ρ) = fun a =>
+      ∑ i : Fin σ.1.card,
+        if orderedPrefixFace σ e i = ρ then orderedWeight (c a) i else 0 by
+    funext a
+    rw [orderedCoordinates, Finset.sum_apply']
+    apply Finset.sum_congr rfl
+    intro i _
+    simp [Finsupp.single_apply, eq_comm]]
+  apply continuous_finsetSum
+  intro i _
+  by_cases hi : orderedPrefixFace σ e i = ρ
+  · simp only [hi, ↓reduceIte, orderedWeight]
+    exact continuous_const.mul ((hcontinuous i.1).sub (hcontinuous (i.1 + 1)))
+  · simp only [hi, ↓reduceIte]
+    exact continuous_const
+
+end BarycentricSubdivision
+
 @[instance_reducible]
 private noncomputable def carrierLinearOrder {K : AbstractSimplicialComplex ι}
     (x : Realization K) : LinearOrder {v // v ∈ (carrier K x).1} :=
@@ -72,43 +380,6 @@ private theorem orderedVertex_antitone {K : AbstractSimplicialComplex ι} (x : R
   rcases h with h | h
   · exact h.le
   · exact h.1.le
-
-/-- The first `i + 1` carrier vertices in decreasing coordinate order. -/
-private noncomputable def prefixVertices {K : AbstractSimplicialComplex ι} (x : Realization K)
-    (i : Fin (carrier K x).1.card) : Finset ι :=
-  (Finset.Iic i).image fun j => (orderedVertex x j).1
-
-private theorem prefixVertices_nonempty {K : AbstractSimplicialComplex ι} (x : Realization K)
-    (i : Fin (carrier K x).1.card) : (prefixVertices x i).Nonempty := by
-  exact ⟨(orderedVertex x i).1, Finset.mem_image.2 ⟨i, Finset.mem_Iic.2 le_rfl, rfl⟩⟩
-
-private theorem prefixVertices_subset_carrier {K : AbstractSimplicialComplex ι}
-    (x : Realization K) (i : Fin (carrier K x).1.card) :
-    prefixVertices x i ⊆ (carrier K x).1 := by
-  intro v hv
-  obtain ⟨j, -, rfl⟩ := Finset.mem_image.1 hv
-  exact (orderedVertex x j).2
-
-private noncomputable def prefixFace {K : AbstractSimplicialComplex ι} (x : Realization K)
-    (i : Fin (carrier K x).1.card) : Face K :=
-  ⟨prefixVertices x i, K.isRelLowerSet_faces.mem_of_le (carrier K x).2
-    (prefixVertices_subset_carrier x i) (prefixVertices_nonempty x i)⟩
-
-private theorem prefixFace_mono {K : AbstractSimplicialComplex ι} (x : Realization K)
-    {i j : Fin (carrier K x).1.card} (hij : i ≤ j) : prefixFace x i ≤ prefixFace x j := by
-  intro v hv
-  obtain ⟨k, hki, rfl⟩ := Finset.mem_image.1 hv
-  exact Finset.mem_image.2 ⟨k, Finset.mem_Iic.2 ((Finset.mem_Iic.1 hki).trans hij), rfl⟩
-
-private theorem card_prefixVertices {K : AbstractSimplicialComplex ι} (x : Realization K)
-    (i : Fin (carrier K x).1.card) : (prefixVertices x i).card = i.1 + 1 := by
-  rw [prefixVertices, Finset.card_image_iff.mpr]
-  · exact Fin.card_Iic i
-  · exact fun _ _ _ _ h => (orderedVertex x).injective (Subtype.ext h)
-
-private theorem card_prefixFace {K : AbstractSimplicialComplex ι} (x : Realization K)
-    (i : Fin (carrier K x).1.card) : (prefixFace x i).1.card = i.1 + 1 :=
-  card_prefixVertices x i
 
 private theorem sum_orderedVertex {K : AbstractSimplicialComplex ι} (x : Realization K)
     (g : ι → ℝ) :
@@ -147,48 +418,6 @@ private theorem orderedCoord_succ_le {K : AbstractSimplicialComplex ι} (x : Rea
     simp only [hks, ↓reduceDIte]
     exact Realization.nonneg K x _
 
-/-- The barycentric coefficient of the `i`th initial face. -/
-private noncomputable def subdivisionWeight {K : AbstractSimplicialComplex ι} (x : Realization K)
-    (i : Fin (carrier K x).1.card) : ℝ :=
-  (i.1 + 1 : ℝ) * (orderedCoord x i.1 - orderedCoord x (i.1 + 1))
-
-private theorem subdivisionWeight_nonneg {K : AbstractSimplicialComplex ι} (x : Realization K)
-    (i : Fin (carrier K x).1.card) : 0 ≤ subdivisionWeight x i := by
-  exact mul_nonneg (by positivity) (sub_nonneg.2 (orderedCoord_succ_le x i.2))
-
-/-- Summation by parts for the coefficients used to decompose a simplex into its barycentric
-subdivision. -/
-private theorem sum_range_succ_mul_sub (f : ℕ → ℝ) (n : ℕ) :
-    ∑ i ∈ Finset.range n, (i + 1 : ℝ) * (f i - f (i + 1)) =
-      ∑ i ∈ Finset.range n, f i - (n : ℝ) * f n := by
-  induction n with
-  | zero => simp
-  | succ n ih =>
-      rw [Finset.sum_range_succ, Finset.sum_range_succ, ih]
-      push_cast
-      ring
-
-/-- The tail of a telescoping sum of consecutive differences. -/
-private theorem sum_range_ite_le_sub (f : ℕ → ℝ) {j n : ℕ} (hjn : j < n) :
-    ∑ i ∈ Finset.range n, (if j ≤ i then f i - f (i + 1) else 0) = f j - f n := by
-  induction n with
-  | zero => omega
-  | succ n ih =>
-      rw [Finset.sum_range_succ]
-      by_cases hj : j = n
-      · subst j
-        have hz : ∑ i ∈ Finset.range n, (if n ≤ i then f i - f (i + 1) else 0) = 0 := by
-          apply Finset.sum_eq_zero
-          intro i hi
-          simp only [Finset.mem_range] at hi
-          simp [Nat.not_le_of_lt hi]
-        rw [hz]
-        simp
-      · have hjn' : j < n := by omega
-        rw [ih hjn']
-        simp only [hjn'.le, ↓reduceIte]
-        ring
-
 private theorem sum_orderedCoord {K : AbstractSimplicialComplex ι} (x : Realization K) :
     ∑ k ∈ Finset.range (carrier K x).1.card, orderedCoord x k = 1 := by
   rw [← Fin.sum_univ_eq_sum_range]
@@ -203,206 +432,28 @@ private theorem sum_orderedCoord {K : AbstractSimplicialComplex ι} (x : Realiza
       let x' : StandardSimplex (carrier K x).1 := ⟨x.1, mem_convexHull_carrier K x⟩
       simpa only [Finsupp.sum, carrier_val] using StandardSimplex.sum_eq_one x'
 
-private theorem sum_subdivisionWeight {K : AbstractSimplicialComplex ι} (x : Realization K) :
-    ∑ i, subdivisionWeight x i = 1 := by
-  calc
-    ∑ i, subdivisionWeight x i =
-        ∑ i ∈ Finset.range (carrier K x).1.card,
-          (i + 1 : ℝ) * (orderedCoord x i - orderedCoord x (i + 1)) := by
-      rw [← Fin.sum_univ_eq_sum_range]
-      apply Finset.sum_congr rfl
-      intro i _
-      rfl
-    _ = 1 := by
-      rw [sum_range_succ_mul_sub, orderedCoord_card, mul_zero, sub_zero, sum_orderedCoord]
-
-/-- The barycentric coordinates on the face-vertices of the subdivision. -/
-private noncomputable def subdivisionCoordinates {K : AbstractSimplicialComplex ι}
-    (x : Realization K) : Face K →₀ ℝ :=
-  ∑ i : Fin (carrier K x).1.card,
-    Finsupp.single (prefixFace x i) (subdivisionWeight x i)
-
-/-- The nested face of the barycentric subdivision carrying `subdivisionCoordinates x`. -/
-private noncomputable def subdivisionFaces {K : AbstractSimplicialComplex ι} (x : Realization K) :
-    Finset (Face K) :=
-  Finset.univ.image (prefixFace x)
-
-private theorem subdivisionFaces_nonempty {K : AbstractSimplicialComplex ι} (x : Realization K) :
-    (subdivisionFaces x).Nonempty := by
-  have hcarrier : (carrier K x).1.Nonempty := K.isRelLowerSet_faces.prop_of_mem (carrier K x).2
-  let i : Fin (carrier K x).1.card := ⟨0, Finset.card_pos.mpr hcarrier⟩
-  exact ⟨prefixFace x i, Finset.mem_image.2 ⟨i, Finset.mem_univ _, rfl⟩⟩
-
-private theorem subdivisionFaces_mem {K : AbstractSimplicialComplex ι} (x : Realization K) :
-    subdivisionFaces x ∈ TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
-      K.toPreAbstractSimplicialComplex := by
-  rw [TauCeti.PreAbstractSimplicialComplex.mem_barycentricSubdivision_iff]
-  refine ⟨subdivisionFaces_nonempty x, ?_⟩
-  intro σ hσ τ hτ hστ
-  obtain ⟨i, -, rfl⟩ := Finset.mem_image.1 hσ
-  obtain ⟨j, -, rfl⟩ := Finset.mem_image.1 hτ
-  exact (le_total i j).imp (prefixFace_mono x) (prefixFace_mono x)
-
-private theorem subdivisionCoordinates_nonneg {K : AbstractSimplicialComplex ι}
-    (x : Realization K) (σ : Face K) : 0 ≤ subdivisionCoordinates x σ := by
-  rw [subdivisionCoordinates]
-  -- Evaluation is the additive homomorphism needed to move through the finite sum of `Finsupp`s.
-  change 0 ≤ Finsupp.applyAddHom σ
-    (∑ i : Fin (carrier K x).1.card,
-      Finsupp.single (prefixFace x i) (subdivisionWeight x i))
-  rw [map_sum]
-  apply Finset.sum_nonneg
-  intro i _
-  by_cases h : prefixFace x i = σ
-  · simp [h, subdivisionWeight_nonneg]
-  · simp [h]
-
-private theorem subdivisionCoordinates_sum {K : AbstractSimplicialComplex ι}
-    (x : Realization K) : (subdivisionCoordinates x).sum (fun _ r => r) = 1 := by
-  rw [subdivisionCoordinates]
-  rw [← Finsupp.sum_finsetSum_index (fun _ => rfl) (fun _ _ _ => rfl)]
-  simp only [Finsupp.sum_single_index]
-  exact sum_subdivisionWeight x
-
-private theorem subdivisionCoordinates_support {K : AbstractSimplicialComplex ι}
-    (x : Realization K) : (subdivisionCoordinates x).support ⊆ subdivisionFaces x := by
-  intro σ hσ
-  by_contra hnot
-  have hne : ∀ i : Fin (carrier K x).1.card, prefixFace x i ≠ σ := by
-    intro i hi
-    apply hnot
-    exact Finset.mem_image.2 ⟨i, Finset.mem_univ _, hi⟩
-  have hz : subdivisionCoordinates x σ = 0 := by
-    simp [subdivisionCoordinates, hne]
-  exact (Finsupp.mem_support_iff.mp hσ) hz
-
-private theorem subdivisionCoordinates_mem {K : AbstractSimplicialComplex ι}
-    (x : Realization K) : subdivisionCoordinates x ∈
-      convexHull ℝ ((fun σ => Finsupp.single σ (1 : ℝ)) ''
-        (subdivisionFaces x : Set (Face K))) := by
-  rw [mem_standardSimplex_iff]
-  exact ⟨subdivisionCoordinates_nonneg x, subdivisionCoordinates_sum x,
-    subdivisionCoordinates_support x⟩
-
-private noncomputable def subdivisionFace {K : AbstractSimplicialComplex ι} (x : Realization K) :
-    Face (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
-      K.toPreAbstractSimplicialComplex) :=
-  ⟨subdivisionFaces x, subdivisionFaces_mem x⟩
-
-private noncomputable def subdivisionStandardSimplex {K : AbstractSimplicialComplex ι}
-    (x : Realization K) : StandardSimplex (subdivisionFaces x) :=
-  ⟨subdivisionCoordinates x, by simpa using subdivisionCoordinates_mem x⟩
-
 /-- The point of the barycentric subdivision obtained by sorting the barycentric coordinates of
 `x` and taking the corresponding nested initial faces. -/
 private noncomputable def subdivisionPreimage {K : AbstractSimplicialComplex ι}
     (x : Realization K) :
     Realization (TauCeti.PreAbstractSimplicialComplex.barycentricSubdivision
       K.toPreAbstractSimplicialComplex) :=
-  faceInclusion _ (subdivisionFace x) (subdivisionStandardSimplex x)
-
-private theorem subdivisionPreimage_val {K : AbstractSimplicialComplex ι} (x : Realization K) :
-    (subdivisionPreimage x : Face K →₀ ℝ) = subdivisionCoordinates x := by
-  exact faceInclusion_val _ (subdivisionFace x) (subdivisionStandardSimplex x)
-
-private theorem barycentricSubdivisionLinearMap_subdivisionCoordinates
-    {K : AbstractSimplicialComplex ι} (x : Realization K) :
-    barycentricSubdivisionLinearMap K (subdivisionCoordinates x) =
-      ∑ i : Fin (carrier K x).1.card,
-        subdivisionWeight x i • faceBarycenter K (prefixFace x i) := by
-  rw [subdivisionCoordinates, map_sum]
-  apply Finset.sum_congr rfl
-  intro i _
-  rw [← Finsupp.smul_single_one, map_smul, barycentricSubdivisionLinearMap_single]
-
-private theorem mem_prefixVertices_iff {K : AbstractSimplicialComplex ι} (x : Realization K)
-    {v : ι} (hv : v ∈ (carrier K x).1) (i : Fin (carrier K x).1.card) :
-    v ∈ prefixVertices x i ↔ (orderedVertex x).symm ⟨v, hv⟩ ≤ i := by
-  constructor
-  · intro h
-    obtain ⟨j, hj, hjv⟩ := Finset.mem_image.1 h
-    have heq : j = (orderedVertex x).symm ⟨v, hv⟩ := by
-      apply (orderedVertex x).injective
-      apply Subtype.ext
-      rw [hjv, Equiv.apply_symm_apply]
-    rw [← heq]
-    exact Finset.mem_Iic.1 hj
-  · intro h
-    exact Finset.mem_image.2
-      ⟨(orderedVertex x).symm ⟨v, hv⟩, Finset.mem_Iic.2 h, by
-        simp only [Equiv.apply_symm_apply]⟩
-
-private theorem subdivisionWeight_mul_card_prefix_inv {K : AbstractSimplicialComplex ι}
-    (x : Realization K) (i : Fin (carrier K x).1.card) :
-    subdivisionWeight x i * ((prefixFace x i).1.card : ℝ)⁻¹ =
-      orderedCoord x i.1 - orderedCoord x (i.1 + 1) := by
-  rw [subdivisionWeight, card_prefixFace]
-  have hne : (i.1 + 1 : ℝ) ≠ 0 := by positivity
-  field_simp
-  norm_num [Nat.cast_add, Nat.cast_one]
-  ring
-
-private theorem barycentricSubdivisionLinearMap_subdivisionCoordinates_apply_of_mem
-    {K : AbstractSimplicialComplex ι} (x : Realization K) {v : ι}
-    (hv : v ∈ (carrier K x).1) :
-    barycentricSubdivisionLinearMap K (subdivisionCoordinates x) v = x.1 v := by
-  rw [barycentricSubdivisionLinearMap_subdivisionCoordinates]
-  simp only [Finset.sum_apply', Finsupp.smul_apply, smul_eq_mul, faceBarycenter_apply]
-  let j : Fin (carrier K x).1.card := (orderedVertex x).symm ⟨v, hv⟩
-  calc
-    ∑ i : Fin (carrier K x).1.card,
-        subdivisionWeight x i *
-          (if v ∈ (prefixFace x i).1 then ((prefixFace x i).1.card : ℝ)⁻¹ else 0) =
-        ∑ i : Fin (carrier K x).1.card,
-          if j ≤ i then orderedCoord x i.1 - orderedCoord x (i.1 + 1) else 0 := by
-      apply Finset.sum_congr rfl
-      intro i _
-      by_cases hji : j ≤ i
-      · have hmem : v ∈ (prefixFace x i).1 := (mem_prefixVertices_iff x hv i).2 hji
-        simp only [hmem, hji, ↓reduceIte]
-        exact subdivisionWeight_mul_card_prefix_inv x i
-      · have hmem : v ∉ (prefixFace x i).1 := fun h =>
-          hji ((mem_prefixVertices_iff x hv i).1 h)
-        simp [hmem, hji]
-    _ = ∑ i ∈ Finset.range (carrier K x).1.card,
-          if j.1 ≤ i then orderedCoord x i - orderedCoord x (i + 1) else 0 := by
-      rw [← Fin.sum_univ_eq_sum_range]
-      apply Finset.sum_congr rfl
-      intro i _
-      rfl
-    _ = orderedCoord x j.1 - orderedCoord x (carrier K x).1.card :=
-      sum_range_ite_le_sub (orderedCoord x) j.2
-    _ = x.1 v := by
-      rw [orderedCoord_card, sub_zero, orderedCoord_of_lt x j.2]
-      exact congrArg (fun w : {v // v ∈ (carrier K x).1} => x.1 w.1)
-        ((orderedVertex x).apply_symm_apply ⟨v, hv⟩)
-
-private theorem barycentricSubdivisionLinearMap_subdivisionCoordinates_apply_of_notMem
-    {K : AbstractSimplicialComplex ι} (x : Realization K) {v : ι}
-    (hv : v ∉ (carrier K x).1) :
-    barycentricSubdivisionLinearMap K (subdivisionCoordinates x) v = x.1 v := by
-  rw [barycentricSubdivisionLinearMap_subdivisionCoordinates]
-  simp only [Finset.sum_apply', Finsupp.smul_apply, smul_eq_mul, faceBarycenter_apply]
-  have hprefix : ∀ i : Fin (carrier K x).1.card, v ∉ (prefixFace x i).1 :=
-    fun i hvi => hv (prefixVertices_subset_carrier x i hvi)
-  simp only [hprefix, ↓reduceIte, mul_zero, Finset.sum_const_zero]
-  rw [carrier_val] at hv
-  exact (Finsupp.notMem_support_iff.mp hv).symm
-
-private theorem barycentricSubdivisionLinearMap_subdivisionCoordinates_eq
-    {K : AbstractSimplicialComplex ι} (x : Realization K) :
-    barycentricSubdivisionLinearMap K (subdivisionCoordinates x) = x.1 := by
-  ext v
-  by_cases hv : v ∈ (carrier K x).1
-  · exact barycentricSubdivisionLinearMap_subdivisionCoordinates_apply_of_mem x hv
-  · exact barycentricSubdivisionLinearMap_subdivisionCoordinates_apply_of_notMem x hv
+  BarycentricSubdivision.orderedSubdivisionPoint (carrier K x) (orderedVertex x)
+    (orderedCoord x) (orderedCoord_succ_le x) (sum_orderedCoord x) (orderedCoord_card x)
 
 private theorem barycentricSubdivisionRealizationMap_subdivisionPreimage
     {K : AbstractSimplicialComplex ι} (x : Realization K) :
     barycentricSubdivisionRealizationMap K (subdivisionPreimage x) = x := by
-  apply Subtype.ext
-  rw [barycentricSubdivisionRealizationMap_val, subdivisionPreimage_val,
-    barycentricSubdivisionLinearMap_subdivisionCoordinates_eq]
+  let x' : StandardSimplex (carrier K x).1 := ⟨x.1, mem_convexHull_carrier K x⟩
+  calc
+    barycentricSubdivisionRealizationMap K (subdivisionPreimage x) =
+        faceInclusion K (carrier K x) x' := by
+      exact BarycentricSubdivision.barycentricSubdivisionRealizationMap_orderedSubdivisionPoint
+        (carrier K x) (orderedVertex x) (orderedCoord x) (orderedCoord_succ_le x)
+        (sum_orderedCoord x) (orderedCoord_card x) x' (fun i => orderedCoord_of_lt x i.2)
+    _ = x := by
+      apply Subtype.ext
+      exact faceInclusion_val K (carrier K x) x'
 
 /-- The canonical map from the realization of the barycentric subdivision to the realization of
 the original complex is surjective.

--- a/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
+++ b/TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Surjective.lean
@@ -69,6 +69,10 @@ private noncomputable def orderedPrefixFace {K : AbstractSimplicialComplex ι} (
   ⟨orderedPrefixVertices e i, K.isRelLowerSet_faces.mem_of_le σ.2
     (orderedPrefixVertices_subset e i) (orderedPrefixVertices_nonempty e i)⟩
 
+private theorem orderedPrefixFace_val {K : AbstractSimplicialComplex ι} (σ : Face K)
+    (e : VertexOrder σ) (i : Fin σ.1.card) :
+    (orderedPrefixFace σ e i).1 = orderedPrefixVertices e i := rfl
+
 private theorem orderedPrefixFace_mono {K : AbstractSimplicialComplex ι} (σ : Face K)
     (e : VertexOrder σ) {i j : Fin σ.1.card} (hij : i ≤ j) :
     orderedPrefixFace σ e i ≤ orderedPrefixFace σ e j := by
@@ -80,7 +84,7 @@ private theorem orderedPrefixFace_mono {K : AbstractSimplicialComplex ι} (σ : 
 private theorem card_orderedPrefixFace {K : AbstractSimplicialComplex ι} (σ : Face K)
     (e : VertexOrder σ) (i : Fin σ.1.card) :
     (orderedPrefixFace σ e i).1.card = i.1 + 1 := by
-  change (orderedPrefixVertices e i).card = i.1 + 1
+  rw [orderedPrefixFace_val]
   rw [orderedPrefixVertices, Finset.card_image_iff.mpr]
   · exact Fin.card_Iic i
   · exact fun _ _ _ _ h => e.injective (Subtype.ext h)
@@ -310,13 +314,13 @@ theorem barycentricSubdivisionRealizationMap_orderedSubdivisionPoint
     exact (Finsupp.notMem_support_iff.mp
       (fun hsupport => hv (StandardSimplex.support_subset x hsupport))).symm
 
-/-- The shared ordered-coordinate construction is continuous when all its coordinates are. -/
+/-- The shared ordered-coordinate construction is continuous when all its used coordinates are. -/
 theorem continuous_orderedSubdivisionPoint {K : AbstractSimplicialComplex ι} {α : Type*}
     [TopologicalSpace α] (σ : Face K) (e : VertexOrder σ) (c : α → ℕ → ℝ)
     (hc : ∀ a {k}, k < σ.1.card → c a (k + 1) ≤ c a k)
     (hsum : ∀ a, ∑ k ∈ Finset.range σ.1.card, c a k = 1)
     (hcard : ∀ a, c a σ.1.card = 0)
-    (hcontinuous : ∀ k, Continuous fun a => c a k) :
+    (hcontinuous : ∀ k ≤ σ.1.card, Continuous fun a => c a k) :
     Continuous fun a => orderedSubdivisionPoint σ e (c a) (hc a) (hsum a) (hcard a) := by
   apply (continuous_faceInclusion _ (orderedSubdivisionFace σ e)).comp
   apply continuous_induced_rng.mpr
@@ -337,7 +341,8 @@ theorem continuous_orderedSubdivisionPoint {K : AbstractSimplicialComplex ι} {�
   intro i _
   by_cases hi : orderedPrefixFace σ e i = ρ
   · simp only [hi, ↓reduceIte, orderedWeight]
-    exact continuous_const.mul ((hcontinuous i.1).sub (hcontinuous (i.1 + 1)))
+    exact continuous_const.mul
+      ((hcontinuous i.1 i.2.le).sub (hcontinuous (i.1 + 1) (Nat.succ_le_of_lt i.2)))
   · simp only [hi, ↓reduceIte]
     exact continuous_const
 


### PR DESCRIPTION
This PR makes the canonical map from the realization of a barycentric subdivision to the original realization into a homeomorphism for every abstract simplicial complex. It advances `TauCetiRoadmap/GeometricTopology/README.md`, Layer 11 milestone “Geometric realization of an abstract simplicial complex,” specifically the subdivision API needed for the roadmap’s “Realization round-trips” acceptance criterion. The merged injectivity step #4648 identified continuity of the inverse as the exact remaining subdivision step, so this is the most effective exposed frontier and does not overlap the reserved collar/gluing work or the open reduced-Burau route. After this PR, the milestone still needs the boundary of the standard `n`-simplex identified homeomorphically with `S^{n-1}`, followed by the general triangulation interface and the eventual reconciliation with Layer 1’s chart-based PL structures.

Prove inverse continuity against the weak topology simplex by simplex. Cover each original simplex by its finitely many closed coordinate-order chambers; on one chamber, use consecutive coordinate differences as coefficients of the nested initial faces in that fixed order. Prove those coefficients are nonnegative and sum to one, prove their weighted face barycenters recover the original point coordinatewise, and use injectivity of the canonical forward map to identify the chamber formula with the global inverse. The finite closed-cover pasting theorem then makes the inverse continuous on each simplex, while the realization’s final-topology characterization assembles the global result.

Add `TauCeti/AlgebraicTopology/SimplicialComplex/Subdivision/Homeomorph.lean` (561 lines) and refresh the predecessor modules’ documentation to point to the completed homeomorphism. No Mathlib source or external formalization is vendored. The proof reuses Mathlib’s finite closed-cover continuity API and `Finset.sum_range_induction` / `Finset.sum_Ico_sub`; its mathematical construction follows Rourke--Sanderson, *Introduction to Piecewise-Linear Topology*, Chapter 2, “Derived Subdivisions,” as credited in the module documentation.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"barycentric-subdivision-realization-homeomorph"}-->

🤖 Prepared with Codex
