### PR TITLE
feat: add type-A carrier graph automorphism

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/GraphAutomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/GraphAutomorphism.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.FunctorOfPoints
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.GraphAutomorphism
+
+/-!
+# The type-A graph automorphism on the general linear group scheme
+
+This file transports signed reverse-inverse-transpose from general-linear matrix points to the
+coordinate Hopf algebra. Its characteristic theorem identifies precomposition by the recovered
+coordinate automorphism with `TauCeti.typeAGraphAutomorphism` under the standard point equivalence.
+
+This is the ambient general-linear input for descending the graph automorphism to the type-`A`
+standard carrier.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti.GeneralLinear
+
+variable (r : ℕ)
+
+/-- Signed reverse-inverse-transpose transported to general-linear coordinate-algebra points. -/
+private noncomputable def typeAGraphPointsMulEquiv (A : CommAlgCat.{0} ℤ) :
+    HopfAlgebra.points
+        (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) A ≃*
+      HopfAlgebra.points
+        (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) A :=
+  ((pointsMulEquiv (R := ℤ) (A := A) (r + 1)).trans
+    (TauCeti.typeAGraphAutomorphism r A)).trans
+      (pointsMulEquiv (R := ℤ) (A := A) (r + 1)).symm
+
+private theorem pointsMulEquiv_typeAGraphPointsMulEquiv
+    (A : CommAlgCat.{0} ℤ)
+    (f : HopfAlgebra.points (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) A) :
+    pointsMulEquiv (r + 1) (typeAGraphPointsMulEquiv r A f) =
+      TauCeti.typeAGraphAutomorphism r A (pointsMulEquiv (r + 1) f) := by
+  rw [typeAGraphPointsMulEquiv, MulEquiv.trans_apply, MulEquiv.trans_apply]
+  exact (pointsMulEquiv (R := ℤ) (A := A) (r + 1)).apply_symm_apply _
+
+/-- The pointwise graph automorphism in the object presentation used by the points functor. -/
+private noncomputable def typeAGraphPointsIsoApp (A : CommAlgCat.{0} ℤ) :
+    (HopfAlgebra.pointsFunctor
+        (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1))).obj A ≅
+      (HopfAlgebra.pointsFunctor
+        (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1))).obj A :=
+  eqToIso (HopfAlgebra.pointsFunctor_obj
+      (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) A) ≪≫
+    (typeAGraphPointsMulEquiv r A).toGrpIso ≪≫
+      eqToIso (HopfAlgebra.pointsFunctor_obj
+        (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) A).symm
+
+/-- The natural automorphism of general-linear points induced by the matrix graph automorphism. -/
+private noncomputable def typeAGraphPointsNatIso :
+    HopfAlgebra.pointsFunctor (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) ≅
+      HopfAlgebra.pointsFunctor (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) :=
+  NatIso.ofComponents
+    (fun A ↦ typeAGraphPointsIsoApp r A)
+    (fun {A B} φ ↦ by
+      apply (cancel_epi (eqToHom (HopfAlgebra.pointsFunctor_obj
+        (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) A).symm)).1
+      apply (cancel_mono (eqToHom (HopfAlgebra.pointsFunctor_obj
+        (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) B))).1
+      rw [typeAGraphPointsIsoApp, typeAGraphPointsIsoApp]
+      simp only [Iso.trans_hom, eqToIso.hom, Category.assoc, eqToHom_trans_assoc,
+        eqToHom_refl, Category.id_comp, eqToHom_trans, Category.comp_id]
+      simp only [← Category.assoc]
+      rw [HopfAlgebra.pointsFunctor_map_eqToHom]
+      slice_rhs 2 3 => rw [HopfAlgebra.pointsFunctor_map_eqToHom]
+      slice_rhs 3 4 => simp
+      simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp,
+        Category.comp_id]
+      apply GrpCat.hom_ext
+      apply MonoidHom.ext
+      intro f
+      rw [GrpCat.comp_apply, GrpCat.comp_apply]
+      change typeAGraphPointsMulEquiv r B (HopfAlgebra.mapPoints φ f) =
+        HopfAlgebra.mapPoints φ (typeAGraphPointsMulEquiv r A f)
+      apply (pointsMulEquiv (R := ℤ) (A := B) (r + 1)).injective
+      simp only [HopfAlgebra.mapPoints]
+      rw [pointsMulEquiv_typeAGraphPointsMulEquiv]
+      change TauCeti.typeAGraphAutomorphism r B
+          (pointsMulEquiv (r + 1) (AlgHom.mapValue φ.hom f)) =
+        pointsMulEquiv (r + 1)
+          (AlgHom.mapValue φ.hom (typeAGraphPointsMulEquiv r A f))
+      rw [pointsMulEquiv_mapValue, pointsMulEquiv_mapValue,
+        pointsMulEquiv_typeAGraphPointsMulEquiv, TauCeti.map_typeAGraphAutomorphism])
+
+/-- The coordinate Hopf-algebra automorphism corresponding to signed reverse-inverse-transpose
+on general-linear points. -/
+noncomputable def typeAGraphCoordinateIso :
+    coordinateHopfAlgebra ℤ (r + 1) ≅ coordinateHopfAlgebra ℤ (r + 1) :=
+  ((CommHopfAlgCat.pointsFunctor (R := ℤ)).preimageIso
+    (typeAGraphPointsNatIso r)).unop
+
+/-- Mapping a general-linear coordinate point along `typeAGraphCoordinateIso` realizes the
+matrix graph automorphism. -/
+theorem pointsMulEquiv_mapPointsFunctor_typeAGraphCoordinateIso
+    (A : CommAlgCat.{0} ℤ)
+    (f : HopfAlgebra.points (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) A) :
+    pointsMulEquiv (r + 1)
+        ((CommHopfAlgCat.mapPointsFunctor (typeAGraphCoordinateIso r).hom).app A f) =
+      TauCeti.typeAGraphAutomorphism r A (pointsMulEquiv (r + 1) f) := by
+  have hmap := (CommHopfAlgCat.pointsFunctor (R := ℤ)).map_preimage
+    (typeAGraphPointsNatIso r).hom
+  have happ := congrArg (fun α => α.app A f) hmap
+  have hcoordinate : (typeAGraphCoordinateIso r).hom.op =
+      (CommHopfAlgCat.pointsFunctor (R := ℤ)).preimage
+        (typeAGraphPointsNatIso r).hom := rfl
+  change pointsMulEquiv (r + 1)
+      (((CommHopfAlgCat.pointsFunctor (R := ℤ)).map
+        (typeAGraphCoordinateIso r).hom.op).app A f) = _
+  rw [hcoordinate, happ]
+  change pointsMulEquiv (r + 1) (typeAGraphPointsMulEquiv r A f) = _
+  exact pointsMulEquiv_typeAGraphPointsMulEquiv r A f
+
+/-- Explicit precomposition form of the action of `typeAGraphCoordinateIso`. -/
+theorem pointsMulEquiv_comp_typeAGraphCoordinateIso
+    (A : CommAlgCat.{0} ℤ)
+    (f : HopfAlgebra.points (R := ℤ) (H := coordinateHopfAlgebra ℤ (r + 1)) A) :
+    pointsMulEquiv (r + 1)
+        (toConv (f.ofConv.comp ((typeAGraphCoordinateIso r).hom.hom :
+          coordinateHopfAlgebra ℤ (r + 1) →ₐ[ℤ] coordinateHopfAlgebra ℤ (r + 1)))) =
+      TauCeti.typeAGraphAutomorphism r A (pointsMulEquiv (r + 1) f) := by
+  rw [← CommHopfAlgCat.mapPointsFunctor_app_apply]
+  exact pointsMulEquiv_mapPointsFunctor_typeAGraphCoordinateIso r A f
+
+end TauCeti.GeneralLinear

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/GraphAutomorphism.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/GraphAutomorphism.lean
@@ -82,11 +82,15 @@ private noncomputable def typeAGraphPointsNatIso :
       apply MonoidHom.ext
       intro f
       rw [GrpCat.comp_apply, GrpCat.comp_apply]
+      -- `pointsFunctor_obj` presents both categorical point objects by the same `WithConv`
+      -- type; rewriting cannot cross those presentation equalities inside the composites.
       change typeAGraphPointsMulEquiv r B (HopfAlgebra.mapPoints φ f) =
         HopfAlgebra.mapPoints φ (typeAGraphPointsMulEquiv r A f)
       apply (pointsMulEquiv (R := ℤ) (A := B) (r + 1)).injective
       simp only [HopfAlgebra.mapPoints]
       rw [pointsMulEquiv_typeAGraphPointsMulEquiv]
+      -- Expose `mapPoints` as postcomposition by `φ`; its public naturality theorem is
+      -- stated for `AlgHom.mapValue`, while the points functor retains the wrapper.
       change TauCeti.typeAGraphAutomorphism r B
           (pointsMulEquiv (r + 1) (AlgHom.mapValue φ.hom f)) =
         pointsMulEquiv (r + 1)
@@ -115,10 +119,14 @@ theorem pointsMulEquiv_mapPointsFunctor_typeAGraphCoordinateIso
   have hcoordinate : (typeAGraphCoordinateIso r).hom.op =
       (CommHopfAlgCat.pointsFunctor (R := ℤ)).preimage
         (typeAGraphPointsNatIso r).hom := rfl
+  -- `mapPointsFunctor` is the same Yoneda map under the opposite-category and `WithConv`
+  -- presentations; no rewrite lemma exposes both wrappers simultaneously.
   change pointsMulEquiv (r + 1)
       (((CommHopfAlgCat.pointsFunctor (R := ℤ)).map
         (typeAGraphCoordinateIso r).hom.op).app A f) = _
   rw [hcoordinate, happ]
+  -- Evaluating the component of `typeAGraphPointsNatIso` reduces to its underlying point
+  -- equivalence only after the `eqToIso` presentation transports cancel.
   change pointsMulEquiv (r + 1) (typeAGraphPointsMulEquiv r A f) = _
   exact pointsMulEquiv_typeAGraphPointsMulEquiv r A f
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -226,6 +226,12 @@ fundamental weights. -/
 def weight (k : Fin (r + 1)) (i : Fin r) : ℤ :=
   (if k = i.castSucc then 1 else 0) - (if k = i.succ then 1 else 0)
 
+/-- The standard-module weight in Kronecker-delta form. -/
+theorem weight_apply (k : Fin (r + 1)) (i : Fin r) :
+    weight r k i =
+      (if k = i.castSucc then 1 else 0) - (if k = i.succ then 1 else 0) :=
+  by rw [weight]
+
 /-- The weights of the standard representation sum to zero. -/
 theorem sum_weight_eq_zero : ∑ k, weight r k = 0 := by
   funext i
@@ -505,6 +511,15 @@ noncomputable def rootSubgroup (k : Fin r ⊕ Fin r) :
     (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k
 
+/-- The root subgroup is the one supplied by the generic Kostant toral-closure construction. -/
+theorem rootSubgroup_def (k : Fin r ⊕ Fin r) :
+    rootSubgroup r k =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k := by
+  rw [rootSubgroup]
+
 /-- The rank-`r` split weight torus `T → G` of the type `A_r` carrier. Maximality is not
 asserted here; see the scope disclaimer in the module documentation. -/
 noncomputable def weightTorus : SplitTorus.groupScheme ℤ (Fin r) ⟶ groupScheme r :=
@@ -512,6 +527,15 @@ noncomputable def weightTorus : SplitTorus.groupScheme ℤ (Fin r) ⟶ groupSche
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
     (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+
+/-- The weight torus is the one supplied by the generic Kostant toral-closure construction. -/
+theorem weightTorus_def :
+    weightTorus r =
+      TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) := by
+  rw [weightTorus]
 
 /-- Including a numbered root subgroup of the type `A_r` carrier into `GL_{r+1}` recovers the
 Kostant root subgroup of the numbered generator. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -227,7 +227,8 @@ def weight (k : Fin (r + 1)) (i : Fin r) : ℤ :=
   (if k = i.castSucc then 1 else 0) - (if k = i.succ then 1 else 0)
 
 /-- The standard-module weight in Kronecker-delta form. -/
-theorem weight_apply (k : Fin (r + 1)) (i : Fin r) :
+@[simp]
+theorem weight_def (k : Fin (r + 1)) (i : Fin r) :
     weight r k i =
       (if k = i.castSucc then 1 else 0) - (if k = i.succ then 1 else 0) :=
   by rw [weight]

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
-public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.DeterminantOne
+public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.Basic
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Rigidity
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.GraphAutomorphism
 
@@ -27,6 +27,9 @@ gives the desired group-scheme automorphism.
 
 * `TauCeti.SlStd.graphRootPerm`: reversal on the positive and negative simple-root indices.
 * `TauCeti.SlStd.graphAutomorphism`: the pinned graph automorphism of the standard carrier.
+* `TauCeti.SlStd.schemePointsMulEquiv_comp_graphAutomorphism`: its signed
+  reverse-inverse-transpose formula on arbitrary carrier points.
+* `TauCeti.SlStd.graphAutomorphism_hom_comp_hom`: its involutivity.
 * `TauCeti.SlStd.rootSubgroup_comp_graphAutomorphism_hom`: its action on root subgroups.
 * `TauCeti.SlStd.weightTorus_comp_graphAutomorphism_hom`: its action on the split torus.
 
@@ -87,6 +90,8 @@ private theorem torusCharacter_weight_rev {A : Type*} [CommRing A]
     _ = TauCeti.torusCharacter (fun i => s i.rev) (weight r k) := by
       have h := (TauCeti.torusCharacter_mulEquivArrowCongr
         (Fin.revPerm : Equiv.Perm (Fin r)) s (weight r k)).symm
+      -- The arrow-congruence API packages reindexing as a bundled `MulEquiv`; expose its
+      -- definitionally equal function action to compare it with `fun i => s i.rev`.
       change TauCeti.torusCharacter s (weight r k ∘ Fin.revPerm) =
         TauCeti.torusCharacter
           ((MulEquiv.arrowCongr Fin.revPerm (MulEquiv.refl Aˣ)) s) (weight r k) at h
@@ -163,11 +168,15 @@ private noncomputable def generalLinearPointsGraphNatIso :
       apply MonoidHom.ext
       intro f
       rw [GrpCat.comp_apply, GrpCat.comp_apply]
+      -- The points functor presents its object values by an equality; after cancelling those
+      -- transports, its action is definitionally `HopfAlgebra.mapPoints`.
       change generalLinearPointsGraphMulEquiv r B (HopfAlgebra.mapPoints φ f) =
         HopfAlgebra.mapPoints φ (generalLinearPointsGraphMulEquiv r A f)
       apply (GeneralLinear.pointsMulEquiv (R := ℤ) (A := B) (r + 1)).injective
       simp only [HopfAlgebra.mapPoints]
       rw [pointsMulEquiv_generalLinearPointsGraphMulEquiv]
+      -- The general-linear points equivalence reads `AlgHom.mapValue` entrywise; this
+      -- definitional presentation is the input expected by its naturality theorem.
       change TauCeti.typeAGraphAutomorphism r B
           (GeneralLinear.pointsMulEquiv (r + 1) (AlgHom.mapValue φ.hom f)) =
         GeneralLinear.pointsMulEquiv (r + 1)
@@ -198,10 +207,14 @@ private theorem pointsMulEquiv_mapPointsFunctor_ambientGraphCoordinateIso
   have hcoordinate : (ambientGraphCoordinateIso r).hom.op =
       (CommHopfAlgCat.pointsFunctor (R := ℤ)).preimage
         (generalLinearPointsGraphNatIso r).hom := rfl
+  -- `ambientGraphCoordinateIso` is obtained by fully faithful preimage, so its mapped points
+  -- functor is definitionally the expression exposed by `hmap`.
   change GeneralLinear.pointsMulEquiv (r + 1)
       (((CommHopfAlgCat.pointsFunctor (R := ℤ)).map
         (ambientGraphCoordinateIso r).hom.op).app A f) = _
   rw [hcoordinate, happ]
+  -- The component of `generalLinearPointsGraphNatIso` retains the object-presentation
+  -- transports; cancelling them leaves the underlying pointwise equivalence.
   change GeneralLinear.pointsMulEquiv (r + 1) (generalLinearPointsGraphMulEquiv r A f) = _
   exact pointsMulEquiv_generalLinearPointsGraphMulEquiv r A f
 
@@ -229,7 +242,23 @@ private theorem typeAGraphAutomorphism_kostantRootSubgroupMatrix
         (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
         (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
         (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r) q := by
-  rw [kostantRootSubgroupMatrix_eq_transvection, kostantRootSubgroupMatrix_eq_transvection]
+  have hk :=
+    TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_transvectionUnit_of_action
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
+      (isNilpotent_rep_rootGenerator r k) (latticeBasis r) (rootSource r k)
+      (rootTarget r k) (rootTarget_ne_rootSource r k)
+      (nilpotencyClass_rep_rootGenerator r k) (rep_rootGenerator_latticeBasis_apply r k) q
+  have hgraph :=
+    TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_transvectionUnit_of_action
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
+      (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r)
+      (rootSource r (graphRootPerm r k)) (rootTarget r (graphRootPerm r k))
+      (rootTarget_ne_rootSource r (graphRootPerm r k))
+      (nilpotencyClass_rep_rootGenerator r (graphRootPerm r k))
+      (rep_rootGenerator_latticeBasis_apply r (graphRootPerm r k)) q
+  rw [hk, hgraph]
   cases k with
   | inl i =>
       simpa only [graphRootPerm_inl, rootTarget_inl, rootSource_inl] using
@@ -239,6 +268,17 @@ private theorem typeAGraphAutomorphism_kostantRootSubgroupMatrix
       simpa only [graphRootPerm_inr, rootTarget_inr, rootSource_inr] using
         TauCeti.typeAGraphAutomorphism_transvectionUnit_lower r i
           (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv q))
+
+/-- Two coordinate Hopf maps are equal if they agree on the universal point of their target. -/
+private theorem hom_eq_of_universalPoint_eq
+    {H K : _root_.CommHopfAlgCat.{0} ℤ} (f g : H ⟶ K)
+    (h : toConv ((AlgHom.id ℤ K).comp f.hom.toAlgHom) =
+      toConv ((AlgHom.id ℤ K).comp g.hom.toAlgHom)) : f = g := by
+  apply _root_.CommHopfAlgCat.hom_ext
+  ext z
+  have hz := congrArg (fun p => p.ofConv z) h
+  simp only [AlgHom.id_apply, AlgHom.comp_apply] at hz
+  exact hz
 
 private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
     (k : Fin r ⊕ Fin r) :
@@ -260,8 +300,7 @@ private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
     (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
     (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r)
-  apply _root_.CommHopfAlgCat.hom_ext
-  ext z
+  apply hom_eq_of_universalPoint_eq
   let q : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ]
       AdditiveGroup.coordinateHopfAlgebra ℤ) :=
     toConv (AlgHom.id ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))
