### PR TITLE
refactor(Algebra): state the recurrence identities over a noncommutative ring

### DIFF
--- a/TauCeti/Algebra/LinearRecurrence/OrderTwo.lean
+++ b/TauCeti/Algebra/LinearRecurrence/OrderTwo.lean
@@ -6,29 +6,31 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.Algebra.BigOperators.Ring.Finset
-import Mathlib.Tactic.LinearCombination
-import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Abel
 
 /-!
 # Products in a second-order linear recurrence
 
-Fix a commutative ring `R`, two elements `D S : R`, and a sequence `d : ℕ → R` obeying the
+Fix a ring `R`, not necessarily commutative, two elements `D S : R`, and a sequence
+`d : ℕ → R` obeying the
 second-order recurrence
 
 `d (r + 2) = D * d (r + 1) - S * d r`.
 
-Two identities hold for every such sequence. Neither asks `d` to be a polynomial, and neither
-asks `R` for an order, a characteristic, or an invertible `2`.
+Two identities hold for such a sequence: the first for every one of them, the second once `d` is
+normalised by `d 0 = 1` and `d 1 = D` and `D` commutes with `S`. Neither asks `d` to be a
+polynomial, neither asks `R` to be commutative, and neither asks it for an order, a
+characteristic, or an invertible `2`.
 
 ## Main results
 
-* `TauCeti.linearRec₂_mul_eq_succ_add_mul_pred`: multiplying a term by `D` moves it one step up
-  and leaves `S` times the term one step down,
-  `D * d m = d (m + 1) + S * d (m - 1)` for `0 < m`.
+* `TauCeti.linearRec₂_mul_eq_succ_add_mul_pred`: for `0 < m`, multiplying a term by `D` moves it
+  one step up and leaves `S` times the term one step down,
+  `D * d m = d (m + 1) + S * d (m - 1)`. It needs no hypothesis on `D` and `S`.
   This is the recurrence itself, re-indexed so that the multiplication rather than the top term
   is the subject; in that form it is what an induction on a product can apply term by term.
 * `TauCeti.linearRec₂_mul_eq_sum_pow_mul`: once `d` is normalised by `d 0 = 1` and `d 1 = D`,
-  a product of two terms is a *sum* of single terms,
+  and `D` commutes with `S`, a product of two terms is a *sum* of single terms,
   `d r * d s = ∑ i ∈ Finset.range (r + 1), S ^ i * d (r + s - 2 * i)` for `r ≤ s`.
 
 The second identity is the point. It is the Clebsch–Gordan shape: the product of two terms
@@ -91,56 +93,52 @@ namespace TauCeti
 
 open Finset
 
-variable {R : Type*} [CommRing R] {D S : R} {d : ℕ → R}
+variable {R : Type*} [Ring R] {D S : R} {d : ℕ → R}
 
 /-- **Multiplying by `D` shifts a term up.** For a sequence obeying
-`d (r + 2) = D * d (r + 1) - S * d r`, multiplication by `D` sends `d m` to the next term plus
-`S` times the previous one. This is the recurrence re-indexed, with the product as the subject. -/
+`d (r + 2) = D * d (r + 1) - S * d r`, multiplication by `D` sends `d m`, for `0 < m`, to the next
+term plus `S` times the previous one. This is the recurrence re-indexed, with the product as the
+subject. No hypothesis relating `D` and `S` is needed. -/
 theorem linearRec₂_mul_eq_succ_add_mul_pred
     (hd : ∀ r, d (r + 2) = D * d (r + 1) - S * d r) {m : ℕ} (hm : 0 < m) :
     D * d m = d (m + 1) + S * d (m - 1) := by
   obtain ⟨k, rfl⟩ : ∃ k, m = k + 1 := ⟨m - 1, by omega⟩
-  rw [show k + 1 + 1 = k + 2 by omega, Nat.add_sub_cancel, hd k]
-  ring
+  rw [show k + 1 + 1 = k + 2 by omega, Nat.add_sub_cancel, hd k, sub_add_cancel]
 
 /-- **A product of two terms is a sum of single terms.** For a sequence obeying
