### PR TITLE
feat: preserve reductivity under direct products

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/FiniteType/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteType/BaseChange.lean
@@ -31,6 +31,9 @@ the original points evaluated on `K`-algebras.
 * `FiniteTypeCommHopfAlgCat.baseChangeFunctor`: functorial base change.
 * `FiniteTypeCommHopfAlgCat.baseChangeTensorProductIso`: the canonical comparison between the
   base change of a tensor product and the tensor product of the base changes.
+* `FiniteTypeCommHopfAlgCat.baseChangeMap_includeLeft_injective` and
+  `FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_injective`: the base-changed coordinate
+  inclusions into a product are injective.
 * `FiniteTypeCommHopfAlgCat.baseChangeIsoOfObjIso`: lift an isomorphism between specified
   underlying base-changed objects to the finite-type full subcategory.
 * `FiniteTypeCommHopfAlgCat.baseChangePointsMulEquiv`: the inherited point equivalence
@@ -195,6 +198,54 @@ theorem baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom
     TensorProduct.tmul_eq_smul_one_tmul s l
   rw [hsH, hsL]
   exact TensorProduct.smul_tmul s ((1 : K) ⊗ₜ[k] (1 : H)) ((1 : K) ⊗ₜ[k] l)
+
+/-- The base change of the left coordinate inclusion into a product is injective. -/
+theorem baseChangeMap_includeLeft_injective
+    (H L : FiniteTypeCommHopfAlgCat.{u, v} k) :
+    Function.Injective (toBialgHom (baseChangeMap (K := K) (includeLeft H L))) := by
+  let H' := baseChange (K := K) H
+  let L' := baseChange (K := K) L
+  let e := baseChangeTensorProductIso K H L
+  apply Function.Injective.of_comp (f := toBialgHom e.hom)
+  have hcomp := congrArg toBialgHom
+    (baseChangeMap_includeLeft_comp_baseChangeTensorProductIso_hom K H L)
+  rw [toBialgHom_comp] at hcomp
+  change (toBialgHom e.hom).comp (toBialgHom (baseChangeMap (K := K) (includeLeft H L))) =
+    Bialgebra.TensorProduct.includeLeft at hcomp
+  have hinclude : Function.Injective
+      (Bialgebra.TensorProduct.includeLeft (R := K) (H₁ := H') (H₂ := L')) := by
+    apply Function.LeftInverse.injective
+      (g := Bialgebra.TensorProduct.projectLeft (R := K) (H₁ := H') (H₂ := L'))
+    intro x
+    simp only [← BialgHom.comp_apply,
+      Bialgebra.TensorProduct.projectLeft_comp_includeLeft, BialgHom.id_apply]
+  intro x y hxy
+  apply hinclude
+  simpa only [Function.comp_apply, ← BialgHom.comp_apply, hcomp] using hxy
+
+/-- The base change of the right coordinate inclusion into a product is injective. -/
+theorem baseChangeMap_includeRight_injective
+    (H L : FiniteTypeCommHopfAlgCat.{u, v} k) :
+    Function.Injective (toBialgHom (baseChangeMap (K := K) (includeRight H L))) := by
+  let H' := baseChange (K := K) H
+  let L' := baseChange (K := K) L
+  let e := baseChangeTensorProductIso K H L
+  apply Function.Injective.of_comp (f := toBialgHom e.hom)
+  have hcomp := congrArg toBialgHom
+    (baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom K H L)
+  rw [toBialgHom_comp] at hcomp
+  change (toBialgHom e.hom).comp (toBialgHom (baseChangeMap (K := K) (includeRight H L))) =
+    Bialgebra.TensorProduct.includeRight at hcomp
+  have hinclude : Function.Injective
+      (Bialgebra.TensorProduct.includeRight (R := K) (H₁ := H') (H₂ := L')) := by
+    apply Function.LeftInverse.injective
+      (g := Bialgebra.TensorProduct.projectRight (R := K) (H₁ := H') (H₂ := L'))
+    intro x
+    simp only [← BialgHom.comp_apply,
+      Bialgebra.TensorProduct.projectRight_comp_includeRight, BialgHom.id_apply]
+  intro x y hxy
+  apply hinclude
+  simpa only [Function.comp_apply, ← BialgHom.comp_apply, hcomp] using hxy
 
 /-- Lift an isomorphism between specified underlying base-changed Hopf algebras to the
 finite-type full subcategory. The object equalities record the chosen presentations of the

--- a/TauCeti/Algebra/AlgebraicGroup/FiniteType/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FiniteType/BaseChange.lean
@@ -210,8 +210,13 @@ theorem baseChangeMap_includeLeft_injective
   have hcomp := congrArg toBialgHom
     (baseChangeMap_includeLeft_comp_baseChangeTensorProductIso_hom K H L)
   rw [toBialgHom_comp] at hcomp
+  -- `includeLeft` is a finite-type categorical abbreviation for this bialgebra map. There is
+  -- deliberately no duplicate categorical `toBialgHom` lemma, so expose that abbreviation here.
   change (toBialgHom e.hom).comp (toBialgHom (baseChangeMap (K := K) (includeLeft H L))) =
     Bialgebra.TensorProduct.includeLeft at hcomp
