### PR TITLE
refactor(InfinityPlace): reuse the public mk_C_eq_algebraMap in Unique.lean

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Unique.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Unique.lean
@@ -8,6 +8,11 @@ module
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.InfinityPlace.Basic
 -- Proof-only: Mathlib's evaluation of a valuation of `F(x)` with `v X > 1` is used inside
 -- `val_algebraMap_eq_zpow_intDegree`; no statement here mentions Ostrowski's theorem.
+-- Proof-only: `CoordinateRing.mk_C_eq_algebraMap`, used in one rewrite below. NOT `public` — a
+-- public import would re-export `TauCeti.WeierstrassCurve.Affine` to downstream files, and any of
+-- them that `open WeierstrassCurve.Affine` inside `namespace TauCeti` would then resolve the open
+-- ambiguously and silently lose `_root_.WeierstrassCurve.Affine`.
+import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.CoordinateRing
 import Mathlib.NumberTheory.RatFunc.Ostrowski
 
 /-!
@@ -167,13 +172,6 @@ section Relation
 
 variable (W)
 
-/-- `AdjoinRoot.mk_C` in the `algebraMap` spelling the rewrite below wants. (`CoordinateRing.lean`
-carries a private lemma of the same shape; neither file exports one, and importing that file here
-for a one-line wrapper around a Mathlib lemma would pull in the Dedekind development.) -/
-private theorem coordinateRing_mk_C (p : F[X]) :
-    CoordinateRing.mk W (Polynomial.C p) = algebraMap F[X] W.CoordinateRing p :=
-  AdjoinRoot.mk_C p
-
 /-- **The Weierstrass equation, in the function field**:
 `y * (y + (a₁X + a₃)) = X³ + a₂X² + a₄X + a₆`. Grouping the two left-hand terms as a product is
 what makes the valuation of the left-hand side a product of two values, which is how the pole
@@ -189,7 +187,8 @@ theorem mk_Y_mul_add_eq :
       + algebraMap F[X] W.CoordinateRing (Polynomial.C W.a₁ * Polynomial.X + Polynomial.C W.a₃))
       = algebraMap F[X] W.CoordinateRing (Polynomial.X ^ 3 + Polynomial.C W.a₂ * Polynomial.X ^ 2
           + Polynomial.C W.a₄ * Polynomial.X + Polynomial.C W.a₆) := by
-    rw [← coordinateRing_mk_C, ← coordinateRing_mk_C, ← map_add, ← map_mul]
+    rw [← TauCeti.WeierstrassCurve.Affine.CoordinateRing.mk_C_eq_algebraMap,
+      ← TauCeti.WeierstrassCurve.Affine.CoordinateRing.mk_C_eq_algebraMap, ← map_add, ← map_mul]
     exact AdjoinRoot.mk_eq_mk.mpr ⟨1, by rw [polynomial]; ring1⟩
   rw [IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField,
     IsScalarTower.algebraMap_apply F[X] W.CoordinateRing W.FunctionField, ← map_add, ← map_mul, hY]


### PR DESCRIPTION
`Unique.lean` carried a private `coordinateRing_mk_C` — a one-line wrapper around Mathlib's
`AdjoinRoot.mk_C`. #4741 and #4830 made `CoordinateRing.mk_C_eq_algebraMap` public and canonical,
so that wrapper is now a duplicate of an exported lemma, and the exported one is **more general**:
it is stated over `[CommRing R]`, the private one over `[Field F]`.

This deletes the wrapper, imports the canonical lemma, and uses it at its single call site.

### The stale docstring goes with it

The wrapper's docstring read:

> `CoordinateRing.lean` carries a private lemma of the same shape; **neither file exports one**, and
> importing that file here for a one-line wrapper around a Mathlib lemma would pull in the Dedekind
> development.

The first clause stopped being true when the public lemma landed. The second was worth measuring
rather than inheriting, and it does not hold either — see below.

### Measuring the import edge, both halves

**The recorded cost is not real.** Importing `Affine/CoordinateRing` into `Unique.lean` adds
**one** TauCeti module — `CoordinateRing` itself — and **zero** Mathlib modules. `Unique.lean`
already reaches everything it needs transitively via
`InfinityPlace/Basic → FunctionField/Norm → FunctionField/Finrank`; four of `CoordinateRing`'s five
closure members were already present. Controlled against a genuinely heavy import
(`Huber/Restricted/Laurent`), which shows **39** new Mathlib modules, so the measurement
discriminates rather than always reporting zero. No Dedekind development is pulled in.

**But the import is still not free, for a different reason — and this is why it is not `public`.**
A `public import` re-exports `TauCeti.WeierstrassCurve.Affine`. Any downstream file that does
`open WeierstrassCurve.Affine` *inside* `namespace TauCeti` then has two candidates, resolves the
open to the `TauCeti` one, and **silently** loses `_root_.WeierstrassCurve.Affine`. That is exactly
what happens to `Isogeny/InfinityPlace.lean:75`, where `infinityPlace` becomes an unknown
identifier at three sites. No import-count measurement can see this; only building the importers
does.

The lemma is used in one rewrite and never in a statement, so a proof-only import is both
sufficient and correct. The reason is recorded at the import so it is not promoted to `public`
later.

### Gates

* `lake build` of the changed module **and both direct importers** — `PointPlace` and
  `Isogeny/InfinityPlace` — "Build completed successfully (2587 jobs)". The importer build is what
  caught the re-export problem; the changed module alone builds fine either way.
* `lake env lean` on the changed file: exit 0, zero bytes — no errors, warnings or `info:`.
* `#lint only simpNF in TauCeti` over the module: 0 errors in **100 declarations** (a nonzero
  count, so the linter is actually seeing the file).
* Style: max width 99 characters, no trailing whitespace.

### Naming note for reviewers

`Unique.lean` sits in `namespace WeierstrassCurve.Affine` while `CoordinateRing.lean` nests under
`namespace TauCeti`, so the short name `CoordinateRing.mk_C_eq_algebraMap` does *not* resolve from
here — it silently misses. The call site uses the fully qualified
`TauCeti.WeierstrassCurve.Affine.CoordinateRing.mk_C_eq_algebraMap`, verified by `#check` rather
than guessed.

Roadmap: EllipticCurves
