### PR TITLE
feat: prove geodesics have constant speed

### DIFF
--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/ConstantSpeed.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/ConstantSpeed.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Reparametrization
+public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.AlongCurve.Metric
+
+/-!
+# Constant speed of geodesics
+
+A geodesic has constant speed on every open preconnected parameter set. We first prove that the
+inner product of its velocity with itself is constant, by differentiating it with the
+metric-product rule and using the geodesic equation. Taking square roots gives the usual
+constant-speed statement.
+
+The open-set formulation is the one used by maximal integral curves, whose parameter domains are
+open intervals. It also yields an all-time specialization directly.
+
+## Main results
+
+* TauCeti.Manifold.IsGeodesicCurveOn.inner_curveVelocity_eq: squared speed is constant on an
+  open preconnected parameter set.
+* TauCeti.Manifold.IsGeodesicCurveOn.norm_curveVelocity_eq: speed is constant there.
+* TauCeti.Manifold.IsGeodesicCurve.norm_curveVelocity_eq: an all-time geodesic has the same
+  speed at any two parameters.
+
+## References
+
+* [Geodesics, the exponential map, and the Hopf--Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
+  Layer 1, "Constant speed".
+* M. P. do Carmo, Riemannian Geometry, Chapter 3, §2.
+* The proof follows the organization of
+  DoCarmoLib/Riemannian/Geodesic/HopfRinow/ConstantSpeed.lean in the Apache-2.0
+  [frenzymath/Poincare-Conjecture](https://github.com/frenzymath/Poincare-Conjecture)
+  repository, revision 24f32e4d600878bfaac6bc2f2f9324175571c321, using Tau Ceti's
+  set-aware geodesic predicate and Mathlib's Riemannian norm.
+-/
+
+public section
+
+open Bundle CovariantDerivative Set
+open scoped ContDiff Manifold Topology
+
+noncomputable section
+
+namespace TauCeti.Manifold
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 2 M]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+  {γ : ℝ → M} {s : Set ℝ}
+
+/-- The coordinate reading of the unrestricted velocity of a C² curve is differentiable at
+each point of an open parameter set. -/
+private theorem IsGeodesicCurveOn.differentiableAt_sectionCoord_curveVelocity
+    (h : IsGeodesicCurveOn I γ s) (hs : IsOpen s) {t : ℝ} (ht : t ∈ s) :
+    DifferentiableAt ℝ
+      (sectionCoord (F := E) γ (curveVelocity I γ) (γ t)) t := by
+  let _ : IsManifold I ((1 : ℕ∞ω) + 1) M := IsManifold.of_le (n := 2) (by norm_num)
+  have hγ : ContMDiffOn 𝓘(ℝ, ℝ) I ((1 : ℕ∞ω) + 1) γ s := by
+    norm_num
+    exact h.contMDiffOn
+  have hwithin := (contDiffWithinAt_sectionCoord_curveVelocityWithin γ h.uniqueDiffOn hγ ht
+    (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t))).differentiableWithinAt
+      (by norm_num)
+  have hdiff : DifferentiableAt ℝ
+      (sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ t)) t :=
+    hwithin.differentiableAt (hs.mem_nhds ht)
+  have heq : sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ t) =ᶠ[𝓝 t]
+      sectionCoord (F := E) γ (curveVelocity I γ) (γ t) := by
+    filter_upwards [hs.mem_nhds ht] with r hr
+    rw [sectionCoord_apply, sectionCoord_apply,
+      curveVelocityWithin_of_mem_nhds (hs.mem_nhds hr)]
+  exact heq.differentiableAt_iff.mp hdiff
+
+/-- Squared speed is constant along a geodesic. On an open preconnected parameter set, the
+inner product of the velocity with itself has the same value at every two parameters. -/
+theorem IsGeodesicCurveOn.inner_curveVelocity_eq
+    (h : IsGeodesicCurveOn I γ s) (hs : IsOpen s) (hconn : IsPreconnected s)
+    {a b : ℝ} (ha : a ∈ s) (hb : b ∈ s) :
+    inner ℝ (curveVelocity I γ a) (curveVelocity I γ a) =
+      inner ℝ (curveVelocity I γ b) (curveVelocity I γ b) := by
+  have hzero := (isGeodesicCurveOn_iff_of_isOpen hs).mp h |>.2
+  have hmetric := (isLeviCivita_leviCivita (I := I) (M := M)).isMetricCompatible
+  apply hs.is_const_of_deriv_eq_zero (f := fun t ↦
+    inner ℝ (curveVelocity I γ t) (curveVelocity I γ t)) hconn
+  · intro t ht
+    have hγt : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t :=
+      (h.contMDiffOn.contMDiffAt (hs.mem_nhds ht)).mdifferentiableAt (by norm_num)
+    exact (hmetric.differentiableAt_inner_alongCurve hγt
+      (h.differentiableAt_sectionCoord_curveVelocity hs ht)
+      (h.differentiableAt_sectionCoord_curveVelocity hs ht)).differentiableWithinAt
+  · intro t ht
+    have hγt : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t :=
+      (h.contMDiffOn.contMDiffAt (hs.mem_nhds ht)).mdifferentiableAt (by norm_num)
+    rw [hmetric.deriv_inner_alongCurve hγt
+      (h.differentiableAt_sectionCoord_curveVelocity hs ht)
+      (h.differentiableAt_sectionCoord_curveVelocity hs ht), hzero t ht]
+    simp
+  · exact ha
+  · exact hb
+
+/-- A geodesic has constant speed. On an open preconnected parameter set, the norm of its
+velocity has the same value at every two parameters. -/
+theorem IsGeodesicCurveOn.norm_curveVelocity_eq
+    (h : IsGeodesicCurveOn I γ s) (hs : IsOpen s) (hconn : IsPreconnected s)
+    {a b : ℝ} (ha : a ∈ s) (hb : b ∈ s) :
+    ‖curveVelocity I γ a‖ = ‖curveVelocity I γ b‖ := by
+  rw [norm_eq_sqrt_real_inner, norm_eq_sqrt_real_inner,
+    h.inner_curveVelocity_eq hs hconn ha hb]
+
+/-- An all-time geodesic has the same squared speed at every two parameters. -/
+theorem IsGeodesicCurve.inner_curveVelocity_eq
+    (h : IsGeodesicCurve I γ) (a b : ℝ) :
+    inner ℝ (curveVelocity I γ a) (curveVelocity I γ a) =
+      inner ℝ (curveVelocity I γ b) (curveVelocity I γ b) :=
+  IsGeodesicCurveOn.inner_curveVelocity_eq
+    ((isGeodesicCurveOn_univ (I := I) (γ := γ)).mpr h) isOpen_univ isPreconnected_univ
+    (Set.mem_univ a) (Set.mem_univ b)
+
+/-- An all-time geodesic has the same speed at every two parameters. -/
+theorem IsGeodesicCurve.norm_curveVelocity_eq
+    (h : IsGeodesicCurve I γ) (a b : ℝ) :
+    ‖curveVelocity I γ a‖ = ‖curveVelocity I γ b‖ :=
+  IsGeodesicCurveOn.norm_curveVelocity_eq
+    ((isGeodesicCurveOn_univ (I := I) (γ := γ)).mpr h) isOpen_univ isPreconnected_univ
+    (Set.mem_univ a) (Set.mem_univ b)
+
+end TauCeti.Manifold
+
+end

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/ConstantSpeed.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/ConstantSpeed.lean
@@ -5,35 +5,36 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Reparametrization
+public import TauCeti.Geometry.Manifold.Riemannian.Geodesic.Basic
 public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.AlongCurve.Metric
 
 /-!
 # Constant speed of geodesics
 
-A geodesic has constant speed on every open preconnected parameter set. We first prove that the
-inner product of its velocity with itself is constant, by differentiating it with the
-metric-product rule and using the geodesic equation. Taking square roots gives the usual
-constant-speed statement.
-
-The open-set formulation is the one used by maximal integral curves, whose parameter domains are
-open intervals. It also yields an all-time specialization directly.
+A geodesic has constant speed on every preconnected parameter set. We first prove that the inner
+product of its within-set velocity with itself is constant, by differentiating it with the
+within-set metric-product rule and using the geodesic equation. Taking square roots gives the usual
+constant-speed statement. On an open set this velocity agrees with the unrestricted
+`curveVelocity` by `curveVelocityWithin_of_mem_nhds`; the all-time specializations below are stated
+directly with `curveVelocity`.
 
 ## Main results
 
-* TauCeti.Manifold.IsGeodesicCurveOn.inner_curveVelocity_eq: squared speed is constant on an
-  open preconnected parameter set.
-* TauCeti.Manifold.IsGeodesicCurveOn.norm_curveVelocity_eq: speed is constant there.
-* TauCeti.Manifold.IsGeodesicCurve.norm_curveVelocity_eq: an all-time geodesic has the same
+* `TauCeti.Manifold.IsGeodesicCurveOn.inner_curveVelocityWithin_self_eq`: squared speed is constant
+  on a preconnected parameter set.
+* `TauCeti.Manifold.IsGeodesicCurveOn.norm_curveVelocityWithin_eq`: speed is constant there.
+* `TauCeti.Manifold.IsGeodesicCurve.inner_curveVelocity_self_eq`: an all-time geodesic has the
+  same squared speed at any two parameters.
+* `TauCeti.Manifold.IsGeodesicCurve.norm_curveVelocity_eq`: an all-time geodesic has the same
   speed at any two parameters.
 
 ## References
 
 * [Geodesics, the exponential map, and the Hopf--Rinow theorem roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HopfRinow/README.md),
   Layer 1, "Constant speed".
-* M. P. do Carmo, Riemannian Geometry, Chapter 3, §2.
+* M. P. do Carmo, *Riemannian Geometry*, Chapter 3, §2.
 * The proof follows the organization of
-  DoCarmoLib/Riemannian/Geodesic/HopfRinow/ConstantSpeed.lean in the Apache-2.0
+  `DoCarmoLib/Riemannian/Geodesic/HopfRinow/ConstantSpeed.lean` in the Apache-2.0
   [frenzymath/Poincare-Conjecture](https://github.com/frenzymath/Poincare-Conjecture)
   repository, revision 24f32e4d600878bfaac6bc2f2f9324175571c321, using Tau Ceti's
   set-aware geodesic predicate and Mathlib's Riemannian norm.
@@ -57,81 +58,69 @@ variable
   [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
   {γ : ℝ → M} {s : Set ℝ}
 
-/-- The coordinate reading of the unrestricted velocity of a C² curve is differentiable at
-each point of an open parameter set. -/
-private theorem IsGeodesicCurveOn.differentiableAt_sectionCoord_curveVelocity
-    (h : IsGeodesicCurveOn I γ s) (hs : IsOpen s) {t : ℝ} (ht : t ∈ s) :
-    DifferentiableAt ℝ
-      (sectionCoord (F := E) γ (curveVelocity I γ) (γ t)) t := by
-  let _ : IsManifold I ((1 : ℕ∞ω) + 1) M := IsManifold.of_le (n := 2) (by norm_num)
-  have hγ : ContMDiffOn 𝓘(ℝ, ℝ) I ((1 : ℕ∞ω) + 1) γ s := by
-    norm_num
-    exact h.contMDiffOn
-  have hwithin := (contDiffWithinAt_sectionCoord_curveVelocityWithin γ h.uniqueDiffOn hγ ht
-    (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t))).differentiableWithinAt
-      (by norm_num)
-  have hdiff : DifferentiableAt ℝ
-      (sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ t)) t :=
-    hwithin.differentiableAt (hs.mem_nhds ht)
-  have heq : sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ t) =ᶠ[𝓝 t]
-      sectionCoord (F := E) γ (curveVelocity I γ) (γ t) := by
-    filter_upwards [hs.mem_nhds ht] with r hr
-    rw [sectionCoord_apply, sectionCoord_apply,
-      curveVelocityWithin_of_mem_nhds (hs.mem_nhds hr)]
-  exact heq.differentiableAt_iff.mp hdiff
-
-/-- Squared speed is constant along a geodesic. On an open preconnected parameter set, the
-inner product of the velocity with itself has the same value at every two parameters. -/
-theorem IsGeodesicCurveOn.inner_curveVelocity_eq
-    (h : IsGeodesicCurveOn I γ s) (hs : IsOpen s) (hconn : IsPreconnected s)
+/-- Squared speed is constant along a geodesic. On a preconnected parameter set, the inner product
+of the within-set velocity with itself has the same value at every two parameters. On an open set
+this velocity agrees with the unrestricted `curveVelocity` by
+`curveVelocityWithin_of_mem_nhds`. -/
+theorem IsGeodesicCurveOn.inner_curveVelocityWithin_self_eq
+    (h : IsGeodesicCurveOn I γ s) (hconn : IsPreconnected s)
     {a b : ℝ} (ha : a ∈ s) (hb : b ∈ s) :