+  -- Mathlib's algebra-level inclusion theorem requires `Module.Flat K H'`, which is not
+  -- available for an arbitrary Hopf algebra. The counit projection gives a retraction without
+  -- adding that unnecessary hypothesis.
   have hinclude : Function.Injective
       (Bialgebra.TensorProduct.includeLeft (R := K) (H₁ := H') (H₂ := L')) := by
     apply Function.LeftInverse.injective
@@ -234,8 +239,12 @@ theorem baseChangeMap_includeRight_injective
   have hcomp := congrArg toBialgHom
     (baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom K H L)
   rw [toBialgHom_comp] at hcomp
+  -- `includeRight` is likewise only a finite-type wrapper around the concrete bialgebra map;
+  -- expose the abbreviation rather than adding a second public statement of that identity.
   change (toBialgHom e.hom).comp (toBialgHom (baseChangeMap (K := K) (includeRight H L))) =
     Bialgebra.TensorProduct.includeRight at hcomp
+  -- As on the left, the bialgebra projection proves injectivity without the flatness
+  -- hypothesis required by Mathlib's algebra-level tensor-product inclusion theorem.
   have hinclude : Function.Injective
       (Bialgebra.TensorProduct.includeRight (R := K) (H₁ := H') (H₂ := L')) := by
     apply Function.LeftInverse.injective

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
@@ -134,6 +134,58 @@ private theorem injective_of_comp_iso
   simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] using
     congrArg (FiniteTypeCommHopfAlgCat.toBialgHom e.hom) hxy
 
+private theorem baseChangeMap_includeLeft_injective
+    (H K : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom
+      (FiniteTypeCommHopfAlgCat.baseChangeMap (K := AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.includeLeft H K))) := by
+  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+  let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
+  let e := FiniteTypeCommHopfAlgCat.baseChangeTensorProductIso (AlgebraicClosure k) H K
+  apply injective_of_comp_iso _ e (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)
+    (FiniteTypeCommHopfAlgCat.baseChangeMap_includeLeft_comp_baseChangeTensorProductIso_hom
+      (AlgebraicClosure k) H K)
+  exact injective_of_retraction
+    (Bialgebra.TensorProduct.includeLeft
+      (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
+    (Bialgebra.TensorProduct.projectLeft
+      (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
+    Bialgebra.TensorProduct.projectLeft_comp_includeLeft
+
+private theorem baseChangeMap_includeRight_injective
+    (H K : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom
+      (FiniteTypeCommHopfAlgCat.baseChangeMap (K := AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.includeRight H K))) := by
+  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+  let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
+  let e := FiniteTypeCommHopfAlgCat.baseChangeTensorProductIso (AlgebraicClosure k) H K
+  apply injective_of_comp_iso _ e (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)
+    (FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom
+      (AlgebraicClosure k) H K)
+  exact injective_of_retraction
+    (Bialgebra.TensorProduct.includeRight
+      (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
+    (Bialgebra.TensorProduct.projectRight
+      (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
+    Bialgebra.TensorProduct.projectRight_comp_includeRight
+
+private theorem includeLeft_toAlgHom
+    (H K : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)) :
+    (FiniteTypeCommHopfAlgCat.toBialgHom
+      (FiniteTypeCommHopfAlgCat.includeLeft H K)).toAlgHom =
+        Algebra.TensorProduct.includeLeft := by
+  apply AlgHom.ext
+  exact FiniteTypeCommHopfAlgCat.includeLeft_apply H K
+
+private theorem includeRight_toAlgHom
+    (H K : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)) :
+    (FiniteTypeCommHopfAlgCat.toBialgHom
+      (FiniteTypeCommHopfAlgCat.includeRight H K)).toAlgHom =
+        Algebra.TensorProduct.includeRight := by
+  apply AlgHom.ext
+  exact FiniteTypeCommHopfAlgCat.includeRight_apply H K
+
 private theorem map_eq_counit_of_ker_eq_augmentation
     {H L : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)}
     (f : H ⟶ L)
@@ -180,6 +232,7 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
   let P := FiniteTypeCommHopfAlgCat.tensorProduct Hbar Kbar
   let e : P₀ ≅ P :=
     FiniteTypeCommHopfAlgCat.baseChangeTensorProductIso (AlgebraicClosure k) H K
+  -- First discharge the smoothness and connectedness fields of reductivity.
   have hsmooth : Algebra.Smooth k (FiniteTypeCommHopfAlgCat.tensorProduct H K) := by
     let smoothH : Algebra.Smooth k H := hH.smooth
     let smoothK : Algebra.Smooth k K := hK.smooth
@@ -198,36 +251,11 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
     (FiniteTypeCommHopfAlgCat.includeLeft H K)
   let fK := FiniteTypeCommHopfAlgCat.baseChangeMap (K := AlgebraicClosure k)
     (FiniteTypeCommHopfAlgCat.includeRight H K)
+  -- Project the candidate unipotent subgroup to each factor.
   have hfH : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom fH) := by
-    have heq : fH ≫ e.hom = FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar :=
-      FiniteTypeCommHopfAlgCat.baseChangeMap_includeLeft_comp_baseChangeTensorProductIso_hom
-        (AlgebraicClosure k) H K
-    have hincl : Function.Injective
-        (FiniteTypeCommHopfAlgCat.toBialgHom
-          (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)) :=
-      injective_of_retraction
-        (Bialgebra.TensorProduct.includeLeft
-          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
-        (Bialgebra.TensorProduct.projectLeft
-          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
-        Bialgebra.TensorProduct.projectLeft_comp_includeLeft
-    exact injective_of_comp_iso fH e
-      (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar) heq hincl
+    simpa only [fH] using baseChangeMap_includeLeft_injective H K
   have hfK : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom fK) := by
-    have heq : fK ≫ e.hom = FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar :=
-      FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom
-        (AlgebraicClosure k) H K
-    have hincl : Function.Injective
-        (FiniteTypeCommHopfAlgCat.toBialgHom
-          (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)) :=
-      injective_of_retraction
-        (Bialgebra.TensorProduct.includeRight
-          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
-        (Bialgebra.TensorProduct.projectRight
-          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
-        Bialgebra.TensorProduct.projectRight_comp_includeRight
-    exact injective_of_comp_iso fK e
-      (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar) heq hincl
+    simpa only [fK] using baseChangeMap_includeRight_injective H K
   have hleft : HopfIdeal.ker
       (FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q)) =
         HopfIdeal.augmentation (AlgebraicClosure k) Hbar := by
@@ -236,6 +264,8 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
       (FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q)) =
         HopfIdeal.augmentation (AlgebraicClosure k) Kbar := by
     exact ker_projection_eq_augmentation hK fK hfK I hI hsourceConnected hU
+  -- Both restrictions are counits, so the tensor-product universal property identifies the
+  -- quotient map itself with the counit.
   let g : P →ₐ[AlgebraicClosure k] (FiniteTypeCommHopfAlgCat.quotient P₀ I) :=
     (FiniteTypeCommHopfAlgCat.toBialgHom (e.inv ≫ q)).toAlgHom
   let ε : P →ₐ[AlgebraicClosure k] (FiniteTypeCommHopfAlgCat.quotient P₀ I) :=
@@ -250,26 +280,14 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
   have hleftMap : g.comp Algebra.TensorProduct.includeLeft =
       (Algebra.ofId (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)).comp
         (Bialgebra.counitAlgHom (AlgebraicClosure k) Hbar) := by
-    have hi : (FiniteTypeCommHopfAlgCat.toBialgHom
-        (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)).toAlgHom =
-        Algebra.TensorProduct.includeLeft := by
-      apply AlgHom.ext
-      intro h
-      exact FiniteTypeCommHopfAlgCat.includeLeft_apply Hbar Kbar h
-    rw [← hi]
+    rw [← includeLeft_toAlgHom]
     simpa only [g] using
       restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)
         (e.inv ≫ q) (fH ≫ q) hleftComp hleft
   have hrightMap : g.comp Algebra.TensorProduct.includeRight =
       (Algebra.ofId (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)).comp
         (Bialgebra.counitAlgHom (AlgebraicClosure k) Kbar) := by
-    have hi : (FiniteTypeCommHopfAlgCat.toBialgHom
-        (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)).toAlgHom =
-        Algebra.TensorProduct.includeRight := by
-      apply AlgHom.ext
-      intro l
-      exact FiniteTypeCommHopfAlgCat.includeRight_apply Hbar Kbar l
-    rw [← hi]
+    rw [← includeRight_toAlgHom]
     simpa only [g] using
       restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)
         (e.inv ≫ q) (fK ≫ q) hrightComp hright
@@ -278,6 +296,8 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
     apply Algebra.TensorProduct.ext'
     intro h l
     rw [Algebra.TensorProduct.productMap_apply_tmul]
+    -- Unfold both maps on a pure tensor: the product map multiplies the factor counits,
+    -- while `ε` uses the tensor-product counit.
     change algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
         (Coalgebra.counit h) *
         algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
@@ -308,6 +328,7 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
   apply SetLike.ext
   intro x
   rw [HopfIdeal.mem_augmentation]
+  -- Expose membership in the underlying ideal, as required by `mkQuotient_eq_zero_iff`.
   change x ∈ I.toIdeal ↔ _
   rw [← FiniteTypeCommHopfAlgCat.mkQuotient_eq_zero_iff P₀ I]
   rw [hq]

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
@@ -124,8 +124,12 @@ private theorem restriction_eq_counit
   intro x
   have h := congrArg (fun φ : H ⟶ M ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ x) hcomp
   rw [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] at h
-  exact h.trans (HopfIdeal.apply_eq_counit_of_ker_eq_augmentation
-    (FiniteTypeCommHopfAlgCat.toBialgHom f) hf x)
+  exact h.trans (TauCeti.BialgHom.apply_eq_counit_of_ker_eq_augmentation
+    (FiniteTypeCommHopfAlgCat.toBialgHom f)
+      (by
+        ext y
+        rw [RingHom.mem_ker, HopfIdeal.mem_toIdeal, ← hf, HopfIdeal.mem_ker])
+      x)
 
 /-- **A direct product of reductive finite-type affine groups is reductive.** -/
 theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
@@ -191,23 +195,33 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
         (Bialgebra.counitAlgHom (AlgebraicClosure k) Hbar) := by
     have h := restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)
       (e.inv ≫ q) (fH ≫ q) hleftComp hleft
-    rw [show (FiniteTypeCommHopfAlgCat.toBialgHom
-      (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)).toAlgHom =
-        (Bialgebra.TensorProduct.includeLeft (R := AlgebraicClosure k)
-          (H₁ := Hbar) (H₂ := Kbar)).toAlgHom from rfl,
-      Bialgebra.TensorProduct.includeLeft_toAlgHom] at h
-    simpa only [g] using h
+    have hi : (FiniteTypeCommHopfAlgCat.toBialgHom
+        (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)).toAlgHom =
+        Algebra.TensorProduct.includeLeft := by
+      apply AlgHom.ext
+      intro x
+      exact (FiniteTypeCommHopfAlgCat.includeLeft_apply Hbar Kbar x).trans
+        (Algebra.TensorProduct.includeLeft_apply x).symm
+    rw [hi] at h
+    apply AlgHom.ext
+    intro x
+    simpa only [g] using DFunLike.congr_fun h x
   have hrightMap : g.comp Algebra.TensorProduct.includeRight =
       (Algebra.ofId (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)).comp
         (Bialgebra.counitAlgHom (AlgebraicClosure k) Kbar) := by
     have h := restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)
       (e.inv ≫ q) (fK ≫ q) hrightComp hright
-    rw [show (FiniteTypeCommHopfAlgCat.toBialgHom
-      (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)).toAlgHom =
-        (Bialgebra.TensorProduct.includeRight (R := AlgebraicClosure k)
-          (H₁ := Hbar) (H₂ := Kbar)).toAlgHom from rfl,
-      Bialgebra.TensorProduct.includeRight_toAlgHom] at h
-    simpa only [g] using h
+    have hi : (FiniteTypeCommHopfAlgCat.toBialgHom
+        (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)).toAlgHom =
+        Algebra.TensorProduct.includeRight := by
+      apply AlgHom.ext
+      intro x
+      exact (FiniteTypeCommHopfAlgCat.includeRight_apply Hbar Kbar x).trans
+        (Algebra.TensorProduct.includeRight_apply x).symm
+    rw [hi] at h
+    apply AlgHom.ext
+    intro x
+    simpa only [g] using DFunLike.congr_fun h x
   have hg : g = ε := by
     rw [← AffineGroup.Product.productMap_restrict g, hleftMap, hrightMap]
     apply Algebra.TensorProduct.ext'

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
@@ -33,8 +33,6 @@ retains normality and is valid in every characteristic.
 
 * J. S. Milne, *Algebraic Groups* (2017), Section 19.b.
 * T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
-
-This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap.
 -/
 
 public section
@@ -113,98 +111,6 @@ private theorem ker_projection_eq_augmentation
     himageSmoothUnipotent
   exact h
 
-private theorem injective_of_retraction
-    {H L : Type u} [CommRing H] [CommRing L]
-    [Bialgebra (AlgebraicClosure k) H] [Bialgebra (AlgebraicClosure k) L]
-    (i : H →ₐc[AlgebraicClosure k] L) (r : L →ₐc[AlgebraicClosure k] H)
-    (hri : r.comp i = BialgHom.id (AlgebraicClosure k) H) :
-    Function.Injective i := by
-  intro x y hxy
-  have := congrArg r hxy
-  simpa only [← BialgHom.comp_apply, hri, BialgHom.id_apply] using this
-
-private theorem injective_of_comp_iso
-    {H L M : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)}
-    (f : H ⟶ L) (e : L ≅ M) (g : H ⟶ M) (hfg : f ≫ e.hom = g)
-    (hg : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom g)) :
-    Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom f) := by
-  intro x y hxy
-  apply hg
-  rw [← hfg]
-  simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] using
-    congrArg (FiniteTypeCommHopfAlgCat.toBialgHom e.hom) hxy
-
-private theorem baseChangeMap_includeLeft_injective
-    (H K : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom
-      (FiniteTypeCommHopfAlgCat.baseChangeMap (K := AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.includeLeft H K))) := by
-  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
-  let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
-  let e := FiniteTypeCommHopfAlgCat.baseChangeTensorProductIso (AlgebraicClosure k) H K
-  apply injective_of_comp_iso _ e (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)
-    (FiniteTypeCommHopfAlgCat.baseChangeMap_includeLeft_comp_baseChangeTensorProductIso_hom
-      (AlgebraicClosure k) H K)
-  exact injective_of_retraction
-    (Bialgebra.TensorProduct.includeLeft
-      (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
-    (Bialgebra.TensorProduct.projectLeft
-      (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
-    Bialgebra.TensorProduct.projectLeft_comp_includeLeft
-
-private theorem baseChangeMap_includeRight_injective
-    (H K : FiniteTypeCommHopfAlgCat.{u, u} k) :
-    Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom
-      (FiniteTypeCommHopfAlgCat.baseChangeMap (K := AlgebraicClosure k)
-        (FiniteTypeCommHopfAlgCat.includeRight H K))) := by
-  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
-  let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
-  let e := FiniteTypeCommHopfAlgCat.baseChangeTensorProductIso (AlgebraicClosure k) H K
-  apply injective_of_comp_iso _ e (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)
-    (FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom
-      (AlgebraicClosure k) H K)
-  exact injective_of_retraction
-    (Bialgebra.TensorProduct.includeRight
-      (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
-    (Bialgebra.TensorProduct.projectRight
-      (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
-    Bialgebra.TensorProduct.projectRight_comp_includeRight
-
-private theorem includeLeft_toAlgHom
-    (H K : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)) :
-    (FiniteTypeCommHopfAlgCat.toBialgHom
-      (FiniteTypeCommHopfAlgCat.includeLeft H K)).toAlgHom =
-        Algebra.TensorProduct.includeLeft := by
-  apply AlgHom.ext
-  exact FiniteTypeCommHopfAlgCat.includeLeft_apply H K
-
-private theorem includeRight_toAlgHom
-    (H K : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)) :
-    (FiniteTypeCommHopfAlgCat.toBialgHom
-      (FiniteTypeCommHopfAlgCat.includeRight H K)).toAlgHom =
-        Algebra.TensorProduct.includeRight := by
-  apply AlgHom.ext
-  exact FiniteTypeCommHopfAlgCat.includeRight_apply H K
-
-private theorem map_eq_counit_of_ker_eq_augmentation
-    {H L : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)}
-    (f : H ⟶ L)
-    (hf : HopfIdeal.ker (FiniteTypeCommHopfAlgCat.toBialgHom f) =
-      HopfIdeal.augmentation (AlgebraicClosure k) H) (x : H) :
-    FiniteTypeCommHopfAlgCat.toBialgHom f x =
-      algebraMap (AlgebraicClosure k) L (Coalgebra.counit x) := by
-  have hmem : x - algebraMap (AlgebraicClosure k) H (Coalgebra.counit x) ∈
-      HopfIdeal.augmentation (AlgebraicClosure k) H := by
-    rw [HopfIdeal.mem_augmentation]
-    simp
-  have hzero : FiniteTypeCommHopfAlgCat.toBialgHom f
-      (x - algebraMap (AlgebraicClosure k) H (Coalgebra.counit x)) = 0 := by
-    rw [← HopfIdeal.mem_ker, hf]
-    exact hmem
-  rw [map_sub, sub_eq_zero] at hzero
-  rw [hzero]
-  exact (FiniteTypeCommHopfAlgCat.toBialgHom f).toAlgHom.commutes (Coalgebra.counit x)
-
 private theorem restriction_eq_counit
     {H L M : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)}
     (i : H ⟶ L) (g : L ⟶ M) (f : H ⟶ M) (hcomp : i ≫ g = f)
@@ -218,7 +124,8 @@ private theorem restriction_eq_counit
   intro x
   have h := congrArg (fun φ : H ⟶ M ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ x) hcomp
   rw [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] at h
-  exact h.trans (map_eq_counit_of_ker_eq_augmentation f hf x)
+  exact h.trans (HopfIdeal.apply_eq_counit_of_ker_eq_augmentation
+    (FiniteTypeCommHopfAlgCat.toBialgHom f) hf x)
 
 /-- **A direct product of reductive finite-type affine groups is reductive.** -/
 theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
@@ -253,9 +160,11 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
     (FiniteTypeCommHopfAlgCat.includeRight H K)
   -- Project the candidate unipotent subgroup to each factor.
   have hfH : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom fH) := by
-    simpa only [fH] using baseChangeMap_includeLeft_injective H K
+    simpa only [fH] using FiniteTypeCommHopfAlgCat.baseChangeMap_includeLeft_injective
+      (K := AlgebraicClosure k) H K
   have hfK : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom fK) := by
-    simpa only [fK] using baseChangeMap_includeRight_injective H K
+    simpa only [fK] using FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_injective
+      (K := AlgebraicClosure k) H K
   have hleft : HopfIdeal.ker
       (FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q)) =
         HopfIdeal.augmentation (AlgebraicClosure k) Hbar := by
@@ -280,17 +189,25 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
   have hleftMap : g.comp Algebra.TensorProduct.includeLeft =
       (Algebra.ofId (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)).comp
         (Bialgebra.counitAlgHom (AlgebraicClosure k) Hbar) := by
-    rw [← includeLeft_toAlgHom]
-    simpa only [g] using
-      restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)
-        (e.inv ≫ q) (fH ≫ q) hleftComp hleft
+    have h := restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)
+      (e.inv ≫ q) (fH ≫ q) hleftComp hleft
+    rw [show (FiniteTypeCommHopfAlgCat.toBialgHom
+      (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)).toAlgHom =
+        (Bialgebra.TensorProduct.includeLeft (R := AlgebraicClosure k)
+          (H₁ := Hbar) (H₂ := Kbar)).toAlgHom from rfl,
+      Bialgebra.TensorProduct.includeLeft_toAlgHom] at h
+    simpa only [g] using h
   have hrightMap : g.comp Algebra.TensorProduct.includeRight =
       (Algebra.ofId (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)).comp
         (Bialgebra.counitAlgHom (AlgebraicClosure k) Kbar) := by
-    rw [← includeRight_toAlgHom]
-    simpa only [g] using
-      restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)
-        (e.inv ≫ q) (fK ≫ q) hrightComp hright
+    have h := restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)
+      (e.inv ≫ q) (fK ≫ q) hrightComp hright
+    rw [show (FiniteTypeCommHopfAlgCat.toBialgHom
+      (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)).toAlgHom =
+        (Bialgebra.TensorProduct.includeRight (R := AlgebraicClosure k)
+          (H₁ := Hbar) (H₂ := Kbar)).toAlgHom from rfl,
+      Bialgebra.TensorProduct.includeRight_toAlgHom] at h
+    simpa only [g] using h
   have hg : g = ε := by
     rw [← AffineGroup.Product.productMap_restrict g, hleftMap, hrightMap]
     apply Algebra.TensorProduct.ext'

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
@@ -1,0 +1,317 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.Product
+public import TauCeti.Algebra.AlgebraicGroup.FiniteType.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Image
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Smooth
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Image.Unipotent
+public import TauCeti.Algebra.AlgebraicGroup.Reductive.Basic
+
+/-!
+# Products of reductive affine groups
+
+The direct product of two reductive affine groups over a field is reductive. After extending
+scalars to an algebraic closure, a connected normal smooth unipotent subgroup of the product maps
+to such a subgroup of each factor. Reductivity makes both projection images trivial. Since the
+two coordinate inclusions generate the tensor-product coordinate algebra, the original subgroup
+is trivial as well.
+
+The proof uses scheme-theoretic images rather than only algebraic-closure-valued points. This
+retains normality and is valid in every characteristic.
+
+## Main declaration
+
+* `TauCeti.reductiveCommHopfAlgProperty.tensorProduct`: direct products of reductive finite-type
+  affine groups are reductive.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Section 19.b.
+* T. A. Springer, *Linear Algebraic Groups*, Chapter 8.
+
+This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace reductiveCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+
+private theorem ker_projection_eq_augmentation
+    {H : FiniteTypeCommHopfAlgCat.{u, u} k}
+    (hH : reductiveCommHopfAlgProperty k H)
+    {P : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)}
+    (f : FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H ⟶ P)
+    (hf : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom f))
+    (I : HopfIdeal (AlgebraicClosure k) P)
+    (hI : I.IsNormal)
+    (hconnected : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient P I).obj)
+    (hunipotent : smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient P I)) :
+    HopfIdeal.ker
+        (FiniteTypeCommHopfAlgCat.toBialgHom
+          (f ≫ FiniteTypeCommHopfAlgCat.mkQuotient P I)) =
+      HopfIdeal.augmentation (AlgebraicClosure k)
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H) := by
+  let g :
+      (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H).obj ⟶
+        (FiniteTypeCommHopfAlgCat.quotient P I).obj :=
+    f.hom ≫ (FiniteTypeCommHopfAlgCat.mkQuotient P I).hom
+  have hker : HopfIdeal.ker g.hom =
+      I.comap (FiniteTypeCommHopfAlgCat.toBialgHom f) := by
+    ext x
+    rw [HopfIdeal.mem_ker, HopfIdeal.mem_comap]
+    change (FiniteTypeCommHopfAlgCat.mkQuotient P I).hom.hom
+        (FiniteTypeCommHopfAlgCat.toBialgHom f x) = 0 ↔ _
+    exact FiniteTypeCommHopfAlgCat.mkQuotient_eq_zero_iff P I _
+  have hnormal : (HopfIdeal.ker g.hom).IsNormal := by
+    rw [hker]
+    exact hI.comap_of_injective _ hf
+  have himageConnected : geometricallyConnectedCommHopfAlgProperty (AlgebraicClosure k)
+      (CommHopfAlgCat.image g) :=
+    geometricallyConnectedCommHopfAlgProperty.image g hconnected
+  have hsource := (smoothUnipotentCommHopfAlgProperty_iff _ _).mp hunipotent
+  have hsmooth : smoothCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient P I).obj :=
+    (smoothCommHopfAlgProperty_iff _).mpr hsource.1
+  let _ : Algebra.Smooth (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P I) :=
+    hsource.1
+  let _ : IsReduced (FiniteTypeCommHopfAlgCat.quotient P I) :=
+    isReduced_of_smooth_of_field (AlgebraicClosure k) _
+  have himageUnipotent : geometricallyUnipotentPointsCommHopfAlgProperty (AlgebraicClosure k)
+      (CommHopfAlgCat.image g) :=
+    geometricallyUnipotentPointsCommHopfAlgProperty.image_of_reduced g
+      ((geometricallyUnipotentPointsCommHopfAlgProperty_iff _ _).mpr hsource.2)
+  have himageSmooth : smoothCommHopfAlgProperty (AlgebraicClosure k)
+      (CommHopfAlgCat.image g) := smoothCommHopfAlgProperty.image g hsmooth
+  have himageSmoothUnipotent : smoothUnipotentCommHopfAlgProperty (AlgebraicClosure k)
+      (FiniteTypeCommHopfAlgCat.quotient
+        (FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H)
+        (HopfIdeal.ker g.hom)) := by
+    rw [smoothUnipotentCommHopfAlgProperty_iff]
+    exact ⟨(smoothCommHopfAlgProperty_iff _).mp himageSmooth,
+      (geometricallyUnipotentPointsCommHopfAlgProperty_iff _ _).mp himageUnipotent⟩
+  have h := hH.eq_augmentation (HopfIdeal.ker g.hom) hnormal himageConnected
+    himageSmoothUnipotent
+  exact h
+
+/-- **A direct product of reductive finite-type affine groups is reductive.** -/
+theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (hH : reductiveCommHopfAlgProperty k H)
+    (hK : reductiveCommHopfAlgProperty k K) :
+    reductiveCommHopfAlgProperty k (FiniteTypeCommHopfAlgCat.tensorProduct H K) := by
+  let Hbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) H
+  let Kbar := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k) K
+  let P₀ := FiniteTypeCommHopfAlgCat.baseChange (K := AlgebraicClosure k)
+    (FiniteTypeCommHopfAlgCat.tensorProduct H K)
+  let P := FiniteTypeCommHopfAlgCat.tensorProduct Hbar Kbar
+  let e : P₀ ≅ P :=
+    FiniteTypeCommHopfAlgCat.baseChangeTensorProductIso (AlgebraicClosure k) H K
+  have hsmooth : Algebra.Smooth k (FiniteTypeCommHopfAlgCat.tensorProduct H K) := by
+    let smoothH : Algebra.Smooth k H := hH.smooth
+    let smoothK : Algebra.Smooth k K := hK.smooth
+    let smoothOverH : Algebra.Smooth H (H ⊗[k] K) :=
+      @Algebra.Smooth.baseChange k _ K H _ _ _ _ smoothK
+    exact @Algebra.Smooth.comp k _ H (H ⊗[k] K) _ _ _ _ _ _ smoothH smoothOverH
+  have hconnected : geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.tensorProduct H K).obj :=
+    geometricallyConnectedCommHopfAlgProperty.tensorProduct H.obj K.obj
+      hH.geometricallyConnected hK.geometricallyConnected
+  rw [reductiveCommHopfAlgProperty_iff]
+  refine ⟨hsmooth, hconnected, ?_⟩
+  intro I hI hsourceConnected hU
+  let q := FiniteTypeCommHopfAlgCat.mkQuotient P₀ I
+  let fH := FiniteTypeCommHopfAlgCat.baseChangeMap (K := AlgebraicClosure k)
+    (FiniteTypeCommHopfAlgCat.includeLeft H K)
+  let fK := FiniteTypeCommHopfAlgCat.baseChangeMap (K := AlgebraicClosure k)
+    (FiniteTypeCommHopfAlgCat.includeRight H K)
+  have hfH : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom fH) := by
+    have heq : fH ≫ e.hom = FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar :=
+      FiniteTypeCommHopfAlgCat.baseChangeMap_includeLeft_comp_baseChangeTensorProductIso_hom
+        (AlgebraicClosure k) H K
+    have hincl : Function.Injective
+        (FiniteTypeCommHopfAlgCat.toBialgHom
+          (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)) := by
+      intro x y hxy
+      have hxy' : x ⊗ₜ[AlgebraicClosure k] (1 : Kbar) =
+          y ⊗ₜ[AlgebraicClosure k] (1 : Kbar) := by
+        rw [FiniteTypeCommHopfAlgCat.includeLeft_apply Hbar Kbar x,
+          FiniteTypeCommHopfAlgCat.includeLeft_apply Hbar Kbar y] at hxy
+        exact hxy
+      have hmap := congrArg
+        (Bialgebra.TensorProduct.projectLeft
+          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar)) hxy'
+      simpa using hmap
+    intro x y hxy
+    apply hincl
+    rw [← heq]
+    simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] using
+      congrArg (FiniteTypeCommHopfAlgCat.toBialgHom e.hom) hxy
+  have hfK : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom fK) := by
+    have heq : fK ≫ e.hom = FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar :=
+      FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom
+        (AlgebraicClosure k) H K
+    have hincl : Function.Injective
+        (FiniteTypeCommHopfAlgCat.toBialgHom
+          (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)) := by
+      intro x y hxy
+      have hxy' : (1 : Hbar) ⊗ₜ[AlgebraicClosure k] x =
+          (1 : Hbar) ⊗ₜ[AlgebraicClosure k] y := by
+        rw [FiniteTypeCommHopfAlgCat.includeRight_apply Hbar Kbar x,
+          FiniteTypeCommHopfAlgCat.includeRight_apply Hbar Kbar y] at hxy
+        exact hxy
+      have hmap := congrArg
+        (Bialgebra.TensorProduct.projectRight
+          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar)) hxy'
+      simpa using hmap
+    intro x y hxy
+    apply hincl
+    rw [← heq]
+    simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] using
+      congrArg (FiniteTypeCommHopfAlgCat.toBialgHom e.hom) hxy
+  have hleft : HopfIdeal.ker
+      (FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q)) =
+        HopfIdeal.augmentation (AlgebraicClosure k) Hbar := by
+    exact ker_projection_eq_augmentation hH fH hfH I hI hsourceConnected hU
+  have hright : HopfIdeal.ker
+      (FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q)) =
+        HopfIdeal.augmentation (AlgebraicClosure k) Kbar := by
+    exact ker_projection_eq_augmentation hK fK hfK I hI hsourceConnected hU
+  have hq' (x : P) :
+      FiniteTypeCommHopfAlgCat.toBialgHom (e.inv ≫ q) x =
+        algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
+          (Coalgebra.counit x) := by
+    dsimp only [P] at x ⊢
+    refine TensorProduct.induction_on x (by simp) (fun h l ↦ ?_) (fun x y hx hy ↦ ?_)
+    · have hleftMap :
+        FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q) h =
+          algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
+            (Coalgebra.counit h) := by
+        have hmem : h - algebraMap (AlgebraicClosure k) Hbar (Coalgebra.counit h) ∈
+            HopfIdeal.augmentation (AlgebraicClosure k) Hbar := by
+          rw [HopfIdeal.mem_augmentation]
+          simp
+        have hzero : FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q)
+            (h - algebraMap (AlgebraicClosure k) Hbar (Coalgebra.counit h)) = 0 := by
+          rw [← HopfIdeal.mem_ker, hleft]
+          exact hmem
+        rw [map_sub] at hzero
+        rw [sub_eq_zero] at hzero
+        rw [hzero]
+        exact (FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q)).toAlgHom.commutes
+          (Coalgebra.counit h)
+      have hrightMap :
+        FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q) l =
+          algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
+            (Coalgebra.counit l) := by
+        have hmem : l - algebraMap (AlgebraicClosure k) Kbar (Coalgebra.counit l) ∈
+            HopfIdeal.augmentation (AlgebraicClosure k) Kbar := by
+          rw [HopfIdeal.mem_augmentation]
+          simp
+        have hzero : FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q)
+            (l - algebraMap (AlgebraicClosure k) Kbar (Coalgebra.counit l)) = 0 := by
+          rw [← HopfIdeal.mem_ker, hright]
+          exact hmem
+        rw [map_sub] at hzero
+        rw [sub_eq_zero] at hzero
+        rw [hzero]
+        exact (FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q)).toAlgHom.commutes
+          (Coalgebra.counit l)
+      have hleftComp := congrArg
+        (fun φ ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ h)
+        (FiniteTypeCommHopfAlgCat.baseChangeMap_includeLeft_comp_baseChangeTensorProductIso_hom
+          (AlgebraicClosure k) H K)
+      have hrightComp := congrArg
+        (fun φ ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ l)
+        (FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom
+          (AlgebraicClosure k) H K)
+      rw [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply,
+        FiniteTypeCommHopfAlgCat.includeLeft_apply] at hleftComp
+      rw [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply,
+        FiniteTypeCommHopfAlgCat.includeRight_apply] at hrightComp
+      have hinvLeft : FiniteTypeCommHopfAlgCat.toBialgHom e.inv
+          (h ⊗ₜ[AlgebraicClosure k] (1 : Kbar)) =
+          FiniteTypeCommHopfAlgCat.toBialgHom fH h := by
+        apply (ConcreteCategory.bijective_of_isIso e.hom).1
+        change FiniteTypeCommHopfAlgCat.toBialgHom e.hom
+            (FiniteTypeCommHopfAlgCat.toBialgHom e.inv
+              (h ⊗ₜ[AlgebraicClosure k] (1 : Kbar))) =
+          FiniteTypeCommHopfAlgCat.toBialgHom e.hom
+            (FiniteTypeCommHopfAlgCat.toBialgHom fH h)
+        rw [hleftComp]
+        have hid := congrArg
+          (fun φ ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ
+            (h ⊗ₜ[AlgebraicClosure k] (1 : Kbar))) e.inv_hom_id
+        simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply,
+          FiniteTypeCommHopfAlgCat.toBialgHom_id, BialgHom.coe_id, id_eq] using hid
+      have hinvRight : FiniteTypeCommHopfAlgCat.toBialgHom e.inv
+          ((1 : Hbar) ⊗ₜ[AlgebraicClosure k] l) =
+          FiniteTypeCommHopfAlgCat.toBialgHom fK l := by
+        apply (ConcreteCategory.bijective_of_isIso e.hom).1
+        change FiniteTypeCommHopfAlgCat.toBialgHom e.hom
+            (FiniteTypeCommHopfAlgCat.toBialgHom e.inv
+              ((1 : Hbar) ⊗ₜ[AlgebraicClosure k] l)) =
+          FiniteTypeCommHopfAlgCat.toBialgHom e.hom
+            (FiniteTypeCommHopfAlgCat.toBialgHom fK l)
+        rw [hrightComp]
+        have hid := congrArg
+          (fun φ ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ
+            ((1 : Hbar) ⊗ₜ[AlgebraicClosure k] l)) e.inv_hom_id
+        simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply,
+          FiniteTypeCommHopfAlgCat.toBialgHom_id, BialgHom.coe_id, id_eq] using hid
+      calc
+        FiniteTypeCommHopfAlgCat.toBialgHom (e.inv ≫ q)
+            (h ⊗ₜ[AlgebraicClosure k] l) =
+            FiniteTypeCommHopfAlgCat.toBialgHom (e.inv ≫ q)
+              ((h ⊗ₜ[AlgebraicClosure k] (1 : Kbar)) *
+                ((1 : Hbar) ⊗ₜ[AlgebraicClosure k] l)) := by simp
+        _ = FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q) h *
+            FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q) l := by
+          simp only [map_mul, FiniteTypeCommHopfAlgCat.toBialgHom_comp,
+            BialgHom.comp_apply, hinvLeft, hinvRight]
+        _ = _ := by rw [hleftMap, hrightMap, mul_comm]; simp
+    · simp only [map_add, hx, hy]
+  have hq (x : P₀) :
+      FiniteTypeCommHopfAlgCat.toBialgHom q x =
+        algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
+          (Coalgebra.counit x) := by
+    have h := hq' (FiniteTypeCommHopfAlgCat.toBialgHom e.hom x)
+    rw [← e.hom_inv_id_assoc q]
+    simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply,
+      CoalgHomClass.counit_comp_apply] using h
+  apply SetLike.ext
+  intro x
+  rw [HopfIdeal.mem_augmentation]
+  change x ∈ I.toIdeal ↔ _
+  rw [← FiniteTypeCommHopfAlgCat.mkQuotient_eq_zero_iff P₀ I]
+  rw [hq]
+  constructor
+  · intro hx
+    have h := congrArg
+      (Coalgebra.counit (R := AlgebraicClosure k)
+        (A := FiniteTypeCommHopfAlgCat.quotient P₀ I)) hx
+    simpa using h
+  · intro hx
+    simp [hx]
+
+end reductiveCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
@@ -77,6 +77,8 @@ private theorem ker_projection_eq_augmentation
       I.comap (FiniteTypeCommHopfAlgCat.toBialgHom f) := by
     ext x
     rw [HopfIdeal.mem_ker, HopfIdeal.mem_comap]
+    -- Unfold the categorical composite just enough to expose the underlying quotient map;
+    -- `mkQuotient_eq_zero_iff` is stated for this concrete map rather than its wrappers.
     change (FiniteTypeCommHopfAlgCat.mkQuotient P I).hom.hom
         (FiniteTypeCommHopfAlgCat.toBialgHom f x) = 0 ↔ _
     exact FiniteTypeCommHopfAlgCat.mkQuotient_eq_zero_iff P I _
@@ -110,6 +112,61 @@ private theorem ker_projection_eq_augmentation
   have h := hH.eq_augmentation (HopfIdeal.ker g.hom) hnormal himageConnected
     himageSmoothUnipotent
   exact h
+
+private theorem injective_of_retraction
+    {H L : Type u} [CommRing H] [CommRing L]
+    [Bialgebra (AlgebraicClosure k) H] [Bialgebra (AlgebraicClosure k) L]
+    (i : H →ₐc[AlgebraicClosure k] L) (r : L →ₐc[AlgebraicClosure k] H)
+    (hri : r.comp i = BialgHom.id (AlgebraicClosure k) H) :
+    Function.Injective i := by
+  intro x y hxy
+  have := congrArg r hxy
+  simpa only [← BialgHom.comp_apply, hri, BialgHom.id_apply] using this
+
+private theorem injective_of_comp_iso
+    {H L M : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)}
+    (f : H ⟶ L) (e : L ≅ M) (g : H ⟶ M) (hfg : f ≫ e.hom = g)
+    (hg : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom g)) :
+    Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom f) := by
+  intro x y hxy
+  apply hg
+  rw [← hfg]
+  simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] using
+    congrArg (FiniteTypeCommHopfAlgCat.toBialgHom e.hom) hxy
+
+private theorem map_eq_counit_of_ker_eq_augmentation
+    {H L : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)}
+    (f : H ⟶ L)
+    (hf : HopfIdeal.ker (FiniteTypeCommHopfAlgCat.toBialgHom f) =
+      HopfIdeal.augmentation (AlgebraicClosure k) H) (x : H) :
+    FiniteTypeCommHopfAlgCat.toBialgHom f x =
+      algebraMap (AlgebraicClosure k) L (Coalgebra.counit x) := by
+  have hmem : x - algebraMap (AlgebraicClosure k) H (Coalgebra.counit x) ∈
+      HopfIdeal.augmentation (AlgebraicClosure k) H := by
+    rw [HopfIdeal.mem_augmentation]
+    simp
+  have hzero : FiniteTypeCommHopfAlgCat.toBialgHom f
+      (x - algebraMap (AlgebraicClosure k) H (Coalgebra.counit x)) = 0 := by
+    rw [← HopfIdeal.mem_ker, hf]
+    exact hmem
+  rw [map_sub, sub_eq_zero] at hzero
+  rw [hzero]
+  exact (FiniteTypeCommHopfAlgCat.toBialgHom f).toAlgHom.commutes (Coalgebra.counit x)
+
+private theorem restriction_eq_counit
+    {H L M : FiniteTypeCommHopfAlgCat.{u, u} (AlgebraicClosure k)}
+    (i : H ⟶ L) (g : L ⟶ M) (f : H ⟶ M) (hcomp : i ≫ g = f)
+    (hf : HopfIdeal.ker (FiniteTypeCommHopfAlgCat.toBialgHom f) =
+      HopfIdeal.augmentation (AlgebraicClosure k) H) :
+    (FiniteTypeCommHopfAlgCat.toBialgHom g).toAlgHom.comp
+        (FiniteTypeCommHopfAlgCat.toBialgHom i).toAlgHom =
+      (Algebra.ofId (AlgebraicClosure k) M).comp
+        (Bialgebra.counitAlgHom (AlgebraicClosure k) H) := by
+  apply AlgHom.ext
+  intro x
+  have h := congrArg (fun φ : H ⟶ M ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ x) hcomp
+  rw [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] at h
+  exact h.trans (map_eq_counit_of_ker_eq_augmentation f hf x)
 
 /-- **A direct product of reductive finite-type affine groups is reductive.** -/
 theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
@@ -147,44 +204,30 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
         (AlgebraicClosure k) H K
     have hincl : Function.Injective
         (FiniteTypeCommHopfAlgCat.toBialgHom
-          (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)) := by
-      intro x y hxy
-      have hxy' : x ⊗ₜ[AlgebraicClosure k] (1 : Kbar) =
-          y ⊗ₜ[AlgebraicClosure k] (1 : Kbar) := by
-        rw [FiniteTypeCommHopfAlgCat.includeLeft_apply Hbar Kbar x,
-          FiniteTypeCommHopfAlgCat.includeLeft_apply Hbar Kbar y] at hxy
-        exact hxy
-      have hmap := congrArg
+          (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)) :=
+      injective_of_retraction
+        (Bialgebra.TensorProduct.includeLeft
+          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
         (Bialgebra.TensorProduct.projectLeft
-          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar)) hxy'
-      simpa using hmap
-    intro x y hxy
-    apply hincl
-    rw [← heq]
-    simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] using
-      congrArg (FiniteTypeCommHopfAlgCat.toBialgHom e.hom) hxy
+          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
+        Bialgebra.TensorProduct.projectLeft_comp_includeLeft
+    exact injective_of_comp_iso fH e
+      (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar) heq hincl
   have hfK : Function.Injective (FiniteTypeCommHopfAlgCat.toBialgHom fK) := by
     have heq : fK ≫ e.hom = FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar :=
       FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom
         (AlgebraicClosure k) H K
     have hincl : Function.Injective
         (FiniteTypeCommHopfAlgCat.toBialgHom
-          (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)) := by
-      intro x y hxy
-      have hxy' : (1 : Hbar) ⊗ₜ[AlgebraicClosure k] x =
-          (1 : Hbar) ⊗ₜ[AlgebraicClosure k] y := by
-        rw [FiniteTypeCommHopfAlgCat.includeRight_apply Hbar Kbar x,
-          FiniteTypeCommHopfAlgCat.includeRight_apply Hbar Kbar y] at hxy
-        exact hxy
-      have hmap := congrArg
+          (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)) :=
+      injective_of_retraction
+        (Bialgebra.TensorProduct.includeRight
+          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
         (Bialgebra.TensorProduct.projectRight
-          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar)) hxy'
-      simpa using hmap
-    intro x y hxy
-    apply hincl
-    rw [← heq]
-    simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] using
-      congrArg (FiniteTypeCommHopfAlgCat.toBialgHom e.hom) hxy
+          (R := AlgebraicClosure k) (H₁ := Hbar) (H₂ := Kbar))
+        Bialgebra.TensorProduct.projectRight_comp_includeRight
+    exact injective_of_comp_iso fK e
+      (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar) heq hincl
   have hleft : HopfIdeal.ker
       (FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q)) =
         HopfIdeal.augmentation (AlgebraicClosure k) Hbar := by
@@ -193,100 +236,67 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
       (FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q)) =
         HopfIdeal.augmentation (AlgebraicClosure k) Kbar := by
     exact ker_projection_eq_augmentation hK fK hfK I hI hsourceConnected hU
+  let g : P →ₐ[AlgebraicClosure k] (FiniteTypeCommHopfAlgCat.quotient P₀ I) :=
+    (FiniteTypeCommHopfAlgCat.toBialgHom (e.inv ≫ q)).toAlgHom
+  let ε : P →ₐ[AlgebraicClosure k] (FiniteTypeCommHopfAlgCat.quotient P₀ I) :=
+    (Algebra.ofId (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)).comp
+      (Bialgebra.counitAlgHom (AlgebraicClosure k) P)
+  have hleftComp : FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar ≫ e.inv ≫ q = fH ≫ q := by
+    rw [← FiniteTypeCommHopfAlgCat.baseChangeMap_includeLeft_comp_baseChangeTensorProductIso_hom
+        (AlgebraicClosure k) H K, Category.assoc, e.hom_inv_id_assoc]
+  have hrightComp : FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar ≫ e.inv ≫ q = fK ≫ q := by
+    rw [← FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom
+        (AlgebraicClosure k) H K, Category.assoc, e.hom_inv_id_assoc]
+  have hleftMap : g.comp Algebra.TensorProduct.includeLeft =
+      (Algebra.ofId (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)).comp
+        (Bialgebra.counitAlgHom (AlgebraicClosure k) Hbar) := by
+    have hi : (FiniteTypeCommHopfAlgCat.toBialgHom
+        (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)).toAlgHom =
+        Algebra.TensorProduct.includeLeft := by
+      apply AlgHom.ext
+      intro h
+      exact FiniteTypeCommHopfAlgCat.includeLeft_apply Hbar Kbar h
+    rw [← hi]
+    simpa only [g] using
+      restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)
+        (e.inv ≫ q) (fH ≫ q) hleftComp hleft
+  have hrightMap : g.comp Algebra.TensorProduct.includeRight =
+      (Algebra.ofId (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)).comp
+        (Bialgebra.counitAlgHom (AlgebraicClosure k) Kbar) := by
+    have hi : (FiniteTypeCommHopfAlgCat.toBialgHom
+        (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)).toAlgHom =
+        Algebra.TensorProduct.includeRight := by
+      apply AlgHom.ext
+      intro l
+      exact FiniteTypeCommHopfAlgCat.includeRight_apply Hbar Kbar l
+    rw [← hi]
+    simpa only [g] using
+      restriction_eq_counit (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)
+        (e.inv ≫ q) (fK ≫ q) hrightComp hright
+  have hg : g = ε := by
+    rw [← AffineGroup.Product.productMap_restrict g, hleftMap, hrightMap]
+    apply Algebra.TensorProduct.ext'
+    intro h l
+    rw [Algebra.TensorProduct.productMap_apply_tmul]
+    change algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
+        (Coalgebra.counit h) *
+        algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
+          (Coalgebra.counit l) =
+      algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
+        (Coalgebra.counit (h ⊗ₜ[AlgebraicClosure k] l))
+    rw [← map_mul]
+    congr 1
+    have hcounit := DFunLike.congr_fun
+      (Bialgebra.TensorProduct.counitAlgHom_def (AlgebraicClosure k)
+        (AlgebraicClosure k) Hbar Kbar) (h ⊗ₜ[AlgebraicClosure k] l)
+    simpa only [Bialgebra.counitAlgHom_apply, AlgHom.comp_apply,
+      Algebra.TensorProduct.map_tmul, AlgEquiv.toAlgHom_apply, Algebra.TensorProduct.rid_tmul,
+      smul_eq_mul, mul_comm] using hcounit.symm
   have hq' (x : P) :
       FiniteTypeCommHopfAlgCat.toBialgHom (e.inv ≫ q) x =
         algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
           (Coalgebra.counit x) := by
-    dsimp only [P] at x ⊢
-    refine TensorProduct.induction_on x (by simp) (fun h l ↦ ?_) (fun x y hx hy ↦ ?_)
-    · have hleftMap :
-        FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q) h =
-          algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
-            (Coalgebra.counit h) := by
-        have hmem : h - algebraMap (AlgebraicClosure k) Hbar (Coalgebra.counit h) ∈
-            HopfIdeal.augmentation (AlgebraicClosure k) Hbar := by
-          rw [HopfIdeal.mem_augmentation]
-          simp
-        have hzero : FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q)
-            (h - algebraMap (AlgebraicClosure k) Hbar (Coalgebra.counit h)) = 0 := by
-          rw [← HopfIdeal.mem_ker, hleft]
-          exact hmem
-        rw [map_sub] at hzero
-        rw [sub_eq_zero] at hzero
-        rw [hzero]
-        exact (FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q)).toAlgHom.commutes
-          (Coalgebra.counit h)
-      have hrightMap :
-        FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q) l =
-          algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
-            (Coalgebra.counit l) := by
-        have hmem : l - algebraMap (AlgebraicClosure k) Kbar (Coalgebra.counit l) ∈
-            HopfIdeal.augmentation (AlgebraicClosure k) Kbar := by
-          rw [HopfIdeal.mem_augmentation]
-          simp
-        have hzero : FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q)
-            (l - algebraMap (AlgebraicClosure k) Kbar (Coalgebra.counit l)) = 0 := by
-          rw [← HopfIdeal.mem_ker, hright]
-          exact hmem
-        rw [map_sub] at hzero
-        rw [sub_eq_zero] at hzero
-        rw [hzero]
-        exact (FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q)).toAlgHom.commutes
-          (Coalgebra.counit l)
-      have hleftComp := congrArg
-        (fun φ ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ h)
-        (FiniteTypeCommHopfAlgCat.baseChangeMap_includeLeft_comp_baseChangeTensorProductIso_hom
-          (AlgebraicClosure k) H K)
-      have hrightComp := congrArg
-        (fun φ ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ l)
-        (FiniteTypeCommHopfAlgCat.baseChangeMap_includeRight_comp_baseChangeTensorProductIso_hom
-          (AlgebraicClosure k) H K)
-      rw [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply,
-        FiniteTypeCommHopfAlgCat.includeLeft_apply] at hleftComp
-      rw [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply,
-        FiniteTypeCommHopfAlgCat.includeRight_apply] at hrightComp
-      have hinvLeft : FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-          (h ⊗ₜ[AlgebraicClosure k] (1 : Kbar)) =
-          FiniteTypeCommHopfAlgCat.toBialgHom fH h := by
-        apply (ConcreteCategory.bijective_of_isIso e.hom).1
-        change FiniteTypeCommHopfAlgCat.toBialgHom e.hom
-            (FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-              (h ⊗ₜ[AlgebraicClosure k] (1 : Kbar))) =
-          FiniteTypeCommHopfAlgCat.toBialgHom e.hom
-            (FiniteTypeCommHopfAlgCat.toBialgHom fH h)
-        rw [hleftComp]
-        have hid := congrArg
-          (fun φ ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ
-            (h ⊗ₜ[AlgebraicClosure k] (1 : Kbar))) e.inv_hom_id
-        simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply,
-          FiniteTypeCommHopfAlgCat.toBialgHom_id, BialgHom.coe_id, id_eq] using hid
-      have hinvRight : FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-          ((1 : Hbar) ⊗ₜ[AlgebraicClosure k] l) =
-          FiniteTypeCommHopfAlgCat.toBialgHom fK l := by
-        apply (ConcreteCategory.bijective_of_isIso e.hom).1
-        change FiniteTypeCommHopfAlgCat.toBialgHom e.hom
-            (FiniteTypeCommHopfAlgCat.toBialgHom e.inv
-              ((1 : Hbar) ⊗ₜ[AlgebraicClosure k] l)) =
-          FiniteTypeCommHopfAlgCat.toBialgHom e.hom
-            (FiniteTypeCommHopfAlgCat.toBialgHom fK l)
-        rw [hrightComp]
-        have hid := congrArg
-          (fun φ ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ
-            ((1 : Hbar) ⊗ₜ[AlgebraicClosure k] l)) e.inv_hom_id
-        simpa only [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply,
-          FiniteTypeCommHopfAlgCat.toBialgHom_id, BialgHom.coe_id, id_eq] using hid
-      calc
-        FiniteTypeCommHopfAlgCat.toBialgHom (e.inv ≫ q)
-            (h ⊗ₜ[AlgebraicClosure k] l) =
-            FiniteTypeCommHopfAlgCat.toBialgHom (e.inv ≫ q)
-              ((h ⊗ₜ[AlgebraicClosure k] (1 : Kbar)) *
-                ((1 : Hbar) ⊗ₜ[AlgebraicClosure k] l)) := by simp
-        _ = FiniteTypeCommHopfAlgCat.toBialgHom (fH ≫ q) h *
-            FiniteTypeCommHopfAlgCat.toBialgHom (fK ≫ q) l := by
-          simp only [map_mul, FiniteTypeCommHopfAlgCat.toBialgHom_comp,
-            BialgHom.comp_apply, hinvLeft, hinvRight]
-        _ = _ := by rw [hleftMap, hrightMap, mul_comm]; simp
-    · simp only [map_add, hx, hy]
+    exact DFunLike.congr_fun hg x
   have hq (x : P₀) :
       FiniteTypeCommHopfAlgCat.toBialgHom q x =
         algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
@@ -199,10 +199,9 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
     have hi : (FiniteTypeCommHopfAlgCat.toBialgHom
         (FiniteTypeCommHopfAlgCat.includeLeft Hbar Kbar)).toAlgHom =
         Algebra.TensorProduct.includeLeft := by
-      apply AlgHom.ext
-      intro x
-      exact (FiniteTypeCommHopfAlgCat.includeLeft_apply Hbar Kbar x).trans
-        (Algebra.TensorProduct.includeLeft_apply x).symm
+      change (Bialgebra.TensorProduct.includeLeft (R := AlgebraicClosure k)
+        (H₁ := Hbar) (H₂ := Kbar)).toAlgHom = Algebra.TensorProduct.includeLeft
+      exact Bialgebra.TensorProduct.includeLeft_toAlgHom
     rw [hi] at h
     apply AlgHom.ext
     intro x
@@ -215,10 +214,9 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
     have hi : (FiniteTypeCommHopfAlgCat.toBialgHom
         (FiniteTypeCommHopfAlgCat.includeRight Hbar Kbar)).toAlgHom =
         Algebra.TensorProduct.includeRight := by
-      apply AlgHom.ext
-      intro x
-      exact (FiniteTypeCommHopfAlgCat.includeRight_apply Hbar Kbar x).trans
-        (Algebra.TensorProduct.includeRight_apply x).symm
+      change (Bialgebra.TensorProduct.includeRight (R := AlgebraicClosure k)
+        (H₁ := Hbar) (H₂ := Kbar)).toAlgHom = Algebra.TensorProduct.includeRight
+      exact Bialgebra.TensorProduct.includeRight_toAlgHom
     rw [hi] at h
     apply AlgHom.ext
     intro x

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
@@ -124,11 +124,12 @@ private theorem restriction_eq_counit
   intro x
   have h := congrArg (fun φ : H ⟶ M ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ x) hcomp
   rw [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] at h
-  exact h.trans (_root_.BialgHom.apply_eq_counit_of_ker_eq_augmentation
-    (FiniteTypeCommHopfAlgCat.toBialgHom f)
+  exact h.trans (_root_.AlgHom.apply_eq_counit_of_ker_eq_augmentation
+    (FiniteTypeCommHopfAlgCat.toBialgHom f).toAlgHom
       (by
         ext y
-        rw [RingHom.mem_ker, HopfIdeal.mem_toIdeal, ← hf, HopfIdeal.mem_ker])
+        rw [RingHom.mem_ker, HopfIdeal.mem_toIdeal, ← hf, HopfIdeal.mem_ker]
+        exact Iff.rfl)
       x)
 
 /-- **A direct product of reductive finite-type affine groups is reductive.** -/
@@ -227,20 +228,13 @@ theorem tensorProduct (H K : FiniteTypeCommHopfAlgCat.{u, u} k)
     apply Algebra.TensorProduct.ext'
     intro h l
     rw [Algebra.TensorProduct.productMap_apply_tmul]
-    -- Unfold both maps on a pure tensor: the product map multiplies the factor counits,
-    -- while `ε` uses the tensor-product counit.
-    change algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
-        (Coalgebra.counit h) *
-        algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
-          (Coalgebra.counit l) =
-      algebraMap (AlgebraicClosure k) (FiniteTypeCommHopfAlgCat.quotient P₀ I)
-        (Coalgebra.counit (h ⊗ₜ[AlgebraicClosure k] l))
+    simp only [ε, AlgHom.comp_apply, Algebra.ofId_apply, Bialgebra.counitAlgHom_apply]
     rw [← map_mul]
     congr 1
     have hcounit := DFunLike.congr_fun
       (Bialgebra.TensorProduct.counitAlgHom_def (AlgebraicClosure k)
         (AlgebraicClosure k) Hbar Kbar) (h ⊗ₜ[AlgebraicClosure k] l)
-    simpa only [Bialgebra.counitAlgHom_apply, AlgHom.comp_apply,
+    simpa only [P, Bialgebra.counitAlgHom_apply, AlgHom.comp_apply,
       Algebra.TensorProduct.map_tmul, AlgEquiv.toAlgHom_apply, Algebra.TensorProduct.rid_tmul,
       smul_eq_mul, mul_comm] using hcounit.symm
   have hq' (x : P) :

--- a/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Reductive/Product.lean
@@ -124,7 +124,7 @@ private theorem restriction_eq_counit
   intro x
   have h := congrArg (fun φ : H ⟶ M ↦ FiniteTypeCommHopfAlgCat.toBialgHom φ x) hcomp
   rw [FiniteTypeCommHopfAlgCat.toBialgHom_comp, BialgHom.comp_apply] at h
-  exact h.trans (TauCeti.BialgHom.apply_eq_counit_of_ker_eq_augmentation
+  exact h.trans (_root_.BialgHom.apply_eq_counit_of_ker_eq_augmentation
     (FiniteTypeCommHopfAlgCat.toBialgHom f)
       (by
         ext y

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -25,7 +25,7 @@ induced morphism of affine group schemes (`TauCeti.CommHopfAlgCat.kernelHopfIdea
 * `TauCeti.HopfIdeal.mem_augmentation` and `TauCeti.HopfIdeal.augmentation_toIdeal`:
   characteristic API.
 * `TauCeti.HopfIdeal.le_augmentation`: every Hopf ideal is contained in the augmentation ideal.
