### PR TITLE
feat(Huber): the degree decomposition of the two-sided restricted families

### DIFF
--- a/TauCeti/LinearAlgebra/Pi.lean
+++ b/TauCeti/LinearAlgebra/Pi.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Pi
+
+/-!
+# Disjointness of `Submodule.pi` supports
+
+For `s : Set ι`, the submodule `Submodule.pi sᶜ (fun _ ↦ ⊥)` of `ι → M` consists of the families
+vanishing outside `s` — the `Pi` analogue of `Finsupp.supported`. This file records that
+complementary supports meet in `⊥`.
+
+Mathlib has `Set.disjoint_pi`, but that is about `Set.pi` and characterises disjointness through
+the fibres; it says nothing about the submodules cut out by a support condition.
+
+## Main results
+
+* `Submodule.disjoint_pi_compl_bot_of_disjoint`: disjoint index sets give disjoint submodules of
+  families vanishing outside them.
+-/
+
+namespace Submodule
+
+variable {A M : Type*} [Semiring A] [AddCommMonoid M] [Module A M]
+
+/-- **Disjoint sets of indices give disjoint submodules of families vanishing outside them.**
+A family vanishing outside `s` and outside `t` at once, for `s` and `t` disjoint, vanishes
+everywhere. The submodules are `Submodule.pi` at the zero submodule.
+
+Nothing here is topological or about any particular index type; the Huber two-sided series use it
+at `ι = ℤ` with `s` and `t` the non-negative and negative degrees. -/
+public theorem disjoint_pi_compl_bot_of_disjoint {ι : Type*} {s t : Set ι} (h : Disjoint s t) :
+    Disjoint (Submodule.pi sᶜ fun _ ↦ (⊥ : Submodule A M))
+      (Submodule.pi tᶜ fun _ ↦ (⊥ : Submodule A M)) :=
+  Submodule.disjoint_def.mpr fun f hs ht ↦ funext fun i ↦ by
+    by_cases hi : i ∈ s
+    · exact ht i (Set.disjoint_left.mp h hi)
+    · exact hs i hi
+
+end Submodule

--- a/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
+++ b/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
@@ -75,18 +75,21 @@ theorem ZeroAtFilter.comp {γ : Type*} [Zero β] [TopologicalSpace β] [Zero γ]
   have h := Filter.Tendsto.comp hφ hg
   rwa [h0] at h
 
-/-- **Zeroing values keeps a function zero at a filter.** If every value of `g` is either the
-corresponding value of `f` or `0`, then `g` inherits `ZeroAtFilter`: since `0` lies in every
-neighbourhood of `0`, the preimage of such a neighbourhood under `g` contains the one under `f`.
+/-- **Zeroing values keeps a function zero at a filter.** If `g` eventually agrees with `f` or
+vanishes, then `g` inherits `ZeroAtFilter`: since `0` lies in every neighbourhood of `0`, the
+preimage of such a neighbourhood under `g` contains the intersection of the one under `f` with
+the set where the hypothesis holds.
 
-Stated pointwise rather than for an indicator, so it carries no decidability hypothesis and also
-covers truncations that are not indicators. -/
-theorem ZeroAtFilter.of_forall_eq_or_eq_zero [Zero β] [TopologicalSpace β] {f g : α → β}
-    (hf : ZeroAtFilter l f) (h : ∀ a, g a = f a ∨ g a = 0) : ZeroAtFilter l g := fun _ hU ↦
-  Filter.mem_map.mpr (Filter.mem_of_superset (Filter.mem_map.mp (hf hU)) fun a ha ↦ by
-    rcases h a with he | he
-    · simpa [he] using ha
-    · simpa [he] using mem_of_mem_nhds hU)
+Only an eventual hypothesis is needed, because convergence along `l` sees `g` only through sets
+in `l`. Stated pointwise rather than for an indicator, so it carries no decidability hypothesis
+and also covers truncations that are not indicators. -/
+theorem ZeroAtFilter.of_eventually_eq_or_eq_zero [Zero β] [TopologicalSpace β] {f g : α → β}
+    (hf : ZeroAtFilter l f) (h : ∀ᶠ a in l, g a = f a ∨ g a = 0) : ZeroAtFilter l g := fun _ hU ↦
+  Filter.mem_map.mpr (Filter.mem_of_superset
+    (Filter.inter_mem (Filter.mem_map.mp (hf hU)) h) fun a ha ↦ by
+      rcases ha.2 with he | he
+      · simpa [he] using ha.1
+      · simpa [he] using mem_of_mem_nhds hU)
 
 end Filter
 

--- a/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
+++ b/TauCeti/Order/Filter/ZeroAndBoundedAtFilter.lean
@@ -75,6 +75,19 @@ theorem ZeroAtFilter.comp {γ : Type*} [Zero β] [TopologicalSpace β] [Zero γ]
   have h := Filter.Tendsto.comp hφ hg
   rwa [h0] at h
 
+/-- **Zeroing values keeps a function zero at a filter.** If every value of `g` is either the
+corresponding value of `f` or `0`, then `g` inherits `ZeroAtFilter`: since `0` lies in every
+neighbourhood of `0`, the preimage of such a neighbourhood under `g` contains the one under `f`.
+
+Stated pointwise rather than for an indicator, so it carries no decidability hypothesis and also
+covers truncations that are not indicators. -/
+theorem ZeroAtFilter.of_forall_eq_or_eq_zero [Zero β] [TopologicalSpace β] {f g : α → β}
+    (hf : ZeroAtFilter l f) (h : ∀ a, g a = f a ∨ g a = 0) : ZeroAtFilter l g := fun _ hU ↦
+  Filter.mem_map.mpr (Filter.mem_of_superset (Filter.mem_map.mp (hf hU)) fun a ha ↦ by
+    rcases h a with he | he
+    · simpa [he] using ha
+    · simpa [he] using mem_of_mem_nhds hU)
+
 end Filter
 
 end

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -44,7 +44,7 @@ a placement hazard:
 
 * `TauCeti.Huber.twoSidedRestrictedSubmodule`: the `A`-module of two-sided restricted families,
   the coefficient object underlying `A⟨X, X⁻¹⟩`.
