### PR TITLE
feat(Valuation): valuation subrings under domination and inclusion

### DIFF
--- a/TauCeti/RingTheory/Valuation/SubringDomination.lean
+++ b/TauCeti/RingTheory/Valuation/SubringDomination.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.Basic
+public import Mathlib.RingTheory.DiscreteValuationRing.Basic
+public import Mathlib.RingTheory.Valuation.LocalSubring
+
+/-!
+# Valuation subrings under domination and inclusion
+
+Two facts about how a valuation of a field is pinned down by its valuation subring.
+
+The first is that a *one-sided* domination already forces equivalence: valuation subrings are
+maximal for the domination order on local subrings, so `𝒪_v ≤ 𝒪_w` collapses to `𝒪_v = 𝒪_w`, and
+equivalence follows. The reverse inclusion, which one might expect to have to prove, is free.
+
+The second is the rank-one rigidity behind that: a valuation subring which is a discrete valuation
+ring has no proper overrings other than the whole field, because its overrings correspond to its
+primes and a DVR has only `⊥` and its maximal ideal.
+
+## Main results
+
+* `Valuation.isEquiv_of_valuationSubring_le` : `𝒪_v ≤ 𝒪_w` in the domination order implies
+  `v.IsEquiv w`.
+* `rankOne_valuationSubring_le_eq_of_ne_top` : a valuation subring that is a DVR is equal to any
+  larger valuation subring other than `⊤`.
+
+## References
+
+* [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/hasse-weil`, commit
+  `513e83879e2f8cbc626eb9e04d660e92be16ccba`,
+  `projects/HasseWeil/HasseWeil/Curves/RankOneDomination.lean`. The proofs are that file's.
+-/
+
+public section
+
+open ValuationSubring
+
+/-- If the valuation subring of `v` dominates downward into that of `w`, then `v` and `w` are
+equivalent. Only one inclusion is needed: valuation subrings are maximal for the domination order
+(`ValuationSubring.isMax_toLocalSubring`), so `𝒪_v ≤ 𝒪_w` already forces equality. -/
+theorem Valuation.isEquiv_of_valuationSubring_le {F : Type*} [Field F] {Γ₀ : Type*}
+    [LinearOrderedCommGroupWithZero Γ₀] (v w : Valuation F Γ₀)
+    (hle : v.valuationSubring.toLocalSubring ≤ w.valuationSubring.toLocalSubring) :
+    v.IsEquiv w := by
+  have heq : v.valuationSubring.toLocalSubring = w.valuationSubring.toLocalSubring :=
+    (v.valuationSubring.isMax_toLocalSubring).eq_of_le hle
+  rw [Valuation.isEquiv_iff_valuationSubring]
+  exact ValuationSubring.toLocalSubring_injective heq
+
+/-- A valuation subring `A` of a field which is a discrete valuation ring is equal to every larger
+valuation subring `B` except `⊤`.
+
+Overrings of `A` correspond to its primes, by `B ↦ A.idealOfLE B`, with
+`ValuationSubring.ofPrime_idealOfLE` reconstructing `B`. A DVR has exactly two primes, so
+`A.idealOfLE B` is `⊥` — giving `B = ⊤`, excluded — or the maximal ideal, giving `B = A`.
+
+The transport of `ofPrime` along an equality of primes is routed through
+`ValuationSubring.primeSpectrumEquiv` rather than `rw`, because `ofPrime` takes an `IsPrime`
+instance argument and rewriting under it is not type correct; `PrimeSpectrum` bundles the
+instance and so avoids the issue. -/
+theorem rankOne_valuationSubring_le_eq_of_ne_top {L : Type*} [Field L] (A B : ValuationSubring L)
+    [IsDiscreteValuationRing A] (hAB : A ≤ B) (hB : B ≠ ⊤) : A = B := by
+  classical
+  have hPprime : (A.idealOfLE B hAB).IsPrime := ValuationSubring.prime_idealOfLE A B hAB
+  have transport : ∀ (C : ValuationSubring L) (hC : A ≤ C),
+      A.idealOfLE B hAB = A.idealOfLE C hC → B = C := by
+    intro C hC hEq
+    have hPS : (⟨A.idealOfLE B hAB, hPprime⟩ : PrimeSpectrum A)
+        = ⟨A.idealOfLE C hC, ValuationSubring.prime_idealOfLE A C hC⟩ :=
+      PrimeSpectrum.ext hEq
+    have hval := congrArg (fun P ↦ ((ValuationSubring.primeSpectrumEquiv A) P).1) hPS
+    simpa only [ValuationSubring.primeSpectrumEquiv_apply, ValuationSubring.ofPrime_idealOfLE]
+      using hval
+  rcases eq_or_ne (A.idealOfLE B hAB) ⊥ with hbot | hne
+  · exfalso
+    apply hB
+    refine transport ⊤ le_top ?_
+    rw [hbot, ValuationSubring.idealOfLE, IsLocalRing.maximalIdeal_eq_bot]
+    refine (Ideal.comap_bot_of_injective (ValuationSubring.inclusion A ⊤ le_top) ?_).symm
+    intro a b hab
+    have hab' := congrArg (Subtype.val (p := fun y ↦ y ∈ (⊤ : ValuationSubring L))) hab
+    rw [ValuationSubring.inclusion, Subring.coe_inclusion, Subring.coe_inclusion] at hab'
+    exact Subtype.ext hab'
+  · have hmax : (A.idealOfLE B hAB).IsMaximal := hPprime.isMaximal hne
+    refine (transport A le_rfl ?_).symm
+    rw [IsLocalRing.eq_maximalIdeal hmax, ValuationSubring.idealOfLE]
+    ext x
+    have hx : (ValuationSubring.inclusion A A le_rfl) x = x :=
+      Subtype.ext (by rw [ValuationSubring.inclusion, Subring.coe_inclusion])
+    rw [Ideal.mem_comap, hx]
+
+end

--- a/TauCeti/RingTheory/Valuation/SubringDomination.lean
+++ b/TauCeti/RingTheory/Valuation/SubringDomination.lean
@@ -5,93 +5,52 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RingTheory.DedekindDomain.Basic
-public import Mathlib.RingTheory.DiscreteValuationRing.Basic
 public import Mathlib.RingTheory.Valuation.LocalSubring
 
 /-!
-# Valuation subrings under domination and inclusion
+# Domination between valuation subrings forces equivalence
 
-Two facts about how a valuation of a field is pinned down by its valuation subring.
+A valuation of a field is determined by its valuation subring, so `v.IsEquiv w` is the same as
+`𝒪_v = 𝒪_w` (`Valuation.isEquiv_iff_valuationSubring`). This file records that for the
+*domination* order only **one** inclusion has to be checked: `𝒪_v ≤ 𝒪_w` already forces
+`𝒪_v = 𝒪_w`, because valuation subrings are maximal for domination
+(`ValuationSubring.isMax_toLocalSubring`, Stacks 052K).
 
-The first is that a *one-sided* domination already forces equivalence: valuation subrings are
-maximal for the domination order on local subrings, so `𝒪_v ≤ 𝒪_w` collapses to `𝒪_v = 𝒪_w`, and
-equivalence follows. The reverse inclusion, which one might expect to have to prove, is free.
-
-The second is the rank-one rigidity behind that: a valuation subring which is a discrete valuation
-ring has no proper overrings other than the whole field, because its overrings correspond to its
-primes and a DVR has only `⊥` and its maximal ideal.
+The order in play is the one on `LocalSubring`, which is domination rather than mere inclusion:
+`A ≤ B` there means `A ≤ B` as subrings *and* that `Subring.inclusion` is a local homomorphism.
+Plain inclusion is not enough — a valuation subring has many larger valuation subrings, obtained
+by coarsening, and those are not equivalent to it. What rules them out is exactly the local-hom
+half of domination, which is why the hypothesis is stated on `toLocalSubring`.
 
 ## Main results
 
-* `Valuation.isEquiv_of_valuationSubring_le` : `𝒪_v ≤ 𝒪_w` in the domination order implies
+* `Valuation.isEquiv_of_toLocalSubring_le` : if `𝒪_v` dominates downward into `𝒪_w`, then
   `v.IsEquiv w`.
-* `rankOne_valuationSubring_le_eq_of_ne_top` : a valuation subring that is a DVR is equal to any
-  larger valuation subring other than `⊤`.
 
 ## References
 
 * [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/hasse-weil`, commit
   `513e83879e2f8cbc626eb9e04d660e92be16ccba`,
-  `projects/HasseWeil/HasseWeil/Curves/RankOneDomination.lean`. The proofs are that file's.
+  `projects/HasseWeil/HasseWeil/Curves/RankOneDomination.lean`. The proof is that file's.
 -/
 
 public section
 
-open ValuationSubring
+/-- **A one-sided domination between valuation subrings already gives equivalence.** If
+`𝒪_v ≤ 𝒪_w` in the domination order on local subrings then `v.IsEquiv w`; the reverse inclusion,
+which one might expect to have to prove, is free, because valuation subrings are maximal for
+domination (`ValuationSubring.isMax_toLocalSubring`).
 
-/-- If the valuation subring of `v` dominates downward into that of `w`, then `v` and `w` are
-equivalent. Only one inclusion is needed: valuation subrings are maximal for the domination order
-(`ValuationSubring.isMax_toLocalSubring`), so `𝒪_v ≤ 𝒪_w` already forces equality. -/
-theorem Valuation.isEquiv_of_valuationSubring_le {F : Type*} [Field F] {Γ₀ : Type*}
-    [LinearOrderedCommGroupWithZero Γ₀] (v w : Valuation F Γ₀)
+The two valuations may take values in different groups: equivalence of valuations is a relation
+between valuations with unrelated value groups, and so is the conclusion here. -/
+theorem Valuation.isEquiv_of_toLocalSubring_le {F : Type*} [Field F] {Γ₁ Γ₂ : Type*}
+    [LinearOrderedCommGroupWithZero Γ₁] [LinearOrderedCommGroupWithZero Γ₂]
+    (v : Valuation F Γ₁) (w : Valuation F Γ₂)
     (hle : v.valuationSubring.toLocalSubring ≤ w.valuationSubring.toLocalSubring) :
     v.IsEquiv w := by
   have heq : v.valuationSubring.toLocalSubring = w.valuationSubring.toLocalSubring :=
     (v.valuationSubring.isMax_toLocalSubring).eq_of_le hle
   rw [Valuation.isEquiv_iff_valuationSubring]
   exact ValuationSubring.toLocalSubring_injective heq
-
-/-- A valuation subring `A` of a field which is a discrete valuation ring is equal to every larger
-valuation subring `B` except `⊤`.
-
-Overrings of `A` correspond to its primes, by `B ↦ A.idealOfLE B`, with
-`ValuationSubring.ofPrime_idealOfLE` reconstructing `B`. A DVR has exactly two primes, so
-`A.idealOfLE B` is `⊥` — giving `B = ⊤`, excluded — or the maximal ideal, giving `B = A`.
-
-The transport of `ofPrime` along an equality of primes is routed through
-`ValuationSubring.primeSpectrumEquiv` rather than `rw`, because `ofPrime` takes an `IsPrime`
-instance argument and rewriting under it is not type correct; `PrimeSpectrum` bundles the
-instance and so avoids the issue. -/
-theorem rankOne_valuationSubring_le_eq_of_ne_top {L : Type*} [Field L] (A B : ValuationSubring L)
-    [IsDiscreteValuationRing A] (hAB : A ≤ B) (hB : B ≠ ⊤) : A = B := by
-  classical
-  have hPprime : (A.idealOfLE B hAB).IsPrime := ValuationSubring.prime_idealOfLE A B hAB
-  have transport : ∀ (C : ValuationSubring L) (hC : A ≤ C),
-      A.idealOfLE B hAB = A.idealOfLE C hC → B = C := by
-    intro C hC hEq
-    have hPS : (⟨A.idealOfLE B hAB, hPprime⟩ : PrimeSpectrum A)
-        = ⟨A.idealOfLE C hC, ValuationSubring.prime_idealOfLE A C hC⟩ :=
-      PrimeSpectrum.ext hEq
-    have hval := congrArg (fun P ↦ ((ValuationSubring.primeSpectrumEquiv A) P).1) hPS
-    simpa only [ValuationSubring.primeSpectrumEquiv_apply, ValuationSubring.ofPrime_idealOfLE]
-      using hval
-  rcases eq_or_ne (A.idealOfLE B hAB) ⊥ with hbot | hne
-  · exfalso
-    apply hB
-    refine transport ⊤ le_top ?_
-    rw [hbot, ValuationSubring.idealOfLE, IsLocalRing.maximalIdeal_eq_bot]
-    refine (Ideal.comap_bot_of_injective (ValuationSubring.inclusion A ⊤ le_top) ?_).symm
-    intro a b hab
-    have hab' := congrArg (Subtype.val (p := fun y ↦ y ∈ (⊤ : ValuationSubring L))) hab
-    rw [ValuationSubring.inclusion, Subring.coe_inclusion, Subring.coe_inclusion] at hab'
-    exact Subtype.ext hab'
-  · have hmax : (A.idealOfLE B hAB).IsMaximal := hPprime.isMaximal hne
-    refine (transport A le_rfl ?_).symm
-    rw [IsLocalRing.eq_maximalIdeal hmax, ValuationSubring.idealOfLE]
-    ext x
-    have hx : (ValuationSubring.inclusion A A le_rfl) x = x :=
-      Subtype.ext (by rw [ValuationSubring.inclusion, Subring.coe_inclusion])
-    rw [Ideal.mem_comap, hx]
 
 end


### PR DESCRIPTION
One general fact about how a valuation of a field is pinned down by its valuation subring: a
*one-sided* domination already forces equivalence.

Roadmap: EllipticCurves

Target: substrate for the Hasse–Weil layer. This is general valuation theory with no curve in
it; the roadmap association is the campaign that needs it, not the subject matter.

## Provenance

Adapted with attribution from [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB),
branch `dev/hasse-weil`, commit `513e83879e2f8cbc626eb9e04d660e92be16ccba`,
`projects/HasseWeil/HasseWeil/Curves/RankOneDomination.lean`. The proof is that file's.

## Contents

`TauCeti/RingTheory/Valuation/SubringDomination.lean` (new)

* `Valuation.isEquiv_of_toLocalSubring_le` — if `𝒪_v ≤ 𝒪_w` in the domination order on local
  subrings then `v.IsEquiv w`. Only one inclusion is needed; the reverse is free, because
  valuation subrings are maximal for domination (`ValuationSubring.isMax_toLocalSubring`,
  Stacks 052K).

The order is the one on `LocalSubring`, which is domination and not mere inclusion: `A ≤ B`
there is `A ≤ B` as subrings **together with** `Subring.inclusion` being a local homomorphism.
Plain inclusion would be false — a valuation subring has larger valuation subrings, obtained by
coarsening, and those are not equivalent to it. It is the local-hom half that collapses the
inclusion to an equality, which is why the hypothesis is stated on `toLocalSubring`.

## Three of the source module's four declarations are deliberately NOT ported

The source file has four theorems and this PR ports one. A reviewer comparing the counts should
not read that as an incomplete port — the other three are **already available under different
names, and are load-bearing where they live**:

| source declaration | already available as | consumed at |
|---|---|---|
| `valuationSubring_isDVR_of_surjective_withZeroInt` | `main`: `valuationSubring_isDiscreteValuationRing_of_surjective`, `Valuation/Discrete/Order.lean:165` | `FunctionField/Place/Basic.lean:256` |
| `Valuation.isEquiv_iff_eq_of_surjective_withZeroInt` | `main`: `Valuation.eq_of_isEquiv_of_surjective`, `Valuation/Discrete/Order.lean:261` | `Place/Basic.lean:317`, `DedekindDomain/AdicValuation/Basic.lean:143` |
| `rankOne_valuationSubring_le_eq_of_ne_top` | **Mathlib**: `ValuationSubring.eq_of_le_of_ne_top`, `Mathlib/RingTheory/Valuation/ValuationSubring.lean:416` | `Mathlib/RingTheory/DedekindDomain/AdicValuation.lean:505` |

The first two are the same statements with the same hypotheses, and `main`'s versions are better
adapted: the second goes through `main`'s own `IsEquiv.ord_nonneg_iff` and
`IsEquiv.ord_eq_zero_iff` rather than the source's uniformizer-exponent computation. `main` also
already carries the two intermediate steps of the first one's proof, as
`valueGroup_eq_top_of_surjective` and `nontrivial_valueGroup_of_surjective`.

The third was in the first revision of this PR and has been **removed** in response to the
`reuse` block, which is correct. Mathlib's `eq_of_le_of_ne_top` proves the same conclusion under
a strictly weaker hypothesis, `[Ring.KrullDimLE 1 A]` in place of `[IsDiscreteValuationRing A]`,
and it is proved there the same way, through `primeSpectrumEquiv`. The specialisation is
automatic: `instance [IsDomain R] [IsDiscreteValuationRing R] : KrullDimLE 1 R`
(`Mathlib/RingTheory/DiscreteValuationRing/TFAE.lean:257`) fires on a valuation subring with no
side conditions. Checked by compiling the removed statement against it, rather than by reading:

```lean
example {L : Type*} [Field L] (A B : ValuationSubring L) [IsDiscreteValuationRing A]
    (hAB : A ≤ B) (hB : B ≠ ⊤) : A = B :=
  ValuationSubring.eq_of_le_of_ne_top A hAB hB
```

## Prior art for what *is* here

Checked with a control that fires (`ValuationSubring.isMax_toLocalSubring`,
`Mathlib/RingTheory/Valuation/LocalSubring.lean:82`), and probing the **statement** rather than
the name:

* `IsEquiv` — or an equality of valuation subrings — concluded from a *domination* inclusion:
  absent from Mathlib and from `main`. Every occurrence of `toLocalSubring` in
  `Mathlib/RingTheory` is in `Valuation/LocalSubring.lean` (the definition, `isMax_toLocalSubring`,
  `isMax_iff`, `exists_le_valuationSubring`, `exists_le_valuationSubring_of_isIntegrallyClosedIn`,
  and two uses); none of them is this implication. `main`'s only hit is a *use* of
  `isMax_toLocalSubring` at `FunctionField/Place/Extension/Existence.lean:86`.
* Mathlib's `Valuation.isEquiv_iff_valuationSubring` is the two-sided statement and is consumed
  here rather than restated.

Recording the miss honestly: the first revision's prior-art check for the removed lemma ran over
`TauCeti/RingTheory` only and not over Mathlib, which is why the duplicate reached review.

## Gates at this head

`lake build TauCeti.RingTheory.Valuation.SubringDomination`: exit 0, "Build completed
successfully (2000 jobs)", zero `error:` / `warning:` / `info:` lines. `#print axioms
Valuation.isEquiv_of_toLocalSubring_le` → `[propext, Classical.choice, Quot.sound]`.
`scripts/lint-dot-notation.py` against the baseline: rc 0, "0 new". No line exceeds 100
codepoints (max 97); no trailing whitespace or tabs.
