### PR TITLE
feat: identify the GLn center quotient with PGL

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Center/Quotient.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Center/Quotient.lean
@@ -118,6 +118,18 @@ theorem centerPointwiseQuotientMk_surjective :
   exact pointwiseQuotientMk_surjective H (centerDefiningIdeal H)
     (isNormal_centerDefiningIdeal H) A
 
+/-- Extension of scalars sends a center-quotient class to the class of the extended point. -/
+@[simp]
+theorem mapPointwiseQuotient_centerPointwiseQuotientMk
+    {A B : CommAlgCat.{v} k} (φ : A ⟶ B)
+    (g : HopfAlgebra.points (R := k) (H := H) A) :
+    mapPointwiseQuotient H (centerDefiningIdeal H) (isNormal_centerDefiningIdeal H) φ
+        (centerPointwiseQuotientMk H A g) =
+      centerPointwiseQuotientMk H B (HopfAlgebra.mapPoints (H := H) φ g) := by
+  rw [centerPointwiseQuotientMk, centerPointwiseQuotientMk]
+  exact mapPointwiseQuotient_mk H (centerDefiningIdeal H)
+    (isNormal_centerDefiningIdeal H) φ g
+
 end Pointwise
 
 /-- The fppf sheaf quotient `G / Z(G)` of an affine group by its center.

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Center.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Center.lean
@@ -37,6 +37,8 @@ coordinate algebra in the basic reductive example.
   `GLₙ`-points.
 * `TauCeti.GeneralLinear.scalarTorusCenterNatIso`: the natural isomorphism from `𝔾ₘ`-points
   to the represented center of `GLₙ`.
+* `TauCeti.GeneralLinear.map_centerPointsSubgroup_pointsMulEquiv_eq_center`: the represented
+  center maps onto the ordinary center of the point group.
 * `TauCeti.GeneralLinear.centerCoordinateLaurentIso`: the center coordinate Hopf algebra of
   `GLₙ` is the Laurent-polynomial Hopf algebra.
 
@@ -76,6 +78,15 @@ theorem pointToGeneralLinear_scalarTorusPoints {A : Type w} [CommRing A] [Algebr
       Matrix.GeneralLinearGroup.scalar (Fin n)
         (MultiplicativeGroup.pointsMulEquiv (R := R) (A := A) f) := by
   simp [scalarTorusPoints]
+
+/-- Under the multiplicative point equivalences, a scalar-torus point is the corresponding
+scalar matrix. -/
+theorem pointsMulEquiv_scalarTorusPoints {A : Type w} [CommRing A] [Algebra R A]
+    (f : WithConv (R[T;T⁻¹] →ₐ[R] A)) :
+    pointsMulEquiv n (scalarTorusPoints n f) =
+      Matrix.GeneralLinearGroup.scalar (Fin n)
+        (MultiplicativeGroup.pointsMulEquiv (R := R) (A := A) f) := by
+  rw [pointsMulEquiv_apply, pointToGeneralLinear_scalarTorusPoints]
 
 /-- The scalar-matrix construction is natural in the value algebra. -/
 theorem mapValue_scalarTorusPoints {A : Type w} {B : Type w'} [CommRing A] [CommRing B]
@@ -178,8 +189,7 @@ theorem scalarTorusCenterHom_bijective (hn : 0 < n) (A : CommAlgCat.{u} k) :
     apply Subtype.ext
     rw [coe_scalarTorusCenterHom_apply]
     apply (pointsMulEquiv (R := k) (A := A) n).injective
-    rw [pointsMulEquiv_apply, pointToGeneralLinear_scalarTorusPoints,
-      MulEquiv.apply_symm_apply]
+    rw [pointsMulEquiv_scalarTorusPoints, MulEquiv.apply_symm_apply]
     exact ha
 
 /-- A general-linear point is universally central exactly when it is a scalar point. -/
@@ -201,6 +211,40 @@ theorem mem_centerPointsSubgroup_iff_exists_scalarTorusPoints (hn : 0 < n)
       _ = g := congrArg Subtype.val hf
   · rintro ⟨f, rfl⟩
     exact scalarTorusPoints_mem_centerPointsSubgroup n f
+
+/-- Under the standard equivalence between `GLₙ`-points and invertible matrices, the represented
+center maps onto the ordinary group-theoretic center. -/
+theorem map_centerPointsSubgroup_pointsMulEquiv_eq_center (A : CommAlgCat.{u} k) :
+    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A).map
+        (pointsMulEquiv (R := k) (A := A) n) =
+      Subgroup.center (Matrix.GeneralLinearGroup (Fin n) A) := by
+  by_cases hn : n = 0
+  · subst n
+    apply le_antisymm <;> intro g hg
+    all_goals
+      have hg_one : g = 1 := by
+        apply Matrix.GeneralLinearGroup.ext
+        exact fun i ↦ i.elim0
+      rw [hg_one]
+      exact Subgroup.one_mem _
+  · apply le_antisymm
+    · rintro _ ⟨q, hq, rfl⟩
+      obtain ⟨f, rfl⟩ :=
+        (mem_centerPointsSubgroup_iff_exists_scalarTorusPoints n
+          (Nat.pos_of_ne_zero hn) A q).1 hq
+      rw [Matrix.GeneralLinearGroup.center_eq_range_scalar]
+      exact ⟨MultiplicativeGroup.pointsMulEquiv f,
+        (pointsMulEquiv_scalarTorusPoints n f).symm⟩
+    · intro g hg
+      rw [Matrix.GeneralLinearGroup.center_eq_range_scalar] at hg
+      obtain ⟨a, ha⟩ := hg
+      let f := (MultiplicativeGroup.pointsMulEquiv (R := k) (A := A)).symm a
+      refine ⟨scalarTorusPoints n f,
+        (mem_centerPointsSubgroup_iff_exists_scalarTorusPoints n
+          (Nat.pos_of_ne_zero hn) A _).2 ⟨f, rfl⟩, ?_⟩
+      exact (pointsMulEquiv_scalarTorusPoints n f).trans
+        ((congrArg (Matrix.GeneralLinearGroup.scalar (Fin n))
+          ((MultiplicativeGroup.pointsMulEquiv (R := k) (A := A)).apply_symm_apply a)).trans ha)
 
 /-- For every value algebra, scalar matrices identify the multiplicative group with the
 represented center of `GLₙ`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
@@ -116,7 +116,8 @@ theorem centerPointwiseQuotientIsoPGL_hom_mk (A : CommAlgCat.{u} k)
     (map_centerPointsSubgroup_pointsMulEquiv n A) q
 
 /-- The group-valued point functor `A ↦ PGL(n, A)`. -/
-@[expose] noncomputable def projectivePointsFunctor : CommAlgCat.{u} k ⥤ GrpCat.{u} where
+noncomputable def projectivePointsFunctor {R : Type u} [CommRing R] :
+    CommAlgCat.{u} R ⥤ GrpCat.{u} where
   obj A := GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A)
   map φ := GrpCat.ofHom (Matrix.ProjGenLinGroup.map φ.hom.toRingHom)
   map_id A := by
@@ -138,17 +139,69 @@ theorem centerPointwiseQuotientIsoPGL_hom_mk (A : CommAlgCat.{u} k)
 
 /-- The objects of `projectivePointsFunctor` are Mathlib's projective general linear groups. -/
 @[simp]
-theorem projectivePointsFunctor_obj (A : CommAlgCat.{u} k) :
+theorem projectivePointsFunctor_obj {R : Type u} [CommRing R] (A : CommAlgCat.{u} R) :
     (projectivePointsFunctor n).obj A =
       GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A) :=
   rfl
 
 /-- The maps of `projectivePointsFunctor` are induced by entrywise extension of scalars. -/
 @[simp]
-theorem projectivePointsFunctor_map {A B : CommAlgCat.{u} k} (φ : A ⟶ B) :
+theorem projectivePointsFunctor_map {R : Type u} [CommRing R]
+    {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
     (projectivePointsFunctor n).map φ =
       GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) :=
   rfl
