### PR TITLE
refactor(MvPolynomial): derive finite_map and the Frobenius identity from existing API

### DIFF
--- a/TauCeti/RingTheory/MvPolynomial/Basic.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Basic.lean
@@ -7,6 +7,8 @@ module
 
 public import Mathlib.RingTheory.Finiteness.Basic
 public import Mathlib.RingTheory.MvPolynomial.Basic
+public import Mathlib.RingTheory.TensorProduct.MvPolynomial
+public import TauCeti.LinearAlgebra.Dimension.BaseChange
 
 /-!
 # Finiteness of `MvPolynomial.map`
@@ -37,40 +39,25 @@ public section
 
 namespace TauCeti
 
+-- `MvPolynomial.algebraMvPolynomial` is deliberately not a global instance: it diamonds for
+-- `Algebra (MvPolynomial σ R) (MvPolynomial σ (MvPolynomial σ S))`. Mathlib installs it locally
+-- wherever the `MvPolynomial σ R`-algebra structure on `MvPolynomial σ S` is wanted, and the
+-- pushout and scalar-tower instances used below are stated under it.
+attribute [local instance] MvPolynomial.algebraMvPolynomial
+
 /-- Polynomial rings preserve module-finiteness of the coefficient map: `MvPolynomial.map f` is
 a finite ring map whenever `f` is. -/
 theorem MvPolynomial.finite_map {σ R S : Type*} [CommRing R] [CommRing S] {f : R →+* S}
     (hf : f.Finite) : (MvPolynomial.map (σ := σ) f).Finite := by
-  classical
   let _ : Algebra R S := f.toAlgebra
-  obtain ⟨t, htfin, ht⟩ := Submodule.fg_def.mp (Module.finite_def.mp hf)
-  let _ : Algebra (MvPolynomial σ R) (MvPolynomial σ S) := (MvPolynomial.map (σ := σ) f).toAlgebra
-  refine Module.finite_def.mpr (Submodule.fg_def.mpr
-    ⟨MvPolynomial.C '' t, htfin.image _, eq_top_iff.mpr fun p _ ↦ ?_⟩)
-  refine MvPolynomial.induction_on' p (fun α c ↦ ?_) (fun p q hp hq ↦ Submodule.add_mem _ hp hq)
-  refine Submodule.span_induction
-    (p := fun c _ ↦ MvPolynomial.monomial α c ∈
-      Submodule.span (MvPolynomial σ R) (MvPolynomial.C '' t))
-    ?_ ?_ ?_ ?_ (ht ▸ Submodule.mem_top : c ∈ Submodule.span R t)
-  · -- a generator `x ∈ t`, as the constant `C x`, scaled by the monomial `X ^ α`
-    intro x hx
-    have hx' : MvPolynomial.monomial α x
-        = (MvPolynomial.monomial α (1 : R)) • (MvPolynomial.C x : MvPolynomial σ S) := by
-      rw [Algebra.smul_def, RingHom.algebraMap_toAlgebra]
-      rw [MvPolynomial.map_monomial, map_one, mul_comm, MvPolynomial.C_mul_monomial, mul_one]
-    rw [hx']
-    exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨x, hx, rfl⟩)
-  · simp
-  · intro x y _ _ hx hy
-    rw [map_add]
-    exact Submodule.add_mem _ hx hy
-  · -- an `R`-scalar becomes the constant `C r` acting through `MvPolynomial.map f`
-    intro r x _ hx
-    have hr : MvPolynomial.monomial α (r • x)
-        = (MvPolynomial.C r : MvPolynomial σ R) • MvPolynomial.monomial α x := by
-      rw [Algebra.smul_def, RingHom.algebraMap_toAlgebra, Algebra.smul_def,
-        RingHom.algebraMap_toAlgebra, MvPolynomial.map_C, MvPolynomial.C_mul_monomial]
-    rw [hr]
-    exact Submodule.smul_mem _ _ hx
+  have _ : Module.Finite R S := hf
+  -- `MvPolynomial σ S` is the base change of `S` along `R → MvPolynomial σ R`. Stating that as a
+  -- `have` is load-bearing: unifying `finite_of_isBaseChange` against the goal directly forces the
+  -- `MvPolynomial σ R`-algebra structure to be `(MvPolynomial.map f).toAlgebra`, for which the
+  -- scalar tower is not an instance, whereas Mathlib's pushout is stated for `algebraMvPolynomial`.
+  have h : Module.Finite (MvPolynomial σ R) (MvPolynomial σ S) :=
+    TauCeti.finite_of_isBaseChange
+      (Algebra.IsPushout.out (R := R) (S := MvPolynomial σ R) (R' := S) (S' := MvPolynomial σ S))
+  exact h
 
 end TauCeti

--- a/TauCeti/RingTheory/MvPolynomial/Expand.lean
+++ b/TauCeti/RingTheory/MvPolynomial/Expand.lean
@@ -5,10 +5,10 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Algebra.CharP.Lemmas
 public import Mathlib.Algebra.MvPolynomial.Expand
 public import Mathlib.RingTheory.Finiteness.Basic
 public import Mathlib.RingTheory.MvPolynomial.Basic
