### PR TITLE
feat(Conformal): one image piece of a crosscut lies in the filled hull

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
@@ -159,7 +159,7 @@ theorem DifferentiableOn.conformalAt_of_isOpen_of_injOn
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
     {z : ℂ} (hz : z ∈ U) : ConformalAt f z := by
   exact (hf.analyticAt (hU.mem_nhds hz)).differentiableAt.conformalAt
-    (hf.deriv_ne_zero_of_injOn hU hinj hz)
+    (deriv_ne_zero_of_injOn hf hU hinj hz)
 
 /-- The open partial homeomorphism associated to an injective holomorphic map is conformal on its
 source. -/

--- a/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
@@ -158,10 +158,8 @@ theorem DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm
 theorem DifferentiableOn.conformalAt_of_isOpen_of_injOn
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
     {z : ℂ} (hz : z ∈ U) : ConformalAt f z := by
-  have hfz : AnalyticAt ℂ f z := hf.analyticAt (hU.mem_nhds hz)
-  have hderiv : deriv f z ≠ 0 :=
-    (exists_injOn_nhds_iff_deriv_ne_zero hfz).mp ⟨U, hU.mem_nhds hz, hinj⟩
-  exact hfz.differentiableAt.conformalAt hderiv
+  exact (hf.analyticAt (hU.mem_nhds hz)).differentiableAt.conformalAt
+    (hf.deriv_ne_zero_of_injOn hU hinj hz)
 
 /-- The open partial homeomorphism associated to an injective holomorphic map is conformal on its
 source. -/

--- a/TauCeti/Analysis/Complex/Conformal/Caratheodory.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Caratheodory.lean
@@ -45,8 +45,9 @@ length–area method:
   `TauCeti.IsJordanCurve.isPathConnected_sdiff_singleton`, so the winding-number two-sidedness
   theorem applies directly. No plane-separation hypothesis is needed.
 
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff` then puts the
-*near* side inside `filledHull J` — the far side cannot be the enclosed one, being wider than `J` —
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton`
+then puts the *near* side inside `filledHull J` — the far side cannot be the enclosed one, being
+wider than `J` —
 and `TauCeti.diam_le_diam_of_subset_filledHull` reads that enclosure as the width bound
 `diam (f '' (ball c r ∩ ball ζ ρ)) ≤ diam J ≤ ε`. Since this holds at every boundary point, the
 extension theorem `TauCeti.exists_continuousOn_closure_eqOn_of_isBounded` assembles the continuous
@@ -71,6 +72,12 @@ which arc of the image boundary the near side clings to.
 
 This is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, the Jordan-domain case of the
 Carathéodory boundary correspondence.
+
+Layer L5 is absent from
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
+human-curated Riemann-mapping-theorem effort, and Mathlib has no boundary correspondence for
+conformal maps and no Jordan curve theorem, so this is new Lean formalization rather than a
+temporary shim.
 
 ## Main results
 
