### PR TITLE
feat(Topology): a quotient by a closed ideal is T1

### DIFF
--- a/TauCeti/Topology/Algebra/Ring/Ideal.lean
+++ b/TauCeti/Topology/Algebra/Ring/Ideal.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Ring.Ideal
+public import Mathlib.Topology.Algebra.Group.Quotient
+
+/-!
+# Separation of the quotient of a topological ring by an ideal
+
+The quotient `R ⧸ I` of a topological ring by an ideal is `T1` exactly when `I` is closed, and
+hence `T0`.
+
+Mathlib proves the corresponding statement for the quotient of a topological group by a
+subgroup, as `QuotientGroup.t1Space_iff` and `QuotientGroup.instT1Space`. Those are stated for
+`G ⧸ N` with `N : AddSubgroup G` in the additive case, whereas `R ⧸ I` is the quotient by an
+`Ideal`. The two quotients are definitionally equal — Mathlib's own
+`Ideal.topologicalRing_quotient` builds the additive structure of `R ⧸ I` out of
+`QuotientAddGroup.instIsTopologicalAddGroup` — but reaching the group statement from an ideal
+still means presenting `I` as `I.toAddSubgroup` and transporting the closedness hypothesis along
+that presentation, which unification does not do on its own: with only `IsClosed (I : Set R)` in
+context, `T1Space (R ⧸ I)` is not synthesized. So the results below are that transport, and
+their proofs delegate to Mathlib rather than reproving anything.
+
+Only separate continuity of addition is needed, matching the hypotheses of the group statements
+these delegate to; no ring topology and no multiplicative continuity is used.
+
+## Main results
+
+* `Ideal.Quotient.t1Space_iff`: `T1Space (R ⧸ I) ↔ IsClosed (I : Set R)`.
+* `Ideal.Quotient.instT1Space`: the instance form, so that `T0Space (R ⧸ I)` is found
+  automatically once `I` is known to be closed.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Example 6.38, where a rational localisation is
+  presented as a quotient `C ⧸ 𝔞` and its Hausdorff completion is taken.
+-/
+
+public section
+
+variable {R : Type*} [TopologicalSpace R] [CommRing R] [SeparatelyContinuousAdd R] (I : Ideal R)
+
+namespace Ideal.Quotient
+
+/-- The quotient of a topological ring by an ideal is `T1` exactly when the ideal is closed.
+This is `QuotientAddGroup.t1Space_iff` read through the identification of `R ⧸ I` with the
+quotient of `R` by `I.toAddSubgroup`. -/
+theorem t1Space_iff : T1Space (R ⧸ I) ↔ IsClosed (I : Set R) :=
+  QuotientAddGroup.t1Space_iff (N := I.toAddSubgroup)
+
+/-- The quotient of a topological ring by a closed ideal is `T1`, hence `T0`. Stated as an
+instance, with the closedness of `I` as an instance argument, so that the separation of `R ⧸ I`
+is available to instance search wherever `I` is known to be closed; this follows
+`Ideal.Quotient.normedCommRing`, which takes `IsClosed (I : Set R)` the same way. -/
+instance instT1Space [IsClosed (I : Set R)] : T1Space (R ⧸ I) := (t1Space_iff I).mpr ‹_›
+
+end Ideal.Quotient


### PR DESCRIPTION
The quotient of a topological ring by an ideal is `T1` exactly when the ideal is closed, and
hence `T0`.

* `Ideal.Quotient.t1Space_iff` — `T1Space (R ⧸ I) ↔ IsClosed (I : Set R)`;
* `Ideal.Quotient.instT1Space` — the instance form, so `T0Space (R ⧸ I)` is found automatically
  once `I` is known to be closed.

## Why this is not already available

Mathlib proves the corresponding statement for a topological *group* modulo a subgroup, as
`QuotientGroup.t1Space_iff` / `QuotientGroup.instT1Space` (`Topology/Algebra/Group/Quotient.lean`).
Those are stated for `G ⧸ N` with `N` an `AddSubgroup` in the additive case, whereas `R ⧸ I` is
the quotient by an `Ideal` and reaches `⧸` through a different `HasQuotient` instance.

The two quotients are *definitionally* equal — Mathlib's own `Ideal.topologicalRing_quotient`
builds the ring quotient's additive structure out of `QuotientAddGroup.instIsTopologicalAddGroup` —
but they are not syntactically equal, and **instance search does not bridge them**. Measured: with
`IsClosed (I : Set R)` supplied as an instance, `T0Space (R ⧸ I)` is not synthesized. Presenting
`I` as `I.toAddSubgroup` once is what makes the group statement apply, which is all either proof
does:

```lean
theorem t1Space_iff : T1Space (R ⧸ I) ↔ IsClosed (I : Set R) :=
  QuotientAddGroup.t1Space_iff (N := I.toAddSubgroup)
```

So this delegates to Mathlib rather than reproving it. `Mathlib/Topology/Algebra/Ring/Ideal.lean`
carries no separation result for `R ⧸ I`, and neither did this repository.

## Generality

The hypothesis is `[SeparatelyContinuousAdd R]`, not `[IsTopologicalRing R]`: that is the section
`QuotientGroup.t1Space_iff` is actually proved in, so nothing stronger is needed. No ring topology
and no multiplicative continuity is used.

Stating the `iff` as well as the instance mirrors Mathlib's pair and supplies the converse, which
the instance alone cannot give.

## Placement

`TauCeti/Topology/Algebra/Ring/Ideal.lean`, mirroring `Mathlib/Topology/Algebra/Ring/Ideal.lean`,
which is where Mathlib puts the quotient topology and the `IsTopologicalRing (R ⧸ I)` instance this
builds on. It joins the existing `Topology/Algebra/Ring/` siblings `Subring.lean` and
`MaximalIdeals.lean`. It is not in `MaximalIdeals.lean` because that file is about maximal ideals
specifically, whereas this holds for an arbitrary ideal.

Both declarations sit in the root `Ideal.Quotient` namespace, beside the `Ideal.Quotient` the
instance argument follows: `Ideal.Quotient.normedCommRing`
(`Mathlib/Analysis/Normed/Group/Quotient.lean:513`) takes `[IsClosed (I : Set R)]` as an instance
binder for this very type, so that spelling is established rather than invented here.

## Consumer

`Topology/Algebra/Ring/MaximalIdeals.lean` on `main` produces exactly this hypothesis —
`Ideal.isClosed_of_isMaximal_of_isOpen_isUnit`, a maximal ideal of a topological ring is closed
when the unit group is open — so that lemma and this one compose directly.

The motivating consumer is Wedhorn's Example 6.38, which presents a rational localisation as a
quotient `C ⧸ a` of a ring of restricted power series; separation of `C ⧸ a` is a prerequisite for
the completion machinery applied to it. That is the same step of AdicSpaces roadmap §4.1
(`README:571`, Proposition 8.30) that #4930 supplies the nonarchimedean half of. Like #4930 this is
a leaf file and is not yet consumed on `main`; I am not claiming 6.38(a) itself here.

## Gate

`lake build` of the new module — 1317 jobs, no errors, warnings or sorries. New leaf file; nothing
on `main` imports it. `scripts/lint-dot-notation.py` reports `0 new`, exit 0.

Roadmap: AdicSpaces
