### PR TITLE
feat: compute the split quadratic Morse flow

### DIFF
--- a/TauCeti/Analysis/Calculus/Morse/GradientFlow.lean
+++ b/TauCeti/Analysis/Calculus/Morse/GradientFlow.lean
@@ -256,15 +256,8 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteS
 `γ' = -∇f(γ)`.  Regularity and uniqueness assumptions used to construct the flow remain
 separate; this predicate records precisely the differential equation needed by its dynamical
 consequences. -/
-def IsNegativeGradient (φ : _root_.Flow ℝ E) (f : E → ℝ) : Prop :=
+@[expose] def IsNegativeGradient (φ : _root_.Flow ℝ E) (f : E → ℝ) : Prop :=
   ∀ x, IsIntegralCurve (fun t ↦ φ t x) (fun _ y ↦ -∇ f y)
-
-/-- A flow is a negative gradient flow exactly when each of its orbit curves solves the
-negative gradient equation. -/
-theorem isNegativeGradient_iff :
-    IsNegativeGradient φ f ↔
-      ∀ x, IsIntegralCurve (fun t ↦ φ t x) (fun _ y ↦ -∇ f y) :=
-  Iff.rfl
 
 /-- Each orbit curve of a negative gradient flow solves the negative gradient equation. -/
 theorem IsNegativeGradient.isIntegralCurve (hφ : IsNegativeGradient φ f) (x : E) :

--- a/TauCeti/Analysis/Calculus/Morse/GradientFlow.lean
+++ b/TauCeti/Analysis/Calculus/Morse/GradientFlow.lean
@@ -55,6 +55,7 @@ route to Morse homology.
   `TauCeti.IsIntegralCurve.eq_of_periodic_neg_gradient`: a periodic negative gradient trajectory
   consists entirely of critical points and is constant.
 * `Flow.IsNegativeGradient`: every orbit of a flow solves the negative gradient equation.
+* `Flow.isNegativeGradient_iff`: the introduction and elimination rule for that predicate.
 * `Flow.IsNegativeGradient.isIntegralCurve`: the orbit curve through a point, as an integral
   curve of the negative gradient field.
 * `Flow.IsNegativeGradient.orbit_antitone`: the defining function is antitone along every orbit
@@ -256,8 +257,13 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteS
 `γ' = -∇f(γ)`.  Regularity and uniqueness assumptions used to construct the flow remain
 separate; this predicate records precisely the differential equation needed by its dynamical
 consequences. -/
-@[expose] def IsNegativeGradient (φ : _root_.Flow ℝ E) (f : E → ℝ) : Prop :=
+def IsNegativeGradient (φ : _root_.Flow ℝ E) (f : E → ℝ) : Prop :=
   ∀ x, IsIntegralCurve (fun t ↦ φ t x) (fun _ y ↦ -∇ f y)
+
+/-- The introduction and elimination rule for a negative-gradient flow. -/
+theorem isNegativeGradient_iff : IsNegativeGradient φ f ↔
+    ∀ x, IsIntegralCurve (fun t ↦ φ t x) (fun _ y ↦ -∇ f y) :=
+  Iff.rfl
 
 /-- Each orbit curve of a negative gradient flow solves the negative gradient equation. -/
 theorem IsNegativeGradient.isIntegralCurve (hφ : IsNegativeGradient φ f) (x : E) :

--- a/TauCeti/Analysis/Calculus/Morse/GradientFlow.lean
+++ b/TauCeti/Analysis/Calculus/Morse/GradientFlow.lean
@@ -256,7 +256,7 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteS
 `γ' = -∇f(γ)`.  Regularity and uniqueness assumptions used to construct the flow remain
 separate; this predicate records precisely the differential equation needed by its dynamical
 consequences. -/
-def IsNegativeGradient (φ : _root_.Flow ℝ E) (f : E → ℝ) : Prop :=
+@[expose] def IsNegativeGradient (φ : _root_.Flow ℝ E) (f : E → ℝ) : Prop :=
   ∀ x, IsIntegralCurve (fun t ↦ φ t x) (fun _ y ↦ -∇ f y)
 
 /-- Each orbit curve of a negative gradient flow solves the negative gradient equation. -/

--- a/TauCeti/Analysis/Calculus/Morse/GradientFlow.lean
+++ b/TauCeti/Analysis/Calculus/Morse/GradientFlow.lean
@@ -256,8 +256,15 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteS
 `γ' = -∇f(γ)`.  Regularity and uniqueness assumptions used to construct the flow remain
 separate; this predicate records precisely the differential equation needed by its dynamical
 consequences. -/
-@[expose] def IsNegativeGradient (φ : _root_.Flow ℝ E) (f : E → ℝ) : Prop :=
+def IsNegativeGradient (φ : _root_.Flow ℝ E) (f : E → ℝ) : Prop :=
   ∀ x, IsIntegralCurve (fun t ↦ φ t x) (fun _ y ↦ -∇ f y)
