### PR TITLE
feat(Spa): the converse half of Wedhorn Proposition 7.49(1)

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
@@ -138,9 +138,8 @@ theorem spa_eq_empty_of_one_mem_closure_zero (Aplus : Subring A)
   rw [spa_def, cont_eq_empty_of_one_mem_closure_zero h, Set.empty_inter]
 
 omit [SeparatelyContinuousAdd A] in
-/-- A prime containing an open ideal is itself open, so its trivial valuation is a point of the
-adic spectrum: the sub-unit condition on `A⁺` is vacuous for a trivial valuation, since `1` lies
-outside a prime. -/
+/-- The trivial valuation of an open prime is a point of the adic spectrum, for any plus ring:
+`A⁺` is unconstrained because a trivial valuation is sub-unit on all of `A`. -/
 theorem trivialSection_mem_spa (Aplus : Subring A) {p : PrimeSpectrum A}
     (hp : IsOpen (p.asIdeal : Set A)) : trivialSection p ∈ spa Aplus := by
   rw [mem_spa_iff]
@@ -151,10 +150,6 @@ theorem trivialSection_mem_spa (Aplus : Subring A) {p : PrimeSpectrum A}
 omit [SeparatelyContinuousAdd A] in
 /-- **The `Spa (A, A⁺) = ∅ → 1 ∈ closure {0}` half of Wedhorn Proposition 7.49(1)**, the converse
 of `spa_eq_empty_of_one_mem_closure_zero`, under the hypothesis that `closure {0}` is open.
-
-If some prime contained `closure {0}` it would contain an open additive subgroup, hence be open,
-and its trivial valuation would then be a point of `Spa (A, A⁺)`. So an empty adic spectrum
-leaves no prime above `closure {0}`, forcing that ideal to be everything.
 
 The openness hypothesis is Wedhorn 7.49(2) and is *not* proved here: it needs the microbiality
 substrate, and is taken as given exactly as Wedhorn's proof takes it. -/
@@ -177,6 +172,7 @@ theorem one_mem_closure_zero_of_spa_eq_empty [IsTopologicalRing A] (Aplus : Subr
   rw [h] at hmem
   exact hmem
 
+omit [SeparatelyContinuousAdd A] in
 /-- **Wedhorn Proposition 7.49(1)**, both directions, once `closure {0}` is open: the adic
 spectrum is empty exactly when `1` lies in the closure of zero. -/
 theorem spa_eq_empty_iff_one_mem_closure_zero [IsTopologicalRing A] (Aplus : Subring A)

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.RingTheory.Valuation.Integral
 public import TauCeti.AlgebraicGeometry.AdicSpace.Cont.Basic
+import Mathlib.Topology.Algebra.OpenSubgroup
 
 /-!
 # The underlying set of the adic spectrum `Spa (A, A⁺)`
@@ -53,6 +54,16 @@ it; the subspace form here needs no such comparison.)
 * `TauCeti.ValuationSpectrum.spa_eq_empty_of_one_mem_closure_zero` : if `1 ∈ closure {0}` in a
   commutative ring `A` with separately continuous addition, then `Spa(A, A⁺) = ∅` for any plus
   ring `A⁺` (the `1 ∈ closure {0} → Spa(A, A⁺) = ∅` half of Wedhorn Proposition 7.49(1)).
+* `TauCeti.ValuationSpectrum.trivialSection_mem_spa` : the trivial valuation of an open prime is
+  a point of the adic spectrum, for any plus ring.
+* `TauCeti.ValuationSpectrum.one_mem_closure_zero_of_spa_eq_empty` : the converse half of
+  Wedhorn Proposition 7.49(1) — over a topological ring in which `closure {0}` is open, an empty
+  adic spectrum forces `1 ∈ closure {0}`.
+* `TauCeti.ValuationSpectrum.spa_eq_empty_iff_one_mem_closure_zero` : the two halves combined.
+
+The openness of `closure {0}` is Wedhorn 7.49(2) and is taken as a hypothesis here, exactly as
+Wedhorn's proof of 7.49(1) takes it; proving it needs the microbiality substrate and is not done
+in this file.
 
 ## References
 
@@ -125,6 +136,54 @@ variable [SeparatelyContinuousAdd A]
 theorem spa_eq_empty_of_one_mem_closure_zero (Aplus : Subring A)
     (h : (1 : A) ∈ closure ({0} : Set A)) : spa Aplus = ∅ := by
   rw [spa_def, cont_eq_empty_of_one_mem_closure_zero h, Set.empty_inter]
