### PR TITLE
feat: expose the profinite completion universal property

### DIFF
--- a/TauCeti/RepresentationTheory/Homological/ContCohomology/Coinduced.lean
+++ b/TauCeti/RepresentationTheory/Homological/ContCohomology/Coinduced.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Topology.Algebra.ConstMulAction
 public import Mathlib.Topology.Algebra.MulAction
 public import TauCeti.Topology.Algebra.Group.LocallyConstant
-public import TauCeti.Topology.Algebra.Group.ProfiniteSection
+public import TauCeti.Topology.Algebra.Group.Profinite.Section
 
 /-!
 # The coinduced discrete module of a subgroup

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -1,0 +1,77 @@
+import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Completion
+
+/-!
+# The universal property of profinite completion
+
+This file restates the categorical universal property of Mathlib's profinite completion for
+unbundled groups and continuous monoid homomorphisms. It also proves that the canonical map from
+a finite group to its profinite completion is bijective.
+
+The correspondence is obtained from `ProfiniteGrp.ProfiniteCompletion.homEquiv`; the finite-group
+result uses its canonical map's dense range and Mathlib's residual-finiteness criterion.
+-/
+
+namespace TauCeti
+
+open CategoryTheory
+
+namespace ProfiniteCompletion
+
+universe u
+
+variable (G : Type u) [Group G]
+variable (P : Type u) [Group P] [TopologicalSpace P] [IsTopologicalGroup P]
+  [CompactSpace P] [TotallyDisconnectedSpace P]
+
+/-- Continuous homomorphisms from the profinite completion of `G` to a profinite group `P`
+correspond to abstract homomorphisms from `G` to `P`. -/
+noncomputable def continuousMonoidHomEquiv :
+    (ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* P) ≃ (G →* P) :=
+  (ConcreteCategory.homEquiv (C := ProfiniteGrp)).symm |>.trans
+    (ProfiniteGrp.ProfiniteCompletion.homEquiv (GrpCat.of G) (ProfiniteGrp.of P)) |>.trans
+      (ConcreteCategory.homEquiv (C := GrpCat))
+
+/-- The unbundled profinite-completion correspondence restricts a continuous homomorphism along
+the canonical map. -/
+@[simp]
+theorem continuousMonoidHomEquiv_apply
+    (f : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* P) (g : G) :
+    continuousMonoidHomEquiv G P f g =
+      f (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) :=
+  rfl
+
+/-- The continuous lift of an abstract homomorphism agrees with it on the original group. -/
+@[simp]
+theorem continuousMonoidHomEquiv_symm_apply_etaFn (f : G →* P) (g : G) :
+    (continuousMonoidHomEquiv G P).symm f
+      (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) = f g := by
+  exact DFunLike.congr_fun ((continuousMonoidHomEquiv G P).apply_symm_apply f) g
+
+/-- Two continuous homomorphisms from a profinite completion agree if they agree on the
+canonical dense image of the original group. -/
+@[ext]
+theorem continuousMonoidHom_ext
+    {f g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* P}
+    (h : ∀ x : G,
+      f (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) x) =
+        g (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) x)) : f = g := by
+  apply (continuousMonoidHomEquiv G P).injective
+  ext x
+  simpa using h x
+
+/-- The canonical map from a finite group to its profinite completion is bijective. -/
+theorem etaFn_bijective_of_finite [Finite G] :
+    Function.Bijective (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G)) := by
+  refine ⟨(ProfiniteGrp.ProfiniteCompletion.etaFn_injective_iff_residuallyFinite
+    (G := GrpCat.of G)).2 inferInstance, ?_⟩
+  intro x
+  have hx : x ∈ closure (Set.range
+      (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G))) := by
+    rw [(ProfiniteGrp.ProfiniteCompletion.denseRange (G := GrpCat.of G)).closure_range]
+    exact Set.mem_univ x
+  rw [(Set.finite_range _).isClosed.closure_eq] at hx
+  exact hx
+
+end ProfiniteCompletion
+
+end TauCeti

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -1,4 +1,6 @@
-import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Completion
+module
+
+public import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Completion
 
 /-!
 # The universal property of profinite completion
