### PR TITLE
refactor(Sobolev): name the uniform translation estimate in Rellich–Kondrachov

### DIFF
--- a/TauCeti/Analysis/Sobolev/RellichKondrachov.lean
+++ b/TauCeti/Analysis/Sobolev/RellichKondrachov.lean
@@ -104,6 +104,39 @@ private theorem W1p0.eLpNorm_valueExtendByZeroL_comp_add_sub_le_mul_enorm_gradie
   rw [W1p0.coeFn_valueExtendByZeroL_eq_value]
   exact W1p0.eLpNorm_value_extendByZeroL_comp_add_sub_le_mul_enorm_gradient hp h u
 
+/-- **Translation acts uniformly small on the unit ball of `W1p0`.** For every `epsilon` there is a
+`delta` such that extending any `u` of norm below one by zero and translating by an `h` with
+`‖h‖ < delta` moves it in `L^p` by at most `epsilon`. This is the equicontinuity hypothesis of the
+Fréchet–Kolmogorov criterion; it follows from the Sobolev translation estimate together with
+`‖∇u‖ ≤ ‖u‖`. -/
+private theorem W1p0.exists_forall_eLpNorm_valueExtendByZeroL_comp_add_sub_le (hp : p ≠ ∞)
+    (epsilon : ENNReal) (hepsilon : 0 < epsilon) :
+    ∃ delta > 0, ∀ u : W1p0 mu Omega p, ‖u‖ < 1 → ∀ h : E, ‖h‖ < delta →
+      eLpNorm (fun x => W1p0.valueExtendByZeroL u (x + h) -
+        W1p0.valueExtendByZeroL u x) p mu ≤ epsilon := by
+  let eta : ENNReal := min epsilon 1
+  have heta_pos : 0 < eta := lt_min hepsilon zero_lt_one
+  have heta_top : eta ≠ ∞ := (min_le_right epsilon 1).trans_lt ENNReal.one_lt_top |>.ne
+  refine ⟨eta.toReal, ENNReal.toReal_pos heta_pos.ne' heta_top, fun u hu h hh => ?_⟩
+  have hh' : ‖h‖ₑ ≤ eta := by
+    rw [← ofReal_norm]
+    exact (ENNReal.ofReal_le_iff_le_toReal heta_top).2 hh.le
+  have hu' : ‖u‖ₑ ≤ 1 :=
+    calc ‖u‖ₑ ≤ ‖(1 : ℝ)‖ₑ := enorm_le_iff_norm_le.mpr (by simpa using hu.le)
+      _ = 1 := by simp
+  calc
+    eLpNorm (fun x => W1p0.valueExtendByZeroL u (x + h) -
+        W1p0.valueExtendByZeroL u x) p mu
+        ≤ ‖h‖ₑ * ‖W1p.gradient (u : W1p mu Omega p)‖ₑ :=
+          W1p0.eLpNorm_valueExtendByZeroL_comp_add_sub_le_mul_enorm_gradient
+            (mu := mu) (Omega := Omega) hp u h
+    _ ≤ ‖h‖ₑ * ‖u‖ₑ := by
+      gcongr
+      exact enorm_le_iff_norm_le.mpr (W1p.norm_gradient_le _)
+    _ ≤ eta * 1 := mul_le_mul' hh' hu'
+    _ = eta := mul_one eta
+    _ ≤ epsilon := min_le_left _ _
+
 private theorem W1p0.isCompactOperator_valueExtendByZeroL (hp : p ≠ ∞)
     (hOmega : IsBounded (Omega : Set E)) :
     IsCompactOperator
@@ -133,30 +166,13 @@ private theorem W1p0.isCompactOperator_valueExtendByZeroL (hp : p ≠ ∞)
   have htrans : ∀ epsilon : ENNReal, 0 < epsilon → ∃ delta > 0, ∀ f ∈ S, ∀ h : E,
       ‖h‖ < delta → eLpNorm (fun x => f (x + h) - f x) p mu ≤ epsilon := by
     intro epsilon hepsilon
-    let eta : ENNReal := min epsilon 1
-    have heta_pos : 0 < eta := lt_min hepsilon zero_lt_one
-    have heta_top : eta ≠ ∞ := (min_le_right epsilon 1).trans_lt ENNReal.one_lt_top |>.ne
-    refine ⟨eta.toReal, ENNReal.toReal_pos heta_pos.ne' heta_top, fun f hf h hh => ?_⟩
+    obtain ⟨delta, hdelta, hbound⟩ :=
+      W1p0.exists_forall_eLpNorm_valueExtendByZeroL_comp_add_sub_le
+        (mu := mu) (Omega := Omega) hp epsilon hepsilon
+    refine ⟨delta, hdelta, fun f hf h hh => ?_⟩
     obtain ⟨u, hu, rfl⟩ := hf
     rw [mem_ball, dist_zero_right] at hu
