### PR TITLE
refactor(CommHopfAlgCat): recover a coordinate morphism from a points map, once

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -53,6 +53,10 @@ shrinking part.
 * `TauCeti.CommHopfAlgCat.pointsFunctor_faithful` and
   `TauCeti.CommHopfAlgCat.pointsFunctor_full`: points recover coordinate Hopf algebra
   morphisms.
+* `TauCeti.CommHopfAlgCat.homOfPointsMap`: the coordinate morphism a natural map of points
+  functors comes from, with `TauCeti.CommHopfAlgCat.mapPointsFunctor_homOfPointsMap` its
+  defining property. This is the form in which fullness is used downstream, where a group-scheme
+  morphism is built from its natural action on points.
 * `TauCeti.CommHopfAlgCat.essImage_pointsFunctor`: the essential image consists exactly of
   group functors with corepresentable underlying functor.
 
@@ -494,6 +498,35 @@ instance pointsFunctor_full :
     dsimp [groupYonedaPointsFunctor]
     infer_instance
   exact Functor.Full.of_iso (groupYonedaPointsFunctorIso (R := R))
+
+/-- The coordinate Hopf-algebra morphism that a natural transformation of group-valued points
+functors comes from, recovered by fullness of the functor of points.
+
+Its direction is `K ⟶ H`, opposite to that of the natural map
+`pointsFunctor H ⟶ pointsFunctor K` it is recovered from. -/
+noncomputable def homOfPointsMap {H K : _root_.CommHopfAlgCat.{u} R}
+    (α : HopfAlgebra.pointsFunctor (R := R) (H := H) ⟶
+      HopfAlgebra.pointsFunctor (R := R) (H := K)) :
+    K ⟶ H :=
+  ((pointsFunctor.{u, u, u} (R := R) :
+      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).preimage
+    (X := op H) (Y := op K) α).unop
+
+/-- Pre-composition by the recovered coordinate morphism is the natural points map it was
+recovered from. This is the defining property of `TauCeti.CommHopfAlgCat.homOfPointsMap`, and
+the only thing its users need. -/
+theorem mapPointsFunctor_homOfPointsMap {H K : _root_.CommHopfAlgCat.{u} R}
+    (α : HopfAlgebra.pointsFunctor (R := R) (H := H) ⟶
+      HopfAlgebra.pointsFunctor (R := R) (H := K)) :
+    (mapPointsFunctor (homOfPointsMap α) :
+      HopfAlgebra.pointsFunctor (R := R) (H := H) ⟶
+        HopfAlgebra.pointsFunctor (R := R) (H := K)) = α := by
+  unfold homOfPointsMap
+  rw [← pointsFunctor_map]
+  exact Functor.map_preimage
+    (pointsFunctor.{u, u, u} (R := R) :
+      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
+
 
 /-- Precomposition by `unopUnop` turns representability on a double opposite into
 corepresentability. This is the type-valued variance correction underlying the essential-image

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean
@@ -55,8 +55,11 @@ shrinking part.
   morphisms.
 * `TauCeti.CommHopfAlgCat.homOfPointsMap`: the coordinate morphism a natural map of points
   functors comes from, with `TauCeti.CommHopfAlgCat.mapPointsFunctor_homOfPointsMap` its
-  defining property. This is the form in which fullness is used downstream, where a group-scheme
-  morphism is built from its natural action on points.
+  defining property, `TauCeti.CommHopfAlgCat.homOfPointsMap_mapPointsFunctor` the converse
+  recovery law, and `TauCeti.CommHopfAlgCat.homOfPointsMap_id` and
+  `TauCeti.CommHopfAlgCat.homOfPointsMap_comp` its functoriality. This is the form in which
+  fullness is used downstream, where a group-scheme morphism is built from its natural action
+  on points.
 * `TauCeti.CommHopfAlgCat.essImage_pointsFunctor`: the essential image consists exactly of
   group functors with corepresentable underlying functor.
 
@@ -515,6 +518,7 @@ noncomputable def homOfPointsMap {H K : _root_.CommHopfAlgCat.{u} R}
 /-- Pre-composition by the recovered coordinate morphism is the natural points map it was
 recovered from. This is the defining property of `TauCeti.CommHopfAlgCat.homOfPointsMap`, and
 the only thing its users need. -/
+@[simp]
 theorem mapPointsFunctor_homOfPointsMap {H K : _root_.CommHopfAlgCat.{u} R}
     (α : HopfAlgebra.pointsFunctor (R := R) (H := H) ⟶
       HopfAlgebra.pointsFunctor (R := R) (H := K)) :
@@ -527,6 +531,55 @@ theorem mapPointsFunctor_homOfPointsMap {H K : _root_.CommHopfAlgCat.{u} R}
     (pointsFunctor.{u, u, u} (R := R) :
       (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
 
+/-- Recovering a coordinate morphism from the points map it induces returns that morphism.
+With `TauCeti.CommHopfAlgCat.mapPointsFunctor_homOfPointsMap` this makes
+`TauCeti.CommHopfAlgCat.homOfPointsMap` a two-sided inverse of
+`TauCeti.CommHopfAlgCat.mapPointsFunctor`, and it is where faithfulness of the functor of
+points is used rather than only its fullness. -/
+@[simp]
+theorem homOfPointsMap_mapPointsFunctor {H K : _root_.CommHopfAlgCat.{u} R} (φ : K ⟶ H) :
+    homOfPointsMap (mapPointsFunctor φ) = φ := by
+  -- `pointsFunctor.map ψ.op` and `mapPointsFunctor ψ` are definitionally but not syntactically
+  -- equal, so `Functor.preimage_map` does not unify against the goal. This `have` is
+  -- load-bearing: it restates the defining property in the functor's own spelling of the
+  -- morphism part, which is the one `Functor.map_injective` unifies against.
+  have h : (pointsFunctor.{u, u, u} (R := R) :
+        (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).map
+        (homOfPointsMap (mapPointsFunctor φ)).op =
+      (pointsFunctor.{u, u, u} (R := R) :
+        (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).map φ.op :=
+    mapPointsFunctor_homOfPointsMap (mapPointsFunctor φ)
+  exact Quiver.Hom.op_inj (Functor.map_injective _ h)
+
+/-- The recovered coordinate morphism of an identity points map is the identity. -/
+@[simp]
+theorem homOfPointsMap_id (H : _root_.CommHopfAlgCat.{u} R) :
+    homOfPointsMap (𝟙 (HopfAlgebra.pointsFunctor (R := R) (H := H) :
+      CommAlgCat.{u} R ⥤ GrpCat.{u})) = 𝟙 H := by
+  rw [← mapPointsFunctor_id (R := R) H, homOfPointsMap_mapPointsFunctor]
+
+/-- The recovered coordinate morphism of a composite points map is the composite of the
+recovered morphisms, in the opposite order: `TauCeti.CommHopfAlgCat.homOfPointsMap` is
+contravariant, like `TauCeti.CommHopfAlgCat.mapPointsFunctor`. -/
+@[simp]
+theorem homOfPointsMap_comp {H K L : _root_.CommHopfAlgCat.{u} R}
+    (α : HopfAlgebra.pointsFunctor (R := R) (H := H) ⟶
+      HopfAlgebra.pointsFunctor (R := R) (H := K))
+    (β : HopfAlgebra.pointsFunctor (R := R) (H := K) ⟶
+      HopfAlgebra.pointsFunctor (R := R) (H := L)) :
+    homOfPointsMap (α ≫ β) = homOfPointsMap β ≫ homOfPointsMap α := by
+  -- As in `homOfPointsMap_mapPointsFunctor`, this `have` is load-bearing: it moves the goal into
+  -- the functor's own spelling of the morphism part before appealing to faithfulness.
+  have h : (pointsFunctor.{u, u, u} (R := R) :
+        (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).map
+        (homOfPointsMap (α ≫ β)).op =
+      (pointsFunctor.{u, u, u} (R := R) :
+        (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).map
+        (homOfPointsMap β ≫ homOfPointsMap α).op := by
+    change mapPointsFunctor (homOfPointsMap (α ≫ β)) =
+      mapPointsFunctor (homOfPointsMap β ≫ homOfPointsMap α)
+    simp only [mapPointsFunctor_comp, mapPointsFunctor_homOfPointsMap]
+  exact Quiver.Hom.op_inj (Functor.map_injective _ h)
 
 /-- Precomposition by `unopUnop` turns representability on a double opposite into
 corepresentability. This is the type-valued variance correction underlying the essential-image

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/DiagonalTorus/Basic.lean
@@ -205,16 +205,11 @@ noncomputable def diagonalTorusCoordinateMap :
     coordinateHopfAlgebra R N ⟶
       _root_.CommHopfAlgCat.of R
         (MonoidAlgebra R (Multiplicative (ULift.{u} (Fin N) →₀ ℤ))) :=
-  ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).preimage
-    (X := Opposite.op (_root_.CommHopfAlgCat.of R
-      (MonoidAlgebra R (Multiplicative (ULift.{u} (Fin N) →₀ ℤ)))))
-    (Y := Opposite.op (coordinateHopfAlgebra R N))
-    (diagonalTorusPointsMap.{u, u} (R := R) (N := N) :
-      HopfAlgebra.pointsFunctor
-          (R := R)
-          (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin N) →₀ ℤ))) ⟶
-        HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R N))).unop
+  CommHopfAlgCat.homOfPointsMap
+    (H := _root_.CommHopfAlgCat.of R
+      (MonoidAlgebra R (Multiplicative (ULift.{u} (Fin N) →₀ ℤ))))
+    (K := coordinateHopfAlgebra R N)
+    (diagonalTorusPointsMap.{u, u} (R := R) (N := N))
 
 /-- Precomposition by the diagonal-torus coordinate morphism is the previously constructed
 natural map on convolution points. -/
@@ -229,12 +224,8 @@ theorem mapPointsFunctor_diagonalTorusCoordinateMap :
         HopfAlgebra.pointsFunctor
             (R := R)
             (H := MonoidAlgebra R (Multiplicative (ULift.{u} (Fin N) →₀ ℤ))) ⟶
-          HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R N)) := by
-  unfold diagonalTorusCoordinateMap
-  rw [← CommHopfAlgCat.pointsFunctor_map]
-  exact Functor.map_preimage
-    (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
+          HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R N)) :=
+  CommHopfAlgCat.mapPointsFunctor_homOfPointsMap _
 
 /-- On every value algebra, the map induced by the diagonal-torus coordinate morphism is
 `diagonalTorusPoints`. -/

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/Decomposition.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Dynamic/Weight/Levi/Decomposition.lean
@@ -189,9 +189,7 @@ theorem mapPointsFunctor_weightLeviToParabolicCoordinateMap_comp_weightParabolic
 `O(L(w)) → O(P(w))`, opposite to the group-scheme morphism. -/
 noncomputable def weightParabolicLimitCoordinateMap (w : Fin N → ℤ) :
     weightLeviCoordinateHopfAlgebra R w ⟶ weightParabolicCoordinateHopfAlgebra R w :=
