### PR TITLE
refactor(ModularForms): name the finite-dimensionality of cusp forms

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Petersson/Orthogonal.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Orthogonal.lean
@@ -180,8 +180,6 @@ private theorem peterssonOrthogonal_eq_orthogonal
 theorem peterssonOrthogonal_peterssonOrthogonal
     (V : Submodule ℂ (CuspForm (Γ.map (mapGL ℝ)) k)) :
     peterssonOrthogonal (peterssonOrthogonal V) = V := by
-  let _ : Module.Finite ℂ (CuspForm (Γ.map (mapGL ℝ)) k) :=
-    Module.Finite.of_injective CuspForm.toModularFormₗ CuspForm.toModularFormₗ_injective
   rw [peterssonOrthogonal_eq_orthogonal, peterssonOrthogonal_eq_orthogonal,
     Submodule.orthogonal_orthogonal]
 
@@ -189,8 +187,6 @@ theorem peterssonOrthogonal_peterssonOrthogonal
 theorem sup_peterssonOrthogonal_eq_top
     (V : Submodule ℂ (CuspForm (Γ.map (mapGL ℝ)) k)) :
     V ⊔ peterssonOrthogonal V = ⊤ := by
-  let _ : Module.Finite ℂ (CuspForm (Γ.map (mapGL ℝ)) k) :=
-    Module.Finite.of_injective CuspForm.toModularFormₗ CuspForm.toModularFormₗ_injective
   rw [peterssonOrthogonal_eq_orthogonal]
   exact Submodule.sup_orthogonal_of_hasOrthogonalProjection
 

--- a/TauCeti/NumberTheory/ModularForms/SturmBound.lean
+++ b/TauCeti/NumberTheory/ModularForms/SturmBound.lean
@@ -135,6 +135,20 @@ instance finiteDimensional_modularForm_finiteIndex
 
 end ModularForm
 
+/-- **Finite-dimensionality of cusp forms.** A cusp form is a modular form, injectively, so this
+is `TauCeti.ModularForm.finiteDimensional_modularForm_finiteIndex` transported along
+`CuspForm.toModularFormₗ`, under exactly the same hypotheses.
+
+It is stated here rather than at its use sites because cusp-form finite-dimensionality is a
+standing hypothesis of the old/new theory, not a fact local to any one argument: before this,
+the two proofs in `TauCeti/NumberTheory/ModularForms/Petersson/Orthogonal.lean` that need it
+each built it inline. -/
+instance finiteDimensional_cuspForm_finiteIndex
+    {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.HasDetOne] [𝒢.IsFiniteRelIndex 𝒮ℒ]
+    [DiscreteTopology 𝒢.strictPeriods] {k : ℤ} :
+    Module.Finite ℂ (CuspForm 𝒢 k) :=
+  Module.Finite.of_injective CuspForm.toModularFormₗ CuspForm.toModularFormₗ_injective
+
 end TauCeti
 
 end


### PR DESCRIPTION
`TauCeti/NumberTheory/ModularForms/Petersson/Orthogonal.lean` built the same three-line
`Module.Finite ℂ (CuspForm …)` term inline in two proofs —
`peterssonOrthogonal_peterssonOrthogonal` and `sup_peterssonOrthogonal_eq_top` — as a
`let _ : … := Module.Finite.of_injective CuspForm.toModularFormₗ CuspForm.toModularFormₗ_injective`.
This names it once and deletes both copies.

## No new mathematics, and no new imports

Every ingredient is already available and none is re-derived:

* `CuspForm.toModularFormₗ` and `CuspForm.toModularFormₗ_injective` — **Mathlib**,
  `Mathlib/NumberTheory/ModularForms/CuspFormSubmodule.lean`;
* `ModularForm.finiteDimensional_modularForm_finiteIndex` — already on `main`,
  `SturmBound.lean`, the corresponding statement for modular forms.

The new instance is the one-line transport of the second along the first. The fact was
already reachable at both sites; it was simply being rebuilt at each use.

## Three design calls, stated rather than left implicit

**Where.** In `SturmBound.lean`, immediately after the `ModularForm` instance it is a
corollary of — not at file scope in `Orthogonal.lean`. Cusp-form finite-dimensionality is a
standing hypothesis of the old/new theory, not a fact local to the orthogonal-complement
argument, and a downstream consumer should not have to import the Petersson development to
reach it. I checked this costs nothing in imports: `CuspForm.toModularFormₗ` is already in
scope in `SturmBound.lean`, so the module's import list is unchanged.

**What.** An `instance`, matching its neighbour `finiteDimensional_modularForm_finiteIndex`,
which is also a global instance. This is what lets both former sites simply drop their
`let _ :` blocks rather than pass a named term.

**How general.** At the neighbour's generality — `{𝒢 : Subgroup (GL (Fin 2) ℝ)}` with
`[𝒢.HasDetOne]`, `[𝒢.IsFiniteRelIndex 𝒮ℒ]`, `[DiscreteTopology 𝒢.strictPeriods]` — rather
than restricted to the `Γ.map (mapGL ℝ)` of the two call sites. Those hypotheses are exactly
the ones the modular-form instance already needs, so the general form costs nothing and is
what makes the instance usable elsewhere.

Named `finiteDimensional_cuspForm_finiteIndex` after the neighbour's stem.

## Gate

`lake build` of both changed modules and their direct importers — `SturmBound`,
`Petersson/Orthogonal`, `Petersson/Unitary`, `Newforms/Basic` — 3481/3481 jobs, no errors,
warnings or sorries. That exercises instance search at both former sites and across every
module that consumes them.

## Scope

Improvement to code already on `main`, which
[`.claude/CLAUDE.md`](https://github.com/TauCetiProject/TauCeti/blob/main/.claude/CLAUDE.md)
puts in scope without a roadmap entry. No statement changes and no declaration is renamed or
removed.

Roadmap: ModularForms
