### PR TITLE
feat: additivity of the Jordan-Hölder multiplicities

### DIFF
--- a/TauCeti/Algebra/Module/Submodule/Quotient.lean
+++ b/TauCeti/Algebra/Module/Submodule/Quotient.lean
@@ -139,11 +139,23 @@ noncomputable def mapSubquotientEquivOfInjective (f : M →ₗ[R] N) (hf : Funct
 
 /-- `TauCeti.mapSubquotientEquivOfInjective` read on representatives: its inverse is induced by
 the restriction `Submodule.equivMapOfInjective` of `f` to `B`. -/
+@[simp]
 theorem mapSubquotientEquivOfInjective_symm_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
     (A B : Submodule R M) (x : ↥B) :
     (mapSubquotientEquivOfInjective f hf A B).symm (Submodule.Quotient.mk x) =
       Submodule.Quotient.mk (Submodule.equivMapOfInjective f hf B x) :=
   (rfl)
+
+/-- `TauCeti.mapSubquotientEquivOfInjective` read on representatives, in the forward direction:
+it undoes the restriction `Submodule.equivMapOfInjective` of `f` to `B`. -/
+@[simp]
+theorem mapSubquotientEquivOfInjective_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (A B : Submodule R M) (x : ↥B) :
+    mapSubquotientEquivOfInjective f hf A B
+        (Submodule.Quotient.mk (Submodule.equivMapOfInjective f hf B x)) =
+      Submodule.Quotient.mk x := by
+  rw [← mapSubquotientEquivOfInjective_symm_apply f hf A B x,
+    LinearEquiv.apply_symm_apply]
 
 /-- The kernel of `x ↦ f x mod A`, on the preimage of `B`, is the trace of the preimage of `A`. -/
 theorem ker_mkQ_comp_submoduleComap (f : M →ₗ[R] N) (A B : Submodule R N) :
@@ -166,11 +178,22 @@ noncomputable def comapSubquotientEquivOfSurjective (f : M →ₗ[R] N) (hf : Fu
 
 /-- `TauCeti.comapSubquotientEquivOfSurjective` read on representatives: it is induced by the
 restriction `LinearMap.submoduleComap` of `f` to the preimage of `B`. -/
+@[simp]
 theorem comapSubquotientEquivOfSurjective_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)
     (A B : Submodule R N) (x : ↥(B.comap f)) :
     comapSubquotientEquivOfSurjective f hf A B (Submodule.Quotient.mk x) =
       Submodule.Quotient.mk (f.submoduleComap B x) :=
   (rfl)
+
+/-- `TauCeti.comapSubquotientEquivOfSurjective` read on representatives, in the inverse direction:
+it undoes the restriction `LinearMap.submoduleComap` of `f` to the preimage of `B`. -/
+@[simp]
+theorem comapSubquotientEquivOfSurjective_symm_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (A B : Submodule R N) (x : ↥(B.comap f)) :
+    (comapSubquotientEquivOfSurjective f hf A B).symm
+        (Submodule.Quotient.mk (f.submoduleComap B x)) = Submodule.Quotient.mk x := by
+  rw [← comapSubquotientEquivOfSurjective_apply f hf A B x,
+    LinearEquiv.symm_apply_apply]
 
 end Subquotient
 

--- a/TauCeti/Algebra/Module/Submodule/Quotient.lean
+++ b/TauCeti/Algebra/Module/Submodule/Quotient.lean
@@ -140,8 +140,9 @@ the restriction `Submodule.equivMapOfInjective` of `f` to `B`. -/
 theorem mapSubquotientEquivOfInjective_symm_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
     (A B : Submodule R M) (x : ↥B) :
     (mapSubquotientEquivOfInjective f hf A B).symm (Submodule.Quotient.mk x) =
-      Submodule.Quotient.mk (Submodule.equivMapOfInjective f hf B x) :=
-  (rfl)
+      Submodule.Quotient.mk (Submodule.equivMapOfInjective f hf B x) := by
+  rw [mapSubquotientEquivOfInjective, LinearEquiv.symm_symm, Submodule.Quotient.equiv_apply,
+    Submodule.mapQ_apply, LinearEquiv.coe_coe]
 
 /-- `TauCeti.mapSubquotientEquivOfInjective` read on representatives, in the forward direction:
 it undoes the restriction `Submodule.equivMapOfInjective` of `f` to `B`. -/
@@ -179,8 +180,9 @@ restriction `LinearMap.submoduleComap` of `f` to the preimage of `B`. -/
 theorem comapSubquotientEquivOfSurjective_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)
     (A B : Submodule R N) (x : ↥(B.comap f)) :
     comapSubquotientEquivOfSurjective f hf A B (Submodule.Quotient.mk x) =
-      Submodule.Quotient.mk (f.submoduleComap B x) :=
-  (rfl)
+      Submodule.Quotient.mk (f.submoduleComap B x) := by
+  rw [comapSubquotientEquivOfSurjective, LinearEquiv.trans_apply, Submodule.quotEquivOfEq_mk,
+    LinearMap.quotKerEquivOfSurjective_apply_mk, LinearMap.comp_apply, Submodule.mkQ_apply]
 
 /-- `TauCeti.comapSubquotientEquivOfSurjective` read on representatives, in the inverse direction:
 it undoes the restriction `LinearMap.submoduleComap` of `f` to the preimage of `B`. -/

--- a/TauCeti/Algebra/Module/Submodule/Quotient.lean
+++ b/TauCeti/Algebra/Module/Submodule/Quotient.lean
@@ -5,13 +5,15 @@ Authors: Codex
 -/
 module
 
+public import Mathlib.LinearAlgebra.Isomorphisms
 public import Mathlib.LinearAlgebra.Quotient.Basic
 
 /-!
 # Submodule intervals and quotients
 
 This file records the generic order correspondence between a submodule interval and submodules of
-the associated quotient.
+the associated quotient, and the identifications of *subquotients* `↥B ⧸ A` that a linear map
+induces when it is injective or surjective.
 
 ## Main declarations
 
@@ -19,6 +21,10 @@ the associated quotient.
   along the inclusion.
 * `TauCeti.iccOrderIsoQuotientOfMapEq`: the interval/quotient correspondence for a
   specified copy of the lower endpoint inside the upper endpoint.
+* `TauCeti.mapSubquotientEquivOfInjective`: an injective linear map identifies the subquotient of
+  the images of two submodules with the subquotient of the two submodules themselves.
+* `TauCeti.comapSubquotientEquivOfSurjective`: a surjective linear map identifies the subquotient
+  of the preimages of two submodules with the subquotient of the two submodules themselves.
 -/
 
 public section
@@ -98,5 +104,74 @@ theorem mem_iccOrderIsoQuotientOfMapEq_symm_apply_iff {p q : Submodule R M}
       ((iccOrderIsoQuotientOfMapEq r hr).symm Q) x).symm
 
 end QuotientInterval
