### PR TITLE
refactor(Spa): generalise the 7.49(1) converse to any open ideal

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean
@@ -54,8 +54,10 @@ it; the subspace form here needs no such comparison.)
 * `TauCeti.ValuationSpectrum.spa_eq_empty_of_one_mem_closure_zero` : if `1 ∈ closure {0}` in a
   commutative ring `A` with separately continuous addition, then `Spa(A, A⁺) = ∅` for any plus
   ring `A⁺` (the `1 ∈ closure {0} → Spa(A, A⁺) = ∅` half of Wedhorn Proposition 7.49(1)).
-* `TauCeti.ValuationSpectrum.trivialSection_mem_spa` : the trivial valuation of an open prime is
-  a point of the adic spectrum, for any plus ring.
+* `TauCeti.ValuationSpectrum.trivialSection_mem_spa_iff` : the trivial valuation of a prime is a
+  point of the adic spectrum exactly when the prime is open, for any plus ring.
+* `TauCeti.ValuationSpectrum.eq_top_of_spa_eq_empty` : an empty adic spectrum forces every open
+  ideal to be the unit ideal.
 * `TauCeti.ValuationSpectrum.one_mem_closure_zero_of_spa_eq_empty` : the converse half of
   Wedhorn Proposition 7.49(1) — over a topological ring in which `closure {0}` is open, an empty
   adic spectrum forces `1 ∈ closure {0}`.
@@ -65,9 +67,21 @@ The openness of `closure {0}` is Wedhorn 7.49(2) and is taken as a hypothesis he
 Wedhorn's proof of 7.49(1) takes it; proving it needs the microbiality substrate and is not done
 in this file.
 
+## Provenance
+
+`trivialSection_mem_spa_iff` is the trivial-valuation witness of AINTLIB
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0), branch `dev/adic-spaces` at commit
+`37bbdaeb9ad9e3bc9f0d660feadc2779e455a91c`, project `projects/AdicSpaces/`, file
+`Adic spaces/AdicSpectrum.lean`, section `Prop752`, with the valuation-spectrum vocabulary adapted
+to this repository's `Spv`/`ValuativeRel` interface and the introduction direction strengthened to
+an equivalence. It reached this file by being factored out of
+`TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean`, which had used it inline.
+
 ## References
 
 * T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Definition 7.23 and Proposition 7.49.
