### PR TITLE
refactor(Huber): prove the weightedMapCompletionEquiv application lemmas by simp only

### DIFF
--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -224,7 +224,8 @@ theorem weightedMapCompletionEquiv_apply (e : A ≃+* B) (he : Continuous e)
     (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i)
     (x : UniformSpace.Completion (weightedRestrictedSubring T hT)) :
     weightedMapCompletionEquiv e he he' hT hS hTS hST x
-      = weightedMapCompletion (φ := (e : A →+* B)) he hT hS hTS x := (rfl)
+      = weightedMapCompletion (φ := (e : A →+* B)) he hT hS hTS x := by
+  simp only [weightedMapCompletionEquiv, RingEquiv.ofRingHom_apply]
 
 /-- **The inverse direction of `TauCeti.Huber.weightedMapCompletionEquiv`** is the map induced by
 `e.symm`. -/
@@ -234,7 +235,8 @@ theorem weightedMapCompletionEquiv_symm_apply (e : A ≃+* B) (he : Continuous e
     (hTS : ∀ i, (e : A →+* B) '' T i ⊆ S i) (hST : ∀ i, (e.symm : B →+* A) '' S i ⊆ T i)
     (y : UniformSpace.Completion (weightedRestrictedSubring S hS)) :
     (weightedMapCompletionEquiv e he he' hT hS hTS hST).symm y
-      = weightedMapCompletion (φ := (e.symm : B →+* A)) he' hS hT hST y := (rfl)
+      = weightedMapCompletion (φ := (e.symm : B →+* A)) he' hS hT hST y := by
+  simp only [weightedMapCompletionEquiv, RingEquiv.ofRingHom_symm, RingEquiv.ofRingHom_apply]
 
 end Functoriality
 

--- a/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
+++ b/TauCeti/RingTheory/Huber/WeightedRestrictedSeries/Completion.lean
@@ -236,7 +236,7 @@ theorem weightedMapCompletionEquiv_symm_apply (e : A ≃+* B) (he : Continuous e
     (y : UniformSpace.Completion (weightedRestrictedSubring S hS)) :
     (weightedMapCompletionEquiv e he he' hT hS hTS hST).symm y
       = weightedMapCompletion (φ := (e.symm : B →+* A)) he' hS hT hST y := by
-  simp only [weightedMapCompletionEquiv, RingEquiv.ofRingHom_symm, RingEquiv.ofRingHom_apply]
+  simp only [weightedMapCompletionEquiv, RingEquiv.ofRingHom_symm_apply]
 
 end Functoriality
 


### PR DESCRIPTION
Answer the `proof-quality` finding that #4969 merged without addressing.

## What happened

#4969 was added to the merge queue at 08:06:55Z. Its `proof-quality` board arrived at 08:11:34Z —
4m39s later — and blocked, with nine other rubrics approving. This queue merges the tree as it
stood at *enqueue* time, so pushing the answer to that PR would have been silently discarded while
GitHub reported it merged; and dequeuing requires `maintain`, which this account does not have
(`DequeuePullRequest` returns `FORBIDDEN`). So #4969 merged at 11:44:11Z carrying the blocking
finding, and this is the follow-up that answers it.

## The change

Both application lemmas for `weightedMapCompletionEquiv` proved their goal with a parenthesised
term-mode `(rfl)`:

```lean
      = weightedMapCompletion (φ := (e : A →+* B)) he hT hS hTS x := (rfl)
```

That succeeds only because the module system seals the definition's body, so the *term* elaborator
sees a definitional equality the *tactic* elaborator does not — `by rfl` fails on the same goal.
Nothing in the source signals that, which is what the finding objected to.

## The proposed fix does not compile, so this is not quite it

The finding's `_Fix:_` was `simp only [weightedMapCompletionEquiv]`. That leaves both goals open:

```
⊢ (RingEquiv.ofRingHom (weightedMapCompletion he hT hS hTS)
      (weightedMapCompletion he' hS hT hST) ⋯ ⋯) x = (weightedMapCompletion he hT hS hTS) x
```

Unfolding the definition exposes the `RingEquiv.ofRingHom` wrapper but does not strip it, so each
proof also needs the coercion lemma — and the inverse direction needs `RingEquiv.ofRingHom_symm`
first, to turn `.symm` into the opposite `ofRingHom`. What ships is therefore

```lean
  simp only [weightedMapCompletionEquiv, RingEquiv.ofRingHom_apply]
  simp only [weightedMapCompletionEquiv, RingEquiv.ofRingHom_symm_apply]
```

Both lists are minimal, which matters because a dead `simp only` argument is a build failure here:
neither `ofRingHom` lemma fires before `weightedMapCompletionEquiv` is unfolded.

### Round 1, `reuse` — applied, and worth recording why I missed it

The inverse proof first composed `ofRingHom_symm` with `ofRingHom_apply`. `reuse` pointed out that
Mathlib already has the combined `RingEquiv.ofRingHom_symm_apply`, and it is right.

I had searched `Mathlib/Algebra/Ring/Equiv.lean` for `ofRingHom`, found `ofRingHom_apply`,
`coe_ringHom_ofRingHom`, `ofRingHom_coe_ringHom` and `ofRingHom_symm`, and concluded the combined
lemma did not exist. That conclusion was an artefact of the instrument: `ofRingHom` carries
`@[simps -isSimp]`, and `Equiv.lean:329` declares

```lean
initialize_simps_projections RingEquiv (toFun → apply, invFun → symm_apply)
```

so **both** projections are generated and neither has source text for a grep to find. The evidence
that settles it is a use site — Mathlib calls the lemma at `Mathlib/Algebra/Colimit/Ring.lean:287`.
For a `simps`-generated name the correct search is "who uses it", not "where is it declared".

## This is not a revert, and it is worth being precise about that

Before #4969, `main` proved these two by `simp [weightedMapCompletionEquiv]`. #4969 changed them to
`(rfl)`; this PR moves them to `simp only [weightedMapCompletionEquiv]`. So the *net* effect of the
two PRs on these proofs is `simp` → `simp only` — a genuine if small improvement, since neither
proof needs the full default simp set.

I should also record why the `(rfl)` version existed at all, because the reason was bad. It was a
restoration: the commit that introduced it was dropped from #4885 by this same queue defect, and I
restored it on the strength of having been dropped rather than by re-arguing that it was right.
`proof-quality` was correct to block it, and I said so on #4969 rather than contesting.

## Notes for review

- Gate: `lake build` of `WeightedRestrictedSeries.Completion` and its three importers
  (`Huber.TopologicallyFiniteType`, `WeightedRestrictedSeries.Complete`,
  `WeightedRestrictedSeries.PairOfDefinition`) — exit 0, zero warnings.
- The finding being answered:
  https://github.com/TauCetiProject/TauCeti/pull/4969#discussion_r3878997529
- **Cleanup disclosure.** The standing rule is a full `/cleanup` on every changed `.lean` file, or
  `fm-cleanup` slung to the cleanup-crew. Neither route was available to me this round: no
  `/cleanup` skill is loaded in this session, and `gc sling leancity.cleanup-crew fm-cleanup`
  is rejected with `convoy_id requires a targeted formulas v2 invocation` — it needs a target
  convoy I do not have. Rather than claim a cleanup I did not run, I am saying so. What I did
  verify by hand on the two changed proofs: minimality of both `simp only` argument lists (probe
  above), no line over 100 characters, docstrings unchanged and still accurate, and no other
  declaration in the file touched. A full-file 11-phase cleanup would also have rewritten
  declarations this PR has no business touching, which cuts against one-topic-per-PR.

Roadmap: AdicSpaces
