### PR TITLE
feat(Huber): topological finite type is stable under open quotients

### DIFF
--- a/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
+++ b/TauCeti/RingTheory/Huber/TopologicallyFiniteType.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Topology.Algebra.Ring.Ideal
 public import TauCeti.RingTheory.Huber.WeightedRestrictedSeries.Completion
 
 /-!
@@ -69,6 +70,15 @@ it.
   topologically of finite type implies topologically of finite type, by the trivial weight family.
 * `TauCeti.Huber.IsTopologicallyFiniteType.continuous`: such a `φ` is continuous, since it factors
   through the presenting algebra's structure map.
+* `TauCeti.Huber.IsStrictlyTopologicallyFiniteType.comp_isOpenQuotientMap` and
+  `TauCeti.Huber.IsTopologicallyFiniteType.comp_isOpenQuotientMap`: both notions are stable under
+  composing with a further open quotient map.
+* `TauCeti.Huber.IsStrictlyTopologicallyFiniteType.quotientMk` and
+  `TauCeti.Huber.IsTopologicallyFiniteType.quotientMk`: in particular, stable under passing to a
+  quotient by an ideal.
+* `TauCeti.Huber.isStrictlyTopologicallyFiniteType_quotientMk_algebraMap`: every quotient of
+  `A⟨X₁, …, Xₖ⟩` is strictly topologically of finite type over `A` — the shape of every Laurent
+  and rational presentation.
 
 ## References
 
