### PR TITLE
feat(Huber): the unit group is open, and maximal ideals are closed

### DIFF
--- a/TauCeti/RingTheory/Huber/UnitGroup.lean
+++ b/TauCeti/RingTheory/Huber/UnitGroup.lean
@@ -5,9 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Algebra.Ring.Ideal
 public import TauCeti.RingTheory.Huber.RingOfDefinition
 public import TauCeti.Topology.Algebra.Nonarchimedean.GeometricSeries
+public import TauCeti.Topology.Algebra.Ring.MaximalIdeals
 
 /-!
 # The unit group of a complete Huber ring is open, and maximal ideals are closed
@@ -21,8 +21,8 @@ The argument is Wedhorn's. The topologically nilpotent elements of a Huber ring 
 (`TauCeti.Huber.isOpen_setOf_isTopologicallyNilpotent`), and completeness makes `1 + A°°` consist
 of units (`IsTopologicallyNilpotent.isUnit_one_add`). Around a unit `u` the set of `x` with
 `u⁻¹x - 1` topologically nilpotent is then an open neighbourhood of `u` made of units, so the unit
-group is open. Its complement is therefore closed and contains every proper ideal, so the closure
-of a maximal ideal is again a proper ideal containing it, hence equal to it by maximality.
+group is open. Closedness of maximal ideals is then immediate from
+`Ideal.isClosed_of_isMaximal_of_isOpen_isUnit`, which holds over any topological ring.
 
 ## Why this does not assume a linear topology
 
@@ -40,23 +40,19 @@ form of Proposition 7.51 that survives the Tate case.
 
 ## Main results
 
-* `Ideal.isClosed_of_isMaximal_of_isOpen_isUnit` : over any topological ring, a maximal ideal is
-  closed as soon as the unit group is open. This is the general engine and mentions neither
-  completeness nor a Huber structure.
 * `TauCeti.Huber.isOpen_setOf_isUnit` : the unit group of a complete Huber ring is open.
 * `TauCeti.Huber.isClosed_of_isMaximal` : **Wedhorn Proposition 7.51, closedness half** — every
   maximal ideal of a complete Huber ring is closed.
 
 ## Provenance
 
-Adapted from AINTLIB (see References), section `MaximalIdealClosed` and section `OpenUnits` of the
-source file, which has both statements as `isClosed_of_isMaximal_of_isOpen_units` and
-`isOpen_units_of_isOpen_topologicallyNilpotent`. The closedness argument is that file's, essentially
-verbatim.
+Adapted from AINTLIB (see References), section `OpenUnits` of the source file, where the statement
+is `isOpen_units_of_isOpen_topologicallyNilpotent`. (That file's other half, the closedness
+argument, is carried over in `TauCeti.Topology.Algebra.Ring.MaximalIdeals`.)
 
-The openness argument is **not**, and the difference is the point of this file. AINTLIB covers a
-unit `u` by the additive translate `u + A°°`, which forces it to rewrite `u + a = u * (1 + u⁻¹a)`
-and to know that `u⁻¹a` is again topologically nilpotent — that is
+The openness argument is **not** taken over verbatim, and the difference is the point of this
+file. AINTLIB covers a unit `u` by the additive translate `u + A°°`, which forces it to rewrite
+`u + a = u * (1 + u⁻¹a)` and to know that `u⁻¹a` is again topologically nilpotent — that is
 `IsTopologicallyNilpotent.mul_left`, which Mathlib states only under `[IsLinearTopology R R]`, so
 AINTLIB carries that hypothesis. It is not removable there: in a Tate ring `A°°` is not an ideal,
 and `ℚ_p` is a counterexample, with `p` topologically nilpotent but `p⁻² * p = p⁻¹` not. The
@@ -79,21 +75,6 @@ discharged rather than carried, and the Huber-level statements need no side cond
 public section
 
 open Topology