+
+/-- A flow is a negative gradient flow exactly when each of its orbit curves solves the
+negative gradient equation. -/
+theorem isNegativeGradient_iff :
+    IsNegativeGradient φ f ↔
+      ∀ x, IsIntegralCurve (fun t ↦ φ t x) (fun _ y ↦ -∇ f y) :=
+  Iff.rfl
 
 /-- Each orbit curve of a negative gradient flow solves the negative gradient equation. -/
 theorem IsNegativeGradient.isIntegralCurve (hφ : IsNegativeGradient φ f) (x : E) :

--- a/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
+++ b/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
@@ -7,9 +7,11 @@ module
 
 public import Mathlib.Analysis.InnerProductSpace.ProdL2
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+public import TauCeti.Analysis.Calculus.Morse.Basic
 public import TauCeti.Analysis.Calculus.Morse.GradientFlow
 public import TauCeti.Analysis.Calculus.Morse.Stable
 import Mathlib.Analysis.InnerProductSpace.Calculus
+import Mathlib.Analysis.InnerProductSpace.Dual
 import Mathlib.Analysis.Calculus.FDeriv.Prod
 
 /-!
@@ -34,6 +36,7 @@ and Hessian determine the corresponding linearized gradient flow and its contrac
 
 * `TauCeti.splitQuadratic`: the standard split quadratic function.
 * `TauCeti.gradient_splitQuadratic`: its gradient is `(x, -y)`.
+* `TauCeti.isNondegenerateCriticalPoint_splitQuadratic_zero`: the origin is nondegenerate.
 * `TauCeti.splitQuadraticFlow`: its explicit negative-gradient flow.
 * `Flow.isNegativeGradient_splitQuadraticFlow`: the flow solves the negative-gradient equation.
 * `Flow.stableSet_splitQuadraticFlow_zero`: the stable set is the first coordinate plane.
@@ -108,6 +111,33 @@ theorem gradient_splitQuadratic_eq_zero_iff [InnerProductSpace ℝ Eₛ] [InnerP
   · rintro rfl
     simp
 
+/-- The origin is a nondegenerate critical point of the split quadratic function. -/
+theorem isNondegenerateCriticalPoint_splitQuadratic_zero
+    [InnerProductSpace ℝ Eₛ] [InnerProductSpace ℝ Eᵤ]
+    [CompleteSpace Eₛ] [CompleteSpace Eᵤ] :
+    IsNondegenerateCriticalPoint (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) 0 := by
+  -- Polarize the quadratic using the involution `(x, y) ↦ (x, -y)` and the Riesz equivalence.
+  let e : WithLp 2 (Eₛ × Eᵤ) ≃L[ℝ] WithLp 2 (Eₛ × Eᵤ) :=
+    (LinearIsometryEquiv.withLpProdCongr 2 (LinearIsometryEquiv.refl ℝ Eₛ)
+      (LinearIsometryEquiv.neg ℝ : Eᵤ ≃ₗᵢ[ℝ] Eᵤ)).toContinuousLinearEquiv
+  let half : WithLp 2 (Eₛ × Eᵤ) ≃L[ℝ] WithLp 2 (Eₛ × Eᵤ) :=
+    ContinuousLinearEquiv.smulLeft (Units.mk0 (2 : ℝ)⁻¹ (by norm_num))
+  let BEquiv : WithLp 2 (Eₛ × Eᵤ) ≃L[ℝ] WithLp 2 (Eₛ × Eᵤ) →L[ℝ] ℝ :=
+    (e.trans half).trans
+      (InnerProductSpace.toDual ℝ (WithLp 2 (Eₛ × Eᵤ))).toContinuousLinearEquiv
+  let B : WithLp 2 (Eₛ × Eᵤ) →L[ℝ] WithLp 2 (Eₛ × Eᵤ) →L[ℝ] ℝ :=
+    BEquiv
+  have hsymm : B.flip = B := by
+    ext z w
+    simp [B, BEquiv, half, e, WithLp.prod_inner_apply, real_inner_comm]
+  have hB : B.IsInvertible := by
+    exact ⟨BEquiv, rfl⟩
+  have h := ContinuousLinearMap.isNondegenerateCriticalPoint_apply_self_of_flip_eq_self B hsymm hB
+  convert h using 1
+  funext z
+  simp [B, BEquiv, half, e, splitQuadratic, WithLp.prod_inner_apply]
+  ring
+
 section
 
 variable [NormedSpace ℝ Eₛ] [NormedSpace ℝ Eᵤ]
@@ -143,7 +173,7 @@ theorem Flow.isNegativeGradient_splitQuadraticFlow
     [CompleteSpace Eₛ] [CompleteSpace Eᵤ] :
     Flow.IsNegativeGradient (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ))
       (TauCeti.splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) := by
