### PR TITLE
feat(Huber): the two-sided restricted Laurent coefficient object

### DIFF
--- a/TauCeti/RingTheory/Huber/Restricted/LaurentZ.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/LaurentZ.lean
@@ -24,14 +24,16 @@ serves Wedhorn 8.31(2) and Example 6.38. Its series are indexed by `ℕ` — it 
 quotients. The object here is indexed by `ℤ` and is not a quotient of anything. The two share the
 word "Laurent" and nothing else; neither subsumes the other.
 
-## Why `ZeroAtFilter cofinite`
+## Why `Filter.zeroAtFilterSubmodule`
 
 This is the idiom already in use for the one-sided object:
 `TauCeti.Huber.IsRestricted` is defined as `Tendsto (coeff f) cofinite (𝓝 0)`, and
 `TauCeti.Huber.isRestricted_iff` records that this *is* Mathlib's `Filter.ZeroAtFilter` at
 `cofinite`. Wedhorn's condition on a two-sided family is that same condition at index type `ℤ`
-rather than `Fin k →₀ ℕ`, so it is stated the same way rather than as a bespoke finiteness
-predicate. `finite_notMem_of_mem_laurentRestricted` recovers Wedhorn's own phrasing.
+rather than `Fin k →₀ ℕ`, so it is built the same way: `restrictedMvPowerSeriesSubmodule` is
+`Filter.zeroAtFilterSubmodule A (cofinite : Filter (Fin k →₀ ℕ))`, and this is the same
+combinator at `cofinite : Filter ℤ`. `finite_notMem_of_mem_laurentRestricted` recovers Wedhorn's
+own phrasing.
 
 ## Main definitions
 
@@ -51,17 +53,15 @@ open scoped Topology
 
 namespace TauCeti.Huber
 
