### PR TITLE
feat: calculate the nonlinear parameter projection

### DIFF
--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -1,0 +1,252 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Fredholm.LevelSet.Smooth
+public import TauCeti.Analysis.Fredholm.UniversalLevelSet
+import Mathlib.Analysis.Calculus.ContDiff.Comp
+import TauCeti.Analysis.Fredholm.SardSmale
+
+/-!
+# Parameter maps on universal Fredholm level sets
+
+Let `f : E × Λ → F` be a parametrized equation and suppose that its total linearization at a
+solution `(x, l)` is `D₁.coprod D₂`. When this linearization is surjective with complemented
+kernel, `TauCeti.levelSetChart` parametrizes the universal level set near `(x, l)` by
+`ker (D₁.coprod D₂)`. Composing its inverse with the projection to `Λ` gives the local parameter
+map `TauCeti.levelSetParameterMap`.
+
+This file calculates that map's derivative at the chart origin. It is exactly
+`TauCeti.parameterProj D₁ D₂`, the linear parameter projection developed in
+`TauCeti.Analysis.Fredholm.Parametric`. Consequently, when `D₁` is Fredholm, the local parameter
+map has Fredholm derivative of the same index as `D₁`; and its derivative is surjective exactly
+when `D₁` is surjective. The final theorem applies local Sard--Smale to show that nearby critical
+values of the parameter map form a closed nowhere dense set.
+
+These results are the local nonlinear calculation in the parametric transversality package of
+McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., Appendix A.3. Passing
+from this one chart to a residual set of parameters for a whole universal moduli space requires
+smooth compatibility and a countable cover, and is not asserted here.
+
+## Main results
+
+* `TauCeti.hasStrictFDerivAt_levelSetParameterMap`: the derivative at the chart origin is the
+  linear parameter projection.
+* `TauCeti.surjective_fderiv_levelSetParameterMap_iff`: regularity of the local parameter map at
+  the origin is equivalent to regularity of the fixed-parameter equation.
+* `TauCeti.index_fderiv_levelSetParameterMap`: the local parameter map has the expected index.
+* `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetParameterMap`:
+  local Sard--Smale for the parameter map of a universal level set.
+
+## References
+
+* D. McDuff, D. Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., AMS Colloquium
+  Publications 52, 2012, Appendix A.3.
+* S. Smale, *An infinite dimensional version of Sard's theorem*, Amer. J. Math. 87 (1965),
+  861--866.
+-/
+
+public section
+
+open Function Module Set
+open scoped ContDiff Topology
+
+namespace TauCeti
+
+variable {K E Λ F : Type*} [NontriviallyNormedField K]
+variable [NormedAddCommGroup E] [NormedSpace K E] [CompleteSpace E]
+variable [NormedAddCommGroup Λ] [NormedSpace K Λ] [CompleteSpace Λ]
+variable [NormedAddCommGroup F] [NormedSpace K F] [CompleteSpace F]
+variable {f : E × Λ → F} {D₁ : E →L[K] F} {D₂ : Λ →L[K] F}
+variable {x : E} {l : Λ} {c : F}
+
+/-- The local projection from a universal level set to its parameter space, written in the
+regular-level-set chart at `(x, l)`.
+
+The function is meaningful on the target of the level-set chart, a neighbourhood of the origin.
+As with `TauCeti.levelSetChart`, its value outside that target is an irrelevant total extension. -/
+noncomputable def levelSetParameterMap
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) : (D₁.coprod D₂).ker → Λ :=
+  fun k ↦ (((levelSetChart hf (LinearMap.range_eq_top.mpr hD) hker hxl).symm k :
+    ↥{z | f z = c}) : E × Λ).2
+
+/-- The local parameter map reads the parameter component of the inverse level-set chart. -/
+theorem levelSetParameterMap_apply
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) (k : (D₁.coprod D₂).ker) :
+    levelSetParameterMap hf hD hker hxl k =
+      (((levelSetChart hf (LinearMap.range_eq_top.mpr hD) hker hxl).symm k :
+        ↥{z | f z = c}) : E × Λ).2 := by
+  unfold levelSetParameterMap
+  rfl
+
+/-- The local parameter map, as an equality of functions, is the parameter component of the
+inverse level-set chart. -/
+private theorem levelSetParameterMap_eq
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) :
+    levelSetParameterMap hf hD hker hxl = fun k ↦
+      (((levelSetChart hf (LinearMap.range_eq_top.mpr hD) hker hxl).symm k :
+        ↥{z | f z = c}) : E × Λ).2 := by
+  funext k
+  exact levelSetParameterMap_apply hf hD hker hxl k
+
+/-- At the chart origin, the local parameter map returns the base parameter. -/
+@[simp]
+theorem levelSetParameterMap_zero
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) :
+    levelSetParameterMap hf hD hker hxl 0 = l := by
+  rw [levelSetParameterMap_apply, levelSetChart_symm_zero]
+
+/-- The local parameter map is as smooth at the chart origin as the parametrized equation. -/
+theorem contDiffAt_levelSetParameterMap {n : ℕ∞ω}
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hcont : ContDiffAt K n f (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) :
+    ContDiffAt K n (levelSetParameterMap hf hD hker hxl) 0 := by
+  have hchart := contDiffAt_coe_levelSetChart_symm hf hcont
+    (LinearMap.range_eq_top.mpr hD) hker hxl
+  rw [levelSetParameterMap_eq]
+  exact hchart.snd
+
+/-- The derivative at the chart origin of the local parameter map is the restriction of the
+ambient parameter projection to the kernel of the total linearization. -/
+theorem hasStrictFDerivAt_levelSetParameterMap
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) :
+    HasStrictFDerivAt (levelSetParameterMap hf hD hker hxl)
+      (parameterProj D₁ D₂) 0 := by
+  have hchart := hasStrictFDerivAt_coe_levelSetChart_symm hf
+    (LinearMap.range_eq_top.mpr hD) hker hxl
+  have hcomp := (ContinuousLinearMap.snd K E Λ).hasStrictFDerivAt.comp 0 hchart
+  have hlinear :
+      (ContinuousLinearMap.snd K E Λ).comp (D₁.coprod D₂).ker.subtypeL =
+        parameterProj D₁ D₂ := by
+    ext k
+    rw [parameterProj_apply]
+    rfl
+  rw [← hlinear]
+  rw [levelSetParameterMap_eq]
+  exact hcomp
+
+/-- The Fréchet derivative of the local parameter map at the chart origin is the linear
+parameter projection. -/
+theorem fderiv_levelSetParameterMap
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) :
+    fderiv K (levelSetParameterMap hf hD hker hxl) 0 = parameterProj D₁ D₂ :=
+  (hasStrictFDerivAt_levelSetParameterMap hf hD hker hxl).hasFDerivAt.fderiv
+
+/-- The local parameter map is regular at the chart origin exactly when the linearization of the
+equation with the parameter fixed is surjective. -/
+theorem surjective_fderiv_levelSetParameterMap_iff
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) :
+    Surjective (fderiv K (levelSetParameterMap hf hD hker hxl) 0) ↔ Surjective D₁ := by
+  rw [fderiv_levelSetParameterMap hf hD hker hxl]
+  exact parameterProj_surjective_iff D₁ D₂ hD
+
+/-- The derivative of the local parameter map has the same continuous-linear-map index as the
+fixed-parameter linearization. When the latter is Fredholm, this common value is their Fredholm
+index. -/
+theorem index_fderiv_levelSetParameterMap
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) :
+    ContinuousLinearMap.index (fderiv K (levelSetParameterMap hf hD hker hxl) 0) =
+      ContinuousLinearMap.index D₁ := by
+  rw [fderiv_levelSetParameterMap hf hD hker hxl]
+  exact index_parameterProj D₁ D₂ hD
+
+section RCLike
+
+variable [IsRCLikeNormedField K] [CompleteSpace K]
+
+/-- If the fixed-parameter linearization is Fredholm, then so is the derivative at the origin of
+the local parameter map. -/
+theorem isFredholm_fderiv_levelSetParameterMap
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) (hD₁ : ContinuousLinearMap.IsFredholm D₁) :
+    ContinuousLinearMap.IsFredholm (fderiv K (levelSetParameterMap hf hD hker hxl) 0) := by
+  rw [fderiv_levelSetParameterMap hf hD hker hxl]
+  exact isFredholm_parameterProj D₁ D₂ hD₁
+
+end RCLike
+
+section Real
+
+variable {E Λ F : Type*}
+variable [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+variable [NormedAddCommGroup Λ] [NormedSpace ℝ Λ] [CompleteSpace Λ]
+variable [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
+variable {f : E × Λ → F} {D₁ : E →L[ℝ] F} {D₂ : Λ →L[ℝ] F}
+variable {x : E} {l : Λ} {c : F}
+
+/-- **Local parametric Sard--Smale.** In a regular chart of a universal level set whose
+fixed-parameter linearization is Fredholm, the critical values of the local parameter map coming
+from a sufficiently small neighbourhood of the chart origin form a closed nowhere dense set.
+
+The differentiability threshold is the one currently supplied by
+`TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints`, rewritten using the fact
+that the kernel of `parameterProj D₁ D₂` has the same dimension as `ker D₁`. -/
+theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetParameterMap
+    {n : ℕ∞ω}
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hcont : ContDiffAt ℝ n f (x, l))
+    (hD₁ : ContinuousLinearMap.IsFredholm D₁)
+    (hD : Surjective (D₁.coprod D₂))
+    (hxl : f (x, l) = c)
+    (hn : ((finrank ℝ D₁.ker * finrank ℝ D₁.ker + 1 : ℕ) : ℕ∞ω) ≤ n) :
+    let hker := hD₁.closedComplemented_ker_coprod hD
+    let g := levelSetParameterMap hf hD hker hxl
+    ∃ N ∈ 𝓝 (0 : (D₁.coprod D₂).ker),
+      IsClosed (g '' (N ∩ {k | ¬ Surjective (fderiv ℝ g k)})) ∧
+        IsNowhereDense (g '' (N ∩ {k | ¬ Surjective (fderiv ℝ g k)})) := by
+  dsimp only
+  let hker := hD₁.closedComplemented_ker_coprod hD
+  let g := levelSetParameterMap hf hD hker hxl
+  have hg : ContDiffAt ℝ n g 0 := contDiffAt_levelSetParameterMap hf hcont hD hker hxl
+  have hg' : fderiv ℝ g 0 = parameterProj D₁ D₂ :=
+    fderiv_levelSetParameterMap hf hD hker hxl
+  have hn' :
+      ((finrank ℝ (parameterProj D₁ D₂).ker * finrank ℝ (parameterProj D₁ D₂).ker + 1 : ℕ) :
+        ℕ∞ω) ≤ n := by
+    simpa only [finrank_ker_parameterProj] using hn
+  have hFred : ContinuousLinearMap.IsFredholm (fderiv ℝ g 0) := by
+    rw [hg']
+    exact isFredholm_parameterProj D₁ D₂ hD₁
+  have hn'' :
+      ((finrank ℝ (fderiv ℝ g 0).ker * finrank ℝ (fderiv ℝ g 0).ker + 1 : ℕ) : ℕ∞ω) ≤ n := by
+    rw [hg']
+    exact hn'
+  exact exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints hg hFred hn''
+
+end Real
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -24,7 +24,10 @@ This file calculates that map's derivative at the chart origin. It is exactly
 `TauCeti.Analysis.Fredholm.Parametric`. Consequently, when `D₁` is Fredholm, the local parameter
 map has Fredholm derivative of the same index as `D₁`; and its derivative is surjective exactly
 when `D₁` is surjective. The final theorem applies local Sard--Smale to show that nearby critical
-values of the parameter map form a closed nowhere dense set.
+values of the parameter map form a closed nowhere dense set. The identification of criticality
+with failure of regularity for the fixed-parameter equation is proved only at the chart origin;
+the nearby critical-value conclusion is not yet a statement about regular parameters of that
+equation.
 
 These results are the local nonlinear calculation in the parametric transversality package of
 McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., Appendix A.3. Passing
@@ -35,7 +38,7 @@ smooth compatibility and a countable cover, and is not asserted here.
 
 * `TauCeti.hasStrictFDerivAt_levelSetParameterMap`: the derivative at the chart origin is the
   linear parameter projection.
-* `TauCeti.surjective_fderiv_levelSetParameterMap_iff`: regularity of the local parameter map at
+* `TauCeti.fderiv_levelSetParameterMap_surjective_iff`: regularity of the local parameter map at
   the origin is equivalent to regularity of the fixed-parameter equation.
 * `TauCeti.index_fderiv_levelSetParameterMap`: the local parameter map has the expected index.
 * `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetParameterMap`:
@@ -88,19 +91,6 @@ theorem levelSetParameterMap_apply
   unfold levelSetParameterMap
   rfl
 
-/-- The local parameter map, as an equality of functions, is the parameter component of the
-inverse level-set chart. -/
-private theorem levelSetParameterMap_eq
-    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
-    (hD : Surjective (D₁.coprod D₂))
-    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
-    (hxl : f (x, l) = c) :
-    levelSetParameterMap hf hD hker hxl = fun k ↦
-      (((levelSetChart hf (LinearMap.range_eq_top.mpr hD) hker hxl).symm k :
-        ↥{z | f z = c}) : E × Λ).2 := by
-  funext k
-  exact levelSetParameterMap_apply hf hD hker hxl k
-
 /-- At the chart origin, the local parameter map returns the base parameter. -/
 @[simp]
 theorem levelSetParameterMap_zero
@@ -121,7 +111,7 @@ theorem contDiffAt_levelSetParameterMap {n : ℕ∞ω}
     ContDiffAt K n (levelSetParameterMap hf hD hker hxl) 0 := by
   have hchart := contDiffAt_coe_levelSetChart_symm hf hcont
     (LinearMap.range_eq_top.mpr hD) hker hxl
-  rw [levelSetParameterMap_eq]
+  rw [funext fun k ↦ levelSetParameterMap_apply hf hD hker hxl k]
   exact hchart.snd
 
 /-- The derivative at the chart origin of the local parameter map is the restriction of the
@@ -135,19 +125,14 @@ theorem hasStrictFDerivAt_levelSetParameterMap
       (parameterProj D₁ D₂) 0 := by
   have hchart := hasStrictFDerivAt_coe_levelSetChart_symm hf
     (LinearMap.range_eq_top.mpr hD) hker hxl
-  have hcomp := (ContinuousLinearMap.snd K E Λ).hasStrictFDerivAt.comp 0 hchart
-  have hlinear :
-      (ContinuousLinearMap.snd K E Λ).comp (D₁.coprod D₂).ker.subtypeL =
-        parameterProj D₁ D₂ := by
-    ext k
-    rw [parameterProj_apply]
-    rfl
-  rw [← hlinear]
-  rw [levelSetParameterMap_eq]
+  have hcomp := hchart.snd
+  rw [parameterProj_eq_comp_subtypeL]
+  rw [funext fun k ↦ levelSetParameterMap_apply hf hD hker hxl k]
   exact hcomp
 
 /-- The Fréchet derivative of the local parameter map at the chart origin is the linear
 parameter projection. -/
+@[simp]
 theorem fderiv_levelSetParameterMap
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))
@@ -158,7 +143,7 @@ theorem fderiv_levelSetParameterMap
 
 /-- The local parameter map is regular at the chart origin exactly when the linearization of the
 equation with the parameter fixed is surjective. -/
-theorem surjective_fderiv_levelSetParameterMap_iff
+theorem fderiv_levelSetParameterMap_surjective_iff
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))
     (hker : (D₁.coprod D₂).ker.ClosedComplemented)
