### PR TITLE
feat: identify Borel intersection with diagonal normalizer

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
@@ -69,8 +69,10 @@ section WeylElement
 variable (R : Type u) [Semiring R]
 
 /-- The Weyl element in the Bruhat decomposition of `GL₂` is the permutation matrix of the
-transposition of the two coordinate lines. -/
-@[simp]
+transposition of the two coordinate lines.
+
+This is not a simp lemma: `GL2WeylElement` is the canonical name used by the Bruhat API, and
+unfolding it makes those theorem statements fail the simp-normal-form linter. -/
 theorem gl2WeylElement_eq_permutationGL_swap :
     GL2WeylElement R = permutationGL (k := R) (Equiv.swap 0 1) := by
   apply Units.ext

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
@@ -70,6 +70,7 @@ variable (R : Type u) [Semiring R]
 
 /-- The Weyl element in the Bruhat decomposition of `GL₂` is the permutation matrix of the
 transposition of the two coordinate lines. -/
+@[simp]
 theorem gl2WeylElement_eq_permutationGL_swap :
     GL2WeylElement R = permutationGL (k := R) (Equiv.swap 0 1) := by
   apply Units.ext

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- The Bruhat Weyl element and the Borel subgroup are compared with the diagonal normalizer below.
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Bruhat
+-- The monomial description of the diagonal normalizer supplies its permutation quotient.
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal.Normalizer
+
+/-!
+# The diagonal normalizer and the Bruhat data of `GL₂`
+
+This file aligns upper-triangular Bruhat data with the diagonal normalizer. For `GLₙ`, an
+upper-triangular monomial matrix is diagonal, and hence
+
+`Bₙ ⊓ N(Tₙ) = Tₙ`.
+
+Specializing to `GL₂`, the Weyl element used in the Bruhat decomposition is the permutation
+matrix of the transposition, so it lies in `N(T)` and induces the nontrivial element of its
+permutation quotient. In particular,
+
+`B ⊓ N(T) = T`,
+
+where `B` is the standard Borel subgroup. This is the kernel identification in the
+rank-one `(B, N)`-pair: the already-established quotient `N(T) / T ≃ S₂` can equivalently be
+written with `B ⊓ N(T)` as its denominator.
+
+The assumption `Nontrivial kˣ` in the intersection theorems is necessary for the full
+group-theoretic normalizer. For example, over `𝔽₂` the diagonal torus of `GL₂` is trivial, so
+its normalizer is all of `GL₂` and the displayed rank-one intersection would instead be `B`.
+
+## Main results
+
+* `TauCeti.gl2WeylElement_eq_permutationGL_swap`: the Bruhat Weyl element is the permutation
+  matrix of the transposition.
+* `TauCeti.gl2WeylElement_mem_normalizer_diagonalTorus`: the Weyl element normalizes the diagonal
+  torus.
+* `TauCeti.diagonalNormalizerPerm_gl2WeylElement`: the Weyl element induces the transposition on
+  the coordinate lines.
+* `TauCeti.UpperTriangularGroup.inf_normalizer_diagonalTorus_eq`: in every dimension, the
+  intersection of the upper-triangular subgroup with the diagonal normalizer is the diagonal
+  torus.
+* `TauCeti.GL2Borel.inf_normalizer_diagonalTorus_eq`: the intersection of the Borel subgroup with
+  the diagonal normalizer is the diagonal torus.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), Sections 26.2–26.3 and 28.1.
+* T. A. Springer, *Linear Algebraic Groups*, second edition (1998), Sections 8.3–8.4.
+
+This advances Layer 7, "Bruhat decomposition and BN-pairs / Tits systems", of the
+ReductiveGroups roadmap by identifying the intersection subgroup, including in the rank-one
+`GL₂` example.
+-/
+
+public section
+
+open Matrix
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+section WeylElement
+
+variable (R : Type u) [Semiring R]
+
+/-- The Weyl element in the Bruhat decomposition of `GL₂` is the permutation matrix of the
+transposition of the two coordinate lines. -/
+theorem gl2WeylElement_eq_permutationGL_swap :
+    GL2WeylElement R = permutationGL (k := R) (Equiv.swap 0 1) := by
+  apply Units.ext
+  rw [permutationGL_coe, coe_gl2WeylElement]
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [Equiv.Perm.permMatrix]
+
+/-- The Bruhat Weyl element normalizes the diagonal torus. -/
+theorem gl2WeylElement_mem_normalizer_diagonalTorus :
+    GL2WeylElement R ∈
+      Subgroup.normalizer (diagonalTorus R 2 : Set (GL (Fin 2) R)) := by
+  rw [gl2WeylElement_eq_permutationGL_swap]
+  exact permutationGL_mem_normalizer (Equiv.swap 0 1)
+
+end WeylElement
+
+section Field
+
+variable {k : Type u} [Field k]
+
+variable [Nontrivial kˣ]
+
+/-- The coordinate permutation induced by the Bruhat Weyl element is the transposition. -/
+@[simp]
+theorem diagonalNormalizerPerm_gl2WeylElement :
+    diagonalNormalizerPerm (k := k) (n := 2)
+        ⟨GL2WeylElement k,
+          gl2WeylElement_mem_normalizer_diagonalTorus (R := k)⟩ =
+      Equiv.swap 0 1 := by
+  apply diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL _
+    (fun _ ↦ (1 : kˣ)) (Equiv.swap 0 1)
+  calc
+    ((⟨GL2WeylElement k,
+        gl2WeylElement_mem_normalizer_diagonalTorus (R := k)⟩ :
+        Subgroup.normalizer (diagonalTorus k 2 : Set (GL (Fin 2) k))) : GL (Fin 2) k) =
+        GL2WeylElement k := rfl
+    _ = permutationGL (k := k) (Equiv.swap 0 1) :=
+      gl2WeylElement_eq_permutationGL_swap k
+    _ = diagGL (fun _ : Fin 2 ↦ (1 : kˣ)) *
+        permutationGL (k := k) (Equiv.swap 0 1) := by
+      rw [show diagGL (fun _ : Fin 2 ↦ (1 : kˣ)) = 1 by
+        exact map_one (diagGL (k := k) (ι := Fin 2)), one_mul]
+
+end Field
+
+section UpperTriangular
+
+section CommRing
+
+variable {R : Type u} [CommRing R] {n : ℕ}
+
+namespace UpperTriangularGroup
+
+/-- Every diagonal matrix is upper triangular, so the diagonal torus lies in the standard
+upper-triangular subgroup. -/
+theorem diagonalTorus_le :
+    diagonalTorus R n ≤ upperTriangularGroup (Fin n) R := by
+  intro g hg
+  obtain ⟨d, rfl⟩ := mem_diagonalTorus_iff_exists_diagGL.mp hg
+  rw [mem_iff]
+  intro i j hji
+  rw [diagGL_coe]
+  exact Matrix.diagonal_apply_ne _ (ne_of_gt hji)
+
+end UpperTriangularGroup
+
+end CommRing
+
+section Field
+
+variable {k : Type u} [Field k] [Nontrivial kˣ] {n : ℕ}
+
+namespace UpperTriangularGroup
+
+/-- A diagonal-normalizer element that is upper triangular is diagonal. Equivalently, an
+upper-triangular monomial matrix cannot carry a nontrivial coordinate permutation. -/
+theorem mem_diagonalTorus_of_mem
+    (g : Subgroup.normalizer (diagonalTorus k n : Set (GL (Fin n) k)))
+    (hg : (g : GL (Fin n) k) ∈ upperTriangularGroup (Fin n) k) :
+    (g : GL (Fin n) k) ∈ diagonalTorus k n := by
+  obtain ⟨d, σ, hfactor⟩ := mem_normalizer_diagonalTorus_iff_exists.mp g.property
+  have hupper := mem_iff.mp hg
+  have hle (ι : Fin n) : σ ι ≤ ι := by
+    by_contra h
+    have hzero := hupper (lt_of_not_ge h)
+    have hentry := congrArg
+      (fun x : GL (Fin n) k ↦ (x : Matrix (Fin n) (Fin n) k) (σ ι) ι) hfactor
+    rw [hzero] at hentry
+    simp only [Units.val_mul, diagGL_coe, permutationGL_coe, Matrix.diagonal_mul] at hentry
+    have hperm : (σ⁻¹.permMatrix k) (σ ι) ι = 1 := by
+      simp [Equiv.Perm.permMatrix]
+    rw [hperm, mul_one] at hentry
+    exact Units.ne_zero (d (σ ι)) hentry.symm
+  have hσ : σ = 1 := by
+    by_contra hne
+    have hstrict : ∃ ι ∈ Finset.univ, (σ ι).val < ι.val := by
+      have hnot : ¬ ∀ ι, σ ι = ι := by
+        intro h
+        apply hne
+        apply Equiv.ext
+        intro ι
+        simpa using h ι
+      obtain ⟨ι, hι⟩ := not_forall.mp hnot
+      exact ⟨ι, Finset.mem_univ _,
+        lt_of_le_of_ne (hle ι) fun hval ↦ hι (Fin.ext hval)⟩
+    have hsum : (∑ ι : Fin n, (σ ι).val) = ∑ ι : Fin n, ι.val :=
+      Equiv.sum_comp σ fun ι : Fin n ↦ ι.val
+    have hsumlt : (∑ ι : Fin n, (σ ι).val) < ∑ ι : Fin n, ι.val :=
+      Finset.sum_lt_sum (fun ι _ ↦ hle ι) hstrict
+    exact hsumlt.ne hsum
+  rw [hσ, map_one, mul_one] at hfactor
+  exact mem_diagonalTorus_iff_exists_diagGL.mpr ⟨d, hfactor.symm⟩
+
+/-- Over a field with at least two units, the intersection of the upper-triangular subgroup of
+`GLₙ` with the normalizer of the diagonal torus is exactly the diagonal torus. -/
+theorem inf_normalizer_diagonalTorus_eq :
+    upperTriangularGroup (Fin n) k ⊓
+        Subgroup.normalizer (diagonalTorus k n : Set (GL (Fin n) k)) =
+      diagonalTorus k n := by
+  apply le_antisymm
+  · intro g hg
+    exact mem_diagonalTorus_of_mem ⟨g, hg.2⟩ hg.1
+  · intro g hg
+    exact ⟨diagonalTorus_le hg, Subgroup.le_normalizer hg⟩
+
+end UpperTriangularGroup
+
+namespace GL2Borel
+
+/-- For `GL₂` over a field with at least two units, the intersection of the standard Borel
+subgroup with the normalizer of the diagonal torus is exactly the diagonal torus. This identifies
+the subgroup `H = B ∩ N` in the rank-one `(B, N)`-pair. -/
+theorem inf_normalizer_diagonalTorus_eq :
+    GL2Borel k ⊓ Subgroup.normalizer (diagonalTorus k 2 : Set (GL (Fin 2) k)) =
+      diagonalTorus k 2 :=
+  UpperTriangularGroup.inf_normalizer_diagonalTorus_eq
+
+end GL2Borel
+
+end Field
+
+end UpperTriangular
+
+end
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
@@ -120,10 +120,7 @@ theorem diagonalTorus_le :
     diagonalTorus R n ≤ upperTriangularGroup (Fin n) R := by
   intro g hg
   obtain ⟨d, rfl⟩ := mem_diagonalTorus_iff_exists_diagGL.mp hg
