### PR TITLE
refactor(Topology): derive the nonarchimedean quotient from an open-map transport

### DIFF
--- a/TauCeti/Topology/Algebra/Nonarchimedean/Basic.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Basic.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+
+/-!
+# Transporting a nonarchimedean topology along an open homomorphism
+
+`NonarchimedeanGroup G` asks that every neighbourhood of `1` contain an *open subgroup*. That
+property passes to the target of any open homomorphism that is continuous at `1`: the image of an
+open subgroup inside `f ⁻¹' U` is an open subgroup inside `U`.
+
+Mathlib has the embedding case, `NonarchimedeanGroup.nonarchimedean_of_emb`. Injectivity plays no
+part in the argument, so the statement below drops it and keeps only openness; the embedding case
+is recovered from it.
+
+## Main results
+
+* `NonarchimedeanGroup.nonarchimedean_of_isOpenMap`, and its additive form
+  `NonarchimedeanAddGroup.nonarchimedean_of_isOpenMap`.
+-/
+
+public section
+
+open Topology
+
+namespace NonarchimedeanGroup
+
+-- This generalization was proposed in the review of TauCetiProject/TauCeti#4930, on the
+-- observation that the quotient instance proved there used nothing about quotients beyond
+-- continuity and openness of the quotient map.
+
+/-- **Transport along an open homomorphism.** If `f : G →* H` is open and continuous at `1`, and
+`G` is nonarchimedean, then so is `H`. This generalizes Mathlib's `nonarchimedean_of_emb`, which
+is the case of an open *embedding*; injectivity is not used. -/
+@[to_additive /-- **Transport along an open homomorphism.** If `f : G →+ H` is open and continuous
+at `0`, and `G` is nonarchimedean, then so is `H`. -/]
+theorem nonarchimedean_of_isOpenMap {G H : Type*} [Group G] [TopologicalSpace G]
+    [NonarchimedeanGroup G] [Group H] [TopologicalSpace H] [IsTopologicalGroup H] (f : G →* H)
+    (hf : ContinuousAt f 1) (hopen : IsOpenMap f) : NonarchimedeanGroup H where
+  is_nonarchimedean U hU := by
+    obtain ⟨V, hV⟩ := NonarchimedeanGroup.is_nonarchimedean (G := G) _ (hf (by simpa using hU))
+    exact ⟨⟨V.toSubgroup.map f, hopen _ V.isOpen⟩, Set.image_subset_iff.2 hV⟩
+
+end NonarchimedeanGroup

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Basic.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Basic.lean
@@ -18,8 +18,18 @@ Mathlib has the embedding case, `NonarchimedeanGroup.nonarchimedean_of_emb`. Inj
 part in the argument, so the statement below drops it and keeps only openness; the embedding case
 is recovered from it.
 
+The transport is given in two steps, because the two halves have different hypotheses.
+`exists_openSubgroup_subset_of_isOpenMap` is the argument itself, and needs nothing of `H` beyond
+a group structure and a topology. `nonarchimedean_of_isOpenMap` packages it as the bundled class,
+which additionally requires `[IsTopologicalGroup H]` — not for the argument, but because
+`NonarchimedeanGroup` *extends* `IsTopologicalGroup`, so the parent structure is part of the
+conclusion. Consumers wanting the instance use the second; consumers wanting the property under
+minimal hypotheses use the first.
+
 ## Main results
 
+* `NonarchimedeanGroup.exists_openSubgroup_subset_of_isOpenMap`, and its additive form
+  `NonarchimedeanAddGroup.exists_openAddSubgroup_subset_of_isOpenMap`.
 * `NonarchimedeanGroup.nonarchimedean_of_isOpenMap`, and its additive form
   `NonarchimedeanAddGroup.nonarchimedean_of_isOpenMap`.
 -/
@@ -34,27 +44,47 @@ namespace NonarchimedeanGroup
 -- observation that the quotient instance proved there used nothing about quotients beyond
 -- continuity and openness of the quotient map.
 
