### PR TITLE
feat(Huber): two-sided restricted series, and Wedhorn's convergence criterion

### DIFF
--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Order.Filter.ZeroAndBoundedAtFilter
 public import TauCeti.Topology.Algebra.Nonarchimedean.ZeroAtFilter
 
 /-!
@@ -80,9 +79,13 @@ section Submodule
 variable (A M : Type*) [Semiring A] [AddCommMonoid M] [TopologicalSpace M] [Module A M]
   [ContinuousAdd M] [ContinuousConstSMul A M]
 
-/-- **The two-sided restricted families `A⟨X, X⁻¹⟩`** of Wedhorn's Example 6.39: the `A`-module of
-families `ℤ → M` tending to `0` along the cofinite filter, i.e. those `∑_{n ∈ ℤ} aₙ Xⁿ` for which
-every neighbourhood of zero omits only finitely many coefficients.
+/-- **The two-sided restricted `M`-valued families**: the `A`-module of families `ℤ → M` tending
+to `0` along the cofinite filter, i.e. those whose coefficients leave every neighbourhood of zero
+finitely often.
+
+At `M = A` this is the coefficient object of Wedhorn's `A⟨X, X⁻¹⟩` (Example 6.39). It is only the
+*coefficients*: no ring structure is defined here, so this is not yet that algebra — see the
+implementation notes.
 
 This is `TauCeti.Huber.restrictedMvPowerSeriesSubmodule`'s condition at the index set `ℤ`, and is
 built from the same Mathlib primitive. -/
@@ -91,14 +94,15 @@ def twoSidedRestrictedSubmodule : Submodule A (ℤ → M) :=
 
 variable {A M}
 
-/-- Membership in `A⟨X, X⁻¹⟩` is the convergence condition on the coefficients. -/
+/-- Membership is the convergence condition on the coefficient family. -/
 @[simp]
 theorem mem_twoSidedRestrictedSubmodule {f : ℤ → M} :
     f ∈ twoSidedRestrictedSubmodule A M ↔ ZeroAtFilter cofinite f := (Iff.rfl)
 
-/-- **Coefficientwise extensionality** for `A⟨X, X⁻¹⟩`: a two-sided restricted family is
-determined by its coefficients. This is the uniqueness statement the two-piece Laurent cover's
-diagram chase consumes when it compares `∑ aₖ ζᵏ` with `∑ bₖ ζ⁻ᵏ`. -/
+/-- **Coefficientwise extensionality**: two members of the submodule that agree at every index are
+equal. This is subtype-and-function extensionality, nothing more — in particular it does *not* say
+that a coefficient family is recovered from any sum it represents, which would need an evaluation
+map that does not exist until there is a ring structure. -/
 @[ext]
 theorem twoSidedRestrictedSubmodule_ext {f g : twoSidedRestrictedSubmodule A M}
     (h : ∀ n, (f : ℤ → M) n = (g : ℤ → M) n) : f = g :=
@@ -111,13 +115,15 @@ section WedhornCriterion
 variable {A M : Type*} [Semiring A] [AddCommGroup M] [TopologicalSpace M] [Module A M]
   [ContinuousConstSMul A M] [NonarchimedeanAddGroup M]
 
-/-- **Example 6.39's defining condition, verbatim**: a two-sided family lies in `A⟨X, X⁻¹⟩`
-exactly when, for every open additive subgroup, only finitely many of its coefficients lie
-outside. -/
+/-- **The membership criterion in Wedhorn's form**: a family lies in the submodule exactly when,
+for every open additive subgroup, only finitely many of its members lie outside. At `M = A` this
+is Example 6.39's defining condition on the coefficients, verbatim. -/
+@[simp]
 theorem mem_twoSidedRestrictedSubmodule_iff_finite_notMem {f : ℤ → M} :
     f ∈ twoSidedRestrictedSubmodule A M ↔
