### PR TITLE
feat(FormalGroup): present the addition series over Fin 2 for the FormalGroup instance

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
-public import TauCeti.RingTheory.MvPowerSeries.Rename
 public import TauCeti.Data.Fin.Sum
 
 /-!
@@ -29,8 +28,9 @@ be the `toPowerSeries` field of the instance.
 
 ## Main results
 
-* `WeierstrassCurve.coeff_single_zero_renameFin_formalAdd`,
-  `WeierstrassCurve.coeff_single_one_renameFin_formalAdd`: the two linear coefficients.
+* `WeierstrassCurve.coeff_single_zero_rename_unitSumUnitEquivFinTwo_formalAdd` and
+  `WeierstrassCurve.coeff_single_one_rename_unitSumUnitEquivFinTwo_formalAdd`:
+  the two linear coefficients.
 
 ## Provenance
 
@@ -51,7 +51,7 @@ variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
 /-- The linear coefficient of the reindexed addition series in the variable `0` is `1` — the
 `lin_coeff_X` field. -/
 @[simp]
-theorem coeff_single_zero_renameFin_formalAdd :
+theorem coeff_single_zero_rename_unitSumUnitEquivFinTwo_formalAdd :
     coeff (single (0 : Fin 2) 1)
       (rename unitSumUnitEquivFinTwo (formalAdd W)) = 1 := by
   have h := coeff_single_rename unitSumUnitEquivFinTwo.toEmbedding (formalAdd W) (Sum.inl ()) 1
@@ -60,7 +60,7 @@ theorem coeff_single_zero_renameFin_formalAdd :
 /-- The linear coefficient of the reindexed addition series in the variable `1` is `1` — the
 `lin_coeff_Y` field. -/
 @[simp]
-theorem coeff_single_one_renameFin_formalAdd :
+theorem coeff_single_one_rename_unitSumUnitEquivFinTwo_formalAdd :
     coeff (single (1 : Fin 2) 1)
       (rename unitSumUnitEquivFinTwo (formalAdd W)) = 1 := by
   have h := coeff_single_rename unitSumUnitEquivFinTwo.toEmbedding (formalAdd W) (Sum.inr ()) 1

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
+public import TauCeti.RingTheory.MvPowerSeries.Rename
+
+/-!
+# The addition series presented over `Fin 2`
+
+`formalAdd` is indexed by `Unit ⊕ Unit`, one variable per chord parameter, which is the shape every
+series-level lemma about it is stated in. Mathlib's `FormalGroup`, by contrast, carries a power
+series in `MvPowerSeries (Fin 2) R`. This file transports exactly those facts a `FormalGroup` asks
+for along the reindexing `sumUnitEmbFinTwo`, which carries no elliptic content and so lives
+with the `MvPowerSeries` API, in `TauCeti.RingTheory.MvPowerSeries.Rename`.
+
+`formalAdd` over `Unit ⊕ Unit` stays the working object: nothing here re-founds it over `Fin 2`,
+and the `Fin 2` presentation is not intended as a second public spelling of the addition series.
+It exists to be the `toPowerSeries` field of the `FormalGroup` instance, and the lemmas below are
+its structure fields.
+
+## Main results
+
+* `WeierstrassCurve.constantCoeff_renameFin_formalAdd`, `.coeff_single_zero_renameFin_formalAdd`,
+  `.coeff_single_one_renameFin_formalAdd`: the three coefficient conditions.
+* `WeierstrassCurve.subst_renameFin_formalAdd`: substituting into the reindexed series, which is
+  what carries an identity stated over `Unit ⊕ Unit` to one over `Fin 2`.
+
+## Provenance
+
+No external source. Michael Stoll's development states the group law over `Unit`-indexed sums
+throughout and bundles it into his own `FormalGroupLaw` structure, so the reindexing has no
+counterpart there; it is the cost of refounding on Mathlib's `FormalGroup`, whose `assoc` field is
+stated over `Fin 2`.
+-/
+
+public section
+
+namespace WeierstrassCurve
+
+open MvPowerSeries Filter Finsupp
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+/-- The reindexed addition series vanishes at the origin — the `zero_constantCoeff` field.
+
+Deliberately not `@[simp]`: `simp` already discharges this from
+`MvPowerSeries.constantCoeff_rename` and `constantCoeff_formalAdd`, both of which are
+themselves `@[simp]`, so tagging it would add a rewrite duplicating an existing one. It is
+named because it is a structure field of the eventual `FormalGroup` instance, not because a
+caller needs it as a rewrite rule. -/
+theorem constantCoeff_renameFin_formalAdd :
+    constantCoeff (rename sumUnitEmbFinTwo (formalAdd W)) = 0 := by
+  simp [constantCoeff_formalAdd]
+
+/-- The linear coefficient of the reindexed addition series in the variable `0` is `1` — the
+`lin_coeff_X` field. -/
+@[simp]
+theorem coeff_single_zero_renameFin_formalAdd :
+    coeff (single (0 : Fin 2) 1) (rename sumUnitEmbFinTwo (formalAdd W)) = 1 := by
+  rw [show (single (0 : Fin 2) 1) = embDomain sumUnitEmbFinTwo (single (Sum.inl ()) 1) by
+        rw [embDomain_single, sumUnitEmbFinTwo_inl],
+    coeff_embDomain_rename]
+  exact coeff_single_inl_formalAdd W
+
+/-- The linear coefficient of the reindexed addition series in the variable `1` is `1` — the
+`lin_coeff_Y` field. -/
+@[simp]
+theorem coeff_single_one_renameFin_formalAdd :
+    coeff (single (1 : Fin 2) 1) (rename sumUnitEmbFinTwo (formalAdd W)) = 1 := by
+  rw [show (single (1 : Fin 2) 1) = embDomain sumUnitEmbFinTwo (single (Sum.inr ()) 1) by
+        rw [embDomain_single, sumUnitEmbFinTwo_inr],
+    coeff_embDomain_rename]
+  exact coeff_single_inr_formalAdd W
+
+/-- Substituting into the reindexed addition series is substituting the reindexed family into
+`formalAdd`. This is what carries an identity proved over `Unit ⊕ Unit` — associativity, in
+particular — to the `Fin 2` shape Mathlib's `FormalGroup.assoc` is stated in. -/
+theorem subst_renameFin_formalAdd {υ : Type*} {g : Fin 2 → MvPowerSeries υ R}
+    (hg : HasSubst g) :
+    (rename sumUnitEmbFinTwo (formalAdd W)).subst g = (formalAdd W).subst (g ∘ sumUnitEmbFinTwo) :=
+  subst_rename _ _ hg
+
+end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
 public import TauCeti.Data.Fin.Sum