+
+omit [SeparatelyContinuousAdd A] in
+/-- A prime containing an open ideal is itself open, so its trivial valuation is a point of the
+adic spectrum: the sub-unit condition on `A⁺` is vacuous for a trivial valuation, since `1` lies
+outside a prime. -/
+theorem trivialSection_mem_spa (Aplus : Subring A) {p : PrimeSpectrum A}
+    (hp : IsOpen (p.asIdeal : Set A)) : trivialSection p ∈ spa Aplus := by
+  rw [mem_spa_iff]
+  refine ⟨(isContinuous_trivialSection_iff p).mpr hp, fun a _ ↦ ?_⟩
+  exact (trivialSection_vle_iff p a 1).mpr
+    (Or.inr ((Ideal.ne_top_iff_one _).mp p.isPrime.ne_top))
+
+omit [SeparatelyContinuousAdd A] in
+/-- **The `Spa (A, A⁺) = ∅ → 1 ∈ closure {0}` half of Wedhorn Proposition 7.49(1)**, the converse
+of `spa_eq_empty_of_one_mem_closure_zero`, under the hypothesis that `closure {0}` is open.
+
+If some prime contained `closure {0}` it would contain an open additive subgroup, hence be open,
+and its trivial valuation would then be a point of `Spa (A, A⁺)`. So an empty adic spectrum
+leaves no prime above `closure {0}`, forcing that ideal to be everything.
+
+The openness hypothesis is Wedhorn 7.49(2) and is *not* proved here: it needs the microbiality
+substrate, and is taken as given exactly as Wedhorn's proof takes it. -/
+theorem one_mem_closure_zero_of_spa_eq_empty [IsTopologicalRing A] (Aplus : Subring A)
+    (hopen : IsOpen (closure ({0} : Set A))) (h : spa Aplus = ∅) :
+    (1 : A) ∈ closure ({0} : Set A) := by
+  by_contra h1
+  -- `closure {0}` is an ideal, and by hypothesis a proper one
+  have hcoe : ((Ideal.closure (⊥ : Ideal A) : Ideal A) : Set A) = closure ({0} : Set A) := by
+    simp [Ideal.closure]
+  have hne : Ideal.closure (⊥ : Ideal A) ≠ ⊤ := by
+    rw [Ne, Ideal.eq_top_iff_one]
+    rw [← SetLike.mem_coe, hcoe]
+    exact h1
+  obtain ⟨m, hm, hle⟩ := Ideal.exists_le_maximal _ hne
+  -- a prime above an open ideal is open, so its trivial valuation is a point of `Spa`
+  have hopen' : IsOpen ((m : Set A)) :=
+    Submodule.isOpen_mono hle (by rw [← hcoe] at hopen; exact hopen)
+  have hmem : trivialSection ⟨m, hm.isPrime⟩ ∈ spa Aplus := trivialSection_mem_spa Aplus hopen'
+  rw [h] at hmem
+  exact hmem
+
+/-- **Wedhorn Proposition 7.49(1)**, both directions, once `closure {0}` is open: the adic
+spectrum is empty exactly when `1` lies in the closure of zero. -/
+theorem spa_eq_empty_iff_one_mem_closure_zero [IsTopologicalRing A] (Aplus : Subring A)
+    (hopen : IsOpen (closure ({0} : Set A))) :
+    spa Aplus = ∅ ↔ (1 : A) ∈ closure ({0} : Set A) :=
+  ⟨one_mem_closure_zero_of_spa_eq_empty Aplus hopen,
+    spa_eq_empty_of_one_mem_closure_zero Aplus⟩
 
 end SeparatelyContinuousAdd
 

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
@@ -58,11 +58,8 @@ point of the adic spectrum — the point of its trivial valuation, `trivialSecti
 Wedhorn states the proposition for maximal ideals; the proof needs only primality. -/
 theorem exists_mem_spa_supp_eq (Aplus : Subring A) (𝔭 : Ideal A) [𝔭.IsPrime]
     (h𝔭 : IsOpen (𝔭 : Set A)) : ∃ v ∈ spa Aplus, supp v = 𝔭 := by
-  refine ⟨trivialSection ⟨𝔭, ‹_›⟩, (mem_spa_iff Aplus _).mpr ⟨?_, fun a _ ↦ ?_⟩, ?_⟩
-  · exact (isContinuous_trivialSection_iff _).mpr h𝔭
-  · exact (trivialSection_vle_iff _ a 1).mpr
-      (Or.inr ((Ideal.ne_top_iff_one 𝔭).mp ‹𝔭.IsPrime›.ne_top))
-  · rw [← suppFun_asIdeal, suppFun_trivialSection]
+  refine ⟨trivialSection ⟨𝔭, ‹_›⟩, trivialSection_mem_spa Aplus h𝔭, ?_⟩
+  rw [← suppFun_asIdeal, suppFun_trivialSection]
 
 /-- **The converse half of Wedhorn Corollary 7.53.** If every maximal ideal of `A` is open and
 every point of `Spa(A, A⁺)` is nonzero on some member of `T`, then `T` generates the unit ideal.


### PR DESCRIPTION
Wedhorn Proposition 7.49(1) currently has only one direction on `main`. This adds the other.

## What this proves

`spa_eq_empty_of_one_mem_closure_zero` (Spa/Basic.lean) already gives `1 ∈ closure {0} → Spa (A, A⁺) = ∅`. This PR adds the converse, under the hypothesis that `closure {0}` is open:

* `trivialSection_mem_spa` — the trivial valuation at an open prime is a point of `Spa (A, A⁺)`, for any plus ring.
* `one_mem_closure_zero_of_spa_eq_empty` — over a topological ring in which `closure {0}` is open, an empty adic spectrum forces `1 ∈ closure {0}`.
* `spa_eq_empty_iff_one_mem_closure_zero` — the two halves combined.

## The argument

Wedhorn's, verbatim in structure (arXiv:1910.05934v1, proof of Proposition 7.49(1)): *"Assume that X = ∅. Then by (2) the ideal closure{0} is open in A. Then every trivial valuation whose support contains closure{0} is an element of X. This shows that A has no prime ideal containing closure{0}, i.e. A = closure{0}."*

If a prime `p` contained `closure {0}`, it would contain an open additive subgroup and hence be open (`Submodule.isOpen_mono`). Its trivial valuation is then a point of the adic spectrum: continuous by main's `isContinuous_trivialSection_iff`, and sub-unit on `A⁺` for free — a trivial valuation takes only the values `0` and `1`, and `1` lies outside a prime, so `trivialSection_vle_iff` discharges the condition with no hypothesis on `A⁺` at all. An empty spectrum therefore leaves no prime above `closure {0}`, forcing that ideal to be everything.

## What this deliberately does *not* do

The openness of `closure {0}` is Wedhorn 7.49(2), and it is **taken as a hypothesis, not proved**. Proving it runs through Lemma 7.45 and the microbiality substrate, which is separate in-flight work. Wedhorn's own proof of 7.49(1) likewise consumes (2) rather than establishing it, so the split follows the source. This is what makes the implication landable now, independently of the substrate.

## Reuse

Everything the proof needs was already on `main` and is reused rather than restated: `trivialSection` and `trivialSection_vle_iff` (ValuationSpectrum.lean), `isContinuous_trivialSection_iff` (Cont/Basic.lean:141), `mem_spa_iff` (Spa/Basic.lean). From Mathlib: `Submodule.isOpen_mono`, `Ideal.exists_le_maximal`, `Ideal.closure`. The one new import is `Mathlib.Topology.Algebra.OpenSubgroup`, non-`public` because it is used only inside a proof.

`one_mem_closure_zero_of_spa_eq_empty` carries `[IsTopologicalRing A]` rather than the file's ambient `[SeparatelyContinuousAdd A]`, because `Ideal.closure` and `Submodule.isOpen_mono` both need the ring/additive-group topology; the two theorems that do not need it carry `omit [SeparatelyContinuousAdd A] in`.

## Verification

`lake build TauCeti.AlgebraicGeometry.AdicSpace.Spa.Basic` — exit 0, 2043 jobs, no errors, warnings, or `info:` diagnostics. Branched off `origin/main`. No line over 100 characters; no `sorry`.

Roadmap: AdicSpaces


---

## Follow-up in this PR: removing the duplicate it exposed

`trivialSection_mem_spa` turned out not to be new content but a factoring. `exists_mem_spa_supp_eq` in `Spa/Points.lean` was already discharging the same two obligations inline (continuity via `isContinuous_trivialSection_iff`, the `A⁺` bound via `trivialSection_vle_iff` with `1 ∉ 𝔭`) — byte-for-byte the body of the new lemma. Leaving both would have been a duplicate, so `exists_mem_spa_supp_eq` now calls `trivialSection_mem_spa` and its proof drops from five lines to two.

`lake build TauCeti.AlgebraicGeometry.AdicSpace.Spa.Points TauCeti.AlgebraicGeometry.AdicSpace.Spa.Basic` — exit 0, 2044 jobs, no errors, warnings, or `info:` diagnostics.
