### PR TITLE
feat(Ideal): the powers of an ideal stabilise once 1 + i annihilates one of them

### DIFF
--- a/TauCeti/RingTheory/Ideal/PowStabilises.lean
+++ b/TauCeti/RingTheory/Ideal/PowStabilises.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Ideal.Operations
+import Mathlib.Tactic.Ring
+
+/-!
+# Stabilisation of the powers of an ideal killed by a unit-like element
+
+If some `1 + i` with `i ∈ I` annihilates `I ^ n`, then the powers of `I` stabilise at `n`:
+`I ^ k = I ^ n` for every `k ≥ n`.
+
+The mechanism is that `(1 + i) * x = 0` rewrites `x` as `-(x * i)`, which moves it one power
+deeper, so `I ^ n` is contained in `I ^ (n + 1)` and the two agree.
+
+## Main results
+
+* `TauCeti.Ideal.pow_eq_pow_succ_of_forall_one_add_mul_eq_zero`: `I ^ n = I ^ (n + 1)`.
+* `TauCeti.Ideal.pow_eq_pow_of_le_of_pow_eq_pow_succ`: `I ^ k = I ^ n` for all `k ≥ n`.
+-/
+
+public section
+
+namespace TauCeti.Ideal
+
+variable {B : Type*} [CommRing B] {I : _root_.Ideal B}
+
+/-- **One power of `I` absorbs the next**, when some `1 + i` with `i ∈ I` annihilates `I ^ n`:
+for `x ∈ I ^ n` the relation `(1 + i) * x = 0` says `x = -(x * i)`, and `x * i` lies in
+`I ^ n * I = I ^ (n + 1)`. -/
+theorem pow_eq_pow_succ_of_forall_one_add_mul_eq_zero {i : B} (hi : i ∈ I) {n : ℕ}
+    (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) : I ^ n = I ^ (n + 1) := by
+  refine le_antisymm (fun x hx ↦ ?_) (_root_.Ideal.pow_le_pow_right n.le_succ)
+  have hx0 : (1 + i) * x = 0 := h x hx
+  have hsum : x + x * i = 0 := by rw [← hx0]; ring
+  have hxeq : x = -(x * i) := eq_neg_of_add_eq_zero_left hsum
+  rw [hxeq, pow_succ]
+  exact neg_mem (_root_.Ideal.mul_mem_mul hx hi)
+
+/-- **The powers stabilise from `n` on**, once `I ^ n = I ^ (n + 1)`. -/
+theorem pow_eq_pow_of_le_of_pow_eq_pow_succ {n : ℕ} (hstab : I ^ n = I ^ (n + 1)) :
+    ∀ {k : ℕ}, n ≤ k → I ^ k = I ^ n := by
+  intro k hk
+  induction k, hk using Nat.le_induction with
+  | base => rfl
+  | succ m hm ih => rw [pow_succ, ih, ← pow_succ, ← hstab]
+
+end TauCeti.Ideal

--- a/TauCeti/RingTheory/Ideal/PowStabilises.lean
+++ b/TauCeti/RingTheory/Ideal/PowStabilises.lean
@@ -21,11 +21,36 @@ deeper, so `I ^ n` is contained in `I ^ (n + 1)` and the two agree.
 
 * `TauCeti.Ideal.pow_eq_pow_succ_of_forall_one_add_mul_eq_zero`: `I ^ n = I ^ (n + 1)`.
 * `TauCeti.Ideal.pow_eq_pow_of_le_of_pow_eq_pow_succ`: `I ^ k = I ^ n` for all `k ≥ n`.
