### PR TITLE
feat: complete the finite de Finetti API

### DIFF
--- a/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
@@ -36,6 +36,10 @@ eventwise rather than packaged in a new total-variation definition.
   finite population;
 * `TauCeti.Probability.sampleWithReplacement`: the mixture of finite powers of those empirical
   measures;
+* `TauCeti.Probability.sampleWithReplacement_eq_bind_pi_empiricalMeasureOfFintype`: its
+  product-mixture characterization;
+* `TauCeti.Probability.ExchangeableAt.finiteDeFinetti`: the paired eventwise finite de Finetti
+  bound;
 * `TauCeti.Probability.ExchangeableAt.prefixLaw_le_sampleWithReplacement_add` and
   `TauCeti.Probability.ExchangeableAt.sampleWithReplacement_le_prefixLaw_add`: the two sides of
   the finite de Finetti bound.
@@ -93,6 +97,14 @@ For a population law `ρ`, this is the `ρ`-mixture of the `ι`-fold product of 
 empirical probability measure. -/
 def sampleWithReplacement (ρ : Measure (κ → α)) : Measure (ι → α) :=
   ρ.bind fun x => (ProbabilityMeasure.pi fun _ : ι => empiricalMeasureOfFintype x).toMeasure
+
+/-- Sampling with replacement is the mixture of the finite product measures of the populations'
+empirical distributions. -/
+@[simp]
+theorem sampleWithReplacement_eq_bind_pi_empiricalMeasureOfFintype (ρ : Measure (κ → α)) :
+    sampleWithReplacement ρ =
+      ρ.bind fun x => (ProbabilityMeasure.pi fun _ : ι => empiricalMeasureOfFintype x).toMeasure :=
+  (rfl)
 
 /-- The product-measure mixture defining sampling with replacement is a measurable kernel. -/
 private theorem aemeasurable_pi_empiricalMeasureOfFintype (ρ : Measure (κ → α)) :
@@ -247,6 +259,21 @@ theorem ExchangeableAt.sampleWithReplacement_le_prefixLaw_add
   rw [← h.sampleWithoutReplacement_eq_prefixLaw hmn hX]
   simpa using sampleWithReplacement_le_sampleWithoutReplacement_add
     (ρ := prefixLaw μ X n) hA
+
+/-- **Finite de Finetti theorem.** If the first `n` coordinates of a process are exchangeable and
+`m ≤ n`, then its `m`-prefix law and the empirical-product mixture of its `n`-prefix law differ by
+at most `choose m 2 / n` on every measurable event, in both directions. -/
+theorem ExchangeableAt.finiteDeFinetti
+    {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → α} {m n : ℕ} [NeZero n] (h : ExchangeableAt μ X n) (hmn : m ≤ n)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) {A : Set (Fin m → α)}
+    (hA : MeasurableSet A) :
+    prefixLaw μ X m A ≤ sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A +
+        m.choose 2 / n ∧
+      sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A ≤ prefixLaw μ X m A +
+        m.choose 2 / n :=
+  ⟨h.prefixLaw_le_sampleWithReplacement_add hmn hX hA,
+    h.sampleWithReplacement_le_prefixLaw_add hmn hX hA⟩
 
 end FiniteExchangeability
 

--- a/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
+++ b/TauCeti/Probability/Exchangeability/FiniteDeFinetti.lean
@@ -225,41 +225,6 @@ end Sampling
 
 section FiniteExchangeability
 
-/-- **Quantitative finite de Finetti bound, exchangeable law to empirical mixture.** If the first
-`n` coordinates of a process are exchangeable and `m ≤ n`, then every measurable event under the
-`m`-prefix law has mass at most its mass under the mixture of `m`-fold products of the empirical
-distribution of the first `n` coordinates, plus `choose m 2 / n`. -/
-theorem ExchangeableAt.prefixLaw_le_sampleWithReplacement_add
-    {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
-    {X : ℕ → Ω → α} {m n : ℕ} [NeZero n] (h : ExchangeableAt μ X n) (hmn : m ≤ n)
-    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) {A : Set (Fin m → α)}
-    (hA : MeasurableSet A) :
-    prefixLaw μ X m A ≤ sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A +
-      m.choose 2 / n := by
-  let _ : IsProbabilityMeasure (prefixLaw μ X n) := by
-    rw [prefixLaw_def, blockLaw_def]
-    exact Measure.isProbabilityMeasure_map (aemeasurable_pi_lambda _ hX)
-  rw [← h.sampleWithoutReplacement_eq_prefixLaw hmn hX]
-  simpa using sampleWithoutReplacement_le_sampleWithReplacement_add
-    (ρ := prefixLaw μ X n) hA
-
-/-- **Quantitative finite de Finetti bound, empirical mixture to exchangeable law.** Under the
-same hypotheses, every measurable event under the empirical-product mixture has mass at most its
-mass under the `m`-prefix law plus `choose m 2 / n`. -/
-theorem ExchangeableAt.sampleWithReplacement_le_prefixLaw_add
-    {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
-    {X : ℕ → Ω → α} {m n : ℕ} [NeZero n] (h : ExchangeableAt μ X n) (hmn : m ≤ n)
-    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) {A : Set (Fin m → α)}
-    (hA : MeasurableSet A) :
-    sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A ≤ prefixLaw μ X m A +
-      m.choose 2 / n := by
-  let _ : IsProbabilityMeasure (prefixLaw μ X n) := by
-    rw [prefixLaw_def, blockLaw_def]
-    exact Measure.isProbabilityMeasure_map (aemeasurable_pi_lambda _ hX)
-  rw [← h.sampleWithoutReplacement_eq_prefixLaw hmn hX]
-  simpa using sampleWithReplacement_le_sampleWithoutReplacement_add
-    (ρ := prefixLaw μ X n) hA
-
 /-- **Finite de Finetti theorem.** If the first `n` coordinates of a process are exchangeable and
 `m ≤ n`, then its `m`-prefix law and the empirical-product mixture of its `n`-prefix law differ by
 at most `choose m 2 / n` on every measurable event, in both directions. -/
