### PR TITLE
feat(Spa): the analytic locus is quasi-compact

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
@@ -14,7 +14,7 @@ public import TauCeti.RingTheory.Huber.OpenIdeal
 /-!
 # Analytic points and the analytic locus of `Spa(A, A⁺)`
 
-**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Definition 7.39, Remark 7.40(3), and
+**Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), Definition 7.39, Remark 7.40(2), (3), and
 Proposition 7.49.**
 
 This file formalizes the analytic locus of the adic spectrum `Spa(A, A⁺)`.
@@ -34,6 +34,8 @@ This file formalizes the analytic locus of the adic spectrum `Spa(A, A⁺)`.
 * `TauCeti.ValuationSpectrum.spaAnalytic_eq_spa_of_isTateRing` : **Wedhorn Remark 7.40(3)**,
   for a Tate ring `A`, the analytic locus is the entire adic spectrum.
 * `TauCeti.ValuationSpectrum.isOpen_val_preimage_spaAnalytic` : the analytic locus is open.
+* `TauCeti.ValuationSpectrum.isCompact_val_preimage_spaAnalytic` : **Wedhorn Remark 7.40(2)**,
+  the analytic locus is quasi-compact; with the previous result, open and quasi-compact.
 * `TauCeti.ValuationSpectrum.spaAnalytic_eq_biUnion_rationalSubset` : generators of an ideal of
   definition give a finite rational cover of the analytic locus.
 * `TauCeti.ValuationSpectrum.isTateRing_completion_locTopology_of_mem_generators` : the completed
@@ -41,7 +43,7 @@ This file formalizes the analytic locus of the adic spectrum `Spa(A, A⁺)`.
 
 ## References
 
-* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.39, Remark 7.40(3), and
+* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.39, Remark 7.40(2), (3), and
   Proposition 7.49.
 -/
 
