### PR TITLE
refactor(Place): get the constant residue at infinity from Euclidean division

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
@@ -91,67 +91,41 @@ noncomputable def infinity : Place F W.FunctionField where
 theorem valuation_infinity : (infinity W).valuation = W.infinityPlace := by
   rw [infinity]
 
+/-- Subtracting a suitable constant takes a rational function of non-positive `intDegree` to one
+of strictly negative `intDegree` — or to `0`, whose `intDegree` is `0` rather than `-∞`, which is
+why the conclusion is a disjunction. Equivalently, the residue of `A` at the infinite place of
+`F(X)` is a constant: it is the Euclidean quotient of `A.num` by the monic `A.denom`, and what is
+left over is the Euclidean remainder. -/
 private theorem exists_sub_C_eq_zero_or_intDegree_neg (A : RatFunc F)
     (hA : A.intDegree ≤ 0) :
     ∃ c : F, A - RatFunc.C c = 0 ∨ (A - RatFunc.C c).intDegree < 0 := by
-  classical
-  by_cases hA0 : A = 0
-  · exact ⟨0, by simp [hA0]⟩
-  have hnum0 : A.num ≠ 0 := RatFunc.num_ne_zero hA0
-  have hden0 : A.denom ≠ 0 := A.denom_ne_zero
-  have hdegree : A.num.natDegree ≤ A.denom.natDegree := by
+  have hden : A.denom.Monic := A.monic_denom
+  have hdenMap0 : algebraMap F[X] (RatFunc F) A.denom ≠ 0 := by simpa using A.denom_ne_zero
+  -- `A.intDegree ≤ 0` bounds the numerator's degree by the denominator's, so the Euclidean
+  -- quotient of `A.num` by the monic `A.denom` is a constant `c`.
+  obtain ⟨c, hc⟩ : ∃ c : F, A.num /ₘ A.denom = Polynomial.C c := by
+    refine ⟨_, Polynomial.eq_C_of_natDegree_eq_zero ?_⟩
+    rw [Polynomial.natDegree_divByMonic _ hden]
     rw [RatFunc.intDegree] at hA
     omega
