### PR TITLE
feat(ModularForms): Γ₁(N/l)-invariance from a nebentypus that factors through N/l

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -780,10 +780,19 @@ drops: `exists_eq_T_zpow_mul_conjScale_mul_T_zpow` writes `δ ∈ Γ₁(N/l)` as
 `T ^ i * conjScale l γ c * T ^ j` with `γ ∈ Γ₀(N)`, the two translations are absorbed by
 `T`-periodicity through `slash_zpow_mul_mul_zpow_eq_smul`, and the middle factor contributes the
 character value read off `γ 1 1` — which the factorisation forces to be `1`, because `γ 1 1` is
-congruent to `δ 1 1 ≡ 1` modulo `N / l`. -/
+congruent to `δ 1 1 ≡ 1` modulo `N / l`.
+
+Adapted from `conductor_slash_eq_self_of_mem_Gamma1_div` in AINTLIB
+(`Eigenforms/ConductorTheorem.lean`:217, Chris Birkbeck, Apache-2.0, commit
+`2baa76f742bdb4fb8ee323fabba41203bd390e08`). The source states it over its own `levelRaiseFun`
+and a `DirichletCharacter`, and routes through a conductor-specific helper; here it is stated over
+`scaleGL` and a units-valued character, and assembled from
+`exists_eq_T_zpow_mul_conjScale_mul_T_zpow`,
+`slash_zpow_mul_mul_zpow_eq_smul` and
+`slash_conjScale_eq_smul_of_slash_scaleGL`. -/
 theorem slash_mapGL_eq_self_of_mem_Gamma1_div (l N : ℕ) [NeZero l] (hlN : l ∣ N)
-    (hNl : N / l ∣ N) (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
-    (hχ : ∀ u : (ZMod N)ˣ, ZMod.unitsMap hNl u = 1 → χ u = 1) (f : ℍ → ℂ)
+    (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (hχ : ∀ u : (ZMod N)ˣ, ZMod.unitsMap (Nat.div_dvd_of_dvd hlN) u = 1 → χ u = 1) (f : ℍ → ℂ)
     (hnb : ∀ (γ : SL(2, ℤ)) (hγ : γ ∈ Gamma0 N),
       (f ∣[k] scaleGL l) ∣[k] mapGL ℝ γ =
         (χ ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) : ℂ) • (f ∣[k] scaleGL l))
@@ -792,19 +801,17 @@ theorem slash_mapGL_eq_self_of_mem_Gamma1_div (l N : ℕ) [NeZero l] (hlN : l �
     f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = f := by
   obtain ⟨i, j, c, γ, hc, hγ, hfactor, hdiag⟩ :=
     exists_eq_T_zpow_mul_conjScale_mul_T_zpow l N hlN δ (Gamma1_in_Gamma0 _ hδ)
-  have hdet : 0 < ((mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) :
-      Matrix (Fin 2) (Fin 2) ℝ).det := by
-    rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL]
-    norm_num
+  have hdet := det_pos_of_mem_slGL (MonoidHom.mem_range.mpr ⟨ModularGroup.T, rfl⟩)
   have hconj := slash_conjScale_eq_smul_of_slash_scaleGL (k := k) f γ hc (hnb γ hγ)
   -- the character value is `1`: `γ 1 1` is congruent to `δ 1 1 ≡ 1` modulo `N / l`
   have hchar : (χ ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) : ℂ) = 1 := by
     obtain ⟨-, hd, hcz⟩ := (Gamma1_mem _ _).mp hδ
-    have hred : ZMod.unitsMap hNl ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) = 1 := by
+    have hred : ZMod.unitsMap (Nat.div_dvd_of_dvd hlN)
+        ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) = 1 := by
       apply Units.ext
       have hval : ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩ : ZMod N) = ((γ 1 1 : ℤ) : ZMod N) := rfl
       rw [Units.val_one, ZMod.unitsMap_def, Units.coe_map, MonoidHom.coe_coe, hval,
-        ZMod.castHom_apply, ZMod.cast_intCast hNl, hdiag]
+        ZMod.castHom_apply, ZMod.cast_intCast (Nat.div_dvd_of_dvd hlN), hdiag]
       push_cast
       rw [hd, hcz, zero_mul, sub_zero]
     rw [hχ _ hred, Units.val_one]

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -769,6 +769,48 @@ theorem CuspForm.levelRaise_mem_cuspFormCharSpace (M d : ℕ) [NeZero d]
       cuspFormCharSpace k (χ.comp (ZMod.unitsMap (Dvd.intro_left d rfl : M ∣ d * M))) :=
   levelRaise_mem_cuspFormCharSpace_of_dvd dvd_rfl χ hf
 
