### PR TITLE
feat(Huber): homomorphisms topologically of finite type

### DIFF
--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -5,29 +5,47 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.RingTheory.Huber.WeightedEval.Completion
+public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Completion
 
 /-!
 # Homomorphisms topologically of finite type
 
-Wedhorn's §6.6. A ring homomorphism `φ : A → B` into a complete `f`-adic ring is *topologically of
-finite type* when `B` is presented as a quotient of a weighted restricted power-series algebra
-`A⟨X₁, …, Xₖ⟩_T` over `A` — by a map that is surjective, continuous and open, and is a map of
-`A`-algebras. It is *strictly* topologically of finite type when the trivial weight family
-`Tᵢ = {1}` suffices, so that the presenting algebra is the ordinary `A⟨X₁, …, Xₖ⟩`.
+Wedhorn's §6.6. A ring homomorphism `φ : A → B` is *topologically of finite type* when `B` is
+presented as an `A`-algebra by an open quotient map out of the completion of a weighted restricted
+power-series ring `A⟨X₁, …, Xₖ⟩_T` on finitely many variables, each weight `Tᵢ` finite. It is
+*strictly* topologically of finite type when the trivial weight family `Tᵢ = {1}` suffices, so
+that the presenting algebra is `TauCeti.Huber.restrictedMvPowerSeriesCompletion`, the object this
+library writes `A⟨X₁, …, Xₖ⟩`.
 
 The notion is what three results the adic-spaces roadmap needs are stated in terms of: the second
 half of Proposition and Definition 6.36 (a Tate ring is strongly noetherian exactly when every
 Tate ring topologically of finite type over it is noetherian), Remark 6.37(1), and Example 6.38,
 which Proposition 8.30 cites by name.
 
+## What is and is not assumed
+
+Wedhorn states 6.28 and 6.29 for an `f`-adic `A` and a *complete* `f`-adic `B`. **Those standing
+hypotheses are deliberately not imposed here**: the definitions ask only that `A` be a
+nonarchimedean topological commutative ring — the least that lets `A⟨X⟩_T` be formed at all — and
+that `B` be a topological commutative ring. The predicates are therefore defined on a wider class
+than Wedhorn's, and agree with his on the class he considers. A consumer that needs completeness
+of `B` should assume it alongside, not read it out of these definitions.
+
+## Notation, and one thing it is easy to get backwards
+
+`A⟨X₁, …, Xₖ⟩_T` names the **uncompleted** weighted ring `TauCeti.Huber.weightedRestrictedSubring`
+of Wedhorn's Remark and Definition 5.48, as it does in the roadmap (`AdicSpaces/README.md`, §0.4).
+Wedhorn's presenting algebra in 6.28/6.29 is its **completion**, which he writes `Â⟨…⟩`; at the
+trivial weight family that completion is `restrictedMvPowerSeriesCompletion`, which this library
+writes `A⟨X₁, …, Xₖ⟩` without a subscript. So the domain of `π` below is a completion throughout,
+never the subring itself.
+
 ## The weighted algebra, and why not the Tate-only one
 
-The presenting algebra is the **weighted** `A⟨X⟩_T`, not `A⟨X⟩`. That is Wedhorn's own Proposition
-and Definition 6.29(i), and it is what the roadmap asks for (`AdicSpaces/README.md`, §5.2): the
-Tate-only algebra is too narrow downstream, since `A_inf` is Huber and not Tate. Definition 6.28,
-the strict variant, is the Tate-only case; the implication between them is
-`IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType`.
+The presenting algebra is the **weighted** one. That is Wedhorn's own 6.29(i), and it is what the
+roadmap asks for (`AdicSpaces/README.md`, §5.2): the Tate-only algebra is too narrow downstream,
+since `A_inf` is Huber and not Tate. Definition 6.28, the strict variant, is the Tate-only case;
+the implication between them is `IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType`.
 
 Two conditions on the weight family are in play and they are not the same. Wedhorn's standing
 hypothesis on `T` — needed even to *form* `A⟨X⟩_T` — is `TauCeti.Huber.IsWeightFamily`, that
@@ -38,10 +56,6 @@ lemma's docstring). Finiteness of each `Tᵢ` is a separate requirement of 6.29(
 the notion one of *finite* type — and is carried explicitly, since `IsWeightFamily` does not imply
 it.
 
