### PR TITLE
feat(Localization): inverting a topologically nilpotent element does not see an open subring

### DIFF
--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -39,8 +39,6 @@ Huber namespace, alongside `TauCeti/RingTheory/Localization/DenIdeal.lean`.
   splits as `(a · r)/s · (b · u)/s`, each half carrying one factor of the denominator.
 * `TauCeti.Localization.awayLift_divBy`: the comparison map to a localisation at a multiple
   `w = u * r` rescales fractions by the cofactor, sending `a/u` to `(a · r)/w`.
-* `TauCeti.Localization.awayMap_subtype_injective`: the induced map on localisations of a
-  subring is injective.
 
 ## Provenance
 
@@ -212,23 +210,5 @@ adic spectrum. -/
 bijective. -/
 instance isLocalizationAwayOne (R : Type*) [CommSemiring R] : IsLocalization.Away (1 : R) R :=
   IsLocalization.away_of_isUnit_of_bijective _ isUnit_one (Equiv.refl _).bijective
-
-/-! ### Localising a subring
-
-Inverting an element of a subring `B ≤ A` on both sides gives a map `B_s → A_s`, and it is always
-injective: an element of `B` that dies in `A` is already zero. Surjectivity is a genuinely
-different matter and needs more than algebra — see
-`TauCeti/RingTheory/Localization/OpenSubring.lean`. -/
-
-/-- **The localisation of a subring injects into the localisation of the ring.** `B → A` is
-injective, so an element of `B` dying in `A` is already zero, and
-`IsLocalization.Away.map_injective_iff` is met at the zeroth power of `s`. -/
-theorem awayMap_subtype_injective {A : Type*} [CommRing A] {B : Subring A} {s : B}
-    (Bs As : Type*) [CommRing Bs] [CommRing As]
-    [Algebra B Bs] [IsLocalization.Away s Bs]
-    [Algebra A As] [IsLocalization.Away (B.subtype s) As] :
-    Function.Injective (IsLocalization.Away.map Bs As B.subtype s) := by
-  rw [IsLocalization.Away.map_injective_iff]
-  exact fun b hb ↦ ⟨0, by rw [pow_zero, one_mul]; exact Subtype.ext hb⟩
 
 end TauCeti.Localization

--- a/TauCeti/RingTheory/Localization/Away.lean
+++ b/TauCeti/RingTheory/Localization/Away.lean
@@ -39,6 +39,8 @@ Huber namespace, alongside `TauCeti/RingTheory/Localization/DenIdeal.lean`.
   splits as `(a · r)/s · (b · u)/s`, each half carrying one factor of the denominator.
 * `TauCeti.Localization.awayLift_divBy`: the comparison map to a localisation at a multiple
   `w = u * r` rescales fractions by the cofactor, sending `a/u` to `(a · r)/w`.
+* `TauCeti.Localization.awayMap_subtype_injective`: the induced map on localisations of a
+  subring is injective.
 
 ## Provenance
 
@@ -210,5 +212,23 @@ adic spectrum. -/
 bijective. -/
 instance isLocalizationAwayOne (R : Type*) [CommSemiring R] : IsLocalization.Away (1 : R) R :=
   IsLocalization.away_of_isUnit_of_bijective _ isUnit_one (Equiv.refl _).bijective
+
+/-! ### Localising a subring
+
+Inverting an element of a subring `B ≤ A` on both sides gives a map `B_s → A_s`, and it is always
+injective: an element of `B` that dies in `A` is already zero. Surjectivity is a genuinely
+different matter and needs more than algebra — see
+`TauCeti/RingTheory/Localization/OpenSubring.lean`. -/
+
+/-- **The localisation of a subring injects into the localisation of the ring.** `B → A` is
+injective, so an element of `B` dying in `A` is already zero, and
+`IsLocalization.Away.map_injective_iff` is met at the zeroth power of `s`. -/
+theorem awayMap_subtype_injective {A : Type*} [CommRing A] {B : Subring A} {s : B}
+    (Bs As : Type*) [CommRing Bs] [CommRing As]
+    [Algebra B Bs] [IsLocalization.Away s Bs]
+    [Algebra A As] [IsLocalization.Away (B.subtype s) As] :
+    Function.Injective (IsLocalization.Away.map Bs As B.subtype s) := by
+  rw [IsLocalization.Away.map_injective_iff]
+  exact fun b hb ↦ ⟨0, by rw [pow_zero, one_mul]; exact Subtype.ext hb⟩
 
 end TauCeti.Localization

