### PR TITLE
feat(Topology): a topologically nilpotent element absorbs into an open subring

### DIFF
--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -212,32 +212,6 @@ theorem IsAdic.comap (e : B ≃+* A) (he : IsInducing e) {I : Ideal A} (h : IsAd
 
 end Transport
 
-section Absorb
-
-variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
-
-/-- **A topologically nilpotent element absorbs any element into any open subring.** For `s`
-topologically nilpotent and `B` open, `a * s ^ n` lies in `B` for all large `n`.
-
-This is the single-element form of `PairOfDefinition.exists_pow_idealOfDefinition_mul_mem`, and
-the same argument: multiplication by `a` is continuous, so `B` pulls back to a neighbourhood of
-`0`, and the powers of `s` converge to `0`. No Huber structure is used — only an open subring and
-a nilpotent element. -/
-theorem eventually_mul_pow_mem_of_isTopologicallyNilpotent {s : A}
-    (hs : IsTopologicallyNilpotent s) {B : Subring A} (hB : IsOpen (B : Set A)) (a : A) :
-    ∀ᶠ n : ℕ in Filter.atTop, a * s ^ n ∈ B :=
-  hs ((hB.preimage (continuous_const_mul a)).mem_nhds (by simp))
-
-/-- The existential form of `eventually_mul_pow_mem_of_isTopologicallyNilpotent`: some power of a
-topologically nilpotent element carries `a` into an open subring. This is the step Wedhorn's
-Lemma 7.44(1) uses to make `B_s → A_s` surjective. -/
-theorem exists_mul_pow_mem_of_isTopologicallyNilpotent {s : A}
-    (hs : IsTopologicallyNilpotent s) {B : Subring A} (hB : IsOpen (B : Set A)) (a : A) :
-    ∃ n : ℕ, a * s ^ n ∈ B :=
-  (eventually_mul_pow_mem_of_isTopologicallyNilpotent hs hB a).exists
-
-end Absorb
-
 namespace PairOfDefinition
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A]

--- a/TauCeti/RingTheory/Huber/Basic.lean
+++ b/TauCeti/RingTheory/Huber/Basic.lean
@@ -212,6 +212,32 @@ theorem IsAdic.comap (e : B ≃+* A) (he : IsInducing e) {I : Ideal A} (h : IsAd
 
 end Transport
 
+section Absorb
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
+
+/-- **A topologically nilpotent element absorbs any element into any open subring.** For `s`
+topologically nilpotent and `B` open, `a * s ^ n` lies in `B` for all large `n`.
+
+This is the single-element form of `PairOfDefinition.exists_pow_idealOfDefinition_mul_mem`, and
+the same argument: multiplication by `a` is continuous, so `B` pulls back to a neighbourhood of
+`0`, and the powers of `s` converge to `0`. No Huber structure is used — only an open subring and
+a nilpotent element. -/
+theorem eventually_mul_pow_mem_of_isTopologicallyNilpotent {s : A}
+    (hs : IsTopologicallyNilpotent s) {B : Subring A} (hB : IsOpen (B : Set A)) (a : A) :
+    ∀ᶠ n : ℕ in Filter.atTop, a * s ^ n ∈ B :=
+  hs ((hB.preimage (continuous_const_mul a)).mem_nhds (by simp))
+
+/-- The existential form of `eventually_mul_pow_mem_of_isTopologicallyNilpotent`: some power of a
+topologically nilpotent element carries `a` into an open subring. This is the step Wedhorn's
+Lemma 7.44(1) uses to make `B_s → A_s` surjective. -/
+theorem exists_mul_pow_mem_of_isTopologicallyNilpotent {s : A}
+    (hs : IsTopologicallyNilpotent s) {B : Subring A} (hB : IsOpen (B : Set A)) (a : A) :
+    ∃ n : ℕ, a * s ^ n ∈ B :=
+  (eventually_mul_pow_mem_of_isTopologicallyNilpotent hs hB a).exists
+
+end Absorb
+
 namespace PairOfDefinition
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A]

--- a/TauCeti/Topology/Algebra/TopologicallyNilpotent.lean
+++ b/TauCeti/Topology/Algebra/TopologicallyNilpotent.lean
@@ -25,6 +25,8 @@ parity `n` has.
 * `IsTopologicallyNilpotent.neg` : the negation of a topologically nilpotent element is
   topologically nilpotent.
 * `isTopologicallyNilpotent_neg` : the same fact as a `simp` iff, mirroring `isPowerBounded_neg`.
+* `eventually_mul_pow_mem_of_isTopologicallyNilpotent`, and its `.exists` form: a topologically
+  nilpotent element absorbs any fixed element into any open subring.
 
 ## Provenance
 
@@ -68,5 +70,32 @@ theorem IsTopologicallyNilpotent.neg {a : R} (ha : IsTopologicallyNilpotent a) :
 theorem isTopologicallyNilpotent_neg {a : R} :
     IsTopologicallyNilpotent (-a) ↔ IsTopologicallyNilpotent a :=
   ⟨fun h ↦ by simpa using h.neg, IsTopologicallyNilpotent.neg⟩
