### PR TITLE
refactor(ModularForms): use Gamma0Map_apply for the nebentypus entry step

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -807,8 +807,12 @@ theorem slash_mapGL_eq_self_of_mem_Gamma1_div (l N : ℕ) [NeZero l] (hlN : l �
   have hchar : (χ ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) : ℂ) = 1 := by
     obtain ⟨-, hd, hcz⟩ := (Gamma1_mem _ _).mp hδ
     have hγ' : γ ∈ Gamma0 (N / l) := Gamma0_le_Gamma0_of_dvd (Nat.div_dvd_of_dvd hlN) hγ
+    -- `Gamma0Map_apply` reads the label as the lower-right entry. Instantiating it here, with the
+    -- entry spelled as `hdiag` spells it, keeps the subtype coercion in one named step instead of
+    -- leaving it for `rw` to discharge silently.
+    have hentry : Gamma0Map (N / l) ⟨γ, hγ'⟩ = ((γ 1 1 : ℤ) : ZMod (N / l)) := Gamma0Map_apply _
     have hlabel : Gamma0Map (N / l) ⟨γ, hγ'⟩ = 1 := by
-      rw [Gamma0Map_apply, hdiag]
+      rw [hentry, hdiag]
       push_cast
       rw [hd, hcz, zero_mul, sub_zero]
     have hred : ZMod.unitsMap (Nat.div_dvd_of_dvd hlN)

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -807,14 +807,8 @@ theorem slash_mapGL_eq_self_of_mem_Gamma1_div (l N : ℕ) [NeZero l] (hlN : l �
   have hchar : (χ ((Gamma0Map N).toHomUnits ⟨γ, hγ⟩) : ℂ) = 1 := by
     obtain ⟨-, hd, hcz⟩ := (Gamma1_mem _ _).mp hδ
     have hγ' : γ ∈ Gamma0 (N / l) := Gamma0_le_Gamma0_of_dvd (Nat.div_dvd_of_dvd hlN) hγ
-    -- Mathlib builds `Gamma0Map` as a bare `MonoidHom.mk` and provides no lemma for its value,
-    -- so reading it as the lower-right entry is a definitional step that cannot be avoided; the
-    -- one lemma naming it, `gamma0Map_apply` in `Fricke/Conjugation.lean`, is `private` there and
-    -- so unavailable here. Naming it once keeps the rest of the proof independent of that
-    -- representation.
-    have hentry : Gamma0Map (N / l) ⟨γ, hγ'⟩ = ((γ 1 1 : ℤ) : ZMod (N / l)) := rfl
     have hlabel : Gamma0Map (N / l) ⟨γ, hγ'⟩ = 1 := by
-      rw [hentry, hdiag]
+      rw [Gamma0Map_apply, hdiag]
       push_cast
       rw [hd, hcz, zero_mul, sub_zero]
     have hred : ZMod.unitsMap (Nat.div_dvd_of_dvd hlN)


### PR DESCRIPTION
`slash_mapGL_eq_self_of_mem_Gamma1_div` reads the value of `Gamma0Map` through a local
`have hentry := rfl`, under a five-line comment explaining that the one lemma naming that step was
`private` in another module and so unavailable here. #5044 promoted that lemma, so the comment is
now false and the `rfl` is now avoidable. No mathematics changes.

## The comment is the last reference to a deleted name

#5044 removed `gamma0Map_apply` from `Fricke/Conjugation.lean` and landed it as the public
`Gamma0Map_apply` in `CongruenceSubgroups/Basic.lean`. Measured on `main` at `e04ec3a4a`, the old
spelling `gamma0Map_apply` occurs exactly **once** in the whole of `TauCeti/` — this comment,
at `Degeneracy.lean:812` — where it asserts that the lemma is `private` in a file that no longer
contains it. The control resolves: `Gamma0Map_apply` is found in four files
(`CongruenceSubgroups/Basic.lean`, `CongruenceSubgroups/Units.lean`, `Degeneracy.lean`,
`Fricke/Conjugation.lean`).

So this removes a statement that is false on current `main`.

## Why it was not part of #5044

#5044 was cut before #4981 merged, so it could not have covered this site. #5044 rewrote the four
unfold sites that existed at its branch point, `Degeneracy.lean:687` among them; #4981 then added
this fifth one, in the same file, at a line #5044 does not touch.

## What changes

The false comment goes, and the local step is proved from the promoted lemma instead of by `rfl`:

```lean
-    -- Mathlib builds `Gamma0Map` as a bare `MonoidHom.mk` and provides no lemma for its value,
-    -- ... `gamma0Map_apply` in `Fricke/Conjugation.lean`, is `private` there and so unavailable
-    have hentry : ... := rfl
+    -- `Gamma0Map_apply` reads the label as the lower-right entry. Instantiating it here, with the
+    -- entry spelled as `hdiag` spells it, keeps the subtype coercion in one named step instead of
+    -- leaving it for `rw` to discharge silently.
+    have hentry : ... := Gamma0Map_apply _
```

`rw [hentry, hdiag]` is unchanged. `Gamma0Map_apply` is already in scope — `Degeneracy.lean`
imports `CongruenceSubgroups.Units`, and #5044 rewrote `Degeneracy.lean:687` to use it — so no
import changes.

## Round 1: why the `have` is kept rather than inlined

The first version of this PR deleted `hentry` outright and rewrote the step as
`rw [Gamma0Map_apply, hdiag]`. `proof-quality` requested changes on that, and it was right: I
measured the intermediate goal and it is worse than the one-line diff suggests. After
`rw [Gamma0Map_apply]` alone the goal is

```
⊢ ↑(↑↑⟨γ, hγ'⟩ 1 1) = 1
```

with the subtype projection still present, and Lean reports that this target *"is not type-correct
under the `implicit` transparency level ... usually caused by unfolding of semireducible
definitions in prior tactic steps"*. The following `rw [hdiag]` lands only by unfolding that
projection, because `hdiag` is stated about `↑γ 1 1`. It does elaborate — that part of the original
claim was tested, not assumed — but it relies on a coercion defeq that nothing in the proof names.

Two alternatives were measured and rejected:

- `rw [Gamma0Map_apply, Subgroup.coe_mk, hdiag]` fails. `Subgroup.coe_mk` unifies against the outer
  `SL(2, ℤ) → Matrix` coercion rather than the subtype one, and the rewrite dies trying to
  synthesize `Group (Matrix (Fin 2) (Fin 2) ℤ)`.
- `simp only [Gamma0Map_apply, Subgroup.coe_mk, hdiag]` closes the goal, but the linter reports
  `Subgroup.coe_mk` as an unused argument — i.e. `simp` is discharging the same coercion defeq
  internally. That is the finding again, one layer further from the reader, so it is not a fix.

Keeping `hentry` and proving it with `Gamma0Map_apply _` puts the coercion normalisation in a
single named step whose statement is written out in full, and leaves `rw [hentry, hdiag]` matching
syntactically. It is also strictly better than the base revision, which reached the same statement
by a bare `rfl` under a false comment.

## Gates

`lake build` of the changed module and all three of its direct importers — `Degeneracy`,
`CuspDescent`, `HeckeSlash.Diagonal.QExpansion`, `Newforms.Basic` — exit 0, 3494 jobs, with
0 `error`, `warning`, `info:` and `sorry` lines in the log. `grep -c 'Built Mathlib'` on the log is
0, so this was a genuine TauCeti-only incremental build. Lean's own diagnostics on the changed file
report 0 errors and 0 warnings on a full (non-partial) elaboration.

`#lint in TauCeti` was started but **did not complete, and is not being reported as passing**: the
build host was at load ~105, the process was starved at ~1% CPU, and I stopped it after ~10 minutes
with no output (exit 143 = SIGTERM). Recording why it is not a gap here rather than quietly
dropping it: this diff adds a local `have` inside an existing tactic proof and changes one term-mode
proof from `rfl` to `Gamma0Map_apply _`. It introduces no declaration, no signature change and no
attribute, so it cannot move the lint surface — and the same scoped `#lint` passed at the previous
head with 0 errors in 335 declarations.

`scripts/lint-env.sh` was **not run** either: it generates a module importing every `TauCeti` file
and so needs a full library build. CI's `pr-build` is the gate for both it and the linters above.

Roadmap: none
