### PR TITLE
feat: identify represented weight-Levi conjugation

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/Action.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/Action.lean
@@ -1,0 +1,291 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Levi.Decomposition
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
+
+/-!
+# The represented conjugation action in a weight parabolic
+
+Let `P(w)`, `U(w)`, and `L(w)` be the represented weight parabolic, unipotent subgroup, and
+Levi subgroup of `GL_N`. Normality of `U(w)` in `P(w)` supplies a categorical conjugation action
+of `L(w)` on `U(w)`. This file transports that action through the coordinate identifications of
+the two relative quotient subgroups and proves that it is exactly the dynamic conjugation action
+used in the pointwise Levi decomposition.
+
+Thus the categorical semidirect product constructed from the two closed subgroup schemes has
+the same multiplication law on algebra-valued points as the dynamic semidirect product.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.Dynamic.weightLeviInParabolicPointsMulEquiv`: relative Levi quotient
+  points are dynamic Levi points.
+* `TauCeti.GeneralLinear.Dynamic.weightUnipotentInParabolicPointsMulEquiv`: relative unipotent
+  quotient points are dynamic unipotent points.
+* `TauCeti.GeneralLinear.Dynamic.representedWeightLeviConjugation`: categorical conjugation,
+  evaluated after transport to dynamic points.
+* `TauCeti.GeneralLinear.Dynamic.representedWeightLeviConjugation_eq_dynamic`: transported
+  categorical conjugation is the dynamic Levi action.
+
+## References
+
+* G. R. Kempf, *Instability in invariant theory*, Annals of Mathematics 108 (1978), §2.
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 13.
+
+This advances the dynamic route to parabolic subgroups and Levi decomposition in Layer 7,
+"Structure theory", of the ReductiveGroups roadmap. It supplies the action comparison needed
+to identify the represented categorical semidirect product with the pointwise dynamic one.
+-/
+
+public section
+
+open CategoryTheory Opposite WithConv
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.GeneralLinear.Dynamic
+
+universe u
+
+noncomputable section
+
+variable (R : Type u) [CommRing R] {N : ℕ}
+
+/-- Points of the relative Levi quotient inside the weight parabolic are canonically the
+dynamic Levi points of the weight cocharacter. -/
+noncomputable def weightLeviInParabolicPointsMulEquiv (w : Fin N → ℤ)
+    (A : CommAlgCat.{u} R) :
+    HopfAlgebra.points (R := R)
+        (H := CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+          (weightLeviInParabolicHopfIdeal R w)) A ≃*
+      Cocharacter.levi A (weightCocharacter (R := R) w) :=
+  (AlgHom.mapDomainMulEquiv (A := A)
+      (CommHopfAlgCat.ofIso (weightLeviInParabolicCoordinateIso R w))).trans
+    ((weightLeviPointsIso R w).app A).groupIsoToMulEquiv
+
+/-- Points of the relative unipotent quotient inside the weight parabolic are canonically the
+dynamic unipotent points of the weight cocharacter. -/
+noncomputable def weightUnipotentInParabolicPointsMulEquiv (w : Fin N → ℤ)
+    (A : CommAlgCat.{u} R) :
+    HopfAlgebra.points (R := R)
+        (H := CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+          (weightUnipotentInParabolicHopfIdeal R w)) A ≃*
+      Cocharacter.unipotent A (weightCocharacter (R := R) w) :=
+  (AlgHom.mapDomainMulEquiv (A := A)
+      (CommHopfAlgCat.ofIso (weightUnipotentInParabolicCoordinateIso R w))).trans
+    ((weightUnipotentPointsIso R w).app A).groupIsoToMulEquiv
+
+/-- The relative Levi point equivalence preserves the underlying point of the ambient general
+linear group. -/
+@[simp]
+theorem coe_weightLeviInParabolicPointsMulEquiv_apply (w : Fin N → ℤ)
+    (A : CommAlgCat.{u} R)
+    (z : HopfAlgebra.points (R := R)
+      (H := CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+        (weightLeviInParabolicHopfIdeal R w)) A) :
+    ((weightLeviInParabolicPointsMulEquiv R w A z :
+        Cocharacter.levi A (weightCocharacter (R := R) w)) :
+      HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) A) =
+      CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
+        (weightParabolicDefiningHopfIdeal R w) A
+        (CommHopfAlgCat.quotientPointsHom (weightParabolicCoordinateHopfAlgebra R w)
+          (weightLeviInParabolicHopfIdeal R w) A z) := by
+  rcases A with ⟨A⟩
+  change (((eqToHom (Cocharacter.leviFunctor_obj
+      (weightCocharacter (R := R) w) (CommAlgCat.of R A)))
+    ((weightLeviPointsIso R w).hom.app (CommAlgCat.of R A)
+      (AlgHom.mapDomainMulEquiv
+        (A := CommAlgCat.of R A)
+        (CommHopfAlgCat.ofIso (weightLeviInParabolicCoordinateIso R w)) z)) :
+      Cocharacter.levi (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
+        HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
+          (CommAlgCat.of R A)) = _
+  rw [coe_weightLeviPointsIso_hom_app_apply, AlgHom.mapDomainMulEquiv_apply]
+  apply WithConv.ofConv_injective
+  apply AlgHom.ext
+  intro x
+  rw [CommHopfAlgCat.quotientPointsHom_apply_apply,
+    CommHopfAlgCat.quotientPointsHom_apply_apply, AlgHom.mapDomain_apply_apply,
+    CommHopfAlgCat.quotientPointsHom_apply_apply]
+  have h := congrArg
+    (fun f : coordinateHopfAlgebra R N ⟶
+        CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+          (weightLeviInParabolicHopfIdeal R w) ↦ f.hom x)
+    (mkQuotient_weightLevi_comp_weightLeviInParabolicCoordinateIso_hom R w)
+  rw [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.comp_apply,
+    CommHopfAlgCat.mkQuotient_apply, CommHopfAlgCat.mkQuotient_apply,
+    weightParabolicCoordinateMap_apply] at h
+  exact congrArg z.ofConv h
+
+/-- The relative unipotent point equivalence preserves the underlying point of the ambient
+general linear group. -/
+@[simp]
+theorem coe_weightUnipotentInParabolicPointsMulEquiv_apply (w : Fin N → ℤ)
+    (A : CommAlgCat.{u} R)
+    (g : HopfAlgebra.points (R := R)
+      (H := CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+        (weightUnipotentInParabolicHopfIdeal R w)) A) :
+    ((weightUnipotentInParabolicPointsMulEquiv R w A g :
+        Cocharacter.unipotent A (weightCocharacter (R := R) w)) :
+      HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N) A) =
+      CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
+        (weightParabolicDefiningHopfIdeal R w) A
+        (CommHopfAlgCat.quotientPointsHom (weightParabolicCoordinateHopfAlgebra R w)
+          (weightUnipotentInParabolicHopfIdeal R w) A g) := by
+  rcases A with ⟨A⟩
+  change (((eqToHom (Cocharacter.unipotentFunctor_obj
+      (weightCocharacter (R := R) w) (CommAlgCat.of R A)))
+    ((weightUnipotentPointsIso R w).hom.app (CommAlgCat.of R A)
+      (AlgHom.mapDomainMulEquiv
+        (A := CommAlgCat.of R A)
+        (CommHopfAlgCat.ofIso (weightUnipotentInParabolicCoordinateIso R w)) g)) :
+      Cocharacter.unipotent (CommAlgCat.of R A) (weightCocharacter (R := R) w)) :
+        HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
+          (CommAlgCat.of R A)) = _
+  rw [coe_weightUnipotentPointsIso_hom_app_apply, AlgHom.mapDomainMulEquiv_apply]
+  apply WithConv.ofConv_injective
+  apply AlgHom.ext
+  intro x
+  rw [CommHopfAlgCat.quotientPointsHom_apply_apply,
+    CommHopfAlgCat.quotientPointsHom_apply_apply, AlgHom.mapDomain_apply_apply,
+    CommHopfAlgCat.quotientPointsHom_apply_apply]
+  have h := congrArg
+    (fun f : coordinateHopfAlgebra R N ⟶
+        CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+          (weightUnipotentInParabolicHopfIdeal R w) ↦ f.hom x)
+    (mkQuotient_weightUnipotent_comp_weightUnipotentInParabolicCoordinateIso_hom R w)
+  rw [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.comp_apply,
+    CommHopfAlgCat.mkQuotient_apply, CommHopfAlgCat.mkQuotient_apply,
+    weightParabolicCoordinateMap_apply] at h
+  exact congrArg g.ofConv h
+
+private theorem quotientPointsHom_quotientNormalConjugation_apply
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H) (hI : I.IsNormal)
+    (A : CommAlgCat.{u} R)
+    (z : HopfAlgebra.points (R := R) (H := CommHopfAlgCat.quotient H J) A)
+    (g : HopfAlgebra.points (R := R) (H := CommHopfAlgCat.quotient H I) A) :
+    CommHopfAlgCat.quotientPointsHom H I A
+        (CommHopfAlgCat.grpObjPointsMulEquiv (CommHopfAlgCat.quotient H I) (op A)
+          ((CommHopfAlgCat.quotientNormalConjugation H I J hI).act
+            ((CommHopfAlgCat.grpObjPointsMulEquiv
+              (CommHopfAlgCat.quotient H J) (op A)).symm z)
+            ((CommHopfAlgCat.grpObjPointsMulEquiv
+              (CommHopfAlgCat.quotient H I) (op A)).symm g))) =
+      CommHopfAlgCat.quotientPointsHom H J A z *
+        CommHopfAlgCat.quotientPointsHom H I A g *
+          (CommHopfAlgCat.quotientPointsHom H J A z)⁻¹ := by
+  let i := CommHopfAlgCat.quotientGrpObjInclusion H I
+  let j := CommHopfAlgCat.quotientGrpObjInclusion H J
+  let z' := (CommHopfAlgCat.grpObjPointsMulEquiv
+    (CommHopfAlgCat.quotient H J) (op A)).symm z
+  let g' := (CommHopfAlgCat.grpObjPointsMulEquiv
+    (CommHopfAlgCat.quotient H I) (op A)).symm g
+  let _ : IsMonHom.Normal i :=
+    (CommHopfAlgCat.quotientGrpObjInclusion_normal_iff H I).2 hI
+  have hact :
+      (CommHopfAlgCat.quotientNormalConjugation H I J hI).act z' g' ≫ i =
+        (z' ≫ j) * (g' ≫ i) * (z' ≫ j)⁻¹ := by
+    change (GrpObj.Action.normalConjugation i j).act z' g' ≫ i = _
+    rw [GrpObj.Action.normalConjugation_act, Category.assoc]
+    exact TauCeti.lift_normalConjugation_comp i (z' ≫ j) g'
+  have hpoints := congrArg (CommHopfAlgCat.grpObjPointsMulEquiv H (op A)) hact
+  simp only [i, j, z', g', map_mul, map_inv] at hpoints
+  rw [CommHopfAlgCat.grpObjPointsMulEquiv_comp_quotientGrpObjInclusion,
+    CommHopfAlgCat.grpObjPointsMulEquiv_comp_quotientGrpObjInclusion,
+    CommHopfAlgCat.grpObjPointsMulEquiv_comp_quotientGrpObjInclusion] at hpoints
+  simpa only [MulEquiv.apply_symm_apply] using hpoints
+
+/-- Conjugation of the relative Levi quotient on the normal relative unipotent quotient. -/
+private noncomputable def weightRelativeLeviConjugation (w : Fin N → ℤ) :
+    GrpObj.Action
+      (CommHopfAlgCat.grpObj
+        (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+          (weightLeviInParabolicHopfIdeal R w)))
+      (CommHopfAlgCat.grpObj
+        (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+          (weightUnipotentInParabolicHopfIdeal R w))) :=
+  CommHopfAlgCat.quotientNormalConjugation (weightParabolicCoordinateHopfAlgebra R w)
+    (weightUnipotentInParabolicHopfIdeal R w) (weightLeviInParabolicHopfIdeal R w)
+    (isNormal_weightUnipotentInParabolicHopfIdeal R w)
+
+/-- Evaluation of represented relative conjugation after transport to dynamic points. -/
+private noncomputable def representedWeightLeviConjugationApply (w : Fin N → ℤ)
+    (A : CommAlgCat.{u} R)
+    (z : Cocharacter.levi A (weightCocharacter (R := R) w))
+    (g : Cocharacter.unipotent A (weightCocharacter (R := R) w)) :
+    Cocharacter.unipotent A (weightCocharacter (R := R) w) := by
+  letI : GrpObj (CommHopfAlgCat.grpObj
+      (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+        (weightLeviInParabolicHopfIdeal R w))) := CommAlgCat.grpObjOpOf
+  letI : GrpObj (CommHopfAlgCat.grpObj
+      (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+        (weightUnipotentInParabolicHopfIdeal R w))) := CommAlgCat.grpObjOpOf
+  exact weightUnipotentInParabolicPointsMulEquiv R w A
+    ((CommHopfAlgCat.grpObjPointsMulEquiv
+      (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+        (weightUnipotentInParabolicHopfIdeal R w)) (op A))
+      ((weightRelativeLeviConjugation R w).act
+        ((CommHopfAlgCat.grpObjPointsMulEquiv
+          (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+            (weightLeviInParabolicHopfIdeal R w)) (op A)).symm
+          ((weightLeviInParabolicPointsMulEquiv R w A).symm z))
+        ((CommHopfAlgCat.grpObjPointsMulEquiv
+          (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+            (weightUnipotentInParabolicHopfIdeal R w)) (op A)).symm
+          ((weightUnipotentInParabolicPointsMulEquiv R w A).symm g))))
+
+/-- The categorical conjugation action of the represented relative Levi subgroup on the
+represented relative unipotent subgroup, transported to dynamic points. -/
+noncomputable def representedWeightLeviConjugation (w : Fin N → ℤ)
+    (A : CommAlgCat.{u} R) :
+    Cocharacter.levi A (weightCocharacter (R := R) w) →*
+      MulAut (Cocharacter.unipotent A (weightCocharacter (R := R) w)) := by
+  letI : GrpObj (CommHopfAlgCat.grpObj
+      (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+        (weightLeviInParabolicHopfIdeal R w))) := CommAlgCat.grpObjOpOf
+  letI : GrpObj (CommHopfAlgCat.grpObj
+      (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+        (weightUnipotentInParabolicHopfIdeal R w))) := CommAlgCat.grpObjOpOf
+  exact (MulAut.congr
+    ((CommHopfAlgCat.grpObjPointsMulEquiv
+      (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+        (weightUnipotentInParabolicHopfIdeal R w)) (op A)).trans
+        (weightUnipotentInParabolicPointsMulEquiv R w A))).toMonoidHom.comp
+    ((weightRelativeLeviConjugation R w).toMulAutHom (op A) |>.comp
+      ((weightLeviInParabolicPointsMulEquiv R w A).symm.trans
+        (CommHopfAlgCat.grpObjPointsMulEquiv
+          (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
+            (weightLeviInParabolicHopfIdeal R w)) (op A)).symm).toMonoidHom)
+
+/-- The categorical conjugation action of the represented Levi subgroup is exactly the dynamic
+Levi conjugation action on every commutative algebra of points. -/
+@[simp]
+theorem representedWeightLeviConjugation_eq_dynamic (w : Fin N → ℤ)
+    (A : CommAlgCat.{u} R) :
+    representedWeightLeviConjugation R w A =
+      Cocharacter.leviConjugation A (weightCocharacter (R := R) w) := by
+  apply MonoidHom.ext
+  intro z
+  apply MulEquiv.ext
+  intro g
+  unfold representedWeightLeviConjugation
+  simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulAut.congr_apply,
+    MulEquiv.trans_apply, GrpObj.Action.toMulAutHom_apply]
+  change representedWeightLeviConjugationApply R w A z g = _
+  apply Subtype.ext
+  rw [Cocharacter.coe_leviConjugation_apply]
+  unfold representedWeightLeviConjugationApply
+  rw [coe_weightUnipotentInParabolicPointsMulEquiv_apply,
+    weightRelativeLeviConjugation,
+    quotientPointsHom_quotientNormalConjugation_apply]
+  simp only [map_mul, map_inv]
+  rw [← coe_weightLeviInParabolicPointsMulEquiv_apply,
+    ← coe_weightUnipotentInParabolicPointsMulEquiv_apply]
+  simp
+
+end
+
+end TauCeti.GeneralLinear.Dynamic

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/Action.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/Action.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Levi.Decomposition
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Dynamic.Weight.Normal
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
 
 /-!
@@ -94,6 +94,8 @@ theorem coe_weightLeviInParabolicPointsMulEquiv_apply (w : Fin N → ℤ)
         (CommHopfAlgCat.quotientPointsHom (weightParabolicCoordinateHopfAlgebra R w)
           (weightLeviInParabolicHopfIdeal R w) A z) := by
   rcases A with ⟨A⟩
+  -- Unwrap the category object and the equality transport defining `leviFunctor_obj` so
+  -- the pointwise comparison lemma for `weightLeviPointsIso` matches the goal.
   change (((eqToHom (Cocharacter.leviFunctor_obj
       (weightCocharacter (R := R) w) (CommAlgCat.of R A)))
     ((weightLeviPointsIso R w).hom.app (CommAlgCat.of R A)
@@ -136,6 +138,8 @@ theorem coe_weightUnipotentInParabolicPointsMulEquiv_apply (w : Fin N → ℤ)
         (CommHopfAlgCat.quotientPointsHom (weightParabolicCoordinateHopfAlgebra R w)
           (weightUnipotentInParabolicHopfIdeal R w) A g) := by
   rcases A with ⟨A⟩
+  -- Unwrap the category object and the equality transport defining `unipotentFunctor_obj`
+  -- so the pointwise comparison lemma for `weightUnipotentPointsIso` matches the goal.
   change (((eqToHom (Cocharacter.unipotentFunctor_obj
       (weightCocharacter (R := R) w) (CommAlgCat.of R A)))
     ((weightUnipotentPointsIso R w).hom.app (CommAlgCat.of R A)
@@ -162,42 +166,6 @@ theorem coe_weightUnipotentInParabolicPointsMulEquiv_apply (w : Fin N → ℤ)
     weightParabolicCoordinateMap_apply] at h
   exact congrArg g.ofConv h
 
-private theorem quotientPointsHom_quotientNormalConjugation_apply
-    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H) (hI : I.IsNormal)
-    (A : CommAlgCat.{u} R)
-    (z : HopfAlgebra.points (R := R) (H := CommHopfAlgCat.quotient H J) A)
-    (g : HopfAlgebra.points (R := R) (H := CommHopfAlgCat.quotient H I) A) :
-    CommHopfAlgCat.quotientPointsHom H I A
-        (CommHopfAlgCat.grpObjPointsMulEquiv (CommHopfAlgCat.quotient H I) (op A)
-          ((CommHopfAlgCat.quotientNormalConjugation H I J hI).act
-            ((CommHopfAlgCat.grpObjPointsMulEquiv
-              (CommHopfAlgCat.quotient H J) (op A)).symm z)
-            ((CommHopfAlgCat.grpObjPointsMulEquiv
-              (CommHopfAlgCat.quotient H I) (op A)).symm g))) =
-      CommHopfAlgCat.quotientPointsHom H J A z *
-        CommHopfAlgCat.quotientPointsHom H I A g *
-          (CommHopfAlgCat.quotientPointsHom H J A z)⁻¹ := by
-  let i := CommHopfAlgCat.quotientGrpObjInclusion H I
-  let j := CommHopfAlgCat.quotientGrpObjInclusion H J
-  let z' := (CommHopfAlgCat.grpObjPointsMulEquiv
-    (CommHopfAlgCat.quotient H J) (op A)).symm z
-  let g' := (CommHopfAlgCat.grpObjPointsMulEquiv
-    (CommHopfAlgCat.quotient H I) (op A)).symm g
-  let _ : IsMonHom.Normal i :=
-    (CommHopfAlgCat.quotientGrpObjInclusion_normal_iff H I).2 hI
-  have hact :
-      (CommHopfAlgCat.quotientNormalConjugation H I J hI).act z' g' ≫ i =
-        (z' ≫ j) * (g' ≫ i) * (z' ≫ j)⁻¹ := by
-    change (GrpObj.Action.normalConjugation i j).act z' g' ≫ i = _
-    rw [GrpObj.Action.normalConjugation_act, Category.assoc]
-    exact TauCeti.lift_normalConjugation_comp i (z' ≫ j) g'
-  have hpoints := congrArg (CommHopfAlgCat.grpObjPointsMulEquiv H (op A)) hact
-  simp only [i, j, z', g', map_mul, map_inv] at hpoints
-  rw [CommHopfAlgCat.grpObjPointsMulEquiv_comp_quotientGrpObjInclusion,
-    CommHopfAlgCat.grpObjPointsMulEquiv_comp_quotientGrpObjInclusion,
-    CommHopfAlgCat.grpObjPointsMulEquiv_comp_quotientGrpObjInclusion] at hpoints
-  simpa only [MulEquiv.apply_symm_apply] using hpoints
-
 /-- Conjugation of the relative Levi quotient on the normal relative unipotent quotient. -/
 private noncomputable def weightRelativeLeviConjugation (w : Fin N → ℤ) :
     GrpObj.Action
@@ -210,32 +178,6 @@ private noncomputable def weightRelativeLeviConjugation (w : Fin N → ℤ) :
   CommHopfAlgCat.quotientNormalConjugation (weightParabolicCoordinateHopfAlgebra R w)
     (weightUnipotentInParabolicHopfIdeal R w) (weightLeviInParabolicHopfIdeal R w)
     (isNormal_weightUnipotentInParabolicHopfIdeal R w)
-
-/-- Evaluation of represented relative conjugation after transport to dynamic points. -/
-private noncomputable def representedWeightLeviConjugationApply (w : Fin N → ℤ)
-    (A : CommAlgCat.{u} R)
-    (z : Cocharacter.levi A (weightCocharacter (R := R) w))
-    (g : Cocharacter.unipotent A (weightCocharacter (R := R) w)) :
-    Cocharacter.unipotent A (weightCocharacter (R := R) w) := by
-  letI : GrpObj (CommHopfAlgCat.grpObj
-      (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
-        (weightLeviInParabolicHopfIdeal R w))) := CommAlgCat.grpObjOpOf
-  letI : GrpObj (CommHopfAlgCat.grpObj
-      (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
-        (weightUnipotentInParabolicHopfIdeal R w))) := CommAlgCat.grpObjOpOf
-  exact weightUnipotentInParabolicPointsMulEquiv R w A
-    ((CommHopfAlgCat.grpObjPointsMulEquiv
-      (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
-        (weightUnipotentInParabolicHopfIdeal R w)) (op A))
-      ((weightRelativeLeviConjugation R w).act
-        ((CommHopfAlgCat.grpObjPointsMulEquiv
-          (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
-            (weightLeviInParabolicHopfIdeal R w)) (op A)).symm
-          ((weightLeviInParabolicPointsMulEquiv R w A).symm z))
-        ((CommHopfAlgCat.grpObjPointsMulEquiv
-          (CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
-            (weightUnipotentInParabolicHopfIdeal R w)) (op A)).symm
-          ((weightUnipotentInParabolicPointsMulEquiv R w A).symm g))))
 
 /-- The categorical conjugation action of the represented relative Levi subgroup on the
 represented relative unipotent subgroup, transported to dynamic points. -/
@@ -273,14 +215,12 @@ theorem representedWeightLeviConjugation_eq_dynamic (w : Fin N → ℤ)
   intro g
   unfold representedWeightLeviConjugation
   simp only [MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom, MulAut.congr_apply,
-    MulEquiv.trans_apply, GrpObj.Action.toMulAutHom_apply]
-  change representedWeightLeviConjugationApply R w A z g = _
+    MulEquiv.trans_apply, MulEquiv.symm_trans_apply, GrpObj.Action.toMulAutHom_apply]
   apply Subtype.ext
   rw [Cocharacter.coe_leviConjugation_apply]
-  unfold representedWeightLeviConjugationApply
   rw [coe_weightUnipotentInParabolicPointsMulEquiv_apply,
     weightRelativeLeviConjugation,
-    quotientPointsHom_quotientNormalConjugation_apply]
+    CommHopfAlgCat.quotientPointsHom_quotientNormalConjugation_apply]
   simp only [map_mul, map_inv]
   rw [← coe_weightLeviInParabolicPointsMulEquiv_apply,
     ← coe_weightUnipotentInParabolicPointsMulEquiv_apply]

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Normal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Normal.lean
@@ -253,7 +253,7 @@ private theorem mkQuotient_comp_eqToIso {H : _root_.CommHopfAlgCat.{u} R}
 
 /-- The quotient-coordinate isomorphism underlying the identification of the relative
 weight-Levi quotient spectrum. -/
-private noncomputable def weightLeviInParabolicCoordinateIso (w : Fin N → ℤ) :
+noncomputable def weightLeviInParabolicCoordinateIso (w : Fin N → ℤ) :
     weightLeviCoordinateHopfAlgebra R w ≅
       CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
         (weightLeviInParabolicHopfIdeal R w) :=
@@ -263,6 +263,22 @@ private noncomputable def weightLeviInParabolicCoordinateIso (w : Fin N → ℤ)
       (weightParabolicCoordinateMap R w)
       (weightParabolicCoordinateMap_surjective R w)
       (weightLeviInParabolicHopfIdeal R w)
+
+/-- The relative Levi coordinate identification commutes with the two inclusions into the
+ambient general linear coordinate algebra. -/
+@[simp]
+theorem mkQuotient_weightLevi_comp_weightLeviInParabolicCoordinateIso_hom
+    (w : Fin N → ℤ) :
+    CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra R N)
+          (weightLeviDefiningHopfIdeal R w) ≫
+        (weightLeviInParabolicCoordinateIso R w).hom =
+      weightParabolicCoordinateMap R w ≫
+        CommHopfAlgCat.mkQuotient (weightParabolicCoordinateHopfAlgebra R w)
+          (weightLeviInParabolicHopfIdeal R w) := by
+  rw [weightLeviInParabolicCoordinateIso, Iso.trans_hom, ← Category.assoc,
+    mkQuotient_comp_eqToIso (R := R)
+      (weightLeviInParabolicHopfIdeal_comapOfSurjective R w).symm,
+    CommHopfAlgCat.mkQuotient_comp_quotientIsoOfSurjective_hom]
 
 /-- The relative quotient spectrum cut out inside the weight parabolic is canonically
 isomorphic to the weight-Levi group scheme. -/
@@ -385,7 +401,7 @@ theorem weightLeviInParabolicGroupSchemeIso_hom_comp_weightLeviToParabolic
 
 /-- The quotient-coordinate isomorphism underlying the identification of the relative
 weight-unipotent quotient spectrum. -/
-private noncomputable def weightUnipotentInParabolicCoordinateIso (w : Fin N → ℤ) :
+noncomputable def weightUnipotentInParabolicCoordinateIso (w : Fin N → ℤ) :
     weightUnipotentCoordinateHopfAlgebra R w ≅
       CommHopfAlgCat.quotient (weightParabolicCoordinateHopfAlgebra R w)
         (weightUnipotentInParabolicHopfIdeal R w) :=
@@ -395,6 +411,22 @@ private noncomputable def weightUnipotentInParabolicCoordinateIso (w : Fin N →
       (weightParabolicCoordinateMap R w)
       (weightParabolicCoordinateMap_surjective R w)
       (weightUnipotentInParabolicHopfIdeal R w)
+
+/-- The relative unipotent coordinate identification commutes with the two inclusions into the
+ambient general linear coordinate algebra. -/
+@[simp]
+theorem mkQuotient_weightUnipotent_comp_weightUnipotentInParabolicCoordinateIso_hom
+    (w : Fin N → ℤ) :
+    CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra R N)
+          (weightUnipotentDefiningHopfIdeal R w) ≫
+        (weightUnipotentInParabolicCoordinateIso R w).hom =
+      weightParabolicCoordinateMap R w ≫
+        CommHopfAlgCat.mkQuotient (weightParabolicCoordinateHopfAlgebra R w)
+          (weightUnipotentInParabolicHopfIdeal R w) := by
+  rw [weightUnipotentInParabolicCoordinateIso, Iso.trans_hom, ← Category.assoc,
+    mkQuotient_comp_eqToIso (R := R)
+      (weightUnipotentInParabolicHopfIdeal_comapOfSurjective R w).symm,
+    CommHopfAlgCat.mkQuotient_comp_quotientIsoOfSurjective_hom]
 
 /-- The relative quotient spectrum cut out inside the weight parabolic is canonically
 isomorphic to the weight-unipotent group scheme. -/

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Basic.lean
@@ -67,6 +67,40 @@ an action of affine group objects. -/
   letI : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
   exact GrpObj.Action.normalConjugation i j
 
+/-- Evaluating quotient normal conjugation on points and including into the ambient group
+gives conjugation by the included acting point. -/
+theorem quotientPointsHom_quotientNormalConjugation_apply
+    (H : _root_.CommHopfAlgCat.{u} R) (I J : HopfIdeal R H) (hI : I.IsNormal)
+    (A : CommAlgCat.{u} R)
+    (z : HopfAlgebra.points (R := R) (H := quotient H J) A)
+    (g : HopfAlgebra.points (R := R) (H := quotient H I) A) :
+    quotientPointsHom H I A
+        (grpObjPointsMulEquiv (quotient H I) (op A)
+          ((quotientNormalConjugation H I J hI).act
+            ((grpObjPointsMulEquiv (quotient H J) (op A)).symm z)
+            ((grpObjPointsMulEquiv (quotient H I) (op A)).symm g))) =
+      quotientPointsHom H J A z * quotientPointsHom H I A g *
+        (quotientPointsHom H J A z)⁻¹ := by
+  let i := quotientGrpObjInclusion H I
+  let j := quotientGrpObjInclusion H J
+  let z' := (grpObjPointsMulEquiv (quotient H J) (op A)).symm z
+  let g' := (grpObjPointsMulEquiv (quotient H I) (op A)).symm g
+  let _ : IsMonHom.Normal i := (quotientGrpObjInclusion_normal_iff H I).2 hI
+  have hact :
+      (quotientNormalConjugation H I J hI).act z' g' ≫ i =
+        (z' ≫ j) * (g' ≫ i) * (z' ≫ j)⁻¹ := by
+    -- Unfold the exposed quotient action to categorical normal conjugation so its
+    -- pointwise action lemma applies to the chosen quotient inclusions.
+    change (GrpObj.Action.normalConjugation i j).act z' g' ≫ i = _
+    rw [GrpObj.Action.normalConjugation_act, Category.assoc]
+    exact TauCeti.lift_normalConjugation_comp i (z' ≫ j) g'
+  have hpoints := congrArg (grpObjPointsMulEquiv H (op A)) hact
+  simp only [i, j, z', g', map_mul, map_inv] at hpoints
+  rw [grpObjPointsMulEquiv_comp_quotientGrpObjInclusion,
+    grpObjPointsMulEquiv_comp_quotientGrpObjInclusion,
+    grpObjPointsMulEquiv_comp_quotientGrpObjInclusion] at hpoints
+  simpa only [MulEquiv.apply_symm_apply] using hpoints
+
 /-- The coordinate Hopf algebra of the semidirect product of a normal closed affine subgroup
 and another closed affine subgroup. Its underlying commutative algebra is
 `(H / I) ⊗[ R ] (H / J)`, and its Hopf structure records conjugation of the second subgroup


### PR DESCRIPTION
This PR identifies the categorical conjugation action of the represented relative Levi quotient on the represented relative unipotent quotient with the dynamic Levi action on every commutative algebra of points. It exposes the two quotient-coordinate identifications, proves their inclusion triangles into `GL_N`, packages the induced point equivalences, and shows that transporting `CommHopfAlgCat.quotientNormalConjugation` through them gives `Cocharacter.leviConjugation` as an equality of actions.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 7, “Borel subgroups, parabolic subgroups, and Levi decomposition,” on the dynamic route. The designated milestone is the represented dynamic Levi decomposition of a weight parabolic; this is the most effective current step because representability, both subgroup inclusions, normality, the represented retraction, and the pointwise decomposition are already present, while the action comparison is the independent missing bridge between the categorical and dynamic semidirect products. After this PR, the in-flight kernel identification must land and semidirect multiplication `U(w) ⋊ L(w) → P(w)` must be proved to be an isomorphism.

The new module is `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/Action.lean` (291 lines); `TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Normal.lean` gains the two coordinate inclusion triangles (34 additions, 2 deletions). It reuses Mathlib's `MulAut.congr` and Tau Ceti's existing generalized-point, normal-conjugation, and quotient-point APIs; no Mathlib infrastructure or external formalization is vendored. The mathematical organization follows Kempf, *Instability in invariant theory*, §2, and Milne, *Algebraic Groups* (2017), Chapter 13, as cited in the module documentation.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"weight-levi-conjugation-action"}-->

🤖 Prepared with Codex
