### PR TITLE
Share the matrix-unit commutator lemma

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/Basic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Basic.lean
@@ -151,6 +151,27 @@ theorem mem_of_trace_eq_zero_of_single_mem {N : Submodule R (Matrix n n R)}
 
 /-! ### Matrix units as commutators -/
 
+/-- The commutator of two matrix units is the difference of the two possible composites. -/
+theorem lie_single_single (a b i j : n) :
+    ⁅single a b (1 : R), single i j (1 : R)⁆ =
+      (if b = i then single a j (1 : R) else 0) -
+        if j = a then single i b (1 : R) else 0 := by
+  rw [LieRing.of_associative_ring_bracket]
+  by_cases hbi : b = i
+  · subst i
+    by_cases hja : j = a
+    · subst j
+      rw [single_mul_single_same, single_mul_single_same]
+      simp
+    · rw [single_mul_single_same, single_mul_single_of_ne (h := hja)]
+      simp [hja]
+  · by_cases hja : j = a
+    · subst j
+      rw [single_mul_single_of_ne (h := hbi), single_mul_single_same]
+      simp [hbi]
+    · rw [single_mul_single_of_ne (h := hbi), single_mul_single_of_ne (h := hja)]
+      simp [hbi, hja]
+
 /-- An off-diagonal matrix unit is a commutator: `Eᵢⱼ = ⁅Eᵢᵢ, Eᵢⱼ⁆` when `i ≠ j`. -/
 theorem lie_single_self_single_of_ne {i j : n} (hij : i ≠ j) (c : R) :
     ⁅single i i (1 : R), single i j c⁆ = single i j c := by

--- a/TauCeti/Algebra/Lie/GeneralLinear/Basic.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Basic.lean
@@ -151,11 +151,13 @@ theorem mem_of_trace_eq_zero_of_single_mem {N : Submodule R (Matrix n n R)}
 
 /-! ### Matrix units as commutators -/
 
-/-- The commutator of two matrix units is the difference of the two possible composites. -/
-theorem lie_single_single (a b i j : n) :
-    ⁅single a b (1 : R), single i j (1 : R)⁆ =
-      (if b = i then single a j (1 : R) else 0) -
-        if j = a then single i b (1 : R) else 0 := by
+/-- The commutator of two single-entry matrices is the difference of the two possible
+composites. -/
+@[simp]
+theorem lie_single_single (a b i j : n) (c d : R) :
+    ⁅single a b c, single i j d⁆ =
+      (if b = i then single a j (c * d) else 0) -
+        if j = a then single i b (d * c) else 0 := by
   rw [LieRing.of_associative_ring_bracket]
   by_cases hbi : b = i
   · subst i

--- a/TauCeti/Algebra/Lie/GeneralLinear/Casimir.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Casimir.lean
@@ -90,7 +90,7 @@ private theorem ι_lie_single_single (a b i j : n) :
     ι K ⁅Matrix.single a b (1 : K), Matrix.single i j (1 : K)⁆ =
       (if b = i then ι K (Matrix.single a j (1 : K)) else 0) -
         if j = a then ι K (Matrix.single i b (1 : K)) else 0 := by
-  rw [lie_single_single]
+  rw [lie_single_single a b i j 1 1]
   by_cases hbi : b = i <;> by_cases hja : j = a <;> simp [hbi, hja]
 
 private theorem ι_single_mul_glCasimir (a b : n) :

--- a/TauCeti/Algebra/Lie/GeneralLinear/Casimir.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/Casimir.lean
@@ -86,27 +86,6 @@ theorem glCasimir_def :
     glCasimir K n = ∑ i, ∑ j, ι K (Matrix.single i j 1) * ι K (Matrix.single j i 1) :=
   (rfl)
 
-private theorem lie_single_single (a b i j : n) :
-    ⁅Matrix.single a b (1 : K), Matrix.single i j (1 : K)⁆ =
-      (if b = i then Matrix.single a j (1 : K) else 0) -
-        if j = a then Matrix.single i b (1 : K) else 0 := by
-  rw [LieRing.of_associative_ring_bracket]
-  by_cases hbi : b = i
-  · subst i
-    by_cases hja : j = a
-    · subst j
-      rw [Matrix.single_mul_single_same, Matrix.single_mul_single_same]
-      simp
-    · rw [Matrix.single_mul_single_same, Matrix.single_mul_single_of_ne (h := hja)]
-      simp [hja]
-  · by_cases hja : j = a
-    · subst j
-      rw [Matrix.single_mul_single_of_ne (h := hbi), Matrix.single_mul_single_same]
-      simp [hbi]
-    · rw [Matrix.single_mul_single_of_ne (h := hbi),
-        Matrix.single_mul_single_of_ne (h := hja)]
-      simp [hbi, hja]
-
 private theorem ι_lie_single_single (a b i j : n) :
     ι K ⁅Matrix.single a b (1 : K), Matrix.single i j (1 : K)⁆ =
       (if b = i then ι K (Matrix.single a j (1 : K)) else 0) -


### PR DESCRIPTION
This PR moves the generic matrix-unit commutator identity to `GeneralLinear.Basic` and reuses it from the Casimir construction, removing a private duplicate. It is a prerequisite cleanup for #4628.

Roadmap: ReductiveGroups

:robot: Prepared with OpenAI Codex
