### PR TITLE
refactor(EllipticCurve): name the chord cubic instead of repeating it five times

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/ThirdPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/ThirdPoint.lean
@@ -75,7 +75,7 @@ where the chord meets the curve. For an unconstrained `AA` it is just the substi
 and carries no such meaning. -/
 -- `AA` is carried as a parameter rather than inlined because the `linear_combination` certificates
 -- below are written against it as a single atom: substituting the expansion here makes `ring` fail
--- in `chord_cubic`, `chord_addX` and `chord_addY` alike.
+-- in `chordCubic_eq_zero`, `chord_addX` and `chord_addY` alike.
 private def chordCubic (AA Λ N q : F) : F :=
   -N + AA * q ^ 3 + W.a₃ * N ^ 2 + W.a₆ * N ^ 3 - Λ * q + Λ * W.a₁ * q ^ 2 +
     N * W.a₁ * q + N * W.a₂ * q ^ 2 + W.a₃ * Λ ^ 2 * q ^ 2 + W.a₄ * q * N ^ 2 +
@@ -84,7 +84,7 @@ private def chordCubic (AA Λ N q : F) : F :=
 
 /-- Each chord parameter is a root of `chordCubic`: a point of the `(z, w)`-chart lying on the
 line `w = Λ z + N` has its parameter annihilate the cubic. Applied at each of `z₁`, `z₂`. -/
-private lemma chord_cubic {AA Λ N q w : F}
+private lemma chordCubic_eq_zero {AA Λ N q w : F}
     (hAA2 : AA = 1 + W.a₂ * Λ + W.a₄ * Λ ^ 2 + W.a₆ * Λ ^ 3)
     (hw : w = q ^ 3 + W.a₁ * q * w + W.a₂ * q ^ 2 * w + W.a₃ * w ^ 2 +
       W.a₄ * q * w ^ 2 + W.a₆ * w ^ 3)
@@ -235,8 +235,8 @@ private lemma chord_addX_addY {q₁ q₂ w₁ w₂ Λ N T₃ wT : F}
     rw [Affine.slope_of_X_ne hxq, div_eq_div_iff (sub_ne_zero.mpr hxq) hN0]
     field_simp
     linear_combination (w₂ - Λ * q₂) * hline₁ - w₁ * hline₂ + Λ * q₂ * hline₁
-  have hCub₁ := chord_cubic W rfl hw₁ hline₁
-  have hCub₂ := chord_cubic W rfl hw₂ hline₂
+  have hCub₁ := chordCubic_eq_zero W rfl hw₁ hline₁
+  have hCub₂ := chordCubic_eq_zero W rfl hw₂ hline₂
   rw [hℓ]
   exact ⟨chord_addX W rfl hline₁ hline₂ hCub₁ hCub₂ hT₃ hwT hA hq12 hN0 hw₁0 hw₂0 hwT0,
     chord_addY W rfl hline₁ hline₂ hCub₁ hCub₂ hT₃ hwT hA hq12 hN0 hw₁0 hw₂0 hwT0⟩

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/ThirdPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/ThirdPoint.lean
@@ -66,8 +66,17 @@ lemma chord_point_nonsingular {q w : F}
 
 
 /-- The cubic in the chord parameter left by substituting the line `w = Λ z + N` into the
-`(z, w)`-form of the Weierstrass equation, written with its leading coefficient `AA` abstracted.
-Its three roots are the parameters of the three points where the chord meets the curve. -/
+`(z, w)`-form of the Weierstrass equation, with its leading coefficient carried as the parameter
+`AA`.
+
+The geometric reading needs `AA` pinned: **when** `AA = 1 + a₂Λ + a₄Λ² + a₆Λ³`, which is what
+`hAA2` supplies at every use below, this is the cubic whose roots are the parameters of the points
+where the chord meets the curve. For an unconstrained `AA` it is just the substituted expression
+and carries no such meaning.
+
+`AA` is abstracted rather than inlined because the `linear_combination` certificates below are
+written against it as a single atom; substituting the expansion into this definition makes `ring`
+fail in all three of `chord_cubic`, `chord_addX` and `chord_addY`. -/
 private def chordCubic (AA Λ N q : F) : F :=
   -N + AA * q ^ 3 + W.a₃ * N ^ 2 + W.a₆ * N ^ 3 - Λ * q + Λ * W.a₁ * q ^ 2 +
     N * W.a₁ * q + N * W.a₂ * q ^ 2 + W.a₃ * Λ ^ 2 * q ^ 2 + W.a₄ * q * N ^ 2 +

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/ThirdPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/ThirdPoint.lean
@@ -72,11 +72,10 @@ lemma chord_point_nonsingular {q w : F}
 The geometric reading needs `AA` pinned: **when** `AA = 1 + a₂Λ + a₄Λ² + a₆Λ³`, which is what
 `hAA2` supplies at every use below, this is the cubic whose roots are the parameters of the points
 where the chord meets the curve. For an unconstrained `AA` it is just the substituted expression