+/-- **Γ₁(N/l)-invariance from a nebentypus of level `N` that factors through `N / l`.**
+
+If the level-raise `f ∣[k] V_l` is an eigenvector of every `γ ∈ Γ₀(N)` with eigenvalue the
+character value `χ` reads off `γ`, if `f` is `T`-periodic, and if `χ` is trivial on the kernel of
+the reduction `(ZMod N)ˣ → (ZMod (N/l))ˣ`, then `f` is invariant under all of `Γ₁(N / l)`.
+
+This is the step that converts a nebentypus into honest invariance, and it is where the conductor
+drops: `exists_eq_T_zpow_mul_conjScale_mul_T_zpow` writes `δ ∈ Γ₁(N/l)` as
+`T ^ i * conjScale l γ c * T ^ j` with `γ ∈ Γ₀(N)`, the two translations are absorbed by
+`T`-periodicity through `slash_zpow_mul_mul_zpow_eq_smul`, and the middle factor contributes the
+character value read off `γ 1 1` — which the factorisation forces to be `1`, because `γ 1 1` is
+congruent to `δ 1 1 ≡ 1` modulo `N / l`. -/
+theorem slash_mapGL_eq_self_of_mem_Gamma1_div (l N : ℕ) [NeZero l] [NeZero N] (hlN : l ∣ N)
+    (hNl : N / l ∣ N) (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (hχ : ∀ u : (ZMod N)ˣ, ZMod.unitsMap hNl u = 1 → χ u = 1) (f : ℍ → ℂ)
+    (hnb : ∀ (γ : SL(2, ℤ)) (hγ : γ ∈ Gamma0 N),
+      (f ∣[k] scaleGL l) ∣[k] mapGL ℝ γ =
+        (χ ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) : ℂ) • (f ∣[k] scaleGL l))
+    (hT : f ∣[k] (mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) = f)
+    (δ : SL(2, ℤ)) (hδ : δ ∈ Gamma1 (N / l)) :
+    f ∣[k] (mapGL ℝ δ : GL (Fin 2) ℝ) = f := by
+  obtain ⟨i, j, c, γ, hc, hγ, hfactor, hdiag⟩ :=
+    exists_eq_T_zpow_mul_conjScale_mul_T_zpow l N hlN δ (Gamma1_in_Gamma0 _ hδ)
+  have hdet : 0 < ((mapGL ℝ ModularGroup.T : GL (Fin 2) ℝ) :
+      Matrix (Fin 2) (Fin 2) ℝ).det := by
+    rw [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL]
+    norm_num
+  have hconj := slash_conjScale_eq_smul_of_slash_scaleGL (k := k) f γ hc (hnb γ hγ)
+  -- the character value is `1`: `γ 1 1` is congruent to `δ 1 1 ≡ 1` modulo `N / l`
+  have hchar : (χ ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) : ℂ) = 1 := by
+    obtain ⟨-, hd, hcz⟩ := (Gamma1_mem _ _).mp hδ
+    have hred : ZMod.unitsMap hNl ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) = 1 := by
+      apply Units.ext
+      have hval : ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩ : ZMod N) = ((γ 1 1 : ℤ) : ZMod N) := rfl
+      rw [Units.val_one, ZMod.unitsMap_def, Units.coe_map, MonoidHom.coe_coe, hval,
+        ZMod.castHom_apply, ZMod.cast_intCast hNl, hdiag]
+      push_cast
+      rw [hd, hcz, zero_mul, sub_zero]
+    rw [hχ _ hred, Units.val_one]
+  rw [hfactor, map_mul, map_mul, map_zpow, map_zpow,
+    slash_zpow_mul_mul_zpow_eq_smul k f hdet hT hconj i j, hchar, one_smul]
+
 end Nebentypus
 
 /-! ### The nebentypus character of a level restriction -/

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -45,6 +45,8 @@ the lower level. The `q`-expansion results go up only.
 * `TauCeti.ModularForm.levelRaise_apply`: `(V_d f) τ = f (d τ)`, the defining formula from which
   the algebraic properties (`levelRaise_one_apply`, `ModularForm.levelRaise_one`,
   `levelRaise_levelRaise`, `levelRaise_injective`) all follow by `ext`.