-  -- A strictly smaller numerator already has zero residue.  In the equal-degree case,
-  -- subtract the quotient of leading coefficients to cancel the leading term.
-  rcases hdegree.lt_or_eq with hdegree | hdegree
-  · refine ⟨0, Or.inr ?_⟩
-    have hdegreeInt : (A.num.natDegree : ℤ) - A.denom.natDegree < 0 := by omega
-    simpa [hA0, RatFunc.intDegree] using hdegreeInt
-  · let c := A.num.leadingCoeff / A.denom.leadingCoeff
-    refine ⟨c, ?_⟩
-    by_cases hsub : A - RatFunc.C c = 0
-    · exact Or.inl hsub
-    · right
-      have hc0 : c ≠ 0 := div_ne_zero (Polynomial.leadingCoeff_ne_zero.mpr hnum0)
-        (Polynomial.leadingCoeff_ne_zero.mpr hden0)
-      have hdenMap0 : algebraMap F[X] (RatFunc F) A.denom ≠ 0 := by
-        simpa using hden0
-      have hquotient : A - RatFunc.C c =
-          algebraMap F[X] (RatFunc F) (A.num - Polynomial.C c * A.denom) /
-            algebraMap F[X] (RatFunc F) A.denom := calc
-        A - RatFunc.C c =
-            algebraMap F[X] (RatFunc F) A.num /
-              algebraMap F[X] (RatFunc F) A.denom - RatFunc.C c :=
-          congrArg (fun z ↦ z - RatFunc.C c) (RatFunc.num_div_denom A).symm
-        _ = algebraMap F[X] (RatFunc F) (A.num - Polynomial.C c * A.denom) /
-              algebraMap F[X] (RatFunc F) A.denom := by
-          rw [← RatFunc.algebraMap_C, map_sub, map_mul]
-          field_simp [hdenMap0]
-      have hpoly0 : A.num - Polynomial.C c * A.denom ≠ 0 := by
-        intro h
-        apply hsub
-        rw [hquotient, h, map_zero, zero_div]
-      have hdegrees : A.num.degree = A.denom.degree := by
-        rw [Polynomial.degree_eq_natDegree hnum0, Polynomial.degree_eq_natDegree hden0, hdegree]
-      have hleading : A.num.leadingCoeff =
-          (Polynomial.C c * A.denom).leadingCoeff := by
-        rw [Polynomial.leadingCoeff_mul, Polynomial.leadingCoeff_C]
-        dsimp [c]
-        field_simp [Polynomial.leadingCoeff_ne_zero.mpr hden0]
-      -- The cancellation makes the new numerator have smaller degree than the denominator.
-      have hdegreeSub :
-          (A.num - Polynomial.C c * A.denom).natDegree < A.denom.natDegree :=
-        (Polynomial.natDegree_lt_natDegree_iff hpoly0).mpr <| by
-          apply (Polynomial.degree_sub_lt_left
-            (hdegrees.trans (Polynomial.degree_C_mul hc0).symm) hnum0 hleading).trans_eq
-          exact hdegrees
-      have hpolyMap0 :
-          algebraMap F[X] (RatFunc F) (A.num - Polynomial.C c * A.denom) ≠ 0 :=
-        (map_ne_zero_iff _ (FaithfulSMul.algebraMap_injective F[X] (RatFunc F))).mpr hpoly0
-      rw [hquotient, RatFunc.intDegree_div hpolyMap0 (by simpa),
-        RatFunc.intDegree_polynomial, RatFunc.intDegree_polynomial]
-      omega
+  refine ⟨c, ?_⟩
+  -- Subtracting `c` leaves exactly the Euclidean remainder over the denominator.
+  have hnum : A.num %ₘ A.denom = A.num - Polynomial.C c * A.denom := by
+    have h := Polynomial.modByMonic_add_div A.num A.denom
+    rw [hc] at h
+    linear_combination h
+  have key : A - RatFunc.C c = algebraMap F[X] (RatFunc F) (A.num %ₘ A.denom) /
+      algebraMap F[X] (RatFunc F) A.denom := by
+    rw [hnum, map_sub, map_mul, RatFunc.algebraMap_C, sub_div, RatFunc.num_div_denom,
+      mul_div_assoc, div_self hdenMap0, mul_one]
+  rw [key]
+  rcases eq_or_ne (A.num %ₘ A.denom) 0 with h0 | h0
+  · exact Or.inl (by simp [h0])
+  · refine Or.inr ?_
+    rw [RatFunc.intDegree_div (by simpa using h0) hdenMap0, RatFunc.intDegree_polynomial,
+      RatFunc.intDegree_polynomial]
+    have h := Polynomial.natDegree_lt_natDegree h0 (Polynomial.degree_modByMonic_lt A.num hden)
+    omega
 
 variable {W}
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
@@ -114,10 +114,15 @@ private theorem exists_sub_C_eq_zero_or_intDegree_neg (A : RatFunc F)
     have h := Polynomial.modByMonic_add_div A.num A.denom
     rw [hc] at h
     linear_combination h
+  -- `A.num = A * A.denom` in the function field: the defining property of `num` and `denom`,
+  -- taken as a term so the identity below is closed by `ring` rather than by ordered rewriting.
+  have hnumA : algebraMap F[X] (RatFunc F) A.num = A * algebraMap F[X] (RatFunc F) A.denom :=
+    (div_eq_iff hdenMap0).mp (RatFunc.num_div_denom A)
   have key : A - RatFunc.C c = algebraMap F[X] (RatFunc F) (A.num %ₘ A.denom) /
       algebraMap F[X] (RatFunc F) A.denom := by
