### PR TITLE
feat(Ideal): the power-stabilization step of Wedhorn 7.49(2)

### DIFF
--- a/TauCeti/RingTheory/Ideal/PowerStabilization.lean
+++ b/TauCeti/RingTheory/Ideal/PowerStabilization.lean
@@ -61,11 +61,12 @@ variable {B : Type*} [Ring B]
 
 /-- If some `i ∈ I` is such that `1 + i` annihilates `I ^ n`, then `I ^ (n + 1) = I ^ n`.
 
-Commutativity is not needed. The two cases are genuinely different: for `n ≥ 1` the element
-`i * x` lands in `I * I ^ n = I ^ (n + 1)`, whereas at `n = 0` that identity fails for a left
-ideal, and the conclusion `I = ⊤` comes instead from `1 + i` annihilating `1`. -/
+Commutativity is not needed. -/
 theorem pow_succ_eq_pow_of_forall_mul_eq_zero {I : _root_.Ideal B} {i : B} (hi : i ∈ I) {n : ℕ}
     (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) : I ^ (n + 1) = I ^ n := by
+  -- The two cases are genuinely different: for `n ≥ 1` the element `i * x` lands in
+  -- `I * I ^ n = I ^ (n + 1)`, whereas at `n = 0` that identity fails for a left ideal, and the
+  -- conclusion `I = ⊤` comes instead from `1 + i` annihilating `1`.
   refine le_antisymm (_root_.Ideal.pow_le_pow_right (Nat.le_succ n)) fun x hx ↦ ?_
   rcases Nat.eq_zero_or_pos n with rfl | hn
   · have hone : (1 : B) + i = 0 := by

--- a/TauCeti/RingTheory/Ideal/PowerStabilization.lean
+++ b/TauCeti/RingTheory/Ideal/PowerStabilization.lean
@@ -6,14 +6,24 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.Ideal.Operations
-public import Mathlib.RingTheory.Localization.Basic
 
 /-!
-# Stabilization of the powers of a finitely generated ideal
+# Stabilization of the powers of an ideal
 
-The commutative-algebra half of Wedhorn's Proposition 7.49(2). If a finitely generated ideal `I`
-of a commutative ring `B` becomes zero after localizing at the submonoid `1 + I`, then the powers
-of `I` stabilize: `I ^ k = I ^ n` for all `k ≥ n`.
+Two facts about when the powers of an ideal `I` become constant.
+
+The first is general: if `I ^ (n + 1) = I ^ n`, then `I ^ k = I ^ n` for every `k ≥ n`. Nothing
+about the ring beyond `Semiring` is used, and no annihilator appears.
+
+The second is the conditional stabilization criterion: if some `i ∈ I` is such that `1 + i`
+annihilates `I ^ n`, then `I ^ (n + 1) = I ^ n`, and hence the powers are constant from `n` on.
+The annihilating element is a **hypothesis** here.
+
+Finite generation of `I`, and the localization at `1 + I` that produces such an `i` in Wedhorn's
+proof of Proposition 7.49(2), are deliberately **outside** this module: nothing below mentions a
+localization, and no theorem here derives the annihilator. The submonoid `1 + I` is defined
+because it is the natural home of that element, and because being a *submonoid* is what allows
+finitely many annihilating witnesses to be combined into one.
 
 ## Main definitions
 
@@ -21,38 +31,62 @@ of `I` stabilize: `I ^ k = I ^ n` for all `k ≥ n`.
 
 ## Main results
 
-* `Ideal.pow_eq_pow_of_forall_mul_eq_zero`: the stabilization step, from an element `i ∈ I` that
-  annihilates `I ^ n` through `1 + i`.
+* `Ideal.pow_eq_pow_of_pow_succ_eq_pow`: `I ^ (n + 1) = I ^ n` propagates to all `k ≥ n`.
+* `Ideal.pow_succ_eq_pow_of_forall_mul_eq_zero`: an `i ∈ I` whose `1 + i` annihilates `I ^ n`
+  gives `I ^ (n + 1) = I ^ n`.
+* `Ideal.pow_eq_pow_of_forall_mul_eq_zero`: hence `I ^ k = I ^ n` for all `k ≥ n`.
 
 ## References
 
-* [Wedhorn, *Adic Spaces*][wedhorn_adic], proof of Proposition 7.49(2).
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], proof of Proposition 7.49(2), where the conditional
+  criterion is the closing step.
 -/
 
 public section
 
