### PR TITLE
feat(MordellWeil): the weak Mordell-Weil theorem, E(K)/2E(K) is finite

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
@@ -145,15 +145,7 @@ lemma mem_selmerGroupA_iff (m : W.M) :
 /-- **`A(S,2)` is finite**, given that each factor's ring of integers has finite class group and
 finitely generated unit group.
 
-Immediate from `IsDedekindDomain.finite_selmerGroupOfEquiv`, because `selmerGroupA` *is* a
-`selmerGroupOfEquiv`: there are finitely many factors, since `f` has finitely many monic
-irreducible divisors, and finitely many relevant primes, since finitely many lie above the
-finitely many bad primes.
-
-Stated here rather than beside the weak Mordell-Weil theorem that consumes it: `selmerGroupA` is
-not `@[expose]`, so downstream the goal `Finite (selmerGroupA R)` and the conclusion of
-`finite_selmerGroupOfEquiv` are not visibly the same type, and closing that gap costs an
-`isDefEq` timeout. In this module the definition is visible and the proof is one `exact`. -/
+This is the finiteness that bounds the image of the descent map, and hence `E(K)/2E(K)`. -/
 theorem finite_selmerGroupA
     [(p : W.f.Factors) → Finite (ClassGroup (W.ringOfIntegersFactor R p))]
     [(p : W.f.Factors) → Monoid.FG (W.ringOfIntegersFactor R p)ˣ] :

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/SelmerGroupA.lean
@@ -142,6 +142,30 @@ lemma mem_selmerGroupA_iff (m : W.M) :
         W.selmerGroupFactor R p := by
   simp [selmerGroupA, selmerGroupFactor, IsDedekindDomain.selmerGroupAbove_def]
 
