### PR TITLE
feat: assemble blockwise symmetric-power transitions

### DIFF
--- a/TauCeti/Analysis/Polynomial/SimpleRoots/Basic.lean
+++ b/TauCeti/Analysis/Polynomial/SimpleRoots/Basic.lean
@@ -79,11 +79,11 @@ surface identifies a neighbourhood in `Sym^g(Σ)` with an open subset of `Sym^g(
 `TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm` says that changing that coordinate acts
 analytically on the elementary symmetric coordinates of one such patch, at multiplicity-free
 tuples. That is the analytic ingredient for the transition maps of the atlas of
-`TauCeti/Geometry/Manifold/SymmetricPower.lean`, not those transition maps themselves: a chart
-there splits a tuple into the factors lying in `k` disjoint patches, of degrees `m 1, …, m k`, and
-regroups the resulting blocks of coefficients along a bijection `(Σ i, Fin (m i)) ≃ Fin n`.
-Neither that assembly across blocks nor the diagonal, where the points of a tuple collide, is
-treated here.
+`TauCeti/Geometry/Manifold/SymmetricPower.lean`. A chart there splits a tuple into the factors
+lying in `k` disjoint patches, of degrees `m 1, …, m k`, and regroups the resulting blocks of
+coefficients along a bijection `(Σ i, Fin (m i)) ≃ Fin n`; that assembly is carried out in
+`TauCeti/Analysis/Polynomial/SimpleRoots/Family.lean`. The diagonal, where the points of a tuple
+collide, is not treated here.
 
 Everything is stated over an `RCLike` field, so it covers the real as well as the complex case,
 except for the elementary polynomial calculus, which needs only a nontrivially normed field; only

--- a/TauCeti/Analysis/Polynomial/SimpleRoots/Family.lean
+++ b/TauCeti/Analysis/Polynomial/SimpleRoots/Family.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Polynomial.SimpleRoots.Basic
+public import TauCeti.Topology.PiCurry
+import Mathlib.Analysis.Analytic.Constructions
+import Mathlib.Analysis.Analytic.Linear
+
+/-!
+# Analytic coordinate changes for families of simple roots
+
+An elementary-symmetric chart on a symmetric power of a surface separates a tuple into the
+points lying in finitely many disjoint coordinate patches. If the multiplicity in patch `i` is
+`m i`, its coordinates form a block `Fin (m i) → 𝕜`; a bijection
+`(Σ i, Fin (m i)) ≃ Fin n` regroups those blocks into the model space `Fin n → 𝕜`.
+
+`TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm` proves that changing the surface
+coordinate is analytic on one block when its roots are distinct. This file applies that result to
+a finite family of blocks and then conjugates the family by the possibly different source and
+target regroupings. The assembled statement is
+`TauCeti.Sym.analyticAt_piSigmaConst_coeffEquiv_map_coeffEquiv_symm`.
+
+Thus the blockwise coordinate-change expression used by elementary-symmetric charts is analytic
+at tuples that are multiplicity-free inside every block. The case where points collide remains
+separate: there the inverse root parametrization is not analytic, and the transition map must
+instead be studied directly as a symmetric holomorphic function.
+
+This is the multiplicity-free assembly step in Lane F4.1 of the analytic Heegaard Floer roadmap,
+whose first target is the smooth complex structure on `Sym^g(Σ)` from elementary symmetric
+functions. The organization follows Ozsváth--Szabó,
+[arXiv:math/0101206](https://arxiv.org/abs/math/0101206), Section 2.1.
+-/
+
+public section
+
+open Topology
+
+namespace TauCeti
+
+namespace Sym
+
+variable {𝕜 : Type*} [RCLike 𝕜] [IsAlgClosed 𝕜]
+variable {ι : Type*} [Finite ι] {m : ι → ℕ} {n : ℕ}
+
+attribute [local instance] Fintype.ofFinite
+
+omit [IsAlgClosed 𝕜] in
+/-- Regrouping a finite family of tuples is analytic. This is kept private because the public
+result below exposes exactly the conjugated coordinate change needed by symmetric-power charts. -/
+private theorem analyticAt_piSigmaConstHomeomorph
+    (e : (Σ i, Fin (m i)) ≃ Fin n) (c : ∀ i, Fin (m i) → 𝕜) :
+    AnalyticAt 𝕜 (piSigmaConstHomeomorph 𝕜 e) c := by
+  refine AnalyticAt.pi fun j => ?_
+  have hblock : AnalyticAt 𝕜 (fun p : (∀ i, Fin (m i) → 𝕜) => p (e.symm j).1) c :=
+    (ContinuousLinearMap.proj (R := 𝕜) (φ := fun i => Fin (m i) → 𝕜)
+      (e.symm j).1).analyticAt c
+  have hcoord : AnalyticAt 𝕜 (fun p : Fin (m (e.symm j).1) → 𝕜 => p (e.symm j).2)
+      (c (e.symm j).1) :=
+    (ContinuousLinearMap.proj (R := 𝕜) (φ := fun _ : Fin (m (e.symm j).1) => 𝕜)
+      (e.symm j).2).analyticAt _
+  convert hcoord.comp hblock using 1
+  ext x
+  exact piSigmaConstHomeomorph_apply 𝕜 e x j
+
+omit [IsAlgClosed 𝕜] in
+/-- The inverse regrouping from one tuple to a finite family of tuples is analytic. -/
+private theorem analyticAt_piSigmaConstHomeomorph_symm
+    (e : (Σ i, Fin (m i)) ≃ Fin n) (c : Fin n → 𝕜) :
+    AnalyticAt 𝕜 (piSigmaConstHomeomorph 𝕜 e).symm c := by
+  refine AnalyticAt.pi fun i => AnalyticAt.pi fun j => ?_
+  convert (ContinuousLinearMap.proj (R := 𝕜) (φ := fun _ : Fin n => 𝕜)
+    (e ⟨i, j⟩)).analyticAt c using 1
+  ext x
+  exact piSigmaConstHomeomorph_symm_apply 𝕜 e x i j
+
+/-- **Coordinate changes on a finite family of multiplicity-free root blocks are analytic.**
+
+For each `i`, the coefficient tuple `c₀ i` represents the pairwise distinct roots `z i`. Applying
+`φ i` to those roots and returning to elementary-symmetric coordinates is analytic jointly in
+the family of coefficient blocks, provided `φ i` is analytic at every represented root. -/
+private theorem analyticAt_pi_coeffEquiv_map_coeffEquiv_symm
+    {φ : ι → 𝕜 → 𝕜} {c₀ z : ∀ i, Fin (m i) → 𝕜}
+    (hz : ∀ i, Function.Injective (z i))
+    (hc₀ : ∀ i, (coeffEquiv 𝕜 (m i)).symm (c₀ i) = ofFn (z i))
+    (hφ : ∀ i j, AnalyticAt 𝕜 (φ i) (z i j)) :
+    AnalyticAt 𝕜
+      (fun c i => coeffEquiv 𝕜 (m i)
+        (_root_.Sym.map (φ i) ((coeffEquiv 𝕜 (m i)).symm (c i)))) c₀ := by
+  refine AnalyticAt.pi fun i => ?_
+  exact AnalyticAt.comp (f := fun c : (∀ i, Fin (m i) → 𝕜) => c i)
+    (analyticAt_coeffEquiv_map_coeffEquiv_symm (hz i) (hc₀ i) (hφ i))
+    ((ContinuousLinearMap.proj (R := 𝕜) (φ := fun i => Fin (m i) → 𝕜) i).analyticAt c₀)
+
+/-- **A blockwise elementary-symmetric coordinate change is analytic after regrouping.**
+
+The bijections `e` and `e'` are the independent choices used to identify the source and target
+families of coefficient blocks with `Fin n → 𝕜`. The transition first undoes `e`, changes the
+underlying coordinate separately on each root block, and then regroups along `e'`. It is analytic
+at every tuple whose roots are pairwise distinct inside each block. -/
+theorem analyticAt_piSigmaConst_coeffEquiv_map_coeffEquiv_symm
+    (e e' : (Σ i, Fin (m i)) ≃ Fin n)
+    {φ : ι → 𝕜 → 𝕜} {c₀ z : ∀ i, Fin (m i) → 𝕜}
+    (hz : ∀ i, Function.Injective (z i))
+    (hc₀ : ∀ i, (coeffEquiv 𝕜 (m i)).symm (c₀ i) = ofFn (z i))
+    (hφ : ∀ i j, AnalyticAt 𝕜 (φ i) (z i j)) :
+    AnalyticAt 𝕜
+      (fun c => piSigmaConstHomeomorph 𝕜 e' (fun i =>
+        coeffEquiv 𝕜 (m i) (_root_.Sym.map (φ i)
+          ((coeffEquiv 𝕜 (m i)).symm ((piSigmaConstHomeomorph 𝕜 e).symm c i)))))
+      (piSigmaConstHomeomorph 𝕜 e c₀) := by
+  have hin := analyticAt_piSigmaConstHomeomorph_symm (𝕜 := 𝕜) e
+    (piSigmaConstHomeomorph 𝕜 e c₀)
+  have hblocks := analyticAt_pi_coeffEquiv_map_coeffEquiv_symm hz hc₀ hφ
+  have hblocks' : AnalyticAt 𝕜
+      (fun c => fun i => coeffEquiv 𝕜 (m i) (_root_.Sym.map (φ i)
+        ((coeffEquiv 𝕜 (m i)).symm (c i))))
+      ((piSigmaConstHomeomorph 𝕜 e).symm (piSigmaConstHomeomorph 𝕜 e c₀)) := by
+    rw [Homeomorph.symm_apply_apply]
+    exact hblocks
+  have hmiddle := AnalyticAt.comp
+    (f := (piSigmaConstHomeomorph 𝕜 e).symm) hblocks' hin
+  have hmiddle' : AnalyticAt 𝕜
+      (fun c => fun i => coeffEquiv 𝕜 (m i) (_root_.Sym.map (φ i)
+        ((coeffEquiv 𝕜 (m i)).symm ((piSigmaConstHomeomorph 𝕜 e).symm c i))))
+      (piSigmaConstHomeomorph 𝕜 e c₀) := by
+    convert hmiddle using 1
+    all_goals rfl
+  convert AnalyticAt.comp
+    (f := fun c => fun i => coeffEquiv 𝕜 (m i) (_root_.Sym.map (φ i)
+      ((coeffEquiv 𝕜 (m i)).symm ((piSigmaConstHomeomorph 𝕜 e).symm c i))))
+    (analyticAt_piSigmaConstHomeomorph (𝕜 := 𝕜) e' _) hmiddle' using 1
+  all_goals rfl
+
+end Sym
+
+end TauCeti

--- a/TauCeti/Analysis/Polynomial/SimpleRoots/Family.lean
+++ b/TauCeti/Analysis/Polynomial/SimpleRoots/Family.lean
@@ -22,7 +22,7 @@ points lying in finitely many disjoint coordinate patches. If the multiplicity i
 coordinate is analytic on one block when its roots are distinct. This file applies that result to
 a finite family of blocks and then conjugates the family by the possibly different source and
 target regroupings. The assembled statement is
-`TauCeti.Sym.analyticAt_piSigmaConst_coeffEquiv_map_coeffEquiv_symm`.
+`TauCeti.Sym.analyticAt_piSigmaConstHomeomorph_coeffEquiv_map_coeffEquiv_symm`.
 
 Thus the blockwise coordinate-change expression used by elementary-symmetric charts is analytic
 at tuples that are multiplicity-free inside every block. The case where points collide remains
@@ -101,7 +101,7 @@ The bijections `e` and `e'` are the independent choices used to identify the sou
 families of coefficient blocks with `Fin n → 𝕜`. The transition first undoes `e`, changes the
 underlying coordinate separately on each root block, and then regroups along `e'`. It is analytic
 at every tuple whose roots are pairwise distinct inside each block. -/
-theorem analyticAt_piSigmaConst_coeffEquiv_map_coeffEquiv_symm
+theorem analyticAt_piSigmaConstHomeomorph_coeffEquiv_map_coeffEquiv_symm
     (e e' : (Σ i, Fin (m i)) ≃ Fin n)
     {φ : ι → 𝕜 → 𝕜} {c₀ z : ∀ i, Fin (m i) → 𝕜}
     (hz : ∀ i, Function.Injective (z i))

--- a/TauCeti/Analysis/Polynomial/SymmetricPower.lean
+++ b/TauCeti/Analysis/Polynomial/SymmetricPower.lean
@@ -56,8 +56,10 @@ surface identifies a neighbourhood in `Sym^g(Σ)` with an open subset of `Sym^g(
 below is what makes that a chart on a topological manifold; the charted structure is assembled
 from it in `TauCeti/Geometry/Manifold/SymmetricPower.lean`. Away from the diagonal the continuity
 proved here is upgraded to analyticity in
-`TauCeti/Analysis/Polynomial/SimpleRoots.lean`. The complex structure itself, and the totally real
-tori `T_α`, `T_β`, are separate later steps.
+`TauCeti/Analysis/Polynomial/SimpleRoots/Basic.lean`, and its assembly across the blocks of an
+elementary-symmetric chart is in `TauCeti/Analysis/Polynomial/SimpleRoots/Family.lean`. The complex
+structure itself, including transition maps at colliding tuples, and the totally real tori
+`T_α`, `T_β`, are separate later steps.
 -/
 
 public section

--- a/TauCeti/Geometry/Manifold/SymmetricPower.lean
+++ b/TauCeti/Geometry/Manifold/SymmetricPower.lean
@@ -42,7 +42,7 @@ single coordinate patch at a multiplicity-free coefficient tuple,
 `TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm` in
 `TauCeti/Analysis/Polynomial/SimpleRoots/Basic.lean`. Its assembly across the blocks that a chart
 below splits a tuple into, along the regrouping `e`, is
-`TauCeti.Sym.analyticAt_piSigmaConst_coeffEquiv_map_coeffEquiv_symm` in
+`TauCeti.Sym.analyticAt_piSigmaConstHomeomorph_coeffEquiv_map_coeffEquiv_symm` in
 `TauCeti/Analysis/Polynomial/SimpleRoots/Family.lean`. The case of colliding points is not done;
 there the degree-`m i` elementary symmetric coordinates genuinely appear.
 

--- a/TauCeti/Geometry/Manifold/SymmetricPower.lean
+++ b/TauCeti/Geometry/Manifold/SymmetricPower.lean
@@ -40,9 +40,11 @@ maps are holomorphic, is the next step of Lane F4.1 and is not done here; so are
 tori `T_α`, `T_β`. What is available towards that holomorphy is the analytic ingredient for a
 single coordinate patch at a multiplicity-free coefficient tuple,
 `TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm` in
-`TauCeti/Analysis/Polynomial/SimpleRoots.lean`; assembling it across the blocks that a chart below
-splits a tuple into, along the regrouping `e`, is not done, and neither is the case of colliding
-points — which is where the degree-`m i` elementary symmetric coordinates genuinely appear.
+`TauCeti/Analysis/Polynomial/SimpleRoots/Basic.lean`. Its assembly across the blocks that a chart
+below splits a tuple into, along the regrouping `e`, is
+`TauCeti.Sym.analyticAt_piSigmaConst_coeffEquiv_map_coeffEquiv_symm` in
+`TauCeti/Analysis/Polynomial/SimpleRoots/Family.lean`. The case of colliding points is not done;
+there the degree-`m i` elementary symmetric coordinates genuinely appear.
 
 ## Main declarations
 

--- a/TauCeti/RingTheory/Polynomial/MonicOfCoeff.lean
+++ b/TauCeti/RingTheory/Polynomial/MonicOfCoeff.lean
@@ -17,7 +17,7 @@ to be `X ^ n`. This file names the resulting polynomial `TauCeti.Polynomial.moni
 tuple `c : Fin n → R`, and records that reading the coefficients back off is inverse to it.
 
 The point of naming it is that it is the object against which analytic dependence on the
-coefficients is stated: `TauCeti/Analysis/Polynomial/SimpleRoots.lean` differentiates
+coefficients is stated: `TauCeti/Analysis/Polynomial/SimpleRoots/Basic.lean` differentiates
 `(c, z) ↦ (monicOfCoeff c).eval z` in `c` and `z` jointly, so the lower coefficients must appear as
 a *free* tuple rather than as the data of a polynomial subtype.
 


### PR DESCRIPTION
This PR assembles analytic elementary-symmetric coordinate changes across a finite family of simple-root blocks and conjugates them by the independent source and target regroupings used by symmetric-power charts. It adds `TauCeti.Sym.analyticAt_piSigmaConst_coeffEquiv_map_coeffEquiv_symm`, which applies the existing one-block simple-root theorem pointwise and proves that the resulting map on `Fin n → 𝕜` is analytic.

The exact roadmap target is `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F4.1, first clause, “`Sym^g(Σ)` geometry: smooth complex structure (elementary symmetric functions).” The milestone it serves is the v3 analytic construction of `HF̂(Y)` over 𝔽₂, whose holomorphic-disk theory requires a complex-manifold structure on `Sym^g(Σ)`. This is the most effective current step because the elementary-symmetric topological charts and the one-patch multiplicity-free analytic coordinate change are already on `main`, and the chart module explicitly names finite-block assembly as their next consumer. After this PR, the first F4.1 clause still needs transition-map holomorphy at colliding tuples, where roots cannot be parametrized analytically, followed by packaging the atlas as a complex manifold.

The proof reuses Mathlib's `AnalyticAt.pi`, continuous coordinate projections, and analytic composition, together with `TauCeti.Sym.analyticAt_coeffEquiv_map_coeffEquiv_symm` and `TauCeti.piSigmaConstHomeomorph`; no Mathlib source is vendored. The mathematical organization follows Ozsváth--Szabó, arXiv:math/0101206, Section 2.1, as credited in the new module documentation.

The new `TauCeti/Analysis/Polynomial/SimpleRoots/Family.lean` module is 140 lines. Adding the second `SimpleRoots` module triggers the repository's prefix-directory rule, so the existing module moves to `TauCeti/Analysis/Polynomial/SimpleRoots/Basic.lean`, with only its forward-looking documentation refreshed; three existing docstrings are updated to the canonical module paths and the new assembled theorem.

| Old module | New module |
| --- | --- |
| `TauCeti.Analysis.Polynomial.SimpleRoots` | `TauCeti.Analysis.Polynomial.SimpleRoots.Basic` |

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"blockwise-symmetric-power-transition-analyticity"}-->

🤖 Prepared with Codex