-
-/-- **A maximal ideal of a topological ring is closed once the unit group is open.** The closure
-of `𝔪` is an ideal containing `𝔪`, and it is proper because it avoids the units — the units are
-open, so their complement is a closed set containing `𝔪` and hence its closure. Maximality then
-forces the closure to be `𝔪` itself. -/
-theorem Ideal.isClosed_of_isMaximal_of_isOpen_isUnit {A : Type*} [CommRing A]
-    [TopologicalSpace A] [IsTopologicalRing A] (hU : IsOpen {a : A | IsUnit a}) (𝔪 : Ideal A)
-    [𝔪.IsMaximal] : IsClosed (𝔪 : Set A) := by
-  rw [← closure_eq_iff_isClosed, ← Ideal.coe_closure]
-  congr 1
-  have hne : 𝔪.closure ≠ ⊤ := by
-    rw [Ideal.ne_top_iff_one]
-    exact fun h1 ↦ (closure_minimal (fun x hx ↦ mt (Ideal.eq_top_of_isUnit_mem 𝔪 hx)
-      (Ideal.IsMaximal.ne_top ‹_›)) hU.isClosed_compl h1) isUnit_one
-  exact (Ideal.IsMaximal.eq_of_le ‹_› hne fun x hx ↦ subset_closure hx).symm
 
 namespace TauCeti.Huber
 

