### PR TITLE
feat: add type B spin weights

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
@@ -1,0 +1,232 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.B.Datum
+public import TauCeti.RepresentationTheory.Spin.Weight
+
+/-!
+# Type `B` spin weights in the simply connected character lattice
+
+The spinor module has weights `1 / 2 * (±e₀ ± ⋯ ± e_{n-1})` in the usual orthonormal
+coordinates.  The simply connected type `Bₙ` datum instead writes its character lattice in the
+fundamental-weight basis, so a weight is recorded by its pairings with the simple coroots
+
+```text
+eᵢ - eᵢ₊₁  (i + 1 < n),       2e_{n-1}  (i + 1 = n).
+```
+
+In those coordinates all spin weights are integral.  This file defines the resulting sign-vector
+family `TauCeti.DynkinType.typeBSpinWeight`, compares it coordinate by coordinate with
+`TauCeti.spinWeight`, and proves that the family spans the full character lattice `Fin n → ℤ`.
+The spanning result is the full-weight input needed to construct the simply connected type `B`
+Chevalley carrier from the spin representation: the adjoint representation supplies only the
+index-two root lattice.
+
+## Main declarations
+
+* `TauCeti.DynkinType.typeBSpinWeight`: a spin weight in fundamental-weight coordinates.
+* `TauCeti.DynkinType.algebraMap_typeBSpinWeight_apply`: comparison with the half-integer
+  orthonormal coordinates of `TauCeti.spinWeight`.
+* `TauCeti.DynkinType.span_range_typeBSpinWeight_eq_top`: the spin weights generate the full
+  simply connected character lattice.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate II.
+* W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), Section 20.1.
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, Section 13.2.
+
+This advances Layer 9, "The Chevalley--Demazure construction", of the ReductiveGroups roadmap:
+the explicit simply connected type `B` carrier requires an admissible spin lattice whose weights
+generate the full character lattice.
+-/
+
+public section
+
+namespace TauCeti.DynkinType
+
+open Set Submodule
+
+/-! ## Integral spin weights -/
+
+/-- The next coordinate used to read a type `B` spin weight, staying at the terminal coordinate
+when there is no successor. -/
+def typeBSpinNext {n : ℕ} (i : Fin n) : Fin n :=
+  ⟨min ((i : ℕ) + 1) (n - 1), by have := i.isLt; omega⟩
+
+/-- Away from the terminal coordinate, `typeBSpinNext` increments the index. -/
+@[simp]
+theorem typeBSpinNext_val_of_lt {n : ℕ} (i : Fin n) (h : (i : ℕ) + 1 < n) :
+    (typeBSpinNext i : ℕ) = (i : ℕ) + 1 := by
+  simp only [typeBSpinNext, Fin.val_mk]
+  omega
+
+/-- At the terminal coordinate, `typeBSpinNext` fixes the index. -/
+@[simp]
+theorem typeBSpinNext_eq_self_of_not_lt {n : ℕ} (i : Fin n) (h : ¬(i : ℕ) + 1 < n) :
+    typeBSpinNext i = i := by
+  apply Fin.ext
+  simp only [typeBSpinNext, Fin.val_mk]
+  have := i.isLt
+  omega
+
+private theorem typeBSpinNext_eq_mk {n : ℕ} (i : Fin n) (h : (i : ℕ) + 1 < n) :
+    typeBSpinNext i = (⟨(i : ℕ) + 1, h⟩ : Fin n) := by
+  apply Fin.ext
+  exact typeBSpinNext_val_of_lt i h
+
+private theorem typeBSpinNext_le_iff {n : ℕ} (i j : Fin n) (h : (i : ℕ) + 1 < n) :
+    typeBSpinNext i ≤ j ↔ (i : ℕ) + 1 ≤ (j : ℕ) := by
+  rw [typeBSpinNext_eq_mk i h]
+  exact Fin.mk_le_mk
+
+/-- The weight of a type `Bₙ` spinor basis vector in fundamental-weight coordinates.
+
+The finite set `s` records the positive signs. At a nonterminal node the coordinate is the
+half-difference of two adjacent signs, hence `1`, `0`, or `-1`; at the terminal node it is the
+last sign, because the last simple coroot is `2e_{n-1}`. -/
+def typeBSpinWeight {n : ℕ} (s : Finset (Fin n)) (i : Fin n) : ℤ :=
+  if (i : ℕ) + 1 < n then
+    (if i ∈ s then 1 else 0) -
+      if typeBSpinNext i ∈ s then 1 else 0
+  else 2 * (if i ∈ s then 1 else 0) - 1
+
+/-- The coordinate formula for a type `B` spin weight. -/
+theorem typeBSpinWeight_apply {n : ℕ} (s : Finset (Fin n)) (i : Fin n) :
+    typeBSpinWeight s i =
+      if (i : ℕ) + 1 < n then
+        (if i ∈ s then 1 else 0) -
+          if typeBSpinNext i ∈ s then 1 else 0
+      else 2 * (if i ∈ s then 1 else 0) - 1 :=
+  (rfl)
+
+/-- In rational coordinates, `typeBSpinWeight` is obtained from the orthonormal sign weight by
+pairing with the simple coroot: take an adjacent difference away from the terminal node and
+double the terminal coordinate. -/
+theorem algebraMap_typeBSpinWeight_apply {n : ℕ} (s : Finset (Fin n)) (i : Fin n) :
+    algebraMap ℤ ℚ (typeBSpinWeight s i) =
+      if h : (i : ℕ) + 1 < n then
+        spinWeight ℚ s i - spinWeight ℚ s (⟨(i : ℕ) + 1, h⟩ : Fin n)
+      else spinWeight ℚ s i + spinWeight ℚ s i := by
+  classical
+  rw [typeBSpinWeight_apply]
+  by_cases hnext : (i : ℕ) + 1 < n
+  · rw [ite_eq_left hnext, typeBSpinNext_eq_mk i hnext, dite_eq_left hnext]
+    by_cases hi : i ∈ s
+    · rw [ite_eq_left hi]
+      by_cases hsucc : (⟨(i : ℕ) + 1, hnext⟩ : Fin n) ∈ s
+      · have hweight :
+            spinWeight ℚ s (⟨(i : ℕ) + 1, hnext⟩ : Fin n) = ⅟(2 : ℚ) :=
+          spinWeight_of_mem hsucc
+        rw [ite_eq_left hsucc, sub_self, map_zero, spinWeight_of_mem hi, hweight, sub_self]
+      · rw [ite_eq_right hsucc, sub_zero, map_one]
+        linarith [spinWeight_add_self_of_mem (K := ℚ) hi,
+          spinWeight_add_self_of_notMem (K := ℚ) hsucc]
+    · rw [ite_eq_right hi]
+      by_cases hsucc : (⟨(i : ℕ) + 1, hnext⟩ : Fin n) ∈ s
+      · rw [ite_eq_left hsucc, zero_sub, map_neg, map_one]
+        linarith [spinWeight_add_self_of_notMem (K := ℚ) hi,
+          spinWeight_add_self_of_mem (K := ℚ) hsucc]
+      · have hweight :
+            spinWeight ℚ s (⟨(i : ℕ) + 1, hnext⟩ : Fin n) = -⅟(2 : ℚ) :=
+          spinWeight_of_notMem hsucc
+        rw [ite_eq_right hsucc, sub_self, map_zero, spinWeight_of_notMem hi, hweight, sub_self]
+  · rw [ite_eq_right hnext, dite_eq_right hnext]
+    by_cases hi : i ∈ s
+    · rw [ite_eq_left hi]
+      norm_num
+      exact (spinWeight_add_self_of_mem (K := ℚ) hi).symm
+    · rw [ite_eq_right hi]
+      norm_num
+      exact (spinWeight_add_self_of_notMem (K := ℚ) hi).symm
+
+/-- The comparison with half-integer spin weights, as an equality of coordinate vectors. -/
+theorem algebraMap_typeBSpinWeight {n : ℕ} (s : Finset (Fin n)) :
+    (fun i : Fin n => algebraMap ℤ ℚ (typeBSpinWeight s i)) =
+      fun i : Fin n => if h : (i : ℕ) + 1 < n then
+        spinWeight ℚ s i - spinWeight ℚ s (⟨(i : ℕ) + 1, h⟩ : Fin n)
+      else spinWeight ℚ s i + spinWeight ℚ s i := by
+  funext i
+  exact algebraMap_typeBSpinWeight_apply s i
+
+/-! ## A spanning family -/
+
+/-- The sign set which is positive through `i` and negative after `i`. Its spin weight is the
+fundamental weight vector at `i`, minus the terminal fundamental weight when `i` is nonterminal. -/
+private def typeBSpinCut {n : ℕ} (i : Fin n) : Finset (Fin n) :=
+  Finset.univ.filter fun j => j ≤ i
+
+private theorem mem_typeBSpinCut_iff {n : ℕ} (i j : Fin n) :
+    j ∈ typeBSpinCut i ↔ j ≤ i := by
+  simp [typeBSpinCut]
+
+/-- The all-positive sign weight has only its terminal fundamental-weight coordinate nonzero. -/
+private theorem typeBSpinWeight_univ_apply {n : ℕ} (i : Fin n) :
+    typeBSpinWeight (Finset.univ : Finset (Fin n)) i =
+      if (i : ℕ) + 1 = n then 1 else 0 := by
+  rw [typeBSpinWeight_apply]
+  by_cases hnext : (i : ℕ) + 1 < n
+  · have hne : ¬(i : ℕ) + 1 = n := by omega
+    rw [ite_eq_left hnext, ite_eq_right hne]
+    simp
+  · have heq : (i : ℕ) + 1 = n := by omega
+    rw [ite_eq_right hnext, ite_eq_left heq]
+    simp
+
+/-- At a terminal node, the corresponding cut sign weight is the coordinate basis vector. -/
+private theorem typeBSpinWeight_cut_eq_single_of_isLast {n : ℕ} (i : Fin n)
+    (hi : (i : ℕ) + 1 = n) :
+    typeBSpinWeight (typeBSpinCut i) = Pi.single i 1 := by
+  classical
+  funext j
+  rw [typeBSpinWeight_apply, Pi.single_apply]
+  simp only [mem_typeBSpinCut_iff]
+  split_ifs with hjnext hji hjsucc hjlast hji <;> simp_all <;> omega
+
+/-- At a nonterminal node, adding the all-positive weight to the cut sign weight gives the
+corresponding coordinate basis vector. -/
+private theorem typeBSpinWeight_cut_add_univ_eq_single {n : ℕ} (i : Fin n)
+    (hi : (i : ℕ) + 1 < n) :
+    typeBSpinWeight (typeBSpinCut i) +
+        typeBSpinWeight (Finset.univ : Finset (Fin n)) = Pi.single i 1 := by
+  classical
+  funext j
+  have hjlt := j.isLt
+  rw [Pi.add_apply, typeBSpinWeight_apply, typeBSpinWeight_univ_apply, Pi.single_apply]
+  by_cases hjnext : (j : ℕ) + 1 < n
+  · have hjnotlast : ¬(j : ℕ) + 1 = n := by omega
+    rw [ite_eq_left hjnext, ite_eq_right hjnotlast]
+    simp only [mem_typeBSpinCut_iff]
+    simp only [typeBSpinNext_le_iff j i hjnext]
+    split_ifs <;> omega
+  · have hjlast : (j : ℕ) + 1 = n := by omega
+    rw [ite_eq_right hjnext, ite_eq_left hjlast]
+    simp only [mem_typeBSpinCut_iff]
+    split_ifs <;> omega
+
+/-- **The type `Bₙ` spin weights generate the full simply connected character lattice.**
+
+For a nonterminal node `i`, the sign sequence positive through `i` has weight
+`ωᵢ - ω_{n-1}`, while the all-positive sequence has weight `ω_{n-1}`. At the terminal node the
+cut sequence is already `ω_{n-1}`. Thus every fundamental-weight basis vector lies in the span. -/
+theorem span_range_typeBSpinWeight_eq_top (n : ℕ) :
+    Submodule.span ℤ (Set.range (typeBSpinWeight (n := n))) = ⊤ := by
+  apply top_unique
+  rw [← (Pi.basisFun ℤ (Fin n)).span_eq]
+  refine Submodule.span_le.2 ?_
+  rintro _ ⟨i, rfl⟩
+  rw [Pi.basisFun_apply]
+  by_cases hi : (i : ℕ) + 1 = n
+  · rw [← typeBSpinWeight_cut_eq_single_of_isLast i hi]
+    exact Submodule.subset_span ⟨typeBSpinCut i, rfl⟩
+  · have hi' : (i : ℕ) + 1 < n := by omega
+    rw [← typeBSpinWeight_cut_add_univ_eq_single i hi']
+    exact Submodule.add_mem _
+      (Submodule.subset_span ⟨typeBSpinCut i, rfl⟩)
+      (Submodule.subset_span ⟨Finset.univ, rfl⟩)
+
+end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
@@ -93,7 +93,6 @@ private theorem algebraMap_indicator_sub_eq_spinWeight_sub {K : Type*} [CommRing
 `typeBSpinWeight` is obtained from the orthonormal sign weight by pairing with the simple
 coroot, that is, by taking an adjacent difference away from the terminal node and doubling the
 terminal coordinate. -/
-@[simp]
 theorem algebraMap_typeBSpinWeight_apply {K : Type*} [CommRing K] [Invertible (2 : K)] {n : ℕ}
     (s : Finset (Fin n)) (i : Fin n) :
     algebraMap ℤ K (typeBSpinWeight s i) =

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
@@ -65,6 +65,7 @@ def typeBSpinWeight {n : ℕ} (s : Finset (Fin n)) (i : Fin n) : ℤ :=
   else 2 * (if i ∈ s then 1 else 0) - 1
 
 /-- The coordinate formula for a type `B` spin weight. -/
+@[simp]
 theorem typeBSpinWeight_apply {n : ℕ} (s : Finset (Fin n)) (i : Fin n) :
     typeBSpinWeight s i =
       if (i : ℕ) + 1 < n then
@@ -73,10 +74,26 @@ theorem typeBSpinWeight_apply {n : ℕ} (s : Finset (Fin n)) (i : Fin n) :
       else 2 * (if i ∈ s then 1 else 0) - 1 :=
   (rfl)
 
+/-- Mapping a difference of sign indicators gives the difference of the corresponding
+half-integral sign weights. -/
+private theorem algebraMap_indicator_sub_eq_spinWeight_sub {K : Type*} [CommRing K]
+    [Invertible (2 : K)] {n : ℕ} (s : Finset (Fin n)) (i j : Fin n) :
+    algebraMap ℤ K ((if i ∈ s then 1 else 0) - if j ∈ s then 1 else 0) =
+      spinWeight K s i - spinWeight K s j := by
+  by_cases hi : i ∈ s
+  · by_cases hj : j ∈ s
+    · simp [hi, hj]
+    · simp [hi, hj, sub_neg_eq_add]
+  · by_cases hj : j ∈ s
+    · simpa [hi, hj, sub_eq_add_neg] using
+        (spinWeight_add_self_of_notMem (K := K) hi).symm
+    · simp [hi, hj]
+
 /-- The coordinate comparison, in any commutative ring in which `2` is invertible:
 `typeBSpinWeight` is obtained from the orthonormal sign weight by pairing with the simple
 coroot, that is, by taking an adjacent difference away from the terminal node and doubling the
 terminal coordinate. -/
+@[simp]
 theorem algebraMap_typeBSpinWeight_apply {K : Type*} [CommRing K] [Invertible (2 : K)] {n : ℕ}
     (s : Finset (Fin n)) (i : Fin n) :
     algebraMap ℤ K (typeBSpinWeight s i) =
@@ -85,28 +102,12 @@ theorem algebraMap_typeBSpinWeight_apply {K : Type*} [CommRing K] [Invertible (2
   classical
   rw [typeBSpinWeight_apply]
   by_cases hnext : (i : ℕ) + 1 < n
-  · rw [ite_eq_left hnext, ite_eq_left hnext]
+  · simpa [hnext] using algebraMap_indicator_sub_eq_spinWeight_sub s i (Order.succ i)
+  · simp only [ite_eq_right hnext]
     by_cases hi : i ∈ s
-    · by_cases hsucc : Order.succ i ∈ s
-      · rw [ite_eq_left hi, ite_eq_left hsucc, sub_self, map_zero, spinWeight_of_mem hi,
-          spinWeight_of_mem hsucc, sub_self]
-      · have hneg : spinWeight K s (Order.succ i) = -spinWeight K s i := by
-          rw [spinWeight_of_mem hi, spinWeight_of_notMem hsucc]
-        rw [ite_eq_left hi, ite_eq_right hsucc, sub_zero, map_one, hneg, sub_neg_eq_add,
-          spinWeight_add_self_of_mem hi]
-    · by_cases hsucc : Order.succ i ∈ s
-      · have hneg : spinWeight K s (Order.succ i) = -spinWeight K s i := by
-          rw [spinWeight_of_notMem hi, spinWeight_of_mem hsucc, neg_neg]
-        rw [ite_eq_right hi, ite_eq_left hsucc, zero_sub, map_neg, map_one, hneg, sub_neg_eq_add,
-          spinWeight_add_self_of_notMem hi]
-      · rw [ite_eq_right hi, ite_eq_right hsucc, sub_self, map_zero, spinWeight_of_notMem hi,
-          spinWeight_of_notMem hsucc, sub_self]
-  · rw [ite_eq_right hnext, ite_eq_right hnext]
-    by_cases hi : i ∈ s
-    · rw [ite_eq_left hi, spinWeight_add_self_of_mem hi]
-      norm_num
-    · rw [ite_eq_right hi, spinWeight_add_self_of_notMem hi]
-      norm_num
+    · simp [hi]
+    · simp only [ite_eq_right hi, mul_zero, zero_sub, map_neg, map_one]
+      exact (spinWeight_add_self_of_notMem (K := K) hi).symm
 
 /-- The comparison with half-integer spin weights, as an equality of coordinate vectors. -/
 theorem algebraMap_typeBSpinWeight {K : Type*} [CommRing K] [Invertible (2 : K)] {n : ℕ}
@@ -132,15 +133,47 @@ private theorem typeBSpinWeight_univ_apply {n : ℕ} (i : Fin n) :
     rw [ite_eq_right hnext, ite_eq_left heq]
     simp
 
+/-- The cut weight has a `1` at the cut, a `-1` at a later terminal node, and zero in every
+other coordinate. -/
+private theorem typeBSpinWeight_Iic_apply {n : ℕ} (i j : Fin n) :
+    typeBSpinWeight (Finset.Iic i) j =
+      if j = i then 1 else if (j : ℕ) + 1 = n then -1 else 0 := by
+  classical
+  rcases lt_trichotomy j i with hji | hji | hij
+  · have hjnext : (j : ℕ) + 1 < n := by omega
+    have hjnotlast : ¬(j : ℕ) + 1 = n := by omega
+    have hjnotmax : ¬IsMax j := not_isMax_of_lt hji
+    have hsuccle : Order.succ j ≤ i :=
+      (Order.succ_le_iff_of_not_isMax hjnotmax).2 hji
+    simp [typeBSpinWeight_apply, hjnext, hjnotlast, Finset.mem_Iic, hji.le, hsuccle, hji.ne]
+  · subst j
+    by_cases hinext : (i : ℕ) + 1 < n
+    · have hinotmax : ¬IsMax i :=
+        not_isMax_of_lt (b := (⟨(i : ℕ) + 1, hinext⟩ : Fin n)) (by simp [Fin.lt_def])
+      simp [typeBSpinWeight_apply, hinext, Finset.mem_Iic,
+        Order.succ_le_iff_of_not_isMax hinotmax]
+    · have hilast : (i : ℕ) + 1 = n := by omega
+      simp [typeBSpinWeight_apply, hilast]
+  · have hjnotle : ¬j ≤ i := not_le_of_gt hij
+    have hsuccnotle : ¬Order.succ j ≤ i := fun h ↦ hjnotle (Order.le_succ j |>.trans h)
+    by_cases hjnext : (j : ℕ) + 1 < n
+    · have hjnotlast : ¬(j : ℕ) + 1 = n := by omega
+      simp [typeBSpinWeight_apply, hjnext, hjnotlast, Finset.mem_Iic, hjnotle, hsuccnotle,
+        hij.ne']
+    · have hjlast : (j : ℕ) + 1 = n := by omega
+      simp [typeBSpinWeight_apply, hjlast, Finset.mem_Iic, hjnotle, hij.ne']
+
 /-- At a terminal node, the corresponding cut sign weight is the coordinate basis vector. -/
 private theorem typeBSpinWeight_cut_eq_single_of_isLast {n : ℕ} (i : Fin n)
     (hi : (i : ℕ) + 1 = n) :
     typeBSpinWeight (Finset.Iic i) = Pi.single i 1 := by
   classical
   funext j
-  rw [typeBSpinWeight_apply, Pi.single_apply]
-  simp only [Finset.mem_Iic]
-  split_ifs with hjnext hji hjsucc hjlast hji <;> simp_all <;> omega
+  rw [typeBSpinWeight_Iic_apply, Pi.single_apply]
+  by_cases hji : j = i
+  · simp [hji]
+  · have hjnotlast : ¬(j : ℕ) + 1 = n := fun hjlast ↦ hji (Fin.ext (by omega))
+    simp [hji, hjnotlast]
 
 /-- At a nonterminal node, adding the all-positive weight to the cut sign weight gives the
 corresponding coordinate basis vector. -/
@@ -150,19 +183,13 @@ private theorem typeBSpinWeight_cut_add_univ_eq_single {n : ℕ} (i : Fin n)
         typeBSpinWeight (Finset.univ : Finset (Fin n)) = Pi.single i 1 := by
   classical
   funext j
-  have hjlt := j.isLt
-  rw [Pi.add_apply, typeBSpinWeight_apply, typeBSpinWeight_univ_apply, Pi.single_apply]
-  by_cases hjnext : (j : ℕ) + 1 < n
-  · have hjnotlast : ¬(j : ℕ) + 1 = n := by omega
-    rw [ite_eq_left hjnext, ite_eq_right hjnotlast]
-    have hjnotmax : ¬IsMax j :=
-      not_isMax_of_lt (b := (⟨(j : ℕ) + 1, hjnext⟩ : Fin n)) (by simp [Fin.lt_def])
-    simp only [Finset.mem_Iic, Order.succ_le_iff_of_not_isMax hjnotmax, Fin.lt_def]
-    split_ifs <;> omega
-  · have hjlast : (j : ℕ) + 1 = n := by omega
-    rw [ite_eq_right hjnext, ite_eq_left hjlast]
-    simp only [Finset.mem_Iic]
-    split_ifs <;> omega
+  rw [Pi.add_apply, typeBSpinWeight_Iic_apply, typeBSpinWeight_univ_apply, Pi.single_apply]
+  by_cases hji : j = i
+  · subst j
+    simp [hi.ne]
+  · by_cases hjlast : (j : ℕ) + 1 = n
+    · simp [hji, hjlast]
+    · simp [hji, hjlast]
 
 /-- **The type `Bₙ` spin weights generate the full simply connected character lattice.**
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Data.Fin.SuccPredOrder
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.B.Datum
 public import TauCeti.RepresentationTheory.Spin.Weight
 
@@ -53,35 +54,23 @@ open Set Submodule
 
 /-! ## Integral spin weights -/
 
-/-- The next coordinate used to read a type `B` spin weight, staying at the terminal coordinate
-when there is no successor. -/
-def typeBSpinNext {n : ℕ} (i : Fin n) : Fin n :=
-  ⟨min ((i : ℕ) + 1) (n - 1), by have := i.isLt; omega⟩
+private theorem orderSucc_eq_mk_of_lt {n : ℕ} (i : Fin n) (h : (i : ℕ) + 1 < n) :
+    Order.succ i = (⟨(i : ℕ) + 1, h⟩ : Fin n) := by
+  cases n with
+  | zero => exact Fin.elim0 i
+  | succ n =>
+      have hi : i ≠ Fin.last n := by
+        intro hi
+        subst i
+        simp at h
+      obtain ⟨j, rfl⟩ := Fin.eq_castSucc_of_ne_last hi
+      rw [Fin.orderSucc_castSucc]
+      apply Fin.ext
+      rfl
 
-/-- Away from the terminal coordinate, `typeBSpinNext` increments the index. -/
-@[simp]
-theorem typeBSpinNext_val_of_lt {n : ℕ} (i : Fin n) (h : (i : ℕ) + 1 < n) :
-    (typeBSpinNext i : ℕ) = (i : ℕ) + 1 := by
-  simp only [typeBSpinNext, Fin.val_mk]
-  omega
-
-/-- At the terminal coordinate, `typeBSpinNext` fixes the index. -/
-@[simp]
-theorem typeBSpinNext_eq_self_of_not_lt {n : ℕ} (i : Fin n) (h : ¬(i : ℕ) + 1 < n) :
-    typeBSpinNext i = i := by
-  apply Fin.ext
-  simp only [typeBSpinNext, Fin.val_mk]
-  have := i.isLt
-  omega
-
-private theorem typeBSpinNext_eq_mk {n : ℕ} (i : Fin n) (h : (i : ℕ) + 1 < n) :
-    typeBSpinNext i = (⟨(i : ℕ) + 1, h⟩ : Fin n) := by
-  apply Fin.ext
-  exact typeBSpinNext_val_of_lt i h
-
-private theorem typeBSpinNext_le_iff {n : ℕ} (i j : Fin n) (h : (i : ℕ) + 1 < n) :
-    typeBSpinNext i ≤ j ↔ (i : ℕ) + 1 ≤ (j : ℕ) := by
-  rw [typeBSpinNext_eq_mk i h]
+private theorem orderSucc_le_iff {n : ℕ} (i j : Fin n) (h : (i : ℕ) + 1 < n) :
+    Order.succ i ≤ j ↔ (i : ℕ) + 1 ≤ (j : ℕ) := by
+  rw [orderSucc_eq_mk_of_lt i h]
   exact Fin.mk_le_mk
 
 /-- The weight of a type `Bₙ` spinor basis vector in fundamental-weight coordinates.
@@ -92,7 +81,7 @@ last sign, because the last simple coroot is `2e_{n-1}`. -/
 def typeBSpinWeight {n : ℕ} (s : Finset (Fin n)) (i : Fin n) : ℤ :=
   if (i : ℕ) + 1 < n then
     (if i ∈ s then 1 else 0) -
-      if typeBSpinNext i ∈ s then 1 else 0
+      if Order.succ i ∈ s then 1 else 0
   else 2 * (if i ∈ s then 1 else 0) - 1
 
 /-- The coordinate formula for a type `B` spin weight. -/
@@ -100,7 +89,7 @@ theorem typeBSpinWeight_apply {n : ℕ} (s : Finset (Fin n)) (i : Fin n) :
     typeBSpinWeight s i =
       if (i : ℕ) + 1 < n then
         (if i ∈ s then 1 else 0) -
-          if typeBSpinNext i ∈ s then 1 else 0
+          if Order.succ i ∈ s then 1 else 0
       else 2 * (if i ∈ s then 1 else 0) - 1 :=
   (rfl)
 
@@ -115,7 +104,7 @@ theorem algebraMap_typeBSpinWeight_apply {n : ℕ} (s : Finset (Fin n)) (i : Fin
   classical
   rw [typeBSpinWeight_apply]
   by_cases hnext : (i : ℕ) + 1 < n
-  · rw [ite_eq_left hnext, typeBSpinNext_eq_mk i hnext, dite_eq_left hnext]
+  · rw [ite_eq_left hnext, orderSucc_eq_mk_of_lt i hnext, dite_eq_left hnext]
     by_cases hi : i ∈ s
     · rw [ite_eq_left hi]
       by_cases hsucc : (⟨(i : ℕ) + 1, hnext⟩ : Fin n) ∈ s
@@ -201,7 +190,7 @@ private theorem typeBSpinWeight_cut_add_univ_eq_single {n : ℕ} (i : Fin n)
   · have hjnotlast : ¬(j : ℕ) + 1 = n := by omega
     rw [ite_eq_left hjnext, ite_eq_right hjnotlast]
     simp only [mem_typeBSpinCut_iff]
-    simp only [typeBSpinNext_le_iff j i hjnext]
+    simp only [orderSucc_le_iff j i hjnext]
     split_ifs <;> omega
   · have hjlast : (j : ℕ) + 1 = n := by omega
     rw [ite_eq_right hjnext, ite_eq_left hjlast]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
@@ -144,15 +144,6 @@ theorem algebraMap_typeBSpinWeight {n : ℕ} (s : Finset (Fin n)) :
 
 /-! ## A spanning family -/
 
-/-- The sign set which is positive through `i` and negative after `i`. Its spin weight is the
-fundamental weight vector at `i`, minus the terminal fundamental weight when `i` is nonterminal. -/
-private def typeBSpinCut {n : ℕ} (i : Fin n) : Finset (Fin n) :=
-  Finset.univ.filter fun j => j ≤ i
-
-private theorem mem_typeBSpinCut_iff {n : ℕ} (i j : Fin n) :
-    j ∈ typeBSpinCut i ↔ j ≤ i := by
-  simp [typeBSpinCut]
-
 /-- The all-positive sign weight has only its terminal fundamental-weight coordinate nonzero. -/
 private theorem typeBSpinWeight_univ_apply {n : ℕ} (i : Fin n) :
     typeBSpinWeight (Finset.univ : Finset (Fin n)) i =
@@ -169,18 +160,18 @@ private theorem typeBSpinWeight_univ_apply {n : ℕ} (i : Fin n) :
 /-- At a terminal node, the corresponding cut sign weight is the coordinate basis vector. -/
 private theorem typeBSpinWeight_cut_eq_single_of_isLast {n : ℕ} (i : Fin n)
     (hi : (i : ℕ) + 1 = n) :
-    typeBSpinWeight (typeBSpinCut i) = Pi.single i 1 := by
+    typeBSpinWeight (Finset.Iic i) = Pi.single i 1 := by
   classical
   funext j
   rw [typeBSpinWeight_apply, Pi.single_apply]
-  simp only [mem_typeBSpinCut_iff]
+  simp only [Finset.mem_Iic]
   split_ifs with hjnext hji hjsucc hjlast hji <;> simp_all <;> omega
 
 /-- At a nonterminal node, adding the all-positive weight to the cut sign weight gives the
 corresponding coordinate basis vector. -/
 private theorem typeBSpinWeight_cut_add_univ_eq_single {n : ℕ} (i : Fin n)
     (hi : (i : ℕ) + 1 < n) :
-    typeBSpinWeight (typeBSpinCut i) +
+    typeBSpinWeight (Finset.Iic i) +
         typeBSpinWeight (Finset.univ : Finset (Fin n)) = Pi.single i 1 := by
   classical
   funext j
@@ -189,12 +180,12 @@ private theorem typeBSpinWeight_cut_add_univ_eq_single {n : ℕ} (i : Fin n)
   by_cases hjnext : (j : ℕ) + 1 < n
   · have hjnotlast : ¬(j : ℕ) + 1 = n := by omega
     rw [ite_eq_left hjnext, ite_eq_right hjnotlast]
-    simp only [mem_typeBSpinCut_iff]
+    simp only [Finset.mem_Iic]
     simp only [orderSucc_le_iff j i hjnext]
     split_ifs <;> omega
   · have hjlast : (j : ℕ) + 1 = n := by omega
     rw [ite_eq_right hjnext, ite_eq_left hjlast]
-    simp only [mem_typeBSpinCut_iff]
+    simp only [Finset.mem_Iic]
     split_ifs <;> omega
 
 /-- **The type `Bₙ` spin weights generate the full simply connected character lattice.**
@@ -211,11 +202,11 @@ theorem span_range_typeBSpinWeight_eq_top (n : ℕ) :
   rw [Pi.basisFun_apply]
   by_cases hi : (i : ℕ) + 1 = n
   · rw [← typeBSpinWeight_cut_eq_single_of_isLast i hi]
-    exact Submodule.subset_span ⟨typeBSpinCut i, rfl⟩
+    exact Submodule.subset_span ⟨Finset.Iic i, rfl⟩
   · have hi' : (i : ℕ) + 1 < n := by omega
     rw [← typeBSpinWeight_cut_add_univ_eq_single i hi']
     exact Submodule.add_mem _
-      (Submodule.subset_span ⟨typeBSpinCut i, rfl⟩)
+      (Submodule.subset_span ⟨Finset.Iic i, rfl⟩)
       (Submodule.subset_span ⟨Finset.univ, rfl⟩)
 
 end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Data.Fin.SuccPredOrder
-public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.B.Datum
 public import TauCeti.RepresentationTheory.Spin.Weight
 
 /-!
@@ -54,25 +53,6 @@ open Set Submodule
 
 /-! ## Integral spin weights -/
 
-private theorem orderSucc_eq_mk_of_lt {n : ℕ} (i : Fin n) (h : (i : ℕ) + 1 < n) :
-    Order.succ i = (⟨(i : ℕ) + 1, h⟩ : Fin n) := by
-  cases n with
-  | zero => exact Fin.elim0 i
-  | succ n =>
-      have hi : i ≠ Fin.last n := by
-        intro hi
-        subst i
-        simp at h
-      obtain ⟨j, rfl⟩ := Fin.eq_castSucc_of_ne_last hi
-      rw [Fin.orderSucc_castSucc]
-      apply Fin.ext
-      rfl
-
-private theorem orderSucc_le_iff {n : ℕ} (i j : Fin n) (h : (i : ℕ) + 1 < n) :
-    Order.succ i ≤ j ↔ (i : ℕ) + 1 ≤ (j : ℕ) := by
-  rw [orderSucc_eq_mk_of_lt i h]
-  exact Fin.mk_le_mk
-
 /-- The weight of a type `Bₙ` spinor basis vector in fundamental-weight coordinates.
 
 The finite set `s` records the positive signs. At a nonterminal node the coordinate is the
@@ -93,52 +73,47 @@ theorem typeBSpinWeight_apply {n : ℕ} (s : Finset (Fin n)) (i : Fin n) :
       else 2 * (if i ∈ s then 1 else 0) - 1 :=
   (rfl)
 
-/-- In rational coordinates, `typeBSpinWeight` is obtained from the orthonormal sign weight by
-pairing with the simple coroot: take an adjacent difference away from the terminal node and
-double the terminal coordinate. -/
-theorem algebraMap_typeBSpinWeight_apply {n : ℕ} (s : Finset (Fin n)) (i : Fin n) :
-    algebraMap ℤ ℚ (typeBSpinWeight s i) =
-      if h : (i : ℕ) + 1 < n then
-        spinWeight ℚ s i - spinWeight ℚ s (⟨(i : ℕ) + 1, h⟩ : Fin n)
-      else spinWeight ℚ s i + spinWeight ℚ s i := by
+/-- The coordinate comparison, in any commutative ring in which `2` is invertible:
+`typeBSpinWeight` is obtained from the orthonormal sign weight by pairing with the simple
+coroot, that is, by taking an adjacent difference away from the terminal node and doubling the
+terminal coordinate. -/
+theorem algebraMap_typeBSpinWeight_apply {K : Type*} [CommRing K] [Invertible (2 : K)] {n : ℕ}
+    (s : Finset (Fin n)) (i : Fin n) :
+    algebraMap ℤ K (typeBSpinWeight s i) =
+      if (i : ℕ) + 1 < n then spinWeight K s i - spinWeight K s (Order.succ i)
+      else spinWeight K s i + spinWeight K s i := by
   classical
   rw [typeBSpinWeight_apply]
   by_cases hnext : (i : ℕ) + 1 < n
-  · rw [ite_eq_left hnext, orderSucc_eq_mk_of_lt i hnext, dite_eq_left hnext]
+  · rw [ite_eq_left hnext, ite_eq_left hnext]
     by_cases hi : i ∈ s
-    · rw [ite_eq_left hi]
-      by_cases hsucc : (⟨(i : ℕ) + 1, hnext⟩ : Fin n) ∈ s
-      · have hweight :
-            spinWeight ℚ s (⟨(i : ℕ) + 1, hnext⟩ : Fin n) = ⅟(2 : ℚ) :=
-          spinWeight_of_mem hsucc
-        rw [ite_eq_left hsucc, sub_self, map_zero, spinWeight_of_mem hi, hweight, sub_self]
-      · rw [ite_eq_right hsucc, sub_zero, map_one]
-        linarith [spinWeight_add_self_of_mem (K := ℚ) hi,
-          spinWeight_add_self_of_notMem (K := ℚ) hsucc]
-    · rw [ite_eq_right hi]
-      by_cases hsucc : (⟨(i : ℕ) + 1, hnext⟩ : Fin n) ∈ s
-      · rw [ite_eq_left hsucc, zero_sub, map_neg, map_one]
-        linarith [spinWeight_add_self_of_notMem (K := ℚ) hi,
-          spinWeight_add_self_of_mem (K := ℚ) hsucc]
-      · have hweight :
-            spinWeight ℚ s (⟨(i : ℕ) + 1, hnext⟩ : Fin n) = -⅟(2 : ℚ) :=
-          spinWeight_of_notMem hsucc
-        rw [ite_eq_right hsucc, sub_self, map_zero, spinWeight_of_notMem hi, hweight, sub_self]
-  · rw [ite_eq_right hnext, dite_eq_right hnext]
+    · by_cases hsucc : Order.succ i ∈ s
+      · rw [ite_eq_left hi, ite_eq_left hsucc, sub_self, map_zero, spinWeight_of_mem hi,
+          spinWeight_of_mem hsucc, sub_self]
+      · have hneg : spinWeight K s (Order.succ i) = -spinWeight K s i := by
+          rw [spinWeight_of_mem hi, spinWeight_of_notMem hsucc]
+        rw [ite_eq_left hi, ite_eq_right hsucc, sub_zero, map_one, hneg, sub_neg_eq_add,
+          spinWeight_add_self_of_mem hi]
+    · by_cases hsucc : Order.succ i ∈ s
+      · have hneg : spinWeight K s (Order.succ i) = -spinWeight K s i := by
+          rw [spinWeight_of_notMem hi, spinWeight_of_mem hsucc, neg_neg]
+        rw [ite_eq_right hi, ite_eq_left hsucc, zero_sub, map_neg, map_one, hneg, sub_neg_eq_add,
+          spinWeight_add_self_of_notMem hi]
+      · rw [ite_eq_right hi, ite_eq_right hsucc, sub_self, map_zero, spinWeight_of_notMem hi,
+          spinWeight_of_notMem hsucc, sub_self]
+  · rw [ite_eq_right hnext, ite_eq_right hnext]
     by_cases hi : i ∈ s
-    · rw [ite_eq_left hi]
+    · rw [ite_eq_left hi, spinWeight_add_self_of_mem hi]
       norm_num
-      exact (spinWeight_add_self_of_mem (K := ℚ) hi).symm
-    · rw [ite_eq_right hi]
+    · rw [ite_eq_right hi, spinWeight_add_self_of_notMem hi]
       norm_num
-      exact (spinWeight_add_self_of_notMem (K := ℚ) hi).symm
 
 /-- The comparison with half-integer spin weights, as an equality of coordinate vectors. -/
-theorem algebraMap_typeBSpinWeight {n : ℕ} (s : Finset (Fin n)) :
-    (fun i : Fin n => algebraMap ℤ ℚ (typeBSpinWeight s i)) =
-      fun i : Fin n => if h : (i : ℕ) + 1 < n then
-        spinWeight ℚ s i - spinWeight ℚ s (⟨(i : ℕ) + 1, h⟩ : Fin n)
-      else spinWeight ℚ s i + spinWeight ℚ s i := by
+theorem algebraMap_typeBSpinWeight {K : Type*} [CommRing K] [Invertible (2 : K)] {n : ℕ}
+    (s : Finset (Fin n)) :
+    (fun i : Fin n => algebraMap ℤ K (typeBSpinWeight s i)) =
+      fun i : Fin n => if (i : ℕ) + 1 < n then spinWeight K s i - spinWeight K s (Order.succ i)
+      else spinWeight K s i + spinWeight K s i := by
   funext i
   exact algebraMap_typeBSpinWeight_apply s i
 
@@ -180,8 +155,9 @@ private theorem typeBSpinWeight_cut_add_univ_eq_single {n : ℕ} (i : Fin n)
   by_cases hjnext : (j : ℕ) + 1 < n
   · have hjnotlast : ¬(j : ℕ) + 1 = n := by omega
     rw [ite_eq_left hjnext, ite_eq_right hjnotlast]
-    simp only [Finset.mem_Iic]
-    simp only [orderSucc_le_iff j i hjnext]
+    have hjnotmax : ¬IsMax j :=
+      not_isMax_of_lt (b := (⟨(j : ℕ) + 1, hjnext⟩ : Fin n)) (by simp [Fin.lt_def])
+    simp only [Finset.mem_Iic, Order.succ_le_iff_of_not_isMax hjnotmax, Fin.lt_def]
     split_ifs <;> omega
   · have hjlast : (j : ℕ) + 1 = n := by omega
     rw [ite_eq_right hjnext, ite_eq_left hjlast]


### PR DESCRIPTION
This PR expresses the type `Bₙ` spinor sign weights in the fundamental-weight coordinates of `DynkinType.typeBSimplyConnectedRootDatum`, identifies those integral coordinates with the adjacent differences and terminal double of the existing half-integer `spinWeight`, and proves that the resulting weights span the full character lattice `Fin n → ℤ`.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, “The Chevalley–Demazure construction”: construct each pinned simply connected carrier from an explicit admissible lattice rather than an existence theorem. The designated milestone is the explicit simply connected type-`B` Chevalley carrier; this PR supplies its full-weight input, because the spin weights generate the entire weight lattice while the existing adjoint carrier reaches only the index-two root lattice. The dependency edge is that `CFSGStatement` milestone L0, “pinned ambient groups,” consumes the type-`B` carrier for the `Bₙ(q)` family.

This is the most effective current step because the generic Kostant toral-closure machinery and the type-`B` simply connected root datum are on `main`, the spinor weight decomposition has landed, and no open PR compares those two coordinate systems. The spanning proof is constructive: an all-positive sign weight gives the terminal fundamental weight, and a sign cut after node `i` gives its difference from the terminal weight, so every fundamental-weight basis vector lies in the span. Rank zero is handled uniformly.

Add `TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/B/SpinWeight.lean` (232 lines). The module reuses `TauCeti.spinWeight`, the pinned type-`B` datum, Mathlib’s `Pi.basisFun`, and ordinary submodule-span infrastructure; no Mathlib source or external formalization is vendored. The coordinate conventions follow Bourbaki, *Lie Groups and Lie Algebras, Chapters 4–6*, Plate II; Fulton–Harris, *Representation Theory*, §20.1; and Humphreys, *Introduction to Lie Algebras and Representation Theory*, §13.2, as credited in the module documentation.

After this PR, the Layer 9 type-`B` carrier still needs an explicit integral spinor lattice, the action and divided-power stability of the numbered Chevalley generators on it, and assembly through the existing Kostant toral-closure construction; the remaining type-`D`, `E₆`, and `E₇` full-weight carriers are separate family targets.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-b-spin-weights-full-lattice"}-->

🤖 Prepared with Codex
