### PR TITLE
feat: define the hypergeometric measure

### DIFF
--- a/TauCeti/Probability/Distributions/Hypergeometric.lean
+++ b/TauCeti/Probability/Distributions/Hypergeometric.lean
@@ -1,0 +1,215 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.Nat.Choose.Vandermonde
+public import Mathlib.MeasureTheory.Integral.Bochner.SumMeasure
+
+/-!
+# The hypergeometric distribution
+
+The hypergeometric law describes the number of marked objects in a sample of size `n`, drawn
+without replacement from a population of size `N` containing `K` marked objects.  For
+`K ≤ N` and `n ≤ N`, its mass at `k` is
+
+```text
+  choose K k * choose (N - K) (n - k) / choose N n.
+```
+
+This file defines the law as a finite weighted sum of Dirac measures, proves its normalization
+from Vandermonde's identity, and provides the mass, support, and finite-integral API needed for
+the later moment, transform, and limit calculations.  Outside the classical parameter range the
+measure is zero, as required by the standard-distributions roadmap.
+
+## Main definitions and results
+
+* `TauCeti.Probability.hypergeometricWeight`: the `ℝ≥0∞`-valued mass function.
+* `TauCeti.Probability.hypergeometricMeasure`: the totalized hypergeometric measure on `ℕ`.
+* `TauCeti.Probability.measurable_hypergeometricMeasure`: measurability in all three parameters.
+* `TauCeti.Probability.isProbabilityMeasure_hypergeometricMeasure`: normalization in the valid
+  parameter range.
+* `TauCeti.Probability.hypergeometricMeasure_singleton`: the exact singleton mass.
+* `TauCeti.Probability.hypergeometricWeight_ne_zero_iff`: the exact support.
+* `TauCeti.Probability.integral_hypergeometricMeasure`: integration as a finite weighted sum.
+
+## References
+
+* N. L. Johnson, A. W. Kemp, S. Kotz, *Univariate Discrete Distributions*, 3rd ed., Wiley,
+  2005, Chapter 6.
+* `TauCetiRoadmap/StandardDistributions/README.md`, Layer 3, "Hypergeometric".
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+/-- The mass assigned to `k` by the hypergeometric parameters `(N, K, n)`.
+
+The explicit `k ≤ n` branch is necessary because natural subtraction is totalized: without it,
+the displayed quotient would generally not vanish when `n < k`. -/
+def hypergeometricWeight (N K n k : ℕ) : ℝ≥0∞ :=
+  if k ≤ n then
+    (K.choose k : ℝ≥0∞) * ((N - K).choose (n - k) : ℝ≥0∞) / (N.choose n : ℝ≥0∞)
+  else 0
+
+/-- The hypergeometric measure with population size `N`, marked count `K`, and sample size `n`.
+
+It is the classical probability measure when `K ≤ N` and `n ≤ N`, and is the zero measure
+otherwise. -/
+def hypergeometricMeasure (N K n : ℕ) : Measure ℕ :=
+  if K ≤ N ∧ n ≤ N then
+    ∑ k ∈ Finset.range (n + 1), hypergeometricWeight N K n k • Measure.dirac k
+  else 0
+
+/-- The hypergeometric law depends measurably on its three natural-valued parameters. -/
+theorem measurable_hypergeometricMeasure :
+    Measurable fun p : ℕ × ℕ × ℕ ↦ hypergeometricMeasure p.1 p.2.1 p.2.2 :=
+  Measurable.of_discrete
+
+/-- Outside the valid parameter range, the hypergeometric measure is zero. -/
+@[simp]
+theorem hypergeometricMeasure_of_invalid {N K n : ℕ} (h : ¬ (K ≤ N ∧ n ≤ N)) :
+    hypergeometricMeasure N K n = 0 := by
+  simp [hypergeometricMeasure, h]
+
+/-- In the valid parameter range, the hypergeometric measure is its defining finite sum. -/
+theorem hypergeometricMeasure_eq_sum_dirac {N K n : ℕ} (hK : K ≤ N) (hn : n ≤ N) :
+    hypergeometricMeasure N K n =
+      ∑ k ∈ Finset.range (n + 1), hypergeometricWeight N K n k • Measure.dirac k := by
+  simp [hypergeometricMeasure, hK, hn]
+
+private theorem sum_choose_mul_choose {N K n : ℕ} (hK : K ≤ N) :
+    ∑ k ∈ Finset.range (n + 1), K.choose k * (N - K).choose (n - k) = N.choose n := by
+  calc
+    _ = ∑ ij ∈ Finset.HasAntidiagonal.antidiagonal n,
+        K.choose ij.1 * (N - K).choose ij.2 := by
+      symm
+      simpa using Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk
+        (fun ij ↦ K.choose ij.1 * (N - K).choose ij.2) n
+    _ = (K + (N - K)).choose n := (Nat.add_choose_eq K (N - K) n).symm
+    _ = N.choose n := by rw [Nat.add_sub_of_le hK]
+
+/-- The hypergeometric weights sum to one in the valid parameter range. -/
+theorem sum_hypergeometricWeight (hK : K ≤ N) (hn : n ≤ N) :
+    ∑ k ∈ Finset.range (n + 1), hypergeometricWeight N K n k = 1 := by
+  calc
+    _ = ∑ k ∈ Finset.range (n + 1),
+        (K.choose k : ℝ≥0∞) * ((N - K).choose (n - k) : ℝ≥0∞) /
+          (N.choose n : ℝ≥0∞) := by
+      apply Finset.sum_congr rfl
+      intro k hk
+      simp [hypergeometricWeight, Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)]
+    _ = (∑ k ∈ Finset.range (n + 1),
+        (K.choose k : ℝ≥0∞) * ((N - K).choose (n - k) : ℝ≥0∞)) /
+          (N.choose n : ℝ≥0∞) := by
+      simp only [div_eq_mul_inv, Finset.sum_mul]
+    _ = 1 := by
+      have hsum :
+          ∑ k ∈ Finset.range (n + 1),
+              (K.choose k : ℝ≥0∞) * ((N - K).choose (n - k) : ℝ≥0∞) =
+            (N.choose n : ℝ≥0∞) := by
+        exact_mod_cast sum_choose_mul_choose (N := N) (K := K) (n := n) hK
+      rw [hsum]
+      apply ENNReal.div_self
+      · exact_mod_cast Nat.choose_ne_zero hn
+      · exact ne_of_lt (ENNReal.natCast_lt_top _)
+
+/-- The hypergeometric law is a probability measure in the classical parameter range. -/
+theorem isProbabilityMeasure_hypergeometricMeasure (hK : K ≤ N) (hn : n ≤ N) :
+    IsProbabilityMeasure (hypergeometricMeasure N K n) := by
+  rw [isProbabilityMeasure_iff, hypergeometricMeasure_eq_sum_dirac hK hn]
+  simpa [Measure.finsetSum_apply] using sum_hypergeometricWeight hK hn
+
+/-- The singleton mass of a valid hypergeometric law is its defining weight. -/
+@[simp]
+theorem hypergeometricMeasure_singleton (hK : K ≤ N) (hn : n ≤ N) (k : ℕ) :
+    hypergeometricMeasure N K n {k} = hypergeometricWeight N K n k := by
+  rw [hypergeometricMeasure_eq_sum_dirac hK hn, Measure.finsetSum_apply]
+  by_cases hk : k ≤ n
+  · rw [Finset.sum_eq_single k]
+    · simp
+    · simp_all
+    · simp_all
+  · rw [Finset.sum_eq_zero]
+    · simp [hypergeometricWeight, hk]
+    · intro j hj
+      have hjk : j ≠ k := ne_of_lt
+        (lt_of_le_of_lt (Finset.mem_range_succ_iff.mp hj) (lt_of_not_ge hk))
+      simp [hjk]
+
+/-- The real singleton mass of a valid hypergeometric law. -/
+theorem hypergeometricMeasure_real_singleton (hK : K ≤ N) (hn : n ≤ N) (k : ℕ) :
+    (hypergeometricMeasure N K n).real {k} =
+      if k ≤ n then
+        (K.choose k : ℝ) * ((N - K).choose (n - k) : ℝ) / (N.choose n : ℝ)
+      else 0 := by
+  rw [measureReal_def, hypergeometricMeasure_singleton hK hn, hypergeometricWeight]
+  split_ifs with hk
+  · rw [ENNReal.toReal_div, ENNReal.toReal_mul]
+    norm_cast
+  · simp
+
+/-- A hypergeometric weight is nonzero exactly on its classical support. -/
+theorem hypergeometricWeight_ne_zero_iff (N K n k : ℕ) :
+    hypergeometricWeight N K n k ≠ 0 ↔
+      k ≤ K ∧ k ≤ n ∧ n - k ≤ N - K := by
+  rw [hypergeometricWeight]
+  by_cases hkn : k ≤ n
+  · simp [hkn, Nat.choose_ne_zero_iff]
+  · simp [hkn]
+
+/-- The singleton mass of a valid hypergeometric law is nonzero exactly on its classical
+support. -/
+theorem hypergeometricMeasure_singleton_ne_zero_iff (hK : K ≤ N) (hn : n ≤ N) (k : ℕ) :
+    hypergeometricMeasure N K n {k} ≠ 0 ↔
+      k ≤ K ∧ k ≤ n ∧ n - k ≤ N - K := by
+  rw [hypergeometricMeasure_singleton hK hn, hypergeometricWeight_ne_zero_iff]
+
+/-- Every hypergeometric weight is finite when the sample size does not exceed the population
+size. -/
+theorem hypergeometricWeight_ne_top (N K n k : ℕ) (hn : n ≤ N) :
+    hypergeometricWeight N K n k ≠ ∞ := by
+  rw [hypergeometricWeight]
+  split_ifs
+  · apply ENNReal.div_ne_top
+    · exact ENNReal.mul_ne_top (ne_of_lt (ENNReal.natCast_lt_top _))
+        (ne_of_lt (ENNReal.natCast_lt_top _))
+    · exact_mod_cast Nat.choose_ne_zero hn
+  · simp
+
+/-- Every function is integrable against a hypergeometric measure, since the measure has finite
+support. -/
+theorem integrable_hypergeometricMeasure {E : Type*} [NormedAddCommGroup E]
+    (f : ℕ → E) (N K n : ℕ) : Integrable f (hypergeometricMeasure N K n) := by
+  rw [hypergeometricMeasure]
+  split_ifs with h
+  · exact integrable_finsetSum_measure.mpr fun _ _ ↦
+      (integrable_dirac (by simp)).smul_measure
+        (hypergeometricWeight_ne_top N K n _ h.2)
+  · simp
+
+/-- Integration against a valid hypergeometric measure is the corresponding finite weighted
+sum. -/
+theorem integral_hypergeometricMeasure {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] (f : ℕ → E) (hK : K ≤ N) (hn : n ≤ N) :
+    ∫ k, f k ∂hypergeometricMeasure N K n =
+      ∑ k ∈ Finset.range (n + 1), (hypergeometricWeight N K n k).toReal • f k := by
+  rw [hypergeometricMeasure_eq_sum_dirac hK hn, integral_finsetSum_measure]
+  · simp
+  · exact fun _ _ ↦
+      (integrable_dirac (by simp)).smul_measure
+        (hypergeometricWeight_ne_top N K n _ hn)
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Distributions/Hypergeometric.lean
+++ b/TauCeti/Probability/Distributions/Hypergeometric.lean
@@ -62,6 +62,19 @@ def hypergeometricWeight (N K n k : ℕ) : ℝ≥0∞ :=
     (K.choose k : ℝ≥0∞) * ((N - K).choose (n - k) : ℝ≥0∞) / (N.choose n : ℝ≥0∞)
   else 0
 