+
+/-- The quotient equivalence commutes with extension of scalars in the value algebra. -/
+theorem centerPointwiseQuotientIsoPGL_hom_naturality {A B : CommAlgCat.{u} k} (φ : A ⟶ B) :
+    CommHopfAlgCat.mapPointwiseQuotient
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ ≫
+      (centerPointwiseQuotientIsoPGL n B).hom =
+    (centerPointwiseQuotientIsoPGL n A).hom ≫
+      GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) := by
+  let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
+      (coordinateHopfAlgebra k n) A) :=
+    (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) A).str
+  let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
+      (coordinateHopfAlgebra k n) B) :=
+    (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) B).str
+  apply GrpCat.hom_ext
+  apply MonoidHom.ext
+  intro x
+  obtain ⟨q, rfl⟩ := CommHopfAlgCat.centerPointwiseQuotientMk_surjective
+    (coordinateHopfAlgebra k n) A x
+  have hmap :
+      CommHopfAlgCat.mapPointwiseQuotient
+          (coordinateHopfAlgebra k n)
+          (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+          (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ
+          (CommHopfAlgCat.centerPointwiseQuotientMk
+            (coordinateHopfAlgebra k n) A q) =
+        CommHopfAlgCat.centerPointwiseQuotientMk
+          (coordinateHopfAlgebra k n) B
+          (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra k n) φ q) := by
+    rw [CommHopfAlgCat.centerPointwiseQuotientMk_apply,
+      CommHopfAlgCat.centerPointwiseQuotientMk_apply]
+    rw [← CommHopfAlgCat.pointwiseQuotientMk_apply
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)),
+      ← CommHopfAlgCat.pointwiseQuotientMk_apply
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n))]
+    exact CommHopfAlgCat.mapPointwiseQuotient_mk
+      (coordinateHopfAlgebra k n)
+      (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+      (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ q
+  simp only [GrpCat.hom_comp, MonoidHom.comp_apply, ConcreteCategory.hom_ofHom]
+  rw [hmap,
+    centerPointwiseQuotientIsoPGL_hom_mk,
+    centerPointwiseQuotientIsoPGL_hom_mk, Matrix.ProjGenLinGroup.map_mk,
+    HopfAlgebra.mapPoints_apply]
+  exact congrArg Matrix.ProjGenLinGroup.mk (pointsMulEquiv_mapValue n φ.hom q)
 
 /-- The pointwise center quotient of `GLₙ` is naturally isomorphic to the projective general
 linear point functor. -/
@@ -167,56 +220,6 @@ noncomputable def centerPointwiseQuotientNatIsoPGL :
       centerPointwiseQuotientIsoPGL n A ≪≫
       eqToIso (projectivePointsFunctor_obj n A).symm) (by
       intro A B φ
-      let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
-          (coordinateHopfAlgebra k n) A) :=
-        (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) A).str
-      let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
-          (coordinateHopfAlgebra k n) B) :=
-        (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) B).str
-      have hbare :
-          CommHopfAlgCat.mapPointwiseQuotient
-            (coordinateHopfAlgebra k n)
-            (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-            (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ ≫
-          (centerPointwiseQuotientIsoPGL n B).hom =
-        (centerPointwiseQuotientIsoPGL n A).hom ≫
-          GrpCat.ofHom
-            (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) := by
-        apply GrpCat.hom_ext
-        apply MonoidHom.ext
-        intro x
-        obtain ⟨q, rfl⟩ := CommHopfAlgCat.centerPointwiseQuotientMk_surjective
-          (coordinateHopfAlgebra k n) A x
-        have hmap :
-            CommHopfAlgCat.mapPointwiseQuotient
-                (coordinateHopfAlgebra k n)
-                (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-                (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ
-                (CommHopfAlgCat.centerPointwiseQuotientMk
-                  (coordinateHopfAlgebra k n) A q) =
-              CommHopfAlgCat.centerPointwiseQuotientMk
-                (coordinateHopfAlgebra k n) B
-                (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra k n) φ q) := by
-          rw [CommHopfAlgCat.centerPointwiseQuotientMk_apply,
-            CommHopfAlgCat.centerPointwiseQuotientMk_apply]
-          rw [← CommHopfAlgCat.pointwiseQuotientMk_apply
-              (coordinateHopfAlgebra k n)
-              (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-              (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)),
-            ← CommHopfAlgCat.pointwiseQuotientMk_apply
-              (coordinateHopfAlgebra k n)
-              (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-              (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n))]
-          exact CommHopfAlgCat.mapPointwiseQuotient_mk
-            (coordinateHopfAlgebra k n)
-            (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-            (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ q
-        simp only [GrpCat.hom_comp, MonoidHom.comp_apply, ConcreteCategory.hom_ofHom]
-        rw [hmap,
-          centerPointwiseQuotientIsoPGL_hom_mk,
-          centerPointwiseQuotientIsoPGL_hom_mk, Matrix.ProjGenLinGroup.map_mk,
-          HopfAlgebra.mapPoints_apply]
-        exact congrArg Matrix.ProjGenLinGroup.mk (pointsMulEquiv_mapValue n φ.hom q)
       have hprojective :
           eqToHom (projectivePointsFunctor_obj n A).symm ≫
               (projectivePointsFunctor n).map φ =
@@ -233,7 +236,8 @@ noncomputable def centerPointwiseQuotientNatIsoPGL :
             (coordinateHopfAlgebra k n)
             (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
             (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) ≫
-              z ≫ eqToHom (projectivePointsFunctor_obj n B).symm) hbare)
+              z ≫ eqToHom (projectivePointsFunctor_obj n B).symm)
+          (centerPointwiseQuotientIsoPGL_hom_naturality n φ))
 
 end GeneralLinear
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
@@ -8,14 +8,13 @@ module
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Projective
 public import TauCeti.Algebra.AlgebraicGroup.Center.Quotient
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Center
-public import TauCeti.Algebra.Group.Subgroup.Map
 
 /-!
 # The projective general linear point functor
 
-The represented center of `GLₙ` maps to the ordinary center of its group of points.  Consequently,
-its pointwise center quotient is Mathlib's projective general linear group
-`PGL(n, A)` over every commutative value algebra `A`.  This file proves that identification and
+The represented center of `GLₙ` maps isomorphically onto the ordinary center of its group of
+points. Consequently, its pointwise center quotient is Mathlib's projective general linear group
+`PGL(n, A)` over every commutative value algebra `A`. This file proves that identification and
 packages it naturally in `A`.
 
 This is an identification of the presheaf quotient before fppf sheafification.  It does not assert
@@ -23,10 +22,13 @@ that the pointwise quotient is already an fppf sheaf, or construct a representin
 
 ## Main declarations
 
+* `TauCeti.GeneralLinear.map_centerPointsSubgroup_pointsMulEquiv_eq_center`: the represented
+  center maps onto the ordinary center of the point group.
 * `TauCeti.GeneralLinear.centerPointwiseQuotientIsoPGL`: the objectwise group isomorphism.
-* `TauCeti.GeneralLinear.projectivePointsFunctor`: the functor `A ↦ PGL(n, A)`.
+* `TauCeti.GeneralLinear.pglPointsFunctor`: the pointwise-quotient presheaf
+  `A ↦ GLₙ(A) / Z(GLₙ(A))`, with values Mathlib names `PGL(n, A)`.
 * `TauCeti.GeneralLinear.centerPointwiseQuotientNatIsoPGL`: the natural identification of the
-  pointwise center quotient of `GLₙ` with `PGLₙ`.
+  pointwise center quotient of `GLₙ` with that presheaf.
 
 ## References
 
@@ -41,48 +43,10 @@ namespace TauCeti
 
 namespace GeneralLinear
 
-universe u
+universe u w
 
 variable {k : Type u} [Field k]
 variable (n : ℕ)
-
-/-- Under the standard equivalence between `GLₙ`-points and invertible matrices, the represented
-center maps onto the ordinary group-theoretic center. -/
-theorem map_centerPointsSubgroup_pointsMulEquiv (A : CommAlgCat.{u} k) :
-    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A).map
-        (pointsMulEquiv (R := k) (A := A) n) =
-      Subgroup.center (Matrix.GeneralLinearGroup (Fin n) A) := by
-  apply le_antisymm
-  · rintro _ ⟨q, hq, rfl⟩
-    have hqcenter :
-        q ∈ Subgroup.center
-          (HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) := by
-      apply HopfAlgebra.center_le_center
-      rw [← CommHopfAlgCat.centerPointsSubgroup_eq_center]
-      exact hq
-    exact Subgroup.map_center_le (pointsMulEquiv (R := k) (A := A) n)
-      (pointsMulEquiv (R := k) (A := A) n).surjective ⟨q, hqcenter, rfl⟩
-  · by_cases hn : n = 0
-    · subst n
-      intro g _
-      have hg : g = 1 := by
-        apply Matrix.GeneralLinearGroup.ext
-        exact fun i ↦ i.elim0
-      rw [hg]
-      exact Subgroup.one_mem _
-    intro g hg
-    rw [Matrix.GeneralLinearGroup.center_eq_range_scalar] at hg
-    obtain ⟨a, ha⟩ := hg
-    let f := (MultiplicativeGroup.pointsMulEquiv (R := k) (A := A)).symm a
-    refine ⟨scalarTorusPoints n f,
-      (mem_centerPointsSubgroup_iff_exists_scalarTorusPoints n
-        (Nat.pos_of_ne_zero hn) A _).2 ⟨f, rfl⟩, ?_⟩
-    calc
-      pointsMulEquiv n (scalarTorusPoints n f) =
-          Matrix.GeneralLinearGroup.scalar (Fin n) a := by
-        rw [pointsMulEquiv_apply, pointToGeneralLinear_scalarTorusPoints,
-          MulEquiv.apply_symm_apply]
-      _ = g := ha
 
 /-- The pointwise quotient of `GLₙ` by its represented center is the projective general linear
 group over the same value algebra. -/
@@ -102,15 +66,15 @@ noncomputable def centerPointwiseQuotientIsoPGL (A : CommAlgCat.{u} k) :
     (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
     (Subgroup.center (Matrix.GeneralLinearGroup (Fin n) A))
     (pointsMulEquiv (R := k) (A := A) n)
-    (map_centerPointsSubgroup_pointsMulEquiv n A)).toGrpIso
+    (map_centerPointsSubgroup_pointsMulEquiv_eq_center n A)).toGrpIso
 
 /-- The quotient equivalence sends the class of a `GLₙ`-point to the class of its associated
 invertible matrix. -/
