### PR TITLE
feat: make prime-discriminant factorization unique

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Basic.lean
@@ -73,16 +73,13 @@ theorem genusPrimeDiscriminants_spec {d : ℤ} (hd : Squarefree d) :
   simpa only [genusPrimeDiscriminants] using h.choose_spec
 
 /-- **Characterization of the chosen prime-discriminant factorization.** Every factorization of
-`fundamentalDiscriminant d` into distinct prime discriminants with at most one even member is the
-finset `genusPrimeDiscriminants hd`. -/
+`fundamentalDiscriminant d` into distinct prime discriminants is the finset
+`genusPrimeDiscriminants hd`. -/
 theorem genusPrimeDiscriminants_eq {d : ℤ} (hd : Squarefree d) {s : Finset ℤ}
     (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
-    (heven : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
-      IsEvenPrimeDiscriminant Q → P = Q)
     (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d) : genusPrimeDiscriminants hd = s := by
-  obtain ⟨hgenus, hgenusEven, hgenusProd⟩ := genusPrimeDiscriminants_spec hd
-  exact finset_primeDiscriminant_eq_of_prod_eq hgenus hgenusEven hs heven
-    (hgenusProd.trans hprod.symm)
+  obtain ⟨hgenus, _, hgenusProd⟩ := genusPrimeDiscriminants_spec hd
+  exact finset_primeDiscriminant_eq_of_prod_eq hgenus hs (hgenusProd.trans hprod.symm)
 
 /-- A chosen complex square root of the radicand of each prime discriminant in
 `genusPrimeDiscriminants hd` (available since `ℂ` is algebraically closed). -/

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Basic.lean
@@ -26,9 +26,9 @@ arbitrary finite set of prime discriminants with chosen roots; here we fix a cho
 factorization finset `genusPrimeDiscriminants` from
 `IsFundamentalDiscriminant.exists_finset_primeDiscriminant`, and chosen complex roots
 `genusFieldRoot` of the radicands (using that `ℂ` is algebraically closed) — and package the
-compositum as `candidateGenusField`. (Both choices are made with `choose`; independence of the
-resulting field from them is not claimed here.) As a first property we record that it contains a
-square root of `d`, so it really is a candidate genus field *of `ℚ(√d)`*.
+compositum as `candidateGenusField`. The factorization is uniquely characterized by
+`genusPrimeDiscriminants_eq`; only the roots retain a choice. As a first property we record that it
+contains a square root of `d`, so it really is a candidate genus field *of `ℚ(√d)`*.
 
 The prime-discriminant description is classical; see D. A. Cox, *Primes of the Form x² + ny²*, and
 F. Lemmermeyer, *Reciprocity Laws*.
@@ -42,6 +42,8 @@ F. Lemmermeyer, *Reciprocity Laws*.
 
 ## Main results
 
+* `TauCeti.Multiquadratic.genusPrimeDiscriminants_eq`: the chosen factor finset is equal to every
+  prime-discriminant factorization satisfying the defining conditions.
 * `TauCeti.Multiquadratic.candidateGenusField_le_iff`: its universal property — it is below an
   intermediate field iff that field contains every chosen root.
 * `TauCeti.Multiquadratic.exists_mem_candidateGenusField_sq_eq`: it contains an element squaring
@@ -69,6 +71,18 @@ theorem genusPrimeDiscriminants_spec {d : ℤ} (hd : Squarefree d) :
       ∏ P ∈ genusPrimeDiscriminants hd, P = fundamentalDiscriminant d := by
   have h := (isFundamentalDiscriminant_fundamentalDiscriminant hd).exists_finset_primeDiscriminant
   simpa only [genusPrimeDiscriminants] using h.choose_spec
+
+/-- **Characterization of the chosen prime-discriminant factorization.** Every factorization of
+`fundamentalDiscriminant d` into distinct prime discriminants with at most one even member is the
+finset `genusPrimeDiscriminants hd`. -/
+theorem genusPrimeDiscriminants_eq {d : ℤ} (hd : Squarefree d) {s : Finset ℤ}
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
+      IsEvenPrimeDiscriminant Q → P = Q)
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d) : genusPrimeDiscriminants hd = s := by
+  obtain ⟨hgenus, hgenusEven, hgenusProd⟩ := genusPrimeDiscriminants_spec hd
+  exact finset_primeDiscriminant_eq_of_prod_eq hgenus hgenusEven hs heven
+    (hgenusProd.trans hprod.symm)
 
 /-- A chosen complex square root of the radicand of each prime discriminant in
 `genusPrimeDiscriminants hd` (available since `ℂ` is algebraically closed). -/

