### PR TITLE
refactor(Plumbing): hoist the duplicated integer arithmetic of the blow-up

### DIFF
--- a/TauCeti/Data/Int/MulPred.lean
+++ b/TauCeti/Data/Int/MulPred.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Order.Ring.Defs
+public import Mathlib.Algebra.Ring.Int.Units
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.LinearCombination
+
+/-!
+# Products of consecutive integers are nonnegative
+
+Over `ℤ` the product `t * (t - 1)` of two consecutive integers is nonnegative, because no integer
+lies strictly between `t - 1` and `t`. This is a genuinely integral statement: over `ℝ` it already
+fails at `t = 1 / 2`, and over `ℕ` it is vacuous.
+
+The unit-shifted form `0 ≤ s * (s - δ)` for `δ : ℤˣ` follows by rescaling, since the only units of
+`ℤ` are `±1` and multiplying by one of them permutes the pair.
+
+## Main results
+
+* `Int.zero_le_mul_sub_one` : `0 ≤ t * (t - 1)`.
+* `Int.zero_le_mul_sub_units` : `0 ≤ s * (s - δ)` for a unit `δ`.
+-/
+
+public section
+
+namespace Int
+
+/-- Two consecutive integers have nonnegative product: no integer lies strictly between `t - 1`
+and `t`. -/
+theorem zero_le_mul_sub_one (t : ℤ) : 0 ≤ t * (t - 1) := by
+  rcases le_or_gt t 0 with ht | ht
+  · nlinarith [mul_nonneg (by omega : (0 : ℤ) ≤ -t) (by omega : (0 : ℤ) ≤ 1 - t)]
+  · exact mul_nonneg (by omega) (by omega)
+
+/-- The exceptional term of a unit exceptional value is nonnegative: rescaling by the unit turns
+`s * (s - δ)` into a product of consecutive integers. Nonnegativity fails for the other odd
+exceptional values, where already `1 * (1 - ε) < 0` for `ε ≥ 3`. -/
+theorem zero_le_mul_sub_units (δ : ℤˣ) (s : ℤ) : 0 ≤ s * (s - (δ : ℤ)) := by
+  have hδ : (δ : ℤ) * (δ : ℤ) = 1 := by
+    rcases Int.units_eq_one_or δ with rfl | rfl <;> norm_num
+  have hEq : ((δ : ℤ) * s) * ((δ : ℤ) * s - 1) = s * (s - (δ : ℤ)) := by
+    linear_combination (s * s) * hδ
+  rw [← hEq]
+  exact zero_le_mul_sub_one _
+
+end Int

--- a/TauCeti/LowDimTopology/Plumbing/EdgeBlowUp.lean
+++ b/TauCeti/LowDimTopology/Plumbing/EdgeBlowUp.lean
@@ -7,6 +7,7 @@ module
 
 import Mathlib.Tactic.LinearCombination
 public import Mathlib.Data.Fintype.BigOperators
+public import TauCeti.Data.Int.MulPred
 public import TauCeti.LowDimTopology.Plumbing.Characteristic
 public import TauCeti.LowDimTopology.Plumbing.NegativeDefinite
 public import TauCeti.LowDimTopology.Plumbing.Weight.Sublevel
@@ -105,25 +106,6 @@ public section
 open Matrix
 
 namespace TauCeti
-
-/-! ### Arithmetic of the exceptional multiplicity -/
-
-/-- Two consecutive integers have nonnegative product: no integer lies strictly between `t - 1`
-and `t`. -/
-private theorem zero_le_mul_sub_one (t : ℤ) : 0 ≤ t * (t - 1) := by
-  rcases le_or_gt t 0 with ht | ht
-  · nlinarith [mul_nonneg (by omega : (0 : ℤ) ≤ -t) (by omega : (0 : ℤ) ≤ 1 - t)]
-  · exact mul_nonneg (by omega) (by omega)
-
-/-- The exceptional term of a unit exceptional value is nonnegative: rescaling by the unit turns
-`s * (s - δ)` into a product of consecutive integers. -/
-private theorem zero_le_mul_sub_units (δ : ℤˣ) (s : ℤ) : 0 ≤ s * (s - (δ : ℤ)) := by
-  have hδ : (δ : ℤ) * (δ : ℤ) = 1 := by
-    rcases Int.units_eq_one_or δ with rfl | rfl <;> norm_num
-  have hEq : ((δ : ℤ) * s) * ((δ : ℤ) * s - 1) = s * (s - (δ : ℤ)) := by
-    linear_combination (s * s) * hδ
-  rw [← hEq]
-  exact zero_le_mul_sub_one _
 
 namespace PlumbingGraph
 
