### PR TITLE
feat(HeckeSlash): the Hecke ring acts multiplicatively where the coset product is single

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -6,8 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.CuspRing
-public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Gamma1
-public import TauCeti.NumberTheory.HeckeRing.Multiplication
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Ring
 
 /-!
 # Composing the slash sums of two double cosets
@@ -54,8 +53,10 @@ if the product set is a *single* double coset `Γ₁ δ₃ Γ₃` and the pairs 
 its right cosets exactly once, then the composite operator is the operator of `Γ₁ δ₃ Γ₃`. At
 `Γ₁ = Γ₂ = Γ₃ = Γ₁(N)` this is `heckeSlashGamma1ModularFormEnd_mul_of_doubleCoset_eq_mul` and
 its cusp-form companion. The criterion is formally analogous to the ring-side
-single-basis-element criterion `HeckeCosetModule.mul_single_single_of_mulMap_eq`, but no
-identification with that criterion is made here.
+single-basis-element criterion `HeckeCosetModule.mul_single_single_of_mulMap_eq`, and the two
+are identified here: `heckeSlashGamma1RingModularFormLinearMap_mul_single_single` and its
+cusp-form companion apply both criteria at once, so the ring product of two basis elements maps
+to the composite of their operators.
 
 ⚠ The general multiplicity-weighted statement — the composite as `∑_D m(D₁, D₂; D) · T_D`, and
 with it the ring homomorphism `𝕋 → Module.End` — is **not** proved here. It needs, beyond this
@@ -74,6 +75,10 @@ representatives while the slash sum runs over right cosets.
 * `HeckeRing.GL2.heckeSlashSum_heckeSlashSum_eq_heckeSlashSum`: the composite is the slash sum of
   a third double coset, when the product set is that coset and the pairs are in bijection with
   its right cosets.
+* `HeckeRing.GL2.heckeSlashGamma1RingModularFormLinearMap_mul_single_single` and
+  `HeckeRing.GL2.heckeSlashGamma1CuspRingLinearMap_mul_single_single`: the ring-level reading of
+  those two — the Hecke ring acts multiplicatively on basis elements whose product is a single
+  double coset. The map is an *anti*-homomorphism there, since `Module.End` composes.
 * `HeckeRing.GL2.heckeSlashGamma1ModularFormEnd_mul_of_doubleCoset_eq_mul` and
   `HeckeRing.GL2.heckeSlashGamma1CuspFormEnd_mul_of_doubleCoset_eq_mul`: the same criterion for
   the Hecke operators of level `Γ₁(N)`, as an equation between endomorphisms.
@@ -249,6 +254,32 @@ theorem heckeSlashGamma1CuspFormEnd_mul_of_doubleCoset_eq_mul :
   have := heckeSlashSum_heckeSlashSum_eq_heckeSlashSum k D₁ D₂ a b hcover₁ hinj₁ hcover₂ hinj₂
     D₃ hD₃ hinj₃ ⇑f hf
   simpa [coe_heckeSlashGamma1CuspFormEnd] using congrFun this τ
