### PR TITLE
refactor(FieldTheory): split the root-adjoining lemma out of Embedding.lean

### DIFF
--- a/TauCeti/FieldTheory/IntermediateField/Adjoin/Roots.lean
+++ b/TauCeti/FieldTheory/IntermediateField/Adjoin/Roots.lean
@@ -15,8 +15,12 @@ For finitely many elements of a field `F` and `0 < n`, there is a finite extensi
 which each of them has an `n`-th root: adjoin the roots inside an algebraic closure.
 
 Nothing here is specific to purely inseparable extensions or to a characteristic exponent; the
-result is stated for an arbitrary positive power. Its first consumer is the embedding theorem in
-`TauCeti/FieldTheory/PurelyInseparable/Embedding.lean`.
+result is stated for an arbitrary positive power.
+
+It has no consumer in this repository yet. The motivating application is the `L'` of Stacks
+10.161.13 (tag 032O), feeding `RingTheory/IntegralClosure/NormalizationFinite`: the embedding
+theorem in `TauCeti/FieldTheory/PurelyInseparable/Embedding.lean` assumes exactly such an
+extension as a hypothesis rather than building one, so it does not use this lemma.
 
 ## Main results
 
@@ -36,12 +40,12 @@ universe u
 
 namespace TauCeti
 
-/-- An auxiliary root-adjoining construction: for finitely many elements `s` of a field `F` and
-`0 < n`, there is a finite extension `E` of `F` in which every `c ∈ s` has an `n`-th root (adjoin
-the roots inside an algebraic closure). Both conjuncts concern the same witness `E`, which is why
-they are bundled.
+/-- For finitely many elements `s` of a field `F` and `0 < n`, there is a finite extension `E` of
+`F` in which every `c ∈ s` has an `n`-th root: adjoin the roots inside an algebraic closure. Both
+conjuncts concern the same witness `E`, which is why they are bundled.
 
-This feeds the construction of the extension `L′` in Stacks, Lemma 10.161.13 (tag 032O) —
+This is the shape the construction of the extension `L′` in Stacks, Lemma 10.161.13 (tag 032O)
+needs —
 "There exists a finite purely inseparable field extension `L′/K` and `q = p^e` such that
 `L ⊂ L′(x^{1/q})`" — but is NOT that extension: nothing here asserts that `E / F` is purely
 inseparable, only that it is finite and contains the required roots. -/
