### PR TITLE
feat: prove maximal unipotent candidates are greatest

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/SmoothContainment.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/SmoothContainment.lean
@@ -83,9 +83,14 @@ theorem ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot
     simpa only [P] using (inferInstance : Algebra.Smooth k H)
   let _ : IsNoetherianRing P.Ring := by
     simpa only [P] using (Algebra.FiniteType.isNoetherianRing k H)
+  have hf_algebraMap : algebraMap H K = f.toAlgHom.toRingHom := by
+    ext x
+    rfl
+  have hPmap : algebraMap P.Ring K = f.toAlgHom.toRingHom := by
+    simpa only [P] using hf_algebraMap
   have hPker : P.ker = (HopfIdeal.ker f).toIdeal := by
     rw [HopfIdeal.ker_toIdeal]
-    rfl
+    exact congrArg RingHom.ker hPmap
   have hker_aug : (HopfIdeal.ker f).toIdeal ≤
       Bialgebra.AugmentationIdeal k H := by
     intro x hx
@@ -145,10 +150,14 @@ theorem ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot
         exact (conormalSubspace_eq_bot_iff_toIdeal_le_sq_augmentationIdeal _).mp
           hconormal (hPker ▸ x.property)
       have hdx : (1 : κ) ⊗ₜ[H] KaehlerDifferential.D k H (x : H) = 0 := by
-        have hker_eq : RingHom.ker (algebraMap H κ) = RingHom.ker g := by
-          apply congrArg RingHom.ker
+        have hgMap : algebraMap H κ = g.toRingHom := by
           ext y