@@ -210,6 +195,11 @@ variable {x : E} {l : Λ} {c : F}
 fixed-parameter linearization is Fredholm, the critical values of the local parameter map coming
 from a sufficiently small neighbourhood of the chart origin form a closed nowhere dense set.
 
+Here criticality is defined intrinsically for the local parameter map. Its equivalence with
+failure of surjectivity of the fixed-parameter linearization has only been established at the
+chart origin, so this result does not yet identify nearby critical values with non-regular
+parameters of the original equation.
+
 The differentiability threshold is the one currently supplied by
 `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints`, rewritten using the fact
 that the kernel of `parameterProj D₁ D₂` has the same dimension as `ker D₁`. -/
@@ -219,15 +209,14 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetPar
     (hcont : ContDiffAt ℝ n f (x, l))
     (hD₁ : ContinuousLinearMap.IsFredholm D₁)
     (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
     (hxl : f (x, l) = c)
     (hn : ((finrank ℝ D₁.ker * finrank ℝ D₁.ker + 1 : ℕ) : ℕ∞ω) ≤ n) :
-    let hker := hD₁.closedComplemented_ker_coprod hD
-    let g := levelSetParameterMap hf hD hker hxl
     ∃ N ∈ 𝓝 (0 : (D₁.coprod D₂).ker),
-      IsClosed (g '' (N ∩ {k | ¬ Surjective (fderiv ℝ g k)})) ∧
-        IsNowhereDense (g '' (N ∩ {k | ¬ Surjective (fderiv ℝ g k)})) := by
-  dsimp only
-  let hker := hD₁.closedComplemented_ker_coprod hD
+      IsClosed (levelSetParameterMap hf hD hker hxl ''
+        (N ∩ {k | ¬ Surjective (fderiv ℝ (levelSetParameterMap hf hD hker hxl) k)})) ∧
+      IsNowhereDense (levelSetParameterMap hf hD hker hxl ''
+        (N ∩ {k | ¬ Surjective (fderiv ℝ (levelSetParameterMap hf hD hker hxl) k)})) := by
   let g := levelSetParameterMap hf hD hker hxl
   have hg : ContDiffAt ℝ n g 0 := contDiffAt_levelSetParameterMap hf hcont hD hker hxl
   have hg' : fderiv ℝ g 0 = parameterProj D₁ D₂ :=
@@ -236,9 +225,7 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetPar
       ((finrank ℝ (parameterProj D₁ D₂).ker * finrank ℝ (parameterProj D₁ D₂).ker + 1 : ℕ) :
         ℕ∞ω) ≤ n := by
     simpa only [finrank_ker_parameterProj] using hn
-  have hFred : ContinuousLinearMap.IsFredholm (fderiv ℝ g 0) := by
-    rw [hg']
-    exact isFredholm_parameterProj D₁ D₂ hD₁
+  have hFred := isFredholm_fderiv_levelSetParameterMap hf hD hker hxl hD₁
   have hn'' :
       ((finrank ℝ (fderiv ℝ g 0).ker * finrank ℝ (fderiv ℝ g 0).ker + 1 : ℕ) : ℕ∞ω) ≤ n := by
     rw [hg']

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -90,6 +90,7 @@ noncomputable def levelSetParameterMap
     ↥{z | f z = c}) : E × Λ).2
 
 /-- The local parameter map reads the parameter component of the inverse level-set chart. -/
+@[simp]
 theorem levelSetParameterMap_apply
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))
@@ -102,7 +103,6 @@ theorem levelSetParameterMap_apply
   rfl
 
 /-- At the chart origin, the local parameter map returns the base parameter. -/
