### PR TITLE
feat: extend compact Kantorovich duality to lsc costs

### DIFF
--- a/TauCeti/MeasureTheory/OptimalTransport/Duality/LowerSemicontinuous.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Duality/LowerSemicontinuous.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.MeasureTheory.OptimalTransport.Duality.Compact
+public import TauCeti.MeasureTheory.OptimalTransport.Existence
+
+/-!
+# Kantorovich duality for lower-semicontinuous costs on compact spaces
+
+This file extends compact Kantorovich duality from continuous finite costs to arbitrary
+lower-semicontinuous costs `c : X × Y → ℝ≥0∞`. In particular, the cost may be unbounded or take
+the value `∞`, so the common primal and dual value is retained in `ℝ≥0∞`.
+
+The bridge is the monotone bounded-continuous approximation `TauCeti.lscApprox`. On compact
+metrizable spaces, minimization over the coupling set commutes with this increasing supremum:
+
+`transportCost c μ ν = ⨆ n, transportCost (lscApprox c n) μ ν`.
+
+For the nontrivial inequality, the sublevel sets of the approximate integral functionals are a
+decreasing sequence of nonempty closed subsets of the compact coupling set. A plan in their
+intersection has `c`-cost bounded by the supremum of the approximate optimal values. Applying
+continuous compact duality at every approximation then identifies the original transport cost
+with the supremum of the positive parts of the values of continuous dual-feasible potentials.
+
+## Main statements
+
+* `TauCeti.transportCost_iSup_eq_iSup` — minimization over compact coupling sets commutes with an
+  increasing supremum of lower-semicontinuous costs;
+* `TauCeti.transportCost_eq_iSup_transportCost_lscApprox` — transport cost commutes with the
+  canonical monotone approximation of a lower-semicontinuous cost;
+* `TauCeti.isLUB_ofReal_kantorovichDualValue_continuous_of_lowerSemicontinuous` — strong
+  Kantorovich duality for a lower-semicontinuous extended-nonnegative cost on compact metrizable
+  spaces, in a form that permits the value `∞`;
+* `TauCeti.transportCost_eq_sSup_ofReal_kantorovichDualValue_continuous_of_lowerSemicontinuous` —
+  the same result as an equality with the supremum of the continuous dual values.
+
+## References
+
+* C. Villani, *Topics in Optimal Transportation*, Graduate Studies in Mathematics 58, 2003,
+  Theorem 1.3.
+* C. Villani, *Optimal Transport: Old and New*, Grundlehren 338, 2009, Theorem 5.10.
+
+This is the compact lower-semicontinuous regime of Layer 2, item 4 of the optimal-transport
+roadmap. Its monotone-approximation theorem is the compact exhaustion step used by the Polish
+lower-semicontinuous regime.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+open scoped ENNReal NNReal Topology
+
+namespace TauCeti
+
+universe u v
+
+variable {X : Type u} {Y : Type v}
+  [PseudoMetricSpace X] [T0Space X] [CompactSpace X] [MeasurableSpace X] [BorelSpace X]
+  [PseudoMetricSpace Y] [T0Space Y] [CompactSpace Y] [MeasurableSpace Y] [BorelSpace Y]
+  {μ : Measure X} {ν : Measure Y} [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+  {c : X × Y → ℝ≥0∞}
+
+/-- **Monotone convergence of optimal transport costs on compact spaces.** The transport cost of
+the pointwise supremum of an increasing sequence of lower-semicontinuous costs is the supremum of
+their transport costs. No finiteness assumption is made: both sides may be `∞`.
+
+Compactness of the feasible set is load-bearing. Without it, an escaping sequence of approximate
+minimizers can make the supremum of the minima strictly smaller than the minimum of the supremum. -/
+theorem transportCost_iSup_eq_iSup {cs : ℕ → X × Y → ℝ≥0∞}
+    (hcs : ∀ n, LowerSemicontinuous (cs n)) (hmono : Monotone cs) :
+    transportCost (fun z ↦ ⨆ n, cs n z) μ ν = ⨆ n, transportCost (cs n) μ ν := by
+  let a : ℝ≥0∞ := ⨆ n : ℕ, transportCost (cs n) μ ν
+  let K : ℕ → Set (ProbabilityMeasure (X × Y)) := fun n ↦
+    {π | IsCoupling π.toMeasure μ ν} ∩
+      {π | ∫⁻ z, cs n z ∂π.toMeasure ≤ a}
+  have ha_le : a ≤ transportCost (fun z ↦ ⨆ n, cs n z) μ ν := by
+    refine iSup_le fun n ↦ transportCost_mono (fun z ↦ le_iSup (fun m ↦ cs m z) n)
+  suffices transportCost (fun z ↦ ⨆ n, cs n z) μ ν ≤ a by
+    exact le_antisymm this ha_le
+  have hK_nonempty (n : ℕ) : (K n).Nonempty := by
+    obtain ⟨π, hπ⟩ := exists_isOptimalCoupling_of_isTightMeasureSet
+      (μ := μ) (ν := ν) IsTightMeasureSet.of_compactSpace
+      IsTightMeasureSet.of_compactSpace (hcs n)
+    let π' : ProbabilityMeasure (X × Y) := ⟨π, hπ.toIsCoupling.isProbabilityMeasure⟩
+    refine ⟨π', hπ.toIsCoupling, ?_⟩
+    -- `π'` only bundles the raw optimal plan `π`; expose that coercion to use its optimal value.
+    change (∫⁻ z, cs n z ∂π) ≤ a
+    exact hπ.lintegral_eq.trans_le (le_iSup (fun m : ℕ ↦ transportCost (cs m) μ ν) n)
+  have hK_succ (n : ℕ) : K (n + 1) ⊆ K n := by
+    rintro π ⟨hπ, hπcost⟩
+    refine ⟨hπ, hπcost.trans' (lintegral_mono fun z ↦ ?_)⟩
+    exact hmono (Nat.le_succ n) z
+  have hK_closed (n : ℕ) : IsClosed (K n) := by
+    exact (isClosed_setOfPred_isCoupling_of_compactSpace
+      (⟨μ, ‹IsProbabilityMeasure μ›⟩ : ProbabilityMeasure X)
+      (⟨ν, ‹IsProbabilityMeasure ν›⟩ : ProbabilityMeasure Y)).inter
+        (isClosed_setOfPred_lintegral_le_probabilityMeasure (hcs n) a)
+  have hK_compact : IsCompact (K 0) :=
+    (isCompact_setOfPred_isCoupling_of_compactSpace
+      (⟨μ, ‹IsProbabilityMeasure μ›⟩ : ProbabilityMeasure X)
+      (⟨ν, ‹IsProbabilityMeasure ν›⟩ : ProbabilityMeasure Y)).inter_right
+        (isClosed_setOfPred_lintegral_le_probabilityMeasure (hcs 0) a)
+  obtain ⟨π, hπ⟩ := IsCompact.nonempty_iInter_of_sequence_nonempty_isCompact_isClosed
+    K hK_succ hK_nonempty hK_compact hK_closed
+  have hπK : ∀ n, π ∈ K n := Set.mem_iInter.1 hπ
+  refine (transportCost_le_lintegral (hπK 0).1 (fun z ↦ ⨆ n, cs n z)).trans ?_
+  rw [lintegral_iSup (fun n ↦ (hcs n).measurable) hmono]
+  exact iSup_le fun n ↦ (hπK n).2
+
+/-- On compact metrizable spaces, the transport costs of the canonical bounded-continuous
+approximations of a lower-semicontinuous cost increase to the transport cost of the original
+cost. This is the minimization counterpart of
+`TauCeti.lintegral_eq_iSup_lintegral_lscApprox`. -/
+theorem transportCost_eq_iSup_transportCost_lscApprox (hc : LowerSemicontinuous c) :
+    transportCost c μ ν =
+      ⨆ n : ℕ, transportCost (fun z ↦ (lscApprox c n z : ℝ≥0∞)) μ ν := by
+  simpa only [iSup_coe_lscApprox hc] using
+    transportCost_iSup_eq_iSup
+      (cs := fun n z ↦ (lscApprox c n z : ℝ≥0∞))
+      (fun n ↦ (ENNReal.continuous_coe.comp (lscApprox c n).continuous).lowerSemicontinuous)
+      (monotone_coe_lscApprox c)
+
+/-- **Strong Kantorovich duality for lower-semicontinuous costs on compact metrizable spaces.**
+The primal transport cost is the least upper bound, in `ℝ≥0∞`, of the positive parts of the
+values of continuous dual-feasible potential pairs.
+
+The extended-nonnegative codomain is essential: an unbounded or infinite-valued cost can have
+primal value `∞`, in which case the continuous dual values are unbounded rather than attaining a
+real supremum. -/
+theorem isLUB_ofReal_kantorovichDualValue_continuous_of_lowerSemicontinuous
+    (hc : LowerSemicontinuous c) :
+    IsLUB {r : ℝ≥0∞ | ∃ φ ψ, Continuous φ ∧ Continuous ψ ∧ DualFeasible c φ ψ ∧
+      ENNReal.ofReal (kantorovichDualValue μ ν φ ψ) = r} (transportCost c μ ν) := by
+  constructor
+  · rintro r ⟨φ, ψ, hφ, hψ, hfeas, rfl⟩
+    have hφi : Integrable φ μ := by
+      simpa only [integrableOn_univ] using
+        hφ.continuousOn.integrableOn_compact' (μ := μ) isCompact_univ MeasurableSet.univ
+    have hψi : Integrable ψ ν := by
+      simpa only [integrableOn_univ] using
+        hψ.continuousOn.integrableOn_compact' (μ := ν) isCompact_univ MeasurableSet.univ
+    exact hfeas.ofReal_kantorovichDualValue_le_transportCost hφi hψi
+  · intro b hb
+    rw [transportCost_eq_iSup_transportCost_lscApprox hc]
+    refine iSup_le fun n ↦ ?_
+    by_cases hbtop : b = ∞
+    · simp only [hbtop, le_top]
+    let cn : X × Y → ℝ := lscApproxAux c n
+    have hcn_cont : Continuous cn := continuous_lscApproxAux c n
+    have hcn_nonneg : ∀ z, 0 ≤ cn z := lscApproxAux_nonneg c n
+    have hcn_le : (fun z ↦ ENNReal.ofReal (cn z)) ≤ c := fun z ↦
+      ofReal_lscApproxAux_le c n z
+    have hleast :
+        (transportCost (fun z ↦ ENNReal.ofReal (cn z)) μ ν).toReal ≤ b.toReal :=
+      (isLUB_kantorovichDualValue_continuous
+        (μ := μ) (ν := ν) hcn_cont hcn_nonneg).2 fun r hr ↦ by
+          obtain ⟨φ, ψ, hφ, hψ, hfeas, rfl⟩ := hr
+          have hfeas' : DualFeasible c φ ψ :=
+            ((dualFeasible_ofReal_iff hcn_nonneg φ ψ).2 hfeas).mono_cost hcn_le
+          exact (ENNReal.ofReal_le_iff_le_toReal hbtop).1
+            (hb ⟨φ, ψ, hφ, hψ, hfeas', rfl⟩)
+    have hcost_ne_top : transportCost (fun z ↦ ENNReal.ofReal (cn z)) μ ν ≠ ∞ :=
+      transportCost_ne_top_of_continuous (μ := μ) (ν := ν)
+        ⟨_, isCoupling_prod μ ν⟩ hcn_cont
+    have hcost_le : transportCost (fun z ↦ ENNReal.ofReal (cn z)) μ ν ≤ b :=
+      (ENNReal.toReal_le_toReal hcost_ne_top hbtop).1 hleast
+    simpa only [cn, coe_lscApprox_apply] using hcost_le
+
+/-- Strong compact duality for a lower-semicontinuous extended-nonnegative cost, written as an
+equality between the primal value and the supremum of the positive parts of all continuous dual
+values. This formulation remains meaningful when the common value is `∞`. -/
+theorem transportCost_eq_sSup_ofReal_kantorovichDualValue_continuous_of_lowerSemicontinuous
+    (hc : LowerSemicontinuous c) :
+    transportCost c μ ν = sSup {r : ℝ≥0∞ | ∃ φ ψ, Continuous φ ∧ Continuous ψ ∧
+      DualFeasible c φ ψ ∧ ENNReal.ofReal (kantorovichDualValue μ ν φ ψ) = r} :=
+  (isLUB_ofReal_kantorovichDualValue_continuous_of_lowerSemicontinuous hc).sSup_eq.symm
+
+end TauCeti

--- a/TauCeti/MeasureTheory/OptimalTransport/Duality/LowerSemicontinuous.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Duality/LowerSemicontinuous.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.MeasureTheory.OptimalTransport.Duality.Compact
-public import TauCeti.MeasureTheory.OptimalTransport.Existence
+import TauCeti.MeasureTheory.OptimalTransport.Existence
 
 /-!
 # Kantorovich duality for lower-semicontinuous costs on compact spaces
@@ -28,10 +28,6 @@ with the supremum of the positive parts of the values of continuous dual-feasibl
 
 ## Main statements
 
-* `TauCeti.transportCost_iSup_eq_iSup` — minimization over compact coupling sets commutes with an
-  increasing supremum of lower-semicontinuous costs;
-* `TauCeti.transportCost_eq_iSup_transportCost_lscApprox` — transport cost commutes with the
-  canonical monotone approximation of a lower-semicontinuous cost;
 * `TauCeti.isLUB_ofReal_kantorovichDualValue_continuous_of_lowerSemicontinuous` — strong
   Kantorovich duality for a lower-semicontinuous extended-nonnegative cost on compact metrizable
   spaces, in a form that permits the value `∞`;
@@ -61,70 +57,11 @@ namespace TauCeti
 universe u v
 
 variable {X : Type u} {Y : Type v}
-  [PseudoMetricSpace X] [T0Space X] [CompactSpace X] [MeasurableSpace X] [BorelSpace X]
-  [PseudoMetricSpace Y] [T0Space Y] [CompactSpace Y] [MeasurableSpace Y] [BorelSpace Y]
+  [TopologicalSpace X] [TopologicalSpace.MetrizableSpace X] [CompactSpace X]
+  [MeasurableSpace X] [BorelSpace X] [TopologicalSpace Y]
+  [TopologicalSpace.MetrizableSpace Y] [CompactSpace Y] [MeasurableSpace Y] [BorelSpace Y]
   {μ : Measure X} {ν : Measure Y} [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
   {c : X × Y → ℝ≥0∞}
-
-/-- **Monotone convergence of optimal transport costs on compact spaces.** The transport cost of
-the pointwise supremum of an increasing sequence of lower-semicontinuous costs is the supremum of
-their transport costs. No finiteness assumption is made: both sides may be `∞`.
-
-Compactness of the feasible set is load-bearing. Without it, an escaping sequence of approximate
-minimizers can make the supremum of the minima strictly smaller than the minimum of the supremum. -/
-theorem transportCost_iSup_eq_iSup {cs : ℕ → X × Y → ℝ≥0∞}
-    (hcs : ∀ n, LowerSemicontinuous (cs n)) (hmono : Monotone cs) :
-    transportCost (fun z ↦ ⨆ n, cs n z) μ ν = ⨆ n, transportCost (cs n) μ ν := by
-  let a : ℝ≥0∞ := ⨆ n : ℕ, transportCost (cs n) μ ν
-  let K : ℕ → Set (ProbabilityMeasure (X × Y)) := fun n ↦
-    {π | IsCoupling π.toMeasure μ ν} ∩
-      {π | ∫⁻ z, cs n z ∂π.toMeasure ≤ a}
-  have ha_le : a ≤ transportCost (fun z ↦ ⨆ n, cs n z) μ ν := by
-    refine iSup_le fun n ↦ transportCost_mono (fun z ↦ le_iSup (fun m ↦ cs m z) n)
-  suffices transportCost (fun z ↦ ⨆ n, cs n z) μ ν ≤ a by
-    exact le_antisymm this ha_le
-  have hK_nonempty (n : ℕ) : (K n).Nonempty := by
-    obtain ⟨π, hπ⟩ := exists_isOptimalCoupling_of_isTightMeasureSet
-      (μ := μ) (ν := ν) IsTightMeasureSet.of_compactSpace
-      IsTightMeasureSet.of_compactSpace (hcs n)
-    let π' : ProbabilityMeasure (X × Y) := ⟨π, hπ.toIsCoupling.isProbabilityMeasure⟩
-    refine ⟨π', hπ.toIsCoupling, ?_⟩
-    -- `π'` only bundles the raw optimal plan `π`; expose that coercion to use its optimal value.
-    change (∫⁻ z, cs n z ∂π) ≤ a
-    exact hπ.lintegral_eq.trans_le (le_iSup (fun m : ℕ ↦ transportCost (cs m) μ ν) n)
-  have hK_succ (n : ℕ) : K (n + 1) ⊆ K n := by
-    rintro π ⟨hπ, hπcost⟩
-    refine ⟨hπ, hπcost.trans' (lintegral_mono fun z ↦ ?_)⟩
-    exact hmono (Nat.le_succ n) z
-  have hK_closed (n : ℕ) : IsClosed (K n) := by
-    exact (isClosed_setOfPred_isCoupling_of_compactSpace
-      (⟨μ, ‹IsProbabilityMeasure μ›⟩ : ProbabilityMeasure X)
-      (⟨ν, ‹IsProbabilityMeasure ν›⟩ : ProbabilityMeasure Y)).inter
-        (isClosed_setOfPred_lintegral_le_probabilityMeasure (hcs n) a)
-  have hK_compact : IsCompact (K 0) :=
-    (isCompact_setOfPred_isCoupling_of_compactSpace
-      (⟨μ, ‹IsProbabilityMeasure μ›⟩ : ProbabilityMeasure X)
-      (⟨ν, ‹IsProbabilityMeasure ν›⟩ : ProbabilityMeasure Y)).inter_right
-        (isClosed_setOfPred_lintegral_le_probabilityMeasure (hcs 0) a)
-  obtain ⟨π, hπ⟩ := IsCompact.nonempty_iInter_of_sequence_nonempty_isCompact_isClosed
-    K hK_succ hK_nonempty hK_compact hK_closed
-  have hπK : ∀ n, π ∈ K n := Set.mem_iInter.1 hπ
-  refine (transportCost_le_lintegral (hπK 0).1 (fun z ↦ ⨆ n, cs n z)).trans ?_
-  rw [lintegral_iSup (fun n ↦ (hcs n).measurable) hmono]
-  exact iSup_le fun n ↦ (hπK n).2
-
-/-- On compact metrizable spaces, the transport costs of the canonical bounded-continuous
-approximations of a lower-semicontinuous cost increase to the transport cost of the original
-cost. This is the minimization counterpart of
-`TauCeti.lintegral_eq_iSup_lintegral_lscApprox`. -/
-theorem transportCost_eq_iSup_transportCost_lscApprox (hc : LowerSemicontinuous c) :
-    transportCost c μ ν =
-      ⨆ n : ℕ, transportCost (fun z ↦ (lscApprox c n z : ℝ≥0∞)) μ ν := by
-  simpa only [iSup_coe_lscApprox hc] using
-    transportCost_iSup_eq_iSup
-      (cs := fun n z ↦ (lscApprox c n z : ℝ≥0∞))
-      (fun n ↦ (ENNReal.continuous_coe.comp (lscApprox c n).continuous).lowerSemicontinuous)
-      (monotone_coe_lscApprox c)
 
 /-- **Strong Kantorovich duality for lower-semicontinuous costs on compact metrizable spaces.**
 The primal transport cost is the least upper bound, in `ℝ≥0∞`, of the positive parts of the
@@ -137,6 +74,8 @@ theorem isLUB_ofReal_kantorovichDualValue_continuous_of_lowerSemicontinuous
     (hc : LowerSemicontinuous c) :
     IsLUB {r : ℝ≥0∞ | ∃ φ ψ, Continuous φ ∧ Continuous ψ ∧ DualFeasible c φ ψ ∧
       ENNReal.ofReal (kantorovichDualValue μ ν φ ψ) = r} (transportCost c μ ν) := by
+  let : PseudoMetricSpace X := TopologicalSpace.pseudoMetrizableSpacePseudoMetric X
+  let : PseudoMetricSpace Y := TopologicalSpace.pseudoMetrizableSpacePseudoMetric Y
   constructor
   · rintro r ⟨φ, ψ, hφ, hψ, hfeas, rfl⟩
     have hφi : Integrable φ μ := by

--- a/TauCeti/MeasureTheory/OptimalTransport/Existence.lean
+++ b/TauCeti/MeasureTheory/OptimalTransport/Existence.lean
@@ -44,6 +44,10 @@ the infimum on the compact set of couplings.
   element of the bundled type `TauCeti.Coupling`;
 * `TauCeti.isCompact_setOfPred_isOptimalCoupling` — the optimal plans themselves form a weakly
   compact set;
+* `TauCeti.transportCost_iSup_eq_iSup` — minimization over compact coupling sets commutes with an
+  increasing supremum of lower-semicontinuous costs;
+* `TauCeti.transportCost_eq_iSup_transportCost_lscApprox` — transport cost commutes with the
+  canonical monotone approximation of a lower-semicontinuous cost;
 * `TauCeti.exists_isOptimalCoupling_edist` and `TauCeti.exists_isOptimalCoupling_edist_rpow` — the
   acceptance instances: the Kantorovich–Rubinstein cost `edist`, and the `p`-Wasserstein cost
   `edist ^ p`, admit optimal plans on a Polish space.
@@ -65,6 +69,8 @@ open MeasureTheory Set
 open scoped ENNReal NNReal Topology
 
 namespace TauCeti
+
+section Tight
 
 /-! The two factors are Borel metrizable spaces, one of the two second countable — the hypotheses
 under which the product is a Borel space and the coupling set is weakly compact. Metrizability is
@@ -119,6 +125,88 @@ theorem isCompact_setOfPred_isOptimalCoupling {μ : Measure X} [IsProbabilityMea
     TopologicalSpace.pseudoMetrizableSpacePseudoMetric (X × Y)
   exact (isCompact_setOfPred_isCoupling (μ := ⟨μ, ‹_›⟩) (ν := ⟨ν, ‹_›⟩) hμ hν).inter_right
     (isClosed_setOfPred_lintegral_le_probabilityMeasure hc _)
+
+end Tight
+
+section CompactMetrizable
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace.MetrizableSpace X]
+  [CompactSpace X] [MeasurableSpace X] [BorelSpace X] [TopologicalSpace Y]
+  [TopologicalSpace.MetrizableSpace Y] [CompactSpace Y] [MeasurableSpace Y] [BorelSpace Y]
+  {μ : Measure X} {ν : Measure Y} [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+
+/-- **Monotone convergence of optimal transport costs on compact spaces.** The transport cost of
+the pointwise supremum of an increasing sequence of lower-semicontinuous costs is the supremum of
+their transport costs. No finiteness assumption is made: both sides may be `∞`.
+
+Compactness of the feasible set is load-bearing. Without it, an escaping sequence of approximate
+minimizers can make the supremum of the minima strictly smaller than the minimum of the supremum. -/
+theorem transportCost_iSup_eq_iSup {cs : ℕ → X × Y → ℝ≥0∞}
+    (hcs : ∀ n, LowerSemicontinuous (cs n)) (hmono : Monotone cs) :
+    transportCost (fun z ↦ ⨆ n, cs n z) μ ν = ⨆ n, transportCost (cs n) μ ν := by
+  let : PseudoMetricSpace X := TopologicalSpace.pseudoMetrizableSpacePseudoMetric X
+  let : PseudoMetricSpace Y := TopologicalSpace.pseudoMetrizableSpacePseudoMetric Y
+  let a : ℝ≥0∞ := ⨆ n : ℕ, transportCost (cs n) μ ν
+  let K : ℕ → Set (ProbabilityMeasure (X × Y)) := fun n ↦
+    {π | IsCoupling π.toMeasure μ ν} ∩
+      {π | ∫⁻ z, cs n z ∂π.toMeasure ≤ a}
+  have ha_le : a ≤ transportCost (fun z ↦ ⨆ n, cs n z) μ ν := by
+    refine iSup_le fun n ↦ transportCost_mono (fun z ↦ le_iSup (fun m ↦ cs m z) n)
+  suffices transportCost (fun z ↦ ⨆ n, cs n z) μ ν ≤ a by
+    exact le_antisymm this ha_le
+  have hK_nonempty (n : ℕ) : (K n).Nonempty := by
+    obtain ⟨π, hπ⟩ := exists_isOptimalCoupling_of_isTightMeasureSet
+      (μ := μ) (ν := ν) IsTightMeasureSet.of_compactSpace
+      IsTightMeasureSet.of_compactSpace (hcs n)
+    let π' : ProbabilityMeasure (X × Y) := ⟨π, hπ.toIsCoupling.isProbabilityMeasure⟩
+    refine ⟨π', hπ.toIsCoupling, ?_⟩
+    -- `π'` only bundles the raw optimal plan `π`; expose that coercion to use its optimal value.
+    change (∫⁻ z, cs n z ∂π) ≤ a
+    exact hπ.lintegral_eq.trans_le (le_iSup (fun m : ℕ ↦ transportCost (cs m) μ ν) n)
+  have hK_succ (n : ℕ) : K (n + 1) ⊆ K n := by
+    rintro π ⟨hπ, hπcost⟩
+    refine ⟨hπ, hπcost.trans' (lintegral_mono fun z ↦ ?_)⟩
+    exact hmono (Nat.le_succ n) z
+  have hK_closed (n : ℕ) : IsClosed (K n) := by
+    exact (isClosed_setOfPred_isCoupling_of_compactSpace
+      (⟨μ, ‹IsProbabilityMeasure μ›⟩ : ProbabilityMeasure X)
+      (⟨ν, ‹IsProbabilityMeasure ν›⟩ : ProbabilityMeasure Y)).inter
+        (isClosed_setOfPred_lintegral_le_probabilityMeasure (hcs n) a)
+  have hK_compact : IsCompact (K 0) :=
+    (isCompact_setOfPred_isCoupling_of_compactSpace
+      (⟨μ, ‹IsProbabilityMeasure μ›⟩ : ProbabilityMeasure X)
+      (⟨ν, ‹IsProbabilityMeasure ν›⟩ : ProbabilityMeasure Y)).inter_right
+        (isClosed_setOfPred_lintegral_le_probabilityMeasure (hcs 0) a)
+  obtain ⟨π, hπ⟩ := IsCompact.nonempty_iInter_of_sequence_nonempty_isCompact_isClosed
+    K hK_succ hK_nonempty hK_compact hK_closed
+  have hπK : ∀ n, π ∈ K n := Set.mem_iInter.1 hπ
+  refine (transportCost_le_lintegral (hπK 0).1 (fun z ↦ ⨆ n, cs n z)).trans ?_
+  rw [lintegral_iSup (fun n ↦ (hcs n).measurable) hmono]
+  exact iSup_le fun n ↦ (hπK n).2
+
+end CompactMetrizable
+
+section CompactPseudoMetric
+
+variable {X Y : Type*} [PseudoMetricSpace X] [T0Space X] [CompactSpace X]
+  [MeasurableSpace X] [BorelSpace X] [PseudoMetricSpace Y] [T0Space Y] [CompactSpace Y]
+  [MeasurableSpace Y] [BorelSpace Y] {μ : Measure X} {ν : Measure Y}
+  [IsProbabilityMeasure μ] [IsProbabilityMeasure ν] {c : X × Y → ℝ≥0∞}
+
+/-- On compact metrizable spaces, the transport costs of the canonical bounded-continuous
+approximations of a lower-semicontinuous cost increase to the transport cost of the original
+cost. This is the minimization counterpart of
+`TauCeti.lintegral_eq_iSup_lintegral_lscApprox`. -/
+theorem transportCost_eq_iSup_transportCost_lscApprox (hc : LowerSemicontinuous c) :
+    transportCost c μ ν =
+      ⨆ n : ℕ, transportCost (fun z ↦ (lscApprox c n z : ℝ≥0∞)) μ ν := by
+  simpa only [iSup_coe_lscApprox hc] using
+    transportCost_iSup_eq_iSup
+      (cs := fun n z ↦ (lscApprox c n z : ℝ≥0∞))
+      (fun n ↦ (ENNReal.continuous_coe.comp (lscApprox c n).continuous).lowerSemicontinuous)
+      (monotone_coe_lscApprox c)
+
+end CompactPseudoMetric
 
 section Polish
 


### PR DESCRIPTION
This PR proves strong Kantorovich duality for lower-semicontinuous extended-nonnegative costs on compact metrizable spaces. It first proves the reusable monotone-convergence theorem `transportCost_iSup_eq_iSup`: minimization over the compact coupling set commutes with an increasing supremum of lower-semicontinuous costs. Specializing to `lscApprox` shows that the approximate optimal values increase to the original transport cost, and compact continuous duality at every approximation identifies that cost with the `ℝ≥0∞` supremum of the positive parts of continuous dual values. The extended codomain honestly retains unbounded, barrier, and infinite optimal values.

The exact target is `TauCetiRoadmap/OptimalTransport/README.md`, Layer 2, item 4, the lower-semicontinuous Kantorovich-duality regime within the milestone “Kantorovich duality, transforms, and optimality certificates.” This is the most effective independent critical-path step because compact continuous duality and lower-semicontinuous approximation are already on `main`, while Layer 3 item 1 is already in flight in #4619; the compact monotone-exhaustion argument supplied here is the reusable bridge from those landed results toward general lower-semicontinuous duality. After this PR, item 4 still needs the noncompact Polish theorem for costs bounded below by integrable split functions, together with its exact dual-attainment tier; the later relaxed Borel-cost regimes remain item 5.

The proof uses the existing compactness of fixed-marginal coupling sets, lower semicontinuity of `lintegral`, primal attainment, the canonical `lscApprox` sequence, and compact continuous Kantorovich duality. No Mathlib infrastructure or external formalization is vendored. The mathematical formulation follows Villani, *Topics in Optimal Transportation*, Theorem 1.3, and *Optimal Transport: Old and New*, Theorem 5.10, as cited in the module documentation.

Add `TauCeti/MeasureTheory/OptimalTransport/Duality/LowerSemicontinuous.lean` (184 lines).

Roadmap: OptimalTransport

<!--tauceti-target:v1 {"focus":"OptimalTransport","id":"kantorovich-duality-lsc-compact"}-->

🤖 Prepared with Codex
