### PR TITLE
Share standard-carrier lattice helpers

### DIFF
--- a/TauCeti/Algebra/Lie/Sl2/IntegralLattice.lean
+++ b/TauCeti/Algebra/Lie/Sl2/IntegralLattice.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Module.Lattice
 public import TauCeti.Algebra.Lie.Sl2.Standard
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.Form
+public import TauCeti.LinearAlgebra.CoordinateLattice
 public import TauCeti.RingTheory.Binomial
 import Mathlib.Tactic.FinCases
 
@@ -229,31 +230,28 @@ variable (n : ℕ)
 A vector belongs to this submodule exactly when each of its coordinates is an integer viewed in
 `ℚ`; see `mem_integralLattice_iff`. -/
 def integralLattice : Submodule ℤ (Sl2Std ℚ n) :=
-  Submodule.span ℤ (Set.range (basis ℚ n))
+  TauCeti.coordinateLattice (Fin (n + 1))
 
 /-- A vector belongs to the standard integral lattice exactly when all its coordinates are
 integer-valued. -/
 @[simp]
 theorem mem_integralLattice_iff {v : Sl2Std ℚ n} :
     v ∈ integralLattice n ↔ ∀ i, ∃ z : ℤ, (z : ℚ) = v i := by
-  rw [integralLattice, Module.Basis.mem_span_iff_repr_mem]
-  simp only [basis_repr_apply, Set.mem_range, eq_comm]
-  rfl
+  exact TauCeti.mem_coordinateLattice_iff (Fin (n + 1))
 
 /-- Integer coordinate vectors are linearly equivalent to the standard integral lattice. -/
 noncomputable def integerCoordinatesLinearEquiv :
     (Fin (n + 1) → ℤ) ≃ₗ[ℤ] integralLattice n :=
-  ((basis ℚ n).restrictScalars ℤ).equivFun.symm
+  (TauCeti.coordinateLatticeBasis (Fin (n + 1))).equivFun.symm
 
 /-- Inverse evaluation of the coordinate linear equivalence yields the integer coordinates. -/
 @[simp]
 theorem coe_integerCoordinatesLinearEquiv_symm_apply (v : integralLattice n) (i : Fin (n + 1)) :
     (((integerCoordinatesLinearEquiv n).symm v i : ℤ) : ℚ) = (v : Sl2Std ℚ n) i := by
-  have h := Module.Basis.restrictScalars_repr_apply ℤ (basis ℚ n) v i
   have hequiv : (integerCoordinatesLinearEquiv n).symm v i =
-      ((basis ℚ n).restrictScalars ℤ).repr v i := rfl
+      (TauCeti.coordinateLatticeBasis (Fin (n + 1))).repr v i := rfl
   rw [hequiv]
-  exact h.trans (basis_repr_apply (v : Sl2Std ℚ n) i)
+  exact TauCeti.intCast_coordinateLatticeBasis_repr (Fin (n + 1)) v i
 
 /-- Forward evaluation of the coordinate linear equivalence on a coordinate vector. -/
 @[simp]
@@ -264,15 +262,15 @@ theorem coe_integerCoordinatesLinearEquiv_apply (z : Fin (n + 1) → ℤ) (i : F
   exact h.symm
 
 noncomputable instance : Module.Free ℤ (integralLattice n) :=
-  Module.Free.of_basis ((basis ℚ n).restrictScalars ℤ)
+  Module.Free.of_basis (TauCeti.coordinateLatticeBasis (Fin (n + 1)))
 
 noncomputable instance : Module.Finite ℤ (integralLattice n) :=
-  Module.Finite.of_basis ((basis ℚ n).restrictScalars ℤ)
+  Module.Finite.of_basis (TauCeti.coordinateLatticeBasis (Fin (n + 1)))
 
 /-- The standard integral lattice has rank `n + 1`. -/
 @[simp]
 theorem finrank_integralLattice : Module.finrank ℤ (integralLattice n) = n + 1 := by
-  have h := Module.finrank_eq_card_basis ((basis ℚ n).restrictScalars ℤ)
+  have h := Module.finrank_eq_card_basis (TauCeti.coordinateLatticeBasis (Fin (n + 1)))
   rw [Fintype.card_fin] at h
   exact h
 
@@ -330,13 +328,10 @@ theorem ringChoose_diag_mem_integralLattice (k : ℕ) {v : Sl2Std ℚ n}
 /-- The rational span of the standard integral lattice is the whole standard module. -/
 theorem span_integralLattice_eq_top :
     Submodule.span ℚ (integralLattice n : Set (Sl2Std ℚ n)) = ⊤ := by
-  rw [integralLattice, Submodule.span_span_of_tower, (basis ℚ n).span_eq]
+  exact (TauCeti.instIsLatticeCoordinateLattice (Fin (n + 1))).span_eq_top
 
 instance : Submodule.IsLattice ℚ (integralLattice n) where
-  fg := by
-    rw [← Module.Finite.iff_fg]
-    infer_instance
-  span_eq_top := span_integralLattice_eq_top n
+  __ := TauCeti.instIsLatticeCoordinateLattice (Fin (n + 1))
 
 /-! ### The restricted rank-one Kostant action -/
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -362,23 +362,28 @@ theorem rep_ringChoose_cartanGenerator_mem_lattice (i : Fin r) (n : ℕ)
     {v : Fin (r + 1) → ℚ} (hv : v ∈ lattice r) :
     rep r (Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (cartanGenerator r i)) n) v ∈
       lattice r := by
