### PR TITLE
ci: keep the shim gate inert when its checker is absent from gate

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -385,8 +385,18 @@ jobs:
       - name: Prepare inherited Mathlib shim obligations
         if: ${{ env.INFRA != '1' }}
         run: |
+          set -euo pipefail
           # Compare with the inherited registry (not today's base tip), so unrelated source
-          # PRs from inheriting registry edits that landed after they branched.
+          # PRs do not inherit registry edits that landed after they branched.
+          #
+          # The checker is workflow-pinned tooling from gate/. A run whose workflow commit
+          # predates it — a manual dispatch against an older base — has no script to invoke,
+          # so leave the mechanism inert there rather than reddening the required build on a
+          # missing file.
+          if [ ! -f gate/scripts/check-expired-mathlib-shims.py ]; then
+            echo "SHIM_CHECK=0" >> "$GITHUB_ENV"
+            exit 0
+          fi
           base_shims="$RUNNER_TEMP/base-mathlib-shims.json"
           if [ -f mergebase/TauCeti/mathlib-shims.json ]; then
             cp mergebase/TauCeti/mathlib-shims.json "$base_shims"


### PR DESCRIPTION
This PR skips the Mathlib shim gate when `gate/scripts/check-expired-mathlib-shims.py` is not present, instead of letting the required `build` status go red on a missing file. The checker is workflow-pinned tooling taken from the commit that supplied the workflow, so a run whose workflow commit predates #3616 — a manual dispatch against an older base — has no script to invoke. Treat that as no check rather than as a failed one.

It also runs the scoping step under `set -euo pipefail`, so an unexpected error there fails closed rather than writing a half-populated `SHIM_CHECK`, and fixes a dropped verb in the comment above it.

Follow-up to #3616, split out because that PR sat exactly on the 2000-addition diff guard.

Roadmap: none

🤖 Prepared with Claude Code