### PR TITLE
feat(FormalGroup): the third point of the chord lies on the curve

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Series.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Add/Series.lean
@@ -76,12 +76,6 @@ open MvPowerSeries
 
 variable {R : Type*} [CommRing R] (W : WeierstrassCurve R)
 
-/-- The two-variable family that substitutes `formalThirdRoot` for the single variable of a
-one-variable series. -/
-theorem hasSubst_formalThirdRoot :
-    HasSubst (fun _ : Unit ↦ formalThirdRoot W) :=
-  hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_formalThirdRoot W
-
 /-- The **addition series** of the chord construction: `F(z₁, z₂) = ι(z₃(z₁, z₂))`, the
 parameter of the sum of the points with parameters `z₁` and `z₂`.
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
@@ -51,10 +51,10 @@ from `formalThirdRoot` by composing with the formal inverse, which is left to a 
 * `WeierstrassCurve.formalIntercept_eq_inr`: the intercept computed from the second point.
 * `WeierstrassCurve.constantCoeff_formalSlope`, `_formalIntercept`, `_formalThirdRoot`: all
   three series vanish at the origin.
-* `WeierstrassCurve.subst_formalThirdRoot_formalW`: over a domain the third point really lies
-  on the chord — reading the `w`-expansion at `formalThirdRoot` returns the chord line read
-  there. This is what makes the third root the parameter of an intersection point rather than
-  merely a root of the cubic.
+* `WeierstrassCurve.subst_formalThirdRoot_formalW`: the third point really lies on the chord —
+  reading the `w`-expansion at `formalThirdRoot` returns the chord line read there. This is what
+  makes the third root the parameter of an intersection point rather than merely a root of the
+  cubic.
 
 ## Implementation notes
 
@@ -91,11 +91,12 @@ the source writes `MvPowerSeries.rename (fun _ => i)`, this file uses the equal 
 The on-line section is adapted from the same project's
 `EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`, its `Domain` section — declarations
 `line_at_thirdRoot` and `subst_thirdRootSeries_wSeries`. Four of that section's steps are not
-ported, because this repository already has them: `X_inl_ne_X_inr` is Mathlib's
-`MvPowerSeries.X_inj`; `line_left` and `line_right` are `formalIntercept_def` and
-`formalIntercept_eq_inr` with the terms moved across the equals sign; and `wsAt_rename` is
-`subst_formalW_wEquation` read through Mathlib's `PowerSeries.toMvPowerSeries_eq_subst`. All
-are inlined at their single use site. The source's `LowVanish` hypotheses have no counterpart
+ported. `X_inl_ne_X_inr` is not needed at all: the cancellation runs through
+`MvPowerSeries.X_sub_X_mem_nonZeroDivisors`, which never separates the two variables. The other
+three this repository already has — `line_left` and `line_right` are `formalIntercept_def` and
+`formalIntercept_eq_inr` with the terms moved across the equals sign, and `wsAt_rename` is
+`subst_formalW_wEquation` read through Mathlib's `PowerSeries.toMvPowerSeries_eq_subst`; all
+three are inlined at their single use site. The source's `LowVanish` hypotheses have no counterpart
 here at all, since `eq_of_wEquation_mvPowerSeries` takes vanishing constant coefficients
 directly.
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
@@ -97,6 +97,10 @@ ported, because this repository already has them: `X_inl_ne_X_inr` is Mathlib's
 are inlined at their single use site. The source's `LowVanish` hypotheses have no counterpart
 here at all, since `eq_of_wEquation_mvPowerSeries` takes vanishing constant coefficients
 directly.
+
+The source guards `line_at_thirdRoot` with `set_option maxRecDepth 4000 in`. That is not ported:
+TauCeti's CI forbids `set_option` under `TauCeti/`, and the proof elaborates at the default
+depth here, so the guard was never load-bearing for this statement.
 -/
 
 public section
@@ -323,7 +327,6 @@ section IsDomain
 
 variable [IsDomain R]
 
