### PR TITLE
feat: maximality of the candidate genus field

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Subfactorization.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Subfactorization.lean
@@ -1,0 +1,226 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.FundamentalDiscriminant.OfSquarefree
+
+/-!
+# Comparing two prime-discriminant factorizations
+
+Let `a` and `d` be integers and write `A = fundamentalDiscriminant a`,
+`D = fundamentalDiscriminant d`. Suppose `A = ∏ P ∈ u, P` and `D = ∏ P ∈ s, P` are factorizations
+into prime discriminants, at most one member of each being even
+(`IsFundamentalDiscriminant.exists_finset_primeDiscriminant` produces such factorizations). This
+file gives a criterion for `u ⊆ s`, that is, for the quadratic field `ℚ(√a)` to sit inside the
+compositum of the prime-discriminant quadratic fields attached to `s`:
+
+* every rational prime dividing `A` divides `D`, and
+* if `2 ∣ A` then `2 ∤ fundamentalDiscriminant c`, where `c` is any integer with `a * d = c * e ^ 2`
+  — that is, `ℚ(√(ad))` is unramified at `2`.
+
+These are exactly the two constraints that the maximality argument for the genus field extracts
+from ramification theory (`TauCeti.Multiquadratic.dvd_fundamentalDiscriminant_base_of_dvd_subfield`
+and `TauCeti.Multiquadratic.not_dvd_fundamentalDiscriminant_mul_of_dvd_subfield`), so the theorem
+below is the arithmetic half of that argument, isolated from the field theory.
+
+The odd part of the criterion is immediate: an odd prime lies under exactly one prime
+discriminant, namely `p* = (-1)^((p-1)/2) p`, so a shared prime forces a shared factor. The even
+part is the announced trap: `-4`, `8` and `-8` all lie over `2`, and mere divisibility cannot tell
+them apart. What separates them is the second hypothesis. Writing `A = E * m` and `D = F * n` with
+`E, F ∈ {-4, 8, -8}` and `m, n ≡ 1 (mod 4)` (a product of odd prime discriminants is `1` mod `4`),
+one has `4a = E * m` and `4d = F * n`; a mismatch `E ≠ F` then makes `a * d` either twice an odd
+number or `-4` times a number that is `1` mod `4`, and neither is `c * e ^ 2` with `c ≡ 1 (mod 4)`.
+
+The classical statement is that the discriminant of a quadratic subfield of the genus field
+divides the discriminant of the base; see D. A. Cox, *Primes of the Form x² + ny²*, §6.A, and
+F. Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2. Divisibility of fundamental
+discriminants is genuinely weaker than the subset relation proved here (`-4 ∣ 8`, yet the
+quadratic field of discriminant `-4` is not the one of discriminant `8`), which is why the
+conclusion is stated as `u ⊆ s`.
+
+## Main results
+
+* `TauCeti.Multiquadratic.IsPrimeDiscriminant.mod_four_eq_one`: an odd prime discriminant is
+  `1` modulo `4`.
+* `TauCeti.Multiquadratic.exists_mod_four_eq_one_four_mul_eq`: splitting the even factor off a
+  prime-discriminant factorization of `fundamentalDiscriminant a` writes `4 * a = E * m` with
+  `m ≡ 1 (mod 4)`.
+* `TauCeti.Multiquadratic.isEvenPrimeDiscriminant_eq_of_four_mul_eq`: the even factors of two such
+  factorizations agree as soon as the square class of the product is unramified at `2`.
+* `TauCeti.Multiquadratic.subset_of_forall_prime_dvd_fundamentalDiscriminant`: the criterion for
+  one factorization to be a subset of the other.
+-/
+
+public section
+
+namespace TauCeti.Multiquadratic
+
+/-- A prime discriminant other than `-4`, `8`, `-8` is congruent to `1` modulo `4`: it is the
+odd prime discriminant `p*`. -/
+theorem IsPrimeDiscriminant.mod_four_eq_one {P : ℤ} (hP : IsPrimeDiscriminant P)
+    (hne : ¬ IsEvenPrimeDiscriminant P) : P % 4 = 1 := by
+  rcases isPrimeDiscriminant_iff.mp hP with hev | ⟨_p, _hp, hodd, rfl⟩
+  · exact absurd hev hne
+  · exact oddPrimeDiscriminant_mod_four_eq_one hodd
+
+/-- A product of odd prime discriminants is congruent to `1` modulo `4`. -/
+theorem prod_primeDiscriminant_mod_four_eq_one {s : Finset ℤ}
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P) (hne : ∀ P ∈ s, ¬ IsEvenPrimeDiscriminant P) :
+    (∏ P ∈ s, P) % 4 = 1 :=
+  Finset.prod_induction _ (fun x => x % 4 = 1)
+    (fun x y hx hy => by
+      have h := Int.mul_emod x y 4
+      rw [hx, hy] at h
+      simpa using h)
+    (by norm_num) fun P hP => (hs P hP).mod_four_eq_one (hne P hP)
+
+/-- **Splitting off the even prime discriminant.** If the prime discriminants in `u` have product
+`fundamentalDiscriminant a` and at most one of them is even, then an even member `E` of `u`
+satisfies `4 * a = E * m` for a complementary factor `m ≡ 1 (mod 4)`, namely the product of the
+remaining (odd) prime discriminants. -/
+theorem exists_mod_four_eq_one_four_mul_eq {a E : ℤ} {u : Finset ℤ}
+    (hu : ∀ P ∈ u, IsPrimeDiscriminant P)
+    (hue : ∀ P ∈ u, ∀ Q ∈ u, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant Q → P = Q)
+    (huprod : ∏ P ∈ u, P = fundamentalDiscriminant a)
+    (hE : E ∈ u) (hEeven : IsEvenPrimeDiscriminant E) :
+    ∃ m : ℤ, m % 4 = 1 ∧ 4 * a = E * m := by
+  classical
+  have hsplit : E * ∏ P ∈ u.erase E, P = fundamentalDiscriminant a := by
+    rw [Finset.mul_prod_erase u (fun P => P) hE]; exact huprod
+  refine ⟨∏ P ∈ u.erase E, P, ?_, ?_⟩
+  · refine prod_primeDiscriminant_mod_four_eq_one
+      (fun P hP => hu P (Finset.mem_of_mem_erase hP)) fun P hP hPev => ?_
+    exact Finset.ne_of_mem_erase hP (hue P (Finset.mem_of_mem_erase hP) E hE hPev hEeven)
+  · have h2 : (2 : ℤ) ∣ fundamentalDiscriminant a :=
+      hsplit ▸ (two_dvd_evenPrimeDiscriminant hEeven).mul_right _
+    have hmod : a % 4 ≠ 1 := fun h =>
+      (two_not_dvd_fundamentalDiscriminant_iff_mod_four_eq_one a).mpr h h2
+    rw [hsplit, fundamentalDiscriminant_def]
+    split_ifs with h
+    · exact absurd h hmod
+    · rfl
+
+/-- An odd number times a square is never twice an odd number. -/
+private theorem odd_mul_sq_ne_two_mul_odd {c e x : ℤ} (hc : c % 2 = 1) (hx : x % 2 = 1) :
+    c * e ^ 2 ≠ 2 * x := by
+  intro h
+  rcases Int.even_or_odd e with ⟨f, rfl⟩ | ⟨f, rfl⟩
+  · have h' : 2 * x = 4 * (c * f ^ 2) := by rw [← h]; ring
+    generalize c * f ^ 2 = k at h'
+    omega
+  · have h' : 2 * x = 4 * (c * f ^ 2) + 4 * (c * f) + c := by rw [← h]; ring
+    generalize c * f ^ 2 = k at h'
+    generalize c * f = l at h'
+    omega
+
+/-- A number that is `1` modulo `4` times a square is never `-4` times a number that is `1`
+modulo `4`. -/
+private theorem mod_four_mul_sq_ne_neg_four_mul {c e x : ℤ} (hc : c % 4 = 1) (hx : x % 4 = 1) :
+    c * e ^ 2 ≠ -4 * x := by
+  intro h
+  rcases Int.even_or_odd e with ⟨f, rfl⟩ | ⟨f, rfl⟩
+  · rcases Int.even_or_odd f with ⟨g, rfl⟩ | ⟨g, rfl⟩
+    · have h' : -4 * x = 16 * (c * g ^ 2) := by rw [← h]; ring
+      generalize c * g ^ 2 = k at h'
+      omega
+    · have h' : -4 * x = 16 * (c * g ^ 2) + 16 * (c * g) + 4 * c := by rw [← h]; ring
+      generalize c * g ^ 2 = k at h'
+      generalize c * g = l at h'
+      omega
+  · have h' : -4 * x = 4 * (c * f ^ 2) + 4 * (c * f) + c := by rw [← h]; ring
+    generalize c * f ^ 2 = k at h'
+    generalize c * f = l at h'
+    omega
+
+/-- **The even prime discriminants of two fundamental discriminants agree** when the square class
+of the product is unramified at `2`. Concretely: if `4 * a = E * m` and `4 * d = F * n` with
+`E`, `F` even prime discriminants and `m ≡ n ≡ 1 (mod 4)`, and if `a * d = c * e ^ 2` with
+`c ≡ 1 (mod 4)`, then `E = F`.
+
+This is what distinguishes `-4`, `8` and `-8`, which no divisibility statement can: for instance
+`4 * 3 = (-4) * (-3)` and `4 * 2 = 8 * 1`, and the product `3 * 2 = 6` has squarefree part `6`,
+which is `2` modulo `4`, not `1`. -/
+theorem isEvenPrimeDiscriminant_eq_of_four_mul_eq {a d c e E F m n : ℤ}
+    (hE : IsEvenPrimeDiscriminant E) (hF : IsEvenPrimeDiscriminant F)
+    (hm : m % 4 = 1) (hn : n % 4 = 1) (ha : 4 * a = E * m) (hd : 4 * d = F * n)
+    (hade : a * d = c * e ^ 2) (hc : c % 4 = 1) : E = F := by
+  have hmn : m * n % 2 = 1 :=
+    Int.odd_iff.mp ((Int.odd_iff.mpr (by omega)).mul (Int.odd_iff.mpr (by omega)))
+  have hmnneg : -(m * n) % 2 = 1 := by omega
+  have hmn4 : m * n % 4 = 1 := by
+    have h := Int.mul_emod m n 4
+    rw [hm, hn] at h
+    simpa using h
+  have hc2 : c % 2 = 1 := by omega
+  rcases hE with rfl | rfl | rfl <;> rcases hF with rfl | rfl | rfl
+  · rfl
+  · exact absurd (show c * e ^ 2 = 2 * -(m * n) by
+      rw [← hade]; have : a = -m := by omega
+      rw [this, show d = 2 * n by omega]; ring) (odd_mul_sq_ne_two_mul_odd hc2 hmnneg)
+  · exact absurd (show c * e ^ 2 = 2 * (m * n) by
+      rw [← hade]; rw [show a = -m by omega, show d = -(2 * n) by omega]; ring)
+      (odd_mul_sq_ne_two_mul_odd hc2 hmn)
+  · exact absurd (show c * e ^ 2 = 2 * -(m * n) by
+      rw [← hade]; rw [show a = 2 * m by omega, show d = -n by omega]; ring)
+      (odd_mul_sq_ne_two_mul_odd hc2 hmnneg)
+  · rfl
+  · exact absurd (show c * e ^ 2 = -4 * (m * n) by
+      rw [← hade]; rw [show a = 2 * m by omega, show d = -(2 * n) by omega]; ring)
+      (mod_four_mul_sq_ne_neg_four_mul hc hmn4)
+  · exact absurd (show c * e ^ 2 = 2 * (m * n) by
+      rw [← hade]; rw [show a = -(2 * m) by omega, show d = -n by omega]; ring)
+      (odd_mul_sq_ne_two_mul_odd hc2 hmn)
+  · exact absurd (show c * e ^ 2 = -4 * (m * n) by
+      rw [← hade]; rw [show a = -(2 * m) by omega, show d = 2 * n by omega]; ring)
+      (mod_four_mul_sq_ne_neg_four_mul hc hmn4)
+  · rfl
+
+/-- **A prime-discriminant factorization sits inside another.** Let `u` and `s` be finite sets of
+prime discriminants, at most one member of each being even, with products
+`fundamentalDiscriminant a` and `fundamentalDiscriminant d`. If every rational prime dividing
+`fundamentalDiscriminant a` divides `fundamentalDiscriminant d`, and if `2 ∣
+fundamentalDiscriminant a` forces `fundamentalDiscriminant c` to be odd for some `c` with
+`a * d = c * e ^ 2`, then `u ⊆ s`.
+
+Both hypotheses are needed, and both are supplied by the ramification theory of a Galois extension
+unramified over `ℚ(√d)`: the first says a prime ramifying in `ℚ(√a)` ramifies in `ℚ(√d)`, the
+second that `2` does not ramify in `ℚ(√(ad))`. -/
+theorem subset_of_forall_prime_dvd_fundamentalDiscriminant {a d c e : ℤ} {s u : Finset ℤ}
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (hse : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant Q → P = Q)
+    (hsprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
+    (hu : ∀ P ∈ u, IsPrimeDiscriminant P)
+    (hue : ∀ P ∈ u, ∀ Q ∈ u, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant Q → P = Q)
+    (huprod : ∏ P ∈ u, P = fundamentalDiscriminant a)
+    (hade : a * d = c * e ^ 2)
+    (hdvd : ∀ p : ℕ, p.Prime → (p : ℤ) ∣ fundamentalDiscriminant a →
+      (p : ℤ) ∣ fundamentalDiscriminant d)
+    (hodd : (2 : ℤ) ∣ fundamentalDiscriminant a → ¬ (2 : ℤ) ∣ fundamentalDiscriminant c) :
+    u ⊆ s := by
+  intro P hP
+  have hPd : IsPrimeDiscriminant P := hu P hP
+  have hpprime : (primeDiscriminantPrime P).Prime := prime_primeDiscriminantPrime hPd
+  have hpa : ((primeDiscriminantPrime P : ℕ) : ℤ) ∣ fundamentalDiscriminant a :=
+    huprod ▸ (primeDiscriminantPrime_dvd hPd).trans (Finset.dvd_prod_of_mem _ hP)
+  have hpd : ((primeDiscriminantPrime P : ℕ) : ℤ) ∣ ∏ P ∈ s, P := by
+    rw [hsprod]; exact hdvd _ hpprime hpa
+  have hpZ : Prime ((primeDiscriminantPrime P : ℕ) : ℤ) :=
+    Int.prime_iff_natAbs_prime.mpr (by simpa using hpprime)
+  obtain ⟨Q, hQ, hpQ⟩ := hpZ.exists_mem_finset_dvd hpd
+  have hQd : IsPrimeDiscriminant Q := hs Q hQ
+  have hpq : primeDiscriminantPrime P = primeDiscriminantPrime Q :=
+    (natCast_dvd_primeDiscriminant_iff hQd hpprime).mp hpQ
+  have heven : IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant Q → P = Q := by
+    intro hPev hQev
+    obtain ⟨m, hm, ham⟩ := exists_mod_four_eq_one_four_mul_eq hu hue huprod hP hPev
+    obtain ⟨n, hn, hdn⟩ := exists_mod_four_eq_one_four_mul_eq hs hse hsprod hQ hQev
+    have h2a : (2 : ℤ) ∣ fundamentalDiscriminant a := by
+      rwa [primeDiscriminantPrime_of_isEvenPrimeDiscriminant hPev, Nat.cast_ofNat] at hpa
+    exact isEvenPrimeDiscriminant_eq_of_four_mul_eq hPev hQev hm hn ham hdn hade
+      ((two_not_dvd_fundamentalDiscriminant_iff_mod_four_eq_one c).mp (hodd h2a))
+  exact eq_of_primeDiscriminantPrime_eq hPd hQd heven hpq ▸ hQ
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Subfactorization.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Subfactorization.lean
@@ -157,25 +157,43 @@ theorem isEvenPrimeDiscriminant_eq_of_four_mul_eq {a d c e E F m n : ℤ}
   have hc2 : c % 2 = 1 := by omega
   rcases hE with rfl | rfl | rfl <;> rcases hF with rfl | rfl | rfl
   · rfl
-  · exact absurd (show c * e ^ 2 = 2 * -(m * n) by
-      rw [← hade]; have : a = -m := by omega
-      rw [this, show d = 2 * n by omega]; ring) (odd_mul_sq_ne_two_mul_odd hc2 hmnneg)
-  · exact absurd (show c * e ^ 2 = 2 * (m * n) by
-      rw [← hade]; rw [show a = -m by omega, show d = -(2 * n) by omega]; ring)
-      (odd_mul_sq_ne_two_mul_odd hc2 hmn)
-  · exact absurd (show c * e ^ 2 = 2 * -(m * n) by
-      rw [← hade]; rw [show a = 2 * m by omega, show d = -n by omega]; ring)
-      (odd_mul_sq_ne_two_mul_odd hc2 hmnneg)
+  · have hcontra : c * e ^ 2 = 2 * -(m * n) := by
+      have ha : a = -m := by omega
+      have hd : d = 2 * n := by omega
+      rw [← hade, ha, hd]
+      ring
+    exact absurd hcontra (odd_mul_sq_ne_two_mul_odd hc2 hmnneg)
+  · have hcontra : c * e ^ 2 = 2 * (m * n) := by
+      have ha : a = -m := by omega
+      have hd : d = -(2 * n) := by omega
+      rw [← hade, ha, hd]
+      ring
+    exact absurd hcontra (odd_mul_sq_ne_two_mul_odd hc2 hmn)
+  · have hcontra : c * e ^ 2 = 2 * -(m * n) := by
+      have ha : a = 2 * m := by omega
+      have hd : d = -n := by omega
+      rw [← hade, ha, hd]
+      ring
+    exact absurd hcontra (odd_mul_sq_ne_two_mul_odd hc2 hmnneg)
   · rfl
-  · exact absurd (show c * e ^ 2 = -4 * (m * n) by
-      rw [← hade]; rw [show a = 2 * m by omega, show d = -(2 * n) by omega]; ring)
-      (mod_four_mul_sq_ne_neg_four_mul hc hmn4)
-  · exact absurd (show c * e ^ 2 = 2 * (m * n) by
-      rw [← hade]; rw [show a = -(2 * m) by omega, show d = -n by omega]; ring)
-      (odd_mul_sq_ne_two_mul_odd hc2 hmn)
-  · exact absurd (show c * e ^ 2 = -4 * (m * n) by
-      rw [← hade]; rw [show a = -(2 * m) by omega, show d = 2 * n by omega]; ring)
-      (mod_four_mul_sq_ne_neg_four_mul hc hmn4)
+  · have hcontra : c * e ^ 2 = -4 * (m * n) := by
+      have ha : a = 2 * m := by omega
+      have hd : d = -(2 * n) := by omega
+      rw [← hade, ha, hd]
+      ring
+    exact absurd hcontra (mod_four_mul_sq_ne_neg_four_mul hc hmn4)
+  · have hcontra : c * e ^ 2 = 2 * (m * n) := by
+      have ha : a = -(2 * m) := by omega
+      have hd : d = -n := by omega
+      rw [← hade, ha, hd]
+      ring
+    exact absurd hcontra (odd_mul_sq_ne_two_mul_odd hc2 hmn)
+  · have hcontra : c * e ^ 2 = -4 * (m * n) := by
+      have ha : a = -(2 * m) := by omega
+      have hd : d = 2 * n := by omega
+      rw [← hade, ha, hd]
+      ring
+    exact absurd hcontra (mod_four_mul_sq_ne_neg_four_mul hc hmn4)
   · rfl
 
 /-- **A prime-discriminant factorization sits inside another.** Let `u` and `s` be finite sets of

--- a/TauCeti/NumberTheory/Multiquadratic/Unramified/Maximality.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Unramified/Maximality.lean
@@ -5,11 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Degree
 public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Ramification
 public import TauCeti.NumberTheory.Multiquadratic.Unramified.Basic
 public import TauCeti.NumberTheory.Multiquadratic.Unramified.Subfields
-import TauCeti.Algebra.Squarefree
+import TauCeti.FieldTheory.IntermediateField.Quadratic
 import TauCeti.NumberTheory.Multiquadratic.FundamentalDiscriminant.Subfactorization
 
 /-!
@@ -52,7 +51,7 @@ In the namespace `TauCeti.Multiquadratic`:
 
 * `exists_mem_candidateGenusField_sq_eq_intCast`: a quadratic subfield `ℚ(√a)` of such an `M` has
   its square root inside the candidate genus field.
-* `exists_algHom_mem_candidateGenusField`: `M` embeds over `ℚ` into the candidate genus field.
+* `nonempty_algHom_candidateGenusField`: `M` embeds over `ℚ` into the candidate genus field.
 * `finrank_le_finrank_candidateGenusField`: hence `[M : ℚ] ≤ [K_gen : ℚ]`, and
   `finrank_le_two_pow_card_genusPrimeDiscriminants` reads that bound off as `2 ^ t`.
 * `nonempty_algEquiv_candidateGenusField`: an extension attaining the bound is `ℚ`-isomorphic to
@@ -73,10 +72,11 @@ namespace TauCeti.Multiquadratic
 field.** If the prime discriminants in `u ⊆ genusPrimeDiscriminants hd` have product
 `fundamentalDiscriminant a`, then `candidateGenusField hd` contains an element squaring to `a`. -/
 theorem exists_mem_candidateGenusField_sq_eq_intCast_of_subset {d a : ℤ} (hd : Squarefree d)
-    {u : Finset ℤ} (hu : ∀ P ∈ u, IsPrimeDiscriminant P)
-    (huprod : ∏ P ∈ u, P = fundamentalDiscriminant a)
+    {u : Finset ℤ} (huprod : ∏ P ∈ u, P = fundamentalDiscriminant a)
     (hsub : u ⊆ genusPrimeDiscriminants hd) :
     ∃ z ∈ candidateGenusField hd, z ^ 2 = ((a : ℤ) : ℂ) := by
+  have hu : ∀ P ∈ u, IsPrimeDiscriminant P := fun P hP =>
+    (genusPrimeDiscriminants_spec hd).1 P (hsub hP)
   obtain ⟨z, hzmem, hz⟩ := exists_mem_adjoin_sq_eq_of_prod_primeDiscriminant_eq hu huprod
     (L := ℂ) (fun P => genusFieldRoot hd ⟨P.val, hsub P.property⟩) fun P => by simp
   refine ⟨z, adjoin_le_iff.mpr ?_ hzmem, ?_⟩
@@ -86,11 +86,33 @@ theorem exists_mem_candidateGenusField_sq_eq_intCast_of_subset {d a : ℤ} (hd :
 
 variable {M : Type*} [Field M] [NumberField M]
 
+private theorem finrank_adjoin_sq_eq_intCast {d : ℤ}
+    (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) {y : M} (hy : y ^ 2 = algebraMap ℤ M d) :
+    Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2 := by
+  have hy_sq_mem : y ^ 2 ∈ (⊥ : IntermediateField ℚ M) := by
+    rw [hy, IsScalarTower.algebraMap_apply ℤ ℚ M]
+    exact IntermediateField.algebraMap_mem _ _
+  have hyQ : y ^ 2 = algebraMap ℚ M ((d : ℤ) : ℚ) := by
+    rw [hy, IsScalarTower.algebraMap_apply ℤ ℚ M]
+    norm_num
+  have hy_not_mem : y ∉ (⊥ : IntermediateField ℚ M) := by
+    intro hy_mem
+    rw [IntermediateField.mem_bot] at hy_mem
+    obtain ⟨r, hr⟩ := hy_mem
+    apply hnsqd
+    refine ⟨r, ?_⟩
+    apply (algebraMap ℚ M).injective
+    simpa only [map_mul, hr, pow_two] using hyQ.symm
+  have hdeg := TauCeti.IntermediateField.finrank_sup_adjoin_simple_eq_mul_two
+    (⊥ : IntermediateField ℚ M) hy_sq_mem hy_not_mem
+  rw [bot_sup_eq] at hdeg
+  simpa using hdeg
+
 section IsGalois
 
 variable [IsGalois ℚ M]
 
-/-- **A quadratic subfield of an unramified abelian extension lies in the candidate genus field.**
+/-- **A quadratic subfield of an unramified Galois extension lies in the candidate genus field.**
 Let `M / ℚ` be Galois, let `y ∈ M` be a square root of a squarefree non-square `d` generating a
 quadratic subfield, and assume `M` is unramified over that subfield at every finite prime. Then for
 every squarefree non-square `a` with a square root in `M`, the candidate genus field
@@ -101,7 +123,6 @@ prime-discriminant factorization of the discriminant of `ℚ(√d)`. -/
 theorem exists_mem_candidateGenusField_sq_eq_intCast {d a : ℤ} (hd : Squarefree d)
     (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) (hsfa : Squarefree a) (hnsqa : ¬ IsSquare ((a : ℤ) : ℚ))
     {x y : M} (hx : x ^ 2 = algebraMap ℤ M a) (hy : y ^ 2 = algebraMap ℤ M d)
-    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
     (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
       Algebra.IsUnramifiedIn (𝓞 M) q) :
     ∃ z ∈ candidateGenusField hd, z ^ 2 = ((a : ℤ) : ℂ) := by
@@ -128,12 +149,13 @@ theorem exists_mem_candidateGenusField_sq_eq_intCast {d a : ℤ} (hd : Squarefre
     obtain ⟨u, hu, hue, huprod⟩ :=
       (isFundamentalDiscriminant_fundamentalDiscriminant hsfa).exists_finset_primeDiscriminant
     obtain ⟨hs, hse, hsprod⟩ := genusPrimeDiscriminants_spec hd
-    refine exists_mem_candidateGenusField_sq_eq_intCast_of_subset hd hu huprod
+    refine exists_mem_candidateGenusField_sq_eq_intCast_of_subset hd huprod
       (subset_of_forall_prime_dvd_fundamentalDiscriminant hs hse hsprod hu hue huprod hce
         (fun p hp hpa => dvd_fundamentalDiscriminant_base_of_dvd_subfield hsfa hnsqa hd hnsqd hx hy
           hunr hp hpa) fun h2 => ?_)
-    have h := not_dvd_fundamentalDiscriminant_mul_of_dvd_subfield hsfa hnsqa hsfc hnsqc hx hy hdeg
-      hunr he hce (p := 2) Nat.prime_two (by exact_mod_cast h2)
+    have hdeg := finrank_adjoin_sq_eq_intCast hnsqd hy
+    have h := not_dvd_fundamentalDiscriminant_mul_of_dvd_subfield hsfa hnsqa hsfc hnsqc hx hy
+      hdeg hunr he hce (p := 2) Nat.prime_two (by exact_mod_cast h2)
     exact_mod_cast h
 
 end IsGalois
@@ -145,17 +167,17 @@ variable [IsAbelianGalois ℚ M]
 /-- **Maximality of the candidate genus field.** Let `M / ℚ` be an abelian number-field extension
 containing a square root `y` of a squarefree non-square `d` that generates a quadratic subfield, and
 suppose `M` is unramified over that subfield at every finite prime. Then `M` admits a `ℚ`-embedding
-into `ℂ` whose image lies inside `candidateGenusField hd`.
+into `candidateGenusField hd`.
 
 Together with the facts that `candidateGenusField hd` is itself abelian over `ℚ`, contains a square
 root of `d`, and is unramified over `ℚ(√d)` at every finite prime, this says it is the largest such
 extension — the maximality half of the genus-field characterisation. -/
-theorem exists_algHom_mem_candidateGenusField {d : ℤ} (hd : Squarefree d)
+theorem nonempty_algHom_candidateGenusField {d : ℤ} (hd : Squarefree d)
     (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) {y : M} (hy : y ^ 2 = algebraMap ℤ M d)
-    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
     (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
       Algebra.IsUnramifiedIn (𝓞 M) q) :
-    ∃ φ : M →ₐ[ℚ] ℂ, ∀ m : M, φ m ∈ candidateGenusField hd := by
+    Nonempty (M →ₐ[ℚ] candidateGenusField hd) := by
+  have hdeg := finrank_adjoin_sq_eq_intCast hnsqd hy
   obtain ⟨n, a, root, hsf, hroot, hindep, htop, -⟩ :=
     exists_squarefree_root_adjoin_range_eq_top_of_isUnramifiedIn_over_quadratic
       (adjoin ℚ {y} : IntermediateField ℚ M) hdeg hunr
@@ -166,9 +188,8 @@ theorem exists_algHom_mem_candidateGenusField {d : ℤ} (hd : Squarefree d)
     have hxi : root i ^ 2 = algebraMap ℤ M (a i) := by
       rw [hroot i, IsScalarTower.algebraMap_apply ℤ ℚ M]
       norm_num
-    exact exists_mem_candidateGenusField_sq_eq_intCast hd hnsqd (hsf i) hnsqa hxi hy hdeg hunr
+    exact exists_mem_candidateGenusField_sq_eq_intCast hd hnsqd (hsf i) hnsqa hxi hy hunr
   choose z hzmem hzsq using key
-  refine ⟨IsAlgClosed.lift (R := ℚ) (S := M) (M := ℂ), fun m => ?_⟩
   set φ : M →ₐ[ℚ] ℂ := IsAlgClosed.lift
   have hle : adjoin ℚ (Set.range root) ≤ (candidateGenusField hd).comap φ := by
     rw [adjoin_le_iff]
@@ -176,26 +197,24 @@ theorem exists_algHom_mem_candidateGenusField {d : ℤ} (hd : Squarefree d)
     have hsqeq : φ (root i) ^ 2 = z i ^ 2 := by
       rw [← map_pow, hroot i, AlgHom.commutes, hzsq i]
       simp
-    change φ (root i) ∈ candidateGenusField hd
+    apply (Subalgebra.mem_comap (candidateGenusField hd).toSubalgebra φ (root i)).mpr
     rcases sq_eq_sq_iff_eq_or_eq_neg.mp hsqeq with h | h
     · rw [h]; exact hzmem i
     · rw [h]; exact neg_mem (hzmem i)
+  refine ⟨φ.codRestrict (candidateGenusField hd).toSubalgebra fun m => ?_⟩
   exact hle (by rw [htop]; exact IntermediateField.mem_top)
 
 /-- **The degree bound from maximality.** Under the hypotheses of
-`exists_algHom_mem_candidateGenusField`, the degree of `M` over `ℚ` is at most the degree of the
+`nonempty_algHom_candidateGenusField`, the degree of `M` over `ℚ` is at most the degree of the
 candidate genus field. -/
 theorem finrank_le_finrank_candidateGenusField {d : ℤ} (hd : Squarefree d)
     (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) {y : M} (hy : y ^ 2 = algebraMap ℤ M d)
-    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
     (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
       Algebra.IsUnramifiedIn (𝓞 M) q) :
     Module.finrank ℚ M ≤ Module.finrank ℚ (candidateGenusField hd) := by
-  obtain ⟨φ, hφ⟩ := exists_algHom_mem_candidateGenusField hd hnsqd hy hdeg hunr
-  set ψ : M →ₐ[ℚ] candidateGenusField hd :=
-    φ.codRestrict (candidateGenusField hd).toSubalgebra hφ
-  exact LinearMap.finrank_le_finrank_of_injective (f := ψ.toLinearMap)
-    fun _ _ h => ψ.toRingHom.injective h
+  obtain ⟨φ⟩ := nonempty_algHom_candidateGenusField hd hnsqd hy hunr
+  exact LinearMap.finrank_le_finrank_of_injective (f := φ.toLinearMap)
+    fun _ _ h => φ.toRingHom.injective h
 
 /-- **`[M : ℚ] ≤ 2 ^ t`.** An abelian extension of `ℚ` that is unramified at every finite prime
 over its quadratic subfield `ℚ(√d)` has degree at most `2 ^ t`, where `t` is the number of prime
@@ -204,34 +223,30 @@ discriminants dividing `fundamentalDiscriminant d` — equivalently, by
 `ℚ(√d)`. The bound is attained by the candidate genus field itself. -/
 theorem finrank_le_two_pow_card_genusPrimeDiscriminants {d : ℤ} (hd : Squarefree d)
     (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) {y : M} (hy : y ^ 2 = algebraMap ℤ M d)
-    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
     (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
       Algebra.IsUnramifiedIn (𝓞 M) q) :
     Module.finrank ℚ M ≤ 2 ^ (genusPrimeDiscriminants hd).card :=
-  (finrank_le_finrank_candidateGenusField hd hnsqd hy hdeg hunr).trans
+  (finrank_le_finrank_candidateGenusField hd hnsqd hy hunr).trans
     (finrank_candidateGenusField hd).le
 
 /-- **Uniqueness at the maximal degree.** An abelian extension of `ℚ` that is unramified at every
 finite prime over its quadratic subfield `ℚ(√d)` and attains the maximal degree `2 ^ t` is
 `ℚ`-isomorphic to the candidate genus field: the embedding of
-`exists_algHom_mem_candidateGenusField` is then forced to be onto. -/
+`nonempty_algHom_candidateGenusField` is then forced to be onto. -/
 theorem nonempty_algEquiv_candidateGenusField {d : ℤ} (hd : Squarefree d)
     (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) {y : M} (hy : y ^ 2 = algebraMap ℤ M d)
-    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
     (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
       Algebra.IsUnramifiedIn (𝓞 M) q)
     (hfr : Module.finrank ℚ M = 2 ^ (genusPrimeDiscriminants hd).card) :
     Nonempty (M ≃ₐ[ℚ] candidateGenusField hd) := by
-  obtain ⟨φ, hφ⟩ := exists_algHom_mem_candidateGenusField hd hnsqd hy hdeg hunr
-  set ψ : M →ₐ[ℚ] candidateGenusField hd :=
-    φ.codRestrict (candidateGenusField hd).toSubalgebra hφ
-  have hinj : Function.Injective ψ := fun _ _ h => ψ.toRingHom.injective h
+  obtain ⟨φ⟩ := nonempty_algHom_candidateGenusField hd hnsqd hy hunr
+  have hinj : Function.Injective φ := fun _ _ h => φ.toRingHom.injective h
   have hrank : Module.finrank ℚ M = Module.finrank ℚ (candidateGenusField hd) := by
     rw [hfr, finrank_candidateGenusField hd]
-  have hsurj : Function.Surjective ψ :=
+  have hsurj : Function.Surjective φ :=
     (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hrank
-      (f := ψ.toLinearMap)).mp hinj
-  exact ⟨AlgEquiv.ofBijective ψ ⟨hinj, hsurj⟩⟩
+      (f := φ.toLinearMap)).mp hinj
+  exact ⟨AlgEquiv.ofBijective φ ⟨hinj, hsurj⟩⟩
 
 end IsAbelianGalois
 

--- a/TauCeti/NumberTheory/Multiquadratic/Unramified/Maximality.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Unramified/Maximality.lean
@@ -1,0 +1,259 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Degree
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Ramification
+public import TauCeti.NumberTheory.Multiquadratic.Unramified.Basic
+public import TauCeti.NumberTheory.Multiquadratic.Unramified.Subfields
+import TauCeti.Algebra.Squarefree
+import TauCeti.NumberTheory.Multiquadratic.FundamentalDiscriminant.Subfactorization
+
+/-!
+# Maximality of the candidate genus field
+
+Let `d` be a squarefree integer that is not a rational square, let `M / ℚ` be an abelian number
+field extension, and let `y ∈ M` be a square root of `d` generating a quadratic subfield
+`F = ℚ(√d)` of `M`. If `M / F` is unramified at every finite prime, then `M` embeds over `ℚ` into
+the candidate genus field `candidateGenusField hd`. Since that field is itself such an extension —
+it is abelian over `ℚ`, contains a square root of `d`, and is unramified over `ℚ(√d)` at every
+finite prime — this makes it the *largest* one, which is the maximality half of the genus-field
+characterisation.
+
+The proof combines three inputs, one field-theoretic and two arithmetic.
+
+* `exists_squarefree_root_adjoin_range_eq_top_of_isUnramifiedIn_over_quadratic` presents `M` as
+  `ℚ(√a₁, …, √aₙ)` for square-class independent squarefree integers `aᵢ`.
+* `dvd_fundamentalDiscriminant_base_of_dvd_subfield` and
+  `not_dvd_fundamentalDiscriminant_mul_of_dvd_subfield` constrain each `aᵢ`: every prime ramifying
+  in `ℚ(√aᵢ)` ramifies in `ℚ(√d)`, and none of them ramifies in `ℚ(√(aᵢ d))`.
+* `subset_of_forall_prime_dvd_fundamentalDiscriminant` turns those two constraints into the
+  statement that the prime-discriminant factorization of `fundamentalDiscriminant aᵢ` is a *subset*
+  of the chosen factorization `genusPrimeDiscriminants hd`, whence `√aᵢ` lies in the compositum.
+
+An `aᵢ` in the square class of `d` is not covered by the second constraint — there `ℚ(√(aᵢ d)) = ℚ`
+— and is handled separately, by scaling the square root of `d` that the candidate genus field
+already contains.
+
+Once every generator has a square root inside `candidateGenusField hd`, any embedding
+`M →ₐ[ℚ] ℂ` sends the generators to `±` those square roots, hence lands inside the candidate genus
+field; comparing degrees gives `[M : ℚ] ≤ 2 ^ t` with `t` the number of primes ramifying in
+`ℚ(√d)`.
+
+This is the classical maximality argument for the genus field; see D. A. Cox, *Primes of the Form
+x² + ny²*, §6.A, and F. Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2.
+
+## Main results
+
+In the namespace `TauCeti.Multiquadratic`:
+
+* `exists_mem_candidateGenusField_sq_eq_intCast`: a quadratic subfield `ℚ(√a)` of such an `M` has
+  its square root inside the candidate genus field.
+* `exists_algHom_mem_candidateGenusField`: `M` embeds over `ℚ` into the candidate genus field.
+* `finrank_le_finrank_candidateGenusField`: hence `[M : ℚ] ≤ [K_gen : ℚ]`, and
+  `finrank_le_two_pow_card_genusPrimeDiscriminants` reads that bound off as `2 ^ t`.
+* `nonempty_algEquiv_candidateGenusField`: an extension attaining the bound is `ℚ`-isomorphic to
+  the candidate genus field.
+* `exists_isUnramifiedIn_and_finrank_eq_two_pow_card`: the candidate genus field is itself such an
+  extension, so the bound is attained and the uniqueness statement is not vacuous.
+-/
+
+public section
+
+open IntermediateField NumberField
+
+open scoped NumberField
+
+namespace TauCeti.Multiquadratic
+
+/-- **A subset of the chosen prime discriminants generates a square root inside the candidate genus
+field.** If the prime discriminants in `u ⊆ genusPrimeDiscriminants hd` have product
+`fundamentalDiscriminant a`, then `candidateGenusField hd` contains an element squaring to `a`. -/
+theorem exists_mem_candidateGenusField_sq_eq_intCast_of_subset {d a : ℤ} (hd : Squarefree d)
+    {u : Finset ℤ} (hu : ∀ P ∈ u, IsPrimeDiscriminant P)
+    (huprod : ∏ P ∈ u, P = fundamentalDiscriminant a)
+    (hsub : u ⊆ genusPrimeDiscriminants hd) :
+    ∃ z ∈ candidateGenusField hd, z ^ 2 = ((a : ℤ) : ℂ) := by
+  obtain ⟨z, hzmem, hz⟩ := exists_mem_adjoin_sq_eq_of_prod_primeDiscriminant_eq hu huprod
+    (L := ℂ) (fun P => genusFieldRoot hd ⟨P.val, hsub P.property⟩) fun P => by simp
+  refine ⟨z, adjoin_le_iff.mpr ?_ hzmem, ?_⟩
+  · rintro _ ⟨P, rfl⟩
+    exact genusFieldRoot_mem_candidateGenusField hd _
+  · rw [hz]; simp
+
+variable {M : Type*} [Field M] [NumberField M]
+
+section IsGalois
+
+variable [IsGalois ℚ M]
+
+/-- **A quadratic subfield of an unramified abelian extension lies in the candidate genus field.**
+Let `M / ℚ` be Galois, let `y ∈ M` be a square root of a squarefree non-square `d` generating a
+quadratic subfield, and assume `M` is unramified over that subfield at every finite prime. Then for
+every squarefree non-square `a` with a square root in `M`, the candidate genus field
+`candidateGenusField hd` contains an element squaring to `a`.
+
+This is the arithmetic core of maximality: the discriminant of `ℚ(√a)` is a *subproduct* of the
+prime-discriminant factorization of the discriminant of `ℚ(√d)`. -/
+theorem exists_mem_candidateGenusField_sq_eq_intCast {d a : ℤ} (hd : Squarefree d)
+    (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) (hsfa : Squarefree a) (hnsqa : ¬ IsSquare ((a : ℤ) : ℚ))
+    {x y : M} (hx : x ^ 2 = algebraMap ℤ M a) (hy : y ^ 2 = algebraMap ℤ M d)
+    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
+    (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
+      Algebra.IsUnramifiedIn (𝓞 M) q) :
+    ∃ z ∈ candidateGenusField hd, z ^ 2 = ((a : ℤ) : ℂ) := by
+  have hdQ : ((d : ℤ) : ℚ) ≠ 0 := Int.cast_ne_zero.mpr hd.ne_zero
+  by_cases hsq : IsSquare (((a * d : ℤ)) : ℚ)
+  · -- `a` and `d` are in the same square class: rescale the square root of `d`.
+    obtain ⟨r, hr⟩ := hsq
+    obtain ⟨w, hwmem, hw⟩ := exists_mem_candidateGenusField_sq_eq hd
+    have hkey : (r / ((d : ℤ) : ℚ)) ^ 2 * ((d : ℤ) : ℚ) = ((a : ℤ) : ℚ) := by
+      rw [div_pow, div_mul_eq_mul_div, div_eq_iff (pow_ne_zero 2 hdQ)]
+      push_cast at hr ⊢
+      linear_combination (-(d : ℚ)) * hr
+    refine ⟨algebraMap ℚ ℂ (r / ((d : ℤ) : ℚ)) * w,
+      mul_mem (IntermediateField.algebraMap_mem _ _) hwmem, ?_⟩
+    rw [mul_pow, hw, ← map_pow, ← map_mul, hkey]
+    simp
+  · -- Otherwise the two ramification constraints apply, and cut `u` down to a subset.
+    obtain ⟨c, e, hsfc, he, hce⟩ :=
+      Int.exists_squarefree_mul_sq (mul_ne_zero hsfa.ne_zero hd.ne_zero)
+    have hnsqc : ¬ IsSquare ((c : ℤ) : ℚ) := fun h => hsq <| by
+      have hcast : ((a * d : ℤ) : ℚ) = ((c : ℤ) : ℚ) * ((e : ℤ) : ℚ) ^ 2 := by
+        exact_mod_cast congrArg (fun n : ℤ => (n : ℚ)) hce
+      exact hcast ▸ (isSquare_mul_sq_iff (Int.cast_ne_zero.mpr he)).mpr h
+    obtain ⟨u, hu, hue, huprod⟩ :=
+      (isFundamentalDiscriminant_fundamentalDiscriminant hsfa).exists_finset_primeDiscriminant
+    obtain ⟨hs, hse, hsprod⟩ := genusPrimeDiscriminants_spec hd
+    refine exists_mem_candidateGenusField_sq_eq_intCast_of_subset hd hu huprod
+      (subset_of_forall_prime_dvd_fundamentalDiscriminant hs hse hsprod hu hue huprod hce
+        (fun p hp hpa => dvd_fundamentalDiscriminant_base_of_dvd_subfield hsfa hnsqa hd hnsqd hx hy
+          hunr hp hpa) fun h2 => ?_)
+    have h := not_dvd_fundamentalDiscriminant_mul_of_dvd_subfield hsfa hnsqa hsfc hnsqc hx hy hdeg
+      hunr he hce (p := 2) Nat.prime_two (by exact_mod_cast h2)
+    exact_mod_cast h
+
+end IsGalois
+
+section IsAbelianGalois
+
+variable [IsAbelianGalois ℚ M]
+
+/-- **Maximality of the candidate genus field.** Let `M / ℚ` be an abelian number-field extension
+containing a square root `y` of a squarefree non-square `d` that generates a quadratic subfield, and
+suppose `M` is unramified over that subfield at every finite prime. Then `M` admits a `ℚ`-embedding
+into `ℂ` whose image lies inside `candidateGenusField hd`.
+
+Together with the facts that `candidateGenusField hd` is itself abelian over `ℚ`, contains a square
+root of `d`, and is unramified over `ℚ(√d)` at every finite prime, this says it is the largest such
+extension — the maximality half of the genus-field characterisation. -/
+theorem exists_algHom_mem_candidateGenusField {d : ℤ} (hd : Squarefree d)
+    (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) {y : M} (hy : y ^ 2 = algebraMap ℤ M d)
+    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
+    (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
+      Algebra.IsUnramifiedIn (𝓞 M) q) :
+    ∃ φ : M →ₐ[ℚ] ℂ, ∀ m : M, φ m ∈ candidateGenusField hd := by
+  obtain ⟨n, a, root, hsf, hroot, hindep, htop, -⟩ :=
+    exists_squarefree_root_adjoin_range_eq_top_of_isUnramifiedIn_over_quadratic
+      (adjoin ℚ {y} : IntermediateField ℚ M) hdeg hunr
+  have key : ∀ i, ∃ z ∈ candidateGenusField hd, z ^ 2 = ((a i : ℤ) : ℂ) := fun i => by
+    have hnsqa : ¬ IsSquare ((a i : ℤ) : ℚ) := by
+      rw [Rat.isSquare_intCast_iff]
+      simpa using hindep {i} ⟨i, Finset.mem_singleton_self i⟩
+    have hxi : root i ^ 2 = algebraMap ℤ M (a i) := by
+      rw [hroot i, IsScalarTower.algebraMap_apply ℤ ℚ M]
+      norm_num
+    exact exists_mem_candidateGenusField_sq_eq_intCast hd hnsqd (hsf i) hnsqa hxi hy hdeg hunr
+  choose z hzmem hzsq using key
+  refine ⟨IsAlgClosed.lift (R := ℚ) (S := M) (M := ℂ), fun m => ?_⟩
+  set φ : M →ₐ[ℚ] ℂ := IsAlgClosed.lift
+  have hle : adjoin ℚ (Set.range root) ≤ (candidateGenusField hd).comap φ := by
+    rw [adjoin_le_iff]
+    rintro _ ⟨i, rfl⟩
+    have hsqeq : φ (root i) ^ 2 = z i ^ 2 := by
+      rw [← map_pow, hroot i, AlgHom.commutes, hzsq i]
+      simp
+    change φ (root i) ∈ candidateGenusField hd
+    rcases sq_eq_sq_iff_eq_or_eq_neg.mp hsqeq with h | h
+    · rw [h]; exact hzmem i
+    · rw [h]; exact neg_mem (hzmem i)
+  exact hle (by rw [htop]; exact IntermediateField.mem_top)
+
+/-- **The degree bound from maximality.** Under the hypotheses of
+`exists_algHom_mem_candidateGenusField`, the degree of `M` over `ℚ` is at most the degree of the
+candidate genus field. -/
+theorem finrank_le_finrank_candidateGenusField {d : ℤ} (hd : Squarefree d)
+    (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) {y : M} (hy : y ^ 2 = algebraMap ℤ M d)
+    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
+    (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
+      Algebra.IsUnramifiedIn (𝓞 M) q) :
+    Module.finrank ℚ M ≤ Module.finrank ℚ (candidateGenusField hd) := by
+  obtain ⟨φ, hφ⟩ := exists_algHom_mem_candidateGenusField hd hnsqd hy hdeg hunr
+  set ψ : M →ₐ[ℚ] candidateGenusField hd :=
+    φ.codRestrict (candidateGenusField hd).toSubalgebra hφ
+  exact LinearMap.finrank_le_finrank_of_injective (f := ψ.toLinearMap)
+    fun _ _ h => ψ.toRingHom.injective h
+
+/-- **`[M : ℚ] ≤ 2 ^ t`.** An abelian extension of `ℚ` that is unramified at every finite prime
+over its quadratic subfield `ℚ(√d)` has degree at most `2 ^ t`, where `t` is the number of prime
+discriminants dividing `fundamentalDiscriminant d` — equivalently, by
+`card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes`, the number of rational primes ramifying in
+`ℚ(√d)`. The bound is attained by the candidate genus field itself. -/
+theorem finrank_le_two_pow_card_genusPrimeDiscriminants {d : ℤ} (hd : Squarefree d)
+    (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) {y : M} (hy : y ^ 2 = algebraMap ℤ M d)
+    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
+    (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
+      Algebra.IsUnramifiedIn (𝓞 M) q) :
+    Module.finrank ℚ M ≤ 2 ^ (genusPrimeDiscriminants hd).card :=
+  (finrank_le_finrank_candidateGenusField hd hnsqd hy hdeg hunr).trans
+    (finrank_candidateGenusField hd).le
+
+/-- **Uniqueness at the maximal degree.** An abelian extension of `ℚ` that is unramified at every
+finite prime over its quadratic subfield `ℚ(√d)` and attains the maximal degree `2 ^ t` is
+`ℚ`-isomorphic to the candidate genus field: the embedding of
+`exists_algHom_mem_candidateGenusField` is then forced to be onto. -/
+theorem nonempty_algEquiv_candidateGenusField {d : ℤ} (hd : Squarefree d)
+    (hnsqd : ¬ IsSquare ((d : ℤ) : ℚ)) {y : M} (hy : y ^ 2 = algebraMap ℤ M d)
+    (hdeg : Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ M) = 2)
+    (hunr : ∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ M)), q.IsPrime → q ≠ ⊥ →
+      Algebra.IsUnramifiedIn (𝓞 M) q)
+    (hfr : Module.finrank ℚ M = 2 ^ (genusPrimeDiscriminants hd).card) :
+    Nonempty (M ≃ₐ[ℚ] candidateGenusField hd) := by
+  obtain ⟨φ, hφ⟩ := exists_algHom_mem_candidateGenusField hd hnsqd hy hdeg hunr
+  set ψ : M →ₐ[ℚ] candidateGenusField hd :=
+    φ.codRestrict (candidateGenusField hd).toSubalgebra hφ
+  have hinj : Function.Injective ψ := fun _ _ h => ψ.toRingHom.injective h
+  have hrank : Module.finrank ℚ M = Module.finrank ℚ (candidateGenusField hd) := by
+    rw [hfr, finrank_candidateGenusField hd]
+  have hsurj : Function.Surjective ψ :=
+    (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hrank
+      (f := ψ.toLinearMap)).mp hinj
+  exact ⟨AlgEquiv.ofBijective ψ ⟨hinj, hsurj⟩⟩
+
+end IsAbelianGalois
+
+/-- **The maximality bound is attained.** The candidate genus field of `ℚ(√d)` is itself an
+abelian extension of `ℚ` of the kind the bound governs: its chosen square root of `d` generates a
+quadratic subfield over which it is unramified at every finite prime, and its degree over `ℚ` is
+exactly `2 ^ t`. So the bound `finrank_le_two_pow_card_genusPrimeDiscriminants` is sharp, and
+`nonempty_algEquiv_candidateGenusField` applies to a nonempty class of extensions. -/
+theorem exists_isUnramifiedIn_and_finrank_eq_two_pow_card {d : ℤ} (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
+    ∃ y : candidateGenusField hd,
+      y ^ 2 = algebraMap ℤ (candidateGenusField hd) d ∧
+        Module.finrank ℚ (adjoin ℚ {y} : IntermediateField ℚ (candidateGenusField hd)) = 2 ∧
+        (∀ q : Ideal (𝓞 (adjoin ℚ {y} : IntermediateField ℚ (candidateGenusField hd))),
+            q.IsPrime → q ≠ ⊥ → Algebra.IsUnramifiedIn (𝓞 (candidateGenusField hd)) q) ∧
+        Module.finrank ℚ (candidateGenusField hd) = 2 ^ (genusPrimeDiscriminants hd).card := by
+  refine ⟨candidateGenusFieldBaseRoot hd, ?_, ?_, ?_, finrank_candidateGenusField hd⟩
+  · rw [candidateGenusFieldBaseRoot_sq hd, IsScalarTower.algebraMap_apply ℤ ℚ]
+    norm_num
+  · rw [← candidateGenusFieldBase_def hd]
+    exact finrank_candidateGenusFieldBase hd hnsq
+  · rw [← candidateGenusFieldBase_def hd]
+    exact fun q hq _ => isUnramifiedIn_candidateGenusField hd hnsq q
+
+end TauCeti.Multiquadratic


### PR DESCRIPTION
This PR proves the maximality half of the genus-field characterisation: an abelian number-field extension `M / ℚ` that contains a square root of a squarefree non-square `d` generating a quadratic subfield `ℚ(√d)`, and that is unramified over that subfield at every finite prime, embeds over `ℚ` into `candidateGenusField hd`. Since the candidate genus field is already known on `main` to be one such extension — abelian over `ℚ` (`IsAbelianGalois ℚ (candidateGenusField hd)`), containing a square root of `d`, and unramified over the embedded `ℚ(√d)` at every finite prime (`isUnramifiedIn_candidateGenusField`) — this makes it the largest one, and pins its degree `2 ^ t` as the maximum.

The exact roadmap target is `TauCetiRoadmap/Multiquadratic/README.md`, Layer 3 (*the genus field and the 2-rank theorem, the summit*), whose first clause asks to define `K_gen` as "the maximal extension of `K = ℚ(√d)` unramified at all places … and abelian over `ℚ`" and to "prove it is multiquadratic". Everything except maximality is on `main`: `candidateGenusField hd` exists, has degree `2 ^ t`, contains `√d`, is abelian, is unramified over `ℚ(√d)` at the finite places, and is totally complex for imaginary `d`; and the two ramification constraints on its competitors were merged in TauCeti#4469 (`exists_squarefree_root_adjoin_range_eq_top_of_isUnramifiedIn_over_quadratic`) and TauCeti#4533 (`dvd_fundamentalDiscriminant_base_of_dvd_subfield`, `not_dvd_fundamentalDiscriminant_mul_of_dvd_subfield`), with no consumer. This PR is that consumer: it is the step those two PRs were built for, and it is what the roadmap's "the *candidate* genus field, and honestly so" caveat has been waiting on.

`TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Subfactorization.lean` (new, 226 lines) is the arithmetic. Given prime-discriminant factorizations `∏ P ∈ u, P = fundamentalDiscriminant a` and `∏ P ∈ s, P = fundamentalDiscriminant d`, each with at most one even member, `subset_of_forall_prime_dvd_fundamentalDiscriminant` proves `u ⊆ s` from the two constraints above. The odd part is immediate — an odd prime lies under exactly one prime discriminant, so `eq_of_primeDiscriminantPrime_eq` identifies the factors. The even part is the trap the roadmap flags: `-4`, `8` and `-8` all lie over `2`, and divisibility cannot separate them (`-4 ∣ 8`, yet the quadratic field of discriminant `-4` is not the one of discriminant `8`) — which is exactly why the conclusion is a subset relation and not `fundamentalDiscriminant a ∣ fundamentalDiscriminant d`. What separates them is the second constraint. Splitting the even factor off each factorization (`exists_mod_four_eq_one_four_mul_eq`, using that a product of odd prime discriminants is `1` mod `4`) writes `4 * a = E * m` and `4 * d = F * n` with `m, n ≡ 1 (mod 4)`; a mismatch `E ≠ F` then makes `a * d` either twice an odd number or `-4` times a number that is `1` mod `4`, and `isEvenPrimeDiscriminant_eq_of_four_mul_eq` rules both out against `a * d = c * e ^ 2` with `c ≡ 1 (mod 4)`.

`TauCeti/NumberTheory/Multiquadratic/Unramified/Maximality.lean` (new, 258 lines) is the field theory. `exists_mem_candidateGenusField_sq_eq_intCast` puts a square root of each squarefree radicand of a quadratic subfield of `M` inside `candidateGenusField hd`, handling separately the radicands in the square class of `d`, where `ℚ(√(ad)) = ℚ` and the second constraint is empty; the square root of `d` the candidate genus field already carries is rescaled instead. `exists_algHom_mem_candidateGenusField` then takes any embedding `M →ₐ[ℚ] ℂ`, observes it sends each Kummer generator to `±` one of those square roots, and concludes via the universal property of `adjoin`. Three consequences follow: `finrank_le_finrank_candidateGenusField`, its numerical form `finrank_le_two_pow_card_genusPrimeDiscriminants` (`[M : ℚ] ≤ 2 ^ t`, with `t` the number of ramified primes by `card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes`), and `nonempty_algEquiv_candidateGenusField`: an extension attaining the bound is `ℚ`-isomorphic to the candidate genus field. `exists_isUnramifiedIn_and_finrank_eq_two_pow_card` closes the file by checking the candidate genus field satisfies the hypotheses itself, so the bound is attained and the uniqueness statement is not vacuous.

What remains for the milestone after this PR: an intrinsic `genusField` definition (maximal unramified at *all* places, abelian over `ℚ`) that this maximality theorem and the merged infinite-place results together discharge for imaginary `d`; the real case, where the infinite places force the narrow genus field; and then `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²`, for which `|Gal(K_gen/K)| = |Cl/Cl²|` (TauCeti#4206) is the imaginary-case cardinality half and the Artin map is still absent. This PR does not overlap the open Multiquadratic work: TauCeti#4831 proves *uniqueness* of the prime-discriminant factorization, which the argument here deliberately does not use — `subset_of_forall_prime_dvd_fundamentalDiscriminant` takes both factorizations as given and compares them directly — and TauCeti#4696 builds genus characters for the independent narrow lower-bound lane.

No Mathlib source and no external formalization is vendored. The roadmap designates kim-em/erdos-unit-distance as the migration source for its Layer-0 square-class machinery; none of it is used here, and both files are independently reconstructed from the classical argument in D. A. Cox, *Primes of the Form x² + ny²*, §6.A and F. Lemmermeyer, *Reciprocity Laws: From Euler to Eisenstein*, §2.2, cited in the module docstrings. No existing declaration is renamed, moved or deleted.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"unramified-abelian-embeds-candidate-genus-field"}-->

🤖 Prepared with Claude Code