-* `TauCeti.HopfIdeal.apply_eq_counit_of_ker_eq_augmentation`: a morphism whose kernel is the
+* `TauCeti.BialgHom.apply_eq_counit_of_ker_eq_augmentation`: a morphism whose kernel is the
   augmentation ideal is evaluation by the counit, followed by the target's scalar map.
 * `TauCeti.HopfIdeal.comapOfSurjective_augmentation`: the augmentation ideal is preserved by
   pullback along a surjective bialgebra morphism.
@@ -71,22 +71,33 @@ theorem mem_augmentation {x : H} :
     x ∈ augmentation R H ↔ Coalgebra.counit (R := R) x = 0 :=
   mem_kerOfSurjective _ _
 
-/-- A bialgebra morphism over a field whose kernel is the augmentation ideal sends each element
-to its counit, viewed as a scalar in the target. -/
+end HopfIdeal
+
+namespace BialgHom
+
+/-- A bialgebra morphism whose kernel is the augmentation ideal sends each element to its
+counit, viewed as a scalar in the target. -/
 theorem apply_eq_counit_of_ker_eq_augmentation
     {k : Type u} {A : Type v} {B : Type w}
-    [Field k] [Ring A] [Ring B] [HopfAlgebra k A] [HopfAlgebra k B]
-    (f : A →ₐc[k] B) (hf : ker f = augmentation k A) (x : A) :
+    [CommRing k] [Ring A] [Ring B] [HopfAlgebra k A] [HopfAlgebra k B]
+    (f : A →ₐc[k] B)
+    (hf : RingHom.ker f = (HopfIdeal.augmentation k A).toIdeal) (x : A) :
     f x = algebraMap k B (Coalgebra.counit x) := by
