### PR TITLE
refactor(WExpansion): free the base ring of the multivariate uniqueness statement

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -48,8 +48,8 @@ equation at the substituted parameter rather than at `z`.
 * `WeierstrassCurve.eq_of_wEquation_mvPowerSeries`: that same uniqueness one index type up, for
   series in `MvPowerSeries σ S` over any `R`-algebra `S` — so it survives scalar extension. It is
   a sibling of `eq_of_wEquation` and not a generalisation of it: filtering by total degree needs
-  subtraction, so this one asks for a `CommRing`, where the univariate statement holds over a
-  `CommSemiring`.
+  subtraction, so this one asks for `[CommRing S]` on the *coefficient algebra*. The curve's base
+  ring `R` is a `CommSemiring` for both.
 * `WeierstrassCurve.subst_wEquationRHS` and `WeierstrassCurve.subst_formalW_wEquation`:
   substituting a series `q` into the equation gives the equation at `q`, so `w(q)` solves it
   there. When moreover `constantCoeff q = 0`, `eq_subst_formalW_of_wEquation` combines this with
@@ -411,64 +411,15 @@ theorem eq_formalW_of_wEquation (w : PowerSeries R)
     w = formalW W :=
   eq_of_wEquation W (by simp) h0 (by simp) hw (formalW_wEquation W)
 
-/-! ### Substituting into the equation
-
-Substituting a series into the `w`-equation gives the equation at the substituted parameters. The
-`w`-equation makes sense in any commutative `R`-algebra, and substitution is an `R`-algebra map, so
-this is just the statement that `wEquationRHS` is built from `+`, `*`, `^` and the structure map.
-
-With `constantCoeff q = 0` — strictly stronger than `PowerSeries.HasSubst q`, which asks only that
-the constant coefficient be nilpotent — this combines with `eq_of_wEquation` to identify the
-substituted solution, which is `eq_subst_formalW_of_wEquation`.
-
-Mathlib's `PowerSeries.subst` is defined only over a `CommRing`, so this section is stated there;
-everything above needs no such hypothesis and keeps the `CommSemiring` of the rest of this file.
--/
-
-section CommRing
-
-variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
-
-/-- Substitution passes through the `w`-equation, carrying both the parameter and the unknown with
-it. Both sides are read in the target algebra, which is why `wEquationRHS` is stated for an
-arbitrary `R`-algebra: substituting a one-variable series into it lands in `MvPowerSeries τ S`. -/
-theorem subst_wEquationRHS {τ S : Type*} [CommRing S] [Algebra R S] {a : MvPowerSeries τ S}
-    (ha : PowerSeries.HasSubst a) (q v : PowerSeries R) :
-    PowerSeries.subst a (wEquationRHS W q v) =
-      wEquationRHS W (PowerSeries.subst a q) (PowerSeries.subst a v) := by
-  rw [wEquationRHS_def, wEquationRHS_def, ← PowerSeries.coe_substAlgHom ha]
-  simp only [map_add, map_mul, map_pow, AlgHom.commutes]
-
-/-- The `w`-expansion composed with a substitutable series `a` solves the `w`-equation at `a`. -/
-theorem subst_formalW_wEquation {τ S : Type*} [CommRing S] [Algebra R S] {a : MvPowerSeries τ S}
-    (ha : PowerSeries.HasSubst a) :
-    PowerSeries.subst a (formalW W) = wEquationRHS W a (PowerSeries.subst a (formalW W)) := by
-  conv_lhs => rw [formalW_wEquation W]
-  rw [subst_wEquationRHS W ha, PowerSeries.subst_X ha]
-
-/-- **The substituted `w`-expansion is the unique solution at the substituted parameter.** For a
-parameter `q` with vanishing constant coefficient, any series with vanishing constant coefficient
-solving the `w`-equation at `q` is `w(q)`.
-
-This is the composite the formal group consumes: `subst_formalW_wEquation` supplies a solution and
-`eq_of_wEquation` says there is only one. Note the hypothesis is `constantCoeff q = 0` rather than
-`PowerSeries.HasSubst q`; the latter asks only for a nilpotent constant coefficient, which is not
-enough for uniqueness. -/
-theorem eq_subst_formalW_of_wEquation {q v : PowerSeries R}
-    (hq : PowerSeries.constantCoeff q = 0) (hv : PowerSeries.constantCoeff v = 0)
-    (h : v = wEquationRHS W q v) : v = PowerSeries.subst q (formalW W) := by
-  have ha : PowerSeries.HasSubst q := PowerSeries.HasSubst.of_constantCoeff_zero' hq
-  refine eq_of_wEquation W hq hv ?_ h (subst_formalW_wEquation W ha)
-  exact PowerSeries.constantCoeff_subst_eq_zero hq (formalW W) (constantCoeff_formalW W)
-
 /-! ### Uniqueness over a multivariate power series ring
 
 `eq_of_wEquation` argues by strong induction on the coefficient index, which needs that index to be
 linearly ordered. Over `MvPowerSeries σ S` no such order is available, so the induction runs on the
 total degree instead: `MvPowerSeries.order` is exactly the filtration by total degree, and the