-          rfl
+          rw [IsScalarTower.algebraMap_apply H K κ]
+          simp only [g]
+          exact congrArg (algebraMap K κ)
+            (congrArg (fun φ : H →+* K => φ y) hf_algebraMap)
+        have hker_eq : RingHom.ker (algebraMap H κ) = RingHom.ker g :=
+          congrArg RingHom.ker hgMap
         let xg : RingHom.ker (algebraMap H κ) :=
           ⟨x, hker_eq.symm ▸ hxker⟩
         have hxsq' : (x : H) ∈ RingHom.ker (algebraMap H κ) ^ 2 := by

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/SmoothContainment.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/SmoothContainment.lean
@@ -1,0 +1,228 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Cotangent
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
+public import Mathlib.RingTheory.Spectrum.Prime.Topology
+public import Mathlib.Topology.Connected.Basic
+import Mathlib.RingTheory.Spectrum.Prime.FreeLocus
+import TauCeti.RingTheory.Idempotents.Connected.Spectrum
+import Mathlib.RingTheory.Ideal.IdempotentFG
+
+/-!
+# Smooth connected closed subgroups with equal tangent spaces
+
+A surjective map of coordinate Hopf algebras represents a closed immersion of affine groups.
+When both groups are smooth and connected, surjectivity on tangent spaces forces this closed
+immersion to be an isomorphism.
+
+The proof uses the conormal module of the surjection. Smoothness makes it finite projective over
+the target. Its fibre at the identity is zero, because its split injection into the relative
+cotangent space is zero there. Projective-module rank is locally constant, so connectedness of
+the target makes the conormal module vanish globally. The kernel is then idempotent; connectedness
+of the source and the counit condition force it to be zero.
+
+## Main declaration
+
+* `TauCeti.HopfIdeal.ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot`: a surjective
+  Hopf map between smooth connected affine groups is injective when its conormal space vanishes.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a and 10.a.
+* A. Borel, *Linear Algebraic Groups*, Section 11.21.
+
+This is the global equality step in Layer 5, "The unipotent radical", of the ReductiveGroups
+roadmap. It upgrades the infinitesimal equality supplied by the maximal-dimension construction to
+equality of closed subgroups.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal
+
+open TensorProduct
+
+variable {k H K : Type u} [Field k] [CommRing H] [CommRing K]
+variable [HopfAlgebra k H] [HopfAlgebra k K]
+
+/-- A surjective Hopf map between smooth connected affine groups is injective if its conormal
+space at the identity vanishes.
+
+Equivalently, a smooth connected closed affine subgroup whose differential is surjective is the
+whole ambient group. -/
+theorem ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot
+    [Algebra.FiniteType k H] (f : H →ₐc[k] K) (hf : Function.Surjective f)
+    (hH_smooth : smoothCommHopfAlgProperty k (_root_.CommHopfAlgCat.of k H))
+    (hH_connected : ConnectedSpace (PrimeSpectrum H))
+    (hK_smooth : smoothCommHopfAlgProperty k (_root_.CommHopfAlgCat.of k K))
+    (hK_connected : ConnectedSpace (PrimeSpectrum K))
+    (hconormal : conormalSubspace (HopfIdeal.ker f) = ⊥) : HopfIdeal.ker f = ⊥ := by
+  let _ : Algebra H K := f.toAlgHom.toAlgebra
+  let _ : IsScalarTower k H K :=
+    IsScalarTower.of_algebraMap_eq' f.toAlgHom.comp_algebraMap.symm
+  let P : Algebra.Extension k K :=
+    { Ring := H
+      σ := Function.surjInv hf
+      algebraMap_σ := Function.surjInv_eq hf }
+  let _ : Algebra.Smooth k H := (smoothCommHopfAlgProperty_iff _).mp hH_smooth
+  let _ : Algebra.Smooth k K := (smoothCommHopfAlgProperty_iff _).mp hK_smooth
+  let _ : ConnectedSpace (PrimeSpectrum H) := hH_connected
+  let _ : ConnectedSpace (PrimeSpectrum K) := hK_connected
+  let _ : Algebra.Smooth k P.Ring := by
+    change Algebra.Smooth k H
+    infer_instance
+  let _ : IsNoetherianRing P.Ring := by
+    change IsNoetherianRing H
+    exact Algebra.FiniteType.isNoetherianRing k H
+  have hPker : P.ker = (HopfIdeal.ker f).toIdeal := by
+    rw [HopfIdeal.ker_toIdeal]
+    rfl
+  have hker_aug : (HopfIdeal.ker f).toIdeal ≤
+      Bialgebra.AugmentationIdeal k H := by
+    intro x hx
+    rw [Bialgebra.AugmentationIdeal, RingHom.mem_ker]
+    have hxker : x ∈ RingHom.ker (f : H →ₐ[k] K) := by
+      simpa only [HopfIdeal.ker_toIdeal] using hx
+    have hcounit := CoalgHomClass.counit_comp_apply f x
+    calc
+      Coalgebra.counit (R := k) x = Coalgebra.counit (R := k) (f x) := hcounit.symm
+      _ = Coalgebra.counit (R := k) 0 := congrArg _ (RingHom.mem_ker.mp hxker)
+      _ = 0 := map_zero (Bialgebra.counitAlgHom k K)
+  have hker_fg : P.ker.FG := by
+    exact P.ker.fg_of_isNoetherianRing
+  have _ : Module.Finite P.Ring P.Cotangent := by
+    have _ : Module.Finite P.Ring P.ker := Module.Finite.of_fg hker_fg
+    exact Module.Finite.of_surjective _ Algebra.Extension.Cotangent.mk_surjective
+  have _ : Module.Finite K P.Cotangent :=
+    Module.Finite.of_restrictScalars_finite P.Ring K P.Cotangent
+  obtain ⟨l, hl⟩ := (P.formallySmooth_iff_split_injection).mp
+    (inferInstance : Algebra.FormallySmooth k K)
+  let _ : Module.Projective K P.CotangentSpace := inferInstance
+  let _ : Module.Projective K P.Cotangent :=
+    Module.Projective.of_split P.cotangentComplex l hl
+  let _ : Module.Flat K P.Cotangent := inferInstance
+  let _ : Module.FinitePresentation K P.Cotangent :=
+    Module.finitePresentation_of_projective K P.Cotangent
+  let p : Ideal K := Bialgebra.AugmentationIdeal k K
+  let _ : p.IsMaximal := by
+    dsimp [p, Bialgebra.AugmentationIdeal]
+    exact RingHom.ker_isMaximal_of_surjective _ fun x ↦
+      ⟨algebraMap k K x, by simp⟩
+  let κ := p.ResidueField
+  let g : H →ₐ[k] κ :=
+    (IsScalarTower.toAlgHom k K κ).comp f.toAlgHom
+  have hgker : RingHom.ker g = Bialgebra.AugmentationIdeal k H := by
+    ext x
+    rw [RingHom.mem_ker, show g x = algebraMap K κ (f x) by rfl,
+      Ideal.algebraMap_residueField_eq_zero]
+    change f x ∈ RingHom.ker (Bialgebra.counitAlgHom k K) ↔
+      x ∈ RingHom.ker (Bialgebra.counitAlgHom k H)
+    simp only [RingHom.mem_ker, Bialgebra.counitAlgHom_apply]
+    rw [CoalgHomClass.counit_comp_apply f x]
+  have hbaseChange_zero : P.cotangentComplex.lTensor κ = 0 := by
+    apply LinearMap.ext
+    intro z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | add x y hx hy => simp [hx, hy]
+    | tmul a m =>
+      obtain ⟨x, rfl⟩ := Algebra.Extension.Cotangent.mk_surjective (P := P) m
+      have hxker : (x : H) ∈ RingHom.ker g := by
+        rw [hgker]
+        exact hker_aug (hPker ▸ x.property)
+      have hxsq : (x : H) ∈ RingHom.ker g ^ 2 := by
+        rw [hgker]
+        exact (conormalSubspace_eq_bot_iff_toIdeal_le_sq_augmentationIdeal _).mp
+          hconormal (hPker ▸ x.property)
+      have hdx : (1 : κ) ⊗ₜ[H] KaehlerDifferential.D k H (x : H) = 0 := by
+        have hker_eq : RingHom.ker (algebraMap H κ) = RingHom.ker g := by
+          apply congrArg RingHom.ker
+          ext y
+          rfl
+        let xg : RingHom.ker (algebraMap H κ) :=
+          ⟨x, hker_eq.symm ▸ hxker⟩
+        have hxsq' : (x : H) ∈ RingHom.ker (algebraMap H κ) ^ 2 := by
+          rw [hker_eq]
+          exact hxsq
+        have hxzero : (RingHom.ker (algebraMap H κ)).toCotangent xg = 0 :=
+          (Ideal.toCotangent_eq_zero _ xg).2 hxsq'
+        simpa only [xg, map_zero,
+          KaehlerDifferential.kerCotangentToTensor_toCotangent] using
+          congrArg (KaehlerDifferential.kerCotangentToTensor k H κ) hxzero
+      rw [LinearMap.lTensor_tmul, P.cotangentComplex_mk]
+      change a ⊗ₜ[K] (1 ⊗ₜ[H] KaehlerDifferential.D k H (x : H)) = 0
+      apply (AlgebraTensorModule.cancelBaseChange H K κ κ
+        (KaehlerDifferential k H)).injective
+      simpa only [map_zero, AlgebraTensorModule.cancelBaseChange_tmul, one_smul,
+        TensorProduct.smul_tmul', smul_eq_mul, mul_one, smul_zero] using
+        congrArg (a • ·) hdx
+  have hfiber : Subsingleton (p.Fiber P.Cotangent) := by
+    have hinjective : Function.Injective (P.cotangentComplex.lTensor κ) := by
+      intro x y hxy
+      have h := congrArg (l.lTensor κ) hxy
+      simpa only [← LinearMap.comp_apply, ← LinearMap.lTensor_comp, hl,
+        LinearMap.lTensor_id, LinearMap.id_apply] using h
+    constructor
+    intro x y
+    apply hinjective
+    rw [hbaseChange_zero]
+    rfl
+  have hrank_identity : Module.rankAtStalk (R := K) P.Cotangent
+      ⟨p, (inferInstance : p.IsMaximal).isPrime⟩ = 0 := by
+    rw [Module.rankAtStalk_eq]
+    exact Module.finrank_zero_of_subsingleton
+  have hrank : Module.rankAtStalk (R := K) P.Cotangent = 0 := by
+    apply funext
+    intro q
+    change Module.rankAtStalk P.Cotangent q = 0
+    calc
+      Module.rankAtStalk P.Cotangent q =
+          Module.rankAtStalk P.Cotangent ⟨p, (inferInstance : p.IsMaximal).isPrime⟩ :=
+        IsLocallyConstant.apply_eq_of_preconnectedSpace
+          (Module.isLocallyConstant_rankAtStalk (R := K) (M := P.Cotangent)) _ _
+      _ = 0 := hrank_identity
+  have hcotangent : Subsingleton P.Cotangent :=
+    (Module.rankAtStalk_eq_zero_iff_subsingleton (R := K) (M := P.Cotangent)).mp hrank
+  have hI_idempotent : IsIdempotentElem (HopfIdeal.ker f).toIdeal := by
+    rw [← hPker]
+    have hcotangentKer : Subsingleton P.ker.Cotangent := by
+      constructor
+      intro x y
+      apply P.cotangentEquivCotangentKer.symm.injective
+      exact Subsingleton.elim _ _
+    exact (Ideal.cotangent_subsingleton_iff (I := P.ker)).mp
+      hcotangentKer
+  let _ : IsNoetherianRing H := Algebra.FiniteType.isNoetherianRing k H
+  obtain ⟨e, he, hspan⟩ :=
+    (Ideal.isIdempotentElem_iff_of_fg (HopfIdeal.ker f).toIdeal
+      (HopfIdeal.ker f).toIdeal.fg_of_isNoetherianRing).mp hI_idempotent
+  rcases eq_zero_or_eq_one_of_isIdempotentElem he with rfl | rfl
+  · apply HopfIdeal.ext
+    intro x
+    rw [← mem_toIdeal, ← mem_toIdeal, bot_toIdeal]
+    simpa using SetLike.ext_iff.mp hspan x
+  · exfalso
+    apply RingHom.ker_ne_top (Bialgebra.counitAlgHom k H).toRingHom
+    apply top_unique
+    intro x _
+    change x ∈ Bialgebra.AugmentationIdeal k H
+    apply hker_aug
+    rw [hspan]
+    simp
+
+end HopfIdeal
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/SmoothContainment.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/SmoothContainment.lean
@@ -80,11 +80,9 @@ theorem ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot
   let _ : ConnectedSpace (PrimeSpectrum H) := hH_connected
   let _ : ConnectedSpace (PrimeSpectrum K) := hK_connected
   let _ : Algebra.Smooth k P.Ring := by
-    change Algebra.Smooth k H
-    infer_instance
+    simpa only [P] using (inferInstance : Algebra.Smooth k H)
   let _ : IsNoetherianRing P.Ring := by
-    change IsNoetherianRing H
-    exact Algebra.FiniteType.isNoetherianRing k H
+    simpa only [P] using (Algebra.FiniteType.isNoetherianRing k H)
   have hPker : P.ker = (HopfIdeal.ker f).toIdeal := by
     rw [HopfIdeal.ker_toIdeal]
     rfl
@@ -124,12 +122,13 @@ theorem ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot
     (IsScalarTower.toAlgHom k K κ).comp f.toAlgHom
   have hgker : RingHom.ker g = Bialgebra.AugmentationIdeal k H := by
     ext x
-    rw [RingHom.mem_ker, show g x = algebraMap K κ (f x) by rfl,
-      Ideal.algebraMap_residueField_eq_zero]
-    change f x ∈ RingHom.ker (Bialgebra.counitAlgHom k K) ↔
-      x ∈ RingHom.ker (Bialgebra.counitAlgHom k H)
-    simp only [RingHom.mem_ker, Bialgebra.counitAlgHom_apply]
-    rw [CoalgHomClass.counit_comp_apply f x]
+    rw [RingHom.mem_ker]
+    simp only [g, AlgHom.coe_comp, Function.comp_apply, IsScalarTower.toAlgHom_apply]
+    rw [Ideal.algebraMap_residueField_eq_zero]
+    simp only [p, Bialgebra.AugmentationIdeal, RingHom.mem_ker]
+    constructor
+    · exact fun hx ↦ (CoalgHomClass.counit_comp_apply f x).symm.trans hx
+    · exact fun hx ↦ (CoalgHomClass.counit_comp_apply f x).trans hx
   have hbaseChange_zero : P.cotangentComplex.lTensor κ = 0 := by
     apply LinearMap.ext
     intro z
@@ -161,6 +160,8 @@ theorem ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot
           KaehlerDifferential.kerCotangentToTensor_toCotangent] using
           congrArg (KaehlerDifferential.kerCotangentToTensor k H κ) hxzero
       rw [LinearMap.lTensor_tmul, P.cotangentComplex_mk]
