### PR TITLE
feat: couple array row coding with its directing measure

### DIFF
--- a/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Basic.lean
@@ -170,6 +170,13 @@ theorem aemeasurable_arrayRow {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
     (hX : ∀ p, AEMeasurable (X p) μ) (i : ℕ) : AEMeasurable (arrayRow X i) μ :=
   aemeasurable_pi_lambda _ fun j => hX (i, j)
 
+/-- Measurability of every row as a path implies measurability of every array entry. -/
+theorem aemeasurable_entry_of_arrayRow {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
+    (hX : ∀ i, AEMeasurable (arrayRow X i) μ) (p : ℕ × ℕ) : AEMeasurable (X p) μ := by
+  rcases p with ⟨i, j⟩
+  simpa only [Function.comp_def, arrayRow] using
+    (measurable_pi_apply j).comp_aemeasurable (hX i)
+
 theorem aemeasurable_arrayCol {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
     (hX : ∀ p, AEMeasurable (X p) μ) (j : ℕ) : AEMeasurable (arrayCol X j) μ :=
   aemeasurable_pi_lambda _ fun i => hX (i, j)

--- a/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/Coding.lean
@@ -93,7 +93,7 @@ variable [StandardBorelSpace α] [Nonempty α]
 
 /-- The law of the array coded by a parameter and one uniform variable per row, computed through
 its row process: it is the uncurried de Finetti barycenter of the parameter law. -/
-private theorem map_prod_unitIntervalCoding_array
+theorem map_prod_unitIntervalCoding_array
     (π : Measure (ProbabilityMeasure (ℕ → α))) :
     ((π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
         fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2)

--- a/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean
@@ -139,7 +139,7 @@ private theorem map_permReindex_one (P : ProbabilityMeasure (ℕ → α)) :
 
 /-- Reassembling the array from its row process turns the joint law of a random measure and the row
 process into the joint law of that random measure and the array. -/
-private theorem map_prod_jointPathLaw_arrayRow (hX : ∀ p, AEMeasurable (X p) μ)
+theorem map_uncurry_jointPathLaw_arrayRow (hX : ∀ p, AEMeasurable (X p) μ)
     (hν : Measurable ν) :
     (jointPathLaw μ (arrayRow X) ν).map (Prod.map id Function.uncurry)
       = μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω) := by
@@ -151,7 +151,7 @@ private theorem map_prod_jointPathLaw_arrayRow (hX : ∀ p, AEMeasurable (X p) �
 
 /-- Reassembling the array from its column process turns the joint law of a random measure and the
 column process into the joint law of that random measure and the array. -/
-private theorem map_prod_jointPathLaw_arrayCol (hX : ∀ p, AEMeasurable (X p) μ)
+theorem map_uncurrySwap_jointPathLaw_arrayCol (hX : ∀ p, AEMeasurable (X p) μ)
     (hν : Measurable ν) :
     (jointPathLaw μ (arrayCol X) ν).map
         (Prod.map id fun x : ℕ → ℕ → α => fun p : ℕ × ℕ => x p.2 p.1)
@@ -195,8 +195,8 @@ theorem SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq [IsFiniteMeasure
   have hν' : Measurable fun ω => (ν ω).map (measurable_reindex (α := α) τ).aemeasurable :=
     (TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex τ)).comp
       hν.measurable_directing
-  rw [← map_prod_jointPathLaw_arrayRow (X := fun p => X (σ p.1, τ p.2)) (fun p => hX _) hν',
-    ← map_prod_jointPathLaw_arrayRow hX hν.measurable_directing,
+  rw [← map_uncurry_jointPathLaw_arrayRow (X := fun p => X (σ p.1, τ p.2)) (fun p => hX _) hν',
+    ← map_uncurry_jointPathLaw_arrayRow hX hν.measurable_directing,
     h.jointPathLaw_arrayRow_pairReindex_eq hX hν σ τ]
 
 /-- **Row permutations leave the row directing measure alone.** The rows are the coordinates of the
@@ -267,8 +267,8 @@ theorem SeparatelyExchangeable.jointLaw_arrayCol_pairReindex_eq [IsFiniteMeasure
   have hν' : Measurable fun ω => (ν ω).map (measurable_reindex (α := α) σ).aemeasurable :=
     (TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex σ)).comp
       hν.measurable_directing
-  rw [← map_prod_jointPathLaw_arrayCol (X := fun p => X (σ p.1, τ p.2)) (fun p => hX _) hν',
-    ← map_prod_jointPathLaw_arrayCol hX hν.measurable_directing,
+  rw [← map_uncurrySwap_jointPathLaw_arrayCol (X := fun p => X (σ p.1, τ p.2)) (fun p => hX _) hν',
+    ← map_uncurrySwap_jointPathLaw_arrayCol hX hν.measurable_directing,
     h.jointPathLaw_arrayCol_pairReindex_eq hX hν σ τ]
 
 /-- **Row permutations push the column directing measure forward.** This is the half of

--- a/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/MixingLaw.lean
@@ -97,11 +97,8 @@ theorem mixingLaw_map_permReindex_arrayRow_eq_of_col_invariant
     (hcol : (μ.map fun ω p ↦ X (p.1, τ p.2) ω) = μ.map fun ω p ↦ X p ω)
     {ν : Ω → ProbabilityMeasure (ℕ → α)} (hν : MixedIIDWith μ (arrayRow X) ν) :
     μ.map (fun ω ↦ (ν ω).map (measurable_reindex τ).aemeasurable) = μ.map ν := by
-  -- the witness gives row measurability; the entries are its coordinates
-  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ := fun p => by
-    have h1 : AEMeasurable (fun ω => arrayRow X p.1 ω p.2) μ :=
-      (measurable_pi_apply p.2).comp_aemeasurable (hν.aemeasurable p.1)
-    simpa [arrayRow_apply] using h1
+  have hX : ∀ p : ℕ × ℕ, AEMeasurable (X p) μ :=
+    aemeasurable_entry_of_arrayRow hν.aemeasurable
   apply mixingLaw_map_eq_of_blockLaw_map_eq hν (measurable_reindex τ)
   intro m k _
   rw [blockLaw_def, blockLaw_def]

--- a/TauCeti/Probability/Exchangeability/Arrays/RowCoding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/RowCoding.lean
@@ -1,0 +1,210 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- Public: the directing-measure equivariance is transported to the canonical coding law.
+public import TauCeti.Probability.Exchangeability.Arrays.JointLaw
+-- Public: the canonical coding map occurs in the definition and every main statement.
+public import TauCeti.Probability.Exchangeability.Arrays.Coding
+-- Non-public: measurability of pushforward on probability measures is used in the symmetry proof.
+import TauCeti.MeasureTheory.Measure.Measurability
+
+/-!
+# Coupled row coding for separately exchangeable arrays
+
+The first functional representation of a separately exchangeable array writes each row as a
+sample from one random path law, using independent uniform noise for the rows.  For the second
+level of the Aldous--Hoover argument, it is essential to retain that random path law as a
+coordinate: column permutations act on it by pushforward, rather than leaving it fixed.
+
+This file packages the resulting canonical joint law.  If `π` is a law on probability measures on
+path space, `arrayRowCodingLaw π` is the law of
+
+```text
+(P, (i, j) ↦ unitIntervalCoding (ℕ → α) P (Uᵢ) j),
+```
+
+where `P` has law `π` and the `Uᵢ` are independent uniform variables.  A directing measure for
+the row process of an array identifies its joint law with this canonical law.  For a separately
+exchangeable array, the canonical law retains the full two-axis symmetry: row permutations act
+on the coded array alone, while column permutations act simultaneously on the array and by
+pushforward on `P`.
+
+This is the coupled interface needed by the second level of the exchangeable-arrays milestone in
+`TauCetiRoadmap/Exchangeability/README.md`, Layer 8.  It does not assert the final
+Aldous--Hoover representation: resolving the random path law into column and cell noise remains
+the next step.
+
+## Main definitions and results
+
+* `TauCeti.Probability.arrayRowCodingLaw` -- the canonical joint law of the random row law and the
+  coded array;
+* `TauCeti.Probability.ConditionallyIIDWith.jointLaw_arrayRow_eq_arrayRowCodingLaw` -- a row
+  directing measure identifies the original coupled law with the canonical coding law;
+* `TauCeti.Probability.SeparatelyExchangeable.map_pairReindex_arrayRowCodingLaw_eq` -- the coupled
+  coding law inherits the two-axis equivariance of the directing measure and the array.
+
+## References
+
+* D. Aldous, "Representations for partially exchangeable arrays of random variables", *Journal of
+  Multivariate Analysis* 11 (1981), 581--598.
+* O. Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005, Chapter 7.
+* O. Kallenberg, *Foundations of Modern Probability*, 3rd ed., Lemma 4.22, for randomization by a
+  uniform variable.
+
+No material is adapted from `cameronfreer/exchangeability`, which treats sequences rather than
+arrays.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+section CodingLaw
+
+variable [StandardBorelSpace α] [Nonempty α]
+
+omit [StandardBorelSpace α] [Nonempty α] in
+/-- A row-process witness supplies measurability of every array entry. -/
+private theorem aemeasurable_entries_of_conditionallyIIDWith_arrayRow
+    {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure (ℕ → α)}
+    (h : ConditionallyIIDWith μ (arrayRow X) ν) (p : ℕ × ℕ) :
+    AEMeasurable (X p) μ := by
+  have hentry : AEMeasurable (fun ω => arrayRow X p.1 ω p.2) μ :=
+    (measurable_pi_apply p.2).comp_aemeasurable (h.aemeasurable p.1)
+  simpa [arrayRow_apply] using hentry
+
+/-- The measurable map which retains a path law and uses one independent uniform variable to
+sample each row from it. -/
+theorem measurable_arrayRowCoding :
+    Measurable fun q : ProbabilityMeasure (ℕ → α) × (ℕ → unitInterval) =>
+      (q.1, fun p : ℕ × ℕ => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2) :=
+  measurable_fst.prodMk (measurable_pi_lambda _ fun p => measurable_unitIntervalCoding_entry p)
+
+/-- The canonical coupled law of a random path measure and the array obtained by independently
+sampling its rows. -/
+def arrayRowCodingLaw (π : Measure (ProbabilityMeasure (ℕ → α))) :
+    Measure (ProbabilityMeasure (ℕ → α) × (ℕ × ℕ → α)) :=
+  (π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
+    fun q => (q.1,
+      fun p : ℕ × ℕ => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2)
+
+/-- The defining pushforward formula for `arrayRowCodingLaw`. -/
+theorem arrayRowCodingLaw_def (π : Measure (ProbabilityMeasure (ℕ → α))) :
+    arrayRowCodingLaw π =
+      (π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
+        fun q => (q.1,
+          fun p : ℕ × ℕ => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2) :=
+  (rfl)
+
+/-- Coding a probability law of random path measures gives a probability law of the coupled
+parameter and array. -/
+instance instIsProbabilityMeasureArrayRowCodingLaw
+    (π : Measure (ProbabilityMeasure (ℕ → α))) [IsProbabilityMeasure π] :
+    IsProbabilityMeasure (arrayRowCodingLaw π) := by
+  rw [arrayRowCodingLaw_def]
+  exact Measure.isProbabilityMeasure_map measurable_arrayRowCoding.aemeasurable
+
+/-- The first marginal of the coupled coding law is the supplied law of the random path measure. -/
+@[simp]
+theorem map_fst_arrayRowCodingLaw (π : Measure (ProbabilityMeasure (ℕ → α))) :
+    (arrayRowCodingLaw π).map Prod.fst = π := by
+  rw [arrayRowCodingLaw_def, Measure.map_map measurable_fst measurable_arrayRowCoding]
+  have hcomp :
+      Prod.fst ∘ (fun q : ProbabilityMeasure (ℕ → α) × (ℕ → unitInterval) =>
+        (q.1, fun p : ℕ × ℕ => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2)) =
+          Prod.fst := rfl
+  rw [hcomp, Measure.map_fst_prod, measure_univ, one_smul]
+
+/-- The array marginal of the coupled coding law is the uncurried de Finetti barycenter of the
+law of the random path measure. -/
+@[simp]
+theorem map_snd_arrayRowCodingLaw (π : Measure (ProbabilityMeasure (ℕ → α))) :
+    (arrayRowCodingLaw π).map Prod.snd =
+      (deFinettiBarycenter π).map Function.uncurry := by
+  rw [arrayRowCodingLaw_def, Measure.map_map measurable_snd measurable_arrayRowCoding,
+    ← map_prod_unitIntervalCoding_eq_deFinettiBarycenter (α := ℕ → α),
+    Measure.map_map measurable_uncurry measurable_unitIntervalCodingPath]
+  refine congrArg (Measure.map · _) ?_
+  funext q p
+  rfl
+
+/-- A directing measure for the row process identifies its joint law with the canonical coupled
+row-coding law.  Unlike the array-law-only coding theorem, this keeps the directing measure as a
+coordinate, so its transformation under column permutations remains visible. -/
+theorem ConditionallyIIDWith.jointLaw_arrayRow_eq_arrayRowCodingLaw
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure (ℕ → α)}
+    (h : ConditionallyIIDWith μ (arrayRow X) ν) :
+    (μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω)) =
+      arrayRowCodingLaw (μ.map ν) := by
+  have hX : ∀ p, AEMeasurable (X p) μ :=
+    aemeasurable_entries_of_conditionallyIIDWith_arrayRow h
+  rw [← map_uncurry_jointPathLaw_arrayRow hX h.measurable_directing,
+    h.jointPathLaw_eq_map_unitIntervalCoding, arrayRowCodingLaw_def]
+  have hinner : Measurable fun q : ProbabilityMeasure (ℕ → α) × (ℕ → unitInterval) =>
+      (q.1, fun i => unitIntervalCoding (ℕ → α) q.1 (q.2 i)) :=
+    measurable_fst.prodMk measurable_unitIntervalCodingPath
+  rw [Measure.map_map (measurable_id.prodMap measurable_uncurry) hinner]
+  refine congrArg (Measure.map · _) ?_
+  funext q
+  apply Prod.ext rfl
+  funext p
+  rfl
+
+/-- The coupled row-coding law of a separately exchangeable array retains both symmetries.  A row
+permutation reindexes only the coded array.  A column permutation also pushes the random path law
+forward by the same coordinate permutation. -/
+theorem SeparatelyExchangeable.map_pairReindex_arrayRowCodingLaw_eq
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ × ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure (ℕ → α)}
+    (h : SeparatelyExchangeable μ X)
+    (hν : ConditionallyIIDWith μ (arrayRow X) ν) (σ τ : Equiv.Perm ℕ) :
+    (arrayRowCodingLaw (μ.map ν)).map
+        (fun q =>
+          (q.1.map (measurable_reindex τ).aemeasurable, pairReindex σ τ q.2)) =
+      arrayRowCodingLaw (μ.map ν) := by
+  have hX : ∀ p, AEMeasurable (X p) μ :=
+    aemeasurable_entries_of_conditionallyIIDWith_arrayRow hν
+  rw [← hν.jointLaw_arrayRow_eq_arrayRowCodingLaw,
+    AEMeasurable.map_map_of_aemeasurable]
+  · have hfun :
+        ((fun q : ProbabilityMeasure (ℕ → α) × (ℕ × ℕ → α) =>
+            (q.1.map (measurable_reindex τ).aemeasurable, pairReindex σ τ q.2)) ∘
+          fun ω => (ν ω, fun p : ℕ × ℕ => X p ω)) =
+            fun ω => ((ν ω).map (measurable_reindex τ).aemeasurable,
+              fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω) := by
+          funext ω
+          rw [Function.comp_apply]
+          refine Prod.ext rfl ?_
+          funext p
+          simp only [pairReindex_apply]
+    rw [hfun]
+    exact h.jointLaw_arrayRow_pairReindex_eq hX hν σ τ
+  · exact ((TauCeti.MeasureTheory.measurable_probabilityMeasure_map
+      (measurable_reindex τ)).comp measurable_fst).prodMk
+        ((measurable_pairReindex σ τ).comp measurable_snd) |>.aemeasurable
+  · exact hν.measurable_directing.aemeasurable.prodMk
+      (aemeasurable_pi_lambda _ hX)
+
+end CodingLaw
+
+end Probability
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Probability/Exchangeability/Arrays/RowCoding.lean
+++ b/TauCeti/Probability/Exchangeability/Arrays/RowCoding.lean
@@ -11,6 +11,8 @@ public import TauCeti.Probability.Exchangeability.Arrays.JointLaw
 public import TauCeti.Probability.Exchangeability.Arrays.Coding
 -- Non-public: measurability of pushforward on probability measures is used in the symmetry proof.
 import TauCeti.MeasureTheory.Measure.Measurability
+-- Non-public: the general symmetry proof transports the canonical conditional law on row paths.
+import TauCeti.Probability.Exchangeability.ConditionallyIID.Map
 
 /-!
 # Coupled row coding for separately exchangeable arrays
@@ -44,8 +46,10 @@ the next step.
   coded array;
 * `TauCeti.Probability.ConditionallyIIDWith.jointLaw_arrayRow_eq_arrayRowCodingLaw` -- a row
   directing measure identifies the original coupled law with the canonical coding law;
+* `TauCeti.Probability.map_pairReindex_arrayRowCodingLaw_eq` -- an invariant parameter law gives
+  the coupled coding law its two-axis equivariance;
 * `TauCeti.Probability.SeparatelyExchangeable.map_pairReindex_arrayRowCodingLaw_eq` -- the coupled
-  coding law inherits the two-axis equivariance of the directing measure and the array.
+  coding law of a separately exchangeable array satisfies that general criterion.
 
 ## References
 
@@ -74,17 +78,6 @@ variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 section CodingLaw
 
 variable [StandardBorelSpace α] [Nonempty α]
-
-omit [StandardBorelSpace α] [Nonempty α] in
-/-- A row-process witness supplies measurability of every array entry. -/
-private theorem aemeasurable_entries_of_conditionallyIIDWith_arrayRow
-    {μ : Measure Ω} {X : ℕ × ℕ → Ω → α}
-    {ν : Ω → ProbabilityMeasure (ℕ → α)}
-    (h : ConditionallyIIDWith μ (arrayRow X) ν) (p : ℕ × ℕ) :
-    AEMeasurable (X p) μ := by
-  have hentry : AEMeasurable (fun ω => arrayRow X p.1 ω p.2) μ :=
-    (measurable_pi_apply p.2).comp_aemeasurable (h.aemeasurable p.1)
-  simpa [arrayRow_apply] using hentry
 
 /-- The measurable map which retains a path law and uses one independent uniform variable to
 sample each row from it. -/
@@ -134,12 +127,116 @@ law of the random path measure. -/
 theorem map_snd_arrayRowCodingLaw (π : Measure (ProbabilityMeasure (ℕ → α))) :
     (arrayRowCodingLaw π).map Prod.snd =
       (deFinettiBarycenter π).map Function.uncurry := by
-  rw [arrayRowCodingLaw_def, Measure.map_map measurable_snd measurable_arrayRowCoding,
-    ← map_prod_unitIntervalCoding_eq_deFinettiBarycenter (α := ℕ → α),
-    Measure.map_map measurable_uncurry measurable_unitIntervalCodingPath]
+  rw [arrayRowCodingLaw_def, Measure.map_map measurable_snd measurable_arrayRowCoding]
+  change
+    ((π.prod (Measure.infinitePi fun _ : ℕ => (volume : Measure unitInterval))).map
+        fun q p => unitIntervalCoding (ℕ → α) q.1 (q.2 p.1) p.2) =
+      (deFinettiBarycenter π).map Function.uncurry
+  exact map_prod_unitIntervalCoding_array π
+
+/-- The coupled coding law is the canonical conditionally i.i.d. law on rows, with the row paths
+uncurried into an array. -/
+private theorem arrayRowCodingLaw_eq_map_iidMixtureLaw
+    (π : Measure (ProbabilityMeasure (ℕ → α))) :
+    arrayRowCodingLaw π =
+      (iidMixtureLaw π id).map (Prod.map id Function.uncurry) := by
+  rw [arrayRowCodingLaw_def, ← map_prod_unitIntervalCoding_eq_iidMixtureLaw,
+    Measure.map_map (measurable_id.prodMap measurable_uncurry)
+      (measurable_fst.prodMk measurable_unitIntervalCodingPath)]
   refine congrArg (Measure.map · _) ?_
-  funext q p
+  funext q
+  apply Prod.ext rfl
+  funext p
   rfl
+
+/-- The coupled row-coding law is equivariant whenever its parameter law is invariant under the
+column pushforward. Row permutations require no invariance hypothesis; column permutations act on
+both the parameter and the coded array. -/
+theorem map_pairReindex_arrayRowCodingLaw_eq
+    (π : Measure (ProbabilityMeasure (ℕ → α))) [IsFiniteMeasure π]
+    (σ τ : Equiv.Perm ℕ)
+    (hπ : π.map (fun P => P.map (measurable_reindex (α := α) τ).aemeasurable) = π) :
+    (arrayRowCodingLaw π).map
+        (fun q =>
+          (q.1.map (measurable_reindex τ).aemeasurable, pairReindex σ τ q.2)) =
+      arrayRowCodingLaw π := by
+  let ρ := iidMixtureLaw π (id : ProbabilityMeasure (ℕ → α) → ProbabilityMeasure (ℕ → α))
+  have hfst : ρ.map Prod.fst = π := by
+    simpa only [ρ] using iidMixtureLaw_map_fst (π := π) (P := id) measurable_id
+  have hρ : IsFiniteMeasure ρ := ⟨by
+    calc
+      ρ Set.univ = (ρ.map Prod.fst) Set.univ := by
+        rw [Measure.map_apply measurable_fst MeasurableSet.univ]
+        simp only [Set.preimage_univ]
+      _ = π Set.univ := by rw [hfst]
+      _ < ⊤ := measure_lt_top π Set.univ⟩
+  let _ := hρ
+  have hpush : Measurable fun P : ProbabilityMeasure (ℕ → α) =>
+      P.map (measurable_reindex (α := α) τ).aemeasurable :=
+    TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex τ)
+  have hbase : ConditionallyIIDWith ρ (fun i q => q.2 i) (fun q => q.1) := by
+    simpa only [ρ, id_eq] using
+      conditionallyIIDWith_iidMixtureLaw
+        (π := π) (P := id) (α := ℕ → α) measurable_id
+  have htrans : ConditionallyIIDWith ρ
+      (fun i q j => q.2 (σ i) (τ j))
+      (fun q => q.1.map (measurable_reindex τ).aemeasurable) := by
+    simpa only using
+      (hbase.comp_injective σ.injective).map_values (measurable_reindex (α := α) τ)
+  have hνlaw :
+      ρ.map (fun q => q.1.map (measurable_reindex (α := α) τ).aemeasurable) = π := by
+    change (iidMixtureLaw π id).map
+      ((fun P => P.map (measurable_reindex (α := α) τ).aemeasurable) ∘ Prod.fst) = π
+    rw [← Measure.map_map hpush measurable_fst,
+      iidMixtureLaw_map_fst (π := π) (P := id) measurable_id, hπ]
+  have hjoint :
+      ρ.map (fun q =>
+        (q.1.map (measurable_reindex (α := α) τ).aemeasurable,
+          fun i j => q.2 (σ i) (τ j))) =
+        iidMixtureLaw π id := by
+    rw [← jointPathLaw_def, htrans.jointPathLaw_eq_iidMixtureLaw, hνlaw]
+  have hK : Measurable
+      (Prod.map (id : ProbabilityMeasure (ℕ → α) → ProbabilityMeasure (ℕ → α))
+        (Function.uncurry : (ℕ → ℕ → α) → (ℕ × ℕ → α))) :=
+    measurable_id.prodMap measurable_uncurry
+  have hF : Measurable fun q : ProbabilityMeasure (ℕ → α) × (ℕ × ℕ → α) =>
+      (q.1.map (measurable_reindex (α := α) τ).aemeasurable,
+        pairReindex σ τ q.2) :=
+    (hpush.comp measurable_fst).prodMk
+      ((measurable_pairReindex σ τ).comp measurable_snd)
+  have htransform : Measurable fun q : ProbabilityMeasure (ℕ → α) × (ℕ → ℕ → α) =>
+      (q.1.map (measurable_reindex (α := α) τ).aemeasurable,
+        fun i j => q.2 (σ i) (τ j)) :=
+    (hpush.comp measurable_fst).prodMk <|
+      measurable_pi_lambda _ fun i =>
+        (measurable_reindex τ).comp ((measurable_pi_apply (σ i)).comp measurable_snd)
+  calc
+    (arrayRowCodingLaw π).map
+          (fun q =>
+            (q.1.map (measurable_reindex τ).aemeasurable, pairReindex σ τ q.2))
+        = ρ.map (fun q =>
+            (q.1.map (measurable_reindex τ).aemeasurable,
+              pairReindex σ τ (Function.uncurry q.2))) := by
+            rw [arrayRowCodingLaw_eq_map_iidMixtureLaw, Measure.map_map hF hK]
+            rfl
+    _ = ρ.map (fun q =>
+          (q.1.map (measurable_reindex τ).aemeasurable,
+            Function.uncurry fun i j => q.2 (σ i) (τ j))) := by
+          refine congrArg (ρ.map ·) (funext fun q => Prod.ext rfl ?_)
+          funext ⟨i, j⟩
+          change pairReindex σ τ (Function.uncurry q.2) (i, j) = q.2 (σ i) (τ j)
+          rw [pairReindex_apply]
+          rfl
+    _ = (ρ.map fun q =>
+          (q.1.map (measurable_reindex τ).aemeasurable,
+            fun i j => q.2 (σ i) (τ j))).map
+          (Prod.map id Function.uncurry) := by
+            rw [Measure.map_map hK htransform]
+            refine congrArg (ρ.map ·) ?_
+            funext q
+            rfl
+    _ = (iidMixtureLaw π id).map (Prod.map id Function.uncurry) := by rw [hjoint]
+    _ = arrayRowCodingLaw π := (arrayRowCodingLaw_eq_map_iidMixtureLaw π).symm
 
 /-- A directing measure for the row process identifies its joint law with the canonical coupled
 row-coding law.  Unlike the array-law-only coding theorem, this keeps the directing measure as a
@@ -151,7 +248,7 @@ theorem ConditionallyIIDWith.jointLaw_arrayRow_eq_arrayRowCodingLaw
     (μ.map fun ω => (ν ω, fun p : ℕ × ℕ => X p ω)) =
       arrayRowCodingLaw (μ.map ν) := by
   have hX : ∀ p, AEMeasurable (X p) μ :=
-    aemeasurable_entries_of_conditionallyIIDWith_arrayRow h
+    aemeasurable_entry_of_arrayRow h.aemeasurable
   rw [← map_uncurry_jointPathLaw_arrayRow hX h.measurable_directing,
     h.jointPathLaw_eq_map_unitIntervalCoding, arrayRowCodingLaw_def]
   have hinner : Measurable fun q : ProbabilityMeasure (ℕ → α) × (ℕ → unitInterval) =>
@@ -176,28 +273,13 @@ theorem SeparatelyExchangeable.map_pairReindex_arrayRowCodingLaw_eq
         (fun q =>
           (q.1.map (measurable_reindex τ).aemeasurable, pairReindex σ τ q.2)) =
       arrayRowCodingLaw (μ.map ν) := by
-  have hX : ∀ p, AEMeasurable (X p) μ :=
-    aemeasurable_entries_of_conditionallyIIDWith_arrayRow hν
-  rw [← hν.jointLaw_arrayRow_eq_arrayRowCodingLaw,
-    AEMeasurable.map_map_of_aemeasurable]
-  · have hfun :
-        ((fun q : ProbabilityMeasure (ℕ → α) × (ℕ × ℕ → α) =>
-            (q.1.map (measurable_reindex τ).aemeasurable, pairReindex σ τ q.2)) ∘
-          fun ω => (ν ω, fun p : ℕ × ℕ => X p ω)) =
-            fun ω => ((ν ω).map (measurable_reindex τ).aemeasurable,
-              fun p : ℕ × ℕ => X (σ p.1, τ p.2) ω) := by
-          funext ω
-          rw [Function.comp_apply]
-          refine Prod.ext rfl ?_
-          funext p
-          simp only [pairReindex_apply]
-    rw [hfun]
-    exact h.jointLaw_arrayRow_pairReindex_eq hX hν σ τ
-  · exact ((TauCeti.MeasureTheory.measurable_probabilityMeasure_map
-      (measurable_reindex τ)).comp measurable_fst).prodMk
-        ((measurable_pairReindex σ τ).comp measurable_snd) |>.aemeasurable
-  · exact hν.measurable_directing.aemeasurable.prodMk
-      (aemeasurable_pi_lambda _ hX)
+  apply TauCeti.Probability.map_pairReindex_arrayRowCodingLaw_eq (μ.map ν) σ τ
+  have hpush : Measurable fun P : ProbabilityMeasure (ℕ → α) =>
+      P.map (measurable_reindex (α := α) τ).aemeasurable :=
+    TauCeti.MeasureTheory.measurable_probabilityMeasure_map (measurable_reindex τ)
+  rw [Measure.map_map hpush hν.measurable_directing]
+  exact h.mixingLaw_map_permReindex_arrayRow_eq
+    (mixedIIDWith_of_conditionallyIIDWith hν) τ
 
 end CodingLaw
 


### PR DESCRIPTION
This PR retains the directing measure as a coordinate in the first functional representation of a separately exchangeable array. It defines `arrayRowCodingLaw π`, the joint law of a random path measure `P` and the array obtained by sampling its rows from `P` with independent uniform noise; proves its probability normalization and two marginal formulas; identifies the joint law of any row-directing measure and its array with this canonical coding law; and proves that, for a separately exchangeable array, row permutations act on the coded array while column permutations act simultaneously on the array and by pushforward on `P`.

The exact roadmap target is `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, “exchangeable arrays and the Aldous–Hoover representation,” specifically the second-level resolution of the coded row into per-column and per-cell randomness. The designated milestone is the Aldous–Hoover functional representation of separately and jointly exchangeable arrays. This is the most effective current step because the first-level row coding and the coupled column equivariance of the row directing measure are on `main`, but the existing coding theorem discards that coupling; `arrayRowCodingLaw` is the canonical law on which the second-level resolution can now operate without losing the column action. After this PR, the milestone still needs the substantive decomposition of the random path law into global, column, and cell noise, followed by transfer of the separate resolution to the full jointly exchangeable representation.

The proof reuses `ConditionallyIIDWith.jointPathLaw_eq_map_unitIntervalCoding`, `SeparatelyExchangeable.jointLaw_arrayRow_pairReindex_eq`, `map_prod_unitIntervalCoding_eq_deFinettiBarycenter`, and Mathlib's product-measure marginal and pushforward composition APIs. It promotes the existing row and column joint-path-law reassembly helpers in `Arrays/JointLaw.lean` under public conclusion-based names so the coupled coding theorem consumes them rather than duplicating their proofs.

The mathematical organization follows David Aldous, “Representations for partially exchangeable arrays of random variables” (1981), and Olav Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Chapter 7; the uniform randomization map follows Kallenberg, *Foundations of Modern Probability*, Lemma 4.22. These sources are cited in the new module documentation. No Mathlib source or external formalization is vendored, and no material is adapted from `cameronfreer/exchangeability`, which treats sequences rather than arrays.

Add `TauCeti/Probability/Exchangeability/Arrays/RowCoding.lean` (210 lines) and promote the two existing joint-law reassembly lemmas in `TauCeti/Probability/Exchangeability/Arrays/JointLaw.lean` without changing their statements or proofs.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"array-directing-measure-coupled-coding"}-->

🤖 Prepared with Codex