-right-hand side of the `w`-equation is a contraction for it. That argument needs additive inverses,
-so this material stays in the `CommRing` section rather than joining the `CommSemiring` development
-above; the two uniqueness statements are siblings and neither subsumes the other.
+right-hand side of the `w`-equation is a contraction for it. That argument needs additive inverses
+in the *coefficient algebra* `S`, and only there, which is why `[CommRing S]` appears below while
+the curve's base ring `R` stays a `CommSemiring`; the two uniqueness statements are siblings and
+neither subsumes the other.
 -/
 
 /-- **The right-hand side of the `w`-equation is a contraction for the total-degree filtration.**
@@ -531,7 +482,8 @@ The coefficients are taken in an arbitrary `R`-algebra `S`, matching `wEquationR
 substitution lemmas above, so the statement survives scalar extension of the curve's base ring.
 
 This is `eq_of_wEquation` one index type up. It is not a generalisation of it: the argument here
-subtracts, so it needs a `CommRing`, whereas the univariate statement holds over a `CommSemiring`.
+subtracts, so it needs `[CommRing S]` on the coefficient algebra, whereas the univariate statement
+needs no inverses at all. The base ring `R` is a `CommSemiring` in both.
 -/
 theorem eq_of_wEquation_mvPowerSeries {σ S : Type*} [CommRing S] [Algebra R S]
     {q v v' : MvPowerSeries σ S}
@@ -550,6 +502,56 @@ theorem eq_of_wEquation_mvPowerSeries {σ S : Type*} [CommRing S] [Algebra R S]
   have hzero : (v - v').order = ⊤ := ENat.eq_top_iff_forall_ge.mpr key
   rw [MvPowerSeries.order_eq_top_iff] at hzero
   exact sub_eq_zero.mp hzero
+
+/-! ### Substituting into the equation
+
+Substituting a series into the `w`-equation gives the equation at the substituted parameters. The
+`w`-equation makes sense in any commutative `R`-algebra, and substitution is an `R`-algebra map, so
+this is just the statement that `wEquationRHS` is built from `+`, `*`, `^` and the structure map.
+
+With `constantCoeff q = 0` — strictly stronger than `PowerSeries.HasSubst q`, which asks only that
+the constant coefficient be nilpotent — this combines with `eq_of_wEquation` to identify the
+substituted solution, which is `eq_subst_formalW_of_wEquation`.
+
+Mathlib's `PowerSeries.subst` is defined only over a `CommRing`, so this section is stated there;
+everything above needs no such hypothesis and keeps the `CommSemiring` of the rest of this file.
+-/
+
+section CommRing
+
+variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
+
+/-- Substitution passes through the `w`-equation, carrying both the parameter and the unknown with
+it. Both sides are read in the target algebra, which is why `wEquationRHS` is stated for an
+arbitrary `R`-algebra: substituting a one-variable series into it lands in `MvPowerSeries τ S`. -/
+theorem subst_wEquationRHS {τ S : Type*} [CommRing S] [Algebra R S] {a : MvPowerSeries τ S}
+    (ha : PowerSeries.HasSubst a) (q v : PowerSeries R) :
+    PowerSeries.subst a (wEquationRHS W q v) =
+      wEquationRHS W (PowerSeries.subst a q) (PowerSeries.subst a v) := by
+  rw [wEquationRHS_def, wEquationRHS_def, ← PowerSeries.coe_substAlgHom ha]
+  simp only [map_add, map_mul, map_pow, AlgHom.commutes]
+
+/-- The `w`-expansion composed with a substitutable series `a` solves the `w`-equation at `a`. -/
+theorem subst_formalW_wEquation {τ S : Type*} [CommRing S] [Algebra R S] {a : MvPowerSeries τ S}
+    (ha : PowerSeries.HasSubst a) :
+    PowerSeries.subst a (formalW W) = wEquationRHS W a (PowerSeries.subst a (formalW W)) := by
+  conv_lhs => rw [formalW_wEquation W]
+  rw [subst_wEquationRHS W ha, PowerSeries.subst_X ha]
+
+/-- **The substituted `w`-expansion is the unique solution at the substituted parameter.** For a
+parameter `q` with vanishing constant coefficient, any series with vanishing constant coefficient
+solving the `w`-equation at `q` is `w(q)`.
+
+This is the composite the formal group consumes: `subst_formalW_wEquation` supplies a solution and
+`eq_of_wEquation` says there is only one. Note the hypothesis is `constantCoeff q = 0` rather than
+`PowerSeries.HasSubst q`; the latter asks only for a nilpotent constant coefficient, which is not
+enough for uniqueness. -/
+theorem eq_subst_formalW_of_wEquation {q v : PowerSeries R}
+    (hq : PowerSeries.constantCoeff q = 0) (hv : PowerSeries.constantCoeff v = 0)
+    (h : v = wEquationRHS W q v) : v = PowerSeries.subst q (formalW W) := by
+  have ha : PowerSeries.HasSubst q := PowerSeries.HasSubst.of_constantCoeff_zero' hq
+  refine eq_of_wEquation W hq hv ?_ h (subst_formalW_wEquation W ha)
+  exact PowerSeries.constantCoeff_subst_eq_zero hq (formalW W) (constantCoeff_formalW W)
 
 /-! ### Base change
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/WExpansion.lean
@@ -479,7 +479,7 @@ series with vanishing constant coefficient that satisfy the `w`-equation at the 
 are equal, provided `q` too has vanishing constant coefficient.
 
 The coefficients are taken in an arbitrary `R`-algebra `S`, matching `wEquationRHS` itself and the
-substitution lemmas above, so the statement survives scalar extension of the curve's base ring.
+substitution lemmas, so the statement survives scalar extension of the curve's base ring.
 
 This is `eq_of_wEquation` one index type up. It is not a generalisation of it: the argument here
 subtracts, so it needs `[CommRing S]` on the coefficient algebra, whereas the univariate statement


### PR DESCRIPTION
`eq_of_wEquation_mvPowerSeries` and its private contraction lemma take coefficients in an arbitrary
`R`-algebra `S` and subtract only there — but they sit inside `section CommRing`, so they also
inherit `[CommRing R]` on the curve's own base ring. No proof in them uses an inverse in `R`. That
hypothesis is therefore strictly stronger than anything needed, and it makes the multivariate
uniqueness unusable for a curve over a `CommSemiring` base even though it holds there.

This moves the `### Uniqueness over a multivariate power series ring` subsection out of
`section CommRing`, under the file's outer `[CommSemiring R]`. **The declarations are unchanged —
only their placement moves.** The elaborated signature becomes