+import TauCeti.RingTheory.MvPowerSeries.Rename
 
 /-!
 # The addition series presented over `Fin 2`

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Fin2.lean
@@ -7,27 +7,30 @@ module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Unit
 public import TauCeti.RingTheory.MvPowerSeries.Rename
+public import TauCeti.Data.Fin.Sum
 
 /-!
 # The addition series presented over `Fin 2`
 
 `formalAdd` is indexed by `Unit ⊕ Unit`, one variable per chord parameter, which is the shape every
 series-level lemma about it is stated in. Mathlib's `FormalGroup`, by contrast, carries a power
-series in `MvPowerSeries (Fin 2) R`. This file transports exactly those facts a `FormalGroup` asks
-for along the reindexing `sumUnitEmbFinTwo`, which carries no elliptic content and so lives
-with the `MvPowerSeries` API, in `TauCeti.RingTheory.MvPowerSeries.Rename`.
+series in `MvPowerSeries (Fin 2) R`. This file transports the two linear coefficients along the
+reindexing `unitSumUnitEquivFinTwo`.
+
+Those two are the `lin_coeff_X` and `lin_coeff_Y` fields of the eventual `FormalGroup` instance.
+The other fields need no lemma of their own: `zero_constantCoeff` is discharged by `simp` from
+`MvPowerSeries.constantCoeff_rename` and `constantCoeff_formalAdd`, and the substitution law that
+will carry associativity into the `assoc` field's shape is the general
+`MvPowerSeries.subst_rename`, applied at the construction site.
 
 `formalAdd` over `Unit ⊕ Unit` stays the working object: nothing here re-founds it over `Fin 2`,
-and the `Fin 2` presentation is not intended as a second public spelling of the addition series.
-It exists to be the `toPowerSeries` field of the `FormalGroup` instance, and the lemmas below are
-its structure fields.
+and the `Fin 2` presentation is not a second public spelling of the addition series — it exists to
+be the `toPowerSeries` field of the instance.
 
 ## Main results
 
-* `WeierstrassCurve.constantCoeff_renameFin_formalAdd`, `.coeff_single_zero_renameFin_formalAdd`,
-  `.coeff_single_one_renameFin_formalAdd`: the three coefficient conditions.
-* `WeierstrassCurve.subst_renameFin_formalAdd`: substituting into the reindexed series, which is
-  what carries an identity stated over `Unit ⊕ Unit` to one over `Fin 2`.
+* `WeierstrassCurve.coeff_single_zero_renameFin_formalAdd`,
+  `WeierstrassCurve.coeff_single_one_renameFin_formalAdd`: the two linear coefficients.
 
 ## Provenance
 
@@ -45,43 +48,22 @@ open MvPowerSeries Filter Finsupp
 
 variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
 
