### PR TITLE
improve(FunctionField): derive Place.eq_of_integers_le from Mathlib

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.FieldTheory.AlgebraicClosure
+public import Mathlib.RingTheory.DiscreteValuationRing.TFAE
 public import Mathlib.RingTheory.Valuation.Integral
 public import Mathlib.RingTheory.Valuation.IsTrivialOn
 public import TauCeti.RingTheory.Valuation.Discrete.Order
@@ -343,30 +344,13 @@ theorem integers_injective : Function.Injective (integers : Place k F → Valuat
 /-- **The valuation ring of a place is a maximal proper subring of `F`** (Stichtenoth,
 Theorem 1.1.13(d)), in the form used to recognize a place from a containment of valuation
 rings: a place whose valuation ring contains the valuation ring of another place is that
-place. -/
-theorem eq_of_integers_le {P Q : Place k F} (h : P.integers ≤ Q.integers) : P = Q := by
-  refine integers_injective (le_antisymm h ?_)
-  by_contra hle
-  obtain ⟨f, hfQ, hfP⟩ := SetLike.not_le_iff_exists.mp hle
-  rw [mem_integers_iff_ord_nonneg] at hfQ
-  rw [mem_integers_iff_ord_nonneg, not_le] at hfP
-  have hf0 : f ≠ 0 := by rintro rfl; simp at hfP
-  have hgP : 0 < P.ord f⁻¹ := by rw [ord_inv]; omega
-  have hgQ : 0 ≤ Q.ord f⁻¹ := by
-    rw [← mem_integers_iff_ord_nonneg]
-    exact h (P.mem_integers_iff_ord_nonneg.mpr hgP.le)
-  have hgQ0 : Q.ord f⁻¹ = 0 := by rw [ord_inv] at hgQ ⊢; omega
-  refine Q.integers_ne_top (top_unique fun y _ ↦ ?_)
-  rcases eq_or_ne y 0 with rfl | hy0
-  · exact zero_mem _
-  set n := (max 0 (-P.ord y)).toNat with hn
-  have hmem : y * f⁻¹ ^ n ∈ P.integers := by
-    rw [mem_integers_iff_ord_nonneg, ord_mul _ hy0 (pow_ne_zero _ (inv_ne_zero hf0)), ord_pow]
-    have : (1 : ℤ) ≤ P.ord f⁻¹ := hgP
-    nlinarith [Int.toNat_of_nonneg (le_max_left 0 (-P.ord y)), le_max_right 0 (-P.ord y)]
-  have := Q.mem_integers_iff_ord_nonneg.mp (h hmem)
-  rw [ord_mul _ hy0 (pow_ne_zero _ (inv_ne_zero hf0)), ord_pow, hgQ0] at this
-  exact Q.mem_integers_iff_ord_nonneg.mpr (by omega)
+place.
+
+This is Mathlib's `ValuationSubring.eq_of_le_of_ne_top` for `𝒪_P`, which applies because a
+discrete valuation ring has Krull dimension at most one; properness of `𝒪_Q` is what rules out
+the other case. -/
+theorem eq_of_integers_le {P Q : Place k F} (h : P.integers ≤ Q.integers) : P = Q :=
+  integers_injective (P.integers.eq_of_le_of_ne_top h Q.integers_ne_top)
 
 /-- The valuation ring of a place is integrally closed in `F`: an element of `F` integral over a
 `k`-algebra whose image lies in `𝒪_P` lies in `𝒪_P`. -/


### PR DESCRIPTION
`TauCeti.Place.eq_of_integers_le` re-proved, from scratch and in 22 lines of `ord` arithmetic,
a theorem Mathlib already has. It is `ValuationSubring.eq_of_le_of_ne_top`, specialised to the
valuation ring of a place. The statement, name and signature are unchanged; only the proof is.

Roadmap: AlgebraicCurves

Attribution only — this improves already-merged code, which `.claude/CLAUDE.md` puts in scope
with no fresh roadmap claim. The roadmap chiefly motivating the file is `AlgebraicCurves`, whose
Layer 0 (*function fields, constant fields, and places*) names this very theorem:

> the three-way correspondence place ↔ normalized discrete valuation (his Def. 1.1.9, axioms
> incl. triviality on `k`) ↔ valuation ring (**Thm. 1.1.13, including (d): valuation rings are
> maximal proper subrings of `F`**).

— `TauCetiRoadmap/AlgebraicCurves/README.md:393-395`. Not `EllipticCurves`: measured on the two
READMEs at roadmap `main`, `Stichtenoth` occurs 48 times in `AlgebraicCurves` against 3 in
`EllipticCurves`, and `place` 116 times; `AlgebraicCurves:36` pins the route as
function-field-first with "places are normalized discrete valuations", which is this file's own
definition.

## The change

`TauCeti/FieldTheory/FunctionField/Place/Basic.lean`, +8 / −24, one file.

```lean
theorem eq_of_integers_le {P Q : Place k F} (h : P.integers ≤ Q.integers) : P = Q :=
  integers_injective (P.integers.eq_of_le_of_ne_top h Q.integers_ne_top)
```

Mathlib's `ValuationSubring.eq_of_le_of_ne_top`
(`Mathlib/RingTheory/Valuation/ValuationSubring.lean:416`) proves `A = B` from `A ≤ B` and
`B ≠ ⊤` under `[Ring.KrullDimLE 1 A]`. Both remaining obligations are already in this file:
`integers_ne_top` (`:323`, Stichtenoth Def. 1.1.4) and `integers_injective` (`:340`). The
instance is found automatically from `instIsDiscreteValuationRing` (`:268`) — a place's
valuation ring is a DVR, and a DVR has Krull dimension at most one.

The deleted proof was the specialisation done by hand: `SetLike.not_le_iff_exists` to pick an
`f` in `𝒪_Q ∖ 𝒪_P`, then `ord_P f⁻¹ ≥ 1` while `ord_Q f⁻¹ = 0`, then multiplying an arbitrary
`y` by a large enough power of `f⁻¹` to force it into `𝒪_P` and hence `𝒪_Q`, contradicting
`integers_ne_top`. That is the standard argument, and it is the argument Mathlib runs — through
`primeSpectrumEquiv` and the overring/prime correspondence — one level up.

## One import added, and why it is the right one

`public import Mathlib.RingTheory.DiscreteValuationRing.TFAE`, for
`instance [IsDomain R] [IsDiscreteValuationRing R] : KrullDimLE 1 R` (`TFAE.lean:257`).

Without it the file does not compile: `failed to synthesize instance of type class
Ring.KrullDimLE 1 ↥P.integers`. That was measured rather than assumed — a probe over this file's
exact existing import list reproduces the same synthesis failure as a control, and adding this
one module clears it. It is also the module that *states the fact being used*, so it is the
honest citation rather than the cheapest one.

## Checks

* Nothing is orphaned. Every lemma the deleted proof consumed is still used elsewhere:
  `ord_inv` 34 hits / 16 files, `ord_mul` 57 / 19, `ord_pow` 31 / 12,
  `mem_integers_iff_ord_nonneg` 33 / 16, and `integers_ne_top` and `integers_injective` are both
  consumed by the new proof itself. Negative control `zzznope_absent`: 0.
  (An earlier run of this check reported 0 for *everything* including lemmas the new proof
  visibly uses — `git grep -E` does not support `\b`, so the pattern matched nothing. The counts
  above are from a re-run without it, which is why they come with a control.)
* `lake build TauCeti.FieldTheory.FunctionField.Place.Basic`: exit 0, 2154 jobs, zero
  `error:` / `warning:` / `info:`.
* All six direct importers — `AffineModel.Place`, `Place.Adic`, `Place.Approximation`,
  `Place.Degree`, `Place.Extension.Basic`, `Place.Filtration` — exit 0, 2768 jobs, zero
  diagnostics.
* `#print axioms TauCeti.Place.eq_of_integers_le` → `[propext, Classical.choice, Quot.sound]`.
* `scripts/lint-dot-notation.py` against the baseline, exit code read without a pipe: rc 0,
  `0 new`. The new call is written in dot-notation form (`P.integers.eq_of_le_of_ne_top`) so it
  adds nothing to the ratchet.
* No line over 100 codepoints (max 98).
* `scripts/lint-env.sh` needs a fully built library, which the no-local-full-builds rule forbids
  here; CI's `pr-build` runs it.

The docstring keeps its Stichtenoth 1.1.13(d) citation — that is what the theorem *is* — and
gains one sentence naming the Mathlib route.
