### PR TITLE
feat: the divisor sum of the ideal von Mangoldt function, and the logarithmic derivative it computes

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Convolution.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Convolution.lean
@@ -28,6 +28,8 @@ on `ArithmeticFunction ℂ`.
   ideal and `0` elsewhere.
 * `TauCeti.Ideal.divisorsAntidiagonal A` is the finite set of pairs `(B, C)` of nonzero ideals with
   `B * C = A`; it is the ideal analogue of Mathlib's `Nat.divisorsAntidiagonal`.
+* `TauCeti.Ideal.divisors A` is its first projection, the finite set of nonzero ideals dividing
+  `A`; it is the ideal analogue of Mathlib's `Nat.divisors`.
 * `TauCeti.IdealArithmeticFunction.convolution f g` is the ideal Dirichlet convolution.
 * `TauCeti.IdealArithmeticFunction.convolutionPow f n` is the `n`-fold convolution power of `f`.
 
@@ -39,6 +41,9 @@ on `ArithmeticFunction ℂ`.
   `TauCeti.IdealArithmeticFunction.convolution_delta`: the convolution monoid laws.
 * `TauCeti.IdealArithmeticFunction.convolution_add` and
   `TauCeti.IdealArithmeticFunction.add_convolution`: bilinearity over pointwise addition.
+* `TauCeti.Ideal.sum_divisorsAntidiagonal_fst` and
+  `TauCeti.Ideal.sum_divisorsAntidiagonal_snd`: a sum over the antidiagonal that depends on only
+  one of the two factors is a sum over the divisors.
 * `TauCeti.IdealArithmeticFunction.convolution_one_one_ne_mul`: ideal convolution is not the
   pointwise product.
 * `TauCeti.normCoeff_delta`, `TauCeti.normCoeff_convolution`, and