+
+section Subquotient
+
+variable {R M N : Type*} [Ring R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+
+/-- An injective linear map carries the trace of `A` in `B` onto the trace of `A.map f` in
+`B.map f`, so it descends to the subquotients. -/
+theorem map_equivMapOfInjective_comap_subtype (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (A B : Submodule R M) :
+    Submodule.map ((Submodule.equivMapOfInjective f hf B : ↥B ≃ₗ[R] ↥(B.map f)) :
+        ↥B →ₗ[R] ↥(B.map f)) (Submodule.comap B.subtype A)
+      = Submodule.comap (B.map f).subtype (A.map f) := by
+  ext y
+  simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨(x : M), hx, (Submodule.coe_equivMapOfInjective_apply f hf B x).symm⟩
+  · rintro ⟨a, ha, hay⟩
+    obtain ⟨b, hb, hby⟩ := y.2
+    have haB : a ∈ B := by rw [hf (hay.trans hby.symm)]; exact hb
+    exact ⟨⟨a, haB⟩, ha, Subtype.ext
+      ((Submodule.coe_equivMapOfInjective_apply f hf B ⟨a, haB⟩).trans hay)⟩
+
+/-- **An injective linear map identifies subquotients.**  For arbitrary submodules `A`, `B` of `M`
+the subquotient cut out by the images `A.map f`, `B.map f` is the subquotient cut out by `A` and
+`B` themselves; for `A ≤ B` this reads `B.map f ⧸ A.map f ≃ₗ[R] B ⧸ A`. -/
+noncomputable def mapSubquotientEquivOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (A B : Submodule R M) :
+    (↥(B.map f) ⧸ Submodule.comap (B.map f).subtype (A.map f)) ≃ₗ[R]
+      (↥B ⧸ Submodule.comap B.subtype A) :=
+  (Submodule.Quotient.equiv _ _ (Submodule.equivMapOfInjective f hf B)
+    (map_equivMapOfInjective_comap_subtype f hf A B)).symm
+
+/-- `TauCeti.mapSubquotientEquivOfInjective` read on representatives: its inverse is induced by
+the restriction `Submodule.equivMapOfInjective` of `f` to `B`. -/
+theorem mapSubquotientEquivOfInjective_symm_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (A B : Submodule R M) (x : ↥B) :
+    (mapSubquotientEquivOfInjective f hf A B).symm (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (Submodule.equivMapOfInjective f hf B x) :=
+  (rfl)
+
+/-- The kernel of `x ↦ f x mod A`, on the preimage of `B`, is the trace of the preimage of `A`. -/
+theorem ker_mkQ_comp_submoduleComap (f : M →ₗ[R] N) (A B : Submodule R N) :
+    LinearMap.ker ((Submodule.comap B.subtype A).mkQ ∘ₗ f.submoduleComap B)
+      = Submodule.comap (B.comap f).subtype (A.comap f) := by
+  ext x
+  simp
+
+/-- **A surjective linear map identifies subquotients.**  For arbitrary submodules `A`, `B` of `N`
+the subquotient cut out by the preimages `A.comap f`, `B.comap f` is the subquotient cut out by `A`
+and `B` themselves; for `A ≤ B` this reads `B.comap f ⧸ A.comap f ≃ₗ[R] B ⧸ A`. -/
+noncomputable def comapSubquotientEquivOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (A B : Submodule R N) :
+    (↥(B.comap f) ⧸ Submodule.comap (B.comap f).subtype (A.comap f)) ≃ₗ[R]
+      (↥B ⧸ Submodule.comap B.subtype A) :=
+  (Submodule.quotEquivOfEq _ _ (ker_mkQ_comp_submoduleComap f A B).symm).trans
+    (LinearMap.quotKerEquivOfSurjective _
+      ((Submodule.mkQ_surjective _).comp
+        (LinearMap.submoduleComap_surjective_of_surjective f B hf)))
+
+/-- `TauCeti.comapSubquotientEquivOfSurjective` read on representatives: it is induced by the
+restriction `LinearMap.submoduleComap` of `f` to the preimage of `B`. -/
+theorem comapSubquotientEquivOfSurjective_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (A B : Submodule R N) (x : ↥(B.comap f)) :
+    comapSubquotientEquivOfSurjective f hf A B (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (f.submoduleComap B x) :=
+  (rfl)
+
+end Subquotient
 
 end TauCeti

--- a/TauCeti/Algebra/Module/Submodule/Quotient.lean
+++ b/TauCeti/Algebra/Module/Submodule/Quotient.lean
@@ -116,16 +116,13 @@ theorem map_equivMapOfInjective_comap_subtype (f : M →ₗ[R] N) (hf : Function
     Submodule.map ((Submodule.equivMapOfInjective f hf B : ↥B ≃ₗ[R] ↥(B.map f)) :
         ↥B →ₗ[R] ↥(B.map f)) (Submodule.comap B.subtype A)
       = Submodule.comap (B.map f).subtype (A.map f) := by
-  ext y
-  simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
-  constructor
-  · rintro ⟨x, hx, rfl⟩
-    exact ⟨(x : M), hx, (Submodule.coe_equivMapOfInjective_apply f hf B x).symm⟩
-  · rintro ⟨a, ha, hay⟩
-    obtain ⟨b, hb, hby⟩ := y.2
-    have haB : a ∈ B := by rw [hf (hay.trans hby.symm)]; exact hb
-    exact ⟨⟨a, haB⟩, ha, Subtype.ext
-      ((Submodule.coe_equivMapOfInjective_apply f hf B ⟨a, haB⟩).trans hay)⟩
+  refine Submodule.map_injective_of_injective (B.map f).injective_subtype ?_
+  have hcomp : (B.map f).subtype ∘ₗ
+      ((Submodule.equivMapOfInjective f hf B : ↥B ≃ₗ[R] ↥(B.map f)) : ↥B →ₗ[R] ↥(B.map f))
+        = f ∘ₗ B.subtype :=
+    LinearMap.ext fun x => Submodule.coe_equivMapOfInjective_apply f hf B x
+  rw [← Submodule.map_comp, hcomp, Submodule.map_comp, Submodule.map_comap_subtype,
+    Submodule.map_comap_subtype, Submodule.map_inf f hf]
 
 /-- **An injective linear map identifies subquotients.**  For arbitrary submodules `A`, `B` of `M`
 the subquotient cut out by the images `A.map f`, `B.map f` is the subquotient cut out by `A` and

--- a/TauCeti/RingTheory/CompositionSeries/Additivity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Additivity.lean
@@ -1,0 +1,404 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Fin
+public import Mathlib.LinearAlgebra.Isomorphisms
+public import TauCeti.RingTheory.CompositionSeries.Multiplicity
+
+/-!
+# Additivity of the Jordan-Hölder multiplicities
+
+The Jordan-Hölder multiplicity `[M : S]` counts the factors isomorphic to `S` in a composition
+series of `M`.  This file proves that it is **additive in a short exact sequence**: for a submodule
+`p` of a module `M` of finite length,
+
+`[M : S] = [p : S] + [M ⧸ p : S]`.
+
+Both the composition factors of `p` and those of `M ⧸ p` are composition factors of `M`, and no
+others are, so a single count splits in two.
+
+The proof glues a composition series of `p` and a composition series of `M ⧸ p` into one series of
+`M`.  Neither half is transported along an isomorphism of the ambient module, so
+`TauCeti.mapCompositionSeries` of `TauCeti/RingTheory/CompositionSeries/Basic.lean` does not apply:
+the lower half is carried along the *injective* map `p.subtype` and the upper half along the
+*surjective* map `p.mkQ`.  Those two transports are built here in the generality that makes them
+symmetric — an arbitrary injective, respectively surjective, linear map — and each rests on the
+identification of the subquotients it induces (`TauCeti.factorEquivMapOfInjective`,
+`TauCeti.factorEquivComapOfSurjective`), which is also what turns coverings into coverings.  The
+resulting series are glued with `RelSeries.smash`, whose index lemmas split the count.
+
+## Main definitions
+
+* `TauCeti.mapCompositionSeriesOfInjective`: the image of a composition series under an injective
+  linear map.
+* `TauCeti.comapCompositionSeriesOfSurjective`: the preimage of a composition series under a
+  surjective linear map.
+
+## Main results
+
+* `TauCeti.factorEquivMapOfInjective` and `TauCeti.factorEquivComapOfSurjective`: an injective map
+  identifies the subquotient `B ⧸ A` with the subquotient of its images, and a surjective map
+  identifies the subquotient of the preimages with `B ⧸ A`.
+* `TauCeti.compositionMultiplicity_smash`: the multiplicities of two composition series glued end
+  to end add.
+* `TauCeti.jordanHolderMultiplicity_eq_submodule_add_quotient`: **additivity**,
+  `[M : S] = [p : S] + [M ⧸ p : S]`.
+* `TauCeti.jordanHolderMultiplicity_eq_add_of_exact`: the same statement for a short exact sequence
+  `0 → A → M → B → 0`.
+* `TauCeti.jordanHolderMultiplicity_prod`: `[M × N : S] = [M : S] + [N : S]`.
+
+## Implementation notes
+
+`TauCeti.mapCompositionSeriesOfInjective` at a linear equivalence is definitionally
+`TauCeti.mapCompositionSeries`; the latter stays in
+`TauCeti/RingTheory/CompositionSeries/Basic.lean` because the transport lemmas of
+`TauCeti/RingTheory/CompositionSeries/Multiplicity.lean` are stated against it, and replacing it by
+the injective form is a refactor of its own.
+
+Coverings are transported through `covBy_iff_quot_is_simple` rather than through an order
+isomorphism: the two factor equivalences are needed anyway, and reading a covering as simplicity of
+its subquotient turns both transports into one line.  The alternative, `Set.OrdConnected` ranges,
+would need a separate argument for each of the two maps.
+
+## References
+
+The additivity of `[Pᵢ : Sⱼ]` is what makes the Cartan matrix of a finite-dimensional algebra
+computable, in Layer 3 of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` ("The Cartan matrix of an
+algebra"); `TauCeti/RingTheory/CompositionSeries/Multiplicity.lean` supplies the multiplicity
+itself.
+
+* Assem, Simson and Skowroński, *Elements of the Representation Theory of Associative Algebras* I,
+  §I.4.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v v' v'' w w'
+
+variable {R : Type u} [Ring R] {M : Type v} [AddCommGroup M] [Module R M]
+variable {N : Type v'} [AddCommGroup N] [Module R N]
+
+/-! ### Subquotients along an injective linear map -/
+
+section Injective
+
+/-- An injective linear map carries the trace of `A` in `B` onto the trace of `A.map f` in
+`B.map f`, so it descends to the subquotients. -/
+theorem map_equivMapOfInjective_comap_subtype (f : M →ₗ[R] N) (hf : Function.Injective f)
+    {A B : Submodule R M} (hAB : A ≤ B) :
+    Submodule.map ((Submodule.equivMapOfInjective f hf B : ↥B ≃ₗ[R] ↥(B.map f)) :
+        ↥B →ₗ[R] ↥(B.map f)) (Submodule.comap B.subtype A)
+      = Submodule.comap (B.map f).subtype (A.map f) := by
+  ext y
+  simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨(x : M), hx, (Submodule.coe_equivMapOfInjective_apply f hf B x).symm⟩
+  · rintro ⟨a, ha, hay⟩
+    exact ⟨⟨a, hAB ha⟩, ha, Subtype.ext
+      ((Submodule.coe_equivMapOfInjective_apply f hf B ⟨a, hAB ha⟩).trans hay)⟩
+
+/-- **An injective linear map identifies subquotients.**  For `A ≤ B` the subquotient of the images
+`A.map f ≤ B.map f` is the subquotient `B ⧸ A` itself. -/
+noncomputable def factorEquivMapOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
+    {A B : Submodule R M} (hAB : A ≤ B) :
+    (↥(B.map f) ⧸ Submodule.comap (B.map f).subtype (A.map f)) ≃ₗ[R]
+      (↥B ⧸ Submodule.comap B.subtype A) :=
+  (Submodule.Quotient.equiv _ _ (Submodule.equivMapOfInjective f hf B)
+    (map_equivMapOfInjective_comap_subtype f hf hAB)).symm
+
+/-- An injective linear map preserves coverings of submodules: the subquotient at the image is the
+subquotient itself, hence again simple. -/
+theorem covBy_map_of_injective (f : M →ₗ[R] N) (hf : Function.Injective f) {A B : Submodule R M}
+    (h : A ⋖ B) : A.map f ⋖ B.map f := by
+  have hsimple : IsSimpleModule R (↥B ⧸ Submodule.comap B.subtype A) :=
+    (covBy_iff_quot_is_simple h.le).mp h
+  exact (covBy_iff_quot_is_simple (Submodule.map_mono h.le)).mpr
+    (IsSimpleModule.congr (factorEquivMapOfInjective f hf h.le))
+
+end Injective
+
+/-! ### Subquotients along a surjective linear map -/
+
+section Surjective
+
+variable (f : M →ₗ[R] N)
+
+/-- A linear map restricted to the preimage of a submodule. -/
+def restrictComap (B : Submodule R N) : ↥(B.comap f) →ₗ[R] ↥B :=
+  f.restrict fun _ hx => hx
+
+@[simp]
+theorem coe_restrictComap_apply (B : Submodule R N) (x : ↥(B.comap f)) :
+    (restrictComap f B x : N) = f x :=
+  (rfl)
+
+theorem restrictComap_surjective (hf : Function.Surjective f) (B : Submodule R N) :
+    Function.Surjective (restrictComap f B) := fun y => by
+  obtain ⟨x, hx⟩ := hf (y : N)
+  refine ⟨⟨x, ?_⟩, Subtype.ext ?_⟩ <;> simp [hx]
+
+/-- The kernel of `X ↦ f X mod A`, on the preimage of `B`, is the trace of the preimage of `A`. -/
+theorem ker_mkQ_comp_restrictComap (A B : Submodule R N) :
+    LinearMap.ker ((Submodule.comap B.subtype A).mkQ ∘ₗ restrictComap f B)
+      = Submodule.comap (B.comap f).subtype (A.comap f) := by
+  ext x
+  simp
+
+/-- **A surjective linear map identifies subquotients.**  For `A ≤ B` the subquotient of the
+preimages `A.comap f ≤ B.comap f` is the subquotient `B ⧸ A` itself. -/
+noncomputable def factorEquivComapOfSurjective (hf : Function.Surjective f) (A B : Submodule R N) :
+    (↥(B.comap f) ⧸ Submodule.comap (B.comap f).subtype (A.comap f)) ≃ₗ[R]
+      (↥B ⧸ Submodule.comap B.subtype A) :=
+  (Submodule.quotEquivOfEq _ _ (ker_mkQ_comp_restrictComap f A B).symm).trans
+    (LinearMap.quotKerEquivOfSurjective _
+      ((Submodule.mkQ_surjective _).comp (restrictComap_surjective f hf B)))
+
+/-- A surjective linear map preserves coverings of submodules: the subquotient at the preimage is
+the subquotient itself, hence again simple. -/
+theorem covBy_comap_of_surjective (hf : Function.Surjective f) {A B : Submodule R N} (h : A ⋖ B) :
+    A.comap f ⋖ B.comap f := by
+  have hsimple : IsSimpleModule R (↥B ⧸ Submodule.comap B.subtype A) :=
+    (covBy_iff_quot_is_simple h.le).mp h
+  exact (covBy_iff_quot_is_simple (Submodule.comap_mono h.le)).mpr
+    (IsSimpleModule.congr (factorEquivComapOfSurjective f hf A B))
+
+end Surjective
+
+/-! ### Transporting a composition series along an injective or a surjective map -/
+
+/-- The image of a composition series under an injective linear map.  As in
+`TauCeti.mapCompositionSeries`, the body is `@[expose]`d so that
+`mapCompositionSeriesOfInjective f hf s i` is definitionally `Submodule.map f (s i)`, which is what
+the factor lemmas below rest on. -/
+@[expose] def mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) : CompositionSeries (Submodule R N) :=
+  s.map ⟨fun A => A.map f, fun h => covBy_map_of_injective f hf h⟩
+
+@[simp]
+theorem mapCompositionSeriesOfInjective_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) (i : Fin (s.length + 1)) :
+    mapCompositionSeriesOfInjective f hf s i = (s i).map f :=
+  (rfl)
+
+@[simp]
+theorem mapCompositionSeriesOfInjective_length (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) :
+    (mapCompositionSeriesOfInjective f hf s).length = s.length :=
+  (rfl)
+
+@[simp]
+theorem head_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) :
+    (mapCompositionSeriesOfInjective f hf s).head = s.head.map f :=
+  (rfl)
+
+@[simp]
+theorem last_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) :
+    (mapCompositionSeriesOfInjective f hf s).last = s.last.map f :=
+  (rfl)
+
+/-- The preimage of a composition series under a surjective linear map.  The body is `@[expose]`d
+for the same reason as `TauCeti.mapCompositionSeriesOfInjective`. -/
+@[expose] def comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) : CompositionSeries (Submodule R M) :=
+  s.map ⟨fun A => A.comap f, fun h => covBy_comap_of_surjective f hf h⟩
+
+@[simp]
+theorem comapCompositionSeriesOfSurjective_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) (i : Fin (s.length + 1)) :
+    comapCompositionSeriesOfSurjective f hf s i = (s i).comap f :=
+  (rfl)
+
+@[simp]
+theorem comapCompositionSeriesOfSurjective_length (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) :
+    (comapCompositionSeriesOfSurjective f hf s).length = s.length :=
+  (rfl)
+
+@[simp]
+theorem head_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) :
+    (comapCompositionSeriesOfSurjective f hf s).head = s.head.comap f :=
+  (rfl)
+
+@[simp]
+theorem last_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) :
+    (comapCompositionSeriesOfSurjective f hf s).last = s.last.comap f :=
+  (rfl)
+
+/-! ### The factors of the transported series -/
+
+variable {S : Type v''} [AddCommGroup S] [Module R S]
+
+/-- Two composition series with the same two submodules at an index have the same factor there.
+The equalities are enough: the subquotient is built from the two submodules alone. -/
+theorem isCompositionFactorAt_congr_of_eq {s t : CompositionSeries (Submodule R M)}
+    {i : Fin s.length} {j : Fin t.length} (hsucc : s i.succ = t j.succ)
+    (hcast : s i.castSucc = t j.castSucc) :
+    IsCompositionFactorAt s i S ↔ IsCompositionFactorAt t j S := by
+  rw [isCompositionFactorAt_iff, isCompositionFactorAt_iff, hcast, hsucc]
+
+@[simp]
+theorem isCompositionFactorAt_mapCompositionSeriesOfInjective_iff (f : M →ₗ[R] N)
+    (hf : Function.Injective f) (s : CompositionSeries (Submodule R M)) (i : Fin s.length) :
+    IsCompositionFactorAt (mapCompositionSeriesOfInjective f hf s) i S ↔
+      IsCompositionFactorAt s i S :=
+  isCompositionFactorAt_iff.trans
+    (Iff.trans
+      ⟨fun ⟨g⟩ => ⟨(factorEquivMapOfInjective f hf (s.step i).le).symm.trans g⟩,
+        fun ⟨g⟩ => ⟨(factorEquivMapOfInjective f hf (s.step i).le).trans g⟩⟩
+      isCompositionFactorAt_iff.symm)
+
+@[simp]
+theorem isCompositionFactorAt_comapCompositionSeriesOfSurjective_iff (f : M →ₗ[R] N)
+    (hf : Function.Surjective f) (s : CompositionSeries (Submodule R N)) (i : Fin s.length) :
+    IsCompositionFactorAt (comapCompositionSeriesOfSurjective f hf s) i S ↔
+      IsCompositionFactorAt s i S :=
+  isCompositionFactorAt_iff.trans
+    (Iff.trans
+      ⟨fun ⟨g⟩ => ⟨(factorEquivComapOfSurjective f hf (s i.castSucc) (s i.succ)).symm.trans g⟩,
+        fun ⟨g⟩ => ⟨(factorEquivComapOfSurjective f hf (s i.castSucc) (s i.succ)).trans g⟩⟩
+      isCompositionFactorAt_iff.symm)
+
+/-- **An injective map preserves multiplicities**: the image of a composition series counts every
+module the same number of times as the series itself. -/
+@[simp]
+theorem compositionMultiplicity_mapCompositionSeriesOfInjective (f : M →ₗ[R] N)
+    (hf : Function.Injective f) (s : CompositionSeries (Submodule R M)) :
+    compositionMultiplicity (mapCompositionSeriesOfInjective f hf s) S =
+      compositionMultiplicity s S := by
+  rw [compositionMultiplicity_def, compositionMultiplicity_def]
+  exact Nat.card_congr (Equiv.subtypeEquivRight fun i =>
+    isCompositionFactorAt_mapCompositionSeriesOfInjective_iff f hf s i)
+
+/-- **A surjective map preserves multiplicities**: the preimage of a composition series counts
+every module the same number of times as the series itself. -/
+@[simp]
+theorem compositionMultiplicity_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N)
+    (hf : Function.Surjective f) (s : CompositionSeries (Submodule R N)) :
+    compositionMultiplicity (comapCompositionSeriesOfSurjective f hf s) S =
+      compositionMultiplicity s S := by
+  rw [compositionMultiplicity_def, compositionMultiplicity_def]
+  exact Nat.card_congr (Equiv.subtypeEquivRight fun i =>
+    isCompositionFactorAt_comapCompositionSeriesOfSurjective_iff f hf s i)
+
+/-! ### Gluing two composition series -/
+
+section Smash
+
+variable (p q : CompositionSeries (Submodule R M)) (h : p.last = q.head)
+
+theorem isCompositionFactorAt_smash_castAdd (i : Fin p.length) :
+    IsCompositionFactorAt (p.smash q h) (i.castAdd q.length) S ↔ IsCompositionFactorAt p i S :=
+  isCompositionFactorAt_congr_of_eq (RelSeries.smash_succ_castAdd h i)
+    (RelSeries.smash_castAdd h i)
+
+theorem isCompositionFactorAt_smash_natAdd (i : Fin q.length) :
+    IsCompositionFactorAt (p.smash q h) (i.natAdd p.length) S ↔ IsCompositionFactorAt q i S :=
+  isCompositionFactorAt_congr_of_eq (RelSeries.smash_succ_natAdd h i)
+    (RelSeries.smash_natAdd h i)
+
+/-- **Gluing adds multiplicities.**  Two composition series joined end to end count every module as
+often as the two of them together. -/
+theorem compositionMultiplicity_smash :
+    compositionMultiplicity (p.smash q h) S =
+      compositionMultiplicity p S + compositionMultiplicity q S := by
+  classical
+  have key : ∀ t : CompositionSeries (Submodule R M),
+      compositionMultiplicity t S =
+        ∑ i : Fin t.length, if IsCompositionFactorAt t i S then 1 else 0 := fun t => by
+    rw [compositionMultiplicity_def, Nat.card_eq_fintype_card, Fintype.card_subtype,
+      Finset.card_filter]
+  have hsplit :
+      (∑ i : Fin (p.length + q.length),
+          if IsCompositionFactorAt (p.smash q h) i S then 1 else 0)
+        = (∑ i : Fin p.length,
+            if IsCompositionFactorAt (p.smash q h) (i.castAdd q.length) S then 1 else 0)
+          + ∑ i : Fin q.length,
+            if IsCompositionFactorAt (p.smash q h) (i.natAdd p.length) S then 1 else 0 :=
+    Fin.sum_univ_add _
+  rw [key, key, key]
+  refine hsplit.trans (congrArg₂ (· + ·) (Finset.sum_congr rfl fun i _ => ?_)
+    (Finset.sum_congr rfl fun i _ => ?_))
+  · exact if_congr (isCompositionFactorAt_smash_castAdd p q h i) rfl rfl
+  · exact if_congr (isCompositionFactorAt_smash_natAdd p q h i) rfl rfl
+
+end Smash
+
+/-! ### Additivity of the Jordan-Hölder multiplicity -/
+
+/-- **The Jordan-Hölder multiplicity is additive.**  For a submodule `p` of a module of finite
+length, `[M : S] = [p : S] + [M ⧸ p : S]`: a composition series of `p`, pushed into `M` along
+`p.subtype`, and one of `M ⧸ p`, pulled back along `p.mkQ`, meet at `p` and glue to a composition
+series of `M`. -/
+theorem jordanHolderMultiplicity_eq_submodule_add_quotient [IsNoetherian R M] [IsArtinian R M]
+    (p : Submodule R M) :
+    jordanHolderMultiplicity R M S =
+      jordanHolderMultiplicity R p S + jordanHolderMultiplicity R (M ⧸ p) S := by
+  obtain ⟨t, htbot, httop⟩ := exists_compositionSeries_of_isNoetherian_isArtinian R p
+  obtain ⟨u, hubot, hutop⟩ := exists_compositionSeries_of_isNoetherian_isArtinian R (M ⧸ p)
+  set t' := mapCompositionSeriesOfInjective p.subtype p.injective_subtype t with ht'
+  set u' := comapCompositionSeriesOfSurjective p.mkQ p.mkQ_surjective u with hu'
+  have hconnect : t'.last = u'.head := by
+    rw [ht', hu', last_mapCompositionSeriesOfInjective, head_comapCompositionSeriesOfSurjective,
+      httop, hubot, Submodule.map_top, Submodule.range_subtype, Submodule.comap_bot,
+      Submodule.ker_mkQ]
+  have hbot : (t'.smash u' hconnect).head = ⊥ := by
+    rw [RelSeries.head_smash, ht', head_mapCompositionSeriesOfInjective, htbot, Submodule.map_bot]
+  have htop : (t'.smash u' hconnect).last = ⊤ := by
+    rw [RelSeries.last_smash, hu', last_comapCompositionSeriesOfSurjective, hutop,
+      Submodule.comap_top]
+  rw [← compositionMultiplicity_eq_jordanHolderMultiplicity _ hbot htop S,
+    compositionMultiplicity_smash, ht', hu',
+    compositionMultiplicity_mapCompositionSeriesOfInjective,
+    compositionMultiplicity_comapCompositionSeriesOfSurjective,
+    compositionMultiplicity_eq_jordanHolderMultiplicity t htbot httop S,
+    compositionMultiplicity_eq_jordanHolderMultiplicity u hubot hutop S]
+
+/-- A submodule contributes at most the whole module's multiplicity. -/
+theorem jordanHolderMultiplicity_submodule_le [IsNoetherian R M] [IsArtinian R M]
+    (p : Submodule R M) :
+    jordanHolderMultiplicity R p S ≤ jordanHolderMultiplicity R M S := by
+  rw [jordanHolderMultiplicity_eq_submodule_add_quotient p]
+  exact Nat.le_add_right _ _
+
+/-- A quotient contributes at most the whole module's multiplicity. -/
+theorem jordanHolderMultiplicity_quotient_le [IsNoetherian R M] [IsArtinian R M]
+    (p : Submodule R M) :
+    jordanHolderMultiplicity R (M ⧸ p) S ≤ jordanHolderMultiplicity R M S := by
+  rw [jordanHolderMultiplicity_eq_submodule_add_quotient p]
+  exact Nat.le_add_left _ _
+
+/-- **Additivity in a short exact sequence** `0 → A → M → B → 0`: the multiplicity of `S` in the
+middle term is the sum of its multiplicities in the two ends. -/
+theorem jordanHolderMultiplicity_eq_add_of_exact [IsNoetherian R M] [IsArtinian R M]
+    {A : Type w} [AddCommGroup A] [Module R A] [IsNoetherian R A] [IsArtinian R A]
+    {B : Type w'} [AddCommGroup B] [Module R B] [IsNoetherian R B] [IsArtinian R B]
+    (f : A →ₗ[R] M) (g : M →ₗ[R] B) (hf : Function.Injective f) (hg : Function.Surjective g)
+    (hfg : LinearMap.range f = LinearMap.ker g) :
+    jordanHolderMultiplicity R M S =
+      jordanHolderMultiplicity R A S + jordanHolderMultiplicity R B S := by
+  rw [jordanHolderMultiplicity_eq_submodule_add_quotient (LinearMap.range f),
+    jordanHolderMultiplicity_eq_of_linearEquiv (LinearEquiv.ofInjective f hf) S,
+    ← jordanHolderMultiplicity_eq_of_linearEquiv
+      ((Submodule.quotEquivOfEq _ _ hfg).trans (g.quotKerEquivOfSurjective hg)) S]
+
+/-- **Additivity on a binary product**: `[M × N : S] = [M : S] + [N : S]`. -/
+theorem jordanHolderMultiplicity_prod [IsNoetherian R M] [IsArtinian R M] [IsNoetherian R N]
+    [IsArtinian R N] :
+    jordanHolderMultiplicity R (M × N) S =
+      jordanHolderMultiplicity R M S + jordanHolderMultiplicity R N S :=
+  jordanHolderMultiplicity_eq_add_of_exact (LinearMap.inl R M N) (LinearMap.snd R M N)
+    (LinearMap.inl_injective) (LinearMap.snd_surjective) (LinearMap.range_inl R M N)
+
+end TauCeti

--- a/TauCeti/RingTheory/CompositionSeries/Additivity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Additivity.lean
@@ -26,9 +26,10 @@ The proof glues a composition series of `p` and a composition series of `M ⧸ p
 `TauCeti.mapCompositionSeries` of `TauCeti/RingTheory/CompositionSeries/Basic.lean` does not apply:
 the lower half is carried along the *injective* map `p.subtype` and the upper half along the
 *surjective* map `p.mkQ`.  Those two transports are built here in the generality that makes them
-symmetric — an arbitrary injective, respectively surjective, linear map — and each rests on the
-identification of the subquotients it induces (`TauCeti.factorEquivMapOfInjective`,
-`TauCeti.factorEquivComapOfSurjective`), which is also what turns coverings into coverings.  The
+symmetric — an arbitrary injective, respectively surjective, linear map — on top of Mathlib's
+`Submodule.map_covBy_of_injective` and `Submodule.comap_covBy_of_surjective`; that each keeps the
+factors themselves, and not just their number, is the identification of the subquotients the map
+induces (`TauCeti.factorEquivMapOfInjective`, `TauCeti.factorEquivComapOfSurjective`).  The
 resulting series are glued with `RelSeries.smash`, whose index lemmas split the count.
 
 ## Main definitions
@@ -59,10 +60,10 @@ resulting series are glued with `RelSeries.smash`, whose index lemmas split the 
 `TauCeti/RingTheory/CompositionSeries/Multiplicity.lean` are stated against it, and replacing it by
 the injective form is a refactor of its own.
 
-Coverings are transported through `covBy_iff_quot_is_simple` rather than through an order
-isomorphism: the two factor equivalences are needed anyway, and reading a covering as simplicity of
-its subquotient turns both transports into one line.  The alternative, `Set.OrdConnected` ranges,
-would need a separate argument for each of the two maps.
+The two factor equivalences are stated as `≃ₗ[R]` rather than as an isomorphism of the two
+subquotients' lattices, because what the multiplicity counts is the isomorphism class of each
+factor: `IsSimpleModule.congr` and `Nonempty (· ≃ₗ[R] S)` both read off a linear equivalence
+directly.
 
 ## References
 
@@ -114,15 +115,6 @@ noncomputable def factorEquivMapOfInjective (f : M →ₗ[R] N) (hf : Function.I
   (Submodule.Quotient.equiv _ _ (Submodule.equivMapOfInjective f hf B)
     (map_equivMapOfInjective_comap_subtype f hf hAB)).symm
 
-/-- An injective linear map preserves coverings of submodules: the subquotient at the image is the
-subquotient itself, hence again simple. -/
-theorem covBy_map_of_injective (f : M →ₗ[R] N) (hf : Function.Injective f) {A B : Submodule R M}
-    (h : A ⋖ B) : A.map f ⋖ B.map f := by
-  have hsimple : IsSimpleModule R (↥B ⧸ Submodule.comap B.subtype A) :=
-    (covBy_iff_quot_is_simple h.le).mp h
-  exact (covBy_iff_quot_is_simple (Submodule.map_mono h.le)).mpr
-    (IsSimpleModule.congr (factorEquivMapOfInjective f hf h.le))
-
 end Injective
 
 /-! ### Subquotients along a surjective linear map -/
@@ -131,23 +123,9 @@ section Surjective
 
 variable (f : M →ₗ[R] N)
 
-/-- A linear map restricted to the preimage of a submodule. -/
-def restrictComap (B : Submodule R N) : ↥(B.comap f) →ₗ[R] ↥B :=
-  f.restrict fun _ hx => hx
-
-@[simp]
-theorem coe_restrictComap_apply (B : Submodule R N) (x : ↥(B.comap f)) :
-    (restrictComap f B x : N) = f x :=
-  (rfl)
-
-theorem restrictComap_surjective (hf : Function.Surjective f) (B : Submodule R N) :
-    Function.Surjective (restrictComap f B) := fun y => by
-  obtain ⟨x, hx⟩ := hf (y : N)
-  refine ⟨⟨x, ?_⟩, Subtype.ext ?_⟩ <;> simp [hx]
-
 /-- The kernel of `X ↦ f X mod A`, on the preimage of `B`, is the trace of the preimage of `A`. -/
-theorem ker_mkQ_comp_restrictComap (A B : Submodule R N) :
-    LinearMap.ker ((Submodule.comap B.subtype A).mkQ ∘ₗ restrictComap f B)
+theorem ker_mkQ_comp_submoduleComap (A B : Submodule R N) :
+    LinearMap.ker ((Submodule.comap B.subtype A).mkQ ∘ₗ f.submoduleComap B)
       = Submodule.comap (B.comap f).subtype (A.comap f) := by
   ext x
   simp
@@ -157,18 +135,10 @@ preimages `A.comap f ≤ B.comap f` is the subquotient `B ⧸ A` itself. -/
 noncomputable def factorEquivComapOfSurjective (hf : Function.Surjective f) (A B : Submodule R N) :
     (↥(B.comap f) ⧸ Submodule.comap (B.comap f).subtype (A.comap f)) ≃ₗ[R]
       (↥B ⧸ Submodule.comap B.subtype A) :=
-  (Submodule.quotEquivOfEq _ _ (ker_mkQ_comp_restrictComap f A B).symm).trans
+  (Submodule.quotEquivOfEq _ _ (ker_mkQ_comp_submoduleComap f A B).symm).trans
     (LinearMap.quotKerEquivOfSurjective _
-      ((Submodule.mkQ_surjective _).comp (restrictComap_surjective f hf B)))
-
-/-- A surjective linear map preserves coverings of submodules: the subquotient at the preimage is
-the subquotient itself, hence again simple. -/
-theorem covBy_comap_of_surjective (hf : Function.Surjective f) {A B : Submodule R N} (h : A ⋖ B) :
-    A.comap f ⋖ B.comap f := by
-  have hsimple : IsSimpleModule R (↥B ⧸ Submodule.comap B.subtype A) :=
-    (covBy_iff_quot_is_simple h.le).mp h
-  exact (covBy_iff_quot_is_simple (Submodule.comap_mono h.le)).mpr
-    (IsSimpleModule.congr (factorEquivComapOfSurjective f hf A B))
+      ((Submodule.mkQ_surjective _).comp
+        (LinearMap.submoduleComap_surjective_of_surjective f B hf)))
 
 end Surjective
 
@@ -180,7 +150,7 @@ end Surjective
 the factor lemmas below rest on. -/
 @[expose] def mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
     (s : CompositionSeries (Submodule R M)) : CompositionSeries (Submodule R N) :=
-  s.map ⟨fun A => A.map f, fun h => covBy_map_of_injective f hf h⟩
+  s.map ⟨fun A => A.map f, Submodule.map_covBy_of_injective hf⟩
 
 @[simp]
 theorem mapCompositionSeriesOfInjective_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
@@ -210,7 +180,7 @@ theorem last_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.
 for the same reason as `TauCeti.mapCompositionSeriesOfInjective`. -/
 @[expose] def comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
     (s : CompositionSeries (Submodule R N)) : CompositionSeries (Submodule R M) :=
-  s.map ⟨fun A => A.comap f, fun h => covBy_comap_of_surjective f hf h⟩
+  s.map ⟨fun A => A.comap f, Submodule.comap_covBy_of_surjective hf⟩
 
 @[simp]
 theorem comapCompositionSeriesOfSurjective_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)

--- a/TauCeti/RingTheory/CompositionSeries/Additivity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Additivity.lean
@@ -188,6 +188,7 @@ theorem jordanHolderMultiplicity_le_of_surjective [IsNoetherian R M] [IsArtinian
   exact Nat.le_add_left _ _
 
 /-- **Additivity on a binary product**: `[M × N : S] = [M : S] + [N : S]`. -/
+@[simp]
 theorem jordanHolderMultiplicity_prod [IsNoetherian R M] [IsArtinian R M] [IsNoetherian R N]
     [IsArtinian R N] :
     jordanHolderMultiplicity R (M × N) S =

--- a/TauCeti/RingTheory/CompositionSeries/Additivity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Additivity.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.BigOperators.Fin
+public import Mathlib.Algebra.Exact.Basic
 public import Mathlib.LinearAlgebra.Isomorphisms
 public import TauCeti.RingTheory.CompositionSeries.Multiplicity
 
@@ -22,50 +23,37 @@ Both the composition factors of `p` and those of `M ⧸ p` are composition facto
 others are, so a single count splits in two.
 
 The proof glues a composition series of `p` and a composition series of `M ⧸ p` into one series of
-`M`.  Neither half is transported along an isomorphism of the ambient module, so
-`TauCeti.mapCompositionSeries` of `TauCeti/RingTheory/CompositionSeries/Basic.lean` does not apply:
-the lower half is carried along the *injective* map `p.subtype` and the upper half along the
-*surjective* map `p.mkQ`.  Those two transports are built here in the generality that makes them
-symmetric — an arbitrary injective, respectively surjective, linear map — on top of Mathlib's
-`Submodule.map_covBy_of_injective` and `Submodule.comap_covBy_of_surjective`; that each keeps the
-factors themselves, and not just their number, is the identification of the subquotients the map
-induces (`TauCeti.factorEquivMapOfInjective`, `TauCeti.factorEquivComapOfSurjective`).  The
-resulting series are glued with `RelSeries.smash`, whose index lemmas split the count.
-
-## Main definitions
-
-* `TauCeti.mapCompositionSeriesOfInjective`: the image of a composition series under an injective
-  linear map.
-* `TauCeti.comapCompositionSeriesOfSurjective`: the preimage of a composition series under a
-  surjective linear map.
+`M`: the lower half is carried along the *injective* map `p.subtype` by
+`TauCeti.mapCompositionSeriesOfInjective` and the upper half along the *surjective* map `p.mkQ` by
+`TauCeti.comapCompositionSeriesOfSurjective`, both of
+`TauCeti/RingTheory/CompositionSeries/Basic.lean`, which preserve every multiplicity.  The two
+resulting series meet at `p` and are glued with `RelSeries.smash`, whose `castAdd`/`natAdd` index
+lemmas split the count of factors isomorphic to `S` into the two halves.
 
 ## Main results
 
-* `TauCeti.factorEquivMapOfInjective` and `TauCeti.factorEquivComapOfSurjective`: an injective map
-  identifies the subquotient `B ⧸ A` with the subquotient of its images, and a surjective map
-  identifies the subquotient of the preimages with `B ⧸ A`.
 * `TauCeti.compositionMultiplicity_smash`: the multiplicities of two composition series glued end
   to end add.
 * `TauCeti.jordanHolderMultiplicity_eq_submodule_add_quotient`: **additivity**,
   `[M : S] = [p : S] + [M ⧸ p : S]`.
+* `TauCeti.jordanHolderMultiplicity_submodule_le` and
+  `TauCeti.jordanHolderMultiplicity_quotient_le`: a submodule and a quotient each contribute at
+  most the whole module's multiplicity.
 * `TauCeti.jordanHolderMultiplicity_eq_add_of_exact`: the same statement for a short exact sequence
   `0 → A → M → B → 0`.
 * `TauCeti.jordanHolderMultiplicity_prod`: `[M × N : S] = [M : S] + [N : S]`.
 
-## Implementation notes
-
-`TauCeti.mapCompositionSeriesOfInjective` at a linear equivalence is definitionally
-`TauCeti.mapCompositionSeries`; the latter stays in
-`TauCeti/RingTheory/CompositionSeries/Basic.lean` because the transport lemmas of
-`TauCeti/RingTheory/CompositionSeries/Multiplicity.lean` are stated against it, and replacing it by
-the injective form is a refactor of its own.
-
-The two factor equivalences are stated as `≃ₗ[R]` rather than as an isomorphism of the two
-subquotients' lattices, because what the multiplicity counts is the isomorphism class of each
-factor: `IsSimpleModule.congr` and `Nonempty (· ≃ₗ[R] S)` both read off a linear equivalence
-directly.
-
 ## References
+
+This file refines Mathlib's `Module.length_eq_add_of_exact` (`Mathlib/RingTheory/Length.lean`, by
+Andrew Yang) from counting the factors of a composition series to counting those isomorphic to a
+fixed simple module `S`, and follows its proof plan: the same two transports along an injective and
+a surjective map, the same `RelSeries.smash` gluing, and the same `map_bot`/`comap_top` endpoint
+bookkeeping.  The monotonicity and product corollaries below are likewise the multiplicity
+analogues of `Module.length_le_of_injective`, `Module.length_le_of_surjective` and
+`Module.length_prod`.  What is new is that the transports are shown to preserve each factor's
+isomorphism class and not merely the number of factors, in
+`TauCeti/RingTheory/CompositionSeries/Basic.lean`.
 
 The additivity of `[Pᵢ : Sⱼ]` is what makes the Cartan matrix of a finite-dimensional algebra
 computable, in Layer 3 of
@@ -85,182 +73,7 @@ universe u v v' v'' w w'
 
 variable {R : Type u} [Ring R] {M : Type v} [AddCommGroup M] [Module R M]
 variable {N : Type v'} [AddCommGroup N] [Module R N]
-
-/-! ### Subquotients along an injective linear map -/
-
-section Injective
-
-/-- An injective linear map carries the trace of `A` in `B` onto the trace of `A.map f` in
-`B.map f`, so it descends to the subquotients. -/
-theorem map_equivMapOfInjective_comap_subtype (f : M →ₗ[R] N) (hf : Function.Injective f)
-    {A B : Submodule R M} (hAB : A ≤ B) :
-    Submodule.map ((Submodule.equivMapOfInjective f hf B : ↥B ≃ₗ[R] ↥(B.map f)) :
-        ↥B →ₗ[R] ↥(B.map f)) (Submodule.comap B.subtype A)
-      = Submodule.comap (B.map f).subtype (A.map f) := by
-  ext y
-  simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
-  constructor
-  · rintro ⟨x, hx, rfl⟩
-    exact ⟨(x : M), hx, (Submodule.coe_equivMapOfInjective_apply f hf B x).symm⟩
-  · rintro ⟨a, ha, hay⟩
-    exact ⟨⟨a, hAB ha⟩, ha, Subtype.ext
-      ((Submodule.coe_equivMapOfInjective_apply f hf B ⟨a, hAB ha⟩).trans hay)⟩
-
-/-- **An injective linear map identifies subquotients.**  For `A ≤ B` the subquotient of the images
-`A.map f ≤ B.map f` is the subquotient `B ⧸ A` itself. -/
-noncomputable def factorEquivMapOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
-    {A B : Submodule R M} (hAB : A ≤ B) :
-    (↥(B.map f) ⧸ Submodule.comap (B.map f).subtype (A.map f)) ≃ₗ[R]
-      (↥B ⧸ Submodule.comap B.subtype A) :=
-  (Submodule.Quotient.equiv _ _ (Submodule.equivMapOfInjective f hf B)
-    (map_equivMapOfInjective_comap_subtype f hf hAB)).symm
-
-end Injective
-
-/-! ### Subquotients along a surjective linear map -/
-
-section Surjective
-
-variable (f : M →ₗ[R] N)
-
-/-- The kernel of `X ↦ f X mod A`, on the preimage of `B`, is the trace of the preimage of `A`. -/
-theorem ker_mkQ_comp_submoduleComap (A B : Submodule R N) :
-    LinearMap.ker ((Submodule.comap B.subtype A).mkQ ∘ₗ f.submoduleComap B)
-      = Submodule.comap (B.comap f).subtype (A.comap f) := by
-  ext x
-  simp
-
-/-- **A surjective linear map identifies subquotients.**  For `A ≤ B` the subquotient of the
-preimages `A.comap f ≤ B.comap f` is the subquotient `B ⧸ A` itself. -/
-noncomputable def factorEquivComapOfSurjective (hf : Function.Surjective f) (A B : Submodule R N) :
-    (↥(B.comap f) ⧸ Submodule.comap (B.comap f).subtype (A.comap f)) ≃ₗ[R]
-      (↥B ⧸ Submodule.comap B.subtype A) :=
-  (Submodule.quotEquivOfEq _ _ (ker_mkQ_comp_submoduleComap f A B).symm).trans
-    (LinearMap.quotKerEquivOfSurjective _
-      ((Submodule.mkQ_surjective _).comp
-        (LinearMap.submoduleComap_surjective_of_surjective f B hf)))
-
-end Surjective
-
-/-! ### Transporting a composition series along an injective or a surjective map -/
-
-/-- The image of a composition series under an injective linear map.  As in
-`TauCeti.mapCompositionSeries`, the body is `@[expose]`d so that
-`mapCompositionSeriesOfInjective f hf s i` is definitionally `Submodule.map f (s i)`, which is what
-the factor lemmas below rest on. -/
-@[expose] def mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
-    (s : CompositionSeries (Submodule R M)) : CompositionSeries (Submodule R N) :=
-  s.map ⟨fun A => A.map f, Submodule.map_covBy_of_injective hf⟩
-
-@[simp]
-theorem mapCompositionSeriesOfInjective_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
-    (s : CompositionSeries (Submodule R M)) (i : Fin (s.length + 1)) :
-    mapCompositionSeriesOfInjective f hf s i = (s i).map f :=
-  (rfl)
-
-@[simp]
-theorem mapCompositionSeriesOfInjective_length (f : M →ₗ[R] N) (hf : Function.Injective f)
-    (s : CompositionSeries (Submodule R M)) :
-    (mapCompositionSeriesOfInjective f hf s).length = s.length :=
-  (rfl)
-
-@[simp]
-theorem head_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
-    (s : CompositionSeries (Submodule R M)) :
-    (mapCompositionSeriesOfInjective f hf s).head = s.head.map f :=
-  (rfl)
-
-@[simp]
-theorem last_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
-    (s : CompositionSeries (Submodule R M)) :
-    (mapCompositionSeriesOfInjective f hf s).last = s.last.map f :=
-  (rfl)
-
-/-- The preimage of a composition series under a surjective linear map.  The body is `@[expose]`d
-for the same reason as `TauCeti.mapCompositionSeriesOfInjective`. -/
-@[expose] def comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
-    (s : CompositionSeries (Submodule R N)) : CompositionSeries (Submodule R M) :=
-  s.map ⟨fun A => A.comap f, Submodule.comap_covBy_of_surjective hf⟩
-
-@[simp]
-theorem comapCompositionSeriesOfSurjective_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)
-    (s : CompositionSeries (Submodule R N)) (i : Fin (s.length + 1)) :
-    comapCompositionSeriesOfSurjective f hf s i = (s i).comap f :=
-  (rfl)
-
-@[simp]
-theorem comapCompositionSeriesOfSurjective_length (f : M →ₗ[R] N) (hf : Function.Surjective f)
-    (s : CompositionSeries (Submodule R N)) :
-    (comapCompositionSeriesOfSurjective f hf s).length = s.length :=
-  (rfl)
-
-@[simp]
-theorem head_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
-    (s : CompositionSeries (Submodule R N)) :
-    (comapCompositionSeriesOfSurjective f hf s).head = s.head.comap f :=
-  (rfl)
-
-@[simp]
-theorem last_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
-    (s : CompositionSeries (Submodule R N)) :
-    (comapCompositionSeriesOfSurjective f hf s).last = s.last.comap f :=
-  (rfl)
-
-/-! ### The factors of the transported series -/
-
 variable {S : Type v''} [AddCommGroup S] [Module R S]
-
-/-- Two composition series with the same two submodules at an index have the same factor there.
-The equalities are enough: the subquotient is built from the two submodules alone. -/
-theorem isCompositionFactorAt_congr_of_eq {s t : CompositionSeries (Submodule R M)}
-    {i : Fin s.length} {j : Fin t.length} (hsucc : s i.succ = t j.succ)
-    (hcast : s i.castSucc = t j.castSucc) :
-    IsCompositionFactorAt s i S ↔ IsCompositionFactorAt t j S := by
-  rw [isCompositionFactorAt_iff, isCompositionFactorAt_iff, hcast, hsucc]
-
-@[simp]
-theorem isCompositionFactorAt_mapCompositionSeriesOfInjective_iff (f : M →ₗ[R] N)
-    (hf : Function.Injective f) (s : CompositionSeries (Submodule R M)) (i : Fin s.length) :
-    IsCompositionFactorAt (mapCompositionSeriesOfInjective f hf s) i S ↔
-      IsCompositionFactorAt s i S :=
-  isCompositionFactorAt_iff.trans
-    (Iff.trans
-      ⟨fun ⟨g⟩ => ⟨(factorEquivMapOfInjective f hf (s.step i).le).symm.trans g⟩,
-        fun ⟨g⟩ => ⟨(factorEquivMapOfInjective f hf (s.step i).le).trans g⟩⟩
-      isCompositionFactorAt_iff.symm)
-
-@[simp]
-theorem isCompositionFactorAt_comapCompositionSeriesOfSurjective_iff (f : M →ₗ[R] N)
-    (hf : Function.Surjective f) (s : CompositionSeries (Submodule R N)) (i : Fin s.length) :
-    IsCompositionFactorAt (comapCompositionSeriesOfSurjective f hf s) i S ↔
-      IsCompositionFactorAt s i S :=
-  isCompositionFactorAt_iff.trans
-    (Iff.trans
-      ⟨fun ⟨g⟩ => ⟨(factorEquivComapOfSurjective f hf (s i.castSucc) (s i.succ)).symm.trans g⟩,
-        fun ⟨g⟩ => ⟨(factorEquivComapOfSurjective f hf (s i.castSucc) (s i.succ)).trans g⟩⟩
-      isCompositionFactorAt_iff.symm)
-
-/-- **An injective map preserves multiplicities**: the image of a composition series counts every
-module the same number of times as the series itself. -/
-@[simp]
-theorem compositionMultiplicity_mapCompositionSeriesOfInjective (f : M →ₗ[R] N)
-    (hf : Function.Injective f) (s : CompositionSeries (Submodule R M)) :
-    compositionMultiplicity (mapCompositionSeriesOfInjective f hf s) S =
-      compositionMultiplicity s S := by
-  rw [compositionMultiplicity_def, compositionMultiplicity_def]
-  exact Nat.card_congr (Equiv.subtypeEquivRight fun i =>
-    isCompositionFactorAt_mapCompositionSeriesOfInjective_iff f hf s i)
-
-/-- **A surjective map preserves multiplicities**: the preimage of a composition series counts
-every module the same number of times as the series itself. -/
-@[simp]
-theorem compositionMultiplicity_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N)
-    (hf : Function.Surjective f) (s : CompositionSeries (Submodule R N)) :
-    compositionMultiplicity (comapCompositionSeriesOfSurjective f hf s) S =
-      compositionMultiplicity s S := by
-  rw [compositionMultiplicity_def, compositionMultiplicity_def]
-  exact Nat.card_congr (Equiv.subtypeEquivRight fun i =>
-    isCompositionFactorAt_comapCompositionSeriesOfSurjective_iff f hf s i)
 
 /-! ### Gluing two composition series -/
 
@@ -268,27 +81,27 @@ section Smash
 
 variable (p q : CompositionSeries (Submodule R M)) (h : p.last = q.head)
 
-theorem isCompositionFactorAt_smash_castAdd (i : Fin p.length) :
+/-- The factors of the first half of a glued series are the factors of the first series. -/
+@[simp]
+theorem isCompositionFactorAt_smash_castAdd_iff (i : Fin p.length) :
     IsCompositionFactorAt (p.smash q h) (i.castAdd q.length) S ↔ IsCompositionFactorAt p i S :=
   isCompositionFactorAt_congr_of_eq (RelSeries.smash_succ_castAdd h i)
     (RelSeries.smash_castAdd h i)
 
-theorem isCompositionFactorAt_smash_natAdd (i : Fin q.length) :
+/-- The factors of the second half of a glued series are the factors of the second series. -/
+@[simp]
+theorem isCompositionFactorAt_smash_natAdd_iff (i : Fin q.length) :
     IsCompositionFactorAt (p.smash q h) (i.natAdd p.length) S ↔ IsCompositionFactorAt q i S :=
   isCompositionFactorAt_congr_of_eq (RelSeries.smash_succ_natAdd h i)
     (RelSeries.smash_natAdd h i)
 
 /-- **Gluing adds multiplicities.**  Two composition series joined end to end count every module as
 often as the two of them together. -/
+@[simp]
 theorem compositionMultiplicity_smash :
     compositionMultiplicity (p.smash q h) S =
       compositionMultiplicity p S + compositionMultiplicity q S := by
   classical
-  have key : ∀ t : CompositionSeries (Submodule R M),
-      compositionMultiplicity t S =
-        ∑ i : Fin t.length, if IsCompositionFactorAt t i S then 1 else 0 := fun t => by
-    rw [compositionMultiplicity_def, Nat.card_eq_fintype_card, Fintype.card_subtype,
-      Finset.card_filter]
   have hsplit :
       (∑ i : Fin (p.length + q.length),
           if IsCompositionFactorAt (p.smash q h) i S then 1 else 0)
@@ -297,11 +110,13 @@ theorem compositionMultiplicity_smash :
           + ∑ i : Fin q.length,
             if IsCompositionFactorAt (p.smash q h) (i.natAdd p.length) S then 1 else 0 :=
     Fin.sum_univ_add _
-  rw [key, key, key]
-  refine hsplit.trans (congrArg₂ (· + ·) (Finset.sum_congr rfl fun i _ => ?_)
-    (Finset.sum_congr rfl fun i _ => ?_))
-  · exact if_congr (isCompositionFactorAt_smash_castAdd p q h i) rfl rfl
-  · exact if_congr (isCompositionFactorAt_smash_natAdd p q h i) rfl rfl
+  rw [compositionMultiplicity_eq_sum_ite, compositionMultiplicity_eq_sum_ite,
+    compositionMultiplicity_eq_sum_ite]
+  exact hsplit.trans (congrArg₂ (· + ·)
+    (Finset.sum_congr rfl fun i _ =>
+      if_congr (isCompositionFactorAt_smash_castAdd_iff p q h i) rfl rfl)
+    (Finset.sum_congr rfl fun i _ =>
+      if_congr (isCompositionFactorAt_smash_natAdd_iff p q h i) rfl rfl))
 
 end Smash
 
@@ -317,20 +132,16 @@ theorem jordanHolderMultiplicity_eq_submodule_add_quotient [IsNoetherian R M] [I
       jordanHolderMultiplicity R p S + jordanHolderMultiplicity R (M ⧸ p) S := by
   obtain ⟨t, htbot, httop⟩ := exists_compositionSeries_of_isNoetherian_isArtinian R p
   obtain ⟨u, hubot, hutop⟩ := exists_compositionSeries_of_isNoetherian_isArtinian R (M ⧸ p)
-  set t' := mapCompositionSeriesOfInjective p.subtype p.injective_subtype t with ht'
-  set u' := comapCompositionSeriesOfSurjective p.mkQ p.mkQ_surjective u with hu'
-  have hconnect : t'.last = u'.head := by
-    rw [ht', hu', last_mapCompositionSeriesOfInjective, head_comapCompositionSeriesOfSurjective,
-      httop, hubot, Submodule.map_top, Submodule.range_subtype, Submodule.comap_bot,
-      Submodule.ker_mkQ]
-  have hbot : (t'.smash u' hconnect).head = ⊥ := by
-    rw [RelSeries.head_smash, ht', head_mapCompositionSeriesOfInjective, htbot, Submodule.map_bot]
-  have htop : (t'.smash u' hconnect).last = ⊤ := by
-    rw [RelSeries.last_smash, hu', last_comapCompositionSeriesOfSurjective, hutop,
-      Submodule.comap_top]
-  rw [← compositionMultiplicity_eq_jordanHolderMultiplicity _ hbot htop S,
-    compositionMultiplicity_smash, ht', hu',
-    compositionMultiplicity_mapCompositionSeriesOfInjective,
+  have hconnect :
+      (mapCompositionSeriesOfInjective p.subtype p.injective_subtype t).last =
+        (comapCompositionSeriesOfSurjective p.mkQ p.mkQ_surjective u).head := by
+    simp [httop, hubot]
+  refine (compositionMultiplicity_eq_jordanHolderMultiplicity
+    ((mapCompositionSeriesOfInjective p.subtype p.injective_subtype t).smash
+      (comapCompositionSeriesOfSurjective p.mkQ p.mkQ_surjective u) hconnect)
+    (by simp [RelSeries.head_smash, htbot]) (by simp [RelSeries.last_smash, hutop])
+    S).symm.trans ?_
+  rw [compositionMultiplicity_smash, compositionMultiplicity_mapCompositionSeriesOfInjective,
     compositionMultiplicity_comapCompositionSeriesOfSurjective,
     compositionMultiplicity_eq_jordanHolderMultiplicity t htbot httop S,
     compositionMultiplicity_eq_jordanHolderMultiplicity u hubot hutop S]
@@ -361,13 +172,14 @@ theorem jordanHolderMultiplicity_eq_add_of_exact [IsNoetherian R M] [IsArtinian 
     {A : Type w} [AddCommGroup A] [Module R A] [IsNoetherian R A] [IsArtinian R A]
     {B : Type w'} [AddCommGroup B] [Module R B] [IsNoetherian R B] [IsArtinian R B]
     (f : A →ₗ[R] M) (g : M →ₗ[R] B) (hf : Function.Injective f) (hg : Function.Surjective g)
-    (hfg : LinearMap.range f = LinearMap.ker g) :
+    (hfg : Function.Exact f g) :
     jordanHolderMultiplicity R M S =
       jordanHolderMultiplicity R A S + jordanHolderMultiplicity R B S := by
   rw [jordanHolderMultiplicity_eq_submodule_add_quotient (LinearMap.range f),
     jordanHolderMultiplicity_eq_of_linearEquiv (LinearEquiv.ofInjective f hf) S,
     ← jordanHolderMultiplicity_eq_of_linearEquiv
-      ((Submodule.quotEquivOfEq _ _ hfg).trans (g.quotKerEquivOfSurjective hg)) S]
+      ((Submodule.quotEquivOfEq _ _ (LinearMap.exact_iff.mp hfg).symm).trans
+        (g.quotKerEquivOfSurjective hg)) S]
 
 /-- **Additivity on a binary product**: `[M × N : S] = [M : S] + [N : S]`. -/
 theorem jordanHolderMultiplicity_prod [IsNoetherian R M] [IsArtinian R M] [IsNoetherian R N]
@@ -375,6 +187,6 @@ theorem jordanHolderMultiplicity_prod [IsNoetherian R M] [IsArtinian R M] [IsNoe
     jordanHolderMultiplicity R (M × N) S =
       jordanHolderMultiplicity R M S + jordanHolderMultiplicity R N S :=
   jordanHolderMultiplicity_eq_add_of_exact (LinearMap.inl R M N) (LinearMap.snd R M N)
-    (LinearMap.inl_injective) (LinearMap.snd_surjective) (LinearMap.range_inl R M N)
+    (LinearMap.inl_injective) (LinearMap.snd_surjective) Function.Exact.inl_snd
 
 end TauCeti

--- a/TauCeti/RingTheory/CompositionSeries/Additivity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Additivity.lean
@@ -163,7 +163,10 @@ theorem jordanHolderMultiplicity_eq_add_of_exact [IsNoetherian R M] [IsArtinian 
       ((Submodule.quotEquivOfEq _ _ (LinearMap.exact_iff.mp hfg).symm).trans
         (g.quotKerEquivOfSurjective hg)) S]
 
-/-- A module that embeds in `M` contributes at most `M`'s multiplicity. -/
+/-- A module that embeds in `M` contributes at most `M`'s multiplicity.  As for
+`TauCeti.jordanHolderMultiplicity_eq_add_of_exact`, the finiteness of `A` follows from that of `M`
+and is a binder only because `jordanHolderMultiplicity R A S` — which already occurs in the
+statement a caller is trying to prove — does not elaborate without it. -/
 theorem jordanHolderMultiplicity_le_of_injective [IsNoetherian R M] [IsArtinian R M]
     {A : Type w} [AddCommGroup A] [Module R A] [IsNoetherian R A] [IsArtinian R A]
     (f : A →ₗ[R] M) (hf : Function.Injective f) :
@@ -172,7 +175,10 @@ theorem jordanHolderMultiplicity_le_of_injective [IsNoetherian R M] [IsArtinian 
     (Submodule.mkQ_surjective _) (LinearMap.exact_map_mkQ_range f)]
   exact Nat.le_add_right _ _
 
-/-- A quotient of `M` contributes at most `M`'s multiplicity. -/
+/-- A quotient of `M` contributes at most `M`'s multiplicity.  As for
+`TauCeti.jordanHolderMultiplicity_eq_add_of_exact`, the finiteness of `B` follows from that of `M`
+and is a binder only because `jordanHolderMultiplicity R B S` — which already occurs in the
+statement a caller is trying to prove — does not elaborate without it. -/
 theorem jordanHolderMultiplicity_le_of_surjective [IsNoetherian R M] [IsArtinian R M]
     {B : Type w'} [AddCommGroup B] [Module R B] [IsNoetherian R B] [IsArtinian R B]
     (g : M →ₗ[R] B) (hg : Function.Surjective g) :

--- a/TauCeti/RingTheory/CompositionSeries/Additivity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Additivity.lean
@@ -26,9 +26,12 @@ The proof glues a composition series of `p` and a composition series of `M ⧸ p
 `M`: the lower half is carried along the *injective* map `p.subtype` by
 `TauCeti.mapCompositionSeriesOfInjective` and the upper half along the *surjective* map `p.mkQ` by
 `TauCeti.comapCompositionSeriesOfSurjective`, both of
-`TauCeti/RingTheory/CompositionSeries/Basic.lean`, which preserve every multiplicity.  The two
-resulting series meet at `p` and are glued with `RelSeries.smash`, whose `castAdd`/`natAdd` index
-lemmas split the count of factors isomorphic to `S` into the two halves.
+`TauCeti/RingTheory/CompositionSeries/Basic.lean`; that these transports preserve every
+multiplicity is `TauCeti.compositionMultiplicity_mapCompositionSeriesOfInjective` and
+`TauCeti.compositionMultiplicity_comapCompositionSeriesOfSurjective`, of
+`TauCeti/RingTheory/CompositionSeries/Multiplicity.lean`.  The two resulting series meet at `p` and
+are glued with `RelSeries.smash`, whose `castAdd`/`natAdd` index lemmas split the count of factors
+isomorphic to `S` into the two halves.
 
 ## Main results
 
@@ -36,11 +39,12 @@ lemmas split the count of factors isomorphic to `S` into the two halves.
   to end add.
 * `TauCeti.jordanHolderMultiplicity_eq_submodule_add_quotient`: **additivity**,
   `[M : S] = [p : S] + [M ⧸ p : S]`.
-* `TauCeti.jordanHolderMultiplicity_submodule_le` and
-  `TauCeti.jordanHolderMultiplicity_quotient_le`: a submodule and a quotient each contribute at
-  most the whole module's multiplicity.
 * `TauCeti.jordanHolderMultiplicity_eq_add_of_exact`: the same statement for a short exact sequence
   `0 → A → M → B → 0`.
+* `TauCeti.jordanHolderMultiplicity_le_of_injective` and
+  `TauCeti.jordanHolderMultiplicity_le_of_surjective`: a submodule and a quotient — more generally
+  the source of an injective map into `M` and the target of a surjective map out of `M` — each
+  contribute at most `M`'s multiplicity.
 * `TauCeti.jordanHolderMultiplicity_prod`: `[M × N : S] = [M : S] + [N : S]`.
 
 ## References
@@ -52,8 +56,12 @@ a surjective map, the same `RelSeries.smash` gluing, and the same `map_bot`/`com
 bookkeeping.  The monotonicity and product corollaries below are likewise the multiplicity
 analogues of `Module.length_le_of_injective`, `Module.length_le_of_surjective` and
 `Module.length_prod`.  What is new is that the transports are shown to preserve each factor's
-isomorphism class and not merely the number of factors, in
-`TauCeti/RingTheory/CompositionSeries/Basic.lean`.
+isomorphism class and not merely the number of factors: the identification of the subquotients is
+`TauCeti.mapSubquotientEquivOfInjective` and `TauCeti.comapSubquotientEquivOfSurjective` of
+`TauCeti/Algebra/Module/Submodule/Quotient.lean`, and the resulting factor-by-factor comparison is
+`TauCeti.isCompositionFactorAt_mapCompositionSeriesOfInjective_iff` and its surjective counterpart
+in `TauCeti/RingTheory/CompositionSeries/Multiplicity.lean`;
+`TauCeti/RingTheory/CompositionSeries/Basic.lean` supplies the transports themselves.
 
 The additivity of `[Pᵢ : Sⱼ]` is what makes the Cartan matrix of a finite-dimensional algebra
 computable, in Layer 3 of
@@ -102,21 +110,9 @@ theorem compositionMultiplicity_smash :
     compositionMultiplicity (p.smash q h) S =
       compositionMultiplicity p S + compositionMultiplicity q S := by
   classical
-  have hsplit :
-      (∑ i : Fin (p.length + q.length),
-          if IsCompositionFactorAt (p.smash q h) i S then 1 else 0)
-        = (∑ i : Fin p.length,
-            if IsCompositionFactorAt (p.smash q h) (i.castAdd q.length) S then 1 else 0)
-          + ∑ i : Fin q.length,
-            if IsCompositionFactorAt (p.smash q h) (i.natAdd p.length) S then 1 else 0 :=
-    Fin.sum_univ_add _
   rw [compositionMultiplicity_eq_sum_ite, compositionMultiplicity_eq_sum_ite,
     compositionMultiplicity_eq_sum_ite]
-  exact hsplit.trans (congrArg₂ (· + ·)
-    (Finset.sum_congr rfl fun i _ =>
-      if_congr (isCompositionFactorAt_smash_castAdd_iff p q h i) rfl rfl)
-    (Finset.sum_congr rfl fun i _ =>
-      if_congr (isCompositionFactorAt_smash_natAdd_iff p q h i) rfl rfl))
+  exact (Fin.sum_univ_add _).trans (by simp)
 
 end Smash
 
@@ -146,20 +142,6 @@ theorem jordanHolderMultiplicity_eq_submodule_add_quotient [IsNoetherian R M] [I
     compositionMultiplicity_eq_jordanHolderMultiplicity t htbot httop S,
     compositionMultiplicity_eq_jordanHolderMultiplicity u hubot hutop S]
 
-/-- A submodule contributes at most the whole module's multiplicity. -/
-theorem jordanHolderMultiplicity_submodule_le [IsNoetherian R M] [IsArtinian R M]
-    (p : Submodule R M) :
-    jordanHolderMultiplicity R p S ≤ jordanHolderMultiplicity R M S := by
-  rw [jordanHolderMultiplicity_eq_submodule_add_quotient p]
-  exact Nat.le_add_right _ _
-
-/-- A quotient contributes at most the whole module's multiplicity. -/
-theorem jordanHolderMultiplicity_quotient_le [IsNoetherian R M] [IsArtinian R M]
-    (p : Submodule R M) :
-    jordanHolderMultiplicity R (M ⧸ p) S ≤ jordanHolderMultiplicity R M S := by
-  rw [jordanHolderMultiplicity_eq_submodule_add_quotient p]
-  exact Nat.le_add_left _ _
-
 /-- **Additivity in a short exact sequence** `0 → A → M → B → 0`: the multiplicity of `S` in the
 middle term is the sum of its multiplicities in the two ends.
 
@@ -180,6 +162,24 @@ theorem jordanHolderMultiplicity_eq_add_of_exact [IsNoetherian R M] [IsArtinian 
     ← jordanHolderMultiplicity_eq_of_linearEquiv
       ((Submodule.quotEquivOfEq _ _ (LinearMap.exact_iff.mp hfg).symm).trans
         (g.quotKerEquivOfSurjective hg)) S]
+
+/-- A module that embeds in `M` contributes at most `M`'s multiplicity. -/
+theorem jordanHolderMultiplicity_le_of_injective [IsNoetherian R M] [IsArtinian R M]
+    {A : Type w} [AddCommGroup A] [Module R A] [IsNoetherian R A] [IsArtinian R A]
+    (f : A →ₗ[R] M) (hf : Function.Injective f) :
+    jordanHolderMultiplicity R A S ≤ jordanHolderMultiplicity R M S := by
+  rw [jordanHolderMultiplicity_eq_add_of_exact f (LinearMap.range f).mkQ hf
+    (Submodule.mkQ_surjective _) (LinearMap.exact_map_mkQ_range f)]
+  exact Nat.le_add_right _ _
+
+/-- A quotient of `M` contributes at most `M`'s multiplicity. -/
+theorem jordanHolderMultiplicity_le_of_surjective [IsNoetherian R M] [IsArtinian R M]
+    {B : Type w'} [AddCommGroup B] [Module R B] [IsNoetherian R B] [IsArtinian R B]
+    (g : M →ₗ[R] B) (hg : Function.Surjective g) :
+    jordanHolderMultiplicity R B S ≤ jordanHolderMultiplicity R M S := by
+  rw [jordanHolderMultiplicity_eq_add_of_exact (LinearMap.ker g).subtype g
+    (Submodule.injective_subtype _) hg (LinearMap.exact_subtype_ker_map g)]
+  exact Nat.le_add_left _ _
 
 /-- **Additivity on a binary product**: `[M × N : S] = [M : S] + [N : S]`. -/
 theorem jordanHolderMultiplicity_prod [IsNoetherian R M] [IsArtinian R M] [IsNoetherian R N]

--- a/TauCeti/RingTheory/CompositionSeries/Additivity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Additivity.lean
@@ -380,7 +380,13 @@ theorem jordanHolderMultiplicity_quotient_le [IsNoetherian R M] [IsArtinian R M]
   exact Nat.le_add_left _ _
 
 /-- **Additivity in a short exact sequence** `0 → A → M → B → 0`: the multiplicity of `S` in the
-middle term is the sum of its multiplicities in the two ends. -/
+middle term is the sum of its multiplicities in the two ends.
+
+Mathematically the finiteness of `A` and of `B` follows from that of `M`, through `A ≃ₗ[R] range f`
+and `M ⧸ ker g ≃ₗ[R] B`.  The assumptions are nevertheless binders here rather than facts derived
+in the proof, because `jordanHolderMultiplicity R A S` and `jordanHolderMultiplicity R B S` carry
+them in their own signatures: the conclusion does not elaborate without them, so a caller holds
+them already in order to state it. -/
 theorem jordanHolderMultiplicity_eq_add_of_exact [IsNoetherian R M] [IsArtinian R M]
     {A : Type w} [AddCommGroup A] [Module R A] [IsNoetherian R A] [IsArtinian R A]
     {B : Type w'} [AddCommGroup B] [Module R B] [IsNoetherian R B] [IsArtinian R B]

--- a/TauCeti/RingTheory/CompositionSeries/Basic.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Basic.lean
@@ -49,23 +49,10 @@ universe u v v'
 variable {R : Type u} [Ring R] {M : Type v} [AddCommGroup M] [Module R M]
 variable {N : Type v'} [AddCommGroup N] [Module R N]
 
-/-- The image of a composition series of `M` under an injective linear map `f : M →ₗ[R] N`.
-
-The body is `@[expose]`d on purpose.  The `_apply` and `_length` lemmas below name the two
-definitional identities it provides, but a *statement* about the transported series at a general
-index also needs the index types `Fin (mapCompositionSeriesOfInjective f hf s).length` and
-`Fin s.length` to be identified, and that identification is only available definitionally: this is
-what lets the factor lemmas of `TauCeti.RingTheory.CompositionSeries.Multiplicity` be stated for
-`i : Fin s.length` instead of carrying `Fin.cast`s and dependent rewrites. -/
-@[expose] def mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
+/-- The image of a composition series of `M` under an injective linear map `f : M →ₗ[R] N`. -/
+def mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
     (s : CompositionSeries (Submodule R M)) : CompositionSeries (Submodule R N) :=
   s.map ⟨fun A => A.map f, Submodule.map_covBy_of_injective hf⟩
-
-@[simp]
-theorem mapCompositionSeriesOfInjective_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
-    (s : CompositionSeries (Submodule R M)) (i : Fin (s.length + 1)) :
-    mapCompositionSeriesOfInjective f hf s i = (s i).map f :=
-  (rfl)
 
 @[simp]
 theorem mapCompositionSeriesOfInjective_length (f : M →ₗ[R] N) (hf : Function.Injective f)
@@ -73,30 +60,32 @@ theorem mapCompositionSeriesOfInjective_length (f : M →ₗ[R] N) (hf : Functio
     (mapCompositionSeriesOfInjective f hf s).length = s.length :=
   (rfl)
 
+/-- The term of the transported series at an index is the image of the term of `s` at that same
+index, transported along `TauCeti.mapCompositionSeriesOfInjective_length`. -/
+@[simp]
+theorem mapCompositionSeriesOfInjective_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M))
+    (i : Fin ((mapCompositionSeriesOfInjective f hf s).length + 1)) :
+    mapCompositionSeriesOfInjective f hf s i =
+      (s (i.cast (by rw [mapCompositionSeriesOfInjective_length]))).map f :=
+  (rfl)
+
 @[simp]
 theorem head_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
     (s : CompositionSeries (Submodule R M)) :
     (mapCompositionSeriesOfInjective f hf s).head = s.head.map f :=
-  mapCompositionSeriesOfInjective_apply f hf s 0
+  (rfl)
 
 @[simp]
 theorem last_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
     (s : CompositionSeries (Submodule R M)) :
     (mapCompositionSeriesOfInjective f hf s).last = s.last.map f :=
-  mapCompositionSeriesOfInjective_apply f hf s (Fin.last _)
+  (rfl)
 
-/-- The preimage of a composition series of `N` under a surjective linear map `f : M →ₗ[R] N`.
-The body is `@[expose]`d for the same reason as
-`TauCeti.mapCompositionSeriesOfInjective`. -/
-@[expose] def comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
+/-- The preimage of a composition series of `N` under a surjective linear map `f : M →ₗ[R] N`. -/
+def comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
     (s : CompositionSeries (Submodule R N)) : CompositionSeries (Submodule R M) :=
   s.map ⟨fun A => A.comap f, Submodule.comap_covBy_of_surjective hf⟩
-
-@[simp]
-theorem comapCompositionSeriesOfSurjective_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)
-    (s : CompositionSeries (Submodule R N)) (i : Fin (s.length + 1)) :
-    comapCompositionSeriesOfSurjective f hf s i = (s i).comap f :=
-  (rfl)
 
 @[simp]
 theorem comapCompositionSeriesOfSurjective_length (f : M →ₗ[R] N) (hf : Function.Surjective f)
@@ -104,16 +93,26 @@ theorem comapCompositionSeriesOfSurjective_length (f : M →ₗ[R] N) (hf : Func
     (comapCompositionSeriesOfSurjective f hf s).length = s.length :=
   (rfl)
 
+/-- The term of the transported series at an index is the preimage of the term of `s` at that same
+index, transported along `TauCeti.comapCompositionSeriesOfSurjective_length`. -/
+@[simp]
+theorem comapCompositionSeriesOfSurjective_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N))
+    (i : Fin ((comapCompositionSeriesOfSurjective f hf s).length + 1)) :
+    comapCompositionSeriesOfSurjective f hf s i =
+      (s (i.cast (by rw [comapCompositionSeriesOfSurjective_length]))).comap f :=
+  (rfl)
+
 @[simp]
 theorem head_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
     (s : CompositionSeries (Submodule R N)) :
     (comapCompositionSeriesOfSurjective f hf s).head = s.head.comap f :=
-  comapCompositionSeriesOfSurjective_apply f hf s 0
+  (rfl)
 
 @[simp]
 theorem last_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
     (s : CompositionSeries (Submodule R N)) :
     (comapCompositionSeriesOfSurjective f hf s).last = s.last.comap f :=
-  comapCompositionSeriesOfSurjective_apply f hf s (Fin.last _)
+  (rfl)
 
 end TauCeti

--- a/TauCeti/RingTheory/CompositionSeries/Basic.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Basic.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.SimpleModule.Basic
-public import TauCeti.Algebra.Module.Submodule.Quotient
 
 /-!
 # Transporting a composition series along a linear map
@@ -32,6 +31,13 @@ two one-sided forms, for the inclusion of a submodule and the projection onto a 
   linear map.
 * `TauCeti.comapCompositionSeriesOfSurjective`: the preimage of a composition series under a
   surjective linear map.
+
+## References
+
+The two transports are exactly the anonymous `let`s inside the proof of Mathlib's
+`Module.length_eq_add_of_exact` (`Mathlib/RingTheory/Length.lean`, by Andrew Yang), packaged here
+as named definitions with an API so that they can be shown to preserve the factors themselves and
+not just their number.
 -/
 
 public section
@@ -45,25 +51,39 @@ variable {N : Type v'} [AddCommGroup N] [Module R N]
 
 /-- The image of a composition series of `M` under an injective linear map `f : M →ₗ[R] N`.
 
-The body is `@[expose]`d on purpose: `mapCompositionSeriesOfInjective f hf s i` is definitionally
-`Submodule.map f (s i)`, and the *statements* of the endpoint lemmas below and of the factor
-lemmas downstream all rest on that definitional identity, which without `@[expose]` would have to
-be carried by `Fin.cast`s and dependent rewrites. -/
+The body is `@[expose]`d on purpose.  The `_apply` and `_length` lemmas below name the two
+definitional identities it provides, but a *statement* about the transported series at a general
+index also needs the index types `Fin (mapCompositionSeriesOfInjective f hf s).length` and
+`Fin s.length` to be identified, and that identification is only available definitionally: this is
+what lets the factor lemmas of `TauCeti.RingTheory.CompositionSeries.Multiplicity` be stated for
+`i : Fin s.length` instead of carrying `Fin.cast`s and dependent rewrites. -/
 @[expose] def mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
     (s : CompositionSeries (Submodule R M)) : CompositionSeries (Submodule R N) :=
   s.map ⟨fun A => A.map f, Submodule.map_covBy_of_injective hf⟩
 
 @[simp]
+theorem mapCompositionSeriesOfInjective_apply (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) (i : Fin (s.length + 1)) :
+    mapCompositionSeriesOfInjective f hf s i = (s i).map f :=
+  (rfl)
+
+@[simp]
+theorem mapCompositionSeriesOfInjective_length (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) :
+    (mapCompositionSeriesOfInjective f hf s).length = s.length :=
+  (rfl)
+
+@[simp]
 theorem head_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
     (s : CompositionSeries (Submodule R M)) :
     (mapCompositionSeriesOfInjective f hf s).head = s.head.map f :=
-  (rfl)
+  mapCompositionSeriesOfInjective_apply f hf s 0
 
 @[simp]
 theorem last_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
     (s : CompositionSeries (Submodule R M)) :
     (mapCompositionSeriesOfInjective f hf s).last = s.last.map f :=
-  (rfl)
+  mapCompositionSeriesOfInjective_apply f hf s (Fin.last _)
 
 /-- The preimage of a composition series of `N` under a surjective linear map `f : M →ₗ[R] N`.
 The body is `@[expose]`d for the same reason as
@@ -73,15 +93,27 @@ The body is `@[expose]`d for the same reason as
   s.map ⟨fun A => A.comap f, Submodule.comap_covBy_of_surjective hf⟩
 
 @[simp]
+theorem comapCompositionSeriesOfSurjective_apply (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) (i : Fin (s.length + 1)) :
+    comapCompositionSeriesOfSurjective f hf s i = (s i).comap f :=
+  (rfl)
+
+@[simp]
+theorem comapCompositionSeriesOfSurjective_length (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) :
+    (comapCompositionSeriesOfSurjective f hf s).length = s.length :=
+  (rfl)
+
+@[simp]
 theorem head_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
     (s : CompositionSeries (Submodule R N)) :
     (comapCompositionSeriesOfSurjective f hf s).head = s.head.comap f :=
-  (rfl)
+  comapCompositionSeriesOfSurjective_apply f hf s 0
 
 @[simp]
 theorem last_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
     (s : CompositionSeries (Submodule R N)) :
     (comapCompositionSeriesOfSurjective f hf s).last = s.last.comap f :=
-  (rfl)
+  comapCompositionSeriesOfSurjective_apply f hf s (Fin.last _)
 
 end TauCeti

--- a/TauCeti/RingTheory/CompositionSeries/Basic.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Basic.lean
@@ -6,23 +6,32 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.SimpleModule.Basic
+public import TauCeti.Algebra.Module.Submodule.Quotient
 
 /-!
-# Transporting a composition series along a linear equivalence
+# Transporting a composition series along a linear map
 
-A linear equivalence `e : M ≃ₗ[R] N` carries the submodules of `M` to the submodules of `N` by the
-order isomorphism `Submodule.orderIsoMapComap e`, so it carries a composition series of `M` to one
-of `N` (`TauCeti.mapCompositionSeries`) and identifies the two series factor by factor
-(`TauCeti.factorEquivMapCompositionSeries`).  This is what makes an invariant read off a composition
-series an invariant of the isomorphism class of the ambient module; the Jordan-Hölder multiplicities
-of `TauCeti.RingTheory.CompositionSeries.Multiplicity` are the consumer this was written for.
+An injective linear map `f : M →ₗ[R] N` carries the submodules of `M` to submodules of `N` and
+preserves coverings (`Submodule.map_covBy_of_injective`), and a surjective one pulls the submodules
+of `N` back and preserves coverings (`Submodule.comap_covBy_of_surjective`), so each carries a
+composition series to a composition series: `TauCeti.mapCompositionSeriesOfInjective` and
+`TauCeti.comapCompositionSeriesOfSurjective`.  That the transported series keeps the *factors*
+themselves, and not just their number, is the identification of subquotients
+`TauCeti.mapSubquotientEquivOfInjective`, respectively
+`TauCeti.comapSubquotientEquivOfSurjective`, of `TauCeti.Algebra.Module.Submodule.Quotient`.
+
+Taking `f` to be a linear equivalence, this is what makes an invariant read off a composition
+series an invariant of the isomorphism class of the ambient module; the Jordan-Hölder
+multiplicities of `TauCeti.RingTheory.CompositionSeries.Multiplicity` are the consumer this was
+written for, and `TauCeti.RingTheory.CompositionSeries.Additivity` is the consumer that needs the
+two one-sided forms, for the inclusion of a submodule and the projection onto a quotient.
 
 ## Main definitions
 
-* `TauCeti.mapCompositionSeries`: the image of a composition series under a linear equivalence of
-  the ambient module.
-* `TauCeti.factorEquivMapCompositionSeries`: the identification of the factor of a composition
-  series at an index with the factor of its image at the same index.
+* `TauCeti.mapCompositionSeriesOfInjective`: the image of a composition series under an injective
+  linear map.
+* `TauCeti.comapCompositionSeriesOfSurjective`: the preimage of a composition series under a
+  surjective linear map.
 -/
 
 public section
@@ -34,78 +43,45 @@ universe u v v'
 variable {R : Type u} [Ring R] {M : Type v} [AddCommGroup M] [Module R M]
 variable {N : Type v'} [AddCommGroup N] [Module R N]
 
-/-- The image of a composition series of `M` under a linear equivalence `M ≃ₗ[R] N`: the image of
-the series under the order isomorphism `Submodule.orderIsoMapComap e`, which preserves coverings.
+/-- The image of a composition series of `M` under an injective linear map `f : M →ₗ[R] N`.
 
-The body is `@[expose]`d on purpose: `mapCompositionSeries e s i` is definitionally
-`Submodule.map ↑e (s i)` — the content of `TauCeti.mapCompositionSeries_apply` below — and the
-*statements* of that lemma, of `TauCeti.factorEquivMapCompositionSeries`, and of the transport
-lemmas downstream all rest on that definitional identity, which without `@[expose]` would have to be
-carried by `Fin.cast`s and dependent rewrites. -/
-@[expose] def mapCompositionSeries (e : M ≃ₗ[R] N) (s : CompositionSeries (Submodule R M)) :
-    CompositionSeries (Submodule R N) :=
-  s.map ⟨fun A => Submodule.map (e : M →ₗ[R] N) A,
-    fun h => (apply_covBy_apply_iff (Submodule.orderIsoMapComap e)).mpr h⟩
+The body is `@[expose]`d on purpose: `mapCompositionSeriesOfInjective f hf s i` is definitionally
+`Submodule.map f (s i)`, and the *statements* of the endpoint lemmas below and of the factor
+lemmas downstream all rest on that definitional identity, which without `@[expose]` would have to
+be carried by `Fin.cast`s and dependent rewrites. -/
+@[expose] def mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) : CompositionSeries (Submodule R N) :=
+  s.map ⟨fun A => A.map f, Submodule.map_covBy_of_injective hf⟩
 
 @[simp]
-theorem mapCompositionSeries_apply (e : M ≃ₗ[R] N) (s : CompositionSeries (Submodule R M))
-    (i : Fin (s.length + 1)) :
-    mapCompositionSeries e s i = Submodule.map (e : M →ₗ[R] N) (s i) :=
-  rfl
+theorem head_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) :
+    (mapCompositionSeriesOfInjective f hf s).head = s.head.map f :=
+  (rfl)
 
 @[simp]
-theorem mapCompositionSeries_length (e : M ≃ₗ[R] N) (s : CompositionSeries (Submodule R M)) :
-    (mapCompositionSeries e s).length = s.length :=
-  rfl
+theorem last_mapCompositionSeriesOfInjective (f : M →ₗ[R] N) (hf : Function.Injective f)
+    (s : CompositionSeries (Submodule R M)) :
+    (mapCompositionSeriesOfInjective f hf s).last = s.last.map f :=
+  (rfl)
+
+/-- The preimage of a composition series of `N` under a surjective linear map `f : M →ₗ[R] N`.
+The body is `@[expose]`d for the same reason as
+`TauCeti.mapCompositionSeriesOfInjective`. -/
+@[expose] def comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) : CompositionSeries (Submodule R M) :=
+  s.map ⟨fun A => A.comap f, Submodule.comap_covBy_of_surjective hf⟩
 
 @[simp]
-theorem head_mapCompositionSeries (e : M ≃ₗ[R] N) (s : CompositionSeries (Submodule R M)) :
-    (mapCompositionSeries e s).head = Submodule.map (e : M →ₗ[R] N) s.head :=
-  rfl
+theorem head_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) :
+    (comapCompositionSeriesOfSurjective f hf s).head = s.head.comap f :=
+  (rfl)
 
 @[simp]
-theorem last_mapCompositionSeries (e : M ≃ₗ[R] N) (s : CompositionSeries (Submodule R M)) :
-    (mapCompositionSeries e s).last = Submodule.map (e : M →ₗ[R] N) s.last :=
-  rfl
-
-/-- Restricting a linear equivalence to a submodule carries the trace of another submodule to the
-trace of its image.  This is the compatibility that lets a linear equivalence be pushed through the
-subquotients of a composition series. -/
-theorem map_submoduleMap_comap_subtype (e : M ≃ₗ[R] N) (A B : Submodule R M) :
-    Submodule.map (e.submoduleMap B).toLinearMap (Submodule.comap B.subtype A)
-      = Submodule.comap (Submodule.map (e : M →ₗ[R] N) B).subtype
-          (Submodule.map (e : M →ₗ[R] N) A) := by
-  ext y
-  simp only [Submodule.mem_map, Submodule.mem_comap, Submodule.coe_subtype]
-  constructor
-  · rintro ⟨x, hx, rfl⟩
-    exact ⟨(x : M), hx, rfl⟩
-  · rintro ⟨a, ha, hay⟩
-    obtain ⟨b, hb, hby⟩ := y.2
-    have hab : a = b := e.injective (hay.trans hby.symm)
-    exact ⟨⟨a, by rw [hab]; exact hb⟩, ha, Subtype.ext hay⟩
-
-/-- A linear equivalence identifies the factors of a composition series with those of its image:
-`LinearEquiv.submoduleMap` carries the trace of `s i.castSucc` in `s i.succ` onto the trace of its
-image, by `TauCeti.map_submoduleMap_comap_subtype`, so it descends to the subquotients.  Its target
-is spelled with `TauCeti.mapCompositionSeries`, which is definitionally `Submodule.map ↑e` applied
-termwise. -/
-noncomputable def factorEquivMapCompositionSeries (e : M ≃ₗ[R] N)
-    (s : CompositionSeries (Submodule R M)) (i : Fin s.length) :
-    (↥(s i.succ) ⧸ Submodule.comap (s i.succ).subtype (s i.castSucc)) ≃ₗ[R]
-      (↥(mapCompositionSeries e s i.succ) ⧸
-        Submodule.comap (mapCompositionSeries e s i.succ).subtype
-          (mapCompositionSeries e s i.castSucc)) :=
-  Submodule.Quotient.equiv _ _ (e.submoduleMap (s i.succ))
-    (map_submoduleMap_comap_subtype e (s i.castSucc) (s i.succ))
-
--- Not `@[simp]`: the implicit type arguments of the left-hand side mention
--- `mapCompositionSeries e s i.succ`, which `mapCompositionSeries_apply` rewrites, so the statement
--- is not in simp-normal form and `simpNF` rejects the tag.
-theorem factorEquivMapCompositionSeries_apply (e : M ≃ₗ[R] N)
-    (s : CompositionSeries (Submodule R M)) (i : Fin s.length) (x : ↥(s i.succ)) :
-    factorEquivMapCompositionSeries e s i (Submodule.Quotient.mk x) =
-      Submodule.Quotient.mk (e.submoduleMap (s i.succ) x) :=
+theorem last_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N) (hf : Function.Surjective f)
+    (s : CompositionSeries (Submodule R N)) :
+    (comapCompositionSeriesOfSurjective f hf s).last = s.last.comap f :=
   (rfl)
 
 end TauCeti

--- a/TauCeti/RingTheory/CompositionSeries/Multiplicity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Multiplicity.lean
@@ -253,26 +253,34 @@ section Transport
 variable {N : Type v'} [AddCommGroup N] [Module R N]
 
 /-- Transporting a composition series along an injective linear map does not change which module
-sits at an index. -/
+sits at an index; the index is transported along
+`TauCeti.mapCompositionSeriesOfInjective_length`. -/
 @[simp]
 theorem isCompositionFactorAt_mapCompositionSeriesOfInjective_iff (f : M →ₗ[R] N)
-    (hf : Function.Injective f) (s : CompositionSeries (Submodule R M)) (i : Fin s.length)
+    (hf : Function.Injective f) (s : CompositionSeries (Submodule R M))
+    (i : Fin (mapCompositionSeriesOfInjective f hf s).length)
     (S : Type w) [AddCommGroup S] [Module R S] :
     IsCompositionFactorAt (mapCompositionSeriesOfInjective f hf s) i S ↔
-      IsCompositionFactorAt s i S :=
-  ⟨fun ⟨g⟩ => ⟨(mapSubquotientEquivOfInjective f hf (s i.castSucc) (s i.succ)).symm.trans g⟩,
-    fun ⟨g⟩ => ⟨(mapSubquotientEquivOfInjective f hf (s i.castSucc) (s i.succ)).trans g⟩⟩
+      IsCompositionFactorAt s (i.cast (mapCompositionSeriesOfInjective_length f hf s)) S := by
+  rw [isCompositionFactorAt_iff, isCompositionFactorAt_iff,
+    mapCompositionSeriesOfInjective_apply, mapCompositionSeriesOfInjective_apply]
+  exact ⟨fun ⟨g⟩ => ⟨(mapSubquotientEquivOfInjective f hf _ _).symm.trans g⟩,
+    fun ⟨g⟩ => ⟨(mapSubquotientEquivOfInjective f hf _ _).trans g⟩⟩
 
 /-- Transporting a composition series along a surjective linear map does not change which module
-sits at an index. -/
+sits at an index; the index is transported along
+`TauCeti.comapCompositionSeriesOfSurjective_length`. -/
 @[simp]
 theorem isCompositionFactorAt_comapCompositionSeriesOfSurjective_iff (f : M →ₗ[R] N)
-    (hf : Function.Surjective f) (s : CompositionSeries (Submodule R N)) (i : Fin s.length)
+    (hf : Function.Surjective f) (s : CompositionSeries (Submodule R N))
+    (i : Fin (comapCompositionSeriesOfSurjective f hf s).length)
     (S : Type w) [AddCommGroup S] [Module R S] :
     IsCompositionFactorAt (comapCompositionSeriesOfSurjective f hf s) i S ↔
-      IsCompositionFactorAt s i S :=
-  ⟨fun ⟨g⟩ => ⟨(comapSubquotientEquivOfSurjective f hf (s i.castSucc) (s i.succ)).symm.trans g⟩,
-    fun ⟨g⟩ => ⟨(comapSubquotientEquivOfSurjective f hf (s i.castSucc) (s i.succ)).trans g⟩⟩
+      IsCompositionFactorAt s (i.cast (comapCompositionSeriesOfSurjective_length f hf s)) S := by
+  rw [isCompositionFactorAt_iff, isCompositionFactorAt_iff,
+    comapCompositionSeriesOfSurjective_apply, comapCompositionSeriesOfSurjective_apply]
+  exact ⟨fun ⟨g⟩ => ⟨(comapSubquotientEquivOfSurjective f hf _ _).symm.trans g⟩,
+    fun ⟨g⟩ => ⟨(comapSubquotientEquivOfSurjective f hf _ _).trans g⟩⟩
 
 /-- **An injective map preserves multiplicities**: the image of a composition series counts every
 module the same number of times as the series itself. -/
@@ -282,8 +290,8 @@ theorem compositionMultiplicity_mapCompositionSeriesOfInjective (f : M →ₗ[R]
     (S : Type w) [AddCommGroup S] [Module R S] :
     compositionMultiplicity (mapCompositionSeriesOfInjective f hf s) S =
       compositionMultiplicity s S :=
-  Nat.card_congr (Equiv.subtypeEquivRight fun i =>
-    isCompositionFactorAt_mapCompositionSeriesOfInjective_iff f hf s i S)
+  Nat.card_congr (Equiv.subtypeEquiv (finCongr (mapCompositionSeriesOfInjective_length f hf s))
+    fun i => isCompositionFactorAt_mapCompositionSeriesOfInjective_iff f hf s i S)
 
 /-- **A surjective map preserves multiplicities**: the preimage of a composition series counts
 every module the same number of times as the series itself. -/
@@ -293,8 +301,9 @@ theorem compositionMultiplicity_comapCompositionSeriesOfSurjective (f : M →ₗ
     (S : Type w) [AddCommGroup S] [Module R S] :
     compositionMultiplicity (comapCompositionSeriesOfSurjective f hf s) S =
       compositionMultiplicity s S :=
-  Nat.card_congr (Equiv.subtypeEquivRight fun i =>
-    isCompositionFactorAt_comapCompositionSeriesOfSurjective_iff f hf s i S)
+  Nat.card_congr
+    (Equiv.subtypeEquiv (finCongr (comapCompositionSeriesOfSurjective_length f hf s))
+      fun i => isCompositionFactorAt_comapCompositionSeriesOfSurjective_iff f hf s i S)
 
 /-- **The multiplicity only depends on the isomorphism class of the ambient module.** -/
 theorem jordanHolderMultiplicity_eq_of_linearEquiv [IsNoetherian R M] [IsArtinian R M]

--- a/TauCeti/RingTheory/CompositionSeries/Multiplicity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Multiplicity.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.Length
+public import TauCeti.Algebra.Module.Submodule.Quotient
 public import TauCeti.RingTheory.CompositionSeries.Basic
 
 /-!

--- a/TauCeti/RingTheory/CompositionSeries/Multiplicity.lean
+++ b/TauCeti/RingTheory/CompositionSeries/Multiplicity.lean
@@ -55,7 +55,7 @@ definitional identity.
 * `TauCeti.jordanHolderMultiplicity_eq_of_linearEquiv`: **the multiplicity is an invariant of the
   isomorphism class of the ambient module**, which is what makes `[Pᵢ : Sⱼ]` well posed for a
   projective cover, an object defined only up to isomorphism.  The transport of a composition
-  series along a linear equivalence that this rests on is
+  series along an injective or a surjective linear map that this rests on is
   `TauCeti.RingTheory.CompositionSeries.Basic`.
 * `TauCeti.jordanHolderMultiplicity_eq_one_of_isSimpleModule_of_linearEquiv` and
   `TauCeti.jordanHolderMultiplicity_eq_zero_of_isEmpty_linearEquiv_of_isSimpleModule`: a simple
@@ -115,6 +115,14 @@ theorem isCompositionFactorAt_congr (e : S ≃ₗ[R] T) :
     IsCompositionFactorAt s i S ↔ IsCompositionFactorAt s i T :=
   ⟨fun h => h.congr e, fun h => h.congr e.symm⟩
 
+/-- Two composition series with the same two submodules at an index have the same factor there.
+The equalities are enough: the subquotient is built from the two submodules alone. -/
+theorem isCompositionFactorAt_congr_of_eq {s t : CompositionSeries (Submodule R M)}
+    {i : Fin s.length} {j : Fin t.length} (hsucc : s i.succ = t j.succ)
+    (hcast : s i.castSucc = t j.castSucc) :
+    IsCompositionFactorAt s i S ↔ IsCompositionFactorAt t j S := by
+  rw [isCompositionFactorAt_iff, isCompositionFactorAt_iff, hcast, hsucc]
+
 /-- **The factors of a composition series are simple**: each step of a composition series is a
 covering, and a covering pair of submodules has simple quotient. -/
 theorem isSimpleModule_subquotient (s : CompositionSeries (Submodule R M)) (i : Fin s.length) :
@@ -142,6 +150,15 @@ theorem compositionMultiplicity_def (s : CompositionSeries (Submodule R M))
     (S : Type w) [AddCommGroup S] [Module R S] :
     compositionMultiplicity s S = Nat.card {i : Fin s.length // IsCompositionFactorAt s i S} :=
   (rfl)
+
+/-- The multiplicity along a fixed composition series as a sum of indicators, the form in which it
+splits along a decomposition of the index set. -/
+theorem compositionMultiplicity_eq_sum_ite (s : CompositionSeries (Submodule R M))
+    (S : Type w) [AddCommGroup S] [Module R S] [∀ i, Decidable (IsCompositionFactorAt s i S)] :
+    compositionMultiplicity s S =
+      ∑ i : Fin s.length, if IsCompositionFactorAt s i S then 1 else 0 := by
+  rw [compositionMultiplicity_def, Nat.card_eq_fintype_card, Fintype.card_subtype,
+    Finset.card_filter]
 
 /-- `S` occurs in `s` — the multiplicity is nonzero — exactly when some index carries a copy of
 `S`. -/
@@ -228,31 +245,55 @@ theorem jordanHolderMultiplicity_eq_zero_of_not_isSimpleModule [IsNoetherian R M
     jordanHolderMultiplicity R M S = 0 :=
   compositionMultiplicity_eq_zero_of_not_isSimpleModule _ S hS
 
-/-! ### Transport along a linear equivalence of the ambient module -/
+/-! ### Transport along an injective or a surjective linear map -/
 
 section Transport
 
 variable {N : Type v'} [AddCommGroup N] [Module R N]
 
-/-- Transporting a composition series along a linear equivalence does not change which module sits
-at an index. -/
+/-- Transporting a composition series along an injective linear map does not change which module
+sits at an index. -/
 @[simp]
-theorem isCompositionFactorAt_mapCompositionSeries_iff (e : M ≃ₗ[R] N)
-    (s : CompositionSeries (Submodule R M)) (i : Fin s.length)
+theorem isCompositionFactorAt_mapCompositionSeriesOfInjective_iff (f : M →ₗ[R] N)
+    (hf : Function.Injective f) (s : CompositionSeries (Submodule R M)) (i : Fin s.length)
     (S : Type w) [AddCommGroup S] [Module R S] :
-    IsCompositionFactorAt (mapCompositionSeries e s) i S ↔ IsCompositionFactorAt s i S :=
-  ⟨fun ⟨f⟩ => ⟨(factorEquivMapCompositionSeries e s i).trans f⟩,
-    fun ⟨f⟩ => ⟨(factorEquivMapCompositionSeries e s i).symm.trans f⟩⟩
+    IsCompositionFactorAt (mapCompositionSeriesOfInjective f hf s) i S ↔
+      IsCompositionFactorAt s i S :=
+  ⟨fun ⟨g⟩ => ⟨(mapSubquotientEquivOfInjective f hf (s i.castSucc) (s i.succ)).symm.trans g⟩,
+    fun ⟨g⟩ => ⟨(mapSubquotientEquivOfInjective f hf (s i.castSucc) (s i.succ)).trans g⟩⟩
 
-/-- **Transport preserves multiplicities.** The image of a composition series under a linear
-equivalence of the ambient module counts every module the same number of times as the series
-itself. -/
+/-- Transporting a composition series along a surjective linear map does not change which module
+sits at an index. -/
 @[simp]
-theorem compositionMultiplicity_mapCompositionSeries (e : M ≃ₗ[R] N)
-    (s : CompositionSeries (Submodule R M)) (S : Type w) [AddCommGroup S] [Module R S] :
-    compositionMultiplicity (mapCompositionSeries e s) S = compositionMultiplicity s S :=
+theorem isCompositionFactorAt_comapCompositionSeriesOfSurjective_iff (f : M →ₗ[R] N)
+    (hf : Function.Surjective f) (s : CompositionSeries (Submodule R N)) (i : Fin s.length)
+    (S : Type w) [AddCommGroup S] [Module R S] :
+    IsCompositionFactorAt (comapCompositionSeriesOfSurjective f hf s) i S ↔
+      IsCompositionFactorAt s i S :=
+  ⟨fun ⟨g⟩ => ⟨(comapSubquotientEquivOfSurjective f hf (s i.castSucc) (s i.succ)).symm.trans g⟩,
+    fun ⟨g⟩ => ⟨(comapSubquotientEquivOfSurjective f hf (s i.castSucc) (s i.succ)).trans g⟩⟩
+
+/-- **An injective map preserves multiplicities**: the image of a composition series counts every
+module the same number of times as the series itself. -/
+@[simp]
+theorem compositionMultiplicity_mapCompositionSeriesOfInjective (f : M →ₗ[R] N)
+    (hf : Function.Injective f) (s : CompositionSeries (Submodule R M))
+    (S : Type w) [AddCommGroup S] [Module R S] :
+    compositionMultiplicity (mapCompositionSeriesOfInjective f hf s) S =
+      compositionMultiplicity s S :=
   Nat.card_congr (Equiv.subtypeEquivRight fun i =>
-    isCompositionFactorAt_mapCompositionSeries_iff e s i S)
+    isCompositionFactorAt_mapCompositionSeriesOfInjective_iff f hf s i S)
+
+/-- **A surjective map preserves multiplicities**: the preimage of a composition series counts
+every module the same number of times as the series itself. -/
+@[simp]
+theorem compositionMultiplicity_comapCompositionSeriesOfSurjective (f : M →ₗ[R] N)
+    (hf : Function.Surjective f) (s : CompositionSeries (Submodule R N))
+    (S : Type w) [AddCommGroup S] [Module R S] :
+    compositionMultiplicity (comapCompositionSeriesOfSurjective f hf s) S =
+      compositionMultiplicity s S :=
+  Nat.card_congr (Equiv.subtypeEquivRight fun i =>
+    isCompositionFactorAt_comapCompositionSeriesOfSurjective_iff f hf s i S)
 
 /-- **The multiplicity only depends on the isomorphism class of the ambient module.** -/
 theorem jordanHolderMultiplicity_eq_of_linearEquiv [IsNoetherian R M] [IsArtinian R M]
@@ -261,10 +302,10 @@ theorem jordanHolderMultiplicity_eq_of_linearEquiv [IsNoetherian R M] [IsArtinia
     jordanHolderMultiplicity R M S = jordanHolderMultiplicity R N S := by
   obtain ⟨s, hbot, htop⟩ := exists_compositionSeries_of_isNoetherian_isArtinian R M
   rw [← compositionMultiplicity_eq_jordanHolderMultiplicity s hbot htop S,
-    ← compositionMultiplicity_eq_jordanHolderMultiplicity (mapCompositionSeries e s)
-      (by rw [head_mapCompositionSeries, hbot, Submodule.map_bot])
-      (by rw [last_mapCompositionSeries, htop, Submodule.map_top, e.range]) S,
-    compositionMultiplicity_mapCompositionSeries]
+    ← compositionMultiplicity_eq_jordanHolderMultiplicity
+      (mapCompositionSeriesOfInjective (e : M →ₗ[R] N) e.injective s)
+      (by simp [hbot]) (by simp [htop, e.range]) S,
+    compositionMultiplicity_mapCompositionSeriesOfInjective]
 
 end Transport
 


### PR DESCRIPTION
This PR proves that the Jordan-Hölder multiplicity `[M : S]` is additive: for a submodule `p` of a module `M` of finite length, `[M : S] = [p : S] + [M ⧸ p : S]`, together with the short-exact-sequence and binary-product forms and the two monotonicity corollaries for an arbitrary injective, respectively surjective, linear map. `TauCeti/RingTheory/CompositionSeries/Multiplicity.lean` already builds the multiplicity and proves it a Jordan-Hölder invariant, but nothing so far relates the multiplicities of a module, a submodule and the quotient, so a multiplicity could only be read off a single composition series and never assembled from a filtration.

The gluing needs two transports. An injective linear map identifies the subquotient cut out by `A`, `B` with the subquotient cut out by their images (`TauCeti.mapSubquotientEquivOfInjective`); a surjective one identifies the subquotient cut out by the preimages with the subquotient cut out by `A`, `B` (`TauCeti.comapSubquotientEquivOfSurjective`). Both are generic statements about submodule subquotients and live in `TauCeti/Algebra/Module/Submodule/Quotient.lean`; neither needs `A ≤ B`. On top of Mathlib's `Submodule.map_covBy_of_injective` and `Submodule.comap_covBy_of_surjective` they turn into `TauCeti.mapCompositionSeriesOfInjective` and `TauCeti.comapCompositionSeriesOfSurjective` in `TauCeti/RingTheory/CompositionSeries/Basic.lean`, which carry composition series to composition series *with the same factors*, hence preserve every multiplicity. A composition series of `p`, pushed along `p.subtype`, and one of `M ⧸ p`, pulled back along `p.mkQ`, then meet at `p`; `RelSeries.smash` glues them into a composition series of `M` from `⊥` to `⊤`, and its `castAdd`/`natAdd` index lemmas split the count of factors isomorphic to `S` into the two halves.

`Basic.lean` previously carried the same transport for a linear *equivalence* only (`mapCompositionSeries`, `factorEquivMapCompositionSeries`, `map_submoduleMap_comap_subtype`). The injective form strictly subsumes it, so per the project's no-backwards-compatibility policy this PR deletes the superseded surface and restates `Multiplicity.lean`'s transport section against the general form, rather than leaving two names for one construction.

### Relation to Mathlib

The development is a factor-tracking refinement of Mathlib's `Module.length_eq_add_of_exact` (`Mathlib/RingTheory/Length.lean`, Andrew Yang) and follows its proof plan: the same two transports along an injective and a surjective map, the same `RelSeries.smash` gluing, and the same `map_bot`/`comap_top` endpoint bookkeeping. `jordanHolderMultiplicity_le_of_injective`, `jordanHolderMultiplicity_le_of_surjective` and `jordanHolderMultiplicity_prod` are the multiplicity analogues of `Module.length_le_of_injective`, `Module.length_le_of_surjective` and `Module.length_prod`. What is new is that the transports are shown to preserve each factor's *isomorphism class* and not merely the number of factors, which is what turns a length statement into a multiplicity statement; Mathlib's version counts factors without identifying them. The `## References` block of `Additivity.lean` records this credit.

The target is the Cartan matrix of Layer 3 of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` ("The Cartan matrix of an algebra", *"defined primarily by the Jordan-Hölder multiplicities `Cᵢⱼ = [Pᵢ : Sⱼ]` of `Sⱼ` in the projective cover `Pᵢ`, well-defined by Jordan-Hölder"*), pinned as `cartanMatrix` in that roadmap's `Suggested.lean`. Additivity is the prerequisite that makes such an entry computable: without it `[Pᵢ : Sⱼ]` is a number attached to one chosen series rather than something a filtration of `Pᵢ` determines. `TauCeti/RingTheory/CompositionSeries/Multiplicity.lean` cites the same roadmap item as its own motivation.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"jordan-holder-multiplicity-additivity"}-->

🤖 Prepared with Claude Code

