### PR TITLE
Span the type C character lattice by weights

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
@@ -153,18 +153,15 @@ theorem span_range_weight_eq_top (n : ℕ) :
       rw [Subsingleton.elim x 0]
       exact Submodule.zero_mem _
   | succ n =>
-      let S := Submodule.span ℤ
-        (Set.range (fun a : Fin (n + 1) => weight (n + 1) a))
-      change S = ⊤
       apply top_unique
       rw [← (Pi.basisFun ℤ (Fin (n + 1))).span_eq]
       refine Submodule.span_le.2 ?_
       rintro _ ⟨a, rfl⟩
       rw [Pi.basisFun_apply]
-      change Pi.single a 1 ∈ S
       induction a using Fin.induction with
       | zero =>
-          have h : weight (n + 1) (0 : Fin (n + 1)) ∈ S :=
+          have h : weight (n + 1) (0 : Fin (n + 1)) ∈
+              Submodule.span ℤ (Set.range (fun a : Fin (n + 1) => weight (n + 1) a)) :=
             Submodule.subset_span (Set.mem_range_self _)
           have heq : Pi.single (0 : Fin (n + 1)) 1 = weight (n + 1) (0 : Fin (n + 1)) := by
             funext i
@@ -182,8 +179,9 @@ theorem span_range_weight_eq_top (n : ℕ) :
           rw [heq]
           exact h
       | succ a ih =>
-          have h : weight (n + 1) a.succ + Pi.single a.castSucc 1 ∈ S :=
-            Submodule.add_mem S (Submodule.subset_span (Set.mem_range_self a.succ)) ih
+          have h : weight (n + 1) a.succ + Pi.single a.castSucc 1 ∈
+              Submodule.span ℤ (Set.range (fun a : Fin (n + 1) => weight (n + 1) a)) :=
+            Submodule.add_mem _ (Submodule.subset_span (Set.mem_range_self a.succ)) ih
           have heq : Pi.single a.succ 1 = weight (n + 1) a.succ + Pi.single a.castSucc 1 := by
             funext i
             simp only [weight_apply, Pi.single_apply, Pi.add_apply, Fin.val_succ]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/C/Model.lean
@@ -65,6 +65,8 @@ hypothesis always holds.
 
 ## Main results
 
+* `TauCeti.DynkinType.TypeC.span_range_weight_eq_top`: the classical weights span the full
+  character lattice in every rank.
 * `TauCeti.DynkinType.TypeC.signedWeight_signedReflection` and
   `TauCeti.DynkinType.TypeC.signedCoweight_signedReflection`: the reflection acts as the reflection
   formula says it does.
@@ -137,6 +139,57 @@ lemma weight_dotProduct_coweight {a c : ℕ} (ha : a < n) :
   simp only [dotProduct, weight, coweight, sub_mul, Finset.sum_sub_distrib,
     key a, key' a]
   split_ifs <;> omega
+
+/-! ## Generation of the character lattice -/
+
+/-- **The classical type-`Cₙ` weights generate the full character lattice.** Each standard
+coordinate character is the partial sum of the weights through that coordinate. -/
+theorem span_range_weight_eq_top (n : ℕ) :
+    Submodule.span ℤ (Set.range (fun a : Fin n => weight n a)) = ⊤ := by
+  cases n with
+  | zero =>
+      apply top_unique
+      intro x _
+      rw [Subsingleton.elim x 0]
+      exact Submodule.zero_mem _
+  | succ n =>
+      let S := Submodule.span ℤ
+        (Set.range (fun a : Fin (n + 1) => weight (n + 1) a))
+      change S = ⊤
+      apply top_unique
+      rw [← (Pi.basisFun ℤ (Fin (n + 1))).span_eq]
+      refine Submodule.span_le.2 ?_
+      rintro _ ⟨a, rfl⟩
+      rw [Pi.basisFun_apply]
+      change Pi.single a 1 ∈ S
+      induction a using Fin.induction with
+      | zero =>
+          have h : weight (n + 1) (0 : Fin (n + 1)) ∈ S :=
+            Submodule.subset_span (Set.mem_range_self _)
+          have heq : Pi.single (0 : Fin (n + 1)) 1 = weight (n + 1) (0 : Fin (n + 1)) := by
+            funext i
+            by_cases hi : i = 0
+            · subst i
+              simp only [weight_apply, Pi.single_eq_same, Fin.val_zero, ↓reduceIte, zero_add,
+                Nat.zero_ne_add_one, sub_zero]
+            · have hval : (i : ℕ) ≠ 0 := by
+                intro hval
+                apply hi
+                exact Fin.ext hval
+              have hval' : (0 : ℕ) ≠ (i : ℕ) := Ne.symm hval
+              simp only [weight_apply, Pi.single_eq_of_ne hi, Fin.val_zero, hval', ↓reduceIte,
+                Nat.zero_ne_add_one, sub_self]
+          rw [heq]
+          exact h
+      | succ a ih =>
+          have h : weight (n + 1) a.succ + Pi.single a.castSucc 1 ∈ S :=
+            Submodule.add_mem S (Submodule.subset_span (Set.mem_range_self a.succ)) ih
+          have heq : Pi.single a.succ 1 = weight (n + 1) a.succ + Pi.single a.castSucc 1 := by
+            funext i
+            simp only [weight_apply, Pi.single_apply, Pi.add_apply, Fin.val_succ]
+            split_ifs <;> simp only [Fin.ext_iff, Fin.val_succ, Fin.val_castSucc] at * <;> omega
+          rw [heq]
+          exact h
 
 /-! ## Signed basis vectors -/
 


### PR DESCRIPTION
Prove in the rank-polymorphic type-C model that the classical standard weights span the entire character lattice. The proof expresses each coordinate basis vector as the corresponding partial sum of weights and includes rank zero.

This is the second prerequisite requested in the review of #4628. It directly advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, “The Chevalley–Demazure construction”: the type-C full-weight carrier needs its represented torus to see the complete simply connected character lattice.

Validation: `lake build` (9,752 jobs) and `bash scripts/lint-env.sh` (no new violations).

Roadmap: ReductiveGroups