### PR TITLE
feat: cancellation in ideal partial sums, and the L-function it continues

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Continuation.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Continuation.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.MellinTransform
-public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Counting
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Estimates
 
 /-!

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Continuation.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Continuation.lean
@@ -36,9 +36,12 @@ and no downstream character family may assume it for free.
 
 ## Implementation notes
 
-The bridge between the two indexings is `TauCeti.idealSummatory_eq_sum_Icc_normCoeff`: an ideal
-partial sum is the partial sum of the norm coefficients over `1 ≤ k ≤ ⌊x⌋₊`, because the
-absolute-norm fibres partition the nonzero ideals of bounded norm. Through it, Mathlib's
+The bridge between the two indexings is the Layer 4 regrouping lemma
+`TauCeti.idealSummatory_eq_sum_Icc_normCoeff` of `Counting.lean`: an ideal partial sum is the
+partial sum of the norm coefficients over `1 ≤ k ≤ ⌊x⌋₊`, because the absolute-norm fibres
+partition the nonzero ideals of bounded norm. The unconditional `O(n)` bounds on those partial
+sums are the Layer 5 estimates `TauCeti.isBigO_sum_Icc_normCoeff` and
+`TauCeti.LSeriesSummable_normCoeff_of_one_lt_re` of `Estimates.lean`. Through them, Mathlib's
 `LSeries_eq_mul_integral` — Abel summation in its integral form — supplies the identity on
 `Re s > 1`, and Mathlib's `mellin_differentiableAt_of_isBigO_rpow` supplies the analyticity: the
 integral is the Mellin transform of `A_χ` at `-s`, and `A_χ` vanishes below the cutoff `1`, so the
@@ -68,44 +71,10 @@ public section
 
 namespace TauCeti
 
-open Filter Finset MeasureTheory
+open Filter MeasureTheory
 open scoped nonZeroDivisors NumberField Topology
 
 variable {K : Type*} [Field K] [NumberField K]
-
-/-! ### Ideal partial sums and partial sums of norm coefficients -/
-
-/-- **An ideal partial sum is a partial sum of norm coefficients.** Summing an ideal arithmetic
-function over the nonzero ideals of absolute norm at most `n` is the same as summing its norm
-coefficients over `1 ≤ k ≤ n`, since the absolute-norm fibres partition those ideals. -/
-theorem idealSummatory_natCast_eq_sum_Icc_normCoeff (f : IdealArithmeticFunction K) (n : ℕ) :
-    idealSummatory K f (n : ℝ) = ∑ k ∈ Icc 1 n, normCoeff K f k := by
-  classical
-  have hmaps : ∀ I ∈ idealsLE K (n : ℝ), Ideal.absNorm (I : Ideal (𝓞 K)) ∈ Icc 1 n := by
-    intro I hI
-    rw [mem_normLE] at hI
-    exact mem_Icc.mpr ⟨Ideal.absNorm_pos_of_nonZeroDivisors I, by exact_mod_cast hI⟩
-  rw [idealSummatory_apply, ← Finset.sum_fiberwise_of_maps_to hmaps f]
-  refine Finset.sum_congr rfl fun k hk ↦ ?_
-  rw [normCoeff_eq_sum_normFiber]
-  refine Finset.sum_congr (Finset.ext fun I ↦ ?_) fun _ _ ↦ rfl
-  rw [Finset.mem_filter, mem_normFiber, mem_normLE]
-  refine ⟨fun h ↦ h.2, fun h ↦ ⟨?_, h⟩⟩
-  rw [h]
-  exact_mod_cast (mem_Icc.mp hk).2
-
-/-- The real-cutoff form of `TauCeti.idealSummatory_natCast_eq_sum_Icc_normCoeff`: the ideal
-partial sum at a nonnegative cutoff `x` is the partial sum of the norm coefficients up to `⌊x⌋₊`.
--/
-theorem idealSummatory_eq_sum_Icc_normCoeff (f : IdealArithmeticFunction K) {x : ℝ} (hx : 0 ≤ x) :
-    idealSummatory K f x = ∑ k ∈ Icc 1 ⌊x⌋₊, normCoeff K f k := by
-  rw [show idealSummatory K f x = idealSummatory K f (⌊x⌋₊ : ℝ) from
-      summatory_eq_summatory_natFloor _ f hx, idealSummatory_natCast_eq_sum_Icc_normCoeff]
-
-/-- Conjugating an ideal arithmetic function conjugates its ideal partial sums. -/
-theorem idealSummatory_star (f : IdealArithmeticFunction K) (x : ℝ) :
-    idealSummatory K (fun I ↦ star (f I)) x = star (idealSummatory K f x) := by
-  rw [idealSummatory_apply, idealSummatory_apply, star_sum]
 
 /-! ### The cancellation exponent -/
 
@@ -206,46 +175,6 @@ theorem not_hasCancellation_one : ¬ HasCancellation (1 : UnitaryIdealWeight K) 
   rw [mul_comm] at hkey
   linarith
 
-/-! ### Elementary bounds for a unitary weight -/
-
-/-- The norm coefficient of a unitary weight at `n` is bounded by the number of nonzero ideals of
-absolute norm `n`, since every value of the weight has modulus at most `1`. -/
-theorem norm_normCoeff_le_card_normFiber (χ : UnitaryIdealWeight K) (n : ℕ) :
-    ‖normCoeff K χ.1.toIdealArithmeticFunction n‖ ≤ (normFiber K n).card := by
-  rw [normCoeff_eq_sum_normFiber]
-  refine (norm_sum_le _ _).trans ?_
-  simpa using Finset.sum_le_card_nsmul _ _ 1 fun I _ ↦ UnitaryIdealWeight.norm_le_one χ _
-
-/-- The partial sums of the absolute values of the norm coefficients of a unitary weight are
-`O(n)`, by comparison with the trivial weight. -/
-theorem isBigO_sum_norm_normCoeff (χ : UnitaryIdealWeight K) :
-    (fun n : ℕ ↦ ∑ k ∈ Icc 1 n, ‖normCoeff K χ.1.toIdealArithmeticFunction k‖)
-      =O[atTop] fun n : ℕ ↦ (n : ℝ) ^ (1 : ℝ) := by
-  refine Asymptotics.IsBigO.trans (Asymptotics.isBigO_of_le _ fun n ↦ ?_)
-    (isBigO_sum_norm_normCoeff_one K)
-  rw [Real.norm_of_nonneg (Finset.sum_nonneg fun _ _ ↦ norm_nonneg _),
-    Real.norm_of_nonneg (Finset.sum_nonneg fun _ _ ↦ norm_nonneg _)]
-  refine Finset.sum_le_sum fun k _ ↦ ?_
-  rw [norm_normCoeff_one]
-  exact norm_normCoeff_le_card_normFiber χ k
-
-/-- The partial sums of the norm coefficients of a unitary weight are `O(n)`; equivalently, by
-`TauCeti.idealSummatory_natCast_eq_sum_Icc_normCoeff`, so are its ideal partial sums. This is the
-unconditional bound that `TauCeti.HasCancellation` improves. -/
-theorem isBigO_sum_Icc_normCoeff (χ : UnitaryIdealWeight K) :
-    (fun n : ℕ ↦ ∑ k ∈ Icc 1 n, normCoeff K χ.1.toIdealArithmeticFunction k)
-      =O[atTop] fun n : ℕ ↦ (n : ℝ) ^ (1 : ℝ) :=
-  (Asymptotics.isBigO_of_le _ fun n ↦ by
-    simpa [Real.norm_of_nonneg (Finset.sum_nonneg fun _ (_ : _ ∈ Icc 1 n) ↦ norm_nonneg _)] using
-      norm_sum_le (Icc 1 n) fun k ↦ normCoeff K χ.1.toIdealArithmeticFunction k).trans
-    (isBigO_sum_norm_normCoeff χ)
-
-/-- The Dirichlet series of the norm coefficients of a unitary weight converges absolutely on
-`Re s > 1`. -/
-theorem LSeriesSummable_normCoeff_of_one_lt_re (χ : UnitaryIdealWeight K) {s : ℂ}
-    (hs : 1 < s.re) : LSeriesSummable (normCoeff K χ.1.toIdealArithmeticFunction) s :=
-  LSeriesSummable_of_sum_norm_bigO (isBigO_sum_norm_normCoeff χ) zero_le_one hs
-
 /-! ### The continued L-function of a unitary weight -/
 
 /-- The **continued L-function of a unitary ideal weight**: the Mellin integral