-    have hh' : ‖h‖ₑ ≤ eta := by
-      rw [← ofReal_norm]
-      exact (ENNReal.ofReal_le_iff_le_toReal heta_top).2 hh.le
-    have hu' : ‖u‖ₑ ≤ 1 :=
-      calc ‖u‖ₑ ≤ ‖(1 : ℝ)‖ₑ := enorm_le_iff_norm_le.mpr (by simpa using hu.le)
-        _ = 1 := by simp
-    calc
-      eLpNorm (fun x => W1p0.valueExtendByZeroL u (x + h) -
-          W1p0.valueExtendByZeroL u x) p mu
-          ≤ ‖h‖ₑ * ‖W1p.gradient (u : W1p mu Omega p)‖ₑ :=
-            W1p0.eLpNorm_valueExtendByZeroL_comp_add_sub_le_mul_enorm_gradient
-              (mu := mu) (Omega := Omega) hp u h
-      _ ≤ ‖h‖ₑ * ‖u‖ₑ := by
-        gcongr
-        exact enorm_le_iff_norm_le.mpr (W1p.norm_gradient_le _)
-      _ ≤ eta * 1 := mul_le_mul' hh' hu'
-      _ = eta := mul_one eta
-      _ ≤ epsilon := min_le_left _ _
+    exact hbound u hu h hh
   -- The criterion makes the extended image relatively compact.
   have hcompact : IsCompact (closure S) :=
     isCompact_closure_of_comp_add_sub_of_isBounded_of_ae_eq_zero_compl


### PR DESCRIPTION
Name the uniform translation estimate that the Rellich–Kondrachov compactness proof passes to
Fréchet–Kolmogorov.

## What moved

`W1p0.isCompactOperator_valueExtendByZeroL` verifies the three hypotheses of the
Fréchet–Kolmogorov criterion inline. The third, equicontinuity, was the bulk of it: a 27-line
`have htrans` establishing that translation acts uniformly small on the image of the unit ball.
That step is about `W1p0` and zero-extension, not about compactness, and it now has a name.

```lean
private theorem W1p0.exists_forall_eLpNorm_valueExtendByZeroL_comp_add_sub_le (hp : p ≠ ∞)
    (epsilon : ENNReal) (hepsilon : 0 < epsilon) :
    ∃ delta > 0, ∀ u : W1p0 mu Omega p, ‖u‖ < 1 → ∀ h : E, ‖h‖ < delta →
      eLpNorm (fun x => W1p0.valueExtendByZeroL u (x + h) -
        W1p0.valueExtendByZeroL u x) p mu ≤ epsilon
```

Measured as source lines of the proof body — the lines after `:= by`, which is what a reviewer
reading the file counts:

| | before | after |
|---|---|---|
| `…isCompactOperator_valueExtendByZeroL` proof body | 57 | **40** |
| its `have htrans` block, within that | 27 | 10 |
| the named estimate's own proof body | — | 22 |

By non-blank comment-stripped code lines the parent goes 54 → 37; the extracted proof is 22 either
way. No line is over 100 characters.

## The statement is over `u`, not over the image set

In the parent the block quantified over `f ∈ S`, where `S := T '' ball 0 1` and both `S` and `T`
are `let`-bound. Extracting it in that shape would have dragged both `let`s into the helper's
interface — and a block lifted out of a `let` binding depends on that binding's definitional
transparency, which a parameter with a defining equation does not reproduce.

It turned out not to need any of that. The block's own first move is

```lean
    obtain ⟨u, hu, rfl⟩ := hf
```

so `S` was **presentation, not interface**: the proof immediately discards the membership and works
with the pre-image `u`. Restating over `u : W1p0 mu Omega p` with `‖u‖ < 1` removes both `let`s from
the picture entirely, and the helper's hypotheses come down to `hp`, `epsilon` and `hepsilon`.

The parent keeps the `S`-shaped statement the criterion wants, and now gets it by destructuring
into the lemma:

```lean
    intro epsilon hepsilon
    obtain ⟨delta, hdelta, hbound⟩ :=
      W1p0.exists_forall_eLpNorm_valueExtendByZeroL_comp_add_sub_le
        (mu := mu) (Omega := Omega) hp epsilon hepsilon
    refine ⟨delta, hdelta, fun f hf h hh => ?_⟩
    obtain ⟨u, hu, rfl⟩ := hf
    rw [mem_ball, dist_zero_right] at hu
    exact hbound u hu h hh
```

The two named arguments are needed and minimal: `obtain … := term` elaborates with no expected
type, so the file's `variable`s stay metavariables and `Measure.IsAddHaarMeasure ?m` is stuck
without `mu`. I checked the alternatives by building each — dropping `(p := p)` is fine because
`hp : p ≠ ∞` determines `p`, and dropping `mu`/`Omega` as well fails with that stuck instance. The
surviving form is character-for-character the one already used at line 132 of this same file, and
`hcompact` immediately below supplies its parameters the same way.

## Notes for review

- Gate: `lake build` of the changed module — exit 0, `Build completed successfully (3072 jobs)`,
  zero warnings. `RellichKondrachov` is a **leaf** (0 importers; control: the same query returns 1
  for `Analysis.Sobolev.Translation`, namely this file), so that is the complete module-scoped gate.
- Contention: the file is untouched by all **128** open PRs (full `--json files` scan, 309 file
  entries; positive control — the same query returns #5044 for
  `CongruenceSubgroups/Basic.lean`), and no unmerged ref touches it. #4947, which created the file,
  merged at 10:13Z today and is on this base.
- Not a mathlib duplicate: the statement is about `W1p0.valueExtendByZeroL`, a TauCeti object. The
  declined ledger has no entry for it.
- **Cleanup.** `/cleanup`'s whole-file mode would rewrite a file this PR barely touches, so I ran
  its per-declaration checks by hand on the two declarations involved instead of the file-wide
  pass, and I am naming that rather than claiming a full run. Checked: the build is warning-free,
  so no linter fires on these lines; the longest line in the file is 99 codepoints and none exceeds
  100; the new declaration carries a docstring; each of its three hypotheses `hp`, `epsilon`,
  `hepsilon` is used in the body; and no declaration other than the two involved is touched. The
  single `by simp` inside the extracted proof is moved verbatim from the parent, not new.

Roadmap: PDE
