### PR TITLE
feat(Ideal): localising at 1 + I, and the annihilator of a power of I

### DIFF
--- a/TauCeti/RingTheory/Ideal/Nilpotent.lean
+++ b/TauCeti/RingTheory/Ideal/Nilpotent.lean
@@ -11,31 +11,32 @@ public import Mathlib.RingTheory.Finiteness.Ideal
 /-!
 # A power of the image of a finitely generated ideal
 
-Let `I` be an ideal of a commutative semiring `B` and let `C` be a `B`-algebra. If every prime of
-`C` contains the image of `I`, that image lies in the nilradical of `C`; when `I` is finitely
-generated the image is then a nilpotent ideal, so one of its powers is `⊥`.
+Let `I` be an ideal of a semiring `B` and let `f : B →+* C` be a ring homomorphism into a
+commutative semiring. If every prime of `C` contains `I.map f`, that image lies in the nilradical
+of `C`; when `I` is finitely generated the image is then a nilpotent ideal, so one of its powers
+is `⊥`.
 
 Nothing here mentions localisation, and nothing subtracts, so the statement is made for an
-arbitrary commutative semiring algebra.
+arbitrary ring homomorphism, with commutativity assumed only where primes are taken.
 
 ## Main results
 
-* `Ideal.exists_pow_map_eq_bot`: if `I` is finitely generated and `I.map (algebraMap B C)` is
-  contained in every prime of `C`, then `(I.map (algebraMap B C)) ^ n = ⊥` for some `n`.
+* `Ideal.exists_pow_map_eq_bot`: if `I` is finitely generated and `I.map f` is contained in every
+  prime of `C`, then `(I.map f) ^ n = ⊥` for some `n`.
 -/
 
 public section
 
 namespace Ideal
 
-variable {B C : Type*} [CommSemiring B] [CommSemiring C] [Algebra B C] {I : Ideal B}
+variable {B C : Type*} [Semiring B] [CommSemiring C] {I : Ideal B}
 
