### PR TITLE
refactor(WExpansion): state the multivariate w-equation uniqueness over an R-algebra

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -46,9 +46,10 @@ equation at the substituted parameter rather than at `z`.
   constant coefficient — two series with vanishing constant coefficient solving the equation at
   that parameter are equal.
 * `WeierstrassCurve.eq_of_wEquation_mvPowerSeries`: that same uniqueness one index type up, for
-  series in `MvPowerSeries σ S` over any commutative `R`-algebra `S`. It is a sibling of
-  `eq_of_wEquation` and not a generalisation of it: filtering by total degree means subtracting,
-  so it needs `[CommRing S]` where the univariate statement holds over a `CommSemiring`.
+  series in `MvPowerSeries σ S` over any commutative `R`-algebra `S` — one index type up and a
+  base change. It is a sibling of `eq_of_wEquation`, not a generalisation of it: filtering by
+  total degree means subtracting, so it needs `[CommRing S]` on the coefficient algebra. The base
+  ring `R` stays a `CommSemiring` throughout.
 * `WeierstrassCurve.subst_wEquationRHS` and `WeierstrassCurve.subst_formalW_wEquation`:
   substituting a series `q` into the equation gives the equation at `q`, so `w(q)` solves it
   there. When moreover `constantCoeff q = 0`, `eq_subst_formalW_of_wEquation` combines this with
@@ -410,6 +411,97 @@ theorem eq_formalW_of_wEquation (w : PowerSeries R)
     w = formalW W :=
   eq_of_wEquation W (by simp) h0 (by simp) hw (formalW_wEquation W)
 