@@ -10,6 +12,8 @@ a finite group to its profinite completion is bijective.
 The correspondence is obtained from `ProfiniteGrp.ProfiniteCompletion.homEquiv`; the finite-group
 result uses its canonical map's dense range and Mathlib's residual-finiteness criterion.
 -/
+
+@[expose] public section
 
 namespace TauCeti
 

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
 module
 
 public import Mathlib.Topology.Algebra.Category.ProfiniteGrp.Completion

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -41,25 +41,34 @@ noncomputable def continuousMonoidHomEquiv :
       (ConcreteCategory.homEquiv (C := GrpCat))
 
 /-- The unbundled profinite-completion correspondence restricts a continuous homomorphism along
-the canonical map.
-
-Mathlib provides no propositional computation rule for the forward direction of
-`ProfiniteGrp.ProfiniteCompletion.homEquiv`: its forward map is definitionally precomposition by
-the unit. The proof below intentionally isolates that definitional reduction behind this opaque
-simp theorem. -/
+the canonical map. -/
 @[simp]
 theorem continuousMonoidHomEquiv_apply
     (f : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* P) (g : G) :
     continuousMonoidHomEquiv G P f g =
-      f (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) :=
-  (rfl)
+      f (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) := by
+  -- The forward direction of `ProfiniteGrp.ProfiniteCompletion.homEquiv` is inverse to
+  -- `ProfiniteGrp.ProfiniteCompletion.lift`, so Mathlib's `lift_eta` computes it.
+  have key : ∀ F : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) ⟶
+        ProfiniteGrp.of P,
+      ProfiniteGrp.ProfiniteCompletion.homEquiv (GrpCat.of G) (ProfiniteGrp.of P) F =
+        ProfiniteGrp.ProfiniteCompletion.eta (GrpCat.of G) ≫ (forget₂ _ _).map F := by
+    intro F
+    have h : ProfiniteGrp.ProfiniteCompletion.lift
+        (ProfiniteGrp.ProfiniteCompletion.homEquiv (GrpCat.of G) (ProfiniteGrp.of P) F) = F :=
+      Equiv.symm_apply_apply
+        (ProfiniteGrp.ProfiniteCompletion.homEquiv (GrpCat.of G) (ProfiniteGrp.of P)) F
+    conv_rhs => rw [← h]
+    exact (ProfiniteGrp.ProfiniteCompletion.lift_eta _).symm
+  -- The remaining concrete-category plumbing is definitional.
+  exact congrArg (fun m : GrpCat.of G ⟶ GrpCat.of P => m.hom g) (key (ConcreteCategory.ofHom f))
 
 /-- The continuous lift of an abstract homomorphism agrees with it on the original group. -/
 @[simp]
 theorem continuousMonoidHomEquiv_symm_apply_etaFn (f : G →* P) (g : G) :
     (continuousMonoidHomEquiv G P).symm f
       (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) = f g := by
-  exact DFunLike.congr_fun ((continuousMonoidHomEquiv G P).apply_symm_apply f) g
+  rw [← continuousMonoidHomEquiv_apply, Equiv.apply_symm_apply]
 
 /-- Two continuous homomorphisms from a profinite completion to a Hausdorff topological group
 agree if they agree on the canonical dense image of the original group. -/

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -41,27 +41,18 @@ noncomputable def continuousMonoidHomEquiv :
       (ConcreteCategory.homEquiv (C := GrpCat))
 
 /-- The unbundled profinite-completion correspondence restricts a continuous homomorphism along
-the canonical map. -/
+the canonical map.
+
+Mathlib provides no propositional computation rule for the forward direction of
+`ProfiniteGrp.ProfiniteCompletion.homEquiv`: its forward map is definitionally precomposition by
+the unit. The proof below intentionally isolates the definitional reduction through the two
+concrete-category equivalences behind this opaque simp theorem. -/
 @[simp]
 theorem continuousMonoidHomEquiv_apply
     (f : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* P) (g : G) :
     continuousMonoidHomEquiv G P f g =