-* `TauCeti.Huber.disjoint_pi_bot_of_disjoint_compl`: disjoint index sets give disjoint
+* `TauCeti.Huber.disjoint_pi_compl_bot_of_disjoint`: disjoint index sets give disjoint
   submodules of families vanishing outside them. Stated for
   an arbitrary set because nothing in it is about `ℤ` or about the sign of a degree; Mathlib has
   the `Finsupp` analogue, `Finsupp.supported`, but no `Pi` one.
@@ -63,7 +63,7 @@ a placement hazard:
   directness** — `A⟨X, X⁻¹⟩` is the sum of its non-negative and negative parts, and that sum is
   direct. This is fact (i) of Wedhorn's Lemma 8.33 at the level of coefficients, and it is what
   the diagram chase there needs; the Example 6.39 universal property does not supply it.
-* `TauCeti.Huber.zeroAtFilter_of_forall_eq_or_eq_zero`: zeroing coefficients keeps a family
+* `Filter.ZeroAtFilter.of_forall_eq_or_eq_zero`: zeroing coefficients keeps a family
   restricted. Stated pointwise rather than for an indicator, so it carries no decidability
   hypothesis; it is what makes the decomposition land inside the submodule rather than merely
   inside `ℤ → M`.
@@ -156,7 +156,7 @@ omit [TopologicalSpace M] in
 /-- **Disjoint sets of indices give disjoint submodules of families vanishing outside them.**
 A family vanishing outside `s` and outside `t` at once, for `s` and `t` disjoint, vanishes
 everywhere. The submodules are Mathlib's `Submodule.pi` at the zero submodule. -/
-theorem disjoint_pi_bot_of_disjoint_compl {ι : Type*} {s t : Set ι} (h : Disjoint s t) :
+theorem disjoint_pi_compl_bot_of_disjoint {ι : Type*} {s t : Set ι} (h : Disjoint s t) :
     Disjoint (Submodule.pi sᶜ fun _ ↦ (⊥ : Submodule A M))
       (Submodule.pi tᶜ fun _ ↦ (⊥ : Submodule A M)) :=
   Submodule.disjoint_def.mpr fun f hs ht ↦ funext fun i ↦ by
@@ -168,7 +168,7 @@ variable (A M) [ContinuousAdd M] [ContinuousConstSMul A M]
 
 /-- **Wedhorn's degree decomposition, Lemma 8.33(i).** A two-sided restricted family is the sum of
 its non-negative part and its negative part: `A⟨z, z⁻¹⟩ = A⟨z⟩ + z⁻¹A⟨z⁻¹⟩` at the level of
