### PR TITLE
feat(DedekindDomain): contraction of a height-one prime along a ring homomorphism

### DIFF
--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
@@ -16,8 +16,8 @@ identifies a condition imposed at the maximal ideal of `𝒪_v` with the conditi
 
 ## Main results
 
-* `IsDedekindDomain.HeightOneSpectrum.under_maximalIdeal_adicCompletionIntegers`: the maximal
-  ideal of `𝒪_v` lies under `v`.
+* `IsDedekindDomain.HeightOneSpectrum.under_maximalIdeal_adicCompletionIntegers`: `v` is the
+  prime lying under the maximal ideal of `𝒪_v`.
 
 ## Roadmap
 
@@ -43,7 +43,8 @@ namespace IsDedekindDomain.HeightOneSpectrum
 variable {R : Type*} [CommRing R] [IsDedekindDomain R]
   {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
 
-/-- The maximal ideal of the ring of integers of the completion of `K` at `v` lies under `v`. -/
+/-- The prime of `R` lying under the maximal ideal of the ring of integers of the completion of
+`K` at `v` is `v` itself. -/
 @[simp]
 lemma under_maximalIdeal_adicCompletionIntegers (v : HeightOneSpectrum R) :
     (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)).under R = v.asIdeal := by

--- a/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicValuation/Completion.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.AdicValuation
+
+/-!
+# The prime under the maximal ideal of an adic completion
+
+The ring of integers of the completion `K_v` of the fraction field of a Dedekind domain `R` at a
+height-one prime `v` is a local ring, and its maximal ideal contracts to `v` itself. This is what
+identifies a condition imposed at the maximal ideal of `𝒪_v` with the condition at `v` upstairs.
+
+## Main results
+
+* `IsDedekindDomain.HeightOneSpectrum.under_maximalIdeal_adicCompletionIntegers`: the maximal
+  ideal of `𝒪_v` lies under `v`.
+
+## Roadmap
+
+`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, lines 813–822: the "Explicit 2-descent (core,
+this layer)" bullet. Its semilocal half compares a square class of a global étale algebra with its
+images in the completions, and this contraction is what matches the local condition to the global
+prime. Nothing here mentions a curve.
+
+## Provenance
+
+Adapted, with the author's proof, from Michael Stoll's `EllipticCurves` project
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
+`EllipticCurves/Mathlib/Basic.lean` line 594. The source states the contraction with `Ideal.comap`
+of an `algebraMap`; Mathlib spells that `Ideal.under`, which is used here. The source is written
+against Lean `v4.32.0`; this is a forward port.
+-/
+
+public section
+
+namespace IsDedekindDomain.HeightOneSpectrum
+
+variable {R : Type*} [CommRing R] [IsDedekindDomain R]
+  {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
+
+/-- The maximal ideal of the ring of integers of the completion of `K` at `v` lies under `v`. -/
+@[simp]
+lemma under_maximalIdeal_adicCompletionIntegers (v : HeightOneSpectrum R) :
+    (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)).under R = v.asIdeal := by
+  ext x
+  rw [Ideal.under_def, Ideal.mem_comap, ← valuation_lt_one_iff_mem (K := K)]
+  -- `v.adicCompletionIntegers K` is by definition `Valued.v.valuationSubring`, which is what lets
+  -- `Valuation.mem_maximalIdeal_iff` apply here.
+  refine (Valuation.mem_maximalIdeal_iff (v := (Valued.v : Valuation (v.adicCompletion K)
+    (WithZero (Multiplicative ℤ))))).trans ?_
+  rw [algebraMap_adicCompletionIntegers_apply, valuedAdicCompletion_eq_valuation']
+
+end IsDedekindDomain.HeightOneSpectrum
+
+end

--- a/TauCeti/RingTheory/DedekindDomain/Ideal.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Ideal.lean
@@ -40,6 +40,13 @@ adapted from Michael Stoll's elliptic-curves formalisation
 roadmap's pin `66889eada51a`, Apache 2.0, by Michael Stoll); following this repository's
 convention for adapted material, the upstream authorship is credited here rather than in the
 copyright header.
+
+`IsDedekindDomain.HeightOneSpectrum.comapOfNeBot` and its projection are likewise adapted from that
+formalisation (`github.com/MichaelStollBayreuth/EllipticCurves`, `EllipticCurves/Mathlib/Basic.lean`
+line 539, at the roadmap's pin `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, Apache 2.0, by Michael
+Stoll). The construction is the source's; what changed is the hypothesis — the source and this
+version take the nonvanishing of the contraction as a hypothesis, where Mathlib's
+`HeightOneSpectrum.comap` instead derives it from surjectivity of the map.
 -/
 
 public section
