### PR TITLE
feat: coprimality of the division polynomials Φₙ and ΨSqₙ

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/IsAlgClosed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/IsAlgClosed.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Basic
+public import Mathlib.FieldTheory.IsAlgClosed.Basic
+
+/-!
+# Every `x`-coordinate of a Weierstrass curve over an algebraically closed field is attained
+
+Fixing `x = a` in the Weierstrass equation leaves a monic quadratic in `y`, so over an
+algebraically closed field it has a root and `a` is the `x`-coordinate of a solution. The statement
+is about `Affine.Equation` alone: no nonsingularity, no ellipticity, and no division polynomial is
+involved, which is why it lives here rather than with any consumer.
+
+## Main results
+
+* `TauCeti.WeierstrassCurve.Affine.exists_point_on_curve`: over an algebraically closed field
+  every element is the `x`-coordinate of a solution of `W.Equation`.
+
+Stated for an arbitrary affine Weierstrass curve over an algebraically closed field. It yields a
+solution of the *equation*, not an element of `W.Point`; a caller wanting a point pairs it with
+`equation_iff_nonsingular_of_Δ_ne_zero` or `equation_iff_nonsingular`, which is what makes the
+hypothesis-free form the useful one.
+
+## Roadmap
+
+`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**". The consumer is
+`DivisionPolynomial/Coprimality.lean`, whose proof of `isCoprime_Φ_ΨSq` passes to the algebraic
+closure and needs a common root of `Φₙ` and `ΨSqₙ` to be the `x`-coordinate of an actual point.
+Nothing here mentions a division polynomial.
+
+## Provenance
+
+Ported, with the author's proof, from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), the
+HasseWeil project at `dev/hasse-weil @ 513e83879e2f` — the revision
+`TauCetiRoadmap/EllipticCurves/README.md:1071` pins for that project. Source file
+`projects/HasseWeil/HasseWeil/Auxiliary/DivisionPolynomial.lean`, section `Coprimality`,
+declaration `exists_point_on_curve`, whose header credits David Kurniadi Angdinata and Junyan Xu.
+Upstream it sits beside its coprimality consumer and is stated for a global
+`WeierstrassCurve`; here it is separated out and stated for the affine model, which is the level
+its content lives at. The degree of the quadratic is `Polynomial.degree_quadratic` here in place of
+the source's explicit `natDegree` bound.
+-/
+
+public section
+
+open Polynomial
+
+namespace TauCeti
+
+namespace WeierstrassCurve
+
+namespace Affine
+
+variable {F : Type*} [Field F] [IsAlgClosed F] (W : _root_.WeierstrassCurve.Affine F)
+
+/-- **Over an algebraically closed field every `x`-coordinate is realised by a point.** Solving the
+Weierstrass equation for `y` at a fixed `x` is finding a root of a quadratic, which an
+algebraically closed field always has. -/
+theorem exists_point_on_curve (a : F) : ∃ b : F, W.Equation a b := by
+  obtain ⟨b, hb⟩ := IsAlgClosed.exists_root
+    (C 1 * X ^ 2 + C (W.a₁ * a + W.a₃) * X + C (-(a ^ 3 + W.a₂ * a ^ 2 + W.a₄ * a + W.a₆)))
+    (by rw [degree_quadratic one_ne_zero]; simp)
+  rw [IsRoot.def] at hb
+  simp only [eval_add, eval_mul, eval_pow, eval_C, eval_X, one_mul] at hb
+  exact ⟨b, (W.equation_iff a b).mpr (by linear_combination hb)⟩
+
+end Affine
+
+end WeierstrassCurve
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/IsAlgClosed.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/IsAlgClosed.lean
@@ -18,7 +18,7 @@ involved, which is why it lives here rather than with any consumer.
 
 ## Main results
 
-* `TauCeti.WeierstrassCurve.Affine.exists_point_on_curve`: over an algebraically closed field
+* `WeierstrassCurve.Affine.exists_point_on_curve`: over an algebraically closed field
   every element is the `x`-coordinate of a solution of `W.Equation`.
 
 Stated for an arbitrary affine Weierstrass curve over an algebraically closed field. It yields a
@@ -50,13 +50,11 @@ public section
 
 open Polynomial
 
-namespace TauCeti
-
 namespace WeierstrassCurve
 
 namespace Affine
 
-variable {F : Type*} [Field F] [IsAlgClosed F] (W : _root_.WeierstrassCurve.Affine F)
+variable {F : Type*} [Field F] [IsAlgClosed F] (W : Affine F)
 
 /-- **Over an algebraically closed field every `x`-coordinate is realised by a point.** Solving the
 Weierstrass equation for `y` at a fixed `x` is finding a root of a quadratic, which an
@@ -73,4 +71,4 @@ end Affine
 
 end WeierstrassCurve
 
-end TauCeti
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Coprimality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Coprimality.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Degree
 public import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.IsAlgClosed
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Eval
 public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.ZSMul
 
@@ -25,8 +26,6 @@ has `X = Z = 0`, so there was no common factor.
 
 ## Main results
 
-* `WeierstrassCurve.exists_point_on_curve`: over an algebraically closed field every element is
-  the `x`-coordinate of a point of the curve.
 * `WeierstrassCurve.isCoprime_Φ_ΨSq`: `IsCoprime (W.Φ n) (W.ΨSq n)` whenever `W.Δ ≠ 0`.
 * `WeierstrassCurve.ΨSq_ne_zero_of_Δ_ne_zero`: `W.ΨSq n ≠ 0` for `n ≠ 0`, with **no** hypothesis
   on the characteristic.
@@ -65,7 +64,9 @@ HasseWeil project at `dev/hasse-weil @ 513e83879e2f` — the revision
 `TauCetiRoadmap/EllipticCurves/README.md:1071` pins for that project, as distinct from the
 restructured `projects/HasseWeil` copy carried at the NagellLutz entry's `dev/modular-curves` pin.
 Source file `projects/HasseWeil/HasseWeil/Auxiliary/DivisionPolynomial.lean`, section
-`Coprimality`, declarations `exists_point_on_curve` and `isCoprime_Φ_ΨSq`. That file's header reads
+`Coprimality`, declaration `isCoprime_Φ_ΨSq`. The section's `exists_point_on_curve`, which the
+proof below calls, is ported in `Affine/IsAlgClosed.lean` instead, since it is about
+`Affine.Equation` and mentions no division polynomial. That file's header reads
 `Authors: David Kurniadi Angdinata, Junyan Xu`; following this repository's convention for adapted
 material the upstream authorship is credited here rather than in the copyright header.
 
@@ -90,17 +91,6 @@ open TauCeti.WeierstrassCurve
 
 variable {F : Type*} [Field F] (W : WeierstrassCurve F)
 
-/-- **Over an algebraically closed field every `x`-coordinate is realised by a point.** Solving the
-Weierstrass equation for `y` at a fixed `x` is finding a root of a quadratic, which an
-algebraically closed field always has. -/
-theorem exists_point_on_curve [IsAlgClosed F] (a : F) : ∃ b : F, W.toAffine.Equation a b := by
-  obtain ⟨b, hb⟩ := IsAlgClosed.exists_root
-    (C 1 * X ^ 2 + C (W.a₁ * a + W.a₃) * X + C (-(a ^ 3 + W.a₂ * a ^ 2 + W.a₄ * a + W.a₆)))
-    (by rw [degree_quadratic one_ne_zero]; simp)
-  rw [IsRoot.def] at hb
-  simp only [eval_add, eval_mul, eval_pow, eval_C, eval_X, one_mul] at hb
-  exact ⟨b, (W.toAffine.equation_iff a b).mpr (by linear_combination hb)⟩
-
 /-- **The division polynomials `Φₙ` and `ΨSqₙ` of a nonsingular curve are coprime**, so the
 `x`-coordinate `Φₙ / ΨSqₙ` of `n • (x, y)` is in lowest terms (Sutherland Lemma 6.8, Silverman
 Exercise III.3.7). Nonsingularity is necessary and no hypothesis on `n` is needed; see the module
@@ -117,7 +107,7 @@ theorem isCoprime_Φ_ΨSq (n : ℤ) (hΔ : W.Δ ≠ 0) : IsCoprime (W.Φ n) (W.�
   obtain ⟨hΦ, hΨ⟩ := h
   simp only [Polynomial.coe_aeval_eq_eval] at hΦ hΨ
   -- a common root of `Φₙ` and `ΨSqₙ` is the `x`-coordinate of a point of the curve
-  obtain ⟨b, hb⟩ := W'.exists_point_on_curve a
+  obtain ⟨b, hb⟩ := Affine.exists_point_on_curve W'.toAffine a
   have hΔ' : W'.Δ ≠ 0 := by rw [hW', map_Δ]; exact (map_ne_zero_iff f f.injective).mpr hΔ
   have hns : W'.toAffine.Nonsingular a b :=
     (W'.toAffine.equation_iff_nonsingular_of_Δ_ne_zero hΔ').mp hb

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Coprimality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Coprimality.lean
@@ -35,7 +35,9 @@ has `X = Z = 0`, so there was no common factor.
 
 **Coprimality needs no hypothesis on `n`.** The statement holds at `n = 0` as well, where it reads
 `IsCoprime 1 0` — true because `Φ_zero` makes the first argument a unit — and the proof below never
-splits on `n`. The two consequences recorded here do need `n ≠ 0`, and take it explicitly.
+splits on `n`. Since no hypothesis mentions `n` it is an explicit argument, while
+`ΨSq_ne_zero_of_Δ_ne_zero` does need `n ≠ 0` and reads `n` off that hypothesis instead — the
+split Mathlib's own `Φ_ne_zero` and `ΨSq_ne_zero` make in this same family.
 
 **`W.Δ ≠ 0` is necessary, not an artefact of the proof.** On the cusp curve `Y² = X³` every
 coefficient vanishes and `cusp_Ψ₂Sq` computes `Ψ₂Sq = 4X³`, while `Φ₂` is `X⁴`; the two share the
@@ -86,7 +88,7 @@ namespace WeierstrassCurve
 
 open TauCeti.WeierstrassCurve
 
-variable {F : Type*} [Field F] (W : WeierstrassCurve F) {n : ℤ}
+variable {F : Type*} [Field F] (W : WeierstrassCurve F)
 
 /-- **Over an algebraically closed field every `x`-coordinate is realised by a point.** Solving the
 Weierstrass equation for `y` at a fixed `x` is finding a root of a quadratic, which an
@@ -103,7 +105,7 @@ theorem exists_point_on_curve [IsAlgClosed F] (a : F) : ∃ b : F, W.toAffine.Eq
 `x`-coordinate `Φₙ / ΨSqₙ` of `n • (x, y)` is in lowest terms (Sutherland Lemma 6.8, Silverman
 Exercise III.3.7). Nonsingularity is necessary and no hypothesis on `n` is needed; see the module
 docstring for both. -/
-theorem isCoprime_Φ_ΨSq (hΔ : W.Δ ≠ 0) : IsCoprime (W.Φ n) (W.ΨSq n) := by
+theorem isCoprime_Φ_ΨSq (n : ℤ) (hΔ : W.Δ ≠ 0) : IsCoprime (W.Φ n) (W.ΨSq n) := by
   let f := algebraMap F (AlgebraicClosure F)
   rw [← Polynomial.isCoprime_map f, ← map_Φ, ← map_ΨSq]
   set W' := W.map f with hW'
@@ -136,8 +138,8 @@ theorem isCoprime_Φ_ΨSq (hΔ : W.Δ ≠ 0) : IsCoprime (W.Φ n) (W.ΨSq n) := 
 /-- **`ΨSqₙ` is nonzero on a nonsingular curve, in every characteristic.** Mathlib's
 `ΨSq_ne_zero` assumes `(n : F) ≠ 0` instead; see the module docstring on why neither statement
 subsumes the other. -/
-theorem ΨSq_ne_zero_of_Δ_ne_zero (hΔ : W.Δ ≠ 0) (hn : n ≠ 0) : W.ΨSq n ≠ 0 := fun h ↦
+theorem ΨSq_ne_zero_of_Δ_ne_zero {n : ℤ} (hΔ : W.Δ ≠ 0) (hn : n ≠ 0) : W.ΨSq n ≠ 0 := fun h ↦
   (W.natDegree_Φ_pos hn).ne'
-    (natDegree_eq_zero_of_isUnit (isCoprime_zero_right.mp (h ▸ W.isCoprime_Φ_ΨSq hΔ)))
+    (natDegree_eq_zero_of_isUnit (isCoprime_zero_right.mp (h ▸ W.isCoprime_Φ_ΨSq n hΔ)))
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Coprimality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Coprimality.lean
@@ -107,7 +107,7 @@ theorem isCoprime_Φ_ΨSq (n : ℤ) (hΔ : W.Δ ≠ 0) : IsCoprime (W.Φ n) (W.�
   obtain ⟨hΦ, hΨ⟩ := h
   simp only [Polynomial.coe_aeval_eq_eval] at hΦ hΨ
   -- a common root of `Φₙ` and `ΨSqₙ` is the `x`-coordinate of a point of the curve
-  obtain ⟨b, hb⟩ := Affine.exists_point_on_curve W'.toAffine a
+  obtain ⟨b, hb⟩ := W'.toAffine.exists_point_on_curve a
   have hΔ' : W'.Δ ≠ 0 := by rw [hW', map_Δ]; exact (map_ne_zero_iff f f.injective).mpr hΔ
   have hns : W'.toAffine.Nonsingular a b :=
     (W'.toAffine.equation_iff_nonsingular_of_Δ_ne_zero hΔ').mp hb

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Coprimality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Coprimality.lean
@@ -1,0 +1,143 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Degree
+public import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Eval
+public import TauCeti.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.ZSMul
+
+/-!
+# Coprimality of the division polynomials `Φₙ` and `ΨSqₙ`
+
+Over a field, the `x`-coordinate of `n • (x, y)` is the rational function `Φₙ / ΨSqₙ`. This file
+proves that numerator and denominator are **coprime** as soon as the curve is nonsingular, so that
+quotient is already in lowest terms and its degree is visible from the two degrees separately.
+
+The argument is the geometric one (Sutherland Lemma 6.8, Silverman Exercise III.3.7). A common
+factor of `Φₙ` and `ΨSqₙ` survives to the algebraic closure, where it has a root `a`; that `a` is
+the `x`-coordinate of an actual point `(a, b)` of the curve, and `Φₙ(a) = ΨSqₙ(a) = 0` makes both
+the `X` and the `Z` Jacobian coordinate of `n • (a, b)` vanish. No point of a nonsingular curve
+has `X = Z = 0`, so there was no common factor.
+
+## Main results
+
+* `WeierstrassCurve.exists_point_on_curve`: over an algebraically closed field every element is
+  the `x`-coordinate of a point of the curve.
+* `WeierstrassCurve.isCoprime_Φ_ΨSq`: `IsCoprime (W.Φ n) (W.ΨSq n)` whenever `W.Δ ≠ 0`.
+* `WeierstrassCurve.ΨSq_ne_zero_of_Δ_ne_zero`: `W.ΨSq n ≠ 0` for `n ≠ 0`, with **no** hypothesis
+  on the characteristic.
+
+## Implementation notes
+
+**Coprimality needs no hypothesis on `n`.** The statement holds at `n = 0` as well, where it reads
+`IsCoprime 1 0` — true because `Φ_zero` makes the first argument a unit — and the proof below never
+splits on `n`. The two consequences recorded here do need `n ≠ 0`, and take it explicitly.
+
+**`W.Δ ≠ 0` is necessary, not an artefact of the proof.** On the cusp curve `Y² = X³` every
+coefficient vanishes and `cusp_Ψ₂Sq` computes `Ψ₂Sq = 4X³`, while `Φ₂` is `X⁴`; the two share the
+factor `X³`. So no version of this statement survives dropping nonsingularity, and the hypothesis
+is stated as `W.Δ ≠ 0` rather than `[W.IsElliptic]` because that is all the proof consumes.
+
+**`ΨSq_ne_zero_of_Δ_ne_zero` trades a characteristic hypothesis for nonsingularity.** Mathlib's
+`ΨSq_ne_zero` concludes the same thing from `(n : F) ≠ 0`, which fails exactly when the
+characteristic divides `n`. Coprimality removes that restriction: were `ΨSqₙ` zero, `Φₙ` would have
+to be a unit, and `natDegree_Φ_pos` says it has positive degree. Neither statement subsumes the
+other — Mathlib's holds on singular curves, this one in every characteristic — so both are useful.
+
+## Roadmap
+
+`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**": for `n ≠ 0`,
+multiplication-by-`n` is an isogeny of degree `n²`, pinned by the division-polynomial
+multiplication formula. Reading that degree off `Φₙ / ΨSqₙ` requires knowing the fraction is in
+lowest terms, which is what this file supplies; `ΨSq_ne_zero_of_Δ_ne_zero` is the accompanying
+statement that the denominator is not the zero polynomial in any characteristic.
+
+## Provenance
+
+Ported, with the authors' proofs, from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), the
+HasseWeil project at `dev/hasse-weil @ 513e83879e2f` — the revision
+`TauCetiRoadmap/EllipticCurves/README.md:1071` pins for that project, as distinct from the
+restructured `projects/HasseWeil` copy carried at the NagellLutz entry's `dev/modular-curves` pin.
+Source file `projects/HasseWeil/HasseWeil/Auxiliary/DivisionPolynomial.lean`, section
+`Coprimality`, declarations `exists_point_on_curve` and `isCoprime_Φ_ΨSq`. That file's header reads
+`Authors: David Kurniadi Angdinata, Junyan Xu`; following this repository's convention for adapted
+material the upstream authorship is credited here rather than in the copyright header.
+
+Three of the source's calls are spelled differently here, because the corresponding lemmas already
+exist under this repository's or Mathlib's names: the source's `evalEval_ψ_sq` and
+`evalEval_φ_eq_Φ` are `Eval.lean`'s `evalEval_Ψ_sq_eq_eval_ΨSq` (composed with
+`evalEval_ψ_eq_evalEval_Ψ`, since Mathlib states the square for `Ψ` rather than `ψ`) and
+`evalEval_φ_eq_eval_Φ`; the source's `zsmul_eq_smulEval` is `ZSMul.lean`'s
+`zsmul_point_eq_smulEval`. The source's `evalEval_eq_of_mk_eq` is not ported: `Eval.lean` already
+has it. The degree computation for the quadratic is `Polynomial.degree_quadratic` here in place of
+the source's explicit `natDegree` bound, and the unused `n ≠ 0` argument of the source's
+`isCoprime_Φ_ΨSq` is dropped. `ΨSq_ne_zero_of_Δ_ne_zero` has no counterpart in the source.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve
+
+open TauCeti.WeierstrassCurve
+
+variable {F : Type*} [Field F] (W : WeierstrassCurve F) {n : ℤ}
+
+/-- **Over an algebraically closed field every `x`-coordinate is realised by a point.** Solving the
+Weierstrass equation for `y` at a fixed `x` is finding a root of a quadratic, which an
+algebraically closed field always has. -/
+theorem exists_point_on_curve [IsAlgClosed F] (a : F) : ∃ b : F, W.toAffine.Equation a b := by
+  obtain ⟨b, hb⟩ := IsAlgClosed.exists_root
+    (C 1 * X ^ 2 + C (W.a₁ * a + W.a₃) * X + C (-(a ^ 3 + W.a₂ * a ^ 2 + W.a₄ * a + W.a₆)))
+    (by rw [degree_quadratic one_ne_zero]; simp)
+  rw [IsRoot.def] at hb
+  simp only [eval_add, eval_mul, eval_pow, eval_C, eval_X, one_mul] at hb
+  exact ⟨b, (W.toAffine.equation_iff a b).mpr (by linear_combination hb)⟩
+
+/-- **The division polynomials `Φₙ` and `ΨSqₙ` of a nonsingular curve are coprime**, so the
+`x`-coordinate `Φₙ / ΨSqₙ` of `n • (x, y)` is in lowest terms (Sutherland Lemma 6.8, Silverman
+Exercise III.3.7). Nonsingularity is necessary and no hypothesis on `n` is needed; see the module
+docstring for both. -/
+theorem isCoprime_Φ_ΨSq (hΔ : W.Δ ≠ 0) : IsCoprime (W.Φ n) (W.ΨSq n) := by
+  let f := algebraMap F (AlgebraicClosure F)
+  rw [← Polynomial.isCoprime_map f, ← map_Φ, ← map_ΨSq]
+  set W' := W.map f with hW'
+  rw [@Polynomial.isCoprime_iff_aeval_ne_zero_of_isAlgClosed _ _
+    (AlgebraicClosure F) _ _ (Algebra.id _)]
+  intro a
+  by_contra h
+  push Not at h
+  obtain ⟨hΦ, hΨ⟩ := h
+  simp only [Polynomial.coe_aeval_eq_eval] at hΦ hΨ
+  -- a common root of `Φₙ` and `ΨSqₙ` is the `x`-coordinate of a point of the curve
+  obtain ⟨b, hb⟩ := W'.exists_point_on_curve a
+  have hΔ' : W'.Δ ≠ 0 := by rw [hW', map_Δ]; exact (map_ne_zero_iff f f.injective).mpr hΔ
+  have hns : W'.toAffine.Nonsingular a b :=
+    (W'.toAffine.equation_iff_nonsingular_of_Δ_ne_zero hΔ').mp hb
+  -- at that point both the `Z` and the `X` Jacobian coordinate of `n • (a, b)` vanish
+  have hψ : (W'.ψ n).evalEval a b = 0 := by
+    refine (pow_eq_zero_iff two_ne_zero).mp ?_
+    rw [evalEval_ψ_eq_evalEval_Ψ W' hb n, evalEval_Ψ_sq_eq_eval_ΨSq W' hb n]
+    exact hΨ
+  have hφ : (W'.φ n).evalEval a b = 0 := by rwa [evalEval_φ_eq_eval_Φ W' hb n]
+  have hZ : smulEval W' a b n 2 = 0 := by simp [smulEval, hψ]
+  have hX : smulEval W' a b n 0 = 0 := by simp [smulEval, hφ]
+  -- but `n • (a, b)` is a nonsingular Jacobian point, and those never have `X = Z = 0`
+  have hns_smul : Jacobian.Nonsingular W' (smulEval W' a b n) := by
+    rw [← Jacobian.nonsingularLift_iff, ← zsmul_point_eq_smulEval W' hns n]
+    exact (n • Jacobian.Point.fromAffine (Affine.Point.some _ _ hns)).nonsingular
+  exact Jacobian.X_ne_zero_of_Z_eq_zero hns_smul hZ hX
+
+/-- **`ΨSqₙ` is nonzero on a nonsingular curve, in every characteristic.** Mathlib's
+`ΨSq_ne_zero` assumes `(n : F) ≠ 0` instead; see the module docstring on why neither statement
+subsumes the other. -/
+theorem ΨSq_ne_zero_of_Δ_ne_zero (hΔ : W.Δ ≠ 0) (hn : n ≠ 0) : W.ΨSq n ≠ 0 := fun h ↦
+  (W.natDegree_Φ_pos hn).ne'
+    (natDegree_eq_zero_of_isUnit (isCoprime_zero_right.mp (h ▸ W.isCoprime_Φ_ΨSq hΔ)))
+
+end WeierstrassCurve


### PR DESCRIPTION
Over a field, the `x`-coordinate of `n • (x, y)` is `Φₙ / ΨSqₙ`. This adds the fact that the
numerator and denominator are coprime once the curve is nonsingular, so that fraction is already
in lowest terms — which is what lets the degree of `[n]` be read off the two degrees separately.

Roadmap: EllipticCurves

> Reopened from #4826, which GitHub closed automatically when its head branch was renamed
> to the `elliptic/` prefix. Same commit (`5bd7cada3`), same content; #4826 carried no review
> verdicts, so nothing is lost. A fork PR cannot be renamed in place — GitHub only retargets
> same-repo PRs.


## What this advances

`TauCetiRoadmap/EllipticCurves/README.md:99` — "**`[n]` is division polynomials**": for `n ≠ 0`,
multiplication-by-`n` is an isogeny of degree `n²`, "pinned by the division-polynomial
multiplication formula, already proved at the point level in the Lutz–Nagell provenance". Reading
`deg [n] = n²` off `Φₙ / ΨSqₙ` needs the fraction to be in lowest terms; that is this PR.

## Contents

Three declarations across **two** new files.

`DivisionPolynomial/Coprimality.lean`:

- `isCoprime_Φ_ΨSq` — `IsCoprime (W.Φ n) (W.ΨSq n)` for `W.Δ ≠ 0`. Sutherland Lemma 6.8,
  Silverman *AEC* Exercise III.3.7.
- `ΨSq_ne_zero_of_Δ_ne_zero` — `W.ΨSq n ≠ 0` for `n ≠ 0`, in **every** characteristic.

`Affine/IsAlgClosed.lean`:

- `Affine.exists_point_on_curve` — over an algebraically closed field every element is the
  `x`-coordinate of a solution of `W.Equation` (solve a quadratic for `y`).

**Why two files.** `exists_point_on_curve` is about `Affine.Equation` alone: no nonsingularity, no
ellipticity, no division polynomial. Review round 2 asked for it to move, and it is right — it is
broadly useful affine-curve material that a division-polynomial file should import, not own. No
existing `Affine/` module fits by subject (`FinitePoint` is finiteness over a finite ring, `Eval`
is the coordinate ring, `Point/Basic` eliminates `Point` constructors, `Point/Place` is Dedekind
places), so it gets a small focused module, modelled on `Affine/FinitePoint.lean`.

It sits directly under `Affine/` rather than `Affine/Point/` because it produces a solution of the
*equation*, not an element of `Affine.Point`; a caller wanting a point pairs it with
`equation_iff_nonsingular_of_Δ_ne_zero`, which is exactly what `isCoprime_Φ_ΨSq` does. The call
site is applied rather than dot notation, because `Affine` is a reducible abbreviation for
`WeierstrassCurve`: dot notation on `toAffine` searches `WeierstrassCurve.*` and never reaches
`TauCeti.WeierstrassCurve.Affine.*`. `Coprimality.lean` already applies the `Eval` lemmas
positionally for the same reason.

## This is a port

Ported with the authors' proofs from AINTLIB (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), the
HasseWeil project at `dev/hasse-weil @ 513e83879e2f` — the revision
`TauCetiRoadmap/EllipticCurves/README.md:1071` pins for that project. Source file
`projects/HasseWeil/HasseWeil/Auxiliary/DivisionPolynomial.lean`, section `Coprimality`,
declarations `exists_point_on_curve` and `isCoprime_Φ_ΨSq`, whose header credits
David Kurniadi Angdinata and Junyan Xu.

Note the source path is ambiguous on its own: a *restructured* `projects/HasseWeil` also exists at
the NagellLutz entry's `dev/modular-curves` pin. The revision is what disambiguates, so the
provenance block names it.

## Three points a reviewer will want checked, with the measurement

**Nothing else needed porting.** Every dependency of the source proof already exists. Three of its
calls are spelled differently here, because the corresponding lemmas exist under other names:
`evalEval_ψ_sq` → `evalEval_Ψ_sq_eq_eval_ΨSq` (composed with `evalEval_ψ_eq_evalEval_Ψ`, since
Mathlib states the square for `Ψ` not `ψ`), `evalEval_φ_eq_Φ` → `evalEval_φ_eq_eval_Φ` (both
`Eval.lean`), and `zsmul_eq_smulEval` → `zsmul_point_eq_smulEval` (`ZSMul.lean`, which records the
rename in its own provenance block). The source's `evalEval_eq_of_mk_eq` is **not** ported —
`Eval.lean` already has it. `exists_point_on_curve` was confirmed absent by concept rather than by
name: `IsAlgClosed` occurs nowhere in Mathlib's `EllipticCurve/` directory.

**The source's unused `n ≠ 0` is dropped from `isCoprime_Φ_ΨSq`.** Upstream states
`(hΔ) (_hn : n ≠ 0)` with `_hn` unused, so the same proof establishes the statement without it —
and the statement is true at `n = 0`, where it reads `IsCoprime 1 0` (`Φ_zero` makes the left
argument a unit). The two corollaries do need `n ≠ 0` and take it explicitly.

**`ΨSq_ne_zero_of_Δ_ne_zero` is not a duplicate of Mathlib's `ΨSq_ne_zero`, and is named for the
hypothesis that distinguishes them.** Mathlib's (`Degree.lean:374`) concludes the same thing from
`(n : F) ≠ 0`, which fails exactly when the characteristic divides `n`; this one replaces that with
`W.Δ ≠ 0`. Neither subsumes the other — Mathlib's holds on singular curves, this one in every
characteristic. It therefore cannot be called `ΨSq_ne_zero` (collision in the root namespace), and
`_of_ne_zero` would name a hypothesis both statements share; `_of_Δ_ne_zero` names the one that
actually discriminates.

## Necessity of the hypothesis

`W.Δ ≠ 0` is not an artefact of the proof. On the cusp `Y² = X³`, `Cusp.lean`'s `cusp_Ψ₂Sq` gives
`Ψ₂Sq = 4X³` while `Φ₂ = X⁴`, sharing the factor `X³`. The hypothesis is stated as `W.Δ ≠ 0`
rather than `[W.IsElliptic]` because that is all the proof consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
