### PR TITLE
docs(FormalGroup): say which evaluation results actually need the adic hypothesis

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Eval.lean
@@ -23,11 +23,12 @@ evaluations, the identities they inherit from the series, and their membership, 
 non-vanishing properties.
 
 Two hypotheses appear here, and they do different work. `PowerSeries.HasEval t` is what evaluation
-itself requires, and it is all the algebraic identities require: each of them is the image of an
-identity of series under the ring homomorphism `PowerSeries.eval₂Hom`. Membership in a power of an
-ideal requires more — the ideal `I`, and that the ambient topology is its adic one — because it
-comes from `MvPowerSeries.eval₂_mem_pow`, which sums the monomial estimates inside the closed set
-`I ^ k`.
+itself requires, and it is what almost every result here asks for: the algebraic identities are
+each the image of an identity of series under the ring homomorphism `PowerSeries.eval₂Hom`, and
+`formalWEval_mem` and `formalInverseEval_mem` read their memberships off those identities, so
+neither takes an adic hypothesis. Exactly one result needs more — `formalUEval_sub_one_mem`, which
+also takes the ideal `I` and that the ambient topology is its adic one, being the file's one appeal
+to `MvPowerSeries.eval₂_mem_pow`, which sums the monomial estimates inside the closed set `I ^ k`.
 
 Only two of the five values are confined to `I ^ k`, and neither needs that estimate: `w(t)` and
 `ι(t)` factor as `t ^ 3 * u(t)` and `-(t * d(t)⁻¹)`, so a parameter in `I ^ k` carries them there.


### PR DESCRIPTION
`FormalGroup/Eval.lean`'s module docstring contradicted itself about which results need the adic
hypothesis, and the wrong half was the one stating the rule.

## The defect

The second paragraph said:

> Membership in a power of an ideal requires more — the ideal `I`, and that the ambient topology is
> its adic one — because it comes from `MvPowerSeries.eval₂_mem_pow` [...]

and the paragraph immediately after it said:

> Only two of the five values are confined to `I ^ k`, and **neither needs that estimate** [...]

The second is correct and the first is wrong on the signatures, not merely inconsistent with it:

* `formalWEval_mem {I : Ideal O} {k : ℕ} {t : O} (ht : PowerSeries.HasEval t) (htk : t ∈ I ^ k)` —
  no `IsAdic`; it rewrites by `formalWEval_eq_pow_mul_formalUEval`.
* `formalInverseEval_mem` — same shape, no `IsAdic`; it rewrites by `formalInverseEval_eq`.
* `formalUEval_sub_one_mem (hI : IsAdic I) …` — the only one that takes `IsAdic`, and the file's
  only call to `MvPowerSeries.eval₂_mem_pow`.

A reader following the old paragraph would look for an adic hypothesis on two lemmas that do not
have one, and would not learn that exactly one result in the file needs the estimate.

## The fix

One paragraph rewritten to say what the signatures say: `PowerSeries.HasEval t` is what almost
everything asks for, the two membership results read their memberships off the factorisations, and
`formalUEval_sub_one_mem` is the single result that additionally takes the ideal and its adic
topology. Nothing else is touched.

## Scope

Documentation of existing code, which the repository rule makes always in scope and which needs no
fresh roadmap claim. Prose only — the declaration list is byte-identical to `main`, verified by
diffing the `theorem`/`def` lines before and after.

This does not collide with #4929 (`feat(FormalGroup): the involution at a parameter`, open, mine),
which also edits this module docstring but in its `Main results` and `Provenance` sections, twenty
or more lines away. Verified: `git merge-tree --write-tree` between the two branches exits 0.

## Gates run

| Gate | Result |
| --- | --- |
| `lake build` of the changed module | **pass** — `Build completed successfully (1995 jobs)`, 0 errors, 0 warnings |
| declaration-loss check against `main` | **pass** — `theorem`/`def` lines identical; prose-only |
| line length | **pass** — longest line 99 characters |
| axioms / module-system / full build / `lint-env` | CI (`pr-build`) |

Roadmap: EllipticCurves

Documentation of code already on `main`; the roadmap chiefly motivating the file is the
EllipticCurves formal-group ladder, milestone (iii). No new mathematics is added, so no roadmap
target is claimed.
