### PR TITLE
refactor(AlgebraicGroup): name the product-factors step in the solvable iff

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
@@ -108,6 +108,13 @@ theorem geometricallySolvablePointsCommHopfAlgProperty_quotient
     (CommHopfAlgCat.mkQuotient H I) _ hH
   exact Ideal.Quotient.mkₐ_surjective k I.toIdeal
 
+/-- **A solvable product has solvable factors.** Each projection is surjective, so solvability
+transports along it. Mathlib has the transport lemmas but no product form. -/
+private theorem isSolvable_and_isSolvable_of_isSolvable_prod {G H : Type*} [Group G] [Group H]
+    [Group.IsSolvable (G × H)] : Group.IsSolvable G ∧ Group.IsSolvable H :=
+  ⟨Group.isSolvable_of_surjective (f := MonoidHom.fst G H) fun x ↦ ⟨(x, 1), rfl⟩,
+    Group.isSolvable_of_surjective (f := MonoidHom.snd G H) fun x ↦ ⟨(1, x), rfl⟩⟩
+
 /-- The tensor-product coordinate algebra has solvable geometric points exactly when both
 factors do. Contravariantly, this is closure and reflection of solvability by direct products of
 affine groups. -/
@@ -150,17 +157,7 @@ theorem geometricallySolvablePointsCommHopfAlgProperty_tensorProduct_iff
     let _ : Group.IsSolvable
         (WithConv (H →ₐ[k] AlgebraicClosure k) ×
           WithConv (K →ₐ[k] AlgebraicClosure k)) := hprod