@@ -751,7 +733,7 @@ theorem characteristicWeight_le_blowUpEdgeCharacteristic (u v : V)
   have hδ : Odd ((δ : ℤ)) := by
     rcases Int.units_eq_one_or δ with rfl | rfl <;> norm_num
   have h' := P.two_mul_characteristicWeight_blowUpEdgeCharacteristic u v h k (δ : ℤ) hδ x s
-  have hnn := zero_le_mul_sub_units δ s
+  have hnn := Int.zero_le_mul_sub_units δ s
   linarith
 
 /-- **The infimum of the characteristic weight is an edge-blow-up invariant.** -/

--- a/TauCeti/LowDimTopology/Plumbing/EdgeBlowUp.lean
+++ b/TauCeti/LowDimTopology/Plumbing/EdgeBlowUp.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 import Mathlib.Tactic.LinearCombination
+import TauCeti.Data.Int.MulPred
 public import Mathlib.Data.Fintype.BigOperators
-public import TauCeti.Data.Int.MulPred
 public import TauCeti.LowDimTopology.Plumbing.Characteristic
 public import TauCeti.LowDimTopology.Plumbing.NegativeDefinite
 public import TauCeti.LowDimTopology.Plumbing.Weight.Sublevel

--- a/TauCeti/LowDimTopology/Plumbing/Weight/BlowUp.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight/BlowUp.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 import Mathlib.Tactic.LinearCombination
-public import TauCeti.Data.Int.MulPred
+import TauCeti.Data.Int.MulPred
 public import TauCeti.LowDimTopology.Plumbing.BlowUp
 public import TauCeti.LowDimTopology.Plumbing.Weight.Sublevel
 

--- a/TauCeti/LowDimTopology/Plumbing/Weight/BlowUp.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Weight/BlowUp.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 import Mathlib.Tactic.LinearCombination
+public import TauCeti.Data.Int.MulPred
 public import TauCeti.LowDimTopology.Plumbing.BlowUp
 public import TauCeti.LowDimTopology.Plumbing.Weight.Sublevel
 
@@ -77,29 +78,6 @@ conventions and the behaviour of `χ_k` under blowing up follow Némethi,
 public section
 
 namespace TauCeti
-
-/-! ### Arithmetic of the exceptional multiplicity
-
-Two integer facts about the term `s * (s - δ)` by which a blow-up changes the weight function.
--/
-
-/-- Two consecutive integers have nonnegative product: no integer lies strictly between `t - 1`
-and `t`. -/
-private theorem zero_le_mul_sub_one (t : ℤ) : 0 ≤ t * (t - 1) := by
-  rcases le_or_gt t 0 with ht | ht
-  · nlinarith [mul_nonneg (by omega : (0 : ℤ) ≤ -t) (by omega : (0 : ℤ) ≤ 1 - t)]
-  · exact mul_nonneg (by omega) (by omega)
-
-/-- The exceptional term of a unit exceptional value is nonnegative: rescaling by the unit turns
-`s * (s - δ)` into a product of consecutive integers. Nonnegativity fails for the other odd
-exceptional values, where already `1 * (1 - ε) < 0` for `ε ≥ 3`. -/
-private theorem zero_le_mul_sub_units (δ : ℤˣ) (s : ℤ) : 0 ≤ s * (s - (δ : ℤ)) := by
-  have hδ : (δ : ℤ) * (δ : ℤ) = 1 := by
-    rcases Int.units_eq_one_or δ with rfl | rfl <;> norm_num
-  have hEq : ((δ : ℤ) * s) * ((δ : ℤ) * s - 1) = s * (s - (δ : ℤ)) := by
-    linear_combination (s * s) * hδ
-  rw [← hEq]
-  exact zero_le_mul_sub_one _
 
 namespace PlumbingGraph
 
