### PR TITLE
feat: add the GL2 Tits system

### DIFF
--- a/TauCeti/Data/Fin/Basic.lean
+++ b/TauCeti/Data/Fin/Basic.lean
@@ -6,9 +6,15 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.BigOperators.Fin
+public import Mathlib.Algebra.Group.End
+
+import Mathlib.Tactic.FinCases
 
 /-!
-# Indicator sums over `Fin n` keyed by a natural number
+# Basic results about finite ordinal types
+
+This file collects elementary facts about finite ordinal types, including the classification of
+permutations of `Fin 2` and indicator sums indexed by `Fin n`.
 
 `Fintype.sum_ite_eq` evaluates a sum whose indicator compares two elements of the index type.
 When the comparison is instead between a natural number and the `Fin.val` of the index — as it is
@@ -17,6 +23,8 @@ range, so the value is a `dite` rather than a plain application.
 
 ## Main results
 
+* `TauCeti.perm_fin_two_eq_one_or_swap`: every permutation of `Fin 2` is the identity or the
+  transposition.
 * `TauCeti.sum_ite_val_add`: a sum against the indicator of `b = k + j` picks out the summand at
   `b - j`, or vanishes when there is no such index.
 -/
@@ -24,6 +32,30 @@ range, so the value is a `dite` rather than a plain application.
 public section
 
 namespace TauCeti
+
+/-- A permutation of `Fin 2` is either the identity or the transposition. -/
+theorem perm_fin_two_eq_one_or_swap (e : Equiv.Perm (Fin 2)) :
+    e = 1 ∨ e = Equiv.swap 0 1 := by
+  by_cases h0 : e 0 = 0
+  · left
+    apply Equiv.ext
+    intro i
+    fin_cases i
+    · exact h0
+    · apply Fin.eq_one_of_ne_zero
+      intro h1
+      exact Fin.zero_ne_one (e.injective (h1.trans h0.symm)).symm
+  · right
+    have h0' : e 0 = 1 := Fin.eq_one_of_ne_zero _ h0
+    apply Equiv.ext
+    intro i
+    fin_cases i
+    · simpa using h0'
+    · have h1 : e 1 = 0 := by
+        by_contra h
+        have h1' : e 1 = 1 := Fin.eq_one_of_ne_zero _ h
+        exact Fin.zero_ne_one (e.injective (h1'.trans h0'.symm)).symm
+      simpa using h1
 
 /-- **A shifted indicator picks out one summand.** Summing `f` over `Fin n` against the indicator
 of `b = k + j` gives `f` at the index `b - j` when that is a valid index and `j ≤ b`, and `0`

