### PR TITLE
feat: add the integral spinor lattice

### DIFF
--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
@@ -40,7 +40,7 @@ private theorem contractLeft_ιMulti_eq_zero {n : ℕ}
 
 /-- Contracting an exterior-basis vector by a coordinate not in its index set gives zero. -/
 @[simp]
-theorem contractLeft_coord_basis_eq_zero_of_not_mem {I : Type w} [LinearOrder I]
+private theorem contractLeft_coord_basis_eq_zero_of_not_mem {I : Type w} [LinearOrder I]
     (b : Module.Basis I R M) (i : I) (s : Finset I) (hi : i ∉ s) :
     contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) = 0 := by
   rw [ExteriorAlgebra.basis_apply]
@@ -105,6 +105,7 @@ theorem basis_singleton_mul_basis_erase {I : Type w} [LinearOrder I]
 
 /-- Contracting an exterior-basis vector erases the contracted coordinate, with the shuffle sign
 that moves that coordinate to the front; it is zero when the coordinate is absent. -/
+@[simp]
 theorem contractLeft_coord_basis {I : Type w} [LinearOrder I]
     (b : Module.Basis I R M) (i : I) (s : Finset I) :
     contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) =

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
@@ -38,7 +38,9 @@ private theorem contractLeft_ιMulti_eq_zero {n : ℕ}
       rw [ExteriorAlgebra.ιMulti_succ_apply, contractLeft_ι_mul, h 0, zero_smul,
         ih (Matrix.vecTail v) (fun i ↦ h i.succ), mul_zero, sub_zero]
 
-private theorem contractLeft_basis_eq_zero_of_not_mem {I : Type w} [LinearOrder I]
+/-- Contracting an exterior-basis vector by a coordinate not in its index set gives zero. -/
+@[simp]
+theorem contractLeft_coord_basis_eq_zero_of_not_mem {I : Type w} [LinearOrder I]
     (b : Module.Basis I R M) (i : I) (s : Finset I) (hi : i ∉ s) :
     contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) = 0 := by
   rw [ExteriorAlgebra.basis_apply]
@@ -57,6 +59,12 @@ private theorem contractLeft_basis_eq_zero_of_not_mem {I : Type w} [LinearOrder 
     exact hj
   · rfl
 
+/-- The sign of moving `i` to the front of the ordered exterior-basis vector indexed by `s`. -/
+def basisEraseSign {I : Type w} [LinearOrder I] (i : I) (s : Finset I) : ℤˣ :=
+  let u : Set.powersetCard I 1 := ⟨{i}, Finset.card_singleton i⟩
+  let t : Set.powersetCard I (s.erase i).card := ⟨s.erase i, rfl⟩
+  (Set.powersetCard.permOfDisjoint (s := u) (t := t) (by simp [u, t])).sign
+
 /-- The exterior-basis vector indexed by a singleton is the image of the corresponding basis
 vector under the exterior-algebra generator. -/
 @[simp]
@@ -74,6 +82,55 @@ theorem basis_singleton {I : Type w} [LinearOrder I]
   have heq : Set.powersetCard.ofFinEmbEquiv.symm a 0 = i := Finset.eq_of_mem_singleton hj'
   exact congrArg (fun j ↦ ExteriorAlgebra.ι R (b j)) heq
 
+/-- Multiplying the basis vector for `i` by the basis vector for `s.erase i` reconstructs the
+basis vector for `s`, with the shuffle sign that moves `i` to the front. -/
+theorem basis_singleton_mul_basis_erase {I : Type w} [LinearOrder I]
+    (b : Module.Basis I R M) (i : I) (s : Finset I) (hi : i ∈ s) :
+    b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i) =
+      basisEraseSign i s • b.ExteriorAlgebra s := by
+  let u : Set.powersetCard I 1 := ⟨{i}, Finset.card_singleton i⟩
+  let t : Set.powersetCard I (s.erase i).card := ⟨s.erase i, rfl⟩
+  have hdisj : Disjoint u.val t.val := by simp [u, t]
+  have hunion : Set.powersetCard.disjUnion hdisj =
+      (Set.powersetCard.ofCard (s := s) (by
+        rw [Finset.card_erase_of_mem hi]
+        have : 0 < s.card := Finset.card_pos.mpr ⟨i, hi⟩
+        omega) : Set.powersetCard I (1 + (s.erase i).card)) := by
+    apply Subtype.ext
+    simp [Set.powersetCard.disjUnion, u, t, hi]
+  have hprod := ExteriorAlgebra.basis_mul_of_disjoint b u t hdisj
+  rw [hunion] at hprod
+  simpa [basisEraseSign, u, t] using hprod
+
+/-- Contracting an exterior-basis vector erases the contracted coordinate, with the shuffle sign
+that moves that coordinate to the front; it is zero when the coordinate is absent. -/
+theorem contractLeft_coord_basis {I : Type w} [LinearOrder I]
+    (b : Module.Basis I R M) (i : I) (s : Finset I) :
+    contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) =
+      if i ∈ s then basisEraseSign i s • b.ExteriorAlgebra (s.erase i) else 0 := by
+  classical
+  split_ifs with hi
+  · have hprod' := basis_singleton_mul_basis_erase b i s hi
+    have hcontract : contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i)
+        (b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i)) =
+        b.ExteriorAlgebra (s.erase i) := by
+      rw [basis_singleton, contractLeft_ι_mul]
+      simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
+      rw [contractLeft_coord_basis_eq_zero_of_not_mem b i (s.erase i) (by simp),
+        mul_zero, sub_zero]
+      simp
+    rcases Int.units_eq_one_or (basisEraseSign i s) with hsign | hsign
+    · rw [hsign, one_smul] at hprod' ⊢
+      rw [← hprod']
+      exact hcontract
+    · have hprodNeg : b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i) =
+          -b.ExteriorAlgebra s := by
+        simpa [hsign] using hprod'
+      rw [hprodNeg, map_neg] at hcontract
+      have h := congrArg Neg.neg hcontract
+      simpa [hsign] using h
+  · exact contractLeft_coord_basis_eq_zero_of_not_mem b i s hi
+
 /-- Creation after contraction by a basis coordinate is the projection onto exterior basis
 vectors containing that coordinate. -/
 @[simp]