+/-- **`A(S,2)` is finite**, given that each factor's ring of integers has finite class group and
+finitely generated unit group.
+
+Immediate from `IsDedekindDomain.finite_selmerGroupOfEquiv`, because `selmerGroupA` *is* a
+`selmerGroupOfEquiv`: there are finitely many factors, since `f` has finitely many monic
+irreducible divisors, and finitely many relevant primes, since finitely many lie above the
+finitely many bad primes.
+
+Stated here rather than beside the weak Mordell-Weil theorem that consumes it: `selmerGroupA` is
+not `@[expose]`, so downstream the goal `Finite (selmerGroupA R)` and the conclusion of
+`finite_selmerGroupOfEquiv` are not visibly the same type, and closing that gap costs an
+`isDefEq` timeout. In this module the definition is visible and the proof is one `exact`. -/
+theorem finite_selmerGroupA
+    [(p : W.f.Factors) → Finite (ClassGroup (W.ringOfIntegersFactor R p))]
+    [(p : W.f.Factors) → Monoid.FG (W.ringOfIntegersFactor R p)ˣ] :
+    Finite (W.selmerGroupA R) :=
+  have : Finite W.f.Factors := Polynomial.Factors.finite W.f_ne_zero
+  IsDedekindDomain.finite_selmerGroupOfEquiv (fun p : W.f.Factors ↦ 𝕃 p)
+    (fun p ↦ W.ringOfIntegersFactor R p)
+    (fun p ↦ HeightOneSpectrum.primesAbove R (W.ringOfIntegersFactor R p) (W.badPrimes R)) 2
+    (fun p ↦ HeightOneSpectrum.primesAbove_finite R (W.ringOfIntegersFactor R p)
+      (W.finite_badPrimes R))
+    (AdjoinRoot.modPowEquivPiFactors W.f_ne_zero W.squarefree_f 2)
+
 /-- Membership of the class of a unit in the `2`-Selmer group of a field factor: its valuation is
 even at every prime of the ring of integers not lying above a bad prime.
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/WeakMordellWeil.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/WeakMordellWeil.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.SelmerGroupA
+
+/-!
+# The weak Mordell–Weil theorem: `E(K)/2E(K)` is finite
+
+Let `W : y² = f(x) = x³ + a₂x² + a₄x + a₆` be an elliptic curve in characteristic `≠ 2` normal
+form over a field `K`, and let `R` be a Dedekind domain with fraction field `K`. **Step 7**, and
+with it the weak Mordell–Weil theorem, is `finite_index_range_nsmulAddMonoidHom_two`: the subgroup
+`2E(K)` has finite index in `E(K)`.
+
+Everything hard is already done. Step 4 (`ker_μ_eq`) says the kernel of the descent map `μ` is
+exactly `2E(K)`, so `E(K)/2E(K)` embeds into the image of `μ`; Step 6
+(`range_μ_le_selmerGroupA`) confines that image to `A(S,2)`. All that remains is that `A(S,2)` is
+finite, and that is `finite_selmerGroupA`, proved beside `selmerGroupA` itself.
+
+The finiteness hypotheses are carried as instances on the factors: each factor's ring of integers
+has finite class group and finitely generated unit group. For `K` a number field these are the
+class number theorem and Dirichlet's unit theorem; they are hypotheses here because this file is
+about an arbitrary Dedekind domain.
+
+## Main results
+
+* `WeierstrassCurve.Affine.finite_index_range_nsmulAddMonoidHom_two_iff`: the criterion — `2E(K)`
+  has finite index exactly when the image of `μ` is finite.
+* `WeierstrassCurve.Affine.finite_index_range_nsmulAddMonoidHom_two`: **the weak Mordell–Weil
+  theorem.**
+
+## Roadmap
+
+`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6 (Mordell–Weil), lines 790–838: Step 7 of the
+weak Mordell–Weil theorem. It is the input to the descent argument in the Mordell–Weil theorem
+proper.
+
+## Provenance
+
+Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+`EllipticCurves/WeakMordellWeil.lean`, the criterion at `:799` and section `Step7`. The source is
+written against Lean `v4.32.0`; this is a forward port.
+
+The source proves `A(S,2)` finite by hand, through two `Subgroup` finiteness facts of its own
+(`Subgroup.instFinitePi` and `Subgroup.finite_comap_of_injective`) and a per-factor
+`finite_selmerGroupFactor`. None of those are needed here: this repository states `selmerGroupA` as
+`IsDedekindDomain.selmerGroupOfEquiv`, whose finiteness is already
+`IsDedekindDomain.finite_selmerGroupOfEquiv`.
+-/
+
+public section
+
+namespace WeierstrassCurve.Affine
+
+open IsDedekindDomain
+
+variable {K : Type*} [Field K] (W : Affine K) [W.IsElliptic] [W.IsCharNeTwoNF]
+
+section Criterion
+
+variable [DecidableEq K]
+
+/-- **The criterion behind the weak Mordell–Weil theorem**: `2E(K)` has finite index in `E(K)`
+exactly when the image of the descent map is finite.
+
+This is Step 4 restated: `ker_μ_eq` identifies the kernel of `μ` with `2E(K)`, so the first
+isomorphism theorem makes `E(K)/2E(K)` and the image of `μ` the same group. -/
+lemma finite_index_range_nsmulAddMonoidHom_two_iff :
+    (nsmulAddMonoidHom (α := W.Point) 2).range.FiniteIndex ↔ Finite (μ (W := W)).range := by
+  rw [← AddSubgroup.finiteIndex_toSubgroup_iff, ← ker_μ_eq,
+    Equiv.finite_iff (QuotientGroup.quotientKerEquivRange (μ (W := W))).symm.toEquiv]
+  exact Subgroup.finiteIndex_iff_finite_quotient
+
+end Criterion
+
+variable (R : Type*) [CommRing R] [IsDedekindDomain R] [Algebra R K] [IsFractionRing R K]
+  [(p : W.f.Factors) → Finite (ClassGroup (W.ringOfIntegersFactor R p))]
+  [(p : W.f.Factors) → Monoid.FG (W.ringOfIntegersFactor R p)ˣ]
+
+variable [DecidableEq K]
+
+include R in
+/-- **The weak Mordell–Weil theorem**: `E(K)/2E(K)` is finite, for an elliptic curve in the normal
+form `y² = x³ + a₂x² + a₄x + a₆` over the fraction field `K` of a Dedekind domain `R`, provided
+that for each irreducible factor `p` of the cubic the ring of integers of `K[X] ⧸ (p)` has finite
+class group and finitely generated unit group.
+
+The image of `μ` lies in `A(S,2)` by Step 6 and `A(S,2)` is finite, so the image is finite; the
+criterion turns that into finiteness of the index. This is the input to the descent argument in
+the Mordell–Weil theorem proper. -/
+theorem finite_index_range_nsmulAddMonoidHom_two :
+    (nsmulAddMonoidHom (α := W.Point) 2).range.FiniteIndex := by
+  rw [W.finite_index_range_nsmulAddMonoidHom_two_iff]
+  have := W.finite_selmerGroupA R
+  exact ((W.selmerGroupA R : Set W.M).toFinite.subset (W.range_μ_le_selmerGroupA R)).to_subtype
+
+end WeierstrassCurve.Affine
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/WeakMordellWeil.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/WeakMordellWeil.lean
@@ -12,7 +12,7 @@ public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.SelmerGroupA
 
 Let `W : y² = f(x) = x³ + a₂x² + a₄x + a₆` be an elliptic curve in characteristic `≠ 2` normal
 form over a field `K`, and let `R` be a Dedekind domain with fraction field `K`. **Step 7**, and
-with it the weak Mordell–Weil theorem, is `finite_index_range_nsmulAddMonoidHom_two`: the subgroup
+with it the weak Mordell–Weil theorem, is `finiteIndex_range_nsmulAddMonoidHom_two`: the subgroup
 `2E(K)` has finite index in `E(K)`.
 
 Everything hard is already done. Step 4 (`ker_μ_eq`) says the kernel of the descent map `μ` is
@@ -27,9 +27,9 @@ about an arbitrary Dedekind domain.
 
 ## Main results
 
-* `WeierstrassCurve.Affine.finite_index_range_nsmulAddMonoidHom_two_iff`: the criterion — `2E(K)`
+* `WeierstrassCurve.Affine.finiteIndex_range_nsmulAddMonoidHom_two_iff`: the criterion — `2E(K)`
   has finite index exactly when the image of `μ` is finite.
-* `WeierstrassCurve.Affine.finite_index_range_nsmulAddMonoidHom_two`: **the weak Mordell–Weil
+* `WeierstrassCurve.Affine.finiteIndex_range_nsmulAddMonoidHom_two`: **the weak Mordell–Weil
   theorem.**
 
 ## Roadmap
@@ -68,9 +68,9 @@ variable [DecidableEq K]
 /-- **The criterion behind the weak Mordell–Weil theorem**: `2E(K)` has finite index in `E(K)`
 exactly when the image of the descent map is finite.
 
-This is Step 4 restated: `ker_μ_eq` identifies the kernel of `μ` with `2E(K)`, so the first
-isomorphism theorem makes `E(K)/2E(K)` and the image of `μ` the same group. -/
-lemma finite_index_range_nsmulAddMonoidHom_two_iff :
+`E(K)/2E(K)` and the image of `μ` are the same group, so finiteness of either is finiteness of
+the other. -/
+lemma finiteIndex_range_nsmulAddMonoidHom_two_iff :
     (nsmulAddMonoidHom (α := W.Point) 2).range.FiniteIndex ↔ Finite (μ (W := W)).range := by
   rw [← AddSubgroup.finiteIndex_toSubgroup_iff, ← ker_μ_eq,
     Equiv.finite_iff (QuotientGroup.quotientKerEquivRange (μ (W := W))).symm.toEquiv]
@@ -90,12 +90,10 @@ form `y² = x³ + a₂x² + a₄x + a₆` over the fraction field `K` of a Dedek
 that for each irreducible factor `p` of the cubic the ring of integers of `K[X] ⧸ (p)` has finite
 class group and finitely generated unit group.
 
-The image of `μ` lies in `A(S,2)` by Step 6 and `A(S,2)` is finite, so the image is finite; the
-criterion turns that into finiteness of the index. This is the input to the descent argument in
-the Mordell–Weil theorem proper. -/
-theorem finite_index_range_nsmulAddMonoidHom_two :
+This is the input to the descent argument in the Mordell–Weil theorem proper. -/
+theorem finiteIndex_range_nsmulAddMonoidHom_two :
     (nsmulAddMonoidHom (α := W.Point) 2).range.FiniteIndex := by
-  rw [W.finite_index_range_nsmulAddMonoidHom_two_iff]
+  rw [W.finiteIndex_range_nsmulAddMonoidHom_two_iff]
   have := W.finite_selmerGroupA R
   exact ((W.selmerGroupA R : Set W.M).toFinite.subset (W.range_μ_le_selmerGroupA R)).to_subtype
 


### PR DESCRIPTION
**Step 7, and with it the weak Mordell–Weil theorem**: `E(K)/2E(K)` is finite.

For an elliptic curve `W : y² = f(x) = x³ + a₂x² + a₄x + a₆` in characteristic `≠ 2` normal form
over the fraction field `K` of a Dedekind domain `R`, this PR proves

```
theorem finiteIndex_range_nsmulAddMonoidHom_two :
    (nsmulAddMonoidHom (α := W.Point) 2).range.FiniteIndex