--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Factorization.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Factorization.lean
@@ -17,6 +17,14 @@ one even value is a fundamental discriminant. This file supplies the **analysis*
 converse existence statement: every fundamental discriminant `D` is a product of a finite set of
 prime discriminants, at most one of which is even.
 
+The factorization is unique once its factors are required to be distinct and to contain at most
+one even prime discriminant.  Its proof first matches the odd factors through the unique rational
+prime below each prime discriminant.  After cancelling their common product, the remaining
+products contain at most one factor each, so the even factors match as well.
+
+This is the classical prime-discriminant factorization; see D. A. Cox, *Primes of the Form
+x² + ny²*, §3.B and §6.A, and F. Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2.
+
 This is a prerequisite for the genus-field layer, which attaches a *family* of prime discriminants
 to a quadratic field `ℚ(√d)`: the square-class independence and degree theorems of
 `Multiquadratic/Prime/Discriminant/Independence.lean` apply to such a family, giving a
@@ -36,6 +44,10 @@ discriminant — odd, `4 ·` odd, `8 ·` odd — then differ only in the single 
 * `TauCeti.Multiquadratic.IsFundamentalDiscriminant.exists_finset_primeDiscriminant`: every
   fundamental discriminant is a product of a finite set of prime discriminants with at most one
   even value — the converse of `isFundamentalDiscriminant_prod`.
+* `TauCeti.Multiquadratic.finset_primeDiscriminant_eq_of_prod_eq`: two such factorizations with
+  the same product have the same factors.
+* `TauCeti.Multiquadratic.IsFundamentalDiscriminant.existsUnique_finset_primeDiscriminant`: every
+  fundamental discriminant has a unique such factorization.
 -/
 
 public section
@@ -159,5 +171,122 @@ theorem IsFundamentalDiscriminant.exists_finset_primeDiscriminant {D : ℤ}
       exact absurd hPe (himg P hP).2
     · rw [hprodimg]
       exact prod_oddPrimeDiscriminant_primeFactors_eq hsf hodd h1