-  rw [mem_iff]
-  intro i j hji
-  rw [diagGL_coe]
-  exact Matrix.diagonal_apply_ne _ (ne_of_gt hji)
+  simpa only [coe_diagonalHom] using (diagonalHom d).property
 
 end UpperTriangularGroup
 
@@ -171,8 +168,9 @@ theorem mem_diagonalTorus_of_mem
     have hsumlt : (∑ ι : Fin n, (σ ι).val) < ∑ ι : Fin n, ι.val :=
       Finset.sum_lt_sum (fun ι _ ↦ hle ι) hstrict
     exact hsumlt.ne hsum
-  rw [hσ, map_one, mul_one] at hfactor
-  exact mem_diagonalTorus_iff_exists_diagGL.mpr ⟨d, hfactor.symm⟩
+  have hperm : diagonalNormalizerPerm (k := k) (n := n) g = 1 := by
+    rw [diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL g d σ hfactor, hσ]
+  exact (diagonalNormalizerPerm_eq_one_iff g).mp hperm
 
 /-- Over a field with at least two units, the intersection of the upper-triangular subgroup of
 `GLₙ` with the normalizer of the diagonal torus is exactly the diagonal torus. -/

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
@@ -70,7 +70,6 @@ variable (R : Type u) [Semiring R]
 
 /-- The Weyl element in the Bruhat decomposition of `GL₂` is the permutation matrix of the
 transposition of the two coordinate lines. -/