+      -- `Extension.CotangentSpace` is an abbreviation for this nested tensor product; exposing
+      -- it is necessary to apply the associativity equivalence `cancelBaseChange` below.
       change a ⊗ₜ[K] (1 ⊗ₜ[H] KaehlerDifferential.D k H (x : H)) = 0
       apply (AlgebraTensorModule.cancelBaseChange H K κ κ
         (KaehlerDifferential k H)).injective
@@ -185,7 +186,7 @@ theorem ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot
   have hrank : Module.rankAtStalk (R := K) P.Cotangent = 0 := by
     apply funext
     intro q
-    change Module.rankAtStalk P.Cotangent q = 0
+    simp only [Pi.zero_apply]
     calc
       Module.rankAtStalk P.Cotangent q =
           Module.rankAtStalk P.Cotangent ⟨p, (inferInstance : p.IsMaximal).isPrime⟩ :=
@@ -216,7 +217,6 @@ theorem ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot
     apply RingHom.ker_ne_top (Bialgebra.counitAlgHom k H).toRingHom
     apply top_unique
     intro x _
-    change x ∈ Bialgebra.AugmentationIdeal k H
     apply hker_aug
     rw [hspan]
     simp

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Product
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.SmoothContainment
 import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
 
 /-!
@@ -19,8 +20,8 @@ shows that the scheme-theoretic product `UV` is another candidate containing bot
 
 This file combines those two inputs. Containment makes Lie dimension monotone, while maximality
 gives the reverse inequality, so `U` and `UV` have equal Lie dimension for every candidate `V`.
