### PR TITLE
feat: prove local logarithm and BCH naturality

### DIFF
--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -147,21 +147,22 @@ variable {B : Type*} [NormedRing B] [NormedAlgebra ℝ B] [CompleteSpace B]
 
 /-- Continuous real algebra homomorphisms commute with the local
 Baker--Campbell--Hausdorff germ. -/
-@[simp]
-theorem map_localBCH {F : Type*} [FunLike F A B] [RingHomClass F A B]
-    (f : F) (hf : Continuous f) :
+@[simp high]
+theorem map_localBCH {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
+    [RingHomClass F A B] (f : F) :
     (localBCH A).map f =
       (localBCH B).compTendsto (Prod.map f f) (by
-        exact (hf.prodMap hf).tendsto' (0, 0) (0, 0) (by simp)) := by
+        exact ((map_continuous f).prodMap (map_continuous f)).tendsto'
+          (0, 0) (0, 0) (by simp)) := by
   let _ : NormedAlgebra ℚ A := NormedAlgebra.restrictScalars ℚ ℝ A
   let _ : NormedAlgebra ℚ B := NormedAlgebra.restrictScalars ℚ ℝ B
   rw [localBCH_def, Germ.map_coe, localBCH_def, Germ.coe_compTendsto, Germ.coe_eq]
   filter_upwards [(tendsto_exp_mul_exp_sub_one A).eventually
-    (eventually_map_logOneAdd (𝕂 := ℝ) f hf)] with p hp
+    (eventually_map_logOneAdd (𝕂 := ℝ) f)] with p hp
   dsimp only [Function.comp_apply, Prod.map]
   rw [hp]
-  have hx : f (exp p.1) = exp (f p.1) := map_exp f hf p.1
-  have hy : f (exp p.2) = exp (f p.2) := map_exp f hf p.2
+  have hx : f (exp p.1) = exp (f p.1) := map_exp f (map_continuous f) p.1
+  have hy : f (exp p.2) = exp (f p.2) := map_exp f (map_continuous f) p.2
   rw [map_sub, map_mul, map_one, hx, hy]
 
 end Naturality

--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -147,21 +147,21 @@ variable {B : Type*} [NormedRing B] [NormedAlgebra ℝ B] [CompleteSpace B]
 /-- Continuous ring homomorphisms commute with the local
 Baker--Campbell--Hausdorff germ. -/
 @[simp high]
-theorem map_localBCH {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
-    [RingHomClass F A B] (f : F) :
+theorem map_localBCH {F : Type*} [FunLike F A B] [RingHomClass F A B]
+    (f : F) (hf : Continuous f) :
     (localBCH A).map f =
       (localBCH B).compTendsto (Prod.map f f) (by
-        exact ((map_continuous f).prodMap (map_continuous f)).tendsto'
+        exact (hf.prodMap hf).tendsto'
           (0, 0) (0, 0) (by simp)) := by
   let _ : NormedAlgebra ℚ A := NormedAlgebra.restrictScalars ℚ ℝ A
   let _ : NormedAlgebra ℚ B := NormedAlgebra.restrictScalars ℚ ℝ B
   rw [localBCH_def, Germ.map_coe, localBCH_def, Germ.coe_compTendsto, Germ.coe_eq]
   filter_upwards [(tendsto_exp_mul_exp_sub_one A).eventually
-    (eventually_map_logOneAdd (𝕂 := ℝ) (𝕃 := ℝ) f)] with p hp
+    (eventually_map_logOneAdd (𝕂 := ℝ) (𝕃 := ℝ) f hf)] with p hp
   dsimp only [Function.comp_apply, Prod.map]
   rw [hp]
-  have hx : f (exp p.1) = exp (f p.1) := map_exp f (map_continuous f) p.1
-  have hy : f (exp p.2) = exp (f p.2) := map_exp f (map_continuous f) p.2
+  have hx : f (exp p.1) = exp (f p.1) := map_exp f hf p.1
+  have hy : f (exp p.2) = exp (f p.2) := map_exp f hf p.2
   rw [map_sub, map_mul, map_one, hx, hy]
 
 end Naturality

--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -33,8 +33,8 @@ representative is analytic at the origin.
 * `NormedSpace.localBCH_tendsto`: the germ tends to zero at the origin.
 * `NormedSpace.eq_localBCH_of_tendsto_of_map_exp_eq`: uniqueness among germs
   tending to zero with the same exponential image.
-* `NormedSpace.map_localBCH`: continuous real algebra homomorphisms commute with
-  the local BCH germ.
+* `NormedSpace.map_localBCH`: continuous ring homomorphisms commute with the
+  local BCH germ.
 
 ## References
 
@@ -144,7 +144,7 @@ section Naturality
 
 variable {B : Type*} [NormedRing B] [NormedAlgebra ℝ B] [CompleteSpace B]
 
-/-- Continuous real algebra homomorphisms commute with the local
+/-- Continuous ring homomorphisms commute with the local
 Baker--Campbell--Hausdorff germ. -/
 @[simp high]
 theorem map_localBCH {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]

--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -157,7 +157,7 @@ theorem map_localBCH {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
   let _ : NormedAlgebra ℚ B := NormedAlgebra.restrictScalars ℚ ℝ B
   rw [localBCH_def, Germ.map_coe, localBCH_def, Germ.coe_compTendsto, Germ.coe_eq]
   filter_upwards [(tendsto_exp_mul_exp_sub_one A).eventually
-    (eventually_map_logOneAdd (𝕂 := ℝ) f)] with p hp
+    (eventually_map_logOneAdd (𝕂 := ℝ) (𝕃 := ℝ) f)] with p hp
   dsimp only [Function.comp_apply, Prod.map]
   rw [hp]
   have hx : f (exp p.1) = exp (f p.1) := map_exp f (map_continuous f) p.1

--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 import Mathlib.Analysis.Analytic.Constructions
-public import Mathlib.Topology.Germ
 public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Inverse
 public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Naturality
 

--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -8,6 +8,7 @@ module
 import Mathlib.Analysis.Analytic.Constructions
 public import Mathlib.Topology.Germ
 public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Inverse