+* [C. Birkbeck, *AINTLIB*](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
+  commit `37bbdaeb`, `projects/AdicSpaces/Adic spaces/AdicSpectrum.lean`.
 -/
 
 public section
@@ -126,6 +140,17 @@ theorem spa_integralClosure (R : Subring A) :
     rw [Valuation.mem_integer_iff, ← map_one v.valuation, valuation_le_iff] at hxint
     exact hxint
 
+/-- The trivial valuation of a prime `p` is a point of the adic spectrum exactly when `p` is open,
+for any plus ring `A⁺`: the sub-unit condition holds at every element of `A`, since a trivial
+valuation takes only the values `0` and `1` and `1` lies outside a prime. -/
+theorem trivialSection_mem_spa_iff (Aplus : Subring A) (p : PrimeSpectrum A) :
+    trivialSection p ∈ spa Aplus ↔ IsOpen (p.asIdeal : Set A) := by
+  rw [mem_spa_iff]
+  refine ⟨fun h ↦ (isContinuous_trivialSection_iff p).mp h.1,
+    fun hp ↦ ⟨(isContinuous_trivialSection_iff p).mpr hp, fun a _ ↦ ?_⟩⟩
+  exact (trivialSection_vle_iff p a 1).mpr
+    (Or.inr ((Ideal.ne_top_iff_one _).mp p.isPrime.ne_top))
+
 section SeparatelyContinuousAdd
 
 variable [SeparatelyContinuousAdd A]
@@ -137,42 +162,39 @@ theorem spa_eq_empty_of_one_mem_closure_zero (Aplus : Subring A)
     (h : (1 : A) ∈ closure ({0} : Set A)) : spa Aplus = ∅ := by
   rw [spa_def, cont_eq_empty_of_one_mem_closure_zero h, Set.empty_inter]
 
-omit [SeparatelyContinuousAdd A] in
-/-- The trivial valuation of an open prime is a point of the adic spectrum, for any plus ring:
-`A⁺` is unconstrained because a trivial valuation is sub-unit on all of `A`. -/
-theorem trivialSection_mem_spa (Aplus : Subring A) {p : PrimeSpectrum A}
-    (hp : IsOpen (p.asIdeal : Set A)) : trivialSection p ∈ spa Aplus := by
-  rw [mem_spa_iff]
-  refine ⟨(isContinuous_trivialSection_iff p).mpr hp, fun a _ ↦ ?_⟩
-  exact (trivialSection_vle_iff p a 1).mpr
-    (Or.inr ((Ideal.ne_top_iff_one _).mp p.isPrime.ne_top))
+/-- **An empty adic spectrum forces every open ideal to be the unit ideal.** A proper open ideal
+would lie in a maximal ideal, which is then open too, and the trivial valuation there would be a
+point of `Spa (A, A⁺)`.
 
-omit [SeparatelyContinuousAdd A] in
+This is the content of the converse half of Wedhorn Proposition 7.49(1); nothing about
+`closure {0}` is used, only that the ideal is open. -/
+theorem eq_top_of_spa_eq_empty (Aplus : Subring A) {I : Ideal A}
+    (hI : IsOpen (I : Set A)) (h : spa Aplus = ∅) : I = ⊤ := by
+  by_contra hne
+  obtain ⟨m, hm, hle⟩ := Ideal.exists_le_maximal I hne
+  have hopen : IsOpen ((m : Set A)) :=
+    AddSubgroup.isOpen_mono (H₁ := I.toAddSubgroup) (H₂ := m.toAddSubgroup) hle hI
+  have hmem : trivialSection ⟨m, hm.isPrime⟩ ∈ spa Aplus :=
+    (trivialSection_mem_spa_iff Aplus _).mpr hopen
+  rw [h] at hmem
+  exact Set.notMem_empty _ hmem
+
 /-- **The `Spa (A, A⁺) = ∅ → 1 ∈ closure {0}` half of Wedhorn Proposition 7.49(1)**, the converse
 of `spa_eq_empty_of_one_mem_closure_zero`, under the hypothesis that `closure {0}` is open.
 
-The openness hypothesis is Wedhorn 7.49(2) and is *not* proved here: it needs the microbiality
-substrate, and is taken as given exactly as Wedhorn's proof takes it. -/
+That openness is not proved here. It is what Wedhorn's proof of 7.49(1) extracts from 7.49(2) once
+the adic spectrum is empty, via the separated-quotient item 7.49(2)(iii); discharging it needs the
+Huber hypotheses 7.49(2) carries, which this statement does not assume. -/
 theorem one_mem_closure_zero_of_spa_eq_empty [IsTopologicalRing A] (Aplus : Subring A)
     (hopen : IsOpen (closure ({0} : Set A))) (h : spa Aplus = ∅) :
     (1 : A) ∈ closure ({0} : Set A) := by
-  by_contra h1
-  -- `closure {0}` is an ideal, and by hypothesis a proper one
   have hcoe : ((Ideal.closure (⊥ : Ideal A) : Ideal A) : Set A) = closure ({0} : Set A) := by
-    simp [Ideal.closure]
-  have hne : Ideal.closure (⊥ : Ideal A) ≠ ⊤ := by
-    rw [Ne, Ideal.eq_top_iff_one]
-    rw [← SetLike.mem_coe, hcoe]
-    exact h1
-  obtain ⟨m, hm, hle⟩ := Ideal.exists_le_maximal _ hne
-  -- a prime above an open ideal is open, so its trivial valuation is a point of `Spa`
-  have hopen' : IsOpen ((m : Set A)) :=
-    Submodule.isOpen_mono hle (by rw [← hcoe] at hopen; exact hopen)
-  have hmem : trivialSection ⟨m, hm.isPrime⟩ ∈ spa Aplus := trivialSection_mem_spa Aplus hopen'
-  rw [h] at hmem
-  exact hmem
+    rw [Ideal.coe_closure, Submodule.bot_coe]
+  have htop : Ideal.closure (⊥ : Ideal A) = ⊤ :=
+    eq_top_of_spa_eq_empty Aplus (by rw [hcoe]; exact hopen) h
+  rw [← hcoe, htop]
+  exact Submodule.mem_top
 
-omit [SeparatelyContinuousAdd A] in
 /-- **Wedhorn Proposition 7.49(1)**, both directions, once `closure {0}` is open: the adic
 spectrum is empty exactly when `1` lies in the closure of zero. -/
 theorem spa_eq_empty_iff_one_mem_closure_zero [IsTopologicalRing A] (Aplus : Subring A)

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Points.lean
@@ -33,11 +33,12 @@ it is supplied by `Ideal.isOpen_of_isMaximal_of_isOpen_isTopologicallyNilpotent`
 
 ## Provenance
 
-Adapted from AINTLIB (see References), section `Prop752` of the source file: the
-trivial-valuation witness and the derivation of 7.52(2) are that file's, with the
-valuation-spectrum vocabulary adapted to this repository's `Spv`/`ValuativeRel` interface
-(`trivialSection`, `mem_spa_iff`, `supp`) and the statement of 7.51 weakened from maximal to
-prime ideals.
+Adapted from AINTLIB (see References), section `Prop752` of the source file: the derivation of
+7.52(2) is that file's, with the valuation-spectrum vocabulary adapted to this repository's
+`Spv`/`ValuativeRel` interface (`trivialSection`, `mem_spa_iff`, `supp`) and the statement of 7.51
+weakened from maximal to prime ideals. The trivial-valuation witness is also that file's, but it no
+longer lives here: it was factored out as `trivialSection_mem_spa_iff` in
+`TauCeti/AlgebraicGeometry/AdicSpace/Spa/Basic.lean`, which carries the credit for it.
 
 ## References
 
@@ -58,7 +59,7 @@ point of the adic spectrum — the point of its trivial valuation, `trivialSecti
 Wedhorn states the proposition for maximal ideals; the proof needs only primality. -/
 theorem exists_mem_spa_supp_eq (Aplus : Subring A) (𝔭 : Ideal A) [𝔭.IsPrime]
     (h𝔭 : IsOpen (𝔭 : Set A)) : ∃ v ∈ spa Aplus, supp v = 𝔭 := by
-  refine ⟨trivialSection ⟨𝔭, ‹_›⟩, trivialSection_mem_spa Aplus h𝔭, ?_⟩
+  refine ⟨trivialSection ⟨𝔭, ‹_›⟩, (trivialSection_mem_spa_iff Aplus _).mpr h𝔭, ?_⟩
   rw [← suppFun_asIdeal, suppFun_trivialSection]
 
 /-- **The converse half of Wedhorn Corollary 7.53.** If every maximal ideal of `A` is open and


### PR DESCRIPTION
Answers six review findings from #5020, which merged before they were answered.

## generality — the main change

`one_mem_closure_zero_of_spa_eq_empty` proved a special case of its own argument: nothing about `closure {0}` was used beyond its being an open ideal. The general statement is now

```lean
theorem eq_top_of_spa_eq_empty (Aplus : Subring A) {I : Ideal A}
    (hI : IsOpen (I : Set A)) (h : spa Aplus = ∅) : I = ⊤
```

and the `closure {0}` form is a corollary of it.

This also removes `[IsTopologicalRing A]` from the general result. That hypothesis was never mathematically needed — it entered only via `Submodule.isOpen_mono` and `Ideal.closure`, and `AddSubgroup.isOpen_mono` does the same work at the file's ambient `[SeparatelyContinuousAdd A]`.

**Why it was there at all, since it bears on trusting the rest of this PR.** While writing #5020 I hit `Unknown constant 'AddSubgroup.isOpen_mono'`, concluded from a grep for `^theorem .*isOpen_mono` that only `Submodule.isOpen_mono` existed, and routed the proof through it. Both steps were wrong: the error was a missing *import*, and `OpenSubgroup.lean` carries `@[to_additive]` on `Subgroup.isOpen_mono`, so the additive twin is generated and has **no source text to grep**. Absence of source is not absence of a declaration.

## The other five

- **api-design** — `trivialSection_mem_spa` stated only the introduction direction while its cont-level analogue `isContinuous_trivialSection_iff` is an equivalence. The converse is free via `mem_spa_iff`, so it becomes `trivialSection_mem_spa_iff`.
- **placement** — all three declarations sat inside `section SeparatelyContinuousAdd` without wanting it, two cancelling it with `omit`. The section *boundary* was the thing misplaced: the iff now sits above the section, and both `omit`s are gone.
- **correctness** — the docstring claimed the openness of `closure {0}` "is Wedhorn 7.49(2)". It is not: 7.49(2) is the analytic-locus proposition, and openness is what Wedhorn's proof of 7.49(1) *extracts* from it once the spectrum is empty (via 7.49(2)(iii)), using Huber hypotheses this statement does not assume.
- **attribution** — the witness is AINTLIB's `Prop752` argument, and factoring it out of `Points.lean` in #5020 left the credit behind, describing code that had moved. `Spa/Basic.lean` now carries the provenance paragraph and the reference, mirroring `Cont/Basic.lean`'s wording; `Points.lean` records where the witness went.
- **proof-quality** — `simp [Ideal.closure]` unfolded the definition's structure body instead of the `@[simp]` coercion lemma (now `Ideal.coe_closure` / `Submodule.bot_coe`), and the contradiction was closed by undocumented defeq through the `EmptyCollection` instance (now `Set.notMem_empty`).

## Note on scope

Two further complaints in that review round are **not** addressed here because they were already fixed before #5020 merged: it reviewed head `7db05f007`, whereas `bdb4e4911` is what landed. The `trivialSection_mem_spa` docstring wording it quotes verbatim had already been replaced, and the redundant instance binder on the combined iff had already been omitted.

## Verification

`lake build TauCeti.AlgebraicGeometry.AdicSpace.Spa.Basic TauCeti.AlgebraicGeometry.AdicSpace.Spa.Points` — exit 0, 2044 jobs, no errors, warnings, or `info:` diagnostics. Branched off current `origin/main` (0 commits behind at push). No line over 100 characters; no `sorry`.

Roadmap: AdicSpaces
