### PR TITLE
feat(FormalGroup): evaluate the chord construction at a pair of parameters

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -104,6 +104,14 @@ private theorem hasEval_pair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     MvPowerSeries.HasEval (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂ : Unit ⊕ Unit → O) :=
   MvPowerSeries.hasEval_of_finite <| by rintro (_ | _) <;> assumption
 
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- A parameter drawn from a positive power of an adic ideal admits evaluation: it lies in `I`,
+and every element of `I` is topologically nilpotent for the `I`-adic topology. -/
+private theorem hasEval_of_mem_pow {I : Ideal O} (hI : IsAdic I) {k : ℕ} (hk : k ≠ 0) {t : O}
+    (ht : t ∈ I ^ k) : PowerSeries.HasEval t :=
+  hI.isTopologicallyNilpotent_of_mem (Ideal.pow_le_self hk ht)
+
 /-- Evaluation at a pair of parameters, as a ring homomorphism. The transport lemmas below take
 identities of series to identities of values along this map. -/
 private noncomputable def evalPair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
@@ -189,18 +197,21 @@ theorem formalInterceptEval_eq {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
 /-- The slope of the chord at parameters of `I ^ k` again lies in `I ^ k`: the slope series has
 vanishing constant coefficient. -/
 theorem formalSlopeEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O}
-    (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hk₁ : t₁ ∈ I ^ k)
-    (hk₂ : t₂ ∈ I ^ k) : W.formalSlopeEval t₁ t₂ ∈ I ^ k :=
-  MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) continuous_ringHomId
-    (hasEval_pair h₁ h₂) hI (pair_mem hk₁ hk₂) W.formalSlope (by simp)
+    (hk₁ : t₁ ∈ I ^ k) (hk₂ : t₂ ∈ I ^ k) : W.formalSlopeEval t₁ t₂ ∈ I ^ k := by
+  rcases eq_or_ne k 0 with rfl | hk
+  · simp
+  · exact MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) continuous_ringHomId
+      (hasEval_pair (hasEval_of_mem_pow hI hk hk₁) (hasEval_of_mem_pow hI hk hk₂)) hI
+      (pair_mem hk₁ hk₂) W.formalSlope (by simp)
 
 /-- The third point's parameter at parameters of `I ^ k` again lies in `I ^ k`. -/
 theorem formalThirdRootEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O}
-    (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hk₁ : t₁ ∈ I ^ k)
-    (hk₂ : t₂ ∈ I ^ k) : W.formalThirdRootEval t₁ t₂ ∈ I ^ k :=
-  MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) continuous_ringHomId
-    (hasEval_pair h₁ h₂) hI (pair_mem hk₁ hk₂) W.formalThirdRoot
-    (by simp)
+    (hk₁ : t₁ ∈ I ^ k) (hk₂ : t₂ ∈ I ^ k) : W.formalThirdRootEval t₁ t₂ ∈ I ^ k := by
+  rcases eq_or_ne k 0 with rfl | hk
+  · simp
+  · exact MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) continuous_ringHomId
+      (hasEval_pair (hasEval_of_mem_pow hI hk hk₁) (hasEval_of_mem_pow hI hk hk₂)) hI
+      (pair_mem hk₁ hk₂) W.formalThirdRoot (by simp)
 
 /-- **Vieta's formula at a pair of parameters**, cleared of the inverse of the cubic's leading
 coefficient: the third root satisfies
@@ -255,8 +266,12 @@ theorem formalAddEval_eq {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
 deviates from their sum by an element of `I ^ (2 * k)`, because it agrees with `z₁ + z₂` below
 total degree two. -/
 theorem formalAddEval_sub_add_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O}
-    (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hk₁ : t₁ ∈ I ^ k)
-    (hk₂ : t₂ ∈ I ^ k) : W.formalAddEval t₁ t₂ - (t₁ + t₂) ∈ I ^ (2 * k) := by
+    (hk₁ : t₁ ∈ I ^ k) (hk₂ : t₂ ∈ I ^ k) :
+    W.formalAddEval t₁ t₂ - (t₁ + t₂) ∈ I ^ (2 * k) := by
+  rcases eq_or_ne k 0 with rfl | hk
+  · simp
+  have h₁ : PowerSeries.HasEval t₁ := hasEval_of_mem_pow hI hk hk₁
+  have h₂ : PowerSeries.HasEval t₂ := hasEval_of_mem_pow hI hk hk₂
   have heval : MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂)
       (W.formalAdd - MvPowerSeries.X (Sum.inl ()) - MvPowerSeries.X (Sum.inr ())) =
       W.formalAddEval t₁ t₂ - (t₁ + t₂) := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -1,0 +1,279 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Eval