-set_option maxRecDepth 4000 in
 /-- The chord line, read at the third root, satisfies the `w`-equation at that parameter.
 
 This is Vieta's formula in the form the uniqueness of the `w`-expansion can consume: the third

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
@@ -9,6 +9,7 @@ public import Mathlib.RingTheory.MvPowerSeries.Inverse
 public import TauCeti.AlgebraicGeometry.EllipticCurve.FormalGroup.WExpansion
 public import TauCeti.RingTheory.MvPowerSeries.Equiv
 public import TauCeti.RingTheory.MvPowerSeries.Inverse
+public import TauCeti.RingTheory.MvPowerSeries.NonZeroDivisors
 
 /-!
 # The chord through two points of a Weierstrass curve near the origin
@@ -321,18 +322,15 @@ theorem hasSubst_formalThirdRoot :
 
 Vieta's formulas produce `formalThirdRoot` from the coefficients of the chord cubic, which by
 itself says nothing about where the curve meets that chord: it is an identity between series, not
-a statement that the point with parameter `z₃` lies on the line `w = λ z + ν`. Over a domain it
-does, and the argument is the classical one — the cubic already has `z₁` and `z₂` among its
-roots, so cancelling `z₁ - z₂` from the difference of the two identities pins the third.
+a statement that the point with parameter `z₃` lies on the line `w = λ z + ν`. It does, and the
+argument is the classical one — the cubic already has `z₁` and `z₂` among its roots, so cancelling
+`z₁ - z₂` from the difference of the two identities pins the third.
 
-`[IsDomain R]` is used for that cancellation and nothing else: `MvPowerSeries.X_inj` separates
-the two variables, and Mathlib's `NoZeroDivisors (MvPowerSeries σ R)` — which needs no hypothesis
-on `σ` — turns the separation into cancellation.
+That cancellation needs no hypothesis on `R`. The difference of two distinct variables is a
+non-zero-divisor of `MvPowerSeries (Unit ⊕ Unit) R` over an arbitrary commutative ring
+(`MvPowerSeries.X_sub_X_mem_nonZeroDivisors`), because the coefficient recursion behind it never
+cancels anything in `R`.
 -/
-
-section IsDomain
-
-variable [IsDomain R]
 
 /-- The chord line, read at the third root, satisfies the `w`-equation at that parameter.
 
@@ -385,10 +383,10 @@ private theorem line_at_thirdRoot :
       (Λ - (C W.a₁ * N + 2 * C W.a₃ * Λ * N + C W.a₄ * N ^ 2 +
         3 * C W.a₆ * Λ * N ^ 2))) = 0 := by
     linear_combination hC1 - hC2
-  have hne : t₁ - t₂ ≠ 0 := by
-    rw [ht₁, ht₂, sub_ne_zero]
-    exact fun h ↦ by simpa using X_inj.mp h
-  have hE1 := (mul_eq_zero.mp hsub).resolve_left hne
+  have hreg : ∀ x : MvPowerSeries (Unit ⊕ Unit) R, (t₁ - t₂) * x = 0 → x = 0 := by
+    rw [ht₁, ht₂]
+    exact (X_sub_X_mem_nonZeroDivisors (by simp)).1
+  have hE1 := hreg _ hsub
   clear_value Λ N t₁ t₂ d
   set B := C W.a₁ * Λ + C W.a₂ * N + C W.a₃ * Λ ^ 2 + 2 * C W.a₄ * Λ * N +
     3 * C W.a₆ * Λ ^ 2 * N with hB