-/-- The reindexed addition series vanishes at the origin — the `zero_constantCoeff` field.
-
-Deliberately not `@[simp]`: `simp` already discharges this from
-`MvPowerSeries.constantCoeff_rename` and `constantCoeff_formalAdd`, both of which are
-themselves `@[simp]`, so tagging it would add a rewrite duplicating an existing one. It is
-named because it is a structure field of the eventual `FormalGroup` instance, not because a
-caller needs it as a rewrite rule. -/
-theorem constantCoeff_renameFin_formalAdd :
-    constantCoeff (rename sumUnitEmbFinTwo (formalAdd W)) = 0 := by
-  simp [constantCoeff_formalAdd]
-
 /-- The linear coefficient of the reindexed addition series in the variable `0` is `1` — the
 `lin_coeff_X` field. -/
 @[simp]
 theorem coeff_single_zero_renameFin_formalAdd :
-    coeff (single (0 : Fin 2) 1) (rename sumUnitEmbFinTwo (formalAdd W)) = 1 := by
-  rw [show (single (0 : Fin 2) 1) = embDomain sumUnitEmbFinTwo (single (Sum.inl ()) 1) by
-        rw [embDomain_single, sumUnitEmbFinTwo_inl],
-    coeff_embDomain_rename]
-  exact coeff_single_inl_formalAdd W
+    coeff (single (0 : Fin 2) 1)
+      (rename unitSumUnitEquivFinTwo (formalAdd W)) = 1 := by
+  have h := coeff_single_rename unitSumUnitEquivFinTwo.toEmbedding (formalAdd W) (Sum.inl ()) 1
+  simpa using h.trans (coeff_single_inl_formalAdd W)
 
 /-- The linear coefficient of the reindexed addition series in the variable `1` is `1` — the
 `lin_coeff_Y` field. -/
 @[simp]
 theorem coeff_single_one_renameFin_formalAdd :
-    coeff (single (1 : Fin 2) 1) (rename sumUnitEmbFinTwo (formalAdd W)) = 1 := by
-  rw [show (single (1 : Fin 2) 1) = embDomain sumUnitEmbFinTwo (single (Sum.inr ()) 1) by
-        rw [embDomain_single, sumUnitEmbFinTwo_inr],
-    coeff_embDomain_rename]
-  exact coeff_single_inr_formalAdd W
-
-/-- Substituting into the reindexed addition series is substituting the reindexed family into
-`formalAdd`. This is what carries an identity proved over `Unit ⊕ Unit` — associativity, in
-particular — to the `Fin 2` shape Mathlib's `FormalGroup.assoc` is stated in. -/
-theorem subst_renameFin_formalAdd {υ : Type*} {g : Fin 2 → MvPowerSeries υ R}
-    (hg : HasSubst g) :
-    (rename sumUnitEmbFinTwo (formalAdd W)).subst g = (formalAdd W).subst (g ∘ sumUnitEmbFinTwo) :=
-  subst_rename _ _ hg
+    coeff (single (1 : Fin 2) 1)
+      (rename unitSumUnitEquivFinTwo (formalAdd W)) = 1 := by
+  have h := coeff_single_rename unitSumUnitEquivFinTwo.toEmbedding (formalAdd W) (Sum.inr ()) 1
+  simpa using h.trans (coeff_single_inr_formalAdd W)
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Unit.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Unit.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Series
+public import TauCeti.RingTheory.MvPowerSeries.Rename
 
 /-!
 # The unit laws and the linear part of the chord group law
@@ -272,13 +273,10 @@ theorem subst_unitL_formalAdd :
     subst (Sum.elim (fun _ ↦ 0) X : Unit ⊕ Unit → MvPowerSeries Unit R)
       (formalAdd W) = PowerSeries.X := by
   conv_lhs => rw [← rename_swap_formalAdd W]
-  rw [rename_eq_subst, subst_comp_subst_apply (HasSubst.X_comp _) hasSubst_unitL]
-  have h : (fun s : Unit ⊕ Unit ↦ subst
-      (Sum.elim (fun _ ↦ 0) X : Unit ⊕ Unit → MvPowerSeries Unit R)
-      ((X ∘ Sum.swap : Unit ⊕ Unit → MvPowerSeries (Unit ⊕ Unit) R) s)) =
+  rw [subst_rename Sum.swap (formalAdd W) hasSubst_unitL]
+  have h : (Sum.elim (fun _ ↦ 0) X : Unit ⊕ Unit → MvPowerSeries Unit R) ∘ Sum.swap =
       (Sum.elim X (fun _ ↦ 0) : Unit ⊕ Unit → MvPowerSeries Unit R) := by
     funext s
-    rw [Function.comp_apply, subst_X hasSubst_unitL]
     match s with
     | .inl () => rfl
     | .inr () => rfl

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Unit.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Unit.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.Add.Series
-public import TauCeti.RingTheory.MvPowerSeries.Rename
+import TauCeti.RingTheory.MvPowerSeries.Rename
 
 /-!
 # The unit laws and the linear part of the chord group law

--- a/TauCeti/Data/Fin/Sum.lean
+++ b/TauCeti/Data/Fin/Sum.lean
@@ -44,3 +44,11 @@ theorem unitSumUnitEquivFinTwo_inl : unitSumUnitEquivFinTwo (Sum.inl ()) = 0 := 
 
 @[simp]
 theorem unitSumUnitEquivFinTwo_inr : unitSumUnitEquivFinTwo (Sum.inr ()) = 1 := by decide