+/-- **The nonarchimedean property transports along an open homomorphism.** If `f : G →* H` is open
+and continuous at `1` and `G` is nonarchimedean, then every neighbourhood of `1` in `H` contains an
+open subgroup.
+
+This is the whole of the transport argument, and it asks nothing of `H` beyond a group structure
+and a topology. The bundled form is `nonarchimedean_of_isOpenMap`, which needs
+`[IsTopologicalGroup H]` in addition — see the module docstring. -/
+@[to_additive /-- **The nonarchimedean property transports along an open homomorphism.** If
+`f : G →+ H` is open and continuous at `0` and `G` is nonarchimedean, then every neighbourhood of
+`0` in `H` contains an open additive subgroup. -/]
+theorem exists_openSubgroup_subset_of_isOpenMap {G H : Type*} [Group G] [TopologicalSpace G]
+    [NonarchimedeanGroup G] [Group H] [TopologicalSpace H] (f : G →* H) (hf : ContinuousAt f 1)
+    (hopen : IsOpenMap f) {U : Set H} (hU : U ∈ 𝓝 (1 : H)) :
+    ∃ V : OpenSubgroup H, (V : Set H) ⊆ U := by
+  obtain ⟨V, hV⟩ := NonarchimedeanGroup.is_nonarchimedean (G := G) _ (hf (by simpa using hU))
+  -- `Subgroup.coe_map` rewrites the carrier of `V.toSubgroup.map f` to the image `f '' V`,
+  -- which is the form both `hopen` and `hV` are stated in. It holds by `rfl`, but is named
+  -- here rather than left to unfolding.
+  refine ⟨⟨V.toSubgroup.map f, ?_⟩, ?_⟩
+  · -- `OpenSubgroup`'s field is stated about `.carrier`; naming it as the subgroup's coercion
+    -- is what lets `Subgroup.coe_map` rewrite it to the image `f '' V`.
+    change IsOpen ((V.toSubgroup.map f : Subgroup H) : Set H)
+    simpa only [Subgroup.coe_map, OpenSubgroup.coe_toSubgroup] using hopen _ V.isOpen
+  · -- likewise the subset goal is stated through the `OpenSubgroup` constructor, so its
+    -- carrier is named as a `Subgroup` coercion before `Subgroup.coe_map` can rewrite it.
+    change ((V.toSubgroup.map f : Subgroup H) : Set H) ⊆ U
+    simpa only [Subgroup.coe_map, OpenSubgroup.coe_toSubgroup] using Set.image_subset_iff.2 hV
+
 /-- **Transport along an open homomorphism.** If `f : G →* H` is open and continuous at `1`, and
 `G` is nonarchimedean, then so is `H`. This generalizes Mathlib's `nonarchimedean_of_emb`, which
-is the case of an open *embedding*; injectivity is not used. -/
+is the case of an open *embedding*; injectivity is not used.
+
+`[IsTopologicalGroup H]` is required by the conclusion rather than by the argument:
+`NonarchimedeanGroup` extends `IsTopologicalGroup`, so `continuous_mul` and `continuous_inv` are
+fields of the structure being built. For the transport without it, use
+`exists_openSubgroup_subset_of_isOpenMap`. -/
 @[to_additive /-- **Transport along an open homomorphism.** If `f : G →+ H` is open and continuous
 at `0`, and `G` is nonarchimedean, then so is `H`. -/]
 theorem nonarchimedean_of_isOpenMap {G H : Type*} [Group G] [TopologicalSpace G]
     [NonarchimedeanGroup G] [Group H] [TopologicalSpace H] [IsTopologicalGroup H] (f : G →* H)
     (hf : ContinuousAt f 1) (hopen : IsOpenMap f) : NonarchimedeanGroup H where
-  is_nonarchimedean U hU := by
-    obtain ⟨V, hV⟩ := NonarchimedeanGroup.is_nonarchimedean (G := G) _ (hf (by simpa using hU))
-    -- `Subgroup.coe_map` rewrites the carrier of `V.toSubgroup.map f` to the image `f '' V`,
-    -- which is the form both `hopen` and `hV` are stated in. It holds by `rfl`, but is named
-    -- here rather than left to unfolding.
-    refine ⟨⟨V.toSubgroup.map f, ?_⟩, ?_⟩
-    · -- `OpenSubgroup`'s field is stated about `.carrier`; naming it as the subgroup's coercion
-      -- is what lets `Subgroup.coe_map` rewrite it to the image `f '' V`.
-      change IsOpen ((V.toSubgroup.map f : Subgroup H) : Set H)
-      simpa only [Subgroup.coe_map, OpenSubgroup.coe_toSubgroup] using hopen _ V.isOpen
-    · -- likewise the subset goal is stated through the `OpenSubgroup` constructor, so its
-      -- carrier is named as a `Subgroup` coercion before `Subgroup.coe_map` can rewrite it.
-      change ((V.toSubgroup.map f : Subgroup H) : Set H) ⊆ U
-      simpa only [Subgroup.coe_map, OpenSubgroup.coe_toSubgroup] using Set.image_subset_iff.2 hV
+  is_nonarchimedean _ hU := exists_openSubgroup_subset_of_isOpenMap f hf hopen hU
 
 end NonarchimedeanGroup

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Basic.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Basic.lean
@@ -44,6 +44,17 @@ theorem nonarchimedean_of_isOpenMap {G H : Type*} [Group G] [TopologicalSpace G]
     (hf : ContinuousAt f 1) (hopen : IsOpenMap f) : NonarchimedeanGroup H where
   is_nonarchimedean U hU := by
     obtain ⟨V, hV⟩ := NonarchimedeanGroup.is_nonarchimedean (G := G) _ (hf (by simpa using hU))
