### PR TITLE
feat: preserve geodesics under affine reparametrization

### DIFF
--- a/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
+++ b/TauCeti/Geometry/Manifold/MFDeriv/Curve.lean
@@ -40,6 +40,9 @@ curve need not carry a `HasMFDerivWithinAt` witness for it.
 * `TauCeti.Manifold.hasMFDerivWithinAt_curveVelocityWithin` and
   `TauCeti.Manifold.curveVelocityWithin_eq_of_hasMFDerivWithinAt`: the two directions relating the
   named velocity to a `HasMFDerivWithinAt` witness.
+* `TauCeti.Manifold.curveVelocityWithin_subset` and
+  `TauCeti.Manifold.curveVelocityWithin_comp`: velocity is unchanged by restriction and obeys the
+  chain rule under reparametrization.
 * `TauCeti.Manifold.hasDerivWithinAt_extChartAt_comp_curve`: reading the curve in the chart
   centred at the current point differentiates it to the velocity itself, with
   `TauCeti.Manifold.hasDerivAt_extChartAt_comp_curve` its unrestricted case and
@@ -154,6 +157,33 @@ theorem curveVelocityWithin_eq_of_hasMFDerivWithinAt
   rw [curveVelocityWithin_apply,
     hγ.mfderivWithin (uniqueMDiffWithinAt_iff_uniqueDiffWithinAt.mpr hs)]
   exact smulRight_one_apply_one w
+
+/-- Restricting the parameter set does not change the velocity of a differentiable curve when
+the smaller set has a unique derivative at the parameter. -/
+theorem curveVelocityWithin_subset {u : Set 𝕜} (hus : u ⊆ s)
+    (hu : UniqueDiffWithinAt 𝕜 u t) (hγ : MDifferentiableWithinAt 𝓘(𝕜, 𝕜) I γ s t) :
+    curveVelocityWithin I γ u t = curveVelocityWithin I γ s t := by
+  rw [curveVelocityWithin_apply, curveVelocityWithin_apply,
+    mfderivWithin_subset hus hu.uniqueMDiffWithinAt hγ]
+
+/-- The velocity of a reparametrized curve is the velocity of the original curve multiplied by
+the derivative of the reparametrization. -/
+theorem curveVelocityWithin_comp {φ : 𝕜 → 𝕜} {u : Set 𝕜} {c : 𝕜}
+    (hφ : HasDerivWithinAt φ c u t) (hmaps : Set.MapsTo φ u s)
+    (hγ : MDifferentiableWithinAt 𝓘(𝕜, 𝕜) I γ s (φ t))
+    (hu : UniqueDiffWithinAt 𝕜 u t) :
+    curveVelocityWithin I (γ ∘ φ) u t = c • curveVelocityWithin I γ s (φ t) := by
+  apply curveVelocityWithin_eq_of_hasMFDerivWithinAt _ hu
+  have hcomp := (hasMFDerivWithinAt_curveVelocityWithin hγ).comp t
+    hφ.hasFDerivWithinAt.hasMFDerivWithinAt hmaps
+  apply hcomp.congr_mfderiv
+  apply ContinuousLinearMap.ext
+  intro z
+  -- The tangent space of the scalar model is definitionally `𝕜`, but exposing that
+  -- identification is needed before the two `smulRight` applications can reduce.
+  change ((show 𝕜 from z) * c) • curveVelocityWithin I γ s (φ t) =
+    (show 𝕜 from z) • (c • curveVelocityWithin I γ s (φ t))
+  rw [mul_smul]
 
 /-- On a parameter set which is a neighbourhood of `t`, the restricted velocity is the
 unrestricted one. -/

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Reparametrization.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Reparametrization.lean
@@ -19,14 +19,22 @@ from the reparametrization.
 The proofs use the naturality of `CovariantDerivative.alongCurveWithin` and the `C¹` regularity of
 the coordinate reading of the velocity of a `C²` curve. Every domain condition is explicit:
 restriction needs an inclusion of parameter sets, while reparametrization needs the affine map to
-carry the new parameter set into the old one.
+carry the new parameter set into the old one. Restriction is the case `a = 1`, `b = 0` of the
+affine statement.
+
+The same two operations are recorded for geodesics carrying prescribed initial data: restriction
+to a parameter set still containing `0` keeps the initial data, and the scaling `t ↦ a * t`, which
+fixes `0`, keeps the initial point and multiplies the initial velocity by `a`.
 
 ## Main results
 