-    rw [hnum, map_sub, map_mul, RatFunc.algebraMap_C, sub_div, RatFunc.num_div_denom,
-      mul_div_assoc, div_self hdenMap0, mul_one]
+    rw [eq_div_iff hdenMap0, hnum]
+    simp only [map_sub, map_mul, RatFunc.algebraMap_C, hnumA]
+    ring
   rw [key]
   rcases eq_or_ne (A.num %ₘ A.denom) 0 with h0 | h0
   · exact Or.inl (by simp [h0])


### PR DESCRIPTION
`exists_sub_C_eq_zero_or_intDegree_neg` is the step of `Place.degree_infinity` that says the
residue of a rational function at the infinite place of `F(X)` is a constant. It proved that in
56 lines of leading-coefficient bookkeeping. But `RatFunc.denom` is **monic**, so the constant is
just the Euclidean quotient `A.num /ₘ A.denom` and what is left is the remainder. The statement,
name, signature and `private` are unchanged; only the proof is, and it gains the docstring it did
not have.

Roadmap: EllipticCurves

Attribution only — this improves already-merged code, which `.claude/CLAUDE.md` puts in scope with
no fresh roadmap claim; the diff adds no declaration. The roadmap chiefly motivating this file is
`EllipticCurves`, whose Layer 0 names the file's main result:

> **The point–place dictionary.** For elliptic `W`, `W.toAffine.Point` is in bijection with the
> **degree-`1` places**: `O ↦ infinityPlace`, and an affine nonsingular `(x₀, y₀) ↦` the maximal
> ideal `(X − x₀, Y − y₀)`. Every later layer passes through this dictionary.

— `TauCetiRoadmap/EllipticCurves/README.md:355-358`, read at roadmap `origin/main`.
`AlgebraicCurves/README.md:942-943` lists the dictionary too, but explicitly as "the EllipticCurves
Layer-0 bridge, supplied here as Prop. 6.1.6's general form" — it defers, in words, to
`EllipticCurves` for the elliptic statement, which is the one this file proves
(`pointEquivDegreeOnePlace`, `:308`).

## The change

`TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean`, one file,
+30 / −56, **no import added**.

The old proof split on `A = 0`, then on `A.num.natDegree < A.denom.natDegree` versus `=`, and in
the equal-degree case set `c := A.num.leadingCoeff / A.denom.leadingCoeff` and re-derived by hand
that subtracting it drops the degree — `degree_eq_natDegree`, `leadingCoeff_mul`, `leadingCoeff_C`,
`degree_C_mul`, `degree_sub_lt_left`, `natDegree_lt_natDegree_iff`, a `calc` and two `field_simp`s.

The new one starts from `RatFunc.monic_denom`, after which Mathlib's `%ₘ` / `/ₘ` API says all of it:

* `A.intDegree ≤ 0` is `A.num.natDegree ≤ A.denom.natDegree`, so `Polynomial.natDegree_divByMonic`
  gives `(A.num /ₘ A.denom).natDegree = 0`, and `Polynomial.eq_C_of_natDegree_eq_zero` makes the
  quotient a constant `C c`. That `c` is the residue.
* `Polynomial.modByMonic_add_div` then rewrites `A - RatFunc.C c` as `A.num %ₘ A.denom` over
  `A.denom`.
* `Polynomial.degree_modByMonic_lt` is precisely the degree drop the old proof re-derived.

Two case splits disappear rather than being restated. `A = 0` needs no branch: there the quotient
and the remainder are both `0`, so the left disjunct fires uniformly. A strictly smaller numerator
needs no branch either — it is the `A.num /ₘ A.denom = 0` instance of the same computation. The
`classical` opening goes with them, nothing in the new proof being a decision.

The disjunction in the statement survives because `RatFunc.intDegree 0 = 0` rather than `-∞`; the
new docstring says so, that being the only reason the conclusion is not a plain inequality.

## Checks

* `lake build TauCeti.AlgebraicGeometry.EllipticCurve.Affine.FunctionField.PointPlace`: exit code
  `0`, `Build completed successfully (2859 jobs)`, zero `error:` / `warning:` / `info:`, and the log
  carries `✔ Built …Affine.FunctionField.PointPlace (145s)` — so the target was really elaborated
  rather than replayed as a no-op.