@@ -231,6 +233,26 @@ theorem isTateRing_completion_locTopology_of_mem_generators (P : PairOfDefinitio
   exact isTateRing_completion_locTopology_of_isTopologicallyNilpotent P _ (g : A) S hden
     (P.isTopologicallyNilpotent_of_mem_idealOfDefinition
       (hG ▸ Ideal.subset_span (Finset.mem_coe.mpr hg)))
+
+/-- **Wedhorn Remark 7.40(2).** The analytic locus is quasi-compact. A finite generating set of
+the extended ideal of definition gives a finite rational cover of it, and each rational subset in
+that cover is quasi-compact, so their union is. Together with `isOpen_val_preimage_spaAnalytic`
+this is the whole of 7.40(2): the analytic locus is an open quasi-compact subset of `Spa(A, A⁺)`.
+
+Stated for the preimage in `spa Aplus` rather than for `spaAnalytic Aplus : Set (Spv A)`, matching
+`isOpen_val_preimage_spaAnalytic`, because quasi-compactness of a rational subset is available in
+that form. -/
+theorem isCompact_val_preimage_spaAnalytic (P : PairOfDefinition A) (Aplus : Subring A) :
+    IsCompact (Subtype.val ⁻¹' spaAnalytic Aplus : Set (spa Aplus)) := by
+  obtain ⟨T, hT⟩ := P.fg_extendedIdealOfDefinition
+  have hopen : IsOpen (Ideal.span (T : Set A) : Set A) := by
+    rw [hT]
+    exact (P.isOpen_iff_exists_pow_le _).mpr ⟨1, by simp⟩
+  rw [spaAnalytic_eq_biUnion_rationalSubset_of_span_eq_extendedIdealOfDefinition P Aplus T hT,
+    Set.preimage_iUnion₂]
+  exact T.isCompact_biUnion fun t _ ↦
+    isCompact_of_mem_spaRationalFamily_of_pairOfDefinition P
+      (mem_spaRationalFamily_iff.mpr ⟨T, t, hopen, rfl⟩)
 
 end TopologicalRing
 


### PR DESCRIPTION
**Wedhorn Remark 7.40(2)**: the analytic locus of `Spa(A, A⁺)` is quasi-compact.

* `TauCeti.ValuationSpectrum.isCompact_val_preimage_spaAnalytic`

## This is an assembly, not a build

Both ingredients are already on `main` and neither is rebuilt here:

* the finite cover — `spaAnalytic_eq_biUnion_rationalSubset_of_span_eq_extendedIdealOfDefinition`
  (`Spa/Analytic.lean`), the rational subsets `R(T/t)` for `t ∈ T` covering exactly the analytic
  locus when `T` generates the extended ideal of definition;
* quasi-compactness of each piece — `isCompact_of_mem_spaRationalFamily_of_pairOfDefinition`
  (`Spa/RationalSubset/Basis.lean`).

The proof takes a finite generating set from `P.fg_extendedIdealOfDefinition`, rewrites by the
cover, and applies `Finset.isCompact_biUnion`. Four lines.

## Statement shape

Stated for `Subtype.val ⁻¹' spaAnalytic Aplus : Set (spa Aplus)` rather than for
`spaAnalytic Aplus : Set (Spv A)`. That matches the existing `isOpen_val_preimage_spaAnalytic`
directly above it, and it is the form in which quasi-compactness of a rational subset is available.
Together the two give the whole of Remark 7.40(2) — the analytic locus is an *open quasi-compact*
subset of `Spa(A, A⁺)`.

## Placement

Into the existing `Spa/Analytic.lean`, in the `TopologicalRing` section beside the cover it
consumes and the openness statement it pairs with. **No import changes**: that file already imports
`Spa.RationalSubset.Basis` (line 10), and `Basis.lean` does not import `Analytic.lean`, so there is
no cycle. The module docstring's "Main results" and its Wedhorn reference are updated to include
7.40(2).

## Gate

`lake build` of the module — 2128 jobs, no errors, warnings or sorries. `Spa/Analytic.lean` has no
importers in `TauCeti/` (checked with a positive control on a module that does have them), so
nothing downstream is affected.

## Roadmap target

`TauCetiRoadmap/AdicSpaces/README.md`, **Layer 2, § 2.3 "The plus ring, emptiness, and analytic
points"** (heading at README:407), measured against roadmap `origin/main` `0658e5c`.

That section's own words, at README:429-430:

> Prove that the analytic locus is open and is covered by rational subsets whose coordinate rings
> are Tate.

**Dependency path from this result to that target.** § 2.3 asks for two properties of the analytic
locus, openness and a rational cover. Both halves are now in place, and this PR is the second:

1. *Open* — `isOpen_val_preimage_spaAnalytic`, already on `main` in this same file.
2. *Covered by rational subsets* — `spaAnalytic_eq_biUnion_rationalSubset_of_span_eq_extendedIdealOfDefinition`
   gives the cover, indexed by a **finite** generating set `T` of the extended ideal of definition
   (`P.fg_extendedIdealOfDefinition`). This PR consumes exactly that cover: because the index set
   is finite and each rational subset in it is quasi-compact
   (`isCompact_of_mem_spaRationalFamily_of_pairOfDefinition`), the union is quasi-compact.

So the compactness proved here is not an independent capability — it is the finiteness content of
§ 2.3's covering clause, and combining it with (1) yields Wedhorn Remark 7.40(2) in full: the
analytic locus is an *open quasi-compact* subset of `Spa(A, A⁺)`. Remark 7.40(2) is one of the
results this file is declared to formalize (module docstring, Definition 7.39 and Remark 7.40(2),
(3)).

Downstream, § 3.5 "Sheaf criteria on the rational basis" (README:530) rests on quasi-compactness of
rational subsets when it requires that "every cover of a rational subset admits a finite rational
refinement"; the argument used here — finite rational cover, each piece quasi-compact — is the
analytic-locus instance of that pattern.

## Roadmap

**`TauCetiRoadmap/AdicSpaces/README.md`, §2.3 "The plus ring, emptiness, and analytic points"**
(README:407-432). That section defines the analytic locus `Spa(A,A⁺)^a` (Definition 7.39) and then
asks, verbatim:

> Prove Proposition 7.49(2), including the criterion for this locus to be empty; [...] Prove that
> the **analytic locus is open and is covered by rational subsets** whose coordinate rings are Tate.

The dependency path is short, because the other two thirds of that sentence are already on `main`:

1. the **cover** is `spaAnalytic_eq_biUnion_rationalSubset_of_span_eq_extendedIdealOfDefinition`
   (`Spa/Analytic.lean`), and its charts being Tate is
   `isTateRing_completion_locTopology_of_mem_generators` in the same file;
2. the **openness** is `isOpen_val_preimage_spaAnalytic`, directly above the new theorem;
3. this PR supplies what that finite cover actually buys — **quasi-compactness**. Wedhorn states the
   pair as Remark 7.40(2), "`(Spa A)^a` is an open quasi-compact subset of `Spa A`", and 7.40 is the
   analytic-locus toolkit that the proof of Proposition 7.49(2) — §2.3's named target — draws on.

So this is not a new capability alongside the roadmap node; it is the missing half of a sentence the
node states, and its two inputs are already merged.

It is also the analytic-locus counterpart of a criterion §3.5 "Sheaf criteria on the rational basis"
lists explicitly ("rational subsets are quasi-compact", README:536), which is the lemma this proof
consumes per chart.

Roadmap: AdicSpaces