@@ -403,6 +401,7 @@ root gives the chord line read there: `w(z₃(z₁, z₂)) = λ(z₁, z₂) · z
 
 This is what makes `formalThirdRoot` the parameter of an actual third intersection point rather
 than merely the third root of a cubic, and it is the identity the addition series is built on. -/
+@[simp]
 theorem subst_formalThirdRoot_formalW :
     subst (fun _ : Unit ↦ formalThirdRoot W) (formalW W) =
       formalSlope W * formalThirdRoot W + formalIntercept W := by
@@ -414,7 +413,6 @@ theorem subst_formalThirdRoot_formalW :
   · exact subst_formalW_wEquation W (PowerSeries.HasSubst.of_constantCoeff_zero
       (constantCoeff_formalThirdRoot W))
 
-end IsDomain
 
 /-! ### Base change
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
@@ -310,6 +310,13 @@ theorem rename_swap_formalThirdRoot :
     show Sum.swap (Sum.inr () : Unit ⊕ Unit) = Sum.inl () from rfl]
   ring
 
+/-- The two-variable family that substitutes `formalThirdRoot` for the single variable of a
+one-variable series. Stated here, beside `formalThirdRoot` itself, because the substitution it
+witnesses is used from this file onwards. -/
+theorem hasSubst_formalThirdRoot :
+    HasSubst (fun _ : Unit ↦ formalThirdRoot W) :=
+  hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_formalThirdRoot W
+
 /-! ### The third point lies on the chord
 
 Vieta's formulas produce `formalThirdRoot` from the coefficients of the chord cubic, which by
@@ -343,18 +350,20 @@ private theorem line_at_thirdRoot :
     intro i
     rw [PowerSeries.toMvPowerSeries_eq_subst]
     exact subst_formalW_wEquation W (PowerSeries.HasSubst.X i)
-  have hC1 : formalSlope W * X (Sum.inl ()) + formalIntercept W =
-      wEquationRHS W (X (Sum.inl ()))
-        (formalSlope W * X (Sum.inl ()) + formalIntercept W) := by
-    rw [show formalSlope W * X (Sum.inl ()) + formalIntercept W =
-      (formalW W).toMvPowerSeries (Sum.inl ()) by rw [formalIntercept_def]; ring]
-    exact hline _
-  have hC2 : formalSlope W * X (Sum.inr ()) + formalIntercept W =
-      wEquationRHS W (X (Sum.inr ()))
-        (formalSlope W * X (Sum.inr ()) + formalIntercept W) := by
-    rw [show formalSlope W * X (Sum.inr ()) + formalIntercept W =
-      (formalW W).toMvPowerSeries (Sum.inr ()) by rw [formalIntercept_eq_inr]; ring]
-    exact hline _
+  -- The chord passes through both of its own endpoints. `Unit ⊕ Unit` has exactly the two
+  -- elements `inl ()` and `inr ()`, so the case split is exhaustive and the two endpoints share
+  -- one argument: `formalIntercept` is defined from the first point and `formalIntercept_eq_inr`
+  -- says the second point gives the same series.
+  have hchord : ∀ i : Unit ⊕ Unit,
+      formalSlope W * X i + formalIntercept W = (formalW W).toMvPowerSeries i := by
+    rintro (⟨⟩ | ⟨⟩)
+    · rw [formalIntercept_def]; ring
+    · rw [formalIntercept_eq_inr]; ring
+  have hC : ∀ i : Unit ⊕ Unit, formalSlope W * X i + formalIntercept W =
+      wEquationRHS W (X i) (formalSlope W * X i + formalIntercept W) := fun i =>
+    (hchord i).trans ((hline i).trans (by rw [hchord i]))
+  have hC1 := hC (Sum.inl ())
+  have hC2 := hC (Sum.inr ())
   have hAd : (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
       C W.a₆ * formalSlope W ^ 3) *
       invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
@@ -399,10 +408,7 @@ theorem subst_formalThirdRoot_formalW :
       formalSlope W * formalThirdRoot W + formalIntercept W := by
   refine eq_of_wEquation_mvPowerSeries W (constantCoeff_formalThirdRoot W) ?_ ?_ ?_
     (line_at_thirdRoot W)
-  -- `hasSubst_formalThirdRoot` is stated downstream, in `Add/Series.lean`, so the one-line
-  -- Mathlib composite it packages is used directly here.
-  · exact constantCoeff_subst_eq_zero
-      (hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_formalThirdRoot W)
+  · exact constantCoeff_subst_eq_zero (hasSubst_formalThirdRoot W)
       (fun _ ↦ constantCoeff_formalThirdRoot W) (constantCoeff_formalW W)
   · simp
   · exact subst_formalW_wEquation W (PowerSeries.HasSubst.of_constantCoeff_zero

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FormalGroup/Chord.lean
@@ -50,6 +50,10 @@ from `formalThirdRoot` by composing with the formal inverse, which is left to a 
 * `WeierstrassCurve.formalIntercept_eq_inr`: the intercept computed from the second point.
 * `WeierstrassCurve.constantCoeff_formalSlope`, `_formalIntercept`, `_formalThirdRoot`: all
   three series vanish at the origin.
+* `WeierstrassCurve.subst_formalThirdRoot_formalW`: over a domain the third point really lies
+  on the chord — reading the `w`-expansion at `formalThirdRoot` returns the chord line read
+  there. This is what makes the third root the parameter of an intersection point rather than
+  merely a root of the cubic.
 
 ## Implementation notes
 
@@ -82,6 +86,17 @@ The source's `wSeries` and `vSeries` are `formalW` and `formalU`, so neither is 
 everything here is stated over the existing `w`-expansion API. Where
 the source writes `MvPowerSeries.rename (fun _ => i)`, this file uses the equal Mathlib map
 `PowerSeries.toMvPowerSeries i`.
+
+The on-line section is adapted from the same project's
+`EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`, its `Domain` section — declarations
+`line_at_thirdRoot` and `subst_thirdRootSeries_wSeries`. Four of that section's steps are not
+ported, because this repository already has them: `X_inl_ne_X_inr` is Mathlib's
+`MvPowerSeries.X_inj`; `line_left` and `line_right` are `formalIntercept_def` and
+`formalIntercept_eq_inr` with the terms moved across the equals sign; and `wsAt_rename` is
+`subst_formalW_wEquation` read through Mathlib's `PowerSeries.toMvPowerSeries_eq_subst`. All
+are inlined at their single use site. The source's `LowVanish` hypotheses have no counterpart
+here at all, since `eq_of_wEquation_mvPowerSeries` takes vanishing constant coefficients
+directly.
 -/
 
 public section
@@ -290,6 +305,107 @@ theorem rename_swap_formalThirdRoot :
   simp only [show Sum.swap (Sum.inl () : Unit ⊕ Unit) = Sum.inr () from rfl,
     show Sum.swap (Sum.inr () : Unit ⊕ Unit) = Sum.inl () from rfl]
   ring
+
+/-! ### The third point lies on the chord
+
+Vieta's formulas produce `formalThirdRoot` from the coefficients of the chord cubic, which by
+itself says nothing about where the curve meets that chord: it is an identity between series, not
+a statement that the point with parameter `z₃` lies on the line `w = λ z + ν`. Over a domain it
+does, and the argument is the classical one — the cubic already has `z₁` and `z₂` among its
+roots, so cancelling `z₁ - z₂` from the difference of the two identities pins the third.
+
+`[IsDomain R]` is used for that cancellation and nothing else: `MvPowerSeries.X_inj` separates
+the two variables, and Mathlib's `NoZeroDivisors (MvPowerSeries σ R)` — which needs no hypothesis
+on `σ` — turns the separation into cancellation.
+-/
+
+section IsDomain
+
+variable [IsDomain R]
+
+set_option maxRecDepth 4000 in
+/-- The chord line, read at the third root, satisfies the `w`-equation at that parameter.
+
+This is Vieta's formula in the form the uniqueness of the `w`-expansion can consume: the third
+root is characterised here by *solving the equation*, not by its coefficient formula. -/
+private theorem line_at_thirdRoot :
+    formalSlope W * formalThirdRoot W + formalIntercept W =
+      wEquationRHS W (formalThirdRoot W)
+        (formalSlope W * formalThirdRoot W + formalIntercept W) := by
+  -- The curve meets the chord at each of the two given parameters. Both are the `w`-equation at
+  -- a variable, which is `subst_formalW_wEquation` read through `toMvPowerSeries`.
+  have hline : ∀ i : Unit ⊕ Unit,
+      (formalW W).toMvPowerSeries i =
+        wEquationRHS W (X i) ((formalW W).toMvPowerSeries i) := by
+    intro i
+    rw [PowerSeries.toMvPowerSeries_eq_subst]
+    exact subst_formalW_wEquation W (PowerSeries.HasSubst.X i)
+  have hC1 : formalSlope W * X (Sum.inl ()) + formalIntercept W =
+      wEquationRHS W (X (Sum.inl ()))
+        (formalSlope W * X (Sum.inl ()) + formalIntercept W) := by
+    rw [show formalSlope W * X (Sum.inl ()) + formalIntercept W =
+      (formalW W).toMvPowerSeries (Sum.inl ()) by rw [formalIntercept_def]; ring]
+    exact hline _
+  have hC2 : formalSlope W * X (Sum.inr ()) + formalIntercept W =
+      wEquationRHS W (X (Sum.inr ()))
+        (formalSlope W * X (Sum.inr ()) + formalIntercept W) := by
+    rw [show formalSlope W * X (Sum.inr ()) + formalIntercept W =
+      (formalW W).toMvPowerSeries (Sum.inr ()) by rw [formalIntercept_eq_inr]; ring]
+    exact hline _
+  have hAd : (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
+      C W.a₆ * formalSlope W ^ 3) *
+      invOfUnit (1 + C W.a₂ * formalSlope W + C W.a₄ * formalSlope W ^ 2 +
+        C W.a₆ * formalSlope W ^ 3) 1 = 1 :=
+    mul_invOfUnit _ 1 (by simp)
+  simp only [wEquationRHS_def, ← c_eq_algebraMap] at hC1 hC2 ⊢
+  rw [formalThirdRoot_def]
+  set Λ := formalSlope W
+  set N := formalIntercept W
+  set t₁ := (X (Sum.inl ()) : MvPowerSeries (Unit ⊕ Unit) R) with ht₁
+  set t₂ := (X (Sum.inr ()) : MvPowerSeries (Unit ⊕ Unit) R) with ht₂
+  set d := invOfUnit (1 + C W.a₂ * Λ + C W.a₄ * Λ ^ 2 + C W.a₆ * Λ ^ 3) 1
+  -- Cancel `t₁ - t₂` from the difference of the two identities: what survives is the linear
+  -- coefficient of the chord cubic, which is what Vieta's formula divides by the leading one.
+  have hsub : (t₁ - t₂) * (-(1 + C W.a₂ * Λ + C W.a₄ * Λ ^ 2 + C W.a₆ * Λ ^ 3) *
+      (t₁ ^ 2 + t₁ * t₂ + t₂ ^ 2) -
+      (C W.a₁ * Λ + C W.a₂ * N + C W.a₃ * Λ ^ 2 + 2 * C W.a₄ * Λ * N +
+        3 * C W.a₆ * Λ ^ 2 * N) * (t₁ + t₂) +
+      (Λ - (C W.a₁ * N + 2 * C W.a₃ * Λ * N + C W.a₄ * N ^ 2 +
+        3 * C W.a₆ * Λ * N ^ 2))) = 0 := by
+    linear_combination hC1 - hC2
+  have hne : t₁ - t₂ ≠ 0 := by
+    rw [ht₁, ht₂, sub_ne_zero]
+    exact fun h ↦ by simpa using X_inj.mp h
+  have hE1 := (mul_eq_zero.mp hsub).resolve_left hne
+  clear_value Λ N t₁ t₂ d
+  set B := C W.a₁ * Λ + C W.a₂ * N + C W.a₃ * Λ ^ 2 + 2 * C W.a₄ * Λ * N +
+    3 * C W.a₆ * Λ ^ 2 * N with hB
+  set T := -t₁ - t₂ - B * d with hT
+  clear_value B T
+  linear_combination hC1 + (T - t₁) * hE1 + ((T - t₁) * (T - t₂) * B) * hAd -
+    ((T - t₁) * (T - t₂) * (1 + C W.a₂ * Λ + C W.a₄ * Λ ^ 2 + C W.a₆ * Λ ^ 3)) * hT +
+    (T ^ 2 - t₁ ^ 2) * hB
+
+/-- **The third intersection point lies on the chord.** Reading the `w`-expansion at the third
+root gives the chord line read there: `w(z₃(z₁, z₂)) = λ(z₁, z₂) · z₃(z₁, z₂) + ν(z₁, z₂)`.
+
+This is what makes `formalThirdRoot` the parameter of an actual third intersection point rather
+than merely the third root of a cubic, and it is the identity the addition series is built on. -/
+theorem subst_formalThirdRoot_formalW :
+    subst (fun _ : Unit ↦ formalThirdRoot W) (formalW W) =
+      formalSlope W * formalThirdRoot W + formalIntercept W := by
+  refine eq_of_wEquation_mvPowerSeries W (constantCoeff_formalThirdRoot W) ?_ ?_ ?_
+    (line_at_thirdRoot W)
+  -- `hasSubst_formalThirdRoot` is stated downstream, in `Add/Series.lean`, so the one-line
+  -- Mathlib composite it packages is used directly here.
+  · exact constantCoeff_subst_eq_zero
+      (hasSubst_of_constantCoeff_zero fun _ ↦ constantCoeff_formalThirdRoot W)
+      (fun _ ↦ constantCoeff_formalThirdRoot W) (constantCoeff_formalW W)
+  · simp
+  · exact subst_formalW_wEquation W (PowerSeries.HasSubst.of_constantCoeff_zero
+      (constantCoeff_formalThirdRoot W))
+
+end IsDomain
 
 /-! ### Base change
 

--- a/TauCeti/RingTheory/MvPowerSeries/NonZeroDivisors.lean
+++ b/TauCeti/RingTheory/MvPowerSeries/NonZeroDivisors.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.MvPowerSeries.NoZeroDivisors
+
+/-!
+# The difference of two variables is a non-zero-divisor
+
+Mathlib shows that a *single* variable is a non-zero-divisor over an arbitrary semiring
+(`MvPowerSeries.X_mem_nonzeroDivisors`), and that `MvPowerSeries σ R` inherits `NoZeroDivisors`
+from `R`. Between those lies a gap: over a ring that *has* zero divisors, is `X i - X j` still
+regular? It is, and this file proves it.
+
+## Main results
+
+* `MvPowerSeries.X_sub_X_mem_nonZeroDivisors`: for `i ≠ j`, the difference `X i - X j` is a
+  non-zero-divisor of `MvPowerSeries σ R` over an arbitrary commutative ring.
+
+## Implementation notes
+
+The proof is a coefficient recursion rather than a cancellation in `R`, which is what lets the
+hypotheses on `R` drop. Reading `f * (X i - X j) = 0` at the exponent `d + single i 1` gives
+`coeff d f = coeff (d + single i 1 - single j 1) f` when `d j ≠ 0`, and `coeff d f = 0` when
+`d j = 0`, since the `X j` term is then absent for degree reasons. Each step lowers the
+`j`-exponent by one, so induction on `d j` walks every coefficient down to that base case.
+-/
+
+public section
+
+namespace MvPowerSeries
+
+open Finsupp nonZeroDivisors
+
+variable {σ R : Type*} [CommRing R]
+
+/-- **The difference of two distinct variables is a non-zero-divisor**, over an arbitrary
+commutative ring: `f * (X i - X j) = 0` forces `f = 0`, with no hypothesis on `R`.
+
+Compare `MvPowerSeries.X_mem_nonzeroDivisors`, the same statement for a single variable, and the
+`NoZeroDivisors (MvPowerSeries σ R)` instance, which requires `R` to have no zero divisors. -/
+theorem X_sub_X_mem_nonZeroDivisors {i j : σ} (hij : i ≠ j) :
+    X i - X j ∈ (MvPowerSeries σ R)⁰ := by
+  classical
+  have main : ∀ f : MvPowerSeries σ R, f * (X i - X j) = 0 → f = 0 := by
+    intro f hf
+    suffices H : ∀ n (d : σ →₀ ℕ), d j = n → coeff d f = 0 by
+      ext d
+      simpa using H (d j) d rfl
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro d hd
+      have hji : single j 1 ≤ d + single i 1 ↔ d j ≠ 0 := by
+        simp [Finsupp.single_le_iff, Finsupp.single_eq_of_ne (Ne.symm hij), Nat.one_le_iff_ne_zero]
+      have key := congr(coeff (d + single i 1) $hf)
+      rw [mul_sub, map_sub, X, X, coeff_mul_monomial, coeff_mul_monomial, map_zero] at key
+      simp only [le_add_self, ite_true, add_tsub_cancel_right, mul_one] at key
+      rcases Nat.eq_zero_or_pos n with hn | hn
+      · have hcond : ¬ single j 1 ≤ d + single i 1 := by simp [hji, hd, hn]
+        simpa [hcond] using key
+      · have hcond : single j 1 ≤ d + single i 1 := hji.mpr (by omega)
+        simp only [hcond, ite_true, sub_eq_zero] at key
+        refine key.trans (ih (n - 1) (by omega) _ ?_)
+        simp [Finsupp.tsub_apply, Finsupp.single_eq_of_ne (Ne.symm hij), hd]
+  rw [mem_nonZeroDivisors_iff]
+  exact ⟨fun x hx ↦ main x (by rwa [mul_comm]), main⟩
+
+end MvPowerSeries


### PR DESCRIPTION
The third point of the chord really lies on the chord — over an arbitrary commutative ring.

`formalThirdRoot` comes out of Vieta's formulas, so it is defined by the *coefficients* of the chord cubic. Nothing in `Chord.lean` so far says that the point with that parameter lies on the line `w = λ z + ν` — that is a separate fact, and it is the one the addition series is built on. This PR proves it:

```lean
theorem subst_formalThirdRoot_formalW :
    subst (fun _ : Unit ↦ formalThirdRoot W) (formalW W) =
      formalSlope W * formalThirdRoot W + formalIntercept W
