### PR TITLE
feat: classify overlapping rectangle cyclic orders

### DIFF
--- a/TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean
@@ -87,7 +87,7 @@ theorem ext {D E : GridRectangleDecomposition x z}
 /-- The diagonal reflection of a two-step rectangle decomposition. It reflects both constituent
 rectangles and the intermediate state, and hence gives a decomposition between the transposed
 endpoint states. -/
-@[expose] def transpose (D : GridRectangleDecomposition x z) :
+def transpose (D : GridRectangleDecomposition x z) :
     GridRectangleDecomposition x.transpose z.transpose where
   middle := D.middle.transpose
   first := D.first.transpose
@@ -96,20 +96,88 @@ endpoint states. -/
 /-- The intermediate state of a transposed decomposition is the transposed intermediate state. -/
 @[simp]
 theorem transpose_middle (D : GridRectangleDecomposition x z) :
-    D.transpose.middle = D.middle.transpose :=
-  rfl
+    D.transpose.middle = D.middle.transpose := by
+  rw [transpose]
 
-/-- The first rectangle of a transposed decomposition is the transposed first rectangle. -/
+/-- The first rectangle of a transposed decomposition has the original initial corner row as its
+initial side column. -/
 @[simp]
-theorem transpose_first (D : GridRectangleDecomposition x z) :
-    D.transpose.first = D.first.transpose :=
-  rfl
+theorem transpose_first_left (D : GridRectangleDecomposition x z) :
+    D.transpose.first.left = D.first.bottom := by
+  rw [transpose]
+  exact D.first.transpose_left
 
-/-- The second rectangle of a transposed decomposition is the transposed second rectangle. -/
+/-- The first rectangle of a transposed decomposition has the original terminal corner row as its
+terminal side column. -/
 @[simp]
-theorem transpose_second (D : GridRectangleDecomposition x z) :
-    D.transpose.second = D.second.transpose :=
-  rfl
+theorem transpose_first_right (D : GridRectangleDecomposition x z) :
+    D.transpose.first.right = D.first.top := by
+  rw [transpose]
+  exact D.first.transpose_right
+
+/-- The first rectangle of a transposed decomposition has the original initial side column as its
+initial corner row. -/
+@[simp]
+theorem transpose_first_bottom (D : GridRectangleDecomposition x z) :
+    D.transpose.first.bottom = D.first.left := by
+  rw [transpose]
+  exact D.first.transpose_bottom
+
+/-- The first rectangle of a transposed decomposition has the original terminal side column as its
+terminal corner row. -/
+@[simp]
+theorem transpose_first_top (D : GridRectangleDecomposition x z) :
+    D.transpose.first.top = D.first.right := by
+  rw [transpose]
+  exact D.first.transpose_top
+
+/-- The second rectangle of a transposed decomposition has the original initial corner row as its
+initial side column. -/
+@[simp]
+theorem transpose_second_left (D : GridRectangleDecomposition x z) :
+    D.transpose.second.left = D.second.bottom := by
+  rw [transpose]
+  exact D.second.transpose_left
+
+/-- The second rectangle of a transposed decomposition has the original terminal corner row as its
+terminal side column. -/
+@[simp]
+theorem transpose_second_right (D : GridRectangleDecomposition x z) :
+    D.transpose.second.right = D.second.top := by
+  rw [transpose]
+  exact D.second.transpose_right
+
+/-- The second rectangle of a transposed decomposition has the original initial side column as its
+initial corner row. -/
+@[simp]
+theorem transpose_second_bottom (D : GridRectangleDecomposition x z) :
+    D.transpose.second.bottom = D.second.left := by
+  rw [transpose]
+  exact D.second.transpose_bottom
+
+/-- The second rectangle of a transposed decomposition has the original terminal side column as
+its terminal corner row. -/
+@[simp]
+theorem transpose_second_top (D : GridRectangleDecomposition x z) :
+    D.transpose.second.top = D.second.right := by
+  rw [transpose]
+  exact D.second.transpose_top
+
+/-- The first rectangle of a transposed decomposition is empty exactly when the original first
+rectangle is. -/
+@[simp]
+theorem isEmpty_transpose_first (D : GridRectangleDecomposition x z) :
+    D.transpose.first.IsEmpty ↔ D.first.IsEmpty := by
+  rw [transpose]
+  exact D.first.isEmpty_transpose
+
+/-- The second rectangle of a transposed decomposition is empty exactly when the original second
+rectangle is. -/
+@[simp]
+theorem isEmpty_transpose_second (D : GridRectangleDecomposition x z) :
+    D.transpose.second.IsEmpty ↔ D.second.IsEmpty := by
+  rw [transpose]
+  exact D.second.isEmpty_transpose
 
 /-- Reflecting a two-step rectangle decomposition twice recovers the original decomposition. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean
@@ -35,8 +35,6 @@ between two given states is determined by its side columns.
 
 ## References
 
-This supplies the shared two-step bookkeeping for
-`TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and `∂² = 0`".
 The decomposition pairing follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
 Chapter 4.6.
 -/
@@ -99,85 +97,105 @@ theorem transpose_middle (D : GridRectangleDecomposition x z) :
     D.transpose.middle = D.middle.transpose := by
   rw [transpose]
 
+/-- The intermediate state and first rectangle of a transposed decomposition are the transposes
+of the original intermediate state and first rectangle. They are paired because the rectangle's
+target is indexed by the intermediate state. -/
+@[simp]
+theorem transpose_first (D : GridRectangleDecomposition x z) :
+    (⟨D.transpose.middle, D.transpose.first⟩ :
+      Σ middle, GridRectangleBetween x.transpose middle) =
+      ⟨D.middle.transpose, D.first.transpose⟩ := by
+  rw [transpose]
+
+/-- The intermediate state and second rectangle of a transposed decomposition are the transposes
+of the original intermediate state and second rectangle. They are paired because the rectangle's
+source is indexed by the intermediate state. -/
+@[simp]
+theorem transpose_second (D : GridRectangleDecomposition x z) :
+    (⟨D.transpose.middle, D.transpose.second⟩ :
+      Σ middle, GridRectangleBetween middle z.transpose) =
+      ⟨D.middle.transpose, D.second.transpose⟩ := by
+  rw [transpose]
+
 /-- The first rectangle of a transposed decomposition has the original initial corner row as its
 initial side column. -/
 @[simp]
 theorem transpose_first_left (D : GridRectangleDecomposition x z) :
     D.transpose.first.left = D.first.bottom := by
-  rw [transpose]
-  exact D.first.transpose_left
+  simpa only [GridRectangleBetween.transpose_left] using
+    congrArg (fun p => p.2.left) D.transpose_first
 
 /-- The first rectangle of a transposed decomposition has the original terminal corner row as its
 terminal side column. -/
 @[simp]
 theorem transpose_first_right (D : GridRectangleDecomposition x z) :
     D.transpose.first.right = D.first.top := by
-  rw [transpose]
-  exact D.first.transpose_right
+  simpa only [GridRectangleBetween.transpose_right] using
+    congrArg (fun p => p.2.right) D.transpose_first
 
 /-- The first rectangle of a transposed decomposition has the original initial side column as its
 initial corner row. -/
 @[simp]
 theorem transpose_first_bottom (D : GridRectangleDecomposition x z) :
     D.transpose.first.bottom = D.first.left := by
-  rw [transpose]
-  exact D.first.transpose_bottom
+  simpa only [GridRectangleBetween.transpose_bottom] using
+    congrArg (fun p => p.2.bottom) D.transpose_first
 
 /-- The first rectangle of a transposed decomposition has the original terminal side column as its
 terminal corner row. -/
 @[simp]
 theorem transpose_first_top (D : GridRectangleDecomposition x z) :
     D.transpose.first.top = D.first.right := by
-  rw [transpose]
-  exact D.first.transpose_top
+  simpa only [GridRectangleBetween.transpose_top] using
+    congrArg (fun p => p.2.top) D.transpose_first
 
 /-- The second rectangle of a transposed decomposition has the original initial corner row as its
 initial side column. -/
 @[simp]
 theorem transpose_second_left (D : GridRectangleDecomposition x z) :
     D.transpose.second.left = D.second.bottom := by
-  rw [transpose]
-  exact D.second.transpose_left
+  simpa only [GridRectangleBetween.transpose_left] using
+    congrArg (fun p => p.2.left) D.transpose_second
 
 /-- The second rectangle of a transposed decomposition has the original terminal corner row as its
 terminal side column. -/
 @[simp]
 theorem transpose_second_right (D : GridRectangleDecomposition x z) :
     D.transpose.second.right = D.second.top := by
-  rw [transpose]
-  exact D.second.transpose_right
+  simpa only [GridRectangleBetween.transpose_right] using
+    congrArg (fun p => p.2.right) D.transpose_second
 
 /-- The second rectangle of a transposed decomposition has the original initial side column as its
 initial corner row. -/
 @[simp]
 theorem transpose_second_bottom (D : GridRectangleDecomposition x z) :
     D.transpose.second.bottom = D.second.left := by
-  rw [transpose]
-  exact D.second.transpose_bottom
+  simpa only [GridRectangleBetween.transpose_bottom] using
+    congrArg (fun p => p.2.bottom) D.transpose_second
 
 /-- The second rectangle of a transposed decomposition has the original terminal side column as
 its terminal corner row. -/
 @[simp]
 theorem transpose_second_top (D : GridRectangleDecomposition x z) :
     D.transpose.second.top = D.second.right := by
-  rw [transpose]
-  exact D.second.transpose_top
+  simpa only [GridRectangleBetween.transpose_top] using
+    congrArg (fun p => p.2.top) D.transpose_second
 
 /-- The first rectangle of a transposed decomposition is empty exactly when the original first
 rectangle is. -/
 @[simp]
 theorem isEmpty_transpose_first (D : GridRectangleDecomposition x z) :
     D.transpose.first.IsEmpty ↔ D.first.IsEmpty := by
-  rw [transpose]
-  exact D.first.isEmpty_transpose
+  exact (congrArg (fun p => p.2.IsEmpty) D.transpose_first).to_iff.trans
+    D.first.isEmpty_transpose
 
 /-- The second rectangle of a transposed decomposition is empty exactly when the original second
 rectangle is. -/
 @[simp]
 theorem isEmpty_transpose_second (D : GridRectangleDecomposition x z) :
     D.transpose.second.IsEmpty ↔ D.second.IsEmpty := by
-  rw [transpose]
-  exact D.second.isEmpty_transpose
+  exact (congrArg (fun p => p.2.IsEmpty) D.transpose_second).to_iff.trans
+    D.second.isEmpty_transpose
 
 /-- Reflecting a two-step rectangle decomposition twice recovers the original decomposition. -/
 @[simp]

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean
@@ -28,6 +28,8 @@ between two given states is determined by its side columns.
 
 * `TauCeti.GridRectangleDecomposition.ext`: a decomposition is determined by the ordered side
   columns of its two rectangles.
+* `TauCeti.GridRectangleDecomposition.transpose`: diagonal reflection of both constituent
+  rectangles gives a decomposition between the transposed endpoint states.
 * `TauCeti.GridRectangleDecomposition.target_mem_twoStepColumnSwapNeighbors`: the target of a
   decomposition is reached from its source by two nontrivial column transpositions.
 
@@ -81,6 +83,38 @@ theorem ext {D E : GridRectangleDecomposition x z}
             GridRectangleBetween.eq_of_sides hsecondLeft hsecondRight
           subst Esecond
           rfl
+
+/-- The diagonal reflection of a two-step rectangle decomposition. It reflects both constituent
+rectangles and the intermediate state, and hence gives a decomposition between the transposed
+endpoint states. -/
+@[expose] def transpose (D : GridRectangleDecomposition x z) :
+    GridRectangleDecomposition x.transpose z.transpose where
+  middle := D.middle.transpose
+  first := D.first.transpose
+  second := D.second.transpose
+
+/-- The intermediate state of a transposed decomposition is the transposed intermediate state. -/
+@[simp]
+theorem transpose_middle (D : GridRectangleDecomposition x z) :
+    D.transpose.middle = D.middle.transpose :=
+  rfl
+
+/-- The first rectangle of a transposed decomposition is the transposed first rectangle. -/
+@[simp]
+theorem transpose_first (D : GridRectangleDecomposition x z) :
+    D.transpose.first = D.first.transpose :=
+  rfl
+
+/-- The second rectangle of a transposed decomposition is the transposed second rectangle. -/
+@[simp]
+theorem transpose_second (D : GridRectangleDecomposition x z) :
+    D.transpose.second = D.second.transpose :=
+  rfl
+
+/-- Reflecting a two-step rectangle decomposition twice recovers the original decomposition. -/
+@[simp]
+theorem transpose_transpose (D : GridRectangleDecomposition x z) : D.transpose.transpose = D := by
+  ext <;> simp
 
 /-- The target of a two-step rectangle decomposition is a two-step column-swap neighbour of its
 source: each of the two rectangles transposes its pair of distinct side columns. -/

--- a/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
@@ -15,11 +15,13 @@ disjoint side columns or share exactly one side column. In the latter case, cons
 alternate two-rectangle decomposition requires knowing the cyclic order of the three side columns
 and of the three rows at their corners.
 
-This file proves the order constraint in the orientation where the common column is the initial
-side of both rectangles. The two remaining side columns lie on opposite choices of the cyclic arc
-from the common column. In either choice, emptiness forces the common corner row to lie strictly
-between the other two rows. Thus the two rectangles form one of the two L-shaped configurations
-that can be recut along the other internal edge.
+This file proves the order constraint in all four orientations of the common column. When the
+common column is the initial side of both rectangles, the two remaining side columns lie on
+opposite choices of the cyclic arc from the common column, while emptiness forces the common
+corner row to lie strictly between the other two rows. The terminal--terminal orientation is the
+reversed counterpart. The mixed orientations follow by diagonally reflecting a decomposition,
+which exchanges column and row order. Thus every one-common-side pair forms one of the L-shaped
+configurations that can be recut along the other internal edge.
 
 The proof uses emptiness for both the source and target state of a rectangle. If the third column
 lies in the first rectangle's column interior, its state point must miss that rectangle's row
@@ -34,6 +36,10 @@ order.
 * `TauCeti.GridRectangleDecomposition.cyclicOrder_of_isEmpty_of_left_eq_left`: when the common
   side is the initial side of both empty rectangles, their other side columns determine one of
   two cyclic orders and the shared corner row lies between the other two rows.
+* `TauCeti.GridRectangleDecomposition.cyclicOrder_of_isEmpty_of_right_eq_right`: the corresponding
+  order constraint when the common side is terminal for both rectangles.
+* `TauCeti.GridRectangleDecomposition.cyclicOrder_of_isEmpty_of_left_eq_right` and
+  `cyclicOrder_of_isEmpty_of_right_eq_left`: the two mixed-orientation constraints.
 
 ## References
 
@@ -140,6 +146,133 @@ theorem cyclicOrder_of_isEmpty_of_left_eq_left (D : GridRectangleDecomposition x
     have hrow := mem_cIoo_swap_of_not_mem D.first.bottom_ne_top
       htop_ne_firstBottom htop_ne_firstTop hnot
     exact ⟨Or.inr hsecondRight, mem_cIoo_cyclic_right hrow⟩
+
+/-- Suppose the two empty rectangles share their terminal side column and no other side. Then
+their two initial sides occur in one of the two possible cyclic orders around the common side,
+while the row of the common corner lies strictly between the other two corner rows. -/
+theorem cyclicOrder_of_isEmpty_of_right_eq_right (D : GridRectangleDecomposition x z)
+    (hright : D.first.right = D.second.right) (hleft : D.first.left ≠ D.second.left)
+    (hfirst : D.first.IsEmpty) (hsecond : D.second.IsEmpty) :
+    (D.first.left ∈ Grid.cIoo D.second.left D.first.right ∨
+        D.second.left ∈ Grid.cIoo D.first.left D.first.right) ∧
+      D.first.bottom ∈ Grid.cIoo D.second.bottom D.first.top := by
+  have hsecondLeft_ne_firstRight : D.second.left ≠ D.first.right :=
+    fun h => D.second.left_ne_right (h.trans hright)
+  have htop : D.second.top = D.first.bottom := by
+    rw [GridRectangleBetween.top_def, GridRectangleBetween.bottom_def, ← hright]
+    exact D.first.map_right
+  have hbottom_ne_firstTop : D.second.bottom ≠ D.first.top := by
+    intro h
+    apply hleft
+    apply D.middle.toPerm.injective
+    rw [← GridRectangleBetween.bottom_def, h, GridRectangleBetween.top_def]
+    exact D.first.map_left
+  have hbottom_ne_firstBottom : D.second.bottom ≠ D.first.bottom := by
+    rw [← htop]
+    exact D.second.bottom_ne_top
+  have hcolumns :
+      D.first.left ∈ Grid.cIoo D.second.left D.first.right ∨
+        D.first.left ∈ Grid.cIoo D.first.right D.second.left :=
+    (Grid.mem_cIoo_or_mem_cIoo_swap_iff hsecondLeft_ne_firstRight).mpr
+      ⟨hleft, D.first.left_ne_right⟩
+  rcases hcolumns with hfirstLeft | hfirstLeft
+  · have hnot : D.first.top ∉ Grid.cIoo D.second.bottom D.first.bottom := by
+      intro hrow
+      exact D.second.not_mem_interior_of_isEmpty hsecond
+        D.first.left_top_mem_target
+        (by
+          rw [GridRectangle.mem_interior]
+          constructor
+          · simpa only [GridRectangle.mem_columnInterior,
+              GridRectangleBetween.toGridRectangle_left,
+              GridRectangleBetween.toGridRectangle_right, ← hright] using hfirstLeft
+          · simpa only [GridRectangle.mem_rowInterior,
+              GridRectangleBetween.toGridRectangle_bottom,
+              GridRectangleBetween.toGridRectangle_top, htop] using hrow)
+    have hrow := mem_cIoo_swap_of_not_mem D.second.bottom_ne_top
+      hbottom_ne_firstTop.symm (by simpa only [htop] using D.first.bottom_ne_top.symm)
+      (by simpa only [htop] using hnot)
+    exact ⟨Or.inl hfirstLeft,
+      mem_cIoo_cyclic_right (by simpa only [htop] using hrow)⟩
+  · have hsecondLeft : D.second.left ∈ Grid.cIoo D.first.left D.first.right :=
+      mem_cIoo_cyclic_left hfirstLeft
+    have hnot : D.second.bottom ∉ Grid.cIoo D.first.bottom D.first.top := by
+      intro hrow
+      exact D.first.not_mem_interior_target_of_isEmpty hfirst
+        D.second.left_bottom_mem_source
+        (by
+          rw [GridRectangle.mem_interior]
+          constructor
+          · simpa only [GridRectangle.mem_columnInterior,
+              GridRectangleBetween.toGridRectangle_left,
+              GridRectangleBetween.toGridRectangle_right] using hsecondLeft
+          · simpa only [GridRectangle.mem_rowInterior,
+              GridRectangleBetween.toGridRectangle_bottom,
+              GridRectangleBetween.toGridRectangle_top] using hrow)
+    have hrow := mem_cIoo_swap_of_not_mem D.first.bottom_ne_top
+      hbottom_ne_firstBottom hbottom_ne_firstTop hnot
+    exact ⟨Or.inr hsecondLeft, mem_cIoo_cyclic_left hrow⟩
+
+/-- Suppose the first empty rectangle's initial side is the second one's terminal side, with no
+other common side. The other side columns have a fixed cyclic order, while the three corner rows
+occur in one of the two orders obtained by reflecting the terminal--terminal case. -/
+theorem cyclicOrder_of_isEmpty_of_left_eq_right (D : GridRectangleDecomposition x z)
+    (hcommon : D.first.left = D.second.right) (hother : D.first.right ≠ D.second.left)
+    (hfirst : D.first.IsEmpty) (hsecond : D.second.IsEmpty) :
+    D.first.right ∈ Grid.cIoo D.first.left D.second.left ∧
+      (D.first.bottom ∈ Grid.cIoo D.second.bottom D.first.top ∨
+        D.second.bottom ∈ Grid.cIoo D.first.bottom D.first.top) := by
+  have htransRight : D.transpose.first.right = D.transpose.second.right := by
+    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_right,
+      GridRectangleBetween.top_def, hcommon] using D.first.map_left.symm
+  have htransLeft : D.transpose.first.left ≠ D.transpose.second.left := by
+    have hsecondLeft_ne_firstLeft : D.second.left ≠ D.first.left := fun h =>
+      D.second.left_ne_right (h.trans hcommon)
+    have hmiddle : D.middle D.second.left = x D.second.left :=
+      D.first.map_of_ne D.second.left hsecondLeft_ne_firstLeft hother.symm
+    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_left,
+      GridRectangleBetween.bottom_def, hmiddle] using
+      x.toPerm.injective.ne hsecondLeft_ne_firstLeft.symm
+  have h := D.transpose.cyclicOrder_of_isEmpty_of_right_eq_right htransRight htransLeft
+    (D.first.isEmpty_transpose.mpr hfirst) (D.second.isEmpty_transpose.mpr hsecond)
+  rcases h with ⟨hrows, hcolumns⟩
+  exact ⟨mem_cIoo_cyclic_left (by
+      simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_bottom,
+        GridRectangleBetween.transpose_top] using hcolumns), by
+    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_left,
+      GridRectangleBetween.transpose_right] using hrows⟩
+
+/-- Suppose the first empty rectangle's terminal side is the second one's initial side, with no
+other common side. The other side columns have a fixed cyclic order, while the three corner rows
+occur in one of the two orders obtained by reflecting the initial--initial case. -/
+theorem cyclicOrder_of_isEmpty_of_right_eq_left (D : GridRectangleDecomposition x z)
+    (hcommon : D.first.right = D.second.left) (hother : D.first.left ≠ D.second.right)
+    (hfirst : D.first.IsEmpty) (hsecond : D.second.IsEmpty) :
+    D.first.right ∈ Grid.cIoo D.first.left D.second.right ∧
+      (D.first.top ∈ Grid.cIoo D.first.bottom D.second.top ∨
+        D.second.top ∈ Grid.cIoo D.first.bottom D.first.top) := by
+  have htransLeft : D.transpose.first.left = D.transpose.second.left := by
+    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_left,
+      GridRectangleBetween.bottom_def, hcommon] using D.first.map_right.symm
+  have htransRight : D.transpose.first.right ≠ D.transpose.second.right := by
+    intro h
+    apply hother
+    apply D.middle.toPerm.injective
+    calc
+      D.middle D.first.left = x D.first.right := D.first.map_left
+      _ = D.first.top := D.first.top_def.symm
+      _ = D.second.top := by
+        simpa only [GridRectangleDecomposition.transpose,
+          GridRectangleBetween.transpose_right] using h
+      _ = D.middle D.second.right := D.second.top_def
+  have h := D.transpose.cyclicOrder_of_isEmpty_of_left_eq_left htransLeft htransRight
+    (D.first.isEmpty_transpose.mpr hfirst) (D.second.isEmpty_transpose.mpr hsecond)
+  rcases h with ⟨hrows, hcolumns⟩
+  exact ⟨by
+    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_bottom,
+      GridRectangleBetween.transpose_top] using hcolumns, by
+    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_left,
+      GridRectangleBetween.transpose_right] using hrows⟩
 
 end GridRectangleDecomposition
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
@@ -43,9 +43,8 @@ order.
 
 ## References
 
-This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.3, "The complexes and
-`∂² = 0`", specifically the overlapping case in the juxtaposition proof. The cyclic-order
-argument follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.6.
+The cyclic-order argument follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*,
+Chapter 4.6.
 -/
 
 public section

--- a/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
@@ -223,32 +223,22 @@ theorem cyclicOrder_of_isEmpty_of_left_eq_right (D : GridRectangleDecomposition 
       (D.first.bottom ∈ Grid.cIoo D.second.bottom D.first.top ∨
         D.second.bottom ∈ Grid.cIoo D.first.bottom D.first.top) := by
   have htransRight : D.transpose.first.right = D.transpose.second.right := by
-    simpa only [GridRectangleDecomposition.transpose_first,
-      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_right,
-      GridRectangleBetween.top_def, hcommon] using D.first.map_left.symm
+    simpa only [transpose_first_right, transpose_second_right, GridRectangleBetween.top_def,
+      hcommon] using D.first.map_left.symm
   have htransLeft : D.transpose.first.left ≠ D.transpose.second.left := by
     have hsecondLeft_ne_firstLeft : D.second.left ≠ D.first.left := fun h =>
       D.second.left_ne_right (h.trans hcommon)
     have hmiddle : D.middle D.second.left = x D.second.left :=
       D.first.map_of_ne D.second.left hsecondLeft_ne_firstLeft hother.symm
-    simpa only [GridRectangleDecomposition.transpose_first,
-      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_left,
-      GridRectangleBetween.bottom_def, hmiddle] using
-      x.toPerm.injective.ne hsecondLeft_ne_firstLeft.symm
+    simpa only [transpose_first_left, transpose_second_left, GridRectangleBetween.bottom_def,
+      hmiddle] using x.toPerm.injective.ne hsecondLeft_ne_firstLeft.symm
   have h := D.transpose.cyclicOrder_of_isEmpty_of_right_eq_right htransRight htransLeft
-    (D.first.isEmpty_transpose.mpr hfirst) (D.second.isEmpty_transpose.mpr hsecond)
+    (D.isEmpty_transpose_first.mpr hfirst) (D.isEmpty_transpose_second.mpr hsecond)
   rcases h with ⟨hrows, hcolumns⟩
-  have hfirstBottom : D.transpose.first.bottom = D.first.left :=
-    (congrArg (fun R => R.bottom) D.transpose_first).trans D.first.transpose_bottom
-  have hsecondBottom : D.transpose.second.bottom = D.second.left :=
-    (congrArg (fun R => R.bottom) D.transpose_second).trans D.second.transpose_bottom
-  have hfirstTop : D.transpose.first.top = D.first.right :=
-    (congrArg (fun R => R.top) D.transpose_first).trans D.first.transpose_top
   exact ⟨mem_cIoo_cyclic_left (by
-      simpa only [hfirstBottom, hsecondBottom, hfirstTop] using hcolumns), by
-    simpa only [GridRectangleDecomposition.transpose_first,
-      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_left,
-      GridRectangleBetween.transpose_right] using hrows⟩
+      simpa only [transpose_first_bottom, transpose_second_bottom, transpose_first_top] using
+        hcolumns), by
+    simpa only [transpose_first_left, transpose_second_left, transpose_first_right] using hrows⟩
 
 /-- Suppose the first empty rectangle's terminal side is the second one's initial side, with no
 other common side. The other side columns have a fixed cyclic order, while the three corner rows
@@ -260,9 +250,8 @@ theorem cyclicOrder_of_isEmpty_of_right_eq_left (D : GridRectangleDecomposition 
       (D.first.top ∈ Grid.cIoo D.first.bottom D.second.top ∨
         D.second.top ∈ Grid.cIoo D.first.bottom D.first.top) := by
   have htransLeft : D.transpose.first.left = D.transpose.second.left := by
-    simpa only [GridRectangleDecomposition.transpose_first,
-      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_left,
-      GridRectangleBetween.bottom_def, hcommon] using D.first.map_right.symm
+    simpa only [transpose_first_left, transpose_second_left, GridRectangleBetween.bottom_def,
+      hcommon] using D.first.map_right.symm
   have htransRight : D.transpose.first.right ≠ D.transpose.second.right := by
     intro h
     apply hother
@@ -271,24 +260,16 @@ theorem cyclicOrder_of_isEmpty_of_right_eq_left (D : GridRectangleDecomposition 
       D.middle D.first.left = x D.first.right := D.first.map_left
       _ = D.first.top := D.first.top_def.symm
       _ = D.second.top := by
-        simpa only [GridRectangleDecomposition.transpose_first,
-          GridRectangleDecomposition.transpose_second,
-          GridRectangleBetween.transpose_right] using h
+        simpa only [transpose_first_right, transpose_second_right] using h
       _ = D.middle D.second.right := D.second.top_def
   have h := D.transpose.cyclicOrder_of_isEmpty_of_left_eq_left htransLeft htransRight
-    (D.first.isEmpty_transpose.mpr hfirst) (D.second.isEmpty_transpose.mpr hsecond)
+    (D.isEmpty_transpose_first.mpr hfirst) (D.isEmpty_transpose_second.mpr hsecond)
   rcases h with ⟨hrows, hcolumns⟩
-  have hfirstBottom : D.transpose.first.bottom = D.first.left :=
-    (congrArg (fun R => R.bottom) D.transpose_first).trans D.first.transpose_bottom
-  have hfirstTop : D.transpose.first.top = D.first.right :=
-    (congrArg (fun R => R.top) D.transpose_first).trans D.first.transpose_top
-  have hsecondTop : D.transpose.second.top = D.second.right :=
-    (congrArg (fun R => R.top) D.transpose_second).trans D.second.transpose_top
   exact ⟨by
-    simpa only [hfirstBottom, hfirstTop, hsecondTop] using hcolumns, by
-    simpa only [GridRectangleDecomposition.transpose_first,
-      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_left,
-      GridRectangleBetween.transpose_right] using hrows⟩
+    simpa only [transpose_first_bottom, transpose_first_top, transpose_second_top] using
+      hcolumns, by
+    simpa only [transpose_first_left, transpose_second_left, transpose_first_right,
+      transpose_second_right] using hrows⟩
 
 end GridRectangleDecomposition
 

--- a/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean
@@ -223,23 +223,31 @@ theorem cyclicOrder_of_isEmpty_of_left_eq_right (D : GridRectangleDecomposition 
       (D.first.bottom ∈ Grid.cIoo D.second.bottom D.first.top ∨
         D.second.bottom ∈ Grid.cIoo D.first.bottom D.first.top) := by
   have htransRight : D.transpose.first.right = D.transpose.second.right := by
-    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_right,
+    simpa only [GridRectangleDecomposition.transpose_first,
+      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_right,
       GridRectangleBetween.top_def, hcommon] using D.first.map_left.symm
   have htransLeft : D.transpose.first.left ≠ D.transpose.second.left := by
     have hsecondLeft_ne_firstLeft : D.second.left ≠ D.first.left := fun h =>
       D.second.left_ne_right (h.trans hcommon)
     have hmiddle : D.middle D.second.left = x D.second.left :=
       D.first.map_of_ne D.second.left hsecondLeft_ne_firstLeft hother.symm
-    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_left,
+    simpa only [GridRectangleDecomposition.transpose_first,
+      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_left,
       GridRectangleBetween.bottom_def, hmiddle] using
       x.toPerm.injective.ne hsecondLeft_ne_firstLeft.symm
   have h := D.transpose.cyclicOrder_of_isEmpty_of_right_eq_right htransRight htransLeft
     (D.first.isEmpty_transpose.mpr hfirst) (D.second.isEmpty_transpose.mpr hsecond)
   rcases h with ⟨hrows, hcolumns⟩
+  have hfirstBottom : D.transpose.first.bottom = D.first.left :=
+    (congrArg (fun R => R.bottom) D.transpose_first).trans D.first.transpose_bottom
+  have hsecondBottom : D.transpose.second.bottom = D.second.left :=
+    (congrArg (fun R => R.bottom) D.transpose_second).trans D.second.transpose_bottom
+  have hfirstTop : D.transpose.first.top = D.first.right :=
+    (congrArg (fun R => R.top) D.transpose_first).trans D.first.transpose_top
   exact ⟨mem_cIoo_cyclic_left (by
-      simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_bottom,
-        GridRectangleBetween.transpose_top] using hcolumns), by
-    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_left,
+      simpa only [hfirstBottom, hsecondBottom, hfirstTop] using hcolumns), by
+    simpa only [GridRectangleDecomposition.transpose_first,
+      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_left,
       GridRectangleBetween.transpose_right] using hrows⟩
 
 /-- Suppose the first empty rectangle's terminal side is the second one's initial side, with no
@@ -252,7 +260,8 @@ theorem cyclicOrder_of_isEmpty_of_right_eq_left (D : GridRectangleDecomposition 
       (D.first.top ∈ Grid.cIoo D.first.bottom D.second.top ∨
         D.second.top ∈ Grid.cIoo D.first.bottom D.first.top) := by
   have htransLeft : D.transpose.first.left = D.transpose.second.left := by
-    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_left,
+    simpa only [GridRectangleDecomposition.transpose_first,
+      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_left,
       GridRectangleBetween.bottom_def, hcommon] using D.first.map_right.symm
   have htransRight : D.transpose.first.right ≠ D.transpose.second.right := by
     intro h
@@ -262,16 +271,23 @@ theorem cyclicOrder_of_isEmpty_of_right_eq_left (D : GridRectangleDecomposition 
       D.middle D.first.left = x D.first.right := D.first.map_left
       _ = D.first.top := D.first.top_def.symm
       _ = D.second.top := by
-        simpa only [GridRectangleDecomposition.transpose,
+        simpa only [GridRectangleDecomposition.transpose_first,
+          GridRectangleDecomposition.transpose_second,
           GridRectangleBetween.transpose_right] using h
       _ = D.middle D.second.right := D.second.top_def
   have h := D.transpose.cyclicOrder_of_isEmpty_of_left_eq_left htransLeft htransRight
     (D.first.isEmpty_transpose.mpr hfirst) (D.second.isEmpty_transpose.mpr hsecond)
   rcases h with ⟨hrows, hcolumns⟩
+  have hfirstBottom : D.transpose.first.bottom = D.first.left :=
+    (congrArg (fun R => R.bottom) D.transpose_first).trans D.first.transpose_bottom
+  have hfirstTop : D.transpose.first.top = D.first.right :=
+    (congrArg (fun R => R.top) D.transpose_first).trans D.first.transpose_top
+  have hsecondTop : D.transpose.second.top = D.second.right :=
+    (congrArg (fun R => R.top) D.transpose_second).trans D.second.transpose_top
   exact ⟨by
-    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_bottom,
-      GridRectangleBetween.transpose_top] using hcolumns, by
-    simpa only [GridRectangleDecomposition.transpose, GridRectangleBetween.transpose_left,
+    simpa only [hfirstBottom, hfirstTop, hsecondTop] using hcolumns, by
+    simpa only [GridRectangleDecomposition.transpose_first,
+      GridRectangleDecomposition.transpose_second, GridRectangleBetween.transpose_left,
       GridRectangleBetween.transpose_right] using hrows⟩
 
 end GridRectangleDecomposition


### PR DESCRIPTION
This PR completes the cyclic-order classification for two composable empty grid rectangles sharing exactly one side column. It proves the terminal--terminal orientation directly, derives both mixed orientations by diagonal transposition, and packages transposition as an involution on two-step rectangle decompositions.

The exact roadmap target is `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G milestone 3, “The complexes and `∂² = 0`,” specifically the overlapping part of the disjoint / overlapping / annular juxtaposition case analysis. The newly merged initial--initial order theorem handled one of the four cases isolated by `GridRectangleDecomposition.side_eq_cases_of_hasOneCommonSide`; the three new theorems now supply the other cases, so every one-common-side decomposition has the column and row order needed by the two L-shaped recutting identities in `Rectangle/Juxtaposition.lean`.

This is the most effective current step toward Lane G.3 because the disjoint-side cancellation is already in flight in #4670, the annular case is complete, and the cyclic-order gap was the next explicit prerequisite for constructing the alternate overlapping decomposition. After this PR, the overlapping case still needs that alternate empty decomposition, preservation of `X`-avoidance and `O`-monomial weight under recutting, and the fixed-point-free pairing; those results can then be assembled with the disjoint and annular cases into the unblocked square-zero theorem.

The change adds 172 lines and removes 5 across `TauCeti/KnotTheory/Grid/Differential/Square/Decomposition.lean` and `TauCeti/KnotTheory/Grid/Differential/Square/OverlapOrder.lean`. The transpose API reuses the existing `GridRectangleBetween.transpose` construction and its emptiness theorem, while the direct geometry reuses the cyclic-interval and source/target emptiness interfaces. No Mathlib code or external formalization is vendored. The mathematics follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 4.6, as credited in the module documentation.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"one-common-side-all-cyclic-orders"}-->

🤖 Prepared with Codex
