### PR TITLE
refactor(CongruenceSubgroups): promote Gamma0Map_apply out of Fricke

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Basic.lean
@@ -239,6 +239,14 @@ private def diagUnit (u : (ZMod N)ˣ) : SpecialLinearGroup (Fin 2) (ZMod N) :=
 private lemma coe_diagUnit (u : (ZMod N)ˣ) :
     (diagUnit u : Matrix (Fin 2) (Fin 2) (ZMod N)) = !![(↑u⁻¹ : ZMod N), 0; 0, ↑u] := rfl
 
+/-- **The value of Mathlib's `Gamma0Map`**: the lower-right entry of the matrix, reduced mod `N`.
+
+`Gamma0Map` is a bare `MonoidHom.mk`, so this holds definitionally; naming it keeps that one
+definitional step out of the `simp` sets that consume it, and gives downstream files a lemma to
+rewrite with instead of unfolding the definition. -/
+theorem Gamma0Map_apply (g : ↥(Gamma0 N)) :
+    Gamma0Map N g = (((g : Matrix (Fin 2) (Fin 2) ℤ) 1 1 : ℤ) : ZMod N) := (rfl)
+
 /-- `(Gamma0Map N).toHomUnits` is surjective: every unit `u ∈ (ZMod N)ˣ` is realized as the
 lower-right entry of some `g ∈ Gamma0 N`, by strong approximation for `SL₂`. -/
 theorem Gamma0Map_toHomUnits_surjective :
@@ -280,7 +288,7 @@ lemma gamma0Twist_mem_Gamma0 {p : ℕ} (h : Nat.Coprime p N) : gamma0Twist N p h
 lemma Gamma0Map_toHomUnits_gamma0Twist {p : ℕ} (h : Nat.Coprime p N) :
     (Gamma0Map N).toHomUnits ⟨gamma0Twist N p h, gamma0Twist_mem_Gamma0 h⟩ =
       ZMod.unitOfCoprime p h :=
-  Units.ext (by simp [Gamma0Map, gamma0Twist_apply_one_one h])
+  Units.ext (by simp [Gamma0Map_apply, gamma0Twist_apply_one_one h])
 
 /-- `-I` lies in `Γ₀(N)`: its lower-left entry is `0`. -/
 theorem neg_one_mem_Gamma0 : (-1 : SL(2, ℤ)) ∈ Gamma0 N := by
@@ -296,7 +304,7 @@ lemma Gamma0.coe_negOne (N : ℕ) : (Gamma0.negOne N : SL(2, ℤ)) = -1 := (rfl)
 /-- The lower-right entry of `-I ∈ Γ₀(N)` is `-1`. -/
 @[simp]
 theorem Gamma0Map_negOne : Gamma0Map N (Gamma0.negOne N) = -1 := by
-  simp [Gamma0Map, Gamma0.coe_negOne]
+  simp [Gamma0Map_apply, Gamma0.coe_negOne]
 
 /-- The unit-valued lower-right entry of `-I ∈ Γ₀(N)` is the unit `-1`. -/
 @[simp]

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Units.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups/Units.lean
@@ -50,6 +50,6 @@ lemma Gamma0Map_toHomUnits_of_dvd {M N : ℕ} (h : M ∣ N) (γ : ↥(Gamma0 N))
     (Gamma0Map M).toHomUnits ⟨(γ : SL(2, ℤ)), hγ⟩ =
       ZMod.unitsMap h ((Gamma0Map N).toHomUnits γ) := by
   ext
-  simp [Gamma0Map, ZMod.unitsMap_def]
+  simp [Gamma0Map_apply, ZMod.unitsMap_def]
 
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -684,7 +684,7 @@ lemma exists_conjScale_mem_Gamma0 (d M : ℕ) (γ : ↥(Gamma0 (d * M))) :
   have hc : (γ : SL(2, ℤ)) 1 0 = d * ((M : ℤ) * t) := by rw [ht]; push_cast; ring
   refine ⟨_, hc, Gamma0_mem.mpr (by simp), ?_⟩
   ext
-  simp [Gamma0Map, ZMod.unitsMap_def]
+  simp [Gamma0Map_apply, ZMod.unitsMap_def]
 
 /-- The `diag(d, 1)`-conjugate of a matrix of `Γ₀(N)` lies in `Γ₀(M)` whenever `d * M ∣ N`, and
 the conjugation leaves the lower-right entry alone: the diamond label of `γ` is read along the

--- a/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/Conjugation.lean
@@ -311,12 +311,6 @@ public theorem coe_frickeConjGamma1 (σ : ↥(Gamma1 N)) :
 
 section NeZero
 
