### PR TITLE
refactor(AlgebraicGroup): prove the parabolic-point coercion bridge directly

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/Kernel.lean
@@ -78,16 +78,8 @@ theorem mem_weightUnipotentInParabolicPointsSubgroup_iff_limit_eq_one
     have hcoe : (p : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R N)
         (CommAlgCat.of R A)) =
         CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra R N)
-          (weightParabolicDefiningHopfIdeal R w) (CommAlgCat.of R A) g := by
-      let p' : Cocharacter.parabolic A (weightCocharacter (R := R) w) :=
-        eqToHom (Cocharacter.parabolicFunctor_obj
-          (weightCocharacter (R := R) w) (CommAlgCat.of R A))
-          ((weightParabolicPointsIso R w).hom.app (CommAlgCat.of R A) g)
-      have hp : p = p' := by
-        apply Subtype.ext
-        rfl
-      rw [hp]
-      exact coe_weightParabolicPointsIso_hom_app_apply R w g
+          (weightParabolicDefiningHopfIdeal R w) (CommAlgCat.of R A) g :=
+      coe_weightParabolicPointsIso_hom_app_apply R w g
     have hpUnipotent : (p : HopfAlgebra.points
         (R := R) (H := coordinateHopfAlgebra R N) (CommAlgCat.of R A)) ∈
         Cocharacter.unipotent A (weightCocharacter (R := R) w) := by


### PR DESCRIPTION
Collapse a nine-line detour in the weight-Levi kernel proof to the term it was working around.

## What was there

The forward branch of `mem_weightUnipotentInParabolicPointsSubgroup_iff_limit_eq_one` needs the
bridge

```lean
hcoe : (p : HopfAlgebra.points ..) = CommHopfAlgCat.quotientPointsHom .. g
```

where `p` is the `let`-bound `(weightParabolicPointsIso R w).hom.app (CommAlgCat.of R A) g`. It got
there the long way:

```lean
      let p' : Cocharacter.parabolic A (weightCocharacter (R := R) w) :=
        eqToHom (Cocharacter.parabolicFunctor_obj
          (weightCocharacter (R := R) w) (CommAlgCat.of R A))
          ((weightParabolicPointsIso R w).hom.app (CommAlgCat.of R A) g)
      have hp : p = p' := by
        apply Subtype.ext
        rfl
      rw [hp]
      exact coe_weightParabolicPointsIso_hom_app_apply R w g
```

The detour exists because `coe_weightParabolicPointsIso_hom_app_apply`
(`Weight/Parabolic.lean:112`) is stated about the `eqToHom`-**transported** point, while `p` is
untransported.

## Why it can go

That transport is definitional — which the proof itself was already saying, since `hp` is closed by
`Subtype.ext rfl`. So the lemma applies to the untransported goal directly and the whole block
becomes

```lean
          (weightParabolicDefiningHopfIdeal R w) (CommAlgCat.of R A) g :=
      coe_weightParabolicPointsIso_hom_app_apply R w g
```

The tell was internal to the file: the **backward** branch of the same theorem crosses the identical
gap in one step, `rw [← coe_weightParabolicPointsIso_hom_app_apply R w g]`, with no `p'` and no
`eqToHom`. One branch treating as nine lines what its twin does in one is a strong hint that the
long form is scaffolding rather than content.

| | before | after |
|---|---|---|
| `…_iff_limit_eq_one` proof body | 80 lines | **72 lines** |

## Notes for review

- Gate: `lake build` of the changed module on a tree rebased onto current `main` — exit 0, zero
  warnings, 3428 jobs. The module is a **leaf** (0 importers; control: the same query returns 6 for
  `Solvable.Basic`), so that is the complete module-scoped gate.
- This is a pure golf: no declaration added, removed, renamed or restated, and no statement
  changed. The proof of the enclosing theorem is the only thing touched.
- It does **not** by itself bring the proof under the 50-line guidance (72 lines). Whether the
  remainder wants decomposing is a separate question and a separate PR; I did not want to mix a
  golf with an extraction.
- **Cleanup disclosure.** The standing rule is a full `/cleanup` on every changed `.lean` file, or
  `fm-cleanup` slung to the cleanup-crew. Neither route is available to me: no `/cleanup` skill is
  loaded in this session, and `gc sling leancity.cleanup-crew fm-cleanup` is rejected with
  `convoy_id requires a targeted formulas v2 invocation`. Rather than claim a cleanup I did not
  run, I am saying so. Verified by hand on the changed region: no line over 100 characters, the
  removed `p'`/`hp` bindings have no other use in the file, and no docstring describes the proof.

Roadmap: ReductiveGroups