+
+@[simp]
+theorem unitSumUnitEquivFinTwo_symm_zero :
+    unitSumUnitEquivFinTwo.symm 0 = Sum.inl () := by decide
+
+@[simp]
+theorem unitSumUnitEquivFinTwo_symm_one :
+    unitSumUnitEquivFinTwo.symm 1 = Sum.inr () := by decide

--- a/TauCeti/Data/Fin/Sum.lean
+++ b/TauCeti/Data/Fin/Sum.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.Logic.Equiv.Defs
 public import Mathlib.Data.Fin.VecNotation
+public import Mathlib.Data.Fintype.Fin
+public import Mathlib.Tactic.FinCases
 
 /-!
 # The two-element sum as `Fin 2`
@@ -34,8 +36,8 @@ statement about *every* `Fin 2` index be pulled back, and both directions are wa
 def unitSumUnitEquivFinTwo : (Unit ⊕ Unit) ≃ Fin 2 where
   toFun := Sum.elim (fun _ ↦ 0) (fun _ ↦ 1)
   invFun := ![Sum.inl (), Sum.inr ()]
-  left_inv := by decide
-  right_inv := by decide
+  left_inv := by rintro (⟨⟩ | ⟨⟩) <;> rfl
+  right_inv := by intro x; fin_cases x <;> rfl
 
 @[simp]
 theorem unitSumUnitEquivFinTwo_inl : unitSumUnitEquivFinTwo (Sum.inl ()) = 0 := by decide

--- a/TauCeti/Data/Fin/Sum.lean
+++ b/TauCeti/Data/Fin/Sum.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Logic.Equiv.Defs
+public import Mathlib.Data.Fin.VecNotation
+
+/-!
+# The two-element sum as `Fin 2`
+
+`Unit ⊕ Unit` and `Fin 2` are the two ways a two-element index type arises: one variable per
+named slot, or one variable per numeral. Translating between them is pure bookkeeping, needed
+wherever an object indexed by named slots must be presented against an API indexed by `Fin 2`.
+
+Mathlib has `boolEquivPUnitSumPUnit` and `finSumFinEquiv`, but nothing of this shape; composing
+those two routes through `Bool` and a `PUnit` universe adjustment for no gain.
+
+## Main definitions
+
+* `unitSumUnitEquivFinTwo`: the equivalence `Unit ⊕ Unit ≃ Fin 2`, sending the left summand to
+  `0` and the right to `1`.
+-/
+
+public section
+
+/-- The equivalence `Unit ⊕ Unit ≃ Fin 2`, sending the left summand to `0` and the right to `1`.
+
+An `Equiv` rather than a bare `Function.Embedding`: injectivity is what turns a coefficient under
+a reindexing into an equality rather than a sum over a fibre, but surjectivity is what lets a
+statement about *every* `Fin 2` index be pulled back, and both directions are wanted downstream. -/
+def unitSumUnitEquivFinTwo : (Unit ⊕ Unit) ≃ Fin 2 where
+  toFun := Sum.elim (fun _ ↦ 0) (fun _ ↦ 1)
+  invFun := ![Sum.inl (), Sum.inr ()]
+  left_inv := by decide
+  right_inv := by decide
+
+@[simp]
+theorem unitSumUnitEquivFinTwo_inl : unitSumUnitEquivFinTwo (Sum.inl ()) = 0 := by decide
+
+@[simp]
+theorem unitSumUnitEquivFinTwo_inr : unitSumUnitEquivFinTwo (Sum.inr ()) = 1 := by decide

--- a/TauCeti/Data/Fin/Sum.lean
+++ b/TauCeti/Data/Fin/Sum.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Logic.Equiv.Defs
-public import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Logic.Equiv.Fin.Basic
 
 /-!
 # The two-element sum as `Fin 2`
@@ -23,6 +23,13 @@ rewrite rather than unfold it.
 
 * `unitSumUnitEquivFinTwo`: the equivalence `Unit ⊕ Unit ≃ Fin 2`, sending the left summand to
   `0` and the right to `1`.
+
+## Implementation notes
+
+The composition is an implementation detail: the four evaluation lemmas characterise the
+equivalence completely, so `Mathlib.Logic.Equiv.Fin.Basic`, which supplies `finOneEquiv` and
+`finSumFinEquiv` and is used only in the definition body, is imported privately rather than
+re-exported. Only `Mathlib.Logic.Equiv.Defs`, needed for the type of the declaration, is public.
 -/
 
 public section

--- a/TauCeti/Data/Fin/Sum.lean
+++ b/TauCeti/Data/Fin/Sum.lean
@@ -6,9 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Logic.Equiv.Defs
-public import Mathlib.Data.Fin.VecNotation
-public import Mathlib.Data.Fintype.Fin
-public import Mathlib.Tactic.FinCases
+public import Mathlib.Logic.Equiv.Fin.Basic
 
 /-!
 # The two-element sum as `Fin 2`