-    inner ℝ (curveVelocity I γ a) (curveVelocity I γ a) =
-      inner ℝ (curveVelocity I γ b) (curveVelocity I γ b) := by
-  have hzero := (isGeodesicCurveOn_iff_of_isOpen hs).mp h |>.2
+    inner ℝ (curveVelocityWithin I γ s a) (curveVelocityWithin I γ s a) =
+      inner ℝ (curveVelocityWithin I γ s b) (curveVelocityWithin I γ s b) := by
   have hmetric := (isLeviCivita_leviCivita (I := I) (M := M)).isMetricCompatible
-  apply hs.is_const_of_deriv_eq_zero (f := fun t ↦
-    inner ℝ (curveVelocity I γ t) (curveVelocity I γ t)) hconn
+  apply hconn.ordConnected.convex.is_const_of_fderivWithin_eq_zero
+    (𝕜 := ℝ)
+    (f := fun t : ℝ ↦
+      inner ℝ (curveVelocityWithin I γ s t) (curveVelocityWithin I γ s t))
   · intro t ht
-    have hγt : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t :=
-      (h.contMDiffOn.contMDiffAt (hs.mem_nhds ht)).mdifferentiableAt (by norm_num)
-    exact (hmetric.differentiableAt_inner_alongCurve hγt
-      (h.differentiableAt_sectionCoord_curveVelocity hs ht)
-      (h.differentiableAt_sectionCoord_curveVelocity hs ht)).differentiableWithinAt
+    have hcoord := differentiableWithinAt_sectionCoord_curveVelocityWithin γ h.uniqueDiffOn
+      h.contMDiffOn ht (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t))
+    exact hmetric.differentiableWithinAt_inner (h.uniqueDiffOn t ht)
+      (h.mdifferentiableOn t ht) hcoord hcoord
   · intro t ht
-    have hγt : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t :=
-      (h.contMDiffOn.contMDiffAt (hs.mem_nhds ht)).mdifferentiableAt (by norm_num)
-    rw [hmetric.deriv_inner_alongCurve hγt
-      (h.differentiableAt_sectionCoord_curveVelocity hs ht)
-      (h.differentiableAt_sectionCoord_curveVelocity hs ht), hzero t ht]
-    simp
+    have hcoord := differentiableWithinAt_sectionCoord_curveVelocityWithin γ h.uniqueDiffOn
+      h.contMDiffOn ht (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t))
+    have hprod := hmetric.hasDerivWithinAt_inner_alongCurveWithin (h.uniqueDiffOn t ht)
+      (h.mdifferentiableOn t ht) hcoord hcoord
+    have hderiv : HasDerivWithinAt (fun r ↦
+        inner ℝ (curveVelocityWithin I γ s r) (curveVelocityWithin I γ s r)) 0 s t :=
+      hprod.congr_deriv (by
+        rw [h.alongCurveWithin_curveVelocityWithin_eq_zero t ht]
+        simp)
+    simpa using hderiv.hasFDerivWithinAt.fderivWithin (h.uniqueDiffOn t ht)
   · exact ha
   · exact hb
 
-/-- A geodesic has constant speed. On an open preconnected parameter set, the norm of its
-velocity has the same value at every two parameters. -/
-theorem IsGeodesicCurveOn.norm_curveVelocity_eq
-    (h : IsGeodesicCurveOn I γ s) (hs : IsOpen s) (hconn : IsPreconnected s)
+/-- A geodesic has constant speed. On a preconnected parameter set, the norm of its within-set
+velocity has the same value at every two parameters. On an open set this velocity agrees with the
+unrestricted `curveVelocity` by `curveVelocityWithin_of_mem_nhds`. -/
+theorem IsGeodesicCurveOn.norm_curveVelocityWithin_eq
+    (h : IsGeodesicCurveOn I γ s) (hconn : IsPreconnected s)
     {a b : ℝ} (ha : a ∈ s) (hb : b ∈ s) :
-    ‖curveVelocity I γ a‖ = ‖curveVelocity I γ b‖ := by
+    ‖curveVelocityWithin I γ s a‖ = ‖curveVelocityWithin I γ s b‖ := by
   rw [norm_eq_sqrt_real_inner, norm_eq_sqrt_real_inner,
-    h.inner_curveVelocity_eq hs hconn ha hb]
+    h.inner_curveVelocityWithin_self_eq hconn ha hb]
 
-/-- An all-time geodesic has the same squared speed at every two parameters. -/
-theorem IsGeodesicCurve.inner_curveVelocity_eq
+/-- An all-time geodesic has the same squared speed, expressed using the unrestricted
+`curveVelocity`, at every two parameters. -/
+theorem IsGeodesicCurve.inner_curveVelocity_self_eq
     (h : IsGeodesicCurve I γ) (a b : ℝ) :
     inner ℝ (curveVelocity I γ a) (curveVelocity I γ a) =
-      inner ℝ (curveVelocity I γ b) (curveVelocity I γ b) :=
-  IsGeodesicCurveOn.inner_curveVelocity_eq
-    ((isGeodesicCurveOn_univ (I := I) (γ := γ)).mpr h) isOpen_univ isPreconnected_univ
-    (Set.mem_univ a) (Set.mem_univ b)
+      inner ℝ (curveVelocity I γ b) (curveVelocity I γ b) := by
+  simpa only [curveVelocityWithin_univ] using
+    IsGeodesicCurveOn.inner_curveVelocityWithin_self_eq
+      ((isGeodesicCurveOn_univ (I := I) (γ := γ)).mpr h) isPreconnected_univ
+      (Set.mem_univ a) (Set.mem_univ b)
 
-/-- An all-time geodesic has the same speed at every two parameters. -/
+/-- An all-time geodesic has the same speed, expressed using the unrestricted `curveVelocity`, at
+every two parameters. -/
 theorem IsGeodesicCurve.norm_curveVelocity_eq
     (h : IsGeodesicCurve I γ) (a b : ℝ) :
-    ‖curveVelocity I γ a‖ = ‖curveVelocity I γ b‖ :=
-  IsGeodesicCurveOn.norm_curveVelocity_eq
-    ((isGeodesicCurveOn_univ (I := I) (γ := γ)).mpr h) isOpen_univ isPreconnected_univ
-    (Set.mem_univ a) (Set.mem_univ b)
+    ‖curveVelocity I γ a‖ = ‖curveVelocity I γ b‖ := by
+  simpa only [curveVelocityWithin_univ] using
+    IsGeodesicCurveOn.norm_curveVelocityWithin_eq
+      ((isGeodesicCurveOn_univ (I := I) (γ := γ)).mpr h) isPreconnected_univ
+      (Set.mem_univ a) (Set.mem_univ b)
 
 end TauCeti.Manifold
 

--- a/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Reparametrization.lean
+++ b/TauCeti/Geometry/Manifold/Riemannian/Geodesic/Reparametrization.lean
@@ -85,13 +85,9 @@ theorem IsGeodesicCurveOn.comp_affine (h : IsGeodesicCurveOn I γ s) (a b : ℝ)
         (h.mdifferentiableOn (φ t) (hmaps ht)))).differentiableWithinAt
     have hsection : DifferentiableWithinAt ℝ
         (sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ (φ t))) s (φ t) := by
-      let _ : IsManifold I ((1 : ℕ∞ω) + 1) M := IsManifold.of_le (n := 2) (by norm_num)
-      have hγ : ContMDiffOn 𝓘(ℝ, ℝ) I ((1 : ℕ∞ω) + 1) γ s := by
-        norm_num
-        exact h.contMDiffOn
-      exact (contDiffWithinAt_sectionCoord_curveVelocityWithin γ h.uniqueDiffOn hγ (hmaps ht)
-        (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I)
-          (γ (φ t)))).differentiableWithinAt (by norm_num)
+      exact differentiableWithinAt_sectionCoord_curveVelocityWithin γ h.uniqueDiffOn
+        h.contMDiffOn (hmaps ht) (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I)
+          (γ (φ t)))
     have hvelocity (r : ℝ) (hr : r ∈ u) :
         curveVelocityWithin I (γ ∘ φ) u r =
           a • curveVelocityWithin I γ s (φ r) :=

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Metric.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Metric.lean
@@ -19,12 +19,19 @@ fields along a curve:
 The proof first handles fields pulled back from smooth local-frame fields, where the result is
 Mathlib's ambient `CovariantDerivative.IsMetricCompatible.mvfderiv_inner_eq` and the chain rule.
 A differentiable field along the curve is locally a finite linear combination of those pullbacks;
-the additive and scalar Leibniz laws of `CovariantDerivative.alongCurve` finish the argument.
+the additive and scalar Leibniz laws of `CovariantDerivative.alongCurveWithin` finish the argument.
 
-## Main result
+## Main results
 
-* `CovariantDerivative.IsMetricCompatible.deriv_inner_alongCurve`: the metric product rule for
-  two differentiable tangent fields along a differentiable real curve.
+* `CovariantDerivative.IsMetricCompatible.hasDerivWithinAt_inner_alongCurveWithin`: the
+  within-set metric product rule for two differentiable tangent fields along a differentiable
+  real curve.
+* `CovariantDerivative.IsMetricCompatible.differentiableWithinAt_inner` and
+  `CovariantDerivative.IsMetricCompatible.derivWithin_inner_alongCurveWithin`: its two principal
+  consequences.
+* `CovariantDerivative.IsMetricCompatible.hasDerivAt_inner_alongCurve`: the unrestricted form,
+  with `CovariantDerivative.IsMetricCompatible.differentiableAt_inner` and
+  `CovariantDerivative.IsMetricCompatible.deriv_inner_alongCurve` as consequences.
 
 ## References
 
