### PR TITLE
fix(DedekindDomain): restore the review round #4867's merge dropped, and answer its final board

### DIFF
--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -7,7 +7,7 @@ module
 
 public import Mathlib.NumberTheory.NumberField.Completion.FinitePlace
 public import TauCeti.RingTheory.DedekindDomain.Ideal
-public import TauCeti.RingTheory.DedekindDomain.SelmerGroup
+public import TauCeti.RingTheory.DedekindDomain.ValuationOfNeZero
 
 /-!
 # Extension of adic completions along an extension of Dedekind domains
@@ -38,10 +38,12 @@ global étale algebra with its images in the completions passes through exactly 
 
 * `IsDedekindDomain.HeightOneSpectrum.valuation_maximalIdeal_adicCompletionIntegers`: the
   valuation attached to the maximal ideal of `𝒪_v` is the valuation of `K_v`.
+* `IsDedekindDomain.HeightOneSpectrum.valuation_adicCompletionIntegers`: the same identification
+  at an arbitrary height-one prime of `𝒪_v`, for every element of `K_v`.
 * `IsDedekindDomain.HeightOneSpectrum.valuationOfNeZero_maximalIdeal_adicCompletionIntegers` and
-  `IsDedekindDomain.HeightOneSpectrum.valuation_adicCompletion_algebraMap`: the same identification
-  in the two forms the square-class conditions of the `2`-descent are stated in — on units of `K`,
-  and at an arbitrary height-one prime of `𝒪_v`.
+  `IsDedekindDomain.HeightOneSpectrum.valuation_adicCompletion_algebraMap`: the two restrictions
+  of it the square-class conditions of the `2`-descent are stated in — on units of `K`, and on the
+  image of `K`.
 * `IsDedekindDomain.HeightOneSpectrum.valued_adicCompletionExtension`: along the extension the
   valuation is raised to the ramification index.
 * `IsDedekindDomain.HeightOneSpectrum.comap_maximalIdeal_adicCompletionIntegersExtension`: the
@@ -163,11 +165,19 @@ theorem valuationOfNeZero_maximalIdeal_adicCompletionIntegers (u : Kˣ) :
   exact v.valuedAdicCompletion_eq_valuation' _
 
 /-- Any height-one prime `P` of the valuation ring `𝒪_v` — necessarily its maximal ideal —
-induces on `K` the valuation `v` itself. -/
+induces on `K_v` the valuation of the completion. -/
+theorem valuation_adicCompletionIntegers (P : HeightOneSpectrum (v.adicCompletionIntegers K))
+    (x : v.adicCompletion K) :
+    P.valuation (v.adicCompletion K) x = Valued.v x := by
+  rw [P.eq_maximalIdeal, valuation_maximalIdeal_adicCompletionIntegers]
+
+/-- Any height-one prime `P` of the valuation ring `𝒪_v` — necessarily its maximal ideal —
+induces on `K` the valuation `v` itself: the restriction to `K` of
+`valuation_adicCompletionIntegers`. -/
 theorem valuation_adicCompletion_algebraMap (P : HeightOneSpectrum (v.adicCompletionIntegers K))
     (z : K) :
     P.valuation (v.adicCompletion K) (algebraMap K (v.adicCompletion K) z) = v.valuation K z := by
-  rw [P.eq_maximalIdeal, valuation_maximalIdeal_adicCompletionIntegers]
+  rw [valuation_adicCompletionIntegers]
   exact v.valuedAdicCompletion_eq_valuation' z
 
 end IsDedekindDomain.HeightOneSpectrum
@@ -278,6 +288,7 @@ lemma valued_adicCompletionExtension (x : v.adicCompletion K) :
   exact valuation_liesOver (K := K) L v w (WithVal.equiv (v.valuation K) a)
 
 /-- The extension maps the ring of integers of `K_v` into the ring of integers of `L_w`. -/
+@[simp]
 lemma adicCompletionExtension_mem_adicCompletionIntegers (x : v.adicCompletionIntegers K) :
     adicCompletionExtension K L v w (x : v.adicCompletion K) ∈ w.adicCompletionIntegers L := by
   rw [mem_adicCompletionIntegers, valued_adicCompletionExtension]