-@[simp]
 theorem gl2WeylElement_eq_permutationGL_swap :
     GL2WeylElement R = permutationGL (k := R) (Equiv.swap 0 1) := by
   apply Units.ext

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/Bruhat.lean
@@ -43,8 +43,6 @@ its normalizer is all of `GL₂` and the displayed rank-one intersection would i
 * `TauCeti.UpperTriangularGroup.inf_normalizer_diagonalTorus_eq`: in every dimension, the
   intersection of the upper-triangular subgroup with the diagonal normalizer is the diagonal
   torus.
-* `TauCeti.GL2Borel.inf_normalizer_diagonalTorus_eq`: the intersection of the Borel subgroup with
-  the diagonal normalizer is the diagonal torus.
 
 ## References
 
@@ -72,6 +70,7 @@ variable (R : Type u) [Semiring R]
 
 /-- The Weyl element in the Bruhat decomposition of `GL₂` is the permutation matrix of the
 transposition of the two coordinate lines. -/
+@[simp]
 theorem gl2WeylElement_eq_permutationGL_swap :
     GL2WeylElement R = permutationGL (k := R) (Equiv.swap 0 1) := by
   apply Units.ext
@@ -95,25 +94,13 @@ variable {k : Type u} [Field k]
 variable [Nontrivial kˣ]
 
 /-- The coordinate permutation induced by the Bruhat Weyl element is the transposition. -/