-  have hmem : x - algebraMap k A (Coalgebra.counit x) ∈ augmentation k A := by
-    rw [mem_augmentation]
+  have hmem : x - algebraMap k A (Coalgebra.counit x) ∈ HopfIdeal.augmentation k A := by
+    rw [HopfIdeal.mem_augmentation]
     simp
   have hzero : f (x - algebraMap k A (Coalgebra.counit x)) = 0 := by
-    rw [← mem_ker, hf]
-    exact hmem
+    apply RingHom.mem_ker.mp
+    exact hf.symm ▸ hmem
   rw [map_sub, sub_eq_zero] at hzero
   rw [hzero]
   exact f.toAlgHom.commutes (Coalgebra.counit x)
+
+end BialgHom
+
+namespace HopfIdeal
+
+variable (R : Type u) (H : Type v) [CommRing R] [Ring H] [HopfAlgebra R H]
 
 /-- The underlying ideal of the augmentation Hopf ideal is the kernel of the counit
 algebra homomorphism. -/

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -25,6 +25,8 @@ induced morphism of affine group schemes (`TauCeti.CommHopfAlgCat.kernelHopfIdea
 * `TauCeti.HopfIdeal.mem_augmentation` and `TauCeti.HopfIdeal.augmentation_toIdeal`:
   characteristic API.
 * `TauCeti.HopfIdeal.le_augmentation`: every Hopf ideal is contained in the augmentation ideal.
+* `TauCeti.HopfIdeal.apply_eq_counit_of_ker_eq_augmentation`: a morphism whose kernel is the
+  augmentation ideal is evaluation by the counit, followed by the target's scalar map.
 * `TauCeti.HopfIdeal.comapOfSurjective_augmentation`: the augmentation ideal is preserved by
   pullback along a surjective bialgebra morphism.
 * `TauCeti.HopfIdeal.counitBialgEquivOfAugmentationEqBot`: a Hopf algebra with zero
@@ -68,6 +70,23 @@ theorem augmentation_def :
 theorem mem_augmentation {x : H} :
     x ∈ augmentation R H ↔ Coalgebra.counit (R := R) x = 0 :=
   mem_kerOfSurjective _ _
+
+/-- A bialgebra morphism over a field whose kernel is the augmentation ideal sends each element
+to its counit, viewed as a scalar in the target. -/
+theorem apply_eq_counit_of_ker_eq_augmentation
+    {k : Type u} {A : Type v} {B : Type w}
+    [Field k] [Ring A] [Ring B] [HopfAlgebra k A] [HopfAlgebra k B]
+    (f : A →ₐc[k] B) (hf : ker f = augmentation k A) (x : A) :
+    f x = algebraMap k B (Coalgebra.counit x) := by
+  have hmem : x - algebraMap k A (Coalgebra.counit x) ∈ augmentation k A := by
+    rw [mem_augmentation]
+    simp
+  have hzero : f (x - algebraMap k A (Coalgebra.counit x)) = 0 := by
+    rw [← mem_ker, hf]
+    exact hmem
+  rw [map_sub, sub_eq_zero] at hzero
+  rw [hzero]
+  exact f.toAlgHom.commutes (Coalgebra.counit x)
 
 /-- The underlying ideal of the augmentation Hopf ideal is the kernel of the counit
 algebra homomorphism. -/

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -25,7 +25,7 @@ induced morphism of affine group schemes (`TauCeti.CommHopfAlgCat.kernelHopfIdea
 * `TauCeti.HopfIdeal.mem_augmentation` and `TauCeti.HopfIdeal.augmentation_toIdeal`:
   characteristic API.
 * `TauCeti.HopfIdeal.le_augmentation`: every Hopf ideal is contained in the augmentation ideal.
-* `TauCeti.BialgHom.apply_eq_counit_of_ker_eq_augmentation`: a morphism whose kernel is the
+* `BialgHom.apply_eq_counit_of_ker_eq_augmentation`: a morphism whose kernel is the
   augmentation ideal is evaluation by the counit, followed by the target's scalar map.
 * `TauCeti.HopfIdeal.comapOfSurjective_augmentation`: the augmentation ideal is preserved by
   pullback along a surjective bialgebra morphism.
@@ -73,7 +73,11 @@ theorem mem_augmentation {x : H} :
 
 end HopfIdeal
 
+end TauCeti
+
 namespace BialgHom
+
+universe u v w
 
 /-- A bialgebra morphism whose kernel is the augmentation ideal sends each element to its
 counit, viewed as a scalar in the target. -/
@@ -81,10 +85,11 @@ theorem apply_eq_counit_of_ker_eq_augmentation
     {k : Type u} {A : Type v} {B : Type w}
     [CommRing k] [Ring A] [Ring B] [HopfAlgebra k A] [HopfAlgebra k B]
     (f : A →ₐc[k] B)
-    (hf : RingHom.ker f = (HopfIdeal.augmentation k A).toIdeal) (x : A) :
+    (hf : RingHom.ker f = (TauCeti.HopfIdeal.augmentation k A).toIdeal) (x : A) :
     f x = algebraMap k B (Coalgebra.counit x) := by
-  have hmem : x - algebraMap k A (Coalgebra.counit x) ∈ HopfIdeal.augmentation k A := by
-    rw [HopfIdeal.mem_augmentation]
+  have hmem : x - algebraMap k A (Coalgebra.counit x) ∈
+      TauCeti.HopfIdeal.augmentation k A := by
+    rw [TauCeti.HopfIdeal.mem_augmentation]
     simp
   have hzero : f (x - algebraMap k A (Coalgebra.counit x)) = 0 := by
     apply RingHom.mem_ker.mp
@@ -94,6 +99,8 @@ theorem apply_eq_counit_of_ker_eq_augmentation
   exact f.toAlgHom.commutes (Coalgebra.counit x)
 
 end BialgHom
+
+namespace TauCeti
 
 namespace HopfIdeal
 

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -25,7 +25,7 @@ induced morphism of affine group schemes (`TauCeti.CommHopfAlgCat.kernelHopfIdea
 * `TauCeti.HopfIdeal.mem_augmentation` and `TauCeti.HopfIdeal.augmentation_toIdeal`:
   characteristic API.
 * `TauCeti.HopfIdeal.le_augmentation`: every Hopf ideal is contained in the augmentation ideal.
-* `BialgHom.apply_eq_counit_of_ker_eq_augmentation`: a morphism whose kernel is the
+* `AlgHom.apply_eq_counit_of_ker_eq_augmentation`: an algebra morphism whose kernel is the
   augmentation ideal is evaluation by the counit, followed by the target's scalar map.
 * `TauCeti.HopfIdeal.comapOfSurjective_augmentation`: the augmentation ideal is preserved by
   pullback along a surjective bialgebra morphism.
@@ -75,16 +75,16 @@ end HopfIdeal
 
 end TauCeti
 
-namespace BialgHom
+namespace AlgHom
 
 universe u v w
 
-/-- A bialgebra morphism whose kernel is the augmentation ideal sends each element to its
+/-- An algebra morphism whose kernel is the augmentation ideal sends each element to its
 counit, viewed as a scalar in the target. -/
 theorem apply_eq_counit_of_ker_eq_augmentation
     {k : Type u} {A : Type v} {B : Type w}
-    [CommRing k] [Ring A] [Ring B] [HopfAlgebra k A] [HopfAlgebra k B]
-    (f : A →ₐc[k] B)
+    [CommRing k] [Ring A] [Ring B] [HopfAlgebra k A] [Algebra k B]
+    (f : A →ₐ[k] B)
     (hf : RingHom.ker f = (TauCeti.HopfIdeal.augmentation k A).toIdeal) (x : A) :
     f x = algebraMap k B (Coalgebra.counit x) := by
   have hmem : x - algebraMap k A (Coalgebra.counit x) ∈
@@ -96,9 +96,9 @@ theorem apply_eq_counit_of_ker_eq_augmentation
     exact hf.symm ▸ hmem
   rw [map_sub, sub_eq_zero] at hzero
   rw [hzero]
-  exact f.toAlgHom.commutes (Coalgebra.counit x)
+  exact f.commutes (Coalgebra.counit x)
 
-end BialgHom
+end AlgHom
 
 namespace TauCeti
 


### PR DESCRIPTION
This PR proves that the tensor product of two reductive finite-type commutative Hopf algebras is reductive, equivalently that direct products preserve reductivity. It advances the ReductiveGroups roadmap's Layer 6 milestone, "Reductive and semisimple groups," specifically the target to develop groups satisfying the geometric definition "smooth, connected, with `R_u(G_k̄)` trivial" and its structural theory.

The proof sends any connected normal smooth unipotent subgroup of the geometric product to its two scheme-theoretic projection images. The image theorems preserve connectedness, normality, smoothness, and unipotence, so reductivity of each factor makes both images trivial; tensor-product induction then shows the original subgroup is trivial. This consumes `FiniteTypeCommHopfAlgCat.baseChangeTensorProductIso` from #4904: its compatibility with the coordinate inclusions identifies the two geometric projection maps needed by the argument.

After this PR, Layer 6 still needs the remaining radical and centre structure, central isogenies and simply connected/adjoint forms, and the characteristic-zero equivalence with linear reductivity.

The module documents the standard mathematical references (Milne, Section 19.b, and Springer, Chapter 8) and adds no compatibility surface or vendored Mathlib declaration.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"reductive-direct-products"}-->

🤖 Prepared with Codex