+
+/-- An odd prime-discriminant factor of one product occurs in any equal prime-discriminant
+product.  The rational prime below an odd prime discriminant determines it uniquely. -/
+private theorem mem_of_not_isEvenPrimeDiscriminant_of_prod_eq {s t : Finset ℤ}
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P) (ht : ∀ P ∈ t, IsPrimeDiscriminant P)
+    (hprod : ∏ P ∈ s, P = ∏ P ∈ t, P) {P : ℤ} (hPs : P ∈ s)
+    (hPodd : ¬ IsEvenPrimeDiscriminant P) : P ∈ t := by
+  let p := primeDiscriminantPrime P
+  have hp : p.Prime := prime_primeDiscriminantPrime (hs P hPs)
+  have hp_prod : (p : ℤ) ∣ ∏ Q ∈ t, Q := by
+    rw [← hprod]
+    exact (primeDiscriminantPrime_dvd (hs P hPs)).trans (Finset.dvd_prod_of_mem id hPs)
+  obtain ⟨Q, hQt, hpQ⟩ : ∃ Q ∈ t, (p : ℤ) ∣ Q :=
+    ((Nat.prime_iff_prime_int.mp hp).dvd_finsetProd_iff id).mp hp_prod
+  have hp_eq : primeDiscriminantPrime P = primeDiscriminantPrime Q :=
+    (natCast_dvd_primeDiscriminant_iff (ht Q hQt) hp).mp hpQ
+  have hPQ : P = Q := eq_of_primeDiscriminantPrime_eq (hs P hPs) (ht Q hQt)
+    (fun hPeven _ => absurd hPeven hPodd) hp_eq
+  rwa [hPQ]
+
+open Classical in
+/-- If a finset contains at most one even prime discriminant and contains `P`, then its even
+filter is the singleton `P`. -/
+private theorem filter_isEvenPrimeDiscriminant_eq_singleton {s : Finset ℤ}
+    (hseven : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
+      IsEvenPrimeDiscriminant Q → P = Q) {P : ℤ} (hPs : P ∈ s)
+    (hPeven : IsEvenPrimeDiscriminant P) : s.filter IsEvenPrimeDiscriminant = {P} := by
+  classical
+  ext Q
+  simp only [Finset.mem_filter, Finset.mem_singleton]
+  exact ⟨fun hQ => hseven Q hQ.1 P hPs hQ.2 hPeven, fun hQP => hQP ▸ ⟨hPs, hPeven⟩⟩
+
+open Classical in
+/-- Equality of the products of two at-most-singleton even-factor sets transfers membership from
+one set to the other. -/
+private theorem mem_of_isEvenPrimeDiscriminant_of_even_prod_eq {s t : Finset ℤ}
+    (hseven : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
+      IsEvenPrimeDiscriminant Q → P = Q)
+    (hteven : ∀ P ∈ t, ∀ Q ∈ t, IsEvenPrimeDiscriminant P →
+      IsEvenPrimeDiscriminant Q → P = Q)
+    (hprod : (∏ P ∈ s with IsEvenPrimeDiscriminant P, P) =
+      ∏ P ∈ t with IsEvenPrimeDiscriminant P, P)
+    {P : ℤ} (hPs : P ∈ s) (hPeven : IsEvenPrimeDiscriminant P) : P ∈ t := by
+  classical
+  have hsfilter := filter_isEvenPrimeDiscriminant_eq_singleton hseven hPs hPeven
+  have hPprod : P = ∏ Q ∈ t with IsEvenPrimeDiscriminant Q, Q := by
+    simpa only [hsfilter, Finset.prod_singleton] using hprod
+  have htfilter_ne : t.filter IsEvenPrimeDiscriminant ≠ ∅ := by
+    intro htempty
+    rw [htempty] at hPprod
+    simp only [Finset.prod_empty] at hPprod
+    rcases hPeven with rfl | rfl | rfl <;> norm_num at hPprod
+  obtain ⟨Q, hQfilter⟩ := Finset.nonempty_iff_ne_empty.mpr htfilter_ne
+  have hQt := (Finset.mem_filter.mp hQfilter).1
+  have hQeven := (Finset.mem_filter.mp hQfilter).2
+  have htfilter := filter_isEvenPrimeDiscriminant_eq_singleton hteven hQt hQeven
+  have hPQ : P = Q := by simpa only [htfilter, Finset.prod_singleton] using hPprod
+  rwa [hPQ]
+
+/-- **Uniqueness of a prime-discriminant factorization.** Two finite sets of prime discriminants,
+each containing at most one even prime discriminant, are equal when their products are equal.
+
+Odd factors are determined by their unique underlying rational prime.  Once those common factors
+are cancelled from the product equality, each remaining even-factor set has at most one member,
+so its product determines that member too. -/
+theorem finset_primeDiscriminant_eq_of_prod_eq {s t : Finset ℤ}
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (hseven : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
+      IsEvenPrimeDiscriminant Q → P = Q)
+    (ht : ∀ P ∈ t, IsPrimeDiscriminant P)
+    (hteven : ∀ P ∈ t, ∀ Q ∈ t, IsEvenPrimeDiscriminant P →
+      IsEvenPrimeDiscriminant Q → P = Q)
+    (hprod : ∏ P ∈ s, P = ∏ P ∈ t, P) : s = t := by
+  classical
+  have hodd : s.filter (fun P => ¬ IsEvenPrimeDiscriminant P) =
+      t.filter (fun P => ¬ IsEvenPrimeDiscriminant P) := by
+    ext P
+    simp only [Finset.mem_filter]
+    constructor
+    · rintro ⟨hPs, hPodd⟩
+      exact ⟨mem_of_not_isEvenPrimeDiscriminant_of_prod_eq hs ht hprod hPs hPodd, hPodd⟩
+    · rintro ⟨hPt, hPodd⟩
+      exact ⟨mem_of_not_isEvenPrimeDiscriminant_of_prod_eq ht hs hprod.symm hPt hPodd, hPodd⟩
+  have hodd_ne : (∏ P ∈ s with ¬ IsEvenPrimeDiscriminant P, P) ≠ 0 := by
+    rw [Finset.prod_ne_zero_iff]
+    intro P hP
+    rcases isPrimeDiscriminant_iff.mp (hs P (Finset.mem_filter.mp hP).1) with
+      hPeven | ⟨p, hp, hPodd, rfl⟩
+    · exact absurd hPeven (Finset.mem_filter.mp hP).2
+    · exact oddPrimeDiscriminant_ne_zero.mpr hp.ne_zero
+  have heven_prod : (∏ P ∈ s with IsEvenPrimeDiscriminant P, P) =
+      ∏ P ∈ t with IsEvenPrimeDiscriminant P, P := by
+    apply mul_right_cancel₀ hodd_ne
+    rw [Finset.prod_filter_mul_prod_filter_not, hodd,
+      Finset.prod_filter_mul_prod_filter_not, hprod]
+  apply Finset.Subset.antisymm
+  · intro P hPs
+    by_cases hPeven : IsEvenPrimeDiscriminant P
+    · exact mem_of_isEvenPrimeDiscriminant_of_even_prod_eq hseven hteven heven_prod hPs hPeven
+    · exact mem_of_not_isEvenPrimeDiscriminant_of_prod_eq hs ht hprod hPs hPeven
+  · intro P hPt
+    by_cases hPeven : IsEvenPrimeDiscriminant P
+    · exact mem_of_isEvenPrimeDiscriminant_of_even_prod_eq hteven hseven heven_prod.symm hPt hPeven
+    · exact mem_of_not_isEvenPrimeDiscriminant_of_prod_eq ht hs hprod.symm hPt hPeven
+
+/-- **Unique prime-discriminant factorization of a fundamental discriminant.** Every fundamental
+discriminant is the product of a unique finite set of prime discriminants containing at most one
+even member. -/
+theorem IsFundamentalDiscriminant.existsUnique_finset_primeDiscriminant {D : ℤ}
+    (hD : IsFundamentalDiscriminant D) :
+    ∃! s : Finset ℤ, (∀ P ∈ s, IsPrimeDiscriminant P) ∧
+      (∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
+        IsEvenPrimeDiscriminant Q → P = Q) ∧
+      ∏ P ∈ s, P = D := by
+  obtain ⟨s, hs, hseven, hprod⟩ := hD.exists_finset_primeDiscriminant
+  refine ⟨s, ⟨hs, hseven, hprod⟩, fun t ht => ?_⟩
+  exact finset_primeDiscriminant_eq_of_prod_eq ht.1 ht.2.1 hs hseven (ht.2.2.trans hprod.symm)
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Factorization.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Factorization.lean
@@ -17,10 +17,10 @@ one even value is a fundamental discriminant. This file supplies the **analysis*
 converse existence statement: every fundamental discriminant `D` is a product of a finite set of
 prime discriminants, at most one of which is even.
 
