### PR TITLE
feat: add Frobenius to the type-A carrier

### DIFF
--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -506,22 +506,12 @@ theorem weightTorus_comp_carrierι :
     TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral_comp_ι]
 
 /-- The `A`-valued points of the type `A_r` carrier, as matrices. -/
-noncomputable def points (A : Type v) [CommRing A] :
+@[expose] noncomputable def points (A : Type v) [CommRing A] :
     Subgroup (Matrix.GeneralLinearGroup (Fin (r + 1)) A) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
     (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A
-
-/-- The type-`A_r` carrier points are the Kostant toral-closure points of the standard admissible
-lattice. -/
-theorem points_def (A : Type v) [CommRing A] :
-    points r A =
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
-        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
-        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A := by
-  rw [points]
 
 /-- **The parametrized numbered root subgroup inside the type-`A_r` carrier points.** The
 parameter is read through the canonical multiplicative copy of the additive group of `A`. -/
@@ -534,7 +524,7 @@ noncomputable def rootSubgroupPoint (i : Fin r ⊕ Fin r) (A : Type v) [CommRing
       (isNilpotent_rep_rootGenerator r i) (latticeBasis r)).comp
         (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm.toMonoidHom)
     (points r A) fun u => by
-      rw [points_def]
+      rw [points]
       exact TauCeti.UniversalEnvelopingAlgebra.kostantGeneratedPointsSubgroup_le_toralPoints
         (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
         (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
@@ -562,7 +552,7 @@ noncomputable def weightTorusPoint (A : Type v) [CommRing A] :
     (TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix
       (lattice r).toAddSubgroup (latticeBasis r) (weight r))
     (points r A) fun s => by
-      rw [points_def]
+      rw [points]
       exact TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_mem_toralPoints
         (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
         (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -61,8 +61,8 @@ is any group here claimed to be finite or simple.
 * `TauCeti.SlStd.lattice` and `TauCeti.SlStd.latticeBasis`: the standard admissible lattice and its
   coordinate basis.
 * `TauCeti.SlStd.groupScheme`, `TauCeti.SlStd.carrierι`, `TauCeti.SlStd.rootSubgroup`,
-  `TauCeti.SlStd.weightTorus`, `TauCeti.SlStd.points`, `TauCeti.SlStd.rootSubgroupPoint`, and
-  `TauCeti.SlStd.weightTorusPoint`: the carrier, its closed immersion into `GL_{r+1}`, its pinned
+  `TauCeti.SlStd.weightTorus`, `TauCeti.SlStd.points`, `TauCeti.SlStd.rootSubgroupPoints`, and
+  `TauCeti.SlStd.weightTorusPoints`: the carrier, its closed immersion into `GL_{r+1}`, its pinned
   generating morphisms, its matrix points, and the parametrized root subgroups and split torus
   inside those points.
 
@@ -506,7 +506,7 @@ theorem weightTorus_comp_carrierι :
     TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral_comp_ι]
 
 /-- The `A`-valued points of the type `A_r` carrier, as matrices. -/
-@[expose] noncomputable def points (A : Type v) [CommRing A] :
+noncomputable def points (A : Type v) [CommRing A] :
     Subgroup (Matrix.GeneralLinearGroup (Fin (r + 1)) A) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
@@ -515,7 +515,7 @@ theorem weightTorus_comp_carrierι :
 
 /-- **The parametrized numbered root subgroup inside the type-`A_r` carrier points.** The
 parameter is read through the canonical multiplicative copy of the additive group of `A`. -/
-noncomputable def rootSubgroupPoint (i : Fin r ⊕ Fin r) (A : Type v) [CommRing A] :
+noncomputable def rootSubgroupPoints (i : Fin r ⊕ Fin r) (A : Type v) [CommRing A] :
     Multiplicative A →* points r A :=
   MonoidHom.codRestrict
     ((TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
@@ -536,9 +536,9 @@ noncomputable def rootSubgroupPoint (i : Fin r ⊕ Fin r) (A : Type v) [CommRing
 
 /-- The numbered root subgroup point is the corresponding divided-power exponential matrix. -/
 @[simp]
-theorem coe_rootSubgroupPoint (i : Fin r ⊕ Fin r) (A : Type v) [CommRing A]
+theorem coe_rootSubgroupPoints (i : Fin r ⊕ Fin r) (A : Type v) [CommRing A]
     (u : Multiplicative A) :
-    (rootSubgroupPoint r i A u : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
+    (rootSubgroupPoints r i A u : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
       TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
         (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
         (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) i
@@ -546,7 +546,7 @@ theorem coe_rootSubgroupPoint (i : Fin r ⊕ Fin r) (A : Type v) [CommRing A]
         ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm u) := (rfl)
 
 /-- **The split weight torus inside the type-`A_r` carrier points.** -/
-noncomputable def weightTorusPoint (A : Type v) [CommRing A] :
+noncomputable def weightTorusPoints (A : Type v) [CommRing A] :
     (Fin r → Aˣ) →* points r A :=
   MonoidHom.codRestrict
     (TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix
@@ -561,8 +561,8 @@ noncomputable def weightTorusPoint (A : Type v) [CommRing A] :
 /-- A split-torus point is the diagonal matrix whose entries are its values on the standard-module
 weights. -/
 @[simp]
-theorem coe_weightTorusPoint (A : Type v) [CommRing A] (s : Fin r → Aˣ) :
-    (weightTorusPoint r A s : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
+theorem coe_weightTorusPoints (A : Type v) [CommRing A] (s : Fin r → Aˣ) :
+    (weightTorusPoints r A s : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
       TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix
         (lattice r).toAddSubgroup (latticeBasis r) (weight r) s := (rfl)
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -61,8 +61,10 @@ is any group here claimed to be finite or simple.
 * `TauCeti.SlStd.lattice` and `TauCeti.SlStd.latticeBasis`: the standard admissible lattice and its
   coordinate basis.
 * `TauCeti.SlStd.groupScheme`, `TauCeti.SlStd.carrierι`, `TauCeti.SlStd.rootSubgroup`,
-  `TauCeti.SlStd.weightTorus` and `TauCeti.SlStd.points`: the carrier, its closed immersion into
-  `GL_{r+1}`, its pinned generating morphisms, and its matrix points.
+  `TauCeti.SlStd.weightTorus`, `TauCeti.SlStd.points`, `TauCeti.SlStd.rootSubgroupPoint`, and
+  `TauCeti.SlStd.weightTorusPoint`: the carrier, its closed immersion into `GL_{r+1}`, its pinned
+  generating morphisms, its matrix points, and the parametrized root subgroups and split torus
+  inside those points.
 
 ## Main results
 
@@ -102,6 +104,8 @@ therefore cannot use the adjoint Geck carrier of
 public section
 
 namespace TauCeti.SlStd
+
+universe v
 
 open LieAlgebra.SpecialLinear
 open scoped Matrix TensorProduct
@@ -502,17 +506,80 @@ theorem weightTorus_comp_carrierι :
     TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral_comp_ι]
 
 /-- The `A`-valued points of the type `A_r` carrier, as matrices. -/
-noncomputable def points (A : Type) [CommRing A] :
+noncomputable def points (A : Type v) [CommRing A] :
     Subgroup (Matrix.GeneralLinearGroup (Fin (r + 1)) A) :=
   TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
     (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A
 
+/-- The type-`A_r` carrier points are the Kostant toral-closure points of the standard admissible
+lattice. -/
+theorem points_def (A : Type v) [CommRing A] :
+    points r A =
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A := by
+  rw [points]
+
+/-- **The parametrized numbered root subgroup inside the type-`A_r` carrier points.** The
+parameter is read through the canonical multiplicative copy of the additive group of `A`. -/
+noncomputable def rootSubgroupPoint (i : Fin r ⊕ Fin r) (A : Type v) [CommRing A] :
+    Multiplicative A →* points r A :=
+  MonoidHom.codRestrict
+    ((TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
+      (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) i
+      (isNilpotent_rep_rootGenerator r i) (latticeBasis r)).comp
+        (AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm.toMonoidHom)
+    (points r A) fun u => by
+      rw [points_def]
+      exact TauCeti.UniversalEnvelopingAlgebra.kostantGeneratedPointsSubgroup_le_toralPoints
+        (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A
+        (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_mem_generatedPoints
+          (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+          (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+          (isNilpotent_rep_rootGenerator r) (latticeBasis r) A i _)
+
+/-- The numbered root subgroup point is the corresponding divided-power exponential matrix. -/
+@[simp]
+theorem coe_rootSubgroupPoint (i : Fin r ⊕ Fin r) (A : Type v) [CommRing A]
+    (u : Multiplicative A) :
+    (rootSubgroupPoint r i A u : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) i
+        (isNilpotent_rep_rootGenerator r i) (latticeBasis r)
+        ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm u) := (rfl)
+
+/-- **The split weight torus inside the type-`A_r` carrier points.** -/
+noncomputable def weightTorusPoint (A : Type v) [CommRing A] :
+    (Fin r → Aˣ) →* points r A :=
+  MonoidHom.codRestrict
+    (TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix
+      (lattice r).toAddSubgroup (latticeBasis r) (weight r))
+    (points r A) fun s => by
+      rw [points_def]
+      exact TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_mem_toralPoints
+        (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A s
+
+/-- A split-torus point is the diagonal matrix whose entries are its values on the standard-module
+weights. -/
+@[simp]
+theorem coe_weightTorusPoint (A : Type v) [CommRing A] (s : Fin r → Aˣ) :
+    (weightTorusPoint r A s : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
+      TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix
+        (lattice r).toAddSubgroup (latticeBasis r) (weight r) s := (rfl)
+
 /-- A matrix is a point of the type `A_r` carrier exactly when the associated convolution point
 kills its toral defining Hopf ideal. -/
 @[simp]
-theorem mem_points_iff (A : Type) [CommRing A]
+theorem mem_points_iff (A : Type v) [CommRing A]
     (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
     g ∈ points r A ↔
       ∀ x ∈ TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal (rootGenerator r)

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
@@ -73,13 +73,10 @@ variable (r p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
 For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the untwisted Steinberg
 endomorphism used to construct `A_r(p ^ k)`. -/
 def frobenius : points r A →* points r A :=
-  ((MulEquiv.subgroupCongr
-        (points_def r A)).symm.toMonoidHom).comp
-    ((TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator r)
-          (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
-          (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
-          (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A).comp
-      (MulEquiv.subgroupCongr (points_def r A)).toMonoidHom)
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A
 
 /-- The Frobenius endomorphism of the type-`A_r` carrier acts by entrywise Frobenius. -/
 @[simp]
@@ -87,12 +84,14 @@ theorem coe_frobenius (g : points r A) :
     (frobenius r p k A g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
       Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
   rw [frobenius]
-  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
-    TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
-    MulEquiv.subgroupCongr_apply]
+  exact TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius
+    (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A g
 
 /-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its
 `p ^ k`-th power. -/
+@[simp]
 theorem coe_frobenius_apply (g : points r A) (i j : Fin (r + 1)) :
     ((frobenius r p k A g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
         Matrix (Fin (r + 1)) (Fin (r + 1)) A) i j =
@@ -152,9 +151,9 @@ theorem map_subtype_fixedSubgroup_frobenius_eq :
       (points r ↥(frobeniusFixedSubring A p k)).map
         (Matrix.GeneralLinearGroup.map (frobeniusFixedSubring A p k).subtype) := by
   rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (frobenius r p k A) _
-      (coe_frobenius r p k A),
-    points_def, points_def,
-    TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup_def,
+      (coe_frobenius r p k A)]
+  unfold points
+  rw [TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup_def,
     TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup_def,
     TauCeti.GeneralLinear.map_hopfIdealPointsSubgroup_frobeniusFixedSubring]
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.Basic
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Frobenius
+
+/-!
+# Frobenius on the full-weight type-A carrier
+
+`TauCeti.SlStd.groupScheme r` is the explicit full-weight Chevalley carrier of type `A_r` built
+from the standard representation of `sl_{r+1}` and its coordinate integral lattice. For a
+commutative value ring `A` of exponential characteristic `p`, this file equips its point group
+`TauCeti.SlStd.points r A` with the `p ^ k`-power Frobenius endomorphism.
+
+The endomorphism raises every matrix entry to its `p ^ k`-th power. In particular it satisfies the
+pinned root-subgroup equation
+
+```text
+F(x_i(u)) = x_i(u ^ (p ^ k))
+```
+
+for every Bourbaki-numbered raising or lowering generator, and it raises every coordinate of the
+split weight torus by the same exponent. Its fixed points are exactly the points of the same
+carrier over the Frobenius-fixed subring.
+
+The construction specializes the generic Frobenius of a Kostant toral closure; it does not reprove
+entrywise Frobenius stability. Nothing here asserts that the carrier is reductive, or that any
+fixed-point group is finite or simple.
+
+## Main definitions
+
+* `TauCeti.SlStd.frobenius`: the `p ^ k`-power Frobenius endomorphism of the type-`A_r` point group.
+
+## Main results
+
+* `TauCeti.SlStd.coe_frobenius` and `TauCeti.SlStd.coe_frobenius_apply`: the endomorphism acts by
+  entrywise Frobenius.
+* `TauCeti.SlStd.frobenius_rootSubgroupPoint` and `TauCeti.SlStd.frobenius_weightTorusPoint`: the
+  equations on the pinned generating root subgroups and split torus.
+* `TauCeti.SlStd.frobenius_zero` and `TauCeti.SlStd.frobenius_add`: the iteration laws.
+* `TauCeti.SlStd.map_subtype_fixedSubgroup_frobenius_eq`: the Frobenius-fixed points are the points
+  over the Frobenius-fixed subring.
+
+## References
+
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17.
+* J. C. Jantzen, *Representations of Algebraic Groups*, II.1.
+
+This advances the "points over an algebraically closed field" and "Chevalley--Demazure
+construction" targets in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`. Its consumer is
+milestone L1 of `TauCetiRoadmap/CFSGStatement/README.md`: on an algebraic closure of `ZMod p`, the
+ordinary `A_r(q)` Steinberg map is this Frobenius with `q = p ^ k`.
+-/
+
+public section
+
+open WithConv
+
+namespace TauCeti.SlStd
+
+universe v
+
+noncomputable section
+
+variable (r p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
+
+/-- The standard carrier's named point group is the generic toral-closure point group to which the
+generic Frobenius API applies. -/
+private theorem points_eq_kostantToralPointsSubgroup :
+    points r A =
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A :=
+  points_def r A
+
+/-- **The `p ^ k`-power Frobenius endomorphism of the full-weight type-`A_r` carrier.**
+
+For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the untwisted Steinberg
+endomorphism used to construct `A_r(p ^ k)`. -/
+def frobenius : points r A →* points r A :=
+  ((MulEquiv.subgroupCongr
+        (points_eq_kostantToralPointsSubgroup r A)).symm.toMonoidHom).comp
+    ((TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator r)
+          (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+          (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+          (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A).comp
+      (MulEquiv.subgroupCongr (points_eq_kostantToralPointsSubgroup r A)).toMonoidHom)
+
+/-- The Frobenius endomorphism of the type-`A_r` carrier acts by entrywise Frobenius. -/
+@[simp]
+theorem coe_frobenius (g : points r A) :
+    (frobenius r p k A g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
+      Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
+  rw [frobenius]
+  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulEquiv.subgroupCongr_symm_apply,
+    TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
+    MulEquiv.subgroupCongr_apply]
+
+/-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its
+`p ^ k`-th power. -/
+theorem coe_frobenius_apply (g : points r A) (i j : Fin (r + 1)) :
+    ((frobenius r p k A g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+        Matrix (Fin (r + 1)) (Fin (r + 1)) A) i j =
+      ((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+        Matrix (Fin (r + 1)) (Fin (r + 1)) A) i j ^ p ^ k := by
+  rw [coe_frobenius, Matrix.GeneralLinearGroup.map_apply, iterateFrobenius_def]
+
+/-- **Frobenius raises the parameter of a numbered type-`A_r` root subgroup to its
+`p ^ k`-th power.** -/
+@[simp]
+theorem frobenius_rootSubgroupPoint (i : Fin r ⊕ Fin r) (u : Multiplicative A) :
+    frobenius r p k A (rootSubgroupPoint r i A u) =
+      rootSubgroupPoint r i A
+        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ p ^ k)) :=
+  Subtype.ext (by
+    rw [coe_frobenius, coe_rootSubgroupPoint, coe_rootSubgroupPoint]
+    apply TauCeti.UniversalEnvelopingAlgebra.map_iterateFrobenius_kostantRootSubgroupMatrix)
+
+/-- **Frobenius raises every coordinate of the pinned split torus to its `p ^ k`-th power.** -/
+@[simp]
+theorem frobenius_weightTorusPoint (s : Fin r → Aˣ) :
+    frobenius r p k A (weightTorusPoint r A s) = weightTorusPoint r A (s ^ p ^ k) :=
+  Subtype.ext (by
+    rw [coe_frobenius, coe_weightTorusPoint, coe_weightTorusPoint]
+    simpa only [TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] using
+      TauCeti.UniversalEnvelopingAlgebra.map_iterateFrobenius_kostantTorusMatrix
+        (M := (lattice r).toAddSubgroup) (b := latticeBasis r) (wt := weight r)
+        (p := p) (k := k) s)
+
+/-- The zeroth Frobenius iterate is the identity on the type-`A_r` point group. -/
+@[simp]
+theorem frobenius_zero : frobenius r p 0 A = MonoidHom.id _ := by
+  refine MonoidHom.ext fun g ↦ Subtype.ext (Matrix.GeneralLinearGroup.ext fun i j ↦ ?_)
+  rw [coe_frobenius_apply, MonoidHom.id_apply, pow_zero, pow_one]
+
+/-- Frobenius iterates add under composition on the type-`A_r` point group. -/
+theorem frobenius_add (m : ℕ) :
+    frobenius r p (k + m) A = (frobenius r p k A).comp (frobenius r p m A) := by
+  refine MonoidHom.ext fun g ↦ Subtype.ext (Matrix.GeneralLinearGroup.ext fun i j ↦ ?_)
+  rw [coe_frobenius_apply, MonoidHom.comp_apply, coe_frobenius_apply,
+    coe_frobenius_apply, ← pow_mul, ← pow_add, Nat.add_comm k m]
+
+/-- A type-`A_r` carrier point is fixed by Frobenius exactly when all of its matrix entries lie in
+the Frobenius-fixed subring. -/
+@[simp]
+theorem frobenius_eq_self_iff (g : points r A) :
+    frobenius r p k A g = g ↔
+      ∀ i j, ((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+          Matrix (Fin (r + 1)) (Fin (r + 1)) A) i j ∈ frobeniusFixedSubring A p k := by
+  rw [← SetLike.coe_eq_coe, coe_frobenius,
+    Matrix.GeneralLinearGroup.map_iterateFrobenius_eq_self_iff]
+
+/-- **The Frobenius-fixed points of the full-weight type-`A_r` carrier are its points over the
+Frobenius-fixed subring.** -/
+theorem map_subtype_fixedSubgroup_frobenius_eq :
+    (fixedSubgroup (frobenius r p k A)).map (points r A).subtype =
+      (points r ↥(frobeniusFixedSubring A p k)).map
+        (Matrix.GeneralLinearGroup.map (frobeniusFixedSubring A p k).subtype) := by
+  rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (frobenius r p k A) _
+      (coe_frobenius r p k A),
+    points_def, points_def,
+    TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup_def,
+    TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup_def,
+    TauCeti.GeneralLinear.map_hopfIdealPointsSubgroup_frobeniusFixedSubring]
+
+end
+
+end TauCeti.SlStd

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
@@ -78,8 +78,10 @@ def frobenius : points r A →* points r A :=
     (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A
 
-/-- The Frobenius endomorphism of the type-`A_r` carrier acts by entrywise Frobenius. -/
-@[simp]
+/-- The Frobenius endomorphism of the type-`A_r` carrier acts by entrywise Frobenius.
+
+This is not a `simp` lemma because `coe_frobenius_apply` is the canonical coefficient-level
+normal form. -/
 theorem coe_frobenius (g : points r A) :
     (frobenius r p k A g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
       Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
@@ -68,28 +68,18 @@ noncomputable section
 
 variable (r p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
 
-/-- The standard carrier's named point group is the generic toral-closure point group to which the
-generic Frobenius API applies. -/
-private theorem points_eq_kostantToralPointsSubgroup :
-    points r A =
-      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
-        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
-        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
-        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A :=
-  points_def r A
-
 /-- **The `p ^ k`-power Frobenius endomorphism of the full-weight type-`A_r` carrier.**
 
 For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the untwisted Steinberg
 endomorphism used to construct `A_r(p ^ k)`. -/
 def frobenius : points r A →* points r A :=
   ((MulEquiv.subgroupCongr
-        (points_eq_kostantToralPointsSubgroup r A)).symm.toMonoidHom).comp
+        (points_def r A)).symm.toMonoidHom).comp
     ((TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator r)
           (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
           (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
           (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A).comp
-      (MulEquiv.subgroupCongr (points_eq_kostantToralPointsSubgroup r A)).toMonoidHom)
+      (MulEquiv.subgroupCongr (points_def r A)).toMonoidHom)
 
 /-- The Frobenius endomorphism of the type-`A_r` carrier acts by entrywise Frobenius. -/
 @[simp]

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean
@@ -39,7 +39,7 @@ fixed-point group is finite or simple.
 
 * `TauCeti.SlStd.coe_frobenius` and `TauCeti.SlStd.coe_frobenius_apply`: the endomorphism acts by
   entrywise Frobenius.
-* `TauCeti.SlStd.frobenius_rootSubgroupPoint` and `TauCeti.SlStd.frobenius_weightTorusPoint`: the
+* `TauCeti.SlStd.frobenius_rootSubgroupPoints` and `TauCeti.SlStd.frobenius_weightTorusPoints`: the
   equations on the pinned generating root subgroups and split torus.
 * `TauCeti.SlStd.frobenius_zero` and `TauCeti.SlStd.frobenius_add`: the iteration laws.
 * `TauCeti.SlStd.map_subtype_fixedSubgroup_frobenius_eq`: the Frobenius-fixed points are the points
@@ -52,8 +52,8 @@ fixed-point group is finite or simple.
 
 This advances the "points over an algebraically closed field" and "Chevalley--Demazure
 construction" targets in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`. Its consumer is
-milestone L1 of `TauCetiRoadmap/CFSGStatement/README.md`: on an algebraic closure of `ZMod p`, the
-ordinary `A_r(q)` Steinberg map is this Frobenius with `q = p ^ k`.
+milestone L1 of `TauCetiRoadmap/CFSGStatement/README.md`: this is the Frobenius component intended
+for a future construction of the `A_r(p ^ k)` Steinberg map over an algebraic closure of `ZMod p`.
 -/
 
 public section
@@ -68,15 +68,50 @@ noncomputable section
 
 variable (r p k : ℕ) (A : Type v) [CommRing A] [ExpChar A p]
 
+private theorem points_eq_kostantToralPointsSubgroup :
+    points r A =
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A := by
+  ext g
+  rw [mem_points_iff,
+    TauCeti.UniversalEnvelopingAlgebra.mem_kostantToralPointsSubgroup_iff]
+
+private def pointsEquivKostantToralPoints :
+    points r A ≃*
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) A :=
+  MulEquiv.subgroupCongr (points_eq_kostantToralPointsSubgroup r A)
+
+@[simp]
+private theorem coe_pointsEquivKostantToralPoints (g : points r A) :
+    (pointsEquivKostantToralPoints r A g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) = g :=
+  rfl
+
 /-- **The `p ^ k`-power Frobenius endomorphism of the full-weight type-`A_r` carrier.**
 
-For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the untwisted Steinberg
-endomorphism used to construct `A_r(p ^ k)`. -/
+For `p` prime, `0 < k`, and `A` an algebraic closure of `ZMod p`, this is the Frobenius component
+intended for a future construction of the `A_r(p ^ k)` Steinberg map. -/
 def frobenius : points r A →* points r A :=
-  TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator r)
-    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
-    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
-    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A
+  (pointsEquivKostantToralPoints r A).symm.toMonoidHom.comp
+    ((TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator r)
+      (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A).comp
+        (pointsEquivKostantToralPoints r A).toMonoidHom)
+
+private theorem pointsEquivKostantToralPoints_frobenius (g : points r A) :
+    pointsEquivKostantToralPoints r A (frobenius r p k A g) =
+      TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A
+        (pointsEquivKostantToralPoints r A g) := by
+  simp only [frobenius, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    MulEquiv.apply_symm_apply]
 
 /-- The Frobenius endomorphism of the type-`A_r` carrier acts by entrywise Frobenius.
 
@@ -85,11 +120,9 @@ normal form. -/
 theorem coe_frobenius (g : points r A) :
     (frobenius r p k A g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
       Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g := by
-  rw [frobenius]
-  exact TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius
-    (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
-    (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
-    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A g
+  have h := congrArg Subtype.val (pointsEquivKostantToralPoints_frobenius r p k A g)
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
+  simpa only [coe_pointsEquivKostantToralPoints] using h
 
 /-- Entrywise, the Frobenius endomorphism raises each matrix coefficient to its
 `p ^ k`-th power. -/
@@ -99,42 +132,82 @@ theorem coe_frobenius_apply (g : points r A) (i j : Fin (r + 1)) :
         Matrix (Fin (r + 1)) (Fin (r + 1)) A) i j =
       ((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
         Matrix (Fin (r + 1)) (Fin (r + 1)) A) i j ^ p ^ k := by
-  rw [coe_frobenius, Matrix.GeneralLinearGroup.map_apply, iterateFrobenius_def]
+  have h := TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius_apply
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A
+      (pointsEquivKostantToralPoints r A g) i j
+  rw [← pointsEquivKostantToralPoints_frobenius] at h
+  simpa only [coe_pointsEquivKostantToralPoints] using h
 
 /-- **Frobenius raises the parameter of a numbered type-`A_r` root subgroup to its
 `p ^ k`-th power.** -/
 @[simp]
-theorem frobenius_rootSubgroupPoint (i : Fin r ⊕ Fin r) (u : Multiplicative A) :
-    frobenius r p k A (rootSubgroupPoint r i A u) =
-      rootSubgroupPoint r i A
-        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ p ^ k)) :=
-  Subtype.ext (by
-    rw [coe_frobenius, coe_rootSubgroupPoint, coe_rootSubgroupPoint]
-    apply TauCeti.UniversalEnvelopingAlgebra.map_iterateFrobenius_kostantRootSubgroupMatrix)
+theorem frobenius_rootSubgroupPoints (i : Fin r ⊕ Fin r) (u : Multiplicative A) :
+    frobenius r p k A (rootSubgroupPoints r i A u) =
+      rootSubgroupPoints r i A
+        (Multiplicative.ofAdd (Multiplicative.toAdd u ^ p ^ k)) := by
+  apply (pointsEquivKostantToralPoints r A).injective
+  rw [pointsEquivKostantToralPoints_frobenius]
+  apply Subtype.ext
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
+    coe_pointsEquivKostantToralPoints, coe_rootSubgroupPoints,
+    coe_pointsEquivKostantToralPoints, coe_rootSubgroupPoints]
+  have h := congrArg Subtype.val
+    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_kostantRootSubgroupMatrix
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A i u)
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
+  exact h
 
 /-- **Frobenius raises every coordinate of the pinned split torus to its `p ^ k`-th power.** -/
 @[simp]
-theorem frobenius_weightTorusPoint (s : Fin r → Aˣ) :
-    frobenius r p k A (weightTorusPoint r A s) = weightTorusPoint r A (s ^ p ^ k) :=
-  Subtype.ext (by
-    rw [coe_frobenius, coe_weightTorusPoint, coe_weightTorusPoint]
-    simpa only [TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] using
-      TauCeti.UniversalEnvelopingAlgebra.map_iterateFrobenius_kostantTorusMatrix
-        (M := (lattice r).toAddSubgroup) (b := latticeBasis r) (wt := weight r)
-        (p := p) (k := k) s)
+theorem frobenius_weightTorusPoints (s : Fin r → Aˣ) :
+    frobenius r p k A (weightTorusPoints r A s) = weightTorusPoints r A (s ^ p ^ k) := by
+  apply (pointsEquivKostantToralPoints r A).injective
+  rw [pointsEquivKostantToralPoints_frobenius]
+  apply Subtype.ext
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius,
+    coe_pointsEquivKostantToralPoints, coe_weightTorusPoints,
+    coe_pointsEquivKostantToralPoints, coe_weightTorusPoints]
+  have h := congrArg Subtype.val
+    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_kostantTorusMatrix
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A s)
+  rw [TauCeti.UniversalEnvelopingAlgebra.coe_kostantToralFrobenius] at h
+  simpa only [TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_apply] using h
 
 /-- The zeroth Frobenius iterate is the identity on the type-`A_r` point group. -/
 @[simp]
 theorem frobenius_zero : frobenius r p 0 A = MonoidHom.id _ := by
-  refine MonoidHom.ext fun g ↦ Subtype.ext (Matrix.GeneralLinearGroup.ext fun i j ↦ ?_)
-  rw [coe_frobenius_apply, MonoidHom.id_apply, pow_zero, pow_one]
+  apply MonoidHom.ext
+  intro g
+  apply (pointsEquivKostantToralPoints r A).injective
+  rw [pointsEquivKostantToralPoints_frobenius, MonoidHom.id_apply]
+  have h := DFunLike.congr_fun
+    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_zero
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p A)
+    (pointsEquivKostantToralPoints r A g)
+  simpa only [MonoidHom.id_apply] using h
 
 /-- Frobenius iterates add under composition on the type-`A_r` point group. -/
 theorem frobenius_add (m : ℕ) :
     frobenius r p (k + m) A = (frobenius r p k A).comp (frobenius r p m A) := by
-  refine MonoidHom.ext fun g ↦ Subtype.ext (Matrix.GeneralLinearGroup.ext fun i j ↦ ?_)
-  rw [coe_frobenius_apply, MonoidHom.comp_apply, coe_frobenius_apply,
-    coe_frobenius_apply, ← pow_mul, ← pow_add, Nat.add_comm k m]
+  apply MonoidHom.ext
+  intro g
+  apply (pointsEquivKostantToralPoints r A).injective
+  rw [pointsEquivKostantToralPoints_frobenius, MonoidHom.comp_apply,
+    pointsEquivKostantToralPoints_frobenius, pointsEquivKostantToralPoints_frobenius]
+  exact DFunLike.congr_fun
+    (TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_add
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A m)
+    (pointsEquivKostantToralPoints r A g)
 
 /-- A type-`A_r` carrier point is fixed by Frobenius exactly when all of its matrix entries lie in
 the Frobenius-fixed subring. -/
@@ -143,8 +216,19 @@ theorem frobenius_eq_self_iff (g : points r A) :
     frobenius r p k A g = g ↔
       ∀ i j, ((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
           Matrix (Fin (r + 1)) (Fin (r + 1)) A) i j ∈ frobeniusFixedSubring A p k := by
-  rw [← SetLike.coe_eq_coe, coe_frobenius,
-    Matrix.GeneralLinearGroup.map_iterateFrobenius_eq_self_iff]
+  have h := TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius_eq_self_iff
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A
+      (pointsEquivKostantToralPoints r A g)
+  rw [← pointsEquivKostantToralPoints_frobenius] at h
+  simp only [coe_pointsEquivKostantToralPoints] at h
+  constructor
+  · intro hg
+    exact h.mp (congrArg (pointsEquivKostantToralPoints r A) hg)
+  · intro hg
+    apply (pointsEquivKostantToralPoints r A).injective
+    exact h.mpr hg
 
 /-- **The Frobenius-fixed points of the full-weight type-`A_r` carrier are its points over the
 Frobenius-fixed subring.** -/
@@ -153,11 +237,15 @@ theorem map_subtype_fixedSubgroup_frobenius_eq :
       (points r ↥(frobeniusFixedSubring A p k)).map
         (Matrix.GeneralLinearGroup.map (frobeniusFixedSubring A p k).subtype) := by
   rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (frobenius r p k A) _
-      (coe_frobenius r p k A)]
-  unfold points
-  rw [TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup_def,
-    TauCeti.UniversalEnvelopingAlgebra.kostantToralPointsSubgroup_def,
-    TauCeti.GeneralLinear.map_hopfIdealPointsSubgroup_frobeniusFixedSubring]
+    (coe_frobenius r p k A)]
+  rw [points_eq_kostantToralPointsSubgroup,
+    points_eq_kostantToralPointsSubgroup]
+  rw [← TauCeti.UniversalEnvelopingAlgebra.map_subtype_fixedSubgroup_kostantToralFrobenius]
+  exact
+    TauCeti.UniversalEnvelopingAlgebra.map_subtype_fixedSubgroup_kostantToralFrobenius_eq
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv ↦ rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) p k A
 
 end
 


### PR DESCRIPTION
This PR equips the explicit full-weight type-`A_r` Chevalley carrier with its `p ^ k`-power Frobenius endomorphism on points. Expose its entrywise matrix action, its equations on every Bourbaki-numbered root subgroup and on the split weight torus, its iteration laws, and the identification of its fixed points with the carrier points over the Frobenius-fixed subring.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9 targets “Points over an algebraically closed field” and “Root subgroup maps,” specifically the first requested field endomorphism on a full-weight pinned carrier. It serves `TauCetiRoadmap/CFSGStatement/README.md` milestone L1, “ordinary and graph-twisted Steinberg maps,” because the ordinary `A_r(q)` branch consumes this endomorphism with `q = p ^ k` and its simple-root-subgroup equation.

This is the most effective unclaimed step because the full-weight type-`A` carrier and its admissible standard lattice are already on `main`, while the full-weight `B`, `D`, and `E₆` carrier prerequisites are independently in flight. After this PR, the type-`A` path still needs the graph automorphism for the twisted family and assembly into `ValidLieTypeIndex`, while the other Lie families need their full-weight carriers and corresponding ordinary or exceptional Steinberg maps.

The point-group API gains `SlStd.rootSubgroupPoint` and `SlStd.weightTorusPoint`, so the characteristic Frobenius equations are stated against named homomorphisms rather than raw subtype witnesses. The existing point API is generalized from `Type` to `Type v`, matching the generic construction it specializes.

The module move required by the repository layout is:

| Old module | New module |
| --- | --- |
| `TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier` | `TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.Basic` |

The moved and extended `Basic.lean` has 713 lines, with 71 added lines; the new `Frobenius.lean` has 173 lines. No in-repository module imported the old path.

The implementation reuses `TauCeti.UniversalEnvelopingAlgebra.kostantToralFrobenius`, `map_iterateFrobenius_kostantRootSubgroupMatrix`, `map_iterateFrobenius_kostantTorusMatrix`, and the existing Hopf-ideal fixed-point theorem; no Mathlib infrastructure is vendored. The mathematical normalization follows Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.17, and Jantzen, *Representations of Algebraic Groups*, II.1, as cited in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

Dependency edge: CFSGStatement L1 consumes the `q`-power Frobenius and its pinned simple-root-subgroup equation on the explicit simply connected type-`A` carrier supplied by ReductiveGroups Layer 9.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-a-carrier-frobenius"}-->

🤖 Prepared with Codex