+* `TauCeti.slash_mapGL_eq_self_of_mem_Gamma1_div`: a function whose level-raise carries a
+  nebentypus that factors through `N / l` is invariant under all of `Γ₁(N / l)`.
 * `TauCeti.Gamma1_map_le_conjAct_scaleGL`, `TauCeti.Gamma0_map_le_conjAct_scaleGL`: the level
   transport, `Γ₁(dM) ≤ diag(d,1)⁻¹ Γ₁(M) diag(d,1)` and likewise for `Γ₀`, which is what makes
   `V_d` a map `M_k(Γ₁(M)) → M_k(Γ₁(dM))`.
@@ -776,11 +778,8 @@ character value `χ` reads off `γ`, if `f` is `T`-periodic, and if `χ` is triv
 the reduction `(ZMod N)ˣ → (ZMod (N/l))ˣ`, then `f` is invariant under all of `Γ₁(N / l)`.
 
 This is the step that converts a nebentypus into honest invariance, and it is where the conductor
-drops: `exists_eq_T_zpow_mul_conjScale_mul_T_zpow` writes `δ ∈ Γ₁(N/l)` as
-`T ^ i * conjScale l γ c * T ^ j` with `γ ∈ Γ₀(N)`, the two translations are absorbed by
-`T`-periodicity through `slash_zpow_mul_mul_zpow_eq_smul`, and the middle factor contributes the
-character value read off `γ 1 1` — which the factorisation forces to be `1`, because `γ 1 1` is
-congruent to `δ 1 1 ≡ 1` modulo `N / l`.
+drops: a form whose character already factors through `N / l` is invariant under the smaller group,
+which is what the conductor argument turns into a statement about newforms.
 
 Adapted from `conductor_slash_eq_self_of_mem_Gamma1_div` in AINTLIB
 (`Eigenforms/ConductorTheorem.lean`:217, Chris Birkbeck, Apache-2.0, commit
@@ -806,14 +805,17 @@ theorem slash_mapGL_eq_self_of_mem_Gamma1_div (l N : ℕ) [NeZero l] (hlN : l �
   -- the character value is `1`: `γ 1 1` is congruent to `δ 1 1 ≡ 1` modulo `N / l`
   have hchar : (χ ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) : ℂ) = 1 := by
     obtain ⟨-, hd, hcz⟩ := (Gamma1_mem _ _).mp hδ
-    have hred : ZMod.unitsMap (Nat.div_dvd_of_dvd hlN)
-        ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) = 1 := by
-      apply Units.ext
-      have hval : ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩ : ZMod N) = ((γ 1 1 : ℤ) : ZMod N) := rfl
-      rw [Units.val_one, ZMod.unitsMap_def, Units.coe_map, MonoidHom.coe_coe, hval,
-        ZMod.castHom_apply, ZMod.cast_intCast (Nat.div_dvd_of_dvd hlN), hdiag]
+    have hγ' : γ ∈ Gamma0 (N / l) := Gamma0_le_Gamma0_of_dvd (Nat.div_dvd_of_dvd hlN) hγ
+    have hlabel : Gamma0Map (N / l) ⟨γ, hγ'⟩ = 1 := by
+      -- `Gamma0Map` is by definition the lower-right entry read in `ZMod (N / l)`
+      change ((γ 1 1 : ℤ) : ZMod (N / l)) = 1
+      rw [hdiag]
       push_cast
       rw [hd, hcz, zero_mul, sub_zero]