```
{R} [CommSemiring R] (W) {σ S} [CommRing S] [Algebra R S] {q v v' : MvPowerSeries σ S}
```

obtained with `#check`, not read off the source.

### Three docstrings blamed the wrong ring

* the module bullet said the statement "asks for a `CommRing`" without saying which;
* the subsection header justified the old placement outright — "needs additive inverses, so this
  material stays in the `CommRing` section";
* the theorem's own note said "it needs a `CommRing`, whereas the univariate statement holds over a
  `CommSemiring`", which reads as a claim about `R`.

All three now say `[CommRing S]` on the *coefficient algebra*, with `R` a `CommSemiring` in both
statements. The sibling relationship with `eq_of_wEquation` is unchanged and still stated: neither
subsumes the other.

### Provenance

Follow-up to #4968, which landed the widening of the coefficients to `S`. The base-ring half was
identified by a [review finding on #4978](https://github.com/TauCetiProject/TauCeti/pull/4978#discussion_r3879717356)
and did not land: that PR was closed as superseded by #4968, which had already merged three hours
before the finding was raised and was never asked for it. Nothing here is a criticism of #4968 —
its final board was all ten green.

### Gates

* `lake build` of the changed module — 1775 jobs, success.
* `lake build` of **all three direct importers** — `FormalGroup/Inverse`, `FormalGroup/Eval`,
  `FormalGroup/Chord` — 2079 jobs, success. This is the load-bearing gate for a placement change:
  moving declarations across a section boundary alters which instances are in scope at their use
  sites, and the changed module alone would not show a downstream break.
* `lake env lean` on the changed file — exit 0, zero bytes: no errors, warnings or `info:`.
* `#lint only simpNF in TauCeti` over the module — 0 errors in **52 declarations** (a nonzero
  count, so the linter is seeing the file).
* Style: max width 99 characters, no trailing whitespace.

Roadmap: EllipticCurves
