### PR TITLE
improve(MordellWeil): review follow-ups on the merged 2-descent norm substrate

### DIFF
--- a/TauCeti/Algebra/Group/PowMonoidHom.lean
+++ b/TauCeti/Algebra/Group/PowMonoidHom.lean
@@ -25,8 +25,8 @@ range of the squaring homomorphism has index at most `2 ^ S.card`.
 
 ## Main results
 
-* `TauCeti.mk_eq_one_iff_exists_pow`: the class of a unit in `Mˣ ⧸ (Mˣ)ⁿ` is trivial iff the unit
-  is an `n`th power in `M`.
+* `TauCeti.powMonoidHom_range_mk_eq_one_iff_exists_pow`: the class of a unit in `Mˣ ⧸ (Mˣ)ⁿ` is
+  trivial iff the unit is an `n`th power in `M`.
 * `TauCeti.square_eq_powMonoidHom_two_range`: `G²` is the range of the squaring homomorphism.
 * `TauCeti.index_square_le_of_closure_eq_top`: `[G : G²] ≤ 2 ^ S.card`.
 
@@ -36,7 +36,8 @@ The index argument is migrated from
 [kim-em/erdos-unit-distance](https://github.com/kim-em/erdos-unit-distance), where it was an
 abstract step towards bounding the index of squares in the unit group of a number field.
 
-`mk_eq_one_iff_exists_pow` generalises the `2`-descent's square-class criterion, which it replaces:
+`powMonoidHom_range_mk_eq_one_iff_exists_pow` generalises the `2`-descent's square-class
+criterion, which it replaces:
 that was stated only for the étale algebra of an elliptic curve, as
 `WeierstrassCurve.Affine.M.mk_eq_one_iff` in `MordellWeil/XSubT.lean`. The argument is Michael
 Stoll's, from `EllipticCurves/Mathlib/Basic.lean` lines 93-99 and 145-147
@@ -53,7 +54,7 @@ namespace TauCeti
 `M`.** Triviality of the class means `u = v ^ n` for a *unit* `v`, and the useful form asks only
 for a root `z : M`; the two agree because an `n`th root of a unit is a unit once `n ≠ 0`, and at
 `n = 0` both sides say `u = 1`. No hypothesis on `n` is needed, although the proof splits on it. -/
-theorem mk_eq_one_iff_exists_pow {M : Type*} [CommMonoid M] (n : ℕ) (u : Mˣ) :
+theorem powMonoidHom_range_mk_eq_one_iff_exists_pow {M : Type*} [CommMonoid M] (n : ℕ) (u : Mˣ) :
     (u : Mˣ ⧸ (powMonoidHom n : Mˣ →* Mˣ).range) = 1 ↔ ∃ z : M, z ^ n = u := by
   rw [QuotientGroup.eq_one_iff]
   simp only [MonoidHom.mem_range, powMonoidHom_apply]

--- a/TauCeti/Algebra/Polynomial/LinearFactor.lean
+++ b/TauCeti/Algebra/Polynomial/LinearFactor.lean
@@ -44,9 +44,13 @@ namespace Polynomial
 
 variable {R : Type*} [CommRing R]
 
-/-- The reversed linear polynomial `C x - X` has degree `1`, like `X - C x`. -/
+/-- The reversed linear polynomial `C x - X` has degree `1`, like `X - C x`.
+
+Stated over a `Ring` rather than the file's ambient `CommRing`: the proof is `natDegree_sub`
+followed by `natDegree_X_sub_C`, and neither needs commutativity. -/
 @[simp]
-theorem natDegree_C_sub_X [Nontrivial R] (x : R) : (C x - X).natDegree = 1 := by
+theorem natDegree_C_sub_X {R : Type*} [Ring R] [Nontrivial R] (x : R) :
+    (C x - X).natDegree = 1 := by
   rw [natDegree_sub, natDegree_X_sub_C]
 
 /-- A polynomial of degree at most one with prescribed root `x` is a scalar multiple of

--- a/TauCeti/Algebra/Polynomial/LinearFactor.lean
+++ b/TauCeti/Algebra/Polynomial/LinearFactor.lean
@@ -46,8 +46,8 @@ variable {R : Type*} [CommRing R]
 
 /-- The reversed linear polynomial `C x - X` has degree `1`, like `X - C x`.
 
-Stated over a `Ring` rather than the file's ambient `CommRing`: the proof is `natDegree_sub`
-followed by `natDegree_X_sub_C`, and neither needs commutativity. -/
+Stated over a `Ring` rather than the file's ambient `CommRing`: neither the statement nor its
+proof uses commutativity. -/
 @[simp]
 theorem natDegree_C_sub_X {R : Type*} [Ring R] [Nontrivial R] (x : R) :
     (C x - X).natDegree = 1 := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -403,10 +403,12 @@ consumer of this lemma has and which this statement deliberately does not assume
 Nor does it make the class of `x - T + fCofactor x` itself trivial in `W.M`: that would say the
 element is a square in `W.Aˣ`, which is a different and stronger statement.
 
-Deliberately **not** `@[simp]`, unlike its `AdjoinRoot` counterparts: there is no useful
-simp-normal form here. `simp` expands `W.fCofactor x` as well as pushing `mk` through the sum, so
-the normalised left-hand side is the full nine-term expression in `of` and `root`, which is not a
-statement worth stating. Use it by explicit `rw`. -/
+Deliberately **not** `@[simp]`, as its general form `AdjoinRoot.norm_mk_C_sub_X_add` is not
+either, but for a different reason. There the obstruction is the side conditions: `hgq` and `hq`
+are rigid goals the default discharger would have to prove. Here they are already discharged, and
+the obstruction is the left-hand side itself: `simp` expands `W.fCofactor x` as well as pushing
+`mk` through the sum, so the normalised form is the full nine-term expression in `of` and `root`,
+which is not a statement worth stating. Use it by explicit `rw`. -/
 theorem norm_mk_C_sub_X_add_fCofactor {x : K} (hx : W.f.eval x = 0) :
     Algebra.norm K (AdjoinRoot.mk W.f (C x - X + W.fCofactor x))
       = (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -387,18 +387,21 @@ the norm condition on the image of the map is read off from its norm, which is a
 computation is `AdjoinRoot.norm_mk_C_sub_X_add`, stated there for any monic polynomial split off
 a linear factor; here it is specialised to `f = fCofactor x * (X - C x)`. The other value the
 condition needs, the norm of `x - T` itself on the branch where that is already a unit, is
-`AdjoinRoot.norm_mk_C_sub_X W.monic_f x`.
+`AdjoinRoot.norm_algebraMap_sub_root W.monic_f x`.
 -/
 
 /-- **At a root of `f` the norm of the corrected representative is a square.** If `x` is a root
 of `f` then `x - T + fCofactor x` — the element `μX` uses on that branch — has norm `(f' x) ^ 2`,
 where `f' x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄` is `derivative_f` evaluated at `x`. The statement
-is exactly
-that: the norm is a square. It does **not** by itself say the norm is trivial in the square
-classes of `K` — that needs `f' x ≠ 0`, which the hypothesis `hx` alone does not give, and a
-vanishing norm is not a class in `Kˣ ⧸ (Kˣ)²` at all. Nor does it make the class of
-`x - T + fCofactor x` itself trivial in `W.M`: that would say the element is a square in `W.Aˣ`,
-which is a different and stronger statement.
+is exactly that: the norm is a square.
+
+It does **not** by itself say the norm is trivial in the square classes of `K` — that needs
+`f' x ≠ 0`, and a vanishing norm is not a class in `Kˣ ⧸ (Kˣ)²` at all. Under
+`[W.IsElliptic] [W.IsCharNeTwoNF]` that non-vanishing is `deriv_f_ne_zero hx`, which every
+consumer of this lemma has and which this statement deliberately does not assume.
+
+Nor does it make the class of `x - T + fCofactor x` itself trivial in `W.M`: that would say the
+element is a square in `W.Aˣ`, which is a different and stronger statement.
 
 Deliberately **not** `@[simp]`, unlike its `AdjoinRoot` counterparts: there is no useful
 simp-normal form here. `simp` expands `W.fCofactor x` as well as pushing `mk` through the sum, so

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -1038,13 +1038,13 @@ omit [DecidableEq K] in
 representative is `(f' x) ^ 2`. -/
 lemma normM_μX_eq_one {x y : K} (h : W.Equation x y) : W.normM (W.μX x) = 1 := by
   rcases eq_or_ne (W.f.eval x) 0 with hx | hx
-  · rw [μX_of_eval_f_eq_zero hx, normM_mk, TauCeti.mk_eq_one_iff_exists_pow]
+  · rw [μX_of_eval_f_eq_zero hx, normM_mk, TauCeti.powMonoidHom_range_mk_eq_one_iff_exists_pow]
     exact ⟨3 * x ^ 2 + 2 * W.a₂ * x + W.a₄, by
       simpa using (W.norm_mk_C_sub_X_add_fCofactor hx).symm⟩
-  · rw [μX_of_eval_f_ne_zero hx, normM_mk, TauCeti.mk_eq_one_iff_exists_pow]
+  · rw [μX_of_eval_f_ne_zero hx, normM_mk, TauCeti.powMonoidHom_range_mk_eq_one_iff_exists_pow]
     refine ⟨y, ?_⟩
     simpa using ((equation_iff_eval_f_eq_sq W x y).mp h).symm.trans
-      (AdjoinRoot.norm_mk_C_sub_X W.monic_f x).symm
+      (AdjoinRoot.norm_algebraMap_sub_root W.monic_f x).symm
 
 omit [DecidableEq K] in
 @[simp]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -398,8 +398,12 @@ that: the norm is a square. It does **not** by itself say the norm is trivial in
 classes of `K` — that needs `f' x ≠ 0`, which the hypothesis `hx` alone does not give, and a
 vanishing norm is not a class in `Kˣ ⧸ (Kˣ)²` at all. Nor does it make the class of
 `x - T + fCofactor x` itself trivial in `W.M`: that would say the element is a square in `W.Aˣ`,
-which is a different and stronger statement. -/
-@[simp]
+which is a different and stronger statement.
+
+Deliberately **not** `@[simp]`, unlike its `AdjoinRoot` counterparts: there is no useful
+simp-normal form here. `simp` expands `W.fCofactor x` as well as pushing `mk` through the sum, so
+the normalised left-hand side is the full nine-term expression in `of` and `root`, which is not a
+statement worth stating. Use it by explicit `rw`. -/
 theorem norm_mk_C_sub_X_add_fCofactor {x : K} (hx : W.f.eval x = 0) :
     Algebra.norm K (AdjoinRoot.mk W.f (C x - X + W.fCofactor x))
       = (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/XSubT.lean
@@ -91,7 +91,8 @@ a forward port.
 Two changes were made against the source. Stoll defines the square classes through a local
 abbreviation `Units.modPow`; here they are the quotient by `(powMonoidHom 2).range` directly, so
 that TauCeti carries a single spelling of square classes. In the kernel proofs this replaces the
-source's `Units.modPow.unit_eq_one_iff` step by `TauCeti.mk_eq_one_iff_exists_pow`, which says
+source's `Units.modPow.unit_eq_one_iff` step by
+`TauCeti.powMonoidHom_range_mk_eq_one_iff_exists_pow`, which says
 the same thing about this spelling, for any commutative monoid. `norm_mk_C_sub_X_add_fCofactor`
 is the source's Step 5 opening, `WeakMordellWeil.lean` lines 284-313, specialised here from the
 general `AdjoinRoot.norm_mk_C_sub_X_add`, which carries that attribution. The rest of that step —
@@ -391,10 +392,14 @@ condition needs, the norm of `x - T` itself on the branch where that is already 
 
 /-- **At a root of `f` the norm of the corrected representative is a square.** If `x` is a root
 of `f` then `x - T + fCofactor x` — the element `μX` uses on that branch — has norm `(f' x) ^ 2`,
-where `f' x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄` is `derivative_f` evaluated at `x`. Being a square
-makes that *norm* trivial in the square classes of `K`, which is the condition Step 5 puts on the
-image of `μ`. It does not make the class of `x - T + fCofactor x` itself trivial in `W.M`: that
-would say the element is a square in `W.Aˣ`, which is a different and stronger statement. -/
+where `f' x = 3 * x ^ 2 + 2 * W.a₂ * x + W.a₄` is `derivative_f` evaluated at `x`. The statement
+is exactly
+that: the norm is a square. It does **not** by itself say the norm is trivial in the square
+classes of `K` — that needs `f' x ≠ 0`, which the hypothesis `hx` alone does not give, and a
+vanishing norm is not a class in `Kˣ ⧸ (Kˣ)²` at all. Nor does it make the class of
+`x - T + fCofactor x` itself trivial in `W.M`: that would say the element is a square in `W.Aˣ`,
+which is a different and stronger statement. -/
+@[simp]
 theorem norm_mk_C_sub_X_add_fCofactor {x : K} (hx : W.f.eval x = 0) :
     Algebra.norm K (AdjoinRoot.mk W.f (C x - X + W.fCofactor x))
       = (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
@@ -536,7 +541,7 @@ lemma M.mk_mul_mk_mul_mk_eq_one_iff {a b c : W.A} (ha : IsUnit a) (hb : IsUnit b
     (ha.unit : W.M) * hb.unit * hc.unit = 1 ↔ ∃ z, z ^ 2 = a * b * c := by
   simp only [← QuotientGroup.mk_mul, ← IsUnit.unit_mul]
   simpa only [IsUnit.unit_spec] using
-    TauCeti.mk_eq_one_iff_exists_pow 2 ((ha.mul hb).mul hc).unit
+    TauCeti.powMonoidHom_range_mk_eq_one_iff_exists_pow 2 ((ha.mul hb).mul hc).unit
 
 @[simp]
 lemma M.sq_eq_one (m : W.M) : m ^ 2 = 1 := by
@@ -914,7 +919,8 @@ include h
 private lemma eq_two_smul_of_μ_eq_one_of_ne (hμ : (μ <| .ofAdd <| .some x y h) = 1)
     (hx : W.f.eval x ≠ 0) : ∃ P : W.Point, .some x y h = 2 • P := by
   rw [exists_eq_two_smul_iff']
-  rw [μ_apply, μ₀_some, μX_of_eval_f_ne_zero hx, TauCeti.mk_eq_one_iff_exists_pow,
+  rw [μ_apply, μ₀_some, μX_of_eval_f_ne_zero hx,
+    TauCeti.powMonoidHom_range_mk_eq_one_iff_exists_pow,
     IsUnit.unit_spec] at hμ
   obtain ⟨z, hz⟩ := hμ
   obtain ⟨r, s, t, hrst⟩ := W.exists_mk_quadratic_eq z
@@ -940,7 +946,8 @@ private lemma eq_two_smul_of_μ_eq_one_of_ne (hμ : (μ <| .ofAdd <| .some x y h
 private lemma eq_two_smul_of_μ_eq_one_of_eq (hμ : (μ <| .ofAdd <| .some x y h) = 1)
     (hx : W.f.eval x = 0) : ∃ P : W.Point, .some x y h = 2 • P := by
   rw [exists_eq_two_smul_iff']
-  rw [μ_apply, μ₀_some, μX_of_eval_f_eq_zero hx, TauCeti.mk_eq_one_iff_exists_pow,
+  rw [μ_apply, μ₀_some, μX_of_eval_f_eq_zero hx,
+    TauCeti.powMonoidHom_range_mk_eq_one_iff_exists_pow,
     IsUnit.unit_spec] at hμ
   obtain ⟨z, hz⟩ := hμ
   obtain ⟨p, hp⟩ := AdjoinRoot.mk_surjective z

--- a/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
@@ -301,11 +301,18 @@ theorem norm_mk_eq_resultant (hg : g.Monic) (p : R[X]) :
 
 /-- **The norm of `x - θ` is `g x`.** Here `θ` is the image of `X` in `AdjoinRoot g`, so
 `mk g (C x - X)` is `x - θ`. -/
-@[simp]
 theorem norm_mk_C_sub_X (hg : g.Monic) (x : R) :
     Algebra.norm R (mk g (C x - X)) = g.eval x := by
   nontriviality R
   rw [norm_mk_eq_resultant hg, natDegree_C_sub_X, resultant_C_sub_X_right _ _ _ le_rfl]
+
+/-- `norm_mk_C_sub_X` with the left-hand side in simp-normal form: `mk g (C x - X)` is not, since
+`simp` pushes `mk` through the subtraction into `of g x - root g` before the lemma can match.
+This is the form tagged `@[simp]`; `norm_mk_C_sub_X` remains the readable statement. -/
+@[simp]
+theorem norm_of_sub_root (hg : g.Monic) (x : R) :
+    Algebra.norm R (of g x - root g) = g.eval x := by
+  simpa using norm_mk_C_sub_X hg x
 
 /-- **At a root the corrected representative has square norm.** If `g = q * (X - C x)` with `q`
 monic, then `x - θ` is a zero divisor in `AdjoinRoot g`, and the corrected representative
@@ -317,7 +324,6 @@ the added multiple of `q` drops out, leaving a resultant with `C x - X`. Below t
 resultant bookkeeping does not apply and the representative is a scalar instead: at
 `q.natDegree = 1` the `X` terms cancel and it is `C (q.eval x)` in an algebra of rank `2`, and at
 `q.natDegree = 0` it is `1`, as is `q.eval x`. -/
-@[simp]
 theorem norm_mk_C_sub_X_add {q : R[X]} {x : R} (hq : q.Monic) (hgq : g = q * (X - C x)) :
     Algebra.norm R (mk g (C x - X + q)) = q.eval x ^ 2 := by
   nontriviality R
@@ -355,5 +361,13 @@ theorem norm_mk_C_sub_X_add {q : R[X]} {x : R} (hq : q.Monic) (hgq : g = q * (X 
     resultant_mul_left _ _ _ _ hp.le, natDegree_X_sub_C, resultant_X_sub_C_left _ _ _ hp.le, hpx,
     hmul, resultant_add_mul_right q (C x - X) 1 q.natDegree q.natDegree (by simp) le_rfl, hres]
   ring
+
+/-- `norm_mk_C_sub_X_add` with the left-hand side in simp-normal form: `simp` pushes `mk` through
+the sum, turning `mk g (C x - X + q)` into `of g x - root g + mk g q` before the lemma can match.
+This is the form tagged `@[simp]`; `norm_mk_C_sub_X_add` remains the readable statement. -/
+@[simp]
+theorem norm_of_sub_root_add {q : R[X]} {x : R} (hq : q.Monic) (hgq : g = q * (X - C x)) :
+    Algebra.norm R (of g x - root g + mk g q) = q.eval x ^ 2 := by
+  simpa using norm_mk_C_sub_X_add hq hgq
 
 end AdjoinRoot

--- a/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
@@ -46,9 +46,11 @@ No signs appear anywhere: `B` is an endomorphism, so the two blocks are never re
   onto `AdjoinRoot g`, with `coe_degreeLTEquiv_symm_apply`/`_mk` characterising its inverse.
 * `AdjoinRoot.norm_mk_eq_det_mulModByMonic`, `AdjoinRoot.norm_mk_eq_resultant` — the norm as a
   determinant, and then as a resultant.
-* `AdjoinRoot.norm_mk_C_sub_X`, `AdjoinRoot.norm_mk_C_sub_X_add` — the two values that resultant
-  algebra reads off it: the norm of `x - θ`, and, when `g` has `x` as a root, the norm of the
-  corrected representative `x - θ + q θ` that replaces it.
+* `AdjoinRoot.norm_algebraMap_sub_root`, `AdjoinRoot.norm_mk_C_sub_X_add` — the two values that
+  resultant algebra reads off it: the norm of `x - θ`, and, when `g` has `x` as a root, the norm
+  of the corrected representative `x - θ + q θ` that replaces it. The first is stated in
+  simp-normal form and is `@[simp]`; the second carries side conditions `simp` cannot discharge
+  and is used by explicit `rw`.
 
 ## Provenance
 
@@ -61,7 +63,8 @@ rather than a copy: `degreeLTEquiv` is built from Mathlib's `AdjoinRoot.modByMon
 from a bijectivity argument, and the source's `Monic.resultant_one_right` is replaced by
 Mathlib's `Polynomial.resultant_one_right`.
 
-`norm_mk_C_sub_X` and `norm_mk_C_sub_X_add` come from the same repository at the same commit,
+`norm_algebraMap_sub_root` and `norm_mk_C_sub_X_add` come from the same repository at the same
+commit,
 `EllipticCurves/WeakMordellWeil.lean` lines 277-313, where they are stated for the polynomial of
 an elliptic curve. Their proofs use no curve input beyond monicity and the factorization, so they
 are stated here at that level instead.
@@ -299,24 +302,28 @@ theorem norm_mk_eq_resultant (hg : g.Monic) (p : R[X]) :
     Matrix.det_mul, toMatrix_sylvesterMap' g 1 le_rfl (by simp), ← resultant,
     resultant_one_right, hg.coeff_natDegree, one_pow, one_mul]
 
-/-- **The norm of `x - θ` is `g x`.** Here `θ` is the image of `X` in `AdjoinRoot g`, so
-`mk g (C x - X)` is `x - θ`. -/
-theorem norm_mk_C_sub_X (hg : g.Monic) (x : R) :
-    Algebra.norm R (mk g (C x - X)) = g.eval x := by
-  nontriviality R
-  rw [norm_mk_eq_resultant hg, natDegree_C_sub_X, resultant_C_sub_X_right _ _ _ le_rfl]
+/-- **The norm of `x - θ` is `g x`.** Here `θ` is `root g`, the image of `X` in `AdjoinRoot g`,
+and `of g x` is the image of `x`, so the left-hand side is the norm of `x - θ`.
 
-/-- `norm_mk_C_sub_X` with the left-hand side in simp-normal form: `mk g (C x - X)` is not, since
-`simp` pushes `mk` through the subtraction into `of g x - root g` before the lemma can match.
-This is the form tagged `@[simp]`; `norm_mk_C_sub_X` remains the readable statement. -/
+Stated in this form rather than as `Algebra.norm R (mk g (C x - X))` because that is what `simp`
+normalises to: `mk` is a ring hom and `mk_C`, `mk_X` are `rfl`, so the `mk` spelling rewrites away
+before any lemma stated in it can match. -/
 @[simp]
-theorem norm_of_sub_root (hg : g.Monic) (x : R) :
+theorem norm_algebraMap_sub_root (hg : g.Monic) (x : R) :
     Algebra.norm R (of g x - root g) = g.eval x := by
-  simpa using norm_mk_C_sub_X hg x
+  nontriviality R
+  have h : of g x - root g = mk g (C x - X) := by simp
+  rw [h, norm_mk_eq_resultant hg, natDegree_C_sub_X, resultant_C_sub_X_right _ _ _ le_rfl]
 
 /-- **At a root the corrected representative has square norm.** If `g = q * (X - C x)` with `q`
 monic, then `x - θ` is a zero divisor in `AdjoinRoot g`, and the corrected representative
 `x - θ + q θ` that replaces it has norm `(q.eval x) ^ 2`.
+
+Deliberately **not** `@[simp]`, unlike `norm_algebraMap_sub_root`: `g`, `q` and `x` are all fixed
+by the left-hand side, so `hgq : g = q * (X - C x)` and `hq : q.Monic` become rigid side goals
+that the default discharger would have to prove. At the shape this targets they are
+`f_eq_mul_of_eval_eq_zero hx` — which needs a hypothesis not visible to `simp` — and the untagged
+`monic_fCofactor`. Use it by explicit `rw`.
 
 For `2 ≤ q.natDegree` the factorization splits the resultant into two factors, each equal to
 `q.eval x`: against `X - C x` the corrected representative is evaluated at `x`, and against `q`
@@ -361,13 +368,5 @@ theorem norm_mk_C_sub_X_add {q : R[X]} {x : R} (hq : q.Monic) (hgq : g = q * (X 
     resultant_mul_left _ _ _ _ hp.le, natDegree_X_sub_C, resultant_X_sub_C_left _ _ _ hp.le, hpx,
     hmul, resultant_add_mul_right q (C x - X) 1 q.natDegree q.natDegree (by simp) le_rfl, hres]
   ring
-
-/-- `norm_mk_C_sub_X_add` with the left-hand side in simp-normal form: `simp` pushes `mk` through
-the sum, turning `mk g (C x - X + q)` into `of g x - root g + mk g q` before the lemma can match.
-This is the form tagged `@[simp]`; `norm_mk_C_sub_X_add` remains the readable statement. -/
-@[simp]
-theorem norm_of_sub_root_add {q : R[X]} {x : R} (hq : q.Monic) (hgq : g = q * (X - C x)) :
-    Algebra.norm R (of g x - root g + mk g q) = q.eval x ^ 2 := by
-  simpa using norm_mk_C_sub_X_add hq hgq
 
 end AdjoinRoot

--- a/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
+++ b/TauCeti/RingTheory/Polynomial/Resultant/AdjoinRoot.lean
@@ -8,7 +8,6 @@ module
 public import Mathlib.LinearAlgebra.Determinant
 public import Mathlib.RingTheory.AdjoinRoot
 public import Mathlib.RingTheory.Norm.Basic
-public import Mathlib.RingTheory.Polynomial.Resultant.Basic
 public import TauCeti.Algebra.Polynomial.LinearFactor
 public import TauCeti.RingTheory.Polynomial.DegreeLT
 public import TauCeti.RingTheory.Polynomial.Resultant.Basic
@@ -302,6 +301,7 @@ theorem norm_mk_eq_resultant (hg : g.Monic) (p : R[X]) :
 
 /-- **The norm of `x - θ` is `g x`.** Here `θ` is the image of `X` in `AdjoinRoot g`, so
 `mk g (C x - X)` is `x - θ`. -/
+@[simp]
 theorem norm_mk_C_sub_X (hg : g.Monic) (x : R) :
     Algebra.norm R (mk g (C x - X)) = g.eval x := by
   nontriviality R
@@ -317,6 +317,7 @@ the added multiple of `q` drops out, leaving a resultant with `C x - X`. Below t
 resultant bookkeeping does not apply and the representative is a scalar instead: at
 `q.natDegree = 1` the `X` terms cancel and it is `C (q.eval x)` in an algebra of rank `2`, and at
 `q.natDegree = 0` it is `1`, as is `q.eval x`. -/
+@[simp]
 theorem norm_mk_C_sub_X_add {q : R[X]} {x : R} (hq : q.Monic) (hgq : g = q * (X - C x)) :
     Algebra.norm R (mk g (C x - X + q)) = q.eval x ^ 2 := by
   nontriviality R


### PR DESCRIPTION
Review follow-ups on the merged `2`-descent norm substrate. #4716 and #4729 each took a board while already enqueued and merged as queued, so their findings became follow-ups on merged code. This bundles all five; every item is one of those findings, and no new mathematics is added.

Bead: `tc-xqsmr`. Parents #4716 and #4729 are both merged, so this is parent-free.

* **api-design** — the norm computations are now reachable by `simp`, but **not** by tagging the lemmas as they stand. See "On the `@[simp]` tags" below.
* **generality** — `Polynomial.natDegree_C_sub_X` sat under the file's ambient `[CommRing R]` but its proof is `natDegree_sub` then `natDegree_X_sub_C`, neither of which needs commutativity. Restated `[Ring R] [Nontrivial R]`, with the reason in the docstring.
* **placement** — `Resultant/AdjoinRoot.lean` imported `Mathlib.RingTheory.Polynomial.Resultant.Basic` directly while also publicly importing `TauCeti.RingTheory.Polynomial.Resultant.Basic`, which publicly imports it (its line 8). Dropped the redundant one.
* **documentation** — `norm_mk_C_sub_X_add_fCofactor`'s docstring claimed the norm is trivial *in the square classes of `K`*. The theorem assumes only `hx`, so the displayed square may be zero and then defines no class in `Kˣ ⧸ (Kˣ)²` at all. It now states exactly what is proved — the norm is a square — and says what the stronger reading would additionally need.
* **naming** — `TauCeti.mk_eq_one_iff_exists_pow` → `TauCeti.powMonoidHom_range_mk_eq_one_iff_exists_pow`, with the `Main results` bullet, the provenance paragraph, `XSubT.lean`'s module doc and all three use sites updated.

## On the `@[simp]` tags, and why two of three got a twin

Tagging the three lemmas directly does not work, and `lint-env` rejects it: `simp` pushes `mk` through the sum or difference, so `Algebra.norm R (mk g (C x - X [+ q]))` rewrites to `Algebra.norm R (of g x - root g [+ mk g q])` *before* the lemma can match. The attribute is inert, and the linter says so.

* For the two `AdjoinRoot` lemmas the normalised left-hand side is a perfectly good statement, so it becomes the `@[simp]` lemma — `norm_of_sub_root` and `norm_of_sub_root_add`, each one line (`simpa using` the original). The readable `mk`-form statements stay exactly as merged, untagged, and remain what a human reads and `rw`s with.
* The curve-level `norm_mk_C_sub_X_add_fCofactor` gets **no** twin. `simp` also unfolds `W.fCofactor x`, so its normal form is a nine-term expression in `of` and `root` — not a statement worth having. It is simply untagged, with that reason recorded in its docstring so the tag is not reinstated later.

So the finding is satisfied where a normal form exists and explicitly declined, with a reason, where it does not.

## Roadmap

Roadmap: EllipticCurves

Attribution only. Improving code already on `main` — refactoring, weakening a hypothesis, fixing an overclaiming docstring, relocating an import, adopting a naming convention — is always in scope and needs no roadmap claim.

## On the naming choice, where the two boards differed

#4729 took the naming finding twice, and the two boards agreed on the defect but proposed different fixes: the first offered `QuotientGroup.mk_eq_one_iff_exists_pow`, the second `mk_powMonoidHom_range_eq_one_iff_exists_pow` or `powMonoidHom_range_mk_eq_one_iff_exists_pow`.

I took the second board's second form, because it is the one that satisfies **both** boards' stated objection. The complaint is that `mk` heads a name in the bare `TauCeti` namespace where it has no referent, and that the name identifies neither `QuotientGroup.mk` nor the quotient `Mˣ ⧸ (powMonoidHom n).range`. Moving to `QuotientGroup` gives `mk` a referent but still does not name *which* quotient — and under this repo's common `open TauCeti` it would read as a fact about an arbitrary quotient's `mk`, which is exactly what the second board warned about. Leading with `powMonoidHom_range` names the subject and matches this file's own peers, `square_eq_powMonoidHom_two_range` and `index_square_le_of_closure_eq_top`, which both anchor the head token to what they are about.

## Gates

`lake build` of all four changed modules is green, 0 errors, 0 warnings. The diff adds no instances, no defs or abbrevs, and no transport-along-an-equality API. `scripts/lint-env.sh` is not run locally — it generates a driver importing every `TauCeti` module, i.e. a full-library build; CI's `pr-build` covers it, and it is what will confirm the three new `@[simp]` lemmas are simp-normal-form clean.