-  ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).preimage
-    (weightParabolicLimitPointsMap R w)).unop
+  CommHopfAlgCat.homOfPointsMap (weightParabolicLimitPointsMap R w)
 
 /-- Precomposition by the limit coordinate morphism is the natural dynamic limit map on
 represented points. -/
@@ -201,12 +199,8 @@ private theorem mapPointsFunctor_weightParabolicLimitCoordinateMap_sameUniverse
       (weightParabolicLimitCoordinateMap R w) :
       HopfAlgebra.pointsFunctor (R := R) (H := weightParabolicCoordinateHopfAlgebra R w) ⟶
         HopfAlgebra.pointsFunctor (R := R) (H := weightLeviCoordinateHopfAlgebra R w)) =
-      weightParabolicLimitPointsMap R w := by
-  unfold weightParabolicLimitCoordinateMap
-  rw [← CommHopfAlgCat.pointsFunctor_map]
-  exact Functor.map_preimage
-    (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
+      weightParabolicLimitPointsMap R w :=
+  CommHopfAlgCat.mapPointsFunctor_homOfPointsMap _
 
 -- A point `g : K → A` is obtained from the generic point `id_K : K → K` by changing its value
 -- algebra along `g`. This formulation crosses universe levels, unlike functoriality inside one

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Subgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Root/Subgroup.lean
@@ -159,9 +159,7 @@ section Scheme
 Its direction is `O(GLₙ) → O(𝔾ₐ)`, opposite to the represented group-scheme morphism. -/
 noncomputable def rootSubgroupCoordinateMap (hij : i ≠ j) :
     coordinateHopfAlgebra R N ⟶ AdditiveGroup.coordinateHopfAlgebra R :=
-  ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).preimage
-    (rootSubgroupPointsMap.{u, u} (R := R) (N := N) hij)).unop
+  CommHopfAlgCat.homOfPointsMap (rootSubgroupPointsMap.{u, u} (R := R) (N := N) hij)
 
 /-- Precomposition by the root-subgroup coordinate morphism is the previously constructed
 natural map on convolution points. -/