--- a/TauCeti/GroupTheory/TitsSystem.lean
+++ b/TauCeti/GroupTheory/TitsSystem.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.GroupTheory.DoubleCoset
+public import Mathlib.GroupTheory.QuotientGroup.Defs
+
+import Mathlib.Algebra.Group.Subgroup.Map
+
+/-!
+# Tits systems
+
+A **Tits system**, or **BN-pair**, in a group `G` consists of two subgroups `B` and `N` and a
+set of lifts in `N` of the simple reflections of `W = N / (B ∩ N)`.  The subgroups generate
+`G`, the intersection `B ∩ N` is normal in `N`, the simple lifts generate `N` modulo that
+intersection and square into it, and the double cosets satisfy the Tits multiplication and
+nondegeneracy axioms.
+
+`TauCeti.TitsSystem` records the simple reflections by chosen lifts in `N`.  This avoids making
+the structure depend on representatives chosen later, while `TauCeti.TitsSystem.WeylGroup` and
+`TauCeti.TitsSystem.simple` recover the quotient and its representation-independent simple set.
+
+## Main definitions
+
+* `TauCeti.TitsSystem`: a Tits system with chosen lifts of its simple reflections.
+* `TauCeti.TitsSystem.intersection`: the subgroup `B ∩ N`, regarded as a subgroup of `N`.
+* `TauCeti.TitsSystem.WeylGroup`: the quotient `N / (B ∩ N)`.
+* `TauCeti.TitsSystem.simple`: the simple reflections in the Weyl group.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), Section 28.1.
+* T. A. Springer, *Linear Algebraic Groups*, second edition (1998), Section 8.3.
+-/
+
+public section
+
+open scoped Pointwise
+
+namespace TauCeti
+
+universe u
+
+/-- A **Tits system** (or **BN-pair**) in `G`, with chosen lifts in `N` of its simple
+reflections.
+
+The field `mul_doubleCoset_subset` is the usual axiom
+`B s B w B ⊆ B (s w) B ∪ B w B`.  Choosing lifts makes the generating and involution axioms
+expressible before constructing the quotient `N / (B ∩ N)`; the resulting simple set in the
+quotient is exposed by `TitsSystem.simple`. -/
+@[ext]
+structure TitsSystem (G : Type u) [Group G] where
+  /-- The subgroup conventionally denoted `B`. -/
+  borel : Subgroup G
+  /-- The subgroup conventionally denoted `N`. -/
+  normalizer : Subgroup G
+  /-- Chosen lifts in `N` of the simple reflections. -/
+  simpleReps : Set normalizer
+  /-- The subgroups `B` and `N` generate the ambient group. -/
+  closure_borel_union_normalizer :
+    Subgroup.closure ((borel : Set G) ∪ normalizer) = ⊤
+  /-- The intersection `B ∩ N`, regarded inside `N`, is normal. -/
+  intersection_normal : (borel.comap normalizer.subtype).Normal
+  /-- The simple lifts together with `B ∩ N` generate `N`. -/
+  closure_intersection_union_simpleReps :
+    Subgroup.closure ((borel.comap normalizer.subtype : Set normalizer) ∪ simpleReps) = ⊤
+  /-- Every simple lift squares into `B ∩ N`. -/
+  simpleRep_sq_mem (s : normalizer) (hs : s ∈ simpleReps) :
+    s * s ∈ borel.comap normalizer.subtype
+  /-- Multiplying a Bruhat cell on the left by a simple cell produces at most the adjacent cell
+  and the original cell. -/
+  mul_doubleCoset_subset (s : normalizer) (hs : s ∈ simpleReps) (w : normalizer) :
+    DoubleCoset.doubleCoset (s : G) borel borel *
+        DoubleCoset.doubleCoset (w : G) borel borel ⊆
+      DoubleCoset.doubleCoset ((s * w : normalizer) : G) borel borel ∪
+        DoubleCoset.doubleCoset (w : G) borel borel
+  /-- No simple reflection conjugates `B` into `B`. -/
+  exists_conj_not_mem (s : normalizer) (hs : s ∈ simpleReps) :
+    ∃ b : borel, (s : G) * (b : G) * (s : G)⁻¹ ∉ borel
+
+namespace TitsSystem
+
+variable {G : Type u} [Group G] (T : TitsSystem G)
+
+/-- The intersection `B ∩ N`, regarded as a subgroup of `N`. -/
+def intersection : Subgroup T.normalizer :=
+  T.borel.comap T.normalizer.subtype
+
+/-- Membership in the intersection means membership in `B` after forgetting the `N` subtype. -/
+@[simp]
+theorem mem_intersection (n : T.normalizer) : n ∈ T.intersection ↔ (n : G) ∈ T.borel :=
+  Iff.rfl
+
+instance intersectionNormal : T.intersection.Normal :=
+  T.intersection_normal
+
+/-- The Weyl group `W = N / (B ∩ N)` of a Tits system. -/
+abbrev WeylGroup :=
+  T.normalizer ⧸ T.intersection
+
+/-- The simple reflections in the Weyl group, obtained from the chosen lifts. -/
+def simple : Set T.WeylGroup :=
+  QuotientGroup.mk' T.intersection '' T.simpleReps
+
+/-- The simple reflections are the images of the chosen simple representatives. -/
+theorem simple_def : T.simple = QuotientGroup.mk' T.intersection '' T.simpleReps :=
+  (rfl)
+
+/-- Every chosen simple representative maps to a simple reflection. -/
+theorem mk_mem_simple (s : T.normalizer) (hs : s ∈ T.simpleReps) :
+    QuotientGroup.mk' T.intersection s ∈ T.simple :=
+  ⟨s, hs, rfl⟩
+
+/-- Every simple reflection has square one. -/
+theorem simple_sq_eq_one {s : T.WeylGroup} (hs : s ∈ T.simple) : s * s = 1 := by
+  obtain ⟨s, hs, rfl⟩ := hs
+  rw [← map_mul]
+  exact (QuotientGroup.eq_one_iff (N := T.intersection) (s * s)).mpr
+    (T.simpleRep_sq_mem s hs)
+
+/-- The simple reflections generate the Weyl group. -/
+theorem closure_simple : Subgroup.closure T.simple = ⊤ := by
+  apply top_unique
+  intro w _
+  obtain ⟨n, rfl⟩ := QuotientGroup.mk'_surjective T.intersection w
+  have hn : n ∈ Subgroup.closure
+      ((T.borel.comap T.normalizer.subtype : Set T.normalizer) ∪ T.simpleReps) := by
+    rw [T.closure_intersection_union_simpleReps]
+    exact Subgroup.mem_top n
+  have hmap : QuotientGroup.mk' T.intersection n ∈
+      (Subgroup.closure
+        ((T.borel.comap T.normalizer.subtype : Set T.normalizer) ∪ T.simpleReps)).map
+          (QuotientGroup.mk' T.intersection) :=
+    ⟨n, hn, rfl⟩
+  rw [MonoidHom.map_closure] at hmap
+  exact ((Subgroup.closure_le (Subgroup.closure T.simple)).mpr (fun x hx ↦ by
+    obtain ⟨y, hy, rfl⟩ := hx
+    rcases hy with hy | hy
+    · have hy' : y ∈ T.intersection := (T.mem_intersection y).mpr hy
+      have hqy : QuotientGroup.mk' T.intersection y = 1 :=
+        (QuotientGroup.eq_one_iff y).mpr hy'
+      rw [hqy]
+      exact (Subgroup.closure T.simple).one_mem
+    · exact Subgroup.subset_closure (T.mk_mem_simple y hy))) hmap
+
+/-- A simple reflection is not the identity. -/
+theorem simple_ne_one {s : T.WeylGroup} (hs : s ∈ T.simple) : s ≠ 1 := by
+  obtain ⟨s, hs, rfl⟩ := hs
+  intro heq
+  have hsB : (s : G) ∈ T.borel :=
+    (T.mem_intersection s).mp ((QuotientGroup.eq_one_iff s).mp heq)
+  obtain ⟨b, hb⟩ := T.exists_conj_not_mem s hs
+  exact hb (T.borel.mul_mem (T.borel.mul_mem hsB b.property) (T.borel.inv_mem hsB))
+
+end TitsSystem
+
+end TauCeti

--- a/TauCeti/GroupTheory/TitsSystem.lean
+++ b/TauCeti/GroupTheory/TitsSystem.lean
@@ -90,23 +90,19 @@ namespace TitsSystem
 variable {G : Type u} [Group G] (T : TitsSystem G)
 
 /-- The intersection `B ∩ N`, regarded as a subgroup of `N`. -/
-def intersection : Subgroup T.subgroupN :=
+abbrev intersection : Subgroup T.subgroupN :=
   T.subgroupB.comap T.subgroupN.subtype
 
 /-- Membership in the intersection means membership in `B` after forgetting the `N` subtype. -/
-@[simp]
 theorem mem_intersection (n : T.subgroupN) : n ∈ T.intersection ↔ (n : G) ∈ T.subgroupB :=
   Iff.rfl
-
-instance subgroupBComapNormal : (T.subgroupB.comap T.subgroupN.subtype).Normal :=
-  T.intersection_normal
 
 instance intersectionNormal : T.intersection.Normal :=
   T.intersection_normal
 
 /-- The Weyl group `W = N / (B ∩ N)` of a Tits system. -/
 abbrev WeylGroup :=
-  T.subgroupN ⧸ T.subgroupB.comap T.subgroupN.subtype
+  T.subgroupN ⧸ T.intersection
 
 /-- Every simple reflection has square one. -/
 theorem simple_sq_eq_one {s : T.WeylGroup} (hs : s ∈ T.simple) : s * s = 1 := by

--- a/TauCeti/GroupTheory/TitsSystem.lean
+++ b/TauCeti/GroupTheory/TitsSystem.lean
@@ -14,18 +14,13 @@ import Mathlib.Algebra.Group.Subgroup.Map
 # Tits systems
 
 A **Tits system**, or **BN-pair**, in a group `G` consists of two subgroups `B` and `N` and a
-set of lifts in `N` of the simple reflections of `W = N / (B ∩ N)`.  The subgroups generate
-`G`, the intersection `B ∩ N` is normal in `N`, the simple lifts generate `N` modulo that
-intersection and square into it, and the double cosets satisfy the Tits multiplication and
-nondegeneracy axioms.
-
-`TauCeti.TitsSystem` records the simple reflections by chosen lifts in `N`.  This avoids making
-the structure depend on representatives chosen later, while `TauCeti.TitsSystem.WeylGroup` and
-`TauCeti.TitsSystem.simple` recover the quotient and its representation-independent simple set.
+set of simple reflections in `W = N / (B ∩ N)`.  The subgroups generate `G`, the intersection
+`B ∩ N` is normal in `N`, the simple reflections generate `W` and are involutions, and the
+double cosets satisfy the Tits multiplication and nondegeneracy axioms.
 
 ## Main definitions
 
-* `TauCeti.TitsSystem`: a Tits system with chosen lifts of its simple reflections.
+* `TauCeti.TitsSystem`: a Tits system with its simple reflections in the Weyl quotient.
 * `TauCeti.TitsSystem.intersection`: the subgroup `B ∩ N`, regarded as a subgroup of `N`.
 * `TauCeti.TitsSystem.WeylGroup`: the quotient `N / (B ∩ N)`.
 * `TauCeti.TitsSystem.simple`: the simple reflections in the Weyl group.
@@ -44,42 +39,51 @@ namespace TauCeti
 
 universe u
 
-/-- A **Tits system** (or **BN-pair**) in `G`, with chosen lifts in `N` of its simple
-reflections.
+/-- A **Tits system** (or **BN-pair**) in `G`.
 
 The field `mul_doubleCoset_subset` is the usual axiom
-`B s B w B ⊆ B (s w) B ∪ B w B`.  Choosing lifts makes the generating and involution axioms
-expressible before constructing the quotient `N / (B ∩ N)`; the resulting simple set in the
-quotient is exposed by `TitsSystem.simple`. -/
+`B s B w B ⊆ B (s w) B ∪ B w B`.  Its representative is supplied existentially so the
+structure records only the representation-independent simple set in `N / (B ∩ N)`. -/
 @[ext]
 structure TitsSystem (G : Type u) [Group G] where
   /-- The subgroup conventionally denoted `B`. -/
   subgroupB : Subgroup G
   /-- The subgroup conventionally denoted `N`. -/
   subgroupN : Subgroup G
-  /-- Chosen lifts in `N` of the simple reflections. -/
-  simpleReps : Set subgroupN
   /-- The subgroups `B` and `N` generate the ambient group. -/
   closure_subgroupB_union_subgroupN :
     Subgroup.closure ((subgroupB : Set G) ∪ subgroupN) = ⊤
   /-- The intersection `B ∩ N`, regarded inside `N`, is normal. -/
   intersection_normal : (subgroupB.comap subgroupN.subtype).Normal
-  /-- The simple lifts together with `B ∩ N` generate `N`. -/
-  closure_intersection_union_simpleReps :
-    Subgroup.closure ((subgroupB.comap subgroupN.subtype : Set subgroupN) ∪ simpleReps) = ⊤
-  /-- Every simple lift squares into `B ∩ N`. -/
-  simpleRep_sq_mem (s : subgroupN) (hs : s ∈ simpleReps) :
-    s * s ∈ subgroupB.comap subgroupN.subtype
+  /-- The simple reflections in the Weyl quotient `N / (B ∩ N)`. -/
+  simple : Set (subgroupN ⧸ subgroupB.comap subgroupN.subtype)
+  /-- The simple reflections generate the Weyl quotient. -/
+  closure_simple :
+    let _ := intersection_normal
+    Subgroup.closure simple = ⊤
+  /-- Every simple reflection has a representative whose square lies in `B ∩ N`. -/
+  exists_simpleRep_sq_mem
+      (s : subgroupN ⧸ subgroupB.comap subgroupN.subtype) (hs : s ∈ simple) :
+    ∃ r : subgroupN,
+      (QuotientGroup.mk r : subgroupN ⧸ subgroupB.comap subgroupN.subtype) = s ∧
+        r * r ∈ subgroupB.comap subgroupN.subtype
   /-- Multiplying a Bruhat cell on the left by a simple cell produces at most the adjacent cell
   and the original cell. -/
-  mul_doubleCoset_subset (s : subgroupN) (hs : s ∈ simpleReps) (w : subgroupN) :
-    DoubleCoset.doubleCoset (s : G) subgroupB subgroupB *
-        DoubleCoset.doubleCoset (w : G) subgroupB subgroupB ⊆
-      DoubleCoset.doubleCoset ((s * w : subgroupN) : G) subgroupB subgroupB ∪
-        DoubleCoset.doubleCoset (w : G) subgroupB subgroupB
+  mul_doubleCoset_subset
+      (s : subgroupN ⧸ subgroupB.comap subgroupN.subtype) (hs : s ∈ simple) :
+    ∃ r : subgroupN,
+      (QuotientGroup.mk r : subgroupN ⧸ subgroupB.comap subgroupN.subtype) = s ∧
+        ∀ w : subgroupN,
+          DoubleCoset.doubleCoset (r : G) subgroupB subgroupB *
+              DoubleCoset.doubleCoset (w : G) subgroupB subgroupB ⊆
+            DoubleCoset.doubleCoset ((r * w : subgroupN) : G) subgroupB subgroupB ∪
+              DoubleCoset.doubleCoset (w : G) subgroupB subgroupB
   /-- No simple reflection conjugates `B` into `B`. -/
-  exists_conj_not_mem (s : subgroupN) (hs : s ∈ simpleReps) :
-    ∃ b : subgroupB, (s : G) * (b : G) * (s : G)⁻¹ ∉ subgroupB
+  exists_conj_not_mem
+      (s : subgroupN ⧸ subgroupB.comap subgroupN.subtype) (hs : s ∈ simple) :
+    ∃ r : subgroupN,
+      (QuotientGroup.mk r : subgroupN ⧸ subgroupB.comap subgroupN.subtype) = s ∧
+        ∃ b : subgroupB, (r : G) * (b : G) * (r : G)⁻¹ ∉ subgroupB
 
 namespace TitsSystem
 
@@ -94,67 +98,29 @@ def intersection : Subgroup T.subgroupN :=
 theorem mem_intersection (n : T.subgroupN) : n ∈ T.intersection ↔ (n : G) ∈ T.subgroupB :=
   Iff.rfl
 
+instance subgroupBComapNormal : (T.subgroupB.comap T.subgroupN.subtype).Normal :=
+  T.intersection_normal
+
 instance intersectionNormal : T.intersection.Normal :=
   T.intersection_normal
 
 /-- The Weyl group `W = N / (B ∩ N)` of a Tits system. -/
 abbrev WeylGroup :=
-  T.subgroupN ⧸ T.intersection
-
-/-- The simple reflections in the Weyl group, obtained from the chosen lifts. -/
-def simple : Set T.WeylGroup :=
-  QuotientGroup.mk' T.intersection '' T.simpleReps
-
-/-- Membership in the simple set means being the image of a chosen simple representative. -/
-@[simp]
-theorem mem_simple (s : T.WeylGroup) :
-    s ∈ T.simple ↔ ∃ r ∈ T.simpleReps, QuotientGroup.mk' T.intersection r = s :=
-  Iff.rfl
-
-/-- Every chosen simple representative maps to a simple reflection. -/
-theorem mk_mem_simple (s : T.subgroupN) (hs : s ∈ T.simpleReps) :
-    QuotientGroup.mk' T.intersection s ∈ T.simple :=
-  (T.mem_simple _).2 ⟨s, hs, rfl⟩
+  T.subgroupN ⧸ T.subgroupB.comap T.subgroupN.subtype
 
 /-- Every simple reflection has square one. -/
 theorem simple_sq_eq_one {s : T.WeylGroup} (hs : s ∈ T.simple) : s * s = 1 := by
-  obtain ⟨r, hr, rfl⟩ := (T.mem_simple _).1 hs
-  rw [← map_mul]
-  exact (QuotientGroup.eq_one_iff (N := T.intersection) (r * r)).mpr
-    (T.simpleRep_sq_mem r hr)
-
-/-- The simple reflections generate the Weyl group. -/
-theorem closure_simple : Subgroup.closure T.simple = ⊤ := by
-  apply top_unique
-  intro w _
-  obtain ⟨n, rfl⟩ := QuotientGroup.mk'_surjective T.intersection w
-  have hn : n ∈ Subgroup.closure
-      ((T.subgroupB.comap T.subgroupN.subtype : Set T.subgroupN) ∪ T.simpleReps) := by
-    rw [T.closure_intersection_union_simpleReps]
-    exact Subgroup.mem_top n
-  have hmap : QuotientGroup.mk' T.intersection n ∈
-      (Subgroup.closure
-        ((T.subgroupB.comap T.subgroupN.subtype : Set T.subgroupN) ∪ T.simpleReps)).map
-          (QuotientGroup.mk' T.intersection) :=
-    ⟨n, hn, rfl⟩
-  rw [MonoidHom.map_closure] at hmap
-  exact ((Subgroup.closure_le (Subgroup.closure T.simple)).mpr (fun x hx ↦ by
-    obtain ⟨y, hy, rfl⟩ := hx
-    rcases hy with hy | hy
-    · have hy' : y ∈ T.intersection := (T.mem_intersection y).mpr hy
-      have hqy : QuotientGroup.mk' T.intersection y = 1 :=
-        (QuotientGroup.eq_one_iff y).mpr hy'
-      rw [hqy]
-      exact (Subgroup.closure T.simple).one_mem
-    · exact Subgroup.subset_closure (T.mk_mem_simple y hy))) hmap
+  obtain ⟨r, rfl, hr⟩ := T.exists_simpleRep_sq_mem s hs
+  rw [← QuotientGroup.mk_mul]
+  exact (QuotientGroup.eq_one_iff (N := T.intersection) (r * r)).mpr hr
 
 /-- A simple reflection is not the identity. -/
 theorem simple_ne_one {s : T.WeylGroup} (hs : s ∈ T.simple) : s ≠ 1 := by
-  obtain ⟨r, hr, rfl⟩ := (T.mem_simple _).1 hs
+  obtain ⟨r, hrs, b, hb⟩ := T.exists_conj_not_mem s hs
   intro heq
+  have hr_one : QuotientGroup.mk' T.intersection r = 1 := hrs.trans heq
   have hsB : (r : G) ∈ T.subgroupB :=
-    (T.mem_intersection r).mp ((QuotientGroup.eq_one_iff r).mp heq)
-  obtain ⟨b, hb⟩ := T.exists_conj_not_mem r hr
+    (T.mem_intersection r).mp ((QuotientGroup.eq_one_iff r).mp hr_one)
   exact hb (T.subgroupB.mul_mem
     (T.subgroupB.mul_mem hsB b.property) (T.subgroupB.inv_mem hsB))
 

--- a/TauCeti/GroupTheory/TitsSystem.lean
+++ b/TauCeti/GroupTheory/TitsSystem.lean
@@ -54,44 +54,44 @@ quotient is exposed by `TitsSystem.simple`. -/
 @[ext]
 structure TitsSystem (G : Type u) [Group G] where
   /-- The subgroup conventionally denoted `B`. -/
-  borel : Subgroup G
+  subgroupB : Subgroup G
   /-- The subgroup conventionally denoted `N`. -/
-  normalizer : Subgroup G
+  subgroupN : Subgroup G
   /-- Chosen lifts in `N` of the simple reflections. -/
-  simpleReps : Set normalizer
+  simpleReps : Set subgroupN
   /-- The subgroups `B` and `N` generate the ambient group. -/
-  closure_borel_union_normalizer :
-    Subgroup.closure ((borel : Set G) ∪ normalizer) = ⊤
+  closure_subgroupB_union_subgroupN :
+    Subgroup.closure ((subgroupB : Set G) ∪ subgroupN) = ⊤
   /-- The intersection `B ∩ N`, regarded inside `N`, is normal. -/
-  intersection_normal : (borel.comap normalizer.subtype).Normal
+  intersection_normal : (subgroupB.comap subgroupN.subtype).Normal
   /-- The simple lifts together with `B ∩ N` generate `N`. -/
   closure_intersection_union_simpleReps :
-    Subgroup.closure ((borel.comap normalizer.subtype : Set normalizer) ∪ simpleReps) = ⊤
+    Subgroup.closure ((subgroupB.comap subgroupN.subtype : Set subgroupN) ∪ simpleReps) = ⊤
   /-- Every simple lift squares into `B ∩ N`. -/
-  simpleRep_sq_mem (s : normalizer) (hs : s ∈ simpleReps) :
-    s * s ∈ borel.comap normalizer.subtype
+  simpleRep_sq_mem (s : subgroupN) (hs : s ∈ simpleReps) :
+    s * s ∈ subgroupB.comap subgroupN.subtype
   /-- Multiplying a Bruhat cell on the left by a simple cell produces at most the adjacent cell
   and the original cell. -/
-  mul_doubleCoset_subset (s : normalizer) (hs : s ∈ simpleReps) (w : normalizer) :
-    DoubleCoset.doubleCoset (s : G) borel borel *
-        DoubleCoset.doubleCoset (w : G) borel borel ⊆
-      DoubleCoset.doubleCoset ((s * w : normalizer) : G) borel borel ∪
-        DoubleCoset.doubleCoset (w : G) borel borel
+  mul_doubleCoset_subset (s : subgroupN) (hs : s ∈ simpleReps) (w : subgroupN) :
+    DoubleCoset.doubleCoset (s : G) subgroupB subgroupB *
+        DoubleCoset.doubleCoset (w : G) subgroupB subgroupB ⊆
+      DoubleCoset.doubleCoset ((s * w : subgroupN) : G) subgroupB subgroupB ∪
+        DoubleCoset.doubleCoset (w : G) subgroupB subgroupB
   /-- No simple reflection conjugates `B` into `B`. -/
-  exists_conj_not_mem (s : normalizer) (hs : s ∈ simpleReps) :
-    ∃ b : borel, (s : G) * (b : G) * (s : G)⁻¹ ∉ borel
+  exists_conj_not_mem (s : subgroupN) (hs : s ∈ simpleReps) :
+    ∃ b : subgroupB, (s : G) * (b : G) * (s : G)⁻¹ ∉ subgroupB
 
 namespace TitsSystem
 
 variable {G : Type u} [Group G] (T : TitsSystem G)
 
 /-- The intersection `B ∩ N`, regarded as a subgroup of `N`. -/
-def intersection : Subgroup T.normalizer :=
-  T.borel.comap T.normalizer.subtype
+def intersection : Subgroup T.subgroupN :=
+  T.subgroupB.comap T.subgroupN.subtype
 
 /-- Membership in the intersection means membership in `B` after forgetting the `N` subtype. -/
 @[simp]
-theorem mem_intersection (n : T.normalizer) : n ∈ T.intersection ↔ (n : G) ∈ T.borel :=
+theorem mem_intersection (n : T.subgroupN) : n ∈ T.intersection ↔ (n : G) ∈ T.subgroupB :=
   Iff.rfl
 
 instance intersectionNormal : T.intersection.Normal :=
@@ -99,27 +99,29 @@ instance intersectionNormal : T.intersection.Normal :=
 
 /-- The Weyl group `W = N / (B ∩ N)` of a Tits system. -/
 abbrev WeylGroup :=
-  T.normalizer ⧸ T.intersection
+  T.subgroupN ⧸ T.intersection
 
 /-- The simple reflections in the Weyl group, obtained from the chosen lifts. -/
 def simple : Set T.WeylGroup :=
   QuotientGroup.mk' T.intersection '' T.simpleReps
 
-/-- The simple reflections are the images of the chosen simple representatives. -/
-theorem simple_def : T.simple = QuotientGroup.mk' T.intersection '' T.simpleReps :=
-  (rfl)
+/-- Membership in the simple set means being the image of a chosen simple representative. -/
+@[simp]
+theorem mem_simple (s : T.WeylGroup) :
+    s ∈ T.simple ↔ ∃ r ∈ T.simpleReps, QuotientGroup.mk' T.intersection r = s :=
+  Iff.rfl
 
 /-- Every chosen simple representative maps to a simple reflection. -/
-theorem mk_mem_simple (s : T.normalizer) (hs : s ∈ T.simpleReps) :
+theorem mk_mem_simple (s : T.subgroupN) (hs : s ∈ T.simpleReps) :
     QuotientGroup.mk' T.intersection s ∈ T.simple :=
-  ⟨s, hs, rfl⟩
+  (T.mem_simple _).2 ⟨s, hs, rfl⟩
 
 /-- Every simple reflection has square one. -/
 theorem simple_sq_eq_one {s : T.WeylGroup} (hs : s ∈ T.simple) : s * s = 1 := by
-  obtain ⟨s, hs, rfl⟩ := hs
+  obtain ⟨r, hr, rfl⟩ := (T.mem_simple _).1 hs
   rw [← map_mul]
-  exact (QuotientGroup.eq_one_iff (N := T.intersection) (s * s)).mpr
-    (T.simpleRep_sq_mem s hs)
+  exact (QuotientGroup.eq_one_iff (N := T.intersection) (r * r)).mpr
+    (T.simpleRep_sq_mem r hr)
 
 /-- The simple reflections generate the Weyl group. -/
 theorem closure_simple : Subgroup.closure T.simple = ⊤ := by
@@ -127,12 +129,12 @@ theorem closure_simple : Subgroup.closure T.simple = ⊤ := by
   intro w _
   obtain ⟨n, rfl⟩ := QuotientGroup.mk'_surjective T.intersection w
   have hn : n ∈ Subgroup.closure
-      ((T.borel.comap T.normalizer.subtype : Set T.normalizer) ∪ T.simpleReps) := by
+      ((T.subgroupB.comap T.subgroupN.subtype : Set T.subgroupN) ∪ T.simpleReps) := by
     rw [T.closure_intersection_union_simpleReps]
     exact Subgroup.mem_top n
   have hmap : QuotientGroup.mk' T.intersection n ∈
       (Subgroup.closure
-        ((T.borel.comap T.normalizer.subtype : Set T.normalizer) ∪ T.simpleReps)).map
+        ((T.subgroupB.comap T.subgroupN.subtype : Set T.subgroupN) ∪ T.simpleReps)).map
           (QuotientGroup.mk' T.intersection) :=
     ⟨n, hn, rfl⟩
   rw [MonoidHom.map_closure] at hmap
@@ -148,12 +150,13 @@ theorem closure_simple : Subgroup.closure T.simple = ⊤ := by
 
 /-- A simple reflection is not the identity. -/
 theorem simple_ne_one {s : T.WeylGroup} (hs : s ∈ T.simple) : s ≠ 1 := by
-  obtain ⟨s, hs, rfl⟩ := hs
+  obtain ⟨r, hr, rfl⟩ := (T.mem_simple _).1 hs
   intro heq
-  have hsB : (s : G) ∈ T.borel :=
-    (T.mem_intersection s).mp ((QuotientGroup.eq_one_iff s).mp heq)
-  obtain ⟨b, hb⟩ := T.exists_conj_not_mem s hs
-  exact hb (T.borel.mul_mem (T.borel.mul_mem hsB b.property) (T.borel.inv_mem hsB))
+  have hsB : (r : G) ∈ T.subgroupB :=
+    (T.mem_intersection r).mp ((QuotientGroup.eq_one_iff r).mp heq)
+  obtain ⟨b, hb⟩ := T.exists_conj_not_mem r hr
+  exact hb (T.subgroupB.mul_mem
+    (T.subgroupB.mul_mem hsB b.property) (T.subgroupB.inv_mem hsB))
 
 end TitsSystem
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
@@ -175,18 +175,6 @@ private theorem gl2_doubleCoset_weyl_mul_union_eq_univ (g : GL2DiagonalNormalize
     rw [hwgCoset, GL2Borel.doubleCoset_one_eq, hgCoset,
       GL2Borel.union_doubleCoset_weyl_eq_univ]
 
-private theorem gl2_tits_mul_doubleCoset_subset
-    (s : GL2DiagonalNormalizer k)
-    (hs : s ∈ ({gl2WeylNormalizer k} : Set (GL2DiagonalNormalizer k)))
-    (g : GL2DiagonalNormalizer k) :
-    DoubleCoset.doubleCoset (s : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) *
-        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) ⊆
-      DoubleCoset.doubleCoset ((s * g : GL2DiagonalNormalizer k) : GL (Fin 2) k)
-          (GL2Borel k) (GL2Borel k) ∪
-        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) := by
-  rw [Set.mem_singleton_iff.mp hs, gl2_doubleCoset_weyl_mul_union_eq_univ]
-  exact Set.subset_univ _
-
 omit [Nontrivial kˣ] in
 private theorem gl2_tits_exists_conj_not_mem
     (s : GL2DiagonalNormalizer k)
@@ -259,8 +247,9 @@ def gl2TitsSystem : TitsSystem (GL (Fin 2) k) where
     exact (GL2Borel k).one_mem
   mul_doubleCoset_subset s hs := by
     rw [Set.mem_singleton_iff] at hs
-    exact ⟨gl2WeylNormalizer k, hs.symm,
-      gl2_tits_mul_doubleCoset_subset k (gl2WeylNormalizer k) (Set.mem_singleton _)⟩
+    refine ⟨gl2WeylNormalizer k, hs.symm, fun g ↦ ?_⟩
+    rw [gl2_doubleCoset_weyl_mul_union_eq_univ]
+    exact Set.subset_univ _
   exists_conj_not_mem s hs := by
     rw [Set.mem_singleton_iff] at hs
     obtain ⟨b, hb⟩ := gl2_tits_exists_conj_not_mem k

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
@@ -1,0 +1,267 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.GroupTheory.TitsSystem
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal.Bruhat
+
+-- Non-public: `perm_fin_two_eq_one_or_swap` classifies the permutation quotient in rank one.
+import TauCeti.LinearAlgebra.TensorSquare
+
+/-!
+# The rank-one Tits system of `GL₂`
+
+Let `B` be the upper-triangular subgroup of `GL₂(k)` and let `N` be the normalizer of its
+diagonal torus `T`. Over a field whose unit group is nontrivial, these subgroups form a Tits
+system. Its single simple reflection is represented by the permutation matrix
+`w = !![0, 1; 1, 0]`.
+
+The proof assembles the rank-one results already available for `GL₂`: Bruhat decomposition and
+generation by `B` and `w`; the equality `B ∩ N = T`; the permutation quotient `N / T ≃ S₂`;
+and the fact that conjugating a nontrivial upper unipotent element by `w` gives a lower
+unipotent element outside `B`.
+
+## Main results
+
+* `TauCeti.gl2TitsSystem`: the standard Tits system of `GL₂(k)`.
+* `TauCeti.gl2TitsSystem_mem_intersection`: its subgroup `B ∩ N` is the diagonal torus inside
+  `N`.
+* `TauCeti.gl2TitsSystemSimpleRep` and `TauCeti.gl2TitsSystem_simple`: its Weyl group has the
+  single simple reflection represented by `GL2WeylElement k`.
+
+## References
+
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), Sections 26.2–26.3 and 28.1.
+* T. A. Springer, *Linear Algebraic Groups*, second edition (1998), Sections 8.3–8.4.
+
+This completes the rank-one example of Layer 7, "Bruhat decomposition and BN-pairs / Tits
+systems", of the ReductiveGroups roadmap.
+-/
+
+public section
+
+open Matrix
+open scoped Pointwise
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+variable (k : Type u) [Field k] [Nontrivial kˣ]
+
+/-- The normalizer of the diagonal torus, abbreviated within the construction. -/
+private abbrev GL2DiagonalNormalizer : Subgroup (GL (Fin 2) k) :=
+  Subgroup.normalizer (diagonalTorus k 2 : Set (GL (Fin 2) k))
+
+/-- The Weyl permutation matrix as an element of the diagonal-torus normalizer. -/
+private def gl2WeylNormalizer : GL2DiagonalNormalizer k :=
+  ⟨GL2WeylElement k, gl2WeylElement_mem_normalizer_diagonalTorus (R := k)⟩
+
+private theorem gl2_borel_comap_normalizer_eq_diagonal :
+    (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype =
+      (diagonalTorus k 2).subgroupOf (GL2DiagonalNormalizer k) := by
+  ext g
+  change (g : GL (Fin 2) k) ∈ GL2Borel k ↔ (g : GL (Fin 2) k) ∈ diagonalTorus k 2
+  constructor
+  · intro hg
+    have hmem : (g : GL (Fin 2) k) ∈
+        GL2Borel k ⊓ GL2DiagonalNormalizer k := ⟨hg, g.property⟩
+    rw [UpperTriangularGroup.inf_normalizer_diagonalTorus_eq] at hmem
+    exact hmem
+  · intro hg
+    exact UpperTriangularGroup.diagonalTorus_le (R := k) (n := 2) hg
+
+private theorem gl2_mem_borel_iff_normalizerPerm_eq_one (g : GL2DiagonalNormalizer k) :
+    (g : GL (Fin 2) k) ∈ GL2Borel k ↔
+      diagonalNormalizerPerm (k := k) (n := 2) g = 1 := by
+  have hinter := SetLike.ext_iff.mp (gl2_borel_comap_normalizer_eq_diagonal k) g
+  constructor
+  · exact fun hg ↦ (diagonalNormalizerPerm_eq_one_iff g).mpr (hinter.mp hg)
+  · exact fun hg ↦ hinter.mpr ((diagonalNormalizerPerm_eq_one_iff g).mp hg)
+
+private theorem finTwo_swap_ne_one : Equiv.swap (0 : Fin 2) 1 ≠ 1 := by
+  intro h
+  have h0 := congrArg (fun σ : Equiv.Perm (Fin 2) ↦ σ 0) h
+  simp at h0
+
+private theorem gl2_normalizer_closure :
+    Subgroup.closure
+        (((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype :
+            Set (GL2DiagonalNormalizer k)) ∪ {gl2WeylNormalizer k}) = ⊤ := by
+  apply top_unique
+  intro g _
+  let C : Subgroup (GL2DiagonalNormalizer k) :=
+    Subgroup.closure
+      (((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype :
+          Set (GL2DiagonalNormalizer k)) ∪ {gl2WeylNormalizer k})
+  have hinter_le :
+      (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype ≤ C := by
+    intro x hx
+    exact Subgroup.subset_closure (Or.inl hx)
+  have hweyl : gl2WeylNormalizer k ∈ C :=
+    Subgroup.subset_closure (Or.inr (Set.mem_singleton _))
+  let φ := diagonalNormalizerPerm (k := k) (n := 2)
+  have hφweyl : φ (gl2WeylNormalizer k) = Equiv.swap 0 1 :=
+    diagonalNormalizerPerm_gl2WeylElement (k := k)
+  rcases perm_fin_two_eq_one_or_swap (φ g) with hg | hg
+  · exact hinter_le ((gl2_mem_borel_iff_normalizerPerm_eq_one k g).mpr hg)
+  · have hker : g * (gl2WeylNormalizer k)⁻¹ ∈
+        (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype := by
+      change ((g * (gl2WeylNormalizer k)⁻¹ : GL2DiagonalNormalizer k) :
+        GL (Fin 2) k) ∈ GL2Borel k
+      apply (gl2_mem_borel_iff_normalizerPerm_eq_one k _).mpr
+      rw [map_mul, map_inv, hg, hφweyl, mul_inv_cancel]
+    have hfactor : g = (g * (gl2WeylNormalizer k)⁻¹) * gl2WeylNormalizer k := by
+      simp
+    rw [hfactor]
+    exact C.mul_mem (hinter_le hker) hweyl
+
+omit [Nontrivial kˣ] in
+private theorem gl2_borel_normalizer_closure :
+    Subgroup.closure
+        ((GL2Borel k : Set (GL (Fin 2) k)) ∪ GL2DiagonalNormalizer k) = ⊤ := by
+  have hle :
+      Subgroup.closure (insert (GL2WeylElement k) (GL2Borel k : Set (GL (Fin 2) k))) ≤
+        Subgroup.closure ((GL2Borel k : Set (GL (Fin 2) k)) ∪ GL2DiagonalNormalizer k) :=
+    Subgroup.closure_mono (by
+      intro g hg
+      rcases hg with (rfl | hg)
+      · exact Or.inr (gl2WeylNormalizer k).property
+      · exact Or.inl hg)
+  rw [GL2Borel.closure_insert_gl2WeylElement_eq_top] at hle
+  exact top_unique hle
+
+omit [Nontrivial kˣ] in
+private theorem gl2_doubleCoset_eq_borel_of_mem
+    {g : GL (Fin 2) k} (hg : g ∈ GL2Borel k) :
+    DoubleCoset.doubleCoset g (GL2Borel k) (GL2Borel k) = (GL2Borel k : Set _) := by
+  calc
+    DoubleCoset.doubleCoset g (GL2Borel k) (GL2Borel k) =
+        DoubleCoset.doubleCoset 1 (GL2Borel k) (GL2Borel k) :=
+      DoubleCoset.doubleCoset_eq_of_mem (by
+        rw [GL2Borel.doubleCoset_one_eq]
+        exact hg)
+    _ = (GL2Borel k : Set _) := GL2Borel.doubleCoset_one_eq
+
+omit [Nontrivial kˣ] in
+private theorem gl2_doubleCoset_eq_weyl_of_notMem
+    {g : GL (Fin 2) k} (hg : g ∉ GL2Borel k) :
+    DoubleCoset.doubleCoset g (GL2Borel k) (GL2Borel k) =
+      DoubleCoset.doubleCoset (GL2WeylElement k) (GL2Borel k) (GL2Borel k) :=
+  DoubleCoset.doubleCoset_eq_of_mem (GL2Borel.mem_doubleCoset_weyl_of_notMem hg)
+
+private theorem gl2_tits_mul_doubleCoset_subset
+    (s : GL2DiagonalNormalizer k)
+    (hs : s ∈ ({gl2WeylNormalizer k} : Set (GL2DiagonalNormalizer k)))
+    (g : GL2DiagonalNormalizer k) :
+    DoubleCoset.doubleCoset (s : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) *
+        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) ⊆
+      DoubleCoset.doubleCoset ((s * g : GL2DiagonalNormalizer k) : GL (Fin 2) k)
+          (GL2Borel k) (GL2Borel k) ∪
+        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) := by
+  rw [Set.mem_singleton_iff.mp hs]
+  intro x _
+  let φ := diagonalNormalizerPerm (k := k) (n := 2)
+  have hφweyl : φ (gl2WeylNormalizer k) = Equiv.swap 0 1 :=
+    diagonalNormalizerPerm_gl2WeylElement (k := k)
+  rcases perm_fin_two_eq_one_or_swap (φ g) with hg | hg
+  · have hgB : (g : GL (Fin 2) k) ∈ GL2Borel k :=
+      (gl2_mem_borel_iff_normalizerPerm_eq_one k g).mpr hg
+    have hwg : ((gl2WeylNormalizer k * g : GL2DiagonalNormalizer k) :
+        GL (Fin 2) k) ∉ GL2Borel k := by
+      rw [gl2_mem_borel_iff_normalizerPerm_eq_one]
+      simp [φ, hφweyl, hg]
+    rw [gl2_doubleCoset_eq_weyl_of_notMem k hwg,
+      gl2_doubleCoset_eq_borel_of_mem k hgB, Set.union_comm,
+      GL2Borel.union_doubleCoset_weyl_eq_univ]
+    exact Set.mem_univ x
+  · have hgB : (g : GL (Fin 2) k) ∉ GL2Borel k := by
+      rw [gl2_mem_borel_iff_normalizerPerm_eq_one]
+      exact hg.trans_ne finTwo_swap_ne_one
+    have hwg : ((gl2WeylNormalizer k * g : GL2DiagonalNormalizer k) :
+        GL (Fin 2) k) ∈ GL2Borel k := by
+      rw [gl2_mem_borel_iff_normalizerPerm_eq_one]
+      simp [φ, hφweyl, hg]
+    rw [gl2_doubleCoset_eq_borel_of_mem k hwg,
+      gl2_doubleCoset_eq_weyl_of_notMem k hgB,
+      GL2Borel.union_doubleCoset_weyl_eq_univ]
+    exact Set.mem_univ x
+
+omit [Nontrivial kˣ] in
+private theorem gl2_tits_exists_conj_not_mem
+    (s : GL2DiagonalNormalizer k)
+    (hs : s ∈ ({gl2WeylNormalizer k} : Set (GL2DiagonalNormalizer k))) :
+    ∃ b : GL2Borel k,
+      (s : GL (Fin 2) k) * (b : GL (Fin 2) k) * (s : GL (Fin 2) k)⁻¹ ∉ GL2Borel k := by
+  rw [Set.mem_singleton_iff.mp hs]
+  refine ⟨⟨GL2Borel.mk 1 1 1, GL2Borel.mk_mem 1 1 1⟩, ?_⟩
+  rw [GL2Borel.mem_iff]
+  simp [gl2WeylNormalizer, Units.val_mul, GL2Borel.coe_mk, Matrix.mul_apply,
+    Fin.sum_univ_two]
+
+/-- The standard rank-one Tits system of `GL₂(k)`: `B` is the upper-triangular subgroup,
+`N` is the diagonal-torus normalizer, and the unique simple reflection is lifted by the Weyl
+permutation matrix. -/
+def gl2TitsSystem : TitsSystem (GL (Fin 2) k) where
+  borel := GL2Borel k
+  normalizer := GL2DiagonalNormalizer k
+  simpleReps := {gl2WeylNormalizer k}
+  closure_borel_union_normalizer := gl2_borel_normalizer_closure k
+  intersection_normal := by
+    rw [gl2_borel_comap_normalizer_eq_diagonal]
+    exact Subgroup.normal_in_normalizer
+  closure_intersection_union_simpleReps := gl2_normalizer_closure k
+  simpleRep_sq_mem s hs := by
+    rw [Set.mem_singleton_iff.mp hs]
+    change GL2WeylElement k * GL2WeylElement k ∈ GL2Borel k
+    rw [gl2WeylElement_mul_self]
+    exact (GL2Borel k).one_mem
+  mul_doubleCoset_subset := gl2_tits_mul_doubleCoset_subset k
+  exists_conj_not_mem := gl2_tits_exists_conj_not_mem k
+
+/-- The chosen lift of the simple reflection in the standard `GL₂` Tits system. -/
+def gl2TitsSystemSimpleRep : (gl2TitsSystem k).normalizer := by
+  change GL2DiagonalNormalizer k
+  exact gl2WeylNormalizer k
+
+/-- The chosen simple lift is the usual Weyl permutation matrix after forgetting the normalizer
+subtype. -/
+@[simp]
+theorem coe_gl2TitsSystemSimpleRep :
+    (gl2TitsSystemSimpleRep k : GL (Fin 2) k) = GL2WeylElement k :=
+  (rfl)
+
+/-- In the standard `GL₂` Tits system, membership in `B ∩ N` is exactly membership in the
+diagonal torus after forgetting the normalizer subtype. -/
+theorem gl2TitsSystem_mem_intersection (n : (gl2TitsSystem k).normalizer) :
+    n ∈ (gl2TitsSystem k).intersection ↔
+      (n : GL (Fin 2) k) ∈ diagonalTorus k 2 := by
+  rw [TitsSystem.mem_intersection]
+  rw [show (gl2TitsSystem k).borel = GL2Borel k from rfl]
+  have hn : (n : GL (Fin 2) k) ∈ GL2DiagonalNormalizer k := by
+    have hn' := n.property
+    change (n : GL (Fin 2) k) ∈ GL2DiagonalNormalizer k at hn'
+    exact hn'
+  have hinter := SetLike.ext_iff.mp (gl2_borel_comap_normalizer_eq_diagonal k)
+    ⟨n, hn⟩
+  exact hinter
+
+/-- The simple set of the standard `GL₂` Tits system is the singleton represented by the Weyl
+permutation matrix. -/
+theorem gl2TitsSystem_simple :
+    (gl2TitsSystem k).simple =
+      {QuotientGroup.mk' (gl2TitsSystem k).intersection (gl2TitsSystemSimpleRep k)} := by
+  rw [TitsSystem.simple_def]
+  have hreps : (gl2TitsSystem k).simpleReps = {gl2TitsSystemSimpleRep k} := by
+    rfl
+  rw [hreps, Set.image_singleton]
+
+end
+
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
@@ -129,17 +129,12 @@ private theorem gl2_borel_normalizer_closure :
   rw [GL2Borel.closure_insert_gl2WeylElement_eq_top] at hle
   exact top_unique hle
 
-private theorem gl2_tits_mul_doubleCoset_subset
-    (s : GL2DiagonalNormalizer k)
-    (hs : s ∈ ({gl2WeylNormalizer k} : Set (GL2DiagonalNormalizer k)))
-    (g : GL2DiagonalNormalizer k) :
-    DoubleCoset.doubleCoset (s : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) *
-        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) ⊆
-      DoubleCoset.doubleCoset ((s * g : GL2DiagonalNormalizer k) : GL (Fin 2) k)
+private theorem gl2_doubleCoset_weyl_mul_union_eq_univ (g : GL2DiagonalNormalizer k) :
+    DoubleCoset.doubleCoset
+          ((gl2WeylNormalizer k * g : GL2DiagonalNormalizer k) : GL (Fin 2) k)
           (GL2Borel k) (GL2Borel k) ∪
-        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) := by
-  rw [Set.mem_singleton_iff.mp hs]
-  intro x _
+        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) =
+      Set.univ := by
   let φ := diagonalNormalizerPerm (k := k) (n := 2)
   have hφweyl : φ (gl2WeylNormalizer k) = Equiv.swap 0 1 :=
     diagonalNormalizerPerm_gl2WeylElement (k := k)
@@ -160,7 +155,6 @@ private theorem gl2_tits_mul_doubleCoset_subset
         exact hgB)
     rw [hwgCoset, hgCoset, GL2Borel.doubleCoset_one_eq, Set.union_comm,
       GL2Borel.union_doubleCoset_weyl_eq_univ]