-@[simp]
 theorem diagonalNormalizerPerm_gl2WeylElement :
     diagonalNormalizerPerm (k := k) (n := 2)
         ⟨GL2WeylElement k,
           gl2WeylElement_mem_normalizer_diagonalTorus (R := k)⟩ =
       Equiv.swap 0 1 := by
-  apply diagonalNormalizerPerm_eq_of_eq_diagGL_mul_permutationGL _
-    (fun _ ↦ (1 : kˣ)) (Equiv.swap 0 1)
-  calc
-    ((⟨GL2WeylElement k,
-        gl2WeylElement_mem_normalizer_diagonalTorus (R := k)⟩ :
-        Subgroup.normalizer (diagonalTorus k 2 : Set (GL (Fin 2) k))) : GL (Fin 2) k) =
-        GL2WeylElement k := rfl
-    _ = permutationGL (k := k) (Equiv.swap 0 1) :=
-      gl2WeylElement_eq_permutationGL_swap k
-    _ = diagGL (fun _ : Fin 2 ↦ (1 : kˣ)) *
-        permutationGL (k := k) (Equiv.swap 0 1) := by
-      rw [show diagGL (fun _ : Fin 2 ↦ (1 : kˣ)) = 1 by
-        exact map_one (diagGL (k := k) (ι := Fin 2)), one_mul]
+  simpa only [gl2WeylElement_eq_permutationGL_swap] using
+    diagonalNormalizerPerm_permutationGL (k := k) (n := 2) (Equiv.swap 0 1)
 
 end Field
 
@@ -198,18 +185,6 @@ theorem inf_normalizer_diagonalTorus_eq :
     exact ⟨diagonalTorus_le hg, Subgroup.le_normalizer hg⟩
 
 end UpperTriangularGroup
-
-namespace GL2Borel
-
-/-- For `GL₂` over a field with at least two units, the intersection of the standard Borel
-subgroup with the normalizer of the diagonal torus is exactly the diagonal torus. This identifies
-the subgroup `H = B ∩ N` in the rank-one `(B, N)`-pair. -/
-theorem inf_normalizer_diagonalTorus_eq :
-    GL2Borel k ⊓ Subgroup.normalizer (diagonalTorus k 2 : Set (GL (Fin 2) k)) =
-      diagonalTorus k 2 :=
-  UpperTriangularGroup.inf_normalizer_diagonalTorus_eq
-
-end GL2Borel
 
 end Field
 


### PR DESCRIPTION
This PR identifies the intersection datum for the standard upper-triangular and diagonal-normalizer subgroups: prove `Bₙ ⊓ N(Tₙ) = Tₙ` for `GLₙ`, specialize it to the standard Borel of `GL₂`, and identify the Bruhat Weyl element with the transposition permutation matrix and its image in the normalizer quotient. This advances the exact Layer 7 target **“Bruhat decomposition and BN-pairs / Tits systems”** in `TauCetiRoadmap/ReductiveGroups/README.md`, supplying the kernel identification `H = B ∩ N` for the rank-one Tits system after the Bruhat decomposition, generation theorem, and `N(T)/T ≃ S₂` calculation already on `main`.

The Layer 7 structure-theory milestone served is the first concrete BN-pair for `GL₂`; after this PR, what remains is to package the general Tits-system axioms and instantiate them from the existing generation and Bruhat theorems together with this intersection and quotient data.

No Mathlib infrastructure is vendored; the proofs reuse the pinned Mathlib matrix, permutation, finite-sum, and subgroup APIs.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"gl2-borel-intersection-diagonal-normalizer"}-->

🤖 Prepared with Codex