-The factorization is unique once its factors are required to be distinct and to contain at most
-one even prime discriminant.  Its proof first matches the odd factors through the unique rational
-prime below each prime discriminant.  After cancelling their common product, the remaining
-products contain at most one factor each, so the even factors match as well.
+The factorization is unique once its factors are required to be distinct. Its proof first matches
+the odd factors through the unique rational prime below each prime discriminant. After cancelling
+their common product, the remaining factors belong to the three-element set `{-4, 8, -8}`; its
+eight subsets have pairwise distinct products, so the even factors match as well.
 
 This is the classical prime-discriminant factorization; see D. A. Cox, *Primes of the Form
 x² + ny²*, §3.B and §6.A, and F. Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2.
@@ -44,10 +44,10 @@ discriminant — odd, `4 ·` odd, `8 ·` odd — then differ only in the single 
 * `TauCeti.Multiquadratic.IsFundamentalDiscriminant.exists_finset_primeDiscriminant`: every
   fundamental discriminant is a product of a finite set of prime discriminants with at most one
   even value — the converse of `isFundamentalDiscriminant_prod`.
-* `TauCeti.Multiquadratic.finset_primeDiscriminant_eq_of_prod_eq`: two such factorizations with
-  the same product have the same factors.
+* `TauCeti.Multiquadratic.finset_primeDiscriminant_eq_of_prod_eq`: two finite sets of prime
+  discriminants with the same product have the same factors.
 * `TauCeti.Multiquadratic.IsFundamentalDiscriminant.existsUnique_finset_primeDiscriminant`: every