@@ -110,8 +117,9 @@ the bounding circle. For every `ε > 0` there is a crosscut radius `ρ > 0` with
 > `Metric.diam (f '' (ball c r ∩ ball ζ ρ)) ≤ ε`.
 
 The preconnectedness hypothesis on the curve `J` minus a point, needed by the enclosure theorem
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff`, is supplied by
-`TauCeti.IsJordanCurve.isPathConnected_sdiff_singleton`. Connectedness of both cut sides and a far
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton`, is
+supplied by `TauCeti.IsJordanCurve.isPathConnected_sdiff_singleton`. Connectedness of both cut
+sides and a far
 side wider than `J` are discharged here. -/
 theorem exists_diam_image_ball_inter_ball_le_of_isJordanCurve_frontier
     (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
@@ -152,7 +160,7 @@ theorem exists_diam_image_ball_inter_ball_le_of_isJordanCurve_frontier
     (hJ.isPathConnected_sdiff_singleton (f z)).isConnected.isPreconnected
   calc diam (f '' (ball c r ∩ ball ζ ρ))
       ≤ diam J := diam_le_diam_of_subset_filledHull hJb
-        (image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff
+        (image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton
           isOpen_ball hρmem.1 hf hinj hAc hBc hJ.isCompact.isClosed hJb hγ hJsub hz hKp hlt)
     _ ≤ ε := hdiamJ.trans (min_le_left _ _)
 

--- a/TauCeti/Analysis/Complex/Conformal/Caratheodory.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Caratheodory.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Inside
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.SmallJordanCurve
+import TauCeti.Topology.JordanCurve.Separation
 public import TauCeti.Analysis.Complex.Conformal.RiemannMapping.Existence
 public import TauCeti.Topology.ClusterSet
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
@@ -14,23 +15,10 @@ import TauCeti.Analysis.Normed.Module.Ball.Cut
 import TauCeti.Topology.MetricSpace.Cut
 
 /-!
-# Carathéodory's continuity theorem, on plane separation
+# Carathéodory's continuity theorem
 
 A conformal map of a disc onto a bounded region whose boundary is a Jordan curve extends
-continuously to the closed disc. This file proves that statement from one unproved input, the
-**plane separation** statement of the roadmap section of `TauCeti/Topology/FilledHull.lean`,
-
-> every point of a Jordan curve is a limit of points inside it, `J ⊆ closure (filledHull J \ J)`,
-
-carried through every theorem below as the explicit hypothesis
-
-> `hsep : ∀ J : Set ℂ, IsJordanCurve J → J ⊆ closure (filledHull J \ J)`.
-
-Nothing else is assumed: `hsep` is the *only* hypothesis here that the repository does not
-discharge, and no theorem below is stated in a shape that presumes anything further. What the file
-therefore establishes is that plane separation is the last gate on the continuity half of layer
-**L5**, and that the gate is a statement about Jordan curves alone — no longer one about conformal
-maps, crosscuts or boundary behaviour.
+continuously to the closed disc.
 
 ## The argument
 
@@ -52,13 +40,14 @@ length–area method:
   two discs, hence convex (`TauCeti.isConnected_ball_inter_ball`); the far side
   `ball c r \ closedBall ζ ρ` is connected by the Möbius reduction
   `TauCeti.isConnected_ball_diff_closedBall`;
-* **the curve has a point of its inside on the image crosscut.** The circular crosscut
-  `ball c r ∩ sphere ζ ρ` is nonempty (`TauCeti.nonempty_ball_inter_sphere`), its image lies on `J`,
-  and it lies in the image of the disc; `hsep` is read at that one point, and only there.
+* **a Jordan curve minus a point is preconnected.** At a point of the circular crosscut, the curve
+  `J` minus that point is path-connected by
+  `TauCeti.IsJordanCurve.isPathConnected_sdiff_singleton`, so the winding-number two-sidedness
+  theorem applies directly. No plane-separation hypothesis is needed.
 
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` then puts the *near* side inside
-`filledHull J` — the far side cannot be the enclosed one, being wider than `J` — and
-`TauCeti.diam_le_diam_of_subset_filledHull` reads that enclosure as the width bound
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff` then puts the
+*near* side inside `filledHull J` — the far side cannot be the enclosed one, being wider than `J` —
+and `TauCeti.diam_le_diam_of_subset_filledHull` reads that enclosure as the width bound
 `diam (f '' (ball c r ∩ ball ζ ρ)) ≤ diam J ≤ ε`. Since this holds at every boundary point, the
 extension theorem `TauCeti.exists_continuousOn_closure_eqOn_of_isBounded` assembles the continuous
 extension on `closedBall c r`.
@@ -81,16 +70,7 @@ which arc of the image boundary the near side clings to.
 ## Roadmap role
 
 This is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, the Jordan-domain case of the
-Carathéodory boundary correspondence, reduced to its one open frontier item. `ConformalMapping`'s
-status record names plane separation for Jordan curves as that item and asks that *how much of it
-the boundary work needs* be settled first; the answer this file gives is `hsep`, at a single point
-of a single curve at each radius.
-
-Layer L5 is absent from
-[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
-human-curated Riemann-mapping-theorem effort, and Mathlib has no boundary correspondence for
-conformal maps and no Jordan curve theorem, so this is new Lean formalization rather than a
-temporary shim.
+Carathéodory boundary correspondence.
 
 ## Main results
 
@@ -125,21 +105,17 @@ variable {f : ℂ → ℂ} {c ζ : ℂ} {r : ℝ}
 
 /-- **The image of a crosscut neighbourhood can be made arbitrarily small.** Let `f` be holomorphic
 and injective on `ball c r`, with bounded image whose boundary is a Jordan curve, and let `ζ` lie on
-the bounding circle. Assuming the plane-separation statement `hsep`, for every `ε > 0` there is a
-crosscut radius `ρ > 0` with
+the bounding circle. For every `ε > 0` there is a crosscut radius `ρ > 0` with
 
 > `Metric.diam (f '' (ball c r ∩ ball ζ ρ)) ≤ ε`.
 
-This is the quantitative heart of the file, and the only place `hsep` is used: it is read once, at
-the image of a point of the circular crosscut `ball c r ∩ sphere ζ ρ`, which lies both on the small
-curve `J` and in the image of the disc. The inputs the enclosure theorem
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` isolates — connectedness of each of the two
-sides of the cut, nonemptiness of the crosscut, and a far side wider than `J` — are all discharged
-here. -/
+The preconnectedness hypothesis on the curve `J` minus a point, needed by the enclosure theorem
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff`, is supplied by
+`TauCeti.IsJordanCurve.isPathConnected_sdiff_singleton`. Connectedness of both cut sides and a far
+side wider than `J` are discharged here. -/
 theorem exists_diam_image_ball_inter_ball_le_of_isJordanCurve_frontier
     (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hb : IsBounded (f '' ball c r)) (hJf : IsJordanCurve (frontier (f '' ball c r)))
-    (hsep : ∀ J : Set ℂ, IsJordanCurve J → J ⊆ closure (filledHull J \ J))
     (hζ : dist ζ c = r) {ε : ℝ} (hε : 0 < ε) :
     ∃ ρ > 0, diam (f '' (ball c r ∩ ball ζ ρ)) ≤ ε := by
   -- the image of the disc has two distinct points, so the far side does not degenerate
@@ -166,19 +142,18 @@ theorem exists_diam_image_ball_inter_ball_le_of_isJordanCurve_frontier
     have h₁ : diam J ≤ d / 2 := hdiamJ.trans (min_le_right _ _)
     have h₂ := hfar ρ hρmem.2.le
     linarith
-  -- the separation hypothesis, read at the image of one point of the circular crosscut
   obtain ⟨z, hz⟩ := nonempty_ball_inter_sphere hζ hρmem.1 hρr
-  have hp : f z ∈ f '' ball c r := mem_image_of_mem f hz.1
-  have hin : f z ∈ closure (filledHull J \ J) := hsep J hJ (hγ (mem_image_of_mem f hz))
   have hAc : IsPreconnected (ball c r ∩ ball ζ ρ) :=
     (isConnected_ball_inter_ball hr hρmem.1
       (by rw [dist_comm, hζ]; linarith [hρmem.1])).isPreconnected
   have hBc : IsPreconnected (ball c r \ closedBall ζ ρ) :=
     (isConnected_ball_diff_closedBall hζ hρmem.1 hρr).isPreconnected
+  have hKp : IsPreconnected (J \ {f z}) :=
+    (hJ.isPathConnected_sdiff_singleton (f z)).isConnected.isPreconnected
   calc diam (f '' (ball c r ∩ ball ζ ρ))
       ≤ diam J := diam_le_diam_of_subset_filledHull hJb
-        (image_inter_ball_subset_filledHull_of_diam_lt isOpen_ball hf hinj hAc hBc hJb hγ
-          hJsub hlt hp hin)
+        (image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff
+          isOpen_ball hρmem.1 hf hinj hAc hBc hJ.isCompact.isClosed hJb hγ hJsub hz hKp hlt)
     _ ≤ ε := hdiamJ.trans (min_le_left _ _)
 
 /-! ## The boundary limit -/
@@ -190,12 +165,11 @@ neighbourhood have images within its diameter of each other by `Metric.dist_le_d
 theorem subsingleton_clusterSetOn_of_isJordanCurve_frontier
     (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hb : IsBounded (f '' ball c r)) (hJf : IsJordanCurve (frontier (f '' ball c r)))
-    (hsep : ∀ J : Set ℂ, IsJordanCurve J → J ⊆ closure (filledHull J \ J))
     (hζ : dist ζ c = r) :
     (clusterSetOn f (ball c r) ζ).Subsingleton := by
   refine subsingleton_clusterSetOn_of_forall_exists fun ε hε => ?_
   obtain ⟨ρ, hρ, hdiam⟩ :=
-    exists_diam_image_ball_inter_ball_le_of_isJordanCurve_frontier hr hf hinj hb hJf hsep hζ hε
+    exists_diam_image_ball_inter_ball_le_of_isJordanCurve_frontier hr hf hinj hb hJf hζ hε
   exact ⟨ρ, hρ, fun _ hx _ hy => (dist_le_diam_of_mem
     (hb.subset (image_mono inter_subset_left))
     (mem_image_of_mem f hx) (mem_image_of_mem f hy)).trans hdiam⟩
@@ -212,17 +186,15 @@ closure of the disc. This is the pointwise form of
 theorem exists_tendsto_nhdsWithin_of_isJordanCurve_frontier
     (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hb : IsBounded (f '' ball c r)) (hJf : IsJordanCurve (frontier (f '' ball c r)))
-    (hsep : ∀ J : Set ℂ, IsJordanCurve J → J ⊆ closure (filledHull J \ J))
     (hζ : dist ζ c = r) :
     ∃ v, Tendsto f (𝓝[ball c r] ζ) (𝓝 v) :=
   exists_tendsto_of_clusterSetOn_subsingleton hb.isCompact_closure
     (fun w hw => subset_closure ⟨w, hw, rfl⟩)
     (by rw [closure_ball c hr.ne']; exact mem_closedBall.mpr hζ.le)
-    (subsingleton_clusterSetOn_of_isJordanCurve_frontier hr hf hinj hb hJf hsep hζ)
+    (subsingleton_clusterSetOn_of_isJordanCurve_frontier hr hf hinj hb hJf hζ)
 
-/-- **Carathéodory's continuity theorem, on plane separation.** A holomorphic injection of a disc
-onto a bounded region whose boundary is a Jordan curve extends continuously to the closed disc,
-granted the plane-separation statement `hsep`.
+/-- **Carathéodory's continuity theorem.** A holomorphic injection of a disc
+onto a bounded region whose boundary is a Jordan curve extends continuously to the closed disc.
 
 Every boundary cluster set is a subsingleton by
 `TauCeti.subsingleton_clusterSetOn_of_isJordanCurve_frontier`, which is exactly what the extension
@@ -233,18 +205,17 @@ with bounded image; `Metric.frontier_ball` and `Metric.closure_ball` turn its `f
 No injectivity is claimed for the extension on the circle, and none is needed for continuity. -/
 theorem exists_continuousOn_closedBall_eqOn_of_isJordanCurve_frontier
     (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
-    (hb : IsBounded (f '' ball c r)) (hJf : IsJordanCurve (frontier (f '' ball c r)))
-    (hsep : ∀ J : Set ℂ, IsJordanCurve J → J ⊆ closure (filledHull J \ J)) :
+    (hb : IsBounded (f '' ball c r)) (hJf : IsJordanCurve (frontier (f '' ball c r))) :
     ∃ F : ℂ → ℂ, ContinuousOn F (closedBall c r) ∧ EqOn F f (ball c r) := by
   have h := exists_continuousOn_closure_eqOn_of_isBounded isOpen_ball hf.continuousOn hb
-    fun w hw => subsingleton_clusterSetOn_of_isJordanCurve_frontier hr hf hinj hb hJf hsep
+    fun w hw => subsingleton_clusterSetOn_of_isJordanCurve_frontier hr hf hinj hb hJf
       (mem_sphere.mp (by rwa [frontier_ball c hr.ne'] at hw))
   rwa [closure_ball c hr.ne'] at h
 
 /-! ## The Jordan-domain form -/
 
 /-- **A bounded Jordan domain is the image of the disc under a holomorphic bijection continuous up
-to the closed disc**, granted the plane-separation statement `hsep`. This is the form layer **L5**
+to the closed disc.** This is the form layer **L5**
 of `TauCetiRoadmap/ConformalMapping/README.md` states its milestone in, minus the injectivity of the
 boundary values.
 
@@ -259,8 +230,7 @@ The extension is named as the map itself rather than beside it: replacing the in
 its extension changes neither its holomorphy on the open disc nor its bijectivity onto `Ω`. -/
 theorem exists_continuousOn_closedBall_bijOn_ball_of_isJordanCurve_frontier {Ω : Set ℂ}
     (hΩo : IsOpen Ω) (hΩc : IsSimplyConnected Ω) (hΩb : IsBounded Ω)
-    (hΩJ : IsJordanCurve (frontier Ω))
-    (hsep : ∀ J : Set ℂ, IsJordanCurve J → J ⊆ closure (filledHull J \ J)) :
+    (hΩJ : IsJordanCurve (frontier Ω)) :
     ∃ g : ℂ → ℂ, ContinuousOn g (closedBall 0 1) ∧ DifferentiableOn ℂ g (ball 0 1) ∧
       BijOn g (ball 0 1) Ω := by
   have hΩne : Ω ≠ univ := by
@@ -277,7 +247,6 @@ theorem exists_continuousOn_closedBall_bijOn_ball_of_isJordanCurve_frontier {Ω 
     rw [himg]; exact hΩJ
   obtain ⟨G, hGc, hGeq⟩ :=
     exists_continuousOn_closedBall_eqOn_of_isJordanCurve_frontier one_pos hgd hgbij.injOn hb hJ
-      hsep
   exact ⟨G, hGc, hgd.congr fun _ hz => hGeq hz, hgbij.congr fun _ hz => (hGeq hz).symm⟩
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -126,10 +126,11 @@ pseudometric space, in `TauCeti/Topology/MetricSpace/Cut.lean`.
 
 * `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` — the closure of the image of
   the cut is that image together with the cluster sets of `f` along it.
-* `TauCeti.closure_image_inter_sphere_inter_image_subset` and
-  `TauCeti.disjoint_image_closure_image_inter_sphere` — so that closure meets the image of the
-  domain only in the image of the cut, and is disjoint from the image of any part of the domain
-  avoiding the cutting circle.
+* `TauCeti.closure_image_inter_sphere_subset_union_frontier_image` — an image crosscut is
+  relatively closed in the image domain, and
+  `TauCeti.disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image`
+  — so a set disjoint from the crosscut has image disjoint from anything on its closure and the
+  image boundary.
 * `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — at an endpoint of a crosscut of a disc a
   cluster set is a continuum once `f` is continuous along the crosscut with bounded image; its
   nonemptiness for a general domain is the generic `TauCeti.clusterSetOn_nonempty`, applied to the
@@ -168,7 +169,7 @@ namespace TauCeti
 
 open Bornology Complex Filter Metric Set Topology
 
-variable {f : ℂ → ℂ} {U : Set ℂ} {c ζ e : ℂ} {r ρ : ℝ}
+variable {f : ℂ → ℂ} {U K V : Set ℂ} {c ζ e : ℂ} {r ρ : ℝ}
 
 /-! ## Where the cut leaves the domain -/
 
@@ -235,41 +236,41 @@ theorem clusterSetOn_inter_sphere_subset_frontier_inter_closure_image (hUo : IsO
       (clusterSetOn_mono inter_subset_left hv))
     fun _ hv => clusterSetOn_subset_closure_image hv
 
-/-- **Closing up an image cut adds no interior point.** For `f` holomorphic and injective on an
-open `U`, the closure of `f '' (U ∩ sphere ζ ρ)` meets `f '' U` only in
-`f '' (U ∩ sphere ζ ρ)`.
+/-- **Taking the closure of an image crosscut adds only boundary points of the image domain.** For
+`f` holomorphic and injective on an open `U`, a point adherent to the image crosscut
+`f '' (U ∩ sphere ζ ρ)` either lies on it or lies on `frontier (f '' U)`: the image crosscut is
+relatively closed in the image domain.
 
-By `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` the points that closing adds
-are cluster values of `f` at points of `frontier U` on the circle, and properness of a conformal map
-(`TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`) puts those on
-`frontier (f '' U)`, which is disjoint from the open set `f '' U`. -/
-theorem closure_image_inter_sphere_inter_image_subset (hUo : IsOpen U)
-    (hfd : DifferentiableOn ℂ f U) (hinj : InjOn f U) :
-    closure (f '' (U ∩ sphere ζ ρ)) ∩ f '' U ⊆ f '' (U ∩ sphere ζ ρ) := by
-  rintro w ⟨hwcl, hwU⟩
+The closure decomposition is
+`TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn`, and
+`TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image` puts every added cluster
+value on `frontier (f '' U)`. -/
+theorem closure_image_inter_sphere_subset_union_frontier_image (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U)
+    (hinj : InjOn f U) :
+    closure (f '' (U ∩ sphere ζ ρ)) ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier (f '' U) := by
   rw [closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hfd.continuousOn.mono inter_subset_left)] at hwcl
-  rcases hwcl with hw | hw
-  · exact hw
-  · obtain ⟨e, he, hwe⟩ := mem_iUnion₂.mp hw
-    have hfr := (clusterSetOn_inter_sphere_subset_frontier_inter_closure_image hUo hfd hinj he.1
-      hwe).1
-    rw [(isOpen_image_of_differentiableOn_of_injOn hUo hfd hinj).frontier_eq] at hfr
-    exact absurd hwU hfr.2
+    (hd.continuousOn.mono inter_subset_left)]
+  exact union_subset_union_right _ (iUnion₂_subset fun _ he =>
+    (clusterSetOn_inter_sphere_subset_frontier_inter_closure_image hUo hd hinj he.1).trans
+      inter_subset_left)
 
-/-- **A part of the domain avoiding the cutting circle has image disjoint from the closed image
-cut.** This is `TauCeti.closure_image_inter_sphere_inter_image_subset` read through injectivity: a
-common point would be the image both of a point of `V` and of a point of the circle, hence of a
-single point lying on both. -/
-theorem disjoint_image_closure_image_inter_sphere (hUo : IsOpen U) (hfd : DifferentiableOn ℂ f U)
-    (hinj : InjOn f U) {V : Set ℂ} (hVU : V ⊆ U) (hV : Disjoint V (sphere ζ ρ)) :
-    Disjoint (f '' V) (closure (f '' (U ∩ sphere ζ ρ))) := by
-  rw [Set.disjoint_left]
-  rintro _ ⟨z, hzV, rfl⟩ hcl
-  obtain ⟨w, hw, hfw⟩ := closure_image_inter_sphere_inter_image_subset hUo hfd hinj
-    ⟨hcl, mem_image_of_mem f (hVU hzV)⟩
-  have hzw : z = w := hinj (hVU hzV) hw.1 hfw.symm
-  exact Set.disjoint_left.mp hV hzV (hzw ▸ hw.2)
+/-- **A subset of the domain missing the crosscut has image off the closed image crosscut and the
+image boundary.** If `V ⊆ U` is disjoint from `U ∩ sphere ζ ρ`, then `f '' V` avoids every `K`
+contained in the closed image crosscut and `frontier (f '' U)`. Injectivity separates it from the
+crosscut, relative closedness handles the closure, and openness of `f '' U` handles the image
+boundary. -/
+theorem disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
+    (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
+    (hV : Disjoint V (U ∩ sphere ζ ρ))
+    (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U)) : Disjoint (f '' V) K := by
+  have hΩo : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hUo hd hinj
+  have hfr : Disjoint (f '' V) (frontier (f '' U)) :=
+    (disjoint_frontier_iff_isOpen.mpr hΩo).symm.mono_left (image_mono hVU)
+  have hKsub : K ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier (f '' U) :=
+    hK.trans (union_subset
+      (closure_image_inter_sphere_subset_union_frontier_image hUo hd hinj) subset_union_right)
+  exact ((hV.image hinj hVU inter_subset_left).union_right hfr).mono_right hKsub
 
 /-- **Each end of an image crosscut of a disc is a continuum.** For `f` continuous along a genuine
 circular crosscut of a disc and with bounded image *of the crosscut*, the cluster set at either

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -126,11 +126,10 @@ pseudometric space, in `TauCeti/Topology/MetricSpace/Cut.lean`.
 
 * `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` — the closure of the image of
   the cut is that image together with the cluster sets of `f` along it.
-* `TauCeti.closure_image_inter_sphere_subset_union_frontier_image` — an image crosscut is
-  relatively closed in the image domain, and
-  `TauCeti.disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image`
-  — so a set disjoint from the crosscut has image disjoint from anything on its closure and the
-  image boundary.
+* `TauCeti.closure_image_inter_sphere_inter_image_subset` and
+  `TauCeti.disjoint_image_closure_image_inter_sphere` — so that closure meets the image of the
+  domain only in the image of the cut, and is disjoint from the image of any part of the domain
+  avoiding the cutting circle.
 * `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — at an endpoint of a crosscut of a disc a
   cluster set is a continuum once `f` is continuous along the crosscut with bounded image; its
   nonemptiness for a general domain is the generic `TauCeti.clusterSetOn_nonempty`, applied to the
@@ -169,7 +168,7 @@ namespace TauCeti
 
 open Bornology Complex Filter Metric Set Topology
 
-variable {f : ℂ → ℂ} {U K V : Set ℂ} {c ζ e : ℂ} {r ρ : ℝ}
+variable {f : ℂ → ℂ} {U : Set ℂ} {c ζ e : ℂ} {r ρ : ℝ}
 
 /-! ## Where the cut leaves the domain -/
 
@@ -236,41 +235,41 @@ theorem clusterSetOn_inter_sphere_subset_frontier_inter_closure_image (hUo : IsO
       (clusterSetOn_mono inter_subset_left hv))
     fun _ hv => clusterSetOn_subset_closure_image hv
 
-/-- **Taking the closure of an image crosscut adds only boundary points of the image domain.** For
-`f` holomorphic and injective on an open `U`, a point adherent to the image crosscut
-`f '' (U ∩ sphere ζ ρ)` either lies on it or lies on `frontier (f '' U)`: the image crosscut is
-relatively closed in the image domain.
+/-- **Closing up an image cut adds no interior point.** For `f` holomorphic and injective on an
+open `U`, the closure of `f '' (U ∩ sphere ζ ρ)` meets `f '' U` only in
+`f '' (U ∩ sphere ζ ρ)`.
 
-The closure decomposition is
-`TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn`, and
-`TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image` puts every added cluster
-value on `frontier (f '' U)`. -/
-theorem closure_image_inter_sphere_subset_union_frontier_image (hUo : IsOpen U)
-    (hd : DifferentiableOn ℂ f U)
-    (hinj : InjOn f U) :
-    closure (f '' (U ∩ sphere ζ ρ)) ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier (f '' U) := by
+By `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` the points that closing adds
+are cluster values of `f` at points of `frontier U` on the circle, and properness of a conformal map
+(`TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`) puts those on
+`frontier (f '' U)`, which is disjoint from the open set `f '' U`. -/
+theorem closure_image_inter_sphere_inter_image_subset (hUo : IsOpen U)
+    (hfd : DifferentiableOn ℂ f U) (hinj : InjOn f U) :
+    closure (f '' (U ∩ sphere ζ ρ)) ∩ f '' U ⊆ f '' (U ∩ sphere ζ ρ) := by
+  rintro w ⟨hwcl, hwU⟩
   rw [closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hd.continuousOn.mono inter_subset_left)]
-  exact union_subset_union_right _ (iUnion₂_subset fun _ he =>
-    (clusterSetOn_inter_sphere_subset_frontier_inter_closure_image hUo hd hinj he.1).trans
-      inter_subset_left)
+    (hfd.continuousOn.mono inter_subset_left)] at hwcl
+  rcases hwcl with hw | hw
+  · exact hw
+  · obtain ⟨e, he, hwe⟩ := mem_iUnion₂.mp hw
+    have hfr := (clusterSetOn_inter_sphere_subset_frontier_inter_closure_image hUo hfd hinj he.1
+      hwe).1
+    rw [(isOpen_image_of_differentiableOn_of_injOn hUo hfd hinj).frontier_eq] at hfr
+    exact absurd hwU hfr.2
 
-/-- **A subset of the domain missing the crosscut has image off the closed image crosscut and the
-image boundary.** If `V ⊆ U` is disjoint from `U ∩ sphere ζ ρ`, then `f '' V` avoids every `K`
-contained in the closed image crosscut and `frontier (f '' U)`. Injectivity separates it from the
-crosscut, relative closedness handles the closure, and openness of `f '' U` handles the image
-boundary. -/
-theorem disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
-    (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
-    (hV : Disjoint V (U ∩ sphere ζ ρ))
-    (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U)) : Disjoint (f '' V) K := by
-  have hΩo : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hUo hd hinj
-  have hfr : Disjoint (f '' V) (frontier (f '' U)) :=
-    (disjoint_frontier_iff_isOpen.mpr hΩo).symm.mono_left (image_mono hVU)
-  have hKsub : K ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier (f '' U) :=
-    hK.trans (union_subset
-      (closure_image_inter_sphere_subset_union_frontier_image hUo hd hinj) subset_union_right)
-  exact ((hV.image hinj hVU inter_subset_left).union_right hfr).mono_right hKsub
+/-- **A part of the domain avoiding the cutting circle has image disjoint from the closed image
+cut.** This is `TauCeti.closure_image_inter_sphere_inter_image_subset` read through injectivity: a
+common point would be the image both of a point of `V` and of a point of the circle, hence of a
+single point lying on both. -/
+theorem disjoint_image_closure_image_inter_sphere (hUo : IsOpen U) (hfd : DifferentiableOn ℂ f U)
+    (hinj : InjOn f U) {V : Set ℂ} (hVU : V ⊆ U) (hV : Disjoint V (sphere ζ ρ)) :
+    Disjoint (f '' V) (closure (f '' (U ∩ sphere ζ ρ))) := by
+  rw [Set.disjoint_left]
+  rintro _ ⟨z, hzV, rfl⟩ hcl
+  obtain ⟨w, hw, hfw⟩ := closure_image_inter_sphere_inter_image_subset hUo hfd hinj
+    ⟨hcl, mem_image_of_mem f (hVU hzV)⟩
+  have hzw : z = w := hinj (hVU hzV) hw.1 hfw.symm
+  exact Set.disjoint_left.mp hV hzV (hzw ▸ hw.2)
 
 /-- **Each end of an image crosscut of a disc is a continuum.** For `f` continuous along a genuine
 circular crosscut of a disc and with bounded image *of the crosscut*, the cluster set at either

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-import TauCeti.Analysis.Complex.Conformal.Crosscut.SmallJordanCurve
 public import TauCeti.Analysis.Normed.Module.FilledHull
 import Mathlib.Analysis.Calculus.Deriv.Slope
 import Mathlib.MeasureTheory.Integral.CircleIntegral
@@ -15,17 +14,23 @@ import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
 import TauCeti.Analysis.Complex.Conformal.InverseFunction
 import TauCeti.Analysis.Contour.Winding.Separation
 import TauCeti.Topology.MetricSpace.Cut
-import TauCeti.Topology.JordanCurve.Separation
 
 /-!
 # One image piece of a crosscut lies inside a compact enclosing set
 
-For a holomorphic injection of `ball c r`, one of the two image pieces — the near side
-`ball c r ∩ ball ζ ρ` or the far side `ball c r \ closedBall ζ ρ` — lies in the filled hull of a
-compact set through the image crosscut. The transversal segment through a point of the crosscut has
-the near side on one side and the far side on the other, and the enclosing set is adherent from both
-sides; the winding-number two-sidedness theorem puts one end in the filled hull. No Jordan curve
-theorem is used.
+For a holomorphic injection of an open set `U`, one of the two image pieces — the near side
+`U ∩ ball ζ ρ` or the far side `U \ closedBall ζ ρ` — lies in the filled hull of a closed bounded
+set `K` through the image crosscut. The hypotheses are:
+
+* `K` contains the image crosscut and is contained in its closure union `frontier (f '' U)`.
+* `K \ {f z₀}` is preconnected at a chosen crosscut point `z₀`.
+* The two image pieces are preconnected (the `GeneralDomain` section) or `U = ball c r` and the
+  preconnectedness is derived from the ball geometry (the first section).
+
+The transversal segment through a point of the crosscut has the near side on one side and the
+far side on the other; the winding-number two-sidedness theorem
+(`Contour.mem_filledHull_or_mem_filledHull_of_isPreconnected_sdiff_singleton`) puts one end in the
+filled hull. No Jordan curve theorem is used.
 
 This is the planar-separation step of the `ConformalMapping` roadmap (L5).
 
@@ -37,10 +42,10 @@ This is the planar-separation step of the `ConformalMapping` roadmap (L5).
   adherent to each of its points from both sides of the transversal.**
 * `TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull` —
   **one of the two image pieces lies in the filled hull of a closed bounded set through the image
-  crosscut.**
-* `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt'` — diameter selection: when the enclosing
-  set is narrower than the far side, the near side is enclosed. Consumes the disjunction above
-  without the `hp`/`hin` plane-separation input.
+  crosscut.** Requires `K \ {f z₀}` preconnected.
+* `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff` — diameter
+  selection: when the enclosing set is narrower than the far side, the near side is enclosed.
+  Consumes the disjunction above without the `hp`/`hin` plane-separation input.
 * `TauCeti.image_subset_filledHull_of_disjoint_inter_sphere` — an image side meeting the inside of
   such a curve lies inside it.
 * `TauCeti.nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull` —
@@ -49,13 +54,15 @@ This is the planar-separation step of the `ConformalMapping` roadmap (L5).
   `hin : p ∈ closure (filledHull K \ K)` is introduced; the diameter criterion below passes it on
   unchanged.
 * `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` — such a curve, if narrower than the far
-  side, encloses the *near* side.
+  side, encloses the *near* side. Takes preconnectedness of the two sides as hypotheses.
 * `TauCeti.image_inter_ball_subset_filledHull_of_frontier_subset` — the enclosure hypothesis is
   implied by the boundary-piece hypothesis of `Conformal/CutDiameter.lean`.
 
 ## References
 
-* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Section 2.2.
+* C. Carathéodory, *Über die Begrenzung einfach zusammenhängender Gebiete*, Math. Ann. 73, 1913.
+* P. L. Duren, *Univalent Functions*, Chapter 3.
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Section 2.3.
 * J. B. Garnett and D. E. Marshall, *Harmonic Measure*, Theorem I.3.1.
 -/
 
@@ -68,13 +75,6 @@ open scoped Topology
 namespace TauCeti
 
 variable {f : ℂ → ℂ} {c ζ z₀ : ℂ} {r ρ : ℝ}
-
-/-- A point of a sphere of positive radius is not its centre. -/
-private theorem sub_ne_zero_of_mem_sphere (hρ : 0 < ρ) (hz₀ : z₀ ∈ sphere ζ ρ) :
-    z₀ - ζ ≠ 0 := by
-  intro h
-  rw [mem_sphere, dist_eq_norm, h, norm_zero] at hz₀
-  exact hρ.ne hz₀
 
 private theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
@@ -115,7 +115,7 @@ theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall
   have hgmem : ∀ w ∈ f '' ball c r, g w ∈ ball c r := fun w hw => Function.invFunOn_mem hw
   have hd0 : deriv f z₀ ≠ 0 :=
     hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀b
-  have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero_of_mem_sphere hρ hz₀s
+  have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀s hρ.ne')
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
   have hv : v ≠ 0 := mul_ne_zero hd0 hzζ
   -- the pulled-back segment has velocity `z₀ - ζ` at `t = 0`
@@ -194,7 +194,7 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
   obtain ⟨hz₀b, hz₀s⟩ := hz₀
   have hd0 : deriv f z₀ ≠ 0 :=
     hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀b
-  have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero_of_mem_sphere hρ hz₀s
+  have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀s hρ.ne')
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
   have hfz : HasDerivAt f (deriv f z₀) z₀ :=
     (hf.differentiableAt (isOpen_ball.mem_nhds hz₀b)).hasDerivAt
@@ -287,7 +287,7 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
   have hv : v ≠ 0 :=
     mul_ne_zero (hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀.1)
-      (sub_ne_zero_of_mem_sphere hρ hz₀.2)
+      (sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀.2 hρ.ne'))
   obtain ⟨η, hη, hnear, hfar⟩ :=
     exists_mem_image_inter_ball_and_image_sdiff_closedBall hf hinj hz₀ hρ
   obtain ⟨hleft, hright⟩ :=
@@ -337,7 +337,7 @@ excluding the far-side case: trapping the far side inside `K` gives
 `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt`, no `hp`/`hin` plane-separation input is
 needed — the preconnectedness hypothesis `hKp` on `K \ {p}` is discharged by
 `IsJordanCurve.isPathConnected_sdiff_singleton` in the intended application. -/
-theorem image_inter_ball_subset_filledHull_of_diam_lt'
+theorem image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
     (hf : DifferentiableOn ℂ f (ball c r))
     (hinj : InjOn f (ball c r)) {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
@@ -354,7 +354,7 @@ theorem image_inter_ball_subset_filledHull_of_diam_lt'
 
 /-! ## An enclosed side is trapped, and narrow -/
 
-section OldInside
+section GeneralDomain
 
 variable {U K V : Set ℂ} {p : ℂ}
 
@@ -441,6 +441,6 @@ theorem image_inter_ball_subset_filledHull_of_frontier_subset (hUo : IsOpen U)
     hb
     fun _ hw => (frontier_image_inter_ball_subset hUo hd hinj hw).imp id fun h => hE ⟨h, hw⟩
 
-end OldInside
+end GeneralDomain
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.Analysis.Normed.Module.FilledHull
 import Mathlib.Analysis.Calculus.Deriv.Slope
 import Mathlib.MeasureTheory.Integral.CircleIntegral
-import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
+import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
 import TauCeti.Analysis.Complex.Conformal.InverseFunction
 import TauCeti.Analysis.Contour.Winding.Separation
@@ -33,21 +33,26 @@ filled hull. No Jordan curve theorem is used.
 
 This is the planar-separation step of the `ConformalMapping` roadmap (L5).
 
+Layer L5 is absent from
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
+human-curated Riemann-mapping-theorem effort, and Mathlib has no boundary correspondence for
+conformal maps, so this is new Lean formalization rather than a temporary shim.
+
 ## Main results
 
 * `TauCeti.exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall` — **the transversal
   segment through a point of the image crosscut, with near side and far side on opposite sides.**
-* `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg`
+* `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg`
   — **the image crosscut is
   adherent to each of its points from both sides of the transversal.**
 * `TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull` —
   **one of the two image pieces lies in the filled hull of a closed bounded set through the image
   crosscut.** Requires `K \ {f z₀}` preconnected.
-* `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff` — diameter
-  selection: when the enclosing set is narrower than the far side, the near side is enclosed.
-  Consumes the disjunction above without the `hp`/`hin` plane-separation input.
-* `TauCeti.image_subset_filledHull_of_disjoint_inter_sphere` — an image side meeting the inside of
-  such a curve lies inside it.
+* `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton`
+  — diameter selection: when the enclosing set is narrower than the far side, the near side is
+  enclosed.
+  Consumes the disjunction above; `IsJordanCurve.isPathConnected_sdiff_singleton` discharges the
+  preconnectedness hypothesis in the intended application.
 * `TauCeti.image_inter_ball_subset_filledHull_of_frontier_subset` — the enclosure hypothesis is
   implied by the boundary-piece hypothesis of `Conformal/CutDiameter.lean`.
 
@@ -69,24 +74,6 @@ namespace TauCeti
 
 variable {f : ℂ → ℂ} {c ζ z₀ : ℂ} {r ρ : ℝ}
 
-private theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
-    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
-    (hz₀ : z₀ ∈ U) (n : ℂ) :
-    HasDerivAt (fun t : ℝ => Function.invFunOn f U (deriv f z₀ * n * t + f z₀)) n 0 := by
-  have h1 : HasDerivAt (fun t : ℝ => deriv f z₀ * n * (t : ℂ) + f z₀)
-      (deriv f z₀ * n) 0 := by
-    simpa using
-      (((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (deriv f z₀ * n)).add_const (f z₀))
-  have h2 : HasDerivAt (Function.invFunOn f U) (deriv f z₀)⁻¹
-      (deriv f z₀ * n * ((0 : ℝ) : ℂ) + f z₀) := by
-    simpa using hasDerivAt_invFunOn hf hU hinj hz₀
-  have h3 := HasDerivAt.scomp (0 : ℝ) h2 h1
-  have h4 : (deriv f z₀ * n) • (deriv f z₀)⁻¹ = n := by
-    rw [smul_eq_mul]
-    field_simp [deriv_ne_zero_of_injOn hf hU hinj hz₀]
-  rw [h4] at h3
-  exact h3
-
 /-- **The transversal segment through a point of the image crosscut.** For small negative `t` the
 segment lies in the image of the near side, and for small positive `t` in the far side. -/
 theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : Set ℂ}
@@ -100,9 +87,7 @@ theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : S
   obtain ⟨hz₀b, hz₀s⟩ := hz₀
   have hΩ : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hU hf hinj
   have hp : f z₀ ∈ f '' U := mem_image_of_mem f hz₀b
-  set g := Function.invFunOn f U with hg_def
-  have hg : DifferentiableOn ℂ g (f '' U) :=
-    TauCeti.DifferentiableOn.invFunOn hf hU hinj
+  set g := Function.invFunOn f U
   have hgf : ∀ z ∈ U, g (f z) = z := fun z hz => hinj.leftInvOn_invFunOn hz
   have hfg : ∀ w ∈ f '' U, f (g w) = w := fun w hw => Function.invFunOn_eq hw
   have hgmem : ∀ w ∈ f '' U, g w ∈ U := fun w hw => Function.invFunOn_mem hw
@@ -110,7 +95,6 @@ theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : S
     deriv_ne_zero_of_injOn hf hU hinj hz₀b
   have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀s hρ.ne')
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
-  have hv : v ≠ 0 := mul_ne_zero hd0 hzζ
   -- the pulled-back segment has velocity `z₀ - ζ` at `t = 0`
   have hφ : HasDerivAt (fun t : ℝ => g (v * t + f z₀)) (z₀ - ζ) 0 :=
     hasDerivAt_invFunOn_comp_segment hf hU hinj hz₀b (z₀ - ζ)
@@ -126,58 +110,66 @@ theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : S
     exact hcont.continuousAt.preimage_mem_nhds (hΩ.mem_nhds h0)
   obtain ⟨η, hη, hηball⟩ := Metric.eventually_nhds_iff.mp (hev.and hΩev)
   have hnorm : ‖z₀ - ζ‖ = ρ := by rwa [← dist_eq_norm, ← mem_sphere]
+  -- shared estimate: for |t| < min η 1, extract preimage and little-o bound
+  have hcore : ∀ t : ℝ, t ∈ Ioo (-(min η 1)) (min η 1) → t ≠ 0 →
+      v * t + f z₀ ∈ f '' U ∧
+      ‖g (v * t + f z₀) - z₀ - t • (z₀ - ζ)‖ ≤ ρ / 2 * |t| := by
+    intro t ht ht0
+    have htη : dist t 0 < η := by
+      rw [Real.dist_eq, sub_zero]
+      exact (abs_lt.mpr ⟨by linarith [ht.1], by linarith [ht.2]⟩).trans_le
+        (min_le_left η 1)
+    obtain ⟨hlo, hmem⟩ := hηball htη
+    rw [hφ0, sub_zero] at hlo
+    exact ⟨hmem, hlo⟩
   refine ⟨min η 1, lt_min hη one_pos, fun t ht => ?_, fun t ht => ?_⟩
   · -- `t < 0`: the pulled-back point is closer to `ζ` than `ρ`
-    have htη : dist t 0 < η := by
-      rw [Real.dist_eq, sub_zero, abs_of_neg ht.2]
-      linarith [ht.1, min_le_left η 1]
     have ht1 : -1 < t := by linarith [ht.1, min_le_right η 1]
-    obtain ⟨hlo, hmem⟩ := hηball htη
-    rw [hφ0, sub_zero, Real.norm_eq_abs, abs_of_neg ht.2] at hlo
-    have hfactor : z₀ - ζ + t • (z₀ - ζ) = (1 + t) • (z₀ - ζ) := by
-      rw [add_smul, one_smul]
+    obtain ⟨hmem, hlo⟩ := hcore t
+      ⟨ht.1, by linarith [ht.2, lt_min hη one_pos]⟩ ht.2.ne
+    rw [abs_of_neg ht.2] at hlo
     refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, ?_⟩, hfg _ hmem⟩
     rw [mem_ball, dist_eq_norm]
     calc ‖g (v * t + f z₀) - ζ‖
-        ≤ ‖z₀ - ζ + t • (z₀ - ζ)‖ +
+        ≤ ‖(1 + t) • (z₀ - ζ)‖ +
             ‖g (v * t + f z₀) - z₀ - t • (z₀ - ζ)‖ := by
-          have := norm_le_insert' (g (v * t + f z₀) - ζ) (z₀ - ζ + t • (z₀ - ζ))
-          have e : g (v * t + f z₀) - ζ - (z₀ - ζ + t • (z₀ - ζ))
-              = g (v * t + f z₀) - z₀ - t • (z₀ - ζ) := by abel
-          rwa [e] at this
+          have := norm_le_insert'
+            (g (v * t + f z₀) - ζ) ((1 + t) • (z₀ - ζ))
+          rwa [show g (v * t + f z₀) - ζ - (1 + t) • (z₀ - ζ)
+              = g (v * t + f z₀) - z₀ - t • (z₀ - ζ) from by
+            rw [add_smul, one_smul]; abel] at this
       _ ≤ (1 + t) * ρ + ρ / 2 * (-t) := by
           gcongr
-          · rw [hfactor, norm_smul, hnorm, Real.norm_eq_abs,
+          · rw [norm_smul, hnorm, Real.norm_eq_abs,
               abs_of_pos (by linarith)]
       _ < ρ := by nlinarith [ht.2]
   · -- `t > 0`: the pulled-back point is farther from `ζ` than `ρ`
-    have htη : dist t 0 < η := by
-      rw [Real.dist_eq, sub_zero, abs_of_pos ht.1]
-      linarith [ht.2, min_le_left η 1]
-    obtain ⟨hlo, hmem⟩ := hηball htη
-    rw [hφ0, sub_zero, Real.norm_eq_abs, abs_of_pos ht.1] at hlo
-    have hfactor : z₀ - ζ + t • (z₀ - ζ) = (1 + t) • (z₀ - ζ) := by
-      rw [add_smul, one_smul]
-    refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, fun hcb => ?_⟩, hfg _ hmem⟩
+    obtain ⟨hmem, hlo⟩ := hcore t
+      ⟨by linarith [ht.1, lt_min hη one_pos], ht.2⟩ ht.1.ne'
+    rw [abs_of_pos ht.1] at hlo
+    refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, fun hcb => ?_⟩,
+      hfg _ hmem⟩
     rw [mem_closedBall, dist_eq_norm] at hcb
     have hlow : (1 + t) * ρ - ρ / 2 * t ≤ ‖g (v * t + f z₀) - ζ‖ := by
       calc (1 + t) * ρ - ρ / 2 * t
-          ≤ ‖z₀ - ζ + t • (z₀ - ζ)‖ -
+          ≤ ‖(1 + t) • (z₀ - ζ)‖ -
               ‖g (v * t + f z₀) - z₀ - t • (z₀ - ζ)‖ := by
-            rw [hfactor, norm_smul, hnorm, Real.norm_eq_abs,
+            rw [norm_smul, hnorm, Real.norm_eq_abs,
               abs_of_pos (by linarith [ht.1])]
             linarith
         _ ≤ ‖g (v * t + f z₀) - ζ‖ := by
-            have := norm_sub_norm_le (z₀ - ζ + t • (z₀ - ζ)) (g (v * t + f z₀) - ζ)
-            have e : z₀ - ζ + t • (z₀ - ζ) - (g (v * t + f z₀) - ζ)
-                = -(g (v * t + f z₀) - z₀ - t • (z₀ - ζ)) := by abel
-            rw [e, norm_neg] at this
+            have := norm_sub_norm_le
+              ((1 + t) • (z₀ - ζ)) (g (v * t + f z₀) - ζ)
+            rw [show (1 + t) • (z₀ - ζ) - (g (v * t + f z₀) - ζ)
+                = -(g (v * t + f z₀) - z₀ - t • (z₀ - ζ)) from by
+              rw [add_smul, one_smul]; abel,
+              norm_neg] at this
             linarith
     nlinarith [ht.1]
 
 /-- **The image crosscut is adherent from both sides of the transversal segment.** In the
 transversal coordinate the crosscut has velocity `i` at the crossing point. -/
-theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg
+theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
     {U : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U)
     (hinj : InjOn f U) (hz₀ : z₀ ∈ U ∩ sphere ζ ρ) (hρ : 0 < ρ) :
@@ -264,7 +256,7 @@ preconnected as a continuous image of a preconnected set and disjoint from `K` b
 so `TauCeti.IsPreconnected.subset_filledHull`
 traps it in the bounded component of `Kᶜ` it meets. Instantiate `V` at `U ∩ ball ζ ρ` for the near
 side and at `U \ closedBall ζ ρ` for the far side. -/
-theorem image_subset_filledHull_of_disjoint_inter_sphere {U V K : Set ℂ} (hUo : IsOpen U)
+private theorem image_subset_filledHull_of_disjoint_inter_sphere {U V K : Set ℂ} (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
     (hV : Disjoint V (U ∩ sphere ζ ρ)) (hVc : IsPreconnected V)
     (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U))
@@ -299,9 +291,8 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
       (sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀.2 hρ.ne'))
   obtain ⟨η, hη, hnear, hfar⟩ :=
     exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall hf hUo hinj hz₀ hρ
-  obtain ⟨hleft, hright⟩ :=
-    mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg
-      hf hUo hinj hz₀ hρ
+  obtain ⟨hleft, hright⟩ := mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
+    hf hUo hinj hz₀ hρ
   -- neither image piece meets `K`
   have hnearK : Disjoint (f '' (U ∩ ball ζ ρ)) K :=
     disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
@@ -339,11 +330,13 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
 enclosed.** This consumes the disjunction
 `TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull` by
 excluding the far-side case: trapping the far side inside `K` gives
-`diam (f '' (U \ closedBall ζ ρ)) ≤ diam K`, contradicting the hypothesis. Unlike
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt`, no `hp`/`hin` plane-separation input is
-needed — the preconnectedness hypothesis `hKp` on `K \ {p}` is discharged by
+`diam (f '' (U \ closedBall ζ ρ)) ≤ diam K`, contradicting the hypothesis. The plane-separation
+input `p ∈ closure (filledHull K \ K)` is replaced by preconnectedness of `K \ {f z₀}`, which is
+discharged by
 `IsJordanCurve.isPathConnected_sdiff_singleton` in the intended application. -/
-theorem image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff {U : Set ℂ}
+theorem
+    image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton
+    {U : Set ℂ}
     (hUo : IsOpen U) (hρ : 0 < ρ)
     (hf : DifferentiableOn ℂ f U)
     (hinj : InjOn f U) (hAc : IsPreconnected (U ∩ ball ζ ρ))
@@ -360,7 +353,7 @@ theorem image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff {U
   · exact h
   · exact absurd (diam_le_diam_of_subset_filledHull hKb h) (not_le.mpr hlt)
 
-/-! ## An enclosed side is trapped, and narrow -/
+/-! ## The frontier route to enclosure -/
 
 section GeneralDomain
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -47,13 +47,6 @@ This is the planar-separation step of the `ConformalMapping` roadmap (L5).
   Consumes the disjunction above without the `hp`/`hin` plane-separation input.
 * `TauCeti.image_subset_filledHull_of_disjoint_inter_sphere` — an image side meeting the inside of
   such a curve lies inside it.
-* `TauCeti.nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull` —
-  one of the two image sides meets the inside of a curve when an image-domain point lies in
-  `closure (filledHull K \ K)`. This is where the inside assumption
-  `hin : p ∈ closure (filledHull K \ K)` is introduced; the diameter criterion below passes it on
-  unchanged.
-* `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` — such a curve, if narrower than the far
-  side, encloses the *near* side. Takes preconnectedness of the two sides as hypotheses.
 * `TauCeti.image_inter_ball_subset_filledHull_of_frontier_subset` — the enclosure hypothesis is
   implied by the boundary-piece hypothesis of `Conformal/CutDiameter.lean`.
 
@@ -85,11 +78,11 @@ private theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
       (((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (deriv f z₀ * n)).add_const (f z₀))
   have h2 : HasDerivAt (Function.invFunOn f U) (deriv f z₀)⁻¹
       (deriv f z₀ * n * ((0 : ℝ) : ℂ) + f z₀) := by
-    simpa using hf.hasDerivAt_invFunOn hU hinj hz₀
+    simpa using hasDerivAt_invFunOn hf hU hinj hz₀
   have h3 := HasDerivAt.scomp (0 : ℝ) h2 h1
   have h4 : (deriv f z₀ * n) • (deriv f z₀)⁻¹ = n := by
     rw [smul_eq_mul]
-    field_simp [hf.deriv_ne_zero_of_injOn hU hinj hz₀]
+    field_simp [deriv_ne_zero_of_injOn hf hU hinj hz₀]
   rw [h4] at h3
   exact h3
 
@@ -113,7 +106,7 @@ theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall {U : Set ℂ}
   have hfg : ∀ w ∈ f '' U, f (g w) = w := fun w hw => Function.invFunOn_eq hw
   have hgmem : ∀ w ∈ f '' U, g w ∈ U := fun w hw => Function.invFunOn_mem hw
   have hd0 : deriv f z₀ ≠ 0 :=
-    hf.deriv_ne_zero_of_injOn hU hinj hz₀b
+    deriv_ne_zero_of_injOn hf hU hinj hz₀b
   have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀s hρ.ne')
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
   have hv : v ≠ 0 := mul_ne_zero hd0 hzζ
@@ -192,7 +185,7 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg {U : Set �
         {q | ((q - f z₀) / (deriv f z₀ * (z₀ - ζ))).im < 0}) := by
   obtain ⟨hz₀b, hz₀s⟩ := hz₀
   have hd0 : deriv f z₀ ≠ 0 :=
-    hf.deriv_ne_zero_of_injOn hU hinj hz₀b
+    deriv_ne_zero_of_injOn hf hU hinj hz₀b
   have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀s hρ.ne')
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
   have hfz : HasDerivAt f (deriv f z₀) z₀ :=
@@ -300,7 +293,7 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
   set p := f z₀ with hp_def
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
   have hv : v ≠ 0 :=
-    mul_ne_zero (hf.deriv_ne_zero_of_injOn hUo hinj hz₀.1)
+    mul_ne_zero (deriv_ne_zero_of_injOn hf hUo hinj hz₀.1)
       (sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀.2 hρ.ne'))
   obtain ⟨η, hη, hnear, hfar⟩ :=
     exists_mem_image_inter_ball_and_image_sdiff_closedBall hf hUo hinj hz₀ hρ
@@ -371,54 +364,6 @@ section GeneralDomain
 variable {U K V : Set ℂ} {p : ℂ}
 
 open Topology
-
-/-- **One of the two image sides meets the inside of a curve with an image-domain point adherent to
-its inside.** If a point `p` of the image domain lies in `closure (filledHull K \ K)` — i.e. is a
-limit of points of `filledHull K \ K` — then a point `q` close enough to `p` lies in the open image
-domain; being off `K` it is off the image crosscut, so it lies on one of the two image sides, and it
-lies in `filledHull K`.
-
-This is where the inside assumption is introduced, at one point as a hypothesis; the diameter
-criterion below passes it on unchanged. For a Jordan curve `K` the hypothesis is the
-plane-separation statement `J ⊆ closure (filledHull J \ J)` recorded in the roadmap section of
-`TauCeti/Topology/FilledHull.lean`, read at `p`. -/
-theorem nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull
-    (hΩo : IsOpen (f '' U)) (hγ : f '' (U ∩ sphere ζ ρ) ⊆ K)
-    (hp : p ∈ f '' U) (hin : p ∈ closure (filledHull K \ K)) :
-    (f '' (U ∩ ball ζ ρ) ∩ filledHull K).Nonempty ∨
-      (f '' (U \ closedBall ζ ρ) ∩ filledHull K).Nonempty := by
-  obtain ⟨q, hqΩ, hqH, hqK⟩ :=
-    mem_closure_iff.mp hin _ hΩo hp
-  rw [image_eq_image_inter_ball_union_image_sdiff_closedBall_union_image_inter_sphere] at hqΩ
-  exact (hqΩ.resolve_right fun h => hqK (hγ h)).imp (fun h => ⟨q, h, hqH⟩) fun h => ⟨q, h, hqH⟩
-
-/-- **A narrow curve next to a crosscut encloses the near side.** Let `K` be bounded, run from the
-image crosscut along the boundary of the image domain, and have a point of its inside next to the
-image crosscut. If `K` is narrower than the *far* image side — the situation at a small crosscut
-radius, where the far side is nearly the whole image domain — then it is the *near* side that `K`
-encloses, and by `TauCeti.diam_le_diam_of_subset_filledHull` that side is no wider than `K`.
-
-Of the two alternatives
-`TauCeti.nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull`
-offers, the far one
-is excluded: it would trap the far side inside `K` and so make it no wider than `K`. The theorem
-still requires both cut sides to be preconnected, a point in the image domain, and the strict
-far-side diameter bound; those inputs are not produced here. -/
-theorem image_inter_ball_subset_filledHull_of_diam_lt (hUo : IsOpen U)
-    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U)
-    (hAc : IsPreconnected (U ∩ ball ζ ρ)) (hBc : IsPreconnected (U \ closedBall ζ ρ))
-    (hKb : IsBounded K) (hγ : f '' (U ∩ sphere ζ ρ) ⊆ K)
-    (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U))
-    (hlt : diam K < diam (f '' (U \ closedBall ζ ρ)))
-    (hp : p ∈ f '' U) (hin : p ∈ closure (filledHull K \ K)) :
-    f '' (U ∩ ball ζ ρ) ⊆ filledHull K := by
-  rcases nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull
-    (isOpen_image_of_differentiableOn_of_injOn hUo hd hinj) hγ hp hin with h | h
-  · exact image_subset_filledHull_of_disjoint_inter_sphere hUo hd hinj inter_subset_left
-      disjoint_inter_ball_inter_sphere hAc hK h
-  · exact absurd (diam_le_diam_of_subset_filledHull hKb
-      (image_subset_filledHull_of_disjoint_inter_sphere hUo hd hinj sdiff_subset
-        disjoint_sdiff_closedBall_inter_sphere hBc hK h)) (not_le.mpr hlt)
 
 /-- **A boundary piece enclosing what the near side clings to encloses the near side.** If every
 boundary point of the image domain on the frontier of the near image side lies in `E`, then the

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -35,9 +35,10 @@ This is the planar-separation step of the `ConformalMapping` roadmap (L5).
 
 ## Main results
 
-* `TauCeti.exists_mem_image_inter_ball_and_image_sdiff_closedBall` — **the transversal
+* `TauCeti.exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall` — **the transversal
   segment through a point of the image crosscut, with near side and far side on opposite sides.**
-* `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg` — **the image crosscut is
+* `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg`
+  — **the image crosscut is
   adherent to each of its points from both sides of the transversal.**
 * `TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull` —
   **one of the two image pieces lies in the filled hull of a closed bounded set through the image
@@ -88,7 +89,7 @@ private theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
 
 /-- **The transversal segment through a point of the image crosscut.** For small negative `t` the
 segment lies in the image of the near side, and for small positive `t` in the far side. -/
-theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall {U : Set ℂ}
+theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
     (hz₀ : z₀ ∈ U ∩ sphere ζ ρ) (hρ : 0 < ρ) :
     ∃ η : ℝ, 0 < η ∧
@@ -176,7 +177,8 @@ theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall {U : Set ℂ}
 
 /-- **The image crosscut is adherent from both sides of the transversal segment.** In the
 transversal coordinate the crosscut has velocity `i` at the crossing point. -/
-theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg {U : Set ℂ}
+theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg
+    {U : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U)
     (hinj : InjOn f U) (hz₀ : z₀ ∈ U ∩ sphere ζ ρ) (hρ : 0 < ρ) :
     f z₀ ∈ closure (f '' (U ∩ sphere ζ ρ) ∩
@@ -296,9 +298,10 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
     mul_ne_zero (deriv_ne_zero_of_injOn hf hUo hinj hz₀.1)
       (sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀.2 hρ.ne'))
   obtain ⟨η, hη, hnear, hfar⟩ :=
-    exists_mem_image_inter_ball_and_image_sdiff_closedBall hf hUo hinj hz₀ hρ
+    exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall hf hUo hinj hz₀ hρ
   obtain ⟨hleft, hright⟩ :=
-    mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg hf hUo hinj hz₀ hρ
+    mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg
+      hf hUo hinj hz₀ hρ
   -- neither image piece meets `K`
   have hnearK : Disjoint (f '' (U ∩ ball ζ ρ)) K :=
     disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -44,9 +44,10 @@ This is the planar-separation step of the `ConformalMapping` roadmap (L5).
 * `TauCeti.image_subset_filledHull_of_disjoint_inter_sphere` — an image side meeting the inside of
   such a curve lies inside it.
 * `TauCeti.nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull` —
-  one of the two image sides meets the inside of a curve with inside points next to the image
-  domain. This is where the inside assumption `hin : p ∈ closure (filledHull K \ K)` is
-  introduced; the diameter criterion below passes it on unchanged.
+  one of the two image sides meets the inside of a curve when an image-domain point lies in
+  `closure (filledHull K \ K)`. This is where the inside assumption
+  `hin : p ∈ closure (filledHull K \ K)` is introduced; the diameter criterion below passes it on
+  unchanged.
 * `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` — such a curve, if narrower than the far
   side, encloses the *near* side.
 * `TauCeti.image_inter_ball_subset_filledHull_of_frontier_subset` — the enclosure hypothesis is
@@ -265,24 +266,22 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
 
 /-- **One of the two image pieces lies in the filled hull of a closed bounded set through the image
 crosscut.** The transversal segment meets the set only at the crossing point, and the set minus that
-point is preconnected, so the winding-number two-sidedness theorem applies. -/
+point is preconnected, so the winding-number two-sidedness theorem applies. The preconnectedness
+hypothesis `hKp` is required only at the selected crossing point `z₀`, not at every crosscut
+point. -/
 theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
     (hf : DifferentiableOn ℂ f (ball c r))
     (hinj : InjOn f (ball c r)) {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
     (hγK : f '' (ball c r ∩ sphere ζ ρ) ⊆ K)
     (hKsub : K ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r))
-    (hKp : ∀ p ∈ f '' (ball c r ∩ sphere ζ ρ), IsPreconnected (K \ {p})) :
+    {z₀ : ℂ} (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ)
+    (hKp : IsPreconnected (K \ {f z₀})) :
     f '' (ball c r ∩ ball ζ ρ) ⊆ filledHull K ∨
       f '' (ball c r \ closedBall ζ ρ) ⊆ filledHull K := by
   have hγKcl : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ K :=
     hK.closure_subset_iff.mpr hγK
   have hr : 0 < r := by linarith
-  -- a point of the crosscut: the point of `sphere ζ ρ` in the direction of the centre
-  have hz₀ : circleMap ζ ρ (c - ζ).arg ∈ ball c r ∩ sphere ζ ρ :=
-    ⟨(circleMap_mem_ball_iff hζ hρ _).mpr (by simpa using hρr),
-      circleMap_mem_sphere ζ hρ.le _⟩
-  set z₀ := circleMap ζ ρ (c - ζ).arg with hz₀_def
   have hΩ : IsOpen (f '' ball c r) := isOpen_image_of_differentiableOn_of_injOn isOpen_ball hf hinj
   set p := f z₀ with hp_def
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
@@ -314,7 +313,7 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
   have key := Contour.mem_filledHull_or_mem_filledHull_of_isPreconnected_sdiff_singleton
     (K := K) (v := v) (z₀ := p) (a := -(η / 2)) (b := η / 2) (s := 0)
     hK hKb hv ⟨by linarith, by linarith⟩
-    (by simpa using hseg) (by simpa using hKp p hpγ)
+    (by simpa using hseg) (by simpa using hKp)
     (by simpa using closure_mono (hγK' _) hleft) (by simpa using closure_mono (hγK' _) hright)
   rcases key with hx | hy
   · left
@@ -344,11 +343,12 @@ theorem image_inter_ball_subset_filledHull_of_diam_lt'
     (hinj : InjOn f (ball c r)) {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
     (hγK : f '' (ball c r ∩ sphere ζ ρ) ⊆ K)
     (hKsub : K ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r))
-    (hKp : ∀ p ∈ f '' (ball c r ∩ sphere ζ ρ), IsPreconnected (K \ {p}))
+    {z₀ : ℂ} (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ)
+    (hKp : IsPreconnected (K \ {f z₀}))
     (hlt : diam K < diam (f '' (ball c r \ closedBall ζ ρ))) :
     f '' (ball c r ∩ ball ζ ρ) ⊆ filledHull K := by
   rcases image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull
-    hζ hρ hρr hf hinj hK hKb hγK hKsub hKp with h | h
+    hζ hρ hρr hf hinj hK hKb hγK hKsub hz₀ hKp with h | h
   · exact h
   · exact absurd (diam_le_diam_of_subset_filledHull hKb h) (not_le.mpr hlt)
 
@@ -375,11 +375,11 @@ theorem image_subset_filledHull_of_disjoint_inter_sphere (hUo : IsOpen U)
     (disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
       hUo hd hinj hVU hV hK) hne
 
-/-- **One of the two image sides meets the inside of a curve with a point of its inside in the image
-domain.** If a point `p` of the image domain is a limit of points of `filledHull K \ K`,
-then such a point
-`q` close enough to `p` lies in the open image domain; being off `K` it is off the image crosscut,
-so it lies on one of the two image sides, and it lies in `filledHull K`.
+/-- **One of the two image sides meets the inside of a curve with an image-domain point adherent to
+its inside.** If a point `p` of the image domain lies in `closure (filledHull K \ K)` — i.e. is a
+limit of points of `filledHull K \ K` — then a point `q` close enough to `p` lies in the open image
+domain; being off `K` it is off the image crosscut, so it lies on one of the two image sides, and it
+lies in `filledHull K`.
 
 This is where the inside assumption is introduced, at one point as a hypothesis; the diameter
 criterion below passes it on unchanged. For a Jordan curve `K` the hypothesis is the

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -18,9 +18,9 @@ import TauCeti.Topology.MetricSpace.Cut
 /-!
 # One image piece of a crosscut lies inside a compact enclosing set
 
-For a holomorphic injection of an open set `U`, one of the two image pieces — the near side
-`U ∩ ball ζ ρ` or the far side `U \ closedBall ζ ρ` — lies in the filled hull of a closed bounded
-set `K` through the image crosscut. The hypotheses are:
+For a holomorphic injection of an open set `U`, one of the two image pieces — the near
+side `U ∩ ball ζ ρ` or the far side `U \ closedBall ζ ρ` — lies in the filled hull of a
+closed bounded set `K` through the image crosscut. The hypotheses are:
 
 * `K` contains the image crosscut and is contained in its closure union `frontier (f '' U)`.
 * `K \ {f z₀}` is preconnected at a chosen crosscut point `z₀`.

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -10,7 +10,6 @@ import Mathlib.Analysis.Calculus.Deriv.Slope
 import Mathlib.MeasureTheory.Integral.CircleIntegral
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
-import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
 import TauCeti.Analysis.Complex.Conformal.InverseFunction
 import TauCeti.Analysis.Contour.Winding.Separation
 import TauCeti.Topology.MetricSpace.Cut
@@ -96,40 +95,40 @@ private theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
 
 /-- **The transversal segment through a point of the image crosscut.** For small negative `t` the
 segment lies in the image of the near side, and for small positive `t` in the far side. -/
-theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall
-    (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
-    (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ) (hρ : 0 < ρ) :
+theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall {U : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
+    (hz₀ : z₀ ∈ U ∩ sphere ζ ρ) (hρ : 0 < ρ) :
     ∃ η : ℝ, 0 < η ∧
       (∀ t : ℝ, t ∈ Ioo (-η) 0 →
-        deriv f z₀ * (z₀ - ζ) * (t : ℂ) + f z₀ ∈ f '' (ball c r ∩ ball ζ ρ)) ∧
+        deriv f z₀ * (z₀ - ζ) * (t : ℂ) + f z₀ ∈ f '' (U ∩ ball ζ ρ)) ∧
       ∀ t : ℝ, t ∈ Ioo 0 η →
-        deriv f z₀ * (z₀ - ζ) * (t : ℂ) + f z₀ ∈ f '' (ball c r \ closedBall ζ ρ) := by
+        deriv f z₀ * (z₀ - ζ) * (t : ℂ) + f z₀ ∈ f '' (U \ closedBall ζ ρ) := by
   obtain ⟨hz₀b, hz₀s⟩ := hz₀
-  have hΩ : IsOpen (f '' ball c r) := isOpen_image_of_differentiableOn_of_injOn isOpen_ball hf hinj
-  have hp : f z₀ ∈ f '' ball c r := mem_image_of_mem f hz₀b
-  set g := Function.invFunOn f (ball c r) with hg_def
-  have hg : DifferentiableOn ℂ g (f '' ball c r) :=
-    TauCeti.DifferentiableOn.invFunOn hf isOpen_ball hinj
-  have hgf : ∀ z ∈ ball c r, g (f z) = z := fun z hz => hinj.leftInvOn_invFunOn hz
-  have hfg : ∀ w ∈ f '' ball c r, f (g w) = w := fun w hw => Function.invFunOn_eq hw
-  have hgmem : ∀ w ∈ f '' ball c r, g w ∈ ball c r := fun w hw => Function.invFunOn_mem hw
+  have hΩ : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hU hf hinj
+  have hp : f z₀ ∈ f '' U := mem_image_of_mem f hz₀b
+  set g := Function.invFunOn f U with hg_def
+  have hg : DifferentiableOn ℂ g (f '' U) :=
+    TauCeti.DifferentiableOn.invFunOn hf hU hinj
+  have hgf : ∀ z ∈ U, g (f z) = z := fun z hz => hinj.leftInvOn_invFunOn hz
+  have hfg : ∀ w ∈ f '' U, f (g w) = w := fun w hw => Function.invFunOn_eq hw
+  have hgmem : ∀ w ∈ f '' U, g w ∈ U := fun w hw => Function.invFunOn_mem hw
   have hd0 : deriv f z₀ ≠ 0 :=
-    hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀b
+    hf.deriv_ne_zero_of_injOn hU hinj hz₀b
   have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀s hρ.ne')
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
   have hv : v ≠ 0 := mul_ne_zero hd0 hzζ
   -- the pulled-back segment has velocity `z₀ - ζ` at `t = 0`
   have hφ : HasDerivAt (fun t : ℝ => g (v * t + f z₀)) (z₀ - ζ) 0 :=
-    hasDerivAt_invFunOn_comp_segment hf isOpen_ball hinj hz₀b (z₀ - ζ)
+    hasDerivAt_invFunOn_comp_segment hf hU hinj hz₀b (z₀ - ζ)
   have hφ0 : g (v * ((0 : ℝ) : ℂ) + f z₀) = z₀ := by simp [hgf z₀ hz₀b]
   -- the little-`o` estimate at `t = 0`, and the segment staying in the image domain
   have hev : ∀ᶠ t : ℝ in 𝓝 0,
       ‖g (v * t + f z₀) - g (v * ((0 : ℝ) : ℂ) + f z₀) - (t - 0) • (z₀ - ζ)‖ ≤
         ρ / 2 * ‖t - 0‖ :=
     (hasDerivAt_iff_isLittleO.mp hφ).def (by positivity)
-  have hΩev : ∀ᶠ t : ℝ in 𝓝 0, v * t + f z₀ ∈ f '' ball c r := by
+  have hΩev : ∀ᶠ t : ℝ in 𝓝 0, v * t + f z₀ ∈ f '' U := by
     have hcont : Continuous fun t : ℝ => v * (t : ℂ) + f z₀ := by fun_prop
-    have h0 : (fun t : ℝ => v * (t : ℂ) + f z₀) 0 ∈ f '' ball c r := by simpa using hp
+    have h0 : (fun t : ℝ => v * (t : ℂ) + f z₀) 0 ∈ f '' U := by simpa using hp
     exact hcont.continuousAt.preimage_mem_nhds (hΩ.mem_nhds h0)
   obtain ⟨η, hη, hηball⟩ := Metric.eventually_nhds_iff.mp (hev.and hΩev)
   have hnorm : ‖z₀ - ζ‖ = ρ := by rwa [← dist_eq_norm, ← mem_sphere]
@@ -184,20 +183,20 @@ theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall
 
 /-- **The image crosscut is adherent from both sides of the transversal segment.** In the
 transversal coordinate the crosscut has velocity `i` at the crossing point. -/
-theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
-    (hf : DifferentiableOn ℂ f (ball c r))
-    (hinj : InjOn f (ball c r)) (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ) (hρ : 0 < ρ) :
-    f z₀ ∈ closure (f '' (ball c r ∩ sphere ζ ρ) ∩
+theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg {U : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U)
+    (hinj : InjOn f U) (hz₀ : z₀ ∈ U ∩ sphere ζ ρ) (hρ : 0 < ρ) :
+    f z₀ ∈ closure (f '' (U ∩ sphere ζ ρ) ∩
         {q | 0 < ((q - f z₀) / (deriv f z₀ * (z₀ - ζ))).im}) ∧
-    f z₀ ∈ closure (f '' (ball c r ∩ sphere ζ ρ) ∩
+    f z₀ ∈ closure (f '' (U ∩ sphere ζ ρ) ∩
         {q | ((q - f z₀) / (deriv f z₀ * (z₀ - ζ))).im < 0}) := by
   obtain ⟨hz₀b, hz₀s⟩ := hz₀
   have hd0 : deriv f z₀ ≠ 0 :=
-    hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀b
+    hf.deriv_ne_zero_of_injOn hU hinj hz₀b
   have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀s hρ.ne')
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
   have hfz : HasDerivAt f (deriv f z₀) z₀ :=
-    (hf.differentiableAt (isOpen_ball.mem_nhds hz₀b)).hasDerivAt
+    (hf.differentiableAt (hU.mem_nhds hz₀b)).hasDerivAt
   obtain ⟨θ₀, -, hθ₀⟩ := exists_mem_Icc_circleMap_eq 0 hz₀s
   rw [zero_add] at hθ₀
   -- the imaginary coordinate of the crosscut, as a function of the angle
@@ -237,20 +236,20 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
   have hcirc : Continuous fun t : ℝ => circleMap ζ ρ (θ₀ + t) :=
     (continuous_circleMap ζ ρ).comp (continuous_const.add continuous_id)
   have hcirc0 : circleMap ζ ρ (θ₀ + 0) = z₀ := by rw [add_zero, hθ₀]
-  have hball : ∀ᶠ t in 𝓝 (0 : ℝ), circleMap ζ ρ (θ₀ + t) ∈ ball c r := by
+  have hball : ∀ᶠ t in 𝓝 (0 : ℝ), circleMap ζ ρ (θ₀ + t) ∈ U := by
     refine hcirc.continuousAt.preimage_mem_nhds ?_
     rw [hcirc0]
-    exact isOpen_ball.mem_nhds hz₀b
+    exact hU.mem_nhds hz₀b
   have hclose : ∀ ε > 0, ∀ᶠ t in 𝓝 (0 : ℝ),
       dist (f (circleMap ζ ρ (θ₀ + t))) (f z₀) < ε := by
     intro ε hε
     have hfc : ContinuousAt (fun t : ℝ => f (circleMap ζ ρ (θ₀ + t))) 0 :=
-      (hf.continuousOn.continuousAt (isOpen_ball.mem_nhds hz₀b)).comp_of_eq
+      (hf.continuousOn.continuousAt (hU.mem_nhds hz₀b)).comp_of_eq
         hcirc.continuousAt hcirc0
     have := hfc.eventually (Metric.ball_mem_nhds _ hε)
     simpa [hθ₀] using this
-  have hmemγ : ∀ t : ℝ, circleMap ζ ρ (θ₀ + t) ∈ ball c r →
-      f (circleMap ζ ρ (θ₀ + t)) ∈ f '' (ball c r ∩ sphere ζ ρ) := fun t ht =>
+  have hmemγ : ∀ t : ℝ, circleMap ζ ρ (θ₀ + t) ∈ U →
+      f (circleMap ζ ρ (θ₀ + t)) ∈ f '' (U ∩ sphere ζ ρ) := fun t ht =>
     mem_image_of_mem f ⟨ht, circleMap_mem_sphere ζ hρ.le _⟩
   constructor
   · rw [Metric.mem_closure_iff]
@@ -289,9 +288,9 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
     mul_ne_zero (hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀.1)
       (sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀.2 hρ.ne'))
   obtain ⟨η, hη, hnear, hfar⟩ :=
-    exists_mem_image_inter_ball_and_image_sdiff_closedBall hf hinj hz₀ hρ
+    exists_mem_image_inter_ball_and_image_sdiff_closedBall hf isOpen_ball hinj hz₀ hρ
   obtain ⟨hleft, hright⟩ :=
-    mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg hf hinj hz₀ hρ
+    mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg hf isOpen_ball hinj hz₀ hρ
   -- neither image piece meets `K`
   have hnearK : Disjoint (f '' (ball c r ∩ ball ζ ρ)) K :=
     disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -23,8 +23,8 @@ set `K` through the image crosscut. The hypotheses are:
 
 * `K` contains the image crosscut and is contained in its closure union `frontier (f '' U)`.
 * `K \ {f z₀}` is preconnected at a chosen crosscut point `z₀`.
-* The two image pieces are preconnected (the `GeneralDomain` section) or `U = ball c r` and the
-  preconnectedness is derived from the ball geometry (the first section).
+* The two image pieces are preconnected (`hAc`, `hBc`). For `U = ball c r` these follow from the
+  ball geometry (`isConnected_ball_inter_ball`, `isConnected_ball_diff_closedBall`).
 
 The transversal segment through a point of the crosscut has the near side on one side and the
 far side on the other; the winding-number two-sidedness theorem
@@ -263,43 +263,58 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg {U : Set �
       ((((hclose ε hε).and hball).filter_mono nhdsWithin_le_nhds).and hneg).exists
     exact ⟨_, ⟨hmemγ t ht2, ht3⟩, by rw [dist_comm]; exact ht1⟩
 
+/-- **An image side that meets the inside of such a curve lies inside it.** The side is
+preconnected as a continuous image of a preconnected set and disjoint from `K` by
+`TauCeti.disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image`,
+so `TauCeti.IsPreconnected.subset_filledHull`
+traps it in the bounded component of `Kᶜ` it meets. Instantiate `V` at `U ∩ ball ζ ρ` for the near
+side and at `U \ closedBall ζ ρ` for the far side. -/
+theorem image_subset_filledHull_of_disjoint_inter_sphere {U V K : Set ℂ} (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
+    (hV : Disjoint V (U ∩ sphere ζ ρ)) (hVc : IsPreconnected V)
+    (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U))
+    (hne : (f '' V ∩ filledHull K).Nonempty) : f '' V ⊆ filledHull K :=
+  IsPreconnected.subset_filledHull (hVc.image f (hd.continuousOn.mono hVU))
+    (disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
+      hUo hd hinj hVU hV hK) hne
+
 /-- **One of the two image pieces lies in the filled hull of a closed bounded set through the image
 crosscut.** The transversal segment meets the set only at the crossing point, and the set minus that
 point is preconnected, so the winding-number two-sidedness theorem applies. The preconnectedness
 hypothesis `hKp` is required only at the selected crossing point `z₀`, not at every crosscut
 point. -/
-theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull
-    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
-    (hf : DifferentiableOn ℂ f (ball c r))
-    (hinj : InjOn f (ball c r)) {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
-    (hγK : f '' (ball c r ∩ sphere ζ ρ) ⊆ K)
-    (hKsub : K ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r))
-    {z₀ : ℂ} (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ)
+theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull {U : Set ℂ}
+    (hUo : IsOpen U) (hρ : 0 < ρ)
+    (hf : DifferentiableOn ℂ f U)
+    (hinj : InjOn f U) (hAc : IsPreconnected (U ∩ ball ζ ρ))
+    (hBc : IsPreconnected (U \ closedBall ζ ρ))
+    {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
+    (hγK : f '' (U ∩ sphere ζ ρ) ⊆ K)
+    (hKsub : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U))
+    {z₀ : ℂ} (hz₀ : z₀ ∈ U ∩ sphere ζ ρ)
     (hKp : IsPreconnected (K \ {f z₀})) :
-    f '' (ball c r ∩ ball ζ ρ) ⊆ filledHull K ∨
-      f '' (ball c r \ closedBall ζ ρ) ⊆ filledHull K := by
-  have hγKcl : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ K :=
+    f '' (U ∩ ball ζ ρ) ⊆ filledHull K ∨
+      f '' (U \ closedBall ζ ρ) ⊆ filledHull K := by
+  have hγKcl : closure (f '' (U ∩ sphere ζ ρ)) ⊆ K :=
     hK.closure_subset_iff.mpr hγK
-  have hr : 0 < r := by linarith
-  have hΩ : IsOpen (f '' ball c r) := isOpen_image_of_differentiableOn_of_injOn isOpen_ball hf hinj
   set p := f z₀ with hp_def
   set v := deriv f z₀ * (z₀ - ζ) with hv_def
   have hv : v ≠ 0 :=
-    mul_ne_zero (hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀.1)
+    mul_ne_zero (hf.deriv_ne_zero_of_injOn hUo hinj hz₀.1)
       (sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀.2 hρ.ne'))
   obtain ⟨η, hη, hnear, hfar⟩ :=
-    exists_mem_image_inter_ball_and_image_sdiff_closedBall hf isOpen_ball hinj hz₀ hρ
+    exists_mem_image_inter_ball_and_image_sdiff_closedBall hf hUo hinj hz₀ hρ
   obtain ⟨hleft, hright⟩ :=
-    mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg hf isOpen_ball hinj hz₀ hρ
+    mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg hf hUo hinj hz₀ hρ
   -- neither image piece meets `K`
-  have hnearK : Disjoint (f '' (ball c r ∩ ball ζ ρ)) K :=
+  have hnearK : Disjoint (f '' (U ∩ ball ζ ρ)) K :=
     disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
-      isOpen_ball hf hinj inter_subset_left disjoint_inter_ball_inter_sphere hKsub
-  have hfarK : Disjoint (f '' (ball c r \ closedBall ζ ρ)) K :=
+      hUo hf hinj inter_subset_left disjoint_inter_ball_inter_sphere hKsub
+  have hfarK : Disjoint (f '' (U \ closedBall ζ ρ)) K :=
     disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
-      isOpen_ball hf hinj sdiff_subset disjoint_sdiff_closedBall_inter_sphere hKsub
+      hUo hf hinj sdiff_subset disjoint_sdiff_closedBall_inter_sphere hKsub
   -- the two-sidedness theorem, applied to `K` and the segment on `[-η/2, η/2]`
-  have hpγ : p ∈ f '' (ball c r ∩ sphere ζ ρ) := mem_image_of_mem f hz₀
+  have hpγ : p ∈ f '' (U ∩ sphere ζ ρ) := mem_image_of_mem f hz₀
   have hpK : p ∈ K := hγKcl (subset_closure hpγ)
   have hseg : ∀ t ∈ Icc (-(η / 2)) (η / 2), v * t + p ∈ K → t = 0 := by
     intro t ht hKt
@@ -307,7 +322,7 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
     rcases lt_or_gt_of_ne ht0 with hneg | hpos
     · exact Set.disjoint_left.mp hnearK (hnear t ⟨by linarith [ht.1], hneg⟩) hKt
     · exact Set.disjoint_left.mp hfarK (hfar t ⟨hpos, by linarith [ht.2]⟩) hKt
-  have hγK' : ∀ S : Set ℂ, f '' (ball c r ∩ sphere ζ ρ) ∩ S ⊆ K ∩ S := fun S =>
+  have hγK' : ∀ S : Set ℂ, f '' (U ∩ sphere ζ ρ) ∩ S ⊆ K ∩ S := fun S =>
     inter_subset_inter (subset_closure.trans hγKcl) subset_rfl
   have key := Contour.mem_filledHull_or_mem_filledHull_of_isPreconnected_sdiff_singleton
     (K := K) (v := v) (z₀ := p) (a := -(η / 2)) (b := η / 2) (s := 0)
@@ -316,38 +331,36 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
     (by simpa using closure_mono (hγK' _) hleft) (by simpa using closure_mono (hγK' _) hright)
   rcases key with hx | hy
   · left
-    have hA : IsPreconnected (f '' (ball c r ∩ ball ζ ρ)) :=
-      ((isConnected_ball_inter_ball hr hρ (by rw [dist_comm, hζ]; linarith)).image f
-        (hf.continuousOn.mono inter_subset_left)).isPreconnected
-    exact IsPreconnected.subset_filledHull hA hnearK
+    exact image_subset_filledHull_of_disjoint_inter_sphere hUo hf hinj inter_subset_left
+      disjoint_inter_ball_inter_sphere hAc hKsub
       ⟨_, hnear (-(η / 2)) ⟨by linarith, by linarith⟩, by simpa using hx⟩
   · right
-    have hB : IsPreconnected (f '' (ball c r \ closedBall ζ ρ)) :=
-      ((isConnected_ball_diff_closedBall hζ hρ hρr).image f
-        (hf.continuousOn.mono sdiff_subset)).isPreconnected
-    exact IsPreconnected.subset_filledHull hB hfarK
+    exact image_subset_filledHull_of_disjoint_inter_sphere hUo hf hinj sdiff_subset
+      disjoint_sdiff_closedBall_inter_sphere hBc hKsub
       ⟨_, hfar (η / 2) ⟨by linarith, by linarith⟩, hy⟩
 
 /-- **Diameter selection: when the enclosing set is narrower than the far side, the near side is
 enclosed.** This consumes the disjunction
 `TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull` by
 excluding the far-side case: trapping the far side inside `K` gives
-`diam (f '' (ball c r \ closedBall ζ ρ)) ≤ diam K`, contradicting the hypothesis. Unlike
+`diam (f '' (U \ closedBall ζ ρ)) ≤ diam K`, contradicting the hypothesis. Unlike
 `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt`, no `hp`/`hin` plane-separation input is
 needed — the preconnectedness hypothesis `hKp` on `K \ {p}` is discharged by
 `IsJordanCurve.isPathConnected_sdiff_singleton` in the intended application. -/
-theorem image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff
-    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
-    (hf : DifferentiableOn ℂ f (ball c r))
-    (hinj : InjOn f (ball c r)) {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
-    (hγK : f '' (ball c r ∩ sphere ζ ρ) ⊆ K)
-    (hKsub : K ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r))
-    {z₀ : ℂ} (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ)
+theorem image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff {U : Set ℂ}
+    (hUo : IsOpen U) (hρ : 0 < ρ)
+    (hf : DifferentiableOn ℂ f U)
+    (hinj : InjOn f U) (hAc : IsPreconnected (U ∩ ball ζ ρ))
+    (hBc : IsPreconnected (U \ closedBall ζ ρ))
+    {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
+    (hγK : f '' (U ∩ sphere ζ ρ) ⊆ K)
+    (hKsub : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U))
+    {z₀ : ℂ} (hz₀ : z₀ ∈ U ∩ sphere ζ ρ)
     (hKp : IsPreconnected (K \ {f z₀}))
-    (hlt : diam K < diam (f '' (ball c r \ closedBall ζ ρ))) :
-    f '' (ball c r ∩ ball ζ ρ) ⊆ filledHull K := by
+    (hlt : diam K < diam (f '' (U \ closedBall ζ ρ))) :
+    f '' (U ∩ ball ζ ρ) ⊆ filledHull K := by
   rcases image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull
-    hζ hρ hρr hf hinj hK hKb hγK hKsub hz₀ hKp with h | h
+    hUo hρ hf hinj hAc hBc hK hKb hγK hKsub hz₀ hKp with h | h
   · exact h
   · exact absurd (diam_le_diam_of_subset_filledHull hKb h) (not_le.mpr hlt)
 
@@ -358,21 +371,6 @@ section GeneralDomain
 variable {U K V : Set ℂ} {p : ℂ}
 
 open Topology
-
-/-- **An image side that meets the inside of such a curve lies inside it.** The side is
-preconnected as a continuous image of a preconnected set and disjoint from `K` by
-`TauCeti.disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image`,
-so `TauCeti.IsPreconnected.subset_filledHull`
-traps it in the bounded component of `Kᶜ` it meets. Instantiate `V` at `U ∩ ball ζ ρ` for the near
-side and at `U \ closedBall ζ ρ` for the far side. -/
-theorem image_subset_filledHull_of_disjoint_inter_sphere (hUo : IsOpen U)
-    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
-    (hV : Disjoint V (U ∩ sphere ζ ρ)) (hVc : IsPreconnected V)
-    (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U))
-    (hne : (f '' V ∩ filledHull K).Nonempty) : f '' V ⊆ filledHull K :=
-  IsPreconnected.subset_filledHull (hVc.image f (hd.continuousOn.mono hVU))
-    (disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
-      hUo hd hinj hVU hV hK) hne
 
 /-- **One of the two image sides meets the inside of a curve with an image-domain point adherent to
 its inside.** If a point `p` of the image domain lies in `closure (filledHull K \ K)` — i.e. is a

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.Analysis.Normed.Module.FilledHull
 import Mathlib.Analysis.Calculus.Deriv.Slope
 import Mathlib.MeasureTheory.Integral.CircleIntegral
-import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
+import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
 import TauCeti.Analysis.Complex.Conformal.InverseFunction
 import TauCeti.Analysis.Contour.Winding.Separation

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Normed.Module.FilledHull
 import Mathlib.Analysis.Calculus.Deriv.Slope
+import Mathlib.Analysis.InnerProductSpace.Calculus
 import Mathlib.MeasureTheory.Integral.CircleIntegral
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
@@ -99,73 +100,55 @@ theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : S
   have hφ : HasDerivAt (fun t : ℝ => g (v * t + f z₀)) (z₀ - ζ) 0 :=
     hasDerivAt_invFunOn_comp_segment hf hU hinj hz₀b (z₀ - ζ)
   have hφ0 : g (v * ((0 : ℝ) : ℂ) + f z₀) = z₀ := by simp [hgf z₀ hz₀b]
-  -- the little-`o` estimate at `t = 0`, and the segment staying in the image domain
+  have hnorm : ‖z₀ - ζ‖ = ρ := by rwa [← dist_eq_norm, ← mem_sphere]
+  -- derivative of ‖g(v*t + f z₀) - ζ‖² at t = 0 is 2ρ², via HasDerivAt.norm_sq
+  set ψ := fun t : ℝ => ‖g (v * t + f z₀) - ζ‖ ^ 2
+  have hψ : HasDerivAt ψ (2 * ρ ^ 2) 0 := by
+    have h1 := (hφ.sub_const ζ).norm_sq
+    rw [hφ0, real_inner_self_eq_norm_sq, hnorm] at h1
+    exact h1
+  have hψ0 : ψ 0 = ρ ^ 2 := by
+    change ‖g (v * ((0 : ℝ) : ℂ) + f z₀) - ζ‖ ^ 2 = ρ ^ 2
+    rw [hφ0, hnorm]
   have hev : ∀ᶠ t : ℝ in 𝓝 0,
-      ‖g (v * t + f z₀) - g (v * ((0 : ℝ) : ℂ) + f z₀) - (t - 0) • (z₀ - ζ)‖ ≤
-        ρ / 2 * ‖t - 0‖ :=
-    (hasDerivAt_iff_isLittleO.mp hφ).def (by positivity)
+      |ψ t - ρ ^ 2 - t * (2 * ρ ^ 2)| ≤ ρ ^ 2 * |t| := by
+    have := (hasDerivAt_iff_isLittleO.mp hψ).def
+      (show (0 : ℝ) < ρ ^ 2 by positivity)
+    simp only [hψ0, sub_zero, Real.norm_eq_abs] at this
+    exact this
   have hΩev : ∀ᶠ t : ℝ in 𝓝 0, v * t + f z₀ ∈ f '' U := by
     have hcont : Continuous fun t : ℝ => v * (t : ℂ) + f z₀ := by fun_prop
     have h0 : (fun t : ℝ => v * (t : ℂ) + f z₀) 0 ∈ f '' U := by simpa using hp
     exact hcont.continuousAt.preimage_mem_nhds (hΩ.mem_nhds h0)
   obtain ⟨η, hη, hηball⟩ := Metric.eventually_nhds_iff.mp (hev.and hΩev)
-  have hnorm : ‖z₀ - ζ‖ = ρ := by rwa [← dist_eq_norm, ← mem_sphere]
-  -- shared estimate: for |t| < min η 1, extract preimage and little-o bound
-  have hcore : ∀ t : ℝ, t ∈ Ioo (-(min η 1)) (min η 1) → t ≠ 0 →
-      v * t + f z₀ ∈ f '' U ∧
-      ‖g (v * t + f z₀) - z₀ - t • (z₀ - ζ)‖ ≤ ρ / 2 * |t| := by
-    intro t ht ht0
+  refine ⟨η, hη, fun t ht => ?_, fun t ht => ?_⟩
+  · -- `t < 0`: ψ(t) < ρ², so the pulled-back point is inside `ball ζ ρ`
     have htη : dist t 0 < η := by
-      rw [Real.dist_eq, sub_zero]
-      exact (abs_lt.mpr ⟨by linarith [ht.1], by linarith [ht.2]⟩).trans_le
-        (min_le_left η 1)
-    obtain ⟨hlo, hmem⟩ := hηball htη
-    rw [hφ0, sub_zero] at hlo
-    exact ⟨hmem, hlo⟩
-  refine ⟨min η 1, lt_min hη one_pos, fun t ht => ?_, fun t ht => ?_⟩
-  · -- `t < 0`: the pulled-back point is closer to `ζ` than `ρ`
-    have ht1 : -1 < t := by linarith [ht.1, min_le_right η 1]
-    obtain ⟨hmem, hlo⟩ := hcore t
-      ⟨ht.1, by linarith [ht.2, lt_min hη one_pos]⟩ ht.2.ne
-    rw [abs_of_neg ht.2] at hlo
+      rw [Real.dist_eq, sub_zero, abs_of_neg ht.2]; linarith [ht.1]
+    obtain ⟨hsq, hmem⟩ := hηball htη
+    rw [abs_of_neg ht.2] at hsq
+    have hle := (abs_le.mp hsq).2
+    have hlt : ψ t < ρ ^ 2 := by
+      have := mul_neg_of_pos_of_neg (show 0 < ρ ^ 2 by positivity) ht.2
+      linarith
     refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, ?_⟩, hfg _ hmem⟩
     rw [mem_ball, dist_eq_norm]
-    calc ‖g (v * t + f z₀) - ζ‖
-        ≤ ‖(1 + t) • (z₀ - ζ)‖ +
-            ‖g (v * t + f z₀) - z₀ - t • (z₀ - ζ)‖ := by
-          have := norm_le_insert'
-            (g (v * t + f z₀) - ζ) ((1 + t) • (z₀ - ζ))
-          rwa [show g (v * t + f z₀) - ζ - (1 + t) • (z₀ - ζ)
-              = g (v * t + f z₀) - z₀ - t • (z₀ - ζ) from by
-            rw [add_smul, one_smul]; abel] at this
-      _ ≤ (1 + t) * ρ + ρ / 2 * (-t) := by
-          gcongr
-          · rw [norm_smul, hnorm, Real.norm_eq_abs,
-              abs_of_pos (by linarith)]
-      _ < ρ := by nlinarith [ht.2]
-  · -- `t > 0`: the pulled-back point is farther from `ζ` than `ρ`
-    obtain ⟨hmem, hlo⟩ := hcore t
-      ⟨by linarith [ht.1, lt_min hη one_pos], ht.2⟩ ht.1.ne'
-    rw [abs_of_pos ht.1] at hlo
+    nlinarith [sq_nonneg (‖g (v * t + f z₀) - ζ‖ - ρ)]
+  · -- `t > 0`: ψ(t) > ρ², so the pulled-back point is outside `closedBall ζ ρ`
+    have htη : dist t 0 < η := by
+      rw [Real.dist_eq, sub_zero, abs_of_pos ht.1]; exact ht.2
+    obtain ⟨hsq, hmem⟩ := hηball htη
+    rw [abs_of_pos ht.1] at hsq
+    have hle := (abs_le.mp hsq).1
+    have hgt : ρ ^ 2 < ψ t := by
+      have := mul_pos (show 0 < ρ ^ 2 by positivity) ht.1
+      linarith
     refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, fun hcb => ?_⟩,
       hfg _ hmem⟩
     rw [mem_closedBall, dist_eq_norm] at hcb
-    have hlow : (1 + t) * ρ - ρ / 2 * t ≤ ‖g (v * t + f z₀) - ζ‖ := by
-      calc (1 + t) * ρ - ρ / 2 * t
-          ≤ ‖(1 + t) • (z₀ - ζ)‖ -
-              ‖g (v * t + f z₀) - z₀ - t • (z₀ - ζ)‖ := by
-            rw [norm_smul, hnorm, Real.norm_eq_abs,
-              abs_of_pos (by linarith [ht.1])]
-            linarith
-        _ ≤ ‖g (v * t + f z₀) - ζ‖ := by
-            have := norm_sub_norm_le
-              ((1 + t) • (z₀ - ζ)) (g (v * t + f z₀) - ζ)
-            rw [show (1 + t) • (z₀ - ζ) - (g (v * t + f z₀) - ζ)
-                = -(g (v * t + f z₀) - z₀ - t • (z₀ - ζ)) from by
-              rw [add_smul, one_smul]; abel,
-              norm_neg] at this
-            linarith
-    nlinarith [ht.1]
+    have hnsq : ‖g (v * ↑t + f z₀) - ζ‖ ^ 2 ≤ ρ ^ 2 :=
+      sq_le_sq' (by linarith [norm_nonneg (g (v * ↑t + f z₀) - ζ)]) hcb
+    linarith
 
 /-- **The image crosscut is adherent from both sides of the transversal segment.** In the
 transversal coordinate the crosscut has velocity `i` at the crossing point. -/

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -38,6 +38,19 @@ This is the planar-separation step of the `ConformalMapping` roadmap (L5).
 * `TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull` —
   **one of the two image pieces lies in the filled hull of a closed bounded set through the image
   crosscut.**
+* `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt'` — diameter selection: when the enclosing
+  set is narrower than the far side, the near side is enclosed. Consumes the disjunction above
+  without the `hp`/`hin` plane-separation input.
+* `TauCeti.image_subset_filledHull_of_disjoint_inter_sphere` — an image side meeting the inside of
+  such a curve lies inside it.
+* `TauCeti.nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull` —
+  one of the two image sides meets the inside of a curve with inside points next to the image
+  domain. This is where the inside assumption `hin : p ∈ closure (filledHull K \ K)` is
+  introduced; the diameter criterion below passes it on unchanged.
+* `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` — such a curve, if narrower than the far
+  side, encloses the *near* side.
+* `TauCeti.image_inter_ball_subset_filledHull_of_frontier_subset` — the enclosure hypothesis is
+  implied by the boundary-piece hypothesis of `Conformal/CutDiameter.lean`.
 
 ## References
 
@@ -281,20 +294,12 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
   obtain ⟨hleft, hright⟩ :=
     mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg hf hinj hz₀ hρ
   -- neither image piece meets `K`
-  have hnotK : ∀ V ⊆ ball c r, Disjoint V (sphere ζ ρ) → Disjoint (f '' V) K := by
-    intro V hV hVs
-    rw [Set.disjoint_left]
-    intro w hwV hwK
-    rcases hKsub hwK with hcl | hfr
-    · exact Set.disjoint_left.mp
-        (disjoint_image_closure_image_inter_sphere isOpen_ball hf hinj hV hVs) hwV hcl
-    · exact (Set.eq_empty_iff_forall_notMem.mp hΩ.inter_frontier_eq) w
-        ⟨image_mono hV hwV, hfr⟩
   have hnearK : Disjoint (f '' (ball c r ∩ ball ζ ρ)) K :=
-    hnotK _ inter_subset_left
-      (Set.disjoint_left.mpr fun x hx hx' => (mem_ball.mp hx.2).ne (mem_sphere.mp hx'))
+    disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
+      isOpen_ball hf hinj inter_subset_left disjoint_inter_ball_inter_sphere hKsub
   have hfarK : Disjoint (f '' (ball c r \ closedBall ζ ρ)) K :=
-    hnotK _ sdiff_subset (Set.disjoint_left.mpr fun x hx hx' => hx.2 (sphere_subset_closedBall hx'))
+    disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
+      isOpen_ball hf hinj sdiff_subset disjoint_sdiff_closedBall_inter_sphere hKsub
   -- the two-sidedness theorem, applied to `K` and the segment on `[-η/2, η/2]`
   have hpγ : p ∈ f '' (ball c r ∩ sphere ζ ρ) := mem_image_of_mem f hz₀
   have hpK : p ∈ K := hγKcl (subset_closure hpγ)
@@ -325,6 +330,28 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
     exact IsPreconnected.subset_filledHull hB hfarK
       ⟨_, hfar (η / 2) ⟨by linarith, by linarith⟩, hy⟩
 
+/-- **Diameter selection: when the enclosing set is narrower than the far side, the near side is
+enclosed.** This consumes the disjunction
+`TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull` by
+excluding the far-side case: trapping the far side inside `K` gives
+`diam (f '' (ball c r \ closedBall ζ ρ)) ≤ diam K`, contradicting the hypothesis. Unlike
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt`, no `hp`/`hin` plane-separation input is
+needed — the preconnectedness hypothesis `hKp` on `K \ {p}` is discharged by
+`IsJordanCurve.isPathConnected_sdiff_singleton` in the intended application. -/
+theorem image_inter_ball_subset_filledHull_of_diam_lt'
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
+    (hf : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
+    (hγK : f '' (ball c r ∩ sphere ζ ρ) ⊆ K)
+    (hKsub : K ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r))
+    (hKp : ∀ p ∈ f '' (ball c r ∩ sphere ζ ρ), IsPreconnected (K \ {p}))
+    (hlt : diam K < diam (f '' (ball c r \ closedBall ζ ρ))) :
+    f '' (ball c r ∩ ball ζ ρ) ⊆ filledHull K := by
+  rcases image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull
+    hζ hρ hρr hf hinj hK hKb hγK hKsub hKp with h | h
+  · exact h
+  · exact absurd (diam_le_diam_of_subset_filledHull hKb h) (not_le.mpr hlt)
+
 /-! ## An enclosed side is trapped, and narrow -/
 
 section OldInside
@@ -333,33 +360,31 @@ variable {U K V : Set ℂ} {p : ℂ}
 
 open Topology
 
-private theorem disjoint_image_of_subset_closure_union_frontier (hUo : IsOpen U)
-    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
-    (hV : Disjoint V (U ∩ sphere ζ ρ))
-    (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U)) : Disjoint (f '' V) K := by
-  have hΩo : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hUo hd hinj
-  rw [Set.disjoint_left]
-  intro w hwV hwK
-  rcases hK hwK with hcl | hfr
-  · have hVs : Disjoint V (sphere ζ ρ) := by
-      rw [Set.disjoint_left] at hV ⊢
-      exact fun x hxV hxs => hV hxV ⟨hVU hxV, hxs⟩
-    exact Set.disjoint_left.mp
-      (disjoint_image_closure_image_inter_sphere hUo hd hinj hVU hVs) hwV hcl
-  · exact (Set.eq_empty_iff_forall_notMem.mp hΩo.inter_frontier_eq) w
-      ⟨image_mono hVU hwV, hfr⟩
-
-/-- **An image side that meets the inside of such a curve lies inside it.** -/
+/-- **An image side that meets the inside of such a curve lies inside it.** The side is
+preconnected as a continuous image of a preconnected set and disjoint from `K` by
+`TauCeti.disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image`,
+so `TauCeti.IsPreconnected.subset_filledHull`
+traps it in the bounded component of `Kᶜ` it meets. Instantiate `V` at `U ∩ ball ζ ρ` for the near
+side and at `U \ closedBall ζ ρ` for the far side. -/
 theorem image_subset_filledHull_of_disjoint_inter_sphere (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
     (hV : Disjoint V (U ∩ sphere ζ ρ)) (hVc : IsPreconnected V)
     (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U))
     (hne : (f '' V ∩ filledHull K).Nonempty) : f '' V ⊆ filledHull K :=
   IsPreconnected.subset_filledHull (hVc.image f (hd.continuousOn.mono hVU))
-    (disjoint_image_of_subset_closure_union_frontier hUo hd hinj hVU hV hK) hne
+    (disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
+      hUo hd hinj hVU hV hK) hne
 
-/-- **One of the two image sides meets the inside of a curve, given an image-domain point adherent
-to the inside.** -/
+/-- **One of the two image sides meets the inside of a curve with a point of its inside in the image
+domain.** If a point `p` of the image domain is a limit of points of `filledHull K \ K`,
+then such a point
+`q` close enough to `p` lies in the open image domain; being off `K` it is off the image crosscut,
+so it lies on one of the two image sides, and it lies in `filledHull K`.
+
+This is where the inside assumption is introduced, at one point as a hypothesis; the diameter
+criterion below passes it on unchanged. For a Jordan curve `K` the hypothesis is the
+plane-separation statement `J ⊆ closure (filledHull J \ J)` recorded in the roadmap section of
+`TauCeti/Topology/FilledHull.lean`, read at `p`. -/
 theorem nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull
     (hΩo : IsOpen (f '' U)) (hγ : f '' (U ∩ sphere ζ ρ) ⊆ K)
     (hp : p ∈ f '' U) (hin : p ∈ closure (filledHull K \ K)) :
@@ -370,7 +395,18 @@ theorem nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_int
   rw [image_eq_image_inter_ball_union_image_sdiff_closedBall_union_image_inter_sphere] at hqΩ
   exact (hqΩ.resolve_right fun h => hqK (hγ h)).imp (fun h => ⟨q, h, hqH⟩) fun h => ⟨q, h, hqH⟩
 
-/-- **When `K` is narrower than the far-side image, the near side is enclosed.** -/
+/-- **A narrow curve next to a crosscut encloses the near side.** Let `K` be bounded, run from the
+image crosscut along the boundary of the image domain, and have a point of its inside next to the
+image crosscut. If `K` is narrower than the *far* image side — the situation at a small crosscut
+radius, where the far side is nearly the whole image domain — then it is the *near* side that `K`
+encloses, and by `TauCeti.diam_le_diam_of_subset_filledHull` that side is no wider than `K`.
+
+Of the two alternatives
+`TauCeti.nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull`
+offers, the far one
+is excluded: it would trap the far side inside `K` and so make it no wider than `K`. The theorem
+still requires both cut sides to be preconnected, a point in the image domain, and the strict
+far-side diameter bound; those inputs are not produced here. -/
 theorem image_inter_ball_subset_filledHull_of_diam_lt (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U)
     (hAc : IsPreconnected (U ∩ ball ζ ρ)) (hBc : IsPreconnected (U \ closedBall ζ ρ))
@@ -387,7 +423,15 @@ theorem image_inter_ball_subset_filledHull_of_diam_lt (hUo : IsOpen U)
       (image_subset_filledHull_of_disjoint_inter_sphere hUo hd hinj sdiff_subset
         disjoint_sdiff_closedBall_inter_sphere hBc hK h)) (not_le.mpr hlt)
 
-/-- **A boundary piece enclosing what the near side clings to encloses the near side.** -/
+/-- **A boundary piece enclosing what the near side clings to encloses the near side.** If every
+boundary point of the image domain on the frontier of the near image side lies in `E`, then the
+frontier of that side lies in `f '' (U ∩ sphere ζ ρ) ∪ E` by
+`TauCeti.frontier_image_inter_ball_subset`, so `TauCeti.subset_filledHull_of_frontier_subset`
+encloses the side.
+
+Thus the frontier route supplies the same filled-hull inclusion as the enclosure route, with the
+same `E`; either inclusion becomes a width bound on the near side by
+`TauCeti.diam_le_diam_of_subset_filledHull`. -/
 theorem image_inter_ball_subset_filledHull_of_frontier_subset (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U)
     (hb : IsBounded (f '' (U ∩ ball ζ ρ))) {E : Set ℂ}

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -127,6 +127,8 @@ theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall
     have ht1 : -1 < t := by linarith [ht.1, min_le_right η 1]
     obtain ⟨hlo, hmem⟩ := hηball htη
     rw [hφ0, sub_zero, Real.norm_eq_abs, abs_of_neg ht.2] at hlo
+    have hfactor : z₀ - ζ + t • (z₀ - ζ) = (1 + t) • (z₀ - ζ) := by
+      rw [add_smul, one_smul]
     refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, ?_⟩, hfg _ hmem⟩
     rw [mem_ball, dist_eq_norm]
     calc ‖g (v * t + f z₀) - ζ‖
@@ -138,9 +140,8 @@ theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall
           rwa [e] at this
       _ ≤ (1 + t) * ρ + ρ / 2 * (-t) := by
           gcongr
-          · rw [show z₀ - ζ + t • (z₀ - ζ) = (1 + t) • (z₀ - ζ) by
-                rw [add_smul, one_smul],
-              norm_smul, hnorm, Real.norm_eq_abs, abs_of_pos (by linarith)]
+          · rw [hfactor, norm_smul, hnorm, Real.norm_eq_abs,
+              abs_of_pos (by linarith)]
       _ < ρ := by nlinarith [ht.2]
   · -- `t > 0`: the pulled-back point is farther from `ζ` than `ρ`
     have htη : dist t 0 < η := by
@@ -148,15 +149,16 @@ theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall
       linarith [ht.2, min_le_left η 1]
     obtain ⟨hlo, hmem⟩ := hηball htη
     rw [hφ0, sub_zero, Real.norm_eq_abs, abs_of_pos ht.1] at hlo
+    have hfactor : z₀ - ζ + t • (z₀ - ζ) = (1 + t) • (z₀ - ζ) := by
+      rw [add_smul, one_smul]
     refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, fun hcb => ?_⟩, hfg _ hmem⟩
     rw [mem_closedBall, dist_eq_norm] at hcb
     have hlow : (1 + t) * ρ - ρ / 2 * t ≤ ‖g (v * t + f z₀) - ζ‖ := by
       calc (1 + t) * ρ - ρ / 2 * t
           ≤ ‖z₀ - ζ + t • (z₀ - ζ)‖ -
               ‖g (v * t + f z₀) - z₀ - t • (z₀ - ζ)‖ := by
-            rw [show z₀ - ζ + t • (z₀ - ζ) = (1 + t) • (z₀ - ζ) by
-                  rw [add_smul, one_smul],
-                norm_smul, hnorm, Real.norm_eq_abs, abs_of_pos (by linarith [ht.1])]
+            rw [hfactor, norm_smul, hnorm, Real.norm_eq_abs,
+              abs_of_pos (by linarith [ht.1])]
             linarith
         _ ≤ ‖g (v * t + f z₀) - ζ‖ := by
             have := norm_sub_norm_le (z₀ - ζ + t • (z₀ - ζ)) (g (v * t + f z₀) - ζ)
@@ -255,11 +257,13 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
     (hf : DifferentiableOn ℂ f (ball c r))
     (hinj : InjOn f (ball c r)) {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
-    (hγK : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ K)
+    (hγK : f '' (ball c r ∩ sphere ζ ρ) ⊆ K)
     (hKsub : K ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r))
     (hKp : ∀ p ∈ f '' (ball c r ∩ sphere ζ ρ), IsPreconnected (K \ {p})) :
     f '' (ball c r ∩ ball ζ ρ) ⊆ filledHull K ∨
       f '' (ball c r \ closedBall ζ ρ) ⊆ filledHull K := by
+  have hγKcl : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ K :=
+    hK.closure_subset_iff.mpr hγK
   have hr : 0 < r := by linarith
   -- a point of the crosscut: the point of `sphere ζ ρ` in the direction of the centre
   have hz₀ : circleMap ζ ρ (c - ζ).arg ∈ ball c r ∩ sphere ζ ρ :=
@@ -293,7 +297,7 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
     hnotK _ sdiff_subset (Set.disjoint_left.mpr fun x hx hx' => hx.2 (sphere_subset_closedBall hx'))
   -- the two-sidedness theorem, applied to `K` and the segment on `[-η/2, η/2]`
   have hpγ : p ∈ f '' (ball c r ∩ sphere ζ ρ) := mem_image_of_mem f hz₀
-  have hpK : p ∈ K := hγK (subset_closure hpγ)
+  have hpK : p ∈ K := hγKcl (subset_closure hpγ)
   have hseg : ∀ t ∈ Icc (-(η / 2)) (η / 2), v * t + p ∈ K → t = 0 := by
     intro t ht hKt
     by_contra ht0
@@ -301,7 +305,7 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
     · exact Set.disjoint_left.mp hnearK (hnear t ⟨by linarith [ht.1], hneg⟩) hKt
     · exact Set.disjoint_left.mp hfarK (hfar t ⟨hpos, by linarith [ht.2]⟩) hKt
   have hγK' : ∀ S : Set ℂ, f '' (ball c r ∩ sphere ζ ρ) ∩ S ⊆ K ∩ S := fun S =>
-    inter_subset_inter (subset_closure.trans hγK) subset_rfl
+    inter_subset_inter (subset_closure.trans hγKcl) subset_rfl
   have key := Contour.mem_filledHull_or_mem_filledHull_of_isPreconnected_sdiff_singleton
     (K := K) (v := v) (z₀ := p) (a := -(η / 2)) (b := η / 2) (s := 0)
     hK hKb hv ⟨by linarith, by linarith⟩
@@ -354,8 +358,8 @@ theorem image_subset_filledHull_of_disjoint_inter_sphere (hUo : IsOpen U)
   IsPreconnected.subset_filledHull (hVc.image f (hd.continuousOn.mono hVU))
     (disjoint_image_of_subset_closure_union_frontier hUo hd hinj hVU hV hK) hne
 
-/-- **One of the two image sides meets the inside of a curve with a point of its inside in the image
-domain.** -/
+/-- **One of the two image sides meets the inside of a curve, given an image-domain point adherent
+to the inside.** -/
 theorem nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull
     (hΩo : IsOpen (f '' U)) (hγ : f '' (U ∩ sphere ζ ρ) ⊆ K)
     (hp : p ∈ f '' U) (hin : p ∈ closure (filledHull K \ K)) :

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.Complex.Conformal.Crosscut.SmallJordanCurve
+import TauCeti.Analysis.Complex.Conformal.Crosscut.SmallJordanCurve
 public import TauCeti.Analysis.Normed.Module.FilledHull
 import Mathlib.Analysis.Calculus.Deriv.Slope
 import Mathlib.MeasureTheory.Integral.CircleIntegral
@@ -18,24 +18,26 @@ import TauCeti.Topology.MetricSpace.Cut
 import TauCeti.Topology.JordanCurve.Separation
 
 /-!
-# The piece a short crosscut cuts off lies inside the small Jordan curve through it
+# One image piece of a crosscut lies inside a compact enclosing set
 
-For a holomorphic injection of `ball c r`, the image of the near side `ball c r ∩ ball ζ ρ` lies
-in the filled hull of a small compact set through the image crosscut when `ρ` is small enough. The
-transversal segment through a point of the crosscut has the near side on one side and the far side
-on the other, and the enclosing set is adherent from both sides; the winding-number two-sidedness
-theorem puts one end in the filled hull. No Jordan curve theorem is used.
+For a holomorphic injection of `ball c r`, one of the two image pieces — the near side
+`ball c r ∩ ball ζ ρ` or the far side `ball c r \ closedBall ζ ρ` — lies in the filled hull of a
+compact set through the image crosscut. The transversal segment through a point of the crosscut has
+the near side on one side and the far side on the other, and the enclosing set is adherent from both
+sides; the winding-number two-sidedness theorem puts one end in the filled hull. No Jordan curve
+theorem is used.
 
 This is the planar-separation step of the `ConformalMapping` roadmap (L5).
 
 ## Main results
 
-* `TauCeti.exists_forall_mem_image_inter_ball_of_mem_ball_inter_sphere` — **the transversal
+* `TauCeti.exists_mem_image_inter_ball_and_image_diff_closedBall` — **the transversal
   segment through a point of the image crosscut, with near side and far side on opposite sides.**
-* `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos` — **the image crosscut is
+* `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg` — **the image crosscut is
   adherent to each of its points from both sides of the transversal.**
 * `TauCeti.image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull` —
-  **one of the two image pieces lies inside a small compact set through the image crosscut.**
+  **one of the two image pieces lies in the filled hull of a closed bounded set through the image
+  crosscut.**
 
 ## References
 
@@ -62,7 +64,7 @@ private theorem sub_ne_zero_of_mem_sphere (hρ : 0 < ρ) (hz₀ : z₀ ∈ spher
 
 /-- **The transversal segment through a point of the image crosscut.** For small negative `t` the
 segment lies in the image of the near side, and for small positive `t` in the far side. -/
-theorem exists_forall_mem_image_inter_ball_of_mem_ball_inter_sphere
+theorem exists_mem_image_inter_ball_and_image_diff_closedBall
     (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ) (hρ : 0 < ρ) :
     ∃ η : ℝ, 0 < η ∧
@@ -86,7 +88,7 @@ theorem exists_forall_mem_image_inter_ball_of_mem_ball_inter_sphere
   have hv : v ≠ 0 := mul_ne_zero hd0 hzζ
   -- the pulled-back segment has velocity `z₀ - ζ` at `t = 0`
   have hφ : HasDerivAt (fun t : ℝ => g (v * t + f z₀)) (z₀ - ζ) 0 :=
-    hf.hasDerivAt_invFunOn_comp_segment isOpen_ball hinj hz₀b (z₀ - ζ)
+    hasDerivAt_invFunOn_comp_segment hf isOpen_ball hinj hz₀b (z₀ - ζ)
   have hφ0 : g (v * ((0 : ℝ) : ℂ) + f z₀) = z₀ := by simp [hgf z₀ hz₀b]
   -- the little-`o` estimate at `t = 0`, and the segment staying in the image domain
   have hev : ∀ᶠ t : ℝ in 𝓝 0,
@@ -148,7 +150,8 @@ theorem exists_forall_mem_image_inter_ball_of_mem_ball_inter_sphere
 
 /-- **The image crosscut is adherent from both sides of the transversal segment.** In the
 transversal coordinate the crosscut has velocity `i` at the crossing point. -/
-theorem mem_closure_image_inter_sphere_inter_setOf_im_pos (hf : DifferentiableOn ℂ f (ball c r))
+theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
+    (hf : DifferentiableOn ℂ f (ball c r))
     (hinj : InjOn f (ball c r)) (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ) (hρ : 0 < ρ) :
     f z₀ ∈ closure (f '' (ball c r ∩ sphere ζ ρ) ∩
         {q | 0 < ((q - f z₀) / (deriv f z₀ * (z₀ - ζ))).im}) ∧
@@ -184,8 +187,7 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos (hf : DifferentiableOn
     rw [h6] at h5
     exact h5
   have hχ0 : χ θ₀ = 0 := by
-    change ((f (circleMap ζ ρ θ₀) - f z₀) / v).im = 0
-    rw [hθ₀, sub_self, zero_div, Complex.zero_im]
+    simp [χ, hθ₀]
   -- the sign of `χ` on either side of `θ₀`
   have hpos : ∀ᶠ t in 𝓝[>] (0 : ℝ), 0 < χ (θ₀ + t) := by
     filter_upwards [hχ.tendsto_slope_zero_right.eventually (lt_mem_nhds zero_lt_one),
@@ -228,9 +230,9 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos (hf : DifferentiableOn
       ((((hclose ε hε).and hball).filter_mono nhdsWithin_le_nhds).and hneg).exists
     exact ⟨_, ⟨hmemγ t ht2, ht3⟩, by rw [dist_comm]; exact ht1⟩
 
-/-- **One of the two image pieces lies inside a small compact set through the image crosscut.**
-The transversal segment meets the set only at the crossing point, and the set minus that point is
-preconnected, so the winding-number two-sidedness theorem applies. -/
+/-- **One of the two image pieces lies in the filled hull of a closed bounded set through the image
+crosscut.** The transversal segment meets the set only at the crossing point, and the set minus that
+point is preconnected, so the winding-number two-sidedness theorem applies. -/
 theorem image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
     (hf : DifferentiableOn ℂ f (ball c r))
@@ -253,8 +255,9 @@ theorem image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_fille
     mul_ne_zero (hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀.1)
       (sub_ne_zero_of_mem_sphere hρ hz₀.2)
   obtain ⟨η, hη, hnear, hfar⟩ :=
-    exists_forall_mem_image_inter_ball_of_mem_ball_inter_sphere hf hinj hz₀ hρ
-  obtain ⟨hleft, hright⟩ := mem_closure_image_inter_sphere_inter_setOf_im_pos hf hinj hz₀ hρ
+    exists_mem_image_inter_ball_and_image_diff_closedBall hf hinj hz₀ hρ
+  obtain ⟨hleft, hright⟩ :=
+    mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg hf hinj hz₀ hρ
   -- neither image piece meets `K`
   have hnotK : ∀ V ⊆ ball c r, Disjoint V (sphere ζ ρ) → Disjoint (f '' V) K := by
     intro V hV hVs
@@ -359,7 +362,7 @@ theorem nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_int
   rw [image_eq_image_inter_ball_union_image_sdiff_closedBall_union_image_inter_sphere] at hqΩ
   exact (hqΩ.resolve_right fun h => hqK (hγ h)).imp (fun h => ⟨q, h, hqH⟩) fun h => ⟨q, h, hqH⟩
 
-/-- **A narrow curve next to a crosscut encloses the near side.** -/
+/-- **When `K` is narrower than the far-side image, the near side is enclosed.** -/
 theorem image_inter_ball_subset_filledHull_of_diam_lt (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U)
     (hAc : IsPreconnected (U ∩ ball ζ ρ)) (hBc : IsPreconnected (U \ closedBall ζ ρ))

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -43,7 +43,7 @@ conformal maps, so this is new Lean formalization rather than a temporary shim.
 
 * `TauCeti.exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall` — **the transversal
   segment through a point of the image crosscut, with near side and far side on opposite sides.**
-* `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg`
+* `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg`
   — **the image crosscut is
   adherent to each of its points from both sides of the transversal.**
 * `TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull` —
@@ -153,7 +153,7 @@ theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : S
 
 /-- **The image crosscut is adherent from both sides of the transversal segment.** In the
 transversal coordinate the crosscut has velocity `i` at the crossing point. -/
-theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
+theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg
     {U : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U)
     (hinj : InjOn f U) (hz₀ : z₀ ∈ U ∩ sphere ζ ρ) (hρ : 0 < ρ) :
@@ -275,8 +275,9 @@ theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_fill
       (sub_ne_zero.mpr (Metric.ne_of_mem_sphere hz₀.2 hρ.ne'))
   obtain ⟨η, hη, hnear, hfar⟩ :=
     exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall hf hUo hinj hz₀ hρ
-  obtain ⟨hleft, hright⟩ := mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
-    hf hUo hinj hz₀ hρ
+  obtain ⟨hleft, hright⟩ :=
+    mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg
+      hf hUo hinj hz₀ hρ
   -- neither image piece meets `K`
   have hnearK : Disjoint (f '' (U ∩ ball ζ ρ)) K :=
     disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -108,8 +108,9 @@ theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : S
     rw [hφ0, real_inner_self_eq_norm_sq, hnorm] at h1
     exact h1
   have hψ0 : ψ 0 = ρ ^ 2 := by
-    change ‖g (v * ((0 : ℝ) : ℂ) + f z₀) - ζ‖ ^ 2 = ρ ^ 2
-    rw [hφ0, hnorm]
+    dsimp only [ψ]
+    simp only [Complex.ofReal_zero, mul_zero, zero_add, hgf z₀ hz₀b,
+      hnorm]
   have hev : ∀ᶠ t : ℝ in 𝓝 0,
       |ψ t - ρ ^ 2 - t * (2 * ρ ^ 2)| ≤ ρ ^ 2 * |t| := by
     have := (hasDerivAt_iff_isLittleO.mp hψ).def

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -31,11 +31,11 @@ This is the planar-separation step of the `ConformalMapping` roadmap (L5).
 
 ## Main results
 
-* `TauCeti.exists_mem_image_inter_ball_and_image_diff_closedBall` — **the transversal
+* `TauCeti.exists_mem_image_inter_ball_and_image_sdiff_closedBall` — **the transversal
   segment through a point of the image crosscut, with near side and far side on opposite sides.**
 * `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg` — **the image crosscut is
   adherent to each of its points from both sides of the transversal.**
-* `TauCeti.image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull` —
+* `TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull` —
   **one of the two image pieces lies in the filled hull of a closed bounded set through the image
   crosscut.**
 
@@ -62,9 +62,27 @@ private theorem sub_ne_zero_of_mem_sphere (hρ : 0 < ρ) (hz₀ : z₀ ∈ spher
   rw [mem_sphere, dist_eq_norm, h, norm_zero] at hz₀
   exact hρ.ne hz₀
 
+private theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
+    (hz₀ : z₀ ∈ U) (n : ℂ) :
+    HasDerivAt (fun t : ℝ => Function.invFunOn f U (deriv f z₀ * n * t + f z₀)) n 0 := by
+  have h1 : HasDerivAt (fun t : ℝ => deriv f z₀ * n * (t : ℂ) + f z₀)
+      (deriv f z₀ * n) 0 := by
+    simpa using
+      (((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (deriv f z₀ * n)).add_const (f z₀))
+  have h2 : HasDerivAt (Function.invFunOn f U) (deriv f z₀)⁻¹
+      (deriv f z₀ * n * ((0 : ℝ) : ℂ) + f z₀) := by
+    simpa using hf.hasDerivAt_invFunOn hU hinj hz₀
+  have h3 := HasDerivAt.scomp (0 : ℝ) h2 h1
+  have h4 : (deriv f z₀ * n) • (deriv f z₀)⁻¹ = n := by
+    rw [smul_eq_mul]
+    field_simp [hf.deriv_ne_zero_of_injOn hU hinj hz₀]
+  rw [h4] at h3
+  exact h3
+
 /-- **The transversal segment through a point of the image crosscut.** For small negative `t` the
 segment lies in the image of the near side, and for small positive `t` in the far side. -/
-theorem exists_mem_image_inter_ball_and_image_diff_closedBall
+theorem exists_mem_image_inter_ball_and_image_sdiff_closedBall
     (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ) (hρ : 0 < ρ) :
     ∃ η : ℝ, 0 < η ∧
@@ -233,7 +251,7 @@ theorem mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg
 /-- **One of the two image pieces lies in the filled hull of a closed bounded set through the image
 crosscut.** The transversal segment meets the set only at the crossing point, and the set minus that
 point is preconnected, so the winding-number two-sidedness theorem applies. -/
-theorem image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull
+theorem image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
     (hf : DifferentiableOn ℂ f (ball c r))
     (hinj : InjOn f (ball c r)) {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
@@ -255,7 +273,7 @@ theorem image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_fille
     mul_ne_zero (hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀.1)
       (sub_ne_zero_of_mem_sphere hρ hz₀.2)
   obtain ⟨η, hη, hnear, hfar⟩ :=
-    exists_mem_image_inter_ball_and_image_diff_closedBall hf hinj hz₀ hρ
+    exists_mem_image_inter_ball_and_image_sdiff_closedBall hf hinj hz₀ hρ
   obtain ⟨hleft, hright⟩ :=
     mem_closure_image_inter_sphere_inter_setOf_im_pos_and_im_neg hf hinj hz₀ hρ
   -- neither image piece meets `K`
@@ -302,20 +320,6 @@ theorem image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_fille
         (hf.continuousOn.mono sdiff_subset)).isPreconnected
     exact IsPreconnected.subset_filledHull hB hfarK
       ⟨_, hfar (η / 2) ⟨by linarith, by linarith⟩, hy⟩
-
-/-- **One of the two image pieces lies inside the small Jordan curve through the crosscut.** -/
-private theorem
-    image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull_of_isJordanCurve
-    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
-    (hf : DifferentiableOn ℂ f (ball c r))
-    (hinj : InjOn f (ball c r)) {J : Set ℂ} (hJ : IsJordanCurve J)
-    (hγJ : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ J)
-    (hJsub : J ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r)) :
-    f '' (ball c r ∩ ball ζ ρ) ⊆ filledHull J ∨
-      f '' (ball c r \ closedBall ζ ρ) ⊆ filledHull J :=
-  image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull hζ hρ hρr hf hinj
-    hJ.isClosed hJ.isCompact.isBounded hγJ hJsub fun p _ =>
-      (IsPathConnected.isConnected (hJ.isPathConnected_sdiff_singleton p)).isPreconnected
 
 /-! ## An enclosed side is trapped, and narrow -/
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -111,10 +111,10 @@ theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : S
     dsimp only [ψ]
     simp only [Complex.ofReal_zero, mul_zero, zero_add, hgf z₀ hz₀b,
       hnorm]
+  have hρsq : (0 : ℝ) < ρ ^ 2 := sq_pos_of_pos hρ
   have hev : ∀ᶠ t : ℝ in 𝓝 0,
       |ψ t - ρ ^ 2 - t * (2 * ρ ^ 2)| ≤ ρ ^ 2 * |t| := by
-    have := (hasDerivAt_iff_isLittleO.mp hψ).def
-      (show (0 : ℝ) < ρ ^ 2 by positivity)
+    have := (hasDerivAt_iff_isLittleO.mp hψ).def hρsq
     simp only [hψ0, sub_zero, Real.norm_eq_abs] at this
     exact this
   have hΩev : ∀ᶠ t : ℝ in 𝓝 0, v * t + f z₀ ∈ f '' U := by
@@ -130,7 +130,7 @@ theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : S
     rw [abs_of_neg ht.2] at hsq
     have hle := (abs_le.mp hsq).2
     have hlt : ψ t < ρ ^ 2 := by
-      have := mul_neg_of_pos_of_neg (show 0 < ρ ^ 2 by positivity) ht.2
+      have := mul_neg_of_pos_of_neg hρsq ht.2
       linarith
     refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, ?_⟩, hfg _ hmem⟩
     rw [mem_ball, dist_eq_norm]
@@ -142,7 +142,7 @@ theorem exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall {U : S
     rw [abs_of_pos ht.1] at hsq
     have hle := (abs_le.mp hsq).1
     have hgt : ρ ^ 2 < ψ t := by
-      have := mul_pos (show 0 < ρ ^ 2 by positivity) ht.1
+      have := mul_pos hρsq ht.1
       linarith
     refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, fun hcb => ?_⟩,
       hfg _ hmem⟩

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
@@ -5,155 +5,350 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
+public import TauCeti.Analysis.Complex.Conformal.Crosscut.SmallJordanCurve
 public import TauCeti.Analysis.Normed.Module.FilledHull
+import Mathlib.Analysis.Calculus.Deriv.Slope
+import Mathlib.MeasureTheory.Integral.CircleIntegral
+import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
+public import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
+import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
+import TauCeti.Analysis.Complex.Conformal.InverseFunction
+import TauCeti.Analysis.Contour.Winding.Separation
 import TauCeti.Topology.MetricSpace.Cut
+import TauCeti.Topology.JordanCurve.Separation
 
 /-!
-# Which side of a crosscut a curve encloses
+# The piece a short crosscut cuts off lies inside the small Jordan curve through it
 
-Write `Ω = f '' U` for the image of an open `U ⊆ ℂ` under a conformal map, cut at `ζ` by the circle
-`sphere ζ ρ` into the near side `U ∩ ball ζ ρ`, the far side `U \ closedBall ζ ρ` and the crosscut
-`U ∩ sphere ζ ρ`, with images `A`, `B` and `γ`. `Conformal/CutDiameter.lean` bounds the width of a
-side by *anything containing its whole frontier*; this file bounds it instead by *anything that cuts
-it off from infinity*, that is, by a bounded `K` with `A ⊆ filledHull K`. The filled hull — `K`
-together with the bounded connected components of `Kᶜ` — is `TauCeti.filledHull` of
-`TauCeti/Topology/FilledHull.lean`, and `TauCeti.diam_le_diam_of_subset_filledHull` is what makes
-the enclosure a width bound.
+For a holomorphic injection of `ball c r`, the image of the near side `ball c r ∩ ball ζ ρ` lies
+in the filled hull of a small compact set through the image crosscut when `ρ` is small enough. The
+transversal segment through a point of the crosscut has the near side on one side and the far side
+on the other, and the enclosing set is adherent from both sides; the winding-number two-sidedness
+theorem puts one end in the filled hull. No Jordan curve theorem is used.
 
-The point of the change is which datum has to be produced. The frontier route asks for the piece
-`frontier Ω ∩ frontier A` of the image boundary that the near side clings to, and asks it to be
-small — but *which* piece of the image boundary that is, is exactly the choice
-`Conformal/Crosscut/BoundarySplit.lean` leaves open. The enclosure route asks only that the near
-side fall inside a small curve running along the crosscut. The file
-`Conformal/Crosscut/SmallJordanCurve.lean` builds such curves from the two cases supplied by
-`Conformal/Crosscut/Jordan.lean` and `Conformal/Crosscut/Arc.lean`: a short image crosscut closes
-up into an arbitrarily small Jordan curve
-(`TauCeti.exists_isJordanCurve_superset_closure_image_ball_inter_sphere_diam_le`).
-
-## The two sides against one curve
-
-The diameter-selection theorem below runs on a bounded `K` lying on the closed image crosscut and
-the image boundary,
-
-> `f '' (U ∩ sphere ζ ρ) ⊆ K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier Ω`,
-
-the shape in which a curve joining the two ends of the image crosscut along `frontier Ω` arrives.
-Its ingredients use only the assumptions they need: trapping a side uses the upper inclusion but
-not boundedness, while existence of an enclosed side uses the lower inclusion but neither
-boundedness nor the upper inclusion. The comparison with the frontier route uses instead the
-filled hull of `f '' (U ∩ sphere ζ ρ) ∪ E`. The upper inclusion keeps `K` off the two sides by
-`TauCeti.closure_image_inter_sphere_subset_union_frontier_image`: the image crosscut is relatively
-closed in the image domain, so its closure adds only boundary points. Two facts locate the enclosed
-side, and a diameter comparison selects the near one.
-
-* **An enclosed side is trapped**: each side is preconnected and disjoint from `K`, so if it meets
-  `filledHull K` it lies inside (`TauCeti.image_subset_filledHull_of_disjoint_inter_sphere`) and is
-  therefore no wider than `K`.
-* **At least one side meets the inside**, as soon as some point of the image domain is a limit of
-  points inside `K`
-  (`TauCeti.nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull`):
-  a point of the inside close enough to it lies in the image domain and off `K`, hence on one of
-  the two sides.
-
-If `K` is narrower than the far side, at most the near side can be enclosed: trapping the far side
-would give `diam B ≤ diam K`. Combining this exclusion with the two facts above,
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` puts the near side inside `filledHull K`.
-
-## What is assumed, and what remains
-
-No theorem here assumes plane separation. The second fact above takes as a hypothesis that one
-*given* point `p` of the image domain satisfies `p ∈ closure (filledHull K \ K)`, a property of the
-set `K` at the point `p`; it is not an unproved theorem in disguise. In the intended application
-`p` is chosen on the image crosscut. This is the only place the inside assumption is introduced;
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` passes it on unchanged.
-
-What that hypothesis costs, when `K` is a Jordan curve, is exactly the open frontier item recorded
-in the roadmap section of `TauCeti/Topology/FilledHull.lean`: that every point of a Jordan curve is
-a limit of points inside it, `J ⊆ closure (filledHull J \ J)`. To apply the reduction at every
-small radius one must also produce a point of the image crosscut, prove the two circular-cut sides
-preconnected, and show that the far-side image has diameter larger than the small curve. This file
-isolates those inputs; it does not discharge them.
-
-That the enclosure route asks for no more than the frontier route does is
-`TauCeti.image_inter_ball_subset_filledHull_of_frontier_subset`: a boundary piece `E` enclosing
-`frontier Ω ∩ frontier A` puts the near side inside `f '' (U ∩ sphere ζ ρ) ∪ E`, so the hypothesis
-produced by the frontier route gives the same inclusion with the same `E`. Either route then reads
-the inclusion as a width bound on the near side through
-`TauCeti.diam_le_diam_of_subset_filledHull`, which is what the Cauchy criterion
-`TauCeti.subsingleton_clusterSetOn_of_forall_exists` of `TauCeti/Topology/ClusterSet.lean` consumes,
-through `Metric.dist_le_diam_of_mem`.
+This is the planar-separation step of the `ConformalMapping` roadmap (L5).
 
 ## Main results
 
-* `TauCeti.image_subset_filledHull_of_disjoint_inter_sphere` — an image side meeting the inside of
-  such a curve lies inside it.
-* `TauCeti.nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull` —
-  one of the two image sides meets the inside of a curve with inside points next to the image
-  domain.
-* `TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` — such a curve, if narrower than the far
-  side, encloses the *near* side.
-* `TauCeti.image_inter_ball_subset_filledHull_of_frontier_subset` — the enclosure hypothesis is
-  implied by the boundary-piece hypothesis of `Conformal/CutDiameter.lean`.
-
-## Roadmap role
-
-This advances layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, the Jordan-domain case of
-the Carathéodory boundary correspondence, by reducing enclosure of the near side to the explicit
-inside, preconnectedness, nonemptiness and far-side diameter inputs above. It is the consumption of
-the filled hull that
-`TauCeti/Analysis/Normed/Module/FilledHull.lean` was built for and names in its roadmap section.
-
-Layer L5 is absent from
-[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
-human-curated Riemann-mapping-theorem effort, and Mathlib has no boundary correspondence for
-conformal maps, so this is new Lean formalization rather than a temporary shim.
+* `TauCeti.exists_forall_mem_image_inter_ball_of_mem_ball_inter_sphere` — **the transversal
+  segment through a point of the image crosscut, with near side and far side on opposite sides.**
+* `TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos` — **the image crosscut is
+  adherent to each of its points from both sides of the transversal.**
+* `TauCeti.image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull` —
+  **one of the two image pieces lies inside a small compact set through the image crosscut.**
 
 ## References
 
-* C. Carathéodory, *Über die gegenseitige Beziehung der Ränder bei der konformen Abbildung*,
-  Math. Ann. **73** (1913).
-* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, §2.2–2.3.
-* P. L. Duren, *Univalent Functions*, Ch. 3.
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Section 2.2.
+* J. B. Garnett and D. E. Marshall, *Harmonic Measure*, Theorem I.3.1.
 -/
 
 public section
 
+open Bornology Complex Filter Metric Set
+
+open scoped Topology
+
 namespace TauCeti
 
-open Bornology Complex Filter Metric Set Topology
+variable {f : ℂ → ℂ} {c ζ z₀ : ℂ} {r ρ : ℝ}
 
-variable {f : ℂ → ℂ} {U K V : Set ℂ} {ζ p : ℂ} {ρ : ℝ}
+/-- A point of a sphere of positive radius is not its centre. -/
+private theorem sub_ne_zero_of_mem_sphere (hρ : 0 < ρ) (hz₀ : z₀ ∈ sphere ζ ρ) :
+    z₀ - ζ ≠ 0 := by
+  intro h
+  rw [mem_sphere, dist_eq_norm, h, norm_zero] at hz₀
+  exact hρ.ne hz₀
+
+/-- **The transversal segment through a point of the image crosscut.** For small negative `t` the
+segment lies in the image of the near side, and for small positive `t` in the far side. -/
+theorem exists_forall_mem_image_inter_ball_of_mem_ball_inter_sphere
+    (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ) (hρ : 0 < ρ) :
+    ∃ η : ℝ, 0 < η ∧
+      (∀ t : ℝ, t ∈ Ioo (-η) 0 →
+        deriv f z₀ * (z₀ - ζ) * (t : ℂ) + f z₀ ∈ f '' (ball c r ∩ ball ζ ρ)) ∧
+      ∀ t : ℝ, t ∈ Ioo 0 η →
+        deriv f z₀ * (z₀ - ζ) * (t : ℂ) + f z₀ ∈ f '' (ball c r \ closedBall ζ ρ) := by
+  obtain ⟨hz₀b, hz₀s⟩ := hz₀
+  have hΩ : IsOpen (f '' ball c r) := isOpen_image_of_differentiableOn_of_injOn isOpen_ball hf hinj
+  have hp : f z₀ ∈ f '' ball c r := mem_image_of_mem f hz₀b
+  set g := Function.invFunOn f (ball c r) with hg_def
+  have hg : DifferentiableOn ℂ g (f '' ball c r) :=
+    TauCeti.DifferentiableOn.invFunOn hf isOpen_ball hinj
+  have hgf : ∀ z ∈ ball c r, g (f z) = z := fun z hz => hinj.leftInvOn_invFunOn hz
+  have hfg : ∀ w ∈ f '' ball c r, f (g w) = w := fun w hw => Function.invFunOn_eq hw
+  have hgmem : ∀ w ∈ f '' ball c r, g w ∈ ball c r := fun w hw => Function.invFunOn_mem hw
+  have hd0 : deriv f z₀ ≠ 0 :=
+    hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀b
+  have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero_of_mem_sphere hρ hz₀s
+  set v := deriv f z₀ * (z₀ - ζ) with hv_def
+  have hv : v ≠ 0 := mul_ne_zero hd0 hzζ
+  -- the pulled-back segment has velocity `z₀ - ζ` at `t = 0`
+  have hφ : HasDerivAt (fun t : ℝ => g (v * t + f z₀)) (z₀ - ζ) 0 :=
+    hf.hasDerivAt_invFunOn_comp_segment isOpen_ball hinj hz₀b (z₀ - ζ)
+  have hφ0 : g (v * ((0 : ℝ) : ℂ) + f z₀) = z₀ := by simp [hgf z₀ hz₀b]
+  -- the little-`o` estimate at `t = 0`, and the segment staying in the image domain
+  have hev : ∀ᶠ t : ℝ in 𝓝 0,
+      ‖g (v * t + f z₀) - g (v * ((0 : ℝ) : ℂ) + f z₀) - (t - 0) • (z₀ - ζ)‖ ≤
+        ρ / 2 * ‖t - 0‖ :=
+    (hasDerivAt_iff_isLittleO.mp hφ).def (by positivity)
+  have hΩev : ∀ᶠ t : ℝ in 𝓝 0, v * t + f z₀ ∈ f '' ball c r := by
+    have hcont : Continuous fun t : ℝ => v * (t : ℂ) + f z₀ := by fun_prop
+    have h0 : (fun t : ℝ => v * (t : ℂ) + f z₀) 0 ∈ f '' ball c r := by simpa using hp
+    exact hcont.continuousAt.preimage_mem_nhds (hΩ.mem_nhds h0)
+  obtain ⟨η, hη, hηball⟩ := Metric.eventually_nhds_iff.mp (hev.and hΩev)
+  have hnorm : ‖z₀ - ζ‖ = ρ := by rwa [← dist_eq_norm, ← mem_sphere]
+  refine ⟨min η 1, lt_min hη one_pos, fun t ht => ?_, fun t ht => ?_⟩
+  · -- `t < 0`: the pulled-back point is closer to `ζ` than `ρ`
+    have htη : dist t 0 < η := by
+      rw [Real.dist_eq, sub_zero, abs_of_neg ht.2]
+      linarith [ht.1, min_le_left η 1]
+    have ht1 : -1 < t := by linarith [ht.1, min_le_right η 1]
+    obtain ⟨hlo, hmem⟩ := hηball htη
+    rw [hφ0, sub_zero, Real.norm_eq_abs, abs_of_neg ht.2] at hlo
+    refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, ?_⟩, hfg _ hmem⟩
+    rw [mem_ball, dist_eq_norm]
+    calc ‖g (v * t + f z₀) - ζ‖
+        ≤ ‖z₀ - ζ + t • (z₀ - ζ)‖ +
+            ‖g (v * t + f z₀) - z₀ - t • (z₀ - ζ)‖ := by
+          have := norm_le_insert' (g (v * t + f z₀) - ζ) (z₀ - ζ + t • (z₀ - ζ))
+          have e : g (v * t + f z₀) - ζ - (z₀ - ζ + t • (z₀ - ζ))
+              = g (v * t + f z₀) - z₀ - t • (z₀ - ζ) := by abel
+          rwa [e] at this
+      _ ≤ (1 + t) * ρ + ρ / 2 * (-t) := by
+          gcongr
+          · rw [show z₀ - ζ + t • (z₀ - ζ) = (1 + t) • (z₀ - ζ) by
+                rw [add_smul, one_smul],
+              norm_smul, hnorm, Real.norm_eq_abs, abs_of_pos (by linarith)]
+      _ < ρ := by nlinarith [ht.2]
+  · -- `t > 0`: the pulled-back point is farther from `ζ` than `ρ`
+    have htη : dist t 0 < η := by
+      rw [Real.dist_eq, sub_zero, abs_of_pos ht.1]
+      linarith [ht.2, min_le_left η 1]
+    obtain ⟨hlo, hmem⟩ := hηball htη
+    rw [hφ0, sub_zero, Real.norm_eq_abs, abs_of_pos ht.1] at hlo
+    refine ⟨g (v * t + f z₀), ⟨hgmem _ hmem, fun hcb => ?_⟩, hfg _ hmem⟩
+    rw [mem_closedBall, dist_eq_norm] at hcb
+    have hlow : (1 + t) * ρ - ρ / 2 * t ≤ ‖g (v * t + f z₀) - ζ‖ := by
+      calc (1 + t) * ρ - ρ / 2 * t
+          ≤ ‖z₀ - ζ + t • (z₀ - ζ)‖ -
+              ‖g (v * t + f z₀) - z₀ - t • (z₀ - ζ)‖ := by
+            rw [show z₀ - ζ + t • (z₀ - ζ) = (1 + t) • (z₀ - ζ) by
+                  rw [add_smul, one_smul],
+                norm_smul, hnorm, Real.norm_eq_abs, abs_of_pos (by linarith [ht.1])]
+            linarith
+        _ ≤ ‖g (v * t + f z₀) - ζ‖ := by
+            have := norm_sub_norm_le (z₀ - ζ + t • (z₀ - ζ)) (g (v * t + f z₀) - ζ)
+            have e : z₀ - ζ + t • (z₀ - ζ) - (g (v * t + f z₀) - ζ)
+                = -(g (v * t + f z₀) - z₀ - t • (z₀ - ζ)) := by abel
+            rw [e, norm_neg] at this
+            linarith
+    nlinarith [ht.1]
+
+/-- **The image crosscut is adherent from both sides of the transversal segment.** In the
+transversal coordinate the crosscut has velocity `i` at the crossing point. -/
+theorem mem_closure_image_inter_sphere_inter_setOf_im_pos (hf : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) (hz₀ : z₀ ∈ ball c r ∩ sphere ζ ρ) (hρ : 0 < ρ) :
+    f z₀ ∈ closure (f '' (ball c r ∩ sphere ζ ρ) ∩
+        {q | 0 < ((q - f z₀) / (deriv f z₀ * (z₀ - ζ))).im}) ∧
+    f z₀ ∈ closure (f '' (ball c r ∩ sphere ζ ρ) ∩
+        {q | ((q - f z₀) / (deriv f z₀ * (z₀ - ζ))).im < 0}) := by
+  obtain ⟨hz₀b, hz₀s⟩ := hz₀
+  have hd0 : deriv f z₀ ≠ 0 :=
+    hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀b
+  have hzζ : z₀ - ζ ≠ 0 := sub_ne_zero_of_mem_sphere hρ hz₀s
+  set v := deriv f z₀ * (z₀ - ζ) with hv_def
+  have hfz : HasDerivAt f (deriv f z₀) z₀ :=
+    (hf.differentiableAt (isOpen_ball.mem_nhds hz₀b)).hasDerivAt
+  obtain ⟨θ₀, -, hθ₀⟩ := exists_mem_Icc_circleMap_eq 0 hz₀s
+  rw [zero_add] at hθ₀
+  -- the imaginary coordinate of the crosscut, as a function of the angle
+  set χ : ℝ → ℝ := fun θ => ((f (circleMap ζ ρ θ) - f z₀) / v).im with hχ_def
+  have hχ : HasDerivAt χ 1 θ₀ := by
+    have h1 : HasDerivAt (circleMap ζ ρ) (circleMap 0 ρ θ₀ * I) θ₀ :=
+      hasDerivAt_circleMap ζ ρ θ₀
+    have h2 : HasDerivAt f (deriv f z₀) (circleMap ζ ρ θ₀) := by rw [hθ₀]; exact hfz
+    have h3 := HasDerivAt.scomp θ₀ h2 h1
+    have h4 : HasDerivAt (fun θ => (f (circleMap ζ ρ θ) - f z₀) / v)
+        ((circleMap 0 ρ θ₀ * I) * deriv f z₀ / v) θ₀ := by
+      simpa [Function.comp_def, smul_eq_mul] using (h3.sub_const (f z₀)).div_const v
+    have h5 : HasDerivAt χ (((circleMap 0 ρ θ₀ * I) * deriv f z₀ / v).im) θ₀ :=
+      Complex.imCLM.hasFDerivAt.comp_hasDerivAt θ₀ h4
+    have hcm : circleMap 0 ρ θ₀ = z₀ - ζ := by rw [← circleMap_sub_center, hθ₀]
+    have h6 : ((circleMap 0 ρ θ₀ * I) * deriv f z₀ / v).im = 1 := by
+      rw [hcm, hv_def]
+      have : (z₀ - ζ) * I * deriv f z₀ / (deriv f z₀ * (z₀ - ζ)) = I := by
+        field_simp
+      rw [this, Complex.I_im]
+    rw [h6] at h5
+    exact h5
+  have hχ0 : χ θ₀ = 0 := by
+    change ((f (circleMap ζ ρ θ₀) - f z₀) / v).im = 0
+    rw [hθ₀, sub_self, zero_div, Complex.zero_im]
+  -- the sign of `χ` on either side of `θ₀`
+  have hpos : ∀ᶠ t in 𝓝[>] (0 : ℝ), 0 < χ (θ₀ + t) := by
+    filter_upwards [hχ.tendsto_slope_zero_right.eventually (lt_mem_nhds zero_lt_one),
+      self_mem_nhdsWithin] with t ht ht0
+    rw [hχ0, sub_zero, smul_eq_mul] at ht
+    exact (pos_iff_pos_of_mul_pos ht).mp (inv_pos.mpr ht0)
+  have hneg : ∀ᶠ t in 𝓝[<] (0 : ℝ), χ (θ₀ + t) < 0 := by
+    filter_upwards [hχ.tendsto_slope_zero_left.eventually (lt_mem_nhds zero_lt_one),
+      self_mem_nhdsWithin] with t ht ht0
+    rw [hχ0, sub_zero, smul_eq_mul] at ht
+    exact (neg_iff_neg_of_mul_pos ht).mp (inv_lt_zero.mpr ht0)
+  -- nearby crosscut points lie in the disc, and their images are close to `f z₀`
+  have hcirc : Continuous fun t : ℝ => circleMap ζ ρ (θ₀ + t) :=
+    (continuous_circleMap ζ ρ).comp (continuous_const.add continuous_id)
+  have hcirc0 : circleMap ζ ρ (θ₀ + 0) = z₀ := by rw [add_zero, hθ₀]
+  have hball : ∀ᶠ t in 𝓝 (0 : ℝ), circleMap ζ ρ (θ₀ + t) ∈ ball c r := by
+    refine hcirc.continuousAt.preimage_mem_nhds ?_
+    rw [hcirc0]
+    exact isOpen_ball.mem_nhds hz₀b
+  have hclose : ∀ ε > 0, ∀ᶠ t in 𝓝 (0 : ℝ),
+      dist (f (circleMap ζ ρ (θ₀ + t))) (f z₀) < ε := by
+    intro ε hε
+    have hfc : ContinuousAt (fun t : ℝ => f (circleMap ζ ρ (θ₀ + t))) 0 :=
+      (hf.continuousOn.continuousAt (isOpen_ball.mem_nhds hz₀b)).comp_of_eq
+        hcirc.continuousAt hcirc0
+    have := hfc.eventually (Metric.ball_mem_nhds _ hε)
+    simpa [hθ₀] using this
+  have hmemγ : ∀ t : ℝ, circleMap ζ ρ (θ₀ + t) ∈ ball c r →
+      f (circleMap ζ ρ (θ₀ + t)) ∈ f '' (ball c r ∩ sphere ζ ρ) := fun t ht =>
+    mem_image_of_mem f ⟨ht, circleMap_mem_sphere ζ hρ.le _⟩
+  constructor
+  · rw [Metric.mem_closure_iff]
+    intro ε hε
+    obtain ⟨t, ⟨ht1, ht2⟩, ht3⟩ :=
+      ((((hclose ε hε).and hball).filter_mono nhdsWithin_le_nhds).and hpos).exists
+    exact ⟨_, ⟨hmemγ t ht2, ht3⟩, by rw [dist_comm]; exact ht1⟩
+  · rw [Metric.mem_closure_iff]
+    intro ε hε
+    obtain ⟨t, ⟨ht1, ht2⟩, ht3⟩ :=
+      ((((hclose ε hε).and hball).filter_mono nhdsWithin_le_nhds).and hneg).exists
+    exact ⟨_, ⟨hmemγ t ht2, ht3⟩, by rw [dist_comm]; exact ht1⟩
+
+/-- **One of the two image pieces lies inside a small compact set through the image crosscut.**
+The transversal segment meets the set only at the crossing point, and the set minus that point is
+preconnected, so the winding-number two-sidedness theorem applies. -/
+theorem image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
+    (hf : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) {K : Set ℂ} (hK : IsClosed K) (hKb : IsBounded K)
+    (hγK : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ K)
+    (hKsub : K ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r))
+    (hKp : ∀ p ∈ f '' (ball c r ∩ sphere ζ ρ), IsPreconnected (K \ {p})) :
+    f '' (ball c r ∩ ball ζ ρ) ⊆ filledHull K ∨
+      f '' (ball c r \ closedBall ζ ρ) ⊆ filledHull K := by
+  have hr : 0 < r := by linarith
+  -- a point of the crosscut: the point of `sphere ζ ρ` in the direction of the centre
+  have hz₀ : circleMap ζ ρ (c - ζ).arg ∈ ball c r ∩ sphere ζ ρ :=
+    ⟨(circleMap_mem_ball_iff hζ hρ _).mpr (by simpa using hρr),
+      circleMap_mem_sphere ζ hρ.le _⟩
+  set z₀ := circleMap ζ ρ (c - ζ).arg with hz₀_def
+  have hΩ : IsOpen (f '' ball c r) := isOpen_image_of_differentiableOn_of_injOn isOpen_ball hf hinj
+  set p := f z₀ with hp_def
+  set v := deriv f z₀ * (z₀ - ζ) with hv_def
+  have hv : v ≠ 0 :=
+    mul_ne_zero (hf.deriv_ne_zero_of_injOn isOpen_ball hinj hz₀.1)
+      (sub_ne_zero_of_mem_sphere hρ hz₀.2)
+  obtain ⟨η, hη, hnear, hfar⟩ :=
+    exists_forall_mem_image_inter_ball_of_mem_ball_inter_sphere hf hinj hz₀ hρ
+  obtain ⟨hleft, hright⟩ := mem_closure_image_inter_sphere_inter_setOf_im_pos hf hinj hz₀ hρ
+  -- neither image piece meets `K`
+  have hnotK : ∀ V ⊆ ball c r, Disjoint V (sphere ζ ρ) → Disjoint (f '' V) K := by
+    intro V hV hVs
+    rw [Set.disjoint_left]
+    intro w hwV hwK
+    rcases hKsub hwK with hcl | hfr
+    · exact Set.disjoint_left.mp
+        (disjoint_image_closure_image_inter_sphere isOpen_ball hf hinj hV hVs) hwV hcl
+    · exact (Set.eq_empty_iff_forall_notMem.mp hΩ.inter_frontier_eq) w
+        ⟨image_mono hV hwV, hfr⟩
+  have hnearK : Disjoint (f '' (ball c r ∩ ball ζ ρ)) K :=
+    hnotK _ inter_subset_left
+      (Set.disjoint_left.mpr fun x hx hx' => (mem_ball.mp hx.2).ne (mem_sphere.mp hx'))
+  have hfarK : Disjoint (f '' (ball c r \ closedBall ζ ρ)) K :=
+    hnotK _ sdiff_subset (Set.disjoint_left.mpr fun x hx hx' => hx.2 (sphere_subset_closedBall hx'))
+  -- the two-sidedness theorem, applied to `K` and the segment on `[-η/2, η/2]`
+  have hpγ : p ∈ f '' (ball c r ∩ sphere ζ ρ) := mem_image_of_mem f hz₀
+  have hpK : p ∈ K := hγK (subset_closure hpγ)
+  have hseg : ∀ t ∈ Icc (-(η / 2)) (η / 2), v * t + p ∈ K → t = 0 := by
+    intro t ht hKt
+    by_contra ht0
+    rcases lt_or_gt_of_ne ht0 with hneg | hpos
+    · exact Set.disjoint_left.mp hnearK (hnear t ⟨by linarith [ht.1], hneg⟩) hKt
+    · exact Set.disjoint_left.mp hfarK (hfar t ⟨hpos, by linarith [ht.2]⟩) hKt
+  have hγK' : ∀ S : Set ℂ, f '' (ball c r ∩ sphere ζ ρ) ∩ S ⊆ K ∩ S := fun S =>
+    inter_subset_inter (subset_closure.trans hγK) subset_rfl
+  have key := Contour.mem_filledHull_or_mem_filledHull_of_isPreconnected_sdiff_singleton
+    (K := K) (v := v) (z₀ := p) (a := -(η / 2)) (b := η / 2) (s := 0)
+    hK hKb hv ⟨by linarith, by linarith⟩
+    (by simpa using hseg) (by simpa using hKp p hpγ)
+    (by simpa using closure_mono (hγK' _) hleft) (by simpa using closure_mono (hγK' _) hright)
+  rcases key with hx | hy
+  · left
+    have hA : IsPreconnected (f '' (ball c r ∩ ball ζ ρ)) :=
+      ((isConnected_ball_inter_ball hr hρ (by rw [dist_comm, hζ]; linarith)).image f
+        (hf.continuousOn.mono inter_subset_left)).isPreconnected
+    exact IsPreconnected.subset_filledHull hA hnearK
+      ⟨_, hnear (-(η / 2)) ⟨by linarith, by linarith⟩, by simpa using hx⟩
+  · right
+    have hB : IsPreconnected (f '' (ball c r \ closedBall ζ ρ)) :=
+      ((isConnected_ball_diff_closedBall hζ hρ hρr).image f
+        (hf.continuousOn.mono sdiff_subset)).isPreconnected
+    exact IsPreconnected.subset_filledHull hB hfarK
+      ⟨_, hfar (η / 2) ⟨by linarith, by linarith⟩, hy⟩
+
+/-- **One of the two image pieces lies inside the small Jordan curve through the crosscut.** -/
+private theorem
+    image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull_of_isJordanCurve
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
+    (hf : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) {J : Set ℂ} (hJ : IsJordanCurve J)
+    (hγJ : closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ J)
+    (hJsub : J ⊆ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪ frontier (f '' ball c r)) :
+    f '' (ball c r ∩ ball ζ ρ) ⊆ filledHull J ∨
+      f '' (ball c r \ closedBall ζ ρ) ⊆ filledHull J :=
+  image_inter_ball_subset_filledHull_or_image_diff_closedBall_subset_filledHull hζ hρ hρr hf hinj
+    hJ.isClosed hJ.isCompact.isBounded hγJ hJsub fun p _ =>
+      (IsPathConnected.isConnected (hJ.isPathConnected_sdiff_singleton p)).isPreconnected
 
 /-! ## An enclosed side is trapped, and narrow -/
 
-/-- **An image side that meets the inside of such a curve lies inside it.** The side is
-preconnected as a continuous image of a preconnected set and disjoint from `K` by
-`TauCeti.disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image`,
-so `TauCeti.IsPreconnected.subset_filledHull`
-traps it in the bounded component of `Kᶜ` it meets. Instantiate `V` at `U ∩ ball ζ ρ` for the near
-side and at `U \ closedBall ζ ρ` for the far side. -/
+section OldInside
+
+variable {U K V : Set ℂ} {p : ℂ}
+
+open Topology
+
+private theorem disjoint_image_of_subset_closure_union_frontier (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
+    (hV : Disjoint V (U ∩ sphere ζ ρ))
+    (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U)) : Disjoint (f '' V) K := by
+  have hΩo : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hUo hd hinj
+  rw [Set.disjoint_left]
+  intro w hwV hwK
+  rcases hK hwK with hcl | hfr
+  · have hVs : Disjoint V (sphere ζ ρ) := by
+      rw [Set.disjoint_left] at hV ⊢
+      exact fun x hxV hxs => hV hxV ⟨hVU hxV, hxs⟩
+    exact Set.disjoint_left.mp
+      (disjoint_image_closure_image_inter_sphere hUo hd hinj hVU hVs) hwV hcl
+  · exact (Set.eq_empty_iff_forall_notMem.mp hΩo.inter_frontier_eq) w
+      ⟨image_mono hVU hwV, hfr⟩
+
+/-- **An image side that meets the inside of such a curve lies inside it.** -/
 theorem image_subset_filledHull_of_disjoint_inter_sphere (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hVU : V ⊆ U)
     (hV : Disjoint V (U ∩ sphere ζ ρ)) (hVc : IsPreconnected V)
     (hK : K ⊆ closure (f '' (U ∩ sphere ζ ρ)) ∪ frontier (f '' U))
     (hne : (f '' V ∩ filledHull K).Nonempty) : f '' V ⊆ filledHull K :=
   IsPreconnected.subset_filledHull (hVc.image f (hd.continuousOn.mono hVU))
-    (disjoint_image_of_subset_closure_image_inter_sphere_union_frontier_image
-      hUo hd hinj hVU hV hK) hne
-
-/-! ## At least one side meets the inside -/
+    (disjoint_image_of_subset_closure_union_frontier hUo hd hinj hVU hV hK) hne
 
 /-- **One of the two image sides meets the inside of a curve with a point of its inside in the image
-domain.** If a point `p` of the image domain is a limit of points of `filledHull K \ K`,
-then such a point
-`q` close enough to `p` lies in the open image domain; being off `K` it is off the image crosscut,
-so it lies on one of the two image sides, and it lies in `filledHull K`.
-
-This is where the inside assumption is introduced, at one point as a hypothesis; the diameter
-criterion below passes it on unchanged. For a Jordan curve `K` the hypothesis is the
-plane-separation statement `J ⊆ closure (filledHull J \ J)` recorded in the roadmap section of
-`TauCeti/Topology/FilledHull.lean`, read at `p`. -/
+domain.** -/
 theorem nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull
     (hΩo : IsOpen (f '' U)) (hγ : f '' (U ∩ sphere ζ ρ) ⊆ K)
     (hp : p ∈ f '' U) (hin : p ∈ closure (filledHull K \ K)) :
@@ -164,18 +359,7 @@ theorem nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_int
   rw [image_eq_image_inter_ball_union_image_sdiff_closedBall_union_image_inter_sphere] at hqΩ
   exact (hqΩ.resolve_right fun h => hqK (hγ h)).imp (fun h => ⟨q, h, hqH⟩) fun h => ⟨q, h, hqH⟩
 
-/-- **A narrow curve next to a crosscut encloses the near side.** Let `K` be bounded, run from the
-image crosscut along the boundary of the image domain, and have a point of its inside next to the
-image crosscut. If `K` is narrower than the *far* image side — the situation at a small crosscut
-radius, where the far side is nearly the whole image domain — then it is the *near* side that `K`
-encloses, and by `TauCeti.diam_le_diam_of_subset_filledHull` that side is no wider than `K`.
-
-Of the two alternatives
-`TauCeti.nonempty_image_inter_ball_inter_filledHull_or_image_sdiff_closedBall_inter_filledHull`
-offers, the far one
-is excluded: it would trap the far side inside `K` and so make it no wider than `K`. The theorem
-still requires both cut sides to be preconnected, a point in the image domain, and the strict
-far-side diameter bound; those inputs are not produced here. -/
+/-- **A narrow curve next to a crosscut encloses the near side.** -/
 theorem image_inter_ball_subset_filledHull_of_diam_lt (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U)
     (hAc : IsPreconnected (U ∩ ball ζ ρ)) (hBc : IsPreconnected (U \ closedBall ζ ρ))
@@ -192,17 +376,7 @@ theorem image_inter_ball_subset_filledHull_of_diam_lt (hUo : IsOpen U)
       (image_subset_filledHull_of_disjoint_inter_sphere hUo hd hinj sdiff_subset
         disjoint_sdiff_closedBall_inter_sphere hBc hK h)) (not_le.mpr hlt)
 
-/-! ## Comparison with the frontier route -/
-
-/-- **A boundary piece enclosing what the near side clings to encloses the near side.** If every
-boundary point of the image domain on the frontier of the near image side lies in `E`, then the
-frontier of that side lies in `f '' (U ∩ sphere ζ ρ) ∪ E` by
-`TauCeti.frontier_image_inter_ball_subset`, so `TauCeti.subset_filledHull_of_frontier_subset`
-encloses the side.
-
-Thus the frontier route supplies the same filled-hull inclusion as the enclosure route, with the
-same `E`; either inclusion becomes a width bound on the near side by
-`TauCeti.diam_le_diam_of_subset_filledHull`. -/
+/-- **A boundary piece enclosing what the near side clings to encloses the near side.** -/
 theorem image_inter_ball_subset_filledHull_of_frontier_subset (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U)
     (hb : IsBounded (f '' (U ∩ ball ζ ρ))) {E : Set ℂ}
@@ -211,5 +385,7 @@ theorem image_inter_ball_subset_filledHull_of_frontier_subset (hUo : IsOpen U)
   subset_filledHull_of_frontier_subset
     hb
     fun _ hw => (frontier_image_inter_ball_subset hUo hd hinj hw).imp id fun h => hE ⟨h, hw⟩
+
+end OldInside
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
@@ -104,8 +104,7 @@ theorem norm_le_one (hf : IsPointedDiscInjectionOn f Ω z₀) {z : ℂ} (hz : z 
 neighbourhood of each point, which by the local injectivity criterion forces `deriv f z ≠ 0`. -/
 theorem deriv_ne_zero (hf : IsPointedDiscInjectionOn f Ω z₀) (hΩo : IsOpen Ω) {z : ℂ} (hz : z ∈ Ω) :
     deriv f z ≠ 0 :=
-  (exists_injOn_nhds_iff_deriv_ne_zero
-    (hf.differentiableOn.analyticOnNhd hΩo z hz)).mp ⟨Ω, hΩo.mem_nhds hz, hf.injOn⟩
+  hf.differentiableOn.deriv_ne_zero_of_injOn hΩo hf.injOn hz
 
 end IsPointedDiscInjectionOn
 

--- a/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
@@ -104,7 +104,7 @@ theorem norm_le_one (hf : IsPointedDiscInjectionOn f Ω z₀) {z : ℂ} (hz : z 
 neighbourhood of each point, which by the local injectivity criterion forces `deriv f z ≠ 0`. -/
 theorem deriv_ne_zero (hf : IsPointedDiscInjectionOn f Ω z₀) (hΩo : IsOpen Ω) {z : ℂ} (hz : z ∈ Ω) :
     deriv f z ≠ 0 :=
-  hf.differentiableOn.deriv_ne_zero_of_injOn hΩo hf.injOn hz
+  deriv_ne_zero_of_injOn hf.differentiableOn hΩo hf.injOn hz
 
 end IsPointedDiscInjectionOn
 

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -45,8 +45,7 @@ theorem DifferentiableOn.invFunOn {f : ℂ → ℂ} {U : Set ℂ} (hf : Differen
   exact ((analyticAt_comp_iff_of_deriv_ne_zero hfz hderiv).mp hcomp).differentiableAt
     |>.differentiableWithinAt
 
-/-- The inverse of a holomorphic open partial homeomorphism of `ℂ` is holomorphic on its
-target. -/
+/-- The inverse of a holomorphic open partial homeomorphism of `ℂ` is holomorphic on its target. -/
 theorem OpenPartialHomeomorph.differentiableOn_symm {e : OpenPartialHomeomorph ℂ ℂ}
     (he : DifferentiableOn ℂ e e.source) :
     DifferentiableOn ℂ e.symm e.target := by

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -22,6 +22,8 @@ functions that are injective on an open set and for holomorphic open partial hom
   holomorphic on its image.
 * `TauCeti.hasDerivAt_invFunOn` — the derivative of the inverse at `f z₀` is
   `(deriv f z₀)⁻¹`, via `HasDerivAt.of_local_left_inverse`.
+* `TauCeti.hasDerivAt_invFunOn_comp_segment` — the chain rule for the inverse along an affine
+  segment through the image of `z₀`.
 * `TauCeti.OpenPartialHomeomorph.differentiableOn_symm` — the inverse of a holomorphic open partial
   homeomorphism is holomorphic on its target.
 -/
@@ -87,5 +89,35 @@ theorem hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set ℂ}
   have hfg : ∀ᶠ y in 𝓝 (f z₀), f (Function.invFunOn f U y) = y :=
     Filter.eventually_of_mem (hΩ.mem_nhds hp) fun w hw => Function.invFunOn_eq hw
   exact HasDerivAt.of_local_left_inverse hgcont hfz hd0 hfg
+
+/-- **The chain rule for the inverse along a segment.** Composing a local inverse `g` with the
+affine segment `t ↦ v * t + f z₀` gives a curve whose derivative at `t = 0` is `n`, when the
+velocity `v = deriv f z₀ * n` and `g` has derivative `(deriv f z₀)⁻¹` at `f z₀`. Only
+nonvanishing of the derivative is needed — not global injectivity. -/
+theorem hasDerivAt_comp_segment_of_hasDerivAt_inv {g : ℂ → ℂ} {z₀ : ℂ}
+    (hd0 : deriv f z₀ ≠ 0) (hg : HasDerivAt g (deriv f z₀)⁻¹ (f z₀)) (n : ℂ) :
+    HasDerivAt (fun t : ℝ => g (deriv f z₀ * n * t + f z₀)) n 0 := by
+  have h1 : HasDerivAt (fun t : ℝ => deriv f z₀ * n * (t : ℂ) + f z₀)
+      (deriv f z₀ * n) 0 := by
+    simpa using
+      (((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (deriv f z₀ * n)).add_const (f z₀))
+  have h2 : HasDerivAt g (deriv f z₀)⁻¹
+      (deriv f z₀ * n * ((0 : ℝ) : ℂ) + f z₀) := by simpa using hg
+  have h3 := HasDerivAt.scomp (0 : ℝ) h2 h1
+  have h4 : (deriv f z₀ * n) • (deriv f z₀)⁻¹ = n := by
+    rw [smul_eq_mul]; field_simp [hd0]
+  rw [h4] at h3
+  exact h3
+
+/-- **The chain rule for `invFunOn` along a segment.** Specialization of
+`hasDerivAt_comp_segment_of_hasDerivAt_inv` to the canonical inverse. -/
+theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
+    (hz₀ : z₀ ∈ U) (n : ℂ) :
+    HasDerivAt (fun t : ℝ => Function.invFunOn f U
+      (deriv f z₀ * n * t + f z₀)) n 0 :=
+  hasDerivAt_comp_segment_of_hasDerivAt_inv
+    (deriv_ne_zero_of_injOn hf hU hinj hz₀)
+    (hasDerivAt_invFunOn hf hU hinj hz₀) n
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -15,6 +15,15 @@ public import TauCeti.Analysis.Complex.Conformal.LocalDegree
 
 This file supplies global-on-the-image forms of the holomorphic inverse function theorem for
 functions that are injective on an open set and for holomorphic open partial homeomorphisms.
+
+## Main results
+
+* `TauCeti.DifferentiableOn.invFunOn` — the inverse of a holomorphic injection on an open set is
+  holomorphic on its image.
+* `DifferentiableOn.hasDerivAt_invFunOn` — the derivative of the inverse at `f z₀` is
+  `(deriv f z₀)⁻¹`, via `HasDerivAt.of_local_left_inverse`.
+* `TauCeti.OpenPartialHomeomorph.differentiableOn_symm` — the inverse of a holomorphic open partial
+  homeomorphism is holomorphic on its target.
 -/
 
 public section
@@ -35,8 +44,7 @@ theorem DifferentiableOn.invFunOn {f : ℂ → ℂ} {U : Set ℂ} (hf : Differen
     DifferentiableOn ℂ (Function.invFunOn f U) (f '' U) := by
   rintro _ ⟨z, hz, rfl⟩
   have hfz : AnalyticAt ℂ f z := hf.analyticAt (hU.mem_nhds hz)
-  have hderiv : deriv f z ≠ 0 :=
-    (exists_injOn_nhds_iff_deriv_ne_zero hfz).mp ⟨U, hU.mem_nhds hz, hinj⟩
+  have hderiv : deriv f z ≠ 0 := hf.deriv_ne_zero_of_injOn hU hinj hz
   have hleft : (Function.invFunOn f U ∘ f) =ᶠ[𝓝 z] id := by
     filter_upwards [hU.mem_nhds hz] with w hw
     exact hinj.leftInvOn_invFunOn hw
@@ -60,28 +68,24 @@ theorem OpenPartialHomeomorph.differentiableOn_symm {e : OpenPartialHomeomorph �
         congrArg (Function.invFunOn e e.source) (e.right_inv hz)
 
 /-- **The derivative of the holomorphic inverse.** At `f z₀`, the inverse `Function.invFunOn f U`
-of a holomorphic injection `f` of the open set `U` has derivative `(deriv f z₀)⁻¹`:
-differentiating `f (invFunOn f U w) = w`, which holds on the open set `f '' U`, by the chain
-rule. -/
+of a holomorphic injection `f` of the open set `U` has derivative `(deriv f z₀)⁻¹`, by
+`HasDerivAt.of_local_left_inverse` applied to the right-inverse relation
+`f (invFunOn f U w) = w` on the open image `f '' U`. -/
 theorem _root_.DifferentiableOn.hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
     (hz₀ : z₀ ∈ U) :
     HasDerivAt (Function.invFunOn f U) (deriv f z₀)⁻¹ (f z₀) := by
   have hΩ : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hU hf hinj
   have hp : f z₀ ∈ f '' U := mem_image_of_mem f hz₀
-  have hgp : HasDerivAt (Function.invFunOn f U) (deriv (Function.invFunOn f U) (f z₀)) (f z₀) :=
-    ((TauCeti.DifferentiableOn.invFunOn hf hU hinj).differentiableAt (hΩ.mem_nhds hp)).hasDerivAt
-  have hfz : HasDerivAt f (deriv f z₀) z₀ :=
-    (hf.differentiableAt (hU.mem_nhds hz₀)).hasDerivAt
+  have hgcont : ContinuousAt (Function.invFunOn f U) (f z₀) :=
+    ((TauCeti.DifferentiableOn.invFunOn hf hU hinj).differentiableAt
+      (hΩ.mem_nhds hp)).continuousAt
   have hgz : Function.invFunOn f U (f z₀) = z₀ := hinj.leftInvOn_invFunOn hz₀
-  have hcomp : HasDerivAt (f ∘ Function.invFunOn f U)
-      (deriv f z₀ * deriv (Function.invFunOn f U) (f z₀)) (f z₀) :=
-    HasDerivAt.comp (f z₀) (by rw [hgz]; exact hfz) hgp
-  have hid : HasDerivAt (f ∘ Function.invFunOn f U) 1 (f z₀) := by
-    refine (hasDerivAt_id (f z₀)).congr_of_eventuallyEq ?_
-    filter_upwards [hΩ.mem_nhds hp] with w hw
-    exact Function.invFunOn_eq hw
-  have := eq_inv_of_mul_eq_one_right (hcomp.unique hid)
-  rwa [this] at hgp
+  have hfz : HasDerivAt f (deriv f z₀) (Function.invFunOn f U (f z₀)) := by
+    rw [hgz]; exact (hf.differentiableAt (hU.mem_nhds hz₀)).hasDerivAt
+  have hd0 : deriv f z₀ ≠ 0 := hf.deriv_ne_zero_of_injOn hU hinj hz₀
+  have hfg : ∀ᶠ y in 𝓝 (f z₀), f (Function.invFunOn f U y) = y :=
+    Filter.eventually_of_mem (hΩ.mem_nhds hp) fun w hw => Function.invFunOn_eq hw
+  exact HasDerivAt.of_local_left_inverse hgcont hfz hd0 hfg
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -20,7 +20,7 @@ functions that are injective on an open set and for holomorphic open partial hom
 
 * `TauCeti.DifferentiableOn.invFunOn` — the inverse of a holomorphic injection on an open set is
   holomorphic on its image.
-* `DifferentiableOn.hasDerivAt_invFunOn` — the derivative of the inverse at `f z₀` is
+* `TauCeti.hasDerivAt_invFunOn` — the derivative of the inverse at `f z₀` is
   `(deriv f z₀)⁻¹`, via `HasDerivAt.of_local_left_inverse`.
 * `TauCeti.OpenPartialHomeomorph.differentiableOn_symm` — the inverse of a holomorphic open partial
   homeomorphism is holomorphic on its target.
@@ -44,7 +44,7 @@ theorem DifferentiableOn.invFunOn {f : ℂ → ℂ} {U : Set ℂ} (hf : Differen
     DifferentiableOn ℂ (Function.invFunOn f U) (f '' U) := by
   rintro _ ⟨z, hz, rfl⟩
   have hfz : AnalyticAt ℂ f z := hf.analyticAt (hU.mem_nhds hz)
-  have hderiv : deriv f z ≠ 0 := hf.deriv_ne_zero_of_injOn hU hinj hz
+  have hderiv : deriv f z ≠ 0 := deriv_ne_zero_of_injOn hf hU hinj hz
   have hleft : (Function.invFunOn f U ∘ f) =ᶠ[𝓝 z] id := by
     filter_upwards [hU.mem_nhds hz] with w hw
     exact hinj.leftInvOn_invFunOn hw
@@ -71,7 +71,7 @@ theorem OpenPartialHomeomorph.differentiableOn_symm {e : OpenPartialHomeomorph �
 of a holomorphic injection `f` of the open set `U` has derivative `(deriv f z₀)⁻¹`, by
 `HasDerivAt.of_local_left_inverse` applied to the right-inverse relation
 `f (invFunOn f U w) = w` on the open image `f '' U`. -/
-theorem _root_.DifferentiableOn.hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set ℂ}
+theorem hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
     (hz₀ : z₀ ∈ U) :
     HasDerivAt (Function.invFunOn f U) (deriv f z₀)⁻¹ (f z₀) := by
@@ -83,7 +83,7 @@ theorem _root_.DifferentiableOn.hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set �
   have hgz : Function.invFunOn f U (f z₀) = z₀ := hinj.leftInvOn_invFunOn hz₀
   have hfz : HasDerivAt f (deriv f z₀) (Function.invFunOn f U (f z₀)) := by
     rw [hgz]; exact (hf.differentiableAt (hU.mem_nhds hz₀)).hasDerivAt
-  have hd0 : deriv f z₀ ≠ 0 := hf.deriv_ne_zero_of_injOn hU hinj hz₀
+  have hd0 : deriv f z₀ ≠ 0 := deriv_ne_zero_of_injOn hf hU hinj hz₀
   have hfg : ∀ᶠ y in 𝓝 (f z₀), f (Function.invFunOn f U y) = y :=
     Filter.eventually_of_mem (hΩ.mem_nhds hp) fun w hw => Function.invFunOn_eq hw
   exact HasDerivAt.of_local_left_inverse hgcont hfz hd0 hfg

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -93,7 +93,7 @@ theorem hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set ℂ}
 /-- **The chain rule for an inverse along a segment.** Composing `g` with the affine segment
 `t ↦ d * n * t + w` gives a curve whose derivative at `t = 0` is `n`, when `g` has derivative
 `d⁻¹` at `w` and `d ≠ 0`. -/
-theorem hasDerivAt_comp_segment_of_hasDerivAt_inv {g : ℂ → ℂ} {w d : ℂ}
+private theorem hasDerivAt_comp_segment_of_hasDerivAt_inv {g : ℂ → ℂ} {w d : ℂ}
     (hd0 : d ≠ 0) (hg : HasDerivAt g d⁻¹ w) (n : ℂ) :
     HasDerivAt (fun t : ℝ => g (d * n * t + w)) n 0 := by
   have h1 : HasDerivAt (fun t : ℝ => d * n * (t : ℂ) + w)

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -85,26 +85,4 @@ theorem _root_.DifferentiableOn.hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set �
   have := eq_inv_of_mul_eq_one_right (hcomp.unique hid)
   rwa [this] at hgp
 
-/-- **The pulled-back transversal segment.** Pulled back by the holomorphic inverse of an
-injection `f`, the straight segment `t ↦ deriv f z₀ * n * t + f z₀` through `f z₀` in the
-direction `deriv f z₀ * n` is a curve through `z₀` with velocity `n`: the pushforward of a
-direction at `z₀` is pulled back to that direction. -/
-theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
-    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
-    (hz₀ : z₀ ∈ U) (n : ℂ) :
-    HasDerivAt (fun t : ℝ => Function.invFunOn f U (deriv f z₀ * n * t + f z₀)) n 0 := by
-  have h1 : HasDerivAt (fun t : ℝ => deriv f z₀ * n * (t : ℂ) + f z₀)
-      (deriv f z₀ * n) 0 := by
-    simpa using
-      (((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (deriv f z₀ * n)).add_const (f z₀))
-  have h2 : HasDerivAt (Function.invFunOn f U) (deriv f z₀)⁻¹
-      (deriv f z₀ * n * ((0 : ℝ) : ℂ) + f z₀) := by
-    simpa using hf.hasDerivAt_invFunOn hU hinj hz₀
-  have h3 := HasDerivAt.scomp (0 : ℝ) h2 h1
-  have h4 : (deriv f z₀ * n) • (deriv f z₀)⁻¹ = n := by
-    rw [smul_eq_mul]
-    field_simp [hf.deriv_ne_zero_of_injOn hU hinj hz₀]
-  rw [h4] at h3
-  exact h3
-
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -85,19 +85,11 @@ theorem _root_.DifferentiableOn.hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set �
   have := eq_inv_of_mul_eq_one_right (hcomp.unique hid)
   rwa [this] at hgp
 
-/-- **The derivative of the holomorphic inverse**, as a value: `deriv (invFunOn f U) (f z₀) =
-(deriv f z₀)⁻¹`. -/
-private theorem deriv_invFunOn_apply {f : ℂ → ℂ} {U : Set ℂ}
-    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
-    (hz₀ : z₀ ∈ U) :
-    deriv (Function.invFunOn f U) (f z₀) = (deriv f z₀)⁻¹ :=
-  (hf.hasDerivAt_invFunOn hU hinj hz₀).deriv
-
 /-- **The pulled-back transversal segment.** Pulled back by the holomorphic inverse of an
 injection `f`, the straight segment `t ↦ deriv f z₀ * n * t + f z₀` through `f z₀` in the
 direction `deriv f z₀ * n` is a curve through `z₀` with velocity `n`: the pushforward of a
 direction at `z₀` is pulled back to that direction. -/
-theorem _root_.DifferentiableOn.hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
+theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
     (hz₀ : z₀ ∈ U) (n : ℂ) :
     HasDerivAt (fun t : ℝ => Function.invFunOn f U (deriv f z₀ * n * t + f z₀)) n 0 := by

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -90,21 +90,20 @@ theorem hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set ℂ}
     Filter.eventually_of_mem (hΩ.mem_nhds hp) fun w hw => Function.invFunOn_eq hw
   exact HasDerivAt.of_local_left_inverse hgcont hfz hd0 hfg
 
-/-- **The chain rule for the inverse along a segment.** Composing a local inverse `g` with the
-affine segment `t ↦ v * t + f z₀` gives a curve whose derivative at `t = 0` is `n`, when the
-velocity `v = deriv f z₀ * n` and `g` has derivative `(deriv f z₀)⁻¹` at `f z₀`. Only
-nonvanishing of the derivative is needed — not global injectivity. -/
-theorem hasDerivAt_comp_segment_of_hasDerivAt_inv {g : ℂ → ℂ} {z₀ : ℂ}
-    (hd0 : deriv f z₀ ≠ 0) (hg : HasDerivAt g (deriv f z₀)⁻¹ (f z₀)) (n : ℂ) :
-    HasDerivAt (fun t : ℝ => g (deriv f z₀ * n * t + f z₀)) n 0 := by
-  have h1 : HasDerivAt (fun t : ℝ => deriv f z₀ * n * (t : ℂ) + f z₀)
-      (deriv f z₀ * n) 0 := by
+/-- **The chain rule for an inverse along a segment.** Composing `g` with the affine segment
+`t ↦ d * n * t + w` gives a curve whose derivative at `t = 0` is `n`, when `g` has derivative
+`d⁻¹` at `w` and `d ≠ 0`. -/
+theorem hasDerivAt_comp_segment_of_hasDerivAt_inv {g : ℂ → ℂ} {w d : ℂ}
+    (hd0 : d ≠ 0) (hg : HasDerivAt g d⁻¹ w) (n : ℂ) :
+    HasDerivAt (fun t : ℝ => g (d * n * t + w)) n 0 := by
+  have h1 : HasDerivAt (fun t : ℝ => d * n * (t : ℂ) + w)
+      (d * n) 0 := by
     simpa using
-      (((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (deriv f z₀ * n)).add_const (f z₀))
-  have h2 : HasDerivAt g (deriv f z₀)⁻¹
-      (deriv f z₀ * n * ((0 : ℝ) : ℂ) + f z₀) := by simpa using hg
+      (((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (d * n)).add_const w)
+  have h2 : HasDerivAt g d⁻¹
+      (d * n * ((0 : ℝ) : ℂ) + w) := by simpa using hg
   have h3 := HasDerivAt.scomp (0 : ℝ) h2 h1
-  have h4 : (deriv f z₀ * n) • (deriv f z₀)⁻¹ = n := by
+  have h4 : (d * n) • d⁻¹ = n := by
     rw [smul_eq_mul]; field_simp [hd0]
   rw [h4] at h3
   exact h3
@@ -116,7 +115,7 @@ theorem hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
     (hz₀ : z₀ ∈ U) (n : ℂ) :
     HasDerivAt (fun t : ℝ => Function.invFunOn f U
       (deriv f z₀ * n * t + f z₀)) n 0 :=
-  hasDerivAt_comp_segment_of_hasDerivAt_inv
+  hasDerivAt_comp_segment_of_hasDerivAt_inv (d := deriv f z₀) (w := f z₀)
     (deriv_ne_zero_of_injOn hf hU hinj hz₀)
     (hasDerivAt_invFunOn hf hU hinj hz₀) n
 

--- a/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
+++ b/TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 import Mathlib.Analysis.Calculus.InverseFunctionTheorem.Analytic
+import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
 public import Mathlib.Topology.OpenPartialHomeomorph.Basic
 public import TauCeti.Analysis.Complex.Conformal.LocalDegree
 
@@ -44,7 +45,8 @@ theorem DifferentiableOn.invFunOn {f : ℂ → ℂ} {U : Set ℂ} (hf : Differen
   exact ((analyticAt_comp_iff_of_deriv_ne_zero hfz hderiv).mp hcomp).differentiableAt
     |>.differentiableWithinAt
 
-/-- The inverse of a holomorphic open partial homeomorphism of `ℂ` is holomorphic on its target. -/
+/-- The inverse of a holomorphic open partial homeomorphism of `ℂ` is holomorphic on its
+target. -/
 theorem OpenPartialHomeomorph.differentiableOn_symm {e : OpenPartialHomeomorph ℂ ℂ}
     (he : DifferentiableOn ℂ e e.source) :
     DifferentiableOn ℂ e.symm e.target := by
@@ -57,5 +59,60 @@ theorem OpenPartialHomeomorph.differentiableOn_symm {e : OpenPartialHomeomorph �
         (e.injOn.leftInvOn_invFunOn (e.map_target hz)).symm
       _ = Function.invFunOn e e.source z :=
         congrArg (Function.invFunOn e e.source) (e.right_inv hz)
+
+/-- **The derivative of the holomorphic inverse.** At `f z₀`, the inverse `Function.invFunOn f U`
+of a holomorphic injection `f` of the open set `U` has derivative `(deriv f z₀)⁻¹`:
+differentiating `f (invFunOn f U w) = w`, which holds on the open set `f '' U`, by the chain
+rule. -/
+theorem _root_.DifferentiableOn.hasDerivAt_invFunOn {f : ℂ → ℂ} {U : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
+    (hz₀ : z₀ ∈ U) :
+    HasDerivAt (Function.invFunOn f U) (deriv f z₀)⁻¹ (f z₀) := by
+  have hΩ : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hU hf hinj
+  have hp : f z₀ ∈ f '' U := mem_image_of_mem f hz₀
+  have hgp : HasDerivAt (Function.invFunOn f U) (deriv (Function.invFunOn f U) (f z₀)) (f z₀) :=
+    ((TauCeti.DifferentiableOn.invFunOn hf hU hinj).differentiableAt (hΩ.mem_nhds hp)).hasDerivAt
+  have hfz : HasDerivAt f (deriv f z₀) z₀ :=
+    (hf.differentiableAt (hU.mem_nhds hz₀)).hasDerivAt
+  have hgz : Function.invFunOn f U (f z₀) = z₀ := hinj.leftInvOn_invFunOn hz₀
+  have hcomp : HasDerivAt (f ∘ Function.invFunOn f U)
+      (deriv f z₀ * deriv (Function.invFunOn f U) (f z₀)) (f z₀) :=
+    HasDerivAt.comp (f z₀) (by rw [hgz]; exact hfz) hgp
+  have hid : HasDerivAt (f ∘ Function.invFunOn f U) 1 (f z₀) := by
+    refine (hasDerivAt_id (f z₀)).congr_of_eventuallyEq ?_
+    filter_upwards [hΩ.mem_nhds hp] with w hw
+    exact Function.invFunOn_eq hw
+  have := eq_inv_of_mul_eq_one_right (hcomp.unique hid)
+  rwa [this] at hgp
+
+/-- **The derivative of the holomorphic inverse**, as a value: `deriv (invFunOn f U) (f z₀) =
+(deriv f z₀)⁻¹`. -/
+private theorem deriv_invFunOn_apply {f : ℂ → ℂ} {U : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
+    (hz₀ : z₀ ∈ U) :
+    deriv (Function.invFunOn f U) (f z₀) = (deriv f z₀)⁻¹ :=
+  (hf.hasDerivAt_invFunOn hU hinj hz₀).deriv
+
+/-- **The pulled-back transversal segment.** Pulled back by the holomorphic inverse of an
+injection `f`, the straight segment `t ↦ deriv f z₀ * n * t + f z₀` through `f z₀` in the
+direction `deriv f z₀ * n` is a curve through `z₀` with velocity `n`: the pushforward of a
+direction at `z₀` is pulled back to that direction. -/
+theorem _root_.DifferentiableOn.hasDerivAt_invFunOn_comp_segment {f : ℂ → ℂ} {U : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) {z₀ : ℂ}
+    (hz₀ : z₀ ∈ U) (n : ℂ) :
+    HasDerivAt (fun t : ℝ => Function.invFunOn f U (deriv f z₀ * n * t + f z₀)) n 0 := by
+  have h1 : HasDerivAt (fun t : ℝ => deriv f z₀ * n * (t : ℂ) + f z₀)
+      (deriv f z₀ * n) 0 := by
+    simpa using
+      (((hasDerivAt_id (0 : ℝ)).ofReal_comp.const_mul (deriv f z₀ * n)).add_const (f z₀))
+  have h2 : HasDerivAt (Function.invFunOn f U) (deriv f z₀)⁻¹
+      (deriv f z₀ * n * ((0 : ℝ) : ℂ) + f z₀) := by
+    simpa using hf.hasDerivAt_invFunOn hU hinj hz₀
+  have h3 := HasDerivAt.scomp (0 : ℝ) h2 h1
+  have h4 : (deriv f z₀ * n) • (deriv f z₀)⁻¹ = n := by
+    rw [smul_eq_mul]
+    field_simp [hf.deriv_ne_zero_of_injOn hU hinj hz₀]
+  rw [h4] at h3
+  exact h3
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
@@ -49,7 +49,7 @@ converse is Mathlib's inverse function theorem
 * `TauCeti.not_injOn_of_deriv_eq_zero` — a critical point destroys injectivity on *every*
   neighbourhood of `z₀`.
 * `TauCeti.exists_injOn_nhds_iff_deriv_ne_zero` — the local injectivity criterion.
-* `DifferentiableOn.deriv_ne_zero_of_injOn` — the derivative of a holomorphic injection of
+* `TauCeti.deriv_ne_zero_of_injOn` — the derivative of a holomorphic injection of
   an open set vanishes nowhere on it.
 
 ## Coordination with upstream Mathlib
@@ -331,7 +331,7 @@ theorem exists_injOn_nhds_iff_deriv_ne_zero {f : ℂ → ℂ} {z₀ : ℂ} (hf :
 /-- **The derivative of a holomorphic injection of an open set vanishes nowhere on it.** The
 pointwise form of `TauCeti.exists_injOn_nhds_iff_deriv_ne_zero`: injectivity on the open set is
 injectivity on a neighbourhood of each of its points. -/
-theorem _root_.DifferentiableOn.deriv_ne_zero_of_injOn {f : ℂ → ℂ} {U : Set ℂ}
+theorem deriv_ne_zero_of_injOn {f : ℂ → ℂ} {U : Set ℂ}
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : Set.InjOn f U) {z : ℂ}
     (hz : z ∈ U) :
     deriv f z ≠ 0 :=

--- a/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
@@ -24,34 +24,31 @@ change of coordinates. Nothing here is derived from Mathlib's
 dependency.
 
 The proof is a Rouché comparison. On a circle small enough that `z₀` is the only solution of
-`f z = f z₀` inside, `‖f - f z₀‖` attains a positive minimum `δ`; for
-`‖w - f z₀‖ < δ` the difference `(f - f z₀) - (f - w) = w - f z₀` is smaller than
-`‖f - f z₀‖` there, so Rouché equates the zero counts of `f - w` and `f - f z₀` inside.
-The latter count collapses to the single order at `z₀`, because `z₀` is its only zero in the
-disc.
+`f z = f z₀` inside, `‖f - f z₀‖` attains a positive minimum `δ`; for `‖w - f z₀‖ < δ` the
+difference `(f - f z₀) - (f - w) = w - f z₀` is smaller than `‖f - f z₀‖` there, so Rouché equates
+the zero counts of `f - w` and `f - f z₀` inside. The latter count collapses to the single order at
+`z₀`, because `z₀` is its only zero in the disc.
 
 Adding the hypothesis that `f'` is zero-free on the punctured disc upgrades the count with
 multiplicity to the sharper classical statement: for `w ≠ f z₀` the `n` solutions are *distinct*
 and each is a *simple* zero of `f - w`.
 
 That refinement yields the **local injectivity criterion**: an analytic function is injective on
-some neighbourhood of `z₀` exactly when `deriv f z₀ ≠ 0`. The forward direction is proved
-here — a critical point makes the degree at least `2`, so a nearby value is attained twice —
-and needs no non-constancy hypothesis, since a function constant near `z₀` is not injective
-there either. The converse is Mathlib's inverse function theorem
+some neighbourhood of `z₀` exactly when `deriv f z₀ ≠ 0`. The forward direction is proved here — a
+critical point makes the degree at least `2`, so a nearby value is attained twice — and needs no
+non-constancy hypothesis, since a function constant near `z₀` is not injective there either. The
+converse is Mathlib's inverse function theorem
 (`HasStrictDerivAt.eventually_left_inverse`), consumed rather than reproved.
 
 ## Main results
 
 * `TauCeti.localDegree` — the count form, with the radius supplied by the caller.
 * `TauCeti.localDegree_card` — the distinct-and-simple form.
-* `TauCeti.exists_localDegree` — the textbook form: if `z₀` is an isolated solution of
-  `f z = f z₀`, suitable radii exist.
+* `TauCeti.exists_localDegree` — the textbook form: if `z₀` is an isolated solution of `f z = f z₀`,
+  suitable radii exist.
 * `TauCeti.not_injOn_of_deriv_eq_zero` — a critical point destroys injectivity on *every*
   neighbourhood of `z₀`.
 * `TauCeti.exists_injOn_nhds_iff_deriv_ne_zero` — the local injectivity criterion.
-* `DifferentiableOn.deriv_ne_zero_of_injOn` — its pointwise form on an open set: a
-  holomorphic injection has nonvanishing derivative throughout.
 
 ## Coordination with upstream Mathlib
 
@@ -123,8 +120,7 @@ theorem localDegree {f : ℂ → ℂ} {z₀ : ℂ} {r : ℝ} (hr : 0 < r)
 
 /-- When every zero in the disc is simple, the count with multiplicity is the number of *distinct*
 zeros. -/
-private lemma count_eq_ncard {A : ℂ → ℂ} {c : ℂ} {R : ℝ}
-    (hA : AnalyticOnNhd ℂ A (closedBall c R))
+private lemma count_eq_ncard {A : ℂ → ℂ} {c : ℂ} {R : ℝ} (hA : AnalyticOnNhd ℂ A (closedBall c R))
     (hsimple : ∀ z ∈ ball c R, A z = 0 → analyticOrderNatAt A z = 1) :
     (∑ᶠ z ∈ ball c R, analyticOrderNatAt A z) = {z ∈ ball c R | A z = 0}.ncard := by
   have hAb : AnalyticOnNhd ℂ A (ball c R) := hA.mono ball_subset_closedBall
@@ -146,8 +142,7 @@ private lemma count_eq_ncard {A : ℂ → ℂ} {c : ℂ} {R : ℝ}
 
 /-- The fiber counted by `count_eq_ncard` is finite, which is what makes its cardinality
 statement mean "exactly this many preimages". -/
-private lemma zeros_finite {A : ℂ → ℂ} {c : ℂ} {R : ℝ}
-    (hA : AnalyticOnNhd ℂ A (closedBall c R))
+private lemma zeros_finite {A : ℂ → ℂ} {c : ℂ} {R : ℝ} (hA : AnalyticOnNhd ℂ A (closedBall c R))
     (hsimple : ∀ z ∈ ball c R, A z = 0 → analyticOrderNatAt A z = 1) :
     {z ∈ ball c R | A z = 0}.Finite := by
   refine Set.Finite.subset (MeromorphicOn.divisor_ball_support_finite hA.meromorphicOn)
@@ -164,8 +159,8 @@ private lemma zeros_finite {A : ℂ → ℂ} {c : ℂ} {R : ℝ}
   simp [Function.mem_support, MeromorphicOn.AnalyticOnNhd.divisor_apply hAb hzb, hord]
 
 /-- **The open-mapping degree**, distinct-and-simple form. Under the additional hypothesis that
-`f'` is zero-free on the punctured disc, every `w ≠ f z₀` close enough to `f z₀` has
-exactly `n` *distinct* preimages in the open disc, each of them a simple zero of `f - w`. -/
+`f'` is zero-free on the punctured disc, every `w ≠ f z₀` close enough to `f z₀` has exactly `n`
+*distinct* preimages in the open disc, each of them a simple zero of `f - w`. -/
 theorem localDegree_card {f : ℂ → ℂ} {z₀ : ℂ} {r : ℝ} (hr : 0 < r)
     (hf : AnalyticOnNhd ℂ f (closedBall z₀ r))
     (hisol : ∀ z ∈ closedBall z₀ r, z ≠ z₀ → f z ≠ f z₀)
@@ -177,8 +172,7 @@ theorem localDegree_card {f : ℂ → ℂ} {z₀ : ℂ} {r : ℝ} (hr : 0 < r)
   obtain ⟨δ, hδ, hcount⟩ := localDegree hr hf hisol
   refine ⟨δ, hδ, fun w hw hwδ => ?_⟩
   have hA : AnalyticOnNhd ℂ (fun ζ => f ζ - w) (closedBall z₀ r) := hf.sub analyticOnNhd_const
-  have hsimple : ∀ z ∈ ball z₀ r, f z - w = 0 →
-      analyticOrderNatAt (fun ζ => f ζ - w) z = 1 := by
+  have hsimple : ∀ z ∈ ball z₀ r, f z - w = 0 → analyticOrderNatAt (fun ζ => f ζ - w) z = 1 := by
     intro z hz hz0
     have hzne : z ≠ z₀ := by
       rintro rfl
@@ -195,9 +189,9 @@ theorem localDegree_card {f : ℂ → ℂ} {z₀ : ℂ} {r : ℝ} (hr : 0 < r)
     fun z hz hfz => hsimple z hz (by rw [hfz, sub_self])⟩
   rw [← hcount w hwδ, count_eq_ncard hA hsimple, hset]
 
-/-- **The open-mapping degree**, textbook form. If `f` is analytic at `z₀` and `z₀` is an
-isolated solution of `f z = f z₀` — equivalently, `f` is not constant near `z₀` — then
-there are radii `r` and `δ` for which `localDegree` applies. -/
+/-- **The open-mapping degree**, textbook form. If `f` is analytic at `z₀` and `z₀` is an isolated
+solution of `f z = f z₀` — equivalently, `f` is not constant near `z₀` — then there are radii `r`
+and `δ` for which `localDegree` applies. -/
 theorem exists_localDegree {f : ℂ → ℂ} {z₀ : ℂ} (hf : AnalyticAt ℂ f z₀)
     (hisol : ∀ᶠ z in 𝓝[≠] z₀, f z ≠ f z₀) :
     ∃ r > 0, AnalyticOnNhd ℂ f (closedBall z₀ r) ∧
@@ -205,8 +199,7 @@ theorem exists_localDegree {f : ℂ → ℂ} {z₀ : ℂ} (hf : AnalyticAt ℂ f
         (∑ᶠ z ∈ ball z₀ r, analyticOrderNatAt (fun ζ => f ζ - w) z)
           = analyticOrderNatAt (fun ζ => f ζ - f z₀) z₀ := by
   obtain ⟨ε₁, hε₁, hA₁⟩ := Metric.eventually_nhds_iff.mp hf.eventually_analyticAt
-  obtain ⟨ε₂, hε₂, hI₂⟩ := Metric.eventually_nhds_iff.mp
-    (eventually_nhdsWithin_iff.mp hisol)
+  obtain ⟨ε₂, hε₂, hI₂⟩ := Metric.eventually_nhds_iff.mp (eventually_nhdsWithin_iff.mp hisol)
   refine ⟨min (ε₁ / 2) (ε₂ / 2), lt_min (by linarith) (by linarith), fun z hz => ?_, ?_⟩
   · exact hA₁ (lt_of_le_of_lt (mem_closedBall.mp hz)
       (lt_of_le_of_lt (min_le_left _ _) (by linarith)))
@@ -282,10 +275,9 @@ private theorem eventually_deriv_ne_zero_of_eventually_ne {f : ℂ → ℂ} {z�
 /-- **Local injectivity fails at a critical point.** An analytic function whose derivative vanishes
 at `z₀` is not injective on *any* neighbourhood of `z₀`.
 
-No non-constancy hypothesis is needed: if `f` is constant near `z₀` the conclusion is
-immediate, and otherwise `f - f z₀` vanishes at `z₀` to finite order `n`, which
-`deriv f z₀ = 0` forces to be at least `2`, so `localDegree_card` produces two distinct
-preimages of a nearby value. -/
+No non-constancy hypothesis is needed: if `f` is constant near `z₀` the conclusion is immediate,
+and otherwise `f - f z₀` vanishes at `z₀` to finite order `n`, which `deriv f z₀ = 0` forces to be
+at least `2`, so `localDegree_card` produces two distinct preimages of a nearby value. -/
 theorem not_injOn_of_deriv_eq_zero {f : ℂ → ℂ} {z₀ : ℂ}
     (hf : AnalyticAt ℂ f z₀) (hd₀ : deriv f z₀ = 0)
     {V : Set ℂ} (hV : V ∈ 𝓝 z₀) :
@@ -324,8 +316,7 @@ theorem not_injOn_of_deriv_eq_zero {f : ℂ → ℂ} {z₀ : ℂ}
 
 The forward direction is `not_injOn_of_deriv_eq_zero`; the reverse is Mathlib's inverse function
 theorem, consumed rather than reproved. -/
-theorem exists_injOn_nhds_iff_deriv_ne_zero {f : ℂ → ℂ} {z₀ : ℂ}
-    (hf : AnalyticAt ℂ f z₀) :
+theorem exists_injOn_nhds_iff_deriv_ne_zero {f : ℂ → ℂ} {z₀ : ℂ} (hf : AnalyticAt ℂ f z₀) :
     (∃ V ∈ 𝓝 z₀, Set.InjOn f V) ↔ deriv f z₀ ≠ 0 := by
   constructor
   · rintro ⟨V, hV, hinj⟩ hd₀

--- a/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
@@ -24,31 +24,34 @@ change of coordinates. Nothing here is derived from Mathlib's
 dependency.
 
 The proof is a Rouché comparison. On a circle small enough that `z₀` is the only solution of
-`f z = f z₀` inside, `‖f - f z₀‖` attains a positive minimum `δ`; for `‖w - f z₀‖ < δ` the
-difference `(f - f z₀) - (f - w) = w - f z₀` is smaller than `‖f - f z₀‖` there, so Rouché equates
-the zero counts of `f - w` and `f - f z₀` inside. The latter count collapses to the single order at
-`z₀`, because `z₀` is its only zero in the disc.
+`f z = f z₀` inside, `‖f - f z₀‖` attains a positive minimum `δ`; for
+`‖w - f z₀‖ < δ` the difference `(f - f z₀) - (f - w) = w - f z₀` is smaller than
+`‖f - f z₀‖` there, so Rouché equates the zero counts of `f - w` and `f - f z₀` inside.
+The latter count collapses to the single order at `z₀`, because `z₀` is its only zero in the
+disc.
 
 Adding the hypothesis that `f'` is zero-free on the punctured disc upgrades the count with
 multiplicity to the sharper classical statement: for `w ≠ f z₀` the `n` solutions are *distinct*
 and each is a *simple* zero of `f - w`.
 
 That refinement yields the **local injectivity criterion**: an analytic function is injective on
-some neighbourhood of `z₀` exactly when `deriv f z₀ ≠ 0`. The forward direction is proved here — a
-critical point makes the degree at least `2`, so a nearby value is attained twice — and needs no
-non-constancy hypothesis, since a function constant near `z₀` is not injective there either. The
-converse is Mathlib's inverse function theorem
+some neighbourhood of `z₀` exactly when `deriv f z₀ ≠ 0`. The forward direction is proved
+here — a critical point makes the degree at least `2`, so a nearby value is attained twice —
+and needs no non-constancy hypothesis, since a function constant near `z₀` is not injective
+there either. The converse is Mathlib's inverse function theorem
 (`HasStrictDerivAt.eventually_left_inverse`), consumed rather than reproved.
 
 ## Main results
 
 * `TauCeti.localDegree` — the count form, with the radius supplied by the caller.
 * `TauCeti.localDegree_card` — the distinct-and-simple form.
-* `TauCeti.exists_localDegree` — the textbook form: if `z₀` is an isolated solution of `f z = f z₀`,
-  suitable radii exist.
+* `TauCeti.exists_localDegree` — the textbook form: if `z₀` is an isolated solution of
+  `f z = f z₀`, suitable radii exist.
 * `TauCeti.not_injOn_of_deriv_eq_zero` — a critical point destroys injectivity on *every*
   neighbourhood of `z₀`.
 * `TauCeti.exists_injOn_nhds_iff_deriv_ne_zero` — the local injectivity criterion.
+* `DifferentiableOn.deriv_ne_zero_of_injOn` — its pointwise form on an open set: a
+  holomorphic injection has nonvanishing derivative throughout.
 
 ## Coordination with upstream Mathlib
 
@@ -120,7 +123,8 @@ theorem localDegree {f : ℂ → ℂ} {z₀ : ℂ} {r : ℝ} (hr : 0 < r)
 
 /-- When every zero in the disc is simple, the count with multiplicity is the number of *distinct*
 zeros. -/
-private lemma count_eq_ncard {A : ℂ → ℂ} {c : ℂ} {R : ℝ} (hA : AnalyticOnNhd ℂ A (closedBall c R))
+private lemma count_eq_ncard {A : ℂ → ℂ} {c : ℂ} {R : ℝ}
+    (hA : AnalyticOnNhd ℂ A (closedBall c R))
     (hsimple : ∀ z ∈ ball c R, A z = 0 → analyticOrderNatAt A z = 1) :
     (∑ᶠ z ∈ ball c R, analyticOrderNatAt A z) = {z ∈ ball c R | A z = 0}.ncard := by
   have hAb : AnalyticOnNhd ℂ A (ball c R) := hA.mono ball_subset_closedBall
@@ -142,7 +146,8 @@ private lemma count_eq_ncard {A : ℂ → ℂ} {c : ℂ} {R : ℝ} (hA : Analyti
 
 /-- The fiber counted by `count_eq_ncard` is finite, which is what makes its cardinality
 statement mean "exactly this many preimages". -/
-private lemma zeros_finite {A : ℂ → ℂ} {c : ℂ} {R : ℝ} (hA : AnalyticOnNhd ℂ A (closedBall c R))
+private lemma zeros_finite {A : ℂ → ℂ} {c : ℂ} {R : ℝ}
+    (hA : AnalyticOnNhd ℂ A (closedBall c R))
     (hsimple : ∀ z ∈ ball c R, A z = 0 → analyticOrderNatAt A z = 1) :
     {z ∈ ball c R | A z = 0}.Finite := by
   refine Set.Finite.subset (MeromorphicOn.divisor_ball_support_finite hA.meromorphicOn)
@@ -159,8 +164,8 @@ private lemma zeros_finite {A : ℂ → ℂ} {c : ℂ} {R : ℝ} (hA : AnalyticO
   simp [Function.mem_support, MeromorphicOn.AnalyticOnNhd.divisor_apply hAb hzb, hord]
 
 /-- **The open-mapping degree**, distinct-and-simple form. Under the additional hypothesis that
-`f'` is zero-free on the punctured disc, every `w ≠ f z₀` close enough to `f z₀` has exactly `n`
-*distinct* preimages in the open disc, each of them a simple zero of `f - w`. -/
+`f'` is zero-free on the punctured disc, every `w ≠ f z₀` close enough to `f z₀` has
+exactly `n` *distinct* preimages in the open disc, each of them a simple zero of `f - w`. -/
 theorem localDegree_card {f : ℂ → ℂ} {z₀ : ℂ} {r : ℝ} (hr : 0 < r)
     (hf : AnalyticOnNhd ℂ f (closedBall z₀ r))
     (hisol : ∀ z ∈ closedBall z₀ r, z ≠ z₀ → f z ≠ f z₀)
@@ -172,7 +177,8 @@ theorem localDegree_card {f : ℂ → ℂ} {z₀ : ℂ} {r : ℝ} (hr : 0 < r)
   obtain ⟨δ, hδ, hcount⟩ := localDegree hr hf hisol
   refine ⟨δ, hδ, fun w hw hwδ => ?_⟩
   have hA : AnalyticOnNhd ℂ (fun ζ => f ζ - w) (closedBall z₀ r) := hf.sub analyticOnNhd_const
-  have hsimple : ∀ z ∈ ball z₀ r, f z - w = 0 → analyticOrderNatAt (fun ζ => f ζ - w) z = 1 := by
+  have hsimple : ∀ z ∈ ball z₀ r, f z - w = 0 →
+      analyticOrderNatAt (fun ζ => f ζ - w) z = 1 := by
     intro z hz hz0
     have hzne : z ≠ z₀ := by
       rintro rfl
@@ -189,9 +195,9 @@ theorem localDegree_card {f : ℂ → ℂ} {z₀ : ℂ} {r : ℝ} (hr : 0 < r)
     fun z hz hfz => hsimple z hz (by rw [hfz, sub_self])⟩
   rw [← hcount w hwδ, count_eq_ncard hA hsimple, hset]
 
-/-- **The open-mapping degree**, textbook form. If `f` is analytic at `z₀` and `z₀` is an isolated
-solution of `f z = f z₀` — equivalently, `f` is not constant near `z₀` — then there are radii `r`
-and `δ` for which `localDegree` applies. -/
+/-- **The open-mapping degree**, textbook form. If `f` is analytic at `z₀` and `z₀` is an
+isolated solution of `f z = f z₀` — equivalently, `f` is not constant near `z₀` — then
+there are radii `r` and `δ` for which `localDegree` applies. -/
 theorem exists_localDegree {f : ℂ → ℂ} {z₀ : ℂ} (hf : AnalyticAt ℂ f z₀)
     (hisol : ∀ᶠ z in 𝓝[≠] z₀, f z ≠ f z₀) :
     ∃ r > 0, AnalyticOnNhd ℂ f (closedBall z₀ r) ∧
@@ -199,7 +205,8 @@ theorem exists_localDegree {f : ℂ → ℂ} {z₀ : ℂ} (hf : AnalyticAt ℂ f
         (∑ᶠ z ∈ ball z₀ r, analyticOrderNatAt (fun ζ => f ζ - w) z)
           = analyticOrderNatAt (fun ζ => f ζ - f z₀) z₀ := by
   obtain ⟨ε₁, hε₁, hA₁⟩ := Metric.eventually_nhds_iff.mp hf.eventually_analyticAt
-  obtain ⟨ε₂, hε₂, hI₂⟩ := Metric.eventually_nhds_iff.mp (eventually_nhdsWithin_iff.mp hisol)
+  obtain ⟨ε₂, hε₂, hI₂⟩ := Metric.eventually_nhds_iff.mp
+    (eventually_nhdsWithin_iff.mp hisol)
   refine ⟨min (ε₁ / 2) (ε₂ / 2), lt_min (by linarith) (by linarith), fun z hz => ?_, ?_⟩
   · exact hA₁ (lt_of_le_of_lt (mem_closedBall.mp hz)
       (lt_of_le_of_lt (min_le_left _ _) (by linarith)))
@@ -275,9 +282,10 @@ private theorem eventually_deriv_ne_zero_of_eventually_ne {f : ℂ → ℂ} {z�
 /-- **Local injectivity fails at a critical point.** An analytic function whose derivative vanishes
 at `z₀` is not injective on *any* neighbourhood of `z₀`.
 
-No non-constancy hypothesis is needed: if `f` is constant near `z₀` the conclusion is immediate,
-and otherwise `f - f z₀` vanishes at `z₀` to finite order `n`, which `deriv f z₀ = 0` forces to be
-at least `2`, so `localDegree_card` produces two distinct preimages of a nearby value. -/
+No non-constancy hypothesis is needed: if `f` is constant near `z₀` the conclusion is
+immediate, and otherwise `f - f z₀` vanishes at `z₀` to finite order `n`, which
+`deriv f z₀ = 0` forces to be at least `2`, so `localDegree_card` produces two distinct
+preimages of a nearby value. -/
 theorem not_injOn_of_deriv_eq_zero {f : ℂ → ℂ} {z₀ : ℂ}
     (hf : AnalyticAt ℂ f z₀) (hd₀ : deriv f z₀ = 0)
     {V : Set ℂ} (hV : V ∈ 𝓝 z₀) :
@@ -316,7 +324,8 @@ theorem not_injOn_of_deriv_eq_zero {f : ℂ → ℂ} {z₀ : ℂ}
 
 The forward direction is `not_injOn_of_deriv_eq_zero`; the reverse is Mathlib's inverse function
 theorem, consumed rather than reproved. -/
-theorem exists_injOn_nhds_iff_deriv_ne_zero {f : ℂ → ℂ} {z₀ : ℂ} (hf : AnalyticAt ℂ f z₀) :
+theorem exists_injOn_nhds_iff_deriv_ne_zero {f : ℂ → ℂ} {z₀ : ℂ}
+    (hf : AnalyticAt ℂ f z₀) :
     (∃ V ∈ 𝓝 z₀, Set.InjOn f V) ↔ deriv f z₀ ≠ 0 := by
   constructor
   · rintro ⟨V, hV, hinj⟩ hd₀
@@ -325,5 +334,15 @@ theorem exists_injOn_nhds_iff_deriv_ne_zero {f : ℂ → ℂ} {z₀ : ℂ} (hf :
     obtain ⟨W, hW, hWeq⟩ :=
       Filter.eventually_iff_exists_mem.mp (hf.hasStrictDerivAt.eventually_left_inverse hd₀)
     exact ⟨W, hW, fun a ha b hb hab => by rw [← hWeq a ha, ← hWeq b hb, hab]⟩
+
+/-- **The derivative of a holomorphic injection of an open set vanishes nowhere on it.** The
+pointwise form of `TauCeti.exists_injOn_nhds_iff_deriv_ne_zero`: injectivity on the open set is
+injectivity on a neighbourhood of each of its points. -/
+theorem _root_.DifferentiableOn.deriv_ne_zero_of_injOn {f : ℂ → ℂ} {U : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : Set.InjOn f U) {z : ℂ}
+    (hz : z ∈ U) :
+    deriv f z ≠ 0 :=
+  (exists_injOn_nhds_iff_deriv_ne_zero (hf.analyticAt (hU.mem_nhds hz))).mp
+    ⟨U, hU.mem_nhds hz, hinj⟩
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
@@ -49,6 +49,8 @@ converse is Mathlib's inverse function theorem
 * `TauCeti.not_injOn_of_deriv_eq_zero` — a critical point destroys injectivity on *every*
   neighbourhood of `z₀`.
 * `TauCeti.exists_injOn_nhds_iff_deriv_ne_zero` — the local injectivity criterion.
+* `DifferentiableOn.deriv_ne_zero_of_injOn` — the derivative of a holomorphic injection of
+  an open set vanishes nowhere on it.
 
 ## Coordination with upstream Mathlib
 

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
@@ -200,12 +200,10 @@ theorem deriv_schwarzReflection_ne_zero (hΩopen : IsOpen Ω) (hΩ : Set.MapsTo 
     (hupper : Set.MapsTo f (Ω ∩ {z : ℂ | 0 < z.im}) {z : ℂ | 0 < z.im})
     (hinj : Set.InjOn f (Ω ∩ {z : ℂ | 0 ≤ z.im}))
     {z : ℂ} (hz : z ∈ Ω) : deriv (schwarzReflection f) z ≠ 0 := by
-  have hA : AnalyticAt ℂ (schwarzReflection f) z :=
-    (differentiableOn_schwarzReflection_of_symmetric hΩopen hΩ hcont hholo hreal).analyticAt
-      (hΩopen.mem_nhds hz)
-  exact (exists_injOn_nhds_iff_deriv_ne_zero hA).mp
-    ⟨Ω, hΩopen.mem_nhds hz,
-      injOn_schwarzReflection_of_symmetric hΩ hupper (fun w hw h => (hreal w hw h).ge) hinj⟩
+  have hd := differentiableOn_schwarzReflection_of_symmetric hΩopen hΩ hcont hholo hreal
+  have hi := injOn_schwarzReflection_of_symmetric hΩ hupper
+    (fun w hw h => (hreal w hw h).ge) hinj
+  exact hd.deriv_ne_zero_of_injOn hΩopen hi hz
 
 /-- **Schwarz reflection of a conformal map is conformal.** Under the hypotheses of the reflection
 principle, together with injectivity of `f` on the closed upper part and the requirement that the

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
@@ -203,7 +203,7 @@ theorem deriv_schwarzReflection_ne_zero (hΩopen : IsOpen Ω) (hΩ : Set.MapsTo 
   have hd := differentiableOn_schwarzReflection_of_symmetric hΩopen hΩ hcont hholo hreal
   have hi := injOn_schwarzReflection_of_symmetric hΩ hupper
     (fun w hw h => (hreal w hw h).ge) hinj
-  exact hd.deriv_ne_zero_of_injOn hΩopen hi hz
+  exact deriv_ne_zero_of_injOn hd hΩopen hi hz
 
 /-- **Schwarz reflection of a conformal map is conformal.** Under the hypotheses of the reflection
 principle, together with injectivity of `f` on the closed upper part and the requirement that the

--- a/TauCeti/Analysis/Complex/ContinuousLog/Basic.lean
+++ b/TauCeti/Analysis/Complex/ContinuousLog/Basic.lean
@@ -76,13 +76,11 @@ at all.
 
 ## Roadmap role
 
-**Plane separation for Jordan curves** is the open frontier item of layer **L5** of
-`TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence. Two
-statements of the development wait on it, and each is a separation statement about a pair of
-points: `J ⊆ closure (filledHull J \ J)`, recorded in the roadmap section of
-`TauCeti/Topology/FilledHull.lean` and consumed as a hypothesis by
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt` of
-`TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean`; and
+**Plane separation for Jordan curves** is an open frontier item of layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence.
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff` of
+`TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean` avoids the plane-separation hypothesis
+entirely by taking `IsPreconnected (K \ {f z₀})` instead. The remaining open statement is
 `frontier Ω ∩ closure A ∩ closure B ⊆ closure γ`, the input
 `TauCeti/Analysis/Complex/Conformal/Crosscut/BoundarySplit.lean` names as missing before its
 dichotomy `TauCeti.subset_or_subset_of_isPreconnected_frontier_image_sdiff` can be fed a boundary
@@ -436,7 +434,7 @@ filled hull outright, or they lie in different components of `Kᶜ`, of which at
 unbounded component of a bounded set's complement.
 
 It is the form in which an obstruction to a logarithm delivers the enclosure hypothesis of
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt`. -/
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff`. -/
 theorem mem_filledHull_or_mem_filledHull_of_not_hasContinuousLogOn (hK : IsClosed K)
     (hKb : Bornology.IsBounded K)
     (h : ¬ HasContinuousLogOn (fun z => (z - a) / (z - b)) K) :

--- a/TauCeti/Analysis/Complex/ContinuousLog/Basic.lean
+++ b/TauCeti/Analysis/Complex/ContinuousLog/Basic.lean
@@ -76,11 +76,13 @@ at all.
 
 ## Roadmap role
 
-**Plane separation for Jordan curves** is an open frontier item of layer **L5** of
+**Plane separation for Jordan curves** was an open frontier item of layer **L5** of
 `TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence.
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff` of
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton` of
 `TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean` avoids the plane-separation hypothesis
-entirely by taking `IsPreconnected (K \ {f z₀})` instead. The remaining open statement is
+entirely by taking `IsPreconnected (K \ {f z₀})` instead, which
+`IsJordanCurve.isPathConnected_sdiff_singleton` discharges; `Caratheodory.lean` is now
+unconditional. The remaining open statement is
 `frontier Ω ∩ closure A ∩ closure B ⊆ closure γ`, the input
 `TauCeti/Analysis/Complex/Conformal/Crosscut/BoundarySplit.lean` names as missing before its
 dichotomy `TauCeti.subset_or_subset_of_isPreconnected_frontier_image_sdiff` can be fed a boundary
@@ -434,7 +436,7 @@ filled hull outright, or they lie in different components of `Kᶜ`, of which at
 unbounded component of a bounded set's complement.
 
 It is the form in which an obstruction to a logarithm delivers the enclosure hypothesis of
-`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff`. -/
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton`. -/
 theorem mem_filledHull_or_mem_filledHull_of_not_hasContinuousLogOn (hK : IsClosed K)
     (hKb : Bornology.IsBounded K)
     (h : ¬ HasContinuousLogOn (fun z => (z - a) / (z - b)) K) :

--- a/TauCeti/Analysis/Complex/ContinuousLog/Path.lean
+++ b/TauCeti/Analysis/Complex/ContinuousLog/Path.lean
@@ -29,13 +29,14 @@ into a Hausdorff space being a closed embedding. No formalization is vendored.
 
 ## Roadmap role
 
-Plane separation for Jordan curves is the open frontier item of layer **L5** of
-`TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence. The
-classical route goes through two inputs: Borsuk's criterion, which turns a logarithm of
-`z ↦ (z - a) / (z - b)` on a compact set into nonseparation of `a` and `b`, and the fact that an
-arc does not separate the plane. The former is in flight in Tau Ceti PR #4701. This file supplies
-the logarithm construction needed for the latter: once that criterion is available, applying
-`TauCeti.hasContinuousLogOn_sub_div_sub_range_of_injective_path` shows immediately that any two
+The Carathéodory enclosure step (layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md`) is now unconditional: the
+preconnectedness/winding-number route in
+`TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean` discharges it without plane
+separation. The classical separation route — Borsuk's criterion (PR #4701) plus arc
+nonseparation — remains relevant for future work. This file supplies the logarithm
+construction needed for that
+route: applying `TauCeti.hasContinuousLogOn_sub_div_sub_range_of_injective_path` shows that any two
 points off a simple arc lie in the same component of its complement.
 
 This is deliberately stated for paths in an arbitrary topological space, since neither the lifting

--- a/TauCeti/Analysis/Complex/PlaneSeparation/Basic.lean
+++ b/TauCeti/Analysis/Complex/PlaneSeparation/Basic.lean
@@ -63,14 +63,15 @@ or to contain an arc; `K` enters only through the frontier of one component of i
 
 ## Roadmap role
 
-**Plane separation for Jordan curves** is the open frontier item of layer **L5** of
-`TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence: the whole of
-`TauCeti/Analysis/Complex/Conformal/Caratheodory.lean` is proved from the single unmet hypothesis
-`∀ J, IsJordanCurve J → J ⊆ closure (filledHull J \ J)`, and the classical route to it runs through
-Janiszewski's theorem. `TauCeti/Analysis/Complex/ContinuousLog/Basic.lean` names exactly one missing
-step on that route — "what remains before Janiszewski is the converse direction" — and this file
-supplies it, so `TauCeti.janiszewski` is now available to the separation theory that layer L5
-waits on.
+**Plane separation for Jordan curves** was the open frontier item of layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence.
+`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton` of
+`TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean` avoids the plane-separation hypothesis
+entirely by taking `IsPreconnected (K \ {f z₀})` instead, which
+`IsJordanCurve.isPathConnected_sdiff_singleton` discharges; `Caratheodory.lean` is now
+unconditional. `TauCeti/Analysis/Complex/ContinuousLog/Basic.lean` names the remaining open
+statement on the classical route through Janiszewski's theorem — the converse direction — and
+this file supplies it, so `TauCeti.janiszewski` is available to that route as well.
 
 Mathlib has no separation theory for the plane and no Jordan curve theorem, and layer L5 is absent
 from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress

--- a/TauCeti/Analysis/Normed/Module/FilledHull.lean
+++ b/TauCeti/Analysis/Normed/Module/FilledHull.lean
@@ -42,14 +42,13 @@ off from infinity is itself small*, with no regularity asked of `K`.
 
 ## Roadmap role
 
-The filled hull is the vocabulary in which the open frontier item of layer **L5** of
-`TauCetiRoadmap/ConformalMapping/README.md` is stated; see the roadmap section of
-`TauCeti/Topology/FilledHull.lean`. The step waiting on that item is the one bounding the piece a
-crosscut cuts off from a Jordan domain: the file
-`TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean` encloses a short image crosscut
-in an arbitrarily small Jordan curve `J`, and the cut-off piece is a connected set disjoint from
-`J`; once separation says it is the inside of `J` that the piece falls on,
-`TauCeti.IsPreconnected.diam_le_diam_of_disjoint` makes it no wider than `J`.
+The filled hull is the vocabulary in which the enclosure step of layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md` is stated. That step is now unconditional: the
+preconnectedness/winding-number route in `TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean`
+places one image piece of a crosscut in the filled hull without plane separation. In the diameter
+bound that follows, `TauCeti/Analysis/Complex/Conformal/Crosscut/SmallJordanCurve.lean` encloses a
+short image crosscut in an arbitrarily small Jordan curve `J`, and
+`TauCeti.IsPreconnected.diam_le_diam_of_disjoint` makes the cut-off piece no wider than `J`.
 
 This is a different route to a diameter bound from `TauCeti.diam_le_diam_of_frontier_subset` of
 `TauCeti/Analysis/Normed/Module/DiamFrontier.lean`, which bounds a set by *any* bounded set

--- a/TauCeti/Topology/FilledHull.lean
+++ b/TauCeti/Topology/FilledHull.lean
@@ -43,17 +43,14 @@ needed downstream, and the first two of which fail without hypotheses on `K`.
 
 ## Roadmap role
 
-Plane separation for Jordan curves is the open frontier item of layer **L5** of
-`TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence:
-`ConformalMapping/STATUS.md` records that nothing in the repository establishes that a Jordan curve
-separates the plane, and asks that how much of it the boundary work needs be settled first. What
-that work needs is the single statement that every point of a Jordan curve is a limit of points
-inside it,
-
-> `J ⊆ closure (filledHull J \ J)`,
-
-which is written in the vocabulary defined here — the inside of `J` is `filledHull J \ J`. So this
-file supplies what the missing stage is stated with rather than presuming it: nothing here assumes
+Plane separation for Jordan curves was the open frontier item of layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence. The
+enclosure step now runs through `IsPreconnected (K \ {f z₀})` and the winding-number two-sidedness
+theorem
+(`TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton`),
+which `IsJordanCurve.isPathConnected_sdiff_singleton` discharges; `Caratheodory.lean` is
+unconditional.
+The inside of `J` is `filledHull J \ J` in the vocabulary defined here. Nothing here assumes
 separation, or any other regularity of `K`.
 
 ## Main results


### PR DESCRIPTION
For a holomorphic injection of an open set, one of the two image pieces of a crosscut lies in the filled hull of a closed bounded set enclosing the image crosscut. The proof constructs a transversal segment through a point of the image crosscut, shows that the enclosing set is adherent from both sides of this transversal, and applies the winding-number separation theorem from #4638 to place one end in the filled hull. No Jordan curve theorem is used.

The disjunction is then eliminated by a diameter bound in image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton (Inside.lean), which concludes that the near side is enclosed when the enclosing set minus a point is preconnected and narrower than the far-side image.

Changed files:

TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
- TauCeti.deriv_ne_zero_of_injOn — pointwise nonvanishing derivative for a holomorphic injection of an open set.

TauCeti/Analysis/Complex/Conformal/InverseFunction.lean
- TauCeti.DifferentiableOn.invFunOn — the inverse of a holomorphic injection on an open set is holomorphic on its image.
- TauCeti.hasDerivAt_invFunOn — the derivative of the inverse at f z₀ is (deriv f z₀)⁻¹, via HasDerivAt.of_local_left_inverse.
- TauCeti.hasDerivAt_invFunOn_comp_segment — the chain rule for the inverse along an affine segment through the image of z₀.

TauCeti/Analysis/Complex/Conformal/Crosscut/Inside.lean
- TauCeti.exists_pos_forall_mem_image_inter_ball_and_image_sdiff_closedBall — existence of a positive radius such that the transversal segment through a point of the image crosscut has near side and far side on opposite sides.
- TauCeti.mem_closure_image_inter_sphere_inter_setOf_im_pos_and_mem_closure_inter_setOf_im_neg — the image crosscut point is in the closure of both the positive- and negative-imaginary-part sides of the transversal.
- TauCeti.image_inter_ball_subset_filledHull_or_image_sdiff_closedBall_subset_filledHull — one of the two image pieces lies in the filled hull.
- TauCeti.image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton — when the enclosing set minus a point is preconnected and narrower than the far-side image, the near side lies in the filled hull.
- TauCeti.image_inter_ball_subset_filledHull_of_frontier_subset — frontier route: the filled-hull inclusion via frontier containment.

TauCeti/Analysis/Complex/Conformal/Caratheodory.lean
- Rewired the enclosure step to image_inter_ball_subset_filledHull_of_diam_lt_of_isPreconnected_sdiff_singleton, dropping the plane-separation hypothesis from two theorem signatures. The preconnectedness of J \ {f z} is supplied by IsJordanCurve.isPathConnected_sdiff_singleton.

TauCeti/Analysis/Complex/Conformal/Biholomotive.lean
- Replaced inline deriv ≠ 0 proofs with deriv_ne_zero_of_injOn.

TauCeti/Analysis/Complex/ContinuousLog/Basic.lean
- Docstring references updated to image_intof_diam_lt_of_isPreconnected_sdiff_singleton.

TauCeti/Analysis/Complex/PlaneSeparation.ledHull.lean
- Roadmap docstrings updated to reflect the removal of the plane-separation hypothesis.

Built from the winding-number separation theorem (#4638), the existing crosscut infrastructure (SmallJordanCurve,
Basic, Image, Endpoints), and the local degory in LocalDegree.lean andInverseFunction.lean. No sorry, no axioms beyond the allowlist. Credit: mathlib4#33505 (IsOpenMap.analyticAt).

Proof generated with Claude Fable 5.                                                                            
Roadmap: ConformalMapping