### PR TITLE
feat(Huber): the weighted restricted series ring is first countable

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/FirstCountable.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/FirstCountable.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Basic
+public import TauCeti.Topology.Algebra.Group.FirstCountable
+public import TauCeti.Topology.Algebra.Nonarchimedean.FirstCountable
+
+/-!
+# First countability of the weighted restricted series ring
+
+`TauCeti.Huber.weightedRestrictedSubring` carries the topology whose neighbourhoods of zero are
+the `U⟨X⟩` for `U` an open additive subgroup of the coefficient ring `A`
+(`TauCeti.Huber.hasBasis_nhds_zero_weightedTopology`). That basis is indexed by *all* of
+`OpenAddSubgroup A`, so it is not countable as it stands; what makes `𝓝 0` countably generated is
+that a countable *cofinal* subfamily suffices, and a nonarchimedean `A` whose own `𝓝 0` is
+countably generated supplies one.
+
+This matters because `FirstCountableTopology` is the class Mathlib's own instances are keyed on —
+notably the completeness of a quotient by a subgroup (Bourbaki IX.3.1 Proposition 4), which the
+theory of rational localisations consumes. With the instance below in scope,
+`FirstCountableTopology (weightedRestrictedSubring T hT)` is found by typeclass resolution alone,
+through `TauCeti.SeparatelyContinuousAdd.toFirstCountableTopology`; no separate declaration is
+needed and none is given.
+
+The hypothesis `[(𝓝 (0 : A)).IsCountablyGenerated]` is not restrictive in the intended
+application: a Huber ring satisfies it, by
+`TauCeti.Huber.IsHuberRing.isCountablyGenerated_nhds_zero`.
+
+## Main results
+
+* `TauCeti.Huber.isCountablyGenerated_nhds_zero_weightedRestrictedSubring`.
+-/
+
+public section
+
+open scoped Topology
+
+namespace TauCeti.Huber
+
+variable {k : ℕ} {A : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+
+/-- **Countable generation of `𝓝 0` passes to `A⟨X⟩_T`.** The `U⟨X⟩` for `U` ranging over a
+countable antitone basis of `𝓝 (0 : A)` by open additive subgroups are cofinal among the
+`U⟨X⟩` for arbitrary `U`, since `TauCeti.Huber.weightedNhd` is monotone. -/
+instance isCountablyGenerated_nhds_zero_weightedRestrictedSubring
+    [(𝓝 (0 : A)).IsCountablyGenerated] {T : Fin k → Set A} {hT : IsWeightFamily T} :
+    (𝓝 (0 : weightedRestrictedSubring T hT)).IsCountablyGenerated := by
+  obtain ⟨V, hV⟩ := NonarchimedeanAddGroup.exists_antitone_basis_openAddSubgroup (G := A)
+  refine Filter.HasBasis.isCountablyGenerated (ι := ℕ)
+    ((hasBasis_nhds_zero_weightedTopology hT).to_hasBasis
+      (p' := fun _ : ℕ ↦ True)
+      (s' := fun n ↦ (weightedNhd T hT (V n).toAddSubgroup :
+        Set (weightedRestrictedSubring T hT))) ?_ ?_)
+  · intro U _
+    obtain ⟨n, -, hn⟩ := hV.toHasBasis.mem_iff.mp (U.isOpen.mem_nhds U.zero_mem)
+    exact ⟨n, trivial, weightedNhd_mono hn⟩
+  · intro n _
+    exact ⟨V n, trivial, le_rfl⟩
+
+end TauCeti.Huber


### PR DESCRIPTION
`TauCeti.Huber.weightedRestrictedSubring` carries the topology whose neighbourhoods of zero are
the `U⟨X⟩` for `U` an open additive subgroup of the coefficient ring `A`
(`hasBasis_nhds_zero_weightedTopology`). That basis is indexed by **all** of
`OpenAddSubgroup A`, so it is not countable as it stands. This shows `𝓝 0` is nonetheless
countably generated, because a countable *cofinal* subfamily suffices and a nonarchimedean `A`
whose own `𝓝 0` is countably generated supplies one — `exists_antitone_basis_openAddSubgroup`
gives an ℕ-indexed antitone basis by open subgroups, and `weightedNhd_mono` transports cofinality
through `U ↦ U⟨X⟩`.

## Why the `𝓝 0` form, and not `FirstCountableTopology`

With this instance in scope, `FirstCountableTopology (weightedRestrictedSubring T hT)` is found by
typeclass resolution alone, through `TauCeti.SeparatelyContinuousAdd.toFirstCountableTopology`.
I verified that (an `example … := by infer_instance` compiles) and then **did not** ship a named
declaration for it, since it would be redundant with the instance chain. The module docstring
records that the consequence is automatic, so a reader does not have to rediscover it.

`FirstCountableTopology` is the class Mathlib's own instances are keyed on — in particular the
completeness of a quotient by a subgroup (`QuotientGroup.completeSpace_*`, Bourbaki IX.3.1
Proposition 4), which is what the theory of rational localisations consumes downstream.

## Hypothesis

`[(𝓝 (0 : A)).IsCountablyGenerated]` is not restrictive where this is wanted: a Huber ring
satisfies it by `IsHuberRing.isCountablyGenerated_nhds_zero`. I state the weaker filter hypothesis
rather than `[IsHuberRing A]` so the result is available to the weighted construction on its own
terms, matching the idiom of the surrounding files (`ClosedSubmodule.lean`, `OpenMapping.lean`,
`DenseSubmodule.lean` all carry `[(𝓤 _).IsCountablyGenerated]` as a hypothesis rather than
deriving it).

## Gate

`lake build` of the new module — 2183 jobs, no errors, warnings or sorries. It is a new leaf
file, so nothing on `main` imports it yet; its consumer is the rational-localisation work in
progress under the AdicSpaces roadmap.

## Roadmap

`TauCetiRoadmap/AdicSpaces/README.md`, **§4.1 "Strongly noetherian Tate rings"** (README:552),
which is the node the rational-localisation work sits in. Its topological paragraph, README:584–586,
states the standing assumption this PR supplies a piece of:

> Prove the additional topological statements separately. The rings and modules in the argument
> are complete, Hausdorff, and **metrisable**; use Layer 0's open mapping theorem to show that the
> relevant images are closed and that the algebraic quotient topology agrees with the topology on
> the target.

For a topological group, metrisability *is* first countability, and `FirstCountableTopology` is
the class Mathlib's instances are keyed on.

**The dependency, concretely.** §4.1 step 3 (README:571) is Proposition 8.30, restriction maps
between rational localisations are flat. Identifying a rational localisation requires Wedhorn's
Example 6.38 presentation `A⟨T/s⟩ ≅ C/a` with `C` a ring of restricted power series, and applying
the universal property of `A⟨T/s⟩` to `C/a` demands `[CompleteSpace (C ⧸ a)]`. Mathlib's route to
that is `QuotientGroup.completeSpace_*` (Bourbaki IX.3.1 Proposition 4), whose hypotheses are
completeness **and `FirstCountableTopology`** — notably *not* closedness of the subgroup, which is
what buys `T0Space` instead. `C` is a completion of the ring this PR is about, so first
countability of that ring is what makes the whole chain available.

Roadmap: AdicSpaces

