### PR TITLE
feat: characterize solvability by derived words

### DIFF
--- a/TauCeti/GroupTheory/Solvable.lean
+++ b/TauCeti/GroupTheory/Solvable.lean
@@ -11,10 +11,12 @@ public import TauCeti.GroupTheory.Commutator
 /-!
 # Derived words and solvable groups
 
-The `n`th derived word is the balanced commutator word on `2 ^ n` inputs: the zeroth word is
-one group element, and the successor word is the commutator of two copies of the preceding word.
-This file proves that its values generate the `n`th derived subgroup. Consequently, a group is
-solvable exactly when one derived word is identically one.
+The `n`th derived word evaluates a perfect binary argument tree of depth `n` by balanced
+commutators: the zeroth word is one group element, and the successor word is the commutator of two
+copies of the preceding word. This file proves that its values generate the `n`th derived subgroup.
+Consequently, a group is solvable exactly when one derived word is identically one. It also records
+the characterization of solvability for direct products via the two surjective projections and the
+converse product instance.
 
 The identity formulation is useful when a group is represented by an affine scheme: an identity
 between derived words can be checked on a schematically dense family of points, while the
@@ -25,8 +27,11 @@ subgroup-valued definition of the derived series cannot be compared pointwise in
 * `TauCeti.isSolvable_prod_iff`: `G × H` is solvable if and only if both `G` and `H` are.
 * `TauCeti.DerivedWordArgs`: the recursively paired arguments of a derived word.
 * `TauCeti.derivedWord`: the balanced iterated commutator word.
+* `TauCeti.map_derivedWord`: derived words commute with group homomorphisms.
 * `TauCeti.derivedSeries_eq_closure_range_derivedWord`: the values of the `n`th derived word
   generate the `n`th derived subgroup.
+* `TauCeti.derivedWord_mem_derivedSeries`: derived-word values lie in the corresponding derived
+  subgroup.
 * `TauCeti.derivedSeries_eq_bot_iff_derivedWord_eq_one`: a fixed derived subgroup vanishes exactly
   when its derived word is identically one.
 * `TauCeti.isSolvable_iff_exists_derivedWord_eq_one`: solvability is equivalent to a derived-word
@@ -68,12 +73,12 @@ def map {G : Type u} {H : Type v} (f : G → H) :
   | _ + 1, .node x y => .node (map f _ x) (map f _ y)
 
 @[simp]
-theorem map_zero {G : Type u} {H : Type v} (f : G → H) (x : G) :
+theorem map_leaf {G : Type u} {H : Type v} (f : G → H) (x : G) :
     map f 0 (.leaf x) = .leaf (f x) :=
   (rfl)
 
 @[simp]
-theorem map_succ {G : Type u} {H : Type v} (f : G → H) (n : ℕ)
+theorem map_node {G : Type u} {H : Type v} (f : G → H) (n : ℕ)
     (x y : DerivedWordArgs G n) :
     map f (n + 1) (.node x y) = .node (map f n x) (map f n y) :=
   (rfl)
@@ -85,10 +90,10 @@ theorem map_id {G : Type u} (n : ℕ) (x : DerivedWordArgs G n) :
   induction n with
   | zero =>
       obtain ⟨x⟩ := x
-      rw [map_zero, id_eq]
+      rw [map_leaf, id_eq]
   | succ n ih =>
       obtain ⟨x, y⟩ := x
-      rw [map_succ, ih, ih]
+      rw [map_node, ih, ih]
 
 /-- Successive maps of derived-word arguments compose pointwise. -/
 theorem map_comp {G : Type u} {H : Type v} {K : Type*} (g : H → K) (f : G → H)