-@[simp]
 theorem levelSetParameterMap_zero
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -23,9 +23,10 @@ This file calculates that map's derivative at the chart origin. It is exactly
 `TauCeti.parameterProj D₁ D₂`, the linear parameter projection developed in
 `TauCeti.Analysis.Fredholm.Parametric`. Every statement about that linear map therefore transfers
 to the derivative at the origin: it is surjective exactly when `D₁` is, by
-`TauCeti.parameterProj_surjective_iff`; it has the same index as `D₁`, by
-`TauCeti.index_parameterProj`; and over a complete `RCLike` field it is Fredholm as soon as `D₁`
-is, by `TauCeti.isFredholm_fderiv_levelSetParameterMap`. The final theorem applies local
+`TauCeti.surjective_fderiv_levelSetParameterMap_iff`; it has the same index as `D₁`, by
+`TauCeti.index_fderiv_levelSetParameterMap`; and over a complete `RCLike` field it is Fredholm as
+soon as `D₁` is, by `TauCeti.isFredholm_fderiv_levelSetParameterMap`. The final theorem applies
+local
 Sard--Smale to show that, inside the chart target, nearby critical values of the parameter map
 form a closed nowhere dense set. The identification of criticality with failure of regularity for
 the fixed-parameter equation is proved only at the chart origin; the nearby critical-value