+/-- The hypergeometric weight agrees with its defining ratio when `k ≤ n`. -/
+@[simp]
+theorem hypergeometricWeight_of_le {N K n k : ℕ} (hkn : k ≤ n) :
+    hypergeometricWeight N K n k =
+      (K.choose k : ℝ≥0∞) * ((N - K).choose (n - k) : ℝ≥0∞) / (N.choose n : ℝ≥0∞) := by
+  simp [hypergeometricWeight, hkn]
+
+/-- The hypergeometric weight vanishes when `n < k`. -/
+@[simp]
+theorem hypergeometricWeight_of_not_le {N K n k : ℕ} (hkn : ¬ k ≤ n) :
+    hypergeometricWeight N K n k = 0 := by
+  simp [hypergeometricWeight, hkn]
+
 /-- The hypergeometric measure with population size `N`, marked count `K`, and sample size `n`.
 
 It is the classical probability measure when `K ≤ N` and `n ≤ N`, and is the zero measure
@@ -78,7 +91,7 @@ theorem measurable_hypergeometricMeasure :
 
 /-- Outside the valid parameter range, the hypergeometric measure is zero. -/
 @[simp]
-theorem hypergeometricMeasure_of_invalid {N K n : ℕ} (h : ¬ (K ≤ N ∧ n ≤ N)) :
+theorem hypergeometricMeasure_eq_zero_of_invalid {N K n : ℕ} (h : ¬ (K ≤ N ∧ n ≤ N)) :
     hypergeometricMeasure N K n = 0 := by
   simp [hypergeometricMeasure, h]
 