@@ -303,10 +342,9 @@ private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
       (CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))) hx
     exact hleft.trans ((typeAGraphAutomorphism_kostantRootSubgroupMatrix
       (A := CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) r k q).trans hy.symm)
-  have hz := congrArg (fun p => p.ofConv z) hp
-  simp only [f, g, q, AlgHom.id_apply, AlgHom.comp_apply] at hz
-  rw [_root_.CommHopfAlgCat.comp_apply]
-  exact hz
+  convert hp using 1
+  · ext z
+    rfl
 
 private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
     (ambientGraphCoordinateIso r).hom ≫
@@ -318,8 +356,7 @@ private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
   let y := GeneralLinear.weightTorusCoordinateMap (R := ℤ)
     (fun i => weight r i ∘ Fin.revPerm)
   have hxy : c ≫ x = y := by
-    apply _root_.CommHopfAlgCat.hom_ext
-    refine DFunLike.ext _ _ fun z => ?_
+    apply hom_eq_of_universalPoint_eq
     let T := MonoidAlgebra ℤ (SplitTorus.characterGroup (Fin r))
     let q : WithConv (T →ₐ[ℤ] T) := toConv (AlgHom.id ℤ T)
     let f : HopfAlgebra.points
@@ -355,15 +392,16 @@ private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
       congr 1
       funext i
       exact torusCharacter_weight_rev_reindex r (SplitTorus.pointsMulEquiv q) i
-    have hz := congrArg (fun p => p.ofConv z) hp
-    simp only [f, g, q, AlgHom.id_apply, AlgHom.comp_apply] at hz
-    rw [_root_.CommHopfAlgCat.comp_apply]
-    exact hz
+    convert hp using 1
+    · ext z
+      rfl
   calc
     (ambientGraphCoordinateIso r).hom ≫
         GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) = y := hxy
     _ = GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) ≫
         SplitTorus.relabelCoordinateMap ℤ Fin.revPerm := by
+      -- Reindexing the weights is definitionally composition with `Fin.revPerm`; spelling that
+      -- family explicitly lets the public coordinate-map reindexing theorem apply.
       change GeneralLinear.weightTorusCoordinateMap (R := ℤ)
           (fun i => weight r i ∘ Fin.revPerm) = _
       have h := GeneralLinear.weightTorusCoordinateMap_reindex
@@ -381,6 +419,10 @@ private noncomputable abbrev definingIdeal :=
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
     (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
     (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+
+/-- The quotient coordinate Hopf algebra underlying the standard carrier. -/
+private noncomputable abbrev carrierCoordinateHopfAlgebra :=
+  CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) (definingIdeal r)
 
 private theorem definingIdeal_comap_ambientGraphCoordinateIso_hom_le :
     (definingIdeal r).comapOfSurjective (ambientGraphCoordinateIso r).hom.hom
@@ -511,6 +553,7 @@ private theorem graphCoordinateIso_hom_comp_torusMap :
           (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
           (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) hz)
     rw [RingHom.mem_ker]
+    -- The composite Hopf morphism acts by the underlying composed bialgebra homomorphism.
     change (GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) ≫
       SplitTorus.relabelCoordinateMap ℤ Fin.revPerm).hom z = 0
     rw [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply, hzero, map_zero]
@@ -536,6 +579,101 @@ private theorem graphCoordinateIso_hom_comp_torusMap :
 /-- **The pinned graph automorphism of the full-weight type-`A_r` standard carrier.** -/
 noncomputable def graphAutomorphism : Aut (groupScheme r) :=
   (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).mapIso (graphCoordinateIso r).op
+
+/-- The standard carrier is represented by its quotient coordinate Hopf algebra. -/
+private theorem groupScheme_eq_hopfSpec :
+    groupScheme r =
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).obj
+        (Opposite.op (carrierCoordinateHopfAlgebra r)) := rfl
+
+/-- Algebra-valued points of the carrier, transported to scheme-valued points. -/
+private noncomputable def groupSchemePointMulEquiv (A : Type) [CommRing A] :
+    WithConv (carrierCoordinateHopfAlgebra r →ₐ[ℤ] A) ≃*
+      ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶ (groupScheme r).X) :=
+  CommHopfAlgCat.mapMulEquivOfPresentation (carrierCoordinateHopfAlgebra r) A
+    (groupScheme_eq_hopfSpec r)
+
+private theorem groupSchemePointMulEquiv_apply_left {A : Type} [CommRing A]
+    (q : WithConv (carrierCoordinateHopfAlgebra r →ₐ[ℤ] A)) :
+    (groupSchemePointMulEquiv r A q).left =
+      Spec.map (CommRingCat.ofHom q.ofConv.toRingHom) ≫
+        eqToHom (congrArg
+          (fun K : Grp (Over (Spec (CommRingCat.of ℤ))) => K.X.left)
+          (groupScheme_eq_hopfSpec r)).symm := by
+  simpa only [groupSchemePointMulEquiv] using
+    CommHopfAlgCat.mapMulEquivOfPresentation_apply_left
+      (carrierCoordinateHopfAlgebra r) A (groupScheme_eq_hopfSpec r)
+      (congrArg (fun K : Grp (Over (Spec (CommRingCat.of ℤ))) => K.X.left)
+        (groupScheme_eq_hopfSpec r)) q
+
+private theorem groupSchemePointMulEquiv_comp_graphAutomorphism
+    {A : Type} [CommRing A]
+    (q : WithConv (carrierCoordinateHopfAlgebra r →ₐ[ℤ] A)) :
+    groupSchemePointMulEquiv r A q ≫ (graphAutomorphism r).hom.hom.hom =
+      groupSchemePointMulEquiv r A
+        ((CommHopfAlgCat.mapPointsFunctor (graphCoordinateIso r).hom).app
+          (CommAlgCat.of ℤ A) q) := by
+  rw [graphAutomorphism, Functor.mapIso_hom, Iso.op_hom]
+  exact CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain
+    (R := ℤ) A (groupScheme_eq_hopfSpec r) (groupScheme_eq_hopfSpec r)
+      (groupSchemePointMulEquiv r A) (groupSchemePointMulEquiv r A)
+      (groupSchemePointMulEquiv_apply_left r) (groupSchemePointMulEquiv_apply_left r)
+      (graphCoordinateIso r).hom q
+
+private theorem groupSchemePointMulEquiv_comp_carrierι
+    {A : Type} [CommRing A]
+    (q : WithConv (carrierCoordinateHopfAlgebra r →ₐ[ℤ] A)) :
+    groupSchemePointMulEquiv r A q ≫ (carrierι r).hom.hom =
+      GeneralLinear.groupSchemePointMulEquiv (r + 1) A
+        ((CommHopfAlgCat.mapPointsFunctor
+          (CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+            (definingIdeal r))).app (CommAlgCat.of ℤ A) q) := by
+  rw [carrierι_def, kostantToralGroupSchemeι_def, CommHopfAlgCat.quotientSpecι_def]
+  exact CommHopfAlgCat.pointMulEquivOfPresentation_mapDomain
+    (R := ℤ) A (GeneralLinear.groupScheme_def ℤ (r + 1)) rfl
+      (GeneralLinear.groupSchemePointMulEquiv (r + 1) A) (groupSchemePointMulEquiv r A)
+      (GeneralLinear.groupSchemePointMulEquiv_apply_left (r + 1) A)
+      (groupSchemePointMulEquiv_apply_left r)
+      (CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+        (definingIdeal r)) q
+
+/-- On every algebra-valued carrier point, the graph automorphism is signed
+reverse-inverse-transpose after the canonical inclusion into `GL_{r+1}`. -/
+theorem schemePointsMulEquiv_comp_graphAutomorphism {A : Type} [CommRing A]
+    (p : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶ (groupScheme r).X) :
+    GeneralLinear.schemePointsMulEquiv (r + 1) A
+        ((p ≫ (graphAutomorphism r).hom.hom.hom) ≫ (carrierι r).hom.hom) =
+      TauCeti.typeAGraphAutomorphism r A
+        (GeneralLinear.schemePointsMulEquiv (r + 1) A (p ≫ (carrierι r).hom.hom)) := by
+  obtain ⟨q, rfl⟩ := (groupSchemePointMulEquiv r A).surjective p
+  have hgraph := groupSchemePointMulEquiv_comp_graphAutomorphism r q
+  have hinclusion := groupSchemePointMulEquiv_comp_carrierι r q
+  have hgraphCarrier := congrArg (fun f => f ≫ (carrierι r).hom.hom) hgraph
+  have hinclusionGraph := groupSchemePointMulEquiv_comp_carrierι (A := A) r
+    ((CommHopfAlgCat.mapPointsFunctor (graphCoordinateIso r).hom).app (CommAlgCat.of ℤ A) q)
+  rw [hgraphCarrier, hinclusionGraph,
+    CommHopfAlgCat.mapPointsFunctor_app_apply, CommHopfAlgCat.mapPointsFunctor_app_apply,
+    GeneralLinear.schemePointsMulEquiv_groupSchemePointMulEquiv,
+    hinclusion, CommHopfAlgCat.mapPointsFunctor_app_apply,
+    GeneralLinear.schemePointsMulEquiv_groupSchemePointMulEquiv,
+    WithConv.ofConv_toConv]
+  let qambient : HopfAlgebra.points
+      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) (CommAlgCat.of ℤ A) :=
+    toConv (q.ofConv.comp
+      (CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+        (definingIdeal r)).hom.toAlgHom)
+  have hpoint :
+      toConv ((q.ofConv.comp (graphCoordinateIso r).hom.hom.toAlgHom).comp
+        (CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+          (definingIdeal r)).hom.toAlgHom) =
+        toConv (qambient.ofConv.comp (ambientGraphCoordinateIso r).hom.hom.toAlgHom) := by
+    apply WithConv.ofConv_injective
+    ext z
+    have hz := congrArg (fun f => q.ofConv (f.hom z))
+      (mkQuotient_comp_graphCoordinateIso_hom r)
+    exact hz
+  rw [hpoint]
+  convert pointsMulEquiv_comp_ambientGraphCoordinateIso r (CommAlgCat.of ℤ A) qambient using 1
 
 /-- The graph automorphism reverses the Bourbaki numbering of every positive and negative simple
 root subgroup, without changing its additive parameter. -/
@@ -564,5 +702,49 @@ theorem weightTorus_comp_graphAutomorphism_hom :
     ← Functor.map_comp, ← op_comp, graphCoordinateIso_hom_comp_torusMap, op_comp,
     Functor.map_comp, SplitTorus.relabel_def]
   simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