+    have hred : ZMod.unitsMap (Nat.div_dvd_of_dvd hlN)
+        ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) = 1 := by
+      rw [← Gamma0Map_toHomUnits_of_dvd (Nat.div_dvd_of_dvd hlN) ⟨γ, hγ⟩ hγ']
+      exact Units.ext hlabel
     rw [hχ _ hred, Units.val_one]
   rw [hfactor, map_mul, map_mul, map_zpow, map_zpow,
     slash_zpow_mul_mul_zpow_eq_smul k f hdet hT hconj i j, hchar, one_smul]

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -781,7 +781,7 @@ drops: `exists_eq_T_zpow_mul_conjScale_mul_T_zpow` writes `δ ∈ Γ₁(N/l)` as
 `T`-periodicity through `slash_zpow_mul_mul_zpow_eq_smul`, and the middle factor contributes the
 character value read off `γ 1 1` — which the factorisation forces to be `1`, because `γ 1 1` is
 congruent to `δ 1 1 ≡ 1` modulo `N / l`. -/
-theorem slash_mapGL_eq_self_of_mem_Gamma1_div (l N : ℕ) [NeZero l] [NeZero N] (hlN : l ∣ N)
+theorem slash_mapGL_eq_self_of_mem_Gamma1_div (l N : ℕ) [NeZero l] (hlN : l ∣ N)
     (hNl : N / l ∣ N) (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
     (hχ : ∀ u : (ZMod N)ˣ, ZMod.unitsMap hNl u = 1 → χ u = 1) (f : ℍ → ℂ)
     (hnb : ∀ (γ : SL(2, ℤ)) (hγ : γ ∈ Gamma0 N),

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -778,8 +778,9 @@ character value `χ` reads off `γ`, if `f` is `T`-periodic, and if `χ` is triv
 the reduction `(ZMod N)ˣ → (ZMod (N/l))ˣ`, then `f` is invariant under all of `Γ₁(N / l)`.
 
 This is the step that converts a nebentypus into honest invariance, and it is where the conductor
-drops: a form whose character already factors through `N / l` is invariant under the smaller group,
-which is what the conductor argument turns into a statement about newforms.
+drops: a form whose character already factors through `N / l` is invariant under all of
+`Γ₁(N / l)`, the larger congruence subgroup at the lower level, which is what the conductor
+argument turns into a statement about newforms.
 
 Adapted from `conductor_slash_eq_self_of_mem_Gamma1_div` in AINTLIB
 (`Eigenforms/ConductorTheorem.lean`:217, Chris Birkbeck, Apache-2.0, commit
@@ -806,10 +807,14 @@ theorem slash_mapGL_eq_self_of_mem_Gamma1_div (l N : ℕ) [NeZero l] (hlN : l �
   have hchar : (χ ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) : ℂ) = 1 := by
     obtain ⟨-, hd, hcz⟩ := (Gamma1_mem _ _).mp hδ
     have hγ' : γ ∈ Gamma0 (N / l) := Gamma0_le_Gamma0_of_dvd (Nat.div_dvd_of_dvd hlN) hγ
+    -- Mathlib builds `Gamma0Map` as a bare `MonoidHom.mk` and provides no lemma for its value,
+    -- so reading it as the lower-right entry is a definitional step that cannot be avoided; the
+    -- one lemma naming it, `gamma0Map_apply` in `Fricke/Conjugation.lean`, is `private` there and
+    -- so unavailable here. Naming it once keeps the rest of the proof independent of that
+    -- representation.
+    have hentry : Gamma0Map (N / l) ⟨γ, hγ'⟩ = ((γ 1 1 : ℤ) : ZMod (N / l)) := rfl
     have hlabel : Gamma0Map (N / l) ⟨γ, hγ'⟩ = 1 := by
-      -- `Gamma0Map` is by definition the lower-right entry read in `ZMod (N / l)`
-      change ((γ 1 1 : ℤ) : ZMod (N / l)) = 1
-      rw [hdiag]
+      rw [hentry, hdiag]
       push_cast
       rw [hd, hcz, zero_mul, sub_zero]
     have hred : ZMod.unitsMap (Nat.div_dvd_of_dvd hlN)


### PR DESCRIPTION
The nebentypus of a level-`N` form descends to invariance under `Γ₁(N/l)` when the character
factors through `N / l`. This adds that step — the point at which the conductor drops.

## What this adds

`TauCeti/NumberTheory/ModularForms/Degeneracy.lean`, one theorem in the existing `Nebentypus`
section:

* `slash_mapGL_eq_self_of_mem_Gamma1_div` — if `f ∣[k] V_l` is an eigenvector of every
  `γ ∈ Γ₀(N)` with eigenvalue the character value read off `γ`, if `f` is `T`-periodic, and if `χ`
  is trivial on the kernel of `(ZMod N)ˣ → (ZMod (N/l))ˣ`, then `f ∣[k] mapGL ℝ δ = f` for every
  `δ ∈ Γ₁(N/l)`.

No new definitions, no new imports: everything it needs is already reachable from this file.

## How the proof is assembled from what is already on main

The source proves this through a conductor-specific helper. Here it composes three lemmas that are
already on `main`, which is why nothing new is introduced:

* `exists_eq_T_zpow_mul_conjScale_mul_T_zpow` (`Degeneracy.lean`:535) writes `δ ∈ Γ₁(N/l) ≤ Γ₀(N/l)`
  as `T ^ i * conjScale l γ c * T ^ j` with `γ ∈ Γ₀(N)`, recording `γ 1 1 = δ 1 1 - δ 1 0 * j`.
* `slash_zpow_mul_mul_zpow_eq_smul` (`Basic.lean`:133) absorbs the two translations into the
  `T`-periodicity hypothesis.
* `slash_conjScale_eq_smul_of_slash_scaleGL` (`Degeneracy.lean`:651) turns the eigenvalue law for
  `f ∣[k] scaleGL l` into one for `f ∣[k] mapGL ℝ (conjScale l γ c)`.

The character value is then `1`: the recorded lower-right entry gives `γ 1 1 ≡ δ 1 1 - δ 1 0 * j`,
and `Gamma1_mem` gives `δ 1 1 ≡ 1`, `δ 1 0 ≡ 0` modulo `N / l`.

## Vocabulary: stated over `main`'s API, not the source's

The source states this over `levelRaiseFun`, `levelRaiseMatrix`, `Gamma0MapUnits` and
`DirichletCharacter`. Measured against `origin/main`, the first three have **zero declaration
sites** — every textual hit is a provenance note recording the rename — so stating a survivor over
them would import a vocabulary this repository has deliberately replaced. Three consequences:

* the character is a `(ZMod N)ˣ →* ℂˣ`, matching `modFormCharSpace`, rather than a
  `DirichletCharacter`; this also keeps `Degeneracy.lean` free of a `DirichletCharacter` import it
  does not currently have;
* "factors through `N / l`" is stated as triviality on the kernel of `ZMod.unitsMap`, which is the
  form the proof consumes and is weaker than carrying a `FactorsThrough` structure;
* the eigenvalue law is taken directly as a hypothesis on `f ∣[k] scaleGL l`. The source instead
  threads a `ModularForm g`, its `modFormCharSpace` membership, and `⇑g = levelRaiseFun l k f`.
  Dropping that plumbing is a generalisation, not a shortcut: the proof never uses `g` except
  through this law, and a caller holding a form supplies it from `coe_levelRaise`.

## Gates run

| Gate | Result |
| --- | --- |
| `lake build` of `Degeneracy` and its five direct importers | **pass** — `Build completed successfully (3528 jobs)`, 0 errors, 0 warnings |
| declaration delta against `main` | **pass** — exactly one theorem added, nothing removed |
| line length | **pass** — longest line 100 |
| axioms / module-system / full build / `lint-env` | CI (`pr-build`) |

Roadmap: ModularForms

Target: ModularForms Layer 4, the conductor theorem of Miyake §4.6.4. This is the level-lowering
step: it is what exhibits a form whose nebentypus factors through `N / l` as invariant under the
smaller group, which is the content the conductor argument turns into a statement about newforms.

## Provenance

Adapted from AINTLIB's `Eigenforms/ConductorTheorem.lean` at pin
`2baa76f742bdb4fb8ee323fabba41203bd390e08`, declaration
`conductor_slash_eq_self_of_mem_Gamma1_div` (:217). The mathematical argument — factor, absorb the
translations, read the character off the lower-right entry — is the source's. The statement over
`main`'s units-valued characters and `scaleGL`/`conjScale`, the removal of the `ModularForm`
plumbing, and the composition from the three existing lemmas above are not: the source's own route
runs through `conductor_slash_T_conj_eq`, a conductor-specific helper whose general form landed
here separately as `slash_zpow_mul_mul_zpow_eq_smul`.
