### PR TITLE
feat: right and left almost split morphisms

### DIFF
--- a/TauCeti/CategoryTheory/AlmostSplit.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit.lean
@@ -6,9 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Homology.ShortComplex.Exact
-public import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
-public import Mathlib.CategoryTheory.Preadditive.Biproducts
-public import Mathlib.CategoryTheory.Simple
 public import TauCeti.CategoryTheory.IrreducibleMorphism
 
 /-!
@@ -43,6 +40,9 @@ what ties the sequence to the arrows of the Auslander-Reiten quiver.
 * `TauCeti.IsRightAlmostSplit` and `TauCeti.IsLeftAlmostSplit`: the definitions, with
   `TauCeti.isRightAlmostSplit_iff` and `TauCeti.isLeftAlmostSplit_iff` as the introduction rules
   and the projections `not_isSplitEpi` / `not_isSplitMono` and `factors`.
+* `TauCeti.isRightAlmostSplit_op_iff` and `TauCeti.isLeftAlmostSplit_op_iff`: **the two notions are
+  exchanged by passage to the opposite category**, so every result about one transports to the
+  other.
 * `TauCeti.IsRightAlmostSplit.indecomposable`: **the target of a right almost split morphism is
   indecomposable**, and `TauCeti.IsLeftAlmostSplit.indecomposable`: the source of a left almost
   split morphism is indecomposable.
@@ -58,14 +58,6 @@ what ties the sequence to the arrows of the Auslander-Reiten quiver.
   `TauCeti.isRightAlmostSplit_comp_iso_iff`, `TauCeti.isRightAlmostSplit_iso_comp_iff` and their
   left-hand analogues, so the notions descend to a skeleton.
 
-Mathlib's `CategoryTheory.Biprod.isIso_inl_iff_isZero` says that an invertible `biprod.inl`
-forces the other summand to vanish, and remarks that the three variations on it "are likely not
-separately useful". The indecomposability arguments below consume all four structure maps, so the
-three remaining cases are recorded here as transports of the Mathlib lemma —
-`TauCeti.isZero_of_isIso_biprod_inr` along `CategoryTheory.Limits.biprod.braiding`, and
-`TauCeti.isZero_of_isIso_biprod_fst`, `TauCeti.isZero_of_isIso_biprod_snd` by inverting
-`biprod.inl ≫ biprod.fst = 𝟙` and `biprod.inr ≫ biprod.snd = 𝟙`.
-
 ## Implementation notes
 
 The definitions are conjunctions rather than structures, matching the shape of
@@ -79,10 +71,10 @@ finite-dimensional algebra that is the intended reading: the ambient category th
 finite-dimensional one, as it already is for `TauCeti.IsIrreducibleMorphism`. The distinction is
 not cosmetic — quantifying an almost-split sequence's lifting properties over a category of
 representations with no finiteness restriction states a strictly stronger condition, and the
-existence theorem for such sequences is false in that form (Paquette, *A note on almost split
-sequences*, arXiv:1104.1195, exhibits infinite-dimensional indecomposable representations of the
-Kronecker quiver that end no almost-split sequence). Instantiating `C` at the finite-dimensional
-subcategory is what recovers the intended notion.
+existence theorem for such sequences is false in that form (Paquette, *A non-existence theorem for
+almost split sequences*, arXiv:1104.1195, exhibits infinite-dimensional indecomposable
+representations of the Kronecker quiver that end no almost-split sequence). Instantiating `C` at
+the finite-dimensional subcategory is what recovers the intended notion.
 
 A right almost split morphism may well be zero: over a field, the map `0 ⟶ k` is right almost
 split, every non-split-epi into the simple projective `k` being zero. So there is no analogue here
@@ -90,10 +82,11 @@ of `TauCeti.IsIrreducibleMorphism.ne_zero`, and this is not an oversight — it 
 of a projective target, where the almost split morphism is the inclusion of the radical.
 
 Indecomposability of the target is proved directly from the definition rather than through
-endomorphism rings, so it needs no finiteness and no field: given `Y ≅ A ⊞ B` with both summands
-nonzero, neither inclusion `A ⟶ Y` nor `B ⟶ Y` is a split epimorphism (a split mono that is a
-split epi is invertible, and an invertible `biprod.inl` kills `B`), so both factor through `f`, and
-`CategoryTheory.Limits.biprod.total` assembles the two factorizations into a section of `f`.
+endomorphism rings, so it needs no additivity, no finiteness and no field: given `Y ≅ A ⊞ B` with
+both summands nonzero, neither inclusion `A ⟶ Y` nor `B ⟶ Y` is a split epimorphism (a section of
+one of them retracts `A ⊞ B` onto that summand along its inclusion, and the two complementary
+structure maps then compose to `0`, collapsing the other summand), so both factor through `f`, and
+`CategoryTheory.Limits.biprod.desc` assembles the two factorizations into a section of `f`.
 
 ## References
 
@@ -105,6 +98,7 @@ non-splitness, which that layer lists as separate requirements on the sequence.
 * M. Auslander, I. Reiten, S. Smalø, *Representation Theory of Artin Algebras*, CUP (1995), V.1.
 * I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
   Algebras, Vol. 1*, LMS Student Texts 65, CUP (2006), IV.1.
+* C. Paquette, *A non-existence theorem for almost split sequences*, arXiv:1104.1195 (2011).
 -/
 
 public section
@@ -116,41 +110,6 @@ open CategoryTheory CategoryTheory.Limits
 universe v u
 
 variable {C : Type u} [Category.{v} C]
-
-/-! ### Invertible structure maps of a binary biproduct -/
-
-section Biproduct
-
-variable [Preadditive C] [HasBinaryBiproducts C] (A B : C)
-
-/-- **If the second inclusion of a binary biproduct is invertible, the first summand is zero**:
-`CategoryTheory.Biprod.isIso_inl_iff_isZero` transported along the braiding, which carries
-`biprod.inr : B ⟶ A ⊞ B` to `biprod.inl : B ⟶ B ⊞ A`. -/
-theorem isZero_of_isIso_biprod_inr [IsIso (biprod.inr : B ⟶ A ⊞ B)] : IsZero A := by
-  have h : (biprod.inr : B ⟶ A ⊞ B) ≫ (biprod.braiding A B).hom = biprod.inl := by
-    apply biprod.hom_ext <;> simp [biprod.braiding]
-  have : IsIso (biprod.inl : B ⟶ B ⊞ A) := by rw [← h]; infer_instance
-  exact (Biprod.isIso_inl_iff_isZero B A).mp this
-
-/-- **If the first projection of a binary biproduct is invertible, the second summand is zero**:
-`biprod.inl ≫ biprod.fst = 𝟙` makes `biprod.inl` the inverse of `biprod.fst`, so
-`CategoryTheory.Biprod.isIso_inl_iff_isZero` applies. -/
-theorem isZero_of_isIso_biprod_fst [IsIso (biprod.fst : A ⊞ B ⟶ A)] : IsZero B := by
-  have h : inv (biprod.fst : A ⊞ B ⟶ A) = biprod.inl :=
-    IsIso.inv_eq_of_inv_hom_id biprod.inl_fst
-  have : IsIso (biprod.inl : A ⟶ A ⊞ B) := by rw [← h]; infer_instance
-  exact (Biprod.isIso_inl_iff_isZero A B).mp this
-
-/-- **If the second projection of a binary biproduct is invertible, the first summand is zero**:
-`biprod.inr ≫ biprod.snd = 𝟙` makes `biprod.inr` the inverse of `biprod.snd`, so
-`TauCeti.isZero_of_isIso_biprod_inr` applies. -/
-theorem isZero_of_isIso_biprod_snd [IsIso (biprod.snd : A ⊞ B ⟶ B)] : IsZero A := by
-  have h : inv (biprod.snd : A ⊞ B ⟶ B) = biprod.inr :=
-    IsIso.inv_eq_of_inv_hom_id biprod.inr_snd
-  have : IsIso (biprod.inr : B ⟶ A ⊞ B) := by rw [← h]; infer_instance
-  exact isZero_of_isIso_biprod_inr A B
-
-end Biproduct
 
 /-! ### The definitions -/
 
@@ -166,7 +125,8 @@ def IsRightAlmostSplit {X Y : C} (f : X ⟶ Y) : Prop :=
 
 /-- **A left almost split morphism**: one that is not a split monomorphism, and through which
 every morphism out of its source that is not a split monomorphism factors. This is the condition
-of `TauCeti.IsRightAlmostSplit` read in the opposite category. -/
+of `TauCeti.IsRightAlmostSplit` read in the opposite category
+(`TauCeti.isRightAlmostSplit_op_iff`). -/
 def IsLeftAlmostSplit {X Y : C} (f : X ⟶ Y) : Prop :=
   ¬ IsSplitMono f ∧ ∀ (Z : C) (g : X ⟶ Z), ¬ IsSplitMono g → ∃ h : Y ⟶ Z, f ≫ h = g
 
@@ -221,6 +181,48 @@ theorem not_isRightAlmostSplit_id (X : C) : ¬ IsRightAlmostSplit (𝟙 X) :=
 @[simp]
 theorem not_isLeftAlmostSplit_id (X : C) : ¬ IsLeftAlmostSplit (𝟙 X) :=
   fun hf => hf.not_isIso inferInstance
