### PR TITLE
improve(FormalGroup): answer the review findings on the multivariate w-equation

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -46,8 +46,10 @@ equation at the substituted parameter rather than at `z`.
   constant coefficient — two series with vanishing constant coefficient solving the equation at
   that parameter are equal.
 * `WeierstrassCurve.eq_of_wEquation_mvPowerSeries`: that same uniqueness one index type up, for
-  series in `MvPowerSeries σ R`. It is a sibling of `eq_of_wEquation` and not a generalisation of
-  it: filtering by total degree means subtracting, which costs the `CommSemiring` hypothesis.
+  series in `MvPowerSeries σ S` over any `R`-algebra `S` — so it survives scalar extension. It is
+  a sibling of `eq_of_wEquation` and not a generalisation of it: filtering by total degree needs
+  subtraction, so this one asks for a `CommRing`, where the univariate statement holds over a
+  `CommSemiring`.
 * `WeierstrassCurve.subst_wEquationRHS` and `WeierstrassCurve.subst_formalW_wEquation`:
   substituting a series `q` into the equation gives the equation at `q`, so `w(q)` solves it
   there. When moreover `constantCoeff q = 0`, `eq_subst_formalW_of_wEquation` combines this with
@@ -462,46 +464,40 @@ theorem eq_subst_formalW_of_wEquation {q v : PowerSeries R}
 /-! ### Uniqueness over a multivariate power series ring
 
 `eq_of_wEquation` argues by strong induction on the coefficient index, which needs that index to be
-linearly ordered. Over `MvPowerSeries σ R` no such order is available, so the induction runs on the
+linearly ordered. Over `MvPowerSeries σ S` no such order is available, so the induction runs on the
 total degree instead: `MvPowerSeries.order` is exactly the filtration by total degree, and the
 right-hand side of the `w`-equation is a contraction for it. That argument needs additive inverses,
 so this material stays in the `CommRing` section rather than joining the `CommSemiring` development
 above; the two uniqueness statements are siblings and neither subsumes the other.
 -/
 
-/-- The `w`-equation in `MvPowerSeries σ R` itself, where the structure map is `MvPowerSeries.C`.
-This is the spelling the order estimates below match against. -/
-theorem wEquationRHS_mvPowerSeries {σ : Type*} (q v : MvPowerSeries σ R) :
-    wEquationRHS W q v =
-      q ^ 3 + MvPowerSeries.C W.a₁ * q * v + MvPowerSeries.C W.a₂ * q ^ 2 * v +
-        MvPowerSeries.C W.a₃ * v ^ 2 + MvPowerSeries.C W.a₄ * q * v ^ 2 +
-        MvPowerSeries.C W.a₆ * v ^ 3 :=
-  (rfl)
-
 /-- **The right-hand side of the `w`-equation is a contraction for the total-degree filtration.**
 If two candidate solutions agree below total degree `k`, then the values of the equation at them
 agree below total degree `k + 1`. Every occurrence of the unknown is multiplied by the parameter,
 which has positive order, or sits in a square or a cube of a series of positive order, and that is
 where the extra degree comes from. -/
-private theorem le_order_wEquationRHS_sub {σ : Type*} {q u v : MvPowerSeries σ R}
+private theorem le_order_wEquationRHS_sub {σ S : Type*} [CommRing S] [Algebra R S]
+    {q u v : MvPowerSeries σ S}
     (hq : 1 ≤ q.order) (hu : 1 ≤ u.order) (hv : 1 ≤ v.order) {k : ℕ}
     (h : (k : ℕ∞) ≤ (u - v).order) :
     ((k + 1 : ℕ) : ℕ∞) ≤ (wEquationRHS W q u - wEquationRHS W q v).order := by
   -- The order estimates used below, in the vocabulary of `MvPowerSeries.order`.
-  have hmono : ∀ {m n : ℕ} {f : MvPowerSeries σ R}, m ≤ n → (n : ℕ∞) ≤ f.order →
+  have hmono : ∀ {m n : ℕ} {f : MvPowerSeries σ S}, m ≤ n → (n : ℕ∞) ≤ f.order →
       (m : ℕ∞) ≤ f.order := fun hmn hf => (Nat.cast_le.mpr hmn).trans hf