--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -118,8 +118,11 @@ theorem valued_algebraMap_eq_exp_neg_one_of_irreducible {π : v.adicCompletionIn
 the valuation of the completion.
 
 This is what lets a condition stated at the height-one primes of `𝒪_v` be read as a condition on
-`K_v`: `𝒪_v` is a discrete valuation ring, so it has exactly one, and it induces `Valued.v`. -/
-@[simp]
+`K_v`: `𝒪_v` is a discrete valuation ring, so it has exactly one, and it induces `Valued.v`.
+
+Not `@[simp]`: this is the special case `P = IsDiscreteValuationRing.maximalIdeal _` of
+`valuation_adicCompletionIntegers`, which carries the annotation instead. With both marked, the
+`simpNF` linter rejects this one — "simp can prove this" — because the general form subsumes it. -/
 theorem valuation_maximalIdeal_adicCompletionIntegers (x : v.adicCompletion K) :
     (IsDiscreteValuationRing.maximalIdeal (v.adicCompletionIntegers K)).valuation
       (v.adicCompletion K) x = Valued.v x := by
@@ -166,6 +169,7 @@ theorem valuationOfNeZero_maximalIdeal_adicCompletionIntegers (u : Kˣ) :
 
 /-- Any height-one prime `P` of the valuation ring `𝒪_v` — necessarily its maximal ideal —
 induces on `K_v` the valuation of the completion. -/
+@[simp]
 theorem valuation_adicCompletionIntegers (P : HeightOneSpectrum (v.adicCompletionIntegers K))
     (x : v.adicCompletion K) :
     P.valuation (v.adicCompletion K) x = Valued.v x := by

--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -38,6 +38,10 @@ global étale algebra with its images in the completions passes through exactly 
 
 * `IsDedekindDomain.HeightOneSpectrum.valuation_maximalIdeal_adicCompletionIntegers`: the
   valuation attached to the maximal ideal of `𝒪_v` is the valuation of `K_v`.
+* `IsDedekindDomain.HeightOneSpectrum.valuationOfNeZero_maximalIdeal_adicCompletionIntegers` and
+  `IsDedekindDomain.HeightOneSpectrum.valuation_adicCompletion_algebraMap`: the same identification
+  in the two forms the square-class conditions of the `2`-descent are stated in — on units of `K`,
+  and at an arbitrary height-one prime of `𝒪_v`.
 * `IsDedekindDomain.HeightOneSpectrum.valued_adicCompletionExtension`: along the extension the
   valuation is raised to the ramification index.
 * `IsDedekindDomain.HeightOneSpectrum.comap_maximalIdeal_adicCompletionIntegersExtension`: the
@@ -95,9 +99,11 @@ variable {R : Type*} [CommRing R] [IsDedekindDomain R]
   {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K] (v : HeightOneSpectrum R)
 
 /-- An irreducible element of the ring of integers of a completion has valuation `exp (-1)`. -/
-theorem valued_irreducible_adicCompletionIntegers {π : v.adicCompletionIntegers K}
+theorem valued_algebraMap_eq_exp_neg_one_of_irreducible {π : v.adicCompletionIntegers K}
     (hπ : Irreducible π) :
     Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) π) = exp (-1) := by
+  -- `v.adicCompletionIntegers K` is by definition `Valued.v.valuationSubring`, which is what lets
+  -- `π`'s maximal ideal be retyped as an ideal of the valuation subring here.
   have hgen : IsLocalRing.maximalIdeal (Valued.v : Valuation (v.adicCompletion K)
       ℤᵐ⁰).valuationSubring = Ideal.span {π} := hπ.maximalIdeal_eq
   have huni := Valuation.isUniformizer_of_maximalIdeal_eq_span
@@ -134,13 +140,13 @@ theorem valuation_maximalIdeal_adicCompletionIntegers (x : v.adicCompletion K) :
     simp [IsDiscreteValuationRing.maximalIdeal]
   have hu2 : Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K)
       (u : v.adicCompletionIntegers K)) = 1 :=
-    (Valuation.valuationSubring.integers (v := Valued.v)).valuation_unit u
+    (adicCompletionIntegers.integers K v).valuation_unit u
   have hπ1 : (IsDiscreteValuationRing.maximalIdeal
       (v.adicCompletionIntegers K)).intValuation π = exp (-1) :=
     (IsDiscreteValuationRing.maximalIdeal _).intValuation_singleton hπ.ne_zero
       hπ.maximalIdeal_eq
   have hπ2 : Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) π) =
-      exp (-1) := v.valued_irreducible_adicCompletionIntegers hπ
+      exp (-1) := v.valued_algebraMap_eq_exp_neg_one_of_irreducible hπ
   simp only [map_mul, map_pow]
   rw [hu1, hu2, hπ1, hπ2]
 
