### PR TITLE
feat: add derivations of symmetric algebras

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Tangent.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+import TauCeti.LinearAlgebra.SymmetricAlgebra.Derivation
 public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
 
@@ -23,10 +24,9 @@ Over commutative rings, the convolution bracket of two tangent derivations is ze
 to calculate on a generator: the generator is primitive, so both convolution products vanish
 there. Thus the tangent Lie algebra of every additive vector group is abelian.
 
-The inverse tangent construction uses the universal property `SymmetricAlgebra.lift` and
-`TauCeti.derivationToDualNumberEquivLift`: a linear map `f : M →ₗ[R] B` sends a generator `x`
-to the pure infinitesimal dual number `ε f(x)`. No choice of basis or finiteness hypothesis on
-`M` is needed.
+The inverse tangent construction uses `SymmetricAlgebra.mkDerivation`: a linear map
+`f : M →ₗ[R] B` extends uniquely from the canonical generators. No choice of basis or finiteness
+hypothesis on `M` is needed.
 
 ## Main declarations
 
@@ -46,7 +46,7 @@ namespace TauCeti
 
 namespace AdditiveGroup
 
-open TauCeti.Bialgebra TrivSqZeroExt
+open TauCeti.Bialgebra
 
 universe u v w
 
@@ -56,61 +56,20 @@ variable {R : Type u} [CommSemiring R]
 variable {M : Type v} [AddCommMonoid M] [Module R M]
 variable {B : Type w} [CommSemiring B] [Algebra R B]
 
-private noncomputable def infinitesimalGenerator (f : M →ₗ[R] B) :
-    M →ₗ[R] DualNumber (CounitAlgebra R (SymmetricAlgebra R M) B) :=
-  (inrHom (CounitAlgebra R (SymmetricAlgebra R M) B)
-      (CounitAlgebra R (SymmetricAlgebra R M) B)).restrictScalars R ∘ₗ
-    (CounitAlgebra.algEquivSelf R (SymmetricAlgebra R M) B).symm.toLinearMap ∘ₗ f
-
-private lemma infinitesimalGenerator_apply (f : M →ₗ[R] B) (x : M) :
-    infinitesimalGenerator f x =
-      inr ((CounitAlgebra.algEquivSelf R (SymmetricAlgebra R M) B).symm (f x)) := by
-  rfl
-
-private noncomputable def tangentLift (f : M →ₗ[R] B) :
-    {ψ : SymmetricAlgebra R M →ₐ[R] DualNumber (CounitAlgebra R (SymmetricAlgebra R M) B) //
-      (fstHom R _ _).comp ψ =
-        IsScalarTower.toAlgHom R (SymmetricAlgebra R M)
-          (CounitAlgebra R (SymmetricAlgebra R M) B)} := by
-  refine ⟨SymmetricAlgebra.lift (infinitesimalGenerator f), ?_⟩
-  apply SymmetricAlgebra.algHom_ext
-  apply LinearMap.ext
-  intro x
-  -- Expose the two algebra-homomorphism compositions once so their generator values reduce.
-  change fst (SymmetricAlgebra.lift (infinitesimalGenerator f)
-      (SymmetricAlgebra.ι R M x)) =
-    algebraMap (SymmetricAlgebra R M)
-      (CounitAlgebra R (SymmetricAlgebra R M) B) (SymmetricAlgebra.ι R M x)
-  rw [SymmetricAlgebra.lift_ι_apply, infinitesimalGenerator_apply, fst_inr]
-  simp only [CounitAlgebra.algebraMap_apply, SymmetricAlgebra.counit_ι, map_zero]
-  rfl
-
 private noncomputable def tangentOfLinear (f : M →ₗ[R] B) :
     Derivation R (SymmetricAlgebra R M)
       (CounitAlgebra R (SymmetricAlgebra R M) B) :=