-/-- The value of mathlib's `Gamma0Map` on a `Γ₀(N)` element: it is the lower-right entry, reduced.
-`Gamma0Map` is a bare `MonoidHom.mk`, so this is definitional; naming it keeps the one
-definitional step out of the `simp` sets below. -/
-private theorem gamma0Map_apply (g : ↥(Gamma0 N)) :
-    Gamma0Map N g = (((g : Matrix (Fin 2) (Fin 2) ℤ) 1 1 : ℤ) : ZMod N) := rfl
-
 /-- **The Fricke conjugation inverts the diamond label.** `Gamma0Map` reads the lower-right entry
 mod `N`; conjugation swaps the two diagonal entries, so it reads `a` where it read `d`, and
 `a · d ≡ 1 (mod N)` because `det σ = 1` and `N ∣ c`.
@@ -327,7 +321,7 @@ computing a nebentypus along the Fricke involution has to redo the determinant a
 public theorem gamma0Map_frickeConjGamma0_mul (σ : ↥(Gamma0 N)) :
     Gamma0Map N (frickeConjGamma0 σ) * Gamma0Map N σ = 1 := by
   have hcast := intCast_apply_zero_zero_mul_apply_one_one_of_mem_Gamma0 (M := N) σ.property
-  simp only [gamma0Map_apply, coe_frickeConjGamma0, coe_frickeConjSL]
+  simp only [Gamma0Map_apply, coe_frickeConjGamma0, coe_frickeConjSL]
   simpa using hcast
 
 /-- **The unit-valued form of `gamma0Map_frickeConjGamma0_mul`**: on units, the `Gamma0Map` image


### PR DESCRIPTION
`gamma0Map_apply` was declared `private` in `Fricke/Conjugation.lean`, although what it says — the
value of Mathlib's `Gamma0Map` is the lower-right entry, reduced mod `N` — is general rather than
Fricke-specific. Because it was private, **four** other sites unfolded `Gamma0Map` by hand instead.
This promotes it and removes all four unfolds. No mathematics changes.

## The duplication it removes

Mathlib has no lemma for `Gamma0Map`'s value: the complete enumeration of `Gamma0Map` in
`Mathlib/NumberTheory/ModularForms/CongruenceSubgroups.lean` is the definition at :95, `Gamma1'`
at :106, `Gamma1_mem'` at :109, and three inline `simp`-unfolds at :120, :122, :126. Mathlib
unfolds its own definition rather than naming it. So this is the missing name, not a wrapper over
an existing one.

In this repository the same unfold appeared at four sites, all now rewritten:

| site | was |
|---|---|
| `CongruenceSubgroups/Basic.lean:283` | `simp [Gamma0Map, gamma0Twist_apply_one_one h]` |
| `CongruenceSubgroups/Basic.lean:299` | `simp [Gamma0Map, Gamma0.coe_negOne]` |
| `CongruenceSubgroups/Units.lean:53` | `simp [Gamma0Map, ZMod.unitsMap_def]` |
| `Degeneracy.lean:687` | `simp [Gamma0Map, ZMod.unitsMap_def]` |

Two of those are in the destination file itself, which was unfolding a definition it already had
four named lemmas about.

## What moves

`Gamma0Map_apply` goes into `CongruenceSubgroups/Basic.lean` immediately before
`Gamma0Map_toHomUnits_surjective`, so it precedes every consumer in the file, joining its four
siblings there (`Gamma0Map_negOne`, `Gamma0Map_toHomUnits_surjective`,
`Gamma0Map_toHomUnits_gamma0Twist`, `Gamma0Map_toHomUnits_negOne`).

Two deliberate choices:

* **Renamed** from `gamma0Map_apply` to `Gamma0Map_apply`. The four siblings it lands beside are
  capitalised; promoting it unchanged would have left it inconsistent with its immediate
  neighbours.
* **Proved `(rfl)` rather than bare `rfl`.** The destination is a `public section` (:86) without
  `@[expose]`, where a bare `rfl` exports the definitional equality and is refused.

The original docstring's reasoning is kept and generalised: `Gamma0Map` is a bare `MonoidHom.mk`,
so the value is definitional, and naming it keeps that one step out of the `simp` sets that
consume it.

## Gates

`lake build` of all four affected modules — `CongruenceSubgroups.Basic`, `CongruenceSubgroups.Units`,
`Degeneracy`, `Fricke.Conjugation`, plus dependent `DiamondOperators` — 3101 jobs, exit 0.
`#lint in TauCeti`: 14 linters, **0 errors in 372 declarations** (plus 132 auto-generated). The
declaration count is quoted rather than just the pass line, because `in TauCeti` is a module-path
prefix and a wrong one lints zero declarations while still printing "All linting checks passed!".

## Sequencing

`tc-o0ud4` proposed doing this after #4981 merges, so that PR's local `hentry` workaround could be
cleaned up in the same change. Measured: #4981's hunks in `Degeneracy.lean` are at lines 45-51 and
769-829, while the site touched here is line 687. **They do not overlap**, so this does not conflict
with #4981 and does not need to wait for it. The `hentry` cleanup remains a one-line follow-up once
#4981 lands, since that code exists only inside its diff.

Roadmap: none