-coefficients. Each summand is again restricted by `zeroAtFilter_of_forall_eq_or_eq_zero`. -/
+coefficients. Each summand is again restricted by `Filter.ZeroAtFilter.of_forall_eq_or_eq_zero`. -/
 theorem twoSidedRestrictedSubmodule_eq_sup :
     twoSidedRestrictedSubmodule A M =
       (twoSidedRestrictedSubmodule A M ⊓
@@ -201,7 +201,7 @@ theorem disjoint_twoSidedRestricted_nonneg_neg :
     rw [Set.disjoint_left]
     intro n hn hn'
     exact lt_irrefl n (lt_of_lt_of_le hn' hn)
-  exact (disjoint_pi_bot_of_disjoint_compl (A := A) (M := M) hst).mono inf_le_right inf_le_right
+  exact (disjoint_pi_compl_bot_of_disjoint (A := A) (M := M) hst).mono inf_le_right inf_le_right
 
 end DegreeSplit
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Order.Filter.ZeroAndBoundedAtFilter
 public import TauCeti.Topology.Algebra.Nonarchimedean.ZeroAtFilter
 
 /-!
@@ -153,7 +154,7 @@ variable (A M : Type*) [Semiring A] [AddCommMonoid M] [TopologicalSpace M] [Modu
 Stated for an arbitrary `s` rather than for the two half-lines it is used at below, because
 nothing in it is about `ℤ` or about the sign of a degree. Mathlib has the `Finsupp` analogue,
 `Finsupp.supported`, but no `Pi` one. -/
-def supportedOn (s : Set ℤ) : Submodule A (ℤ → M) where
+def supportedOn {ι : Type*} (s : Set ι) : Submodule A (ι → M) where
   carrier := {f | ∀ n ∉ s, f n = 0}
   zero_mem' _ _ := rfl
   add_mem' hf hg n hn := by simp [hf n hn, hg n hn]
@@ -164,25 +165,18 @@ variable {A M}
 omit [TopologicalSpace M] in
 /-- Membership in `supportedOn` is vanishing outside the set of degrees. -/
 @[simp]
-theorem mem_supportedOn {s : Set ℤ} {f : ℤ → M} :
+theorem mem_supportedOn {ι : Type*} {s : Set ι} {f : ι → M} :
     f ∈ supportedOn A M s ↔ ∀ n ∉ s, f n = 0 := (Iff.rfl)
 
-/-- **Zeroing coefficients keeps a family restricted.** If every coefficient of `g` is either the
-corresponding coefficient of `f` or `0`, then `g` inherits the convergence condition: zeroing can
-only shrink the set of indices at which the family leaves a neighbourhood of `0`.
-
-Stated pointwise rather than for an indicator so that it carries no decidability hypothesis. It is
-what makes the degree split below land *inside* the submodule rather than merely inside
-`ℤ → M`. -/
-theorem zeroAtFilter_of_forall_eq_or_eq_zero {f g : ℤ → M} (hf : ZeroAtFilter cofinite f)
-    (h : ∀ n, g n = f n ∨ g n = 0) : ZeroAtFilter cofinite g := by
-  intro U hU
-  have h0 : (0 : M) ∈ U := mem_of_mem_nhds hU
-  refine Filter.mem_map.mpr (Filter.mem_cofinite.mpr (Set.Finite.subset
-    (Filter.mem_cofinite.mp (Filter.mem_map.mp (hf hU))) fun n hn ↦ ?_))
-  rcases h n with hgn | hgn
-  · simpa [hgn] using hn
-  · exact absurd (by simpa [hgn] using h0) hn
+omit [TopologicalSpace M] in
+/-- **Disjoint sets of indices give disjoint supported submodules.** A family supported on both
+of two disjoint sets vanishes everywhere. -/
+theorem disjoint_supportedOn {ι : Type*} {s t : Set ι} (h : Disjoint s t) :
+    Disjoint (supportedOn A M s) (supportedOn A M t) :=
+  Submodule.disjoint_def.mpr fun f hs ht ↦ funext fun i ↦ by
+    by_cases hi : i ∈ s
+    · exact ht i (Set.disjoint_left.mp h hi)
+    · exact hs i hi
 
 variable (A M) [ContinuousAdd M] [ContinuousConstSMul A M]
 
@@ -196,9 +190,9 @@ theorem twoSidedRestrictedSubmodule_eq_sup :
   refine le_antisymm (fun f hf ↦ ?_) (sup_le inf_le_left inf_le_left)
   refine Submodule.mem_sup.mpr
     ⟨fun n ↦ if 0 ≤ n then f n else 0, ⟨?_, ?_⟩, fun n ↦ if n < 0 then f n else 0, ⟨?_, ?_⟩, ?_⟩
-  · exact zeroAtFilter_of_forall_eq_or_eq_zero hf fun n ↦ by split_ifs <;> simp
+  · exact hf.of_forall_eq_or_eq_zero fun n ↦ by split_ifs <;> simp
   · intro n hn; simpa using fun h ↦ absurd h (by simpa using hn)
-  · exact zeroAtFilter_of_forall_eq_or_eq_zero hf fun n ↦ by split_ifs <;> simp
+  · exact hf.of_forall_eq_or_eq_zero fun n ↦ by split_ifs <;> simp
   · intro n hn; simpa using fun h ↦ absurd h (by simpa using hn)
   · funext n; by_cases h : (0 : ℤ) ≤ n <;> simp [h, not_lt.mpr, not_le.mp]
 
@@ -207,12 +201,13 @@ degrees at once is zero, so the two summands of `twoSidedRestrictedSubmodule_eq_
 Together they exhibit `A⟨z, z⁻¹⟩` as the internal direct sum of the two half-line pieces. -/
 theorem disjoint_twoSidedRestricted_nonneg_neg :
     Disjoint (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | 0 ≤ n})
-      (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | n < 0}) := by
-  refine Submodule.disjoint_def.mpr fun f hnonneg hneg ↦ ?_
-  funext n
-  by_cases h : (0 : ℤ) ≤ n
-  · exact hneg.2 n (by simpa using h)
-  · exact hnonneg.2 n (by simpa using h)
+      (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | n < 0}) :=
+  by
+  have hst : Disjoint {n : ℤ | 0 ≤ n} {n : ℤ | n < 0} := by
+    rw [Set.disjoint_left]
+    intro n hn hn'
+    exact lt_irrefl n (lt_of_lt_of_le hn' hn)
+  exact (disjoint_supportedOn (A := A) (M := M) hst).mono inf_le_right inf_le_right
 
 end DegreeSplit
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -44,7 +44,8 @@ a placement hazard:
 
 * `TauCeti.Huber.twoSidedRestrictedSubmodule`: the `A`-module of two-sided restricted families,
   the coefficient object underlying `A⟨X, X⁻¹⟩`.
-* `TauCeti.Huber.supportedOn`: the families vanishing outside a given set of degrees. Stated for
+* `TauCeti.Huber.disjoint_pi_bot_of_disjoint_compl`: disjoint index sets give disjoint
+  submodules of families vanishing outside them. Stated for
   an arbitrary set because nothing in it is about `ℤ` or about the sign of a degree; Mathlib has
   the `Finsupp` analogue, `Finsupp.supported`, but no `Pi` one.
 
@@ -149,30 +150,15 @@ section DegreeSplit
 
 variable (A M : Type*) [Semiring A] [AddCommMonoid M] [TopologicalSpace M] [Module A M]
 
-/-- The families supported on a set of degrees: those vanishing at every index outside `s`.
-
-Stated for an arbitrary `s` rather than for the two half-lines it is used at below, because
-nothing in it is about `ℤ` or about the sign of a degree. Mathlib has the `Finsupp` analogue,
-`Finsupp.supported`, but no `Pi` one. -/
-def supportedOn {ι : Type*} (s : Set ι) : Submodule A (ι → M) where
-  carrier := {f | ∀ n ∉ s, f n = 0}
-  zero_mem' _ _ := rfl
-  add_mem' hf hg n hn := by simp [hf n hn, hg n hn]
-  smul_mem' c _ hf n hn := by simp [hf n hn]
-
 variable {A M}
 
 omit [TopologicalSpace M] in
-/-- Membership in `supportedOn` is vanishing outside the set of degrees. -/
-@[simp]
-theorem mem_supportedOn {ι : Type*} {s : Set ι} {f : ι → M} :
-    f ∈ supportedOn A M s ↔ ∀ n ∉ s, f n = 0 := (Iff.rfl)
-
-omit [TopologicalSpace M] in
-/-- **Disjoint sets of indices give disjoint supported submodules.** A family supported on both
-of two disjoint sets vanishes everywhere. -/
-theorem disjoint_supportedOn {ι : Type*} {s t : Set ι} (h : Disjoint s t) :
-    Disjoint (supportedOn A M s) (supportedOn A M t) :=
+/-- **Disjoint sets of indices give disjoint submodules of families vanishing outside them.**
+A family vanishing outside `s` and outside `t` at once, for `s` and `t` disjoint, vanishes
+everywhere. The submodules are Mathlib's `Submodule.pi` at the zero submodule. -/
+theorem disjoint_pi_bot_of_disjoint_compl {ι : Type*} {s t : Set ι} (h : Disjoint s t) :
+    Disjoint (Submodule.pi sᶜ fun _ ↦ (⊥ : Submodule A M))
+      (Submodule.pi tᶜ fun _ ↦ (⊥ : Submodule A M)) :=
   Submodule.disjoint_def.mpr fun f hs ht ↦ funext fun i ↦ by
     by_cases hi : i ∈ s
     · exact ht i (Set.disjoint_left.mp h hi)
@@ -185,29 +171,37 @@ its non-negative part and its negative part: `A⟨z, z⁻¹⟩ = A⟨z⟩ + z⁻
 coefficients. Each summand is again restricted by `zeroAtFilter_of_forall_eq_or_eq_zero`. -/
 theorem twoSidedRestrictedSubmodule_eq_sup :
     twoSidedRestrictedSubmodule A M =
-      (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | 0 ≤ n}) ⊔
-        (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | n < 0}) := by
+      (twoSidedRestrictedSubmodule A M ⊓
+          Submodule.pi {n : ℤ | 0 ≤ n}ᶜ fun _ ↦ (⊥ : Submodule A M)) ⊔
+        (twoSidedRestrictedSubmodule A M ⊓
+          Submodule.pi {n : ℤ | n < 0}ᶜ fun _ ↦ (⊥ : Submodule A M)) := by
   refine le_antisymm (fun f hf ↦ ?_) (sup_le inf_le_left inf_le_left)
+  have hcompl : {n : ℤ | n < 0} = {n : ℤ | 0 ≤ n}ᶜ := by ext n; simp [not_le]
   refine Submodule.mem_sup.mpr
-    ⟨fun n ↦ if 0 ≤ n then f n else 0, ⟨?_, ?_⟩, fun n ↦ if n < 0 then f n else 0, ⟨?_, ?_⟩, ?_⟩
-  · exact hf.of_forall_eq_or_eq_zero fun n ↦ by split_ifs <;> simp
-  · intro n hn; simpa using fun h ↦ absurd h (by simpa using hn)
-  · exact hf.of_forall_eq_or_eq_zero fun n ↦ by split_ifs <;> simp
-  · intro n hn; simpa using fun h ↦ absurd h (by simpa using hn)
-  · funext n; by_cases h : (0 : ℤ) ≤ n <;> simp [h, not_lt.mpr, not_le.mp]
+    ⟨{n : ℤ | 0 ≤ n}.indicator f, ⟨?_, ?_⟩, {n : ℤ | n < 0}.indicator f, ⟨?_, ?_⟩, ?_⟩
+  · exact hf.of_forall_eq_or_eq_zero fun n ↦ by
+      by_cases h : n ∈ {n : ℤ | 0 ≤ n} <;> simp [h]
+  · intro n hn; simpa [Set.indicator_apply] using fun h ↦ absurd h (by simpa using hn)
+  · exact hf.of_forall_eq_or_eq_zero fun n ↦ by
+      by_cases h : n ∈ {n : ℤ | n < 0} <;> simp [h]
+  · intro n hn; simpa [Set.indicator_apply] using fun h ↦ absurd h (by simpa using hn)
+  · rw [hcompl]; exact Set.indicator_self_add_compl _ f
 
 /-- **The decomposition is direct.** A family supported in non-negative degrees and in negative
 degrees at once is zero, so the two summands of `twoSidedRestrictedSubmodule_eq_sup` meet in `⊥`.
 Together they exhibit `A⟨z, z⁻¹⟩` as the internal direct sum of the two half-line pieces. -/
 theorem disjoint_twoSidedRestricted_nonneg_neg :
-    Disjoint (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | 0 ≤ n})
-      (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | n < 0}) :=
+    Disjoint
+      (twoSidedRestrictedSubmodule A M ⊓
+        Submodule.pi {n : ℤ | 0 ≤ n}ᶜ fun _ ↦ (⊥ : Submodule A M))
+      (twoSidedRestrictedSubmodule A M ⊓
+        Submodule.pi {n : ℤ | n < 0}ᶜ fun _ ↦ (⊥ : Submodule A M)) :=
   by
   have hst : Disjoint {n : ℤ | 0 ≤ n} {n : ℤ | n < 0} := by
     rw [Set.disjoint_left]
     intro n hn hn'
     exact lt_irrefl n (lt_of_lt_of_le hn' hn)
-  exact (disjoint_supportedOn (A := A) (M := M) hst).mono inf_le_right inf_le_right
+  exact (disjoint_pi_bot_of_disjoint_compl (A := A) (M := M) hst).mono inf_le_right inf_le_right
 
 end DegreeSplit
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -63,7 +63,10 @@ a placement hazard:
   directness** — `A⟨X, X⁻¹⟩` is the sum of its non-negative and negative parts, and that sum is
   direct. This is fact (i) of Wedhorn's Lemma 8.33 at the level of coefficients, and it is what
   the diagram chase there needs; the Example 6.39 universal property does not supply it.
-* `Filter.ZeroAtFilter.of_forall_eq_or_eq_zero`: zeroing coefficients keeps a family
+* `TauCeti.Huber.twoSidedRestrictedSubmodule_eq_sup_compl`: the same decomposition along an
+  arbitrary set of degrees and its complement, of which the sign partition above is a special
+  case. Nothing in the argument uses the order on `ℤ`, only that the two sets are complementary.
+* `Filter.ZeroAtFilter.of_eventually_eq_or_eq_zero`: zeroing coefficients keeps a family
   restricted. Stated pointwise rather than for an indicator, so it carries no decidability
   hypothesis; it is what makes the decomposition land inside the submodule rather than merely
   inside `ℤ → M`.
@@ -166,26 +169,42 @@ theorem disjoint_pi_compl_bot_of_disjoint {ι : Type*} {s t : Set ι} (h : Disjo
 
 variable (A M) [ContinuousAdd M] [ContinuousConstSMul A M]
 
+/-- **The degree decomposition along any set of degrees and its complement.** A two-sided
+restricted family is the sum of its part supported in `s` and its part supported in `sᶜ`. The
+argument uses nothing about `s` beyond the two sets being complementary: the witnesses are the
+two indicators of `f`, each restricted by `Filter.ZeroAtFilter.of_eventually_eq_or_eq_zero`, and
+they add back to `f` by `Set.indicator_self_add_compl`. The sign partition of
+`twoSidedRestrictedSubmodule_eq_sup` is the case `s = {n | 0 ≤ n}`. -/
+theorem twoSidedRestrictedSubmodule_eq_sup_compl (s : Set ℤ) :
+    twoSidedRestrictedSubmodule A M =
+      (twoSidedRestrictedSubmodule A M ⊓
+          Submodule.pi sᶜ fun _ ↦ (⊥ : Submodule A M)) ⊔
+        (twoSidedRestrictedSubmodule A M ⊓
+          Submodule.pi s fun _ ↦ (⊥ : Submodule A M)) := by
+  refine le_antisymm (fun f hf ↦ ?_) (sup_le inf_le_left inf_le_left)
+  refine Submodule.mem_sup.mpr
+    ⟨s.indicator f, ⟨?_, ?_⟩, sᶜ.indicator f, ⟨?_, ?_⟩, ?_⟩
+  · exact hf.of_eventually_eq_or_eq_zero (.of_forall fun n ↦ by
+      by_cases h : n ∈ s <;> simp [h])
+  · intro n hn; simpa [Set.indicator_apply] using fun h ↦ absurd h (by simpa using hn)
+  · exact hf.of_eventually_eq_or_eq_zero (.of_forall fun n ↦ by
+      by_cases h : n ∈ sᶜ <;> simp [h])
+  · intro n hn; simpa [Set.indicator_apply] using fun h ↦ absurd h (by simpa using hn)
+  · exact Set.indicator_self_add_compl _ f
+
 /-- **Wedhorn's degree decomposition, Lemma 8.33(i).** A two-sided restricted family is the sum of
 its non-negative part and its negative part: `A⟨z, z⁻¹⟩ = A⟨z⟩ + z⁻¹A⟨z⁻¹⟩` at the level of
-coefficients. Each summand is again restricted by `Filter.ZeroAtFilter.of_forall_eq_or_eq_zero`. -/
+coefficients. This is `twoSidedRestrictedSubmodule_eq_sup_compl` at the sign partition, which is
+where the restrictedness of each summand is established. -/
 theorem twoSidedRestrictedSubmodule_eq_sup :
     twoSidedRestrictedSubmodule A M =
       (twoSidedRestrictedSubmodule A M ⊓
           Submodule.pi {n : ℤ | 0 ≤ n}ᶜ fun _ ↦ (⊥ : Submodule A M)) ⊔
         (twoSidedRestrictedSubmodule A M ⊓
           Submodule.pi {n : ℤ | n < 0}ᶜ fun _ ↦ (⊥ : Submodule A M)) := by
-  refine le_antisymm (fun f hf ↦ ?_) (sup_le inf_le_left inf_le_left)
-  have hcompl : {n : ℤ | n < 0} = {n : ℤ | 0 ≤ n}ᶜ := by ext n; simp [not_le]
-  refine Submodule.mem_sup.mpr
-    ⟨{n : ℤ | 0 ≤ n}.indicator f, ⟨?_, ?_⟩, {n : ℤ | n < 0}.indicator f, ⟨?_, ?_⟩, ?_⟩
-  · exact hf.of_forall_eq_or_eq_zero fun n ↦ by
-      by_cases h : n ∈ {n : ℤ | 0 ≤ n} <;> simp [h]
-  · intro n hn; simpa [Set.indicator_apply] using fun h ↦ absurd h (by simpa using hn)
-  · exact hf.of_forall_eq_or_eq_zero fun n ↦ by
-      by_cases h : n ∈ {n : ℤ | n < 0} <;> simp [h]
-  · intro n hn; simpa [Set.indicator_apply] using fun h ↦ absurd h (by simpa using hn)
-  · rw [hcompl]; exact Set.indicator_self_add_compl _ f
+  have hcompl : {n : ℤ | n < 0}ᶜ = {n : ℤ | 0 ≤ n} := by ext n; simp
+  rw [hcompl]
+  exact twoSidedRestrictedSubmodule_eq_sup_compl A M {n : ℤ | 0 ≤ n}
 
 /-- **The decomposition is direct.** A family supported in non-negative degrees and in negative
 degrees at once is zero, so the two summands of `twoSidedRestrictedSubmodule_eq_sup` meet in `⊥`.

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -13,8 +13,8 @@ public import TauCeti.Topology.Algebra.Nonarchimedean.ZeroAtFilter
 Wedhorn's Example 6.39 introduces, for a Tate ring `A`, the ring of formal series
 `∑_{n ∈ ℤ} aₙ Xⁿ` whose coefficients satisfy a convergence condition: for every neighbourhood `U`
 of zero, all but finitely many `aₙ` lie in `U`. This module builds the underlying coefficient
-object — the `A`-module of such two-sided families — together with its coefficients and
-extensionality.
+object — the `A`-module of such two-sided families — together with its coefficients,
+extensionality, and the decomposition of that module by degree.
 
 The condition is exactly the one `TauCeti.Huber.IsRestricted` already expresses for the
 one-sided series `A⟨X₁, …, Xₖ⟩`: a coefficient family tending to `0` along the cofinite filter,
@@ -43,6 +43,9 @@ a placement hazard:
 
 * `TauCeti.Huber.twoSidedRestrictedSubmodule`: the `A`-module of two-sided restricted families,
   the coefficient object underlying `A⟨X, X⁻¹⟩`.
+* `TauCeti.Huber.supportedOn`: the families vanishing outside a given set of degrees. Stated for
+  an arbitrary set because nothing in it is about `ℤ` or about the sign of a degree; Mathlib has
+  the `Finsupp` analogue, `Finsupp.supported`, but no `Pi` one.
 
 ## Main results
 
@@ -53,6 +56,15 @@ a placement hazard:
   `TauCeti/Topology/Algebra/Nonarchimedean/ZeroAtFilter.lean` because neither direction of it
   looks at the index set or at series.
 * `TauCeti.Huber.twoSidedRestrictedSubmodule_ext`: coefficientwise extensionality.
+* `TauCeti.Huber.twoSidedRestrictedSubmodule_eq_sup` and
+  `TauCeti.Huber.disjoint_twoSidedRestricted_nonneg_neg`: **the degree decomposition and its
+  directness** — `A⟨X, X⁻¹⟩` is the sum of its non-negative and negative parts, and that sum is
+  direct. This is fact (i) of Wedhorn's Lemma 8.33 at the level of coefficients, and it is what
+  the diagram chase there needs; the Example 6.39 universal property does not supply it.
+* `TauCeti.Huber.zeroAtFilter_of_forall_eq_or_eq_zero`: zeroing coefficients keeps a family
+  restricted. Stated pointwise rather than for an indicator, so it carries no decidability
+  hypothesis; it is what makes the decomposition land inside the submodule rather than merely
+  inside `ℤ → M`.
 
 ## Implementation notes
 
@@ -65,7 +77,8 @@ finite sum. That is separate work and does not belong to this rung.
 
 ## References
 
-* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Example 6.39.
+* [T. Wedhorn, *Adic Spaces*][wedhorn_adic] (arXiv:1910.05934v1), Example 6.39 and §8.2.1,
+  Lemma 8.33.
 -/
 
 public section
@@ -130,5 +143,77 @@ theorem mem_twoSidedRestrictedSubmodule_iff_finite_notMem {f : ℤ → M} :
   exact NonarchimedeanAddGroup.zeroAtFilter_cofinite_iff_finite_notMem
 
 end WedhornCriterion
+
+section DegreeSplit
+
+variable (A M : Type*) [Semiring A] [AddCommMonoid M] [TopologicalSpace M] [Module A M]
+
+/-- The families supported on a set of degrees: those vanishing at every index outside `s`.
+
+Stated for an arbitrary `s` rather than for the two half-lines it is used at below, because
+nothing in it is about `ℤ` or about the sign of a degree. Mathlib has the `Finsupp` analogue,
+`Finsupp.supported`, but no `Pi` one. -/
+def supportedOn (s : Set ℤ) : Submodule A (ℤ → M) where
+  carrier := {f | ∀ n ∉ s, f n = 0}
+  zero_mem' _ _ := rfl
+  add_mem' hf hg n hn := by simp [hf n hn, hg n hn]
+  smul_mem' c _ hf n hn := by simp [hf n hn]
+
+variable {A M}
+
+omit [TopologicalSpace M] in
+/-- Membership in `supportedOn` is vanishing outside the set of degrees. -/
+@[simp]
+theorem mem_supportedOn {s : Set ℤ} {f : ℤ → M} :
+    f ∈ supportedOn A M s ↔ ∀ n ∉ s, f n = 0 := (Iff.rfl)
+
+/-- **Zeroing coefficients keeps a family restricted.** If every coefficient of `g` is either the
+corresponding coefficient of `f` or `0`, then `g` inherits the convergence condition: zeroing can
+only shrink the set of indices at which the family leaves a neighbourhood of `0`.
+
+Stated pointwise rather than for an indicator so that it carries no decidability hypothesis. It is
+what makes the degree split below land *inside* the submodule rather than merely inside
+`ℤ → M`. -/
+theorem zeroAtFilter_of_forall_eq_or_eq_zero {f g : ℤ → M} (hf : ZeroAtFilter cofinite f)
+    (h : ∀ n, g n = f n ∨ g n = 0) : ZeroAtFilter cofinite g := by
+  intro U hU
+  have h0 : (0 : M) ∈ U := mem_of_mem_nhds hU
+  refine Filter.mem_map.mpr (Filter.mem_cofinite.mpr (Set.Finite.subset
+    (Filter.mem_cofinite.mp (Filter.mem_map.mp (hf hU))) fun n hn ↦ ?_))
+  rcases h n with hgn | hgn
+  · simpa [hgn] using hn
+  · exact absurd (by simpa [hgn] using h0) hn
+
+variable (A M) [ContinuousAdd M] [ContinuousConstSMul A M]
+
+/-- **Wedhorn's degree decomposition, Lemma 8.33(i).** A two-sided restricted family is the sum of
+its non-negative part and its negative part: `A⟨z, z⁻¹⟩ = A⟨z⟩ + z⁻¹A⟨z⁻¹⟩` at the level of
+coefficients. Each summand is again restricted by `zeroAtFilter_of_forall_eq_or_eq_zero`. -/
+theorem twoSidedRestrictedSubmodule_eq_sup :
+    twoSidedRestrictedSubmodule A M =
+      (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | 0 ≤ n}) ⊔
+        (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | n < 0}) := by
+  refine le_antisymm (fun f hf ↦ ?_) (sup_le inf_le_left inf_le_left)
+  refine Submodule.mem_sup.mpr
+    ⟨fun n ↦ if 0 ≤ n then f n else 0, ⟨?_, ?_⟩, fun n ↦ if n < 0 then f n else 0, ⟨?_, ?_⟩, ?_⟩
+  · exact zeroAtFilter_of_forall_eq_or_eq_zero hf fun n ↦ by split_ifs <;> simp
+  · intro n hn; simpa using fun h ↦ absurd h (by simpa using hn)
+  · exact zeroAtFilter_of_forall_eq_or_eq_zero hf fun n ↦ by split_ifs <;> simp
+  · intro n hn; simpa using fun h ↦ absurd h (by simpa using hn)
+  · funext n; by_cases h : (0 : ℤ) ≤ n <;> simp [h, not_lt.mpr, not_le.mp]
+
+/-- **The decomposition is direct.** A family supported in non-negative degrees and in negative
+degrees at once is zero, so the two summands of `twoSidedRestrictedSubmodule_eq_sup` meet in `⊥`.
+Together they exhibit `A⟨z, z⁻¹⟩` as the internal direct sum of the two half-line pieces. -/
+theorem disjoint_twoSidedRestricted_nonneg_neg :
+    Disjoint (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | 0 ≤ n})
+      (twoSidedRestrictedSubmodule A M ⊓ supportedOn A M {n : ℤ | n < 0}) := by
+  refine Submodule.disjoint_def.mpr fun f hnonneg hneg ↦ ?_
+  funext n
+  by_cases h : (0 : ℤ) ≤ n
+  · exact hneg.2 n (by simpa using h)
+  · exact hnonneg.2 n (by simpa using h)
+
+end DegreeSplit
 
 end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.LinearAlgebra.Pi
 public import TauCeti.Order.Filter.ZeroAndBoundedAtFilter
 public import TauCeti.Topology.Algebra.Nonarchimedean.ZeroAtFilter
 
