### PR TITLE
feat(Nat): the base-p logarithm and the p-adic valuation are sublinear

### DIFF
--- a/TauCeti/Data/Nat/Log.lean
+++ b/TauCeti/Data/Nat/Log.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.Nat.Log
+public import Mathlib.Order.Filter.AtTopBot.Tendsto
+public import Mathlib.Order.Monotone.Basic
+public import Mathlib.Tactic.Common
+
+/-!
+# The base-`b` logarithm grows by at most one, and is sublinear
+
+Two facts about `Nat.log` that Mathlib does not carry. Mathlib has the exact criterion for when
+the logarithm jumps at a successor (`Nat.log_lt_log_succ_iff`), but not the resulting one-step
+bound, and it has no asymptotic statement at all.
+
+## Main results
+
+* `Nat.log_succ_le` : `Nat.log b (n + 1) ≤ Nat.log b n + 1`.
+* `tendsto_sub_log_atTop` : `n - Nat.log p n → ∞` for `1 < p`, i.e. the logarithm is sublinear.
+
+## References
+
+* [M. Stoll, *EllipticCurves*](https://github.com/MichaelStollBayreuth/EllipticCurves), commit
+  `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`,
+  `EllipticCurves/Mathlib/Chabauty/PadicValNat.lean`. The proofs are that file's, with its `lia`
+  calls replaced by `omega`, which is this repository's idiom.
+-/
+
+public section
+
+open Filter
+
+/-- `Nat.log` increases by at most one when its argument does. -/
+theorem Nat.log_succ_le (b n : ℕ) : Nat.log b (n + 1) ≤ Nat.log b n + 1 := by
+  by_cases hb : 1 < b
+  · rcases Nat.eq_zero_or_pos (Nat.log b (n + 1)) with h0 | hL
+    · omega
+    set L := Nat.log b (n + 1) with hLdef
+    have hpL : b ^ L ≤ n + 1 := Nat.pow_log_le_self b (Nat.succ_ne_zero n)
+    have hone : 1 ≤ b ^ (L - 1) := Nat.one_le_pow _ _ (by omega)
+    have h2 : 2 * b ^ (L - 1) ≤ b ^ L := by
+      have he : b ^ L = b ^ (L - 1) * b := by rw [← Nat.pow_succ]; congr 1; omega
+      rw [he, Nat.mul_comm (b ^ (L - 1)) b]
+      exact Nat.mul_le_mul_right _ hb
+    have h4 : b ^ (L - 1) ≤ n := by omega
+    have := Nat.le_log_of_pow_le hb h4
+    omega
+  · simp [Nat.log_of_left_le_one (by omega : b ≤ 1)]
+
+/-- `n - Nat.log p n → ∞`: the base-`p` logarithm is sublinear. -/
+theorem tendsto_sub_log_atTop {p : ℕ} (hp : 1 < p) :
+    Tendsto (fun n ↦ n - Nat.log p n) atTop atTop := by
+  apply tendsto_atTop_atTop_of_monotone
+  · refine monotone_nat_of_le_succ fun n ↦ ?_
+    have h1 : Nat.log p (n + 1) ≤ Nat.log p n + 1 := Nat.log_succ_le p n
+    have h2 : Nat.log p n ≤ Nat.log p (n + 1) := Nat.log_mono_right (Nat.le_succ n)
+    omega
+  · intro B
+    refine ⟨p ^ (B + 1), ?_⟩
+    rw [Nat.log_pow hp]
+    have hk : B + 1 ≤ 2 ^ B := Nat.lt_two_pow_self
+    have h2 : 2 ^ (B + 1) ≤ p ^ (B + 1) := Nat.pow_le_pow_left (by omega) (B + 1)
+    have h3 : 2 * (B + 1) ≤ 2 ^ (B + 1) := by rw [Nat.pow_succ]; omega
+    omega
+
+end

--- a/TauCeti/NumberTheory/Padics/SubPadicValNat.lean
+++ b/TauCeti/NumberTheory/Padics/SubPadicValNat.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.NumberTheory.Padics.PadicVal.Basic
+public import TauCeti.Data.Nat.Log
+
+/-!
+# The `p`-adic valuation is sublinear
+
+`n - padicValNat p n → ∞` for `1 < p`. This is the `padicValNat` counterpart of
+`tendsto_sub_log_atTop`, and follows from it because the `p`-adic valuation is dominated by the
+base-`p` logarithm (`padicValNat_le_nat_log`).
+
+Mathlib carries no asymptotic statement about `padicValNat`, and this is the form consumers want:
+subtracting the valuation from `n` still leaves something tending to infinity, so a construction
+may spend `padicValNat p n` of its budget and retain unbounded room.
+
+## Main results
+
+* `tendsto_sub_padicValNat_atTop` : `n - padicValNat p n → ∞` for `1 < p`.
+
+## References
+
+* [M. Stoll, *EllipticCurves*](https://github.com/MichaelStollBayreuth/EllipticCurves), commit
+  `66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e`,
+  `EllipticCurves/Mathlib/Chabauty/PadicValNat.lean`. The proof is that file's.
+-/
+
+public section
+
+open Filter
+
+/-- `n - v_p(n) → ∞`: the `p`-adic valuation is sublinear. -/
+theorem tendsto_sub_padicValNat_atTop {p : ℕ} (hp : 1 < p) :
+    Tendsto (fun n ↦ n - padicValNat p n) atTop atTop :=
+  tendsto_atTop_mono (fun n ↦ Nat.sub_le_sub_left (padicValNat_le_nat_log n) n)
+    (tendsto_sub_log_atTop hp)
+
+end


### PR DESCRIPTION
Three general lemmas: the base-`p` logarithm grows by at most one at a successor, and both it and
the `p`-adic valuation are sublinear — `n - Nat.log p n` and `n - padicValNat p n` tend to
infinity.

Roadmap: EllipticCurves

Target: prerequisite material for the Chabauty/Mordell–Weil layer. These are general
number-theoretic lemmas with no curve in them; the roadmap association is the campaign that needs
them, not the subject matter.

## Provenance

Adapted with attribution from [M. Stoll,
*EllipticCurves*](https://github.com/MichaelStollBayreuth/EllipticCurves), commit
`66889eada51a74c2f5dfb7fb5909b0b5a0a2d96e` (Apache-2.0),
`EllipticCurves/Mathlib/Chabauty/PadicValNat.lean` — a file its author collects as Mathlib
candidates. The proofs are that file's.

## Contents

**`TauCeti/Data/Nat/Log.lean`** (new)

* `Nat.log_succ_le` — `Nat.log b (n + 1) ≤ Nat.log b n + 1`.
* `tendsto_sub_log_atTop` — `n - Nat.log p n → ∞` for `1 < p`.

**`TauCeti/NumberTheory/Padics/SubPadicValNat.lean`** (new)

* `tendsto_sub_padicValNat_atTop` — `n - padicValNat p n → ∞` for `1 < p`.

Split so the pure `Nat.log` material does not sit in a Padics module: the first two mention no
valuation, and only the third needs `padicValNat`.

## Prior art, checked by statement rather than by name

A name check reads false-fresh when the work exists under another spelling, so the probe was on
the statements, with a control that must fire:

* **Successor bound on `Nat.log`** — absent. Mathlib has the exact *criterion* for when the
  logarithm jumps (`Nat.log_lt_log_succ_iff`, `Nat.log_eq_log_succ_iff`, `Data/Nat/Log.lean:250`
  and `:258`) but not the resulting one-step bound. Control: `Nat.log_mono_right` resolves at
  `:247`.
* **Any `Tendsto` statement about `Nat.log` or `padicValNat`** — absent from the whole Mathlib
  tree, however spelled.
* `padicValNat_le_nat_log` (`NumberTheory/Padics/PadicVal/Basic.lean:466`) **is** Mathlib's and is
  consumed, not restated — it is the domination that reduces the third result to the second.

## Three porting adjustments, none cosmetic

* **`lia` → `omega`.** The source uses `lia` five times. It is not this repository's idiom —
  `omega` appears in 531 files on `main` — and a copy-paste port does not compile here.
* **`pow_succ` → `Nat.pow_succ`** at two sites. The generic `Monoid` form does not match a
  natural-number literal power, and the rewrite fails with "did not find an occurrence of the
  pattern" on a goal that looks like it should match.
* **`mul_comm` → `Nat.mul_comm`** with explicit arguments, for the same reason and to pin the
  occurrence.

## Gates

`lake build` of both modules: exit 0, "Build completed successfully (1143 jobs)", zero errors and
zero warnings. Comment-stripped code scan for `sorry` / `native_decide` / `maxHeartbeats`: zero,
with a control confirming the scanner sees the declarations. No line exceeds 100 characters.
`#lint only simpNF` over `TauCeti.Data.Nat` and `TauCeti.NumberTheory.Padics`: "All linting checks
passed".