+public import TauCeti.RingTheory.MvPowerSeries.Substitution
+
+/-!
+# Evaluating the chord construction at a pair of parameters
+
+The chord construction of `FormalGroup/Chord.lean` and the addition series of
+`FormalGroup/Add/Series.lean` are two-variable power series. This file evaluates them at a pair
+of parameters, as `FormalGroup/Eval.lean` evaluates the one-variable series at a single one, and
+carries the identities of series over to identities of values.
+
+The pair is the family `Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂` on `Unit ⊕ Unit`, and it admits
+evaluation as soon as each parameter does — `MvPowerSeries.hasEval_sumElim`, the decay condition
+being vacuous over finitely many variables.
+
+## Main definitions
+
+* `WeierstrassCurve.formalSlopeEval` : the slope `λ(t₁, t₂)` of the chord.
+* `WeierstrassCurve.formalInterceptEval` : the intercept `ν(t₁, t₂)`.
+* `WeierstrassCurve.formalThirdRootEval` : the parameter `t₃(t₁, t₂)` of the third point.
+* `WeierstrassCurve.formalAddEval` : the value `F(t₁, t₂)` of the addition series.
+
+## Main results
+
+* `WeierstrassCurve.formalSlopeEval_mul_sub` : `λ(t₁, t₂) * (t₂ - t₁) = w(t₂) - w(t₁)`.
+* `WeierstrassCurve.formalInterceptEval_eq` : `ν(t₁, t₂) = w(t₁) - λ(t₁, t₂) * t₁`.
+* `WeierstrassCurve.formalSlopeEval_mem`, `WeierstrassCurve.formalThirdRootEval_mem` : parameters
+  in `I ^ k` keep the slope and the third root there.
+* `WeierstrassCurve.formalThirdRootEval_relation` : Vieta's formula at a pair, cleared of the
+  inverse of the cubic's leading coefficient.
+* `WeierstrassCurve.formalAddEval_eq` : `F(t₁, t₂) = ι(t₃(t₁, t₂))`.
+* `WeierstrassCurve.formalAddEval_sub_add_mem` : `F(t₁, t₂) - (t₁ + t₂) ∈ I ^ (2 * k)` for
+  parameters in `I ^ k`, so the group law is `t₁ + t₂` to first order.
+
+## Implementation notes
+
+Two of the series are built from one-variable ones through `PowerSeries.toMvPowerSeries` and
+`MvPowerSeries.subst`; evaluating those is `PowerSeries.eval₂_id_toMvPowerSeries` and
+`MvPowerSeries.aeval_subst`, both of which hold over a coefficient ring that is not discrete —
+which the ambient adic ring is not.
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], IV.1.
+
+## Provenance
+
+Adapted from Michael Stoll's `EllipticCurves` project
+(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
+`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`, whose full expansion is
+`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`),
+`EllipticCurves/WeierstrassFormalGroup/Eval.lean` — its pair-evaluation layer, declarations
+`slopeEval`, `interceptEval`, `thirdRootEval`, `addEval`, `hasEval_pairElim`, `eval_pair_rename`,
+`eval_pair_subst_single`, `slopeEval_mul_sub`, `interceptEval_eq`, `slopeEval_mem`,
+`thirdRootEval_mem`, `thirdRootEval_relation`, `addEval_eq` and `addEval_sub_add_mem`.
+
+Three things are spelled differently here.
+
+* The source's `eval_pair_rename` transports along `MvPowerSeries.rename`; this repository builds
+  the one-variable series into two variables with `PowerSeries.toMvPowerSeries` instead, so the
+  transport is `PowerSeries.eval₂_id_toMvPowerSeries`.
+* The source states everything over `IsLocalRing.maximalIdeal O` at `k = 1`; the membership
+  results here are over an arbitrary adic ideal and an arbitrary power of it, and the identities
+  that use no ideal at all take `PowerSeries.HasEval` on each parameter, matching
+  `FormalGroup/Eval.lean`.
+* The source evaluates through its own `ChabautyColeman.MvPSeries.eval`, a wrapper for
+  `MvPowerSeries.eval₂ (RingHom.id _)`, which is not ported.
+-/
+
+public section
+
+open PowerSeries MvPowerSeries
+
+namespace WeierstrassCurve
+
+variable {O : Type*} [CommRing O] [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O]
+  [T2Space O] [IsTopologicalRing O] [IsLinearTopology O O] (W : WeierstrassCurve O)
+
+/-- The pair `(t₁, t₂)` as a family indexed by the two variables of the chord construction. -/
+private def pair (t₁ t₂ : O) : Unit ⊕ Unit → O := Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂
+
+omit [CommRing O] [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O] [T2Space O]
+  [IsTopologicalRing O] [IsLinearTopology O O] in
+/-- The pair takes the first parameter on the first variable. -/
+private theorem pair_inl (t₁ t₂ : O) : pair t₁ t₂ (Sum.inl ()) = t₁ := rfl
+
+omit [CommRing O] [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O] [T2Space O]
+  [IsTopologicalRing O] [IsLinearTopology O O] in
+/-- The pair takes the second parameter on the second variable. -/
+private theorem pair_inr (t₁ t₂ : O) : pair t₁ t₂ (Sum.inr ()) = t₂ := rfl
+
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- A pair of parameters admits evaluation as soon as each of them does. -/
+private theorem hasEval_pair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
+    (h₂ : PowerSeries.HasEval t₂) : MvPowerSeries.HasEval (pair t₁ t₂) :=
+  MvPowerSeries.hasEval_sumElim (fun _ ↦ h₁) fun _ ↦ h₂
+
+/-- Evaluation at a pair of parameters, as a ring homomorphism. Every identity in this file is
+the image of an identity of series under this map. -/
+private noncomputable def evalPair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
+    (h₂ : PowerSeries.HasEval t₂) : MvPowerSeries (Unit ⊕ Unit) O →+* O :=
+  MvPowerSeries.eval₂Hom (φ := RingHom.id O) (by simpa using continuous_id) (hasEval_pair h₁ h₂)
+
+/-- `evalPair` is `MvPowerSeries.eval₂` at the identity ring hom, as a function. -/
+private theorem coe_evalPair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
+    (h₂ : PowerSeries.HasEval t₂) :
+    ⇑(evalPair h₁ h₂) = MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) :=
+  MvPowerSeries.coe_eval₂Hom (φ := RingHom.id O) _ (hasEval_pair h₁ h₂)
+
+/-- The value of the slope series at a pair of parameters. -/
+noncomputable def formalSlopeEval (t₁ t₂ : O) : O :=
+  MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalSlope
+
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- `formalSlopeEval` is evaluation of `formalSlope` at the pair, through the identity ring hom. -/
+theorem formalSlopeEval_def (t₁ t₂ : O) :
+    W.formalSlopeEval t₁ t₂ =
+      MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂)
+        W.formalSlope := (rfl)
+
+/-- The value of the intercept series at a pair of parameters. -/
+noncomputable def formalInterceptEval (t₁ t₂ : O) : O :=
+  MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalIntercept
+
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- `formalInterceptEval` is evaluation of `formalIntercept` at the pair, through the identity
+ring hom. -/
+theorem formalInterceptEval_def (t₁ t₂ : O) :
+    W.formalInterceptEval t₁ t₂ =
+      MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂)
+        W.formalIntercept := (rfl)
+
+/-- The value of the third-root series at a pair of parameters. -/
+noncomputable def formalThirdRootEval (t₁ t₂ : O) : O :=
+  MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalThirdRoot
+
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- `formalThirdRootEval` is evaluation of `formalThirdRoot` at the pair, through the identity
+ring hom. -/
+theorem formalThirdRootEval_def (t₁ t₂ : O) :
+    W.formalThirdRootEval t₁ t₂ =
+      MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂)
+        W.formalThirdRoot := (rfl)
+
+/-- The value of the addition series at a pair of parameters. -/
+noncomputable def formalAddEval (t₁ t₂ : O) : O :=
+  MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalAdd
+
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- `formalAddEval` is evaluation of `formalAdd` at the pair, through the identity ring hom. -/
+theorem formalAddEval_def (t₁ t₂ : O) :
+    W.formalAddEval t₁ t₂ =
+      MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂)
+        W.formalAdd := (rfl)
+
+/-- **The evaluated slope identity**: `λ(t₁, t₂) * (t₂ - t₁) = w(t₂) - w(t₁)`. -/
+theorem formalSlopeEval_mul_sub {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
+    (h₂ : PowerSeries.HasEval t₂) :
+    W.formalSlopeEval t₁ t₂ * (t₂ - t₁) = W.formalWEval t₂ - W.formalWEval t₁ := by
+  have h := congrArg (evalPair h₁ h₂) W.formalSlope_mul_sub
+  rw [map_mul, map_sub, map_sub] at h
+  simpa [formalSlopeEval, W.formalWEval_def, coe_evalPair, pair_inl, pair_inr,
+    PowerSeries.eval₂_id_toMvPowerSeries (hasEval_pair h₁ h₂),
+    MvPowerSeries.eval₂_X] using h
+
+/-- **The evaluated intercept identity**: `ν(t₁, t₂) = w(t₁) - λ(t₁, t₂) * t₁`. -/
+theorem formalInterceptEval_eq {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
+    (h₂ : PowerSeries.HasEval t₂) :
+    W.formalInterceptEval t₁ t₂ = W.formalWEval t₁ - W.formalSlopeEval t₁ t₂ * t₁ := by
+  have h := congrArg (evalPair h₁ h₂) W.formalIntercept_def
+  rw [map_sub, map_mul] at h
+  simpa [formalInterceptEval, formalSlopeEval, W.formalWEval_def, coe_evalPair, pair_inl,
+    pair_inr, PowerSeries.eval₂_id_toMvPowerSeries (hasEval_pair h₁ h₂),
+    MvPowerSeries.eval₂_X] using h
+
+/-- The slope of the chord at parameters of `I ^ k` again lies in `I ^ k`: the slope series has
+vanishing constant coefficient. -/
+theorem formalSlopeEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O}
+    (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hk₁ : t₁ ∈ I ^ k)
+    (hk₂ : t₂ ∈ I ^ k) : W.formalSlopeEval t₁ t₂ ∈ I ^ k :=
+  MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) (by simpa using continuous_id)
+    (hasEval_pair h₁ h₂) hI (by rintro (_ | _) <;> [exact hk₁; exact hk₂]) W.formalSlope (by simp)
+
+/-- The third point's parameter at parameters of `I ^ k` again lies in `I ^ k`. -/
+theorem formalThirdRootEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O}
+    (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hk₁ : t₁ ∈ I ^ k)
+    (hk₂ : t₂ ∈ I ^ k) : W.formalThirdRootEval t₁ t₂ ∈ I ^ k :=
+  MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) (by simpa using continuous_id)
+    (hasEval_pair h₁ h₂) hI (by rintro (_ | _) <;> [exact hk₁; exact hk₂]) W.formalThirdRoot
+    (by simp)
+
+/-- **Vieta's formula at a pair of parameters**, cleared of the inverse of the cubic's leading
+coefficient: the third root satisfies
+`(1 + a₂λ + a₄λ² + a₆λ³)(t₃ + t₁ + t₂) = -(a₁λ + a₂ν + a₃λ² + 2a₄λν + 3a₆λ²ν)`. -/
+theorem formalThirdRootEval_relation {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
+    (h₂ : PowerSeries.HasEval t₂) :
+    (1 + W.a₂ * W.formalSlopeEval t₁ t₂ + W.a₄ * W.formalSlopeEval t₁ t₂ ^ 2 +
+        W.a₆ * W.formalSlopeEval t₁ t₂ ^ 3) *
+      (W.formalThirdRootEval t₁ t₂ + t₁ + t₂) =
+      -(W.a₁ * W.formalSlopeEval t₁ t₂ + W.a₂ * W.formalInterceptEval t₁ t₂ +
+        W.a₃ * W.formalSlopeEval t₁ t₂ ^ 2 +
+        2 * W.a₄ * W.formalSlopeEval t₁ t₂ * W.formalInterceptEval t₁ t₂ +
+        3 * W.a₆ * W.formalSlopeEval t₁ t₂ ^ 2 * W.formalInterceptEval t₁ t₂) := by
+  have hT := congrArg (evalPair h₁ h₂) W.formalThirdRoot_def
+  have hD := congrArg (evalPair h₁ h₂) (MvPowerSeries.mul_invOfUnit
+    (1 + MvPowerSeries.C W.a₂ * W.formalSlope + MvPowerSeries.C W.a₄ * W.formalSlope ^ 2 +
+      MvPowerSeries.C W.a₆ * W.formalSlope ^ 3) 1 (by simp))
+  simp only [map_sub, map_neg, map_add, map_mul, map_pow, map_one, map_ofNat, coe_evalPair,
+    MvPowerSeries.eval₂_X, MvPowerSeries.eval₂_C, RingHom.id_apply, pair_inl, pair_inr] at hT hD
+  simp only [show MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalSlope =
+      W.formalSlopeEval t₁ t₂ from rfl,
+    show MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalIntercept =
+      W.formalInterceptEval t₁ t₂ from rfl,
+    show MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalThirdRoot =
+      W.formalThirdRootEval t₁ t₂ from rfl] at hT hD
+  set L := W.formalSlopeEval t₁ t₂
+  set N := W.formalInterceptEval t₁ t₂
+  set T := W.formalThirdRootEval t₁ t₂
+  set d := MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂)
+    (MvPowerSeries.invOfUnit (1 + MvPowerSeries.C W.a₂ * W.formalSlope +
+      MvPowerSeries.C W.a₄ * W.formalSlope ^ 2 + MvPowerSeries.C W.a₆ * W.formalSlope ^ 3) 1)
+  clear_value L N T d
+  linear_combination (1 + W.a₂ * L + W.a₄ * L ^ 2 + W.a₆ * L ^ 3) * hT -
+    (W.a₁ * L + W.a₂ * N + W.a₃ * L ^ 2 + 2 * W.a₄ * L * N + 3 * W.a₆ * L ^ 2 * N) * hD
+
+/-- **The addition series at a pair of parameters is the formal inverse of the third root**:
+`F(t₁, t₂) = ι(t₃(t₁, t₂))`, the sum of two points being the negative of the third point of the
+chord through them. -/
+theorem formalAddEval_eq {I : Ideal O} (hI : IsAdic I) {t₁ t₂ : O}
+    (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hm₁ : t₁ ∈ I) (hm₂ : t₂ ∈ I) :
+    W.formalAddEval t₁ t₂ = W.formalInverseEval (W.formalThirdRootEval t₁ t₂) := by
+  have hmem : W.formalThirdRootEval t₁ t₂ ∈ I := by
+    simpa using W.formalThirdRootEval_mem (k := 1) hI h₁ h₂ (by simpa using hm₁)
+      (by simpa using hm₂)
+  have hT : PowerSeries.HasEval (W.formalThirdRootEval t₁ t₂) :=
+    hI.isTopologicallyNilpotent_of_mem hmem
+  have hae : MvPowerSeries.aeval (hasEval_pair h₁ h₂) W.formalThirdRoot =
+      W.formalThirdRootEval t₁ t₂ :=
+    congrFun (MvPowerSeries.coe_aeval (hasEval_pair h₁ h₂)) W.formalThirdRoot
+  have hT' : PowerSeries.HasEval (MvPowerSeries.aeval (hasEval_pair h₁ h₂) W.formalThirdRoot) := by
+    rw [hae]; exact hT
+  have h := MvPowerSeries.aeval_subst W.hasSubst_formalThirdRoot
+    (MvPowerSeries.continuous_aeval (hasEval_pair h₁ h₂))
+    (PowerSeries.hasEval hT') W.formalInverse
+  rw [← W.formalAdd_def] at h
+  simpa [formalAddEval, W.formalInverseEval_def, MvPowerSeries.coe_aeval, PowerSeries.eval₂,
+    show MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalThirdRoot =
+      W.formalThirdRootEval t₁ t₂ from rfl] using h
+
+/-- **The group law is `t₁ + t₂` to first order**: at parameters of `I ^ k` the addition series
+deviates from their sum by an element of `I ^ (2 * k)`, because it agrees with `z₁ + z₂` below
+total degree two. -/
+theorem formalAddEval_sub_add_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O}
+    (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hk₁ : t₁ ∈ I ^ k)
+    (hk₂ : t₂ ∈ I ^ k) : W.formalAddEval t₁ t₂ - (t₁ + t₂) ∈ I ^ (2 * k) := by
+  have heval : MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂)
+      (W.formalAdd - MvPowerSeries.X (Sum.inl ()) - MvPowerSeries.X (Sum.inr ())) =
+      W.formalAddEval t₁ t₂ - (t₁ + t₂) := by
+    rw [← coe_evalPair h₁ h₂, map_sub, map_sub]
+    simp [coe_evalPair, formalAddEval, MvPowerSeries.eval₂_X, pair_inl, pair_inr, sub_sub]
+  rw [← heval]
+  exact MvPowerSeries.eval₂_mem_pow_mul (φ := RingHom.id O) (by simpa using continuous_id)
+    (hasEval_pair h₁ h₂) hI (by rintro (_ | _) <;> [exact hk₁; exact hk₂]) _
+    (fun d hd ↦ W.coeff_formalAdd_sub_eq_zero_of_degree_lt hd)
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -18,8 +18,8 @@ of parameters, as `FormalGroup/Eval.lean` evaluates the one-variable series at a
 carries the identities of series over to identities of values.
 
 The pair is the family `Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂` on `Unit ⊕ Unit`, and it admits