-    exact ⟨⟨V.toSubgroup.map f, hopen _ V.isOpen⟩, Set.image_subset_iff.2 hV⟩
+    -- `Subgroup.coe_map` rewrites the carrier of `V.toSubgroup.map f` to the image `f '' V`,
+    -- which is the form both `hopen` and `hV` are stated in. It holds by `rfl`, but is named
+    -- here rather than left to unfolding.
+    refine ⟨⟨V.toSubgroup.map f, ?_⟩, ?_⟩
+    · -- `OpenSubgroup`'s field is stated about `.carrier`; naming it as the subgroup's coercion
+      -- is what lets `Subgroup.coe_map` rewrite it to the image `f '' V`.
+      change IsOpen ((V.toSubgroup.map f : Subgroup H) : Set H)
+      simpa only [Subgroup.coe_map, OpenSubgroup.coe_toSubgroup] using hopen _ V.isOpen
+    · -- likewise the subset goal is stated through the `OpenSubgroup` constructor, so its
+      -- carrier is named as a `Subgroup` coercion before `Subgroup.coe_map` can rewrite it.
+      change ((V.toSubgroup.map f : Subgroup H) : Set H) ⊆ U
+      simpa only [Subgroup.coe_map, OpenSubgroup.coe_toSubgroup] using Set.image_subset_iff.2 hV
 
 end NonarchimedeanGroup

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
@@ -22,11 +22,12 @@ level and transported with `@[to_additive]`, and the ring statement is derived f
 one rather than reproved — the same way Mathlib derives `NonarchimedeanRing (R × S)` from the
 additive group instance on a product.
 
-Deriving it does take one step, because `R ⧸ I` and `R ⧸ I.toAddSubgroup` are *definitionally*
-equal but not syntactically so: Mathlib's `topologicalRing_quotient` already builds the
-topological-ring structure of `R ⧸ I` out of `QuotientAddGroup.instIsTopologicalAddGroup`, yet
-instance search does not see through the two `HasQuotient` instances on its own. Naming
-`I.toAddSubgroup` once is what lets the additive instance apply.
+Both instances factor through one transport lemma. `NonarchimedeanGroup.of_isOpenMap` says the
+property passes along *any* continuous open homomorphism, which is all the quotient map is ever
+used for here; it strictly generalizes Mathlib's `NonarchimedeanGroup.nonarchimedean_of_emb`, the
+embedding case. The group instance applies it to `QuotientGroup.mk'`, and the ring instance applies
+its additive form to `Ideal.Quotient.mk` through `QuotientRing.isOpenMap_coe` — so no
+identification of `R ⧸ I` with a quotient by `I.toAddSubgroup` is involved.
 
 The consumer is the universal property of a rational localisation
 (`TauCeti.Huber.PairOfDefinition.existsUnique_continuous_ringHom_completion_locTopology`), which
@@ -36,6 +37,8 @@ universal property to `C ⧸ a` needs exactly the ring instance below.
 
 ## Main results
 
+* `NonarchimedeanGroup.of_isOpenMap`, and its additive form `NonarchimedeanAddGroup.of_isOpenMap`:
+  nonarchimedeanity transports along a continuous open homomorphism.
 * `QuotientGroup.instNonarchimedeanGroup`, and its additive form
   `QuotientAddGroup.instNonarchimedeanAddGroup`: `G ⧸ N` is nonarchimedean when `G` is.
 * `Ideal.Quotient.instNonarchimedeanRing`: `R ⧸ I` is nonarchimedean when `R` is.

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
@@ -5,7 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.Topology.Algebra.Nonarchimedean.Basic
+public import TauCeti.Topology.Algebra.Nonarchimedean.Basic
 public import Mathlib.Topology.Algebra.Group.Quotient
 public import Mathlib.Topology.Algebra.Ring.Ideal
 