-  simp only [Flow.IsNegativeGradient]
+  rw [Flow.isNegativeGradient_iff]
   intro z t
   have hs : HasDerivAt (fun u : ℝ ↦ Real.exp (-u) • z.fst)
       (-Real.exp (-t) • z.fst) t := by

--- a/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
+++ b/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
@@ -1,0 +1,231 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.ProdL2
+public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
+public import TauCeti.Analysis.Calculus.Morse.GradientFlow
+public import TauCeti.Analysis.Calculus.Morse.Stable
+import Mathlib.Analysis.InnerProductSpace.Calculus
+import Mathlib.Analysis.Calculus.FDeriv.Prod
+
+/-!
+# The split quadratic model of a Morse flow
+
+The local dynamical model at a nondegenerate critical point is the negative-gradient flow of a
+split quadratic form.  On a product of real Hilbert spaces, put
+
+`q(x, y) = (‖x‖² - ‖y‖²) / 2`.
+
+Its gradient is `(x, -y)`, so its negative-gradient flow is
+
+`φ t (x, y) = (exp (-t) • x, exp t • y)`.
+
+This file constructs that flow and computes its stable and unstable sets exactly.  The stable set
+of the origin is the first coordinate plane and the unstable set is the second coordinate plane.
+Thus the two sets in the linear model are genuine closed linear subspaces, rather than only sets
+defined by asymptotic convergence.  This is the model that the stable-manifold theorem perturbs
+near a Morse critical point.
+
+## Main declarations
+
+* `TauCeti.splitQuadratic`: the standard split quadratic function.
+* `TauCeti.gradient_splitQuadratic`: its gradient is `(x, -y)`.
+* `TauCeti.splitQuadraticFlow`: its explicit negative-gradient flow.
+* `Flow.isNegativeGradient_splitQuadraticFlow`: the flow solves the negative-gradient equation.
+* `Flow.stableSet_splitQuadraticFlow_zero`: the stable set is the first coordinate plane.
+* `Flow.unstableSet_splitQuadraticFlow_zero`: the unstable set is the second coordinate plane.
+
+## References
+
+* M. Audin and M. Damian, *Morse Theory and Floer Homology*, Springer Universitext, 2014,
+  Chapters 1--2.
+* [Heegaard Floer homology roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/HeegaardFloer/README.md),
+  Lane M, "Morse homology".
+-/
+
+public section
+
+open Filter Function InnerProductSpace Set Topology
+open scoped Gradient
+
+noncomputable section
+
+variable {Eₛ Eᵤ : Type*}
+  [NormedAddCommGroup Eₛ] [InnerProductSpace ℝ Eₛ]
+  [NormedAddCommGroup Eᵤ] [InnerProductSpace ℝ Eᵤ]
+
+namespace TauCeti
+
+/-- The standard split quadratic function, positive on the first factor and negative on the
+second.  The factor `2⁻¹` normalizes its gradient to `(x, -y)`. -/
+def splitQuadratic (z : WithLp 2 (Eₛ × Eᵤ)) : ℝ :=
+  (‖z.fst‖ ^ 2 - ‖z.snd‖ ^ 2) / 2
+
+/-- The gradient of the split quadratic function is the identity on the first factor and minus
+the identity on the second. -/
+theorem hasGradientAt_splitQuadratic [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
+    (z : WithLp 2 (Eₛ × Eᵤ)) :
+    HasGradientAt (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ))
+      (WithLp.toLp 2 (z.fst, -z.snd)) z := by
+  rw [hasGradientAt_iff_hasFDerivAt]
+  convert
+    ((((WithLp.fstL 2 ℝ Eₛ Eᵤ).hasFDerivAt (x := z)).norm_sq.sub
+      (((WithLp.sndL 2 ℝ Eₛ Eᵤ).hasFDerivAt (x := z)).norm_sq)).const_mul (2 : ℝ)⁻¹) using 1 <;>
+    ext w <;>
+    simp [splitQuadratic, WithLp.prod_inner_apply] <;> ring
+
+/-- Formula for the gradient of the split quadratic function. -/
+@[simp]
+theorem gradient_splitQuadratic [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
+    (z : WithLp 2 (Eₛ × Eᵤ)) :
+    ∇ (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) z =
+      WithLp.toLp 2 (z.fst, -z.snd) := by
+  exact (hasGradientAt_splitQuadratic z).gradient
+
+/-- The origin is the unique critical point of the split quadratic function. -/
+@[simp]
+theorem gradient_splitQuadratic_eq_zero_iff [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
+    (z : WithLp 2 (Eₛ × Eᵤ)) :
+    ∇ (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) z = 0 ↔ z = 0 := by
+  rw [gradient_splitQuadratic]
+  constructor
+  · intro h
+    apply WithLp.ofLp_injective
+    apply Prod.ext
+    · simpa using congrArg WithLp.fst h
+    · simpa using congrArg WithLp.snd h
+  · rintro rfl
+    simp
+
+/-- The explicit hyperbolic flow of the split quadratic function.  Its first coordinate contracts
+in forward time and its second coordinate contracts in backward time. -/
+def splitQuadraticFlow : _root_.Flow ℝ (WithLp 2 (Eₛ × Eᵤ)) where
+  toFun t z := WithLp.toLp 2 (Real.exp (-t) • z.fst, Real.exp t • z.snd)
+  cont' := by fun_prop
+  map_add' t u z := by
+    apply WithLp.ofLp_injective
+    ext <;> simp [Real.exp_add, mul_smul, mul_comm]
+  map_zero' z := by
+    apply WithLp.ofLp_injective
+    simp only [Real.exp_zero, neg_zero, one_smul]
+    exact Prod.eta _
+
+/-- Evaluation of the split quadratic flow. -/
+@[simp]
+theorem splitQuadraticFlow_apply (t : ℝ) (z : WithLp 2 (Eₛ × Eᵤ)) :
+    splitQuadraticFlow t z =
+      WithLp.toLp 2 (Real.exp (-t) • z.fst, Real.exp t • z.snd) :=
+  (rfl)
+
+end TauCeti
+
+/-- Every orbit of the explicit split flow solves the negative-gradient equation for
+`TauCeti.splitQuadratic`. -/
+theorem Flow.isNegativeGradient_splitQuadraticFlow [CompleteSpace Eₛ] [CompleteSpace Eᵤ] :
+    Flow.IsNegativeGradient (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ))
+      (TauCeti.splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) := by
+  simp only [Flow.IsNegativeGradient]
+  intro z t
+  have hs : HasDerivAt (fun u : ℝ ↦ Real.exp (-u) • z.fst)
+      (-Real.exp (-t) • z.fst) t := by
+    convert ((Real.hasDerivAt_exp (-t)).comp t (hasDerivAt_neg t)).smul_const z.fst using 1 <;>
+      simp
+  have hu : HasDerivAt (fun u : ℝ ↦ Real.exp u • z.snd) (Real.exp t • z.snd) t :=
+    (Real.hasDerivAt_exp t).smul_const z.snd
+  have hprod := hs.hasFDerivAt.prodMk hu.hasFDerivAt
+  have htoLp :=
+    (WithLp.prodContinuousLinearEquiv 2 ℝ Eₛ Eᵤ).symm.hasFDerivAt.comp t hprod
+  convert htoLp.hasDerivAt using 1
+  · rfl
+  · change -∇ TauCeti.splitQuadratic
+        (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ) t z) = _
+    rw [TauCeti.gradient_splitQuadratic]
+    apply WithLp.ofLp_injective
+    ext <;> simp
+
+namespace TauCeti
+
+private theorem tendsto_exp_neg_smul_atTop (x : Eₛ) :
+    Tendsto (fun t : ℝ ↦ Real.exp (-t) • x) atTop (𝓝 0) :=
+  by simpa using Real.tendsto_exp_neg_atTop_nhds_zero.smul_const x
+
+private theorem tendsto_exp_smul_atBot (y : Eᵤ) :
+    Tendsto (fun t : ℝ ↦ Real.exp t • y) atBot (𝓝 0) :=
+  by simpa using Real.tendsto_exp_atBot.smul_const y
+
+private theorem eq_zero_of_tendsto_exp_smul_atTop {y : Eᵤ}
+    (h : Tendsto (fun t : ℝ ↦ Real.exp t • y) atTop (𝓝 0)) : y = 0 := by
+  have h' := Real.tendsto_exp_neg_atTop_nhds_zero.smul h
+  have hy : Tendsto (fun _ : ℝ ↦ y) atTop (𝓝 0) := by
+    convert h' using 1 <;> simp [smul_smul, ← Real.exp_add]
+  exact tendsto_nhds_unique tendsto_const_nhds hy
+
+private theorem eq_zero_of_tendsto_exp_neg_smul_atBot {x : Eₛ}
+    (h : Tendsto (fun t : ℝ ↦ Real.exp (-t) • x) atBot (𝓝 0)) : x = 0 := by
+  have h' := Real.tendsto_exp_atBot.smul h
+  have hx : Tendsto (fun _ : ℝ ↦ x) atBot (𝓝 0) := by
+    convert h' using 1 <;> simp [smul_smul, ← Real.exp_add]
+  exact tendsto_nhds_unique tendsto_const_nhds hx
+
+/-- A point converges to the origin in forward time exactly when its expanding coordinate
+vanishes. -/
+theorem tendsto_splitQuadraticFlow_atTop_iff (z : WithLp 2 (Eₛ × Eᵤ)) :
+    Tendsto (fun t ↦ splitQuadraticFlow t z) atTop (𝓝 0) ↔ z.snd = 0 := by
+  constructor
+  · intro h
+    exact eq_zero_of_tendsto_exp_smul_atTop
+      (((WithLp.sndL 2 ℝ Eₛ Eᵤ).continuous.continuousAt.tendsto.comp h).congr'
+        (Eventually.of_forall fun _ ↦ rfl))
+  · intro hz
+    have hprod := (tendsto_exp_neg_smul_atTop z.fst).prodMk_nhds
+      (show Tendsto (fun _ : ℝ ↦ (0 : Eᵤ)) atTop (𝓝 0) from tendsto_const_nhds)
+    have hto := (WithLp.prod_continuous_toLp 2 Eₛ Eᵤ).continuousAt.tendsto.comp hprod
+    convert hto using 1
+    · simp [Function.comp_def, hz]
+    · exact congrArg 𝓝 (WithLp.toLp_zero (V := Eₛ × Eᵤ) 2).symm
+
+/-- A point converges to the origin in backward time exactly when its expanding-backward
+coordinate vanishes. -/
+theorem tendsto_splitQuadraticFlow_atBot_iff (z : WithLp 2 (Eₛ × Eᵤ)) :
+    Tendsto (fun t ↦ splitQuadraticFlow t z) atBot (𝓝 0) ↔ z.fst = 0 := by
+  constructor
+  · intro h
+    exact eq_zero_of_tendsto_exp_neg_smul_atBot
+      (((WithLp.fstL 2 ℝ Eₛ Eᵤ).continuous.continuousAt.tendsto.comp h).congr'
+        (Eventually.of_forall fun _ ↦ rfl))
+  · intro hz
+    have hprod :=
+      (show Tendsto (fun _ : ℝ ↦ (0 : Eₛ)) atBot (𝓝 0) from tendsto_const_nhds).prodMk_nhds
+        (tendsto_exp_smul_atBot z.snd)
+    have hto := (WithLp.prod_continuous_toLp 2 Eₛ Eᵤ).continuousAt.tendsto.comp hprod
+    convert hto using 1
+    · simp [Function.comp_def, hz]
+    · exact congrArg 𝓝 (WithLp.toLp_zero (V := Eₛ × Eᵤ) 2).symm
+
+end TauCeti
+
+namespace Flow
+
+/-- The stable set of the split quadratic flow at the origin is the first coordinate plane. -/
+theorem stableSet_splitQuadraticFlow_zero :
+    stableSet (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ)) 0 =
+      {z : WithLp 2 (Eₛ × Eᵤ) | z.snd = 0} := by
+  ext z
+  rw [mem_stableSet, TauCeti.tendsto_splitQuadraticFlow_atTop_iff]
+  rfl
+
+/-- The unstable set of the split quadratic flow at the origin is the second coordinate plane. -/
+theorem unstableSet_splitQuadraticFlow_zero :
+    unstableSet (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ)) 0 =
+      {z : WithLp 2 (Eₛ × Eᵤ) | z.fst = 0} := by
+  ext z
+  rw [mem_unstableSet, TauCeti.tendsto_splitQuadraticFlow_atBot_iff]
+  rfl
+
+end Flow
+
+end