@@ -51,145 +58,137 @@ open TauCeti.Manifold
 variable
   {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
-  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 2 M]
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 1 M]
   [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
   [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
   [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
   {cov : _root_.CovariantDerivative I E (fun x : M ↦ TangentSpace I x)}
-  {γ : ℝ → M} {t : ℝ}
+  {γ : ℝ → M} {s : Set ℝ} {t : ℝ}
 
-/-- The product-rule statement at one parameter, packaged for the local-frame induction. -/
-private def HasMetricProductRuleAt
+/-- The within-set product-rule statement at one parameter, packaged for the local-frame
+induction. -/
+private abbrev HasMetricProductRuleWithinAt
     (V W : ∀ r, TangentSpace I (γ r)) : Prop :=
-  DifferentiableAt ℝ (fun r ↦ inner ℝ (V r) (W r)) t ∧
-    deriv (fun r ↦ inner ℝ (V r) (W r)) t =
-      inner ℝ (alongCurve cov γ V t) (W t) +
-        inner ℝ (V t) (alongCurve cov γ W t)
+  HasDerivWithinAt (fun r ↦ inner ℝ (V r) (W r))
+    (inner ℝ (alongCurveWithin cov γ V s t) (W t) +
+      inner ℝ (V t) (alongCurveWithin cov γ W s t)) s t
 
 /-- Metric compatibility along a curve for fields pulled back from ambient differentiable
 sections. -/
-private theorem IsMetricCompatible.hasMetricProductRuleAt_pullback
+private theorem IsMetricCompatible.hasMetricProductRuleWithinAt_pullback
     (hcov : CovariantDerivative.IsMetricCompatible
       (V := fun x : M ↦ TangentSpace I x) cov)
-    (hγ : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t)
+    (hu : UniqueDiffWithinAt ℝ s t)
+    (hγ : MDifferentiableWithinAt 𝓘(ℝ, ℝ) I γ s t)
     {X Y : (x : M) → TangentSpace I x}
     (hX : MDiffAt (T% X) (γ t)) (hY : MDiffAt (T% Y) (γ t)) :
-    HasMetricProductRuleAt (cov := cov) (γ := γ) (t := t) (fun r ↦ X (γ r))
+    HasMetricProductRuleWithinAt (cov := cov) (γ := γ) (s := s) (t := t) (fun r ↦ X (γ r))
       (fun r ↦ Y (γ r)) := by
-  rw [HasMetricProductRuleAt]
-  let v := curveVelocity I γ t
+  let v := curveVelocityWithin I γ s t
   let Z : (x : M) → TangentSpace I x := FiberBundle.extend E v
   have hinner : MDifferentiableAt I 𝓘(ℝ, ℝ) (fun x ↦ inner ℝ (X x) (Y x)) (γ t) :=
     MDifferentiableAt.inner_bundle (IB := I) (F := E)
       (E := fun x : M ↦ TangentSpace I x) (b := id) hX hY
-  have hchain := hasDerivAt_comp_curve hinner
-    (hasMFDerivAt_curveVelocity hγ)
+  have hchain := hasDerivWithinAt_comp_curve hinner
+    (hasMFDerivWithinAt_curveVelocityWithin hγ)
   have hmetric := hcov.mvfderiv_inner_eq Z hX hY
-  have hZ : Z (γ t) = curveVelocity I γ t := by
-    exact FiberBundle.extend_apply_self E v
-  dsimp only at hmetric
-  rw [hZ] at hmetric
+  have hZ : Z (γ t) = curveVelocityWithin I γ s t := FiberBundle.extend_apply_self E v
   have hmetric' :
-      mvfderiv I (fun x ↦ inner ℝ (X x) (Y x)) (γ t) (curveVelocity I γ t) =
-        inner ℝ (cov X (γ t) (curveVelocity I γ t)) (Y (γ t)) +
-          inner ℝ (X (γ t)) (cov Y (γ t) (curveVelocity I γ t)) := by
-    simpa only [Function.comp_apply] using hmetric
+      mvfderiv I (fun x ↦ inner ℝ (X x) (Y x)) (γ t) (curveVelocityWithin I γ s t) =
+        inner ℝ (cov X (γ t) (curveVelocityWithin I γ s t)) (Y (γ t)) +
+          inner ℝ (X (γ t)) (cov Y (γ t) (curveVelocityWithin I γ s t)) := by
+    simpa only [Function.comp_apply, hZ] using hmetric
   rw [hmetric'] at hchain
-  rw [alongCurve_pullback cov γ X (hasMFDerivAt_curveVelocity hγ) hX,
-    alongCurve_pullback cov γ Y (hasMFDerivAt_curveVelocity hγ) hY]
-  exact ⟨hchain.differentiableAt, hchain.deriv⟩
+  change HasDerivWithinAt (fun r ↦ inner ℝ (X (γ r)) (Y (γ r)))
+    (inner ℝ (alongCurveWithin cov γ (fun r ↦ X (γ r)) s t) (Y (γ t)) +
+      inner ℝ (X (γ t)) (alongCurveWithin cov γ (fun r ↦ Y (γ r)) s t)) s t
+  rw [alongCurveWithin_pullback_curveVelocityWithin cov γ X hu hγ hX,
+    alongCurveWithin_pullback_curveVelocityWithin cov γ Y hu hγ hY]
+  -- The chain-rule result uses a definitionally equal real normed-space instance.
+  convert hchain using 1 <;> rfl
+
+omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- The product rule is symmetric in its fields. -/
+private lemma HasMetricProductRuleWithinAt.symm
+    {V W : ∀ r, TangentSpace I (γ r)}
+    (h : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W) :
+    HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) W V := by
+  change HasDerivWithinAt (fun r ↦ inner ℝ (V r) (W r)) _ s t at h
+  change HasDerivWithinAt (fun r ↦ inner ℝ (W r) (V r)) _ s t
+  have hfun : (fun r ↦ inner ℝ (W r) (V r)) = fun r ↦ inner ℝ (V r) (W r) := by
+    funext r
+    exact real_inner_comm _ _
+  rw [hfun]
+  refine h.congr_deriv ?_
+  rw [real_inner_comm (alongCurveWithin cov γ V s t) (W t),
+    real_inner_comm (V t) (alongCurveWithin cov γ W s t), add_comm]
 
 omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
 /-- The product rule is additive in its first field. -/
-private lemma HasMetricProductRuleAt.add_left
+private lemma HasMetricProductRuleWithinAt.add_left
     {V V' W : ∀ r, TangentSpace I (γ r)}
-    (hV : HasMetricProductRuleAt (cov := cov) (t := t) V W)
-    (hV' : HasMetricProductRuleAt (cov := cov) (t := t) V' W)
-    (hcoordV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t)
-    (hcoordV' : DifferentiableAt ℝ (sectionCoord (F := E) γ V' (γ t)) t) :
-    HasMetricProductRuleAt (cov := cov) (t := t) (fun r ↦ V r + V' r) W := by
-  rw [HasMetricProductRuleAt] at hV hV' ⊢
+    (hV : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W)
+    (hV' : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V' W)
+    (hcoordV : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ V (γ t)) s t)
+    (hcoordV' : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ V' (γ t)) s t) :
+    HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t)
+      (fun r ↦ V r + V' r) W := by
+  change HasDerivWithinAt (fun r ↦ inner ℝ (V r) (W r)) _ s t at hV
+  change HasDerivWithinAt (fun r ↦ inner ℝ (V' r) (W r)) _ s t at hV'
+  change HasDerivWithinAt (fun r ↦ inner ℝ (V r + V' r) (W r)) _ s t
   have hfun : (fun r ↦ inner ℝ (V r + V' r) (W r)) =
-      (fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V' r) (W r)) := by
+      fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V' r) (W r) := by
     funext r
     exact inner_add_left _ _ _
-  constructor
-  · rw [hfun]
-    exact hV.1.add hV'.1
-  · have hd := deriv_add hV.1 hV'.1
-    change deriv (fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V' r) (W r)) t = _ at hd
-    rw [hfun, hd, hV.2, hV'.2,
-      alongCurve_add cov γ V V' hcoordV hcoordV']
-    simp only [inner_add_left]
-    ring
+  rw [hfun]
+  refine (hV.add hV').congr_deriv ?_
+  rw [alongCurveWithin_add cov γ V V' s hcoordV hcoordV']
+  simp only [inner_add_left]
+  ring
 
 omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
 /-- The product rule is additive in its second field. -/
-private lemma HasMetricProductRuleAt.add_right
+private lemma HasMetricProductRuleWithinAt.add_right
     {V W W' : ∀ r, TangentSpace I (γ r)}
-    (hW : HasMetricProductRuleAt (cov := cov) (t := t) V W)
-    (hW' : HasMetricProductRuleAt (cov := cov) (t := t) V W')
-    (hcoordW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t)
-    (hcoordW' : DifferentiableAt ℝ (sectionCoord (F := E) γ W' (γ t)) t) :
-    HasMetricProductRuleAt (cov := cov) (t := t) V (fun r ↦ W r + W' r) := by
-  rw [HasMetricProductRuleAt] at hW hW' ⊢
-  have hfun : (fun r ↦ inner ℝ (V r) (W r + W' r)) =
-      (fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V r) (W' r)) := by
-    funext r
-    exact inner_add_right _ _ _
-  constructor
-  · rw [hfun]
-    exact hW.1.add hW'.1
-  · have hd := deriv_add hW.1 hW'.1
-    change deriv (fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V r) (W' r)) t = _ at hd
-    rw [hfun, hd, hW.2, hW'.2,
-      alongCurve_add cov γ W W' hcoordW hcoordW']
-    simp only [inner_add_right]
-    ring
+    (hW : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W)
+    (hW' : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W')
+    (hcoordW : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ W (γ t)) s t)
+    (hcoordW' : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ W' (γ t)) s t) :
+    HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V
+      (fun r ↦ W r + W' r) :=
+  (hW.symm.add_left hW'.symm hcoordW hcoordW').symm
 
 omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
 /-- The product rule is preserved by multiplying its first field by a differentiable scalar. -/
-private lemma HasMetricProductRuleAt.smul_left
+private lemma HasMetricProductRuleWithinAt.smul_left
     {V W : ∀ r, TangentSpace I (γ r)} {f : ℝ → ℝ}
-    (hV : HasMetricProductRuleAt (cov := cov) (t := t) V W)
-    (hf : DifferentiableAt ℝ f t)
-    (hcoordV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t) :
-    HasMetricProductRuleAt (cov := cov) (t := t) (fun r ↦ f r • V r) W := by
-  rw [HasMetricProductRuleAt] at hV ⊢
+    (hV : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W)
+    (hf : DifferentiableWithinAt ℝ f s t)
+    (hcoordV : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ V (γ t)) s t) :
+    HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t)
+      (fun r ↦ f r • V r) W := by
+  change HasDerivWithinAt (fun r ↦ inner ℝ (V r) (W r)) _ s t at hV
+  change HasDerivWithinAt (fun r ↦ inner ℝ (f r • V r) (W r)) _ s t
   have hfun : (fun r ↦ inner ℝ (f r • V r) (W r)) =
-      (fun r ↦ f r * inner ℝ (V r) (W r)) := by
+      fun r ↦ f r * inner ℝ (V r) (W r) := by
     funext r
     exact real_inner_smul_left _ _ _
-  constructor
-  · rw [hfun]
-    exact hf.mul hV.1
-  · have hd := deriv_mul hf hV.1
-    change deriv (fun r ↦ f r * inner ℝ (V r) (W r)) t = _ at hd
-    rw [hfun, hd, hV.2, alongCurve_smul cov γ V f hf hcoordV]
-    simp only [inner_add_left, real_inner_smul_left]
-    ring
+  rw [hfun]
+  refine (hf.hasDerivWithinAt.mul hV).congr_deriv ?_
+  rw [alongCurveWithin_smul cov γ V f s hf hcoordV]
+  simp only [inner_add_left, real_inner_smul_left]
+  ring
 
 omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
 /-- The product rule is preserved by multiplying its second field by a differentiable scalar. -/
-private lemma HasMetricProductRuleAt.smul_right
+private lemma HasMetricProductRuleWithinAt.smul_right
     {V W : ∀ r, TangentSpace I (γ r)} {f : ℝ → ℝ}
-    (hW : HasMetricProductRuleAt (cov := cov) (t := t) V W)
-    (hf : DifferentiableAt ℝ f t)
-    (hcoordW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t) :
-    HasMetricProductRuleAt (cov := cov) (t := t) V (fun r ↦ f r • W r) := by
-  rw [HasMetricProductRuleAt] at hW ⊢
-  have hfun : (fun r ↦ inner ℝ (V r) (f r • W r)) =
-      (fun r ↦ f r * inner ℝ (V r) (W r)) := by
-    funext r
-    rw [real_inner_smul_right, mul_comm]
-  constructor
-  · rw [hfun]
-    exact hf.mul hW.1
-  · have hd := deriv_mul hf hW.1
-    change deriv (fun r ↦ f r * inner ℝ (V r) (W r)) t = _ at hd
-    rw [hfun, hd, hW.2, alongCurve_smul cov γ W f hf hcoordW]
-    simp only [inner_add_right, real_inner_smul_right]
-    ring
+    (hW : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W)
+    (hf : DifferentiableWithinAt ℝ f s t)
+    (hcoordW : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ W (γ t)) s t) :
+    HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V
+      (fun r ↦ f r • W r) :=
+  (hW.symm.smul_left hf hcoordW).symm
 
 omit [FiniteDimensional ℝ E]
   [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
@@ -197,85 +196,76 @@ omit [FiniteDimensional ℝ E]
   [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
 /-- A finite sum of fields with differentiable coordinate readings again has a differentiable
 coordinate reading. -/
-private lemma differentiableAt_sectionCoord_finsetSum
+private lemma differentiableWithinAt_sectionCoord_finsetSum
     {ι : Type*} {A : Finset ι} {U : ι → ∀ r, TangentSpace I (γ r)}
-    (hU : ∀ i ∈ A, DifferentiableAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) t) :
-    DifferentiableAt ℝ
-      (sectionCoord (F := E) γ (fun r ↦ ∑ i ∈ A, U i r) (γ t)) t := by
-  classical
-  have hfun : sectionCoord (F := E) γ (fun r ↦ ∑ i ∈ A, U i r) (γ t) =
-      fun r ↦ ∑ i ∈ A, sectionCoord (F := E) γ (U i) (γ t) r := by
-    funext r
-    simp only [sectionCoord_apply, map_sum]
-  rw [hfun]
-  exact DifferentiableAt.fun_sum hU
+    (hU : ∀ i ∈ A,
+      DifferentiableWithinAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) s t) :
+    DifferentiableWithinAt ℝ
+      (sectionCoord (F := E) γ (fun r ↦ ∑ i ∈ A, U i r) (γ t)) s t := by
+  rw [sectionCoord_sum]
+  exact DifferentiableWithinAt.fun_sum hU
 
 omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
 /-- The product rule is preserved by a finite sum in its first field. -/
-private lemma HasMetricProductRuleAt.finsetSum_left
+private lemma HasMetricProductRuleWithinAt.finsetSum_left
     {ι : Type*} {A : Finset ι} {U : ι → ∀ r, TangentSpace I (γ r)}
     {W : ∀ r, TangentSpace I (γ r)}
-    (hU : ∀ i ∈ A, HasMetricProductRuleAt (cov := cov) (t := t) (U i) W)
+    (hU : ∀ i ∈ A,
+      HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) (U i) W)
     (hcoordU : ∀ i ∈ A,
-      DifferentiableAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) t) :
-    HasMetricProductRuleAt (cov := cov) (t := t) (fun r ↦ ∑ i ∈ A, U i r) W := by
+      DifferentiableWithinAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) s t) :
+    HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t)
+      (fun r ↦ ∑ i ∈ A, U i r) W := by
   classical
   induction A using Finset.induction_on with
   | empty =>
-      rw [HasMetricProductRuleAt]
-      simp
+      change HasDerivWithinAt (fun r ↦ inner ℝ (0 : TangentSpace I (γ r)) (W r)) _ s t
+      simpa using (hasDerivWithinAt_const (x := t) (s := s) (c := (0 : ℝ)))
   | @insert a A ha ih =>
       have ha_rule := hU a (Finset.mem_insert_self a A)
       have hA_rule := ih (fun i hi ↦ hU i (Finset.mem_insert_of_mem hi))
         (fun i hi ↦ hcoordU i (Finset.mem_insert_of_mem hi))
       have hsum := ha_rule.add_left hA_rule
         (hcoordU a (Finset.mem_insert_self a A))
-        (differentiableAt_sectionCoord_finsetSum
+        (differentiableWithinAt_sectionCoord_finsetSum
           (fun i hi ↦ hcoordU i (Finset.mem_insert_of_mem hi)))
       simpa only [Finset.sum_insert ha, Pi.add_apply] using hsum
 
 omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
 /-- The product rule is preserved by a finite sum in its second field. -/
-private lemma HasMetricProductRuleAt.finsetSum_right
+private lemma HasMetricProductRuleWithinAt.finsetSum_right
     {ι : Type*} {A : Finset ι} {V : ∀ r, TangentSpace I (γ r)}
     {U : ι → ∀ r, TangentSpace I (γ r)}
-    (hU : ∀ i ∈ A, HasMetricProductRuleAt (cov := cov) (t := t) V (U i))
+    (hU : ∀ i ∈ A,
+      HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V (U i))
     (hcoordU : ∀ i ∈ A,
-      DifferentiableAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) t) :
-    HasMetricProductRuleAt (cov := cov) (t := t) V (fun r ↦ ∑ i ∈ A, U i r) := by
-  classical
-  induction A using Finset.induction_on with
-  | empty =>
-      rw [HasMetricProductRuleAt]
-      simp
-  | @insert a A ha ih =>
-      have ha_rule := hU a (Finset.mem_insert_self a A)
-      have hA_rule := ih (fun i hi ↦ hU i (Finset.mem_insert_of_mem hi))
-        (fun i hi ↦ hcoordU i (Finset.mem_insert_of_mem hi))
-      have hsum := ha_rule.add_right hA_rule
-        (hcoordU a (Finset.mem_insert_self a A))
-        (differentiableAt_sectionCoord_finsetSum
-          (fun i hi ↦ hcoordU i (Finset.mem_insert_of_mem hi)))
-      simpa only [Finset.sum_insert ha, Pi.add_apply] using hsum
+      DifferentiableWithinAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) s t) :
+    HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V
+      (fun r ↦ ∑ i ∈ A, U i r) :=
+  ((HasMetricProductRuleWithinAt.finsetSum_left
+    (hU := fun i hi ↦ (hU i hi).symm) hcoordU).symm)
 
-/-- The metric product rule for arbitrary differentiable fields along a curve. -/
-private theorem IsMetricCompatible.hasMetricProductRuleAt
+/-- The metric product rule for arbitrary differentiable fields along a curve, within a parameter
+set. -/
+private theorem IsMetricCompatible.hasMetricProductRuleWithinAt
     (hcov : CovariantDerivative.IsMetricCompatible
       (V := fun x : M ↦ TangentSpace I x) cov)
-    (hγ : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t)
+    (hu : UniqueDiffWithinAt ℝ s t)
+    (hγ : MDifferentiableWithinAt 𝓘(ℝ, ℝ) I γ s t)
     {V W : ∀ r, TangentSpace I (γ r)}
-    (hV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t)
-    (hW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t) :
-    HasMetricProductRuleAt (cov := cov) (t := t) V W := by
+    (hV : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ V (γ t)) s t)
+    (hW : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ W (γ t)) s t) :
+    HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W := by
   classical
+  -- Choose a smooth local frame around the point of the curve.
   let e := trivializationAt E (TangentSpace I) (γ t)
   let b := Module.finBasis ℝ E
   let X : Fin (Module.finrank ℝ E) → (x : M) → TangentSpace I x :=
     fun i ↦ e.localFrame b i
   let aV : Fin (Module.finrank ℝ E) → ℝ → ℝ := fun i r ↦
-    b.repr (sectionCoord (F := E) γ V (γ t) r) i
+    b.coord i (sectionCoord (F := E) γ V (γ t) r)
   let aW : Fin (Module.finrank ℝ E) → ℝ → ℝ := fun i r ↦
-    b.repr (sectionCoord (F := E) γ W (γ t) r) i
+    b.coord i (sectionCoord (F := E) γ W (γ t) r)
   let U : Fin (Module.finrank ℝ E) → ∀ r, TangentSpace I (γ r) :=
     fun i r ↦ aV i r • X i (γ r)
   let Z : Fin (Module.finrank ℝ E) → ∀ r, TangentSpace I (γ r) :=
@@ -285,91 +275,155 @@ private theorem IsMetricCompatible.hasMetricProductRuleAt
   have hframe (i : Fin (Module.finrank ℝ E)) : MDiffAt (T% (X i)) (γ t) := by
     exact (((e.isLocalFrameOn_localFrame_baseSet I 1 b).contMDiffOn i).mdifferentiableOn
       one_ne_zero).mdifferentiableAt (e.open_baseSet.mem_nhds hbase)
-  have haV (i : Fin (Module.finrank ℝ E)) : DifferentiableAt ℝ (aV i) t := by
-    change DifferentiableAt ℝ ((b.coord i) ∘ sectionCoord (F := E) γ V (γ t)) t
-    exact (LinearMap.toContinuousLinearMap (b.coord i)).differentiableAt.comp t hV
-  have haW (i : Fin (Module.finrank ℝ E)) : DifferentiableAt ℝ (aW i) t := by
-    change DifferentiableAt ℝ ((b.coord i) ∘ sectionCoord (F := E) γ W (γ t)) t
-    exact (LinearMap.toContinuousLinearMap (b.coord i)).differentiableAt.comp t hW
+  -- Coordinate coefficients and pulled-back frame fields are differentiable within the set.
+  have haV (i : Fin (Module.finrank ℝ E)) : DifferentiableWithinAt ℝ (aV i) s t := by
+    exact (LinearMap.toContinuousLinearMap (b.coord i)).differentiableAt
+      |>.comp_differentiableWithinAt t hV
+  have haW (i : Fin (Module.finrank ℝ E)) : DifferentiableWithinAt ℝ (aW i) s t := by
+    exact (LinearMap.toContinuousLinearMap (b.coord i)).differentiableAt
+      |>.comp_differentiableWithinAt t hW
   have hcoordX (i : Fin (Module.finrank ℝ E)) :
-      DifferentiableAt ℝ
-        (sectionCoord (F := E) γ (fun r ↦ X i (γ r)) (γ t)) t := by
-    exact differentiableAt_sectionCoord γ (fun r ↦ X i (γ r))
-      ((hframe i).comp t hγ) hbase
+      DifferentiableWithinAt ℝ
+        (sectionCoord (F := E) γ (fun r ↦ X i (γ r)) (γ t)) s t := by
+    exact differentiableWithinAt_sectionCoord γ (fun r ↦ X i (γ r))
+      ((hframe i).comp_mdifferentiableWithinAt t hγ) hbase
+  have hcoordTerm (a : Fin (Module.finrank ℝ E) → ℝ → ℝ)
+      (ha : ∀ i, DifferentiableWithinAt ℝ (a i) s t)
+      (i : Fin (Module.finrank ℝ E)) :
+      DifferentiableWithinAt ℝ
+        (sectionCoord (F := E) γ (fun r ↦ a i r • X i (γ r)) (γ t)) s t := by
+    rw [sectionCoord_smul]
+    exact (ha i).smul (hcoordX i)
   have hcoordU (i : Fin (Module.finrank ℝ E)) :
-      DifferentiableAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) t := by
-    rw [show sectionCoord (F := E) γ (U i) (γ t) =
-      aV i • sectionCoord (F := E) γ (fun r ↦ X i (γ r)) (γ t) by
-        exact sectionCoord_smul γ (fun r ↦ X i (γ r)) (aV i) (γ t)]
-    exact (haV i).smul (hcoordX i)
+      DifferentiableWithinAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) s t :=
+    hcoordTerm aV haV i
   have hcoordZ (i : Fin (Module.finrank ℝ E)) :
-      DifferentiableAt ℝ (sectionCoord (F := E) γ (Z i) (γ t)) t := by
-    rw [show sectionCoord (F := E) γ (Z i) (γ t) =
-      aW i • sectionCoord (F := E) γ (fun r ↦ X i (γ r)) (γ t) by
-        exact sectionCoord_smul γ (fun r ↦ X i (γ r)) (aW i) (γ t)]
-    exact (haW i).smul (hcoordX i)
+      DifferentiableWithinAt ℝ (sectionCoord (F := E) γ (Z i) (γ t)) s t :=
+    hcoordTerm aW haW i
+  -- Apply metric compatibility termwise, then sum both frame expansions.
   have hterm (i j : Fin (Module.finrank ℝ E)) :
-      HasMetricProductRuleAt (cov := cov) (t := t) (U i) (Z j) := by
-    exact ((hcov.hasMetricProductRuleAt_pullback hγ (hframe i) (hframe j)).smul_left
+      HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) (U i) (Z j) := by
+    exact ((hcov.hasMetricProductRuleWithinAt_pullback hu hγ (hframe i) (hframe j)).smul_left
       (haV i) (hcoordX i)).smul_right (haW j) (hcoordX j)
-  have hsum : HasMetricProductRuleAt (cov := cov) (t := t)
+  have hsum : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t)
       (fun r ↦ ∑ i, U i r) (fun r ↦ ∑ j, Z j r) := by
-    refine HasMetricProductRuleAt.finsetSum_left
+    refine HasMetricProductRuleWithinAt.finsetSum_left
       (A := Finset.univ) (U := U) (W := fun r ↦ ∑ j, Z j r) ?_ ?_
     · intro i hi
-      exact HasMetricProductRuleAt.finsetSum_right
+      exact HasMetricProductRuleWithinAt.finsetSum_right
         (A := Finset.univ) (hU := fun j _ ↦ hterm i j) (fun j _ ↦ hcoordZ j)
     · exact fun i _ ↦ hcoordU i
-  have hnear : ∀ᶠ r in 𝓝 t, γ r ∈ e.baseSet :=
-    hγ.continuousAt.preimage_mem_nhds (e.open_baseSet.mem_nhds hbase)
-  have hVsum : V =ᶠ[𝓝 t] fun r ↦ ∑ i, U i r := by
+  -- The chosen frame expansion agrees with each original field near `t` and at `t` itself.
+  have hnear : ∀ᶠ r in 𝓝[s] t, γ r ∈ e.baseSet :=
+    hγ.continuousWithinAt.preimage_mem_nhdsWithin (e.open_baseSet.mem_nhds hbase)
+  have frameExpansion (Q : ∀ r, TangentSpace I (γ r)) :
+      Q =ᶠ[𝓝[s] t] fun r ↦ ∑ i,
+        b.repr (sectionCoord (F := E) γ Q (γ t) r) i • X i (γ r) := by
     filter_upwards [hnear] with r hr
     calc
