### PR TITLE
refactor(ModularForms): name the strict period 1 of Γ₁(N)

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Cusps/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Cusps/Basic.lean
@@ -247,6 +247,17 @@ lemma Subgroup.exists_pos_nat_integerCuspWidth_eq_mul_strictWidthInfty
 
 end IntegerCuspWidth
 
+/-! ### The strict period `1` of `Γ₁(N)` -/
+
+/-- **`1` is a strict period of `Γ₁(N)`**, viewed in `GL (Fin 2) ℝ`.
+
+This is the side condition the period-`1` `q`-expansion API asks for at every congruence level —
+`ModularForm.qExpansion_smul`, `qExpansion_levelRaise_coeff` and `isCusp_of_mem_strictPeriods` all
+take it as a hypothesis — so it is named here rather than reproved at each use site. -/
+theorem one_mem_strictPeriods_Gamma1_map (N : ℕ) :
+    (1 : ℝ) ∈ ((CongruenceSubgroup.Gamma1 N).map (mapGL ℝ)).strictPeriods := by
+  simp [CongruenceSubgroup.strictPeriods_Gamma1]
+
 end TauCeti
 
 end

--- a/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
+++ b/TauCeti/NumberTheory/ModularForms/Degeneracy.lean
@@ -15,6 +15,7 @@ public import TauCeti.NumberTheory.ModularForms.DiamondOperators
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal.Basic
 
 import TauCeti.Analysis.Complex.UpperHalfPlane.Manifold
+import TauCeti.NumberTheory.ModularForms.Cusps.Basic
 
 /-!
 # The level-raising degeneracy maps `V_d`
