### PR TITLE
feat: juxtapose grid rectangles

### DIFF
--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -40,6 +40,9 @@ directions before taking products.
 * `TauCeti.Grid.mem_cIco`: membership in the clockwise half-open arc.
 * `TauCeti.Grid.card_cIco`: the length of a half-open arc in standard representatives.
 * `TauCeti.Grid.cIco_union_swap`: opposite nondegenerate half-open arcs partition the grid.
+* `TauCeti.Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo`: an interior point cuts a half-open arc
+  into two adjacent half-open arcs.
+* `TauCeti.Grid.disjoint_cIco_cIco_of_mem_cIoo`: the two pieces of such a cut are disjoint.
 * `TauCeti.Grid.Noninterleaving`: two endpoint pairs lie on the same cyclic side of each other.
 * `TauCeti.Grid.noninterleaving_rev`: non-interleaving is preserved by reversing every endpoint
   with `Fin.rev`, exchanging the two endpoints within each pair.
@@ -379,28 +382,9 @@ theorem mem_cIoo_or_mem_cIoo_swap_iff {a b x : Fin n} (h : a ≠ b) :
           have hxb : x.val < b.val := Nat.lt_of_le_of_ne (Nat.le_of_not_gt hbx) (by omega)
           simp [hab, hxb]⟩)
 
-/-- Cyclically rotating three distinct points preserves their clockwise order. -/
-theorem mem_cIoo_rotate {a b c : Fin n} :
-    b ∈ cIoo a c ↔ c ∈ cIoo b a := by
-  constructor
-  · intro h
-    have hba : b ≠ a := fun hba => by
-      subst b
-      exact Grid.left_notMem_cIoo a c h
-    rw [mem_cIoo] at h ⊢
-    refine ⟨hba, ?_⟩
-    split_ifs at h ⊢ <;> omega
-  · intro h
-    have hac : a ≠ c := fun hac => by
-      subst c
-      exact Grid.right_notMem_cIoo b a h
-    rw [mem_cIoo] at h ⊢
-    refine ⟨hac, ?_⟩
-    split_ifs at h ⊢ <;> omega
-
 /-- A point strictly between two endpoints cuts their half-open cyclic interval into two
 adjacent half-open intervals. -/
-theorem cIco_union_cIco_eq_of_mem_cIoo {a b c : Fin n} (h : b ∈ cIoo a c) :
+theorem cIco_union_cIco_eq_cIco_of_mem_cIoo {a b c : Fin n} (h : b ∈ cIoo a c) :
     cIco a b ∪ cIco b c = cIco a c := by
   ext x
   rw [Finset.mem_union, mem_cIco, mem_cIco, mem_cIco]

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -379,6 +379,44 @@ theorem mem_cIoo_or_mem_cIoo_swap_iff {a b x : Fin n} (h : a ≠ b) :
           have hxb : x.val < b.val := Nat.lt_of_le_of_ne (Nat.le_of_not_gt hbx) (by omega)
           simp [hab, hxb]⟩)
 
+/-- Cyclically rotating three distinct points preserves their clockwise order. -/
+theorem mem_cIoo_rotate {a b c : Fin n} :
+    b ∈ cIoo a c ↔ c ∈ cIoo b a := by
+  constructor
+  · intro h
+    have hba : b ≠ a := fun hba => by
+      subst b
+      exact Grid.left_notMem_cIoo a c h
+    rw [mem_cIoo] at h ⊢
+    refine ⟨hba, ?_⟩
+    split_ifs at h ⊢ <;> omega
+  · intro h
+    have hac : a ≠ c := fun hac => by
+      subst c
+      exact Grid.right_notMem_cIoo b a h
+    rw [mem_cIoo] at h ⊢
+    refine ⟨hac, ?_⟩
+    split_ifs at h ⊢ <;> omega
+
+/-- A point strictly between two endpoints cuts their half-open cyclic interval into two
+adjacent half-open intervals. -/
+theorem cIco_union_cIco_eq_of_mem_cIoo {a b c : Fin n} (h : b ∈ cIoo a c) :
+    cIco a b ∪ cIco b c = cIco a c := by
+  ext x
+  rw [Finset.mem_union, mem_cIco, mem_cIco, mem_cIco]
+  rw [mem_cIoo] at h
+  split_ifs at h ⊢ <;> omega
+
+/-- The two pieces obtained by cutting a half-open cyclic interval at an interior point are
+disjoint. -/
+theorem disjoint_cIco_cIco_of_mem_cIoo {a b c : Fin n} (h : b ∈ cIoo a c) :
+    Disjoint (cIco a b) (cIco b c) := by
+  rw [Finset.disjoint_left]
+  intro x hxab hxbc
+  rw [mem_cIco] at hxab hxbc
+  rw [mem_cIoo] at h
+  split_ifs at h hxab hxbc <;> omega
+
 /-- A point outside the clockwise interval from `a` to `b` is either an endpoint or lies in
 the opposite clockwise interval. -/
 theorem not_mem_cIoo_iff {a b x : Fin n} (h : a ≠ b) :

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -49,10 +49,11 @@ directions before taking products.
 
 ## References
 
-This supplies a prerequisite for `TauCetiRoadmap/HeegaardFloer/README.md`, Lane G.3, "The
-complexes and `∂² = 0`", where the annular cases in the juxtaposition proof use the fact that
-the two complementary cyclic intervals partition the non-endpoint columns or rows. The
-terminology follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
+This supplies a prerequisite for `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3,
+"The complexes and `∂² = 0`". The annular cases in the juxtaposition proof use the fact that the
+two complementary cyclic intervals partition the non-endpoint columns or rows, while the
+half-open cut lemmas feed the overlapping-rectangle case. The terminology follows
+Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
 -/
 
 public section

--- a/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
@@ -31,8 +31,9 @@ preserves `X`-avoidance and the product of the `O`-monomial weights in the one-c
   repartition identity.
 * `TauCeti.GridRectangle.coveredSquares_union_eq_of_mem_cIoo'`: the complementary orientation
   of the same identity.
-* `TauCeti.GridRectangle.disjoint_coveredSquares_of_mem_cIoo`: the two pieces on each side of
-  the first identity are disjoint.
+* `TauCeti.GridRectangle.disjoint_coveredSquares_of_row_mem_cIoo` and
+  `TauCeti.GridRectangle.disjoint_coveredSquares_of_col_mem_cIoo`: the two pieces on the left
+  and right sides of the first identity are disjoint.
 * `TauCeti.GridRectangle.prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo`: any
   multiplicative weight is preserved by the repartition.
 