```

## No hypothesis on the coefficient ring

Round 2's `generality` finding asked that `[IsDomain R]` go. It has: the hypothesis now appears nowhere in the file.

It was load-bearing at exactly one step. The cubic already has `z₁` and `z₂` among its roots, so the difference of the two on-line identities is divisible by `z₁ - z₂`; cancelling it leaves exactly the linear coefficient Vieta divides by the leading one. That cancellation ran through `mul_eq_zero`, which wanted `NoZeroDivisors (MvPowerSeries σ R)`, together with `z₁ - z₂ ≠ 0` from `MvPowerSeries.X_inj`.

The cancellation needs nothing of `R`. New file `TauCeti/RingTheory/MvPowerSeries/NonZeroDivisors.lean`:

```lean
theorem X_sub_X_mem_nonZeroDivisors {i j : σ} (hij : i ≠ j) :
    X i - X j ∈ (MvPowerSeries σ R)⁰
```

over an arbitrary `CommRing R`, proved by a **coefficient recursion** rather than by cancelling in `R`. Reading `f * (X i - X j) = 0` at the exponent `d + single i 1` gives `coeff d f = coeff (d + single i 1 - single j 1) f` when `d j ≠ 0`, and `coeff d f = 0` when `d j = 0`, because the `X j` term is then absent for degree reasons; induction on `d j` walks every coefficient down to that base case.

Mathlib has the two neighbouring facts but not this one. `MvPowerSeries.X_mem_nonzeroDivisors` is the single-variable case over any semiring; the `NoZeroDivisors (MvPowerSeries σ R)` instance covers a difference only once `R` itself has no zero divisors. Everything about a *difference* of variables sits after `variable [Semiring R] [NoZeroDivisors R]` in `Mathlib/RingTheory/MvPowerSeries/NoZeroDivisors.lean` — behind exactly the hypothesis being dropped.

### Why not the universal curve

The finding's suggested route was to prove the identity for the universal Weierstrass curve over its polynomial coefficient domain and transport it by base change. That route is genuinely available — `map_specialize`, the `map_formal*` family and `MvPowerSeries.map_subst` all exist, there is precedent in `DivisionPolynomial/Universal.lean`, and there is no import cycle. It was not taken: it would make `Chord.lean`, a foundational file, depend on `Universal.lean` and its `Jacobian.Point` / `CoordinateRing` / `FractionRing` cone. `placement` currently approves this PR, and it should not have to be surrendered in order to satisfy `generality`. The regularity lemma reaches the same generality with no new dependency of that kind.

## `@[simp]`

Round 2's `api-design` finding asked for `@[simp]` on `subst_formalThirdRoot_formalW`; it is tagged. The tag is **measured, not assumed**: `runLinter` on the module passes, so `simpNF` accepts the left-hand side rather than simplifying it further.

## Placement

`Chord.lean`, beside `formalSlope` / `formalIntercept` / `formalThirdRoot`, which the statement is entirely about. `Chord.lean` already `public import`s `WExpansion`, so the uniqueness engine (`eq_of_wEquation_mvPowerSeries`) and `subst_formalW_wEquation` arrive with **no new import**. A separate module for one chord fact would be worse placed, not better.

This PR adds one import, `TauCeti.RingTheory.MvPowerSeries.NonZeroDivisors` — a new sibling in a directory `Chord.lean` already depends on (it imports `...MvPowerSeries.Equiv` and `...MvPowerSeries.Inverse`). The regularity lemma is general power-series algebra with no elliptic content, so it is recorded there rather than inlined, mirroring Mathlib's own `RingTheory/MvPowerSeries/NoZeroDivisors.lean`.

## What is deliberately *not* ported

The source's `Domain` section is largely already present here under other names. The `Provenance` block carries this same ledger so a later reader does not re-derive it:

| source | why not ported |
|---|---|
| `X_inl_ne_X_inr` | no longer needed at all: the cancellation goes through `X_sub_X_mem_nonZeroDivisors`, which never separates the variables |
| `line_left`, `line_right` | `formalIntercept_def` / `formalIntercept_eq_inr` with terms moved across the equals sign; inlined as a `ring` step |
| `wsAt_rename` | `subst_formalW_wEquation` read through Mathlib's `PowerSeries.toMvPowerSeries_eq_subst`; two lines |
| the `LowVanish` hypotheses | no counterpart needed — `eq_of_wEquation_mvPowerSeries` takes vanishing constant coefficients directly |

`hasSubst_formalThirdRoot` used to be stated *downstream* in `Add/Series.lean`, with the one-line Mathlib composite it packages inlined here instead. Round 1's `reuse` finding asked for the declaration itself rather than a documented duplicate, so it now lives in `Chord.lean` beside `constantCoeff_formalThirdRoot`. Every existing consumer — `Add/Series.lean`, `Add/Unit.lean:254`, `PairEval.lean:258` — reaches it through the unchanged import chain; no call site moved.

## Gate

Rebased onto current `main` **before** gating, so this builds against the tree CI will see. `main` had moved 53 commits and **bumped the mathlib pin** (`653c36f0` → `97b6a17d`), so the rebase was mandatory rather than hygienic — a pre-bump branch does not build against post-bump `main` in the sandbox. `lake exe cache get` was run for the new pin.

- `lake build` of the new module, `Chord`, and the whole downstream cone the `@[simp]` tag could disturb — `Add.Series`, `Add.Unit`, `PairEval` — → **EXIT=0**, no `error` / `warning` / `info:` / `sorry`. The cone matters here specifically: adding a simp lemma can break proofs that never mention it, so building only the direct importer would not have been enough.
- `lake exe runLinter` on both modules that gain declarations — `Chord` and the new `NonZeroDivisors` — → **"Linting passed"**, exit 0 each. This is what backs the `@[simp]` claim above. (`Add/Series.lean` only *loses* the relocated `hasSubst_formalThirdRoot`.)
- `scripts/lint-env.sh` was **not** run — it needs a fully built library and local full builds are barred here; CI's `pr-build` runs it and carries the grandfathered baseline the per-module run does not.
- The head commit is **documentation-only** — two stale sentences in `Chord.lean`'s prose that the `IsDomain` removal had left behind: the `Main results` entry still said the theorem held "over a domain", and the `Provenance` ledger still credited `X_inl_ne_X_inr` to `MvPowerSeries.X_inj`, which the file no longer uses at all. No declaration, statement, proof or attribute changed. Re-gated anyway: `lake build` of `Chord` → **EXIT=0**, 2066 jobs, no `error` / `warning` / `info:` / `sorry`, olean regenerated.
- Repo-audit checks run locally, since a green `lake build` says nothing about them: no live `set_option` under `TauCeti/` (every hit is prose explaining why the source's was dropped), longest line 100 characters or under measured **decoded** rather than in bytes, no trailing whitespace, and the new file is 73 lines against the 1000-line cap.

Roadmap: EllipticCurves

Advances `TauCetiRoadmap/EllipticCurves/README.md:573`, formal-group milestone (i) — *the elliptic formal group law `Ê` over the coefficient ring, from expanding the group law at `O` (AEC IV.1), as an instance of Mathlib's `RingTheory/FormalGroup`* — whose own text names the Stoll development as the port source.

## Provenance

Adapted from Michael Stoll's `EllipticCurves` project (`github.com/MichaelStollBayreuth/EllipticCurves`, Apache-2.0, pinned by `TauCetiRoadmap/EllipticCurves/README.md` at `66889eada51a`), `EllipticCurves/WeierstrassFormalGroup/GroupLaw.lean`, its `Domain` section — declarations `line_at_thirdRoot` and `subst_thirdRootSeries_wSeries`.



