### PR TITLE
docs(Huber): fix what #4885's merge left behind — three doc claims and a dropped proof

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -37,6 +37,9 @@ Hausdorff — over a complete Hausdorff base, and over a discrete one — is
 * `TauCeti.Huber.weightedMapCompletion`: the map `A⟨X⟩_T → B⟨X⟩_S` on completions induced by a
   continuous ring map carrying each weight into the corresponding one — the completion-level
   companion of `TauCeti.Huber.weightedMap`.
+* `TauCeti.Huber.weightedMapCompletionEquiv`: the `RingEquiv` `A⟨X⟩_T ≃+* B⟨X⟩_S` on completions
+  induced by a bicontinuous ring isomorphism carrying the weights into one another in both
+  directions.
 * `TauCeti.Huber.restrictedMvPowerSeriesCompletionFinZeroEquiv`: at `k = 0`, the identification
   of `A⟨⟩` with the separated completion `Â`, carried across the completions from the
   ring-level `TauCeti.Huber.weightedRestrictedSubringFinZeroEquiv`.
@@ -52,6 +55,8 @@ Hausdorff — over a complete Hausdorff base, and over a discrete one — is
   and its continuity.
 * `TauCeti.Huber.weightedMapCompletion_id` and `TauCeti.Huber.weightedMapCompletion_comp`: the
   functor laws.
+* `TauCeti.Huber.weightedMapCompletionEquiv_apply` and `…_symm_apply`: each direction of the
+  equivalence is the corresponding `TauCeti.Huber.weightedMapCompletion`.
 * `TauCeti.Huber.restrictedMvPowerSeriesCompletionFinZeroEquiv_coe`,
   `…_symm_coe`, `continuous_restrictedMvPowerSeriesCompletionFinZeroEquiv` and its `_symm`: the
   zero-variable identification on canonical images, and its continuity in both directions.
@@ -179,10 +184,15 @@ theorem weightedMapCompletion_comp {C : Type*} [CommRing C] [TopologicalSpace C]
   simp only [weightedMapCompletion, weightedMap_comp hφ hψ hT hS hR hTS' hSR']
   exact UniformSpace.Completion.mapRingHom_comp _ _
 
-/-- **The isomorphism `A⟨X⟩_T ≃+* B⟨X⟩_S` induced by a bicontinuous ring isomorphism**, acting
-coefficientwise on completions. Continuity of `e` and of `e.symm` are both hypotheses; neither
-follows from the other for a bare `RingEquiv`, because `TauCeti.Huber.weightedMapCompletion` goes
-through `UniformSpace.Completion.mapRingHom`, which induces nothing from a discontinuous map.
+/-- **The isomorphism `A⟨X⟩_T ≃+* B⟨X⟩_S` induced by a bicontinuous ring isomorphism.** On the
+canonical image of `A⟨X⟩_T` it acts coefficientwise, by
+`TauCeti.Huber.weightedMapCompletion_coe`; on a general element of the completion it is the
+induced map and nothing more.
+
+Continuity of `e` and of `e.symm` are separate hypotheses: a `RingEquiv` is not assumed to be a
+homeomorphism, so continuity of `e.symm` does not follow from continuity of `e`. Both are then
+consumed, because `TauCeti.Huber.weightedMapCompletion` goes through
+`UniformSpace.Completion.mapRingHom`, which induces nothing from a discontinuous map.
 
 This is the `RingEquiv` packaging of `TauCeti.Huber.weightedMapCompletion`: the two induced maps
 are mutually inverse by `TauCeti.Huber.weightedMapCompletion_comp` and
@@ -205,7 +215,9 @@ noncomputable def weightedMapCompletionEquiv (e : A ≃+* B) (he : Continuous e)
       simp)
 
 /-- **The forward direction of `TauCeti.Huber.weightedMapCompletionEquiv`** is the induced map