-variable {B : Type*} [CommRing B]
-
 namespace Ideal
 
+section Semiring
+
+variable {R : Type*} [Semiring R]
+
+/-- Once the powers of an ideal repeat once, they are constant from that point on. -/
+theorem pow_eq_pow_of_pow_succ_eq_pow {I : _root_.Ideal R} {n : ℕ} (h : I ^ (n + 1) = I ^ n)
+    {k : ℕ} (hk : n ≤ k) : I ^ k = I ^ n := by
+  induction k, hk using Nat.le_induction with
+  | base => rfl
+  | succ m _ ih =>
+    have hstep : I ^ (m + 1) = I ^ (n + 1) := by rw [Submodule.pow_succ, Submodule.pow_succ, ih]
+    rw [hstep, h]
+
+end Semiring
+
+section Ring
+
+variable {B : Type*} [Ring B]
+
 /-- The submonoid `1 + I` of `B`, for an ideal `I`. It is multiplicatively closed because
-`(1 + a)(1 + b) = 1 + (a + ab + b)`. This is the submonoid Wedhorn localizes at in the proof of
-Proposition 7.49(2). -/
+`ab - 1 = a(b - 1) + (a - 1)`, which needs only closure of `I` under left multiplication. -/
 def oneAdd (I : _root_.Ideal B) : Submonoid B where
   carrier := {x | x - 1 ∈ I}
   one_mem' := by simp
   mul_mem' {a b} ha hb := by
     simp only [Set.mem_ofPred_eq] at ha hb ⊢
-    have h : a * b - 1 = (a - 1) * b + (b - 1) := by ring
+    have h : a * b - 1 = a * (b - 1) + (a - 1) := by
+      rw [mul_sub, mul_one]; abel
     rw [h]
-    exact I.add_mem (I.mul_mem_right _ ha) hb
+    exact I.add_mem (I.mul_mem_left _ hb) ha
 
 @[simp]
 theorem mem_oneAdd {I : _root_.Ideal B} {x : B} : x ∈ I.oneAdd ↔ x - 1 ∈ I := Iff.rfl
 
-/-- **The stabilization step in Wedhorn's Proposition 7.49(2).** If some `i ∈ I` is such that
-`1 + i` annihilates `I ^ n`, then `I ^ (n + 1) = I ^ n`: for `x ∈ I ^ n` the relation
-`(1 + i) * x = 0` reads `x = -(x * i)`, whose right-hand side lies in `I ^ n * I`. -/
+end Ring
+
+section CommRing
+
+variable {B : Type*} [CommRing B]
+
+/-- If some `i ∈ I` is such that `1 + i` annihilates `I ^ n`, then `I ^ (n + 1) = I ^ n`. -/
 theorem pow_succ_eq_pow_of_forall_mul_eq_zero {I : _root_.Ideal B} {i : B} (hi : i ∈ I) {n : ℕ}
     (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) : I ^ (n + 1) = I ^ n := by
   refine le_antisymm (_root_.Ideal.pow_le_pow_right (Nat.le_succ n)) fun x hx ↦ ?_
