### PR TITLE
feat: the fixed field of a normal extension is purely inseparable

### DIFF
--- a/TauCeti/FieldTheory/Normal/FixedField.lean
+++ b/TauCeti/FieldTheory/Normal/FixedField.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.Galois.Basic
+public import Mathlib.FieldTheory.PurelyInseparable.Basic
+
+/-!
+# The fixed field of the automorphism group of a normal extension
+
+For a normal extension `E / F`, the fixed field `E ^ Aut(E/F)` sits between `F` and `E` with
+`F ⊆ E ^ Aut(E/F)` purely inseparable and `E ^ Aut(E/F) ⊆ E` Galois. This is the splitting of
+Stacks, Fields, Lemma 9.27.3(2), whose proof reads "We set `E_insep = E^{Aut(E/F)}`. Details
+omitted." Mathlib has the Galois half as `IsGalois.of_fixed_field`; the purely inseparable half
+is new here. The two are stated separately, one conclusion each.
+
+Order matters for the consumer (`TauCeti.IsIntegralClosure.finite_of_forall_isPurelyInseparable`):
+the purely inseparable step has to sit *below* the separable one, because the integral closure
+of a polynomial ring in a separable extension is no longer a polynomial ring.
+
+## Main results
+
+* `TauCeti.IntermediateField.isPurelyInseparable_fixedField_top`: for `E / F` normal, the fixed
+  field of `Gal(E/F)` is purely inseparable over `F`.
+
+## Provenance
+
+Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
+(`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
+`RingTheory/IntegralClosure/NormalizationFinite`. The mathematics is Stacks, Fields,
+Lemma 9.27.3(2) (tag 030M), the splitting used by Stacks 10.161.12 (tag 032N).
+-/
+
+public section
+
+namespace TauCeti
+
+/-- Source: Stacks, Fields, Lemma 9.27.3(2): "`F ⊂ E_insep` is purely inseparable", with
+`E_insep = E^{Aut(E/F)}` (proof: "Details omitted"). For a normal extension `E / F`, the fixed
+field of the full automorphism group is purely inseparable over `F`: an element fixed by every
+automorphism has a single conjugate, since `minpoly F x` splits in `E` and its roots form one
+orbit. -/
+theorem IntermediateField.isPurelyInseparable_fixedField_top (F E : Type*) [Field F] [Field E]
+    [Algebra F E] [Normal F E] :
+    IsPurelyInseparable F (IntermediateField.fixedField (⊤ : Subgroup (E ≃ₐ[F] E))) := by
+  refine ⟨inferInstance, fun x hx ↦ ?_⟩
+  have hinj : Function.Injective
+      (algebraMap (IntermediateField.fixedField (⊤ : Subgroup (E ≃ₐ[F] E))) E) :=
+    RingHom.injective _
+  set y : E := (x : E) with hy
+  have hint : IsIntegral F y := Normal.isIntegral ‹Normal F E› y
+  have hyx : minpoly F y = minpoly F x := minpoly.algebraMap_eq hinj x
+  have hsep : (minpoly F y).Separable := by rw [hyx]; exact hx
+  -- Every Galois conjugate of `y` is `y` itself: a conjugate is `σ y` for some automorphism `σ`,
+  -- and `y` lies in the fixed field of all of them.
+  have hall : ∀ z : E, Polynomial.aeval z (minpoly F y) = 0 → z = y := by
+    intro z hz
+    obtain ⟨σ, hσ⟩ := minpoly.exists_algEquiv_of_root' (Algebra.IsAlgebraic.isAlgebraic y) hz
+    rw [← hσ]
+    exact (IntermediateField.mem_fixedField_iff _ _).mp x.2 σ (Subgroup.mem_top σ)
+  -- `minpoly F y` splits in `E` and is separable, so it has `natDegree` many distinct roots;
+  -- all of them are `y`, so that degree is one.
+  set q : Polynomial E := (minpoly F y).map (algebraMap F E) with hq
+  have hq0 : q ≠ 0 := ((minpoly.monic hint).map (algebraMap F E)).ne_zero
+  have hcard : Multiset.card q.roots = q.natDegree :=
+    Polynomial.splits_iff_card_roots.mp (Normal.splits ‹Normal F E› y)
+  have hnodup : q.roots.Nodup := Polynomial.nodup_roots (Polynomial.Separable.map hsep)
+  have hsub : q.roots ⊆ {y} := by
+    intro z hz
+    rw [Polynomial.mem_roots hq0] at hz
+    refine Multiset.mem_singleton.mpr (hall z ?_)
+    rw [Polynomial.aeval_def, Polynomial.eval₂_eq_eval_map]
+    exact hz
+  have hle : Multiset.card q.roots ≤ 1 := by
+    simpa using Multiset.card_le_card ((Multiset.le_iff_subset hnodup).mpr hsub)
+  have h1 : 0 < (minpoly F y).natDegree := minpoly.natDegree_pos hint
+  have h2 : q.natDegree = (minpoly F y).natDegree :=
+    Polynomial.natDegree_map _
+  have hnd : (minpoly F y).natDegree = 1 := by omega
+  have hdeg : (minpoly F y).degree = 1 := by
+    rw [Polynomial.degree_eq_natDegree (minpoly.ne_zero hint), hnd]; rfl
+  obtain ⟨a, ha⟩ := minpoly.mem_range_of_degree_eq_one F y hdeg
+  refine ⟨a, hinj ?_⟩
+  rw [← IsScalarTower.algebraMap_apply]
+  simpa [hy] using ha
+
+end TauCeti


### PR DESCRIPTION
Adds `TauCeti/FieldTheory/Normal/FixedField.lean`.

* `IntermediateField.isPurelyInseparable_fixedField_top` — for a normal extension `E / F`, the
  fixed field of the full automorphism group is purely inseparable over `F`.

Source: Stacks, Fields, Lemma 9.27.3(2) (tag 030M), where the proof reads "Details omitted";
the argument is supplied here. Every root of `minpoly F y` in `E` is a Galois conjugate of `y`
(`minpoly.exists_algEquiv_of_root'`, which needs exactly `[Normal F E]`), and `y` is fixed, so
all roots coincide; the minimal polynomial splits and is separable, so its roots are distinct,
forcing degree one.

Prior art was checked: no Mathlib declaration mentions both `fixedField` and
`PurelyInseparable`, and the only bridge between `Normal` and `IsPurelyInseparable` at the pin
runs the other way (`IsPurelyInseparable.normal`).

Part of the **normalization-finiteness (Nagata / N-2)** development: Noether's finiteness
theorem *without* a separability hypothesis. Mathlib currently proves only the separable case
(`IsIntegralClosure.finite`, through the trace form, which degenerates inseparably), so the
purely inseparable / Frobenius case is not available upstream. This file is one of the
independent leaves that case rests on.

**Roadmap target.** `TauCetiRoadmap/EllipticCurves/README.md:106-108, 1096` — the support
module `RingTheory/IntegralClosure/NormalizationFinite`, needed for module-finiteness of the
isogeny intermediate ring and through it the relative ideal norm.

Roadmap: EllipticCurves

## Series

One of **four independent leaf files** opening in parallel — this one has no in-repository
imports, so it stands alone and does not depend on the others. The dependent PRs (the purely
inseparable core, the assembly with the main theorem, and the consumer bridge) are already
proved and will open as their parents merge, per the project's no-stacking rule.

## Verification

Built against the pin on current `main` (`653c36f019`), not the pin the work was developed on:

- `lake build` exit 0 — **zero** diagnostics, checked for `info:` as well as errors and warnings
- axioms of every declaration: exactly `propext`, `Classical.choice`, `Quot.sound`
- no `sorry`, no `maxHeartbeats` override, no new `set_option`

## Absence claims re-verified at the pin

Every "Mathlib does not have this" statement above was re-checked **by shape, not by name**, against
`653c36f019` — the pin on current `main`, not the pin this was developed on:

- no `Nagata` / `Japanese ring` / `IsJapanese` anywhere in Mathlib;
- `IsIntegralClosure.finite` still sits under `variable [Algebra.IsSeparable K L]`, so the
  inseparable case is genuinely still open upstream;
- name-level matches for `finite_map`, `tower_bot`, `finite_of_injective`,
  `finiteDimensional_of_finite` were each run down and are unrelated (single-variable `Polynomial`,
  `IsIntegral.tower_bot`, Sylow, finite Galois groups);
- the section-local `attribute [local instance]` on `algebraMvPolynomial` and on
  `FractionRing.liftAlgebra` are both still in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWrLwxwLXS49cy8Mu5jagk
