### PR TITLE
feat: start the solvable radical construction

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Cotangent.lean
@@ -44,6 +44,8 @@ needed in Layer 2 of the ReductiveGroups roadmap.
   vanishing means that the defining ideal has no linear term at the identity.
 * `TauCeti.HopfIdeal.finrank_quotientLie_add_finrank_conormal`: the resulting dimension formula.
 * `TauCeti.HopfIdeal.finrank_quotientLie_le`: the resulting closed-subgroup dimension bound.
+* `TauCeti.HopfIdeal.exists_maximal_finrank_quotientLie`: every nonempty family of closed
+  subgroups contains one of maximal Lie dimension.
 * `TauCeti.HopfIdeal.finrank_quotientLie_antitone`: inclusion of closed subgroups cannot increase
   Lie dimension.
 
@@ -391,6 +393,44 @@ theorem finrank_quotientLie_le (I : HopfIdeal k H)
         (Derivation k H (Bialgebra.CounitAlgebra k H k)) := by
   have h := finrank_quotientLie_add_finrank_conormal I
   omega
+
+/-- Every nonempty family of closed affine subgroups contains one of maximal Lie dimension.
+
+The family is specified by a predicate on its defining Hopf ideals. Its attained dimensions lie
+in the finite interval from zero to the Lie dimension of the ambient group, so a maximum exists
+without any finiteness assumption on the family itself. -/
+theorem exists_maximal_finrank_quotientLie
+    [FiniteDimensional k (Bialgebra.CotangentSpace k H)]
+    (P : HopfIdeal k H → Prop) (hP : ∃ I, P I) :
+    ∃ I : HopfIdeal k H, P I ∧
+      ∀ J : HopfIdeal k H, P J →
+        Module.finrank k
+            (Derivation k (H ⧸ J.toIdeal)
+              (Bialgebra.CounitAlgebra k (H ⧸ J.toIdeal) k)) ≤
+          Module.finrank k
+            (Derivation k (H ⧸ I.toIdeal)
+              (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) := by
+  let dimensions : Set ℕ := {n | ∃ I : HopfIdeal k H, P I ∧
+    Module.finrank k
+      (Derivation k (H ⧸ I.toIdeal)
+        (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) = n}
+  have hdimensions_finite : dimensions.Finite := by
+    apply (Set.finite_Iic
+      (Module.finrank k (Derivation k H (Bialgebra.CounitAlgebra k H k)))).subset
+    rintro n ⟨I, _, rfl⟩
+    exact finrank_quotientLie_le I
+  have hdimensions_nonempty : dimensions.Nonempty := by
+    obtain ⟨I, hI⟩ := hP
+    exact ⟨_, I, hI, rfl⟩
+  obtain ⟨n, hn, hnmax⟩ :=
+    Set.exists_max_image dimensions id hdimensions_finite hdimensions_nonempty
+  obtain ⟨I, hI, hIn⟩ := hn
+  refine ⟨I, hI, fun J hJ ↦ ?_⟩
+  have hJmem : Module.finrank k
+      (Derivation k (H ⧸ J.toIdeal)
+        (Bialgebra.CounitAlgebra k (H ⧸ J.toIdeal) k)) ∈ dimensions :=
+    ⟨J, hJ, rfl⟩
+  simpa only [id_eq, hIn] using hnmax _ hJmem
 
 /-- Lie dimension is antitone in the defining Hopf ideal: if `I ≤ J`, then the closed subgroup
 cut out by `J` is contained in the one cut out by `I`, so its Lie dimension is no larger. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Basic.lean
@@ -25,7 +25,8 @@ and one of the candidates has maximal Lie dimension.
 To turn a maximal-dimensional candidate into the solvable radical, one must next show that the
 scheme-theoretic multiplication image of two candidates is again a candidate. The connectedness,
 smoothness, and source-solvability results already exist; the remaining input is solvability of
-the image, equivalently the relevant faithfully-flat image theorem.
+the image, for which the current image theorem requires faithful flatness of the canonical Hopf
+image inclusion.
 
 ## Main declarations
 

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Basic.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Solvable
+
+/-!
+# Candidates for the solvable radical
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over a field. A candidate
+for its solvable radical is a connected normal smooth solvable closed subgroup. In Hopf
+coordinates this is a normal Hopf ideal `I` whose quotient `H/I` is geometrically connected,
+smooth, and has a solvable group of geometric points.
+
+This file proves the boundedness step in the maximal-dimension construction. Every
+unipotent-radical candidate is a solvable-radical candidate, so in particular the identity
+subgroup is a candidate. The Lie dimension of every candidate is bounded by that of the ambient
+group. Hence the natural numbers occurring as candidate dimensions form a nonempty finite set,
+and one of the candidates has maximal Lie dimension.
+
+To turn a maximal-dimensional candidate into the solvable radical, one must next show that the
+scheme-theoretic multiplication image of two candidates is again a candidate. The connectedness,
+smoothness, and source-solvability results already exist; the remaining input is solvability of
+the image, equivalently the relevant faithfully-flat image theorem.
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.IsSolvableRadicalCandidate`: a connected normal smooth solvable closed
+  subgroup in coordinate-Hopf-algebra form.
+* `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate.isSolvableRadicalCandidate`: every
+  unipotent-radical candidate is a solvable-radical candidate.
+* `TauCeti.HopfIdeal.isSolvableRadicalCandidate_augmentation`: the identity subgroup is a
+  candidate.
+* `TauCeti.HopfIdeal.exists_isSolvableRadicalCandidate_maximal_finrank_quotientLie`: existence of
+  a solvable-radical candidate of maximal Lie dimension.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§6.45–6.46.
+* A. Borel, *Linear Algebraic Groups*, §11.21.
+
+This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap. The
+radical `R(G)` required there is the greatest connected normal smooth solvable closed subgroup;
+the maximal-dimension candidate constructed here is the first step in that construction.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal
+
+variable {k : Type u} [Field k]
+
+/-- A Hopf ideal cuts out a **solvable-radical candidate** when the represented closed subgroup
+is normal, geometrically connected, smooth, and has a solvable group of geometric points.
+
+Normality is a property of the ideal in the ambient coordinate Hopf algebra. The other three
+conditions are properties of its finite-type quotient coordinate Hopf algebra. -/
+def IsSolvableRadicalCandidate (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (I : HopfIdeal k H) : Prop :=
+  I.IsNormal ∧
+    geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj ∧
+    Algebra.Smooth k (FiniteTypeCommHopfAlgCat.quotient H I) ∧
+    geometricallySolvablePointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj
+
+namespace IsSolvableRadicalCandidate
+
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H}
+
+/-- A normal Hopf ideal with geometrically connected, smooth, solvable quotient is a
+solvable-radical candidate. -/
+theorem mk (h_normal : I.IsNormal)
+    (h_connected : geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj)
+    (h_smooth : Algebra.Smooth k (FiniteTypeCommHopfAlgCat.quotient H I))
+    (h_solvable : geometricallySolvablePointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj) :
+    IsSolvableRadicalCandidate H I :=
+  ⟨h_normal, h_connected, h_smooth, h_solvable⟩
+
+/-- A solvable-radical candidate is normal in the ambient affine group. -/
+theorem isNormal (hI : IsSolvableRadicalCandidate H I) : I.IsNormal :=
+  hI.1
+
+/-- A solvable-radical candidate is geometrically connected. -/
+theorem geometricallyConnected (hI : IsSolvableRadicalCandidate H I) :
+    geometricallyConnectedCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+  hI.2.1
+
+/-- A solvable-radical candidate is smooth. -/
+theorem smooth (hI : IsSolvableRadicalCandidate H I) :
+    Algebra.Smooth k (FiniteTypeCommHopfAlgCat.quotient H I) :=
+  hI.2.2.1
+
+/-- A solvable-radical candidate has a solvable group of geometric points. -/
+theorem geometricallySolvable (hI : IsSolvableRadicalCandidate H I) :
+    geometricallySolvablePointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+  hI.2.2.2
+
+end IsSolvableRadicalCandidate
+
+namespace IsUnipotentRadicalCandidate
+
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I : HopfIdeal k H}
+
+/-- Every unipotent-radical candidate is a solvable-radical candidate. -/
+theorem isSolvableRadicalCandidate (hI : IsUnipotentRadicalCandidate H I) :
+    IsSolvableRadicalCandidate H I := by
+  have hU := (smoothUnipotentCommHopfAlgProperty_iff k
+    (FiniteTypeCommHopfAlgCat.quotient H I)).mp hI.smoothUnipotent
+  have hU' : geometricallyUnipotentPointsCommHopfAlgProperty k
+      (FiniteTypeCommHopfAlgCat.quotient H I).obj :=
+    (geometricallyUnipotentPointsCommHopfAlgProperty_iff k _).mpr hU.2
+  exact IsSolvableRadicalCandidate.mk hI.isNormal hI.geometricallyConnected hU.1
+    (geometricallyUnipotentPointsCommHopfAlgProperty.geometricallySolvable hU')
+
+end IsUnipotentRadicalCandidate
+
+/-- The augmentation ideal cuts out the identity subgroup, hence is a solvable-radical
+candidate. This makes the family of candidates nonempty without any hypothesis on the ambient
+finite-type affine group. -/
+theorem isSolvableRadicalCandidate_augmentation
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    IsSolvableRadicalCandidate H (augmentation k H) :=
+  (isUnipotentRadicalCandidate_augmentation H).isSolvableRadicalCandidate
+
+/-- There exists a connected normal smooth solvable closed subgroup of maximal Lie dimension.
+
+The theorem asserts maximality only among solvable-radical candidates. Turning this candidate
+into the greatest such subgroup requires closure of candidates under scheme-theoretic binary
+products. -/
+theorem exists_isSolvableRadicalCandidate_maximal_finrank_quotientLie
+    (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    ∃ I : HopfIdeal k H,
+      IsSolvableRadicalCandidate H I ∧
+        ∀ J : HopfIdeal k H, IsSolvableRadicalCandidate H J →
+          Module.finrank k
+              (Derivation k (H ⧸ J.toIdeal)
+                (Bialgebra.CounitAlgebra k (H ⧸ J.toIdeal) k)) ≤
+            Module.finrank k
+              (Derivation k (H ⧸ I.toIdeal)
+                (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) := by
+  exact exists_maximal_finrank_quotientLie (IsSolvableRadicalCandidate H)
+    ⟨augmentation k H, isSolvableRadicalCandidate_augmentation H⟩
+
+end HopfIdeal
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Basic.lean
@@ -167,27 +167,8 @@ theorem exists_isUnipotentRadicalCandidate_maximal_finrank_quotientLie
             Module.finrank k
               (Derivation k (H ⧸ I.toIdeal)
                 (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) := by
-  let dimensions : Set ℕ := {n | ∃ I : HopfIdeal k H,
-    IsUnipotentRadicalCandidate H I ∧
-      Module.finrank k
-        (Derivation k (H ⧸ I.toIdeal)
-          (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) = n}
-  have hdimensions_finite : dimensions.Finite := by
-    apply (Set.finite_Iic
-      (Module.finrank k (Derivation k H (Bialgebra.CounitAlgebra k H k)))).subset
-    rintro n ⟨I, _, rfl⟩
-    exact finrank_quotientLie_le I
-  have hdimensions_nonempty : dimensions.Nonempty := by
-    exact ⟨_, augmentation k H, isUnipotentRadicalCandidate_augmentation H, rfl⟩
-  obtain ⟨n, hn, hnmax⟩ :=
-    Set.exists_max_image dimensions id hdimensions_finite hdimensions_nonempty
-  obtain ⟨I, hI, hIn⟩ := hn
-  refine ⟨I, hI, fun J hJ ↦ ?_⟩
-  have hJmem : Module.finrank k
-      (Derivation k (H ⧸ J.toIdeal)
-        (Bialgebra.CounitAlgebra k (H ⧸ J.toIdeal) k)) ∈ dimensions :=
-    ⟨J, hJ, rfl⟩
-  simpa only [id_eq, hIn] using hnmax _ hJmem
+  exact exists_maximal_finrank_quotientLie (IsUnipotentRadicalCandidate H)
+    ⟨augmentation k H, isUnipotentRadicalCandidate_augmentation H⟩
 
 end HopfIdeal
 


### PR DESCRIPTION
This PR starts the solvable-radical construction required by `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “Reductive and semisimple groups,” specifically its target to develop the radical `R(G)` as the maximal connected normal solvable geometric subgroup. It defines the exact coordinate-Hopf-algebra candidates, proves that unipotent-radical candidates are solvable-radical candidates, and chooses a candidate of maximal Lie dimension.

This is the most effective current step because the unipotent radical landed in #4940 and the existing solvability, connectedness, smoothness, normal-product, and cotangent APIs now make the analogous Layer 6 maximal-dimension construction expressible. The new `IsSolvableRadicalCandidate` predicate is exercised nontrivially: every unipotent-radical candidate maps into it, the augmentation ideal supplies the identity candidate, and the maximal-dimension theorem consumes the resulting nonempty family.

The bounded-dimension choice is factored once into `HopfIdeal.exists_maximal_finrank_quotientLie`, which says that every nonempty predicate-defined family of closed subgroups has a member of maximal Lie dimension. The existing unipotent-radical theorem is reimplemented as a specialization of that general result, while the new solvable theorem is a second consumer; this removes the previously local copy instead of introducing a parallel proof.

The new module is `TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Basic.lean` (163 lines). `HopfIdeal/Cotangent.lean` gains the 38-line general maximum theorem and its documentation, and `Unipotent/Radical/Basic.lean` replaces its 27-line local argument with the two-line specialization. In total the PR adds 205 lines and removes 21.

After this PR, the Layer 6 radical target still needs binary-product closure for solvable-radical candidates, then the maximal candidate must be proved greatest and packaged as `R(G)`. The explicit dependency for the product step is solvability of the scheme-theoretic multiplication image: the source semidirect product is already solvable, while the current image theorem requires faithful flatness of the canonical Hopf image inclusion.

The construction follows J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§6.45–6.46, and A. Borel, *Linear Algebraic Groups*, §11.21, as cited in the module documentation. No Mathlib implementation or external formalization is vendored; the proof consumes Tau Ceti’s existing unipotent-to-solvable theorem and Hopf-ideal cotangent dimension bound together with Mathlib’s finite-set maximum API.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"solvable-radical-candidates"}-->

🤖 Prepared with Codex