@@ -63,13 +97,11 @@ theorem pow_succ_eq_pow_of_forall_mul_eq_zero {I : _root_.Ideal B} {i : B} (hi :
   rw [hx0, pow_succ]
   exact neg_mem (mul_mem_mul hx hi)
 
-/-- The powers of `I` are constant from `n` on, under the same hypothesis. -/
+/-- Under the same hypothesis, the powers of `I` are constant from `n` on. -/
 theorem pow_eq_pow_of_forall_mul_eq_zero {I : _root_.Ideal B} {i : B} (hi : i ∈ I) {n : ℕ}
-    (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) {k : ℕ} (hk : n ≤ k) : I ^ k = I ^ n := by
-  induction k, hk using Nat.le_induction with
-  | base => rfl
-  | succ m hm ih =>
-    rw [← ih] at h ⊢
-    exact pow_succ_eq_pow_of_forall_mul_eq_zero hi h
+    (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) {k : ℕ} (hk : n ≤ k) : I ^ k = I ^ n :=
+  pow_eq_pow_of_pow_succ_eq_pow (pow_succ_eq_pow_of_forall_mul_eq_zero hi h) hk
+
+end CommRing
 
 end Ideal

--- a/TauCeti/RingTheory/Ideal/PowerStabilization.lean
+++ b/TauCeti/RingTheory/Ideal/PowerStabilization.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Ideal.Operations
+public import Mathlib.RingTheory.Localization.Basic
+
+/-!
+# Stabilization of the powers of a finitely generated ideal
+
+The commutative-algebra half of Wedhorn's Proposition 7.49(2). If a finitely generated ideal `I`
+of a commutative ring `B` becomes zero after localizing at the submonoid `1 + I`, then the powers
+of `I` stabilize: `I ^ k = I ^ n` for all `k ≥ n`.
+
+## Main definitions
+
+* `Ideal.oneAdd`: the submonoid `1 + I` of `B`.
+
+## Main results
+
+* `Ideal.pow_eq_pow_of_forall_mul_eq_zero`: the stabilization step, from an element `i ∈ I` that
+  annihilates `I ^ n` through `1 + i`.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], proof of Proposition 7.49(2).
+-/
+
+public section
+
+variable {B : Type*} [CommRing B]
+
+namespace Ideal
+
+/-- The submonoid `1 + I` of `B`, for an ideal `I`. It is multiplicatively closed because
+`(1 + a)(1 + b) = 1 + (a + ab + b)`. This is the submonoid Wedhorn localizes at in the proof of
+Proposition 7.49(2). -/
+def oneAdd (I : _root_.Ideal B) : Submonoid B where
+  carrier := {x | x - 1 ∈ I}
+  one_mem' := by simp
+  mul_mem' {a b} ha hb := by
+    simp only [Set.mem_ofPred_eq] at ha hb ⊢
+    have h : a * b - 1 = (a - 1) * b + (b - 1) := by ring
+    rw [h]
+    exact I.add_mem (I.mul_mem_right _ ha) hb
+
+@[simp]
+theorem mem_oneAdd {I : _root_.Ideal B} {x : B} : x ∈ I.oneAdd ↔ x - 1 ∈ I := Iff.rfl
+
+/-- **The stabilization step in Wedhorn's Proposition 7.49(2).** If some `i ∈ I` is such that
+`1 + i` annihilates `I ^ n`, then `I ^ (n + 1) = I ^ n`: for `x ∈ I ^ n` the relation
+`(1 + i) * x = 0` reads `x = -(x * i)`, whose right-hand side lies in `I ^ n * I`. -/
+theorem pow_succ_eq_pow_of_forall_mul_eq_zero {I : _root_.Ideal B} {i : B} (hi : i ∈ I) {n : ℕ}
+    (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) : I ^ (n + 1) = I ^ n := by
+  refine le_antisymm (_root_.Ideal.pow_le_pow_right (Nat.le_succ n)) fun x hx ↦ ?_
+  have hx0 : x = -(x * i) := by
+    have hxx : (1 + i) * x = 0 := h x hx
+    have hsum : x * i + x = 0 := by rw [← hxx]; ring
+    exact eq_neg_of_add_eq_zero_right hsum
+  rw [hx0, pow_succ]
+  exact neg_mem (mul_mem_mul hx hi)
+
+/-- The powers of `I` are constant from `n` on, under the same hypothesis. -/
+theorem pow_eq_pow_of_forall_mul_eq_zero {I : _root_.Ideal B} {i : B} (hi : i ∈ I) {n : ℕ}
+    (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) {k : ℕ} (hk : n ≤ k) : I ^ k = I ^ n := by
+  induction k, hk using Nat.le_induction with
+  | base => rfl
+  | succ m hm ih =>
+    rw [← ih] at h ⊢
+    exact pow_succ_eq_pow_of_forall_mul_eq_zero hi h
+
+end Ideal

--- a/TauCeti/RingTheory/Ideal/PowerStabilization.lean
+++ b/TauCeti/RingTheory/Ideal/PowerStabilization.lean
@@ -17,17 +17,11 @@ about the ring beyond `Semiring` is used, and no annihilator appears.
 
 The second is the conditional stabilization criterion: if some `i ∈ I` is such that `1 + i`
 annihilates `I ^ n`, then `I ^ (n + 1) = I ^ n`, and hence the powers are constant from `n` on.
