### PR TITLE
feat(ModularForms): the Fricke diamond-shift W ∘ ⟨d⟩ = ⟨d⁻¹⟩ ∘ W

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Fricke/Operator.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Operator.lean
@@ -209,16 +209,18 @@ public theorem frickeOperator_coe_cuspForm (k : ℤ)
     rw [coe_frickeOperator, ModularFormClass.coe_modularForm, ModularFormClass.coe_modularForm,
       coe_frickeOperatorCusp]
 
-/-- **The diamond shift** `W ∘ ⟨d⟩ = ⟨d⁻¹⟩ ∘ W` on `M_k(Γ₁(N))`.
-
-Slashing by `W` moves a representative `g` of `d` across it as `frickeConjSL g`
-(`mapGL_mul_frickeGL`), and that matrix carries the diamond label `d⁻¹`
-(`toHomUnits_gamma0Map_frickeConjGamma0_eq_inv`). Since both diamond operators may be evaluated
-at any representative with the right label (`coe_diamondOp`), the two sides are the same slash by
-a product. -/
+/-- **The diamond shift** `W ∘ ⟨d⟩ = ⟨d⁻¹⟩ ∘ W` on `M_k(Γ₁(N))`: the Fricke operator does not
+commute with the diamond operators, it inverts their label. Read on a nebentypus space this says
+`W` carries `M_k(Γ₁(N), χ)` into `M_k(Γ₁(N), χ⁻¹)`. -/
+@[simp]
 public theorem frickeOperator_diamondOp (k : ℤ) (d : (ZMod N)ˣ) :
     (frickeOperator (N := N) k).comp (diamondOp k d) =
       (diamondOp k d⁻¹).comp (frickeOperator (N := N) k) := by
+  -- `W` moves a representative `g` of `d` across it as `frickeConjSL g`
+  -- (`mapGL_mul_frickeGL`), and that matrix carries the label `d⁻¹`
+  -- (`toHomUnits_gamma0Map_frickeConjGamma0_eq_inv`). `coe_diamondOp` evaluates a diamond
+  -- operator at any representative with the right label, so both sides become one slash by a
+  -- product.
   obtain ⟨g, hg⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
   refine LinearMap.ext fun f ↦ DFunLike.coe_injective ?_
   rw [LinearMap.comp_apply, LinearMap.comp_apply, coe_frickeOperator,
@@ -227,15 +229,18 @@ public theorem frickeOperator_diamondOp (k : ℤ) (d : (ZMod N)ˣ) :
     mapGL_mul_frickeGL]
 
 /-- **The diamond shift on cusp forms**: the `S_k(Γ₁(N))` counterpart of
-`frickeOperator_diamondOp`, proved the same way from `coe_diamondOpCusp`. -/
+`frickeOperator_diamondOp`. -/
+@[simp]
 public theorem frickeOperatorCusp_diamondOpCusp (k : ℤ) (d : (ZMod N)ˣ) :
     (frickeOperatorCusp (N := N) k).comp (diamondOpCusp k d) =
       (diamondOpCusp k d⁻¹).comp (frickeOperatorCusp (N := N) k) := by