-  rw [lattice, TauCeti.coordinateLattice_def] at hv ⊢
-  induction hv using Submodule.span_induction with
-  | mem v hv =>
-      obtain ⟨x, rfl⟩ := hv
-      rw [Pi.basisFun_apply, Ring.map_choose]
-      have hweight := (TauCeti.UniversalEnvelopingAlgebra.isCartanWeightVector_iff
-        (cartanGenerator r) (rep r)).1 (isCartanWeightVector_single r x) i
-      rw [ringChoose_end_apply_of_apply_eq_smul hweight n, TauCeti.Ring.choose_intCast,
-        Int.cast_smul_eq_zsmul ℚ]
-      have hx : Pi.single x (1 : ℚ) ∈
-          Submodule.span ℤ (Set.range (Pi.basisFun ℚ (Fin (r + 1)))) := by
-        rw [← Pi.basisFun_apply]
-        exact Submodule.subset_span (Set.mem_range_self x)
-      exact Submodule.smul_mem _ _ hx
-  | zero => rw [map_zero]; exact zero_mem _
-  | add x y _ _ hx hy => rw [map_add]; exact add_mem hx hy
-  | smul z x _ hx => rw [map_zsmul]; exact Submodule.smul_mem _ z hx
+  rw [lattice] at hv ⊢
+  refine TauCeti.coordinateLattice_induction (Fin (r + 1))
+    (p := fun w => rep r
+      (Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (cartanGenerator r i)) n) w ∈
+        TauCeti.coordinateLattice (Fin (r + 1))) (v := v) hv ?_ ?_ ?_ ?_
+  · intro x
+    rw [Pi.basisFun_apply, Ring.map_choose]
+    have hweight := (TauCeti.UniversalEnvelopingAlgebra.isCartanWeightVector_iff
+      (cartanGenerator r) (rep r)).1 (isCartanWeightVector_single r x) i
+    rw [ringChoose_end_apply_of_apply_eq_smul hweight n, TauCeti.Ring.choose_intCast,
+      Int.cast_smul_eq_zsmul ℚ]
+    rw [← Pi.basisFun_apply]
+    exact Submodule.smul_mem _ _
+      (TauCeti.basisFun_mem_coordinateLattice (Fin (r + 1)) x)
+  · rw [map_zero]
+    exact zero_mem _
+  · intro x y hx hy
+    rw [map_add]
+    exact add_mem hx hy
+  · intro z x hx
+    rw [map_zsmul]
+    exact Submodule.smul_mem _ z hx
 
 /-- **The standard lattice is an admissible lattice**: the Kostant `ℤ`-form presented by the
 numbered Chevalley generators preserves it. -/

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -12,6 +12,7 @@ public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Schem
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Relations
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.Torus
 public import TauCeti.Algebra.Lie.UniversalEnveloping.MatrixRepresentation
+public import TauCeti.LinearAlgebra.CoordinateLattice
 public import TauCeti.LinearAlgebra.Eigenspace.Binomial
 public import TauCeti.RingTheory.Binomial
 import TauCeti.Algebra.Lie.GeneralLinear.DiagonalCartan
@@ -309,31 +310,30 @@ theorem lie_cartanGenerator_rootGenerator (k : Fin r ⊕ Fin r) (j : Fin r) :
 /-- **The standard `ℤ`-lattice of the standard `sl_{r+1}`-module**, spanned by the coordinate
 vectors. -/
 def lattice : Submodule ℤ (Fin (r + 1) → ℚ) :=
-  Submodule.span ℤ (Set.range (Pi.basisFun ℚ (Fin (r + 1))))
+  TauCeti.coordinateLattice (Fin (r + 1))
 
 /-- A vector lies in the standard lattice exactly when all of its coordinates are integers. -/
 @[simp]
 theorem mem_lattice_iff {v : Fin (r + 1) → ℚ} :
     v ∈ lattice r ↔ ∀ i, ∃ z : ℤ, (z : ℚ) = v i := by
-  rw [lattice, Module.Basis.mem_span_iff_repr_mem]
-  simp only [Pi.basisFun_repr, algebraMap_int_eq, Int.coe_castRingHom, Set.mem_range]
+  exact TauCeti.mem_coordinateLattice_iff (Fin (r + 1))
 
 theorem single_mem_lattice (i : Fin (r + 1)) : Pi.single i (1 : ℚ) ∈ lattice r := by
-  rw [lattice, ← Pi.basisFun_apply]
-  exact Submodule.subset_span (Set.mem_range_self i)
+  rw [← Pi.basisFun_apply]
+  exact TauCeti.basisFun_mem_coordinateLattice (Fin (r + 1)) i
 
 /-- The coordinate basis of the standard lattice.
 
 The carrier subtype and `ℤ`-module structure of a submodule are definitionally equal to those of
 its underlying additive subgroup, so the restricted-scalars basis has the displayed target type. -/
 noncomputable def latticeBasis : Module.Basis (Fin (r + 1)) ℤ (lattice r).toAddSubgroup :=
-  (Pi.basisFun ℚ (Fin (r + 1))).restrictScalars ℤ
+  TauCeti.coordinateLatticeBasis (Fin (r + 1))
 
 @[simp]
 theorem coe_latticeBasis (i : Fin (r + 1)) :
     ((latticeBasis r i : (lattice r).toAddSubgroup) : Fin (r + 1) → ℚ) = Pi.single i 1 := by
-  unfold latticeBasis lattice
-  rw [Module.Basis.restrictScalars_apply, Pi.basisFun_apply]
+  rw [← Pi.basisFun_apply, latticeBasis]
+  exact TauCeti.coe_coordinateLatticeBasis (Fin (r + 1)) i
 
 /-! ## Stability of the lattice under the Kostant form -/
 
