### PR TITLE
refactor(Newforms): promote the NeZero side conditions of `d * M ∣ N`

### DIFF
--- a/TauCeti/Algebra/GroupWithZero/Divisibility.lean
+++ b/TauCeti/Algebra/GroupWithZero/Divisibility.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.GroupWithZero.Divisibility
+
+/-!
+# `NeZero` passes to divisors
+
+Mathlib's `ne_zero_of_dvd_ne_zero` says that a divisor of a nonzero element is nonzero, as the
+proposition `p ≠ 0`. Instance resolution needs the same fact as the class `NeZero p`, and a
+caller holding `[NeZero q]` together with `p ∣ q` has to repackage the conclusion by hand;
+Mathlib does exactly that inline in `Mathlib/GroupTheory/Index.lean` and
+`Mathlib/GroupTheory/Schreier.lean`. This file names the repackaging once, so that a divisibility
+hypothesis can discharge a `NeZero` side condition in one term.
+
+## Main results
+
+* `NeZero.of_dvd`: a divisor of an element carrying `NeZero` carries `NeZero`.
+-/
+
+public section
+
+namespace NeZero
+
+/-- **`NeZero` passes to divisors.** If `q` carries `NeZero` and `p ∣ q`, then so does `p`. This
+is `ne_zero_of_dvd_ne_zero` with the conclusion packaged as an instance instead of as `p ≠ 0`.
+Composed with `dvd_of_mul_right_dvd` and `dvd_of_mul_left_dvd` it discharges both side conditions
+carried by a hypothesis of the shape `d * M ∣ N`. -/
+theorem of_dvd {α : Type*} [MonoidWithZero α] {p q : α} [NeZero q] (h : p ∣ q) : NeZero p :=
+  ⟨ne_zero_of_dvd_ne_zero (NeZero.ne q) h⟩
+
+end NeZero

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -9,6 +9,7 @@ import Mathlib.Data.Nat.Prime.Int
 import TauCeti.Data.ZMod.Divisibility
 public import Mathlib.NumberTheory.ModularForms.QExpansion
 public import Mathlib.RingTheory.PowerSeries.Expand
+public import TauCeti.Algebra.GroupWithZero.Divisibility
 public import TauCeti.NumberTheory.ModularForms.Basic
 public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups.Units
 public import TauCeti.NumberTheory.ModularForms.DiamondOperators
@@ -707,13 +708,13 @@ reduction of `u` acts on `f`. Both sides are slashes by a matrix of `Γ₀`, rel
 theorem CuspForm.diamondOpCusp_levelRaise {M d N : ℕ} [NeZero N]
     (hdvd : d * M ∣ N) (k : ℤ) (u : (ZMod N)ˣ)
     (f : CuspForm ((Gamma1 M).map (mapGL ℝ)) k) :
-    haveI : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using hdvd)⟩
-    haveI : NeZero M := ⟨fun hM ↦ NeZero.ne N (by simpa [hM] using hdvd)⟩
+    haveI : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd hdvd)
+    haveI : NeZero M := NeZero.of_dvd (dvd_of_mul_left_dvd hdvd)
     diamondOpCusp k u (CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd hdvd) f) =
       CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd hdvd)
         (diamondOpCusp k (ZMod.unitsMap ((Dvd.intro_left d rfl).trans hdvd) u) f) := by