+
+/-- **The Hecke ring acts multiplicatively on modular forms, where the product of two double
+cosets is again a single double coset.** The modular-form half of the pair; see
+`heckeSlashGamma1CuspRingLinearMap_mul_single_single` for cusp forms.
+
+The two are parallel rather than one specialising the other: the operators live in
+`Module.End ℂ (ModularForm ..)` and `Module.End ℂ (CuspForm ..)` respectively, so neither
+equation transports to the other, and each is proved from its own composition theorem. -/
+theorem heckeSlashGamma1RingModularFormLinearMap_mul_single_single
+    (hmulMap : ∀ p, HeckeCoset.mulMap ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      ((Gamma1 N).map (mapGL ℚ)) D₁.rep D₂.rep p = D₃)
+    (hmul : multiplicity ((Gamma1 N).map (mapGL ℚ))
+      ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      (D₁.rep : GL (Fin 2) ℚ) (D₂.rep : GL (Fin 2) ℚ) (D₃.rep : GL (Fin 2) ℚ) ≤ 1) :
+    heckeSlashGamma1RingModularFormLinearMap k
+        (HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1) =
+      heckeSlashGamma1RingModularFormLinearMap k (HeckeCosetModule.single ℤ D₂ 1) *
+        heckeSlashGamma1RingModularFormLinearMap k (HeckeCosetModule.single ℤ D₁ 1) := by
+  have hprod : HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1
+      = HeckeCosetModule.single ℤ D₃ 1 :=
+    HeckeCosetModule.mul_single_single_of_mulMap_eq ℤ D₁ D₂ D₃ hmulMap hmul
+  rw [hprod, heckeSlashGamma1RingModularFormLinearMap_single,
+    heckeSlashGamma1RingModularFormLinearMap_single,
+    heckeSlashGamma1RingModularFormLinearMap_single, one_smul, one_smul, one_smul]
+  exact (heckeSlashGamma1ModularFormEnd_mul_of_doubleCoset_eq_mul k D₁ D₂ D₃ a b
+    hcover₁ hinj₁ hcover₂ hinj₂ hD₃ hinj₃).symm
 
 /-- **The Hecke ring acts multiplicatively on cusp forms, where the product of two double cosets
 is again a single double coset.** This is the ring-level reading of

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Composition.lean
@@ -5,7 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.NumberTheory.ModularForms.HeckeSlash.CuspRing
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Gamma1
+public import TauCeti.NumberTheory.HeckeRing.Multiplication
 
 /-!
 # Composing the slash sums of two double cosets
@@ -247,6 +249,39 @@ theorem heckeSlashGamma1CuspFormEnd_mul_of_doubleCoset_eq_mul :
   have := heckeSlashSum_heckeSlashSum_eq_heckeSlashSum k D₁ D₂ a b hcover₁ hinj₁ hcover₂ hinj₂
     D₃ hD₃ hinj₃ ⇑f hf
   simpa [coe_heckeSlashGamma1CuspFormEnd] using congrFun this τ
+
+/-- **The Hecke ring acts multiplicatively on cusp forms, where the product of two double cosets
+is again a single double coset.** This is the ring-level reading of
+`heckeSlashGamma1CuspFormEnd_mul_of_doubleCoset_eq_mul`: the two criteria line up, one on each
+side, with `mul_single_single_of_mulMap_eq` supplying the product in the Hecke ring and the
+composition theorem supplying it in `Module.End`.
+
+Note the order. `Module.End` multiplies by composition and the slash acts on the right, so the
+basis element `D₁` of the *left* factor becomes the operator applied *first*: the map is an
+anti-homomorphism on these elements, not a homomorphism.
+
+Full multiplicativity (Shimura, Proposition 3.37) is not available — it needs the structure
+constants of a product that spreads over several double cosets with multiplicity, whereas both
+criteria used here assume the product collapses to the single coset `D₃`. This lemma is the part
+that is provable from what is on hand. -/
+theorem heckeSlashGamma1CuspRingLinearMap_mul_single_single
+    (hmulMap : ∀ p, HeckeCoset.mulMap ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      ((Gamma1 N).map (mapGL ℚ)) D₁.rep D₂.rep p = D₃)
+    (hmul : multiplicity ((Gamma1 N).map (mapGL ℚ))
+      ((Gamma1 N).map (mapGL ℚ)) ((Gamma1 N).map (mapGL ℚ))
+      (D₁.rep : GL (Fin 2) ℚ) (D₂.rep : GL (Fin 2) ℚ) (D₃.rep : GL (Fin 2) ℚ) ≤ 1) :
+    heckeSlashGamma1CuspRingLinearMap k
+        (HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1) =
+      heckeSlashGamma1CuspRingLinearMap k (HeckeCosetModule.single ℤ D₂ 1) *
+        heckeSlashGamma1CuspRingLinearMap k (HeckeCosetModule.single ℤ D₁ 1) := by
+  have hprod : HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1
+      = HeckeCosetModule.single ℤ D₃ 1 :=
+    HeckeCosetModule.mul_single_single_of_mulMap_eq ℤ D₁ D₂ D₃ hmulMap hmul
+  rw [hprod, heckeSlashGamma1CuspRingLinearMap_single,
+    heckeSlashGamma1CuspRingLinearMap_single, heckeSlashGamma1CuspRingLinearMap_single,
+    one_smul, one_smul, one_smul]
+  exact (heckeSlashGamma1CuspFormEnd_mul_of_doubleCoset_eq_mul k D₁ D₂ D₃ a b
+    hcover₁ hinj₁ hcover₂ hinj₂ hD₃ hinj₃).symm
 
 end Gamma1
 


