### PR TITLE
feat: the value-ring naturality of the Kostant matrix torus

### DIFF
--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Frobenius.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ToralClosure/Frobenius.lean
@@ -126,16 +126,10 @@ the `p ^ k`-th power. -/
 theorem map_iterateFrobenius_kostantTorusMatrix (s : κ → Aˣ) :
     Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) (kostantTorusMatrix M b wt s) =
       kostantTorusMatrix M b wt (s ^ p ^ k) := by
-  have hchar : ∀ i : Fin n,
-      torusCharacter (s ^ p ^ k) (wt i) = torusCharacter s (wt i) ^ p ^ k := by
-    intro i
-    have hpow := congrFun (map_pow (torusCharacterHom (R := A) wt) s (p ^ k)) i
-    rwa [torusCharacterHom_apply, Pi.pow_apply, torusCharacterHom_apply] at hpow
-  refine Matrix.GeneralLinearGroup.ext fun r c => ?_
-  simp only [Matrix.GeneralLinearGroup.map_apply, kostantTorusMatrix_apply, diagGL_apply]
-  split_ifs with hrc
-  · rw [iterateFrobenius_def, ← Units.val_pow_eq_pow_val, hchar r]
-  · exact map_zero (iterateFrobenius A p k)
+  rw [map_kostantTorusMatrix]
+  refine congrArg (kostantTorusMatrix M b wt) (funext fun j => Units.ext ?_)
+  rw [Units.coe_map, MonoidHom.coe_coe, iterateFrobenius_def, Pi.pow_apply,
+    Units.val_pow_eq_pow_val]
 
 end Generators
 

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus/Basic.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Torus/Basic.lean
@@ -477,6 +477,22 @@ theorem kostantTorusMatrix_apply (s : κ → Aˣ) :
     (kostantTorusPoints_toLinearEquiv M b wt s)
   rw [hlinear, basisWeightTorus_apply, toMatrix_basisDiagonal, diagGL_coe]
 
+omit [Module ℚ V] in
+/-- **The matrix torus is natural in the value ring.** Applying a ring homomorphism entrywise to a
+torus point written in a weight basis gives the torus point of the transported parameters. The
+`p ^ k`-power Frobenius is the case
+`TauCeti.UniversalEnvelopingAlgebra.map_iterateFrobenius_kostantTorusMatrix`. -/
+-- Not `@[simp]`: `kostantTorusMatrix_apply` already simplifies the left-hand side to its
+-- diagonal form, so `simpNF` rejects this higher-level equation as not being in normal form.
+theorem map_kostantTorusMatrix {B : Type*} [CommRing B] [Algebra ℤ B] (φ : A →+* B) (s : κ → Aˣ) :
+    Matrix.GeneralLinearGroup.map φ (kostantTorusMatrix M b wt s) =
+      kostantTorusMatrix M b wt fun j => Units.map (φ : A →* B) (s j) := by
+  refine Matrix.GeneralLinearGroup.ext fun r c => ?_
+  simp only [Matrix.GeneralLinearGroup.map_apply, kostantTorusMatrix_apply, diagGL_apply]
+  split_ifs
+  · rw [← map_torusCharacter φ s (wt r), Units.coe_map, MonoidHom.coe_coe]
+  · exact map_zero φ
+
 end Matrix
 
 /-! ## The pinning equation -/


### PR DESCRIPTION

`TauCeti.UniversalEnvelopingAlgebra.map_kostantTorusMatrix`: applying a ring homomorphism
entrywise to a Kostant torus point written in a weight basis gives the torus point of the
transported parameters. The point-level naturality `map_kostantTorusPoints` and the matrix-level
Frobenius equation `map_iterateFrobenius_kostantTorusMatrix` both already existed; this adds the
missing general matrix-level statement between them, and rederives the Frobenius equation as its
special case at `iterateFrobenius` (net −10 lines in
`Kostant/RootSubgroup/Scheme/ToralClosure/Frobenius.lean`).

This mirrors the root-subgroup side, where the general `map_kostantRootSubgroupMatrix`
(`Kostant/RootSubgroup/Coordinate.lean`) already exists and
`map_iterateFrobenius_kostantRootSubgroupMatrix` is derived from it. The torus side now has the
same shape.

**Scope.** The lemma is the prerequisite for stating the value-ring functoriality of the pinned
Geck carrier's points, the "functorially in the field" half of the Layer 9 target "Points over an
algebraically closed field" in `TauCetiRoadmap/ReductiveGroups/README.md` ("so that a field
endomorphism induces a group endomorphism of the points"). It is split out of that work per the
one-topic rule; the consumer PR stacks on this one. The Frobenius rederivation is included here
rather than there because it is this lemma's in-repo consumer and the generality cleanup it
forces, not an opportunistic extra.

Roadmap: ReductiveGroups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