-  let _ : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using hdvd)⟩
-  let _ : NeZero M := ⟨fun hM ↦ NeZero.ne N (by simpa [hM] using hdvd)⟩
+  let _ : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd hdvd)
+  let _ : NeZero M := NeZero.of_dvd (dvd_of_mul_left_dvd hdvd)
   obtain ⟨γ, hγ⟩ := Gamma0Map_toHomUnits_surjective u
   obtain ⟨c, hc, hm, heq⟩ := exists_conjScale_mem_Gamma0_of_dvd d M N hdvd γ
   refine DFunLike.coe_injective ?_

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Degeneracy.lean
@@ -88,17 +88,17 @@ not vanish at level `M`, and `b ↦ d b mod p` stops being a permutation once `p
 theorem heckeTCuspNat_levelRaise (hdvd : d * M ∣ N) (hp : p.Prime)
     (hpN : Nat.Coprime p N) (f : CuspForm ((Gamma1 M).map (mapGL ℝ)) k) :
     haveI : NeZero N := ⟨fun hN ↦ hp.ne_one (by simpa [hN] using hpN)⟩
-    haveI : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using hdvd)⟩
-    haveI : NeZero M := ⟨fun hM ↦ NeZero.ne N (by simpa [hM] using hdvd)⟩
+    haveI : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd hdvd)
+    haveI : NeZero M := NeZero.of_dvd (dvd_of_mul_left_dvd hdvd)
     haveI : NeZero p := ⟨hp.ne_zero⟩
     heckeTCuspNat k p (CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd hdvd) f) =
       CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd hdvd) (heckeTCuspNat k p f) := by
   have : NeZero N := ⟨fun hN ↦ hp.ne_one (by simpa [hN] using hpN)⟩
-  have : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using hdvd)⟩
-  have : NeZero M := ⟨fun hM ↦ NeZero.ne N (by simpa [hM] using hdvd)⟩
+  have : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd hdvd)
+  have : NeZero M := NeZero.of_dvd (dvd_of_mul_left_dvd hdvd)
   have : NeZero p := ⟨hp.ne_zero⟩
   have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
-  have hMdvd : M ∣ N := (Dvd.intro_left d rfl).trans hdvd
+  have hMdvd : M ∣ N := dvd_of_mul_left_dvd hdvd
   have hpM : Nat.Coprime p M := hpN.coprime_dvd_right hMdvd
   have hpd : Nat.Coprime p d := hpN.coprime_dvd_right ((dvd_mul_right d M).trans hdvd)
   have hf : ∀ γ ∈ (Gamma1 M).map (mapGL ℝ), ⇑f ∣[k] γ = ⇑f :=

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
@@ -46,9 +46,6 @@ subspace is still missing.
 
 ## Main results
 
-* `TauCeti.neZero_of_mul_dvd_left` and `TauCeti.neZero_of_mul_dvd_right`: the two `NeZero` side
-  conditions carried by the hypothesis `d * M ∣ N`. They are used inside the statements below,
-  which is why they are public rather than proof-local.
 * `TauCeti.levelRaise_mem_cuspFormsOld` and `TauCeti.cuspFormsOld_le`: the introduction and
   elimination rules for the old subspace.
 * `TauCeti.levelRaise_mem_cuspFormsOldMultiples` and `TauCeti.cuspFormsOldMultiples_le`: the
@@ -97,21 +94,6 @@ open _root_.CuspForm
 
 variable {k : ℤ}
 
-/-! ### Level transport at a divisor -/
-
-/-- **The level-raising index is nonzero.** From `d * M ∣ N` and `N ≠ 0`, the index `d` of the
-level-raising operator `V_d` is nonzero. It is stated as a `NeZero` instance, and it is public
-because the hypothesis `d * M ∣ N` occurs in the *statements* below, which cannot mention `V_d`
-until the instance is available. -/
-theorem neZero_of_mul_dvd_left {d M N : ℕ} [NeZero N] (h : d * M ∣ N) : NeZero d :=
-  ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using h)⟩
-
-/-- **The source level is nonzero.** From `d * M ∣ N` and `N ≠ 0`, the level `M` that `V_d` raises
-from is nonzero, which is what indexing `S_k(Γ₁(M))` needs. Public for the same reason as
-`neZero_of_mul_dvd_left`. -/
-theorem neZero_of_mul_dvd_right {d M N : ℕ} [NeZero N] (h : d * M ∣ N) : NeZero M :=
-  ⟨fun hM ↦ NeZero.ne N (by simpa [hM] using h)⟩
-
 /-! ### The old subspace -/
 
 /-- The **old subspace** `S_k(Γ₁(N))ᵒˡᵈ`: the subspace of `S_k(Γ₁(N))` spanned by the images of
@@ -121,7 +103,7 @@ condition `M ≠ N` removes exactly the identity operator at level `N`. -/
 def cuspFormsOld (N : ℕ) [NeZero N] (k : ℤ) :
     Submodule ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
   ⨆ (M : ℕ) (d : ℕ) (h : d * M ∣ N ∧ M ≠ N),
-    have : NeZero d := neZero_of_mul_dvd_left h.1
+    have : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd h.1)
     LinearMap.range (CuspForm.levelRaiseₗ (k := k) d (Gamma1_map_le_conjAct_scaleGL_of_dvd h.1))
 
 variable {M d N : ℕ}
@@ -130,9 +112,9 @@ variable {M d N : ℕ}
 is old. -/
 theorem levelRaise_mem_cuspFormsOld [NeZero N] (h : d * M ∣ N) (hM : M ≠ N)
     (k : ℤ) (f : CuspForm ((Gamma1 M).map (mapGL ℝ)) k) :
-    haveI : NeZero d := neZero_of_mul_dvd_left h
+    haveI : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd h)
     CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) f ∈ cuspFormsOld N k :=
-  let _ := neZero_of_mul_dvd_left h
+  let _ := NeZero.of_dvd (dvd_of_mul_right_dvd h)
   Submodule.mem_iSup_of_mem M (Submodule.mem_iSup_of_mem d
     (Submodule.mem_iSup_of_mem ⟨h, hM⟩ ⟨f, CuspForm.levelRaiseₗ_apply d _ f⟩))
 
@@ -141,11 +123,11 @@ proper divisor level contains the whole old subspace. -/
 theorem cuspFormsOld_le [NeZero N] {V : Submodule ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k)}
     (hV : ∀ (M d : ℕ) (h : d * M ∣ N), M ≠ N →
       ∀ f : CuspForm ((Gamma1 M).map (mapGL ℝ)) k,
-        haveI : NeZero d := neZero_of_mul_dvd_left h
+        haveI : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd h)
         CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) f ∈ V) :
     cuspFormsOld N k ≤ V := by
   refine iSup_le fun M ↦ iSup_le fun d ↦ iSup_le fun h ↦ ?_
-  have := neZero_of_mul_dvd_left h.1
+  have := NeZero.of_dvd (dvd_of_mul_right_dvd h.1)
   rintro _ ⟨f, rfl⟩
   rw [CuspForm.levelRaiseₗ_apply]
   exact hV M d h.1 h.2 f
@@ -184,7 +166,7 @@ theorem cuspFormsOld_le_of_prime [NeZero N]
           rcases hd with rfl | rfl
           · exact ⟨p, by rw [← hpL]; ring⟩
           · exact ⟨1, by rw [← hpL, mul_one]⟩
-        haveI : NeZero d := neZero_of_mul_dvd_left hdvd
+        haveI : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd hdvd)
         CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd hdvd) g ∈ V) :
     cuspFormsOld N k ≤ V := by
   refine cuspFormsOld_le fun M d hdvd hM f ↦ ?_
@@ -235,7 +217,7 @@ is Petersson-orthogonal to `V_d g` for every cusp form `g` of proper divisor lev
 theorem mem_cuspFormsNew_iff [NeZero N] {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} :
     f ∈ cuspFormsNew N k ↔ ∀ (M d : ℕ) (h : d * M ∣ N), M ≠ N →
       ∀ g : CuspForm ((Gamma1 M).map (mapGL ℝ)) k,
-        haveI : NeZero d := neZero_of_mul_dvd_left h
+        haveI : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd h)
         peterssonInnerCosets
           (CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) g) f = 0 := by
   rw [cuspFormsNew]
@@ -288,8 +270,8 @@ for. -/
 def cuspFormsOldMultiples (N : ℕ) [NeZero N] (k : ℤ) (m : ℕ) :
     Submodule ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
   ⨆ (M : ℕ) (d : ℕ) (h : d * M ∣ N ∧ M ≠ N ∧ m ∣ M),
-    have : NeZero d := neZero_of_mul_dvd_left h.1
-    have : NeZero M := neZero_of_mul_dvd_right h.1
+    have : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd h.1)
+    have : NeZero M := NeZero.of_dvd (dvd_of_mul_left_dvd h.1)
     (cuspFormsNew M k).map
       (CuspForm.levelRaiseₗ (k := k) d (Gamma1_map_le_conjAct_scaleGL_of_dvd h.1))
 
@@ -297,13 +279,13 @@ def cuspFormsOldMultiples (N : ℕ) [NeZero N] (k : ℤ) (m : ℕ) :
 lies in `cuspFormsOldMultiples`. -/
 theorem levelRaise_mem_cuspFormsOldMultiples [NeZero N] {m : ℕ} (h : d * M ∣ N) (hM : M ≠ N)
     (hm : m ∣ M) (k : ℤ) (g : CuspForm ((Gamma1 M).map (mapGL ℝ)) k)
-    (hg : haveI : NeZero M := neZero_of_mul_dvd_right h
+    (hg : haveI : NeZero M := NeZero.of_dvd (dvd_of_mul_left_dvd h)
       g ∈ cuspFormsNew M k) :
-    haveI : NeZero d := neZero_of_mul_dvd_left h
+    haveI : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd h)
     CuspForm.levelRaiseₗ (k := k) d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) g ∈
       cuspFormsOldMultiples N k m :=
-  let _ := neZero_of_mul_dvd_left h
-  let _ := neZero_of_mul_dvd_right h
+  let _ := NeZero.of_dvd (dvd_of_mul_right_dvd h)
+  let _ := NeZero.of_dvd (dvd_of_mul_left_dvd h)
   Submodule.mem_iSup_of_mem M (Submodule.mem_iSup_of_mem d
     (Submodule.mem_iSup_of_mem ⟨h, hM, hm⟩ (Submodule.mem_map_of_mem hg)))
 
@@ -315,7 +297,7 @@ theorem cuspFormsOldMultiples_le_cuspFormsOld (N : ℕ) [NeZero N] (k : ℤ) (m 
     cuspFormsOldMultiples N k m ≤ cuspFormsOld N k := by
   refine iSup_le fun M ↦ iSup_le fun d ↦ iSup_le fun h ↦ ?_
   rintro x ⟨f, -, rfl⟩
-  have : NeZero d := neZero_of_mul_dvd_left h.1
+  have : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd h.1)
   -- the generator is a `levelRaiseₗ` application; `levelRaiseₗ_apply` is the bridge to the
   -- bare `levelRaise` that the old subspace's introduction rule is stated with
   simpa only [CuspForm.levelRaiseₗ_apply] using levelRaise_mem_cuspFormsOld h.1 h.2.1 k f
@@ -329,14 +311,14 @@ theorem cuspFormsOldMultiples_le [NeZero N] {m : ℕ}
     {V : Submodule ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k)}
     (hV : ∀ (M d : ℕ) (h : d * M ∣ N), M ≠ N → m ∣ M →
       ∀ g : CuspForm ((Gamma1 M).map (mapGL ℝ)) k,
-        haveI : NeZero M := neZero_of_mul_dvd_right h
+        haveI : NeZero M := NeZero.of_dvd (dvd_of_mul_left_dvd h)
         g ∈ cuspFormsNew M k →
-        haveI : NeZero d := neZero_of_mul_dvd_left h
+        haveI : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd h)
         CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) g ∈ V) :
     cuspFormsOldMultiples N k m ≤ V := by
   refine iSup_le fun M ↦ iSup_le fun d ↦ iSup_le fun h ↦ ?_
-  have := neZero_of_mul_dvd_left h.1
-  have := neZero_of_mul_dvd_right h.1
+  have := NeZero.of_dvd (dvd_of_mul_right_dvd h.1)
+  have := NeZero.of_dvd (dvd_of_mul_left_dvd h.1)
   rintro _ ⟨g, hg, rfl⟩
   -- Why consumers want this rule rather than the lattice lemmas: a bare `iSup_le` against a
   -- `Submodule.comap` leaves the `CompleteLattice` instance stuck on a metavariable, whereas an
@@ -360,7 +342,7 @@ theorem diamondOpCusp_mem_cuspFormsOld [NeZero N] (u : (ZMod N)ˣ)
     diamondOpCusp k u f ∈ cuspFormsOld N k := by
   refine cuspFormsOld_le (V := (cuspFormsOld N k).comap (diamondOpCusp k u)) ?_ hf
   intro M d hdvd hM g
-  have := neZero_of_mul_dvd_right hdvd
+  have := NeZero.of_dvd (dvd_of_mul_left_dvd hdvd)
   rw [Submodule.mem_comap, CuspForm.diamondOpCusp_levelRaise hdvd]
   exact levelRaise_mem_cuspFormsOld hdvd hM k _
 

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Basic.lean
@@ -46,6 +46,9 @@ subspace is still missing.
 
 ## Main results
 
+* `TauCeti.neZero_of_mul_dvd_left` and `TauCeti.neZero_of_mul_dvd_right`: the two `NeZero` side
+  conditions carried by the hypothesis `d * M ∣ N`. They are used inside the statements below,
+  which is why they are public rather than proof-local.
 * `TauCeti.levelRaise_mem_cuspFormsOld` and `TauCeti.cuspFormsOld_le`: the introduction and
   elimination rules for the old subspace.
 * `TauCeti.levelRaise_mem_cuspFormsOldMultiples` and `TauCeti.cuspFormsOldMultiples_le`: the
@@ -96,12 +99,17 @@ variable {k : ℤ}
 
 /-! ### Level transport at a divisor -/
 
-/-- A factor of a divisor of a nonzero number is nonzero. -/
-private lemma neZero_of_mul_dvd_left {d M N : ℕ} [NeZero N] (h : d * M ∣ N) : NeZero d :=
+/-- **The level-raising index is nonzero.** From `d * M ∣ N` and `N ≠ 0`, the index `d` of the
+level-raising operator `V_d` is nonzero. It is stated as a `NeZero` instance, and it is public
+because the hypothesis `d * M ∣ N` occurs in the *statements* below, which cannot mention `V_d`
+until the instance is available. -/
+theorem neZero_of_mul_dvd_left {d M N : ℕ} [NeZero N] (h : d * M ∣ N) : NeZero d :=
   ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using h)⟩
 
-/-- A factor of a divisor of a nonzero number is nonzero. -/
-private lemma neZero_of_mul_dvd_right {d M N : ℕ} [NeZero N] (h : d * M ∣ N) : NeZero M :=
+/-- **The source level is nonzero.** From `d * M ∣ N` and `N ≠ 0`, the level `M` that `V_d` raises
+from is nonzero, which is what indexing `S_k(Γ₁(M))` needs. Public for the same reason as
+`neZero_of_mul_dvd_left`. -/
+theorem neZero_of_mul_dvd_right {d M N : ℕ} [NeZero N] (h : d * M ∣ N) : NeZero M :=
   ⟨fun hM ↦ NeZero.ne N (by simpa [hM] using h)⟩
 
 /-! ### The old subspace -/
@@ -122,7 +130,7 @@ variable {M d N : ℕ}
 is old. -/
 theorem levelRaise_mem_cuspFormsOld [NeZero N] (h : d * M ∣ N) (hM : M ≠ N)
     (k : ℤ) (f : CuspForm ((Gamma1 M).map (mapGL ℝ)) k) :
-    haveI : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using h)⟩
+    haveI : NeZero d := neZero_of_mul_dvd_left h
     CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) f ∈ cuspFormsOld N k :=
   let _ := neZero_of_mul_dvd_left h
   Submodule.mem_iSup_of_mem M (Submodule.mem_iSup_of_mem d
@@ -133,7 +141,7 @@ proper divisor level contains the whole old subspace. -/
 theorem cuspFormsOld_le [NeZero N] {V : Submodule ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k)}
     (hV : ∀ (M d : ℕ) (h : d * M ∣ N), M ≠ N →
       ∀ f : CuspForm ((Gamma1 M).map (mapGL ℝ)) k,
-        haveI : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using h)⟩
+        haveI : NeZero d := neZero_of_mul_dvd_left h
         CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) f ∈ V) :
     cuspFormsOld N k ≤ V := by
   refine iSup_le fun M ↦ iSup_le fun d ↦ iSup_le fun h ↦ ?_
@@ -176,7 +184,7 @@ theorem cuspFormsOld_le_of_prime [NeZero N]
           rcases hd with rfl | rfl
           · exact ⟨p, by rw [← hpL]; ring⟩
           · exact ⟨1, by rw [← hpL, mul_one]⟩
-        haveI : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using hdvd)⟩
+        haveI : NeZero d := neZero_of_mul_dvd_left hdvd
         CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd hdvd) g ∈ V) :
     cuspFormsOld N k ≤ V := by
   refine cuspFormsOld_le fun M d hdvd hM f ↦ ?_
@@ -227,7 +235,7 @@ is Petersson-orthogonal to `V_d g` for every cusp form `g` of proper divisor lev
 theorem mem_cuspFormsNew_iff [NeZero N] {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} :
     f ∈ cuspFormsNew N k ↔ ∀ (M d : ℕ) (h : d * M ∣ N), M ≠ N →
       ∀ g : CuspForm ((Gamma1 M).map (mapGL ℝ)) k,
-        haveI : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using h)⟩
+        haveI : NeZero d := neZero_of_mul_dvd_left h
         peterssonInnerCosets
           (CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) g) f = 0 := by
   rw [cuspFormsNew]
@@ -289,9 +297,9 @@ def cuspFormsOldMultiples (N : ℕ) [NeZero N] (k : ℤ) (m : ℕ) :
 lies in `cuspFormsOldMultiples`. -/
 theorem levelRaise_mem_cuspFormsOldMultiples [NeZero N] {m : ℕ} (h : d * M ∣ N) (hM : M ≠ N)
     (hm : m ∣ M) (k : ℤ) (g : CuspForm ((Gamma1 M).map (mapGL ℝ)) k)
-    (hg : haveI : NeZero M := ⟨fun hM ↦ NeZero.ne N (by simpa [hM] using h)⟩
+    (hg : haveI : NeZero M := neZero_of_mul_dvd_right h
       g ∈ cuspFormsNew M k) :
-    haveI : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using h)⟩
+    haveI : NeZero d := neZero_of_mul_dvd_left h
     CuspForm.levelRaiseₗ (k := k) d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) g ∈
       cuspFormsOldMultiples N k m :=
   let _ := neZero_of_mul_dvd_left h
@@ -321,9 +329,9 @@ theorem cuspFormsOldMultiples_le [NeZero N] {m : ℕ}
     {V : Submodule ℂ (CuspForm ((Gamma1 N).map (mapGL ℝ)) k)}
     (hV : ∀ (M d : ℕ) (h : d * M ∣ N), M ≠ N → m ∣ M →
       ∀ g : CuspForm ((Gamma1 M).map (mapGL ℝ)) k,
-        haveI : NeZero M := ⟨fun hM ↦ NeZero.ne N (by simpa [hM] using h)⟩
+        haveI : NeZero M := neZero_of_mul_dvd_right h
         g ∈ cuspFormsNew M k →
-        haveI : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using h)⟩
+        haveI : NeZero d := neZero_of_mul_dvd_left h
         CuspForm.levelRaise d (Gamma1_map_le_conjAct_scaleGL_of_dvd h) g ∈ V) :
     cuspFormsOldMultiples N k m ≤ V := by
   refine iSup_le fun M ↦ iSup_le fun d ↦ iSup_le fun h ↦ ?_

--- a/TauCeti/NumberTheory/ModularForms/Newforms/HeckeStability.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/HeckeStability.lean
@@ -59,7 +59,7 @@ theorem heckeTCuspNat_mem_cuspFormsOld [NeZero N] (hp : p.Prime)
   have : NeZero p := ⟨hp.ne_zero⟩
   refine cuspFormsOld_le (V := (cuspFormsOld N k).comap (HeckeRing.GL2.heckeTCuspNat k p)) ?_ hf
   intro M d hdvd hM g
-  have : NeZero M := neZero_of_mul_dvd_right hdvd
+  have : NeZero M := NeZero.of_dvd (dvd_of_mul_left_dvd hdvd)
   rw [Submodule.mem_comap,
     HeckeRing.GL2.heckeTCuspNat_levelRaise (k := k) (d := d) (M := M) (p := p) hdvd hp hpN]
   exact levelRaise_mem_cuspFormsOld hdvd hM k _

--- a/TauCeti/NumberTheory/ModularForms/Newforms/HeckeStability.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/HeckeStability.lean
@@ -59,9 +59,7 @@ theorem heckeTCuspNat_mem_cuspFormsOld [NeZero N] (hp : p.Prime)
   have : NeZero p := ⟨hp.ne_zero⟩
   refine cuspFormsOld_le (V := (cuspFormsOld N k).comap (HeckeRing.GL2.heckeTCuspNat k p)) ?_ hf
   intro M d hdvd hM g
-  -- `Newforms/Basic.lean`'s `neZero_of_mul_dvd_right` is private, so derive the instance here,
-  -- by the same argument `heckeTCuspNat_levelRaise` uses in its own statement.
-  have : NeZero M := ⟨fun hM ↦ NeZero.ne N (by simpa [hM] using hdvd)⟩
+  have : NeZero M := neZero_of_mul_dvd_right hdvd
   rw [Submodule.mem_comap,
     HeckeRing.GL2.heckeTCuspNat_levelRaise (k := k) (d := d) (M := M) (p := p) hdvd hp hpN]
   exact levelRaise_mem_cuspFormsOld hdvd hM k _

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
@@ -90,8 +90,8 @@ theorem cuspFormsOldMultiples_map_diamondOpCusp_le (u : (ZMod N)ˣ) (m : ℕ) :
     (cuspFormsOldMultiples N k m).map (diamondOpCusp k u) ≤ cuspFormsOldMultiples N k m := by
   rw [Submodule.map_le_iff_le_comap]
   refine cuspFormsOldMultiples_le fun M d h hM hm g hg ↦ ?_
-  have : NeZero d := ⟨fun hd ↦ NeZero.ne N (by simpa [hd] using h)⟩
-  have : NeZero M := ⟨fun hM' ↦ NeZero.ne N (by simpa [hM'] using h)⟩
+  have : NeZero d := neZero_of_mul_dvd_left h
+  have : NeZero M := neZero_of_mul_dvd_right h
   rw [Submodule.mem_comap, CuspForm.diamondOpCusp_levelRaise h]
   -- `levelRaiseₗ_apply` bridges the introduction rule's `levelRaiseₗ` to the bare `levelRaise`
   -- that `diamondOpCusp_levelRaise` produced above

--- a/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
+++ b/TauCeti/NumberTheory/ModularForms/Newforms/Nebentypus.lean
@@ -90,8 +90,8 @@ theorem cuspFormsOldMultiples_map_diamondOpCusp_le (u : (ZMod N)ˣ) (m : ℕ) :
     (cuspFormsOldMultiples N k m).map (diamondOpCusp k u) ≤ cuspFormsOldMultiples N k m := by
   rw [Submodule.map_le_iff_le_comap]
   refine cuspFormsOldMultiples_le fun M d h hM hm g hg ↦ ?_
-  have : NeZero d := neZero_of_mul_dvd_left h
-  have : NeZero M := neZero_of_mul_dvd_right h
+  have : NeZero d := NeZero.of_dvd (dvd_of_mul_right_dvd h)
+  have : NeZero M := NeZero.of_dvd (dvd_of_mul_left_dvd h)
   rw [Submodule.mem_comap, CuspForm.diamondOpCusp_levelRaise h]
   -- `levelRaiseₗ_apply` bridges the introduction rule's `levelRaiseₗ` to the bare `levelRaise`
   -- that `diamondOpCusp_levelRaise` produced above


### PR DESCRIPTION
The `d * M ∣ N` hypothesis that runs through the old-subspace API carries two `NeZero` side
conditions: the level-raising index `d` and the source level `M` are both nonzero because `N` is.
Across five files the repository derived that fact by hand thirty times, in two spellings — the
inline term `⟨fun hd ↦ NeZero.ne N (by simpa [hd] using h)⟩`, and a pair of *private* helpers
`neZero_of_mul_dvd_left` / `neZero_of_mul_dvd_right` in `Newforms/Basic.lean` that only proofs in
that one file could reach. A **statement** mentioning `V_d` or `S_k(Γ₁(M))` needs the instance
before it can be written down, and a statement cannot mention a private name, so the statements
open-coded it; `Newforms/HeckeStability.lean` even carried a comment saying so.

This states the fact once, at the level it actually lives at:

```lean
theorem NeZero.of_dvd {α : Type*} [MonoidWithZero α] {p q : α} [NeZero q] (h : p ∣ q) : NeZero p
```

in a new `TauCeti/Algebra/GroupWithZero/Divisibility.lean`, mirroring the Mathlib file that holds
`ne_zero_of_dvd_ne_zero` — which it is *proved from*, not re-derived by `simpa`. Mathlib has this
fact only as the proposition `p ≠ 0`; it has no `NeZero` form, and open-codes the repackaging
inline at `GroupTheory/Index.lean:775` and `GroupTheory/Schreier.lean:201`. TauCeti already uses
`ne_zero_of_dvd_ne_zero` directly in `Algebra/Group/Conj.lean` and `HeckeRing/GLn/Basic.lean`, so
this is the established idiom here.

The two side conditions of `d * M ∣ N` are then `NeZero.of_dvd (dvd_of_mul_right_dvd h)` for `d`
and `NeZero.of_dvd (dvd_of_mul_left_dvd h)` for `M`, used at **all thirty** occurrences: the 22
call sites of the deleted pair (`Newforms/Basic.lean` 19, `Newforms/Nebentypus.lean` 2,
`Newforms/HeckeStability.lean` 1) and the 8 inline clones, four each in
`ModularForms/Degeneracy.lean` and `HeckeSlash/Degeneracy.lean`. Neither the old names nor the
inline term occurs anywhere in `TauCeti/` any more.

No statement changes: `NeZero` is a `Prop` class, so replacing one instance term by another leaves
every theorem definitionally what it was.

## One import reaches all five consumers

`ModularForms/Degeneracy.lean` is an all-public common ancestor of the other four:
`HeckeSlash/Degeneracy.lean` reaches it through `HeckeSlash/Diagonal/QExpansion.lean`, and
`Newforms/HeckeStability.lean` and `Newforms/Nebentypus.lean` through `Newforms/Basic.lean`. So a
single `public import` there serves everything, and it must be `public` because the lemma is used
inside statements.

## Correction to this PR's round-1 description

The earlier description claimed the two `Degeneracy.lean` files could not reach the lemmas and
that serving them was a separate placement decision. The `reuse` rubric was right to call that
wrong, and I have checked it: `HeckeSlash/Degeneracy.lean` uses
`Gamma1_map_le_conjAct_scaleGL_of_dvd`, defined at `ModularForms/Degeneracy.lean:459`, so it
already imports that file transitively. The reachable common ancestor existed; the pair was simply
placed too late, in the specialized `d * M ∣ N` shape, which is what left the eight clones alive.
Moving the fact down and generalising it to the divisor level answers `reuse`, `generality` and
`placement` together, and removing the old docstrings' `V_d` / `S_k(Γ₁(M))` framing answers
`documentation` — that framing was what described `NeZero M` as "what indexing `S_k(Γ₁(M))`
needs", which is not what that type requires.

## Where the line is drawn

`ModularForms/Degeneracy.lean` writes `(Dvd.intro_left d rfl).trans hdvd` for `M ∣ N` at three
places (`:714`, `:731`, `:758`). Those are *inside statements* and produce divisibility proofs, not
`NeZero` instances, so they are a different change and are left alone. The one such spelling in a
*proof* body, `hMdvd` in `HeckeSlash/Degeneracy.lean`, sat two lines under an edited line and now
matches its neighbours as `dvd_of_mul_left_dvd hdvd`.

## Gate

`lake build` of the six changed modules and their direct importers: **3930 jobs, rc=0, zero
error/warning/info lines**. No line exceeds 100 codepoints in any changed file except the
pre-existing AINTLIB URL at `Newforms/Basic.lean:77`, byte-identical on `main`.

Roadmap: ModularForms