-This is the equality needed to show that the connected quotient `UV/U` has zero-dimensional Lie
-algebra and is therefore trivial, proving that `U` contains every candidate.
+The resulting tangent-space equality, together with smoothness and connectedness, proves `UV = U`
+and hence that `U` contains every candidate.
 
 ## Main declarations
 
@@ -33,6 +34,10 @@ The declarations are in `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate`.
   bijection on tangent Lie algebras.
 * `conormalSubspace_productOfNormal_le_left_eq_bot_of_maximal`:
   the relative defining ideal of the maximal candidate in that product has zero conormal space.
+* `productOfNormal_eq_left_of_maximal`:
+  a maximal-dimensional candidate contains every candidate, because their product equals it.
+* `le_of_finrank_maximal`:
+  a maximal-dimensional candidate is the greatest unipotent-radical candidate.
 
 ## References
 
@@ -148,6 +153,88 @@ theorem conormalSubspace_productOfNormal_le_left_eq_bot_of_maximal
       I.map (Bialgebra.Quotient.mkBialgHom P.toIdeal) :=
     CommHopfAlgCat.ker_quotientMapOfLe H.obj hPI
   simpa only [P] using hker ▸ hconormal
+
+/-- Multiplying a maximal-dimensional unipotent-radical candidate by any other candidate does
+not enlarge it.
+
+The preceding tangent-space calculation gives zero conormal space for the inclusion of the
+maximal candidate in the product. Both groups are smooth and connected, so
+`HopfIdeal.ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot` upgrades this
+first-order equality to equality of the closed subgroups. -/
+theorem productOfNormal_eq_left_of_maximal
+    (hI : IsUnipotentRadicalCandidate H I)
+    (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
+      Module.finrank k
+          (Derivation k (H ⧸ K.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
+        Module.finrank k
+          (Derivation k (H ⧸ I.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
+    (hJ : IsUnipotentRadicalCandidate H J) :
+    HopfIdeal.ker
+        (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom = I := by
+  let P : HopfIdeal k H :=
+    HopfIdeal.ker (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom
+  let hPI : P ≤ I :=
+    CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal
+  let q := FiniteTypeCommHopfAlgCat.toBialgHom
+    (FiniteTypeCommHopfAlgCat.quotientMapOfLe H hPI)
+  have hP : IsUnipotentRadicalCandidate H P := hI.productOfNormal hJ
+  have hP_smooth : smoothCommHopfAlgProperty k
+      (_root_.CommHopfAlgCat.of k (H ⧸ P.toIdeal)) :=
+    (smoothCommHopfAlgProperty_iff _).mpr
+      ((smoothUnipotentCommHopfAlgProperty_iff k
+        (FiniteTypeCommHopfAlgCat.quotient H P)).mp hP.smoothUnipotent).1
+  have hI_smooth : smoothCommHopfAlgProperty k
+      (_root_.CommHopfAlgCat.of k (H ⧸ I.toIdeal)) :=
+    (smoothCommHopfAlgProperty_iff _).mpr
+      ((smoothUnipotentCommHopfAlgProperty_iff k
+        (FiniteTypeCommHopfAlgCat.quotient H I)).mp hI.smoothUnipotent).1
+  have hP_connected : ConnectedSpace (PrimeSpectrum (H ⧸ P.toIdeal)) :=
+    geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ hP.geometricallyConnected
+  have hI_connected : ConnectedSpace (PrimeSpectrum (H ⧸ I.toIdeal)) :=
+    geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ hI.geometricallyConnected
+  have hker_q : HopfIdeal.ker q =
+      I.map (Bialgebra.Quotient.mkBialgHom P.toIdeal) :=
+    CommHopfAlgCat.ker_quotientMapOfLe H.obj hPI
+  have hconormal_q : HopfIdeal.conormalSubspace (HopfIdeal.ker q) = ⊥ := by
+    rw [hker_q]
+    simpa only [P] using
+      hI.conormalSubspace_productOfNormal_le_left_eq_bot_of_maximal hmax hJ
+  have hqker : HopfIdeal.ker q = ⊥ :=
+    HopfIdeal.ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot q
+      (FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hPI)
+      hP_smooth hP_connected hI_smooth hI_connected
+      hconormal_q
+  have hmap : I.map (Bialgebra.Quotient.mkBialgHom P.toIdeal) = ⊥ := by
+    rw [← CommHopfAlgCat.ker_quotientMapOfLe H.obj hPI]
+    exact hqker
+  have hIP : I ≤ P := by
+    rw [← toIdeal_le_toIdeal]
+    have hle := (HopfIdeal.map_eq_bot_iff I
+      (Bialgebra.Quotient.mkBialgHom P.toIdeal)).mp hmap
+    intro x hx
+    have hxker := hle hx
+    rw [RingHom.mem_ker] at hxker
+    exact Ideal.Quotient.eq_zero_iff_mem.mp hxker
+  exact le_antisymm hPI hIP
+
+/-- A maximal-dimensional unipotent-radical candidate is the greatest candidate.
+
+The order on Hopf ideals reverses inclusion of the represented closed subgroups: `I ≤ J` says
+that the subgroup defined by `I` contains the subgroup defined by `J`. -/
+theorem le_of_finrank_maximal
+    (hI : IsUnipotentRadicalCandidate H I)
+    (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
+      Module.finrank k
+          (Derivation k (H ⧸ K.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
+        Module.finrank k
+          (Derivation k (H ⧸ I.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
+    (hJ : IsUnipotentRadicalCandidate H J) : I ≤ J := by
+  rw [← hI.productOfNormal_eq_left_of_maximal hmax hJ]
+  exact CommHopfAlgCat.ker_productMapOfNormal_le_right H.obj I J hI.isNormal
 
 end HopfIdeal.IsUnipotentRadicalCandidate
 


### PR DESCRIPTION
This PR proves that a maximal-Lie-dimension unipotent-radical candidate is the greatest candidate. It advances the exact ReductiveGroups Layer 5 target “the unipotent radical `R_u(G)`: the maximal connected normal unipotent closed subgroup” by closing the maximal-dimension-to-greatest step.

It adds a general rigidity theorem for a surjective Hopf map between smooth connected affine groups: vanishing conormal space at the identity forces the kernel Hopf ideal to vanish. The proof uses Mathlib's formally-smooth split conormal sequence, locally constant projective-module stalk rank, and finitely generated idempotent-ideal infrastructure. It then applies that theorem to the scheme-theoretic product of a maximal-dimensional candidate with an arbitrary candidate, proves the product equals the maximal candidate, and exposes the resulting greatest-candidate order theorem.

Milestone: Layer 5, construction of the maximal connected normal unipotent closed subgroup. After this PR, the remaining work is to package the greatest candidate as `R_u(G)` under the roadmap's field/descent hypotheses and connect it to the geometric definition of reductivity.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"maximal-unipotent-candidate-eq-product"}-->

🤖 Prepared with Codex