@@ -87,7 +88,7 @@ theorem coveredSquares_union_eq_of_mem_cIoo' {a b c u v w : Fin n}
 
 /-- In the first L-shaped repartition, the two rectangles on the left have disjoint covered
 square domains. -/
-theorem disjoint_coveredSquares_of_mem_cIoo {a b c u v w : Fin n}
+theorem disjoint_coveredSquares_of_row_mem_cIoo {a b c u v w : Fin n}
     (hrow : v ∈ Grid.cIoo u w) :
     Disjoint
       ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
@@ -103,7 +104,7 @@ theorem disjoint_coveredSquares_of_mem_cIoo {a b c u v w : Fin n}
 
 /-- In the first L-shaped repartition, the two rectangles on the right have disjoint covered
 square domains. -/
-theorem disjoint_coveredSquares_of_mem_cIoo_alt {a b c u v w : Fin n}
+theorem disjoint_coveredSquares_of_col_mem_cIoo {a b c u v w : Fin n}
     (hcol : b ∈ Grid.cIoo a c) :
     Disjoint
       ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares
@@ -119,7 +120,7 @@ theorem disjoint_coveredSquares_of_mem_cIoo_alt {a b c u v w : Fin n}
 
 /-- In the complementary L-shaped repartition, the two alternate rectangles have disjoint
 covered-square domains. -/
-theorem disjoint_coveredSquares_of_mem_cIoo_alt' {a b c u v w : Fin n}
+theorem disjoint_coveredSquares_of_col_mem_cIoo_compl {a b c u v w : Fin n}
     (hcol : c ∈ Grid.cIoo a b) :
     Disjoint
       ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares
@@ -147,9 +148,9 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo
           f p) *
         ∏ p ∈ ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares,
           f p := by
-  rw [← Finset.prod_union (disjoint_coveredSquares_of_mem_cIoo hrow),
+  rw [← Finset.prod_union (disjoint_coveredSquares_of_row_mem_cIoo hrow),
     coveredSquares_union_eq_of_mem_cIoo hcol hrow,
-    Finset.prod_union (disjoint_coveredSquares_of_mem_cIoo_alt hcol)]
+    Finset.prod_union (disjoint_coveredSquares_of_col_mem_cIoo hcol)]
 
 /-- Recutting the complementary L-shaped domain preserves the product of any commutative weight
 on its covered squares. -/
@@ -164,9 +165,9 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo'
           f p) *
         ∏ p ∈ ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
           f p := by
