### PR TITLE
feat: transport principles for integral closures and their finiteness

### DIFF
--- a/TauCeti/RingTheory/IntegralClosure/Transfer.lean
+++ b/TauCeti/RingTheory/IntegralClosure/Transfer.lean
@@ -7,8 +7,6 @@ module
 
 public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
-public import Mathlib.FieldTheory.Minpoly.Field
-public import Mathlib.RingTheory.Algebraic.Basic
 public import Mathlib.RingTheory.Localization.FractionRing
 public import Mathlib.RingTheory.Noetherian.Basic
 
@@ -16,7 +14,8 @@ public import Mathlib.RingTheory.Noetherian.Basic
 # Transport principles for integral closures and their finiteness
 
 Three general facts that the finiteness of integral closures is assembled from, each stated in
-the abstract `IsIntegralClosure` form and independent of the others.
+an abstract typeclass form — `IsIntegralClosure` for the first two, `IsFractionRing` for the
+third — and independent of the others.
 
 * Descending the base: an integral closure of `A` in `B` is also the integral closure of `R` in
   `B` when `A` is integral over `R` — the converse of Mathlib's `IsIntegralClosure.tower_top`,
@@ -147,19 +146,14 @@ theorem IsFractionRing.finiteDimensional_of_finite (R S K L : Type*) [CommRing R
         exact V.smul_mem _ (hS _)
   -- inverses: `b⁻¹` is a `K`-polynomial in `b` divided by a nonzero constant coefficient
   have hinv : ∀ b : S, b ∈ nonZeroDivisors S → (algebraMap S L b)⁻¹ ∈ V := by
-    intro b hb
-    have hb0 : algebraMap S L b ≠ 0 :=
-      (map_ne_zero_iff _ (IsFractionRing.injective S L)).mpr (nonZeroDivisors.ne_zero hb)
+    intro b _
     have hint : IsIntegral K (algebraMap S L b) :=
       (IsIntegral.map (IsScalarTower.toAlgHom R S L) (IsIntegral.of_finite R b)).tower_top
-    set p := minpoly K (algebraMap S L b) with hp
-    have key : (algebraMap S L b)⁻¹
-        = (-(p.coeff 0)⁻¹) • Polynomial.aeval (algebraMap S L b) p.divX := by
-      rw [inv_eq_of_root_of_coeff_zero_ne_zero (minpoly.aeval K _)
-        (minpoly.coeff_zero_ne_zero hint hb0), Algebra.smul_def, map_neg, map_inv₀, neg_mul,
-        ← div_eq_inv_mul]
-    rw [key]
-    exact V.smul_mem _ (hpoly b _)
+    -- the inverse of a nonzero integral element already lies in the algebra it generates
+    obtain ⟨q, hq⟩ :=
+      Algebra.adjoin_mem_exists_aeval K (algebraMap S L b) hint.inv_mem_adjoin
+    rw [← hq]
+    exact hpoly b q
   -- `L` is the fraction field of `S`, so `V` is everything
   have htop : V = ⊤ := by
     refine eq_top_iff.mpr fun z _ ↦ ?_

--- a/TauCeti/RingTheory/IntegralClosure/Transfer.lean
+++ b/TauCeti/RingTheory/IntegralClosure/Transfer.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.Module.Torsion.Free
 public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
 public import Mathlib.FieldTheory.Minpoly.Field
@@ -26,8 +25,8 @@ the abstract `IsIntegralClosure` form and independent of the others.
   module over the Noetherian ring `A`, so is the integral closure in a ring that embeds into it —
   the "as `R` is Noetherian it suffices to enlarge the field" step that Stacks uses in
   Lemmas 10.161.5, 10.161.12 and 10.161.13.
-* Fraction fields: the fraction field of a domain finite over `R` is finite-dimensional over the
-  fraction field of `R`, for arbitrary fraction fields (Mathlib states this only for
+* Fraction fields: the fraction field of a domain `S` finite over `R` is finite-dimensional over
+  any intermediate field `K` with `R → K → L` (Mathlib states this only for the concrete
   `FractionRing R` and `FractionRing S`).
 
 ## Main results
@@ -69,8 +68,7 @@ theorem IsIntegralClosure.tower_bot {R A B C : Type*} [CommRing R] [CommRing A] 
 /-- Source: Stacks, Lemma 10.161.12 (tag 032N), proof: "Choose a finite normal field extension
 `M/K` containing `L`. As `R` is Noetherian it suffices to show that the integral closure of `R`
 in `M` is finite over `R`." Finiteness of integral closures descends along injective `A`-algebra
-maps of the top rings: `C` maps `A`-linearly and injectively into `C'`, and a submodule of a
-finite module over a Noetherian ring is finite. -/
+maps of the top rings. -/
 theorem IsIntegralClosure.finite_of_injective {A : Type*} [CommRing A] [IsNoetherianRing A]
     {M K' : Type*} [CommRing M] [CommRing K'] [Algebra A M] [Algebra A K'] {C C' : Type*}
     [CommRing C] [CommRing C'] [Algebra A C] [Algebra C M] [IsScalarTower A C M]
@@ -80,8 +78,9 @@ theorem IsIntegralClosure.finite_of_injective {A : Type*} [CommRing A] [IsNoethe
   -- `C → M → K'` makes `C` an algebra over which `IsIntegralClosure.lift` can land in `C'`
   let _ : Algebra C K' := (ι.toRingHom.comp (algebraMap C M)).toAlgebra
   have : IsScalarTower A C K' := IsScalarTower.of_algebraMap_eq fun a ↦ by
-    change algebraMap A K' a = ι (algebraMap C M (algebraMap A C a))
-    rw [← IsScalarTower.algebraMap_apply A C M a, AlgHom.commutes]
+    rw [RingHom.algebraMap_toAlgebra, RingHom.comp_apply,
+      ← IsScalarTower.algebraMap_apply A C M a]
+    exact (ι.commutes a).symm
   have : Algebra.IsIntegral A C := ⟨fun x ↦ IsIntegralClosure.isIntegral A M x⟩
   have hinj : Function.Injective (IsIntegralClosure.lift (S := C) A C' K') := fun a b hab ↦ by
     refine IsIntegralClosure.algebraMap_injective C A M (hι ?_)
@@ -94,7 +93,10 @@ theorem IsIntegralClosure.finite_of_injective {A : Type*} [CommRing A] [IsNoethe
 the fraction field of `S`. Then `M` is also a finite field extension of `K`" (`S` finite over
 `R`, `K` the fraction field of `R`). The fraction field of a domain `S` finite and torsion-free
 over a domain `R` is finite-dimensional over the fraction field of `R`, for abstract fraction
-fields `K` and `L`; Mathlib's instance covers only `FractionRing R` and `FractionRing S`. -/
+fields `K` and `L`. NOTE the hypotheses are weaker than that sentence suggests: `K` need only
+be an intermediate field with `R → K → L`, not a fraction field of `R`, and neither `R` being a
+domain nor `S` torsion-free over it is assumed. Mathlib covers only the concrete
+`FractionRing R` / `FractionRing S` case. -/
 theorem IsFractionRing.finiteDimensional_of_finite (R S K L : Type*) [CommRing R] [CommRing S]
     [IsDomain S] [Algebra R S] [Module.Finite R S]
     [Field K] [Field L] [Algebra R K] [Algebra S L] [IsFractionRing S L]

--- a/TauCeti/RingTheory/IntegralClosure/Transfer.lean
+++ b/TauCeti/RingTheory/IntegralClosure/Transfer.lean
@@ -5,28 +5,22 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
-public import Mathlib.RingTheory.Localization.FractionRing
 public import Mathlib.RingTheory.Noetherian.Basic
 
 /-!
 # Transport principles for integral closures and their finiteness
 
-Three general facts that the finiteness of integral closures is assembled from, each stated in
-an abstract typeclass form — `IsIntegralClosure` for the first two, `IsFractionRing` for the
-third — and independent of the others.
+Two general facts that the finiteness of integral closures is assembled from, each stated in the
+abstract typeclass form `IsIntegralClosure`, and independent of each other.
 
 * Descending the base: an integral closure of `A` in `B` is also the integral closure of `R` in
   `B` when `A` is integral over `R` — the converse of Mathlib's `IsIntegralClosure.tower_top`,
-  and Stacks, Lemma 10.36.16 (tag 00GQ).
+  and Stacks, Lemma 10.36.16 (tag 0308).
 * Descending along an embedding: if the integral closure of `A` in a bigger ring is a finite
   module over the Noetherian ring `A`, so is the integral closure in a ring that embeds into it —
   the "as `R` is Noetherian it suffices to enlarge the field" step that Stacks uses in
   Lemmas 10.161.5, 10.161.12 and 10.161.13.
-* Fraction fields: a fraction field of a ring `S` finite over `R` is finite-dimensional over any
-  intermediate field `K` with `R → K → L` (Mathlib states this only for the concrete
-  `FractionRing R` and `FractionRing S`).
 
 ## Main results
 
@@ -34,23 +28,23 @@ third — and independent of the others.
   closure of `R` in `B` when `A` is integral over `R`.
 * `TauCeti.IsIntegralClosure.finite_of_injective`: finiteness of an integral closure descends
   along an injective `A`-algebra map of the top rings, over a Noetherian `A`.
-* `TauCeti.IsFractionRing.finiteDimensional_of_finite`: `Frac S` is finite-dimensional over any
-  intermediate field `K`, when `S` is a finite `R`-module.
 
 ## Provenance
 
 Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
 (`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
 `RingTheory/IntegralClosure/NormalizationFinite`. The statements are Stacks, Lemmas 10.36.16
-and 10.36.15(2) (tags 00GQ, 00GP; "Proof. Omitted"), the Noetherian reduction sentence of
-Stacks 10.161.12 (tag 032N), and the fraction-field sentence of Stacks 10.161.5 (tag 032I).
+and 10.36.15(2) (tags 0308, 02JM; "Proof. Omitted") and the Noetherian reduction sentence of
+Stacks 10.161.12 (tag 032N). The fraction-field sentence of Stacks 10.161.5 (tag 032I) is
+generic localization material and lives in
+`TauCeti/RingTheory/Localization/FiniteDimensional.lean`.
 -/
 
 public section
 
 namespace TauCeti
 
-/-- Source: Stacks, Lemma 10.36.16 (tag 00GQ): "Let `A → B → C` be ring maps. Let `B′` be the
+/-- Source: Stacks, Lemma 10.36.16 (tag 0308): "Let `A → B → C` be ring maps. Let `B′` be the
 integral closure of `A` in `B`, let `C′` be the integral closure of `B′` in `C`. Then `C′` is
 the integral closure of `A` in `C`." Here in the form used by normalization-finiteness: if `C` is
 the integral closure of `A` in `B` and `A` is integral over `R`, then `C` is the integral closure
@@ -87,80 +81,5 @@ theorem IsIntegralClosure.finite_of_injective {A : Type*} [CommRing A] [IsNoethe
     rwa [IsIntegralClosure.algebraMap_lift, IsIntegralClosure.algebraMap_lift] at h
   exact Module.Finite.of_injective
     (IsIntegralClosure.lift (S := C) A C' K').toLinearMap hinj
-
-/-- A fraction field `L` of a ring `S` that is finite as an `R`-module is finite-dimensional
-over any intermediate field `K`, that is, any field with `R → K → L`.
-
-This is the content of Stacks, Lemma 10.161.5 (tag 032I) — "Let `M` be a finite field extension
-of the fraction field of `S`. Then `M` is also a finite field extension of `K`" — but the
-hypotheses here are weaker than that sentence suggests, and deliberately so: `K` need not be a
-fraction field of `R`, and no domain or torsion-freeness assumption on `R` or `S` is used.
-Mathlib covers only the concrete `FractionRing R` / `FractionRing S` case. -/
-theorem IsFractionRing.finiteDimensional_of_finite (R S K L : Type*) [CommRing R] [CommRing S]
-    [Algebra R S] [Module.Finite R S]
-    [Field K] [Field L] [Algebra R K] [Algebra S L] [IsFractionRing S L]
-    [Algebra K L] [Algebra R L] [IsScalarTower R K L] [IsScalarTower R S L] :
-    FiniteDimensional K L := by
-  classical
-  obtain ⟨t, ht⟩ := (Module.finite_def.mp ‹Module.Finite R S›)
-  -- `V` is the `K`-span of the image of a finite `R`-generating set of `S`
-  set V : Submodule K L := Submodule.span K ((algebraMap S L) '' (t : Set S)) with hV
-  -- every element of `S` already lies in `V`: an `R`-scalar is a `K`-scalar along `R → K → L`
-  have hS : ∀ x : S, algebraMap S L x ∈ V := by
-    intro x
-    have hx : x ∈ Submodule.span R (t : Set S) := ht ▸ Submodule.mem_top
-    induction hx using Submodule.span_induction with
-    | mem y hy => exact Submodule.subset_span ⟨y, hy, rfl⟩
-    | zero => simp
-    | add y z _ _ hy hz => simpa [map_add] using V.add_mem hy hz
-    | smul r y _ hy =>
-        have : algebraMap S L (r • y)
-            = algebraMap R K r • algebraMap S L y := by
-          rw [Algebra.smul_def, map_mul, ← IsScalarTower.algebraMap_apply R S L,
-            Algebra.smul_def, ← IsScalarTower.algebraMap_apply R K L]
-        rw [this]
-        exact V.smul_mem _ hy
-  -- `V` absorbs multiplication by the image of `S`
-  have hmul : ∀ (x : S) (v : L), v ∈ V → algebraMap S L x * v ∈ V := by
-    intro x v hv
-    induction hv using Submodule.span_induction with
-    | mem y hy =>
-        obtain ⟨y, hy, rfl⟩ := hy
-        simpa [← map_mul] using hS (x * y)
-    | zero => simp
-    | add y z _ _ hy hz => simpa [mul_add] using V.add_mem hy hz
-    | smul k y _ hy =>
-        rw [Algebra.smul_def, ← mul_assoc, mul_comm (algebraMap S L x), mul_assoc,
-          ← Algebra.smul_def]
-        exact V.smul_mem _ hy
-  -- a `K`-polynomial in an element of the image of `S` stays in `V`
-  have hpoly : ∀ (b : S) (q : Polynomial K), Polynomial.aeval (algebraMap S L b) q ∈ V := by
-    intro b q
-    induction q using Polynomial.induction_on' with
-    | add q r hq hr => simpa [map_add] using V.add_mem hq hr
-    | monomial j k =>
-        have : Polynomial.aeval (algebraMap S L b) (Polynomial.monomial j k)
-            = k • algebraMap S L (b ^ j) := by
-          simp [Polynomial.aeval_monomial, Algebra.smul_def, map_pow]
-        rw [this]
-        exact V.smul_mem _ (hS _)
-  -- inverses: `b⁻¹` is a `K`-polynomial in `b` divided by a nonzero constant coefficient
-  have hinv : ∀ b : S, b ∈ nonZeroDivisors S → (algebraMap S L b)⁻¹ ∈ V := by
-    intro b _
-    have hint : IsIntegral K (algebraMap S L b) :=
-      (IsIntegral.map (IsScalarTower.toAlgHom R S L) (IsIntegral.of_finite R b)).tower_top
-    -- the inverse of a nonzero integral element already lies in the algebra it generates
-    obtain ⟨q, hq⟩ :=
-      Algebra.adjoin_mem_exists_aeval K (algebraMap S L b) hint.inv_mem_adjoin
-    rw [← hq]
-    exact hpoly b q
-  -- `L` is the fraction field of `S`, so `V` is everything
-  have htop : V = ⊤ := by
-    refine eq_top_iff.mpr fun z _ ↦ ?_
-    obtain ⟨a, b, hb, rfl⟩ := IsFractionRing.div_surjective (A := S) (K := L) z
-    rw [div_eq_mul_inv]
-    exact hmul a _ (hinv b hb)
-  exact Module.finite_def.mpr
-    (htop ▸ Submodule.fg_span (Set.Finite.image _ t.finite_toSet))
 
 end TauCeti

--- a/TauCeti/RingTheory/IntegralClosure/Transfer.lean
+++ b/TauCeti/RingTheory/IntegralClosure/Transfer.lean
@@ -50,7 +50,7 @@ the integral closure of `A` in `C`." Here in the form used by normalization-fini
 the integral closure of `A` in `B` and `A` is integral over `R`, then `C` is the integral closure
 of `R` in `B`. The converse of Mathlib's `IsIntegralClosure.tower_top`. -/
 theorem IsIntegralClosure.tower_bot {R A B C : Type*} [CommRing R] [CommRing A] [CommRing B]
-    [CommRing C] [Algebra R A] [Algebra R B] [Algebra A B] [Algebra C B] [IsScalarTower R A B]
+    [CommSemiring C] [Algebra R A] [Algebra R B] [Algebra A B] [Algebra C B] [IsScalarTower R A B]
     [IsIntegralClosure C A B] [Algebra.IsIntegral R A] : IsIntegralClosure C R B := by
   refine ⟨IsIntegralClosure.algebraMap_injective C A B, fun {x} ↦ ⟨fun hx ↦ ?_, fun hy ↦ ?_⟩⟩
   · -- integral over `R` ⇒ integral over `A`, so it is hit by `C`

--- a/TauCeti/RingTheory/IntegralClosure/Transfer.lean
+++ b/TauCeti/RingTheory/IntegralClosure/Transfer.lean
@@ -36,8 +36,8 @@ the abstract `IsIntegralClosure` form and independent of the others.
   closure of `R` in `B` when `A` is integral over `R`.
 * `TauCeti.IsIntegralClosure.finite_of_injective`: finiteness of an integral closure descends
   along an injective `A`-algebra map of the top rings, over a Noetherian `A`.
-* `TauCeti.IsFractionRing.finiteDimensional_of_finite`: `Frac S / Frac R` is finite when `S / R`
-  is a finite extension of domains.
+* `TauCeti.IsFractionRing.finiteDimensional_of_finite`: `Frac S` is finite-dimensional over any
+  intermediate field `K`, when `S` is a finite `R`-module.
 
 ## Provenance
 
@@ -96,8 +96,8 @@ the fraction field of `S`. Then `M` is also a finite field extension of `K`" (`S
 over a domain `R` is finite-dimensional over the fraction field of `R`, for abstract fraction
 fields `K` and `L`; Mathlib's instance covers only `FractionRing R` and `FractionRing S`. -/
 theorem IsFractionRing.finiteDimensional_of_finite (R S K L : Type*) [CommRing R] [CommRing S]
-    [IsDomain R] [IsDomain S] [Algebra R S] [Module.IsTorsionFree R S] [Module.Finite R S]
-    [Field K] [Field L] [Algebra R K] [IsFractionRing R K] [Algebra S L] [IsFractionRing S L]
+    [IsDomain S] [Algebra R S] [Module.Finite R S]
+    [Field K] [Field L] [Algebra R K] [Algebra S L] [IsFractionRing S L]
     [Algebra K L] [Algebra R L] [IsScalarTower R K L] [IsScalarTower R S L] :
     FiniteDimensional K L := by
   classical

--- a/TauCeti/RingTheory/IntegralClosure/Transfer.lean
+++ b/TauCeti/RingTheory/IntegralClosure/Transfer.lean
@@ -24,8 +24,8 @@ third — and independent of the others.
   module over the Noetherian ring `A`, so is the integral closure in a ring that embeds into it —
   the "as `R` is Noetherian it suffices to enlarge the field" step that Stacks uses in
   Lemmas 10.161.5, 10.161.12 and 10.161.13.
-* Fraction fields: the fraction field of a domain `S` finite over `R` is finite-dimensional over
-  any intermediate field `K` with `R → K → L` (Mathlib states this only for the concrete
+* Fraction fields: a fraction field of a ring `S` finite over `R` is finite-dimensional over any
+  intermediate field `K` with `R → K → L` (Mathlib states this only for the concrete
   `FractionRing R` and `FractionRing S`).
 
 ## Main results
@@ -88,16 +88,16 @@ theorem IsIntegralClosure.finite_of_injective {A : Type*} [CommRing A] [IsNoethe
   exact Module.Finite.of_injective
     (IsIntegralClosure.lift (S := C) A C' K').toLinearMap hinj
 
-/-- Source: Stacks, Lemma 10.161.5 (tag 032I), proof: "Let `M` be a finite field extension of
-the fraction field of `S`. Then `M` is also a finite field extension of `K`" (`S` finite over
-`R`, `K` the fraction field of `R`). The fraction field of a domain `S` finite and torsion-free
-over a domain `R` is finite-dimensional over the fraction field of `R`, for abstract fraction
-fields `K` and `L`. NOTE the hypotheses are weaker than that sentence suggests: `K` need only
-be an intermediate field with `R → K → L`, not a fraction field of `R`, and neither `R` being a
-domain nor `S` torsion-free over it is assumed. Mathlib covers only the concrete
-`FractionRing R` / `FractionRing S` case. -/
+/-- A fraction field `L` of a ring `S` that is finite as an `R`-module is finite-dimensional
+over any intermediate field `K`, that is, any field with `R → K → L`.
+
+This is the content of Stacks, Lemma 10.161.5 (tag 032I) — "Let `M` be a finite field extension
+of the fraction field of `S`. Then `M` is also a finite field extension of `K`" — but the
+hypotheses here are weaker than that sentence suggests, and deliberately so: `K` need not be a
+fraction field of `R`, and no domain or torsion-freeness assumption on `R` or `S` is used.
+Mathlib covers only the concrete `FractionRing R` / `FractionRing S` case. -/
 theorem IsFractionRing.finiteDimensional_of_finite (R S K L : Type*) [CommRing R] [CommRing S]
-    [IsDomain S] [Algebra R S] [Module.Finite R S]
+    [Algebra R S] [Module.Finite R S]
     [Field K] [Field L] [Algebra R K] [Algebra S L] [IsFractionRing S L]
     [Algebra K L] [Algebra R L] [IsScalarTower R K L] [IsScalarTower R S L] :
     FiniteDimensional K L := by

--- a/TauCeti/RingTheory/IntegralClosure/Transfer.lean
+++ b/TauCeti/RingTheory/IntegralClosure/Transfer.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Module.Torsion.Free
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+public import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
+public import Mathlib.FieldTheory.Minpoly.Field
+public import Mathlib.RingTheory.Algebraic.Basic
+public import Mathlib.RingTheory.Localization.FractionRing
+public import Mathlib.RingTheory.Noetherian.Basic
+
+/-!
+# Transport principles for integral closures and their finiteness
+
+Three general facts that the finiteness of integral closures is assembled from, each stated in
+the abstract `IsIntegralClosure` form and independent of the others.
+
+* Descending the base: an integral closure of `A` in `B` is also the integral closure of `R` in
+  `B` when `A` is integral over `R` — the converse of Mathlib's `IsIntegralClosure.tower_top`,
+  and Stacks, Lemma 10.36.16 (tag 00GQ).
+* Descending along an embedding: if the integral closure of `A` in a bigger ring is a finite
+  module over the Noetherian ring `A`, so is the integral closure in a ring that embeds into it —
+  the "as `R` is Noetherian it suffices to enlarge the field" step that Stacks uses in
+  Lemmas 10.161.5, 10.161.12 and 10.161.13.
+* Fraction fields: the fraction field of a domain finite over `R` is finite-dimensional over the
+  fraction field of `R`, for arbitrary fraction fields (Mathlib states this only for
+  `FractionRing R` and `FractionRing S`).
+
+## Main results
+
+* `TauCeti.IsIntegralClosure.tower_bot`: the integral closure of `A` in `B` is the integral
+  closure of `R` in `B` when `A` is integral over `R`.
+* `TauCeti.IsIntegralClosure.finite_of_injective`: finiteness of an integral closure descends
+  along an injective `A`-algebra map of the top rings, over a Noetherian `A`.
+* `TauCeti.IsFractionRing.finiteDimensional_of_finite`: `Frac S / Frac R` is finite when `S / R`
+  is a finite extension of domains.
+
+## Provenance
+
+Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
+(`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
+`RingTheory/IntegralClosure/NormalizationFinite`. The statements are Stacks, Lemmas 10.36.16
+and 10.36.15(2) (tags 00GQ, 00GP; "Proof. Omitted"), the Noetherian reduction sentence of
+Stacks 10.161.12 (tag 032N), and the fraction-field sentence of Stacks 10.161.5 (tag 032I).
+-/
+
+public section
+
+namespace TauCeti
+
+/-- Source: Stacks, Lemma 10.36.16 (tag 00GQ): "Let `A → B → C` be ring maps. Let `B′` be the
+integral closure of `A` in `B`, let `C′` be the integral closure of `B′` in `C`. Then `C′` is
+the integral closure of `A` in `C`." Here in the form used by normalization-finiteness: if `C` is
+the integral closure of `A` in `B` and `A` is integral over `R`, then `C` is the integral closure
+of `R` in `B`. The converse of Mathlib's `IsIntegralClosure.tower_top`. -/
+theorem IsIntegralClosure.tower_bot {R A B C : Type*} [CommRing R] [CommRing A] [CommRing B]
+    [CommRing C] [Algebra R A] [Algebra R B] [Algebra A B] [Algebra C B] [IsScalarTower R A B]
+    [IsIntegralClosure C A B] [Algebra.IsIntegral R A] : IsIntegralClosure C R B := by
+  refine ⟨IsIntegralClosure.algebraMap_injective C A B, fun {x} ↦ ⟨fun hx ↦ ?_, fun hy ↦ ?_⟩⟩
+  · -- integral over `R` ⇒ integral over `A`, so it is hit by `C`
+    exact (IsIntegralClosure.isIntegral_iff (A := C) (R := A)).mp hx.tower_top
+  · -- hit by `C` ⇒ integral over `A`, and `A` is integral over `R`
+    exact isIntegral_trans x ((IsIntegralClosure.isIntegral_iff (A := C) (R := A)).mpr hy)
+
+/-- Source: Stacks, Lemma 10.161.12 (tag 032N), proof: "Choose a finite normal field extension
+`M/K` containing `L`. As `R` is Noetherian it suffices to show that the integral closure of `R`
+in `M` is finite over `R`." Finiteness of integral closures descends along injective `A`-algebra
+maps of the top rings: `C` maps `A`-linearly and injectively into `C'`, and a submodule of a
+finite module over a Noetherian ring is finite. -/
+theorem IsIntegralClosure.finite_of_injective {A : Type*} [CommRing A] [IsNoetherianRing A]
+    {M K' : Type*} [CommRing M] [CommRing K'] [Algebra A M] [Algebra A K'] {C C' : Type*}
+    [CommRing C] [CommRing C'] [Algebra A C] [Algebra C M] [IsScalarTower A C M]
+    [IsIntegralClosure C A M] [Algebra A C'] [Algebra C' K'] [IsScalarTower A C' K']
+    [IsIntegralClosure C' A K'] [Module.Finite A C'] (ι : M →ₐ[A] K')
+    (hι : Function.Injective ι) : Module.Finite A C := by
+  -- `C → M → K'` makes `C` an algebra over which `IsIntegralClosure.lift` can land in `C'`
+  let _ : Algebra C K' := (ι.toRingHom.comp (algebraMap C M)).toAlgebra
+  have : IsScalarTower A C K' := IsScalarTower.of_algebraMap_eq fun a ↦ by
+    change algebraMap A K' a = ι (algebraMap C M (algebraMap A C a))
+    rw [← IsScalarTower.algebraMap_apply A C M a, AlgHom.commutes]
+  have : Algebra.IsIntegral A C := ⟨fun x ↦ IsIntegralClosure.isIntegral A M x⟩
+  have hinj : Function.Injective (IsIntegralClosure.lift (S := C) A C' K') := fun a b hab ↦ by
+    refine IsIntegralClosure.algebraMap_injective C A M (hι ?_)
+    have h := congrArg (algebraMap C' K') hab
+    rwa [IsIntegralClosure.algebraMap_lift, IsIntegralClosure.algebraMap_lift] at h
+  exact Module.Finite.of_injective
+    (IsIntegralClosure.lift (S := C) A C' K').toLinearMap hinj
+
+/-- Source: Stacks, Lemma 10.161.5 (tag 032I), proof: "Let `M` be a finite field extension of
+the fraction field of `S`. Then `M` is also a finite field extension of `K`" (`S` finite over
+`R`, `K` the fraction field of `R`). The fraction field of a domain `S` finite and torsion-free
+over a domain `R` is finite-dimensional over the fraction field of `R`, for abstract fraction
+fields `K` and `L`; Mathlib's instance covers only `FractionRing R` and `FractionRing S`. -/
+theorem IsFractionRing.finiteDimensional_of_finite (R S K L : Type*) [CommRing R] [CommRing S]
+    [IsDomain R] [IsDomain S] [Algebra R S] [Module.IsTorsionFree R S] [Module.Finite R S]
+    [Field K] [Field L] [Algebra R K] [IsFractionRing R K] [Algebra S L] [IsFractionRing S L]
+    [Algebra K L] [Algebra R L] [IsScalarTower R K L] [IsScalarTower R S L] :
+    FiniteDimensional K L := by
+  classical
+  obtain ⟨t, ht⟩ := (Module.finite_def.mp ‹Module.Finite R S›)
+  -- `V` is the `K`-span of the image of a finite `R`-generating set of `S`
+  set V : Submodule K L := Submodule.span K ((algebraMap S L) '' (t : Set S)) with hV
+  -- every element of `S` already lies in `V`: an `R`-scalar is a `K`-scalar along `R → K → L`
+  have hS : ∀ x : S, algebraMap S L x ∈ V := by
+    intro x
+    have hx : x ∈ Submodule.span R (t : Set S) := ht ▸ Submodule.mem_top
+    induction hx using Submodule.span_induction with
+    | mem y hy => exact Submodule.subset_span ⟨y, hy, rfl⟩
+    | zero => simp
+    | add y z _ _ hy hz => simpa [map_add] using V.add_mem hy hz
+    | smul r y _ hy =>
+        have : algebraMap S L (r • y)
+            = algebraMap R K r • algebraMap S L y := by
+          rw [Algebra.smul_def, map_mul, ← IsScalarTower.algebraMap_apply R S L,
+            Algebra.smul_def, ← IsScalarTower.algebraMap_apply R K L]
+        rw [this]
+        exact V.smul_mem _ hy
+  -- `V` absorbs multiplication by the image of `S`
+  have hmul : ∀ (x : S) (v : L), v ∈ V → algebraMap S L x * v ∈ V := by
+    intro x v hv
+    induction hv using Submodule.span_induction with
+    | mem y hy =>
+        obtain ⟨y, hy, rfl⟩ := hy
+        simpa [← map_mul] using hS (x * y)
+    | zero => simp
+    | add y z _ _ hy hz => simpa [mul_add] using V.add_mem hy hz
+    | smul k y _ hy =>
+        rw [Algebra.smul_def, ← mul_assoc, mul_comm (algebraMap S L x), mul_assoc,
+          ← Algebra.smul_def]
+        exact V.smul_mem _ hy
+  -- a `K`-polynomial in an element of the image of `S` stays in `V`
+  have hpoly : ∀ (b : S) (q : Polynomial K), Polynomial.aeval (algebraMap S L b) q ∈ V := by
+    intro b q
+    induction q using Polynomial.induction_on' with
+    | add q r hq hr => simpa [map_add] using V.add_mem hq hr
+    | monomial j k =>
+        have : Polynomial.aeval (algebraMap S L b) (Polynomial.monomial j k)
+            = k • algebraMap S L (b ^ j) := by
+          simp [Polynomial.aeval_monomial, Algebra.smul_def, map_pow]
+        rw [this]
+        exact V.smul_mem _ (hS _)
+  -- inverses: `b⁻¹` is a `K`-polynomial in `b` divided by a nonzero constant coefficient
+  have hinv : ∀ b : S, b ∈ nonZeroDivisors S → (algebraMap S L b)⁻¹ ∈ V := by
+    intro b hb
+    have hb0 : algebraMap S L b ≠ 0 :=
+      (map_ne_zero_iff _ (IsFractionRing.injective S L)).mpr (nonZeroDivisors.ne_zero hb)
+    have hint : IsIntegral K (algebraMap S L b) :=
+      (IsIntegral.map (IsScalarTower.toAlgHom R S L) (IsIntegral.of_finite R b)).tower_top
+    set p := minpoly K (algebraMap S L b) with hp
+    have key : (algebraMap S L b)⁻¹
+        = (-(p.coeff 0)⁻¹) • Polynomial.aeval (algebraMap S L b) p.divX := by
+      rw [inv_eq_of_root_of_coeff_zero_ne_zero (minpoly.aeval K _)
+        (minpoly.coeff_zero_ne_zero hint hb0), Algebra.smul_def, map_neg, map_inv₀, neg_mul,
+        ← div_eq_inv_mul]
+    rw [key]
+    exact V.smul_mem _ (hpoly b _)
+  -- `L` is the fraction field of `S`, so `V` is everything
+  have htop : V = ⊤ := by
+    refine eq_top_iff.mpr fun z _ ↦ ?_
+    obtain ⟨a, b, hb, rfl⟩ := IsFractionRing.div_surjective (A := S) (K := L) z
+    rw [div_eq_mul_inv]
+    exact hmul a _ (hinv b hb)
+  exact Module.finite_def.mpr
+    (htop ▸ Submodule.fg_span (Set.Finite.image _ t.finite_toSet))
+
+end TauCeti

--- a/TauCeti/RingTheory/Localization/FiniteDimensional.lean
+++ b/TauCeti/RingTheory/Localization/FiniteDimensional.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
 public import Mathlib.RingTheory.Localization.FractionRing
 
@@ -61,20 +60,12 @@ theorem IsFractionRing.finiteDimensional_of_finite (R S K L : Type*) [CommRing R
   -- `V` is the `K`-span of the image of a finite `R`-generating set of `S`
   set V : Submodule K L := Submodule.span K ((algebraMap S L) '' (t : Set S)) with hV
   -- every element of `S` already lies in `V`: an `R`-scalar is a `K`-scalar along `R → K → L`
-  have hS : ∀ x : S, algebraMap S L x ∈ V := by
-    intro x
-    have hx : x ∈ Submodule.span R (t : Set S) := ht ▸ Submodule.mem_top
-    induction hx using Submodule.span_induction with
-    | mem y hy => exact Submodule.subset_span ⟨y, hy, rfl⟩
-    | zero => simp
-    | add y z _ _ hy hz => simpa [map_add] using V.add_mem hy hz
-    | smul r y _ hy =>
-        have : algebraMap S L (r • y)
-            = algebraMap R K r • algebraMap S L y := by
-          rw [Algebra.smul_def, map_mul, ← IsScalarTower.algebraMap_apply R S L,
-            Algebra.smul_def, ← IsScalarTower.algebraMap_apply R K L]
-        rw [this]
-        exact V.smul_mem _ hy
+  -- the `R`-span of the mapped generators already contains the image of `S`, and the `K`-span
+  -- contains the `R`-span
+  have hS : ∀ x : S, algebraMap S L x ∈ V := fun x ↦
+    Submodule.span_subset_span R K _
+      (Submodule.map_mem_span_algebraMap_image (T := L) x (t : Set S)
+        (ht ▸ Submodule.mem_top))
   -- `V` absorbs multiplication by the image of `S`
   have hmul : ∀ (x : S) (v : L), v ∈ V → algebraMap S L x * v ∈ V := by
     intro x v hv

--- a/TauCeti/RingTheory/Localization/FiniteDimensional.lean
+++ b/TauCeti/RingTheory/Localization/FiniteDimensional.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+public import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
+public import Mathlib.RingTheory.Localization.FractionRing
+
+/-!
+# Finite-dimensionality of a fraction field over an intermediate field
+
+Let `S` be finite as a module over `R`, and let `L` be a fraction field of `S`. Then `L` is
+finite-dimensional over *any* intermediate field `K`, that is, any field sitting in a tower
+`R → K → L`. Mathlib proves this only for the concrete `FractionRing R` and `FractionRing S`;
+the statement here is about abstract fraction fields and an arbitrary intermediate field.
+
+## Main results
+
+* `TauCeti.IsFractionRing.finiteDimensional_of_finite`: `L` is finite-dimensional over `K`.
+
+## Provenance
+
+Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
+(`TauCetiRoadmap/EllipticCurves/README.md:1096`). This is the fraction-field sentence of Stacks,
+Lemma 10.161.5 (tag 032I).
+
+## Implementation notes
+
+The proof is elementary and does not use integral-closure *theory*, only the integrality of a
+finite module element: `V` is the `K`-span of the image of a finite `R`-generating set of `S`, it
+absorbs multiplication by the image of `S`, and it contains the inverse of every nonzero element
+of that image because such an element is integral over `K` and the inverse of a nonzero integral
+element lies in the algebra it generates. `L` is then `V` because every element of `L` is a
+quotient of elements of the image of `S`.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A fraction field `L` of a ring `S` that is finite as an `R`-module is finite-dimensional
+over any intermediate field `K`, that is, any field with `R → K → L`.
+
+This is the content of Stacks, Lemma 10.161.5 (tag 032I) — "Let `M` be a finite field extension
+of the fraction field of `S`. Then `M` is also a finite field extension of `K`" — but the
+hypotheses here are weaker than that sentence suggests, and deliberately so: `K` need not be a
+fraction field of `R`, and no assumption on `R` beyond `Module.Finite R S` is used. No *explicit*
+`IsDomain S` hypothesis is needed either, but that is not extra generality: `IsFractionRing S L`
+with `L` a field already forces `algebraMap S L` to be injective, and hence `S` to be a domain.
+Mathlib covers only the concrete `FractionRing R` / `FractionRing S` case. -/
+theorem IsFractionRing.finiteDimensional_of_finite (R S K L : Type*) [CommRing R] [CommRing S]
+    [Algebra R S] [Module.Finite R S]
+    [Field K] [Field L] [Algebra R K] [Algebra S L] [IsFractionRing S L]
+    [Algebra K L] [Algebra R L] [IsScalarTower R K L] [IsScalarTower R S L] :
+    FiniteDimensional K L := by
+  classical
+  obtain ⟨t, ht⟩ := (Module.finite_def.mp ‹Module.Finite R S›)
+  -- `V` is the `K`-span of the image of a finite `R`-generating set of `S`
+  set V : Submodule K L := Submodule.span K ((algebraMap S L) '' (t : Set S)) with hV
+  -- every element of `S` already lies in `V`: an `R`-scalar is a `K`-scalar along `R → K → L`
+  have hS : ∀ x : S, algebraMap S L x ∈ V := by
+    intro x
+    have hx : x ∈ Submodule.span R (t : Set S) := ht ▸ Submodule.mem_top
+    induction hx using Submodule.span_induction with
+    | mem y hy => exact Submodule.subset_span ⟨y, hy, rfl⟩
+    | zero => simp
+    | add y z _ _ hy hz => simpa [map_add] using V.add_mem hy hz
+    | smul r y _ hy =>
+        have : algebraMap S L (r • y)
+            = algebraMap R K r • algebraMap S L y := by
+          rw [Algebra.smul_def, map_mul, ← IsScalarTower.algebraMap_apply R S L,
+            Algebra.smul_def, ← IsScalarTower.algebraMap_apply R K L]
+        rw [this]
+        exact V.smul_mem _ hy
+  -- `V` absorbs multiplication by the image of `S`
+  have hmul : ∀ (x : S) (v : L), v ∈ V → algebraMap S L x * v ∈ V := by
+    intro x v hv
+    induction hv using Submodule.span_induction with
+    | mem y hy =>
+        obtain ⟨y, hy, rfl⟩ := hy
+        simpa [← map_mul] using hS (x * y)
+    | zero => simp
+    | add y z _ _ hy hz => simpa [mul_add] using V.add_mem hy hz
+    | smul k y _ hy =>
+        rw [Algebra.smul_def, ← mul_assoc, mul_comm (algebraMap S L x), mul_assoc,
+          ← Algebra.smul_def]
+        exact V.smul_mem _ hy
+  -- a `K`-polynomial in an element of the image of `S` stays in `V`
+  have hpoly : ∀ (b : S) (q : Polynomial K), Polynomial.aeval (algebraMap S L b) q ∈ V := by
+    intro b q
+    induction q using Polynomial.induction_on' with
+    | add q r hq hr => simpa [map_add] using V.add_mem hq hr
+    | monomial j k =>
+        have : Polynomial.aeval (algebraMap S L b) (Polynomial.monomial j k)
+            = k • algebraMap S L (b ^ j) := by
+          simp [Polynomial.aeval_monomial, Algebra.smul_def, map_pow]
+        rw [this]
+        exact V.smul_mem _ (hS _)
+  -- inverses: `b⁻¹` is a `K`-polynomial in `b` divided by a nonzero constant coefficient
+  have hinv : ∀ b : S, b ∈ nonZeroDivisors S → (algebraMap S L b)⁻¹ ∈ V := by
+    intro b _
+    have hint : IsIntegral K (algebraMap S L b) :=
+      (IsIntegral.map (IsScalarTower.toAlgHom R S L) (IsIntegral.of_finite R b)).tower_top
+    -- the inverse of a nonzero integral element already lies in the algebra it generates
+    obtain ⟨q, hq⟩ :=
+      Algebra.adjoin_mem_exists_aeval K (algebraMap S L b) hint.inv_mem_adjoin
+    rw [← hq]
+    exact hpoly b q
+  -- `L` is the fraction field of `S`, so `V` is everything
+  have htop : V = ⊤ := by
+    refine eq_top_iff.mpr fun z _ ↦ ?_
+    obtain ⟨a, b, hb, rfl⟩ := IsFractionRing.div_surjective (A := S) (K := L) z
+    rw [div_eq_mul_inv]
+    exact hmul a _ (hinv b hb)
+  exact Module.finite_def.mpr
+    (htop ▸ Submodule.fg_span (Set.Finite.image _ t.finite_toSet))
+
+end TauCeti
+
+end


### PR DESCRIPTION
Adds `TauCeti/RingTheory/IntegralClosure/Transfer.lean`.

* `IsIntegralClosure.tower_bot` — the converse of Mathlib's `IsIntegralClosure.tower_top`: an
  integral closure of `A` in `B` is also the integral closure of `R` in `B` once `A` is
  integral over `R`. Stacks, Lemma 10.36.16 (tag 00GQ).
* `IsIntegralClosure.finite_of_injective` — finiteness of an integral closure descends along an
  injective algebra map of the top rings over a Noetherian base. This is the "as `R` is
  Noetherian it suffices to enlarge the field" step Stacks uses three times.
* `IsFractionRing.finiteDimensional_of_finite` — `Frac S / Frac R` is finite-dimensional for
  **abstract** fraction fields when `S / R` is a finite extension of domains. Mathlib states
  this only for the concrete `FractionRing R` / `FractionRing S`, and that instance is not
  usable outside its own section. Stacks, Lemma 10.161.5 (tag 032I).

The third is proved by a direct spanning set rather than through
`Module.Finite.of_isLocalization`: that route needs
`IsLocalization (Algebra.algebraMapSubmonoid S R⁰) L`, and the only producer at the pin that
applies to a genuine extension `S / R` is `IsIntegralClosure.isLocalization`, which requires
`S` to *be* an integral closure — not assumed here. (The other instances producing that class
are the degenerate self-case `algebraMapSubmonoid R M` and a number-field-specific one, neither
of which applies.) Mathlib's own use of this route, at `DedekindDomain/Different.lean:772`,
goes through exactly that integral-closure producer and only for concrete `FractionRing`.

Part of the **normalization-finiteness (Nagata / N-2)** development: Noether's finiteness
theorem *without* a separability hypothesis. Mathlib currently proves only the separable case
(`IsIntegralClosure.finite`, through the trace form, which degenerates inseparably), so the
purely inseparable / Frobenius case is not available upstream. This file is one of the
independent leaves that case rests on.

**Roadmap target.** `TauCetiRoadmap/EllipticCurves/README.md:106-108, 1096` — the support
module `RingTheory/IntegralClosure/NormalizationFinite`, needed for module-finiteness of the
isogeny intermediate ring and through it the relative ideal norm.

Roadmap: EllipticCurves

## Series

One of **four independent leaf files** opening in parallel — this one has no in-repository
imports, so it stands alone and does not depend on the others. The dependent PRs (the purely
inseparable core, the assembly with the main theorem, and the consumer bridge) are already
proved and will open as their parents merge, per the project's no-stacking rule.

## Verification

Built against the pin on current `main` (`653c36f019`), not the pin the work was developed on:

- `lake build` exit 0 — **zero** diagnostics, checked for `info:` as well as errors and warnings
- axioms of every declaration: exactly `propext`, `Classical.choice`, `Quot.sound`
- no `sorry`, no `maxHeartbeats` override, no new `set_option`

## Absence claims re-verified at the pin

Every "Mathlib does not have this" statement above was re-checked **by shape, not by name**, against
`653c36f019` — the pin on current `main`, not the pin this was developed on:

- no `Nagata` / `Japanese ring` / `IsJapanese` anywhere in Mathlib;
- `IsIntegralClosure.finite` still sits under `variable [Algebra.IsSeparable K L]`, so the
  inseparable case is genuinely still open upstream;
- name-level matches for `finite_map`, `tower_bot`, `finite_of_injective`,
  `finiteDimensional_of_finite` were each run down and are unrelated (single-variable `Polynomial`,
  `IsIntegral.tower_bot`, Sylow, finite Galois groups);
- the section-local `attribute [local instance]` on `algebraMvPolynomial` and on
  `FractionRing.liftAlgebra` are both still in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWrLwxwLXS49cy8Mu5jagk
