### PR TITLE
feat: classify covers over disconnected bases

### DIFF
--- a/TauCeti/AlgebraicTopology/PathComponent.lean
+++ b/TauCeti/AlgebraicTopology/PathComponent.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.AlgebraicTopology.FundamentalGroup.Basic
 public import TauCeti.AlgebraicTopology.SemilocallySimplyConnected.Basic
-public import TauCeti.Topology.PathComponent
+public import TauCeti.Topology.ConnectedComponents
 
 /-!
 # The algebraic topology of a path component
@@ -52,6 +52,16 @@ instance instSemilocallySimplyConnectedSpaceSubtypePathComponent
     apply homotopic_pathComponent_of_map_subtypeVal_homotopic x₀
     rw [Path.map_refl]
     exact hloop (γ.map continuous_subtype_val) (by simpa using hγ)⟩
+
+/-- A fibre of the quotient to connected components is semilocally simply connected when the
+ambient space is locally path-connected and semilocally simply connected. -/
+instance instSemilocallySimplyConnectedSpaceConnectedComponentsFiber
+    [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
+    (C : ConnectedComponents X) :
+    SemilocallySimplyConnectedSpace (ConnectedComponents.mk ⁻¹' {C} : Set X) := by
+  obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe C
+  rw [connectedComponents_preimage_singleton, ← pathComponent_eq_connectedComponent]
+  infer_instance
 
 /-- **The path component of `x₀` carries the ambient fundamental group at each of its
 points.** Loops at such a point and their homotopies never leave the path component. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Components.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Components.lean
@@ -21,7 +21,7 @@ universal-cover construction.
 The disjoint-union classification in
 `TauCeti.AlgebraicTopology.UniversalCover.Classification.Sigma` therefore applies. Composing the
 resulting covering projection with the component homeomorphism gives a cover of `X`; monodromy
-is transported by `TauCeti.IsCoveringMap.monodromyHomeomorphCompNatIso`. This proves essential
+is transported by `IsCoveringMap.monodromyHomeomorphCompNatIso`. This proves essential
 surjectivity over an arbitrary base. Fullness only needs local path-connectedness, and
 faithfulness has no hypothesis, so monodromy is an equivalence.
 
@@ -90,7 +90,7 @@ theorem exists_monodromyFunctor_iso_of_locallyPathConnectedSpace
     FundamentalGroupoidFunctor.equivOfHomotopyEquiv h.toHomotopyEquiv
   exact eqToIso (monodromyFunctor_obj p) ≪≫
     IsCoveringMap.monodromyNatIso p.isCoveringMap_proj hp totalHomeomorph htotal ≪≫
-    IsCoveringMap.monodromyHomeomorphCompNatIso q.isCoveringMap_proj h ≪≫
+    q.isCoveringMap_proj.monodromyHomeomorphCompNatIso h ≪≫
     Functor.isoWhiskerLeft (FundamentalGroupoid.map (h.symm : C(X, _))) qIso ≪≫
     (Functor.associator _ _ _).symm ≪≫
     Functor.isoWhiskerRight componentEquivalence.counitIso F ≪≫

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Components.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Components.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.InducedMaps
+public import TauCeti.AlgebraicTopology.PathComponent
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Sigma
+
+/-!
+# Covering spaces over a locally path-connected base
+
+Let `X` be locally path-connected and semilocally simply connected, with no connectedness
+assumption. Its connected components are open and coincide with its path components, so
+`TauCeti.connectedComponentsSigmaHomeomorph` identifies `X` with the disjoint union of the
+fibres of `X → ConnectedComponents X`. Each summand satisfies the standing hypotheses for the
+universal-cover construction.
+
+The disjoint-union classification in
+`TauCeti.AlgebraicTopology.UniversalCover.Classification.Sigma` therefore applies. Composing the
+resulting covering projection with the component homeomorphism gives a cover of `X`; monodromy
+is transported by `TauCeti.IsCoveringMap.monodromyHomeomorphCompNatIso`. This proves essential
+surjectivity over an arbitrary base. Fullness only needs local path-connectedness, and
+faithfulness has no hypothesis, so monodromy is an equivalence.
+
+## Main declarations
+
+* `TauCeti.CoveringSpace.exists_monodromyFunctor_iso_of_locallyPathConnectedSpace`: every functor
+  from the fundamental groupoid of `X` to types is the monodromy of a covering space.
+* `TauCeti.CoveringSpace.monodromyEquivalenceOfLocallyPathConnectedSpace`: **covering spaces over
+  a locally path-connected, semilocally simply connected base are equivalent to functors from
+  its fundamental groupoid to types.**
+
+## References
+
+This closes the disconnected-cover part of Stage 2, item 8 of
+`TauCetiRoadmap/UniversalCovers/README.md`. It consumes the based-path universal-cover
+construction adapted from Kim Morrison's
+[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292), and the
+disjoint-union classification already built from it. The mathematical classification follows
+Hatcher, *Algebraic Topology*, Section 1.3; no external formalization is copied or adapted here.
+-/
+
+public section
+noncomputable section
+
+open CategoryTheory Topology
+
+universe u
+
+namespace TauCeti.CoveringSpace
+
+variable {X : Type u} [TopologicalSpace X] [LocallyPathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X]
+
+private abbrev Component (C : ConnectedComponents X) :=
+  (ConnectedComponents.mk ⁻¹' {C} : Set X)
+
+/-- **Every fundamental-groupoid action over a locally path-connected, semilocally simply
+connected base is the monodromy of a covering space.** No connectedness hypothesis is imposed on
+the base. -/
+theorem exists_monodromyFunctor_iso_of_locallyPathConnectedSpace
+    (F : FundamentalGroupoid X ⥤ Type u) :
+    ∃ p : CoveringSpace (TopCat.of X), Nonempty ((monodromyFunctor (TopCat.of X)).obj p ≅ F) := by
+  let h : (Σ C : ConnectedComponents X, Component C) ≃ₜ X :=
+    connectedComponentsSigmaHomeomorph
+  let hMap : C((Σ C : ConnectedComponents X, Component C), X) := h
+  choose q hq using exists_monodromyFunctor_iso_sigma
+    (ι := ConnectedComponents X)
+    (X := fun C : ConnectedComponents X ↦
+      (ConnectedComponents.mk ⁻¹' {C} : Set X))
+    (FundamentalGroupoid.map hMap ⋙ F)
+  let hp : IsCoveringMap (h ∘ q.proj) := q.isCoveringMap_proj.homeomorph_comp h
+  let pMap : TopCat.of ((q : TopCat) : Type u) ⟶ TopCat.of X :=
+    TopCat.ofHom ⟨h ∘ q.proj, hp.continuous⟩
+  let p : CoveringSpace (TopCat.of X) := mk pMap hp
+  refine ⟨p, ⟨?_⟩⟩
+  let totalHomeomorph : (p : TopCat) ≃ₜ (q : TopCat) :=
+    TopCat.homeoOfIso (eqToIso (mk_coe pMap hp))
+  have htotal : (h ∘ q.proj) ∘ totalHomeomorph = p.proj := by
+    funext z
+    have hproj := DFunLike.congr_fun (congrArg TopCat.Hom.hom (mk_proj pMap hp)) z
+    exact hproj.symm
+  let qIso : q.isCoveringMap_proj.monodromyFunctor ≅
+      FundamentalGroupoid.map hMap ⋙ F :=
+    eqToIso (monodromyFunctor_obj q).symm ≪≫ hq.some
+  let componentEquivalence :=
+    FundamentalGroupoidFunctor.equivOfHomotopyEquiv h.toHomotopyEquiv
+  exact eqToIso (monodromyFunctor_obj p) ≪≫
+    IsCoveringMap.monodromyNatIso p.isCoveringMap_proj hp totalHomeomorph htotal ≪≫
+    IsCoveringMap.monodromyHomeomorphCompNatIso q.isCoveringMap_proj h ≪≫
+    Functor.isoWhiskerLeft (FundamentalGroupoid.map (h.symm : C(X, _))) qIso ≪≫
+    (Functor.associator _ _ _).symm ≪≫
+    Functor.isoWhiskerRight componentEquivalence.counitIso F ≪≫
+    Functor.leftUnitor F
+
+/-- **Classification of covering spaces over an arbitrary locally path-connected, semilocally
+simply connected base.** Monodromy is an equivalence from covering spaces over `X` to functors
+from the fundamental groupoid of `X` to types. -/
+def monodromyEquivalenceOfLocallyPathConnectedSpace (X : Type u) [TopologicalSpace X]
+    [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] :
+    CoveringSpace (TopCat.of X) ≌ (FundamentalGroupoid X ⥤ Type u) :=
+  haveI : (monodromyFunctor (TopCat.of X)).Faithful :=
+    monodromyFunctor_faithful (TopCat.of X)
+  haveI : (monodromyFunctor (TopCat.of X)).Full := monodromyFunctor_full
+  haveI : (monodromyFunctor (TopCat.of X)).EssSurj :=
+    ⟨fun F ↦ exists_monodromyFunctor_iso_of_locallyPathConnectedSpace F⟩
+  haveI : (monodromyFunctor (TopCat.of X)).IsEquivalence := {}
+  (monodromyFunctor (TopCat.of X)).asEquivalence
+
+@[simp]
+theorem monodromyEquivalenceOfLocallyPathConnectedSpace_functor (X : Type u)
+    [TopologicalSpace X] [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X] :
+    (monodromyEquivalenceOfLocallyPathConnectedSpace X).functor =
+      monodromyFunctor (TopCat.of X) :=
+  (rfl)
+
+end TauCeti.CoveringSpace

--- a/TauCeti/Topology/ConnectedComponents.lean
+++ b/TauCeti/Topology/ConnectedComponents.lean
@@ -78,13 +78,7 @@ over `C`, so this decomposition does not require choosing representatives. -/
 noncomputable def connectedComponentsSigmaHomeomorph [LocallyConnectedSpace X] :
     (Σ C : ConnectedComponents X, (ConnectedComponents.mk ⁻¹' {C} : Set X)) ≃ₜ X := by
   let e : (Σ C : ConnectedComponents X, (ConnectedComponents.mk ⁻¹' {C} : Set X)) ≃ X :=
-    Equiv.ofBijective (fun z ↦ (z.2 : X)) ⟨by
-      rintro ⟨C, x⟩ ⟨D, y⟩ hxy
-      have hCD : C = D := by
-        exact x.2.symm.trans (congrArg ConnectedComponents.mk hxy) |>.trans y.2
-      subst D
-      exact Sigma.ext rfl (heq_of_eq (Subtype.ext hxy)), fun x ↦
-        ⟨⟨ConnectedComponents.mk x, ⟨x, Set.mem_singleton _⟩⟩, rfl⟩⟩
+    Equiv.sigmaPreimageEquiv ConnectedComponents.mk
   exact e.toHomeomorphOfContinuousOpen
     (continuous_sigma fun _ ↦ continuous_subtype_val)
     (isOpenMap_sigma.mpr fun C ↦
@@ -99,9 +93,8 @@ theorem connectedComponentsSigmaHomeomorph_apply [LocallyConnectedSpace X]
 @[simp]
 theorem connectedComponentsSigmaHomeomorph_symm_apply [LocallyConnectedSpace X] (x : X) :
     connectedComponentsSigmaHomeomorph.symm x =
-      ⟨ConnectedComponents.mk x, ⟨x, Set.mem_singleton _⟩⟩ := by
-  apply connectedComponentsSigmaHomeomorph.injective
-  rw [Homeomorph.apply_symm_apply, connectedComponentsSigmaHomeomorph_apply]
+      ⟨ConnectedComponents.mk x, ⟨x, Set.mem_singleton _⟩⟩ :=
+  (rfl)
 
 /-- A space with finitely many irreducible components has finitely many connected components. -/
 theorem finite_connectedComponents_of_finite_irreducibleComponents

--- a/TauCeti/Topology/ConnectedComponents.lean
+++ b/TauCeti/Topology/ConnectedComponents.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Topology.Connected.Clopen
 public import Mathlib.Topology.Irreducible
+public import TauCeti.Topology.PathComponent
 import Mathlib.Topology.Homeomorph.Lemmas
 
 /-!
@@ -21,6 +22,8 @@ components.
   the connected component of the image point.
 * `TauCeti.instT1SpaceConnectedComponents`: the connected-components quotient of any topological
   space is a T1 space.
+* `TauCeti.connectedComponentsSigmaHomeomorph`: a locally connected space is homeomorphic
+  to the disjoint union of its connected components.
 * `TauCeti.finite_connectedComponents_of_finite_irreducibleComponents`: finiteness of the
   irreducible components implies finiteness of the connected components.
 -/
@@ -49,6 +52,56 @@ instance instT1SpaceConnectedComponents : T1Space (ConnectedComponents X) :=
     rw [← ConnectedComponents.isQuotientMap_coe.isClosed_preimage,
       connectedComponents_preimage_singleton]
     exact isClosed_connectedComponent⟩
+
+/-- A fibre of the quotient to connected components is path-connected when the ambient space is
+locally path-connected. -/
+instance instPathConnectedSpaceConnectedComponentsFiber [LocallyPathConnectedSpace X]
+    (C : ConnectedComponents X) :
+    PathConnectedSpace (ConnectedComponents.mk ⁻¹' {C} : Set X) := by
+  obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe C
+  rw [connectedComponents_preimage_singleton, ← pathComponent_eq_connectedComponent]
+  infer_instance
+
+/-- A fibre of the quotient to connected components is locally path-connected when the ambient
+space is locally path-connected. -/
+instance instLocallyPathConnectedSpaceConnectedComponentsFiber [LocallyPathConnectedSpace X]
+    (C : ConnectedComponents X) :
+    LocallyPathConnectedSpace (ConnectedComponents.mk ⁻¹' {C} : Set X) := by
+  obtain ⟨x, rfl⟩ := ConnectedComponents.surjective_coe C
+  rw [connectedComponents_preimage_singleton, ← pathComponent_eq_connectedComponent]
+  infer_instance
+
+/-- **A locally connected space is the disjoint union of its connected components.**
+
+The summand indexed by `C : ConnectedComponents X` is the fibre of the canonical quotient map
+over `C`, so this decomposition does not require choosing representatives. -/
+noncomputable def connectedComponentsSigmaHomeomorph [LocallyConnectedSpace X] :
+    (Σ C : ConnectedComponents X, (ConnectedComponents.mk ⁻¹' {C} : Set X)) ≃ₜ X := by
+  let e : (Σ C : ConnectedComponents X, (ConnectedComponents.mk ⁻¹' {C} : Set X)) ≃ X :=
+    Equiv.ofBijective (fun z ↦ (z.2 : X)) ⟨by
+      rintro ⟨C, x⟩ ⟨D, y⟩ hxy
+      have hCD : C = D := by
+        exact x.2.symm.trans (congrArg ConnectedComponents.mk hxy) |>.trans y.2
+      subst D
+      exact Sigma.ext rfl (heq_of_eq (Subtype.ext hxy)), fun x ↦
+        ⟨⟨ConnectedComponents.mk x, ⟨x, Set.mem_singleton _⟩⟩, rfl⟩⟩
+  exact e.toHomeomorphOfContinuousOpen
+    (continuous_sigma fun _ ↦ continuous_subtype_val)
+    (isOpenMap_sigma.mpr fun C ↦
+      ((isOpen_discrete {C}).preimage ConnectedComponents.continuous_coe).isOpenMap_subtype_val)
+
+@[simp]
+theorem connectedComponentsSigmaHomeomorph_apply [LocallyConnectedSpace X]
+    (z : Σ C : ConnectedComponents X, (ConnectedComponents.mk ⁻¹' {C} : Set X)) :
+    connectedComponentsSigmaHomeomorph z = z.2 :=
+  (rfl)
+
+@[simp]
+theorem connectedComponentsSigmaHomeomorph_symm_apply [LocallyConnectedSpace X] (x : X) :
+    connectedComponentsSigmaHomeomorph.symm x =
+      ⟨ConnectedComponents.mk x, ⟨x, Set.mem_singleton _⟩⟩ := by
+  apply connectedComponentsSigmaHomeomorph.injective
+  rw [Homeomorph.apply_symm_apply, connectedComponentsSigmaHomeomorph_apply]
 
 /-- A space with finitely many irreducible components has finitely many connected components. -/
 theorem finite_connectedComponents_of_finite_irreducibleComponents

--- a/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
+++ b/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
@@ -28,7 +28,7 @@ packages its functoriality in the covering map.
   between their monodromy functors.
 * `TauCeti.IsCoveringMap.monodromyNatIso`: an isomorphism of covers induces a natural
   isomorphism between their monodromy functors.
-* `TauCeti.IsCoveringMap.monodromyHomeomorphCompNatIso`: changing the base by a homeomorphism
+* `IsCoveringMap.monodromyHomeomorphCompNatIso`: changing the base by a homeomorphism
   transports the monodromy functor by the inverse homeomorphism.
 
 ## References
@@ -234,7 +234,8 @@ theorem homeomorphCompFiberEquiv_symm_apply_coe (h : X ≃ₜ Y) (y : Y)
 /-- Fibre transport after changing the base by a homeomorphism agrees with transport along the
 inverse image of the path. -/
 @[simp]
-theorem homeomorphCompFiberEquiv_monodromy (hp : _root_.IsCoveringMap p)
+theorem _root_.IsCoveringMap.homeomorphCompFiberEquiv_monodromy
+    (hp : _root_.IsCoveringMap p)
     (h : X ≃ₜ Y) {x y : Y} (a : Path.Homotopic.Quotient x y)
     (e : (h ∘ p) ⁻¹' {x}) :
     homeomorphCompFiberEquiv (p := p) h y ((hp.homeomorph_comp h).monodromy a e) =
@@ -261,7 +262,8 @@ theorem homeomorphCompFiberEquiv_monodromy (hp : _root_.IsCoveringMap p)
 
 /-- **Changing the base of a covering map by a homeomorphism transports monodromy along the
 inverse homeomorphism.** -/
-noncomputable def monodromyHomeomorphCompNatIso (hp : _root_.IsCoveringMap p)
+noncomputable def _root_.IsCoveringMap.monodromyHomeomorphCompNatIso
+    (hp : _root_.IsCoveringMap p)
     (h : X ≃ₜ Y) :
     (hp.homeomorph_comp h).monodromyFunctor ≅
       FundamentalGroupoid.map (h.symm : C(Y, X)) ⋙ hp.monodromyFunctor :=
@@ -270,14 +272,15 @@ noncomputable def monodromyHomeomorphCompNatIso (hp : _root_.IsCoveringMap p)
     (by
       intro x y a
       ext e
-      exact homeomorphCompFiberEquiv_monodromy hp h a e)
+      exact hp.homeomorphCompFiberEquiv_monodromy h a e)
 
 /-- The forward component of the monodromy isomorphism for a homeomorphic base is the canonical
 equivalence of fibres. -/
 @[simp]
-theorem monodromyHomeomorphCompNatIso_hom_app (hp : _root_.IsCoveringMap p)
+theorem _root_.IsCoveringMap.monodromyHomeomorphCompNatIso_hom_app
+    (hp : _root_.IsCoveringMap p)
     (h : X ≃ₜ Y) (y : Y) :
-    (monodromyHomeomorphCompNatIso hp h).hom.app (FundamentalGroupoid.mk y) =
+    (hp.monodromyHomeomorphCompNatIso h).hom.app (FundamentalGroupoid.mk y) =
       (homeomorphCompFiberEquiv (p := p) h y).toIso.hom :=
   (rfl)
 

--- a/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
+++ b/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
@@ -202,19 +202,10 @@ omit [TopologicalSpace E] in
 /-- The fibre of a covering map after composing its projection with a base homeomorphism is the
 original fibre over the inverse image of the basepoint. -/
 def homeomorphCompFiberEquiv (h : X ≃ₜ Y) (y : Y) :
-    (h ∘ p) ⁻¹' {y} ≃ p ⁻¹' {h.symm y} where
-  toFun e := ⟨e, by
-    simp only [Set.mem_preimage, Set.mem_singleton_iff]
-    apply h.injective
-    rw [h.apply_symm_apply]
-    simpa only [Set.mem_preimage, Set.mem_singleton_iff, Function.comp_apply] using e.2⟩
-  invFun e := ⟨e, by
+    (h ∘ p) ⁻¹' {y} ≃ p ⁻¹' {h.symm y} :=
+  Equiv.setCongr <| Set.ext fun _ ↦ by
     simp only [Set.mem_preimage, Set.mem_singleton_iff, Function.comp_apply]
-    have he : p e = h.symm y := by
-      simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e.2
-    rw [he, h.apply_symm_apply]⟩
-  left_inv _ := Subtype.ext rfl
-  right_inv _ := Subtype.ext rfl
+    exact h.eq_symm_apply.symm
 
 omit [TopologicalSpace E] in
 /-- On underlying points, the fibre equivalence for a homeomorphism of bases is the identity. -/

--- a/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
+++ b/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
@@ -28,6 +28,8 @@ packages its functoriality in the covering map.
   between their monodromy functors.
 * `TauCeti.IsCoveringMap.monodromyNatIso`: an isomorphism of covers induces a natural
   isomorphism between their monodromy functors.
+* `TauCeti.IsCoveringMap.monodromyHomeomorphCompNatIso`: changing the base by a homeomorphism
+  transports the monodromy functor by the inverse homeomorphism.
 
 ## References
 
@@ -191,6 +193,95 @@ theorem monodromyNatIso_inv (hp : _root_.IsCoveringMap p)
       monodromyNatTrans hq hp (h.symm : C(F, E))
         ((Equiv.comp_symm_eq h.toEquiv q p).2 hh.symm) :=
   (rfl)
+
+section BaseHomeomorph
+
+variable {Y : Type v} [TopologicalSpace Y]
+
+/-- The fibre of a covering map after composing its projection with a base homeomorphism is the
+original fibre over the inverse image of the basepoint. -/
+def homeomorphCompFiberEquiv (h : X ≃ₜ Y) (y : Y) :
+    (h ∘ p) ⁻¹' {y} ≃ p ⁻¹' {h.symm y} where
+  toFun e := ⟨e, by
+    simp only [Set.mem_preimage, Set.mem_singleton_iff]
+    apply h.injective
+    rw [h.apply_symm_apply]
+    simpa only [Set.mem_preimage, Set.mem_singleton_iff, Function.comp_apply] using e.2⟩
+  invFun e := ⟨e, by
+    simp only [Set.mem_preimage, Set.mem_singleton_iff, Function.comp_apply]
+    rw [show p e = h.symm y by
+      simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e.2, h.apply_symm_apply]⟩
+  left_inv _ := Subtype.ext rfl
+  right_inv _ := Subtype.ext rfl
+
+omit [TopologicalSpace E] in
+/-- On underlying points, the fibre equivalence for a homeomorphism of bases is the identity. -/
+@[simp]
+theorem homeomorphCompFiberEquiv_apply_coe (h : X ≃ₜ Y) (y : Y)
+    (e : (h ∘ p) ⁻¹' {y}) :
+    (homeomorphCompFiberEquiv (p := p) h y e : E) = e :=
+  (rfl)
+
+omit [TopologicalSpace E] in
+/-- On underlying points, the inverse fibre equivalence for a homeomorphism of bases is the
+identity. -/
+@[simp]
+theorem homeomorphCompFiberEquiv_symm_apply_coe (h : X ≃ₜ Y) (y : Y)
+    (e : p ⁻¹' {h.symm y}) :
+    ((homeomorphCompFiberEquiv (p := p) h y).symm e : E) = e :=
+  (rfl)
+
+/-- Fibre transport after changing the base by a homeomorphism agrees with transport along the
+inverse image of the path. -/
+@[simp]
+theorem homeomorphCompFiberEquiv_monodromy (hp : _root_.IsCoveringMap p)
+    (h : X ≃ₜ Y) {x y : Y} (a : Path.Homotopic.Quotient x y)
+    (e : (h ∘ p) ⁻¹' {x}) :
+    homeomorphCompFiberEquiv (p := p) h y ((hp.homeomorph_comp h).monodromy a e) =
+      hp.monodromy (a.map (h.symm : C(Y, X)))
+        (homeomorphCompFiberEquiv (p := p) h x e) := by
+  obtain ⟨γ⟩ := a
+  apply Subtype.ext
+  let ex := homeomorphCompFiberEquiv (p := p) h x e
+  let Γ : C(I, E) := hp.liftPath (γ.map h.symm.continuous) e (by
+    have hex : (ex : E) = e := homeomorphCompFiberEquiv_apply_coe h x e
+    rw [← hex]
+    simpa using ex.2.symm)
+  have hΓ : Γ = (hp.homeomorph_comp h).liftPath γ e (by
+      simpa using e.2.symm) := by
+    refine ((hp.homeomorph_comp h).eq_liftPath_iff' (γ_0 := by
+      simpa using e.2.symm)).2 ⟨?_, ?_⟩
+    · funext t
+      -- Expose the composite projection so the lift equation for `Γ` can be applied pointwise.
+      change h (p (Γ t)) = γ t
+      rw [show p (Γ t) = h.symm (γ t) from congrFun (hp.liftPath_lifts
+        (γ.map h.symm.continuous) e _) t, h.apply_symm_apply]
+    · exact hp.liftPath_zero (γ.map h.symm.continuous) e _
+  exact congrArg (fun q : C(I, E) ↦ q 1) hΓ.symm
+
+/-- **Changing the base of a covering map by a homeomorphism transports monodromy along the
+inverse homeomorphism.** -/
+noncomputable def monodromyHomeomorphCompNatIso (hp : _root_.IsCoveringMap p)
+    (h : X ≃ₜ Y) :
+    (hp.homeomorph_comp h).monodromyFunctor ≅
+      FundamentalGroupoid.map (h.symm : C(Y, X)) ⋙ hp.monodromyFunctor :=
+  NatIso.ofComponents
+    (fun y ↦ (homeomorphCompFiberEquiv (p := p) h y.as).toIso)
+    (by
+      intro x y a
+      ext e
+      exact homeomorphCompFiberEquiv_monodromy hp h a e)
+
+/-- The forward component of the monodromy isomorphism for a homeomorphic base is the canonical
+equivalence of fibres. -/
+@[simp]
+theorem monodromyHomeomorphCompNatIso_hom_app (hp : _root_.IsCoveringMap p)
+    (h : X ≃ₜ Y) (y : Y) :
+    (monodromyHomeomorphCompNatIso hp h).hom.app (FundamentalGroupoid.mk y) =
+      (homeomorphCompFiberEquiv (p := p) h y).toIso.hom :=
+  (rfl)
+
+end BaseHomeomorph
 
 end IsCoveringMap
 

--- a/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
+++ b/TauCeti/Topology/Homotopy/Monodromy/Functoriality.lean
@@ -198,6 +198,7 @@ section BaseHomeomorph
 
 variable {Y : Type v} [TopologicalSpace Y]
 
+omit [TopologicalSpace E] in
 /-- The fibre of a covering map after composing its projection with a base homeomorphism is the
 original fibre over the inverse image of the basepoint. -/
 def homeomorphCompFiberEquiv (h : X ≃ₜ Y) (y : Y) :
@@ -209,8 +210,9 @@ def homeomorphCompFiberEquiv (h : X ≃ₜ Y) (y : Y) :
     simpa only [Set.mem_preimage, Set.mem_singleton_iff, Function.comp_apply] using e.2⟩
   invFun e := ⟨e, by
     simp only [Set.mem_preimage, Set.mem_singleton_iff, Function.comp_apply]
-    rw [show p e = h.symm y by
-      simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e.2, h.apply_symm_apply]⟩
+    have he : p e = h.symm y := by
+      simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e.2
+    rw [he, h.apply_symm_apply]⟩
   left_inv _ := Subtype.ext rfl
   right_inv _ := Subtype.ext rfl
 
@@ -255,8 +257,9 @@ theorem _root_.IsCoveringMap.homeomorphCompFiberEquiv_monodromy
     · funext t
       -- Expose the composite projection so the lift equation for `Γ` can be applied pointwise.
       change h (p (Γ t)) = γ t
-      rw [show p (Γ t) = h.symm (γ t) from congrFun (hp.liftPath_lifts
-        (γ.map h.symm.continuous) e _) t, h.apply_symm_apply]
+      have hΓt : p (Γ t) = h.symm (γ t) :=
+        congrFun (hp.liftPath_lifts (γ.map h.symm.continuous) e _) t
+      rw [hΓt, h.apply_symm_apply]
     · exact hp.liftPath_zero (γ.map h.symm.continuous) e _
   exact congrArg (fun q : C(I, E) ↦ q 1) hΓ.symm
 


### PR DESCRIPTION
This PR completes the disconnected-base clause of `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, by classifying covering spaces over every locally path-connected, semilocally simply connected base as functors from its fundamental groupoid to types, without assuming the base is path-connected.

The designated milestone is Stage 2 item 8, “Galois correspondence: get the bookkeeping right,” specifically its alternative lens requiring disconnected covers to be described as functors out of the fundamental groupoid. This is the most effective current step because merged PR #4631 proves the classification for an explicit disjoint union and merged PR #4621 supplies the path-component hypotheses that #4631 names as its remaining blocker. The dependency edge is direct: the arbitrary-base classification decomposes `X` into the canonical fibres of `X → ConnectedComponents X`, applies #4631 summandwise, and transports the resulting cover and monodromy across the decomposition homeomorphism. After this PR, no work remains on item 8's alternative monodromy-functor classification for arbitrary nice bases.

Add `TauCeti.connectedComponentsSigmaHomeomorph`, together with path-connectedness, local path-connectedness, and semilocal simple-connectivity instances for its component fibres. Add `TauCeti.IsCoveringMap.monodromyHomeomorphCompNatIso`, which identifies monodromy after composing a covering projection with a base homeomorphism with monodromy precomposed by the inverse homeomorphism. The new `TauCeti.CoveringSpace.exists_monodromyFunctor_iso_of_locallyPathConnectedSpace` applies the disjoint-union theorem to the component fibres, and `monodromyEquivalenceOfLocallyPathConnectedSpace` packages essential surjectivity with the existing full and faithful monodromy functor.

Add the 120-line `TauCeti/AlgebraicTopology/UniversalCover/Classification/Components.lean` module and extend three canonical supporting modules, for 275 insertions and one deletion total. The mathematical classification follows Hatcher, *Algebraic Topology*, Section 1.3, and consumes the universal-cover construction adapted from Kim Morrison's mathlib4#38292. No Mathlib source is vendored; the proof reuses Mathlib's connected-component quotient, covering-map composition, path lifting, induced fundamental-groupoid equivalence, and categorical whiskering APIs.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"monodromy-equivalence-locally-path-connected-base"}-->

🤖 Prepared with Codex
