### PR TITLE
refactor(EllipticCurve): identify the Weierstrass partials with Polynomial.derivative

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
@@ -21,29 +21,32 @@ derivative it is named after.
 * `WeierstrassCurve.Affine.derivative_polynomial`: `W_Y` is `Polynomial.derivative W(X, Y)`, an
   identity of bivariate polynomials. No evaluation is involved: `R[X][Y]` is a polynomial ring in
   `Y` over `R[X]`, so `Polynomial.derivative` already differentiates in `Y`.
+* `WeierstrassCurve.Affine.equivPolynomial_mapCoeffs_polynomial`: `W_X` is the coefficientwise
+  derivative of `W(X, Y)`, again an identity of bivariate polynomials with no evaluation involved.
 * `WeierstrassCurve.Affine.derivative_eval_polynomial`: the chain rule along a substitution
   `Y := p`, which expresses `derivative (W(X, p))` through *both* partials. For a constant
   `p = C y` the `Y`-term drops out and this reads `W_X(X, y)`.
 
-Both hold over an arbitrary commutative ring.
+All three hold over an arbitrary commutative ring.
 
 ## Implementation notes
 
 `Polynomial.derivative` on `R[X][Y]` differentiates in `Y`, so `derivative_polynomial` is an
 identity of bivariate polynomials with no evaluation anywhere. Differentiating in `X` instead means
-differentiating the coefficients, and that *is* expressible bare, as
-`PolynomialModule.equivPolynomialSelf (Polynomial.derivative'.mapCoeffs W.polynomial)` — the shape
-standing on the right of `Polynomial.Bivariate.pderiv_zero_equivMvPolynomial`; no `MvPolynomial`
-transport is needed to say it.
+differentiating the coefficients, which `Derivation.mapCoeffs` does; reading the result back in
+`R[X][Y]` along `PolynomialModule.equivPolynomial` gives the shape standing on the right of
+`Polynomial.Bivariate.pderiv_zero_equivMvPolynomial`, so no `MvPolynomial` transport is needed to
+state that partial either.
 
-`derivative_eval_polynomial` is nonetheless stated after substituting `Y := p`, for two reasons
-that are about usability rather than expressibility: that is the form consumers meet the partials
-in, and it avoids a round trip through `PolynomialModule`. At that level the two partials appear
-together, as the chain rule, rather than one at a time.
+Each partial is therefore stated bare and one at a time, and the chain rule is *derived* from the
+two rather than taken as primitive: `derivative_eval_polynomial` follows from
+`equivPolynomial_mapCoeffs_polynomial` and `derivative_polynomial` through
+`Derivation.apply_eval_eq`. The substituted form remains the one most consumers meet, so it is
+kept, but it is now a corollary of the bare identities rather than the only statement of them.
 
 ## Provenance
 
-Both identities come from the proof of
+Two of the three identities come from the proof of
 `WeierstrassCurve.Affine.Point.nonsingular_of_isUnit_XYIdeal` in `Affine/Point/ToClass.lean`,
 which is itself ported from the AINTLIB `HasseWeil` project
 (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, by Chris Birkbeck), where they were local `have`s
@@ -55,6 +58,9 @@ over a commutative ring. `derivative_eval_polynomial` goes beyond its `have`: th
 only the constant substitution `p = C y`, for which the `Y`-term drops out, so the chain rule for
 an arbitrary `p : R[X]` is a generalisation of it rather than an extraction of it. The constant
 case is what the call site in `ToClass.lean` recovers.
+
+`equivPolynomial_mapCoeffs_polynomial` has no counterpart in the source: the `have`s worked
+with the substituted form throughout, and the bare `X`-partial is stated here for the first time.
 -/
 
 public section
@@ -73,17 +79,31 @@ nose. -/
     derivative_C, derivative_X_pow, derivative_X, C_ofNat, Nat.cast_ofNat, zero_mul, zero_add,
     sub_zero, mul_one, pow_one, Nat.add_one_sub_one]
 
