### PR TITLE
feat: finiteness of MvPolynomial.expand and MvPolynomial.map

### DIFF
--- a/TauCeti/Algebra/MvPolynomial/Expand.lean
+++ b/TauCeti/Algebra/MvPolynomial/Expand.lean
@@ -37,19 +37,26 @@ in `S[X_i]`.
 
 Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
 (`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
-`RingTheory/IntegralClosure/NormalizationFinite`. The mathematics is the finiteness sentence of
-Stacks 10.161.13 (tag 032O), stated for `n` variables at once.
+`RingTheory/IntegralClosure/NormalizationFinite`.
+
+The argument is the finiteness sentence of Stacks 10.161.13 (tag 032O). **That lemma is
+univariate**: it is stated for the rings `R[x]` and `R'[x^{1/q}]` in a single variable. What is
+formalized here is its multivariate form, over a finite variable type `σ`, which is what the
+`n`-variable Noether normalization downstream needs. The mathematical content of each step is
+Stacks'; the passage to several variables at once is not, and is not claimed as such below.
 -/
 
 public section
 
 namespace TauCeti
 
-/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "`R′[x^{1/q}]` is finite over `R[x]`" —
+/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
+Proof: "`R′[x^{1/q}]` is finite over `R[x]`" —
 the inductive step of the spanning argument. Every monomial lies in the span, over the image of
 `MvPolynomial.expand n`, of the monomials with all exponents below `n`: write each exponent as
 `n * γ + β` with `β < n`, so that `X ^ (n • γ + β) = expand n (X ^ γ) * X ^ β`. -/
-theorem MvPolynomial.monomial_mem_span_monomial_lt {σ R : Type*} [CommSemiring R] [Finite σ]
+private theorem MvPolynomial.monomial_mem_span_monomial_lt {σ R : Type*} [CommSemiring R]
+    [Finite σ]
     {n : ℕ} (hn : 0 < n) (d : σ →₀ ℕ) (r : R) :
     MvPolynomial.monomial d r ∈
       Submodule.span (MvPolynomial.expand (σ := σ) (R := R) n).range
@@ -86,7 +93,8 @@ theorem MvPolynomial.monomial_mem_span_monomial_lt {σ R : Type*} [CommSemiring 
   rw [key, ← ha]
   exact Submodule.smul_mem _ a hmem
 
-/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "`R′[x^{1/q}]` is finite over `R[x]`".
+/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
+Proof: "`R′[x^{1/q}]` is finite over `R[x]`".
 Over the image of `MvPolynomial.expand n`, the finitely many monomials with all exponents below
 `n` span the whole polynomial ring. -/
 theorem MvPolynomial.span_monomial_lt_eq_top {σ R : Type*} [CommSemiring R] [Finite σ] {n : ℕ}
@@ -99,7 +107,8 @@ theorem MvPolynomial.span_monomial_lt_eq_top {σ R : Type*} [CommSemiring R] [Fi
   exact MvPolynomial.induction_on' f (fun d r => MvPolynomial.monomial_mem_span_monomial_lt hn d r)
     (fun p q hp hq => Submodule.add_mem _ hp hq)
 
-/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "`R′[x^{1/q}]` is finite over `R[x]`".
+/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
+Proof: "`R′[x^{1/q}]` is finite over `R[x]`".
 `MvPolynomial.expand n` is a finite ring map for `0 < n`: the polynomial ring is spanned over
 `R[X_i ^ n]` by the monomials with exponents below `n`. -/
 theorem MvPolynomial.finite_expand {σ R : Type*} [CommRing R] [Finite σ] {n : ℕ} (hn : 0 < n) :
@@ -123,7 +132,8 @@ theorem MvPolynomial.finite_expand {σ R : Type*} [CommRing R] [Finite σ] {n : 
   rw [hfac]
   exact RingHom.Finite.comp h₂ h₁
 
-/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "Since `R` is N-2 we see that `R′` is
+/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
+Proof: "Since `R` is N-2 we see that `R′` is
 finite over `R` and hence `R′[x^{1/q}]` is finite over `R[x]`". Polynomial rings preserve
 module-finiteness of the coefficient map: `MvPolynomial.map f` is finite whenever `f` is. -/
 theorem MvPolynomial.finite_map {σ R S : Type*} [CommRing R] [CommRing S] {f : R →+* S}
@@ -163,13 +173,14 @@ theorem MvPolynomial.finite_map {σ R S : Type*} [CommRing R] [CommRing S] {f : 
     rw [hr]
     exact Submodule.smul_mem _ _ hx
 
-/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "There exists a finite purely inseparable
+/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
+Proof: "There exists a finite purely inseparable
 field extension `L′/K` and `q = p^e` such that `L ⊂ L′(x^{1/q})`; some details omitted" — the
 coefficient half of the omitted details. If every coefficient of `g` has a `p ^ n`-th root in
 `S`, then `g(X ^ (p ^ n))`, read in `S[X_i]`, is a `p ^ n`-th power: with
 `h = ∑ d_α X ^ α` for `d_α ^ (p ^ n) = f (coeff α g)`, Frobenius gives
 `h ^ (p ^ n) = ∑ f (coeff α g) X ^ (p ^ n • α)`. -/
-theorem MvPolynomial.exists_pow_eq_map_expand {σ R S : Type*} [CommRing R] [CommRing S]
+theorem MvPolynomial.exists_pow_eq_map_expand {σ R S : Type*} [CommSemiring R] [CommSemiring S]
     (f : R →+* S) (p : ℕ) [ExpChar S p] (n : ℕ) {g : MvPolynomial σ R}
     (hg : ∀ i ∈ g.support, ∃ d : S, d ^ p ^ n = f (g.coeff i)) :
     ∃ h : MvPolynomial σ S, h ^ p ^ n = MvPolynomial.map f (MvPolynomial.expand (p ^ n) g) := by

--- a/TauCeti/Algebra/MvPolynomial/Expand.lean
+++ b/TauCeti/Algebra/MvPolynomial/Expand.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.CharP.Lemmas
+public import Mathlib.Algebra.MvPolynomial.Expand
+public import Mathlib.RingTheory.Finiteness.Basic
+public import Mathlib.RingTheory.MvPolynomial.Basic
+
+/-!
+# Finiteness of `MvPolynomial.expand` and of `MvPolynomial.map`
+
+The polynomial ring `R[X_i]` is a finite module over its image under `MvPolynomial.expand n`
+(the subring `R[X_i ^ n]`), spanned by the monomials whose exponents are all below `n`; and
+`MvPolynomial.map f` is a finite ring map whenever `f` is. Composed, they say that
+`k'[X_1, …, X_r]` is a finite module over `k[X_1 ^ q, …, X_r ^ q]` for a finite extension
+`k' / k` — the finiteness that Stacks 10.161.13 (tag 032O) records as "`R'[x^{1/q}]` is finite
+over `R[x]`" and that the purely inseparable half of normalization-finiteness rests on.
+
+Also here is the coefficient-level Frobenius computation behind Stacks' "some details omitted":
+if every coefficient of `g` acquires a `q`-th root in `S`, then `g(X ^ q)` becomes a `q`-th power
+in `S[X_i]`.
+
+## Main results
+
+* `TauCeti.MvPolynomial.span_monomial_lt_eq_top`: over the image of `expand n`, the monomials
+  with all exponents below `n` span the polynomial ring.
+* `TauCeti.MvPolynomial.finite_expand`: `expand n` is a finite ring map for `0 < n`.
+* `TauCeti.MvPolynomial.finite_map`: `MvPolynomial.map f` is finite when `f` is.
+* `TauCeti.MvPolynomial.exists_pow_eq_map_expand`: `(map f) (expand (p ^ n) g)` is a
+  `p ^ n`-th power once the coefficients of `g` have `p ^ n`-th roots in `S`.
+
+## Provenance
+
+Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
+(`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
+`RingTheory/IntegralClosure/NormalizationFinite`. The mathematics is the finiteness sentence of
+Stacks 10.161.13 (tag 032O), stated for `n` variables at once.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "`R′[x^{1/q}]` is finite over `R[x]`" —
+the inductive step of the spanning argument. Every monomial lies in the span, over the image of
+`MvPolynomial.expand n`, of the monomials with all exponents below `n`: write each exponent as
+`n * γ + β` with `β < n`, so that `X ^ (n • γ + β) = expand n (X ^ γ) * X ^ β`. -/
+theorem MvPolynomial.monomial_mem_span_monomial_lt {σ R : Type*} [CommSemiring R] [Finite σ]
+    {n : ℕ} (hn : 0 < n) (d : σ →₀ ℕ) (r : R) :
+    MvPolynomial.monomial d r ∈
+      Submodule.span (MvPolynomial.expand (σ := σ) (R := R) n).range
+        (Set.range fun β : σ → Fin n =>
+          MvPolynomial.monomial (Finsupp.equivFunOnFinite.symm fun i => (β i : ℕ)) (1 : R)) := by
+  classical
+  -- the exponent `d i` splits as `n * (d i / n) + d i % n`
+  have hexp :
+      n • (Finsupp.equivFunOnFinite.symm fun i => d i / n)
+        + (Finsupp.equivFunOnFinite.symm fun i =>
+            ((⟨d i % n, Nat.mod_lt _ hn⟩ : Fin n) : ℕ)) = d := by
+    ext i
+    simp [Nat.div_add_mod]
+  -- the sub-`n` part is one of the generators
+  have hmem :
+      MvPolynomial.monomial (Finsupp.equivFunOnFinite.symm fun i =>
+          ((⟨d i % n, Nat.mod_lt _ hn⟩ : Fin n) : ℕ)) (1 : R) ∈
+        Submodule.span (MvPolynomial.expand (σ := σ) (R := R) n).range
+          (Set.range fun β : σ → Fin n =>
+            MvPolynomial.monomial (Finsupp.equivFunOnFinite.symm fun i => (β i : ℕ)) (1 : R)) :=
+    Submodule.subset_span ⟨fun i => ⟨d i % n, Nat.mod_lt _ hn⟩, rfl⟩
+  -- name the scalar, so that the `•`/`*` defeq check stays cheap
+  obtain ⟨a, ha⟩ : ∃ a : (MvPolynomial.expand (σ := σ) (R := R) n).range,
+      (a : MvPolynomial σ R)
+        = (MvPolynomial.expand (σ := σ) (R := R) n)
+            (MvPolynomial.monomial (Finsupp.equivFunOnFinite.symm fun i => d i / n) r) :=
+    ⟨⟨_, AlgHom.mem_range_self _ _⟩, rfl⟩
+  have key : (MvPolynomial.monomial d r : MvPolynomial σ R)
+      = (MvPolynomial.expand (σ := σ) (R := R) n)
+            (MvPolynomial.monomial (Finsupp.equivFunOnFinite.symm fun i => d i / n) r) *
+          MvPolynomial.monomial (Finsupp.equivFunOnFinite.symm fun i =>
+            ((⟨d i % n, Nat.mod_lt _ hn⟩ : Fin n) : ℕ)) (1 : R) := by
+    rw [MvPolynomial.expand_monomial, MvPolynomial.monomial_mul_monomial, mul_one, hexp]
+  rw [key, ← ha]
+  exact Submodule.smul_mem _ a hmem
+
+/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "`R′[x^{1/q}]` is finite over `R[x]`".
+Over the image of `MvPolynomial.expand n`, the finitely many monomials with all exponents below
+`n` span the whole polynomial ring. -/
+theorem MvPolynomial.span_monomial_lt_eq_top {σ R : Type*} [CommSemiring R] [Finite σ] {n : ℕ}
+    (hn : 0 < n) :
+    Submodule.span (MvPolynomial.expand (σ := σ) (R := R) n).range
+      (Set.range fun β : σ → Fin n =>
+        MvPolynomial.monomial (Finsupp.equivFunOnFinite.symm fun i => (β i : ℕ)) (1 : R)) = ⊤ := by
+  rw [eq_top_iff]
+  rintro f -
+  exact MvPolynomial.induction_on' f (fun d r => MvPolynomial.monomial_mem_span_monomial_lt hn d r)
+    (fun p q hp hq => Submodule.add_mem _ hp hq)
+
+/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "`R′[x^{1/q}]` is finite over `R[x]`".
+`MvPolynomial.expand n` is a finite ring map for `0 < n`: the polynomial ring is spanned over
+`R[X_i ^ n]` by the monomials with exponents below `n`. -/
+theorem MvPolynomial.finite_expand {σ R : Type*} [CommRing R] [Finite σ] {n : ℕ} (hn : 0 < n) :
+    (MvPolynomial.expand (σ := σ) (R := R) n).toRingHom.Finite := by
+  classical
+  -- `MvPolynomial σ R` is a finite module over the subalgebra `R[X_i ^ n]`
+  have hfin : Module.Finite (MvPolynomial.expand (σ := σ) (R := R) n).range
+      (MvPolynomial σ R) :=
+    Module.Finite.of_fg_top (Submodule.fg_def.2 ⟨_, Set.finite_range _,
+      MvPolynomial.span_monomial_lt_eq_top hn⟩)
+  -- Factor `expand n` as `R[X_i] ↠ R[X_i ^ n] ↪ R[X_i]`. Going through the range keeps the
+  -- `Module (MvPolynomial σ R) (MvPolynomial σ R)` diamond out of the way: instance search
+  -- picks `Semiring.toModule` (plain multiplication), not the `expand`-algebra the statement
+  -- means, and the two are not defeq.
+  have h₁ : ((MvPolynomial.expand (σ := σ) (R := R) n).rangeRestrict.toRingHom).Finite :=
+    RingHom.Finite.of_surjective _ (AlgHom.rangeRestrict_surjective _)
+  have h₂ : ((MvPolynomial.expand (σ := σ) (R := R) n).range.val.toRingHom).Finite := hfin
+  have hfac : (MvPolynomial.expand (σ := σ) (R := R) n).toRingHom
+      = ((MvPolynomial.expand (σ := σ) (R := R) n).range.val.toRingHom).comp
+        ((MvPolynomial.expand (σ := σ) (R := R) n).rangeRestrict.toRingHom) := rfl
+  rw [hfac]
+  exact RingHom.Finite.comp h₂ h₁
+
+/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "Since `R` is N-2 we see that `R′` is
+finite over `R` and hence `R′[x^{1/q}]` is finite over `R[x]`". Polynomial rings preserve
+module-finiteness of the coefficient map: `MvPolynomial.map f` is finite whenever `f` is. -/
+theorem MvPolynomial.finite_map {σ R S : Type*} [CommRing R] [CommRing S] {f : R →+* S}
+    (hf : f.Finite) : (MvPolynomial.map (σ := σ) f).Finite := by
+  classical
+  let _ : Algebra R S := f.toAlgebra
+  obtain ⟨t, htfin, ht⟩ := Submodule.fg_def.mp (Module.finite_def.mp hf)
+  let _ : Algebra (MvPolynomial σ R) (MvPolynomial σ S) := (MvPolynomial.map (σ := σ) f).toAlgebra
+  refine Module.finite_def.mpr (Submodule.fg_def.mpr
+    ⟨MvPolynomial.C '' t, htfin.image _, eq_top_iff.mpr fun p _ ↦ ?_⟩)
+  refine MvPolynomial.induction_on' p (fun α c ↦ ?_) (fun p q hp hq ↦ Submodule.add_mem _ hp hq)
+  refine Submodule.span_induction
+    (p := fun c _ ↦ MvPolynomial.monomial α c ∈
+      Submodule.span (MvPolynomial σ R) (MvPolynomial.C '' t))
+    ?_ ?_ ?_ ?_ (ht ▸ Submodule.mem_top : c ∈ Submodule.span R t)
+  · -- a generator `x ∈ t`, as the constant `C x`, scaled by the monomial `X ^ α`
+    intro x hx
+    have hx' : MvPolynomial.monomial α x
+        = (MvPolynomial.monomial α (1 : R)) • (MvPolynomial.C x : MvPolynomial σ S) := by
+      rw [Algebra.smul_def]
+      change _ = MvPolynomial.map f (MvPolynomial.monomial α 1) * MvPolynomial.C x
+      rw [MvPolynomial.map_monomial, map_one, mul_comm, MvPolynomial.C_mul_monomial, mul_one]
+    rw [hx']
+    exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨x, hx, rfl⟩)
+  · simp
+  · intro x y _ _ hx hy
+    rw [map_add]
+    exact Submodule.add_mem _ hx hy
+  · -- an `R`-scalar becomes the constant `C r` acting through `MvPolynomial.map f`
+    intro r x _ hx
+    have hr : MvPolynomial.monomial α (r • x)
+        = (MvPolynomial.C r : MvPolynomial σ R) • MvPolynomial.monomial α x := by
+      rw [Algebra.smul_def]
+      change _ = MvPolynomial.map f (MvPolynomial.C r) * MvPolynomial.monomial α x
+      rw [MvPolynomial.map_C, MvPolynomial.C_mul_monomial]
+      rfl
+    rw [hr]
+    exact Submodule.smul_mem _ _ hx
+
+/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "There exists a finite purely inseparable
+field extension `L′/K` and `q = p^e` such that `L ⊂ L′(x^{1/q})`; some details omitted" — the
+coefficient half of the omitted details. If every coefficient of `g` has a `p ^ n`-th root in
+`S`, then `g(X ^ (p ^ n))`, read in `S[X_i]`, is a `p ^ n`-th power: with
+`h = ∑ d_α X ^ α` for `d_α ^ (p ^ n) = f (coeff α g)`, Frobenius gives
+`h ^ (p ^ n) = ∑ f (coeff α g) X ^ (p ^ n • α)`. -/
+theorem MvPolynomial.exists_pow_eq_map_expand {σ R S : Type*} [CommRing R] [CommRing S]
+    (f : R →+* S) (p : ℕ) [ExpChar S p] (n : ℕ) {g : MvPolynomial σ R}
+    (hg : ∀ i ∈ g.support, ∃ d : S, d ^ p ^ n = f (g.coeff i)) :
+    ∃ h : MvPolynomial σ S, h ^ p ^ n = MvPolynomial.map f (MvPolynomial.expand (p ^ n) g) := by
+  classical
+  -- total-ise the choice of roots, so the witness is a plain sum over `g.support`
+  have hg' : ∀ i : σ →₀ ℕ, ∃ d : S, i ∈ g.support → d ^ p ^ n = f (g.coeff i) := by
+    intro i
+    by_cases hi : i ∈ g.support
+    · obtain ⟨d, hd⟩ := hg i hi
+      exact ⟨d, fun _ ↦ hd⟩
+    · exact ⟨0, fun h ↦ absurd h hi⟩
+  choose d hd using hg'
+  refine ⟨∑ α ∈ g.support, MvPolynomial.monomial α (d α), ?_⟩
+  -- Frobenius is additive, so the `p ^ n`-th power is taken monomial by monomial
+  rw [sum_pow_char_pow]
+  conv_rhs => rw [MvPolynomial.as_sum g]
+  rw [map_sum, map_sum]
+  refine Finset.sum_congr rfl fun α hα ↦ ?_
+  rw [MvPolynomial.monomial_pow, hd α hα, MvPolynomial.expand_monomial,
+    MvPolynomial.map_monomial]
+
+end TauCeti

--- a/TauCeti/RingTheory/MvPolynomial/Basic.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Basic.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Finiteness.Basic
+public import Mathlib.RingTheory.MvPolynomial.Basic
+
+/-!
+# Finiteness of `MvPolynomial.map`
+
+`MvPolynomial.map f` is a finite ring map whenever `f` is: a family generating `S` over `R`
+generates `MvPolynomial σ S` over `MvPolynomial σ R` once its members are read as constants.
+
+This is the coefficient-extension half of the finiteness that Stacks 10.161.13 (tag 032O)
+records as "`R'[x^{1/q}]` is finite over `R[x]`"; the `expand` half lives in
+`TauCeti/RingTheory/MvPolynomial/Expand.lean`. Nothing here mentions `expand`, which is why it
+sits in this file rather than that one.
+
+## Main results
+
+* `TauCeti.MvPolynomial.finite_map`: `MvPolynomial.map f` is finite when `f` is.
+
+## Provenance
+
+Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
+(`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
+`RingTheory/IntegralClosure/NormalizationFinite`. The argument is Stacks 10.161.13 (tag 032O),
+which is univariate; the multivariate form is not claimed as source material.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
+Proof: "Since `R` is N-2 we see that `R′` is
+finite over `R` and hence `R′[x^{1/q}]` is finite over `R[x]`". Polynomial rings preserve
+module-finiteness of the coefficient map: `MvPolynomial.map f` is finite whenever `f` is. -/
+theorem MvPolynomial.finite_map {σ R S : Type*} [CommRing R] [CommRing S] {f : R →+* S}
+    (hf : f.Finite) : (MvPolynomial.map (σ := σ) f).Finite := by
+  classical
+  let _ : Algebra R S := f.toAlgebra
+  obtain ⟨t, htfin, ht⟩ := Submodule.fg_def.mp (Module.finite_def.mp hf)
+  let _ : Algebra (MvPolynomial σ R) (MvPolynomial σ S) := (MvPolynomial.map (σ := σ) f).toAlgebra
+  refine Module.finite_def.mpr (Submodule.fg_def.mpr
+    ⟨MvPolynomial.C '' t, htfin.image _, eq_top_iff.mpr fun p _ ↦ ?_⟩)
+  refine MvPolynomial.induction_on' p (fun α c ↦ ?_) (fun p q hp hq ↦ Submodule.add_mem _ hp hq)
+  refine Submodule.span_induction
+    (p := fun c _ ↦ MvPolynomial.monomial α c ∈
+      Submodule.span (MvPolynomial σ R) (MvPolynomial.C '' t))
+    ?_ ?_ ?_ ?_ (ht ▸ Submodule.mem_top : c ∈ Submodule.span R t)
+  · -- a generator `x ∈ t`, as the constant `C x`, scaled by the monomial `X ^ α`
+    intro x hx
+    have hx' : MvPolynomial.monomial α x
+        = (MvPolynomial.monomial α (1 : R)) • (MvPolynomial.C x : MvPolynomial σ S) := by
+      rw [Algebra.smul_def, RingHom.algebraMap_toAlgebra]
+      rw [MvPolynomial.map_monomial, map_one, mul_comm, MvPolynomial.C_mul_monomial, mul_one]
+    rw [hx']
+    exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨x, hx, rfl⟩)
+  · simp
+  · intro x y _ _ hx hy
+    rw [map_add]
+    exact Submodule.add_mem _ hx hy
+  · -- an `R`-scalar becomes the constant `C r` acting through `MvPolynomial.map f`
+    intro r x _ hx
+    have hr : MvPolynomial.monomial α (r • x)
+        = (MvPolynomial.C r : MvPolynomial σ R) • MvPolynomial.monomial α x := by
+      rw [Algebra.smul_def, RingHom.algebraMap_toAlgebra, Algebra.smul_def,
+        RingHom.algebraMap_toAlgebra, MvPolynomial.map_C, MvPolynomial.C_mul_monomial]
+    rw [hr]
+    exact Submodule.smul_mem _ _ hx
+
+end TauCeti

--- a/TauCeti/RingTheory/MvPolynomial/Basic.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Basic.lean
@@ -28,17 +28,17 @@ sits in this file rather than that one.
 Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
 (`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
 `RingTheory/IntegralClosure/NormalizationFinite`. The argument is Stacks 10.161.13 (tag 032O),
-which is univariate; the multivariate form is not claimed as source material.
+which is univariate and whose proof records it as "Since `R` is N-2 we see that `R′` is finite
+over `R` and hence `R′[x^{1/q}]` is finite over `R[x]`"; the multivariate form is not claimed as
+source material.
 -/
 
 public section
 
 namespace TauCeti
 
-/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
-Proof: "Since `R` is N-2 we see that `R′` is
-finite over `R` and hence `R′[x^{1/q}]` is finite over `R[x]`". Polynomial rings preserve
-module-finiteness of the coefficient map: `MvPolynomial.map f` is finite whenever `f` is. -/
+/-- Polynomial rings preserve module-finiteness of the coefficient map: `MvPolynomial.map f` is
+a finite ring map whenever `f` is. -/
 theorem MvPolynomial.finite_map {σ R S : Type*} [CommRing R] [CommRing S] {f : R →+* S}
     (hf : f.Finite) : (MvPolynomial.map (σ := σ) f).Finite := by
   classical

--- a/TauCeti/RingTheory/MvPolynomial/Expand.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Expand.lean
@@ -131,9 +131,13 @@ theorem MvPolynomial.finite_expand {σ R : Type*} [CommRing R] [Finite σ] {n : 
   have h₁ : ((MvPolynomial.expand (σ := σ) (R := R) n).rangeRestrict.toRingHom).Finite :=
     RingHom.Finite.of_surjective _ (AlgHom.rangeRestrict_surjective _)
   have h₂ : ((MvPolynomial.expand (σ := σ) (R := R) n).range.val.toRingHom).Finite := hfin
+  -- from Mathlib's `(Subalgebra.val _).comp φ.rangeRestrict = φ`, rather than by `rfl`, so the
+  -- factorisation does not depend on how bundled-hom composition happens to be implemented
   have hfac : (MvPolynomial.expand (σ := σ) (R := R) n).toRingHom
       = ((MvPolynomial.expand (σ := σ) (R := R) n).range.val.toRingHom).comp
-        ((MvPolynomial.expand (σ := σ) (R := R) n).rangeRestrict.toRingHom) := rfl
+        ((MvPolynomial.expand (σ := σ) (R := R) n).rangeRestrict.toRingHom) :=
+    congrArg AlgHom.toRingHom
+      (MvPolynomial.expand (σ := σ) (R := R) n).val_comp_rangeRestrict.symm
   rw [hfac]
   exact RingHom.Finite.comp h₂ h₁
 

--- a/TauCeti/RingTheory/MvPolynomial/Expand.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Expand.lean
@@ -14,10 +14,12 @@ public import Mathlib.RingTheory.MvPolynomial.Basic
 # Finiteness of `MvPolynomial.expand`
 
 The polynomial ring `R[X_i]` is a finite module over its image under `MvPolynomial.expand n`
-(the subring `R[X_i ^ n]`), spanned by the monomials whose exponents are all below `n`; and
-`MvPolynomial.map f` is a finite ring map whenever `f` is. Composed, they say that
+(the subring `R[X_i ^ n]`), spanned by the monomials whose exponents are all below `n`.
+
+Composed with the finiteness of `MvPolynomial.map f` — a separate result, proved in
+`TauCeti/RingTheory/MvPolynomial/Basic.lean` and not imported here — this gives that
 `k'[X_1, …, X_r]` is a finite module over `k[X_1 ^ q, …, X_r ^ q]` for a finite extension
-`k' / k` — the finiteness that Stacks 10.161.13 (tag 032O) records as "`R'[x^{1/q}]` is finite
+`k' / k`, the finiteness that Stacks 10.161.13 (tag 032O) records as "`R'[x^{1/q}]` is finite
 over `R[x]`" and that the purely inseparable half of normalization-finiteness rests on.
 
 Also here is the coefficient-level Frobenius computation behind Stacks' "some details omitted":
@@ -37,6 +39,14 @@ in `S[X_i]`.
 Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
 (`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
 `RingTheory/IntegralClosure/NormalizationFinite`.
+
+All three results are the multivariate form of the univariate argument in Stacks, Lemma 10.161.13
+(tag 032O), whose proof records only "`R′[x^{1/q}]` is finite over `R[x]`" for the first two. The
+third is the coefficient half of the details that lemma omits: "There exists a finite purely
+inseparable field extension `L′/K` and `q = p^e` such that `L ⊂ L′(x^{1/q})`; some details
+omitted". Concretely, with `h = ∑ d_α X ^ α` for `d_α ^ (p ^ n) = f (coeff α g)`, Frobenius gives
+`h ^ (p ^ n) = ∑ f (coeff α g) X ^ (p ^ n • α)`. The multivariate forms are not claimed as source
+material.
 
 The argument is the finiteness sentence of Stacks 10.161.13 (tag 032O). **That lemma is
 univariate**: it is stated for the rings `R[x]` and `R'[x^{1/q}]` in a single variable. What is
@@ -92,10 +102,8 @@ private theorem MvPolynomial.monomial_mem_span_monomial_lt {σ R : Type*} [CommS
   rw [key, ← ha]
   exact Submodule.smul_mem _ a hmem
 
-/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
-Proof: "`R′[x^{1/q}]` is finite over `R[x]`".
-Over the image of `MvPolynomial.expand n`, the finitely many monomials with all exponents below
-`n` span the whole polynomial ring. -/
+/-- Over the image of `MvPolynomial.expand n`, the finitely many monomials with all exponents
+below `n` span the whole polynomial ring. -/
 theorem MvPolynomial.span_monomial_lt_eq_top {σ R : Type*} [CommSemiring R] [Finite σ] {n : ℕ}
     (hn : 0 < n) :
     Submodule.span (MvPolynomial.expand (σ := σ) (R := R) n).range
@@ -106,9 +114,7 @@ theorem MvPolynomial.span_monomial_lt_eq_top {σ R : Type*} [CommSemiring R] [Fi
   exact MvPolynomial.induction_on' f (fun d r => MvPolynomial.monomial_mem_span_monomial_lt hn d r)
     (fun p q hp hq => Submodule.add_mem _ hp hq)
 
-/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
-Proof: "`R′[x^{1/q}]` is finite over `R[x]`".
-`MvPolynomial.expand n` is a finite ring map for `0 < n`: the polynomial ring is spanned over
+/-- `MvPolynomial.expand n` is a finite ring map for `0 < n`: the polynomial ring is spanned over
 `R[X_i ^ n]` by the monomials with exponents below `n`. -/
 theorem MvPolynomial.finite_expand {σ R : Type*} [CommRing R] [Finite σ] {n : ℕ} (hn : 0 < n) :
     (MvPolynomial.expand (σ := σ) (R := R) n).toRingHom.Finite := by
@@ -131,13 +137,8 @@ theorem MvPolynomial.finite_expand {σ R : Type*} [CommRing R] [Finite σ] {n : 
   rw [hfac]
   exact RingHom.Finite.comp h₂ h₁
 
-/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
-Proof: "There exists a finite purely inseparable
-field extension `L′/K` and `q = p^e` such that `L ⊂ L′(x^{1/q})`; some details omitted" — the
-coefficient half of the omitted details. If every coefficient of `g` has a `p ^ n`-th root in
-`S`, then `g(X ^ (p ^ n))`, read in `S[X_i]`, is a `p ^ n`-th power: with
-`h = ∑ d_α X ^ α` for `d_α ^ (p ^ n) = f (coeff α g)`, Frobenius gives
-`h ^ (p ^ n) = ∑ f (coeff α g) X ^ (p ^ n • α)`. -/
+/-- If every coefficient of `g` has a `p ^ n`-th root in `S`, then `g(X ^ (p ^ n))`, read in
+`S[X_i]`, is a `p ^ n`-th power. -/
 theorem MvPolynomial.exists_pow_eq_map_expand {σ R S : Type*} [CommSemiring R] [CommSemiring S]
     (f : R →+* S) (p : ℕ) [ExpChar S p] (n : ℕ) {g : MvPolynomial σ R}
     (hg : ∀ i ∈ g.support, ∃ d : S, d ^ p ^ n = f (g.coeff i)) :

--- a/TauCeti/RingTheory/MvPolynomial/Expand.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Expand.lean
@@ -11,7 +11,7 @@ public import Mathlib.RingTheory.Finiteness.Basic
 public import Mathlib.RingTheory.MvPolynomial.Basic
 
 /-!
-# Finiteness of `MvPolynomial.expand` and of `MvPolynomial.map`
+# Finiteness of `MvPolynomial.expand`
 
 The polynomial ring `R[X_i]` is a finite module over its image under `MvPolynomial.expand n`
 (the subring `R[X_i ^ n]`), spanned by the monomials whose exponents are all below `n`; and
@@ -29,7 +29,6 @@ in `S[X_i]`.
 * `TauCeti.MvPolynomial.span_monomial_lt_eq_top`: over the image of `expand n`, the monomials
   with all exponents below `n` span the polynomial ring.
 * `TauCeti.MvPolynomial.finite_expand`: `expand n` is a finite ring map for `0 < n`.
-* `TauCeti.MvPolynomial.finite_map`: `MvPolynomial.map f` is finite when `f` is.
 * `TauCeti.MvPolynomial.exists_pow_eq_map_expand`: `(map f) (expand (p ^ n) g)` is a
   `p ^ n`-th power once the coefficients of `g` have `p ^ n`-th roots in `S`.
 
@@ -131,47 +130,6 @@ theorem MvPolynomial.finite_expand {σ R : Type*} [CommRing R] [Finite σ] {n : 
         ((MvPolynomial.expand (σ := σ) (R := R) n).rangeRestrict.toRingHom) := rfl
   rw [hfac]
   exact RingHom.Finite.comp h₂ h₁
-
-/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
-Proof: "Since `R` is N-2 we see that `R′` is
-finite over `R` and hence `R′[x^{1/q}]` is finite over `R[x]`". Polynomial rings preserve
-module-finiteness of the coefficient map: `MvPolynomial.map f` is finite whenever `f` is. -/
-theorem MvPolynomial.finite_map {σ R S : Type*} [CommRing R] [CommRing S] {f : R →+* S}
-    (hf : f.Finite) : (MvPolynomial.map (σ := σ) f).Finite := by
-  classical
-  let _ : Algebra R S := f.toAlgebra
-  obtain ⟨t, htfin, ht⟩ := Submodule.fg_def.mp (Module.finite_def.mp hf)
-  let _ : Algebra (MvPolynomial σ R) (MvPolynomial σ S) := (MvPolynomial.map (σ := σ) f).toAlgebra
-  refine Module.finite_def.mpr (Submodule.fg_def.mpr
-    ⟨MvPolynomial.C '' t, htfin.image _, eq_top_iff.mpr fun p _ ↦ ?_⟩)
-  refine MvPolynomial.induction_on' p (fun α c ↦ ?_) (fun p q hp hq ↦ Submodule.add_mem _ hp hq)
-  refine Submodule.span_induction
-    (p := fun c _ ↦ MvPolynomial.monomial α c ∈
-      Submodule.span (MvPolynomial σ R) (MvPolynomial.C '' t))
-    ?_ ?_ ?_ ?_ (ht ▸ Submodule.mem_top : c ∈ Submodule.span R t)
-  · -- a generator `x ∈ t`, as the constant `C x`, scaled by the monomial `X ^ α`
-    intro x hx
-    have hx' : MvPolynomial.monomial α x
-        = (MvPolynomial.monomial α (1 : R)) • (MvPolynomial.C x : MvPolynomial σ S) := by
-      rw [Algebra.smul_def]
-      change _ = MvPolynomial.map f (MvPolynomial.monomial α 1) * MvPolynomial.C x
-      rw [MvPolynomial.map_monomial, map_one, mul_comm, MvPolynomial.C_mul_monomial, mul_one]
-    rw [hx']
-    exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨x, hx, rfl⟩)
-  · simp
-  · intro x y _ _ hx hy
-    rw [map_add]
-    exact Submodule.add_mem _ hx hy
-  · -- an `R`-scalar becomes the constant `C r` acting through `MvPolynomial.map f`
-    intro r x _ hx
-    have hr : MvPolynomial.monomial α (r • x)
-        = (MvPolynomial.C r : MvPolynomial σ R) • MvPolynomial.monomial α x := by
-      rw [Algebra.smul_def]
-      change _ = MvPolynomial.map f (MvPolynomial.C r) * MvPolynomial.monomial α x
-      rw [MvPolynomial.map_C, MvPolynomial.C_mul_monomial]
-      rfl
-    rw [hr]
-    exact Submodule.smul_mem _ _ hx
 
 /-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
 Proof: "There exists a finite purely inseparable


### PR DESCRIPTION
Adds `TauCeti/RingTheory/MvPolynomial/Expand.lean` and `TauCeti/RingTheory/MvPolynomial/Basic.lean`.

(Both paths changed during review: the file moved out of `TauCeti/Algebra/` on the placement
rubric, and `finite_map` — which never mentions `expand` — was split into `Basic.lean`.)

* `MvPolynomial.monomial_mem_span_monomial_lt` / `span_monomial_lt_eq_top` — over the image of
  `MvPolynomial.expand n`, the monomials with all exponents below `n` span the polynomial ring.
* `MvPolynomial.finite_expand` — `expand n` is a finite ring map for `0 < n`.
* `MvPolynomial.finite_map` — `MvPolynomial.map f` is finite whenever `f` is.
* `MvPolynomial.exists_pow_eq_map_expand` — `g(X ^ q)` is a `q`-th power once the coefficients
  of `g` acquire `q`-th roots in the target.

Source: Stacks, Lemma 10.161.13 (tag 032O), "`R'[x^{1/q}]` is finite over `R[x]`", and the
coefficient half of its "some details omitted".

`finite_map` is proved from a spanning set rather than by base change.

**Correction (this claim was wrong when first written).** An earlier version of this paragraph
said there is "no `Module.Finite.of_isBaseChange` to transport along it". That was measured
against **Mathlib only**, where it is true — but TauCeti has
`TauCeti.finite_of_isBaseChange` (`TauCeti/LinearAlgebra/Dimension/BaseChange.lean:37`), which
is exactly such a transport. The reuse rubric caught this and is right; the claim is withdrawn.

What remains true is the obstruction, not the absence: `Algebra.IsPushout R (MvPolynomial R) S
(MvPolynomial S)` is stated under a section-local
`attribute [local instance] algebraMvPolynomial`, whose own docstring records a diamond and is
deliberately not a global instance. See the reuse thread for what happened when the base-change
route was attempted.

Part of the **normalization-finiteness (Nagata / N-2)** development: Noether's finiteness
theorem *without* a separability hypothesis. Mathlib currently proves only the separable case
(`IsIntegralClosure.finite`, through the trace form, which degenerates inseparably), so the
purely inseparable / Frobenius case is not available upstream. This file is one of the
independent leaves that case rests on.

**Roadmap target.** `TauCetiRoadmap/EllipticCurves/README.md:106-108, 1096` — the support
module `RingTheory/IntegralClosure/NormalizationFinite`, needed for module-finiteness of the
isogeny intermediate ring and through it the relative ideal norm.

Roadmap: EllipticCurves

## Series

One of **four independent leaf files** opening in parallel — this one has no in-repository
imports, so it stands alone and does not depend on the others. The dependent PRs (the purely
inseparable core, the assembly with the main theorem, and the consumer bridge) are already
proved and will open as their parents merge, per the project's no-stacking rule.

## Verification

Built against the pin on current `main` (`653c36f019`), not the pin the work was developed on:

- `lake build` exit 0 — **zero** diagnostics, checked for `info:` as well as errors and warnings
- axioms of every declaration: exactly `propext`, `Classical.choice`, `Quot.sound`
- no `sorry`, no `maxHeartbeats` override, no new `set_option`

## Absence claims re-verified at the pin

Every "Mathlib does not have this" statement above was re-checked **by shape, not by name**, against
`653c36f019` — the pin on current `main`, not the pin this was developed on:

- no `Nagata` / `Japanese ring` / `IsJapanese` anywhere in Mathlib;
- `IsIntegralClosure.finite` still sits under `variable [Algebra.IsSeparable K L]`, so the
  inseparable case is genuinely still open upstream;
- name-level matches for `finite_map`, `tower_bot`, `finite_of_injective`,
  `finiteDimensional_of_finite` were each run down and are unrelated (single-variable `Polynomial`,
  `IsIntegral.tower_bot`, Sylow, finite Galois groups);
- the section-local `attribute [local instance]` on `algebraMvPolynomial` and on
  `FractionRing.liftAlgebra` are both still in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWrLwxwLXS49cy8Mu5jagk
