### PR TITLE
refactor(Huber): package weightedMapCompletion as a RingEquiv

### DIFF
--- a/TauCeti/RingTheory/Huber/StronglyNoetherian.lean
+++ b/TauCeti/RingTheory/Huber/StronglyNoetherian.lean
@@ -173,30 +173,13 @@ variable {A B : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
 /-- **The isomorphism `A⟨X₁,…,Xₖ⟩ ≃+* B⟨X₁,…,Xₖ⟩` induced by a bicontinuous ring isomorphism
 `e : A ≃+* B`**, acting coefficientwise. Continuity of `e` and of `e.symm` are both hypotheses;
 neither follows from the other for a bare `RingEquiv`. -/
--- Built from `weightedMapCompletion` in each direction; the two are mutually inverse by
--- `weightedMapCompletion_id` and `weightedMapCompletion_comp`. Both continuity hypotheses are
--- load-bearing because `weightedMapCompletion` goes through `UniformSpace.Completion.mapRingHom`,
--- which induces nothing on completions from a discontinuous map.
+-- The equiv is `TauCeti.Huber.weightedMapCompletionEquiv` at the constant weight family; both
+-- continuity hypotheses are load-bearing there.
 private noncomputable def restrictedMvPowerSeriesCompletionCongr (e : A ≃+* B) (he : Continuous e)
     (he' : Continuous e.symm) (k : ℕ) :
     restrictedMvPowerSeriesCompletion k A ≃+* restrictedMvPowerSeriesCompletion k B :=
-  RingEquiv.ofRingHom
-    (weightedMapCompletion (φ := (e : A →+* B)) he isWeightFamily_one_weight
-      isWeightFamily_one_weight
-      fun _ ↦ by simp)
-    (weightedMapCompletion (φ := (e.symm : B →+* A)) he' isWeightFamily_one_weight
-      isWeightFamily_one_weight
-      fun _ ↦ by simp)
-    (by
-      rw [weightedMapCompletion_comp he' he isWeightFamily_one_weight isWeightFamily_one_weight
-        isWeightFamily_one_weight (fun _ ↦ by simp)
-        (fun _ ↦ by simp)]
-      simp)
-    (by
-      rw [weightedMapCompletion_comp he he' isWeightFamily_one_weight isWeightFamily_one_weight
-        isWeightFamily_one_weight (fun _ ↦ by simp)
-        (fun _ ↦ by simp)]
-      simp)
+  weightedMapCompletionEquiv e he he' isWeightFamily_one_weight isWeightFamily_one_weight
+    (fun _ ↦ by simp) (fun _ ↦ by simp)
 
 /-- **Strong noetherianness is invariant under a bicontinuous ring isomorphism.** Continuity of
 `e` and of `e.symm` are both hypotheses; neither follows from the other for a bare `RingEquiv`. -/

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -179,6 +179,31 @@ theorem weightedMapCompletion_comp {C : Type*} [CommRing C] [TopologicalSpace C]
   simp only [weightedMapCompletion, weightedMap_comp hφ hψ hT hS hR hTS' hSR']
   exact UniformSpace.Completion.mapRingHom_comp _ _
 
+/-- **The isomorphism `A⟨X⟩_T ≃+* B⟨X⟩_S` induced by a bicontinuous ring isomorphism**, acting
+coefficientwise on completions. Continuity of `e` and of `e.symm` are both hypotheses; neither
+follows from the other for a bare `RingEquiv`, because `TauCeti.Huber.weightedMapCompletion` goes
+through `UniformSpace.Completion.mapRingHom`, which induces nothing from a discontinuous map.
+
+This is the `RingEquiv` packaging of `TauCeti.Huber.weightedMapCompletion`: the two induced maps
+are mutually inverse by `TauCeti.Huber.weightedMapCompletion_comp` and
+`TauCeti.Huber.weightedMapCompletion_id`. -/
+noncomputable def weightedMapCompletionEquiv (e : A ≃+* B) (he : Continuous e)
+    (he' : Continuous e.symm) (hT : IsWeightFamily T) (hS : IsWeightFamily S)
+    (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i) :
+    UniformSpace.Completion (weightedRestrictedSubring T hT) ≃+*
+      UniformSpace.Completion (weightedRestrictedSubring S hS) :=
+  RingEquiv.ofRingHom
+    (weightedMapCompletion (φ := (e : A →+* B)) he hT hS hTS)
+    (weightedMapCompletion (φ := (e.symm : B →+* A)) he' hS hT hST)
+    (by
+      rw [weightedMapCompletion_comp he' he hS hT hS
+        (fun i ↦ Set.image_subset_iff.mp (hST i)) (fun i ↦ Set.image_subset_iff.mp (hTS i))]
+      simp)
+    (by
+      rw [weightedMapCompletion_comp he he' hT hS hT
+        (fun i ↦ Set.image_subset_iff.mp (hTS i)) (fun i ↦ Set.image_subset_iff.mp (hST i))]
+      simp)
+
 end Functoriality
 
 /-! ### Zero variables -/

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -212,8 +212,7 @@ theorem weightedMapCompletionEquiv_apply (e : A ≃+* B) (he : Continuous e)
     (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i)
     (x : UniformSpace.Completion (weightedRestrictedSubring T hT)) :
     weightedMapCompletionEquiv e he he' hT hS hTS hST x
-      = weightedMapCompletion (φ := (e : A →+* B)) he hT hS hTS x := by
-  simp [weightedMapCompletionEquiv]
+      = weightedMapCompletion (φ := (e : A →+* B)) he hT hS hTS x := (rfl)
 
 /-- **The inverse direction of `TauCeti.Huber.weightedMapCompletionEquiv`** is the map induced by
 `e.symm`. -/
@@ -223,8 +222,7 @@ theorem weightedMapCompletionEquiv_symm_apply (e : A ≃+* B) (he : Continuous e
     (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i)
     (y : UniformSpace.Completion (weightedRestrictedSubring S hS)) :
     (weightedMapCompletionEquiv e he he' hT hS hTS hST).symm y
-      = weightedMapCompletion (φ := (e.symm : B →+* A)) he' hS hT hST y := by
-  simp [weightedMapCompletionEquiv]
+      = weightedMapCompletion (φ := (e.symm : B →+* A)) he' hS hT hST y := (rfl)
 
 end Functoriality
 

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -204,6 +204,28 @@ noncomputable def weightedMapCompletionEquiv (e : A ≃+* B) (he : Continuous e)
         (fun i ↦ Set.image_subset_iff.mp (hTS i)) (fun i ↦ Set.image_subset_iff.mp (hST i))]
       simp)
 
+/-- **The forward direction of `TauCeti.Huber.weightedMapCompletionEquiv`** is the induced map
+`TauCeti.Huber.weightedMapCompletion`, so the equivalence acts coefficientwise. -/
+@[simp]
+theorem weightedMapCompletionEquiv_apply (e : A ≃+* B) (he : Continuous e)
+    (he' : Continuous e.symm) (hT : IsWeightFamily T) (hS : IsWeightFamily S)
+    (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i)
+    (x : UniformSpace.Completion (weightedRestrictedSubring T hT)) :
+    weightedMapCompletionEquiv e he he' hT hS hTS hST x
+      = weightedMapCompletion (φ := (e : A →+* B)) he hT hS hTS x := by
+  simp [weightedMapCompletionEquiv]
+
+/-- **The inverse direction of `TauCeti.Huber.weightedMapCompletionEquiv`** is the map induced by
+`e.symm`. -/
+@[simp]
+theorem weightedMapCompletionEquiv_symm_apply (e : A ≃+* B) (he : Continuous e)
+    (he' : Continuous e.symm) (hT : IsWeightFamily T) (hS : IsWeightFamily S)
+    (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i)
+    (y : UniformSpace.Completion (weightedRestrictedSubring S hS)) :
+    (weightedMapCompletionEquiv e he he' hT hS hTS hST).symm y
+      = weightedMapCompletion (φ := (e.symm : B →+* A)) he' hS hT hST y := by
+  simp [weightedMapCompletionEquiv]
+
 end Functoriality
 
 /-! ### Zero variables -/


### PR DESCRIPTION
Package `weightedMapCompletion` as a `RingEquiv`, so the transport along a bicontinuous ring
isomorphism is an API item rather than an assembly repeated at the use site.

## What moved

`restrictedMvPowerSeriesCompletionCongr` built its isomorphism by hand: `RingEquiv.ofRingHom` over
two `weightedMapCompletion` maps, with **both inverse laws re-derived inline** from
`weightedMapCompletion_comp` plus a `simp`. None of that is specific to the constant weight family
it was used at, so it now sits beside its siblings in `WeightedRestrictedSeries/Completion.lean`:

```
Huber.weightedMapCompletionEquiv (e : A ≃+* B) (he : Continuous e) (he' : Continuous e.symm)
    (hT : IsWeightFamily T) (hS : IsWeightFamily S)
    (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i) :
    UniformSpace.Completion (weightedRestrictedSubring T hT) ≃+*
      UniformSpace.Completion (weightedRestrictedSubring S hS)
```

completing that file's functoriality section, which had the map, the identity law and the
composition law but not the equiv the two laws exist to justify. The consumer is now two lines:

```lean
weightedMapCompletionEquiv e he he' isWeightFamily_one_weight isWeightFamily_one_weight
  (fun _ ↦ by simp) (fun _ ↦ by simp)
```

Both continuity hypotheses stay load-bearing — `weightedMapCompletion` goes through
`UniformSpace.Completion.mapRingHom`, which induces nothing from a discontinuous map — and that
explanation moves from a comment at the use site into the new definition's docstring.

## This is an API move, not a line saving

Worth stating plainly, because the tracking issue predicted otherwise. The deletion in
`StronglyNoetherian.lean` is 17 lines; the equiv with its docstring is 25 in `Completion.lean`, so
the **net is +8**. The issue's "~20 lines off main" was inherited from a reviewer's estimate on the
closed #4018 and does not hold for this implementation. What the change buys is that the inverse
laws are proved once, in the file that owns them, instead of at each transport site.

## Application API

Both directions carry `@[simp]` lemmas identifying the equivalence with the corresponding
`weightedMapCompletion` map — `weightedMapCompletionEquiv_apply` and
`weightedMapCompletionEquiv_symm_apply` — so the advertised coefficientwise action is available
without unfolding `RingEquiv.ofRingHom`. This matches `weightedMapCompletion_coe`'s style in the
same file.

Both are proved by `:= (rfl)`. Bare `rfl` fails here, but not because the two sides differ: they
are definitionally equal. It fails because the definition's body is sealed at the module boundary,
so a term-mode `rfl` would require exposing it; the parenthesised form elaborates against the
sealed body instead.

## Notes for review

- `restrictedMvPowerSeriesCompletionCongr` and `isStronglyNoetherian_congr` are unchanged in
  statement; only the construction is rerouted.
- Gate: `lake build` of `WeightedRestrictedSeries.Completion`, `StronglyNoetherian` and the other
  three importers (`TopologicallyFiniteType`, `WeightedRestrictedSeries.Complete`,
  `WeightedRestrictedSeries.PairOfDefinition`) — **2311 jobs, exit 0, zero warnings** (re-run after adding the application lemmas).

Roadmap: AdicSpaces