-`d (r + 2) = D * d (r + 1) - S * d r` and normalised by `d 0 = 1`, `d 1 = D`, the product
-`d r * d s` with `r ≤ s` equals `∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i)`: no product of
-`d`-values survives on the right. -/
-theorem linearRec₂_mul_eq_sum_pow_mul (h0 : d 0 = 1) (h1 : d 1 = D)
-    (hd : ∀ r, d (r + 2) = D * d (r + 1) - S * d r) :
-    ∀ {r s : ℕ}, r ≤ s → d r * d s = ∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i) := by
-  intro r
-  induction r using Nat.strong_induction_on with
-  | _ r ih =>
-    intro s hrs
-    match r, ih with
-    | 0, _ => simp [h0]
-    | 1, _ =>
-      rw [h1, linearRec₂_mul_eq_succ_add_mul_pred hd (m := s) (by omega),
-        sum_range_succ, sum_range_one, pow_zero, one_mul, pow_one,
-        show 1 + s - 2 * 0 = s + 1 by omega, show 1 + s - 2 * 1 = s - 1 by omega]
-    | (r + 2), ih =>
-      have key : ∀ i ∈ range (r + 2),
-          D * (S ^ i * d (r + 1 + s - 2 * i)) =
-            S ^ i * d (r + 2 + s - 2 * i) + S ^ (i + 1) * d (r + s - 2 * i) := by
-        intro i hi
-        rw [mem_range] at hi
-        have h := linearRec₂_mul_eq_succ_add_mul_pred hd (m := r + 1 + s - 2 * i) (by omega)
-        rw [show r + 1 + s - 2 * i + 1 = r + 2 + s - 2 * i by omega,
-          show r + 1 + s - 2 * i - 1 = r + s - 2 * i by omega] at h
-        linear_combination S ^ i * h
-      have hL : d (r + 2) * d s = D * (d (r + 1) * d s) - S * (d r * d s) := by
-        linear_combination d s * hd r
-      rw [hL, ih (r + 1) (by omega) (by omega), ih r (by omega) (by omega),
-        mul_sum, sum_congr rfl key, sum_add_distrib]
-      have hshift : S * ∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i) =
-          ∑ i ∈ range (r + 1), S ^ (i + 1) * d (r + s - 2 * i) := by
-        rw [mul_sum]
-        exact sum_congr rfl fun i _ ↦ by ring
-      rw [hshift, sum_range_succ (fun i ↦ S ^ (i + 1) * d (r + s - 2 * i)) (r + 1),
-        sum_range_succ (fun i ↦ S ^ i * d (r + 2 + s - 2 * i)) (r + 2),
-        show r + 2 + s - 2 * (r + 2) = r + s - 2 * (r + 1) by omega]
-      ring
+`d (r + 2) = D * d (r + 1) - S * d r`, normalised by `d 0 = 1` and `d 1 = D`, and with `D`
+commuting with `S`, the product `d r * d s` with `r ≤ s` equals
+`∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i)`: no product of `d`-values survives on the
+right. -/
+theorem linearRec₂_mul_eq_sum_pow_mul (h0 : d 0 = 1) (h1 : d 1 = D) (hDS : Commute D S)
+    (hd : ∀ r, d (r + 2) = D * d (r + 1) - S * d r) {r s : ℕ} (hrs : r ≤ s) :
+    d r * d s = ∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i) := by
+  induction r using Nat.twoStepInduction generalizing s with
+  | zero => simp [h0]
+  | one =>
+    rw [h1, linearRec₂_mul_eq_succ_add_mul_pred hd (m := s) (by omega), sum_range_succ,
+      sum_range_one, show 1 + s - 2 * 0 = s + 1 by omega, show 1 + s - 2 * 1 = s - 1 by omega]
+    simp
+  | more r ih1 ih2 =>
+    have key : ∀ i ∈ range (r + 2),
+        D * (S ^ i * d (r + 1 + s - 2 * i)) =
+          S ^ i * d (r + 2 + s - 2 * i) + S ^ (i + 1) * d (r + s - 2 * i) := by
+      intro i hi
+      rw [mem_range] at hi
+      have h := linearRec₂_mul_eq_succ_add_mul_pred hd (m := r + 1 + s - 2 * i) (by omega)
+      rw [show r + 1 + s - 2 * i + 1 = r + 2 + s - 2 * i by omega,
+        show r + 1 + s - 2 * i - 1 = r + s - 2 * i by omega] at h
+      rw [← mul_assoc, (hDS.pow_right i).eq, mul_assoc, h, mul_add, ← mul_assoc, ← pow_succ]
+    have hL : d (r + 2) * d s = D * (d (r + 1) * d s) - S * (d r * d s) := by
+      rw [hd r, sub_mul, mul_assoc, mul_assoc]
+    have hshift : S * ∑ i ∈ range (r + 1), S ^ i * d (r + s - 2 * i) =
+        ∑ i ∈ range (r + 1), S ^ (i + 1) * d (r + s - 2 * i) := by
+      rw [mul_sum]
+      exact sum_congr rfl fun i _ ↦ by rw [← mul_assoc, ← pow_succ']
+    rw [hL, ih2 (by omega), ih1 (by omega), mul_sum, sum_congr rfl key, sum_add_distrib, hshift,
+      sum_range_succ (fun i ↦ S ^ (i + 1) * d (r + s - 2 * i)) (r + 1),
+      sum_range_succ (fun i ↦ S ^ i * d (r + 2 + s - 2 * i)) (r + 2),
+      show r + 2 + s - 2 * (r + 2) = r + s - 2 * (r + 1) by omega]
+    abel
 
 end TauCeti


### PR DESCRIPTION
Follow-up to #4796, which merged the two second-order recurrence identities. A second review
board on that PR raised findings that were correct but did not land: the bot auto-merged the
moment the first board went green, while the commit answering the second board was already pushed
and waiting for its own round. This PR carries that work to `main`.

Purely a restatement and reproof of two existing theorems. No new mathematics, no new
declarations, no change to what either identity says.

## `[CommRing R]` was too strong, and the consumer proves it

`linearRec₂_mul_eq_succ_add_mul_pred` never reorders a product at all.
`linearRec₂_mul_eq_sum_pow_mul` reorders exactly one, `D * S ^ i`; the `d`-values are never
commuted with anything.

That this matters is not hypothetical. The on-`main` consumer of the identity is
`HeckeRing.GL2.heckeT_prime_pow_mul` (`TauCeti/NumberTheory/HeckeRing/GL2/Recurrence.lean:340`),
and that file has to prove its commutation **by hand** at `Recurrence.lean:123`:

```lean
have hcomm : heckeT ⟨p, hp.pos⟩ * heckeTScalar p = heckeTScalar p * heckeT ⟨p, hp.pos⟩ := by
  rw [heckeT_prime p hp]
  exact HeckeCosetModule.mul_comm_of_antiInvolution ...
```

An ambient `CommRing` would make that line unnecessary, so the ring the identity is actually
consumed in is not commutative and the merged statement cannot be applied there without inventing
a `CommRing` instance for it.

So: `variable {R : Type*} [Ring R]`, with `(hDS : Commute D S)` added to
`linearRec₂_mul_eq_sum_pow_mul` **only**. `linearRec₂_mul_eq_succ_add_mul_pred` stays free of any
hypothesis relating `D` and `S`.

`ring` and `linear_combination` both need commutativity, so the algebra is now explicit:
`sub_add_cancel` for the recurrence step, `(hDS.pow_right i).eq` with `mul_add` and `← pow_succ`
for the summand, `sub_mul`/`mul_assoc` for the split, `← pow_succ'` for the shift, and `abel` for
the final regrouping. The `Mathlib.Tactic.Ring` and `Mathlib.Tactic.LinearCombination` imports are
replaced by the single `Mathlib.Tactic.Abel`.

## The induction is a two-step recursion, and now says so

The merged statement carries `∀ {r s : ℕ}, r ≤ s → …` inside its conclusion rather than as
binders. That shape existed only so the proof could `intro r` and then re-split with
`induction r using Nat.strong_induction_on` followed by `match r, ih with` — advertising a strong
recursion where the argument is a two-step one.

Restated with ordinary `{r s : ℕ} (hrs : r ≤ s)` binders and proved by
`induction r using Nat.twoStepInduction generalizing s`. `ih1` and `ih2` now land at `r` and
`r + 1` directly, the `match` is gone, and the four `by omega` side goals that discharged
`r < r + 2` and `r + 1 < r + 2` disappear with it.

In the `r = 1` case the order-sensitive `pow_zero` / `one_mul` / `pow_one` rewrite tail becomes
`simp`; `one_mul` previously fired on whichever `1 * _` appeared first, so the step depended on
the exact output shape of `sum_range_succ`.

## Two docstrings claimed more than their theorems

* the docstring of `linearRec₂_mul_eq_succ_add_mul_pred` stated its conclusion unconditionally,
  while the theorem requires `0 < m` — and the identity is false at `m = 0`;
* the module docstring said "Two identities hold for every such sequence", while the second also
  needs `d 0 = 1` and `d 1 = D`.

Both qualified. The header sentence no longer describes `R` as commutative, and the
`## Main results` entries carry their hypotheses.

## Still outstanding, deliberately not in this PR

The same board observed that `heckeT_prime_pow_mul` is this identity specialised, proved on `main`
by the same induction over ~140 lines of file-local scaffolding
(`Recurrence.lean:195-335`), so the repo currently carries the argument twice. That is real and
should be fixed by reproving `heckeT_prime_pow_mul` from `linearRec₂_mul_eq_sum_pow_mul` and
deleting the scaffolding — but it is a separate topic touching a different file, and it depends on
the weakening in this PR (that is what lets `hcomm` serve as the `Commute` witness, with no
invented instance). It follows as its own PR once this merges.

## Gates

`lake build TauCeti.Algebra.LinearRecurrence.OrderTwo` green at the branch head; axioms
`[propext, Quot.sound]` and `[propext, Classical.choice, Quot.sound]`; `#lint` over the 13 default
linters reports 0 errors in 2 declarations.

Roadmap: ModularForms