-variable {A : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [ContinuousAdd A]
+  [ContinuousConstSMul A A]
 
 /-- **Wedhorn Example 6.39**, the coefficient families of `A⟨X, X⁻¹⟩`: two-sided families
 `a : ℤ → A` such that for every neighbourhood `U` of zero, `aₙ ∈ U` for all but finitely many
 `n` — that is, `a` tends to `0` along `cofinite`. -/
-def laurentRestricted (A : Type*) [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A] :
-    Submodule A (ℤ → A) where
-  carrier := {a | ZeroAtFilter cofinite a}
-  zero_mem' := zero_zeroAtFilter _
-  add_mem' ha hb := ha.add hb
-  smul_mem' c _ ha := ha.smul c
+def laurentRestricted (A : Type*) [CommRing A] [TopologicalSpace A] [ContinuousAdd A]
+    [ContinuousConstSMul A A] : Submodule A (ℤ → A) :=
+  Filter.zeroAtFilterSubmodule A (Filter.cofinite : Filter ℤ)
 
 /-- Membership, unfolded. -/
 theorem mem_laurentRestricted_iff {a : ℤ → A} :

--- a/TauCeti/RingTheory/Huber/Restricted/LaurentZ.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/LaurentZ.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.RingTheory.Huber.Restricted.PowerSeries
+
+/-!
+# The two-sided restricted Laurent object — SCAFFOLD
+-/
+
+public section
+
+open Filter
+
+open scoped Topology
+
+namespace TauCeti.Huber
+
+variable (A : Type*) [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+
+/-- **Wedhorn Example 6.39.** The coefficient families of `A⟨X, X⁻¹⟩`: two-sided families
+`a : ℤ → A` such that for every neighbourhood `U` of zero, `aₙ ∈ U` for all but finitely many
+`n` — that is, `a` tends to `0` along `cofinite`. -/
+def laurentRestricted : Submodule A (ℤ → A) where
+  carrier := {a | ZeroAtFilter cofinite a}
+  zero_mem' := zero_zeroAtFilter _
+  add_mem' ha hb := ha.add hb
+  smul_mem' c _ ha := ha.smul c
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Restricted/LaurentZ.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/LaurentZ.lean
@@ -8,7 +8,39 @@ module
 public import TauCeti.RingTheory.Huber.Restricted.PowerSeries
 
 /-!
-# The two-sided restricted Laurent object — SCAFFOLD
+# The two-sided restricted Laurent coefficient object
+
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Example 6.39.** For a Tate ring `A`, the ring
+`A⟨X, X⁻¹⟩` consists of the two-sided formal series `∑_{n ∈ ℤ} aₙ Xⁿ` whose coefficients satisfy:
+for every neighbourhood `U` of zero, all but finitely many `aₙ` lie in `U`. This file carries the
+*coefficient object* — the families themselves, with extensionality — and nothing else. The ring
+structure (convolution), its topology, and the presentation `A⟨X, Y⟩/(XY - 1)` are separate.
+
+## Not to be confused with `TauCeti.RingTheory.Huber.Restricted.Laurent`
+
+That module is titled "The Laurent quotients `A⟨X⟩/(f - X)` and `A⟨X⟩/(1 - f X)` are flat" and
+serves Wedhorn 8.31(2) and Example 6.38. Its series are indexed by `ℕ` — it works inside
+`MvPowerSeries (Fin 1) A` — and its content is `mulX`, `restrictedX` and flatness of two
+quotients. The object here is indexed by `ℤ` and is not a quotient of anything. The two share the
+word "Laurent" and nothing else; neither subsumes the other.
+
+## Why `ZeroAtFilter cofinite`
+
+This is the idiom already in use for the one-sided object:
+`TauCeti.Huber.IsRestricted` is defined as `Tendsto (coeff f) cofinite (𝓝 0)`, and
+`TauCeti.Huber.isRestricted_iff` records that this *is* Mathlib's `Filter.ZeroAtFilter` at
+`cofinite`. Wedhorn's condition on a two-sided family is that same condition at index type `ℤ`
+rather than `Fin k →₀ ℕ`, so it is stated the same way rather than as a bespoke finiteness
+predicate. `finite_notMem_of_mem_laurentRestricted` recovers Wedhorn's own phrasing.
+
+## Main definitions
+
+* `TauCeti.Huber.laurentRestricted` : the coefficient families, as a submodule of `ℤ → A`.
+
+## Main results
+
+* `TauCeti.Huber.finite_notMem_of_mem_laurentRestricted` : Wedhorn's condition verbatim.
+* `TauCeti.Huber.laurentRestricted_ext` : coefficientwise extensionality.
 -/
 
 public section
@@ -19,15 +51,33 @@ open scoped Topology
 
 namespace TauCeti.Huber
 
-variable (A : Type*) [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A]
 
-/-- **Wedhorn Example 6.39.** The coefficient families of `A⟨X, X⁻¹⟩`: two-sided families
+/-- **Wedhorn Example 6.39**, the coefficient families of `A⟨X, X⁻¹⟩`: two-sided families
 `a : ℤ → A` such that for every neighbourhood `U` of zero, `aₙ ∈ U` for all but finitely many
 `n` — that is, `a` tends to `0` along `cofinite`. -/
-def laurentRestricted : Submodule A (ℤ → A) where
+def laurentRestricted (A : Type*) [CommRing A] [TopologicalSpace A] [NonarchimedeanRing A] :
+    Submodule A (ℤ → A) where
   carrier := {a | ZeroAtFilter cofinite a}
   zero_mem' := zero_zeroAtFilter _
   add_mem' ha hb := ha.add hb
   smul_mem' c _ ha := ha.smul c
+
+/-- Membership, unfolded. -/
+theorem mem_laurentRestricted_iff {a : ℤ → A} :
+    a ∈ laurentRestricted A ↔ ZeroAtFilter cofinite a := (Iff.rfl)
+
+/-- **Wedhorn's condition verbatim**: for every open additive subgroup, all but finitely many
+coefficients lie in it. -/
+theorem finite_notMem_of_mem_laurentRestricted {a : ℤ → A} (ha : a ∈ laurentRestricted A)
+    (W : OpenAddSubgroup A) : {n : ℤ | a n ∉ (W : Set A)}.Finite := by
+  have := (tendsto_nhds.mp ha) _ W.isOpen (SetLike.mem_coe.mpr W.zero_mem)
+  rwa [Filter.mem_cofinite] at this
+
+/-- **Coefficientwise extensionality.** -/
+@[ext]
+theorem laurentRestricted_ext {a b : laurentRestricted A}
+    (h : ∀ n : ℤ, (a : ℤ → A) n = (b : ℤ → A) n) : a = b :=
+  Subtype.ext (funext h)
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSided.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSided.lean
@@ -16,13 +16,19 @@ for every neighbourhood `U` of zero, all but finitely many `aₙ` lie in `U`. Th
 *coefficient object* — the families themselves, with extensionality — and nothing else. The ring
 structure (convolution), its topology, and the presentation `A⟨X, Y⟩/(XY - 1)` are separate.
 
-## Not to be confused with `TauCeti.RingTheory.Huber.Restricted.Laurent`
+## Why this file is not called `Laurent`
 
-That module is titled "The Laurent quotients `A⟨X⟩/(f - X)` and `A⟨X⟩/(1 - f X)` are flat" and
-serves Wedhorn 8.31(2) and Example 6.38. Its series are indexed by `ℕ` — it works inside
-`MvPowerSeries (Fin 1) A` — and its content is `mulX`, `restrictedX` and flatness of two
-quotients. The object here is indexed by `ℤ` and is not a quotient of anything. The two share the
-word "Laurent" and nothing else; neither subsumes the other.
+"Laurent" already means two other things nearby, so the name is avoided here deliberately:
+
+* `TauCeti.RingTheory.Huber.Restricted.Laurent` — "The Laurent quotients `A⟨X⟩/(f - X)` and
+  `A⟨X⟩/(1 - f X)` are flat", Wedhorn 8.31(2) and Example 6.38. Indexed by `ℕ`, inside
+  `MvPowerSeries (Fin 1) A`; its content is `mulX`, `restrictedX` and flatness of two quotients.
+  Those quotients are the two *pieces* of the cover whose *overlap* the object here serves.
+* `TauCeti.RingTheory.Huber.LaurentSeries` — `K⸨X⸩` for a field `K` with the `X`-adic topology,
+  the equal-characteristic Tate example.
+
+The object here is the two-sided restricted series over a general coefficient ring, indexed by
+`ℤ`, and is not a quotient of anything.
 
 ## Why `Filter.zeroAtFilterSubmodule`
 


### PR DESCRIPTION
**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Example 6.39.** For a Tate ring `A`, `A⟨X, X⁻¹⟩`
consists of the two-sided formal series `∑_{n ∈ ℤ} aₙ Xⁿ` such that for every neighbourhood `U`
of zero, all but finitely many `aₙ` lie in `U`. This is the **coefficient object** for that ring:
the families themselves, with extensionality. Nothing else.

## ⚠ This is not `Restricted/Laurent.lean`

`TauCeti/RingTheory/Huber/Restricted/Laurent.lean` already exists, and any search for "Laurent"
finds it first. It is a **different object** and neither subsumes the other:

| | `Restricted/Laurent.lean` (on `main`) | this PR |
| --- | --- | --- |
| header | "The Laurent quotients `A⟨X⟩/(f - X)` and `A⟨X⟩/(1 - f X)` are flat" | Example 6.39's coefficient families |
| Wedhorn | 8.31(2), and Example 6.38 | Example 6.39 |
| index | `ℕ` — lives in `MvPowerSeries (Fin 1) A` | **`ℤ`** |
| content | `mulX`, `restrictedX`, flatness of two quotients | the two-sided families, and that they form a submodule |

Verified absent before writing, by both probes: `git grep "6\.39"` over `TauCeti/` at
`origin/main` returns nothing, and `restrictedLaurent` / `laurentRestricted` /
`restrictedLaurentSeries` are zero declarations (control: `restrictedMvPowerSeriesCompletion`
resolves; negative control zero).

## Why `ZeroAtFilter cofinite` rather than a bespoke predicate

Because that is how the one-sided object already says the same thing.
`TauCeti.Huber.IsRestricted` (`Restricted/PowerSeries.lean:204`) is
`Tendsto (coeff f) cofinite (𝓝 0)`, and `isRestricted_iff` records that this *is* Mathlib's
`Filter.ZeroAtFilter` at `cofinite`. Wedhorn's condition on a two-sided family is that condition
at index type `ℤ` instead of `Fin k →₀ ℕ` — so it is stated the same way, and the instance block
is the one `restrictedMvPowerSeriesSubring` carries, for the same reason.
`finite_notMem_of_mem_laurentRestricted` recovers Wedhorn's own phrasing ("all but finitely many
coefficients lie in `W`"), mirroring `IsRestricted.finite_coeff_notMem`.

## Scope

This is rung **(a)** of the re-scoped Example 6.39 work: the object, coefficients, and
ext/uniqueness. The ring structure (convolution), its topology, and the presentation
`A⟨X, Y⟩/(XY - 1)` are separate rungs and deliberately absent here.

Its consumer is Layer 4.1 step 5 — Lemma 8.33 identifies the overlap term of a two-piece Laurent
cover as `O_X(U₁ ∩ U₂) = A⟨ζ, ζ⁻¹⟩/(f - ζ)`, and that ring is this one.

## Gate

`lake build` of the new module — 1746 jobs, no errors, warnings or sorries. It is a new leaf
file; nothing on `main` imports it yet.

Roadmap: AdicSpaces