--- a/TauCeti/RingTheory/Huber/UnitGroup.lean
+++ b/TauCeti/RingTheory/Huber/UnitGroup.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Ring.Ideal
+public import TauCeti.RingTheory.Huber.RingOfDefinition
+public import TauCeti.Topology.Algebra.Nonarchimedean.GeometricSeries
+
+/-!
+# The unit group of a complete Huber ring is open, and maximal ideals are closed
+
+This is the first half of Wedhorn's Proposition 7.51, whose statement is "*then `𝔪` is closed
+and there exists `v ∈ Spa A` with `supp v = 𝔪`*". Only the closedness conjunct is proved here;
+the existence conjunct needs nonemptiness of the adic spectrum (Wedhorn Proposition 7.49), which
+is a separate development.
+
+The argument is Wedhorn's. The topologically nilpotent elements of a Huber ring form an open set
+(`TauCeti.Huber.isOpen_setOf_isTopologicallyNilpotent`), and completeness makes `1 + A°°` consist
+of units (`IsTopologicallyNilpotent.isUnit_one_add`). Around a unit `u` the set of `x` with
+`u⁻¹x - 1` topologically nilpotent is then an open neighbourhood of `u` made of units, so the unit
+group is open. Its complement is therefore closed and contains every proper ideal, so the closure
+of a maximal ideal is again a proper ideal containing it, hence equal to it by maximality.
+
+## Why this does not assume a linear topology
+
+`TauCeti.Topology.Algebra.Nonarchimedean.MaximalIdeals` proves the *openness* of maximal ideals, and
+everything in it carries `[IsLinearTopology A A]` — a basis of neighbourhoods of zero consisting of
+ideals. That is not incidental. An open ideal of a Tate ring is the whole ring
+(`TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`), so no *proper* ideal of a nonzero Tate ring is open
+and the results in that file are adic-only; over `ℚ_p`, `IsTopologicallyNilpotent.mem_of_isMaximal`
+would otherwise put `p` in the zero ideal.
+
+Closedness carries no such hypothesis, so it is available for every complete Huber ring, Tate ones
+included. Getting there does take a different argument from the linear-topology one — see the
+Provenance section — but the resulting statements are hypothesis-free, which is what makes this the
+form of Proposition 7.51 that survives the Tate case.
+
+## Main results
+
+* `Ideal.isClosed_of_isMaximal_of_isOpen_isUnit` : over any topological ring, a maximal ideal is
+  closed as soon as the unit group is open. This is the general engine and mentions neither
+  completeness nor a Huber structure.
+* `TauCeti.Huber.isOpen_setOf_isUnit` : the unit group of a complete Huber ring is open.
+* `TauCeti.Huber.isClosed_of_isMaximal` : **Wedhorn Proposition 7.51, closedness half** — every
+  maximal ideal of a complete Huber ring is closed.
+
+## Provenance
+
+Adapted from AINTLIB (see References), section `MaximalIdealClosed` and section `OpenUnits` of the
+source file, which has both statements as `isClosed_of_isMaximal_of_isOpen_units` and
+`isOpen_units_of_isOpen_topologicallyNilpotent`. The closedness argument is that file's, essentially
+verbatim.
+
+The openness argument is **not**, and the difference is the point of this file. AINTLIB covers a
+unit `u` by the additive translate `u + A°°`, which forces it to rewrite `u + a = u * (1 + u⁻¹a)`
+and to know that `u⁻¹a` is again topologically nilpotent — that is
+`IsTopologicallyNilpotent.mul_left`, which Mathlib states only under `[IsLinearTopology R R]`, so
+AINTLIB carries that hypothesis. It is not removable there: in a Tate ring `A°°` is not an ideal,
+and `ℚ_p` is a counterexample, with `p` topologically nilpotent but `p⁻² * p = p⁻¹` not. The
+hypothesis is load bearing for that route, not an oversight.
+
+The proof here covers `u` by the *multiplicative* neighbourhood `{x : u⁻¹x - 1 ∈ A°°}` instead. That
+needs only continuity of `x ↦ u⁻¹x - 1` and the geometric series, never that `A°°` absorbs
+multiplication, so it holds with no linear-topology hypothesis at all and therefore applies to Tate
+rings. Separately, this repository already has
+`TauCeti.Huber.isOpen_setOf_isTopologicallyNilpotent`, so AINTLIB's `A°°`-openness hypothesis is
+discharged rather than carried, and the Huber-level statements need no side conditions.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Propositions 5.38, 7.51.
+* [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
+  commit `37bbdaeb`, `projects/AdicSpaces/Adic spaces/AdicSpectrum.lean`.
+-/
+
+public section
+
+open Topology
+
+/-- **A maximal ideal of a topological ring is closed once the unit group is open.** The closure
+of `𝔪` is an ideal containing `𝔪`, and it is proper because it avoids the units — the units are
+open, so their complement is a closed set containing `𝔪` and hence its closure. Maximality then
+forces the closure to be `𝔪` itself. -/
+theorem Ideal.isClosed_of_isMaximal_of_isOpen_isUnit {A : Type*} [CommRing A]
+    [TopologicalSpace A] [IsTopologicalRing A] (hU : IsOpen {a : A | IsUnit a}) (𝔪 : Ideal A)
+    [𝔪.IsMaximal] : IsClosed (𝔪 : Set A) := by
+  rw [← closure_eq_iff_isClosed, ← Ideal.coe_closure]
+  congr 1
+  have hne : 𝔪.closure ≠ ⊤ := by
+    rw [Ideal.ne_top_iff_one]
+    exact fun h1 ↦ (closure_minimal (fun x hx ↦ mt (Ideal.eq_top_of_isUnit_mem 𝔪 hx)
+      (Ideal.IsMaximal.ne_top ‹_›)) hU.isClosed_compl h1) isUnit_one
+  exact (Ideal.IsMaximal.eq_of_le ‹_› hne fun x hx ↦ subset_closure hx).symm
+
+namespace TauCeti.Huber
+
+variable {A : Type*} [CommRing A] [UniformSpace A] [T2Space A] [CompleteSpace A]
+  [IsTopologicalRing A] [IsUniformAddGroup A] [IsHuberRing A]
+
+/-- **The unit group of a complete Huber ring is open.** Around a unit `u` the set of `x` with
+`u⁻¹x - 1` topologically nilpotent is an open neighbourhood of `u` consisting of units: it is open
+because `A°°` is and `x ↦ u⁻¹x - 1` is continuous, it contains `u` because `u⁻¹u - 1 = 0`, and each
+of its points is a unit because `u⁻¹x = 1 + (u⁻¹x - 1)` is one by the geometric series
+(Proposition 5.38) and `x = u * (u⁻¹x)`. -/
+theorem isOpen_setOf_isUnit : IsOpen {a : A | IsUnit a} := by
+  rw [isOpen_iff_forall_mem_open]
+  rintro u hu
+  obtain ⟨u, rfl⟩ := (hu : IsUnit u)
+  refine ⟨(fun x : A ↦ (↑u⁻¹ : A) * x - 1) ⁻¹' {a : A | IsTopologicallyNilpotent a},
+    fun x hx ↦ ?_, ?_, ?_⟩
+  · have h1 : IsUnit ((↑u⁻¹ : A) * x) := by
+      simpa using (hx : IsTopologicallyNilpotent ((↑u⁻¹ : A) * x - 1)).isUnit_one_add
+    simpa [← mul_assoc, u.mul_inv] using u.isUnit.mul h1
+  · exact isOpen_setOf_isTopologicallyNilpotent.preimage
+      ((continuous_const.mul continuous_id).sub continuous_const)
+  · simp only [Set.mem_preimage, Set.mem_ofPred_eq, u.inv_mul, sub_self]
+    exact IsTopologicallyNilpotent.zero
+
+/-- **Wedhorn Proposition 7.51, closedness half**: every maximal ideal of a complete Huber ring
+is closed. Wedhorn states it for a complete affinoid ring; the affinoid `A⁺` plays no part in the
+argument, so the plus subring is absent here. -/
+theorem isClosed_of_isMaximal (𝔪 : Ideal A) [𝔪.IsMaximal] : IsClosed (𝔪 : Set A) :=
+  Ideal.isClosed_of_isMaximal_of_isOpen_isUnit isOpen_setOf_isUnit 𝔪
+
+end TauCeti.Huber
+
+end

--- a/TauCeti/Topology/Algebra/Ring/MaximalIdeals.lean
+++ b/TauCeti/Topology/Algebra/Ring/MaximalIdeals.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Ideal.Maximal
+public import Mathlib.Topology.Algebra.Ring.Ideal
+
+/-!
+# Maximal ideals of a topological ring with open unit group
+
+A maximal ideal of a topological ring is closed as soon as the unit group is open. The closure of
+`𝔪` is again an ideal, and it is proper because the units are open, so their complement is a closed
+set containing `𝔪` and hence containing its closure; maximality then forces that closure to be `𝔪`.
+
+Openness of the unit group is the only topological input, and it stays a hypothesis so that any
+route to it can consume this lemma. `TauCeti.RingTheory.Huber.UnitGroup` supplies one for complete
+Huber rings and reads Wedhorn's Proposition 7.51 off it, but nothing here mentions completeness, a
+nonarchimedean topology, or commutativity: `Ideal A` is the lattice of left ideals of a ring `A`,
+and a proper left ideal already avoids the units.
+
+Contrast `TauCeti.Topology.Algebra.Nonarchimedean.MaximalIdeals`, which proves maximal ideals
+*open*. That argument needs a linear topology and is vacuous for a Tate ring, where no proper ideal
+is open; closedness is the form that survives.
+
+## Main results
+
+* `Ideal.isClosed_of_isMaximal_of_isOpen_isUnit` : a maximal ideal of a topological ring is closed
+  once the unit group is open.
+
+## Provenance
+
+Adapted from AINTLIB (see References), section `MaximalIdealClosed` of the source file, where the
+statement is `isClosed_of_isMaximal_of_isOpen_units`. The argument is that file's, essentially
+verbatim; only the commutativity hypothesis is dropped.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Proposition 7.51.
+* [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
+  commit `37bbdaeb`, `projects/AdicSpaces/Adic spaces/AdicSpectrum.lean`.
+-/
+
+public section
+
+/-- **A maximal ideal of a topological ring is closed once the unit group is open.** The closure
+of `𝔪` is an ideal containing `𝔪`, and it is proper because it avoids the units — the units are
+open, so their complement is a closed set containing `𝔪` and hence its closure. Maximality then
+forces the closure to be `𝔪` itself. -/
+theorem Ideal.isClosed_of_isMaximal_of_isOpen_isUnit {A : Type*} [Ring A] [TopologicalSpace A]
+    [IsTopologicalRing A] (hU : IsOpen {a : A | IsUnit a}) (𝔪 : Ideal A) [𝔪.IsMaximal] :
+    IsClosed (𝔪 : Set A) := by
+  rw [← closure_eq_iff_isClosed, ← Ideal.coe_closure]
+  congr 1
+  have hne : 𝔪.closure ≠ ⊤ := by
+    rw [Ideal.ne_top_iff_one]
+    exact fun h1 ↦ (closure_minimal (fun x hx ↦ mt (Ideal.eq_top_of_isUnit_mem 𝔪 hx)
+      (Ideal.IsMaximal.ne_top ‹_›)) hU.isClosed_compl h1) isUnit_one
+  exact (Ideal.IsMaximal.eq_of_le ‹_› hne fun x hx ↦ subset_closure hx).symm
+
+end


### PR DESCRIPTION
The unit group of a complete Huber ring is open, and consequently every maximal ideal of such a
ring is closed. This is the **closedness half of Wedhorn Proposition 7.51** — whose statement is
"*then `𝔪` is closed and there exists `v ∈ Spa A` with `supp v = 𝔪`*". Only that first conjunct
is proved here; the existence conjunct needs nonemptiness of the adic spectrum (Proposition 7.49)
and is a separate development.

Roadmap: AdicSpaces

## Why this is in scope

Proposition 7.51 is **not** named in `AdicSpaces/README.md`, and I am not claiming it is. This
lands as a *prerequisite that named targets need*:

* `README.md:415` — "State Proposition 7.52(2), the complete-case unit criterion, separately."
* `README.md:392` — "Corollary 7.53: if `T` is a finite subset of a complete Hausdorff affinoid
  ring, then `T` generates the unit ideal if and only if the standard family covers `Spa(A,A⁺)`."

In Wedhorn both are reformulations of 7.51, and both are already partly on `main`
(`isUnit_of_forall_not_vle_zero`, `span_eq_top_iff_forall_mem_spa_exists_not_vle_zero`). The
existing route to them runs through *openness* of maximal ideals, which is vacuous for exactly the
rings the roadmap targets — see below. Closedness is the half of 7.51 that survives.

## The point: this is the Tate-compatible statement

`TauCeti/Topology/Algebra/Nonarchimedean/MaximalIdeals.lean` proves maximal ideals are **open**, and
every declaration in it carries `[IsLinearTopology A A]`. That is not incidental. An open ideal of a
Tate ring is the whole ring (`IsTateRing.isOpen_iff_eq_top`), so no *proper* ideal of a nonzero Tate
ring is open, and that file is adic-only — it cannot be repaired for the Tate case. (Sanity check:
over `ℚ_p`, `IsTopologicallyNilpotent.mem_of_isMaximal` would otherwise put `p` in the zero ideal.)

Closedness needs no linear topology, so it holds for every complete Huber ring, Tate ones included.

## Contents

**`TauCeti/Topology/Algebra/Ring/MaximalIdeals.lean`** (new, beside the existing `Ring/Subring.lean`)

* `Ideal.isClosed_of_isMaximal_of_isOpen_isUnit` — over any topological ring, a maximal ideal is
  closed as soon as the unit group is open. The general engine; mentions neither completeness nor a
  Huber structure, so anyone who obtains unit-openness another way can reuse it.

**`TauCeti/RingTheory/Huber/UnitGroup.lean`**

* `TauCeti.Huber.isOpen_setOf_isUnit` — the unit group of a complete Huber ring is open.
* `TauCeti.Huber.isClosed_of_isMaximal` — Wedhorn 7.51, closedness half.

## Provenance, and the one real adaptation

Adapted from AINTLIB (`github.com/CBirkbeck/AINTLIB`, branch `dev/adic-spaces`, commit `37bbdaeb`,
`projects/AdicSpaces/Adic spaces/AdicSpectrum.lean`), sections `MaximalIdealClosed` and `OpenUnits`,
which have both statements as `isClosed_of_isMaximal_of_isOpen_units` and
`isOpen_units_of_isOpen_topologicallyNilpotent`. **The closedness argument is that file's,
essentially verbatim.**

The openness argument is **not**, and this is the substance of the PR rather than a hypothesis
deletion. AINTLIB covers a unit `u` by the *additive* translate `u + A°°`, which forces it to
rewrite `u + a = u * (1 + u⁻¹a)` and hence to know that `u⁻¹a` is again topologically nilpotent.
That is `IsTopologicallyNilpotent.mul_left`, which Mathlib states only under
`[IsLinearTopology R R]`, so AINTLIB carries that hypothesis — and it is **not removable on that
route**: in a Tate ring `A°°` is not an ideal, with `ℚ_p` a counterexample (`p` is topologically
nilpotent, `p⁻² * p = p⁻¹` is not).

This proof covers `u` by the *multiplicative* neighbourhood `{x : u⁻¹x - 1 ∈ A°°}` instead. It needs
only continuity of `x ↦ u⁻¹x - 1` and the geometric series, never that `A°°` absorbs multiplication,
so it carries no linear-topology hypothesis and therefore reaches Tate rings.

Separately, `main` already has `TauCeti.Huber.isOpen_setOf_isTopologicallyNilpotent`, so AINTLIB's
`A°°`-openness hypothesis is discharged rather than carried and the two Huber-level statements take
no side conditions at all.

## Reuse

`Ideal.closure` / `Ideal.coe_closure` are Mathlib's (`Mathlib/Topology/Algebra/Ring/Ideal.lean`),
used in preference to the more general `Submodule.topologicalClosure`. The geometric-series input is
`main`'s existing `IsTopologicallyNilpotent.isUnit_one_add`, whose own docstring already anticipates
this file — "*the units of a complete nonarchimedean ring contain the coset `1 + A°°`, which is what
makes the unit group open*". `[NonarchimedeanAddGroup A]` is deliberately absent from the variable
block: `IsHuberRing.toNonarchimedeanRing` already supplies it, and the `overlappingInstances` linter
rejects carrying both.

## Review follow-ups (round 1)

Round 1 was 8/10 green, with `generality` and `placement` both pointing at
`Ideal.isClosed_of_isMaximal_of_isOpen_isUnit` and at nothing else. Both are fixed, neither is
contested.

**placement.** The opening round asked the rubric directly — *"if the placement rubric prefers a
topology-level home, say so and I will split it out"* — and it did. The theorem now lives in the new
`TauCeti/Topology/Algebra/Ring/MaximalIdeals.lean`, beside `Ring/Subring.lean`, and took its
`Mathlib.Topology.Algebra.Ring.Ideal` import with it; `Huber/UnitGroup.lean` imports that file
instead of that Mathlib module. It is still **not** merged into
`Topology/Algebra/Nonarchimedean/MaximalIdeals.lean`: that file's variable block carries the
`[IsLinearTopology A A]` this result must avoid, and weakening it there would disturb the two
adic-only theorems it exists to state. Instead, `Huber/UnitGroup.lean` and the new file
cross-reference each other, and the new file additionally points at that adic-only open-ideal result
and says why closedness is the form that survives the Tate case.

**generality.** The signature assumed `[CommRing A]`; it is now `[Ring A]`. Commutativity was never
used, and the bound is set by `Ideal.closure` / `Ideal.coe_closure`, which Mathlib states for
`[Ring R] [IsTopologicalRing R]`. Everything else the proof touches —
`Ideal.eq_top_of_isUnit_mem`, `Ideal.ne_top_iff_one`, `Ideal.IsMaximal.ne_top`,
`Ideal.IsMaximal.eq_of_le` — is `[Semiring α]`. `Ideal A` is the lattice of *left* ideals of a ring,
and a proper left ideal already avoids the units, since `eq_top_of_isUnit_mem` goes through
`IsUnit.exists_left_inv`. So the result now covers noncommutative topological rings; the Huber
consumer is unaffected, as it supplies `[CommRing A]`.

Docstrings and provenance split along the same line: AINTLIB's `MaximalIdealClosed` attribution
follows the theorem into the new file, and `OpenUnits` stays with the openness argument above.