--- a/TauCeti/RingTheory/Localization/OpenSubring.lean
+++ b/TauCeti/RingTheory/Localization/OpenSubring.lean
@@ -5,7 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import TauCeti.RingTheory.Localization.Away
+public import Mathlib.RingTheory.Localization.Away.Basic
 public import TauCeti.Topology.Algebra.TopologicallyNilpotent
 
 /-!
@@ -17,8 +17,7 @@ nilpotent in `A`. Inverting `s` on both sides does not distinguish the two rings
 
 The point is that `B` is open, so a topologically nilpotent `s` absorbs every element of `A` into
 `B` after enough multiplications. Passing to `B_s` makes that absorption invertible, which is
-exactly what surjectivity needs. Injectivity is not topological at all and lives one file down, in
-`RingTheory/Localization/Away.lean`, as `TauCeti.Localization.awayMap_subtype_injective`.
+exactly what surjectivity needs. Injectivity is not topological at all and is Mathlib's already.
 
 ## Implementation notes
 
@@ -29,6 +28,11 @@ commuting the product.
 
 Only `ContinuousMul` is assumed, matching the absorption lemma: continuity of addition, a
 nonarchimedean neighbourhood basis and any Huber structure are all irrelevant here.
+
+Injectivity is not proved here at all: it is Mathlib's `IsLocalization.map_injective_of_injective`
+applied to `Subring.subtype_injective`, which already says an injective ring map induces an
+injective map on the corresponding localisations. Nothing about the subring being *open*, or about
+`s`, enters that half.
 
 ## Source
 
