### PR TITLE
feat: naturality of the explicit low-degree cup products

### DIFF
--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/CupProduct.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/CupProduct.lean
@@ -55,6 +55,20 @@ of the general inhomogeneous formula
   bidegree `(1,1)` it holds only on classes, with the sign `-1`.
 * `TauCeti.ContCohomology.explicitCup11_comm_of_neg_eq_self`: the `2`-torsion specialization, in
   which the `(1,1)` cup is symmetric.
+* `TauCeti.ContCohomology.explicitMap0_explicitCup00`, `explicitMap1_explicitCup01`,
+  `explicitMap1_explicitCup10`, `explicitMap2_explicitCup02`, `explicitMap2_explicitCup20` and
+  `explicitMap2_explicitCup11`: **naturality in compatible pairs**, one theorem per shape. A
+  continuous homomorphism `φ : H →ₜ* G` and coefficient maps `f_M`, `f_N`, `f_P` intertwining `μ`
+  with an `H`-equivariant pairing `μ'` carry `x ⌣_μ y` to `(φ, f)^* x ⌣_{μ'} (φ, f)^* y`.
+* `TauCeti.ContCohomology.explicitRes0_explicitCup00`, `explicitRes1_explicitCup01`,
+  `explicitRes1_explicitCup10`, `explicitRes2_explicitCup02`, `explicitRes2_explicitCup20` and
+  `explicitRes2_explicitCup11`: **compatibility with restriction**, the instance at the pair
+  `(S ↪ G, id)`, whose restricted equivariance hypothesis is
+  `TauCeti.ContCohomology.equivariant_subgroup`.
+* `TauCeti.ContCohomology.explicitCoeff0_explicitCup00`, `explicitCoeff1_explicitCup01`,
+  `explicitCoeff1_explicitCup10`, `explicitCoeff2_explicitCup02`, `explicitCoeff2_explicitCup20`
+  and `explicitCoeff2_explicitCup11`: **naturality in the pairing**, the instance at the pair
+  `(id, f)`.
 
 ## Implementation notes
 
@@ -97,13 +111,18 @@ This implements the "six low-degree shapes" and "graded commutativity" milestone
 the human-authored roadmap at
 `TauCetiRoadmap/ProfiniteCohomology/README.md`, whose §3 fixes the six formulas and whose
 `Suggested.lean` fixes the names `explicitCup00`, `explicitCup01`, `explicitCup10`,
-`explicitCup02`, `explicitCup11` and `explicitCup20`.
+`explicitCup02`, `explicitCup11` and `explicitCup20`, together with the restriction and
+coefficient-map halves of that layer's "compatibilities" milestone. The inflation half of that
+milestone needs the pairing induced on the `N`-invariants and is not proved here; the projection
+formula is
+`TauCeti/RepresentationTheory/Homological/ContCohomology/ProjectionFormula.lean`.
 
 ## References
 
 * J. Neukirch, A. Schmidt, K. Wingberg, *Cohomology of Number Fields*, 2nd ed., I §4: the cup
-  product on inhomogeneous cochains and its low-degree formulas, and (1.4.4) for graded
-  commutativity.
+  product on inhomogeneous cochains and its low-degree formulas, (1.4.2) for naturality in the
+  coefficients, (1.4.4) for graded commutativity, and (1.5.3)(i) for compatibility with
+  restriction.
 * K. Brown, *Cohomology of Groups*, V §3: the cochain-level cup product, and (3.6) for graded
   commutativity.
 -/
@@ -112,7 +131,7 @@ public section
 
 namespace TauCeti.ContCohomology
 
-universe uG uM uN uP
+universe uG uH uM uN uP
 
 section Pairing
 
@@ -203,6 +222,25 @@ theorem continuous_flip : Continuous fun p : N × M => μ.flip p.1 p.2 :=
   hμ.comp continuous_swap
 
 end Pairing
+
+section PairingSubgroup
+
+variable {G : Type uG} [Group G]
+  {M : Type uM} [AddCommGroup M] [DistribMulAction G M]
+  {N : Type uN} [AddCommGroup N] [DistribMulAction G N]
+  {P : Type uP} [AddCommGroup P] [DistribMulAction G P]
+  (μ : M →+ N →+ P)
+  (hequiv : ∀ (g : G) (m : M) (x : N), μ (g • m) (g • x) = g • μ m x)
+
+include hequiv in
+/-- **An equivariant pairing stays equivariant for the restricted action of a subgroup.** This is
+the hypothesis the restricted cup products below have to be fed; the two scalar actions agree by
+definition, and this is the named form that keeps those statements readable. -/
+theorem equivariant_subgroup (S : Subgroup G) (s : S) (m : M) (x : N) :
+    μ (s • m) (s • x) = s • μ m x :=
+  hequiv (s : G) m x
+
+end PairingSubgroup
 
 section CupZeroZero
 
@@ -770,5 +808,457 @@ theorem explicitCup11_comm_of_neg_eq_self (hP : ∀ x : P, -x = x) (a : H1 G M) 
   rw [explicitCup11_eq_neg_flip G M N P μ hμ hequiv a b, hneg]
 
 end CommOneOne
