### PR TITLE
feat(Huber): power-boundedness descends along the completion map (Wedhorn 7.47(1))

### DIFF
--- a/TauCeti/RingTheory/Huber/Completion.lean
+++ b/TauCeti/RingTheory/Huber/Completion.lean
@@ -43,6 +43,12 @@ converge because `Â` is complete, and their sums exhibit the element as a combi
   `TauCeti.Huber.isPowerBounded_completion_coe_of_isPowerBounded`: boundedness and
   power-boundedness transfer from `A` to its completion along the canonical map. Both are stated
   for a Huber ring, with no pair of definition in the signature.
+* `TauCeti.Huber.isBounded_of_isBounded_image_completion_coe` and
+  `TauCeti.Huber.isPowerBounded_of_isPowerBounded_completion_coe`: the converses, which come back
+  down to `A` through the open-subgroup correspondence
+  `UniformSpace.Completion.preimage_closure_image_coe`.
+* `TauCeti.Huber.isPowerBounded_completion_coe_iff`: the two power-bounded directions together —
+  Wedhorn's Lemma 7.47(1) at the level of elements, that `A⁰` is the preimage of `Â⁰`.
 * `TauCeti.Huber.PairOfDefinition.hasBasis_nhds_zero_completion`: the closures of the images of
   the powers `Iⁿ` are a neighbourhood basis of zero in `Â`.
 * `TauCeti.Huber.PairOfDefinition.completionIdeal_pow`: `Îⁿ` is the closure of the image of `Iⁿ`.
@@ -451,6 +457,33 @@ theorem isBounded_image_completion_coe_of_isBounded [IsHuberRing A] {X : Set A}
   exact closure_minimal (Set.image_subset_iff.mpr hmaps) isClosed_closure
     (image_closure_subset_closure_image hcont ⟨y, hy, rfl⟩)
 
+/-- **The converse of `isBounded_image_completion_coe_of_isBounded`.** A set whose image in `Â` is
+bounded was already bounded in `A`.
+
+The step that comes back down to `A` is the open-subgroup correspondence: `Iⁿ` is open, so
+`UniformSpace.Completion.preimage_closure_image_coe` says an element of `A` whose image lies in
+`closure (ι '' Iⁿ)` — that is, in `completionIdealImage n` — lies in `Iⁿ` itself. -/
+theorem isBounded_of_isBounded_image_completion_coe [IsHuberRing A] {X : Set A}
+    (hX : IsBounded (((↑) : A → Completion A) '' X)) : IsBounded X := by
+  refine (IsHuberRing.nonempty_pairOfDefinition (A := A)).elim fun P ↦ ?_
+  rw [isBounded_iff]
+  intro U hU
+  obtain ⟨n, -, hnU⟩ := P.hasBasis_nhds_zero.mem_iff.mp hU
+  obtain ⟨W, hW, hWX⟩ := isBounded_iff.mp hX _ ((P.isOpen_completionIdealImage n).mem_nhds
+    (P.completionIdealImage n).zero_mem)
+  obtain ⟨m, -, hmW⟩ := (P.hasBasis_nhds_zero_completion).mem_iff.mp hW
+  refine ⟨P.idealImage m, (P.isOpen_idealImage m).mem_nhds (P.idealImage m).zero_mem,
+    Set.Subset.trans ?_ hnU⟩
+  rintro _ ⟨v, hv, x, hx, rfl⟩
+  have hup : ((v * x : A) : Completion A) ∈ P.completionIdealImage n := by
+    rw [Completion.coe_mul]
+    exact hWX (Set.mul_mem_mul (hmW (P.coe_mem_completionIdealImage hv)) ⟨x, hx, rfl⟩)
+  have hback := UniformSpace.Completion.preimage_closure_image_coe (P.isOpen_idealImage n)
+  have : (v * x : A) ∈ ((P.idealImage n : AddSubgroup A) : Set A) := by
+    rw [← hback, Set.mem_preimage, ← P.coe_completionIdealImage]
+    exact hup
+  simpa using this
+
 /-- **A power-bounded element of `A` stays power-bounded in `Â`.** -/
 theorem isPowerBounded_completion_coe_of_isPowerBounded [IsHuberRing A] {a : A}
     (ha : IsPowerBounded a) : IsPowerBounded ((a : Completion A)) := by