-  obtain ⟨g, hg⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
-  refine LinearMap.ext fun f ↦ DFunLike.coe_injective ?_
-  rw [LinearMap.comp_apply, LinearMap.comp_apply, coe_frickeOperatorCusp,
-    coe_diamondOpCusp k d g hg, coe_diamondOpCusp k d⁻¹ (frickeConjGamma0 g) (by simp [hg]),
-    coe_frickeOperatorCusp, ← SlashAction.slash_mul, ← SlashAction.slash_mul,
-    coe_frickeConjGamma0, mapGL_mul_frickeGL]
+  -- Both operators commute with the coercion `S_k(Γ₁(N)) → M_k(Γ₁(N))`, so this is the modular
+  -- identity read on the image; no second representative-and-slash argument is needed.
+  refine LinearMap.ext fun f ↦ DFunLike.coe_injective (funext fun z ↦ ?_)
+  have h := LinearMap.congr_fun (frickeOperator_diamondOp (N := N) k d)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)
+  rw [LinearMap.comp_apply, LinearMap.comp_apply, diamondOp_coe_cuspForm,
+    frickeOperator_coe_cuspForm, frickeOperator_coe_cuspForm, diamondOp_coe_cuspForm] at h
+  simpa [LinearMap.comp_apply] using DFunLike.congr_fun h z
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Operator.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Operator.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.NumberTheory.ModularForms.Basic
+public import TauCeti.NumberTheory.ModularForms.DiamondOperators
 public import TauCeti.NumberTheory.ModularForms.Fricke.Conjugation
 
 /-!
@@ -49,6 +50,14 @@ Scalars commute past a slash only on the positive-determinant branch — mathlib
 `det W = N > 0`, so `ModularForm.smul_slash_of_det_pos` of
 `TauCeti/NumberTheory/ModularForms/Basic.lean` applies and gives `map_smul'` for both operators.
 
+## The diamond shift
+
+`W` conjugates a representative `σ ∈ Γ₀(N)` of `d : (ZMod N)ˣ` into `frickeConjGamma0 σ`, whose
+diamond label is `d⁻¹` (`toHomUnits_gamma0Map_frickeConjGamma0_eq_inv`). So `W` does not commute
+with the diamond operators; it shifts them, `W ∘ ⟨d⟩ = ⟨d⁻¹⟩ ∘ W`. Read on a nebentypus space
+this says `W` carries `M_k(Γ₁(N), χ)` into `M_k(Γ₁(N), χ⁻¹)`, which is what the character-space
+transport of the later Fricke rungs is built from.
+
 ## Main definitions
 
 * `TauCeti.frickeOperator`: the un-normalized Fricke slash operator on `M_k(Γ₁(N))`.
@@ -63,6 +72,8 @@ Scalars commute past a slash only on the positive-determinant branch — mathlib
   operators are `⇑f ∣[k] W`.
 * `TauCeti.frickeOperator_coe_cuspForm`: the two operators agree under the coercion
   `S_k(Γ₁(N)) → M_k(Γ₁(N))`.
+* `TauCeti.frickeOperator_diamondOp`, `TauCeti.frickeOperatorCusp_diamondOpCusp`: the
+  **diamond shift** `W ∘ ⟨d⟩ = ⟨d⁻¹⟩ ∘ W`, on modular and on cusp forms.
 
 ## Provenance
 
@@ -88,12 +99,15 @@ AINTLIB proves `ℂ`-linearity with its own `smul_slash_pos_det`; the correspond
 `ModularForm.smul_slash_of_det_pos` was already on hand, and is more general (any scalar `α`
 acting on `ℂ` by an `IsScalarTower`, rather than `ℂ` itself).
 
-The diamond-shift theorem `frickeOperator_diamondOp` of the source (`W ∘ ⟨d⟩ = ⟨d⁻¹⟩ ∘ W`) is
-deliberately *not* ported here: it is stated through AINTLIB's `Gamma0MapUnits`, the unit-valued
-refinement of mathlib's `CongruenceSubgroup.Gamma0Map`, which TauCeti does not have — the same
-definition whose absence already kept `Gamma0MapUnits_frickeConjSL` out of
-`Fricke/Conjugation.lean`.
-It belongs with that definition and with the character-space transport, not here.
+The source states the diamond shift through AINTLIB's `Gamma0MapUnits`, the unit-valued
+refinement of mathlib's `CongruenceSubgroup.Gamma0Map`, which TauCeti does not define. It is
+ported here over the composite `(Gamma0Map N).toHomUnits` that this repository already uses for
+the diamond label — the same substitution by which `Gamma0MapUnits_frickeConjSL` became
+`toHomUnits_gamma0Map_frickeConjGamma0_eq_inv` in `Fricke/Conjugation.lean`, and the reason no
+`Gamma0MapUnits` definition is needed to state it. AINTLIB evaluates `⟨d⟩` on a representative
+through its private `diamondOp_eq_diamondOpAux`; the public `coe_diamondOp` does that here, so
+no auxiliary is introduced. The cusp-form twin `frickeOperatorCusp_diamondOpCusp` has no
+counterpart in the source.
 
 ## References
 
