### PR TITLE
docs(MvPolynomial): state the result in monomial_mem_span_monomial_lt's docstring

### DIFF
--- a/TauCeti/RingTheory/MvPolynomial/Expand.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Expand.lean
@@ -59,11 +59,9 @@ public section
 
 namespace TauCeti
 
-/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
-Proof: "`R′[x^{1/q}]` is finite over `R[x]`" —
-the inductive step of the spanning argument. Every monomial lies in the span, over the image of
-`MvPolynomial.expand n`, of the monomials with all exponents below `n`: write each exponent as
-`n * γ + β` with `β < n`, so that `X ^ (n • γ + β) = expand n (X ^ γ) * X ^ β`. -/
+/-- Every monomial lies in the span, over the image of `MvPolynomial.expand n`, of the monomials
+with all exponents below `n`: write each exponent as `n * γ + β` with `β < n`, so that
+`X ^ (n • γ + β) = expand n (X ^ γ) * X ^ β`. -/
 private theorem MvPolynomial.monomial_mem_span_monomial_lt {σ R : Type*} [CommSemiring R]
     [Finite σ]
     {n : ℕ} (hn : 0 < n) (d : σ →₀ ℕ) (r : R) :


### PR DESCRIPTION
Finishes the documentation finding from #4886, which merged before this last piece landed.

## What this changes

One docstring. `private theorem MvPolynomial.monomial_mem_span_monomial_lt` in `TauCeti/RingTheory/MvPolynomial/Expand.lean` still opened with a Stacks attribution and a quoted `Proof: "…"` passage before reaching its statement:

```
/-- Multivariate form of the univariate argument in Stacks, Lemma 10.161.13 (tag 032O).
Proof: "`R′[x^{1/q}]` is finite over `R[x]`" —
the inductive step of the spanning argument. Every monomial lies in the span, …
```

It now states the result first, matching the four docstrings beside it. No code changes, no statement changes.

## Why it is separate

The documentation finding on #4886 named the `finite_map` docstring in `RingTheory/MvPolynomial/Basic.lean` and "the same proof-focused pattern … for the three public theorems in `Expand.lean`". All four were fixed on that PR. This file's *private* helper was not named by the finding and was left behind; #4886 then merged, so the remainder needs its own PR.

After this, `Expand.lean` has no proof-quoting docstring openers at all.

## Verification

`lake build TauCeti.RingTheory.MvPolynomial.Expand` — exit 0, 1669 jobs, no errors, warnings, or `info:` diagnostics. Branched off current `origin/main` (`61c1929a2`). No line over 100 characters.

Roadmap: EllipticCurves