-  (derivationToDualNumberEquivLift R (SymmetricAlgebra R M)
-    (CounitAlgebra R (SymmetricAlgebra R M) B)).symm (tangentLift f)
+  SymmetricAlgebra.mkDerivation <|
+    (CounitAlgebra.algEquivSelf R (SymmetricAlgebra R M) B).symm.toLinearMap ∘ₗ f
 
 private lemma tangentOfLinear_ι (f : M →ₗ[R] B) (x : M) :
     CounitAlgebra.algEquivSelf R (SymmetricAlgebra R M) B
         (tangentOfLinear f (SymmetricAlgebra.ι R M x)) = f x := by
-  rw [tangentOfLinear, derivationToDualNumberEquivLift_symm_apply, tangentLift,
-    SymmetricAlgebra.lift_ι_apply, infinitesimalGenerator_apply, snd_inr,
-    AlgEquiv.apply_symm_apply]
-
-/-- Two tangent derivations of a symmetric algebra are equal if they agree on its generators. -/
-@[ext]
-theorem derivation_ext
-    {d e : Derivation R (SymmetricAlgebra R M)
-      (CounitAlgebra R (SymmetricAlgebra R M) B)}
-    (h : ∀ x, d (SymmetricAlgebra.ι R M x) = e (SymmetricAlgebra.ι R M x)) : d = e := by
-  apply Derivation.ext
-  intro a
-  induction a using SymmetricAlgebra.induction with
-  | algebraMap r => simp only [Derivation.map_algebraMap]
-  | ι x => exact h x
-  | mul a b ha hb => simp only [Derivation.leibniz, ha, hb]
-  | add a b ha hb => simp only [map_add, ha, hb]
+  rw [tangentOfLinear, SymmetricAlgebra.mkDerivation_ι, LinearMap.comp_apply]
+  -- Cross the linear-map coercion to expose the inverse algebra equivalence.
+  change CounitAlgebra.algEquivSelf R (SymmetricAlgebra R M) B
+      ((CounitAlgebra.algEquivSelf R (SymmetricAlgebra R M) B).symm (f x)) = f x
+  exact AlgEquiv.apply_symm_apply _ _
 
 /-- The tangent module of the additive vector group represented by `SymmetricAlgebra R M` is
 the module `M →ₗ[R] B` of possible generator values.
@@ -126,7 +85,7 @@ noncomputable def tangentLinearEquiv :
       d.toLinearMap ∘ₗ SymmetricAlgebra.ι R M
   invFun := tangentOfLinear
   left_inv d := by
-    apply derivation_ext
+    apply SymmetricAlgebra.derivation_ext
     intro x
     apply (CounitAlgebra.algEquivSelf R (SymmetricAlgebra R M) B).injective
     exact tangentOfLinear_ι _ _
@@ -242,7 +201,7 @@ values on the generators. -/
 theorem tangent_bracket_eq_zero
     (d e : Derivation R (SymmetricAlgebra R M)
       (CounitAlgebra R (SymmetricAlgebra R M) B)) : ⁅d, e⁆ = 0 := by