@@ -172,12 +170,8 @@ theorem mapPointsFunctor_rootSubgroupCoordinateMap (hij : i ≠ j) :
         HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R N)) =
       (rootSubgroupPointsMap.{u, u} hij :
         HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ⟶
-          HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R N)) := by
-  unfold rootSubgroupCoordinateMap
-  rw [← CommHopfAlgCat.pointsFunctor_map]
-  exact Functor.map_preimage
-    (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
+          HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R N)) :=
+  CommHopfAlgCat.mapPointsFunctor_homOfPointsMap _
 
 /-- On every same-universe value algebra, the map induced by the root-subgroup coordinate
 morphism is the elementary root subgroup homomorphism already constructed on points. -/

--- a/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/RootSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/SpecialLinear/RootSubgroup.lean
@@ -151,9 +151,7 @@ section Scheme
 action on points. -/
 noncomputable def rootSubgroupCoordinateMap (hij : i ≠ j) :
     coordinateHopfAlgebra R N ⟶ AdditiveGroup.coordinateHopfAlgebra R :=
-  ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).preimage
-    (rootSubgroupPointsMap.{u, u} (R := R) (N := N) hij)).unop
+  CommHopfAlgCat.homOfPointsMap (rootSubgroupPointsMap.{u, u} (R := R) (N := N) hij)
 
 /-- Precomposition by the coordinate morphism is the constructed natural map on points. -/
 theorem mapPointsFunctor_rootSubgroupCoordinateMap (hij : i ≠ j) :
