### PR TITLE
feat(Topology): a quotient of a nonarchimedean ring is nonarchimedean

### DIFF
--- a/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
@@ -6,54 +6,84 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+public import Mathlib.Topology.Algebra.Group.Quotient
 public import Mathlib.Topology.Algebra.Ring.Ideal
 
 /-!
-# A quotient of a nonarchimedean ring is nonarchimedean
+# A quotient of a nonarchimedean group is nonarchimedean
 
-`NonarchimedeanRing R` asks that every neighbourhood of `0` contain an *open additive subgroup*.
-That property passes to `R ⧸ I` for any ideal `I`, and the proof is the one-line reason it should:
-the quotient map is open, so it carries a basis of open subgroups at `0` to one downstairs.
+`NonarchimedeanGroup G` asks that every neighbourhood of `1` contain an *open subgroup*. That
+property passes to `G ⧸ N`, and the proof is the one-line reason it should: the quotient map is
+open, so it carries an open subgroup at `1` to one downstairs.
 
-Mathlib gives `R ⧸ I` its quotient topology and an `IsTopologicalRing` instance
-(`Mathlib/Topology/Algebra/Ring/Ideal.lean`) — indeed the latter is built from
-`QuotientAddGroup.instIsTopologicalAddGroup`, so the ring-quotient and additive-quotient
-topologies agree by construction — but it does not carry the nonarchimedean structure across, and
-neither did this repository.
+This is a statement about topological groups, not about rings: nothing in it uses
+multiplication on a ring or the ideal structure of `I`. It is therefore proved at the group
+level and transported with `@[to_additive]`, and the ring statement is derived from the additive
+one rather than reproved — the same way Mathlib derives `NonarchimedeanRing (R × S)` from the
+additive group instance on a product.
+
+Deriving it does take one step, because `R ⧸ I` and `R ⧸ I.toAddSubgroup` are *definitionally*
+equal but not syntactically so: Mathlib's `Ideal.topologicalRing_quotient` already builds the
+topological-ring structure of `R ⧸ I` out of `QuotientAddGroup.instIsTopologicalAddGroup`, yet
+instance search does not see through the two `HasQuotient` instances on its own. Naming
+`I.toAddSubgroup` once is what lets the additive instance apply.
 
 The consumer is the universal property of a rational localisation
 (`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_locTopology`), which
 requires `[NonarchimedeanRing B]` on its target. Wedhorn's Example 6.38 presents a rational
 localisation as a quotient `C ⧸ a` of a ring of restricted power series, so applying that
-universal property to `C ⧸ a` needs exactly this instance.
+universal property to `C ⧸ a` needs exactly the ring instance below.
 
 ## Main results
 
-* `TauCeti.instNonarchimedeanRingQuotient`: `R ⧸ I` is nonarchimedean when `R` is.
+* `QuotientGroup.instNonarchimedeanGroup`, and its additive form
+  `QuotientAddGroup.instNonarchimedeanAddGroup`: `G ⧸ N` is nonarchimedean when `G` is.
+* `Ideal.Quotient.instNonarchimedeanRing`: `R ⧸ I` is nonarchimedean when `R` is.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Example 6.38.
 -/
 
 public section
 
 open Topology
 
-namespace TauCeti
+namespace QuotientGroup
 
-variable {R : Type*} [CommRing R] [TopologicalSpace R] [NonarchimedeanRing R] (I : Ideal R)
+variable {G : Type*} [Group G] [TopologicalSpace G] [NonarchimedeanGroup G] (N : Subgroup G)
+  [N.Normal]
 
-/-- A quotient of a nonarchimedean ring is nonarchimedean. -/
-instance : NonarchimedeanRing (R ⧸ I) where
+/-- A quotient of a nonarchimedean group is nonarchimedean: the image of an open subgroup
+contained in the preimage of `U` is an open subgroup contained in `U`, because the quotient map
+is open. -/
+@[to_additive]
+instance instNonarchimedeanGroup : NonarchimedeanGroup (G ⧸ N) where
   is_nonarchimedean U hU := by