@@ -82,34 +139,12 @@ theorem ι_mul_contractLeft_coord_basis {I : Type w} [LinearOrder I]
     ExteriorAlgebra.ι R (b i) *
         contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i) (b.ExteriorAlgebra s) =
       if i ∈ s then b.ExteriorAlgebra s else 0 := by
+  rw [contractLeft_coord_basis]
   split_ifs with hi
-  · let a : Set.powersetCard I 1 := ⟨{i}, Finset.card_singleton i⟩
-    let t : Set.powersetCard I (s.erase i).card := ⟨s.erase i, rfl⟩
-    have hdisj : Disjoint a.val t.val := by simp [a, t]
-    have hunion : Set.powersetCard.disjUnion hdisj =
-        (Set.powersetCard.ofCard (s := s) (by
-          rw [Finset.card_erase_of_mem hi]
-          have : 0 < s.card := Finset.card_pos.mpr ⟨i, hi⟩
-          omega) : Set.powersetCard I (1 + (s.erase i).card)) := by
-      apply Subtype.ext
-      simp [Set.powersetCard.disjUnion, a, t, hi]
-    have hprod := ExteriorAlgebra.basis_mul_of_disjoint b a t hdisj
-    rw [hunion] at hprod
-    simp only [a, t, Set.powersetCard.val_ofCard] at hprod
-    have hfixed : ExteriorAlgebra.ι R (b i) *
-        contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i)
-          (b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i)) =
-        b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i) := by
-      rw [basis_singleton]
-      rw [contractLeft_ι_mul]
-      simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
-      rw [contractLeft_basis_eq_zero_of_not_mem b i (s.erase i) (by simp),
-        mul_zero, sub_zero]
-      simp
-    rw [hprod] at hfixed
-    rcases Int.units_eq_one_or (Equiv.Perm.sign
-      (Set.powersetCard.permOfDisjoint hdisj)) with hsign | hsign <;>
-      rw [hsign] at hfixed <;> simpa using hfixed
-  · rw [contractLeft_basis_eq_zero_of_not_mem b i s hi, mul_zero]
+  · rw [← basis_singleton]
+    rw [mul_smul_comm]
+    rw [basis_singleton_mul_basis_erase b i s hi]
+    rcases Int.units_eq_one_or (basisEraseSign i s) with hsign | hsign <;> simp [hsign]
+  · rw [mul_zero]
 
 end TauCeti.ExteriorAlgebra

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
@@ -57,7 +57,10 @@ private theorem contractLeft_basis_eq_zero_of_not_mem {I : Type w} [LinearOrder 
     exact hj
   · rfl
 
-private theorem basis_exteriorAlgebra_singleton_eq_ι {I : Type w} [LinearOrder I]
+/-- The exterior-basis vector indexed by a singleton is the image of the corresponding basis
+vector under the exterior-algebra generator. -/
+@[simp]
+theorem basis_singleton {I : Type w} [LinearOrder I]
     (b : Module.Basis I R M) (i : I) :
     b.ExteriorAlgebra {i} = ExteriorAlgebra.ι R (b i) := by
   let a : Set.powersetCard I 1 :=
@@ -97,7 +100,7 @@ theorem ι_mul_contractLeft_coord_basis {I : Type w} [LinearOrder I]
         contractLeft (Q := (0 : QuadraticForm R M)) (b.coord i)
           (b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i)) =
         b.ExteriorAlgebra {i} * b.ExteriorAlgebra (s.erase i) := by