+
+/-- Applying the graph automorphism twice is the identity on the standard carrier. -/
+@[simp]
+theorem graphAutomorphism_hom_comp_hom :
+    (graphAutomorphism r).hom ≫ (graphAutomorphism r).hom = 𝟙 (groupScheme r) := by
+  apply TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme_hom_ext
+    (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+  · intro k
+    rw [← rootSubgroup_def]
+    have h₁ := rootSubgroup_comp_graphAutomorphism_hom r k
+    have h₂ := rootSubgroup_comp_graphAutomorphism_hom r (graphRootPerm r k)
+    calc
+      rootSubgroup r k ≫ ((graphAutomorphism r).hom ≫ (graphAutomorphism r).hom) =
+          (rootSubgroup r k ≫ (graphAutomorphism r).hom) ≫
+            (graphAutomorphism r).hom := (Category.assoc _ _ _).symm
+      _ = rootSubgroup r (graphRootPerm r k) ≫ (graphAutomorphism r).hom := by rw [h₁]
+      _ = rootSubgroup r (graphRootPerm r (graphRootPerm r k)) := h₂
+      _ = rootSubgroup r k := by rw [graphRootPerm_apply_apply]
+      _ = rootSubgroup r k ≫ 𝟙 (groupScheme r) := (Category.comp_id _).symm
+  · rw [← weightTorus_def]
+    have htorus := weightTorus_comp_graphAutomorphism_hom r
+    calc
+      weightTorus r ≫ ((graphAutomorphism r).hom ≫ (graphAutomorphism r).hom) =
+          (weightTorus r ≫ (graphAutomorphism r).hom) ≫
+            (graphAutomorphism r).hom := (Category.assoc _ _ _).symm
+      _ = (SplitTorus.relabel ℤ Fin.revPerm ≫ weightTorus r) ≫
+          (graphAutomorphism r).hom := by rw [htorus]
+      _ = SplitTorus.relabel ℤ Fin.revPerm ≫
+          (weightTorus r ≫ (graphAutomorphism r).hom) := Category.assoc _ _ _
+      _ = SplitTorus.relabel ℤ Fin.revPerm ≫
+          (SplitTorus.relabel ℤ Fin.revPerm ≫ weightTorus r) := by rw [htorus]
+      _ = (SplitTorus.relabel ℤ Fin.revPerm ≫ SplitTorus.relabel ℤ Fin.revPerm) ≫
+          weightTorus r := (Category.assoc _ _ _).symm
+      _ = SplitTorus.relabel ℤ
+            ((Fin.revPerm : Equiv.Perm (Fin r)) * Fin.revPerm) ≫ weightTorus r := by
+        rw [SplitTorus.relabel_comp]
+      _ = weightTorus r := by
+        have hrev : (Fin.revPerm : Equiv.Perm (Fin r)) * Fin.revPerm = 1 := by
+          ext i
+          simp
+        rw [hrev, SplitTorus.relabel_one, Category.id_comp]
+      _ = weightTorus r ≫ 𝟙 (groupScheme r) := (Category.comp_id _).symm
 
 end TauCeti.SlStd

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
@@ -1,0 +1,568 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.DeterminantOne
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Rigidity
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.GraphAutomorphism
+
+/-!
+# The pinned graph automorphism of the type-A standard carrier
+
+The signed reverse-inverse-transpose automorphism of `GL_{r+1}` preserves the full-weight
+type-`A_r` Chevalley carrier. This file descends it to an automorphism of
+`TauCeti.SlStd.groupScheme r`. On the chosen pinning it reverses the Bourbaki numbering without
+changing root-subgroup parameters, and on the split torus it reverses the coordinates.
+
+The proof first recovers the ambient coordinate Hopf-algebra automorphism from its natural action
+on matrix points. The positive and negative transvection formulas and the diagonal formula then
+show that it preserves every generator of the carrier's defining ideal. Passing to the quotient
+gives the desired group-scheme automorphism.
+
+## Main declarations
+
+* `TauCeti.SlStd.graphRootPerm`: reversal on the positive and negative simple-root indices.
+* `TauCeti.SlStd.graphAutomorphism`: the pinned graph automorphism of the standard carrier.
+* `TauCeti.SlStd.rootSubgroup_comp_graphAutomorphism_hom`: its action on root subgroups.
+* `TauCeti.SlStd.weightTorus_comp_graphAutomorphism_hom`: its action on the split torus.
+
+## References
+
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.15.
+* R. Steinberg, *Lectures on Chevalley Groups*, §10.
+
+This advances the Pinnings and Chevalley--Demazure construction targets in Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md`. It supplies the graph part of the Steinberg map needed
+by milestone L1 of `TauCetiRoadmap/CFSGStatement/README.md` for the twisted family `²A_r(q)`.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory WithConv
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti.SlStd
+
+open TauCeti.UniversalEnvelopingAlgebra
+
+attribute [local instance high] Algebra.toModule
+
+variable (r : ℕ)
+
+/-- Reversal of the Bourbaki node on both the positive and negative simple-root indices. -/
+def graphRootPerm : Equiv.Perm (Fin r ⊕ Fin r) :=
+  Equiv.sumCongr Fin.revPerm Fin.revPerm
+
+@[simp] theorem graphRootPerm_inl (i : Fin r) : graphRootPerm r (.inl i) = .inl i.rev := by
+  simp [graphRootPerm]
+
+@[simp] theorem graphRootPerm_inr (i : Fin r) : graphRootPerm r (.inr i) = .inr i.rev := by
+  simp [graphRootPerm]
+
+@[simp] theorem graphRootPerm_apply_apply (k : Fin r ⊕ Fin r) :
+    graphRootPerm r (graphRootPerm r k) = k := by
+  cases k <;> simp [graphRootPerm]
+
+private theorem weight_rev_rev (k : Fin (r + 1)) (i : Fin r) :
+    weight r k.rev i.rev = -weight r k i := by
+  rw [weight_apply, weight_apply]
+  simp only [← Fin.rev_succ, ← Fin.rev_castSucc, Fin.rev_injective.eq_iff]
+  ring
+
+private theorem torusCharacter_weight_rev {A : Type*} [CommRing A]
+    (s : Fin r → Aˣ) (k : Fin (r + 1)) :
+    (TauCeti.torusCharacter s (weight r k.rev))⁻¹ =
+      TauCeti.torusCharacter (fun i => s i.rev) (weight r k) := by
+  rw [← TauCeti.torusCharacter_neg]
+  calc
+    TauCeti.torusCharacter s (-weight r k.rev) =
+        TauCeti.torusCharacter s (weight r k ∘ Fin.revPerm) := by
+      congr 1
+      funext i
+      simpa using (weight_rev_rev r k.rev i).symm
+    _ = TauCeti.torusCharacter (fun i => s i.rev) (weight r k) := by
+      have h := (TauCeti.torusCharacter_mulEquivArrowCongr
+        (Fin.revPerm : Equiv.Perm (Fin r)) s (weight r k)).symm
+      change TauCeti.torusCharacter s (weight r k ∘ Fin.revPerm) =
+        TauCeti.torusCharacter
+          ((MulEquiv.arrowCongr Fin.revPerm (MulEquiv.refl Aˣ)) s) (weight r k) at h
+      change TauCeti.torusCharacter s (weight r k ∘ Fin.revPerm) =
+        TauCeti.torusCharacter
+          ((MulEquiv.arrowCongr Fin.revPerm (MulEquiv.refl Aˣ)) s) (weight r k)
+      exact h
+
+private theorem torusCharacter_weight_rev_reindex {A : Type*} [CommRing A]
+    (s : Fin r → Aˣ) (k : Fin (r + 1)) :
+    (TauCeti.torusCharacter s (weight r k.rev))⁻¹ =
+      TauCeti.torusCharacter s (weight r k ∘ Fin.revPerm) := by
+  rw [torusCharacter_weight_rev]
+  exact TauCeti.torusCharacter_mulEquivArrowCongr
+    (Fin.revPerm : Equiv.Perm (Fin r)) s (weight r k)
+
+/-! ## The ambient coordinate automorphism -/
+
+/-- Signed reverse-inverse-transpose transported to general-linear coordinate-algebra points. -/
+private noncomputable def generalLinearPointsGraphMulEquiv (A : CommAlgCat.{0} ℤ) :
+    HopfAlgebra.points
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A ≃*
+      HopfAlgebra.points
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A :=
+  ((GeneralLinear.pointsMulEquiv (R := ℤ) (A := A) (r + 1)).trans
+    (TauCeti.typeAGraphAutomorphism r A)).trans
+      (GeneralLinear.pointsMulEquiv (R := ℤ) (A := A) (r + 1)).symm
+
+private theorem pointsMulEquiv_generalLinearPointsGraphMulEquiv
+    (A : CommAlgCat.{0} ℤ)
+    (f : HopfAlgebra.points
+      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A) :
+    GeneralLinear.pointsMulEquiv (r + 1) (generalLinearPointsGraphMulEquiv r A f) =
+      TauCeti.typeAGraphAutomorphism r A (GeneralLinear.pointsMulEquiv (r + 1) f) := by
+  rw [generalLinearPointsGraphMulEquiv, MulEquiv.trans_apply, MulEquiv.trans_apply]
+  exact (GeneralLinear.pointsMulEquiv (R := ℤ) (A := A) (r + 1)).apply_symm_apply _
+
+/-- The pointwise graph automorphism in the object presentation used by the points functor. -/
+private noncomputable def generalLinearPointsGraphIsoApp (A : CommAlgCat.{0} ℤ) :
+    (HopfAlgebra.pointsFunctor
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))).obj A ≅
+      (HopfAlgebra.pointsFunctor
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))).obj A :=
+  eqToIso (HopfAlgebra.pointsFunctor_obj
+      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A) ≪≫
+    (generalLinearPointsGraphMulEquiv r A).toGrpIso ≪≫
+      eqToIso (HopfAlgebra.pointsFunctor_obj
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A).symm
+
+/-- The natural automorphism of the general-linear functor of points induced by the matrix graph
+automorphism. -/
+private noncomputable def generalLinearPointsGraphNatIso :
+    HopfAlgebra.pointsFunctor
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) ≅
+      HopfAlgebra.pointsFunctor
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) :=
+  NatIso.ofComponents
+    (fun A ↦ generalLinearPointsGraphIsoApp r A)
+    (fun {A B} φ ↦ by
+      apply (cancel_epi (eqToHom (HopfAlgebra.pointsFunctor_obj
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A).symm)).1
+      apply (cancel_mono (eqToHom (HopfAlgebra.pointsFunctor_obj
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) B))).1
+      rw [generalLinearPointsGraphIsoApp, generalLinearPointsGraphIsoApp]
+      simp only [Iso.trans_hom, eqToIso.hom, Category.assoc, eqToHom_trans_assoc,
+        eqToHom_refl, Category.id_comp, eqToHom_trans, Category.comp_id]
+      simp only [← Category.assoc]
+      rw [HopfAlgebra.pointsFunctor_map_eqToHom]
+      slice_rhs 2 3 => rw [HopfAlgebra.pointsFunctor_map_eqToHom]
+      slice_rhs 3 4 => simp
+      simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp,
+        Category.comp_id]
+      apply GrpCat.hom_ext
+      apply MonoidHom.ext
+      intro f
+      rw [GrpCat.comp_apply, GrpCat.comp_apply]
+      change generalLinearPointsGraphMulEquiv r B (HopfAlgebra.mapPoints φ f) =
+        HopfAlgebra.mapPoints φ (generalLinearPointsGraphMulEquiv r A f)
+      apply (GeneralLinear.pointsMulEquiv (R := ℤ) (A := B) (r + 1)).injective
+      simp only [HopfAlgebra.mapPoints]
+      rw [pointsMulEquiv_generalLinearPointsGraphMulEquiv]
+      change TauCeti.typeAGraphAutomorphism r B
+          (GeneralLinear.pointsMulEquiv (r + 1) (AlgHom.mapValue φ.hom f)) =
+        GeneralLinear.pointsMulEquiv (r + 1)
+          (AlgHom.mapValue φ.hom (generalLinearPointsGraphMulEquiv r A f))
+      rw [GeneralLinear.pointsMulEquiv_mapValue,
+        GeneralLinear.pointsMulEquiv_mapValue,
+        pointsMulEquiv_generalLinearPointsGraphMulEquiv,
+        TauCeti.map_typeAGraphAutomorphism])
+
+/-- The coordinate Hopf-algebra automorphism corresponding to signed reverse-inverse-transpose
+on general-linear points. -/
+private noncomputable def ambientGraphCoordinateIso :
+    GeneralLinear.coordinateHopfAlgebra ℤ (r + 1) ≅
+      GeneralLinear.coordinateHopfAlgebra ℤ (r + 1) :=
+  ((CommHopfAlgCat.pointsFunctor (R := ℤ)).preimageIso
+    (generalLinearPointsGraphNatIso r)).unop
+
+private theorem pointsMulEquiv_mapPointsFunctor_ambientGraphCoordinateIso
+    (A : CommAlgCat.{0} ℤ)
+    (f : HopfAlgebra.points
+      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A) :
+    GeneralLinear.pointsMulEquiv (r + 1)
+        ((CommHopfAlgCat.mapPointsFunctor (ambientGraphCoordinateIso r).hom).app A f) =
+      TauCeti.typeAGraphAutomorphism r A (GeneralLinear.pointsMulEquiv (r + 1) f) := by
+  have hmap := (CommHopfAlgCat.pointsFunctor (R := ℤ)).map_preimage
+    (generalLinearPointsGraphNatIso r).hom
+  have happ := congrArg (fun α => α.app A f) hmap
+  have hcoordinate : (ambientGraphCoordinateIso r).hom.op =
+      (CommHopfAlgCat.pointsFunctor (R := ℤ)).preimage
+        (generalLinearPointsGraphNatIso r).hom := rfl
+  change GeneralLinear.pointsMulEquiv (r + 1)
+      (((CommHopfAlgCat.pointsFunctor (R := ℤ)).map
+        (ambientGraphCoordinateIso r).hom.op).app A f) = _
+  rw [hcoordinate, happ]
+  change GeneralLinear.pointsMulEquiv (r + 1) (generalLinearPointsGraphMulEquiv r A f) = _
+  exact pointsMulEquiv_generalLinearPointsGraphMulEquiv r A f
+
+private theorem pointsMulEquiv_comp_ambientGraphCoordinateIso
+    (A : CommAlgCat.{0} ℤ)
+    (f : HopfAlgebra.points
+      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A) :
+    GeneralLinear.pointsMulEquiv (r + 1)
+        (toConv (f.ofConv.comp ((ambientGraphCoordinateIso r).hom.hom :
+          GeneralLinear.coordinateHopfAlgebra ℤ (r + 1) →ₐ[ℤ]
+            GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)))) =
+      TauCeti.typeAGraphAutomorphism r A (GeneralLinear.pointsMulEquiv (r + 1) f) := by
+  rw [← CommHopfAlgCat.mapPointsFunctor_app_apply]
+  exact pointsMulEquiv_mapPointsFunctor_ambientGraphCoordinateIso r A f
+
+private theorem typeAGraphAutomorphism_kostantRootSubgroupMatrix
+    {A : Type*} [CommRing A] (k : Fin r ⊕ Fin r)
+    (q : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ] A)) :
+    TauCeti.typeAGraphAutomorphism r A
+        (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
+          (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+          (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
+          (isNilpotent_rep_rootGenerator r k) (latticeBasis r) q) =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
+        (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r) q := by
+  rw [kostantRootSubgroupMatrix_eq_transvection, kostantRootSubgroupMatrix_eq_transvection]
+  cases k with
+  | inl i =>
+      simpa only [graphRootPerm_inl, rootTarget_inl, rootSource_inl] using
+        TauCeti.typeAGraphAutomorphism_transvectionUnit r i
+          (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv q))
+  | inr i =>
+      simpa only [graphRootPerm_inr, rootTarget_inr, rootSource_inr] using
+        TauCeti.typeAGraphAutomorphism_transvectionUnit_lower r i
+          (Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv q))
+
+private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
+    (k : Fin r ⊕ Fin r) :
+    (ambientGraphCoordinateIso r).hom ≫
+        TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator r)
+          (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+          (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
+          (isNilpotent_rep_rootGenerator r k) (latticeBasis r) =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
+        (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r) := by
+  let c := (ambientGraphCoordinateIso r).hom
+  let x := TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
+    (isNilpotent_rep_rootGenerator r k) (latticeBasis r)
+  let y := TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
+    (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r)
+  apply _root_.CommHopfAlgCat.hom_ext
+  ext z
+  let q : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ]
+      AdditiveGroup.coordinateHopfAlgebra ℤ) :=
+    toConv (AlgHom.id ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))
+  let f : HopfAlgebra.points
+      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+        (CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) :=
+    toConv (q.ofConv.comp x.hom.toAlgHom)
+  let g : HopfAlgebra.points
+      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+        (CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) :=
+    toConv (q.ofConv.comp y.hom.toAlgHom)
+  have hx : GeneralLinear.pointToGeneralLinear (r + 1) f =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
+        (isNilpotent_rep_rootGenerator r k) (latticeBasis r) q :=
+    TauCeti.UniversalEnvelopingAlgebra.pointsMulEquiv_kostantRootSubgroupCoordinateMap
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
+      (isNilpotent_rep_rootGenerator r k) (latticeBasis r)
+      (A := AdditiveGroup.coordinateHopfAlgebra ℤ) q
+  have hy : GeneralLinear.pointToGeneralLinear (r + 1) g =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
+        (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
+        (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r) q :=
+    TauCeti.UniversalEnvelopingAlgebra.pointsMulEquiv_kostantRootSubgroupCoordinateMap
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
+      (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r)
+      (A := AdditiveGroup.coordinateHopfAlgebra ℤ) q
+  have hp : toConv (f.ofConv.comp c.hom.toAlgHom) = g := by
+    apply (GeneralLinear.pointsMulEquiv
+      (R := ℤ) (A := CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))
+        (r + 1)).injective
+    rw [pointsMulEquiv_comp_ambientGraphCoordinateIso,
+      GeneralLinear.pointsMulEquiv_apply, GeneralLinear.pointsMulEquiv_apply]
+    have hleft := congrArg (TauCeti.typeAGraphAutomorphism r
+      (CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))) hx
+    exact hleft.trans ((typeAGraphAutomorphism_kostantRootSubgroupMatrix
+      (A := CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) r k q).trans hy.symm)
+  have hz := congrArg (fun p => p.ofConv z) hp
+  simp only [f, g, q, AlgHom.id_apply, AlgHom.comp_apply] at hz
+  rw [_root_.CommHopfAlgCat.comp_apply]
+  exact hz
+
+private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
+    (ambientGraphCoordinateIso r).hom ≫
+        GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) =
+      GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) ≫
+        SplitTorus.relabelCoordinateMap ℤ Fin.revPerm := by
+  let c := (ambientGraphCoordinateIso r).hom
+  let x := GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r)
+  let y := GeneralLinear.weightTorusCoordinateMap (R := ℤ)
+    (fun i => weight r i ∘ Fin.revPerm)
+  have hxy : c ≫ x = y := by
+    apply _root_.CommHopfAlgCat.hom_ext
+    refine DFunLike.ext _ _ fun z => ?_
+    let T := MonoidAlgebra ℤ (SplitTorus.characterGroup (Fin r))
+    let q : WithConv (T →ₐ[ℤ] T) := toConv (AlgHom.id ℤ T)
+    let f : HopfAlgebra.points
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+          (CommAlgCat.of ℤ T) :=
+      toConv (q.ofConv.comp x.hom.toAlgHom)
+    let g : HopfAlgebra.points
+        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+          (CommAlgCat.of ℤ T) :=
+      toConv (q.ofConv.comp y.hom.toAlgHom)
+    have hx : GeneralLinear.pointsMulEquiv (r + 1) f =
+        diagGL fun i => TauCeti.torusCharacter (SplitTorus.pointsMulEquiv q) (weight r i) := by
+      calc
+        _ = GeneralLinear.pointsMulEquiv (r + 1)
+            ((CommHopfAlgCat.mapPointsFunctor x).app (CommAlgCat.of ℤ T) q) := by
+          rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
+        _ = _ := GeneralLinear.pointsMulEquiv_mapPointsFunctor_weightTorusCoordinateMap
+          (weight r) (CommAlgCat.of ℤ T) q
+    have hy : GeneralLinear.pointsMulEquiv (r + 1) g =
+        diagGL fun i => TauCeti.torusCharacter (SplitTorus.pointsMulEquiv q)
+          (weight r i ∘ Fin.revPerm) := by
+      calc
+        _ = GeneralLinear.pointsMulEquiv (r + 1)
+            ((CommHopfAlgCat.mapPointsFunctor y).app (CommAlgCat.of ℤ T) q) := by
+          rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
+        _ = _ := GeneralLinear.pointsMulEquiv_mapPointsFunctor_weightTorusCoordinateMap
+          (fun i => weight r i ∘ Fin.revPerm) (CommAlgCat.of ℤ T) q
+    have hp : toConv (f.ofConv.comp c.hom.toAlgHom) = g := by
+      apply (GeneralLinear.pointsMulEquiv (R := ℤ) (A := CommAlgCat.of ℤ T)
+        (r + 1)).injective
+      rw [pointsMulEquiv_comp_ambientGraphCoordinateIso, hx, hy,
+        TauCeti.typeAGraphAutomorphism_diagGL]
+      congr 1
+      funext i
+      exact torusCharacter_weight_rev_reindex r (SplitTorus.pointsMulEquiv q) i
+    have hz := congrArg (fun p => p.ofConv z) hp
+    simp only [f, g, q, AlgHom.id_apply, AlgHom.comp_apply] at hz
+    rw [_root_.CommHopfAlgCat.comp_apply]
+    exact hz
+  calc
+    (ambientGraphCoordinateIso r).hom ≫
+        GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) = y := hxy
+    _ = GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) ≫
+        SplitTorus.relabelCoordinateMap ℤ Fin.revPerm := by
+      change GeneralLinear.weightTorusCoordinateMap (R := ℤ)
+          (fun i => weight r i ∘ Fin.revPerm) = _
+      have h := GeneralLinear.weightTorusCoordinateMap_reindex
+        (R := ℤ) (Fin.revPerm : Equiv.Perm (Fin r)) (weight r)
+      have hrev : (Fin.revPerm : Equiv.Perm (Fin r))⁻¹ = Fin.revPerm :=
+        Fin.revPerm_symm
+      rw [hrev] at h
+      exact h
+
+/-! ## Descent to the standard carrier -/
+
+/-- The defining Hopf ideal of the full-weight standard carrier. -/
+private noncomputable abbrev definingIdeal :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal (rootGenerator r)
+    (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+
+private theorem definingIdeal_comap_ambientGraphCoordinateIso_hom_le :
+    (definingIdeal r).comapOfSurjective (ambientGraphCoordinateIso r).hom.hom
+        (ConcreteCategory.bijective_of_isIso (ambientGraphCoordinateIso r).hom).2 ≤
+      definingIdeal r := by
+  refine kostantToralDefiningIdeal_comapOfSurjective_le_of_comp_eq
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+      (ambientGraphCoordinateIso r).hom _ (graphRootPerm r)
+      (SplitTorus.relabelCoordinateMap ℤ Fin.revPerm)
+      (SplitTorus.relabelCoordinateMap_injective ℤ Fin.revPerm) (fun k => ?_) ?_
+  · rw [ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap,
+      graphRootPerm_apply_apply]
+  · exact ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap r
+
+private theorem definingIdeal_comap_ambientGraphCoordinateIso_inv_le :
+    (definingIdeal r).comapOfSurjective (ambientGraphCoordinateIso r).inv.hom
+        (ConcreteCategory.bijective_of_isIso (ambientGraphCoordinateIso r).inv).2 ≤
+      definingIdeal r := by
+  let c := ambientGraphCoordinateIso r
+  refine kostantToralDefiningIdeal_comapOfSurjective_le_of_comp_eq
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+      c.inv _ (graphRootPerm r) (SplitTorus.relabelCoordinateMap ℤ Fin.revPerm)
+      (SplitTorus.relabelCoordinateMap_injective ℤ Fin.revPerm) (fun k => ?_) ?_
+  · rw [← ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap r k,
+      Iso.inv_hom_id_assoc]
+  · rw [← cancel_epi c.hom]
+    simp only [← Category.assoc, c.hom_inv_id, Category.id_comp]
+    rw [ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap, Category.assoc,
+      SplitTorus.relabelCoordinateMap_comp]
+    have hrev : (Fin.revPerm : Equiv.Perm (Fin r)) * Fin.revPerm = 1 := by
+      ext i
+      simp
+    rw [hrev, SplitTorus.relabelCoordinateMap_one, Category.comp_id]
+
+private theorem definingIdeal_comap_ambientGraphCoordinateIso :
+    (definingIdeal r).comapOfSurjective (ambientGraphCoordinateIso r).hom.hom
+        (ConcreteCategory.bijective_of_isIso (ambientGraphCoordinateIso r).hom).2 =
+      definingIdeal r := by
+  exact HopfIdeal.comapOfSurjective_eq_of_hom_le_of_inv_le
+    (ambientGraphCoordinateIso r) (definingIdeal r)
+    (definingIdeal_comap_ambientGraphCoordinateIso_hom_le r)
+    (definingIdeal_comap_ambientGraphCoordinateIso_inv_le r)
+
+/-- The graph automorphism induced on the standard carrier's quotient coordinate algebra. -/
+private noncomputable def graphCoordinateIso :
+    CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+        (definingIdeal r) ≅
+      CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+        (definingIdeal r) :=
+  CommHopfAlgCat.quotientIsoOfComapEq (ambientGraphCoordinateIso r) (definingIdeal r)
+    (definingIdeal_comap_ambientGraphCoordinateIso r)
+
+private theorem mkQuotient_comp_graphCoordinateIso_hom :
+    CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+          (definingIdeal r) ≫
+        (graphCoordinateIso r).hom =
+      (ambientGraphCoordinateIso r).hom ≫
+        CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
+          (definingIdeal r) := by
+  exact CommHopfAlgCat.mkQuotient_comp_quotientIsoOfComapEq_hom
+    (ambientGraphCoordinateIso r) (definingIdeal r)
+    (definingIdeal_comap_ambientGraphCoordinateIso r)
+
+private theorem graphCoordinateIso_hom_comp_rootMap (k : Fin r ⊕ Fin r) :
+    (graphCoordinateIso r).hom ≫
+        TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap
+          (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+          (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+          (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k =
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap
+        (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) (graphRootPerm r k) := by
+  let J := definingIdeal r
+  let y := TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap
+    (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
+    (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r)
+  have hy : J.toIdeal ≤ RingHom.ker y.hom.toAlgHom.toRingHom :=
+    TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal_toIdeal_le_root_ker
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) (graphRootPerm r k)
+  have hleft := CommHopfAlgCat.liftQuotient_unique J y hy
+    ((graphCoordinateIso r).hom ≫
+      TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap
+        (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) k) (by
+      rw [← Category.assoc, mkQuotient_comp_graphCoordinateIso_hom, Category.assoc,
+        TauCeti.UniversalEnvelopingAlgebra.mkQuotient_comp_kostantRootSubgroupToralCoordinateMap,
+        ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap])
+  have hright := CommHopfAlgCat.liftQuotient_unique J y hy
+    (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToralCoordinateMap
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) (graphRootPerm r k))
+    (TauCeti.UniversalEnvelopingAlgebra.mkQuotient_comp_kostantRootSubgroupToralCoordinateMap
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) (graphRootPerm r k))
+  exact hleft.trans hright.symm
+
+private theorem graphCoordinateIso_hom_comp_torusMap :
+    (graphCoordinateIso r).hom ≫
+        TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToralCoordinateMap
+          (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+          (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+          (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) =
+      TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToralCoordinateMap
+          (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+          (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+          (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) ≫
+        SplitTorus.relabelCoordinateMap ℤ Fin.revPerm := by
+  let J := definingIdeal r
+  let y := GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) ≫
+    SplitTorus.relabelCoordinateMap ℤ Fin.revPerm
+  have hy : J.toIdeal ≤ RingHom.ker y.hom.toAlgHom.toRingHom := by
+    intro z hz
+    have hzero : (GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r)).hom z = 0 := by
+      simpa using RingHom.mem_ker.mp
+        (TauCeti.UniversalEnvelopingAlgebra.kostantToralDefiningIdeal_toIdeal_le_torus_ker
+          (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+          (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+          (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) hz)
+    rw [RingHom.mem_ker]
+    change (GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) ≫
+      SplitTorus.relabelCoordinateMap ℤ Fin.revPerm).hom z = 0
+    rw [_root_.CommHopfAlgCat.hom_comp, BialgHom.comp_apply, hzero, map_zero]
+  have hleft := CommHopfAlgCat.liftQuotient_unique J y hy
+    ((graphCoordinateIso r).hom ≫
+      TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToralCoordinateMap
+        (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+        (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+        (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)) (by
+      rw [← Category.assoc, mkQuotient_comp_graphCoordinateIso_hom, Category.assoc,
+        TauCeti.UniversalEnvelopingAlgebra.mkQuotient_comp_kostantWeightTorusToralCoordinateMap,
+        ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap])
+  have hright := CommHopfAlgCat.liftQuotient_unique J y hy
+    (TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToralCoordinateMap
+      (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+      (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r) ≫
+        SplitTorus.relabelCoordinateMap ℤ Fin.revPerm) (by
+      rw [← Category.assoc,
+        TauCeti.UniversalEnvelopingAlgebra.mkQuotient_comp_kostantWeightTorusToralCoordinateMap])
+  exact hleft.trans hright.symm
+
+/-- **The pinned graph automorphism of the full-weight type-`A_r` standard carrier.** -/
+noncomputable def graphAutomorphism : Aut (groupScheme r) :=
+  (AlgebraicGeometry.hopfSpec (CommRingCat.of ℤ)).mapIso (graphCoordinateIso r).op
+
+/-- The graph automorphism reverses the Bourbaki numbering of every positive and negative simple
+root subgroup, without changing its additive parameter. -/
+@[simp]
+theorem rootSubgroup_comp_graphAutomorphism_hom (k : Fin r ⊕ Fin r) :
+    rootSubgroup r k ≫ (graphAutomorphism r).hom =
+      rootSubgroup r (graphRootPerm r k) := by
+  rw [rootSubgroup_def, kostantRootSubgroupToToral_def, graphAutomorphism,
+    Functor.mapIso_hom, Iso.op_hom, Category.assoc,
+    ← Functor.map_comp, ← op_comp, graphCoordinateIso_hom_comp_rootMap]
+  rw [rootSubgroup_def]
+  exact (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral_def
+    (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
+    (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
+    (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
+    (graphRootPerm r k)).symm
+
+/-- The graph automorphism normalizes the split torus and reverses its Bourbaki-numbered
+coordinates. -/
+@[simp]
+theorem weightTorus_comp_graphAutomorphism_hom :
+    weightTorus r ≫ (graphAutomorphism r).hom =
+      SplitTorus.relabel ℤ Fin.revPerm ≫ weightTorus r := by
+  rw [weightTorus_def, kostantWeightTorusToToral_def, graphAutomorphism,
+    Functor.mapIso_hom, Iso.op_hom, Category.assoc,
+    ← Functor.map_comp, ← op_comp, graphCoordinateIso_hom_comp_torusMap, op_comp,
+    Functor.map_comp, SplitTorus.relabel_def]
+  simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
+
+end TauCeti.SlStd

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
@@ -5,10 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Yoneda
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.GraphAutomorphism
 public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.Basic
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Rigidity
-public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.GraphAutomorphism
 
 /-!
 # The pinned graph automorphism of the type-A standard carrier
@@ -19,17 +18,19 @@ type-`A_r` Chevalley carrier. This file descends it to an automorphism of
 changing root-subgroup parameters, and on the split torus it reverses the coordinates.
 
 The proof first recovers the ambient coordinate Hopf-algebra automorphism from its natural action
-on matrix points. The positive and negative transvection formulas and the diagonal formula then
-show that it preserves every generator of the carrier's defining ideal. Passing to the quotient
-gives the desired group-scheme automorphism.
+on matrix points. The root subgroups are permuted among themselves and the weight torus is carried
+to itself up to relabelling, so the largest Hopf ideal killed by all those coordinate maps is
+invariant. The automorphism therefore descends to the quotient.
 
 ## Main declarations
 
 * `TauCeti.SlStd.graphRootPerm`: reversal on the positive and negative simple-root indices.
 * `TauCeti.SlStd.graphAutomorphism`: the pinned graph automorphism of the standard carrier.
-* `TauCeti.SlStd.schemePointsMulEquiv_comp_graphAutomorphism`: its signed
+* `TauCeti.SlStd.graphAutomorphismPoints`: its induced automorphism on algebra-valued matrix
+  points.
+* `TauCeti.SlStd.generalLinearSchemePointsMulEquiv_graphAutomorphism_comp_carrierι`: its signed
   reverse-inverse-transpose formula on arbitrary carrier points.
-* `TauCeti.SlStd.graphAutomorphism_hom_comp_hom`: its involutivity.
+* `TauCeti.SlStd.graphAutomorphism_hom_comp_self`: its involutivity.
 * `TauCeti.SlStd.rootSubgroup_comp_graphAutomorphism_hom`: its action on root subgroups.
 * `TauCeti.SlStd.weightTorus_comp_graphAutomorphism_hom`: its action on the split torus.
 
@@ -66,169 +67,24 @@ def graphRootPerm : Equiv.Perm (Fin r ⊕ Fin r) :=
 @[simp] theorem graphRootPerm_inr (i : Fin r) : graphRootPerm r (.inr i) = .inr i.rev := by
   simp [graphRootPerm]
 
-@[simp] theorem graphRootPerm_apply_apply (k : Fin r ⊕ Fin r) :
+@[simp] theorem graphRootPerm_graphRootPerm (k : Fin r ⊕ Fin r) :
     graphRootPerm r (graphRootPerm r k) = k := by
   cases k <;> simp [graphRootPerm]
 
 private theorem weight_rev_rev (k : Fin (r + 1)) (i : Fin r) :
     weight r k.rev i.rev = -weight r k i := by
-  rw [weight_apply, weight_apply]
+  rw [weight_def, weight_def]
   simp only [← Fin.rev_succ, ← Fin.rev_castSucc, Fin.rev_injective.eq_iff]
   ring
-
-private theorem torusCharacter_weight_rev {A : Type*} [CommRing A]
-    (s : Fin r → Aˣ) (k : Fin (r + 1)) :
-    (TauCeti.torusCharacter s (weight r k.rev))⁻¹ =
-      TauCeti.torusCharacter (fun i => s i.rev) (weight r k) := by
-  rw [← TauCeti.torusCharacter_neg]
-  calc
-    TauCeti.torusCharacter s (-weight r k.rev) =
-        TauCeti.torusCharacter s (weight r k ∘ Fin.revPerm) := by
-      congr 1
-      funext i
-      simpa using (weight_rev_rev r k.rev i).symm
-    _ = TauCeti.torusCharacter (fun i => s i.rev) (weight r k) := by
-      have h := (TauCeti.torusCharacter_mulEquivArrowCongr
-        (Fin.revPerm : Equiv.Perm (Fin r)) s (weight r k)).symm
-      -- The arrow-congruence API packages reindexing as a bundled `MulEquiv`; expose its
-      -- definitionally equal function action to compare it with `fun i => s i.rev`.
-      change TauCeti.torusCharacter s (weight r k ∘ Fin.revPerm) =
-        TauCeti.torusCharacter
-          ((MulEquiv.arrowCongr Fin.revPerm (MulEquiv.refl Aˣ)) s) (weight r k) at h
-      change TauCeti.torusCharacter s (weight r k ∘ Fin.revPerm) =
-        TauCeti.torusCharacter
-          ((MulEquiv.arrowCongr Fin.revPerm (MulEquiv.refl Aˣ)) s) (weight r k)
-      exact h
 
 private theorem torusCharacter_weight_rev_reindex {A : Type*} [CommRing A]
     (s : Fin r → Aˣ) (k : Fin (r + 1)) :
     (TauCeti.torusCharacter s (weight r k.rev))⁻¹ =
       TauCeti.torusCharacter s (weight r k ∘ Fin.revPerm) := by
-  rw [torusCharacter_weight_rev]
-  exact TauCeti.torusCharacter_mulEquivArrowCongr
-    (Fin.revPerm : Equiv.Perm (Fin r)) s (weight r k)
-
-/-! ## The ambient coordinate automorphism -/
-
-/-- Signed reverse-inverse-transpose transported to general-linear coordinate-algebra points. -/
-private noncomputable def generalLinearPointsGraphMulEquiv (A : CommAlgCat.{0} ℤ) :
-    HopfAlgebra.points
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A ≃*
-      HopfAlgebra.points
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A :=
-  ((GeneralLinear.pointsMulEquiv (R := ℤ) (A := A) (r + 1)).trans
-    (TauCeti.typeAGraphAutomorphism r A)).trans
-      (GeneralLinear.pointsMulEquiv (R := ℤ) (A := A) (r + 1)).symm
-
-private theorem pointsMulEquiv_generalLinearPointsGraphMulEquiv
-    (A : CommAlgCat.{0} ℤ)
-    (f : HopfAlgebra.points
-      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A) :
-    GeneralLinear.pointsMulEquiv (r + 1) (generalLinearPointsGraphMulEquiv r A f) =
-      TauCeti.typeAGraphAutomorphism r A (GeneralLinear.pointsMulEquiv (r + 1) f) := by
-  rw [generalLinearPointsGraphMulEquiv, MulEquiv.trans_apply, MulEquiv.trans_apply]
-  exact (GeneralLinear.pointsMulEquiv (R := ℤ) (A := A) (r + 1)).apply_symm_apply _
-
-/-- The pointwise graph automorphism in the object presentation used by the points functor. -/
-private noncomputable def generalLinearPointsGraphIsoApp (A : CommAlgCat.{0} ℤ) :
-    (HopfAlgebra.pointsFunctor
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))).obj A ≅
-      (HopfAlgebra.pointsFunctor
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))).obj A :=
-  eqToIso (HopfAlgebra.pointsFunctor_obj
-      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A) ≪≫
-    (generalLinearPointsGraphMulEquiv r A).toGrpIso ≪≫
-      eqToIso (HopfAlgebra.pointsFunctor_obj
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A).symm
-
-/-- The natural automorphism of the general-linear functor of points induced by the matrix graph
-automorphism. -/
-private noncomputable def generalLinearPointsGraphNatIso :
-    HopfAlgebra.pointsFunctor
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) ≅
-      HopfAlgebra.pointsFunctor
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) :=
-  NatIso.ofComponents
-    (fun A ↦ generalLinearPointsGraphIsoApp r A)
-    (fun {A B} φ ↦ by
-      apply (cancel_epi (eqToHom (HopfAlgebra.pointsFunctor_obj
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A).symm)).1
-      apply (cancel_mono (eqToHom (HopfAlgebra.pointsFunctor_obj
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) B))).1
-      rw [generalLinearPointsGraphIsoApp, generalLinearPointsGraphIsoApp]
-      simp only [Iso.trans_hom, eqToIso.hom, Category.assoc, eqToHom_trans_assoc,
-        eqToHom_refl, Category.id_comp, eqToHom_trans, Category.comp_id]
-      simp only [← Category.assoc]
-      rw [HopfAlgebra.pointsFunctor_map_eqToHom]
-      slice_rhs 2 3 => rw [HopfAlgebra.pointsFunctor_map_eqToHom]
-      slice_rhs 3 4 => simp
-      simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp,
-        Category.comp_id]
-      apply GrpCat.hom_ext
-      apply MonoidHom.ext
-      intro f
-      rw [GrpCat.comp_apply, GrpCat.comp_apply]
-      -- The points functor presents its object values by an equality; after cancelling those
-      -- transports, its action is definitionally `HopfAlgebra.mapPoints`.
-      change generalLinearPointsGraphMulEquiv r B (HopfAlgebra.mapPoints φ f) =
-        HopfAlgebra.mapPoints φ (generalLinearPointsGraphMulEquiv r A f)
-      apply (GeneralLinear.pointsMulEquiv (R := ℤ) (A := B) (r + 1)).injective
-      simp only [HopfAlgebra.mapPoints]
-      rw [pointsMulEquiv_generalLinearPointsGraphMulEquiv]
-      -- The general-linear points equivalence reads `AlgHom.mapValue` entrywise; this
-      -- definitional presentation is the input expected by its naturality theorem.
-      change TauCeti.typeAGraphAutomorphism r B
-          (GeneralLinear.pointsMulEquiv (r + 1) (AlgHom.mapValue φ.hom f)) =
-        GeneralLinear.pointsMulEquiv (r + 1)
-          (AlgHom.mapValue φ.hom (generalLinearPointsGraphMulEquiv r A f))
-      rw [GeneralLinear.pointsMulEquiv_mapValue,
-        GeneralLinear.pointsMulEquiv_mapValue,
-        pointsMulEquiv_generalLinearPointsGraphMulEquiv,
-        TauCeti.map_typeAGraphAutomorphism])
-
-/-- The coordinate Hopf-algebra automorphism corresponding to signed reverse-inverse-transpose
-on general-linear points. -/
-private noncomputable def ambientGraphCoordinateIso :
-    GeneralLinear.coordinateHopfAlgebra ℤ (r + 1) ≅
-      GeneralLinear.coordinateHopfAlgebra ℤ (r + 1) :=
-  ((CommHopfAlgCat.pointsFunctor (R := ℤ)).preimageIso
-    (generalLinearPointsGraphNatIso r)).unop
-
-private theorem pointsMulEquiv_mapPointsFunctor_ambientGraphCoordinateIso
-    (A : CommAlgCat.{0} ℤ)
-    (f : HopfAlgebra.points
-      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A) :
-    GeneralLinear.pointsMulEquiv (r + 1)
-        ((CommHopfAlgCat.mapPointsFunctor (ambientGraphCoordinateIso r).hom).app A f) =
-      TauCeti.typeAGraphAutomorphism r A (GeneralLinear.pointsMulEquiv (r + 1) f) := by
-  have hmap := (CommHopfAlgCat.pointsFunctor (R := ℤ)).map_preimage
-    (generalLinearPointsGraphNatIso r).hom
-  have happ := congrArg (fun α => α.app A f) hmap
-  have hcoordinate : (ambientGraphCoordinateIso r).hom.op =
-      (CommHopfAlgCat.pointsFunctor (R := ℤ)).preimage
-        (generalLinearPointsGraphNatIso r).hom := rfl
-  -- `ambientGraphCoordinateIso` is obtained by fully faithful preimage, so its mapped points
-  -- functor is definitionally the expression exposed by `hmap`.
-  change GeneralLinear.pointsMulEquiv (r + 1)
-      (((CommHopfAlgCat.pointsFunctor (R := ℤ)).map
-        (ambientGraphCoordinateIso r).hom.op).app A f) = _
-  rw [hcoordinate, happ]
-  -- The component of `generalLinearPointsGraphNatIso` retains the object-presentation
-  -- transports; cancelling them leaves the underlying pointwise equivalence.
-  change GeneralLinear.pointsMulEquiv (r + 1) (generalLinearPointsGraphMulEquiv r A f) = _
-  exact pointsMulEquiv_generalLinearPointsGraphMulEquiv r A f
-
-private theorem pointsMulEquiv_comp_ambientGraphCoordinateIso
-    (A : CommAlgCat.{0} ℤ)
-    (f : HopfAlgebra.points
-      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) A) :
-    GeneralLinear.pointsMulEquiv (r + 1)
-        (toConv (f.ofConv.comp ((ambientGraphCoordinateIso r).hom.hom :
-          GeneralLinear.coordinateHopfAlgebra ℤ (r + 1) →ₐ[ℤ]
-            GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)))) =
-      TauCeti.typeAGraphAutomorphism r A (GeneralLinear.pointsMulEquiv (r + 1) f) := by
-  rw [← CommHopfAlgCat.mapPointsFunctor_app_apply]
-  exact pointsMulEquiv_mapPointsFunctor_ambientGraphCoordinateIso r A f
+  rw [← TauCeti.torusCharacter_neg]
+  congr 1
+  funext i
+  simpa using (weight_rev_rev r k.rev i).symm
 
 private theorem typeAGraphAutomorphism_kostantRootSubgroupMatrix
     {A : Type*} [CommRing A] (k : Fin r ⊕ Fin r)
@@ -280,9 +136,19 @@ private theorem hom_eq_of_universalPoint_eq
   simp only [AlgHom.id_apply, AlgHom.comp_apply] at hz
   exact hz
 
+/-- Precomposing the universal point agrees with composing its represented coordinate map. -/
+private theorem universalPoint_comp
+    {H K : _root_.CommHopfAlgCat.{0} ℤ} (c : H ⟶ H) (x : H ⟶ K) :
+    toConv ((AlgHom.id ℤ K).comp (c ≫ x).hom.toAlgHom) =
+      toConv ((toConv ((AlgHom.id ℤ K).comp x.hom.toAlgHom)).ofConv.comp
+        c.hom.toAlgHom) := by
+  apply WithConv.ofConv_injective
+  ext z
+  rfl
+
 private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
     (k : Fin r ⊕ Fin r) :
-    (ambientGraphCoordinateIso r).hom ≫
+    (GeneralLinear.typeAGraphCoordinateIso r).hom ≫
         TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator r)
           (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
           (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
@@ -291,7 +157,7 @@ private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
         (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
         (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
         (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r) := by
-  let c := (ambientGraphCoordinateIso r).hom
+  let c := (GeneralLinear.typeAGraphCoordinateIso r).hom
   let x := TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
     (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
@@ -336,22 +202,21 @@ private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
     apply (GeneralLinear.pointsMulEquiv
       (R := ℤ) (A := CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))
         (r + 1)).injective
-    rw [pointsMulEquiv_comp_ambientGraphCoordinateIso,
+    rw [GeneralLinear.pointsMulEquiv_comp_typeAGraphCoordinateIso,
       GeneralLinear.pointsMulEquiv_apply, GeneralLinear.pointsMulEquiv_apply]
     have hleft := congrArg (TauCeti.typeAGraphAutomorphism r
       (CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))) hx
     exact hleft.trans ((typeAGraphAutomorphism_kostantRootSubgroupMatrix
       (A := CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) r k q).trans hy.symm)
-  convert hp using 1
-  · ext z
-    rfl
+  rw [universalPoint_comp]
+  exact hp
 
 private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
-    (ambientGraphCoordinateIso r).hom ≫
+    (GeneralLinear.typeAGraphCoordinateIso r).hom ≫
         GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) =
       GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) ≫
         SplitTorus.relabelCoordinateMap ℤ Fin.revPerm := by
-  let c := (ambientGraphCoordinateIso r).hom
+  let c := (GeneralLinear.typeAGraphCoordinateIso r).hom
   let x := GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r)
   let y := GeneralLinear.weightTorusCoordinateMap (R := ℤ)
     (fun i => weight r i ∘ Fin.revPerm)
@@ -387,16 +252,15 @@ private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
     have hp : toConv (f.ofConv.comp c.hom.toAlgHom) = g := by
       apply (GeneralLinear.pointsMulEquiv (R := ℤ) (A := CommAlgCat.of ℤ T)
         (r + 1)).injective
-      rw [pointsMulEquiv_comp_ambientGraphCoordinateIso, hx, hy,
+      rw [GeneralLinear.pointsMulEquiv_comp_typeAGraphCoordinateIso, hx, hy,
         TauCeti.typeAGraphAutomorphism_diagGL]
       congr 1
       funext i
       exact torusCharacter_weight_rev_reindex r (SplitTorus.pointsMulEquiv q) i
-    convert hp using 1
-    · ext z
-      rfl
+    rw [universalPoint_comp]
+    exact hp
   calc
-    (ambientGraphCoordinateIso r).hom ≫
+    (GeneralLinear.typeAGraphCoordinateIso r).hom ≫
         GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) = y := hxy
     _ = GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) ≫
         SplitTorus.relabelCoordinateMap ℤ Fin.revPerm := by
@@ -425,25 +289,25 @@ private noncomputable abbrev carrierCoordinateHopfAlgebra :=
   CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) (definingIdeal r)
 
 private theorem definingIdeal_comap_ambientGraphCoordinateIso_hom_le :
-    (definingIdeal r).comapOfSurjective (ambientGraphCoordinateIso r).hom.hom
-        (ConcreteCategory.bijective_of_isIso (ambientGraphCoordinateIso r).hom).2 ≤
+    (definingIdeal r).comapOfSurjective (GeneralLinear.typeAGraphCoordinateIso r).hom.hom
+        (ConcreteCategory.bijective_of_isIso (GeneralLinear.typeAGraphCoordinateIso r).hom).2 ≤
       definingIdeal r := by
   refine kostantToralDefiningIdeal_comapOfSurjective_le_of_comp_eq
       (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
       (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
       (isNilpotent_rep_rootGenerator r) (latticeBasis r) (weight r)
-      (ambientGraphCoordinateIso r).hom _ (graphRootPerm r)
+      (GeneralLinear.typeAGraphCoordinateIso r).hom _ (graphRootPerm r)
       (SplitTorus.relabelCoordinateMap ℤ Fin.revPerm)
       (SplitTorus.relabelCoordinateMap_injective ℤ Fin.revPerm) (fun k => ?_) ?_
   · rw [ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap,
-      graphRootPerm_apply_apply]
+      graphRootPerm_graphRootPerm]
   · exact ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap r
 
 private theorem definingIdeal_comap_ambientGraphCoordinateIso_inv_le :
-    (definingIdeal r).comapOfSurjective (ambientGraphCoordinateIso r).inv.hom
-        (ConcreteCategory.bijective_of_isIso (ambientGraphCoordinateIso r).inv).2 ≤
+    (definingIdeal r).comapOfSurjective (GeneralLinear.typeAGraphCoordinateIso r).inv.hom
+        (ConcreteCategory.bijective_of_isIso (GeneralLinear.typeAGraphCoordinateIso r).inv).2 ≤
       definingIdeal r := by
-  let c := ambientGraphCoordinateIso r
+  let c := GeneralLinear.typeAGraphCoordinateIso r
   refine kostantToralDefiningIdeal_comapOfSurjective_le_of_comp_eq
       (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
       (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv)
@@ -462,11 +326,11 @@ private theorem definingIdeal_comap_ambientGraphCoordinateIso_inv_le :
     rw [hrev, SplitTorus.relabelCoordinateMap_one, Category.comp_id]
 
 private theorem definingIdeal_comap_ambientGraphCoordinateIso :
-    (definingIdeal r).comapOfSurjective (ambientGraphCoordinateIso r).hom.hom
-        (ConcreteCategory.bijective_of_isIso (ambientGraphCoordinateIso r).hom).2 =
+    (definingIdeal r).comapOfSurjective (GeneralLinear.typeAGraphCoordinateIso r).hom.hom
+        (ConcreteCategory.bijective_of_isIso (GeneralLinear.typeAGraphCoordinateIso r).hom).2 =
       definingIdeal r := by
   exact HopfIdeal.comapOfSurjective_eq_of_hom_le_of_inv_le
-    (ambientGraphCoordinateIso r) (definingIdeal r)
+    (GeneralLinear.typeAGraphCoordinateIso r) (definingIdeal r)
     (definingIdeal_comap_ambientGraphCoordinateIso_hom_le r)
     (definingIdeal_comap_ambientGraphCoordinateIso_inv_le r)
 
@@ -476,18 +340,18 @@ private noncomputable def graphCoordinateIso :
         (definingIdeal r) ≅
       CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
         (definingIdeal r) :=
-  CommHopfAlgCat.quotientIsoOfComapEq (ambientGraphCoordinateIso r) (definingIdeal r)
+  CommHopfAlgCat.quotientIsoOfComapEq (GeneralLinear.typeAGraphCoordinateIso r) (definingIdeal r)
     (definingIdeal_comap_ambientGraphCoordinateIso r)
 
 private theorem mkQuotient_comp_graphCoordinateIso_hom :
     CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
           (definingIdeal r) ≫
         (graphCoordinateIso r).hom =
-      (ambientGraphCoordinateIso r).hom ≫
+      (GeneralLinear.typeAGraphCoordinateIso r).hom ≫
         CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
           (definingIdeal r) := by
   exact CommHopfAlgCat.mkQuotient_comp_quotientIsoOfComapEq_hom
-    (ambientGraphCoordinateIso r) (definingIdeal r)
+    (GeneralLinear.typeAGraphCoordinateIso r) (definingIdeal r)
     (definingIdeal_comap_ambientGraphCoordinateIso r)
 
 private theorem graphCoordinateIso_hom_comp_rootMap (k : Fin r ⊕ Fin r) :
@@ -639,10 +503,11 @@ private theorem groupSchemePointMulEquiv_comp_carrierι
 
 /-- On every algebra-valued carrier point, the graph automorphism is signed
 reverse-inverse-transpose after the canonical inclusion into `GL_{r+1}`. -/
-theorem schemePointsMulEquiv_comp_graphAutomorphism {A : Type} [CommRing A]
+theorem generalLinearSchemePointsMulEquiv_graphAutomorphism_comp_carrierι
+    {A : Type} [CommRing A]
     (p : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of ℤ)) ⟶ (groupScheme r).X) :
     GeneralLinear.schemePointsMulEquiv (r + 1) A
-        ((p ≫ (graphAutomorphism r).hom.hom.hom) ≫ (carrierι r).hom.hom) =
+        (p ≫ (graphAutomorphism r).hom.hom.hom ≫ (carrierι r).hom.hom) =
       TauCeti.typeAGraphAutomorphism r A
         (GeneralLinear.schemePointsMulEquiv (r + 1) A (p ≫ (carrierι r).hom.hom)) := by
   obtain ⟨q, rfl⟩ := (groupSchemePointMulEquiv r A).surjective p
@@ -651,7 +516,7 @@ theorem schemePointsMulEquiv_comp_graphAutomorphism {A : Type} [CommRing A]
   have hgraphCarrier := congrArg (fun f => f ≫ (carrierι r).hom.hom) hgraph
   have hinclusionGraph := groupSchemePointMulEquiv_comp_carrierι (A := A) r
     ((CommHopfAlgCat.mapPointsFunctor (graphCoordinateIso r).hom).app (CommAlgCat.of ℤ A) q)
-  rw [hgraphCarrier, hinclusionGraph,
+  rw [← Category.assoc, hgraphCarrier, hinclusionGraph,
     CommHopfAlgCat.mapPointsFunctor_app_apply, CommHopfAlgCat.mapPointsFunctor_app_apply,
     GeneralLinear.schemePointsMulEquiv_groupSchemePointMulEquiv,
     hinclusion, CommHopfAlgCat.mapPointsFunctor_app_apply,
@@ -666,18 +531,109 @@ theorem schemePointsMulEquiv_comp_graphAutomorphism {A : Type} [CommRing A]
       toConv ((q.ofConv.comp (graphCoordinateIso r).hom.hom.toAlgHom).comp
         (CommHopfAlgCat.mkQuotient (GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
           (definingIdeal r)).hom.toAlgHom) =
-        toConv (qambient.ofConv.comp (ambientGraphCoordinateIso r).hom.hom.toAlgHom) := by
+        toConv (qambient.ofConv.comp
+          (GeneralLinear.typeAGraphCoordinateIso r).hom.hom.toAlgHom) := by
     apply WithConv.ofConv_injective
     ext z
     have hz := congrArg (fun f => q.ofConv (f.hom z))
       (mkQuotient_comp_graphCoordinateIso_hom r)
     exact hz
   rw [hpoint]
-  convert pointsMulEquiv_comp_ambientGraphCoordinateIso r (CommAlgCat.of ℤ A) qambient using 1
+  exact GeneralLinear.pointsMulEquiv_comp_typeAGraphCoordinateIso r
+    (CommAlgCat.of ℤ A) qambient
+
+/-- Signed reverse-inverse-transpose preserves the matrix points of the standard carrier. -/
+theorem typeAGraphAutomorphism_mem_points {A : Type} [CommRing A]
+    (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) (hg : g ∈ points r A) :
+    TauCeti.typeAGraphAutomorphism r A g ∈ points r A := by
+  rw [mem_points_iff] at hg ⊢
+  intro x hx
+  let q : HopfAlgebra.points
+      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1)) (CommAlgCat.of ℤ A) :=
+    (GeneralLinear.pointsMulEquiv (R := ℤ) (A := CommAlgCat.of ℤ A) (r + 1)).symm g
+  have hpoint :
+      (GeneralLinear.pointsMulEquiv (R := ℤ) (A := CommAlgCat.of ℤ A) (r + 1)).symm
+          (TauCeti.typeAGraphAutomorphism r A g) =
+        toConv (q.ofConv.comp
+          (GeneralLinear.typeAGraphCoordinateIso r).hom.hom.toAlgHom) := by
+    apply (GeneralLinear.pointsMulEquiv
+      (R := ℤ) (A := CommAlgCat.of ℤ A) (r + 1)).injective
+    rw [MulEquiv.apply_symm_apply,
+      GeneralLinear.pointsMulEquiv_comp_typeAGraphCoordinateIso]
+    exact congrArg (TauCeti.typeAGraphAutomorphism r A)
+      ((GeneralLinear.pointsMulEquiv
+        (R := ℤ) (A := CommAlgCat.of ℤ A) (r + 1)).apply_symm_apply g).symm
+  rw [hpoint]
+  change q.ofConv ((GeneralLinear.typeAGraphCoordinateIso r).hom.hom x) = 0
+  apply hg
+  apply HopfIdeal.mem_comapOfSurjective.mp
+  rw [definingIdeal_comap_ambientGraphCoordinateIso]
+  exact hx
+
+/-- **The pinned graph automorphism on algebra-valued points of the standard carrier.** -/
+noncomputable def graphAutomorphismPoints (A : Type) [CommRing A] :
+    points r A ≃* points r A where
+  toFun g := ⟨TauCeti.typeAGraphAutomorphism r A
+      (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A),
+    typeAGraphAutomorphism_mem_points (A := A) r
+      (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) g.property⟩
+  invFun g := ⟨TauCeti.typeAGraphAutomorphism r A
+      (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A),
+    typeAGraphAutomorphism_mem_points (A := A) r
+      (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) g.property⟩
+  left_inv g := Subtype.ext (TauCeti.typeAGraphAutomorphism_typeAGraphAutomorphism r
+    (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A))
+  right_inv g := Subtype.ext (TauCeti.typeAGraphAutomorphism_typeAGraphAutomorphism r
+    (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A))
+  map_mul' g h := Subtype.ext (map_mul (TauCeti.typeAGraphAutomorphism r A)
+    (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A)
+    (h : Matrix.GeneralLinearGroup (Fin (r + 1)) A))
+
+/-- The point-group graph automorphism is signed reverse-inverse-transpose on matrices. -/
+@[simp]
+theorem coe_graphAutomorphismPoints {A : Type} [CommRing A] (g : points r A) :
+    (graphAutomorphismPoints r A g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) =
+      TauCeti.typeAGraphAutomorphism r A g := by
+  unfold graphAutomorphismPoints
+  rfl
+
+/-- The point-group graph automorphism reverses the numbered root subgroups. -/
+@[simp]
+theorem graphAutomorphismPoints_rootSubgroupPoints {A : Type} [CommRing A]
+    (i : Fin r ⊕ Fin r) (u : Multiplicative A) :
+    graphAutomorphismPoints r A (rootSubgroupPoints r i A u) =
+      rootSubgroupPoints r (graphRootPerm r i) A u := by
+  apply Subtype.ext
+  rw [coe_graphAutomorphismPoints, coe_rootSubgroupPoints, coe_rootSubgroupPoints]
+  exact typeAGraphAutomorphism_kostantRootSubgroupMatrix r i
+    ((AdditiveGroup.gaPointsMulEquiv (R := ℤ) (A := A)).symm u)
+
+/-- The point-group graph automorphism reverses the coordinates of the split weight torus. -/
+@[simp]
+theorem graphAutomorphismPoints_weightTorusPoints {A : Type} [CommRing A]
+    (s : Fin r → Aˣ) :
+    graphAutomorphismPoints r A (weightTorusPoints r A s) =
+      weightTorusPoints r A (fun i => s i.rev) := by
+  apply Subtype.ext
+  rw [coe_graphAutomorphismPoints, coe_weightTorusPoints, coe_weightTorusPoints,
+    TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_apply,
+    TauCeti.UniversalEnvelopingAlgebra.kostantTorusMatrix_apply,
+    TauCeti.typeAGraphAutomorphism_diagGL]
+  congr 1
+  funext i
+  rw [torusCharacter_weight_rev_reindex]
+  have hs : (MulEquiv.arrowCongr Fin.revPerm (MulEquiv.refl Aˣ)) s =
+      (fun j => s j.rev) := by
+    funext j
+    simp only [MulEquiv.arrowCongr_apply, MulEquiv.refl_apply, Fin.revPerm_symm,
+      Fin.revPerm_apply]
+  rw [← hs]
+  exact (TauCeti.torusCharacter_mulEquivArrowCongr
+    (Fin.revPerm : Equiv.Perm (Fin r)) s (weight r i)).symm
 
 /-- The graph automorphism reverses the Bourbaki numbering of every positive and negative simple
 root subgroup, without changing its additive parameter. -/
-@[simp]
+@[reassoc (attr := simp)]
 theorem rootSubgroup_comp_graphAutomorphism_hom (k : Fin r ⊕ Fin r) :
     rootSubgroup r k ≫ (graphAutomorphism r).hom =
       rootSubgroup r (graphRootPerm r k) := by
@@ -693,7 +649,7 @@ theorem rootSubgroup_comp_graphAutomorphism_hom (k : Fin r ⊕ Fin r) :
 
 /-- The graph automorphism normalizes the split torus and reverses its Bourbaki-numbered
 coordinates. -/
-@[simp]
+@[reassoc (attr := simp)]
 theorem weightTorus_comp_graphAutomorphism_hom :
     weightTorus r ≫ (graphAutomorphism r).hom =
       SplitTorus.relabel ℤ Fin.revPerm ≫ weightTorus r := by
@@ -704,8 +660,8 @@ theorem weightTorus_comp_graphAutomorphism_hom :
   simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
 
 /-- Applying the graph automorphism twice is the identity on the standard carrier. -/
-@[simp]
-theorem graphAutomorphism_hom_comp_hom :
+@[reassoc (attr := simp)]
+theorem graphAutomorphism_hom_comp_self :
     (graphAutomorphism r).hom ≫ (graphAutomorphism r).hom = 𝟙 (groupScheme r) := by
   apply TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme_hom_ext
     (rootGenerator r) (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
@@ -721,7 +677,7 @@ theorem graphAutomorphism_hom_comp_hom :
             (graphAutomorphism r).hom := (Category.assoc _ _ _).symm
       _ = rootSubgroup r (graphRootPerm r k) ≫ (graphAutomorphism r).hom := by rw [h₁]
       _ = rootSubgroup r (graphRootPerm r (graphRootPerm r k)) := h₂
-      _ = rootSubgroup r k := by rw [graphRootPerm_apply_apply]
+      _ = rootSubgroup r k := by rw [graphRootPerm_graphRootPerm]
       _ = rootSubgroup r k ≫ 𝟙 (groupScheme r) := (Category.comp_id _).symm
   · rw [← weightTorus_def]
     have htorus := weightTorus_comp_graphAutomorphism_hom r
@@ -746,5 +702,18 @@ theorem graphAutomorphism_hom_comp_hom :
           simp
         rw [hrev, SplitTorus.relabel_one, Category.id_comp]
       _ = weightTorus r ≫ 𝟙 (groupScheme r) := (Category.comp_id _).symm
+
+/-- The inverse leg of the graph automorphism is its forward leg. -/
+@[simp]
+theorem graphAutomorphism_inv : (graphAutomorphism r).inv = (graphAutomorphism r).hom := by
+  calc
+    (graphAutomorphism r).inv = 𝟙 (groupScheme r) ≫ (graphAutomorphism r).inv :=
+      (Category.id_comp _).symm
+    _ = ((graphAutomorphism r).hom ≫ (graphAutomorphism r).hom) ≫
+        (graphAutomorphism r).inv := by rw [graphAutomorphism_hom_comp_self]
+    _ = (graphAutomorphism r).hom ≫
+        ((graphAutomorphism r).hom ≫ (graphAutomorphism r).inv) := Category.assoc _ _ _
+    _ = (graphAutomorphism r).hom := by
+      rw [(graphAutomorphism r).hom_inv_id, Category.comp_id]
 
 end TauCeti.SlStd

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/GraphAutomorphism.lean
@@ -146,6 +146,24 @@ private theorem universalPoint_comp
   ext z
   rfl
 
+/-- Recover an ambient coordinate-map identity from its matrix equality on the universal point. -/
+private theorem typeAGraphCoordinateIso_hom_comp_eq_of_universalPoint
+    {K : _root_.CommHopfAlgCat.{0} ℤ}
+    (x y : GeneralLinear.coordinateHopfAlgebra ℤ (r + 1) ⟶ K)
+    (h : TauCeti.typeAGraphAutomorphism r (CommAlgCat.of ℤ K)
+        (GeneralLinear.pointToGeneralLinear (r + 1)
+          (toConv ((AlgHom.id ℤ K).comp x.hom.toAlgHom))) =
+      GeneralLinear.pointToGeneralLinear (r + 1)
+        (toConv ((AlgHom.id ℤ K).comp y.hom.toAlgHom))) :
+    (GeneralLinear.typeAGraphCoordinateIso r).hom ≫ x = y := by
+  apply hom_eq_of_universalPoint_eq
+  rw [universalPoint_comp]
+  apply (GeneralLinear.pointsMulEquiv
+    (R := ℤ) (A := CommAlgCat.of ℤ K) (r + 1)).injective
+  rw [GeneralLinear.pointsMulEquiv_comp_typeAGraphCoordinateIso,
+    GeneralLinear.pointsMulEquiv_apply, GeneralLinear.pointsMulEquiv_apply]
+  exact h
+
 private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
     (k : Fin r ⊕ Fin r) :
     (GeneralLinear.typeAGraphCoordinateIso r).hom ≫
@@ -157,7 +175,6 @@ private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
         (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
         (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
         (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r) := by
-  let c := (GeneralLinear.typeAGraphCoordinateIso r).hom
   let x := TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator r)
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
     (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
@@ -166,19 +183,12 @@ private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
     (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
     (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
     (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r)
-  apply hom_eq_of_universalPoint_eq
+  apply typeAGraphCoordinateIso_hom_comp_eq_of_universalPoint
   let q : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ]
       AdditiveGroup.coordinateHopfAlgebra ℤ) :=
     toConv (AlgHom.id ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))
-  let f : HopfAlgebra.points
-      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
-        (CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) :=
-    toConv (q.ofConv.comp x.hom.toAlgHom)
-  let g : HopfAlgebra.points
-      (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
-        (CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) :=
-    toConv (q.ofConv.comp y.hom.toAlgHom)
-  have hx : GeneralLinear.pointToGeneralLinear (r + 1) f =
+  have hx : GeneralLinear.pointToGeneralLinear (r + 1)
+      (toConv (q.ofConv.comp x.hom.toAlgHom)) =
       TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
         (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
         (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
@@ -188,7 +198,8 @@ private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
       (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) k
       (isNilpotent_rep_rootGenerator r k) (latticeBasis r)
       (A := AdditiveGroup.coordinateHopfAlgebra ℤ) q
-  have hy : GeneralLinear.pointToGeneralLinear (r + 1) g =
+  have hy : GeneralLinear.pointToGeneralLinear (r + 1)
+      (toConv (q.ofConv.comp y.hom.toAlgHom)) =
       TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix (rootGenerator r)
         (cartanGenerator r) (rep r) (lattice r).toAddSubgroup
         (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
@@ -198,18 +209,9 @@ private theorem ambientGraphCoordinateIso_hom_comp_rootSubgroupCoordinateMap
       (fun _ hu _ hv => rep_kostantForm_mem_lattice r hu hv) (graphRootPerm r k)
       (isNilpotent_rep_rootGenerator r (graphRootPerm r k)) (latticeBasis r)
       (A := AdditiveGroup.coordinateHopfAlgebra ℤ) q
-  have hp : toConv (f.ofConv.comp c.hom.toAlgHom) = g := by
-    apply (GeneralLinear.pointsMulEquiv
-      (R := ℤ) (A := CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))
-        (r + 1)).injective
-    rw [GeneralLinear.pointsMulEquiv_comp_typeAGraphCoordinateIso,
-      GeneralLinear.pointsMulEquiv_apply, GeneralLinear.pointsMulEquiv_apply]
-    have hleft := congrArg (TauCeti.typeAGraphAutomorphism r
-      (CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))) hx
-    exact hleft.trans ((typeAGraphAutomorphism_kostantRootSubgroupMatrix
-      (A := CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) r k q).trans hy.symm)
-  rw [universalPoint_comp]
-  exact hp
+  rw [hx, hy]
+  exact typeAGraphAutomorphism_kostantRootSubgroupMatrix
+    (A := CommAlgCat.of ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) r k q
 
 private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
     (GeneralLinear.typeAGraphCoordinateIso r).hom ≫
@@ -221,18 +223,11 @@ private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
   let y := GeneralLinear.weightTorusCoordinateMap (R := ℤ)
     (fun i => weight r i ∘ Fin.revPerm)
   have hxy : c ≫ x = y := by
-    apply hom_eq_of_universalPoint_eq
+    apply typeAGraphCoordinateIso_hom_comp_eq_of_universalPoint
     let T := MonoidAlgebra ℤ (SplitTorus.characterGroup (Fin r))
     let q : WithConv (T →ₐ[ℤ] T) := toConv (AlgHom.id ℤ T)
-    let f : HopfAlgebra.points
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
-          (CommAlgCat.of ℤ T) :=
-      toConv (q.ofConv.comp x.hom.toAlgHom)
-    let g : HopfAlgebra.points
-        (R := ℤ) (H := GeneralLinear.coordinateHopfAlgebra ℤ (r + 1))
-          (CommAlgCat.of ℤ T) :=
-      toConv (q.ofConv.comp y.hom.toAlgHom)
-    have hx : GeneralLinear.pointsMulEquiv (r + 1) f =
+    have hx : GeneralLinear.pointsMulEquiv (r + 1)
+        (toConv (q.ofConv.comp x.hom.toAlgHom)) =
         diagGL fun i => TauCeti.torusCharacter (SplitTorus.pointsMulEquiv q) (weight r i) := by
       calc
         _ = GeneralLinear.pointsMulEquiv (r + 1)
@@ -240,7 +235,8 @@ private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
           rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
         _ = _ := GeneralLinear.pointsMulEquiv_mapPointsFunctor_weightTorusCoordinateMap
           (weight r) (CommAlgCat.of ℤ T) q
-    have hy : GeneralLinear.pointsMulEquiv (r + 1) g =
+    have hy : GeneralLinear.pointsMulEquiv (r + 1)
+        (toConv (q.ofConv.comp y.hom.toAlgHom)) =
         diagGL fun i => TauCeti.torusCharacter (SplitTorus.pointsMulEquiv q)
           (weight r i ∘ Fin.revPerm) := by
       calc
@@ -249,16 +245,11 @@ private theorem ambientGraphCoordinateIso_hom_comp_weightTorusCoordinateMap :
           rw [CommHopfAlgCat.mapPointsFunctor_app_apply]
         _ = _ := GeneralLinear.pointsMulEquiv_mapPointsFunctor_weightTorusCoordinateMap
           (fun i => weight r i ∘ Fin.revPerm) (CommAlgCat.of ℤ T) q
-    have hp : toConv (f.ofConv.comp c.hom.toAlgHom) = g := by
-      apply (GeneralLinear.pointsMulEquiv (R := ℤ) (A := CommAlgCat.of ℤ T)
-        (r + 1)).injective
-      rw [GeneralLinear.pointsMulEquiv_comp_typeAGraphCoordinateIso, hx, hy,
-        TauCeti.typeAGraphAutomorphism_diagGL]
-      congr 1
-      funext i
-      exact torusCharacter_weight_rev_reindex r (SplitTorus.pointsMulEquiv q) i
-    rw [universalPoint_comp]
-    exact hp
+    rw [← GeneralLinear.pointsMulEquiv_apply, ← GeneralLinear.pointsMulEquiv_apply,
+      hx, hy, TauCeti.typeAGraphAutomorphism_diagGL]
+    congr 1
+    funext i
+    exact torusCharacter_weight_rev_reindex r (SplitTorus.pointsMulEquiv q) i
   calc
     (GeneralLinear.typeAGraphCoordinateIso r).hom ≫
         GeneralLinear.weightTorusCoordinateMap (R := ℤ) (weight r) = y := hxy
@@ -564,6 +555,8 @@ theorem typeAGraphAutomorphism_mem_points {A : Type} [CommRing A]
       ((GeneralLinear.pointsMulEquiv
         (R := ℤ) (A := CommAlgCat.of ℤ A) (r + 1)).apply_symm_apply g).symm
   rw [hpoint]
+  -- `mem_points_iff` evaluates the represented point as an algebra hom, whereas `hpoint`
+  -- retains the `WithConv` and bialgebra-hom wrappers around that same evaluation.
   change q.ofConv ((GeneralLinear.typeAGraphCoordinateIso r).hom.hom x) = 0
   apply hg
   apply HopfIdeal.mem_comapOfSurjective.mp

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -332,6 +332,7 @@ private theorem typeAGraphSign_succ_mul_neg_mul_inv_castSucc (i : Fin r) (c : A)
     simp
   rw [hsucc, hs_inv]
   simp only [Units.val_neg]
+  -- Coercing the sign units to `A` exposes the scalar identity proved below.
   change (-(s : A)) * (-c) * (s : A) = c
   have hneg : (-(s : A)) * (-c) * (s : A) = (s : A) * c * (s : A) := by ring
   rw [hneg]
@@ -351,6 +352,7 @@ theorem typeAGraphAutomorphism_transvectionUnit_lower (r : ℕ) (i : Fin r) (c :
   let p : GL (Fin (r + 1)) A := permutationGL (k := A) Fin.revPerm
   let hpos : i.castSucc ≠ i.succ := (Fin.castSucc_lt_succ (i := i)).ne
   let hneg : i.rev.succ ≠ i.rev.castSucc := (Fin.castSucc_lt_succ (i := i.rev)).ne'
+  -- Normalize the conjugator and the two index inequalities to their local names.
   change (d * p) * transvectionUnit hpos (-c) * (d * p)⁻¹ = _
   calc
     _ = d * (p * transvectionUnit hpos (-c) * p⁻¹) * d⁻¹ := by group
@@ -394,6 +396,7 @@ theorem typeAGraphAutomorphism_diagGL (r : ℕ) (d : Fin (r + 1) → Aˣ) :
     simpa only [p, Equiv.Perm.inv_def, Fin.revPerm_symm, Fin.revPerm_apply] using
       permutationGL_mul_diagGL_mul_inv (k := A)
         (Fin.revPerm : Equiv.Perm (Fin (r + 1))) (fun i => (d i)⁻¹)
+  -- Normalize the public conjugator definition to the local signed diagonal and reversal.
   change (diagGL s * p) * diagGL (fun i => (d i)⁻¹) * (diagGL s * p)⁻¹ = _
   calc
     _ = diagGL s * (p * diagGL (fun i => (d i)⁻¹) * p⁻¹) * (diagGL s)⁻¹ := by

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -315,6 +315,8 @@ private theorem typeAGraphAutomorphism_transvectionUnit_aux (r : ℕ)
   rw [typeAGraphAutomorphism_apply, inverseTranspose_transvectionUnit]
   let d : GL (Fin (r + 1)) A := diagGL (typeAGraphSign (A := A))
   let p : GL (Fin (r + 1)) A := permutationGL (k := A) Fin.revPerm
+  -- Unfold the public conjugator into the local diagonal/reversal factors; rewriting cannot
+  -- match this factorization beneath both multiplication and inversion at once.
   change (d * p) * transvectionUnit hij.symm (-c) * (d * p)⁻¹ = _
   calc
     _ = d * (p * transvectionUnit hij.symm (-c) * p⁻¹) * d⁻¹ := by group

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -38,6 +38,9 @@ carrier.
 
 * `TauCeti.typeAGraphAutomorphism_transvectionUnit`: the sign-free equation on every positive
   simple-root subgroup.
+* `TauCeti.typeAGraphAutomorphism_transvectionUnit_lower`: the corresponding equation on every
+  negative simple-root subgroup.
+* `TauCeti.typeAGraphAutomorphism_diagGL`: the automorphism reverses and inverts diagonal entries.
 * `TauCeti.typeAGraphAutomorphism_mul_self`: the automorphism has order dividing two.
 * `TauCeti.map_typeAGraphAutomorphism`: the construction is natural in the coefficient ring.
 
@@ -313,6 +316,95 @@ theorem typeAGraphAutomorphism_transvectionUnit (r : ℕ) (i : Fin r) (c : A) :
       rw [diagGL_mul_transvectionUnit_mul_inv]
     _ = transvectionUnit hpos c := by
       rw [typeAGraphSign_castSucc_mul_neg_mul_inv_succ]
+
+private theorem typeAGraphSign_succ_mul_neg_mul_inv_castSucc (i : Fin r) (c : A) :
+    ((typeAGraphSign (A := A) i.succ : A) * (-c) *
+      ((typeAGraphSign (A := A) i.castSucc)⁻¹ : Aˣ)) = c := by
+  let s : Aˣ := typeAGraphSign (A := A) i.castSucc
+  have hs_sq : s * s = 1 := by
+    dsimp only [s, typeAGraphSign, Fin.val_castSucc]
+    rw [← pow_add, ← two_mul (i : ℕ), pow_mul]
+    simp
+  have hs_inv : s⁻¹ = s := inv_eq_iff_mul_eq_one.mpr hs_sq
+  have hsucc : typeAGraphSign (A := A) i.succ = -s := by
+    dsimp only [s, typeAGraphSign, Fin.val_succ]
+    rw [pow_succ]
+    simp
+  rw [hsucc, hs_inv]
+  simp only [Units.val_neg]
+  change (-(s : A)) * (-c) * (s : A) = c
+  have hneg : (-(s : A)) * (-c) * (s : A) = (s : A) * c * (s : A) := by ring
+  rw [hneg]
+  calc
+    (s : A) * c * (s : A) = c * ((s : A) * (s : A)) := by ac_rfl
+    _ = c := by rw [show (s : A) * (s : A) = 1 from congrArg Units.val hs_sq, mul_one]
+
+/-- The pinned graph automorphism reverses the negative simple-root subgroups without changing
+their parameters. -/
+@[simp]
+theorem typeAGraphAutomorphism_transvectionUnit_lower (r : ℕ) (i : Fin r) (c : A) :
+    typeAGraphAutomorphism r A
+        (transvectionUnit (Fin.castSucc_lt_succ (i := i)).ne' c) =
+      transvectionUnit (Fin.castSucc_lt_succ (i := i.rev)).ne' c := by
+  rw [typeAGraphAutomorphism_apply, inverseTranspose_transvectionUnit]
+  let d : GL (Fin (r + 1)) A := diagGL (typeAGraphSign (A := A))
+  let p : GL (Fin (r + 1)) A := permutationGL (k := A) Fin.revPerm
+  let hpos : i.castSucc ≠ i.succ := (Fin.castSucc_lt_succ (i := i)).ne
+  let hneg : i.rev.succ ≠ i.rev.castSucc := (Fin.castSucc_lt_succ (i := i.rev)).ne'
+  change (d * p) * transvectionUnit hpos (-c) * (d * p)⁻¹ = _
+  calc
+    _ = d * (p * transvectionUnit hpos (-c) * p⁻¹) * d⁻¹ := by group
+    _ = d * transvectionUnit (Fin.rev_injective.ne hpos) (-c) * d⁻¹ := by
+      rw [permutationGL_conj_transvectionUnit]
+    _ = d * transvectionUnit hneg (-c) * d⁻¹ := by
+      congr 3 <;> simp only [Fin.rev_castSucc, Fin.rev_succ]
+    _ = transvectionUnit hneg
+          (((typeAGraphSign (A := A)) i.rev.succ : A) * (-c) *
+            (((typeAGraphSign (A := A)) i.rev.castSucc)⁻¹ : Aˣ)) := by
+      rw [diagGL_mul_transvectionUnit_mul_inv]
+    _ = transvectionUnit hneg c := by
+      rw [typeAGraphSign_succ_mul_neg_mul_inv_castSucc]
+
+private theorem inverseTranspose_diagGL (r : ℕ) (d : Fin (r + 1) → Aˣ) :
+    Matrix.GeneralLinearGroup.inverseTranspose (diagGL d) =
+      diagGL (fun i => (d i)⁻¹) := by
+  have hInv : (diagGL d)⁻¹ = diagGL (fun i => (d i)⁻¹) := by
+    rw [← map_inv]
+    rfl
+  apply Units.ext
+  rw [Matrix.GeneralLinearGroup.coe_inverseTranspose, hInv]
+  ext i j
+  by_cases hij : i = j
+  · subst j
+    simp [Matrix.transpose_apply]
+  · have hji : j ≠ i := Ne.symm hij
+    simp [Matrix.transpose_apply, hij, hji]
+
+/-- On the diagonal torus, the pinned graph automorphism reverses and inverts the diagonal
+entries. -/
+@[simp]
+theorem typeAGraphAutomorphism_diagGL (r : ℕ) (d : Fin (r + 1) → Aˣ) :
+    typeAGraphAutomorphism r A (diagGL d) =
+      diagGL (fun i => (d i.rev)⁻¹) := by
+  rw [typeAGraphAutomorphism_apply, inverseTranspose_diagGL]
+  let s : Fin (r + 1) → Aˣ := typeAGraphSign (A := A)
+  let p : GL (Fin (r + 1)) A := permutationGL (k := A) Fin.revPerm
+  have hp : p * diagGL (fun i => (d i)⁻¹) * p⁻¹ =
+      diagGL (fun i => (d i.rev)⁻¹) := by
+    simpa only [p, Equiv.Perm.inv_def, Fin.revPerm_symm, Fin.revPerm_apply] using
+      permutationGL_mul_diagGL_mul_inv (k := A)
+        (Fin.revPerm : Equiv.Perm (Fin (r + 1))) (fun i => (d i)⁻¹)
+  change (diagGL s * p) * diagGL (fun i => (d i)⁻¹) * (diagGL s * p)⁻¹ = _
+  calc
+    _ = diagGL s * (p * diagGL (fun i => (d i)⁻¹) * p⁻¹) * (diagGL s)⁻¹ := by
+      group
+    _ = diagGL s * diagGL (fun i => (d i.rev)⁻¹) * (diagGL s)⁻¹ := by rw [hp]
+    _ = diagGL (fun i => (d i.rev)⁻¹) := by
+      rw [← map_inv]
+      simp only [← map_mul]
+      congr 1
+      funext i
+      simp [mul_assoc]
 
 /-- Entrywise base change carries the signed reversal matrix to the signed reversal matrix. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -116,8 +116,48 @@ universe u
 
 variable {A : Type u} [CommRing A]
 
+/-- Inverse transpose inverts the entries of an invertible diagonal matrix. -/
+@[simp]
+theorem inverseTranspose_diagGL {ι : Type*} [Fintype ι] [DecidableEq ι] (d : ι → Aˣ) :
+    Matrix.GeneralLinearGroup.inverseTranspose (diagGL d) = diagGL (fun i => (d i)⁻¹) := by
+  have hInv : (diagGL d)⁻¹ = diagGL (fun i => (d i)⁻¹) := by
+    rw [← map_inv]
+    rfl
+  apply Units.ext
+  rw [Matrix.GeneralLinearGroup.coe_inverseTranspose, hInv]
+  ext i j
+  by_cases hij : i = j
+  · subst j
+    simp [Matrix.transpose_apply]
+  · have hji : j ≠ i := Ne.symm hij
+    simp [Matrix.transpose_apply, hij, hji]
+
 /-- The alternating diagonal signs used to pin the type-`A_r` graph automorphism. -/
 private def typeAGraphSign (i : Fin (r + 1)) : Aˣ := (-1 : Aˣ) ^ (i : ℕ)
+
+private theorem typeAGraphSign_mul_self (i : Fin (r + 1)) :
+    typeAGraphSign (A := A) i * typeAGraphSign (A := A) i = 1 := by
+  simp only [typeAGraphSign, ← pow_add, ← two_mul (i : ℕ), pow_mul]
+  simp
+
+private theorem typeAGraphSign_inv (i : Fin (r + 1)) :
+    (typeAGraphSign (A := A) i)⁻¹ = typeAGraphSign (A := A) i :=
+  inv_eq_iff_mul_eq_one.mpr (typeAGraphSign_mul_self (A := A) i)
+
+private theorem typeAGraphSign_succ (i : Fin r) :
+    typeAGraphSign (A := A) i.succ = -typeAGraphSign (A := A) i.castSucc := by
+  simp only [typeAGraphSign, Fin.val_succ, Fin.val_castSucc, pow_succ]
+  simp
+
+private theorem typeAGraphSign_mul_mul (i : Fin (r + 1)) (c : A) :
+    (typeAGraphSign (A := A) i : A) * c * (typeAGraphSign (A := A) i : A) = c := by
+  calc
+    _ = c * ((typeAGraphSign (A := A) i : A) *
+        (typeAGraphSign (A := A) i : A)) := by ac_rfl
+    _ = c := by
+      rw [show (typeAGraphSign (A := A) i : A) *
+          (typeAGraphSign (A := A) i : A) = 1 from
+        congrArg Units.val (typeAGraphSign_mul_self (A := A) i), mul_one]
 
 /-- The signed reversal matrix `Q` used in the pinned type-`A_r` graph automorphism. It first
 reverses the standard basis and then applies alternating signs. -/
@@ -141,19 +181,8 @@ private theorem inverseTranspose_diagGL_typeAGraphSign (r : ℕ) :
     Matrix.GeneralLinearGroup.inverseTranspose
         (diagGL (typeAGraphSign (A := A) : Fin (r + 1) → Aˣ)) =
       diagGL (typeAGraphSign (A := A)) := by
-  have hInv :
-      (diagGL (typeAGraphSign (A := A) : Fin (r + 1) → Aˣ))⁻¹ =
-        diagGL (fun i => (typeAGraphSign (A := A) i)⁻¹) := by
-    rw [← map_inv]
-    rfl
-  apply Units.ext
-  rw [Matrix.GeneralLinearGroup.coe_inverseTranspose, hInv]
-  ext i j
-  by_cases hij : i = j
-  · subst j
-    simp [typeAGraphSign, Matrix.transpose_apply]
-  · have hji : j ≠ i := Ne.symm hij
-    simp [typeAGraphSign, Matrix.transpose_apply, hij, hji]
+  rw [inverseTranspose_diagGL]
+  congr 1
 
 private theorem permutationGL_rev_inv (r : ℕ) :
     (permutationGL (k := A) (Fin.revPerm : Equiv.Perm (Fin (r + 1))))⁻¹ =
@@ -268,27 +297,30 @@ theorem inverseTranspose_transvectionUnit {n : Type*} [Fintype n] [DecidableEq n
 private theorem typeAGraphSign_castSucc_mul_neg_mul_inv_succ (i : Fin r) (c : A) :
     ((typeAGraphSign (A := A) i.castSucc : A) * (-c) *
       ((typeAGraphSign (A := A) i.succ)⁻¹ : Aˣ)) = c := by
-  let s : Aˣ := typeAGraphSign (A := A) i.castSucc
-  have hs_sq : s * s = 1 := by
-    dsimp only [s, typeAGraphSign, Fin.val_castSucc]
-    rw [← pow_add, ← two_mul (i : ℕ), pow_mul]
-    simp
-  have hs_inv : s⁻¹ = s := inv_eq_iff_mul_eq_one.mpr hs_sq
-  have hsucc : typeAGraphSign (A := A) i.succ = -s := by
-    dsimp only [s, typeAGraphSign, Fin.val_succ]
-    rw [pow_succ]
-    simp
-  rw [hsucc, inv_neg, hs_inv]
+  rw [typeAGraphSign_succ, inv_neg, typeAGraphSign_inv]
   simp only [Units.val_neg]
-  have hcast : typeAGraphSign (A := A) i.castSucc = s := rfl
-  rw [hcast]
-  -- Expose the values of the units so the remaining equality is an identity in `A`.
-  change (s : A) * (-c) * (-(s : A)) = c
-  have hneg : (s : A) * (-c) * (-(s : A)) = (s : A) * c * (s : A) := by ring
+  have hneg : (typeAGraphSign (A := A) i.castSucc : A) * (-c) *
+      (-(typeAGraphSign (A := A) i.castSucc : A)) =
+        (typeAGraphSign (A := A) i.castSucc : A) * c *
+          (typeAGraphSign (A := A) i.castSucc : A) := by ring
   rw [hneg]
+  exact typeAGraphSign_mul_mul (A := A) i.castSucc c
+
+private theorem typeAGraphAutomorphism_transvectionUnit_aux (r : ℕ)
+    {i j : Fin (r + 1)} (hij : i ≠ j) (c : A) :
+    typeAGraphAutomorphism r A (transvectionUnit hij c) =
+      transvectionUnit (Fin.rev_injective.ne hij.symm)
+        ((typeAGraphSign (A := A) j.rev : A) * (-c) *
+          ((typeAGraphSign (A := A) i.rev)⁻¹ : Aˣ)) := by
+  rw [typeAGraphAutomorphism_apply, inverseTranspose_transvectionUnit]
+  let d : GL (Fin (r + 1)) A := diagGL (typeAGraphSign (A := A))
+  let p : GL (Fin (r + 1)) A := permutationGL (k := A) Fin.revPerm
+  change (d * p) * transvectionUnit hij.symm (-c) * (d * p)⁻¹ = _
   calc
-    (s : A) * c * (s : A) = c * ((s : A) * (s : A)) := by ac_rfl
-    _ = c := by rw [show (s : A) * (s : A) = 1 from congrArg Units.val hs_sq, mul_one]
+    _ = d * (p * transvectionUnit hij.symm (-c) * p⁻¹) * d⁻¹ := by group
+    _ = d * transvectionUnit (Fin.rev_injective.ne hij.symm) (-c) * d⁻¹ := by
+      rw [permutationGL_conj_transvectionUnit]
+    _ = _ := by rw [diagGL_mul_transvectionUnit_mul_inv]
 
 /-- **The pinned graph automorphism reverses the positive simple-root subgroups without changing
 their parameters.** In Bourbaki numbering, the node `i` is carried to `i.rev`. -/
@@ -297,48 +329,22 @@ theorem typeAGraphAutomorphism_transvectionUnit (r : ℕ) (i : Fin r) (c : A) :
     typeAGraphAutomorphism r A
         (transvectionUnit (Fin.castSucc_lt_succ (i := i)).ne c) =
       transvectionUnit (Fin.castSucc_lt_succ (i := i.rev)).ne c := by
-  rw [typeAGraphAutomorphism_apply, inverseTranspose_transvectionUnit]
-  let d : GL (Fin (r + 1)) A := diagGL (typeAGraphSign (A := A))
-  let p : GL (Fin (r + 1)) A := permutationGL (k := A) Fin.revPerm
-  let hneg : i.succ ≠ i.castSucc := (Fin.castSucc_lt_succ (i := i)).ne'
-  let hpos : i.rev.castSucc ≠ i.rev.succ := (Fin.castSucc_lt_succ (i := i.rev)).ne
-  -- Normalize the conjugator and the two index inequalities to their local names.
-  change (d * p) * transvectionUnit hneg (-c) * (d * p)⁻¹ = _
-  calc
-    _ = d * (p * transvectionUnit hneg (-c) * p⁻¹) * d⁻¹ := by group
-    _ = d * transvectionUnit (Fin.rev_injective.ne hneg) (-c) * d⁻¹ := by
-      rw [permutationGL_conj_transvectionUnit]
-    _ = d * transvectionUnit hpos (-c) * d⁻¹ := by
-      congr 3 <;> simp only [Fin.rev_succ, Fin.rev_castSucc]
-    _ = transvectionUnit hpos
-          (((typeAGraphSign (A := A)) i.rev.castSucc : A) * (-c) *
-            (((typeAGraphSign (A := A)) i.rev.succ)⁻¹ : Aˣ)) := by
-      rw [diagGL_mul_transvectionUnit_mul_inv]
-    _ = transvectionUnit hpos c := by
-      rw [typeAGraphSign_castSucc_mul_neg_mul_inv_succ]
+  simpa only [Fin.rev_succ, Fin.rev_castSucc,
+    typeAGraphSign_castSucc_mul_neg_mul_inv_succ] using
+      typeAGraphAutomorphism_transvectionUnit_aux r
+        (Fin.castSucc_lt_succ (i := i)).ne c
 
 private theorem typeAGraphSign_succ_mul_neg_mul_inv_castSucc (i : Fin r) (c : A) :
     ((typeAGraphSign (A := A) i.succ : A) * (-c) *
       ((typeAGraphSign (A := A) i.castSucc)⁻¹ : Aˣ)) = c := by
-  let s : Aˣ := typeAGraphSign (A := A) i.castSucc
-  have hs_sq : s * s = 1 := by
-    dsimp only [s, typeAGraphSign, Fin.val_castSucc]
-    rw [← pow_add, ← two_mul (i : ℕ), pow_mul]
-    simp
-  have hs_inv : s⁻¹ = s := inv_eq_iff_mul_eq_one.mpr hs_sq
-  have hsucc : typeAGraphSign (A := A) i.succ = -s := by
-    dsimp only [s, typeAGraphSign, Fin.val_succ]
-    rw [pow_succ]
-    simp
-  rw [hsucc, hs_inv]
+  rw [typeAGraphSign_succ, typeAGraphSign_inv]
   simp only [Units.val_neg]
-  -- Coercing the sign units to `A` exposes the scalar identity proved below.
-  change (-(s : A)) * (-c) * (s : A) = c
-  have hneg : (-(s : A)) * (-c) * (s : A) = (s : A) * c * (s : A) := by ring
+  have hneg : (-(typeAGraphSign (A := A) i.castSucc : A)) * (-c) *
+      (typeAGraphSign (A := A) i.castSucc : A) =
+        (typeAGraphSign (A := A) i.castSucc : A) * c *
+          (typeAGraphSign (A := A) i.castSucc : A) := by ring
   rw [hneg]
-  calc
-    (s : A) * c * (s : A) = c * ((s : A) * (s : A)) := by ac_rfl
-    _ = c := by rw [show (s : A) * (s : A) = 1 from congrArg Units.val hs_sq, mul_one]
+  exact typeAGraphSign_mul_mul (A := A) i.castSucc c
 
 /-- The pinned graph automorphism reverses the negative simple-root subgroups without changing
 their parameters. -/
@@ -347,40 +353,10 @@ theorem typeAGraphAutomorphism_transvectionUnit_lower (r : ℕ) (i : Fin r) (c :
     typeAGraphAutomorphism r A
         (transvectionUnit (Fin.castSucc_lt_succ (i := i)).ne' c) =
       transvectionUnit (Fin.castSucc_lt_succ (i := i.rev)).ne' c := by
-  rw [typeAGraphAutomorphism_apply, inverseTranspose_transvectionUnit]
-  let d : GL (Fin (r + 1)) A := diagGL (typeAGraphSign (A := A))
-  let p : GL (Fin (r + 1)) A := permutationGL (k := A) Fin.revPerm
-  let hpos : i.castSucc ≠ i.succ := (Fin.castSucc_lt_succ (i := i)).ne
-  let hneg : i.rev.succ ≠ i.rev.castSucc := (Fin.castSucc_lt_succ (i := i.rev)).ne'
-  -- Normalize the conjugator and the two index inequalities to their local names.
-  change (d * p) * transvectionUnit hpos (-c) * (d * p)⁻¹ = _
-  calc
-    _ = d * (p * transvectionUnit hpos (-c) * p⁻¹) * d⁻¹ := by group
-    _ = d * transvectionUnit (Fin.rev_injective.ne hpos) (-c) * d⁻¹ := by
-      rw [permutationGL_conj_transvectionUnit]
-    _ = d * transvectionUnit hneg (-c) * d⁻¹ := by
-      congr 3 <;> simp only [Fin.rev_castSucc, Fin.rev_succ]
-    _ = transvectionUnit hneg
-          (((typeAGraphSign (A := A)) i.rev.succ : A) * (-c) *
-            (((typeAGraphSign (A := A)) i.rev.castSucc)⁻¹ : Aˣ)) := by
-      rw [diagGL_mul_transvectionUnit_mul_inv]
-    _ = transvectionUnit hneg c := by
-      rw [typeAGraphSign_succ_mul_neg_mul_inv_castSucc]
-
-private theorem inverseTranspose_diagGL (r : ℕ) (d : Fin (r + 1) → Aˣ) :
-    Matrix.GeneralLinearGroup.inverseTranspose (diagGL d) =
-      diagGL (fun i => (d i)⁻¹) := by
-  have hInv : (diagGL d)⁻¹ = diagGL (fun i => (d i)⁻¹) := by
-    rw [← map_inv]
-    rfl
-  apply Units.ext
-  rw [Matrix.GeneralLinearGroup.coe_inverseTranspose, hInv]
-  ext i j
-  by_cases hij : i = j
-  · subst j
-    simp [Matrix.transpose_apply]
-  · have hji : j ≠ i := Ne.symm hij
-    simp [Matrix.transpose_apply, hij, hji]
+  simpa only [Fin.rev_castSucc, Fin.rev_succ,
+    typeAGraphSign_succ_mul_neg_mul_inv_castSucc] using
+      typeAGraphAutomorphism_transvectionUnit_aux r
+        (Fin.castSucc_lt_succ (i := i)).ne' c
 
 /-- On the diagonal torus, the pinned graph automorphism reverses and inverts the diagonal
 entries. -/


### PR DESCRIPTION
This PR constructs the pinned type-`A_r` graph automorphism of the full-weight standard carrier by descending signed reverse-inverse-transpose through the carrier's defining Hopf ideal. It proves the required formulas on positive and negative simple-root transvections and diagonal matrices, recovers the natural coordinate-algebra automorphism through the functor of points, and records the resulting scheme-level action on every numbered root subgroup and on the split torus.

The exact target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 9, “Pinnings” and “The Chevalley–Demazure construction”: supply the pinned graph automorphism on the explicitly constructed type-A standard carrier. The designated milestone is ReductiveGroups Layer 9's pinned Chevalley–Demazure group construction. After this PR, composing this graph automorphism with the already-landed carrier Frobenius and identifying the fixed points with the `²A_r(q)` family remain.

No Mathlib infrastructure is vendored; the construction reuses Mathlib's `Fin.revPerm` and general-linear matrix API together with Tau Ceti's fully faithful Hopf-algebra functor of points and quotient-by-Hopf-ideal infrastructure.

Consumer roadmap: CFSGStatement

Dependency edge: CFSGStatement milestone L1 consumes this pinned type-A carrier graph automorphism together with carrier Frobenius to define the Steinberg map for `²A_r(q)`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-a-carrier-graph-automorphism"}-->

The changed modules pass the targeted build, the changed-declaration axiom audit, and the lint-environment audit.

🤖 Prepared with Codex