@@ -353,14 +353,8 @@ theorem rep_dividedPower_rootGenerator_mem_lattice (k : Fin r ⊕ Fin r) (n : �
     rep r (Associative.dividedPower n
         (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator r k))) v ∈ lattice r := by
   rw [Associative.map_dividedPower]
-  match n with
-  | 0 => rwa [Associative.dividedPower_zero, Module.End.one_apply]
-  | 1 => rw [Associative.dividedPower_one]; exact rep_rootGenerator_mem_lattice r k hv
-  | (n + 2) =>
-      rw [Associative.dividedPower_def,
-        pow_eq_zero_of_le (m := 2) (by omega) (pow_two_rep_rootGenerator_eq_zero r k), smul_zero,
-        LinearMap.zero_apply]
-      exact zero_mem _
+  exact Associative.dividedPower_apply_mem_of_pow_two_eq_zero _ _
+    (pow_two_rep_rootGenerator_eq_zero r k) (rep_rootGenerator_mem_lattice r k) n hv
 
 /-- **Every Cartan binomial operator preserves the standard lattice.** The coordinate vectors are
 weight vectors with integer weights, so the binomial coefficients act on them by integers. -/
@@ -368,7 +362,7 @@ theorem rep_ringChoose_cartanGenerator_mem_lattice (i : Fin r) (n : ℕ)
     {v : Fin (r + 1) → ℚ} (hv : v ∈ lattice r) :
     rep r (Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (cartanGenerator r i)) n) v ∈
       lattice r := by
-  rw [lattice] at hv ⊢
+  rw [lattice, TauCeti.coordinateLattice_def] at hv ⊢
   induction hv using Submodule.span_induction with
   | mem v hv =>
       obtain ⟨x, rfl⟩ := hv

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Basic.lean
@@ -363,27 +363,13 @@ theorem rep_ringChoose_cartanGenerator_mem_lattice (i : Fin r) (n : ℕ)
     rep r (Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (cartanGenerator r i)) n) v ∈
       lattice r := by
   rw [lattice] at hv ⊢
-  refine TauCeti.coordinateLattice_induction (Fin (r + 1))
-    (p := fun w => rep r
-      (Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ (cartanGenerator r i)) n) w ∈
-        TauCeti.coordinateLattice (Fin (r + 1))) (v := v) hv ?_ ?_ ?_ ?_
-  · intro x
-    rw [Pi.basisFun_apply, Ring.map_choose]
-    have hweight := (TauCeti.UniversalEnvelopingAlgebra.isCartanWeightVector_iff
-      (cartanGenerator r) (rep r)).1 (isCartanWeightVector_single r x) i
-    rw [ringChoose_end_apply_of_apply_eq_smul hweight n, TauCeti.Ring.choose_intCast,
-      Int.cast_smul_eq_zsmul ℚ]
-    rw [← Pi.basisFun_apply]
-    exact Submodule.smul_mem _ _
-      (TauCeti.basisFun_mem_coordinateLattice (Fin (r + 1)) x)
-  · rw [map_zero]
-    exact zero_mem _
-  · intro x y hx hy
-    rw [map_add]
-    exact add_mem hx hy
-  · intro z x hx
-    rw [map_zsmul]
-    exact Submodule.smul_mem _ z hx
+  rw [Ring.map_choose]
+  refine TauCeti.ringChoose_end_apply_mem_coordinateLattice_of_apply_eq_intCast_smul
+    (Fin (r + 1)) (weight := fun x => weight r x i) ?_ n hv
+  intro x
+  rw [Pi.basisFun_apply]
+  exact (TauCeti.UniversalEnvelopingAlgebra.isCartanWeightVector_iff
+    (cartanGenerator r) (rep r)).1 (isCartanWeightVector_single r x) i
 
 /-- **The standard lattice is an admissible lattice**: the Kostant `ℤ`-form presented by the
 numbered Chevalley generators preserves it. -/