@@ -44,10 +45,6 @@ a placement hazard:
 
 * `TauCeti.Huber.twoSidedRestrictedSubmodule`: the `A`-module of two-sided restricted families,
   the coefficient object underlying `A⟨X, X⁻¹⟩`.
-* `TauCeti.Huber.disjoint_pi_compl_bot_of_disjoint`: disjoint index sets give disjoint
-  submodules of families vanishing outside them. Stated for
-  an arbitrary set because nothing in it is about `ℤ` or about the sign of a degree; Mathlib has
-  the `Finsupp` analogue, `Finsupp.supported`, but no `Pi` one.
 
 ## Main results
 
@@ -155,18 +152,6 @@ variable (A M : Type*) [Semiring A] [AddCommMonoid M] [TopologicalSpace M] [Modu
 
 variable {A M}
 
-omit [TopologicalSpace M] in
-/-- **Disjoint sets of indices give disjoint submodules of families vanishing outside them.**
-A family vanishing outside `s` and outside `t` at once, for `s` and `t` disjoint, vanishes
-everywhere. The submodules are Mathlib's `Submodule.pi` at the zero submodule. -/
-theorem disjoint_pi_compl_bot_of_disjoint {ι : Type*} {s t : Set ι} (h : Disjoint s t) :
-    Disjoint (Submodule.pi sᶜ fun _ ↦ (⊥ : Submodule A M))
-      (Submodule.pi tᶜ fun _ ↦ (⊥ : Submodule A M)) :=
-  Submodule.disjoint_def.mpr fun f hs ht ↦ funext fun i ↦ by
-    by_cases hi : i ∈ s
-    · exact ht i (Set.disjoint_left.mp h hi)
-    · exact hs i hi
-
 variable (A M) [ContinuousAdd M] [ContinuousConstSMul A M]
 
 /-- **The degree decomposition along any set of degrees and its complement.** A two-sided
@@ -220,7 +205,8 @@ theorem disjoint_twoSidedRestricted_nonneg_neg :
     rw [Set.disjoint_left]
     intro n hn hn'
     exact lt_irrefl n (lt_of_lt_of_le hn' hn)
-  exact (disjoint_pi_compl_bot_of_disjoint (A := A) (M := M) hst).mono inf_le_right inf_le_right
+  exact (Submodule.disjoint_pi_compl_bot_of_disjoint (A := A) (M := M) hst).mono
+    inf_le_right inf_le_right
 
 end DegreeSplit
 

--- a/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
+++ b/TauCeti/RingTheory/Huber/Restricted/TwoSidedSeries.lean
@@ -60,9 +60,11 @@ a placement hazard:
   directness** — `A⟨X, X⁻¹⟩` is the sum of its non-negative and negative parts, and that sum is
   direct. This is fact (i) of Wedhorn's Lemma 8.33 at the level of coefficients, and it is what
   the diagram chase there needs; the Example 6.39 universal property does not supply it.
-* `TauCeti.Huber.twoSidedRestrictedSubmodule_eq_sup_compl`: the same decomposition along an
-  arbitrary set of degrees and its complement, of which the sign partition above is a special
-  case. Nothing in the argument uses the order on `ℤ`, only that the two sets are complementary.
+* `TauCeti.Huber.twoSidedRestrictedSubmodule_eq_sup_compl` and
+  `TauCeti.Huber.disjoint_twoSidedRestricted_compl`: the same decomposition and directness along
+  an arbitrary set of degrees and its complement, of which the sign partition above is a special
+  case. Nothing in either argument uses the order on `ℤ`, only that the two sets are
+  complementary.
 * `Filter.ZeroAtFilter.of_eventually_eq_or_eq_zero`: zeroing coefficients keeps a family
   restricted. Stated pointwise rather than for an indicator, so it carries no decidability
   hypothesis; it is what makes the decomposition land inside the submodule rather than merely
@@ -191,22 +193,38 @@ theorem twoSidedRestrictedSubmodule_eq_sup :
   rw [hcompl]
   exact twoSidedRestrictedSubmodule_eq_sup_compl A M {n : ℤ | 0 ≤ n}
 
+/-- **The degree decomposition along any set of degrees is direct.** A family supported in `sᶜ`
+and in `s` at once is zero, so the two summands of `twoSidedRestrictedSubmodule_eq_sup_compl`
+meet in `⊥`. As with the decomposition itself, the argument uses nothing about `s` beyond the
+two sets being complementary: the witness is `Submodule.disjoint_pi_compl_bot_of_disjoint` at
+`Disjoint s sᶜ`. The sign partition of `disjoint_twoSidedRestricted_nonneg_neg` is the case
+`s = {n | 0 ≤ n}`. -/
+theorem disjoint_twoSidedRestricted_compl (s : Set ℤ) :
+    Disjoint
+      (twoSidedRestrictedSubmodule A M ⊓
+        Submodule.pi sᶜ fun _ ↦ (⊥ : Submodule A M))
+      (twoSidedRestrictedSubmodule A M ⊓
+        Submodule.pi s fun _ ↦ (⊥ : Submodule A M)) := by
+  have h : Disjoint (Submodule.pi sᶜ fun _ ↦ (⊥ : Submodule A M))
+      (Submodule.pi s fun _ ↦ (⊥ : Submodule A M)) := by
+    have hs := Submodule.disjoint_pi_compl_bot_of_disjoint (A := A) (M := M)
+      (disjoint_compl_right (a := s))
+    rwa [compl_compl] at hs
+  exact h.mono inf_le_right inf_le_right
+
 /-- **The decomposition is direct.** A family supported in non-negative degrees and in negative
 degrees at once is zero, so the two summands of `twoSidedRestrictedSubmodule_eq_sup` meet in `⊥`.
-Together they exhibit `A⟨z, z⁻¹⟩` as the internal direct sum of the two half-line pieces. -/
+Together they exhibit `A⟨z, z⁻¹⟩` as the internal direct sum of the two half-line pieces. This is
+`disjoint_twoSidedRestricted_compl` at the sign partition. -/
 theorem disjoint_twoSidedRestricted_nonneg_neg :
     Disjoint
       (twoSidedRestrictedSubmodule A M ⊓
         Submodule.pi {n : ℤ | 0 ≤ n}ᶜ fun _ ↦ (⊥ : Submodule A M))
       (twoSidedRestrictedSubmodule A M ⊓
-        Submodule.pi {n : ℤ | n < 0}ᶜ fun _ ↦ (⊥ : Submodule A M)) :=
-  by
-  have hst : Disjoint {n : ℤ | 0 ≤ n} {n : ℤ | n < 0} := by
-    rw [Set.disjoint_left]
-    intro n hn hn'
-    exact lt_irrefl n (lt_of_lt_of_le hn' hn)
-  exact (Submodule.disjoint_pi_compl_bot_of_disjoint (A := A) (M := M) hst).mono
-    inf_le_right inf_le_right
+        Submodule.pi {n : ℤ | n < 0}ᶜ fun _ ↦ (⊥ : Submodule A M)) := by
+  have hcompl : {n : ℤ | n < 0}ᶜ = {n : ℤ | 0 ≤ n} := by ext n; simp
+  rw [hcompl]
+  exact disjoint_twoSidedRestricted_compl A M {n : ℤ | 0 ≤ n}
 
 end DegreeSplit
 


### PR DESCRIPTION
Wedhorn's Lemma 8.33 chases a diagram whose surjectivity step is the fact that `A⟨z, z⁻¹⟩` splits
as `A⟨z⟩ + z⁻¹A⟨z⁻¹⟩`. Example 6.39's universal property does not deliver it, which is why it is
its own step rather than a corollary. This proves it at the level of coefficients, on the object
rung (a) landed in #4907.

Roadmap: AdicSpaces

Target: AdicSpaces README Layer 4.1 step 5 (Lemma 8.33, the augmented Čech complex of a two-piece
Laurent cover). Source: Wedhorn, Adic Spaces, arXiv:1910.05934v1, section 8.2.1, Lemma 8.33.

## What is added

Five declarations across three files.

| declaration | file | |
|---|---|---|
| `Submodule.disjoint_pi_compl_bot_of_disjoint` | `LinearAlgebra/Pi.lean` (new) | disjoint index sets give disjoint submodules of families vanishing outside them |
| `Filter.ZeroAtFilter.of_eventually_eq_or_eq_zero` | `Order/Filter/ZeroAndBoundedAtFilter.lean` | zeroing coefficients keeps a family restricted |
| `twoSidedRestrictedSubmodule_eq_sup_compl` | `RingTheory/Huber/Restricted/TwoSidedSeries.lean` | the decomposition along any set of degrees and its complement |
| `twoSidedRestrictedSubmodule_eq_sup` | same | the sign partition, as a special case of it |
| `disjoint_twoSidedRestricted_nonneg_neg` | same | its directness |

The last two are the statement this rung exists for; the rest are what they need.

## The support submodules are Mathlib's, not new ones

An earlier revision defined a bespoke `supportedOn (s : Set ℤ)` for the families vanishing
outside `s`. That was a duplication of Mathlib's generic Pi-submodule construction, and it is
gone: the supports are now `Submodule.pi sᶜ (fun _ ↦ ⊥)` throughout, and the truncations are
`Set.indicator`. Only one fact about those submodules was missing, the disjointness of
complementary supports, and it is the first row above.

`Submodule.pi` occurs in no file on `main` outside this PR, and Mathlib has no disjointness lemma
for these submodules — its `Set.disjoint_pi` is about `Set.pi` and characterises disjointness
through the fibres, a different statement about a different object. So the lemma is new rather
than a re-derivation, and it lives in `TauCeti/LinearAlgebra/Pi.lean`, mirroring Mathlib's
`Mathlib/LinearAlgebra/Pi.lean` where `Submodule.pi` is defined. It is topology-free and belongs
nowhere near the Huber hierarchy.

## Two choices of generality, and why

**The truncation lemma asks only for an eventual hypothesis.** The natural form is
`fun n ↦ if n ∈ s then f n else 0`, which drags a `DecidablePred (· ∈ s)` through every use site.
Asking instead that each value of `g` be `f`'s or `0` removes that hypothesis and also covers
truncations that are not indicators. Asking it only `∀ᶠ n in l` weakens it further at no cost:
convergence along `l` sees `g` only through sets in `l`, so the proof intersects the eventual set
with the preimage under `f` rather than taking the preimage alone.

**The decomposition is stated for an arbitrary set of degrees and its complement.** Its proof uses
no order property of `ℤ` — only that the two index sets are complementary — so
`twoSidedRestrictedSubmodule_eq_sup_compl` carries the content and the sign partition is derived
from it by rewriting `{n | n < 0}ᶜ` to `{n | 0 ≤ n}`.

## Note on authorship

The `Submodule.pi` / `Set.indicator` reformulation is `02668bd7e`, by another worker answering the
`reuse` block on this PR; that rubric re-reviewed and cleared it. This branch builds on that
commit rather than replacing it — it is what makes the arbitrary-complement statement expressible
at all.
