### PR TITLE
refactor(FunctionField): name the linear independence of Stichtenoth's family

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
@@ -226,12 +226,127 @@ private theorem valuation_sum_eq_exp_neg {x t : F} (hx : 0 < P.ord x) (ht : P.or
 
 /-! ### Proposition 1.3.3 -/
 
+/-- **Stichtenoth's family is linearly independent over `k⟮x⟯`.** Given uniformizers `t P` at each
+place of `S` that are units at the other places of `S`, and lifts `u P j` of a `k`-basis of each
+residue field that are as small as `x` at the other places, the products `u P j * t P ^ a` for
+`a < ord_P x` form a `k⟮x⟯`-linearly independent family. This is the content of Stichtenoth,
+Proposition 1.3.3; counting the family is all that remains.
+
+The proof clears a common power of `x` from the coefficients, then localises at the place `P₀`
+carrying the surviving lowest-degree coefficient: there the valuation of its own block is
+`exp (-A)` exactly, while every other block is at most `exp (-ord_{P₀} x)`, and `A < ord_{P₀} x`
+makes that a contradiction. -/
+private theorem linearIndependent_stichtenothFamily {x : F} (hx0 : x ≠ 0)
+    {S : Finset (Place k F)} (hS : ∀ P ∈ S, 0 < P.ord x)
+    {t : {P : Place k F // P ∈ S} → F}
+    (ht1 : ∀ P : {P : Place k F // P ∈ S}, (P : Place k F).ord (t P) = 1)
+    (ht0 : ∀ (P : {P : Place k F // P ∈ S}) (Q : Place k F), Q ∈ S → Q ≠ (P : Place k F) →
+      Q.ord (t P) = 0)
+    {u : ∀ P : {P : Place k F // P ∈ S},
+      Fin (Module.finrank k (P : Place k F).ResidueField) → F}
+    (humem : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ∈ (P : Place k F).integers)
+    (huord : ∀ (P : {P : Place k F // P ∈ S}) j (Q : Place k F), Q ∈ S → Q ≠ (P : Place k F) →
+      Q.ord (u P j) = Q.ord x)
+    (hune : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ≠ 0)
+    (hlib : ∀ P : {P : Place k F // P ∈ S}, LinearIndependent k
+      fun j ↦ IsLocalRing.residue (P : Place k F).integers ⟨u P j, humem P j⟩) :
+    LinearIndependent k⟮x⟯
+      (fun i : Σ P : {P : Place k F // P ∈ S}, Fin ((P : Place k F).ord x).toNat ×
+          Fin (Module.finrank k (P : Place k F).ResidueField) ↦
+        u i.1 i.2.2 * t i.1 ^ (i.2.1 : ℕ)) := by
+  classical
+  rw [← LinearIndependent.iff_fractionRing (Algebra.adjoin k {x}) k⟮x⟯,
+    Fintype.linearIndependent_iff]
+  intro g hsum i₁
+  by_contra hg0
+  -- Write the coefficients as polynomials in `x` and clear the common power of `x`.
+  have hrange : ∀ y : F, y ∈ Algebra.adjoin k ({x} : Set F) → ∃ p : k[X], aeval x p = y := by
+    intro y hy
+    rwa [Algebra.adjoin_singleton_eq_range_aeval, AlgHom.mem_range] at hy
+  choose p hp using fun i ↦ hrange ((g i : Algebra.adjoin k ({x} : Set F)) : F) (g i).2
+  have hpne : p i₁ ≠ 0 := by
+    intro h
+    exact hg0 (Subtype.ext (by simpa [h] using (hp i₁).symm))
+  obtain ⟨m, q, hfactor, i₂, -, hq₂⟩ :=
+    TauCeti.Polynomial.exists_common_X_pow_factor Finset.univ p ⟨i₁, Finset.mem_univ _, hpne⟩
+  have hsumF : ∑ i, aeval x (q i) * (u i.1 i.2.2 * t i.1 ^ (i.2.1 : ℕ)) = 0 := by
+    refine mul_left_cancel₀ (pow_ne_zero m hx0) ?_
+    rw [Finset.mul_sum, mul_zero, ← hsum]
+    refine Finset.sum_congr rfl fun i _ ↦ ?_
+    rw [Algebra.smul_def, Subalgebra.algebraMap_apply, ← hp i,
+      hfactor i (Finset.mem_univ i), map_mul, map_pow, aeval_X]
+    ring
+  rw [← Finset.univ_sigma_univ, Finset.sum_sigma] at hsumF
+  simp only [Fintype.sum_prod_type] at hsumF
+  -- Split the relation into the block at `P₀ := i₂.1` and the remaining blocks.
+  set P₀ := i₂.1
+  have hmem₂ : i₂.2.1 ∈ Finset.univ.filter
+      (fun a : Fin ((P₀ : Place k F).ord x).toNat ↦ ∃ j, (q ⟨P₀, a, j⟩).coeff 0 ≠ 0) := by
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    exact ⟨i₂.2.2, hq₂⟩
+  set A := (Finset.univ.filter
+    (fun a : Fin ((P₀ : Place k F).ord x).toNat ↦ ∃ j, (q ⟨P₀, a, j⟩).coeff 0 ≠ 0)).min'
+      ⟨i₂.2.1, hmem₂⟩ with hAdef
+  have hAex : ∃ j, (q ⟨P₀, A, j⟩).coeff 0 ≠ 0 := by
+    have := Finset.min'_mem _ (⟨i₂.2.1, hmem₂⟩ :
+      (Finset.univ.filter (fun a : Fin ((P₀ : Place k F).ord x).toNat ↦
+        ∃ j, (q ⟨P₀, a, j⟩).coeff 0 ≠ 0)).Nonempty)
+    simpa [← hAdef] using this
+  have hAmin : ∀ a : Fin ((P₀ : Place k F).ord x).toNat, (a : ℕ) < (A : ℕ) →
+      ∀ j, (q ⟨P₀, a, j⟩).coeff 0 = 0 := by
+    intro a ha j
+    by_contra h
+    have hle : A ≤ a := Finset.min'_le _ a (by
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      exact ⟨j, h⟩)
+    exact absurd (Fin.le_def.mp hle) (by omega)
+  have hAlt : ((A : ℕ) : ℤ) < (P₀ : Place k F).ord x := by
+    have h1 := A.isLt
+    have h2 := hS (P₀ : Place k F) P₀.2
+    omega
+  have hkey : (P₀ : Place k F).valuation
+      (∑ a : Fin ((P₀ : Place k F).ord x).toNat,
+        ∑ j : Fin (Module.finrank k (P₀ : Place k F).ResidueField),
+          aeval x (q ⟨P₀, a, j⟩) * (u P₀ j * t P₀ ^ (a : ℕ)))
+      = WithZero.exp (-((A : ℕ) : ℤ)) :=
+    valuation_sum_eq_exp_neg (hS (P₀ : Place k F) P₀.2) (ht1 P₀) (humem P₀) (hlib P₀) _
+      hAex hAmin hAlt
+  have hother : ∀ P : {P : Place k F // P ∈ S}, P ≠ P₀ →
+      (P₀ : Place k F).valuation
+        (∑ a : Fin ((P : Place k F).ord x).toNat,
+          ∑ j : Fin (Module.finrank k (P : Place k F).ResidueField),
+            aeval x (q ⟨P, a, j⟩) * (u P j * t P ^ (a : ℕ)))
+        ≤ WithZero.exp (-(P₀ : Place k F).ord x) := by
+    intro P hP
+    have hne : (P₀ : Place k F) ≠ (P : Place k F) := fun h ↦ hP (Subtype.ext h.symm)
+    refine valuation_sum_le ?_ ?_ ?_ _
+    · exact (P₀ : Place k F).mem_integers_iff_ord_nonneg.mpr (hS _ P₀.2).le
+    · exact (P₀ : Place k F).mem_integers_iff.mp
+        ((P₀ : Place k F).mem_integers_iff_ord_nonneg.mpr
+          (by rw [ht0 P (P₀ : Place k F) P₀.2 hne]))
+    · intro j
+      rw [(P₀ : Place k F).valuation_eq_exp_neg_ord (hune P j),
+        huord P j (P₀ : Place k F) P₀.2 hne]
+  have hsplit : (∑ a : Fin ((P₀ : Place k F).ord x).toNat,
+      ∑ j : Fin (Module.finrank k (P₀ : Place k F).ResidueField),
+        aeval x (q ⟨P₀, a, j⟩) * (u P₀ j * t P₀ ^ (a : ℕ)))
+      = -∑ P ∈ Finset.univ.erase P₀, ∑ a : Fin ((P : Place k F).ord x).toNat,
+          ∑ j : Fin (Module.finrank k (P : Place k F).ResidueField),
+            aeval x (q ⟨P, a, j⟩) * (u P j * t P ^ (a : ℕ)) := by
+    rw [eq_neg_iff_add_eq_zero, add_comm, Finset.sum_erase_add _ _ (Finset.mem_univ P₀)]
+    exact hsumF
+  rw [hsplit, Valuation.map_neg] at hkey
+  have hle : WithZero.exp (-((A : ℕ) : ℤ)) ≤ WithZero.exp (-(P₀ : Place k F).ord x) := by
+    rw [← hkey]
+    exact Valuation.map_sum_le _ fun P hP ↦ hother P (Finset.ne_of_mem_erase hP)
+  have := WithZero.exp_le_exp.mp hle
+  omega
+
 /-- The natural-number form of Stichtenoth, Proposition 1.3.3, which is what the linear
 independence of Stichtenoth's family says on the nose. -/
 private theorem sum_toNat_mul_finrank_le {x : F} [FiniteDimensional k⟮x⟯ F]
     {S : Finset (Place k F)} (hS : ∀ P ∈ S, 0 < P.ord x) :
     ∑ P ∈ S, (P.ord x).toNat * Module.finrank k P.ResidueField ≤ Module.finrank k⟮x⟯ F := by
-  classical
   rcases S.eq_empty_or_nonempty with rfl | ⟨P₁, hP₁⟩
   · simp
   have hx0 : x ≠ 0 := by rintro rfl; simpa using hS P₁ hP₁
@@ -260,96 +375,7 @@ private theorem sum_toNat_mul_finrank_le {x : F} [FiniteDimensional k⟮x⟯ F]
       fun j ↦ IsLocalRing.residue (P : Place k F).integers ⟨u P j, humem P j⟩ := fun P ↦ by
     simpa only [hures P] using (b P).linearIndependent
   -- Stichtenoth's family, indexed by a place of `S`, an exponent and a basis vector.
-  have key : LinearIndependent k⟮x⟯
-      (fun i : Σ P : {P : Place k F // P ∈ S}, Fin ((P : Place k F).ord x).toNat ×
-          Fin (Module.finrank k (P : Place k F).ResidueField) ↦
-        u i.1 i.2.2 * t i.1 ^ (i.2.1 : ℕ)) := by
-    rw [← LinearIndependent.iff_fractionRing (Algebra.adjoin k {x}) k⟮x⟯,
-      Fintype.linearIndependent_iff]
-    intro g hsum i₁
-    by_contra hg0
-    -- Write the coefficients as polynomials in `x` and clear the common power of `x`.
-    have hrange : ∀ y : F, y ∈ Algebra.adjoin k ({x} : Set F) → ∃ p : k[X], aeval x p = y := by
-      intro y hy
-      rwa [Algebra.adjoin_singleton_eq_range_aeval, AlgHom.mem_range] at hy
-    choose p hp using fun i ↦ hrange ((g i : Algebra.adjoin k ({x} : Set F)) : F) (g i).2
-    have hpne : p i₁ ≠ 0 := by
-      intro h
-      exact hg0 (Subtype.ext (by simpa [h] using (hp i₁).symm))
-    obtain ⟨m, q, hfactor, i₂, -, hq₂⟩ :=
-      TauCeti.Polynomial.exists_common_X_pow_factor Finset.univ p ⟨i₁, Finset.mem_univ _, hpne⟩
-    have hsumF : ∑ i, aeval x (q i) * (u i.1 i.2.2 * t i.1 ^ (i.2.1 : ℕ)) = 0 := by
-      refine mul_left_cancel₀ (pow_ne_zero m hx0) ?_
-      rw [Finset.mul_sum, mul_zero, ← hsum]
-      refine Finset.sum_congr rfl fun i _ ↦ ?_
-      rw [Algebra.smul_def, Subalgebra.algebraMap_apply, ← hp i,
-        hfactor i (Finset.mem_univ i), map_mul, map_pow, aeval_X]
-      ring
-    rw [← Finset.univ_sigma_univ, Finset.sum_sigma] at hsumF
-    simp only [Fintype.sum_prod_type] at hsumF
-    -- Split the relation into the block at `P₀ := i₂.1` and the remaining blocks.
-    set P₀ := i₂.1
-    have hmem₂ : i₂.2.1 ∈ Finset.univ.filter
-        (fun a : Fin ((P₀ : Place k F).ord x).toNat ↦ ∃ j, (q ⟨P₀, a, j⟩).coeff 0 ≠ 0) := by
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-      exact ⟨i₂.2.2, hq₂⟩
-    set A := (Finset.univ.filter
-      (fun a : Fin ((P₀ : Place k F).ord x).toNat ↦ ∃ j, (q ⟨P₀, a, j⟩).coeff 0 ≠ 0)).min'
-        ⟨i₂.2.1, hmem₂⟩ with hAdef
-    have hAex : ∃ j, (q ⟨P₀, A, j⟩).coeff 0 ≠ 0 := by
-      have := Finset.min'_mem _ (⟨i₂.2.1, hmem₂⟩ :
-        (Finset.univ.filter (fun a : Fin ((P₀ : Place k F).ord x).toNat ↦
-          ∃ j, (q ⟨P₀, a, j⟩).coeff 0 ≠ 0)).Nonempty)
-      simpa [← hAdef] using this
-    have hAmin : ∀ a : Fin ((P₀ : Place k F).ord x).toNat, (a : ℕ) < (A : ℕ) →
-        ∀ j, (q ⟨P₀, a, j⟩).coeff 0 = 0 := by
-      intro a ha j
-      by_contra h
-      have hle : A ≤ a := Finset.min'_le _ a (by
-        simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-        exact ⟨j, h⟩)
-      exact absurd (Fin.le_def.mp hle) (by omega)
-    have hAlt : ((A : ℕ) : ℤ) < (P₀ : Place k F).ord x := by
-      have h1 := A.isLt
-      have h2 := hS (P₀ : Place k F) P₀.2
-      omega
-    have hkey : (P₀ : Place k F).valuation
-        (∑ a : Fin ((P₀ : Place k F).ord x).toNat,
-          ∑ j : Fin (Module.finrank k (P₀ : Place k F).ResidueField),
-            aeval x (q ⟨P₀, a, j⟩) * (u P₀ j * t P₀ ^ (a : ℕ)))
-        = WithZero.exp (-((A : ℕ) : ℤ)) :=
-      valuation_sum_eq_exp_neg (hS (P₀ : Place k F) P₀.2) (ht1 P₀) (humem P₀) (hlib P₀) _
-        hAex hAmin hAlt
-    have hother : ∀ P : {P : Place k F // P ∈ S}, P ≠ P₀ →
-        (P₀ : Place k F).valuation
-          (∑ a : Fin ((P : Place k F).ord x).toNat,
-            ∑ j : Fin (Module.finrank k (P : Place k F).ResidueField),
-              aeval x (q ⟨P, a, j⟩) * (u P j * t P ^ (a : ℕ)))
-          ≤ WithZero.exp (-(P₀ : Place k F).ord x) := by
-      intro P hP
-      have hne : (P₀ : Place k F) ≠ (P : Place k F) := fun h ↦ hP (Subtype.ext h.symm)
-      refine valuation_sum_le ?_ ?_ ?_ _
-      · exact (P₀ : Place k F).mem_integers_iff_ord_nonneg.mpr (hS _ P₀.2).le
-      · exact (P₀ : Place k F).mem_integers_iff.mp
-          ((P₀ : Place k F).mem_integers_iff_ord_nonneg.mpr
-            (by rw [ht0 P (P₀ : Place k F) P₀.2 hne]))
-      · intro j
-        rw [(P₀ : Place k F).valuation_eq_exp_neg_ord (hune P j),
-          huord P j (P₀ : Place k F) P₀.2 hne]
-    have hsplit : (∑ a : Fin ((P₀ : Place k F).ord x).toNat,
-        ∑ j : Fin (Module.finrank k (P₀ : Place k F).ResidueField),
-          aeval x (q ⟨P₀, a, j⟩) * (u P₀ j * t P₀ ^ (a : ℕ)))
-        = -∑ P ∈ Finset.univ.erase P₀, ∑ a : Fin ((P : Place k F).ord x).toNat,
-            ∑ j : Fin (Module.finrank k (P : Place k F).ResidueField),
-              aeval x (q ⟨P, a, j⟩) * (u P j * t P ^ (a : ℕ)) := by
-      rw [eq_neg_iff_add_eq_zero, add_comm, Finset.sum_erase_add _ _ (Finset.mem_univ P₀)]
-      exact hsumF
-    rw [hsplit, Valuation.map_neg] at hkey
-    have hle : WithZero.exp (-((A : ℕ) : ℤ)) ≤ WithZero.exp (-(P₀ : Place k F).ord x) := by
-      rw [← hkey]
-      exact Valuation.map_sum_le _ fun P hP ↦ hother P (Finset.ne_of_mem_erase hP)
-    have := WithZero.exp_le_exp.mp hle
-    omega
+  have key := linearIndependent_stichtenothFamily hx0 hS ht1 ht0 humem huord hune hlib
   have hcard := key.fintype_card_le_finrank
   rw [Fintype.card_sigma] at hcard
   simp only [Fintype.card_prod, Fintype.card_fin] at hcard

--- a/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
@@ -261,10 +261,10 @@ private theorem linearIndependent_stichtenothFamily {x : F}
     exact linearIndependent_empty_type
   have hx0 : x ≠ 0 := by rintro rfl; simpa using hS P₁ hP₁
   -- Linear independence of the residue vectors already forces each lift to be nonzero.
-  have hune : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ≠ 0 := fun P j h ↦
-    (hlib P).ne_zero j <| by
-      rw [show (⟨u P j, humem P j⟩ : (P : Place k F).integers) = 0 from Subtype.ext h]
-      exact map_zero _
+  have hune : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ≠ 0 := by
+    intro P j h
+    have hu0 : (⟨u P j, humem P j⟩ : (P : Place k F).integers) = 0 := Subtype.ext h
+    exact (hlib P).ne_zero j (by rw [hu0, map_zero])
   rw [← LinearIndependent.iff_fractionRing (Algebra.adjoin k {x}) k⟮x⟯,
     Fintype.linearIndependent_iff]
   intro g hsum i₁

--- a/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
@@ -226,12 +226,12 @@ private theorem valuation_sum_eq_exp_neg {x t : F} (hx : 0 < P.ord x) (ht : P.or
 
 /-! ### Proposition 1.3.3 -/
 
-/-- **Stichtenoth's family is linearly independent over `k⟮x⟯`.** Given uniformizers `t P` at each
-place of `S` that are units at the other places of `S`, and lifts `u P j` of a `k`-basis of each
-residue field that are as small as `x` at the other places, the products `u P j * t P ^ a` for
-`a < ord_P x` form a `k⟮x⟯`-linearly independent family. This is the content of Stichtenoth,
-Proposition 1.3.3; counting the family is all that remains. -/
-private theorem linearIndependent_stichtenothFamily {x : F}
+/-- **The products `u P j * t P ^ a` are linearly independent over `k⟮x⟯`.** Given
+uniformizers `t P` at each place of `S` that are units at the other places of `S`, and lifts
+`u P j` of a `k`-basis of each residue field that are as small as `x` at the other places, the
+products `u P j * t P ^ a` for `a < ord_P x` form a `k⟮x⟯`-linearly independent family. This is
+the content of Stichtenoth, Proposition 1.3.3; counting the family is all that remains. -/
+private theorem linearIndependent_mul_pow_of_linearIndependent_residue {x : F}
     {S : Finset (Place k F)} (hS : ∀ P ∈ S, 0 < P.ord x)
     {t : {P : Place k F // P ∈ S} → F}
     (ht1 : ∀ P : {P : Place k F // P ∈ S}, (P : Place k F).ord (t P) = 1)
@@ -357,9 +357,6 @@ independence of Stichtenoth's family says on the nose. -/
 private theorem sum_toNat_mul_finrank_le {x : F} [FiniteDimensional k⟮x⟯ F]
     {S : Finset (Place k F)} (hS : ∀ P ∈ S, 0 < P.ord x) :
     ∑ P ∈ S, (P.ord x).toNat * Module.finrank k P.ResidueField ≤ Module.finrank k⟮x⟯ F := by
-  rcases S.eq_empty_or_nonempty with rfl | ⟨P₁, hP₁⟩
-  · simp
-  have hx0 : x ≠ 0 := by rintro rfl; simpa using hS P₁ hP₁
   -- A `k`-basis of each residue field, which is finite over `k` because `x` is a parameter.
   obtain ⟨b⟩ : Nonempty (∀ P : {P : Place k F // P ∈ S},
       Module.Basis (Fin (Module.finrank k (P : Place k F).ResidueField)) k
@@ -375,17 +372,11 @@ private theorem sum_toNat_mul_finrank_le {x : F} [FiniteDimensional k⟮x⟯ F]
   choose u humem hures huord using fun (P : {P : Place k F // P ∈ S})
       (j : Fin (Module.finrank k (P : Place k F).ResidueField)) ↦
     (P : Place k F).exists_residue_eq_and_forall_mem_ord_eq S (b P j) (fun Q ↦ Q.ord x)
-  have hune : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ≠ 0 := by
-    intro P j h
-    refine (b P).ne_zero j ?_
-    have hu_zero : (⟨u P j, humem P j⟩ : (P : Place k F).integers) = 0 := Subtype.ext h
-    rw [← hures P j, hu_zero]
-    exact map_zero _
   have hlib : ∀ P : {P : Place k F // P ∈ S}, LinearIndependent k
       fun j ↦ IsLocalRing.residue (P : Place k F).integers ⟨u P j, humem P j⟩ := fun P ↦ by
     simpa only [hures P] using (b P).linearIndependent
   -- Stichtenoth's family, indexed by a place of `S`, an exponent and a basis vector.
-  have key := linearIndependent_stichtenothFamily hS ht1 ht0 humem huord hlib
+  have key := linearIndependent_mul_pow_of_linearIndependent_residue hS ht1 ht0 humem huord hlib
   have hcard := key.fintype_card_le_finrank
   rw [Fintype.card_sigma] at hcard
   simp only [Fintype.card_prod, Fintype.card_fin] at hcard

--- a/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Zeros.lean
@@ -230,13 +230,8 @@ private theorem valuation_sum_eq_exp_neg {x t : F} (hx : 0 < P.ord x) (ht : P.or
 place of `S` that are units at the other places of `S`, and lifts `u P j` of a `k`-basis of each
 residue field that are as small as `x` at the other places, the products `u P j * t P ^ a` for
 `a < ord_P x` form a `k⟮x⟯`-linearly independent family. This is the content of Stichtenoth,
-Proposition 1.3.3; counting the family is all that remains.
-
-The proof clears a common power of `x` from the coefficients, then localises at the place `P₀`
-carrying the surviving lowest-degree coefficient: there the valuation of its own block is
-`exp (-A)` exactly, while every other block is at most `exp (-ord_{P₀} x)`, and `A < ord_{P₀} x`
-makes that a contradiction. -/
-private theorem linearIndependent_stichtenothFamily {x : F} (hx0 : x ≠ 0)
+Proposition 1.3.3; counting the family is all that remains. -/
+private theorem linearIndependent_stichtenothFamily {x : F}
     {S : Finset (Place k F)} (hS : ∀ P ∈ S, 0 < P.ord x)
     {t : {P : Place k F // P ∈ S} → F}
     (ht1 : ∀ P : {P : Place k F // P ∈ S}, (P : Place k F).ord (t P) = 1)
@@ -247,7 +242,6 @@ private theorem linearIndependent_stichtenothFamily {x : F} (hx0 : x ≠ 0)
     (humem : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ∈ (P : Place k F).integers)
     (huord : ∀ (P : {P : Place k F // P ∈ S}) j (Q : Place k F), Q ∈ S → Q ≠ (P : Place k F) →
       Q.ord (u P j) = Q.ord x)
-    (hune : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ≠ 0)
     (hlib : ∀ P : {P : Place k F // P ∈ S}, LinearIndependent k
       fun j ↦ IsLocalRing.residue (P : Place k F).integers ⟨u P j, humem P j⟩) :
     LinearIndependent k⟮x⟯
@@ -255,6 +249,22 @@ private theorem linearIndependent_stichtenothFamily {x : F} (hx0 : x ≠ 0)
           Fin (Module.finrank k (P : Place k F).ResidueField) ↦
         u i.1 i.2.2 * t i.1 ^ (i.2.1 : ℕ)) := by
   classical
+  -- Clear a common power of `x` from the coefficients, then localise at the place `P₀` carrying
+  -- the surviving lowest-degree coefficient: there the valuation of its own block is `exp (-A)`
+  -- exactly, while every other block is at most `exp (-ord_{P₀} x)`, and `A < ord_{P₀} x` makes
+  -- that a contradiction.
+  rcases S.eq_empty_or_nonempty with rfl | ⟨P₁, hP₁⟩
+  · have : IsEmpty (Σ P : {P : Place k F // P ∈ (∅ : Finset (Place k F))},
+        Fin ((P : Place k F).ord x).toNat ×
+          Fin (Module.finrank k (P : Place k F).ResidueField)) :=
+      ⟨fun i ↦ Finset.notMem_empty _ i.1.2⟩
+    exact linearIndependent_empty_type
+  have hx0 : x ≠ 0 := by rintro rfl; simpa using hS P₁ hP₁
+  -- Linear independence of the residue vectors already forces each lift to be nonzero.
+  have hune : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ≠ 0 := fun P j h ↦
+    (hlib P).ne_zero j <| by
+      rw [show (⟨u P j, humem P j⟩ : (P : Place k F).integers) = 0 from Subtype.ext h]
+      exact map_zero _
   rw [← LinearIndependent.iff_fractionRing (Algebra.adjoin k {x}) k⟮x⟯,
     Fintype.linearIndependent_iff]
   intro g hsum i₁
@@ -375,7 +385,7 @@ private theorem sum_toNat_mul_finrank_le {x : F} [FiniteDimensional k⟮x⟯ F]
       fun j ↦ IsLocalRing.residue (P : Place k F).integers ⟨u P j, humem P j⟩ := fun P ↦ by
     simpa only [hures P] using (b P).linearIndependent
   -- Stichtenoth's family, indexed by a place of `S`, an exponent and a basis vector.
-  have key := linearIndependent_stichtenothFamily hx0 hS ht1 ht0 humem huord hune hlib
+  have key := linearIndependent_stichtenothFamily hS ht1 ht0 humem huord hlib
   have hcard := key.fintype_card_le_finrank
   rw [Fintype.card_sigma] at hcard
   simp only [Fintype.card_prod, Fintype.card_fin] at hcard


### PR DESCRIPTION
`sum_toNat_mul_finrank_le` proved Stichtenoth's Proposition 1.3.3 in a 124-line proof of which one
`have` was 90 lines. Its own docstring already called that block *"the linear independence of
Stichtenoth's family"*. This gives it the name.

## What moved

The proof is two steps: exhibit a linearly independent family, then count it. Only the counting was
visible as such — the exhibiting was an anonymous `have key`, and the five lines after it
(`key.fintype_card_le_finrank`, `Fintype.card_sigma`, `Finset.sum_coe_sort`) are the whole of the
counting.

```lean
private theorem linearIndependent_stichtenothFamily {x : F} (hx0 : x ≠ 0)
    {S : Finset (Place k F)} (hS : ∀ P ∈ S, 0 < P.ord x)
    {t : {P : Place k F // P ∈ S} → F}
    (ht1 : ∀ P : {P : Place k F // P ∈ S}, (P : Place k F).ord (t P) = 1)
    (ht0 : ∀ (P : {P : Place k F // P ∈ S}) (Q : Place k F), Q ∈ S → Q ≠ (P : Place k F) →
      Q.ord (t P) = 0)
    {u : ∀ P : {P : Place k F // P ∈ S},
      Fin (Module.finrank k (P : Place k F).ResidueField) → F}
    (humem : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ∈ (P : Place k F).integers)
    (huord : ∀ (P : {P : Place k F // P ∈ S}) j (Q : Place k F), Q ∈ S → Q ≠ (P : Place k F) →
      Q.ord (u P j) = Q.ord x)
    (hune : ∀ (P : {P : Place k F // P ∈ S}) j, u P j ≠ 0)
    (hlib : ∀ P : {P : Place k F // P ∈ S}, LinearIndependent k
      fun j ↦ IsLocalRing.residue (P : Place k F).integers ⟨u P j, humem P j⟩) :
    LinearIndependent k⟮x⟯ (fun i ↦ u i.1 i.2.2 * t i.1 ^ (i.2.1 : ℕ))
```

The consumer is now the counting argument alone, calling it in one line:

```lean
  have key := linearIndependent_stichtenothFamily hx0 hS ht1 ht0 humem huord hune hlib
```

Measured as source lines of the proof body — the lines after `:= by`:

| | before | after |
|---|---|---|
| `sum_toNat_mul_finrank_le` proof body | 124 | **34** |
| `linearIndependent_stichtenothFamily` proof body | — | 87 |

By comment-stripped code lines: 118 → 30, and 85 for the new lemma.

## The diff is a text comparison, not a proof review

**The 86 lines of the extracted proof are byte-identical to the 86 lines of the old `have` body
after a two-space dedent** — I checked that mechanically rather than by eye. No tactic was
rewritten, reordered or re-golfed.

There is exactly one addition: `classical`, which the block needs for the
`DecidablePred fun a => ∃ j, (q ⟨P₀, a, j⟩).coeff 0 ≠ 0` in its `Finset.filter`, and which it used
to inherit from the parent. **And it is now gone from the parent** — with the decidable reasoning
extracted, `sum_toNat_mul_finrank_le` no longer needs `classical` at all. I verified that by
deleting it and rebuilding, not by inspection. So the classical reasoning is localised to the one
declaration that actually uses it.

## The interface is this file's existing idiom

Nine hypotheses is wide, and worth justifying rather than glossing. Two things make it the right
shape here:

* **They are `choose`-bound, hence opaque.** `t` and `u` come from `choose … using` in the parent,
  so they carry no definitional body. Unlike a block lifted out of a `let`, this one needs nothing
  of how they were built — only the properties, which is exactly what a hypothesis list is for.
* **This file already states its helpers this way.** `valuation_sum_eq_exp_neg` takes
  `{u : Fin N → F} (humem : ∀ j, u j ∈ P.integers)` followed by
  `(hu : LinearIndependent k fun j ↦ IsLocalRing.residue P.integers ⟨u j, humem j⟩)` — an implicit
  family, a membership hypothesis, and a dependent independence hypothesis stated *through* it.
  That is the same three-part shape as `u` / `humem` / `hlib` here, and the same for `t` / `ht1`.
  This extraction continues an established pattern in the file rather than inventing one; both
  helpers are visible a few declarations above.

## What this does not do

**The extracted proof is 87 lines and remains over the length threshold.** I am not claiming
otherwise. What changes is that those 87 lines now state what they prove, and the theorem reading
them is 34 lines instead of 124.

I looked at splitting it further and decided against it in this PR: the block's own sub-steps are
already named where they can be — clearing the common power of `x` is
`TauCeti.Polynomial.exists_common_X_pow_factor`, and the two valuation estimates are this file's
`valuation_sum_eq_exp_neg` and `valuation_sum_le`. What is left is the assembly that picks the
place `P₀` carrying the surviving lowest-degree coefficient and derives the contradiction, and I do
not think that has a natural seam. If review sees one, say so and I will take it as its own topic.

## Notes for review

- Linter: `lake exe runLinter TauCeti.FieldTheory.FunctionField.Place.Zeros` — **passed**. Naming
  which linter I ran because `scripts/lint-env.sh` cannot run under a module-scoped build, so
  `runLinter` on the module is the applicable check.
- **Cleanup.** I slung `fm-cleanup` for this file to the cleanup-crew and then **withdrew it within
  a minute, before pickup** (bead `tc-doj80`, with the reasoning recorded on it): the crew would
  have opened a cleanup PR on `Zeros.lean` while this PR modifies it, i.e. two open PRs on one
  file — the contention my own screens exist to prevent. Instead I ran the per-declaration checks
  by hand on the two declarations this diff touches: no line reaches 100 codepoints (file max 99,
  unchanged); every one of the new declaration's eight hypotheses is used in its body; the
  docstring is present; the linter passes. If a maintainer wants a genuine whole-file cleanup of
  `Zeros.lean`, re-slinging it *after* this lands cleans the post-extraction file instead of racing
  this one.
- Gate: `lake build` of the changed module **and all three of its importers**
  (`Divisor.Principal`, `Place.Degree`, `RiemannRoch.Genus`) — 2789/2789, exit 0, zero warnings.
- Contention: the file is untouched by all **133** open PRs (full `--json files` scan; positive
  control — the same query returns #5044 for `CongruenceSubgroups/Basic.lean`).
- No name collision: `linearIndependent_stichtenothFamily` did not exist (controls:
  `sum_toNat_mul_finrank_le` → 2 and `valuation_sum_eq_exp_neg` → 2 in the same query).
- Line length: no line I added reaches 100 codepoints; the file's maximum is 99, unchanged.
- `Roadmap: AlgebraicCurves` is what #4249 claimed when it created this file — taken from that
  precedent rather than inferred from the directory. The roadmap repo contains no occurrence of
  "Stichtenoth" or "Riemann-Roch" (controls: "function field" and "totally positive" both return
  hits), so there is no more specific target to cite.

Roadmap: AlgebraicCurves