@@ -187,7 +165,7 @@ theorem characteristicWeight_le_blowUpCharacteristic (k : P.characteristicVector
   have hδ : Odd ((δ : ℤ)) := by
     rcases Int.units_eq_one_or δ with rfl | rfl <;> norm_num
   have h := P.two_mul_characteristicWeight_blowUpCharacteristic v k (δ : ℤ) hδ x s
-  have hnn := zero_le_mul_sub_units δ s
+  have hnn := Int.zero_le_mul_sub_units δ s
   linarith
 
 /-- **The infimum of the characteristic weight is a blow-up invariant.** For a characteristic


### PR DESCRIPTION
Dedup finding **D10**, first of three PRs. This one is the mechanical half: two integer lemmas declared twice.

`zero_le_mul_sub_one` and `zero_le_mul_sub_units` were `private` in both `Plumbing/EdgeBlowUp.lean` (`:113`, `:120`) and `Plumbing/Weight/BlowUp.lean` (`:88`, `:96`). The two copies of `zero_le_mul_sub_one` were **byte-identical**, statement and proof; the two of `zero_le_mul_sub_units` were identical in statement and proof and differed only in one docstring sentence. They now live once, in a new `TauCeti/Data/Int/MulPred.lean`, and each file's single external call site is re-pointed.

**Why `Data/Int/` and not somewhere in `Plumbing/`.** Neither statement mentions a plumbing graph — they are facts about `ℤ`. And the first is genuinely *integral*, not ordered-ring-general: `0 ≤ t * (t - 1)` already fails over `ℝ` at `t = 1/2`, and is vacuous over `ℕ`. Discreteness is exactly what carries it. The two obvious in-tree homes are both topically wrong: `Weight/Sublevel.lean` is the two files' only shared import ancestor but is about sublevel sets, and `Algebra/Order/Ring/Units.lean` exists but is specifically about finite index of the positive-units subgroup.

**Prior art.** Mathlib has neither statement. The nearest is `Nat.even_mul_pred_self` (`Algebra/Group/Nat/Even.lean:72`), which is over `ℕ` and about *evenness* — over `ℕ` the nonnegativity is vacuous, so it is a different fact rather than a weaker form of this one.

**Two details worth flagging rather than leaving to review:**

- The merged docstring keeps the extra sentence only `Weight/BlowUp.lean` carried — that nonnegativity fails for the other odd exceptional values, `1 * (1 - ε) < 0` for `ε ≥ 3`. It is the one piece of content either docstring had that the other lacked, so nothing is lost in the merge.
- `zero_le_mul_sub_one` has **no** external call site in either file; it exists to prove `zero_le_mul_sub_units`. I have kept it public rather than private because it is the general statement of the pair and the more likely of the two to be wanted elsewhere. If `reuse` would rather it were private, say so and I will change it — but a one-call-site *private* lemma is what that rubric usually objects to, which is the other horn.

Both now-empty section headers are removed, including the module-docstring sentence in `Weight/BlowUp.lean` ("Two integer facts about the term `s * (s - δ)` …") that would otherwise have been left describing declarations no longer in the file.

**Not in this PR**, deliberately, since D10 lists 20 declarations across 6 files and "one topic per PR" forbids doing them together: the `characteristic{Lower,Upper}FaceExponent_*` restatements and `min_characteristicFaceExponent_eq_zero` (a second PR — I have not yet re-verified those sites at current `main`), and the `blowUpVertexEquiv`/`blowUpEdgeEquiv` unification, which needs a general `Γ.Simplex` notion that `main` does not have and is therefore a design change rather than a deduplication.

Gates: `lake build` of the new module and both consumers clean, 1880 jobs, 0 errors, 0 warnings; longest lines 98/100/99; `TauCeti/` only.

## Round 2 — `api-design`

`MulPred` is now an ordinary `import` in both blow-up modules rather than a `public import`, as
the finding asked. It is proof-only in both: `Int.zero_le_mul_sub_units` is used exactly once per
file, inside a `have` in a `theorem`'s proof, and neither file carries any `@[expose]`, so no
statement depends on the module. The demoted line is grouped with each file's other non-public
import.

Nothing downstream can observe the change, measured at this head rather than assumed: the only
uses of either lemma outside `MulPred.lean` are those two in-proof `have`s, and both blow-up
modules are leaves — 0 importers each, against a control showing the same query returns 1 for
`Plumbing.BlowUp` and 4 for `Weight.Sublevel`.

Re-gated after the change: `lake build` of the three modules — exit 0, "Build completed
successfully (1880 jobs)", 0 error, 0 warning, 0 `info:` and 0 `sorry` lines.

Roadmap: CombinatorialHeegaardFloer