@@ -163,12 +161,8 @@ theorem mapPointsFunctor_rootSubgroupCoordinateMap (hij : i ≠ j) :
         HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R N)) =
       (rootSubgroupPointsMap.{u, u} hij :
         HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ⟶
-          HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R N)) := by
-  unfold rootSubgroupCoordinateMap
-  rw [← CommHopfAlgCat.pointsFunctor_map]
-  exact Functor.map_preimage
-    (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
+          HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R N)) :=
+  CommHopfAlgCat.mapPointsFunctor_homOfPointsMap _
 
 /-- On a same-universe algebra, the coordinate morphism induces the previously constructed
 special-linear root subgroup map. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Symplectic/RootSubgroup.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Symplectic/RootSubgroup.lean
@@ -275,9 +275,7 @@ section Scheme
 /-- The coordinate Hopf-algebra morphism selected by a symplectic root index. -/
 noncomputable def rootSubgroupCoordinateMap (root : GLSymplecticFin.RootSubgroupIndex m) :
     coordinateHopfAlgebra R m ⟶ AdditiveGroup.coordinateHopfAlgebra R :=
-  ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).preimage
-    (rootSubgroupPointsMap.{u, u} (R := R) root)).unop
+  CommHopfAlgCat.homOfPointsMap (rootSubgroupPointsMap.{u, u} (R := R) root)
 
 /-- The coordinate morphism of the positive long-root subgroup, recovered from its natural
 action on points. -/
@@ -303,12 +301,8 @@ theorem mapPointsFunctor_rootSubgroupCoordinateMap
       (rootSubgroupCoordinateMap (R := R) root) :
       HopfAlgebra.pointsFunctor (R := R) (H := AdditiveGroup.coordinateHopfAlgebra R) ⟶
         HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R m)) =