+
+## References
+
+These are the closing step of the proof of Proposition 7.49(2) in
+[T. Wedhorn, *Adic Spaces*](https://arxiv.org/abs/1910.05934) (arXiv:1910.05934v1), extracted as
+ideal-power stabilisation. Wedhorn reaches `(1 + i) I ^ n = 0` by localising at `1 + I`; that
+route needs the adic setting, whereas the implication recorded here does not, so it is stated
+over an arbitrary (semi)ring.
 -/
 
 public section
 
 namespace TauCeti.Ideal
+
+section CommSemiring
+
+variable {B : Type*} [CommSemiring B] {I : _root_.Ideal B}
+
+/-- **The powers stabilise from `n` on**, once `I ^ n = I ^ (n + 1)`. No commutativity and no
+additive inverses are used: the induction rewrites with `pow_succ` alone. -/
+theorem pow_eq_pow_of_le_of_pow_eq_pow_succ {n : ℕ} (hstab : I ^ n = I ^ (n + 1)) :
+    ∀ {k : ℕ}, n ≤ k → I ^ k = I ^ n := by
+  intro k hk
+  induction k, hk using Nat.le_induction with
+  | base => rfl
+  | succ m hm ih => rw [pow_succ, ih, ← pow_succ, ← hstab]
+
+end CommSemiring
+
+section CommRing
 
 variable {B : Type*} [CommRing B] {I : _root_.Ideal B}
 
@@ -41,12 +66,6 @@ theorem pow_eq_pow_succ_of_forall_one_add_mul_eq_zero {i : B} (hi : i ∈ I) {n 
   rw [hxeq, pow_succ]
   exact neg_mem (_root_.Ideal.mul_mem_mul hx hi)
 
-/-- **The powers stabilise from `n` on**, once `I ^ n = I ^ (n + 1)`. -/
-theorem pow_eq_pow_of_le_of_pow_eq_pow_succ {n : ℕ} (hstab : I ^ n = I ^ (n + 1)) :
-    ∀ {k : ℕ}, n ≤ k → I ^ k = I ^ n := by
-  intro k hk
-  induction k, hk using Nat.le_induction with
-  | base => rfl
-  | succ m hm ih => rw [pow_succ, ih, ← pow_succ, ← hstab]
+end CommRing
 
 end TauCeti.Ideal


### PR DESCRIPTION
The closing step of Wedhorn's proof of Proposition 7.49(2), split off as a standalone commutative-algebra fact.

## What this proves

```lean
theorem pow_eq_pow_succ_of_forall_one_add_mul_eq_zero {i : B} (hi : i ∈ I) {n : ℕ}
    (h : ∀ x ∈ I ^ n, (1 + i) * x = 0) : I ^ n = I ^ (n + 1)

theorem pow_eq_pow_of_le_of_pow_eq_pow_succ {n : ℕ} (hstab : I ^ n = I ^ (n + 1)) :
    ∀ {k : ℕ}, n ≤ k → I ^ k = I ^ n
```

The mechanism is one line: for `x ∈ I ^ n`, `(1 + i) * x = 0` says `x = -(x * i)`, and `x * i` lies in `I ^ n * I = I ^ (n+1)`. So `I ^ n ⊆ I ^ (n+1)`, and the reverse is `Ideal.pow_le_pow_right`.

## Why it is stated over an arbitrary commutative ring

Wedhorn (arXiv:1910.05934v1, proof of Proposition 7.49(2)) reaches `(1 + i) I^n = 0` by localising at `S = 1 + I` and using that `φ(I)` lies in every prime of `S⁻¹B`, then concludes `I^k = I^n`. That last implication uses **nothing** about localisations, valuations, or adic rings — only that `i ∈ I` and that `1 + i` kills `I^n`. Stating it separately keeps the adic hypotheses out of a fact that does not need them, and makes it reusable.

Bead tc-4w1xw scopes 7.49(2)'s second half into three conclusions (a), (b), (c). This PR is **(c)**, which the bead singles out as "short and worth stating as its own lemma". (a) and (b) — obtaining `φ(I^n) = 0` from the primes hypothesis, and descending it to `(1+i) I^n = 0` in `B` — are the localisation half and are left for a follow-up, since they need a `1 + I` submonoid that Mathlib does not have and an "f.g. ideal of nilpotents is nilpotent" step. Splitting there keeps one topic per PR: this is ideal-power stabilisation, that is the localisation argument.

## Roadmap grounding

This adds new declarations, so it cites the target rather than the area.

**AdicSpaces, README.md:427** (verified on `origin/main`): *"Prove Proposition 7.49(2), including the criterion for this locus to be empty"*. This is a sub-result of that proposition's proof. Wedhorn 7.49 is the identified blocker of the `O_X` chain; its first half runs through Lemma 7.45 and the microbiality substrate, which is why this half is separable and buildable now.

## Verification

`lake build TauCeti.RingTheory.Ideal.PowStabilises` — exit 0, 1309 jobs, no errors, warnings, or `info:` diagnostics. Branched off `origin/main`, 3 commits behind at push. No line over 100 characters; no `sorry`.

Prior art checked on `origin/main` with a firing control: no ideal-power-stabilisation lemma in `TauCeti/` (0 hits against 80 files under `TauCeti/RingTheory/` mentioning `Ideal`, negative control 0).

Roadmap: AdicSpaces