@@ -194,5 +208,34 @@ public theorem frickeOperator_coe_cuspForm (k : ℤ)
   DFunLike.coe_injective <| by
     rw [coe_frickeOperator, ModularFormClass.coe_modularForm, ModularFormClass.coe_modularForm,
       coe_frickeOperatorCusp]
+
+/-- **The diamond shift** `W ∘ ⟨d⟩ = ⟨d⁻¹⟩ ∘ W` on `M_k(Γ₁(N))`.
+
+Slashing by `W` moves a representative `g` of `d` across it as `frickeConjSL g`
+(`mapGL_mul_frickeGL`), and that matrix carries the diamond label `d⁻¹`
+(`toHomUnits_gamma0Map_frickeConjGamma0_eq_inv`). Since both diamond operators may be evaluated
+at any representative with the right label (`coe_diamondOp`), the two sides are the same slash by
+a product. -/
+public theorem frickeOperator_diamondOp (k : ℤ) (d : (ZMod N)ˣ) :
+    (frickeOperator (N := N) k).comp (diamondOp k d) =
+      (diamondOp k d⁻¹).comp (frickeOperator (N := N) k) := by
+  obtain ⟨g, hg⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
+  refine LinearMap.ext fun f ↦ DFunLike.coe_injective ?_
+  rw [LinearMap.comp_apply, LinearMap.comp_apply, coe_frickeOperator,
+    coe_diamondOp k d g hg, coe_diamondOp k d⁻¹ (frickeConjGamma0 g) (by simp [hg]),
+    coe_frickeOperator, ← SlashAction.slash_mul, ← SlashAction.slash_mul, coe_frickeConjGamma0,
+    mapGL_mul_frickeGL]
+
+/-- **The diamond shift on cusp forms**: the `S_k(Γ₁(N))` counterpart of
+`frickeOperator_diamondOp`, proved the same way from `coe_diamondOpCusp`. -/
+public theorem frickeOperatorCusp_diamondOpCusp (k : ℤ) (d : (ZMod N)ˣ) :
+    (frickeOperatorCusp (N := N) k).comp (diamondOpCusp k d) =
+      (diamondOpCusp k d⁻¹).comp (frickeOperatorCusp (N := N) k) := by
+  obtain ⟨g, hg⟩ := Gamma0Map_toHomUnits_surjective (N := N) d
+  refine LinearMap.ext fun f ↦ DFunLike.coe_injective ?_
+  rw [LinearMap.comp_apply, LinearMap.comp_apply, coe_frickeOperatorCusp,
+    coe_diamondOpCusp k d g hg, coe_diamondOpCusp k d⁻¹ (frickeConjGamma0 g) (by simp [hg]),
+    coe_frickeOperatorCusp, ← SlashAction.slash_mul, ← SlashAction.slash_mul,
+    coe_frickeConjGamma0, mapGL_mul_frickeGL]
 
 end TauCeti


### PR DESCRIPTION
Roadmap: ModularForms

The **diamond shift** `W ∘ ⟨d⟩ = ⟨d⁻¹⟩ ∘ W`, on modular and on cusp forms — AINTLIB's
`frickeOperator_diamondOp`, the last unported result of the Fricke side that
`Fricke/Operator.lean` itself names.

## What this adds