@@ -44,6 +45,10 @@ smooth compatibility and a countable cover, and is not asserted here.
   the parameter projection of the universal level set.
 * `TauCeti.exists_apply_eq_of_levelSetParameterMap`: every value of the local parameter map is a
   parameter at which the equation has a solution.
+* `TauCeti.surjective_fderiv_levelSetParameterMap_iff`: the chart origin is a regular point of the
+  local parameter map exactly when the fixed-parameter linearization is surjective.
+* `TauCeti.index_fderiv_levelSetParameterMap`: that derivative has the index of the
+  fixed-parameter linearization.
 * `TauCeti.isFredholm_fderiv_levelSetParameterMap`: over a complete `RCLike` field, that
   derivative is Fredholm as soon as the fixed-parameter linearization is.
 * `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetParameterMap`:
@@ -177,6 +182,32 @@ theorem fderiv_levelSetParameterMap
     fderiv K (levelSetParameterMap hf hD hker hxl) 0 = parameterProj D₁ D₂ :=
   (hasStrictFDerivAt_levelSetParameterMap hf hD hker hxl).hasFDerivAt.fderiv
 
+/-- **Regularity at the chart origin.** The derivative of the local parameter map at the chart
+origin is surjective exactly when the fixed-parameter linearization is. This is the
+transversality criterion the parametric package is aimed at, transported to the nonlinear map by
+`TauCeti.fderiv_levelSetParameterMap`. -/
+theorem surjective_fderiv_levelSetParameterMap_iff
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) :
+    Surjective (fderiv K (levelSetParameterMap hf hD hker hxl) 0) ↔ Surjective D₁ := by
+  rw [fderiv_levelSetParameterMap]
+  exact parameterProj_surjective_iff D₁ D₂ hD
+
+/-- The derivative of the local parameter map at the chart origin has the same index as the
+fixed-parameter linearization. Neither map is assumed Fredholm: both indices are differences of
+`Module.finrank`s, junk values included. -/
+theorem index_fderiv_levelSetParameterMap
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) :
+    ContinuousLinearMap.index (fderiv K (levelSetParameterMap hf hD hker hxl) 0) =
+      ContinuousLinearMap.index D₁ := by
+  rw [fderiv_levelSetParameterMap]
+  exact index_parameterProj D₁ D₂ hD
+
 section RCLike
 
 variable [IsRCLikeNormedField K] [CompleteSpace K]
@@ -213,9 +244,8 @@ extension of `TauCeti.levelSetParameterMap`.
 
 Here criticality is defined intrinsically for the local parameter map. Its equivalence with
 failure of surjectivity of the fixed-parameter linearization has only been established at the
-chart origin, by `TauCeti.fderiv_levelSetParameterMap` and
-`TauCeti.parameterProj_surjective_iff`, so this result does not yet identify nearby critical
-values with non-regular parameters of the original equation.
+chart origin, by `TauCeti.surjective_fderiv_levelSetParameterMap_iff`, so this result does not yet
+identify nearby critical values with non-regular parameters of the original equation.
 
 The differentiability threshold is the one currently supplied by
 `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints`, rewritten using the fact

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -80,6 +80,7 @@ noncomputable def levelSetParameterMap
     ↥{z | f z = c}) : E × Λ).2
 
 /-- The local parameter map reads the parameter component of the inverse level-set chart. -/
+@[simp]
 theorem levelSetParameterMap_apply
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -240,7 +240,10 @@ from a sufficiently small neighbourhood of the chart origin form a closed nowher
 
 The neighbourhood is contained in the target of the level-set chart, on which the local parameter
 map really is the parameter projection of the universal level set rather than the irrelevant total
-extension of `TauCeti.levelSetParameterMap`.
+extension of `TauCeti.levelSetParameterMap`. It can also be confined to any prescribed
+neighbourhood `U` of the chart origin, as
+`TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints` allows; take `U = univ` for
+the plain statement.
 
 Here criticality is defined intrinsically for the local parameter map. Its equivalence with
 failure of surjectivity of the fixed-parameter linearization has only been established at the
@@ -251,15 +254,16 @@ The differentiability threshold is the one currently supplied by
 `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints`, rewritten using the fact
 that the kernel of `parameterProj D₁ D₂` has the same dimension as `ker D₁`. -/
 theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetParameterMap
-    {n : ℕ∞ω}
+    {n : ℕ∞ω} {U : Set (D₁.coprod D₂).ker}
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hcont : ContDiffAt ℝ n f (x, l))
     (hD₁ : ContinuousLinearMap.IsFredholm D₁)
     (hD : Surjective (D₁.coprod D₂))
     (hxl : f (x, l) = c)
-    (hn : ((finrank ℝ D₁.ker * finrank ℝ D₁.ker + 1 : ℕ) : ℕ∞ω) ≤ n) :
+    (hn : ((finrank ℝ D₁.ker * finrank ℝ D₁.ker + 1 : ℕ) : ℕ∞ω) ≤ n)
+    (hU : U ∈ 𝓝 (0 : (D₁.coprod D₂).ker)) :
     ∃ N ∈ 𝓝 (0 : (D₁.coprod D₂).ker),