-* `TauCeti.Manifold.IsGeodesicCurveOn.mono`: restrict a geodesic to a smaller parameter set.
 * `TauCeti.Manifold.IsGeodesicCurveOn.comp_affine`: precompose a geodesic with
   `t ↦ a * t + b`.
+* `TauCeti.Manifold.IsGeodesicCurveOn.mono`: restrict a geodesic to a smaller parameter set.
 * `TauCeti.Manifold.IsGeodesicCurve.comp_affine`: the all-time specialization.
+* `TauCeti.Manifold.IsGeodesicCurveOnFrom.mono` and
+  `TauCeti.Manifold.IsGeodesicCurveOnFrom.comp_mul_left`: the two operations on a geodesic with
+  prescribed initial data.
 
 ## References
 
@@ -56,49 +64,7 @@ variable
   [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
   [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
   [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
-  {γ : ℝ → M} {s u : Set ℝ}
-
-private theorem differentiableWithinAt_sectionCoord_velocity
-    (h : IsGeodesicCurveOn I γ s) {t : ℝ} (ht : t ∈ s) :
-    DifferentiableWithinAt ℝ
-      (sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ t)) s t := by
-  let _ : IsManifold I ((1 : ℕ∞ω) + 1) M := IsManifold.of_le (n := 2) (by norm_num)
-  have hγ : ContMDiffOn 𝓘(ℝ, ℝ) I ((1 : ℕ∞ω) + 1) γ s := by
-    norm_num
-    exact h.contMDiffOn
-  exact (contDiffWithinAt_sectionCoord_curveVelocityWithin γ h.uniqueDiffOn hγ ht
-    (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t))).differentiableWithinAt
-      (by norm_num)
-
-private theorem differentiableWithinAt_chart_reading
-    (h : IsGeodesicCurveOn I γ s) {t : ℝ} (ht : t ∈ s) :
-    DifferentiableWithinAt ℝ (extChartAt I (γ t) ∘ γ) s t :=
-  (hasDerivWithinAt_extChartAt_comp_curve
-    (hasMFDerivWithinAt_curveVelocityWithin (h.mdifferentiableOn t ht))).differentiableWithinAt
-
-/-- A geodesic remains a geodesic after restriction to a smaller parameter set with unique
-derivatives. The smaller set need not be open or an interval. -/
-theorem IsGeodesicCurveOn.mono (h : IsGeodesicCurveOn I γ s) (hu : UniqueDiffOn ℝ u)
-    (hus : u ⊆ s) : IsGeodesicCurveOn I γ u where
-  uniqueDiffOn := hu
-  contMDiffOn := h.contMDiffOn.mono hus
-  alongCurveWithin_curveVelocityWithin_eq_zero t ht := by
-    have hvelocity (r : ℝ) (hr : r ∈ u) :
-        curveVelocityWithin I γ u r = curveVelocityWithin I γ s r :=
-      curveVelocityWithin_subset hus (hu r hr) (h.mdifferentiableOn r (hus hr))
-    have hvelocity_eventually :
-        curveVelocityWithin I γ u =ᶠ[𝓝[u] t] curveVelocityWithin I γ s := by
-      filter_upwards [self_mem_nhdsWithin] with r hr
-      exact hvelocity r hr
-    calc
-      alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ u) u t =
-          alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) u t :=
-        alongCurveWithin_congr (leviCivita I M) γ _ hvelocity_eventually (hvelocity t ht)
-      _ = alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s t :=
-        alongCurveWithin_subset (leviCivita I M) γ _ hus (hu t ht)
-          (differentiableWithinAt_sectionCoord_velocity h (hus ht))
-          (differentiableWithinAt_chart_reading h (hus ht))
-      _ = 0 := h.alongCurveWithin_curveVelocityWithin_eq_zero t (hus ht)
+  {γ : ℝ → M} {s u : Set ℝ} {p : M} {v : TangentSpace I p}
 
 /-- A geodesic remains a geodesic after the affine reparametrization `t ↦ a * t + b`, provided
 that map carries the new parameter set into the original one. The case `a = 0` is included and