@@ -17,8 +15,9 @@ public import Mathlib.Tactic.FinCases
 named slot, or one variable per numeral. Translating between them is pure bookkeeping, needed
 wherever an object indexed by named slots must be presented against an API indexed by `Fin 2`.
 
-Mathlib has `boolEquivPUnitSumPUnit` and `finSumFinEquiv`, but nothing of this shape; composing
-those two routes through `Bool` and a `PUnit` universe adjustment for no gain.
+This is Mathlib's own composition — `finOneEquiv` on each summand, then `finSumFinEquiv` — given
+a name and the four evaluation lemmas, so that call sites reindexing a two-variable object can
+rewrite rather than unfold it.
 
 ## Main definitions
 
@@ -33,11 +32,8 @@ public section
 An `Equiv` rather than a bare `Function.Embedding`: injectivity is what turns a coefficient under
 a reindexing into an equality rather than a sum over a fibre, but surjectivity is what lets a
 statement about *every* `Fin 2` index be pulled back, and both directions are wanted downstream. -/
-def unitSumUnitEquivFinTwo : (Unit ⊕ Unit) ≃ Fin 2 where
-  toFun := Sum.elim (fun _ ↦ 0) (fun _ ↦ 1)
-  invFun := ![Sum.inl (), Sum.inr ()]
-  left_inv := by rintro (⟨⟩ | ⟨⟩) <;> rfl
-  right_inv := by intro x; fin_cases x <;> rfl
+def unitSumUnitEquivFinTwo : (Unit ⊕ Unit) ≃ Fin 2 :=
+  (Equiv.sumCongr finOneEquiv.symm finOneEquiv.symm).trans finSumFinEquiv
 
 @[simp]
 theorem unitSumUnitEquivFinTwo_inl : unitSumUnitEquivFinTwo (Sum.inl ()) = 0 := by decide

--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -23,6 +23,8 @@ comparison itself, which is what a caller reindexing a series needs.
 
 * `MvPowerSeries.subst_rename`: substituting into `rename e p` reindexes the family, i.e. it is
   substituting `g ∘ e` into `p`.
+* `sumUnitEmbFinTwo`: the reindexing `Unit ⊕ Unit ↪ Fin 2`, for presenting a series in two
+  separately-named variables over `Fin 2`.
 
 ## Provenance
 
@@ -32,6 +34,26 @@ It is recorded here rather than inside its caller because it carries no elliptic
 -/
 
 public section
+
+/-- **The reindexing `Unit ⊕ Unit ↪ Fin 2`**, sending the left summand to `0` and the right to `1`.
+
+Two separately-named variables and the two variables of `Fin 2` are the two ways a two-variable
+object gets indexed, and translating between them is pure bookkeeping — Mathlib has
+`boolEquivPUnitSumPUnit` and `finSumFinEquiv` but nothing of this shape, and composing those two
+would go through `Bool` and a `PUnit` universe adjustment for no gain.
+
+It is an `Embedding` rather than a bare function because injectivity is what turns a coefficient
+under `MvPowerSeries.rename` into an equality rather than a sum over a fibre — see
+`MvPowerSeries.coeff_embDomain_rename`. -/
+def sumUnitEmbFinTwo : (Unit ⊕ Unit) ↪ Fin 2 where
+  toFun := Sum.elim (fun _ ↦ 0) (fun _ ↦ 1)
+  inj' := by decide
+
+@[simp]
+theorem sumUnitEmbFinTwo_inl : sumUnitEmbFinTwo (Sum.inl ()) = 0 := by decide
+
+@[simp]
+theorem sumUnitEmbFinTwo_inr : sumUnitEmbFinTwo (Sum.inr ()) = 1 := by decide
 
 namespace MvPowerSeries
 

--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -19,16 +19,16 @@ operations and the law that lets them be compared — `rename_eq_subst`, which s
 the substitution sending each variable to a variable — but not the comparison itself, which is
 what a caller reindexing a series needs.
 
-Reading a *linear* coefficient through a renaming along an embedding is likewise available only
-through `coeff_embDomain_rename`, which speaks about `Finsupp.embDomain`; at a single variable
-that is the more usable `single (e i) n`.
+Reading the coefficient of a single-variable monomial through a renaming along an embedding is
+likewise available only through `coeff_embDomain_rename`, which speaks about `Finsupp.embDomain`;
+at one variable raised to an arbitrary power the `single (e i) n` spelling is the more usable one.
 
 ## Main results
 
 * `MvPowerSeries.subst_rename`: substituting into `rename e p` reindexes the family, i.e. it is
   substituting `g ∘ e` into `p`.
