### PR TITLE
refactor(HeckeSlash): use the defining equations of T_n instead of unfolding it

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Operators.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Operators.lean
@@ -129,8 +129,7 @@ theorem coe_heckeTNat_prime (hp : p.Prime)
     ⇑(heckeTNat (N := N) k p (_hn := ⟨hp.ne_zero⟩) f) =
       heckeSlashUpperTri k p ⇑f + ⇑(diamondOpNat k p f) ∣[k] scaleRep p := by
   let _ : NeZero p := ⟨hp.ne_zero⟩
-  unfold heckeTNat
-  rw [coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime k hp]
+  rw [heckeTNat_def, coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime k hp]
 
 /-- **The classical `T_p` formula on cusp forms, at every prime.** -/
 theorem coe_heckeTCuspNat_prime (hp : p.Prime)
@@ -138,8 +137,7 @@ theorem coe_heckeTCuspNat_prime (hp : p.Prime)
     ⇑(heckeTCuspNat (N := N) k p (_hn := ⟨hp.ne_zero⟩) f) =
       heckeSlashUpperTri k p ⇑f + ⇑(diamondOpCuspNat k p f) ∣[k] scaleRep p := by
   let _ : NeZero p := ⟨hp.ne_zero⟩
-  unfold heckeTCuspNat
-  rw [coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime k hp]
+  rw [heckeTCuspNat_def, coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime k hp]
 
 /-- At a positive index dividing the level, `T_p` is the upper-triangular operator. This is the
 operator modern sources denote by `U_p`. -/
@@ -148,8 +146,7 @@ theorem heckeTNat_eq_upperTri (hpN : p ∣ N) :
       (_hn := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩) =
       heckeSlashUpperTriModularFormEnd k hpN := by
   let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
-  unfold heckeTNat
-  rw [heckeSlashGamma1ModularFormEnd_diagCosetGamma1 k hpN]
+  rw [heckeTNat_def, heckeSlashGamma1ModularFormEnd_diagCosetGamma1 k hpN]
 
 /-- At a positive index dividing the level, the cusp-form `T_p` is the upper-triangular
 operator. -/
@@ -158,8 +155,7 @@ theorem heckeTCuspNat_eq_upperTri (hpN : p ∣ N) :
       (_hn := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩) =
       heckeSlashUpperTriCuspFormEnd k hpN := by
   let _ : NeZero p := ⟨fun h ↦ NeZero.ne N (Nat.eq_zero_of_zero_dvd (h ▸ hpN))⟩
-  unfold heckeTCuspNat
-  rw [heckeSlashGamma1CuspFormEnd_diagCosetGamma1 k hpN]
+  rw [heckeTCuspNat_def, heckeSlashGamma1CuspFormEnd_diagCosetGamma1 k hpN]
 
 /-- The first Hecke operator on modular forms is the identity. -/
 @[simp] theorem heckeTNat_one : heckeTNat (N := N) k 1 = 1 := by


### PR DESCRIPTION
`TauCeti/NumberTheory/ModularForms/HeckeSlash/Operators.lean` states the same step two
different ways. It publishes the defining equations

* `heckeTNat_def` (`:91`) and `heckeTCuspNat_def` (`:96`), both `rfl`,

rewrites with them in two proofs,

* `:118` — `rw [heckeTNat_def, coe_heckeSlashGamma1ModularFormEnd]`
* `:124` — `rw [heckeTCuspNat_def, coe_heckeSlashGamma1CuspFormEnd]`

and then reaches straight past them in four others,

* `:132`, `:151` — `unfold heckeTNat`, each followed by a separate `rw`
* `:141`, `:161` — `unfold heckeTCuspNat`, likewise.

This uses the named equations in all six, and folds each `unfold` + `rw` pair into the
single `rw [..._def, ...]` the first two already use, so the six proofs now read the same
way.

## What does and does not change

Nothing about the statements, and nothing about the proof terms: both `_def` lemmas are
`rfl`, so this performs the same rewrite by a name instead of through the definition body.
The gain is that the four proofs stop depending on the shape of that body — restating
`heckeTNat` over anything else would leave them compiling, whereas `unfold` would not.

`rw` matching where `unfold` did is **not** automatic here, and was measured rather than
assumed. All four goals carry an explicit instance argument (`_hn := ⟨hp.ne_zero⟩`, or the
`NeZero` witness built from `p ∣ N`) alongside a `let _ : NeZero p := …` local instance,
and `rw` matches syntactically where `unfold` works up to definitional unfolding — so the
rewrite could plausibly have failed to find its pattern. It does match: the changed module
and both of its direct importers, `HeckeSlash/BadPrime.lean` and
`HeckeSlash/LevelSupported.lean`, build clean (3116/3116 jobs, no errors, warnings or
sorries).

## Scope

Improvement to code already on `main`, in the sense
[`.claude/CLAUDE.md`](https://github.com/TauCetiProject/TauCeti/blob/main/.claude/CLAUDE.md)
allows without a roadmap entry — "adopting a cleaner idiom". No declaration is added,
removed, renamed or restated, and no mathematics changes.

Roadmap: ModularForms