-  fundamental discriminant has a unique such factorization.
+  fundamental discriminant has a unique factorization into a finite set of prime discriminants.
 -/
 
 public section
@@ -192,57 +192,33 @@ private theorem mem_of_not_isEvenPrimeDiscriminant_of_prod_eq {s t : Finset ℤ}
   rwa [hPQ]
 
 open Classical in
-/-- If a finset contains at most one even prime discriminant and contains `P`, then its even
-filter is the singleton `P`. -/
-private theorem filter_isEvenPrimeDiscriminant_eq_singleton {s : Finset ℤ}
-    (hseven : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
-      IsEvenPrimeDiscriminant Q → P = Q) {P : ℤ} (hPs : P ∈ s)
-    (hPeven : IsEvenPrimeDiscriminant P) : s.filter IsEvenPrimeDiscriminant = {P} := by
+/-- A finset of even prime discriminants is determined by its product. -/
+private theorem finset_isEvenPrimeDiscriminant_eq_of_prod_eq {s t : Finset ℤ}
+    (hs : ∀ P ∈ s, IsEvenPrimeDiscriminant P)
+    (ht : ∀ P ∈ t, IsEvenPrimeDiscriminant P)
+    (hprod : ∏ P ∈ s, P = ∏ P ∈ t, P) : s = t := by
   classical
-  ext Q
-  simp only [Finset.mem_filter, Finset.mem_singleton]
-  exact ⟨fun hQ => hseven Q hQ.1 P hPs hQ.2 hPeven, fun hQP => hQP ▸ ⟨hPs, hPeven⟩⟩
+  have hs_mem : s ∈ ({-4, 8, -8} : Finset ℤ).powerset := by
+    rw [Finset.mem_powerset]
+    intro P hP
+    simpa only [Finset.mem_insert, Finset.mem_singleton, IsEvenPrimeDiscriminant] using hs P hP
+  have ht_mem : t ∈ ({-4, 8, -8} : Finset ℤ).powerset := by
+    rw [Finset.mem_powerset]
+    intro P hP
+    simpa only [Finset.mem_insert, Finset.mem_singleton, IsEvenPrimeDiscriminant] using ht P hP
+  fin_cases hs_mem <;> fin_cases ht_mem
+  all_goals norm_num at hprod
+  all_goals rfl
 