@@ -112,8 +78,20 @@ theorem IsGeodesicCurveOn.comp_affine (h : IsGeodesicCurveOn I γ s) (a b : ℝ)
     exact h.contMDiffOn.comp hφ.contMDiff.contMDiffOn hmaps
   alongCurveWithin_curveVelocityWithin_eq_zero t ht := by
     let φ : ℝ → ℝ := fun r ↦ a * r + b
-    have hφ (r : ℝ) : HasDerivWithinAt φ a u r := by
-      exact ((hasDerivAt_const_mul a).add_const b).hasDerivWithinAt
+    have hφ (r : ℝ) : HasDerivWithinAt φ a u r :=
+      ((hasDerivAt_const_mul a).add_const b).hasDerivWithinAt
+    have hchart : DifferentiableWithinAt ℝ (extChartAt I (γ (φ t)) ∘ γ) s (φ t) :=
+      (hasDerivWithinAt_extChartAt_comp_curve (hasMFDerivWithinAt_curveVelocityWithin
+        (h.mdifferentiableOn (φ t) (hmaps ht)))).differentiableWithinAt
+    have hsection : DifferentiableWithinAt ℝ
+        (sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ (φ t))) s (φ t) := by
+      let _ : IsManifold I ((1 : ℕ∞ω) + 1) M := IsManifold.of_le (n := 2) (by norm_num)
+      have hγ : ContMDiffOn 𝓘(ℝ, ℝ) I ((1 : ℕ∞ω) + 1) γ s := by
+        norm_num
+        exact h.contMDiffOn
+      exact (contDiffWithinAt_sectionCoord_curveVelocityWithin γ h.uniqueDiffOn hγ (hmaps ht)
+        (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I)
+          (γ (φ t)))).differentiableWithinAt (by norm_num)
     have hvelocity (r : ℝ) (hr : r ∈ u) :
         curveVelocityWithin I (γ ∘ φ) u r =
           a • curveVelocityWithin I γ s (φ r) :=
@@ -128,10 +106,7 @@ theorem IsGeodesicCurveOn.comp_affine (h : IsGeodesicCurveOn I γ s) (a b : ℝ)
             (fun r ↦ curveVelocityWithin I γ s (φ r)) u t =
           a • alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s (φ t) := by
       rw [alongCurveWithin_comp (leviCivita I M) γ (curveVelocityWithin I γ s) φ
-        (hφ t).differentiableWithinAt hmaps
-        (differentiableWithinAt_chart_reading h (hmaps ht))
-        (differentiableWithinAt_sectionCoord_velocity h (hmaps ht)),
-        (hφ t).derivWithin (hu t ht)]
+        (hφ t).differentiableWithinAt hmaps hchart hsection, (hφ t).derivWithin (hu t ht)]
     calc
       alongCurveWithin (leviCivita I M) (γ ∘ φ)
           (curveVelocityWithin I (γ ∘ φ) u) u t =
@@ -147,11 +122,44 @@ theorem IsGeodesicCurveOn.comp_affine (h : IsGeodesicCurveOn I γ s) (a b : ℝ)
           (curveVelocityWithin I γ s) s (φ t)) := by rw [hreparam]
       _ = 0 := by rw [h.alongCurveWithin_curveVelocityWithin_eq_zero (φ t) (hmaps ht)]; simp
 
+/-- A geodesic remains a geodesic after restriction to a smaller parameter set with unique
+derivatives. The smaller set need not be open or an interval. -/
+theorem IsGeodesicCurveOn.mono (h : IsGeodesicCurveOn I γ s) (hu : UniqueDiffOn ℝ u)
+    (hus : u ⊆ s) : IsGeodesicCurveOn I γ u := by
+  simpa [Function.comp_def] using h.comp_affine 1 0 hu (fun t ht ↦ by simpa using hus ht)
+
 /-- An all-time geodesic remains an all-time geodesic after an affine reparametrization. -/
 theorem IsGeodesicCurve.comp_affine (h : IsGeodesicCurve I γ) (a b : ℝ) :
     IsGeodesicCurve I (γ ∘ fun t : ℝ ↦ a * t + b) := by
   rw [← isGeodesicCurveOn_univ] at h ⊢
   exact h.comp_affine a b uniqueDiffOn_univ (mapsTo_univ _ _)