-    constructor
-    · exact Group.isSolvable_of_surjective
-        (G := WithConv (H →ₐ[k] AlgebraicClosure k) ×
-          WithConv (K →ₐ[k] AlgebraicClosure k))
-        (G' := WithConv (H →ₐ[k] AlgebraicClosure k))
-        (f := MonoidHom.fst _ _) (fun x ↦ ⟨(x, 1), rfl⟩)
-    · exact Group.isSolvable_of_surjective
-        (G := WithConv (H →ₐ[k] AlgebraicClosure k) ×
-          WithConv (K →ₐ[k] AlgebraicClosure k))
-        (G' := WithConv (K →ₐ[k] AlgebraicClosure k))
-        (f := MonoidHom.snd _ _) (fun x ↦ ⟨(1, x), rfl⟩)
+    exact isSolvable_and_isSolvable_of_isSolvable_prod
   · rintro ⟨hH, hK⟩
     let _ : Group.IsSolvable (WithConv (H →ₐ[k] AlgebraicClosure k)) := hH
     let _ : Group.IsSolvable (WithConv (K →ₐ[k] AlgebraicClosure k)) := hK

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Basic.lean
@@ -10,6 +10,7 @@ public import Mathlib.GroupTheory.Solvable
 public import Mathlib.RingTheory.HopfAlgebra.TensorProduct
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Product
+public import TauCeti.GroupTheory.Solvable
 
 /-!
 # Geometric solvability of affine groups
@@ -108,13 +109,6 @@ theorem geometricallySolvablePointsCommHopfAlgProperty_quotient
     (CommHopfAlgCat.mkQuotient H I) _ hH
   exact Ideal.Quotient.mkₐ_surjective k I.toIdeal
 
-/-- **A solvable product has solvable factors.** Each projection is surjective, so solvability
-transports along it. Mathlib has the transport lemmas but no product form. -/
-private theorem isSolvable_and_isSolvable_of_isSolvable_prod {G H : Type*} [Group G] [Group H]
-    [Group.IsSolvable (G × H)] : Group.IsSolvable G ∧ Group.IsSolvable H :=
-  ⟨Group.isSolvable_of_surjective (f := MonoidHom.fst G H) fun x ↦ ⟨(x, 1), rfl⟩,
-    Group.isSolvable_of_surjective (f := MonoidHom.snd G H) fun x ↦ ⟨(1, x), rfl⟩⟩
-
 /-- The tensor-product coordinate algebra has solvable geometric points exactly when both
 factors do. Contravariantly, this is closure and reflection of solvability by direct products of
 affine groups. -/
@@ -154,10 +148,7 @@ theorem geometricallySolvablePointsCommHopfAlgProperty_tensorProduct_iff
           WithConv (K →ₐ[k] AlgebraicClosure k))
         (G' := WithConv (((H : Type v) ⊗[k] (K : Type v)) →ₐ[k] AlgebraicClosure k))
         (f := finv) hfinv_injective
-    let _ : Group.IsSolvable
-        (WithConv (H →ₐ[k] AlgebraicClosure k) ×
-          WithConv (K →ₐ[k] AlgebraicClosure k)) := hprod
-    exact isSolvable_and_isSolvable_of_isSolvable_prod
+    exact isSolvable_prod_iff.mp hprod
   · rintro ⟨hH, hK⟩
     let _ : Group.IsSolvable (WithConv (H →ₐ[k] AlgebraicClosure k)) := hH
     let _ : Group.IsSolvable (WithConv (K →ₐ[k] AlgebraicClosure k)) := hK

--- a/TauCeti/GroupTheory/Solvable.lean
+++ b/TauCeti/GroupTheory/Solvable.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.Solvable
+
+/-!
+# Solvability of a direct product
+
+The two projections out of a direct product are surjective, and solvability transports along a
+surjection, so a solvable product has solvable factors. In the other direction a product of two
+solvable groups is solvable. This file packages the two directions as a single characterisation.
+
+## Main results
+
+* `TauCeti.isSolvable_prod_iff`: `G × H` is solvable if and only if both `G` and `H` are.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A direct product of groups is solvable exactly when both of its factors are. -/
+theorem isSolvable_prod_iff {G H : Type*} [Group G] [Group H] :
+    Group.IsSolvable (G × H) ↔ Group.IsSolvable G ∧ Group.IsSolvable H :=
+  ⟨fun _ ↦ ⟨Group.isSolvable_of_surjective (f := MonoidHom.fst G H) fun x ↦ ⟨(x, 1), rfl⟩,
+      Group.isSolvable_of_surjective (f := MonoidHom.snd G H) fun x ↦ ⟨(1, x), rfl⟩⟩,
+    fun ⟨_, _⟩ ↦ inferInstance⟩
+
+end TauCeti

--- a/TauCeti/GroupTheory/Solvable.lean
+++ b/TauCeti/GroupTheory/Solvable.lean
@@ -24,6 +24,7 @@ public section
 namespace TauCeti
 
 /-- A direct product of groups is solvable exactly when both of its factors are. -/
+@[simp]
 theorem isSolvable_prod_iff {G H : Type*} [Group G] [Group H] :
     Group.IsSolvable (G × H) ↔ Group.IsSolvable G ∧ Group.IsSolvable H :=
   ⟨fun _ ↦ ⟨Group.isSolvable_of_surjective (f := MonoidHom.fst G H) fun x ↦ ⟨(x, 1), rfl⟩,


### PR DESCRIPTION
Name the product-factors step in the tensor-product solvability criterion, and give it a public
home in `GroupTheory/`.

## What moved

`geometricallySolvablePointsCommHopfAlgProperty_tensorProduct_iff` derived both factors'
solvability inline, applying `Group.isSolvable_of_surjective` twice through `MonoidHom.fst` and
`MonoidHom.snd`. That step has nothing to do with Hopf algebras — it is a general fact about
groups, and it now lives in a new `TauCeti/GroupTheory/Solvable.lean`:

```lean
@[simp]
theorem TauCeti.isSolvable_prod_iff {G H : Type*} [Group G] [Group H] :
    Group.IsSolvable (G × H) ↔ Group.IsSolvable G ∧ Group.IsSolvable H
```

| | before | after |
|---|---|---|
| `…_tensorProduct_iff` proof body | 52 lines | **39 lines** |
| `TauCeti/GroupTheory/Solvable.lean` | — | 33 lines, one theorem |

Naming the step also retired a three-line `let _ : Group.IsSolvable (… × …) := hprod` that existed
only to feed the instance argument of the round-1 private helper; the iff takes that argument
explicitly.

## Relation to Mathlib

`Mathlib/GroupTheory/Solvable.lean` has

- `Group.isSolvable_of_surjective` — the transport this proof composes, and
- an instance `[IsSolvable G] → [IsSolvable G'] → IsSolvable (G × G')` (line 184) — the
  **converse** direction, which makes the `←` half of `isSolvable_prod_iff` exactly
  `inferInstance`.

What it does not have is the reflection direction, `IsSolvable (G × H) → IsSolvable G ∧
IsSolvable H`. That is the content here.

> **Correction to an earlier revision of this description.** It claimed Mathlib had "no product
> form". That was too broad — Mathlib has the *construction*, just not the *reflection*. The claim
> is corrected above, and the declaration docstring now makes no Mathlib claim at all.

## Round 1 findings — both applied

- **placement.** The helper was `private` in an algebraic-group file despite carrying only
  abstract group hypotheses. It is now a public theorem in a new `TauCeti/GroupTheory/Solvable.lean`
  that `Solvable/Basic.lean` imports — the module the finding named.
- **documentation.** The docstring narrated the proof and asserted a Mathlib gap. It is now
  result-only: *"A direct product of groups is solvable exactly when both of its factors are."*
  The proof sketch and the Mathlib relation moved into the module docstring, which is where the
  house style of e.g. `GroupTheory/ExponentTwo.lean` keeps them.

### One deliberate deviation, flagged

The placement finding described moving the statement as it stood — one-directional, returning a
conjunction. I made it an **iff** instead. My reasons, and I will narrow it to the one-directional
form on request:

- `Mathlib/GroupTheory/Solvable.lean:178` states the analogous subgroup/quotient fact in exactly
  this shape — `isSolvable_iff_subgroup_quotient : IsSolvable G ↔ IsSolvable H ∧ IsSolvable (G ⧸ H)`
  — so the iff is the idiom of the very file being mirrored.
- The `←` half is `inferInstance` off the existing Mathlib instance, so no new mathematics is
  claimed and the proof grows by one line.
- `.mp` is precisely the statement the finding asked for, so nothing it requested is lost.

A public one-directional lemma returning `A ∧ B` would have been the weaker of the two APIs.

## Round 2 findings — one applied, one contested

- **api-design** (applied). The lemma is now `@[simp]`. Because its LHS is a *class* application,
  a careless tag could turn goals that instance resolution closes into conjunctions `simp` leaves
  open — so this was checked, not assumed: the module and all six importers build clean (exit 0,
  zero warnings, 3479 jobs), and a scoped `#lint only simpNF in TauCeti` driver reports
  `Found 0 errors in 1 declarations` / `All linting checks passed!`.
- **generality** (contested). It asks for `universe u v` with `{G : Type u} {H : Type v}` in place
  of `{G H : Type*}`, on the stated ground that the latter "places both groups in one shared
  universe". It does not: `Type*` elaborates to a fresh universe at each binder. The shipped
  declaration is already

  ```
  ∀ {G : Type u_1} {H : Type u_2} [Group G] [Group H], …
  ```

  and the proposed spelling elaborates to an identical signature — verified three ways against the
  built module, on the PR thread. No change made.

## Notes for review

- Gate (re-run at this head, with `@[simp]` in place): `lake build` of the new module,
  `Solvable.Basic`, and all six current importers
  (`Semisimple.Basic`, `Unipotent.Solvable`, `Solvable.Derived`, `Solvable.Extension`,
  `Solvable.UpperTriangular`, `Solvable.SemidirectProduct`) — exit 0, zero warnings. Six, not the
  four named in the round-1 gate: `main` has gained two importers since.

Roadmap: ReductiveGroups