+
+
+section Absorb
+
+variable {A : Type*} [Ring A] [TopologicalSpace A] [ContinuousMul A]
+
+/-- **A topologically nilpotent element absorbs any element into any open subring.** For `s`
+topologically nilpotent and `B` open, `a * s ^ n` lies in `B` for all large `n`.
+
+Multiplication by `a` is continuous, so `B` pulls back to a neighbourhood of `0`, and the powers
+of `s` converge to `0`. Neither commutativity nor continuity of addition is used — only
+`ContinuousMul` — and no Huber structure enters, which is why this sits here rather than beside
+the ring-of-definition form it generalises,
+`TauCeti.Huber.PairOfDefinition.exists_pow_idealOfDefinition_mul_mem`. -/
+theorem eventually_mul_pow_mem_of_isTopologicallyNilpotent {s : A}
+    (hs : IsTopologicallyNilpotent s) {B : Subring A} (hB : IsOpen (B : Set A)) (a : A) :
+    ∀ᶠ n : ℕ in atTop, a * s ^ n ∈ B :=
+  hs ((hB.preimage (continuous_const_mul a)).mem_nhds (by simp))
+
+/-- The existential form of `eventually_mul_pow_mem_of_isTopologicallyNilpotent`: some power of a
+topologically nilpotent element carries `a` into an open subring. -/
+theorem exists_mul_pow_mem_of_isTopologicallyNilpotent {s : A}
+    (hs : IsTopologicallyNilpotent s) {B : Subring A} (hB : IsOpen (B : Set A)) (a : A) :
+    ∃ n : ℕ, a * s ^ n ∈ B :=
+  (eventually_mul_pow_mem_of_isTopologicallyNilpotent hs hB a).exists
+
+end Absorb
 
 end


### PR DESCRIPTION
For `s` topologically nilpotent and `B` an open subring of a topological ring `A`, the products `a * s ^ n` lie in `B` for all large `n`.

### What it adds

Two lemmas in `TauCeti/RingTheory/Huber/Basic.lean`:

* `TauCeti.Huber.eventually_mul_pow_mem_of_isTopologicallyNilpotent` — the `∀ᶠ` form;
* `TauCeti.Huber.exists_mul_pow_mem_of_isTopologicallyNilpotent` — its `.exists` corollary, which is the one the intended consumer uses.

This is the **single-element form** of `PairOfDefinition.exists_pow_idealOfDefinition_mul_mem`, which sits one section below in the same file and states the same absorption for the *ideal of definition*. The proof is the same argument: multiplication by `a` is continuous, so `B` pulls back to a neighbourhood of `0`, and the powers of `s` converge to `0` by the definition of `IsTopologicallyNilpotent`.

No Huber structure is used — only a topological ring, an open subring and a nilpotent element — so it lives in its own section, outside `namespace PairOfDefinition`. No new imports: `IsTopologicallyNilpotent` already resolves in this file through `Huber.PowerBounded`.

### Why now, and what this is *not*

It is the missing first step of **Wedhorn's Lemma 7.44(1)**: for a non-open prime `q` of `B` one picks a topologically nilpotent `s ∉ q`, and this absorption is exactly what makes `B_s → A_s` surjective, hence an isomorphism, hence `Γ_v = Γ_w`. That is what discharges the whole-codomain hypothesis of #4910's continuity criterion from the natural "the restriction is continuous".

**That localisation step is not in this PR, and this PR does not claim 7.44(1).** Naming a declaration after a lemma it does not prove is precisely the failure that blocked #4910 — an upstream docstring named a sufficient criterion "Wedhorn 7.44(2)", the claim propagated through a route table into a PR body, and the correctness rubric caught it. Not repeated here: the lemmas are named and documented for what they prove.

### Prior art

Verified absent before writing, at the current pin (main `79663ffa9`): a shape probe over `TauCeti/RingTheory/Huber/` for `s ^ n` / `x ^ n` together with membership in a subring returns nothing, against a resolving control of a 20-file `IsTopologicallyNilpotent` API (`exists_pow_lt_of_isTopologicallyNilpotent`, `isOpen_setOf_isTopologicallyNilpotent`, `Ideal.isOpen_of_isMaximal_of_isOpen_isTopologicallyNilpotent`, …). The AINTLIB adapt route was **not** used and is explicitly dead for this material.

### Gates

`lake build` of the changed module and **all sixteen** direct importers — exit 0, "Build completed successfully (2894 jobs)", zero log matches for `error`, `warning`, `info:` and `Try this`/`Try these`. `#print axioms` on both lemmas: `[propext, Classical.choice, Quot.sound]`. `scripts/lint-style.sh` exit 0, 3764 conforming headers; no line over 100 codepoints.

Roadmap: AdicSpaces

Target: AdicSpaces README Layer 3.3 / the Wedhorn 7.49 chain — 7.44(1) feeds 7.44(3), which 7.45 and 7.49(2) both invoke for existence of a continuous extension.