-and carries no such meaning.
-
-`AA` is abstracted rather than inlined because the `linear_combination` certificates below are
-written against it as a single atom; substituting the expansion into this definition makes `ring`
-fail in all three of `chord_cubic`, `chord_addX` and `chord_addY`. -/
+and carries no such meaning. -/
+-- `AA` is carried as a parameter rather than inlined because the `linear_combination` certificates
+-- below are written against it as a single atom: substituting the expansion here makes `ring` fail
+-- in `chord_cubic`, `chord_addX` and `chord_addY` alike.
 private def chordCubic (AA Λ N q : F) : F :=
   -N + AA * q ^ 3 + W.a₃ * N ^ 2 + W.a₆ * N ^ 3 - Λ * q + Λ * W.a₁ * q ^ 2 +
     N * W.a₁ * q + N * W.a₂ * q ^ 2 + W.a₃ * Λ ^ 2 * q ^ 2 + W.a₄ * q * N ^ 2 +

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/ThirdPoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/ThirdPoint.lean
@@ -65,18 +65,24 @@ lemma chord_point_nonsingular {q w : F}
   linear_combination hw
 
 
-/-- The cubic satisfied by each chord parameter. Substituting the line `w = Λ z + N` into the
-`(z, w)`-form of the Weierstrass equation leaves this cubic in `z`, whose three roots are the
-parameters of the three points where the chord meets the curve. Applied at each of `z₁`, `z₂`. -/
+/-- The cubic in the chord parameter left by substituting the line `w = Λ z + N` into the
+`(z, w)`-form of the Weierstrass equation, written with its leading coefficient `AA` abstracted.
+Its three roots are the parameters of the three points where the chord meets the curve. -/
+private def chordCubic (AA Λ N q : F) : F :=
+  -N + AA * q ^ 3 + W.a₃ * N ^ 2 + W.a₆ * N ^ 3 - Λ * q + Λ * W.a₁ * q ^ 2 +
+    N * W.a₁ * q + N * W.a₂ * q ^ 2 + W.a₃ * Λ ^ 2 * q ^ 2 + W.a₄ * q * N ^ 2 +
+    2 * Λ * N * W.a₃ * q + 2 * Λ * N * W.a₄ * q ^ 2 + 3 * Λ * W.a₆ * q * N ^ 2 +
+    3 * N * W.a₆ * Λ ^ 2 * q ^ 2
+
+/-- Each chord parameter is a root of `chordCubic`: a point of the `(z, w)`-chart lying on the
+line `w = Λ z + N` has its parameter annihilate the cubic. Applied at each of `z₁`, `z₂`. -/
 private lemma chord_cubic {AA Λ N q w : F}
     (hAA2 : AA = 1 + W.a₂ * Λ + W.a₄ * Λ ^ 2 + W.a₆ * Λ ^ 3)
     (hw : w = q ^ 3 + W.a₁ * q * w + W.a₂ * q ^ 2 * w + W.a₃ * w ^ 2 +
       W.a₄ * q * w ^ 2 + W.a₆ * w ^ 3)
     (hline : w = Λ * q + N) :