@@ -160,6 +173,7 @@ theorem hypergeometricMeasure_real_singleton (hK : K ≤ N) (hn : n ≤ N) (k : 
   · simp
 
 /-- A hypergeometric weight is nonzero exactly on its classical support. -/
+@[simp]
 theorem hypergeometricWeight_ne_zero_iff (N K n k : ℕ) :
     hypergeometricWeight N K n k ≠ 0 ↔
       k ≤ K ∧ k ≤ n ∧ n - k ≤ N - K := by
@@ -170,6 +184,7 @@ theorem hypergeometricWeight_ne_zero_iff (N K n k : ℕ) :
 
 /-- The singleton mass of a valid hypergeometric law is nonzero exactly on its classical
 support. -/
+@[simp]
 theorem hypergeometricMeasure_singleton_ne_zero_iff (hK : K ≤ N) (hn : n ≤ N) (k : ℕ) :
     hypergeometricMeasure N K n {k} ≠ 0 ↔
       k ≤ K ∧ k ≤ n ∧ n - k ≤ N - K := by

--- a/TauCeti/Probability/Distributions/Hypergeometric.lean
+++ b/TauCeti/Probability/Distributions/Hypergeometric.lean
@@ -184,7 +184,6 @@ theorem hypergeometricWeight_ne_zero_iff (N K n k : ℕ) :
 
 /-- The singleton mass of a valid hypergeometric law is nonzero exactly on its classical
 support. -/
-@[simp]
 theorem hypergeometricMeasure_singleton_ne_zero_iff (hK : K ≤ N) (hn : n ≤ N) (k : ℕ) :
     hypergeometricMeasure N K n {k} ≠ 0 ↔
       k ≤ K ∧ k ≤ n ∧ n - k ≤ N - K := by


### PR DESCRIPTION
This PR defines the totalized hypergeometric measure on `ℕ`, proves its Vandermonde normalization in the classical parameter range, and exposes parameter measurability, exact singleton masses and support, and finite-sum integration. It advances the `StandardDistributions` Layer 3 target “Hypergeometric `hypergeometricMeasure (N K n : ℕ)`” by completing the measure, probability, mass, support, and shared measurability foundations needed by every later formula.

The assigned `IntegralLattices` roadmap’s next Layer 4 critical-path dependency—the orthogonal quotient of a finite bilinear module—is already in flight in #3805, so this PR takes this unclaimed critical-path distribution target rather than duplicate that work.

The normalization proof reuses Mathlib’s `Nat.add_choose_eq` Vandermonde identity and `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk`; the measure and integral formulas reuse Mathlib’s finite sums of weighted Dirac measures. No external formalization is vendored.

After this PR, the Layer 3 Hypergeometric milestone still needs the boundary moments, mean and variance, cumulative-mass and transform formulas, sampling symmetry, and binomial limit listed in the roadmap.

Roadmap: StandardDistributions

<!--tauceti-target:v1 {"focus":"StandardDistributions","id":"hypergeometric-measure"}-->

Verification: `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex
