### PR TITLE
feat: the divisor of a Weil differential

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Differential/Divisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Divisor.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.Int.LeastGreatest
+public import TauCeti.FieldTheory.FunctionField.Differential.Weil
+public import TauCeti.FieldTheory.FunctionField.Repartition.IndexOfSpecialty
+
+/-!
+# The divisor of a Weil differential
+
+A nonzero Weil differential `ω` of an algebraic function field `F / k` with exact constant field
+is bounded by many divisors, and among them there is a largest one: there is a divisor `(ω)` with
+
+`ω ∈ Ω_F(D) ↔ D ≤ (ω)`.
+
+This file constructs `(ω)` and proves that characterization.  It is Stichtenoth, *Algebraic
+Function Fields and Codes*, 2nd ed., Lemma 1.5.10 and Definition 1.5.11, together with the first
+half of Proposition 1.5.13, the translation rule `(x · ω) = div x + (ω)`.
+
+Two facts drive the construction.  Degrees are bounded on the divisors bounding `ω`, because a
+divisor `D` with `A_F(D) + F = A_F` bounds no nonzero Weil differential at all, and every divisor
+of large enough degree is of that kind by Riemann's theorem.  And the divisors bounding `ω` are
+closed under the pointwise maximum, by `TauCeti.weilDifferentialFiltration_sup`.  A divisor of
+maximal degree among them is therefore the largest of them, because a strictly larger divisor of
+a function field has a strictly larger degree.
+
+## Main definitions
+
+* `TauCeti.Divisor.ofWeilDifferential`: the divisor `(ω)` of a Weil differential (Stichtenoth,
+  Definition 1.5.11), the greatest divisor bounding it, with the junk value `0` when there is
+  none — that is, for `ω = 0` and for the linear forms that are not Weil differentials.
+
+## Main results
+
+* `TauCeti.exists_isGreatest_setOf_mem_weilDifferentialFiltration`: **Stichtenoth, Lemma 1.5.10**,
+  the existence of a greatest divisor bounding a nonzero Weil differential.
+* `TauCeti.mem_weilDifferentialFiltration_iff_le_ofWeilDifferential`: the characterization
+  `ω ∈ Ω_F(D) ↔ D ≤ (ω)`.
+* `TauCeti.Divisor.ofWeilDifferential_repartitionDualMul`: **Stichtenoth, Proposition 1.5.13**,
+  first half — `(x · ω) = (ω) + div x` for a nonzero function `x`.
+* `TauCeti.mem_riemannRochSpace_ofWeilDifferential_sub_iff`: `x ∈ L((ω) - D)` exactly when
+  `x · ω ∈ Ω_F(D)`, the elementwise form of the map of Stichtenoth's Duality Theorem 1.5.14.
+
+The complementary halves of Propositions 1.5.13 and 1.5.14 — that any two canonical divisors are
+linearly equivalent, and that `x ↦ x · ω` is onto `Ω_F(D)` — are exactly the statements that need
+`dim_F Ω_F = 1` (Proposition 1.5.9), and are not proved here.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Section I.5 (Lemma 1.5.10, Definition 1.5.11, Proposition 1.5.13).
+-/
+
+public section
+
+namespace TauCeti
+
+variable {k F : Type*} [Field k] [Field F] [Algebra k F]
+  {ω : Module.Dual k ↥(repartitionSpace k F)}
+
+/-! ### The divisors bounding a nonzero Weil differential -/
+
+/-- **The divisors bounding a nonzero Weil differential have bounded degree** (Stichtenoth, in the
+proof of Lemma 1.5.10).  A divisor `D` bounding a nonzero Weil differential has
+`A_F(D) + F ≠ A_F`, so it is special; and by Riemann's theorem every divisor of large enough
+degree is nonspecial. -/
+theorem exists_forall_degree_le_of_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) (hω : ω ≠ 0) :
+    ∃ c : ℤ, ∀ D : Divisor k F, ω ∈ weilDifferentialFiltration D → Divisor.degree D ≤ c := by
+  obtain ⟨c, hc⟩ := exists_forall_indexOfSpecialty_eq_zero hF hex
+  refine ⟨c, fun D hD ↦ not_lt.mp fun hlt ↦ hω ?_⟩
+  have hbot : weilDifferentialFiltration D = ⊥ :=
+    (weilDifferentialFiltration_eq_bot_iff hF D).mpr
+      ((adeleFiltration_sup_diagonalRepartitions_eq_repartitionSpace_iff hF hex D).mpr
+        (hc D hlt.le))
+  rwa [hbot, Submodule.mem_bot] at hD
+
+/-- **Stichtenoth, Lemma 1.5.10**: among the divisors bounding a nonzero Weil differential there
+is a greatest one.  The set is nonempty by the definition of a Weil differential, closed under the
+pointwise maximum by `TauCeti.weilDifferentialFiltration_sup`, and of bounded degree; a member of
+maximal degree is therefore its greatest element. -/
+theorem exists_isGreatest_setOf_mem_weilDifferentialFiltration (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) (hωΩ : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    ∃ W : Divisor k F, IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W := by
+  obtain ⟨c, hc⟩ := exists_forall_degree_le_of_mem_weilDifferentialFiltration hF hex hω
+  obtain ⟨D₀, hD₀⟩ := mem_weilDifferentialSpace_iff.mp hωΩ
+  -- pick a divisor `W` bounding `ω` of maximal degree among those bounding `ω`
+  obtain ⟨n, ⟨W, hW, rfl⟩, hmax⟩ := Int.exists_greatest_of_bdd
+    (P := fun n ↦ ∃ D : Divisor k F, ω ∈ weilDifferentialFiltration D ∧ Divisor.degree D = n)
+    ⟨c, by rintro n ⟨D, hD, rfl⟩; exact hc D hD⟩ ⟨_, D₀, hD₀, rfl⟩
+  refine ⟨W, hW, fun B hB ↦ ?_⟩
+  have hsup : ω ∈ weilDifferentialFiltration (W ⊔ B) := by
+    rw [weilDifferentialFiltration_sup]
+    exact Submodule.mem_inf.mpr ⟨hW, hB⟩
+  have heq : W = W ⊔ B :=
+    Divisor.eq_of_le_of_degree_eq hF le_sup_left
+      (le_antisymm (Divisor.degree_le_of_le le_sup_left) (hmax _ ⟨W ⊔ B, hsup, rfl⟩))
+  exact le_sup_right.trans heq.ge
+
+/-! ### The divisor of a Weil differential -/
+
+open scoped Classical in
+/-- **The divisor `(ω)` of a Weil differential** (Stichtenoth, Definition 1.5.11): the greatest
+divisor `D` with `ω ∈ Ω_F(D)`.
+
+For a nonzero Weil differential of a function field with exact constant field such a divisor
+exists, by `TauCeti.exists_isGreatest_setOf_mem_weilDifferentialFiltration`, and
+`TauCeti.mem_weilDifferentialFiltration_iff_le_ofWeilDifferential` is the resulting
+characterization.  Otherwise — for `ω = 0`, which every divisor bounds, and for a linear form no
+divisor bounds — this is the junk value `0`. -/
+noncomputable def Divisor.ofWeilDifferential (ω : Module.Dual k ↥(repartitionSpace k F)) :
+    Divisor k F :=
+  if h : ∃ W : Divisor k F, IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W then
+    h.choose
+  else 0
+
+/-- The divisor of a Weil differential is *the* greatest divisor bounding it: exhibiting one such
+greatest divisor identifies it, with no further hypotheses. -/
+theorem Divisor.ofWeilDifferential_eq_of_isGreatest {W : Divisor k F}
+    (h : IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W) :
+    Divisor.ofWeilDifferential ω = W := by
+  have hgr : ∃ W : Divisor k F,
+      IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W := ⟨W, h⟩
+  rw [Divisor.ofWeilDifferential, dite_eq_left_of_eq_true (eq_true hgr)]
+  exact hgr.choose_spec.unique h
+
+/-- **Stichtenoth, Lemma 1.5.10**, in terms of `TauCeti.Divisor.ofWeilDifferential`: `(ω)` is the
+greatest divisor bounding a nonzero Weil differential `ω`. -/
+theorem isGreatest_ofWeilDifferential (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) (hωΩ : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D}
+      (Divisor.ofWeilDifferential ω) := by
+  obtain ⟨W, hW⟩ := exists_isGreatest_setOf_mem_weilDifferentialFiltration hF hex hωΩ hω
+  rw [Divisor.ofWeilDifferential_eq_of_isGreatest hW]
+  exact hW
+
+/-- A nonzero Weil differential is bounded by its own divisor. -/
+theorem mem_weilDifferentialFiltration_ofWeilDifferential (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) (hωΩ : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) :
+    ω ∈ weilDifferentialFiltration (Divisor.ofWeilDifferential ω) :=
+  (isGreatest_ofWeilDifferential hF hex hωΩ hω).1
+
+/-- **The characterization of the divisor of a Weil differential**: a divisor bounds a nonzero
+Weil differential exactly when it is at most the divisor of that differential. -/
+theorem mem_weilDifferentialFiltration_iff_le_ofWeilDifferential
+    (hF : IsFunctionField k F) (hex : IsIntegrallyClosedIn k F)
+    (hωΩ : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0) (D : Divisor k F) :
+    ω ∈ weilDifferentialFiltration D ↔ D ≤ Divisor.ofWeilDifferential ω :=
+  ⟨fun hD ↦ (isGreatest_ofWeilDifferential hF hex hωΩ hω).2 hD, fun hD ↦
+    weilDifferentialFiltration_antitone hD
+      (mem_weilDifferentialFiltration_ofWeilDifferential hF hex hωΩ hω)⟩
+
+/-! ### Multiplication by a function -/
+
+/-- **Stichtenoth, Proposition 1.5.13**, first half: multiplying a nonzero Weil differential by a
+nonzero function translates its divisor by the principal divisor of that function,
+`(x · ω) = (ω) + div x`.  So the divisors of the nonzero multiples of `ω` form one full linear
+equivalence class. -/
+theorem Divisor.ofWeilDifferential_repartitionDualMul (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) (hωΩ : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0)
+    (z : Fˣ) :
+    Divisor.ofWeilDifferential (repartitionDualMul hF (z : F) ω) =
+      Divisor.ofWeilDifferential ω + Divisor.principal hF z := by
+  refine Divisor.ofWeilDifferential_eq_of_isGreatest
+    ⟨(repartitionDualMul_mem_weilDifferentialFiltration_iff hF z).mpr
+      (mem_weilDifferentialFiltration_ofWeilDifferential hF hex hωΩ hω),
+    fun D hD ↦ sub_le_iff_le_add.mp ?_⟩
+  refine (mem_weilDifferentialFiltration_iff_le_ofWeilDifferential hF hex hωΩ hω _).mp
+    ((repartitionDualMul_mem_weilDifferentialFiltration_iff hF z).mp ?_)
+  rwa [sub_add_cancel]
+
+/-- **The elementwise Duality map** (Stichtenoth, in the proof of Theorem 1.5.14): a nonzero
+function lies in `L((ω) - D)` exactly when multiplying `ω` by it gives a Weil differential bounded
+by `D`.  The remaining content of the Duality Theorem is that `x ↦ x · ω` is onto `Ω_F(D)`, which
+needs the one-dimensionality of `Ω_F` over `F`. -/
+theorem mem_riemannRochSpace_ofWeilDifferential_sub_iff (hF : IsFunctionField k F)
+    (hex : IsIntegrallyClosedIn k F) (hωΩ : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0)
+    (z : Fˣ) (D : Divisor k F) :
+    (z : F) ∈ riemannRochSpace (Divisor.ofWeilDifferential ω - D) ↔
+      repartitionDualMul hF (z : F) ω ∈ weilDifferentialFiltration D := by
+  have hrearrange : Divisor.principal hF z + (Divisor.ofWeilDifferential ω - D) =
+      Divisor.ofWeilDifferential ω + Divisor.principal hF z - D := by abel
+  rw [mem_riemannRochSpace_units_iff hF,
+    mem_weilDifferentialFiltration_iff_le_ofWeilDifferential hF hex
+      (repartitionDualMul_mem_weilDifferentialSpace hF (z : F) hωΩ)
+      (repartitionDualMul_ne_zero hF z hω) D,
+    Divisor.ofWeilDifferential_repartitionDualMul hF hex hωΩ hω z, hrearrange, sub_nonneg]
+
+end TauCeti

--- a/TauCeti/FieldTheory/FunctionField/Differential/Divisor.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Divisor.lean
@@ -31,8 +31,8 @@ a function field has a strictly larger degree.
 ## Main definitions
 
 * `TauCeti.Divisor.ofWeilDifferential`: the divisor `(ω)` of a Weil differential (Stichtenoth,
-  Definition 1.5.11), the greatest divisor bounding it, with the junk value `0` when there is
-  none — that is, for `ω = 0` and for the linear forms that are not Weil differentials.
+  Definition 1.5.11), the greatest divisor bounding it, with the junk value `0` whenever the
+  divisors bounding `ω` have no greatest element.
 
 ## Main results
 
@@ -107,11 +107,13 @@ open scoped Classical in
 /-- **The divisor `(ω)` of a Weil differential** (Stichtenoth, Definition 1.5.11): the greatest
 divisor `D` with `ω ∈ Ω_F(D)`.
 
-For a nonzero Weil differential of a function field with exact constant field such a divisor
-exists, by `TauCeti.exists_isGreatest_setOf_mem_weilDifferentialFiltration`, and
+Under `IsFunctionField k F` and `IsIntegrallyClosedIn k F`, such a divisor exists for every
+nonzero Weil differential `ω`, by
+`TauCeti.exists_isGreatest_setOf_mem_weilDifferentialFiltration`, and
 `TauCeti.mem_weilDifferentialFiltration_iff_le_ofWeilDifferential` is the resulting
-characterization.  Otherwise — for `ω = 0`, which every divisor bounds, and for a linear form no
-divisor bounds — this is the junk value `0`. -/
+characterization.  Whenever the divisors bounding `ω` have no greatest element this is instead the
+junk value `0` — always so for a linear form no divisor bounds, and, unless the divisor group is
+trivial, also for `ω = 0`, which every divisor bounds. -/
 noncomputable def Divisor.ofWeilDifferential (ω : Module.Dual k ↥(repartitionSpace k F)) :
     Divisor k F :=
   if h : ∃ W : Divisor k F, IsGreatest {D : Divisor k F | ω ∈ weilDifferentialFiltration D} W then
@@ -173,15 +175,18 @@ theorem Divisor.ofWeilDifferential_repartitionDualMul (hF : IsFunctionField k F)
     ((repartitionDualMul_mem_weilDifferentialFiltration_iff hF z).mp ?_)
   rwa [sub_add_cancel]
 
-/-- **The elementwise Duality map** (Stichtenoth, in the proof of Theorem 1.5.14): a nonzero
-function lies in `L((ω) - D)` exactly when multiplying `ω` by it gives a Weil differential bounded
-by `D`.  The remaining content of the Duality Theorem is that `x ↦ x · ω` is onto `Ω_F(D)`, which
-needs the one-dimensionality of `Ω_F` over `F`. -/
+/-- **The elementwise Duality map** (Stichtenoth, in the proof of Theorem 1.5.14): a function lies
+in `L((ω) - D)` exactly when multiplying `ω` by it gives a Weil differential bounded by `D`.  The
+remaining content of the Duality Theorem is that `x ↦ x · ω` is onto `Ω_F(D)`, which needs the
+one-dimensionality of `Ω_F` over `F`. -/
 theorem mem_riemannRochSpace_ofWeilDifferential_sub_iff (hF : IsFunctionField k F)
     (hex : IsIntegrallyClosedIn k F) (hωΩ : ω ∈ weilDifferentialSpace k F) (hω : ω ≠ 0)