-      V r = e.symmL ℝ (γ r) (sectionCoord (F := E) γ V (γ t) r) := by
+      Q r = e.symmL ℝ (γ r) (sectionCoord (F := E) γ Q (γ t) r) := by
         rw [sectionCoord_apply, e.symmL_continuousLinearMapAt (R := ℝ) hr]
       _ = e.symmL ℝ (γ r)
-          (∑ i, b.repr (sectionCoord (F := E) γ V (γ t) r) i • b i) := by
+          (∑ i, b.repr (sectionCoord (F := E) γ Q (γ t) r) i • b i) := by
         rw [b.sum_repr]
-      _ = ∑ i, U i r := by
-        simp only [map_sum, map_smul, U, aV, X, symmL_basis_eq_localFrame b hr]
-  have hWsum : W =ᶠ[𝓝 t] fun r ↦ ∑ i, Z i r := by
-    filter_upwards [hnear] with r hr
+      _ = ∑ i, b.repr (sectionCoord (F := E) γ Q (γ t) r) i • X i (γ r) := by
+        simp only [map_sum, map_smul, X, symmL_basis_eq_localFrame b hr]
+  have frameExpansionAt (Q : ∀ r, TangentSpace I (γ r)) :
+      Q t = ∑ i, b.repr (sectionCoord (F := E) γ Q (γ t) t) i • X i (γ t) := by
     calc
-      W r = e.symmL ℝ (γ r) (sectionCoord (F := E) γ W (γ t) r) := by
-        rw [sectionCoord_apply, e.symmL_continuousLinearMapAt (R := ℝ) hr]
-      _ = e.symmL ℝ (γ r)
-          (∑ i, b.repr (sectionCoord (F := E) γ W (γ t) r) i • b i) := by
+      Q t = e.symmL ℝ (γ t) (sectionCoord (F := E) γ Q (γ t) t) := by
+        rw [sectionCoord_apply, e.symmL_continuousLinearMapAt (R := ℝ) hbase]
+      _ = e.symmL ℝ (γ t)
+          (∑ i, b.repr (sectionCoord (F := E) γ Q (γ t) t) i • b i) := by
         rw [b.sum_repr]
-      _ = ∑ i, Z i r := by
-        simp only [map_sum, map_smul, Z, aW, X, symmL_basis_eq_localFrame b hr]
-  have hinner : (fun r ↦ inner ℝ (V r) (W r)) =ᶠ[𝓝 t]
+      _ = ∑ i, b.repr (sectionCoord (F := E) γ Q (γ t) t) i • X i (γ t) := by
+        simp only [map_sum, map_smul, X, symmL_basis_eq_localFrame b hbase]
+  have hVsum : V =ᶠ[𝓝[s] t] fun r ↦ ∑ i, U i r := by
+    simpa only [U, aV, b.coord_apply] using frameExpansion V
+  have hWsum : W =ᶠ[𝓝[s] t] fun r ↦ ∑ i, Z i r := by
+    simpa only [Z, aW, b.coord_apply] using frameExpansion W
+  have hVt : V t = ∑ i, U i t := by
+    simpa only [U, aV, b.coord_apply] using frameExpansionAt V
+  have hWt : W t = ∑ i, Z i t := by
+    simpa only [Z, aW, b.coord_apply] using frameExpansionAt W
+  have hinner : (fun r ↦ inner ℝ (V r) (W r)) =ᶠ[𝓝[s] t]
       fun r ↦ inner ℝ (∑ i, U i r) (∑ j, Z j r) := by
     filter_upwards [hVsum, hWsum] with r hVr hWr
     rw [hVr, hWr]
     rfl
-  have hDV : alongCurve cov γ V t =
-      alongCurve cov γ (fun r ↦ ∑ i, U i r) t :=
-    alongCurve_congr cov γ V hVsum
-  have hDW : alongCurve cov γ W t =
-      alongCurve cov γ (fun r ↦ ∑ i, Z i r) t :=
-    alongCurve_congr cov γ W hWsum
-  have hVt : V t = ∑ i, U i t := hVsum.self_of_nhds
-  have hWt : W t = ∑ i, Z i t := hWsum.self_of_nhds
-  rw [HasMetricProductRuleAt] at hsum ⊢
-  constructor
-  · exact hinner.differentiableAt_iff.mpr hsum.1
-  · calc
-      deriv (fun r ↦ inner ℝ (V r) (W r)) t =
-          deriv (fun r ↦ inner ℝ (∑ i, U i r) (∑ j, Z j r)) t := hinner.deriv_eq
-      _ = inner ℝ (alongCurve cov γ (fun r ↦ ∑ i, U i r) t) (∑ j, Z j t) +
-          inner ℝ (∑ i, U i t) (alongCurve cov γ (fun r ↦ ∑ j, Z j r) t) := hsum.2
-      _ = inner ℝ (alongCurve cov γ V t) (W t) +
-          inner ℝ (V t) (alongCurve cov γ W t) := by
-        rw [hDV, hDW, hVt, hWt]
+  have hDV : alongCurveWithin cov γ V s t =
+      alongCurveWithin cov γ (fun r ↦ ∑ i, U i r) s t :=
+    alongCurveWithin_congr cov γ V hVsum hVt
+  have hDW : alongCurveWithin cov γ W s t =
+      alongCurveWithin cov γ (fun r ↦ ∑ i, Z i r) s t :=
+    alongCurveWithin_congr cov γ W hWsum hWt
+  have hinnerAt : inner ℝ (V t) (W t) = inner ℝ (∑ i, U i t) (∑ j, Z j t) := by
+    rw [hVt, hWt]
+  refine (hsum.congr_of_eventuallyEq hinner hinnerAt).congr_deriv ?_
+  rw [hDV, hDW, hVt, hWt]
+
+/-- The within-set product rule for a metric-compatible covariant derivative acting on two
+differentiable tangent fields along a differentiable real curve. -/
+theorem IsMetricCompatible.hasDerivWithinAt_inner_alongCurveWithin
+    (hcov : CovariantDerivative.IsMetricCompatible
+      (V := fun x : M ↦ TangentSpace I x) cov)
+    (hu : UniqueDiffWithinAt ℝ s t)
+    (hγ : MDifferentiableWithinAt 𝓘(ℝ, ℝ) I γ s t)
+    {V W : ∀ r, TangentSpace I (γ r)}
+    (hV : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ V (γ t)) s t)
+    (hW : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ W (γ t)) s t) :
+    HasDerivWithinAt (fun r ↦ inner ℝ (V r) (W r))
+      (inner ℝ (alongCurveWithin cov γ V s t) (W t) +
+        inner ℝ (V t) (alongCurveWithin cov γ W s t)) s t :=
+  hcov.hasMetricProductRuleWithinAt hu hγ hV hW
+
+/-- The fibrewise inner product of two differentiable tangent fields along a differentiable curve
+is differentiable within the parameter set. -/
+theorem IsMetricCompatible.differentiableWithinAt_inner
+    (hcov : CovariantDerivative.IsMetricCompatible
+      (V := fun x : M ↦ TangentSpace I x) cov)
+    (hu : UniqueDiffWithinAt ℝ s t)
+    (hγ : MDifferentiableWithinAt 𝓘(ℝ, ℝ) I γ s t)
+    {V W : ∀ r, TangentSpace I (γ r)}
+    (hV : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ V (γ t)) s t)
+    (hW : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ W (γ t)) s t) :
+    DifferentiableWithinAt ℝ (fun r ↦ inner ℝ (V r) (W r)) s t :=
+  (hcov.hasDerivWithinAt_inner_alongCurveWithin hu hγ hV hW).differentiableWithinAt
+
+/-- The derivative identity supplied by metric compatibility within a parameter set. -/
+theorem IsMetricCompatible.derivWithin_inner_alongCurveWithin
+    (hcov : CovariantDerivative.IsMetricCompatible
+      (V := fun x : M ↦ TangentSpace I x) cov)
+    (hu : UniqueDiffWithinAt ℝ s t)
+    (hγ : MDifferentiableWithinAt 𝓘(ℝ, ℝ) I γ s t)
+    {V W : ∀ r, TangentSpace I (γ r)}
+    (hV : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ V (γ t)) s t)
+    (hW : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ W (γ t)) s t) :
+    derivWithin (fun r ↦ inner ℝ (V r) (W r)) s t =
+      inner ℝ (alongCurveWithin cov γ V s t) (W t) +
+        inner ℝ (V t) (alongCurveWithin cov γ W s t) :=
+  (hcov.hasDerivWithinAt_inner_alongCurveWithin hu hγ hV hW).derivWithin hu
+
+/-- The unrestricted product rule for a metric-compatible covariant derivative acting on two
+differentiable tangent fields along a differentiable real curve. -/
+theorem IsMetricCompatible.hasDerivAt_inner_alongCurve
+    (hcov : CovariantDerivative.IsMetricCompatible
+      (V := fun x : M ↦ TangentSpace I x) cov)
+    (hγ : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t)
+    {V W : ∀ r, TangentSpace I (γ r)}
+    (hV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t)
+    (hW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t) :
+    HasDerivAt (fun r ↦ inner ℝ (V r) (W r))
+      (inner ℝ (alongCurve cov γ V t) (W t) +
+        inner ℝ (V t) (alongCurve cov γ W t)) t := by
+  apply hasDerivWithinAt_univ.mp
+  simpa only [alongCurveWithin_univ] using
+    hcov.hasDerivWithinAt_inner_alongCurveWithin uniqueDiffWithinAt_univ
+      hγ.mdifferentiableWithinAt hV.differentiableWithinAt hW.differentiableWithinAt
 
 /-- The fibrewise inner product of two differentiable tangent fields along a differentiable curve
 is differentiable. -/
-theorem IsMetricCompatible.differentiableAt_inner_alongCurve
+theorem IsMetricCompatible.differentiableAt_inner
     (hcov : CovariantDerivative.IsMetricCompatible
       (V := fun x : M ↦ TangentSpace I x) cov)
     (hγ : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t)
