### PR TITLE
docs(FormalGroup): do not call F(0,0) = 0 the first formal-group-law axiom

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/AddSeries.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/AddSeries.lean
@@ -28,7 +28,8 @@ That series is `formalAdd`, and it is the series underlying the elliptic formal 
 ## Main results
 
 * `WeierstrassCurve.constantCoeff_formalAdd`: `F(0, 0) = 0`, so `F` may itself be substituted
-  into a power series. This is the first of the formal-group-law axioms.
+  into a power series, which every later statement about the group law needs. Mathlib's
+  `FormalGroup` carries this as its `zero_constantCoeff` field.
 * `WeierstrassCurve.rename_swap_formalAdd`: `F(z₂, z₁) = F(z₁, z₂)`. The chord does not depend
   on the order of its two points, so the group law is commutative.
 


### PR DESCRIPTION
`FormalGroup/AddSeries.lean` described `constantCoeff_formalAdd` as "the first of the
formal-group-law axioms". Which axiomatisation was meant was left unsaid, and the two available
readings disagree:

* Mathlib's `FormalGroup` carries `F(0,0) = 0` as its `zero_constantCoeff` **field**, so under
  that presentation it is an axiom — though not obviously the *first*, since the structure's
  first field is the series itself.
* In the classical presentation it is a **consequence**: `F(0,0) = 0` follows from the unit laws
  `F(X,0) = X` and `F(0,Y) = Y`.

The file builds no `FormalGroup` instance and proves no unit law, so it was in no position to
assert either reading. It now says what the lemma is actually for — `F` may itself be
substituted into a power series, which every later statement about the group law needs — and
points at where Mathlib records the same fact, without ranking it among anyone's axioms.

Documentation only: no statement, proof, or import changes.

Roadmap: EllipticCurves
