### PR TITLE
refactor(Multiquadratic): name the unit-norm argument in the narrow relation

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/RamifiedPrime/Narrow.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/RamifiedPrime/Narrow.lean
@@ -174,38 +174,6 @@ theorem exists_nonempty_prod_narrowMk0_eq_one_of_unit
     exact absurd hσγ (hne v)
   · exact hSne
 
-/-- **Without a totally positive associate of `θ`, every unit has norm one.** If no unit `u`
-makes `θ * u` or its negative totally positive, then `u * conj u = 1` for every unit: the
-alternative `u * conj u = -1` would make `θu / conj (θu)` the square `u ^ 2`, and hence exhibit
-the associate the hypothesis denies. -/
-private theorem mul_ringOfIntegersQuadraticConj_unit_eq_one_of_forall_not_isTotallyPositive
-    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
-    (hA : ¬ ∃ u : (𝓞 K)ˣ, IsTotallyPositive ((θ * (u : 𝓞 K) : 𝓞 K) : K) ∨
-      IsTotallyPositive (-((θ * (u : 𝓞 K) : 𝓞 K) : K))) (u : (𝓞 K)ˣ) :
-    (u : 𝓞 K) * ringOfIntegersQuadraticConj hmin hgen (u : 𝓞 K) = 1 := by
-  have hθK : ((θ : 𝓞 K) : K) ≠ 0 := coe_gen_ne_zero hmin
-  rcases mul_ringOfIntegersQuadraticConj_unit_eq_one_or_neg_one hmin hgen u with h | h
-  · exact h
-  · refine absurd ⟨u, ?_⟩ hA
-    -- With `u σu = -1`, the ratio `θu / σ(θu)` is the square `u²`.
-    have huK : ((u : 𝓞 K) : K) ≠ 0 := RingOfIntegers.coe_ne_zero_iff.mpr u.ne_zero
-    have hu' : ((u : 𝓞 K) : K) * quadraticConj hmin hgen ((u : 𝓞 K) : K) = -1 := by
-      simpa [coe_ringOfIntegersQuadraticConj] using congrArg (fun x : 𝓞 K => (x : K)) h
-    have hcjK : quadraticConj hmin hgen ((θ * (u : 𝓞 K) : 𝓞 K) : K) =
-        -(θ : K) * quadraticConj hmin hgen ((u : 𝓞 K) : K) := by
-      push_cast
-      rw [map_mul, quadraticConj_gen hmin hgen]
-    have hcjne : quadraticConj hmin hgen ((u : 𝓞 K) : K) ≠ 0 := fun h0 => by
-      rw [h0, mul_zero] at hu'
-      exact zero_ne_one (neg_eq_zero.mp hu'.symm).symm
-    have hdiv : ((θ * (u : 𝓞 K) : 𝓞 K) : K) /
-        quadraticConj hmin hgen ((θ * (u : 𝓞 K) : 𝓞 K) : K) = ((u : 𝓞 K) : K) ^ 2 := by
-      rw [hcjK, div_eq_iff (by simp [hθK, hcjne])]
-      push_cast
-      linear_combination ((θ : K) * ((u : 𝓞 K) : K)) * hu'
-    exact isTotallyPositive_or_isTotallyPositive_neg_of_isTotallyPositive_div_quadraticConj
-      hmin hgen (by rw [hdiv]; exact isTotallyPositive_sq huK)
-
 /-- **An explicit relation of narrow genus theory.** For `K = ℚ(√d)` with `d` squarefree and
 `1 < |d|`, some *nonempty* set `S` of ramified primes has `∏_{p ∈ S} [𝔭_p]⁺ = 1` in `Cl⁺(K)`.
 
@@ -256,8 +224,11 @@ theorem exists_nonempty_prod_narrowMk0_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C
       intro hTC
       exact hA ⟨1, Or.inl (isTotallyPositive_iff.mpr fun w hw =>
         absurd hw (InfinitePlace.not_isReal_iff_isComplex.mpr (IsTotallyComplex.isComplex w)))⟩
-    have hnormone :=
-      mul_ringOfIntegersQuadraticConj_unit_eq_one_of_forall_not_isTotallyPositive hmin hgen hA
+    have hnormone : ∀ u : (𝓞 K)ˣ,
+        (u : 𝓞 K) * ringOfIntegersQuadraticConj hmin hgen (u : 𝓞 K) = 1 := fun u =>
+      (mul_ringOfIntegersQuadraticConj_unit_eq_one_or_neg_one hmin hgen u).resolve_right
+        fun h => hA ⟨u, isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_neg_one
+          hmin hgen u.ne_zero h⟩
     obtain ⟨ε, hεpos, hεsq⟩ := exists_isTotallyPositive_notMem_square hmin hgen hcomplex hnormone
     refine exists_nonempty_prod_narrowMk0_eq_one_of_unit hmin hgen hprime hover hεpos fun v hv =>
       hεsq ?_

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/RamifiedPrime/Narrow.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/RamifiedPrime/Narrow.lean
@@ -174,6 +174,38 @@ theorem exists_nonempty_prod_narrowMk0_eq_one_of_unit
     exact absurd hσγ (hne v)
   · exact hSne
 
+/-- **Without a totally positive associate of `θ`, every unit has norm one.** If no unit `u`
+makes `θ * u` or its negative totally positive, then `u * conj u = 1` for every unit: the
+alternative `u * conj u = -1` would make `θu / conj (θu)` the square `u ^ 2`, and hence exhibit
+the associate the hypothesis denies. -/
+private theorem mul_ringOfIntegersQuadraticConj_unit_eq_one_of_forall_not_isTotallyPositive
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hA : ¬ ∃ u : (𝓞 K)ˣ, IsTotallyPositive ((θ * (u : 𝓞 K) : 𝓞 K) : K) ∨
+      IsTotallyPositive (-((θ * (u : 𝓞 K) : 𝓞 K) : K))) (u : (𝓞 K)ˣ) :
+    (u : 𝓞 K) * ringOfIntegersQuadraticConj hmin hgen (u : 𝓞 K) = 1 := by
+  have hθK : ((θ : 𝓞 K) : K) ≠ 0 := coe_gen_ne_zero hmin
+  rcases mul_ringOfIntegersQuadraticConj_unit_eq_one_or_neg_one hmin hgen u with h | h
+  · exact h
+  · refine absurd ⟨u, ?_⟩ hA
+    -- With `u σu = -1`, the ratio `θu / σ(θu)` is the square `u²`.
+    have huK : ((u : 𝓞 K) : K) ≠ 0 := RingOfIntegers.coe_ne_zero_iff.mpr u.ne_zero
+    have hu' : ((u : 𝓞 K) : K) * quadraticConj hmin hgen ((u : 𝓞 K) : K) = -1 := by
+      simpa [coe_ringOfIntegersQuadraticConj] using congrArg (fun x : 𝓞 K => (x : K)) h
+    have hcjK : quadraticConj hmin hgen ((θ * (u : 𝓞 K) : 𝓞 K) : K) =
+        -(θ : K) * quadraticConj hmin hgen ((u : 𝓞 K) : K) := by
+      push_cast
+      rw [map_mul, quadraticConj_gen hmin hgen]
+    have hcjne : quadraticConj hmin hgen ((u : 𝓞 K) : K) ≠ 0 := fun h0 => by
+      rw [h0, mul_zero] at hu'
+      exact zero_ne_one (neg_eq_zero.mp hu'.symm).symm
+    have hdiv : ((θ * (u : 𝓞 K) : 𝓞 K) : K) /
+        quadraticConj hmin hgen ((θ * (u : 𝓞 K) : 𝓞 K) : K) = ((u : 𝓞 K) : K) ^ 2 := by
+      rw [hcjK, div_eq_iff (by simp [hθK, hcjne])]
+      push_cast
+      linear_combination ((θ : K) * ((u : 𝓞 K) : K)) * hu'
+    exact isTotallyPositive_or_isTotallyPositive_neg_of_isTotallyPositive_div_quadraticConj
+      hmin hgen (by rw [hdiv]; exact isTotallyPositive_sq huK)
+
 /-- **An explicit relation of narrow genus theory.** For `K = ℚ(√d)` with `d` squarefree and
 `1 < |d|`, some *nonempty* set `S` of ramified primes has `∏_{p ∈ S} [𝔭_p]⁺ = 1` in `Cl⁺(K)`.
 
@@ -224,30 +256,8 @@ theorem exists_nonempty_prod_narrowMk0_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C
       intro hTC
       exact hA ⟨1, Or.inl (isTotallyPositive_iff.mpr fun w hw =>
         absurd hw (InfinitePlace.not_isReal_iff_isComplex.mpr (IsTotallyComplex.isComplex w)))⟩
-    have hnormone : ∀ u : (𝓞 K)ˣ,
-        (u : 𝓞 K) * ringOfIntegersQuadraticConj hmin hgen (u : 𝓞 K) = 1 := by
-      intro u
-      rcases mul_ringOfIntegersQuadraticConj_unit_eq_one_or_neg_one hmin hgen u with h | h
-      · exact h
-      · refine absurd ⟨u, ?_⟩ hA
-        -- With `u σu = -1`, the ratio `θu / σ(θu)` is the square `u²`.
-        have huK : ((u : 𝓞 K) : K) ≠ 0 := RingOfIntegers.coe_ne_zero_iff.mpr u.ne_zero
-        have hu' : ((u : 𝓞 K) : K) * quadraticConj hmin hgen ((u : 𝓞 K) : K) = -1 := by
-          simpa [coe_ringOfIntegersQuadraticConj] using congrArg (fun x : 𝓞 K => (x : K)) h
-        have hcjK : quadraticConj hmin hgen ((θ * (u : 𝓞 K) : 𝓞 K) : K) =
-            -(θ : K) * quadraticConj hmin hgen ((u : 𝓞 K) : K) := by
-          push_cast
-          rw [map_mul, quadraticConj_gen hmin hgen]
-        have hcjne : quadraticConj hmin hgen ((u : 𝓞 K) : K) ≠ 0 := fun h0 => by
-          rw [h0, mul_zero] at hu'
-          exact zero_ne_one (neg_eq_zero.mp hu'.symm).symm
-        have hdiv : ((θ * (u : 𝓞 K) : 𝓞 K) : K) /
-            quadraticConj hmin hgen ((θ * (u : 𝓞 K) : 𝓞 K) : K) = ((u : 𝓞 K) : K) ^ 2 := by
-          rw [hcjK, div_eq_iff (by simp [hθK, hcjne])]
-          push_cast
-          linear_combination ((θ : K) * ((u : 𝓞 K) : K)) * hu'
-        exact isTotallyPositive_or_isTotallyPositive_neg_of_isTotallyPositive_div_quadraticConj
-          hmin hgen (by rw [hdiv]; exact isTotallyPositive_sq huK)
+    have hnormone :=
+      mul_ringOfIntegersQuadraticConj_unit_eq_one_of_forall_not_isTotallyPositive hmin hgen hA
     obtain ⟨ε, hεpos, hεsq⟩ := exists_isTotallyPositive_notMem_square hmin hgen hcomplex hnormone
     refine exists_nonempty_prod_narrowMk0_eq_one_of_unit hmin hgen hprime hover hεpos fun v hv =>
       hεsq ?_

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/RamifiedPrime/Narrow.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/RamifiedPrime/Narrow.lean
@@ -228,7 +228,7 @@ theorem exists_nonempty_prod_narrowMk0_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C
         (u : 𝓞 K) * ringOfIntegersQuadraticConj hmin hgen (u : 𝓞 K) = 1 := fun u =>
       (mul_ringOfIntegersQuadraticConj_unit_eq_one_or_neg_one hmin hgen u).resolve_right
         fun h => hA ⟨u, isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_neg_one
-          hmin hgen u.ne_zero h⟩
+          hmin hgen h⟩
     obtain ⟨ε, hεpos, hεsq⟩ := exists_isTotallyPositive_notMem_square hmin hgen hcomplex hnormone
     refine exists_nonempty_prod_narrowMk0_eq_one_of_unit hmin hgen hprime hover hεpos fun v hv =>
       hεsq ?_

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Units.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Units.lean
@@ -64,8 +64,10 @@ sign at every real place. The extra factor `θ` is what absorbs the sign that th
 not have to. -/
 theorem isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_neg_one
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) {u : 𝓞 K}
-    (hu : u ≠ 0) (hnorm : u * ringOfIntegersQuadraticConj hmin hgen u = -1) :
+    (hnorm : u * ringOfIntegersQuadraticConj hmin hgen u = -1) :
     IsTotallyPositive ((θ * u : 𝓞 K) : K) ∨ IsTotallyPositive (-((θ * u : 𝓞 K) : K)) := by
+  -- `u = 0` would make the norm `0`, not `-1`.
+  have hu : u ≠ 0 := by rintro rfl; simp at hnorm
   have hθK : ((θ : 𝓞 K) : K) ≠ 0 := coe_gen_ne_zero hmin
   have huK : (u : K) ≠ 0 := RingOfIntegers.coe_ne_zero_iff.mpr hu
   have hu' : (u : K) * quadraticConj hmin hgen (u : K) = -1 := by

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Units.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Units.lean
@@ -57,6 +57,34 @@ theorem isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_one
   rw [hdiv]
   exact isTotallyPositive_sq huK
 
+/-- **A nonzero element of norm minus one makes `θ` times it `±` totally positive.** The `-1`
+companion of `isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_one`: when
+`u σu = -1` the ratio `θu / σ(θu)` is the square `u ^ 2`, so `θu` and its conjugate have the same
+sign at every real place. The extra factor `θ` is what absorbs the sign that the `+1` case does
+not have to. -/
+theorem isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_neg_one
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) {u : 𝓞 K}
+    (hu : u ≠ 0) (hnorm : u * ringOfIntegersQuadraticConj hmin hgen u = -1) :
+    IsTotallyPositive ((θ * u : 𝓞 K) : K) ∨ IsTotallyPositive (-((θ * u : 𝓞 K) : K)) := by
+  have hθK : ((θ : 𝓞 K) : K) ≠ 0 := coe_gen_ne_zero hmin
+  have huK : (u : K) ≠ 0 := RingOfIntegers.coe_ne_zero_iff.mpr hu
+  have hu' : (u : K) * quadraticConj hmin hgen (u : K) = -1 := by
+    simpa [coe_ringOfIntegersQuadraticConj] using congrArg (fun x : 𝓞 K => (x : K)) hnorm
+  have hcjK : quadraticConj hmin hgen ((θ * u : 𝓞 K) : K) =
+      -(θ : K) * quadraticConj hmin hgen (u : K) := by
+    push_cast
+    rw [map_mul, quadraticConj_gen hmin hgen]
+  have hcjne : quadraticConj hmin hgen (u : K) ≠ 0 := fun h0 => by
+    rw [h0, mul_zero] at hu'
+    exact zero_ne_one (neg_eq_zero.mp hu'.symm).symm
+  have hdiv : ((θ * u : 𝓞 K) : K) /
+      quadraticConj hmin hgen ((θ * u : 𝓞 K) : K) = (u : K) ^ 2 := by
+    rw [hcjK, div_eq_iff (by simp [hθK, hcjne])]
+    push_cast
+    linear_combination ((θ : K) * (u : K)) * hu'
+  exact isTotallyPositive_or_isTotallyPositive_neg_of_isTotallyPositive_div_quadraticConj
+    hmin hgen (by rw [hdiv]; exact isTotallyPositive_sq huK)
+
 open scoped Pointwise in
 /-- **A real quadratic field with no unit of norm `-1` has a totally positive unit that is not a
 square.** With every unit of norm one, every unit is `±` a totally positive unit


### PR DESCRIPTION
Name the `-1` case of the quadratic norm dichotomy, and use it to shorten the narrow relation.

## What the lemma is

`Conjugation/Units.lean` already carries **the `+1` case**:
`isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_one` — a nonzero element of norm
one is `±` totally positive. Its `-1` companion was written out inside
`exists_nonempty_prod_narrowMk0_eq_one`, buried under that proof's case analysis. It now sits
beside its sibling:

```
isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_neg_one
    (hmin …) (hgen …) {u : 𝓞 K}
    (hnorm : u * ringOfIntegersQuadraticConj hmin hgen u = -1) :
    IsTotallyPositive ((θ * u : 𝓞 K) : K) ∨ IsTotallyPositive (-((θ * u : 𝓞 K) : K))
```

When `u σu = -1` the ratio `θu / σ(θu)` is the square `u ^ 2`, so `θu` and its conjugate agree in
sign at every real place. The extra factor `θ` is what absorbs the sign the `+1` case does not
have to.

Stated for an **element**, not a unit: the unit structure was never used. Nonzeroness is not a
hypothesis either — `u * σu = -1` already forces it, so it is derived in one line inside the proof.

(The `+1` sibling carries the same redundant `u ≠ 0`. Removing it there is a signature change to
merged code with its own call site, so it is left for a separate one-topic change rather than
bundled into this one.)

## What moved

| | before | after |
|---|---|---|
| `exists_nonempty_prod_narrowMk0_eq_one` body | 62 lines | **43 lines** |
| `…_eq_neg_one` (new, in `Conjugation/Units.lean`) | — | 18 lines |

The theorem's negative branch needs "every unit has norm one". That is now derived where the
negated existential actually lives, in four lines:

```lean
have hnormone : ∀ u : (𝓞 K)ˣ,
    (u : 𝓞 K) * ringOfIntegersQuadraticConj hmin hgen (u : 𝓞 K) = 1 := fun u =>
  (mul_ringOfIntegersQuadraticConj_unit_eq_one_or_neg_one hmin hgen u).resolve_right
    fun h => hA ⟨u, isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_neg_one
      hmin hgen h⟩
```

resolving the existing dichotomy `mul_ringOfIntegersQuadraticConj_unit_eq_one_or_neg_one` against
the new lemma. `hnormone` feeds `exists_isTotallyPositive_notMem_square` and the later `hnormone v`
unchanged.

## Placement

`Conjugation/Units.lean`, immediately after the `+1` case whose dichotomy it completes. Nothing in
the statement mentions ramified primes or narrow class groups, so the multiquadratic file was the
wrong home for it; `Narrow.lean` already imported this module.

## Notes for review

- No new imports.
- Gate: `lake build` of `Conjugation.Units`, `RamifiedPrime.Narrow` and its importer
  `Quadratic.TwoRank` — **3558 jobs, exit 0, zero warnings**.

Roadmap: Multiquadratic