-`TauCeti.Huber.weightedMapCompletion`, so the equivalence acts coefficientwise. -/
+`TauCeti.Huber.weightedMapCompletion`; combined with
+`TauCeti.Huber.weightedMapCompletion_coe` this describes its action on canonical images of
+`A⟨X⟩_T`. -/
 @[simp]
 theorem weightedMapCompletionEquiv_apply (e : A ≃+* B) (he : Continuous e)
     (he' : Continuous e.symm) (hT : IsWeightFamily T) (hS : IsWeightFamily S)

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -224,8 +224,7 @@ theorem weightedMapCompletionEquiv_apply (e : A ≃+* B) (he : Continuous e)
     (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i)
     (x : UniformSpace.Completion (weightedRestrictedSubring T hT)) :
     weightedMapCompletionEquiv e he he' hT hS hTS hST x
-      = weightedMapCompletion (φ := (e : A →+* B)) he hT hS hTS x := by
-  simp [weightedMapCompletionEquiv]
+      = weightedMapCompletion (φ := (e : A →+* B)) he hT hS hTS x := (rfl)
 
 /-- **The inverse direction of `TauCeti.Huber.weightedMapCompletionEquiv`** is the map induced by
 `e.symm`. -/
@@ -235,8 +234,7 @@ theorem weightedMapCompletionEquiv_symm_apply (e : A ≃+* B) (he : Continuous e
     (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i)
     (y : UniformSpace.Completion (weightedRestrictedSubring S hS)) :
     (weightedMapCompletionEquiv e he he' hT hS hTS hST).symm y
-      = weightedMapCompletion (φ := (e.symm : B →+* A)) he' hS hT hST y := by
-  simp [weightedMapCompletionEquiv]
+      = weightedMapCompletion (φ := (e.symm : B →+* A)) he' hS hT hST y := (rfl)
 
 end Functoriality
 


### PR DESCRIPTION
Correct three documentation claims that landed on main with #4885.

## Why this PR exists

Everything here is fallout from #4885's merge, in one file, around one declaration
(`weightedMapCompletionEquiv`) — two separate ways that merge left `main` behind the PR's own
review.

**(a) Its `documentation` board was still `request_changes` when the queue took it**, so three
findings were never answered and the defects are on `main`. The wording below follows the
reviewer's own suggested fixes.

**(b) Its last commit never landed.** `60aab0864` was pushed *after* #4885 was enqueued, and the
merge queue builds its group from the tree **at enqueue time** — so the commit was silently
dropped while GitHub shows the PR merged with all its commits. Verified: `58d61d495`, the enqueued
head, is byte-identical to `main`, and `60aab0864` differs by exactly the two proofs restored
here. Reported to foreman-2 rather than re-pushed quietly.

## The three claims

**1. The module header index went stale for the file's headline addition.** `## Main definitions`
listed `weightedMapCompletion` and `## Main results` listed `_coe` / `_id` / `_comp`, but neither
mentioned the new public `weightedMapCompletionEquiv` or its two application lemmas. Both lists now
carry them.

**2. Two unrelated causal claims were joined.** The equiv's docstring read "neither follows from
the other for a bare `RingEquiv`, because `weightedMapCompletion` goes through
`UniformSpace.Completion.mapRingHom`". `mapRingHom` explains why both continuity hypotheses are
*consumed*; it does not explain why continuity of `e.symm` does not *follow* from continuity of
`e` — that is because a `RingEquiv` is not assumed to be a homeomorphism. Now two sentences, one
per claim.

**3. "Acts coefficientwise" was an overclaim.** Both the definition's docstring and
`weightedMapCompletionEquiv_apply`'s said the equivalence acts coefficientwise. The statements do
not deliver that: `_apply` only rewrites the equiv's application to `weightedMapCompletion`, and
the coefficientwise description comes from `weightedMapCompletion_coe`, which holds **only on
canonical images of `A⟨X⟩_T`** — not on general elements of the completion. Both now say so.

## The dropped proof

Both application lemmas are back to `:= (rfl)` instead of `by simp [weightedMapCompletionEquiv]`,
which had been unfolding the definition in order to prove a statement about it. The two sides are
definitionally equal; bare `rfl` fails only because the definition's body is sealed at the module
boundary, and the parenthesised form elaborates against the sealed body.

## Notes for review

- No statement or attribute changes. Two proof bodies change, restoring the dropped commit;
  everything else is documentation.
- Gate: `lake build` of `WeightedRestrictedSeries.Completion` — **2181 jobs, exit 0, zero
  warnings**.

Roadmap: AdicSpaces
