### PR TITLE
feat: restrict local trivializations

### DIFF
--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Free.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Free.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Category.ModuleCat.Sheaf.Free
+
+/-!
+# Free sheaves on one generator
+
+This file records the canonical identification between the free sheaf of modules on one
+generator and the tensor unit. It is stated over an arbitrary site and without tying the
+universe of the coefficient modules to either universe of the site.
+
+## Main declaration
+
+* `TauCeti.SheafOfModules.freePUnitIsoUnit` identifies the free sheaf on `PUnit` with the sheaf
+  of rings itself, regarded as a sheaf of modules.
+
+This comparison is used both by tensor-unit computations and when restricting a rank-one local
+trivialization. No formalization is vendored; it is Mathlib's canonical isomorphism from a
+coproduct indexed by a unique type to its unique summand.
+-/
+
+public section
+
+open CategoryTheory Limits
+
+namespace TauCeti
+
+universe u v₁ u₁
+
+noncomputable section
+
+namespace SheafOfModules
+
+variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
+  [HasWeakSheafify J AddCommGrpCat.{u}]
+  [J.WEqualsLocallyBijective AddCommGrpCat.{u}]
+
+/-- The free sheaf on one generator is canonically isomorphic to the tensor unit. -/
+def freePUnitIsoUnit (S : Sheaf J RingCat.{u}) :
+    _root_.SheafOfModules.free.{u, v₁, u₁} (R := S) PUnit.{u + 1} ≅
+      _root_.SheafOfModules.unit.{v₁, u₁, u} S :=
+  coproductUniqueIso (fun _ : PUnit.{u + 1} ↦
+    _root_.SheafOfModules.unit.{v₁, u₁, u} S)
+
+end SheafOfModules
+
+end
+
+
+end TauCeti

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/Restriction.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/Restriction.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Category.ModuleCat.Sheaf.Invertible.LocalTriviality
+public import TauCeti.Algebra.Category.ModuleCat.Sheaf.Free
+public import Mathlib.Algebra.Category.ModuleCat.Sheaf.PushforwardContinuous
+
+/-!
+# Restricting local trivializations
+
+A local trivialization of a sheaf of modules over an object `X` remains a trivialization after
+restriction along a morphism `f : Y ⟶ X`. This file packages that elementary but necessary
+step for the local-triviality formulation of invertible sheaves.
+
+## Main declarations
+
+* `SheafOfModules.overMapFreePUnitIso` identifies the restriction of the standard free
+  rank-one sheaf over `X` with the standard free rank-one sheaf over `Y`;
+* `SheafOfModules.LocalTrivializations.isoOver` restricts one chosen trivialization in an atlas
+  along a morphism into its covering object;
+* `SheafOfModules.LocalTrivializations.ofRefinement` transports an entire atlas to any cover
+  equipped with refinement arrows into the original cover.
+
+The common refinement of two atlases can therefore carry both sets of trivializations on the
+same cover. Together with compatibility of tensor products with restriction, this is the final
+local-triviality input for closure of invertible sheaves under tensor product. That closure is
+needed for the Picard group in `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A, item
+"Invertible sheaves on a scheme; the Picard group `Pic X` under `⊗`".
+
+No formalization is vendored. The construction reuses Mathlib's `SheafOfModules.overMap`,
+`SheafOfModules.overFunctorMap`, and `SheafOfModules.overMapUnitIso`, and the standard
+free-rank-one/tensor-unit comparison already in Tau Ceti.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u v₁ u₁
+
+noncomputable section
+
+namespace SheafOfModules
+
+variable {C : Type u₁} [Category.{v₁} C] {J : GrothendieckTopology C}
+  {R : Sheaf J RingCat.{u}}
+  [∀ Y : C, HasWeakSheafify (J.over Y) AddCommGrpCat.{u}]
+  [∀ Y : C, (J.over Y).WEqualsLocallyBijective AddCommGrpCat.{u}]
+
+/-- Restriction along `f : Y ⟶ X` carries the standard free rank-one sheaf over `X` to the
+standard free rank-one sheaf over `Y`.
+
+For one generator this follows directly by identifying both free sheaves with their tensor
+units and using Mathlib's canonical comparison for restriction of the unit. -/
+def overMapFreePUnitIso {X Y : C} (f : Y ⟶ X) :
+    (_root_.SheafOfModules.overMap R f).obj
+        (_root_.SheafOfModules.free (R := R.over X) PUnit) ≅
+      _root_.SheafOfModules.free (R := R.over Y) PUnit :=
+  (_root_.SheafOfModules.overMap R f).mapIso
+      (freePUnitIsoUnit (R.over X) :
+        _root_.SheafOfModules.free (R := R.over X) PUnit ≅
+          _root_.SheafOfModules.unit (R.over X)) ≪≫
+    _root_.SheafOfModules.overMapUnitIso (R := R) f ≪≫
+      (freePUnitIsoUnit (R.over Y) :
+        _root_.SheafOfModules.free (R := R.over Y) PUnit ≅
+          _root_.SheafOfModules.unit (R.over Y)).symm
+
+namespace LocalTrivializations
+
+variable {M : SheafOfModules.{u} R}
+
+/-- Restrict one member of a local trivialization atlas along a morphism into its covering
+object. The resulting isomorphism trivializes `M` over the source of that morphism. -/
+def isoOver (t : LocalTrivializations M) (i : t.I) {Y : C} (f : Y ⟶ t.X i) :
+    _root_.SheafOfModules.free (R := R.over Y) PUnit ≅ M.over Y :=
+  (overMapFreePUnitIso (R := R) f).symm ≪≫
+    (_root_.SheafOfModules.overMap R f).mapIso (t.iso i) ≪≫
+      (_root_.SheafOfModules.overFunctorMap R f).app M
+
+/-- Replace the cover of a local trivialization atlas by a refining cover.
+
+Each object `Y j` of the new cover is equipped with a chosen arrow into an object of the old
+cover. Restricting the corresponding old trivialization along that arrow supplies the new one. -/
+def ofRefinement (t : LocalTrivializations M) {I : Type u₁} (Y : I → C)
+    (coversTop : J.CoversTop Y) (index : I → t.I) (map : ∀ j, Y j ⟶ t.X (index j)) :
+    LocalTrivializations M where
+  I := I
+  X := Y
+  coversTop := coversTop
+  iso j := t.isoOver (index j) (map j)
+
+/-- Refining a local trivialization atlas uses the indexing type of the refining cover. -/
+@[simp]
+lemma ofRefinement_I (t : LocalTrivializations M) {I : Type u₁} (Y : I → C)
+    (coversTop : J.CoversTop Y) (index : I → t.I) (map : ∀ j, Y j ⟶ t.X (index j)) :
+    (t.ofRefinement Y coversTop index map).I = I :=
+  (rfl)
+
+/-- The covering objects of a refined local trivialization atlas are the specified refining
+objects. -/
+@[simp]
+lemma ofRefinement_X (t : LocalTrivializations M) {I : Type u₁} (Y : I → C)
+    (coversTop : J.CoversTop Y) (index : I → t.I) (map : ∀ j, Y j ⟶ t.X (index j)) :
+    (t.ofRefinement Y coversTop index map).X =
+      fun j ↦ Y ((ofRefinement_I t Y coversTop index map).mp j) :=
+  (rfl)
+
+/-- The trivializations of a refined atlas are obtained by restricting the chosen old
+trivializations along the refinement arrows. -/
+@[simp]
+lemma ofRefinement_iso (t : LocalTrivializations M) {I : Type u₁} (Y : I → C)
+    (coversTop : J.CoversTop Y) (index : I → t.I) (map : ∀ j, Y j ⟶ t.X (index j))
+    (j : (t.ofRefinement Y coversTop index map).I) :
+    (t.ofRefinement Y coversTop index map).iso j =
+      cast (by rw [ofRefinement_X])
+        (t.isoOver (index ((ofRefinement_I t Y coversTop index map).mp j))
+          (map ((ofRefinement_I t Y coversTop index map).mp j))) :=
+  (rfl)
+
+end LocalTrivializations
+
+end SheafOfModules
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/TensorProduct.lean
+++ b/TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/TensorProduct.lean
@@ -6,19 +6,19 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Category.ModuleCat.Sheaf.Invertible.Basic
+public import TauCeti.Algebra.Category.ModuleCat.Sheaf.Free
 public import TauCeti.Algebra.Category.ModuleCat.Sheaf.TensorProduct
 
 /-!
 # Tensor products with trivial invertible sheaves
 
 For a sheaf of commutative rings `R` on a site, the free sheaf of `R`-modules on one generator
-is canonically isomorphic to the tensor unit. Consequently, tensoring an invertible sheaf with a
-globally trivial rank-one sheaf preserves invertibility.
+is canonically isomorphic to the tensor unit by `SheafOfModules.freePUnitIsoUnit`, defined in
+`TauCeti/Algebra/Category/ModuleCat/Sheaf/Free.lean`. This file uses that comparison to show that
+tensoring an invertible sheaf with a globally trivial rank-one sheaf preserves invertibility.
 
 ## Main declarations
 
-* `SheafOfModules.freePUnitIsoUnit` identifies the standard free rank-one sheaf with the sheaf
-  of rings;
 * `SheafOfModules.tensorProductFreePUnitIsoLeft` and
   `SheafOfModules.tensorProductFreePUnitIsoRight` identify tensoring with that standard sheaf
   with the identity;
@@ -33,8 +33,8 @@ the standard free rank-one sheaf there. This advances
 Picard group `Pic X` under `⊗`". The common-refinement and restriction compatibility needed for
 the full closure theorem remain subsequent work.
 
-No formalization is vendored. The construction reuses Mathlib's
-`CategoryTheory.Limits.coproductUniqueIso` and Tau Ceti's sheafified tensor-unit isomorphisms.
+No formalization is vendored. The construction reuses Tau Ceti's generic free-rank-one/unit
+comparison and sheafified tensor-unit isomorphisms.
 -/
 
 public section
@@ -53,11 +53,6 @@ variable [∀ Y : C, HasWeakSheafify (J.over Y) AddCommGrpCat.{u}]
 variable [∀ Y : C, (J.over Y).WEqualsLocallyBijective AddCommGrpCat.{u}]
 
 namespace SheafOfModules
-
-/-- The free sheaf on one generator is canonically isomorphic to the tensor unit. -/
-def freePUnitIsoUnit (S : Sheaf J RingCat.{u}) :
-    _root_.SheafOfModules.free (R := S) PUnit ≅ _root_.SheafOfModules.unit S :=
-  coproductUniqueIso (fun _ : PUnit ↦ _root_.SheafOfModules.unit S)
 
 variable (R : Sheaf J CommRingCat.{u})
 


### PR DESCRIPTION
This PR restricts a chosen rank-one local trivialization along a refinement arrow and transports an entire atlas to a refining cover. It advances the exact target `TauCetiRoadmap/JacobianChallenge/README.md`, Layer A milestone “Invertible sheaves on a scheme; the Picard group `Pic X` under `⊗`”: `LocalTrivializations.ofRefinement` is the atlas-level operation needed to put two local trivializations on one common cover.

This is the most effective current step because open PR #4995 constructs precisely such a common refinement and open PR #4815 supplies the tensor–restriction comparison, while neither restricts the chosen trivializing isomorphisms themselves. Their planned consumer, `SheafOfModules.IsInvertible.tensorProduct [IsInvertible M] [IsInvertible N]`, uses the two refined atlases to reduce tensor closure locally to the already-merged trivial-factor computation. After this PR, the milestone still needs those two open prerequisites to merge, the arbitrary-factor tensor-closure assembly, duals, coherent associativity, and the Picard group on isomorphism classes.

Add `TauCeti/Algebra/Category/ModuleCat/Sheaf/Invertible/Restriction.lean` with `overMapFreePUnitIso`, `LocalTrivializations.isoOver`, `LocalTrivializations.ofRefinement`, and the constructor’s characteristic lemmas. Relocate the existing `freePUnitIsoUnit` to the new generic `TauCeti/Algebra/Category/ModuleCat/Sheaf/Free.lean` and generalize it so the coefficient-module universe is independent of both site universes; the old tensor-product module imports its canonical new home and retains no duplicate declaration. The construction reuses Mathlib’s `SheafOfModules.overMap`, `overFunctorMap`, `overMapUnitIso`, and `CategoryTheory.Limits.coproductUniqueIso`; no Mathlib implementation or external formalization is vendored.

Roadmap: JacobianChallenge

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"local-trivialization-refinement-isomorphism"}-->

🤖 Prepared with Codex