-    (z : Fˣ) (D : Divisor k F) :
-    (z : F) ∈ riemannRochSpace (Divisor.ofWeilDifferential ω - D) ↔
-      repartitionDualMul hF (z : F) ω ∈ weilDifferentialFiltration D := by
+    (x : F) (D : Divisor k F) :
+    x ∈ riemannRochSpace (Divisor.ofWeilDifferential ω - D) ↔
+      repartitionDualMul hF x ω ∈ weilDifferentialFiltration D := by
+  rcases eq_or_ne x 0 with rfl | hx
+  · simp
+  obtain ⟨z, rfl⟩ : ∃ z : Fˣ, (z : F) = x := ⟨Units.mk0 x hx, rfl⟩
   have hrearrange : Divisor.principal hF z + (Divisor.ofWeilDifferential ω - D) =
       Divisor.ofWeilDifferential ω + Divisor.principal hF z - D := by abel
   rw [mem_riemannRochSpace_units_iff hF,

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -152,6 +152,7 @@ theorem weilDifferentialFiltration_antitone :
 divisors into a lattice operation — `TauCeti.submoduleOfAdeleFiltrationSupDiagonalRepartitions_sup`
 — and annihilators take the resulting sum to an intersection.  This is what makes the set of
 divisors bounding a nonzero Weil differential have a greatest element. -/
+@[simp]
 theorem weilDifferentialFiltration_sup (D E : Divisor k F) :
     weilDifferentialFiltration (D ⊔ E) =
       weilDifferentialFiltration D ⊓ weilDifferentialFiltration E := by
@@ -222,8 +223,8 @@ by the inverse function recovers the form. -/
 theorem repartitionDualMul_inv_repartitionDualMul (hF : IsFunctionField k F) (z : Fˣ)
     (ω : Module.Dual k ↥(repartitionSpace k F)) :
     repartitionDualMul hF ((z⁻¹ : Fˣ) : F) (repartitionDualMul hF (z : F) ω) = ω := by
-  rw [← Module.End.mul_apply, ← map_mul, ← Units.val_mul, inv_mul_cancel, Units.val_one,
-    map_one, Module.End.one_apply]
+  rw [← Module.End.mul_apply, ← map_mul]
+  simp
 
 /-- Multiplying a nonzero linear form on `A_F` by a nonzero function leaves it nonzero. -/
 theorem repartitionDualMul_ne_zero (hF : IsFunctionField k F) (z : Fˣ)

--- a/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
+++ b/TauCeti/FieldTheory/FunctionField/Differential/Weil.lean
@@ -45,6 +45,8 @@ specialty, and are not proved here.
 * `TauCeti.weilDifferentialFiltration_antitone` and `TauCeti.mem_weilDifferentialSpace_iff`: the
   filtration is antitone and directed, so a `k`-linear form is a Weil differential exactly when
   some single divisor bounds it.
+* `TauCeti.weilDifferentialFiltration_sup`: `Ω_F(D ⊔ E) = Ω_F(D) ∩ Ω_F(E)`, the step towards the
+  divisor of a Weil differential.
 * `TauCeti.weilDifferentialFiltration_eq_bot_iff`: `Ω_F(D) = 0` exactly when every repartition
   differs from a constant by one bounded by `D`.
 * `TauCeti.repartitionDualMul_mem_weilDifferentialFiltration_iff`: for `z ∈ Fˣ`, a linear form
@@ -145,6 +147,17 @@ theorem weilDifferentialFiltration_antitone :
       Submodule k (Module.Dual k ↥(repartitionSpace k F))) := fun _ _ h ↦
   Submodule.dualAnnihilator_anti (submoduleOfAdeleFiltrationSupDiagonalRepartitions_mono h)
 