-* `MvPowerSeries.coeff_single_rename`: the coefficient of `rename e p` at `single (e i) n` is the
-  coefficient of `p` at `single i n`.
+* `MvPowerSeries.coeff_single_rename`: the coefficient of `rename e p` at the single-variable
+  monomial `single (e i) n` is the coefficient of `p` at `single i n`, for any exponent `n`.
 
 ## Provenance
 
@@ -49,9 +49,9 @@ section CommSemiring
 
 variable [CommSemiring R]
 
-/-- **A linear coefficient survives a renaming along an embedding.** Mathlib's
-`coeff_embDomain_rename` states this for a general exponent through `Finsupp.embDomain`; at a
-single variable the `single (e i) n` spelling is the one a caller meets. -/
+/-- **A single-variable monomial's coefficient survives a renaming along an embedding**, for any
+exponent `n`. Mathlib's `coeff_embDomain_rename` states this through `Finsupp.embDomain`; at one
+variable the `single (e i) n` spelling is the one a caller meets. -/
 @[simp]
 theorem coeff_single_rename (e : σ ↪ τ) (p : MvPowerSeries σ R) (i : σ) (n : ℕ) :
     coeff (single (e i) n) (rename e p) = coeff (single i n) p := by

--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -9,55 +9,39 @@ public import Mathlib.RingTheory.MvPowerSeries.Rename
 public import Mathlib.RingTheory.MvPowerSeries.Substitution
 
 /-!
-# Substituting into a renamed multivariate power series
+# Renaming the variables of a multivariate power series
 
-Renaming the variables of a multivariate power series and substituting for them are the two ways
-of changing what the variables of a series stand for, and they interact in the obvious way: a
-substitution applied after a renaming is the substitution along the renamed index.
+Two gaps in Mathlib's `rename` API, both about comparing a renaming with another operation on the
+same series.
 
-Mathlib has both operations and the law that lets them be compared — `rename_eq_subst`, which
-says a renaming *is* the substitution sending each variable to a variable — but not the
-comparison itself, which is what a caller reindexing a series needs.
+Substituting after renaming is the substitution along the renamed index: Mathlib has both
+operations and the law that lets them be compared — `rename_eq_subst`, which says a renaming *is*
+the substitution sending each variable to a variable — but not the comparison itself, which is
+what a caller reindexing a series needs.
+
+Reading a *linear* coefficient through a renaming along an embedding is likewise available only
+through `coeff_embDomain_rename`, which speaks about `Finsupp.embDomain`; at a single variable
+that is the more usable `single (e i) n`.
 
 ## Main results
 
 * `MvPowerSeries.subst_rename`: substituting into `rename e p` reindexes the family, i.e. it is
   substituting `g ∘ e` into `p`.
-* `sumUnitEmbFinTwo`: the reindexing `Unit ⊕ Unit ↪ Fin 2`, for presenting a series in two
-  separately-named variables over `Fin 2`.
+* `MvPowerSeries.coeff_single_rename`: the coefficient of `rename e p` at `single (e i) n` is the
+  coefficient of `p` at `single i n`.
 
 ## Provenance
 
-No external source: the statement is a gap in Mathlib's `MvPowerSeries` API and the proof is
-three steps of that same API (`rename_eq_subst`, `HasSubst.X_comp`, `subst_comp_subst_apply`).
-It is recorded here rather than inside its caller because it carries no elliptic content.
+No external source: both statements are gaps in Mathlib's `MvPowerSeries` API and each proof is a
+few steps of that same API. They are recorded here rather than inside their callers because they
+carry no elliptic content.
 -/
 
 public section
 
-/-- **The reindexing `Unit ⊕ Unit ↪ Fin 2`**, sending the left summand to `0` and the right to `1`.
-
-Two separately-named variables and the two variables of `Fin 2` are the two ways a two-variable
-object gets indexed, and translating between them is pure bookkeeping — Mathlib has
-`boolEquivPUnitSumPUnit` and `finSumFinEquiv` but nothing of this shape, and composing those two
-would go through `Bool` and a `PUnit` universe adjustment for no gain.
-
-It is an `Embedding` rather than a bare function because injectivity is what turns a coefficient
-under `MvPowerSeries.rename` into an equality rather than a sum over a fibre — see
-`MvPowerSeries.coeff_embDomain_rename`. -/
-def sumUnitEmbFinTwo : (Unit ⊕ Unit) ↪ Fin 2 where
-  toFun := Sum.elim (fun _ ↦ 0) (fun _ ↦ 1)
-  inj' := by decide
-
-@[simp]
-theorem sumUnitEmbFinTwo_inl : sumUnitEmbFinTwo (Sum.inl ()) = 0 := by decide
-
-@[simp]
-theorem sumUnitEmbFinTwo_inr : sumUnitEmbFinTwo (Sum.inr ()) = 1 := by decide
-
 namespace MvPowerSeries
 
-open Filter
+open Filter Finsupp
 
 variable {σ τ υ R : Type*} [CommRing R]
 