-      N ⊆ (levelSetChart hf (LinearMap.range_eq_top.mpr hD)
+      N ⊆ U ∩ (levelSetChart hf (LinearMap.range_eq_top.mpr hD)
         (hD₁.closedComplemented_ker_coprod hD) hxl).target ∧
       IsClosed (levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl ''
         (N ∩ {k | ¬ Surjective (fderiv ℝ
@@ -285,7 +289,8 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetPar
     (hD₁.closedComplemented_ker_coprod hD) hxl).open_target.mem_nhds
       (mem_levelSetChart_target hf (LinearMap.range_eq_top.mpr hD)
         (hD₁.closedComplemented_ker_coprod hD) hxl)
-  exact exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints hg hFred hn'' htarget
+  exact exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints hg hFred hn''
+    (Filter.inter_mem hU htarget)
 
 end Real
 

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -21,13 +21,15 @@ map `TauCeti.levelSetParameterMap`.
 
 This file calculates that map's derivative at the chart origin. It is exactly
 `TauCeti.parameterProj D₁ D₂`, the linear parameter projection developed in
-`TauCeti.Analysis.Fredholm.Parametric`. Consequently, when `D₁` is Fredholm, the local parameter
-map has Fredholm derivative of the same index as `D₁`; and its derivative is surjective exactly
-when `D₁` is surjective. The final theorem applies local Sard--Smale to show that nearby critical
-values of the parameter map form a closed nowhere dense set. The identification of criticality
-with failure of regularity for the fixed-parameter equation is proved only at the chart origin;
-the nearby critical-value conclusion is not yet a statement about regular parameters of that
-equation.
+`TauCeti.Analysis.Fredholm.Parametric`. Every statement about that linear map therefore transfers
+to the derivative at the origin: it is surjective exactly when `D₁` is, by
+`TauCeti.parameterProj_surjective_iff`; it has the same index as `D₁`, by
+`TauCeti.index_parameterProj`; and over a complete `RCLike` field it is Fredholm as soon as `D₁`
+is, by `TauCeti.isFredholm_fderiv_levelSetParameterMap`. The final theorem applies local
+Sard--Smale to show that, inside the chart target, nearby critical values of the parameter map
+form a closed nowhere dense set. The identification of criticality with failure of regularity for
+the fixed-parameter equation is proved only at the chart origin; the nearby critical-value
+conclusion is not yet a statement about regular parameters of that equation.
 
 These results are the local nonlinear calculation in the parametric transversality package of
 McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., Appendix A.3. Passing
@@ -38,9 +40,10 @@ smooth compatibility and a countable cover, and is not asserted here.
 
 * `TauCeti.hasStrictFDerivAt_levelSetParameterMap`: the derivative at the chart origin is the
   linear parameter projection.
-* `TauCeti.fderiv_levelSetParameterMap_surjective_iff`: regularity of the local parameter map at
-  the origin is equivalent to regularity of the fixed-parameter equation.
-* `TauCeti.index_fderiv_levelSetParameterMap`: the local parameter map has the expected index.
+* `TauCeti.exists_apply_eq_of_levelSetParameterMap`: every value of the local parameter map is a
+  parameter at which the equation has a solution.
+* `TauCeti.isFredholm_fderiv_levelSetParameterMap`: over a complete `RCLike` field, that
+  derivative is Fredholm as soon as the fixed-parameter linearization is.
 * `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetParameterMap`:
   local Sard--Smale for the parameter map of a universal level set.
 
@@ -80,7 +83,6 @@ noncomputable def levelSetParameterMap
     ↥{z | f z = c}) : E × Λ).2
 
 /-- The local parameter map reads the parameter component of the inverse level-set chart. -/
-@[simp]
 theorem levelSetParameterMap_apply
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))
@@ -93,6 +95,7 @@ theorem levelSetParameterMap_apply
   rfl
 
 /-- At the chart origin, the local parameter map returns the base parameter. -/
+@[simp]
 theorem levelSetParameterMap_zero
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))
@@ -100,6 +103,20 @@ theorem levelSetParameterMap_zero
     (hxl : f (x, l) = c) :
     levelSetParameterMap hf hD hker hxl 0 = l := by
   rw [levelSetParameterMap_apply, levelSetChart_symm_zero]
+
+/-- Every value of the local parameter map is a parameter for which the equation has a solution:
+the chart parametrizes the universal level set, so the point it produces solves the equation at
+the parameter that the map returns. -/
+theorem exists_apply_eq_of_levelSetParameterMap
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) (k : (D₁.coprod D₂).ker) :
+    ∃ x' : E, f (x', levelSetParameterMap hf hD hker hxl k) = c := by
+  refine ⟨(((levelSetChart hf (LinearMap.range_eq_top.mpr hD) hker hxl).symm k :
+    ↥{z | f z = c}) : E × Λ).1, ?_⟩
+  rw [levelSetParameterMap_apply]
+  exact ((levelSetChart hf (LinearMap.range_eq_top.mpr hD) hker hxl).symm k).2
 
 /-- The local parameter map is as smooth at the chart origin as the parametrized equation. -/
 theorem contDiffAt_levelSetParameterMap {n : ℕ∞ω}
@@ -144,30 +161,6 @@ theorem fderiv_levelSetParameterMap
     fderiv K (levelSetParameterMap hf hD hker hxl) 0 = parameterProj D₁ D₂ :=
   (hasStrictFDerivAt_levelSetParameterMap hf hD hker hxl).hasFDerivAt.fderiv
 
-/-- The local parameter map is regular at the chart origin exactly when the linearization of the
-equation with the parameter fixed is surjective. -/
-theorem fderiv_levelSetParameterMap_surjective_iff
-    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
-    (hD : Surjective (D₁.coprod D₂))
-    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
-    (hxl : f (x, l) = c) :
-    Surjective (fderiv K (levelSetParameterMap hf hD hker hxl) 0) ↔ Surjective D₁ := by
-  rw [fderiv_levelSetParameterMap hf hD hker hxl]
-  exact parameterProj_surjective_iff D₁ D₂ hD
-
-/-- The derivative of the local parameter map has the same continuous-linear-map index as the
-fixed-parameter linearization. When the latter is Fredholm, this common value is their Fredholm
-index. -/
-theorem index_fderiv_levelSetParameterMap
-    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
-    (hD : Surjective (D₁.coprod D₂))
-    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
-    (hxl : f (x, l) = c) :
-    ContinuousLinearMap.index (fderiv K (levelSetParameterMap hf hD hker hxl) 0) =
-      ContinuousLinearMap.index D₁ := by
-  rw [fderiv_levelSetParameterMap hf hD hker hxl]
-  exact index_parameterProj D₁ D₂ hD
-
 section RCLike
 
 variable [IsRCLikeNormedField K] [CompleteSpace K]
@@ -198,10 +191,15 @@ variable {x : E} {l : Λ} {c : F}
 fixed-parameter linearization is Fredholm, the critical values of the local parameter map coming
 from a sufficiently small neighbourhood of the chart origin form a closed nowhere dense set.
 
+The neighbourhood is contained in the target of the level-set chart, on which the local parameter
+map really is the parameter projection of the universal level set rather than the irrelevant total
+extension of `TauCeti.levelSetParameterMap`.
+
 Here criticality is defined intrinsically for the local parameter map. Its equivalence with
 failure of surjectivity of the fixed-parameter linearization has only been established at the
-chart origin, so this result does not yet identify nearby critical values with non-regular
-parameters of the original equation.
+chart origin, by `TauCeti.fderiv_levelSetParameterMap` and
+`TauCeti.parameterProj_surjective_iff`, so this result does not yet identify nearby critical
+values with non-regular parameters of the original equation.
 
 The differentiability threshold is the one currently supplied by
 `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints`, rewritten using the fact