+public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Naturality
 
 /-!
 # The local Baker--Campbell--Hausdorff map
@@ -33,6 +34,8 @@ representative is analytic at the origin.
 * `NormedSpace.localBCH_tendsto`: the germ tends to zero at the origin.
 * `NormedSpace.eq_localBCH_of_tendsto_of_map_exp_eq`: uniqueness among germs
   tending to zero with the same exponential image.
+* `NormedSpace.map_localBCH`: continuous real algebra homomorphisms commute with
+  the local BCH germ.
 
 ## References
 
@@ -137,5 +140,30 @@ theorem eq_localBCH_of_tendsto_of_map_exp_eq (f : Germ (𝓝 ((0, 0) : A × A)) 
       filter_upwards [hf.eventually (eventually_logOneAdd_exp_sub_one A), hmap'] with p hp hmap_p
       rw [← hmap_p]
       exact hp.symm
+
+section Naturality
+
+variable {B : Type*} [NormedRing B] [NormedAlgebra ℝ B] [CompleteSpace B]
+
+/-- Continuous real algebra homomorphisms commute with the local
+Baker--Campbell--Hausdorff germ. -/
+theorem map_localBCH (f : A →A[ℝ] B) :
+    (localBCH A).map f =
+      (localBCH B).compTendsto (Prod.map f f) (by
+        exact (f.continuous.prodMap f.continuous).tendsto' (0, 0) (0, 0) (by simp)) := by
+  rw [localBCH_def, Germ.map_coe, localBCH_def, Germ.coe_compTendsto, Germ.coe_eq]
+  filter_upwards [(tendsto_exp_mul_exp_sub_one A).eventually
+    (eventually_map_logOneAdd f)] with p hp
+  dsimp only [Function.comp_apply, Prod.map]
+  rw [hp]
+  have hx : f (exp p.1) = exp (f p.1) :=
+    map_exp_of_mem_ball (f := f) f.continuous p.1
+      ((expSeries_radius_eq_top ℝ A).symm ▸ edist_lt_top _ _)
+  have hy : f (exp p.2) = exp (f p.2) :=
+    map_exp_of_mem_ball (f := f) f.continuous p.2
+      ((expSeries_radius_eq_top ℝ A).symm ▸ edist_lt_top _ _)
+  rw [map_sub, map_mul, map_one, hx, hy]
+
+end Naturality
 
 end NormedSpace

--- a/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
+++ b/TauCeti/Analysis/Normed/Algebra/BCH/Local.lean
@@ -147,21 +147,21 @@ variable {B : Type*} [NormedRing B] [NormedAlgebra ℝ B] [CompleteSpace B]
 
 /-- Continuous real algebra homomorphisms commute with the local
 Baker--Campbell--Hausdorff germ. -/
-theorem map_localBCH (f : A →A[ℝ] B) :
+@[simp]
+theorem map_localBCH {F : Type*} [FunLike F A B] [RingHomClass F A B]
+    (f : F) (hf : Continuous f) :
     (localBCH A).map f =
       (localBCH B).compTendsto (Prod.map f f) (by
-        exact (f.continuous.prodMap f.continuous).tendsto' (0, 0) (0, 0) (by simp)) := by
+        exact (hf.prodMap hf).tendsto' (0, 0) (0, 0) (by simp)) := by
+  let _ : NormedAlgebra ℚ A := NormedAlgebra.restrictScalars ℚ ℝ A
+  let _ : NormedAlgebra ℚ B := NormedAlgebra.restrictScalars ℚ ℝ B
   rw [localBCH_def, Germ.map_coe, localBCH_def, Germ.coe_compTendsto, Germ.coe_eq]
   filter_upwards [(tendsto_exp_mul_exp_sub_one A).eventually
-    (eventually_map_logOneAdd f)] with p hp
+    (eventually_map_logOneAdd (𝕂 := ℝ) f hf)] with p hp
   dsimp only [Function.comp_apply, Prod.map]
   rw [hp]
-  have hx : f (exp p.1) = exp (f p.1) :=
-    map_exp_of_mem_ball (f := f) f.continuous p.1
-      ((expSeries_radius_eq_top ℝ A).symm ▸ edist_lt_top _ _)
-  have hy : f (exp p.2) = exp (f p.2) :=
-    map_exp_of_mem_ball (f := f) f.continuous p.2
-      ((expSeries_radius_eq_top ℝ A).symm ▸ edist_lt_top _ _)
+  have hx : f (exp p.1) = exp (f p.1) := map_exp f hf p.1
+  have hy : f (exp p.2) = exp (f p.2) := map_exp f hf p.2
   rw [map_sub, map_mul, map_one, hx, hy]
 
 end Naturality

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -66,39 +66,41 @@ section Normed
 variable {𝕂 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
 variable [ContinuousSMul ℚ≥0 𝕂]
 variable [NormedRing A] [NormedAlgebra 𝕂 A]
-variable [NormedRing B] [NormedAlgebra 𝕂 B]
+variable [NormedRing B] [Algebra 𝕂 B]
 variable [CompleteSpace A]
 
 /-- Continuous ring homomorphisms commute with `logOneAdd` on the open unit ball. -/
-theorem map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B]
-    (f : F) (hf : Continuous f) {u : A} (hu : ‖u‖ < 1) :
+theorem map_logOneAdd {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
+    [RingHomClass F A B] (f : F) {u : A} (hu : ‖u‖ < 1) :
     f (logOneAdd 𝕂 A u) = logOneAdd 𝕂 B (f u) := by
   rw [logOneAdd_eq_tsum, logOneAdd_eq_tsum]
   calc
     f (∑' n : ℕ, ((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) =
         ∑' n : ℕ, f (((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) := by
-      exact ((summable_logOneAdd 𝕂 A hu).hasSum.map f hf).tsum_eq.symm
+      exact ((summable_logOneAdd 𝕂 A hu).hasSum.map f (map_continuous f)).tsum_eq.symm
     _ = ∑' n : ℕ, ((-1 : 𝕂) ^ (n + 1) / n) • (f u) ^ n := by
       apply tsum_congr
       intro n
-      simpa [Rat.cast_div, Rat.cast_pow, map_pow] using
-        (map_ratCast_smul f 𝕂 𝕂 ((-1 : ℚ) ^ (n + 1) / n) (u ^ n))
+      simpa only [logOneAddSeries_apply, List.ofFn_const, List.prod_replicate,
+        Function.comp_def] using
+        map_logOneAddSeries_apply (𝕂 := 𝕂) f (fun _ : Fin n ↦ u)
 
 /-- A continuous ring homomorphism commutes with `logOneAdd` near the origin. -/
-theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B]
-    (f : F) (hf : Continuous f) :
+theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
+    [RingHomClass F A B] (f : F) :
     ∀ᶠ u in 𝓝 (0 : A), f (logOneAdd 𝕂 A u) = logOneAdd 𝕂 B (f u) := by
   filter_upwards [Metric.ball_mem_nhds (0 : A) zero_lt_one] with u hu
-  exact map_logOneAdd (𝕂 := 𝕂) f hf (by simpa [Metric.mem_ball, dist_zero_right] using hu)
+  exact map_logOneAdd (𝕂 := 𝕂) f (by simpa [Metric.mem_ball, dist_zero_right] using hu)
 
 /-- Continuous ring homomorphisms commute with the germ of `logOneAdd` at the origin. -/
-theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [RingHomClass F A B]
-    (f : F) (hf : Continuous f) :
+@[simp high]
+theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
+    [RingHomClass F A B] (f : F) :
     (↑(logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) A).map f =
       (↑(logOneAdd 𝕂 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
-        exact hf.tendsto' 0 0 (map_zero f)) := by
+        exact (map_continuous f).tendsto' 0 0 (map_zero f)) := by
   rw [Germ.map_coe, Germ.coe_compTendsto, Germ.coe_eq]
-  filter_upwards [eventually_map_logOneAdd (𝕂 := 𝕂) f hf] with u hu
+  filter_upwards [eventually_map_logOneAdd (𝕂 := 𝕂) f] with u hu
   exact hu
 
 end Normed

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -69,12 +69,12 @@ variable {𝕂 𝕃 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
 variable [Field 𝕃] [CharZero 𝕃]
 variable [ContinuousSMul ℚ≥0 𝕂]
 variable [NormedRing A] [NormedAlgebra 𝕂 A]
-variable [Ring B] [Algebra 𝕃 B] [TopologicalSpace B] [IsTopologicalRing B] [T2Space B]
+variable [Ring B] [Algebra 𝕃 B] [TopologicalSpace B] [IsTopologicalRing B]
 variable [CompleteSpace A]
 
 /-- Continuous ring homomorphisms commute with `logOneAdd` on the open unit ball. -/
 theorem map_logOneAdd_of_mem_ball {F : Type*} [FunLike F A B] [RingHomClass F A B]
-    (f : F) (hf : Continuous f) {u : A} (hu : ‖u‖ < 1) :
+    [T2Space B] (f : F) (hf : Continuous f) {u : A} (hu : ‖u‖ < 1) :
     f (logOneAdd 𝕂 A u) = logOneAdd 𝕃 B (f u) := by
   rw [logOneAdd_eq_tsum, logOneAdd_eq_tsum]
   calc
@@ -90,7 +90,7 @@ theorem map_logOneAdd_of_mem_ball {F : Type*} [FunLike F A B] [RingHomClass F A 
 
 /-- A continuous ring homomorphism commutes with `logOneAdd` near the origin. -/
 theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B]
-    (f : F) (hf : Continuous f) :
+    [T2Space B] (f : F) (hf : Continuous f) :
     ∀ᶠ u in 𝓝 (0 : A), f (logOneAdd 𝕂 A u) = logOneAdd 𝕃 B (f u) := by
   filter_upwards [Metric.ball_mem_nhds (0 : A) zero_lt_one] with u hu
   exact map_logOneAdd_of_mem_ball (𝕂 := 𝕂) (𝕃 := 𝕃) f hf
@@ -99,7 +99,7 @@ theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B
 /-- Continuous ring homomorphisms commute with the germ of `logOneAdd` at the origin. -/
 @[simp]
 theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [RingHomClass F A B]
-    (f : F) (hf : Continuous f) :
+    [T2Space B] (f : F) (hf : Continuous f) :
     (↑(f ∘ logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) B) =
       (↑(logOneAdd 𝕃 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
         exact hf.tendsto' 0 0 (map_zero f)) := by

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -18,7 +18,7 @@ local identity as an equality of germs at the origin.
 ## Main results
 
 * `NormedSpace.map_logOneAddSeries_apply`: naturality of each homogeneous term.
-* `NormedSpace.map_logOneAdd_of_mem_ball`: naturality on the open unit ball.
+* `NormedSpace.map_logOneAdd_of_norm_lt_one`: naturality on the open unit ball.
 * `NormedSpace.eventually_map_logOneAdd`: naturality near the origin.
 * `NormedSpace.map_logOneAdd_germ`: naturality as an equality of germs.
 
@@ -72,7 +72,7 @@ variable [Ring B] [Algebra 𝕃 B] [TopologicalSpace B] [IsTopologicalRing B]
 variable [CompleteSpace A]
 
 /-- Continuous ring homomorphisms commute with `logOneAdd` on the open unit ball. -/
-theorem map_logOneAdd_of_mem_ball {F : Type*} [FunLike F A B] [RingHomClass F A B]
+theorem map_logOneAdd_of_norm_lt_one {F : Type*} [FunLike F A B] [RingHomClass F A B]
     [T2Space B] (f : F) (hf : Continuous f) {u : A} (hu : ‖u‖ < 1) :
     f (logOneAdd 𝕂 A u) = logOneAdd 𝕃 B (f u) := by
   rw [logOneAdd_eq_tsum, logOneAdd_eq_tsum]
@@ -92,7 +92,7 @@ theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B
     [T2Space B] (f : F) (hf : Continuous f) :
     ∀ᶠ u in 𝓝 (0 : A), f (logOneAdd 𝕂 A u) = logOneAdd 𝕃 B (f u) := by
   filter_upwards [Metric.ball_mem_nhds (0 : A) zero_lt_one] with u hu
-  exact map_logOneAdd_of_mem_ball (𝕂 := 𝕂) (𝕃 := 𝕃) f hf
+  exact map_logOneAdd_of_norm_lt_one (𝕂 := 𝕂) (𝕃 := 𝕃) f hf
     (by simpa [Metric.mem_ball, dist_zero_right] using hu)
 
 /-- Continuous ring homomorphisms commute with the germ of `logOneAdd` at the origin. -/
@@ -104,6 +104,18 @@ theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [RingHomClass F A B]
   rw [Germ.coe_compTendsto, Germ.coe_eq]
   filter_upwards [eventually_map_logOneAdd (𝕂 := 𝕂) (𝕃 := 𝕃) f hf] with u hu
   exact hu
+
+/- The same-field logarithm germ equation is the simplifier boundary.  The
+generic theorem above intentionally remains explicit because its target field
+does not occur in the left-hand side. -/
+@[simp high]
+private theorem map_logOneAdd_germ_sameField {F : Type*} [FunLike F A B]
+    [ContinuousMapClass F A B] [RingHomClass F A B] [T2Space B] (f : F)
+    [Algebra 𝕂 B] :
+    (↑(f ∘ logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) B) =
+      (↑(logOneAdd 𝕂 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
+        exact (map_continuous f).tendsto' 0 0 (map_zero f)) :=
+  map_logOneAdd_germ (𝕂 := 𝕂) (𝕃 := 𝕂) f (map_continuous f)
 
 end Normed
 

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -45,6 +45,7 @@ variable [Ring B] [Algebra 𝕃 B] [TopologicalSpace B] [IsTopologicalRing B]
 
 /-- Ring homomorphisms commute with each homogeneous term of
 `logOneAddSeries`. -/
+@[simp high]
 theorem map_logOneAddSeries_apply {F : Type*} [FunLike F A B] [RingHomClass F A B]
     (f : F) {n : ℕ} (v : Fin n → A) :
     f (logOneAddSeries 𝕂 A n v) = logOneAddSeries 𝕃 B n (f ∘ v) := by
@@ -96,6 +97,7 @@ theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B
     (by simpa [Metric.mem_ball, dist_zero_right] using hu)
 
 /-- Continuous ring homomorphisms commute with the germ of `logOneAdd` at the origin. -/
+@[simp]
 theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [RingHomClass F A B]
     (f : F) (hf : Continuous f) :
     (↑(f ∘ logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) B) =

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -26,8 +26,7 @@ local identity as an equality of germs at the origin.
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 3, "Baker--Campbell--Hausdorff".
-* `NormedSpace.map_exp_of_mem_ball` in Mathlib's exponential naturality
-  development, whose `tsum`/`HasSum.map`/termwise-naturality proof pattern is adapted here.
+* `NormedSpace.map_exp_of_mem_ball` in Mathlib's exponential naturality development.
 -/
 
 public section

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -26,6 +26,8 @@ local identity as an equality of germs at the origin.
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 3, "Baker--Campbell--Hausdorff".
+* `NormedSpace.map_exp_of_mem_ball` in Mathlib's exponential naturality
+  development, whose `tsum`/`HasSum.map`/termwise-naturality proof pattern is adapted here.
 -/
 
 public section
@@ -64,10 +66,10 @@ end Algebra
 section Normed
 
 variable {𝕂 𝕃 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
-variable [NontriviallyNormedField 𝕃] [CharZero 𝕃]
+variable [Field 𝕃] [CharZero 𝕃]
 variable [ContinuousSMul ℚ≥0 𝕂]
 variable [NormedRing A] [NormedAlgebra 𝕂 A]
-variable [NormedRing B] [Algebra 𝕃 B]
+variable [Ring B] [Algebra 𝕃 B] [TopologicalSpace B] [IsTopologicalRing B] [T2Space B]
 variable [CompleteSpace A]
 
 /-- Continuous ring homomorphisms commute with `logOneAdd` on the open unit ball. -/

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Germ
+public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Basic
+
+/-!
+# Naturality of the local logarithm
+
+This file proves that continuous algebra homomorphisms commute with the
+power series for `log (1 + u)` wherever it converges. It also packages this
+local identity as an equality of germs at the origin.
+
+## Main results
+
+* `NormedSpace.map_logOneAddSeries_apply`: naturality of each homogeneous term.
+* `NormedSpace.map_logOneAdd`: naturality on the open unit ball.
+* `NormedSpace.eventually_map_logOneAdd`: naturality near the origin.
+* `NormedSpace.map_logOneAdd_germ`: naturality as an equality of germs.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 3, "Baker--Campbell--Hausdorff".
+-/
+
+public section
+
+open Filter Topology
+
+noncomputable section
+
+namespace NormedSpace
+
+section Algebra
+
+variable {𝕂 A B : Type*} [Field 𝕂] [CharZero 𝕂]
+variable [Ring A] [Algebra 𝕂 A] [TopologicalSpace A] [IsTopologicalRing A]
+variable [Ring B] [Algebra 𝕂 B] [TopologicalSpace B] [IsTopologicalRing B]
+
+/-- Algebra homomorphisms commute with each homogeneous term of
+`logOneAddSeries`. -/
+theorem map_logOneAddSeries_apply (f : A →ₐ[𝕂] B) {n : ℕ} (v : Fin n → A) :
+    f (logOneAddSeries 𝕂 A n v) = logOneAddSeries 𝕂 B n (f ∘ v) := by
+  rw [logOneAddSeries_apply, logOneAddSeries_apply, map_smul, map_list_prod]
+  simp only [List.map_ofFn]
+
+end Algebra
+
+section Normed
+
+variable {𝕂 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
+variable [ContinuousSMul ℚ≥0 𝕂]
+variable [NormedRing A] [NormedAlgebra 𝕂 A]
+variable [NormedRing B] [NormedAlgebra 𝕂 B]
+variable [CompleteSpace A]
+
+/-- Continuous algebra homomorphisms commute with `logOneAdd` on the open unit ball. -/
+theorem map_logOneAdd (f : A →A[𝕂] B) {u : A} (hu : ‖u‖ < 1) :
+    f (logOneAdd 𝕂 A u) = logOneAdd 𝕂 B (f u) := by
+  rw [logOneAdd_eq_tsum, logOneAdd_eq_tsum]
+  calc
+    f (∑' n : ℕ, ((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) =
+        ∑' n : ℕ, f (((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) := by
+      simpa only [ContinuousAlgHom.coe_toContinuousLinearMap] using
+        f.toContinuousLinearMap.map_tsum (summable_logOneAdd 𝕂 A hu)
+    _ = ∑' n : ℕ, ((-1 : 𝕂) ^ (n + 1) / n) • (f u) ^ n := by
+      apply tsum_congr
+      intro n
+      simp only [map_smul, map_pow]
+
+/-- A continuous algebra homomorphism commutes with `logOneAdd` near the origin. -/
+theorem eventually_map_logOneAdd (f : A →A[𝕂] B) :
+    ∀ᶠ u in 𝓝 (0 : A), f (logOneAdd 𝕂 A u) = logOneAdd 𝕂 B (f u) := by
+  filter_upwards [Metric.ball_mem_nhds (0 : A) zero_lt_one] with u hu
+  exact map_logOneAdd f (by simpa [Metric.mem_ball, dist_zero_right] using hu)
+
+/-- Continuous algebra homomorphisms commute with the germ of `logOneAdd` at the origin. -/
+theorem map_logOneAdd_germ (f : A →A[𝕂] B) :
+    (↑(logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) A).map f =
+      (↑(logOneAdd 𝕂 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
+        exact f.continuous.tendsto' 0 0 (map_zero f)) := by
+  rw [Germ.map_coe, Germ.coe_compTendsto, Germ.coe_eq]
+  filter_upwards [eventually_map_logOneAdd f] with u hu
+  exact hu
+
+end Normed
+
+end NormedSpace

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -38,70 +38,80 @@ namespace NormedSpace
 
 section Algebra
 
-variable {𝕂 A B : Type*} [Field 𝕂] [CharZero 𝕂]
+variable {𝕂 𝕃 A B : Type*} [Field 𝕂] [CharZero 𝕂] [Field 𝕃] [CharZero 𝕃]
 variable [Ring A] [Algebra 𝕂 A] [TopologicalSpace A] [IsTopologicalRing A]
-variable [Ring B] [Algebra 𝕂 B] [TopologicalSpace B] [IsTopologicalRing B]
+variable [Ring B] [Algebra 𝕃 B] [TopologicalSpace B] [IsTopologicalRing B]
 
 /-- Ring homomorphisms commute with each homogeneous term of
 `logOneAddSeries`. -/
 theorem map_logOneAddSeries_apply {F : Type*} [FunLike F A B] [RingHomClass F A B]
     (f : F) {n : ℕ} (v : Fin n → A) :
-    f (logOneAddSeries 𝕂 A n v) = logOneAddSeries 𝕂 B n (f ∘ v) := by
+    f (logOneAddSeries 𝕂 A n v) = logOneAddSeries 𝕃 B n (f ∘ v) := by
   rw [logOneAddSeries_apply, logOneAddSeries_apply]
   calc
     f (((-1 : 𝕂) ^ (n + 1) / n) • (List.ofFn v).prod) =
-        ((-1 : 𝕂) ^ (n + 1) / n) • f (List.ofFn v).prod := by
+        ((-1 : 𝕃) ^ (n + 1) / n) • f (List.ofFn v).prod := by
       simpa [Rat.cast_div, Rat.cast_pow] using
-        (map_ratCast_smul f 𝕂 𝕂 ((-1 : ℚ) ^ (n + 1) / n)
+        (map_ratCast_smul f 𝕂 𝕃 ((-1 : ℚ) ^ (n + 1) / n)
           ((List.ofFn v).prod))
-    _ = ((-1 : 𝕂) ^ (n + 1) / n) • (List.map f (List.ofFn v)).prod := by
+    _ = ((-1 : 𝕃) ^ (n + 1) / n) • (List.map f (List.ofFn v)).prod := by
       rw [map_list_prod]
-    _ = ((-1 : 𝕂) ^ (n + 1) / n) • (List.ofFn (f ∘ v)).prod := by
+    _ = ((-1 : 𝕃) ^ (n + 1) / n) • (List.ofFn (f ∘ v)).prod := by
       simp only [List.map_ofFn]
 
 end Algebra
 
 section Normed
 
-variable {𝕂 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
+variable {𝕂 𝕃 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
+variable [NontriviallyNormedField 𝕃] [CharZero 𝕃]
 variable [ContinuousSMul ℚ≥0 𝕂]
 variable [NormedRing A] [NormedAlgebra 𝕂 A]
-variable [NormedRing B] [Algebra 𝕂 B]
+variable [NormedRing B] [Algebra 𝕃 B]
 variable [CompleteSpace A]
 
 /-- Continuous ring homomorphisms commute with `logOneAdd` on the open unit ball. -/
 theorem map_logOneAdd {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
     [RingHomClass F A B] (f : F) {u : A} (hu : ‖u‖ < 1) :
-    f (logOneAdd 𝕂 A u) = logOneAdd 𝕂 B (f u) := by
+    f (logOneAdd 𝕂 A u) = logOneAdd 𝕃 B (f u) := by
   rw [logOneAdd_eq_tsum, logOneAdd_eq_tsum]
   calc
     f (∑' n : ℕ, ((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) =
         ∑' n : ℕ, f (((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) := by
       exact ((summable_logOneAdd 𝕂 A hu).hasSum.map f (map_continuous f)).tsum_eq.symm
-    _ = ∑' n : ℕ, ((-1 : 𝕂) ^ (n + 1) / n) • (f u) ^ n := by
+    _ = ∑' n : ℕ, ((-1 : 𝕃) ^ (n + 1) / n) • (f u) ^ n := by
       apply tsum_congr
       intro n
       simpa only [logOneAddSeries_apply, List.ofFn_const, List.prod_replicate,
         Function.comp_def] using
-        map_logOneAddSeries_apply (𝕂 := 𝕂) f (fun _ : Fin n ↦ u)
+        map_logOneAddSeries_apply (𝕂 := 𝕂) (𝕃 := 𝕃) f (fun _ : Fin n ↦ u)
 
 /-- A continuous ring homomorphism commutes with `logOneAdd` near the origin. -/
 theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
     [RingHomClass F A B] (f : F) :
-    ∀ᶠ u in 𝓝 (0 : A), f (logOneAdd 𝕂 A u) = logOneAdd 𝕂 B (f u) := by
+    ∀ᶠ u in 𝓝 (0 : A), f (logOneAdd 𝕂 A u) = logOneAdd 𝕃 B (f u) := by
   filter_upwards [Metric.ball_mem_nhds (0 : A) zero_lt_one] with u hu
-  exact map_logOneAdd (𝕂 := 𝕂) f (by simpa [Metric.mem_ball, dist_zero_right] using hu)
+  exact map_logOneAdd (𝕂 := 𝕂) (𝕃 := 𝕃) f
+    (by simpa [Metric.mem_ball, dist_zero_right] using hu)
 
 /-- Continuous ring homomorphisms commute with the germ of `logOneAdd` at the origin. -/
-@[simp high]
 theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
     [RingHomClass F A B] (f : F) :
-    (↑(logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) A).map f =
-      (↑(logOneAdd 𝕂 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
+    (↑(f ∘ logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) B) =
+      (↑(logOneAdd 𝕃 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
         exact (map_continuous f).tendsto' 0 0 (map_zero f)) := by
-  rw [Germ.map_coe, Germ.coe_compTendsto, Germ.coe_eq]
-  filter_upwards [eventually_map_logOneAdd (𝕂 := 𝕂) f] with u hu
+  rw [Germ.coe_compTendsto, Germ.coe_eq]
+  filter_upwards [eventually_map_logOneAdd (𝕂 := 𝕂) (𝕃 := 𝕃) f] with u hu
   exact hu
+
+/-- The same-field logarithm germ equation is a simplifier rule. -/
+@[simp high]
+theorem map_logOneAdd_germ_sameField {F : Type*} [FunLike F A B]
+    [ContinuousMapClass F A B] [RingHomClass F A B] (f : F) [Algebra 𝕂 B] :
+    (↑(f ∘ logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) B) =
+      (↑(logOneAdd 𝕂 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
+        exact (map_continuous f).tendsto' 0 0 (map_zero f)) :=
+  map_logOneAdd_germ (𝕂 := 𝕂) (𝕃 := 𝕂) f
 
 end Normed
 

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -45,7 +45,6 @@ variable [Ring B] [Algebra 𝕃 B] [TopologicalSpace B] [IsTopologicalRing B]
 
 /-- Ring homomorphisms commute with each homogeneous term of
 `logOneAddSeries`. -/
-@[simp high]
 theorem map_logOneAddSeries_apply {F : Type*} [FunLike F A B] [RingHomClass F A B]
     (f : F) {n : ℕ} (v : Fin n → A) :
     f (logOneAddSeries 𝕂 A n v) = logOneAddSeries 𝕃 B n (f ∘ v) := by
@@ -97,7 +96,6 @@ theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B
     (by simpa [Metric.mem_ball, dist_zero_right] using hu)
 
 /-- Continuous ring homomorphisms commute with the germ of `logOneAdd` at the origin. -/
-@[simp]
 theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [RingHomClass F A B]
     [T2Space B] (f : F) (hf : Continuous f) :
     (↑(f ∘ logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) B) =

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -11,8 +11,8 @@ public import TauCeti.Analysis.Normed.Algebra.LogOneAdd.Basic
 /-!
 # Naturality of the local logarithm
 
-This file proves that continuous algebra homomorphisms commute with the
-power series for `log (1 + u)` wherever it converges. It also packages this
+This file proves that continuous ring homomorphisms commute with the
+power series for `log (1 + u)` on the open unit ball. It also packages this
 local identity as an equality of germs at the origin.
 
 ## Main results
@@ -42,12 +42,22 @@ variable {𝕂 A B : Type*} [Field 𝕂] [CharZero 𝕂]
 variable [Ring A] [Algebra 𝕂 A] [TopologicalSpace A] [IsTopologicalRing A]
 variable [Ring B] [Algebra 𝕂 B] [TopologicalSpace B] [IsTopologicalRing B]
 
-/-- Algebra homomorphisms commute with each homogeneous term of
+/-- Ring homomorphisms commute with each homogeneous term of
 `logOneAddSeries`. -/
-theorem map_logOneAddSeries_apply (f : A →ₐ[𝕂] B) {n : ℕ} (v : Fin n → A) :
+theorem map_logOneAddSeries_apply {F : Type*} [FunLike F A B] [RingHomClass F A B]
+    (f : F) {n : ℕ} (v : Fin n → A) :
     f (logOneAddSeries 𝕂 A n v) = logOneAddSeries 𝕂 B n (f ∘ v) := by
-  rw [logOneAddSeries_apply, logOneAddSeries_apply, map_smul, map_list_prod]
-  simp only [List.map_ofFn]
+  rw [logOneAddSeries_apply, logOneAddSeries_apply]
+  calc
+    f (((-1 : 𝕂) ^ (n + 1) / n) • (List.ofFn v).prod) =
+        ((-1 : 𝕂) ^ (n + 1) / n) • f (List.ofFn v).prod := by
+      simpa [Rat.cast_div, Rat.cast_pow] using
+        (map_ratCast_smul f 𝕂 𝕂 ((-1 : ℚ) ^ (n + 1) / n)
+          ((List.ofFn v).prod))
+    _ = ((-1 : 𝕂) ^ (n + 1) / n) • (List.map f (List.ofFn v)).prod := by
+      rw [map_list_prod]
+    _ = ((-1 : 𝕂) ^ (n + 1) / n) • (List.ofFn (f ∘ v)).prod := by
+      simp only [List.map_ofFn]
 
 end Algebra
 
@@ -59,33 +69,36 @@ variable [NormedRing A] [NormedAlgebra 𝕂 A]
 variable [NormedRing B] [NormedAlgebra 𝕂 B]
 variable [CompleteSpace A]
 
-/-- Continuous algebra homomorphisms commute with `logOneAdd` on the open unit ball. -/
-theorem map_logOneAdd (f : A →A[𝕂] B) {u : A} (hu : ‖u‖ < 1) :
+/-- Continuous ring homomorphisms commute with `logOneAdd` on the open unit ball. -/
+theorem map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B]
+    (f : F) (hf : Continuous f) {u : A} (hu : ‖u‖ < 1) :
     f (logOneAdd 𝕂 A u) = logOneAdd 𝕂 B (f u) := by
   rw [logOneAdd_eq_tsum, logOneAdd_eq_tsum]
   calc
     f (∑' n : ℕ, ((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) =
         ∑' n : ℕ, f (((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) := by
-      simpa only [ContinuousAlgHom.coe_toContinuousLinearMap] using
-        f.toContinuousLinearMap.map_tsum (summable_logOneAdd 𝕂 A hu)
+      exact ((summable_logOneAdd 𝕂 A hu).hasSum.map f hf).tsum_eq.symm
     _ = ∑' n : ℕ, ((-1 : 𝕂) ^ (n + 1) / n) • (f u) ^ n := by
       apply tsum_congr
       intro n
-      simp only [map_smul, map_pow]
+      simpa [Rat.cast_div, Rat.cast_pow, map_pow] using
+        (map_ratCast_smul f 𝕂 𝕂 ((-1 : ℚ) ^ (n + 1) / n) (u ^ n))
 
-/-- A continuous algebra homomorphism commutes with `logOneAdd` near the origin. -/
-theorem eventually_map_logOneAdd (f : A →A[𝕂] B) :
+/-- A continuous ring homomorphism commutes with `logOneAdd` near the origin. -/
+theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B]
+    (f : F) (hf : Continuous f) :
     ∀ᶠ u in 𝓝 (0 : A), f (logOneAdd 𝕂 A u) = logOneAdd 𝕂 B (f u) := by
   filter_upwards [Metric.ball_mem_nhds (0 : A) zero_lt_one] with u hu
-  exact map_logOneAdd f (by simpa [Metric.mem_ball, dist_zero_right] using hu)
+  exact map_logOneAdd (𝕂 := 𝕂) f hf (by simpa [Metric.mem_ball, dist_zero_right] using hu)
 
-/-- Continuous algebra homomorphisms commute with the germ of `logOneAdd` at the origin. -/
-theorem map_logOneAdd_germ (f : A →A[𝕂] B) :
+/-- Continuous ring homomorphisms commute with the germ of `logOneAdd` at the origin. -/
+theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [RingHomClass F A B]
+    (f : F) (hf : Continuous f) :
     (↑(logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) A).map f =
       (↑(logOneAdd 𝕂 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
-        exact f.continuous.tendsto' 0 0 (map_zero f)) := by
+        exact hf.tendsto' 0 0 (map_zero f)) := by
   rw [Germ.map_coe, Germ.coe_compTendsto, Germ.coe_eq]
-  filter_upwards [eventually_map_logOneAdd f] with u hu
+  filter_upwards [eventually_map_logOneAdd (𝕂 := 𝕂) f hf] with u hu
   exact hu
 
 end Normed

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -18,7 +18,7 @@ local identity as an equality of germs at the origin.
 ## Main results
 
 * `NormedSpace.map_logOneAddSeries_apply`: naturality of each homogeneous term.
-* `NormedSpace.map_logOneAdd`: naturality on the open unit ball.
+* `NormedSpace.map_logOneAdd_of_mem_ball`: naturality on the open unit ball.
 * `NormedSpace.eventually_map_logOneAdd`: naturality near the origin.
 * `NormedSpace.map_logOneAdd_germ`: naturality as an equality of germs.
 
@@ -73,14 +73,14 @@ variable [Ring B] [Algebra 𝕃 B] [TopologicalSpace B] [IsTopologicalRing B] [T
 variable [CompleteSpace A]
 
 /-- Continuous ring homomorphisms commute with `logOneAdd` on the open unit ball. -/
-theorem map_logOneAdd {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
-    [RingHomClass F A B] (f : F) {u : A} (hu : ‖u‖ < 1) :
+theorem map_logOneAdd_of_mem_ball {F : Type*} [FunLike F A B] [RingHomClass F A B]
+    (f : F) (hf : Continuous f) {u : A} (hu : ‖u‖ < 1) :
     f (logOneAdd 𝕂 A u) = logOneAdd 𝕃 B (f u) := by
   rw [logOneAdd_eq_tsum, logOneAdd_eq_tsum]
   calc
     f (∑' n : ℕ, ((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) =
         ∑' n : ℕ, f (((-1 : 𝕂) ^ (n + 1) / n) • u ^ n) := by
-      exact ((summable_logOneAdd 𝕂 A hu).hasSum.map f (map_continuous f)).tsum_eq.symm
+      exact ((summable_logOneAdd 𝕂 A hu).hasSum.map f hf).tsum_eq.symm
     _ = ∑' n : ℕ, ((-1 : 𝕃) ^ (n + 1) / n) • (f u) ^ n := by
       apply tsum_congr
       intro n
@@ -89,31 +89,31 @@ theorem map_logOneAdd {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
         map_logOneAddSeries_apply (𝕂 := 𝕂) (𝕃 := 𝕃) f (fun _ : Fin n ↦ u)
 
 /-- A continuous ring homomorphism commutes with `logOneAdd` near the origin. -/
-theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
-    [RingHomClass F A B] (f : F) :
+theorem eventually_map_logOneAdd {F : Type*} [FunLike F A B] [RingHomClass F A B]
+    (f : F) (hf : Continuous f) :
     ∀ᶠ u in 𝓝 (0 : A), f (logOneAdd 𝕂 A u) = logOneAdd 𝕃 B (f u) := by
   filter_upwards [Metric.ball_mem_nhds (0 : A) zero_lt_one] with u hu
-  exact map_logOneAdd (𝕂 := 𝕂) (𝕃 := 𝕃) f
+  exact map_logOneAdd_of_mem_ball (𝕂 := 𝕂) (𝕃 := 𝕃) f hf
     (by simpa [Metric.mem_ball, dist_zero_right] using hu)
 
 /-- Continuous ring homomorphisms commute with the germ of `logOneAdd` at the origin. -/
-theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [ContinuousMapClass F A B]
-    [RingHomClass F A B] (f : F) :
+theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [RingHomClass F A B]
+    (f : F) (hf : Continuous f) :
     (↑(f ∘ logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) B) =
       (↑(logOneAdd 𝕃 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
-        exact (map_continuous f).tendsto' 0 0 (map_zero f)) := by
+        exact hf.tendsto' 0 0 (map_zero f)) := by
   rw [Germ.coe_compTendsto, Germ.coe_eq]
-  filter_upwards [eventually_map_logOneAdd (𝕂 := 𝕂) (𝕃 := 𝕃) f] with u hu
+  filter_upwards [eventually_map_logOneAdd (𝕂 := 𝕂) (𝕃 := 𝕃) f hf] with u hu
   exact hu
 
 /-- The same-field logarithm germ equation is a simplifier rule. -/
 @[simp high]
-theorem map_logOneAdd_germ_sameField {F : Type*} [FunLike F A B]
+private theorem map_logOneAdd_germ_sameField {F : Type*} [FunLike F A B]
     [ContinuousMapClass F A B] [RingHomClass F A B] (f : F) [Algebra 𝕂 B] :
     (↑(f ∘ logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) B) =
       (↑(logOneAdd 𝕂 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
         exact (map_continuous f).tendsto' 0 0 (map_zero f)) :=
-  map_logOneAdd_germ (𝕂 := 𝕂) (𝕃 := 𝕂) f
+  map_logOneAdd_germ (𝕂 := 𝕂) (𝕃 := 𝕂) f (map_continuous f)
 
 end Normed
 

--- a/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
+++ b/TauCeti/Analysis/Normed/Algebra/LogOneAdd/Naturality.lean
@@ -105,15 +105,6 @@ theorem map_logOneAdd_germ {F : Type*} [FunLike F A B] [RingHomClass F A B]
   filter_upwards [eventually_map_logOneAdd (𝕂 := 𝕂) (𝕃 := 𝕃) f hf] with u hu
   exact hu
 
-/-- The same-field logarithm germ equation is a simplifier rule. -/
-@[simp high]
-private theorem map_logOneAdd_germ_sameField {F : Type*} [FunLike F A B]
-    [ContinuousMapClass F A B] [RingHomClass F A B] (f : F) [Algebra 𝕂 B] :
-    (↑(f ∘ logOneAdd 𝕂 A) : Germ (𝓝 (0 : A)) B) =
-      (↑(logOneAdd 𝕂 B) : Germ (𝓝 (0 : B)) B).compTendsto f (by
-        exact (map_continuous f).tendsto' 0 0 (map_zero f)) :=
-  map_logOneAdd_germ (𝕂 := 𝕂) (𝕃 := 𝕂) f (map_continuous f)
-
 end Normed
 
 end NormedSpace


### PR DESCRIPTION
Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"LieGroups/Suggested.lean#bch"}-->

## Summary

Proves that ring homomorphisms commute with each homogeneous term of the local logarithm series and specializes this to continuous real ring homomorphisms of the local BCH germ.

## Roadmap target

Advances `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`, Deliverable A, Layer 3, Baker--Campbell--Hausdorff functoriality.

## Verification

Exact-cache focused 2,727-job and full 9,813-job builds; axiom, module, lint, consumer, and golf gates; fresh differentiated 13-rubric contract and structure reviews.

## Scale and generality

Changes two TauCeti files by +147/−1 lines. The coefficient theorem uses the algebraic AlgHom boundary with no topology; the analytic ladder permits separate characteristic-zero scalar fields for the convergent value, neighborhood identity, and germ and needs source completeness; BCH remains over complete real normed algebras.

## 2+1 fixes

- **Proof quality:** replaced the undocumented `change` in `map_localBCH` with focused `dsimp only` proof plumbing.
- **Reuse:** reused the homogeneous-term naturality theorem in the convergent logarithm proof.
- **API design:** registered the germ equation in the canonical simplifier surface, including the high-priority same-field specialization that resolves the `simpNF` orientation.
- **Generality:** exposed the natural target `Algebra`/continuous-map boundary and kept coefficient transport at the algebraic `AlgHom` boundary.
- **Generality:** separated source and target scalar fields throughout the logarithm naturality ladder.
- **Placement:** removed the redundant direct `Germ` import from `BCH/Local`.

## Scope

- **Consumes:** existing local logarithm coefficients, convergence, neighborhood, germ, and local BCH interfaces.
- **Provides:** naturality of each logarithm term and local BCH under continuous ring homomorphisms, including the same-field germ normal form.
- **Fits:** advances RepresentationTheory Layer 3 BCH functoriality in Deliverable A.
- **Boundary:** formal Lie-series coefficients, quantitative pointwise BCH domains, and later Lie-group transport remain downstream.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [465c9e7](https://github.com/TauCetiProject/TauCetiReview/tree/465c9e7f030871aa0d5fbc533ada5219e9a96f2c/rubrics) · local 2+1 review @ [ut-lean-review](https://github.com/utensil/formal-land/tree/11870ae6f95672bc7368474182e7e958866e2e10/lean4/skills/ut-lean-review) fixed: proof-quality (1), reuse (1), api-design (2), generality (2), placement (1)</sub>