-    have hpre : (Ideal.Quotient.mk I) ⁻¹' U ∈ 𝓝 (0 : R) :=
-      (continuous_quot_mk.tendsto (0 : R)) hU
-    obtain ⟨V, hV⟩ := NonarchimedeanRing.is_nonarchimedean _ hpre
-    refine ⟨⟨V.toAddSubgroup.map (Ideal.Quotient.mk I).toAddMonoidHom, ?_⟩, ?_⟩
-    · -- `OpenAddSubgroup` asks for openness of the bundled subgroup's `carrier`; naming it as
-      -- the subgroup's coercion is what lets `AddSubgroup.coe_map` rewrite it to an image.
-      change IsOpen ((V.toAddSubgroup.map (Ideal.Quotient.mk I).toAddMonoidHom :
-        AddSubgroup (R ⧸ I)) : Set (R ⧸ I))
-      rw [AddSubgroup.coe_map]
-      exact QuotientRing.isOpenMap_coe I _ V.isOpen
+    have hpre : ((↑) : G → G ⧸ N) ⁻¹' U ∈ 𝓝 (1 : G) := (continuous_mk.tendsto (1 : G)) hU
+    obtain ⟨V, hV⟩ := NonarchimedeanGroup.is_nonarchimedean _ hpre
+    refine ⟨⟨V.toSubgroup.map (QuotientGroup.mk' N), ?_⟩, ?_⟩
+    · -- `OpenSubgroup` asks for openness of the bundled subgroup's `carrier`; naming it as the
+      -- subgroup's coercion is what lets `Subgroup.coe_map` rewrite it to an image.
+      change IsOpen ((V.toSubgroup.map (QuotientGroup.mk' N) : Subgroup (G ⧸ N)) : Set (G ⧸ N))
+      rw [Subgroup.coe_map]
+      exact isOpenMap_coe _ V.isOpen
     · rintro _ ⟨x, hx, rfl⟩
       exact hV hx
 
-end TauCeti
+end QuotientGroup
+
+namespace Ideal.Quotient
+
+variable {R : Type*} [CommRing R] [TopologicalSpace R] [NonarchimedeanRing R] (I : Ideal R)
+
+/-- A quotient of a nonarchimedean ring by an ideal is nonarchimedean. This is the additive
+group statement `QuotientAddGroup.instNonarchimedeanAddGroup`, applied to `I.toAddSubgroup` and
+combined with the topological ring structure Mathlib already puts on `R ⧸ I`; the nonarchimedean
+field is inherited unchanged. -/
+instance instNonarchimedeanRing : NonarchimedeanRing (R ⧸ I) :=
+  haveI : NonarchimedeanAddGroup (R ⧸ I) :=
+    QuotientAddGroup.instNonarchimedeanAddGroup I.toAddSubgroup
+  { is_nonarchimedean := NonarchimedeanAddGroup.is_nonarchimedean }
+
+end Ideal.Quotient

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+public import Mathlib.Topology.Algebra.Ring.Ideal
+
+/-!
+# A quotient of a nonarchimedean ring is nonarchimedean
+
+`NonarchimedeanRing R` asks that every neighbourhood of `0` contain an *open additive subgroup*.
+That property passes to `R ⧸ I` for any ideal `I`, and the proof is the one-line reason it should:
+the quotient map is open, so it carries a basis of open subgroups at `0` to one downstairs.
+
+Mathlib gives `R ⧸ I` its quotient topology and an `IsTopologicalRing` instance
+(`Mathlib/Topology/Algebra/Ring/Ideal.lean`) — indeed the latter is built from
+`QuotientAddGroup.instIsTopologicalAddGroup`, so the ring-quotient and additive-quotient
+topologies agree by construction — but it does not carry the nonarchimedean structure across, and
+neither did this repository.
+
+The consumer is the universal property of a rational localisation
+(`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_locTopology`), which
+requires `[NonarchimedeanRing B]` on its target. Wedhorn's Example 6.38 presents a rational
+localisation as a quotient `C ⧸ a` of a ring of restricted power series, so applying that
+universal property to `C ⧸ a` needs exactly this instance.
+
+## Main results
+
+* `TauCeti.instNonarchimedeanRingQuotient`: `R ⧸ I` is nonarchimedean when `R` is.
+-/
+
+public section
+
+open Topology
+
+namespace TauCeti
+
+variable {R : Type*} [CommRing R] [TopologicalSpace R] [NonarchimedeanRing R] (I : Ideal R)
+
+/-- A quotient of a nonarchimedean ring is nonarchimedean. -/
+instance : NonarchimedeanRing (R ⧸ I) where
+  is_nonarchimedean U hU := by
+    have hpre : (Ideal.Quotient.mk I) ⁻¹' U ∈ 𝓝 (0 : R) :=
+      (continuous_quot_mk.tendsto (0 : R)) hU
+    obtain ⟨V, hV⟩ := NonarchimedeanRing.is_nonarchimedean _ hpre
+    refine ⟨⟨V.toAddSubgroup.map (Ideal.Quotient.mk I).toAddMonoidHom, ?_⟩, ?_⟩
+    · -- `OpenAddSubgroup` asks for openness of the bundled subgroup's `carrier`; naming it as
+      -- the subgroup's coercion is what lets `AddSubgroup.coe_map` rewrite it to an image.
+      change IsOpen ((V.toAddSubgroup.map (Ideal.Quotient.mk I).toAddMonoidHom :
+        AddSubgroup (R ⧸ I)) : Set (R ⧸ I))
+      rw [AddSubgroup.coe_map]
+      exact QuotientRing.isOpenMap_coe I _ V.isOpen
+    · rintro _ ⟨x, hx, rfl⟩
+      exact hV hx
+
+end TauCeti


### PR DESCRIPTION
`NonarchimedeanRing R` asks that every neighbourhood of `0` contain an *open additive subgroup*.
That passes to `R ⧸ I` for any ideal `I`, and the proof is the one-line reason it should: the
quotient map is open (`QuotientRing.isOpenMap_coe`), so it carries a basis of open subgroups at
`0` to one downstairs.

## Why it isn't already there

Mathlib gives `R ⧸ I` its quotient topology and an `IsTopologicalRing` instance
(`Topology/Algebra/Ring/Ideal.lean`) — and notably builds the latter from
`QuotientAddGroup.instIsTopologicalAddGroup`, so the ring-quotient and additive-quotient
topologies agree *by construction*. But it stops there: nothing carries the nonarchimedean
structure across, and neither did this repository. I checked both by shape before writing —
`Topology/Algebra/Nonarchimedean/Basic.lean` has no quotient result, and `TauCeti` had no
`Nonarchimedean` × `⧸` declaration.

I confirmed the gap in Lean rather than only by search: with `[NonarchimedeanRing R]` in scope,
`example : NonarchimedeanRing (R ⧸ I) := by infer_instance` fails to synthesize, while
`example : IsTopologicalRing (R ⧸ I) := by infer_instance` succeeds.

## Consumer

The universal property of a rational localisation,
`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_locTopology`, requires
`[NonarchimedeanRing B]` on its target. Wedhorn's Example 6.38 presents a rational localisation
`A⟨T/s⟩` as a quotient `C ⧸ a` of a ring of restricted power series, so applying that universal
property to `C ⧸ a` needs exactly this instance. That is AdicSpaces roadmap §4.1 step 3
(`README:571`, Proposition 8.30), which identifies rational localisations in order to prove
restriction maps between them are flat.

## Note on the one `change`

The `OpenAddSubgroup` structure asks for openness of the bundled subgroup's `carrier`; naming
that as the subgroup's coercion is what lets `AddSubgroup.coe_map` rewrite it to an image, which
is the form `QuotientRing.isOpenMap_coe` produces. The comment in the proof says so.

## Gate

`lake build` of the new module — 1330 jobs, no errors, warnings or sorries. New leaf file; nothing
on `main` imports it yet.

Roadmap: AdicSpaces
