### PR TITLE
refactor(NumberField): state the algebraMap-Galois bridge once

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.NumberTheory.LegendreSymbol.Basic
 public import TauCeti.NumberTheory.Multiquadratic.Galois.Basic
 public import TauCeti.NumberTheory.NumberField.SplitsCompletely
-public import TauCeti.NumberTheory.NumberField.AutomorphismAction
+import TauCeti.NumberTheory.NumberField.AutomorphismAction
 import TauCeti.RingTheory.Ideal.LiesOver
 import TauCeti.NumberTheory.NumberField.IntegralSqrt
 

--- a/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.NumberTheory.LegendreSymbol.Basic
 public import TauCeti.NumberTheory.Multiquadratic.Galois.Basic
 public import TauCeti.NumberTheory.NumberField.SplitsCompletely
+public import TauCeti.NumberTheory.NumberField.AutomorphismAction
 import TauCeti.RingTheory.Ideal.LiesOver
 import TauCeti.NumberTheory.NumberField.IntegralSqrt
 
@@ -125,18 +126,13 @@ private theorem map_ne_neg_of_legendreSym_eq_one (d : ℤ) (r : K) (hr : r ^ 2 =
   have hfacQ : (R - A) * (R + A) ∈ Q := by
     rw [heq]
     exact (TauCeti.algebraMap_int_mem_iff_dvd_of_liesOver Q _).mpr (dvd_sub_comm.mp hpa)
-  -- `algebraMap` intertwines the Galois action on `𝓞 K` with the one on `K`.
-  have hbridge (x : 𝓞 K) : algebraMap (𝓞 K) K (σ • x) = σ (algebraMap (𝓞 K) K x) := by
-    have hcoe : algebraMap (𝓞 K) K (σ • x) = σ • algebraMap (𝓞 K) K x :=
-      integralClosure.coe_smul σ x
-    rw [hcoe, AlgEquiv.smul_def]
   -- `σ` sends `R ↦ -R` and fixes the integer `A`.
   have hsR : σ • R = - R := by
     apply FaithfulSMul.algebraMap_injective (𝓞 K) K
-    rw [hbridge R, map_neg, algebraMap_integralSqrt, hflip]
+    rw [algebraMap_smul_eq_apply σ R, map_neg, algebraMap_integralSqrt, hflip]
   have hsA : σ • A = A := by
     apply FaithfulSMul.algebraMap_injective (𝓞 K) K
-    rw [hbridge A, hAdef, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K,
+    rw [algebraMap_smul_eq_apply σ A, hAdef, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K,
       IsScalarTower.algebraMap_apply ℤ ℚ K, AlgEquiv.commutes]
   -- Applying `σ` to whichever factor lies in `Q` and adding the two gives `2 A ∈ Q`.
   have hmapQ : ∀ x ∈ Q, σ • x ∈ Q := fun x hx => by

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Ramification.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Ramification.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Compositum
 public import TauCeti.NumberTheory.NumberField.RamifiedPrimes
+public import TauCeti.NumberTheory.NumberField.AutomorphismAction
 import TauCeti.NumberTheory.NumberField.Quadratic.TotalRamification
 import TauCeti.NumberTheory.RamificationInertia.Tower
 import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Independence
@@ -107,12 +108,6 @@ private theorem eq_primeDiscriminantPrime_of_apply_eq_neg {M : Type v} [Field M]
     (hσ : ∀ z : 𝓞 M, σ • z - z ∈ P) (hneg : σ x = -x) :
     p = primeDiscriminantPrime D := by
   have : Fact p.Prime := ⟨hp⟩
-  have hbridge (z : 𝓞 M) : algebraMap (𝓞 M) M (σ • z) = σ (algebraMap (𝓞 M) M z) := by
-    have hcoe : algebraMap (𝓞 M) M (σ • z) = σ • algebraMap (𝓞 M) M z := by
-      rw [← NumberField.RingOfIntegers.coe_eq_algebraMap,
-        ← NumberField.RingOfIntegers.coe_eq_algebraMap]
-      exact integralClosure.coe_smul σ z
-    rw [hcoe, AlgEquiv.smul_def]
   by_cases hp2 : p = 2
   · subst p
     by_contra hne
@@ -125,7 +120,7 @@ private theorem eq_primeDiscriminantPrime_of_apply_eq_neg {M : Type v} [Field M]
     -- `W` is given by its value, so its image in `M` is that value definitionally.
     have hWval : algebraMap (𝓞 M) M W = (1 + x) / 2 := rfl
     have hWcoe : algebraMap (𝓞 M) M (σ • W - W) = -x := by
-      rw [map_sub, hbridge, hWval, map_div₀, map_add, map_one, hneg, map_ofNat]
+      rw [map_sub, algebraMap_smul_eq_apply, hWval, map_div₀, map_add, map_one, hneg, map_ofNat]
       ring
     have hWsq : (σ • W - W) ^ 2 = algebraMap ℤ (𝓞 M) (primeDiscriminantRadicand D) := by
       apply FaithfulSMul.algebraMap_injective (𝓞 M) M
@@ -138,7 +133,7 @@ private theorem eq_primeDiscriminantPrime_of_apply_eq_neg {M : Type v} [Field M]
   · let R : 𝓞 M := NumberField.integralSqrt hx
     have hR : σ • R = -R := by
       apply FaithfulSMul.algebraMap_injective (𝓞 M) M
-      rw [hbridge, map_neg]
+      rw [algebraMap_smul_eq_apply, map_neg]
       simpa only [R, NumberField.algebraMap_integralSqrt] using hneg
     have htwoR : (2 : 𝓞 M) * R ∈ P := by
       have hsub := hσ R

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Ramification.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Ramification.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Compositum
 public import TauCeti.NumberTheory.NumberField.RamifiedPrimes
-public import TauCeti.NumberTheory.NumberField.AutomorphismAction
+import TauCeti.NumberTheory.NumberField.AutomorphismAction
 import TauCeti.NumberTheory.NumberField.Quadratic.TotalRamification
 import TauCeti.NumberTheory.RamificationInertia.Tower
 import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Independence

--- a/TauCeti/NumberTheory/NumberField/AutomorphismAction.lean
+++ b/TauCeti/NumberTheory/NumberField/AutomorphismAction.lean
@@ -14,15 +14,15 @@ A ring automorphism of a field restricts to its ring of integers, because it pre
 integrality. This file records how that restricted action relates to the ambient one: the
 structure map `𝓞 K → K` is equivariant, carrying `σ • z` to `σ` applied to the image of `z`.
 
-The automorphism is taken over an arbitrary base ring `R`, matching the generality of
-`integralClosure.coe_smul`; the number-field case is `R = ℚ`. Nothing here needs `K` to be
-finite-dimensional, so `[NumberField K]` is deliberately not assumed.
+`𝓞 K` is the integral closure of `ℤ`, and any ring automorphism of `K` preserves `ℤ`-integrality,
+so the base ring `R` over which `σ` is linear is irrelevant to both statement and proof; it is a
+free parameter, specialized to `ℚ` by the callers. Nothing here needs `K` to be finite-dimensional
+either, so `[NumberField K]` is not assumed.
 
-Mathlib proves the corresponding statement for a general integral closure
-(`integralClosure.coe_smul`), stated with the coercion and with the action written as a scalar
-multiplication on both sides. Callers working with a number field invariably want the
-`algebraMap` spelling on the left and function application on the right, so that conversion is
-made once here rather than at each use site.
+This is the `AlgEquiv` specialization of Mathlib's `integralClosure.coe_smul`, which is stated
+for an arbitrary `[Group G] [MulSemiringAction G K]` and therefore cannot phrase the right-hand
+side as function application. Callers want exactly that applied form, so the specialization is
+recorded once here rather than reconstructed at each use site.
 
 ## Main results
 
@@ -35,7 +35,7 @@ open scoped NumberField
 
 namespace NumberField
 
-variable {R K : Type*} [CommRing R] [Field K] [Algebra R K]
+variable {R K : Type*} [CommSemiring R] [Field K] [Algebra R K]
 
 /-- **`algebraMap` intertwines the automorphism actions on `𝓞 K` and on `K`.** The action on the
 ring of integers is the restriction of the action on `K` (`integralClosure.coe_smul`), so the
@@ -43,11 +43,7 @@ structure map sends `σ • z` to `σ` applied to the image of `z`.
 
 Not named `algebraMap_smul`: that is Mathlib's unrelated `algebraMap R A r • m = r • m`. -/
 @[simp] theorem algebraMap_smul_eq_apply (σ : K ≃ₐ[R] K) (z : 𝓞 K) :
-    algebraMap (𝓞 K) K (σ • z) = σ (algebraMap (𝓞 K) K z) := by
-  have hcoe : algebraMap (𝓞 K) K (σ • z) = σ • algebraMap (𝓞 K) K z := by
-    rw [← NumberField.RingOfIntegers.coe_eq_algebraMap,
-      ← NumberField.RingOfIntegers.coe_eq_algebraMap]
-    exact integralClosure.coe_smul σ z
-  rw [hcoe, AlgEquiv.smul_def]
+    algebraMap (𝓞 K) K (σ • z) = σ (algebraMap (𝓞 K) K z) :=
+  integralClosure.coe_smul σ z
 
 end NumberField

--- a/TauCeti/NumberTheory/NumberField/AutomorphismAction.lean
+++ b/TauCeti/NumberTheory/NumberField/AutomorphismAction.lean
@@ -10,9 +10,13 @@ public import Mathlib.NumberTheory.NumberField.Basic
 /-!
 # Automorphisms acting on the ring of integers
 
-An automorphism of a number field restricts to the ring of integers, because it preserves
+A ring automorphism of a field restricts to its ring of integers, because it preserves
 integrality. This file records how that restricted action relates to the ambient one: the
 structure map `𝓞 K → K` is equivariant, carrying `σ • z` to `σ` applied to the image of `z`.
+
+The automorphism is taken over an arbitrary base ring `R`, matching the generality of
+`integralClosure.coe_smul`; the number-field case is `R = ℚ`. Nothing here needs `K` to be
+finite-dimensional, so `[NumberField K]` is deliberately not assumed.
 
 Mathlib proves the corresponding statement for a general integral closure
 (`integralClosure.coe_smul`), stated with the coercion and with the action written as a scalar
@@ -31,14 +35,14 @@ open scoped NumberField
 
 namespace NumberField
 
-variable {K : Type*} [Field K] [NumberField K]
+variable {R K : Type*} [CommRing R] [Field K] [Algebra R K]
 
-/-- **`algebraMap` intertwines the Galois actions on `𝓞 K` and on `K`.** The action on the ring
-of integers is the restriction of the action on `K` (`integralClosure.coe_smul`), so the structure
-map sends `σ • z` to `σ` applied to the image of `z`.
+/-- **`algebraMap` intertwines the automorphism actions on `𝓞 K` and on `K`.** The action on the
+ring of integers is the restriction of the action on `K` (`integralClosure.coe_smul`), so the
+structure map sends `σ • z` to `σ` applied to the image of `z`.
 
 Not named `algebraMap_smul`: that is Mathlib's unrelated `algebraMap R A r • m = r • m`. -/
-@[simp] theorem algebraMap_smul_eq_apply (σ : K ≃ₐ[ℚ] K) (z : 𝓞 K) :
+@[simp] theorem algebraMap_smul_eq_apply (σ : K ≃ₐ[R] K) (z : 𝓞 K) :
     algebraMap (𝓞 K) K (σ • z) = σ (algebraMap (𝓞 K) K z) := by
   have hcoe : algebraMap (𝓞 K) K (σ • z) = σ • algebraMap (𝓞 K) K z := by
     rw [← NumberField.RingOfIntegers.coe_eq_algebraMap,

--- a/TauCeti/NumberTheory/NumberField/AutomorphismAction.lean
+++ b/TauCeti/NumberTheory/NumberField/AutomorphismAction.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.NumberField.Basic
+
+/-!
+# Automorphisms acting on the ring of integers
+
+An automorphism of a number field restricts to the ring of integers, because it preserves
+integrality. This file records how that restricted action relates to the ambient one: the
+structure map `𝓞 K → K` is equivariant, carrying `σ • z` to `σ` applied to the image of `z`.
+
+Mathlib proves the corresponding statement for a general integral closure
+(`integralClosure.coe_smul`), stated with the coercion and with the action written as a scalar
+multiplication on both sides. Callers working with a number field invariably want the
+`algebraMap` spelling on the left and function application on the right, so that conversion is
+made once here rather than at each use site.
+
+## Main results
+
+* `NumberField.algebraMap_smul_eq_apply`: `algebraMap (𝓞 K) K (σ • z) = σ (algebraMap (𝓞 K) K z)`.
+-/
+
+public section
+
+open scoped NumberField
+
+namespace NumberField
+
+variable {K : Type*} [Field K] [NumberField K]
+
+/-- **`algebraMap` intertwines the Galois actions on `𝓞 K` and on `K`.** The action on the ring
+of integers is the restriction of the action on `K` (`integralClosure.coe_smul`), so the structure
+map sends `σ • z` to `σ` applied to the image of `z`.
+
+Not named `algebraMap_smul`: that is Mathlib's unrelated `algebraMap R A r • m = r • m`. -/
+@[simp] theorem algebraMap_smul_eq_apply (σ : K ≃ₐ[ℚ] K) (z : 𝓞 K) :
+    algebraMap (𝓞 K) K (σ • z) = σ (algebraMap (𝓞 K) K z) := by
+  have hcoe : algebraMap (𝓞 K) K (σ • z) = σ • algebraMap (𝓞 K) K z := by
+    rw [← NumberField.RingOfIntegers.coe_eq_algebraMap,
+      ← NumberField.RingOfIntegers.coe_eq_algebraMap]
+    exact integralClosure.coe_smul σ z
+  rw [hcoe, AlgEquiv.smul_def]
+
+end NumberField

--- a/TauCeti/NumberTheory/NumberField/AutomorphismAction.lean
+++ b/TauCeti/NumberTheory/NumberField/AutomorphismAction.lean
@@ -44,6 +44,8 @@ structure map sends `σ • z` to `σ` applied to the image of `z`.
 Not named `algebraMap_smul`: that is Mathlib's unrelated `algebraMap R A r • m = r • m`. -/
 @[simp] theorem algebraMap_smul_eq_apply (σ : K ≃ₐ[R] K) (z : 𝓞 K) :
     algebraMap (𝓞 K) K (σ • z) = σ (algebraMap (𝓞 K) K z) :=
+  -- `integralClosure.coe_smul` proves this up to two definitional identifications:
+  -- `RingOfIntegers.val` is an `abbrev` for `algebraMap`, and `AlgEquiv.smul_def` is `rfl`.
   integralClosure.coe_smul σ z
 
 end NumberField

--- a/TauCeti/NumberTheory/NumberField/Frobenius.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius.lean
@@ -10,7 +10,6 @@ public import TauCeti.NumberTheory.LegendreSymbol.Frobenius
 public import TauCeti.NumberTheory.NumberField.IntegralSqrt
 import TauCeti.NumberTheory.NumberField.AutomorphismAction
 import Mathlib.Algebra.CharP.Basic
-import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
 
 /-!
 # Frobenius elements of a Galois number field and their action on square roots

--- a/TauCeti/NumberTheory/NumberField/Frobenius.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.NumberTheory.NumberField.Ideal.Basic
 public import TauCeti.NumberTheory.LegendreSymbol.Frobenius
 public import TauCeti.NumberTheory.NumberField.IntegralSqrt
+public import TauCeti.NumberTheory.NumberField.AutomorphismAction
 import Mathlib.Algebra.CharP.Basic
 import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
 
@@ -87,14 +88,7 @@ theorem isArithFrobAt_apply_sqrt (hodd : p ≠ 2) {d : ℤ} (hd : ¬ (p : ℤ) �
   have hsmul : σ • integralSqrt hx = legendreSym p d • integralSqrt hx :=
     TauCeti.IsArithFrobAt.smul_sqrt hσ hodd hd (integralSqrt_sq hx)
   have hcoe := congrArg (algebraMap (𝓞 K) K) hsmul
-  -- `algebraMap` intertwines the Galois actions on `𝓞 K` and `K` (`integralClosure.coe_smul`).
-  have hbridge : algebraMap (𝓞 K) K (σ • integralSqrt hx) =
-      σ (algebraMap (𝓞 K) K (integralSqrt hx)) := by
-    have hc : algebraMap (𝓞 K) K (σ • integralSqrt hx) =
-        σ • algebraMap (𝓞 K) K (integralSqrt hx) :=
-      integralClosure.coe_smul σ (integralSqrt hx)
-    rw [hc, AlgEquiv.smul_def]
-  rw [map_zsmul, algebraMap_integralSqrt, hbridge] at hcoe
+  rw [map_zsmul, algebraMap_integralSqrt, algebraMap_smul_eq_apply] at hcoe
   rwa [algebraMap_integralSqrt] at hcoe
 
 /-- **A Frobenius fixes `√d` iff `d` is a quadratic residue mod `p`.** Under the hypotheses of

--- a/TauCeti/NumberTheory/NumberField/Frobenius.lean
+++ b/TauCeti/NumberTheory/NumberField/Frobenius.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.NumberTheory.NumberField.Ideal.Basic
 public import TauCeti.NumberTheory.LegendreSymbol.Frobenius
 public import TauCeti.NumberTheory.NumberField.IntegralSqrt
-public import TauCeti.NumberTheory.NumberField.AutomorphismAction
+import TauCeti.NumberTheory.NumberField.AutomorphismAction
 import Mathlib.Algebra.CharP.Basic
 import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
 
@@ -29,7 +29,7 @@ services on top of Mathlib's `RingTheory/Frobenius.lean`:
 * **the square-root action** — for `p` odd and `x ∈ K` with `x² = d ∈ ℤ`, `p ∤ d`, a
   Frobenius at any ideal `Q` over `p` satisfies `σ x = legendreSym p d • x`, transporting the
   `𝓞 K`-level computation `TauCeti.AlgHom.IsArithFrobAt.apply_sqrt` along the Galois action
-  on the ring of integers (via `integralClosure.coe_smul`), with the `σ x = x`
+  on the ring of integers (via `NumberField.algebraMap_smul_eq_apply`), with the `σ x = x`
   characterization read off from it.
 
 `TauCeti.NumberTheory.Multiquadratic.Frobenius` combines the two to describe the Frobenius of


### PR DESCRIPTION
Three files each opened with the same proof-local `have hbridge`, proving that the structure map
`𝓞 K → K` carries a Galois automorphism across. State it once.

## The duplication

| file | lines | form |
|---|---|---|
| `Multiquadratic/MultiquadraticSplitting.lean` | 129–132 | `∀ x : 𝓞 K` |
| `Multiquadratic/Prime/Discriminant/Ramification.lean` | 110–115 | `∀ z : 𝓞 M`, via `RingOfIntegers.coe_eq_algebraMap` |
| `NumberField/Frobenius.lean` | 91–96 | specialised to `integralSqrt hx` |

Each proves `algebraMap (𝓞 K) K (σ • z) = σ (algebraMap (𝓞 K) K z)` by `integralClosure.coe_smul`
followed by `AlgEquiv.smul_def`; two of them carry the same explanatory comment. All three are
replaced by `NumberField.algebraMap_smul_eq_apply`, used at five call sites.

## Why a lemma and not `integralClosure.coe_smul` directly

`integralClosure.coe_smul` is stated for an arbitrary `[Group G] [MulSemiringAction G K]`, so it
cannot phrase the right-hand side as *function application* — only as `σ • x`. Every caller here
wants the applied form, and each of the three sites had written that conversion out for itself.
Using `integralClosure.coe_smul` directly at the call sites is what produced the three copies.

The proof is now the single term `integralClosure.coe_smul σ z`: `RingOfIntegers.val` is an
`abbrev` for `algebraMap` and `AlgEquiv.smul_def` is `rfl`, so this lemma *is* that lemma in the
spelling the callers need. That is the point of it — it buys the spelling, not the mathematics.

## Why a new module

`AutomorphismAction.lean` rather than an existing file, because nothing about this statement
concerns the subjects of the candidate hosts. `IntegralSqrt.lean` is the only TauCeti module all
three consumers already import — I checked, by intersecting their import closures, and the
intersection is just `NumberField.IntegralSqrt` and `RingTheory.Ideal.LiesOver` — but that is
dependency accident, not subject: `IntegralSqrt` packages a square root as an algebraic integer,
and this lemma has no square root in it. A reader looking for how automorphisms interact with
`𝓞 K` would not search there.

The cost is one import line in each of the three consumers — a plain `import`, not `public`,
since the lemma appears only inside tactic proofs and no public signature mentions it. The module
imports only `Mathlib.NumberTheory.NumberField.Basic`.

## `@[simp]`

Marked `@[simp]`: the orientation removes an operation from under `algebraMap`, and the
right-hand side `σ (algebraMap _ z)` cannot rematch the left, so it cannot loop. The neighbouring
transfer lemmas `algebraMap_integralSqrt` and `integralSqrt_sq` are `@[simp]` for the same reason.

## Naming

`algebraMap_smul_eq_apply` names the left-hand side and then the applied form it produces.
Deliberately **not** `algebraMap_smul`: Mathlib already uses that for the unrelated
`algebraMap R A r • m = r • m` (`Algebra/Basic.lean`, `Algebra/Tower.lean`).

## Hypotheses

`{R K} [CommSemiring R] [Field K] [Algebra R K]` with `σ : K ≃ₐ[R] K`. `𝓞 K` is the integral
closure of `ℤ` and any ring automorphism of `K` preserves `ℤ`-integrality, so `R` — the base over
which `σ` is linear — is irrelevant to statement and proof; callers specialize it to `ℚ`.
`[NumberField K]` is not assumed: its `FiniteDimensional ℚ K` half is used by neither the
statement nor the proof. All five call sites are unchanged.

## Notes for review

- Gate: `lake build` of the new module and all three consumers — **3580 jobs, exit 0, zero
  warnings**, including the `@[simp]` attribute and the generalized signature.

Roadmap: Multiquadratic