+
+/-- A geodesic with prescribed initial data keeps that data after restriction to a smaller
+parameter set with unique derivatives which still contains the initial parameter `0`. -/
+theorem IsGeodesicCurveOnFrom.mono (h : IsGeodesicCurveOnFrom I γ s p v) (hu : UniqueDiffOn ℝ u)
+    (hus : u ⊆ s) (h0 : (0 : ℝ) ∈ u) : IsGeodesicCurveOnFrom I γ u p v where
+  isGeodesicCurveOn := h.isGeodesicCurveOn.mono hu hus
+  zero_mem := h0
+  initial_eq := by
+    rw [curveVelocityWithin_subset hus (hu 0 h0)
+      (h.isGeodesicCurveOn.mdifferentiableOn 0 (hus h0))]
+    exact h.initial_eq
+
+/-- The reparametrization `t ↦ a * t` fixes the initial parameter `0`, so a geodesic with
+prescribed initial data keeps its initial point and has its initial velocity multiplied by `a`. -/
+theorem IsGeodesicCurveOnFrom.comp_mul_left (h : IsGeodesicCurveOnFrom I γ s p v) (a : ℝ)
+    (hu : UniqueDiffOn ℝ u) (hmaps : MapsTo (fun t : ℝ ↦ a * t) u s) (h0 : (0 : ℝ) ∈ u) :
+    IsGeodesicCurveOnFrom I (γ ∘ fun t : ℝ ↦ a * t) u p (a • v) where
+  isGeodesicCurveOn := by
+    simpa using h.isGeodesicCurveOn.comp_affine a 0 hu (fun t ht ↦ by simpa using hmaps ht)
+  zero_mem := h0
+  initial_eq := by
+    rw [curveVelocityWithin_comp (hasDerivAt_const_mul a).hasDerivWithinAt hmaps
+      (h.isGeodesicCurveOn.mdifferentiableOn _ (hmaps h0)) (hu 0 h0)]
+    rw [Function.comp_apply, mul_zero]
+    -- Scaling the fibre component by `a` is a map of the tangent bundle, so it can be applied
+    -- to the bundled initial data of `h`.
+    exact congrArg (fun z : TangentBundle I M ↦ TotalSpace.mk' E z.proj (a • z.snd)) h.initial_eq
 
 end TauCeti.Manifold
 

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Reparametrization.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Reparametrization.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Basic
+
+/-!
+# Restriction and affine reparametrization of geodesics
+
+A geodesic remains a geodesic after restricting its parameter set, provided the smaller set still
+has unique derivatives. It also remains a geodesic after an affine change of parameter
+`t ↦ a * t + b`. The latter statement is special to affine reparametrizations: the velocity gains
+one factor of `a`, and its covariant derivative gains a second factor, with no acceleration term
+from the reparametrization.
+
+The proofs use the naturality of `CovariantDerivative.alongCurveWithin` and the `C¹` regularity of
+the coordinate reading of the velocity of a `C²` curve. Every domain condition is explicit:
+restriction needs an inclusion of parameter sets, while reparametrization needs the affine map to
+carry the new parameter set into the old one.
+
+## Main results
+
+* `TauCeti.Manifold.IsGeodesicCurveOn.mono`: restrict a geodesic to a smaller parameter set.
+* `TauCeti.Manifold.IsGeodesicCurveOn.comp_affine`: precompose a geodesic with
+  `t ↦ a * t + b`.
+* `TauCeti.Manifold.IsGeodesicCurve.comp_affine`: the all-time specialization.
+
+## References
+
+* M. P. do Carmo, *Riemannian Geometry*, Chapter 3, Section 2.
+* J. M. Lee, *Introduction to Riemannian Manifolds*, Chapter 4, Problem 4-10.
+* The reparametrization argument follows `ParallelReparametrization.lean` in the Apache-2.0
+  [`frenzymath/Poincare-Conjecture`](https://github.com/frenzymath/Poincare-Conjecture)
+  repository, revision `24f32e4d600878bfaac6bc2f2f9324175571c321`, adapted to Tau Ceti's
+  interval-aware geodesic and along-curve APIs.
+* [The Hopf--Rinow roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
+  Layer 1, "Maximal interval and homogeneity".
+-/
+
+public section
+
+open Bundle CovariantDerivative Filter Set
+open scoped ContDiff Manifold Topology
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 2 M]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+  {γ : ℝ → M} {s u : Set ℝ}
+
+private theorem differentiableWithinAt_sectionCoord_velocity
+    (h : IsGeodesicCurveOn I γ s) {t : ℝ} (ht : t ∈ s) :
+    DifferentiableWithinAt ℝ
+      (sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ t)) s t := by
+  let _ : IsManifold I ((1 : ℕ∞ω) + 1) M := IsManifold.of_le (n := 2) (by norm_num)
+  have hγ : ContMDiffOn 𝓘(ℝ, ℝ) I ((1 : ℕ∞ω) + 1) γ s := by
+    norm_num
+    exact h.contMDiffOn
+  exact (contDiffWithinAt_sectionCoord_curveVelocityWithin γ h.uniqueDiffOn hγ ht
+    (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t))).differentiableWithinAt
+      (by norm_num)
+
+private theorem differentiableWithinAt_chart_reading
+    (h : IsGeodesicCurveOn I γ s) {t : ℝ} (ht : t ∈ s) :
+    DifferentiableWithinAt ℝ (extChartAt I (γ t) ∘ γ) s t :=
+  (hasDerivWithinAt_extChartAt_comp_curve
+    (hasMFDerivWithinAt_curveVelocityWithin (h.mdifferentiableOn t ht))).differentiableWithinAt
+
+/-- A geodesic remains a geodesic after restriction to a smaller parameter set with unique
+derivatives. The smaller set need not be open or an interval. -/
+theorem IsGeodesicCurveOn.mono (h : IsGeodesicCurveOn I γ s) (hu : UniqueDiffOn ℝ u)
+    (hus : u ⊆ s) : IsGeodesicCurveOn I γ u where
+  uniqueDiffOn := hu
+  contMDiffOn := h.contMDiffOn.mono hus
+  alongCurveWithin_curveVelocityWithin_eq_zero t ht := by
+    have hvelocity (r : ℝ) (hr : r ∈ u) :
+        curveVelocityWithin I γ u r = curveVelocityWithin I γ s r :=
+      curveVelocityWithin_subset hus (hu r hr) (h.mdifferentiableOn r (hus hr))
+    have hvelocity_eventually :
+        curveVelocityWithin I γ u =ᶠ[𝓝[u] t] curveVelocityWithin I γ s := by
+      filter_upwards [self_mem_nhdsWithin] with r hr
+      exact hvelocity r hr
+    calc
+      alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ u) u t =
+          alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) u t :=
+        alongCurveWithin_congr (leviCivita I M) γ _ hvelocity_eventually (hvelocity t ht)
+      _ = alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s t :=
+        alongCurveWithin_subset (leviCivita I M) γ _ hus (hu t ht)
+          (differentiableWithinAt_sectionCoord_velocity h (hus ht))
+          (differentiableWithinAt_chart_reading h (hus ht))
+      _ = 0 := h.alongCurveWithin_curveVelocityWithin_eq_zero t (hus ht)
+
+/-- A geodesic remains a geodesic after the affine reparametrization `t ↦ a * t + b`, provided
+that map carries the new parameter set into the original one. The case `a = 0` is included and
+gives a constant curve. -/
+theorem IsGeodesicCurveOn.comp_affine (h : IsGeodesicCurveOn I γ s) (a b : ℝ)
+    (hu : UniqueDiffOn ℝ u) (hmaps : MapsTo (fun t : ℝ ↦ a * t + b) u s) :
+    IsGeodesicCurveOn I (γ ∘ fun t : ℝ ↦ a * t + b) u where
+  uniqueDiffOn := hu
+  contMDiffOn := by
+    have hφ : ContDiff ℝ 2 (fun t : ℝ ↦ a * t + b) := by fun_prop
+    exact h.contMDiffOn.comp hφ.contMDiff.contMDiffOn hmaps
+  alongCurveWithin_curveVelocityWithin_eq_zero t ht := by
+    let φ : ℝ → ℝ := fun r ↦ a * r + b
+    have hφ (r : ℝ) : HasDerivWithinAt φ a u r := by
+      exact ((hasDerivAt_const_mul a).add_const b).hasDerivWithinAt
+    have hvelocity (r : ℝ) (hr : r ∈ u) :
+        curveVelocityWithin I (γ ∘ φ) u r =
+          a • curveVelocityWithin I γ s (φ r) :=
+      curveVelocityWithin_comp (hφ r) hmaps (h.mdifferentiableOn (φ r) (hmaps hr)) (hu r hr)
+    have hvelocity_eventually :
+        curveVelocityWithin I (γ ∘ φ) u =ᶠ[𝓝[u] t]
+          fun r ↦ a • curveVelocityWithin I γ s (φ r) := by
+      filter_upwards [self_mem_nhdsWithin] with r hr
+      exact hvelocity r hr
+    have hreparam :
+        alongCurveWithin (leviCivita I M) (γ ∘ φ)
+            (fun r ↦ curveVelocityWithin I γ s (φ r)) u t =
+          a • alongCurveWithin (leviCivita I M) γ (curveVelocityWithin I γ s) s (φ t) := by
+      rw [alongCurveWithin_comp (leviCivita I M) γ (curveVelocityWithin I γ s) φ
+        (hφ t).differentiableWithinAt hmaps
+        (differentiableWithinAt_chart_reading h (hmaps ht))
+        (differentiableWithinAt_sectionCoord_velocity h (hmaps ht)),
+        (hφ t).derivWithin (hu t ht)]
+    calc
+      alongCurveWithin (leviCivita I M) (γ ∘ φ)
+          (curveVelocityWithin I (γ ∘ φ) u) u t =
+          alongCurveWithin (leviCivita I M) (γ ∘ φ)
+            (fun r ↦ a • curveVelocityWithin I γ s (φ r)) u t :=
+        alongCurveWithin_congr (leviCivita I M) (γ ∘ φ) _ hvelocity_eventually
+          (hvelocity t ht)
+      _ = a • alongCurveWithin (leviCivita I M) (γ ∘ φ)
+          (fun r ↦ curveVelocityWithin I γ s (φ r)) u t :=
+        alongCurveWithin_const_smul (leviCivita I M) (γ ∘ φ)
+          (fun r ↦ curveVelocityWithin I γ s (φ r)) a u t
+      _ = a • (a • alongCurveWithin (leviCivita I M) γ
+          (curveVelocityWithin I γ s) s (φ t)) := by rw [hreparam]
+      _ = 0 := by rw [h.alongCurveWithin_curveVelocityWithin_eq_zero (φ t) (hmaps ht)]; simp
+
+/-- An all-time geodesic remains an all-time geodesic after an affine reparametrization. -/
+theorem IsGeodesicCurve.comp_affine (h : IsGeodesicCurve I γ) (a b : ℝ) :
+    IsGeodesicCurve I (γ ∘ fun t : ℝ ↦ a * t + b) := by
+  rw [← isGeodesicCurveOn_univ] at h ⊢
+  exact h.comp_affine a b uniqueDiffOn_univ (mapsTo_univ _ _)
+
+end TauCeti.Manifold
+
+end

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Geometry.Manifold.MFDeriv.Curve
 public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.AlongCurve.Basic
 public import Mathlib.Geometry.Manifold.MFDeriv.Atlas