+
+/-! ### Duality -/
+
+-- Mathlib supplies the two instances `[IsSplitMono g] → IsSplitEpi g.op` and
+-- `[IsSplitEpi g] → IsSplitMono g.op`; their converses, needed to move the negative clauses of the
+-- two predicates across the duality, are not stated there.
+private theorem isSplitMono_of_isSplitEpi_op {Z W : C} (g : Z ⟶ W) [IsSplitEpi g.op] :
+    IsSplitMono g :=
+  IsSplitMono.mk' ⟨(section_ g.op).unop, Quiver.Hom.op_inj (IsSplitEpi.id g.op)⟩
+
+private theorem isSplitEpi_of_isSplitMono_op {Z W : C} (g : Z ⟶ W) [IsSplitMono g.op] :
+    IsSplitEpi g :=
+  IsSplitEpi.mk' ⟨(retraction g.op).unop, Quiver.Hom.op_inj (IsSplitMono.id g.op)⟩
+
+/-- **The opposite of a left almost split morphism is right almost split**, and conversely: the
+two notions are exchanged by passage to the opposite category. -/
+@[simp]
+theorem isRightAlmostSplit_op_iff : IsRightAlmostSplit f.op ↔ IsLeftAlmostSplit f := by
+  constructor
+  · refine fun hf => ⟨fun hs => hf.not_isSplitEpi inferInstance, fun Z g hg => ?_⟩
+    have hg' : ¬ IsSplitEpi g.op := fun hs => hg (isSplitMono_of_isSplitEpi_op g)
+    obtain ⟨h, hh⟩ := hf.factors (Opposite.op Z) g.op hg'
+    exact ⟨h.unop, Quiver.Hom.op_inj (by simpa using hh)⟩
+  · refine fun hf => ⟨fun hs => hf.not_isSplitMono (isSplitMono_of_isSplitEpi_op f),
+      fun Z g hg => ?_⟩
+    have hg' : ¬ IsSplitMono g.unop := fun hs => hg (inferInstanceAs (IsSplitEpi g.unop.op))
+    obtain ⟨h, hh⟩ := hf.factors Z.unop g.unop hg'
+    exact ⟨h.op, Quiver.Hom.unop_inj (by simpa using hh)⟩
+
+/-- **The opposite of a right almost split morphism is left almost split**, and conversely. -/
+@[simp]
+theorem isLeftAlmostSplit_op_iff : IsLeftAlmostSplit f.op ↔ IsRightAlmostSplit f := by
+  constructor
+  · refine fun hf => ⟨fun hs => hf.not_isSplitMono inferInstance, fun Z g hg => ?_⟩
+    have hg' : ¬ IsSplitMono g.op := fun hs => hg (isSplitEpi_of_isSplitMono_op g)
+    obtain ⟨h, hh⟩ := hf.factors (Opposite.op Z) g.op hg'
+    exact ⟨h.unop, Quiver.Hom.op_inj (by simpa using hh)⟩
+  · refine fun hf => ⟨fun hs => hf.not_isSplitEpi (isSplitEpi_of_isSplitMono_op f),
+      fun Z g hg => ?_⟩
+    have hg' : ¬ IsSplitEpi g.unop := fun hs => hg (inferInstanceAs (IsSplitMono g.unop.op))
+    obtain ⟨h, hh⟩ := hf.factors Z.unop g.unop hg'
+    exact ⟨h.op, Quiver.Hom.unop_inj (by simpa using hh)⟩
 
 /-! ### Invariance under isomorphisms of the source and the target -/
 
