### PR TITLE
feat: compute coderivation square components

### DIFF
--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -38,8 +38,8 @@ downstream, in the `DGAInfinity` roadmap.
 * `TauCeti.ReducedTensorWords.IsCoderivation`: the co-Leibniz rule.
 * `TauCeti.ReducedTensorWords.coderiv`: the coderivation with prescribed Taylor components.
 * `TauCeti.ReducedTensorWords.coderivations`: the submodule of coderivations.
-* `TauCeti.ReducedTensorWords.taylorComponent`: the arity component of a linear endomorphism of
-  reduced tensor words.
+* `LinearMap.taylorComponent`: the arity component of a linear endomorphism of reduced tensor
+  words.
 
 ## Main results
 
@@ -505,7 +505,15 @@ theorem coderivEquivTaylor_symm_apply (F : ReducedTensorWords R M →ₗ[R] M) :
     (coderivEquivTaylor R M).symm F =
       ⟨coderiv R F, (mem_coderivations R M).2 (isCoderivation_coderiv R F)⟩ := (rfl)
 
-variable {R M}
+end ReducedTensorWords
+
+end TauCeti
+
+namespace LinearMap
+
+open TauCeti TauCeti.ReducedTensorWords
+
+variable {R : Type uR} {M : Type uM} [CommSemiring R] [AddCommMonoid M] [Module R M]
 
 /-- The arity-`n` piece of the Taylor component `letter R M ∘ₗ b`: restrict to words of length
 `n`, apply the endomorphism, and retain its length-one component. -/
@@ -551,27 +559,36 @@ theorem taylorComponent_smul (r : R)
     taylorComponent (r • b) n = r • taylorComponent b n := by
   simp only [taylorComponent, LinearMap.comp_smul, LinearMap.smul_comp]
 
+end LinearMap
+
+namespace TauCeti
+
+namespace ReducedTensorWords
+
+variable {R : Type uR} {M : Type uM} [CommSemiring R] [AddCommMonoid M] [Module R M]
+
 /-- A coderivation vanishes exactly when each of its aritywise Taylor components vanishes. -/
 theorem IsCoderivation.eq_zero_iff_taylorComponent_eq_zero
     {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} (hb : IsCoderivation R b) :
-    b = 0 ↔ ∀ n, taylorComponent b n = 0 := by
+    b = 0 ↔ ∀ n, b.taylorComponent n = 0 := by
   constructor
   · rintro rfl n
-    exact taylorComponent_zero n
+    exact LinearMap.taylorComponent_zero n
   · intro h
     have hzero := (mem_coderivations R M).1 (coderivations R M).zero_mem
     apply hb.eq_of_letter_comp_eq hzero
     apply linearMap_ext R M
     intro n x
     have hn := LinearMap.congr_fun (h n) (PiTensorProduct.tprod R x)
-    simpa only [taylorComponent_apply, LinearMap.comp_apply, LinearMap.zero_apply, map_zero]
+    simpa only [LinearMap.taylorComponent_apply, LinearMap.comp_apply, LinearMap.zero_apply,
+      map_zero]
       using hn
 
 /-- A coderivation vanishes exactly when every arity component vanishes on pure tensors. -/
 theorem IsCoderivation.eq_zero_iff_taylorComponent_tprod_eq_zero
     {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} (hb : IsCoderivation R b) :
     b = 0 ↔ ∀ n (x : Fin n.1 → M),
-      taylorComponent b n (PiTensorProduct.tprod R x) = 0 := by
+      b.taylorComponent n (PiTensorProduct.tprod R x) = 0 := by
   rw [hb.eq_zero_iff_taylorComponent_eq_zero]
   constructor
   · intro h n x

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -514,14 +514,9 @@ noncomputable def taylorComponent
     TensorPower R n.1 M →ₗ[R] M :=
   (letter R M ∘ₗ b) ∘ₗ of R M n
 
-/-- A Taylor arity component as a composite of linear maps. -/
-theorem taylorComponent_def
-    (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n}) :
-    taylorComponent b n = (letter R M ∘ₗ b) ∘ₗ of R M n :=
-  (rfl)
-
 /-- Evaluation of a Taylor arity component is restriction to words of the specified length
 followed by projection to letters. -/
+@[simp]
 theorem taylorComponent_apply
     (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n})
     (x : TensorPower R n.1 M) :