--- a/TauCeti/LinearAlgebra/CoordinateLattice.lean
+++ b/TauCeti/LinearAlgebra/CoordinateLattice.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Basis.Submodule
+public import Mathlib.LinearAlgebra.StdBasis
+
+/-!
+# The integral lattice in a rational coordinate space
+
+For a finite index type `ι`, this file packages the standard integral lattice in `ι → ℚ`: the
+`ℤ`-span of the coordinate vectors. It records its coordinatewise membership criterion and its
+canonical basis. These declarations are shared by the standard Chevalley carriers and the Geck
+module instead of rebuilding the same restricted-scalars basis in each construction.
+
+## Main declarations
+
+* `TauCeti.coordinateLattice`: the `ℤ`-span of the standard basis of `ι → ℚ`.
+* `TauCeti.mem_coordinateLattice_iff`: membership means that every coordinate is integral.
+* `TauCeti.basisFun_mem_coordinateLattice` and `TauCeti.coordinateLatticeBasis`: the standard
+  coordinate vectors and basis over `ℤ`.
+
+This is a reusable prerequisite for the Chevalley--Demazure carriers in Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+variable (ι : Type u) [Fintype ι]
+
+/-- The standard integral lattice in the rational coordinate space `ι → ℚ`. -/
+@[expose] def coordinateLattice : Submodule ℤ (ι → ℚ) :=
+  Submodule.span ℤ (Set.range (Pi.basisFun ℚ ι))
+
+/-- The coordinate lattice is the span of the standard basis. -/
+theorem coordinateLattice_def :
+    coordinateLattice ι = Submodule.span ℤ (Set.range (Pi.basisFun ℚ ι)) := rfl
+
+/-- A rational coordinate vector lies in the standard lattice exactly when every coordinate is
+an integer. -/
+@[simp] theorem mem_coordinateLattice_iff {v : ι → ℚ} :
+    v ∈ coordinateLattice ι ↔ ∀ i, ∃ z : ℤ, (z : ℚ) = v i := by
+  rw [coordinateLattice, Module.Basis.mem_span_iff_repr_mem]
+  simp only [Pi.basisFun_repr, algebraMap_int_eq, Int.coe_castRingHom, Set.mem_range]
+
+/-- Every standard coordinate basis vector lies in the coordinate lattice. -/
+theorem basisFun_mem_coordinateLattice (i : ι) :
+    Pi.basisFun ℚ ι i ∈ coordinateLattice ι := by
+  rw [coordinateLattice]
+  exact Submodule.subset_span (Set.mem_range_self i)
+
+/-- The standard coordinate vectors, regarded as a basis of the coordinate lattice over `ℤ`. -/
+@[expose] noncomputable def coordinateLatticeBasis :
+    Module.Basis ι ℤ (coordinateLattice ι) :=
+  (Pi.basisFun ℚ ι).restrictScalars ℤ
+
+/-- A coordinate-lattice basis vector is the corresponding standard coordinate vector. -/
+@[simp] theorem coe_coordinateLatticeBasis (i : ι) :
+    ((coordinateLatticeBasis ι i : coordinateLattice ι) : ι → ℚ) = Pi.basisFun ℚ ι i := by
+  unfold coordinateLatticeBasis coordinateLattice
+  rw [Module.Basis.restrictScalars_apply]
+
+/-- Extending a coordinate-lattice basis coefficient to `ℚ` recovers the corresponding rational
+coordinate. -/
+@[simp] theorem intCast_coordinateLatticeBasis_repr (v : coordinateLattice ι) (i : ι) :
+    ((coordinateLatticeBasis ι).repr v i : ℚ) = (v : ι → ℚ) i := by
+  unfold coordinateLatticeBasis coordinateLattice at *
+  rw [← eq_intCast (algebraMap ℤ ℚ) _, Module.Basis.restrictScalars_repr_apply]
+  rfl
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CoordinateLattice.lean
+++ b/TauCeti/LinearAlgebra/CoordinateLattice.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Algebra.Module.Lattice
 public import Mathlib.LinearAlgebra.Basis.Submodule
 public import Mathlib.LinearAlgebra.StdBasis
+public import TauCeti.LinearAlgebra.Eigenspace.Binomial
 
 /-!
 # The integral lattice in a rational coordinate space
@@ -36,6 +37,8 @@ universe u
 
 variable (ι : Type u) [Finite ι]
 
+attribute [local instance] TauCeti.moduleNNRat
+
 /-- The standard integral lattice in the rational coordinate space `ι → ℚ`. -/
 def coordinateLattice : Submodule ℤ (ι → ℚ) :=
   Submodule.span ℤ (Set.range (Pi.basisFun ℚ ι))
@@ -53,22 +56,15 @@ theorem basisFun_mem_coordinateLattice (i : ι) :
   rw [coordinateLattice]
   exact Submodule.subset_span (Set.mem_range_self i)
 
-/-- To prove a property of every vector in the coordinate lattice, it is enough to prove it for
-the standard coordinate vectors and show that it is preserved by the `ℤ`-module operations. -/
-theorem coordinateLattice_induction {p : (ι → ℚ) → Prop} {v : ι → ℚ}
-    (hv : v ∈ coordinateLattice ι)
-    (basis : ∀ i, p (Pi.basisFun ℚ ι i))
-    (zero : p 0)
-    (add : ∀ x y, p x → p y → p (x + y))
-    (smul : ∀ (z : ℤ) x, p x → p (z • x)) : p v := by
-  rw [coordinateLattice] at hv
-  induction hv using Submodule.span_induction with
-  | mem x hx =>
-      obtain ⟨i, rfl⟩ := hx
-      exact basis i
-  | zero => exact zero
-  | add x y _ _ hx hy => exact add x y hx hy
-  | smul z x _ hx => exact smul z x hx
+/-- Binomial coefficients of an endomorphism preserve the coordinate lattice when every standard
+coordinate vector is an eigenvector with an integer eigenvalue. -/
+theorem ringChoose_end_apply_mem_coordinateLattice_of_apply_eq_intCast_smul
+    {f : Module.End ℚ (ι → ℚ)} {weight : ι → ℤ}
+    (heigen : ∀ i, f (Pi.basisFun ℚ ι i) = (weight i : ℚ) • Pi.basisFun ℚ ι i)
+    (n : ℕ) {v : ι → ℚ} (hv : v ∈ coordinateLattice ι) :
+    (Ring.choose f n) v ∈ coordinateLattice ι := by
+  rw [coordinateLattice] at hv ⊢
+  exact ringChoose_end_apply_mem_span_of_apply_eq_intCast_smul heigen n hv
 
 /-- The standard coordinate vectors, regarded as a basis of the coordinate lattice over `ℤ`. -/
 noncomputable def coordinateLatticeBasis :

--- a/TauCeti/LinearAlgebra/CoordinateLattice.lean
+++ b/TauCeti/LinearAlgebra/CoordinateLattice.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.Module.Lattice
 public import Mathlib.LinearAlgebra.Basis.Submodule
 public import Mathlib.LinearAlgebra.StdBasis
 
@@ -33,15 +34,11 @@ namespace TauCeti
 
 universe u
 
-variable (ι : Type u) [Fintype ι]
+variable (ι : Type u) [Finite ι]
 
 /-- The standard integral lattice in the rational coordinate space `ι → ℚ`. -/