@@ -67,11 +71,13 @@ theorem awayMap_subtype_surjective_of_isTopologicallyNilpotent (hB : IsOpen (B :
 
 /-- **Inverting a topologically nilpotent element does not see an open subring.** For `B` an open
 subring of `A` and `s : B` topologically nilpotent in `A`, the induced map `B_s → A_s` is a ring
-isomorphism: injective for any subring, surjective because `s` absorbs into the open `B`. -/
+isomorphism: injective for any subring by `IsLocalization.map_injective_of_injective`, surjective
+because `s` absorbs into the open `B`. -/
 noncomputable def awayRingEquivOfIsTopologicallyNilpotent (hB : IsOpen (B : Set A))
     (hs : IsTopologicallyNilpotent (s : A)) : Bs ≃+* As :=
-  RingEquiv.ofBijective _ ⟨awayMap_subtype_injective Bs As,
-    awayMap_subtype_surjective_of_isTopologicallyNilpotent Bs As hB hs⟩
+  RingEquiv.ofBijective _
+    ⟨IsLocalization.map_injective_of_injective _ _ _ B.subtype_injective,
+      awayMap_subtype_surjective_of_isTopologicallyNilpotent Bs As hB hs⟩
 
 @[simp] theorem coe_awayRingEquivOfIsTopologicallyNilpotent (hB : IsOpen (B : Set A))
     (hs : IsTopologicallyNilpotent (s : A)) :

--- a/TauCeti/RingTheory/Localization/OpenSubring.lean
+++ b/TauCeti/RingTheory/Localization/OpenSubring.lean
@@ -54,7 +54,12 @@ namespace TauCeti.Localization
 
 variable {A : Type*} [CommRing A] [TopologicalSpace A] [ContinuousMul A]
 variable {B : Subring A} {s : B}
-variable (Bs As : Type*) [CommRing Bs] [CommRing As]
+
+section Surjective
+
+-- Surjectivity needs no subtraction in the localisations: `IsLocalization.Away.map_surjective_iff`
+-- is stated over a `CommSemiring`, unlike its injectivity counterpart, which re-binds `CommRing`.
+variable (Bs As : Type*) [CommSemiring Bs] [CommSemiring As]
   [Algebra B Bs] [IsLocalization.Away s Bs]
   [Algebra A As] [IsLocalization.Away (B.subtype s) As]
 
@@ -68,6 +73,16 @@ theorem awayMap_subtype_surjective_of_isTopologicallyNilpotent (hB : IsOpen (B :
   intro a
   obtain ⟨n, hn⟩ := exists_mul_pow_mem_of_isTopologicallyNilpotent hs hB a
   exact ⟨⟨a * (s : A) ^ n, hn⟩, n, mul_comm a ((s : A) ^ n)⟩
+
+end Surjective
+
+section RingEquiv
+
+-- The isomorphism itself is a `RingEquiv`, and its injectivity half goes through
+-- `IsLocalization.map_injective_of_injective`, so here the targets must be rings.
+variable (Bs As : Type*) [CommRing Bs] [CommRing As]
+  [Algebra B Bs] [IsLocalization.Away s Bs]
+  [Algebra A As] [IsLocalization.Away (B.subtype s) As]
 
 /-- **Inverting a topologically nilpotent element does not see an open subring.** For `B` an open
 subring of `A` and `s : B` topologically nilpotent in `A`, the induced map `B_s → A_s` is a ring
@@ -86,6 +101,8 @@ noncomputable def awayRingEquivOfIsTopologicallyNilpotent (hB : IsOpen (B : Set 
   -- `rfl` cannot see through `awayRingEquivOfIsTopologicallyNilpotent`: its body is not exposed
   -- outside this module, so the coercion is unfolded through `RingEquiv`'s own interface lemma.
   RingEquiv.coe_ofBijective _ _
+
+end RingEquiv
 
 end TauCeti.Localization
 

--- a/TauCeti/RingTheory/Localization/OpenSubring.lean
+++ b/TauCeti/RingTheory/Localization/OpenSubring.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.RingTheory.Localization.Away.Basic
+public import TauCeti.Topology.Algebra.TopologicallyNilpotent
+
+/-!
+# Localising an open subring at a topologically nilpotent element
+
+Let `B` be an **open** subring of a topological ring `A`, and let `s : B` be topologically
+nilpotent in `A`. Inverting `s` on both sides does not distinguish the two rings: the induced map
+`B_s → A_s` is a ring isomorphism.
+
+The point is that `B` is open, so a topologically nilpotent `s` absorbs every element of `A` into
+`B` after enough multiplications. Passing to `B_s` makes that absorption invertible, which is
+exactly what surjectivity needs, while injectivity is free because `B → A` is injective to begin
+with.
+
+## Implementation notes
+
+Both halves go through the Mathlib criteria rather than through elements of the localisations.
+`IsLocalization.Away.map_injective_iff` reduces injectivity to "if `b` dies in `A` then some
+`sⁿ * b` dies in `B`", which holds with `n = 0` since `Subring.subtype` is injective — no power of
+`s` is needed. `IsLocalization.Away.map_surjective_iff` reduces surjectivity to "every `a : A` is
+`sᵐ` times the image of something in `B`", which is `exists_mul_pow_mem_of_isTopologicallyNilpotent`
+verbatim, up to commuting the product.
+
+Only `ContinuousMul` is assumed, matching the absorption lemma: continuity of addition, a
+nonarchimedean neighbourhood basis and any Huber structure are all irrelevant here.
+
+## Source
+
+Wedhorn, *Adic Spaces* (arXiv:1910.05934v1), the localisation step inside the proof of Lemma
+7.44(1). Only that step is formalised here — the spectral half of 7.44(1), the homeomorphism
+between the complements of the two closed subsets, is **not** proved in this file.
+
+## Main results
+
+* `injective_awayMap_subtype`: the induced map on localisations is injective, for any subring.
+* `surjective_awayMap_subtype_of_isTopologicallyNilpotent`: it is surjective when the subring is
+  open and `s` is topologically nilpotent.
+* `bijective_awayMap_subtype_of_isTopologicallyNilpotent`: hence bijective.
+* `awayRingEquivOfIsTopologicallyNilpotent`: the isomorphism `B_s ≃+* A_s` it packages.
+-/
+
+public section
+
+variable {A : Type*} [CommRing A]
+variable {B : Subring A} {s : B}
+variable (Bs As : Type*) [CommRing Bs] [CommRing As]
+  [Algebra B Bs] [IsLocalization.Away s Bs]
+  [Algebra A As] [IsLocalization.Away (B.subtype s) As]
+
+/-- **The localisation of a subring injects into the localisation of the ring.** No topology and no
+openness are needed: `B → A` is injective, so an element of `B` that dies in `A` is already zero,
+and the criterion is met with the zeroth power of `s`. -/
+theorem injective_awayMap_subtype :
+    Function.Injective (IsLocalization.Away.map Bs As B.subtype s) := by
+  rw [IsLocalization.Away.map_injective_iff]
+  exact fun b hb ↦ ⟨0, by rw [pow_zero, one_mul]; exact Subtype.ext hb⟩
+
+-- The topology enters only from here: it is what makes `s` absorb elements of `A` into `B`.
+variable [TopologicalSpace A] [ContinuousMul A]
+
+/-- **The localisation of an open subring surjects onto the localisation of the ring.** Given
+`a : A`, the topologically nilpotent `s` absorbs it into the open subring `B` after some number of
+multiplications, and inverting `s` undoes them. -/
+theorem surjective_awayMap_subtype_of_isTopologicallyNilpotent (hB : IsOpen (B : Set A))
+    (hs : IsTopologicallyNilpotent (s : A)) :
+    Function.Surjective (IsLocalization.Away.map Bs As B.subtype s) := by
+  rw [IsLocalization.Away.map_surjective_iff]
+  intro a
+  obtain ⟨n, hn⟩ := exists_mul_pow_mem_of_isTopologicallyNilpotent hs hB a
+  exact ⟨⟨a * (s : A) ^ n, hn⟩, n, mul_comm a ((s : A) ^ n)⟩
+
+/-- **Inverting a topologically nilpotent element does not see an open subring.** For `B` an open
+subring of `A` and `s : B` topologically nilpotent in `A`, the induced map `B_s → A_s` is
+bijective. -/
+theorem bijective_awayMap_subtype_of_isTopologicallyNilpotent (hB : IsOpen (B : Set A))
+    (hs : IsTopologicallyNilpotent (s : A)) :
+    Function.Bijective (IsLocalization.Away.map Bs As B.subtype s) :=
+  ⟨injective_awayMap_subtype Bs As,
+    surjective_awayMap_subtype_of_isTopologicallyNilpotent Bs As hB hs⟩
+
+/-- The isomorphism `B_s ≃+* A_s` of
+`bijective_awayMap_subtype_of_isTopologicallyNilpotent`. -/
+noncomputable def awayRingEquivOfIsTopologicallyNilpotent (hB : IsOpen (B : Set A))
+    (hs : IsTopologicallyNilpotent (s : A)) : Bs ≃+* As :=
+  RingEquiv.ofBijective _ (bijective_awayMap_subtype_of_isTopologicallyNilpotent Bs As hB hs)
+
+@[simp] theorem coe_awayRingEquivOfIsTopologicallyNilpotent (hB : IsOpen (B : Set A))
+    (hs : IsTopologicallyNilpotent (s : A)) :
+    ⇑(awayRingEquivOfIsTopologicallyNilpotent Bs As hB hs) =
+      IsLocalization.Away.map Bs As B.subtype s :=
+  -- `rfl` cannot see through `awayRingEquivOfIsTopologicallyNilpotent`: its body is not exposed
+  -- outside this module, so the coercion is unfolded through `RingEquiv`'s own interface lemma.
+  RingEquiv.coe_ofBijective _ _
+
+end

--- a/TauCeti/RingTheory/Localization/OpenSubring.lean
+++ b/TauCeti/RingTheory/Localization/OpenSubring.lean
@@ -55,10 +55,9 @@ namespace TauCeti.Localization
 variable {A : Type*} [CommRing A] [TopologicalSpace A] [ContinuousMul A]
 variable {B : Subring A} {s : B}
 
-section Surjective
-
--- Surjectivity needs no subtraction in the localisations: `IsLocalization.Away.map_surjective_iff`
--- is stated over a `CommSemiring`, unlike its injectivity counterpart, which re-binds `CommRing`.
+-- Neither half needs subtraction in the localisations: `IsLocalization.Away.map_surjective_iff` and
+-- `IsLocalization.map_injective_of_injective` are both stated over a `CommSemiring`, so the two
+-- localisation targets stay semirings even though `A`, and hence the subring `B`, is a ring.
 variable (Bs As : Type*) [CommSemiring Bs] [CommSemiring As]
   [Algebra B Bs] [IsLocalization.Away s Bs]
   [Algebra A As] [IsLocalization.Away (B.subtype s) As]
@@ -73,16 +72,6 @@ theorem awayMap_subtype_surjective_of_isTopologicallyNilpotent (hB : IsOpen (B :
   intro a
   obtain ⟨n, hn⟩ := exists_mul_pow_mem_of_isTopologicallyNilpotent hs hB a
   exact ⟨⟨a * (s : A) ^ n, hn⟩, n, mul_comm a ((s : A) ^ n)⟩
-
-end Surjective
-
-section RingEquiv
-
--- The isomorphism itself is a `RingEquiv`, and its injectivity half goes through
--- `IsLocalization.map_injective_of_injective`, so here the targets must be rings.
-variable (Bs As : Type*) [CommRing Bs] [CommRing As]
-  [Algebra B Bs] [IsLocalization.Away s Bs]
-  [Algebra A As] [IsLocalization.Away (B.subtype s) As]
 
 /-- **Inverting a topologically nilpotent element does not see an open subring.** For `B` an open
 subring of `A` and `s : B` topologically nilpotent in `A`, the induced map `B_s → A_s` is a ring
@@ -101,8 +90,6 @@ noncomputable def awayRingEquivOfIsTopologicallyNilpotent (hB : IsOpen (B : Set 
   -- `rfl` cannot see through `awayRingEquivOfIsTopologicallyNilpotent`: its body is not exposed
   -- outside this module, so the coercion is unfolded through `RingEquiv`'s own interface lemma.
   RingEquiv.coe_ofBijective _ _
-
-end RingEquiv
 
 end TauCeti.Localization
 

--- a/TauCeti/RingTheory/Localization/OpenSubring.lean
+++ b/TauCeti/RingTheory/Localization/OpenSubring.lean
@@ -5,7 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.RingTheory.Localization.Away.Basic
+public import TauCeti.RingTheory.Localization.Away
 public import TauCeti.Topology.Algebra.TopologicallyNilpotent
 
 /-!
@@ -17,17 +17,15 @@ nilpotent in `A`. Inverting `s` on both sides does not distinguish the two rings
 
 The point is that `B` is open, so a topologically nilpotent `s` absorbs every element of `A` into
 `B` after enough multiplications. Passing to `B_s` makes that absorption invertible, which is
-exactly what surjectivity needs, while injectivity is free because `B → A` is injective to begin
-with.
+exactly what surjectivity needs. Injectivity is not topological at all and lives one file down, in
+`RingTheory/Localization/Away.lean`, as `TauCeti.Localization.awayMap_subtype_injective`.
 
 ## Implementation notes
 
-Both halves go through the Mathlib criteria rather than through elements of the localisations.
-`IsLocalization.Away.map_injective_iff` reduces injectivity to "if `b` dies in `A` then some
-`sⁿ * b` dies in `B`", which holds with `n = 0` since `Subring.subtype` is injective — no power of
-`s` is needed. `IsLocalization.Away.map_surjective_iff` reduces surjectivity to "every `a : A` is
-`sᵐ` times the image of something in `B`", which is `exists_mul_pow_mem_of_isTopologicallyNilpotent`
-verbatim, up to commuting the product.
+Surjectivity goes through the Mathlib criterion rather than through elements of the localisations:
+`IsLocalization.Away.map_surjective_iff` reduces it to "every `a : A` is `sᵐ` times the image of
+something in `B`", which is `exists_mul_pow_mem_of_isTopologicallyNilpotent` verbatim, up to
+commuting the product.
 
 Only `ContinuousMul` is assumed, matching the absorption lemma: continuity of addition, a
 nonarchimedean neighbourhood basis and any Huber structure are all irrelevant here.
@@ -40,36 +38,26 @@ between the complements of the two closed subsets, is **not** proved in this fil
 
 ## Main results
 
-* `injective_awayMap_subtype`: the induced map on localisations is injective, for any subring.
-* `surjective_awayMap_subtype_of_isTopologicallyNilpotent`: it is surjective when the subring is
-  open and `s` is topologically nilpotent.
-* `bijective_awayMap_subtype_of_isTopologicallyNilpotent`: hence bijective.
-* `awayRingEquivOfIsTopologicallyNilpotent`: the isomorphism `B_s ≃+* A_s` it packages.
+* `TauCeti.Localization.awayMap_subtype_surjective_of_isTopologicallyNilpotent`: the induced map on
+  localisations is surjective when the subring is open and `s` is topologically nilpotent.
+* `TauCeti.Localization.awayRingEquivOfIsTopologicallyNilpotent`: the resulting isomorphism
+  `B_s ≃+* A_s`.
 -/
 
 public section
 
-variable {A : Type*} [CommRing A]
+namespace TauCeti.Localization
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [ContinuousMul A]
 variable {B : Subring A} {s : B}
 variable (Bs As : Type*) [CommRing Bs] [CommRing As]
   [Algebra B Bs] [IsLocalization.Away s Bs]
   [Algebra A As] [IsLocalization.Away (B.subtype s) As]
 
-/-- **The localisation of a subring injects into the localisation of the ring.** No topology and no
-openness are needed: `B → A` is injective, so an element of `B` that dies in `A` is already zero,
-and the criterion is met with the zeroth power of `s`. -/
-theorem injective_awayMap_subtype :
-    Function.Injective (IsLocalization.Away.map Bs As B.subtype s) := by
-  rw [IsLocalization.Away.map_injective_iff]
-  exact fun b hb ↦ ⟨0, by rw [pow_zero, one_mul]; exact Subtype.ext hb⟩
-
--- The topology enters only from here: it is what makes `s` absorb elements of `A` into `B`.
-variable [TopologicalSpace A] [ContinuousMul A]
-
 /-- **The localisation of an open subring surjects onto the localisation of the ring.** Given
 `a : A`, the topologically nilpotent `s` absorbs it into the open subring `B` after some number of
 multiplications, and inverting `s` undoes them. -/
-theorem surjective_awayMap_subtype_of_isTopologicallyNilpotent (hB : IsOpen (B : Set A))
+theorem awayMap_subtype_surjective_of_isTopologicallyNilpotent (hB : IsOpen (B : Set A))
     (hs : IsTopologicallyNilpotent (s : A)) :
     Function.Surjective (IsLocalization.Away.map Bs As B.subtype s) := by
   rw [IsLocalization.Away.map_surjective_iff]
@@ -78,19 +66,12 @@ theorem surjective_awayMap_subtype_of_isTopologicallyNilpotent (hB : IsOpen (B :
   exact ⟨⟨a * (s : A) ^ n, hn⟩, n, mul_comm a ((s : A) ^ n)⟩
 
 /-- **Inverting a topologically nilpotent element does not see an open subring.** For `B` an open
-subring of `A` and `s : B` topologically nilpotent in `A`, the induced map `B_s → A_s` is
-bijective. -/
-theorem bijective_awayMap_subtype_of_isTopologicallyNilpotent (hB : IsOpen (B : Set A))
-    (hs : IsTopologicallyNilpotent (s : A)) :
-    Function.Bijective (IsLocalization.Away.map Bs As B.subtype s) :=
-  ⟨injective_awayMap_subtype Bs As,
-    surjective_awayMap_subtype_of_isTopologicallyNilpotent Bs As hB hs⟩
-
-/-- The isomorphism `B_s ≃+* A_s` of
-`bijective_awayMap_subtype_of_isTopologicallyNilpotent`. -/
+subring of `A` and `s : B` topologically nilpotent in `A`, the induced map `B_s → A_s` is a ring
+isomorphism: injective for any subring, surjective because `s` absorbs into the open `B`. -/
 noncomputable def awayRingEquivOfIsTopologicallyNilpotent (hB : IsOpen (B : Set A))
     (hs : IsTopologicallyNilpotent (s : A)) : Bs ≃+* As :=
-  RingEquiv.ofBijective _ (bijective_awayMap_subtype_of_isTopologicallyNilpotent Bs As hB hs)
+  RingEquiv.ofBijective _ ⟨awayMap_subtype_injective Bs As,
+    awayMap_subtype_surjective_of_isTopologicallyNilpotent Bs As hB hs⟩
 
 @[simp] theorem coe_awayRingEquivOfIsTopologicallyNilpotent (hB : IsOpen (B : Set A))
     (hs : IsTopologicallyNilpotent (s : A)) :
@@ -99,5 +80,7 @@ noncomputable def awayRingEquivOfIsTopologicallyNilpotent (hB : IsOpen (B : Set 
   -- `rfl` cannot see through `awayRingEquivOfIsTopologicallyNilpotent`: its body is not exposed
   -- outside this module, so the coercion is unfolded through `RingEquiv`'s own interface lemma.
   RingEquiv.coe_ofBijective _ _
+
+end TauCeti.Localization
 
 end


### PR DESCRIPTION
For `B` an **open** subring of a topological ring `A` and `s : B` topologically nilpotent in `A`,
the induced map on away-localisations `B_s → A_s` is a ring isomorphism. **One new file**, three
declarations, nothing else touched.

## What this does *not* claim

Wedhorn's Lemma 7.44(1) is two statements: this localisation step, and a **homeomorphism** between
the complements of the two closed subsets. **Only the localisation step is here**, in the file
docstring as well as the title. This is deliberate — a docstring implying the whole of 7.44(1) is
what put #4910 through a correctness round.

## The mathematics

Surjectivity is the only half that needs proving, and it is one line through the Mathlib criterion.
`IsLocalization.Away.map_surjective_iff` reduces it to *"every `a : A` is `sᵐ` times the image of
something in `B`"*, which is `exists_mul_pow_mem_of_isTopologicallyNilpotent` verbatim, up to
`mul_comm`: a topologically nilpotent element absorbs any element of `A` into any open subring.

Injectivity is **not proved here at all** — it is Mathlib's `IsLocalization.map_injective_of_injective`
applied to `Subring.subtype_injective`. Nothing about openness, or about `s`, enters that half.

Only `ContinuousMul` is assumed, matching the absorption lemma. Continuity of addition, a
nonarchimedean neighbourhood basis and any Huber structure are all irrelevant, so none is required.

The absorption lemma's path moved during #4934's review: that PR's body placed it in
`RingTheory/Huber/Basic.lean`, but on `main` it is
`TauCeti/Topology/Algebra/TopologicallyNilpotent.lean:87`. Verified before importing — the name
resolves at the new path and is absent from `Huber/Basic.lean`.

## Review history

**Round 4 — `generality`, taken.** The isomorphism half drops to `CommSemiring` too, so the two
variable blocks collapse into one and both sections go with them. **This reverses the second half of
round 3's suggested fix, and round 4 is the one that is right** — recorded here rather than
contested, because I checked it before acting.

Round 3 said to keep `CommRing` "separately for the `RingEquiv` definition and coercion theorem".
That reads as sound and is not: it turns on a near miss between two Mathlib lemmas with nearly the
same name. `IsLocalization.Away.awayMap_injective_iff` (`Localization/Away/Basic.lean:501`) *does*
re-bind `[CommRing R]`, through `injective_iff_map_eq_zero` — but this file never calls it. The
lemma it actually applies is `IsLocalization.map_injective_of_injective`, at
`Localization/Defs.lean:715`, which sits **inside** that file's `CommSemiring` section (`end
CommSemiring` is at `:902`) and needs no subtraction. `RingEquiv.ofBijective` is stated for
`NonAssocSemiring`. So neither half of the bijection wanted a ring, and the sections existed only to
separate two blocks that differed in nothing else.

`A` and `B` keep `[CommRing A]`: `B : Subring A` and `IsTopologicallyNilpotent` are what require it,
and no round has questioned them.

Verified from the **elaborated signatures**, read back after the move rather than inferred from the
source, since section-variable binders drop silently: all three declarations carry `[CommSemiring
Bs] [CommSemiring As]` and all four of `Algebra ↥B Bs`, `IsLocalization.Away s Bs`, `Algebra A As`,
`IsLocalization.Away (B.subtype s) As`. Nothing was lost in the merge.

**Round 3 — `generality`, taken (first half; second half superseded by round 4).**
`IsLocalization.Away.map_surjective_iff` is stated over a `CommSemiring`, so the surjectivity
theorem never needed rings for either localisation target, and it took `[CommSemiring Bs]
[CommSemiring As]` from this round on. The round's further suggestion — keep `CommRing` for the
`RingEquiv` and its coercion lemma — was implemented at `cac2d1eda` and then undone above.

**Round 2 — `reuse` block, taken.** `awayMap_subtype_injective` duplicated Mathlib's
`IsLocalization.map_injective_of_injective`, which already says an injective ring map induces an
injective map on the corresponding localisations. Deleted; the equiv now passes
`IsLocalization.map_injective_of_injective _ _ _ B.subtype_injective` directly, exactly as Mathlib
applies it in `ZariskisMainTheorem.lean`.

I verified the citation before acting, because the fix hinges on a name that nearly does not exist.
My first search found only `map_injective_of_injective'` — *primed*, in `Localization/Basic.lean`,
carrying `[IsDomain S]`, which would **not** cover an arbitrary topological ring and would have made
the finding wrong. That was my error: I had searched only `Basic.lean` and a shell glob silently
failed. The unprimed lemma is real, in `Localization/Defs.lean:715`, generic and without a domain
hypothesis. The block is correct.

**That deletion moots two round-1 fixes, which is why the diff shrank rather than grew.** Round 1's
`placement` asked me to move the injectivity theorem into `Away.lean`, and `naming` asked me to
rename it; deleting it removes the subject of both. `Away.lean` is consequently **byte-identical
with `main`** again and this PR is a single file. The import returns to Mathlib's `Away.Basic`,
since nothing is consumed from TauCeti's `Away.lean` any more and importing it would be an unused
dependency.

**Round 1 — `naming`, taken.** The surviving theorem is
`awayMap_subtype_surjective_of_isTopologicallyNilpotent`, predicate as a suffix. I checked rather
than assumed: my first count suggested this repo used the *prefix* form, which would have made the
finding wrong, but that count came from a broken instrument — `git grep -E` does not support `\b`,
so `_injective\b` matched a literal `b` and scored 0. With controls that must fire (`_apply` → 4449,
`_iff` → 2852), the real counts on `main` are **suffix 499 vs prefix 24** for `injective`, 306 vs 15
for `surjective`. The finding is correct.

**Round 1 — `scope`.** `TauCetiRoadmap/AdicSpaces/README.md` **§2.3 "The plus ring, emptiness, and
analytic points"** says in as many words *"Prove Proposition 7.49(1)"* and *"Prove Proposition
7.49(2)"*. The path from here:

- #4910 (**merged** `2026-08-28T18:40:10Z`) landed Wedhorn 7.44(2) as a sufficient criterion whose
  hypothesis is openness at every `γ` in the **whole codomain**.
- Wedhorn's own 7.44(2) quantifies over `γ ∈ Γ_v = Γ_w`, and obtains that equality from part (1) —
  verbatim at `wedhorn.txt:3327`: *"Then (1) shows that `B_q → A_p` is an isomorphism and in
  particular `Γ_v = Γ_w`."*
- This PR is the isomorphism half of that sentence.

**Stated honestly:** the immediate use site is the `Γ_v = Γ_w` corollary, which is *not* in this PR —
it needs valuation machinery this file deliberately does not import, and it is the next step on bead
`tc-g8n2g`. So this PR is one step short of #4910's call site, and I would rather say so than imply
a direct consumer.

Since that round, a downstream bead has named this PR independently: `tc-vyv31` (adic lane, another
worker's) was re-scoped and its title now reads *"the equality is BLOCKED on 7.44(1) (`tc-g8n2g` /
#5096)"*. Precisely — `tc-vyv31` waits on the equality, which is step (c), which consumes what this
PR proves; so it depends on #5096 **through** step (c), not directly on the declarations here. One
link, not zero. Noted because a reviewer would not find `tc-vyv31` unaided.

## Gates

At head `6a0e2b34b`, on merge-base `f42e3235f`:

`lake build TauCeti.RingTheory.Localization.OpenSubring` — **exit 0, 1515 jobs**, log carries
`Build completed successfully (1515 jobs)`, zero errors and zero warnings. Nothing in `Mathlib` was
re-elaborated. The module has **no importers** anywhere in `TauCeti/`, so that single module is the
complete module-scoped gate rather than a sample of one.

`#lint only simpNF unusedArguments docBlame in TauCeti.RingTheory.Localization.OpenSubring` —
**0 errors in 3 declarations** (plus 7 auto-generated), 3 linters, exit 0. The count is quoted
because a wrong module prefix lints zero declarations and still prints "All linting checks passed!".
Both counts are unchanged from `cac2d1eda`: this round adds and removes no declaration.

Elaborated signatures of all three declarations read back from a temporary `#check` against the
built module, then removed — see round 4 above for what they show.

Longest line 100 codepoints, 0 over the limit, no trailing whitespace. Net change measured from the
**merge-base** (not `origin/main`, which drifts under a running build): one file, **+96/−0**, and
zero declarations removed.

`scripts/lint-env.sh` and `scripts/lint-style.sh` **not run**, and not reported as passing. Both
generate a module importing every `TauCeti/**/*.lean` and elaborate it against built oleans, so both
need a full library build; local full builds are not run here. CI's `pr-build` is their gate.

Roadmap: AdicSpaces