-  rw [← Finset.prod_union (disjoint_coveredSquares_of_mem_cIoo hrow),
+  rw [← Finset.prod_union (disjoint_coveredSquares_of_row_mem_cIoo hrow),
     coveredSquares_union_eq_of_mem_cIoo' hcol hrow,
-    Finset.prod_union (disjoint_coveredSquares_of_mem_cIoo_alt' hcol)]
+    Finset.prod_union (disjoint_coveredSquares_of_col_mem_cIoo_compl hcol)]
 
 end GridRectangle
 

--- a/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import TauCeti.KnotTheory.Grid.Rectangle.Squares
+
+/-!
+# Juxtaposing toroidal grid rectangles
+
+Two rectangles in a nondiagonal term of the grid differential square can share one corner.
+Cutting their L-shaped union along its other internal edge gives the alternate two-rectangle
+decomposition. This file proves the finite-domain identity behind that cut.
+
+The one-dimensional input is that an interior point `b` cuts the clockwise half-open interval
+from `a` to `c` into the disjoint intervals from `a` to `b` and from `b` to `c`. Applying this in
+both coordinates gives two forms of the L-shaped identity for `GridRectangle.coveredSquares`.
+The disjointness statements record that both displayed unions are honest partitions, not merely
+equal unions with hidden overlap.
+
+These identities use the square-centred, half-open domains counted by the unblocked grid
+differential. They are the geometric step needed to show that the alternate decomposition
+preserves `X`-avoidance and the product of the `O`-monomial weights in the one-common-side case.
+
+## Main results
+
+* `TauCeti.GridRectangle.coveredSquares_union_eq_of_mem_cIoo`: the first L-shaped
+  repartition identity.
+* `TauCeti.GridRectangle.coveredSquares_union_eq_of_mem_cIoo'`: the complementary orientation
+  of the same identity.
+* `TauCeti.GridRectangle.disjoint_coveredSquares_of_mem_cIoo`: the two pieces on each side of
+  the first identity are disjoint.
+* `TauCeti.GridRectangle.prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo`: any
+  multiplicative weight is preserved by the repartition.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and
+`∂² = 0`", specifically the overlapping-rectangle case of the juxtaposition proof. The cut
+follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.6.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridRectangle
+
+variable {n : ℕ}
+
+/-- If `b` and `v` lie between the corresponding outer sides, the two indicated pairs of
+rectangles are the two cuts of the same L-shaped set of squares. -/
+theorem coveredSquares_union_eq_of_mem_cIoo {a b c u v w : Fin n}
+    (hcol : b ∈ Grid.cIoo a c) (hrow : v ∈ Grid.cIoo u w) :
+    ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares ∪
+        ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
+      ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares ∪
+        ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares := by
+  ext p
+  simp only [Finset.mem_union, mem_coveredSquares, mem_coveredColumns, mem_coveredRows]
+  have hcols := congrArg (fun s : Finset (Fin n) => p.1 ∈ s)
+    (Grid.cIco_union_cIco_eq_of_mem_cIoo hcol)
+  have hrows := congrArg (fun s : Finset (Fin n) => p.2 ∈ s)
+    (Grid.cIco_union_cIco_eq_of_mem_cIoo hrow)
+  simp only [Finset.mem_union] at hcols hrows
+  tauto
+
+/-- The complementary L-shaped repartition: here the second outer endpoint lies between the
+first two in each coordinate. -/
+theorem coveredSquares_union_eq_of_mem_cIoo' {a b c u v w : Fin n}
+    (hcol : c ∈ Grid.cIoo a b) (hrow : v ∈ Grid.cIoo u w) :
+    ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares ∪
+        ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
+      ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares ∪
+        ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares := by
+  ext p
+  simp only [Finset.mem_union, mem_coveredSquares, mem_coveredColumns, mem_coveredRows]
+  have hcols := congrArg (fun s : Finset (Fin n) => p.1 ∈ s)
+    (Grid.cIco_union_cIco_eq_of_mem_cIoo hcol)
+  have hrows := congrArg (fun s : Finset (Fin n) => p.2 ∈ s)
+    (Grid.cIco_union_cIco_eq_of_mem_cIoo hrow)
+  simp only [Finset.mem_union] at hcols hrows
+  tauto
+
+/-- In the first L-shaped repartition, the two rectangles on the left have disjoint covered
+square domains. -/
+theorem disjoint_coveredSquares_of_mem_cIoo {a b c u v w : Fin n}
+    (hrow : v ∈ Grid.cIoo u w) :
+    Disjoint
+      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
+      ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares := by
+  rw [Finset.disjoint_left]
+  intro p hp hq
+  rw [mem_coveredSquares] at hp hq
+  have hp2 : p.2 ∈ Grid.cIco u v :=
+    (mem_coveredRows _ p.2).mp hp.2
+  have hq2 : p.2 ∈ Grid.cIco v w :=
+    (mem_coveredRows _ p.2).mp hq.2
+  exact (Finset.disjoint_left.mp (Grid.disjoint_cIco_cIco_of_mem_cIoo hrow)) hp2 hq2
+
+/-- In the first L-shaped repartition, the two rectangles on the right have disjoint covered
+square domains. -/
+theorem disjoint_coveredSquares_of_mem_cIoo_alt {a b c u v w : Fin n}
+    (hcol : b ∈ Grid.cIoo a c) :
+    Disjoint
+      ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares
+      ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares := by
+  rw [Finset.disjoint_left]
+  intro p hp hq
+  rw [mem_coveredSquares] at hp hq
+  have hp1 : p.1 ∈ Grid.cIco b c :=
+    (mem_coveredColumns _ p.1).mp hp.1
+  have hq1 : p.1 ∈ Grid.cIco a b :=
+    (mem_coveredColumns _ p.1).mp hq.1
+  exact (Finset.disjoint_left.mp (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm) hp1 hq1
+
+/-- In the complementary L-shaped repartition, the two alternate rectangles have disjoint
+covered-square domains. -/
+theorem disjoint_coveredSquares_of_mem_cIoo_alt' {a b c u v w : Fin n}
+    (hcol : c ∈ Grid.cIoo a b) :
+    Disjoint
+      ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares
+      ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares := by
+  rw [Finset.disjoint_left]
+  intro p hp hq
+  rw [mem_coveredSquares] at hp hq
+  have hp1 : p.1 ∈ Grid.cIco a c :=
+    (mem_coveredColumns _ p.1).mp hp.1
+  have hq1 : p.1 ∈ Grid.cIco c b :=
+    (mem_coveredColumns _ p.1).mp hq.1
+  exact (Finset.disjoint_left.mp (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol)) hp1 hq1
+
+/-- Recutting the first L-shaped domain preserves the product of any commutative weight on its
+covered squares. In the unblocked differential, specializing the weight to the variables of the
+covered `O`-markings gives preservation of the product of rectangle monomials. -/
+theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo
+    {a b c u v w : Fin n} {M : Type*} [CommMonoid M] (f : Fin n × Fin n → M)
+    (hcol : b ∈ Grid.cIoo a c) (hrow : v ∈ Grid.cIoo u w) :
+    (∏ p ∈ ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
+        f p) *
+        ∏ p ∈ ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares,
+          f p =
+      (∏ p ∈ ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares,
+          f p) *
+        ∏ p ∈ ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares,
+          f p := by
+  rw [← Finset.prod_union (disjoint_coveredSquares_of_mem_cIoo hrow),
+    coveredSquares_union_eq_of_mem_cIoo hcol hrow,
+    Finset.prod_union (disjoint_coveredSquares_of_mem_cIoo_alt hcol)]
+
+/-- Recutting the complementary L-shaped domain preserves the product of any commutative weight
+on its covered squares. -/
+theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo'
+    {a b c u v w : Fin n} {M : Type*} [CommMonoid M] (f : Fin n × Fin n → M)
+    (hcol : c ∈ Grid.cIoo a b) (hrow : v ∈ Grid.cIoo u w) :
+    (∏ p ∈ ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
+        f p) *
+        ∏ p ∈ ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares,
+          f p =
+      (∏ p ∈ ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares,
+          f p) *
+        ∏ p ∈ ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
+          f p := by
+  rw [← Finset.prod_union (disjoint_coveredSquares_of_mem_cIoo hrow),
+    coveredSquares_union_eq_of_mem_cIoo' hcol hrow,
+    Finset.prod_union (disjoint_coveredSquares_of_mem_cIoo_alt' hcol)]
+
+end GridRectangle
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
@@ -24,18 +24,29 @@ unions are honest partitions, not merely equal unions with hidden overlap.
 These identities use the square-centred, half-open domains counted by the unblocked grid
 differential. They are the geometric step needed to show that the alternate decomposition
 preserves `X`-avoidance and the product of the `O`-monomial weights in the one-common-side case.
+They do not yet apply to `GridRectangle.AvoidsMarkings`, which tests the open grid-line interior;
+that predicate must first be aligned with the square-centred convention.
 
 ## Main results
 
 The following results are in the `TauCeti.GridRectangle` namespace:
 
 * `coveredSquares_union_eq_of_mem_cIoo`: the first L-shaped repartition identity.
-* `coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut`: the complementary column-cut
+* `coveredSquares_union_eq_of_mem_cIoo_complementary_column_cut`: the complementary column-cut
   orientation of the same identity.
+* `coveredSquares_union_eq_of_mem_cIoo_shared_terminal_column` and
+  `coveredSquares_union_eq_of_mem_cIoo_shared_terminal_column_row_swap`: the two orientations
+  whose original rectangles share their terminal column.
 * `prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo`: any multiplicative weight is
   preserved by the first repartition.
-* `prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_complementary_col_cut`: any
+* `prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_complementary_column_cut`: any
   multiplicative weight is preserved by the complementary column-cut repartition.
+* `prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_shared_terminal_column` and its
+  row-swapped orientation: any multiplicative weight is preserved by the terminal-column
+  repartitions.
+* `disjoint_coveredSquares_of_mem_cIoo_columns` and
+  `disjoint_coveredSquares_of_mem_cIoo_rows`: the coordinate-cut facts ensuring that every
+  displayed union is disjoint.
 
 ## References
 
@@ -52,11 +63,11 @@ namespace GridRectangle
 
 variable {n : ℕ}
 
-private theorem product_union_eq_union_product {s s' : Finset α} {t t' : Finset β}
-    [DecidableEq α] [DecidableEq β] :
-    s ×ˢ t ∪ (s ∪ s') ×ˢ t' = s' ×ˢ t' ∪ s ×ˢ (t ∪ t') := by
-  rw [Finset.union_product, Finset.product_union]
-  ac_rfl
+private theorem prod_mul_prod_eq_of_disjoint_of_union_eq {M : Type*} [CommMonoid M]
+    [DecidableEq α] (f : α → M) {s₁ s₂ s₃ s₄ : Finset α} (h₁₂ : Disjoint s₁ s₂)
+    (h₃₄ : Disjoint s₃ s₄) (hunion : s₁ ∪ s₂ = s₃ ∪ s₄) :
+    (∏ x ∈ s₁, f x) * ∏ x ∈ s₂, f x = (∏ x ∈ s₃, f x) * ∏ x ∈ s₄, f x := by
+  rw [← Finset.prod_union h₁₂, hunion, Finset.prod_union h₃₄]
 
 /-- If `b` and `v` lie between the corresponding outer sides, the two indicated pairs of
 rectangles are the two cuts of the same L-shaped set of squares. -/
@@ -69,11 +80,14 @@ theorem coveredSquares_union_eq_of_mem_cIoo {a b c u v w : Fin n}
   simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
   rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
     ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
-  exact product_union_eq_union_product
+  simp only [Finset.union_product, Finset.product_union]
+  ac_rfl
 
-/-- The complementary L-shaped repartition uses the same row cut, with `v` between `u` and `w`,
-while in the column coordinate `c` lies between `a` and `b`. -/
-theorem coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut {a b c u v w : Fin n}
+/-- If `v` lies between `u` and `w` and `c` lies between `a` and `b`, the L-shape
+`[a,b) × [u,v) ∪ [a,c) × [v,w)` recuts as
+`[a,c) × [u,w) ∪ [c,b) × [u,v)`. Here the column cut point is a side of the first
+rectangle rather than of the second. -/
+theorem coveredSquares_union_eq_of_mem_cIoo_complementary_column_cut {a b c u v w : Fin n}
     (hcol : c ∈ Grid.cIoo a b) (hrow : v ∈ Grid.cIoo u w) :
     ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares ∪
         ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
@@ -82,10 +96,36 @@ theorem coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut {a b c u v w :
   simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
   rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
     ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
-  simpa only [Finset.union_comm] using
-    (product_union_eq_union_product
-      (s := Grid.cIco a c) (s' := Grid.cIco c b)
-      (t := Grid.cIco v w) (t' := Grid.cIco u v))
+  simp only [Finset.union_product, Finset.product_union]
+  ac_rfl
+
+/-- If the original rectangles share their terminal column and their rows meet in cyclic order,
+the resulting L-shape can be recut along the other internal column edge. -/
+theorem coveredSquares_union_eq_of_mem_cIoo_shared_terminal_column {a b c u v w : Fin n}
+    (hcol : b ∈ Grid.cIoo a c) (hrow : v ∈ Grid.cIoo u w) :
+    ({ left := b, right := c, bottom := u, top := v } : GridRectangle n).coveredSquares ∪
+        ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
+      ({ left := a, right := b, bottom := v, top := w } : GridRectangle n).coveredSquares ∪
+        ({ left := b, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares := by
+  simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
+  rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
+    ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
+  simp only [Finset.union_product, Finset.product_union]
+  ac_rfl
+
+/-- The row-swapped orientation of
+`coveredSquares_union_eq_of_mem_cIoo_shared_terminal_column`. -/
+theorem coveredSquares_union_eq_of_mem_cIoo_shared_terminal_column_row_swap
+    {a b c u v w : Fin n} (hcol : b ∈ Grid.cIoo a c) (hrow : v ∈ Grid.cIoo u w) :
+    ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares ∪
+        ({ left := a, right := c, bottom := u, top := v } : GridRectangle n).coveredSquares =
+      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares ∪
+        ({ left := b, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares := by
+  simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
+  rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
+    ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
+  simp only [Finset.union_product, Finset.product_union]
+  ac_rfl
 
 /-- Recutting the first L-shaped domain preserves the product of any commutative weight on its
 covered squares. In the unblocked differential, specializing the weight to the variables of the
@@ -101,24 +141,14 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo
           f p) *
         ∏ p ∈ ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares,
           f p := by
-  have hleft : Disjoint
-      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
-      ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
-    (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
-      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
-  have hright : Disjoint
-      ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares
-      ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares :=
-    (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-      simpa only [coveredColumns_def] using
-        (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm))
-  rw [← Finset.prod_union hleft,
-    coveredSquares_union_eq_of_mem_cIoo hcol hrow,
-    Finset.prod_union hright]
+  exact prod_mul_prod_eq_of_disjoint_of_union_eq f
+    (disjoint_coveredSquares_of_mem_cIoo_rows hrow)
+    (disjoint_coveredSquares_of_mem_cIoo_columns hcol).symm
+    (coveredSquares_union_eq_of_mem_cIoo hcol hrow)
 
 /-- Recutting the complementary L-shaped domain preserves the product of any commutative weight
 on its covered squares. -/
-theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_complementary_col_cut
+theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_complementary_column_cut
     {a b c u v w : Fin n} {M : Type*} [CommMonoid M] (f : Fin n × Fin n → M)
     (hcol : c ∈ Grid.cIoo a b) (hrow : v ∈ Grid.cIoo u w) :
     (∏ p ∈ ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
@@ -129,19 +159,46 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_complementary
           f p) *
         ∏ p ∈ ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
           f p := by
-  have hleft : Disjoint
-      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
-      ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
-    (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
-      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
-  have hright : Disjoint
-      ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares
-      ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares :=
-    (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-      simpa only [coveredColumns_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
-  rw [← Finset.prod_union hleft,
-    coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut hcol hrow,
-    Finset.prod_union hright]
+  exact prod_mul_prod_eq_of_disjoint_of_union_eq f
+    (disjoint_coveredSquares_of_mem_cIoo_rows hrow)
+    (disjoint_coveredSquares_of_mem_cIoo_columns hcol)
+    (coveredSquares_union_eq_of_mem_cIoo_complementary_column_cut hcol hrow)
+
+/-- Recutting an L-shaped domain whose original rectangles share their terminal column preserves
+the product of any commutative weight on its covered squares. -/
+theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_shared_terminal_column
+    {a b c u v w : Fin n} {M : Type*} [CommMonoid M] (f : Fin n × Fin n → M)
+    (hcol : b ∈ Grid.cIoo a c) (hrow : v ∈ Grid.cIoo u w) :
+    (∏ p ∈ ({ left := b, right := c, bottom := u, top := v } : GridRectangle n).coveredSquares,
+        f p) *
+        ∏ p ∈ ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares,
+          f p =
+      (∏ p ∈ ({ left := a, right := b, bottom := v, top := w } : GridRectangle n).coveredSquares,
+          f p) *
+        ∏ p ∈ ({ left := b, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares,
+          f p := by
+  exact prod_mul_prod_eq_of_disjoint_of_union_eq f
+    (disjoint_coveredSquares_of_mem_cIoo_rows hrow)
+    (disjoint_coveredSquares_of_mem_cIoo_columns hcol)
+    (coveredSquares_union_eq_of_mem_cIoo_shared_terminal_column hcol hrow)
+
+/-- The row-swapped orientation of
+`prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_shared_terminal_column`. -/
+theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_shared_terminal_column_row_swap
+    {a b c u v w : Fin n} {M : Type*} [CommMonoid M] (f : Fin n × Fin n → M)
+    (hcol : b ∈ Grid.cIoo a c) (hrow : v ∈ Grid.cIoo u w) :
+    (∏ p ∈ ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares,
+        f p) *
+        ∏ p ∈ ({ left := a, right := c, bottom := u, top := v } : GridRectangle n).coveredSquares,
+          f p =
+      (∏ p ∈ ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
+          f p) *
+        ∏ p ∈ ({ left := b, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares,
+          f p := by
+  exact prod_mul_prod_eq_of_disjoint_of_union_eq f
+    (disjoint_coveredSquares_of_mem_cIoo_rows hrow).symm
+    (disjoint_coveredSquares_of_mem_cIoo_columns hcol)
+    (coveredSquares_union_eq_of_mem_cIoo_shared_terminal_column_row_swap hcol hrow)
 
 end GridRectangle
 

--- a/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
@@ -65,7 +65,7 @@ theorem coveredSquares_union_eq_of_mem_cIoo {a b c u v w : Fin n}
         ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
       ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares ∪
         ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares := by
-  simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
+  simp only [coveredSquares_def, GridRectangle.coveredColumns, GridRectangle.coveredRows]
   rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
     ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
   exact product_union_eq_union_product
@@ -78,7 +78,7 @@ theorem coveredSquares_union_eq_of_mem_cIoo' {a b c u v w : Fin n}
         ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
       ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares ∪
         ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares := by
-  simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
+  simp only [coveredSquares_def, GridRectangle.coveredColumns, GridRectangle.coveredRows]
   rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
     ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
   simpa only [Finset.union_comm] using
@@ -104,12 +104,12 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo
       ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
       ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
     (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
-      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
+      simpa only [GridRectangle.coveredRows] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
   have hright : Disjoint
       ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares
       ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares :=
     (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-      simpa only [coveredColumns_def] using
+      simpa only [GridRectangle.coveredColumns] using
         (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm))
   rw [← Finset.prod_union hleft,
     coveredSquares_union_eq_of_mem_cIoo hcol hrow,
@@ -132,12 +132,12 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo'
       ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
       ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
     (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
-      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
+      simpa only [GridRectangle.coveredRows] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
   have hright : Disjoint
       ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares
       ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares :=
     (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-      simpa only [coveredColumns_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
+      simpa only [GridRectangle.coveredColumns] using Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
   rw [← Finset.prod_union hleft,
     coveredSquares_union_eq_of_mem_cIoo' hcol hrow,
     Finset.prod_union hright]

--- a/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
@@ -27,14 +27,15 @@ preserves `X`-avoidance and the product of the `O`-monomial weights in the one-c
 
 ## Main results
 
-* `TauCeti.GridRectangle.coveredSquares_union_eq_of_mem_cIoo`: the first L-shaped
-  repartition identity.
-* `TauCeti.GridRectangle.coveredSquares_union_eq_of_mem_cIoo'`: the complementary orientation
-  of the same identity.
-* `TauCeti.GridRectangle.prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo`: any
-  multiplicative weight is preserved by the first repartition.
-* `TauCeti.GridRectangle.prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo'`: any
-  multiplicative weight is preserved by the complementary repartition.
+The following results are in the `TauCeti.GridRectangle` namespace:
+
+* `coveredSquares_union_eq_of_mem_cIoo`: the first L-shaped repartition identity.
+* `coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut`: the complementary column-cut
+  orientation of the same identity.
+* `prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo`: any multiplicative weight is
+  preserved by the first repartition.
+* `prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_complementary_col_cut`: any
+  multiplicative weight is preserved by the complementary column-cut repartition.
 
 ## References
 
@@ -65,20 +66,20 @@ theorem coveredSquares_union_eq_of_mem_cIoo {a b c u v w : Fin n}
         ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
       ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares ∪
         ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares := by
-  simp only [coveredSquares_def, GridRectangle.coveredColumns, GridRectangle.coveredRows]
+  simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
   rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
     ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
   exact product_union_eq_union_product
 
 /-- The complementary L-shaped repartition uses the same row cut, with `v` between `u` and `w`,
 while in the column coordinate `c` lies between `a` and `b`. -/
-theorem coveredSquares_union_eq_of_mem_cIoo' {a b c u v w : Fin n}
+theorem coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut {a b c u v w : Fin n}
     (hcol : c ∈ Grid.cIoo a b) (hrow : v ∈ Grid.cIoo u w) :
     ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares ∪
         ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
       ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares ∪
         ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares := by
-  simp only [coveredSquares_def, GridRectangle.coveredColumns, GridRectangle.coveredRows]
+  simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
   rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
     ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
   simpa only [Finset.union_comm] using
@@ -104,12 +105,12 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo
       ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
       ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
     (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
-      simpa only [GridRectangle.coveredRows] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
+      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
   have hright : Disjoint
       ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares
       ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares :=
     (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-      simpa only [GridRectangle.coveredColumns] using
+      simpa only [coveredColumns_def] using
         (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm))
   rw [← Finset.prod_union hleft,
     coveredSquares_union_eq_of_mem_cIoo hcol hrow,
@@ -117,7 +118,7 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo
 
 /-- Recutting the complementary L-shaped domain preserves the product of any commutative weight
 on its covered squares. -/
-theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo'
+theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo_complementary_col_cut
     {a b c u v w : Fin n} {M : Type*} [CommMonoid M] (f : Fin n × Fin n → M)
     (hcol : c ∈ Grid.cIoo a b) (hrow : v ∈ Grid.cIoo u w) :
     (∏ p ∈ ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
@@ -132,14 +133,14 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo'
       ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
       ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
     (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
-      simpa only [GridRectangle.coveredRows] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
+      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
   have hright : Disjoint
       ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares
       ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares :=
     (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
-      simpa only [GridRectangle.coveredColumns] using Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
+      simpa only [coveredColumns_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
   rw [← Finset.prod_union hleft,
-    coveredSquares_union_eq_of_mem_cIoo' hcol hrow,
+    coveredSquares_union_eq_of_mem_cIoo_complementary_col_cut hcol hrow,
     Finset.prod_union hright]
 
 end GridRectangle

--- a/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Juxtaposition.lean
@@ -18,8 +18,8 @@ decomposition. This file proves the finite-domain identity behind that cut.
 The one-dimensional input is that an interior point `b` cuts the clockwise half-open interval
 from `a` to `c` into the disjoint intervals from `a` to `b` and from `b` to `c`. Applying this in
 both coordinates gives two forms of the L-shaped identity for `GridRectangle.coveredSquares`.
-The disjointness statements record that both displayed unions are honest partitions, not merely
-equal unions with hidden overlap.
+The coordinate cuts and `GridRectangle.disjoint_coveredSquares_iff` ensure that both displayed
+unions are honest partitions, not merely equal unions with hidden overlap.
 
 These identities use the square-centred, half-open domains counted by the unblocked grid
 differential. They are the geometric step needed to show that the alternate decomposition
@@ -31,11 +31,10 @@ preserves `X`-avoidance and the product of the `O`-monomial weights in the one-c
   repartition identity.
 * `TauCeti.GridRectangle.coveredSquares_union_eq_of_mem_cIoo'`: the complementary orientation
   of the same identity.
-* `TauCeti.GridRectangle.disjoint_coveredSquares_of_row_mem_cIoo` and
-  `TauCeti.GridRectangle.disjoint_coveredSquares_of_col_mem_cIoo`: the two pieces on the left
-  and right sides of the first identity are disjoint.
 * `TauCeti.GridRectangle.prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo`: any
-  multiplicative weight is preserved by the repartition.
+  multiplicative weight is preserved by the first repartition.
+* `TauCeti.GridRectangle.prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo'`: any
+  multiplicative weight is preserved by the complementary repartition.
 
 ## References
 
@@ -52,6 +51,12 @@ namespace GridRectangle
 
 variable {n : ℕ}
 
+private theorem product_union_eq_union_product {s s' : Finset α} {t t' : Finset β}
+    [DecidableEq α] [DecidableEq β] :
+    s ×ˢ t ∪ (s ∪ s') ×ˢ t' = s' ×ˢ t' ∪ s ×ˢ (t ∪ t') := by
+  rw [Finset.union_product, Finset.product_union]
+  ac_rfl
+
 /-- If `b` and `v` lie between the corresponding outer sides, the two indicated pairs of
 rectangles are the two cuts of the same L-shaped set of squares. -/
 theorem coveredSquares_union_eq_of_mem_cIoo {a b c u v w : Fin n}
@@ -60,79 +65,26 @@ theorem coveredSquares_union_eq_of_mem_cIoo {a b c u v w : Fin n}
         ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
       ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares ∪
         ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares := by
-  ext p
-  simp only [Finset.mem_union, mem_coveredSquares, mem_coveredColumns, mem_coveredRows]
-  have hcols := congrArg (fun s : Finset (Fin n) => p.1 ∈ s)
-    (Grid.cIco_union_cIco_eq_of_mem_cIoo hcol)
-  have hrows := congrArg (fun s : Finset (Fin n) => p.2 ∈ s)
-    (Grid.cIco_union_cIco_eq_of_mem_cIoo hrow)
-  simp only [Finset.mem_union] at hcols hrows
-  tauto
+  simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
+  rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
+    ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
+  exact product_union_eq_union_product
 
-/-- The complementary L-shaped repartition: here the second outer endpoint lies between the
-first two in each coordinate. -/
+/-- The complementary L-shaped repartition uses the same row cut, with `v` between `u` and `w`,
+while in the column coordinate `c` lies between `a` and `b`. -/
 theorem coveredSquares_union_eq_of_mem_cIoo' {a b c u v w : Fin n}
     (hcol : c ∈ Grid.cIoo a b) (hrow : v ∈ Grid.cIoo u w) :
     ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares ∪
         ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares =
       ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares ∪
         ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares := by
-  ext p
-  simp only [Finset.mem_union, mem_coveredSquares, mem_coveredColumns, mem_coveredRows]
-  have hcols := congrArg (fun s : Finset (Fin n) => p.1 ∈ s)
-    (Grid.cIco_union_cIco_eq_of_mem_cIoo hcol)
-  have hrows := congrArg (fun s : Finset (Fin n) => p.2 ∈ s)
-    (Grid.cIco_union_cIco_eq_of_mem_cIoo hrow)
-  simp only [Finset.mem_union] at hcols hrows
-  tauto
-
-/-- In the first L-shaped repartition, the two rectangles on the left have disjoint covered
-square domains. -/
-theorem disjoint_coveredSquares_of_row_mem_cIoo {a b c u v w : Fin n}
-    (hrow : v ∈ Grid.cIoo u w) :
-    Disjoint
-      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
-      ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares := by
-  rw [Finset.disjoint_left]
-  intro p hp hq
-  rw [mem_coveredSquares] at hp hq
-  have hp2 : p.2 ∈ Grid.cIco u v :=
-    (mem_coveredRows _ p.2).mp hp.2
-  have hq2 : p.2 ∈ Grid.cIco v w :=
-    (mem_coveredRows _ p.2).mp hq.2
-  exact (Finset.disjoint_left.mp (Grid.disjoint_cIco_cIco_of_mem_cIoo hrow)) hp2 hq2
-
-/-- In the first L-shaped repartition, the two rectangles on the right have disjoint covered
-square domains. -/
-theorem disjoint_coveredSquares_of_col_mem_cIoo {a b c u v w : Fin n}
-    (hcol : b ∈ Grid.cIoo a c) :
-    Disjoint
-      ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares
-      ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares := by
-  rw [Finset.disjoint_left]
-  intro p hp hq
-  rw [mem_coveredSquares] at hp hq
-  have hp1 : p.1 ∈ Grid.cIco b c :=
-    (mem_coveredColumns _ p.1).mp hp.1
-  have hq1 : p.1 ∈ Grid.cIco a b :=
-    (mem_coveredColumns _ p.1).mp hq.1
-  exact (Finset.disjoint_left.mp (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm) hp1 hq1
-
-/-- In the complementary L-shaped repartition, the two alternate rectangles have disjoint
-covered-square domains. -/
-theorem disjoint_coveredSquares_of_col_mem_cIoo_compl {a b c u v w : Fin n}
-    (hcol : c ∈ Grid.cIoo a b) :
-    Disjoint
-      ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares
-      ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares := by
-  rw [Finset.disjoint_left]
-  intro p hp hq
-  rw [mem_coveredSquares] at hp hq
-  have hp1 : p.1 ∈ Grid.cIco a c :=
-    (mem_coveredColumns _ p.1).mp hp.1
-  have hq1 : p.1 ∈ Grid.cIco c b :=
-    (mem_coveredColumns _ p.1).mp hq.1
-  exact (Finset.disjoint_left.mp (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol)) hp1 hq1
+  simp only [coveredSquares_def, coveredColumns_def, coveredRows_def]
+  rw [← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hcol,
+    ← Grid.cIco_union_cIco_eq_cIco_of_mem_cIoo hrow]
+  simpa only [Finset.union_comm] using
+    (product_union_eq_union_product
+      (s := Grid.cIco a c) (s' := Grid.cIco c b)
+      (t := Grid.cIco v w) (t' := Grid.cIco u v))
 
 /-- Recutting the first L-shaped domain preserves the product of any commutative weight on its
 covered squares. In the unblocked differential, specializing the weight to the variables of the
@@ -148,9 +100,20 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo
           f p) *
         ∏ p ∈ ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares,
           f p := by
-  rw [← Finset.prod_union (disjoint_coveredSquares_of_row_mem_cIoo hrow),
+  have hleft : Disjoint
+      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
+      ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
+    (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
+      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
+  have hright : Disjoint
+      ({ left := b, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares
+      ({ left := a, right := b, bottom := u, top := w } : GridRectangle n).coveredSquares :=
+    (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
+      simpa only [coveredColumns_def] using
+        (Grid.disjoint_cIco_cIco_of_mem_cIoo hcol).symm))
+  rw [← Finset.prod_union hleft,
     coveredSquares_union_eq_of_mem_cIoo hcol hrow,
-    Finset.prod_union (disjoint_coveredSquares_of_col_mem_cIoo hcol)]
+    Finset.prod_union hright]
 
 /-- Recutting the complementary L-shaped domain preserves the product of any commutative weight
 on its covered squares. -/
@@ -165,9 +128,19 @@ theorem prod_coveredSquares_mul_prod_coveredSquares_eq_of_mem_cIoo'
           f p) *
         ∏ p ∈ ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares,
           f p := by
-  rw [← Finset.prod_union (disjoint_coveredSquares_of_row_mem_cIoo hrow),
+  have hleft : Disjoint
+      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
+      ({ left := a, right := c, bottom := v, top := w } : GridRectangle n).coveredSquares :=
+    (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
+      simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hrow))
+  have hright : Disjoint
+      ({ left := a, right := c, bottom := u, top := w } : GridRectangle n).coveredSquares
+      ({ left := c, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares :=
+    (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
+      simpa only [coveredColumns_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo hcol))
+  rw [← Finset.prod_union hleft,
     coveredSquares_union_eq_of_mem_cIoo' hcol hrow,
-    Finset.prod_union (disjoint_coveredSquares_of_col_mem_cIoo_compl hcol)]
+    Finset.prod_union hright]
 
 end GridRectangle
 

--- a/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
@@ -40,8 +40,12 @@ everything it feeds.
 
 ## Main results
 
+* `TauCeti.GridRectangle.coveredColumns_def`, `TauCeti.GridRectangle.coveredRows_def`: the
+  one-dimensional covered domains are the corresponding half-open cyclic intervals.
 * `TauCeti.GridRectangle.interior_subset_coveredSquares`: every grid point strictly inside a
   rectangle names a square the rectangle covers.
+* `TauCeti.GridRectangle.disjoint_coveredSquares_iff`: two covered-square domains are disjoint
+  exactly when their covered columns or their covered rows are disjoint.
 * `TauCeti.GridRectangle.card_coveredSquares`: the number of covered squares is the product of the
   two arc lengths.
 
@@ -83,6 +87,14 @@ interval. -/
 @[simp]
 theorem mem_coveredRows (r : Fin n) : r ∈ R.coveredRows ↔ r ∈ Grid.cIco R.bottom R.top :=
   Iff.rfl
+
+/-- The covered columns are the half-open cyclic interval between the vertical sides. -/
+theorem coveredColumns_def : R.coveredColumns = Grid.cIco R.left R.right :=
+  Finset.ext fun c => R.mem_coveredColumns c
+
+/-- The covered rows are the half-open cyclic interval between the horizontal sides. -/
+theorem coveredRows_def : R.coveredRows = Grid.cIco R.bottom R.top :=
+  Finset.ext fun r => R.mem_coveredRows r
 
 /-- Every interior column is a covered column. For distinct vertical sides the covered columns
 also contain the initial column; for coincident sides both sets are empty. -/
@@ -128,6 +140,14 @@ theorem coveredSquares_def : R.coveredSquares = R.coveredColumns ×ˢ R.coveredR
 theorem mem_coveredSquares (p : Fin n × Fin n) :
     p ∈ R.coveredSquares ↔ p.1 ∈ R.coveredColumns ∧ p.2 ∈ R.coveredRows := by
   simp [coveredSquares]
+
+/-- Two rectangles have disjoint covered-square domains exactly when their covered columns or
+their covered rows are disjoint. -/
+theorem disjoint_coveredSquares_iff (R S : GridRectangle n) :
+    Disjoint R.coveredSquares S.coveredSquares ↔
+      Disjoint R.coveredColumns S.coveredColumns ∨ Disjoint R.coveredRows S.coveredRows := by
+  rw [coveredSquares_def, coveredSquares_def]
+  exact Finset.disjoint_product
 
 /-- Every grid point strictly inside a rectangle names a square that the rectangle covers. -/
 theorem interior_subset_coveredSquares : R.interior ⊆ R.coveredSquares :=

--- a/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
@@ -44,6 +44,10 @@ everything it feeds.
   rectangle names a square the rectangle covers.
 * `TauCeti.GridRectangle.disjoint_coveredSquares_iff`: two covered-square domains are disjoint
   exactly when their covered columns or their covered rows are disjoint.
+* `TauCeti.GridRectangle.disjoint_coveredSquares_of_mem_cIoo_columns`: adjacent column arcs give
+  disjoint covered-square domains.
+* `TauCeti.GridRectangle.disjoint_coveredSquares_of_mem_cIoo_rows`: adjacent row arcs give
+  disjoint covered-square domains.
 * `TauCeti.GridRectangle.card_coveredSquares`: the number of covered squares is the product of the
   two arc lengths.
 
@@ -146,6 +150,26 @@ theorem disjoint_coveredSquares_iff (R S : GridRectangle n) :
       Disjoint R.coveredColumns S.coveredColumns ∨ Disjoint R.coveredRows S.coveredRows := by
   rw [coveredSquares_def, coveredSquares_def]
   exact Finset.disjoint_product
+
+/-- Cutting a column arc at an interior point gives disjoint covered-square domains, regardless
+of the row arcs paired with the two pieces. -/
+theorem disjoint_coveredSquares_of_mem_cIoo_columns {a b c u v u' v' : Fin n}
+    (h : b ∈ Grid.cIoo a c) :
+    Disjoint
+      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
+      ({ left := b, right := c, bottom := u', top := v' } : GridRectangle n).coveredSquares :=
+  (disjoint_coveredSquares_iff _ _).mpr (Or.inl (by
+    simpa only [coveredColumns_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo h))
+
+/-- Cutting a row arc at an interior point gives disjoint covered-square domains, regardless of
+the column arcs paired with the two pieces. -/
+theorem disjoint_coveredSquares_of_mem_cIoo_rows {a b a' b' u v w : Fin n}
+    (h : v ∈ Grid.cIoo u w) :
+    Disjoint
+      ({ left := a, right := b, bottom := u, top := v } : GridRectangle n).coveredSquares
+      ({ left := a', right := b', bottom := v, top := w } : GridRectangle n).coveredSquares :=
+  (disjoint_coveredSquares_iff _ _).mpr (Or.inr (by
+    simpa only [coveredRows_def] using Grid.disjoint_cIco_cIco_of_mem_cIoo h))
 
 /-- Every grid point strictly inside a rectangle names a square that the rectangle covers. -/
 theorem interior_subset_coveredSquares : R.interior ⊆ R.coveredSquares :=

--- a/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
@@ -66,13 +66,21 @@ variable {n : ℕ} (R : GridRectangle n)
 
 /-- The columns of squares covered by a toroidal grid rectangle: the clockwise half-open arc
 from the initial vertical side to the terminal one. -/
-@[expose] noncomputable def coveredColumns : Finset (Fin n) :=
+noncomputable def coveredColumns : Finset (Fin n) :=
   Grid.cIco R.left R.right
+
+/-- The covered columns are the half-open cyclic interval between the vertical sides. -/
+theorem coveredColumns_def : R.coveredColumns = Grid.cIco R.left R.right :=
+  (rfl)
 
 /-- The rows of squares covered by a toroidal grid rectangle: the clockwise half-open arc from
 the initial horizontal side to the terminal one. -/
-@[expose] noncomputable def coveredRows : Finset (Fin n) :=
+noncomputable def coveredRows : Finset (Fin n) :=
   Grid.cIco R.bottom R.top
+
+/-- The covered rows are the half-open cyclic interval between the horizontal sides. -/
+theorem coveredRows_def : R.coveredRows = Grid.cIco R.bottom R.top :=
+  (rfl)
 
 /-- Membership in the covered columns is membership in the corresponding half-open circular
 interval. -/

--- a/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Squares.lean
@@ -40,8 +40,6 @@ everything it feeds.
 
 ## Main results
 
-* `TauCeti.GridRectangle.coveredColumns_def`, `TauCeti.GridRectangle.coveredRows_def`: the
-  one-dimensional covered domains are the corresponding half-open cyclic intervals.
 * `TauCeti.GridRectangle.interior_subset_coveredSquares`: every grid point strictly inside a
   rectangle names a square the rectangle covers.
 * `TauCeti.GridRectangle.disjoint_coveredSquares_iff`: two covered-square domains are disjoint
@@ -68,12 +66,12 @@ variable {n : ℕ} (R : GridRectangle n)
 
 /-- The columns of squares covered by a toroidal grid rectangle: the clockwise half-open arc
 from the initial vertical side to the terminal one. -/
-noncomputable def coveredColumns : Finset (Fin n) :=
+@[expose] noncomputable def coveredColumns : Finset (Fin n) :=
   Grid.cIco R.left R.right
 
 /-- The rows of squares covered by a toroidal grid rectangle: the clockwise half-open arc from
 the initial horizontal side to the terminal one. -/
-noncomputable def coveredRows : Finset (Fin n) :=
+@[expose] noncomputable def coveredRows : Finset (Fin n) :=
   Grid.cIco R.bottom R.top
 
 /-- Membership in the covered columns is membership in the corresponding half-open circular
@@ -87,14 +85,6 @@ interval. -/
 @[simp]
 theorem mem_coveredRows (r : Fin n) : r ∈ R.coveredRows ↔ r ∈ Grid.cIco R.bottom R.top :=
   Iff.rfl
-
-/-- The covered columns are the half-open cyclic interval between the vertical sides. -/
-theorem coveredColumns_def : R.coveredColumns = Grid.cIco R.left R.right :=
-  Finset.ext fun c => R.mem_coveredColumns c
-
-/-- The covered rows are the half-open cyclic interval between the horizontal sides. -/
-theorem coveredRows_def : R.coveredRows = Grid.cIco R.bottom R.top :=
-  Finset.ext fun r => R.mem_coveredRows r
 
 /-- Every interior column is a covered column. For distinct vertical sides the covered columns
 also contain the initial column; for coincident sides both sets are empty. -/


### PR DESCRIPTION
This PR proves the finite-domain geometry for juxtaposing two toroidal grid rectangles along a common side. It adds the cyclic half-open interval cut used by the geometry, identifies the two L-shaped unions of covered squares before and after recutting, proves the corresponding domains are disjoint, and shows that arbitrary commutative-monoid weights multiply to the same value under the recut.

The exact roadmap target is `CombinatorialHeegaardFloer/README.md`, Lane G milestone 3, “The complexes and `∂² = 0`,” specifically the overlapping-pair part of the disjoint / overlapping / annular juxtaposition case analysis. This is the most direct missing geometric input after the annular case landed and while the disjoint-side coefficient reindexing is already in flight.

What remains after this PR is to use rectangle emptiness to obtain the needed cyclic orders in both coordinates, construct the alternate empty decomposition for `HasOneCommonSide`, cancel its coefficient with the disjoint and annular cases, and assemble the square-zero theorem.

The construction follows the overlapping-rectangle juxtaposition argument in Ozsváth–Stipsicz–Szabó, *Grid Homology for Knots and Links*, Chapter 4.6. No Mathlib infrastructure is vendored; the proofs consume Mathlib's `Finset.prod_union` together with Tau Ceti's existing cyclic-interval and `coveredSquares` APIs.

The new `Rectangle/Juxtaposition.lean` module has 173 lines, and `CyclicInterval.lean` gains 38 lines, for 211 added lines total.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"grid-rectangle-juxtaposition"}-->

🤖 Prepared with Codex