@@ -215,6 +213,8 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetPar
     (hxl : f (x, l) = c)
     (hn : ((finrank ℝ D₁.ker * finrank ℝ D₁.ker + 1 : ℕ) : ℕ∞ω) ≤ n) :
     ∃ N ∈ 𝓝 (0 : (D₁.coprod D₂).ker),
+      N ⊆ (levelSetChart hf (LinearMap.range_eq_top.mpr hD)
+        (hD₁.closedComplemented_ker_coprod hD) hxl).target ∧
       IsClosed (levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl ''
         (N ∩ {k | ¬ Surjective (fderiv ℝ
           (levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl) k)})) ∧
@@ -235,7 +235,11 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetPar
       ((finrank ℝ (fderiv ℝ g 0).ker * finrank ℝ (fderiv ℝ g 0).ker + 1 : ℕ) : ℕ∞ω) ≤ n := by
     rw [hg']
     exact hn'
-  exact exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints hg hFred hn''
+  have htarget := (levelSetChart hf (LinearMap.range_eq_top.mpr hD)
+    (hD₁.closedComplemented_ker_coprod hD) hxl).open_target.mem_nhds
+      (mem_levelSetChart_target hf (LinearMap.range_eq_top.mpr hD)
+        (hD₁.closedComplemented_ker_coprod hD) hxl)
+  exact exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints hg hFred hn'' htarget
 
 end Real
 

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -40,6 +40,8 @@ smooth compatibility and a countable cover, and is not asserted here.
 
 * `TauCeti.hasStrictFDerivAt_levelSetParameterMap`: the derivative at the chart origin is the
   linear parameter projection.
+* `TauCeti.levelSetParameterMap_levelSetChart`: on the chart source, the local parameter map is
+  the parameter projection of the universal level set.
 * `TauCeti.exists_apply_eq_of_levelSetParameterMap`: every value of the local parameter map is a
   parameter at which the equation has a solution.
 * `TauCeti.isFredholm_fderiv_levelSetParameterMap`: over a complete `RCLike` field, that
@@ -103,6 +105,20 @@ theorem levelSetParameterMap_zero
     (hxl : f (x, l) = c) :
     levelSetParameterMap hf hD hker hxl 0 = l := by
   rw [levelSetParameterMap_apply, levelSetChart_symm_zero]
+
+/-- On the source of the level-set chart, the local parameter map really is the parameter
+projection of the universal level set: it sends the chart image of a solution `z` back to the
+parameter component of `z`. -/
+theorem levelSetParameterMap_levelSetChart
+    (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
+    (hD : Surjective (D₁.coprod D₂))
+    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
+    (hxl : f (x, l) = c) {z : ↥{z | f z = c}}
+    (hz : z ∈ (levelSetChart hf (LinearMap.range_eq_top.mpr hD) hker hxl).source) :
+    levelSetParameterMap hf hD hker hxl
+        (levelSetChart hf (LinearMap.range_eq_top.mpr hD) hker hxl z) = ((z : E × Λ)).2 := by
+  rw [levelSetParameterMap_apply,
+    (levelSetChart hf (LinearMap.range_eq_top.mpr hD) hker hxl).left_inv hz]
 
 /-- Every value of the local parameter map is a parameter for which the equation has a solution:
 the chart parametrizes the universal level set, so the point it produces solves the equation at

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -43,7 +43,7 @@ smooth compatibility and a countable cover, and is not asserted here.
   linear parameter projection.
 * `TauCeti.levelSetParameterMap_levelSetChart`: on the chart source, the local parameter map is
   the parameter projection of the universal level set.
-* `TauCeti.exists_apply_eq_of_levelSetParameterMap`: every value of the local parameter map is a
+* `TauCeti.exists_apply_levelSetParameterMap_eq`: every value of the local parameter map is a
   parameter at which the equation has a solution.
 * `TauCeti.surjective_fderiv_levelSetParameterMap_iff`: the chart origin is a regular point of the
   local parameter map exactly when the fixed-parameter linearization is surjective.
@@ -128,7 +128,7 @@ theorem levelSetParameterMap_levelSetChart
 /-- Every value of the local parameter map is a parameter for which the equation has a solution:
 the chart parametrizes the universal level set, so the point it produces solves the equation at
 the parameter that the map returns. -/
-theorem exists_apply_eq_of_levelSetParameterMap
+theorem exists_apply_levelSetParameterMap_eq
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))
     (hker : (D₁.coprod D₂).ker.ClosedComplemented)

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -174,10 +174,10 @@ the local parameter map. -/
 theorem isFredholm_fderiv_levelSetParameterMap
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))
-    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
     (hxl : f (x, l) = c) (hD₁ : ContinuousLinearMap.IsFredholm D₁) :
-    ContinuousLinearMap.IsFredholm (fderiv K (levelSetParameterMap hf hD hker hxl) 0) := by
-  rw [fderiv_levelSetParameterMap hf hD hker hxl]
+    ContinuousLinearMap.IsFredholm
+      (fderiv K (levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl) 0) := by
+  rw [fderiv_levelSetParameterMap]
   exact isFredholm_parameterProj D₁ D₂ hD₁
 
 end RCLike
@@ -209,23 +209,25 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints_levelSetPar
     (hcont : ContDiffAt ℝ n f (x, l))
     (hD₁ : ContinuousLinearMap.IsFredholm D₁)
     (hD : Surjective (D₁.coprod D₂))
-    (hker : (D₁.coprod D₂).ker.ClosedComplemented)
     (hxl : f (x, l) = c)
     (hn : ((finrank ℝ D₁.ker * finrank ℝ D₁.ker + 1 : ℕ) : ℕ∞ω) ≤ n) :
     ∃ N ∈ 𝓝 (0 : (D₁.coprod D₂).ker),
-      IsClosed (levelSetParameterMap hf hD hker hxl ''
-        (N ∩ {k | ¬ Surjective (fderiv ℝ (levelSetParameterMap hf hD hker hxl) k)})) ∧
-      IsNowhereDense (levelSetParameterMap hf hD hker hxl ''
-        (N ∩ {k | ¬ Surjective (fderiv ℝ (levelSetParameterMap hf hD hker hxl) k)})) := by
-  let g := levelSetParameterMap hf hD hker hxl
-  have hg : ContDiffAt ℝ n g 0 := contDiffAt_levelSetParameterMap hf hcont hD hker hxl
+      IsClosed (levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl ''
+        (N ∩ {k | ¬ Surjective (fderiv ℝ
+          (levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl) k)})) ∧
+      IsNowhereDense (levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl ''
+        (N ∩ {k | ¬ Surjective (fderiv ℝ
+          (levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl) k)})) := by
+  let g := levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl
+  have hg : ContDiffAt ℝ n g 0 :=
+    contDiffAt_levelSetParameterMap hf hcont hD (hD₁.closedComplemented_ker_coprod hD) hxl
   have hg' : fderiv ℝ g 0 = parameterProj D₁ D₂ :=