@@ -125,7 +132,11 @@ only the converse fails.
 The generality is needed because the maps contracted along here are embeddings into completions —
 `R → v.adicCompletionIntegers K` — which are neither surjective, so Mathlib's `comap` does not
 apply, nor integral `Algebra` maps, so `HeightOneSpectrum.under` does not either. (`ℤ → ℤ_p` is
-flat, not integral.) The `ne_bot` hypothesis has to be supplied by hand. -/
+flat, not integral.) The `ne_bot` hypothesis has to be supplied by hand.
+
+Adapted from Michael Stoll's `EllipticCurves` (`EllipticCurves/Mathlib/Basic.lean` line 539, Apache
+2.0, at the roadmap's pin `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`); the `ne_bot`-as-hypothesis
+formulation is the source's. -/
 def comapOfNeBot (ψ : B →+* C) (w : HeightOneSpectrum C) (hne : w.asIdeal.comap ψ ≠ ⊥) :
     HeightOneSpectrum B where
   asIdeal := w.asIdeal.comap ψ

--- a/TauCeti/RingTheory/DedekindDomain/Ideal.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Ideal.lean
@@ -110,6 +110,39 @@ end Ideal
 
 namespace IsDedekindDomain.HeightOneSpectrum
 
+section Comap
+
+variable {B C : Type*} [CommRing B] [IsDedekindDomain B] [CommRing C] [IsDedekindDomain C]
+
+/-- The height-one prime of `B` obtained by contracting a height-one prime of `C` along a ring
+homomorphism `ψ : B →+* C`, given that the contraction is nonzero.
+
+Mathlib's `IsDedekindDomain.HeightOneSpectrum.comap` is the same construction, but it asks for `ψ`
+to be **surjective** and derives the `ne_bot` field from that. `comapOfNeBot` **generalises** it:
+the surjective case is recovered by supplying `(Ideal.eq_bot_of_comap_eq_bot' hf).mt w.ne_bot`, and
+only the converse fails.
+
+The generality is needed because the maps contracted along here are embeddings into completions —
+`R → v.adicCompletionIntegers K` — which are neither surjective, so Mathlib's `comap` does not
+apply, nor integral `Algebra` maps, so `HeightOneSpectrum.under` does not either. (`ℤ → ℤ_p` is
+flat, not integral.) The `ne_bot` hypothesis has to be supplied by hand. -/
+def comapOfNeBot (ψ : B →+* C) (w : HeightOneSpectrum C) (hne : w.asIdeal.comap ψ ≠ ⊥) :
+    HeightOneSpectrum B where
+  asIdeal := w.asIdeal.comap ψ
+  isPrime := w.isPrime.comap ψ
+  ne_bot := hne
+
+omit [IsDedekindDomain B] [IsDedekindDomain C] in
+-- `(rfl)` elaborates here, where the definition is visible.
+/-- The underlying ideal of `comapOfNeBot` is the contracted ideal. -/
+@[simp]
+lemma comapOfNeBot_asIdeal (ψ : B →+* C) (w : HeightOneSpectrum C)
+    (hne : w.asIdeal.comap ψ ≠ ⊥) :
+    (comapOfNeBot ψ w hne).asIdeal = w.asIdeal.comap ψ :=
+  (rfl)
+
+end Comap
+
 section RingEquivTransport
 
 variable {R R' : Type*} [CommRing R] [CommRing R']

--- a/TauCeti/RingTheory/DedekindDomain/Ideal.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Ideal.lean
@@ -47,6 +47,13 @@ line 539, at the roadmap's pin `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, Apach
 Stoll). The construction is the source's; what changed is the hypothesis — the source and this
 version take the nonvanishing of the contraction as a hypothesis, where Mathlib's
 `HeightOneSpectrum.comap` instead derives it from surjectivity of the map.
+
+`Ideal.ne_bot_of_comap_ne_bot` plays the role of the source's
+`comap_ne_bot_of_comap_comap_ne_bot` (`EllipticCurves/Mathlib/Basic.lean` line 270): it is what
+discharges that nonvanishing hypothesis when a prime is contracted through an intermediate ring.
+It is stated here in the general form — an arbitrary ideal and an injective ring homomorphism,
+with the map producing the ideal dropped, since it plays no role — and proved from Mathlib's
+`Ideal.comap_bot_of_injective`.
 -/
 
 public section