@@ -271,9 +236,41 @@ theorem ExchangeableAt.finiteDeFinetti
     prefixLaw μ X m A ≤ sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A +
         m.choose 2 / n ∧
       sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A ≤ prefixLaw μ X m A +
-        m.choose 2 / n :=
-  ⟨h.prefixLaw_le_sampleWithReplacement_add hmn hX hA,
-    h.sampleWithReplacement_le_prefixLaw_add hmn hX hA⟩
+        m.choose 2 / n := by
+  let _ : IsProbabilityMeasure (prefixLaw μ X n) := by
+    rw [prefixLaw_def, blockLaw_def]
+    exact Measure.isProbabilityMeasure_map (aemeasurable_pi_lambda _ hX)
+  rw [← h.sampleWithoutReplacement_eq_prefixLaw hmn hX]
+  constructor
+  · simpa using sampleWithoutReplacement_le_sampleWithReplacement_add
+      (ρ := prefixLaw μ X n) hA
+  · simpa using sampleWithReplacement_le_sampleWithoutReplacement_add
+      (ρ := prefixLaw μ X n) hA
+
+/-- **Quantitative finite de Finetti bound, exchangeable law to empirical mixture.** If the first
+`n` coordinates of a process are exchangeable and `m ≤ n`, then every measurable event under the
+`m`-prefix law has mass at most its mass under the mixture of `m`-fold products of the empirical
+distribution of the first `n` coordinates, plus `choose m 2 / n`. -/
+theorem ExchangeableAt.prefixLaw_le_sampleWithReplacement_add
+    {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → α} {m n : ℕ} [NeZero n] (h : ExchangeableAt μ X n) (hmn : m ≤ n)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) {A : Set (Fin m → α)}
+    (hA : MeasurableSet A) :
+    prefixLaw μ X m A ≤ sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A +
+      m.choose 2 / n :=
+  (h.finiteDeFinetti hmn hX hA).1
+
+/-- **Quantitative finite de Finetti bound, empirical mixture to exchangeable law.** Under the
+same hypotheses, every measurable event under the empirical-product mixture has mass at most its
+mass under the `m`-prefix law plus `choose m 2 / n`. -/
+theorem ExchangeableAt.sampleWithReplacement_le_prefixLaw_add
+    {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → α} {m n : ℕ} [NeZero n] (h : ExchangeableAt μ X n) (hmn : m ≤ n)
+    (hX : ∀ i : Fin n, AEMeasurable (X i.val) μ) {A : Set (Fin m → α)}
+    (hA : MeasurableSet A) :
+    sampleWithReplacement (ι := Fin m) (prefixLaw μ X n) A ≤ prefixLaw μ X m A +
+      m.choose 2 / n :=
+  (h.finiteDeFinetti hmn hX hA).2
 
 end FiniteExchangeability
 


### PR DESCRIPTION
This PR exposes the two remaining public presentation points of the Exchangeability roadmap's Layer 8 “finite de Finetti bounds” milestone: `sampleWithReplacement_eq_bind_pi_empiricalMeasureOfFintype` characterizes sampling with replacement as the mixture of finite product laws of empirical measures, and `ExchangeableAt.finiteDeFinetti` pairs the two sharp eventwise inequalities comparing an exchangeable prefix law with that empirical-product mixture.

The exact target is `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, “finite de Finetti bounds,” whose key milestones name `sampleWithReplacement_eq_bind_pi_empiricalMeasureOfFintype` and `ExchangeableAt.finiteDeFinetti`. The underlying representation and collision estimates were already proved on `main`; this PR gives the sealed definition its canonical bind lemma and packages the existing one-sided bounds under the roadmap's principal theorem name without duplicating their proofs. After this PR, nothing remains in the finite de Finetti bounds milestone; Layer 8 continues separately with countable-index extensions, affine decomposition, Markov exchangeability, and exchangeable arrays.

The mathematics follows P. Diaconis and D. Freedman, “Finite exchangeable sequences,” *Annals of Probability* 8 (1980), 745–764, as already credited in the module documentation. No Mathlib infrastructure or external formal code is vendored; the implementation reuses Tau Ceti's existing `sampleWithoutReplacement_eq_prefixLaw` and collision-bound theorems, whose construction consumes Mathlib's `Measure.bind` and `ProbabilityMeasure.pi` APIs.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"exchangeableat-finitedefinetti"}-->

🤖 Prepared with Codex
