### PR TITLE
Generalize Cartan-binomial lattice stability

### DIFF
--- a/TauCeti/LinearAlgebra/Eigenspace/Binomial.lean
+++ b/TauCeti/LinearAlgebra/Eigenspace/Binomial.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RingTheory.Binomial
 public import TauCeti.Algebra.Module.Rat
+public import TauCeti.RingTheory.Binomial
 
 /-!
 # Generalized binomial coefficients of an endomorphism at an eigenvector
@@ -37,6 +37,8 @@ diagonal in a fixed basis rather than merely applied to one eigenvector.
   scales an eigenvector by the binomial coefficient of its eigenvalue.
 * `TauCeti.ringChoose_end_apply_of_apply_eq_natCast_smul`: the specialization to a natural-number
   eigenvalue, where the scalar is `Nat.choose`.
+* `TauCeti.ringChoose_end_apply_mem_span_of_apply_eq_intCast_smul`: binomial coefficients of an
+  endomorphism preserve the integral span of integer-eigenvalue generators.
 
 ## References
 
@@ -91,5 +93,22 @@ integrally. -/
 theorem ringChoose_end_apply_of_apply_eq_natCast_smul {f : Module.End ℚ V} {v : V} {j : ℕ}
     (h : f v = (j : ℚ) • v) (n : ℕ) : (Ring.choose f n) v = (j.choose n : ℚ) • v := by
   rw [ringChoose_end_apply_of_apply_eq_smul h, Ring.choose_natCast]
+
+/-- Binomial coefficients of an endomorphism preserve the integral span of any family of
+eigenvectors whose eigenvalues are integers. -/
+theorem ringChoose_end_apply_mem_span_of_apply_eq_intCast_smul {I : Type*}
+    {f : Module.End ℚ V} {e : I → V} {weight : I → ℤ}
+    (heigen : ∀ i, f (e i) = (weight i : ℚ) • e i) (n : ℕ) {v : V}
+    (hv : v ∈ Submodule.span ℤ (Set.range e)) :
+    (Ring.choose f n) v ∈ Submodule.span ℤ (Set.range e) := by
+  induction hv using Submodule.span_induction with
+  | mem v hv =>
+      obtain ⟨i, rfl⟩ := hv
+      rw [ringChoose_end_apply_of_apply_eq_smul (heigen i) n,
+        Ring.choose_intCast, Int.cast_smul_eq_zsmul ℚ]
+      exact Submodule.smul_mem _ _ (Submodule.subset_span (Set.mem_range_self i))
+  | zero => rw [map_zero]; exact Submodule.zero_mem _
+  | add x y _ _ hx hy => rw [map_add]; exact Submodule.add_mem _ hx hy
+  | smul z x _ hx => rw [map_zsmul]; exact Submodule.smul_mem _ z hx
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
@@ -306,24 +306,14 @@ theorem geckRepresentation_ringChoose_lieBasis_h_mem_geckCoordinateLattice
         (Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).h i)) n) v ∈
       t.geckCoordinateLattice ht := by
   rw [geckCoordinateLattice] at hv ⊢
-  induction hv using Submodule.span_induction with
-  | mem v hv =>
-      obtain ⟨x, rfl⟩ := hv
-      rw [Pi.basisFun_apply]
-      rw [Ring.map_choose]
-      have hweight := (UniversalEnvelopingAlgebra.isCartanWeightVector_iff
-        (h := (t.lieBasis ht).h) (ρ := t.geckRepresentation ht)).1
-          (t.isCartanWeightVector_geckRepresentation_single ht x) i
-      rw [ringChoose_end_apply_of_apply_eq_smul hweight n,
-        TauCeti.Ring.choose_intCast, Int.cast_smul_eq_zsmul ℚ]
-      have hx : Pi.single x (1 : ℚ) ∈
-          Submodule.span ℤ (range (Pi.basisFun ℚ (t.GeckIndex ht))) := by
-        rw [← Pi.basisFun_apply]
-        exact Submodule.subset_span (mem_range_self x)
-      exact Submodule.smul_mem _ _ hx
-  | zero => rw [map_zero]; exact zero_mem _
-  | add x y _ _ hx hy => rw [map_add]; exact add_mem hx hy
-  | smul z x _ hx => rw [map_zsmul]; exact Submodule.smul_mem _ z hx
+  rw [Ring.map_choose]
+  apply ringChoose_end_apply_mem_span_of_apply_eq_intCast_smul
+    (weight := fun x => t.geckWeight ht x i) (n := n) ?_ hv
+  intro x
+  rw [Pi.basisFun_apply]
+  exact (UniversalEnvelopingAlgebra.isCartanWeightVector_iff
+    (h := (t.lieBasis ht).h) (ρ := t.geckRepresentation ht)).1
+      (t.isCartanWeightVector_geckRepresentation_single ht x) i
 
 /-! ## Divided powers of the numbered root generators -/
 


### PR DESCRIPTION
Extract the integral-span argument for generalized binomial coefficients into a reusable eigenvector lemma, then use it to simplify the Geck coordinate-lattice proof.

This is the first prerequisite refactor requested in the review of #4628. Its motivating roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, “The Chevalley–Demazure construction”: the carrier lattice must be stable under the Cartan binomial operators in the Kostant form.

Validation: `lake build` (9,752 jobs) and `bash scripts/lint-env.sh` (no new violations).

Roadmap: ReductiveGroups