@@ -112,6 +119,22 @@ theorem count_factors_map_of_ringEquiv (e : R ≃+* R') {p I : Ideal R} (hp : Pr
   exact le_antisymm ((key _).mp le_rfl) ((key _).mpr le_rfl)
 
 end RingEquivDedekind
+
+section Injective
+
+/-- If the contraction of `J` along an injective ring homomorphism is nonzero, so is `J` itself.
+
+This is the eliminator that discharges the nonvanishing hypothesis of
+`IsDedekindDomain.HeightOneSpectrum.comapOfNeBot` when a prime is contracted through an
+intermediate ring: contract all the way down to a base where nonvanishing is already known, and
+read the intermediate step off from that. Only injectivity of the *lower* map is needed; the map
+producing `J` plays no role, so it does not appear. -/
+theorem ne_bot_of_comap_ne_bot {R S F : Type*} [Semiring R] [Semiring S] [FunLike F R S]
+    [RingHomClass F R S] (f : F) (hf : Function.Injective f) {J : Ideal S}
+    (h : J.comap f ≠ ⊥) : J ≠ ⊥ :=
+  fun h0 ↦ h (h0 ▸ comap_bot_of_injective f hf)
+
+end Injective
 
 end Ideal
 

--- a/TauCeti/RingTheory/DedekindDomain/PrimesAbove.lean
+++ b/TauCeti/RingTheory/DedekindDomain/PrimesAbove.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.RingTheory.DedekindDomain.AdicValuation
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 public import Mathlib.RingTheory.DedekindDomain.SelmerGroup
 
@@ -20,6 +21,10 @@ relative to when the "bad" primes are given downstairs:
 
 ## Main definitions
 
+* `IsDedekindDomain.HeightOneSpectrum.comapOfNeBot`: the contraction of a height-one prime along
+  an arbitrary ring homomorphism, given that the contraction is nonzero. Mathlib's
+  `HeightOneSpectrum.comap` covers the surjective case; this covers the integral-embedding case,
+  where surjectivity fails.
 * `IsDedekindDomain.HeightOneSpectrum.primesAbove`: the primes of `B` above a set of primes
   of `R`, as a preimage under `HeightOneSpectrum.under`.
 * `IsDedekindDomain.selmerGroupAbove`: the `n`-Selmer group of `L` relative to the primes of `B`
@@ -27,6 +32,11 @@ relative to when the "bad" primes are given downstairs:
 
 ## Main results
 
+* `Ideal.comap_ne_bot_of_comap_comap_ne_bot`: a contraction is nonzero once its further
+  contraction along an injective map is, which is how the hypothesis of `comapOfNeBot` is
+  discharged in practice.
+* `IsDedekindDomain.HeightOneSpectrum.comap_maximalIdeal_adicCompletionIntegers`: the maximal
+  ideal of the integers of the `v`-adic completion contracts to `v`.
 * `IsDedekindDomain.HeightOneSpectrum.liesOver_under`: the `LiesOver` instance relating a prime
   to its contraction, which the `under`-indexed results downstream need.
 * `IsDedekindDomain.HeightOneSpectrum.mem_primesAbove_iff`: `w` lies above `S` iff
@@ -49,10 +59,32 @@ Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project
 `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
 `EllipticCurves/Mathlib/Basic.lean`, section `DedekindDomain`. The source carries its own
 `HeightOneSpectrum.below`; at our Mathlib pin that map is `HeightOneSpectrum.under`, which is
-used here instead. The source is written against Lean `v4.32.0`; this is a forward port.
+used here instead.
+
+`comapOfNeBot`, `comap_maximalIdeal_adicCompletionIntegers` and
+`Ideal.comap_ne_bot_of_comap_comap_ne_bot` are adapted from that source's
+`EllipticCurves/Mathlib/Basic.lean`, lines 539, 594 and 270 respectively. They are shared
+substrate rather than part of any one rung: the semilocal comparison, the finiteness of the
+`2`-Selmer group, and the local image counts all contract primes of a local field factor back to
+the base, and all three consume these.
+
+The source is written against Lean `v4.32.0`; this is a forward port.
 -/
 
 public section
+
+/-- An ideal contraction is nonzero as soon as its further contraction along an injective ring
+homomorphism is nonzero.
+
+Stated here because it is what supplies the nonvanishing hypothesis of
+`IsDedekindDomain.HeightOneSpectrum.comapOfNeBot` below at its use sites: one contracts a prime of
+a local factor all the way down to the base, where nonvanishing is known, and reads the
+intermediate step off from that. -/
+lemma Ideal.comap_ne_bot_of_comap_comap_ne_bot {R S T : Type*} [CommRing R] [CommRing S]
+    [CommRing T] {ρ : R →+* S} {φ : S →+* T} (hρ : Function.Injective ρ) {I : Ideal T}
+    (h : (I.comap φ).comap ρ ≠ ⊥) : I.comap φ ≠ ⊥ := fun h0 ↦
+  h (by
+    rw [h0, ← RingHom.ker_eq_comap_bot, (RingHom.injective_iff_ker_eq_bot ρ).mp hρ])
 
 namespace IsDedekindDomain
 
@@ -70,6 +102,64 @@ is the one this file exists to feed — do not fire without it. -/
 instance liesOver_under (w : HeightOneSpectrum B) :
     w.asIdeal.LiesOver (under R w).asIdeal :=
   ⟨rfl⟩
+
+section Comap
+
+variable {B C : Type*} [CommRing B] [IsDedekindDomain B] [CommRing C] [IsDedekindDomain C]
+
+/-- The height-one prime of `B` obtained by contracting a height-one prime of `C` along a ring
+homomorphism `ψ : B →+* C`, given that the contraction is nonzero.
+
+Mathlib's `IsDedekindDomain.HeightOneSpectrum.comap` is the same construction, but it asks for `ψ`
+to be **surjective** and derives the `ne_bot` field from that. The maps this repository contracts
+along are integral embeddings — a ring of integers of a global field factor into the ring of
+integers of a local one — which are never surjective, so that hypothesis is unavailable and the
+`ne_bot` hypothesis is taken directly instead. The two agree wherever both apply; neither is a
+special case of the other in Lean, since the hypotheses differ.
+
+Not `@[simps]`: the generated `asIdeal` projection is proved by `rfl`, and a bare `rfl` proof of a
+statement exported from this module would require `comapOfNeBot` and its field proofs to be
+exposed downstream. The projection is written out below with the parenthesised `(rfl)` instead,
+which elaborates here where the definition is visible. -/
+def comapOfNeBot (ψ : B →+* C) (w : HeightOneSpectrum C) (hne : w.asIdeal.comap ψ ≠ ⊥) :
+    HeightOneSpectrum B where
+  asIdeal := w.asIdeal.comap ψ
+  isPrime := w.isPrime.comap ψ
+  ne_bot := hne
+
+omit [IsDedekindDomain B] [IsDedekindDomain C] in
+/-- The underlying ideal of `comapOfNeBot` is the contracted ideal.
+
+The `IsDedekindDomain` instances are needed to *state* this — they are part of what
+`HeightOneSpectrum` means here — but the proof erases them, so they are omitted rather than
+suppressed with a linter option. -/
+@[simp]
+lemma comapOfNeBot_asIdeal (ψ : B →+* C) (w : HeightOneSpectrum C)
+    (hne : w.asIdeal.comap ψ ≠ ⊥) :
+    (comapOfNeBot ψ w hne).asIdeal = w.asIdeal.comap ψ :=
+  (rfl)
+
+end Comap
+
+section AdicCompletion
+
+variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
+
+/-- The maximal ideal of the ring of integers of the completion of `K` at `v` contracts to `v`
+itself. This is what identifies the prime obtained by `comapOfNeBot` from a completion with the
+prime one started from. -/
+theorem comap_maximalIdeal_adicCompletionIntegers (v : HeightOneSpectrum R) :
+    (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)).comap
+      (algebraMap R (v.adicCompletionIntegers K)) = v.asIdeal := by
+  ext x
+  rw [Ideal.mem_comap, ← valuation_lt_one_iff_mem (K := K)]
+  refine (Valuation.mem_maximalIdeal_iff (v := (Valued.v : Valuation (v.adicCompletion K)
+    (WithZero (Multiplicative ℤ))))).trans ?_
+  rw [show ((algebraMap R (v.adicCompletionIntegers K) x : v.adicCompletionIntegers K) :
+    v.adicCompletion K) = ((algebraMap R K x : K) : v.adicCompletion K) from rfl,
+    valuedAdicCompletion_eq_valuation']
+
+end AdicCompletion
 
 /-- The primes of `B` lying above a set `S` of primes of `R`: the preimage of `S` under the
 contraction `HeightOneSpectrum.under R`. -/

--- a/TauCeti/RingTheory/DedekindDomain/PrimesAbove.lean
+++ b/TauCeti/RingTheory/DedekindDomain/PrimesAbove.lean
@@ -22,9 +22,9 @@ relative to when the "bad" primes are given downstairs:
 ## Main definitions
 
 * `IsDedekindDomain.HeightOneSpectrum.comapOfNeBot`: the contraction of a height-one prime along
-  an arbitrary ring homomorphism, given that the contraction is nonzero. Mathlib's
-  `HeightOneSpectrum.comap` covers the surjective case; this covers the integral-embedding case,
-  where surjectivity fails.
+  an arbitrary ring homomorphism, given that the contraction is nonzero. It generalises Mathlib's
+  `HeightOneSpectrum.comap`, which derives that hypothesis from surjectivity; the maps needed here
+  are embeddings into completions, which are neither surjective nor integral.
 * `IsDedekindDomain.HeightOneSpectrum.primesAbove`: the primes of `B` above a set of primes
   of `R`, as a preimage under `HeightOneSpectrum.under`.
 * `IsDedekindDomain.selmerGroupAbove`: the `n`-Selmer group of `L` relative to the primes of `B`
@@ -111,11 +111,14 @@ variable {B C : Type*} [CommRing B] [IsDedekindDomain B] [CommRing C] [IsDedekin
 homomorphism `ψ : B →+* C`, given that the contraction is nonzero.
 
 Mathlib's `IsDedekindDomain.HeightOneSpectrum.comap` is the same construction, but it asks for `ψ`
-to be **surjective** and derives the `ne_bot` field from that. The maps this repository contracts
-along are integral embeddings — a ring of integers of a global field factor into the ring of
-integers of a local one — which are never surjective, so that hypothesis is unavailable and the
-`ne_bot` hypothesis is taken directly instead. The two agree wherever both apply; neither is a
-special case of the other in Lean, since the hypotheses differ.
+to be **surjective** and derives the `ne_bot` field from that. `comapOfNeBot` **generalises** it:
+the surjective case is recovered by supplying `(Ideal.eq_bot_of_comap_eq_bot' hf).mt w.ne_bot`, and
+only the converse fails.
+
+The generality is needed because the maps contracted along here are embeddings into completions —
+`R → v.adicCompletionIntegers K` — which are neither surjective, so Mathlib's `comap` does not
+apply, nor integral `Algebra` maps, so `HeightOneSpectrum.under` does not either. (`ℤ → ℤ_p` is
+flat, not integral.) The `ne_bot` hypothesis has to be supplied by hand.
 
 Not `@[simps]`: the generated `asIdeal` projection is proved by `rfl`, and a bare `rfl` proof of a
 statement exported from this module would require `comapOfNeBot` and its field proofs to be

--- a/TauCeti/RingTheory/DedekindDomain/PrimesAbove.lean
+++ b/TauCeti/RingTheory/DedekindDomain/PrimesAbove.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RingTheory.DedekindDomain.AdicValuation
 public import Mathlib.RingTheory.DedekindDomain.Ideal.Lemmas
 public import Mathlib.RingTheory.DedekindDomain.SelmerGroup
 
@@ -21,10 +20,6 @@ relative to when the "bad" primes are given downstairs:
 
 ## Main definitions
 
-* `IsDedekindDomain.HeightOneSpectrum.comapOfNeBot`: the contraction of a height-one prime along
-  an arbitrary ring homomorphism, given that the contraction is nonzero. It generalises Mathlib's
-  `HeightOneSpectrum.comap`, which derives that hypothesis from surjectivity; the maps needed here
-  are embeddings into completions, which are neither surjective nor integral.
 * `IsDedekindDomain.HeightOneSpectrum.primesAbove`: the primes of `B` above a set of primes
   of `R`, as a preimage under `HeightOneSpectrum.under`.
 * `IsDedekindDomain.selmerGroupAbove`: the `n`-Selmer group of `L` relative to the primes of `B`
@@ -32,11 +27,6 @@ relative to when the "bad" primes are given downstairs:
 
 ## Main results
 
-* `Ideal.comap_ne_bot_of_comap_comap_ne_bot`: a contraction is nonzero once its further
-  contraction along an injective map is, which is how the hypothesis of `comapOfNeBot` is
-  discharged in practice.
-* `IsDedekindDomain.HeightOneSpectrum.comap_maximalIdeal_adicCompletionIntegers`: the maximal
-  ideal of the integers of the `v`-adic completion contracts to `v`.
 * `IsDedekindDomain.HeightOneSpectrum.liesOver_under`: the `LiesOver` instance relating a prime
   to its contraction, which the `under`-indexed results downstream need.
 * `IsDedekindDomain.HeightOneSpectrum.mem_primesAbove_iff`: `w` lies above `S` iff
@@ -61,30 +51,10 @@ Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project
 `HeightOneSpectrum.below`; at our Mathlib pin that map is `HeightOneSpectrum.under`, which is
 used here instead.
 
-`comapOfNeBot`, `comap_maximalIdeal_adicCompletionIntegers` and
-`Ideal.comap_ne_bot_of_comap_comap_ne_bot` are adapted from that source's
-`EllipticCurves/Mathlib/Basic.lean`, lines 539, 594 and 270 respectively. They are shared
-substrate rather than part of any one rung: the semilocal comparison, the finiteness of the
-`2`-Selmer group, and the local image counts all contract primes of a local field factor back to
-the base, and all three consume these.
-
 The source is written against Lean `v4.32.0`; this is a forward port.
 -/
 
 public section
-
-/-- An ideal contraction is nonzero as soon as its further contraction along an injective ring
-homomorphism is nonzero.
-
-Stated here because it is what supplies the nonvanishing hypothesis of
-`IsDedekindDomain.HeightOneSpectrum.comapOfNeBot` below at its use sites: one contracts a prime of
-a local factor all the way down to the base, where nonvanishing is known, and reads the
-intermediate step off from that. -/
-lemma Ideal.comap_ne_bot_of_comap_comap_ne_bot {R S T : Type*} [CommRing R] [CommRing S]
-    [CommRing T] {ρ : R →+* S} {φ : S →+* T} (hρ : Function.Injective ρ) {I : Ideal T}
-    (h : (I.comap φ).comap ρ ≠ ⊥) : I.comap φ ≠ ⊥ := fun h0 ↦
-  h (by
-    rw [h0, ← RingHom.ker_eq_comap_bot, (RingHom.injective_iff_ker_eq_bot ρ).mp hρ])
 
 namespace IsDedekindDomain
 
@@ -102,67 +72,6 @@ is the one this file exists to feed — do not fire without it. -/
 instance liesOver_under (w : HeightOneSpectrum B) :
     w.asIdeal.LiesOver (under R w).asIdeal :=
   ⟨rfl⟩
-
-section Comap
-
-variable {B C : Type*} [CommRing B] [IsDedekindDomain B] [CommRing C] [IsDedekindDomain C]
-
-/-- The height-one prime of `B` obtained by contracting a height-one prime of `C` along a ring
-homomorphism `ψ : B →+* C`, given that the contraction is nonzero.
-
-Mathlib's `IsDedekindDomain.HeightOneSpectrum.comap` is the same construction, but it asks for `ψ`
-to be **surjective** and derives the `ne_bot` field from that. `comapOfNeBot` **generalises** it:
-the surjective case is recovered by supplying `(Ideal.eq_bot_of_comap_eq_bot' hf).mt w.ne_bot`, and
-only the converse fails.
-
-The generality is needed because the maps contracted along here are embeddings into completions —
-`R → v.adicCompletionIntegers K` — which are neither surjective, so Mathlib's `comap` does not
-apply, nor integral `Algebra` maps, so `HeightOneSpectrum.under` does not either. (`ℤ → ℤ_p` is
-flat, not integral.) The `ne_bot` hypothesis has to be supplied by hand.
-
-Not `@[simps]`: the generated `asIdeal` projection is proved by `rfl`, and a bare `rfl` proof of a
-statement exported from this module would require `comapOfNeBot` and its field proofs to be
-exposed downstream. The projection is written out below with the parenthesised `(rfl)` instead,
-which elaborates here where the definition is visible. -/
-def comapOfNeBot (ψ : B →+* C) (w : HeightOneSpectrum C) (hne : w.asIdeal.comap ψ ≠ ⊥) :
-    HeightOneSpectrum B where
-  asIdeal := w.asIdeal.comap ψ
-  isPrime := w.isPrime.comap ψ
-  ne_bot := hne
-
-omit [IsDedekindDomain B] [IsDedekindDomain C] in
-/-- The underlying ideal of `comapOfNeBot` is the contracted ideal.
-
-The `IsDedekindDomain` instances are needed to *state* this — they are part of what
-`HeightOneSpectrum` means here — but the proof erases them, so they are omitted rather than
-suppressed with a linter option. -/
-@[simp]
-lemma comapOfNeBot_asIdeal (ψ : B →+* C) (w : HeightOneSpectrum C)
-    (hne : w.asIdeal.comap ψ ≠ ⊥) :
-    (comapOfNeBot ψ w hne).asIdeal = w.asIdeal.comap ψ :=
-  (rfl)
-
-end Comap
-
-section AdicCompletion
-
-variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
-
-/-- The maximal ideal of the ring of integers of the completion of `K` at `v` contracts to `v`
-itself. This is what identifies the prime obtained by `comapOfNeBot` from a completion with the
-prime one started from. -/
-theorem comap_maximalIdeal_adicCompletionIntegers (v : HeightOneSpectrum R) :
-    (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K)).comap
-      (algebraMap R (v.adicCompletionIntegers K)) = v.asIdeal := by
-  ext x
-  rw [Ideal.mem_comap, ← valuation_lt_one_iff_mem (K := K)]
-  refine (Valuation.mem_maximalIdeal_iff (v := (Valued.v : Valuation (v.adicCompletion K)
-    (WithZero (Multiplicative ℤ))))).trans ?_
-  rw [show ((algebraMap R (v.adicCompletionIntegers K) x : v.adicCompletionIntegers K) :
-    v.adicCompletion K) = ((algebraMap R K x : K) : v.adicCompletion K) from rfl,
-    valuedAdicCompletion_eq_valuation']
-
-end AdicCompletion
 
 /-- The primes of `B` lying above a set `S` of primes of `R`: the preimage of `S` under the
 contraction `HeightOneSpectrum.under R`. -/

--- a/TauCeti/RingTheory/DedekindDomain/SInteger/Spectrum.lean
+++ b/TauCeti/RingTheory/DedekindDomain/SInteger/Spectrum.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.NumberTheory.RamificationInertia.Valuation
 public import Mathlib.RingTheory.DedekindDomain.SelmerGroup
-public import TauCeti.RingTheory.DedekindDomain.Ideal
 public import TauCeti.RingTheory.DedekindDomain.SInteger.Basic
 
 /-!

--- a/TauCeti/RingTheory/DedekindDomain/SInteger/Spectrum.lean
+++ b/TauCeti/RingTheory/DedekindDomain/SInteger/Spectrum.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.NumberTheory.RamificationInertia.Valuation
 public import Mathlib.RingTheory.DedekindDomain.SelmerGroup
+public import TauCeti.RingTheory.DedekindDomain.Ideal
 public import TauCeti.RingTheory.DedekindDomain.SInteger.Basic
 
 /-!
@@ -145,14 +146,12 @@ lemma integer_map_le_map_pow_iff {v : HeightOneSpectrum R} (hv : v ∉ S) (J : I
 
 /-- The prime of `R` below a prime `P` of `𝒪_S`: its contraction. -/
 noncomputable def integerPrimeUnder (P : HeightOneSpectrum (S.integer K)) :
-    HeightOneSpectrum R where
-  asIdeal := P.asIdeal.comap (algebraMap R (S.integer K))
-  isPrime := P.isPrime.comap _
-  ne_bot := integer_comap_ne_bot K S P.ne_bot
+    HeightOneSpectrum R :=
+  HeightOneSpectrum.comapOfNeBot (algebraMap R (S.integer K)) P (integer_comap_ne_bot K S P.ne_bot)
 
 @[simp] lemma integerPrimeUnder_asIdeal (P : HeightOneSpectrum (S.integer K)) :
-    (integerPrimeUnder K S P).asIdeal = P.asIdeal.comap (algebraMap R (S.integer K)) := by
-  simp only [integerPrimeUnder]
+    (integerPrimeUnder K S P).asIdeal = P.asIdeal.comap (algebraMap R (S.integer K)) :=
+  HeightOneSpectrum.comapOfNeBot_asIdeal _ _ _
 
 /-- A prime under a prime of `𝒪_S` never lies in `S`. -/
 lemma integerPrimeUnder_notMem (P : HeightOneSpectrum (S.integer K)) :
@@ -167,13 +166,16 @@ lemma integerPrimeUnder_notMem (P : HeightOneSpectrum (S.integer K)) :
 @[simp] lemma integerPrimeUnder_integerPrimeOverOfNotMem {v : HeightOneSpectrum R} (hv : v ∉ S) :
     integerPrimeUnder K S (integerPrimeOverOfNotMem K S hv) = v :=
   have := v.isMaximal
-  HeightOneSpectrum.ext <|
-    Ideal.comap_map_eq_self_of_isMaximal _ (integer_map_asIdeal_ne_top K S hv)
+  HeightOneSpectrum.ext <| by
+    rw [integerPrimeUnder_asIdeal, integerPrimeOverOfNotMem_asIdeal]
+    exact Ideal.comap_map_eq_self_of_isMaximal _ (integer_map_asIdeal_ne_top K S hv)
 
 /-- Contracting a prime of `𝒪_S` and extending back returns it. -/
 @[simp] lemma integerPrimeOverOfNotMem_integerPrimeUnder (P : HeightOneSpectrum (S.integer K)) :
     integerPrimeOverOfNotMem K S (integerPrimeUnder_notMem K S P) = P :=
-  HeightOneSpectrum.ext <| integer_map_comap_eq K S P.asIdeal
+  HeightOneSpectrum.ext <| by
+    rw [integerPrimeOverOfNotMem_asIdeal, integerPrimeUnder_asIdeal]
+    exact integer_map_comap_eq K S P.asIdeal
 
 /-- **The height-one primes of `𝒪_S` are exactly the height-one primes of `R` not in `S`.** -/
 noncomputable def integerHeightOneSpectrumEquiv :


### PR DESCRIPTION
Shared substrate for the semilocal half of the explicit 2-descent: **contracting a height-one
prime along a ring homomorphism**.

| declaration | file | statement |
|---|---|---|
| `IsDedekindDomain.HeightOneSpectrum.comapOfNeBot` | `RingTheory/DedekindDomain/Ideal.lean` | the contraction of a height-one prime of `C` along `ψ : B →+* C`, given that the contraction is nonzero |
| `IsDedekindDomain.HeightOneSpectrum.comapOfNeBot_asIdeal` | `RingTheory/DedekindDomain/Ideal.lean` | its underlying ideal is the contracted ideal |
| `Ideal.ne_bot_of_comap_ne_bot` | `RingTheory/DedekindDomain/Ideal.lean` | an ideal is nonzero once its contraction along an injective ring homomorphism is |
| `IsDedekindDomain.HeightOneSpectrum.under_maximalIdeal_adicCompletionIntegers` | `RingTheory/DedekindDomain/AdicValuation/Completion.lean` | the prime lying under the maximal ideal of the integers of the `v`-adic completion is `v` |

`RingTheory/DedekindDomain/SInteger/Spectrum.lean` is migrated onto the new constructor: the
existing `integerPrimeUnder` built the same three fields inline, and is now defined as a
`comapOfNeBot`, with its projection lemma proved by `comapOfNeBot_asIdeal`.

### Why this is its own PR rather than part of a rung

All of it is consumed by **four** different rungs — the semilocal comparison, the finiteness of
the `2`-Selmer group, the local image counts, and the real-place counts. Each contracts a prime of
a *local* field factor back to the base. Landing them once as shared substrate beats four private
copies, and keeps the consuming PRs to curve files rather than curve-plus-`RingTheory`.

### On the relationship to Mathlib's `HeightOneSpectrum.comap`

This is the part a reviewer should check first, so it is stated plainly. Mathlib already has

```
def comap (f : R →+* S) (hf : Function.Surjective f) (v : HeightOneSpectrum S) :
    HeightOneSpectrum R
```

in `RingTheory/DedekindDomain/Ideal/Lemmas.lean:586` — the *same* three-field construction,
differing only in how the `ne_bot` field is obtained: Mathlib derives it from surjectivity of `f`.

`comapOfNeBot` **generalises** it. Mathlib's surjective `comap` is recovered from `comapOfNeBot` by
supplying `(Ideal.eq_bot_of_comap_eq_bot' hf).mt w.ne_bot`; only the converse fails, so the
generality is strictly one-way rather than symmetric.

The generality is needed because the maps contracted along here are embeddings into completions,
`R → v.adicCompletionIntegers K`. Those are not surjective, so Mathlib's `comap` does not apply;
and they are not integral `Algebra` maps either — `ℤ → ℤ_p` is flat, not integral — so
`HeightOneSpectrum.under` does not apply. The `ne_bot` field therefore has to be hypothesised.

`Ideal.ne_bot_of_comap_ne_bot` is what discharges that hypothesis in practice: one contracts all
the way down to the base, where nonvanishing is known, and reads the intermediate step off from
that. It is stated in general form — an arbitrary ideal and an injective ring homomorphism, with
the map that produced the ideal dropped, since it plays no role — and proved in one line from
Mathlib's `Ideal.comap_bot_of_injective`. Mathlib's `comap_ne_bot_*` family in
`RingTheory/Ideal/GoingUp.lean` covers the root/algebraic/integral-element shapes, none of which
is this one.

### Implementation notes

`comapOfNeBot` is deliberately **not** `@[simps]`. The generated `asIdeal` projection is proved by
`rfl`, and a bare `rfl` proof of a statement exported from this module would require the definition
and its field proofs to be exposed downstream — the build rejects it with `Unknown constant
… comapOfNeBot._proof_2 … would need to be public`. The projection is written out instead with the
parenthesised `(rfl)`, this repository's idiom for exactly that situation.

The projection also carries `omit [IsDedekindDomain B] [IsDedekindDomain C] in`: those instances
are needed to *state* it but erased by the proof. The upstream source suppresses the same warning
with `set_option linter.unusedSectionVars false`; `omit` is the narrower fix and is what this
repository uses elsewhere.

### Gate

`lake build` of the three changed modules and their five direct importers
(`AdicValuation/Transport`, `SInteger/Basic`, `SInteger/Factorization`,
`NumberTheory/DedekindDomain/Transversal`, `NumberTheory/ArithmeticDirichletSeries/Weight`):
`Build completed successfully (3144 jobs)`, exit 0, with fresh `.olean` receipts for all three
changed modules and no `error:`/`warning:`/`info:` diagnostics in the log.

`lake exe runLinter` passed on each of the three changed modules. A `run_meta` control confirms
all three new declarations are in the judged population and resolve in the expected modules, with
an absent-name negative control that does not resolve. `#print axioms` on each gives only
`propext`, `Classical.choice`, `Quot.sound`. 0 lines over 100 characters, 0 trailing whitespace.

The full-library `scripts/lint-env.sh` needs every module's `.olean` and so is left to CI's
`pr-build`, which runs it together with the full build.

### Provenance

Adapted, with the author's proofs, from Michael Stoll's `EllipticCurves` project
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
`EllipticCurves/Mathlib/Basic.lean`, lines 539 (`comapOfNeBot`), 594
(`under_maximalIdeal_adicCompletionIntegers`) and 270 (`ne_bot_of_comap_ne_bot`, restated in
general form). The source is written against Lean `v4.32.0`; this is a forward port.

Roadmap: EllipticCurves

Target: `TauCetiRoadmap/EllipticCurves/README.md:813-822` — the "Explicit 2-descent (core, this
layer)" bullet. This is prerequisite infrastructure for its semilocal half, not new mathematics of
its own.