-open Classical in
-/-- Equality of the products of two at-most-singleton even-factor sets transfers membership from
-one set to the other. -/
-private theorem mem_of_isEvenPrimeDiscriminant_of_even_prod_eq {s t : Finset ℤ}
-    (hseven : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
-      IsEvenPrimeDiscriminant Q → P = Q)
-    (hteven : ∀ P ∈ t, ∀ Q ∈ t, IsEvenPrimeDiscriminant P →
-      IsEvenPrimeDiscriminant Q → P = Q)
-    (hprod : (∏ P ∈ s with IsEvenPrimeDiscriminant P, P) =
-      ∏ P ∈ t with IsEvenPrimeDiscriminant P, P)
-    {P : ℤ} (hPs : P ∈ s) (hPeven : IsEvenPrimeDiscriminant P) : P ∈ t := by
-  classical
-  have hsfilter := filter_isEvenPrimeDiscriminant_eq_singleton hseven hPs hPeven
-  have hPprod : P = ∏ Q ∈ t with IsEvenPrimeDiscriminant Q, Q := by
-    simpa only [hsfilter, Finset.prod_singleton] using hprod
-  have htfilter_ne : t.filter IsEvenPrimeDiscriminant ≠ ∅ := by
-    intro htempty
-    rw [htempty] at hPprod
-    simp only [Finset.prod_empty] at hPprod
-    rcases hPeven with rfl | rfl | rfl <;> norm_num at hPprod
-  obtain ⟨Q, hQfilter⟩ := Finset.nonempty_iff_ne_empty.mpr htfilter_ne
-  have hQt := (Finset.mem_filter.mp hQfilter).1
-  have hQeven := (Finset.mem_filter.mp hQfilter).2
-  have htfilter := filter_isEvenPrimeDiscriminant_eq_singleton hteven hQt hQeven
-  have hPQ : P = Q := by simpa only [htfilter, Finset.prod_singleton] using hPprod
-  rwa [hPQ]
+/-- **Uniqueness of a prime-discriminant factorization.** Two finite sets of prime discriminants
+are equal when their products are equal.
 