@@ -462,6 +495,26 @@ theorem isPowerBounded_completion_coe_of_isPowerBounded [IsHuberRing A] {a : A}
     simpa only [hcoe] using Set.range_comp' (((↑) : A → Completion A)) (a ^ · : ℕ → A)
   rw [isPowerBounded_iff, h]
   exact isBounded_image_completion_coe_of_isBounded (isPowerBounded_iff.mp ha)
+
+/-- **The converse of `isPowerBounded_completion_coe_of_isPowerBounded`.** An element of `A` whose
+image in `Â` is power-bounded was already power-bounded. -/
+theorem isPowerBounded_of_isPowerBounded_completion_coe [IsHuberRing A] {a : A}
+    (ha : IsPowerBounded ((a : Completion A))) : IsPowerBounded a := by
+  have hcoe : ∀ k : ℕ, ((a : Completion A)) ^ k = ((a ^ k : A) : Completion A) :=
+    fun k ↦ (map_pow Completion.coeRingHom a k).symm
+  have h : Set.range (((a : Completion A)) ^ · : ℕ → Completion A)
+      = ((↑) : A → Completion A) '' Set.range (a ^ · : ℕ → A) := by
+    simpa only [hcoe] using Set.range_comp' (((↑) : A → Completion A)) (a ^ · : ℕ → A)
+  rw [isPowerBounded_iff] at ha ⊢
+  rw [h] at ha
+  exact isBounded_of_isBounded_image_completion_coe ha
+
+/-- **Wedhorn Lemma 7.47(1), at the level of elements: `A⁰` is the preimage of `Â⁰`.** An element of
+`A` is power-bounded exactly when its image in the completion is. -/
+theorem isPowerBounded_completion_coe_iff [IsHuberRing A] {a : A} :
+    IsPowerBounded ((a : Completion A)) ↔ IsPowerBounded a :=
+  ⟨isPowerBounded_of_isPowerBounded_completion_coe,
+    isPowerBounded_completion_coe_of_isPowerBounded⟩
 
 /-- Wedhorn Remark 6.8: the completion of a Huber ring is a Huber ring. -/
 instance IsHuberRing.completion [IsHuberRing A] : IsHuberRing (Completion A) :=

--- a/TauCeti/Topology/Algebra/Nonarchimedean/Completion.lean
+++ b/TauCeti/Topology/Algebra/Nonarchimedean/Completion.lean
@@ -40,6 +40,9 @@ of `G`.
   additive subgroup of `A` is open, and
   `UniformSpace.Completion.isOpen_topologicalClosure_map_coeRingHom` says the same of an open
   subring.
+* `UniformSpace.Completion.preimage_closure_image_coe`: for an *open* subgroup `G`, the preimage
+  under `A → Â` of the closure of the image of `G` is `G` itself. With the openness result above
+  this is the bijection of Wedhorn's Example 5.33 between the open subgroups of `A` and of `Â`.
 * `UniformSpace.Completion.ker_coeRingHom`: the kernel of `A → Â` is the closure of `⊥`.
 * `UniformSpace.Completion.isIntegrallyClosedIn_topologicalClosure_map_coeRingHom`:
   Huber's Lemma 2.4.3(iv), the closure in `Â` of the image of an open subring of `A` integrally
@@ -75,6 +78,19 @@ theorem isOpen_closure_image_coe {G : AddSubgroup A} (hG : IsOpen (G : Set A)) :
   have hmem := Completion.isDenseInducing_coe.closure_image_mem_nhds (hG.mem_nhds G.zero_mem)
   rw [Completion.coe_zero] at hmem
   exact AddSubgroup.isOpen_of_mem_nhds ((G.map Completion.toCompl).topologicalClosure) hmem