@@ -377,7 +431,7 @@ theorem IsMetricCompatible.differentiableAt_inner_alongCurve
     (hV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t)
     (hW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t) :
     DifferentiableAt ℝ (fun r ↦ inner ℝ (V r) (W r)) t :=
-  (hcov.hasMetricProductRuleAt hγ hV hW).1
+  (hcov.hasDerivAt_inner_alongCurve hγ hV hW).differentiableAt
 
 /-- The product rule for a metric-compatible covariant derivative acting on two differentiable
 tangent fields along a differentiable real curve. -/
@@ -391,7 +445,7 @@ theorem IsMetricCompatible.deriv_inner_alongCurve
     deriv (fun r ↦ inner ℝ (V r) (W r)) t =
       inner ℝ (alongCurve cov γ V t) (W t) +
         inner ℝ (V t) (alongCurve cov γ W t) :=
-  (hcov.hasMetricProductRuleAt hγ hV hW).2
+  (hcov.hasDerivAt_inner_alongCurve hγ hV hW).deriv
 
 end CovariantDerivative
 

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Metric.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Metric.lean
@@ -99,9 +99,7 @@ private theorem IsMetricCompatible.hasMetricProductRuleWithinAt_pullback
           inner ℝ (X (γ t)) (cov Y (γ t) (curveVelocityWithin I γ s t)) := by
     simpa only [Function.comp_apply, hZ] using hmetric
   rw [hmetric'] at hchain
-  change HasDerivWithinAt (fun r ↦ inner ℝ (X (γ r)) (Y (γ r)))
-    (inner ℝ (alongCurveWithin cov γ (fun r ↦ X (γ r)) s t) (Y (γ t)) +
-      inner ℝ (X (γ t)) (alongCurveWithin cov γ (fun r ↦ Y (γ r)) s t)) s t
+  dsimp only [HasMetricProductRuleWithinAt]
   rw [alongCurveWithin_pullback_curveVelocityWithin cov γ X hu hγ hX,
     alongCurveWithin_pullback_curveVelocityWithin cov γ Y hu hγ hY]
   -- The chain-rule result uses a definitionally equal real normed-space instance.
@@ -113,8 +111,7 @@ private lemma HasMetricProductRuleWithinAt.symm
     {V W : ∀ r, TangentSpace I (γ r)}
     (h : HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) V W) :
     HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t) W V := by
-  change HasDerivWithinAt (fun r ↦ inner ℝ (V r) (W r)) _ s t at h
-  change HasDerivWithinAt (fun r ↦ inner ℝ (W r) (V r)) _ s t
+  dsimp only [HasMetricProductRuleWithinAt] at h ⊢
   have hfun : (fun r ↦ inner ℝ (W r) (V r)) = fun r ↦ inner ℝ (V r) (W r) := by
     funext r
     exact real_inner_comm _ _
