### PR TITLE
docs(ModularForms): correct the stale Hecke-action claim in Newforms/Basic

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
@@ -27,9 +27,13 @@ The old subspace is stable under the diamond operators, because `V_d` intertwine
 (`TauCeti.CuspForm.diamondOpCusp_levelRaise`). This is the lemma behind the fixed-nebentypus
 refinement `S_k(N, χ)ⁿᵉʷ = S_k(Γ₁(N))ⁿᵉʷ ⊓ S_k(N, χ)` of Layer 3 of the ModularForms roadmap,
 which additionally needs the diamond operators to be Petersson-unitary and is carried out in
-`TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean`. The stability of the new subspace
-under the Hecke operators is still missing: the Hecke action on forms is Layer 2 of that
-roadmap, and does not yet exist.
+`TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean`.
+
+The old subspace is likewise stable under the Hecke operators at primes `p` coprime to the level
+(`TauCeti.heckeTCuspNat_mem_cuspFormsOld`, in
+`TauCeti/NumberTheory/ModularForms/Newforms/HeckeStability.lean`), for the Hecke action
+`TauCeti.HeckeRing.GL2.heckeTCuspNat` on cusp forms. The corresponding stability of the *new*
+subspace is still missing.
 
 ## Main definitions
 


### PR DESCRIPTION
`TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean`'s module docstring makes a claim about the
Hecke action that is false on current `main`. This corrects it. Documentation only — no
declaration is added, removed or changed.

## The stale claim

The module docstring ends its discussion of stability with:

> The stability of the new subspace under the Hecke operators is still missing: the Hecke action
> on forms is Layer 2 of that roadmap, and does not yet exist.

The second clause is wrong twice over:

* **The Hecke action on cusp forms exists.** `TauCeti.HeckeRing.GL2.heckeTCuspNat` landed in #4307
  on 2026-08-23, at `TauCeti/NumberTheory/ModularForms/HeckeSlash/Operators.lean:86`. The file
  carrying the stale sentence was last touched on 2026-08-19, four days earlier, so the sentence
  was accurate when written and has simply not been revisited since.
* **Stability of the *old* subspace under the Hecke operators now exists too.**
  `TauCeti.heckeTCuspNat_mem_cuspFormsOld` landed in #4911, at
  `TauCeti/NumberTheory/ModularForms/Newforms/HeckeStability.lean:54`.

The sentence is also the file's only pointer to Hecke stability, so a reader arriving at the
old/new subspaces is told the whole subject does not exist when half of it now does.

## What the replacement says

Only what is measured on `main`:

* the old subspace is stable under the Hecke operators **at primes `p` coprime to the level** —
  `heckeTCuspNat_mem_cuspFormsOld` carries `hp : p.Prime` and `hpN : Nat.Coprime p N`, and
  dropping either hypothesis would replace a stale claim with a false one;
* it names the file that proves it, and the Hecke action it is stated over;
* the corresponding stability of the **new** subspace is still missing — which remains true:
  `heckeT_n_preserves_cuspFormsNew` probes 0 files on `main`.

The paragraph is split in two, so that the diamond-operator discussion and the Hecke discussion
are no longer one run-on paragraph.

## Verification

Every declaration named in the new text was probed at `main` `93c67a308` before being cited:
`HeckeRing.GL2.heckeTCuspNat` (Operators.lean:86), `heckeTCuspNat_mem_cuspFormsOld`
(HeckeStability.lean:54). The claim of absence for the new subspace was probed the same way and
returns 0.

Roadmap: ModularForms