* `TauCeti.frickeOperator_diamondOp` — `(frickeOperator k).comp (diamondOp k d) = (diamondOp k d⁻¹).comp (frickeOperator k)`
* `TauCeti.frickeOperatorCusp_diamondOpCusp` — the `S_k(Γ₁(N))` twin

Slashing by `W` moves a representative `g ∈ Γ₀(N)` of `d` across it as `frickeConjSL g`
(`mapGL_mul_frickeGL`), and that matrix carries the diamond label `d⁻¹`
(`toHomUnits_gamma0Map_frickeConjGamma0_eq_inv`). Since `coe_diamondOp` evaluates `⟨d⟩` at
*any* representative with the right label, both sides reduce to the same slash by a product.
Nine lines each, no auxiliary declarations.

Read on a nebentypus space this says `W` carries `M_k(Γ₁(N), χ)` into `M_k(Γ₁(N), χ⁻¹)` — the
mechanism behind the roadmap's Layer 6 remark that for general nebentypus the `W_Q` "need not
even preserve the `χ`-space", and the input to the character-space transport of the later rungs.

## Why it was not here already, and what changed

`Fricke/Operator.lean`'s module docstring said the diamond shift "is deliberately *not* ported
here: it is stated through AINTLIB's `Gamma0MapUnits` ... which TauCeti does not have". That
premise is still true about the *definition* — `Gamma0MapUnits` has no declaration on `main` —
but it never blocked the theorem. `Fricke/Conjugation.lean:146` records the resolution: TauCeti
routes around that definition through mathlib's `MonoidHom.toHomUnits`, which is how
AINTLIB's `Gamma0MapUnits_frickeConjSL` already became
`toHomUnits_gamma0Map_frickeConjGamma0_eq_inv`. The same substitution states the diamond shift,
so **no `Gamma0MapUnits` definition is introduced** — adding one would re-add exactly what
`main` chose to omit.

That paragraph of the module docstring is rewritten accordingly: a file may not ship asserting
that a theorem it contains was deliberately left out.

## Placement

Both theorems go in `Fricke/Operator.lean`, next to the operators they are about and where the
deferral note was made. This adds `public import TauCeti.NumberTheory.ModularForms.DiamondOperators`,
which respects the layering — Layer 6 (Fricke) depending on Layer 0 (diamonds), not the reverse.
`Fricke/Operator.lean` is a **leaf module**: nothing in the repository imports it, so the new
import has no fan-out.

## Provenance

Ported from the AINTLIB `LeanModularForms` project
([`LeanModularForms/HeckeRIngs/GL2/Fricke.lean`](https://github.com/CBirkbeck/AINTLIB) L331,
commit `340875adfb2` — the commit this file's provenance block already pins), Apache-2.0,
Chris Birkbeck. AINTLIB evaluates `⟨d⟩` through its private `diamondOp_eq_diamondOpAux`; the
public `coe_diamondOp` does that here, so no auxiliary is introduced. The source has **no**
cusp-form twin of this theorem — `frickeOperatorCusp_diamondOpCusp` is new, and is stated for
parity with every other declaration in the file.

Roadmap target: `TauCetiRoadmap/ModularForms/README.md`, **Layer 6: Atkin–Lehner and Fricke
operators** — "AINTLIB provides the Fricke side to migrate — `frickeOperator`/`frickeOperatorCusp`
... (`HeckeRIngs/GL2/Fricke.lean`)".

## Verification

* `lake build TauCeti.NumberTheory.ModularForms.Fricke.Operator` — exit 0, no `error:`,
  `warning:` or `info:` diagnostics; `.olean` artefact present.
* `lake build` (whole project) — clean.
* Absence checked on `main` before writing, with resolving controls: `frickeOperator_diamondOp`
  occurs only inside the deferral docstring quoted above, never as a declaration.
* Mathlib checked with a resolving control (41 files mention `ModularForm`): `diamondOp` and
  `fricke` each match **0** files, so neither operator — and hence neither statement — exists
  upstream.
