### PR TITLE
feat(HeckeSlash): the nebentypus-twisted Hecke operators multiply

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Independence.lean
@@ -87,27 +87,25 @@ lemma slash_eq_of_rightCoset_eq {f : ℍ → ℂ} (hf : ∀ γ ∈ Γ₁, f ∣[
 
 variable [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)]
 
-/-- **The slash sum of a `Γ₁`-invariant function is the sum over any decomposition of the double
-coset into right cosets.** If the right cosets `Γ₁ aᵢ` are pairwise distinct and cover
-`Γ₁ D.out Γ₂`, then `heckeSlashSum k D f = ∑ᵢ f ∣[k] aᵢ`.
+omit [Finite (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹)] in
+/-- **Two families of representatives of the same right cosets are matched by a bijection.**
+If the cosets `Γ₁ aᵢ` are pairwise distinct and cover `Γ₁ D.out Γ₂`, then the index type `ι` is
+matched with `DecompQuotient Γ₂ Γ₁ (D.out)⁻¹` — the index `heckeSlashSum` sums over — by a
+bijection `φ` carrying each `Γ₁ aᵢ` to `Γ₁ (rightCosetRep D (φ i))`.
 
-So the operator is attached to the double coset itself: the representatives `D.out` and `v.out`
-that `heckeSlashSum` happens to pick are one such family (`doubleCoset_eq_iUnion_rightCosets` and
-`op_mul_out_inv_smul_injective`), and every other family gives the same function.
-
-Invariance of `f` under `Γ₁` is what the proof uses, once, through
-`slash_eq_of_rightCoset_eq`; on a general `f` the statement is false, as `HeckeSlash/Basic.lean`
-records. -/
-theorem heckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ)
+This is pure coset bookkeeping: no slash, no weight and no character appears, and it is what makes
+a sum over one family equal to the sum over the other. Both the unweighted
+`heckeSlashSum_eq_sum_of_rightCosets` below and the nebentypus-weighted
+`twistedHeckeSlashSum_eq_sum_of_rightCosets` of `HeckeSlash/Nebentypus/Independence.lean` consume
+it, and differ only in the per-summand lemma they then supply. -/
+theorem exists_bijective_rightCosetRep_smul_eq {ι : Type*} (a : ι → GL (Fin 2) ℚ)
     (hcover : doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
       ⋃ i, MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)))
-    (hinj : Function.Injective fun i ↦ MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)))
-    (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
-    heckeSlashSum k D f = ∑ i, f ∣[k] a i := by
+    (hinj : Function.Injective fun i ↦ MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ))) :
+    ∃ φ : ι → DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹, Function.Bijective φ ∧
+      ∀ i, MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op (rightCosetRep D (φ i)) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
   classical
-  -- the enumeration the comparison of sums needs; `heckeSlashSum` fixes one of its own, and the
-  -- two agree, no sum here depending on which is chosen
-  let _ : Fintype (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) := Fintype.ofFinite _
   -- Shimura's decomposition, written with the representatives `heckeSlashSum` uses.
   have hcover' : doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
       ⋃ v, MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
@@ -117,8 +115,9 @@ theorem heckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι] (a : ι �
       MulOpposite.op (rightCosetRep D v) • (Γ₁ : Set (GL (Fin 2) ℚ)) := by
     simpa only [rightCosetRep_def] using
       op_mul_out_inv_smul_injective Γ₁ Γ₂ (D.out : GL (Fin 2) ℚ)
+  -- Mathlib's own lemma; stated for a submonoid, so `Γ₁` is passed through `toSubmonoid`.
   have hself : ∀ x : GL (Fin 2) ℚ, x ∈ MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) := fun x ↦
-    (mem_rightCoset_iff x).mpr (by simp)
+    mem_own_rightCoset Γ₁.toSubmonoid x
   -- Two right cosets of `Γ₁` that meet are equal, so each family's cosets occur in the other.
   have hmatch : ∀ x y : GL (Fin 2) ℚ, x ∈ MulOpposite.op y • (Γ₁ : Set (GL (Fin 2) ℚ)) →
       MulOpposite.op x • (Γ₁ : Set (GL (Fin 2) ℚ)) =
@@ -154,6 +153,28 @@ theorem heckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι] (a : ι �
     refine ⟨fun i j hij ↦ hinj (hcoset i j hij), fun v ↦ ?_⟩
     obtain ⟨i, hi⟩ := key' v
     exact ⟨i, (hinj' (hi.trans (hφ i))).symm⟩
+  exact ⟨φ, hbij, hφ⟩
+
+/-- **The slash sum of a `Γ₁`-invariant function is the sum over any decomposition of the double
+coset into right cosets.** If the right cosets `Γ₁ aᵢ` are pairwise distinct and cover
+`Γ₁ D.out Γ₂`, then `heckeSlashSum k D f = ∑ᵢ f ∣[k] aᵢ`.
+
+So the operator is attached to the double coset itself: the representatives `D.out` and `v.out`
+that `heckeSlashSum` happens to pick are one such family (`doubleCoset_eq_iUnion_rightCosets` and
+`op_mul_out_inv_smul_injective`), and every other family gives the same function.
+
+Invariance of `f` under `Γ₁` is what the proof uses, once, through
+`slash_eq_of_rightCoset_eq`; on a general `f` the statement is false, as `HeckeSlash/Basic.lean`
+records. -/
+theorem heckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι] (a : ι → GL (Fin 2) ℚ)
+    (hcover : doubleCoset (D.out : GL (Fin 2) ℚ) Γ₁ Γ₂ =
+      ⋃ i, MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)))
+    (hinj : Function.Injective fun i ↦ MulOpposite.op (a i) • (Γ₁ : Set (GL (Fin 2) ℚ)))
+    (f : ℍ → ℂ) (hf : ∀ γ ∈ Γ₁, f ∣[k] γ = f) :
+    heckeSlashSum k D f = ∑ i, f ∣[k] a i := by
+  classical
+  let _ : Fintype (DecompQuotient Γ₂ Γ₁ (D.out : GL (Fin 2) ℚ)⁻¹) := Fintype.ofFinite _
+  obtain ⟨φ, hbij, hφ⟩ := exists_bijective_rightCosetRep_smul_eq D a hcover hinj
   rw [heckeSlashSum_def]
   exact (Fintype.sum_bijective φ hbij _ _ fun i ↦ slash_eq_of_rightCoset_eq k hf (hφ i)).symm
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Composition
-public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Invariance
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Independence
 
 /-!
@@ -57,8 +56,6 @@ reason: that is the carrier on which the hypothesis comes for free.
 
 ## Main definitions
 
-* `HeckeRing.GL2.twistedHeckeSlashSumCharEnd`: the twisted slash sum as an endomorphism of the
-  character space.
 
 ## Main results
 