-  apply derivation_ext
+  apply SymmetricAlgebra.derivation_ext
   intro x
   rw [Derivation.bracket_apply, SymmetricAlgebra.comul_ι]
   simp

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Derivation.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Derivation.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.SymmetricAlgebra.Basic
+public import Mathlib.RingTheory.Derivation.Basic
+
+/-!
+# Derivations of symmetric algebras
+
+A derivation of `SymmetricAlgebra R M` is determined by its values on the canonical generators.
+Conversely, every linear map from `M` to a module over its symmetric algebra extends uniquely to a
+derivation. This file packages the extension and the resulting linear equivalence.
+
+The public interface follows Mathlib's analogous `Polynomial.mkDerivation` and
+`MvPolynomial.mkDerivation` APIs.
+
+The construction uses the trivial square-zero extension. A prescribed value `f x` is paired with
+the generator `SymmetricAlgebra.ι R M x`; the universal property of the symmetric algebra extends
+this pair multiplicatively, and projection to the square-zero component gives the derivation.
+
+## Main definitions and results
+
+* `SymmetricAlgebra.mkDerivation`: extend prescribed values on the canonical generators.
+* `SymmetricAlgebra.derivation_ext`: symmetric-algebra derivations agree when they agree on the
+  canonical generators.
+* `SymmetricAlgebra.mkDerivationEquiv`: derivations are linearly equivalent to their restrictions
+  to the canonical generators.
+
+## Roadmap
+
+This supplies the derivation input for the PBW action on `SymmetricAlgebra R L`, toward the
+Poincare--Birkhoff--Witt target in Layer 3 of
+`TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`.
+-/
+
+public section
+
+namespace SymmetricAlgebra
+
+noncomputable section
+
+universe u v w
+
+variable {R : Type u} {M : Type v} {A : Type w}
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
+variable [AddCommMonoid A] [Module R A] [Module (SymmetricAlgebra R M) A]
+variable [IsScalarTower R (SymmetricAlgebra R M) A]
+
+/-- The right-module structure induced by commutativity, used by the square-zero extension. -/
+local instance commOppositeModule (S A : Type*) [CommSemiring S] [AddCommMonoid A] [Module S A] :
+    Module Sᵐᵒᵖ A :=
+  Module.compHom A (RingEquiv.toOpposite S).symm.toRingHom
+
+local instance commCentralScalar (S A : Type*) [CommSemiring S] [AddCommMonoid A] [Module S A] :
+    IsCentralScalar S A where
+  op_smul_eq_smul _ _ := rfl
+
+private noncomputable def derivationGeneratorLift
+    (f : M →ₗ[R] A) :
+    M →ₗ[R] TrivSqZeroExt (SymmetricAlgebra R M) A :=
+  (TrivSqZeroExt.inlAlgHom R (SymmetricAlgebra R M) A).toLinearMap.comp
+      (ι R M) +
+    ((TrivSqZeroExt.inrHom (SymmetricAlgebra R M) A).restrictScalars R).comp f
+
+private noncomputable def derivationLift (f : M →ₗ[R] A) :
+    SymmetricAlgebra R M →ₐ[R]
+      TrivSqZeroExt (SymmetricAlgebra R M) A :=
+  lift (derivationGeneratorLift f)
+
+private theorem derivationLift_fst (f : M →ₗ[R] A)
+    (a : SymmetricAlgebra R M) :
+    (derivationLift f a).fst = a := by
+  have h : (TrivSqZeroExt.fstHom R (SymmetricAlgebra R M) A).comp
+      (derivationLift f) =
+      AlgHom.id R (SymmetricAlgebra R M) := by
+    apply algHom_ext
+    ext x
+    simp [derivationLift, derivationGeneratorLift]
+  exact AlgHom.congr_fun h a
+
+private noncomputable def mkDerivationAux (f : M →ₗ[R] A) :
+    Derivation R (SymmetricAlgebra R M) A where
+  toLinearMap :=
+    ((TrivSqZeroExt.sndHom (SymmetricAlgebra R M) A).restrictScalars R).comp
+      (derivationLift f).toLinearMap
+  map_one_eq_zero' := by
+    -- Expose the square-zero component used as the derivation value.
+    change (derivationLift f 1).snd = 0
+    rw [map_one, TrivSqZeroExt.snd_one]
+  leibniz' a b := by
+    -- Express Leibniz in the square-zero component before expanding multiplication.
+    change (derivationLift f (a * b)).snd =
+      a • (derivationLift f b).snd + b • (derivationLift f a).snd
+    rw [map_mul, TrivSqZeroExt.snd_mul, derivationLift_fst, derivationLift_fst]
+    simp only [op_smul_eq_smul]
+
+private theorem mkDerivationAux_ι (f : M →ₗ[R] A) (x : M) :
+    mkDerivationAux f (ι R M x) = f x := by
+  simp [mkDerivationAux, derivationLift, derivationGeneratorLift]
+
+omit [IsScalarTower R (SymmetricAlgebra R M) A] in
+/-- Two derivations of a symmetric algebra are equal if they agree on the canonical generators. -/
+@[ext]
+theorem derivation_ext
+    {D₁ D₂ : Derivation R (SymmetricAlgebra R M) A}
+    (h : ∀ x, D₁ (ι R M x) = D₂ (ι R M x)) : D₁ = D₂ := by
+  apply Derivation.ext
+  intro a
+  induction a using SymmetricAlgebra.induction with
+  | algebraMap r => simp
+  | ι x => exact h x
+  | mul a b ha hb => simp only [Derivation.leibniz, ha, hb]
+  | add a b ha hb => simp only [map_add, ha, hb]
+
+/-- The derivation on `SymmetricAlgebra R M` taking the prescribed value `f x` on each canonical
+generator `SymmetricAlgebra.ι R M x`. -/
+noncomputable def mkDerivation :
+    (M →ₗ[R] A) →ₗ[R] Derivation R (SymmetricAlgebra R M) A where
+  toFun := mkDerivationAux
+  map_add' f g := derivation_ext fun x => by simp [mkDerivationAux_ι]
+  map_smul' r f := derivation_ext fun x => by simp [mkDerivationAux_ι]
+
+/-- `mkDerivation` takes the prescribed value on a canonical symmetric-algebra generator. -/
+@[simp]
+theorem mkDerivation_ι (f : M →ₗ[R] A) (x : M) :
+    mkDerivation f (ι R M x) = f x :=
+  mkDerivationAux_ι f x
+
+/-- Restriction to the canonical generators identifies derivations of a symmetric algebra with
+linear maps out of its generating module. -/
+noncomputable def mkDerivationEquiv :
+    (M →ₗ[R] A) ≃ₗ[R] Derivation R (SymmetricAlgebra R M) A :=
+  LinearEquiv.symm <|
+    { invFun := mkDerivation
+      toFun := fun D => D.toLinearMap.comp (ι R M)
+      map_add' := fun _ _ => rfl
+      map_smul' := fun _ _ => rfl
+      left_inv := fun _D => derivation_ext fun x => mkDerivation_ι _ x
+      right_inv := fun f => LinearMap.ext fun x => mkDerivation_ι f x }
+
+@[simp]
+theorem mkDerivationEquiv_apply (f : M →ₗ[R] A) :
+    mkDerivationEquiv f = mkDerivation f := by
+  rfl
+
+@[simp]
+theorem mkDerivationEquiv_symm_apply
+    (D : Derivation R (SymmetricAlgebra R M) A) :
+    (mkDerivationEquiv.symm D : M →ₗ[R] A) =
+      D.toLinearMap.comp (ι R M) := by
+  rfl
+
+end
+
+end SymmetricAlgebra


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the derivation interface needed for the PBW action on a symmetric algebra.