@@ -189,8 +195,8 @@ noncomputable def adicCompletionExtension : v.adicCompletion K →+* w.adicCompl
       (uniformContinuous_algebraMap_liesOver (K := K) (L := L) v w).continuous).comp
       (adicCompletion.equiv K v).toRingHom
 
-/-- The completion of `x : K_v` under `adicCompletionExtension` is the base change of its
-underlying element of the completion of `WithVal (v.valuation K)`. -/
+/-- Under `toCompletion`, the image of `x` is `UniformSpace.Completion.map` of the algebra map
+applied to `x.toCompletion`. -/
 @[simp]
 lemma toCompletion_adicCompletionExtension (x : v.adicCompletion K) :
     (adicCompletionExtension K L v w x).toCompletion =
@@ -209,6 +215,10 @@ lemma adicCompletionExtension_coe (x : K) :
   rw [toCompletion_adicCompletionExtension, adicCompletion.coe_toCompletion,
     UniformSpace.Completion.map_coe
       (uniformContinuous_algebraMap_liesOver (K := K) (L := L) v w)]
+  -- `WithVal` is a type synonym, so `algebraMap (WithVal _) (WithVal _)` is `algebraMap K L`
+  -- transported along it; these two rewrites name that identification rather than leaving it to
+  -- a bare `rfl`.
+  rw [WithVal.algebraMap_left_apply, WithVal.algebraMap_right_apply]
   rfl
 
 /-- `adicCompletionExtension` is continuous. -/
@@ -267,10 +277,11 @@ lemma valued_adicCompletionExtension (x : v.adicCompletion K) :
     Valued.valuedCompletion_apply, Valued.valuedCompletion_apply]
   exact valuation_liesOver (K := K) L v w (WithVal.equiv (v.valuation K) a)
 
+/-- The extension maps the ring of integers of `K_v` into the ring of integers of `L_w`. -/
 lemma adicCompletionExtension_mem_adicCompletionIntegers (x : v.adicCompletionIntegers K) :
     adicCompletionExtension K L v w (x : v.adicCompletion K) ∈ w.adicCompletionIntegers L := by
   rw [mem_adicCompletionIntegers, valued_adicCompletionExtension]
-  exact pow_le_one' x.2 _
+  exact pow_le_one' ((mem_adicCompletionIntegers ..).mp x.2) _
 
 /-- The restriction of `adicCompletionExtension` to the rings of integers. -/
 noncomputable def adicCompletionIntegersExtension :

--- a/TauCeti/RingTheory/DedekindDomain/Ideal.lean
+++ b/TauCeti/RingTheory/DedekindDomain/Ideal.lean
@@ -35,6 +35,13 @@ of an ideal weight on a number field; the design of the predicate — nonzerones
 `⊥` is prime to no set at all — is taken from there, while nothing in it is specific to a number
 field.
 