-    -N + AA * q ^ 3 + W.a₃ * N ^ 2 + W.a₆ * N ^ 3 - Λ * q + Λ * W.a₁ * q ^ 2 +
-      N * W.a₁ * q + N * W.a₂ * q ^ 2 + W.a₃ * Λ ^ 2 * q ^ 2 + W.a₄ * q * N ^ 2 +
-      2 * Λ * N * W.a₃ * q + 2 * Λ * N * W.a₄ * q ^ 2 + 3 * Λ * W.a₆ * q * N ^ 2 +
-      3 * N * W.a₆ * Λ ^ 2 * q ^ 2 = 0 := by
+    W.chordCubic AA Λ N q = 0 := by
+  simp only [chordCubic]
   linear_combination -hw + (1 + w*(-W.a₃ - N*W.a₆ - W.a₄*q - Λ*W.a₆*q) - N*W.a₃
     - W.a₁*q - W.a₂*q^2 - W.a₆*N^2 - W.a₆*w^2 - Λ*W.a₃*q - Λ*W.a₄*q^2 - N*W.a₄*q
     - W.a₆*Λ^2*q^2 - 2*Λ*N*W.a₆*q) * hline + (q^3) * hAA2
@@ -85,19 +91,13 @@ private lemma chord_cubic {AA Λ N q w : F}
 private lemma chord_addX {AA Λ N q₁ q₂ w₁ w₂ T₃ wT : F}
     (hAA2 : AA = 1 + W.a₂ * Λ + W.a₄ * Λ ^ 2 + W.a₆ * Λ ^ 3)
     (hline₁ : w₁ = Λ * q₁ + N) (hline₂ : w₂ = Λ * q₂ + N)
-    (hCub₁ : -N + AA * q₁ ^ 3 + W.a₃ * N ^ 2 + W.a₆ * N ^ 3 - Λ * q₁ + Λ * W.a₁ * q₁ ^ 2 +
-      N * W.a₁ * q₁ + N * W.a₂ * q₁ ^ 2 + W.a₃ * Λ ^ 2 * q₁ ^ 2 + W.a₄ * q₁ * N ^ 2 +
-      2 * Λ * N * W.a₃ * q₁ + 2 * Λ * N * W.a₄ * q₁ ^ 2 + 3 * Λ * W.a₆ * q₁ * N ^ 2 +
-      3 * N * W.a₆ * Λ ^ 2 * q₁ ^ 2 = 0)
-    (hCub₂ : -N + AA * q₂ ^ 3 + W.a₃ * N ^ 2 + W.a₆ * N ^ 3 - Λ * q₂ + Λ * W.a₁ * q₂ ^ 2 +
-      N * W.a₁ * q₂ + N * W.a₂ * q₂ ^ 2 + W.a₃ * Λ ^ 2 * q₂ ^ 2 + W.a₄ * q₂ * N ^ 2 +
-      2 * Λ * N * W.a₃ * q₂ + 2 * Λ * N * W.a₄ * q₂ ^ 2 + 3 * Λ * W.a₆ * q₂ * N ^ 2 +
-      3 * N * W.a₆ * Λ ^ 2 * q₂ ^ 2 = 0)
+    (hCub₁ : W.chordCubic AA Λ N q₁ = 0) (hCub₂ : W.chordCubic AA Λ N q₂ = 0)
     (hT₃ : AA * (T₃ + q₁ + q₂) =
       -(W.a₁ * Λ + W.a₂ * N + W.a₃ * Λ ^ 2 + 2 * W.a₄ * Λ * N + 3 * W.a₆ * Λ ^ 2 * N))
     (hwT : wT = Λ * T₃ + N) (hA : AA ≠ 0) (hq12 : q₁ - q₂ ≠ 0) (hN0 : N ≠ 0)
     (hw₁0 : w₁ ≠ 0) (hw₂0 : w₂ ≠ 0) (hwT0 : wT ≠ 0) :
     T₃ / wT = W.toAffine.addX (q₁ / w₁) (q₂ / w₂) (Λ / N) := by
+  simp only [chordCubic] at hCub₁ hCub₂
   rw [Affine.addX]
   field_simp
   refine mul_left_cancel₀ (mul_ne_zero (pow_ne_zero 3 hA) hq12) ?_
@@ -132,20 +132,14 @@ private lemma chord_addX {AA Λ N q₁ q₂ w₁ w₂ T₃ wT : F}
 private lemma chord_addY {AA Λ N q₁ q₂ w₁ w₂ T₃ wT : F}
     (hAA2 : AA = 1 + W.a₂ * Λ + W.a₄ * Λ ^ 2 + W.a₆ * Λ ^ 3)
     (hline₁ : w₁ = Λ * q₁ + N) (hline₂ : w₂ = Λ * q₂ + N)
