### PR TITLE
refactor(UniversalCover): name the per-vertex neighborhood construction

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/PathHomotopyDiscreteness.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/PathHomotopyDiscreteness.lean
@@ -146,8 +146,46 @@ private theorem Path.exists_partition_with_property {x y : X} (γ : Path x y) (P
   obtain ⟨⟨z, hz⟩, h_seg⟩ := ht_cover i
   exact ⟨U z hz, hU_open z hz, hU_P z hz, fun s hs ↦ h_seg ⟨hs.1, hs.2⟩⟩
 
-/-- Given segment neighborhoods covering each subpath of `γ`, construct the vertex neighborhoods
-as path components of the finite intersections of adjacent segment neighborhoods. -/
+/-- The vertex neighborhood at a single index `j`: the path component, around `γ (t j)`, of the
+intersection of the segment neighborhoods `U i` adjacent to `j`. It is open and path-connected,
+contains `γ (t j)`, and lies inside each adjacent `U i`. -/
+private theorem Path.exists_vertexNeighborhood [LocallyPathConnectedSpace X]
+    {x y : X} {γ : Path x y} {n : ℕ} {t : Fin (n + 1) → unitInterval} {U : Fin n → Set X}
+    (h_mono : Monotone t) (hU_open : ∀ i, IsOpen (U i))
+    (hU_contains : ∀ i : Fin n, ∀ s : unitInterval,
+      (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U i) (j : Fin (n + 1)) :
+    ∃ V : Set X, IsOpen V ∧ IsPathConnected V ∧ γ (t j) ∈ V ∧
+      (∀ i : Fin n, j = i.castSucc → V ⊆ U i) ∧
+      (∀ i : Fin n, j = i.succ → V ⊆ U i) := by
+  let U_inter := ⋂ i : Fin n, ⋂ (_ : j = i.castSucc ∨ j = i.succ), U i
+  have hγ_in_inter : γ (t j) ∈ U_inter := by
+    simp only [U_inter, Set.mem_iInter]
+    intro i hi
+    exact hU_contains i (t j) <| by
+      cases hi with
+      | inl h =>
+          constructor <;> apply h_mono <;> simp [h, Fin.le_def]
+      | inr h =>
+          constructor <;> apply h_mono <;> simp [h, Fin.le_def, Fin.succ]
+  refine ⟨pathComponentIn U_inter (γ (t j)), ?_, isPathConnected_pathComponentIn hγ_in_inter,
+    mem_pathComponentIn_self hγ_in_inter, ?_, ?_⟩
+  · apply IsOpen.pathComponentIn
+    apply isOpen_iInter_of_finite
+    intro i
+    apply isOpen_iInter_of_finite
+    intro _
+    exact hU_open i
+  · intro i hi
+    trans U_inter
+    · exact pathComponentIn_subset
+    · exact Set.iInter_subset_of_subset i <| Set.iInter_subset_of_subset (Or.inl hi) <| subset_rfl
+  · intro i hi
+    trans U_inter
+    · exact pathComponentIn_subset
+    · exact Set.iInter_subset_of_subset i <| Set.iInter_subset_of_subset (Or.inr hi) <| subset_rfl
+
+/-- Given segment neighborhoods covering each subpath of `γ`, the vertex neighborhoods of
+`Path.exists_vertexNeighborhood` assemble into a family indexed by the partition points. -/
 private theorem Path.exists_vertexNeighborhood_family [LocallyPathConnectedSpace X]
     {x y : X} {γ : Path x y} {n : ℕ} {t : Fin (n + 1) → unitInterval} {U : Fin n → Set X}
     (h_mono : Monotone t) (hU_open : ∀ i, IsOpen (U i))
@@ -159,38 +197,8 @@ private theorem Path.exists_vertexNeighborhood_family [LocallyPathConnectedSpace
       (∀ j, γ (t j) ∈ V j) ∧
       (∀ i : Fin n, V i.castSucc ⊆ U i) ∧
       (∀ i : Fin n, V i.succ ⊆ U i) := by
-  have V_data : ∀ j : Fin (n + 1),
-      ∃ V : Set X, IsOpen V ∧ IsPathConnected V ∧ γ (t j) ∈ V ∧
-        (∀ i : Fin n, j = i.castSucc → V ⊆ U i) ∧
-        (∀ i : Fin n, j = i.succ → V ⊆ U i) := by
-    intro j
-    let U_inter := ⋂ i : Fin n, ⋂ (_ : j = i.castSucc ∨ j = i.succ), U i
-    have hγ_in_inter : γ (t j) ∈ U_inter := by
-      simp only [U_inter, Set.mem_iInter]
-      intro i hi
-      exact hU_contains i (t j) <| by
-        cases hi with
-        | inl h =>
-            constructor <;> apply h_mono <;> simp [h, Fin.le_def]
-        | inr h =>
-            constructor <;> apply h_mono <;> simp [h, Fin.le_def, Fin.succ]
-    refine ⟨pathComponentIn U_inter (γ (t j)), ?_, isPathConnected_pathComponentIn hγ_in_inter,
-      mem_pathComponentIn_self hγ_in_inter, ?_, ?_⟩
-    · apply IsOpen.pathComponentIn
-      apply isOpen_iInter_of_finite
-      intro i
-      apply isOpen_iInter_of_finite
-      intro _
-      exact hU_open i
-    · intro i hi
-      trans U_inter
-      · exact pathComponentIn_subset
-      · exact Set.iInter_subset_of_subset i <| Set.iInter_subset_of_subset (Or.inl hi) <| subset_rfl
-    · intro i hi
-      trans U_inter
-      · exact pathComponentIn_subset
-      · exact Set.iInter_subset_of_subset i <| Set.iInter_subset_of_subset (Or.inr hi) <| subset_rfl
-  choose V hV_open hV_pathConn hγ_in_V hV_left hV_right using V_data
+  choose V hV_open hV_pathConn hγ_in_V hV_left hV_right using
+    Path.exists_vertexNeighborhood h_mono hU_open hU_contains
   refine ⟨V, hV_open, hV_pathConn, hγ_in_V, ?_, ?_⟩
   · intro i
     exact hV_left i.castSucc i rfl


### PR DESCRIPTION
Name the per-vertex construction that `Path.exists_vertexNeighborhood_family` was doing inside a
`have`, so the family theorem becomes what it actually is: a `choose` over it.

## What moved

`Path.exists_vertexNeighborhood_family`'s proof was one 31-line
`have V_data : ∀ j : Fin (n + 1), ∃ V : Set X, …` — the construction of a *single* vertex
neighborhood, universally quantified — followed by `choose` and six lines of index plumbing. The
construction is about one index; only the plumbing is about the family. So the construction gets
the name and the `∀ j` becomes a parameter:

```lean
private theorem Path.exists_vertexNeighborhood [LocallyPathConnectedSpace X]
    {x y : X} {γ : Path x y} {n : ℕ} {t : Fin (n + 1) → unitInterval} {U : Fin n → Set X}
    (h_mono : Monotone t) (hU_open : ∀ i, IsOpen (U i))
    (hU_contains : ∀ i : Fin n, ∀ s : unitInterval,
      (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U i) (j : Fin (n + 1)) :
    ∃ V : Set X, IsOpen V ∧ IsPathConnected V ∧ γ (t j) ∈ V ∧
      (∀ i : Fin n, j = i.castSucc → V ⊆ U i) ∧
      (∀ i : Fin n, j = i.succ → V ⊆ U i)
```

and the family theorem is now its whole proof:

```lean
  choose V hV_open hV_pathConn hγ_in_V hV_left hV_right using
    Path.exists_vertexNeighborhood h_mono hU_open hU_contains
  refine ⟨V, hV_open, hV_pathConn, hγ_in_V, ?_, ?_⟩
  · intro i
    exact hV_left i.castSucc i rfl
  · intro i
    exact hV_right i.succ i rfl
```

Measured as source lines of the proof body — the lines after `:= by`:

| | before | after |
|---|---|---|
| `Path.exists_vertexNeighborhood_family` proof body | 37 | **7** |
| `Path.exists_vertexNeighborhood` proof body | — | 26 |

Comment-stripped code lines give the same three numbers. Both proofs are now under the 30-line
threshold; the family was over it.

## The interface is the theorem's own hypotheses, and the proof is untouched

The extracted block referenced **no** local binder of the enclosing proof — `V_data` was the
proof's first tactic, and its body uses only `h_mono`, `hU_open`, `hU_contains` and the section
variables. So the new declaration's hypotheses are exactly the family theorem's, plus the index
`j` that the `∀` was already binding. Nothing had to be restated to get it out.

That makes this diff mechanically checkable, and I checked it: **the 26 lines of the new proof are
byte-identical to the 26 lines of the old `have` body after a two-space dedent**, with the block's
opening `intro j` deleted because `j` is now a parameter. No tactic was rewritten, reordered or
re-golfed.

## Docstrings

The family carried the prose describing the construction — "construct the vertex neighborhoods as
path components of the finite intersections of adjacent segment neighborhoods". That sentence
describes what now lives in `Path.exists_vertexNeighborhood`, so it moved there (specialised to
the one index), and the family's docstring now says what the family does: assemble them.

## Notes for review

- Gate: `lake build` of the changed module **and its one importer**
  (`UniversalCover.BasedPath` — found by grep, control: the same query returns 1) — exit 0, zero
  warnings. The module is not a leaf, so the importer is part of the gate.
- Contention: the file is untouched by all **129** open PRs (full `--json files` scan, 300 distinct
  files; positive control — the same query returns #5044 for `CongruenceSubgroups/Basic.lean`), and
  no ref outside `main` has touched it in the last 14 days.
- No name collision: `Path.exists_vertexNeighborhood` did not exist (control: the `_family` spelling
  returns its two occurrences). The declined ledger has no entry for this file.
- Line length: no line I added exceeds 99 codepoints; the file's pre-existing maximum of 100 is
  unchanged and untouched.

Roadmap: UniversalCovers