-/-- **A power of the image of `I` vanishes.** If every prime of `C` contains the image of `I`,
-that image lies in the nilradical; being finitely generated it is then nilpotent. -/
-theorem exists_pow_map_eq_bot (hfg : I.FG)
-    (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
-    ∃ n : ℕ, (I.map (algebraMap B C)) ^ n = ⊥ := by
-  obtain ⟨n, hn⟩ := (hfg.map (algebraMap B C)).isNilpotent_iff_le_nilradical.mpr
+/-- **A power of the image of `I` vanishes.** If every prime of `C` contains the image of `I`
+under `f`, that image lies in the nilradical; being finitely generated it is then nilpotent. -/
+theorem exists_pow_map_eq_bot (f : B →+* C) (hfg : I.FG)
+    (hprime : ∀ P : Ideal C, P.IsPrime → I.map f ≤ P) :
+    ∃ n : ℕ, (I.map f) ^ n = ⊥ := by
+  obtain ⟨n, hn⟩ := (hfg.map f).isNilpotent_iff_le_nilradical.mpr
     fun x hx ↦ mem_nilradical.mpr (nilpotent_iff_mem_prime.mpr fun P hP ↦ hprime P hP hx)
   exact ⟨n, by simpa using hn⟩
 

--- a/TauCeti/RingTheory/Ideal/Nilpotent.lean
+++ b/TauCeti/RingTheory/Ideal/Nilpotent.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Noetherian.Nilpotent
+public import Mathlib.RingTheory.Finiteness.Ideal
+
+/-!
+# A power of the image of a finitely generated ideal
+
+Let `I` be an ideal of a commutative semiring `B` and let `C` be a `B`-algebra. If every prime of
+`C` contains the image of `I`, that image lies in the nilradical of `C`; when `I` is finitely
+generated the image is then a nilpotent ideal, so one of its powers is `⊥`.
+
+Nothing here mentions localisation, and nothing subtracts, so the statement is made for an
+arbitrary commutative semiring algebra.
+
+## Main results
+
+* `Ideal.exists_pow_map_eq_bot`: if `I` is finitely generated and `I.map (algebraMap B C)` is
+  contained in every prime of `C`, then `(I.map (algebraMap B C)) ^ n = ⊥` for some `n`.
+-/
+
+public section
+
+namespace Ideal
+
+variable {B C : Type*} [CommSemiring B] [CommSemiring C] [Algebra B C] {I : Ideal B}
+
+/-- **A power of the image of `I` vanishes.** If every prime of `C` contains the image of `I`,
+that image lies in the nilradical; being finitely generated it is then nilpotent. -/
+theorem exists_pow_map_eq_bot (hfg : I.FG)
+    (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
+    ∃ n : ℕ, (I.map (algebraMap B C)) ^ n = ⊥ := by
+  obtain ⟨n, hn⟩ := (hfg.map (algebraMap B C)).isNilpotent_iff_le_nilradical.mpr
+    fun x hx ↦ mem_nilradical.mpr (nilpotent_iff_mem_prime.mpr fun P hP ↦ hprime P hP hx)
+  exact ⟨n, by simpa using hn⟩
+
+end Ideal

--- a/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
+++ b/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
@@ -13,9 +13,11 @@ import Mathlib.Tactic.Ring
 /-!
 # Localising a ring at `1 + I`
 
-For an ideal `I` of a commutative ring `B`, the set `1 + I` is a submonoid, and localising at it
-makes every element of `I` lie in every prime exactly when a power of `I` is annihilated by a
-single element of `1 + I`.
+For an ideal `I` of a commutative ring `B`, the set `1 + I` is a submonoid. If `I` is finitely
+generated and its image in a localisation at `1 + I` lies in every prime there, then a single
+element of `1 + I` annihilates a power of `I`.
+
+Only that implication is proved here, and only under `I.FG`; the converse is not stated.
 
 ## Main results
 
@@ -24,6 +26,12 @@ single element of `1 + I`.
   prime of the localisation, some power of that image is zero.
 * `Ideal.exists_mem_oneAdd_forall_mul_eq_zero`: the same hypothesis produces a single
   `s ∈ 1 + I` with `s * x = 0` for every `x ∈ I ^ n`.
+
+## References
+
+* T. Wedhorn, *Adic Spaces*, arXiv:1910.05934v1, Proposition 7.49(2). The construction here
+  follows the argument of that proposition's proof, which localises at `1 + I` in exactly this
+  way; the statements below are stated for their own sake and do not mention `Spa`.
 -/
 
 public section
@@ -54,8 +62,8 @@ variable {I} {C : Type*} [CommRing C] [Algebra B C]
 that image lies in the nilradical; being finitely generated it is then nilpotent.
 
 Nothing here needs `C` to be a localisation — only a `B`-algebra in which the image of `I` is
-contained in every prime. Wedhorn applies it to `C = (1 + I)⁻¹ B`, where that hypothesis is what
-his claim supplies. -/
+contained in every prime. It is used below at `C = (1 + I)⁻¹ B`, which is the case arising in the
+proof of Wedhorn's Proposition 7.49(2). -/
 theorem exists_pow_map_eq_bot (hfg : I.FG)
     (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
     ∃ n : ℕ, (I.map (algebraMap B C)) ^ n = ⊥ := by
@@ -71,9 +79,10 @@ section Localisation
 
 variable [IsLocalization (oneAdd I) C]
 
-/-- **A single element of `1 + I` annihilates a power of `I`.** Part (a) kills `I ^ n` in the
-localisation; each generator is then killed in `B` by some element of `1 + I`, and the product of
-those finitely many elements — again in `1 + I`, since it is a submonoid — kills all of `I ^ n`. -/
+/-- **A single element of `1 + I` annihilates a power of `I`.** Let `I` be a finitely generated
+ideal of `B` whose image in a localisation `C` at `1 + I` is contained in every prime of `C`.
+Then there are `n : ℕ` and `s ∈ 1 + I` with `s * x = 0` for every `x ∈ I ^ n` — one `s` serving
+the whole of `I ^ n`, not one per element. -/
 theorem exists_mem_oneAdd_forall_mul_eq_zero (hfg : I.FG)
     (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
     ∃ (n : ℕ) (s : B), s ∈ oneAdd I ∧ ∀ x ∈ I ^ n, s * x = 0 := by

--- a/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
+++ b/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
@@ -19,20 +19,20 @@ single element of `1 + I`.
 
 ## Main results
 
-* `TauCeti.Ideal.oneAdd`: `1 + I` as a submonoid of `B`.
-* `TauCeti.Ideal.exists_pow_map_eq_bot`: if `I` is finitely generated and its image lies in every
+* `Ideal.oneAdd`: `1 + I` as a submonoid of `B`.
+* `Ideal.exists_pow_map_eq_bot`: if `I` is finitely generated and its image lies in every
   prime of the localisation, some power of that image is zero.
-* `TauCeti.Ideal.exists_mem_one_add_mul_pow_eq_zero`: the same hypothesis produces a single
+* `Ideal.exists_mem_oneAdd_forall_mul_eq_zero`: the same hypothesis produces a single
   `s ∈ 1 + I` with `s * x = 0` for every `x ∈ I ^ n`.
 -/
 
 public section
 
-namespace TauCeti.Ideal
+namespace Ideal
 
 open scoped Pointwise
 
-variable {B : Type*} [CommRing B] (I : _root_.Ideal B)
+variable {B : Type*} [CommRing B] (I : Ideal B)
 
 /-- **`1 + I` is a submonoid.** Closure is the identity
 `(1 + a)(1 + b) = 1 + (ab + a + b)`, written here on representatives as
@@ -57,14 +57,14 @@ Nothing here needs `C` to be a localisation — only a `B`-algebra in which the 
 contained in every prime. Wedhorn applies it to `C = (1 + I)⁻¹ B`, where that hypothesis is what
 his claim supplies. -/
 theorem exists_pow_map_eq_bot (hfg : I.FG)
-    (hprime : ∀ P : _root_.Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
+    (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
     ∃ n : ℕ, (I.map (algebraMap B C)) ^ n = ⊥ := by
-  have hle : I.map (algebraMap B C) ≤ (⊥ : _root_.Ideal C).radical := by
+  have hle : I.map (algebraMap B C) ≤ (⊥ : Ideal C).radical := by
     intro x hx
-    rw [_root_.Ideal.radical_eq_sInf, Submodule.mem_sInf]
+    rw [Ideal.radical_eq_sInf, Submodule.mem_sInf]
     rintro P ⟨-, hP⟩
     exact hprime P hP hx
-  obtain ⟨n, hn⟩ := _root_.Ideal.exists_pow_le_of_le_radical_of_fg hle (hfg.map _)
+  obtain ⟨n, hn⟩ := Ideal.exists_pow_le_of_le_radical_of_fg hle (hfg.map _)
   exact ⟨n, le_bot_iff.mp hn⟩
 
 section Localisation
@@ -75,7 +75,7 @@ variable [IsLocalization (oneAdd I) C]
 localisation; each generator is then killed in `B` by some element of `1 + I`, and the product of
 those finitely many elements — again in `1 + I`, since it is a submonoid — kills all of `I ^ n`. -/
 theorem exists_mem_oneAdd_forall_mul_eq_zero (hfg : I.FG)
-    (hprime : ∀ P : _root_.Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
+    (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
     ∃ (n : ℕ) (s : B), s ∈ oneAdd I ∧ ∀ x ∈ I ^ n, s * x = 0 := by
   classical
   obtain ⟨n, hn⟩ := exists_pow_map_eq_bot (C := C) hfg hprime
@@ -83,15 +83,15 @@ theorem exists_mem_oneAdd_forall_mul_eq_zero (hfg : I.FG)
   have hzero : ∀ x ∈ I ^ n, algebraMap B C x = 0 := by
     intro x hx
     have : algebraMap B C x ∈ (I ^ n).map (algebraMap B C) :=
-      _root_.Ideal.mem_map_of_mem _ hx
-    rwa [_root_.Ideal.map_pow, hn, _root_.Ideal.mem_bot] at this
+      Ideal.mem_map_of_mem _ hx
+    rwa [Ideal.map_pow, hn, Ideal.mem_bot] at this
   -- a finite generating set for `I ^ n`
   obtain ⟨T, hT⟩ := (hfg.pow : (I ^ n).FG)
   -- an annihilator in `1 + I` for each generator
   have hgen : ∀ t ∈ T, ∃ m : oneAdd I, (m : B) * t = 0 := by
     intro t ht
     exact (IsLocalization.map_eq_zero_iff (oneAdd I) C t).mp
-      (hzero t (hT ▸ _root_.Ideal.subset_span ht))
+      (hzero t (hT ▸ Ideal.subset_span ht))
   choose m hm using hgen
   refine ⟨n, ∏ t ∈ T.attach, (m t.1 t.2 : B), ?_, ?_⟩
   · exact Submonoid.prod_mem _ fun t _ ↦ (m t.1 t.2).2
@@ -107,4 +107,4 @@ theorem exists_mem_oneAdd_forall_mul_eq_zero (hfg : I.FG)
 
 end Localisation
 
-end TauCeti.Ideal
+end Ideal

--- a/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
+++ b/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
@@ -19,13 +19,18 @@ element of `1 + I` annihilates a power of `I`.
 
 Only that implication is proved here, and only under `I.FG`; the converse is not stated.
 
+The nilpotence step is separated out and is not about localisation at all: it holds for the image
+of `I` in *any* commutative `B`-algebra whose primes all contain it, and needs only semirings.
+Localisation enters afterwards, to turn "the image is zero" into an annihilator lying in `1 + I`.
+
 ## Main results
 
 * `Ideal.oneAdd`: `1 + I` as a submonoid of `B`.
-* `Ideal.exists_pow_map_eq_bot`: if `I` is finitely generated and its image lies in every
-  prime of the localisation, some power of that image is zero.
-* `Ideal.exists_mem_oneAdd_forall_mul_eq_zero`: the same hypothesis produces a single
-  `s ∈ 1 + I` with `s * x = 0` for every `x ∈ I ^ n`.
+* `Ideal.exists_pow_map_eq_bot`: if `I` is finitely generated and its image lies in every prime
+  of an arbitrary commutative `B`-algebra, some power of that image is zero. Stated over
+  semirings, and applied below to the localisation.
+* `Ideal.exists_mem_oneAdd_forall_mul_eq_zero`: for a localisation at `1 + I`, the same
+  hypothesis produces a single `s ∈ 1 + I` with `s * x = 0` for every `x ∈ I ^ n`.
 
 ## References
 
@@ -39,6 +44,26 @@ public section
 namespace Ideal
 
 open scoped Pointwise
+
+section Nilpotent
+
+variable {B C : Type*} [CommSemiring B] [CommSemiring C] [Algebra B C] {I : Ideal B}
+
+/-- **A power of the image of `I` vanishes.** If every prime of `C` contains the image of `I`,
+that image lies in the nilradical; being finitely generated it is then nilpotent.
+
+Nothing here needs `C` to be a localisation — only a `B`-algebra in which the image of `I` is
+contained in every prime — and nothing needs subtraction, so this is stated over semirings while
+the rest of the file works over `CommRing` for `oneAdd`. It is used below at `C = (1 + I)⁻¹ B`,
+which is the case arising in the proof of Wedhorn's Proposition 7.49(2). -/
+theorem exists_pow_map_eq_bot (hfg : I.FG)
+    (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
+    ∃ n : ℕ, (I.map (algebraMap B C)) ^ n = ⊥ := by
+  obtain ⟨n, hn⟩ := (hfg.map (algebraMap B C)).isNilpotent_iff_le_nilradical.mpr
+    fun x hx ↦ mem_nilradical.mpr (nilpotent_iff_mem_prime.mpr fun P hP ↦ hprime P hP hx)
+  exact ⟨n, by simpa using hn⟩
+
+end Nilpotent
 
 variable {B : Type*} [CommRing B] (I : Ideal B)
 
@@ -57,23 +82,6 @@ def oneAdd : Submonoid B where
 @[simp] lemma mem_oneAdd {x : B} : x ∈ oneAdd I ↔ x - 1 ∈ I := Iff.rfl
 
 variable {I} {C : Type*} [CommRing C] [Algebra B C]
-
-/-- **A power of the image of `I` vanishes.** If every prime of `C` contains the image of `I`,
-that image lies in the nilradical; being finitely generated it is then nilpotent.
-
-Nothing here needs `C` to be a localisation — only a `B`-algebra in which the image of `I` is
-contained in every prime. It is used below at `C = (1 + I)⁻¹ B`, which is the case arising in the
-proof of Wedhorn's Proposition 7.49(2). -/
-theorem exists_pow_map_eq_bot (hfg : I.FG)
-    (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
-    ∃ n : ℕ, (I.map (algebraMap B C)) ^ n = ⊥ := by
-  have hle : I.map (algebraMap B C) ≤ (⊥ : Ideal C).radical := by
-    intro x hx
-    rw [Ideal.radical_eq_sInf, Submodule.mem_sInf]
-    rintro P ⟨-, hP⟩
-    exact hprime P hP hx
-  obtain ⟨n, hn⟩ := Ideal.exists_pow_le_of_le_radical_of_fg hle (hfg.map _)
-  exact ⟨n, le_bot_iff.mp hn⟩
 
 section Localisation
 

--- a/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
+++ b/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
@@ -8,14 +8,14 @@ module
 public import TauCeti.RingTheory.Ideal.Nilpotent
 public import Mathlib.RingTheory.Localization.Defs
 public import Mathlib.RingTheory.Finiteness.Ideal
-import Mathlib.Tactic.Ring
+import Mathlib.Tactic.NoncommRing
 
 /-!
-# Localising a semiring at `1 + I`
+# Localising at `1 + I`
 
-For an ideal `I` of a commutative semiring `B`, the set `1 + I` is a submonoid. If `I` is finitely
-generated and its image in a localisation at `1 + I` lies in every prime there, then a single
-element of `1 + I` annihilates a power of `I`.
+For an ideal `I` of a semiring `B`, the set `1 + I` is a submonoid of `B`. If `B` is commutative,
+`I` is finitely generated, and its image in a localisation at `1 + I` lies in every prime there,
+then a single element of `1 + I` annihilates a power of `I`.
 
 Only that implication is proved here, and only under `I.FG`; the converse is not stated.
 
@@ -25,8 +25,8 @@ to turn "the image of `I ^ n` is zero" into an annihilator lying in `1 + I`.
 
 ## Main results
 
-* `Ideal.oneAdd`: `1 + I` as a submonoid of `B`. Membership is recorded existentially, as
-  `∃ a ∈ I, x = 1 + a`, so that no subtraction is needed.
+* `Ideal.oneAdd`: `1 + I` as a submonoid of an arbitrary semiring `B`. Membership is recorded
+  existentially, as `∃ a ∈ I, x = 1 + a`, so that no subtraction is needed.
 * `Ideal.exists_mem_oneAdd_forall_mul_eq_zero`: if `I` is finitely generated and its image in a
   localisation `C` at `1 + I` is contained in every prime of `C`, there is a single `s ∈ 1 + I`
   with `s * x = 0` for every `x ∈ I ^ n`.
@@ -42,23 +42,28 @@ public section
 
 namespace Ideal
 
-variable {B : Type*} [CommSemiring B] (I : Ideal B)
+section Semiring
 
-/-- **`1 + I` is a submonoid.** Closure is the identity `(1 + a)(1 + b) = 1 + (a + b + a * b)`. -/
+variable {B : Type*} [Semiring B] (I : Ideal B)
+
+/-- **`1 + I` is a submonoid.** Closure is the identity `(1 + a)(1 + b) = 1 + (a + b + a * b)`,
+which needs no commutativity: `a * b` lies in `I` because `I` is closed under left
+multiplication. -/
 def oneAdd : Submonoid B where
   carrier := {x | ∃ a ∈ I, x = 1 + a}
   one_mem' := ⟨0, I.zero_mem, (add_zero 1).symm⟩
   mul_mem' {_ _} := by
     rintro ⟨a, ha, rfl⟩ ⟨b, hb, rfl⟩
-    exact ⟨a + b + a * b, I.add_mem (I.add_mem ha hb) (I.mul_mem_left a hb), by ring⟩
+    exact ⟨a + b + a * b, I.add_mem (I.add_mem ha hb) (I.mul_mem_left a hb), by noncomm_ring⟩
 
 @[simp] lemma mem_oneAdd {x : B} : x ∈ oneAdd I ↔ ∃ a ∈ I, x = 1 + a := Iff.rfl
 
-variable {I} {C : Type*} [CommSemiring C] [Algebra B C]
+end Semiring
 
 section Localisation
 
-variable [IsLocalization (oneAdd I) C]
+variable {B C : Type*} [CommSemiring B] [CommSemiring C] [Algebra B C] {I : Ideal B}
+  [IsLocalization (oneAdd I) C]
 
 /-- **A single element of `1 + I` annihilates a power of `I`.** Let `I` be a finitely generated
 ideal of `B` whose image in a localisation `C` at `1 + I` is contained in every prime of `C`.
@@ -68,7 +73,7 @@ theorem exists_mem_oneAdd_forall_mul_eq_zero (hfg : I.FG)
     (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
     ∃ (n : ℕ) (s : B), s ∈ oneAdd I ∧ ∀ x ∈ I ^ n, s * x = 0 := by
   classical
-  obtain ⟨n, hn⟩ := exists_pow_map_eq_bot (C := C) hfg hprime
+  obtain ⟨n, hn⟩ := exists_pow_map_eq_bot (algebraMap B C) hfg hprime
   -- every element of `I ^ n` maps to zero
   have hzero : ∀ x ∈ I ^ n, algebraMap B C x = 0 := by
     intro x hx

--- a/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
+++ b/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.Localization.Defs
+public import Mathlib.RingTheory.Noetherian.Nilpotent
+public import Mathlib.RingTheory.Finiteness.Ideal
+import Mathlib.Tactic.Ring
+
+/-!
+# Localising a ring at `1 + I`
+
+For an ideal `I` of a commutative ring `B`, the set `1 + I` is a submonoid, and localising at it
+makes every element of `I` lie in every prime exactly when a power of `I` is annihilated by a
+single element of `1 + I`.
+
+## Main results
+
+* `TauCeti.Ideal.oneAdd`: `1 + I` as a submonoid of `B`.
+* `TauCeti.Ideal.exists_pow_map_eq_bot`: if `I` is finitely generated and its image lies in every
+  prime of the localisation, some power of that image is zero.
+* `TauCeti.Ideal.exists_mem_one_add_mul_pow_eq_zero`: the same hypothesis produces a single
+  `s ∈ 1 + I` with `s * x = 0` for every `x ∈ I ^ n`.
+-/
+
+public section
+
+namespace TauCeti.Ideal
+
+open scoped Pointwise
+
+variable {B : Type*} [CommRing B] (I : _root_.Ideal B)
+
+/-- **`1 + I` is a submonoid.** Closure is the identity
+`(1 + a)(1 + b) = 1 + (ab + a + b)`, written here on representatives as
+`ab - 1 = (a - 1)(b - 1) + (a - 1) + (b - 1)`. -/
+def oneAdd : Submonoid B where
+  carrier := {x | x - 1 ∈ I}
+  one_mem' := by simp
+  mul_mem' {a b} ha hb := by
+    simp only [Set.mem_ofPred_eq] at *
+    have hexp : a * b - 1 = (a - 1) * (b - 1) + (a - 1) + (b - 1) := by ring
+    rw [hexp]
+    exact I.add_mem (I.add_mem (I.mul_mem_left _ hb) ha) hb
+
+@[simp] lemma mem_oneAdd {x : B} : x ∈ oneAdd I ↔ x - 1 ∈ I := Iff.rfl
+
+variable {I} {C : Type*} [CommRing C] [Algebra B C]
+
+/-- **A power of the image of `I` vanishes.** If every prime of `C` contains the image of `I`,
+that image lies in the nilradical; being finitely generated it is then nilpotent.
+
+Nothing here needs `C` to be a localisation — only a `B`-algebra in which the image of `I` is
+contained in every prime. Wedhorn applies it to `C = (1 + I)⁻¹ B`, where that hypothesis is what
+his claim supplies. -/
+theorem exists_pow_map_eq_bot (hfg : I.FG)
+    (hprime : ∀ P : _root_.Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
+    ∃ n : ℕ, (I.map (algebraMap B C)) ^ n = ⊥ := by
+  have hle : I.map (algebraMap B C) ≤ (⊥ : _root_.Ideal C).radical := by
+    intro x hx
+    rw [_root_.Ideal.radical_eq_sInf, Submodule.mem_sInf]
+    rintro P ⟨-, hP⟩
+    exact hprime P hP hx
+  obtain ⟨n, hn⟩ := _root_.Ideal.exists_pow_le_of_le_radical_of_fg hle (hfg.map _)
+  exact ⟨n, le_bot_iff.mp hn⟩
+
+section Localisation
+
+variable [IsLocalization (oneAdd I) C]
+
+/-- **A single element of `1 + I` annihilates a power of `I`.** Part (a) kills `I ^ n` in the
+localisation; each generator is then killed in `B` by some element of `1 + I`, and the product of
+those finitely many elements — again in `1 + I`, since it is a submonoid — kills all of `I ^ n`. -/
+theorem exists_mem_oneAdd_forall_mul_eq_zero (hfg : I.FG)
+    (hprime : ∀ P : _root_.Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
+    ∃ (n : ℕ) (s : B), s ∈ oneAdd I ∧ ∀ x ∈ I ^ n, s * x = 0 := by
+  classical
+  obtain ⟨n, hn⟩ := exists_pow_map_eq_bot (C := C) hfg hprime
+  -- every element of `I ^ n` maps to zero
+  have hzero : ∀ x ∈ I ^ n, algebraMap B C x = 0 := by
+    intro x hx
+    have : algebraMap B C x ∈ (I ^ n).map (algebraMap B C) :=
+      _root_.Ideal.mem_map_of_mem _ hx
+    rwa [_root_.Ideal.map_pow, hn, _root_.Ideal.mem_bot] at this
+  -- a finite generating set for `I ^ n`
+  obtain ⟨T, hT⟩ := (hfg.pow : (I ^ n).FG)
+  -- an annihilator in `1 + I` for each generator
+  have hgen : ∀ t ∈ T, ∃ m : oneAdd I, (m : B) * t = 0 := by
+    intro t ht
+    exact (IsLocalization.map_eq_zero_iff (oneAdd I) C t).mp
+      (hzero t (hT ▸ _root_.Ideal.subset_span ht))
+  choose m hm using hgen
+  refine ⟨n, ∏ t ∈ T.attach, (m t.1 t.2 : B), ?_, ?_⟩
+  · exact Submonoid.prod_mem _ fun t _ ↦ (m t.1 t.2).2
+  · rw [← hT]
+    intro x hx
+    induction hx using Submodule.span_induction with
+    | mem y hy =>
+        obtain ⟨t, rfl⟩ : ∃ t : T, (t : B) = y := ⟨⟨y, hy⟩, rfl⟩
+        rw [← Finset.prod_erase_mul _ _ (Finset.mem_attach T t), mul_assoc, hm t.1 t.2, mul_zero]
+    | zero => simp
+    | add y z _ _ hy hz => rw [mul_add, hy, hz, add_zero]
+    | smul c y _ hy => rw [smul_eq_mul, mul_comm c y, ← mul_assoc, hy, zero_mul]
+
+end Localisation
+
+end TauCeti.Ideal

--- a/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
+++ b/TauCeti/RingTheory/Ideal/OneAddLocalisation.lean
@@ -5,32 +5,31 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.RingTheory.Ideal.Nilpotent
 public import Mathlib.RingTheory.Localization.Defs
-public import Mathlib.RingTheory.Noetherian.Nilpotent
 public import Mathlib.RingTheory.Finiteness.Ideal
 import Mathlib.Tactic.Ring
 
 /-!
-# Localising a ring at `1 + I`
+# Localising a semiring at `1 + I`
 
-For an ideal `I` of a commutative ring `B`, the set `1 + I` is a submonoid. If `I` is finitely
+For an ideal `I` of a commutative semiring `B`, the set `1 + I` is a submonoid. If `I` is finitely
 generated and its image in a localisation at `1 + I` lies in every prime there, then a single
 element of `1 + I` annihilates a power of `I`.
 
 Only that implication is proved here, and only under `I.FG`; the converse is not stated.
 
-The nilpotence step is separated out and is not about localisation at all: it holds for the image
-of `I` in *any* commutative `B`-algebra whose primes all contain it, and needs only semirings.
-Localisation enters afterwards, to turn "the image is zero" into an annihilator lying in `1 + I`.
+The nilpotence step is not about localisation at all and lives in
+`TauCeti.RingTheory.Ideal.Nilpotent` as `Ideal.exists_pow_map_eq_bot`. Localisation enters here,
+to turn "the image of `I ^ n` is zero" into an annihilator lying in `1 + I`.
 
 ## Main results
 
-* `Ideal.oneAdd`: `1 + I` as a submonoid of `B`.
-* `Ideal.exists_pow_map_eq_bot`: if `I` is finitely generated and its image lies in every prime
-  of an arbitrary commutative `B`-algebra, some power of that image is zero. Stated over
-  semirings, and applied below to the localisation.
-* `Ideal.exists_mem_oneAdd_forall_mul_eq_zero`: for a localisation at `1 + I`, the same
-  hypothesis produces a single `s ∈ 1 + I` with `s * x = 0` for every `x ∈ I ^ n`.
+* `Ideal.oneAdd`: `1 + I` as a submonoid of `B`. Membership is recorded existentially, as
+  `∃ a ∈ I, x = 1 + a`, so that no subtraction is needed.
+* `Ideal.exists_mem_oneAdd_forall_mul_eq_zero`: if `I` is finitely generated and its image in a
+  localisation `C` at `1 + I` is contained in every prime of `C`, there is a single `s ∈ 1 + I`
+  with `s * x = 0` for every `x ∈ I ^ n`.
 
 ## References
 
@@ -43,45 +42,19 @@ public section
 
 namespace Ideal
 
-open scoped Pointwise
+variable {B : Type*} [CommSemiring B] (I : Ideal B)
 
-section Nilpotent
-
-variable {B C : Type*} [CommSemiring B] [CommSemiring C] [Algebra B C] {I : Ideal B}
-
-/-- **A power of the image of `I` vanishes.** If every prime of `C` contains the image of `I`,
-that image lies in the nilradical; being finitely generated it is then nilpotent.
-
-Nothing here needs `C` to be a localisation — only a `B`-algebra in which the image of `I` is
-contained in every prime — and nothing needs subtraction, so this is stated over semirings while
-the rest of the file works over `CommRing` for `oneAdd`. It is used below at `C = (1 + I)⁻¹ B`,
-which is the case arising in the proof of Wedhorn's Proposition 7.49(2). -/
-theorem exists_pow_map_eq_bot (hfg : I.FG)
-    (hprime : ∀ P : Ideal C, P.IsPrime → I.map (algebraMap B C) ≤ P) :
-    ∃ n : ℕ, (I.map (algebraMap B C)) ^ n = ⊥ := by
-  obtain ⟨n, hn⟩ := (hfg.map (algebraMap B C)).isNilpotent_iff_le_nilradical.mpr
-    fun x hx ↦ mem_nilradical.mpr (nilpotent_iff_mem_prime.mpr fun P hP ↦ hprime P hP hx)
-  exact ⟨n, by simpa using hn⟩
-
-end Nilpotent
-
-variable {B : Type*} [CommRing B] (I : Ideal B)
-
-/-- **`1 + I` is a submonoid.** Closure is the identity
-`(1 + a)(1 + b) = 1 + (ab + a + b)`, written here on representatives as
-`ab - 1 = (a - 1)(b - 1) + (a - 1) + (b - 1)`. -/
+/-- **`1 + I` is a submonoid.** Closure is the identity `(1 + a)(1 + b) = 1 + (a + b + a * b)`. -/
 def oneAdd : Submonoid B where
-  carrier := {x | x - 1 ∈ I}
-  one_mem' := by simp
-  mul_mem' {a b} ha hb := by
-    simp only [Set.mem_ofPred_eq] at *
-    have hexp : a * b - 1 = (a - 1) * (b - 1) + (a - 1) + (b - 1) := by ring
-    rw [hexp]
-    exact I.add_mem (I.add_mem (I.mul_mem_left _ hb) ha) hb
+  carrier := {x | ∃ a ∈ I, x = 1 + a}
+  one_mem' := ⟨0, I.zero_mem, (add_zero 1).symm⟩
+  mul_mem' {_ _} := by
+    rintro ⟨a, ha, rfl⟩ ⟨b, hb, rfl⟩
+    exact ⟨a + b + a * b, I.add_mem (I.add_mem ha hb) (I.mul_mem_left a hb), by ring⟩
 
-@[simp] lemma mem_oneAdd {x : B} : x ∈ oneAdd I ↔ x - 1 ∈ I := Iff.rfl
+@[simp] lemma mem_oneAdd {x : B} : x ∈ oneAdd I ↔ ∃ a ∈ I, x = 1 + a := Iff.rfl
 
-variable {I} {C : Type*} [CommRing C] [Algebra B C]
+variable {I} {C : Type*} [CommSemiring C] [Algebra B C]
 
 section Localisation
 


### PR DESCRIPTION
The localisation half of Wedhorn's proof of Proposition 7.49(2). With #5093 (the stabilisation step) this completes bead tc-4w1xw.

## What this adds

**`Ideal.exists_pow_map_eq_bot`**, in a new module `TauCeti/RingTheory/Ideal/Nilpotent.lean` — if `I` is a finitely generated ideal of `B` and `f : B →+* C` carries it into every prime of `C`, then `(I.map f) ^ n = ⊥` for some `n`. Every element of the image is nilpotent by `nilpotent_iff_mem_prime`, so the image lies in the nilradical, and a finitely generated ideal there is nilpotent by `Ideal.FG.isNilpotent_iff_le_nilradical`.

**`Ideal.oneAdd`** — `1 + I` as a submonoid of `B`. Mathlib does not carry it; closure is the identity `(1 + a)(1 + b) = 1 + (a + b + a * b)`.

**`Ideal.exists_mem_oneAdd_forall_mul_eq_zero`** — descending to `B`: a *single* `s ∈ 1 + I` annihilates all of `I ^ n`. Each generator of `I ^ n` is killed by some element of `1 + I` via `IsLocalization.map_eq_zero_iff`; the product over the finitely many generators is again in `1 + I` because it is a submonoid, kills each generator, and hence kills the span.

## Hypotheses, and why the nilpotence step is its own module

Each declaration carries only what its own proof uses, and the elaborated signatures were read back rather than trusting the section headers:

| declaration | assumptions |
|---|---|
| `Ideal.oneAdd`, `Ideal.mem_oneAdd` | `[Semiring B]` |
| `Ideal.exists_pow_map_eq_bot` | `[Semiring B] [CommSemiring C]`, an explicit `f : B →+* C` |
| `Ideal.exists_mem_oneAdd_forall_mul_eq_zero` | `[CommSemiring B] [CommSemiring C] [Algebra B C] [IsLocalization (oneAdd I) C]` |

`oneAdd` needs no commutativity: `a * b` lies in `I` because a Mathlib `Ideal` is a left ideal, and what remains is the additive reassociation that `noncomm_ring` discharges. Nothing subtracts anywhere — membership in `1 + I` is recorded existentially as `∃ a ∈ I, x = 1 + a` rather than as `x - 1 ∈ I`, which is what lets the whole file leave `CommRing` behind.

`exists_pow_map_eq_bot` takes a bare ring homomorphism rather than an `Algebra` instance, because that is all its proof sees: on the source side its only input is `Ideal.FG.map`, stated in mathlib as `{R S} [Semiring R] [Semiring S] (h : I.FG) (f : R →+* S)` (`RingTheory/Finiteness/Ideal.lean:27`). Commutativity enters only on the target, where the primes are — `nilpotent_iff_mem_prime` and `Ideal.FG.isNilpotent_iff_le_nilradical` are both `[CommSemiring]`. Wedhorn applies the result at `f = algebraMap B (1 + I)⁻¹B`, where his claim supplies the containment; since the statement never mentions localisation, keeping it in `OneAddLocalisation` hid generic material under a narrower topic, so it lives in its own module and the localisation file imports it. TauCeti had no ideal-nilpotence module — `RingTheory/Nilpotent/` is about nilpotent exponentials and the Chevalley commutator — hence a new one rather than an existing home.

## What is deliberately not proved

The hypothesis `∀ P prime, I.map (algebraMap B C) ≤ P` is Wedhorn's **claim**. It runs through Lemma 7.45 and the microbiality substrate (beads tc-5x8pj, tc-cttcb), which is why 7.49 has been unbuildable as a whole. It is taken as a hypothesis here, exactly as bead tc-4w1xw specifies — that split is what makes this half landable now, and it is a genuine sub-result rather than a workaround.

## Roadmap grounding

New declarations, so citing the target rather than the area.

**AdicSpaces, README.md:427** (verified on `origin/main`, not `HEAD`): *"Prove Proposition 7.49(2), including the criterion for this locus to be empty"*. Wedhorn 7.49 is the identified blocker of the `O_X` chain.

## Verification

At `0eba89ffc`, using the rig's build command:

* `env LEAN4_GUARDRAILS_BYPASS=1 lake build TauCeti.RingTheory.Ideal.Nilpotent TauCeti.RingTheory.Ideal.OneAddLocalisation` — exit 0, "Build completed successfully (1481 jobs)", no error, warning or `sorry`. `OneAddLocalisation` has no importers and imports the new module, so those two are the complete module-scoped gate (checked with a positive control, since an unquoted `--include=*.lean` silently reports no matches under zsh).
* `#lint only <the 13 default linters> in TauCeti` — "Found 0 errors in 4 declarations (plus 4 automatically generated ones) ... All linting checks passed!" The count of 4 is the check that the module-prefix scope actually caught these declarations.
* `#print axioms` on all four — exactly `propext`, `Classical.choice`, `Quot.sound` (`oneAdd` and `mem_oneAdd` need only `propext`).
* `scripts/lint-dot-notation.py` — `0 new`. `scripts/HeaderStyle.lean` on both files — conforming. No line over 100 characters, measured in codepoints (max 98).

The diff against `main` is these two files.

Roadmap: AdicSpaces