-    (hCub₁ : -N + AA * q₁ ^ 3 + W.a₃ * N ^ 2 + W.a₆ * N ^ 3 - Λ * q₁ + Λ * W.a₁ * q₁ ^ 2 +
-      N * W.a₁ * q₁ + N * W.a₂ * q₁ ^ 2 + W.a₃ * Λ ^ 2 * q₁ ^ 2 + W.a₄ * q₁ * N ^ 2 +
-      2 * Λ * N * W.a₃ * q₁ + 2 * Λ * N * W.a₄ * q₁ ^ 2 + 3 * Λ * W.a₆ * q₁ * N ^ 2 +
-      3 * N * W.a₆ * Λ ^ 2 * q₁ ^ 2 = 0)
-    (hCub₂ : -N + AA * q₂ ^ 3 + W.a₃ * N ^ 2 + W.a₆ * N ^ 3 - Λ * q₂ + Λ * W.a₁ * q₂ ^ 2 +
-      N * W.a₁ * q₂ + N * W.a₂ * q₂ ^ 2 + W.a₃ * Λ ^ 2 * q₂ ^ 2 + W.a₄ * q₂ * N ^ 2 +
-      2 * Λ * N * W.a₃ * q₂ + 2 * Λ * N * W.a₄ * q₂ ^ 2 + 3 * Λ * W.a₆ * q₂ * N ^ 2 +
-      3 * N * W.a₆ * Λ ^ 2 * q₂ ^ 2 = 0)
+    (hCub₁ : W.chordCubic AA Λ N q₁ = 0) (hCub₂ : W.chordCubic AA Λ N q₂ = 0)
     (hT₃ : AA * (T₃ + q₁ + q₂) =
       -(W.a₁ * Λ + W.a₂ * N + W.a₃ * Λ ^ 2 + 2 * W.a₄ * Λ * N + 3 * W.a₆ * Λ ^ 2 * N))
     (hwT : wT = Λ * T₃ + N) (hA : AA ≠ 0) (hq12 : q₁ - q₂ ≠ 0) (hN0 : N ≠ 0)
     (hw₁0 : w₁ ≠ 0) (hw₂0 : w₂ ≠ 0) (hwT0 : wT ≠ 0) :
     (1 - W.a₁ * T₃ - W.a₃ * wT) / wT =
       W.toAffine.addY (q₁ / w₁) (q₂ / w₂) (-1 / w₁) (Λ / N) := by
+  simp only [chordCubic] at hCub₁ hCub₂
   rw [Affine.addY, Affine.negAddY, Affine.addX, Affine.negY]
   field_simp
   refine mul_left_cancel₀ (mul_ne_zero (pow_ne_zero 3 hA) hq12) ?_


### PR DESCRIPTION
`FormalGroup/ThirdPoint.lean` spelled out the same four-line cubic **five times**: once as the
conclusion of `chord_cubic`, and twice each as the `hCub₁` / `hCub₂` hypotheses of `chord_addX`
and `chord_addY`.

Those five copies were one unchecked invariant. `chord_addX_addY` builds the hypotheses by
calling `chord_cubic` and hands them straight to the two consumers:

```lean
have hCub₁ := chord_cubic W rfl hw₁ hline₁
have hCub₂ := chord_cubic W rfl hw₂ hline₂
exact ⟨chord_addX W rfl hline₁ hline₂ hCub₁ hCub₂ …, chord_addY W rfl hline₁ hline₂ hCub₁ hCub₂ …⟩
```

so the consumers' hypotheses had to match the producer's conclusion character for character, with
nothing but copy-paste enforcing it. A mistyped coefficient in one of the four hypothesis copies
would not be caught at its definition; it would surface later as an unprovable goal.

(The quotations above name the lemma `chord_cubic` because that is what it is called on
`main`. This PR renames it — see *What changes*.)

## What changes

The polynomial is named once,

```lean
private def chordCubic (AA Λ N q : F) : F := …
```