+/-! ### Uniqueness over a multivariate power series ring
+
+`eq_of_wEquation` argues by strong induction on the coefficient index, which needs that index to be
+linearly ordered. Over `MvPowerSeries σ S` no such order is available, so the induction runs on the
+total degree instead: `MvPowerSeries.order` is exactly the filtration by total degree, and the
+right-hand side of the `w`-equation is a contraction for it. That argument needs additive inverses
+in the *coefficient algebra* `S`, which is why `[CommRing S]` appears below; the base ring `R`
+stays a `CommSemiring`
+above; the two uniqueness statements are siblings and neither subsumes the other.
+-/
+
+/-- **The right-hand side of the `w`-equation is a contraction for the total-degree filtration.**
+If two candidate solutions agree below total degree `k`, then the values of the equation at them
+agree below total degree `k + 1`. Every occurrence of the unknown is multiplied by the parameter,
+which has positive order, or sits in a square or a cube of a series of positive order, and that is
+where the extra degree comes from. -/
+private theorem le_order_wEquationRHS_sub {σ S : Type*} [CommRing S] [Algebra R S]
+    {q u v : MvPowerSeries σ S}
+    (hq : 1 ≤ q.order) (hu : 1 ≤ u.order) (hv : 1 ≤ v.order) {k : ℕ}
+    (h : (k : ℕ∞) ≤ (u - v).order) :
+    ((k + 1 : ℕ) : ℕ∞) ≤ (wEquationRHS W q u - wEquationRHS W q v).order := by
+  -- The order estimates used below, in the vocabulary of `MvPowerSeries.order`.
+  have hmono : ∀ {m n : ℕ} {f : MvPowerSeries σ S}, m ≤ n → (n : ℕ∞) ≤ f.order →
+      (m : ℕ∞) ≤ f.order := fun hmn hf => (Nat.cast_le.mpr hmn).trans hf
+  have hadd : ∀ {m : ℕ} {f g : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order → (m : ℕ∞) ≤ g.order →
+      (m : ℕ∞) ≤ (f + g).order :=
+    fun hf hg => (le_min hf hg).trans MvPowerSeries.min_order_le_add
+  have hmul : ∀ {m n : ℕ} {f g : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order → (n : ℕ∞) ≤ g.order →
+      ((m + n : ℕ) : ℕ∞) ≤ (f * g).order := by
+    intro m n f g hf hg
+    push_cast
+    exact (add_le_add hf hg).trans MvPowerSeries.le_order_mul
+  -- Any left factor will do: the estimate uses nothing about the multiplier.
+  have hC : ∀ {m : ℕ} (c : MvPowerSeries σ S) {f : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order →
+      (m : ℕ∞) ≤ (c * f).order := by
+    intro m c f hf
+    exact (hf.trans le_add_self).trans MvPowerSeries.le_order_mul
+  -- The three differences that carry the gain.
+  have hq2 : ((2 : ℕ) : ℕ∞) ≤ (q * q).order := hmul hq hq
+  have hlin : ((k + 1 : ℕ) : ℕ∞) ≤ (q * (u - v)).order := hmono (by omega) (hmul hq h)
+  have hsq : ((k + 1 : ℕ) : ℕ∞) ≤ (u ^ 2 - v ^ 2).order := by
+    have he : u ^ 2 - v ^ 2 = (u + v) * (u - v) := by ring
+    rw [he]
+    exact hmono (by omega) (hmul (hadd hu hv) h)
+  have hcb : ((k + 1 : ℕ) : ℕ∞) ≤ (u ^ 3 - v ^ 3).order := by
+    have he : u ^ 3 - v ^ 3 = (u * u + u * v + v * v) * (u - v) := by ring
+    rw [he]
+    exact hmono (by omega) (hmul (hadd (hadd (hmul hu hu) (hmul hu hv)) (hmul hv hv)) h)
+  -- Reassemble the difference and bound each summand.
+  have hstep : wEquationRHS W q u - wEquationRHS W q v =
+      algebraMap R (MvPowerSeries σ S) W.a₁ * (q * (u - v)) +
+        algebraMap R (MvPowerSeries σ S) W.a₂ * (q * q * (u - v)) +
+        algebraMap R (MvPowerSeries σ S) W.a₃ * (u ^ 2 - v ^ 2) +
+        algebraMap R (MvPowerSeries σ S) W.a₄ * (q * (u ^ 2 - v ^ 2)) +
+        algebraMap R (MvPowerSeries σ S) W.a₆ * (u ^ 3 - v ^ 3) := by
+    rw [wEquationRHS_def, wEquationRHS_def]
+    ring
+  rw [hstep]
+  refine hadd (hadd (hadd (hadd (hC _ hlin) (hC _ ?_)) (hC _ hsq)) (hC _ ?_)) (hC _ hcb)
+  · exact hmono (by omega) (hmul hq2 h)
+  · exact hmono (by omega) (hmul hq hsq)
+
+/-- **Uniqueness of the solution of the `w`-equation over a multivariate power series ring.** Two
+series with vanishing constant coefficient that satisfy the `w`-equation at the same parameter `q`
+are equal, provided `q` too has vanishing constant coefficient.
+
+The candidates lie in `MvPowerSeries σ S` for an arbitrary commutative `R`-algebra `S`, so this is
+both one index type up and a base change.
+
+It is not a generalisation of `eq_of_wEquation`: the argument here subtracts, so it needs
+`[CommRing S]` on the coefficient algebra, whereas the univariate statement holds over a
+`CommSemiring`. The base ring `R` is a `CommSemiring` in both.
+-/
+theorem eq_of_wEquation_mvPowerSeries {σ S : Type*} [CommRing S] [Algebra R S]
+    {q v v' : MvPowerSeries σ S}
+    (hq : MvPowerSeries.constantCoeff q = 0) (hv : MvPowerSeries.constantCoeff v = 0)
+    (hv' : MvPowerSeries.constantCoeff v' = 0) (h : v = wEquationRHS W q v)
+    (h' : v' = wEquationRHS W q v') : v = v' := by
+  rw [← MvPowerSeries.one_le_order_iff_constCoeff_eq_zero] at hq hv hv'
+  -- The difference vanishes below every total degree, so it is zero.
+  have key : ∀ k : ℕ, (k : ℕ∞) ≤ (v - v').order := by
+    intro k
+    induction k with
+    | zero => simp
+    | succ k ih =>
+      have := le_order_wEquationRHS_sub W hq hv hv' ih
+      rwa [← h, ← h'] at this
+  have hzero : (v - v').order = ⊤ := ENat.eq_top_iff_forall_ge.mpr key
+  rw [MvPowerSeries.order_eq_top_iff] at hzero
+  exact sub_eq_zero.mp hzero
+
 /-! ### Substituting into the equation
 
 Substituting a series into the `w`-equation gives the equation at the substituted parameters. The
@@ -459,109 +551,6 @@ theorem eq_subst_formalW_of_wEquation {q v : PowerSeries R}
   have ha : PowerSeries.HasSubst q := PowerSeries.HasSubst.of_constantCoeff_zero' hq
   refine eq_of_wEquation W hq hv ?_ h (subst_formalW_wEquation W ha)
   exact PowerSeries.constantCoeff_subst_eq_zero hq (formalW W) (constantCoeff_formalW W)
-
-/-! ### Uniqueness over a multivariate power series ring
-
-`eq_of_wEquation` argues by strong induction on the coefficient index, which needs that index to be
-linearly ordered. Over `MvPowerSeries σ S` no such order is available, so the induction runs on the
-total degree instead: `MvPowerSeries.order` is exactly the filtration by total degree, and the
-right-hand side of the `w`-equation is a contraction for it. That argument needs additive inverses,
-so this material stays in the `CommRing` section rather than joining the `CommSemiring` development
-above; the two uniqueness statements are siblings and neither subsumes the other.
--/
-
-/-- The `w`-equation in `MvPowerSeries σ S` itself, where the structure map factors as
-`MvPowerSeries.C` after `algebraMap R S`. This is the spelling the order estimates below match
-against.
-
-Private: it is an implementation detail of those estimates, and consumers wanting the equation
-itself have `wEquationRHS_def`. It asks only `[CommSemiring S]` — the identity is an unfolding and
-subtracts nothing, unlike the contraction and uniqueness results below, which need `[CommRing S]`.
--/
-private theorem wEquationRHS_mvPowerSeries {σ S : Type*} [CommSemiring S] [Algebra R S]
-    (q v : MvPowerSeries σ S) :
-    wEquationRHS W q v =
-      q ^ 3 + MvPowerSeries.C (algebraMap R S W.a₁) * q * v +
-        MvPowerSeries.C (algebraMap R S W.a₂) * q ^ 2 * v +
-        MvPowerSeries.C (algebraMap R S W.a₃) * v ^ 2 +
-        MvPowerSeries.C (algebraMap R S W.a₄) * q * v ^ 2 +
-        MvPowerSeries.C (algebraMap R S W.a₆) * v ^ 3 := by
-  simp only [wEquationRHS_def, MvPowerSeries.algebraMap_apply]
-
-/-- **The right-hand side of the `w`-equation is a contraction for the total-degree filtration.**
-If two candidate solutions agree below total degree `k`, then the values of the equation at them
-agree below total degree `k + 1`. Every occurrence of the unknown is multiplied by the parameter,
-which has positive order, or sits in a square or a cube of a series of positive order, and that is
-where the extra degree comes from. -/
-private theorem le_order_wEquationRHS_sub {σ S : Type*} [CommRing S] [Algebra R S]
-    {q u v : MvPowerSeries σ S}
-    (hq : 1 ≤ q.order) (hu : 1 ≤ u.order) (hv : 1 ≤ v.order) {k : ℕ}
-    (h : (k : ℕ∞) ≤ (u - v).order) :
-    ((k + 1 : ℕ) : ℕ∞) ≤ (wEquationRHS W q u - wEquationRHS W q v).order := by
-  -- The order estimates used below, in the vocabulary of `MvPowerSeries.order`.
-  have hmono : ∀ {m n : ℕ} {f : MvPowerSeries σ S}, m ≤ n → (n : ℕ∞) ≤ f.order →
-      (m : ℕ∞) ≤ f.order := fun hmn hf => (Nat.cast_le.mpr hmn).trans hf
-  have hadd : ∀ {m : ℕ} {f g : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order → (m : ℕ∞) ≤ g.order →
-      (m : ℕ∞) ≤ (f + g).order :=
-    fun hf hg => (le_min hf hg).trans MvPowerSeries.min_order_le_add
-  have hmul : ∀ {m n : ℕ} {f g : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order → (n : ℕ∞) ≤ g.order →
-      ((m + n : ℕ) : ℕ∞) ≤ (f * g).order := by
-    intro m n f g hf hg
-    push_cast
-    exact (add_le_add hf hg).trans MvPowerSeries.le_order_mul
-  have hC : ∀ {m : ℕ} (a : S) {f : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order →
-      (m : ℕ∞) ≤ (MvPowerSeries.C a * f).order := by
-    intro m a f hf
-    exact (hf.trans le_add_self).trans MvPowerSeries.le_order_mul
-  -- The three differences that carry the gain.
-  have hq2 : ((2 : ℕ) : ℕ∞) ≤ (q * q).order := hmul hq hq
-  have hlin : ((k + 1 : ℕ) : ℕ∞) ≤ (q * (u - v)).order := hmono (by omega) (hmul hq h)
-  have hsq : ((k + 1 : ℕ) : ℕ∞) ≤ (u ^ 2 - v ^ 2).order := by
-    have he : u ^ 2 - v ^ 2 = (u + v) * (u - v) := by ring
-    rw [he]
-    exact hmono (by omega) (hmul (hadd hu hv) h)
-  have hcb : ((k + 1 : ℕ) : ℕ∞) ≤ (u ^ 3 - v ^ 3).order := by
-    have he : u ^ 3 - v ^ 3 = (u * u + u * v + v * v) * (u - v) := by ring
-    rw [he]
-    exact hmono (by omega) (hmul (hadd (hadd (hmul hu hu) (hmul hu hv)) (hmul hv hv)) h)
-  -- Reassemble the difference and bound each summand.
-  have hstep : wEquationRHS W q u - wEquationRHS W q v =
-      MvPowerSeries.C (algebraMap R S W.a₁) * (q * (u - v)) +
-        MvPowerSeries.C (algebraMap R S W.a₂) * (q * q * (u - v)) +
-        MvPowerSeries.C (algebraMap R S W.a₃) * (u ^ 2 - v ^ 2) +
-        MvPowerSeries.C (algebraMap R S W.a₄) * (q * (u ^ 2 - v ^ 2)) +
-        MvPowerSeries.C (algebraMap R S W.a₆) * (u ^ 3 - v ^ 3) := by
-    rw [wEquationRHS_mvPowerSeries, wEquationRHS_mvPowerSeries]
-    ring
-  rw [hstep]
-  refine hadd (hadd (hadd (hadd (hC _ hlin) (hC _ ?_)) (hC _ hsq)) (hC _ ?_)) (hC _ hcb)
-  · exact hmono (by omega) (hmul hq2 h)
-  · exact hmono (by omega) (hmul hq hsq)
-
-/-- **Uniqueness of the solution of the `w`-equation over a multivariate power series ring.** Two
-series with vanishing constant coefficient that satisfy the `w`-equation at the same parameter `q`
-are equal, provided `q` too has vanishing constant coefficient.
-
-This is `eq_of_wEquation` one index type up. It is not a generalisation of it: the argument here
-subtracts, so it needs a `CommRing`, whereas the univariate statement holds over a `CommSemiring`.
--/
-theorem eq_of_wEquation_mvPowerSeries {σ S : Type*} [CommRing S] [Algebra R S]
-    {q v v' : MvPowerSeries σ S}
-    (hq : MvPowerSeries.constantCoeff q = 0) (hv : MvPowerSeries.constantCoeff v = 0)
-    (hv' : MvPowerSeries.constantCoeff v' = 0) (h : v = wEquationRHS W q v)
-    (h' : v' = wEquationRHS W q v') : v = v' := by
-  rw [← MvPowerSeries.one_le_order_iff_constCoeff_eq_zero] at hq hv hv'
-  -- The difference vanishes below every total degree, so it is zero.
-  have key : ∀ k : ℕ, (k : ℕ∞) ≤ (v - v').order := by
-    intro k
-    induction k with
-    | zero => simp
-    | succ k ih =>
-      have := le_order_wEquationRHS_sub W hq hv hv' ih
-      rwa [← h, ← h'] at this
-  have hzero : (v - v').order = ⊤ := ENat.eq_top_iff_forall_ge.mpr key
-  rw [MvPowerSeries.order_eq_top_iff] at hzero
-  exact sub_eq_zero.mp hzero
 
 /-! ### Base change
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -46,8 +46,9 @@ equation at the substituted parameter rather than at `z`.
   constant coefficient — two series with vanishing constant coefficient solving the equation at
   that parameter are equal.
 * `WeierstrassCurve.eq_of_wEquation_mvPowerSeries`: that same uniqueness one index type up, for
-  series in `MvPowerSeries σ R`. It is a sibling of `eq_of_wEquation` and not a generalisation of
-  it: filtering by total degree means subtracting, which costs the `CommSemiring` hypothesis.
+  series in `MvPowerSeries σ S` over any commutative `R`-algebra `S`. It is a sibling of
+  `eq_of_wEquation` and not a generalisation of it: filtering by total degree means subtracting,
+  so it needs `[CommRing S]` where the univariate statement holds over a `CommSemiring`.
 * `WeierstrassCurve.subst_wEquationRHS` and `WeierstrassCurve.subst_formalW_wEquation`:
   substituting a series `q` into the equation gives the equation at `q`, so `w(q)` solves it
   there. When moreover `constantCoeff q = 0`, `eq_subst_formalW_of_wEquation` combines this with
@@ -92,7 +93,7 @@ contraction route, adapted from the same project's
 `EllipticCurves/WeierstrassFormalGroup/ThirdPoint.lean`, declarations `mvWStepAt` and
 `eq_of_mvWStepAt_fixed`. Two things there are deliberately not ported. Stoll's `mvWStepAt` is a
 second copy of the equation; `wEquationRHS` is stated over an arbitrary `R`-algebra, so reading it
-in `MvPowerSeries σ R` already *is* that definition. And Stoll's filtration is carried by a private
+in `MvPowerSeries σ S` already *is* that definition. And Stoll's filtration is carried by a private
 predicate `LowVanish k f`, "every coefficient of total degree below `k` vanishes" — that is
 Mathlib's `MvPowerSeries.order`, so the estimates here are stated as `(k : ℕ∞) ≤ f.order` and the
 predicate and its nine lemmas are not ported either.
@@ -462,7 +463,7 @@ theorem eq_subst_formalW_of_wEquation {q v : PowerSeries R}
 /-! ### Uniqueness over a multivariate power series ring
 
 `eq_of_wEquation` argues by strong induction on the coefficient index, which needs that index to be
-linearly ordered. Over `MvPowerSeries σ R` no such order is available, so the induction runs on the
+linearly ordered. Over `MvPowerSeries σ S` no such order is available, so the induction runs on the
 total degree instead: `MvPowerSeries.order` is exactly the filtration by total degree, and the
 right-hand side of the `w`-equation is a contraction for it. That argument needs additive inverses,
 so this material stays in the `CommRing` section rather than joining the `CommSemiring` development
@@ -471,8 +472,13 @@ above; the two uniqueness statements are siblings and neither subsumes the other
 
 /-- The `w`-equation in `MvPowerSeries σ S` itself, where the structure map factors as
 `MvPowerSeries.C` after `algebraMap R S`. This is the spelling the order estimates below match
-against. -/
-theorem wEquationRHS_mvPowerSeries {σ S : Type*} [CommRing S] [Algebra R S]
+against.
+
+Private: it is an implementation detail of those estimates, and consumers wanting the equation
+itself have `wEquationRHS_def`. It asks only `[CommSemiring S]` — the identity is an unfolding and
+subtracts nothing, unlike the contraction and uniqueness results below, which need `[CommRing S]`.
+-/
+private theorem wEquationRHS_mvPowerSeries {σ S : Type*} [CommSemiring S] [Algebra R S]
     (q v : MvPowerSeries σ S) :
     wEquationRHS W q v =
       q ^ 3 + MvPowerSeries.C (algebraMap R S W.a₁) * q * v +

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -469,36 +469,41 @@ so this material stays in the `CommRing` section rather than joining the `CommSe
 above; the two uniqueness statements are siblings and neither subsumes the other.
 -/
 
-/-- The `w`-equation in `MvPowerSeries σ R` itself, where the structure map is `MvPowerSeries.C`.
-This is the spelling the order estimates below match against. -/
-theorem wEquationRHS_mvPowerSeries {σ : Type*} (q v : MvPowerSeries σ R) :
+/-- The `w`-equation in `MvPowerSeries σ S` itself, where the structure map factors as
+`MvPowerSeries.C` after `algebraMap R S`. This is the spelling the order estimates below match
+against. -/
+theorem wEquationRHS_mvPowerSeries {σ S : Type*} [CommRing S] [Algebra R S]
+    (q v : MvPowerSeries σ S) :
     wEquationRHS W q v =
-      q ^ 3 + MvPowerSeries.C W.a₁ * q * v + MvPowerSeries.C W.a₂ * q ^ 2 * v +
-        MvPowerSeries.C W.a₃ * v ^ 2 + MvPowerSeries.C W.a₄ * q * v ^ 2 +
-        MvPowerSeries.C W.a₆ * v ^ 3 :=
-  (rfl)
+      q ^ 3 + MvPowerSeries.C (algebraMap R S W.a₁) * q * v +
+        MvPowerSeries.C (algebraMap R S W.a₂) * q ^ 2 * v +
+        MvPowerSeries.C (algebraMap R S W.a₃) * v ^ 2 +
+        MvPowerSeries.C (algebraMap R S W.a₄) * q * v ^ 2 +
+        MvPowerSeries.C (algebraMap R S W.a₆) * v ^ 3 := by
+  simp only [wEquationRHS_def, MvPowerSeries.algebraMap_apply]
 
 /-- **The right-hand side of the `w`-equation is a contraction for the total-degree filtration.**
 If two candidate solutions agree below total degree `k`, then the values of the equation at them
 agree below total degree `k + 1`. Every occurrence of the unknown is multiplied by the parameter,
 which has positive order, or sits in a square or a cube of a series of positive order, and that is
 where the extra degree comes from. -/
-private theorem le_order_wEquationRHS_sub {σ : Type*} {q u v : MvPowerSeries σ R}
+private theorem le_order_wEquationRHS_sub {σ S : Type*} [CommRing S] [Algebra R S]
+    {q u v : MvPowerSeries σ S}
     (hq : 1 ≤ q.order) (hu : 1 ≤ u.order) (hv : 1 ≤ v.order) {k : ℕ}
     (h : (k : ℕ∞) ≤ (u - v).order) :
     ((k + 1 : ℕ) : ℕ∞) ≤ (wEquationRHS W q u - wEquationRHS W q v).order := by
   -- The order estimates used below, in the vocabulary of `MvPowerSeries.order`.
-  have hmono : ∀ {m n : ℕ} {f : MvPowerSeries σ R}, m ≤ n → (n : ℕ∞) ≤ f.order →
+  have hmono : ∀ {m n : ℕ} {f : MvPowerSeries σ S}, m ≤ n → (n : ℕ∞) ≤ f.order →
       (m : ℕ∞) ≤ f.order := fun hmn hf => (Nat.cast_le.mpr hmn).trans hf
-  have hadd : ∀ {m : ℕ} {f g : MvPowerSeries σ R}, (m : ℕ∞) ≤ f.order → (m : ℕ∞) ≤ g.order →
+  have hadd : ∀ {m : ℕ} {f g : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order → (m : ℕ∞) ≤ g.order →
       (m : ℕ∞) ≤ (f + g).order :=
     fun hf hg => (le_min hf hg).trans MvPowerSeries.min_order_le_add
-  have hmul : ∀ {m n : ℕ} {f g : MvPowerSeries σ R}, (m : ℕ∞) ≤ f.order → (n : ℕ∞) ≤ g.order →
+  have hmul : ∀ {m n : ℕ} {f g : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order → (n : ℕ∞) ≤ g.order →
       ((m + n : ℕ) : ℕ∞) ≤ (f * g).order := by
     intro m n f g hf hg
     push_cast
     exact (add_le_add hf hg).trans MvPowerSeries.le_order_mul
-  have hC : ∀ {m : ℕ} (a : R) {f : MvPowerSeries σ R}, (m : ℕ∞) ≤ f.order →
+  have hC : ∀ {m : ℕ} (a : S) {f : MvPowerSeries σ S}, (m : ℕ∞) ≤ f.order →
       (m : ℕ∞) ≤ (MvPowerSeries.C a * f).order := by
     intro m a f hf
     exact (hf.trans le_add_self).trans MvPowerSeries.le_order_mul
@@ -515,9 +520,11 @@ private theorem le_order_wEquationRHS_sub {σ : Type*} {q u v : MvPowerSeries σ
     exact hmono (by omega) (hmul (hadd (hadd (hmul hu hu) (hmul hu hv)) (hmul hv hv)) h)
   -- Reassemble the difference and bound each summand.
   have hstep : wEquationRHS W q u - wEquationRHS W q v =
-      MvPowerSeries.C W.a₁ * (q * (u - v)) + MvPowerSeries.C W.a₂ * (q * q * (u - v)) +
-        MvPowerSeries.C W.a₃ * (u ^ 2 - v ^ 2) + MvPowerSeries.C W.a₄ * (q * (u ^ 2 - v ^ 2)) +
-        MvPowerSeries.C W.a₆ * (u ^ 3 - v ^ 3) := by
+      MvPowerSeries.C (algebraMap R S W.a₁) * (q * (u - v)) +
+        MvPowerSeries.C (algebraMap R S W.a₂) * (q * q * (u - v)) +
+        MvPowerSeries.C (algebraMap R S W.a₃) * (u ^ 2 - v ^ 2) +
+        MvPowerSeries.C (algebraMap R S W.a₄) * (q * (u ^ 2 - v ^ 2)) +
+        MvPowerSeries.C (algebraMap R S W.a₆) * (u ^ 3 - v ^ 3) := by
     rw [wEquationRHS_mvPowerSeries, wEquationRHS_mvPowerSeries]
     ring
   rw [hstep]
@@ -532,7 +539,8 @@ are equal, provided `q` too has vanishing constant coefficient.
 This is `eq_of_wEquation` one index type up. It is not a generalisation of it: the argument here
 subtracts, so it needs a `CommRing`, whereas the univariate statement holds over a `CommSemiring`.
 -/
-theorem eq_of_wEquation_mvPowerSeries {σ : Type*} {q v v' : MvPowerSeries σ R}
+theorem eq_of_wEquation_mvPowerSeries {σ S : Type*} [CommRing S] [Algebra R S]
+    {q v v' : MvPowerSeries σ S}
     (hq : MvPowerSeries.constantCoeff q = 0) (hv : MvPowerSeries.constantCoeff v = 0)
     (hv' : MvPowerSeries.constantCoeff v' = 0) (h : v = wEquationRHS W q v)
     (h' : v' = wEquationRHS W q v') : v = v' := by


### PR DESCRIPTION
Discharges the generality finding that **#4912 landed unfixed on `main`**.

#4912 merged at `a61e93366` (head `74870859a`) with nine of ten rubrics green and one live
`generality` finding at `WExpansion.lean:535`. The author had read the board, judged the finding
correct and written the fix — but could not build or push it, because the merge queue merges the
**enqueue-time tree** and the fix arrived after enqueue (see le-mlahn). Nobody erred; the fix
simply needs to land as a follow-up, which is this PR.

### The finding

Quoted from the review thread on #4912 rather than paraphrased:

> `eq_of_wEquation_mvPowerSeries` fixes `q v v' : MvPowerSeries σ R`, although `wEquationRHS` and
> the contraction proof work over any commutative `R`-algebra coefficient ring. *Fix:* Introduce
> `S` with `[CommRing S] [Algebra R S]` and state the candidates in `MvPowerSeries σ S`; likewise
> generalize the private contraction lemma.

### What changed

Three declarations move from `MvPowerSeries σ R` to `MvPowerSeries σ S` under
`[CommRing S] [Algebra R S]`:

* `eq_of_wEquation_mvPowerSeries` — the public uniqueness theorem the finding names;
* `le_order_wEquationRHS_sub` — the private contraction lemma, as the finding also asks;
* `wEquationRHS_mvPowerSeries` — the spelling the order estimates match against, which has to move
  with them.

`wEquationRHS` itself was **already** general in its coefficient algebra
(`{A} [CommSemiring A] [Algebra R A]`), so nothing about the equation needed changing — only the
`MvPowerSeries` statements were pinned to `R`. The file already uses this exact idiom next door at
`subst_wEquationRHS`, so the shape is native rather than novel.

**One consequence worth flagging for review:** `wEquationRHS_mvPowerSeries` is no longer `rfl`.
Over `R` the structure map *is* `MvPowerSeries.C`; over `S` it factors as `C` after
`algebraMap R S`, so the proof now goes through `MvPowerSeries.algebraMap_apply`. That is the one
technical step, and it is the route the original author had already resolved against Mathlib at
the pinned revision.

### What is deliberately not changed

`eq_of_wEquation` and `eq_of_wEquation_mvPowerSeries` remain a **pair**, not a generalisation. The
multivariate argument subtracts, so it needs `CommRing`; the univariate statement holds over
`CommSemiring`. That is recorded in the module docstring and was settled in review on the original
PR, so this PR does not merge them.

Scope is one file. No other file is touched.

### Gates

* `lake build` of the changed module — 1775 jobs, success.
* `lake build` of **all three direct importers** — `FormalGroup/Inverse`, `FormalGroup/Eval`,
  `FormalGroup/Chord` — 2079 jobs, success. This is the load-bearing gate for a signature
  widening: `MvPowerSeries σ R → MvPowerSeries σ S` is exactly the change that can leave a
  downstream call site unable to infer `S`, and the changed module alone would not show it.
* `lake env lean` on the changed file: exit 0, zero bytes — no errors, warnings or `info:`.
* `#lint only simpNF in TauCeti` over the module: 0 errors in **53 declarations** (nonzero count,
  so the linter is genuinely seeing the file).
* Style: max width 99 characters, no trailing whitespace.

Roadmap: EllipticCurves
