### PR TITLE
feat(FormalGroup): base change of the addition series

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Series.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Series.lean
@@ -32,6 +32,9 @@ That series is `formalAdd`, and it is the series underlying the elliptic formal 
   `FormalGroup` carries this as its `zero_constantCoeff` field.
 * `WeierstrassCurve.rename_swap_formalAdd`: `F(z₂, z₁) = F(z₁, z₂)`. The chord does not depend
   on the order of its two points, so the group law is commutative.
+* `WeierstrassCurve.map_formalAdd`: `F` commutes with base change along a ring homomorphism,
+  completing the base-change block that `Chord.lean` and `Inverse.lean` already carry for the
+  two series `F` is built from.
 
 ## Implementation notes
 
@@ -55,7 +58,8 @@ Adapted from Michael Stoll's `EllipticCurves` project
 (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
 `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
 `EllipticCurves/WeierstrassFormalGroup/Chord.lean` — declarations `addSeries`,
-`hasSubst_thirdRootSeries`, `constantCoeff_addSeries` and `rename_swap_addSeries`.
+`hasSubst_thirdRootSeries`, `constantCoeff_addSeries`, `rename_swap_addSeries` and
+`map_addSeries`.
 
 The source's `addSeries` is named `formalAdd` here, continuing the renaming this repository
 already applies to the rest of that file: the source's `wSeries`, `vSeries`, `slopeSeries`,
@@ -106,5 +110,21 @@ theorem rename_swap_formalAdd : rename Sum.swap (formalAdd W) = formalAdd W := b
   congr 1
   funext u
   rw [← rename_eq_subst, rename_swap_formalThirdRoot W]
+
+section BaseChange
+
+variable {S : Type*} [CommRing S] (φ : R →+* S)
+
+/-- **The addition series commutes with base change.** -/
+@[simp]
+theorem map_formalAdd :
+    formalAdd (W.map φ) = MvPowerSeries.map φ (formalAdd W) := by
+  rw [formalAdd_def, formalAdd_def, MvPowerSeries.map_subst (hasSubst_formalThirdRoot W)]
+  congr 1
+  · funext _
+    exact map_formalThirdRoot W φ
+  · exact map_formalInverse W φ
+
+end BaseChange
 
 end WeierstrassCurve


### PR DESCRIPTION
`Chord.lean` and `Inverse.lean` each carry a base-change lemma for every series they build, and
the addition series `F(z₁, z₂) = ι(z₃(z₁, z₂))` was the one left without one. This adds it, so the
chord construction's base-change block is complete.

Roadmap: EllipticCurves

## What is added

* `WeierstrassCurve.map_formalAdd` — `formalAdd (W.map φ) = MvPowerSeries.map φ (formalAdd W)`,
  tagged `@[simp]` like its six siblings.

One theorem, six lines of proof, no helpers and no new general lemma: the general fact it needs
("`map` commutes with `subst`") is already Mathlib's `MvPowerSeries.map_subst`
(`RingTheory/MvPowerSeries/Substitution.lean:349`), so nothing had to be added for it.

## Placement

In `FormalGroup/AddSeries.lean`, beside `formalAdd` itself. That follows the block's existing
convention rather than inventing one: `map_formalThirdRoot` lives in `Chord.lean` and
`map_formalInverse` in `Inverse.lean`, i.e. each `map_` lemma sits in the file that defines its
object. There is no `FormalGroup/Map.lean` on main.

**A note for whoever merges second.** #4845 is open and *renames*
`FormalGroup/AddSeries.lean` → `FormalGroup/Add/Series.lean` (confirmed by `status: renamed` in
its file list). `git merge-tree` of this branch against #4845's head is clean — the rename carries
this addition with it — but if #4845 lands first, this lemma should end up in `Add/Series.lean`,
which is the same "beside `formalAdd`" rule applied to the new path. Nothing here needs to change
for that; it is a rename, not a relocation of the declaration.

## Orientation

Stated in the house orientation, `object (W.map φ) = map φ (object W)`, matching
`map_formalThirdRoot` and `map_formalInverse`. The source states the mirror image
(`map φ W.addSeries = (W.map φ).addSeries`); flipping it is not cosmetic — in the house
orientation the two `congr` subgoals land *exactly* on the house lemmas
`map_formalThirdRoot` / `map_formalInverse`, so the proof needs no `.symm` anywhere and is a line
shorter than the source's.

## Parents

Both parents are merged, and verified **by content** rather than by `mergedAt`:

| dependency | on main in |
|---|---|
| `formalAdd`, `hasSubst_formalThirdRoot` | `FormalGroup/AddSeries.lean` (#4819) |
| `map_formalThirdRoot` | `FormalGroup/Chord.lean` (#4832) |
| `map_formalInverse` | `FormalGroup/Inverse.lean` (#4832) |

## Provenance

Adapted from Michael Stoll's `EllipticCurves` project
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`),
`EllipticCurves/WeierstrassFormalGroup/Chord.lean` — declaration `map_addSeries`, the seventh and
last of that file's naturality block. The house renaming of the source's `addSeries`,
`thirdRootSeries` and `inverseSeries` to `formalAdd`, `formalThirdRoot` and `formalInverse` is the
one this file already applies; source names appear only in the Provenance section.

## Roadmap and consumer

Advances milestone (i) of `TauCetiRoadmap/EllipticCurves/README.md:572-574` — the elliptic formal
group *law* `Ê` as an instance of Mathlib's `RingTheory/FormalGroup`. The named consumer is FG-3
(`assoc_addSeries_universal`), which transports the associativity identity from the universal
curve and so needs `formalAdd`'s base change; that is on milestone (i)'s critical path.

## Verification

`lake build TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.AddSeries` →
`Build completed successfully` (2067 jobs, 27 s), exit 0, `.olean` written, and **no diagnostics
of any severity** — green on the first attempt. `AddSeries.lean` has no importers in `TauCeti/`,
so it is the whole module-scoped gate. Mathlib is the manifest pin
`653c36f019ec26896d6bf8b738b41c9ea99c7d16`. The full build is CI's `pr-build`; `lint-env.sh` needs
every `TauCeti/**` olean and so cannot run in a module-scoped worktree, leaving the environment
linters to CI.

Absence re-checked at the current tip (`350a0888`) under **both** spellings — `map_formalAdd` and
the source's `map_addSeries` — each 0 files on `origin/main`, with a negative control
(`zzznotreal`, absent) and a positive control (`MvPowerSeries`, present) proving the instrument
discriminates. Unscoped `git merge-tree` against every open PR touching `FormalGroup/`
(#4845, #4818, #4860, #4868) is clean, each checked with its live head verified against
`FETCH_HEAD`.

OPENED: #4892 (substrate: evaluating a substitution over non-discrete coefficients). That plus
this one is 2 open PRs.