-      rw [basis_exteriorAlgebra_singleton_eq_ι]
+      rw [basis_singleton]
       rw [contractLeft_ι_mul]
       simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
       rw [contractLeft_basis_eq_zero_of_not_mem b i (s.erase i) (by simp),

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
@@ -134,8 +134,10 @@ theorem contractLeft_coord_basis {I : Type w} [LinearOrder I]
   · exact contractLeft_coord_basis_eq_zero_of_not_mem b i s hi
 
 /-- Creation after contraction by a basis coordinate is the projection onto exterior basis
-vectors containing that coordinate. -/
-@[simp]
+vectors containing that coordinate.
+
+This is not a `simp` lemma because `contractLeft_coord_basis` is the canonical normal form for
+the contraction in its left-hand side. -/
 theorem ι_mul_contractLeft_coord_basis {I : Type w} [LinearOrder I]
     (b : Module.Basis I R M) (i : I) (s : Finset I) :
     ExteriorAlgebra.ι R (b i) *

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Contraction.lean
@@ -59,7 +59,8 @@ theorem contractLeft_coord_basis_eq_zero_of_not_mem {I : Type w} [LinearOrder I]
     exact hj
   · rfl
 
-/-- The sign of moving `i` to the front of the ordered exterior-basis vector indexed by `s`. -/
+/-- The shuffle sign for the singleton basis vector indexed by `i` followed by the basis vector
+indexed by `s.erase i`. When `i ∈ s`, this is the sign of moving `i` to the front of `s`. -/
 def basisEraseSign {I : Type w} [LinearOrder I] (i : I) (s : Finset I) : ℤˣ :=
   let u : Set.powersetCard I 1 := ⟨{i}, Finset.card_singleton i⟩
   let t : Set.powersetCard I (s.erase i).card := ⟨s.erase i, rfl⟩

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/End.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/End.lean
@@ -94,7 +94,8 @@ private theorem basisFactor_apply {n : ℕ}
         (b.ExteriorAlgebra t) =
       (if (i ∈ s ↔ i ∈ t) then 1 else 0) • b.ExteriorAlgebra t := by
   by_cases his : i ∈ s <;> by_cases hit : i ∈ t <;>
-    simp [his, hit, occupationProjection, ι_mul_contractLeft_coord_basis,
+    simp [-contractLeft_coord_basis, his, hit, occupationProjection,
+      ι_mul_contractLeft_coord_basis,
       vacancyProjection_basis]
 
 private theorem listProd_basisFactor_apply {n : ℕ}

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/IntegralLattice.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/IntegralLattice.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+import TauCeti.LinearAlgebra.IntegralLattice.Basic
+
+public import TauCeti.Algebra.Module.Lattice
+public import TauCeti.LinearAlgebra.ExteriorAlgebra.Contraction
+
+/-!
+# The coordinate integral lattice in an exterior algebra
+
+Let `b : Basis ι ℚ M`. The exterior basis `b.ExteriorAlgebra`, indexed by finite subsets of `ι`,
+defines a canonical integral form of `ExteriorAlgebra ℚ M`: take the `ℤ`-span of its basis vectors.
+This file constructs that lattice and proves that it is closed under the exterior product.
+
+The multiplication statement is the useful point. Products of exterior basis vectors are either
+zero or another basis vector with sign given by the shuffle permutation, so multiplication does
+not introduce denominators. In particular, exterior multiplication by any basis vector preserves
+the lattice. This is the creation-operator half of the integral spinor lattice used to construct
+the simply connected type-`B` and type-`D` Chevalley carriers.
+
+## Main definitions and results
+
+* `TauCeti.ExteriorAlgebra.integralLattice`: the `ℤ`-span of an exterior basis.
+* `TauCeti.ExteriorAlgebra.integralLatticeBasis`: the exterior basis restricted to `ℤ`.
+* `TauCeti.ExteriorAlgebra.mem_integralLattice_iff`: membership means that every exterior-basis
+  coordinate is integral.
+* `TauCeti.ExteriorAlgebra.mul_mem_integralLattice`: the lattice is closed under multiplication.
+* `TauCeti.ExteriorAlgebra.ι_basis_mul_mem_integralLattice`: creation by a basis vector preserves
+  the lattice.
+* `TauCeti.ExteriorAlgebra.contractLeft_coord_mem_integralLattice`: contraction by a dual basis
+  coordinate preserves the lattice.
+
+## Roadmap
+
+This is the integral-lattice input for the full-weight spin carriers required by Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md`. Those type-`B` and type-`D` carriers are in turn
+consumed by milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md`.
+
+## References
+
+* C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+-/
+
+public section
+
+namespace TauCeti.ExteriorAlgebra
+
+universe u
+
+variable {M : Type u} [AddCommGroup M] [Module ℚ M]
+variable {ι : Type*} [LinearOrder ι] (b : Module.Basis ι ℚ M)
+
+/-- The coordinate `ℤ`-lattice in an exterior algebra, spanned by the exterior basis attached to
+`b`. -/
+def integralLattice : Submodule ℤ (_root_.ExteriorAlgebra ℚ M) :=
+  Submodule.span ℤ (Set.range b.ExteriorAlgebra)
+
+/-- An element belongs to the coordinate integral lattice exactly when all of its exterior-basis
+coordinates are integers. -/
+@[simp]
+theorem mem_integralLattice_iff {x : _root_.ExteriorAlgebra ℚ M} :
+    x ∈ integralLattice b ↔
+      ∀ s, ∃ z : ℤ, (z : ℚ) = b.ExteriorAlgebra.repr x s := by
+  rw [integralLattice, Module.Basis.mem_span_iff_repr_mem]
+  simp only [algebraMap_int_eq, Int.coe_castRingHom, Set.mem_range]
+
+/-- Every exterior-basis vector belongs to the coordinate integral lattice. -/
+theorem basis_mem_integralLattice (s : Finset ι) :
+    b.ExteriorAlgebra s ∈ integralLattice b := by
+  rw [integralLattice]
+  exact Submodule.subset_span (Set.mem_range_self s)
+
+/-- The exterior basis, restricted from rational to integer scalars, is a basis of the coordinate
+integral lattice. -/
+noncomputable def integralLatticeBasis :
+    Module.Basis (Finset ι) ℤ (integralLattice b) :=
+  b.ExteriorAlgebra.restrictScalars ℤ
+
+/-- A vector of the integral-lattice basis is the corresponding rational exterior-basis vector. -/
+@[simp]
+theorem coe_integralLatticeBasis (s : Finset ι) :
+    ((integralLatticeBasis b s : integralLattice b) :
+      _root_.ExteriorAlgebra ℚ M) = b.ExteriorAlgebra s := by
+  unfold integralLatticeBasis integralLattice
+  rw [Module.Basis.restrictScalars_apply]
+
+noncomputable instance : Module.Free ℤ (integralLattice b) :=
+  Module.Free.of_basis (integralLatticeBasis b)
+
+/-- The rational span of the coordinate integral lattice is the whole exterior algebra. -/
+theorem span_integralLattice_eq_top :
+    Submodule.span ℚ (integralLattice b : Set (_root_.ExteriorAlgebra ℚ M)) = ⊤ := by
+  rw [integralLattice, Submodule.span_span_of_tower, b.ExteriorAlgebra.span_eq]
+
+section Finite
+
+variable [Finite ι]
+
+noncomputable local instance : Fintype ι := Fintype.ofFinite ι
+
+noncomputable instance : Module.Finite ℤ (integralLattice b) :=
+  Module.Finite.of_basis (integralLatticeBasis b)
+
+/-- The coordinate integral lattice has rank `2 ^ card ι`. -/
+@[simp]
+theorem finrank_integralLattice :
+    Module.finrank ℤ (integralLattice b) = 2 ^ Nat.card ι := by
+  have h := Module.finrank_eq_card_basis (integralLatticeBasis b)
+  simpa only [Fintype.card_finset, Nat.card_eq_fintype_card] using h
+
+instance : Submodule.IsLattice ℚ (integralLattice b) where
+  __ := TauCeti.IntegralLattice.isLattice_span_basis b.ExteriorAlgebra
+
+end Finite
+
+/-- The unit of the exterior algebra belongs to the coordinate integral lattice. -/
+theorem one_mem_integralLattice :
+    (1 : _root_.ExteriorAlgebra ℚ M) ∈ integralLattice b := by
+  have h := basis_mem_integralLattice b (∅ : Finset ι)
+  simpa [_root_.ExteriorAlgebra.basis_apply] using h
+
+/-- The product of two exterior-basis vectors belongs to the coordinate integral lattice. -/
+theorem basis_mul_basis_mem_integralLattice (s t : Finset ι) :
+    b.ExteriorAlgebra s * b.ExteriorAlgebra t ∈ integralLattice b := by
+  by_cases h : Disjoint s t
+  · have h' : Disjoint
+        (⟨s, rfl⟩ : Set.powersetCard ι s.card).val
+        (⟨t, rfl⟩ : Set.powersetCard ι t.card).val := by
+      simpa using h
+    rw [_root_.ExteriorAlgebra.basis_mul_of_disjoint b
+      (⟨s, rfl⟩ : Set.powersetCard ι s.card)
+      (⟨t, rfl⟩ : Set.powersetCard ι t.card) h']
+    exact Submodule.smul_mem _ _ (basis_mem_integralLattice b _)
+  · have h' : ¬Disjoint
+        (⟨s, rfl⟩ : Set.powersetCard ι s.card).val
+        (⟨t, rfl⟩ : Set.powersetCard ι t.card).val := by
+      simpa using h
+    rw [_root_.ExteriorAlgebra.basis_mul_of_not_disjoint b
+      (⟨s, rfl⟩ : Set.powersetCard ι s.card)
+      (⟨t, rfl⟩ : Set.powersetCard ι t.card) h']
+    exact zero_mem _
+
+/-- The coordinate integral lattice is closed under the exterior-algebra multiplication. -/
+theorem mul_mem_integralLattice {x y : _root_.ExteriorAlgebra ℚ M}
+    (hx : x ∈ integralLattice b) (hy : y ∈ integralLattice b) :
+    x * y ∈ integralLattice b := by
+  rw [integralLattice] at hx hy ⊢
+  induction hx using Submodule.span_induction with
+  | mem x hx =>
+      obtain ⟨s, rfl⟩ := hx
+      induction hy using Submodule.span_induction with
+      | mem y hy =>
+          obtain ⟨t, rfl⟩ := hy
+          exact basis_mul_basis_mem_integralLattice b s t
+      | zero => simp
+      | add y z _ _ hy hz => simpa only [mul_add] using add_mem hy hz
+      | smul z y _ hy =>
+          simpa only [← Int.cast_smul_eq_zsmul ℚ, mul_smul_comm] using
+            Submodule.smul_mem _ z hy
+  | zero => simp
+  | add x z _ _ hx hz => simpa only [add_mul] using add_mem hx hz
+  | smul z x _ hx =>
+      simpa only [← Int.cast_smul_eq_zsmul ℚ, smul_mul_assoc] using
+        Submodule.smul_mem _ z hx
+
+/-- Exterior multiplication by a basis vector preserves the coordinate integral lattice. -/
+theorem ι_basis_mul_mem_integralLattice (i : ι) {x : _root_.ExteriorAlgebra ℚ M}
+    (hx : x ∈ integralLattice b) :
+    _root_.ExteriorAlgebra.ι ℚ (b i) * x ∈ integralLattice b := by
+  have hi : _root_.ExteriorAlgebra.ι ℚ (b i) ∈ integralLattice b := by
+    have h := basis_mem_integralLattice b ({i} : Finset ι)
+    simpa only [basis_singleton] using h
+  exact mul_mem_integralLattice b hi hx
+
+/-- Contracting an exterior-basis vector by a dual basis coordinate gives an element of the
+coordinate integral lattice. -/
+theorem contractLeft_coord_basis_mem_integralLattice (i : ι) (s : Finset ι) :
+    CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm ℚ M)) (b.coord i)
+        (b.ExteriorAlgebra s) ∈ integralLattice b := by
+  classical
+  induction s using Finset.induction_on with
+  | empty =>
+      simp [_root_.ExteriorAlgebra.basis_apply]
+  | @insert a s ha ih =>
+      let u : Set.powersetCard ι 1 := ⟨{a}, Finset.card_singleton a⟩
+      let t : Set.powersetCard ι s.card := ⟨s, rfl⟩
+      have hdisj : Disjoint u.val t.val := by
+        simp [u, t, ha]
+      have hunion : (Set.powersetCard.disjUnion hdisj).val = insert a s := by
+        ext j
+        simp [Set.powersetCard.disjUnion, u, t]
+      have hprod := _root_.ExteriorAlgebra.basis_mul_of_disjoint b u t hdisj
+      rw [hunion] at hprod
+      have hfirst : (b.coord i) (b a) • b.ExteriorAlgebra s ∈ integralLattice b := by
+        simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
+        split_ifs <;> simp only [one_smul, zero_smul, basis_mem_integralLattice, zero_mem]
+      have hsecond : _root_.ExteriorAlgebra.ι ℚ (b a) *
+          CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm ℚ M)) (b.coord i)
+            (b.ExteriorAlgebra s) ∈ integralLattice b :=
+        ι_basis_mul_mem_integralLattice b a ih
+      have hleft : CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm ℚ M)) (b.coord i)
+          (b.ExteriorAlgebra {a} * b.ExteriorAlgebra s) ∈ integralLattice b := by
+        rw [basis_singleton, CliffordAlgebra.contractLeft_ι_mul]
+        exact sub_mem hfirst hsecond
+      rcases Int.units_eq_one_or (Equiv.Perm.sign
+        (Set.powersetCard.permOfDisjoint hdisj)) with hsign | hsign
+      · rw [hsign, one_smul] at hprod
+        rw [← hprod]
+        exact hleft
+      · rw [hsign] at hprod
+        have hprod' : b.ExteriorAlgebra {a} * b.ExteriorAlgebra s =
+            -b.ExteriorAlgebra (insert a s) := by
+          simpa [u, t] using hprod
+        have hneg : -CliffordAlgebra.contractLeft
+            (Q := (0 : QuadraticForm ℚ M)) (b.coord i)
+              (b.ExteriorAlgebra (insert a s)) ∈ integralLattice b := by
+          rw [← map_neg, ← hprod']
+          exact hleft
+        exact (neg_mem_iff.mp hneg)
+
+/-- Contraction by a dual basis coordinate preserves the coordinate integral lattice. This is the
+annihilation-operator counterpart of `ι_basis_mul_mem_integralLattice`. -/
+theorem contractLeft_coord_mem_integralLattice (i : ι)
+    {x : _root_.ExteriorAlgebra ℚ M} (hx : x ∈ integralLattice b) :
+    CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm ℚ M)) (b.coord i) x ∈
+      integralLattice b := by
+  rw [integralLattice] at hx ⊢
+  induction hx using Submodule.span_induction with
+  | mem x hx =>
+      obtain ⟨s, rfl⟩ := hx
+      exact contractLeft_coord_basis_mem_integralLattice b i s
+  | zero => rw [map_zero]; exact zero_mem _
+  | add x y _ _ hx hy => rw [map_add]; exact add_mem hx hy
+  | smul z x _ hx =>
+      rw [← Int.cast_smul_eq_zsmul ℚ, map_smul, Int.cast_smul_eq_zsmul ℚ]
+      exact Submodule.smul_mem _ z hx
+
+end TauCeti.ExteriorAlgebra

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/IntegralLattice.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/IntegralLattice.lean
@@ -102,7 +102,8 @@ section Finite
 
 variable [Finite ι]
 
