### PR TITLE
feat: add topology on real Spin groups

### DIFF
--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -301,9 +301,11 @@ end Det
 section Coordinate
 
 variable {R : Type u} [CommRing R] {n : Type v} [Fintype n] [DecidableEq n]
+  {N : Type w} [AddCommMonoid N] [Module R N]
 
 /-- The coordinate inclusion of a special orthogonal group into `GL(n, R)`. -/
-noncomputable def specialOrthogonalToGeneralLinear (Q : QuadraticForm R (n → R)) :
+noncomputable def _root_.TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear
+    (Q : QuadraticMap R (n → R) N) :
     specialOrthogonalGroup Q →* Matrix.GeneralLinearGroup n R :=
   (Matrix.GeneralLinearGroup.toLin (n := n) (R := R)).symm.toMonoidHom.comp
     ((LinearMap.GeneralLinearGroup.generalLinearEquiv R (n → R)).symm.toMonoidHom.comp
@@ -311,14 +313,16 @@ noncomputable def specialOrthogonalToGeneralLinear (Q : QuadraticForm R (n → R
 
 /-- A special orthogonal transformation acts through its usual coordinate matrix. -/
 @[simp]
-theorem specialOrthogonalToGeneralLinear_apply (Q : QuadraticForm R (n → R))
+theorem _root_.TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear_apply
+    (Q : QuadraticMap R (n → R) N)
     (g : specialOrthogonalGroup Q) (i j : n) :
     specialOrthogonalToGeneralLinear Q g i j =
       (g : (n → R) ≃ₗ[R] (n → R)) (Pi.single j 1) i := by
   rfl
 
 /-- The coordinate inclusion of a special orthogonal group is injective. -/
-theorem specialOrthogonalToGeneralLinear_injective (Q : QuadraticForm R (n → R)) :
+theorem _root_.TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear_injective
+    (Q : QuadraticMap R (n → R) N) :
     Function.Injective (specialOrthogonalToGeneralLinear Q) :=
   (Matrix.GeneralLinearGroup.toLin (n := n) (R := R)).symm.injective.comp
     ((LinearMap.GeneralLinearGroup.generalLinearEquiv R (n → R)).symm.injective.comp

--- a/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/OrthogonalGroup.lean
@@ -38,6 +38,8 @@ negating it and is a transvection rather than a reflection in `v ^ ⊥`.
 * `TauCeti.QuadraticMap.orthogonalGroup Q`: the `Q`-preserving linear automorphisms of `M`, as a
   subgroup of `M ≃ₗ[R] M`.
 * `TauCeti.QuadraticMap.specialOrthogonalGroup Q`: its determinant-one subgroup.
+* `TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear Q`: the faithful coordinate inclusion of
+  a special orthogonal group into matrix `GL`.
 * `TauCeti.QuadraticMap.reflection Q v`: the reflection in the hyperplane orthogonal to a vector `v`
   with `Q v` invertible, built from Mathlib's `Module.reflection`.
 * `TauCeti.QuadraticMap.reflectionOrthogonal Q v`: the same reflection bundled as an element of
@@ -295,6 +297,34 @@ instance specialOrthogonalGroup_normal (Q : QuadraticMap R M N) :
   infer_instance
 
 end Det
+
+section Coordinate
+
+variable {R : Type u} [CommRing R] {n : Type v} [Fintype n] [DecidableEq n]
+
+/-- The coordinate inclusion of a special orthogonal group into `GL(n, R)`. -/
+noncomputable def specialOrthogonalToGeneralLinear (Q : QuadraticForm R (n → R)) :
+    specialOrthogonalGroup Q →* Matrix.GeneralLinearGroup n R :=
+  (Matrix.GeneralLinearGroup.toLin (n := n) (R := R)).symm.toMonoidHom.comp
+    ((LinearMap.GeneralLinearGroup.generalLinearEquiv R (n → R)).symm.toMonoidHom.comp
+      (specialOrthogonalGroup Q).subtype)
+
+/-- A special orthogonal transformation acts through its usual coordinate matrix. -/
+@[simp]
+theorem specialOrthogonalToGeneralLinear_apply (Q : QuadraticForm R (n → R))
+    (g : specialOrthogonalGroup Q) (i j : n) :
+    specialOrthogonalToGeneralLinear Q g i j =
+      (g : (n → R) ≃ₗ[R] (n → R)) (Pi.single j 1) i := by
+  rfl
+
+/-- The coordinate inclusion of a special orthogonal group is injective. -/
+theorem specialOrthogonalToGeneralLinear_injective (Q : QuadraticForm R (n → R)) :
+    Function.Injective (specialOrthogonalToGeneralLinear Q) :=
+  (Matrix.GeneralLinearGroup.toLin (n := n) (R := R)).symm.injective.comp
+    ((LinearMap.GeneralLinearGroup.generalLinearEquiv R (n → R)).symm.injective.comp
+      Subtype.coe_injective)
+
+end Coordinate
 
 section Reflection
 

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Basic.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Basic.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Dimension
+public import Mathlib.Algebra.CharP.Invertible
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Star
+public import Mathlib.Topology.Algebra.Ring.Real
+public import Mathlib.Topology.Algebra.Module.ModuleTopology
+public import Mathlib.Topology.Algebra.Star
+
+/-!
+# Topology on real Clifford algebras
+
+This file gives a real Clifford algebra its real module topology and topological additive-group
+structure. The topology is Hausdorff, and Clifford reverse, involution, and star are continuous,
+without a finite-dimensionality assumption. In finite dimension, multiplication is continuous.
+
+The topology is intrinsic: it depends only on the real module structure of the Clifford algebra and
+does not use a basis, Pin or Spin groups, or their actions. A basis appears only in the proof that
+the topology is Hausdorff.
+
+## Main results
+
+* `CliffordAlgebra.instTopologicalSpaceRealCliffordAlgebra` installs the real module topology.
+* `CliffordAlgebra.instIsTopologicalAddGroupRealCliffordAlgebra` makes addition continuous.
+* `CliffordAlgebra.instIsTopologicalRingRealCliffordAlgebra` makes multiplication continuous.
+* `CliffordAlgebra.instT2SpaceRealCliffordAlgebra` proves the topology is Hausdorff.
+* `CliffordAlgebra.continuous_reverse_realCliffordAlgebra` and
+  `CliffordAlgebra.continuous_involute_realCliffordAlgebra` prove continuity of the two canonical
+  Clifford involutions.
+* `CliffordAlgebra.instContinuousStarRealCliffordAlgebra` packages continuity of Clifford star.
+-/
+
+public section
+
+
+namespace CliffordAlgebra
+
+open TauCeti
+
+noncomputable section
+
+universe u
+
+
+variable {V : Type u} [AddCommGroup V] [Module ℝ V]
+
+/-- The canonical topology on a real Clifford algebra is its real module topology. -/
+instance instTopologicalSpaceRealCliffordAlgebra (Q : QuadraticForm ℝ V) :
+    TopologicalSpace (CliffordAlgebra Q) :=
+  moduleTopology ℝ _
+
+/-- A real Clifford algebra is a topological additive group for its real module topology. -/
+instance instIsTopologicalAddGroupRealCliffordAlgebra (Q : QuadraticForm ℝ V) :
+    IsTopologicalAddGroup (CliffordAlgebra Q) :=
+  IsModuleTopology.topologicalAddGroup ℝ _
+
+/-- Clifford reversal is continuous for the real module topology. -/
+@[fun_prop]
+theorem continuous_reverse_realCliffordAlgebra (Q : QuadraticForm ℝ V) :
+    Continuous (reverse (Q := Q) : CliffordAlgebra Q → CliffordAlgebra Q) :=
+  IsModuleTopology.continuous_of_linearMap (reverse (Q := Q))
+
+/-- The Clifford grade involution is continuous for the real module topology. -/
+@[fun_prop]
+theorem continuous_involute_realCliffordAlgebra (Q : QuadraticForm ℝ V) :
+    Continuous (involute (Q := Q) : CliffordAlgebra Q → CliffordAlgebra Q) :=
+  IsModuleTopology.continuous_of_linearMap (involute (Q := Q)).toLinearMap
+
+/-- Clifford star is continuous for the real module topology. -/
+instance instContinuousStarRealCliffordAlgebra (Q : QuadraticForm ℝ V) :
+    ContinuousStar (CliffordAlgebra Q) where
+  continuous_star := by
+    convert (continuous_reverse_realCliffordAlgebra Q).comp
+      (continuous_involute_realCliffordAlgebra Q) using 1
+    funext x
+    exact star_def x
+
+/-- The real module topology on a Clifford algebra is Hausdorff. -/
+instance instT2SpaceRealCliffordAlgebra (Q : QuadraticForm ℝ V) :
+    T2Space (CliffordAlgebra Q) := by
+  let b := Module.Free.chooseBasis ℝ (CliffordAlgebra Q)
+  let f : CliffordAlgebra Q → (Module.Free.ChooseBasisIndex ℝ (CliffordAlgebra Q) → ℝ) :=
+    fun x i => b.repr x i
+  exact T2Space.of_injective_continuous (f := f)
+    (by
+      intro x y h
+      apply b.repr.injective
+      ext i
+      exact congrFun h i)
+    (continuous_pi fun i => IsModuleTopology.continuous_of_linearMap (b.coord i))
+
+variable [FiniteDimensional ℝ V]
+
+/-- A finite-dimensional real Clifford algebra is a topological ring for its real module
+topology. -/
+instance instIsTopologicalRingRealCliffordAlgebra (Q : QuadraticForm ℝ V) :
+    IsTopologicalRing (CliffordAlgebra Q) :=
+  IsModuleTopology.isTopologicalRing ℝ _
+
+end
+
+end CliffordAlgebra

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -44,7 +44,8 @@ topologized special orthogonal group.
 
 * `CliffordAlgebra.instIsTopologicalGroupRealSpinGroup` equips `spinGroup Q` with a topological
   group structure for its canonical subtype topology.
-* `CliffordAlgebra.continuous_spinVectorAction` proves fixed-vector continuity of the Spin action.
+* `CliffordAlgebra.continuous_spinVectorAction_apply` proves fixed-vector continuity of the Spin
+  action.
 * `CliffordAlgebra.continuous_spinToSpecialOrthogonal_pi` proves continuity of the Spin
   projection for every quadratic form on a finite real coordinate space.
 * `CliffordAlgebra.continuous_realCliffordSpinDoubleCoverZero_rightHom` specializes this result to
@@ -82,7 +83,7 @@ instance instIsTopologicalGroupRealSpinGroup (Q : QuadraticForm ℝ V) :
 /-- For a fixed vector, its image under the real Spin action depends continuously on the Spin
 element. -/
 @[fun_prop]
-theorem continuous_spinVectorAction [TopologicalSpace V] [IsModuleTopology ℝ V]
+theorem continuous_spinVectorAction_apply [TopologicalSpace V] [IsModuleTopology ℝ V]
     (Q : QuadraticForm ℝ V) (v : V) :
     Continuous (fun x : spinGroup Q => spinVectorAction Q x v) := by
   let _ : IsTopologicalAddGroup V := IsModuleTopology.topologicalAddGroup ℝ V
@@ -117,7 +118,7 @@ theorem continuous_spinToSpecialOrthogonal_pi
       TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear_apply,
       coe_spinToSpecialOrthogonal_apply, Function.comp_def] using
       (continuous_apply i).comp
-        (continuous_spinVectorAction Q (Pi.single j 1))
+        (continuous_spinVectorAction_apply Q (Pi.single j 1))
   simpa only [MonoidHom.coe_comp] using h
 
 /-- The projection field of the compact real Spin double cover is continuous. -/

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -44,6 +44,7 @@ topologized special orthogonal group.
 
 * `CliffordAlgebra.instIsTopologicalGroupRealSpinGroup` equips `spinGroup Q` with a topological
   group structure for its canonical subtype topology.
+* `CliffordAlgebra.continuous_spinVectorAction` proves fixed-vector continuity of the Spin action.
 * `CliffordAlgebra.continuous_spinToSpecialOrthogonal_pi` proves continuity of the Spin
   projection for every quadratic form on a finite real coordinate space.
 * `CliffordAlgebra.continuous_realCliffordSpinDoubleCoverZero_rightHom` specializes this result to
@@ -80,10 +81,11 @@ instance instIsTopologicalGroupRealSpinGroup (Q : QuadraticForm ℝ V) :
 
 /-- For a fixed vector, its image under the real Spin action depends continuously on the Spin
 element. -/
-private theorem continuous_spinVectorAction_pi
-    {n : Type u} [Finite n] (Q : QuadraticForm ℝ (n → ℝ)) (v : n → ℝ) :
+@[fun_prop]
+theorem continuous_spinVectorAction [TopologicalSpace V] [IsModuleTopology ℝ V]
+    (Q : QuadraticForm ℝ V) (v : V) :
     Continuous (fun x : spinGroup Q => spinVectorAction Q x v) := by
-  let _ := Fintype.ofFinite n
+  let _ : IsTopologicalAddGroup V := IsModuleTopology.topologicalAddGroup ℝ V
   have hval : Continuous (fun x : spinGroup Q => (x : CliffordAlgebra Q)) :=
     continuous_subtype_val
   have hstar : Continuous (fun x : spinGroup Q => star (x : CliffordAlgebra Q)) :=
@@ -115,7 +117,7 @@ theorem continuous_spinToSpecialOrthogonal_pi
       TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear_apply,
       coe_spinToSpecialOrthogonal_apply, Function.comp_def] using
       (continuous_apply i).comp
-        (continuous_spinVectorAction_pi Q (Pi.single j 1))
+        (continuous_spinVectorAction Q (Pi.single j 1))
   simpa only [MonoidHom.coe_comp] using h
 
 /-- The projection field of the compact real Spin double cover is continuous. -/

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Spin.Real
+public import TauCeti.Topology.Algebra.CliffordAlgebra.Basic
+public import TauCeti.Topology.Algebra.QuadraticForm.SpecialOrthogonal
+
+/-!
+# Topology on finite-dimensional real Spin groups
+
+This file uses the canonical subtype topology on a finite-dimensional real Spin group. The
+surrounding Clifford algebra has its real module topology from
+`TauCeti.Topology.Algebra.CliffordAlgebra.Basic`. A real special orthogonal group in coordinates has
+the independently induced topology from
+`TauCeti.Topology.Algebra.QuadraticForm.SpecialOrthogonal`.
+
+For a quadratic form on a finite real coordinate space, continuity of the Spin projection is proved
+from the explicit Clifford conjugation formula for `spinVectorAction`. This supplies the
+topological-group bridge for standard real Spin groups and, in particular, for the compact real
+double cover at signature `(n, 0)`. It makes no compactness, connectedness, simple-connectivity,
+fibration, or universal-cover claim.
+
+## Continuity argument
+
+For `x : spinPQ p q` and a fixed vector `v`, the public action equation gives
+
+`ι Q (spinVectorAction Q x v) = x * ι Q v * star x`.
+
+On the Spin group, `star x` is the inverse of `x`. The subtype coercion and Clifford star are
+continuous, so the right-hand side is continuous in `x`. The continuous vector-part map `ιInv Q`
+is a left inverse to `ι Q`; applying it proves continuity of
+`x ↦ spinVectorAction Q x v`.
+
+A map into matrices is continuous exactly when each matrix entry is continuous. The `(i, j)` entry
+of the standard matrix of the Spin action is the `i`th coordinate of the action on
+`Pi.single j 1`. The fixed-vector result therefore proves continuity into the independently
+topologized special orthogonal group.
+
+## Main results
+
+* `CliffordAlgebra.instIsTopologicalGroupRealSpinGroup` equips `spinGroup Q` with a topological
+  group structure for its canonical subtype topology.
+* `CliffordAlgebra.continuous_spinToSpecialOrthogonal_realPi` proves continuity of the Spin
+  projection for every quadratic form on a finite real coordinate space.
+* `CliffordAlgebra.continuous_realCliffordSpinDoubleCoverZero_rightHom` specializes this result to
+  the projection field of the packaged compact real double cover.
+
+## References
+
+This supplies the topological-group bridge in Layer 7 of
+`TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. See H. B. Lawson and
+M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+-/
+
+public section
+
+
+namespace CliffordAlgebra
+
+open TauCeti
+
+noncomputable section
+
+universe u
+
+
+variable {V : Type u} [AddCommGroup V] [Module ℝ V] [FiniteDimensional ℝ V]
+
+/-- A finite-dimensional real Spin group is a topological group for its canonical subtype
+topology. Multiplication is inherited from the Clifford algebra, while inversion is Clifford
+star. -/
+instance instIsTopologicalGroupRealSpinGroup (Q : QuadraticForm ℝ V) :
+    IsTopologicalGroup (spinGroup Q) where
+  continuous_mul := continuous_mul
+  continuous_inv := continuous_induced_rng.mpr continuous_subtype_val.star
+
+/-- For a fixed vector, its image under the real Spin action depends continuously on the Spin
+element.
+
+After applying the continuous vector-part map `ιInv`, the action is the product
+`x * ι(v) * star x` in the Clifford algebra. Both the subtype coercion and Clifford star are
+continuous. -/
+private theorem continuous_spinVectorAction_realPi
+    {n : Type u} [Finite n] (Q : QuadraticForm ℝ (n → ℝ)) (v : n → ℝ) :
+    Continuous (fun x : spinGroup Q => spinVectorAction Q x v) := by
+  let _ := Fintype.ofFinite n
+  have hval : Continuous (fun x : spinGroup Q => (x : CliffordAlgebra Q)) :=
+    continuous_subtype_val
+  have hstar : Continuous (fun x : spinGroup Q => star (x : CliffordAlgebra Q)) :=
+    continuous_subtype_val.star
+  have hprod : Continuous (fun x : spinGroup Q =>
+      (x : CliffordAlgebra Q) * ι Q v * star (x : CliffordAlgebra Q)) :=
+    (hval.mul continuous_const).mul hstar
+  have hvector := (IsModuleTopology.continuous_of_linearMap (ιInv Q)).comp hprod
+  convert hvector using 1
+  funext x
+  rw [← ιInv_ι Q (spinVectorAction Q x v), ι_spinVectorAction_apply]
+  rfl
+
+/-- The matrix entry of the coordinate realization of the Spin projection is the corresponding
+coordinate of the action on a standard basis vector. This bridge isolates the nested coercions
+from the special orthogonal group through matrix units. -/
+private theorem coe_spinProjectionGeneralLinear_apply
+    {n : Type u} [Fintype n] [DecidableEq n] (Q : QuadraticForm ℝ (n → ℝ))
+    (x : spinGroup Q) (i j : n) :
+    (((Units.coeHom (Matrix n n ℝ)).comp
+      ((TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear Q).comp
+        (spinToSpecialOrthogonal Q))) x) i j =
+      spinVectorAction Q x (Pi.single j 1) i := by
+  rw [MonoidHom.comp_apply, Units.coeHom_apply, MonoidHom.comp_apply,
+    TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear_apply,
+    coe_spinToSpecialOrthogonal_apply]
+
+/-- The real Spin action of a quadratic form on a finite coordinate space is continuous as a map to
+the special orthogonal group with its standard coordinate topology. -/
+@[fun_prop]
+theorem continuous_spinToSpecialOrthogonal_realPi
+    {n : Type u} [Fintype n] [DecidableEq n] (Q : QuadraticForm ℝ (n → ℝ)) :
+    Continuous (spinToSpecialOrthogonal Q) := by
+  apply (TauCeti.QuadraticMap.isEmbedding_specialOrthogonalToGeneralLinear
+    Q).isInducing.continuous_iff.mpr
+  have h : Continuous
+      ((TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear Q).comp
+        (spinToSpecialOrthogonal Q)) := by
+    apply Continuous.of_coeHom_comp
+    apply continuous_matrix
+    intro i j
+    simpa only [coe_spinProjectionGeneralLinear_apply, Function.comp_def] using
+      (continuous_apply i).comp
+        (continuous_spinVectorAction_realPi Q (Pi.single j 1))
+  simpa only [MonoidHom.coe_comp] using h
+
+/-- The projection field of the compact real Spin double cover is continuous. -/
+@[fun_prop]
+theorem continuous_realCliffordSpinDoubleCoverZero_rightHom (n : ℕ) [NeZero n] :
+    Continuous (realCliffordSpinDoubleCoverZero n).rightHom := by
+  rw [realCliffordSpinDoubleCoverZero_rightHom]
+  exact continuous_spinToSpecialOrthogonal_realPi (realCliffordForm n 0)
+
+end
+
+
+end CliffordAlgebra

--- a/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
+++ b/TauCeti/Topology/Algebra/CliffordAlgebra/Spin.lean
@@ -26,7 +26,7 @@ fibration, or universal-cover claim.
 
 ## Continuity argument
 
-For `x : spinPQ p q` and a fixed vector `v`, the public action equation gives
+For `x : spinGroup Q` and a fixed vector `v`, the public action equation gives
 
 `ι Q (spinVectorAction Q x v) = x * ι Q v * star x`.
 
@@ -44,7 +44,7 @@ topologized special orthogonal group.
 
 * `CliffordAlgebra.instIsTopologicalGroupRealSpinGroup` equips `spinGroup Q` with a topological
   group structure for its canonical subtype topology.
-* `CliffordAlgebra.continuous_spinToSpecialOrthogonal_realPi` proves continuity of the Spin
+* `CliffordAlgebra.continuous_spinToSpecialOrthogonal_pi` proves continuity of the Spin
   projection for every quadratic form on a finite real coordinate space.
 * `CliffordAlgebra.continuous_realCliffordSpinDoubleCoverZero_rightHom` specializes this result to
   the projection field of the packaged compact real double cover.
@@ -79,12 +79,8 @@ instance instIsTopologicalGroupRealSpinGroup (Q : QuadraticForm ℝ V) :
   continuous_inv := continuous_induced_rng.mpr continuous_subtype_val.star
 
 /-- For a fixed vector, its image under the real Spin action depends continuously on the Spin
-element.
-
-After applying the continuous vector-part map `ιInv`, the action is the product
-`x * ι(v) * star x` in the Clifford algebra. Both the subtype coercion and Clifford star are
-continuous. -/
-private theorem continuous_spinVectorAction_realPi
+element. -/
+private theorem continuous_spinVectorAction_pi
     {n : Type u} [Finite n] (Q : QuadraticForm ℝ (n → ℝ)) (v : n → ℝ) :
     Continuous (fun x : spinGroup Q => spinVectorAction Q x v) := by
   let _ := Fintype.ofFinite n
@@ -101,24 +97,10 @@ private theorem continuous_spinVectorAction_realPi
   rw [← ιInv_ι Q (spinVectorAction Q x v), ι_spinVectorAction_apply]
   rfl
 
-/-- The matrix entry of the coordinate realization of the Spin projection is the corresponding
-coordinate of the action on a standard basis vector. This bridge isolates the nested coercions
-from the special orthogonal group through matrix units. -/
-private theorem coe_spinProjectionGeneralLinear_apply
-    {n : Type u} [Fintype n] [DecidableEq n] (Q : QuadraticForm ℝ (n → ℝ))
-    (x : spinGroup Q) (i j : n) :
-    (((Units.coeHom (Matrix n n ℝ)).comp
-      ((TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear Q).comp
-        (spinToSpecialOrthogonal Q))) x) i j =
-      spinVectorAction Q x (Pi.single j 1) i := by
-  rw [MonoidHom.comp_apply, Units.coeHom_apply, MonoidHom.comp_apply,
-    TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear_apply,
-    coe_spinToSpecialOrthogonal_apply]
-
 /-- The real Spin action of a quadratic form on a finite coordinate space is continuous as a map to
 the special orthogonal group with its standard coordinate topology. -/
 @[fun_prop]
-theorem continuous_spinToSpecialOrthogonal_realPi
+theorem continuous_spinToSpecialOrthogonal_pi
     {n : Type u} [Fintype n] [DecidableEq n] (Q : QuadraticForm ℝ (n → ℝ)) :
     Continuous (spinToSpecialOrthogonal Q) := by
   apply (TauCeti.QuadraticMap.isEmbedding_specialOrthogonalToGeneralLinear
@@ -129,9 +111,11 @@ theorem continuous_spinToSpecialOrthogonal_realPi
     apply Continuous.of_coeHom_comp
     apply continuous_matrix
     intro i j
-    simpa only [coe_spinProjectionGeneralLinear_apply, Function.comp_def] using
+    simpa only [MonoidHom.comp_apply, Units.coeHom_apply,
+      TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear_apply,
+      coe_spinToSpecialOrthogonal_apply, Function.comp_def] using
       (continuous_apply i).comp
-        (continuous_spinVectorAction_realPi Q (Pi.single j 1))
+        (continuous_spinVectorAction_pi Q (Pi.single j 1))
   simpa only [MonoidHom.coe_comp] using h
 
 /-- The projection field of the compact real Spin double cover is continuous. -/
@@ -139,7 +123,7 @@ theorem continuous_spinToSpecialOrthogonal_realPi
 theorem continuous_realCliffordSpinDoubleCoverZero_rightHom (n : ℕ) [NeZero n] :
     Continuous (realCliffordSpinDoubleCoverZero n).rightHom := by
   rw [realCliffordSpinDoubleCoverZero_rightHom]
-  exact continuous_spinToSpecialOrthogonal_realPi (realCliffordForm n 0)
+  exact continuous_spinToSpecialOrthogonal_pi (realCliffordForm n 0)
 
 end
 

--- a/TauCeti/Topology/Algebra/QuadraticForm/SpecialOrthogonal.lean
+++ b/TauCeti/Topology/Algebra/QuadraticForm/SpecialOrthogonal.lean
@@ -12,17 +12,16 @@ public import Mathlib.Topology.Algebra.Ring.Real
 /-!
 # Topology on real special orthogonal groups in coordinates
 
-For a quadratic form `Q` on a finite real coordinate space `n → ℝ`, this file sends
-`specialOrthogonalGroup Q` faithfully to `GL(n, ℝ)` and induces the standard coordinate topology
-from that embedding. The resulting special orthogonal group is Hausdorff and a topological group.
+For a quadratic form `Q` on a finite real coordinate space `n → ℝ`, this file induces the
+standard coordinate topology from the faithful map of `specialOrthogonalGroup Q` into `GL(n, ℝ)`
+defined in `TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup`. The resulting special orthogonal
+group is Hausdorff and a topological group.
 
 The construction applies to an arbitrary quadratic form on the coordinate space. It does not use a
 Clifford algebra or a Spin group.
 
-## Main definitions and results
+## Main results
 
-* `TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear` is the faithful coordinate map.
-* `TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear_apply` gives its matrix entries.
 * `TauCeti.QuadraticMap.isEmbedding_specialOrthogonalToGeneralLinear` records that it is a
   topological embedding.
 -/
@@ -40,28 +39,6 @@ universe u
 
 
 variable {n : Type u} [Fintype n] [DecidableEq n]
-
-/-- The coordinate inclusion of a real special orthogonal group into `GL(n, ℝ)`. -/
-noncomputable def specialOrthogonalToGeneralLinear (Q : QuadraticForm ℝ (n → ℝ)) :
-    specialOrthogonalGroup Q →* Matrix.GeneralLinearGroup n ℝ :=
-  (Matrix.GeneralLinearGroup.toLin (n := n) (R := ℝ)).symm.toMonoidHom.comp
-    ((LinearMap.GeneralLinearGroup.generalLinearEquiv ℝ (n → ℝ)).symm.toMonoidHom.comp
-      (specialOrthogonalGroup Q).subtype)
-
-/-- A real special orthogonal transformation acts through its usual coordinate matrix. -/
-@[simp]
-theorem specialOrthogonalToGeneralLinear_apply (Q : QuadraticForm ℝ (n → ℝ))
-    (g : specialOrthogonalGroup Q) (i j : n) :
-    specialOrthogonalToGeneralLinear Q g i j =
-      (g : (n → ℝ) ≃ₗ[ℝ] (n → ℝ)) (Pi.single j 1) i := by
-  rfl
-
-/-- The coordinate inclusion of a real special orthogonal group is injective. -/
-theorem specialOrthogonalToGeneralLinear_injective (Q : QuadraticForm ℝ (n → ℝ)) :
-    Function.Injective (specialOrthogonalToGeneralLinear Q) :=
-  (Matrix.GeneralLinearGroup.toLin (n := n) (R := ℝ)).symm.injective.comp
-    ((LinearMap.GeneralLinearGroup.generalLinearEquiv ℝ (n → ℝ)).symm.injective.comp
-      Subtype.coe_injective)
 
 /-- The canonical topology on a real special orthogonal group in coordinates is induced by its
 faithful representation in `GL(n, ℝ)`. -/

--- a/TauCeti/Topology/Algebra/QuadraticForm/SpecialOrthogonal.lean
+++ b/TauCeti/Topology/Algebra/QuadraticForm/SpecialOrthogonal.lean
@@ -13,8 +13,9 @@ public import Mathlib.Topology.Algebra.Group.Matrix
 
 For a quadratic map `Q` on a finite coordinate space `n → R`, this file induces the
 standard coordinate topology from the faithful map of `specialOrthogonalGroup Q` into `GL(n, R)`
-defined in `TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup`. The resulting special orthogonal
-group is Hausdorff and a topological group.
+defined in `TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup`. Over a topological ring the
+resulting special orthogonal group is a topological group, and it is Hausdorff when `R` is
+Hausdorff.
 
 The construction applies to an arbitrary quadratic map on the coordinate space. It does not use a
 Clifford algebra or a Spin group.

--- a/TauCeti/Topology/Algebra/QuadraticForm/SpecialOrthogonal.lean
+++ b/TauCeti/Topology/Algebra/QuadraticForm/SpecialOrthogonal.lean
@@ -7,17 +7,16 @@ module
 
 public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
 public import Mathlib.Topology.Algebra.Group.Matrix
-public import Mathlib.Topology.Algebra.Ring.Real
 
 /-!
-# Topology on real special orthogonal groups in coordinates
+# Topology on special orthogonal groups in coordinates
 
-For a quadratic form `Q` on a finite real coordinate space `n → ℝ`, this file induces the
-standard coordinate topology from the faithful map of `specialOrthogonalGroup Q` into `GL(n, ℝ)`
+For a quadratic map `Q` on a finite coordinate space `n → R`, this file induces the
+standard coordinate topology from the faithful map of `specialOrthogonalGroup Q` into `GL(n, R)`
 defined in `TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup`. The resulting special orthogonal
 group is Hausdorff and a topological group.
 
-The construction applies to an arbitrary quadratic form on the coordinate space. It does not use a
+The construction applies to an arbitrary quadratic map on the coordinate space. It does not use a
 Clifford algebra or a Spin group.
 
 ## Main results
@@ -35,29 +34,36 @@ namespace QuadraticMap
 
 noncomputable section
 
-universe u
+universe u v w
 
 
 variable {n : Type u} [Fintype n] [DecidableEq n]
+  {R : Type v} [CommRing R] [TopologicalSpace R]
+  {N : Type w} [AddCommMonoid N] [Module R N]
 
-/-- The canonical topology on a real special orthogonal group in coordinates is induced by its
-faithful representation in `GL(n, ℝ)`. -/
-instance instTopologicalSpaceSpecialOrthogonalGroupRealPi (Q : QuadraticForm ℝ (n → ℝ)) :
+/-- The canonical topology on a special orthogonal group in coordinates is induced by its
+faithful representation in `GL(n, R)`. -/
+instance _root_.TauCeti.QuadraticMap.instTopologicalSpaceSpecialOrthogonalGroupPi
+    (Q : QuadraticMap R (n → R) N) :
     TopologicalSpace (specialOrthogonalGroup Q) :=
   TopologicalSpace.induced (specialOrthogonalToGeneralLinear Q) inferInstance
 
-/-- The coordinate inclusion of a real special orthogonal group is a topological embedding. -/
-theorem isEmbedding_specialOrthogonalToGeneralLinear (Q : QuadraticForm ℝ (n → ℝ)) :
+/-- The coordinate inclusion of a special orthogonal group is a topological embedding. -/
+theorem _root_.TauCeti.QuadraticMap.isEmbedding_specialOrthogonalToGeneralLinear
+    (Q : QuadraticMap R (n → R) N) :
     Topology.IsEmbedding (specialOrthogonalToGeneralLinear Q) :=
   (specialOrthogonalToGeneralLinear_injective Q).isEmbedding_induced
 
-/-- A real special orthogonal group in coordinates is a topological group. -/
-instance instIsTopologicalGroupSpecialOrthogonalGroupRealPi (Q : QuadraticForm ℝ (n → ℝ)) :
+/-- A special orthogonal group in coordinates over a topological ring is a topological group. -/
+instance _root_.TauCeti.QuadraticMap.instIsTopologicalGroupSpecialOrthogonalGroupPi
+    [IsTopologicalRing R]
+    (Q : QuadraticMap R (n → R) N) :
     IsTopologicalGroup (specialOrthogonalGroup Q) :=
   topologicalGroup_induced (specialOrthogonalToGeneralLinear Q)
 
-/-- A real special orthogonal group in coordinates is Hausdorff. -/
-instance instT2SpaceSpecialOrthogonalGroupRealPi (Q : QuadraticForm ℝ (n → ℝ)) :
+/-- A special orthogonal group in Hausdorff coordinates is Hausdorff. -/
+instance _root_.TauCeti.QuadraticMap.instT2SpaceSpecialOrthogonalGroupPi [T2Space R]
+    (Q : QuadraticMap R (n → R) N) :
     T2Space (specialOrthogonalGroup Q) :=
   (isEmbedding_specialOrthogonalToGeneralLinear Q).t2Space
 

--- a/TauCeti/Topology/Algebra/QuadraticForm/SpecialOrthogonal.lean
+++ b/TauCeti/Topology/Algebra/QuadraticForm/SpecialOrthogonal.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
+public import Mathlib.Topology.Algebra.Group.Matrix
+public import Mathlib.Topology.Algebra.Ring.Real
+
+/-!
+# Topology on real special orthogonal groups in coordinates
+
+For a quadratic form `Q` on a finite real coordinate space `n → ℝ`, this file sends
+`specialOrthogonalGroup Q` faithfully to `GL(n, ℝ)` and induces the standard coordinate topology
+from that embedding. The resulting special orthogonal group is Hausdorff and a topological group.
+
+The construction applies to an arbitrary quadratic form on the coordinate space. It does not use a
+Clifford algebra or a Spin group.
+
+## Main definitions and results
+
+* `TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear` is the faithful coordinate map.
+* `TauCeti.QuadraticMap.specialOrthogonalToGeneralLinear_apply` gives its matrix entries.
+* `TauCeti.QuadraticMap.isEmbedding_specialOrthogonalToGeneralLinear` records that it is a
+  topological embedding.
+-/
+
+public section
+
+
+namespace TauCeti
+
+namespace QuadraticMap
+
+noncomputable section
+
+universe u
+
+
+variable {n : Type u} [Fintype n] [DecidableEq n]
+
+/-- The coordinate inclusion of a real special orthogonal group into `GL(n, ℝ)`. -/
+noncomputable def specialOrthogonalToGeneralLinear (Q : QuadraticForm ℝ (n → ℝ)) :
+    specialOrthogonalGroup Q →* Matrix.GeneralLinearGroup n ℝ :=
+  (Matrix.GeneralLinearGroup.toLin (n := n) (R := ℝ)).symm.toMonoidHom.comp
+    ((LinearMap.GeneralLinearGroup.generalLinearEquiv ℝ (n → ℝ)).symm.toMonoidHom.comp
+      (specialOrthogonalGroup Q).subtype)
+
+/-- A real special orthogonal transformation acts through its usual coordinate matrix. -/
+@[simp]
+theorem specialOrthogonalToGeneralLinear_apply (Q : QuadraticForm ℝ (n → ℝ))
+    (g : specialOrthogonalGroup Q) (i j : n) :
+    specialOrthogonalToGeneralLinear Q g i j =
+      (g : (n → ℝ) ≃ₗ[ℝ] (n → ℝ)) (Pi.single j 1) i := by
+  rfl
+
+/-- The coordinate inclusion of a real special orthogonal group is injective. -/
+theorem specialOrthogonalToGeneralLinear_injective (Q : QuadraticForm ℝ (n → ℝ)) :
+    Function.Injective (specialOrthogonalToGeneralLinear Q) :=
+  (Matrix.GeneralLinearGroup.toLin (n := n) (R := ℝ)).symm.injective.comp
+    ((LinearMap.GeneralLinearGroup.generalLinearEquiv ℝ (n → ℝ)).symm.injective.comp
+      Subtype.coe_injective)
+
+/-- The canonical topology on a real special orthogonal group in coordinates is induced by its
+faithful representation in `GL(n, ℝ)`. -/
+instance instTopologicalSpaceSpecialOrthogonalGroupRealPi (Q : QuadraticForm ℝ (n → ℝ)) :
+    TopologicalSpace (specialOrthogonalGroup Q) :=
+  TopologicalSpace.induced (specialOrthogonalToGeneralLinear Q) inferInstance
+
+/-- The coordinate inclusion of a real special orthogonal group is a topological embedding. -/
+theorem isEmbedding_specialOrthogonalToGeneralLinear (Q : QuadraticForm ℝ (n → ℝ)) :
+    Topology.IsEmbedding (specialOrthogonalToGeneralLinear Q) :=
+  (specialOrthogonalToGeneralLinear_injective Q).isEmbedding_induced
+
+/-- A real special orthogonal group in coordinates is a topological group. -/
+instance instIsTopologicalGroupSpecialOrthogonalGroupRealPi (Q : QuadraticForm ℝ (n → ℝ)) :
+    IsTopologicalGroup (specialOrthogonalGroup Q) :=
+  topologicalGroup_induced (specialOrthogonalToGeneralLinear Q)
+
+/-- A real special orthogonal group in coordinates is Hausdorff. -/
+instance instT2SpaceSpecialOrthogonalGroupRealPi (Q : QuadraticForm ℝ (n → ℝ)) :
+    T2Space (specialOrthogonalGroup Q) :=
+  (isEmbedding_specialOrthogonalToGeneralLinear Q).t2Space
+
+end
+
+
+end QuadraticMap
+
+end TauCeti


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the topology needed for compact real Spin groups.

- Gives real Clifford algebras their module topology, continuous addition and star, and a Hausdorff topology. Multiplication is continuous in finite dimension.
- Gives coordinate special orthogonal groups for arbitrary quadratic maps the topology induced by their faithful matrix representation over a topological commutative ring.
- Makes finite-dimensional real Spin groups topological groups and proves continuity of the generic and packaged `(n, 0)` Spin projections.

## Roadmap target

Supplies the topological-group input for [SpinRepresentations Layer 7](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-7-real-clifford-algebras-bott-periodicity-and-spinp-q).

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#spinPQ"}-->

## Verification

Focused build, generic and real consumers, source guards, proof golf, and the complete mechanical gate pass at `de5a572f`.

## Scale and generality

Adds 349 lines. The coordinate special orthogonal topology is generic over topological commutative rings. Additive, star, and Hausdorff Clifford topology needs no finite-dimensional assumption. Multiplication and the Spin topological-group instance remain finite-dimensional.

## Scope

- **Consumes:** Real Clifford and Spin APIs, module topology, matrix topology, and the Layer 2 double cover.
- **Provides:** Canonical Clifford topology, generic coordinate special orthogonal topology, topological-group and Hausdorff instances, and continuous generic and `(n, 0)` Spin projections.
- **Fits:** Supplies the topology used by Layer 7 real Spin groups and the later compact connectivity work.
- **Boundary:** Does not prove compactness, connectedness, simple connectivity, manifold structure, fibrations, or covering results.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [465c9e7](https://github.com/TauCetiProject/TauCetiReview/commit/465c9e7f030871aa0d5fbc533ada5219e9a96f2c) · local 2+1 review @ [ut-lean-review](https://github.com/utensil/formal-land/commit/a2f40797) fixed: generality (2), reuse (1)</sub>