@@ -202,6 +207,51 @@ theorem one_lt_card_divisorsAntidiagonal {A : (Ideal (𝓞 K))⁰} (hA : A ≠ 1
   refine Finset.one_lt_card.mpr ⟨(1, A), by simp, (A, 1), by simp, ?_⟩
   simp only [ne_eq, Prod.mk.injEq, not_and]
   exact fun h => absurd h.symm hA
+
+/-! ### The divisors of a nonzero ideal -/
+
+/-- The **divisors** of a nonzero ideal `A`: the finite set of nonzero ideals dividing `A`. It is
+the first projection of `TauCeti.Ideal.divisorsAntidiagonal`, and the ideal analogue of Mathlib's
+`Nat.divisors`. -/
+noncomputable def divisors (A : (Ideal (𝓞 K))⁰) : Finset ((Ideal (𝓞 K))⁰) :=
+  (divisorsAntidiagonal A).image Prod.fst
+
+/-- A nonzero ideal is a divisor of `A` exactly when it divides `A`. -/
+@[simp]
+theorem mem_divisors {A B : (Ideal (𝓞 K))⁰} :
+    B ∈ divisors A ↔ (B : Ideal (𝓞 K)) ∣ (A : Ideal (𝓞 K)) := by
+  refine ⟨fun hB ↦ ?_, fun ⟨C, hC⟩ ↦ ?_⟩
+  · obtain ⟨p, hp, rfl⟩ := Finset.mem_image.mp hB
+    exact fst_dvd_of_mem_divisorsAntidiagonal hp
+  · have hC0 : C ≠ 0 := fun h ↦
+      nonZeroDivisors.coe_ne_zero A (by rw [hC, h, mul_zero])
+    exact Finset.mem_image.mpr
+      ⟨(B, ⟨C, mem_nonZeroDivisors_of_ne_zero hC0⟩),
+        mem_divisorsAntidiagonal.mpr (Subtype.ext (by simpa using hC.symm)), rfl⟩
+
+/-- The unit ideal is its own only divisor. -/
+@[simp]
+theorem divisors_one : divisors (1 : (Ideal (𝓞 K))⁰) = {1} := by
+  rw [divisors, divisorsAntidiagonal_one, Finset.image_singleton]
+
+/-- A sum over the antidiagonal of `A` that depends only on the first factor is a sum over the
+divisors of `A`. -/
+theorem sum_divisorsAntidiagonal_fst {M : Type*} [AddCommMonoid M] (A : (Ideal (𝓞 K))⁰)
+    (f : (Ideal (𝓞 K))⁰ → M) :
+    ∑ p ∈ divisorsAntidiagonal A, f p.1 = ∑ B ∈ divisors A, f B := by
+  refine (Finset.sum_image fun p hp q hq hpq ↦ Prod.ext hpq ?_).symm
+  refine mul_left_cancel (a := p.1) ?_
+  rw [mem_divisorsAntidiagonal.mp hp, ← mem_divisorsAntidiagonal.mp hq, hpq]
+
+/-- A sum over the antidiagonal of `A` that depends only on the second factor is a sum over the
+divisors of `A`. -/
+theorem sum_divisorsAntidiagonal_snd {M : Type*} [AddCommMonoid M] (A : (Ideal (𝓞 K))⁰)
+    (f : (Ideal (𝓞 K))⁰ → M) :
+    ∑ p ∈ divisorsAntidiagonal A, f p.2 = ∑ B ∈ divisors A, f B := by
+  rw [← sum_divisorsAntidiagonal_fst]
+  exact Finset.sum_nbij' Prod.swap Prod.swap (fun p hp ↦ swap_mem_divisorsAntidiagonal hp)
+    (fun p hp ↦ swap_mem_divisorsAntidiagonal hp) (fun _ _ ↦ Prod.swap_swap _)
+    (fun _ _ ↦ Prod.swap_swap _) (fun _ _ ↦ rfl)
 
 end Ideal
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Estimates.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.NumberTheory.LSeries.Convergence
 public import Mathlib.NumberTheory.LSeries.SumCoeff
 public import Mathlib.NumberTheory.NumberField.Ideal.Asymptotics
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Trivial
 
 /-!
@@ -38,7 +39,9 @@ of a convergent series of nonnegative terms must become arbitrarily small.
 * `TauCeti.idealCount_linearBounds`: such a package exists for every number field.
 * `TauCeti.abscissaOfAbsConv_normCoeff_one`: the abscissa of absolute convergence of the trivial
   ideal weight is exactly `1`; `TauCeti.LSeriesSummable_normCoeff_one_iff` is the sharp
-  convergence criterion.
+  convergence criterion, and `TauCeti.idealAbscissaOfAbsConv_one` the same value for the
+  ideal-indexed series, which the nonnegativity of the coefficients makes agree with the grouped
+  one.
 * `TauCeti.abscissaOfAbsConv_dedekindZetaCoeff` and `TauCeti.LSeriesSummable_dedekindZetaCoeff_iff`
   are the same two statements for `TauCeti.dedekindZetaCoeff`, the coefficient system Mathlib's
   `NumberField.dedekindZeta` is the `LSeries` of.  That system counts *all* integral ideals, so it
@@ -409,6 +412,16 @@ theorem LSeriesSummable_normCoeff_one_iff {s : ℂ} :
         (not_LSeriesSummable_normCoeff_one K)
   · rw [abscissaOfAbsConv_normCoeff_one K]
     exact_mod_cast h
+
+open scoped ComplexOrder in
+/-- **The ideal-indexed abscissa of absolute convergence of the trivial ideal weight is `1`.**
+Its coefficients are nonnegative, so there is no cancellation inside a norm fibre to separate the
+ideal-indexed abscissa from the grouped one. -/
+@[simp]
+theorem idealAbscissaOfAbsConv_one :
+    idealAbscissaOfAbsConv K (1 : IdealArithmeticFunction K) = 1 := by
+  rw [idealAbscissaOfAbsConv_eq_abscissaOfAbsConv K 1 fun _ ↦ zero_le_one,
+    abscissaOfAbsConv_normCoeff_one]
 
 /-- **The Dedekind zeta series has abscissa of absolute convergence `1`.** -/
 @[simp]

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean
@@ -9,7 +9,6 @@ public import Mathlib.Analysis.Calculus.LogDeriv
 public import Mathlib.NumberTheory.LSeries.Convolution
 public import Mathlib.NumberTheory.LSeries.Deriv
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Estimates
-public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.VonMangoldt
 
 /-!
@@ -18,7 +17,10 @@ public import TauCeti.NumberTheory.ArithmeticDirichletSeries.VonMangoldt
 For a completely multiplicative ideal weight `χ`, the von Mangoldt transform `χ Λ` is the
 coefficient system of the logarithmic derivative of the Dirichlet series of `χ`: on the half-plane
 where the ideal-indexed series of `χ` converges absolutely,
-`∑_A χ(A) Λ(A) N(A)^{-s} = -L'(s) / L(s)`.
+`(∑_A χ(A) Λ(A) N(A)^{-s}) L(s) = -L'(s)`, hence `∑_A χ(A) Λ(A) N(A)^{-s} = -L'(s) / L(s)` at every
+point of that half-plane at which `L(s) ≠ 0`.  The nonvanishing is an explicit hypothesis of the
+quotient forms below: it is not proved here, since for the Dedekind zeta function it is the Euler
+product of Layer 3.
 
 The proof is purely algebraic apart from one convergence estimate. The divisor sum
 `TauCeti.IdealArithmeticFunction.convolution_vonMangoldt_one` identifies `Λ ⋆ 1` with the ideal
@@ -36,10 +38,12 @@ needed.
   transform of `f` converges absolutely wherever that of `f` does.
 * `TauCeti.MultiplicativeIdealWeight.convolution_vonMangoldtTransform`: the convolution identity
   `(χ Λ) ⋆ χ = (log N) χ` for a completely multiplicative weight.
+* `TauCeti.MultiplicativeIdealWeight.LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv`:
+  the identity in product form, on the whole half-plane and with no nonvanishing hypothesis.
 * `TauCeti.MultiplicativeIdealWeight.LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv`:
-  the logarithmic derivative identity.
+  the logarithmic derivative identity, assuming `L(s) ≠ 0`.
 * `TauCeti.LSeries_normCoeff_vonMangoldt_eq_neg_logDeriv_dedekindZeta`: its instance at the trivial
-  weight, `-ζ_K'(s) / ζ_K(s) = ∑_A Λ(A) N(A)^{-s}` on `Re s > 1`.
+  weight, `-ζ_K'(s) / ζ_K(s) = ∑_A Λ(A) N(A)^{-s}` for `Re s > 1` with `ζ_K(s) ≠ 0`.
 
 ## Roadmap role
 
@@ -50,6 +54,7 @@ nonnegative von Mangoldt coefficient system on `Re s > 1`.
 
 ## References
 
+* H. Davenport, *Multiplicative Number Theory*, Chapter 1.
 * J. Neukirch, *Algebraic Number Theory*, Chapter VII.
 * G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapters I.2 and II.
 * Mathlib's `ArithmeticFunction.vonMangoldt_mul_zeta` is the rational-prime analogue of the divisor

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean
@@ -14,13 +14,13 @@ public import TauCeti.NumberTheory.ArithmeticDirichletSeries.VonMangoldt
 /-!
 # The logarithmic derivative of the Dirichlet series of an ideal weight
 
-For a completely multiplicative ideal weight `χ`, the von Mangoldt transform `χ Λ` is the
-coefficient system of the logarithmic derivative of the Dirichlet series of `χ`: on the half-plane
-where the ideal-indexed series of `χ` converges absolutely,
-`(∑_A χ(A) Λ(A) N(A)^{-s}) L(s) = -L'(s)`, hence `∑_A χ(A) Λ(A) N(A)^{-s} = -L'(s) / L(s)` at every
-point of that half-plane at which `L(s) ≠ 0`.  The nonvanishing is an explicit hypothesis of the
-quotient forms below: it is not proved here, since for the Dedekind zeta function it is the Euler
-product of Layer 3.
+For a completely multiplicative ideal arithmetic function `χ` — a multiplicative ideal weight, for
+instance — the von Mangoldt transform `χ Λ` is the coefficient system of the logarithmic derivative
+of the Dirichlet series of `χ`: on the half-plane where the ideal-indexed series of `χ` converges
+absolutely, `(∑_A χ(A) Λ(A) N(A)^{-s}) L(s) = -L'(s)`, hence
+`∑_A χ(A) Λ(A) N(A)^{-s} = -L'(s) / L(s)` at every point of that half-plane at which `L(s) ≠ 0`.
+The nonvanishing is an explicit hypothesis of the quotient forms below: it is not proved here,
+since for the Dedekind zeta function it is the Euler product of Layer 3.
 
 The proof is purely algebraic apart from one convergence estimate. The divisor sum
 `TauCeti.IdealArithmeticFunction.convolution_vonMangoldt_one` identifies `Λ ⋆ 1` with the ideal
@@ -28,7 +28,8 @@ logarithm, complete multiplicativity twists that identity into
 `(χ Λ) ⋆ χ = (log N) χ`, regrouping by absolute norm turns the ideal convolution into Mathlib's
 Dirichlet convolution, and the absolute norm is constant on a norm fibre, so the regrouped
 `(log N) χ` is exactly Mathlib's `LSeries.logMul` of the regrouped `χ`. No Euler product is
-needed.
+needed.  Nothing beyond complete multiplicativity is used, so none of this asks for the finiteness
+condition carried by `TauCeti.MultiplicativeIdealWeight`.
 
 ## Main results
 
@@ -36,14 +37,14 @@ needed.
   regrouping of `f`.
 * `TauCeti.summable_idealTerm_vonMangoldtTransform`: the ideal-indexed series of the von Mangoldt
   transform of `f` converges absolutely wherever that of `f` does.
-* `TauCeti.MultiplicativeIdealWeight.convolution_vonMangoldtTransform`: the convolution identity
-  `(χ Λ) ⋆ χ = (log N) χ` for a completely multiplicative weight.
-* `TauCeti.MultiplicativeIdealWeight.LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv`:
-  the identity in product form, on the whole half-plane and with no nonvanishing hypothesis.
-* `TauCeti.MultiplicativeIdealWeight.LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv`:
-  the logarithmic derivative identity, assuming `L(s) ≠ 0`.
-* `TauCeti.LSeries_normCoeff_vonMangoldt_eq_neg_logDeriv_dedekindZeta`: its instance at the trivial
-  weight, `-ζ_K'(s) / ζ_K(s) = ∑_A Λ(A) N(A)^{-s}` for `Re s > 1` with `ζ_K(s) ≠ 0`.
+* `TauCeti.IdealArithmeticFunction.convolution_vonMangoldtTransform`: the convolution identity
+  `(χ Λ) ⋆ χ = (log N) χ` for a completely multiplicative `χ`.
+* `TauCeti.LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv`: the identity in product form,
+  on the whole half-plane and with no nonvanishing hypothesis.
+* `TauCeti.LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv`: the logarithmic derivative
+  identity, assuming `L(s) ≠ 0`.
+* `TauCeti.LSeries_normCoeff_vonMangoldt_eq_neg_logDeriv_dedekindZeta`: its instance at the
+  constant-one weight, `-ζ_K'(s) / ζ_K(s) = ∑_A Λ(A) N(A)^{-s}` for `Re s > 1` with `ζ_K(s) ≠ 0`.
 
 ## Roadmap role
 
@@ -136,91 +137,89 @@ theorem summable_idealTerm_vonMangoldtTransform {f : IdealArithmeticFunction K} 
 
 /-! ### The logarithmic derivative -/
 
-namespace MultiplicativeIdealWeight
+namespace IdealArithmeticFunction
 
-/-- **The convolution identity behind the logarithmic derivative.** For a completely multiplicative
-weight `χ`, convolving the von Mangoldt transform `χ Λ` with `χ` gives the pointwise product of the
-ideal logarithm with `χ`. It is the divisor sum `Λ ⋆ 1 = log N`, twisted by `χ`. -/
-theorem convolution_vonMangoldtTransform (χ : MultiplicativeIdealWeight K) :
-    IdealArithmeticFunction.convolution χ.toIdealArithmeticFunction.vonMangoldtTransform
-        χ.toIdealArithmeticFunction =
-      IdealArithmeticFunction.log * χ.toIdealArithmeticFunction := by
+/-- **The convolution identity behind the logarithmic derivative.** For a completely
+multiplicative ideal arithmetic function `f`, convolving the von Mangoldt transform `f Λ` with `f`
+gives the pointwise product of the ideal logarithm with `f`. It is the divisor sum `Λ ⋆ 1 = log N`,
+twisted by `f`.
+
+Only complete multiplicativity enters, so the hypothesis is stated for a bare ideal arithmetic
+function; a `TauCeti.MultiplicativeIdealWeight` supplies it through its multiplicativity. -/
+theorem convolution_vonMangoldtTransform {f : IdealArithmeticFunction K}
+    (hf : ∀ A B : (Ideal (𝓞 K))⁰, f (A * B) = f A * f B) :
+    convolution f.vonMangoldtTransform f = log * f := by
   funext A
-  rw [Pi.mul_apply, ← IdealArithmeticFunction.convolution_vonMangoldt_one,
-    IdealArithmeticFunction.convolution_apply, IdealArithmeticFunction.convolution_apply,
+  rw [Pi.mul_apply, ← convolution_vonMangoldt_one, convolution_apply, convolution_apply,
     Finset.sum_mul]
   refine Finset.sum_congr rfl fun p hp ↦ ?_
-  have hA : (A : Ideal (𝓞 K)) = (p.1 : Ideal (𝓞 K)) * (p.2 : Ideal (𝓞 K)) := by
-    rw [← Ideal.mem_divisorsAntidiagonal.mp hp]; simp
-  simp only [IdealArithmeticFunction.vonMangoldtTransform_apply, Pi.one_apply,
-    toIdealArithmeticFunction_apply, hA, _root_.map_mul]
+  have hA : A = p.1 * p.2 := (Ideal.mem_divisorsAntidiagonal.mp hp).symm
+  simp only [vonMangoldtTransform_apply, Pi.one_apply, hA, hf]
   ring
 
+end IdealArithmeticFunction
+
 /-- Regrouping the convolution identity by absolute norm identifies the Dirichlet-convolution
-product of the two regrouped coefficient systems with `LSeries.logMul` of the regrouping of `χ`. -/
-theorem normCoeff_vonMangoldtTransform_mul (χ : MultiplicativeIdealWeight K) :
-    ((normCoeff K χ.toIdealArithmeticFunction.vonMangoldtTransform *
-        normCoeff K χ.toIdealArithmeticFunction : ArithmeticFunction ℂ) : ℕ → ℂ) =
-      LSeries.logMul (normCoeff K χ.toIdealArithmeticFunction) := by
-  rw [← normCoeff_convolution, convolution_vonMangoldtTransform, normCoeff_log_mul]
+product of the two regrouped coefficient systems with `LSeries.logMul` of the regrouping of `f`. -/
+theorem normCoeff_vonMangoldtTransform_mul {f : IdealArithmeticFunction K}
+    (hf : ∀ A B : (Ideal (𝓞 K))⁰, f (A * B) = f A * f B) :
+    ((normCoeff K f.vonMangoldtTransform * normCoeff K f : ArithmeticFunction ℂ) : ℕ → ℂ) =
+      LSeries.logMul (normCoeff K f) := by
+  rw [← normCoeff_convolution, IdealArithmeticFunction.convolution_vonMangoldtTransform hf,
+    normCoeff_log_mul]
 
 /-- **The von Mangoldt transform is the coefficient system of the logarithmic derivative**, in
-product form: on the half-plane of absolute convergence of the ideal-indexed series of `χ`, the
-`LSeries` of the regrouped `χ Λ` times the `LSeries` of the regrouped `χ` is `-L'`. -/
-theorem LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv
-    (χ : MultiplicativeIdealWeight K) {s : ℂ}
-    (hs : idealAbscissaOfAbsConv K χ.toIdealArithmeticFunction < s.re) :
-    LSeries (normCoeff K χ.toIdealArithmeticFunction.vonMangoldtTransform) s *
-        LSeries (normCoeff K χ.toIdealArithmeticFunction) s =
-      -deriv (LSeries (normCoeff K χ.toIdealArithmeticFunction)) s := by
-  have habs : LSeries.abscissaOfAbsConv (normCoeff K χ.toIdealArithmeticFunction) < s.re :=
+product form: on the half-plane of absolute convergence of the ideal-indexed series of a completely
+multiplicative `f`, the `LSeries` of the regrouped `f Λ` times the `LSeries` of the regrouped `f`
+is `-L'`. -/
+theorem LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv {f : IdealArithmeticFunction K}
+    (hf : ∀ A B : (Ideal (𝓞 K))⁰, f (A * B) = f A * f B) {s : ℂ}
+    (hs : idealAbscissaOfAbsConv K f < s.re) :
+    LSeries (normCoeff K f.vonMangoldtTransform) s * LSeries (normCoeff K f) s =
+      -deriv (LSeries (normCoeff K f)) s := by
+  have habs : LSeries.abscissaOfAbsConv (normCoeff K f) < s.re :=
     lt_of_le_of_lt (abscissaOfAbsConv_normCoeff_le K _) hs
   rw [← ArithmeticFunction.LSeries_mul'
       (LSeriesSummable_normCoeff K (summable_idealTerm_vonMangoldtTransform hs))
       (LSeriesSummable_normCoeff K (summable_idealTerm_of_idealAbscissaOfAbsConv_lt_re K hs)),
-    normCoeff_vonMangoldtTransform_mul, LSeries_deriv habs, neg_neg]
+    normCoeff_vonMangoldtTransform_mul hf, LSeries_deriv habs, neg_neg]
 
 /-- **The exact coefficient identity for the logarithmic derivative.** On the half-plane of
-absolute convergence of the ideal-indexed series of a completely multiplicative weight `χ`, and
-away from the zeros of its `LSeries`, the `LSeries` of the regrouped von Mangoldt transform `χ Λ`
-is the negative of the logarithmic derivative.
+absolute convergence of the ideal-indexed series of a completely multiplicative ideal arithmetic
+function `f`, and away from the zeros of its `LSeries`, the `LSeries` of the regrouped von Mangoldt
+transform `f Λ` is the negative of the logarithmic derivative.
 
 Every prime power carries a coefficient here; removing the higher prime powers is a later
 estimate, not a simplification of this identity. -/
-theorem LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv
-    (χ : MultiplicativeIdealWeight K) {s : ℂ}
-    (hs : idealAbscissaOfAbsConv K χ.toIdealArithmeticFunction < s.re)
-    (hL : LSeries (normCoeff K χ.toIdealArithmeticFunction) s ≠ 0) :
-    LSeries (normCoeff K χ.toIdealArithmeticFunction.vonMangoldtTransform) s =
-      -logDeriv (LSeries (normCoeff K χ.toIdealArithmeticFunction)) s := by
+theorem LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv {f : IdealArithmeticFunction K}
+    (hf : ∀ A B : (Ideal (𝓞 K))⁰, f (A * B) = f A * f B) {s : ℂ}
+    (hs : idealAbscissaOfAbsConv K f < s.re) (hL : LSeries (normCoeff K f) s ≠ 0) :
+    LSeries (normCoeff K f.vonMangoldtTransform) s =
+      -logDeriv (LSeries (normCoeff K f)) s := by
   rw [logDeriv_apply, ← neg_div, eq_div_iff hL]
-  exact LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv χ hs
-
-end MultiplicativeIdealWeight
+  exact LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv hf hs
 
 /-! ### The Dedekind zeta function -/
 
 /-- **The logarithmic derivative of the Dedekind zeta function**: for `Re s > 1` and away from the
 zeros of `ζ_K`, the Dirichlet series with the ideal von Mangoldt coefficients is `-ζ_K'/ζ_K`.
 
-This is the trivial-weight instance of
-`TauCeti.MultiplicativeIdealWeight.LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv`, whose
-absolute-convergence hypothesis is `1 < Re s` here by `TauCeti.idealAbscissaOfAbsConv_one`. The
-nonvanishing hypothesis is genuinely assumed: `ζ_K` has no zero on `Re s > 1`, but that is the
-Euler product of Layer 3 and is not available yet. -/
+This is the constant-one instance of
+`TauCeti.LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv`, whose absolute-convergence
+hypothesis is `1 < Re s` here by `TauCeti.idealAbscissaOfAbsConv_one`. The nonvanishing hypothesis
+is genuinely assumed: `ζ_K` has no zero on `Re s > 1`, but that is the Euler product of Layer 3 and
+is not available yet. -/
 theorem LSeries_normCoeff_vonMangoldt_eq_neg_logDeriv_dedekindZeta {s : ℂ} (hs : 1 < s.re)
     (hζ : NumberField.dedekindZeta K s ≠ 0) :
     LSeries (normCoeff K (IdealArithmeticFunction.vonMangoldt : IdealArithmeticFunction K)) s =
       -logDeriv (NumberField.dedekindZeta K) s := by
   have hzeta : NumberField.dedekindZeta K = LSeries (normCoeff K (1 : IdealArithmeticFunction K)) :=
     funext (dedekindZeta_eq_LSeries_normCoeff_one K)
-  have hone := MultiplicativeIdealWeight.toIdealArithmeticFunction_one (K := K)
-  have hs' : idealAbscissaOfAbsConv K
-      (1 : MultiplicativeIdealWeight K).toIdealArithmeticFunction < s.re := by
-    rw [hone, idealAbscissaOfAbsConv_one]
+  have hs' : idealAbscissaOfAbsConv K (1 : IdealArithmeticFunction K) < s.re := by
+    rw [idealAbscissaOfAbsConv_one]
     exact_mod_cast hs
-  have := MultiplicativeIdealWeight.LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv
-    (1 : MultiplicativeIdealWeight K) hs' (by rwa [hone, ← hzeta])
-  rwa [hone, IdealArithmeticFunction.vonMangoldtTransform_one, ← hzeta] at this
+  have := LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv
+    (f := (1 : IdealArithmeticFunction K)) (fun A B ↦ by simp) hs' (by rwa [← hzeta])
+  rwa [IdealArithmeticFunction.vonMangoldtTransform_one, ← hzeta] at this
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Calculus.LogDeriv
+public import Mathlib.NumberTheory.LSeries.Convolution
+public import Mathlib.NumberTheory.LSeries.Deriv
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Estimates
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Regroup
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.VonMangoldt
+
+/-!
+# The logarithmic derivative of the Dirichlet series of an ideal weight
+
+For a completely multiplicative ideal weight `χ`, the von Mangoldt transform `χ Λ` is the
+coefficient system of the logarithmic derivative of the Dirichlet series of `χ`: on the half-plane
+where the ideal-indexed series of `χ` converges absolutely,
+`∑_A χ(A) Λ(A) N(A)^{-s} = -L'(s) / L(s)`.
+
+The proof is purely algebraic apart from one convergence estimate. The divisor sum
+`TauCeti.IdealArithmeticFunction.convolution_vonMangoldt_one` identifies `Λ ⋆ 1` with the ideal
+logarithm, complete multiplicativity twists that identity into
+`(χ Λ) ⋆ χ = (log N) χ`, regrouping by absolute norm turns the ideal convolution into Mathlib's
+Dirichlet convolution, and the absolute norm is constant on a norm fibre, so the regrouped
+`(log N) χ` is exactly Mathlib's `LSeries.logMul` of the regrouped `χ`. No Euler product is
+needed.
+
+## Main results
+
+* `TauCeti.normCoeff_log_mul`: regrouping `(log N) f` by absolute norm is `LSeries.logMul` of the
+  regrouping of `f`.
+* `TauCeti.summable_idealTerm_vonMangoldtTransform`: the ideal-indexed series of the von Mangoldt
+  transform of `f` converges absolutely wherever that of `f` does.
+* `TauCeti.MultiplicativeIdealWeight.convolution_vonMangoldtTransform`: the convolution identity
+  `(χ Λ) ⋆ χ = (log N) χ` for a completely multiplicative weight.
+* `TauCeti.MultiplicativeIdealWeight.LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv`:
+  the logarithmic derivative identity.
+* `TauCeti.LSeries_normCoeff_vonMangoldt_eq_neg_logDeriv_dedekindZeta`: its instance at the trivial
+  weight, `-ζ_K'(s) / ζ_K(s) = ∑_A Λ(A) N(A)^{-s}` on `Re s > 1`.
+
+## Roadmap role
+
+This completes Layer **2.3** of `TauCetiRoadmap/ArithmeticDirichletSeries/README.md`, whose target
+asks for "the exact coefficient identity for the logarithmic derivative of an Euler product on its
+absolute-convergence half-plane". Layer 10.1 consumes the trivial-weight instance as the exact
+nonnegative von Mangoldt coefficient system on `Re s > 1`.
+
+## References
+
+* J. Neukirch, *Algebraic Number Theory*, Chapter VII.
+* G. Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapters I.2 and II.
+* Mathlib's `ArithmeticFunction.vonMangoldt_mul_zeta` is the rational-prime analogue of the divisor
+  sum used here, and Mathlib's `LSeries_deriv` supplies the analytic half of the identity.
+-/
+
+public section
+
+namespace TauCeti
+
+open NumberField LSeries
+open scoped nonZeroDivisors NumberField ComplexOrder
+
+variable {K : Type*} [Field K] [NumberField K]
+
+/-! ### Regrouping the ideal logarithm -/
+
+/-- Regrouping the pointwise product of the ideal logarithm with `f` multiplies the `n`-th
+coefficient by `log n`: the absolute norm is constant on a norm fibre, so the logarithm factors out
+of the fibre sum. This identifies it with Mathlib's `LSeries.logMul`. -/
+theorem normCoeff_log_mul (f : IdealArithmeticFunction K) :
+    (normCoeff K (IdealArithmeticFunction.log * f) : ℕ → ℂ) =
+      LSeries.logMul (normCoeff K f) := by
+  funext n
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp
+  rw [normCoeff_eq_sum_normFiber, LSeries.logMul, normCoeff_eq_sum_normFiber, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun I hI ↦ ?_
+  rw [Pi.mul_apply, IdealArithmeticFunction.log_apply, (mem_normFiber K).mp hI,
+    Complex.natCast_log]
+
+/-! ### Absolute convergence of the twisted series -/
+
+/-- **The ideal logarithm does not move the abscissa.** The ideal-indexed Dirichlet series of
+`(log N) f` converges absolutely wherever that of `f` does, because `log t` is dominated by every
+positive power of `t`. This is the ideal-indexed analogue of Mathlib's
+`LSeries.abscissaOfAbsConv_logMul`. -/
+theorem summable_idealTerm_log_mul {f : IdealArithmeticFunction K} {s : ℂ}
+    (hs : idealAbscissaOfAbsConv K f < s.re) :
+    Summable (idealTerm K (IdealArithmeticFunction.log * f) s) := by
+  obtain ⟨x, hx, hxs⟩ := exists_summable_idealTerm_lt_re K hs
+  have hδ : 0 < s.re - x := by linarith
+  rw [← summable_norm_iff] at hx ⊢
+  refine (hx.mul_left (s.re - x)⁻¹).of_nonneg_of_le (fun _ ↦ norm_nonneg _) fun I ↦ ?_
+  have hN1 : (1 : ℝ) ≤ (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) := by
+    exact_mod_cast Ideal.absNorm_pos_of_nonZeroDivisors I
+  have hN0 : (0 : ℝ) < (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) := by linarith
+  have hsplit : (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ s.re =
+      (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ (s.re - x) *
+        (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ x := by
+    rw [← Real.rpow_add hN0]; ring_nf
+  rw [norm_idealTerm, norm_idealTerm, Complex.ofReal_re, Pi.mul_apply, norm_mul,
+    IdealArithmeticFunction.log_apply, Complex.norm_real,
+    Real.norm_of_nonneg (Real.log_nonneg hN1), hsplit, div_mul_eq_div_div, ← mul_div_assoc]
+  gcongr
+  calc Real.log (Ideal.absNorm (I : Ideal (𝓞 K))) * ‖f I‖ /
+        (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ (s.re - x)
+      = Real.log (Ideal.absNorm (I : Ideal (𝓞 K))) /
+          (Ideal.absNorm (I : Ideal (𝓞 K)) : ℝ) ^ (s.re - x) * ‖f I‖ := by ring
+    _ ≤ (s.re - x)⁻¹ * ‖f I‖ := by
+        gcongr
+        rw [div_le_iff₀ (Real.rpow_pos_of_pos hN0 _), inv_mul_eq_div]
+        exact Real.log_le_rpow_div hN0.le hδ
+
+/-- The ideal-indexed Dirichlet series of the von Mangoldt transform of `f` converges absolutely
+wherever that of `f` does, because `Λ (A) ≤ log N(A)`. -/
+theorem summable_idealTerm_vonMangoldtTransform {f : IdealArithmeticFunction K} {s : ℂ}
+    (hs : idealAbscissaOfAbsConv K f < s.re) :
+    Summable (idealTerm K f.vonMangoldtTransform s) := by
+  rw [← summable_norm_iff]
+  refine (summable_norm_iff.mpr (summable_idealTerm_log_mul hs)).of_nonneg_of_le
+    (fun _ ↦ norm_nonneg _) fun I ↦ ?_
+  rw [norm_idealTerm, norm_idealTerm]
+  gcongr
+  rw [IdealArithmeticFunction.vonMangoldtTransform_apply, Pi.mul_apply, norm_mul, norm_mul,
+    mul_comm]
+  gcongr
+  exact IdealArithmeticFunction.norm_vonMangoldt_le_norm_log I
+
+/-! ### The logarithmic derivative -/
+
+namespace MultiplicativeIdealWeight
+
+/-- **The convolution identity behind the logarithmic derivative.** For a completely multiplicative
+weight `χ`, convolving the von Mangoldt transform `χ Λ` with `χ` gives the pointwise product of the
+ideal logarithm with `χ`. It is the divisor sum `Λ ⋆ 1 = log N`, twisted by `χ`. -/
+theorem convolution_vonMangoldtTransform (χ : MultiplicativeIdealWeight K) :
+    IdealArithmeticFunction.convolution χ.toIdealArithmeticFunction.vonMangoldtTransform
+        χ.toIdealArithmeticFunction =
+      IdealArithmeticFunction.log * χ.toIdealArithmeticFunction := by
+  funext A
+  rw [Pi.mul_apply, ← IdealArithmeticFunction.convolution_vonMangoldt_one,
+    IdealArithmeticFunction.convolution_apply, IdealArithmeticFunction.convolution_apply,
+    Finset.sum_mul]
+  refine Finset.sum_congr rfl fun p hp ↦ ?_
+  have hA : (A : Ideal (𝓞 K)) = (p.1 : Ideal (𝓞 K)) * (p.2 : Ideal (𝓞 K)) := by
+    rw [← Ideal.mem_divisorsAntidiagonal.mp hp]; simp
+  simp only [IdealArithmeticFunction.vonMangoldtTransform_apply, Pi.one_apply,
+    toIdealArithmeticFunction_apply, hA, _root_.map_mul]
+  ring
+
+/-- Regrouping the convolution identity by absolute norm identifies the Dirichlet-convolution
+product of the two regrouped coefficient systems with `LSeries.logMul` of the regrouping of `χ`. -/
+theorem normCoeff_vonMangoldtTransform_mul (χ : MultiplicativeIdealWeight K) :
+    ((normCoeff K χ.toIdealArithmeticFunction.vonMangoldtTransform *
+        normCoeff K χ.toIdealArithmeticFunction : ArithmeticFunction ℂ) : ℕ → ℂ) =
+      LSeries.logMul (normCoeff K χ.toIdealArithmeticFunction) := by
+  rw [← normCoeff_convolution, convolution_vonMangoldtTransform, normCoeff_log_mul]
+
+/-- **The von Mangoldt transform is the coefficient system of the logarithmic derivative**, in
+product form: on the half-plane of absolute convergence of the ideal-indexed series of `χ`, the
+`LSeries` of the regrouped `χ Λ` times the `LSeries` of the regrouped `χ` is `-L'`. -/
+theorem LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv
+    (χ : MultiplicativeIdealWeight K) {s : ℂ}
+    (hs : idealAbscissaOfAbsConv K χ.toIdealArithmeticFunction < s.re) :
+    LSeries (normCoeff K χ.toIdealArithmeticFunction.vonMangoldtTransform) s *
+        LSeries (normCoeff K χ.toIdealArithmeticFunction) s =
+      -deriv (LSeries (normCoeff K χ.toIdealArithmeticFunction)) s := by
+  have habs : LSeries.abscissaOfAbsConv (normCoeff K χ.toIdealArithmeticFunction) < s.re :=
+    lt_of_le_of_lt (abscissaOfAbsConv_normCoeff_le K _) hs
+  rw [← ArithmeticFunction.LSeries_mul'
+      (LSeriesSummable_normCoeff K (summable_idealTerm_vonMangoldtTransform hs))
+      (LSeriesSummable_normCoeff K (summable_idealTerm_of_idealAbscissaOfAbsConv_lt_re K hs)),
+    normCoeff_vonMangoldtTransform_mul, LSeries_deriv habs, neg_neg]
+
+/-- **The exact coefficient identity for the logarithmic derivative.** On the half-plane of
+absolute convergence of the ideal-indexed series of a completely multiplicative weight `χ`, and
+away from the zeros of its `LSeries`, the `LSeries` of the regrouped von Mangoldt transform `χ Λ`
+is the negative of the logarithmic derivative.
+
+Every prime power carries a coefficient here; removing the higher prime powers is a later
+estimate, not a simplification of this identity. -/
+theorem LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv
+    (χ : MultiplicativeIdealWeight K) {s : ℂ}
+    (hs : idealAbscissaOfAbsConv K χ.toIdealArithmeticFunction < s.re)
+    (hL : LSeries (normCoeff K χ.toIdealArithmeticFunction) s ≠ 0) :
+    LSeries (normCoeff K χ.toIdealArithmeticFunction.vonMangoldtTransform) s =
+      -logDeriv (LSeries (normCoeff K χ.toIdealArithmeticFunction)) s := by
+  rw [logDeriv_apply, ← neg_div, eq_div_iff hL]
+  exact LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv χ hs
+
+end MultiplicativeIdealWeight
+
+/-! ### The Dedekind zeta function -/
+
+/-- **The logarithmic derivative of the Dedekind zeta function**: for `Re s > 1` and away from the
+zeros of `ζ_K`, the Dirichlet series with the ideal von Mangoldt coefficients is `-ζ_K'/ζ_K`.
+
+This is the trivial-weight instance of
+`TauCeti.MultiplicativeIdealWeight.LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv`, whose
+absolute-convergence hypothesis is `1 < Re s` here by `TauCeti.idealAbscissaOfAbsConv_one`. The
+nonvanishing hypothesis is genuinely assumed: `ζ_K` has no zero on `Re s > 1`, but that is the
+Euler product of Layer 3 and is not available yet. -/
+theorem LSeries_normCoeff_vonMangoldt_eq_neg_logDeriv_dedekindZeta {s : ℂ} (hs : 1 < s.re)
+    (hζ : NumberField.dedekindZeta K s ≠ 0) :
+    LSeries (normCoeff K (IdealArithmeticFunction.vonMangoldt : IdealArithmeticFunction K)) s =
+      -logDeriv (NumberField.dedekindZeta K) s := by
+  have hzeta : NumberField.dedekindZeta K = LSeries (normCoeff K (1 : IdealArithmeticFunction K)) :=
+    funext (dedekindZeta_eq_LSeries_normCoeff_one K)
+  have hone := MultiplicativeIdealWeight.toIdealArithmeticFunction_one (K := K)
+  have hs' : idealAbscissaOfAbsConv K
+      (1 : MultiplicativeIdealWeight K).toIdealArithmeticFunction < s.re := by
+    rw [hone, idealAbscissaOfAbsConv_one]
+    exact_mod_cast hs
+  have := MultiplicativeIdealWeight.LSeries_normCoeff_vonMangoldtTransform_eq_neg_logDeriv
+    (1 : MultiplicativeIdealWeight K) hs' (by rwa [hone, ← hzeta])
+  rwa [hone, IdealArithmeticFunction.vonMangoldtTransform_one, ← hzeta] at this
+
+end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean
@@ -88,7 +88,7 @@ theorem normCoeff_log_mul (f : IdealArithmeticFunction K) :
 
 /-! ### Absolute convergence of the twisted series -/
 
-/-- **The ideal logarithm does not move the abscissa.** The ideal-indexed Dirichlet series of
+/-- **The ideal logarithm does not increase the abscissa.** The ideal-indexed Dirichlet series of
 `(log N) f` converges absolutely wherever that of `f` does, because `log t` is dominated by every
 positive power of `t`. This is the ideal-indexed analogue of Mathlib's
 `LSeries.abscissaOfAbsConv_logMul`. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/Regroup.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/Regroup.lean
@@ -180,11 +180,18 @@ theorem idealAbscissaOfAbsConv_def (f : IdealArithmeticFunction K) :
     idealAbscissaOfAbsConv K f = sInf (Real.toEReal '' {x : ℝ | Summable (idealTerm K f x)}) :=
   (rfl)
 
+/-- Strictly to the right of the ideal-indexed abscissa the series already converges absolutely at
+some real point further to the left. This is the ideal analogue of Mathlib's
+`LSeriesSummable_lt_re_of_abscissaOfAbsConv_lt_re`. -/
+theorem exists_summable_idealTerm_lt_re {f : IdealArithmeticFunction K} {s : ℂ}
+    (hs : idealAbscissaOfAbsConv K f < s.re) :
+    ∃ x : ℝ, Summable (idealTerm K f x) ∧ x < s.re := by
+  simpa [idealAbscissaOfAbsConv, sInf_lt_iff] using hs
+
 /-- The ideal-indexed series converges absolutely strictly to the right of its abscissa. -/
 theorem summable_idealTerm_of_idealAbscissaOfAbsConv_lt_re {f : IdealArithmeticFunction K} {s : ℂ}
     (hs : idealAbscissaOfAbsConv K f < s.re) : Summable (idealTerm K f s) := by
-  obtain ⟨y, hy, hys⟩ : ∃ y : ℝ, Summable (idealTerm K f y) ∧ y < s.re := by
-    simpa [idealAbscissaOfAbsConv, sInf_lt_iff] using hs
+  obtain ⟨y, hy, hys⟩ := exists_summable_idealTerm_lt_re K hs
   exact summable_idealTerm_of_re_le_re K (Complex.ofReal_re y ▸ hys.le) hy
 
 /-- A point of absolute convergence bounds the ideal-indexed abscissa. -/

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.IsPrimePow
+public import Mathlib.RingTheory.UniqueFactorizationDomain.Multiplicity
+public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Convolution
 public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Weight
 
 /-!
@@ -13,8 +15,9 @@ public import TauCeti.NumberTheory.ArithmeticDirichletSeries.Weight
 
 The von Mangoldt function of a nonzero ideal `A` of the ring of integers of a number field is
 `log N(P)` when `A` is a positive power of a prime ideal `P`, and zero otherwise.  This file
-packages that function as an `IdealArithmeticFunction` and defines its pointwise product with an
-ideal arithmetic function.
+packages that function as an `IdealArithmeticFunction`, defines its pointwise product with an
+ideal arithmetic function, and proves its divisor sum: summing it over the divisors of `A` gives
+`log N(A)`.
 
 ## Main definitions
 
@@ -22,6 +25,8 @@ ideal arithmetic function.
   function.
 * `TauCeti.IdealArithmeticFunction.vonMangoldtTransform` sends `f` to the weighted function
   `A ↦ f(A) Λ(A)`.
+* `TauCeti.IdealArithmeticFunction.log` is the ideal logarithm `A ↦ log N(A)`, the ideal analogue
+  of Mathlib's `ArithmeticFunction.log`.
 
 ## Main results
 
@@ -32,6 +37,9 @@ ideal arithmetic function.
 * `TauCeti.IdealArithmeticFunction.vonMangoldtTransform_ne_zero_iff` identifies the support of
   the transform, and its specialization in `TauCeti.MultiplicativeIdealWeight` describes this as
   the good prime powers for a completely multiplicative weight.
+* `TauCeti.IdealArithmeticFunction.sum_vonMangoldt_divisors` and
+  `TauCeti.IdealArithmeticFunction.convolution_vonMangoldt_one`: the divisor sum `Λ ⋆ 1 = log N`,
+  the ideal analogue of Mathlib's `ArithmeticFunction.vonMangoldt_mul_zeta`.
 
 The definition chooses a prime base from a proof that `A` is a prime power.  Mathlib's
 `eq_of_prime_pow_eq`, applied to ideals, identifies that choice with any prime base supplied by a
@@ -47,9 +55,10 @@ chosen from `IsPrimePow` rather than computed by `Nat.minFac`, its logarithmic w
 ## Roadmap role
 
 This is the algebraic part of Layer **2.3** of
-`TauCetiRoadmap/ArithmeticDirichletSeries/README.md`.  The logarithmic-derivative identity named in
-that target additionally requires the Euler-product package of Layer 3; this file supplies its
-coefficient and exact prime-power support in advance.
+`TauCetiRoadmap/ArithmeticDirichletSeries/README.md`: the coefficient, its exact prime-power
+support, and the divisor sum.  The logarithmic-derivative identity that the divisor sum feeds is
+`TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean`; it needs no Euler product, only
+the Layer 2.1 convolution and the Layer 1.2 regrouping.
 
 ## References
 
@@ -204,6 +213,188 @@ function. -/
 theorem vonMangoldtTransform_one :
     (1 : IdealArithmeticFunction K).vonMangoldtTransform = vonMangoldt := by
   rw [vonMangoldtTransform, one_mul]
+
+/-! ### The ideal logarithm and the divisor sum -/
+
+/-- The **ideal logarithm**: the ideal arithmetic function whose value at a nonzero ideal `A` is
+`log N(A)`.  Like Mathlib's `ArithmeticFunction.log`, the name refers to the bundled function on
+the carrier, not to the real logarithm. -/
+noncomputable def log : IdealArithmeticFunction K := fun A ↦
+  (Real.log (Ideal.absNorm (A : Ideal (𝓞 K))) : ℂ)
+
+/-- Evaluation of the ideal logarithm. -/
+@[simp]
+theorem log_apply (A : (Ideal (𝓞 K))⁰) :
+    (log : IdealArithmeticFunction K) A = Real.log (Ideal.absNorm (A : Ideal (𝓞 K))) :=
+  (rfl)
+
+/-- The ideal logarithm vanishes at the unit ideal. -/
+@[simp]
+theorem log_one : (log : IdealArithmeticFunction K) 1 = 0 := by
+  simp [Ideal.one_eq_top]
+
+/-- The ideal logarithm is completely additive. -/
+theorem log_mul (A B : (Ideal (𝓞 K))⁰) :
+    (log : IdealArithmeticFunction K) (A * B) = log A + log B := by
+  have hA : (Ideal.absNorm (A : Ideal (𝓞 K)) : ℝ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (Ideal.absNorm_pos_of_nonZeroDivisors A).ne'
+  have hB : (Ideal.absNorm (B : Ideal (𝓞 K)) : ℝ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (Ideal.absNorm_pos_of_nonZeroDivisors B).ne'
+  rw [log_apply, log_apply, log_apply, Submonoid.coe_mul, _root_.map_mul, Nat.cast_mul,
+    Real.log_mul hA hB, Complex.ofReal_add]
+
+/-- The values of the ideal logarithm are nonnegative reals. -/
+theorem log_re_nonneg (A : (Ideal (𝓞 K))⁰) :
+    0 ≤ ((log : IdealArithmeticFunction K) A).re := by
+  rw [log_apply, Complex.ofReal_re]
+  exact Real.log_nonneg (Nat.one_le_cast.mpr (Ideal.absNorm_pos_of_nonZeroDivisors A))
+
+/-- The values of the ideal logarithm are real. -/
+theorem log_im (A : (Ideal (𝓞 K))⁰) : ((log : IdealArithmeticFunction K) A).im = 0 := by
+  rw [log_apply, Complex.ofReal_im]
+
+/-- The ideal von Mangoldt function is dominated by the ideal logarithm: its value at `P ^ k` is
+`log N(P)`, while the logarithm there is `k log N(P)`. -/
+theorem norm_vonMangoldt_le_norm_log (A : (Ideal (𝓞 K))⁰) :
+    ‖(vonMangoldt : IdealArithmeticFunction K) A‖ ≤ ‖(log : IdealArithmeticFunction K) A‖ := by
+  by_cases hA : IsPrimePow (A : Ideal (𝓞 K))
+  · obtain ⟨P, k, hP, hk, hpow⟩ := hA
+    have hlog : 0 ≤ Real.log (Ideal.absNorm P) :=
+      Real.log_nonneg (mod_cast (one_lt_absNorm_of_prime hP).le)
+    rw [vonMangoldt_apply_of_eq_prime_pow hP hk hpow, log_apply, ← hpow, _root_.map_pow,
+      Nat.cast_pow, Real.log_pow, Complex.norm_real, Complex.norm_real,
+      Real.norm_of_nonneg hlog, Real.norm_of_nonneg (by positivity)]
+    exact le_mul_of_one_le_left hlog (mod_cast hk)
+  · rw [vonMangoldt_eq_zero_of_not_isPrimePow hA, norm_zero]
+    exact norm_nonneg _
+
+/-- The logarithm of the absolute norm of a product of nonzero ideals is the sum of the logarithms
+of their absolute norms. -/
+private theorem log_absNorm_multiset_prod :
+    ∀ {t : Multiset (Ideal (𝓞 K))}, t.prod ≠ 0 →
+      (Real.log (Ideal.absNorm t.prod) : ℂ) =
+        (t.map fun P ↦ (Real.log (Ideal.absNorm P) : ℂ)).sum := by
+  intro t
+  induction t using Multiset.induction with
+  | empty => simp
+  | cons a t ih =>
+    intro ht
+    have ha0 : a ≠ 0 := fun h ↦ ht <| by rw [Multiset.prod_cons, h, zero_mul]
+    have hp0 : t.prod ≠ 0 := fun h ↦ ht <| by rw [Multiset.prod_cons, h, mul_zero]
+    have ha : Ideal.absNorm a ≠ 0 := fun h ↦
+      ha0 ((Ideal.absNorm_eq_zero_iff.mp h).trans Ideal.zero_eq_bot.symm)
+    have hp : Ideal.absNorm t.prod ≠ 0 := fun h ↦
+      hp0 ((Ideal.absNorm_eq_zero_iff.mp h).trans Ideal.zero_eq_bot.symm)
+    rw [Multiset.prod_cons, _root_.map_mul, Multiset.map_cons, Multiset.sum_cons, ← ih hp0,
+      Nat.cast_mul, Real.log_mul (mod_cast ha) (mod_cast hp), Complex.ofReal_add]
+
+open Finset UniqueFactorizationMonoid in
+/-- **The divisor sum of the ideal von Mangoldt function.** Summing `Λ` over the divisors of a
+nonzero ideal `A` gives `log N(A)`.
+
+The prime-power divisors of `A` are exactly the ideals `P ^ k` with `P` a prime factor of `A` and
+`1 ≤ k ≤ v_P(A)`, and `Λ (P ^ k) = log N(P)`, so the sum is `∑ v_P(A) log N(P) = log N(A)`. -/
+theorem sum_vonMangoldt_divisors (A : (Ideal (𝓞 K))⁰) :
+    ∑ B ∈ Ideal.divisors A, (vonMangoldt : IdealArithmeticFunction K) B = log A := by
+  classical
+  have hA0 : (A : Ideal (𝓞 K)) ≠ 0 := nonZeroDivisors.coe_ne_zero A
+  have hnormalize : ∀ I : Ideal (𝓞 K), normalize I = I := fun I ↦
+    associated_iff_eq.mp (normalize_associated I)
+  set m : Multiset (Ideal (𝓞 K)) := normalizedFactors (A : Ideal (𝓞 K)) with hm
+  set S : Finset ((Ideal (𝓞 K))⁰) := {B ∈ Ideal.divisors A | Prime (B : Ideal (𝓞 K))} with hS
+  set T : Finset ((Ideal (𝓞 K))⁰) :=
+    {B ∈ Ideal.divisors A | IsPrimePow (B : Ideal (𝓞 K))} with hT
+  set D : Finset ((_ : (Ideal (𝓞 K))⁰) × ℕ) :=
+    S.sigma (fun B ↦ Finset.Icc 1 (m.count (B : Ideal (𝓞 K)))) with hD
+  -- The prime divisors of `A` are the elements of `m`.
+  have hmemS : ∀ B : (Ideal (𝓞 K))⁰, B ∈ S ↔ (B : Ideal (𝓞 K)) ∈ m := by
+    intro B
+    rw [hS, Finset.mem_filter, Ideal.mem_divisors]
+    refine ⟨fun hB ↦ ?_, fun hB ↦ ⟨dvd_of_mem_normalizedFactors hB,
+      prime_of_normalized_factor _ hB⟩⟩
+    obtain ⟨P, hP, hassoc⟩ :=
+      exists_mem_normalizedFactors_of_dvd hA0 hB.2.irreducible hB.1
+    rwa [associated_iff_eq.mp hassoc]
+  -- A power of a prime divisor divides `A` exactly up to its multiplicity.
+  have hpow : ∀ B ∈ S, ∀ k : ℕ,
+      ((B : Ideal (𝓞 K)) ^ k ∣ (A : Ideal (𝓞 K)) ↔ k ≤ m.count (B : Ideal (𝓞 K))) := by
+    intro B hB k
+    rw [pow_dvd_iff_le_emultiplicity, emultiplicity_eq_count_normalizedFactors
+      (Finset.mem_filter.mp hB).2.irreducible hA0, hnormalize, ← hm, Nat.cast_le]
+  -- Raising a prime divisor to an admissible exponent is a bijection from `D` onto `T`.
+  have hinj : ∀ x ∈ D, ∀ y ∈ D, x.1 ^ x.2 = y.1 ^ y.2 → x = y := by
+    rintro ⟨B, k⟩ hBk ⟨C, l⟩ hCl h
+    simp only [hD, Finset.mem_sigma, Finset.mem_Icc] at hBk hCl
+    obtain ⟨hBS, hk1, -⟩ := hBk
+    obtain ⟨hCS, -, -⟩ := hCl
+    have hB : Prime (B : Ideal (𝓞 K)) := (Finset.mem_filter.mp hBS).2
+    have hC : Prime (C : Ideal (𝓞 K)) := (Finset.mem_filter.mp hCS).2
+    have hcoe : (B : Ideal (𝓞 K)) ^ k = (C : Ideal (𝓞 K)) ^ l := by
+      simpa using congrArg Subtype.val h
+    have hBC : B = C := Subtype.ext (eq_of_prime_pow_eq hB hC (by omega) hcoe)
+    subst hBC
+    have hkl : k = l := Nat.pow_right_injective (one_lt_absNorm_of_prime hB) <| by
+      simpa using congrArg Ideal.absNorm hcoe
+    simp [hkl]
+  have himage : D.image (fun x ↦ x.1 ^ x.2) = T := by
+    ext B
+    simp only [hT, hD, Finset.mem_filter, Ideal.mem_divisors, Finset.mem_image, Finset.mem_sigma,
+      Finset.mem_Icc]
+    constructor
+    · rintro ⟨⟨C, k⟩, ⟨hC, hk1, hk2⟩, rfl⟩
+      have hCprime : Prime (C : Ideal (𝓞 K)) := (Finset.mem_filter.mp hC).2
+      refine ⟨by simpa using (hpow C hC k).mpr hk2, C, k, hCprime, hk1, by simp⟩
+    · rintro ⟨hdvd, P, k, hP, hk, hPB⟩
+      have hPdvd : P ∣ (A : Ideal (𝓞 K)) :=
+        (dvd_pow_self P (by omega)).trans (hPB ▸ hdvd)
+      have hPS : (⟨P, mem_nonZeroDivisors_of_ne_zero hP.ne_zero⟩ : (Ideal (𝓞 K))⁰) ∈ S :=
+        Finset.mem_filter.mpr ⟨Ideal.mem_divisors.mpr hPdvd, hP⟩
+      refine ⟨⟨⟨P, mem_nonZeroDivisors_of_ne_zero hP.ne_zero⟩, k⟩,
+        ⟨hPS, hk, (hpow _ hPS k).mp (hPB ▸ hdvd)⟩, Subtype.ext ?_⟩
+      simpa using hPB
+  have hprod : m.prod = (A : Ideal (𝓞 K)) := associated_iff_eq.mp (prod_normalizedFactors hA0)
+  calc ∑ B ∈ Ideal.divisors A, (vonMangoldt : IdealArithmeticFunction K) B
+      = ∑ B ∈ T, vonMangoldt B :=
+        (Finset.sum_filter_of_ne fun B _ hB ↦
+          by_contra fun h ↦ hB (vonMangoldt_eq_zero_of_not_isPrimePow h)).symm
+    _ = ∑ x ∈ D, (vonMangoldt : IdealArithmeticFunction K) (x.1 ^ x.2) := by
+        rw [← himage, Finset.sum_image hinj]
+    _ = ∑ B ∈ S, ∑ k ∈ Finset.Icc 1 (m.count (B : Ideal (𝓞 K))),
+          (vonMangoldt : IdealArithmeticFunction K) (B ^ k) :=
+        (Finset.sum_sigma' (f := fun (B : (Ideal (𝓞 K))⁰) (k : ℕ) ↦
+          (vonMangoldt : IdealArithmeticFunction K) (B ^ k)) _ _).symm
+    _ = ∑ B ∈ S, m.count (B : Ideal (𝓞 K)) • (log : IdealArithmeticFunction K) B := by
+        refine Finset.sum_congr rfl fun B hB ↦ ?_
+        have hB' : Prime (B : Ideal (𝓞 K)) := (Finset.mem_filter.mp hB).2
+        rw [Finset.sum_congr rfl fun k hk ↦
+          vonMangoldt_apply_prime_pow hB' (by simp only [Finset.mem_Icc] at hk; omega)]
+        simp [Nat.card_Icc]
+    _ = (m.map fun P ↦ (Real.log (Ideal.absNorm P) : ℂ)).sum := by
+        refine (Finset.sum_nbij (i := fun (B : (Ideal (𝓞 K))⁰) ↦ (B : Ideal (𝓞 K)))
+          (fun (B : (Ideal (𝓞 K))⁰) hB ↦ Multiset.mem_toFinset.mpr ((hmemS B).mp hB))
+          (fun (B : (Ideal (𝓞 K))⁰) _ (C : (Ideal (𝓞 K))⁰) _ h ↦ Subtype.ext h)
+          (fun P hP ↦ ?_) fun _ _ ↦ rfl).trans
+          (Finset.sum_multiset_map_count m fun P ↦ (Real.log (Ideal.absNorm P) : ℂ)).symm
+        have hP' := Multiset.mem_toFinset.mp hP
+        exact ⟨⟨P, mem_nonZeroDivisors_of_ne_zero (prime_of_normalized_factor _ hP').ne_zero⟩,
+          (hmemS _).mpr hP', rfl⟩
+    _ = log A := by rw [log_apply, ← hprod, log_absNorm_multiset_prod (hprod ▸ hA0)]
+
+/-- **The divisor sum of the ideal von Mangoldt function, in convolution form.** Convolving `Λ`
+with the everywhere-one function on nonzero ideals gives the ideal logarithm.  This is the ideal
+analogue of Mathlib's `ArithmeticFunction.vonMangoldt_mul_zeta`. -/
+@[simp]
+theorem convolution_vonMangoldt_one :
+    convolution (vonMangoldt : IdealArithmeticFunction K) 1 = log := by
+  funext A
+  simpa using (Ideal.sum_divisorsAntidiagonal_fst A
+    (vonMangoldt : IdealArithmeticFunction K)).trans (sum_vonMangoldt_divisors A)
+
+/-- Convolving the everywhere-one function on nonzero ideals with `Λ` gives `log N`. -/
+@[simp]
+theorem convolution_one_vonMangoldt :
+    convolution (1 : IdealArithmeticFunction K) vonMangoldt = log := by
+  rw [convolution_comm, convolution_vonMangoldt_one]
 
 end IdealArithmeticFunction
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -37,7 +37,7 @@ ideal arithmetic function, and proves its divisor sum: summing it over the divis
 * `TauCeti.IdealArithmeticFunction.vonMangoldtTransform_ne_zero_iff` identifies the support of
   the transform, and its specialization in `TauCeti.MultiplicativeIdealWeight` describes this as
   the good prime powers for a completely multiplicative weight.
-* `TauCeti.IdealArithmeticFunction.sum_vonMangoldt_divisors` and
+* `TauCeti.IdealArithmeticFunction.vonMangoldt_sum` and
   `TauCeti.IdealArithmeticFunction.convolution_vonMangoldt_one`: the divisor sum `Λ ⋆ 1 = log N`,
   the ideal analogue of Mathlib's `ArithmeticFunction.vonMangoldt_mul_zeta`.
 
@@ -268,32 +268,37 @@ theorem norm_vonMangoldt_le_norm_log (A : (Ideal (𝓞 K))⁰) :
     exact norm_nonneg _
 
 /-- The logarithm of the absolute norm of a product of nonzero ideals is the sum of the logarithms
-of their absolute norms. -/
-private theorem log_absNorm_multiset_prod :
-    ∀ {t : Multiset (Ideal (𝓞 K))}, t.prod ≠ 0 →
-      (Real.log (Ideal.absNorm t.prod) : ℂ) =
-        (t.map fun P ↦ (Real.log (Ideal.absNorm P) : ℂ)).sum := by
-  intro t
-  induction t using Multiset.induction with
-  | empty => simp
-  | cons a t ih =>
-    intro ht
-    have ha0 : a ≠ 0 := fun h ↦ ht <| by rw [Multiset.prod_cons, h, zero_mul]
-    have hp0 : t.prod ≠ 0 := fun h ↦ ht <| by rw [Multiset.prod_cons, h, mul_zero]
-    have ha : Ideal.absNorm a ≠ 0 := fun h ↦
-      ha0 ((Ideal.absNorm_eq_zero_iff.mp h).trans Ideal.zero_eq_bot.symm)
-    have hp : Ideal.absNorm t.prod ≠ 0 := fun h ↦
-      hp0 ((Ideal.absNorm_eq_zero_iff.mp h).trans Ideal.zero_eq_bot.symm)
-    rw [Multiset.prod_cons, _root_.map_mul, Multiset.map_cons, Multiset.sum_cons, ← ih hp0,
-      Nat.cast_mul, Real.log_mul (mod_cast ha) (mod_cast hp), Complex.ofReal_add]
+of their absolute norms.  This is Mathlib's `Real.log_multiset_prod`, transported along the
+multiplicativity of the absolute norm. -/
+private theorem log_absNorm_multiset_prod {t : Multiset (Ideal (𝓞 K))} (ht : t.prod ≠ 0) :
+    (Real.log (Ideal.absNorm t.prod) : ℂ) =
+      (t.map fun P ↦ (Real.log (Ideal.absNorm P) : ℂ)).sum := by
+  have hne : ∀ x ∈ t.map fun P ↦ (Ideal.absNorm P : ℝ), x ≠ 0 := by
+    rintro _ hx
+    obtain ⟨P, hP, rfl⟩ := Multiset.mem_map.mp hx
+    have hP0 : P ≠ 0 := fun h ↦ ht (zero_dvd_iff.mp (h ▸ Multiset.dvd_prod hP))
+    exact Nat.cast_ne_zero.mpr fun h ↦
+      hP0 ((Ideal.absNorm_eq_zero_iff.mp h).trans Ideal.zero_eq_bot.symm)
+  have hcast : ((Ideal.absNorm t.prod : ℕ) : ℝ) = (t.map fun P ↦ (Ideal.absNorm P : ℝ)).prod := by
+    rw [map_multiset_prod, Nat.cast_multiset_prod, Multiset.map_map]
+    rfl
+  have hreal : Real.log (Ideal.absNorm t.prod) =
+      (t.map fun P ↦ Real.log (Ideal.absNorm P)).sum := by
+    rw [hcast, Real.log_multiset_prod hne, Multiset.map_map]
+    rfl
+  rw [hreal]
+  simpa [Multiset.map_map] using
+    map_multiset_sum Complex.ofRealHom (t.map fun P ↦ Real.log (Ideal.absNorm P))
 
 open Finset UniqueFactorizationMonoid in
 /-- **The divisor sum of the ideal von Mangoldt function.** Summing `Λ` over the divisors of a
 nonzero ideal `A` gives `log N(A)`.
 
 The prime-power divisors of `A` are exactly the ideals `P ^ k` with `P` a prime factor of `A` and
-`1 ≤ k ≤ v_P(A)`, and `Λ (P ^ k) = log N(P)`, so the sum is `∑ v_P(A) log N(P) = log N(A)`. -/
-theorem sum_vonMangoldt_divisors (A : (Ideal (𝓞 K))⁰) :
+`1 ≤ k ≤ v_P(A)`, and `Λ (P ^ k) = log N(P)`, so the sum is `∑ v_P(A) log N(P) = log N(A)`.
+
+This is the ideal analogue of Mathlib's `ArithmeticFunction.vonMangoldt_sum`. -/
+theorem vonMangoldt_sum (A : (Ideal (𝓞 K))⁰) :
     ∑ B ∈ Ideal.divisors A, (vonMangoldt : IdealArithmeticFunction K) B = log A := by
   classical
   have hA0 : (A : Ideal (𝓞 K)) ≠ 0 := nonZeroDivisors.coe_ne_zero A
@@ -351,7 +356,7 @@ theorem sum_vonMangoldt_divisors (A : (Ideal (𝓞 K))⁰) :
       refine ⟨⟨⟨P, mem_nonZeroDivisors_of_ne_zero hP.ne_zero⟩, k⟩,
         ⟨hPS, hk, (hpow _ hPS k).mp (hPB ▸ hdvd)⟩, Subtype.ext ?_⟩
       simpa using hPB
-  have hprod : m.prod = (A : Ideal (𝓞 K)) := associated_iff_eq.mp (prod_normalizedFactors hA0)
+  have hprod : m.prod = (A : Ideal (𝓞 K)) := Ideal.prod_normalizedFactors_eq_self hA0
   calc ∑ B ∈ Ideal.divisors A, (vonMangoldt : IdealArithmeticFunction K) B
       = ∑ B ∈ T, vonMangoldt B :=
         (Finset.sum_filter_of_ne fun B _ hB ↦
@@ -387,7 +392,7 @@ theorem convolution_vonMangoldt_one :
     convolution (vonMangoldt : IdealArithmeticFunction K) 1 = log := by
   funext A
   simpa using (Ideal.sum_divisorsAntidiagonal_fst A
-    (vonMangoldt : IdealArithmeticFunction K)).trans (sum_vonMangoldt_divisors A)
+    (vonMangoldt : IdealArithmeticFunction K)).trans (vonMangoldt_sum A)
 
 end IdealArithmeticFunction
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -229,7 +229,6 @@ theorem log_apply (A : (Ideal (𝓞 K))⁰) :
   (rfl)
 
 /-- The ideal logarithm vanishes at the unit ideal. -/
-@[simp]
 theorem log_one : (log : IdealArithmeticFunction K) 1 = 0 := by
   simp [Ideal.one_eq_top]
 

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/VonMangoldt.lean
@@ -389,12 +389,6 @@ theorem convolution_vonMangoldt_one :
   simpa using (Ideal.sum_divisorsAntidiagonal_fst A
     (vonMangoldt : IdealArithmeticFunction K)).trans (sum_vonMangoldt_divisors A)
 
-/-- Convolving the everywhere-one function on nonzero ideals with `Λ` gives `log N`. -/
-@[simp]
-theorem convolution_one_vonMangoldt :
-    convolution (1 : IdealArithmeticFunction K) vonMangoldt = log := by
-  rw [convolution_comm, convolution_vonMangoldt_one]
-
 end IdealArithmeticFunction
 
 namespace MultiplicativeIdealWeight


### PR DESCRIPTION
This PR proves the divisor sum of the ideal von Mangoldt function and spends it on the exact coefficient identity for the logarithmic derivative of the Dirichlet series of a completely multiplicative ideal weight. Summing `Λ` over the divisors of a nonzero ideal `A` of `𝓞 K` gives `log N(A)` (`TauCeti.IdealArithmeticFunction.sum_vonMangoldt_divisors`, in convolution form `convolution_vonMangoldt_one : Λ ⋆ 1 = log`), and twisting that identity by a `TauCeti.MultiplicativeIdealWeight` gives `(χ Λ) ⋆ χ = (log N) χ`, which regroups by absolute norm into Mathlib's Dirichlet convolution and yields `∑_A χ(A) Λ(A) N(A)^(-s) = -L'(s)/L(s)` on the half-plane where the ideal-indexed series of `χ` converges absolutely. The trivial weight gives the headline instance `-ζ_K'(s)/ζ_K(s) = ∑_A Λ(A) N(A)^(-s)` for `Re s > 1`.

Roadmap: ArithmeticDirichletSeries

<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"logarithmic-derivative-coefficient-identity"}-->

The milestone is Layer **2.3** ("Von Mangoldt transform") of `TauCetiRoadmap/ArithmeticDirichletSeries/README.md`, which asks to "Define the ideal von Mangoldt weight and the transform attached to a weight. Prove support on prime powers and the exact coefficient identity for the logarithmic derivative of an Euler product on its absolute-convergence half-plane." The first two clauses are already on `main` in `ArithmeticDirichletSeries/VonMangoldt.lean`; this PR supplies the third, so Layer 2 is complete after it. What Layer 2 leaves for its consumers is unchanged: Layer 3 still needs 3.1's `EulerProductData` package, 3.2's finite Euler product (in flight in #4870) and 3.3's passage to the infinite product, and Layer 10.1 will consume the trivial-weight identity here as its exact nonnegative coefficient system once the Wiener–Ikehara theorem of Layer 9 exists.

The one substantive claim to check is that the identity does **not** need the Euler product, contrary to the forecast in the module docstring of `VonMangoldt.lean` on `main` ("The logarithmic-derivative identity named in that target additionally requires the Euler-product package of Layer 3"). That docstring is corrected here, and the reason is the divisor sum: `-L'` is the `LSeries` of `LSeries.logMul` of the regrouped coefficients by Mathlib's `LSeries_deriv`, and `LSeries.logMul` of `TauCeti.normCoeff χ` is exactly `TauCeti.normCoeff ((log N) χ)` because the absolute norm is constant on a norm fibre, so the whole identity reduces to `(χ Λ) ⋆ χ = (log N) χ` and hence to `Λ ⋆ 1 = log N`. Only the Layer 2.1 convolution and the Layer 1.2 regrouping are used; both are on `main`, so this is reached in the roadmap's own order.

`TauCeti.IdealArithmeticFunction.log` is the ideal logarithm `A ↦ log N(A)`, the ideal analogue of Mathlib's `ArithmeticFunction.log`, which Mathlib likewise defines in its `VonMangoldt.lean`; it comes with `log_apply`, `log_one`, the complete additivity `log_mul`, `log_re_nonneg`, `log_im` and the domination `norm_vonMangoldt_le_norm_log` used for convergence. The divisor sum is proved by reindexing: the prime-power divisors of `A` are exactly the `P ^ k` with `P` a prime factor and `1 ≤ k ≤ v_P(A)`, the multiplicity bound coming from Mathlib's `pow_dvd_iff_le_emultiplicity` and `UniqueFactorizationMonoid.emultiplicity_eq_count_normalizedFactors`, and `Finset.sum_multiset_map_count` then turns the multiplicity-weighted sum into a multiset sum over `normalizedFactors A`. This is the ideal analogue of Mathlib's `ArithmeticFunction.vonMangoldt_mul_zeta`, credited in the docstrings; Mathlib's proof uses `Nat.recOnPrimeCoprime`, which has no ideal counterpart here, so the argument is the direct reindexing instead.

Convergence is the only analytic input. `TauCeti.summable_idealTerm_log_mul` is the ideal-indexed analogue of Mathlib's `LSeries.abscissaOfAbsConv_logMul`: multiplying by `log N` does not move the ideal-indexed abscissa, since `log t ≤ t^δ / δ` (Mathlib's `Real.log_le_rpow_div`). Since `Λ (A) ≤ log N(A)`, the same bound gives `TauCeti.summable_idealTerm_vonMangoldtTransform`, and the already-merged `TauCeti.LSeriesSummable_normCoeff` moves both to the grouped series, so Mathlib's `ArithmeticFunction.LSeries_mul'` applies. The nonvanishing hypothesis of the quotient form is genuinely assumed rather than proved: `ζ_K` has no zero on `Re s > 1`, but that is the Euler product of Layer 3 and is not available yet, so the product form `LSeries_normCoeff_vonMangoldtTransform_mul_eq_neg_deriv` is stated separately and carries no such hypothesis.

Files: `TauCeti/NumberTheory/ArithmeticDirichletSeries/LogDeriv.lean` (new, 226 lines) with the transport, the convergence estimates and the two identities; `VonMangoldt.lean` (+192) with the ideal logarithm and the divisor sum, its canonical home beside `Λ`; `Convolution.lean` (+50) with `TauCeti.Ideal.divisors` — the first projection of the already-merged `divisorsAntidiagonal`, with `mem_divisors`, `divisors_one` and the two reindexings `sum_divisorsAntidiagonal_fst` and `sum_divisorsAntidiagonal_snd` that state a one-factor antidiagonal sum as a divisor sum; `Regroup.lean` (+11) with `exists_summable_idealTerm_lt_re`, the ideal analogue of Mathlib's `LSeriesSummable_lt_re_of_abscissaOfAbsConv_lt_re`, factored out of the existing proof just below it; and `Estimates.lean` (+13) with `idealAbscissaOfAbsConv_one`, which belongs beside the Layer 5.1a `abscissaOfAbsConv_normCoeff_one` it is derived from and is what makes the Dedekind zeta instance's hypothesis read `1 < Re s`.

No Mathlib source is vendored. Beyond `ArithmeticFunction.vonMangoldt_mul_zeta` the central Mathlib inputs, all named in the module docstrings, are `LSeries_deriv` and `LSeries.logMul` from `Mathlib/NumberTheory/LSeries/Deriv.lean`, `ArithmeticFunction.LSeries_mul'` from `Mathlib/NumberTheory/LSeries/Convolution.lean`, `logDeriv` from `Mathlib/Analysis/Calculus/LogDeriv.lean`, and `Real.log_le_rpow_div`. The mathematics is the standard treatment in Davenport, *Multiplicative Number Theory*, Chapter 1, Tenenbaum, *Introduction to Analytic and Probabilistic Number Theory*, Chapters I.2 and II, and Neukirch, *Algebraic Number Theory*, Chapter VII.

🤖 Prepared with Claude Code