-evaluation as soon as each parameter does — `MvPowerSeries.hasEval_of_finite`, the decay
-condition being vacuous over finitely many variables.
+evaluation as soon as each parameter does — the decay condition is vacuous over finitely many
+variables, so `MvPowerSeries.hasEval_of_finite_of_isTopologicallyNilpotent` applies.
 
 ## Main definitions
 
@@ -44,8 +44,8 @@ condition being vacuous over finitely many variables.
 
 Two of the series are built from one-variable ones through `PowerSeries.toMvPowerSeries` and
 `MvPowerSeries.subst`; evaluating those is `PowerSeries.eval₂_id_toMvPowerSeries` and
-`MvPowerSeries.aeval_subst`, both of which hold over a coefficient ring that is not discrete —
-which the ambient adic ring is not.
+`MvPowerSeries.aeval_subst`, neither of which requires the coefficient ring to be discrete —
+which matters here, because the ambient adic ring need not be.
 
 ## References
 
@@ -102,7 +102,7 @@ omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
 private theorem hasEval_pair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) :
     MvPowerSeries.HasEval (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂ : Unit ⊕ Unit → O) :=
-  MvPowerSeries.hasEval_of_finite <| by rintro (_ | _) <;> assumption
+  MvPowerSeries.hasEval_of_finite_of_isTopologicallyNilpotent <| by rintro (_ | _) <;> assumption
 
 omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
   [IsLinearTopology O O] in

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -18,8 +18,8 @@ of parameters, as `FormalGroup/Eval.lean` evaluates the one-variable series at a
 carries the identities of series over to identities of values.
 
 The pair is the family `Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂` on `Unit ⊕ Unit`, and it admits
-evaluation as soon as each parameter does — `MvPowerSeries.hasEval_sumElim`, the decay condition
-being vacuous over finitely many variables.
+evaluation as soon as each parameter does — `MvPowerSeries.hasEval_of_finite`, the decay
+condition being vacuous over finitely many variables.
 
 ## Main definitions
 
@@ -84,41 +84,41 @@ namespace WeierstrassCurve
 variable {O : Type*} [CommRing O] [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O]
   [T2Space O] [IsTopologicalRing O] [IsLinearTopology O O] (W : WeierstrassCurve O)
 
-/-- The pair `(t₁, t₂)` as a family indexed by the two variables of the chord construction. -/
-private def pair (t₁ t₂ : O) : Unit ⊕ Unit → O := Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂
-
-omit [CommRing O] [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O] [T2Space O]
+omit [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O] [T2Space O]
   [IsTopologicalRing O] [IsLinearTopology O O] in
-/-- The pair takes the first parameter on the first variable. -/
-private theorem pair_inl (t₁ t₂ : O) : pair t₁ t₂ (Sum.inl ()) = t₁ := rfl
+/-- Both entries of the pair lie in `I ^ k` as soon as the two parameters do. -/
+private theorem pair_mem {I : Ideal O} {k : ℕ} {t₁ t₂ : O} (hk₁ : t₁ ∈ I ^ k) (hk₂ : t₂ ∈ I ^ k) :
+    ∀ i, (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂ : Unit ⊕ Unit → O) i ∈ I ^ k := by
+  rintro (_ | _) <;> [exact hk₁; exact hk₂]
 
-omit [CommRing O] [UniformSpace O] [IsUniformAddGroup O] [CompleteSpace O] [T2Space O]
-  [IsTopologicalRing O] [IsLinearTopology O O] in
-/-- The pair takes the second parameter on the second variable. -/
-private theorem pair_inr (t₁ t₂ : O) : pair t₁ t₂ (Sum.inr ()) = t₂ := rfl
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- The identity ring homomorphism is continuous. -/
+private theorem continuous_ringHomId : Continuous (RingHom.id O) := by simpa using continuous_id
 
 omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
   [IsLinearTopology O O] in
 /-- A pair of parameters admits evaluation as soon as each of them does. -/
 private theorem hasEval_pair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
-    (h₂ : PowerSeries.HasEval t₂) : MvPowerSeries.HasEval (pair t₁ t₂) :=
+    (h₂ : PowerSeries.HasEval t₂) :
+    MvPowerSeries.HasEval (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂ : Unit ⊕ Unit → O) :=
   MvPowerSeries.hasEval_of_finite <| by rintro (_ | _) <;> assumption
 
-/-- Evaluation at a pair of parameters, as a ring homomorphism. Every identity in this file is
-the image of an identity of series under this map. -/
+/-- Evaluation at a pair of parameters, as a ring homomorphism. The transport lemmas below take
+identities of series to identities of values along this map. -/
 private noncomputable def evalPair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) : MvPowerSeries (Unit ⊕ Unit) O →+* O :=
-  MvPowerSeries.eval₂Hom (φ := RingHom.id O) (by simpa using continuous_id) (hasEval_pair h₁ h₂)
+  MvPowerSeries.eval₂Hom (φ := RingHom.id O) continuous_ringHomId (hasEval_pair h₁ h₂)
 
 /-- `evalPair` is `MvPowerSeries.eval₂` at the identity ring hom, as a function. -/
 private theorem coe_evalPair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) :
-    ⇑(evalPair h₁ h₂) = MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) :=
+    ⇑(evalPair h₁ h₂) = MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂) :=
   MvPowerSeries.coe_eval₂Hom (φ := RingHom.id O) _ (hasEval_pair h₁ h₂)
 
 /-- The value of the slope series at a pair of parameters. -/
 noncomputable def formalSlopeEval (t₁ t₂ : O) : O :=
-  MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalSlope
+  MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂) W.formalSlope
 
 omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
   [IsLinearTopology O O] in
@@ -130,7 +130,7 @@ theorem formalSlopeEval_def (t₁ t₂ : O) :
 
 /-- The value of the intercept series at a pair of parameters. -/
 noncomputable def formalInterceptEval (t₁ t₂ : O) : O :=
-  MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalIntercept
+  MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂) W.formalIntercept
 
 omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
   [IsLinearTopology O O] in
@@ -143,7 +143,7 @@ theorem formalInterceptEval_def (t₁ t₂ : O) :
 
 /-- The value of the third-root series at a pair of parameters. -/
 noncomputable def formalThirdRootEval (t₁ t₂ : O) : O :=
-  MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalThirdRoot
+  MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂) W.formalThirdRoot
 
 omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
   [IsLinearTopology O O] in
@@ -156,7 +156,7 @@ theorem formalThirdRootEval_def (t₁ t₂ : O) :
 
 /-- The value of the addition series at a pair of parameters. -/
 noncomputable def formalAddEval (t₁ t₂ : O) : O :=
-  MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalAdd
+  MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂) W.formalAdd
 
 omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
   [IsLinearTopology O O] in
@@ -166,40 +166,13 @@ theorem formalAddEval_def (t₁ t₂ : O) :
       MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂)
         W.formalAdd := (rfl)
 
-omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
-  [IsLinearTopology O O] in
-/-- Folding lemma: the evaluation of `formalSlope` at the pair is `formalSlopeEval`.
-Stated over the private `pair` so the transport proofs rewrite with it rather than
-relying on definitional equality. -/
-private theorem eval_pair_formalSlope (t₁ t₂ : O) :
-    MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalSlope =
-      W.formalSlopeEval t₁ t₂ := rfl
-
-omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
-  [IsLinearTopology O O] in
-/-- Folding lemma: the evaluation of `formalIntercept` at the pair is `formalInterceptEval`.
-Stated over the private `pair` so the transport proofs rewrite with it rather than
-relying on definitional equality. -/
-private theorem eval_pair_formalIntercept (t₁ t₂ : O) :
-    MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalIntercept =
-      W.formalInterceptEval t₁ t₂ := rfl
-
-omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
-  [IsLinearTopology O O] in
-/-- Folding lemma: the evaluation of `formalThirdRoot` at the pair is `formalThirdRootEval`.
-Stated over the private `pair` so the transport proofs rewrite with it rather than
-relying on definitional equality. -/
-private theorem eval_pair_formalThirdRoot (t₁ t₂ : O) :
-    MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalThirdRoot =
-      W.formalThirdRootEval t₁ t₂ := rfl
-
 /-- **The evaluated slope identity**: `λ(t₁, t₂) * (t₂ - t₁) = w(t₂) - w(t₁)`. -/
 theorem formalSlopeEval_mul_sub {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) :
     W.formalSlopeEval t₁ t₂ * (t₂ - t₁) = W.formalWEval t₂ - W.formalWEval t₁ := by
   have h := congrArg (evalPair h₁ h₂) W.formalSlope_mul_sub
   rw [map_mul, map_sub, map_sub] at h
-  simpa [formalSlopeEval, W.formalWEval_def, coe_evalPair, pair_inl, pair_inr,
+  simpa [formalSlopeEval, W.formalWEval_def, coe_evalPair, Sum.elim_inl, Sum.elim_inr,
     PowerSeries.eval₂_id_toMvPowerSeries (hasEval_pair h₁ h₂),
     MvPowerSeries.eval₂_X] using h
 
@@ -209,8 +182,8 @@ theorem formalInterceptEval_eq {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     W.formalInterceptEval t₁ t₂ = W.formalWEval t₁ - W.formalSlopeEval t₁ t₂ * t₁ := by
   have h := congrArg (evalPair h₁ h₂) W.formalIntercept_def
   rw [map_sub, map_mul] at h
-  simpa [formalInterceptEval, formalSlopeEval, W.formalWEval_def, coe_evalPair, pair_inl,
-    pair_inr, PowerSeries.eval₂_id_toMvPowerSeries (hasEval_pair h₁ h₂),
+  simpa [formalInterceptEval, formalSlopeEval, W.formalWEval_def, coe_evalPair, Sum.elim_inl,
+    Sum.elim_inr, PowerSeries.eval₂_id_toMvPowerSeries (hasEval_pair h₁ h₂),
     MvPowerSeries.eval₂_X] using h
 
 /-- The slope of the chord at parameters of `I ^ k` again lies in `I ^ k`: the slope series has
@@ -218,15 +191,15 @@ vanishing constant coefficient. -/
 theorem formalSlopeEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O}
     (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hk₁ : t₁ ∈ I ^ k)
     (hk₂ : t₂ ∈ I ^ k) : W.formalSlopeEval t₁ t₂ ∈ I ^ k :=
-  MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) (by simpa using continuous_id)
-    (hasEval_pair h₁ h₂) hI (by rintro (_ | _) <;> [exact hk₁; exact hk₂]) W.formalSlope (by simp)
+  MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) continuous_ringHomId
+    (hasEval_pair h₁ h₂) hI (pair_mem hk₁ hk₂) W.formalSlope (by simp)
 
 /-- The third point's parameter at parameters of `I ^ k` again lies in `I ^ k`. -/
 theorem formalThirdRootEval_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O}
     (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hk₁ : t₁ ∈ I ^ k)
     (hk₂ : t₂ ∈ I ^ k) : W.formalThirdRootEval t₁ t₂ ∈ I ^ k :=
-  MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) (by simpa using continuous_id)
-    (hasEval_pair h₁ h₂) hI (by rintro (_ | _) <;> [exact hk₁; exact hk₂]) W.formalThirdRoot
+  MvPowerSeries.eval₂_mem_pow (φ := RingHom.id O) continuous_ringHomId
+    (hasEval_pair h₁ h₂) hI (pair_mem hk₁ hk₂) W.formalThirdRoot
     (by simp)
 
 /-- **Vieta's formula at a pair of parameters**, cleared of the inverse of the cubic's leading
@@ -246,13 +219,14 @@ theorem formalThirdRootEval_relation {t₁ t₂ : O} (h₁ : PowerSeries.HasEval
     (1 + MvPowerSeries.C W.a₂ * W.formalSlope + MvPowerSeries.C W.a₄ * W.formalSlope ^ 2 +
       MvPowerSeries.C W.a₆ * W.formalSlope ^ 3) 1 (by simp))
   simp only [map_sub, map_neg, map_add, map_mul, map_pow, map_one, map_ofNat, coe_evalPair,
-    MvPowerSeries.eval₂_X, MvPowerSeries.eval₂_C, RingHom.id_apply, pair_inl, pair_inr] at hT hD
-  simp only [W.eval_pair_formalSlope, W.eval_pair_formalIntercept,
-    W.eval_pair_formalThirdRoot] at hT hD
+    MvPowerSeries.eval₂_X, MvPowerSeries.eval₂_C, RingHom.id_apply, Sum.elim_inl,
+    Sum.elim_inr] at hT hD
+  simp only [← W.formalSlopeEval_def, ← W.formalInterceptEval_def,
+    ← W.formalThirdRootEval_def] at hT hD
   set L := W.formalSlopeEval t₁ t₂
   set N := W.formalInterceptEval t₁ t₂
   set T := W.formalThirdRootEval t₁ t₂
-  set d := MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂)
+  set d := MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂)
     (MvPowerSeries.invOfUnit (1 + MvPowerSeries.C W.a₂ * W.formalSlope +
       MvPowerSeries.C W.a₄ * W.formalSlope ^ 2 + MvPowerSeries.C W.a₆ * W.formalSlope ^ 3) 1)
   clear_value L N T d
@@ -275,7 +249,7 @@ theorem formalAddEval_eq {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (PowerSeries.hasEval hT') W.formalInverse
   rw [← W.formalAdd_def] at h
   simpa [formalAddEval, W.formalInverseEval_def, MvPowerSeries.coe_aeval, PowerSeries.eval₂,
-    W.eval_pair_formalThirdRoot] using h
+    ← W.formalThirdRootEval_def] using h
 
 /-- **The group law is `t₁ + t₂` to first order**: at parameters of `I ^ k` the addition series
 deviates from their sum by an element of `I ^ (2 * k)`, because it agrees with `z₁ + z₂` below
@@ -283,14 +257,14 @@ total degree two. -/
 theorem formalAddEval_sub_add_mem {I : Ideal O} (hI : IsAdic I) {k : ℕ} {t₁ t₂ : O}
     (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hk₁ : t₁ ∈ I ^ k)
     (hk₂ : t₂ ∈ I ^ k) : W.formalAddEval t₁ t₂ - (t₁ + t₂) ∈ I ^ (2 * k) := by
-  have heval : MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂)
+  have heval : MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂)
       (W.formalAdd - MvPowerSeries.X (Sum.inl ()) - MvPowerSeries.X (Sum.inr ())) =
       W.formalAddEval t₁ t₂ - (t₁ + t₂) := by
     rw [← coe_evalPair h₁ h₂, map_sub, map_sub]
-    simp [coe_evalPair, formalAddEval, MvPowerSeries.eval₂_X, pair_inl, pair_inr, sub_sub]
+    simp [coe_evalPair, formalAddEval, MvPowerSeries.eval₂_X, Sum.elim_inl, Sum.elim_inr, sub_sub]
   rw [← heval]
-  exact MvPowerSeries.eval₂_mem_pow_mul (φ := RingHom.id O) (by simpa using continuous_id)
-    (hasEval_pair h₁ h₂) hI (by rintro (_ | _) <;> [exact hk₁; exact hk₂]) _
+  exact MvPowerSeries.eval₂_mem_pow_mul (φ := RingHom.id O) continuous_ringHomId
+    (hasEval_pair h₁ h₂) hI (pair_mem hk₁ hk₂) _
     (fun d hd ↦ W.coeff_formalAdd_sub_eq_zero_of_degree_lt hd)
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean
@@ -102,7 +102,7 @@ omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
 /-- A pair of parameters admits evaluation as soon as each of them does. -/
 private theorem hasEval_pair {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) : MvPowerSeries.HasEval (pair t₁ t₂) :=
-  MvPowerSeries.hasEval_sumElim (fun _ ↦ h₁) fun _ ↦ h₂
+  MvPowerSeries.hasEval_of_finite <| by rintro (_ | _) <;> assumption
 
 /-- Evaluation at a pair of parameters, as a ring homomorphism. Every identity in this file is
 the image of an identity of series under this map. -/