-    exact Set.mem_univ x
   · have hgB : (g : GL (Fin 2) k) ∉ GL2Borel k := by
       rw [gl2_mem_borel_iff_normalizerPerm_eq_one]
       exact hg.trans_ne (Equiv.swap_eq_one_iff.not.mpr Fin.zero_ne_one)
@@ -180,7 +174,18 @@ private theorem gl2_tits_mul_doubleCoset_subset
       (GL2Borel.mem_doubleCoset_weyl_of_notMem hgB)
     rw [hwgCoset, GL2Borel.doubleCoset_one_eq, hgCoset,
       GL2Borel.union_doubleCoset_weyl_eq_univ]
-    exact Set.mem_univ x
+
+private theorem gl2_tits_mul_doubleCoset_subset
+    (s : GL2DiagonalNormalizer k)
+    (hs : s ∈ ({gl2WeylNormalizer k} : Set (GL2DiagonalNormalizer k)))
+    (g : GL2DiagonalNormalizer k) :
+    DoubleCoset.doubleCoset (s : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) *
+        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) ⊆
+      DoubleCoset.doubleCoset ((s * g : GL2DiagonalNormalizer k) : GL (Fin 2) k)
+          (GL2Borel k) (GL2Borel k) ∪
+        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) := by
+  rw [Set.mem_singleton_iff.mp hs, gl2_doubleCoset_weyl_mul_union_eq_univ]
+  exact Set.subset_univ _
 
 omit [Nontrivial kˣ] in
 private theorem gl2_tits_exists_conj_not_mem

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
@@ -8,8 +8,7 @@ module
 public import TauCeti.GroupTheory.TitsSystem
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal.Bruhat
 
