### PR TITLE
feat(FormalGroup): the involution at a parameter

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
@@ -63,7 +63,9 @@ ideal at all: the series identity `mul_invOfUnit_formalInverseDenom` evaluates t
 * `WeierstrassCurve.formalWEval_ne_zero`, `WeierstrassCurve.formalInverseEval_ne_zero` : the two
   non-vanishing statements.
 * `WeierstrassCurve.formalInverseEval_formalInverseEval` : the involution `ι(ι(t)) = t`, and
-  `WeierstrassCurve.formalWEval_formalInverseEval` : `w(ι(t)) = -(w(t) * d(t)⁻¹)`.
+  `WeierstrassCurve.formalWEval_formalInverseEval` : `w(ι(t)) = -(w(t) * d(t)⁻¹)`. Both ask only
+  that `t` and `ι(t)` admit evaluation; `WeierstrassCurve.hasEval_formalInverseEval` supplies the
+  second from an adic ideal when that is how a consumer holds it.
 
 ## Implementation notes
 
@@ -114,9 +116,9 @@ Four things are spelled differently here.
   definition.
 * The source's private `eval_subst_single` is not ported. It is `MvPSeries.eval_subst`
   specialised, and this repository's `PowerSeries.aeval_subst` already states that fact without
-  the `DiscreteUniformity` hypotheses Mathlib's `MvPowerSeries.eval₂_subst` carries — which are
-  unsatisfiable here, coefficients and values being one adic ring. The two involution proofs call
-  it directly.
+  the `DiscreteUniformity` hypotheses Mathlib's `MvPowerSeries.eval₂_subst` carries — which a
+  general adic ring does not supply, coefficients and values here being the same such ring. The
+  two involution proofs call it directly.
 
 The adic hypothesis is carried as an explicit `IsAdic I` argument for the reason given under
 implementation notes above.
@@ -316,15 +318,17 @@ theorem formalInverseEval_ne_zero {t : O} (ht : PowerSeries.HasEval t) (ht0 : t 
 /-! ### The involution
 
 `ι` is an involution on the series (`subst_formalInverse_self`), and evaluating that identity at a
-parameter needs evaluation of a substitution. Mathlib's `MvPowerSeries.eval₂_subst` cannot supply
-it here — it carries `[DiscreteUniformity R] [DiscreteUniformity S]`, and coefficients and values
-live in the same adic ring — so these two go through `PowerSeries.aeval_subst`, which is that
-statement without the discreteness.
+parameter needs evaluation of a substitution. Mathlib's `MvPowerSeries.eval₂_subst` is not
+applicable at this generality: it carries `[DiscreteUniformity R] [DiscreteUniformity S]`, and a
+general adic ring supplies no such instance. These two therefore go through
+`PowerSeries.aeval_subst`, which is the same statement with an arbitrary uniform structure on the
+coefficients.
 -/
 
-/-- The two evaluations at an inverted parameter share a preamble: `ι(t)` must itself admit
-evaluation, which is `formalInverseEval_mem` at `k = 1` fed back through `IsAdic`. -/
-private theorem hasEval_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
+/-- **`ι(t)` admits evaluation** when `t` is drawn from an ideal carrying the ambient topology:
+`formalInverseEval_mem` puts it in the same ideal. This is the adic route to the second hypothesis
+of the two identities below, which do not themselves need an ideal. -/
+theorem hasEval_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
     PowerSeries.HasEval (W.formalInverseEval t) :=
   hI.isTopologicallyNilpotent_of_mem <| by
     simpa using W.formalInverseEval_mem (k := 1)
@@ -332,37 +336,35 @@ private theorem hasEval_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} 
 
 /-- **The `w`-expansion at an inverted parameter**: `w(ι(t)) = -(w(t) * d(t)⁻¹)`, the evaluation of
 the series identity `subst_formalInverse_formalW`. -/
-theorem formalWEval_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
+theorem formalWEval_formalInverseEval {t : O} (hE : PowerSeries.HasEval t)
+    (hV : PowerSeries.HasEval (W.formalInverseEval t)) :
     W.formalWEval (W.formalInverseEval t) =
       -(W.formalWEval t * W.formalInverseDenomInvEval t) := by
