### PR TITLE
feat(Huber): a Tate ring with every maximal ideal open is zero

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
@@ -86,7 +86,14 @@ theorem span_eq_top_of_forall_mem_spa_exists_not_vle_zero (Aplus : Subring A)
 `Spa(A, A⁺)` vanishes on `f`, then `f` is a unit.
 
 Wedhorn states this for a complete affinoid ring; as with the converse above, openness of the
-maximal ideals is what replaces completeness. -/
+maximal ideals is what replaces completeness.
+
+⚠ That replacement is not innocent: `hmax` is unsatisfiable over a nonzero Tate ring, so this
+statement and the converse above are vacuous on the affinoid rings Wedhorn applies them to. In a
+Tate ring an ideal is open exactly when it is `⊤`, so no proper ideal is open; see
+`TauCeti.Huber.IsTateRing.subsingleton_of_forall_isMaximal_isOpen`. A form usable for Tate rings
+has to reach the point of Proposition 7.51 without going through an open maximal ideal —
+`mem_of_forall_vle_one`, which is 7.52(1), avoids the problem entirely. -/
 theorem isUnit_of_forall_not_vle_zero (Aplus : Subring A)
     (hmax : ∀ (𝔪 : Ideal A), 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) {f : A}
     (h : ∀ v ∈ spa Aplus, ¬ v.toValuativeRel.vle f 0) : IsUnit f := by

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
@@ -91,6 +91,7 @@ maximal ideals is what replaces completeness.
 ⚠ That replacement is not innocent: `hmax` is unsatisfiable over a nonzero Tate ring, so this
 statement and the converse above are vacuous on the affinoid rings Wedhorn applies them to. In a
 Tate ring an ideal is open exactly when it is `⊤`, so no proper ideal is open; see
+`TauCeti.Huber.IsTateRing.not_isOpen_of_isMaximal`, and its consequence
 `TauCeti.Huber.IsTateRing.subsingleton_of_forall_isMaximal_isOpen`. A form usable for Tate rings
 has to reach the point of Proposition 7.51 without going through an open maximal ideal —
 `mem_of_forall_vle_one`, which is 7.52(1), avoids the problem entirely. -/

--- a/TauCeti/RingTheory/Huber/OpenIdeal.lean
+++ b/TauCeti/RingTheory/Huber/OpenIdeal.lean
@@ -105,6 +105,20 @@ theorem IsTateRing.isOpen_iff_eq_top [IsTateRing A] (J : Ideal A) :
     IsOpen (J : Set A) ↔ J = ⊤ :=
   ⟨IsTateRing.eq_top_of_isOpen, fun h ↦ h.symm ▸ isOpen_univ⟩
 
+/-- **A nonzero Tate ring has no open maximal ideal**, so requiring every maximal ideal to be
+open forces the ring to be zero: an open ideal is `⊤`, and a maximal ideal is proper.
+
+Worth naming because that hypothesis is easy to write down and impossible to satisfy. Wedhorn's
+Proposition 7.52(2) carries it, and the statements that inherit it — among them
+`TauCeti.ValuationSpectrum.isUnit_of_forall_not_vle_zero` — are therefore vacuous on exactly the
+affinoid rings they are meant for, since those are Tate. -/
+theorem IsTateRing.subsingleton_of_forall_isMaximal_isOpen [IsTateRing A]
+    (hmax : ∀ 𝔪 : Ideal A, 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) : Subsingleton A := by
+  rw [← not_nontrivial_iff_subsingleton]
+  intro _
+  obtain ⟨𝔪, h𝔪⟩ := Ideal.exists_maximal A
+  exact h𝔪.ne_top ((IsTateRing.isOpen_iff_eq_top 𝔪).mp (hmax 𝔪 h𝔪))
+
 end Tate
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/OpenIdeal.lean
+++ b/TauCeti/RingTheory/Huber/OpenIdeal.lean
@@ -105,19 +105,30 @@ theorem IsTateRing.isOpen_iff_eq_top [IsTateRing A] (J : Ideal A) :
     IsOpen (J : Set A) ↔ J = ⊤ :=
   ⟨IsTateRing.eq_top_of_isOpen, fun h ↦ h.symm ▸ isOpen_univ⟩
 