-@[expose] def coordinateLattice : Submodule ℤ (ι → ℚ) :=
+def coordinateLattice : Submodule ℤ (ι → ℚ) :=
   Submodule.span ℤ (Set.range (Pi.basisFun ℚ ι))
-
-/-- The coordinate lattice is the span of the standard basis. -/
-theorem coordinateLattice_def :
-    coordinateLattice ι = Submodule.span ℤ (Set.range (Pi.basisFun ℚ ι)) := rfl
 
 /-- A rational coordinate vector lies in the standard lattice exactly when every coordinate is
 an integer. -/
@@ -56,8 +53,25 @@ theorem basisFun_mem_coordinateLattice (i : ι) :
   rw [coordinateLattice]
   exact Submodule.subset_span (Set.mem_range_self i)
 
+/-- To prove a property of every vector in the coordinate lattice, it is enough to prove it for
+the standard coordinate vectors and show that it is preserved by the `ℤ`-module operations. -/
+theorem coordinateLattice_induction {p : (ι → ℚ) → Prop} {v : ι → ℚ}
+    (hv : v ∈ coordinateLattice ι)
+    (basis : ∀ i, p (Pi.basisFun ℚ ι i))
+    (zero : p 0)
+    (add : ∀ x y, p x → p y → p (x + y))
+    (smul : ∀ (z : ℤ) x, p x → p (z • x)) : p v := by
+  rw [coordinateLattice] at hv
+  induction hv using Submodule.span_induction with
+  | mem x hx =>
+      obtain ⟨i, rfl⟩ := hx
+      exact basis i
+  | zero => exact zero
+  | add x y _ _ hx hy => exact add x y hx hy
+  | smul z x _ hx => exact smul z x hx
+
 /-- The standard coordinate vectors, regarded as a basis of the coordinate lattice over `ℤ`. -/
-@[expose] noncomputable def coordinateLatticeBasis :
+noncomputable def coordinateLatticeBasis :
     Module.Basis ι ℤ (coordinateLattice ι) :=
   (Pi.basisFun ℚ ι).restrictScalars ℤ
 
@@ -72,7 +86,16 @@ coordinate. -/
 @[simp] theorem intCast_coordinateLatticeBasis_repr (v : coordinateLattice ι) (i : ι) :
     ((coordinateLatticeBasis ι).repr v i : ℚ) = (v : ι → ℚ) i := by
   unfold coordinateLatticeBasis coordinateLattice at *
-  rw [← eq_intCast (algebraMap ℤ ℚ) _, Module.Basis.restrictScalars_repr_apply]
-  rfl
+  rw [← eq_intCast (algebraMap ℤ ℚ) _, Module.Basis.restrictScalars_repr_apply,
+    Pi.basisFun_repr]
+
+/-- The standard coordinate lattice is finitely generated and spans its rational coordinate
+space. -/
+instance instIsLatticeCoordinateLattice : Submodule.IsLattice ℚ (coordinateLattice ι) where
+  fg := by
+    rw [coordinateLattice]
+    exact Submodule.fg_span (Set.finite_range _)
+  span_eq_top := by
+    rw [coordinateLattice, Submodule.span_span_of_tower, (Pi.basisFun ℚ ι).span_eq]
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
@@ -154,16 +154,15 @@ theorem isCartanWeightVector_geckCoordinateBasisFin (i : Fin (t.geckDim ht)) :
 the latter contains every standard coordinate vector. -/
 theorem geckCoordinateLattice_le_geckOrbit :
     t.geckCoordinateLattice ht ≤ t.geckOrbit ht := by
+  classical
   intro v hv
-  rw [geckCoordinateLattice] at hv
-  refine TauCeti.coordinateLattice_induction (t.GeckIndex ht) hv ?_ (zero_mem _) ?_ ?_
-  · intro i
-    rw [Pi.basisFun_apply]
-    exact t.single_mem_geckOrbit ht i
-  · intro x y hx hy
-    exact add_mem hx hy
-  · intro z x hx
-    exact Submodule.smul_mem _ z hx
+  choose z hz using (t.mem_geckCoordinateLattice_iff ht).1 hv
+  have hv_eq : v = ∑ i, z i • Pi.single i (1 : ℚ) := by
+    funext j
+    simp [Pi.single_apply, hz]
+  rw [hv_eq]
+  exact Submodule.sum_mem _ fun i _ =>
+    Submodule.smul_mem _ (z i) (t.single_mem_geckOrbit ht i)
 
 /-- The coordinate lattice is finitely generated over `ℤ` and spans the ambient rational Geck
 module. -/
@@ -299,27 +298,13 @@ theorem geckRepresentation_ringChoose_lieBasis_h_mem_geckCoordinateLattice
       t.geckCoordinateLattice ht := by
   rw [geckCoordinateLattice] at hv ⊢
   rw [Ring.map_choose]