-@[simp]
 theorem centerPointwiseQuotientIsoPGL_hom_mk (A : CommAlgCat.{u} k)
     (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
     (centerPointwiseQuotientIsoPGL n A).hom
-        (CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A q) =
+        (↑q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+          CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) =
       Matrix.ProjGenLinGroup.mk (pointsMulEquiv (R := k) (A := A) n q) := by
   let _ : (CommHopfAlgCat.centerPointsSubgroup
       (coordinateHopfAlgebra k n) A).Normal :=
@@ -118,29 +82,30 @@ theorem centerPointwiseQuotientIsoPGL_hom_mk (A : CommAlgCat.{u} k)
       (coordinateHopfAlgebra k n)
       (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
       (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A
-  rw [CommHopfAlgCat.centerPointwiseQuotientMk_apply]
   exact QuotientGroup.congr_mk'
     (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
     (Subgroup.center (Matrix.GeneralLinearGroup (Fin n) A))
     (pointsMulEquiv (R := k) (A := A) n)
-    (map_centerPointsSubgroup_pointsMulEquiv n A) q
+    (map_centerPointsSubgroup_pointsMulEquiv_eq_center n A) q
 
 /-- The inverse quotient equivalence sends the class of an invertible matrix to the class of its
 associated `GLₙ`-point. -/
-@[simp]
 theorem centerPointwiseQuotientIsoPGL_inv_mk (A : CommAlgCat.{u} k)
     (g : Matrix.GeneralLinearGroup (Fin n) A) :
     (centerPointwiseQuotientIsoPGL n A).inv (Matrix.ProjGenLinGroup.mk g) =
-      CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A
-        ((pointsMulEquiv (R := k) (A := A) n).symm g) := by
+      (↑((pointsMulEquiv (R := k) (A := A) n).symm g) :
+        HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+          CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) := by
   have h := centerPointwiseQuotientIsoPGL_hom_mk n A
     ((pointsMulEquiv (R := k) (A := A) n).symm g)
   rw [MulEquiv.apply_symm_apply] at h
   rw [← h, Iso.hom_inv_id_apply]
 
-/-- The group-valued point functor `A ↦ PGL(n, A)`. -/
-noncomputable def projectivePointsFunctor {R : Type u} [CommRing R] :
-    CommAlgCat.{u} R ⥤ GrpCat.{u} where
+/-- The presheaf `A ↦ GLₙ(A) / Z(GLₙ(A))`, with values given by Mathlib's
+`Matrix.ProjGenLinGroup`, packaged as a group-valued functor. This is not the functor of points of
+the algebraic group `PGLₙ`; obtaining that functor requires fppf sheafification. -/
+noncomputable def pglPointsFunctor {R : Type u} [CommRing R] :
+    CommAlgCat.{w} R ⥤ GrpCat.{w} where
   obj A := GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A)
   map φ := GrpCat.ofHom (Matrix.ProjGenLinGroup.map φ.hom.toRingHom)
   map_id A := by
@@ -150,36 +115,22 @@ noncomputable def projectivePointsFunctor {R : Type u} [CommRing R] :
     apply GrpCat.hom_ext
     exact Matrix.ProjGenLinGroup.map_comp φ.hom.toRingHom ψ.hom.toRingHom
 
-private theorem projectivePointsFunctor_obj_private {R : Type u} [CommRing R]
-    (A : CommAlgCat.{u} R) :
-    (projectivePointsFunctor n).obj A =
-      GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A) :=
-  rfl
-
-/-- The objects of `projectivePointsFunctor` are Mathlib's projective general linear groups. -/
+/-- The objects of `pglPointsFunctor` are Mathlib's projective general linear groups. -/
 @[simp]
-theorem projectivePointsFunctor_obj {R : Type u} [CommRing R] (A : CommAlgCat.{u} R) :
-    (projectivePointsFunctor n).obj A =
+theorem pglPointsFunctor_obj {R : Type u} [CommRing R] (A : CommAlgCat.{w} R) :
+    (pglPointsFunctor n).obj A =
       GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A) :=
-  projectivePointsFunctor_obj_private n A
+  (rfl)
 
-private theorem projectivePointsFunctor_obj_proof_eq_rfl {R : Type u} [CommRing R]
-    (A : CommAlgCat.{u} R) :
-    projectivePointsFunctor_obj n A = rfl :=
-  Subsingleton.elim _ _
-
-/-- The maps of `projectivePointsFunctor` are induced by entrywise extension of scalars. -/
+/-- The maps of `pglPointsFunctor` are induced by entrywise extension of scalars. -/
 @[simp]
-theorem projectivePointsFunctor_map {R : Type u} [CommRing R]
-    {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
-    (projectivePointsFunctor n).map φ =
-      eqToHom (projectivePointsFunctor_obj n A) ≫
+theorem pglPointsFunctor_map {R : Type u} [CommRing R]
+    {A B : CommAlgCat.{w} R} (φ : A ⟶ B) :
+    (pglPointsFunctor n).map φ =
+      eqToHom (pglPointsFunctor_obj n A) ≫
         GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) ≫
-          eqToHom (projectivePointsFunctor_obj n B).symm := by
-  rw [projectivePointsFunctor_obj_proof_eq_rfl n A,
-    projectivePointsFunctor_obj_proof_eq_rfl n B]
-  unfold projectivePointsFunctor
-  simp only [eqToHom_refl, Category.id_comp, Category.comp_id]
+          eqToHom (pglPointsFunctor_obj n B).symm :=
+  (rfl)
 
 /-- The quotient equivalence commutes with extension of scalars in the value algebra. -/
 theorem centerPointwiseQuotientIsoPGL_hom_naturality {A B : CommAlgCat.{u} k} (φ : A ⟶ B) :
@@ -201,45 +152,34 @@ theorem centerPointwiseQuotientIsoPGL_hom_naturality {A B : CommAlgCat.{u} k} (�
   intro x
   obtain ⟨q, rfl⟩ := CommHopfAlgCat.centerPointwiseQuotientMk_surjective
     (coordinateHopfAlgebra k n) A x
-  have hmap :
-      CommHopfAlgCat.mapPointwiseQuotient
-          (coordinateHopfAlgebra k n)
-          (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-          (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ
-          (CommHopfAlgCat.centerPointwiseQuotientMk
-            (coordinateHopfAlgebra k n) A q) =
-        CommHopfAlgCat.centerPointwiseQuotientMk
-          (coordinateHopfAlgebra k n) B
-          (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra k n) φ q) := by
-    rw [CommHopfAlgCat.centerPointwiseQuotientMk_apply,
-      CommHopfAlgCat.centerPointwiseQuotientMk_apply]
-    rw [← CommHopfAlgCat.pointwiseQuotientMk_apply
-        (coordinateHopfAlgebra k n)
-        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)),
-      ← CommHopfAlgCat.pointwiseQuotientMk_apply
-        (coordinateHopfAlgebra k n)
-        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n))]
-    exact CommHopfAlgCat.mapPointwiseQuotient_mk
-      (coordinateHopfAlgebra k n)
-      (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-      (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ q
   simp only [GrpCat.hom_comp, MonoidHom.comp_apply, ConcreteCategory.hom_ofHom]
-  rw [hmap,
-    centerPointwiseQuotientIsoPGL_hom_mk,
+  rw [CommHopfAlgCat.mapPointwiseQuotient_centerPointwiseQuotientMk]
+  rw [CommHopfAlgCat.centerPointwiseQuotientMk_apply,
+    CommHopfAlgCat.centerPointwiseQuotientMk_apply]
+  -- Normalize both projection applications to the quotient coercions used by the public API.
+  change
+    (centerPointwiseQuotientIsoPGL n B).hom
+        (↑(HopfAlgebra.mapPoints (H := coordinateHopfAlgebra k n) φ q) :
+          HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) B ⧸
+            CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) B) =
+      Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom
+        ((centerPointwiseQuotientIsoPGL n A).hom
+          (↑q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+            CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A))
+  rw [centerPointwiseQuotientIsoPGL_hom_mk,
     centerPointwiseQuotientIsoPGL_hom_mk, Matrix.ProjGenLinGroup.map_mk,
     HopfAlgebra.mapPoints_apply]
   exact congrArg Matrix.ProjGenLinGroup.mk (pointsMulEquiv_mapValue n φ.hom q)
 
-/-- The pointwise center quotient of `GLₙ` is naturally isomorphic to the projective general
-linear point functor. -/
+/-- The pointwise center quotient of `GLₙ` is naturally isomorphic to the presheaf with values
+Mathlib's projective general linear groups. This is a presheaf-level statement before fppf
+sheafification, not an identification with the functor of points of the algebraic group `PGLₙ`. -/
 noncomputable def centerPointwiseQuotientNatIsoPGL :
     CommHopfAlgCat.pointwiseQuotientFunctor
         (coordinateHopfAlgebra k n)
         (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
         (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) ≅
-      projectivePointsFunctor n :=
+      pglPointsFunctor n :=
   NatIso.ofComponents
     (fun A =>
       eqToIso (CommHopfAlgCat.pointwiseQuotientFunctor_obj
@@ -247,15 +187,15 @@ noncomputable def centerPointwiseQuotientNatIsoPGL :
         (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
         (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) ≪≫
       centerPointwiseQuotientIsoPGL n A ≪≫
-      eqToIso (projectivePointsFunctor_obj n A).symm) (by
+      eqToIso (pglPointsFunctor_obj n A).symm) (by
       intro A B φ
       have hprojective :
-          eqToHom (projectivePointsFunctor_obj n A).symm ≫
-              (projectivePointsFunctor n).map φ =
+          eqToHom (pglPointsFunctor_obj n A).symm ≫
+              (pglPointsFunctor n).map φ =
               GrpCat.ofHom
                 (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) ≫
-              eqToHom (projectivePointsFunctor_obj n B).symm := by
-        rw [projectivePointsFunctor_map]
+              eqToHom (pglPointsFunctor_obj n B).symm := by
+        rw [pglPointsFunctor_map]
         simp
       simpa only [Iso.trans_hom, eqToIso.hom,
         CommHopfAlgCat.pointwiseQuotientFunctor_map, Category.assoc,
@@ -266,44 +206,59 @@ noncomputable def centerPointwiseQuotientNatIsoPGL :
             (coordinateHopfAlgebra k n)
             (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
             (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) ≫
-              z ≫ eqToHom (projectivePointsFunctor_obj n B).symm)
+              z ≫ eqToHom (pglPointsFunctor_obj n B).symm)
           (centerPointwiseQuotientIsoPGL_hom_naturality n φ))
 
-private theorem centerPointwiseQuotientNatIsoPGL_hom_app_transports
+/-- After transport to the concrete quotient groups, the hom component of the natural
+identification is the objectwise quotient isomorphism. -/
+theorem centerPointwiseQuotientNatIsoPGL_hom_app
     (A : CommAlgCat.{u} k) :
     eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
         (coordinateHopfAlgebra k n)
         (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
         (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm ≫
       (centerPointwiseQuotientNatIsoPGL n).hom.app A ≫
-        eqToHom (projectivePointsFunctor_obj n A) =
+        eqToHom (pglPointsFunctor_obj n A) =
       (centerPointwiseQuotientIsoPGL n A).hom := by
+  unfold centerPointwiseQuotientNatIsoPGL
+  simp
+
+/-- After transport to the concrete quotient groups, the inverse component of the natural
+identification is the inverse objectwise quotient isomorphism. -/
+theorem centerPointwiseQuotientNatIsoPGL_inv_app
+    (A : CommAlgCat.{u} k) :
+    eqToHom (pglPointsFunctor_obj n A).symm ≫
+        (centerPointwiseQuotientNatIsoPGL n).inv.app A ≫
+      eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) =
+    (centerPointwiseQuotientIsoPGL n A).inv := by
   unfold centerPointwiseQuotientNatIsoPGL
   simp
 
 /-- After transport to the concrete quotient groups, the hom component of the natural
 identification sends a quotient class to the class of its associated invertible matrix. -/
-@[simp]
 theorem centerPointwiseQuotientNatIsoPGL_hom_app_mk (A : CommAlgCat.{u} k)
     (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
-    eqToHom (projectivePointsFunctor_obj n A)
+    eqToHom (pglPointsFunctor_obj n A)
         ((centerPointwiseQuotientNatIsoPGL n).hom.app A
           (eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
               (coordinateHopfAlgebra k n)
               (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
               (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm
-            (CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A q))) =
+            (↑q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+              CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A))) =
       Matrix.ProjGenLinGroup.mk (pointsMulEquiv (R := k) (A := A) n q) := by
   have h := congrArg
-    (fun f ↦ f (CommHopfAlgCat.centerPointwiseQuotientMk
-      (coordinateHopfAlgebra k n) A q))
-    (centerPointwiseQuotientNatIsoPGL_hom_app_transports n A)
+    (fun f ↦ f (↑q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+      CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A))
+    (centerPointwiseQuotientNatIsoPGL_hom_app n A)
   simp only [GrpCat.hom_comp, MonoidHom.comp_apply] at h
   rw [h, centerPointwiseQuotientIsoPGL_hom_mk]
 
 /-- After transport to the concrete quotient groups, the inverse component of the natural
 identification sends the class of an invertible matrix to its associated quotient class. -/
-@[simp]
 theorem centerPointwiseQuotientNatIsoPGL_inv_app_mk (A : CommAlgCat.{u} k)
     (g : Matrix.GeneralLinearGroup (Fin n) A) :
     eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
@@ -311,21 +266,13 @@ theorem centerPointwiseQuotientNatIsoPGL_inv_app_mk (A : CommAlgCat.{u} k)
         (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
         (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A)
       ((centerPointwiseQuotientNatIsoPGL n).inv.app A
-        (eqToHom (projectivePointsFunctor_obj n A).symm
+        (eqToHom (pglPointsFunctor_obj n A).symm
           (Matrix.ProjGenLinGroup.mk g))) =
-      CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A
-        ((pointsMulEquiv (R := k) (A := A) n).symm g) := by
-  have htransports :
-      eqToHom (projectivePointsFunctor_obj n A).symm ≫
-          (centerPointwiseQuotientNatIsoPGL n).inv.app A ≫
-        eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
-          (coordinateHopfAlgebra k n)
-          (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-          (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) =
-      (centerPointwiseQuotientIsoPGL n A).inv := by
-    unfold centerPointwiseQuotientNatIsoPGL
-    simp
-  have h := congrArg (fun f ↦ f (Matrix.ProjGenLinGroup.mk g)) htransports
+      (↑((pointsMulEquiv (R := k) (A := A) n).symm g) :
+        HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A ⧸
+          CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A) := by
+  have h := congrArg (fun f ↦ f (Matrix.ProjGenLinGroup.mk g))
+    (centerPointwiseQuotientNatIsoPGL_inv_app n A)
   simp only [GrpCat.hom_comp, MonoidHom.comp_apply] at h
   rw [h, centerPointwiseQuotientIsoPGL_inv_mk]
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
@@ -116,7 +116,7 @@ theorem centerPointwiseQuotientIsoPGL_hom_mk (A : CommAlgCat.{u} k)
     (map_centerPointsSubgroup_pointsMulEquiv n A) q
 
 /-- The group-valued point functor `A ↦ PGL(n, A)`. -/
-noncomputable def projectivePointsFunctor {R : Type u} [CommRing R] :
+@[expose] noncomputable def projectivePointsFunctor {R : Type u} [CommRing R] :
     CommAlgCat.{u} R ⥤ GrpCat.{u} where
   obj A := GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A)
   map φ := GrpCat.ofHom (Matrix.ProjGenLinGroup.map φ.hom.toRingHom)

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Projective
+public import TauCeti.Algebra.AlgebraicGroup.Center.Quotient
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Center
+
+/-!
+# The projective general linear point functor
+
+The represented center of `GLₙ` maps to the ordinary center of its group of points.  Consequently,
+its pointwise center quotient is Mathlib's projective general linear group
+`PGL(n, A)` over every commutative value algebra `A`.  This file proves that identification and
+packages it naturally in `A`.
+
+This is an identification of the presheaf quotient before fppf sheafification.  It does not assert
+that the pointwise quotient is already an fppf sheaf, or construct a representing Hopf algebra.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.centerPointwiseQuotientIsoPGL`: the objectwise group isomorphism.
+* `TauCeti.GeneralLinear.projectivePointsFunctor`: the functor `A ↦ PGL(n, A)`.
+* `TauCeti.GeneralLinear.centerPointwiseQuotientNatIsoPGL`: the natural identification of the
+  pointwise center quotient of `GLₙ` with `PGLₙ`.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Examples 5.5 and 21.4.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+namespace GeneralLinear
+
+universe u
+
+variable {k : Type u} [Field k]
+variable (n : ℕ)
+
+/-- Under the standard equivalence between `GLₙ`-points and invertible matrices, the represented
+center maps onto the ordinary group-theoretic center. -/
+theorem map_centerPointsSubgroup_pointsMulEquiv (A : CommAlgCat.{u} k) :
+    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A).map
+        (pointsMulEquiv (R := k) (A := A) n) =
+      Subgroup.center (Matrix.GeneralLinearGroup (Fin n) A) := by
+  ext g
+  constructor
+  · rintro ⟨q, hq, rfl⟩
+    have hqcenter :
+        q ∈ Subgroup.center
+          (HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) := by
+      apply HopfAlgebra.center_le_center
+      rw [← CommHopfAlgCat.centerPointsSubgroup_eq_center]
+      exact hq
+    exact (Subgroup.centerCongr (pointsMulEquiv (R := k) (A := A) n)
+      ⟨q, hqcenter⟩).2
+  · intro hg
+    rw [Matrix.GeneralLinearGroup.center_eq_range_scalar] at hg
+    obtain ⟨a, ha⟩ := hg
+    let f := (MultiplicativeGroup.pointsMulEquiv (R := k) (A := A)).symm a
+    refine ⟨scalarTorusPoints n f, scalarTorusPoints_mem_centerPointsSubgroup n f, ?_⟩
+    calc
+      pointsMulEquiv n (scalarTorusPoints n f) =
+          Matrix.GeneralLinearGroup.scalar (Fin n) a := by
+        rw [pointsMulEquiv_apply, pointToGeneralLinear_scalarTorusPoints,
+          MulEquiv.apply_symm_apply]
+      _ = g := ha
+
+/-- The pointwise quotient of `GLₙ` by its represented center is the projective general linear
+group over the same value algebra. -/
+noncomputable def centerPointwiseQuotientIsoPGL (A : CommAlgCat.{u} k) :
+    CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) A ≅
+      GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A) := by
+  let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
+      (coordinateHopfAlgebra k n) A) :=
+    (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) A).str
+  let _ : (CommHopfAlgCat.centerPointsSubgroup
+      (coordinateHopfAlgebra k n) A).Normal :=
+    CommHopfAlgCat.quotientPointsSubgroup_normal
+      (coordinateHopfAlgebra k n)
+      (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+      (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A
+  exact (QuotientGroup.congr
+    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
+    (Subgroup.center (Matrix.GeneralLinearGroup (Fin n) A))
+    (pointsMulEquiv (R := k) (A := A) n)
+    (map_centerPointsSubgroup_pointsMulEquiv n A)).toGrpIso
+
+/-- The quotient equivalence sends the class of a `GLₙ`-point to the class of its associated
+invertible matrix. -/
+@[simp]
+theorem centerPointwiseQuotientIsoPGL_hom_mk (A : CommAlgCat.{u} k)
+    (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
+    (centerPointwiseQuotientIsoPGL n A).hom
+        (CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A q) =
+      Matrix.ProjGenLinGroup.mk (pointsMulEquiv (R := k) (A := A) n q) := by
+  let _ : (CommHopfAlgCat.centerPointsSubgroup
+      (coordinateHopfAlgebra k n) A).Normal :=
+    CommHopfAlgCat.quotientPointsSubgroup_normal
+      (coordinateHopfAlgebra k n)
+      (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+      (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A
+  rw [CommHopfAlgCat.centerPointwiseQuotientMk_apply]
+  exact QuotientGroup.congr_mk'
+    (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A)
+    (Subgroup.center (Matrix.GeneralLinearGroup (Fin n) A))
+    (pointsMulEquiv (R := k) (A := A) n)
+    (map_centerPointsSubgroup_pointsMulEquiv n A) q
+
+/-- The group-valued point functor `A ↦ PGL(n, A)`. -/
+@[expose] noncomputable def projectivePointsFunctor : CommAlgCat.{u} k ⥤ GrpCat.{u} where
+  obj A := GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A)
+  map φ := GrpCat.ofHom (Matrix.ProjGenLinGroup.map φ.hom.toRingHom)
+  map_id A := by
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro x
+    induction x using Matrix.ProjGenLinGroup.induction_on with
+    | mk g => simp
+  map_comp {A B C} φ ψ := by
+    apply GrpCat.hom_ext
+    apply MonoidHom.ext
+    intro x
+    induction x using Matrix.ProjGenLinGroup.induction_on with
+    | mk g =>
+      apply congrArg Matrix.ProjGenLinGroup.mk
+      apply Matrix.GeneralLinearGroup.ext
+      intro i j
+      rfl
+
+/-- The objects of `projectivePointsFunctor` are Mathlib's projective general linear groups. -/
+@[simp]
+theorem projectivePointsFunctor_obj (A : CommAlgCat.{u} k) :
+    (projectivePointsFunctor n).obj A =
+      GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A) :=
+  rfl
+
+/-- The maps of `projectivePointsFunctor` are induced by entrywise extension of scalars. -/
+@[simp]
+theorem projectivePointsFunctor_map {A B : CommAlgCat.{u} k} (φ : A ⟶ B) :
+    (projectivePointsFunctor n).map φ =
+      GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) :=
+  rfl
+
+/-- The pointwise center quotient of `GLₙ` is naturally isomorphic to the projective general
+linear point functor. -/
+noncomputable def centerPointwiseQuotientNatIsoPGL :
+    CommHopfAlgCat.pointwiseQuotientFunctor
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) ≅
+      projectivePointsFunctor n :=
+  NatIso.ofComponents
+    (fun A =>
+      eqToIso (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) ≪≫
+      centerPointwiseQuotientIsoPGL n A ≪≫
+      eqToIso (projectivePointsFunctor_obj n A).symm) (by
+      intro A B φ
+      let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
+          (coordinateHopfAlgebra k n) A) :=
+        (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) A).str
+      let _ : Group (CommHopfAlgCat.centerPointwiseQuotient
+          (coordinateHopfAlgebra k n) B) :=
+        (CommHopfAlgCat.centerPointwiseQuotient (coordinateHopfAlgebra k n) B).str
+      have hbare :
+          CommHopfAlgCat.mapPointwiseQuotient
+            (coordinateHopfAlgebra k n)
+            (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+            (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ ≫
+          (centerPointwiseQuotientIsoPGL n B).hom =
+        (centerPointwiseQuotientIsoPGL n A).hom ≫
+          GrpCat.ofHom
+            (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) := by
+        apply GrpCat.hom_ext
+        apply MonoidHom.ext
+        intro x
+        obtain ⟨q, rfl⟩ := CommHopfAlgCat.centerPointwiseQuotientMk_surjective
+          (coordinateHopfAlgebra k n) A x
+        have hmap :
+            CommHopfAlgCat.mapPointwiseQuotient
+                (coordinateHopfAlgebra k n)
+                (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+                (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ
+                (CommHopfAlgCat.centerPointwiseQuotientMk
+                  (coordinateHopfAlgebra k n) A q) =
+              CommHopfAlgCat.centerPointwiseQuotientMk
+                (coordinateHopfAlgebra k n) B
+                (HopfAlgebra.mapPoints (H := coordinateHopfAlgebra k n) φ q) := by
+          rw [CommHopfAlgCat.centerPointwiseQuotientMk_apply,
+            CommHopfAlgCat.centerPointwiseQuotientMk_apply]
+          rw [← CommHopfAlgCat.pointwiseQuotientMk_apply
+              (coordinateHopfAlgebra k n)
+              (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+              (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)),
+            ← CommHopfAlgCat.pointwiseQuotientMk_apply
+              (coordinateHopfAlgebra k n)
+              (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+              (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n))]
+          exact CommHopfAlgCat.mapPointwiseQuotient_mk
+            (coordinateHopfAlgebra k n)
+            (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+            (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) φ q
+        simp only [GrpCat.hom_comp, MonoidHom.comp_apply, ConcreteCategory.hom_ofHom]
+        rw [hmap,
+          centerPointwiseQuotientIsoPGL_hom_mk,
+          centerPointwiseQuotientIsoPGL_hom_mk, Matrix.ProjGenLinGroup.map_mk,
+          HopfAlgebra.mapPoints_apply]
+        exact congrArg Matrix.ProjGenLinGroup.mk (pointsMulEquiv_mapValue n φ.hom q)
+      have hprojective :
+          eqToHom (projectivePointsFunctor_obj n A).symm ≫
+              (projectivePointsFunctor n).map φ =
+            GrpCat.ofHom
+                (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) ≫
+              eqToHom (projectivePointsFunctor_obj n B).symm := by
+        rfl
+      simpa only [Iso.trans_hom, eqToIso.hom,
+        CommHopfAlgCat.pointwiseQuotientFunctor_map, Category.assoc,
+        eqToHom_trans_assoc, eqToHom_refl, Category.id_comp, Category.comp_id,
+        hprojective] using
+        congrArg (fun z =>
+          eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+            (coordinateHopfAlgebra k n)
+            (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+            (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) ≫
+              z ≫ eqToHom (projectivePointsFunctor_obj n B).symm) hbare)
+
+end GeneralLinear
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
@@ -70,6 +70,7 @@ noncomputable def centerPointwiseQuotientIsoPGL (A : CommAlgCat.{u} k) :
 
 /-- The quotient equivalence sends the class of a `GLₙ`-point to the class of its associated
 invertible matrix. -/
+@[simp]
 theorem centerPointwiseQuotientIsoPGL_hom_mk (A : CommAlgCat.{u} k)
     (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
     (centerPointwiseQuotientIsoPGL n A).hom
@@ -90,6 +91,7 @@ theorem centerPointwiseQuotientIsoPGL_hom_mk (A : CommAlgCat.{u} k)
 
 /-- The inverse quotient equivalence sends the class of an invertible matrix to the class of its
 associated `GLₙ`-point. -/
+@[simp]
 theorem centerPointwiseQuotientIsoPGL_inv_mk (A : CommAlgCat.{u} k)
     (g : Matrix.GeneralLinearGroup (Fin n) A) :
     (centerPointwiseQuotientIsoPGL n A).inv (Matrix.ProjGenLinGroup.mk g) =
@@ -211,6 +213,7 @@ noncomputable def centerPointwiseQuotientNatIsoPGL :
 
 /-- After transport to the concrete quotient groups, the hom component of the natural
 identification is the objectwise quotient isomorphism. -/
+@[simp]
 theorem centerPointwiseQuotientNatIsoPGL_hom_app
     (A : CommAlgCat.{u} k) :
     eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
@@ -225,6 +228,7 @@ theorem centerPointwiseQuotientNatIsoPGL_hom_app
 
 /-- After transport to the concrete quotient groups, the inverse component of the natural
 identification is the inverse objectwise quotient isomorphism. -/
+@[simp]
 theorem centerPointwiseQuotientNatIsoPGL_inv_app
     (A : CommAlgCat.{u} k) :
     eqToHom (pglPointsFunctor_obj n A).symm ≫
@@ -239,6 +243,7 @@ theorem centerPointwiseQuotientNatIsoPGL_inv_app
 
 /-- After transport to the concrete quotient groups, the hom component of the natural
 identification sends a quotient class to the class of its associated invertible matrix. -/
+@[simp]
 theorem centerPointwiseQuotientNatIsoPGL_hom_app_mk (A : CommAlgCat.{u} k)
     (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
     eqToHom (pglPointsFunctor_obj n A)
@@ -259,6 +264,7 @@ theorem centerPointwiseQuotientNatIsoPGL_hom_app_mk (A : CommAlgCat.{u} k)
 
 /-- After transport to the concrete quotient groups, the inverse component of the natural
 identification sends the class of an invertible matrix to its associated quotient class. -/
+@[simp]
 theorem centerPointwiseQuotientNatIsoPGL_inv_app_mk (A : CommAlgCat.{u} k)
     (g : Matrix.GeneralLinearGroup (Fin n) A) :
     eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Projective
 public import TauCeti.Algebra.AlgebraicGroup.Center.Quotient
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Center
+public import TauCeti.Algebra.Group.Subgroup.Map
 
 /-!
 # The projective general linear point functor
@@ -51,22 +52,31 @@ theorem map_centerPointsSubgroup_pointsMulEquiv (A : CommAlgCat.{u} k) :
     (CommHopfAlgCat.centerPointsSubgroup (coordinateHopfAlgebra k n) A).map
         (pointsMulEquiv (R := k) (A := A) n) =
       Subgroup.center (Matrix.GeneralLinearGroup (Fin n) A) := by
-  ext g
-  constructor
-  · rintro ⟨q, hq, rfl⟩
+  apply le_antisymm
+  · rintro _ ⟨q, hq, rfl⟩
     have hqcenter :
         q ∈ Subgroup.center
           (HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) := by
       apply HopfAlgebra.center_le_center
       rw [← CommHopfAlgCat.centerPointsSubgroup_eq_center]
       exact hq
-    exact (Subgroup.centerCongr (pointsMulEquiv (R := k) (A := A) n)
-      ⟨q, hqcenter⟩).2
-  · intro hg
+    exact Subgroup.map_center_le (pointsMulEquiv (R := k) (A := A) n)
+      (pointsMulEquiv (R := k) (A := A) n).surjective ⟨q, hqcenter, rfl⟩
+  · by_cases hn : n = 0
+    · subst n
+      intro g _
+      have hg : g = 1 := by
+        apply Matrix.GeneralLinearGroup.ext
+        exact fun i ↦ i.elim0
+      rw [hg]
+      exact Subgroup.one_mem _
+    intro g hg
     rw [Matrix.GeneralLinearGroup.center_eq_range_scalar] at hg
     obtain ⟨a, ha⟩ := hg
     let f := (MultiplicativeGroup.pointsMulEquiv (R := k) (A := A)).symm a
-    refine ⟨scalarTorusPoints n f, scalarTorusPoints_mem_centerPointsSubgroup n f, ?_⟩
+    refine ⟨scalarTorusPoints n f,
+      (mem_centerPointsSubgroup_iff_exists_scalarTorusPoints n
+        (Nat.pos_of_ne_zero hn) A _).2 ⟨f, rfl⟩, ?_⟩
     calc
       pointsMulEquiv n (scalarTorusPoints n f) =
           Matrix.GeneralLinearGroup.scalar (Fin n) a := by
@@ -162,10 +172,10 @@ private theorem projectivePointsFunctor_obj_proof_eq_rfl {R : Type u} [CommRing 
 @[simp]
 theorem projectivePointsFunctor_map {R : Type u} [CommRing R]
     {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
-    eqToHom (projectivePointsFunctor_obj n A).symm ≫
-        (projectivePointsFunctor n).map φ =
-      GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) ≫
-        eqToHom (projectivePointsFunctor_obj n B).symm := by
+    (projectivePointsFunctor n).map φ =
+      eqToHom (projectivePointsFunctor_obj n A) ≫
+        GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) ≫
+          eqToHom (projectivePointsFunctor_obj n B).symm := by
   rw [projectivePointsFunctor_obj_proof_eq_rfl n A,
     projectivePointsFunctor_obj_proof_eq_rfl n B]
   unfold projectivePointsFunctor
@@ -245,7 +255,8 @@ noncomputable def centerPointwiseQuotientNatIsoPGL :
               GrpCat.ofHom
                 (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) ≫
               eqToHom (projectivePointsFunctor_obj n B).symm := by
-        exact projectivePointsFunctor_map n φ
+        rw [projectivePointsFunctor_map]
+        simp
       simpa only [Iso.trans_hom, eqToIso.hom,
         CommHopfAlgCat.pointwiseQuotientFunctor_map, Category.assoc,
         eqToHom_trans_assoc, eqToHom_refl, Category.id_comp, Category.comp_id,
@@ -270,27 +281,6 @@ private theorem centerPointwiseQuotientNatIsoPGL_hom_app_transports
   unfold centerPointwiseQuotientNatIsoPGL
   simp
 
-private theorem centerPointwiseQuotientNatIsoPGL_hom_app_mk_private
-    (A : CommAlgCat.{u} k)
-    (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
-    eqToHom (projectivePointsFunctor_obj n A)
-        ((centerPointwiseQuotientNatIsoPGL n).hom.app A
-          (eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
-              (coordinateHopfAlgebra k n)
-              (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-              (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm
-            (CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A q))) =
-      Matrix.ProjGenLinGroup.mk (pointsMulEquiv (R := k) (A := A) n q) := by
-  change (eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
-        (coordinateHopfAlgebra k n)
-        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
-        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm ≫
-      (centerPointwiseQuotientNatIsoPGL n).hom.app A ≫
-        eqToHom (projectivePointsFunctor_obj n A))
-      (CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A q) = _
-  rw [centerPointwiseQuotientNatIsoPGL_hom_app_transports,
-    centerPointwiseQuotientIsoPGL_hom_mk]
-
 /-- After transport to the concrete quotient groups, the hom component of the natural
 identification sends a quotient class to the class of its associated invertible matrix. -/
 @[simp]
@@ -303,8 +293,41 @@ theorem centerPointwiseQuotientNatIsoPGL_hom_app_mk (A : CommAlgCat.{u} k)
               (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
               (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm
             (CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A q))) =
-      Matrix.ProjGenLinGroup.mk (pointsMulEquiv (R := k) (A := A) n q) :=
-  centerPointwiseQuotientNatIsoPGL_hom_app_mk_private n A q
+      Matrix.ProjGenLinGroup.mk (pointsMulEquiv (R := k) (A := A) n q) := by
+  have h := congrArg
+    (fun f ↦ f (CommHopfAlgCat.centerPointwiseQuotientMk
+      (coordinateHopfAlgebra k n) A q))
+    (centerPointwiseQuotientNatIsoPGL_hom_app_transports n A)
+  simp only [GrpCat.hom_comp, MonoidHom.comp_apply] at h
+  rw [h, centerPointwiseQuotientIsoPGL_hom_mk]
+
+/-- After transport to the concrete quotient groups, the inverse component of the natural
+identification sends the class of an invertible matrix to its associated quotient class. -/
+@[simp]
+theorem centerPointwiseQuotientNatIsoPGL_inv_app_mk (A : CommAlgCat.{u} k)
+    (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A)
+      ((centerPointwiseQuotientNatIsoPGL n).inv.app A
+        (eqToHom (projectivePointsFunctor_obj n A).symm
+          (Matrix.ProjGenLinGroup.mk g))) =
+      CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A
+        ((pointsMulEquiv (R := k) (A := A) n).symm g) := by
+  have htransports :
+      eqToHom (projectivePointsFunctor_obj n A).symm ≫
+          (centerPointwiseQuotientNatIsoPGL n).inv.app A ≫
+        eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+          (coordinateHopfAlgebra k n)
+          (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+          (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) =
+      (centerPointwiseQuotientIsoPGL n A).inv := by
+    unfold centerPointwiseQuotientNatIsoPGL
+    simp
+  have h := congrArg (fun f ↦ f (Matrix.ProjGenLinGroup.mk g)) htransports
+  simp only [GrpCat.hom_comp, MonoidHom.comp_apply] at h
+  rw [h, centerPointwiseQuotientIsoPGL_inv_mk]
 
 end GeneralLinear
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Projective.lean
@@ -115,42 +115,61 @@ theorem centerPointwiseQuotientIsoPGL_hom_mk (A : CommAlgCat.{u} k)
     (pointsMulEquiv (R := k) (A := A) n)
     (map_centerPointsSubgroup_pointsMulEquiv n A) q
 
+/-- The inverse quotient equivalence sends the class of an invertible matrix to the class of its
+associated `GLₙ`-point. -/
+@[simp]
+theorem centerPointwiseQuotientIsoPGL_inv_mk (A : CommAlgCat.{u} k)
+    (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    (centerPointwiseQuotientIsoPGL n A).inv (Matrix.ProjGenLinGroup.mk g) =
+      CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A
+        ((pointsMulEquiv (R := k) (A := A) n).symm g) := by
+  have h := centerPointwiseQuotientIsoPGL_hom_mk n A
+    ((pointsMulEquiv (R := k) (A := A) n).symm g)
+  rw [MulEquiv.apply_symm_apply] at h
+  rw [← h, Iso.hom_inv_id_apply]
+
 /-- The group-valued point functor `A ↦ PGL(n, A)`. -/
-@[expose] noncomputable def projectivePointsFunctor {R : Type u} [CommRing R] :
+noncomputable def projectivePointsFunctor {R : Type u} [CommRing R] :
     CommAlgCat.{u} R ⥤ GrpCat.{u} where
   obj A := GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A)
   map φ := GrpCat.ofHom (Matrix.ProjGenLinGroup.map φ.hom.toRingHom)
   map_id A := by
     apply GrpCat.hom_ext
-    apply MonoidHom.ext
-    intro x
-    induction x using Matrix.ProjGenLinGroup.induction_on with
-    | mk g => simp
+    exact Matrix.ProjGenLinGroup.map_id
   map_comp {A B C} φ ψ := by
     apply GrpCat.hom_ext
-    apply MonoidHom.ext
-    intro x
-    induction x using Matrix.ProjGenLinGroup.induction_on with
-    | mk g =>
-      apply congrArg Matrix.ProjGenLinGroup.mk
-      apply Matrix.GeneralLinearGroup.ext
-      intro i j
-      rfl
+    exact Matrix.ProjGenLinGroup.map_comp φ.hom.toRingHom ψ.hom.toRingHom
+
+private theorem projectivePointsFunctor_obj_private {R : Type u} [CommRing R]
+    (A : CommAlgCat.{u} R) :
+    (projectivePointsFunctor n).obj A =
+      GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A) :=
+  rfl
 
 /-- The objects of `projectivePointsFunctor` are Mathlib's projective general linear groups. -/
 @[simp]
 theorem projectivePointsFunctor_obj {R : Type u} [CommRing R] (A : CommAlgCat.{u} R) :
     (projectivePointsFunctor n).obj A =
       GrpCat.of (Matrix.ProjGenLinGroup (Fin n) A) :=
-  rfl
+  projectivePointsFunctor_obj_private n A
+
+private theorem projectivePointsFunctor_obj_proof_eq_rfl {R : Type u} [CommRing R]
+    (A : CommAlgCat.{u} R) :
+    projectivePointsFunctor_obj n A = rfl :=
+  Subsingleton.elim _ _
 
 /-- The maps of `projectivePointsFunctor` are induced by entrywise extension of scalars. -/
 @[simp]
 theorem projectivePointsFunctor_map {R : Type u} [CommRing R]
     {A B : CommAlgCat.{u} R} (φ : A ⟶ B) :
-    (projectivePointsFunctor n).map φ =
-      GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) :=
-  rfl
+    eqToHom (projectivePointsFunctor_obj n A).symm ≫
+        (projectivePointsFunctor n).map φ =
+      GrpCat.ofHom (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) ≫
+        eqToHom (projectivePointsFunctor_obj n B).symm := by
+  rw [projectivePointsFunctor_obj_proof_eq_rfl n A,
+    projectivePointsFunctor_obj_proof_eq_rfl n B]
+  unfold projectivePointsFunctor
+  simp only [eqToHom_refl, Category.id_comp, Category.comp_id]
 
 /-- The quotient equivalence commutes with extension of scalars in the value algebra. -/
 theorem centerPointwiseQuotientIsoPGL_hom_naturality {A B : CommAlgCat.{u} k} (φ : A ⟶ B) :
@@ -223,10 +242,10 @@ noncomputable def centerPointwiseQuotientNatIsoPGL :
       have hprojective :
           eqToHom (projectivePointsFunctor_obj n A).symm ≫
               (projectivePointsFunctor n).map φ =
-            GrpCat.ofHom
+              GrpCat.ofHom
                 (Matrix.ProjGenLinGroup.map (n := Fin n) φ.hom.toRingHom) ≫
               eqToHom (projectivePointsFunctor_obj n B).symm := by
-        rfl
+        exact projectivePointsFunctor_map n φ
       simpa only [Iso.trans_hom, eqToIso.hom,
         CommHopfAlgCat.pointwiseQuotientFunctor_map, Category.assoc,
         eqToHom_trans_assoc, eqToHom_refl, Category.id_comp, Category.comp_id,
@@ -238,6 +257,54 @@ noncomputable def centerPointwiseQuotientNatIsoPGL :
             (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A) ≫
               z ≫ eqToHom (projectivePointsFunctor_obj n B).symm)
           (centerPointwiseQuotientIsoPGL_hom_naturality n φ))
+
+private theorem centerPointwiseQuotientNatIsoPGL_hom_app_transports
+    (A : CommAlgCat.{u} k) :
+    eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm ≫
+      (centerPointwiseQuotientNatIsoPGL n).hom.app A ≫
+        eqToHom (projectivePointsFunctor_obj n A) =
+      (centerPointwiseQuotientIsoPGL n A).hom := by
+  unfold centerPointwiseQuotientNatIsoPGL
+  simp
+
+private theorem centerPointwiseQuotientNatIsoPGL_hom_app_mk_private
+    (A : CommAlgCat.{u} k)
+    (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
+    eqToHom (projectivePointsFunctor_obj n A)
+        ((centerPointwiseQuotientNatIsoPGL n).hom.app A
+          (eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+              (coordinateHopfAlgebra k n)
+              (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+              (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm
+            (CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A q))) =
+      Matrix.ProjGenLinGroup.mk (pointsMulEquiv (R := k) (A := A) n q) := by
+  change (eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+        (coordinateHopfAlgebra k n)
+        (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+        (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm ≫
+      (centerPointwiseQuotientNatIsoPGL n).hom.app A ≫
+        eqToHom (projectivePointsFunctor_obj n A))
+      (CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A q) = _
+  rw [centerPointwiseQuotientNatIsoPGL_hom_app_transports,
+    centerPointwiseQuotientIsoPGL_hom_mk]
+
+/-- After transport to the concrete quotient groups, the hom component of the natural
+identification sends a quotient class to the class of its associated invertible matrix. -/
+@[simp]
+theorem centerPointwiseQuotientNatIsoPGL_hom_app_mk (A : CommAlgCat.{u} k)
+    (q : HopfAlgebra.points (R := k) (H := coordinateHopfAlgebra k n) A) :
+    eqToHom (projectivePointsFunctor_obj n A)
+        ((centerPointwiseQuotientNatIsoPGL n).hom.app A
+          (eqToHom (CommHopfAlgCat.pointwiseQuotientFunctor_obj
+              (coordinateHopfAlgebra k n)
+              (CommHopfAlgCat.centerDefiningIdeal (coordinateHopfAlgebra k n))
+              (CommHopfAlgCat.isNormal_centerDefiningIdeal (coordinateHopfAlgebra k n)) A).symm
+            (CommHopfAlgCat.centerPointwiseQuotientMk (coordinateHopfAlgebra k n) A q))) =
+      Matrix.ProjGenLinGroup.mk (pointsMulEquiv (R := k) (A := A) n q) :=
+  centerPointwiseQuotientNatIsoPGL_hom_app_mk_private n A q
 
 end GeneralLinear
 


### PR DESCRIPTION
This PR identifies the pointwise quotient of `GLₙ` by its represented center with Mathlib's `Matrix.ProjGenLinGroup`, naturally in the commutative value algebra. It proves that the standard equivalence from Hopf-algebra points to invertible matrices maps the represented center exactly onto the group-theoretic center, lifts that equivalence through both quotients, and packages `A ↦ PGL(n, A)` as a group-valued functor with a natural isomorphism from the existing center-quotient point functor.

This advances the ReductiveGroups Layer 6 milestone “reductive and semisimple groups,” specifically its requirement for central quotients and adjoint forms, and supplies the roadmap's worked-example target `PGLₙ` at the point-functor level.

After this PR, the `PGLₙ` path still needs to identify the fppf sheafification of this pointwise quotient with a represented affine group scheme and prove the resulting group's adjoint-form properties.

The construction reuses Mathlib's `Matrix.ProjGenLinGroup`, `Matrix.ProjGenLinGroup.map`, `QuotientGroup.congr`, and `Matrix.GeneralLinearGroup.center_eq_range_scalar`; no Mathlib infrastructure is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"gln-center-quotient-pgl-points"}-->

🤖 Prepared with Codex
