### PR TITLE
feat: the compact Frobenius-Schur indicator 1 as a real structure

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/FrobeniusSchur/RealStructure.lean
+++ b/TauCeti/RepresentationTheory/Compact/FrobeniusSchur/RealStructure.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Compact.FrobeniusSchur.InvariantForm
+public import TauCeti.RepresentationTheory.InvariantForm.RealStructure
+
+/-!
+# Frobenius-Schur indicator `1` is a real structure, for a compact group
+
+`TauCeti/RepresentationTheory/Compact/FrobeniusSchur/InvariantForm.lean` reads the three values of
+the Frobenius-Schur indicator of an irreducible unitary representation of a compact group off
+invariant bilinear forms, and stops there: an invariant *symmetric* form is strictly weaker than a
+real form, and none of its statements mentions a structure map.  This file supplies the missing
+step, in the operational shape the reality applications ask for:
+
+`ν₂(π) = 1` iff `π` carries a **structure map** -- a conjugate-linear involution `K` of `V`
+commuting with the action, `TauCeti.Representation.IsRealStructure` -- equivalently iff `π` is
+**realizable over `ℝ`**, that is, is the complexification of a real representation.
+
+Nothing new has to be integrated over the group.  The unitarity hypothesis the whole
+Frobenius-Schur layer already carries *is* a positive definite invariant Hermitian form, namely the
+inner product of `V` itself, and against a fixed such form a real structure and a nondegenerate
+invariant symmetric form are interchangeable data
+(`Representation.exists_isRealStructure_iff`, in
+`TauCeti/RepresentationTheory/InvariantForm/RealStructure.lean`).  So the compact-group criterion is
+the finite-group one of
+`TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Realizability.lean` with the summed
+invariant Hermitian form replaced by the inner product a unitary representation comes with; the
+Haar integral enters only through the invariant-form criterion this file rewrites.
+
+## Main statements
+
+* `ContRepresentation.frobeniusSchurIndicator_eq_one_iff_exists_isRealStructure`: **the indicator
+  is `1` exactly when the representation carries a real structure.**
+* `ContRepresentation.frobeniusSchurIndicator_eq_one_iff_isRealizableOverReal`: **the indicator is
+  `1` exactly when the representation is realizable over `ℝ`.**
+
+## Implementation notes
+
+The roadmap phrases the criterion with an unbundled structure map, a conjugate-linear
+`J : V →ₗ⋆[ℂ] V` with `J (J v) = v` commuting with the action.  That is exactly
+`TauCeti.Representation.IsRealStructure`, which
+`TauCeti/RepresentationTheory/RealForm.lean` already defines and equips with the passage to a real
+form, so the statements below are given in terms of the named predicate rather than its unfolding.
+
+## References
+
+This discharges the `frobeniusSchurIndicator_eq_one_iff_exists_structureMap` target of Layer 6b of
+the [compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
+whose invariant-form companions are proved in
+`TauCeti/RepresentationTheory/Compact/FrobeniusSchur/InvariantForm.lean`.
+
+* T. Bröcker, T. tom Dieck, *Representations of Compact Lie Groups*, Springer GTM 98 (1985),
+  Chapter II, §6.
+* Daniel Bump, *Lie Groups*, second edition, Chapter 2.
+-/
+
+public section
+
+open scoped ComplexOrder InnerProductSpace
+
+open TauCeti TauCeti.ContRepresentation
+
+namespace ContRepresentation
+
+/-! ### The inner product as an invariant Hermitian form -/
+
+section Inner
+
+variable {G V : Type*} [Monoid G] [NormedAddCommGroup V] [InnerProductSpace ℂ V]
+
+/-- **The inner product of a unitary representation is invariant.**  This is the whole of the
+Hermitian input the real-structure construction needs; unitarity supplies it with no averaging. -/
+private theorem isInvariantSesqForm_innerₛₗ {π : ContRepresentation ℂ G V} (hπ : IsUnitary π) :
+    Representation.IsInvariantSesqForm π.toRepresentation (innerₛₗ ℂ (E := V)) :=
+  Representation.isInvariantSesqForm_iff.mpr fun g x y => hπ.inner_map_map g x y
+
+/-- The inner product is Hermitian. -/
+private theorem isSymm_innerₛₗ : (innerₛₗ ℂ (E := V)).IsSymm where
+  eq x y := by simpa only [innerₛₗ_apply_apply] using inner_conj_symm (𝕜 := ℂ) y x
+
+/-- The inner product is nonnegative on the diagonal, in the complex order. -/
+private theorem isNonneg_innerₛₗ : (innerₛₗ ℂ (E := V)).IsNonneg where
+  nonneg x := by
+    have h : ⟪x, x⟫_ℂ = ((‖x‖ ^ 2 : ℝ) : ℂ) := by
+      rw [inner_self_eq_norm_sq_to_K]
+      norm_cast
+    rw [innerₛₗ_apply_apply, h]
+    exact Complex.zero_le_real.mpr (sq_nonneg _)
+
+/-- The inner product is definite off the origin. -/
+private theorem innerₛₗ_apply_self_ne_zero {x : V} (hx : x ≠ 0) : innerₛₗ ℂ x x ≠ 0 := by
+  simpa only [innerₛₗ_apply_apply] using inner_self_ne_zero.mpr hx
+
+end Inner
+
+/-! ### The criterion -/
+
+section CompactGroup
+
+variable {G V : Type*} [Group G] [TopologicalSpace G] [IsTopologicalGroup G]
+  [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace ℂ V] [FiniteDimensional ℂ V]
+
+variable (π : ContRepresentation ℂ G V) (hπ : Continuous π)
+
+include hπ
+
+/-- **The indicator is `1` exactly when there is a real structure**: an irreducible unitary
+representation of a compact group has Frobenius-Schur indicator `1` exactly when it carries a
+conjugate-linear involution of `V` commuting with the action.
+
+The invariant-form criterion supplies a nondegenerate invariant symmetric form, and the inner
+product of the unitary representation supplies the positive definite invariant Hermitian form that
+turns one datum into the other. -/
+theorem frobeniusSchurIndicator_eq_one_iff_exists_isRealStructure (hunitary : IsUnitary π)
+    (hirr : Representation.IsIrreducible π.toRepresentation) :
+    frobeniusSchurIndicator π hπ = 1 ↔
+      ∃ K : V →ₛₗ[starRingEnd ℂ] V, Representation.IsRealStructure π.toRepresentation K := by
+  have := hirr
+  rw [frobeniusSchurIndicator_eq_one_iff π hπ hunitary hirr]
+  exact (Representation.exists_isRealStructure_iff (isInvariantSesqForm_innerₛₗ hunitary)
+    isSymm_innerₛₗ isNonneg_innerₛₗ fun _ hx => innerₛₗ_apply_self_ne_zero hx).symm
+
+/-- **The indicator is `1` exactly when the representation is realizable over `ℝ`**: the
+Frobenius-Schur criterion for a compact group in its realizability form, the compact mirror of
+`TauCeti.Representation.frobeniusSchurIndicator_eq_one_iff_isRealizableOverReal` for a finite
+group.  The real form is the fixed space of the structure map. -/
+theorem frobeniusSchurIndicator_eq_one_iff_isRealizableOverReal (hunitary : IsUnitary π)
+    (hirr : Representation.IsIrreducible π.toRepresentation) :
+    frobeniusSchurIndicator π hπ = 1 ↔
+      Representation.IsRealizableOverReal π.toRepresentation := by
+  rw [frobeniusSchurIndicator_eq_one_iff_exists_isRealStructure π hπ hunitary hirr,
+    Representation.isRealizableOverReal_iff_exists_isRealStructure]
+
+end CompactGroup
+
+end ContRepresentation

--- a/TauCeti/RepresentationTheory/InvariantForm/RealStructure.lean
+++ b/TauCeti/RepresentationTheory/InvariantForm/RealStructure.lean
@@ -11,12 +11,13 @@ public import TauCeti.RepresentationTheory.InvariantForm.Hermitian
 public import TauCeti.RepresentationTheory.RealForm
 
 /-!
-# A real structure out of an invariant symmetric form and an invariant Hermitian form
+# Real structures and invariant symmetric forms, against a fixed invariant Hermitian form
 
 An invariant *symmetric bilinear* form `B` on an irreducible complex representation is strictly
 weaker than a real form.  Together with a positive definite invariant *Hermitian* form `H`,
 however, it produces one: this file builds a `Representation.IsRealStructure` -- a conjugate-linear
-involution of `V` commuting with the action -- out of the two forms.
+involution of `V` commuting with the action -- out of the two forms, and goes back again, so that
+against a fixed `H` the two data are interchangeable.
 
 Comparing the two forms produces a conjugate-linear map `J` of `V` determined by
 `H (J x) y = B x y`.  It exists because `H`, read as a map `V → V*`, is injective by definiteness
@@ -37,18 +38,41 @@ Hermitian form is where finiteness enters, in
 `TauCeti/RepresentationTheory/InvariantForm/Hermitian.lean`, and the Frobenius-Schur criterion this
 feeds is in `TauCeti/RepresentationTheory/CharacterTable/FrobeniusSchur/Realizability.lean`.
 
+The **converse** passage, from a real structure `K` back to an invariant symmetric form, is the
+second half of the file, and it needs neither irreducibility nor finite dimensionality.  The naive
+guess `B x y = H (K x) y` is bilinear, invariant and nondegenerate for free, but it is symmetric
+only if `H` is compatible with `K` in the sense `H (K x) (K y) = conj (H x y)`, which an arbitrary
+invariant `H` need not be.  Replacing `H` by the **balanced** form
+`H x y + conj (H (K x) (K y))` -- still invariant, Hermitian and positive definite, since `K` is
+bijective -- makes it compatible, and then `B x y = H (K x) y` is symmetric.  Against a fixed `H`
+the two directions assemble into `Representation.exists_isRealStructure_iff`, which is what turns
+the Frobenius-Schur value `1` into realizability over `ℝ` whenever a positive definite invariant
+Hermitian form is available -- by Haar averaging for a compact group as much as by summation for a
+finite one.
+
 ## Main results
 
 * `Representation.exists_isRealStructure_of_isInvariantForm_of_isInvariantSesqForm`: **an
   irreducible representation carrying a nondegenerate invariant symmetric form and a nonnegative
   invariant Hermitian form that is definite off the origin has a real structure.**
+* `Representation.exists_isInvariantForm_isSymm_nondegenerate_of_isRealStructure`: **a real
+  structure, together with a positive definite invariant Hermitian form, produces a nondegenerate
+  invariant symmetric form.**
+* `Representation.exists_isRealStructure_iff`: against a positive definite invariant Hermitian
+  form, an irreducible finite-dimensional representation has a real structure exactly when it
+  carries a nondegenerate invariant symmetric form.
 
 ## References
 
 * [Character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
   Layer 7: the passage from a "compatible Hermitian form" to the real structure that the
   realizability target `frobeniusSchurIndicatorRep_eq_one_realizable` is read off from.
+* [Compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md),
+  Layer 6b: the structure-map reading of the Frobenius-Schur value `1`, which consumes the
+  equivalence below.
 * J.-P. Serre, *Linear Representations of Finite Groups*, GTM 42 (1977), §13.2.
+* T. Bröcker, T. tom Dieck, *Representations of Compact Lie Groups*, Springer GTM 98 (1985),
+  Chapter II, §6.
 -/
 
 public section
@@ -290,5 +314,146 @@ theorem exists_isRealStructure_of_isInvariantForm_of_isInvariantSesqForm {B : Bi
   · simp only [LinearMap.smul_apply, compareForms_apply_rep hBinv hHinv hdef, map_smul]
 
 end RealStructure
+
+/-! ### The balanced Hermitian form of a conjugate-linear map -/
+
+section Balanced
+
+variable {V : Type*} [AddCommGroup V] [Module ℂ V]
+
+/-- The **balanced** form of a sesquilinear form `H` against a conjugate-linear map `K`:
+`x, y ↦ H x y + conj (H (K x) (K y))`.  Each argument of the second summand picks up a conjugation
+from `K`, and the outer conjugation restores the shape of a sesquilinear form, conjugate-linear in
+the first argument and linear in the second.  Adding it to `H` is what forces the compatibility
+`balance H K (K x) (K y) = conj (balance H K x y)` when `K` is an involution. -/
+private noncomputable def balance (H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ) (K : V →ₛₗ[starRingEnd ℂ] V) :
+    V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ where
+  toFun x :=
+    { toFun := fun y => H x y + (starRingEnd ℂ) (H (K x) (K y))
+      map_add' := fun y z => by simp only [map_add]; ring
+      map_smul' := fun c y => by
+        simp only [map_smulₛₗ, RingHom.id_apply, smul_eq_mul, map_mul, Complex.conj_conj]
+        ring }
+  map_add' x y := by
+    ext z
+    simp only [map_add, LinearMap.add_apply, LinearMap.coe_mk, AddHom.coe_mk]
+    ring
+  map_smul' c x := by
+    ext z
+    simp only [map_smulₛₗ, LinearMap.smul_apply, smul_eq_mul, map_mul, Complex.conj_conj,
+      LinearMap.coe_mk, AddHom.coe_mk]
+    ring
+
+private theorem balance_apply (H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ) (K : V →ₛₗ[starRingEnd ℂ] V) (x y : V) :
+    balance H K x y = H x y + (starRingEnd ℂ) (H (K x) (K y)) := (rfl)
+
+/-- **The balanced form is compatible with the involution it was balanced against**: replacing both
+arguments by their `K`-images conjugates the value.  This is the only property of `balance` that
+`H` alone does not already have, and the whole point of the construction. -/
+private theorem balance_map_map {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ} {K : V →ₛₗ[starRingEnd ℂ] V}
+    (hK : Function.Involutive ⇑K) (x y : V) :
+    balance H K (K x) (K y) = (starRingEnd ℂ) (balance H K x y) := by
+  rw [balance_apply, balance_apply, hK x, hK y, map_add, Complex.conj_conj, add_comm]
+
+/-- The balanced form is Hermitian if `H` is. -/
+private theorem isSymm_balance {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ} (hH : H.IsSymm)
+    (K : V →ₛₗ[starRingEnd ℂ] V) : (balance H K).IsSymm where
+  eq x y := by
+    rw [balance_apply, balance_apply, map_add, Complex.conj_conj, hH.eq x y,
+      hH.eq (K y) (K x)]
+
+/-- A nonnegative complex number has vanishing imaginary part, so conjugation fixes it. -/
+private theorem conj_eq_self_of_nonneg {z : ℂ} (hz : 0 ≤ z) : (starRingEnd ℂ) z = z :=
+  Complex.conj_eq_iff_im.mpr (Complex.nonneg_iff.mp hz).2.symm
+
+/-- The balanced form is nonnegative if `H` is: both summands are, the second because conjugation
+fixes a nonnegative complex number. -/
+private theorem isNonneg_balance {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ} (hH : H.IsNonneg)
+    (K : V →ₛₗ[starRingEnd ℂ] V) : (balance H K).IsNonneg where
+  nonneg x := by
+    rw [balance_apply, conj_eq_self_of_nonneg (hH.nonneg (K x))]
+    exact add_nonneg (hH.nonneg x) (hH.nonneg (K x))
+
+/-- The balanced form is definite off the origin if `H` is: the first summand is already nonzero
+and the second is nonnegative. -/
+private theorem balance_apply_self_ne_zero {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ} (hH : H.IsNonneg)
+    (hdef : ∀ x : V, x ≠ 0 → H x x ≠ 0) (K : V →ₛₗ[starRingEnd ℂ] V) {x : V} (hx : x ≠ 0) :
+    balance H K x x ≠ 0 := by
+  rw [balance_apply, conj_eq_self_of_nonneg (hH.nonneg (K x))]
+  exact (add_pos_of_pos_of_nonneg
+    (lt_of_le_of_ne (hH.nonneg x) (Ne.symm (hdef x hx))) (hH.nonneg (K x))).ne'
+
+end Balanced
+
+/-! ### An invariant symmetric form out of a real structure -/
+
+section OfRealStructure
+
+variable {G V : Type*} [Group G] [AddCommGroup V] [Module ℂ V] {ρ : Representation ℂ G V}
+
+/-- The balanced form of an invariant form against an equivariant map is invariant. -/
+private theorem isInvariantSesqForm_balance {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ}
+    {K : V →ₛₗ[starRingEnd ℂ] V} (hHinv : IsInvariantSesqForm ρ H)
+    (hK : ∀ (g : G) (v : V), K (ρ g v) = ρ g (K v)) : IsInvariantSesqForm ρ (balance H K) :=
+  isInvariantSesqForm_iff.mpr fun g x y => by
+    rw [balance_apply, balance_apply, hHinv.apply g x y, hK g x, hK g y, hHinv.apply g (K x) (K y)]
+
+/-- **A real structure produces a nondegenerate invariant symmetric form.**  Balancing the given
+invariant Hermitian form `H` against the real structure `K` makes it satisfy
+`H (K x) (K y) = conj (H x y)`, and then `B x y = H (K x) y` is a bilinear form -- the two
+conjugations, one from `K` and one from the first argument of `H`, cancel -- which is invariant
+because both `H` and `K` are, symmetric by the compatibility, and nondegenerate because `H` is
+definite and `K` is bijective.
+
+Neither irreducibility nor finite dimensionality is used: this is the elementary direction of the
+correspondence, the other being
+`Representation.exists_isRealStructure_of_isInvariantForm_of_isInvariantSesqForm`. -/
+theorem exists_isInvariantForm_isSymm_nondegenerate_of_isRealStructure
+    {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ} {K : V →ₛₗ[starRingEnd ℂ] V} (hK : IsRealStructure ρ K)
+    (hHinv : IsInvariantSesqForm ρ H) (hHsymm : H.IsSymm) (hHnonneg : H.IsNonneg)
+    (hdef : ∀ x : V, x ≠ 0 → H x x ≠ 0) :
+    ∃ B : BilinForm ℂ V, IsInvariantForm ρ B ∧ B.IsSymm ∧ B.Nondegenerate := by
+  -- The candidate form, `B x y = balance H K (K x) y`; the composite is honestly `ℂ`-bilinear,
+  -- the conjugation `K` carries cancelling the one the first argument of a sesquilinear form does.
+  refine ⟨(balance H K).comp K, ?_, ?_, ?_, ?_⟩
+  · exact isInvariantForm_iff.mpr fun g x y => by
+      rw [LinearMap.comp_apply, LinearMap.comp_apply, hK.isIntertwining g x,
+        (isInvariantSesqForm_balance hHinv hK.isIntertwining).apply g (K x) y]
+  · -- Symmetry: move `K` from one argument to the other with `hK.involutive` and the
+    -- compatibility, then read off the Hermitian symmetry of the balanced form.
+    refine ⟨fun x y => ?_⟩
+    rw [LinearMap.comp_apply, LinearMap.comp_apply, ← hK.involutive y,
+      balance_map_map hK.involutive x (K y), ← (isSymm_balance hHsymm K).eq (K y) x,
+      Complex.conj_conj, hK.involutive y]
+  · -- Left separation: a vector killed by `B` has `balance H K (K x) (K x) = 0`.
+    intro x hx
+    by_contra hx0
+    have hKx : K x ≠ 0 := fun h =>
+      hx0 (hK.involutive.injective (h.trans (map_zero K).symm))
+    exact balance_apply_self_ne_zero hHnonneg hdef K hKx (by simpa using hx (K x))
+  · -- Right separation: pairing against `K y` gives `balance H K y y = 0`.
+    intro y hy
+    by_contra hy0
+    refine balance_apply_self_ne_zero hHnonneg hdef K hy0 ?_
+    have h := hy (K y)
+    rwa [LinearMap.comp_apply, hK.involutive y] at h
+
+variable [FiniteDimensional ℂ V] [ρ.IsIrreducible]
+
+/-- **Against a positive definite invariant Hermitian form, a real structure is the same datum as a
+nondegenerate invariant symmetric form.**  Both directions are proved above; the Hermitian form is
+the fixed background datum, supplied by summation over a finite group or by Haar averaging over a
+compact one. -/
+theorem exists_isRealStructure_iff {H : V →ₗ⋆[ℂ] V →ₗ[ℂ] ℂ} (hHinv : IsInvariantSesqForm ρ H)
+    (hHsymm : H.IsSymm) (hHnonneg : H.IsNonneg) (hdef : ∀ x : V, x ≠ 0 → H x x ≠ 0) :
+    (∃ K : V →ₛₗ[starRingEnd ℂ] V, IsRealStructure ρ K) ↔
+      ∃ B : BilinForm ℂ V, IsInvariantForm ρ B ∧ B.IsSymm ∧ B.Nondegenerate :=
+  ⟨fun ⟨_, hK⟩ =>
+      exists_isInvariantForm_isSymm_nondegenerate_of_isRealStructure hK hHinv hHsymm hHnonneg hdef,
+    fun ⟨_, hBinv, hBsymm, hBnd⟩ =>
+      exists_isRealStructure_of_isInvariantForm_of_isInvariantSesqForm hBinv hBsymm hBnd hHinv
+        hHnonneg hdef⟩
+
+end OfRealStructure
 
 end Representation


### PR DESCRIPTION
This PR reads the Frobenius-Schur value `1` of an irreducible unitary representation of a compact group as a **structure map**: a conjugate-linear involution `K` of the carrier commuting with the action (`TauCeti.Representation.IsRealStructure`), equivalently as **realizability over `ℝ`**. `TauCeti/RepresentationTheory/Compact/FrobeniusSchur/InvariantForm.lean` stops at invariant bilinear forms and says so in its docstring — "none of the statements below mentions a structure map or a real or quaternionic form" — and this is the step it defers.

The mathematical content is a general statement about a complex representation carrying a positive definite invariant Hermitian form `H`: against a fixed such `H`, a real structure and a nondegenerate invariant symmetric bilinear form are interchangeable data. One direction is the merged `Representation.exists_isRealStructure_of_isInvariantForm_of_isInvariantSesqForm`, which compares the two forms and rescales by a Schur scalar. The converse is new and elementary — it uses neither irreducibility nor finite dimensionality. The naive guess `B x y = H (K x) y` is bilinear (the conjugation `K` carries cancels the one the first argument of a sesquilinear form carries), invariant and nondegenerate for free, but it is symmetric only when `H (K x) (K y) = conj (H x y)`, which an arbitrary invariant `H` need not satisfy. Replacing `H` by the balanced form `H x y + conj (H (K x) (K y))` — still invariant, Hermitian and positive definite, `K` being bijective — forces that compatibility, and then `B` is symmetric. The two directions assemble into `Representation.exists_isRealStructure_iff`.

The compact-group criterion then needs nothing new integrated over the group: the unitarity hypothesis the whole Frobenius-Schur layer already carries *is* a positive definite invariant Hermitian form, namely the inner product of the carrier, so `ContRepresentation.frobeniusSchurIndicator_eq_one_iff_exists_isRealStructure` is the invariant-form criterion rewritten through the equivalence, and `ContRepresentation.frobeniusSchurIndicator_eq_one_iff_isRealizableOverReal` follows from `Representation.isRealizableOverReal_iff_exists_isRealStructure`. This is the compact mirror of the finite-group `Representation.frobeniusSchurIndicator_eq_one_iff_isRealizableOverReal`, with the summed invariant Hermitian form replaced by the inner product a unitary representation comes with.

The target is `frobeniusSchurIndicator_eq_one_iff_exists_structureMap` of Layer 6b ("the Frobenius-Schur reality trichotomy for compact groups") of `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, pinned in the accompanying `Suggested.lean`: "`ν₂ = +1` iff realizable over `ℝ`, in structure-map form: there is a conjugate-linear `J : V →ₗ⋆[ℂ] V` with `J² = 1` commuting with the action (its fixed points are the real form)". The roadmap phrases it with an unbundled `J`; that is exactly `TauCeti.Representation.IsRealStructure`, which `TauCeti/RepresentationTheory/RealForm.lean` already defines and equips with the passage to a real form, so the statements are given in terms of the named predicate rather than its unfolding — the roadmap's parenthetical about the fixed points is then the second theorem. The quaternionic companion `J² = -1` for `ν₂ = -1` is deliberately not in scope here; it needs a structure predicate the repository does not yet have.

Files: `TauCeti/RepresentationTheory/Compact/FrobeniusSchur/RealStructure.lean` is new (142 lines); `TauCeti/RepresentationTheory/InvariantForm/RealStructure.lean` gains the converse direction, the balanced-form machinery it rests on, and the assembled equivalence, with its module docstring updated to describe the file as the correspondence rather than just one direction. No Mathlib code was vendored. `lake build`, `lake exe axioms` (85175 declarations, allowlist only), `scripts/lint-style.sh`, `scripts/lint-env.sh` and `scripts/lint-dot-notation.py` all pass locally.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"frobeniusschurindicator-eq-one-iff-exists-structuremap"}-->

🤖 Prepared with Claude Code
