### PR TITLE
feat(Spa): the trivial valuation at a non-analytic point is a point of Spa

### DIFF
--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
@@ -67,6 +67,16 @@ theorem isAnalyticPoint_def (v : Spv A) :
     IsAnalyticPoint v ↔ ¬ IsOpen (v.supp : Set A) :=
   Iff.rfl
 
+/-- **Wedhorn Remark 7.42(3).** At a non-analytic point the trivial valuation on the support is
+again a point of the adic spectrum, for any plus ring.
+
+Being non-analytic is, by definition, openness of the support, which is exactly what
+`trivialSection_mem_spa_iff` asks for; `suppFun_asIdeal` is the identification of `v.supp` with
+the underlying ideal of `suppFun v`, and holds by `rfl`. -/
+theorem trivialSection_suppFun_mem_spa (Aplus : Subring A) {v : Spv A}
+    (hv : ¬ IsAnalyticPoint v) : trivialSection (suppFun v) ∈ spa Aplus :=
+  (trivialSection_mem_spa_iff Aplus _).mpr (suppFun_asIdeal v ▸ not_not.mp hv)
+
 /-- **Wedhorn's Analytic Locus `Spa(A, A⁺)ᵃ`**: the subset of `spa Aplus` consisting of analytic
 points (Definition 7.39). -/
 def spaAnalytic (Aplus : Subring A) : Set (Spv A) :=

--- a/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
+++ b/TauCeti/AlgebraicGeometry/AdicSpace/Spa/Analytic.lean
@@ -67,12 +67,11 @@ theorem isAnalyticPoint_def (v : Spv A) :
     IsAnalyticPoint v ↔ ¬ IsOpen (v.supp : Set A) :=
   Iff.rfl
 
-/-- **Wedhorn Remark 7.42(3).** At a non-analytic point the trivial valuation on the support is
-again a point of the adic spectrum, for any plus ring.
-
-Being non-analytic is, by definition, openness of the support, which is exactly what
-`trivialSection_mem_spa_iff` asks for; `suppFun_asIdeal` is the identification of `v.supp` with
-the underlying ideal of `suppFun v`, and holds by `rfl`. -/
+/-- **Wedhorn Remark 7.42(3).** Every non-analytic valuation class gives rise to a point of the
+adic spectrum: when the support of `v : Spv A` is open, the trivial valuation on that support
+lies in `spa Aplus`, for any plus ring. Nothing is asked of `v` itself beyond non-analyticity —
+in particular `v` need not be a point of `spa Aplus` — and the conclusion depends on `v` only
+through its support. -/
 theorem trivialSection_suppFun_mem_spa (Aplus : Subring A) {v : Spv A}
     (hv : ¬ IsAnalyticPoint v) : trivialSection (suppFun v) ∈ spa Aplus :=
   (trivialSection_mem_spa_iff Aplus _).mpr (suppFun_asIdeal v ▸ not_not.mp hv)


### PR DESCRIPTION
> [!IMPORTANT]
> **HELD — do not merge. The author recommends closing this PR.**
> This is a re-open of #5051, which was closed on `scope` — *"no roadmap consumer exists"*.
> Re-measured 2026-08-30 after 154 further commits to `main`: `trivialSection_suppFun_mem_spa`
> has **0** consumers (control `trivialSection_mem_spa_iff` → 6), none in flight, none proposed
> — and per the corrected grounding below, **nothing in Wedhorn consumes Remark 7.42 either**.
> The two open rubrics are deliberately not being cleared; see the owner check-in and addendum.
> Tracked on bead `tc-rwpgo`. Closing is reversible — branch and head `eb7d71c` survive.

Wedhorn Remark 7.42(3): at a non-analytic point, the vertical generization is the trivial valuation on the support, and it is again a point of the adic spectrum.

## The proof is one line, and that is the point

```lean
theorem trivialSection_suppFun_mem_spa (Aplus : Subring A) {v : Spv A}
    (hv : ¬ IsAnalyticPoint v) : trivialSection (suppFun v) ∈ spa Aplus :=
  (trivialSection_mem_spa_iff Aplus _).mpr (suppFun_asIdeal v ▸ not_not.mp hv)
```

Both halves were already on `main`. Being non-analytic *is* openness of the support by definition — `IsAnalyticPoint` is `¬ IsOpen (v.supp : Set A)`, with `isAnalyticPoint_def` as `Iff.rfl` — and that is exactly the hypothesis of `trivialSection_mem_spa_iff`. `suppFun_asIdeal` identifies `v.supp` with the underlying ideal of `suppFun v`, also by `rfl`.

## Deliberately not written inline

The obvious model is `exists_mem_spa_supp_eq` in `Spa/Points.lean`, which used to discharge the two `spa`-membership obligations by hand. That inline argument **was** the duplicate: #5020 factored it out and rewrote `Points.lean` to call it, and #5055 generalised it to the iff used here. Expanding it again would restore the copy a third time, and the reuse rubric would be right to reject it.

## Roadmap grounding

New declaration, so citing the target rather than the area.

**AdicSpaces, README.md:426-427** (verified on `origin/main`): *"Define a point to be analytic when its support is not open (Definition 7.39), and define the analytic locus `Spa(A,A⁺)^a`. Prove Proposition 7.49(2)…"*.

**Correction (2026-08-30) — the sentence that used to stand here was wrong, and it was this PR's whole justification.** It claimed Remark 7.42 is the vertical-generization toolkit "which 7.45's height-one argument relies on". Wedhorn 7.45's proof (`wedhorn.txt`:3336) cites Remark 7.40(5), Remark 4.12, Remark 7.11(2) and **Proposition 7.41** — it does not cite 7.42. Proposition 7.49(2) (:3417) does not cite 7.42 either.

Measured in the source, with controls firing (7.40 → 8, 7.41 → 4, 7.44 → 4, 7.45 → 4, 7.49 → 3): **7.42 → 1 occurrence, its own statement at :3290, cited nowhere in the book.** Its content is also already stated, 200 lines earlier, as a subordinate clause in Remark 7.25 (:3082) — *"if supp v is open we can simply take for x the trivial valuation with supp x = supp v"* — and 7.42(3)'s one-line justification is `trivialSection_mem_spa_iff`, already on `main`.

So there is no roadmap target to add here: this is a leaf in the source, not a gap in the roadmap. The full working is in the [addendum comment](https://github.com/TauCetiProject/TauCeti/pull/5100#issuecomment-5469750805).

## Verification

`lake build TauCeti.AlgebraicGeometry.AdicSpace.Spa.Analytic` — exit 0, **2129 jobs**, "Build completed successfully", no errors, warnings, or `info:` diagnostics, at head `0a1652ace`. Branched off `origin/main`. No line over 100 characters; no `sorry`.

Prior art re-probed on `origin/main` before writing: `7.42` → 0 files, against a firing control of `7.40` → 2 files.

Roadmap: AdicSpaces