+
+/-! ### Naturality in compatible pairs
+
+A compatible pair `(φ : H →ₜ* G, f : M →+ M')` in the sense of
+`TauCeti/RepresentationTheory/Homological/ContCohomology/ExplicitFunctoriality.lean` pulls a cup
+product back to a cup product as soon as the two pairings are intertwined by the three coefficient
+maps, `f_P (μ m x) = μ' (f_M m) (f_N x)`. Each of the six shapes gets one such theorem, and each
+proof is the same computation on cochains: the pullback moves the coefficient maps inside `μ`,
+where the intertwining hypothesis turns it into `μ'`, and the translation factor `φ h •` becomes
+`h •` by equivariance of the coefficient map it meets.
+
+The two named instances follow from the descriptions of restriction and of coefficient maps as
+compatible pairs: `explicitRes*_explicitCup**` is the pair `(S ↪ G, id)`, and
+`explicitCoeff*_explicitCup**` is the pair `(id, f)`. -/
+
+section NaturalityZeroZero
+
+variable (G : Type uG) [Group G]
+  (M : Type uM) [AddCommGroup M] [DistribMulAction G M]
+  (N : Type uN) [AddCommGroup N] [DistribMulAction G N]
+  (P : Type uP) [AddCommGroup P] [DistribMulAction G P]
+  (μ : M →+ N →+ P)
+  (hequiv : ∀ (g : G) (m : M) (x : N), μ (g • m) (g • x) = g • μ m x)
+  (H : Type uH) [Group H]
+  (M' : Type*) [AddCommGroup M'] [DistribMulAction H M']
+  (N' : Type*) [AddCommGroup N'] [DistribMulAction H N']
+  (P' : Type*) [AddCommGroup P'] [DistribMulAction H P']
+  (μ' : M' →+ N' →+ P')
+  (hequiv' : ∀ (h : H) (m : M') (x : N'), μ' (h • m) (h • x) = h • μ' m x)
+  (φ : H →* G) (fM : M →+ M') (fN : N →+ N') (fP : P →+ P')
+  (hfM : ∀ (h : H) (m : M), fM (φ h • m) = h • fM m)
+  (hfN : ∀ (h : H) (x : N), fN (φ h • x) = h • fN x)
+  (hfP : ∀ (h : H) (x : P), fP (φ h • x) = h • fP x)
+  (hpair : ∀ (m : M) (x : N), fP (μ m x) = μ' (fM m) (fN x))
+
+include hpair in
+/-- **Naturality of the `(0,0)` cup product in compatible pairs.** In degree zero the cup product
+*is* the pairing, so the statement is the intertwining hypothesis read on invariant elements. -/
+theorem explicitMap0_explicitCup00 (m : H0 G M) (x : H0 G N) :
+    explicitMap0 G P φ fP hfP (explicitCup00 G M N P μ hequiv m x) =
+      explicitCup00 H M' N' P' μ' hequiv'
+        (explicitMap0 G M φ fM hfM m) (explicitMap0 G N φ fN hfN x) :=
+  Subtype.ext (by simp [hpair])
+
+/-- **The `(0,0)` cup product commutes with restriction** (NSW (1.5.3)(i)). -/
+theorem explicitRes0_explicitCup00 (S : Subgroup G) (m : H0 G M) (x : H0 G N) :
+    explicitRes0 G P S (explicitCup00 G M N P μ hequiv m x) =
+      explicitCup00 S M N P μ (equivariant_subgroup μ hequiv S)
+        (explicitRes0 G M S m) (explicitRes0 G N S x) :=
+  Subtype.ext (by simp)
+
+end NaturalityZeroZero
+
+section NaturalityZeroOne
+
+variable (G : Type uG) [Group G] [TopologicalSpace G]
+  (M : Type uM) [AddCommGroup M] [TopologicalSpace M] [DistribMulAction G M]
+  (N : Type uN) [AddCommGroup N] [TopologicalSpace N] [IsTopologicalAddGroup N]
+    [DistribMulAction G N] [ContinuousSMul G N]
+  (P : Type uP) [AddCommGroup P] [TopologicalSpace P] [IsTopologicalAddGroup P]
+    [DistribMulAction G P] [ContinuousSMul G P]
+  (μ : M →+ N →+ P) (hμ : Continuous fun p : M × N => μ p.1 p.2)
+  (hequiv : ∀ (g : G) (m : M) (x : N), μ (g • m) (g • x) = g • μ m x)
+  (H : Type uH) [Group H] [TopologicalSpace H]
+  (M' : Type*) [AddCommGroup M'] [TopologicalSpace M'] [DistribMulAction H M']
+  (N' : Type*) [AddCommGroup N'] [TopologicalSpace N'] [IsTopologicalAddGroup N']
+    [DistribMulAction H N'] [ContinuousSMul H N']
+  (P' : Type*) [AddCommGroup P'] [TopologicalSpace P'] [IsTopologicalAddGroup P']
+    [DistribMulAction H P'] [ContinuousSMul H P']
+  (μ' : M' →+ N' →+ P') (hμ' : Continuous fun p : M' × N' => μ' p.1 p.2)
+  (hequiv' : ∀ (h : H) (m : M') (x : N'), μ' (h • m) (h • x) = h • μ' m x)
+  (φ : H →ₜ* G) (fM : M →+ M') (fN : N →+ N') (fP : P →+ P')
+  (hcN : Continuous fN) (hcP : Continuous fP)
+  (hfM : ∀ (h : H) (m : M), fM (φ h • m) = h • fM m)
+  (hfN : ∀ (h : H) (x : N), fN (φ h • x) = h • fN x)
+  (hfP : ∀ (h : H) (x : P), fP (φ h • x) = h • fP x)
+  (hpair : ∀ (m : M) (x : N), fP (μ m x) = μ' (fM m) (fN x))
+
+include hpair in
+/-- **Naturality of the `(0,1)` cup product in compatible pairs.** -/
+theorem explicitMap1_explicitCup01 (m : H0 G M) (b : H1 G N) :
+    explicitMap1 G P H P' φ fP hcP hfP (explicitCup01 G M N P μ hμ hequiv m b) =
+      explicitCup01 H M' N' P' μ' hμ' hequiv'
+        (explicitMap0 G M (φ : H →* G) fM hfM m)
+        (explicitMap1 G N H N' φ fN hcN hfN b) := by
+  -- `coe_explicitMap0` is supplied as a local equation rather than left to `simp`: the group map
+  -- of the degree-zero pullback is the `MonoidHom` coercion of `φ`, which `simp` will not match
+  -- against the `ContinuousMonoidHom` application appearing in `hfM`.
+  have hcoe : ((explicitMap0 G M (φ : H →* G) fM hfM m : M')) = fM (m : M) :=
+    coe_explicitMap0 G M (φ : H →* G) fM hfM m
+  induction b using QuotientAddGroup.induction_on with
+  | _ c =>
+    simp only [explicitCup01_mk, explicitMap1_mk]
+    exact congrArg (fun z : Z1 H P' => (z : H1 H P'))
+      (Subtype.ext (funext fun h => by simp [cocyclesMap1_coe, hcoe, hpair]))
+
+/-- **The `(0,1)` cup product commutes with restriction** (NSW (1.5.3)(i)). -/
+theorem explicitRes1_explicitCup01 (S : Subgroup G) (m : H0 G M) (b : H1 G N) :
+    explicitRes1 G P S (explicitCup01 G M N P μ hμ hequiv m b) =
+      explicitCup01 S M N P μ hμ (equivariant_subgroup μ hequiv S)
+        (explicitRes0 G M S m) (explicitRes1 G N S b) := by
+  simp only [explicitRes0_eq_explicitMap0, explicitRes1_eq_explicitMap1]
+  exact explicitMap1_explicitCup01 G M N P μ hμ hequiv S M N P μ hμ
+    (equivariant_subgroup μ hequiv S)
+    (ContinuousMonoidHom.subgroupSubtype S) (AddMonoidHom.id M) (AddMonoidHom.id N)
+    (AddMonoidHom.id P) continuous_id continuous_id (id_subgroupSubtype_smul G M S)
+    (id_subgroupSubtype_smul G N S) (id_subgroupSubtype_smul G P S) (fun _ _ => rfl) m b
+
+end NaturalityZeroOne
+
+section NaturalityOneZero
+
+variable (G : Type uG) [Group G] [TopologicalSpace G]
+  (M : Type uM) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+    [DistribMulAction G M] [ContinuousSMul G M]
+  (N : Type uN) [AddCommGroup N] [TopologicalSpace N] [DistribMulAction G N]
+  (P : Type uP) [AddCommGroup P] [TopologicalSpace P] [IsTopologicalAddGroup P]
+    [DistribMulAction G P] [ContinuousSMul G P]
+  (μ : M →+ N →+ P) (hμ : Continuous fun p : M × N => μ p.1 p.2)
+  (hequiv : ∀ (g : G) (m : M) (x : N), μ (g • m) (g • x) = g • μ m x)
+  (H : Type uH) [Group H] [TopologicalSpace H]
+  (M' : Type*) [AddCommGroup M'] [TopologicalSpace M'] [IsTopologicalAddGroup M']
+    [DistribMulAction H M'] [ContinuousSMul H M']
+  (N' : Type*) [AddCommGroup N'] [TopologicalSpace N'] [DistribMulAction H N']
+  (P' : Type*) [AddCommGroup P'] [TopologicalSpace P'] [IsTopologicalAddGroup P']
+    [DistribMulAction H P'] [ContinuousSMul H P']
+  (μ' : M' →+ N' →+ P') (hμ' : Continuous fun p : M' × N' => μ' p.1 p.2)
+  (hequiv' : ∀ (h : H) (m : M') (x : N'), μ' (h • m) (h • x) = h • μ' m x)
+  (φ : H →ₜ* G) (fM : M →+ M') (fN : N →+ N') (fP : P →+ P')
+  (hcM : Continuous fM) (hcP : Continuous fP)
+  (hfM : ∀ (h : H) (m : M), fM (φ h • m) = h • fM m)
+  (hfN : ∀ (h : H) (x : N), fN (φ h • x) = h • fN x)
+  (hfP : ∀ (h : H) (x : P), fP (φ h • x) = h • fP x)
+  (hpair : ∀ (m : M) (x : N), fP (μ m x) = μ' (fM m) (fN x))
+
+include hpair in
+/-- **Naturality of the `(1,0)` cup product in compatible pairs.** The translation factor of the
+`(1,0)` formula is carried across by equivariance of `f_N`, even though it acts on an invariant
+element. -/
+theorem explicitMap1_explicitCup10 (a : H1 G M) (n : H0 G N) :
+    explicitMap1 G P H P' φ fP hcP hfP (explicitCup10 G M N P μ hμ hequiv a n) =
+      explicitCup10 H M' N' P' μ' hμ' hequiv'
+        (explicitMap1 G M H M' φ fM hcM hfM a)
+        (explicitMap0 G N (φ : H →* G) fN hfN n) := by
+  -- As in the `(0,1)` shape, `coe_explicitMap0` is supplied explicitly because `simp` cannot
+  -- match the `MonoidHom` coercion of `φ` against the `ContinuousMonoidHom` application in `hfN`.
+  have hcoe : ((explicitMap0 G N (φ : H →* G) fN hfN n : N')) = fN (n : N) :=
+    coe_explicitMap0 G N (φ : H →* G) fN hfN n
+  induction a using QuotientAddGroup.induction_on with
+  | _ c =>
+    simp only [explicitCup10_mk, explicitMap1_mk]
+    exact congrArg (fun z : Z1 H P' => (z : H1 H P'))
+      (Subtype.ext (funext fun h => by simp [cocyclesMap1_coe, hcoe, hpair, hfN]))
+
+/-- **The `(1,0)` cup product commutes with restriction** (NSW (1.5.3)(i)). -/
+theorem explicitRes1_explicitCup10 (S : Subgroup G) (a : H1 G M) (n : H0 G N) :
+    explicitRes1 G P S (explicitCup10 G M N P μ hμ hequiv a n) =
+      explicitCup10 S M N P μ hμ (equivariant_subgroup μ hequiv S)
+        (explicitRes1 G M S a) (explicitRes0 G N S n) := by
+  simp only [explicitRes0_eq_explicitMap0, explicitRes1_eq_explicitMap1]
+  exact explicitMap1_explicitCup10 G M N P μ hμ hequiv S M N P μ hμ
+    (equivariant_subgroup μ hequiv S)
+    (ContinuousMonoidHom.subgroupSubtype S) (AddMonoidHom.id M) (AddMonoidHom.id N)
+    (AddMonoidHom.id P) continuous_id continuous_id (id_subgroupSubtype_smul G M S)
+    (id_subgroupSubtype_smul G N S) (id_subgroupSubtype_smul G P S) (fun _ _ => rfl) a n
+
+end NaturalityOneZero
+
+section NaturalityZeroTwo
+
+variable (G : Type uG) [Group G] [TopologicalSpace G] [ContinuousMul G]
+  (M : Type uM) [AddCommGroup M] [TopologicalSpace M] [DistribMulAction G M]
+  (N : Type uN) [AddCommGroup N] [TopologicalSpace N] [IsTopologicalAddGroup N]
+    [DistribMulAction G N] [ContinuousSMul G N]
+  (P : Type uP) [AddCommGroup P] [TopologicalSpace P] [IsTopologicalAddGroup P]
+    [DistribMulAction G P] [ContinuousSMul G P]
+  (μ : M →+ N →+ P) (hμ : Continuous fun p : M × N => μ p.1 p.2)
+  (hequiv : ∀ (g : G) (m : M) (x : N), μ (g • m) (g • x) = g • μ m x)
+  (H : Type uH) [Group H] [TopologicalSpace H] [ContinuousMul H]
+  (M' : Type*) [AddCommGroup M'] [TopologicalSpace M'] [DistribMulAction H M']
+  (N' : Type*) [AddCommGroup N'] [TopologicalSpace N'] [IsTopologicalAddGroup N']
+    [DistribMulAction H N'] [ContinuousSMul H N']
+  (P' : Type*) [AddCommGroup P'] [TopologicalSpace P'] [IsTopologicalAddGroup P']
+    [DistribMulAction H P'] [ContinuousSMul H P']
+  (μ' : M' →+ N' →+ P') (hμ' : Continuous fun p : M' × N' => μ' p.1 p.2)
+  (hequiv' : ∀ (h : H) (m : M') (x : N'), μ' (h • m) (h • x) = h • μ' m x)
+  (φ : H →ₜ* G) (fM : M →+ M') (fN : N →+ N') (fP : P →+ P')
+  (hcN : Continuous fN) (hcP : Continuous fP)
+  (hfM : ∀ (h : H) (m : M), fM (φ h • m) = h • fM m)
+  (hfN : ∀ (h : H) (x : N), fN (φ h • x) = h • fN x)
+  (hfP : ∀ (h : H) (x : P), fP (φ h • x) = h • fP x)
+  (hpair : ∀ (m : M) (x : N), fP (μ m x) = μ' (fM m) (fN x))
+
+include hpair in
+/-- **Naturality of the `(0,2)` cup product in compatible pairs.** -/
+theorem explicitMap2_explicitCup02 (m : H0 G M) (b : H2 G N) :
+    explicitMap2 G P H P' φ fP hcP hfP (explicitCup02 G M N P μ hμ hequiv m b) =
+      explicitCup02 H M' N' P' μ' hμ' hequiv'
+        (explicitMap0 G M (φ : H →* G) fM hfM m)
+        (explicitMap2 G N H N' φ fN hcN hfN b) := by
+  -- `coe_explicitMap0` is supplied as a local equation rather than left to `simp`: the group map
+  -- of the degree-zero pullback is the `MonoidHom` coercion of `φ`, which `simp` will not match
+  -- against the `ContinuousMonoidHom` application appearing in `hfM`.
+  have hcoe : ((explicitMap0 G M (φ : H →* G) fM hfM m : M')) = fM (m : M) :=
+    coe_explicitMap0 G M (φ : H →* G) fM hfM m
+  induction b using QuotientAddGroup.induction_on with
+  | _ c =>
+    simp only [explicitCup02_mk, explicitMap2_mk]
+    exact congrArg (fun z : Z2 H P' => (z : H2 H P'))
+      (Subtype.ext (funext fun q => by
+        obtain ⟨h, k⟩ := q
+        simp [cocyclesMap2_coe, hcoe, hpair]))
+
+/-- **The `(0,2)` cup product commutes with restriction** (NSW (1.5.3)(i)). -/
+theorem explicitRes2_explicitCup02 (S : Subgroup G) [ContinuousMul S] (m : H0 G M) (b : H2 G N) :
+    explicitRes2 G P S (explicitCup02 G M N P μ hμ hequiv m b) =
+      explicitCup02 S M N P μ hμ (equivariant_subgroup μ hequiv S)
+        (explicitRes0 G M S m) (explicitRes2 G N S b) := by
+  simp only [explicitRes0_eq_explicitMap0, explicitRes2_eq_explicitMap2]
+  exact explicitMap2_explicitCup02 G M N P μ hμ hequiv S M N P μ hμ
+    (equivariant_subgroup μ hequiv S)
+    (ContinuousMonoidHom.subgroupSubtype S) (AddMonoidHom.id M) (AddMonoidHom.id N)
+    (AddMonoidHom.id P) continuous_id continuous_id (id_subgroupSubtype_smul G M S)
+    (id_subgroupSubtype_smul G N S) (id_subgroupSubtype_smul G P S) (fun _ _ => rfl) m b
+
+end NaturalityZeroTwo
+
+section NaturalityTwoZero
+
+variable (G : Type uG) [Group G] [TopologicalSpace G] [ContinuousMul G]
+  (M : Type uM) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+    [DistribMulAction G M] [ContinuousSMul G M]
+  (N : Type uN) [AddCommGroup N] [TopologicalSpace N] [DistribMulAction G N]
+  (P : Type uP) [AddCommGroup P] [TopologicalSpace P] [IsTopologicalAddGroup P]
+    [DistribMulAction G P] [ContinuousSMul G P]
+  (μ : M →+ N →+ P) (hμ : Continuous fun p : M × N => μ p.1 p.2)
+  (hequiv : ∀ (g : G) (m : M) (x : N), μ (g • m) (g • x) = g • μ m x)
+  (H : Type uH) [Group H] [TopologicalSpace H] [ContinuousMul H]
+  (M' : Type*) [AddCommGroup M'] [TopologicalSpace M'] [IsTopologicalAddGroup M']
+    [DistribMulAction H M'] [ContinuousSMul H M']
+  (N' : Type*) [AddCommGroup N'] [TopologicalSpace N'] [DistribMulAction H N']
+  (P' : Type*) [AddCommGroup P'] [TopologicalSpace P'] [IsTopologicalAddGroup P']
+    [DistribMulAction H P'] [ContinuousSMul H P']
+  (μ' : M' →+ N' →+ P') (hμ' : Continuous fun p : M' × N' => μ' p.1 p.2)
+  (hequiv' : ∀ (h : H) (m : M') (x : N'), μ' (h • m) (h • x) = h • μ' m x)
+  (φ : H →ₜ* G) (fM : M →+ M') (fN : N →+ N') (fP : P →+ P')
+  (hcM : Continuous fM) (hcP : Continuous fP)
+  (hfM : ∀ (h : H) (m : M), fM (φ h • m) = h • fM m)
+  (hfN : ∀ (h : H) (x : N), fN (φ h • x) = h • fN x)
+  (hfP : ∀ (h : H) (x : P), fP (φ h • x) = h • fP x)
+  (hpair : ∀ (m : M) (x : N), fP (μ m x) = μ' (fM m) (fN x))
+
+include hpair in
+/-- **Naturality of the `(2,0)` cup product in compatible pairs.** The translation factor of the
+`(2,0)` formula is `(φ h * φ k) •`, which multiplicativity of `φ` turns into `φ (h * k) •` before
+equivariance of `f_N` applies. -/
+theorem explicitMap2_explicitCup20 (a : H2 G M) (n : H0 G N) :
+    explicitMap2 G P H P' φ fP hcP hfP (explicitCup20 G M N P μ hμ hequiv a n) =
+      explicitCup20 H M' N' P' μ' hμ' hequiv'
+        (explicitMap2 G M H M' φ fM hcM hfM a)
+        (explicitMap0 G N (φ : H →* G) fN hfN n) := by
+  -- As in the `(0,1)` shape, `coe_explicitMap0` is supplied explicitly because `simp` cannot
+  -- match the `MonoidHom` coercion of `φ` against the `ContinuousMonoidHom` application in `hfN`.
+  have hcoe : ((explicitMap0 G N (φ : H →* G) fN hfN n : N')) = fN (n : N) :=
+    coe_explicitMap0 G N (φ : H →* G) fN hfN n
+  have hmul : ∀ (h k : H) (x : N), fN ((φ h * φ k) • x) = (h * k) • fN x := fun h k x => by
+    rw [← map_mul]
+    exact hfN (h * k) x
+  induction a using QuotientAddGroup.induction_on with
+  | _ c =>
+    simp only [explicitCup20_mk, explicitMap2_mk]
+    exact congrArg (fun z : Z2 H P' => (z : H2 H P'))
+      (Subtype.ext (funext fun q => by
+        obtain ⟨h, k⟩ := q
+        simp [cocyclesMap2_coe, hcoe, hpair, hmul]))
+
+/-- **The `(2,0)` cup product commutes with restriction** (NSW (1.5.3)(i)). -/
+theorem explicitRes2_explicitCup20 (S : Subgroup G) [ContinuousMul S] (a : H2 G M) (n : H0 G N) :
+    explicitRes2 G P S (explicitCup20 G M N P μ hμ hequiv a n) =
+      explicitCup20 S M N P μ hμ (equivariant_subgroup μ hequiv S)
+        (explicitRes2 G M S a) (explicitRes0 G N S n) := by
+  simp only [explicitRes0_eq_explicitMap0, explicitRes2_eq_explicitMap2]
+  exact explicitMap2_explicitCup20 G M N P μ hμ hequiv S M N P μ hμ
+    (equivariant_subgroup μ hequiv S)
+    (ContinuousMonoidHom.subgroupSubtype S) (AddMonoidHom.id M) (AddMonoidHom.id N)
+    (AddMonoidHom.id P) continuous_id continuous_id (id_subgroupSubtype_smul G M S)
+    (id_subgroupSubtype_smul G N S) (id_subgroupSubtype_smul G P S) (fun _ _ => rfl) a n
+
+end NaturalityTwoZero
+
+section NaturalityOneOne
+
+variable (G : Type uG) [Group G] [TopologicalSpace G] [ContinuousMul G]
+  (M : Type uM) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+    [DistribMulAction G M] [ContinuousSMul G M]
+  (N : Type uN) [AddCommGroup N] [TopologicalSpace N] [IsTopologicalAddGroup N]
+    [DistribMulAction G N] [ContinuousSMul G N]
+  (P : Type uP) [AddCommGroup P] [TopologicalSpace P] [IsTopologicalAddGroup P]
+    [DistribMulAction G P] [ContinuousSMul G P]
+  (μ : M →+ N →+ P) (hμ : Continuous fun p : M × N => μ p.1 p.2)
+  (hequiv : ∀ (g : G) (m : M) (x : N), μ (g • m) (g • x) = g • μ m x)
+  (H : Type uH) [Group H] [TopologicalSpace H] [ContinuousMul H]
+  (M' : Type*) [AddCommGroup M'] [TopologicalSpace M'] [IsTopologicalAddGroup M']
+    [DistribMulAction H M'] [ContinuousSMul H M']
+  (N' : Type*) [AddCommGroup N'] [TopologicalSpace N'] [IsTopologicalAddGroup N']
+    [DistribMulAction H N'] [ContinuousSMul H N']
+  (P' : Type*) [AddCommGroup P'] [TopologicalSpace P'] [IsTopologicalAddGroup P']
+    [DistribMulAction H P'] [ContinuousSMul H P']
+  (μ' : M' →+ N' →+ P') (hμ' : Continuous fun p : M' × N' => μ' p.1 p.2)
+  (hequiv' : ∀ (h : H) (m : M') (x : N'), μ' (h • m) (h • x) = h • μ' m x)
+  (φ : H →ₜ* G) (fM : M →+ M') (fN : N →+ N') (fP : P →+ P')
+  (hcM : Continuous fM) (hcN : Continuous fN) (hcP : Continuous fP)
+  (hfM : ∀ (h : H) (m : M), fM (φ h • m) = h • fM m)
+  (hfN : ∀ (h : H) (x : N), fN (φ h • x) = h • fN x)
+  (hfP : ∀ (h : H) (x : P), fP (φ h • x) = h • fP x)
+  (hpair : ∀ (m : M) (x : N), fP (μ m x) = μ' (fM m) (fN x))
+
+include hpair in
+/-- **Naturality of the `(1,1)` cup product in compatible pairs.** This is the only shape that is
+not a coefficient map, so it is also the only one whose naturality does not already follow from
+the composition law `TauCeti.ContCohomology.explicitMap1_comp`. -/
+theorem explicitMap2_explicitCup11 (a : H1 G M) (b : H1 G N) :
+    explicitMap2 G P H P' φ fP hcP hfP (explicitCup11 G M N P μ hμ hequiv a b) =
+      explicitCup11 H M' N' P' μ' hμ' hequiv'
+        (explicitMap1 G M H M' φ fM hcM hfM a)
+        (explicitMap1 G N H N' φ fN hcN hfN b) := by
+  induction a using QuotientAddGroup.induction_on with
+  | _ x =>
+    induction b using QuotientAddGroup.induction_on with
+    | _ y =>
+      simp only [explicitCup11_mk, explicitMap1_mk, explicitMap2_mk]
+      exact congrArg (fun z : Z2 H P' => (z : H2 H P'))
+        (Subtype.ext (funext fun q => by
+          obtain ⟨h, k⟩ := q
+          simp [cocyclesMap1_coe, cocyclesMap2_coe, hpair, hfN]))
+
+/-- **The `(1,1)` cup product commutes with restriction** (NSW (1.5.3)(i)). -/
+theorem explicitRes2_explicitCup11 (S : Subgroup G) [ContinuousMul S] (a : H1 G M) (b : H1 G N) :
+    explicitRes2 G P S (explicitCup11 G M N P μ hμ hequiv a b) =
+      explicitCup11 S M N P μ hμ (equivariant_subgroup μ hequiv S)
+        (explicitRes1 G M S a) (explicitRes1 G N S b) := by
+  simp only [explicitRes1_eq_explicitMap1, explicitRes2_eq_explicitMap2]
+  exact explicitMap2_explicitCup11 G M N P μ hμ hequiv S M N P μ hμ
+    (equivariant_subgroup μ hequiv S)
+    (ContinuousMonoidHom.subgroupSubtype S) (AddMonoidHom.id M) (AddMonoidHom.id N)
+    (AddMonoidHom.id P) continuous_id continuous_id continuous_id
+    (id_subgroupSubtype_smul G M S) (id_subgroupSubtype_smul G N S)
+    (id_subgroupSubtype_smul G P S) (fun _ _ => rfl) a b
+
+end NaturalityOneOne
+
+section NaturalityCoefficients
+
+/-! The coefficient-map instances of the six naturality theorems, NSW (1.4.2): the compatible pair
+is `(id, f)`, the group does not move, and the intertwining hypothesis is naturality of the cup
+product in the pairing. -/
+
+variable (G : Type uG) [Group G] [TopologicalSpace G] [ContinuousMul G]
+  (M : Type uM) [AddCommGroup M] [TopologicalSpace M] [IsTopologicalAddGroup M]
+    [DistribMulAction G M] [ContinuousSMul G M]
+  (N : Type uN) [AddCommGroup N] [TopologicalSpace N] [IsTopologicalAddGroup N]
+    [DistribMulAction G N] [ContinuousSMul G N]
+  (P : Type uP) [AddCommGroup P] [TopologicalSpace P] [IsTopologicalAddGroup P]
+    [DistribMulAction G P] [ContinuousSMul G P]
+  (M' : Type*) [AddCommGroup M'] [TopologicalSpace M'] [IsTopologicalAddGroup M']
+    [DistribMulAction G M'] [ContinuousSMul G M']
+  (N' : Type*) [AddCommGroup N'] [TopologicalSpace N'] [IsTopologicalAddGroup N']
+    [DistribMulAction G N'] [ContinuousSMul G N']
+  (P' : Type*) [AddCommGroup P'] [TopologicalSpace P'] [IsTopologicalAddGroup P']
+    [DistribMulAction G P'] [ContinuousSMul G P']
+  (μ : M →+ N →+ P) (hμ : Continuous fun p : M × N => μ p.1 p.2)
+  (hequiv : ∀ (g : G) (m : M) (x : N), μ (g • m) (g • x) = g • μ m x)
+  (μ' : M' →+ N' →+ P') (hμ' : Continuous fun p : M' × N' => μ' p.1 p.2)
+  (hequiv' : ∀ (g : G) (m : M') (x : N'), μ' (g • m) (g • x) = g • μ' m x)
+  (fM : M →+[G] M') (fN : N →+[G] N') (fP : P →+[G] P')
+  (hcM : Continuous fM) (hcN : Continuous fN) (hcP : Continuous fP)
+  (hpair : ∀ (m : M) (x : N), fP (μ m x) = μ' (fM m) (fN x))
+
+include hpair
+
+omit [TopologicalSpace G] [ContinuousMul G] [TopologicalSpace M] [IsTopologicalAddGroup M]
+  [ContinuousSMul G M] [TopologicalSpace N] [IsTopologicalAddGroup N] [ContinuousSMul G N]
+  [TopologicalSpace P] [IsTopologicalAddGroup P] [ContinuousSMul G P] [TopologicalSpace M']
+  [IsTopologicalAddGroup M'] [ContinuousSMul G M'] [TopologicalSpace N']
+  [IsTopologicalAddGroup N'] [ContinuousSMul G N'] [TopologicalSpace P']
+  [IsTopologicalAddGroup P'] [ContinuousSMul G P'] in
+/-- **Naturality of the `(0,0)` cup product in the coefficient maps** (NSW (1.4.2)). -/
+theorem explicitCoeff0_explicitCup00 (m : H0 G M) (x : H0 G N) :
+    explicitCoeff0 G P fP (explicitCup00 G M N P μ hequiv m x) =
+      explicitCup00 G M' N' P' μ' hequiv'
+        (explicitCoeff0 G M fM m) (explicitCoeff0 G N fN x) :=
+  Subtype.ext (by simp [hpair])
+
+omit [ContinuousMul G] [IsTopologicalAddGroup M] [ContinuousSMul G M]
+  [IsTopologicalAddGroup M'] [ContinuousSMul G M'] in
+/-- **Naturality of the `(0,1)` cup product in the coefficient maps** (NSW (1.4.2)). -/
+theorem explicitCoeff1_explicitCup01 (m : H0 G M) (b : H1 G N) :
+    explicitCoeff1 G P fP hcP (explicitCup01 G M N P μ hμ hequiv m b) =
+      explicitCup01 G M' N' P' μ' hμ' hequiv'
+        (explicitCoeff0 G M fM m) (explicitCoeff1 G N fN hcN b) := by
+  simp only [explicitCoeff0_eq_explicitMap0, explicitCoeff1_eq_explicitMap1]
+  exact explicitMap1_explicitCup01 G M N P μ hμ hequiv G M' N' P' μ' hμ' hequiv'
+    (ContinuousMonoidHom.id G) fM fN fP hcN hcP (fun g m => fM.map_smul g m)
+    (fun g x => fN.map_smul g x) (fun g x => fP.map_smul g x) hpair m b
+
+omit [ContinuousMul G] [IsTopologicalAddGroup N] [ContinuousSMul G N]
+  [IsTopologicalAddGroup N'] [ContinuousSMul G N'] in
+/-- **Naturality of the `(1,0)` cup product in the coefficient maps** (NSW (1.4.2)). -/
+theorem explicitCoeff1_explicitCup10 (a : H1 G M) (n : H0 G N) :
+    explicitCoeff1 G P fP hcP (explicitCup10 G M N P μ hμ hequiv a n) =
+      explicitCup10 G M' N' P' μ' hμ' hequiv'
+        (explicitCoeff1 G M fM hcM a) (explicitCoeff0 G N fN n) := by
+  simp only [explicitCoeff0_eq_explicitMap0, explicitCoeff1_eq_explicitMap1]
+  exact explicitMap1_explicitCup10 G M N P μ hμ hequiv G M' N' P' μ' hμ' hequiv'
+    (ContinuousMonoidHom.id G) fM fN fP hcM hcP (fun g m => fM.map_smul g m)
+    (fun g x => fN.map_smul g x) (fun g x => fP.map_smul g x) hpair a n
+
+omit [IsTopologicalAddGroup M] [ContinuousSMul G M] [IsTopologicalAddGroup M']
+  [ContinuousSMul G M'] in
+/-- **Naturality of the `(0,2)` cup product in the coefficient maps** (NSW (1.4.2)). -/
+theorem explicitCoeff2_explicitCup02 (m : H0 G M) (b : H2 G N) :
+    explicitCoeff2 G P fP hcP (explicitCup02 G M N P μ hμ hequiv m b) =
+      explicitCup02 G M' N' P' μ' hμ' hequiv'
+        (explicitCoeff0 G M fM m) (explicitCoeff2 G N fN hcN b) := by
+  simp only [explicitCoeff0_eq_explicitMap0, explicitCoeff2_eq_explicitMap2]
+  exact explicitMap2_explicitCup02 G M N P μ hμ hequiv G M' N' P' μ' hμ' hequiv'
+    (ContinuousMonoidHom.id G) fM fN fP hcN hcP (fun g m => fM.map_smul g m)
+    (fun g x => fN.map_smul g x) (fun g x => fP.map_smul g x) hpair m b
+
+omit [IsTopologicalAddGroup N] [ContinuousSMul G N] [IsTopologicalAddGroup N']
+  [ContinuousSMul G N'] in
+/-- **Naturality of the `(2,0)` cup product in the coefficient maps** (NSW (1.4.2)). -/
+theorem explicitCoeff2_explicitCup20 (a : H2 G M) (n : H0 G N) :
+    explicitCoeff2 G P fP hcP (explicitCup20 G M N P μ hμ hequiv a n) =
+      explicitCup20 G M' N' P' μ' hμ' hequiv'
+        (explicitCoeff2 G M fM hcM a) (explicitCoeff0 G N fN n) := by
+  simp only [explicitCoeff0_eq_explicitMap0, explicitCoeff2_eq_explicitMap2]
+  exact explicitMap2_explicitCup20 G M N P μ hμ hequiv G M' N' P' μ' hμ' hequiv'
+    (ContinuousMonoidHom.id G) fM fN fP hcM hcP (fun g m => fM.map_smul g m)
+    (fun g x => fN.map_smul g x) (fun g x => fP.map_smul g x) hpair a n
+
+/-- **Naturality of the `(1,1)` cup product in the coefficient maps** (NSW (1.4.2)). -/
+theorem explicitCoeff2_explicitCup11 (a : H1 G M) (b : H1 G N) :
+    explicitCoeff2 G P fP hcP (explicitCup11 G M N P μ hμ hequiv a b) =
+      explicitCup11 G M' N' P' μ' hμ' hequiv'
+        (explicitCoeff1 G M fM hcM a) (explicitCoeff1 G N fN hcN b) := by
+  simp only [explicitCoeff1_eq_explicitMap1, explicitCoeff2_eq_explicitMap2]
+  exact explicitMap2_explicitCup11 G M N P μ hμ hequiv G M' N' P' μ' hμ' hequiv'
+    (ContinuousMonoidHom.id G) fM fN fP hcM hcN hcP (fun g m => fM.map_smul g m)
+    (fun g x => fN.map_smul g x) (fun g x => fP.map_smul g x) hpair a b
+
+end NaturalityCoefficients
 
 end TauCeti.ContCohomology

--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/ExplicitFunctoriality.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/ExplicitFunctoriality.lean
@@ -21,7 +21,11 @@ The resulting maps are `TauCeti.ContCohomology.explicitMap1` and `explicitMap2`.
 and composition laws make the construction genuinely functorial, while the `_mk` theorems fix
 their values on cocycle classes. The named specializations `explicitRes1`, `explicitRes2`,
 `explicitCoeff1`, and `explicitCoeff2` provide restriction and coefficient maps in positive
-degrees.
+degrees, and `explicitRes1_eq_explicitMap1`, `explicitRes2_eq_explicitMap2`,
+`explicitCoeff1_eq_explicitMap1` and `explicitCoeff2_eq_explicitMap2` exhibit each of them as the
+compatible pair it is, so that a theorem proved for a general pair specializes to all four. They
+are the positive-degree counterparts of `explicitRes0_eq_explicitMap0` and
+`explicitCoeff0_eq_explicitMap0`.
 
 This is functoriality of the *explicit* model: the carriers are the quotients `Z¹/B¹` and `Z²/B²`
 of plain continuous cochains. Mathlib's `ContinuousCohomology.map` is the compatible-pair pullback
@@ -471,6 +475,18 @@ theorem explicitRes1_mk (S : Subgroup G) (c : Z1 G M) :
         continuous_id (id_subgroupSubtype_smul G M S) c : H1 S M) :=
   explicitMap1_mk G M S M _ _ _ _ c
 
+/-- Restriction on explicit `H¹` is the compatible-pair pullback along the inclusion of the
+subgroup with the identity on the coefficients, the degree-one counterpart of
+`TauCeti.ContCohomology.explicitRes0_eq_explicitMap0`. -/
+theorem explicitRes1_eq_explicitMap1 (S : Subgroup G) :
+    explicitRes1 G M S =
+      explicitMap1 G M S M (ContinuousMonoidHom.subgroupSubtype S) (AddMonoidHom.id M)
+        continuous_id (id_subgroupSubtype_smul G M S) := by
+  apply AddMonoidHom.ext
+  intro x
+  induction x using QuotientAddGroup.induction_on with
+  | _ c => rw [explicitRes1_mk, explicitMap1_mk]
+
 /-- Restricting explicit `H¹` first to `S` and then to a subgroup `T` of `S` is restriction
 along the composite inclusion. -/
 theorem explicitRes1_comp (S : Subgroup G) (T : Subgroup S) :
@@ -498,6 +514,17 @@ theorem explicitRes2_mk (S : Subgroup G) [ContinuousMul G] [ContinuousMul S] (c 
       (cocyclesMap2 G M S M (ContinuousMonoidHom.subgroupSubtype S) (AddMonoidHom.id M)
         continuous_id (id_subgroupSubtype_smul G M S) c : H2 S M) :=
   explicitMap2_mk G M S M _ _ _ _ c
+
+/-- Restriction on explicit `H²` is the compatible-pair pullback along the inclusion of the
+subgroup with the identity on the coefficients. -/
+theorem explicitRes2_eq_explicitMap2 (S : Subgroup G) [ContinuousMul G] [ContinuousMul S] :
+    explicitRes2 G M S =
+      explicitMap2 G M S M (ContinuousMonoidHom.subgroupSubtype S) (AddMonoidHom.id M)
+        continuous_id (id_subgroupSubtype_smul G M S) := by
+  apply AddMonoidHom.ext
+  intro x
+  induction x using QuotientAddGroup.induction_on with
+  | _ c => rw [explicitRes2_mk, explicitMap2_mk]
 
 /-- Restricting explicit `H²` first to `S` and then to a subgroup `T` of `S` is restriction
 along the composite inclusion. -/
@@ -529,6 +556,24 @@ theorem explicitCoeff1_mk {N : Type uN} [AddCommGroup N] [TopologicalSpace N]
       (cocyclesMap1 G M G N (ContinuousMonoidHom.id G) f hf
         (fun g m => f.map_smul g m) c : H1 G N) :=
   explicitMap1_mk G M G N _ _ _ _ c
+
+/-- A coefficient map on explicit `H¹` is the compatible-pair pullback along the identity of the
+group, the degree-one counterpart of
+`TauCeti.ContCohomology.explicitCoeff0_eq_explicitMap0`. -/
+theorem explicitCoeff1_eq_explicitMap1 {N : Type uN} [AddCommGroup N] [TopologicalSpace N]
+    [IsTopologicalAddGroup N] [DistribMulAction G N] [ContinuousSMul G N]
+    (f : M →+[G] N) (hf : Continuous f) :
+    explicitCoeff1 G M f hf =
+      explicitMap1 G M G N (ContinuousMonoidHom.id G) f hf (fun g m => f.map_smul g m) := by
+  apply AddMonoidHom.ext
+  intro x
+  induction x using QuotientAddGroup.induction_on with
+  | _ c =>
+    -- `hf : Continuous ⇑f` is stated for the bundled `f`, so the two sides differ by the
+    -- coercion `M →+[G] N → M →+ N` and `rw` cannot see through it on the right.
+    rw [explicitCoeff1_mk]
+    exact (explicitMap1_mk G M G N (ContinuousMonoidHom.id G) (f : M →+ N) hf
+      (fun g m => f.map_smul g m) c).symm
 
 /-- The identity coefficient map induces the identity on explicit `H¹`. -/
 @[simp]
@@ -569,6 +614,23 @@ theorem explicitCoeff2_mk [ContinuousMul G]
       (cocyclesMap2 G M G N (ContinuousMonoidHom.id G) f hf
         (fun g m => f.map_smul g m) c : H2 G N) :=
   explicitMap2_mk G M G N _ _ _ _ c
+
+/-- A coefficient map on explicit `H²` is the compatible-pair pullback along the identity of the
+group. -/
+theorem explicitCoeff2_eq_explicitMap2 [ContinuousMul G]
+    {N : Type uN} [AddCommGroup N] [TopologicalSpace N]
+    [IsTopologicalAddGroup N] [DistribMulAction G N] [ContinuousSMul G N]
+    (f : M →+[G] N) (hf : Continuous f) :
+    explicitCoeff2 G M f hf =
+      explicitMap2 G M G N (ContinuousMonoidHom.id G) f hf (fun g m => f.map_smul g m) := by
+  apply AddMonoidHom.ext
+  intro x
+  induction x using QuotientAddGroup.induction_on with
+  | _ c =>
+    -- As in degree one, the coercion of `f` blocks a rewrite on the right-hand side.
+    rw [explicitCoeff2_mk]
+    exact (explicitMap2_mk G M G N (ContinuousMonoidHom.id G) (f : M →+ N) hf
+      (fun g m => f.map_smul g m) c).symm
 
 /-- The identity coefficient map induces the identity on explicit `H²`. -/
 @[simp]


### PR DESCRIPTION
This PR proves that the six explicit low-degree cup products are natural in compatible pairs, and derives from that general theorem the two named compatibilities the roadmap asks for: restriction, NSW (1.5.3)(i), and the coefficient maps, NSW (1.4.2). A compatible pair is a continuous homomorphism `φ : H →ₜ* G` together with coefficient maps `f_M`, `f_N`, `f_P` that intertwine a `G`-equivariant pairing `μ` with an `H`-equivariant pairing `μ'`, `f_P (μ m x) = μ' (f_M m) (f_N x)`; the theorems say that pulling back along it carries `x ⌣_μ y` to `(φ, f)^* x ⌣_{μ'} (φ, f)^* y`, in each of the six shapes `(0,0)`, `(0,1)`, `(1,0)`, `(0,2)`, `(2,0)` and `(1,1)`. The restriction instance is the pair `(S ↪ G, id)` and the coefficient instance is the pair `(id, f)`, so all twelve named statements come from six cochain computations rather than twelve.

The target is the "Compatibilities" milestone of Layer 8 of the ProfiniteCohomology roadmap (`TauCetiRoadmap/ProfiniteCohomology/README.md`, §5, Layer 8), whose four items are restriction, inflation, coefficient maps and the projection formula. Item 4 landed in #4939 and items 1 and 3 are what this PR supplies; what remains in that bullet is item 2, inflation, which additionally needs the pairing induced on the `N`-invariants of the coefficient modules, together with the layer's connecting-map identities and the Bockstein. Layer 8's prerequisites (Layer 2's explicit complex and compatible-pair functoriality) are on `main`, as are the six cup shapes (#4872) and graded commutativity (#4914) this builds directly on. Layer 9's mod-`2` pairing and Layer 13's `evensNorm_res` are the milestones that consume the restriction compatibility.

New declarations, all in `TauCeti/RepresentationTheory/Homological/ContCohomology/CupProduct.lean` (+498 lines):

* `equivariant_subgroup`: an equivariant pairing stays equivariant for the restricted action of a subgroup, the hypothesis the restricted cups are fed.
* `explicitMap0_explicitCup00`, `explicitMap1_explicitCup01`, `explicitMap1_explicitCup10`, `explicitMap2_explicitCup02`, `explicitMap2_explicitCup20`, `explicitMap2_explicitCup11`: naturality in compatible pairs.
* `explicitRes0_explicitCup00`, `explicitRes1_explicitCup01`, `explicitRes1_explicitCup10`, `explicitRes2_explicitCup02`, `explicitRes2_explicitCup20`, `explicitRes2_explicitCup11`: compatibility with restriction.
* `explicitCoeff0_explicitCup00`, `explicitCoeff1_explicitCup01`, `explicitCoeff1_explicitCup10`, `explicitCoeff2_explicitCup02`, `explicitCoeff2_explicitCup20`, `explicitCoeff2_explicitCup11`: naturality in the pairing.

The derivation of the named instances needs to see restriction and coefficient maps as the compatible pairs they are, which existed only in degree zero (`explicitRes0_eq_explicitMap0`, `explicitCoeff0_eq_explicitMap0`). So `TauCeti/RepresentationTheory/Homological/ContCohomology/ExplicitFunctoriality.lean` gains their four positive-degree counterparts, `explicitRes1_eq_explicitMap1`, `explicitRes2_eq_explicitMap2`, `explicitCoeff1_eq_explicitMap1` and `explicitCoeff2_eq_explicitMap2` (+64 lines, including the module docstring). Every one of them is used below; none is a restatement of an existing lemma. Nothing was vendored from Mathlib: Mathlib carries no cup product on `groupCohomology` and hence no naturality statement to transfer, and the statements here are stated for the roadmap's unbundled continuous modules.

Both files stay in place: the naturality of the cup products belongs next to the cup products it is about, and the four bridging lemmas belong next to the maps they describe. `CupProduct.lean` grows to 1264 lines, within the 1500-line ceiling for an existing file.

The mathematics is the classical cochain computation, NSW I §4: the pullback moves the coefficient maps inside `μ`, where the intertwining hypothesis turns it into `μ'`, and the translation factor `φ h •` becomes `h •` by equivariance of the coefficient map it meets. In the `(2,0)` shape that factor is `(φ h * φ k) •`, which multiplicativity of `φ` turns into `φ (h * k) •` first.

Roadmap: ProfiniteCohomology

<!--tauceti-target:v1 {"focus":"ProfiniteCohomology","id":"explicitcup-naturality-compatible-pairs"}-->

🤖 Prepared with Claude Code