-The annihilating element is a **hypothesis** here.
+The annihilating element is a **hypothesis** here, and neither statement needs commutativity.
 
 Finite generation of `I`, and the localization at `1 + I` that produces such an `i` in Wedhorn's
 proof of Proposition 7.49(2), are deliberately **outside** this module: nothing below mentions a
-localization, and no theorem here derives the annihilator. The submonoid `1 + I` is defined
-because it is the natural home of that element, and because being a *submonoid* is what allows
-finitely many annihilating witnesses to be combined into one.
-
-## Main definitions
-
-* `Ideal.oneAdd`: the submonoid `1 + I` of `B`.
+localization, and no theorem here derives the annihilator.
 
 ## Main results
 
@@ -65,43 +59,34 @@ section Ring
 
 variable {B : Type*} [Ring B]
 
-/-- The submonoid `1 + I` of `B`, for an ideal `I`. It is multiplicatively closed because
-`ab - 1 = a(b - 1) + (a - 1)`, which needs only closure of `I` under left multiplication. -/
-def oneAdd (I : _root_.Ideal B) : Submonoid B where
-  carrier := {x | x - 1 ∈ I}
-  one_mem' := by simp
-  mul_mem' {a b} ha hb := by
-    simp only [Set.mem_ofPred_eq] at ha hb ⊢
-    have h : a * b - 1 = a * (b - 1) + (a - 1) := by
-      rw [mul_sub, mul_one]; abel
-    rw [h]
-    exact I.add_mem (I.mul_mem_left _ hb) ha
+/-- If some `i ∈ I` is such that `1 + i` annihilates `I ^ n`, then `I ^ (n + 1) = I ^ n`.
 
-@[simp]
-theorem mem_oneAdd {I : _root_.Ideal B} {x : B} : x ∈ I.oneAdd ↔ x - 1 ∈ I := Iff.rfl
-
-end Ring
-
-section CommRing
-
-variable {B : Type*} [CommRing B]
-
-/-- If some `i ∈ I` is such that `1 + i` annihilates `I ^ n`, then `I ^ (n + 1) = I ^ n`. -/
+Commutativity is not needed. The two cases are genuinely different: for `n ≥ 1` the element
+`i * x` lands in `I * I ^ n = I ^ (n + 1)`, whereas at `n = 0` that identity fails for a left
+ideal, and the conclusion `I = ⊤` comes instead from `1 + i` annihilating `1`. -/
 theorem pow_succ_eq_pow_of_forall_mul_eq_zero {I : _root_.Ideal B} {i : B} (hi : i ∈ I) {n : ℕ}
     (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) : I ^ (n + 1) = I ^ n := by
   refine le_antisymm (_root_.Ideal.pow_le_pow_right (Nat.le_succ n)) fun x hx ↦ ?_
-  have hx0 : x = -(x * i) := by
-    have hxx : (1 + i) * x = 0 := h x hx
-    have hsum : x * i + x = 0 := by rw [← hxx]; ring
-    exact eq_neg_of_add_eq_zero_right hsum
-  rw [hx0, pow_succ]
-  exact neg_mem (mul_mem_mul hx hi)
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  · have hone : (1 : B) + i = 0 := by
+      simpa using h 1 (by rw [Submodule.pow_zero, Ideal.one_eq_top]; trivial)
+    have h1 : (1 : B) ∈ I := by
+      rw [eq_neg_iff_add_eq_zero.mpr hone]
+      exact neg_mem hi
+    rw [Submodule.pow_one, (eq_top_iff_one I).mpr h1]
+    trivial
+  · have hx0 : x = -(i * x) := by
+      have hxx : (1 + i) * x = 0 := h x hx
+      have hsum : i * x + x = 0 := by rw [← hxx, add_mul, one_mul, add_comm]
+      exact eq_neg_of_add_eq_zero_right hsum
+    rw [I.pow_succ' hn.ne', hx0]
+    exact neg_mem (mul_mem_mul hi hx)
 
 /-- Under the same hypothesis, the powers of `I` are constant from `n` on. -/
 theorem pow_eq_pow_of_forall_mul_eq_zero {I : _root_.Ideal B} {i : B} (hi : i ∈ I) {n : ℕ}
     (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) {k : ℕ} (hk : n ≤ k) : I ^ k = I ^ n :=
   pow_eq_pow_of_pow_succ_eq_pow (pow_succ_eq_pow_of_forall_mul_eq_zero hi h) hk
 
-end CommRing
+end Ring
 
 end Ideal


