### PR TITLE
refactor(Quadratic): drop the redundant nonzeroness hypothesis, +1 case

### DIFF
--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Units.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Units.lean
@@ -42,8 +42,10 @@ embedding of a quadratic field is one fixed embedding, or that embedding compose
 real embeddings give `u` the same sign. -/
 theorem isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_one
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) {u : 𝓞 K}
-    (hu : u ≠ 0) (hnorm : u * ringOfIntegersQuadraticConj hmin hgen u = 1) :
+    (hnorm : u * ringOfIntegersQuadraticConj hmin hgen u = 1) :
     IsTotallyPositive (u : K) ∨ IsTotallyPositive (-(u : K)) := by
+  -- `u = 0` would make the norm `0`, not `1`.
+  have hu : u ≠ 0 := by rintro rfl; simp at hnorm
   have huK : (u : K) ≠ 0 := RingOfIntegers.coe_ne_zero_iff.mpr hu
   have hσ : (u : K) * quadraticConj hmin hgen (u : K) = 1 := by
     simpa [coe_ringOfIntegersQuadraticConj] using congrArg (fun x : 𝓞 K => (x : K)) hnorm
@@ -108,7 +110,7 @@ theorem exists_isTotallyPositive_notMem_square (hmin : minpoly ℤ θ = X ^ 2 - 
     rintro x -
     obtain ⟨u, rfl⟩ := QuotientGroup.mk'_surjective H x
     rcases isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_one hmin hgen
-      u.ne_zero (hnorm u) with h | h
+      (hnorm u) with h | h
     · exact ⟨0, by simp, by simpa using ((QuotientGroup.eq_one_iff _).mpr (hsquare u h)).symm⟩
     · refine ⟨1, by simp, ?_⟩
       rw [QuotientGroup.mk'_apply, QuotientGroup.eq]


### PR DESCRIPTION
Remove a hypothesis that is a consequence, in the `+1` case of the quadratic norm dichotomy.

## What changes

`isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_one` took both

```
(hu : u ≠ 0) (hnorm : u * ringOfIntegersQuadraticConj hmin hgen u = 1)
```

but the second forces the first: `u = 0` makes the norm `0`, not `1`. `hu` is now derived inside
the proof in one line, and the lemma's single caller (same file) no longer passes `u.ne_zero`.

`hu` was genuinely *used* in the proof — that is why it survived — it simply did not need to be
assumed.

## Why separately from #4854

#4854 made exactly this change to the `-1` companion
`isTotallyPositive_or_neg_of_mul_ringOfIntegersQuadraticConj_eq_neg_one`, and deliberately left
this one alone: removing a hypothesis from an already-merged public lemma is a signature change
with its own call site, so it belongs in its own commit rather than bundled into the PR that
introduced the companion. That PR's body and commit message both said so. This is the promised
follow-up, and it makes the pair symmetric again.

## Notes for review

- One file, +4/−2. No new imports.
- Gate: `lake build` of `Conjugation.Units`, its importer
  `Multiquadratic.Quadratic.RamifiedPrime.Narrow`, and `Quadratic.TwoRank` — **3558 jobs, exit 0,
  zero warnings**.
- The lemma has no other user in the tree (`git grep` finds only the definition and its one call).

Roadmap: Multiquadratic