+public import Mathlib.RingTheory.MvPolynomial.Expand
 
 /-!
 # Finiteness of `MvPolynomial.expand`
@@ -157,12 +157,17 @@ theorem MvPolynomial.exists_pow_eq_map_expand {σ R S : Type*} [CommSemiring R] 
     · exact ⟨0, fun h ↦ absurd h hi⟩
   choose d hd using hg'
   refine ⟨∑ α ∈ g.support, MvPolynomial.monomial α (d α), ?_⟩
-  -- Frobenius is additive, so the `p ^ n`-th power is taken monomial by monomial
-  rw [sum_pow_char_pow]
-  conv_rhs => rw [MvPolynomial.as_sum g]
-  rw [map_sum, map_sum]
-  refine Finset.sum_congr rfl fun α hα ↦ ?_
-  rw [MvPolynomial.monomial_pow, hd α hα, MvPolynomial.expand_monomial,
-    MvPolynomial.map_monomial]
+  -- the chosen-root polynomial maps under the iterated Frobenius to `map f g`
+  have hmap : MvPolynomial.map (iterateFrobenius S p n)
+      (∑ α ∈ g.support, MvPolynomial.monomial α (d α)) = MvPolynomial.map f g := by
+    rw [map_sum]
+    conv_rhs => rw [MvPolynomial.as_sum g]
+    rw [map_sum]
+    refine Finset.sum_congr rfl fun α hα ↦ ?_
+    rw [MvPolynomial.map_monomial, MvPolynomial.map_monomial, iterateFrobenius_def, hd α hα]
+  -- so Mathlib's Frobenius/expand identity supplies the power, with `map_expand` moving `map`
+  -- past `expand` on each side
+  rw [← MvPolynomial.map_iterateFrobenius_expand (p := p) _ n, MvPolynomial.map_expand, hmap,
+    ← MvPolynomial.map_expand]
 
 end TauCeti


### PR DESCRIPTION
Completes the two-item `reuse` finding from #4886, which merged with neither item applied.

## The two changes

**`finite_map`** reconstructed finite generation by hand — a `span_induction` over an `R`-generating set, transporting monomials one at a time. `TauCeti.finite_of_isBaseChange` already transports finiteness along a base change, and `MvPolynomial σ S` *is* the base change of `S` along `R → MvPolynomial σ R`; Mathlib supplies exactly that pushout as `Algebra.IsPushout R (MvPolynomial σ R) S (MvPolynomial σ S)` (`RingTheory/TensorProduct/MvPolynomial.lean:181`), whose `.out` is the `IsBaseChange` the lemma consumes. **32 proof lines become 6.**

**`exists_pow_eq_map_expand`** expanded sums and monomial powers to rederive Mathlib's `MvPolynomial.map_iterateFrobenius_expand`. It now proves the chosen-root polynomial maps under `iterateFrobenius` to `map f g` and appeals to that identity, with `map_expand` moving `map` past `expand` on each side. This removes the only use of `sum_pow_char_pow`, and with it the `Mathlib.Algebra.CharP.Lemmas` import.

## On the earlier contest — please read before re-clearing

The first item was contested on #4886 and the finding was cleared. I want to be explicit that **the contest was made in good faith and its diagnosis was correct**, because this PR reverses its conclusion and the reasoning deserves to be on the record rather than silently overridden.

The contest reported three build attempts all failing on:

```
failed to synthesize instance of type class
  IsScalarTower R (MvPolynomial σ R) (MvPolynomial σ S)
```

and diagnosed it exactly right: `RingHom.Finite` is `Module.Finite` for `f.toAlgebra`, whereas the pushout and scalar-tower instances are stated for `MvPolynomial.algebraMvPolynomial`. Unifying `finite_of_isBaseChange` against the goal directly forces the former, for which that tower is not an instance. I hit the same wall.

What the analysis missed is that the two algebra structures are **defeq** — their `algebraMap`s agree by `rfl` (`Algebra/MvPolynomial/Eval.lean`) — so the obstruction is only in *unification order*, not in mathematics. Stating the result against `algebraMvPolynomial` in an intermediate `have` and then transferring it discharges the goal:

```lean
have h : Module.Finite (MvPolynomial σ R) (MvPolynomial σ S) :=
  TauCeti.finite_of_isBaseChange
    (Algebra.IsPushout.out (R := R) (S := MvPolynomial σ R) (R' := S) (S' := MvPolynomial σ S))
exact h
```

That `have` is load-bearing and is commented as such in the source, so the next reader does not "simplify" it back into a direct `exact` and re-hit the wall.

The second item was never contested — the #4886 thread says "not contested and I will take it next round" — but that PR merged first, so it was simply left undone.

## Verification

`lake build TauCeti.RingTheory.MvPolynomial.Basic TauCeti.RingTheory.MvPolynomial.Expand` — exit 0, 1717 jobs, no errors, warnings, or `info:` diagnostics. Branched off current `origin/main`, 0 commits behind at push. `sum_pow_char_pow` occurrences remaining: 0. No line over 100 characters; no `sorry`.

Roadmap: EllipticCurves