-      f (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) := by
-  -- The forward direction of `ProfiniteGrp.ProfiniteCompletion.homEquiv` is inverse to
-  -- `ProfiniteGrp.ProfiniteCompletion.lift`, so Mathlib's `lift_eta` computes it.
-  have key : ∀ F : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) ⟶
-        ProfiniteGrp.of P,
-      ProfiniteGrp.ProfiniteCompletion.homEquiv (GrpCat.of G) (ProfiniteGrp.of P) F =
-        ProfiniteGrp.ProfiniteCompletion.eta (GrpCat.of G) ≫ (forget₂ _ _).map F := by
-    intro F
-    have h : ProfiniteGrp.ProfiniteCompletion.lift
-        (ProfiniteGrp.ProfiniteCompletion.homEquiv (GrpCat.of G) (ProfiniteGrp.of P) F) = F :=
-      Equiv.symm_apply_apply
-        (ProfiniteGrp.ProfiniteCompletion.homEquiv (GrpCat.of G) (ProfiniteGrp.of P)) F
-    conv_rhs => rw [← h]
-    exact (ProfiniteGrp.ProfiniteCompletion.lift_eta _).symm
-  -- The remaining concrete-category plumbing is definitional.
-  exact congrArg (fun m : GrpCat.of G ⟶ GrpCat.of P => m.hom g) (key (ConcreteCategory.ofHom f))
+      f (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) :=
+  (rfl)
 
 /-- The continuous lift of an abstract homomorphism agrees with it on the original group. -/
 @[simp]

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -18,7 +18,7 @@ The correspondence is obtained from `ProfiniteGrp.ProfiniteCompletion.homEquiv`;
 result uses its canonical map's dense range and Mathlib's residual-finiteness criterion.
 -/
 
-@[expose] public section
+public section
 
 namespace TauCeti
 
@@ -26,7 +26,7 @@ open CategoryTheory
 
 namespace ProfiniteCompletion
 
-universe u
+universe u v
 
 variable (G : Type u) [Group G]
 variable (P : Type u) [Group P] [TopologicalSpace P] [IsTopologicalGroup P]
@@ -47,7 +47,7 @@ theorem continuousMonoidHomEquiv_apply
     (f : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* P) (g : G) :
     continuousMonoidHomEquiv G P f g =
       f (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) :=
-  rfl
+  (rfl)
 
 /-- The continuous lift of an abstract homomorphism agrees with it on the original group. -/
 @[simp]
@@ -56,17 +56,18 @@ theorem continuousMonoidHomEquiv_symm_apply_etaFn (f : G →* P) (g : G) :
       (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) = f g := by
   exact DFunLike.congr_fun ((continuousMonoidHomEquiv G P).apply_symm_apply f) g
 
-/-- Two continuous homomorphisms from a profinite completion agree if they agree on the
-canonical dense image of the original group. -/
+/-- Two continuous homomorphisms from a profinite completion to a Hausdorff topological group
+agree if they agree on the canonical dense image of the original group. -/
 @[ext]
 theorem continuousMonoidHom_ext
-    {f g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* P}
+    {Q : Type v} [Group Q] [TopologicalSpace Q] [T2Space Q]
+    {f g : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* Q}
     (h : ∀ x : G,
       f (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) x) =
         g (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) x)) : f = g := by
-  apply (continuousMonoidHomEquiv G P).injective
-  ext x
-  simpa using h x
+  apply DFunLike.coe_injective
+  exact (ProfiniteGrp.ProfiniteCompletion.denseRange (G := GrpCat.of G)).equalizer
+    f.continuous_toFun g.continuous_toFun (funext h)
 
 /-- The canonical map from a finite group to its profinite completion is bijective. -/
 theorem etaFn_bijective_of_finite [Finite G] :

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -41,7 +41,12 @@ noncomputable def continuousMonoidHomEquiv :
       (ConcreteCategory.homEquiv (C := GrpCat))
 
 /-- The unbundled profinite-completion correspondence restricts a continuous homomorphism along