@@ -275,7 +204,7 @@ theorem continuedLFunctionOfWeight_eq_LSeries (χ : UnitaryIdealWeight K) {s : �
       (isBigO_sum_Icc_normCoeff χ)]
   congr 1
   refine setIntegral_congr_fun measurableSet_Ioi fun t ht ↦ ?_
-  rw [idealSummatory_eq_sum_Icc_normCoeff _ (by linarith [Set.mem_Ioi.mp ht] : (0 : ℝ) ≤ t)]
+  rw [idealSummatory_eq_sum_Icc_normCoeff K _ (by linarith [Set.mem_Ioi.mp ht] : (0 : ℝ) ≤ t)]
 
 /-! ### Analyticity past the line `Re s = 1` -/
 
@@ -288,7 +217,7 @@ private theorem locallyIntegrableOn_idealSummatory (f : IdealArithmeticFunction 
   refine (h.mono_set Set.Ioi_subset_Ici_self).congr
     ((ae_restrict_iff' measurableSet_Ioi).2 (.of_forall fun t ht ↦ ?_))
   rw [one_mul]
-  exact (idealSummatory_eq_sum_Icc_normCoeff f (le_of_lt ht)).symm
+  exact (idealSummatory_eq_sum_Icc_normCoeff K f (le_of_lt ht)).symm
 
 /-- Ideal partial sums vanish near `0`, so they are `O` of every real power there. -/
 private theorem isBigO_idealSummatory_nhdsGT_zero (f : IdealArithmeticFunction K) (c : ℝ) :
@@ -311,13 +240,16 @@ private theorem integral_Ioi_one_eq_mellin (f : IdealArithmeticFunction K) (s : 
       (fun t ht ↦ Set.mem_Ioi.mpr (lt_of_lt_of_le zero_lt_one (Set.mem_Ici.mp ht))) ?_
     rintro t ⟨-, ht⟩
     rw [idealSummatory_eq_zero_of_lt_one K f (by simpa using ht), smul_zero]
+  -- Mathlib writes the Mellin exponent as `(-s) - 1`, the integrand above as `-(s + 1)`.
+  have hexp : (-s) - 1 = -(s + 1) := by ring
   rw [mellin, h, integral_Ici_eq_integral_Ioi]
   refine setIntegral_congr_fun measurableSet_Ioi fun t _ ↦ ?_
-  rw [smul_eq_mul, mul_comm ((t : ℂ) ^ ((-s) - 1)), show (-s) - 1 = -(s + 1) from by ring]
+  rw [smul_eq_mul, mul_comm ((t : ℂ) ^ ((-s) - 1)), hexp]
 
-/-- **The continued L-function is analytic past `Re s = 1`.** Cancellation at rate
-`1 - 1 / [K : ℚ]` makes the defining Mellin integral converge, and depend analytically on `s`,
-throughout the half-plane `Re s > 1 - 1 / [K : ℚ]`. -/
+/-- **The continued L-function is complex differentiable past `Re s = 1`.** Cancellation at rate
+`1 - 1 / [K : ℚ]` makes the defining Mellin integral converge, and depend differentiably on `s`,
+at every point of the half-plane `Re s > 1 - 1 / [K : ℚ]`. The half-plane form, and with it
+analyticity on a neighbourhood, is `TauCeti.analyticOnNhd_continuedLFunctionOfWeight`. -/
 theorem differentiableAt_continuedLFunctionOfWeight {χ : UnitaryIdealWeight K}
     (hχ : HasCancellation χ) {s : ℂ} (hs : cancellationExponent K < s.re) :
     DifferentiableAt ℂ (continuedLFunctionOfWeight χ) s := by

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Continuation.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Continuation.lean
@@ -1,0 +1,346 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.MellinTransform
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Counting
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Estimates
+
+/-!
+# Cancellation in ideal partial sums, and the L-function it continues
+
+The Dirichlet series of a unitary ideal weight `χ` converges absolutely only on `Re s > 1`, because
+`|χ|` is `1` on the good ideals and the ideals of `𝓞 K` of absolute norm at most `x` are linear in
+`x`. Any continuation past that line has to come from *cancellation* in the ideal partial sums
+`A_χ(x) = ∑_{N(I) ≤ x} χ(I)`. This file names that hypothesis and spends it.
+
+* `TauCeti.HasCancellation χ` is the bound `A_χ(x) = O(x ^ (1 - 1 / [K : ℚ]))`, with the exponent
+  `TauCeti.cancellationExponent K`.
+* `TauCeti.continuedLFunctionOfWeight χ` is the Mellin integral `s ∫_1^∞ A_χ(t) t^(-s-1) dt`,
+  which is what Abel summation turns the Dirichlet series into.
+
+The two main results are that the integral *is* the Dirichlet series where the latter converges
+(`TauCeti.continuedLFunctionOfWeight_eq_LSeries`, on `Re s > 1`, with no cancellation hypothesis),
+and that under `TauCeti.HasCancellation` it is analytic on the strictly larger half-plane
+`Re s > 1 - 1 / [K : ℚ]` (`TauCeti.differentiableAt_continuedLFunctionOfWeight` and
+`TauCeti.analyticOnNhd_continuedLFunctionOfWeight`). Together they exhibit
+`TauCeti.continuedLFunctionOfWeight χ` as an analytic continuation of the norm-regrouped series.
+
+`TauCeti.not_hasCancellation_one` is the accompanying rejection test: the trivial weight has no
+cancellation at all, since its ideal partial sums are bounded below by a positive multiple of `x`
+by the Layer 5 count `TauCeti.idealCount_linearBounds`. So the hypothesis is a genuine restriction,
+and no downstream character family may assume it for free.
+
+## Implementation notes
+
+The bridge between the two indexings is `TauCeti.idealSummatory_eq_sum_Icc_normCoeff`: an ideal
+partial sum is the partial sum of the norm coefficients over `1 ≤ k ≤ ⌊x⌋₊`, because the
+absolute-norm fibres partition the nonzero ideals of bounded norm. Through it, Mathlib's
+`LSeries_eq_mul_integral` — Abel summation in its integral form — supplies the identity on
+`Re s > 1`, and Mathlib's `mellin_differentiableAt_of_isBigO_rpow` supplies the analyticity: the
+integral is the Mellin transform of `A_χ` at `-s`, and `A_χ` vanishes below the cutoff `1`, so the
+only constraint on the strip is the growth bound at infinity.
+
+## Roadmap role
+
+This is Layer **6.5** of `TauCetiRoadmap/ArithmeticDirichletSeries/README.md`, whose export table
+names `HasCancellation` and `continuedLFunctionOfWeight`. Of that node this file supplies the
+definition, the agreement with the norm-regrouped series on `Re s > 1`, the analyticity on
+`Re s > 1 - 1 / [K : ℚ]`, and the trivial-weight rejection test; the conjugation operation is
+`TauCeti.HasCancellation.conj`. The remaining Layer 6.5 exports — the good-ideal restriction, the
+pointwise square, and the imaginary norm twist of a weight with cancellation — are not proved here.
+
+## References
+
+* H. Davenport, *Multiplicative Number Theory*, Chapter 1, for partial summation and the
+  half-plane of a Dirichlet series with bounded partial sums.
+* J. Neukirch, *Algebraic Number Theory*, Chapter VII, for Hecke characters and their L-series.
+* G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapter II.
+* Mathlib's `LSeries_eq_mul_integral` in `Mathlib/NumberTheory/LSeries/SumCoeff.lean`, by
+  Xavier Roblot, and `mellin_differentiableAt_of_isBigO_rpow` in
+  `Mathlib/Analysis/MellinTransform.lean`: the two analytic inputs used here.
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter Finset MeasureTheory
+open scoped nonZeroDivisors NumberField Topology
+
+variable {K : Type*} [Field K] [NumberField K]
+
+/-! ### Ideal partial sums and partial sums of norm coefficients -/
+
+/-- **An ideal partial sum is a partial sum of norm coefficients.** Summing an ideal arithmetic
+function over the nonzero ideals of absolute norm at most `n` is the same as summing its norm
+coefficients over `1 ≤ k ≤ n`, since the absolute-norm fibres partition those ideals. -/
+theorem idealSummatory_natCast_eq_sum_Icc_normCoeff (f : IdealArithmeticFunction K) (n : ℕ) :
+    idealSummatory K f (n : ℝ) = ∑ k ∈ Icc 1 n, normCoeff K f k := by
+  classical
+  have hmaps : ∀ I ∈ idealsLE K (n : ℝ), Ideal.absNorm (I : Ideal (𝓞 K)) ∈ Icc 1 n := by
+    intro I hI
+    rw [mem_normLE] at hI
+    exact mem_Icc.mpr ⟨Ideal.absNorm_pos_of_nonZeroDivisors I, by exact_mod_cast hI⟩
+  rw [idealSummatory_apply, ← Finset.sum_fiberwise_of_maps_to hmaps f]
+  refine Finset.sum_congr rfl fun k hk ↦ ?_
+  rw [normCoeff_eq_sum_normFiber]
+  refine Finset.sum_congr (Finset.ext fun I ↦ ?_) fun _ _ ↦ rfl
+  rw [Finset.mem_filter, mem_normFiber, mem_normLE]
+  refine ⟨fun h ↦ h.2, fun h ↦ ⟨?_, h⟩⟩
+  rw [h]
+  exact_mod_cast (mem_Icc.mp hk).2
+
+/-- The real-cutoff form of `TauCeti.idealSummatory_natCast_eq_sum_Icc_normCoeff`: the ideal
+partial sum at a nonnegative cutoff `x` is the partial sum of the norm coefficients up to `⌊x⌋₊`.
+-/
+theorem idealSummatory_eq_sum_Icc_normCoeff (f : IdealArithmeticFunction K) {x : ℝ} (hx : 0 ≤ x) :
+    idealSummatory K f x = ∑ k ∈ Icc 1 ⌊x⌋₊, normCoeff K f k := by
+  rw [show idealSummatory K f x = idealSummatory K f (⌊x⌋₊ : ℝ) from
+      summatory_eq_summatory_natFloor _ f hx, idealSummatory_natCast_eq_sum_Icc_normCoeff]
+
+/-- Conjugating an ideal arithmetic function conjugates its ideal partial sums. -/
+theorem idealSummatory_star (f : IdealArithmeticFunction K) (x : ℝ) :
+    idealSummatory K (fun I ↦ star (f I)) x = star (idealSummatory K f x) := by
+  rw [idealSummatory_apply, idealSummatory_apply, star_sum]
+
+/-! ### The cancellation exponent -/
+
+variable (K) in
+/-- The exponent `1 - 1 / [K : ℚ]` of the cancellation hypothesis of a unitary ideal weight. It
+lies in `[0, 1)`, so cancellation at this rate is strictly stronger than the trivial linear bound
+on ideal partial sums, and continues the associated Dirichlet series past `Re s = 1`. -/
+noncomputable def cancellationExponent : ℝ := 1 - (Module.finrank ℚ K : ℝ)⁻¹
+
+variable (K) in
+/-- Defining equation of `TauCeti.cancellationExponent`. -/
+theorem cancellationExponent_def :
+    cancellationExponent K = 1 - (Module.finrank ℚ K : ℝ)⁻¹ :=
+  (rfl)
+
+variable (K) in
+/-- The cancellation exponent is nonnegative, since `[K : ℚ] ≥ 1`. -/
+theorem cancellationExponent_nonneg : 0 ≤ cancellationExponent K := by
+  have h : (1 : ℝ) ≤ (Module.finrank ℚ K : ℝ) := by exact_mod_cast Module.finrank_pos (R := ℚ)
+  have := inv_le_one_of_one_le₀ h
+  simpa [cancellationExponent] using this
+
+variable (K) in
+/-- The cancellation exponent is strictly less than `1`, since `[K : ℚ]` is finite. -/
+theorem cancellationExponent_lt_one : cancellationExponent K < 1 := by
+  have h : (0 : ℝ) < (Module.finrank ℚ K : ℝ) := by exact_mod_cast Module.finrank_pos (R := ℚ)
+  have := inv_pos.mpr h
+  simpa [cancellationExponent] using this
+
+/-! ### Cancellation in the ideal partial sums -/
+
+/-- **Cancellation** in the ideal partial sums of a unitary ideal weight: the sums
+`∑_{N(I) ≤ x} χ(I)` are `O(x ^ (1 - 1 / [K : ℚ]))`.
+
+Without any hypothesis those sums are only `O(x)`, which is exactly what the trivial weight
+achieves; see `TauCeti.not_hasCancellation_one`. A finite quotient of the free ideal group is no
+substitute for this hypothesis, since the values of a weight at the primes may be arbitrary.
+
+The predicate is stated for unitary weights, and not for a general ideal arithmetic function,
+because the rate `TauCeti.cancellationExponent K` is the one calibrated to coefficients of modulus
+at most `1`: a function of unbounded size would have to carry its own exponent. -/
+def HasCancellation (χ : UnitaryIdealWeight K) : Prop :=
+  (fun x : ℝ ↦ idealSummatory K χ.1.toIdealArithmeticFunction x) =O[atTop]
+    fun x : ℝ ↦ x ^ cancellationExponent K
+
+/-- Defining equation of `TauCeti.HasCancellation`. -/
+theorem hasCancellation_def (χ : UnitaryIdealWeight K) :
+    HasCancellation χ ↔
+      (fun x : ℝ ↦ idealSummatory K χ.1.toIdealArithmeticFunction x) =O[atTop]
+        fun x : ℝ ↦ x ^ cancellationExponent K :=
+  (Iff.rfl)
+
+/-- Cancellation is preserved by conjugation of the weight. -/
+theorem HasCancellation.conj {χ : UnitaryIdealWeight K} (hχ : HasCancellation χ) :
+    HasCancellation (UnitaryIdealWeight.conj χ) := by
+  have hconj : (UnitaryIdealWeight.conj χ).1.toIdealArithmeticFunction
+      = fun I ↦ star (χ.1.toIdealArithmeticFunction I) :=
+    funext fun I ↦ by simp [UnitaryIdealWeight.val_conj, MultiplicativeIdealWeight.conj_apply]
+  rw [hasCancellation_def, ← Asymptotics.isBigO_norm_left] at hχ ⊢
+  refine hχ.congr' (Eventually.of_forall fun x ↦ ?_) EventuallyEq.rfl
+  simp only [hconj, idealSummatory_star, norm_star]
+
+/-- **Rejection test: the trivial weight has no cancellation.** Its ideal partial sums count the
+nonzero ideals of bounded absolute norm, and the Layer 5 bound `TauCeti.idealCount_linearBounds`
+puts a positive multiple of `x` below that count, whereas `x ^ (1 - 1 / [K : ℚ])` is `o(x)`.
+
+So the hypothesis `TauCeti.HasCancellation` genuinely excludes the trivial weight, and with it the
+Dedekind zeta function, whose series has a pole at `s = 1`. -/
+theorem not_hasCancellation_one : ¬ HasCancellation (1 : UnitaryIdealWeight K) := by
+  obtain ⟨b⟩ := idealCount_linearBounds K
+  have hθ : cancellationExponent K < 1 := cancellationExponent_lt_one K
+  intro h
+  rw [hasCancellation_def, Asymptotics.isBigO_iff] at h
+  obtain ⟨C, hC⟩ := h
+  obtain ⟨x, ⟨hCx, hlim⟩, hx1⟩ :=
+    ((hC.and ((tendsto_rpow_atTop (by linarith : (0:ℝ) < 1 - cancellationExponent K)
+      ).eventually_gt_atTop (C / b.lower))).and (eventually_ge_atTop (1 : ℝ))).exists
+  have hx0 : (0 : ℝ) < x := lt_of_lt_of_le zero_lt_one hx1
+  have hcount : b.lower * x ≤ ‖idealSummatory K
+      (1 : UnitaryIdealWeight K).1.toIdealArithmeticFunction x‖ := by
+    have hval : idealSummatory K (1 : UnitaryIdealWeight K).1.toIdealArithmeticFunction x
+        = ((idealsLE K x).card : ℂ) := by
+      simp [idealSummatory_apply]
+    rw [hval, Complex.norm_natCast,
+      ← Nat.card_coe_normLE (fun I : (Ideal (𝓞 K))⁰ ↦ Ideal.absNorm (I : Ideal (𝓞 K))) x]
+    exact b.le_card x hx1
+  rw [Real.norm_rpow_of_nonneg hx0.le, Real.norm_of_nonneg hx0.le] at hCx
+  -- Splitting `x = x ^ θ * x ^ (1 - θ)` turns the two bounds into `C < C`.
+  have hsplit : x ^ cancellationExponent K * x ^ (1 - cancellationExponent K) = x := by
+    rw [← Real.rpow_add hx0]
+    simp
+  have hpow : (0 : ℝ) < x ^ cancellationExponent K := Real.rpow_pos_of_pos hx0 _
+  have hkey : b.lower * (x ^ (1 - cancellationExponent K)) ≤ C := by
+    have := hcount.trans hCx
+    rw [← hsplit] at this
+    nlinarith [b.lower_pos]
+  have hgt : C < x ^ (1 - cancellationExponent K) * b.lower := (div_lt_iff₀ b.lower_pos).mp hlim
+  rw [mul_comm] at hkey
+  linarith
+
+/-! ### Elementary bounds for a unitary weight -/
+
+/-- The norm coefficient of a unitary weight at `n` is bounded by the number of nonzero ideals of
+absolute norm `n`, since every value of the weight has modulus at most `1`. -/
+theorem norm_normCoeff_le_card_normFiber (χ : UnitaryIdealWeight K) (n : ℕ) :
+    ‖normCoeff K χ.1.toIdealArithmeticFunction n‖ ≤ (normFiber K n).card := by
+  rw [normCoeff_eq_sum_normFiber]
+  refine (norm_sum_le _ _).trans ?_
+  simpa using Finset.sum_le_card_nsmul _ _ 1 fun I _ ↦ UnitaryIdealWeight.norm_le_one χ _
+
+/-- The partial sums of the absolute values of the norm coefficients of a unitary weight are
+`O(n)`, by comparison with the trivial weight. -/
+theorem isBigO_sum_norm_normCoeff (χ : UnitaryIdealWeight K) :
+    (fun n : ℕ ↦ ∑ k ∈ Icc 1 n, ‖normCoeff K χ.1.toIdealArithmeticFunction k‖)
+      =O[atTop] fun n : ℕ ↦ (n : ℝ) ^ (1 : ℝ) := by
+  refine Asymptotics.IsBigO.trans (Asymptotics.isBigO_of_le _ fun n ↦ ?_)
+    (isBigO_sum_norm_normCoeff_one K)
+  rw [Real.norm_of_nonneg (Finset.sum_nonneg fun _ _ ↦ norm_nonneg _),
+    Real.norm_of_nonneg (Finset.sum_nonneg fun _ _ ↦ norm_nonneg _)]
+  refine Finset.sum_le_sum fun k _ ↦ ?_
+  rw [norm_normCoeff_one]
+  exact norm_normCoeff_le_card_normFiber χ k
+
+/-- The partial sums of the norm coefficients of a unitary weight are `O(n)`; equivalently, by
+`TauCeti.idealSummatory_natCast_eq_sum_Icc_normCoeff`, so are its ideal partial sums. This is the
+unconditional bound that `TauCeti.HasCancellation` improves. -/
+theorem isBigO_sum_Icc_normCoeff (χ : UnitaryIdealWeight K) :
+    (fun n : ℕ ↦ ∑ k ∈ Icc 1 n, normCoeff K χ.1.toIdealArithmeticFunction k)
+      =O[atTop] fun n : ℕ ↦ (n : ℝ) ^ (1 : ℝ) :=
+  (Asymptotics.isBigO_of_le _ fun n ↦ by
+    simpa [Real.norm_of_nonneg (Finset.sum_nonneg fun _ (_ : _ ∈ Icc 1 n) ↦ norm_nonneg _)] using
+      norm_sum_le (Icc 1 n) fun k ↦ normCoeff K χ.1.toIdealArithmeticFunction k).trans
+    (isBigO_sum_norm_normCoeff χ)
+
+/-- The Dirichlet series of the norm coefficients of a unitary weight converges absolutely on
+`Re s > 1`. -/
+theorem LSeriesSummable_normCoeff_of_one_lt_re (χ : UnitaryIdealWeight K) {s : ℂ}
+    (hs : 1 < s.re) : LSeriesSummable (normCoeff K χ.1.toIdealArithmeticFunction) s :=
+  LSeriesSummable_of_sum_norm_bigO (isBigO_sum_norm_normCoeff χ) zero_le_one hs
+
+/-! ### The continued L-function of a unitary weight -/
+
+/-- The **continued L-function of a unitary ideal weight**: the Mellin integral
+`s ∫_1^∞ A_χ(t) t^(-s-1) dt` of its ideal partial sums `A_χ`.
+
+On `Re s > 1` this is the Dirichlet series of the norm coefficients, by
+`TauCeti.continuedLFunctionOfWeight_eq_LSeries`; under `TauCeti.HasCancellation` it is analytic on
+the larger half-plane `Re s > TauCeti.cancellationExponent K`, by
+`TauCeti.analyticOnNhd_continuedLFunctionOfWeight`. -/
+noncomputable def continuedLFunctionOfWeight (χ : UnitaryIdealWeight K) (s : ℂ) : ℂ :=
+  s * ∫ t in Set.Ioi (1 : ℝ),
+    idealSummatory K χ.1.toIdealArithmeticFunction t * (t : ℂ) ^ (-(s + 1))
+
+/-- Defining equation of `TauCeti.continuedLFunctionOfWeight`. -/
+theorem continuedLFunctionOfWeight_def (χ : UnitaryIdealWeight K) (s : ℂ) :
+    continuedLFunctionOfWeight χ s = s * ∫ t in Set.Ioi (1 : ℝ),
+      idealSummatory K χ.1.toIdealArithmeticFunction t * (t : ℂ) ^ (-(s + 1)) :=
+  (rfl)
+
+/-- **The continued L-function is the Dirichlet series on `Re s > 1`.** No cancellation hypothesis
+is needed: the identity is Abel summation, in Mathlib's integral form
+`LSeries_eq_mul_integral`, applied to the unconditional linear bound on ideal partial sums. -/
+theorem continuedLFunctionOfWeight_eq_LSeries (χ : UnitaryIdealWeight K) {s : ℂ} (hs : 1 < s.re) :
+    continuedLFunctionOfWeight χ s = LSeries (normCoeff K χ.1.toIdealArithmeticFunction) s := by
+  rw [continuedLFunctionOfWeight_def,
+    LSeries_eq_mul_integral _ zero_le_one hs (LSeriesSummable_normCoeff_of_one_lt_re χ hs)
+      (isBigO_sum_Icc_normCoeff χ)]
+  congr 1
+  refine setIntegral_congr_fun measurableSet_Ioi fun t ht ↦ ?_
+  rw [idealSummatory_eq_sum_Icc_normCoeff _ (by linarith [Set.mem_Ioi.mp ht] : (0 : ℝ) ≤ t)]
+
+/-! ### Analyticity past the line `Re s = 1` -/
+
+/-- Ideal partial sums are locally integrable on `(0, ∞)`: they are the step function of the
+partial sums of the norm coefficients. -/
+private theorem locallyIntegrableOn_idealSummatory (f : IdealArithmeticFunction K) :
+    LocallyIntegrableOn (fun t : ℝ ↦ idealSummatory K f t) (Set.Ioi 0) := by
+  have h := locallyIntegrableOn_mul_sum_Icc (fun k ↦ normCoeff K f k) (m := 1) (a := 0) le_rfl
+    (g := fun _ ↦ (1 : ℂ)) ((locallyIntegrable_const (1 : ℂ)).locallyIntegrableOn _)
+  refine (h.mono_set Set.Ioi_subset_Ici_self).congr
+    ((ae_restrict_iff' measurableSet_Ioi).2 (.of_forall fun t ht ↦ ?_))
+  rw [one_mul]
+  exact (idealSummatory_eq_sum_Icc_normCoeff f (le_of_lt ht)).symm
+
+/-- Ideal partial sums vanish near `0`, so they are `O` of every real power there. -/
+private theorem isBigO_idealSummatory_nhdsGT_zero (f : IdealArithmeticFunction K) (c : ℝ) :
+    (fun t : ℝ ↦ idealSummatory K f t) =O[𝓝[>] (0 : ℝ)] fun t : ℝ ↦ t ^ c := by
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨1, ?_⟩
+  filter_upwards [nhdsWithin_le_nhds (Iio_mem_nhds (zero_lt_one' ℝ))] with t ht
+  rw [idealSummatory_eq_zero_of_lt_one K f ht, norm_zero, one_mul]
+  exact norm_nonneg _
+
+/-- The integral defining `TauCeti.continuedLFunctionOfWeight` is the Mellin transform of the
+ideal partial sums at `-s`: the integrand vanishes below the cutoff `1`, so extending the range
+from `(1, ∞)` to `(0, ∞)` changes nothing. -/
+private theorem integral_Ioi_one_eq_mellin (f : IdealArithmeticFunction K) (s : ℂ) :
+    ∫ t in Set.Ioi (1 : ℝ), idealSummatory K f t * (t : ℂ) ^ (-(s + 1))
+      = mellin (fun t : ℝ ↦ idealSummatory K f t) (-s) := by
+  have h : ∫ t in Set.Ioi (0 : ℝ), (t : ℂ) ^ ((-s) - 1) • idealSummatory K f t
+      = ∫ t in Set.Ici (1 : ℝ), (t : ℂ) ^ ((-s) - 1) • idealSummatory K f t := by
+    refine setIntegral_eq_of_subset_of_forall_sdiff_eq_zero measurableSet_Ioi
+      (fun t ht ↦ Set.mem_Ioi.mpr (lt_of_lt_of_le zero_lt_one (Set.mem_Ici.mp ht))) ?_
+    rintro t ⟨-, ht⟩
+    rw [idealSummatory_eq_zero_of_lt_one K f (by simpa using ht), smul_zero]
+  rw [mellin, h, integral_Ici_eq_integral_Ioi]
+  refine setIntegral_congr_fun measurableSet_Ioi fun t _ ↦ ?_
+  rw [smul_eq_mul, mul_comm ((t : ℂ) ^ ((-s) - 1)), show (-s) - 1 = -(s + 1) from by ring]
+
+/-- **The continued L-function is analytic past `Re s = 1`.** Cancellation at rate
+`1 - 1 / [K : ℚ]` makes the defining Mellin integral converge, and depend analytically on `s`,
+throughout the half-plane `Re s > 1 - 1 / [K : ℚ]`. -/
+theorem differentiableAt_continuedLFunctionOfWeight {χ : UnitaryIdealWeight K}
+    (hχ : HasCancellation χ) {s : ℂ} (hs : cancellationExponent K < s.re) :
+    DifferentiableAt ℂ (continuedLFunctionOfWeight χ) s := by
+  have hmellin : DifferentiableAt ℂ
+      (mellin fun t : ℝ ↦ idealSummatory K χ.1.toIdealArithmeticFunction t) (-s) :=
+    mellin_differentiableAt_of_isBigO_rpow (a := -cancellationExponent K) (b := -s.re - 1)
+      (locallyIntegrableOn_idealSummatory _)
+      (by simpa only [neg_neg] using (hasCancellation_def χ).mp hχ) (by simpa using hs)
+      (isBigO_idealSummatory_nhdsGT_zero _ _) (by simp)
+  have hfun : continuedLFunctionOfWeight χ =
+      fun z : ℂ ↦ z * mellin (fun t : ℝ ↦ idealSummatory K χ.1.toIdealArithmeticFunction t) (-z) :=
+    funext fun z ↦ by rw [continuedLFunctionOfWeight_def, integral_Ioi_one_eq_mellin]
+  rw [hfun]
+  exact differentiableAt_id.mul (hmellin.comp s differentiable_neg.differentiableAt)
+
+/-- **The continued L-function is analytic on `Re s > 1 - 1 / [K : ℚ]`**, the half-plane form of
+`TauCeti.differentiableAt_continuedLFunctionOfWeight`. -/
+theorem analyticOnNhd_continuedLFunctionOfWeight {χ : UnitaryIdealWeight K}
+    (hχ : HasCancellation χ) :
+    AnalyticOnNhd ℂ (continuedLFunctionOfWeight χ)
+      {s : ℂ | cancellationExponent K < s.re} :=
+  DifferentiableOn.analyticOnNhd
+    (fun _ hs ↦ (differentiableAt_continuedLFunctionOfWeight hχ hs).differentiableWithinAt)
+    (isOpen_lt continuous_const Complex.continuous_re)
+
+end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Counting.lean
@@ -40,6 +40,14 @@ A prime-power ideal is `𝔭 ^ k` for a unique height-one prime `𝔭` and a uni
 `TauCeti.idealPrimePower_eq_of_base_eq_of_exponent_eq` records that it determines the ideal.  The
 exponent is `1` exactly on the primes themselves, which is `TauCeti.primePowerExponent_eq_one_iff`.
 
+The absolute-norm fibres of `TauCeti.normFiber` partition the ideals of bounded norm, so an ideal
+summatory function regroups by absolute norm:
+`TauCeti.idealSummatory_natCast_eq_sum_Icc_sum_normFiber` for a general weight, and
+`TauCeti.idealSummatory_natCast_eq_sum_Icc_normCoeff` together with its real-cutoff form
+`TauCeti.idealSummatory_eq_sum_Icc_normCoeff` for the norm coefficients of an ideal arithmetic
+function. This is the bridge between the ideal and the natural-number indexings, used by Layer 5
+for the ideal counts and by Layer 6 for Abel summation.
+
 For `0 ≤ x`, a real cutoff and its floor select the same indices, so
 `TauCeti.normLE_eq_normLE_natFloor` and `TauCeti.summatory_eq_summatory_natFloor` convert between
 the real and natural conventions. The small-cutoff cases are degenerate for a reason worth
@@ -330,6 +338,48 @@ theorem idealSummatory_eq_zero_of_lt_one {M : Type*} [AddCommMonoid M]
 theorem idealSummatory_one {M : Type*} [AddCommMonoid M] (w : (Ideal (𝓞 K))⁰ → M) :
     idealSummatory K w 1 = w 1 := by
   rw [idealSummatory_apply, idealsLE_one, Finset.sum_singleton]
+
+/-- Conjugating a weight conjugates its ideal summatory function. -/
+theorem idealSummatory_star {M : Type*} [AddCommMonoid M] [StarAddMonoid M]
+    (w : (Ideal (𝓞 K))⁰ → M) (x : ℝ) :
+    idealSummatory K (fun I ↦ star (w I)) x = star (idealSummatory K w x) := by
+  rw [idealSummatory_apply, idealSummatory_apply, star_sum]
+
+/-! ### Regrouping an ideal summatory function by absolute norm -/
+
+/-- **The absolute-norm fibres partition the ideals of bounded norm.** Summing a weight over the
+nonzero integral ideals of absolute norm at most `n` is the same as summing it over the fibres
+`TauCeti.normFiber K k` for `1 ≤ k ≤ n`, since a nonzero ideal has absolute norm at least `1`. -/
+theorem idealSummatory_natCast_eq_sum_Icc_sum_normFiber {M : Type*} [AddCommMonoid M]
+    (w : (Ideal (𝓞 K))⁰ → M) (n : ℕ) :
+    idealSummatory K w (n : ℝ) = ∑ k ∈ Finset.Icc 1 n, ∑ I ∈ normFiber K k, w I := by
+  classical
+  have hmaps : ∀ I ∈ idealsLE K (n : ℝ), Ideal.absNorm (I : Ideal (𝓞 K)) ∈ Finset.Icc 1 n := by
+    intro I hI
+    rw [mem_normLE] at hI
+    exact Finset.mem_Icc.mpr ⟨Ideal.absNorm_pos_of_nonZeroDivisors I, by exact_mod_cast hI⟩
+  rw [idealSummatory_apply, ← Finset.sum_fiberwise_of_maps_to hmaps w]
+  refine Finset.sum_congr rfl fun k hk ↦ Finset.sum_congr (Finset.ext fun I ↦ ?_) fun _ _ ↦ rfl
+  rw [Finset.mem_filter, mem_normFiber, mem_normLE]
+  refine ⟨fun h ↦ h.2, fun h ↦ ⟨?_, h⟩⟩
+  rw [h]
+  exact_mod_cast (Finset.mem_Icc.mp hk).2
+
+/-- **An ideal partial sum is a partial sum of norm coefficients.** Summing an ideal arithmetic
+function over the nonzero ideals of absolute norm at most `n` is the same as summing its norm
+coefficients over `1 ≤ k ≤ n`, since the absolute-norm fibres partition those ideals. -/
+theorem idealSummatory_natCast_eq_sum_Icc_normCoeff (f : IdealArithmeticFunction K) (n : ℕ) :
+    idealSummatory K f (n : ℝ) = ∑ k ∈ Finset.Icc 1 n, normCoeff K f k := by
+  rw [idealSummatory_natCast_eq_sum_Icc_sum_normFiber]
+  exact Finset.sum_congr rfl fun k _ ↦ (normCoeff_eq_sum_normFiber K f k).symm
+
+/-- The real-cutoff form of `TauCeti.idealSummatory_natCast_eq_sum_Icc_normCoeff`: the ideal
+partial sum at a nonnegative cutoff `x` is the partial sum of the norm coefficients up to `⌊x⌋₊`.
+-/
+theorem idealSummatory_eq_sum_Icc_normCoeff (f : IdealArithmeticFunction K) {x : ℝ} (hx : 0 ≤ x) :
+    idealSummatory K f x = ∑ k ∈ Finset.Icc 1 ⌊x⌋₊, normCoeff K f k :=
+  (summatory_eq_summatory_natFloor _ f hx).trans
+    (idealSummatory_natCast_eq_sum_Icc_normCoeff K f ⌊x⌋₊)
 
 /-! ### The weighted prime counts -/
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.NumberTheory.LSeries.Convergence
 public import Mathlib.NumberTheory.LSeries.SumCoeff
 public import Mathlib.NumberTheory.NumberField.Ideal.Asymptotics
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Counting
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Trivial
 
 /-!
@@ -17,7 +18,9 @@ Mathlib's `NumberField.Ideal.tendsto_norm_le_div_atTop₀` says that the number 
 ideals of `𝓞 K` of absolute norm at most `x` is asymptotic to `ρ x`, with `ρ` the positive residue
 of the Dedekind zeta function.  This file turns that single asymptotic into the *two-sided* linear
 bounds that every later estimate of the roadmap counts against, and then spends them on the exact
-abscissa of absolute convergence of the trivial ideal weight.
+abscissa of absolute convergence of the trivial ideal weight and on the unconditional `O(n)` bound
+for the partial sums of an arbitrary *unitary* ideal weight, whose coefficients the trivial ones
+dominate.
 
 Both directions are needed.  Convergence uses the upper bound alone: it makes the partial sums of
 the norm coefficients `O(n)`, so Mathlib's `LSeriesSummable_of_sum_norm_bigO` gives absolute
@@ -44,6 +47,11 @@ of a convergent series of nonnegative terms must become arbitrarily small.
   `NumberField.dedekindZeta` is the `LSeries` of.  That system counts *all* integral ideals, so it
   differs from the trivial norm coefficients at `n = 0` and the two statements are related only
   through the `n ≠ 0` congruence `LSeries.abscissaOfAbsConv_congr`.
+* `TauCeti.isBigO_sum_norm_normCoeff`, `TauCeti.isBigO_sum_Icc_normCoeff` and
+  `TauCeti.LSeriesSummable_normCoeff_of_one_lt_re` transfer the upper count to an arbitrary
+  unitary ideal weight, whose coefficients are dominated by the trivial ones because a unitary
+  weight has modulus at most `1` at every ideal.  These are the unconditional bounds that the
+  cancellation hypothesis of Layer 6 improves.
 
 ## Implementation notes
 
@@ -62,7 +70,8 @@ prove convergence at `Re s > 1`, and it has no lower bound at all.
 This is Layer **5.1** (the ideal-count half) together with Layer **5.1a** of
 `TauCetiRoadmap/ArithmeticDirichletSeries/README.md`.  As that layer demands, the exact abscissa
 is derived from the two-sided linear ideal counts alone: neither the analytic continuation of the
-Dedekind zeta function nor its pole at `s = 1` is used.
+Dedekind zeta function nor its pole at `s = 1` is used.  The unitary-weight comparison at the end
+of the file is the Layer 5 estimate that Layer 6 consumes for Abel summation.
 
 ## References
 
@@ -202,25 +211,12 @@ absolute norm at most `n`, because the absolute-norm fibres partition them. -/
 theorem sum_norm_normCoeff_one (n : ℕ) :
     ∑ k ∈ Finset.Icc 1 n, ‖normCoeff K (1 : IdealArithmeticFunction K) k‖
       = Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ (n : ℝ)} := by
-  classical
-  have hfin := finite_setOf_absNorm_real_le K (n : ℝ)
-  have key : hfin.toFinset.card = ∑ k ∈ Finset.Icc 1 n, (normFiber K k).card := by
-    refine Finset.card_eq_sum_card_fiberwise
-      (f := fun I : (Ideal (𝓞 K))⁰ ↦ Ideal.absNorm (I : Ideal (𝓞 K)))
-      (t := Finset.Icc 1 n) (fun I hI ↦ ?_) |>.trans (Finset.sum_congr rfl fun k hk ↦ ?_)
-    · rw [Finset.mem_coe, Finset.mem_Icc]
-      refine ⟨Ideal.absNorm_pos_of_nonZeroDivisors I, ?_⟩
-      rw [Finset.mem_coe, Set.Finite.mem_toFinset] at hI
-      exact_mod_cast hI
-    · congr 1
-      ext I
-      rw [Finset.mem_filter, Set.Finite.mem_toFinset, Set.mem_ofPred_eq, mem_normFiber]
-      refine ⟨fun h ↦ h.2, fun h ↦ ⟨?_, h⟩⟩
-      rw [h]
-      exact_mod_cast (Finset.mem_Icc.mp hk).2
   have hcard : Nat.card {I : (Ideal (𝓞 K))⁰ // (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ≤ (n : ℝ)}
-      = hfin.toFinset.card := Nat.card_eq_card_finite_toFinset hfin
-  rw [hcard, key, Nat.cast_sum]
+      = ∑ k ∈ Finset.Icc 1 n, (normFiber K k).card := by
+    rw [Nat.card_coe_normLE (fun I : (Ideal (𝓞 K))⁰ ↦ Ideal.absNorm (I : Ideal (𝓞 K))) (n : ℝ)]
+    simpa [idealSummatory_apply] using
+      idealSummatory_natCast_eq_sum_Icc_sum_normFiber K (fun _ ↦ (1 : ℕ)) n
+  rw [hcard, Nat.cast_sum]
   exact Finset.sum_congr rfl fun k _ ↦ norm_normCoeff_one K k
 
 /-! ### The exact abscissa of the trivial ideal weight -/
@@ -424,5 +420,48 @@ theorem LSeriesSummable_dedekindZetaCoeff_iff {s : ℂ} :
     LSeriesSummable (fun n ↦ (dedekindZetaCoeff K n : ℂ)) s ↔ 1 < s.re := by
   rw [← LSeriesSummable_normCoeff_one_iff K]
   exact LSeriesSummable_congr s fun {n} hn ↦ by rw [normCoeff_one_apply, ite_eq_right hn]
+
+/-! ### Unconditional bounds for a general unitary weight -/
+
+variable {K}
+
+/-- The norm coefficient of a unitary weight at `n` is bounded by the number of nonzero ideals of
+absolute norm `n`, since every value of the weight has modulus at most `1`. -/
+theorem norm_normCoeff_le_card_normFiber (χ : UnitaryIdealWeight K) (n : ℕ) :
+    ‖normCoeff K χ.1.toIdealArithmeticFunction n‖ ≤ (normFiber K n).card := by
+  rw [normCoeff_eq_sum_normFiber]
+  refine (norm_sum_le _ _).trans ?_
+  simpa using Finset.sum_le_card_nsmul _ _ 1 fun I _ ↦ UnitaryIdealWeight.norm_le_one χ _
+
+/-- The partial sums of the absolute values of the norm coefficients of a unitary weight are
+`O(n)`, by comparison with the trivial weight. -/
+theorem isBigO_sum_norm_normCoeff (χ : UnitaryIdealWeight K) :
+    (fun n : ℕ ↦ ∑ k ∈ Finset.Icc 1 n, ‖normCoeff K χ.1.toIdealArithmeticFunction k‖)
+      =O[atTop] fun n : ℕ ↦ (n : ℝ) ^ (1 : ℝ) := by
+  refine Asymptotics.IsBigO.trans (Asymptotics.isBigO_of_le _ fun n ↦ ?_)
+    (isBigO_sum_norm_normCoeff_one K)
+  rw [Real.norm_of_nonneg (Finset.sum_nonneg fun _ _ ↦ norm_nonneg _),
+    Real.norm_of_nonneg (Finset.sum_nonneg fun _ _ ↦ norm_nonneg _)]
+  refine Finset.sum_le_sum fun k _ ↦ ?_
+  rw [norm_normCoeff_one]
+  exact norm_normCoeff_le_card_normFiber χ k
+
+/-- The partial sums of the norm coefficients of a unitary weight are `O(n)`; equivalently, by
+`TauCeti.idealSummatory_natCast_eq_sum_Icc_normCoeff`, so are its ideal partial sums. This is the
+unconditional bound that Layer 6's cancellation hypothesis improves. -/
+theorem isBigO_sum_Icc_normCoeff (χ : UnitaryIdealWeight K) :
+    (fun n : ℕ ↦ ∑ k ∈ Finset.Icc 1 n, normCoeff K χ.1.toIdealArithmeticFunction k)
+      =O[atTop] fun n : ℕ ↦ (n : ℝ) ^ (1 : ℝ) :=
+  (Asymptotics.isBigO_of_le _ fun n ↦ by
+    simpa [Real.norm_of_nonneg (Finset.sum_nonneg fun _ (_ : _ ∈ Finset.Icc 1 n) ↦
+      norm_nonneg _)] using
+      norm_sum_le (Finset.Icc 1 n) fun k ↦ normCoeff K χ.1.toIdealArithmeticFunction k).trans
+    (isBigO_sum_norm_normCoeff χ)
+
+/-- The Dirichlet series of the norm coefficients of a unitary weight converges absolutely on
+`Re s > 1`. -/
+theorem LSeriesSummable_normCoeff_of_one_lt_re (χ : UnitaryIdealWeight K) {s : ℂ}
+    (hs : 1 < s.re) : LSeriesSummable (normCoeff K χ.1.toIdealArithmeticFunction) s :=
+  LSeriesSummable_of_sum_norm_bigO (isBigO_sum_norm_normCoeff χ) zero_le_one hs
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean
@@ -612,6 +612,14 @@ theorem norm_eq_one (χ : UnitaryIdealWeight K) {I : Ideal (𝓞 K)} (hI : χ.1.
   refine hI.induction_on (by simp) fun 𝔭 J h𝔭 _ ih ↦ ?_
   rw [map_mul, norm_mul, χ.2 𝔭 h𝔭, ih, one_mul]
 
+/-- **A unitary weight has modulus at most one on every ideal**: modulus `1` on the good ideals by
+`TauCeti.UnitaryIdealWeight.norm_eq_one`, and value `0` elsewhere. -/
+theorem norm_le_one (χ : UnitaryIdealWeight K) (I : Ideal (𝓞 K)) : ‖χ.1 I‖ ≤ 1 := by
+  by_cases hI : χ.1.IsGood I
+  · exact (norm_eq_one χ hI).le
+  · rw [(MultiplicativeIdealWeight.apply_eq_zero_iff_not_isGood χ.1 I).mpr hI, norm_zero]
+    exact zero_le_one
+
 /-- The trivial weight is unitary. -/
 noncomputable instance : One (UnitaryIdealWeight K) :=
   ⟨1, fun 𝔭 _ ↦ by simp [MultiplicativeIdealWeight.one_apply, 𝔭.ne_bot]⟩


### PR DESCRIPTION
This PR names the cancellation hypothesis that continues the Dirichlet series of a unitary ideal weight past `Re s = 1`, builds the continued function it produces, and proves the two facts that make it a continuation: it is the norm-regrouped series where that series converges, and it is analytic on a strictly larger half-plane. It adds `TauCeti/NumberTheory/ArithmeticDirichletSeries/Continuation.lean` (346 lines) and one lemma to `TauCeti/NumberTheory/ArithmeticDirichletSeries/Weight.lean` (+8 lines).

The milestone is Layer **6.5** ("Cancellation and a named continuation") of `TauCetiRoadmap/ArithmeticDirichletSeries/README.md`, whose export-table row reads "cancellation and continuation | 6 | `HasCancellation`, `continuedLFunctionOfWeight` | a named continuation into the strip supplied by the ideal partial-sum estimate". Layer 6.5 asks to "Define `HasCancellation χ` by the uniform `O(X^(1-1/[K:ℚ]))` bound for ideal partial sums. Use Abel summation to construct `continuedLFunctionOfWeight χ` for `χ : UnitaryIdealWeight K`, prove agreement with the norm-regrouped series on `Re s > 1`, and analyticity on `Re s > 1-1/[K:ℚ]`." All four clauses are here. What remains for the node afterwards is the list of weight operations it also asks to export — the good-ideal restriction, the pointwise square, and the imaginary norm twist of a weight with cancellation — of which this PR supplies only conjugation (`TauCeti.HasCancellation.conj`); the other three change the partial sums nontrivially and each needs its own estimate.

Roadmap: ArithmeticDirichletSeries

<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"continuedlfunctionofweight"}-->

`TauCeti.cancellationExponent K` is `1 - 1/[K : ℚ]`, proved to lie in `[0, 1)`, and `TauCeti.HasCancellation χ` is `(fun x ↦ ∑_{N(I) ≤ x} χ(I)) =O[atTop] (· ^ cancellationExponent K)`, stated on the already-merged ideal partial sum `TauCeti.idealSummatory` of `Counting.lean`. `TauCeti.continuedLFunctionOfWeight χ s` is `s * ∫ t in Ioi 1, A_χ(t) * t ^ (-(s+1))`, the shape Abel summation turns a Dirichlet series into. `TauCeti.continuedLFunctionOfWeight_eq_LSeries` identifies it with `LSeries (normCoeff K χ)` on `Re s > 1` and deliberately assumes **no** cancellation: the identity holds for every unitary weight, because the unconditional linear ideal count already gives the `O(n)` partial-sum bound Mathlib's `LSeries_eq_mul_integral` needs. `TauCeti.differentiableAt_continuedLFunctionOfWeight` and `TauCeti.analyticOnNhd_continuedLFunctionOfWeight` are where cancellation is spent, on `Re s > 1 - 1/[K:ℚ]`. Since that exponent is `< 1`, the two together exhibit the integral as an analytic continuation of the series.

`TauCeti.not_hasCancellation_one` is the honesty check the roadmap demands of this hypothesis: the trivial weight has **no** cancellation, since the already-merged Layer 5 bound `TauCeti.idealCount_linearBounds` puts `lower * x` below its ideal partial sums while `x ^ (1 - 1/[K:ℚ])` is `o(x)`. So `HasCancellation` is a genuine restriction, it excludes the Dedekind zeta function whose series has a pole at `s = 1`, and no downstream character family may help itself to it — which is exactly the rejection test recorded in the roadmap's Layer 8.2 note ("The package does not assert cancellation for the trivial weight … their partial sums have linear size"). The predicate is not left unexercised: it has three consumers here besides that test.

The bridge between the two indexings is `TauCeti.idealSummatory_eq_sum_Icc_normCoeff` (with its natural-cutoff form `idealSummatory_natCast_eq_sum_Icc_normCoeff`): an ideal partial sum is the partial sum of the norm coefficients over `1 ≤ k ≤ ⌊x⌋₊`, because the absolute-norm fibres partition the nonzero ideals of bounded norm. This is the only new combinatorial input; everything else is Mathlib. Analyticity comes from Mathlib's Mellin API rather than a hand-rolled differentiation under the integral sign: `TauCeti.continuedLFunctionOfWeight χ s` is `s * mellin A_χ (-s)`, since `A_χ` vanishes below the cutoff `1` and the range may therefore be extended from `(1, ∞)` to `(0, ∞)`, so `mellin_differentiableAt_of_isBigO_rpow` applies with the growth bound at infinity as its only real constraint — the bound at `0` is free.

The stated prerequisites are on `main`. Layer 0's `MultiplicativeIdealWeight`/`UnitaryIdealWeight` come from `Weight.lean` (#3903, #3904), Layer 1's `normCoeff` from `NormCoeff.lean` (#4004), Layer 4's `idealSummatory` and cutoff carriers from `Counting.lean` (#4495), and Layer 5's `idealCount_linearBounds` and `isBigO_sum_norm_normCoeff_one` from `Estimates.lean` (#4592). The roadmap's ordering note says Layer 6 can be developed after Layers 1 and 4; 6.1 is #4876 and 6.3 is #4916, and this node depends on neither — it consumes Mathlib's Abel summation directly, as Layer 6.1 instructs ("consume Mathlib's exact identity"), and adds no competing summation-by-parts API.

Also in the diff: `TauCeti.UnitaryIdealWeight.norm_le_one`, that a unitary weight has modulus at most `1` at *every* ideal — `1` at a good ideal by the existing `norm_eq_one`, and `0` elsewhere. It belongs beside `norm_eq_one` in `Weight.lean` rather than in the new file, since it depends on nothing later.

No Mathlib source is vendored. The two analytic inputs are Xavier Roblot's `LSeries_eq_mul_integral` from `Mathlib/NumberTheory/LSeries/SumCoeff.lean` and `mellin_differentiableAt_of_isBigO_rpow` from `Mathlib/Analysis/MellinTransform.lean`, both credited in the module docstring; the argument — bounded partial sums push a Dirichlet series' half-plane of analyticity left to the growth exponent — is the standard one in Davenport, *Multiplicative Number Theory*, Chapter 1, and Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapter II, with the Hecke-character setting from Neukirch, *Algebraic Number Theory*, Chapter VII.

🤖 Prepared with Claude Code