and the root lemma is renamed `chord_cubic` → **`chordCubic_eq_zero`**, so that it states its
conclusion rather than re-spelling the definition it is about. `chordCubic_eq_zero` now concludes
`W.chordCubic AA Λ N q = 0`, and `chord_addX` / `chord_addY` take `W.chordCubic AA Λ N q₁ = 0` and
`W.chordCubic AA Λ N q₂ = 0`. The typechecker enforces the match.

Each of the three proofs opens with `simp only [chordCubic]`: `linear_combination` finishes with
`ring1`, which treats a semi-reducible `def` as an atom and so will not see the polynomial without
it. The `linear_combination` certificates themselves are untouched.

**This is a refactor of already-merged material** — the same statements up to the new name, the
same proofs, nothing new proved.

## This is not a line-count change

Net −6 lines. The definition costs roughly what the four hypothesis copies save; the win is the
removed duplication and the named concept, not the size. What does improve is legibility at the
two use sites: `chord_addX` and `chord_addY` each had two four-line polynomial blobs sitting among
their eleven other hypotheses, and now each has a one-line hypothesis.

## Deliberately not in this PR

The file repeats a *second* polynomial — the chord's leading coefficient
`1 + a₂Λ + a₄Λ² + a₆Λ³` — **seven** times: `hAA2` in `chordCubic_eq_zero`, `chord_addX` and
`chord_addY`, and `hT₃` / `hA` in both `chord_addX_addY` and `chord_point_add`. Naming that one is
a separate decision, because two of those seven occurrences are in the signature of the **public**
`chord_point_add`, whereas every occurrence touched here lives in a `private` lemma — which is
what keeps this change entirely internal to the file.

## Gates

Re-measured at the current head after a rebase onto `main` (see *Rebase*), not carried over from
an earlier round.

`lake build` of the changed module (the only changed module; `ThirdPoint.lean` has no importers in
the repository — re-checked at this head): `Build completed successfully (1990 jobs)`, exit 0, and
the log contains no `error` / `warning` / `info:` line at all. Longest line 99 characters, counted
in **codepoints** rather than bytes — this file is Unicode-dense (`Λ`, `₃`, `≠`), so a byte count
overstates it.

**Which linter ran, precisely.** `scripts/lint-env.sh` could **not** run here, for the same reason
as in the previous round: its docstring-scan driver imports every `TauCeti` module, so under a
module-scoped build it dies on the first missing `.olean` of an unrelated module and reports
`LINT-ENV: FAIL — driver failure`. In this round the missing module was `TauCeti.Algebra.AddCircle`
(the previous round hit `AdditiveFrobeniusKernel/Basic`), which is the tell that the module named
is incidental. The direct measurement: **210 `.olean`s built against 3974 source modules**, i.e.
the driver needs ~19× more of the library than a module-scoped build produces. That is a driver
failure, not a verdict on this diff. CI runs lint-env; I could not.

What I ran instead is `lake exe runLinter TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.ThirdPoint`,
which returns `Linting passed` (exit 0, captured directly rather than through a pipe, so the status
is the linter's and not a downstream command's). Because that receipt has been questioned on this
board — the concern being that `runLinter` can pass vacuously — the previous round verified the
instrument with a matched pair on this exact module and invocation rather than asserting it:

| run | result |
|---|---|
| with a deliberate `@[simp] theorem … : n + 0 = n` planted | **exit 1**, `simpNF` reports it by name and line |
| probe removed (the committed state) | **exit 0**, `Linting passed` |

Both runs print `9 declarations (plus 3 automatically generated ones) … with 14 linters`, so the
environment was populated, not empty. The vacuous case is real but is the *root* invocation
`runLinter TauCeti`, which has no imports; naming the module avoids it. Every declaration this PR
touches is `private`, and the planted probe confirms the run reaches declarations in this module.

## Rebase

This branch was based on `e06eb7331`, which predates the mathlib pin bump that landed on `main` at
`1b6e5b4e8` (`653c36f0…` → `97b6a17d…`). Its previously green `sandboxed-build` ran *before* that
bump, so it was no longer evidence about current `main`. The branch is now rebased onto `main`
(0 behind, pins identical to `main`) and the gates above were run against the new pin. The diff is
still one file: the three original commits plus the rename.

Roadmap: EllipticCurves