@@ -166,6 +166,33 @@ theorem formalAddEval_def (t₁ t₂ : O) :
       MvPowerSeries.eval₂ (RingHom.id O) (Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂)
         W.formalAdd := (rfl)
 
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- Folding lemma: the evaluation of `formalSlope` at the pair is `formalSlopeEval`.
+Stated over the private `pair` so the transport proofs rewrite with it rather than
+relying on definitional equality. -/
+private theorem eval_pair_formalSlope (t₁ t₂ : O) :
+    MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalSlope =
+      W.formalSlopeEval t₁ t₂ := rfl
+
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- Folding lemma: the evaluation of `formalIntercept` at the pair is `formalInterceptEval`.
+Stated over the private `pair` so the transport proofs rewrite with it rather than
+relying on definitional equality. -/
+private theorem eval_pair_formalIntercept (t₁ t₂ : O) :
+    MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalIntercept =
+      W.formalInterceptEval t₁ t₂ := rfl
+
+omit [IsUniformAddGroup O] [CompleteSpace O] [T2Space O] [IsTopologicalRing O]
+  [IsLinearTopology O O] in
+/-- Folding lemma: the evaluation of `formalThirdRoot` at the pair is `formalThirdRootEval`.
+Stated over the private `pair` so the transport proofs rewrite with it rather than
+relying on definitional equality. -/
+private theorem eval_pair_formalThirdRoot (t₁ t₂ : O) :
+    MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalThirdRoot =
+      W.formalThirdRootEval t₁ t₂ := rfl
+
 /-- **The evaluated slope identity**: `λ(t₁, t₂) * (t₂ - t₁) = w(t₂) - w(t₁)`. -/
 theorem formalSlopeEval_mul_sub {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
     (h₂ : PowerSeries.HasEval t₂) :
@@ -220,12 +247,8 @@ theorem formalThirdRootEval_relation {t₁ t₂ : O} (h₁ : PowerSeries.HasEval
       MvPowerSeries.C W.a₆ * W.formalSlope ^ 3) 1 (by simp))
   simp only [map_sub, map_neg, map_add, map_mul, map_pow, map_one, map_ofNat, coe_evalPair,
     MvPowerSeries.eval₂_X, MvPowerSeries.eval₂_C, RingHom.id_apply, pair_inl, pair_inr] at hT hD
-  simp only [show MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalSlope =
-      W.formalSlopeEval t₁ t₂ from rfl,
-    show MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalIntercept =
-      W.formalInterceptEval t₁ t₂ from rfl,
-    show MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalThirdRoot =
-      W.formalThirdRootEval t₁ t₂ from rfl] at hT hD
+  simp only [W.eval_pair_formalSlope, W.eval_pair_formalIntercept,
+    W.eval_pair_formalThirdRoot] at hT hD
   set L := W.formalSlopeEval t₁ t₂
   set N := W.formalInterceptEval t₁ t₂
   set T := W.formalThirdRootEval t₁ t₂