- Extends prescribed generator values to a derivation.
- Identifies derivations with linear maps out of the generating module.
- Reuses the construction for additive-group tangent vectors.

## Roadmap target

Supplies a prerequisite for [Layer 3 PBW](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md#layer-3-enveloping-algebra-verma-modules-and-lλ).

## Verification

Focused/full builds, consumers, axiom/module audits, golf, and aggregate `2+1` pass at `c96ccdfa5ec791ae7629aef6637bd8fbee2a230e`.

## Scale and generality

Changes two files by +173/−55 lines. The API works over a commutative semiring and for module-valued derivations over the symmetric algebra.

## Scope

- **Consumes:** the symmetric-algebra universal property and square-zero extensions.
- **Provides:** generator extension, extensionality, and the restriction equivalence.
- **Fits:** gives the PBW action one canonical derivation owner.
- **Boundary:** the PBW action and associated-graded injectivity remain downstream.

<sub>🤖 GPT-5.6 Sol high · [rubrics](https://github.com/TauCetiProject/TauCetiReview/commit/98e9b073b76e65285fa72d4b8e0a61e272a78fd8) · [2+1](https://github.com/utensil/formal-land/commit/a2f407974d068772356bc7ec209fc5d88dac3217) fixed: attribution 1, proof quality 1, reuse 1</sub>