+/-- **The divisors bounding a fixed Weil differential are closed under pointwise maximum**:
+`Ω_F(D ⊔ E) = Ω_F(D) ∩ Ω_F(E)`.  Both `Ω_F(D)` and `A_F(D) + F` turn the pointwise maximum of
+divisors into a lattice operation — `TauCeti.submoduleOfAdeleFiltrationSupDiagonalRepartitions_sup`
+— and annihilators take the resulting sum to an intersection.  This is what makes the set of
+divisors bounding a nonzero Weil differential have a greatest element. -/
+theorem weilDifferentialFiltration_sup (D E : Divisor k F) :
+    weilDifferentialFiltration (D ⊔ E) =
+      weilDifferentialFiltration D ⊓ weilDifferentialFiltration E := by
+  rw [weilDifferentialFiltration, weilDifferentialFiltration, weilDifferentialFiltration,
+    submoduleOfAdeleFiltrationSupDiagonalRepartitions_sup, Submodule.dualAnnihilator_sup_eq]
+
 /-- **`Ω_F(D)` vanishes exactly when `A_F(D) + F` is everything**: the only `k`-linear form on
 `A_F` vanishing on `A_F(D) + F` is `0` precisely when every repartition already differs from a
 constant by one whose poles are bounded by `D`. -/
@@ -204,6 +217,20 @@ theorem repartitionDualMul_apply_apply (hF : IsFunctionField k F) (f : F)
     repartitionDualMul hF f ω a = ω (repartitionMul hF f a) :=
   (rfl)
 
+/-- Multiplying by a nonzero function is invertible on the linear forms on `A_F`: multiplying back
+by the inverse function recovers the form. -/
+theorem repartitionDualMul_inv_repartitionDualMul (hF : IsFunctionField k F) (z : Fˣ)
+    (ω : Module.Dual k ↥(repartitionSpace k F)) :
+    repartitionDualMul hF ((z⁻¹ : Fˣ) : F) (repartitionDualMul hF (z : F) ω) = ω := by
+  rw [← Module.End.mul_apply, ← map_mul, ← Units.val_mul, inv_mul_cancel, Units.val_one,
+    map_one, Module.End.one_apply]
+
+/-- Multiplying a nonzero linear form on `A_F` by a nonzero function leaves it nonzero. -/
+theorem repartitionDualMul_ne_zero (hF : IsFunctionField k F) (z : Fˣ)
+    {ω : Module.Dual k ↥(repartitionSpace k F)} (hω : ω ≠ 0) :
+    repartitionDualMul hF (z : F) ω ≠ 0 := fun h ↦ hω <| by
+  rw [← repartitionDualMul_inv_repartitionDualMul hF z ω, h, map_zero]
+
 /-- **Multiplication translates the filtration by a principal divisor**: for a nonzero function
 `z`, a linear form is bounded by `D` exactly when `z · ω` is bounded by `D + div z`, exactly as
 multiplication by `z` carries `A_F(D + div z)` into `A_F(D)`. -/
