### PR TITLE
feat(Spa): a non-analytic point's trivial valuation is again a point of Spa (Wedhorn 7.42(3))

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
@@ -33,6 +33,9 @@ This file formalizes the analytic locus of the adic spectrum `Spa(A, A⁺)`.
   `Spv A` (and hence `Spa(A, A⁺)`) is analytic.
 * `TauCeti.ValuationSpectrum.spaAnalytic_eq_spa_of_isTateRing` : **Wedhorn Remark 7.40(3)**,
   for a Tate ring `A`, the analytic locus is the entire adic spectrum.
+* `TauCeti.ValuationSpectrum.trivialSection_suppFun_mem_spa` : **Wedhorn Remark 7.42(3)** —
+  for a non-analytic point, the trivial valuation at its support is again a point of the adic
+  spectrum.
 * `TauCeti.ValuationSpectrum.isOpen_val_preimage_spaAnalytic` : the analytic locus is open.
 * `TauCeti.ValuationSpectrum.spaAnalytic_eq_biUnion_rationalSubset` : generators of an ideal of
   definition give a finite rational cover of the analytic locus.
@@ -41,8 +44,8 @@ This file formalizes the analytic locus of the adic spectrum `Spa(A, A⁺)`.
 
 ## References
 
-* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.39, Remark 7.40(3), and
-  Proposition 7.49.
+* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.39, Remark 7.40(3),
+  Remark 7.42(3), and Proposition 7.49.
 -/
 
 public section
@@ -89,6 +92,21 @@ theorem spaAnalytic_subset_spa (Aplus : Subring A) :
 /-- Enlarging the plus ring shrinks the analytic locus. -/
 theorem spaAnalytic_antitone : Antitone (spaAnalytic (A := A)) := fun _ _ hle ↦
   Set.inter_subset_inter_left _ (spa_antitone hle)
+
+/-- **Wedhorn Remark 7.42(3).** For a *non-analytic* point `v`, the trivial valuation at `supp v`
+is again a point of the adic spectrum. Wedhorn obtains it as the vertical generization `v/Γ_v`;
+that construction is not yet available here, so this states the trivial-valuation form directly,
+which is what the generization is.
+
+Non-analyticity is definitionally the openness of `supp v`, so the hypothesis *is* the input
+`trivialSection_mem_spa` asks for and nothing has to be derived. Two hypotheses Wedhorn's statement
+carries are therefore absent here: `v` need not itself lie in `spa Aplus`, and `A` need not be a
+topological ring. -/
+theorem trivialSection_suppFun_mem_spa (Aplus : Subring A) {v : Spv A}
+    (hv : ¬ IsAnalyticPoint v) : trivialSection (suppFun v) ∈ spa Aplus := by
+  refine trivialSection_mem_spa Aplus ?_
+  rw [suppFun_asIdeal]
+  exact not_not.mp ((isAnalyticPoint_def v).not.mp hv)
 
 section TopologicalRing
 


### PR DESCRIPTION
Wedhorn's Remark 7.42(3): if a point `v` of `Spv A` is **not** analytic, the trivial valuation at
`supp v` is again a point of the adic spectrum.

Adds one declaration, `TauCeti.ValuationSpectrum.trivialSection_suppFun_mem_spa`, in
`TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean`. No other declaration is touched and no
import is added.

## What the proof is

Wedhorn reaches this through the vertical generization `v/Γ_v`, observing that for a non-analytic
point that generization *is* the trivial valuation at `supp v`. The `v/H` construction is not on
`main` yet, so this states the trivial-valuation form directly — the same object, not a weakening.

It is three lines because non-analyticity is *definitionally* the openness of `supp v`
(`isAnalyticPoint_def`), and openness is exactly the input `trivialSection_mem_spa` takes. Nothing
has to be derived; the content is that the two vocabularies line up. The one wrinkle is the module
boundary: `suppFun` is sealed, so `(suppFun v).asIdeal` does not reduce to `v.supp` during
elaboration, and `suppFun_asIdeal` has to be rewritten with explicitly rather than left to defeq.

## Generality

Two hypotheses Wedhorn's statement carries are absent here, deliberately:

* `v` need not itself lie in `spa Aplus` — only non-analyticity is used;
* `A` need not be a topological ring, so this sits in the file's unconstrained section rather than
  under `section TopologicalRing`.

A trivial valuation is sub-unit on *every* subring, which is why `Aplus` carries no condition.

## Not a duplicate

`trivialSection_mem_spa` (`Spa/Basic.lean:143`) is the general open-prime fact and is **reused**,
not restated; `exists_mem_spa_supp_eq` (`Spa/Points.lean`) is its existence form for an ideal given
directly rather than as a support. Nothing on `main` mentions Remark 7.42 — verified by grep over
`TauCeti/` with an absent-name control.

I originally planned to extract `trivialSection_mem_spa` myself out of `exists_mem_spa_supp_eq`'s
proof body; #5020 landed exactly that extraction while this was being built, so that half was
dropped and this PR now reuses it. That is why the diff is one theorem rather than a refactor.

## Gate

`lake build` of the changed module — 2129 jobs, exit 0, **zero** `error:`/`warning:`/`info:`
diagnostics. `lake exe runLinter` clean. No line over 100 characters. The branch is exactly at
`origin/main` (0 behind, 0 ahead) and touches one file.

Roadmap: AdicSpaces