--- a/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
+++ b/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
@@ -55,8 +55,7 @@ open scoped Gradient
 noncomputable section
 
 variable {Eₛ Eᵤ : Type*}
-  [NormedAddCommGroup Eₛ] [InnerProductSpace ℝ Eₛ]
-  [NormedAddCommGroup Eᵤ] [InnerProductSpace ℝ Eᵤ]
+  [NormedAddCommGroup Eₛ] [NormedAddCommGroup Eᵤ]
 
 namespace TauCeti
 
@@ -67,7 +66,8 @@ def splitQuadratic (z : WithLp 2 (Eₛ × Eᵤ)) : ℝ :=
 
 /-- The gradient of the split quadratic function is the identity on the first factor and minus
 the identity on the second. -/
-theorem hasGradientAt_splitQuadratic [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
+theorem hasGradientAt_splitQuadratic [InnerProductSpace ℝ Eₛ] [InnerProductSpace ℝ Eᵤ]
+    [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
     (z : WithLp 2 (Eₛ × Eᵤ)) :
     HasGradientAt (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ))
       (WithLp.toLp 2 (z.fst, -z.snd)) z := by
@@ -80,14 +80,16 @@ theorem hasGradientAt_splitQuadratic [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
 
 /-- Formula for the gradient of the split quadratic function. -/
 @[simp]
-theorem gradient_splitQuadratic [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
+theorem gradient_splitQuadratic [InnerProductSpace ℝ Eₛ] [InnerProductSpace ℝ Eᵤ]
+    [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
     (z : WithLp 2 (Eₛ × Eᵤ)) :
     ∇ (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) z =
       WithLp.toLp 2 (z.fst, -z.snd) := by
   exact (hasGradientAt_splitQuadratic z).gradient
 
 /-- The origin is the unique critical point of the split quadratic function. -/
-theorem gradient_splitQuadratic_eq_zero_iff [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
+theorem gradient_splitQuadratic_eq_zero_iff [InnerProductSpace ℝ Eₛ] [InnerProductSpace ℝ Eᵤ]
+    [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
     (z : WithLp 2 (Eₛ × Eᵤ)) :
     ∇ (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) z = 0 ↔ z = 0 := by
   rw [gradient_splitQuadratic]
@@ -99,6 +101,10 @@ theorem gradient_splitQuadratic_eq_zero_iff [CompleteSpace Eₛ] [CompleteSpace 
     · simpa using congrArg WithLp.snd h
   · rintro rfl
     simp
+
+section
+
+variable [NormedSpace ℝ Eₛ] [NormedSpace ℝ Eᵤ]
 
 /-- The explicit hyperbolic flow of the split quadratic function.  Its first coordinate contracts
 in forward time and its second coordinate contracts in backward time. -/
@@ -120,14 +126,18 @@ theorem splitQuadraticFlow_apply (t : ℝ) (z : WithLp 2 (Eₛ × Eᵤ)) :
       WithLp.toLp 2 (Real.exp (-t) • z.fst, Real.exp t • z.snd) :=
   (rfl)
 
+end
+
 end TauCeti
 
 /-- Every orbit of the explicit split flow solves the negative-gradient equation for
 `TauCeti.splitQuadratic`. -/
-theorem Flow.isNegativeGradient_splitQuadraticFlow [CompleteSpace Eₛ] [CompleteSpace Eᵤ] :
+theorem Flow.isNegativeGradient_splitQuadraticFlow
+    [InnerProductSpace ℝ Eₛ] [InnerProductSpace ℝ Eᵤ]
+    [CompleteSpace Eₛ] [CompleteSpace Eᵤ] :
     Flow.IsNegativeGradient (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ))
       (TauCeti.splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) := by
-  simp only [Flow.IsNegativeGradient]
+  rw [Flow.isNegativeGradient_iff]
   intro z t
   have hs : HasDerivAt (fun u : ℝ ↦ Real.exp (-u) • z.fst)
       (-Real.exp (-t) • z.fst) t := by
@@ -140,11 +150,14 @@ theorem Flow.isNegativeGradient_splitQuadraticFlow [CompleteSpace Eₛ] [Complet
     (WithLp.prodContinuousLinearEquiv 2 ℝ Eₛ Eᵤ).symm.hasFDerivAt.comp t hprod
   convert htoLp.hasDerivAt using 1
   · rfl
-  · change -∇ TauCeti.splitQuadratic
+  · -- Expose the vector-field value so the explicit gradient formula rewrites the goal.
+    change -∇ TauCeti.splitQuadratic
         (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ) t z) = _
     rw [TauCeti.gradient_splitQuadratic]
     apply WithLp.ofLp_injective
     ext <;> simp
+
+variable [NormedSpace ℝ Eₛ] [NormedSpace ℝ Eᵤ]
 
 namespace TauCeti
 
@@ -180,8 +193,9 @@ theorem tendsto_splitQuadraticFlow_atTop_iff (z : WithLp 2 (Eₛ × Eᵤ)) :
       (((WithLp.sndL 2 ℝ Eₛ Eᵤ).continuous.continuousAt.tendsto.comp h).congr'
         (Eventually.of_forall fun _ ↦ rfl))
   · intro hz
+    have hzero : Tendsto (fun _ : ℝ ↦ (0 : Eᵤ)) atTop (𝓝 0) := tendsto_const_nhds
     have hprod := (tendsto_exp_neg_smul_atTop z.fst).prodMk_nhds
-      (show Tendsto (fun _ : ℝ ↦ (0 : Eᵤ)) atTop (𝓝 0) from tendsto_const_nhds)
+      hzero
     have hto := (WithLp.prod_continuous_toLp 2 Eₛ Eᵤ).continuousAt.tendsto.comp hprod
     convert hto using 1
     · simp [Function.comp_def, hz]
@@ -197,9 +211,8 @@ theorem tendsto_splitQuadraticFlow_atBot_iff (z : WithLp 2 (Eₛ × Eᵤ)) :
       (((WithLp.fstL 2 ℝ Eₛ Eᵤ).continuous.continuousAt.tendsto.comp h).congr'
         (Eventually.of_forall fun _ ↦ rfl))
   · intro hz
-    have hprod :=
-      (show Tendsto (fun _ : ℝ ↦ (0 : Eₛ)) atBot (𝓝 0) from tendsto_const_nhds).prodMk_nhds
-        (tendsto_exp_smul_atBot z.snd)
+    have hzero : Tendsto (fun _ : ℝ ↦ (0 : Eₛ)) atBot (𝓝 0) := tendsto_const_nhds
+    have hprod := hzero.prodMk_nhds (tendsto_exp_smul_atBot z.snd)
     have hto := (WithLp.prod_continuous_toLp 2 Eₛ Eᵤ).continuousAt.tendsto.comp hprod
     convert hto using 1
     · simp [Function.comp_def, hz]

--- a/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
+++ b/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
@@ -15,8 +15,8 @@ import Mathlib.Analysis.Calculus.FDeriv.Prod
 /-!
 # The split quadratic model of a Morse flow
 
-The local dynamical model at a nondegenerate critical point is the negative-gradient flow of a
-split quadratic form.  On a product of real Hilbert spaces, put
+This file studies the standard split-quadratic example of a negative-gradient flow.  On a product
+of real Hilbert spaces, put
 
 `q(x, y) = (‖x‖² - ‖y‖²) / 2`.
 
@@ -26,9 +26,9 @@ Its gradient is `(x, -y)`, so its negative-gradient flow is
 
 This file constructs that flow and computes its stable and unstable sets exactly.  The stable set
 of the origin is the first coordinate plane and the unstable set is the second coordinate plane.
-Thus the two sets in the linear model are genuine closed linear subspaces, rather than only sets
-defined by asymptotic convergence.  This is the model that the stable-manifold theorem perturbs
-near a Morse critical point.
+Thus the two sets in this normalized linear example are genuine closed linear subspaces, rather
+than only sets defined by asymptotic convergence.  For a general Morse critical point, the metric
+and Hessian determine the corresponding linearized gradient flow and its contraction rates.
 
 ## Main declarations
 
@@ -63,6 +63,12 @@ namespace TauCeti
 second.  The factor `2⁻¹` normalizes its gradient to `(x, -y)`. -/
 def splitQuadratic (z : WithLp 2 (Eₛ × Eᵤ)) : ℝ :=
   (‖z.fst‖ ^ 2 - ‖z.snd‖ ^ 2) / 2
+
+/-- Evaluation of the standard split quadratic function. -/
+@[simp]
+theorem splitQuadratic_apply (z : WithLp 2 (Eₛ × Eᵤ)) :
+    splitQuadratic z = (‖z.fst‖ ^ 2 - ‖z.snd‖ ^ 2) / 2 :=
+  (rfl)
 
 /-- The gradient of the split quadratic function is the identity on the first factor and minus
 the identity on the second. -/
@@ -137,7 +143,7 @@ theorem Flow.isNegativeGradient_splitQuadraticFlow
     [CompleteSpace Eₛ] [CompleteSpace Eᵤ] :
     Flow.IsNegativeGradient (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ))
       (TauCeti.splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) := by
-  rw [Flow.isNegativeGradient_iff]
+  simp only [Flow.IsNegativeGradient]
   intro z t
   have hs : HasDerivAt (fun u : ℝ ↦ Real.exp (-u) • z.fst)
       (-Real.exp (-t) • z.fst) t := by
@@ -149,7 +155,9 @@ theorem Flow.isNegativeGradient_splitQuadraticFlow
   have htoLp :=
     (WithLp.prodContinuousLinearEquiv 2 ℝ Eₛ Eᵤ).symm.hasFDerivAt.comp t hprod
   convert htoLp.hasDerivAt using 1
-  · rfl
+  · funext u
+    simp only [TauCeti.splitQuadraticFlow_apply, Function.comp_apply,
+      WithLp.prodContinuousLinearEquiv_symm_apply]
   · -- Expose the vector-field value so the explicit gradient formula rewrites the goal.
     change -∇ TauCeti.splitQuadratic
         (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ) t z) = _
@@ -185,13 +193,15 @@ private theorem eq_zero_of_tendsto_exp_neg_smul_atBot {x : Eₛ}
 
 /-- A point converges to the origin in forward time exactly when its expanding coordinate
 vanishes. -/
-theorem tendsto_splitQuadraticFlow_atTop_iff (z : WithLp 2 (Eₛ × Eᵤ)) :
+theorem tendsto_splitQuadraticFlow_atTop_nhds_zero_iff (z : WithLp 2 (Eₛ × Eᵤ)) :
     Tendsto (fun t ↦ splitQuadraticFlow t z) atTop (𝓝 0) ↔ z.snd = 0 := by
   constructor
   · intro h
     exact eq_zero_of_tendsto_exp_smul_atTop
       (((WithLp.sndL 2 ℝ Eₛ Eᵤ).continuous.continuousAt.tendsto.comp h).congr'
-        (Eventually.of_forall fun _ ↦ rfl))
+        (Eventually.of_forall fun t ↦ by
+          simp only [Function.comp_apply, splitQuadraticFlow_apply, WithLp.sndL_apply,
+            WithLp.toLp_snd]))
   · intro hz
     have hzero : Tendsto (fun _ : ℝ ↦ (0 : Eᵤ)) atTop (𝓝 0) := tendsto_const_nhds
     have hprod := (tendsto_exp_neg_smul_atTop z.fst).prodMk_nhds
@@ -203,13 +213,15 @@ theorem tendsto_splitQuadraticFlow_atTop_iff (z : WithLp 2 (Eₛ × Eᵤ)) :
 
 /-- A point converges to the origin in backward time exactly when its expanding-backward
 coordinate vanishes. -/
-theorem tendsto_splitQuadraticFlow_atBot_iff (z : WithLp 2 (Eₛ × Eᵤ)) :
+theorem tendsto_splitQuadraticFlow_atBot_nhds_zero_iff (z : WithLp 2 (Eₛ × Eᵤ)) :
     Tendsto (fun t ↦ splitQuadraticFlow t z) atBot (𝓝 0) ↔ z.fst = 0 := by
   constructor
   · intro h
     exact eq_zero_of_tendsto_exp_neg_smul_atBot
       (((WithLp.fstL 2 ℝ Eₛ Eᵤ).continuous.continuousAt.tendsto.comp h).congr'
-        (Eventually.of_forall fun _ ↦ rfl))
+        (Eventually.of_forall fun t ↦ by
+          simp only [Function.comp_apply, splitQuadraticFlow_apply, WithLp.fstL_apply,
+            WithLp.toLp_fst]))
   · intro hz
     have hzero : Tendsto (fun _ : ℝ ↦ (0 : Eₛ)) atBot (𝓝 0) := tendsto_const_nhds
     have hprod := hzero.prodMk_nhds (tendsto_exp_smul_atBot z.snd)
@@ -223,19 +235,21 @@ end TauCeti
 namespace Flow
 
 /-- The stable set of the split quadratic flow at the origin is the first coordinate plane. -/
+@[simp]
 theorem stableSet_splitQuadraticFlow_zero :
     stableSet (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ)) 0 =
       {z : WithLp 2 (Eₛ × Eᵤ) | z.snd = 0} := by
   ext z
-  rw [mem_stableSet, TauCeti.tendsto_splitQuadraticFlow_atTop_iff]
+  rw [mem_stableSet, TauCeti.tendsto_splitQuadraticFlow_atTop_nhds_zero_iff]
   rfl
 
 /-- The unstable set of the split quadratic flow at the origin is the second coordinate plane. -/
+@[simp]
 theorem unstableSet_splitQuadraticFlow_zero :
     unstableSet (TauCeti.splitQuadraticFlow (Eₛ := Eₛ) (Eᵤ := Eᵤ)) 0 =
       {z : WithLp 2 (Eₛ × Eᵤ) | z.fst = 0} := by
   ext z
-  rw [mem_unstableSet, TauCeti.tendsto_splitQuadraticFlow_atBot_iff]
+  rw [mem_unstableSet, TauCeti.tendsto_splitQuadraticFlow_atBot_nhds_zero_iff]
   rfl
 
 end Flow

--- a/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
+++ b/TauCeti/Analysis/Calculus/Morse/SplitModel.lean
@@ -87,7 +87,6 @@ theorem gradient_splitQuadratic [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
   exact (hasGradientAt_splitQuadratic z).gradient
 
 /-- The origin is the unique critical point of the split quadratic function. -/
-@[simp]
 theorem gradient_splitQuadratic_eq_zero_iff [CompleteSpace Eₛ] [CompleteSpace Eᵤ]
     (z : WithLp 2 (Eₛ × Eᵤ)) :
     ∇ (splitQuadratic (Eₛ := Eₛ) (Eᵤ := Eᵤ)) z = 0 ↔ z = 0 := by


### PR DESCRIPTION
This PR computes the split quadratic Morse flow and its exact stable and unstable sets. It advances Lane M's "Morse homology" milestone, specifically the target "Morse functions and gradient flows; stable/unstable manifolds," by supplying the hyperbolic local model that the stable-manifold theorem consumes after the Morse normal form.

The new module defines `q(x, y) = (‖x‖² - ‖y‖²) / 2` on the `WithLp 2` product, computes its gradient, constructs the explicit flow `(e⁻ᵗx, eᵗy)`, proves that every orbit solves the negative-gradient equation, characterizes forward and backward convergence, and identifies the stable and unstable sets of the origin with the two coordinate planes. It reuses Mathlib's `WithLp`, continuous-linear-map derivative calculus, exponential limits, and `Flow` infrastructure, together with Tau Ceti's existing `Flow.IsNegativeGradient`, `stableSet`, and `unstableSet` APIs; the one-line `@[expose]` adjustment makes that existing predicate constructible across Lean's module boundary.

The remaining work after this PR is to perturb this exact model to obtain nonlinear local stable and unstable manifolds, then prove the λ-lemma, Morse–Smale transversality, broken-trajectory compactification, gluing, and `d² = 0`.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"split-quadratic-morse-flow"}-->

🤖 Prepared with Codex
