### PR TITLE
docs: cite the Stoll commit that exists

### DIFF
--- a/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
@@ -44,7 +44,7 @@ already carried by `HasEval`. Taking `I` to be `IsLocalRing.maximalIdeal S` and 
 ## Provenance
 
 Adapted from Michael Stoll's `EllipticCurves` (`github.com/MichaelStollBayreuth/EllipticCurves`,
-Apache-2.0) at commit `66889eada51ac1eb2a1c98b3c1ba5b0bbe64a8d0`, file
+Apache-2.0) at commit `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, file
 `EllipticCurves/WeierstrassFormalGroup/Eval.lean`, where these are
 `ChabautyColeman.MvPSeries.eval_mem_maximalIdeal_pow`, `..._pow_mul` and `..._pow_add_mul`. That
 development evaluates through its own `ChabautyColeman.MvPSeries.eval`, which is by definition

--- a/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean
@@ -32,7 +32,7 @@ series evaluated at arguments of `I ^ n` is confined to `I ^ n`, in
 ## Provenance
 
 Adapted from Michael Stoll's `EllipticCurves` (`github.com/MichaelStollBayreuth/EllipticCurves`,
-Apache-2.0) at commit `66889eada51ac1eb2a1c98b3c1ba5b0bbe64a8d0`, file
+Apache-2.0) at commit `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, file
 `EllipticCurves/Mathlib/Chabauty/AdicTopology.lean`, where these appear as `IsAdic.isOpen_pow`
 and `IsAdic.isClosed_pow` among that development's Mathlib-bound material.
 -/


### PR DESCRIPTION
Two provenance docstrings cite Michael Stoll's `EllipticCurves` at a commit sha that **does not
exist**. This replaces it with the real one. Docstrings only; no code, no declaration, no import
changes.

Roadmap: EllipticCurves

Beads: `tc-71duh` (this rung), `tc-dgk0p`.

## The defect

Both shas begin `66889eada51a`, which is the abbreviation the roadmap pins
(`TauCetiRoadmap/EllipticCurves/README.md`). One of the two 40-character expansions is fabricated:

| sha | upstream `GET /commits/{sha}` |
|---|---|
| `66889eada51ac1eb2a1c98b3c1ba5b0bbe64a8d0` | **HTTP 422 — "No commit found for SHA"** |
| `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e` | resolves (2026-07-22, *"Reflow two comparator/README.md lines to the 100-column limit"*) |

Resolving the abbreviation directly, `GET /commits/66889eada51a`, returns
`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e` — so the second is the commit the roadmap pin denotes
and the first is a bad expansion of it.

## Sites

The bad sha occurs in exactly two files on `main`, once each:

- `TauCeti/RingTheory/MvPowerSeries/Evaluation.lean:47`
- `TauCeti/Topology/Algebra/Nonarchimedean/AdicTopology.lean:35`

The correct sha is already cited in three other places, which is what makes the two odd ones out
visible: `RingTheory/Polynomial/DegreeLT.lean:38`,
`RingTheory/Polynomial/Resultant/AdjoinRoot.lean:58`,
`RingTheory/Polynomial/Resultant/Basic.lean:29`.

## Why the rest of both citations is already right

The two blocks were written against the *correct* tree — only the abbreviation was mis-expanded —
so the fix is the sha alone. Verified at `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, each with a
control that fails:

- `EllipticCurves/WeierstrassFormalGroup/Eval.lean` and
  `EllipticCurves/Mathlib/Chabauty/AdicTopology.lean` both exist at that commit
  (`EllipticCurves/NoSuchFile.lean` → 404).
- The cited declarations are present in those files: `eval_mem_maximalIdeal_pow` (4 hits) in the
  first, `isOpen_pow`/`isClosed_pow` (3 hits) in the second (a nonsense name → 0 hits).

A sha that resolves but a path that does not would leave the citation just as broken, so both were
checked rather than only the commit.

## Diff shape

Two files, two lines, one token each. Both shas are 40 characters, so no line length changes and
no reflow is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