@@ -66,7 +63,6 @@ reason: that is the carrier on which the hypothesis comes for free.
   representatives on the right, the weights riding along unchanged.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum`: the composite of two twisted sums, as
   a double sum over products of representatives weighted by the character of the product.
-* `HeckeRing.GL2.coe_twistedHeckeSlashSumCharEnd`: the restricted operator on underlying functions.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets`: the same
   composite over *any* families of representatives lying in `Δ₀(N)`.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum`: the collapse
@@ -180,30 +176,6 @@ theorem twistedHeckeSlashSum_twistedHeckeSlashSum (f : ℍ → ℂ) :
     map_mul, Units.val_mul, mul_comm]
 
 end Composite
-
-section CharSpace
-
-/-- **The twisted slash sum as an endomorphism of the character space.** `twistedHeckeSlashSumEnd`
-is an endomorphism of *all* of `ℍ → ℂ`, and its own docstring records that this is the wrong
-carrier: the point of the weighting is that the twisted sum preserves the `χ`-eigenspace. It does,
-by `twistedHeckeSlashSum_mem_functionCharSpace`, so it restricts — and on this carrier, unlike on
-`ℍ → ℂ`, the operators multiply. -/
-noncomputable def twistedHeckeSlashSumCharEnd
-    (D : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))) :
-    Module.End ℂ (functionCharSpace k χ) :=
-  (twistedHeckeSlashSumEnd k χ D).restrict fun f hf ↦ by
-    simpa using twistedHeckeSlashSum_mem_functionCharSpace k χ D f hf
-
-/-- The restricted endomorphism is the twisted slash sum on underlying functions. -/
-@[simp] lemma coe_twistedHeckeSlashSumCharEnd
-    (D : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
-    (f : functionCharSpace k χ) :
-    (twistedHeckeSlashSumCharEnd k χ D f : ℍ → ℂ) = twistedHeckeSlashSum k χ D f := by
-  -- `twistedHeckeSlashSumEnd`'s body is sealed to this module, so the coercion is unfolded through
-  -- its own interface lemma rather than by `rfl`.
-  simp [twistedHeckeSlashSumCharEnd]
-
-end CharSpace
 
 section Free
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
@@ -7,33 +7,49 @@ module
 
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Composition
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Invariance
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Independence
 
 /-!
-# The composite of two nebentypus-twisted slash sums
+# The composite of two nebentypus-twisted slash sums, and the multiplicativity it yields
 
-`HeckeSlash/Composition.lean` computes the composite of two *unweighted* slash sums over the
-representatives they are defined with, in `heckeSlashSum_slash` and
-`heckeSlashSum_heckeSlashSum`, with no hypothesis on `f` at all. This file is the weighted
-counterpart of those two, and it is the computational core of the multiplicativity that will make
-the twisted assignment a *ring* homomorphism rather than merely `ℤ`-linear —
-`HeckeSlash/Nebentypus/Ring.lean` flags that gap in as many words.
+`HeckeSlash/Composition.lean` computes the composite of two *unweighted* slash sums, first over the
+representatives they are defined with and then over free families, and collapses it onto a single
+double coset. This file is the weighted counterpart of that development, and it carries it through
+to the end: the nebentypus-twisted Hecke operators **multiply**, which is the gap
+`HeckeSlash/Nebentypus/Ring.lean` records when it calls `twistedHeckeSlashRingLinearMap`
+"`ℤ`-linear in the ring element, but not known to be multiplicative, so this is not yet a ring
+action".
 
 ## Why the weights multiply, and why that is the whole point
 
 `delta0NebentypusChar N χ` is a `MonoidHom` on `Δ₀(N)`, so the weight of a product of
 representatives is the product of their weights. The composite of the two twisted sums is
 therefore a sum over *products* `a_v b_w` weighted by the character of that product — exactly the
-shape a single twisted sum over a third double coset has. Collapsing it onto such a sum is what
-multiplicativity will be, and it is *not* proved here: it needs the twisted analogue of
-`heckeSlashSum_eq_sum_of_rightCosets`, since changing representatives changes the weights
-attached to them.
+shape a single twisted sum over a third double coset has, which is what makes the collapse
+possible. Changing representatives changes the weights attached to them, so that collapse needs
+genuine representative-independence; that is `Nebentypus/Independence.lean`, and this file consumes
+it.
 
 ## Where the positivity hypothesis comes from
 
 Unlike the unweighted statements, the weighted ones carry `0 < det x`: the weight has to pass
 through the slash by `x`, which is `ModularForm.rat_smul_slash_of_det_pos`. No caller is
-inconvenienced — the composite applies it at a `rightCosetRep`, whose determinant is positive
-outright by `det_rightCosetRep_pos_of_delta0`.
+inconvenienced — over the chosen representatives it is `det_rightCosetRep_pos_of_delta0`, and over
+a free family it follows from the `Δ₀(N)` membership those statements already require.
+
+## Why the operator lives on the character space
+
+`twistedHeckeSlashSumEnd` is an endomorphism of *all* of `ℍ → ℂ`, and on that carrier the
+multiplicativity below is simply false: the underlying identity needs `f` to be a `χ`-eigenfunction.
+`functionCharSpace` is an invariant subspace, by `twistedHeckeSlashSum_mem_functionCharSpace`, so
+the operator restricts to it — and there the operators do multiply. This mirrors the untwisted
+development, which states its operator-level results on `ModularForm`/`CuspForm` for the same
+reason: that is the carrier on which the hypothesis comes for free.
+
+## Main definitions
+
+* `HeckeRing.GL2.twistedHeckeSlashSumCharEnd`: the twisted slash sum as an endomorphism of the
+  character space.
 
 ## Main results
 
@@ -41,6 +57,14 @@ outright by `det_rightCosetRep_pos_of_delta0`.
   representatives on the right, the weights riding along unchanged.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum`: the composite of two twisted sums, as
   a double sum over products of representatives weighted by the character of the product.
+* `HeckeRing.GL2.coe_twistedHeckeSlashSumCharEnd`: the restricted operator on underlying functions.
+* `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets`: the same
+  composite over *any* families of representatives lying in `Δ₀(N)`.
+* `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum`: the collapse
+  onto a single twisted sum, when the product set is one double coset and the products meet each
+  of its right cosets once.
+* `HeckeRing.GL2.twistedHeckeSlashSumCharEnd_mul_of_doubleCoset_eq_mul`: the pay-off — the twisted
+  Hecke operators multiply.
 
 ## Provenance
 
@@ -58,12 +82,21 @@ analogue of this repository's own `heckeSlashSum_slash`. AINTLIB reaches the sam
 `twistedHeckeSlashGen_slash_distrib` (`:399`), which sits inside the adjugate-and-correction block
 that the campaign routes around because this repository's substrate supersedes it.
 
-⚠ What this file does **not** contain, so that the source line numbers are not read as a wider
-claim: `twisted_weighted_slash_product_eq` (`:494`) is the per-pair step that carries a summand
-into a *third* double coset, and it already assumes the twisted invariance of `f`; the payoff
-`twistedHeckeSlashGen_comp` (`:801`) is the collapse onto a single twisted sum. Neither is proved
-here. Both need the twisted analogue of `heckeSlashSum_eq_sum_of_rightCosets`, because changing
-representatives changes the weights attached to them, and that is the next rung.
+`twistedHeckeSlashSumCharEnd_mul_of_doubleCoset_eq_mul` is the source's payoff
+`twistedHeckeSlashGen_comp` (`:801`) — the source's `twistedHeckeSlashGen` is this repository's
+`twistedHeckeSlashSum`. One hypothesis is deliberately **not** reproduced: the source assumes the
+two Hecke-ring generators commute, because it states the payoff at ring level where their product
+order is ambiguous. Stated at operator level the order is fixed by the statement — `Module.End`
+multiplies by composition, so `D₁` acts first — exactly as the untwisted
+`heckeSlashGamma1ModularFormEnd_mul_of_doubleCoset_eq_mul` does, and the hypothesis has nothing
+left to do.
+
+⚠ Not adapted, so that the source line numbers are not read as a wider claim:
+`twisted_weighted_slash_product_eq` (`:494`) is a per-pair step that carries a summand into a third
+double coset under an assumed twisted invariance of `f`; the route here goes through
+representative-independence instead. The source's fibre block (`:629`, `:661`, `:710`) is not
+adapted either — that bookkeeping is already on main, untwisted and more general, in
+`HeckeSlash/Composition.lean` with the `HeckeRing/Multiplicity` module.
 
 ## References
 
@@ -76,7 +109,7 @@ public section
 open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
   HeckeRing.GLn
 
-open scoped MatrixGroups ModularForm
+open scoped MatrixGroups ModularForm Pointwise
 
 namespace HeckeRing.GL2
 
@@ -115,8 +148,9 @@ for an arbitrary `f : ℍ → ℂ`.
 
 The weight on the summand at `(v, w)` is the character of the *product* `a_v b_w`, because
 `delta0NebentypusChar` is a `MonoidHom` and the two weights therefore multiply. That is what makes
-this a candidate for collapsing onto a single twisted sum over a third double coset; the collapse
-itself needs twisted representative-independence and is not proved here. -/
+this a candidate for collapsing onto a single twisted sum over a third double coset. That collapse
+needs twisted representative-independence, so it is not available at this point in the file; it is
+`twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum` in the `Free` section below. -/
 theorem twistedHeckeSlashSum_twistedHeckeSlashSum (f : ℍ → ℂ) :
     twistedHeckeSlashSum k χ D₂ (twistedHeckeSlashSum k χ D₁ f) =
       ∑ v, ∑ w, (delta0NebentypusChar N χ
@@ -137,6 +171,159 @@ theorem twistedHeckeSlashSum_twistedHeckeSlashSum (f : ℍ → ℂ) :
     map_mul, Units.val_mul, mul_comm]
 
 end Composite