+The file also identifies any height-one prime of a discrete valuation ring with its maximal ideal
+(`IsDedekindDomain.HeightOneSpectrum.eq_maximalIdeal`), which is what lets a condition stated at
+the height-one primes of such a ring be read as a condition on its valuation. It was split out of
+material adapted from Michael Stoll's elliptic-curves formalisation
+(`EllipticCurves/Mathlib/AdicCompletionExtension.lean` at the roadmap's pin `66889eada51a`,
+Apache 2.0, by Michael Stoll), where it is the step behind `valuation_adicCompletion_algebraMap`.
+
 The theorem `IsDedekindDomain.HeightOneSpectrum.exists_mem_notMem` was split out of material
 adapted from Michael Stoll's elliptic-curves formalisation
 (`github.com/MichaelStollBayreuth/EllipticCurves`, `EllipticCurves/Mathlib/SIntegers.lean` at the

--- a/TauCeti/RingTheory/DedekindDomain/SelmerGroup.lean
+++ b/TauCeti/RingTheory/DedekindDomain/SelmerGroup.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.DedekindDomain.SelmerGroup
+public import TauCeti.RingTheory.DedekindDomain.ValuationOfNeZero
 
 import Mathlib.RingTheory.DedekindDomain.FiniteAdeleRing
 
@@ -23,8 +24,6 @@ a representative.
 
 ## Main results
 
-* `IsDedekindDomain.HeightOneSpectrum.valuationOfNeZero_eq_one_iff`: a unit has trivial `v`-adic
-  `valuationOfNeZero` exactly when its `v`-adic `valuation` is `1`.
 * `IsDedekindDomain.HeightOneSpectrum.valuationOfNeZeroMod_mk_eq_one_iff`: the class of a unit
   has trivial `v`-adic `valuationOfNeZeroMod n` exactly when `n` divides its `v`-adic valuation.
 * `IsDedekindDomain.HeightOneSpectrum.dvd_toAdd_valuationOfNeZero`: if the `v`-adic valuation of
@@ -36,7 +35,9 @@ Michael Stoll's elliptic-curves formalisation
 (`github.com/MichaelStollBayreuth/EllipticCurves`, at the `EllipticCurves` roadmap's pin
 `66889eada51a`, Apache 2.0, by Michael Stoll) reaches for a
 `HeightOneSpectrum.valuationOfNeZero_eq_iff` in this role; no such lemma exists at our Mathlib
-pin, so it is supplied here, with `valuationOfNeZero_eq_one_iff` as its `m = 1` case.
+pin, so it and its `m = 1` case `valuationOfNeZero_eq_one_iff` are supplied in
+`TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean`, which this file imports — they are
+generic, and the completion API needs them without needing the Selmer groups below.
 `valuationOfNeZeroMod_mk_eq_one_iff`, `dvd_toAdd_valuationOfNeZero` and
 `finite_setOfPred_valuation_ne_one` are adapted from that source's
 `EllipticCurves/Mathlib/Basic.lean`. Following this repository's convention for adapted material,
@@ -49,19 +50,6 @@ namespace IsDedekindDomain.HeightOneSpectrum
 
 variable {R : Type*} [CommRing R] [IsDedekindDomain R]
   {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
-
-/-- The `Multiplicative ℤ`-valued valuation of a unit is determined by the `ℤᵐ⁰`-valued one.
-Mathlib carries only the coerced form `valuationOfNeZero_eq`, which this complements. -/
-theorem valuationOfNeZero_eq_iff (v : HeightOneSpectrum R) (u : Kˣ) (m : Multiplicative ℤ) :
-    v.valuationOfNeZero u = m ↔ v.valuation K (u : K) = (m : WithZero (Multiplicative ℤ)) := by
-  rw [← WithZero.coe_inj, valuationOfNeZero_eq]
-
-/-- A unit has trivial `v`-adic `valuationOfNeZero` iff its `v`-adic valuation is `1`, the case
-`m = 1` of `valuationOfNeZero_eq_iff`. -/
-@[simp]
-theorem valuationOfNeZero_eq_one_iff (v : HeightOneSpectrum R) (x : Kˣ) :
-    v.valuationOfNeZero x = 1 ↔ v.valuation K (x : K) = 1 := by
-  simpa using valuationOfNeZero_eq_iff v x 1
 
 /-- The class of a unit `u` in `Kˣ ⧸ (Kˣ)ⁿ` has trivial `v`-adic valuation mod `n` exactly when
 `n` divides the `v`-adic valuation of `u`. Membership in `IsDedekindDomain.selmerGroup` is the

--- a/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
+++ b/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
@@ -51,16 +51,21 @@ variable {R : Type*} [CommRing R] [IsDedekindDomain R]
 
 /-- The `Multiplicative ℤ`-valued valuation of a unit is determined by the `ℤᵐ⁰`-valued one.
 Mathlib carries only the coerced form `valuationOfNeZero_eq`, which this complements. -/
+@[simp]
 theorem valuationOfNeZero_eq_iff (v : HeightOneSpectrum R) (u : Kˣ) (m : Multiplicative ℤ) :
     v.valuationOfNeZero u = m ↔ v.valuation K (u : K) = (m : WithZero (Multiplicative ℤ)) := by
   rw [← WithZero.coe_inj, valuationOfNeZero_eq]
 
 /-- A unit has trivial `v`-adic `valuationOfNeZero` iff its `v`-adic valuation is `1`, the case
-`m = 1` of `valuationOfNeZero_eq_iff`. -/
-@[simp]
+`m = 1` of `valuationOfNeZero_eq_iff`.
+
+Not `@[simp]`: it is the `m = 1` instance of `valuationOfNeZero_eq_iff`, which carries the
+annotation instead. With both marked, `simpNF` rejects this one — "simp can prove this" — because
+the general form subsumes it. Every consumer names it explicitly, so nothing depends on the
+attribute. -/
 theorem valuationOfNeZero_eq_one_iff (v : HeightOneSpectrum R) (x : Kˣ) :
     v.valuationOfNeZero x = 1 ↔ v.valuation K (x : K) = 1 := by
-  simpa using valuationOfNeZero_eq_iff v x 1
+  simp
 
 end IsDedekindDomain.HeightOneSpectrum
 

--- a/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
+++ b/TauCeti/RingTheory/DedekindDomain/ValuationOfNeZero.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.SelmerGroup
+
+/-!
+# The `Multiplicative ℤ`-valued adic valuation of a unit
+
+Mathlib attaches to a height one prime `v` of a Dedekind domain `R` a homomorphism
+`v.valuationOfNeZero : Kˣ →* Multiplicative ℤ`, the `v`-adic valuation of a unit of the fraction
+field read without the adjoined zero, and relates it to `v.valuation K` in one direction only:
+`valuationOfNeZero_eq` coerces it into `ℤᵐ⁰`. This file supplies the two complements that make it
+usable as a rewriting rule.
+
+## Main results
+
+* `IsDedekindDomain.HeightOneSpectrum.valuationOfNeZero_eq_iff`: the `Multiplicative ℤ`-valued
+  valuation of a unit is determined by the `ℤᵐ⁰`-valued one.
+* `IsDedekindDomain.HeightOneSpectrum.valuationOfNeZero_eq_one_iff`: its `m = 1` case, that a unit
+  has trivial `v`-adic `valuationOfNeZero` exactly when its `v`-adic valuation is `1`.
+
+## Implementation notes
+
+These live in their own module rather than beside their first consumer. `valuationOfNeZero` is
+declared in `Mathlib/RingTheory/DedekindDomain/SelmerGroup.lean`, so any host must import that;
+but the *generic* completion and `S`-integer APIs that need these two lemmas must not, in
+consequence, also inherit this repository's Selmer-group development. Keeping the pair here lets
+`TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean` use them without depending on
+`TauCeti/RingTheory/DedekindDomain/SelmerGroup.lean`, which is downstream of it.
+
+## Provenance
+
+Michael Stoll's elliptic-curves formalisation
+(`github.com/MichaelStollBayreuth/EllipticCurves`, at the `EllipticCurves` roadmap's pin
+`66889eada51a`, Apache 2.0, by Michael Stoll) reaches for a
+`HeightOneSpectrum.valuationOfNeZero_eq_iff`; no such lemma exists at our Mathlib pin, so it is
+supplied here. Following this repository's convention for adapted material, the upstream
+authorship is credited here rather than in the copyright header.
+-/
+
+public section
+
+namespace IsDedekindDomain.HeightOneSpectrum
+
+variable {R : Type*} [CommRing R] [IsDedekindDomain R]
+  {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
+
+/-- The `Multiplicative ℤ`-valued valuation of a unit is determined by the `ℤᵐ⁰`-valued one.
+Mathlib carries only the coerced form `valuationOfNeZero_eq`, which this complements. -/
+theorem valuationOfNeZero_eq_iff (v : HeightOneSpectrum R) (u : Kˣ) (m : Multiplicative ℤ) :
+    v.valuationOfNeZero u = m ↔ v.valuation K (u : K) = (m : WithZero (Multiplicative ℤ)) := by
+  rw [← WithZero.coe_inj, valuationOfNeZero_eq]
+
+/-- A unit has trivial `v`-adic `valuationOfNeZero` iff its `v`-adic valuation is `1`, the case
+`m = 1` of `valuationOfNeZero_eq_iff`. -/
+@[simp]
+theorem valuationOfNeZero_eq_one_iff (v : HeightOneSpectrum R) (x : Kˣ) :
+    v.valuationOfNeZero x = 1 ↔ v.valuation K (x : K) = 1 := by
+  simpa using valuationOfNeZero_eq_iff v x 1
+
+end IsDedekindDomain.HeightOneSpectrum
+
+end


### PR DESCRIPTION
Restores a review round that **#4867 merged without**, and lands the three findings its final board
raised. Both halves were written and gated before that merge; neither reached `main`.

### Why this PR exists

#4867 was enqueued at `c570b18b2` while its board was green, then pushed to `df3f9b0f3`. The merge
queue builds its group from the tree **at enqueue time**, and a push to an enqueued PR neither
dequeues it nor updates the group — so the squash `412efb5cc` carries `c570b18b2`, and `df3f9b0f3`
never landed. GitHub shows #4867 as merged with all seven commits, so nothing surfaces the loss.

Measured against `main`:

```
git diff c570b18b2 origin/main -- …/AdicCompletionExtension.lean   → IDENTICAL
git diff df3f9b0f3 origin/main -- …/AdicCompletionExtension.lean   → 6 insertions, 17 deletions
main: valued_irreducible_adicCompletionIntegers        = 1   (old name)
main: valued_algebraMap_eq_exp_neg_one_of_irreducible  = 0   (the rename never landed)
```

This is a mechanical hazard, not a review dispute; it is reported separately so the queue
configuration can be fixed.

### What this restores — the dropped round (`df3f9b0f3`)

| rubric | change |
|---|---|
| naming | `valued_irreducible_adicCompletionIntegers` → `valued_algebraMap_eq_exp_neg_one_of_irreducible`: the old name spliced its hypothesis in without `of` and omitted the conclusion's value |
| attribution | provenance for `eq_maximalIdeal` in `Ideal.lean`, whose module docstring credits every other adapted declaration |
| documentation | docstring for `adicCompletionExtension_mem_adicCompletionIntegers`, the only undocumented public declaration; `Ideal.lean`'s module docstring updated for what now lives in it; the `toCompletion_adicCompletionExtension` docstring, which described the image of `x` as "the completion of `x`" and called the map a "base change" (FLT source terminology — no tensor product is involved); two consumer-facing valuation forms added to `## Main results` |
| proof-quality | `adicCompletionIntegers.integers` in place of `Valuation.valuationSubring.integers`, which typechecked only by unfolding `adicCompletionIntegers` into a valuation subring; `(mem_adicCompletionIntegers ..).mp` instead of using a membership proof as a valuation bound; `WithVal.algebraMap_left_apply`/`_right_apply` naming the `WithVal` crossing before the residual `rfl` |

### And the three findings from #4867's final board

- **placement + api-design** (the same defect from two rubrics): the generic completion module
  publicly imported `TauCeti…DedekindDomain.SelmerGroup` **solely** for `valuationOfNeZero_eq_iff`,
  putting the whole Selmer-group development into every consumer's surface and pointing foundational
  local theory at its own downstream consumer. Measured: exactly one name was used from that module.
- **generality**: `valuation_adicCompletion_algebraMap` was specialised to `z : K` when the argument
  gives it for every element of the completion.
- **api-design**: the characteristic membership rule lacked `@[simp]`.

### On the new module

The obvious fix does not work, and the failure is worth recording. `valuationOfNeZero` is declared in
**Mathlib's** `RingTheory/DedekindDomain/SelmerGroup.lean`, so any host must import that. Moving the
lemma into the existing `AdicValuation/Basic.lean` fails to build (`Unknown identifier
valuationOfNeZero_eq`) and, had it built, would have forced a Mathlib Selmer-group import onto a
foundational file and its three importers — trading one reversed dependency for another.

So the pair lives in `RingTheory/DedekindDomain/ValuationOfNeZero.lean`. They move together because
`valuationOfNeZero_eq_one_iff` is the `m = 1` case of `valuationOfNeZero_eq_iff` and the docstring
already tied them; splitting a lemma from its own corollary would be the worse smell.

The fix is verified at the environment level rather than by grep: a `run_meta` check over
`env.allImportedModuleNames` confirms `TauCeti.RingTheory.DedekindDomain.SelmerGroup` is no longer in
`AdicCompletionExtension`'s import closure, with a must-fail control proving the detector does see
modules that *are* imported.

`valuation_adicCompletionIntegers` is stated for all of `K_v` and the `algebraMap` form derived from
it. `@[simp]` on `adicCompletionExtension_mem_adicCompletionIntegers` is accepted by `simpNF`.

### Gate

`lake build` of the four changed modules and their eight direct importers — including
`SInteger/Unit` and `SInteger/SelmerGroup/Basic`, which consume the moved
`valuationOfNeZero_eq_one_iff` transitively: **`Build completed successfully (3675 jobs)`**, exit 0,
no `error:`/`warning:`/`info:` diagnostics. `lake exe runLinter` clean on all four. A `run_meta`
probe confirms the restored rename is present and the old name absent, the moved pair resolves in the
new module, the generality form is present, and `SelmerGroup` is out of the import closure — with an
absent-name negative control.

That gate ran immediately before a rebase onto four newer `main` commits (#4946, #4921, #4943,
#4937), none of which touch these files. CI's `pr-build` is the full build and the authority.

Roadmap: EllipticCurves

Target: `TauCetiRoadmap/EllipticCurves/README.md:813-822` — the "Explicit 2-descent (core, this
layer)" bullet. Review follow-up on already-landed prerequisite infrastructure, not new mathematics.