-  refine TauCeti.coordinateLattice_induction (t.GeckIndex ht)
-    (p := fun w => Ring.choose (t.geckRepresentation ht
-      (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).h i))) n w ∈
-        TauCeti.coordinateLattice (t.GeckIndex ht)) (v := v) hv ?_ ?_ ?_ ?_
-  · intro x
-    rw [Pi.basisFun_apply]
-    have hweight := (UniversalEnvelopingAlgebra.isCartanWeightVector_iff
-      (h := (t.lieBasis ht).h) (ρ := t.geckRepresentation ht)).1
-        (t.isCartanWeightVector_geckRepresentation_single ht x) i
-    rw [ringChoose_end_apply_of_apply_eq_smul hweight n, TauCeti.Ring.choose_intCast,
-      Int.cast_smul_eq_zsmul ℚ]
-    rw [← Pi.basisFun_apply]
-    exact zsmul_mem (TauCeti.basisFun_mem_coordinateLattice (t.GeckIndex ht) x) _
-  · rw [map_zero]
-    exact zero_mem _
-  · intro x y hx hy
-    rw [map_add]
-    exact add_mem hx hy
-  · intro z x hx
-    rw [map_zsmul]
-    exact Submodule.smul_mem _ z hx
+  refine TauCeti.ringChoose_end_apply_mem_coordinateLattice_of_apply_eq_intCast_smul
+    (t.GeckIndex ht) (weight := fun x => t.geckWeight ht x i) ?_ n hv
+  intro x
+  rw [Pi.basisFun_apply]
+  exact (UniversalEnvelopingAlgebra.isCartanWeightVector_iff
+    (h := (t.lieBasis ht).h) (ρ := t.geckRepresentation ht)).1
+      (t.isCartanWeightVector_geckRepresentation_single ht x) i
 
 /-! ## Divided powers of the numbered root generators -/
 

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
@@ -132,15 +132,8 @@ theorem intCast_geckCoordinateBasisFin_repr
     (v : (t.geckCoordinateLattice ht).toAddSubgroup) (i : Fin (t.geckDim ht)) :
     ((t.geckCoordinateBasisFin ht).repr v i : ℚ) =
       (v : t.GeckIndex ht → ℚ) ((Fintype.equivFin (t.GeckIndex ht)).symm i) := by
-  unfold geckCoordinateBasisFin geckCoordinateBasis geckCoordinateLattice
-    TauCeti.coordinateLatticeBasis TauCeti.coordinateLattice at *
-  rw [Module.Basis.repr_reindex_apply]
-  let v' : Submodule.span ℤ (Set.range (Pi.basisFun ℚ (t.GeckIndex ht))) :=
-    ⟨v, v.property⟩
-  change ((Module.Basis.restrictScalars ℤ (Pi.basisFun ℚ (t.GeckIndex ht))).repr v'
-      ((Fintype.equivFin (t.GeckIndex ht)).symm i) : ℚ) = _
-  rw [← eq_intCast (algebraMap ℤ ℚ) _, Module.Basis.restrictScalars_repr_apply]
-  rfl
+  rw [geckCoordinateBasisFin, Module.Basis.repr_reindex_apply]
+  exact TauCeti.intCast_coordinateLatticeBasis_repr (t.GeckIndex ht) v _
 
 /-- The integral weight of a finite-ordinal Geck coordinate basis vector. The Cartan argument uses
 the Bourbaki numbering, while the coordinate argument uses the `Fintype.equivFin` ordering of
@@ -161,22 +154,22 @@ theorem isCartanWeightVector_geckCoordinateBasisFin (i : Fin (t.geckDim ht)) :
 the latter contains every standard coordinate vector. -/
 theorem geckCoordinateLattice_le_geckOrbit :
     t.geckCoordinateLattice ht ≤ t.geckOrbit ht := by
-  rw [geckCoordinateLattice, TauCeti.coordinateLattice_def, Submodule.span_le]
-  rintro - ⟨i, rfl⟩
-  rw [Pi.basisFun_apply]
-  exact t.single_mem_geckOrbit ht i
+  intro v hv
+  rw [geckCoordinateLattice] at hv
+  refine TauCeti.coordinateLattice_induction (t.GeckIndex ht) hv ?_ (zero_mem _) ?_ ?_
+  · intro i
+    rw [Pi.basisFun_apply]
+    exact t.single_mem_geckOrbit ht i
+  · intro x y hx hy
+    exact add_mem hx hy
+  · intro z x hx
+    exact Submodule.smul_mem _ z hx
 
 /-- The coordinate lattice is finitely generated over `ℤ` and spans the ambient rational Geck
 module. -/
 instance instIsLatticeGeckCoordinateLattice :
     Submodule.IsLattice ℚ (t.geckCoordinateLattice ht) where
-  fg := by
-    rw [geckCoordinateLattice, TauCeti.coordinateLattice_def]
-    exact Submodule.fg_span (Set.finite_range _)
-  span_eq_top := by
-    rw [geckCoordinateLattice, TauCeti.coordinateLattice_def,
-      Submodule.span_span_of_tower,
-      (Pi.basisFun ℚ (t.GeckIndex ht)).span_eq]
+  __ := TauCeti.instIsLatticeCoordinateLattice (t.GeckIndex ht)
 
 /-! ## Stability under integral matrices -/
 
@@ -304,15 +297,29 @@ theorem geckRepresentation_ringChoose_lieBasis_h_mem_geckCoordinateLattice
     t.geckRepresentation ht
         (Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).h i)) n) v ∈
       t.geckCoordinateLattice ht := by
-  rw [geckCoordinateLattice, TauCeti.coordinateLattice_def] at hv ⊢
+  rw [geckCoordinateLattice] at hv ⊢
   rw [Ring.map_choose]