--- Non-public: `perm_fin_two_eq_one_or_swap` classifies the permutation quotient in rank one.
-import TauCeti.LinearAlgebra.TensorSquare
+import TauCeti.Data.Fin.Basic
 
 /-!
 # The rank-one Tits system of `GL₂`
@@ -66,7 +65,7 @@ private theorem gl2_borel_comap_normalizer_eq_diagonal :
     (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype =
       (diagonalTorus k 2).subgroupOf (GL2DiagonalNormalizer k) := by
   ext g
-  change (g : GL (Fin 2) k) ∈ GL2Borel k ↔ (g : GL (Fin 2) k) ∈ diagonalTorus k 2
+  rw [Subgroup.mem_comap, Subgroup.mem_subgroupOf]
   constructor
   · intro hg
     have hmem : (g : GL (Fin 2) k) ∈
@@ -83,11 +82,6 @@ private theorem gl2_mem_borel_iff_normalizerPerm_eq_one (g : GL2DiagonalNormaliz
   constructor
   · exact fun hg ↦ (diagonalNormalizerPerm_eq_one_iff g).mpr (hinter.mp hg)
   · exact fun hg ↦ hinter.mpr ((diagonalNormalizerPerm_eq_one_iff g).mp hg)
-
-private theorem finTwo_swap_ne_one : Equiv.swap (0 : Fin 2) 1 ≠ 1 := by
-  intro h
-  have h0 := congrArg (fun σ : Equiv.Perm (Fin 2) ↦ σ 0) h
-  simp at h0
 
 private theorem gl2_normalizer_closure :
     Subgroup.closure
@@ -112,8 +106,7 @@ private theorem gl2_normalizer_closure :
   · exact hinter_le ((gl2_mem_borel_iff_normalizerPerm_eq_one k g).mpr hg)
   · have hker : g * (gl2WeylNormalizer k)⁻¹ ∈
         (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype := by
-      change ((g * (gl2WeylNormalizer k)⁻¹ : GL2DiagonalNormalizer k) :
-        GL (Fin 2) k) ∈ GL2Borel k
+      rw [Subgroup.mem_comap, Subgroup.subtype_apply]
       apply (gl2_mem_borel_iff_normalizerPerm_eq_one k _).mpr
       rw [map_mul, map_inv, hg, hφweyl, mul_inv_cancel]
     have hfactor : g = (g * (gl2WeylNormalizer k)⁻¹) * gl2WeylNormalizer k := by
@@ -136,25 +129,6 @@ private theorem gl2_borel_normalizer_closure :
   rw [GL2Borel.closure_insert_gl2WeylElement_eq_top] at hle
   exact top_unique hle
 
-omit [Nontrivial kˣ] in
-private theorem gl2_doubleCoset_eq_borel_of_mem
-    {g : GL (Fin 2) k} (hg : g ∈ GL2Borel k) :
-    DoubleCoset.doubleCoset g (GL2Borel k) (GL2Borel k) = (GL2Borel k : Set _) := by
-  calc
-    DoubleCoset.doubleCoset g (GL2Borel k) (GL2Borel k) =
-        DoubleCoset.doubleCoset 1 (GL2Borel k) (GL2Borel k) :=
-      DoubleCoset.doubleCoset_eq_of_mem (by
-        rw [GL2Borel.doubleCoset_one_eq]
-        exact hg)
-    _ = (GL2Borel k : Set _) := GL2Borel.doubleCoset_one_eq
-
-omit [Nontrivial kˣ] in
-private theorem gl2_doubleCoset_eq_weyl_of_notMem
-    {g : GL (Fin 2) k} (hg : g ∉ GL2Borel k) :
-    DoubleCoset.doubleCoset g (GL2Borel k) (GL2Borel k) =
-      DoubleCoset.doubleCoset (GL2WeylElement k) (GL2Borel k) (GL2Borel k) :=
-  DoubleCoset.doubleCoset_eq_of_mem (GL2Borel.mem_doubleCoset_weyl_of_notMem hg)
-
 private theorem gl2_tits_mul_doubleCoset_subset
     (s : GL2DiagonalNormalizer k)
     (hs : s ∈ ({gl2WeylNormalizer k} : Set (GL2DiagonalNormalizer k)))
@@ -176,19 +150,35 @@ private theorem gl2_tits_mul_doubleCoset_subset
         GL (Fin 2) k) ∉ GL2Borel k := by
       rw [gl2_mem_borel_iff_normalizerPerm_eq_one]
       simp [φ, hφweyl, hg]
-    rw [gl2_doubleCoset_eq_weyl_of_notMem k hwg,
-      gl2_doubleCoset_eq_borel_of_mem k hgB, Set.union_comm,
+    have hwgCoset := DoubleCoset.doubleCoset_eq_of_mem
+      (GL2Borel.mem_doubleCoset_weyl_of_notMem hwg)
+    have hgCoset :
+        DoubleCoset.doubleCoset (g : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) =
+          DoubleCoset.doubleCoset (1 : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) :=
+      DoubleCoset.doubleCoset_eq_of_mem (by
+        rw [GL2Borel.doubleCoset_one_eq]
+        exact hgB)
+    rw [hwgCoset, hgCoset, GL2Borel.doubleCoset_one_eq, Set.union_comm,
       GL2Borel.union_doubleCoset_weyl_eq_univ]
     exact Set.mem_univ x
   · have hgB : (g : GL (Fin 2) k) ∉ GL2Borel k := by
       rw [gl2_mem_borel_iff_normalizerPerm_eq_one]
-      exact hg.trans_ne finTwo_swap_ne_one
+      exact hg.trans_ne (Equiv.swap_eq_one_iff.not.mpr Fin.zero_ne_one)
     have hwg : ((gl2WeylNormalizer k * g : GL2DiagonalNormalizer k) :
         GL (Fin 2) k) ∈ GL2Borel k := by
       rw [gl2_mem_borel_iff_normalizerPerm_eq_one]
       simp [φ, hφweyl, hg]
-    rw [gl2_doubleCoset_eq_borel_of_mem k hwg,
-      gl2_doubleCoset_eq_weyl_of_notMem k hgB,
+    have hwgCoset :
+        DoubleCoset.doubleCoset
+            ((gl2WeylNormalizer k * g : GL2DiagonalNormalizer k) : GL (Fin 2) k)
+            (GL2Borel k) (GL2Borel k) =
+          DoubleCoset.doubleCoset (1 : GL (Fin 2) k) (GL2Borel k) (GL2Borel k) :=
+      DoubleCoset.doubleCoset_eq_of_mem (by
+        rw [GL2Borel.doubleCoset_one_eq]
+        exact hwg)
+    have hgCoset := DoubleCoset.doubleCoset_eq_of_mem
+      (GL2Borel.mem_doubleCoset_weyl_of_notMem hgB)
+    rw [hwgCoset, GL2Borel.doubleCoset_one_eq, hgCoset,
       GL2Borel.union_doubleCoset_weyl_eq_univ]
     exact Set.mem_univ x
 
@@ -208,26 +198,26 @@ private theorem gl2_tits_exists_conj_not_mem
 `N` is the diagonal-torus normalizer, and the unique simple reflection is lifted by the Weyl
 permutation matrix. -/
 def gl2TitsSystem : TitsSystem (GL (Fin 2) k) where
-  borel := GL2Borel k
-  normalizer := GL2DiagonalNormalizer k
+  subgroupB := GL2Borel k
+  subgroupN := GL2DiagonalNormalizer k
   simpleReps := {gl2WeylNormalizer k}
-  closure_borel_union_normalizer := gl2_borel_normalizer_closure k
+  closure_subgroupB_union_subgroupN := gl2_borel_normalizer_closure k
   intersection_normal := by
     rw [gl2_borel_comap_normalizer_eq_diagonal]
     exact Subgroup.normal_in_normalizer
   closure_intersection_union_simpleReps := gl2_normalizer_closure k
   simpleRep_sq_mem s hs := by
     rw [Set.mem_singleton_iff.mp hs]
-    change GL2WeylElement k * GL2WeylElement k ∈ GL2Borel k
+    rw [Subgroup.mem_comap, map_mul]
+    simp only [Subgroup.subtype_apply, gl2WeylNormalizer]
     rw [gl2WeylElement_mul_self]
     exact (GL2Borel k).one_mem
   mul_doubleCoset_subset := gl2_tits_mul_doubleCoset_subset k
   exists_conj_not_mem := gl2_tits_exists_conj_not_mem k
 
 /-- The chosen lift of the simple reflection in the standard `GL₂` Tits system. -/
-def gl2TitsSystemSimpleRep : (gl2TitsSystem k).normalizer := by
-  change GL2DiagonalNormalizer k
-  exact gl2WeylNormalizer k
+def gl2TitsSystemSimpleRep : (gl2TitsSystem k).subgroupN :=
+  gl2WeylNormalizer k
 
 /-- The chosen simple lift is the usual Weyl permutation matrix after forgetting the normalizer
 subtype. -/
@@ -238,28 +228,28 @@ theorem coe_gl2TitsSystemSimpleRep :
 
 /-- In the standard `GL₂` Tits system, membership in `B ∩ N` is exactly membership in the
 diagonal torus after forgetting the normalizer subtype. -/
-theorem gl2TitsSystem_mem_intersection (n : (gl2TitsSystem k).normalizer) :
+theorem gl2TitsSystem_mem_intersection (n : (gl2TitsSystem k).subgroupN) :
     n ∈ (gl2TitsSystem k).intersection ↔
       (n : GL (Fin 2) k) ∈ diagonalTorus k 2 := by
   rw [TitsSystem.mem_intersection]
-  rw [show (gl2TitsSystem k).borel = GL2Borel k from rfl]
-  have hn : (n : GL (Fin 2) k) ∈ GL2DiagonalNormalizer k := by
-    have hn' := n.property
-    change (n : GL (Fin 2) k) ∈ GL2DiagonalNormalizer k at hn'
-    exact hn'
+  let n' : GL2DiagonalNormalizer k :=
+    ⟨n, by simpa only [gl2TitsSystem] using n.property⟩
   have hinter := SetLike.ext_iff.mp (gl2_borel_comap_normalizer_eq_diagonal k)
-    ⟨n, hn⟩
-  exact hinter
+    n'
+  rw [Subgroup.mem_comap, Subgroup.mem_subgroupOf, Subgroup.subtype_apply] at hinter
+  simpa only [n', gl2TitsSystem] using hinter
 
 /-- The simple set of the standard `GL₂` Tits system is the singleton represented by the Weyl
 permutation matrix. -/
 theorem gl2TitsSystem_simple :
     (gl2TitsSystem k).simple =
       {QuotientGroup.mk' (gl2TitsSystem k).intersection (gl2TitsSystemSimpleRep k)} := by
-  rw [TitsSystem.simple_def]
   have hreps : (gl2TitsSystem k).simpleReps = {gl2TitsSystemSimpleRep k} := by
     rfl
-  rw [hreps, Set.image_singleton]
+  ext s
+  rw [TitsSystem.mem_simple, hreps]
+  simp only [Set.mem_singleton_iff, exists_eq_left]
+  exact eq_comm
 
 end
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
@@ -195,32 +195,91 @@ private theorem gl2_tits_exists_conj_not_mem
     Fin.sum_univ_two]
 
 /-- The standard rank-one Tits system of `GL₂(k)`: `B` is the upper-triangular subgroup,
-`N` is the diagonal-torus normalizer, and the unique simple reflection is lifted by the Weyl
-permutation matrix. -/
+`N` is the diagonal-torus normalizer, and its unique simple reflection is represented by the
+Weyl permutation matrix. -/
 def gl2TitsSystem : TitsSystem (GL (Fin 2) k) where
   subgroupB := GL2Borel k
   subgroupN := GL2DiagonalNormalizer k
-  simpleReps := {gl2WeylNormalizer k}
   closure_subgroupB_union_subgroupN := gl2_borel_normalizer_closure k
   intersection_normal := by
     rw [gl2_borel_comap_normalizer_eq_diagonal]
     exact Subgroup.normal_in_normalizer
-  closure_intersection_union_simpleReps := gl2_normalizer_closure k
-  simpleRep_sq_mem s hs := by
-    rw [Set.mem_singleton_iff.mp hs]
+  simple := {QuotientGroup.mk (gl2WeylNormalizer k)}
+  closure_simple := by
+    let _ : ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype).Normal := by
+      rw [gl2_borel_comap_normalizer_eq_diagonal]
+      exact Subgroup.normal_in_normalizer
+    apply top_unique
+    intro s _
+    obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective
+      ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype) s
+    have hg : g ∈ Subgroup.closure
+        (((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype :
+            Set (GL2DiagonalNormalizer k)) ∪ {gl2WeylNormalizer k}) := by
+      rw [gl2_normalizer_closure]
+      exact Subgroup.mem_top g
+    have hmap : QuotientGroup.mk'
+          ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype) g ∈
+        (Subgroup.closure
+          (((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype :
+              Set (GL2DiagonalNormalizer k)) ∪ {gl2WeylNormalizer k})).map
+            (QuotientGroup.mk'
+              ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype)) :=
+      ⟨g, hg, rfl⟩
+    rw [MonoidHom.map_closure] at hmap
+    exact ((Subgroup.closure_le
+      (Subgroup.closure
+        ({QuotientGroup.mk (gl2WeylNormalizer k)} :
+          Set (GL2DiagonalNormalizer k ⧸
+            (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype)))).mpr (fun x hx ↦ by
+      obtain ⟨y, hy, rfl⟩ := hx
+      rcases hy with hy | hy
+      · have hqy : QuotientGroup.mk'
+            ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype) y = 1 :=
+          (QuotientGroup.eq_one_iff y).mpr hy
+        rw [hqy]
+        exact (Subgroup.closure
+          ({QuotientGroup.mk (gl2WeylNormalizer k)} :
+            Set (GL2DiagonalNormalizer k ⧸
+              (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype))).one_mem
+      · rw [Set.mem_singleton_iff] at hy
+        subst y
+        exact Subgroup.subset_closure (Set.mem_singleton _))) hmap
+  exists_simpleRep_sq_mem s hs := by
+    rw [Set.mem_singleton_iff] at hs
+    refine ⟨gl2WeylNormalizer k, hs.symm, ?_⟩
     rw [Subgroup.mem_comap, map_mul]
     simp only [Subgroup.subtype_apply, gl2WeylNormalizer]
     rw [gl2WeylElement_mul_self]
     exact (GL2Borel k).one_mem
-  mul_doubleCoset_subset := gl2_tits_mul_doubleCoset_subset k
-  exists_conj_not_mem := gl2_tits_exists_conj_not_mem k
+  mul_doubleCoset_subset s hs := by
+    rw [Set.mem_singleton_iff] at hs
+    exact ⟨gl2WeylNormalizer k, hs.symm,
+      gl2_tits_mul_doubleCoset_subset k (gl2WeylNormalizer k) (Set.mem_singleton _)⟩
+  exists_conj_not_mem s hs := by
+    rw [Set.mem_singleton_iff] at hs
+    obtain ⟨b, hb⟩ := gl2_tits_exists_conj_not_mem k
+      (gl2WeylNormalizer k) (Set.mem_singleton _)
+    exact ⟨gl2WeylNormalizer k, hs.symm, b, hb⟩
 
-/-- The chosen lift of the simple reflection in the standard `GL₂` Tits system. -/
+/-- The `B` subgroup of the standard `GL₂` Tits system is the upper-triangular subgroup. -/
+@[simp]
+theorem gl2TitsSystem_subgroupB : (gl2TitsSystem k).subgroupB = GL2Borel k :=
+  by rw [gl2TitsSystem]
+
+/-- The `N` subgroup of the standard `GL₂` Tits system is the diagonal-torus normalizer. -/
+@[simp]
+theorem gl2TitsSystem_subgroupN :
+    (gl2TitsSystem k).subgroupN =
+      Subgroup.normalizer (diagonalTorus k 2 : Set (GL (Fin 2) k)) :=
+  by rw [gl2TitsSystem]
+
+/-- The standard representative of the simple reflection in the `GL₂` Tits system. -/
 def gl2TitsSystemSimpleRep : (gl2TitsSystem k).subgroupN :=
   gl2WeylNormalizer k
 
-/-- The chosen simple lift is the usual Weyl permutation matrix after forgetting the normalizer
-subtype. -/
+/-- The standard simple representative is the Weyl permutation matrix after forgetting the
+normalizer subtype. -/
 @[simp]
 theorem coe_gl2TitsSystemSimpleRep :
     (gl2TitsSystemSimpleRep k : GL (Fin 2) k) = GL2WeylElement k :=
@@ -243,13 +302,10 @@ theorem gl2TitsSystem_mem_intersection (n : (gl2TitsSystem k).subgroupN) :
 permutation matrix. -/
 theorem gl2TitsSystem_simple :
     (gl2TitsSystem k).simple =
-      {QuotientGroup.mk' (gl2TitsSystem k).intersection (gl2TitsSystemSimpleRep k)} := by
-  have hreps : (gl2TitsSystem k).simpleReps = {gl2TitsSystemSimpleRep k} := by
-    rfl
+      {(QuotientGroup.mk (gl2TitsSystemSimpleRep k) : (gl2TitsSystem k).WeylGroup)} := by
   ext s
-  rw [TitsSystem.mem_simple, hreps]
-  simp only [Set.mem_singleton_iff, exists_eq_left]
-  exact eq_comm
+  simp only [gl2TitsSystem, gl2TitsSystemSimpleRep]
+  rfl
 
 end
 

--- a/TauCeti/LinearAlgebra/TensorSquare.lean
+++ b/TauCeti/LinearAlgebra/TensorSquare.lean
@@ -8,8 +8,9 @@ module
 public import Mathlib.Algebra.Ring.Invertible
 public import Mathlib.LinearAlgebra.ExteriorPower.Pairing
 public import Mathlib.LinearAlgebra.TensorPower.Basic
-public import TauCeti.Data.Fin.Basic
 public import TauCeti.LinearAlgebra.SymmetricPower.Basic
+
+import TauCeti.Data.Fin.Basic
 
 /-!
 # Decomposing a tensor square

--- a/TauCeti/LinearAlgebra/TensorSquare.lean
+++ b/TauCeti/LinearAlgebra/TensorSquare.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Ring.Invertible
 public import Mathlib.LinearAlgebra.ExteriorPower.Pairing
 public import Mathlib.LinearAlgebra.TensorPower.Basic
+public import TauCeti.Data.Fin.Basic
 public import TauCeti.LinearAlgebra.SymmetricPower.Basic
 
 /-!
@@ -46,31 +47,6 @@ variable (R : Type) (M : Type v)
 
 namespace TauCeti
 
-/-- A permutation of `Fin 2` is either the identity or the transposition: the classification
-that drives every computation with the two orders on a tensor square. -/
-theorem perm_fin_two_eq_one_or_swap (e : Equiv.Perm (Fin 2)) :
-    e = 1 ∨ e = Equiv.swap 0 1 := by
-  by_cases h0 : e 0 = 0
-  · left
-    apply Equiv.ext
-    intro i
-    fin_cases i
-    · exact h0
-    · apply Fin.eq_one_of_ne_zero
-      intro h1
-      exact one_ne_zero (e.injective (h1.trans h0.symm))
-  · right
-    have h0' : e 0 = 1 := Fin.eq_one_of_ne_zero _ h0
-    apply Equiv.ext
-    intro i
-    fin_cases i
-    · simpa using h0'
-    · have h1 : e 1 = 0 := by
-        by_contra h
-        have h1' : e 1 = 1 := Fin.eq_one_of_ne_zero _ h
-        exact one_ne_zero (e.injective (h1'.trans h0'.symm))
-      simpa using h1
-
 section Swap
 
 variable [CommSemiring R] [AddCommMonoid M] [Module R M]
@@ -106,6 +82,7 @@ variable [CommRing R] [Invertible (2 : R)] [AddCommGroup M] [Module R M]
 
 namespace TauCeti
 
+/-- Projection onto the symmetric part of a tensor square. -/
 private noncomputable def symmetricProjection : (⨂[R]^2 M) →ₗ[R] ⨂[R]^2 M :=
   (⅟ (2 : R)) • (LinearMap.id + (tensorSwap R M).toLinearMap)
 
@@ -184,12 +161,14 @@ end exteriorPower
 
 namespace TauCeti
 
+/-- The comparison map from a tensor square to its symmetric and exterior square quotients. -/
 private noncomputable def tensorSquareToSymmetricExterior :
     (⨂[R]^2 M) →ₗ[R] (Sym[R]^2 M) × (⋀[R]^2 M) :=
   (SymmetricPower.mk R (Fin 2) M).prod
     (PiTensorProduct.lift
       (exteriorPower.ιMulti R 2 (M := M)).toMultilinearMap)
 
+/-- The sum of the canonical maps from the symmetric and exterior squares into the tensor square. -/
 private noncomputable def symmetricExteriorToTensorSquare :
     (Sym[R]^2 M) × (⋀[R]^2 M) →ₗ[R] ⨂[R]^2 M :=
   (SymmetricPower.toTensorSquare R M).coprod

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 import Mathlib.LinearAlgebra.PiTensorProduct.Basis
+import TauCeti.Data.Fin.Basic
+
 public import TauCeti.LinearAlgebra.TensorSquare
 public import TauCeti.LinearAlgebra.ExteriorPower
 public import TauCeti.RepresentationTheory.ExteriorPower
@@ -111,6 +113,7 @@ private theorem mk_comp_toTensorPower {R : Type} {M : Type*}
     toTensorPower_ιMulti_two, map_sub, hswap, sub_self]
   simp
 
+/-- The symmetric-square map to the quotient of the tensor square by alternating tensors. -/
 private noncomputable def symToAlternatingQuotient {R : Type} {M : Type*}
     [Field R] [AddCommGroup M] [Module R M] :
     Sym[R]^2 M →ₗ[R]


### PR DESCRIPTION
This PR defines Tits systems through chosen lifts of their simple reflections and packages the standard rank-one BN-pair of `GL₂(k)`: `B` is the upper-triangular subgroup, `N` is the normalizer of the diagonal torus, and the Weyl permutation matrix is the unique simple lift.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 7, **"Bruhat decomposition and BN-pairs / Tits systems"**. The designated milestone is the rank-one `GL₂` Tits-system example. This is the most effective current step because the Bruhat decomposition and generation theorem, `N(T)/T ≃ S₂`, and the newly merged identification `B ∩ N(T) = T` are all on `main`, so the actual Tits axioms are now the first unmet conclusion rather than more supporting infrastructure. After this PR, the milestone still needs Tits systems for general split reductive groups and their connection to the roadmap's root-datum and dynamic-parabolic routes.

`TauCeti.TitsSystem` records `B`, `N`, chosen simple lifts, generation of `G` and `N/(B ∩ N)`, involutivity modulo the intersection, the Bruhat-cell multiplication axiom, and nondegeneracy. Its API constructs the Weyl quotient, proves that the simple reflections are nonidentity involutions, and proves that they generate the quotient. The `GL₂` instance uses the existing Bruhat cover, diagonal-normalizer permutation map, intersection theorem, and the explicit conjugation of an upper unipotent element into a lower one. The mathematical organization follows Humphreys, *Linear Algebraic Groups*, §28.1, and Springer, *Linear Algebraic Groups*, second edition, §8.3, as cited in both module documentations. No Mathlib infrastructure or external formalization is vendored; the existing Tau Ceti classification of permutations of `Fin 2` is reused.

Add `TauCeti/GroupTheory/TitsSystem.lean` (160 lines) and `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean` (267 lines).

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"gl2-rank-one-tits-system"}-->

🤖 Prepared with Codex