+
+/-- **An open additive subgroup is recovered from the closure of its image.** For `G` open, the
+preimage under `A → Â` of the closure of the image of `G` is `G` itself.
+
+This is the injectivity half of the bijection `G ↦ closure (ι '' G)` between the open subgroups of
+`A` and those of `Â` (Wedhorn, Example 5.33); `isOpen_closure_image_coe` says the map lands in open
+subgroups. Note it holds without assuming `A` separated: the kernel of `A → Â` is the closure of
+`⊥`, which lies in every neighbourhood of `0` and hence in the open `G`. -/
+theorem preimage_closure_image_coe {G : AddSubgroup A} (hG : IsOpen (G : Set A)) :
+    ((↑) : A → Completion A) ⁻¹' closure (((↑) : A → Completion A) '' (G : Set A))
+      = (G : Set A) := by
+  rw [← Completion.isDenseInducing_coe.isInducing.closure_eq_preimage_closure_image]
+  exact (AddSubgroup.isClosed_of_isOpen G hG).closure_eq
 
 end AddGroup
 


### PR DESCRIPTION
Wedhorn's Lemma 7.47(1) says that an element of a Huber ring is power-bounded exactly when its
image in the completion is. Only the forward direction was on `main`
(`isPowerBounded_completion_coe_of_isPowerBounded`). This adds the converse, and hence the `iff`.

| declaration | file |
|---|---|
| `UniformSpace.Completion.preimage_closure_image_coe` | `TauCeti/Topology/Algebra/Nonarchimedean/Completion.lean` |
| `TauCeti.Huber.isBounded_of_isBounded_image_completion_coe` | `TauCeti/RingTheory/Huber/Completion.lean` |
| `TauCeti.Huber.isPowerBounded_of_isPowerBounded_completion_coe` | `TauCeti/RingTheory/Huber/Completion.lean` |
| `TauCeti.Huber.isPowerBounded_completion_coe_iff` | `TauCeti/RingTheory/Huber/Completion.lean` |

## Why the first one is here, and why it is not in a Huber file

The descent needs a fact that is not about Huber rings at all: for an **open** additive subgroup
`G ⊆ A`, the preimage under `A → Â` of the closure of the image of `G` is `G` itself. That is the
injectivity half of the bijection in Wedhorn's Example 5.33. Its companion — that the closure of
the image is open, `isOpen_closure_image_coe` — was already in
`Topology/Algebra/Nonarchimedean/Completion.lean`, and this sits directly beside it: the statement
mentions no pair of definition, no ring of definition and no adic topology, only a nonarchimedean
group and its completion.

It needs **no separatedness hypothesis**, which is the part worth stating. The kernel of `A → Â` is
the closure of `⊥`; that lies in every neighbourhood of zero, hence inside the open `G`, so no
information is lost even when `A` is not Hausdorff. The proof is
`IsInducing.closure_eq_preimage_closure_image` for the dense inducing coercion, followed by
`AddSubgroup.isClosed_of_isOpen`.

## The descent

Boundedness of the image gives, for each `n`, an `m` with
`ι(Iᵐ) * ι(range (a ^ ·)) ⊆ completionIdealImage n`, and `completionIdealImage n` is by definition
the closure of `ι(Iⁿ)`. Because `Iⁿ` is open, the preimage lemma pulls the product back to `Iⁿ`,
which is exactly boundedness in `A`. The power-bounded statement follows by rewriting
`range ((ι a) ^ ·)` as `ι '' range (a ^ ·)` through `Set.range_comp'`.

## Scope

This is 7.47(1) **at the level of elements**. Wedhorn's (2) — the topologically-nilpotent
correspondence — and the packaging of (1) and (2) as correspondences of *subrings* under the 5.33
bijection are not here. 7.47(3) and (4) are already on `main` and are untouched.

## Not a duplicate

`isPowerBounded_completion_coe_of_isPowerBounded` is the forward direction and is reused, not
restated. Mathlib has no `IsPowerBounded` for Huber rings and no open-subgroup/completion preimage
lemma; `IsDenseInducing.closure_eq_preimage_closure_image` is the general topological input and is
called, not reproved.

## Gate

`lake build` of both changed modules **and their two direct importers**
(`Huber.WeightedRestrictedSeries.PairOfDefinition`, `Huber.LocalizationTopology.Completion`) —
2311 jobs, exit 0, **zero** `error:`/`warning:`/`info:` diagnostics. `lake exe runLinter` clean on
both changed modules. A `run_meta` probe confirms all four declarations resolve in their expected
modules, with an absent-name negative control. Axioms: `propext`, `Classical.choice`, `Quot.sound`.

Roadmap: AdicSpaces