-  have hadd : ∀ {m : ℕ} {f g : MvPowerSeries σ R}, (m : ℕ∞) ≤ f.order → (m : ℕ∞) ≤ g.order →
+  have hadd : ∀ {m : ℕ} {f g : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order → (m : ℕ∞) ≤ g.order →
       (m : ℕ∞) ≤ (f + g).order :=
     fun hf hg => (le_min hf hg).trans MvPowerSeries.min_order_le_add
-  have hmul : ∀ {m n : ℕ} {f g : MvPowerSeries σ R}, (m : ℕ∞) ≤ f.order → (n : ℕ∞) ≤ g.order →
+  have hmul : ∀ {m n : ℕ} {f g : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order → (n : ℕ∞) ≤ g.order →
       ((m + n : ℕ) : ℕ∞) ≤ (f * g).order := by
     intro m n f g hf hg
     push_cast
     exact (add_le_add hf hg).trans MvPowerSeries.le_order_mul
-  have hC : ∀ {m : ℕ} (a : R) {f : MvPowerSeries σ R}, (m : ℕ∞) ≤ f.order →
-      (m : ℕ∞) ≤ (MvPowerSeries.C a * f).order := by
+  have hC : ∀ {m : ℕ} (a : R) {f : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order →
+      (m : ℕ∞) ≤ (algebraMap R (MvPowerSeries σ S) a * f).order := by
     intro m a f hf
-    exact (hf.trans le_add_self).trans MvPowerSeries.le_order_mul
+    -- The scalar has to be read in the coefficient ring `S` for `le_order_smul` to apply.
+    rw [MvPowerSeries.algebraMap_apply, ← MvPowerSeries.smul_eq_C_mul]
+    exact hf.trans MvPowerSeries.le_order_smul
   -- The three differences that carry the gain.
   have hq2 : ((2 : ℕ) : ℕ∞) ≤ (q * q).order := hmul hq hq
   have hlin : ((k + 1 : ℕ) : ℕ∞) ≤ (q * (u - v)).order := hmono (by omega) (hmul hq h)
@@ -515,10 +511,12 @@ private theorem le_order_wEquationRHS_sub {σ : Type*} {q u v : MvPowerSeries σ
     exact hmono (by omega) (hmul (hadd (hadd (hmul hu hu) (hmul hu hv)) (hmul hv hv)) h)
   -- Reassemble the difference and bound each summand.
   have hstep : wEquationRHS W q u - wEquationRHS W q v =
-      MvPowerSeries.C W.a₁ * (q * (u - v)) + MvPowerSeries.C W.a₂ * (q * q * (u - v)) +
-        MvPowerSeries.C W.a₃ * (u ^ 2 - v ^ 2) + MvPowerSeries.C W.a₄ * (q * (u ^ 2 - v ^ 2)) +
-        MvPowerSeries.C W.a₆ * (u ^ 3 - v ^ 3) := by
-    rw [wEquationRHS_mvPowerSeries, wEquationRHS_mvPowerSeries]
+      algebraMap R (MvPowerSeries σ S) W.a₁ * (q * (u - v)) +
+        algebraMap R (MvPowerSeries σ S) W.a₂ * (q * q * (u - v)) +
+        algebraMap R (MvPowerSeries σ S) W.a₃ * (u ^ 2 - v ^ 2) +
+        algebraMap R (MvPowerSeries σ S) W.a₄ * (q * (u ^ 2 - v ^ 2)) +
+        algebraMap R (MvPowerSeries σ S) W.a₆ * (u ^ 3 - v ^ 3) := by
+    rw [wEquationRHS_def, wEquationRHS_def]
     ring
   rw [hstep]
   refine hadd (hadd (hadd (hadd (hC _ hlin) (hC _ ?_)) (hC _ hsq)) (hC _ ?_)) (hC _ hcb)
@@ -529,10 +527,14 @@ private theorem le_order_wEquationRHS_sub {σ : Type*} {q u v : MvPowerSeries σ
 series with vanishing constant coefficient that satisfy the `w`-equation at the same parameter `q`
 are equal, provided `q` too has vanishing constant coefficient.
 
+The coefficients are taken in an arbitrary `R`-algebra `S`, matching `wEquationRHS` itself and the
+substitution lemmas above, so the statement survives scalar extension of the curve's base ring.
+
 This is `eq_of_wEquation` one index type up. It is not a generalisation of it: the argument here
 subtracts, so it needs a `CommRing`, whereas the univariate statement holds over a `CommSemiring`.
 -/
-theorem eq_of_wEquation_mvPowerSeries {σ : Type*} {q v v' : MvPowerSeries σ R}
+theorem eq_of_wEquation_mvPowerSeries {σ S : Type*} [CommRing S] [Algebra R S]
+    {q v v' : MvPowerSeries σ S}
     (hq : MvPowerSeries.constantCoeff q = 0) (hv : MvPowerSeries.constantCoeff v = 0)
     (hv' : MvPowerSeries.constantCoeff v' = 0) (h : v = wEquationRHS W q v)
     (h' : v' = wEquationRHS W q v') : v = v' := by


### PR DESCRIPTION
#4912 landed its **first** commit rather than its reviewed head, so three findings that had already
been answered on that branch are not in the library. This restores those answers and adds the one
finding that was still outstanding when it merged.

## Why this PR exists

`gh` reports #4912 merged at `2026-08-28T04:21:27Z` with head `74870859a`, but `main`'s
`WExpansion.lean` is byte-identical to the branch's *first* commit `c241709d1`, not to that head:

| ref | sha256 of the file | `wEquationRHS_mvPowerSeries` | `le_order_smul` |
|---|---|---|---|
| `main` | `0c31f5424b95` | 2 | 0 |
| `c241709d1` (first commit) | `0c31f5424b95` | 2 | 0 |
| `74870859a` (reviewed head) | `7bbd5c2c3426` | 0 | 1 |

So the `reuse` and `correctness` answers pushed in round 1 are absent from `main`, and the
declarations those rubrics objected to are live. This PR is not a new topic: it is the same review
conversation, finished.

## What it changes

**`reuse` — both findings.**

* `wEquationRHS_mvPowerSeries` is **removed**. `wEquationRHS_def` already states the equation over
  an arbitrary `R`-algebra, so the `MvPowerSeries.C` spelling was a specialization with a single
  call site; the reassembly step now rewrites with `wEquationRHS_def`. (The parallel that had been
  cited for it, `wEquationRHS_powerSeries`, earns its keep with five uses across two files, because
  the univariate coefficient lemmas match `PowerSeries.C` syntactically. This one had one use, and
  its consumer ends in `ring`, which does not care about the spelling.)
* the local `hC` no longer re-derives Mathlib's scalar-multiplication order bound.

**`correctness`.** The module-results bullet said subtraction "costs the `CommSemiring` hypothesis",
which reads as though this theorem *required* one. It now says what the declaration docstring
already said — it needs a `CommRing`, where the univariate statement holds over a `CommSemiring`.

**`generality`.** `eq_of_wEquation_mvPowerSeries` and the private contraction lemma took their
coefficients in the curve's own base ring, so neither survived scalar extension. Both now take an
arbitrary `R`-algebra `S`. This is the file's own convention: `wEquationRHS` is stated over an
arbitrary `R`-algebra, and `subst_wEquationRHS` and `subst_formalW_wEquation` already quantify over
`{τ S} [CommRing S] [Algebra R S]`.

That change also improves the proof rather than merely widening it. Reading the scalar in `S` is
what lets `MvPowerSeries.le_order_smul` apply, via `algebraMap_apply` and `smul_eq_C_mul`; the old
proof reached `le_order_smul` through `Algebra.smul_def`, which worked only because `S` was `R`. The
generality defect was in the proof as well as the statement.

## Deliberate pair, unchanged

`eq_of_wEquation_mvPowerSeries` remains a **sibling** of `eq_of_wEquation`, not a generalisation of
it: the contraction argument subtracts and so needs a `CommRing`, whereas the univariate statement
holds over a `CommSemiring`. Neither subsumes the other — the same shape as the `ΨSq_ne_zero` pair
in #4828 and the `psiFunctionField_ne_zero` pair in #4871.

## Verification

* Module-scoped build on the committed bytes, all six oleans deleted first so their return means
  something, with the file's sha256 captured at gate start **and** end (`5b9801f2e1c39508` both
  times): exit `0`, all six restored, `Build completed successfully (2081 jobs)`.
* The target set is the post-#4845 layout: `WExpansion`, `Chord`, `Inverse`, **`Eval`** (a new
  direct importer of this file) and **`Add.Series`** (renamed from `AddSeries`, which no longer
  exists). `Add/Unit.lean` was checked and does not import this file.
* `scripts/HeaderStyle.lean`: conforming, exit `0`.
* Longest line 99 codepoints.

## Roadmap

Roadmap: EllipticCurves

Improve-class: this modestly generalises and cleans up declarations already in the library, and
answers review findings on them. Per the repository contract that needs no fresh roadmap claim; the
roadmap chiefly motivating the material is EllipticCurves, Layer 1, the formal-group milestone (i).