-      rootSubgroupPointsMap.{u, u} root := by
-  unfold rootSubgroupCoordinateMap
-  rw [← CommHopfAlgCat.pointsFunctor_map]
-  exact Functor.map_preimage
-    (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
+      rootSubgroupPointsMap.{u, u} root :=
+  CommHopfAlgCat.mapPointsFunctor_homOfPointsMap _
 
 /-- Precomposition by the positive long-root coordinate morphism gives its natural point map. -/
 theorem mapPointsFunctor_positiveLongRootSubgroupCoordinateMap (i : Fin m) :

--- a/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/UpperUnitriangular/Scheme.lean
@@ -116,21 +116,15 @@ noncomputable def inclusionPointsMap :
 points. -/
 noncomputable def coordinateMap :
     GeneralLinear.coordinateHopfAlgebra R n ⟶ coordinateHopfAlgebra R (Fin n) :=
-  ((CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}).preimage
-    (inclusionPointsMap.{u, u} (R := R) n)).unop
+  CommHopfAlgCat.homOfPointsMap (inclusionPointsMap.{u, u} (R := R) n)
 
 /-- Precomposition by `coordinateMap` is the upper-unitriangular inclusion on points. -/
 theorem mapPointsFunctor_coordinateMap :
     (CommHopfAlgCat.mapPointsFunctor.{u, u, u} (coordinateMap R n) :
       HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R (Fin n)) ⟶
         HopfAlgebra.pointsFunctor (R := R) (H := GeneralLinear.coordinateHopfAlgebra R n)) =
-      inclusionPointsMap.{u, u} (R := R) n := by
-  unfold coordinateMap
-  rw [← CommHopfAlgCat.pointsFunctor_map]
-  exact Functor.map_preimage
-    (CommHopfAlgCat.pointsFunctor.{u, u, u} (R := R) :
-      (_root_.CommHopfAlgCat.{u} R)ᵒᵖ ⥤ CommAlgCat.{u} R ⥤ GrpCat.{u}) _
+      inclusionPointsMap.{u, u} (R := R) n :=
+  CommHopfAlgCat.mapPointsFunctor_homOfPointsMap _
 
 /-- On every same-universe value algebra, `coordinateMap` induces the ordinary inclusion of
 upper-unitriangular matrices. -/


### PR DESCRIPTION
Six places in the affine-group-scheme development recover a coordinate Hopf-algebra morphism from
a natural transformation of group-valued points functors. Each one spelled out the same
`preimage`-of-`pointsFunctor` construct, and each proved the same "precomposition by it is the
points map I started from" lemma with the same four-line script. This PR extracts both once, next
to the fullness instance they rest on, and re-points every site.

## What is added

In `TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/Yoneda.lean`, immediately after
`pointsFunctor_full`, whose content they package:

* `TauCeti.CommHopfAlgCat.homOfPointsMap` — the coordinate morphism `K ⟶ H` that a natural map
  `pointsFunctor H ⟶ pointsFunctor K` comes from.
* `TauCeti.CommHopfAlgCat.mapPointsFunctor_homOfPointsMap` — its defining property, and the only
  thing the six users need.
* `TauCeti.CommHopfAlgCat.homOfPointsMap_mapPointsFunctor` — the converse recovery law, where
  faithfulness of the functor of points is used rather than only its fullness.
* `TauCeti.CommHopfAlgCat.homOfPointsMap_id` and `TauCeti.CommHopfAlgCat.homOfPointsMap_comp` —
  its functoriality, contravariant like `mapPointsFunctor`.

All four carry `@[simp]`, mirroring Mathlib's own annotation of the construction they specialize:
`Functor.map_preimage`, `Functor.preimage_map`, `Functor.preimage_id` and `Functor.preimage_comp`
are each `@[simp]` in `Mathlib/CategoryTheory/Functor/FullyFaithful.lean`.

The last three were added in response to the round-1 `api-design` finding, which asked for the
inverse and functoriality API that makes the operation usable without unfolding it.

### These are not restatements of the Mathlib lemmas

`pointsFunctor.map ψ.op` and `mapPointsFunctor ψ` are definitionally but **not syntactically**
equal, so citing the Mathlib lemma at a use site does not work — it is a type mismatch, not a
cosmetic difference. Applying `Functor.preimage_map` directly reports

