### PR TITLE
feat(FormalGroup): the formal inverse of a Weierstrass curve, and its involutivity

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Inverse.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Inverse.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.PowerSeries.Inverse
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.WExpansion
+
+/-!
+# The formal inverse of a Weierstrass curve
+
+In the `(z, w)`-chart of `WeierstrassCurve.formalW`, where `x = z / w` and `y = -1 / w`, the
+negative of the point with parameter `z` has parameter `ι(z) = -z / (1 - a₁ z - a₃ w(z))`. This
+file constructs that series and proves it is an involution.
+
+The denominator is `formalInverseDenom`; its constant coefficient is `1`, so it is a unit, which is
+what makes `formalInverse` a power series at all.
+
+## Main definitions
+
+* `WeierstrassCurve.formalInverseDenom`: the series `1 - a₁ z - a₃ w(z)` inverted in `ι`.
+* `WeierstrassCurve.formalInverse`: the parameter `ι(z)` of the negative point.
+
+## Main results
+
+* `WeierstrassCurve.subst_formalInverse_self`: `ι(ι(z)) = z`, the formal inverse is an
+  involution. This is the formal-series form of `-(-P) = P`.
+* `WeierstrassCurve.subst_formalInverse_formalW` and
+  `WeierstrassCurve.subst_formalInverse_formalInverseDenom`: the two substitution identities the
+  involution is assembled from, giving the `w`-coordinate and the denominator at the negative
+  point.
+* `WeierstrassCurve.isUnit_formalInverseDenom`: the denominator is a unit.
+* `WeierstrassCurve.constantCoeff_formalInverse`: `ι(0) = 0`, so `ι` may itself be substituted
+  into a power series — `WeierstrassCurve.hasSubst_formalInverse`.
+
+## Implementation notes
+
+The substitution identities are proved through the uniqueness of the solution of the
+`w`-equation (`WeierstrassCurve.eq_subst_formalW_of_wEquation`) rather than by comparing
+coefficients: `w ∘ ι` and the candidate `-w · u⁻¹` both solve that equation at the parameter
+`ι`, and a solution with vanishing constant coefficient is unique.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], IV.1.
+
+## Provenance
+
+Adapted from Michael Stoll's `EllipticCurves` project
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+`EllipticCurves/WeierstrassFormalGroup/Chord.lean` — declarations `uSeries`,
+`constantCoeff_uSeries`, `mul_invOfUnit_uSeries`, `isUnit_uSeries`, `inverseSeries`,
+`constantCoeff_inverseSeries`, `hasSubst_inverseSeries`, `subst_inverseSeries_invOfUnit`,
+`subst_inverseSeries_wSeries`, `subst_inverseSeries_uSeries` and `subst_inverseSeries_self`.
+
+The source's `uSeries` is renamed `formalInverseDenom` here. It must not be called `formalU`: that
+name is already taken, in `FormalGroup/WExpansion.lean`, by the unit part `w(z) / z ^ 3`, which
+is a different series (it is the source's `vSeries`). The source proves the substitution
+identities through its own private `wStep` recursion; this file uses the `w`-equation API of
+`FormalGroup/WExpansion.lean` instead, so the source's `wStepAt` lemmas are not ported.
+-/
+
+public section
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+/-! ### The denominator of the formal inverse -/
+
+/-- The denominator `1 - a₁ z - a₃ w(z)` of the formal inverse.
+
+Up to sign and a factor of `w`, this is the `y`-coordinate of the negative of the point with
+parameter `z`, in the coordinates `x = z / w`, `y = -1 / w`. -/
+noncomputable def formalInverseDenom : PowerSeries R :=
+  1 - PowerSeries.C W.a₁ * PowerSeries.X - PowerSeries.C W.a₃ * formalW W
+
+/-- The defining formula for `formalInverseDenom`. -/
+theorem formalInverseDenom_def :
+    formalInverseDenom W =
+      1 - PowerSeries.C W.a₁ * PowerSeries.X - PowerSeries.C W.a₃ * formalW W :=
+  (rfl)
+
+/-- The denominator of the formal inverse is `1` at the origin, which is what makes it a unit. -/
+@[simp]
+theorem constantCoeff_formalInverseDenom :
+    PowerSeries.constantCoeff (formalInverseDenom W) = 1 := by
+  rw [formalInverseDenom_def]
+  simp
+
+/-- The denominator times its `invOfUnit` is `1`. -/
+theorem mul_invOfUnit_formalInverseDenom :
+    formalInverseDenom W * PowerSeries.invOfUnit (formalInverseDenom W) 1 = 1 :=
+  PowerSeries.mul_invOfUnit _ _ (by simp)
+
+/-- The denominator of the formal inverse is a unit. -/
+theorem isUnit_formalInverseDenom : IsUnit (formalInverseDenom W) :=
+  IsUnit.of_mul_eq_one _ (mul_invOfUnit_formalInverseDenom W)
+
+/-! ### The formal inverse -/
+
+/-- The parameter `ι(z) = -z / (1 - a₁ z - a₃ w(z))` of the negative of the point with parameter
+`z` on the curve `(z, w(z))`. -/
+noncomputable def formalInverse : PowerSeries R :=
+  -(PowerSeries.X * PowerSeries.invOfUnit (formalInverseDenom W) 1)
+
+/-- The defining formula for `formalInverse`. -/
+theorem formalInverse_def :
+    formalInverse W = -(PowerSeries.X * PowerSeries.invOfUnit (formalInverseDenom W) 1) :=
+  (rfl)
+
+/-- The formal inverse vanishes at the origin: the negative of `O` is `O`. -/
+@[simp]
+theorem constantCoeff_formalInverse : PowerSeries.constantCoeff (formalInverse W) = 0 := by
+  rw [formalInverse_def]
+  simp
+
+/-- The formal inverse may be substituted into a power series. -/
+theorem hasSubst_formalInverse : PowerSeries.HasSubst (formalInverse W) :=
+  PowerSeries.HasSubst.of_constantCoeff_zero' (constantCoeff_formalInverse W)
+
+/-! ### Substituting the formal inverse -/
+
+/-- Substitution along `ι` fixes `1`. -/
+private theorem subst_formalInverse_one :
+    PowerSeries.subst (formalInverse W) (1 : PowerSeries R) = 1 := by
+  rw [← PowerSeries.coe_substAlgHom (hasSubst_formalInverse W), map_one]
+
+/-- Substitution along `ι` carries `invOfUnit` to the `invOfUnit` of the image. -/
+private theorem subst_formalInverse_invOfUnit {D : PowerSeries R}
+    (hD : PowerSeries.constantCoeff D = 1)
+    (hD' : PowerSeries.constantCoeff (PowerSeries.subst (formalInverse W) D) = 1) :
+    PowerSeries.subst (formalInverse W) (PowerSeries.invOfUnit D 1) =
+      PowerSeries.invOfUnit (PowerSeries.subst (formalInverse W) D) 1 := by
+  have hmul : PowerSeries.subst (formalInverse W) D *
+      PowerSeries.invOfUnit (PowerSeries.subst (formalInverse W) D) 1 = 1 :=
+    PowerSeries.mul_invOfUnit _ 1 (by rw [hD']; rfl)
+  refine (IsUnit.of_mul_eq_one _ hmul).mul_left_cancel ?_
+  rw [hmul, ← PowerSeries.subst_mul (hasSubst_formalInverse W),
+    PowerSeries.mul_invOfUnit _ 1 (by rw [hD]; rfl), subst_formalInverse_one W]
+
+/-- Composing the `w`-expansion with the formal inverse gives `-w / (1 - a₁ z - a₃ w)`, the
+`w`-coordinate of the negative point.
+
+Both sides solve the `w`-equation at the parameter `ι` and have vanishing constant coefficient,
+so they agree by `eq_subst_formalW_of_wEquation`. Clearing the denominator `u ^ 3`, the identity
+to check is `-w u ^ 2 = -z ^ 3 + a₁ z w u - a₂ z ^ 2 w + a₃ w ^ 2 u - a₄ z w ^ 2 - a₆ w ^ 3`,
+which is the `w`-equation itself after `a₁ z w + a₃ w ^ 2 = w (1 - u)`. -/
+theorem subst_formalInverse_formalW :
+    PowerSeries.subst (formalInverse W) (formalW W) =
+      -(formalW W * PowerSeries.invOfUnit (formalInverseDenom W) 1) := by
+  have hu := mul_invOfUnit_formalInverseDenom W
+  have hw := formalW_wEquation W
+  refine (eq_subst_formalW_of_wEquation W (constantCoeff_formalInverse W) ?_ ?_).symm
+  · simp
+  · refine ((isUnit_formalInverseDenom W).pow 3).mul_left_cancel ?_
+    rw [wEquationRHS_powerSeries, formalInverse_def, formalInverseDenom_def] at *
+    grind
+
+/-- Composing the denominator with the formal inverse inverts it. -/
+theorem subst_formalInverse_formalInverseDenom :
+    PowerSeries.subst (formalInverse W) (formalInverseDenom W) =
+      PowerSeries.invOfUnit (formalInverseDenom W) 1 := by
+  have hu := mul_invOfUnit_formalInverseDenom W
+  refine (isUnit_formalInverseDenom W).mul_left_cancel ?_
+  rw [mul_invOfUnit_formalInverseDenom W, formalInverseDenom_def,
+    ← PowerSeries.coe_substAlgHom (hasSubst_formalInverse W)]
+  -- `subst_C` lands on `MvPowerSeries.C`; `C_apply` is what identifies it with `PowerSeries.C`,
+  -- without which the two spellings of the same map are opaque to `grind`.
+  simp only [map_sub, map_mul, map_one, PowerSeries.coe_substAlgHom,
+    PowerSeries.substAlgHom_X, PowerSeries.subst_C, ← PowerSeries.C_apply,
+    subst_formalInverse_formalW W]
+  rw [formalInverse_def, formalInverseDenom_def] at *
+  grind
+
+/-- **The formal inverse is an involution**: `ι(ι(z)) = z`.
+
+This is the formal-series form of `-(-P) = P` for the group law near the origin. -/
+theorem subst_formalInverse_self :
+    PowerSeries.subst (formalInverse W) (formalInverse W) = PowerSeries.X := by
+  have hu := mul_invOfUnit_formalInverseDenom W
+  have hinv := subst_formalInverse_invOfUnit W (D := formalInverseDenom W) (by simp)
+    (by rw [subst_formalInverse_formalInverseDenom W]
+        simp [PowerSeries.constantCoeff_invOfUnit])
+  have hdouble : PowerSeries.invOfUnit (PowerSeries.invOfUnit (formalInverseDenom W) 1) 1 =
+      formalInverseDenom W := by
+    have h2 : PowerSeries.invOfUnit (formalInverseDenom W) 1 *
+        PowerSeries.invOfUnit (PowerSeries.invOfUnit (formalInverseDenom W) 1) 1 = 1 :=
+      PowerSeries.mul_invOfUnit _ 1 (by simp [PowerSeries.constantCoeff_invOfUnit])
+    calc PowerSeries.invOfUnit (PowerSeries.invOfUnit (formalInverseDenom W) 1) 1
+        = formalInverseDenom W * (PowerSeries.invOfUnit (formalInverseDenom W) 1 *
+            PowerSeries.invOfUnit (PowerSeries.invOfUnit (formalInverseDenom W) 1) 1) := by
+          rw [← mul_assoc, hu, one_mul]
+      _ = formalInverseDenom W := by rw [h2, mul_one]
+  have hexp : PowerSeries.subst (formalInverse W) (formalInverse W) =
+      -(formalInverse W * PowerSeries.subst (formalInverse W)
+        (PowerSeries.invOfUnit (formalInverseDenom W) 1)) := by
+    have h : PowerSeries.subst (formalInverse W) (formalInverse W) =
+        PowerSeries.subst (formalInverse W)
+          (-(PowerSeries.X * PowerSeries.invOfUnit (formalInverseDenom W) 1)) := by
+      rw [← formalInverse_def]
+    rw [h, ← PowerSeries.coe_substAlgHom (hasSubst_formalInverse W), map_neg, map_mul,
+      PowerSeries.substAlgHom_X (hasSubst_formalInverse W)]
+  rw [hexp, hinv, subst_formalInverse_formalInverseDenom W, hdouble, formalInverse_def]
+  linear_combination (PowerSeries.X : PowerSeries R) * hu
+
+end WeierstrassCurve


### PR DESCRIPTION
The `w`-expansion of a Weierstrass curve parametrises the curve near the point at
infinity, and `FormalGroup/Chord.lean` builds the chord through two such points as far as
`formalThirdRoot`. It then stops, and says so:

> Together these are the data of the chord construction: the formal group law of `W` is
> obtained from `formalThirdRoot` by composing with the formal inverse, **which is left to a
> later file.**

This is that later file. It constructs the formal inverse

`ι(z) = -z / (1 - a₁ z - a₃ w(z))`,

the parameter of the negative of the point with parameter `z`, and proves it is an
involution.

## What is here

* `formalInverseDenom`, the denominator `1 - a₁ z - a₃ w(z)`, with `isUnit_formalInverseDenom`: its
  constant coefficient is `1`, which is what makes `formalInverse` a power series at all.
* `formalInverse`, with `constantCoeff_formalInverse` and `hasSubst_formalInverse`, so `ι` may
  itself be substituted into a power series.
* `subst_formalInverse_formalW`: `w ∘ ι = -w / (1 - a₁ z - a₃ w)`, the `w`-coordinate of the
  negative point.
* `subst_formalInverse_formalInverseDenom`: composing the denominator with `ι` inverts it.
* `subst_formalInverse_self`: **`ι(ι(z)) = z`** — the formal-series form of `-(-P) = P`.

Nothing here needs the chord, so the file deliberately imports only `WExpansion`, not
`Chord.lean`: the formal inverse is one-variable and independent of the two-variable chord
data. The addition series `F(z₁, z₂) = ι(z₃(z₁, z₂))`, which does need both, is left to a
following PR rather than bundled here.

## Proofs

The two substitution identities go through uniqueness of the solution of the `w`-equation
(`eq_subst_formalW_of_wEquation`) rather than by comparing coefficients: `w ∘ ι` and the
candidate `-w · u⁻¹` both solve that equation at the parameter `ι` and both have vanishing
constant coefficient. The source instead re-runs its own private `wStep` recursion, which
this repository does not have and does not need, so those source lemmas are not ported.

## Provenance

Adapted from Michael Stoll's `EllipticCurves` project
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0), pinned by
`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`, file
`EllipticCurves/WeierstrassFormalGroup/Chord.lean` — declarations `uSeries`,
`constantCoeff_uSeries`, `mul_invOfUnit_uSeries`, `isUnit_uSeries`, `inverseSeries`,
`constantCoeff_inverseSeries`, `hasSubst_inverseSeries`, `subst_inverseSeries_invOfUnit`,
`subst_inverseSeries_wSeries`, `subst_inverseSeries_uSeries` and `subst_inverseSeries_self`.

The source's `uSeries` is renamed `formalInverseDenom`. It must **not** be called `formalU`:
that name is already taken in `FormalGroup/WExpansion.lean` by the unit part `w(z) / z ^ 3`,
which is a different series (it is the source's `vSeries`). It is spelled out rather than
abbreviated to `formalInv...` because `Inv` in Mathlib names means the *multiplicative*
inverse, and this is the denominator of the series inverting a point under *addition*.

This completes the port of the section of the source file that `#4728` began; `#4728` carried
it as far as `thirdRootSeries` and the swap-invariance block.

## Roadmap

Prerequisite for `TauCetiRoadmap/EllipticCurves/README.md:572-574`, milestone (i) of the
formal group: "The elliptic formal group *law* `Ê` over the coefficient ring, from expanding
the group law at `O` (AEC IV.1), as an instance of Mathlib's `RingTheory/FormalGroup`".
That instance is `fun _ ↦ W.addSeries` and `addSeries` is `ι ∘ z₃`, so it cannot be stated
until `ι` exists. README:580 names the Stoll development as the port source.

Bead: tc-4jeoq (FG-1b). This is **not** FG-3 split: FG-3 (tc-n3y1v) is associativity and the
Mathlib `FormalGroup` instance over Stoll's `GroupLaw.lean`. This PR is the piece FG-1 left
unported at the end of `Chord.lean`, which FG-3 in turn depends on. Follow-up rung tc-zbw4i
(`addSeries`) is prepared and held behind this PR rather than stacked.

Roadmap: EllipticCurves