-/-- **Uniqueness of a prime-discriminant factorization.** Two finite sets of prime discriminants,
-each containing at most one even prime discriminant, are equal when their products are equal.
-
-Odd factors are determined by their unique underlying rational prime.  Once those common factors
-are cancelled from the product equality, each remaining even-factor set has at most one member,
-so its product determines that member too. -/
+Odd factors are determined by their unique underlying rational prime. Once those common factors
+are cancelled from the product equality, each remaining factor belongs to `{-4, 8, -8}`; the
+products of the eight possible subsets are distinct, so the even factors match too. -/
 theorem finset_primeDiscriminant_eq_of_prod_eq {s t : Finset ℤ}
     (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
-    (hseven : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
-      IsEvenPrimeDiscriminant Q → P = Q)
     (ht : ∀ P ∈ t, IsPrimeDiscriminant P)
-    (hteven : ∀ P ∈ t, ∀ Q ∈ t, IsEvenPrimeDiscriminant P →
-      IsEvenPrimeDiscriminant Q → P = Q)
     (hprod : ∏ P ∈ s, P = ∏ P ∈ t, P) : s = t := by
   classical
   have hodd : s.filter (fun P => ¬ IsEvenPrimeDiscriminant P) =
@@ -266,27 +242,24 @@ theorem finset_primeDiscriminant_eq_of_prod_eq {s t : Finset ℤ}
     apply mul_right_cancel₀ hodd_ne
     rw [Finset.prod_filter_mul_prod_filter_not, hodd,
       Finset.prod_filter_mul_prod_filter_not, hprod]
-  apply Finset.Subset.antisymm
-  · intro P hPs
-    by_cases hPeven : IsEvenPrimeDiscriminant P
-    · exact mem_of_isEvenPrimeDiscriminant_of_even_prod_eq hseven hteven heven_prod hPs hPeven
-    · exact mem_of_not_isEvenPrimeDiscriminant_of_prod_eq hs ht hprod hPs hPeven
-  · intro P hPt
-    by_cases hPeven : IsEvenPrimeDiscriminant P
-    · exact mem_of_isEvenPrimeDiscriminant_of_even_prod_eq hteven hseven heven_prod.symm hPt hPeven
-    · exact mem_of_not_isEvenPrimeDiscriminant_of_prod_eq ht hs hprod.symm hPt hPeven
+  have heven : s.filter IsEvenPrimeDiscriminant = t.filter IsEvenPrimeDiscriminant :=
+    finset_isEvenPrimeDiscriminant_eq_of_prod_eq
+      (fun P hP => (Finset.mem_filter.mp hP).2)
+      (fun P hP => (Finset.mem_filter.mp hP).2) heven_prod
+  ext P
+  by_cases hPeven : IsEvenPrimeDiscriminant P
+  · simpa only [Finset.ext_iff, Finset.mem_filter, hPeven, and_true] using
+      Finset.ext_iff.mp heven P
+  · simpa only [Finset.ext_iff, Finset.mem_filter, hPeven, not_false_eq_true, and_true] using
+      Finset.ext_iff.mp hodd P
 
 /-- **Unique prime-discriminant factorization of a fundamental discriminant.** Every fundamental
-discriminant is the product of a unique finite set of prime discriminants containing at most one
-even member. -/
+discriminant is the product of a unique finite set of prime discriminants. -/
 theorem IsFundamentalDiscriminant.existsUnique_finset_primeDiscriminant {D : ℤ}
     (hD : IsFundamentalDiscriminant D) :
-    ∃! s : Finset ℤ, (∀ P ∈ s, IsPrimeDiscriminant P) ∧
-      (∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P →
-        IsEvenPrimeDiscriminant Q → P = Q) ∧
-      ∏ P ∈ s, P = D := by
-  obtain ⟨s, hs, hseven, hprod⟩ := hD.exists_finset_primeDiscriminant
-  refine ⟨s, ⟨hs, hseven, hprod⟩, fun t ht => ?_⟩
-  exact finset_primeDiscriminant_eq_of_prod_eq ht.1 ht.2.1 hs hseven (ht.2.2.trans hprod.symm)
+    ∃! s : Finset ℤ, (∀ P ∈ s, IsPrimeDiscriminant P) ∧ ∏ P ∈ s, P = D := by
+  obtain ⟨s, hs, _, hprod⟩ := hD.exists_finset_primeDiscriminant
+  refine ⟨s, ⟨hs, hprod⟩, fun t ht => ?_⟩
+  exact finset_primeDiscriminant_eq_of_prod_eq ht.1 hs (ht.2.trans hprod.symm)
 
 end TauCeti.Multiquadratic


### PR DESCRIPTION
This PR makes the prime-discriminant factorization of a fundamental discriminant unique, and characterizes the chosen factor finset `genusPrimeDiscriminants hd` by that uniqueness. It advances `TauCetiRoadmap/Multiquadratic/README.md`, Layer 3 milestone “the genus field and the 2-rank theorem,” specifically the current maximality step: turn the discriminant constraints on quadratic subfields of an unramified abelian extension into membership in the prime-discriminant compositum `candidateGenusField hd`.

This is the most effective current step because `dvd_fundamentalDiscriminant_base_of_dvd_subfield` and `not_dvd_fundamentalDiscriminant_mul_of_dvd_subfield` already constrain the discriminants of those subfields, while `candidateGenusField` was still built from a merely chosen factorization. Ordinary rational-prime support cannot identify the factor over `2`, since `-4`, `8`, and `-8` all lie above the same prime. `finset_primeDiscriminant_eq_of_prod_eq` resolves that ambiguity: it matches odd factors through `primeDiscriminantPrime`, cancels their common nonzero product, and then identifies the at-most-singleton even factors. `IsFundamentalDiscriminant.existsUnique_finset_primeDiscriminant` packages existence and uniqueness, and `genusPrimeDiscriminants_eq` turns every valid factorization into the exact chosen finset used by the candidate genus field.

After this PR, the maximality milestone still needs to combine this uniqueness with the two ramification constraints to prove each squarefree Kummer generator lies in `candidateGenusField hd`, then conclude the whole competing unramified abelian extension is contained in it and define the intrinsic genus field; the Artin-reciprocity identification and the real/narrow case remain later Layer 3 work. The open genus-character PR addresses the independent lower-bound lane for the real narrow 2-rank formula and does not overlap this factorization step.

The proof reuses Tau Ceti’s `primeDiscriminantPrime` API and Mathlib’s prime-divides-finset-product theorem. No Mathlib source or external formalization is vendored. The mathematics is the classical unique factorization of fundamental discriminants into prime discriminants, following the conventions in D. A. Cox, *Primes of the Form x² + ny²*, §3.B and §6.A, and F. Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2, as cited in the modules.

Files changed: `TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Factorization.lean` (+129) and `TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Basic.lean` (+17/−3).

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"exists-unique-finset-prime-discriminant"}-->

🤖 Prepared with Codex