-  apply ringChoose_end_apply_mem_span_of_apply_eq_intCast_smul
-    (weight := fun x => t.geckWeight ht x i) (n := n) ?_ hv
-  intro x
-  rw [Pi.basisFun_apply]
-  exact (UniversalEnvelopingAlgebra.isCartanWeightVector_iff
-    (h := (t.lieBasis ht).h) (ρ := t.geckRepresentation ht)).1
-      (t.isCartanWeightVector_geckRepresentation_single ht x) i
+  refine TauCeti.coordinateLattice_induction (t.GeckIndex ht)
+    (p := fun w => Ring.choose (t.geckRepresentation ht
+      (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).h i))) n w ∈
+        TauCeti.coordinateLattice (t.GeckIndex ht)) (v := v) hv ?_ ?_ ?_ ?_
+  · intro x
+    rw [Pi.basisFun_apply]
+    have hweight := (UniversalEnvelopingAlgebra.isCartanWeightVector_iff
+      (h := (t.lieBasis ht).h) (ρ := t.geckRepresentation ht)).1
+        (t.isCartanWeightVector_geckRepresentation_single ht x) i
+    rw [ringChoose_end_apply_of_apply_eq_smul hweight n, TauCeti.Ring.choose_intCast,
+      Int.cast_smul_eq_zsmul ℚ]
+    rw [← Pi.basisFun_apply]
+    exact zsmul_mem (TauCeti.basisFun_mem_coordinateLattice (t.GeckIndex ht) x) _
+  · rw [map_zero]
+    exact zero_mem _
+  · intro x y hx hy
+    rw [map_add]
+    exact add_mem hx hy
+  · intro z x hx
+    rw [map_zsmul]
+    exact Submodule.smul_mem _ z hx
 
 /-! ## Divided powers of the numbered root generators -/
 
@@ -383,8 +390,8 @@ theorem geckOrbit_le_geckCoordinateLattice :
   · rw [← LieAlgebra.Basis.kostantForm_def, ← t.kostantForm_def ht]
     exact hu
   · rw [← Pi.basisFun_apply (R := ℚ)]
-    rw [geckCoordinateLattice, TauCeti.coordinateLattice_def]
-    exact Submodule.subset_span (mem_range_self x)
+    rw [geckCoordinateLattice]
+    exact TauCeti.basisFun_mem_coordinateLattice (t.GeckIndex ht) x
 
 /-- **The integral orbit of the standard coordinate vectors is the coordinate lattice.** The
 containment `TauCeti.DynkinType.geckCoordinateLattice_le_geckOrbit` holds because the identity of

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Basic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.Module.Lattice
+public import TauCeti.LinearAlgebra.CoordinateLattice
 public import TauCeti.LinearAlgebra.Eigenspace.Binomial
 public import TauCeti.LinearAlgebra.RootSystem.GeckConstruction.DividedPower
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.KostantForm
@@ -83,19 +84,18 @@ variable (t : DynkinType) (ht : t.Valid)
 /-- **The coordinate `ℤ`-lattice in the pinned Geck module**, spanned by the standard coordinate
 vectors. -/
 def geckCoordinateLattice : Submodule ℤ (t.GeckIndex ht → ℚ) :=
-  Submodule.span ℤ (Set.range (Pi.basisFun ℚ (t.GeckIndex ht)))
+  TauCeti.coordinateLattice (t.GeckIndex ht)
 
 /-- A vector belongs to the Geck coordinate lattice exactly when all its coordinates are
 integer-valued. -/
 @[simp]
 theorem mem_geckCoordinateLattice_iff {v : t.GeckIndex ht → ℚ} :
     v ∈ t.geckCoordinateLattice ht ↔ ∀ i, ∃ z : ℤ, (z : ℚ) = v i := by
-  rw [geckCoordinateLattice, Module.Basis.mem_span_iff_repr_mem]
-  simp only [Pi.basisFun_repr, algebraMap_int_eq, Int.coe_castRingHom, Set.mem_range]
+  exact TauCeti.mem_coordinateLattice_iff (t.GeckIndex ht)
 
 /-- The standard coordinate basis of the Geck coordinate lattice. -/
 def geckCoordinateBasis : Module.Basis (t.GeckIndex ht) ℤ (t.geckCoordinateLattice ht) :=
-  (Pi.basisFun ℚ (t.GeckIndex ht)).restrictScalars ℤ
+  TauCeti.coordinateLatticeBasis (t.GeckIndex ht)
 
 /-- The underlying vector of a Geck coordinate basis element is the corresponding standard
 coordinate vector. -/
@@ -103,8 +103,8 @@ coordinate vector. -/
 theorem coe_geckCoordinateBasis (i : t.GeckIndex ht) :
     ((t.geckCoordinateBasis ht i : t.geckCoordinateLattice ht) : t.GeckIndex ht → ℚ) =
       Pi.single i 1 := by
-  unfold geckCoordinateBasis geckCoordinateLattice
-  rw [Module.Basis.restrictScalars_apply, Pi.basisFun_apply]
+  rw [← Pi.basisFun_apply, geckCoordinateBasis]
+  exact TauCeti.coe_coordinateLatticeBasis (t.GeckIndex ht) i
 
 /-- The coordinate basis reindexed by a finite ordinal. This is the basis shape consumed by the
 Kostant generated-group-scheme construction.
@@ -132,13 +132,11 @@ theorem intCast_geckCoordinateBasisFin_repr
     (v : (t.geckCoordinateLattice ht).toAddSubgroup) (i : Fin (t.geckDim ht)) :
     ((t.geckCoordinateBasisFin ht).repr v i : ℚ) =
       (v : t.GeckIndex ht → ℚ) ((Fintype.equivFin (t.GeckIndex ht)).symm i) := by
-  unfold geckCoordinateBasisFin geckCoordinateBasis geckCoordinateLattice at *
+  unfold geckCoordinateBasisFin geckCoordinateBasis geckCoordinateLattice
+    TauCeti.coordinateLatticeBasis TauCeti.coordinateLattice at *
   rw [Module.Basis.repr_reindex_apply]
   let v' : Submodule.span ℤ (Set.range (Pi.basisFun ℚ (t.GeckIndex ht))) :=
     ⟨v, v.property⟩