@@ -922,7 +923,7 @@ theorem ModularForm.qExpansion_levelRaise_coeff_Gamma1 (M : ℕ) [NeZero M] [NeZ
       if d ∣ n then (qExpansion 1 f).coeff (n / d) else 0 := by
   have : NeZero (d * M) := ⟨Nat.mul_ne_zero (NeZero.ne d) (NeZero.ne M)⟩
   refine ModularForm.qExpansion_levelRaise_coeff ?_ ?_ _ f n <;>
-    simp [CongruenceSubgroup.strictPeriods_Gamma1]
+    exact one_mem_strictPeriods_Gamma1_map _
 
 /-- **The `q`-expansion of a level-raised cusp form.** A cusp form and its image under the
 inclusion into modular forms have the same underlying function, so the substitution `q ↦ q ^ d`
@@ -957,7 +958,7 @@ theorem CuspForm.qExpansion_levelRaise_coeff_Gamma1 (M : ℕ) [NeZero M] [NeZero
       if d ∣ n then (qExpansion 1 f).coeff (n / d) else 0 := by
   have : NeZero (d * M) := ⟨Nat.mul_ne_zero (NeZero.ne d) (NeZero.ne M)⟩
   refine CuspForm.qExpansion_levelRaise_coeff ?_ ?_ _ f n <;>
-    simp [CongruenceSubgroup.strictPeriods_Gamma1]
+    exact one_mem_strictPeriods_Gamma1_map _
 
 end QExpansion
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/QExpansion.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Diagonal/QExpansion.lean
@@ -9,6 +9,8 @@ public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
 public import TauCeti.NumberTheory.ModularForms.Degeneracy
 public import TauCeti.NumberTheory.ModularForms.SlashActionRat
 
+import TauCeti.NumberTheory.ModularForms.Cusps.Basic
+
 /-!
 # The `q`-expansion of a rational diagonal slash
 
@@ -131,7 +133,7 @@ theorem _root_.ModularForm.qExpansion_slash_natDiagGL_d_one_coeff_Gamma1
   let _ : NeZero (d * M) := ⟨Nat.mul_ne_zero (NeZero.ne d) (NeZero.ne M)⟩
   refine ModularForm.qExpansion_slash_natDiagGL_d_one_coeff ?_ ?_
     (Gamma1_map_le_conjAct_scaleGL M d) f n <;>
-    simp [CongruenceSubgroup.strictPeriods_Gamma1]
+    exact one_mem_strictPeriods_Gamma1_map _
 
 end TauCeti
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/LevelSupported.lean
@@ -8,6 +8,8 @@ module
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Operators
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.QExpansion
 
+import TauCeti.NumberTheory.ModularForms.Cusps.Basic
+
 /-!
 # The Hecke operators at an index supported on the level
 
@@ -256,7 +258,7 @@ theorem qExpansion_coeff_heckeTNat_of_primeFactors_subset (n : ℕ) [NeZero n]
     (qExpansion 1 (heckeTNat (N := N) k n f)).coeff m = (qExpansion 1 f).coeff (n * m) := by
   rw [coe_heckeTNat_of_primeFactors_subset k n hn f]
   exact qExpansion_coeff_heckeSlashUpperTri' k n
-    (by simp [CongruenceSubgroup.strictPeriods_Gamma1]) (Nat.pos_of_ne_zero (NeZero.ne n)) f m
+    (TauCeti.one_mem_strictPeriods_Gamma1_map _) (Nat.pos_of_ne_zero (NeZero.ne n)) f m
 
 /-- **The `q`-expansion recurrence on cusp forms**: `aₘ(T_n f) = a_{n m}(f)` at an index
 supported on the level. -/
@@ -266,7 +268,7 @@ theorem qExpansion_coeff_heckeTCuspNat_of_primeFactors_subset (n : ℕ) [NeZero 
     (qExpansion 1 (heckeTCuspNat (N := N) k n f)).coeff m = (qExpansion 1 f).coeff (n * m) := by
   rw [coe_heckeTCuspNat_of_primeFactors_subset k n hn f]
   exact qExpansion_coeff_heckeSlashUpperTri' k n
-    (by simp [CongruenceSubgroup.strictPeriods_Gamma1]) (Nat.pos_of_ne_zero (NeZero.ne n)) f m
+    (TauCeti.one_mem_strictPeriods_Gamma1_map _) (Nat.pos_of_ne_zero (NeZero.ne n)) f m
 
 end HeckeRing.GL2
 

--- a/TauCeti/NumberTheory/ModularForms/HeckeSlash/Recurrence.lean
+++ b/TauCeti/NumberTheory/ModularForms/HeckeSlash/Recurrence.lean
@@ -9,6 +9,8 @@ public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Diagonal.QExpansion
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.Prime
 public import TauCeti.NumberTheory.ModularForms.HeckeSlash.UpperTri.QExpansion
 
+import TauCeti.NumberTheory.ModularForms.Cusps.Basic
+
 /-!
 # The Fourier-coefficient recurrence for `Tₚ`, at every prime
 
@@ -95,8 +97,8 @@ private theorem qExpansion_coeff_add_slash_scaleRep [NeZero p]
       (qExpansion 1 f).coeff (p * m) +
         if p ∣ m then (p : ℂ) ^ (k - 1) * (qExpansion 1 g).coeff (m / p) else 0 := by
   have hp : 0 < p := Nat.pos_of_ne_zero (NeZero.ne p)
-  have hΓ : (1 : ℝ) ∈ ((Gamma1 N).map (mapGL ℝ)).strictPeriods := by
-    simp [CongruenceSubgroup.strictPeriods_Gamma1]
+  have hΓ : (1 : ℝ) ∈ ((Gamma1 N).map (mapGL ℝ)).strictPeriods :=
+    TauCeti.one_mem_strictPeriods_Gamma1_map N
   let _ : Fact (IsCusp OnePoint.infty ((Gamma1 N).map (mapGL ℝ))) :=
     ⟨((Gamma1 N).map (mapGL ℝ)).isCusp_of_mem_strictPeriods one_pos hΓ⟩
   have hU : AnalyticAt ℂ (cuspFunction 1 (heckeSlashUpperTri k p ⇑f)) 0 :=
@@ -130,8 +132,8 @@ theorem qExpansion_coeff_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime
         if p ∣ m then (p : ℂ) ^ (k - 1) * (qExpansion 1 (diamondOpNat k p f)).coeff (m / p)
         else 0 := by
   have _ : NeZero p := ⟨hp.ne_zero⟩
-  have hΓ : (1 : ℝ) ∈ ((Gamma1 N).map (mapGL ℝ)).strictPeriods := by
-    simp [CongruenceSubgroup.strictPeriods_Gamma1]
+  have hΓ : (1 : ℝ) ∈ ((Gamma1 N).map (mapGL ℝ)).strictPeriods :=
+    TauCeti.one_mem_strictPeriods_Gamma1_map N
   have hSum := ModularFormClass.analyticAt_cuspFunction_zero
     (heckeSlashGamma1ModularFormEnd k (diagCosetGamma1 N p) f) one_pos hΓ
   rw [coe_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime k hp f] at hSum
@@ -147,8 +149,8 @@ theorem qExpansion_coeff_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime
         if p ∣ m then (p : ℂ) ^ (k - 1) * (qExpansion 1 (diamondOpCuspNat k p f)).coeff (m / p)
         else 0 := by
   have _ : NeZero p := ⟨hp.ne_zero⟩
-  have hΓ : (1 : ℝ) ∈ ((Gamma1 N).map (mapGL ℝ)).strictPeriods := by
-    simp [CongruenceSubgroup.strictPeriods_Gamma1]
+  have hΓ : (1 : ℝ) ∈ ((Gamma1 N).map (mapGL ℝ)).strictPeriods :=
+    TauCeti.one_mem_strictPeriods_Gamma1_map N
   have hSum := ModularFormClass.analyticAt_cuspFunction_zero
     (heckeSlashGamma1CuspFormEnd k (diagCosetGamma1 N p) f) one_pos hΓ
   rw [coe_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime k hp f] at hSum
@@ -170,7 +172,7 @@ theorem qExpansion_coeff_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_mem_m
   rw [qExpansion_coeff_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_of_prime k hp f m,
     diamondOpNat_of_coprime k h, diamondOp_apply_of_mem_modFormCharSpace k χ _ hf,
     FunLike.coe_smul, ModularForm.qExpansion_smul one_pos
-      (by simp [CongruenceSubgroup.strictPeriods_Gamma1])]
+      (TauCeti.one_mem_strictPeriods_Gamma1_map _)]
   refine congrArg _ (if_congr Iff.rfl ?_ rfl)
   rw [map_smul, smul_eq_mul]
   ring
@@ -186,7 +188,7 @@ theorem qExpansion_coeff_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_mem_cusp
   rw [qExpansion_coeff_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_of_prime k hp f m,
     diamondOpCuspNat_of_coprime k h, diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ _ hf,
     FunLike.coe_smul, ModularForm.qExpansion_smul one_pos
-      (by simp [CongruenceSubgroup.strictPeriods_Gamma1])]
+      (TauCeti.one_mem_strictPeriods_Gamma1_map _)]
   refine congrArg _ (if_congr Iff.rfl ?_ rfl)
   rw [map_smul, smul_eq_mul]
   ring
@@ -244,7 +246,7 @@ theorem eq_qExpansion_coeff_of_heckeSlashGamma1ModularFormEnd_diagCosetGamma1_eq
     (h1 : (qExpansion 1 f).coeff 1 = 1) : c = (qExpansion 1 f).coeff p := by
   have h := qExpansion_coeff_one_heckeSlashGamma1ModularFormEnd_diagCosetGamma1 k hp f
   rwa [hc, FunLike.coe_smul, ModularForm.qExpansion_smul one_pos
-      (by simp [CongruenceSubgroup.strictPeriods_Gamma1]),
+      (TauCeti.one_mem_strictPeriods_Gamma1_map _),
     map_smul, smul_eq_mul, h1, mul_one] at h
 
 /-- **The Hecke eigenvalue of a normalized eigenvector, on cusp forms.** -/
@@ -254,7 +256,7 @@ theorem eq_qExpansion_coeff_of_heckeSlashGamma1CuspFormEnd_diagCosetGamma1_eq_sm
     (h1 : (qExpansion 1 f).coeff 1 = 1) : c = (qExpansion 1 f).coeff p := by
   have h := qExpansion_coeff_one_heckeSlashGamma1CuspFormEnd_diagCosetGamma1 k hp f
   rwa [hc, FunLike.coe_smul, ModularForm.qExpansion_smul one_pos
-      (by simp [CongruenceSubgroup.strictPeriods_Gamma1]),
+      (TauCeti.one_mem_strictPeriods_Gamma1_map _),
     map_smul, smul_eq_mul, h1, mul_one] at h
 
 end HeckeRing.GL2


### PR DESCRIPTION
The side condition `(1 : ℝ) ∈ ((Gamma1 N).map (mapGL ℝ)).strictPeriods` was discharged by an inline
`simp [CongruenceSubgroup.strictPeriods_Gamma1]` at **twelve sites across four files**. The period-1
`q`-expansion API asks for it everywhere — `ModularForm.qExpansion_smul`,
`qExpansion_levelRaise_coeff` and `isCusp_of_mem_strictPeriods` all take it as a hypothesis — so
this names it once and uses it as a term.

## What is added

One lemma, `TauCeti.one_mem_strictPeriods_Gamma1_map`, and twelve call sites converted. No statement
anywhere changes.

Mathlib names the subgroup-level fact (`CongruenceSubgroup.strictPeriods_Gamma1`, an `@[simp]` lemma
computing `strictPeriods (Gamma1 N) = AddSubgroup.zmultiples 1`) but not the membership form at the
`.map (mapGL ℝ)` spelling, and TauCeti had no named version — hence twelve copies.

## Placement, and the alternative that was rejected

`Cusps/Basic.lean` is the strict-period and integer-cusp-width file, and it already imports
`Mathlib.NumberTheory.ModularForms.Cusps` where `strictPeriods_Gamma1` lives, so **no new Mathlib
dependency is introduced**.

`CongruenceSubgroups/Basic.lean` was the alternative and is thematically just as good — it already
holds the `Gamma1_map` family, and all four consumers reach it. It was rejected because it does
*not* import Mathlib's `Cusps`, so siting the lemma there would force that import into a
foundational file and push the dependency onto everything downstream. `Cusps/Basic.lean` is the
cheaper edge.

## A module-system note worth flagging to reviewers

The four consumers get a **non-public** import: the lemma is used only inside proof bodies, so it
does not belong in any public interface.

Because a non-public import is **not transitive**, `HeckeSlash/Diagonal/QExpansion.lean` needs its
own import even though it publicly imports `Degeneracy`, which imports the lemma. The same applies
to `LevelSupported.lean` and `Recurrence.lean`. That is why four import lines appear rather than
one — it is deliberate, not redundancy.

`Recurrence.lean` and `LevelSupported.lean` sit in `namespace HeckeRing.GL2` rather than
`namespace TauCeti`, so they use the qualified `TauCeti.one_mem_strictPeriods_Gamma1_map`.

## Gates

* `lake build` of all five changed modules — exit 0, no `error`/`warning`/`info` diagnostics.
* `lake build` of all ten direct importers — exit 0.
* `lake exe runLinter TauCeti.NumberTheory.ModularForms.Cusps.Basic` — exit 0, "Linting passed".
  That is the named-module form, which sees public declarations; the new lemma is public, so it is
  in scope. The full environment linter (`lint-env`) needs a whole-library build and runs in CI.
* No line exceeds 100 characters (counted in characters, not bytes).
* **`simpNF` exposure is nil by construction**: no `@[simp]` attribute is added or removed, and no
  simp-tagged statement is touched.

## Origin

Found by the `reuse` reviewer on #5015, which called it "a real repo-wide observation that outlives
this PR". It is carved out here as its own topic because #5015 is parked on unrelated grounds.

Roadmap: ModularForms
