### PR TITLE
feat(EllipticCurve): the conjugation-fixed elements are the functions of x

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -485,6 +485,53 @@ theorem isDedekindDomain_coordinateRing [W.IsElliptic] : IsDedekindDomain W.Coor
 
 end IntegrallyClosed
 
+section EvenFunctions
+
+variable {F : Type*} [Field F] (W : _root_.WeierstrassCurve.Affine F)
+
+namespace CoordinateRing
+
+/-- **The conjugation-fixed elements are exactly the functions of `x`.** In characteristic other
+than two, an element of the coordinate ring is fixed by `conj` precisely when it lies in the image
+of `F[X]`, that is, when it does not involve `y`.
+
+This completes the involution API: `conj` is the involution, `conj_conj` its involutivity,
+`conj_smul_basis` its action on the basis and `mul_conj` its norm; this is its fixed-point set.
+
+Characteristic two is genuinely excluded rather than merely inconvenient: there `conj` fixes
+`mk W Y` whenever `a₁ = a₃ = 0`, so the statement fails. -/
+theorem conj_eq_self_iff [NeZero (2 : F)] (x : W.CoordinateRing) :
+    conj W x = x ↔ ∃ p : F[X], x = p • (1 : W.CoordinateRing) := by
+  refine ⟨fun h => ?_, ?_⟩
+  · obtain ⟨p, q, rfl⟩ := exists_smul_basis_eq x
+    refine ⟨p, ?_⟩
+    -- The trace identity turns `conj x = x` into `2x = 2p - q·(a₁X + a₃)`, whose basis
+    -- coordinates then force `q = 0` because `2 ≠ 0` in the domain `F[X]`.
+    have hq : q = 0 := by
+      -- Conjugation negates the `Y`-coordinate, so `conj x = x` forces `q = -q`. Comparing
+      -- coordinates is `smul_basis_eq_zero`; the passage from `q + q = 0` to `q = 0` is where
+      -- characteristic two is excluded, and it is taken in the `F`-module `F[X]` so that only
+      -- `(2 : F) ≠ 0` is needed rather than a numeral in `F[X]`.
+      rw [conj_smul_basis, negPolynomial, ← sub_eq_zero] at h
+      have h2 : (-(q * (C W.a₁ * X + C W.a₃))) • (1 : W.CoordinateRing) +
+          (-(q + q)) • mk W Y = 0 := by
+        rw [← h, smul_mk_eq_mk, smul_mk_eq_mk, ← map_sub]
+        congr 1
+        simp only [map_neg, map_mul, map_add]
+        ring
+      have hqq : (2 : F) • q = 0 := by
+        rw [two_smul]
+        have := (smul_basis_eq_zero h2).2
+        rwa [neg_eq_zero] at this
+      exact (smul_eq_zero.mp hqq).resolve_left (NeZero.ne (2 : F))
+    rw [hq, zero_smul, add_zero]
+  · rintro ⟨p, rfl⟩
+    rw [map_smul, map_one]
+
+end CoordinateRing
+
+end EvenFunctions
+
 end WeierstrassCurve.Affine
 
 end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.lean
@@ -485,11 +485,19 @@ theorem isDedekindDomain_coordinateRing [W.IsElliptic] : IsDedekindDomain W.Coor
 
 end IntegrallyClosed
 
+end WeierstrassCurve.Affine
+
+end TauCeti
+
 section EvenFunctions
 
-variable {F : Type*} [Field F] (W : _root_.WeierstrassCurve.Affine F)
+variable {F : Type*} [Field F] (W : WeierstrassCurve.Affine F)
 
-namespace CoordinateRing
+namespace WeierstrassCurve.Affine.CoordinateRing
+
+-- `conj` lives in TauCeti's namespace, but this lemma must not: its own namespace is a Mathlib
+-- type's, and dot notation there does not elaborate from inside `namespace TauCeti`.
+open TauCeti.WeierstrassCurve.Affine.CoordinateRing
 
 /-- **The conjugation-fixed elements are exactly the functions of `x`.** In characteristic other
 than two, an element of the coordinate ring is fixed by `conj` precisely when it lies in the image
@@ -528,10 +536,6 @@ theorem conj_eq_self_iff [NeZero (2 : F)] (x : W.CoordinateRing) :
   · rintro ⟨p, rfl⟩
     rw [map_smul, map_one]
 
-end CoordinateRing
+end WeierstrassCurve.Affine.CoordinateRing
 
 end EvenFunctions
-
-end WeierstrassCurve.Affine
-
-end TauCeti


### PR DESCRIPTION
In characteristic other than two, an element of a Weierstrass coordinate ring is fixed by the
conjugation involution exactly when it lies in the image of `F[X]` — that is, when it is a function
of `x` alone and does not involve `y`.

### Why this is worth landing without a downstream consumer

It completes an API `main` already exposes. `Affine/CoordinateRing.lean` has the involution
(`conj`), its involutivity (`conj_conj`), its action on the basis (`conj_smul_basis`) and its norm
(`mul_conj`); the fixed-point set is the one missing piece of that set. This is the same
justification that carried #4912 and #4968 — a public theorem completing an API already exposed at
one type — so the land-the-consumer rule settled by #4264 does not bite here.

### Why the hypothesis is `[NeZero (2 : F)]` and not a condition on `F[X]`

The proof compares basis coordinates and reaches `q + q = 0`. Rather than argue that `(2 : F[X])`
is a non-zero-divisor, it takes that step in the `F`-module structure on `F[X]`: `q + q = (2 : F) • q`,
so `smul_eq_zero` needs only `(2 : F) ≠ 0`. The characteristic assumption therefore sits on the
base field, where it belongs, and no numeral in `F[X]` is involved.

Characteristic two is genuinely excluded rather than merely inconvenient: there `conj` fixes
`mk W Y` whenever `a₁ = a₃ = 0`, so the statement is false, not just unproven. The docstring says so.

### Placement

The lemma needs `[Field F]` — `F[X]` must be a domain for the coordinate comparison — while the
`CoordinateRing` namespace section of that file is stated over `CommRing`. It is therefore added in
a new `section EvenFunctions` at the end of the file, reopening `namespace CoordinateRing`, beside
the existing `Field` sections.

Roadmap: EllipticCurves

### Attribution

Adapted from the AINTLIB `HasseWeil` project
(`projects/HasseWeil/HasseWeil/EvenFunctions.lean`, Chris Birkbeck, Apache-2.0) at commit
`513e83879e2f`: the statement of `negInvolution_eq_iff` (:156), restated over `main`'s `conj`.

**Only that one declaration is ported.** The source module has eleven; nine or ten of them are
already on `main` in a stronger form and are deliberately not re-ported:

* source `negInvolution` (a `→+*`) → `main`'s `conj`, which is an `AlgEquiv` over `F[X]`
* `negInvolution_involutive` → `conj_conj`; `negInvolution_smul_basis` → `conj_smul_basis`
* `negInvolution_mk_Y` / `_mk_C` / `_of` → `main`'s private `conjHom_mk_Y` / `conjHom_mk_C` /
  `conjHom_conjHom`, which stay private: this proof goes through the public `conj` API instead.

The source proof spends most of its length extracting `q = 0` from `q + q = 0` coefficient by
coefficient. Over `main`'s API that reduces to `smul_basis_eq_zero` plus `smul_eq_zero`, which is
why the proof here is short.