```

under the hypotheses that each factor's ring of integers has finite class group and finitely
generated unit group — for `K` a number field, the class number theorem and Dirichlet's unit
theorem.

### The argument

Everything hard is already on `main`. Step 4 (`ker_μ_eq`) identifies the kernel of the descent map
`μ` with `2E(K)`, so `E(K)/2E(K)` *is* the image of `μ`; Step 6 (`range_μ_le_selmerGroupA`, #4813)
confines that image to `A(S,2)`. All that remains is that `A(S,2)` is finite.

That last step is almost free, and deliberately so. `selmerGroupA` is *defined* as
`IsDedekindDomain.selmerGroupOfEquiv` at the decomposition of `W.A` into its field factors, so its
finiteness is `IsDedekindDomain.finite_selmerGroupOfEquiv` — already on `main` from EC-3 — applied
to a finite set of bad primes.

### Files

| file | lines | contents |
|---|---|---|
| `MordellWeil/WeakMordellWeil.lean` | +104 | `finiteIndex_range_nsmulAddMonoidHom_two_iff` (the criterion) and `finiteIndex_range_nsmulAddMonoidHom_two` (the theorem) |
| `MordellWeil/SelmerGroupA.lean` | +24 | `finite_selmerGroupA` |

### Implementation notes

These are the proof-side facts behind the layout; they are deliberately kept out of the docstrings,
which state the public results and their purpose only.

**`finite_selmerGroupA` sits beside `selmerGroupA`, not beside the theorem that consumes it.** It
was written in `WeakMordellWeil.lean` first and failed with `(deterministic) timeout at isDefEq,
maximum number of heartbeats (200000) has been reached`. `selmerGroupA` is not `@[expose]`, so
downstream the goal `Finite (selmerGroupA R)` and `finite_selmerGroupOfEquiv`'s conclusion are not
visibly the same type, and the elaborator spends its whole budget trying to see it. At the
definition site the proof is a single `exact`. The symptom presents as a performance problem and is
really a visibility one.

**The criterion takes `[DecidableEq K]`; `finite_selmerGroupA` does not.** Only the declarations
mentioning `W.Point` need it, which is Mathlib's requirement for the `AddCommGroup` instance.

**Naming.** The `FiniteIndex` predicate is lower-camel-cased inside the theorem names, so these are
`finiteIndex_range_nsmulAddMonoidHom_two{,_iff}`.

### Reuse

Three declarations the source needs here are **not** ported, because this repository's spelling
makes them unnecessary: `Subgroup.instFinitePi`, `Subgroup.finite_comap_of_injective`, and a
per-factor `finite_selmerGroupFactor`. The source proves `A(S,2)` finite by hand through those;
stating `selmerGroupA` as a `selmerGroupOfEquiv` means `finite_selmerGroupOfEquiv` covers it. Every
other input — `ker_μ_eq`, `range_μ_le_selmerGroupA`, `finite_badPrimes`, `primesAbove_finite`,
`Polynomial.Factors.finite`, and Mathlib's `finiteIndex_toSubgroup_iff`,
`quotientKerEquivRange`, `finiteIndex_iff_finite_quotient` — is used as it stands.

### Gate

`lake build` of the changed modules and their closure: `Build completed successfully`, zero
errors, warnings or sorries. Scoped `#lint in TauCeti`: **0 errors in 577 declarations** (plus 281
auto-generated) across 14 linters, with a `run_meta` control confirming all three new declarations
are in the judged population. 0 lines over 100 characters, 0 trailing whitespace.

### Provenance

Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
`EllipticCurves/WeakMordellWeil.lean`, the criterion at `:799` and section `Step7`. The source is
written against Lean `v4.32.0`; this is a forward port.

Roadmap: EllipticCurves

Target: `TauCetiRoadmap/EllipticCurves/README.md:813-822` — the "Explicit 2-descent (core, this
layer)" bullet, the weak Mordell–Weil theorem.

This is the target the new mathematics advances: `finiteIndex_range_nsmulAddMonoidHom_two` is
that bullet's statement. Step 7 itself is described at README:790-838, and with Steps 1-6 already
on `main` this PR is **the Layer 6 capstone**.