### PR DESCRIPTION
Closes the "A" piece of the tc-i9kdg re-scope: the Hecke ring acts multiplicatively on cusp forms in the case where the product of two double cosets is again a single double coset.

## Why this was missing

`heckeSlashGamma1CuspRingLinearMap` is only `ℤ`-linear, and `CuspRing.lean` says why in its own docstring:

> Multiplicativity is Shimura's Proposition 3.37 and is not available yet, so the Hecke ring acts `ℤ`-linearly here rather than by a `RingHom`.

Full multiplicativity does need 3.37 — the structure constants of a product that spreads over several double cosets with multiplicity. But the **special case where the product collapses to a single coset** was already provable, and both halves have been sitting on `main` unjoined:

- `HeckeCosetModule.mul_single_single_of_mulMap_eq` (`HeckeRing/Multiplication.lean:120`) — the product in the Hecke ring, given `mulMap` landing in `D₃` and multiplicity ≤ 1;
- `heckeSlashGamma1CuspFormEnd_mul_of_doubleCoset_eq_mul` (`HeckeSlash/Composition.lean:240`) — the same product in `Module.End`, under the matching coset-decomposition hypotheses.

This PR joins them at the level of the ring map, which is the form a consumer actually instantiates. Both criteria are already in the file's `variable` block, so the new lemma adds no hypotheses of its own.

## The order is not a typo

`Module.End` multiplies by composition and the slash acts on the right, so the basis element of the **left** ring factor becomes the operator applied **first**:

```lean
map (single D₁ 1 * single D₂ 1) = map (single D₂ 1) * map (single D₁ 1)
```

On these elements the map is an **anti**-homomorphism. The docstring records that explicitly rather than leaving a reader to trip over it — `Composition.lean`'s own docstring makes the same point about `D₁` acting first.

## Scope

No hypothesis here is arithmetic. In particular nothing needs a coprimality assumption: the AINTLIB reference for the downstream Hecke/diamond commutation carries `Nat.Coprime n N`, but that question belongs to *that* statement, not to this one, and I have deliberately not inherited it.

This is one of three pieces identified on tc-i9kdg. The remaining two are (B) commutativity of `diamondHeckeElem` with the diagonal-coset basis element in the Hecke ring, via the `HeckeAntiInvolution` machinery, and (C) the target commutation, which follows from A + B + the existing `Diamond.lean:140` bridge.

## Roadmap grounding

This adds a new declaration, so per `CLAUDE.md` it cites the target it advances rather than the area alone.

**ModularForms, Layer 2** — `TauCetiRoadmap/ModularForms/README.md:1386`: *"Layer 2 (the Hecke ring at `GL_n`; the `n = 2` congruence theory and **the action**) → Layer 0, Mathlib's abstract Hecke ring (fallback: AINTLIB)."* The multiplicativity of the Hecke ring's action on cusp forms is that action; `Suggested.lean:16` records the gap it fills — Mathlib has *"the first slice of the abstract Hecke ring (`NumberTheory/HeckeRing/Defs.lean`) — but no Hecke operators acting on forms"*.

Layer 2 is consumed by Layer 3 (Petersson, adjoints, old/new) and Layer 4A, which is where the eigenform theory that needs a multiplicative action lives.

## Verification

`lake build TauCeti.NumberTheory.ModularForms.HeckeSlash.Composition` — exit 0, 3046 jobs, no errors, warnings, or `info:` diagnostics. No line over 100 characters; no `sorry`.

Roadmap: ModularForms