@@ -139,5 +149,62 @@ theorem IsTopologicallyFiniteType.continuous {φ : A →+* B} (h : IsTopological
   obtain ⟨k, T, _, hT, π, hπ, hcomm⟩ := h
   rw [← hcomm]
   exact hπ.continuous.comp (continuous_algebraMap_completion_weightedRestrictedSubring k A hT)
+
+/-! ### Stability under a further open quotient
+
+Wedhorn presents an algebra topologically of finite type as an open quotient of a restricted
+power-series ring, so composing that presentation with another open quotient map is again a
+presentation of the same shape. This is what lets a *quotient* of `A⟨X₁, …, Xₖ⟩` — the form every
+rational localisation and Laurent presentation takes — inherit finite type without exhibiting a
+fresh presentation by hand.
+-/
+
+section OpenQuotient
+
+variable {C : Type*} [CommRing C] [TopologicalSpace C]
+
+/-- **A strict presentation pushes along an open quotient map.** If `φ : A → B` is strictly
+topologically of finite type and `ψ : B → C` is an open quotient map, then so is `ψ ∘ φ`: compose
+the presenting `A⟨X₁, …, Xₖ⟩ ↠ B` with `ψ`, and use that open quotient maps compose. -/
+theorem IsStrictlyTopologicallyFiniteType.comp_isOpenQuotientMap {φ : A →+* B} {ψ : B →+* C}
+    (h : IsStrictlyTopologicallyFiniteType φ) (hψ : IsOpenQuotientMap ψ) :
+    IsStrictlyTopologicallyFiniteType (ψ.comp φ) := by
+  obtain ⟨k, π, hπ, hcomm⟩ := h
+  exact ⟨k, ψ.comp π, hψ.comp hπ, by rw [RingHom.comp_assoc, hcomm]⟩
+
+/-- **A presentation pushes along an open quotient map**, the weighted form of
+`TauCeti.Huber.IsStrictlyTopologicallyFiniteType.comp_isOpenQuotientMap`. The weight family is
+carried across unchanged; only the presenting map moves. -/
+theorem IsTopologicallyFiniteType.comp_isOpenQuotientMap {φ : A →+* B} {ψ : B →+* C}
+    (h : IsTopologicallyFiniteType φ) (hψ : IsOpenQuotientMap ψ) :
+    IsTopologicallyFiniteType (ψ.comp φ) := by
+  obtain ⟨k, T, hTfin, hT, π, hπ, hcomm⟩ := h
+  exact ⟨k, T, hTfin, hT, ψ.comp π, hψ.comp hπ, by rw [RingHom.comp_assoc, hcomm]⟩
+
+variable [IsTopologicalRing B]
+
+/-- **Strict finite type passes to a quotient by an ideal.** The quotient map of a topological
+ring is an open quotient map, so this is the previous lemma at `ψ = Ideal.Quotient.mk I`. -/
+theorem IsStrictlyTopologicallyFiniteType.quotientMk {φ : A →+* B}
+    (h : IsStrictlyTopologicallyFiniteType φ) (I : Ideal B) :
+    IsStrictlyTopologicallyFiniteType ((Ideal.Quotient.mk I).comp φ) :=
+  h.comp_isOpenQuotientMap (QuotientRing.isOpenQuotientMap_mk I)
+
+/-- **Finite type passes to a quotient by an ideal.** -/
+theorem IsTopologicallyFiniteType.quotientMk {φ : A →+* B} (h : IsTopologicallyFiniteType φ)
+    (I : Ideal B) : IsTopologicallyFiniteType ((Ideal.Quotient.mk I).comp φ) :=
+  h.comp_isOpenQuotientMap (QuotientRing.isOpenQuotientMap_mk I)
+
+/-- **Every quotient of `A⟨X₁, …, Xₖ⟩` is strictly topologically of finite type over `A`.** This is
+the form every Laurent and rational presentation takes — Wedhorn's Examples 6.38 and 6.39 exhibit
+their rings this way — so it is the statement those examples reduce to once the presenting ideal
+is named. -/
+theorem isStrictlyTopologicallyFiniteType_quotientMk_algebraMap (k : ℕ)
+    (I : Ideal (restrictedMvPowerSeriesCompletion k A)) :
+    IsStrictlyTopologicallyFiniteType
+      ((Ideal.Quotient.mk I).comp (algebraMap A (restrictedMvPowerSeriesCompletion k A))) :=
+  (isStrictlyTopologicallyFiniteType_algebraMap k).quotientMk I
+
+end OpenQuotient
 
 end TauCeti.Huber


### PR DESCRIPTION
Wedhorn presents an algebra topologically of finite type as an *open quotient* of a restricted
power-series ring `A⟨X₁, …, Xₖ⟩`. Composing such a presentation with a further open quotient map is
again a presentation of the same shape, so both `IsTopologicallyFiniteType` and its strict form are
stable under further open quotients — and in particular under passing to a quotient by an ideal.

This adds those stability lemmas to the file that defines the two predicates, together with the
corollary they exist for: **every quotient of `A⟨X₁, …, Xₖ⟩` is strictly topologically of finite
type over `A`**. That is the shape every Laurent and rational presentation takes, so it is the
statement Wedhorn's Examples 6.38 and 6.39 reduce to once the presenting ideal is named.

### What is here

* `IsStrictlyTopologicallyFiniteType.comp_isOpenQuotientMap` and
  `IsTopologicallyFiniteType.comp_isOpenQuotientMap` — compose a presentation with an open
  quotient map. The witness is the composed presenting map; open quotient maps compose
  (`IsOpenQuotientMap.comp`), and the weight family is carried across unchanged.
* `IsStrictlyTopologicallyFiniteType.quotientMk` and `IsTopologicallyFiniteType.quotientMk` — the
  same at `ψ = Ideal.Quotient.mk I`, using Mathlib's `QuotientRing.isOpenQuotientMap_mk`.
* `isStrictlyTopologicallyFiniteType_quotientMk_algebraMap` — the corollary above, obtained from
  `isStrictlyTopologicallyFiniteType_algebraMap` (the presentation by the identity).

### What is not here

Not Example 6.39 itself. This PR names no ring: it does not construct `A⟨X,X⁻¹⟩`, the ideal
`(XY − 1)`, or the isomorphism `A⟨X,X⁻¹⟩ ≅ A⟨X,Y⟩/(XY − 1)`. The completed ring
`A⟨X₁, …, Xₖ⟩` has no variables exposed yet (`restrictedX` exists only for the *subring* at
`k = 1`, in `Restricted/Laurent.lean`), so `XY − 1` is not currently expressible; naming it is
separate work. This PR is the general stability fact that work will consume.

### Why it is needed, and a note for whoever builds Example 6.39

Measured against Wedhorn's text while scoping Example 6.39 for Layer 4.1 step 5: the *second*
sentence of 6.39 ("`A⟨X,X⁻¹⟩` is an `A`-algebra topologically of finite type") is exactly the
corollary added here, once the ideal is named. The *first* sentence — the two-sided series ring —
is genuinely separate, and Lemma 8.33's proof needs more from it than the isomorphism does: its
diagram chase uses the decomposition `A⟨ζ,ζ⁻¹⟩ = A⟨ζ⟩ + ζ⁻¹A⟨ζ⁻¹⟩`, the matching ideal
decomposition, and uniqueness of the coefficients of a two-sided series. None of those follows
from the universal property alone. That is recorded on the tracking issue; it does not affect the
correctness of anything in this PR, which is self-contained.

### Prior art

`IsOpenQuotientMap.comp` and `QuotientRing.isOpenQuotientMap_mk` are Mathlib's and are reused
rather than reproved; the only new import is `Mathlib.Topology.Algebra.Ring.Ideal`, for the
quotient-ring topology and that lemma. Nothing on `main` states stability of either predicate
under quotients — checked by statement across `TauCeti/RingTheory/Huber/`.

Roadmap: AdicSpaces