-  have hE : PowerSeries.HasEval t := hI.isTopologicallyNilpotent_of_mem ht
   have hcoe : ∀ f : PowerSeries O, PowerSeries.aeval hE f = eval₂ (RingHom.id O) t f :=
     congrFun (PowerSeries.coe_aeval hE)
   have hsub : PowerSeries.aeval hE W.formalInverse = W.formalInverseEval t := by
     rw [hcoe, ← W.formalInverseEval_def]
-  have hV : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) :=
-    hsub ▸ W.hasEval_formalInverseEval hI ht
+  have hV' : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) := hsub ▸ hV
   have h := PowerSeries.aeval_subst W.hasSubst_formalInverse
-    (PowerSeries.continuous_aeval hE) hV W.formalW
+    (PowerSeries.continuous_aeval hE) hV' W.formalW
   rw [W.subst_formalInverse_formalW, map_neg, map_mul,
-    congrFun (PowerSeries.coe_aeval hV) W.formalW, hsub] at h
+    congrFun (PowerSeries.coe_aeval hV') W.formalW, hsub] at h
   simpa [hcoe, formalWEval, formalInverseEval, formalInverseDenomInvEval] using h.symm
 
 /-- **The formal inverse is an involution at a parameter**: `ι(ι(t)) = t`. This is `-(-P) = P` for
 the group law near the origin, evaluated at `t`. -/
-theorem formalInverseEval_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
+theorem formalInverseEval_formalInverseEval {t : O} (hE : PowerSeries.HasEval t)
+    (hV : PowerSeries.HasEval (W.formalInverseEval t)) :
     W.formalInverseEval (W.formalInverseEval t) = t := by
-  have hE : PowerSeries.HasEval t := hI.isTopologicallyNilpotent_of_mem ht
   have hcoe : ∀ f : PowerSeries O, PowerSeries.aeval hE f = eval₂ (RingHom.id O) t f :=
     congrFun (PowerSeries.coe_aeval hE)
   have hsub : PowerSeries.aeval hE W.formalInverse = W.formalInverseEval t := by
     rw [hcoe, ← W.formalInverseEval_def]
-  have hV : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) :=
-    hsub ▸ W.hasEval_formalInverseEval hI ht
+  have hV' : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) := hsub ▸ hV
   have h := PowerSeries.aeval_subst W.hasSubst_formalInverse