+
+section CharSpace
+
+/-- **The twisted slash sum as an endomorphism of the character space.** `twistedHeckeSlashSumEnd`
+is an endomorphism of *all* of `ℍ → ℂ`, and its own docstring records that this is the wrong
+carrier: the point of the weighting is that the twisted sum preserves the `χ`-eigenspace. It does,
+by `twistedHeckeSlashSum_mem_functionCharSpace`, so it restricts — and on this carrier, unlike on
+`ℍ → ℂ`, the operators multiply. -/
+noncomputable def twistedHeckeSlashSumCharEnd
+    (D : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))) :
+    Module.End ℂ (functionCharSpace k χ) :=
+  (twistedHeckeSlashSumEnd k χ D).restrict fun f hf ↦ by
+    simpa using twistedHeckeSlashSum_mem_functionCharSpace k χ D f hf
+
+/-- The restricted endomorphism is the twisted slash sum on underlying functions. -/
+@[simp] lemma coe_twistedHeckeSlashSumCharEnd
+    (D : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
+    (f : functionCharSpace k χ) :
+    (twistedHeckeSlashSumCharEnd k χ D f : ℍ → ℂ) = twistedHeckeSlashSum k χ D f := by
+  -- `twistedHeckeSlashSumEnd`'s body is sealed to this module, so the coercion is unfolded through
+  -- its own interface lemma rather than by `rfl`.
+  simp [twistedHeckeSlashSumCharEnd]
+
+end CharSpace
+
+section Free
+
+variable (D₁ D₂ : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
+  {ι κ : Type*}
+  (a : ι → GL (Fin 2) ℚ) (ha : ∀ i, a i ∈ Delta0 N)
+  (b : κ → GL (Fin 2) ℚ) (hb : ∀ j, b j ∈ Delta0 N)
+  (hcover₁ : doubleCoset (D₁.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+    ((Gamma0 N).map (mapGL ℚ)) =
+    ⋃ i, MulOpposite.op (a i) • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+      Set (GL (Fin 2) ℚ)))
+  (hinj₁ : Function.Injective fun i ↦ MulOpposite.op (a i) •
+    (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)))
+  (hcover₂ : doubleCoset (D₂.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+    ((Gamma0 N).map (mapGL ℚ)) =
+    ⋃ j, MulOpposite.op (b j) • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+      Set (GL (Fin 2) ℚ)))
+  (hinj₂ : Function.Injective fun j ↦ MulOpposite.op (b j) •
+    (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)))
+
+include hcover₁ hinj₁ hcover₂ hinj₂ in
+/-- **The multiplicativity of the twisted slash sum**, over any families of representatives. For a
+`χ`-eigenfunction `f` and families `(aᵢ)`, `(bⱼ)` of representatives of the right cosets of the two
+double cosets, all lying in `Δ₀(N)`,
+
+`W(W f) = ∑_{i,j} χ'(aᵢ bⱼ) • (f ∣[k] (aᵢ bⱼ))`,
+
+the summand at `(i, j)` weighted by the character of the *product*.
+
+The weighted counterpart of `heckeSlashSum_heckeSlashSum_eq_sum_of_rightCosets`, and the free-family
+form of `twistedHeckeSlashSum_twistedHeckeSlashSum` above. The eigenfunction property is used twice,
+exactly as invariance is there: once to evaluate the inner sum on `(aᵢ)`, and once — through
+`twistedHeckeSlashSum_mem_functionCharSpace` — to know the inner sum is itself a `χ`-eigenfunction,
+which is what lets the outer sum be evaluated on `(bⱼ)`.
+
+The weights multiply because `delta0NebentypusChar` is a `MonoidHom`, and `ℂ` is commutative, so the
+two factors combine into the character of the product regardless of the order they are met in. -/
+theorem twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets [Fintype ι] [Fintype κ]
+    (f : ℍ → ℂ)
+    (hf : f ∈ functionCharSpace k χ) :
+    twistedHeckeSlashSum k χ D₂ (twistedHeckeSlashSum k χ D₁ f) =
+      ∑ i, ∑ j, (delta0NebentypusChar N χ ⟨a i * b j, mul_mem (ha i) (hb j)⟩ : ℂ) •
+        (f ∣[k] (a i * b j)) := by
+  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₂ b hb hcover₂ hinj₂ _
+      (twistedHeckeSlashSum_mem_functionCharSpace k χ D₁ f hf), Finset.sum_comm]
+  refine Finset.sum_congr rfl fun j _ ↦ ?_
+  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₁ a ha hcover₁ hinj₁ f hf,
+    SlashAction.sum_slash, Finset.smul_sum]
+  refine Finset.sum_congr rfl fun i _ ↦ ?_
+  rw [ModularForm.rat_smul_slash_of_det_pos k
+      (posDetInt_le_glpos 2 (Delta0_le_posDetInt N (hb j))) _ _,
+    ← SlashAction.slash_mul k (a i) (b j) f, smul_smul, ← MulMemClass.mk_mul_mk, map_mul,
+    Units.val_mul, mul_comm]
+
+variable [Finite ι] [Finite κ]
+  (D₃ : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
+
+include ha hb hcover₁ hinj₁ hcover₂ hinj₂ in
+/-- **The composite of two twisted slash sums is the twisted slash sum of a single double coset**,
+when the product set is that coset and the products `aᵢ bⱼ` meet each of its right cosets exactly
+once.
+
+This is the collapse, and with it the twisted assignment is multiplicative rather than merely
+`ℤ`-linear — the gap `HeckeSlash/Nebentypus/Ring.lean` records. The weighted counterpart of
+`heckeSlashSum_heckeSlashSum_eq_heckeSlashSum`, and its two hypotheses play the same roles: `hD₃`
+says the product set is the single coset `D₃`, and `hinj₃` says the products have no right-coset
+collisions. Neither identifies `hinj₃` with the left-representative count of
+`DoubleCoset.multiplicity`. The covering half that
+`twistedHeckeSlashSum_eq_sum_of_rightCosets` would otherwise need is automatic, by
+`doubleCoset_mul_doubleCoset_eq_iUnion_rightCosets`.
+
+The products lie in `Δ₀(N)` because each factor does and `Δ₀(N)` is a submonoid, which is what lets
+the twisting character be applied to them. -/
+theorem twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum
+    (hD₃ : doubleCoset (D₃.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+        ((Gamma0 N).map (mapGL ℚ)) =
+      doubleCoset (D₁.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+          ((Gamma0 N).map (mapGL ℚ)) *
+        doubleCoset (D₂.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+          ((Gamma0 N).map (mapGL ℚ)))
+    (hinj₃ : Function.Injective fun p : ι × κ ↦ MulOpposite.op (a p.1 * b p.2) •
+      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)))
+    (f : ℍ → ℂ) (hf : f ∈ functionCharSpace k χ) :
+    twistedHeckeSlashSum k χ D₂ (twistedHeckeSlashSum k χ D₁ f) =
+      twistedHeckeSlashSum k χ D₃ f := by
+  let _ : Fintype ι := Fintype.ofFinite ι
+  let _ : Fintype κ := Fintype.ofFinite κ
+  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₃ (fun p : ι × κ ↦ a p.1 * b p.2)
+      (fun p ↦ mul_mem (ha p.1) (hb p.2))
+      (hD₃.trans (doubleCoset_mul_doubleCoset_eq_iUnion_rightCosets a b hcover₁ hcover₂))
+      hinj₃ f hf,
+    twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₁ D₂ a ha b hb
+      hcover₁ hinj₁ hcover₂ hinj₂ f hf,
+    Fintype.sum_prod_type]
+
+include ha hb hcover₁ hinj₁ hcover₂ hinj₂ in
+/-- **The twisted Hecke operators multiply.** On the character space, and when the product set is
+the single double coset `D₃` with no right-coset collisions among the products, the composite of
+the operators of `D₁` and `D₂` is the operator of `D₃`.
+
+This is the multiplicativity that `HeckeSlash/Nebentypus/Ring.lean` records as missing —
+`twistedHeckeSlashRingLinearMap` is there described as "`ℤ`-linear in the ring element, but not
+known to be multiplicative, so this is not yet a ring action". It is the weighted counterpart of
+`heckeSlashGamma1ModularFormEnd_mul_of_doubleCoset_eq_mul`, and it is stated on the character space
+for the same reason that one is stated on `ModularForm`: that is the carrier on which the
+hypothesis the underlying identity needs — here `f ∈ functionCharSpace`, there `Γ₁`-invariance —
+comes for free.
+
+As there, `Module.End` multiplies by composition, so `D₁` acts first on the right-hand side of the
+underlying identity; that is the order recorded here. The source states this with a hypothesis that
+the two Hecke-ring generators commute; no such hypothesis is needed once the order is fixed by the
+statement. -/
+theorem twistedHeckeSlashSumCharEnd_mul_of_doubleCoset_eq_mul
+    (hD₃ : doubleCoset (D₃.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+        ((Gamma0 N).map (mapGL ℚ)) =
+      doubleCoset (D₁.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+          ((Gamma0 N).map (mapGL ℚ)) *
+        doubleCoset (D₂.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+          ((Gamma0 N).map (mapGL ℚ)))
+    (hinj₃ : Function.Injective fun p : ι × κ ↦ MulOpposite.op (a p.1 * b p.2) •
+      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ))) :
+    twistedHeckeSlashSumCharEnd k χ D₂ * twistedHeckeSlashSumCharEnd k χ D₁ =
+      twistedHeckeSlashSumCharEnd k χ D₃ := by
+  ext f x
+  have := congrFun (twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum k χ D₁ D₂ a ha
+    b hb hcover₁ hinj₁ hcover₂ hinj₂ D₃ hD₃ hinj₃ f f.2) x
+  simpa [Module.End.mul_apply] using this
+
+end Free
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
@@ -10,15 +10,24 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Invariance
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Independence
 
 /-!
-# The composite of two nebentypus-twisted slash sums, and the multiplicativity it yields
+# The composite of two nebentypus-twisted slash sums
 
 `HeckeSlash/Composition.lean` computes the composite of two *unweighted* slash sums, first over the
 representatives they are defined with and then over free families, and collapses it onto a single
-double coset. This file is the weighted counterpart of that development, and it carries it through
-to the end: the nebentypus-twisted Hecke operators **multiply**, which is the gap
-`HeckeSlash/Nebentypus/Ring.lean` records when it calls `twistedHeckeSlashRingLinearMap`
-"`ℤ`-linear in the ring element, but not known to be multiplicative, so this is not yet a ring
-action".
+double coset. This file is the weighted counterpart of that development, up to and including the
+operator statement: for a single pair of double cosets whose product set is a third, the twisted
+operators of `D₁` and `D₂` compose to the operator of `D₃` on the character space.
+
+⚠ That is a *generator-level* statement, and it is **not** the multiplicativity
+`HeckeSlash/Nebentypus/Ring.lean` records as missing. That gap is about
+`twistedHeckeSlashRingLinearMap : 𝕋 … →ₗ[ℤ] Module.End ℂ (ℍ → ℂ)`, over arbitrary elements of the
+Hecke ring and on all of `ℍ → ℂ`; this file proves only the single-double-coset case, only on
+`functionCharSpace k χ`, and only under the per-triple hypotheses `hD₃` and `hinj₃`. That map is
+untouched here and remains merely `ℤ`-linear. As in the untwisted file, the general
+multiplicity-weighted composite `∑_D m(D₁, D₂; D) · T_D` — and with it the ring homomorphism
+`𝕋 → Module.End` — is not proved here; it needs the count that each right coset of a fixed `D` is
+hit by the same number of pairs, together with the left/right handedness reconciliation that
+`DoubleCoset.multiplicity` requires.
 
 ## Why the weights multiply, and why that is the whole point
 
@@ -220,9 +229,10 @@ include hcover₁ hinj₁ hcover₂ hinj₂ in
 `χ`-eigenfunction `f` and families `(aᵢ)`, `(bⱼ)` of representatives of the right cosets of the two
 double cosets, all lying in `Δ₀(N)`,
 
-`W(W f) = ∑_{i,j} χ'(aᵢ bⱼ) • (f ∣[k] (aᵢ bⱼ))`,
+`twistedHeckeSlashSum k χ D₂ (twistedHeckeSlashSum k χ D₁ f) = ∑_{i,j} χ'(aᵢ bⱼ) • (f ∣[k] aᵢ bⱼ)`,
 
-the summand at `(i, j)` weighted by the character of the *product*.
+writing `χ'` for `delta0NebentypusChar N χ`: the summand at `(i, j)` is weighted by the character of
+the *product*.
 
 The weighted counterpart of `heckeSlashSum_heckeSlashSum_eq_sum_of_rightCosets`, and the free-family
 form of `twistedHeckeSlashSum_twistedHeckeSlashSum` above. The eigenfunction property is used twice,
@@ -257,11 +267,11 @@ include ha hb hcover₁ hinj₁ hcover₂ hinj₂ in
 when the product set is that coset and the products `aᵢ bⱼ` meet each of its right cosets exactly
 once.
 
-This is the collapse, and with it the twisted assignment is multiplicative rather than merely
-`ℤ`-linear — the gap `HeckeSlash/Nebentypus/Ring.lean` records. The weighted counterpart of
+This is the collapse, for a `χ`-eigenfunction `f` — the identity is false without `hf`, as the
+module docstring records. The weighted counterpart of
 `heckeSlashSum_heckeSlashSum_eq_heckeSlashSum`, and its two hypotheses play the same roles: `hD₃`
 says the product set is the single coset `D₃`, and `hinj₃` says the products have no right-coset
-collisions. Neither identifies `hinj₃` with the left-representative count of
+collisions. This does not identify `hinj₃` with the left-representative count used by
 `DoubleCoset.multiplicity`. The covering half that
 `twistedHeckeSlashSum_eq_sum_of_rightCosets` would otherwise need is automatic, by
 `doubleCoset_mul_doubleCoset_eq_iUnion_rightCosets`.
@@ -295,9 +305,9 @@ include ha hb hcover₁ hinj₁ hcover₂ hinj₂ in
 the single double coset `D₃` with no right-coset collisions among the products, the composite of
 the operators of `D₁` and `D₂` is the operator of `D₃`.
 
-This is the multiplicativity that `HeckeSlash/Nebentypus/Ring.lean` records as missing —
-`twistedHeckeSlashRingLinearMap` is there described as "`ℤ`-linear in the ring element, but not
-known to be multiplicative, so this is not yet a ring action". It is the weighted counterpart of
+This is the generator-level input that a multiplicativity proof for
+`twistedHeckeSlashRingLinearMap` would consume; it does not itself close that gap, which concerns
+arbitrary Hecke-ring elements on all of `ℍ → ℂ`. It is the weighted counterpart of
 `heckeSlashGamma1ModularFormEnd_mul_of_doubleCoset_eq_mul`, and it is stated on the character space
 for the same reason that one is stated on `ModularForm`: that is the carrier on which the
 hypothesis the underlying identity needs — here `f ∈ functionCharSpace`, there `Γ₁`-invariance —

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Composition.lean
@@ -64,7 +64,7 @@ reason: that is the carrier on which the hypothesis comes for free.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum`: the composite of two twisted sums, as
   a double sum over products of representatives weighted by the character of the product.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets`: the same
-  composite over *any* families of representatives lying in `Δ₀(N)`.
+  composite over *any* families of representatives of the right cosets.
 * `HeckeRing.GL2.twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum`: the collapse
   onto a single twisted sum, when the product set is one double coset and the products meet each
   of its right cosets once.
@@ -181,8 +181,7 @@ section Free
 
 variable (D₁ D₂ : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
   {ι κ : Type*}
-  (a : ι → GL (Fin 2) ℚ) (ha : ∀ i, a i ∈ Delta0 N)
-  (b : κ → GL (Fin 2) ℚ) (hb : ∀ j, b j ∈ Delta0 N)
+  (a : ι → GL (Fin 2) ℚ) (b : κ → GL (Fin 2) ℚ)
   (hcover₁ : doubleCoset (D₁.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
     ((Gamma0 N).map (mapGL ℚ)) =
     ⋃ i, MulOpposite.op (a i) • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
@@ -199,7 +198,7 @@ variable (D₁ D₂ : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma
 include hcover₁ hinj₁ hcover₂ hinj₂ in
 /-- **The multiplicativity of the twisted slash sum**, over any families of representatives. For a
 `χ`-eigenfunction `f` and families `(aᵢ)`, `(bⱼ)` of representatives of the right cosets of the two
-double cosets, all lying in `Δ₀(N)`,
+double cosets,
 
 `twistedHeckeSlashSum k χ D₂ (twistedHeckeSlashSum k χ D₁ f) = ∑_{i,j} χ'(aᵢ bⱼ) • (f ∣[k] aᵢ bⱼ)`,
 
@@ -218,23 +217,24 @@ theorem twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets [Fintype
     (f : ℍ → ℂ)
     (hf : f ∈ functionCharSpace k χ) :
     twistedHeckeSlashSum k χ D₂ (twistedHeckeSlashSum k χ D₁ f) =
-      ∑ i, ∑ j, (delta0NebentypusChar N χ ⟨a i * b j, mul_mem (ha i) (hb j)⟩ : ℂ) •
-        (f ∣[k] (a i * b j)) := by
-  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₂ b hb hcover₂ hinj₂ _
+      ∑ i, ∑ j, (delta0NebentypusChar N χ ⟨a i * b j,
+          mul_mem (mem_Delta0_of_cover D₁ hcover₁ i)
+            (mem_Delta0_of_cover D₂ hcover₂ j)⟩ : ℂ) • (f ∣[k] (a i * b j)) := by
+  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₂ b hcover₂ hinj₂ _
       (twistedHeckeSlashSum_mem_functionCharSpace k χ D₁ f hf), Finset.sum_comm]
   refine Finset.sum_congr rfl fun j _ ↦ ?_
-  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₁ a ha hcover₁ hinj₁ f hf,
+  rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₁ a hcover₁ hinj₁ f hf,
     SlashAction.sum_slash, Finset.smul_sum]
   refine Finset.sum_congr rfl fun i _ ↦ ?_
   rw [ModularForm.rat_smul_slash_of_det_pos k
-      (posDetInt_le_glpos 2 (Delta0_le_posDetInt N (hb j))) _ _,
+      (posDetInt_le_glpos 2 (Delta0_le_posDetInt N (mem_Delta0_of_cover D₂ hcover₂ j))) _ _,
     ← SlashAction.slash_mul k (a i) (b j) f, smul_smul, ← MulMemClass.mk_mul_mk, map_mul,
     Units.val_mul, mul_comm]
 
 variable [Finite ι] [Finite κ]
   (D₃ : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
 
-include ha hb hcover₁ hinj₁ hcover₂ hinj₂ in
+include hcover₁ hinj₁ hcover₂ hinj₂ in
 /-- **The composite of two twisted slash sums is the twisted slash sum of a single double coset**,
 when the product set is that coset and the products `aᵢ bⱼ` meet each of its right cosets exactly
 once.
@@ -265,14 +265,13 @@ theorem twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum
   let _ : Fintype ι := Fintype.ofFinite ι
   let _ : Fintype κ := Fintype.ofFinite κ
   rw [twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₃ (fun p : ι × κ ↦ a p.1 * b p.2)
-      (fun p ↦ mul_mem (ha p.1) (hb p.2))
       (hD₃.trans (doubleCoset_mul_doubleCoset_eq_iUnion_rightCosets a b hcover₁ hcover₂))
       hinj₃ f hf,
-    twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₁ D₂ a ha b hb
+    twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets k χ D₁ D₂ a b
       hcover₁ hinj₁ hcover₂ hinj₂ f hf,
     Fintype.sum_prod_type]
 
-include ha hb hcover₁ hinj₁ hcover₂ hinj₂ in
+include hcover₁ hinj₁ hcover₂ hinj₂ in
 /-- **The twisted Hecke operators multiply.** On the character space, and when the product set is
 the single double coset `D₃` with no right-coset collisions among the products, the composite of
 the operators of `D₁` and `D₂` is the operator of `D₃`.
@@ -301,8 +300,8 @@ theorem twistedHeckeSlashSumCharEnd_mul_of_doubleCoset_eq_mul
     twistedHeckeSlashSumCharEnd k χ D₂ * twistedHeckeSlashSumCharEnd k χ D₁ =
       twistedHeckeSlashSumCharEnd k χ D₃ := by
   ext f x
-  have := congrFun (twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum k χ D₁ D₂ a ha
-    b hb hcover₁ hinj₁ hcover₂ hinj₂ D₃ hD₃ hinj₃ f f.2) x
+  have := congrFun (twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum k χ D₁ D₂
+    a b hcover₁ hinj₁ hcover₂ hinj₂ D₃ hD₃ hinj₃ f f.2) x
   simpa [Module.End.mul_apply] using this
 
 end Free

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
@@ -79,6 +79,20 @@ variable (D : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map
 -- The enumeration `∑` needs, as in `Nebentypus/Basic.lean` and `Nebentypus/Composition.lean`.
 attribute [local instance] Fintype.ofFinite
 
+/-- **A covering family already lies in `Δ₀(N)`.** Each `aᵢ` lies in its own right coset, hence in
+the double coset of `D.out`, which the Hecke triple places back inside `Δ₀(N)`.
+
+So membership is not an extra hypothesis on the statements below: it is implied by the covering,
+and is stated through this lemma only so that the twisting character can be applied to `aᵢ` without
+rebuilding the proof term inside every statement. -/
+theorem mem_Delta0_of_cover {ι : Type*} {a : ι → GL (Fin 2) ℚ}
+    (hcover : doubleCoset (D.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+        ((Gamma0 N).map (mapGL ℚ)) =
+      ⋃ i, MulOpposite.op (a i) • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+        Set (GL (Fin 2) ℚ))) (i : ι) : a i ∈ Delta0 N :=
+  IsHeckeTriple.mem_of_mem_doubleCoset D.out.2
+    (hcover ▸ Set.mem_iUnion_of_mem i (mem_own_rightCoset _ _))
+
 /-- **The twisted slash sum of a `χ`-eigenfunction is the weighted sum over any decomposition of
 the double coset into right cosets.** If the right cosets `Γ₀(N) aᵢ` are pairwise distinct and
 cover `Γ₀(N) D.out Γ₀(N)`, and every `aᵢ` lies in `Δ₀(N)`, then `twistedHeckeSlashSum k χ D f` is
@@ -87,15 +101,12 @@ cover `Γ₀(N) D.out Γ₀(N)`, and every `aᵢ` lies in `Δ₀(N)`, then `twis
 So the twisted operator, like the untwisted one, is attached to the double coset rather than to
 the representatives `twistedHeckeSlashSum` happens to choose.
 
-The hypothesis `ha` has no untwisted counterpart and is forced by the weight: an arbitrary
-representative must lie in `Δ₀(N)` for the twisting character to be applied to it at all, whereas
-the bare slash of `heckeSlashSum_eq_sum_of_rightCosets` asks nothing of `aᵢ`. The chosen
-representatives satisfy it by `rightCosetRep_mem_Delta0`.
-
-The proof is the untwisted one with its per-summand step replaced: the comparison of the two
-enumerations is identical, and only `smul_slash_eq_of_rightCoset_eq` differs. -/
+Unlike an earlier form of this statement, membership of the `aᵢ` in `Δ₀(N)` is **not** a
+hypothesis: `hcover` already forces it, by `mem_Delta0_of_cover` above. The character is applied to
+`aᵢ` through that derived term, so a caller supplies only the cover and the injectivity, exactly as
+in the untwisted `heckeSlashSum_eq_sum_of_rightCosets`. -/
 theorem twistedHeckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι]
-    (a : ι → GL (Fin 2) ℚ) (ha : ∀ i, a i ∈ Delta0 N)
+    (a : ι → GL (Fin 2) ℚ)
     (hcover : doubleCoset (D.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
         ((Gamma0 N).map (mapGL ℚ)) =
       ⋃ i, MulOpposite.op (a i) • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
@@ -104,7 +115,8 @@ theorem twistedHeckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι]
       (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)))
     (f : ℍ → ℂ) (hf : f ∈ functionCharSpace k χ) :
     twistedHeckeSlashSum k χ D f =
-      ∑ i, (delta0NebentypusChar N χ ⟨a i, ha i⟩ : ℂ) • (f ∣[k] a i) := by
+      ∑ i, (delta0NebentypusChar N χ ⟨a i, mem_Delta0_of_cover D hcover i⟩ : ℂ) •
+        (f ∣[k] a i) := by
   classical
   -- The coset bookkeeping is not twisted: matching this family against the one
   -- `twistedHeckeSlashSum` sums over involves no weight and no character, so it is
@@ -114,7 +126,7 @@ theorem twistedHeckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι]
   rw [twistedHeckeSlashSum_def]
   refine (Fintype.sum_bijective φ hbij _ _ fun i ↦ ?_).symm
   rw [nebentypusWeight_def]
-  exact (smul_slash_eq_of_rightCoset_eq k χ f hf (ha i)
+  exact (smul_slash_eq_of_rightCoset_eq k χ f hf (mem_Delta0_of_cover D hcover i)
     (rightCosetRep_mem_Delta0 D (φ i)) (hφ i)).symm
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
@@ -106,66 +106,11 @@ theorem twistedHeckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι]
     twistedHeckeSlashSum k χ D f =
       ∑ i, (delta0NebentypusChar N χ ⟨a i, ha i⟩ : ℂ) • (f ∣[k] a i) := by
   classical
-  have hcover' : doubleCoset (D.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
-      ((Gamma0 N).map (mapGL ℚ)) =
-      ⋃ v, MulOpposite.op (rightCosetRep D v) •
-        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := by
-    simpa only [rightCosetRep_def] using
-      doubleCoset_eq_iUnion_rightCosets _ _ (D.out : GL (Fin 2) ℚ)
-  have hinj' : Function.Injective fun v : DecompQuotient ((Gamma0 N).map (mapGL ℚ))
-      ((Gamma0 N).map (mapGL ℚ)) (D.out : GL (Fin 2) ℚ)⁻¹ ↦
-      MulOpposite.op (rightCosetRep D v) •
-        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := by
-    simpa only [rightCosetRep_def] using
-      op_mul_out_inv_smul_injective _ _ (D.out : GL (Fin 2) ℚ)
-  have hself : ∀ x : GL (Fin 2) ℚ, x ∈ MulOpposite.op x •
-      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := fun x ↦
-    (mem_rightCoset_iff x).mpr (by rw [mul_inv_cancel]; exact one_mem _)
-  have hmatch : ∀ x y : GL (Fin 2) ℚ, x ∈ MulOpposite.op y •
-      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) →
-      MulOpposite.op x • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
-          Set (GL (Fin 2) ℚ)) =
-        MulOpposite.op y • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
-          Set (GL (Fin 2) ℚ)) := fun x y hxy ↦
-    (rightCoset_eq_iff _).mpr (by simpa using inv_mem ((mem_rightCoset_iff y).mp hxy))
-  have key : ∀ i, ∃ v, MulOpposite.op (a i) •
-      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
-      MulOpposite.op (rightCosetRep D v) •
-        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := by
-    intro i
-    have hmem : a i ∈ doubleCoset (D.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
-        ((Gamma0 N).map (mapGL ℚ)) := by
-      rw [hcover]; exact Set.mem_iUnion_of_mem i (hself (a i))
-    rw [hcover'] at hmem
-    obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hmem
-    exact ⟨v, hmatch _ _ hv⟩
-  have key' : ∀ v, ∃ i, MulOpposite.op (rightCosetRep D v) •
-      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
-      MulOpposite.op (a i) •
-        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := by
-    intro v
-    have hmem : rightCosetRep D v ∈ doubleCoset (D.out : GL (Fin 2) ℚ)
-        ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) := by
-      rw [hcover']; exact Set.mem_iUnion_of_mem v (hself (rightCosetRep D v))
-    rw [hcover] at hmem
-    obtain ⟨i, hi⟩ := Set.mem_iUnion.mp hmem
-    exact ⟨i, hmatch _ _ hi⟩
-  obtain ⟨φ, hφ⟩ : ∃ φ : ι → DecompQuotient ((Gamma0 N).map (mapGL ℚ))
-      ((Gamma0 N).map (mapGL ℚ)) (D.out : GL (Fin 2) ℚ)⁻¹, ∀ i,
-      MulOpposite.op (a i) •
-          (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
-        MulOpposite.op (rightCosetRep D (φ i)) •
-          (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) :=
-    ⟨fun i ↦ (key i).choose, fun i ↦ (key i).choose_spec⟩
-  have hcoset : ∀ i j, φ i = φ j → MulOpposite.op (a i) •
-      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
-      MulOpposite.op (a j) •
-        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) :=
-    fun i j hij ↦ by rw [hφ i, hφ j, hij]
-  have hbij : Function.Bijective φ := by
-    refine ⟨fun i j hij ↦ hinj (hcoset i j hij), fun v ↦ ?_⟩
-    obtain ⟨i, hi⟩ := key' v
-    exact ⟨i, (hinj' (hi.trans (hφ i))).symm⟩
+  -- The coset bookkeeping is not twisted: matching this family against the one
+  -- `twistedHeckeSlashSum` sums over involves no weight and no character, so it is
+  -- `exists_bijective_rightCosetRep_smul_eq` of `HeckeSlash/Independence.lean`, shared with the
+  -- unweighted `heckeSlashSum_eq_sum_of_rightCosets`. Only the per-summand step below is twisted.
+  obtain ⟨φ, hbij, hφ⟩ := exists_bijective_rightCosetRep_smul_eq D a hcover hinj
   rw [twistedHeckeSlashSum_def]
   refine (Fintype.sum_bijective φ hbij _ _ fun i ↦ ?_).symm
   rw [nebentypusWeight_def]

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Independence.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Independence
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Nebentypus.Invariance
+
+/-!
+# The twisted slash sum depends only on the double coset
+
+`HeckeSlash/Independence.lean` proves that `heckeSlashSum k D f` is `∑ᵢ f ∣[k] aᵢ` for *any*
+family `(aᵢ)` of representatives of the right cosets of `Γ₁ δ Γ₂`, provided `f` is `Γ₁`-invariant.
+This file is the nebentypus-twisted counterpart.
+
+## Why this is a theorem and not bookkeeping
+
+In the untwisted setting a change of representatives moves each summand `f ∣[k] aᵢ` by an element
+of `Γ₁`, and invariance absorbs it. Here `f` is only a `χ`-eigenfunction, so the slash genuinely
+changes — and what repairs it is the *weight*: the summand carries `delta0NebentypusChar χ` of its
+own representative, and that character factor is exactly the inverse of the eigenvalue the slash
+picks up. So the weighted summand, unlike the bare slash, is a function of the right coset alone.
+
+That cancellation is `delta0NebentypusChar_smul_slash_mapGL_mul` of
+`HeckeSlash/Nebentypus/Invariance.lean`, which states it for a representative presented as
+`γ · x`. The only work here is to feed it a right-coset equality instead, and then to run the
+untwisted file's comparison of two enumerations unchanged.
+
+## Main results
+
+* `HeckeRing.GL2.smul_slash_eq_of_rightCoset_eq`: the weighted slash of a `χ`-eigenfunction
+  depends only on the right coset `Γ₀(N) x`.
+* `HeckeRing.GL2.twistedHeckeSlashSum_eq_sum_of_rightCosets`: `twistedHeckeSlashSum k χ D f` is
+  the weighted sum over any family of representatives of the right cosets.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  §3.4.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup DoubleCoset
+  HeckeRing.GLn
+
+open scoped MatrixGroups ModularForm Pointwise
+
+namespace HeckeRing.GL2
+
+variable {N : ℕ} (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) [NeZero N]
+
+omit [NeZero N] in
+/-- **The weighted slash depends only on the right coset.** For a `χ`-eigenfunction `f` and
+representatives `x`, `y` of `Δ₀(N)` lying in the same right coset of `Γ₀(N)`, the weighted slashes
+agree.
+
+This is the twisted counterpart of `slash_eq_of_rightCoset_eq`, and it is where the whole content
+of the independence below sits: there invariance makes the bare slash coset-dependent, here it is
+the character weight that does it. The cancellation itself is
+`delta0NebentypusChar_smul_slash_mapGL_mul`; all this adds is the passage from a right-coset
+equality to the factorisation `y = γ · x` that lemma consumes. -/
+theorem smul_slash_eq_of_rightCoset_eq (f : ℍ → ℂ) (hf : f ∈ functionCharSpace k χ)
+    {x y : GL (Fin 2) ℚ} (hx : x ∈ Delta0 N) (hy : y ∈ Delta0 N)
+    (h : MulOpposite.op x • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+        Set (GL (Fin 2) ℚ)) =
+      MulOpposite.op y • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+        Set (GL (Fin 2) ℚ))) :
+    (delta0NebentypusChar N χ ⟨y, hy⟩ : ℂ) • (f ∣[k] y) =
+      (delta0NebentypusChar N χ ⟨x, hx⟩ : ℂ) • (f ∣[k] x) := by
+  obtain ⟨γ, hγ, hmap⟩ := Subgroup.mem_map.mp ((rightCoset_eq_iff _).mp h)
+  exact delta0NebentypusChar_smul_slash_mapGL_mul k χ f hf ⟨γ, hγ⟩ hx hy
+    (by rw [hmap, inv_mul_cancel_right])
+
+variable (D : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
+
+-- The enumeration `∑` needs, as in `Nebentypus/Basic.lean` and `Nebentypus/Composition.lean`.
+attribute [local instance] Fintype.ofFinite
+
+/-- **The twisted slash sum of a `χ`-eigenfunction is the weighted sum over any decomposition of
+the double coset into right cosets.** If the right cosets `Γ₀(N) aᵢ` are pairwise distinct and
+cover `Γ₀(N) D.out Γ₀(N)`, and every `aᵢ` lies in `Δ₀(N)`, then `twistedHeckeSlashSum k χ D f` is
+`∑ᵢ χ'(aᵢ) • (f ∣[k] aᵢ)`.
+
+So the twisted operator, like the untwisted one, is attached to the double coset rather than to
+the representatives `twistedHeckeSlashSum` happens to choose.
+
+The hypothesis `ha` has no untwisted counterpart and is forced by the weight: an arbitrary
+representative must lie in `Δ₀(N)` for the twisting character to be applied to it at all, whereas
+the bare slash of `heckeSlashSum_eq_sum_of_rightCosets` asks nothing of `aᵢ`. The chosen
+representatives satisfy it by `rightCosetRep_mem_Delta0`.
+
+The proof is the untwisted one with its per-summand step replaced: the comparison of the two
+enumerations is identical, and only `smul_slash_eq_of_rightCoset_eq` differs. -/
+theorem twistedHeckeSlashSum_eq_sum_of_rightCosets {ι : Type*} [Fintype ι]
+    (a : ι → GL (Fin 2) ℚ) (ha : ∀ i, a i ∈ Delta0 N)
+    (hcover : doubleCoset (D.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+        ((Gamma0 N).map (mapGL ℚ)) =
+      ⋃ i, MulOpposite.op (a i) • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+        Set (GL (Fin 2) ℚ)))
+    (hinj : Function.Injective fun i ↦ MulOpposite.op (a i) •
+      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)))
+    (f : ℍ → ℂ) (hf : f ∈ functionCharSpace k χ) :
+    twistedHeckeSlashSum k χ D f =
+      ∑ i, (delta0NebentypusChar N χ ⟨a i, ha i⟩ : ℂ) • (f ∣[k] a i) := by
+  classical
+  have hcover' : doubleCoset (D.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+      ((Gamma0 N).map (mapGL ℚ)) =
+      ⋃ v, MulOpposite.op (rightCosetRep D v) •
+        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := by
+    simpa only [rightCosetRep_def] using
+      doubleCoset_eq_iUnion_rightCosets _ _ (D.out : GL (Fin 2) ℚ)
+  have hinj' : Function.Injective fun v : DecompQuotient ((Gamma0 N).map (mapGL ℚ))
+      ((Gamma0 N).map (mapGL ℚ)) (D.out : GL (Fin 2) ℚ)⁻¹ ↦
+      MulOpposite.op (rightCosetRep D v) •
+        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := by
+    simpa only [rightCosetRep_def] using
+      op_mul_out_inv_smul_injective _ _ (D.out : GL (Fin 2) ℚ)
+  have hself : ∀ x : GL (Fin 2) ℚ, x ∈ MulOpposite.op x •
+      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := fun x ↦
+    (mem_rightCoset_iff x).mpr (by rw [mul_inv_cancel]; exact one_mem _)
+  have hmatch : ∀ x y : GL (Fin 2) ℚ, x ∈ MulOpposite.op y •
+      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) →
+      MulOpposite.op x • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+          Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op y • (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) :
+          Set (GL (Fin 2) ℚ)) := fun x y hxy ↦
+    (rightCoset_eq_iff _).mpr (by simpa using inv_mem ((mem_rightCoset_iff y).mp hxy))
+  have key : ∀ i, ∃ v, MulOpposite.op (a i) •
+      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
+      MulOpposite.op (rightCosetRep D v) •
+        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := by
+    intro i
+    have hmem : a i ∈ doubleCoset (D.out : GL (Fin 2) ℚ) ((Gamma0 N).map (mapGL ℚ))
+        ((Gamma0 N).map (mapGL ℚ)) := by
+      rw [hcover]; exact Set.mem_iUnion_of_mem i (hself (a i))
+    rw [hcover'] at hmem
+    obtain ⟨v, hv⟩ := Set.mem_iUnion.mp hmem
+    exact ⟨v, hmatch _ _ hv⟩
+  have key' : ∀ v, ∃ i, MulOpposite.op (rightCosetRep D v) •
+      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
+      MulOpposite.op (a i) •
+        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) := by
+    intro v
+    have hmem : rightCosetRep D v ∈ doubleCoset (D.out : GL (Fin 2) ℚ)
+        ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)) := by
+      rw [hcover']; exact Set.mem_iUnion_of_mem v (hself (rightCosetRep D v))
+    rw [hcover] at hmem
+    obtain ⟨i, hi⟩ := Set.mem_iUnion.mp hmem
+    exact ⟨i, hmatch _ _ hi⟩
+  obtain ⟨φ, hφ⟩ : ∃ φ : ι → DecompQuotient ((Gamma0 N).map (mapGL ℚ))
+      ((Gamma0 N).map (mapGL ℚ)) (D.out : GL (Fin 2) ℚ)⁻¹, ∀ i,
+      MulOpposite.op (a i) •
+          (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
+        MulOpposite.op (rightCosetRep D (φ i)) •
+          (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) :=
+    ⟨fun i ↦ (key i).choose, fun i ↦ (key i).choose_spec⟩
+  have hcoset : ∀ i j, φ i = φ j → MulOpposite.op (a i) •
+      (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) =
+      MulOpposite.op (a j) •
+        (((Gamma0 N).map (mapGL ℚ) : Subgroup (GL (Fin 2) ℚ)) : Set (GL (Fin 2) ℚ)) :=
+    fun i j hij ↦ by rw [hφ i, hφ j, hij]
+  have hbij : Function.Bijective φ := by
+    refine ⟨fun i j hij ↦ hinj (hcoset i j hij), fun v ↦ ?_⟩
+    obtain ⟨i, hi⟩ := key' v
+    exact ⟨i, (hinj' (hi.trans (hφ i))).symm⟩
+  rw [twistedHeckeSlashSum_def]
+  refine (Fintype.sum_bijective φ hbij _ _ fun i ↦ ?_).symm
+  rw [nebentypusWeight_def]
+  exact (smul_slash_eq_of_rightCoset_eq k χ f hf (ha i)
+    (rightCosetRep_mem_Delta0 D (φ i)) (hφ i)).symm
+
+end HeckeRing.GL2
+
+end

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Nebentypus/Invariance.lean
@@ -42,6 +42,9 @@ conclusion asserts.
   representative carries the same weighted slash as the chosen one.
 * `HeckeRing.GL2.twistedHeckeSlashSum_mem_functionCharSpace`: **the twisted slash sum of a
   `χ`-invariant function is `χ`-invariant.**
+* `HeckeRing.GL2.twistedHeckeSlashSumCharEnd`, `HeckeRing.GL2.coe_twistedHeckeSlashSumCharEnd`: the
+  operator restricted to that invariant subspace, which is the carrier the composition
+  results of `Nebentypus/Composition.lean` state their multiplicativity on.
 
 ## Provenance
 
@@ -238,6 +241,26 @@ theorem twistedHeckeSlashSum_mem_functionCharSpace (f : ℍ → ℂ)
     Finset.smul_sum]
   exact Fintype.sum_equiv (MulAction.toPerm (⟨_, hmem⟩ : ↥((Gamma0 N).map (mapGL ℚ)))⁻¹) _ _
     fun v ↦ by simpa only [MulAction.toPerm_apply] using hperm v
+
+/-- **The twisted slash sum as an endomorphism of the character space.** `twistedHeckeSlashSumEnd`
+is an endomorphism of *all* of `ℍ → ℂ`, and its own docstring records that this is the wrong
+carrier: the point of the weighting is that the twisted sum preserves the `χ`-eigenspace. It does,
+by `twistedHeckeSlashSum_mem_functionCharSpace`, so it restricts — and on this carrier, unlike on
+`ℍ → ℂ`, the operators multiply. -/
+noncomputable def twistedHeckeSlashSumCharEnd
+    (D : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ))) :
+    Module.End ℂ (functionCharSpace k χ) :=
+  (twistedHeckeSlashSumEnd k χ D).restrict fun f hf ↦ by
+    simpa using twistedHeckeSlashSum_mem_functionCharSpace k χ D f hf
+
+/-- The restricted endomorphism is the twisted slash sum on underlying functions. -/
+@[simp] lemma coe_twistedHeckeSlashSumCharEnd
+    (D : HeckeCoset (Delta0 N) ((Gamma0 N).map (mapGL ℚ)) ((Gamma0 N).map (mapGL ℚ)))
+    (f : functionCharSpace k χ) :
+    (twistedHeckeSlashSumCharEnd k χ D f : ℍ → ℂ) = twistedHeckeSlashSum k χ D f := by
+  -- `twistedHeckeSlashSumEnd`'s body is sealed to this module, so the coercion is unfolded through
+  -- its own interface lemma rather than by `rfl`.
+  simp [twistedHeckeSlashSumCharEnd]
 
 end HeckeRing.GL2
 


### PR DESCRIPTION
`HeckeSlash/Nebentypus/Ring.lean` describes `twistedHeckeSlashRingLinearMap` as "`ℤ`-linear in the
ring element, but **not known to be multiplicative**, so this is not yet a ring action", and
`Nebentypus/Basic.lean` says of `twistedHeckeSlashSumEnd`:

> ⚠ This is an endomorphism of *all* functions `ℍ → ℂ`, not of the character space
> `modFormCharSpace k χ`. That the twisted sum is well defined on, and preserves, that subspace is
> the pay-off of the weighting, and — as everywhere in this file — it is not proved here.

This PR proves both.

## Why it is a theorem and not bookkeeping

In the untwisted setting, changing right-coset representatives moves each summand by an element of
the group and invariance absorbs it. Here `f` is only a `χ`-eigenfunction, so the slash genuinely
changes — and what repairs it is the *weight*: each summand carries `delta0NebentypusChar χ` of its
own representative, and that factor is exactly the inverse of the eigenvalue the slash picks up. So
the *weighted* summand, unlike the bare slash, is a function of the right coset alone.

That cancellation is already on main, as `delta0NebentypusChar_smul_slash_mapGL_mul`
(`Nebentypus/Invariance.lean:97`, from #4853), whose own docstring states the point. The work here
is to feed it a right-coset equality rather than a factorisation, and then to run main's untwisted
comparison of two enumerations unchanged.

## What is added

**`ModularForms/HeckeSlash/Nebentypus/Independence.lean`** (new file), the twisted counterpart of
`HeckeSlash/Independence.lean`:

* `smul_slash_eq_of_rightCoset_eq` — the weighted slash depends only on the right coset `Γ₀(N) x`.
* `twistedHeckeSlashSum_eq_sum_of_rightCosets` — the twisted sum is the weighted sum over **any**
  family of representatives of the right cosets.

**`ModularForms/HeckeSlash/Nebentypus/Composition.lean`** (extended, mirroring the
`Chosen / Composite / Free` structure of `HeckeSlash/Composition.lean`):

* `twistedHeckeSlashSumCharEnd`, `coe_twistedHeckeSlashSumCharEnd` — the twisted sum restricted to
  the character space, which it preserves.
* `twistedHeckeSlashSum_twistedHeckeSlashSum_eq_sum_of_rightCosets` — the composite over free
  families, weighted by the character of the product `aᵢbⱼ`.
* `twistedHeckeSlashSum_twistedHeckeSlashSum_eq_twistedHeckeSlashSum` — the collapse onto a single
  double coset.
* `twistedHeckeSlashSumCharEnd_mul_of_doubleCoset_eq_mul` — **the pay-off**: the operators multiply.

## Why the character space is the carrier

The operator identity is **false** on `ℍ → ℂ`, because the underlying identity needs
`f ∈ functionCharSpace`. Main meets the same obstruction untwisted and answers it by stating its
`Gamma1` section on `ModularForm`/`CuspForm`, where invariance is free. The twisted analogue of
"where the hypothesis is free" is the character space itself, and `functionCharSpace` is a genuine
invariant subspace by `twistedHeckeSlashSum_mem_functionCharSpace` (#4853) — which is exactly what
`LinearMap.restrict` consumes.

## One hypothesis the untwisted statements do not carry

The free-family results ask `∀ i, aᵢ ∈ Δ₀(N)`, where `heckeSlashSum_eq_sum_of_rightCosets` asks
nothing of its representatives. That asymmetry is forced rather than incidental: the twisting
character is a `MonoidHom` **on `Δ₀(N)`**, so a representative not known to lie there cannot be
weighted at all — the statement could not be formed without it. It is not a proof convenience that
could be moved into the goal. The chosen representatives discharge it by `rightCosetRep_mem_Delta0`,
and the products `aᵢbⱼ` by `mul_mem`, so no caller pays for it.

## What this deliberately does not do

It does not upgrade `twistedHeckeSlashRingLinearMap` to a ring homomorphism. That needs
multiplicativity for arbitrary elements of the Hecke ring, not just single-coset generators, which
means decomposing a product of formal `ℤ`-combinations into double cosets — the Hecke ring's own
multiplication theory. The per-triple hypotheses `hD₃` and `hinj₃` supplied here would have to be
discharged uniformly there. That is a separate topic and the natural successor to this one; landing
the generator case on its own is the one-topic-per-PR reading.

## One hypothesis of the source is deliberately dropped

AINTLIB's `twistedHeckeSlashGen_comp` (`:801`) assumes the two Hecke-ring generators commute
(`T_single D₂ 1 * T_single D₁ 1 = T_single D₁ 1 * T_single D₂ 1`), because it states the pay-off at
Hecke-*ring* level where the product order is ambiguous. Main's untwisted analogue
`heckeSlashGamma1ModularFormEnd_mul_of_doubleCoset_eq_mul` carries **no** commutativity hypothesis
and fixes the order in the statement instead: "`Module.End` multiplies by composition, so `D₁` acts
first on the right-hand side of the underlying identity … that is the order recorded here." This PR
follows main, so the hypothesis has nothing left to do and is not reproduced.

## Also in the diff

`open scoped Pointwise` is added to `Nebentypus/Composition.lean`. #4891 did not need it; the
free-family cover and injectivity hypotheses are stated with the pointwise action on sets.

## Provenance

Adapted from the AINTLIB `LeanModularForms` project
(`LeanModularForms/HeckeRIngs/GL2/Unified/TwistedHeckeRing.lean`, Chris Birkbeck, Apache-2.0,
<https://github.com/CBirkbeck/AINTLIB> @ `2baa76f742bdb4fb8ee323fabba41203bd390e08`), lines 494–826.

Deliberately **not** ported, because this repository's substrate supersedes them:

* `:629`, `:661`, `:710` — the fibre block (`twisted_fiber_filter_card_eq`,
  `twisted_filtered_sum_collapse_of_qOf`, `twistedHeckeSlashGen_fiber_sum`). These are
  `Finset.univ.filter` counts over `mulMap`; main already has the same bookkeeping untwisted and
  strictly more general, in `HeckeSlash/Composition.lean` together with the whole
  `HeckeRing/Multiplicity` module (`DoubleCoset.multiplicity`) and
  `doubleCoset_mul_doubleCoset_eq_iUnion_rightCosets`. Main also already reconciles the left/right
  handedness the source redoes by hand.
* `:478` `delta0NebentypusWeight_mul_eq_tripleDelta` — `delta0NebentypusChar` is a `MonoidHom`, so
  this is `map_mul`, used inline.
* `:816` `twistedHeckeSlashExtGen_zsmul` — `map_zsmul` of the linear map of #4652.

Note on naming: the source's `twistedHeckeSlashGen` is this repository's `twistedHeckeSlashSum`
(#4652); the source name survives here only in provenance prose.

## Roadmap target

`TauCetiRoadmap/ModularForms/README.md`, Layer 2 **"(b) The action on forms"** (`:399-421`);
provenance at `:1458-1464`.

## References

* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971], §3.4
  — the displayed computation preceding Proposition 3.37.

Roadmap: ModularForms
