### PR TITLE
refactor(ModularForms): stop unfolding Mathlib definitions in isBoundedAtImInfty_galoisProd

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/GaloisProd.lean
+++ b/TauCeti/NumberTheory/ModularForms/GaloisProd.lean
@@ -103,7 +103,7 @@ ring. -/
 lemma isBoundedAtImInfty_galoisProd {R : Type*} [SeminormedCommRing R] {N : ℕ} {f : ℍ → R}
     (hf_bdd : IsBoundedAtImInfty f) :
     IsBoundedAtImInfty (galoisProd N f) := by
-  unfold galoisProd IsBoundedAtImInfty Filter.BoundedAtFilter
+  unfold galoisProd
   rw [← Finset.prod_fn]
   refine Filter.BoundedAtFilter.prod _ fun j _ ↦ hf_bdd.comp_tendsto ?_
   simp only [atImInfty, Filter.tendsto_comap_iff, Function.comp_def]


### PR DESCRIPTION
`isBoundedAtImInfty_galoisProd` opened with

```lean
unfold galoisProd IsBoundedAtImInfty Filter.BoundedAtFilter
```

reaching through two **Mathlib** definitions to expose the `=O` behind them. Neither unfold is
needed.

`UpperHalfPlane.IsBoundedAtImInfty f` is *defined* as `Filter.BoundedAtFilter atImInfty f`
(`Mathlib/Analysis/Complex/UpperHalfPlane/FunctionsBoundedAtInfty.lean:46`), so the
`Filter.BoundedAtFilter.prod` two lines further down already applies to the goal as stated, and
`refine` sees through both definitions on its own. Dropping them changes nothing else in the
proof.

`galoisProd` — Tau Ceti's own definition — is still unfolded, because the
`rw [← Finset.prod_fn]` immediately below needs the product in function form, and the file
records at `:53` that `galoisProd` deliberately has no equation lemma to rewrite with. So this
PR does not touch that.

## Why this one line and not others

Unfolding a *Mathlib* definition inside a Tau Ceti proof reaches past the API into a body the
proof does not own; unfolding a Tau Ceti definition is a much weaker thing and is often the
intended route. I surveyed every `unfold` under `TauCeti/NumberTheory/ModularForms/` before
picking: with this change in, **all of them target a Tau Ceti definition** — `levelRaise`,
`galoisProd`, `fdBoundary*`, `restProd`, `normRest`, `orderAtCusp`, `orderOfVanishingAt`,
`canonicalReps`, `qExpansionLinearMap` and friends. `IsBoundedAtImInfty` and
`Filter.BoundedAtFilter` were the only Mathlib ones in the tree, so this is the complete fix for
that pattern here rather than one arbitrary instance of it.

## Gate

`lake build` of the changed module and its direct importer (`Norm/Trace.lean`) — 3051 jobs, no
errors, warnings or sorries.

## Scope

Improvement to code already on `main`, which
[`.claude/CLAUDE.md`](https://github.com/TauCetiProject/TauCeti/blob/main/.claude/CLAUDE.md)
puts in scope without a roadmap entry. No statement changes; no declaration added, renamed or
removed.

Roadmap: ModularForms