-    fderiv_levelSetParameterMap hf hD hker hxl
+    fderiv_levelSetParameterMap hf hD (hD₁.closedComplemented_ker_coprod hD) hxl
   have hn' :
       ((finrank ℝ (parameterProj D₁ D₂).ker * finrank ℝ (parameterProj D₁ D₂).ker + 1 : ℕ) :
         ℕ∞ω) ≤ n := by
     simpa only [finrank_ker_parameterProj] using hn
-  have hFred := isFredholm_fderiv_levelSetParameterMap hf hD hker hxl hD₁
+  have hFred := isFredholm_fderiv_levelSetParameterMap hf hD hxl hD₁
   have hn'' :
       ((finrank ℝ (fderiv ℝ g 0).ker * finrank ℝ (fderiv ℝ g 0).ker + 1 : ℕ) : ℕ∞ω) ≤ n := by
     rw [hg']

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -126,8 +126,11 @@ theorem hasStrictFDerivAt_levelSetParameterMap
   have hchart := hasStrictFDerivAt_coe_levelSetChart_symm hf
     (LinearMap.range_eq_top.mpr hD) hker hxl
   have hcomp := hchart.snd
-  rw [parameterProj_eq_comp_subtypeL]
-  rw [funext fun k ↦ levelSetParameterMap_apply hf hD hker hxl k]
+  have hproj : parameterProj D₁ D₂ =
+      (ContinuousLinearMap.snd K E Λ).comp (D₁.coprod D₂).ker.subtypeL := by
+    ext v
+    simp
+  rw [hproj, funext fun k ↦ levelSetParameterMap_apply hf hD hker hxl k]
   exact hcomp
 
 /-- The Fréchet derivative of the local parameter map at the chart origin is the linear

--- a/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean
@@ -93,7 +93,6 @@ theorem levelSetParameterMap_apply
   rfl
 
 /-- At the chart origin, the local parameter map returns the base parameter. -/
-@[simp]
 theorem levelSetParameterMap_zero
     (hf : HasStrictFDerivAt f (D₁.coprod D₂) (x, l))
     (hD : Surjective (D₁.coprod D₂))

--- a/TauCeti/Analysis/Fredholm/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/Parametric.lean
@@ -135,16 +135,6 @@ omit [IsTopologicalAddGroup E] [ContinuousSMul 𝕜 E] [IsTopologicalAddGroup Λ
 theorem parameterProj_apply (v : (D₁.coprod D₂).ker) : parameterProj D₁ D₂ v = (v : E × Λ).2 :=
   (rfl)
 
-omit [IsTopologicalAddGroup E] [ContinuousSMul 𝕜 E] [IsTopologicalAddGroup Λ]
-  [ContinuousSMul 𝕜 Λ] [ContinuousSMul 𝕜 F] in
-/-- The parameter projection is the ambient second projection composed with the kernel
-inclusion. -/
-theorem parameterProj_eq_comp_subtypeL :
-    parameterProj D₁ D₂ =
-      (ContinuousLinearMap.snd 𝕜 E Λ).comp (D₁.coprod D₂).ker.subtypeL := by
-  ext v
-  simp
-
 /-! ### Exactness at the candidate tangent space: the kernel of the projection -/
 
 /-- The embedding `x ↦ (x, 0)` of `ker D₁` into the kernel of the total linearization: the formal

--- a/TauCeti/Analysis/Fredholm/Parametric.lean
+++ b/TauCeti/Analysis/Fredholm/Parametric.lean
@@ -135,6 +135,16 @@ omit [IsTopologicalAddGroup E] [ContinuousSMul 𝕜 E] [IsTopologicalAddGroup Λ
 theorem parameterProj_apply (v : (D₁.coprod D₂).ker) : parameterProj D₁ D₂ v = (v : E × Λ).2 :=
   (rfl)
 
+omit [IsTopologicalAddGroup E] [ContinuousSMul 𝕜 E] [IsTopologicalAddGroup Λ]
+  [ContinuousSMul 𝕜 Λ] [ContinuousSMul 𝕜 F] in
+/-- The parameter projection is the ambient second projection composed with the kernel
+inclusion. -/
+theorem parameterProj_eq_comp_subtypeL :
+    parameterProj D₁ D₂ =
+      (ContinuousLinearMap.snd 𝕜 E Λ).comp (D₁.coprod D₂).ker.subtypeL := by
+  ext v
+  simp
+
 /-! ### Exactness at the candidate tangent space: the kernel of the projection -/
 
 /-- The embedding `x ↦ (x, 0)` of `ker D₁` into the kernel of the total linearization: the formal

--- a/TauCeti/Analysis/Fredholm/SardSmale.lean
+++ b/TauCeti/Analysis/Fredholm/SardSmale.lean
@@ -72,9 +72,9 @@ The regularity threshold is inherited unchanged from the finite-dimensional theo
 
 ## Main results
 
-* `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints`: the local form -- near a
-  point with Fredholm derivative there is a neighbourhood whose critical values are closed and
-  nowhere dense.
+* `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints`: the local form -- inside
+  any neighbourhood of a point with Fredholm derivative there is a neighbourhood whose critical
+  values are closed and nowhere dense.
 * `TauCeti.isMeagre_image_criticalPoints_of_isFredholm`: **the Sard--Smale theorem**.
 * `TauCeti.dense_compl_image_criticalPoints_of_isFredholm`: the regular values of a Fredholm map
   are dense, the form transversality arguments consume.
@@ -234,6 +234,8 @@ private theorem surjective_fderiv_iff_slice (pkg : ContinuousLinearMap.FredholmP
 
 /-- **Sard--Smale, locally.** Near a point where a sufficiently smooth map has Fredholm
 derivative there is a neighbourhood on which the critical values form a closed nowhere dense set.
+The neighbourhood can be taken inside any prescribed neighbourhood `U` of the point, so the
+conclusion can be confined to a region on which `f` is known to be the map of interest.
 
 Completeness of the target enters through Smale's local properness lemma, which supplies the
 compactness used to prove that the local critical-value image is closed.
@@ -242,10 +244,11 @@ The regularity threshold `(dim ker)² + 1` is the one inherited from the finite-
 Morse--Sard theorem `TauCeti.interior_image_criticalPoints_eq_empty`, which the fibrewise step
 applies to the obstruction slice, a map out of `ker (fderiv ℝ f a)`. -/
 theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
-    {f : E → F} {a : E} {n : ℕ∞ω} (hf : ContDiffAt ℝ n f a)
+    {f : E → F} {a : E} {U : Set E} {n : ℕ∞ω} (hf : ContDiffAt ℝ n f a)
     (hFred : (fderiv ℝ f a).IsFredholm)
-    (hn : ((finrank ℝ (fderiv ℝ f a).ker * finrank ℝ (fderiv ℝ f a).ker + 1 : ℕ) : ℕ∞ω) ≤ n) :
-    ∃ N ∈ 𝓝 a, IsClosed (f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)})) ∧
+    (hn : ((finrank ℝ (fderiv ℝ f a).ker * finrank ℝ (fderiv ℝ f a).ker + 1 : ℕ) : ℕ∞ω) ≤ n)
+    (hU : U ∈ 𝓝 a) :
+    ∃ N ∈ 𝓝 a, N ⊆ U ∧ IsClosed (f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)})) ∧
       IsNowhereDense (f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)})) := by
   set T := fderiv ℝ f a with hTdef
   set k : ℕ := finrank ℝ T.ker * finrank ℝ T.ker + 1 with hkdef