* **Importers: none.** `PointPlace` is a leaf module — `grep -rl` over `TauCeti/` for its module
  path returns 0 files, against a positive control (`…InfinityPlace.Unique`: 2 files) and a
  negative control (0). Its only two textual mentions elsewhere (`InfinityPlace/Unique.lean:76`,
  `Point/Place.lean:69`) are forward-pointing prose in modules it *imports*, and neither names the
  lemma. Nothing downstream can be disturbed.
* Rebased onto `origin/main` immediately before pushing: 0 behind / 1 ahead. The three commits
  merged in the meantime (#5059, #5063, #5040) touch `GradedModule/Opposite.lean`,
  `UniversalCover/PathHomotopyDiscreteness.lean` and `NumberField/SplitsCompletely.lean`; none of
  the three appears anywhere in the 2859-module closure the build log enumerates, so the rebase
  cannot have invalidated that build. The declaration set of the file is 17 before and 17 after.
* `#print axioms`: `TauCeti.Place.degree_infinity` and
  `WeierstrassCurve.Affine.pointEquivDegreeOnePlace` — the public consumers, which reach the
  private lemma transitively — both `[propext, Classical.choice, Quot.sound]`.
* `scripts/lint-dot-notation.py` against the baseline, exit code read without a pipe: rc `0`,
  `1152 total, 1293 grandfathered, 0 new, 141 ratchetable`. The 141 is pre-existing baseline drift
  on `main` rather than anything from this diff, and that is measured, not inferred: running the
  lint's own `find_violations` over this one file gives **0 findings on my version and 0 on the
  `origin/main` version, identical sets** — with a positive control showing the instrument does
  fire (1 finding on `TauCeti/Topology/FilledHull.lean`), so the matching zeros are a measurement
  and not a query that failed to run.
* No line over 100 **codepoints** (max 98), measured in codepoints rather than bytes.
* **Environment linters — `lake exe runLinter` on this module: exit `0`, `Linting passed`.** Run on
  the exact pushed content (the working file was re-diffed against `git show <head>:<path>` first).
  That pass is load-bearing rather than vacuous, and I measured why rather than assuming it:
  injecting a matched pair of `@[simp]` lemmas differing *only* in visibility —
  `theorem zzzPubProbe (n : Nat) : n + 0 = n := by simp` and `private theorem zzzPrivProbe …`, whose
  left-hand side is not in simp-normal form — makes `simpNF` report **both**, the private one under
  its private name: `Found 2 errors in 907 declarations (plus 380 automatically generated ones) …
  with 14 linters`, naming `zzzPubProbe` and `zzzPrivProbe✝`. The public probe is the control that
  *would have failed* had the mechanism been absent; the private one is the subject, and it matters
  here because the declaration this PR changes is `private`. Both probes were then removed and the
  file restored byte-identically before the passing run above. (The whole-library form
  `runLinter TauCeti` *would* be vacuous — the root `TauCeti.lean` is intentionally empty and the
  lakefile glob is authoritative — but that is a different command.)
* `scripts/lint-env.sh` is still not run: it needs a fully built library, which the
  no-local-full-builds rule forbids here, and CI's `pr-build` runs it. It remains the fuller check —
  the default linter set minus `docBlame`, over every `TauCeti` module, against a grandfathered
  baseline that per-module `runLinter` has no notion of. Independently of both, this diff's exposure
  to that set is nil by construction: no signature change (nothing for `unusedArguments` /
  `unusedSectionVars`), no `@[simp]` added or removed (nothing for `simpNF`), and a docstring added
  where there was none.

The proof was developed first against a standalone probe importing only
`Mathlib.FieldTheory.RatFunc.Degree` and `Mathlib.Algebra.Polynomial.FieldDivision` (exit 0, zero
diagnostics), so the five Mathlib lemmas it leans on are known to hold with no Tau Ceti context in
scope; the module build above is the real gate.
