### PR TITLE
refactor(NumberField): name the signed product formula for totally positive elements

### DIFF
--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -176,15 +176,15 @@ omit [NumberField K] in
     totallyPositiveIntegerUnits (K := K) = ⊤ := by
   ext u; simp
 
-/-- **The norm of a totally positive element is nonnegative.**
-
-Over a totally complex field the hypothesis is vacuous (`not_isReal_of_isTotallyComplex`), so the
-conclusion holds for every `x` there, including `x = 0` whose norm is `0`. -/
-theorem norm_nonneg_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
-    0 ≤ Algebra.norm ℚ x := by
+/-- **The signed product formula at a totally positive element.** For a totally positive `x` the
+product of `w x ^ mult w` over the infinite places is the norm itself, and not merely its absolute
+value as in `InfinitePlace.prod_eq_abs_norm`: at a real place total positivity identifies `w x`
+with the value of the corresponding real embedding, and a complex place contributes a conjugate
+pair, whose product is a square. -/
+private theorem norm_eq_prod_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
+    ((Algebra.norm ℚ x : ℚ) : ℝ) = ∏ w : InfinitePlace K, w x ^ mult w := by
   classical
-  -- Compare in `ℂ`, where the norm is the product over all the embeddings, then descend to `ℝ`;
-  -- against `prod_eq_abs_norm` this says the absolute value there costs nothing.
+  -- Compare in `ℂ`, where the norm is the product over all the embeddings, then descend to `ℝ`.
   have key : ((Algebra.norm ℚ x : ℚ) : ℂ) =
       ((∏ w : InfinitePlace K, w x ^ mult w : ℝ) : ℂ) := by
     rw [← eq_ratCast (algebraMap ℚ ℂ) (Algebra.norm ℚ x), Algebra.norm_eq_prod_embeddings ℚ ℂ x,
@@ -223,8 +223,16 @@ theorem norm_nonneg_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
         Finset.prod_pair hne, ComplexEmbedding.conjugate_coe_eq, Complex.mul_conj,
         Complex.normSq_eq_norm_sq, norm_embedding_eq,
         (not_isReal_iff_isComplex.mp hw).mult_eq_two]
-  have hreal : ((Algebra.norm ℚ x : ℚ) : ℝ) = ∏ w : InfinitePlace K, w x ^ mult w := by
-    exact_mod_cast key
+  exact_mod_cast key
+
+/-- **The norm of a totally positive element is nonnegative.**
+
+Over a totally complex field the hypothesis is vacuous (`not_isReal_of_isTotallyComplex`), so the
+conclusion holds for every `x` there, including `x = 0` whose norm is `0`. -/
+theorem norm_nonneg_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
+    0 ≤ Algebra.norm ℚ x := by
+  -- Against `prod_eq_abs_norm`, the signed product formula says the absolute value costs nothing.
+  have hreal := norm_eq_prod_of_isTotallyPositive hpos
   rw [InfinitePlace.prod_eq_abs_norm] at hreal
   have habs : |Algebra.norm ℚ x| = Algebra.norm ℚ x := by exact_mod_cast hreal.symm
   exact abs_eq_self.mp habs


### PR DESCRIPTION
`norm_nonneg_of_isTotallyPositive` spent 41 of its 46 lines proving something it never said out
loud: that for a totally positive `x` the product over the infinite places is the norm **itself**,
not its absolute value. This gives that statement a name.

## What moved

Mathlib has `InfinitePlace.prod_eq_abs_norm : ∏ w, w x ^ mult w = |Algebra.norm ℚ x|`. The whole
content of `norm_nonneg_of_isTotallyPositive` was the observation that under total positivity the
absolute value is not doing any work — proved by computing the product over each place's fibre of
embeddings: a real place has one embedding, which total positivity identifies with `w x`, and a
complex place has a conjugate pair, whose product is a square. That computation is now the lemma:

```lean
private theorem norm_eq_prod_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
    ((Algebra.norm ℚ x : ℚ) : ℝ) = ∏ w : InfinitePlace K, w x ^ mult w
```

and the theorem that consumes it is now the two-line argument it always was:

```lean
theorem norm_nonneg_of_isTotallyPositive {x : K} (hpos : IsTotallyPositive x) :
    0 ≤ Algebra.norm ℚ x := by
  -- Against `prod_eq_abs_norm`, the signed product formula says the absolute value costs nothing.
  have hreal := norm_eq_prod_of_isTotallyPositive hpos
  rw [InfinitePlace.prod_eq_abs_norm] at hreal
  have habs : |Algebra.norm ℚ x| = Algebra.norm ℚ x := by exact_mod_cast hreal.symm
  exact abs_eq_self.mp habs
```

Measured as source lines of the proof body — the lines after `:= by`:

| | before | after |
|---|---|---|
| `norm_nonneg_of_isTotallyPositive` proof body | 46 | **5** |
| `norm_eq_prod_of_isTotallyPositive` proof body | — | 41 |

By comment-stripped code lines: 43 → 4, and 39 for the new lemma.

**I am not claiming this brings everything under the 30-line threshold, because it does not.** The
extracted proof is 41 lines. What changes is that those 41 lines now carry a statement of what they
prove, and the theorem reading them is 5 lines instead of 46. The 41 lines are the pre-existing
proof moved verbatim: the `have key` block is byte-identical, the `classical` moved with the
`Finset.filter` reasoning that needs it, and the closing `exact_mod_cast key` replaces the
`have hreal := by exact_mod_cast key` that used to introduce the same fact locally. No tactic was
rewritten.

Splitting the 41 further would mean naming the two `by_cases hw : IsReal w` branches, whose
statements are about the fibres of `InfinitePlace.mk` rather than about number fields. That is a
different topic and I have not done it here.

## Why `private`

This file has no other `private` declaration, so this is a deliberate choice worth stating. The
lemma is a proof-structuring helper for a single consumer, and keeping it private leaves the
module's documented API — the `## Main definitions and results` list in the header — untouched, so
this PR stays a refactor of existing code rather than an addition to the file's surface.

There is a real argument the other way: this *is* the signed refinement of a mathlib lemma, and
mathlib has no such statement (`prod_eq_abs_norm` at
`Mathlib/NumberTheory/NumberField/InfinitePlace/Basic.lean:370` is the only one, and the sole
occurrences of either spelling in this repository were the two inside this proof). If review
prefers it exposed, promoting it is deleting one word plus a line in the header's results list —
tell me and I will.

## Notes for review

- Gate: `lake build` of the changed module **and all five of its importers**
  (`NarrowClassGroup.Basic`, `Quadratic.Conjugation.Ambiguous.Basic`,
  `Quadratic.Conjugation.Ambiguous.Structure`, `Quadratic.Conjugation.InfinitePlace`,
  `Units.Signature.Basic` — found by grep over module names) — exit 0, zero warnings.
- Contention: the file is untouched by all **128** open PRs (full `--json files` scan; positive
  control — the same query returns #5044 for `CongruenceSubgroups/Basic.lean`).
- No name collision: `norm_eq_prod_of_isTotallyPositive` did not exist.
- Line length: no line I added exceeds 100 codepoints; the file's pre-existing maximum is unchanged.
- `Roadmap: Multiquadratic` per the module header, which names "the narrow class group of the
  multiquadratic roadmap (Layer 3)" as this file's purpose — not inferred from the directory.

Roadmap: Multiquadratic