-Wedhorn writes the presenting algebra `Â⟨X₁, …, Xₖ⟩_T`, with the completion taken after forming the
-restricted series; `UniformSpace.Completion (weightedRestrictedSubring T hT)` is that algebra, and
-is what the roadmap writes `A⟨X₁, …, Xₖ⟩_T`.
-
 ## Main definitions
 
 * `TauCeti.Huber.IsStrictlyTopologicallyFiniteType`: Wedhorn Definition 6.28.
@@ -49,8 +63,12 @@ is what the roadmap writes `A⟨X₁, …, Xₖ⟩_T`.
 
 ## Main results
 
+* `TauCeti.Huber.isStrictlyTopologicallyFiniteType_algebraMap`: the structure map
+  `A → A⟨X₁, …, Xₖ⟩` is strictly topologically of finite type — the presentation by the identity.
 * `TauCeti.Huber.IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType`: strictly
   topologically of finite type implies topologically of finite type, by the trivial weight family.
+* `TauCeti.Huber.IsTopologicallyFiniteType.continuous`: such a `φ` is continuous, since it factors
+  through the presenting algebra's structure map.
 
 ## References
 
@@ -68,48 +86,58 @@ variable {A : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
   {B : Type*} [CommRing B] [TopologicalSpace B]
 
 /-- **Wedhorn Proposition and Definition 6.29(i)**: `φ : A → B` is *topologically of finite type*
-when `B` is presented, as an `A`-algebra, by a surjective continuous open homomorphism out of a
-weighted restricted power-series algebra `A⟨X₁, …, Xₖ⟩_T` on finitely many variables with each
-weight `Tᵢ` finite. -/
+when `B` is presented, as an `A`-algebra, by an open quotient map out of the completion of a
+weighted restricted power-series ring on finitely many variables with each weight `Tᵢ` finite. -/
 def IsTopologicallyFiniteType (φ : A →+* B) : Prop :=
   ∃ (k : ℕ) (T : Fin k → Set A) (_ : ∀ i, (T i).Finite) (hT : IsWeightFamily T)
     (π : Completion (weightedRestrictedSubring T hT) →+* B),
-    Function.Surjective π ∧ Continuous π ∧ IsOpenMap π ∧
-      π.comp (Completion.coeRingHom.comp (weightedC T hT)) = φ
+    IsOpenQuotientMap π ∧ π.comp (algebraMap A (Completion (weightedRestrictedSubring T hT))) = φ
 
 /-- Unfolding lemma for the sealed definition `TauCeti.Huber.IsTopologicallyFiniteType`. -/
 theorem isTopologicallyFiniteType_iff {φ : A →+* B} :
     IsTopologicallyFiniteType φ ↔
       ∃ (k : ℕ) (T : Fin k → Set A) (_ : ∀ i, (T i).Finite) (hT : IsWeightFamily T)
         (π : Completion (weightedRestrictedSubring T hT) →+* B),
-        Function.Surjective π ∧ Continuous π ∧ IsOpenMap π ∧
-          π.comp (Completion.coeRingHom.comp (weightedC T hT)) = φ :=
+        IsOpenQuotientMap π ∧
+          π.comp (algebraMap A (Completion (weightedRestrictedSubring T hT))) = φ :=
   (Iff.rfl)
 
 /-- **Wedhorn Definition 6.28**: `φ : A → B` is *strictly* topologically of finite type when the
-presenting algebra can be taken to be the ordinary `A⟨X₁, …, Xₖ⟩`, the trivial weight family. -/
+presenting algebra can be taken to be `A⟨X₁, …, Xₖ⟩`, the trivial weight family. -/
 def IsStrictlyTopologicallyFiniteType (φ : A →+* B) : Prop :=
-  ∃ (k : ℕ) (π : Completion (weightedRestrictedSubring (fun _ : Fin k ↦ ({1} : Set A))
-      isWeightFamily_one_weight) →+* B),
-    Function.Surjective π ∧ Continuous π ∧ IsOpenMap π ∧
-      π.comp (Completion.coeRingHom.comp (weightedC _ isWeightFamily_one_weight)) = φ
+  ∃ (k : ℕ) (π : restrictedMvPowerSeriesCompletion k A →+* B),
+    IsOpenQuotientMap π ∧
+      π.comp (algebraMap A (restrictedMvPowerSeriesCompletion k A)) = φ
 
 /-- Unfolding lemma for the sealed definition
 `TauCeti.Huber.IsStrictlyTopologicallyFiniteType`. -/
 theorem isStrictlyTopologicallyFiniteType_iff {φ : A →+* B} :
     IsStrictlyTopologicallyFiniteType φ ↔
-      ∃ (k : ℕ) (π : Completion (weightedRestrictedSubring (fun _ : Fin k ↦ ({1} : Set A))
-          isWeightFamily_one_weight) →+* B),
-        Function.Surjective π ∧ Continuous π ∧ IsOpenMap π ∧
-          π.comp (Completion.coeRingHom.comp (weightedC _ isWeightFamily_one_weight)) = φ :=
+      ∃ (k : ℕ) (π : restrictedMvPowerSeriesCompletion k A →+* B),
+        IsOpenQuotientMap π ∧
+          π.comp (algebraMap A (restrictedMvPowerSeriesCompletion k A)) = φ :=
   (Iff.rfl)
+
+/-- **The presentation by the identity**: the structure map `A → A⟨X₁, …, Xₖ⟩` is strictly
+topologically of finite type. This is the witness that the conditions are simultaneously
+satisfiable, and the `k = 0` case says the completion map `A → Â` is one too. -/
+theorem isStrictlyTopologicallyFiniteType_algebraMap (k : ℕ) :
+    IsStrictlyTopologicallyFiniteType (algebraMap A (restrictedMvPowerSeriesCompletion k A)) :=
+  ⟨k, RingHom.id _, IsOpenQuotientMap.id, RingHom.id_comp _⟩
 
 /-- The trivial weight family is finite and satisfies the standing hypothesis, so a strict
 presentation is a presentation. -/
 theorem IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType {φ : A →+* B}
     (h : IsStrictlyTopologicallyFiniteType φ) : IsTopologicallyFiniteType φ := by
-  obtain ⟨k, π, hsurj, hcont, hopen, hcomm⟩ := h
-  exact ⟨k, _, fun _ ↦ Set.finite_singleton 1, isWeightFamily_one_weight, π, hsurj, hcont, hopen,
-    hcomm⟩
+  obtain ⟨k, π, hπ, hcomm⟩ := h
+  exact ⟨k, _, fun _ ↦ Set.finite_singleton 1, isWeightFamily_one_weight, π, hπ, hcomm⟩
+
+/-- A homomorphism topologically of finite type is continuous: it factors as an open quotient map
+after the presenting algebra's structure map, and both are continuous. -/
+theorem IsTopologicallyFiniteType.continuous {φ : A →+* B} (h : IsTopologicallyFiniteType φ) :
+    Continuous φ := by
+  obtain ⟨k, T, _, hT, π, hπ, hcomm⟩ := h
+  rw [← hcomm]
+  exact hπ.continuous.comp (continuous_algebraMap_completion_weightedRestrictedSubring k A hT)
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Huber.WeightedEval.Completion
+
+/-!
+# Homomorphisms topologically of finite type
+
+Wedhorn's §6.6. A ring homomorphism `φ : A → B` into a complete `f`-adic ring is *topologically of
+finite type* when `B` is presented as a quotient of a weighted restricted power-series algebra
+`A⟨X₁, …, Xₖ⟩_T` over `A` — by a map that is surjective, continuous and open, and is a map of
+`A`-algebras. It is *strictly* topologically of finite type when the trivial weight family
+`Tᵢ = {1}` suffices, so that the presenting algebra is the ordinary `A⟨X₁, …, Xₖ⟩`.
+
+The notion is what three results the adic-spaces roadmap needs are stated in terms of: the second
+half of Proposition and Definition 6.36 (a Tate ring is strongly noetherian exactly when every
+Tate ring topologically of finite type over it is noetherian), Remark 6.37(1), and Example 6.38,
+which Proposition 8.30 cites by name.
+
+## The weighted algebra, and why not the Tate-only one
+
+The presenting algebra is the **weighted** `A⟨X⟩_T`, not `A⟨X⟩`. That is Wedhorn's own Proposition
+and Definition 6.29(i), and it is what the roadmap asks for (`AdicSpaces/README.md`, §5.2): the
+Tate-only algebra is too narrow downstream, since `A_inf` is Huber and not Tate. Definition 6.28,
+the strict variant, is the Tate-only case; the implication between them is
+`IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType`.
+
+Two conditions on the weight family are in play and they are not the same. Wedhorn's standing
+hypothesis on `T` — needed even to *form* `A⟨X⟩_T` — is `TauCeti.Huber.IsWeightFamily`, that
+`Tᵢ^m · U` is a neighbourhood of zero for every `m` and every neighbourhood `U` of zero. The
+phrasing in 6.29(i), that each `Tᵢ · A` is open, is the `U = ⊤` case, and is recovered from it by
+`TauCeti.Huber.IsWeightFamily.isOpen_weightMul_top`; the converse is not available here (see that
+lemma's docstring). Finiteness of each `Tᵢ` is a separate requirement of 6.29(i) — it is what makes
+the notion one of *finite* type — and is carried explicitly, since `IsWeightFamily` does not imply
+it.
+
+Wedhorn writes the presenting algebra `Â⟨X₁, …, Xₖ⟩_T`, with the completion taken after forming the
+restricted series; `UniformSpace.Completion (weightedRestrictedSubring T hT)` is that algebra, and
+is what the roadmap writes `A⟨X₁, …, Xₖ⟩_T`.
+
+## Main definitions
+
+* `TauCeti.Huber.IsStrictlyTopologicallyFiniteType`: Wedhorn Definition 6.28.
+* `TauCeti.Huber.IsTopologicallyFiniteType`: Wedhorn Proposition and Definition 6.29(i).
+
+## Main results
+
+* `TauCeti.Huber.IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType`: strictly
+  topologically of finite type implies topologically of finite type, by the trivial weight family.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), §6.6, Definition 6.28 and
+  Proposition and Definition 6.29.
+-/
+
+public section
+
+namespace TauCeti.Huber
+
+open UniformSpace
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+  {B : Type*} [CommRing B] [TopologicalSpace B]
+
+/-- **Wedhorn Proposition and Definition 6.29(i)**: `φ : A → B` is *topologically of finite type*
+when `B` is presented, as an `A`-algebra, by a surjective continuous open homomorphism out of a
+weighted restricted power-series algebra `A⟨X₁, …, Xₖ⟩_T` on finitely many variables with each
+weight `Tᵢ` finite. -/
+def IsTopologicallyFiniteType (φ : A →+* B) : Prop :=
+  ∃ (k : ℕ) (T : Fin k → Set A) (_ : ∀ i, (T i).Finite) (hT : IsWeightFamily T)
+    (π : Completion (weightedRestrictedSubring T hT) →+* B),
+    Function.Surjective π ∧ Continuous π ∧ IsOpenMap π ∧
+      π.comp (Completion.coeRingHom.comp (weightedC T hT)) = φ
+
+/-- Unfolding lemma for the sealed definition `TauCeti.Huber.IsTopologicallyFiniteType`. -/
+theorem isTopologicallyFiniteType_iff {φ : A →+* B} :
+    IsTopologicallyFiniteType φ ↔
+      ∃ (k : ℕ) (T : Fin k → Set A) (_ : ∀ i, (T i).Finite) (hT : IsWeightFamily T)
+        (π : Completion (weightedRestrictedSubring T hT) →+* B),
+        Function.Surjective π ∧ Continuous π ∧ IsOpenMap π ∧
+          π.comp (Completion.coeRingHom.comp (weightedC T hT)) = φ :=
+  (Iff.rfl)
+
+/-- **Wedhorn Definition 6.28**: `φ : A → B` is *strictly* topologically of finite type when the
+presenting algebra can be taken to be the ordinary `A⟨X₁, …, Xₖ⟩`, the trivial weight family. -/
+def IsStrictlyTopologicallyFiniteType (φ : A →+* B) : Prop :=
+  ∃ (k : ℕ) (π : Completion (weightedRestrictedSubring (fun _ : Fin k ↦ ({1} : Set A))
+      isWeightFamily_one_weight) →+* B),
+    Function.Surjective π ∧ Continuous π ∧ IsOpenMap π ∧
+      π.comp (Completion.coeRingHom.comp (weightedC _ isWeightFamily_one_weight)) = φ
+
+/-- Unfolding lemma for the sealed definition
+`TauCeti.Huber.IsStrictlyTopologicallyFiniteType`. -/
+theorem isStrictlyTopologicallyFiniteType_iff {φ : A →+* B} :
+    IsStrictlyTopologicallyFiniteType φ ↔
+      ∃ (k : ℕ) (π : Completion (weightedRestrictedSubring (fun _ : Fin k ↦ ({1} : Set A))
+          isWeightFamily_one_weight) →+* B),
+        Function.Surjective π ∧ Continuous π ∧ IsOpenMap π ∧
+          π.comp (Completion.coeRingHom.comp (weightedC _ isWeightFamily_one_weight)) = φ :=
+  (Iff.rfl)
+
+/-- The trivial weight family is finite and satisfies the standing hypothesis, so a strict
+presentation is a presentation. -/
+theorem IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType {φ : A →+* B}
+    (h : IsStrictlyTopologicallyFiniteType φ) : IsTopologicallyFiniteType φ := by
+  obtain ⟨k, π, hsurj, hcont, hopen, hcomm⟩ := h
+  exact ⟨k, _, fun _ ↦ Set.finite_singleton 1, isWeightFamily_one_weight, π, hsurj, hcont, hopen,
+    hcomm⟩
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -43,8 +43,10 @@ Hausdorff — over a complete Hausdorff base, and over a discrete one — is
 
 ## Main results
 
-* `TauCeti.Huber.continuous_algebraMap_restrictedMvPowerSeriesCompletion`: the structure map
-  `A → A⟨X₁,…,Xₖ⟩` is continuous.
+* `TauCeti.Huber.continuous_algebraMap_completion_weightedRestrictedSubring`: the structure map
+  `A → A⟨X⟩_T` into the completion is continuous, for an arbitrary weight family;
+  `TauCeti.Huber.continuous_algebraMap_restrictedMvPowerSeriesCompletion` is the trivial-weight
+  case, the structure map `A → A⟨X₁,…,Xₖ⟩`.
 * `TauCeti.Huber.weightedMapCompletion_coe` and
   `TauCeti.Huber.continuous_weightedMapCompletion`: the induced map on the image of `A⟨X⟩_T`,
   and its continuity.
@@ -86,14 +88,22 @@ noncomputable abbrev restrictedMvPowerSeriesCompletion : Type _ :=
   UniformSpace.Completion
     (weightedRestrictedSubring (fun _ : Fin k ↦ ({1} : Set A)) isWeightFamily_one_weight)
 
-/-- The structure map `A → A⟨X₁,…,Xₖ⟩` is continuous. -/
-theorem continuous_algebraMap_restrictedMvPowerSeriesCompletion :
-    Continuous (algebraMap A (restrictedMvPowerSeriesCompletion k A)) := by
-  have h : Continuous (algebraMap A (weightedRestrictedSubring
-      (fun _ : Fin k ↦ ({1} : Set A)) isWeightFamily_one_weight)) :=
-    (continuous_weightedC isWeightFamily_one_weight).congr fun a ↦ Subtype.ext (by simp)
+/-- The structure map `A → A⟨X⟩_T` into the completion of a weighted restricted power-series ring
+is continuous. Nothing in the argument uses the shape of the weights, so it is stated for an
+arbitrary weight family; `continuous_algebraMap_restrictedMvPowerSeriesCompletion` is the trivial
+one. -/
+theorem continuous_algebraMap_completion_weightedRestrictedSubring {T : Fin k → Set A}
+    (hT : IsWeightFamily T) :
+    Continuous (algebraMap A (UniformSpace.Completion (weightedRestrictedSubring T hT))) := by
+  have h : Continuous (algebraMap A (weightedRestrictedSubring T hT)) :=
+    (continuous_weightedC hT).congr fun a ↦ Subtype.ext (by simp)
   exact ((UniformSpace.Completion.continuous_coe _).comp h).congr fun a ↦
     (UniformSpace.Completion.algebraMap_def _ _ a).symm
+
+/-- The structure map `A → A⟨X₁,…,Xₖ⟩` is continuous. -/
+theorem continuous_algebraMap_restrictedMvPowerSeriesCompletion :
+    Continuous (algebraMap A (restrictedMvPowerSeriesCompletion k A)) :=
+  continuous_algebraMap_completion_weightedRestrictedSubring k A isWeightFamily_one_weight
 
 /-! ### Functoriality in the coefficient ring -/
 


### PR DESCRIPTION
Wedhorn's §6.6. A ring homomorphism `φ : A → B` is **topologically of finite type** when `B` is
presented as a quotient of a weighted restricted power-series algebra `A⟨X₁, …, Xₖ⟩_T` over `A` by
a map that is surjective, continuous and open, and is a map of `A`-algebras; **strictly** so when
the trivial weight family `Tᵢ = {1}` suffices, i.e. the presenting algebra is the ordinary
`A⟨X₁, …, Xₖ⟩`.

- `IsTopologicallyFiniteType` — Proposition and Definition 6.29(i).
- `IsStrictlyTopologicallyFiniteType` — Definition 6.28.
- `IsStrictlyTopologicallyFiniteType.isTopologicallyFiniteType` — the implication, via
  `isWeightFamily_one_weight`.
- Unfolding lemmas for both, since neither definition is `@[expose]`d.

## Roadmap

`Roadmap: AdicSpaces`

Two places in `TauCetiRoadmap/AdicSpaces/README.md` bear on this, and they pull in the same
direction:

- **Prerequisite for Layer 4.1 step 3** (README:571, "Proposition 8.30: prove that restriction maps
  between rational localisations are flat"). Wedhorn's proof of 8.30 opens *"By Example 6.38 we
  know that `O_X(V)` is again a strongly noetherian Tate ring"*, and Example 6.38 is stated in
  terms of "topologically of finite type" — a notion absent from the library entirely. Remark
  6.37(1) and the second half of Proposition and Definition 6.36 are stated in it too.
- **§5.2** (README:644) already specifies the notion, and fixes its formulation: the presenting
  algebra must be the **weighted** `A⟨X₁,…,Xₙ⟩_T`, *"not the Tate-only `A⟨X₁,…,Xₙ⟩`, since Layer 6's
  `A_inf` is Huber and not Tate."*

This PR is the definition only. Per the campaign's scoping, 6.36's equivalence, Remark 6.37(1) and
Example 6.38 are deliberately **not** attempted here — Example 6.38 needs the quotient presentation
`C/𝔞` and is its own chunk.

## Three formulation choices, and why

**Weighted, not Tate-only.** Wedhorn 6.29(i) asks for `Â⟨X₁,…,Xₙ⟩_{T₁,…,Tₙ}`; 6.28, the *strict*
variant, is the Tate-only case. Defining only the Tate version would have to be restated at
Layer 5.

**The standing hypothesis on the weights is `IsWeightFamily`, and it is not literally 6.29(i)'s
phrasing.** 6.29(i) says each `Tᵢ · A` is open. The library's `IsWeightFamily` is the
all-neighbourhoods form — `Tᵢ^m · U` is a neighbourhood of zero for every `m` and every
neighbourhood `U` — which is what `weightedRestrictedSubring` requires in order to be closed under
multiplication at all, so the definition has no choice. The two are related by
`IsWeightFamily.isOpen_weightMul_top`, which derives 6.29(i)'s phrasing as the `U = ⊤` case; that
lemma's own docstring records that only this direction is available and that Wedhorn fixes the
all-neighbourhoods form as the standing hypothesis.

**Finiteness of each `Tᵢ` is carried separately.** 6.29(i) asks for *finite* subsets, and
`IsWeightFamily` does not imply finiteness — without it, "finite type" would be a misnomer. So it
is an explicit `∀ i, (T i).Finite`.

The presenting algebra is `UniformSpace.Completion (weightedRestrictedSubring T hT)`: Wedhorn
writes `Â⟨…⟩` and `WeightedEval/Completion.lean` records that this is the algebra the roadmap
writes `A⟨X₁,…,Xₖ⟩`. The `A`-algebra condition is stated as an equality of ring homomorphisms,
`π.comp (Completion.coeRingHom.comp (weightedC T hT)) = φ`, rather than pointwise.

## Attribution

Original work; there is no formal source. The informal source is
[T. Wedhorn, *Adic Spaces*] (arXiv:1910.05934v1), §6.6, Definition 6.28 and Proposition and
Definition 6.29. **Measured absence**, since this is a new notion: `TopologicallyFiniteType` and
"topologically of finite type" return 0 files on `main` (controls `IsTateRing` 18,
`powerBoundedSubring` 9, `IsStronglyNoetherian` 3, `weightedRestrictedSubring` 12 all resolve), 0
files in Mathlib at the pin on three phrasings, and AINTLIB has **no formal definition** — the
phrase occurs only as docstring prose in two files, and `Wedhorn828.lean` works *around* the
missing notion by exhibiting the Example 6.38 surjection directly.

## Gates

- `lake build TauCeti.RingTheory.Huber.TopologicallyFiniteType` — `Build completed successfully
  (2307 jobs)`, exit 0, no warnings. The module is a leaf; nothing imports it, so that is the
  complete cone.
- `#lint only <13 default environment linters> in TauCeti` over the built closure —
  `0 errors in 285 declarations`.
- The definition is exercised, not just elaborated: Wedhorn 6.36(ii) — *"every Tate ring
  topologically of finite type over `A` is noetherian"* — is now statable, and
  `h.isTopologicallyFiniteType` applies as API. Both check against the built module.
- Style: no line over 100 codepoints, no `λ`/`$`/`push_neg`/`set_option`, no `≥`/`>` in Lean code,
  every declaration documented.