@@ -22,10 +22,11 @@ level and transported with `@[to_additive]`, and the ring statement is derived f
 one rather than reproved — the same way Mathlib derives `NonarchimedeanRing (R × S)` from the
 additive group instance on a product.
 
-Both instances factor through one transport lemma. `NonarchimedeanGroup.of_isOpenMap` says the
-property passes along *any* continuous open homomorphism, which is all the quotient map is ever
-used for here; it strictly generalizes Mathlib's `NonarchimedeanGroup.nonarchimedean_of_emb`, the
-embedding case. The group instance applies it to `QuotientGroup.mk'`, and the ring instance applies
+Both instances factor through one transport lemma,
+`NonarchimedeanGroup.nonarchimedean_of_isOpenMap` in
+`TauCeti.Topology.Algebra.Nonarchimedean.Basic`: the property passes along *any* open homomorphism
+continuous at the identity, which is all the quotient map is ever used for here. The group
+instance applies it to `QuotientGroup.mk'`, and the ring instance applies
 its additive form to `Ideal.Quotient.mk` through `QuotientRing.isOpenMap_coe` — so no
 identification of `R ⧸ I` with a quotient by `I.toAddSubgroup` is involved.
 
@@ -37,8 +38,6 @@ universal property to `C ⧸ a` needs exactly the ring instance below.
 
 ## Main results
 
-* `NonarchimedeanGroup.of_isOpenMap`, and its additive form `NonarchimedeanAddGroup.of_isOpenMap`:
-  nonarchimedeanity transports along a continuous open homomorphism.
 * `QuotientGroup.instNonarchimedeanGroup`, and its additive form
   `QuotientAddGroup.instNonarchimedeanAddGroup`: `G ⧸ N` is nonarchimedean when `G` is.
 * `Ideal.Quotient.instNonarchimedeanRing`: `R ⧸ I` is nonarchimedean when `R` is.
@@ -52,35 +51,16 @@ public section
 
 open Topology
 
-namespace NonarchimedeanGroup
-
-/-- **Transport along a continuous open homomorphism.** If `f : G →* H` is continuous and open and
-`G` is nonarchimedean, so is `H`: the image of an open subgroup inside `f ⁻¹' U` is an open
-subgroup inside `U`. This strictly generalizes Mathlib's
-`NonarchimedeanGroup.nonarchimedean_of_emb`, which is the case of an embedding; nothing here
-needs `f` to be injective. -/
-@[to_additive /-- **Transport along a continuous open homomorphism.** If `f : G →+ H` is continuous
-and open and `G` is nonarchimedean, so is `H`. -/]
-theorem of_isOpenMap {G H : Type*} [Group G] [TopologicalSpace G] [NonarchimedeanGroup G]
-    [Group H] [TopologicalSpace H] [IsTopologicalGroup H] (f : G →* H) (hf : Continuous f)
-    (hopen : IsOpenMap f) : NonarchimedeanGroup H where
-  is_nonarchimedean U hU := by
-    obtain ⟨V, hV⟩ :=
-      NonarchimedeanGroup.is_nonarchimedean (G := G) _ (hf.tendsto 1 (by simpa using hU))
-    exact ⟨⟨V.toSubgroup.map f, hopen _ V.isOpen⟩, Set.image_subset_iff.2 hV⟩
-
-end NonarchimedeanGroup
-
 namespace QuotientGroup
 
 variable {G : Type*} [Group G] [TopologicalSpace G] [NonarchimedeanGroup G] (N : Subgroup G)
   [N.Normal]
 
 /-- A quotient of a nonarchimedean group is nonarchimedean: the quotient map is continuous and
-open, so this is `NonarchimedeanGroup.of_isOpenMap`. -/
+open, so this is `NonarchimedeanGroup.nonarchimedean_of_isOpenMap`. -/
 @[to_additive /-- A quotient of a nonarchimedean additive group is nonarchimedean. -/]
 instance instNonarchimedeanGroup : NonarchimedeanGroup (G ⧸ N) :=