@@ -316,9 +318,6 @@ theorem IsLeftAlmostSplit.mono_of_mono (hf : IsLeftAlmostSplit f) {Z : C} (g : X
 
 /-- **An irreducible morphism into the target of a right almost split morphism factors through it
 by a split monomorphism**, so its source is a retract of the source of the almost split morphism.
-Indeed the factorization exists because an irreducible morphism is not a split epimorphism, and
-then irreducibility applied to that very factorization forces the first factor to split, the
-second factor being the almost split morphism, which is not a split epimorphism either.
 
 This is why the middle term of an almost-split sequence receives all the irreducible morphisms
 into its right-hand end. -/
@@ -341,85 +340,80 @@ theorem IsLeftAlmostSplit.exists_isSplitEpi_of_isIrreducibleMorphism (hf : IsLef
 
 section Indecomposable
 
-variable [Preadditive C] [HasBinaryBiproducts C]
+variable [HasZeroMorphisms C] [HasBinaryBiproducts C]
 
-/-- **The target of a right almost split morphism is indecomposable.**
-
-It is nonzero, since a morphism to a zero object always splits. And if `Y ≅ A ⊞ B` with both
-summands nonzero then neither inclusion `A ⟶ Y` nor `B ⟶ Y` is a split epimorphism — each is a
-split monomorphism, so a splitting epimorphism would make it invertible, and an invertible
-`biprod.inl` forces `B` to vanish. Both inclusions therefore factor through `f`, and
-`CategoryTheory.Limits.biprod.total` glues the two factorizations into a section of `f`,
-contradicting that `f` does not split. -/
+/-- **The target of a right almost split morphism is indecomposable.** So the indecomposability of
+the right-hand end of an almost-split sequence is a consequence of its lifting property rather
+than a hypothesis on it. -/
 theorem IsRightAlmostSplit.indecomposable (hf : IsRightAlmostSplit f) : Indecomposable Y := by
   refine ⟨fun hY => hf.not_isSplitEpi (IsSplitEpi.mk' ⟨0, hY.eq_of_src _ _⟩), fun A B e => ?_⟩
   by_contra hcon
   rw [not_or] at hcon
   obtain ⟨hA, hB⟩ := hcon
+  -- A section of an inclusion `A ⟶ Y` retracts `A ⊞ B` onto `A` along `biprod.inl`, and
+  -- `biprod.inl ≫ biprod.snd = 0` then collapses `B`; symmetrically for the other inclusion.
   have hiA : ¬ IsSplitEpi (biprod.inl ≫ e.inv : A ⟶ Y) := by
-    intro _
-    have : IsSplitMono (biprod.inl ≫ e.inv : A ⟶ Y) :=
-      IsSplitMono.mk' ⟨e.hom ≫ biprod.fst, by simp⟩
-    have : IsIso (biprod.inl ≫ e.inv : A ⟶ Y) := isIso_of_mono_of_isSplitEpi _
-    have hinl : IsIso (biprod.inl : A ⟶ A ⊞ B) := by
-      have hh : (biprod.inl ≫ e.inv) ≫ e.hom = (biprod.inl : A ⟶ A ⊞ B) := by simp
-      rw [← hh]
-      infer_instance
-    exact hB ((Biprod.isIso_inl_iff_isZero A B).mp hinl)
+    intro h
+    obtain ⟨s, hs⟩ := h.exists_splitEpi.some
+    have h₁ : s ≫ biprod.inl = e.hom := by
+      rw [← cancel_mono e.inv, e.hom_inv_id, Category.assoc]; exact hs
+    refine hB ?_
+    rw [IsZero.iff_id_eq_zero]
+    calc 𝟙 B = biprod.inr ≫ (e.inv ≫ s ≫ biprod.inl) ≫ biprod.snd := by
+          rw [h₁, e.inv_hom_id, Category.id_comp, biprod.inr_snd]
+      _ = 0 := by simp
   have hiB : ¬ IsSplitEpi (biprod.inr ≫ e.inv : B ⟶ Y) := by
-    intro _
-    have : IsSplitMono (biprod.inr ≫ e.inv : B ⟶ Y) :=
-      IsSplitMono.mk' ⟨e.hom ≫ biprod.snd, by simp⟩
-    have : IsIso (biprod.inr ≫ e.inv : B ⟶ Y) := isIso_of_mono_of_isSplitEpi _
-    have hinr : IsIso (biprod.inr : B ⟶ A ⊞ B) := by
-      have hh : (biprod.inr ≫ e.inv) ≫ e.hom = (biprod.inr : B ⟶ A ⊞ B) := by simp
-      rw [← hh]
-      infer_instance
-    exact hA (isZero_of_isIso_biprod_inr A B)
+    intro h
+    obtain ⟨s, hs⟩ := h.exists_splitEpi.some
+    have h₁ : s ≫ biprod.inr = e.hom := by
+      rw [← cancel_mono e.inv, e.hom_inv_id, Category.assoc]; exact hs
+    refine hA ?_
+    rw [IsZero.iff_id_eq_zero]
+    calc 𝟙 A = biprod.inl ≫ (e.inv ≫ s ≫ biprod.inr) ≫ biprod.fst := by
+          rw [h₁, e.inv_hom_id, Category.id_comp, biprod.inl_fst]
+      _ = 0 := by simp
   obtain ⟨u, hu⟩ := hf.factors A _ hiA
   obtain ⟨v, hv⟩ := hf.factors B _ hiB
-  refine hf.not_isSplitEpi (IsSplitEpi.mk' ⟨e.hom ≫ (biprod.fst ≫ u + biprod.snd ≫ v), ?_⟩)
-  have key : (biprod.fst ≫ u + biprod.snd ≫ v) ≫ f
-      = (biprod.fst ≫ biprod.inl + biprod.snd ≫ biprod.inr) ≫ e.inv := by
-    simp only [Preadditive.add_comp, Category.assoc, hu, hv]
-  rw [Category.assoc, key, biprod.total, Category.id_comp, e.hom_inv_id]
+  refine hf.not_isSplitEpi (IsSplitEpi.mk' ⟨e.hom ≫ biprod.desc u v, ?_⟩)
+  have key : biprod.desc u v ≫ f = e.inv := by
+    apply biprod.hom_ext' <;> simp [hu, hv]
+  rw [Category.assoc, key, e.hom_inv_id]
 
 /-- **The source of a left almost split morphism is indecomposable**, dually to
-`TauCeti.IsRightAlmostSplit.indecomposable`: the two projections of a nontrivial decomposition of
-the source are not split monomorphisms, so both factor through `f`, and the two factorizations
-glue into a retraction of `f`. -/
+`TauCeti.IsRightAlmostSplit.indecomposable`. -/
 theorem IsLeftAlmostSplit.indecomposable (hf : IsLeftAlmostSplit f) : Indecomposable X := by
   refine ⟨fun hX => hf.not_isSplitMono (IsSplitMono.mk' ⟨0, hX.eq_of_src _ _⟩), fun A B e => ?_⟩
   by_contra hcon
   rw [not_or] at hcon
   obtain ⟨hA, hB⟩ := hcon
+  -- Dually, a retraction of a projection `X ⟶ A` sections `A ⊞ B` off `A` along `biprod.fst`,
+  -- and `biprod.inr ≫ biprod.fst = 0` then collapses `B`.
   have hpA : ¬ IsSplitMono (e.hom ≫ biprod.fst : X ⟶ A) := by
-    intro _
-    have : IsSplitEpi (e.hom ≫ biprod.fst : X ⟶ A) :=
-      IsSplitEpi.mk' ⟨biprod.inl ≫ e.inv, by simp⟩
-    have : IsIso (e.hom ≫ biprod.fst : X ⟶ A) := isIso_of_mono_of_isSplitEpi _
-    have hfst : IsIso (biprod.fst : A ⊞ B ⟶ A) := by
-      have hh : e.inv ≫ (e.hom ≫ biprod.fst) = (biprod.fst : A ⊞ B ⟶ A) := by simp
-      rw [← hh]
-      infer_instance
-    exact hB (isZero_of_isIso_biprod_fst A B)
+    intro h
+    obtain ⟨r, hr⟩ := h.exists_splitMono.some
+    have h₁ : biprod.fst ≫ r = e.inv := by
+      rw [← cancel_epi e.hom, e.hom_inv_id, ← Category.assoc]; exact hr
+    refine hB ?_
+    rw [IsZero.iff_id_eq_zero]
+    calc 𝟙 B = biprod.inr ≫ ((biprod.fst ≫ r) ≫ e.hom) ≫ biprod.snd := by
+          rw [h₁, e.inv_hom_id, Category.id_comp, biprod.inr_snd]
+      _ = 0 := by simp
   have hpB : ¬ IsSplitMono (e.hom ≫ biprod.snd : X ⟶ B) := by
-    intro _
-    have : IsSplitEpi (e.hom ≫ biprod.snd : X ⟶ B) :=
-      IsSplitEpi.mk' ⟨biprod.inr ≫ e.inv, by simp⟩
-    have : IsIso (e.hom ≫ biprod.snd : X ⟶ B) := isIso_of_mono_of_isSplitEpi _
-    have hsnd : IsIso (biprod.snd : A ⊞ B ⟶ B) := by
-      have hh : e.inv ≫ (e.hom ≫ biprod.snd) = (biprod.snd : A ⊞ B ⟶ B) := by simp
-      rw [← hh]
-      infer_instance
-    exact hA (isZero_of_isIso_biprod_snd A B)
+    intro h
+    obtain ⟨r, hr⟩ := h.exists_splitMono.some
+    have h₁ : biprod.snd ≫ r = e.inv := by
+      rw [← cancel_epi e.hom, e.hom_inv_id, ← Category.assoc]; exact hr
+    refine hA ?_
+    rw [IsZero.iff_id_eq_zero]
+    calc 𝟙 A = biprod.inl ≫ ((biprod.snd ≫ r) ≫ e.hom) ≫ biprod.fst := by
+          rw [h₁, e.inv_hom_id, Category.id_comp, biprod.inl_fst]
+      _ = 0 := by simp
   obtain ⟨u, hu⟩ := hf.factors A _ hpA
   obtain ⟨v, hv⟩ := hf.factors B _ hpB
-  refine hf.not_isSplitMono (IsSplitMono.mk' ⟨(u ≫ biprod.inl + v ≫ biprod.inr) ≫ e.inv, ?_⟩)
-  have key : f ≫ (u ≫ biprod.inl + v ≫ biprod.inr)
-      = e.hom ≫ (biprod.fst ≫ biprod.inl + biprod.snd ≫ biprod.inr) := by
-    simp only [Preadditive.comp_add, ← Category.assoc, hu, hv]
-  rw [← Category.assoc, key, biprod.total, Category.comp_id, e.hom_inv_id]
+  refine hf.not_isSplitMono (IsSplitMono.mk' ⟨biprod.lift u v ≫ e.inv, ?_⟩)
+  have key : f ≫ biprod.lift u v = e.hom := by
+    apply biprod.hom_ext <;> simp [hu, hv]
+  rw [← Category.assoc, key, e.hom_inv_id]
 
 end Indecomposable
 

--- a/TauCeti/CategoryTheory/AlmostSplit.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit.lean
@@ -1,0 +1,472 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Homology.ShortComplex.Exact
+public import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
+public import Mathlib.CategoryTheory.Preadditive.Biproducts
+public import TauCeti.CategoryTheory.IrreducibleMorphism
+
+/-!
+# Right and left almost split morphisms
+
+A morphism `f : X ⟶ Y` is **right almost split** when it is not a split epimorphism and *every*
+morphism `Z ⟶ Y` that is not a split epimorphism factors through it. Dually `f` is **left almost
+split** when it is not a split monomorphism and every morphism `X ⟶ Z` that is not a split
+monomorphism factors through it. So a right almost split morphism into `Y` is a single map that
+absorbs all the "inessential" maps into `Y` at once, and a left almost split morphism out of `X`
+absorbs all the inessential maps out of `X`.
+
+These are the two lifting properties an **almost-split (Auslander-Reiten) sequence**
+`0 → τM → E → M → 0` carries: `E ⟶ M` is right almost split and `τM ⟶ E` is left almost split.
+This file builds them as conditions on a single morphism of an arbitrary category, so that the
+sequence-level notion can be assembled from them, and proves the two facts that make the
+definition of an almost-split sequence non-redundant: **the target of a right almost split
+morphism is indecomposable**, and dually **the source of a left almost split morphism is
+indecomposable**. Neither end of an almost-split sequence has to be *assumed* indecomposable — the
+lifting properties already force it — and a short complex whose `g` is right almost split admits
+no splitting, so non-splitness is likewise a consequence rather than a hypothesis.
+
+The connection to `TauCeti.IsIrreducibleMorphism` is the sharpened factorization
+`TauCeti.IsRightAlmostSplit.exists_isSplitMono_of_isIrreducibleMorphism`: an irreducible morphism
+into `Y` not only factors through a right almost split `f : X ⟶ Y`, it factors through it by a
+**split monomorphism**, exhibiting its source as a retract of `X`. This is what makes the middle
+term of an almost-split sequence the receptacle of the irreducible morphisms into `M`, and hence
+what ties the sequence to the arrows of the Auslander-Reiten quiver.
+
+## Main results
+
+* `TauCeti.IsRightAlmostSplit` and `TauCeti.IsLeftAlmostSplit`: the definitions, with
+  `TauCeti.isRightAlmostSplit_iff` and `TauCeti.isLeftAlmostSplit_iff` as the introduction rules
+  and the projections `not_isSplitEpi` / `not_isSplitMono` and `factors`.
+* `TauCeti.IsRightAlmostSplit.indecomposable`: **the target of a right almost split morphism is
+  indecomposable**, and `TauCeti.IsLeftAlmostSplit.indecomposable`: the source of a left almost
+  split morphism is indecomposable.
+* `TauCeti.isEmpty_splitting_of_isRightAlmostSplit` and
+  `TauCeti.isEmpty_splitting_of_isLeftAlmostSplit`: a short complex one of whose maps is almost
+  split on the corresponding side has no splitting.
+* `TauCeti.IsRightAlmostSplit.exists_isSplitMono_of_isIrreducibleMorphism` and
+  `TauCeti.IsLeftAlmostSplit.exists_isSplitEpi_of_isIrreducibleMorphism`: **an irreducible
+  morphism factors through an almost split morphism by a split mono, resp. a split epi.**
+* `TauCeti.IsRightAlmostSplit.epi_of_epi` and `TauCeti.IsLeftAlmostSplit.mono_of_mono`: a right
+  almost split morphism is an epimorphism as soon as *some* non-split-epi into its target is one.
+* Invariance under isomorphisms of the source and the target,
+  `TauCeti.isRightAlmostSplit_comp_iso_iff`, `TauCeti.isRightAlmostSplit_iso_comp_iff` and their
+  left-hand analogues, so the notions descend to a skeleton.
+
+Four facts about binary biproducts are proved on the way and stated for reuse:
+`TauCeti.isZero_of_isIso_biprod_inl`, `TauCeti.isZero_of_isIso_biprod_inr`,
+`TauCeti.isZero_of_isIso_biprod_fst` and `TauCeti.isZero_of_isIso_biprod_snd`. Mathlib proves
+`CategoryTheory.Limits.biprod.isIso_inl_iff_id_eq_fst_comp_inl` and remarks that the three
+variations on it "are likely not separately useful"; the statements below are a different
+conclusion from the same hypothesis — an invertible structure map of a biproduct annihilates the
+*other* summand — which is exactly what the indecomposability arguments consume.
+
+## Implementation notes
+
+The definitions are conjunctions rather than structures, matching the shape of
+`TauCeti.IsIrreducibleMorphism`; their bodies are not exposed outside this module, so
+`TauCeti.isRightAlmostSplit_iff` and `TauCeti.isLeftAlmostSplit_iff` are the introduction rules.
+
+Both predicates are stated for `f : X ⟶ Y` in the same category, the right-hand notion being a
+condition at the target `Y` and the left-hand one a condition at the source `X`. The lifting
+quantifiers range over *all* objects of the ambient category. For the Auslander-Reiten theory of a
+finite-dimensional algebra that is the intended reading: the ambient category there is the
+finite-dimensional one, as it already is for `TauCeti.IsIrreducibleMorphism`. The distinction is
+not cosmetic — quantifying an almost-split sequence's lifting properties over a category of
+representations with no finiteness restriction states a strictly stronger condition, and the
+existence theorem for such sequences is false in that form (Paquette, *A note on almost split
+sequences*, arXiv:1104.1195, exhibits infinite-dimensional indecomposable representations of the
+Kronecker quiver that end no almost-split sequence). Instantiating `C` at the finite-dimensional
+subcategory is what recovers the intended notion.
+
+A right almost split morphism may well be zero: over a field, the map `0 ⟶ k` is right almost
+split, every non-split-epi into the simple projective `k` being zero. So there is no analogue here
+of `TauCeti.IsIrreducibleMorphism.ne_zero`, and this is not an oversight — it is the boundary case
+of a projective target, where the almost split morphism is the inclusion of the radical.
+
+Indecomposability of the target is proved directly from the definition rather than through
+endomorphism rings, so it needs no finiteness and no field: given `Y ≅ A ⊞ B` with both summands
+nonzero, neither inclusion `A ⟶ Y` nor `B ⟶ Y` is a split epimorphism (a split mono that is a
+split epi is invertible, and an invertible `biprod.inl` kills `B`), so both factor through `f`, and
+`CategoryTheory.Limits.biprod.total` assembles the two factorizations into a section of `f`.
+
+## References
+
+This builds the right and left almost split conditions named in Layer 6 (Auslander-Reiten theory)
+of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` as the two lifting
+clauses of an almost-split sequence, together with the indecomposability of its ends and its
+non-splitness, which that layer lists as separate requirements on the sequence.
+
+* M. Auslander, I. Reiten, S. Smalø, *Representation Theory of Artin Algebras*, CUP (1995), V.1.
+* I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
+  Algebras, Vol. 1*, LMS Student Texts 65, CUP (2006), IV.1.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+variable {C : Type u} [Category.{v} C]
+
+/-! ### Invertible structure maps of a binary biproduct -/
+
+section Biproduct
+
+variable [HasZeroMorphisms C] (A B : C) [HasBinaryBiproduct A B]
+
+/-- **If the first inclusion of a binary biproduct is invertible, the second summand is zero.**
+Composing the inverse of `biprod.inl` with `biprod.inl ≫ biprod.snd = 0` shows `biprod.snd` is
+zero, and `biprod.snd` retracts `biprod.inr`. -/
+theorem isZero_of_isIso_biprod_inl [IsIso (biprod.inl : A ⟶ A ⊞ B)] : IsZero B := by
+  have hsnd : (biprod.snd : A ⊞ B ⟶ B) = 0 :=
+    calc (biprod.snd : A ⊞ B ⟶ B)
+        = (inv (biprod.inl : A ⟶ A ⊞ B) ≫ biprod.inl) ≫ biprod.snd := by
+          rw [IsIso.inv_hom_id, Category.id_comp]
+      _ = 0 := by rw [Category.assoc, biprod.inl_snd, comp_zero]
+  rw [IsZero.iff_id_eq_zero]
+  calc 𝟙 B = (biprod.inr : B ⟶ A ⊞ B) ≫ biprod.snd := biprod.inr_snd.symm
+    _ = 0 := by rw [hsnd, comp_zero]
+
+/-- **If the second inclusion of a binary biproduct is invertible, the first summand is zero.** -/
+theorem isZero_of_isIso_biprod_inr [IsIso (biprod.inr : B ⟶ A ⊞ B)] : IsZero A := by
+  have hfst : (biprod.fst : A ⊞ B ⟶ A) = 0 :=
+    calc (biprod.fst : A ⊞ B ⟶ A)
+        = (inv (biprod.inr : B ⟶ A ⊞ B) ≫ biprod.inr) ≫ biprod.fst := by
+          rw [IsIso.inv_hom_id, Category.id_comp]
+      _ = 0 := by rw [Category.assoc, biprod.inr_fst, comp_zero]
+  rw [IsZero.iff_id_eq_zero]
+  calc 𝟙 A = (biprod.inl : A ⟶ A ⊞ B) ≫ biprod.fst := biprod.inl_fst.symm
+    _ = 0 := by rw [hfst, comp_zero]
+
+/-- **If the first projection of a binary biproduct is invertible, the second summand is zero.**
+Composing `biprod.inr ≫ biprod.fst = 0` with the inverse of `biprod.fst` shows `biprod.inr` is
+zero, and `biprod.inr` sections `biprod.snd`. -/
+theorem isZero_of_isIso_biprod_fst [IsIso (biprod.fst : A ⊞ B ⟶ A)] : IsZero B := by
+  have hinr : (biprod.inr : B ⟶ A ⊞ B) = 0 :=
+    calc (biprod.inr : B ⟶ A ⊞ B)
+        = biprod.inr ≫ ((biprod.fst : A ⊞ B ⟶ A) ≫ inv biprod.fst) := by
+          rw [IsIso.hom_inv_id, Category.comp_id]
+      _ = 0 := by rw [← Category.assoc, biprod.inr_fst, zero_comp]
+  rw [IsZero.iff_id_eq_zero]
+  calc 𝟙 B = (biprod.inr : B ⟶ A ⊞ B) ≫ biprod.snd := biprod.inr_snd.symm
+    _ = 0 := by rw [hinr, zero_comp]
+
+/-- **If the second projection of a binary biproduct is invertible, the first summand is zero.** -/
+theorem isZero_of_isIso_biprod_snd [IsIso (biprod.snd : A ⊞ B ⟶ B)] : IsZero A := by
+  have hinl : (biprod.inl : A ⟶ A ⊞ B) = 0 :=
+    calc (biprod.inl : A ⟶ A ⊞ B)
+        = biprod.inl ≫ ((biprod.snd : A ⊞ B ⟶ B) ≫ inv biprod.snd) := by
+          rw [IsIso.hom_inv_id, Category.comp_id]
+      _ = 0 := by rw [← Category.assoc, biprod.inl_snd, zero_comp]
+  rw [IsZero.iff_id_eq_zero]
+  calc 𝟙 A = (biprod.inl : A ⟶ A ⊞ B) ≫ biprod.fst := biprod.inl_fst.symm
+    _ = 0 := by rw [hinl, zero_comp]
+
+end Biproduct
+
+/-! ### The definitions -/
+
+/-- **A right almost split morphism**: one that is not a split epimorphism, and through which
+every morphism to its target that is not a split epimorphism factors.
+
+The negative clause is what makes the notion nonvacuous: without it every split epimorphism would
+qualify, the identity among them. With it, a right almost split morphism is in particular not an
+isomorphism (`TauCeti.IsRightAlmostSplit.not_isIso`) and its target is indecomposable
+(`TauCeti.IsRightAlmostSplit.indecomposable`). -/
+def IsRightAlmostSplit {X Y : C} (f : X ⟶ Y) : Prop :=
+  ¬ IsSplitEpi f ∧ ∀ (Z : C) (g : Z ⟶ Y), ¬ IsSplitEpi g → ∃ h : Z ⟶ X, h ≫ f = g
+
+/-- **A left almost split morphism**: one that is not a split monomorphism, and through which
+every morphism out of its source that is not a split monomorphism factors. This is the condition
+of `TauCeti.IsRightAlmostSplit` read in the opposite category. -/
+def IsLeftAlmostSplit {X Y : C} (f : X ⟶ Y) : Prop :=
+  ¬ IsSplitMono f ∧ ∀ (Z : C) (g : X ⟶ Z), ¬ IsSplitMono g → ∃ h : Y ⟶ Z, f ≫ h = g
+
+variable {X Y : C} {f : X ⟶ Y}
+
+/-- **The two clauses of being right almost split**, spelled out. This is both the introduction
+rule — the body of `TauCeti.IsRightAlmostSplit` is not exposed outside this module — and the
+elimination rule; the components are also available as
+`TauCeti.IsRightAlmostSplit.not_isSplitEpi` and `TauCeti.IsRightAlmostSplit.factors`. -/
+theorem isRightAlmostSplit_iff :
+    IsRightAlmostSplit f ↔
+      ¬ IsSplitEpi f ∧ ∀ (Z : C) (g : Z ⟶ Y), ¬ IsSplitEpi g → ∃ h : Z ⟶ X, h ≫ f = g :=
+  Iff.rfl
+
+/-- **The two clauses of being left almost split**, spelled out; the introduction and elimination
+rule for `TauCeti.IsLeftAlmostSplit`. -/
+theorem isLeftAlmostSplit_iff :
+    IsLeftAlmostSplit f ↔
+      ¬ IsSplitMono f ∧ ∀ (Z : C) (g : X ⟶ Z), ¬ IsSplitMono g → ∃ h : Y ⟶ Z, f ≫ h = g :=
+  Iff.rfl
+
+/-- A right almost split morphism is not a split epimorphism. -/
+theorem IsRightAlmostSplit.not_isSplitEpi (hf : IsRightAlmostSplit f) : ¬ IsSplitEpi f := hf.1
+
+/-- **The factorization property**: every morphism to the target of a right almost split morphism
+that is not itself a split epimorphism factors through it. -/
+theorem IsRightAlmostSplit.factors (hf : IsRightAlmostSplit f) (Z : C) (g : Z ⟶ Y)
+    (hg : ¬ IsSplitEpi g) : ∃ h : Z ⟶ X, h ≫ f = g := hf.2 Z g hg
+
+/-- A left almost split morphism is not a split monomorphism. -/
+theorem IsLeftAlmostSplit.not_isSplitMono (hf : IsLeftAlmostSplit f) : ¬ IsSplitMono f := hf.1
+
+/-- **The factorization property**: every morphism out of the source of a left almost split
+morphism that is not itself a split monomorphism factors through it. -/
+theorem IsLeftAlmostSplit.factors (hf : IsLeftAlmostSplit f) (Z : C) (g : X ⟶ Z)
+    (hg : ¬ IsSplitMono g) : ∃ h : Y ⟶ Z, f ≫ h = g := hf.2 Z g hg
+
+/-- **A right almost split morphism is not an isomorphism**, an isomorphism being a split epi. -/
+theorem IsRightAlmostSplit.not_isIso (hf : IsRightAlmostSplit f) : ¬ IsIso f :=
+  fun _ => hf.not_isSplitEpi inferInstance
+
+/-- **A left almost split morphism is not an isomorphism**, an isomorphism being a split mono. -/
+theorem IsLeftAlmostSplit.not_isIso (hf : IsLeftAlmostSplit f) : ¬ IsIso f :=
+  fun _ => hf.not_isSplitMono inferInstance
+
+/-- An identity is not right almost split. -/
+@[simp]
+theorem not_isRightAlmostSplit_id (X : C) : ¬ IsRightAlmostSplit (𝟙 X) :=
+  fun hf => hf.not_isIso inferInstance
+
+/-- An identity is not left almost split. -/
+@[simp]
+theorem not_isLeftAlmostSplit_id (X : C) : ¬ IsLeftAlmostSplit (𝟙 X) :=
+  fun hf => hf.not_isIso inferInstance
+
+/-! ### Invariance under isomorphisms of the source and the target -/
+
+/-- **Postcomposing a right almost split morphism with an isomorphism keeps it right almost
+split.** -/
+theorem IsRightAlmostSplit.comp_iso (hf : IsRightAlmostSplit f) {Y' : C} (e : Y ≅ Y') :
+    IsRightAlmostSplit (f ≫ e.hom) := by
+  refine ⟨fun _ => hf.not_isSplitEpi (isSplitEpi_of_isSplitEpi_comp_iso f e), fun Z g hg => ?_⟩
+  have hg' : ¬ IsSplitEpi (g ≫ e.inv) := by
+    intro _
+    have hcomp : IsSplitEpi ((g ≫ e.inv) ≫ e.hom) := inferInstance
+    rw [Category.assoc, e.inv_hom_id, Category.comp_id] at hcomp
+    exact hg hcomp
+  obtain ⟨h, hh⟩ := hf.factors Z (g ≫ e.inv) hg'
+  exact ⟨h, by rw [← Category.assoc, hh, Category.assoc, e.inv_hom_id, Category.comp_id]⟩
+
+/-- **Precomposing a right almost split morphism with an isomorphism keeps it right almost
+split.** -/
+theorem IsRightAlmostSplit.iso_comp (hf : IsRightAlmostSplit f) {X' : C} (e : X' ≅ X) :
+    IsRightAlmostSplit (e.hom ≫ f) := by
+  refine ⟨fun _ => hf.not_isSplitEpi (isSplitEpi_of_isSplitEpi_comp e.hom f), fun Z g hg => ?_⟩
+  obtain ⟨h, hh⟩ := hf.factors Z g hg
+  exact ⟨h ≫ e.inv, by rw [Category.assoc, ← Category.assoc e.inv, e.inv_hom_id,
+    Category.id_comp, hh]⟩
+
+/-- **Precomposing a left almost split morphism with an isomorphism keeps it left almost
+split.** -/
+theorem IsLeftAlmostSplit.iso_comp (hf : IsLeftAlmostSplit f) {X' : C} (e : X' ≅ X) :
+    IsLeftAlmostSplit (e.hom ≫ f) := by
+  refine ⟨fun _ => hf.not_isSplitMono (isSplitMono_of_isSplitMono_iso_comp e f), fun Z g hg => ?_⟩
+  have hg' : ¬ IsSplitMono (e.inv ≫ g) := by
+    intro _
+    have hcomp : IsSplitMono (e.hom ≫ e.inv ≫ g) := inferInstance
+    rw [← Category.assoc, e.hom_inv_id, Category.id_comp] at hcomp
+    exact hg hcomp
+  obtain ⟨h, hh⟩ := hf.factors Z (e.inv ≫ g) hg'
+  exact ⟨h, by rw [Category.assoc, hh, ← Category.assoc, e.hom_inv_id, Category.id_comp]⟩
+
+/-- **Postcomposing a left almost split morphism with an isomorphism keeps it left almost
+split.** -/
+theorem IsLeftAlmostSplit.comp_iso (hf : IsLeftAlmostSplit f) {Y' : C} (e : Y ≅ Y') :
+    IsLeftAlmostSplit (f ≫ e.hom) := by
+  refine ⟨fun _ => hf.not_isSplitMono (isSplitMono_of_isSplitMono_comp f e.hom), fun Z g hg => ?_⟩
+  obtain ⟨h, hh⟩ := hf.factors Z g hg
+  exact ⟨e.inv ≫ h, by rw [Category.assoc, ← Category.assoc e.hom, e.hom_inv_id,
+    Category.id_comp, hh]⟩
+
+/-- Being right almost split is invariant under an isomorphism of the target. -/
+@[simp]
+theorem isRightAlmostSplit_comp_iso_iff {Y' : C} (e : Y ≅ Y') :
+    IsRightAlmostSplit (f ≫ e.hom) ↔ IsRightAlmostSplit f := by
+  refine ⟨fun hf => ?_, fun hf => hf.comp_iso e⟩
+  have h : (f ≫ e.hom) ≫ e.symm.hom = f := by simp
+  exact h ▸ hf.comp_iso e.symm
+
+/-- Being right almost split is invariant under an isomorphism of the source. -/
+@[simp]
+theorem isRightAlmostSplit_iso_comp_iff {X' : C} (e : X' ≅ X) :
+    IsRightAlmostSplit (e.hom ≫ f) ↔ IsRightAlmostSplit f := by
+  refine ⟨fun hf => ?_, fun hf => hf.iso_comp e⟩
+  have h : e.symm.hom ≫ e.hom ≫ f = f := by simp
+  exact h ▸ hf.iso_comp e.symm
+
+/-- Being left almost split is invariant under an isomorphism of the source. -/
+@[simp]
+theorem isLeftAlmostSplit_iso_comp_iff {X' : C} (e : X' ≅ X) :
+    IsLeftAlmostSplit (e.hom ≫ f) ↔ IsLeftAlmostSplit f := by
+  refine ⟨fun hf => ?_, fun hf => hf.iso_comp e⟩
+  have h : e.symm.hom ≫ e.hom ≫ f = f := by simp
+  exact h ▸ hf.iso_comp e.symm
+
+/-- Being left almost split is invariant under an isomorphism of the target. -/
+@[simp]
+theorem isLeftAlmostSplit_comp_iso_iff {Y' : C} (e : Y ≅ Y') :
+    IsLeftAlmostSplit (f ≫ e.hom) ↔ IsLeftAlmostSplit f := by
+  refine ⟨fun hf => ?_, fun hf => hf.comp_iso e⟩
+  have h : (f ≫ e.hom) ≫ e.symm.hom = f := by simp
+  exact h ▸ hf.comp_iso e.symm
+
+/-! ### Interaction with epimorphisms, monomorphisms, and irreducible morphisms -/
+
+/-- **A right almost split morphism is an epimorphism as soon as some non-split epimorphism into
+its target is one.** For a module category this is how the almost split morphism onto a
+non-projective module is seen to be surjective: a projective cover of it is an epimorphism and,
+the module being non-projective, not a split one. -/
+theorem IsRightAlmostSplit.epi_of_epi (hf : IsRightAlmostSplit f) {Z : C} (g : Z ⟶ Y) [Epi g]
+    (hg : ¬ IsSplitEpi g) : Epi f := by
+  obtain ⟨h, hh⟩ := hf.factors Z g hg
+  have : Epi (h ≫ f) := hh ▸ ‹Epi g›
+  exact _root_.CategoryTheory.epi_of_epi h f
+
+/-- **A left almost split morphism is a monomorphism as soon as some non-split monomorphism out of
+its source is one.** -/
+theorem IsLeftAlmostSplit.mono_of_mono (hf : IsLeftAlmostSplit f) {Z : C} (g : X ⟶ Z) [Mono g]
+    (hg : ¬ IsSplitMono g) : Mono f := by
+  obtain ⟨h, hh⟩ := hf.factors Z g hg
+  have : Mono (f ≫ h) := hh ▸ ‹Mono g›
+  exact _root_.CategoryTheory.mono_of_mono f h
+
+/-- **An irreducible morphism into the target of a right almost split morphism factors through it
+by a split monomorphism**, so its source is a retract of the source of the almost split morphism.
+Indeed the factorization exists because an irreducible morphism is not a split epimorphism, and
+then irreducibility applied to that very factorization forces the first factor to split, the
+second factor being the almost split morphism, which is not a split epimorphism either.
+
+This is why the middle term of an almost-split sequence receives all the irreducible morphisms
+into its right-hand end. -/
+theorem IsRightAlmostSplit.exists_isSplitMono_of_isIrreducibleMorphism (hf : IsRightAlmostSplit f)
+    {Z : C} {g : Z ⟶ Y} (hg : IsIrreducibleMorphism g) :
+    ∃ h : Z ⟶ X, IsSplitMono h ∧ h ≫ f = g := by
+  obtain ⟨h, hh⟩ := hf.factors Z g hg.not_isSplitEpi
+  exact ⟨h, hg.isSplitMono_of_not_isSplitEpi hh hf.not_isSplitEpi, hh⟩
+
+/-- **An irreducible morphism out of the source of a left almost split morphism factors through it
+by a split epimorphism**, so its target is a retract of the target of the almost split
+morphism. -/
+theorem IsLeftAlmostSplit.exists_isSplitEpi_of_isIrreducibleMorphism (hf : IsLeftAlmostSplit f)
+    {Z : C} {g : X ⟶ Z} (hg : IsIrreducibleMorphism g) :
+    ∃ h : Y ⟶ Z, IsSplitEpi h ∧ f ≫ h = g := by
+  obtain ⟨h, hh⟩ := hf.factors Z g hg.not_isSplitMono
+  exact ⟨h, hg.isSplitEpi_of_not_isSplitMono hh hf.not_isSplitMono, hh⟩
+
+/-! ### Indecomposability of the almost split end -/
+
+section Indecomposable
+
+variable [Preadditive C] [HasBinaryBiproducts C]
+
+/-- **The target of a right almost split morphism is indecomposable.**
+
+It is nonzero, since a morphism to a zero object always splits. And if `Y ≅ A ⊞ B` with both
+summands nonzero then neither inclusion `A ⟶ Y` nor `B ⟶ Y` is a split epimorphism — each is a
+split monomorphism, so a splitting epimorphism would make it invertible, and an invertible
+`biprod.inl` forces `B` to vanish. Both inclusions therefore factor through `f`, and
+`CategoryTheory.Limits.biprod.total` glues the two factorizations into a section of `f`,
+contradicting that `f` does not split. -/
+theorem IsRightAlmostSplit.indecomposable (hf : IsRightAlmostSplit f) : Indecomposable Y := by
+  refine ⟨fun hY => hf.not_isSplitEpi (IsSplitEpi.mk' ⟨0, hY.eq_of_src _ _⟩), fun A B e => ?_⟩
+  by_contra hcon
+  rw [not_or] at hcon
+  obtain ⟨hA, hB⟩ := hcon
+  have hiA : ¬ IsSplitEpi (biprod.inl ≫ e.inv : A ⟶ Y) := by
+    intro _
+    have : IsSplitMono (biprod.inl ≫ e.inv : A ⟶ Y) :=
+      IsSplitMono.mk' ⟨e.hom ≫ biprod.fst, by simp⟩
+    have : IsIso (biprod.inl ≫ e.inv : A ⟶ Y) := isIso_of_mono_of_isSplitEpi _
+    have hinl : IsIso (biprod.inl : A ⟶ A ⊞ B) := by
+      have hh : (biprod.inl ≫ e.inv) ≫ e.hom = (biprod.inl : A ⟶ A ⊞ B) := by simp
+      rw [← hh]
+      infer_instance
+    exact hB (isZero_of_isIso_biprod_inl A B)
+  have hiB : ¬ IsSplitEpi (biprod.inr ≫ e.inv : B ⟶ Y) := by
+    intro _
+    have : IsSplitMono (biprod.inr ≫ e.inv : B ⟶ Y) :=
+      IsSplitMono.mk' ⟨e.hom ≫ biprod.snd, by simp⟩
+    have : IsIso (biprod.inr ≫ e.inv : B ⟶ Y) := isIso_of_mono_of_isSplitEpi _
+    have hinr : IsIso (biprod.inr : B ⟶ A ⊞ B) := by
+      have hh : (biprod.inr ≫ e.inv) ≫ e.hom = (biprod.inr : B ⟶ A ⊞ B) := by simp
+      rw [← hh]
+      infer_instance
+    exact hA (isZero_of_isIso_biprod_inr A B)
+  obtain ⟨u, hu⟩ := hf.factors A _ hiA
+  obtain ⟨v, hv⟩ := hf.factors B _ hiB
+  refine hf.not_isSplitEpi (IsSplitEpi.mk' ⟨e.hom ≫ (biprod.fst ≫ u + biprod.snd ≫ v), ?_⟩)
+  have key : (biprod.fst ≫ u + biprod.snd ≫ v) ≫ f
+      = (biprod.fst ≫ biprod.inl + biprod.snd ≫ biprod.inr) ≫ e.inv := by
+    simp only [Preadditive.add_comp, Category.assoc, hu, hv]
+  rw [Category.assoc, key, biprod.total, Category.id_comp, e.hom_inv_id]
+
+/-- **The source of a left almost split morphism is indecomposable**, dually to
+`TauCeti.IsRightAlmostSplit.indecomposable`: the two projections of a nontrivial decomposition of
+the source are not split monomorphisms, so both factor through `f`, and the two factorizations
+glue into a retraction of `f`. -/
+theorem IsLeftAlmostSplit.indecomposable (hf : IsLeftAlmostSplit f) : Indecomposable X := by
+  refine ⟨fun hX => hf.not_isSplitMono (IsSplitMono.mk' ⟨0, hX.eq_of_src _ _⟩), fun A B e => ?_⟩
+  by_contra hcon
+  rw [not_or] at hcon
+  obtain ⟨hA, hB⟩ := hcon
+  have hpA : ¬ IsSplitMono (e.hom ≫ biprod.fst : X ⟶ A) := by
+    intro _
+    have : IsSplitEpi (e.hom ≫ biprod.fst : X ⟶ A) :=
+      IsSplitEpi.mk' ⟨biprod.inl ≫ e.inv, by simp⟩
+    have : IsIso (e.hom ≫ biprod.fst : X ⟶ A) := isIso_of_mono_of_isSplitEpi _
+    have hfst : IsIso (biprod.fst : A ⊞ B ⟶ A) := by
+      have hh : e.inv ≫ (e.hom ≫ biprod.fst) = (biprod.fst : A ⊞ B ⟶ A) := by simp
+      rw [← hh]
+      infer_instance
+    exact hB (isZero_of_isIso_biprod_fst A B)
+  have hpB : ¬ IsSplitMono (e.hom ≫ biprod.snd : X ⟶ B) := by
+    intro _
+    have : IsSplitEpi (e.hom ≫ biprod.snd : X ⟶ B) :=
+      IsSplitEpi.mk' ⟨biprod.inr ≫ e.inv, by simp⟩
+    have : IsIso (e.hom ≫ biprod.snd : X ⟶ B) := isIso_of_mono_of_isSplitEpi _
+    have hsnd : IsIso (biprod.snd : A ⊞ B ⟶ B) := by
+      have hh : e.inv ≫ (e.hom ≫ biprod.snd) = (biprod.snd : A ⊞ B ⟶ B) := by simp
+      rw [← hh]
+      infer_instance
+    exact hA (isZero_of_isIso_biprod_snd A B)
+  obtain ⟨u, hu⟩ := hf.factors A _ hpA
+  obtain ⟨v, hv⟩ := hf.factors B _ hpB
+  refine hf.not_isSplitMono (IsSplitMono.mk' ⟨(u ≫ biprod.inl + v ≫ biprod.inr) ≫ e.inv, ?_⟩)
+  have key : f ≫ (u ≫ biprod.inl + v ≫ biprod.inr)
+      = e.hom ≫ (biprod.fst ≫ biprod.inl + biprod.snd ≫ biprod.inr) := by
+    simp only [Preadditive.comp_add, ← Category.assoc, hu, hv]
+  rw [← Category.assoc, key, biprod.total, Category.comp_id, e.hom_inv_id]
+
+end Indecomposable
+
+/-! ### Almost split maps in a short complex -/
+
+section ShortComplex
+
+variable [Preadditive C] {S : ShortComplex C}
+
+/-- **A short complex whose second map is right almost split does not split.** The `not_split`
+clause in the definition of an almost-split sequence is therefore redundant: it is implied by the
+right almost split clause alone. -/
+theorem isEmpty_splitting_of_isRightAlmostSplit (hg : IsRightAlmostSplit S.g) :
+    IsEmpty S.Splitting :=
+  ⟨fun s => hg.not_isSplitEpi s.isSplitEpi_g⟩
+
+/-- **A short complex whose first map is left almost split does not split.** -/
+theorem isEmpty_splitting_of_isLeftAlmostSplit (hf : IsLeftAlmostSplit S.f) :
+    IsEmpty S.Splitting :=
+  ⟨fun s => hf.not_isSplitMono s.isSplitMono_f⟩
+
+end ShortComplex
+
+end TauCeti

--- a/TauCeti/CategoryTheory/AlmostSplit.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Homology.ShortComplex.Exact
 public import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
 public import Mathlib.CategoryTheory.Preadditive.Biproducts
+public import Mathlib.CategoryTheory.Simple
 public import TauCeti.CategoryTheory.IrreducibleMorphism
 
 /-!
@@ -57,13 +58,13 @@ what ties the sequence to the arrows of the Auslander-Reiten quiver.
   `TauCeti.isRightAlmostSplit_comp_iso_iff`, `TauCeti.isRightAlmostSplit_iso_comp_iff` and their
   left-hand analogues, so the notions descend to a skeleton.
 
-Four facts about binary biproducts are proved on the way and stated for reuse:
-`TauCeti.isZero_of_isIso_biprod_inl`, `TauCeti.isZero_of_isIso_biprod_inr`,
-`TauCeti.isZero_of_isIso_biprod_fst` and `TauCeti.isZero_of_isIso_biprod_snd`. Mathlib proves
-`CategoryTheory.Limits.biprod.isIso_inl_iff_id_eq_fst_comp_inl` and remarks that the three
-variations on it "are likely not separately useful"; the statements below are a different
-conclusion from the same hypothesis — an invertible structure map of a biproduct annihilates the
-*other* summand — which is exactly what the indecomposability arguments consume.
+Mathlib's `CategoryTheory.Biprod.isIso_inl_iff_isZero` says that an invertible `biprod.inl`
+forces the other summand to vanish, and remarks that the three variations on it "are likely not
+separately useful". The indecomposability arguments below consume all four structure maps, so the
+three remaining cases are recorded here as transports of the Mathlib lemma —
+`TauCeti.isZero_of_isIso_biprod_inr` along `CategoryTheory.Limits.biprod.braiding`, and
+`TauCeti.isZero_of_isIso_biprod_fst`, `TauCeti.isZero_of_isIso_biprod_snd` by inverting
+`biprod.inl ≫ biprod.fst = 𝟙` and `biprod.inr ≫ biprod.snd = 𝟙`.
 
 ## Implementation notes
 
@@ -120,55 +121,34 @@ variable {C : Type u} [Category.{v} C]
 
 section Biproduct
 
-variable [HasZeroMorphisms C] (A B : C) [HasBinaryBiproduct A B]
+variable [Preadditive C] [HasBinaryBiproducts C] (A B : C)
 
-/-- **If the first inclusion of a binary biproduct is invertible, the second summand is zero.**
-Composing the inverse of `biprod.inl` with `biprod.inl ≫ biprod.snd = 0` shows `biprod.snd` is
-zero, and `biprod.snd` retracts `biprod.inr`. -/
-theorem isZero_of_isIso_biprod_inl [IsIso (biprod.inl : A ⟶ A ⊞ B)] : IsZero B := by
-  have hsnd : (biprod.snd : A ⊞ B ⟶ B) = 0 :=
-    calc (biprod.snd : A ⊞ B ⟶ B)
-        = (inv (biprod.inl : A ⟶ A ⊞ B) ≫ biprod.inl) ≫ biprod.snd := by
-          rw [IsIso.inv_hom_id, Category.id_comp]
-      _ = 0 := by rw [Category.assoc, biprod.inl_snd, comp_zero]
-  rw [IsZero.iff_id_eq_zero]
-  calc 𝟙 B = (biprod.inr : B ⟶ A ⊞ B) ≫ biprod.snd := biprod.inr_snd.symm
-    _ = 0 := by rw [hsnd, comp_zero]
-
-/-- **If the second inclusion of a binary biproduct is invertible, the first summand is zero.** -/
+/-- **If the second inclusion of a binary biproduct is invertible, the first summand is zero**:
+`CategoryTheory.Biprod.isIso_inl_iff_isZero` transported along the braiding, which carries
+`biprod.inr : B ⟶ A ⊞ B` to `biprod.inl : B ⟶ B ⊞ A`. -/
 theorem isZero_of_isIso_biprod_inr [IsIso (biprod.inr : B ⟶ A ⊞ B)] : IsZero A := by
-  have hfst : (biprod.fst : A ⊞ B ⟶ A) = 0 :=
-    calc (biprod.fst : A ⊞ B ⟶ A)
-        = (inv (biprod.inr : B ⟶ A ⊞ B) ≫ biprod.inr) ≫ biprod.fst := by
-          rw [IsIso.inv_hom_id, Category.id_comp]
-      _ = 0 := by rw [Category.assoc, biprod.inr_fst, comp_zero]
-  rw [IsZero.iff_id_eq_zero]
-  calc 𝟙 A = (biprod.inl : A ⟶ A ⊞ B) ≫ biprod.fst := biprod.inl_fst.symm
-    _ = 0 := by rw [hfst, comp_zero]
+  have h : (biprod.inr : B ⟶ A ⊞ B) ≫ (biprod.braiding A B).hom = biprod.inl := by
+    apply biprod.hom_ext <;> simp [biprod.braiding]
+  have : IsIso (biprod.inl : B ⟶ B ⊞ A) := by rw [← h]; infer_instance
+  exact (Biprod.isIso_inl_iff_isZero B A).mp this
 
-/-- **If the first projection of a binary biproduct is invertible, the second summand is zero.**
-Composing `biprod.inr ≫ biprod.fst = 0` with the inverse of `biprod.fst` shows `biprod.inr` is
-zero, and `biprod.inr` sections `biprod.snd`. -/
+/-- **If the first projection of a binary biproduct is invertible, the second summand is zero**:
+`biprod.inl ≫ biprod.fst = 𝟙` makes `biprod.inl` the inverse of `biprod.fst`, so
+`CategoryTheory.Biprod.isIso_inl_iff_isZero` applies. -/
 theorem isZero_of_isIso_biprod_fst [IsIso (biprod.fst : A ⊞ B ⟶ A)] : IsZero B := by
-  have hinr : (biprod.inr : B ⟶ A ⊞ B) = 0 :=
-    calc (biprod.inr : B ⟶ A ⊞ B)
-        = biprod.inr ≫ ((biprod.fst : A ⊞ B ⟶ A) ≫ inv biprod.fst) := by
-          rw [IsIso.hom_inv_id, Category.comp_id]
-      _ = 0 := by rw [← Category.assoc, biprod.inr_fst, zero_comp]
-  rw [IsZero.iff_id_eq_zero]
-  calc 𝟙 B = (biprod.inr : B ⟶ A ⊞ B) ≫ biprod.snd := biprod.inr_snd.symm
-    _ = 0 := by rw [hinr, zero_comp]
+  have h : inv (biprod.fst : A ⊞ B ⟶ A) = biprod.inl :=
+    IsIso.inv_eq_of_inv_hom_id biprod.inl_fst
+  have : IsIso (biprod.inl : A ⟶ A ⊞ B) := by rw [← h]; infer_instance
+  exact (Biprod.isIso_inl_iff_isZero A B).mp this
 
-/-- **If the second projection of a binary biproduct is invertible, the first summand is zero.** -/
+/-- **If the second projection of a binary biproduct is invertible, the first summand is zero**:
+`biprod.inr ≫ biprod.snd = 𝟙` makes `biprod.inr` the inverse of `biprod.snd`, so
+`TauCeti.isZero_of_isIso_biprod_inr` applies. -/
 theorem isZero_of_isIso_biprod_snd [IsIso (biprod.snd : A ⊞ B ⟶ B)] : IsZero A := by
-  have hinl : (biprod.inl : A ⟶ A ⊞ B) = 0 :=
-    calc (biprod.inl : A ⟶ A ⊞ B)
-        = biprod.inl ≫ ((biprod.snd : A ⊞ B ⟶ B) ≫ inv biprod.snd) := by
-          rw [IsIso.hom_inv_id, Category.comp_id]
-      _ = 0 := by rw [← Category.assoc, biprod.inl_snd, zero_comp]
-  rw [IsZero.iff_id_eq_zero]
-  calc 𝟙 A = (biprod.inl : A ⟶ A ⊞ B) ≫ biprod.fst := biprod.inl_fst.symm
-    _ = 0 := by rw [hinl, zero_comp]
+  have h : inv (biprod.snd : A ⊞ B ⟶ B) = biprod.inr :=
+    IsIso.inv_eq_of_inv_hom_id biprod.inr_snd
+  have : IsIso (biprod.inr : B ⟶ A ⊞ B) := by rw [← h]; infer_instance
+  exact isZero_of_isIso_biprod_inr A B
 
 end Biproduct
 
@@ -249,13 +229,10 @@ split.** -/
 theorem IsRightAlmostSplit.comp_iso (hf : IsRightAlmostSplit f) {Y' : C} (e : Y ≅ Y') :
     IsRightAlmostSplit (f ≫ e.hom) := by
   refine ⟨fun _ => hf.not_isSplitEpi (isSplitEpi_of_isSplitEpi_comp_iso f e), fun Z g hg => ?_⟩
-  have hg' : ¬ IsSplitEpi (g ≫ e.inv) := by
-    intro _
-    have hcomp : IsSplitEpi ((g ≫ e.inv) ≫ e.hom) := inferInstance
-    rw [Category.assoc, e.inv_hom_id, Category.comp_id] at hcomp
-    exact hg hcomp
-  obtain ⟨h, hh⟩ := hf.factors Z (g ≫ e.inv) hg'
-  exact ⟨h, by rw [← Category.assoc, hh, Category.assoc, e.inv_hom_id, Category.comp_id]⟩
+  have hg' : ¬ IsSplitEpi (g ≫ e.symm.hom) :=
+    fun _ => hg (isSplitEpi_of_isSplitEpi_comp_iso g e.symm)
+  obtain ⟨h, hh⟩ := hf.factors Z (g ≫ e.symm.hom) hg'
+  exact ⟨h, by rw [← Category.assoc, hh]; simp⟩
 
 /-- **Precomposing a right almost split morphism with an isomorphism keeps it right almost
 split.** -/
@@ -271,13 +248,10 @@ split.** -/
 theorem IsLeftAlmostSplit.iso_comp (hf : IsLeftAlmostSplit f) {X' : C} (e : X' ≅ X) :
     IsLeftAlmostSplit (e.hom ≫ f) := by
   refine ⟨fun _ => hf.not_isSplitMono (isSplitMono_of_isSplitMono_iso_comp e f), fun Z g hg => ?_⟩
-  have hg' : ¬ IsSplitMono (e.inv ≫ g) := by
-    intro _
-    have hcomp : IsSplitMono (e.hom ≫ e.inv ≫ g) := inferInstance
-    rw [← Category.assoc, e.hom_inv_id, Category.id_comp] at hcomp
-    exact hg hcomp
-  obtain ⟨h, hh⟩ := hf.factors Z (e.inv ≫ g) hg'
-  exact ⟨h, by rw [Category.assoc, hh, ← Category.assoc, e.hom_inv_id, Category.id_comp]⟩
+  have hg' : ¬ IsSplitMono (e.symm.hom ≫ g) :=
+    fun _ => hg (isSplitMono_of_isSplitMono_iso_comp e.symm g)
+  obtain ⟨h, hh⟩ := hf.factors Z (e.symm.hom ≫ g) hg'
+  exact ⟨h, by rw [Category.assoc, hh]; simp⟩
 
 /-- **Postcomposing a left almost split morphism with an isomorphism keeps it left almost
 split.** -/
@@ -391,7 +365,7 @@ theorem IsRightAlmostSplit.indecomposable (hf : IsRightAlmostSplit f) : Indecomp
       have hh : (biprod.inl ≫ e.inv) ≫ e.hom = (biprod.inl : A ⟶ A ⊞ B) := by simp
       rw [← hh]
       infer_instance
-    exact hB (isZero_of_isIso_biprod_inl A B)
+    exact hB ((Biprod.isIso_inl_iff_isZero A B).mp hinl)
   have hiB : ¬ IsSplitEpi (biprod.inr ≫ e.inv : B ⟶ Y) := by
     intro _
     have : IsSplitMono (biprod.inr ≫ e.inv : B ⟶ Y) :=

--- a/TauCeti/CategoryTheory/AlmostSplit.lean
+++ b/TauCeti/CategoryTheory/AlmostSplit.lean
@@ -22,11 +22,12 @@ These are the two lifting properties an **almost-split (Auslander-Reiten) sequen
 `0 → τM → E → M → 0` carries: `E ⟶ M` is right almost split and `τM ⟶ E` is left almost split.
 This file builds them as conditions on a single morphism of an arbitrary category, so that the
 sequence-level notion can be assembled from them, and proves the two facts that make the
-definition of an almost-split sequence non-redundant: **the target of a right almost split
-morphism is indecomposable**, and dually **the source of a left almost split morphism is
-indecomposable**. Neither end of an almost-split sequence has to be *assumed* indecomposable — the
-lifting properties already force it — and a short complex whose `g` is right almost split admits
-no splitting, so non-splitness is likewise a consequence rather than a hypothesis.
+indecomposability clauses in the definition of an almost-split sequence redundant: **the target of
+a right almost split morphism is indecomposable**, and dually **the source of a left almost split
+morphism is indecomposable**. Neither end of an almost-split sequence has to be *assumed*
+indecomposable — the lifting properties already force it — and a short complex whose `g` is right
+almost split admits no splitting, so non-splitness is likewise a consequence rather than a
+hypothesis.
 
 The connection to `TauCeti.IsIrreducibleMorphism` is the sharpened factorization
 `TauCeti.IsRightAlmostSplit.exists_isSplitMono_of_isIrreducibleMorphism`: an irreducible morphism
@@ -234,7 +235,7 @@ theorem IsRightAlmostSplit.comp_iso (hf : IsRightAlmostSplit f) {Y' : C} (e : Y 
   have hg' : ¬ IsSplitEpi (g ≫ e.symm.hom) :=
     fun _ => hg (isSplitEpi_of_isSplitEpi_comp_iso g e.symm)
   obtain ⟨h, hh⟩ := hf.factors Z (g ≫ e.symm.hom) hg'
-  exact ⟨h, by rw [← Category.assoc, hh]; simp⟩
+  exact ⟨h, by simp [reassoc_of% hh]⟩
 
 /-- **Precomposing a right almost split morphism with an isomorphism keeps it right almost
 split.** -/
@@ -242,8 +243,7 @@ theorem IsRightAlmostSplit.iso_comp (hf : IsRightAlmostSplit f) {X' : C} (e : X'
     IsRightAlmostSplit (e.hom ≫ f) := by
   refine ⟨fun _ => hf.not_isSplitEpi (isSplitEpi_of_isSplitEpi_comp e.hom f), fun Z g hg => ?_⟩
   obtain ⟨h, hh⟩ := hf.factors Z g hg
-  exact ⟨h ≫ e.inv, by rw [Category.assoc, ← Category.assoc e.inv, e.inv_hom_id,
-    Category.id_comp, hh]⟩
+  exact ⟨h ≫ e.inv, by simp [hh]⟩
 
 /-- **Precomposing a left almost split morphism with an isomorphism keeps it left almost
 split.** -/
@@ -253,7 +253,7 @@ theorem IsLeftAlmostSplit.iso_comp (hf : IsLeftAlmostSplit f) {X' : C} (e : X' �
   have hg' : ¬ IsSplitMono (e.symm.hom ≫ g) :=
     fun _ => hg (isSplitMono_of_isSplitMono_iso_comp e.symm g)
   obtain ⟨h, hh⟩ := hf.factors Z (e.symm.hom ≫ g) hg'
-  exact ⟨h, by rw [Category.assoc, hh]; simp⟩
+  exact ⟨h, by simp [hh]⟩
 
 /-- **Postcomposing a left almost split morphism with an isomorphism keeps it left almost
 split.** -/
@@ -261,8 +261,7 @@ theorem IsLeftAlmostSplit.comp_iso (hf : IsLeftAlmostSplit f) {Y' : C} (e : Y �
     IsLeftAlmostSplit (f ≫ e.hom) := by
   refine ⟨fun _ => hf.not_isSplitMono (isSplitMono_of_isSplitMono_comp f e.hom), fun Z g hg => ?_⟩
   obtain ⟨h, hh⟩ := hf.factors Z g hg
-  exact ⟨e.inv ≫ h, by rw [Category.assoc, ← Category.assoc e.hom, e.hom_inv_id,
-    Category.id_comp, hh]⟩
+  exact ⟨e.inv ≫ h, by simp [hh]⟩
 
 /-- Being right almost split is invariant under an isomorphism of the target. -/
 @[simp]


### PR DESCRIPTION
This PR builds the two lifting conditions that an almost-split (Auslander-Reiten) sequence carries at its ends — `TauCeti.IsRightAlmostSplit` and `TauCeti.IsLeftAlmostSplit` — as conditions on a single morphism of an arbitrary category, and proves that they force what the definition of such a sequence would otherwise have to assume. This is the Layer 6E target `IsAlmostSplit` of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, whose bullet reads "`IsAlmostSplit S` for a `ShortComplex S`, `0 → τM → E → M → 0`, that is `ShortComplex.ShortExact`, non-split, with `M` indecomposable non-projective and every non-split-epi `X → M` factoring through `E → M` (right almost split), dually on the left at `τM`": the two parenthesised clauses are exactly the predicates built here, and they are the prerequisite a definition of `IsAlmostSplit` consumes. The file follows the already-merged `TauCeti/CategoryTheory/IrreducibleMorphism.lean`, which implements the sibling `IsIrreducibleMorphism` target of the same layer in the same general-category form.

The mathematical content is that neither end of an almost-split sequence has to be *assumed* indecomposable and it does not have to be *assumed* non-split: `TauCeti.IsRightAlmostSplit.indecomposable` proves that the target of a right almost split morphism is indecomposable, `TauCeti.IsLeftAlmostSplit.indecomposable` that the source of a left almost split morphism is, and `TauCeti.isEmpty_splitting_of_isRightAlmostSplit` (with its left-hand twin) that a short complex whose `g` is right almost split has `IsEmpty S.Splitting`. The indecomposability proof is direct from the definition rather than through endomorphism rings, so it needs no finiteness and no field: given `Y ≅ A ⊞ B` with both summands nonzero, neither inclusion is a split epimorphism — a split mono that splits epi is invertible, and an invertible `biprod.inl` annihilates `B` — so both factor through `f`, and `biprod.total` glues the two factorizations into a section of `f`. Alongside these, `TauCeti.IsRightAlmostSplit.exists_isSplitMono_of_isIrreducibleMorphism` shows that an irreducible morphism into the target factors through a right almost split morphism *by a split monomorphism*, which is what makes the middle term of an almost-split sequence the receptacle of the irreducible morphisms into its right end and ties the sequence to the arrows of the Auslander-Reiten quiver; the file also carries the introduction and elimination rules, invariance under isomorphisms of the source and the target, and the criterion that a right almost split morphism is an epimorphism as soon as some non-split epimorphism into its target is one.

The indecomposability arguments consume all four structure maps of a binary biproduct in the form "an invertible structure map annihilates the other summand". Mathlib proves the `inl` case, `CategoryTheory.Biprod.isIso_inl_iff_isZero`, and remarks in a comment there that the three variations on it "are likely not separately useful"; that lemma is used directly, and the three remaining cases are recorded here as two-line transports of it — `TauCeti.isZero_of_isIso_biprod_inr` along `CategoryTheory.Limits.biprod.braiding`, and `TauCeti.isZero_of_isIso_biprod_fst` and `TauCeti.isZero_of_isIso_biprod_snd` by inverting `biprod.inl ≫ biprod.fst = 𝟙` and `biprod.inr ≫ biprod.snd = 𝟙`. No Mathlib code was vendored.

The lifting quantifiers range over all objects of the ambient category, which is the same choice `IrreducibleMorphism.lean` already documents and defends: for the Auslander-Reiten theory of a finite-dimensional algebra the ambient category is the finite-dimensional one, and instantiating `C` there recovers the intended notion. The module docstring records why the distinction matters — quantifying over a representation category with no finiteness restriction states a strictly stronger condition, and the existence theorem for almost-split sequences is false in that form (Paquette, arXiv:1104.1195) — so that whoever assembles the pinned `IsAlmostSplit`, which carries its finite-dimensionality side conditions explicitly, instantiates these predicates rather than reproving them. The pinned signature itself is untouched by this PR, and its `not_split`, `indec₁` and `indec₃` fields are shown here to be redundant.

New file: `TauCeti/CategoryTheory/AlmostSplit.lean` (446 lines). `lake build` and `lake exe axioms` are green, with the axiom audit reporting all declarations within `[propext, Classical.choice, Quot.sound]`.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"almost-split-morphisms"}-->

🤖 Prepared with Claude Code