@@ -54,8 +58,7 @@ theorem exists_finiteDimensional_forall_exists_pow_eq (F : Type u) [Field F] (s 
   have hroot : ∀ c : F, ∃ d : AlgebraicClosure F,
       d ^ n = algebraMap F (AlgebraicClosure F) c := fun c ↦ IsAlgClosed.exists_pow_nat_eq _ hn
   choose d hd using hroot
-  have hTfin : (d '' (s : Set F)).Finite := s.finite_toSet.image d
-  have : Finite (d '' (s : Set F)) := hTfin
+  have : Finite (d '' (s : Set F)) := (s.finite_toSet.image d).to_subtype
   refine ⟨IntermediateField.adjoin F (d '' (s : Set F)), inferInstance, inferInstance,
     IntermediateField.finiteDimensional_adjoin (fun x _ ↦ Algebra.IsIntegral.isIntegral x),
     fun c hc ↦ ⟨⟨d c, IntermediateField.subset_adjoin F _ ⟨c, hc, rfl⟩⟩, ?_⟩⟩

--- a/TauCeti/FieldTheory/IntermediateField/AdjoinRoots.lean
+++ b/TauCeti/FieldTheory/IntermediateField/AdjoinRoots.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
+import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+
+/-!
+# Adjoining roots of finitely many elements
+
+For finitely many elements of a field `F` and `0 < n`, there is a finite extension of `F` in
+which each of them has an `n`-th root: adjoin the roots inside an algebraic closure.
+
+Nothing here is specific to purely inseparable extensions or to a characteristic exponent; the
+result is stated for an arbitrary positive power. Its first consumer is the embedding theorem in
+`TauCeti/FieldTheory/PurelyInseparable/Embedding.lean`.
+
+## Main results
+
+* `TauCeti.exists_finiteDimensional_forall_exists_pow_eq`: a finite extension of `F` containing
+  `n`-th roots of finitely many given elements of `F`.
+
+## Provenance
+
+Roadmap: EllipticCurves, the Layers 0-1 target *Function-field foundations and isogenies*
+(`TauCetiRoadmap/EllipticCurves/README.md:1096`), through the support module
+`RingTheory/IntegralClosure/NormalizationFinite`.
+-/
+
+public section
+
+universe u
+
+namespace TauCeti
+
+/-- An auxiliary root-adjoining construction: for finitely many elements `s` of a field `F` and
+`0 < n`, there is a finite extension `E` of `F` in which every `c ∈ s` has an `n`-th root (adjoin
+the roots inside an algebraic closure). Both conjuncts concern the same witness `E`, which is why
+they are bundled.
+
+This feeds the construction of the extension `L′` in Stacks, Lemma 10.161.13 (tag 032O) —
+"There exists a finite purely inseparable field extension `L′/K` and `q = p^e` such that
+`L ⊂ L′(x^{1/q})`" — but is NOT that extension: nothing here asserts that `E / F` is purely
+inseparable, only that it is finite and contains the required roots. -/
+theorem exists_finiteDimensional_forall_exists_pow_eq (F : Type u) [Field F] (s : Finset F)
+    {n : ℕ} (hn : 0 < n) :
+    ∃ (E : Type u) (_ : Field E) (_ : Algebra F E),
+      FiniteDimensional F E ∧ ∀ c ∈ s, ∃ d : E, d ^ n = algebraMap F E c := by
+  classical
+  -- pick an `n`-th root of each `c` inside an algebraic closure, then adjoin the finitely many
+  have hroot : ∀ c : F, ∃ d : AlgebraicClosure F,
+      d ^ n = algebraMap F (AlgebraicClosure F) c := fun c ↦ IsAlgClosed.exists_pow_nat_eq _ hn
+  choose d hd using hroot
+  have hTfin : (d '' (s : Set F)).Finite := s.finite_toSet.image d
+  have : Finite (d '' (s : Set F)) := hTfin
+  refine ⟨IntermediateField.adjoin F (d '' (s : Set F)), inferInstance, inferInstance,
+    IntermediateField.finiteDimensional_adjoin (fun x _ ↦ Algebra.IsIntegral.isIntegral x),
+    fun c hc ↦ ⟨⟨d c, IntermediateField.subset_adjoin F _ ⟨c, hc, rfl⟩⟩, ?_⟩⟩
+  ext
+  push_cast
+  exact hd c
+
+end TauCeti

--- a/TauCeti/FieldTheory/PurelyInseparable/Embedding.lean
+++ b/TauCeti/FieldTheory/PurelyInseparable/Embedding.lean
@@ -22,7 +22,7 @@ normalization-finiteness needs, `k'(X_1, …, X_r)`, is not perfect.
 The companion existence statement — for finitely many elements of a field, a finite extension
 containing `n`-th roots of all of them — is
 `TauCeti.exists_finiteDimensional_forall_exists_pow_eq`, in
-`TauCeti/FieldTheory/IntermediateField/AdjoinRoots.lean`; nothing about it is specific to purely
+`TauCeti/FieldTheory/IntermediateField/Adjoin/Roots.lean`; nothing about it is specific to purely
 inseparable extensions.
 
 ## Main results

--- a/TauCeti/FieldTheory/PurelyInseparable/Embedding.lean
+++ b/TauCeti/FieldTheory/PurelyInseparable/Embedding.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.IntermediateField.Adjoin.Basic
-public import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
 public import Mathlib.FieldTheory.PurelyInseparable.Exponent
 
 /-!
@@ -20,13 +19,14 @@ embeds into `K'` over `K`: the embedding is `ψ⁻¹ ∘ φ` for `φ` the Froben
 (`IsPurelyInseparable.instNonemptyAlgHomOfPerfectField`); the target that
 normalization-finiteness needs, `k'(X_1, …, X_r)`, is not perfect.
 
-The companion existence statement produces, for finitely many elements of a field, a finite
-extension containing `n`-th roots of all of them.
+The companion existence statement — for finitely many elements of a field, a finite extension
+containing `n`-th roots of all of them — is
+`TauCeti.exists_finiteDimensional_forall_exists_pow_eq`, in
+`TauCeti/FieldTheory/IntermediateField/AdjoinRoots.lean`; nothing about it is specific to purely
+inseparable extensions.
 
 ## Main results
 
-* `TauCeti.exists_finiteDimensional_forall_exists_pow_eq`: a finite extension of `F`
-  containing `n`-th roots of finitely many given elements of `F`.
 * `TauCeti.IsPurelyInseparable.nonempty_algHom_of_forall_exists_pow_eq`: the embedding of a
   purely inseparable extension of bounded exponent into any field over `K` containing
   `p ^ n`-th roots of the Frobenius images of a generating set.
@@ -46,29 +46,6 @@ universe u
 
 namespace TauCeti
 
-/-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "There exists a finite purely inseparable
-field extension `L′/K` and `q = p^e` such that `L ⊂ L′(x^{1/q})`; some details omitted" — the
-extension `L'`. For finitely many elements `s` of a field `F` and `0 < n`, there is a finite
-extension `E` of `F` in which every `c ∈ s` has an `n`-th root (adjoin roots inside an algebraic
-closure). Both conjuncts concern the same witness `E`, which is why they are bundled. -/
-theorem exists_finiteDimensional_forall_exists_pow_eq (F : Type u) [Field F] (s : Finset F)
-    {n : ℕ} (hn : 0 < n) :
-    ∃ (E : Type u) (_ : Field E) (_ : Algebra F E),
-      FiniteDimensional F E ∧ ∀ c ∈ s, ∃ d : E, d ^ n = algebraMap F E c := by
-  classical
-  -- pick an `n`-th root of each `c` inside an algebraic closure, then adjoin the finitely many
-  have hroot : ∀ c : F, ∃ d : AlgebraicClosure F,
-      d ^ n = algebraMap F (AlgebraicClosure F) c := fun c ↦ IsAlgClosed.exists_pow_nat_eq _ hn
-  choose d hd using hroot
-  have hTfin : (d '' (s : Set F)).Finite := s.finite_toSet.image d
-  have : Finite (d '' (s : Set F)) := hTfin
-  refine ⟨IntermediateField.adjoin F (d '' (s : Set F)), inferInstance, inferInstance,
-    IntermediateField.finiteDimensional_adjoin (fun x _ ↦ Algebra.IsIntegral.isIntegral x),
-    fun c hc ↦ ⟨⟨d c, IntermediateField.subset_adjoin F _ ⟨c, hc, rfl⟩⟩, ?_⟩⟩
-  ext
-  push_cast
-  exact hd c
-
 /-- Source: Stacks, Lemma 10.161.13 (tag 032O), proof: "`L ⊂ L′(x^{1/q})`; some details omitted"
 — the embedding. Let `M / K` be purely inseparable of exponent at most `n`, with Frobenius
 `φ = IsPurelyInseparable.iterateFrobenius K M p hn : M →+* K`, and let `s` generate `M` over
@@ -87,7 +64,8 @@ theorem IsPurelyInseparable.nonempty_algHom_of_forall_exists_pow_eq (K M : Type*
   set φ := IsPurelyInseparable.iterateFrobenius K M p hn with hφ
   set ψ := iterateFrobenius K' p n with hψ
   set θ : M →+* K' := (algebraMap K K').comp φ with hθ
-  have hψ_apply : ∀ y : K', ψ y = y ^ p ^ n := fun _ ↦ rfl
+  have hψ_apply : ∀ y : K', ψ y = y ^ p ^ n := fun y ↦
+    iterateFrobenius_def (R := K') (p := p) (n := n) (x := y)
   -- The single computation both the `K`-algebra law (B2.2) and the `K`-linearity of the
   -- assembled embedding (B2.6) rest on: on the image of `K`, `θ` and `ψ` agree.
   have hKθ : ∀ a : K, θ (algebraMap K M a) = ψ (algebraMap K K' a) := fun a ↦ by
@@ -102,7 +80,7 @@ theorem IsPurelyInseparable.nonempty_algHom_of_forall_exists_pow_eq (K M : Type*
   have hsG : s ⊆ (G : Set M) := by
     intro x hx
     obtain ⟨y, hy⟩ := h x hx
-    exact RingHom.mem_fieldRange.mpr ⟨y, by rw [hψ_apply, hy]; rfl⟩
+    exact RingHom.mem_fieldRange.mpr ⟨y, by simpa [hθ, hφ, hψ_apply] using hy⟩
   have hGtop : G = ⊤ := by
     rw [eq_top_iff, ← hs]
     exact IntermediateField.adjoin_le_iff.mpr hsG


### PR DESCRIPTION
Re-applies review answers from #4888 that the merge queue discarded.

## What this changes

`TauCeti.exists_finiteDimensional_forall_exists_pow_eq` — for finitely many elements of a field `F` and `0 < n`, a finite extension of `F` in which each has an `n`-th root — moves out of `TauCeti/FieldTheory/PurelyInseparable/Embedding.lean` into `TauCeti/FieldTheory/IntermediateField/Adjoin/Roots.lean`.

Nothing about the statement is specific to purely inseparable extensions or to a characteristic exponent; it lived in `Embedding.lean` only because that module was written first. Moving it also narrows `Embedding.lean`, which no longer needs `Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure`.

**The moved statement is unchanged.** The lemma's type is byte-identical to `main`'s.

## Two proof-step edits in `Embedding.lean` — disclosed

This PR also contains two proof-body changes to `IsPurelyInseparable.nonempty_algHom_of_forall_exists_pow_eq`, which stays in `Embedding.lean`:

```
-  have hψ_apply : ∀ y : K', ψ y = y ^ p ^ n := fun _ ↦ rfl
+  have hψ_apply : ∀ y : K', ψ y = y ^ p ^ n := fun y ↦
+    iterateFrobenius_def (R := K') (p := p) (n := n) (x := y)

-    exact RingHom.mem_fieldRange.mpr ⟨y, by rw [hψ_apply, hy]; rfl⟩
+    exact RingHom.mem_fieldRange.mpr ⟨y, by simpa [hθ, hφ, hψ_apply] using hy⟩
```

Neither changes a statement. Both replace a proof step that leaned on definitional unfolding with one that goes through the named API (`iterateFrobenius_def`), which is what makes the step survive the narrowed import.

An earlier version of this description claimed "both declarations remain exactly as they are on `main`". **That was wrong**, and the `correctness`, `scope` and `proof-quality` reviews were right to flag it. The cause: the repair patch was taken as the range diff `7030f0cab..12d22655d`, which spans *both* discarded commits, and `274eb46c9` carried these proof edits alongside the import narrowing. I described the patch by its intent instead of reading its hunks. They are genuine dropped review answers, so they are disclosed here rather than deleted.

## Why it is a separate PR

Both changes were already made on #4888, as `274eb46c9` and `12d22655d`. Both were pushed **after** that PR entered the merge queue, so the queue merged the enqueue-time tree and dropped them silently while reporting the PR merged:

```
23:27:44Z  7030f0cab  last pre-enqueue commit
23:54:44Z  AddedToMergeQueueEvent
00:35:24Z  274eb46c9  review: narrow the AlgebraicClosure import   <- discarded
01:21:23Z  12d22655d  review: split the root-adjoining lemma        <- discarded
03:30:58Z  MERGED -> 30905ec98
```

`main`'s `Embedding.lean` is byte-identical to `7030f0cab`, which identifies the merged tree as the pre-enqueue one. Nothing mathematical was lost — both declarations are on `main` — but these review answers were, and #4888 is closed.

## Review round 1

- **placement / naming** — the file now sits in `IntermediateField/Adjoin/Roots.lean` beside `Adjoin/EqTop.lean`, `Adjoin/Inv.lean`, `Adjoin/Transcendental.lean`, matching Mathlib's layout; the old flat name also read as a plural of the unrelated `AdjoinRoot`. No declaration renamed.
- **correctness / api-design / documentation / scope** — the module docstring claimed `Embedding.lean` as its "first consumer". That was false: `Embedding.lean` does not import the module and takes the root condition as a hypothesis. The docstring now states there is no in-repo consumer yet and names the motivating application as prospective.
- **api-design** — the theorem docstring no longer opens "An auxiliary root-adjoining construction"; it is the module's only main result.
- **proof-quality** — `have : Finite (d '' s) := hTfin` typechecked only via the defeq `Set.Finite s ≡ Finite ↥s`; it now uses `(s.finite_toSet.image d).to_subtype`, and the one-use `hTfin` is gone.

## Verification

`lake build TauCeti.FieldTheory.IntermediateField.Adjoin.Roots TauCeti.FieldTheory.PurelyInseparable.Embedding` — exit 0, 2015 jobs, no errors, warnings, or `info:` diagnostics. No line over 100 characters; no `sorry`.

Roadmap: EllipticCurves