-    (PowerSeries.continuous_aeval hE) hV W.formalInverse
+    (PowerSeries.continuous_aeval hE) hV' W.formalInverse
   rw [W.subst_formalInverse_self,
-    congrFun (PowerSeries.coe_aeval hV) W.formalInverse, hsub] at h
+    congrFun (PowerSeries.coe_aeval hV') W.formalInverse, hsub] at h
   simpa [hcoe, formalInverseEval, PowerSeries.eval₂_X] using h.symm
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
@@ -10,6 +10,7 @@ public import Mathlib.Topology.Algebra.Nonarchimedean.AdicTopology
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Inverse
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.WExpansion
 public import TauCeti.RingTheory.MvPowerSeries.Evaluation
+public import TauCeti.RingTheory.MvPowerSeries.Substitution
 public import TauCeti.Topology.Algebra.Nonarchimedean.AdicTopology
 public import TauCeti.Topology.Algebra.Nonarchimedean.GeometricSeries
 
@@ -61,6 +62,8 @@ ideal at all: the series identity `mul_invOfUnit_formalInverseDenom` evaluates t
 * `WeierstrassCurve.formalWEval_wEquation` : the `w`-equation at a parameter.
 * `WeierstrassCurve.formalWEval_ne_zero`, `WeierstrassCurve.formalInverseEval_ne_zero` : the two
   non-vanishing statements.
+* `WeierstrassCurve.formalInverseEval_formalInverseEval` : the involution `ι(ι(t)) = t`, and
+  `WeierstrassCurve.formalWEval_formalInverseEval` : `w(ι(t)) = -(w(t) * d(t)⁻¹)`.
 
 ## Implementation notes
 
@@ -90,7 +93,8 @@ Adapted from Michael Stoll's `EllipticCurves` project
 `EllipticCurves/WeierstrassFormalGroup/Eval.lean` — its evaluation layer down to the formal
 inverse, declarations `wEval`, `vEval`, `wEval_mem`, `wEval_eq`, `wEval_eq_cube_mul`,
 `vEval_sub_one_mem`, `isUnit_vEval`, `uEval`, `duEval`, `iotaEval`, `uEval_eq`,
-`uEval_mul_duEval`, `isUnit_uEval`, `iotaEval_eq` and `iotaEval_mem`.
+`uEval_mul_duEval`, `isUnit_uEval`, `iotaEval_eq`, `iotaEval_mem`, `wEval_iotaEval` and
+`iotaEval_iotaEval`.
 
 Four things are spelled differently here.
 
@@ -108,6 +112,11 @@ Four things are spelled differently here.
 * The source's `wPoly` is this repository's `WeierstrassCurve.wEquationRHS`, which is generic over
   an algebra, so evaluating it at `O` gives the element-level equation without a second
   definition.
+* The source's private `eval_subst_single` is not ported. It is `MvPSeries.eval_subst`
+  specialised, and this repository's `PowerSeries.aeval_subst` already states that fact without
+  the `DiscreteUniformity` hypotheses Mathlib's `MvPowerSeries.eval₂_subst` carries — which are
+  unsatisfiable here, coefficients and values being one adic ring. The two involution proofs call
+  it directly.
 
 The adic hypothesis is carried as an explicit `IsAdic I` argument for the reason given under
 implementation notes above.
@@ -303,5 +312,57 @@ theorem formalInverseEval_ne_zero {t : O} (ht : PowerSeries.HasEval t) (ht0 : t 
     W.formalInverseEval t ≠ 0 := by
   rw [W.formalInverseEval_eq ht, neg_ne_zero]
   exact fun h ↦ ht0 ((W.isUnit_formalInverseDenomInvEval ht).mul_left_eq_zero.mp h)
+
+/-! ### The involution
+
+`ι` is an involution on the series (`subst_formalInverse_self`), and evaluating that identity at a
+parameter needs evaluation of a substitution. Mathlib's `MvPowerSeries.eval₂_subst` cannot supply
+it here — it carries `[DiscreteUniformity R] [DiscreteUniformity S]`, and coefficients and values
+live in the same adic ring — so these two go through `PowerSeries.aeval_subst`, which is that
+statement without the discreteness.
+-/
+
+/-- The two evaluations at an inverted parameter share a preamble: `ι(t)` must itself admit
+evaluation, which is `formalInverseEval_mem` at `k = 1` fed back through `IsAdic`. -/
+private theorem hasEval_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
+    PowerSeries.HasEval (W.formalInverseEval t) :=
+  hI.isTopologicallyNilpotent_of_mem <| by
+    simpa using W.formalInverseEval_mem (k := 1)
+      (hI.isTopologicallyNilpotent_of_mem ht) (by simpa using ht)
+
+/-- **The `w`-expansion at an inverted parameter**: `w(ι(t)) = -(w(t) * d(t)⁻¹)`, the evaluation of
+the series identity `subst_formalInverse_formalW`. -/
+theorem formalWEval_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
+    W.formalWEval (W.formalInverseEval t) =
+      -(W.formalWEval t * W.formalInverseDenomInvEval t) := by
+  have hE : PowerSeries.HasEval t := hI.isTopologicallyNilpotent_of_mem ht
+  have hcoe : ∀ f : PowerSeries O, PowerSeries.aeval hE f = eval₂ (RingHom.id O) t f :=
+    congrFun (PowerSeries.coe_aeval hE)
+  have hsub : PowerSeries.aeval hE W.formalInverse = W.formalInverseEval t := by
+    rw [hcoe, ← W.formalInverseEval_def]
+  have hV : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) :=
+    hsub ▸ W.hasEval_formalInverseEval hI ht
+  have h := PowerSeries.aeval_subst W.hasSubst_formalInverse
+    (PowerSeries.continuous_aeval hE) hV W.formalW
+  rw [W.subst_formalInverse_formalW, map_neg, map_mul,
+    congrFun (PowerSeries.coe_aeval hV) W.formalW, hsub] at h
+  simpa [hcoe, formalWEval, formalInverseEval, formalInverseDenomInvEval] using h.symm
+
+/-- **The formal inverse is an involution at a parameter**: `ι(ι(t)) = t`. This is `-(-P) = P` for
+the group law near the origin, evaluated at `t`. -/
+theorem formalInverseEval_formalInverseEval {I : Ideal O} (hI : IsAdic I) {t : O} (ht : t ∈ I) :
+    W.formalInverseEval (W.formalInverseEval t) = t := by
+  have hE : PowerSeries.HasEval t := hI.isTopologicallyNilpotent_of_mem ht
+  have hcoe : ∀ f : PowerSeries O, PowerSeries.aeval hE f = eval₂ (RingHom.id O) t f :=
+    congrFun (PowerSeries.coe_aeval hE)
+  have hsub : PowerSeries.aeval hE W.formalInverse = W.formalInverseEval t := by
+    rw [hcoe, ← W.formalInverseEval_def]
+  have hV : PowerSeries.HasEval (PowerSeries.aeval hE W.formalInverse) :=
+    hsub ▸ W.hasEval_formalInverseEval hI ht
+  have h := PowerSeries.aeval_subst W.hasSubst_formalInverse
+    (PowerSeries.continuous_aeval hE) hV W.formalInverse
+  rw [W.subst_formalInverse_self,
+    congrFun (PowerSeries.coe_aeval hV) W.formalInverse, hsub] at h
+  simpa [hcoe, formalInverseEval, PowerSeries.eval₂_X] using h.symm
 
 end WeierstrassCurve


### PR DESCRIPTION
`ι` is an involution on the formal inverse *series* (`subst_formalInverse_self`, on `main`), and
`w` composed with it has a closed form (`subst_formalInverse_formalW`). This evaluates both at a
parameter, completing the one-variable evaluation layer of `FormalGroup/Eval.lean`.

## What this adds

`TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean`

* `formalInverseEval_formalInverseEval` — `ι(ι(t)) = t`, the group-law fact `-(-P) = P` near the
  origin, at a parameter.
* `formalWEval_formalInverseEval` — `w(ι(t)) = -(w(t) * d(t)⁻¹)`.
* `hasEval_formalInverseEval` — `ι(t)` admits evaluation when `t` is drawn from an ideal carrying
  the ambient topology, since `formalInverseEval_mem` puts it in the same ideal.

All three take only what they use. The two identities ask for `PowerSeries.HasEval t` and
`PowerSeries.HasEval (W.formalInverseEval t)` and no ideal at all; `hasEval_formalInverseEval` is
the adic route to the second, for consumers that hold their parameter that way.

**Round 1 correction.** The first version of this PR stated both identities over `IsAdic I` and
`t ∈ I`, and the body argued that was deliberate — that `ι(t)` could only be shown topologically
nilpotent through membership. `generality` and `api-design` both pointed out that this is false:
membership is *one* route to `HasEval (ι(t))`, not the only one, and the proofs never touch the
ideal again once the two `HasEval` facts are in hand. They were right, and this is the same
over-constraint that #4860 was corrected for one round earlier — I reintroduced it here. Fixed by
stating the general forms and exposing the adic route as its own lemma rather than by duplicating
each identity into a convenience corollary, which would add two thin wrappers over a single call.

## Why this could not be written before

#4860 recorded the involution as **blocked rather than deferred**, and named the obstruction:
Mathlib's `MvPowerSeries.eval₂_subst` carries `[DiscreteUniformity R] [DiscreteUniformity S]` on
the two coefficient rings, and a general adic ring supplies no such instance — here the
coefficients and the evaluation target are the *same* such ring. (`documentation` was right that
the earlier wording overstated this as "unsatisfiable": a ring that happens to be discrete could
satisfy both. The obstruction is that the instances are unavailable at this generality, not that
they are contradictory. Both the module note and the section docstring now say that.)

#4892 (merged) supplies `PowerSeries.aeval_subst`: the same conclusion with an arbitrary uniform
structure on the coefficients. Both proofs here call it directly, which is why the source's
private `eval_subst_single` is **not** ported — it is `MvPSeries.eval_subst` specialised, and
`PowerSeries.aeval_subst` already states that fact at the generality this file needs.

## Reuse

The two series-level identities are already on `main` (`FormalGroup/Inverse.lean`) and are not
restated. Nothing general is added: `PowerSeries.aeval_subst` is used as it stands, and the only
new private declaration is the shared membership preamble, which has two call sites in this file.

## Gates run

| Gate | Result |
| --- | --- |
| `lake build` of the changed module | **pass** — `Build completed successfully (1996 jobs)`, 0 errors, 0 warnings |
| declaration-loss check against `main` | **pass** — delta is exactly the three additions, nothing removed |
| line length | **pass** — longest line 99 characters |
| axioms / module-system / full build / `lint-env` | CI (`pr-build`) |

Roadmap: EllipticCurves

Target: `TauCetiRoadmap/EllipticCurves/README.md`:572-580 — milestone **(iii)** of the formal-group
ladder, "Convergence: over a complete valued field, `Ê(𝔪)` as an honest group of points" (576-577),
with the Stoll development named as the port source at 579-580. The involution is what makes the
negation on `Ê(𝔪)` an involution, so it is a prerequisite of that milestone's group structure.

Consumers: FG-5 (`tc-lb1z8`, valuations of the formal group data over a DVR). Counted at the pin
in the source's `WeierstrassFormalGroup/Foundations.lean` (879 lines), FG-5 uses
`iotaEval_iotaEval` **3** times and `wEval_iotaEval` **2** times, so both public results here are
consumed. (The tracking bead said four uses of the involution; the measured figure is three.)

The roadmap bullet, quoted in full so the scope question is answerable from this body:

> **The formal group — four milestones with four different hypothesis sets, not one.**
> (i) The elliptic formal group *law* `Ê` over the coefficient ring, from expanding the group
> law at `O` (AEC IV.1), as an instance of Mathlib's `RingTheory/FormalGroup`; `[m]` on `Ê`.
> (ii) The formal logarithm and exponential, over a coefficient ring containing `ℚ`
> (characteristic-zero hypotheses only here). (iii) Convergence: over a complete valued
> field, `Ê(𝔪)` as an honest group of points. (iv) The identification `Ê(𝔪) ≅ E₁(K)` with
> the kernel of reduction for an integral model (IV.6; consumed by Layers 3–4). **These cannot
> share one typeclass bundle**, and the existing sorry-free Stoll development (provenance) is
> the port source — refounded on Mathlib's formal-group-law layer, not rebuilt from nothing.

Two points this settles in advance, both of which were raised and cleared on #4860 and #4868:
the bullet states that the four milestones have *four different hypothesis sets* and *cannot share
one typeclass bundle* — that is separateness, not sequence, and no "first"/"then"/"before"/"after"
appears in 572-580; and nothing in this diff consumes milestone (i), which is tracked as FG-3
(`tc-n3y1v`) — no `FormalGroup` instance, group law or associativity appears in any statement,
proof or import here.

## Provenance

Adapted from Michael Stoll's `EllipticCurves`
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0), pinned by
`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`, whose full expansion is
`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e` — file
`EllipticCurves/WeierstrassFormalGroup/Eval.lean`, declarations `wEval_iotaEval` (:313) and
`iotaEval_iotaEval` (:321). The mathematics is the source's; the statement over an arbitrary adic
ideal rather than `IsLocalRing.maximalIdeal`, and the use of `PowerSeries.aeval_subst` in place of
the source's private `eval_subst_single`, are not.