@@ -226,9 +253,7 @@ theorem repartitionDualMul_mem_weilDifferentialFiltration_iff (hF : IsFunctionFi
       rw [coe_repartitionMul_apply]
       exact smul_mem_diagonalRepartitions (y : F) ha
   refine ⟨fun h ↦ ?_, key z D ω⟩
-  have hzz : repartitionDualMul hF ((z⁻¹ : Fˣ) : F) (repartitionDualMul hF (z : F) ω) = ω := by
-    rw [← Module.End.mul_apply, ← map_mul, ← Units.val_mul, inv_mul_cancel, Units.val_one,
-      map_one, Module.End.one_apply]
+  have hzz := repartitionDualMul_inv_repartitionDualMul hF z ω
   have hD : D + Divisor.principal hF z + Divisor.principal hF z⁻¹ = D := by
     rw [Divisor.principal_inv, add_neg_cancel_right]
   have h' := key z⁻¹ _ _ h

--- a/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
@@ -50,6 +50,10 @@ differentials are the work that consumes this file.
 * `TauCeti.adeleFiltration_le_repartitionSpace`, `TauCeti.adeleFiltration_mono` and
   `TauCeti.directed_adeleFiltration`: the filtration lands in `A_F`, and is monotone and
   directed.
+* `TauCeti.adeleFiltration_sup` and
+  `TauCeti.submoduleOfAdeleFiltrationSupDiagonalRepartitions_sup`:
+  `A_F(D ⊔ E) = A_F(D) + A_F(E)`, and the same splitting after adding the constants — the
+  place-by-place statement that directedness only records qualitatively.
 * `TauCeti.repartitionSpace_eq_iSup` and `TauCeti.coe_repartitionSpace_eq_iUnion`:
   `A_F = ⋃_D A_F(D)`, the exhaustion.
 * `TauCeti.diagonalRepartitions_le_repartitionSpace`: the diagonal `F ↪ A_F`, which is where
@@ -205,6 +209,36 @@ attached to the pointwise maximum of the two divisors. -/
 theorem directed_adeleFiltration :
     Directed (· ≤ ·) (adeleFiltration : Divisor k F → Submodule k (Place k F → F)) :=
   fun D E ↦ ⟨D ⊔ E, adeleFiltration_mono le_sup_left, adeleFiltration_mono le_sup_right⟩
+
+/-- **The filtration turns the pointwise maximum of two divisors into a sum of subspaces**:
+`A_F(D ⊔ E) = A_F(D) + A_F(E)`.  Only `≤` has content, and it holds because the defining bound is
+a *pointwise* one: splitting a repartition bounded by `D ⊔ E` into the places where it already
+satisfies the bound of `D` and the places where it does not writes it as a sum of one repartition
+bounded by `D` and one bounded by `E`.  The corresponding statement for `TauCeti.riemannRochSpace`
+is false, since a single function cannot be truncated place by place. -/
+theorem adeleFiltration_sup (D E : Divisor k F) :
+    adeleFiltration (D ⊔ E) = adeleFiltration D ⊔ adeleFiltration E := by
+  classical
+  refine le_antisymm (fun a ha ↦ ?_)
+    (sup_le (adeleFiltration_mono le_sup_left) (adeleFiltration_mono le_sup_right))
+  -- at each place the bound of `D ⊔ E` is the bound of `D` or the bound of `E`
+  have hsplit : ∀ P : Place k F, ¬ P.valuation (a P) ≤ WithZero.exp (D.coeff P) →
+      P.valuation (a P) ≤ WithZero.exp (E.coeff P) := by
+    intro P hP
+    have h := ha P
+    rw [WeilDivisor.coeff_sup] at h
+    rcases le_total (E.coeff P) (D.coeff P) with hle | hle
+    · exact absurd (by rwa [sup_eq_left.mpr hle] at h) hP
+    · rwa [sup_eq_right.mpr hle] at h
+  refine Submodule.mem_sup.mpr
+    ⟨fun P ↦ if P.valuation (a P) ≤ WithZero.exp (D.coeff P) then a P else 0, fun P ↦ ?_,
+      fun P ↦ if P.valuation (a P) ≤ WithZero.exp (D.coeff P) then 0 else a P, fun P ↦ ?_,
+      funext fun P ↦ ?_⟩
+  · by_cases h : P.valuation (a P) ≤ WithZero.exp (D.coeff P) <;> simp [h]
+  · by_cases h : P.valuation (a P) ≤ WithZero.exp (D.coeff P)
+    · simp [h]
+    · simpa [h] using hsplit P h
+  · by_cases h : P.valuation (a P) ≤ WithZero.exp (D.coeff P) <;> simp [h]
 
 /-- Every `A_F(D)` consists of repartitions: outside the support of `D` its defining bound reads
 `v_P (a P) ≤ exp 0 = 1`. -/
@@ -399,6 +433,29 @@ theorem submoduleOfAdeleFiltrationSupDiagonalRepartitions_mono {D E : Divisor k 
     submoduleOfAdeleFiltrationSupDiagonalRepartitions D ≤
       submoduleOfAdeleFiltrationSupDiagonalRepartitions E :=
   Submodule.comap_mono (sup_le_sup_right (adeleFiltration_mono h) _)
+
+/-- **`(A_F(D ⊔ E) + F) ∩ A_F` is the sum of the subspaces of `D` and of `E`**: the pointwise
+splitting `TauCeti.adeleFiltration_sup` survives adding the constants and cutting down to `A_F`,
+because the `A_F(E)`-half of the splitting already lies in `A_F`, hence so does the rest. -/
+theorem submoduleOfAdeleFiltrationSupDiagonalRepartitions_sup (D E : Divisor k F) :
+    submoduleOfAdeleFiltrationSupDiagonalRepartitions (D ⊔ E) =
+      submoduleOfAdeleFiltrationSupDiagonalRepartitions D ⊔
+        submoduleOfAdeleFiltrationSupDiagonalRepartitions E := by
+  refine le_antisymm (fun a ha ↦ ?_) (sup_le
+    (submoduleOfAdeleFiltrationSupDiagonalRepartitions_mono le_sup_left)
+    (submoduleOfAdeleFiltrationSupDiagonalRepartitions_mono le_sup_right))
+  obtain ⟨u, hu, f, hf, huf⟩ := Submodule.mem_sup.mp
+    (mem_submoduleOfAdeleFiltrationSupDiagonalRepartitions_iff.mp ha)
+  rw [adeleFiltration_sup] at hu
+  obtain ⟨x, hx, y, hy, hxy⟩ := Submodule.mem_sup.mp hu
+  have hyA : y ∈ repartitionSpace k F := adeleFiltration_le_repartitionSpace E hy
+  have hxf : x + f = (a : Place k F → F) - y := by rw [← huf, ← hxy]; abel
+  refine Submodule.mem_sup.mpr ⟨a - ⟨y, hyA⟩,
+    mem_submoduleOfAdeleFiltrationSupDiagonalRepartitions_iff.mpr ?_, ⟨y, hyA⟩,
+    mem_submoduleOfAdeleFiltrationSupDiagonalRepartitions_iff.mpr (Submodule.mem_sup_left hy),
+    sub_add_cancel a _⟩
+  simp only [Submodule.coe_sub, ← hxf]
+  exact Submodule.add_mem_sup hx hf
 
 /-! ### Translating the filtration by a principal divisor -/
 

--- a/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Repartition/Basic.lean
@@ -216,6 +216,7 @@ a *pointwise* one: splitting a repartition bounded by `D ⊔ E` into the places 
 satisfies the bound of `D` and the places where it does not writes it as a sum of one repartition
 bounded by `D` and one bounded by `E`.  The corresponding statement for `TauCeti.riemannRochSpace`
 is false, since a single function cannot be truncated place by place. -/
+@[simp]
 theorem adeleFiltration_sup (D E : Divisor k F) :
     adeleFiltration (D ⊔ E) = adeleFiltration D ⊔ adeleFiltration E := by
   classical
@@ -437,6 +438,7 @@ theorem submoduleOfAdeleFiltrationSupDiagonalRepartitions_mono {D E : Divisor k 
 /-- **`(A_F(D ⊔ E) + F) ∩ A_F` is the sum of the subspaces of `D` and of `E`**: the pointwise
 splitting `TauCeti.adeleFiltration_sup` survives adding the constants and cutting down to `A_F`,
 because the `A_F(E)`-half of the splitting already lies in `A_F`, hence so does the rest. -/
+@[simp]
 theorem submoduleOfAdeleFiltrationSupDiagonalRepartitions_sup (D E : Divisor k F) :
     submoduleOfAdeleFiltrationSupDiagonalRepartitions (D ⊔ E) =
       submoduleOfAdeleFiltrationSupDiagonalRepartitions D ⊔


### PR DESCRIPTION
This PR constructs the divisor `(ω)` of a nonzero Weil differential of an algebraic function field `F / k` with exact constant field: the greatest divisor `D` with `ω ∈ Ω_F(D)`, characterized by `ω ∈ Ω_F(D) ↔ D ≤ (ω)`. It also proves the translation rule `(x · ω) = (ω) + div x` for a nonzero function `x`, and the elementwise form of the map of the Duality Theorem, `x ∈ L((ω) - D) ↔ x · ω ∈ Ω_F(D)`. This is Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Lemma 1.5.10, Definition 1.5.11 and the first half of Proposition 1.5.13; no code is copied or adapted from any existing formalization, and in particular not from `vaca22/riemann-roch-function-fields`, which the roadmap's coordination section records as covering the same mathematics by the same Stichtenoth route.

The target is `TauCetiRoadmap/AlgebraicCurves/README.md`, Layer 4 ("repartitions, Weil differentials, and Riemann–Roch"), the "Weil differentials" bullet, which lists "the divisor `(ω)` of `ω ≠ 0` (existence of the maximum: Lemma 1.5.10, Def. 1.5.11 …); `(f·ω) = div f + (ω)` … (Prop. 1.5.13)". Its prerequisites are on `main`: the objects `Ω_F(D)`, `Ω_F` and the `F`-action (#4788), the quotient interpretation of the index of specialty (#4825), and Riemann's theorem with the genus (#4463). After this PR, Layer 4 still needs `dim_F Ω_F = 1` (Proposition 1.5.9, in flight as #4865), the canonical class, the Duality Theorem 1.5.14, and Riemann–Roch itself.

The construction runs as Stichtenoth's. The divisors bounding `ω` have bounded degree, because a divisor `D` with `A_F(D) + F = A_F` bounds no nonzero Weil differential — that is the merged `weilDifferentialFiltration_eq_bot_iff` read against `adeleFiltration_sup_diagonalRepartitions_eq_repartitionSpace_iff` — while by Riemann's theorem every divisor of large enough degree is of that kind. They are also closed under the pointwise maximum of divisors: `A_F(D ⊔ E) = A_F(D) + A_F(E)`, because that filtration's defining bound is a *pointwise* one, so a repartition bounded by `D ⊔ E` splits into the places where it already meets the bound of `D` and the rest; adding the constants preserves the splitting, and `Submodule.dualAnnihilator_sup_eq` then turns the sum into the intersection `Ω_F(D ⊔ E) = Ω_F(D) ∩ Ω_F(E)`. A divisor of maximal degree among those bounding `ω` — `Int.exists_greatest_of_bdd` supplies one — is therefore the greatest one, since a strictly larger divisor of a function field has a strictly larger degree (`Divisor.eq_of_le_of_degree_eq`).

The hypotheses `ω ∈ Ω_F` and `ω ≠ 0` are not vacuous: `weilDifferentialFiltration_eq_bot_iff` says that `Ω_F(D) ≠ 0` exactly for the special divisors, and every divisor of degree at most `g - 2` is special, so `Ω_F ≠ 0`. That statement is not proved here because it is part of #4865, which derives it from `dim_k Ω_F(D) = i(D)`; this PR is otherwise independent of that one and restates none of its dimension formulas.

The new file is `TauCeti/FieldTheory/FunctionField/Differential/Divisor.lean` (193 lines). Two existing files gain the lemmas the construction needs, each in its canonical home: `Repartition/Basic.lean` gains `adeleFiltration_sup` and `submoduleOfAdeleFiltrationSupDiagonalRepartitions_sup`, next to the monotonicity and directedness statements they sharpen, and `Differential/Weil.lean` gains `weilDifferentialFiltration_sup` next to `weilDifferentialFiltration_antitone`, together with `repartitionDualMul_inv_repartitionDualMul` and `repartitionDualMul_ne_zero` — the first of which was already an unnamed `have` inside `repartitionDualMul_mem_weilDifferentialFiltration_iff`, and is now that proof's single named step.

`Divisor.ofWeilDifferential` is total, with the junk value `0` where no greatest divisor exists (for `ω = 0`, which every divisor bounds, and for a linear form no divisor bounds); its docstring says so, and `Divisor.ofWeilDifferential_eq_of_isGreatest` pins the definition down from any exhibited greatest divisor, with no hypotheses at all.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"divisor-of-a-weil-differential"}-->

🤖 Prepared with Claude Code