-  -- Unfolding identifies the coordinate lattice's additive-subgroup carrier with the span
-  -- carrier expected by `Basis.restrictScalars`; this is a definitional subtype equality, so
-  -- there is no propositional equality to rewrite with.
   change ((Module.Basis.restrictScalars ℤ (Pi.basisFun ℚ (t.GeckIndex ht))).repr v'
       ((Fintype.equivFin (t.GeckIndex ht)).symm i) : ℚ) = _
   rw [← eq_intCast (algebraMap ℤ ℚ) _, Module.Basis.restrictScalars_repr_apply]
@@ -163,7 +161,7 @@ theorem isCartanWeightVector_geckCoordinateBasisFin (i : Fin (t.geckDim ht)) :
 the latter contains every standard coordinate vector. -/
 theorem geckCoordinateLattice_le_geckOrbit :
     t.geckCoordinateLattice ht ≤ t.geckOrbit ht := by
-  rw [geckCoordinateLattice, Submodule.span_le]
+  rw [geckCoordinateLattice, TauCeti.coordinateLattice_def, Submodule.span_le]
   rintro - ⟨i, rfl⟩
   rw [Pi.basisFun_apply]
   exact t.single_mem_geckOrbit ht i
@@ -173,10 +171,11 @@ module. -/
 instance instIsLatticeGeckCoordinateLattice :
     Submodule.IsLattice ℚ (t.geckCoordinateLattice ht) where
   fg := by
-    rw [geckCoordinateLattice]
+    rw [geckCoordinateLattice, TauCeti.coordinateLattice_def]
     exact Submodule.fg_span (Set.finite_range _)
   span_eq_top := by
-    rw [geckCoordinateLattice, Submodule.span_span_of_tower,
+    rw [geckCoordinateLattice, TauCeti.coordinateLattice_def,
+      Submodule.span_span_of_tower,
       (Pi.basisFun ℚ (t.GeckIndex ht)).span_eq]
 
 /-! ## Stability under integral matrices -/
@@ -305,7 +304,7 @@ theorem geckRepresentation_ringChoose_lieBasis_h_mem_geckCoordinateLattice
     t.geckRepresentation ht
         (Ring.choose (_root_.UniversalEnvelopingAlgebra.ι ℚ ((t.lieBasis ht).h i)) n) v ∈
       t.geckCoordinateLattice ht := by
-  rw [geckCoordinateLattice] at hv ⊢
+  rw [geckCoordinateLattice, TauCeti.coordinateLattice_def] at hv ⊢
   rw [Ring.map_choose]
   apply ringChoose_end_apply_mem_span_of_apply_eq_intCast_smul
     (weight := fun x => t.geckWeight ht x i) (n := n) ?_ hv
@@ -384,6 +383,7 @@ theorem geckOrbit_le_geckCoordinateLattice :
   · rw [← LieAlgebra.Basis.kostantForm_def, ← t.kostantForm_def ht]
     exact hu
   · rw [← Pi.basisFun_apply (R := ℚ)]
+    rw [geckCoordinateLattice, TauCeti.coordinateLattice_def]
     exact Submodule.subset_span (mem_range_self x)
 
 /-- **The integral orbit of the standard coordinate vectors is the coordinate lattice.** The

--- a/TauCeti/RingTheory/DividedPowers/Associative.lean
+++ b/TauCeti/RingTheory/DividedPowers/Associative.lean
@@ -40,6 +40,8 @@ definition is made here.
   antidiagonal sum.
 * `TauCeti.Associative.dividedPower_sub`: the corresponding signed expansion for a difference.
 * `TauCeti.Associative.map_dividedPower`: divided powers are natural under algebra homomorphisms.
+* `TauCeti.Associative.dividedPower_apply_mem_of_pow_two_eq_zero`: a square-zero endomorphism
+  preserving an integral submodule has all divided powers preserving it.
 * `TauCeti.Associative.dividedPower_units_conj`: divided powers are equivariant for conjugation by
   a unit.
 
@@ -81,6 +83,26 @@ theorem dividedPower_one (x : A) : dividedPower 1 x = x := by
 @[simp]
 theorem dividedPower_eval_zero {n : ℕ} (hn : n ≠ 0) : dividedPower n (0 : A) = 0 := by
   simp [dividedPower_def, hn]
+
+section ModuleEnd
+
+variable {V : Type*} [AddCommGroup V] [Module ℚ V]
+
+/-- Every divided power of a square-zero endomorphism preserves an integral submodule once the
+endomorphism itself does. -/
+theorem dividedPower_apply_mem_of_pow_two_eq_zero
+    (f : Module.End ℚ V) (N : Submodule ℤ V) (hf : f ^ 2 = 0)
+    (hN : ∀ {v : V}, v ∈ N → f v ∈ N) (n : ℕ) {v : V} (hv : v ∈ N) :
+    dividedPower n f v ∈ N := by
+  match n with
+  | 0 => rwa [dividedPower_zero, Module.End.one_apply]
+  | 1 => rw [dividedPower_one]; exact hN hv
+  | n + 2 =>
+      rw [dividedPower_def, pow_eq_zero_of_le (m := 2) (by omega) hf, smul_zero,
+        LinearMap.zero_apply]
+      exact zero_mem _
+
+end ModuleEnd
 
 /-- Multiplying a divided power by its factorial recovers the ordinary power. -/
 theorem factorial_smul_dividedPower_eq_pow (n : ℕ) (x : A) :


### PR DESCRIPTION
This PR extracts the standard rational coordinate lattice and its restricted-scalars basis into a shared index-generic construction, then migrates the type-A and Geck carriers to it. It also factors their square-zero divided-power stability argument into a reusable endomorphism lemma, providing the remaining shared-lattice prerequisite for #4628.

Roadmap: ReductiveGroups

:robot: Prepared with OpenAI Codex