@@ -97,40 +102,36 @@ theorem map_comp {G : Type u} {H : Type v} {K : Type*} (g : H → K) (f : G → 
   induction n with
   | zero =>
       obtain ⟨x⟩ := x
-      rw [map_zero, map_zero, map_zero, Function.comp_apply]
+      rw [map_leaf, map_leaf, map_leaf, Function.comp_apply]
   | succ n ih =>
       obtain ⟨x, y⟩ := x
-      rw [map_succ, map_succ, map_succ, ih, ih]
+      rw [map_node, map_node, map_node, ih, ih]
 
 end DerivedWordArgs
 
-/-- The balanced iterated commutator word defining the derived series. -/
+/-- Evaluate a depth-`n` argument tree by balanced commutators: a leaf evaluates to its element,
+and a node to the commutator of the values of its two subtrees. Its values generate
+`derivedSeries G n` (`derivedSeries_eq_closure_range_derivedWord`). -/
 def derivedWord (G : Type u) [Group G] :
     (n : ℕ) → DerivedWordArgs G n → G
   | 0, .leaf x => x
   | _ + 1, .node x y => ⁅derivedWord G _ x, derivedWord G _ y⁆
 
 @[simp]
-theorem derivedWord_zero (G : Type u) [Group G] (x : G) :
+theorem derivedWord_leaf (G : Type u) [Group G] (x : G) :
     derivedWord G 0 (.leaf x) = x :=
   (rfl)
 
 @[simp]
-theorem derivedWord_succ (G : Type u) [Group G] (n : ℕ)
+theorem derivedWord_node (G : Type u) [Group G] (n : ℕ)
     (x y : DerivedWordArgs G n) :
     derivedWord G (n + 1) (.node x y) = ⁅derivedWord G n x, derivedWord G n y⁆ :=
   (rfl)
 
-end TauCeti
-
-namespace MonoidHom
-
-open TauCeti
-
 /-- Derived words commute with group homomorphisms. -/
 @[simp]
-theorem map_derivedWord {G : Type u} {H : Type v} [Group G] [Group H]
-    (f : G →* H) (n : ℕ) (x : DerivedWordArgs G n) :
+theorem map_derivedWord {G : Type u} {H : Type v} {F : Type*} [Group G] [Group H]
+    [FunLike F G H] [MonoidHomClass F G H] (f : F) (n : ℕ) (x : DerivedWordArgs G n) :
     f (derivedWord G n x) = derivedWord H n (DerivedWordArgs.map f n x) := by
   induction n with
   | zero =>
@@ -138,40 +139,15 @@ theorem map_derivedWord {G : Type u} {H : Type v} [Group G] [Group H]
       rfl
   | succ n ih =>
       obtain ⟨x, y⟩ := x
-      rw [DerivedWordArgs.map_succ, derivedWord_succ, derivedWord_succ,
+      rw [DerivedWordArgs.map_node, derivedWord_node, derivedWord_node,
         map_commutatorElement, ih, ih]
 
-end MonoidHom
-
-namespace TauCeti
-
 /-- Conjugating a derived-word value amounts to conjugating each of its arguments. -/
-theorem conj_derivedWord (G : Type u) [Group G] (g : G) (n : ℕ)
+private theorem conj_derivedWord (G : Type u) [Group G] (g : G) (n : ℕ)
     (x : DerivedWordArgs G n) :
     g * derivedWord G n x * g⁻¹ =
       derivedWord G n (DerivedWordArgs.map (MulAut.conj g) n x) := by
-  simpa only [MulEquiv.coe_toMonoidHom, MulAut.conj_apply] using
-    MonoidHom.map_derivedWord (MulAut.conj g).toMonoidHom n x
-
-private theorem normal_closure_range_derivedWord (G : Type u) [Group G] (n : ℕ) :
-    (Subgroup.closure (Set.range (derivedWord G n))).Normal where
-  conj_mem x hx g := by
-    induction hx using Subgroup.closure_induction with
-    | mem x hx =>
-        obtain ⟨a, rfl⟩ := hx
-        rw [conj_derivedWord]
-        exact Subgroup.subset_closure ⟨_, rfl⟩
-    | one => simp
-    | mul x y _ _ hx hy =>
-        have hconj : g * (x * y) * g⁻¹ = (g * x * g⁻¹) * (g * y * g⁻¹) := by
-          group
-        rw [hconj]
-        exact Subgroup.mul_mem _ hx hy
-    | inv x _ hx =>
-        have hconj : g * x⁻¹ * g⁻¹ = (g * x * g⁻¹)⁻¹ := by
-          group
-        rw [hconj]
-        exact Subgroup.inv_mem _ hx
+  simpa only [MulAut.conj_apply] using map_derivedWord (MulAut.conj g) n x
 
 /-- The values of the `n`th derived word generate the `n`th derived subgroup. -/
 theorem derivedSeries_eq_closure_range_derivedWord (G : Type u) [Group G] (n : ℕ) :
@@ -187,12 +163,14 @@ theorem derivedSeries_eq_closure_range_derivedWord (G : Type u) [Group G] (n : �
       rw [derivedSeries_succ, ih]
       apply le_antisymm
       · let N := Subgroup.closure (Set.range (derivedWord G (n + 1)))
-        let _ : N.Normal := normal_closure_range_derivedWord G (n + 1)
+        have hnorm : Subgroup.closure (Set.range (derivedWord G n)) ≤
+            Subgroup.normalizer (N : Set G) := Subgroup.le_normalizer_closure_iff.mpr <| by
+          rintro g _ _ ⟨x, rfl⟩
+          rw [conj_derivedWord]
+          exact Subgroup.subset_closure ⟨_, rfl⟩
         apply commutator_closure_closure_le
-        · rw [N.normalizer_eq_top]
-          exact le_top
-        · rw [N.normalizer_eq_top]
-          exact le_top
+        · exact hnorm
+        · exact hnorm
         · rintro _ ⟨x, rfl⟩ _ ⟨y, rfl⟩
           exact Subgroup.subset_closure ⟨.node x y, rfl⟩
       · rw [Subgroup.closure_le]

--- a/TauCeti/GroupTheory/Solvable.lean
+++ b/TauCeti/GroupTheory/Solvable.lean
@@ -121,9 +121,15 @@ theorem derivedWord_succ (G : Type u) [Group G] (n : ℕ)
     derivedWord G (n + 1) (.node x y) = ⁅derivedWord G n x, derivedWord G n y⁆ :=
   (rfl)
 
+end TauCeti
+
+namespace MonoidHom
+
+open TauCeti
+
 /-- Derived words commute with group homomorphisms. -/
 @[simp]
-theorem MonoidHom.map_derivedWord {G : Type u} {H : Type v} [Group G] [Group H]
+theorem map_derivedWord {G : Type u} {H : Type v} [Group G] [Group H]
     (f : G →* H) (n : ℕ) (x : DerivedWordArgs G n) :
     f (derivedWord G n x) = derivedWord H n (DerivedWordArgs.map f n x) := by
   induction n with
@@ -134,6 +140,10 @@ theorem MonoidHom.map_derivedWord {G : Type u} {H : Type v} [Group G] [Group H]
       obtain ⟨x, y⟩ := x
       rw [DerivedWordArgs.map_succ, derivedWord_succ, derivedWord_succ,
         map_commutatorElement, ih, ih]
+
+end MonoidHom
+
+namespace TauCeti
 
 /-- Conjugating a derived-word value amounts to conjugating each of its arguments. -/
 theorem conj_derivedWord (G : Type u) [Group G] (g : G) (n : ℕ)

--- a/TauCeti/GroupTheory/Solvable.lean
+++ b/TauCeti/GroupTheory/Solvable.lean
@@ -6,20 +6,40 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.GroupTheory.Solvable
+public import TauCeti.GroupTheory.Commutator
 
 /-!
-# Solvability of a direct product
+# Derived words and solvable groups
 
-The two projections out of a direct product are surjective, and solvability transports along a
-surjection, so a solvable product has solvable factors. In the other direction a product of two
-solvable groups is solvable. This file packages the two directions as a single characterisation.
+The `n`th derived word is the balanced commutator word on `2 ^ n` inputs: the zeroth word is
+one group element, and the successor word is the commutator of two copies of the preceding word.
+This file proves that its values generate the `n`th derived subgroup. Consequently, a group is
+solvable exactly when one derived word is identically one.
 
-## Main results
+The identity formulation is useful when a group is represented by an affine scheme: an identity
+between derived words can be checked on a schematically dense family of points, while the
+subgroup-valued definition of the derived series cannot be compared pointwise in that way.
+
+## Main declarations
 
 * `TauCeti.isSolvable_prod_iff`: `G × H` is solvable if and only if both `G` and `H` are.
+* `TauCeti.DerivedWordArgs`: the recursively paired arguments of a derived word.
+* `TauCeti.derivedWord`: the balanced iterated commutator word.
+* `TauCeti.derivedSeries_eq_closure_range_derivedWord`: the values of the `n`th derived word
+  generate the `n`th derived subgroup.
+* `TauCeti.derivedSeries_eq_bot_iff_derivedWord_eq_one`: a fixed derived subgroup vanishes exactly
+  when its derived word is identically one.
+* `TauCeti.isSolvable_iff_exists_derivedWord_eq_one`: solvability is equivalent to a derived-word
+  identity.
+
+This is a prerequisite for descending geometric solvability along schematically dense morphisms
+from smooth affine groups. That descent supplies the multiplication-image step in the construction
+of the solvable radical in Layer 6 of the ReductiveGroups roadmap.
 -/
 
 public section
+
+open scoped commutatorElement
 
 namespace TauCeti
 
@@ -30,5 +50,172 @@ theorem isSolvable_prod_iff {G H : Type*} [Group G] [Group H] :
   ⟨fun _ ↦ ⟨Group.isSolvable_of_surjective (f := MonoidHom.fst G H) fun x ↦ ⟨(x, 1), rfl⟩,
       Group.isSolvable_of_surjective (f := MonoidHom.snd G H) fun x ↦ ⟨(1, x), rfl⟩⟩,
     fun ⟨_, _⟩ ↦ inferInstance⟩
+
+universe u v
+
+/-- The argument trees for derived words. A tree at depth zero is one group element, and a tree at
+successor depth consists of two argument trees of the preceding depth. -/
+inductive DerivedWordArgs (G : Type u) : ℕ → Type u
+  | leaf : G → DerivedWordArgs G 0
+  | node : DerivedWordArgs G n → DerivedWordArgs G n → DerivedWordArgs G (n + 1)
+
+namespace DerivedWordArgs
+
+/-- Apply a function to every entry in the arguments of a derived word. -/
+def map {G : Type u} {H : Type v} (f : G → H) :
+    (n : ℕ) → DerivedWordArgs G n → DerivedWordArgs H n
+  | 0, .leaf x => .leaf (f x)
+  | _ + 1, .node x y => .node (map f _ x) (map f _ y)
+
+@[simp]
+theorem map_zero {G : Type u} {H : Type v} (f : G → H) (x : G) :
+    map f 0 (.leaf x) = .leaf (f x) :=
+  (rfl)
+
+@[simp]
+theorem map_succ {G : Type u} {H : Type v} (f : G → H) (n : ℕ)
+    (x y : DerivedWordArgs G n) :
+    map f (n + 1) (.node x y) = .node (map f n x) (map f n y) :=
+  (rfl)
+
+/-- Mapping the identity function leaves derived-word arguments unchanged. -/
+@[simp]
+theorem map_id {G : Type u} (n : ℕ) (x : DerivedWordArgs G n) :
+    map id n x = x := by
+  induction n with
+  | zero =>
+      obtain ⟨x⟩ := x
+      rw [map_zero, id_eq]
+  | succ n ih =>
+      obtain ⟨x, y⟩ := x
+      rw [map_succ, ih, ih]
+
+/-- Successive maps of derived-word arguments compose pointwise. -/
+theorem map_comp {G : Type u} {H : Type v} {K : Type*} (g : H → K) (f : G → H)
+    (n : ℕ) (x : DerivedWordArgs G n) :
+    map (g ∘ f) n x = map g n (map f n x) := by
+  induction n with
+  | zero =>
+      obtain ⟨x⟩ := x
+      rw [map_zero, map_zero, map_zero, Function.comp_apply]
+  | succ n ih =>
+      obtain ⟨x, y⟩ := x
+      rw [map_succ, map_succ, map_succ, ih, ih]
+
+end DerivedWordArgs
+
+/-- The balanced iterated commutator word defining the derived series. -/
+def derivedWord (G : Type u) [Group G] :
+    (n : ℕ) → DerivedWordArgs G n → G
+  | 0, .leaf x => x
+  | _ + 1, .node x y => ⁅derivedWord G _ x, derivedWord G _ y⁆
+
+@[simp]
+theorem derivedWord_zero (G : Type u) [Group G] (x : G) :
+    derivedWord G 0 (.leaf x) = x :=
+  (rfl)
+
+@[simp]
+theorem derivedWord_succ (G : Type u) [Group G] (n : ℕ)
+    (x y : DerivedWordArgs G n) :
+    derivedWord G (n + 1) (.node x y) = ⁅derivedWord G n x, derivedWord G n y⁆ :=
+  (rfl)
+
+/-- Derived words commute with group homomorphisms. -/
+@[simp]
+theorem MonoidHom.map_derivedWord {G : Type u} {H : Type v} [Group G] [Group H]
+    (f : G →* H) (n : ℕ) (x : DerivedWordArgs G n) :
+    f (derivedWord G n x) = derivedWord H n (DerivedWordArgs.map f n x) := by
+  induction n with
+  | zero =>
+      obtain ⟨x⟩ := x
+      rfl
+  | succ n ih =>
+      obtain ⟨x, y⟩ := x
+      rw [DerivedWordArgs.map_succ, derivedWord_succ, derivedWord_succ,
+        map_commutatorElement, ih, ih]
+
+/-- Conjugating a derived-word value amounts to conjugating each of its arguments. -/
+theorem conj_derivedWord (G : Type u) [Group G] (g : G) (n : ℕ)
+    (x : DerivedWordArgs G n) :
+    g * derivedWord G n x * g⁻¹ =
+      derivedWord G n (DerivedWordArgs.map (MulAut.conj g) n x) := by
+  simpa only [MulEquiv.coe_toMonoidHom, MulAut.conj_apply] using
+    MonoidHom.map_derivedWord (MulAut.conj g).toMonoidHom n x
+
+private theorem normal_closure_range_derivedWord (G : Type u) [Group G] (n : ℕ) :
+    (Subgroup.closure (Set.range (derivedWord G n))).Normal where
+  conj_mem x hx g := by
+    induction hx using Subgroup.closure_induction with
+    | mem x hx =>
+        obtain ⟨a, rfl⟩ := hx
+        rw [conj_derivedWord]
+        exact Subgroup.subset_closure ⟨_, rfl⟩
+    | one => simp
+    | mul x y _ _ hx hy =>
+        have hconj : g * (x * y) * g⁻¹ = (g * x * g⁻¹) * (g * y * g⁻¹) := by
+          group
+        rw [hconj]
+        exact Subgroup.mul_mem _ hx hy
+    | inv x _ hx =>
+        have hconj : g * x⁻¹ * g⁻¹ = (g * x * g⁻¹)⁻¹ := by
+          group
+        rw [hconj]
+        exact Subgroup.inv_mem _ hx
+
+/-- The values of the `n`th derived word generate the `n`th derived subgroup. -/
+theorem derivedSeries_eq_closure_range_derivedWord (G : Type u) [Group G] (n : ℕ) :
+    derivedSeries G n = Subgroup.closure (Set.range (derivedWord G n)) := by
+  induction n with
+  | zero =>
+      rw [derivedSeries_zero]
+      apply le_antisymm
+      · intro x _
+        exact Subgroup.subset_closure ⟨.leaf x, rfl⟩
+      · exact le_top
+  | succ n ih =>
+      rw [derivedSeries_succ, ih]
+      apply le_antisymm
+      · let N := Subgroup.closure (Set.range (derivedWord G (n + 1)))
+        let _ : N.Normal := normal_closure_range_derivedWord G (n + 1)
+        apply commutator_closure_closure_le
+        · rw [N.normalizer_eq_top]
+          exact le_top
+        · rw [N.normalizer_eq_top]
+          exact le_top
+        · rintro _ ⟨x, rfl⟩ _ ⟨y, rfl⟩
+          exact Subgroup.subset_closure ⟨.node x y, rfl⟩
+      · rw [Subgroup.closure_le]
+        rintro _ ⟨z, rfl⟩
+        cases z with
+        | node x y =>
+            exact Subgroup.commutator_mem_commutator
+              (Subgroup.subset_closure ⟨x, rfl⟩)
+              (Subgroup.subset_closure ⟨y, rfl⟩)
+
+/-- Every value of the `n`th derived word belongs to the `n`th derived subgroup. -/
+theorem derivedWord_mem_derivedSeries (G : Type u) [Group G] (n : ℕ)
+    (x : DerivedWordArgs G n) :
+    derivedWord G n x ∈ derivedSeries G n := by
+  rw [derivedSeries_eq_closure_range_derivedWord]
+  exact Subgroup.subset_closure ⟨x, rfl⟩
+
+/-- The `n`th derived subgroup is trivial exactly when the `n`th derived word is identically
+one. -/
+theorem derivedSeries_eq_bot_iff_derivedWord_eq_one (G : Type u) [Group G] (n : ℕ) :
+    derivedSeries G n = ⊥ ↔ ∀ x : DerivedWordArgs G n, derivedWord G n x = 1 := by
+  constructor
+  · intro hn x
+    exact Subgroup.mem_bot.mp (hn ▸ derivedWord_mem_derivedSeries G n x)
+  · intro hn
+    rw [derivedSeries_eq_closure_range_derivedWord, Subgroup.closure_eq_bot_iff]
+    rintro _ ⟨x, rfl⟩
+    exact hn x
+
+/-- A group is solvable exactly when some derived word is identically one. -/
+theorem isSolvable_iff_exists_derivedWord_eq_one (G : Type u) [Group G] :
+    Group.IsSolvable G ↔ ∃ n : ℕ, ∀ x : DerivedWordArgs G n, derivedWord G n x = 1 := by
+  rw [Group.isSolvable_def]
+  simp only [derivedSeries_eq_bot_iff_derivedWord_eq_one]
 
 end TauCeti


### PR DESCRIPTION
This PR adds the derived-word identity interface needed to descend geometric solvability along a schematically dense morphism from a smooth affine group. Define the arguments of the `n`th derived word as a depth-`n` binary tree, evaluate that tree by balanced commutators, prove naturality under group homomorphisms, and identify the subgroup generated by all its values with Mathlib's `derivedSeries G n`. Deduce both the fixed-depth criterion `derivedSeries G n = ⊥` iff the `n`th word is identically one and the existential characterization of `Group.IsSolvable`.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “develop the radical `R(G)` (maximal connected normal solvable, geometric).” The in-flight candidate construction in #4999 names solvability of the scheme-theoretic multiplication image as its next blocker; the planned declaration `geometricallySolvablePointsCommHopfAlgProperty.image_of_smooth_source` consumes this PR's word identity by expressing solvability as finitely many iterated commutator equations, which finite-type point separation can reflect across the injective coordinate map of the image.

This is the most effective complete rung because the existing descent theorem requires faithful flatness of the canonical source-to-image Hopf inclusion, while the radical's actual semidirect-product source is smooth and therefore supports the more local schematically-dense identity argument. After this PR, the Layer 6 radical milestone still needs iterated Hopf-coordinate maps for these words, smooth-source point separation to prove the image-solvability theorem, binary closure of the candidates from #4999, and the maximal-dimension argument packaging the greatest candidate as `R(G)`.

Add `TauCeti/GroupTheory/Solvable.lean` (212 lines). The proof reuses Mathlib's derived-series and commutator-subgroup APIs and Tau Ceti's generator-level commutator lemma; no Mathlib code or external formalization is vendored or adapted.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"solvable-iterated-commutator-word"}-->

🤖 Prepared with Codex