```
Application type mismatch: The argument mapPointsFunctor φ
  has type    ... HopfAlgebra.pointsFunctor ⟶ HopfAlgebra.pointsFunctor
  but is expected to have type
              ... (pointsFunctor.obj (op H)) ⟶ (pointsFunctor.obj (op K))
```

Each proof therefore routes through a load-bearing `have` that restates the goal in the functor's
own spelling of the morphism part before appealing to `Functor.map_injective`. That `have` is
commented as load-bearing in the source so a later reader does not "simplify" it away. This is why
the three lemmas earn names rather than being left to their call sites to re-derive.

## What is re-pointed

Each definition loses the functor ascription and the `.unop`, and each companion lemma loses its
`unfold`/`rw`/`Functor.map_preimage` script for a one-line term proof.

| declaration | file |
|---|---|
| `GeneralLinear.rootSubgroupCoordinateMap` | `GeneralLinear/Root/Subgroup.lean` |
| `SpecialLinear.rootSubgroupCoordinateMap` | `SpecialLinear/RootSubgroup.lean` |
| `Symplectic.rootSubgroupCoordinateMap` | `Symplectic/RootSubgroup.lean` |
| `UpperUnitriangular.coordinateMap` | `UpperUnitriangular/Scheme.lean` |
| `GeneralLinear.diagonalTorusCoordinateMap` | `GeneralLinear/DiagonalTorus/Basic.lean` |
| `GeneralLinear.weightParabolicLimitCoordinateMap` | `.../Dynamic/Weight/Levi/Decomposition.lean` |

No statement changes. Every re-pointed declaration keeps its name, signature and docstring, so
nothing downstream moves; the six companion lemmas keep their exact statements too, which is why
their own users (`..._app` lemmas and the scheme-points lemmas) are untouched.

The `diagonalTorusCoordinateMap` site is the one that shows the extraction was worth making: it
had to pass `(X := ...)`, `(Y := ...)` and a full type ascription by hand to get the construct to
elaborate. With `homOfPointsMap` the two implicit Hopf algebras are named directly and the
ascription goes away.

## Why

Dedup finding A01 (repository dedup sweep, 2026-08-24). The general statement was measured absent
before writing: `homOfPointsMap`, `mapPointsFunctor_homOfPointsMap`, `hopfSpecMapOfPresentation`
and `pointsHomOfModels` each match 0 files on `main`, while the positive controls `pointsFunctor`
(33 files), `hopfSpec` (72) and `liftQuotient` (13) fire strongly, so the zeros are
instrument-checked rather than a broken query. The 129 open PRs were also scanned by changed-file
list: 5 touch `AlgebraicGroup/`, none of them any of the six files here.

## Deliberately out of scope

Two nearby things use `preimage` but are *not* this construct, and are left alone rather than
bent to fit:

* `GeneralLinear.centerCoordinateLaurentIso` and `SpecialLinear.centerCoordinateIsoGroupAlgebra`
  use `preimageIso` — they recover an *isomorphism*, not a morphism.
* The `hopfSpec.fullyFaithful.preimage` sites (`HopfIdeal/Scheme/Equalizer.lean`,
  `HopfIdeal/Scheme/Classification.lean`, `GeneralLinear/Weight/Parabolic.lean`) are the preimage
  of a different functor.

The rest of finding A01 — the `eqToHom ≫ hopfSpec.map ≫ eqToHom` presentation-transport step and
the points-model injectivity pipeline — is a separate topic and is not attempted here.

## Gate

`lake build` of all 7 changed modules and their 18 direct importers, re-run after the
`api-design` fix: green — "Build completed successfully (3669 jobs)", exit 0, no error, warning
or `sorry` lines.

The four `@[simp]` annotations were checked for simp-normal-form violations rather than argued
about, using a reduced-scope copy of `scripts/lint-env.sh`'s own legacy `#lint only simpNF in
TauCeti` driver over this PR's 25-module closure. None of the four is reported. The run is
instrument-checked in both directions: its nonce marker is present, proving elaboration got past
the `#lint`, and the report does contain 27 pre-existing findings — including ones named in the
same `TauCeti.CommHopfAlgCat.*` form — so a violation of mine would have been named.

The full build, the axiom check and the complete `lint-env` run in CI.

Roadmap: ReductiveGroups