-      ∀ W : OpenAddSubgroup M, {n | f n ∉ (W : Set M)}.Finite :=
-  NonarchimedeanAddGroup.zeroAtFilter_cofinite_iff_finite_notMem
+      ∀ W : OpenAddSubgroup M, {n | f n ∉ (W : Set M)}.Finite := by
+  rw [mem_twoSidedRestrictedSubmodule]
+  exact NonarchimedeanAddGroup.zeroAtFilter_cofinite_iff_finite_notMem
 
 end WedhornCriterion
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -5,7 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.RingTheory.Huber.Restricted.PowerSeries
+public import Mathlib.Order.Filter.ZeroAndBoundedAtFilter
+public import TauCeti.Topology.Algebra.Nonarchimedean.ZeroAtFilter
 
 /-!
 # Two-sided restricted series `A⟨X, X⁻¹⟩`
@@ -46,13 +47,12 @@ a placement hazard:
 
 ## Main results
 
-* `TauCeti.Huber.zeroAtFilter_cofinite_iff_finite_notMem`: over a nonarchimedean additive group,
-  a family tends to `0` cofinitely **iff** all but finitely many of its members lie in each open
-  additive subgroup. This is Wedhorn's phrasing of the condition, and the `←` direction is what
-  makes it usable as a criterion rather than only as a consequence. Stated for an arbitrary index
-  type, since neither direction looks at the index set.
-* `TauCeti.Huber.mem_twoSidedRestrictedSubmodule_iff_finite_notMem`: that criterion at `ℤ`, which
-  is Example 6.39's defining condition verbatim.
+* `TauCeti.Huber.mem_twoSidedRestrictedSubmodule_iff_finite_notMem`: Example 6.39's defining
+  condition verbatim — membership is the finiteness condition on open additive subgroups. It is
+  the `ℤ` case of `NonarchimedeanAddGroup.zeroAtFilter_cofinite_iff_finite_notMem`, which is
+  stated for an arbitrary index type in
+  `TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean` because neither direction of it
+  looks at the index set or at series.
 * `TauCeti.Huber.twoSidedRestrictedSubmodule_ext`: coefficientwise extensionality.
 
 ## Implementation notes
@@ -74,33 +74,6 @@ public section
 open Filter Topology
 
 namespace TauCeti.Huber
-
-section Criterion
-
-variable {ι : Type*} {G : Type*} [AddGroup G] [TopologicalSpace G]
-
-/-- **Restrictedness, as Wedhorn states it.** A family tends to `0` along the cofinite filter
-exactly when, for every open additive subgroup `W`, all but finitely many of its members lie in
-`W`.
-
-The `→` direction holds in any topological additive group, and is the form
-`TauCeti.Huber.IsRestricted.finite_coeff_notMem` records for one-sided series. The `←` direction
-is where nonarchimedeanness enters: it supplies an open subgroup inside each neighbourhood of
-zero, which turns the family of open subgroups into a neighbourhood basis and so upgrades the
-consequence into a criterion.
-
-Neither direction inspects the index set, so `ι` is arbitrary. -/
-theorem zeroAtFilter_cofinite_iff_finite_notMem [NonarchimedeanAddGroup G] {f : ι → G} :
-    ZeroAtFilter cofinite f ↔ ∀ W : OpenAddSubgroup G, {n | f n ∉ (W : Set G)}.Finite := by
-  refine ⟨fun hf W ↦ ?_, fun h ↦ ?_⟩
-  · have := (tendsto_nhds.mp hf) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
-    rwa [Filter.mem_cofinite] at this
-  · refine tendsto_nhds.mpr fun U hU h0 ↦ ?_
-    obtain ⟨W, hWU⟩ := NonarchimedeanAddGroup.is_nonarchimedean U (hU.mem_nhds h0)
-    rw [Filter.mem_cofinite]
-    exact (h W).subset fun n hn ↦ fun hnW ↦ hn (hWU hnW)
-
-end Criterion
 
 section Submodule
 