@@ -239,14 +262,9 @@ theorem formalThirdRootEval_relation {t₁ t₂ : O} (h₁ : PowerSeries.HasEval
 /-- **The addition series at a pair of parameters is the formal inverse of the third root**:
 `F(t₁, t₂) = ι(t₃(t₁, t₂))`, the sum of two points being the negative of the third point of the
 chord through them. -/
-theorem formalAddEval_eq {I : Ideal O} (hI : IsAdic I) {t₁ t₂ : O}
-    (h₁ : PowerSeries.HasEval t₁) (h₂ : PowerSeries.HasEval t₂) (hm₁ : t₁ ∈ I) (hm₂ : t₂ ∈ I) :
+theorem formalAddEval_eq {t₁ t₂ : O} (h₁ : PowerSeries.HasEval t₁)
+    (h₂ : PowerSeries.HasEval t₂) (hT : PowerSeries.HasEval (W.formalThirdRootEval t₁ t₂)) :
     W.formalAddEval t₁ t₂ = W.formalInverseEval (W.formalThirdRootEval t₁ t₂) := by
-  have hmem : W.formalThirdRootEval t₁ t₂ ∈ I := by
-    simpa using W.formalThirdRootEval_mem (k := 1) hI h₁ h₂ (by simpa using hm₁)
-      (by simpa using hm₂)
-  have hT : PowerSeries.HasEval (W.formalThirdRootEval t₁ t₂) :=
-    hI.isTopologicallyNilpotent_of_mem hmem
   have hae : MvPowerSeries.aeval (hasEval_pair h₁ h₂) W.formalThirdRoot =
       W.formalThirdRootEval t₁ t₂ :=
     congrFun (MvPowerSeries.coe_aeval (hasEval_pair h₁ h₂)) W.formalThirdRoot
@@ -257,8 +275,7 @@ theorem formalAddEval_eq {I : Ideal O} (hI : IsAdic I) {t₁ t₂ : O}
     (PowerSeries.hasEval hT') W.formalInverse
   rw [← W.formalAdd_def] at h
   simpa [formalAddEval, W.formalInverseEval_def, MvPowerSeries.coe_aeval, PowerSeries.eval₂,
-    show MvPowerSeries.eval₂ (RingHom.id O) (pair t₁ t₂) W.formalThirdRoot =
-      W.formalThirdRootEval t₁ t₂ from rfl] using h
+    W.eval_pair_formalThirdRoot] using h
 
 /-- **The group law is `t₁ + t₂` to first order**: at parameters of `I ^ k` the addition series
 deviates from their sum by an element of `I ^ (2 * k)`, because it agrees with `z₁ + z₂` below

--- a/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
@@ -59,7 +59,6 @@ of `HasEval` vacuous; that is the one place the hypothesis does work rather than
   admissible evaluation point.
 * `MvPowerSeries.hasEval_of_mem` : a family of finitely many arguments drawn from `I` is an
   admissible evaluation point.
-* `MvPowerSeries.hasEval_sumElim` : two such families assemble into one on a sum type.
 * `MvPowerSeries.eval₂_sub_constantCoeff_mem` : the value and the image of the constant term
   differ by an element of `I`.
 
@@ -188,16 +187,6 @@ type with finitely many variables, lying in `I` is the only condition the argume
 already gives them the `HasEval` property that evaluation requires. -/
 theorem hasEval_of_mem [Finite σ] (hI : IsAdic I) (hmem : ∀ i, a i ∈ I) : HasEval a :=
   hasEval_of_finite fun s ↦ hI.isTopologicallyNilpotent_of_mem (hmem s)
-
-omit [IsUniformAddGroup S] [CompleteSpace S] [T2Space S] [IsTopologicalRing S]
-  [IsLinearTopology S S] in
-/-- **A pair of topologically nilpotent arguments can be substituted into a two-variable power
-series.** Mathlib's `HasEval` constructions cover a constant family, a single variable and images
-under a continuous map, but not a family assembled from two others; this is that case. -/
-theorem hasEval_sumElim {τ : Type*} [Finite σ] [Finite τ] {b : σ → S} {c : τ → S}
-    (hb : ∀ i, IsTopologicallyNilpotent (b i)) (hc : ∀ j, IsTopologicallyNilpotent (c j)) :
-    HasEval (Sum.elim b c) :=
-  hasEval_of_finite <| by rintro (i | j) <;> simp [hb, hc]
 
 /-- **The value differs from the image of the constant term by an element of `I`.** Equivalently,
 for arguments drawn from `I` the value of `f` is congruent to the image of its constant term

--- a/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
@@ -18,10 +18,10 @@ confined to `I ^ k` as soon as the arguments are and `φ` sends the constant ter
 confinement improves when the series vanishes in low total degree or when `φ` sends every
 coefficient into a power of `I`.
 
-Three further results serve the same arguments from either side. Over finitely many variables
-every family admits evaluation; arguments drawn from `I` satisfy `MvPowerSeries.HasEval` in the
-first place, so that the value is defined at all; and the value is congruent to the image of the
-constant term modulo `I`.
+Three further results serve the same arguments from either side. Over finitely many variables a
+pointwise topologically nilpotent family admits evaluation; arguments drawn from `I` satisfy
+`MvPowerSeries.HasEval` in the first place, so that the value is defined at all; and the value is
+congruent to the image of the constant term modulo `I`.
 
 They are proved differently. `hasEval_of_finite` does not use the estimates above at all: over
 finitely many variables the decay condition at infinity is vacuous, so topological nilpotence
@@ -173,23 +173,6 @@ theorem eval₂_mem_pow_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic 
     eval₂ φ a f ∈ I ^ (c * j) := by
   simpa using eval₂_mem_pow_add_mul (k := 0) hφ ha hI hmem f (fun _ ↦ by simp) hcoeff
 
-omit [IsUniformAddGroup S] [CompleteSpace S] [T2Space S] [IsTopologicalRing S]
-  [IsLinearTopology S S] in
-/-- **Finitely many topologically nilpotent arguments can be substituted into a power series.**
-Over finitely many variables the decay condition `HasEval` asks for at infinity is vacuous, so
-pointwise topological nilpotence is the whole of it. -/
-theorem hasEval_of_finite [Finite σ] (h : ∀ i, IsTopologicallyNilpotent (a i)) : HasEval a where
-  hpow := h
-  tendsto_zero := by simp [Filter.cofinite_eq_bot]
-
-omit [IsUniformAddGroup S] [CompleteSpace S] [T2Space S] [IsTopologicalRing S]
-  [IsLinearTopology S S] in
-/-- **A family drawn from an adic ideal can be substituted into a power series.** For an index
-type with finitely many variables, lying in `I` is the only condition the arguments need: it
-already gives them the `HasEval` property that evaluation requires. -/
-theorem hasEval_of_mem [Finite σ] (hI : IsAdic I) (hmem : ∀ i, a i ∈ I) : HasEval a :=
-  hasEval_of_finite fun s ↦ hI.isTopologicallyNilpotent_of_mem (hmem s)
-
 /-- **The value differs from the image of the constant term by an element of `I`.** Equivalently,
 for arguments drawn from `I` the value of `f` is congruent to the image of its constant term
 modulo `I`. -/
@@ -205,5 +188,26 @@ theorem eval₂_sub_constantCoeff_mem (hφ : Continuous φ) (ha : HasEval a)
   rwa [hsplit] at key
 
 end Eval
+
+section HasEval
+
+-- Neither result below needs the uniform structure the evaluation bounds require: `HasEval` is
+-- a condition on a topological ring alone.
+variable {σ : Type*} {S : Type*} [CommRing S] [TopologicalSpace S] {a : σ → S} {I : Ideal S}
+
+/-- **Finitely many topologically nilpotent arguments can be substituted into a power series.**
+Over finitely many variables the decay condition `HasEval` asks for at infinity is vacuous, so
+pointwise topological nilpotence is the whole of it. -/
+theorem hasEval_of_finite [Finite σ] (h : ∀ i, IsTopologicallyNilpotent (a i)) : HasEval a where
+  hpow := h
+  tendsto_zero := by simp [Filter.cofinite_eq_bot]
+
+/-- **A family drawn from an adic ideal can be substituted into a power series.** For an index
+type with finitely many variables, lying in `I` is the only condition the arguments need: it
+already gives them the `HasEval` property that evaluation requires. -/
+theorem hasEval_of_mem [Finite σ] (hI : IsAdic I) (hmem : ∀ i, a i ∈ I) : HasEval a :=
+  hasEval_of_finite fun s ↦ hI.isTopologicallyNilpotent_of_mem (hmem s)
+
+end HasEval
 
 end MvPowerSeries

--- a/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
@@ -5,6 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
+public import Mathlib.Data.Finite.Sum
 public import Mathlib.RingTheory.MvPowerSeries.Evaluation
 public import TauCeti.Topology.Algebra.Nonarchimedean.AdicTopology
 
@@ -54,8 +55,11 @@ of `HasEval` vacuous; that is the one place the hypothesis does work rather than
   arguments of `I ^ j`, takes values in `I ^ (c * j)`.
 * `MvPowerSeries.eval₂_mem_pow_add_mul` : if moreover `φ` sends every coefficient into `I ^ k`,
   the value lies in `I ^ (k + c * j)`.
+* `MvPowerSeries.hasEval_of_finite` : finitely many topologically nilpotent arguments are an
+  admissible evaluation point.
 * `MvPowerSeries.hasEval_of_mem` : a family of finitely many arguments drawn from `I` is an
   admissible evaluation point.
+* `MvPowerSeries.hasEval_sumElim` : two such families assemble into one on a sum type.
 * `MvPowerSeries.eval₂_sub_constantCoeff_mem` : the value and the image of the constant term
   differ by an element of `I`.
 
@@ -170,12 +174,30 @@ theorem eval₂_mem_pow_mul (hφ : Continuous φ) (ha : HasEval a) (hI : IsAdic 
 
 omit [IsUniformAddGroup S] [CompleteSpace S] [T2Space S] [IsTopologicalRing S]
   [IsLinearTopology S S] in
+/-- **Finitely many topologically nilpotent arguments can be substituted into a power series.**
+Over finitely many variables the decay condition `HasEval` asks for at infinity is vacuous, so
+pointwise topological nilpotence is the whole of it. -/
+theorem hasEval_of_finite [Finite σ] (h : ∀ i, IsTopologicallyNilpotent (a i)) : HasEval a where
+  hpow := h
+  tendsto_zero := by simp [Filter.cofinite_eq_bot]
+
+omit [IsUniformAddGroup S] [CompleteSpace S] [T2Space S] [IsTopologicalRing S]
+  [IsLinearTopology S S] in
 /-- **A family drawn from an adic ideal can be substituted into a power series.** For an index
 type with finitely many variables, lying in `I` is the only condition the arguments need: it
 already gives them the `HasEval` property that evaluation requires. -/
-theorem hasEval_of_mem [Finite σ] (hI : IsAdic I) (hmem : ∀ i, a i ∈ I) : HasEval a where
-  hpow s := hI.isTopologicallyNilpotent_of_mem (hmem s)
-  tendsto_zero := by simp [Filter.cofinite_eq_bot]
+theorem hasEval_of_mem [Finite σ] (hI : IsAdic I) (hmem : ∀ i, a i ∈ I) : HasEval a :=
+  hasEval_of_finite fun s ↦ hI.isTopologicallyNilpotent_of_mem (hmem s)
+
+omit [IsUniformAddGroup S] [CompleteSpace S] [T2Space S] [IsTopologicalRing S]
+  [IsLinearTopology S S] in
+/-- **A pair of topologically nilpotent arguments can be substituted into a two-variable power
+series.** Mathlib's `HasEval` constructions cover a constant family, a single variable and images
+under a continuous map, but not a family assembled from two others; this is that case. -/
+theorem hasEval_sumElim {τ : Type*} [Finite σ] [Finite τ] {b : σ → S} {c : τ → S}
+    (hb : ∀ i, IsTopologicallyNilpotent (b i)) (hc : ∀ j, IsTopologicallyNilpotent (c j)) :
+    HasEval (Sum.elim b c) :=
+  hasEval_of_finite <| by rintro (i | j) <;> simp [hb, hc]
 
 /-- **The value differs from the image of the constant term by an element of `I`.** Equivalently,
 for arguments drawn from `I` the value of `f` is congruent to the image of its constant term

--- a/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
@@ -5,7 +5,6 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.Data.Finite.Sum
 public import Mathlib.RingTheory.MvPowerSeries.Evaluation
 public import TauCeti.Topology.Algebra.Nonarchimedean.AdicTopology
 
@@ -19,16 +18,18 @@ confined to `I ^ k` as soon as the arguments are and `φ` sends the constant ter
 confinement improves when the series vanishes in low total degree or when `φ` sends every
 coefficient into a power of `I`.
 
-Two further results serve the same arguments from either side. Arguments drawn from `I` satisfy
-`MvPowerSeries.HasEval` in the first place, so that the value is defined at all; and the value is
-congruent to the image of the constant term modulo `I`.
+Three further results serve the same arguments from either side. Over finitely many variables
+every family admits evaluation; arguments drawn from `I` satisfy `MvPowerSeries.HasEval` in the
+first place, so that the value is defined at all; and the value is congruent to the image of the
+constant term modulo `I`.
 
-They are proved differently. `hasEval_of_mem` does not use the estimates above at all: each
-argument is topologically nilpotent because it lies in `I`, and over finitely many variables the
-decay condition at infinity is vacuous. `eval₂_sub_constantCoeff_mem` is the one that reduces to
-them — subtracting the constant term kills the constant monomial and every surviving monomial
-carries an argument, so the difference is the `k = 1` case of `eval₂_mem_pow` applied to
-`f - C (constantCoeff f)`.
+They are proved differently. `hasEval_of_finite` does not use the estimates above at all: over
+finitely many variables the decay condition at infinity is vacuous, so topological nilpotence
+of each argument is the whole content. `hasEval_of_mem` is its corollary, obtained by supplying
+that nilpotence from membership in `I` through `IsAdic.isTopologicallyNilpotent_of_mem`.
+`eval₂_sub_constantCoeff_mem` is the one that reduces to them — subtracting the constant term
+kills the constant monomial and every surviving monomial carries an argument, so the difference
+is the `k = 1` case of `eval₂_mem_pow` applied to `f - C (constantCoeff f)`.
 
 The three bounds have the same one-line mechanism. `MvPowerSeries.hasSum_eval₂` writes the value
 as the sum of its monomial values `φ (coeff d f) * ∏ s, a s ^ d s`; each such monomial is checked
@@ -44,8 +45,9 @@ type need not be finite, because the summation argument uses only the `Tendsto a
 already carried by `HasEval`. Taking `I` to be `IsLocalRing.maximalIdeal S` and `φ` to be
 `RingHom.id S` recovers the source statements.
 
-Finiteness of `σ` survives in `hasEval_of_mem` alone, where it is what makes the decay condition
-of `HasEval` vacuous; that is the one place the hypothesis does work rather than being inherited.
+Finiteness of `σ` survives in `hasEval_of_finite`, where it is what makes the decay condition of
+`HasEval` vacuous; that is the one place the hypothesis does work, and `hasEval_of_mem` inherits
+it from there.
 
 ## Main results
 

--- a/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Evaluation.lean
@@ -23,7 +23,8 @@ pointwise topologically nilpotent family admits evaluation; arguments drawn from
 `MvPowerSeries.HasEval` in the first place, so that the value is defined at all; and the value is
 congruent to the image of the constant term modulo `I`.
 
-They are proved differently. `hasEval_of_finite` does not use the estimates above at all: over
+They are proved differently. `hasEval_of_finite_of_isTopologicallyNilpotent` does not use the
+estimates above at all: over
 finitely many variables the decay condition at infinity is vacuous, so topological nilpotence
 of each argument is the whole content. `hasEval_of_mem` is its corollary, obtained by supplying
 that nilpotence from membership in `I` through `IsAdic.isTopologicallyNilpotent_of_mem`.
@@ -45,7 +46,8 @@ type need not be finite, because the summation argument uses only the `Tendsto a
 already carried by `HasEval`. Taking `I` to be `IsLocalRing.maximalIdeal S` and `φ` to be
 `RingHom.id S` recovers the source statements.
 
-Finiteness of `σ` survives in `hasEval_of_finite`, where it is what makes the decay condition of
+Finiteness of `σ` survives in `hasEval_of_finite_of_isTopologicallyNilpotent`, where it is what
+makes the decay condition of
 `HasEval` vacuous; that is the one place the hypothesis does work, and `hasEval_of_mem` inherits
 it from there.
 
@@ -57,7 +59,8 @@ it from there.
   arguments of `I ^ j`, takes values in `I ^ (c * j)`.
 * `MvPowerSeries.eval₂_mem_pow_add_mul` : if moreover `φ` sends every coefficient into `I ^ k`,
   the value lies in `I ^ (k + c * j)`.
-* `MvPowerSeries.hasEval_of_finite` : finitely many topologically nilpotent arguments are an
+* `MvPowerSeries.hasEval_of_finite_of_isTopologicallyNilpotent` : finitely many topologically
+  nilpotent arguments are an
   admissible evaluation point.
 * `MvPowerSeries.hasEval_of_mem` : a family of finitely many arguments drawn from `I` is an
   admissible evaluation point.
@@ -198,7 +201,8 @@ variable {σ : Type*} {S : Type*} [CommRing S] [TopologicalSpace S] {a : σ → 
 /-- **Finitely many topologically nilpotent arguments can be substituted into a power series.**
 Over finitely many variables the decay condition `HasEval` asks for at infinity is vacuous, so
 pointwise topological nilpotence is the whole of it. -/
-theorem hasEval_of_finite [Finite σ] (h : ∀ i, IsTopologicallyNilpotent (a i)) : HasEval a where
+theorem hasEval_of_finite_of_isTopologicallyNilpotent [Finite σ]
+    (h : ∀ i, IsTopologicallyNilpotent (a i)) : HasEval a where
   hpow := h
   tendsto_zero := by simp [Filter.cofinite_eq_bot]
 
@@ -206,7 +210,7 @@ theorem hasEval_of_finite [Finite σ] (h : ∀ i, IsTopologicallyNilpotent (a i)
 type with finitely many variables, lying in `I` is the only condition the arguments need: it
 already gives them the `HasEval` property that evaluation requires. -/
 theorem hasEval_of_mem [Finite σ] (hI : IsAdic I) (hmem : ∀ i, a i ∈ I) : HasEval a :=
-  hasEval_of_finite fun s ↦ hI.isTopologicallyNilpotent_of_mem (hmem s)
+  hasEval_of_finite_of_isTopologicallyNilpotent fun s ↦ hI.isTopologicallyNilpotent_of_mem (hmem s)
 
 end HasEval
 

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -172,11 +172,13 @@ variable {R : Type*} [CommRing R] [UniformSpace R] [IsUniformAddGroup R] [IsTopo
 
 /-- `PowerSeries.eval₂_toMvPowerSeries` at the identity ring homomorphism.
 
-This is **not** a cosmetic restatement. `algebraMap R R` and `RingHom.id R` are definitionally
-equal but not syntactically so, and `algebraMap` is not reducible, so `simp` cannot match the
-general lemma against a goal phrased over `RingHom.id`. An evaluation layer whose coefficients and
-values are the same ring — which is what the formal group of a curve over an adic ring needs — is
-always phrased over `RingHom.id`, so without this form the general lemma is unusable there. -/
+The specialization exists so that consumers phrased over `RingHom.id` need not perform the
+normalization themselves. `algebraMap R R` and `RingHom.id R` are definitionally equal but not
+syntactically so, and `algebraMap` is not reducible; that is easy to discharge once, as the
+`simpa` below does, but it means the general lemma does not fire as a `simp` *rewrite rule*
+against a goal phrased over `RingHom.id`. An evaluation layer whose coefficients and values are
+the same ring — what the formal group of a curve over an adic ring needs — is phrased that way
+throughout, so it is this form its `simp` sets can use. -/
 theorem eval₂_id_toMvPowerSeries {σ : Type*} {a : σ → R} (ha : MvPowerSeries.HasEval a) (i : σ)
     (f : PowerSeries R) :
     MvPowerSeries.eval₂ (RingHom.id R) a (toMvPowerSeries i f) =

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.RingTheory.MvPowerSeries.Equiv
 public import Mathlib.RingTheory.PowerSeries.Substitution
 
 /-!
@@ -39,6 +40,10 @@ uniformities are shadowed, so the evaluation the statement is about is never re-
 * `MvPowerSeries.aeval_subst` : a continuous algebra homomorphism applied to a substitution is the
   evaluation at the substituted family.
 * `PowerSeries.aeval_subst` : the same for a substitution into a univariate series.
+* `PowerSeries.eval₂_toMvPowerSeries` and `PowerSeries.eval₂_id_toMvPowerSeries` : evaluating a
+  univariate series viewed in several variables is evaluating it at the matching entry of the
+  family — the case of `aeval_subst` at a single variable, which is how a one-variable series
+  meets a two-variable evaluation.
 
 Both are wanted for the formal group of an elliptic curve over a complete local ring, where the
 group law is a power series over the very ring it is evaluated in: the involution relating the
@@ -139,5 +144,41 @@ theorem aeval_subst {a : MvPowerSeries τ S} {ε : MvPowerSeries τ S →ₐ[R] 
     (hε : Continuous ε) (hb : HasEval (ε a)) (f : PowerSeries R) :
     ε (subst a f) = aeval hb f :=
   MvPowerSeries.aeval_subst ha.const hε (hasEval hb) f
+
+/-- Evaluating the image of a univariate series under `PowerSeries.toMvPowerSeries i` at a family
+`a` is evaluating the series itself at the entry `a i`: sending the single variable to the `i`-th
+one and then evaluating is evaluating at `a i`.
+
+`toMvPowerSeries` is a substitution, so this is `aeval_subst` at the family `MvPowerSeries.X i`;
+it is stated for `eval₂` rather than `aeval` because the evaluation of a family is what consumers
+hold, and the `aeval` form would carry the `HasEval` proof in a position where two propositionally
+equal parameters are not definitionally equal. -/
+theorem eval₂_toMvPowerSeries {σ : Type*} {a : σ → T} (ha : MvPowerSeries.HasEval a) (i : σ)
+    (f : PowerSeries R) :
+    MvPowerSeries.eval₂ (algebraMap R T) a (toMvPowerSeries i f) =
+      eval₂ (algebraMap R T) (a i) f := by
+  have hX : MvPowerSeries.aeval ha (MvPowerSeries.X i) = a i :=
+    (congrFun (MvPowerSeries.coe_aeval (R := R) ha) (MvPowerSeries.X i)).trans
+      (MvPowerSeries.eval₂_X (algebraMap R T) a i)
+  have h := aeval_subst (HasSubst.X i) (MvPowerSeries.continuous_aeval ha) (hX ▸ ha.hpow i) f
+  rw [← toMvPowerSeries_eq_subst] at h
+  rw [← congrFun (MvPowerSeries.coe_aeval (R := R) ha) (toMvPowerSeries i f), h,
+    congrFun (coe_aeval (hX ▸ ha.hpow i)) f, hX]
+
+section SelfEval
+
+variable {R : Type*} [CommRing R] [UniformSpace R] [IsUniformAddGroup R] [IsTopologicalRing R]
+  [IsLinearTopology R R] [T2Space R] [CompleteSpace R]
+
+/-- `PowerSeries.eval₂_toMvPowerSeries` at the identity ring homomorphism, which is the form the
+evaluation layer of a formal group uses: there the coefficients and the values live in the same
+ring, so `algebraMap` is not the shape the statement is met in. -/
+theorem eval₂_id_toMvPowerSeries {σ : Type*} {a : σ → R} (ha : MvPowerSeries.HasEval a) (i : σ)
+    (f : PowerSeries R) :
+    MvPowerSeries.eval₂ (RingHom.id R) a (toMvPowerSeries i f) =
+      eval₂ (RingHom.id R) (a i) f := by
+  simpa using eval₂_toMvPowerSeries (R := R) (T := R) ha i f
+
+end SelfEval
 
 end PowerSeries

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -45,9 +45,12 @@ uniformities are shadowed, so the evaluation the statement is about is never re-
   family — the case of `aeval_subst` at a single variable, which is how a one-variable series
   meets a two-variable evaluation.
 
-Both are wanted for the formal group of an elliptic curve over a complete local ring, where the
-group law is a power series over the very ring it is evaluated in: the involution relating the
-`w`-expansion to the formal inverse is an identity between two such evaluated substitutions.
+The two `aeval_subst` results are wanted for the formal group of an elliptic curve over a complete
+local ring, where the group law is a power series over the very ring it is evaluated in: the
+involution relating the `w`-expansion to the formal inverse is an identity between two such
+evaluated substitutions. The two `toMvPowerSeries` results serve the same development from the
+other side: the chord construction is a two-variable series, and its identities are proved by
+evaluating one-variable series — `w`, the slope, the formal inverse — at entries of the pair.
 
 ## Provenance
 
@@ -58,6 +61,11 @@ Apache-2.0) at commit `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, file
 `eval`. Here the three rings are independent and the statement is about Mathlib's
 `MvPowerSeries.aeval`; it equally generalises Mathlib's `MvPowerSeries.eval₂_subst`, whose
 `DiscreteUniformity` hypotheses it removes.
+
+`PowerSeries.eval₂_toMvPowerSeries` and `PowerSeries.eval₂_id_toMvPowerSeries` are the same
+source file's `eval_pair_rename` and `eval_pair_subst_single`, respelled: the source moves a
+one-variable series into two variables along `MvPowerSeries.rename (fun _ ↦ i)`, whereas these
+transport along `PowerSeries.toMvPowerSeries i`.
 
 The proof is not the source's. That one establishes continuity of `subst` for the ambient product
 topologies (its own `MvPowerSeries.continuous_subst'`) and applies uniqueness there; refining the

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -161,6 +161,7 @@ one and then evaluating is evaluating at `a i`.
 it is stated for `eval₂` rather than `aeval` because the evaluation of a family is what consumers
 hold, and the `aeval` form would carry the `HasEval` proof in a position where two propositionally
 equal parameters are not definitionally equal. -/
+@[simp]
 theorem eval₂_toMvPowerSeries {σ : Type*} {a : σ → T} (ha : MvPowerSeries.HasEval a) (i : σ)
     (f : PowerSeries R) :
     MvPowerSeries.eval₂ (algebraMap R T) a (toMvPowerSeries i f) =
@@ -187,6 +188,7 @@ syntactically so, and `algebraMap` is not reducible; that is easy to discharge o
 against a goal phrased over `RingHom.id`. An evaluation layer whose coefficients and values are
 the same ring — what the formal group of a curve over an adic ring needs — is phrased that way
 throughout, so it is this form its `simp` sets can use. -/
+@[simp]
 theorem eval₂_id_toMvPowerSeries {σ : Type*} {a : σ → R} (ha : MvPowerSeries.HasEval a) (i : σ)
     (f : PowerSeries R) :
     MvPowerSeries.eval₂ (RingHom.id R) a (toMvPowerSeries i f) =

--- a/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Substitution.lean
@@ -170,9 +170,13 @@ section SelfEval
 variable {R : Type*} [CommRing R] [UniformSpace R] [IsUniformAddGroup R] [IsTopologicalRing R]
   [IsLinearTopology R R] [T2Space R] [CompleteSpace R]
 
-/-- `PowerSeries.eval₂_toMvPowerSeries` at the identity ring homomorphism, which is the form the
-evaluation layer of a formal group uses: there the coefficients and the values live in the same
-ring, so `algebraMap` is not the shape the statement is met in. -/
+/-- `PowerSeries.eval₂_toMvPowerSeries` at the identity ring homomorphism.
+
+This is **not** a cosmetic restatement. `algebraMap R R` and `RingHom.id R` are definitionally
+equal but not syntactically so, and `algebraMap` is not reducible, so `simp` cannot match the
+general lemma against a goal phrased over `RingHom.id`. An evaluation layer whose coefficients and
+values are the same ring — which is what the formal group of a curve over an adic ring needs — is
+always phrased over `RingHom.id`, so without this form the general lemma is unusable there. -/
 theorem eval₂_id_toMvPowerSeries {σ : Type*} {a : σ → R} (ha : MvPowerSeries.HasEval a) (i : σ)
     (f : PowerSeries R) :
     MvPowerSeries.eval₂ (RingHom.id R) a (toMvPowerSeries i f) =


### PR DESCRIPTION
`FormalGroup/Eval.lean` evaluates the one-variable series at a single parameter. The chord data
(`formalSlope`, `formalIntercept`, `formalThirdRoot`) and the addition series (`formalAdd`) are
two-variable series; this evaluates them at a **pair** of parameters and carries the identities of
series over to identities of values.

## What this adds

`TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/PairEval.lean` (new)

* `formalSlopeEval`, `formalInterceptEval`, `formalThirdRootEval`, `formalAddEval` — the four
  evaluations at the pair `Sum.elim (fun _ ↦ t₁) fun _ ↦ t₂`, each with its `_def` equation lemma
  so consumers never unfold a definition.
* `formalSlopeEval_mul_sub` — `λ(t₁, t₂) * (t₂ - t₁) = w(t₂) - w(t₁)`.
* `formalInterceptEval_eq` — `ν(t₁, t₂) = w(t₁) - λ(t₁, t₂) * t₁`.
* `formalSlopeEval_mem`, `formalThirdRootEval_mem` — parameters in `I ^ k` keep the slope and the
  third root there.
* `formalThirdRootEval_relation` — Vieta's formula at a pair, cleared of the inverse of the cubic's
  leading coefficient.
* `formalAddEval_eq` — `F(t₁, t₂) = ι(t₃(t₁, t₂))`: the sum of two points is the negative of the
  third point of the chord through them.
* `formalAddEval_sub_add_mem` — `F(t₁, t₂) - (t₁ + t₂) ∈ I ^ (2 * k)` for parameters in `I ^ k`,
  i.e. the group law is `t₁ + t₂` to first order.

Hypotheses follow the split `Eval.lean` settled: the identities take `PowerSeries.HasEval` on each
parameter and no ideal; only the membership results additionally take `IsAdic I` and `t ∈ I ^ k`,
and they are `k`-indexed rather than fixed at `k = 1`.

## Two general prerequisites, placed generically

Both are needed by this file and neither is about elliptic curves, so they go in the generic
modules rather than in `namespace WeierstrassCurve` — the placement this repository's review
approved for #4860's `IsAdic.isTopologicallyNilpotent_of_mem`.

* `TauCeti/RingTheory/MvPowerSeries/Substitution.lean` — `PowerSeries.eval₂_toMvPowerSeries` and
  its single-ring form `eval₂_id_toMvPowerSeries`: evaluating a one-variable series *viewed in
  several variables* is evaluating it at the matching entry of the family. This is how `formalW`
  meets a two-variable evaluation, since this repository builds one-variable series into two with
  `PowerSeries.toMvPowerSeries`, and `toMvPowerSeries_eq_subst` makes that a substitution.
* `TauCeti/RingTheory/MvPowerSeries/Evaluation.lean` — `MvPowerSeries.hasEval_of_finite` (over
  finitely many variables, pointwise topological nilpotence is the whole of `HasEval`).
  `hasEval_of_mem` becomes a one-line corollary of it rather than a second proof of the same
  fact. An earlier revision of this PR also added `hasEval_sumElim`; it was deleted in review
  (it satisfied `reuse` and mooted `generality` and `documentation` at once), and this list is
  corrected accordingly — the file adds one declaration, not two.

**A scope question for the reviewer, stated rather than assumed.** These two could instead ship as
a prerequisite PR ahead of this one, per "ship a prerequisite refactor as its own PR". I kept them
here because they are useless alone — nothing else on `main` consumes either — and because the
single topic is "evaluate the chord construction at a pair", of which they are the substrate. If
you would rather see them split, say so and I will split them.

## Provenance

Adapted from Michael Stoll's `EllipticCurves` project
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`, whose full expansion is
`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`), `EllipticCurves/WeierstrassFormalGroup/Eval.lean` —
its pair-evaluation layer: `slopeEval`, `interceptEval`, `thirdRootEval`, `addEval`,
`hasEval_pairElim`, `eval_pair_rename`, `slopeEval_mul_sub`, `interceptEval_eq`, `slopeEval_mem`,
`thirdRootEval_mem`, `thirdRootEval_relation`, `addEval_eq` and `addEval_sub_add_mem`.

Three things are spelled differently here.

* The source's `eval_pair_rename` transports along `MvPowerSeries.rename`; this repository builds
  one-variable series into two variables with `PowerSeries.toMvPowerSeries`, so the transport is
  `PowerSeries.eval₂_toMvPowerSeries` instead.
* The source states everything over `IsLocalRing.maximalIdeal O` at `k = 1`. The memberships here
  are over an arbitrary adic ideal and an arbitrary power of it, and the identities that use no
  ideal take `PowerSeries.HasEval` on each parameter.
* The source evaluates through its own `ChabautyColeman.MvPSeries.eval`, a wrapper for
  `MvPowerSeries.eval₂ (RingHom.id _)`, which is not ported.

`addEval_sub_add_mem` also drops the source's `j ≠ 0`: the source needs it only to get `t ∈ 𝔪` from
`t ∈ 𝔪 ^ j`, and `HasEval` is a separate hypothesis here.

## Parents, all merged

This was written against four PRs and held until every one landed: #4860 (the one-variable
evaluation layer), #4868 (`MvPowerSeries.eval₂_mem_pow` and friends), #4892
(`PowerSeries.aeval_subst`, without which the substitution could not be evaluated over a
non-discrete ring) and #4845 (`coeff_formalAdd_sub_eq_zero_of_degree_lt`, which
`formalAddEval_sub_add_mem` consumes). Verified on `main` by commit-subject grep and by a content
probe for the declaration actually consumed, with a control.

## Gates run

| Gate | Result |
| --- | --- |
| `lake build` of the changed modules and their importers | **pass** — `Build completed successfully (2082 jobs)`, 0 errors, 0 warnings |
| line length | **pass** — longest lines 99 / 99 / 98 |
| axioms / module-system / full build / `lint-env` | CI (`pr-build`) |

Roadmap: EllipticCurves

Target: `TauCetiRoadmap/EllipticCurves/README.md`:572-580 — milestone **(iii)** of the formal-group
ladder, "Convergence: over a complete valued field, `Ê(𝔪)` as an honest group of points" (576-577),
with the Stoll development named as the port source at 579-580. The pair evaluation is what makes
the group *operation* on `Ê(𝔪)` computable at parameters: `formalAddEval_eq` identifies it, and
`formalAddEval_sub_add_mem` is the first-order estimate the filtration argument runs on.

Consumers: FG-5 (`tc-lb1z8`, valuations of the formal group data over a DVR) and FG-4 C
(`tc-5pdxn`, the formal points layer).

The roadmap bullet in full, so the scope question is answerable from this body:

> **The formal group — four milestones with four different hypothesis sets, not one.**
> (i) The elliptic formal group *law* `Ê` over the coefficient ring, from expanding the group
> law at `O` (AEC IV.1), as an instance of Mathlib's `RingTheory/FormalGroup`; `[m]` on `Ê`.
> (ii) The formal logarithm and exponential, over a coefficient ring containing `ℚ`
> (characteristic-zero hypotheses only here). (iii) Convergence: over a complete valued
> field, `Ê(𝔪)` as an honest group of points. (iv) The identification `Ê(𝔪) ≅ E₁(K)` with
> the kernel of reduction for an integral model (IV.6; consumed by Layers 3–4). **These cannot
> share one typeclass bundle**, and the existing sorry-free Stoll development (provenance) is
> the port source — refounded on Mathlib's formal-group-law layer, not rebuilt from nothing.

The bullet states four *different hypothesis sets* that *cannot share one typeclass bundle* — that
is separateness, not sequence, and no "first"/"then"/"before"/"after" appears in 572-580. Nothing
in this diff consumes milestone (i): it evaluates series already on `main` through
`MvPowerSeries.eval₂`, and no `FormalGroup` instance, group law or associativity appears in any
statement, proof or import. Milestone (i) is tracked as FG-3 (`tc-n3y1v`).