@@ -133,9 +130,7 @@ private lemma HasMetricProductRuleWithinAt.add_left
     (hcoordV' : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ V' (γ t)) s t) :
     HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t)
       (fun r ↦ V r + V' r) W := by
-  change HasDerivWithinAt (fun r ↦ inner ℝ (V r) (W r)) _ s t at hV
-  change HasDerivWithinAt (fun r ↦ inner ℝ (V' r) (W r)) _ s t at hV'
-  change HasDerivWithinAt (fun r ↦ inner ℝ (V r + V' r) (W r)) _ s t
+  dsimp only [HasMetricProductRuleWithinAt] at hV hV' ⊢
   have hfun : (fun r ↦ inner ℝ (V r + V' r) (W r)) =
       fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V' r) (W r) := by
     funext r
@@ -167,8 +162,7 @@ private lemma HasMetricProductRuleWithinAt.smul_left
     (hcoordV : DifferentiableWithinAt ℝ (sectionCoord (F := E) γ V (γ t)) s t) :
     HasMetricProductRuleWithinAt (cov := cov) (s := s) (t := t)
       (fun r ↦ f r • V r) W := by
-  change HasDerivWithinAt (fun r ↦ inner ℝ (V r) (W r)) _ s t at hV
-  change HasDerivWithinAt (fun r ↦ inner ℝ (f r • V r) (W r)) _ s t
+  dsimp only [HasMetricProductRuleWithinAt] at hV ⊢
   have hfun : (fun r ↦ inner ℝ (f r • V r) (W r)) =
       fun r ↦ f r * inner ℝ (V r) (W r) := by
     funext r
@@ -219,8 +213,8 @@ private lemma HasMetricProductRuleWithinAt.finsetSum_left
   classical
   induction A using Finset.induction_on with
   | empty =>
-      change HasDerivWithinAt (fun r ↦ inner ℝ (0 : TangentSpace I (γ r)) (W r)) _ s t
-      simpa using (hasDerivWithinAt_const (x := t) (s := s) (c := (0 : ℝ)))
+      simpa [HasMetricProductRuleWithinAt] using
+        (hasDerivWithinAt_const (x := t) (s := s) (c := (0 : ℝ)))
   | @insert a A ha ih =>
       have ha_rule := hU a (Finset.mem_insert_self a A)
       have hA_rule := ih (fun i hi ↦ hU i (Finset.mem_insert_of_mem hi))

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Metric.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Metric.lean
@@ -1,0 +1,398 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Geometry.Manifold.VectorBundle.CovariantDerivative.AlongCurve.Pullback
+public import Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.Metric
+
+/-!
+# Metric compatibility along a curve
+
+This file proves the product rule for a metric-compatible covariant derivative acting on tangent
+fields along a curve:
+
+`(d/dt) ⟪V, W⟫ = ⟪D V / dt, W⟫ + ⟪V, D W / dt⟫`.
+
+The proof first handles fields pulled back from smooth local-frame fields, where the result is
+Mathlib's ambient `CovariantDerivative.IsMetricCompatible.mvfderiv_inner_eq` and the chain rule.
+A differentiable field along the curve is locally a finite linear combination of those pullbacks;
+the additive and scalar Leibniz laws of `CovariantDerivative.alongCurve` finish the argument.
+
+## Main result
+
+* `CovariantDerivative.IsMetricCompatible.deriv_inner_alongCurve`: the metric product rule for
+  two differentiable tangent fields along a differentiable real curve.
+
+## References
+
+* M. P. do Carmo, *Riemannian Geometry*, Chapter 2, Proposition 3.2.
+* The proof organization is adapted from
+  `DoCarmoLib/Riemannian/Connection/MetricCompatibilityAlong.lean` in the Apache-2.0
+  [`frenzymath/Poincare-Conjecture`](https://github.com/frenzymath/Poincare-Conjecture)
+  repository, revision `24f32e4d600878bfaac6bc2f2f9324175571c321`, replacing its custom connection
+  and metric APIs with Mathlib's `CovariantDerivative.IsMetricCompatible` and Tau Ceti's
+  moving-chart derivative.
+-/
+
+public section
+
+open Bundle Filter Function
+open scoped Manifold Topology
+
+noncomputable section
+
+namespace CovariantDerivative
+
+open TauCeti.Manifold
+
+variable
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 2 M]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)]
+  {cov : _root_.CovariantDerivative I E (fun x : M ↦ TangentSpace I x)}
+  {γ : ℝ → M} {t : ℝ}
+
+/-- The product-rule statement at one parameter, packaged for the local-frame induction. -/
+private def HasMetricProductRuleAt
+    (V W : ∀ r, TangentSpace I (γ r)) : Prop :=
+  DifferentiableAt ℝ (fun r ↦ inner ℝ (V r) (W r)) t ∧
+    deriv (fun r ↦ inner ℝ (V r) (W r)) t =
+      inner ℝ (alongCurve cov γ V t) (W t) +
+        inner ℝ (V t) (alongCurve cov γ W t)
+
+/-- Metric compatibility along a curve for fields pulled back from ambient differentiable
+sections. -/
+private theorem IsMetricCompatible.hasMetricProductRuleAt_pullback
+    (hcov : CovariantDerivative.IsMetricCompatible
+      (V := fun x : M ↦ TangentSpace I x) cov)
+    (hγ : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t)
+    {X Y : (x : M) → TangentSpace I x}
+    (hX : MDiffAt (T% X) (γ t)) (hY : MDiffAt (T% Y) (γ t)) :
+    HasMetricProductRuleAt (cov := cov) (γ := γ) (t := t) (fun r ↦ X (γ r))
+      (fun r ↦ Y (γ r)) := by
+  rw [HasMetricProductRuleAt]
+  let v := curveVelocity I γ t
+  let Z : (x : M) → TangentSpace I x := FiberBundle.extend E v
+  have hinner : MDifferentiableAt I 𝓘(ℝ, ℝ) (fun x ↦ inner ℝ (X x) (Y x)) (γ t) :=
+    MDifferentiableAt.inner_bundle (IB := I) (F := E)
+      (E := fun x : M ↦ TangentSpace I x) (b := id) hX hY
+  have hchain := hasDerivAt_comp_curve hinner
+    (hasMFDerivAt_curveVelocity hγ)
+  have hmetric := hcov.mvfderiv_inner_eq Z hX hY
+  have hZ : Z (γ t) = curveVelocity I γ t := by
+    exact FiberBundle.extend_apply_self E v
+  dsimp only at hmetric
+  rw [hZ] at hmetric
+  have hmetric' :
+      mvfderiv I (fun x ↦ inner ℝ (X x) (Y x)) (γ t) (curveVelocity I γ t) =
+        inner ℝ (cov X (γ t) (curveVelocity I γ t)) (Y (γ t)) +
+          inner ℝ (X (γ t)) (cov Y (γ t) (curveVelocity I γ t)) := by
+    simpa only [Function.comp_apply] using hmetric
+  rw [hmetric'] at hchain
+  rw [alongCurve_pullback cov γ X (hasMFDerivAt_curveVelocity hγ) hX,
+    alongCurve_pullback cov γ Y (hasMFDerivAt_curveVelocity hγ) hY]
+  exact ⟨hchain.differentiableAt, hchain.deriv⟩
+
+omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- The product rule is additive in its first field. -/
+private lemma HasMetricProductRuleAt.add_left
+    {V V' W : ∀ r, TangentSpace I (γ r)}
+    (hV : HasMetricProductRuleAt (cov := cov) (t := t) V W)
+    (hV' : HasMetricProductRuleAt (cov := cov) (t := t) V' W)
+    (hcoordV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t)
+    (hcoordV' : DifferentiableAt ℝ (sectionCoord (F := E) γ V' (γ t)) t) :
+    HasMetricProductRuleAt (cov := cov) (t := t) (fun r ↦ V r + V' r) W := by
+  rw [HasMetricProductRuleAt] at hV hV' ⊢
+  have hfun : (fun r ↦ inner ℝ (V r + V' r) (W r)) =
+      (fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V' r) (W r)) := by
+    funext r
+    exact inner_add_left _ _ _
+  constructor
+  · rw [hfun]
+    exact hV.1.add hV'.1
+  · have hd := deriv_add hV.1 hV'.1
+    change deriv (fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V' r) (W r)) t = _ at hd
+    rw [hfun, hd, hV.2, hV'.2,
+      alongCurve_add cov γ V V' hcoordV hcoordV']
+    simp only [inner_add_left]
+    ring
+
+omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- The product rule is additive in its second field. -/
+private lemma HasMetricProductRuleAt.add_right
+    {V W W' : ∀ r, TangentSpace I (γ r)}
+    (hW : HasMetricProductRuleAt (cov := cov) (t := t) V W)
+    (hW' : HasMetricProductRuleAt (cov := cov) (t := t) V W')
+    (hcoordW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t)
+    (hcoordW' : DifferentiableAt ℝ (sectionCoord (F := E) γ W' (γ t)) t) :
+    HasMetricProductRuleAt (cov := cov) (t := t) V (fun r ↦ W r + W' r) := by
+  rw [HasMetricProductRuleAt] at hW hW' ⊢
+  have hfun : (fun r ↦ inner ℝ (V r) (W r + W' r)) =
+      (fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V r) (W' r)) := by
+    funext r
+    exact inner_add_right _ _ _
+  constructor
+  · rw [hfun]
+    exact hW.1.add hW'.1
+  · have hd := deriv_add hW.1 hW'.1
+    change deriv (fun r ↦ inner ℝ (V r) (W r) + inner ℝ (V r) (W' r)) t = _ at hd
+    rw [hfun, hd, hW.2, hW'.2,
+      alongCurve_add cov γ W W' hcoordW hcoordW']
+    simp only [inner_add_right]
+    ring
+
+omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- The product rule is preserved by multiplying its first field by a differentiable scalar. -/
+private lemma HasMetricProductRuleAt.smul_left
+    {V W : ∀ r, TangentSpace I (γ r)} {f : ℝ → ℝ}
+    (hV : HasMetricProductRuleAt (cov := cov) (t := t) V W)
+    (hf : DifferentiableAt ℝ f t)
+    (hcoordV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t) :
+    HasMetricProductRuleAt (cov := cov) (t := t) (fun r ↦ f r • V r) W := by
+  rw [HasMetricProductRuleAt] at hV ⊢
+  have hfun : (fun r ↦ inner ℝ (f r • V r) (W r)) =
+      (fun r ↦ f r * inner ℝ (V r) (W r)) := by
+    funext r
+    exact real_inner_smul_left _ _ _
+  constructor
+  · rw [hfun]
+    exact hf.mul hV.1
+  · have hd := deriv_mul hf hV.1
+    change deriv (fun r ↦ f r * inner ℝ (V r) (W r)) t = _ at hd
+    rw [hfun, hd, hV.2, alongCurve_smul cov γ V f hf hcoordV]
+    simp only [inner_add_left, real_inner_smul_left]
+    ring
+
+omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- The product rule is preserved by multiplying its second field by a differentiable scalar. -/
+private lemma HasMetricProductRuleAt.smul_right
+    {V W : ∀ r, TangentSpace I (γ r)} {f : ℝ → ℝ}
+    (hW : HasMetricProductRuleAt (cov := cov) (t := t) V W)
+    (hf : DifferentiableAt ℝ f t)
+    (hcoordW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t) :
+    HasMetricProductRuleAt (cov := cov) (t := t) V (fun r ↦ f r • W r) := by
+  rw [HasMetricProductRuleAt] at hW ⊢
+  have hfun : (fun r ↦ inner ℝ (V r) (f r • W r)) =
+      (fun r ↦ f r * inner ℝ (V r) (W r)) := by
+    funext r
+    rw [real_inner_smul_right, mul_comm]
+  constructor
+  · rw [hfun]
+    exact hf.mul hW.1
+  · have hd := deriv_mul hf hW.1
+    change deriv (fun r ↦ f r * inner ℝ (V r) (W r)) t = _ at hd
+    rw [hfun, hd, hW.2, alongCurve_smul cov γ W f hf hcoordW]
+    simp only [inner_add_right, real_inner_smul_right]
+    ring
+
+omit [FiniteDimensional ℝ E]
+  [RiemannianBundle (fun x : M ↦ TangentSpace I x)]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I]
+  [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- A finite sum of fields with differentiable coordinate readings again has a differentiable
+coordinate reading. -/
+private lemma differentiableAt_sectionCoord_finsetSum
+    {ι : Type*} {A : Finset ι} {U : ι → ∀ r, TangentSpace I (γ r)}
+    (hU : ∀ i ∈ A, DifferentiableAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) t) :
+    DifferentiableAt ℝ
+      (sectionCoord (F := E) γ (fun r ↦ ∑ i ∈ A, U i r) (γ t)) t := by
+  classical
+  have hfun : sectionCoord (F := E) γ (fun r ↦ ∑ i ∈ A, U i r) (γ t) =
+      fun r ↦ ∑ i ∈ A, sectionCoord (F := E) γ (U i) (γ t) r := by
+    funext r
+    simp only [sectionCoord_apply, map_sum]
+  rw [hfun]
+  exact DifferentiableAt.fun_sum hU
+
+omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- The product rule is preserved by a finite sum in its first field. -/
+private lemma HasMetricProductRuleAt.finsetSum_left
+    {ι : Type*} {A : Finset ι} {U : ι → ∀ r, TangentSpace I (γ r)}
+    {W : ∀ r, TangentSpace I (γ r)}
+    (hU : ∀ i ∈ A, HasMetricProductRuleAt (cov := cov) (t := t) (U i) W)
+    (hcoordU : ∀ i ∈ A,
+      DifferentiableAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) t) :
+    HasMetricProductRuleAt (cov := cov) (t := t) (fun r ↦ ∑ i ∈ A, U i r) W := by
+  classical
+  induction A using Finset.induction_on with
+  | empty =>
+      rw [HasMetricProductRuleAt]
+      simp
+  | @insert a A ha ih =>
+      have ha_rule := hU a (Finset.mem_insert_self a A)
+      have hA_rule := ih (fun i hi ↦ hU i (Finset.mem_insert_of_mem hi))
+        (fun i hi ↦ hcoordU i (Finset.mem_insert_of_mem hi))
+      have hsum := ha_rule.add_left hA_rule
+        (hcoordU a (Finset.mem_insert_self a A))
+        (differentiableAt_sectionCoord_finsetSum
+          (fun i hi ↦ hcoordU i (Finset.mem_insert_of_mem hi)))
+      simpa only [Finset.sum_insert ha, Pi.add_apply] using hsum
+
+omit [IsContMDiffRiemannianBundle I 1 E (fun x : M ↦ TangentSpace I x)] in
+/-- The product rule is preserved by a finite sum in its second field. -/
+private lemma HasMetricProductRuleAt.finsetSum_right
+    {ι : Type*} {A : Finset ι} {V : ∀ r, TangentSpace I (γ r)}
+    {U : ι → ∀ r, TangentSpace I (γ r)}
+    (hU : ∀ i ∈ A, HasMetricProductRuleAt (cov := cov) (t := t) V (U i))
+    (hcoordU : ∀ i ∈ A,
+      DifferentiableAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) t) :
+    HasMetricProductRuleAt (cov := cov) (t := t) V (fun r ↦ ∑ i ∈ A, U i r) := by
+  classical
+  induction A using Finset.induction_on with
+  | empty =>
+      rw [HasMetricProductRuleAt]
+      simp
+  | @insert a A ha ih =>
+      have ha_rule := hU a (Finset.mem_insert_self a A)
+      have hA_rule := ih (fun i hi ↦ hU i (Finset.mem_insert_of_mem hi))
+        (fun i hi ↦ hcoordU i (Finset.mem_insert_of_mem hi))
+      have hsum := ha_rule.add_right hA_rule
+        (hcoordU a (Finset.mem_insert_self a A))
+        (differentiableAt_sectionCoord_finsetSum
+          (fun i hi ↦ hcoordU i (Finset.mem_insert_of_mem hi)))
+      simpa only [Finset.sum_insert ha, Pi.add_apply] using hsum
+
+/-- The metric product rule for arbitrary differentiable fields along a curve. -/
+private theorem IsMetricCompatible.hasMetricProductRuleAt
+    (hcov : CovariantDerivative.IsMetricCompatible
+      (V := fun x : M ↦ TangentSpace I x) cov)
+    (hγ : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t)
+    {V W : ∀ r, TangentSpace I (γ r)}
+    (hV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t)
+    (hW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t) :
+    HasMetricProductRuleAt (cov := cov) (t := t) V W := by
+  classical
+  let e := trivializationAt E (TangentSpace I) (γ t)
+  let b := Module.finBasis ℝ E
+  let X : Fin (Module.finrank ℝ E) → (x : M) → TangentSpace I x :=
+    fun i ↦ e.localFrame b i
+  let aV : Fin (Module.finrank ℝ E) → ℝ → ℝ := fun i r ↦
+    b.repr (sectionCoord (F := E) γ V (γ t) r) i
+  let aW : Fin (Module.finrank ℝ E) → ℝ → ℝ := fun i r ↦
+    b.repr (sectionCoord (F := E) γ W (γ t) r) i
+  let U : Fin (Module.finrank ℝ E) → ∀ r, TangentSpace I (γ r) :=
+    fun i r ↦ aV i r • X i (γ r)
+  let Z : Fin (Module.finrank ℝ E) → ∀ r, TangentSpace I (γ r) :=
+    fun i r ↦ aW i r • X i (γ r)
+  have hbase : γ t ∈ e.baseSet :=
+    FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t)
+  have hframe (i : Fin (Module.finrank ℝ E)) : MDiffAt (T% (X i)) (γ t) := by
+    exact (((e.isLocalFrameOn_localFrame_baseSet I 1 b).contMDiffOn i).mdifferentiableOn
+      one_ne_zero).mdifferentiableAt (e.open_baseSet.mem_nhds hbase)
+  have haV (i : Fin (Module.finrank ℝ E)) : DifferentiableAt ℝ (aV i) t := by
+    change DifferentiableAt ℝ ((b.coord i) ∘ sectionCoord (F := E) γ V (γ t)) t
+    exact (LinearMap.toContinuousLinearMap (b.coord i)).differentiableAt.comp t hV
+  have haW (i : Fin (Module.finrank ℝ E)) : DifferentiableAt ℝ (aW i) t := by
+    change DifferentiableAt ℝ ((b.coord i) ∘ sectionCoord (F := E) γ W (γ t)) t
+    exact (LinearMap.toContinuousLinearMap (b.coord i)).differentiableAt.comp t hW
+  have hcoordX (i : Fin (Module.finrank ℝ E)) :
+      DifferentiableAt ℝ
+        (sectionCoord (F := E) γ (fun r ↦ X i (γ r)) (γ t)) t := by
+    exact differentiableAt_sectionCoord γ (fun r ↦ X i (γ r))
+      ((hframe i).comp t hγ) hbase
+  have hcoordU (i : Fin (Module.finrank ℝ E)) :
+      DifferentiableAt ℝ (sectionCoord (F := E) γ (U i) (γ t)) t := by
+    rw [show sectionCoord (F := E) γ (U i) (γ t) =
+      aV i • sectionCoord (F := E) γ (fun r ↦ X i (γ r)) (γ t) by
+        exact sectionCoord_smul γ (fun r ↦ X i (γ r)) (aV i) (γ t)]
+    exact (haV i).smul (hcoordX i)
+  have hcoordZ (i : Fin (Module.finrank ℝ E)) :
+      DifferentiableAt ℝ (sectionCoord (F := E) γ (Z i) (γ t)) t := by
+    rw [show sectionCoord (F := E) γ (Z i) (γ t) =
+      aW i • sectionCoord (F := E) γ (fun r ↦ X i (γ r)) (γ t) by
+        exact sectionCoord_smul γ (fun r ↦ X i (γ r)) (aW i) (γ t)]
+    exact (haW i).smul (hcoordX i)
+  have hterm (i j : Fin (Module.finrank ℝ E)) :
+      HasMetricProductRuleAt (cov := cov) (t := t) (U i) (Z j) := by
+    exact ((hcov.hasMetricProductRuleAt_pullback hγ (hframe i) (hframe j)).smul_left
+      (haV i) (hcoordX i)).smul_right (haW j) (hcoordX j)
+  have hsum : HasMetricProductRuleAt (cov := cov) (t := t)
+      (fun r ↦ ∑ i, U i r) (fun r ↦ ∑ j, Z j r) := by
+    refine HasMetricProductRuleAt.finsetSum_left
+      (A := Finset.univ) (U := U) (W := fun r ↦ ∑ j, Z j r) ?_ ?_
+    · intro i hi
+      exact HasMetricProductRuleAt.finsetSum_right
+        (A := Finset.univ) (hU := fun j _ ↦ hterm i j) (fun j _ ↦ hcoordZ j)
+    · exact fun i _ ↦ hcoordU i
+  have hnear : ∀ᶠ r in 𝓝 t, γ r ∈ e.baseSet :=
+    hγ.continuousAt.preimage_mem_nhds (e.open_baseSet.mem_nhds hbase)
+  have hVsum : V =ᶠ[𝓝 t] fun r ↦ ∑ i, U i r := by
+    filter_upwards [hnear] with r hr
+    calc
+      V r = e.symmL ℝ (γ r) (sectionCoord (F := E) γ V (γ t) r) := by
+        rw [sectionCoord_apply, e.symmL_continuousLinearMapAt (R := ℝ) hr]
+      _ = e.symmL ℝ (γ r)
+          (∑ i, b.repr (sectionCoord (F := E) γ V (γ t) r) i • b i) := by
+        rw [b.sum_repr]
+      _ = ∑ i, U i r := by
+        simp only [map_sum, map_smul, U, aV, X, symmL_basis_eq_localFrame b hr]
+  have hWsum : W =ᶠ[𝓝 t] fun r ↦ ∑ i, Z i r := by
+    filter_upwards [hnear] with r hr
+    calc
+      W r = e.symmL ℝ (γ r) (sectionCoord (F := E) γ W (γ t) r) := by
+        rw [sectionCoord_apply, e.symmL_continuousLinearMapAt (R := ℝ) hr]
+      _ = e.symmL ℝ (γ r)
+          (∑ i, b.repr (sectionCoord (F := E) γ W (γ t) r) i • b i) := by
+        rw [b.sum_repr]
+      _ = ∑ i, Z i r := by
+        simp only [map_sum, map_smul, Z, aW, X, symmL_basis_eq_localFrame b hr]
+  have hinner : (fun r ↦ inner ℝ (V r) (W r)) =ᶠ[𝓝 t]
+      fun r ↦ inner ℝ (∑ i, U i r) (∑ j, Z j r) := by
+    filter_upwards [hVsum, hWsum] with r hVr hWr
+    rw [hVr, hWr]
+    rfl
+  have hDV : alongCurve cov γ V t =
+      alongCurve cov γ (fun r ↦ ∑ i, U i r) t :=
+    alongCurve_congr cov γ V hVsum
+  have hDW : alongCurve cov γ W t =
+      alongCurve cov γ (fun r ↦ ∑ i, Z i r) t :=
+    alongCurve_congr cov γ W hWsum
+  have hVt : V t = ∑ i, U i t := hVsum.self_of_nhds
+  have hWt : W t = ∑ i, Z i t := hWsum.self_of_nhds
+  rw [HasMetricProductRuleAt] at hsum ⊢
+  constructor
+  · exact hinner.differentiableAt_iff.mpr hsum.1
+  · calc
+      deriv (fun r ↦ inner ℝ (V r) (W r)) t =
+          deriv (fun r ↦ inner ℝ (∑ i, U i r) (∑ j, Z j r)) t := hinner.deriv_eq
+      _ = inner ℝ (alongCurve cov γ (fun r ↦ ∑ i, U i r) t) (∑ j, Z j t) +
+          inner ℝ (∑ i, U i t) (alongCurve cov γ (fun r ↦ ∑ j, Z j r) t) := hsum.2
+      _ = inner ℝ (alongCurve cov γ V t) (W t) +
+          inner ℝ (V t) (alongCurve cov γ W t) := by
+        rw [hDV, hDW, hVt, hWt]
+
+/-- The fibrewise inner product of two differentiable tangent fields along a differentiable curve
+is differentiable. -/
+theorem IsMetricCompatible.differentiableAt_inner_alongCurve
+    (hcov : CovariantDerivative.IsMetricCompatible
+      (V := fun x : M ↦ TangentSpace I x) cov)
+    (hγ : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t)
+    {V W : ∀ r, TangentSpace I (γ r)}
+    (hV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t)
+    (hW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t) :
+    DifferentiableAt ℝ (fun r ↦ inner ℝ (V r) (W r)) t :=
+  (hcov.hasMetricProductRuleAt hγ hV hW).1
+
+/-- The product rule for a metric-compatible covariant derivative acting on two differentiable
+tangent fields along a differentiable real curve. -/
+theorem IsMetricCompatible.deriv_inner_alongCurve
+    (hcov : CovariantDerivative.IsMetricCompatible
+      (V := fun x : M ↦ TangentSpace I x) cov)
+    (hγ : MDifferentiableAt 𝓘(ℝ, ℝ) I γ t)
+    {V W : ∀ r, TangentSpace I (γ r)}
+    (hV : DifferentiableAt ℝ (sectionCoord (F := E) γ V (γ t)) t)
+    (hW : DifferentiableAt ℝ (sectionCoord (F := E) γ W (γ t)) t) :
+    deriv (fun r ↦ inner ℝ (V r) (W r)) t =
+      inner ℝ (alongCurve cov γ V t) (W t) +
+        inner ℝ (V t) (alongCurve cov γ W t) :=
+  (hcov.hasMetricProductRuleAt hγ hV hW).2
+
+end CovariantDerivative
+
+end

--- a/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/CovariantDerivative/AlongCurve/Pullback.lean
@@ -47,7 +47,9 @@ for the Levi-Civita connection.
   `TauCeti.Manifold.sectionCoord_curveVelocityWithin_eventuallyEq` its eventual-equality form for
   the velocity field.
 * `TauCeti.Manifold.contDiffWithinAt_sectionCoord_curveVelocityWithin`: a `C^(n + 1)` curve has a
-  `C^n` coordinate velocity field.
+  `C^n` coordinate velocity field; its `C²` differentiability specializations are
+  `TauCeti.Manifold.differentiableWithinAt_sectionCoord_curveVelocityWithin` and
+  `TauCeti.Manifold.differentiableAt_sectionCoord_curveVelocity`.
 * `TauCeti.Manifold.derivWithin_sectionCoord_pullback`: the derivative of the coordinate reading
   of a pulled-back field is the reading of the flat frame derivative in the direction of the
   velocity.
@@ -150,6 +152,42 @@ theorem contDiffWithinAt_sectionCoord_curveVelocityWithin {n : ℕ∞ω} [IsMani
   exact hderiv.congr_of_eventuallyEq_of_mem
     (sectionCoord_curveVelocityWithin_eventuallyEq γ hs
       (hγ.mdifferentiableOn (by simp)) ht hx) ht
+
+omit [CompleteSpace 𝕜] [FiniteDimensional 𝕜 E]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
+/-- The coordinate reading of the within-set velocity of a `C²` curve is differentiable within
+the parameter set. -/
+theorem differentiableWithinAt_sectionCoord_curveVelocityWithin [IsManifold I 2 M]
+    {x : M} {s : Set 𝕜} {t : 𝕜} (hs : UniqueDiffOn 𝕜 s)
+    (hγ : ContMDiffOn 𝓘(𝕜, 𝕜) I 2 γ s) (ht : t ∈ s)
+    (hx : γ t ∈ (trivializationAt E (TangentSpace I) x).baseSet) :
+    DifferentiableWithinAt 𝕜
+      (sectionCoord (F := E) γ (curveVelocityWithin I γ s) x) s t := by
+  let _ : IsManifold I ((1 : ℕ∞ω) + 1) M := IsManifold.of_le (n := 2) (by norm_num)
+  have hγ' : ContMDiffOn 𝓘(𝕜, 𝕜) I ((1 : ℕ∞ω) + 1) γ s := by
+    simpa only [show (1 : ℕ∞ω) + 1 = 2 by norm_num] using hγ
+  exact (contDiffWithinAt_sectionCoord_curveVelocityWithin γ hs hγ' ht hx)
+    |>.differentiableWithinAt (by norm_num)
+
+omit [CompleteSpace 𝕜] [FiniteDimensional 𝕜 E]
+  [ContMDiffVectorBundle 1 E (TangentSpace I : M → Type _) I] in
+/-- On an open parameter set, the coordinate reading of the unrestricted velocity of a `C²`
+curve is differentiable at every parameter in the set. -/
+theorem differentiableAt_sectionCoord_curveVelocity [IsManifold I 2 M]
+    {s : Set 𝕜} {t : 𝕜} (hγ : ContMDiffOn 𝓘(𝕜, 𝕜) I 2 γ s)
+    (hs : IsOpen s) (ht : t ∈ s) :
+    DifferentiableAt 𝕜 (sectionCoord (F := E) γ (curveVelocity I γ) (γ t)) t := by
+  have hwithin : DifferentiableAt 𝕜
+      (sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ t)) t :=
+    (differentiableWithinAt_sectionCoord_curveVelocityWithin γ hs.uniqueDiffOn hγ ht
+      (FiberBundle.mem_baseSet_trivializationAt E (TangentSpace I) (γ t)))
+      |>.differentiableAt (hs.mem_nhds ht)
+  have heq : sectionCoord (F := E) γ (curveVelocityWithin I γ s) (γ t) =ᶠ[𝓝 t]
+      sectionCoord (F := E) γ (curveVelocity I γ) (γ t) := by
+    filter_upwards [hs.mem_nhds ht] with r hr
+    rw [sectionCoord_apply, sectionCoord_apply,
+      curveVelocityWithin_of_mem_nhds (hs.mem_nhds hr)]
+  exact heq.differentiableAt_iff.mp hwithin
 
 omit [FiniteDimensional 𝕜 E]
   [IsManifold I 1 M]

--- a/TauCeti/Geometry/Manifold/VectorBundle/SectionAlongCurve.lean
+++ b/TauCeti/Geometry/Manifold/VectorBundle/SectionAlongCurve.lean
@@ -63,6 +63,15 @@ theorem sectionCoord_add (W' : ∀ t, V (γ t)) (x : M) :
   funext t
   exact map_add _ _ _
 
+/-- Coordinate reading commutes with finite sums of sections along a curve. -/
+@[simp]
+theorem sectionCoord_sum {ι : Type*} (A : Finset ι) (U : ι → ∀ t, V (γ t)) (x : M) :
+    sectionCoord (F := F) γ (fun t ↦ ∑ i ∈ A, U i t) x =
+      fun t ↦ ∑ i ∈ A, sectionCoord (F := F) γ (U i) x t := by
+  classical
+  funext t
+  simp only [sectionCoord_apply, map_sum]
+
 /-- Coordinate reading commutes with pointwise scalar multiplication of a section along a curve. -/
 @[simp]
 theorem sectionCoord_smul (f : 𝕜 → 𝕜) (x : M) :


### PR DESCRIPTION
This PR proves that a geodesic has constant squared speed and constant speed on every open preconnected parameter domain, and provides all-time specializations. It first adds the reusable metric product rule for differentiable tangent fields along a curve, proved by expansion in a smooth local frame and Mathlib's ambient `CovariantDerivative.IsMetricCompatible.mvfderiv_inner_eq`, then applies the Levi-Civita metric compatibility and the geodesic equation.

This advances the exact HopfRinow Layer 1 target “Constant speed,” specifically the form consumed by maximal open intervals and the finite-endpoint Cauchy argument. After this PR, the boundary-sensitive formulation for non-open preconnected parameter sets remains, while the critical path still needs the geodesic spray/local flow, maximal-interval packaging, and finite-endpoint extension criterion before that downstream argument can be assembled.

The proof organization is adapted from `DoCarmoLib/Riemannian/Connection/MetricCompatibilityAlong.lean` and `DoCarmoLib/Riemannian/Geodesic/HopfRinow/ConstantSpeed.lean` in the Apache-2.0 `frenzymath/Poincare-Conjecture` repository at revision `24f32e4d600878bfaac6bc2f2f9324175571c321`; no Mathlib infrastructure is vendored.

Roadmap: HopfRinow

<!--tauceti-target:v1 {"focus":"HopfRinow","id":"constant-speed-geodesics"}-->

Verification completed with `lake exe cache get`, `lake build`, and `lake exe axioms`.

🤖 Prepared with Codex