@@ -404,9 +407,12 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
   -- Smale's local properness, on a closed ball inside `N`.
   obtain ⟨N₂, hN₂, hprop⟩ := hT.exists_mem_nhds_forall_isCompact_inter_preimage
     hFred.isClosed_range hFred.finite_ker hFred.closedComplemented_ker
-  obtain ⟨r, hr, hball⟩ := Metric.mem_nhds_iff.1 (Filter.inter_mem (hNopen.mem_nhds haN) hN₂)
+  obtain ⟨r, hr, hball⟩ := Metric.mem_nhds_iff.1
+    (Filter.inter_mem (Filter.inter_mem (hNopen.mem_nhds haN) hN₂) hU)
   set N' : Set E := Metric.closedBall a (r / 2) with hN'def
-  have hN'ball : N' ⊆ N ∩ N₂ := (Metric.closedBall_subset_ball (by linarith)).trans hball
+  have hN'sub : N' ⊆ N ∩ N₂ ∩ U := (Metric.closedBall_subset_ball (by linarith)).trans hball
+  have hN'ball : N' ⊆ N ∩ N₂ := fun z hz ↦ (hN'sub hz).1
+  have hN'U : N' ⊆ U := fun z hz ↦ (hN'sub hz).2
   have hN'nhds : N' ∈ 𝓝 a := Metric.closedBall_mem_nhds a (by linarith)
   have hcritclosed : IsClosed (N' ∩ {x | ¬ Surjective (fderiv ℝ f x)}) := by
     have heq : N' ∩ {x | ¬ Surjective (fderiv ℝ f x)} =
@@ -437,7 +443,7 @@ theorem exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
     have himgclosed := (isProperMap_iff_isCompact_preimage.2
       ⟨hcontOn.domRestrict, fun K hK ↦ hpre K hK⟩).isClosedMap _ isClosed_univ
     rwa [Set.image_univ, Set.range_domRestrict] at himgclosed
-  refine ⟨N', hN'nhds, hclosedimg, ?_⟩
+  refine ⟨N', hN'nhds, hN'U, hclosedimg, ?_⟩
   rw [hclosedimg.isNowhereDense_iff]
   refine Set.eq_empty_of_subset_empty ?_
   rw [← hNint]
@@ -469,10 +475,9 @@ theorem isMeagre_image_criticalPoints_of_isFredholm {n : ℕ∞ω} (hU : IsOpen 
   have hloc : ∀ x ∈ U, ∃ N ⊆ U, N ∈ 𝓝 x ∧
       IsNowhereDense (f '' (N ∩ {x | ¬ Surjective (fderiv ℝ f x)})) := by
     intro x hx
-    obtain ⟨N, hN, -, hNnd⟩ := exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
-      (hf x hx) (hFred x hx) (hn x hx)
-    refine ⟨N ∩ U, Set.inter_subset_right, Filter.inter_mem hN (hU.mem_nhds hx), ?_⟩
-    exact hNnd.mono (Set.image_mono (Set.inter_subset_inter Set.inter_subset_left le_rfl))
+    obtain ⟨N, hN, hNU, -, hNnd⟩ := exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints
+      (hf x hx) (hFred x hx) (hn x hx) (hU.mem_nhds hx)
+    exact ⟨N, hNU, hN, hNnd⟩
   choose! N hNU hNnhds hNnd using hloc
   obtain ⟨t, htU, htc, htcover⟩ := TopologicalSpace.countable_cover_nhdsWithin
     (f := N) (s := U) fun x hx ↦ nhdsWithin_le_nhds (hNnhds x hx)


### PR DESCRIPTION
This PR computes the nonlinear parameter projection in a regular chart of a universal Fredholm level set. It defines `levelSetParameterMap`, proves that its derivative at the chart origin is exactly the existing linear map `parameterProj D₁ D₂`, and derives the expected surjectivity, Fredholm, and index statements. It then applies the local Sard--Smale theorem to show that critical values coming from a sufficiently small chart neighbourhood form a closed nowhere dense set.

The exact roadmap target is `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F0, milestone “the moduli space = zero set of a Fredholm section, generically a manifold of dimension = index” package. This is the most effective current step because `parameterProj`, the complemented-kernel theorem for universal linearizations, smooth regular-level-set charts, and Sard--Smale are all on `main`, while the only open HeegaardFloer PR (#5018) develops the independent split-quadratic Morse-flow model in Lane M. After this PR, the Lane F0 milestone still needs smooth compatibility and a countable localization across universal-level-set charts to obtain a residual set of regular parameters globally; the separate strip-operator target `d/ds + A(s)` also remains.

The new module `TauCeti/Analysis/Fredholm/LevelSet/Parametric.lean` is 252 lines. Its public API keeps the level-set chart construction generic over a nontrivially normed field, specializes Fredholmness only to the existing RCLike setting, and specializes Sard--Smale only to real Banach spaces. No Mathlib code or external formalization is vendored. The construction follows McDuff--Salamon, *J-holomorphic Curves and Symplectic Topology*, 2nd ed., Appendix A.3, and Smale, *An infinite dimensional version of Sard's theorem* (1965), as credited in the module documentation.

The PR now also generalizes `TauCeti.exists_mem_nhds_isClosed_isNowhereDense_image_criticalPoints` in `TauCeti/Analysis/Fredholm/SardSmale.lean` to shrink into a prescribed neighbourhood of the base point. This is the fix the `api-design` review finding on [#discussion_r3911296798](https://github.com/TauCetiProject/TauCeti/pull/5070#discussion_r3911296798) asked for: without it the exported local Sard--Smale statement cannot confine its neighbourhood to the level-set chart target, where `levelSetParameterMap` is the actual parameter projection rather than the total extension. The existing global Sard--Smale theorem now takes its `N ⊆ U` from the generalized local form instead of intersecting afterwards.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"nonlinear-parameter-projection"}-->

🤖 Prepared with Codex