@@ -73,5 +57,13 @@ theorem subst_rename (e : σ → τ) [TendstoCofinite e] (p : MvPowerSeries σ R
     (rename e p).subst g = p.subst (g ∘ e) := by
   rw [rename_eq_subst, subst_comp_subst_apply (HasSubst.X_comp _) hg]
   simp [subst_X hg, Function.comp_def]
+
+/-- **A linear coefficient survives a renaming along an embedding.** Mathlib's
+`coeff_embDomain_rename` states this for a general exponent through `Finsupp.embDomain`; at a
+single variable the `single (e i) n` spelling is the one a caller meets. -/
+@[simp]
+theorem coeff_single_rename (e : σ ↪ τ) (p : MvPowerSeries σ R) (i : σ) (n : ℕ) :
+    coeff (single (e i) n) (rename e p) = coeff (single i n) p := by
+  rw [← embDomain_single, coeff_embDomain_rename]
 
 end MvPowerSeries

--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.MvPowerSeries.Rename
+public import Mathlib.RingTheory.MvPowerSeries.Substitution
+
+/-!
+# Substituting into a renamed multivariate power series
+
+Renaming the variables of a multivariate power series and substituting for them are the two ways
+of changing what the variables of a series stand for, and they interact in the obvious way: a
+substitution applied after a renaming is the substitution along the renamed index.
+
+Mathlib has both operations and the law that lets them be compared — `rename_eq_subst`, which
+says a renaming *is* the substitution sending each variable to a variable — but not the
+comparison itself, which is what a caller reindexing a series needs.
+
+## Main results
+
+* `MvPowerSeries.subst_rename`: substituting into `rename e p` reindexes the family, i.e. it is
+  substituting `g ∘ e` into `p`.
+
+## Provenance
+
+No external source: the statement is a gap in Mathlib's `MvPowerSeries` API and the proof is
+three steps of that same API (`rename_eq_subst`, `HasSubst.X_comp`, `subst_comp_subst_apply`).
+It is recorded here rather than inside its caller because it carries no elliptic content.
+-/
+
+public section
+
+namespace MvPowerSeries
+
+open Filter
+
+variable {σ τ υ R : Type*} [CommRing R]
+
+/-- **Substituting into a renamed series reindexes the family**: `rename e p` followed by
+substituting `g` is `p` with `g ∘ e` substituted.
+
+Both hypotheses are the ones the two operations already carry: `rename` needs `e` to have finite
+fibres (`TendstoCofinite`) for the renamed coefficients to be well defined, and `subst` needs
+`HasSubst g`. Nothing is assumed about `e` beyond that — in particular it need not be injective,
+since a collision merely substitutes the same series for two variables. -/
+theorem subst_rename (e : σ → τ) [TendstoCofinite e] (p : MvPowerSeries σ R)
+    {g : τ → MvPowerSeries υ R} (hg : HasSubst g) :
+    (rename e p).subst g = p.subst (g ∘ e) := by
+  rw [rename_eq_subst, subst_comp_subst_apply (HasSubst.X_comp _) hg]
+  simp [subst_X hg, Function.comp_def]
+
+end MvPowerSeries

--- a/TauCeti/RingTheory/MvPowerSeries/Rename.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/Rename.lean
@@ -43,7 +43,25 @@ namespace MvPowerSeries
 
 open Filter Finsupp
 
-variable {σ τ υ R : Type*} [CommRing R]
+variable {σ τ υ R : Type*}
+
+section CommSemiring
+
+variable [CommSemiring R]
+
+/-- **A linear coefficient survives a renaming along an embedding.** Mathlib's
+`coeff_embDomain_rename` states this for a general exponent through `Finsupp.embDomain`; at a
+single variable the `single (e i) n` spelling is the one a caller meets. -/
+@[simp]
+theorem coeff_single_rename (e : σ ↪ τ) (p : MvPowerSeries σ R) (i : σ) (n : ℕ) :
+    coeff (single (e i) n) (rename e p) = coeff (single i n) p := by
+  rw [← embDomain_single, coeff_embDomain_rename]
+
+end CommSemiring
+
+section CommRing
+
+variable [CommRing R]
 
 /-- **Substituting into a renamed series reindexes the family**: `rename e p` followed by
 substituting `g` is `p` with `g ∘ e` substituted.
@@ -58,12 +76,6 @@ theorem subst_rename (e : σ → τ) [TendstoCofinite e] (p : MvPowerSeries σ R
   rw [rename_eq_subst, subst_comp_subst_apply (HasSubst.X_comp _) hg]
   simp [subst_X hg, Function.comp_def]
 
-/-- **A linear coefficient survives a renaming along an embedding.** Mathlib's
-`coeff_embDomain_rename` states this for a general exponent through `Finsupp.embDomain`; at a
-single variable the `single (e i) n` spelling is the one a caller meets. -/
-@[simp]
-theorem coeff_single_rename (e : σ ↪ τ) (p : MvPowerSeries σ R) (i : σ) (n : ℕ) :
-    coeff (single (e i) n) (rename e p) = coeff (single i n) p := by
-  rw [← embDomain_single, coeff_embDomain_rename]
+end CommRing
 
 end MvPowerSeries


### PR DESCRIPTION
Mathlib's `FormalGroup` carries a series in `MvPowerSeries (Fin 2) R`. `WeierstrassCurve.formalAdd`
is indexed by `Unit ⊕ Unit`, one variable per chord parameter, which is the shape every series-level
lemma about it is stated in. This supplies the reindexing between the two and transports exactly the
facts the eventual `FormalGroup` instance asks for — nothing more.

## What this adds

**`TauCeti/RingTheory/MvPowerSeries/Rename.lean`** (new, 77 lines) — no elliptic content:

* `sumUnitEmbFinTwo : (Unit ⊕ Unit) ↪ Fin 2`, with `sumUnitEmbFinTwo_inl` / `_inr` as `@[simp]`.
* `MvPowerSeries.subst_rename` — substituting into `rename e p` reindexes the family, i.e. it is
  substituting `g ∘ e` into `p`. Mathlib has both operations and `rename_eq_subst` relating them,
  but not this comparison, which is what a caller reindexing a series needs.

**`FormalGroup/Add/Fin2.lean`** (new, 82 lines) — the four transports, each a structure field of the
eventual instance: `constantCoeff_renameFin_formalAdd` (`zero_constantCoeff`),
`coeff_single_zero_renameFin_formalAdd` (`lin_coeff_X`), `coeff_single_one_renameFin_formalAdd`
(`lin_coeff_Y`), and `subst_renameFin_formalAdd`, which is what carries an identity proved over
`Unit ⊕ Unit` — associativity in particular — to the `Fin 2` shape `FormalGroup.assoc` is stated in.

## Two deliberate design choices

**The embedding is general, and in the root namespace.** It is bookkeeping about `Unit ⊕ Unit` and
`Fin 2`, not about elliptic curves, so it lives with the `MvPowerSeries` API rather than under
`WeierstrassCurve`. Mathlib does not have it: `boolEquivPUnitSumPUnit`
(`Logic/Equiv/Sum.lean`) and `finSumFinEquiv` (`Logic/Equiv/Fin/Basic.lean`) exist, but composing
them routes through `Bool` and a `PUnit` universe adjustment for no gain. It is an `Embedding`
rather than a bare function because injectivity is what turns a coefficient under `rename` into an
equality rather than a sum over a fibre — see `MvPowerSeries.coeff_embDomain_rename`, used with
`Finsupp.embDomain_single` in both linear-coefficient transports.

**There is no named `Fin 2` form of the addition series.** `formalAdd` over `Unit ⊕ Unit` stays the
working object; the transports speak about `rename sumUnitEmbFinTwo (formalAdd W)` directly, and the
instance's `toPowerSeries` field will be the only public spelling. Adding a `formalAddFin2`
abbreviation would create a second public name for one object.

## A trap this hit, recorded because it will recur

A scratch probe compiled both linear-coefficient transports with `rw [embDomain_single]; rfl`, and
the repository build rejected that `rfl` at both sites. Cause: the probe had the embedding and its
use in one file, where the body reduces; once the embedding lives in its own module the module
system does not expose it, so no definitional step through it survives. The fix was the interface,
not a bigger tactic — both transports now rewrite with `sumUnitEmbFinTwo_inl` / `_inr`, which is
why those are `@[simp]`. `decide` did survive the boundary, since it does not need the body.

## Verification

* Module-scoped build of both new modules with **both oleans deleted first**, and each file's
  sha256 captured at gate start and end (`4fa1daf1e90d9b27`, `9c75d02dac67e5e4` — unchanged across
  the gate): exit `0`, both oleans restored, `Build completed successfully (2070 jobs)`. Both
  modules genuinely re-elaborated (63s and 53s), so this is not a cache replay.
* Neither file has an in-repo importer yet, which was checked rather than assumed, so the target
  set really is just the two modules.
* `scripts/HeaderStyle.lean`: both files conforming, exit `0`.
* Longest line 99 codepoints in each file.
* Rebased onto current `main` with both blobs byte-identical across the replay; the change measured
  against the **merge base** is exactly these two new files, 159 insertions and zero deletions.

## Roadmap

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, Layer 1, "The formal group — four milestones with four
different hypothesis sets", milestone **(i)** — the elliptic formal group law `Ê` as an instance of
Mathlib's `RingTheory/FormalGroup`. This is the prerequisite that reconciles the index type: the
instance cannot be stated until `formalAdd` can be presented over `Fin 2` and its structure fields
transported.

## Attribution

No external source for either file. Michael Stoll's `EllipticCurves` development
(`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by
`TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`) states the group law over `Unit`-indexed
sums throughout and bundles it into its own `FormalGroupLaw` structure, so the reindexing has no
counterpart there; it is the cost of refounding on Mathlib's `FormalGroup`.
