### PR TITLE
feat: tensor invertible sheaves with trivial factors

### DIFF
--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/TensorProduct.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/TensorProduct.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Category.ModuleCat.Sheaf.Invertible.Basic
+public import TauCeti.Algebra.Category.ModuleCat.Sheaf.TensorProduct
+
+/-!
+# Tensor products with trivial invertible sheaves
+
+For a sheaf of commutative rings `R` on a site, the free sheaf of `R`-modules on one generator
+is canonically isomorphic to the tensor unit. Consequently, tensoring an invertible sheaf with a
+globally trivial rank-one sheaf preserves invertibility.
+
+## Main declarations
+
+* `SheafOfModules.freePUnitIsoUnit` identifies the standard free rank-one sheaf with the sheaf
+  of rings;
+* `SheafOfModules.tensorProductFreePUnitIsoLeft` and
+  `SheafOfModules.tensorProductFreePUnitIsoRight` identify tensoring with that standard sheaf
+  with the identity;
+* `SheafOfModules.IsInvertible.tensorProduct_of_iso_unit_left` and
+  `SheafOfModules.IsInvertible.tensorProduct_of_iso_unit_right` show that a tensor product is
+  invertible when one factor is globally trivial and the other is invertible.
+
+These are the local computations needed to prove that arbitrary invertible sheaves are closed
+under tensor product: after refining two trivializing covers to a common cover, both factors are
+the standard free rank-one sheaf there. This advances
+`TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, item "Invertible sheaves on a scheme; the
+Picard group `Pic X` under `⊗`". The common-refinement and restriction compatibility needed for
+the full closure theorem remain subsequent work.
+
+No formalization is vendored. The construction reuses Mathlib's
+`CategoryTheory.Limits.coproductUniqueIso` and Tau Ceti's sheafified tensor-unit isomorphisms.
+-/
+
+public section
+
+open CategoryTheory Limits
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+variable {C : Type u} [Category.{u} C] {J : GrothendieckTopology C}
+variable [HasWeakSheafify J AddCommGrpCat.{u}] [J.WEqualsLocallyBijective AddCommGrpCat.{u}]
+variable [∀ Y : C, HasWeakSheafify (J.over Y) AddCommGrpCat.{u}]
+variable [∀ Y : C, (J.over Y).WEqualsLocallyBijective AddCommGrpCat.{u}]
+
+namespace SheafOfModules
+
+/-- The free sheaf on one generator is canonically isomorphic to the tensor unit. -/
+def freePUnitIsoUnit (S : Sheaf J RingCat.{u}) :
+    _root_.SheafOfModules.free (R := S) PUnit ≅ _root_.SheafOfModules.unit S :=
+  coproductUniqueIso (fun _ : PUnit ↦ _root_.SheafOfModules.unit S)
+
+variable (R : Sheaf J CommRingCat.{u})
+
+/-- Tensoring on the left by the standard free rank-one sheaf does nothing. -/
+def tensorProductFreePUnitIsoLeft
+    (M : SheafOfModules.{u} (ringCatSheaf R)) :
+    tensorProduct R (_root_.SheafOfModules.free (R := ringCatSheaf R) PUnit) M ≅ M :=
+  tensorProductCongrLeft R (freePUnitIsoUnit (ringCatSheaf R)) ≪≫
+    tensorProductUnitIsoLeft R M
+
+/-- Tensoring on the right by the standard free rank-one sheaf does nothing. -/
+def tensorProductFreePUnitIsoRight
+    (M : SheafOfModules.{u} (ringCatSheaf R)) :
+    tensorProduct R M (_root_.SheafOfModules.free (R := ringCatSheaf R) PUnit) ≅ M :=
+  tensorProductCongrRight R (freePUnitIsoUnit (ringCatSheaf R)) ≪≫
+    tensorProductUnitIsoRight R M
+
+namespace IsInvertible
+
+variable {M N : SheafOfModules.{u} (ringCatSheaf R)}
+
+/-- A tensor product is invertible when its left factor is isomorphic to the tensor unit and its
+right factor is invertible. This is the local form used after trivializing the left factor. -/
+theorem tensorProduct_of_iso_unit_left [IsInvertible N]
+    (e : M ≅ _root_.SheafOfModules.unit (ringCatSheaf R)) :
+    IsInvertible (tensorProduct R M N) :=
+  IsInvertible.of_iso
+    ((tensorProductCongrLeft R e ≪≫ tensorProductUnitIsoLeft R N).symm)
+
+/-- A tensor product is invertible when its right factor is isomorphic to the tensor unit and its
+left factor is invertible. This is the local form used after trivializing the right factor. -/
+theorem tensorProduct_of_iso_unit_right [IsInvertible M]
+    (e : N ≅ _root_.SheafOfModules.unit (ringCatSheaf R)) :
+    IsInvertible (tensorProduct R M N) :=
+  IsInvertible.of_iso
+    ((tensorProductCongrRight R e ≪≫ tensorProductUnitIsoRight R M).symm)
+
+/-- Tensoring an invertible sheaf on the left by the standard free rank-one sheaf preserves
+invertibility. -/
+instance tensorProduct_freePUnit_left [IsInvertible N] :
+    IsInvertible
+      (tensorProduct R (_root_.SheafOfModules.free (R := ringCatSheaf R) PUnit) N) :=
+  tensorProduct_of_iso_unit_left R (freePUnitIsoUnit (ringCatSheaf R))
+
+/-- Tensoring an invertible sheaf on the right by the standard free rank-one sheaf preserves
+invertibility. -/
+instance tensorProduct_freePUnit_right [IsInvertible M] :
+    IsInvertible
+      (tensorProduct R M (_root_.SheafOfModules.free (R := ringCatSheaf R) PUnit)) :=
+  tensorProduct_of_iso_unit_right R (freePUnitIsoUnit (ringCatSheaf R))
+
+end IsInvertible
+
+end SheafOfModules
+
+end
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/LineBundle/TensorProduct.lean
+++ b/TauCeti/AlgebraicGeometry/LineBundle/TensorProduct.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Category.ModuleCat.Sheaf.Invertible.TensorProduct
+public import TauCeti.AlgebraicGeometry.LineBundle.Basic
+
+/-!
+# Tensoring line bundles with the trivial bundle
+
+The sheafified tensor product of `𝒪_X`-modules has the trivial line bundle as a unit. This file
+packages that computation in the category `InvertibleSheaf X`: tensoring an invertible sheaf on
+either side by `InvertibleSheaf.trivial X` again gives an invertible sheaf, canonically isomorphic
+to the original one.
+
+## Main declarations
+
+* `InvertibleSheaf.tensorTrivialLeft` and `InvertibleSheaf.tensorTrivialRight` package the two
+  tensor products as invertible sheaves;
+* `InvertibleSheaf.tensorTrivialLeftIso` and `InvertibleSheaf.tensorTrivialRightIso` are their
+  unit isomorphisms in the full category of invertible sheaves.
+
+This is the scheme-level local computation used in the construction of the tensor product of two
+arbitrary line bundles. It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, item
+"Invertible sheaves on a scheme; the Picard group `Pic X` under `⊗`". Closure under tensor
+product for two arbitrary locally trivial factors, duals, and the Picard group remain subsequent
+work.
+
+No formalization is vendored. The proofs specialize the site-level isomorphisms from
+`TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/TensorProduct.lean` to the structure sheaf of
+`X`.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+noncomputable section
+
+namespace InvertibleSheaf
+
+variable {X : Scheme.{u}}
+
+/-- Tensoring an invertible sheaf on the left by the trivial line bundle, packaged as an
+invertible sheaf. -/
+def tensorTrivialLeft (L : InvertibleSheaf X) : InvertibleSheaf X :=
+  ⟨TauCeti.SheafOfModules.tensorProduct X.sheaf
+      (_root_.SheafOfModules.free (R := X.ringCatSheaf) PUnit) L.obj,
+    by
+      let _ : TauCeti.SheafOfModules.IsInvertible (R := X.ringCatSheaf) L.obj := L.property
+      exact TauCeti.SheafOfModules.IsInvertible.tensorProduct_of_iso_unit_left X.sheaf
+        (TauCeti.SheafOfModules.freePUnitIsoUnit X.ringCatSheaf)⟩
+
+/-- The underlying sheaf of `tensorTrivialLeft` is the tensor product of the trivial sheaf and
+the given sheaf. -/
+@[simp]
+lemma tensorTrivialLeft_obj (L : InvertibleSheaf X) :
+    (tensorTrivialLeft L).obj =
+      TauCeti.SheafOfModules.tensorProduct X.sheaf
+        (trivial X).obj L.obj := by
+  rw [trivial_obj]
+  exact (rfl)
+
+/-- Tensoring an invertible sheaf on the right by the trivial line bundle, packaged as an
+invertible sheaf. -/
+def tensorTrivialRight (L : InvertibleSheaf X) : InvertibleSheaf X :=
+  ⟨TauCeti.SheafOfModules.tensorProduct X.sheaf L.obj
+      (_root_.SheafOfModules.free (R := X.ringCatSheaf) PUnit),
+    by
+      let _ : TauCeti.SheafOfModules.IsInvertible (R := X.ringCatSheaf) L.obj := L.property
+      exact TauCeti.SheafOfModules.IsInvertible.tensorProduct_of_iso_unit_right X.sheaf
+        (TauCeti.SheafOfModules.freePUnitIsoUnit X.ringCatSheaf)⟩
+
+/-- The underlying sheaf of `tensorTrivialRight` is the tensor product of the given sheaf and
+the trivial sheaf. -/
+@[simp]
+lemma tensorTrivialRight_obj (L : InvertibleSheaf X) :
+    (tensorTrivialRight L).obj =
+      TauCeti.SheafOfModules.tensorProduct X.sheaf L.obj
+        (trivial X).obj := by
+  rw [trivial_obj]
+  exact (rfl)
+
+/-- The trivial line bundle is a left unit for the sheafified tensor product of invertible
+sheaves. -/
+def tensorTrivialLeftIso (L : InvertibleSheaf X) : tensorTrivialLeft L ≅ L :=
+  ObjectProperty.isoMk (SheafOfModules.isInvertible X)
+    (TauCeti.SheafOfModules.tensorProductFreePUnitIsoLeft X.sheaf L.obj)
+
+/-- The trivial line bundle is a right unit for the sheafified tensor product of invertible
+sheaves. -/
+def tensorTrivialRightIso (L : InvertibleSheaf X) : tensorTrivialRight L ≅ L :=
+  ObjectProperty.isoMk (SheafOfModules.isInvertible X)
+    (TauCeti.SheafOfModules.tensorProductFreePUnitIsoRight X.sheaf L.obj)
+
+end InvertibleSheaf
+
+end
+
+end AlgebraicGeometry
+
+end TauCeti


### PR DESCRIPTION
This PR supplies the canonical tensor-unit computation for the standard free rank-one sheaf and packages its consequences for invertible sheaves on a site and line bundles on a scheme. It advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, milestone “Invertible sheaves on a scheme; the Picard group `Pic X` under `⊗`”, by proving that tensoring with any factor isomorphic to the unit preserves invertibility and by making the trivial line bundle a left and right tensor unit inside `InvertibleSheaf X`.

This is the most effective current step because the sheafified tensor product landed in #4565 and local trivializations already exist, while the eventual arbitrary-factor closure proof needs precisely this computation on every member of a common refinement. The generic file identifies `free PUnit` with the module-sheaf unit via Mathlib’s `CategoryTheory.Limits.coproductUniqueIso`, derives both tensor-unit isomorphisms, and proves both globally trivial-factor closure theorems and their standard instances; the scheme file packages the corresponding invertible-sheaf objects and isomorphisms.

After this PR, the Layer A milestone still needs compatibility of the sheafified tensor product with restriction to over-sites, a common refinement of two trivializing covers, closure for two arbitrary invertible sheaves, duals, associativity/coherence, and the group structure on isomorphism classes.

No Mathlib infrastructure is vendored. The construction reuses Mathlib’s singleton-coproduct isomorphism and Tau Ceti’s existing sheafified tensor congruence and tensor-unit isomorphisms; no informal source beyond the roadmap’s standard line-bundle construction is followed.

Roadmap: JacobianChallenge

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"tensor-product-trivial-invertible-sheaves"}-->

🤖 Prepared with Codex