@@ -532,14 +527,14 @@ theorem taylorComponent_apply
 @[simp]
 theorem taylorComponent_zero (n : {n : ℕ // 0 < n}) :
     taylorComponent (0 : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) n = 0 := by
-  rw [taylorComponent_def, LinearMap.comp_zero, LinearMap.zero_comp]
+  rw [taylorComponent, LinearMap.comp_zero, LinearMap.zero_comp]
 
 /-- The arity components of `coderiv F` are the restrictions of `F` to each tensor length. -/
 @[simp]
 theorem taylorComponent_coderiv (F : ReducedTensorWords R M →ₗ[R] M)
     (n : {n : ℕ // 0 < n}) :
     taylorComponent (coderiv R F) n = F ∘ₗ of R M n := by
-  rw [taylorComponent_def, letter_comp_coderiv]
+  rw [taylorComponent, letter_comp_coderiv]
 
 /-- Taking an arity component preserves addition of endomorphisms. -/
 @[simp]
@@ -547,14 +542,14 @@ theorem taylorComponent_add
     (b₁ b₂ : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M)
     (n : {n : ℕ // 0 < n}) :
     taylorComponent (b₁ + b₂) n = taylorComponent b₁ n + taylorComponent b₂ n := by
-  simp only [taylorComponent_def, LinearMap.comp_add, LinearMap.add_comp]
+  simp only [taylorComponent, LinearMap.comp_add, LinearMap.add_comp]
 
 /-- Taking an arity component preserves scalar multiplication of endomorphisms. -/
 @[simp]
 theorem taylorComponent_smul (r : R)
     (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n}) :
     taylorComponent (r • b) n = r • taylorComponent b n := by
-  simp only [taylorComponent_def, LinearMap.comp_smul, LinearMap.smul_comp]
+  simp only [taylorComponent, LinearMap.comp_smul, LinearMap.smul_comp]
 
 /-- A coderivation vanishes exactly when each of its aritywise Taylor components vanishes. -/
 theorem IsCoderivation.eq_zero_iff_taylorComponent_eq_zero

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -522,7 +522,6 @@ theorem taylorComponent_def
 
 /-- Evaluation of a Taylor arity component is restriction to words of the specified length
 followed by projection to letters. -/
-@[simp]
 theorem taylorComponent_apply
     (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n})
     (x : TensorPower R n.1 M) :

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -38,6 +38,8 @@ downstream, in the `DGAInfinity` roadmap.
 * `TauCeti.ReducedTensorWords.IsCoderivation`: the co-Leibniz rule.
 * `TauCeti.ReducedTensorWords.coderiv`: the coderivation with prescribed Taylor components.
 * `TauCeti.ReducedTensorWords.coderivations`: the submodule of coderivations.
+* `TauCeti.ReducedTensorWords.taylorComponent`: the arity component of a linear endomorphism of
+  reduced tensor words.
 
 ## Main results
 
@@ -48,6 +50,8 @@ downstream, in the `DGAInfinity` roadmap.
   components `F`.
 * `TauCeti.ReducedTensorWords.coderivEquivTaylor`: coderivations are linearly isomorphic to their
   Taylor components.
+* `TauCeti.ReducedTensorWords.IsCoderivation.eq_zero_iff_taylorComponent_eq_zero`: a coderivation
+  vanishes exactly when all of its arity components vanish.
 
 ## References
 
@@ -500,6 +504,65 @@ theorem coderivEquivTaylor_apply (b : coderivations R M) :
 theorem coderivEquivTaylor_symm_apply (F : ReducedTensorWords R M →ₗ[R] M) :
     (coderivEquivTaylor R M).symm F =
       ⟨coderiv R F, (mem_coderivations R M).2 (isCoderivation_coderiv R F)⟩ := (rfl)
+
+variable {R M}
+
+/-- The arity-`n` piece of the Taylor component `letter R M ∘ₗ b`: restrict to words of length
+`n`, apply the endomorphism, and retain its length-one component. -/
+noncomputable def taylorComponent
+    (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n}) :
+    TensorPower R n.1 M →ₗ[R] M :=
+  (letter R M ∘ₗ b) ∘ₗ of R M n
+
+/-- A Taylor arity component as a composite of linear maps. -/
+theorem taylorComponent_def
+    (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n}) :
+    taylorComponent b n = (letter R M ∘ₗ b) ∘ₗ of R M n :=
+  (rfl)
+
+/-- Evaluation of a Taylor arity component is restriction to words of the specified length
+followed by projection to letters. -/
+@[simp]
+theorem taylorComponent_apply
+    (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n})
+    (x : TensorPower R n.1 M) :
+    taylorComponent b n x = letter R M (b (of R M n x)) :=
+  (rfl)
+
+/-- Every arity component of the zero endomorphism is zero. -/
+@[simp]
+theorem taylorComponent_zero (n : {n : ℕ // 0 < n}) :
+    taylorComponent (0 : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) n = 0 := by
+  rw [taylorComponent_def, LinearMap.comp_zero, LinearMap.zero_comp]
+
+/-- A coderivation vanishes exactly when each of its aritywise Taylor components vanishes. -/
+theorem IsCoderivation.eq_zero_iff_taylorComponent_eq_zero
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} (hb : IsCoderivation R b) :
+    b = 0 ↔ ∀ n, taylorComponent b n = 0 := by
+  constructor
+  · rintro rfl n
+    exact taylorComponent_zero n
+  · intro h
+    have hzero := (mem_coderivations R M).1 (coderivations R M).zero_mem
+    apply hb.eq_of_letter_comp_eq hzero
+    apply linearMap_ext R M
+    intro n x
+    have hn := LinearMap.congr_fun (h n) (PiTensorProduct.tprod R x)
+    simpa only [taylorComponent_apply, LinearMap.comp_apply, LinearMap.zero_apply, map_zero]
+      using hn
+
+/-- A coderivation vanishes exactly when every arity component vanishes on pure tensors. -/
+theorem IsCoderivation.eq_zero_iff_taylorComponent_tprod_eq_zero
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} (hb : IsCoderivation R b) :
+    b = 0 ↔ ∀ n (x : Fin n.1 → M),
+      taylorComponent b n (PiTensorProduct.tprod R x) = 0 := by
+  rw [hb.eq_zero_iff_taylorComponent_eq_zero]
+  constructor
+  · intro h n x
+    rw [h n, LinearMap.zero_apply]
+  · intro h n
+    refine PiTensorProduct.ext (MultilinearMap.ext fun x ↦ ?_)
+    simpa only [LinearMap.compMultilinearMap_apply, LinearMap.zero_apply] using h n x
 
 end ReducedTensorWords
 

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/Coderivation.lean
@@ -535,6 +535,28 @@ theorem taylorComponent_zero (n : {n : ℕ // 0 < n}) :
     taylorComponent (0 : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) n = 0 := by
   rw [taylorComponent_def, LinearMap.comp_zero, LinearMap.zero_comp]
 
+/-- The arity components of `coderiv F` are the restrictions of `F` to each tensor length. -/
+@[simp]
+theorem taylorComponent_coderiv (F : ReducedTensorWords R M →ₗ[R] M)
+    (n : {n : ℕ // 0 < n}) :
+    taylorComponent (coderiv R F) n = F ∘ₗ of R M n := by
+  rw [taylorComponent_def, letter_comp_coderiv]
+
+/-- Taking an arity component preserves addition of endomorphisms. -/
+@[simp]
+theorem taylorComponent_add
+    (b₁ b₂ : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M)
+    (n : {n : ℕ // 0 < n}) :
+    taylorComponent (b₁ + b₂) n = taylorComponent b₁ n + taylorComponent b₂ n := by
+  simp only [taylorComponent_def, LinearMap.comp_add, LinearMap.add_comp]
+
+/-- Taking an arity component preserves scalar multiplication of endomorphisms. -/
+@[simp]
+theorem taylorComponent_smul (r : R)
+    (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n}) :
+    taylorComponent (r • b) n = r • taylorComponent b n := by
+  simp only [taylorComponent_def, LinearMap.comp_smul, LinearMap.smul_comp]
+
 /-- A coderivation vanishes exactly when each of its aritywise Taylor components vanishes. -/
 theorem IsCoderivation.eq_zero_iff_taylorComponent_eq_zero
     {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} (hb : IsCoderivation R b) :

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
@@ -705,10 +705,10 @@ Taylor map to words of length `n`. -/
 @[simp]
 theorem ReducedTensorWords.taylorComponent_gradedCoderiv (G : InternalGrading R M)
     (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ) (n : {n : ℕ // 0 < n}) :
-    taylorComponent (gradedCoderiv G F q) n = F ∘ₗ of R M n := by
+    (gradedCoderiv G F q).taylorComponent n = F ∘ₗ of R M n := by
   apply LinearMap.ext
   intro x
-  simp only [taylorComponent_apply, LinearMap.comp_apply]
+  simp only [LinearMap.taylorComponent_apply, LinearMap.comp_apply]
   rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv]
 
 /-- A graded coderivation whose letter component raises degrees by `r` raises degrees by `r`:

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
@@ -734,9 +734,8 @@ theorem ReducedTensorWords.map_koszulTwist_comp_self (G : InternalGrading R M) (
     ReducedTensorWords.map_id]
 
 /-- The square of a graded coderivation anticommuting with the letterwise Koszul twist is an
-ordinary coderivation.  The anticommutation relation expresses oddness when `q` is odd and cancels
-the two mixed terms after applying the graded co-Leibniz rule twice.  For even `q`, the twist is the
-identity and the hypothesis instead reduces to `b + b = 0`. -/
+ordinary coderivation.  The anticommutation relation expresses oddness when `q` is odd.  For even
+`q`, the twist is the identity and the hypothesis instead reduces to `b + b = 0`. -/
 theorem ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self
     {G : InternalGrading R M} {q : ℤ}
     {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
@@ -706,7 +706,10 @@ Taylor map to words of length `n`. -/
 theorem ReducedTensorWords.taylorComponent_gradedCoderiv (G : InternalGrading R M)
     (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ) (n : {n : ℕ // 0 < n}) :
     taylorComponent (gradedCoderiv G F q) n = F ∘ₗ of R M n := by
-  rw [taylorComponent_def, letter_comp_gradedCoderiv]
+  apply LinearMap.ext
+  intro x
+  simp only [taylorComponent_apply, LinearMap.comp_apply]
+  rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv]
 
 /-- A graded coderivation whose letter component raises degrees by `r` raises degrees by `r`:
 being determined by its letter component, it inherits homogeneity from it. The twist parameter
@@ -723,15 +726,6 @@ theorem ReducedTensorWords.IsGradedCoderivation.isHomogeneous {G : InternalGradi
 end Letter
 
 /-! ### Squares of anticommuting graded coderivations -/
-
-/-- Applying the same Koszul twist twice to every letter of a tensor word is the identity. -/
-@[simp]
-theorem ReducedTensorWords.map_koszulTwist_comp_self (G : InternalGrading R M) (q : ℤ) :
-    ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ
-        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) =
-      LinearMap.id := by
-  rw [← ReducedTensorWords.map_comp, InternalGrading.koszulTwist_comp_self,
-    ReducedTensorWords.map_id]
 
 /-- The square of a graded coderivation anticommuting with the letterwise Koszul twist is an
 ordinary coderivation.  The anticommutation relation expresses oddness when `q` is odd.  For even
@@ -787,7 +781,9 @@ theorem ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self
             (LinearMap.lTensor (ReducedTensorWords R M) b
               (LinearMap.rTensor (ReducedTensorWords R M) τ w))) =
         LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
-    have hτ : τ ∘ₗ τ = LinearMap.id := map_koszulTwist_comp_self G q
+    have hτ : τ ∘ₗ τ = LinearMap.id := by
+      rw [← ReducedTensorWords.map_comp, InternalGrading.koszulTwist_comp_self,
+        ReducedTensorWords.map_id]
     rw [hcommute, ← LinearMap.lTensor_comp_apply, ← LinearMap.rTensor_comp_apply,
       hτ, LinearMap.rTensor_id_apply]
   rw [hfirst, hcrossLeft, hcrossRight, hlast]

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
@@ -806,29 +806,6 @@ theorem ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self
         LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
       rw [hcross, add_zero]
 
-/-- Under anticommutation with the letterwise Koszul twist, a graded coderivation squares to zero
-exactly when all Taylor arity component maps of its square vanish. -/
-theorem ReducedTensorWords.IsGradedCoderivation.comp_self_eq_zero_iff_taylorComponent_eq_zero
-    {G : InternalGrading R M} {q : ℤ}
-    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
-    (hb : IsGradedCoderivation G q b)
-    (hanti : b ∘ₗ ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) +
-        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ b = 0) :
-    b ∘ₗ b = 0 ↔ ∀ n, taylorComponent (b ∘ₗ b) n = 0 :=
-  (hb.isCoderivation_comp_self hanti).eq_zero_iff_taylorComponent_eq_zero
-
-/-- Under anticommutation with the letterwise Koszul twist, a graded coderivation squares to zero
-exactly when all Taylor arity components of its square vanish on pure tensors. -/
-theorem ReducedTensorWords.IsGradedCoderivation.comp_self_eq_zero_iff_taylorComponent_tprod_eq_zero
-    {G : InternalGrading R M} {q : ℤ}
-    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
-    (hb : IsGradedCoderivation G q b)
-    (hanti : b ∘ₗ ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) +
-        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ b = 0) :
-    b ∘ₗ b = 0 ↔ ∀ n (x : Fin n.1 → M),
-      taylorComponent (b ∘ₗ b) n (PiTensorProduct.tprod R x) = 0 :=
-  (hb.isCoderivation_comp_self hanti).eq_zero_iff_taylorComponent_tprod_eq_zero
-
 /-! ### Twist parameter zero -/
 
 /-- A `0`-twisted graded coderivation is a coderivation: the twist of parameter zero is the

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
@@ -56,6 +56,8 @@ by `isHomogeneous_gradedCoderiv` and `IsGradedCoderivation.isHomogeneous`.
   coderivation with letter component `F`.
 * `TauCeti.ReducedTensorWords.IsGradedCoderivation.eq_of_letter_comp_eq`: a graded coderivation is
   determined by its letter component.
+* `TauCeti.ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self`: the square of an odd
+  graded coderivation is an ordinary coderivation.
 * `TauCeti.ReducedTensorWords.isHomogeneous_gradedCoderiv`: if `F` raises degrees by `r` then so
   does `gradedCoderiv G F q`, independently of the twist parameter.
 * `TauCeti.ReducedTensorWords.gradedCoderivEquivTaylor`: the `q`-twisted coderivations form a
@@ -711,6 +713,89 @@ theorem ReducedTensorWords.IsGradedCoderivation.isHomogeneous {G : InternalGradi
   exact isHomogeneous_gradedCoderiv G (letter R M ∘ₗ b) q r hhom
 
 end Letter
+
+/-! ### Squares of odd graded coderivations -/
+
+/-- Applying the same Koszul twist twice to every letter of a tensor word is the identity. -/
+@[simp]
+theorem ReducedTensorWords.map_koszulTwist_comp_self (G : InternalGrading R M) (q : ℤ) :
+    ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ
+        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) =
+      LinearMap.id := by
+  rw [← ReducedTensorWords.map_comp, InternalGrading.koszulTwist_comp_self,
+    ReducedTensorWords.map_id]
+
+/-- The square of an odd graded coderivation is an ordinary coderivation.  Here oddness is stated
+intrinsically as anticommutation with the letterwise Koszul twist; this is exactly the relation
+that cancels the two mixed terms after applying the graded co-Leibniz rule twice. -/
+theorem ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self
+    {G : InternalGrading R M} {q : ℤ}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
+    (hb : IsGradedCoderivation G q b)
+    (hodd : b ∘ₗ ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) +
+        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ b = 0) :
+    IsCoderivation R (b ∘ₗ b) := by
+  rw [isCoderivation_iff]
+  apply LinearMap.ext
+  intro z
+  simp only [LinearMap.comp_apply, LinearMap.add_apply]
+  rw [hb.deconcatenation_apply (b z), hb.deconcatenation_apply z]
+  simp only [map_add]
+  let τ := ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q)
+  let w := deconcatenation R M z
+  have hfirst :
+      LinearMap.rTensor (ReducedTensorWords R M) b
+          (LinearMap.rTensor (ReducedTensorWords R M) b w) =
+        LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
+    rw [← LinearMap.rTensor_comp_apply]
+  have hcrossLeft :
+      LinearMap.rTensor (ReducedTensorWords R M) b
+          (LinearMap.lTensor (ReducedTensorWords R M) b
+            (LinearMap.rTensor (ReducedTensorWords R M) τ w)) =
+        TensorProduct.map (b ∘ₗ τ) b w := by
+    rw [← LinearMap.comp_apply, LinearMap.rTensor_comp_lTensor, LinearMap.map_rTensor]
+  have hcrossRight :
+      LinearMap.lTensor (ReducedTensorWords R M) b
+          (LinearMap.rTensor (ReducedTensorWords R M) τ
+            (LinearMap.rTensor (ReducedTensorWords R M) b w)) =
+        TensorProduct.map (τ ∘ₗ b) b w := by
+    rw [← LinearMap.rTensor_comp_apply, ← LinearMap.comp_apply,
+      LinearMap.lTensor_comp_rTensor]
+  have hcross :
+      TensorProduct.map (b ∘ₗ τ) b w + TensorProduct.map (τ ∘ₗ b) b w = 0 := by
+    have hodd' : b ∘ₗ τ + τ ∘ₗ b = 0 := hodd
+    rw [← LinearMap.add_apply, ← TensorProduct.map_add_left,
+      hodd', TensorProduct.map_zero_left, LinearMap.zero_apply]
+  have hcommute (y : ReducedTensorWords R M ⊗[R] ReducedTensorWords R M) :
+      LinearMap.rTensor (ReducedTensorWords R M) τ
+          (LinearMap.lTensor (ReducedTensorWords R M) b y) =
+        LinearMap.lTensor (ReducedTensorWords R M) b
+          (LinearMap.rTensor (ReducedTensorWords R M) τ y) := by
+    rw [← LinearMap.comp_apply, LinearMap.rTensor_comp_lTensor,
+      ← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor]
+  have hlast :
+      LinearMap.lTensor (ReducedTensorWords R M) b
+          (LinearMap.rTensor (ReducedTensorWords R M) τ
+            (LinearMap.lTensor (ReducedTensorWords R M) b
+              (LinearMap.rTensor (ReducedTensorWords R M) τ w))) =
+        LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
+    have hτ : τ ∘ₗ τ = LinearMap.id := map_koszulTwist_comp_self G q
+    rw [hcommute, ← LinearMap.lTensor_comp_apply, ← LinearMap.rTensor_comp_apply,
+      hτ, LinearMap.rTensor_id_apply]
+  rw [hfirst, hcrossLeft, hcrossRight, hlast]
+  calc
+    (LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
+          TensorProduct.map (b ∘ₗ τ) b w) +
+        (TensorProduct.map (τ ∘ₗ b) b w +
+          LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w) =
+      LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
+          (TensorProduct.map (b ∘ₗ τ) b w +
+            TensorProduct.map (τ ∘ₗ b) b w) +
+        LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
+          ac_rfl
+    _ = LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
+        LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
+      rw [hcross, add_zero]
 
 /-! ### Twist parameter zero -/
 

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/GradedCoderivation.lean
@@ -56,8 +56,8 @@ by `isHomogeneous_gradedCoderiv` and `IsGradedCoderivation.isHomogeneous`.
   coderivation with letter component `F`.
 * `TauCeti.ReducedTensorWords.IsGradedCoderivation.eq_of_letter_comp_eq`: a graded coderivation is
   determined by its letter component.
-* `TauCeti.ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self`: the square of an odd
-  graded coderivation is an ordinary coderivation.
+* `TauCeti.ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self`: a graded coderivation
+  anticommuting with its letterwise Koszul twist has an ordinary coderivation as its square.
 * `TauCeti.ReducedTensorWords.isHomogeneous_gradedCoderiv`: if `F` raises degrees by `r` then so
   does `gradedCoderiv G F q`, independently of the twist parameter.
 * `TauCeti.ReducedTensorWords.gradedCoderivEquivTaylor`: the `q`-twisted coderivations form a
@@ -700,6 +700,14 @@ theorem ReducedTensorWords.letter_comp_gradedCoderiv (G : InternalGrading R M)
     · exact letter_splice_self R (twistedTuple G q x 0 0)
         (F (subword R x 0 n)) hn (by omega)
 
+/-- The arity-`n` component of a graded Taylor expansion is the restriction of its defining
+Taylor map to words of length `n`. -/
+@[simp]
+theorem ReducedTensorWords.taylorComponent_gradedCoderiv (G : InternalGrading R M)
+    (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ) (n : {n : ℕ // 0 < n}) :
+    taylorComponent (gradedCoderiv G F q) n = F ∘ₗ of R M n := by
+  rw [taylorComponent_def, letter_comp_gradedCoderiv]
+
 /-- A graded coderivation whose letter component raises degrees by `r` raises degrees by `r`:
 being determined by its letter component, it inherits homogeneity from it. The twist parameter
 `q` of the co-Leibniz identity is independent of this shift. -/
@@ -714,7 +722,7 @@ theorem ReducedTensorWords.IsGradedCoderivation.isHomogeneous {G : InternalGradi
 
 end Letter
 
-/-! ### Squares of odd graded coderivations -/
+/-! ### Squares of anticommuting graded coderivations -/
 
 /-- Applying the same Koszul twist twice to every letter of a tensor word is the identity. -/
 @[simp]
@@ -725,9 +733,10 @@ theorem ReducedTensorWords.map_koszulTwist_comp_self (G : InternalGrading R M) (
   rw [← ReducedTensorWords.map_comp, InternalGrading.koszulTwist_comp_self,
     ReducedTensorWords.map_id]
 
-/-- The square of an odd graded coderivation is an ordinary coderivation.  Here oddness is stated
-intrinsically as anticommutation with the letterwise Koszul twist; this is exactly the relation
-that cancels the two mixed terms after applying the graded co-Leibniz rule twice. -/
+/-- The square of a graded coderivation anticommuting with the letterwise Koszul twist is an
+ordinary coderivation.  The anticommutation relation expresses oddness when `q` is odd and cancels
+the two mixed terms after applying the graded co-Leibniz rule twice.  For even `q`, the twist is the
+identity and the hypothesis instead reduces to `b + b = 0`. -/
 theorem ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self
     {G : InternalGrading R M} {q : ℤ}
     {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
@@ -796,6 +805,29 @@ theorem ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self
     _ = LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
         LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
       rw [hcross, add_zero]
+
+/-- Under anticommutation with the letterwise Koszul twist, a graded coderivation squares to zero
+exactly when all Taylor arity component maps of its square vanish. -/
+theorem ReducedTensorWords.IsGradedCoderivation.comp_self_eq_zero_iff_taylorComponent_eq_zero
+    {G : InternalGrading R M} {q : ℤ}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
+    (hb : IsGradedCoderivation G q b)
+    (hanti : b ∘ₗ ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) +
+        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ b = 0) :
+    b ∘ₗ b = 0 ↔ ∀ n, taylorComponent (b ∘ₗ b) n = 0 :=
+  (hb.isCoderivation_comp_self hanti).eq_zero_iff_taylorComponent_eq_zero
+
+/-- Under anticommutation with the letterwise Koszul twist, a graded coderivation squares to zero
+exactly when all Taylor arity components of its square vanish on pure tensors. -/
+theorem ReducedTensorWords.IsGradedCoderivation.comp_self_eq_zero_iff_taylorComponent_tprod_eq_zero
+    {G : InternalGrading R M} {q : ℤ}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
+    (hb : IsGradedCoderivation G q b)
+    (hanti : b ∘ₗ ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) +
+        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ b = 0) :
+    b ∘ₗ b = 0 ↔ ∀ n (x : Fin n.1 → M),
+      taylorComponent (b ∘ₗ b) n (PiTensorProduct.tprod R x) = 0 :=
+  (hb.isCoderivation_comp_self hanti).eq_zero_iff_taylorComponent_tprod_eq_zero
 
 /-! ### Twist parameter zero -/
 

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
@@ -30,9 +30,9 @@ identity and the hypothesis reduces to `b + b = 0`.
 
 ## Main results
 
-* `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod`: the
-  arity formula for a composite of two graded Taylor expansions.
-* `taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod_of_homogeneous`:
+* `TauCeti.ReducedTensorWords.taylorComponent_comp_gradedCoderiv_of_tprod`: the arity formula for
+  composing an endomorphism with a graded Taylor expansion.
+* `taylorComponent_comp_gradedCoderiv_of_tprod_of_homogeneous`:
   the corresponding signed formula on homogeneous letters.
 
 ## References
@@ -55,28 +55,27 @@ section Ring
 
 variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
 
-/-- The Taylor component of a composite of graded Taylor expansions is obtained by applying the
-outer Taylor map to every signed nonempty one-block collapse made by the inner expansion.  Only
-the inner twist parameter occurs in the resulting formula. -/
-theorem taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod
-    (G : InternalGrading R M)
-    (F₁ : ReducedTensorWords R M →ₗ[R] M) (q₁ : ℤ)
+/-- The Taylor component of an endomorphism composed with a graded Taylor expansion is obtained by
+applying the outer endomorphism's letter component to every signed nonempty one-block collapse
+made by the inner expansion. -/
+theorem taylorComponent_comp_gradedCoderiv_of_tprod
+    (G : InternalGrading R M) (b₁ : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M)
     (F₂ : ReducedTensorWords R M →ₗ[R] M) (q₂ : ℤ)
     {n : ℕ} (hn : 0 < n) (x : Fin n → M) :
-    taylorComponent (gradedCoderiv G F₁ q₁ ∘ₗ gradedCoderiv G F₂ q₂) ⟨n, hn⟩
+    taylorComponent (b₁ ∘ₗ gradedCoderiv G F₂ q₂) ⟨n, hn⟩
         (PiTensorProduct.tprod R x) =
       ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
-        F₁ (splice R (InternalGrading.twistedTuple G q₂ x 0 p) 0 n p d
+        (letter R M ∘ₗ b₁) (splice R (InternalGrading.twistedTuple G q₂ x 0 p) 0 n p d
           (F₂ (subword R x p d))) := by
   calc
     _ = ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
-        F₁ (splice R (InternalGrading.twistedTuple G q₂ x 0 p) 0 n p d
+        (letter R M ∘ₗ b₁) (splice R (InternalGrading.twistedTuple G q₂ x 0 p) 0 n p d
           (F₂ (subword R x p d))) := by
       rw [taylorComponent_apply]
       simp only [LinearMap.comp_apply]
-      rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv,
-        gradedCoderiv_of_tprod, map_sum]
-      exact Finset.sum_congr rfl fun p _ ↦ by rw [map_sum]
+      rw [← LinearMap.comp_apply (letter R M), gradedCoderiv_of_tprod, map_sum]
+      exact Finset.sum_congr rfl fun p _ ↦ by
+        simp only [map_sum, LinearMap.comp_apply]
     _ = _ := by
       refine Finset.sum_congr rfl fun p hp ↦ ?_
       apply (Finset.sum_subset ?_ ?_).symm
@@ -92,22 +91,21 @@ theorem taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod
           omega
         rw [splice_eq_zero_of_not_fits R _ _ hfit, map_zero]
 
-/-- On homogeneous inputs, the Taylor component of a composite is an insertion sum with the
+/-- On homogeneous inputs, the Taylor component of such a composite is an insertion sum with the
 Koszul sign contributed by the inner twist and the degrees of the letters preceding the inserted
 operation. -/
-theorem taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod_of_homogeneous
-    (G : InternalGrading R M)
-    (F₁ : ReducedTensorWords R M →ₗ[R] M) (q₁ : ℤ)
+theorem taylorComponent_comp_gradedCoderiv_of_tprod_of_homogeneous
+    (G : InternalGrading R M) (b₁ : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M)
     (F₂ : ReducedTensorWords R M →ₗ[R] M) (q₂ : ℤ)
     {n : ℕ} (hn : 0 < n) (x : Fin n → M) (𝒟 : Fin n → ℤ)
     (hx : ∀ i, x i ∈ G.piece (𝒟 i)) :
-    taylorComponent (gradedCoderiv G F₁ q₁ ∘ₗ gradedCoderiv G F₂ q₂) ⟨n, hn⟩
+    taylorComponent (b₁ ∘ₗ gradedCoderiv G F₂ q₂) ⟨n, hn⟩
         (PiTensorProduct.tprod R x) =
       ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
         (((q₂ * ∑ j ∈ Finset.range p,
           if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
-          F₁ (splice R x 0 n p d (F₂ (subword R x p d))) := by
-  rw [taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod G F₁ q₁ F₂ q₂ hn x]
+          (letter R M ∘ₗ b₁) (splice R x 0 n p d (F₂ (subword R x p d))) := by
+  rw [taylorComponent_comp_gradedCoderiv_of_tprod G b₁ F₂ q₂ hn x]
   refine Finset.sum_congr rfl fun p _ ↦ ?_
   refine Finset.sum_congr rfl fun d _ ↦ ?_
   rw [splice_twistedTuple_smul G q₂ x 𝒟 hx p d, map_smul]

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
@@ -11,8 +11,8 @@ public import TauCeti.LinearAlgebra.TensorCoalgebra.GradedCoderivation
 # Taylor components of composites of graded Taylor expansions
 
 For the reduced tensor coalgebra `Tᶜ(M)`, the arity-`n` Taylor component of an endomorphism,
-defined in `TauCeti.LinearAlgebra.TensorCoalgebra.Coderivation`, is its restriction to words of
-length `n`, followed by projection to words of length one.
+`LinearMap.taylorComponent`, is its restriction to words of length `n`, followed by projection to
+words of length one.
 
 This file computes the Taylor components of a composite of two graded Taylor expansions.  On
 homogeneous letters, specializing both expansions to the same Taylor map gives the square formula
@@ -62,7 +62,7 @@ theorem taylorComponent_comp_gradedCoderiv_of_tprod
     (G : InternalGrading R M) (b₁ : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M)
     (F₂ : ReducedTensorWords R M →ₗ[R] M) (q₂ : ℤ)
     {n : ℕ} (hn : 0 < n) (x : Fin n → M) :
-    taylorComponent (b₁ ∘ₗ gradedCoderiv G F₂ q₂) ⟨n, hn⟩
+    (b₁ ∘ₗ gradedCoderiv G F₂ q₂).taylorComponent ⟨n, hn⟩
         (PiTensorProduct.tprod R x) =
       ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
         (letter R M ∘ₗ b₁) (splice R (InternalGrading.twistedTuple G q₂ x 0 p) 0 n p d
@@ -71,7 +71,7 @@ theorem taylorComponent_comp_gradedCoderiv_of_tprod
     _ = ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
         (letter R M ∘ₗ b₁) (splice R (InternalGrading.twistedTuple G q₂ x 0 p) 0 n p d
           (F₂ (subword R x p d))) := by
-      rw [taylorComponent_apply]
+      rw [LinearMap.taylorComponent_apply]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.comp_apply (letter R M), gradedCoderiv_of_tprod, map_sum]
       exact Finset.sum_congr rfl fun p _ ↦ by
@@ -99,7 +99,7 @@ theorem taylorComponent_comp_gradedCoderiv_of_tprod_of_homogeneous
     (F₂ : ReducedTensorWords R M →ₗ[R] M) (q₂ : ℤ)
     {n : ℕ} (hn : 0 < n) (x : Fin n → M) (𝒟 : Fin n → ℤ)
     (hx : ∀ i, x i ∈ G.piece (𝒟 i)) :
-    taylorComponent (b₁ ∘ₗ gradedCoderiv G F₂ q₂) ⟨n, hn⟩
+    (b₁ ∘ₗ gradedCoderiv G F₂ q₂).taylorComponent ⟨n, hn⟩
         (PiTensorProduct.tprod R x) =
       ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
         (((q₂ * ∑ j ∈ Finset.range p,

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
@@ -26,9 +26,7 @@ coderivation anticommuting with its Koszul twist has an ordinary coderivation as
 if and only if every arity component map vanishes.
 
 Anticommutation with the twist expresses oddness when `q` is odd; when `q` is even the twist is the
-identity and the hypothesis reduces to `b + b = 0`.  A later suspension bridge can discharge the
-odd case from degree-one homogeneity and identify the displayed sums with the unsuspended
-Stasheff identities.
+identity and the hypothesis reduces to `b + b = 0`.
 
 ## Main results
 
@@ -36,10 +34,6 @@ Stasheff identities.
   arity formula for a composite of two graded Taylor expansions.
 * `taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod_of_homogeneous`:
   the corresponding signed formula on homogeneous letters.
-* `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv_comp_self_of_tprod`: the square
-  specialization on pure tensors.
-* `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous`:
-  the signed Stasheff insertion formula for the square.
 
 ## References
 
@@ -98,17 +92,6 @@ theorem taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod
           omega
         rw [splice_eq_zero_of_not_fits R _ _ hfit, map_zero]
 
-/-- The pure-tensor formula for the square of one graded Taylor expansion. -/
-theorem taylorComponent_gradedCoderiv_comp_self_of_tprod
-    (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ)
-    {n : ℕ} (hn : 0 < n) (x : Fin n → M) :
-    taylorComponent (gradedCoderiv G F q ∘ₗ gradedCoderiv G F q) ⟨n, hn⟩
-        (PiTensorProduct.tprod R x) =
-      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
-        F (splice R (InternalGrading.twistedTuple G q x 0 p) 0 n p d
-          (F (subword R x p d))) :=
-  taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod G F q F q hn x
-
 /-- On homogeneous inputs, the Taylor component of a composite is an insertion sum with the
 Koszul sign contributed by the inner twist and the degrees of the letters preceding the inserted
 operation. -/
@@ -128,22 +111,6 @@ theorem taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod_of_homogeneous
   refine Finset.sum_congr rfl fun p _ ↦ ?_
   refine Finset.sum_congr rfl fun d _ ↦ ?_
   rw [splice_twistedTuple_smul G q₂ x 𝒟 hx p d, map_smul]
-
-/-- On homogeneous inputs, the Taylor component of the square is the Stasheff insertion sum with
-the Koszul sign contributed by the degrees of the letters preceding the inserted operation.  The
-indices are exactly the decompositions `n = p + d + t` with `d ≥ 1`. -/
-theorem taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous
-    (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ)
-    {n : ℕ} (hn : 0 < n) (x : Fin n → M) (𝒟 : Fin n → ℤ)
-    (hx : ∀ i, x i ∈ G.piece (𝒟 i)) :
-    taylorComponent (gradedCoderiv G F q ∘ₗ gradedCoderiv G F q) ⟨n, hn⟩
-        (PiTensorProduct.tprod R x) =
-      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
-        (((q * ∑ j ∈ Finset.range p,
-          if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
-          F (splice R x 0 n p d (F (subword R x p d))) := by
-  exact taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod_of_homogeneous
-    G F q F q hn x 𝒟 hx
 
 end Ring
 

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
@@ -123,20 +123,38 @@ theorem IsGradedCoderivation.comp_self_eq_zero_iff_taylorComponent_eq_zero
   (hb.isCoderivation_comp_self hodd).eq_zero_iff_taylorComponent_eq_zero
 
 /-- The Taylor component of the square of a graded Taylor expansion is obtained by applying the
-outer Taylor map to every signed one-block collapse made by the inner expansion. -/
+outer Taylor map to every signed nonempty one-block collapse made by the inner expansion. -/
 theorem taylorComponent_gradedCoderiv_comp_self_of_tprod
     (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ)
     {n : ℕ} (hn : 0 < n) (x : Fin n → M) :
     taylorComponent (gradedCoderiv G F q ∘ₗ gradedCoderiv G F q) ⟨n, hn⟩
         (PiTensorProduct.tprod R x) =
-      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
+      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
         F (splice R (InternalGrading.twistedTuple G q x 0 p) 0 n p d
           (F (subword R x p d))) := by
-  rw [taylorComponent_apply]
-  simp only [LinearMap.comp_apply]
-  rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv,
-    gradedCoderiv_of_tprod, map_sum]
-  exact Finset.sum_congr rfl fun p _ ↦ by rw [map_sum]
+  calc
+    _ = ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
+        F (splice R (InternalGrading.twistedTuple G q x 0 p) 0 n p d
+          (F (subword R x p d))) := by
+      rw [taylorComponent_apply]
+      simp only [LinearMap.comp_apply]
+      rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv,
+        gradedCoderiv_of_tprod, map_sum]
+      exact Finset.sum_congr rfl fun p _ ↦ by rw [map_sum]
+    _ = _ := by
+      refine Finset.sum_congr rfl fun p hp ↦ ?_
+      apply (Finset.sum_subset ?_ ?_).symm
+      · intro d hd
+        rw [Finset.mem_Icc] at hd
+        rw [Finset.mem_range]
+        omega
+      · intro d _ hd
+        have hfit : ¬(0 < d ∧ p + d ≤ n) := by
+          intro h
+          apply hd
+          rw [Finset.mem_Icc]
+          omega
+        rw [splice_eq_zero_of_not_fits R _ _ hfit, map_zero]
 
 /-- On homogeneous inputs, the Taylor component of the square is the Stasheff insertion sum with
 the Koszul sign contributed by the degrees of the letters preceding the inserted operation. -/
@@ -146,21 +164,39 @@ theorem taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous
     (hx : ∀ i, x i ∈ G.piece (𝒟 i)) :
     taylorComponent (gradedCoderiv G F q ∘ₗ gradedCoderiv G F q) ⟨n, hn⟩
         (PiTensorProduct.tprod R x) =
-      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
+      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
         (((q * ∑ j ∈ Finset.range p,
           if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
           F (splice R x 0 n p d (F (subword R x p d))) := by
-  rw [taylorComponent_apply]
-  simp only [LinearMap.comp_apply]
-  rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv,
-    gradedCoderiv_of_tprod_of_homogeneous G F q hn x 𝒟 hx, map_sum]
-  refine Finset.sum_congr rfl fun p _ ↦ ?_
-  rw [map_sum]
-  exact Finset.sum_congr rfl fun d _ ↦ by rw [map_smul]
+  calc
+    _ = ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
+        (((q * ∑ j ∈ Finset.range p,
+          if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
+          F (splice R x 0 n p d (F (subword R x p d))) := by
+      rw [taylorComponent_apply]
+      simp only [LinearMap.comp_apply]
+      rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv,
+        gradedCoderiv_of_tprod_of_homogeneous G F q hn x 𝒟 hx, map_sum]
+      refine Finset.sum_congr rfl fun p _ ↦ ?_
+      rw [map_sum]
+      exact Finset.sum_congr rfl fun d _ ↦ by rw [map_smul]
+    _ = _ := by
+      refine Finset.sum_congr rfl fun p hp ↦ ?_
+      apply (Finset.sum_subset ?_ ?_).symm
+      · intro d hd
+        rw [Finset.mem_Icc] at hd
+        rw [Finset.mem_range]
+        omega
+      · intro d _ hd
+        have hfit : ¬(0 < d ∧ p + d ≤ n) := by
+          intro h
+          apply hd
+          rw [Finset.mem_Icc]
+          omega
+        rw [splice_eq_zero_of_not_fits R _ _ hfit, map_zero, smul_zero]
 
 /-- For a twist-one coderivation, the coefficient in the square's Taylor component is the usual
-Koszul sign of the total degree of the prefix.  Terms with `d = 0` or `p + d > n` are zero by the
-definitions of `subword` and `splice`; the remaining indices are exactly the decompositions
+Koszul sign of the total degree of the prefix.  The indices are exactly the decompositions
 `n = p + d + t` with `d ≥ 1`. -/
 theorem taylorComponent_gradedCoderiv_one_comp_self_of_tprod_of_homogeneous
     (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M)
@@ -168,7 +204,7 @@ theorem taylorComponent_gradedCoderiv_one_comp_self_of_tprod_of_homogeneous
     (hx : ∀ i, x i ∈ G.piece (𝒟 i)) :
     taylorComponent (gradedCoderiv G F 1 ∘ₗ gradedCoderiv G F 1) ⟨n, hn⟩
         (PiTensorProduct.tprod R x) =
-      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
+      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
         (((∑ j ∈ Finset.range p,
           if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
           F (splice R x 0 n p d (F (subword R x p d))) := by

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
@@ -1,0 +1,254 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.TensorCoalgebra.GradedCoderivation
+
+/-!
+# Taylor components of composites of graded coderivations
+
+For the reduced tensor coalgebra `Tᶜ(M)`, the arity-`n` Taylor component of an endomorphism is
+its restriction to words of length `n`, followed by projection to words of length one.  A
+coderivation is zero exactly when all these components vanish.
+
+This file computes the Taylor components of the square of the graded Taylor expansion
+`gradedCoderiv G F q`.  On homogeneous letters the result is
+
+`∑_{r+s+t=n} (-1)^(q (|x₁| + ⋯ + |xᵣ|))
+  F(x₁,…,xᵣ,F(xᵣ₊₁,…,xᵣ₊ₛ),…,xₙ)`,
+
+the suspended Stasheff sum when `q = 1`.  We also prove the general algebraic fact behind the
+square-zero test: if a `q`-twisted coderivation anticommutes with its Koszul twist, then its square
+is an ordinary coderivation.  Consequently its square vanishes if and only if every displayed
+Taylor component vanishes.
+
+The anticommutation hypothesis is the intrinsic oddness condition used in the cancellation of the
+two mixed co-Leibniz terms.  A later suspension bridge can discharge it from degree-one
+homogeneity and identify the displayed sums with the unsuspended Stasheff identities.
+
+## Main definitions
+
+* `TauCeti.ReducedTensorWords.taylorComponent`: the arity component of a linear endomorphism of
+  reduced tensor words.
+
+## Main results
+
+* `TauCeti.ReducedTensorWords.IsCoderivation.eq_zero_iff_taylorComponent_eq_zero`: a coderivation
+  vanishes exactly when all of its Taylor components vanish.
+* `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous`:
+  the signed arity formula for the square of a graded Taylor expansion.
+* `TauCeti.ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self`: the square of an odd
+  graded coderivation is an ordinary coderivation.
+
+## References
+
+* E. Getzler and J. D. S. Jones, *A-infinity algebras and the cyclic bar complex*, Sections 1--2.
+* B. Keller, *Introduction to A-infinity algebras and modules*, Sections 3.1 and 3.6.
+-/
+
+public section
+
+open scoped BigOperators DirectSum TensorProduct
+
+universe uR uM
+
+namespace TauCeti
+
+namespace ReducedTensorWords
+
+section Semiring
+
+variable {R : Type uR} {M : Type uM} [CommSemiring R] [AddCommMonoid M] [Module R M]
+
+/-- The arity-`n` Taylor component of an endomorphism of reduced tensor words: include a word of
+length `n`, apply the endomorphism, and retain its length-one component. -/
+noncomputable def taylorComponent
+    (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n}) :
+    TensorPower R n.1 M →ₗ[R] M :=
+  (letter R M ∘ₗ b) ∘ₗ of R M n
+
+/-- Evaluation of a Taylor component is restriction to words of the specified length followed by
+the projection to letters. -/
+@[simp]
+theorem taylorComponent_apply
+    (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n})
+    (x : TensorPower R n.1 M) :
+    taylorComponent b n x = letter R M (b (of R M n x)) :=
+  (rfl)
+
+/-- A coderivation vanishes exactly when each of its aritywise Taylor components vanishes. -/
+theorem IsCoderivation.eq_zero_iff_taylorComponent_eq_zero
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} (hb : IsCoderivation R b) :
+    b = 0 ↔ ∀ n, taylorComponent b n = 0 := by
+  constructor
+  · rintro rfl n
+    simp [taylorComponent]
+  · intro h
+    have hzero : IsCoderivation R
+        (0 : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) := by
+      rw [isCoderivation_iff]
+      simp
+    apply hb.eq_of_letter_comp_eq hzero
+    apply linearMap_ext R M
+    intro n x
+    have hn := LinearMap.congr_fun (h n) (PiTensorProduct.tprod R x)
+    simpa [taylorComponent, LinearMap.comp_apply] using hn
+
+end Semiring
+
+section Ring
+
+variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
+
+/-- Applying the same Koszul twist twice to every letter of a tensor word is the identity. -/
+@[simp]
+theorem map_koszulTwist_comp_self (G : InternalGrading R M) (q : ℤ) :
+    ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ
+        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) =
+      LinearMap.id := by
+  rw [← ReducedTensorWords.map_comp, InternalGrading.koszulTwist_comp_self,
+    ReducedTensorWords.map_id]
+
+/-- The square of an odd graded coderivation is an ordinary coderivation.  Here oddness is stated
+intrinsically as anticommutation with the letterwise Koszul twist; this is exactly the relation
+that cancels the two mixed terms after applying the graded co-Leibniz rule twice. -/
+theorem IsGradedCoderivation.isCoderivation_comp_self {G : InternalGrading R M} {q : ℤ}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
+    (hb : IsGradedCoderivation G q b)
+    (hodd : b ∘ₗ ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) +
+        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ b = 0) :
+    IsCoderivation R (b ∘ₗ b) := by
+  rw [isCoderivation_iff]
+  apply LinearMap.ext
+  intro z
+  simp only [LinearMap.comp_apply, LinearMap.add_apply]
+  rw [hb.deconcatenation_apply (b z), hb.deconcatenation_apply z]
+  simp only [map_add]
+  let τ := ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q)
+  let w := deconcatenation R M z
+  have hfirst :
+      LinearMap.rTensor (ReducedTensorWords R M) b
+          (LinearMap.rTensor (ReducedTensorWords R M) b w) =
+        LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
+    rw [← LinearMap.rTensor_comp_apply]
+  have hcrossLeft :
+      LinearMap.rTensor (ReducedTensorWords R M) b
+          (LinearMap.lTensor (ReducedTensorWords R M) b
+            (LinearMap.rTensor (ReducedTensorWords R M) τ w)) =
+        TensorProduct.map (b ∘ₗ τ) b w := by
+    rw [← LinearMap.comp_apply, LinearMap.rTensor_comp_lTensor, LinearMap.map_rTensor]
+  have hcrossRight :
+      LinearMap.lTensor (ReducedTensorWords R M) b
+          (LinearMap.rTensor (ReducedTensorWords R M) τ
+            (LinearMap.rTensor (ReducedTensorWords R M) b w)) =
+        TensorProduct.map (τ ∘ₗ b) b w := by
+    rw [← LinearMap.rTensor_comp_apply, ← LinearMap.comp_apply,
+      LinearMap.lTensor_comp_rTensor]
+  have hcross :
+      TensorProduct.map (b ∘ₗ τ) b w + TensorProduct.map (τ ∘ₗ b) b w = 0 := by
+    have hodd' : b ∘ₗ τ + τ ∘ₗ b = 0 := hodd
+    rw [← LinearMap.add_apply, ← TensorProduct.map_add_left,
+      hodd', TensorProduct.map_zero_left, LinearMap.zero_apply]
+  have hcommute (y : ReducedTensorWords R M ⊗[R] ReducedTensorWords R M) :
+      LinearMap.rTensor (ReducedTensorWords R M) τ
+          (LinearMap.lTensor (ReducedTensorWords R M) b y) =
+        LinearMap.lTensor (ReducedTensorWords R M) b
+          (LinearMap.rTensor (ReducedTensorWords R M) τ y) := by
+    rw [← LinearMap.comp_apply, LinearMap.rTensor_comp_lTensor,
+      ← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor]
+  have hlast :
+      LinearMap.lTensor (ReducedTensorWords R M) b
+          (LinearMap.rTensor (ReducedTensorWords R M) τ
+            (LinearMap.lTensor (ReducedTensorWords R M) b
+              (LinearMap.rTensor (ReducedTensorWords R M) τ w))) =
+        LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
+    have hτ : τ ∘ₗ τ = LinearMap.id := map_koszulTwist_comp_self G q
+    rw [hcommute, ← LinearMap.lTensor_comp_apply, ← LinearMap.rTensor_comp_apply,
+      hτ, LinearMap.rTensor_id_apply]
+  rw [hfirst, hcrossLeft, hcrossRight, hlast]
+  calc
+    (LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
+          TensorProduct.map (b ∘ₗ τ) b w) +
+        (TensorProduct.map (τ ∘ₗ b) b w +
+          LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w) =
+      LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
+          (TensorProduct.map (b ∘ₗ τ) b w +
+            TensorProduct.map (τ ∘ₗ b) b w) +
+        LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
+          ac_rfl
+    _ = LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
+        LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
+      rw [hcross, add_zero]
+
+/-- Under the intrinsic oddness relation, a graded coderivation squares to zero exactly when all
+Taylor components of its square vanish. -/
+theorem IsGradedCoderivation.comp_self_eq_zero_iff_taylorComponent_eq_zero
+    {G : InternalGrading R M} {q : ℤ}
+    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
+    (hb : IsGradedCoderivation G q b)
+    (hodd : b ∘ₗ ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) +
+        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ b = 0) :
+    b ∘ₗ b = 0 ↔ ∀ n, taylorComponent (b ∘ₗ b) n = 0 :=
+  (hb.isCoderivation_comp_self hodd).eq_zero_iff_taylorComponent_eq_zero
+
+/-- The Taylor component of the square of a graded Taylor expansion is obtained by applying the
+outer Taylor map to every signed one-block collapse made by the inner expansion. -/
+theorem taylorComponent_gradedCoderiv_comp_self_of_tprod
+    (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ)
+    {n : ℕ} (hn : 0 < n) (x : Fin n → M) :
+    taylorComponent (gradedCoderiv G F q ∘ₗ gradedCoderiv G F q) ⟨n, hn⟩
+        (PiTensorProduct.tprod R x) =
+      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
+        F (splice R (InternalGrading.twistedTuple G q x 0 p) 0 n p d
+          (F (subword R x p d))) := by
+  rw [taylorComponent_apply]
+  simp only [LinearMap.comp_apply]
+  rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv,
+    gradedCoderiv_of_tprod, map_sum]
+  exact Finset.sum_congr rfl fun p _ ↦ by rw [map_sum]
+
+/-- On homogeneous inputs, the Taylor component of the square is the Stasheff insertion sum with
+the Koszul sign contributed by the degrees of the letters preceding the inserted operation. -/
+theorem taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous
+    (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ)
+    {n : ℕ} (hn : 0 < n) (x : Fin n → M) (𝒟 : Fin n → ℤ)
+    (hx : ∀ i, x i ∈ G.piece (𝒟 i)) :
+    taylorComponent (gradedCoderiv G F q ∘ₗ gradedCoderiv G F q) ⟨n, hn⟩
+        (PiTensorProduct.tprod R x) =
+      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
+        (((q * ∑ j ∈ Finset.range p,
+          if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
+          F (splice R x 0 n p d (F (subword R x p d))) := by
+  rw [taylorComponent_apply]
+  simp only [LinearMap.comp_apply]
+  rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv,
+    gradedCoderiv_of_tprod_of_homogeneous G F q hn x 𝒟 hx, map_sum]
+  refine Finset.sum_congr rfl fun p _ ↦ ?_
+  rw [map_sum]
+  exact Finset.sum_congr rfl fun d _ ↦ by rw [map_smul]
+
+/-- For a twist-one coderivation, the coefficient in the square's Taylor component is the usual
+Koszul sign of the total degree of the prefix.  Terms with `d = 0` or `p + d > n` are zero by the
+definitions of `subword` and `splice`; the remaining indices are exactly the decompositions
+`n = p + d + t` with `d ≥ 1`. -/
+theorem taylorComponent_gradedCoderiv_one_comp_self_of_tprod_of_homogeneous
+    (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M)
+    {n : ℕ} (hn : 0 < n) (x : Fin n → M) (𝒟 : Fin n → ℤ)
+    (hx : ∀ i, x i ∈ G.piece (𝒟 i)) :
+    taylorComponent (gradedCoderiv G F 1 ∘ₗ gradedCoderiv G F 1) ⟨n, hn⟩
+        (PiTensorProduct.tprod R x) =
+      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
+        (((∑ j ∈ Finset.range p,
+          if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
+          F (splice R x 0 n p d (F (subword R x p d))) := by
+  simpa using
+    taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous G F 1 hn x 𝒟 hx
+
+end Ring
+
+end ReducedTensorWords
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
@@ -14,16 +14,16 @@ For the reduced tensor coalgebra `Tᶜ(M)`, the arity-`n` Taylor component of an
 its restriction to words of length `n`, followed by projection to words of length one.  A
 coderivation is zero exactly when all these components vanish.
 
-This file computes the Taylor components of the square of the graded Taylor expansion
-`gradedCoderiv G F q`.  On homogeneous letters the result is
+This file computes the Taylor components of the graded Taylor expansion and of its square.  On
+homogeneous letters the square's component is
 
 `∑_{r+s+t=n} (-1)^(q (|x₁| + ⋯ + |xᵣ|))
   F(x₁,…,xᵣ,F(xᵣ₊₁,…,xᵣ₊ₛ),…,xₙ)`,
 
-the suspended Stasheff sum when `q = 1`.  We also prove the general algebraic fact behind the
-square-zero test: if a `q`-twisted coderivation anticommutes with its Koszul twist, then its square
-is an ordinary coderivation.  Consequently its square vanishes if and only if every displayed
-Taylor component vanishes.
+the suspended Stasheff sum when `q = 1`.  The general algebraic fact that a `q`-twisted
+coderivation anticommuting with its Koszul twist has an ordinary coderivation as its square is in
+`TauCeti.LinearAlgebra.TensorCoalgebra.GradedCoderivation`.  Consequently its square vanishes if
+and only if every displayed Taylor component vanishes.
 
 The anticommutation hypothesis is the intrinsic oddness condition used in the cancellation of the
 two mixed co-Leibniz terms.  A later suspension bridge can discharge it from degree-one
@@ -40,8 +40,8 @@ homogeneity and identify the displayed sums with the unsuspended Stasheff identi
   vanishes exactly when all of its Taylor components vanish.
 * `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous`:
   the signed arity formula for the square of a graded Taylor expansion.
-* `TauCeti.ReducedTensorWords.IsGradedCoderivation.isCoderivation_comp_self`: the square of an odd
-  graded coderivation is an ordinary coderivation.
+* `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv`: the Taylor component of a graded
+  Taylor expansion is the corresponding restriction of its defining Taylor map.
 
 ## References
 
@@ -103,85 +103,13 @@ section Ring
 
 variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
 
-/-- Applying the same Koszul twist twice to every letter of a tensor word is the identity. -/
+/-- The arity-`n` Taylor component of a graded Taylor expansion is the restriction of its
+defining Taylor map to words of length `n`. -/
 @[simp]
-theorem map_koszulTwist_comp_self (G : InternalGrading R M) (q : ℤ) :
-    ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ
-        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) =
-      LinearMap.id := by
-  rw [← ReducedTensorWords.map_comp, InternalGrading.koszulTwist_comp_self,
-    ReducedTensorWords.map_id]
-
-/-- The square of an odd graded coderivation is an ordinary coderivation.  Here oddness is stated
-intrinsically as anticommutation with the letterwise Koszul twist; this is exactly the relation
-that cancels the two mixed terms after applying the graded co-Leibniz rule twice. -/
-theorem IsGradedCoderivation.isCoderivation_comp_self {G : InternalGrading R M} {q : ℤ}
-    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
-    (hb : IsGradedCoderivation G q b)
-    (hodd : b ∘ₗ ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) +
-        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ b = 0) :
-    IsCoderivation R (b ∘ₗ b) := by
-  rw [isCoderivation_iff]
-  apply LinearMap.ext
-  intro z
-  simp only [LinearMap.comp_apply, LinearMap.add_apply]
-  rw [hb.deconcatenation_apply (b z), hb.deconcatenation_apply z]
-  simp only [map_add]
-  let τ := ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q)
-  let w := deconcatenation R M z
-  have hfirst :
-      LinearMap.rTensor (ReducedTensorWords R M) b
-          (LinearMap.rTensor (ReducedTensorWords R M) b w) =
-        LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
-    rw [← LinearMap.rTensor_comp_apply]
-  have hcrossLeft :
-      LinearMap.rTensor (ReducedTensorWords R M) b
-          (LinearMap.lTensor (ReducedTensorWords R M) b
-            (LinearMap.rTensor (ReducedTensorWords R M) τ w)) =
-        TensorProduct.map (b ∘ₗ τ) b w := by
-    rw [← LinearMap.comp_apply, LinearMap.rTensor_comp_lTensor, LinearMap.map_rTensor]
-  have hcrossRight :
-      LinearMap.lTensor (ReducedTensorWords R M) b
-          (LinearMap.rTensor (ReducedTensorWords R M) τ
-            (LinearMap.rTensor (ReducedTensorWords R M) b w)) =
-        TensorProduct.map (τ ∘ₗ b) b w := by
-    rw [← LinearMap.rTensor_comp_apply, ← LinearMap.comp_apply,
-      LinearMap.lTensor_comp_rTensor]
-  have hcross :
-      TensorProduct.map (b ∘ₗ τ) b w + TensorProduct.map (τ ∘ₗ b) b w = 0 := by
-    have hodd' : b ∘ₗ τ + τ ∘ₗ b = 0 := hodd
-    rw [← LinearMap.add_apply, ← TensorProduct.map_add_left,
-      hodd', TensorProduct.map_zero_left, LinearMap.zero_apply]
-  have hcommute (y : ReducedTensorWords R M ⊗[R] ReducedTensorWords R M) :
-      LinearMap.rTensor (ReducedTensorWords R M) τ
-          (LinearMap.lTensor (ReducedTensorWords R M) b y) =
-        LinearMap.lTensor (ReducedTensorWords R M) b
-          (LinearMap.rTensor (ReducedTensorWords R M) τ y) := by
-    rw [← LinearMap.comp_apply, LinearMap.rTensor_comp_lTensor,
-      ← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor]
-  have hlast :
-      LinearMap.lTensor (ReducedTensorWords R M) b
-          (LinearMap.rTensor (ReducedTensorWords R M) τ
-            (LinearMap.lTensor (ReducedTensorWords R M) b
-              (LinearMap.rTensor (ReducedTensorWords R M) τ w))) =
-        LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
-    have hτ : τ ∘ₗ τ = LinearMap.id := map_koszulTwist_comp_self G q
-    rw [hcommute, ← LinearMap.lTensor_comp_apply, ← LinearMap.rTensor_comp_apply,
-      hτ, LinearMap.rTensor_id_apply]
-  rw [hfirst, hcrossLeft, hcrossRight, hlast]
-  calc
-    (LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
-          TensorProduct.map (b ∘ₗ τ) b w) +
-        (TensorProduct.map (τ ∘ₗ b) b w +
-          LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w) =
-      LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
-          (TensorProduct.map (b ∘ₗ τ) b w +
-            TensorProduct.map (τ ∘ₗ b) b w) +
-        LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
-          ac_rfl
-    _ = LinearMap.rTensor (ReducedTensorWords R M) (b ∘ₗ b) w +
-        LinearMap.lTensor (ReducedTensorWords R M) (b ∘ₗ b) w := by
-      rw [hcross, add_zero]
+theorem taylorComponent_gradedCoderiv (G : InternalGrading R M)
+    (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ) (n : {n : ℕ // 0 < n}) :
+    taylorComponent (gradedCoderiv G F q) n = F ∘ₗ of R M n := by
+  rw [taylorComponent, letter_comp_gradedCoderiv]
 
 /-- Under the intrinsic oddness relation, a graded coderivation squares to zero exactly when all
 Taylor components of its square vanish. -/

--- a/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
+++ b/TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean
@@ -8,40 +8,38 @@ module
 public import TauCeti.LinearAlgebra.TensorCoalgebra.GradedCoderivation
 
 /-!
-# Taylor components of composites of graded coderivations
+# Taylor components of composites of graded Taylor expansions
 
-For the reduced tensor coalgebra `Tᶜ(M)`, the arity-`n` Taylor component of an endomorphism is
-its restriction to words of length `n`, followed by projection to words of length one.  A
-coderivation is zero exactly when all these components vanish.
+For the reduced tensor coalgebra `Tᶜ(M)`, the arity-`n` Taylor component of an endomorphism,
+defined in `TauCeti.LinearAlgebra.TensorCoalgebra.Coderivation`, is its restriction to words of
+length `n`, followed by projection to words of length one.
 
-This file computes the Taylor components of the graded Taylor expansion and of its square.  On
-homogeneous letters the square's component is
+This file computes the Taylor components of a composite of two graded Taylor expansions.  On
+homogeneous letters, specializing both expansions to the same Taylor map gives the square formula
 
 `∑_{r+s+t=n} (-1)^(q (|x₁| + ⋯ + |xᵣ|))
   F(x₁,…,xᵣ,F(xᵣ₊₁,…,xᵣ₊ₛ),…,xₙ)`,
 
 the suspended Stasheff sum when `q = 1`.  The general algebraic fact that a `q`-twisted
 coderivation anticommuting with its Koszul twist has an ordinary coderivation as its square is in
-`TauCeti.LinearAlgebra.TensorCoalgebra.GradedCoderivation`.  Consequently its square vanishes if
-and only if every displayed Taylor component vanishes.
+`TauCeti.LinearAlgebra.TensorCoalgebra.GradedCoderivation`.  It also shows that the square vanishes
+if and only if every arity component map vanishes.
 
-The anticommutation hypothesis is the intrinsic oddness condition used in the cancellation of the
-two mixed co-Leibniz terms.  A later suspension bridge can discharge it from degree-one
-homogeneity and identify the displayed sums with the unsuspended Stasheff identities.
-
-## Main definitions
-
-* `TauCeti.ReducedTensorWords.taylorComponent`: the arity component of a linear endomorphism of
-  reduced tensor words.
+Anticommutation with the twist expresses oddness when `q` is odd; when `q` is even the twist is the
+identity and the hypothesis reduces to `b + b = 0`.  A later suspension bridge can discharge the
+odd case from degree-one homogeneity and identify the displayed sums with the unsuspended
+Stasheff identities.
 
 ## Main results
 
-* `TauCeti.ReducedTensorWords.IsCoderivation.eq_zero_iff_taylorComponent_eq_zero`: a coderivation
-  vanishes exactly when all of its Taylor components vanish.
+* `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod`: the
+  arity formula for a composite of two graded Taylor expansions.
+* `taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod_of_homogeneous`:
+  the corresponding signed formula on homogeneous letters.
+* `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv_comp_self_of_tprod`: the square
+  specialization on pure tensors.
 * `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous`:
-  the signed arity formula for the square of a graded Taylor expansion.
-* `TauCeti.ReducedTensorWords.taylorComponent_gradedCoderiv`: the Taylor component of a graded
-  Taylor expansion is the corresponding restriction of its defining Taylor map.
+  the signed Stasheff insertion formula for the square.
 
 ## References
 
@@ -59,83 +57,27 @@ namespace TauCeti
 
 namespace ReducedTensorWords
 
-section Semiring
-
-variable {R : Type uR} {M : Type uM} [CommSemiring R] [AddCommMonoid M] [Module R M]
-
-/-- The arity-`n` Taylor component of an endomorphism of reduced tensor words: include a word of
-length `n`, apply the endomorphism, and retain its length-one component. -/
-noncomputable def taylorComponent
-    (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n}) :
-    TensorPower R n.1 M →ₗ[R] M :=
-  (letter R M ∘ₗ b) ∘ₗ of R M n
-
-/-- Evaluation of a Taylor component is restriction to words of the specified length followed by
-the projection to letters. -/
-@[simp]
-theorem taylorComponent_apply
-    (b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) (n : {n : ℕ // 0 < n})
-    (x : TensorPower R n.1 M) :
-    taylorComponent b n x = letter R M (b (of R M n x)) :=
-  (rfl)
-
-/-- A coderivation vanishes exactly when each of its aritywise Taylor components vanishes. -/
-theorem IsCoderivation.eq_zero_iff_taylorComponent_eq_zero
-    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M} (hb : IsCoderivation R b) :
-    b = 0 ↔ ∀ n, taylorComponent b n = 0 := by
-  constructor
-  · rintro rfl n
-    simp [taylorComponent]
-  · intro h
-    have hzero : IsCoderivation R
-        (0 : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M) := by
-      rw [isCoderivation_iff]
-      simp
-    apply hb.eq_of_letter_comp_eq hzero
-    apply linearMap_ext R M
-    intro n x
-    have hn := LinearMap.congr_fun (h n) (PiTensorProduct.tprod R x)
-    simpa [taylorComponent, LinearMap.comp_apply] using hn
-
-end Semiring
-
 section Ring
 
 variable {R : Type uR} {M : Type uM} [CommRing R] [AddCommMonoid M] [Module R M]
 
-/-- The arity-`n` Taylor component of a graded Taylor expansion is the restriction of its
-defining Taylor map to words of length `n`. -/
-@[simp]
-theorem taylorComponent_gradedCoderiv (G : InternalGrading R M)
-    (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ) (n : {n : ℕ // 0 < n}) :
-    taylorComponent (gradedCoderiv G F q) n = F ∘ₗ of R M n := by
-  rw [taylorComponent, letter_comp_gradedCoderiv]
-
-/-- Under the intrinsic oddness relation, a graded coderivation squares to zero exactly when all
-Taylor components of its square vanish. -/
-theorem IsGradedCoderivation.comp_self_eq_zero_iff_taylorComponent_eq_zero
-    {G : InternalGrading R M} {q : ℤ}
-    {b : ReducedTensorWords R M →ₗ[R] ReducedTensorWords R M}
-    (hb : IsGradedCoderivation G q b)
-    (hodd : b ∘ₗ ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) +
-        ReducedTensorWords.map (R := R) (InternalGrading.koszulTwist G q) ∘ₗ b = 0) :
-    b ∘ₗ b = 0 ↔ ∀ n, taylorComponent (b ∘ₗ b) n = 0 :=
-  (hb.isCoderivation_comp_self hodd).eq_zero_iff_taylorComponent_eq_zero
-
-/-- The Taylor component of the square of a graded Taylor expansion is obtained by applying the
-outer Taylor map to every signed nonempty one-block collapse made by the inner expansion. -/
-theorem taylorComponent_gradedCoderiv_comp_self_of_tprod
-    (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ)
+/-- The Taylor component of a composite of graded Taylor expansions is obtained by applying the
+outer Taylor map to every signed nonempty one-block collapse made by the inner expansion.  Only
+the inner twist parameter occurs in the resulting formula. -/
+theorem taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod
+    (G : InternalGrading R M)
+    (F₁ : ReducedTensorWords R M →ₗ[R] M) (q₁ : ℤ)
+    (F₂ : ReducedTensorWords R M →ₗ[R] M) (q₂ : ℤ)
     {n : ℕ} (hn : 0 < n) (x : Fin n → M) :
-    taylorComponent (gradedCoderiv G F q ∘ₗ gradedCoderiv G F q) ⟨n, hn⟩
+    taylorComponent (gradedCoderiv G F₁ q₁ ∘ₗ gradedCoderiv G F₂ q₂) ⟨n, hn⟩
         (PiTensorProduct.tprod R x) =
       ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
-        F (splice R (InternalGrading.twistedTuple G q x 0 p) 0 n p d
-          (F (subword R x p d))) := by
+        F₁ (splice R (InternalGrading.twistedTuple G q₂ x 0 p) 0 n p d
+          (F₂ (subword R x p d))) := by
   calc
     _ = ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
-        F (splice R (InternalGrading.twistedTuple G q x 0 p) 0 n p d
-          (F (subword R x p d))) := by
+        F₁ (splice R (InternalGrading.twistedTuple G q₂ x 0 p) 0 n p d
+          (F₂ (subword R x p d))) := by
       rw [taylorComponent_apply]
       simp only [LinearMap.comp_apply]
       rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv,
@@ -156,8 +98,40 @@ theorem taylorComponent_gradedCoderiv_comp_self_of_tprod
           omega
         rw [splice_eq_zero_of_not_fits R _ _ hfit, map_zero]
 
+/-- The pure-tensor formula for the square of one graded Taylor expansion. -/
+theorem taylorComponent_gradedCoderiv_comp_self_of_tprod
+    (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ)
+    {n : ℕ} (hn : 0 < n) (x : Fin n → M) :
+    taylorComponent (gradedCoderiv G F q ∘ₗ gradedCoderiv G F q) ⟨n, hn⟩
+        (PiTensorProduct.tprod R x) =
+      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
+        F (splice R (InternalGrading.twistedTuple G q x 0 p) 0 n p d
+          (F (subword R x p d))) :=
+  taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod G F q F q hn x
+
+/-- On homogeneous inputs, the Taylor component of a composite is an insertion sum with the
+Koszul sign contributed by the inner twist and the degrees of the letters preceding the inserted
+operation. -/
+theorem taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod_of_homogeneous
+    (G : InternalGrading R M)
+    (F₁ : ReducedTensorWords R M →ₗ[R] M) (q₁ : ℤ)
+    (F₂ : ReducedTensorWords R M →ₗ[R] M) (q₂ : ℤ)
+    {n : ℕ} (hn : 0 < n) (x : Fin n → M) (𝒟 : Fin n → ℤ)
+    (hx : ∀ i, x i ∈ G.piece (𝒟 i)) :
+    taylorComponent (gradedCoderiv G F₁ q₁ ∘ₗ gradedCoderiv G F₂ q₂) ⟨n, hn⟩
+        (PiTensorProduct.tprod R x) =
+      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
+        (((q₂ * ∑ j ∈ Finset.range p,
+          if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
+          F₁ (splice R x 0 n p d (F₂ (subword R x p d))) := by
+  rw [taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod G F₁ q₁ F₂ q₂ hn x]
+  refine Finset.sum_congr rfl fun p _ ↦ ?_
+  refine Finset.sum_congr rfl fun d _ ↦ ?_
+  rw [splice_twistedTuple_smul G q₂ x 𝒟 hx p d, map_smul]
+
 /-- On homogeneous inputs, the Taylor component of the square is the Stasheff insertion sum with
-the Koszul sign contributed by the degrees of the letters preceding the inserted operation. -/
+the Koszul sign contributed by the degrees of the letters preceding the inserted operation.  The
+indices are exactly the decompositions `n = p + d + t` with `d ≥ 1`. -/
 theorem taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous
     (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M) (q : ℤ)
     {n : ℕ} (hn : 0 < n) (x : Fin n → M) (𝒟 : Fin n → ℤ)
@@ -168,48 +142,8 @@ theorem taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous
         (((q * ∑ j ∈ Finset.range p,
           if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
           F (splice R x 0 n p d (F (subword R x p d))) := by
-  calc
-    _ = ∑ p ∈ Finset.range n, ∑ d ∈ Finset.range (n + 1),
-        (((q * ∑ j ∈ Finset.range p,
-          if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
-          F (splice R x 0 n p d (F (subword R x p d))) := by
-      rw [taylorComponent_apply]
-      simp only [LinearMap.comp_apply]
-      rw [← LinearMap.comp_apply (letter R M), letter_comp_gradedCoderiv,
-        gradedCoderiv_of_tprod_of_homogeneous G F q hn x 𝒟 hx, map_sum]
-      refine Finset.sum_congr rfl fun p _ ↦ ?_
-      rw [map_sum]
-      exact Finset.sum_congr rfl fun d _ ↦ by rw [map_smul]
-    _ = _ := by
-      refine Finset.sum_congr rfl fun p hp ↦ ?_
-      apply (Finset.sum_subset ?_ ?_).symm
-      · intro d hd
-        rw [Finset.mem_Icc] at hd
-        rw [Finset.mem_range]
-        omega
-      · intro d _ hd
-        have hfit : ¬(0 < d ∧ p + d ≤ n) := by
-          intro h
-          apply hd
-          rw [Finset.mem_Icc]
-          omega
-        rw [splice_eq_zero_of_not_fits R _ _ hfit, map_zero, smul_zero]
-
-/-- For a twist-one coderivation, the coefficient in the square's Taylor component is the usual
-Koszul sign of the total degree of the prefix.  The indices are exactly the decompositions
-`n = p + d + t` with `d ≥ 1`. -/
-theorem taylorComponent_gradedCoderiv_one_comp_self_of_tprod_of_homogeneous
-    (G : InternalGrading R M) (F : ReducedTensorWords R M →ₗ[R] M)
-    {n : ℕ} (hn : 0 < n) (x : Fin n → M) (𝒟 : Fin n → ℤ)
-    (hx : ∀ i, x i ∈ G.piece (𝒟 i)) :
-    taylorComponent (gradedCoderiv G F 1 ∘ₗ gradedCoderiv G F 1) ⟨n, hn⟩
-        (PiTensorProduct.tprod R x) =
-      ∑ p ∈ Finset.range n, ∑ d ∈ Finset.Icc 1 (n - p),
-        (((∑ j ∈ Finset.range p,
-          if h : j < n then 𝒟 ⟨j, h⟩ else 0).negOnePow : ℤ) : R) •
-          F (splice R x 0 n p d (F (subword R x p d))) := by
-  simpa using
-    taylorComponent_gradedCoderiv_comp_self_of_tprod_of_homogeneous G F 1 hn x 𝒟 hx
+  exact taylorComponent_gradedCoderiv_comp_gradedCoderiv_of_tprod_of_homogeneous
+    G F q F q hn x 𝒟 hx
 
 end Ring
 


### PR DESCRIPTION
This PR computes the aritywise Taylor components of the square of a Koszul-signed coderivation of the reduced tensor coalgebra. Define `ReducedTensorWords.taylorComponent` by restricting an endomorphism to tensor length `n` and projecting its value to one letter; prove that a coderivation vanishes exactly when all these components vanish; prove that a graded coderivation satisfying the intrinsic oddness relation with the letterwise Koszul twist has an ordinary coderivation as its square; and calculate the square on homogeneous pure tensors as the signed sum over decompositions `n = r + s + t`.

The exact roadmap target is `TauCetiRoadmap/DGAInfinity/README.md`, Layer 0, “signed graded multilinear and tensor-coalgebra infrastructure,” final bullet: “Prove the general Stasheff component formula and the arity `1`--`4` equations verbatim.” The designated milestone is the Layer 0 arity-component identification of `b² = 0` with the suspended Stasheff identities, which Layer 2 consumes to define a nonunital `A∞` algebra by a square-zero coderivation and expose its operations. This is the most effective current step because merged PR #4601 now supplies the graded coderivation/Taylor correspondence, while open PR #4516 supplies the distinct suspension-to-unsuspended sign bridge and explicitly identifies the coalgebraic `b ∘ b` calculation as what remains. After this PR, the milestone still needs the intrinsic oddness relation discharged from degree-one homogeneity and this component formula combined with #4516 to state the arity `1`--`4` equations from `b² = 0` in the unsuspended API.

The new module `TauCeti/LinearAlgebra/TensorCoalgebra/TaylorComponent.lean` has 254 lines. Its square proof applies the graded co-Leibniz identity twice: the two mixed tensor terms cancel by anticommutation, while involutivity of the letterwise Koszul twist leaves the two ordinary co-Leibniz terms. The evaluation theorem then reuses `gradedCoderiv_of_tprod_of_homogeneous` and `letter_comp_gradedCoderiv`, so the prefix coefficient is Mathlib's `Int.negOnePow` sign already carried by the existing Koszul-twist API. No Mathlib infrastructure or external formalization is vendored.

The conventions and formulas follow E. Getzler and J. D. S. Jones, *A-infinity algebras and the cyclic bar complex*, Sections 1--2, and B. Keller, *Introduction to A-infinity algebras and modules*, Sections 3.1 and 3.6, as cited in the module documentation.

Roadmap: DGAInfinity

<!--tauceti-target:v1 {"focus":"DGAInfinity","id":"coderivation-square-stasheff-components"}-->

🤖 Prepared with Codex