-/-- **A nonzero Tate ring has no open maximal ideal**, so requiring every maximal ideal to be
-open forces the ring to be zero: an open ideal is `⊤`, and a maximal ideal is proper.
+/-- **No maximal ideal of a Tate ring is open.** An open ideal is `⊤` and a maximal ideal is
+proper, so the two cannot meet. This is the sharp form: one maximal ideal is enough, and no
+hypothesis about the others is needed. -/
+theorem IsTateRing.not_isOpen_of_isMaximal [IsTateRing A] {𝔪 : Ideal A} (h𝔪 : 𝔪.IsMaximal) :
+    ¬ IsOpen (𝔪 : Set A) :=
+  fun h ↦ h𝔪.ne_top ((IsTateRing.isOpen_iff_eq_top 𝔪).mp h)
+
+/-- **Requiring every maximal ideal to be open forces a Tate ring to be zero**, since a nonzero
+ring has a maximal ideal and `IsTateRing.not_isOpen_of_isMaximal` says that one cannot be open.
 
 Worth naming because that hypothesis is easy to write down and impossible to satisfy. Wedhorn's
 Proposition 7.52(2) carries it, and the statements that inherit it — among them
 `TauCeti.ValuationSpectrum.isUnit_of_forall_not_vle_zero` — are therefore vacuous on exactly the
-affinoid rings they are meant for, since those are Tate. -/
+affinoid rings they are meant for, since those are Tate.
+
+Note the quantifier is doing real work: over the zero ring there is no maximal ideal, so `hmax`
+holds and the conclusion holds too. Dropping it to a single maximal ideal would give a statement
+whose own hypotheses are contradictory. -/
 theorem IsTateRing.subsingleton_of_forall_isMaximal_isOpen [IsTateRing A]
     (hmax : ∀ 𝔪 : Ideal A, 𝔪.IsMaximal → IsOpen (𝔪 : Set A)) : Subsingleton A := by
   rw [← not_nontrivial_iff_subsingleton]
   intro _
   obtain ⟨𝔪, h𝔪⟩ := Ideal.exists_maximal A
-  exact h𝔪.ne_top ((IsTateRing.isOpen_iff_eq_top 𝔪).mp (hmax 𝔪 h𝔪))
+  exact IsTateRing.not_isOpen_of_isMaximal h𝔪 (hmax 𝔪 h𝔪)
 
 end Tate
 


### PR DESCRIPTION
Wedhorn's Proposition 7.52(2) is stated with the hypothesis that every maximal ideal of `A` is
open. In a Tate ring that hypothesis is **unsatisfiable**: an ideal is open exactly when it is `⊤`
(`TauCeti.Huber.IsTateRing.isOpen_iff_eq_top`), and a maximal ideal is proper, so requiring it
forces the ring to be zero. The affinoid rings Wedhorn applies the proposition to are Tate, so
the statements carrying the hypothesis are vacuous precisely where they are meant to be used.

This names the obstruction and warns where the trap is. It does not attempt the repair.

## Why it is worth naming rather than leaving implicit

The hypothesis is inherited easily and silently — it reads like a mild regularity condition. At
the time this was first noticed, no merged statement carried it. Today six do, across three files:

* `Spa/Points.lean` — `span_eq_top_of_forall_mem_spa_exists_not_vle_zero`,
  `isUnit_of_forall_not_vle_zero`
* `Spa/Localization/UniversalProperty.lean` — two statements
* `Spa/RationalSubset/Basic.lean` — two statements

Nothing on `main` is unsound as a result; the statements are true, just empty over their intended
rings. What this PR buys is that the emptiness is now machine-checked and documented at the site,
so the next author does not inherit it unnoticed.

## Placement

The lemma goes in `RingTheory/Huber/OpenIdeal.lean`, next to `IsTateRing.isOpen_iff_eq_top`,
which is the fact it is one step from — not in `Spa/Points.lean` beside the affected statement.
`Points.lean` does not import the Tate API and has three importers of its own, so putting it
there would have widened their import surface for a two-line consequence. `Points.lean` instead
gets a docstring warning that names the new lemma, which needs no import.

## What a real fix needs

A form of 7.52(2) for complete Tate rings that does not route through open maximal ideals. The
current proof uses openness only to turn a maximal ideal into a point of `Spa` via Proposition
7.51; the repair is a different route to that point. `mem_of_forall_vle_one` — 7.52(1) — already
avoids the problem and is the signpost.

## Gate

`lake build` of both changed modules and every direct importer — `Spa/Analytic`,
`RationalSubset/{Basic,Basis}`, `Localization/UniversalProperty`,
`Topology/Algebra/Nonarchimedean/MaximalIdeals` — 2169 jobs, no errors, warnings or sorries.

Roadmap: AdicSpaces
