### PR TITLE
feat(MordellWeil): the Mordell-Weil theorem, E(K) is finitely generated

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/FinitelyGenerated.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/FinitelyGenerated.lean
@@ -66,8 +66,11 @@ section Northcott
 variable [AdmissibleAbsValues F] [Northcott (logHeight₁ (K := F))]
 variable [DecidableEq F] [W.toAffine.IsElliptic]
 
-/-- The torsion subgroup of the group of `K`-rational points on an elliptic curve over a
-number field `K` is finite. -/
+/-- The torsion subgroup of `E(F)` is finite, for any field `F` carrying admissible absolute
+values whose `logHeight₁` satisfies the Northcott property. No number field is needed: the
+descent uses only the approximate parallelogram law and Northcott finiteness, both of which are
+available at that generality. A number field is one such `F`, via
+`Mathlib/NumberTheory/Height/NumberField.lean`. -/
 theorem finite_torsion : Finite (AddCommGroup.torsion W.Point) := by
   obtain ⟨C, hC⟩ := approx_parallelogram_law W
   exact AddCommGroup.finite_torsion_of_descent' hC

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/FinitelyGenerated.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/FinitelyGenerated.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.Descent
+public import Mathlib.NumberTheory.Height.NumberField
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Point.VariableChange
+public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.NaiveHeight
+public import TauCeti.AlgebraicGeometry.EllipticCurve.MordellWeil.WeakMordellWeil
+public import TauCeti.NumberTheory.NumberField.IntegralClosure
+
+/-!
+# Finite generation of the group of rational points
+
+The descent is complete: the weak Mordell–Weil theorem gives that `E(K)/2E(K)` is finite, the
+naïve height satisfies the approximate parallelogram law and the Northcott property, and Mathlib's
+descent engine `AddCommGroup.fg_of_descent'` turns those two into finite generation of `E(K)`.
+
+The statements are named for their conclusions, per the roadmap: no declaration is called
+`mordellWeil`, and the classical name appears in docstrings only.
+
+## Main results
+
+* `WeierstrassCurve.Affine.finite_torsion` : the torsion subgroup of `E(K)` is finite.
+* `WeierstrassCurve.Affine.fg_point` : `E(K)` is finitely generated, for a curve in the normal
+  form `y² = f(x)` over the fraction field of a Dedekind domain, under per-factor class-group and
+  unit-group finiteness.
+* `WeierstrassCurve.Affine.fg_point_of_variableChange` : the same for an arbitrary Weierstrass
+  curve, transferred along an admissible change of variables.
+* `WeierstrassCurve.Affine.fg_point_of_numberField` : **the Mordell–Weil theorem** — `E(K)` is
+  finitely generated for an elliptic curve over a number field.
+
+## Two divergences from the source, both forced by what is already on `main`
+
+*Unit groups are `Monoid.FG`, not `Group.FG`.* The source states `fg_point` with
+`Group.FG (ringOfIntegersFactor R p)ˣ`, but `main`'s weak Mordell–Weil theorem
+(`finiteIndex_range_nsmulAddMonoidHom_two`) takes `Monoid.FG`. Matching `main` avoids an
+impedance mismatch at the one place the hypothesis is used; `Group.fg_iff_monoid_fg` converts,
+and `fg_point_of_numberField` does exactly that when discharging it from Dirichlet's theorem.
+
+*The finiteness inputs are `TauCeti`'s.* `NumberField.finite_classGroup_integralClosure` and
+`NumberField.fg_units_integralClosure` are in
+`TauCeti.NumberTheory.NumberField.IntegralClosure`, since they are general number theory and
+mention no curve.
+
+## References
+
+* [M. Stoll, *EllipticCurves*](https://github.com/MichaelStollBayreuth/EllipticCurves), commit
+  `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, `EllipticCurves/MordellWeil.lean` (`:350`, `:371`,
+  `:390`, `:416`), Apache-2.0. The proofs are that file's.
+-/
+
+public section
+
+open Height NumberField
+
+namespace WeierstrassCurve.Affine
+
+variable {F : Type*} [Field F] {W : Affine F}
+
+section Northcott
+
+variable [AdmissibleAbsValues F] [Northcott (logHeight₁ (K := F))]
+variable [DecidableEq F] [W.toAffine.IsElliptic]
+
+/-- The torsion subgroup of the group of `K`-rational points on an elliptic curve over a
+number field `K` is finite. -/
+theorem finite_torsion : Finite (AddCommGroup.torsion W.Point) := by
+  obtain ⟨C, hC⟩ := approx_parallelogram_law W
+  exact AddCommGroup.finite_torsion_of_descent' hC
+
+/-- **The Mordell–Weil theorem**, general version: `E(K)` is finitely generated, for an elliptic
+curve `E` given by an equation `y² = f(x)` with a monic cubic `f` (`a₁ = a₃ = 0`) over a field `K`
+such that `K` has admissible absolute values with the Northcott property, `K` is the fraction
+field of a Dedekind domain `R`, and for each irreducible factor `p` of `f` the integral closure of
+`R` in `K[X] ⧸ (p)` has finite class group and finitely generated unit group.
+
+For `K` a number field all of these hold; see `fg_point_of_numberField`.
+
+The per-factor hypotheses cannot be replaced by the corresponding hypotheses on `R` itself: by a
+theorem of Claborn, refined by Leedham-Green and by Clark, *every* abelian group is the class
+group of the integral closure of a PID in a separable quadratic extension, so
+`Finite (ClassGroup R)` gives no control over the class groups of the factors. -/
+theorem fg_point (R : Type*) [CommRing R] [IsDedekindDomain R] [Algebra R F]
+    [IsFractionRing R F] [W.IsCharNeTwoNF]
+    [(p : W.f.Factors) → Finite (ClassGroup (W.ringOfIntegersFactor R p))]
+    [(p : W.f.Factors) → Monoid.FG (W.ringOfIntegersFactor R p)ˣ] :
+    AddGroup.FG W.Point := by
+  have H₂ (P : W.Point) : 0 ≤ P.naiveHeight := by
+    rw [Point.naiveHeight_eq_logHeight P]
+    positivity
+  obtain ⟨C, hC⟩ := approx_parallelogram_law W
+  exact AddCommGroup.fg_of_descent' (W.finiteIndex_range_nsmulAddMonoidHom_two R) H₂ hC
+
+/-- **The Mordell–Weil theorem** for an arbitrary Weierstrass curve: `E(K)` is finitely generated,
+given an admissible change of variables `C` bringing `E` into the normal form `y² = f(x)`,
+together with the finiteness hypotheses of `fg_point` for the model `C • E`. The result transfers
+along the isomorphism of point groups `Point.equivVariableChange`.
+
+Such a `C` exists whenever `2` is invertible in `K`, by completing the square. -/
+theorem fg_point_of_variableChange (R : Type*) [CommRing R] [IsDedekindDomain R] [Algebra R F]
+    [IsFractionRing R F] (C : VariableChange F) [(C • W).IsCharNeTwoNF]
+    [(p : (C • W).toAffine.f.Factors) →
+      Finite (ClassGroup ((C • W).toAffine.ringOfIntegersFactor R p))]
+    [(p : (C • W).toAffine.f.Factors) →
+      Monoid.FG ((C • W).toAffine.ringOfIntegersFactor R p)ˣ] :
+    AddGroup.FG W.Point := by
+  have := fg_point (W := (C • W).toAffine) R
+  exact AddGroup.fg_of_surjective (f := (Point.equivVariableChange W C).toAddMonoidHom)
+    (Point.equivVariableChange W C).surjective
+
+end Northcott
+
+section NumberField
+
+variable {F : Type*} [Field F] [NumberField F] [DecidableEq F] {W : Affine F}
+  [W.toAffine.IsElliptic]
+
+/-- **The Mordell–Weil theorem**: the group `E(K)` of `K`-rational points of an elliptic curve `E`
+over a number field `K` is finitely generated.
+
+The square on the left-hand side is completed by an admissible change of variables, possible since
+`K` has characteristic zero, and the finiteness hypotheses of `fg_point` for the resulting model
+are the class number theorem and Dirichlet's unit theorem. -/
+theorem fg_point_of_numberField : AddGroup.FG W.Point := by
+  have := invertibleOfNonzero (two_ne_zero (α := F))
+  obtain ⟨C, hC⟩ := exists_variableChange_isCharNeTwoNF (W := W)
+  have (p : (C • W).toAffine.f.Factors) :
+      Finite (ClassGroup ((C • W).toAffine.ringOfIntegersFactor (𝓞 F) p)) :=
+    NumberField.finite_classGroup_integralClosure F (AdjoinRoot (p : Polynomial F))
+  have (p : (C • W).toAffine.f.Factors) :
+      Monoid.FG ((C • W).toAffine.ringOfIntegersFactor (𝓞 F) p)ˣ :=
+    Group.fg_iff_monoid_fg.mp
+      (NumberField.fg_units_integralClosure F (AdjoinRoot (p : Polynomial F)))
+  exact fg_point_of_variableChange (𝓞 F) C
+
+end NumberField
+
+end WeierstrassCurve.Affine
+
+end

--- a/TauCeti/NumberTheory/NumberField/IntegralClosure.lean
+++ b/TauCeti/NumberTheory/NumberField/IntegralClosure.lean
@@ -50,9 +50,9 @@ theorem isIntegralClosure_int_integralClosure :
     IsIntegralClosure (integralClosure (𝓞 K) L) ℤ L := by
   refine ⟨Subtype.val_injective, fun {x} ↦ ⟨fun hx ↦ ?_, fun ⟨y, hy⟩ ↦ ?_⟩⟩
   · exact ⟨⟨x, IsIntegral.tower_top (A := 𝓞 K) hx⟩, rfl⟩
-  · have hyint : IsIntegral (𝓞 K) (y : L) := y.2
-    have := isIntegral_trans (R := ℤ) (y : L) hyint
-    rwa [show (y : L) = x from hy] at this
+  · have hyint : IsIntegral (𝓞 K) (algebraMap (integralClosure (𝓞 K) L) L y) := y.2
+    have := isIntegral_trans (R := ℤ) _ hyint
+    rwa [hy] at this
 
 variable [NumberField K] [FiniteDimensional K L]
 

--- a/TauCeti/NumberTheory/NumberField/IntegralClosure.lean
+++ b/TauCeti/NumberTheory/NumberField/IntegralClosure.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.ClassNumber.AdmissibleAbs
+public import Mathlib.NumberTheory.ClassNumber.Finite
+public import Mathlib.NumberTheory.NumberField.Units.DirichletTheorem
+public import Mathlib.RingTheory.IntegralClosure.IsIntegralClosure.Basic
+
+/-!
+# The integral closure of `𝓞 K` in a finite extension of number fields
+
+For a finite extension `L` of a number field `K`, the integral closure of `𝓞 K` in `L` is the
+integral closure of `ℤ` in `L`, hence isomorphic to `𝓞 L`. Two consequences transfer along that
+identification and are the finiteness inputs of the Mordell–Weil descent: the class group of the
+integral closure is finite, and its unit group is finitely generated.
+
+Both are stated for `integralClosure (𝓞 K) L` rather than for `𝓞 L`, because that is the ring the
+descent actually produces — `WeierstrassCurve.Affine.ringOfIntegersFactor` is an integral closure
+in a quotient `K[X] ⧸ (p)`, not a ring of integers presented as such.
+
+## Main results
+
+* `isIntegralClosure_int_integralClosure` : the integral closure of `𝓞 K` in `L` is the integral
+  closure of `ℤ` in `L`.
+* `NumberField.finite_classGroup_integralClosure` : the **class number theorem** for it.
+* `NumberField.fg_units_integralClosure` : the finite-generation half of **Dirichlet's unit
+  theorem** for it.
+
+## References
+
+* [M. Stoll, *EllipticCurves*](https://github.com/MichaelStollBayreuth/EllipticCurves), commit
+  `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`, `EllipticCurves/Mathlib/Basic.lean`, Apache-2.0.
+  That file collects general-purpose results its author flags as Mathlib candidates; these three
+  are adapted from it essentially verbatim.
+-/
+
+public section
+
+open NumberField
+
+variable (K L : Type*) [Field K] [Field L] [Algebra K L]
+
+/-- The integral closure of `𝓞 K` in an extension `L` of `K` is the integral closure of `ℤ`
+in `L`. -/
+theorem isIntegralClosure_int_integralClosure :
+    IsIntegralClosure (integralClosure (𝓞 K) L) ℤ L := by
+  refine ⟨Subtype.val_injective, fun {x} ↦ ⟨fun hx ↦ ?_, fun ⟨y, hy⟩ ↦ ?_⟩⟩
+  · exact ⟨⟨x, IsIntegral.tower_top (A := 𝓞 K) hx⟩, rfl⟩
+  · have hyint : IsIntegral (𝓞 K) (y : L) := y.2
+    have := isIntegral_trans (R := ℤ) (y : L) hyint
+    rwa [show (y : L) = x from hy] at this
+
+variable [NumberField K] [FiniteDimensional K L]
+
+/-- The **class number theorem** for the integral closure of `𝓞 K` in a finite extension `L`
+of the number field `K`: its class group is finite. -/
+theorem NumberField.finite_classGroup_integralClosure :
+    Finite (ClassGroup (integralClosure (𝓞 K) L)) := by
+  have : NumberField L := .of_module_finite K L
+  have := isIntegralClosure_int_integralClosure K L
+  have := ClassGroup.fintypeOfAdmissibleOfFinite ℚ L
+    (S := integralClosure (𝓞 K) L) AbsoluteValue.absIsAdmissible
+  exact Finite.of_fintype _
+
+/-- **Dirichlet's unit theorem** (finite generation) for the integral closure of `𝓞 K` in a
+finite extension `L` of the number field `K`: its unit group is finitely generated. -/
+theorem NumberField.fg_units_integralClosure :
+    Group.FG (integralClosure (𝓞 K) L)ˣ := by
+  have : NumberField L := .of_module_finite K L
+  have e : integralClosure (𝓞 K) L ≃ₐ[𝓞 K] (𝓞 L) :=
+    IsIntegralClosure.equiv (𝓞 K) (integralClosure (𝓞 K) L) L (𝓞 L)
+  have : Group.FG (𝓞 L)ˣ := Group.fg_iff_monoid_fg.mpr inferInstance
+  exact Group.fg_of_surjective
+    (f := (Units.mapEquiv e.symm.toRingEquiv.toMulEquiv).toMonoidHom)
+    (Units.mapEquiv e.symm.toRingEquiv.toMulEquiv).surjective
+
+end


### PR DESCRIPTION
**The Mordell–Weil theorem**: the group `E(K)` of `K`-rational points of an elliptic curve over a
number field is finitely generated.

This completes the descent. The weak Mordell–Weil theorem (#4857) gives that `E(K)/2E(K)` is
finite; the naïve height (#4882) satisfies the approximate parallelogram law and the Northcott
property; Mathlib's `AddCommGroup.fg_of_descent'` turns those two into finite generation.

Roadmap: EllipticCurves

Target: `EllipticCurves/README.md:800-806`, Layer 6 — the naïve x-height route. This is the
terminal rung of that route; the canonical (Néron–Tate) height remains a separate later milestone
(README:804-812) and is not built here.

## Provenance

Adapted with attribution from [M. Stoll,
*EllipticCurves*](https://github.com/MichaelStollBayreuth/EllipticCurves), commit
`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e` (Apache-2.0): `EllipticCurves/MordellWeil.lean` at
`:350`, `:371`, `:390`, `:416` for the four theorems, and `EllipticCurves/Mathlib/Basic.lean` at
`:1212`, `:1224`, `:1234` for the three integral-closure supplements — a file its author collects
as Mathlib candidates. The proofs are that file's.

## Contents

**`TauCeti/NumberTheory/NumberField/IntegralClosure.lean`** (new)

* `isIntegralClosure_int_integralClosure` — the integral closure of `𝓞 K` in `L` is the integral
  closure of `ℤ` in `L`.
* `NumberField.finite_classGroup_integralClosure` — the class number theorem for it.
* `NumberField.fg_units_integralClosure` — the finite-generation half of Dirichlet's unit theorem
  for it.

**`TauCeti/AlgebraicGeometry/EllipticCurve/MordellWeil/FinitelyGenerated.lean`** (new)

* `finite_torsion` — the torsion subgroup of `E(K)` is finite.
* `fg_point` — `E(K)` is finitely generated over the fraction field of a Dedekind domain, under
  per-factor class-group and unit-group finiteness.
* `fg_point_of_variableChange` — the same for an arbitrary Weierstrass curve, transferred along
  `Point.equivVariableChange`.
* `fg_point_of_numberField` — the headline.

Statement-named per the roadmap (README:792-794): no declaration is called `mordellWeil`, and the
classical name appears in docstrings only.

## Two divergences from the source, both forced by `main`

**Per-factor unit groups are `Monoid.FG`, not `Group.FG`.** The source states `fg_point` with
`Group.FG (ringOfIntegersFactor R p)ˣ`, but `main`'s weak Mordell–Weil theorem
(`WeakMordellWeil.lean:94`) takes `Monoid.FG`. Matching `main` avoids an impedance mismatch at the
one place the hypothesis is consumed; `Group.fg_iff_monoid_fg` converts, and
`fg_point_of_numberField` does exactly that when discharging it from Dirichlet's theorem.

**The three supplements live in `NumberTheory/`, not `MordellWeil/`.** They are general number
theory and mention no curve. Placing them beside the descent would repeat the placement finding
that split #4882 into four modules.

## Prior art, checked by shape rather than by name

A name-based check reads false-fresh when the work exists under other names, so the probe was on
conclusions and codomains, with a control that must resolve:

* `AddGroup.FG` on a point group — the only hit on `main` is `SelmerGroup.lean:128`, which *takes*
  `[AddGroup.FG W.Point]` as a hypothesis. Nothing proves it.
* `Finite (… torsion …)` — absent.
* `fg_of_descent` / `finite_torsion_of_descent` — never invoked on `main`.
* `Finite (ClassGroup (integralClosure …))` and `Group.FG (integralClosure …)ˣ` — absent by
  codomain; `main`'s only `Finite (ClassGroup …)` occurrences are the *hypothesis* forms in
  `WeakMordellWeil.lean:82` and `SelmerGroupA.lean:150`, which is the control firing.

**This discharges an assumption `main` already carries.** `SelmerGroup.lean:128` states
`card_range_μ` under `[AddGroup.FG W.Point]`; for elliptic curves over number fields that is now a
theorem rather than a hypothesis.

## What is consumed rather than restated

From `main`: `finiteIndex_range_nsmulAddMonoidHom_two` (WeakMordellWeil.lean:94 — read from the
tip, since the bead's `finite_index_…` spelling is superseded), `ringOfIntegersFactor` and its
Dedekind/fraction-field instances (BadPrimes.lean:236–247), `Point.equivVariableChange`
(VariableChange.lean:167), and the height layer from #4882. From Mathlib:
`AddCommGroup.fg_of_descent'` and `AddCommGroup.finite_torsion_of_descent'`
(`GroupTheory/Descent.lean`), `exists_variableChange_isCharNeTwoNF`, `AddGroup.fg_of_surjective`,
and the number-field `AdmissibleAbsValues` / `Northcott` instances
(`NumberTheory/Height/NumberField.lean`).

## Gates

`lake build` of both modules: exit 0, "Build completed successfully (3630 jobs)", zero errors and
zero warnings, both `.olean`s present. Comment-stripped code scan for `sorry` / `native_decide` /
`maxHeartbeats`: zero, with a control confirming the scanner sees the declarations. No line
exceeds 100 characters. `#lint only simpNF` over `TauCeti.AlgebraicGeometry.EllipticCurve` and
`TauCeti.NumberTheory.NumberField`: "All linting checks passed".