+/-- **The `X`-partial derivative of `W(X, Y)` is a coefficientwise derivative.** Differentiating
+`W(X, Y)` in `X` means differentiating its coefficients, which `Derivation.mapCoeffs` does; reading
+the result back in `R[X][Y]` gives `W_X(X, Y)` on the nose. -/
+@[simp] theorem equivPolynomial_mapCoeffs_polynomial :
+    PolynomialModule.equivPolynomial (derivative'.mapCoeffs W.polynomial) = W.polynomialX := by
+  rw [← PolynomialModule.equivPolynomialSelf_apply_eq]
+  have h : PolynomialModule.equivPolynomialSelf (PolynomialModule.single R[X] 0 1) = 1 := by simp
+  simp [polynomial, polynomialX, map_sub, map_add, Derivation.leibniz,
+    -PolynomialModule.equivPolynomialSelf_apply_eq, map_smul, smul_eq_mul, C_ofNat, h]
+  ring
+
 /-- **The chain rule for `W(X, Y)` along a substitution `Y := p`.** Differentiating the
 one-variable polynomial `W(X, p)` splits into the two partials of `W`, the `Y`-one weighted by
 `p'`. Substituting a constant `p = C y` kills the second term and leaves `W_X(X, y)`. -/
 @[simp] theorem derivative_eval_polynomial (p : R[X]) :
     derivative (W.polynomial.eval p) =
       W.polynomialX.eval p + W.polynomialY.eval p * derivative p := by
-  simp only [polynomial, polynomialX, polynomialY, C_add, C_mul, C_pow, eval_sub, eval_add,
-    eval_pow, eval_X, eval_mul, eval_C, eval_ofNat, derivative_sub, derivative_add, derivative_mul,
-    derivative_C, derivative_pow, derivative_X, C_ofNat, Nat.cast_ofNat, zero_mul, add_zero,
-    zero_add, mul_one, pow_one, Nat.add_one_sub_one]
-  ring
+  -- Evaluating a `PolynomialModule R[X] R[X]` agrees with evaluating the polynomial it names.
+  have hbridge : ∀ m : PolynomialModule R[X] R[X],
+      PolynomialModule.eval p m = eval p (PolynomialModule.equivPolynomial m) := by
+    intro m
+    induction m using PolynomialModule.induction_linear <;> simp_all [mul_comm]
+  have h := Derivation.apply_eval_eq (derivative' (R := R)) p W.polynomial
+  rw [hbridge, equivPolynomial_mapCoeffs_polynomial, derivative_polynomial] at h
+  simpa using h
 
 end WeierstrassCurve.Affine
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck, The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Basic
+
+/-!
+# The Weierstrass partial derivatives are derivatives
+
+Mathlib defines the two partial derivatives `WeierstrassCurve.Affine.polynomialX` and
+`WeierstrassCurve.Affine.polynomialY` of the Weierstrass polynomial `W(X, Y)` by explicit
+formulae, and marks both definitions with the comment
+`TODO: define this in terms of Polynomial.derivative`. This file identifies each of them with the
+derivative it is named after.
+
+## Main statements
+
+* `WeierstrassCurve.Affine.derivative_polynomial`: `W_Y` is `Polynomial.derivative W(X, Y)`, an
+  identity of bivariate polynomials. No evaluation is involved: `R[X][Y]` is a polynomial ring in
+  `Y` over `R[X]`, so `Polynomial.derivative` already differentiates in `Y`.
+* `WeierstrassCurve.Affine.derivative_eval_polynomial`: for each `y : R`, `W_X(X, y)` is the
+  derivative of the one-variable polynomial `W(X, y)`.
+
+Both hold over an arbitrary commutative ring.
+
+## Implementation notes
+
+The two statements are asymmetric because `Polynomial.derivative` on `R[X][Y]` differentiates in
+`Y` only. Differentiating in `X` means differentiating the coefficients instead, and Mathlib's
+bivariate API reaches that only by transporting to `MvPolynomial`, in
+`Polynomial.Bivariate.pderiv_zero_equivMvPolynomial`. Substituting `Y := y` before differentiating
+avoids that detour and produces the `X`-partial in the shape its consumers use, at the cost of
+fixing a `y`.
+
+## Provenance
+
+Both statements were extracted from the proof of
+`WeierstrassCurve.Affine.Point.nonsingular_of_isUnit_XYIdeal` in `Affine/Point/ToClass.lean`,
+which is itself ported from the AINTLIB `HasseWeil` project
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, by Chris Birkbeck). There they were local `have`s
+over a field, and stated after evaluating at a point; here they are stated over a commutative
+ring, and before evaluation.
+-/
+
+public section
+
+open Polynomial
+
+namespace WeierstrassCurve.Affine
+
+variable {R : Type*} [CommRing R] {W : Affine R}
+
+/-- **The `Y`-partial derivative of `W(X, Y)` is a `Polynomial.derivative`.** Viewing `R[X][Y]` as
+a polynomial ring in `Y` over `R[X]`, differentiating `W(X, Y)` in `Y` gives `W_Y(X, Y)` on the
+nose. -/
+theorem derivative_polynomial : derivative W.polynomial = W.polynomialY := by
+  simp only [polynomial, polynomialY, derivative_sub, derivative_add, derivative_mul,
+    derivative_C, derivative_X_pow, derivative_X, C_ofNat, Nat.cast_ofNat, zero_mul, zero_add,
+    sub_zero, mul_one, pow_one, Nat.add_one_sub_one]
+
+/-- **The `X`-partial derivative of `W(X, Y)` is a `Polynomial.derivative`,** after substituting a
+value for `Y`. Differentiating the one-variable polynomial `W(X, y)` gives `W_X(X, y)`. -/
+theorem derivative_eval_polynomial (y : R) :
+    derivative (W.polynomial.eval (C y)) = W.polynomialX.eval (C y) := by
+  simp only [polynomial, polynomialX, C_add, C_mul, C_pow, eval_sub, eval_add, eval_pow, eval_X,
+    eval_mul, eval_C, eval_ofNat, derivative_sub, derivative_add, derivative_mul, derivative_C,
+    derivative_pow, derivative_X, C_ofNat, Nat.cast_ofNat, zero_mul, mul_zero, add_zero,
+    zero_add, mul_one, pow_one, Nat.add_one_sub_one]
+  ring
+
+end WeierstrassCurve.Affine
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
@@ -43,12 +43,18 @@ together, as the chain rule, rather than one at a time.
 
 ## Provenance
 
-Both statements were extracted from the proof of
+Both identities come from the proof of
 `WeierstrassCurve.Affine.Point.nonsingular_of_isUnit_XYIdeal` in `Affine/Point/ToClass.lean`,
 which is itself ported from the AINTLIB `HasseWeil` project
-(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, by Chris Birkbeck). There they were local `have`s
-over a field, and stated after evaluating at a point; here they are stated over a commutative
-ring, and before evaluation.
+(`github.com/CBirkbeck/AINTLIB`, Apache-2.0, by Chris Birkbeck), where they were local `have`s
+over a field, stated after evaluating at a point.
+
+They are restated here to different degrees, and only one of them is a straight extraction.
+`derivative_polynomial` is the identity the `have` already had, moved ahead of the evaluation and
+over a commutative ring. `derivative_eval_polynomial` goes beyond its `have`: that one covered
+only the constant substitution `p = C y`, for which the `Y`-term drops out, so the chain rule for
+an arbitrary `p : R[X]` is a generalisation of it rather than an extraction of it. The constant
+case is what the call site in `ToClass.lean` recovers.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean
@@ -21,19 +21,25 @@ derivative it is named after.
 * `WeierstrassCurve.Affine.derivative_polynomial`: `W_Y` is `Polynomial.derivative W(X, Y)`, an
   identity of bivariate polynomials. No evaluation is involved: `R[X][Y]` is a polynomial ring in
   `Y` over `R[X]`, so `Polynomial.derivative` already differentiates in `Y`.
-* `WeierstrassCurve.Affine.derivative_eval_polynomial`: for each `y : R`, `W_X(X, y)` is the
-  derivative of the one-variable polynomial `W(X, y)`.
+* `WeierstrassCurve.Affine.derivative_eval_polynomial`: the chain rule along a substitution
+  `Y := p`, which expresses `derivative (W(X, p))` through *both* partials. For a constant
+  `p = C y` the `Y`-term drops out and this reads `W_X(X, y)`.
 
 Both hold over an arbitrary commutative ring.
 
 ## Implementation notes
 
-The two statements are asymmetric because `Polynomial.derivative` on `R[X][Y]` differentiates in
-`Y` only. Differentiating in `X` means differentiating the coefficients instead, and Mathlib's
-bivariate API reaches that only by transporting to `MvPolynomial`, in
-`Polynomial.Bivariate.pderiv_zero_equivMvPolynomial`. Substituting `Y := y` before differentiating
-avoids that detour and produces the `X`-partial in the shape its consumers use, at the cost of
-fixing a `y`.
+`Polynomial.derivative` on `R[X][Y]` differentiates in `Y`, so `derivative_polynomial` is an
+identity of bivariate polynomials with no evaluation anywhere. Differentiating in `X` instead means
+differentiating the coefficients, and that *is* expressible bare, as
+`PolynomialModule.equivPolynomialSelf (Polynomial.derivative'.mapCoeffs W.polynomial)` — the shape
+standing on the right of `Polynomial.Bivariate.pderiv_zero_equivMvPolynomial`; no `MvPolynomial`
+transport is needed to say it.
+
+`derivative_eval_polynomial` is nonetheless stated after substituting `Y := p`, for two reasons
+that are about usability rather than expressibility: that is the form consumers meet the partials
+in, and it avoids a round trip through `PolynomialModule`. At that level the two partials appear
+together, as the chain rule, rather than one at a time.
 
 ## Provenance
 
@@ -56,18 +62,20 @@ variable {R : Type*} [CommRing R] {W : Affine R}
 /-- **The `Y`-partial derivative of `W(X, Y)` is a `Polynomial.derivative`.** Viewing `R[X][Y]` as
 a polynomial ring in `Y` over `R[X]`, differentiating `W(X, Y)` in `Y` gives `W_Y(X, Y)` on the
 nose. -/
-theorem derivative_polynomial : derivative W.polynomial = W.polynomialY := by
+@[simp] theorem derivative_polynomial : derivative W.polynomial = W.polynomialY := by
   simp only [polynomial, polynomialY, derivative_sub, derivative_add, derivative_mul,
     derivative_C, derivative_X_pow, derivative_X, C_ofNat, Nat.cast_ofNat, zero_mul, zero_add,
     sub_zero, mul_one, pow_one, Nat.add_one_sub_one]
 
-/-- **The `X`-partial derivative of `W(X, Y)` is a `Polynomial.derivative`,** after substituting a
-value for `Y`. Differentiating the one-variable polynomial `W(X, y)` gives `W_X(X, y)`. -/
-theorem derivative_eval_polynomial (y : R) :
-    derivative (W.polynomial.eval (C y)) = W.polynomialX.eval (C y) := by
-  simp only [polynomial, polynomialX, C_add, C_mul, C_pow, eval_sub, eval_add, eval_pow, eval_X,
-    eval_mul, eval_C, eval_ofNat, derivative_sub, derivative_add, derivative_mul, derivative_C,
-    derivative_pow, derivative_X, C_ofNat, Nat.cast_ofNat, zero_mul, mul_zero, add_zero,
+/-- **The chain rule for `W(X, Y)` along a substitution `Y := p`.** Differentiating the
+one-variable polynomial `W(X, p)` splits into the two partials of `W`, the `Y`-one weighted by
+`p'`. Substituting a constant `p = C y` kills the second term and leaves `W_X(X, y)`. -/
+@[simp] theorem derivative_eval_polynomial (p : R[X]) :
+    derivative (W.polynomial.eval p) =
+      W.polynomialX.eval p + W.polynomialY.eval p * derivative p := by
+  simp only [polynomial, polynomialX, polynomialY, C_add, C_mul, C_pow, eval_sub, eval_add,
+    eval_pow, eval_X, eval_mul, eval_C, eval_ofNat, derivative_sub, derivative_add, derivative_mul,
+    derivative_C, derivative_pow, derivative_X, C_ofNat, Nat.cast_ofNat, zero_mul, add_zero,
     zero_add, mul_one, pow_one, Nat.add_one_sub_one]
   ring
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/ToClass.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/ToClass.lean
@@ -292,7 +292,7 @@ private theorem nonsingular_of_isUnit_XYIdeal {x y : F} (heq : W.Equation x y)
   have hdY_apply (p : P) : dY p = (p.derivative.eval (C y)).eval x := rfl
   have hWX : dX W.polynomial = 0 := by
     rw [hdX_apply, W.derivative_eval_polynomial]
-    exact hs.1
+    simpa using hs.1
   have hWY : dY W.polynomial = 0 := by
     rw [hdY_apply, W.derivative_polynomial]
     exact hs.2

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/ToClass.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/ToClass.lean
@@ -295,7 +295,7 @@ private theorem nonsingular_of_isUnit_XYIdeal {x y : F} (heq : W.Equation x y)
     simpa using hs.1
   have hWY : dY W.polynomial = 0 := by
     rw [hdY_apply, W.derivative_polynomial]
-    exact hs.2
+    simpa only [evalEval] using hs.2
   have hdX_mul (p q : P) : dX (p * q) =
       p.evalEval x y * dX q + q.evalEval x y * dX p := by
     rw [hdX_apply, hdX_apply, hdX_apply]

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/ToClass.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/ToClass.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck, The Tau Ceti contributors
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Derivative
 import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.XYIdealMaximal
 import Mathlib.LinearAlgebra.DirectSum.Finite
 import Mathlib.LinearAlgebra.FreeModule.Norm
@@ -289,19 +290,12 @@ private theorem nonsingular_of_isUnit_XYIdeal {x y : F} (heq : W.Equation x y)
     (evalY.comp (Polynomial.derivative.restrictScalars F))
   have hdX_apply (p : P) : dX p = (p.eval (C y)).derivative.eval x := rfl
   have hdY_apply (p : P) : dY p = (p.derivative.eval (C y)).eval x := rfl
-  have hpolynomialX : (W.polynomial.eval (C y)).derivative.eval x =
-      W.polynomialX.evalEval x y := by
-    simp only [polynomial, polynomialX, evalEval]
-    simp [Polynomial.derivative_pow]
-    ring
-  have hpolynomialY : (W.polynomial.derivative.eval (C y)).eval x =
-      W.polynomialY.evalEval x y := by
-    simp only [polynomial, polynomialY, evalEval]
-    simp [Polynomial.derivative_pow]
   have hWX : dX W.polynomial = 0 := by
-    rw [hdX_apply, hpolynomialX, hs.1]
+    rw [hdX_apply, W.derivative_eval_polynomial]
+    exact hs.1
   have hWY : dY W.polynomial = 0 := by
-    rw [hdY_apply, hpolynomialY, hs.2]
+    rw [hdY_apply, W.derivative_polynomial]
+    exact hs.2
   have hdX_mul (p q : P) : dX (p * q) =
       p.evalEval x y * dX q + q.evalEval x y * dX p := by
     rw [hdX_apply, hdX_apply, hdX_apply]


### PR DESCRIPTION
Mathlib defines the two partial derivatives of the Weierstrass polynomial,
`WeierstrassCurve.Affine.polynomialX` and `polynomialY`, by explicit formulae, and marks **both**
definitions with the same comment (`Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Basic.lean`):

```
-- TODO: define this in terms of `Polynomial.derivative`.
```

The proof of `nonsingular_of_isUnit_XYIdeal` in `Affine/Point/ToClass.lean` already contained that
identification, as two local `have`s (`hpolynomialX`, `hpolynomialY`) stated over the field `F` and
after evaluating at a point. This PR lifts them out of the proof body into a new file.

**This is a refactor of already-merged material, plus one modest generalisation** — both of which
`.claude/CLAUDE.md` puts in scope without a roadmap entry ("refactoring, simplifying proofs, fixing
or modestly generalising an existing lemma"). Precisely: the `Y` identity is the `have` restated
ahead of its evaluation; the `X` one is generalised from the constant substitution the `have` used
to the chain rule along an arbitrary substitution. Nothing here is new mathematics in the sense the
roadmap gates. The attribution line at the bottom is attribution, not a claim that this PR advances
a roadmap target.

## What lands

New file `TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Derivative.lean`, over an arbitrary
`CommRing R` (the proof had them over a field):

* `WeierstrassCurve.Affine.derivative_polynomial : derivative W.polynomial = W.polynomialY`
* `WeierstrassCurve.Affine.equivPolynomial_mapCoeffs_polynomial :`
  `PolynomialModule.equivPolynomial (derivative'.mapCoeffs W.polynomial) = W.polynomialX`
* `WeierstrassCurve.Affine.derivative_eval_polynomial (p : R[X]) :`
  `derivative (W.polynomial.eval p) = W.polynomialX.eval p + W.polynomialY.eval p * derivative p`

All three are `@[simp]`. The third is *derived* from the first two, not computed again.

| | as local `have`s (field `F`, at a point `(x, y)`) | here (any `CommRing R`) |
|---|---|---|
| `Y` | `(W.polynomial.derivative.eval (C y)).eval x = W.polynomialY.evalEval x y` | `derivative W.polynomial = W.polynomialY` |
| `X` | `(W.polynomial.eval (C y)).derivative.eval x = W.polynomialX.evalEval x y` | the chain rule above, for arbitrary `p` |

For `polynomialY` this is a bare identity of bivariate polynomials with no evaluation at all —
precisely what Mathlib's TODO asks for. For `polynomialX`, the `have` only ever used the constant
substitution `p = C y`, where the `Y`-term vanishes; the chain rule is the statement the same proof
actually gives, and the constant case is what `ToClass.lean` recovers by `simpa`.

## Both partials are stated bare

`Polynomial.derivative` on `R[X][Y]` differentiates in `Y`, so the `Y`-partial needs no evaluation.
Differentiating in `X` means differentiating the *coefficients*, which `Derivation.mapCoeffs` does;
reading the result back in `R[X][Y]` gives the shape on the right of
`Polynomial.Bivariate.pderiv_zero_equivMvPolynomial`, so no `MvPolynomial` transport is needed to
state that one either.

Round 3 asked (`api-design`, `generality`) that this bare `X`-partial be the primitive rather than
a chain rule presented as one. It now is: `equivPolynomial_mapCoeffs_polynomial` is stated first,
and `derivative_eval_polynomial` is derived from it together with `derivative_polynomial` through
`Derivation.apply_eval_eq`. The substituted form is kept — it is the shape consumers meet the
partials in, and it is what `ToClass.lean` uses — but it is now a corollary rather than the only
statement of the `X`-partial.

**On the `@[simp]` spelling.** `api-design` named the left-hand side
`PolynomialModule.equivPolynomialSelf (derivative'.mapCoeffs W.polynomial)`. That spelling cannot
carry `@[simp]`: Mathlib already has
`@[simp] PolynomialModule.equivPolynomialSelf_apply_eq : equivPolynomialSelf p = equivPolynomial p`,
so `simpNF` rejects it and the lemma would never fire —

```
Left-hand side simplifies from
  PolynomialModule.equivPolynomialSelf (Polynomial.derivative'.mapCoeffs W.polynomial)
to
  PolynomialModule.equivPolynomial (Polynomial.derivative'.mapCoeffs W.polynomial)
```

The statement therefore uses the simp-normal head `equivPolynomial`. It is the same function
(`equivPolynomialSelf_apply_eq` is `rfl`) and hence the same identity, which is what `generality`
allowed "up to preferred orientation"; the proof re-enters the `Self` form for the one rewrite that
needs its `R[X][Y]`-linearity.

## What is deliberately *not* extracted

The same proof contains two further self-contained `have`s, `hdX_mul` and `hdY_mul` — Leibniz
rules for the two "evaluate, then differentiate" operators. They are left in place: each is a
three-line composition of `Polynomial.derivative_mul` with `eval_mul`, used exactly once, and
promoting them would add one-use helpers rather than reusable API.

## This does **not** discharge the proof-length cap

Measured on this branch: `nonsingular_of_isUnit_XYIdeal` goes from **148 to 141 lines** — still far
over the 50-line threshold. The bulk of that proof is the linear-algebra plumbing (the descent to
the coordinate ring and the cotangent map), which is untouched here. This PR is the derivative
bridge only; the length cap is a separate piece of work.

## Proof form

`derivative_polynomial` is a squeezed `simp only` set rather than a bare `simp`, and that is
deliberate and measured: the first drafts leaned on the generic `map_add` / `map_mul` / `map_pow`
hom lemmas, which forced repeated `AddHomClass` / `MulHomClass` instance searches and profiled at
3.67s. Switching to the `Polynomial`-specific `C_add` / `C_mul` / `C_pow` and the explicit
`derivative_*` / `eval_*` lemmas brought it to roughly 0.13s.

`derivative_eval_polynomial` no longer carries that computation at all. It is now four lines which
rewrite the two bare partials into `Derivation.apply_eval_eq`; the hand-run `simp only` set that
used to prove it is gone, which is the substance of the round-3 change. Its one local `have` is a
general `PolynomialModule.eval` / `equivPolynomial` bridge, kept local because it has a single call
site.

`unusedSimpArgs` is clean and `lake exe runLinter` passes on both changed modules.

## Placement

The lemmas are about `W.polynomial` / `polynomialX` / `polynomialY`, i.e. Mathlib's
`Affine/Basic.lean` territory, not about the coordinate-ring evaluation that `Affine/Eval.lean`
covers, so they get their own file rather than joining an existing one. They are declared in the
root `WeierstrassCurve.Affine` namespace, matching how the rest of the elliptic tree extends
Mathlib's affine API (e.g. `Affine/Formula/VariableChange.lean`).

Both lemmas are natural mathlib candidates — they answer a TODO Mathlib itself records — so
they are mathlib-track: dedupe on landing upstream.

Roadmap: EllipticCurves