+import Mathlib.Analysis.Calculus.ContDiff.Deriv
 
 /-!
 # The along-curve derivative of a pulled-back vector field
@@ -45,6 +46,8 @@ for the Levi-Civita connection.
   `x` is the reading of its velocity in the tangent-bundle trivialization at `x`, with
   `TauCeti.Manifold.sectionCoord_curveVelocityWithin_eventuallyEq` its eventual-equality form for
   the velocity field.
+* `TauCeti.Manifold.contDiffWithinAt_sectionCoord_curveVelocityWithin`: a `C^(n + 1)` curve has a
+  `C^n` coordinate velocity field.
 * `TauCeti.Manifold.derivWithin_sectionCoord_pullback`: the derivative of the coordinate reading
   of a pulled-back field is the reading of the flat frame derivative in the direction of the
   velocity.
@@ -78,7 +81,7 @@ for the Levi-Civita connection.
 public section
 
 open Bundle Filter Module Set
-open scoped Manifold Topology
+open scoped ContDiff Manifold Topology
 
 noncomputable section
 
@@ -126,6 +129,27 @@ theorem sectionCoord_curveVelocityWithin_eventuallyEq {x : M} {s : Set 𝕜} {t 
   filter_upwards [hbase, self_mem_nhdsWithin] with r hr hrs
   rw [sectionCoord_apply, derivWithin_extChartAt_comp γ hr (hs r hrs)
     (hasMFDerivWithinAt_curveVelocityWithin (hγ r hrs))]
+
+omit [CompleteSpace 𝕜] [FiniteDimensional 𝕜 E]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
+/-- If a curve is `C^(n + 1)` on a parameter set with unique derivatives, then the coordinate
+reading of its velocity in any tangent-bundle chart containing the current point is `C^n` there.
+This is the regularity step which makes the derivative in the along-curve formula an honest
+second derivative when the curve is `C²`. -/
+theorem contDiffWithinAt_sectionCoord_curveVelocityWithin {n : ℕ∞ω} [IsManifold I (n + 1) M]
+    {x : M} {s : Set 𝕜}
+    {t : 𝕜} (hs : UniqueDiffOn 𝕜 s) (hγ : ContMDiffOn 𝓘(𝕜, 𝕜) I (n + 1) γ s)
+    (ht : t ∈ s) (hx : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) :
+    ContDiffWithinAt 𝕜 n (sectionCoord (F := E) γ (curveVelocityWithin I γ s) x) s t := by
+  have hchart : ContDiffWithinAt 𝕜 (n + 1) (extChartAt I x ∘ γ) s t :=
+    ((contMDiffWithinAt_iff_target_of_mem_source
+      (by simpa only [TangentBundle.trivializationAt_baseSet] using hx)).mp (hγ t ht)).2
+      |>.contDiffWithinAt
+  have hderiv : ContDiffWithinAt 𝕜 n (derivWithin (extChartAt I x ∘ γ) s) s t :=
+    hchart.derivWithin hs le_rfl ht
+  exact hderiv.congr_of_eventuallyEq_of_mem
+    (sectionCoord_curveVelocityWithin_eventuallyEq γ hs
+      (hγ.mdifferentiableOn (by simp)) ht hx) ht
 
 omit [FiniteDimensional 𝕜 E]
   [IsManifold I 1 M]


### PR DESCRIPTION
This PR preserves interval-aware geodesics under restriction and affine reparametrization. It advances `TauCetiRoadmap/HopfRinow/README.md`, Layer 1, “Maximal interval and homogeneity”: the eventual identity `γ_{p,λv}(t) = γ_{p,v}(λt)` requires first proving that affine changes of parameter preserve the connection-based geodesic equation on their mapped domains. It also supplies the `C²` chart-reading regularity explicitly identified as the remaining prerequisite by the newly merged `IsGeodesicCurveOn` step.

This is the most effective current step because `IsGeodesicCurveOn`, its chart equation, the velocity API, and `CovariantDerivative.alongCurveWithin_comp` are now on `main`, while the chart-independence infrastructure for the geodesic spray is already in flight in #4794 and #4797. The proof therefore closes the exposed reparametrization frontier without duplicating that spray work.

Add `curveVelocityWithin_subset` and `curveVelocityWithin_comp` at the generic manifold-calculus level. Prove `contDiffWithinAt_sectionCoord_curveVelocityWithin`, showing that a `C^(n + 1)` curve has a `C^n` coordinate velocity field. Then add `Riemannian/Geodesic/Reparametrization.lean`, whose main results are `IsGeodesicCurveOn.comp_affine`, its restriction case `IsGeodesicCurveOn.mono` (the values `a = 1`, `b = 0`), and the all-time specialization `IsGeodesicCurve.comp_affine`. The affine proof tracks both speed factors: velocity scales by `a`, and its covariant derivative scales by `a²`. The same two operations are recorded for the bundled initial-data predicate by `IsGeodesicCurveOnFrom.mono` and `IsGeodesicCurveOnFrom.comp_mul_left`, the latter returning initial velocity `a • v` because `t ↦ a * t` fixes the initial parameter.

The reparametrization proof plan is adapted from `formalized-sources/LeeRiemannian/LeeLib/Ch04/ParallelReparametrization.lean` in `frenzymath/Poincare-Conjecture` at revision `24f32e4d600878bfaac6bc2f2f9324175571c321` (Apache-2.0), as credited in the module documentation; no Mathlib infrastructure is vendored.

After this PR, the Layer 1 maximal-interval and homogeneity milestone still needs the chart-independent smooth geodesic spray and its local existence/uniqueness theory, followed by maximal geodesic domains and the precise scaling relation between those domains.

Add one 166-line module and 55 supporting lines across two existing modules (221 insertions, one deletion total).

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"affine-reparametrization-geodesics"}-->

🤖 Prepared with Codex