-the canonical map. -/
+the canonical map.
+
+Mathlib provides no propositional computation rule for the forward direction of
+`ProfiniteGrp.ProfiniteCompletion.homEquiv`: its forward map is definitionally precomposition by
+the unit. The proof below intentionally isolates that definitional reduction behind this opaque
+simp theorem. -/
 @[simp]
 theorem continuousMonoidHomEquiv_apply
     (f : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* P) (g : G) :

--- a/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Completion.lean
@@ -41,17 +41,14 @@ noncomputable def continuousMonoidHomEquiv :
       (ConcreteCategory.homEquiv (C := GrpCat))
 
 /-- The unbundled profinite-completion correspondence restricts a continuous homomorphism along
-the canonical map.
-
-Mathlib provides no propositional computation rule for the forward direction of
-`ProfiniteGrp.ProfiniteCompletion.homEquiv`: its forward map is definitionally precomposition by
-the unit. The proof below intentionally isolates the definitional reduction through the two
-concrete-category equivalences behind this opaque simp theorem. -/
+the canonical map. -/
 @[simp]
 theorem continuousMonoidHomEquiv_apply
     (f : ProfiniteGrp.ProfiniteCompletion.completion (GrpCat.of G) →ₜ* P) (g : G) :
     continuousMonoidHomEquiv G P f g =
       f (ProfiniteGrp.ProfiniteCompletion.etaFn (GrpCat.of G) g) :=
+  -- Mathlib has no propositional forward computation rule for `homEquiv`; isolate its
+  -- definitional reduction through both concrete-category equivalences in this opaque theorem.
   (rfl)
 
 /-- The continuous lift of an abstract homomorphism agrees with it on the original group. -/

--- a/TauCeti/Topology/Algebra/Group/Profinite/Section.lean
+++ b/TauCeti/Topology/Algebra/Group/Profinite/Section.lean
@@ -18,7 +18,7 @@ import Mathlib.Topology.Homeomorph.Lemmas
 # Continuous sections of profinite quotients
 
 Let `G` be a profinite group — compact, totally disconnected, and topological, in the unbundled
-classes — and let `H` be a *closed* subgroup. This file proves that the quotient map
+classes — and let `H` be a *closed* subgroup. This module proves that the quotient map
 `G → G ⧸ H` admits a continuous section normalized at the identity coset, and deduces the same
 for the projection `G ⧸ K → G ⧸ H` attached to a pair of subgroups `K ≤ H`.
 


### PR DESCRIPTION
This PR exposes Mathlib's categorical profinite-completion adjunction as an unbundled equivalence between continuous homomorphisms from the completion and abstract homomorphisms from the original group. Add the two computation rules needed to use that equivalence without unfolding it, an extensionality theorem on the canonical dense image, and the finite-group check that the completion unit is bijective.

The exact roadmap target is `TauCetiRoadmap/ProfiniteProPGroups/README.md`, Layer 0, “Profinite completion”: add the unbundled universal property supplied by `ProfiniteGrp.ProfiniteCompletion.lift` and prove that the unit is bijective on a finite group. This is the most effective current step because open PR #5036 supplies Layer 0's preceding quotient, subgroup, compactness, and inverse-limit milestones, while this final milestone is independent of that branch and otherwise untouched.

After this PR, the profinite-completion milestone is complete; Layer 0 still needs #5036 to merge before the roadmap proceeds to supernatural order and index.

Add `TauCeti/Topology/Algebra/Group/Profinite/Completion.lean` (77 lines). The construction directly transports `ProfiniteGrp.ProfiniteCompletion.homEquiv` through the concrete-category equivalences; finite-group bijectivity reuses Mathlib's `etaFn_injective_iff_residuallyFinite`, `denseRange`, and closedness of finite sets. No Mathlib infrastructure or external formalization is vendored.

Roadmap: ProfiniteProPGroups

<!--tauceti-target:v1 {"focus":"ProfiniteProPGroups","id":"profinite-completion-universal-property"}-->

🤖 Prepared with Codex