### PR DESCRIPTION
The commutative-algebra core of Wedhorn's Proposition 7.49(2).

* `Ideal.pow_eq_pow_of_pow_succ_eq_pow` — if `I ^ (n + 1) = I ^ n` then `I ^ k = I ^ n` for every
  `k ≥ n`, over a bare `Semiring`;
* `Ideal.pow_succ_eq_pow_of_forall_mul_eq_zero` — if some `i ∈ I` is such that `1 + i` annihilates
  `I ^ n`, then `I ^ (n + 1) = I ^ n`;
* `Ideal.pow_eq_pow_of_forall_mul_eq_zero` — hence `I ^ k = I ^ n` for every `k ≥ n`.

## What this is, and what it deliberately is not

Wedhorn's proof of 7.49(2) runs: localize at `S = 1 + I`; *the claim* gives that `φ(I)` lies in
every prime of `S⁻¹B`; hence `φ(Iⁿ) = 0` for some `n` since `I` is finitely generated; hence some
`i ∈ I` has `(1 + i) Iⁿ = 0`; **hence `I^k = I^n` for `k ≥ n`.**

This PR is that last step. It takes the annihilation as a hypothesis and proves the stabilization,
which is pure ideal arithmetic — no Huber ring, no adic topology, no valuation, and (after review)
no commutativity either.

**The localization half is #5095**, "feat(Ideal): localising at 1 + I, and the annihilator of a
power of I". It supplies precisely the two intermediate steps this PR takes as given, and its
conclusion is this PR's hypothesis on the nose:

| #5095 concludes | this PR assumes |
|---|---|
| `∃ n s, s ∈ Ideal.oneAdd I ∧ ∀ x ∈ I ^ n, s * x = 0` | `hi : i ∈ I`, `∀ x ∈ I ^ n, (1 + i) * x = 0` |

with `i := s - 1`, since `s ∈ Ideal.oneAdd I` unfolds to `s - 1 ∈ I`. `Ideal.oneAdd` itself was
declared here in the first revision and was removed by `122f833` in response to the `placement`
finding on this PR, whose fix asked for it to live in a dedicated ideal/localization module. That
module is the file #5095 adds, `TauCeti/RingTheory/Ideal/OneAddLocalisation.lean`, and it is where
`Ideal.oneAdd` now lives; it is on neither branch's `main`.

**Neither PR discharges the claim.** The claim needs Wedhorn's Lemma 7.45 and the
microbial/vertical-generization substrate, which is being built separately; nothing here depends on
it.

## Proof note

The stabilization is short, and is the reason the hypothesis is stated as an annihilation rather
than an equality of ideals: for `n ≥ 1` and `x ∈ I ^ n`, `(1 + i) * x = 0` rearranges to
`x = -(i * x)`, whose right-hand side lies in `I * I ^ n = I ^ (n + 1)`. That gives
`I ^ n ≤ I ^ (n + 1)`; the reverse inclusion is `Ideal.pow_le_pow_right`, and `Nat.le_induction`
carries it to all `k ≥ n`.

The case `n = 0` is genuinely different rather than a degenerate instance, and is proved
separately: `I * I ^ n = I ^ (n + 1)` is not available for a left ideal at `n = 0`, and the
conclusion `I = ⊤` comes instead from `1 + i` annihilating `1`, which forces `1 = -i ∈ I`.

Only the left-hand identity is used, so both annihilation lemmas are stated over `Ring`, not
`CommRing`, and the propagation lemma over `Semiring`.

## Prior art

The conclusion is absent from `TauCeti` — a probe by statement shape returns only unrelated
polynomial and Hecke lemmas, against a control of 79 files under `TauCeti/RingTheory/` mentioning
`Ideal`.

## Gate

`lake build` of the new module — 1321 jobs, no errors, warnings or sorries. New leaf file, no
importers, so that is the complete module-scoped gate.

**Base note:** that receipt, and the CI green at `62aaaa2`, both pre-date the mathlib pin bump that
landed on `main` at `2026-08-29T10:09:09Z` (#4926, `653c36f0` → `97b6a17d`). This branch is
therefore based on pre-bump `main`. It will be rebased onto current `main` — and re-gated — once
#5095 lands, so that the rebase and the localization half arrive in the review's base together
rather than costing two separate review rounds.

Roadmap: AdicSpaces