-noncomputable local instance : Fintype ι := Fintype.ofFinite ι
+/-- The finite type structure on the index type used within this section. -/
+noncomputable local instance finiteIndexFintype : Fintype ι := Fintype.ofFinite ι
 
 noncomputable instance : Module.Finite ℤ (integralLattice b) :=
   Module.Finite.of_basis (integralLatticeBasis b)

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/IntegralLattice.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/IntegralLattice.lean
@@ -7,7 +7,7 @@ module
 
 import TauCeti.LinearAlgebra.IntegralLattice.Basic
 
-public import TauCeti.Algebra.Module.Lattice
+public import Mathlib.Algebra.Module.Lattice
 public import TauCeti.LinearAlgebra.ExteriorAlgebra.Contraction
 
 /-!
@@ -184,46 +184,11 @@ coordinate integral lattice. -/
 theorem contractLeft_coord_basis_mem_integralLattice (i : ι) (s : Finset ι) :
     CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm ℚ M)) (b.coord i)
         (b.ExteriorAlgebra s) ∈ integralLattice b := by
-  classical
-  induction s using Finset.induction_on with
-  | empty =>
-      simp [_root_.ExteriorAlgebra.basis_apply]
-  | @insert a s ha ih =>
-      let u : Set.powersetCard ι 1 := ⟨{a}, Finset.card_singleton a⟩
-      let t : Set.powersetCard ι s.card := ⟨s, rfl⟩
-      have hdisj : Disjoint u.val t.val := by
-        simp [u, t, ha]
-      have hunion : (Set.powersetCard.disjUnion hdisj).val = insert a s := by
-        ext j
-        simp [Set.powersetCard.disjUnion, u, t]
-      have hprod := _root_.ExteriorAlgebra.basis_mul_of_disjoint b u t hdisj
-      rw [hunion] at hprod
-      have hfirst : (b.coord i) (b a) • b.ExteriorAlgebra s ∈ integralLattice b := by
-        simp only [Module.Basis.coord_apply, Module.Basis.repr_self, Finsupp.single_apply]
-        split_ifs <;> simp only [one_smul, zero_smul, basis_mem_integralLattice, zero_mem]
-      have hsecond : _root_.ExteriorAlgebra.ι ℚ (b a) *
-          CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm ℚ M)) (b.coord i)
-            (b.ExteriorAlgebra s) ∈ integralLattice b :=
-        ι_basis_mul_mem_integralLattice b a ih
-      have hleft : CliffordAlgebra.contractLeft (Q := (0 : QuadraticForm ℚ M)) (b.coord i)
-          (b.ExteriorAlgebra {a} * b.ExteriorAlgebra s) ∈ integralLattice b := by
-        rw [basis_singleton, CliffordAlgebra.contractLeft_ι_mul]
-        exact sub_mem hfirst hsecond
-      rcases Int.units_eq_one_or (Equiv.Perm.sign
-        (Set.powersetCard.permOfDisjoint hdisj)) with hsign | hsign
-      · rw [hsign, one_smul] at hprod
-        rw [← hprod]
-        exact hleft
-      · rw [hsign] at hprod
-        have hprod' : b.ExteriorAlgebra {a} * b.ExteriorAlgebra s =
-            -b.ExteriorAlgebra (insert a s) := by
-          simpa [u, t] using hprod
-        have hneg : -CliffordAlgebra.contractLeft
-            (Q := (0 : QuadraticForm ℚ M)) (b.coord i)
-              (b.ExteriorAlgebra (insert a s)) ∈ integralLattice b := by
-          rw [← map_neg, ← hprod']
-          exact hleft
-        exact (neg_mem_iff.mp hneg)
+  rw [contractLeft_coord_basis]
+  split_ifs
+  · exact Submodule.smul_mem _ (basisEraseSign i s : ℤ)
+      (basis_mem_integralLattice b (s.erase i))
+  · exact zero_mem _
 
 /-- Contraction by a dual basis coordinate preserves the coordinate integral lattice. This is the
 annihilation-operator counterpart of `ι_basis_mul_mem_integralLattice`. -/

--- a/TauCeti/RepresentationTheory/Spin/IntegralLattice.lean
+++ b/TauCeti/RepresentationTheory/Spin/IntegralLattice.lean
@@ -31,6 +31,8 @@ step.
 
 * `TauCeti.SpinPolarizationData.integralSpinActionSubring`: the Clifford elements whose action
   preserves the coordinate integral lattice.
+* `TauCeti.SpinPolarizationData.integralSpinAction`: their induced integral representation on
+  that lattice.
 * `TauCeti.SpinPolarizationData.ι_basis_mem_integralSpinActionSubring`: creation operators are
   integral.
 * `TauCeti.SpinPolarizationData.ι_dualVector_mem_integralSpinActionSubring`: annihilation
@@ -91,6 +93,35 @@ theorem mem_integralSpinActionSubring {c : CliffordAlgebra Q} :
         (TauCeti.ExteriorAlgebra.integralLattice b)
         (TauCeti.ExteriorAlgebra.integralLattice b) :=
   Iff.rfl
+
+/-- The integral representation obtained by restricting the spin action to the Clifford elements
+that preserve the coordinate integral lattice. -/
+noncomputable def integralSpinAction :
+    P.integralSpinActionSubring b →+*
+      Module.End ℤ (TauCeti.ExteriorAlgebra.integralLattice b) where
+  toFun c :=
+    { toFun := fun x =>
+        ⟨spinAction Q P (c : CliffordAlgebra Q) x,
+          c.property x.property⟩
+      map_add' := fun x y => Subtype.ext (by simp)
+      map_smul' := fun z x => Subtype.ext
+        (map_zsmul (spinAction Q P (c : CliffordAlgebra Q)) z
+          (x : ExteriorAlgebra ℚ P.W)) }
+  map_one' := LinearMap.ext fun x => Subtype.ext (by simp)
+  map_mul' := fun c d => LinearMap.ext fun x => Subtype.ext (by simp)
+  map_zero' := LinearMap.ext fun x => Subtype.ext (by simp)
+  map_add' := fun c d => LinearMap.ext fun x => Subtype.ext (by simp)
+
+/-- The ambient value of the integral spin action is the original rational spin action. -/
+@[simp]
+theorem coe_integralSpinAction_apply (c : P.integralSpinActionSubring b)
+    (x : TauCeti.ExteriorAlgebra.integralLattice b) :
+    ((P.integralSpinAction b c x : TauCeti.ExteriorAlgebra.integralLattice b) :
+        ExteriorAlgebra ℚ P.W) =
+      spinAction Q P (c : CliffordAlgebra Q) (x : ExteriorAlgebra ℚ P.W) :=
+  by
+    rw [integralSpinAction]
+    rfl
 
 /-- A basis vector in the first isotropic summand acts integrally on the spinor lattice: its
 Clifford action is exterior multiplication by that basis vector. -/

--- a/TauCeti/RepresentationTheory/Spin/IntegralLattice.lean
+++ b/TauCeti/RepresentationTheory/Spin/IntegralLattice.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.ExteriorAlgebra.IntegralLattice
+public import TauCeti.RepresentationTheory.Spin.Polarization.CliffordAction
+
+/-!
+# The integral lattice in the spinor module
+
+For a polarized rational quadratic space, the spinor module is the exterior algebra of the first
+isotropic summand. A basis `b` of that summand gives it the coordinate integral lattice
+`TauCeti.ExteriorAlgebra.integralLattice b`.
+
+This file packages the Clifford elements whose spin action preserves that lattice as a subring.
+The two primitive kinds of Clifford generator used in the Fock model belong to it: a basis vector
+of the first isotropic summand acts by exterior multiplication (creation), and its polar-dual
+vector in the second summand acts by contraction by the corresponding coordinate (annihilation).
+Consequently every integral noncommutative polynomial in creation and annihilation operators
+preserves the spinor lattice. This is the integrality mechanism used when the type-`B` and type-`D`
+Chevalley root generators are written as quadratic combinations of those operators.
+
+No claim about those Chevalley generators is made here: identifying the orthogonal matrix model
+and its numbered root vectors with these quadratic Clifford elements is the next carrier-specific
+step.
+
+## Main definition and results
+
+* `TauCeti.SpinPolarizationData.integralSpinActionSubring`: the Clifford elements whose action
+  preserves the coordinate integral lattice.
+* `TauCeti.SpinPolarizationData.ι_basis_mem_integralSpinActionSubring`: creation operators are
+  integral.
+* `TauCeti.SpinPolarizationData.ι_dualVector_mem_integralSpinActionSubring`: annihilation
+  operators are integral.
+
+## Roadmap
+
+This supplies the shared integral-spinor-lattice prerequisite for the full-weight type-`B` and
+type-`D` Chevalley carriers in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`. Those carriers
+are consumed by milestone L0 of `TauCetiRoadmap/CFSGStatement/README.md`.
+
+## References
+
+* C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
+* W. Fulton and J. Harris, *Representation Theory: A First Course*, §20.1.
+-/
+
+public section
+
+open CliffordAlgebra
+
+namespace TauCeti.SpinPolarizationData
+
+universe u v
+
+variable {V : Type u} [AddCommGroup V] [Module ℚ V]
+variable {Q : QuadraticForm ℚ V} (P : SpinPolarizationData Q)
+variable {ι : Type v} [LinearOrder ι] (b : Module.Basis ι ℚ P.W)
+
+/-- The subring of the Clifford algebra consisting of the elements whose spin action preserves
+the coordinate integral lattice in the spinor module. -/
+def integralSpinActionSubring : Subring (CliffordAlgebra Q) where
+  carrier := {c | Set.MapsTo (spinAction Q P c)
+    (TauCeti.ExteriorAlgebra.integralLattice b)
+    (TauCeti.ExteriorAlgebra.integralLattice b)}
+  zero_mem' x hx := by
+    rw [map_zero, LinearMap.zero_apply]
+    exact zero_mem _
+  one_mem' x hx := by
+    rw [map_one, Module.End.one_apply]
+    exact hx
+  add_mem' {c d} hc hd x hx := by
+    rw [map_add, LinearMap.add_apply]
+    exact add_mem (hc hx) (hd hx)
+  neg_mem' {c} hc x hx := by
+    rw [map_neg, LinearMap.neg_apply]
+    exact neg_mem (hc hx)
+  mul_mem' {c d} hc hd x hx := by
+    rw [map_mul, Module.End.mul_apply]
+    exact hc (hd hx)
+
+/-- Membership in the integral-action subring means precisely that the spin action preserves the
+coordinate integral lattice. -/
+@[simp]
+theorem mem_integralSpinActionSubring {c : CliffordAlgebra Q} :
+    c ∈ P.integralSpinActionSubring b ↔
+      Set.MapsTo (spinAction Q P c)
+        (TauCeti.ExteriorAlgebra.integralLattice b)
+        (TauCeti.ExteriorAlgebra.integralLattice b) :=
+  Iff.rfl
+
+/-- A basis vector in the first isotropic summand acts integrally on the spinor lattice: its
+Clifford action is exterior multiplication by that basis vector. -/
+theorem ι_basis_mem_integralSpinActionSubring (i : ι) :
+    CliffordAlgebra.ι Q (b i : V) ∈ P.integralSpinActionSubring b := by
+  rw [mem_integralSpinActionSubring]
+  intro x hx
+  rw [spinAction_ι_wedge]
+  exact TauCeti.ExteriorAlgebra.ι_basis_mul_mem_integralLattice b i hx
+
+/-- The polar-dual basis vector in the second isotropic summand acts integrally on the spinor
+lattice: its Clifford action is contraction by the corresponding basis coordinate. -/
+theorem ι_dualVector_mem_integralSpinActionSubring (i : ι) :
+    CliffordAlgebra.ι Q (P.dualVector b i : V) ∈ P.integralSpinActionSubring b := by
+  rw [mem_integralSpinActionSubring]
+  intro x hx
+  rw [spinAction_ι_contract, P.pairingEquiv_dualVector]
+  exact TauCeti.ExteriorAlgebra.contractLeft_coord_mem_integralLattice b i hx
+
+end TauCeti.SpinPolarizationData


### PR DESCRIPTION
This PR equips the exterior-algebra spinor model with its coordinate `ℤ`-lattice and proves that both primitive Fock operators preserve it: basis vectors act by integral exterior multiplication, while polar-dual vectors act by integral coordinate contraction. Package the Clifford elements preserving this lattice as a subring, so integral noncommutative combinations of creation and annihilation operators are immediately available to the type-`B` and type-`D` carrier constructions.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9 target “The Chevalley–Demazure construction,” specifically the full-weight admissible spin lattices needed for the simply connected orthogonal carriers. It serves `TauCetiRoadmap/CFSGStatement/README.md` milestone L0, “explicit pinned Chevalley--Demazure groups,” because L0 requires explicit simply connected pinned carriers rather than existence choices.

After this PR, match the numbered type-`B` and type-`D` Chevalley root vectors with quadratic Clifford expressions, prove their divided powers preserve this lattice, and assemble the resulting carriers and pinnings; the other Layer 9 families and the remaining uniform group-scheme interface also remain before CFSGStatement L0 is complete.

The construction uses Mathlib's `Basis.ExteriorAlgebra`, `Basis.restrictScalars`, `CliffordAlgebra.contractLeft`, and `Set.MapsTo`; no Mathlib infrastructure is vendored. The mathematical normalization follows Chevalley's exterior-algebra spinor construction, with Jantzen for the integral-form context and Fulton–Harris for the Fock model, as cited in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

Dependency edge: CFSGStatement L0 consumes the explicit simply connected pinned type-`B` and type-`D` carriers from ReductiveGroups Layer 9, and those carriers consume this integral spinor lattice to obtain an admissible `ℤ`-form for their Chevalley action.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"integral-spinor-lattice"}-->

🤖 Prepared with Codex