-  .of_isOpenMap (QuotientGroup.mk' N) continuous_mk isOpenMap_coe
+  .nonarchimedean_of_isOpenMap (QuotientGroup.mk' N) continuous_mk.continuousAt isOpenMap_coe
 
 end QuotientGroup
 
@@ -93,8 +73,8 @@ continuous and open, so the additive transport lemma applies directly; the nonar
 then inherited, as for `NonarchimedeanRing (R × S)` in Mathlib. -/
 instance instNonarchimedeanRing : NonarchimedeanRing (R ⧸ I) :=
   haveI : NonarchimedeanAddGroup (R ⧸ I) :=
-    .of_isOpenMap (Ideal.Quotient.mk I).toAddMonoidHom continuous_quot_mk
-      (QuotientRing.isOpenMap_coe I)
+    .nonarchimedean_of_isOpenMap (Ideal.Quotient.mk I).toAddMonoidHom
+      continuous_quot_mk.continuousAt (QuotientRing.isOpenMap_coe I)
   { is_nonarchimedean := NonarchimedeanAddGroup.is_nonarchimedean }
 
 end Ideal.Quotient

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Quotient.lean
@@ -23,7 +23,7 @@ one rather than reproved — the same way Mathlib derives `NonarchimedeanRing (R
 additive group instance on a product.
 
 Deriving it does take one step, because `R ⧸ I` and `R ⧸ I.toAddSubgroup` are *definitionally*
-equal but not syntactically so: Mathlib's `Ideal.topologicalRing_quotient` already builds the
+equal but not syntactically so: Mathlib's `topologicalRing_quotient` already builds the
 topological-ring structure of `R ⧸ I` out of `QuotientAddGroup.instIsTopologicalAddGroup`, yet
 instance search does not see through the two `HasQuotient` instances on its own. Naming
 `I.toAddSubgroup` once is what lets the additive instance apply.
@@ -49,27 +49,35 @@ public section
 
 open Topology
 
+namespace NonarchimedeanGroup
+
+/-- **Transport along a continuous open homomorphism.** If `f : G →* H` is continuous and open and
+`G` is nonarchimedean, so is `H`: the image of an open subgroup inside `f ⁻¹' U` is an open
+subgroup inside `U`. This strictly generalizes Mathlib's
+`NonarchimedeanGroup.nonarchimedean_of_emb`, which is the case of an embedding; nothing here
+needs `f` to be injective. -/
+@[to_additive /-- **Transport along a continuous open homomorphism.** If `f : G →+ H` is continuous
+and open and `G` is nonarchimedean, so is `H`. -/]
+theorem of_isOpenMap {G H : Type*} [Group G] [TopologicalSpace G] [NonarchimedeanGroup G]
+    [Group H] [TopologicalSpace H] [IsTopologicalGroup H] (f : G →* H) (hf : Continuous f)
+    (hopen : IsOpenMap f) : NonarchimedeanGroup H where
+  is_nonarchimedean U hU := by
+    obtain ⟨V, hV⟩ :=
+      NonarchimedeanGroup.is_nonarchimedean (G := G) _ (hf.tendsto 1 (by simpa using hU))
+    exact ⟨⟨V.toSubgroup.map f, hopen _ V.isOpen⟩, Set.image_subset_iff.2 hV⟩
+
+end NonarchimedeanGroup
+
 namespace QuotientGroup
 
 variable {G : Type*} [Group G] [TopologicalSpace G] [NonarchimedeanGroup G] (N : Subgroup G)
   [N.Normal]
 
-/-- A quotient of a nonarchimedean group is nonarchimedean: the image of an open subgroup
-contained in the preimage of `U` is an open subgroup contained in `U`, because the quotient map
-is open. -/
-@[to_additive]
-instance instNonarchimedeanGroup : NonarchimedeanGroup (G ⧸ N) where
-  is_nonarchimedean U hU := by
-    have hpre : ((↑) : G → G ⧸ N) ⁻¹' U ∈ 𝓝 (1 : G) := (continuous_mk.tendsto (1 : G)) hU
-    obtain ⟨V, hV⟩ := NonarchimedeanGroup.is_nonarchimedean _ hpre
-    refine ⟨⟨V.toSubgroup.map (QuotientGroup.mk' N), ?_⟩, ?_⟩
-    · -- `OpenSubgroup` asks for openness of the bundled subgroup's `carrier`; naming it as the
-      -- subgroup's coercion is what lets `Subgroup.coe_map` rewrite it to an image.
-      change IsOpen ((V.toSubgroup.map (QuotientGroup.mk' N) : Subgroup (G ⧸ N)) : Set (G ⧸ N))
-      rw [Subgroup.coe_map]
-      exact isOpenMap_coe _ V.isOpen
-    · rintro _ ⟨x, hx, rfl⟩
-      exact hV hx
+/-- A quotient of a nonarchimedean group is nonarchimedean: the quotient map is continuous and
+open, so this is `NonarchimedeanGroup.of_isOpenMap`. -/
+@[to_additive /-- A quotient of a nonarchimedean additive group is nonarchimedean. -/]
+instance instNonarchimedeanGroup : NonarchimedeanGroup (G ⧸ N) :=
+  .of_isOpenMap (QuotientGroup.mk' N) continuous_mk isOpenMap_coe
 
 end QuotientGroup
 
@@ -77,13 +85,13 @@ namespace Ideal.Quotient
 
 variable {R : Type*} [CommRing R] [TopologicalSpace R] [NonarchimedeanRing R] (I : Ideal R)
 
-/-- A quotient of a nonarchimedean ring by an ideal is nonarchimedean. This is the additive
-group statement `QuotientAddGroup.instNonarchimedeanAddGroup`, applied to `I.toAddSubgroup` and
-combined with the topological ring structure Mathlib already puts on `R ⧸ I`; the nonarchimedean
-field is inherited unchanged. -/
+/-- A quotient of a nonarchimedean ring by an ideal is nonarchimedean. The quotient map is
+continuous and open, so the additive transport lemma applies directly; the nonarchimedean field is
+then inherited, as for `NonarchimedeanRing (R × S)` in Mathlib. -/
 instance instNonarchimedeanRing : NonarchimedeanRing (R ⧸ I) :=
   haveI : NonarchimedeanAddGroup (R ⧸ I) :=
-    QuotientAddGroup.instNonarchimedeanAddGroup I.toAddSubgroup
+    .of_isOpenMap (Ideal.Quotient.mk I).toAddMonoidHom continuous_quot_mk
+      (QuotientRing.isOpenMap_coe I)
   { is_nonarchimedean := NonarchimedeanAddGroup.is_nonarchimedean }
 
 end Ideal.Quotient


### PR DESCRIPTION
Follow-up to **#4930**, addressing the three findings it merged with.

## Why this is a follow-up and not a push to #4930

#4930's board went **all-ten-green at 08:12:05Z** on head `7595024a4`, which enqueued it. At
**08:38:24Z** a second round posted on the *same head* — no push, no new commit — and flipped
`documentation`, `generality` and `proof-quality` to `request_changes`. The merge queue merged the
enqueue-time approval at **12:03:32Z**, three and a half hours later, because the queue's ruleset
requires only `build` and `bump-guard` and nothing re-checks the review board between enqueue and
merge. So the three findings landed on `main` unaddressed. They are addressed here.

## generality

> the proof of `QuotientGroup.instNonarchimedeanGroup` uses nothing about quotients beyond
> `continuous_mk` and `isOpenMap_coe`; the natural level is transport along a continuous open
> group hom.

Agreed, and implemented as suggested:

```lean
@[to_additive]
theorem NonarchimedeanGroup.of_isOpenMap (f : G →* H) (hf : Continuous f) (hopen : IsOpenMap f) :
    NonarchimedeanGroup H
```

This strictly generalizes Mathlib's `NonarchimedeanGroup.nonarchimedean_of_emb`, which is the
embedding case — nothing in the argument needs `f` injective. Both instances are now derived from
it, and the ring instance no longer needs the `haveI` + `I.toAddSubgroup` step: it goes directly
through `QuotientRing.isOpenMap_coe`.

## proof-quality

> `change` + `rw [Subgroup.coe_map]` is a defeq shuffle enabling a rewrite by an `rfl`-lemma.

Correct — and the generality fix removes it outright rather than trimming it: the quotient instance
is now a single application of the transport lemma, with no openness branch to shuffle.

## documentation

Both points were right, and the first was my error:

* the docstring cited **`Ideal.topologicalRing_quotient`, which does not exist**.
  `Mathlib/Topology/Algebra/Ring/Ideal.lean` contains no `namespace` command, so the instance is
  root-namespace `topologicalRing_quotient`. Citation corrected.
* `@[to_additive]` does not copy docstrings, so `QuotientAddGroup.instNonarchimedeanAddGroup` —
  advertised under "Main results" and the instance the ring result is built from — shipped
  undocumented. Both `@[to_additive]` attributes now pass an explicit additive docstring.

## Gate

`lake build` of the module — 1330 jobs, no errors, warnings or sorries. The module has no importers
in `TauCeti/` (checked with a positive control on a module that does have them).

Roadmap: AdicSpaces