@@ -144,7 +117,7 @@ outside. -/
 theorem mem_twoSidedRestrictedSubmodule_iff_finite_notMem {f : ℤ → M} :
     f ∈ twoSidedRestrictedSubmodule A M ↔
       ∀ W : OpenAddSubgroup M, {n | f n ∉ (W : Set M)}.Finite :=
-  zeroAtFilter_cofinite_iff_finite_notMem
+  NonarchimedeanAddGroup.zeroAtFilter_cofinite_iff_finite_notMem
 
 end WedhornCriterion
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Huber.Restricted.PowerSeries
+
+/-!
+# Two-sided restricted series `A⟨X, X⁻¹⟩`
+
+Wedhorn's Example 6.39 introduces, for a Tate ring `A`, the ring of formal series
+`∑_{n ∈ ℤ} aₙ Xⁿ` whose coefficients satisfy a convergence condition: for every neighbourhood `U`
+of zero, all but finitely many `aₙ` lie in `U`. This module builds the underlying coefficient
+object — the `A`-module of such two-sided families — together with its coefficients and
+extensionality.
+
+The condition is exactly the one `TauCeti.Huber.IsRestricted` already expresses for the
+one-sided series `A⟨X₁, …, Xₖ⟩`: a coefficient family tending to `0` along the cofinite filter,
+i.e. Mathlib's `Filter.ZeroAtFilter` at `Filter.cofinite`. Nothing in that predicate refers to the
+shape of the index set, so the two-sided object is the same notion indexed by `ℤ` rather than by
+`Fin k →₀ ℕ`, and is built from the same Mathlib primitive
+(`Filter.zeroAtFilterSubmodule`) that `TauCeti.Huber.restrictedMvPowerSeriesSubmodule` is built
+from.
+
+## Why this file is not called `Laurent`
+
+Two neighbouring modules already use that word for different objects, and a third meaning would be
+a placement hazard:
+
+* `TauCeti.RingTheory.Huber.Restricted.Laurent` is Wedhorn's **Example 6.38** — the *Laurent
+  rational subsets* `{|f| ≤ 1}` and `{|f| ≥ 1}`, whose coordinate rings `A⟨X⟩/(f - X)` and
+  `A⟨X⟩/(1 - f X)` are quotients of the **one-sided** `A⟨X⟩`. Those are the two *pieces* of the
+  cover whose *overlap* is the ring this file serves.
+* `TauCeti.RingTheory.Huber.LaurentSeries` is the formal Laurent series **field** `K⸨X⸩` over a
+  *field* `K` with the `X`-adic topology. That is a different object in three ways: its base is a
+  field rather than an arbitrary Tate ring, its series have only finitely many negative terms, and
+  its topology is `X`-adic rather than coefficientwise. It is **not** reusable here; the
+  distinguishing feature is precisely the convergence condition on the coefficients.
+
+## Main definitions
+
+* `TauCeti.Huber.twoSidedRestrictedSubmodule`: the `A`-module of two-sided restricted families,
+  the coefficient object underlying `A⟨X, X⁻¹⟩`.
+
+## Main results
+
+* `TauCeti.Huber.zeroAtFilter_cofinite_iff_finite_notMem`: over a nonarchimedean additive group,
+  a family tends to `0` cofinitely **iff** all but finitely many of its members lie in each open
+  additive subgroup. This is Wedhorn's phrasing of the condition, and the `←` direction is what
+  makes it usable as a criterion rather than only as a consequence. Stated for an arbitrary index
+  type, since neither direction looks at the index set.
+* `TauCeti.Huber.mem_twoSidedRestrictedSubmodule_iff_finite_notMem`: that criterion at `ℤ`, which
+  is Example 6.39's defining condition verbatim.
+* `TauCeti.Huber.twoSidedRestrictedSubmodule_ext`: coefficientwise extensionality.
+
+## Implementation notes
+
+Only the additive and `A`-module structure is built here. The **ring** structure is deliberately
+absent: the coefficient convolution `(fg)ₙ = ∑_{i + j = n} aᵢ bⱼ` is a *finite* sum for one-sided
+series — which is what `TauCeti.Huber.IsRestricted.mul` exploits, through
+`MvPowerSeries.coeff_mul` over a finite antidiagonal — but over `ℤ` that antidiagonal is infinite,
+so multiplication needs a summability argument in a complete ring rather than a rearrangement of a
+finite sum. That is separate work and does not belong to this rung.
+
+## References
+
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Example 6.39.
+-/
+
+public section
+
+open Filter Topology
+
+namespace TauCeti.Huber
+
+section Criterion
+
+variable {ι : Type*} {G : Type*} [AddGroup G] [TopologicalSpace G]
+
+/-- **Restrictedness, as Wedhorn states it.** A family tends to `0` along the cofinite filter
+exactly when, for every open additive subgroup `W`, all but finitely many of its members lie in
+`W`.
+
+The `→` direction holds in any topological additive group, and is the form
+`TauCeti.Huber.IsRestricted.finite_coeff_notMem` records for one-sided series. The `←` direction
+is where nonarchimedeanness enters: it supplies an open subgroup inside each neighbourhood of
+zero, which turns the family of open subgroups into a neighbourhood basis and so upgrades the
+consequence into a criterion.
+
+Neither direction inspects the index set, so `ι` is arbitrary. -/
+theorem zeroAtFilter_cofinite_iff_finite_notMem [NonarchimedeanAddGroup G] {f : ι → G} :
+    ZeroAtFilter cofinite f ↔ ∀ W : OpenAddSubgroup G, {n | f n ∉ (W : Set G)}.Finite := by
+  refine ⟨fun hf W ↦ ?_, fun h ↦ ?_⟩
+  · have := (tendsto_nhds.mp hf) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
+    rwa [Filter.mem_cofinite] at this
+  · refine tendsto_nhds.mpr fun U hU h0 ↦ ?_
+    obtain ⟨W, hWU⟩ := NonarchimedeanAddGroup.is_nonarchimedean U (hU.mem_nhds h0)
+    rw [Filter.mem_cofinite]
+    exact (h W).subset fun n hn ↦ fun hnW ↦ hn (hWU hnW)
+
+end Criterion
+
+section Submodule
+
+variable (A M : Type*) [Semiring A] [AddCommMonoid M] [TopologicalSpace M] [Module A M]
+  [ContinuousAdd M] [ContinuousConstSMul A M]
+
+/-- **The two-sided restricted families `A⟨X, X⁻¹⟩`** of Wedhorn's Example 6.39: the `A`-module of
+families `ℤ → M` tending to `0` along the cofinite filter, i.e. those `∑_{n ∈ ℤ} aₙ Xⁿ` for which
+every neighbourhood of zero omits only finitely many coefficients.
+
+This is `TauCeti.Huber.restrictedMvPowerSeriesSubmodule`'s condition at the index set `ℤ`, and is
+built from the same Mathlib primitive. -/
+def twoSidedRestrictedSubmodule : Submodule A (ℤ → M) :=
+  Filter.zeroAtFilterSubmodule A (Filter.cofinite : Filter ℤ)
+
+variable {A M}
+
+/-- Membership in `A⟨X, X⁻¹⟩` is the convergence condition on the coefficients. -/
+@[simp]
+theorem mem_twoSidedRestrictedSubmodule {f : ℤ → M} :
+    f ∈ twoSidedRestrictedSubmodule A M ↔ ZeroAtFilter cofinite f := (Iff.rfl)
+
+/-- **Coefficientwise extensionality** for `A⟨X, X⁻¹⟩`: a two-sided restricted family is
+determined by its coefficients. This is the uniqueness statement the two-piece Laurent cover's
+diagram chase consumes when it compares `∑ aₖ ζᵏ` with `∑ bₖ ζ⁻ᵏ`. -/
+@[ext]
+theorem twoSidedRestrictedSubmodule_ext {f g : twoSidedRestrictedSubmodule A M}
+    (h : ∀ n, (f : ℤ → M) n = (g : ℤ → M) n) : f = g :=
+  Subtype.ext (funext h)
+
+end Submodule
+
+section WedhornCriterion
+
+variable {A M : Type*} [Semiring A] [AddCommGroup M] [TopologicalSpace M] [Module A M]
+  [ContinuousConstSMul A M] [NonarchimedeanAddGroup M]
+
+/-- **Example 6.39's defining condition, verbatim**: a two-sided family lies in `A⟨X, X⁻¹⟩`
+exactly when, for every open additive subgroup, only finitely many of its coefficients lie
+outside. -/
+theorem mem_twoSidedRestrictedSubmodule_iff_finite_notMem {f : ℤ → M} :
+    f ∈ twoSidedRestrictedSubmodule A M ↔
+      ∀ W : OpenAddSubgroup M, {n | f n ∉ (W : Set M)}.Finite :=
+  zeroAtFilter_cofinite_iff_finite_notMem
+
+end WedhornCriterion
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -117,8 +117,12 @@ variable {A M : Type*} [Semiring A] [AddCommGroup M] [TopologicalSpace M] [Modul
 
 /-- **The membership criterion in Wedhorn's form**: a family lies in the submodule exactly when,
 for every open additive subgroup, only finitely many of its members lie outside. At `M = A` this
-is Example 6.39's defining condition on the coefficients, verbatim. -/
-@[simp]
+is Example 6.39's defining condition on the coefficients, verbatim.
+
+Deliberately **not** `@[simp]`: `mem_twoSidedRestrictedSubmodule` is already `@[simp]` and rewrites
+this left-hand side to `ZeroAtFilter cofinite f`, so tagging this one too fails the `simpNF` linter
+— simp reaches the membership unfolding first and this lemma can never fire. The `@[simp]` stays on
+the membership lemma, matching the one-sided `mem_restrictedMvPowerSeriesSubmodule`. -/
 theorem mem_twoSidedRestrictedSubmodule_iff_finite_notMem {f : ℤ → M} :
     f ∈ twoSidedRestrictedSubmodule A M ↔
       ∀ W : OpenAddSubgroup M, {n | f n ∉ (W : Set M)}.Finite := by

--- a/TauCeti/Topology/Algebra/Nonarchimedean/FirstCountable.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/FirstCountable.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+public import TauCeti.Topology.Algebra.Nonarchimedean.OpenAddSubgroupBasis
 
 /-!
 # A first-countable nonarchimedean group has a decreasing basis of open subgroups
@@ -57,13 +57,7 @@ is the one the proof consumes. -/
 theorem exists_antitone_basis_openAddSubgroup [(𝓝 (0 : G)).IsCountablyGenerated]
     [NonarchimedeanAddGroup G] :
     ∃ V : ℕ → OpenAddSubgroup G, (𝓝 (0 : G)).HasAntitoneBasis fun n ↦ (V n : Set G) := by
-  have hb : (𝓝 (0 : G)).HasBasis (fun _ : OpenAddSubgroup G ↦ True) fun V ↦ (V : Set G) := by
-    refine Filter.hasBasis_iff.mpr fun S ↦ ⟨fun hS ↦ ?_, ?_⟩
-    · obtain ⟨V, hV⟩ := NonarchimedeanAddGroup.is_nonarchimedean S hS
-      exact ⟨V, trivial, hV⟩
-    · rintro ⟨V, -, hV⟩
-      exact Filter.mem_of_superset (V.isOpen.mem_nhds V.zero_mem) hV
-  obtain ⟨V, -, hV⟩ := hb.exists_antitone_subbasis
+  obtain ⟨V, -, hV⟩ := (nhds_zero_hasBasis_openAddSubgroup G).exists_antitone_subbasis
   exact ⟨V, hV⟩
 
 end NonarchimedeanAddGroup

--- a/TauCeti/Topology/Algebra/Nonarchimedean/OpenAddSubgroupBasis.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/OpenAddSubgroupBasis.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+
+/-!
+# The open subgroups of a nonarchimedean group are a basis of the neighbourhoods of zero
+
+`NonarchimedeanAddGroup` is stated as an existence property — every neighbourhood of zero contains
+an open subgroup — and the filter-basis form is what consumers actually use. This module records
+that form once.
+
+It is deliberately separate from
+`TauCeti/Topology/Algebra/Nonarchimedean/FirstCountable.lean`, where this statement previously
+lived as a `have` inside `NonarchimedeanAddGroup.exists_antitone_basis_openAddSubgroup`: that
+theorem additionally assumes `(𝓝 0).IsCountablyGenerated`, which it needs only to extract an
+antitone *sequence* from the basis. The basis itself needs no countability, so hiding it inside a
+first-countability result put a countability hypothesis on a statement that does not use one.
+
+## Main results
+
+* `NonarchimedeanAddGroup.nhds_zero_hasBasis_openAddSubgroup`
+-/
+
+public section
+
+open Filter Topology
+
+namespace NonarchimedeanAddGroup
+
+variable (G : Type*) [AddGroup G] [TopologicalSpace G] [NonarchimedeanAddGroup G]
+
+/-- **The open additive subgroups form a basis of `𝓝 0`.** One direction is the defining property
+of `NonarchimedeanAddGroup`; the other is that an open subgroup is a neighbourhood of zero, since
+it is open and contains zero. -/
+theorem nhds_zero_hasBasis_openAddSubgroup :
+    (𝓝 (0 : G)).HasBasis (fun _ : OpenAddSubgroup G ↦ True) fun V ↦ (V : Set G) := by
+  refine Filter.hasBasis_iff.mpr fun S ↦ ⟨fun hS ↦ ?_, ?_⟩
+  · obtain ⟨V, hV⟩ := NonarchimedeanAddGroup.is_nonarchimedean S hS
+    exact ⟨V, trivial, hV⟩
+  · rintro ⟨V, -, hV⟩
+    exact Filter.mem_of_superset (V.isOpen.mem_nhds V.zero_mem) hV
+
+end NonarchimedeanAddGroup

--- a/TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Order.Filter.ZeroAndBoundedAtFilter
-public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+public import TauCeti.Topology.Algebra.Nonarchimedean.OpenAddSubgroupBasis
 
 /-!
 # Cofinite convergence in a nonarchimedean group is a finiteness condition
@@ -38,17 +38,14 @@ variable {ι : Type*} {G : Type*} [AddGroup G] [TopologicalSpace G] [Nonarchimed
 along the cofinite filter exactly when, for every open additive subgroup `W`, all but finitely
 many of its members lie in `W`.
 
-The `→` direction needs only that an open subgroup is a neighbourhood of zero. The `←` direction
-is where nonarchimedeanness is used: it supplies an open subgroup inside each neighbourhood of
-zero, so the open subgroups are a neighbourhood basis and the finiteness condition is enough. -/
+Both directions are the single fact that the open subgroups are a basis of `𝓝 0`
+(`NonarchimedeanAddGroup.nhds_zero_hasBasis_openAddSubgroup`), read through
+`Filter.HasBasis.tendsto_right_iff`: convergence along a filter is membership of each basic
+neighbourhood eventually, and `Filter.eventually_cofinite` turns "eventually along `cofinite`"
+into the finiteness of the exceptional set. -/
 theorem zeroAtFilter_cofinite_iff_finite_notMem {f : ι → G} :
     ZeroAtFilter cofinite f ↔ ∀ W : OpenAddSubgroup G, {n | f n ∉ (W : Set G)}.Finite := by
-  refine ⟨fun hf W ↦ ?_, fun h ↦ ?_⟩
-  · have := (tendsto_nhds.mp hf) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
-    rwa [Filter.mem_cofinite] at this
-  · refine tendsto_nhds.mpr fun U hU h0 ↦ ?_
-    obtain ⟨W, hWU⟩ := NonarchimedeanAddGroup.is_nonarchimedean U (hU.mem_nhds h0)
-    rw [Filter.mem_cofinite]
-    exact (h W).subset fun n hn ↦ fun hnW ↦ hn (hWU hnW)
+  simp only [ZeroAtFilter, (nhds_zero_hasBasis_openAddSubgroup G).tendsto_right_iff, true_implies,
+    Filter.eventually_cofinite]
 
 end NonarchimedeanAddGroup

--- a/TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Order.Filter.ZeroAndBoundedAtFilter
+public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+
+/-!
+# Cofinite convergence in a nonarchimedean group is a finiteness condition
+
+In a nonarchimedean additive group the open subgroups form a basis of neighbourhoods of zero, so
+a family converges to zero along the cofinite filter exactly when each open subgroup omits only
+finitely many of its members.
+
+The `→` direction is available in any topological additive group: an open subgroup is a
+neighbourhood of zero, so cofinitely many members lie in it. It is nonarchimedeanness that gives
+the converse, and with it the upgrade from a *consequence* of convergence to a *criterion* for it.
+
+Nothing here looks at the index type, so it is arbitrary.
+
+## Main results
+
+* `NonarchimedeanAddGroup.zeroAtFilter_cofinite_iff_finite_notMem`
+-/
+
+public section
+
+open Filter Topology
+
+namespace NonarchimedeanAddGroup
+
+variable {ι : Type*} {G : Type*} [AddGroup G] [TopologicalSpace G] [NonarchimedeanAddGroup G]
+
+/-- **Cofinite convergence, as a finiteness condition on open subgroups.** A family tends to `0`
+along the cofinite filter exactly when, for every open additive subgroup `W`, all but finitely
+many of its members lie in `W`.
+
+The `→` direction needs only that an open subgroup is a neighbourhood of zero. The `←` direction
+is where nonarchimedeanness is used: it supplies an open subgroup inside each neighbourhood of
+zero, so the open subgroups are a neighbourhood basis and the finiteness condition is enough. -/
+theorem zeroAtFilter_cofinite_iff_finite_notMem {f : ι → G} :
+    ZeroAtFilter cofinite f ↔ ∀ W : OpenAddSubgroup G, {n | f n ∉ (W : Set G)}.Finite := by
+  refine ⟨fun hf W ↦ ?_, fun h ↦ ?_⟩
+  · have := (tendsto_nhds.mp hf) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
+    rwa [Filter.mem_cofinite] at this
+  · refine tendsto_nhds.mpr fun U hU h0 ↦ ?_
+    obtain ⟨W, hWU⟩ := NonarchimedeanAddGroup.is_nonarchimedean U (hU.mem_nhds h0)
+    rw [Filter.mem_cofinite]
+    exact (h W).subset fun n hn ↦ fun hnW ↦ hn (hWU hnW)
+
+end NonarchimedeanAddGroup


### PR DESCRIPTION
Wedhorn's Example 6.39 introduces, for a Tate ring `A`, the ring of formal series
`∑_{n ∈ ℤ} aₙ Xⁿ` whose coefficients converge: for every neighbourhood `U` of zero, all but
finitely many `aₙ` lie in `U`. This builds the coefficient object underlying that ring — the
`A`-module of such two-sided families — with its coefficients and extensionality.

### What is here

* `twoSidedRestrictedSubmodule A M` — the `A`-module of families `ℤ → M` tending to `0` along the
  cofinite filter.
* `zeroAtFilter_cofinite_iff_finite_notMem` — **Wedhorn's phrasing, as an iff**: over a
  nonarchimedean additive group a family tends to `0` cofinitely exactly when each open additive
  subgroup omits only finitely many of its members. Stated at an arbitrary index type, since
  neither direction inspects the index set.
* `mem_twoSidedRestrictedSubmodule_iff_finite_notMem` — that criterion at `ℤ`, which is Example
  6.39's defining condition verbatim.
* `twoSidedRestrictedSubmodule_ext` — coefficientwise extensionality.

The `→` half of the criterion is the form `IsRestricted.finite_coeff_notMem` already records for
one-sided series. The `←` half is the new content and is where nonarchimedeanness enters: it puts
an open subgroup inside each neighbourhood of zero, which turns a consequence into a usable
criterion.

### Reuse, and why this is not a duplicate

The restrictedness condition is *the same predicate* main already uses: `IsRestricted` is
`Filter.ZeroAtFilter` at `Filter.cofinite`, and nothing in it refers to the shape of the index
set. So this object is that notion indexed by `ℤ` instead of `Fin k →₀ ℕ`, and is built from the
same Mathlib primitive (`Filter.zeroAtFilterSubmodule`) that `restrictedMvPowerSeriesSubmodule` is
built from. No parallel predicate is introduced.

Two neighbouring modules use the word "Laurent" for **different** objects, which is why this file
does not:

* `Restricted/Laurent.lean` is Example **6.38** — the Laurent *rational subsets*, whose coordinate
  rings `A⟨X⟩/(f - X)` and `A⟨X⟩/(1 - f X)` are quotients of the **one-sided** `A⟨X⟩`. Those are
  the two *pieces* of the cover whose *overlap* this file serves.
* `Huber/LaurentSeries.lean` is the formal Laurent series **field** `K⸨X⸩` over a *field*, with the
  `X`-adic topology. Three mismatches with Example 6.39 — base ring, two-sidedness, and topology —
  so it is not reusable here. The distinguishing feature is exactly the convergence condition on
  the coefficients. Both distinctions are recorded in the module docstring.

### What is not here

The **ring** structure, deliberately. For one-sided series the coefficient convolution is a finite
sum over `MvPowerSeries.coeff_mul`'s antidiagonal, which is what `IsRestricted.mul` exploits; over
`ℤ` that antidiagonal is infinite, so multiplication needs a summability argument in a complete
ring rather than a rearrangement of a finite sum. That is separate work. Also not here: the
decomposition `A⟨z,z⁻¹⟩ = A⟨z⟩ + z⁻¹A⟨z⁻¹⟩`, the ideal form for `(f - z)`, and the isomorphism to
`A⟨X,Y⟩/(XY - 1)` — each is its own tracked rung on top of this one.

### Roadmap target

**`TauCetiRoadmap/AdicSpaces/README.md`, Layer 4 "sheafiness and Tate acyclicity", §4.1 "Strongly
noetherian Tate rings", step 5** — verbatim: *"Lemma 8.33: prove exactness for a two-piece Laurent
cover."*

The dependency from that target to this module is direct and is visible in Wedhorn's own proof.
Lemma 8.33 identifies the overlap term of the two-piece cover as

```text
O_X(U₁ ∩ U₂) = A⟨ζ,η⟩/(f − ζ, 1 − ζη) = A⟨ζ,ζ⁻¹⟩/(f − ζ)     (Wedhorn 8.2.1)
```

and its diagram chase then puts `A⟨ζ,ζ⁻¹⟩` in the middle column, where it uses three properties of
that object: the decomposition `A⟨ζ,ζ⁻¹⟩ = A⟨ζ⟩ + ζ⁻¹A⟨ζ⁻¹⟩`, the matching ideal decomposition for
`(f − ζ)`, and **uniqueness of the coefficients of a two-sided series** — the step
`0 = ∑ aₖζᵏ − ∑ bₖζ⁻ᵏ ⟹ aₖ = bₖ = 0 (k > 0), a₀ = b₀`, which is how `im(ι) = ker(λ)` is obtained.
The coefficient object and its extensionality built here are what that step is stated about; the
three properties themselves are the following rungs and are tracked separately.

Roadmap: AdicSpaces

