### PR TITLE
feat: publish the relative splitting criterion

### DIFF
--- a/TauCeti/NumberTheory/NumberField/SplitsCompletely.lean
+++ b/TauCeti/NumberTheory/NumberField/SplitsCompletely.lean
@@ -30,6 +30,8 @@ off from residues.
 
 ## Main results
 
+* `NumberField.ncard_primesOver_eq_finrank_iff_of_isGalois`: the relative criterion over an
+  arbitrary Dedekind base.
 * `NumberField.ncard_primesOver_eq_finrank_iff`: the rational-prime specialization.
 * `NumberField.bijective_algebraMap_quotient_of_ncard_primesOver_eq_finrank`:
   complete splitting makes each residue field the prime field.
@@ -58,7 +60,10 @@ namespace NumberField
 variable (K L : Type*) [Field K] [Field L] [NumberField K] [NumberField L] [Algebra K L]
   [IsGalois K L]
 
-private theorem ncard_primesOver_eq_finrank_iff_of_isGalois {A : Type*} [CommRing A]
+/-- In a Galois extension of number fields, the number of primes over a maximal ideal of a
+Dedekind base equals the relative degree iff the common ramification index and inertia degree
+are both `1`. -/
+theorem ncard_primesOver_eq_finrank_iff_of_isGalois {A : Type*} [CommRing A]
     [IsDedekindDomain A] [Algebra A (𝓞 L)] [Module.Finite A (𝓞 L)]
     [IsTorsionFree A (𝓞 L)] [IsGaloisGroup Gal(L/K) A (𝓞 L)] (P : Ideal A) [P.IsMaximal] :
     (primesOver P (𝓞 L)).ncard = finrank K L ↔


### PR DESCRIPTION
This PR publishes `NumberField.ncard_primesOver_eq_finrank_iff_of_isGalois`, exposing the existing relative criterion that a maximal ideal of an arbitrary Dedekind base has as many primes above it as the relative degree exactly when the common ramification index and inertia degree are both one. It advances `TauCetiRoadmap/NumberFieldArithmetic/README.md`, Layer 1.1 “The relative splitting criteria,” specifically the instruction to publish the general-base form already proved privately in `NumberField/SplitsCompletely.lean` without restating it in a second namespace.

This is the most effective current critical-path step because every later splitting, Frobenius, and Dedekind-theorem layer rests on Layer 1, while the proof already exists and the roadmap explicitly identifies visibility—not a replacement proof—as the missing work. After this PR, Layer 1 next needs the quantified unramified-set statement of Layer 1.2, followed by the prime-in-subfield dictionary of Layer 1.3.

The same file gains an accurate public-declaration docstring and lists the relative theorem among its main results. The proof continues to reuse `TauCeti.RamificationInertia.ncard_primesOver_eq_natCard_iff_of_isGaloisGroup` and Mathlib’s `IsGaloisGroup.card_eq_finrank`; no Mathlib infrastructure or external formalization is vendored. Modify `TauCeti/NumberTheory/NumberField/SplitsCompletely.lean` by 6 additions and 1 deletion.

Roadmap: NumberFieldArithmetic

<!--tauceti-target:v1 {"focus":"NumberFieldArithmetic","id":"ncard-primesover-eq-finrank-iff-of-isgalois"}-->

🤖 Prepared with Codex
