### PR TITLE
refactor(CliffordAlgebra): name the multiplicative step of the parity formula

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
@@ -81,8 +81,7 @@ private theorem lipschitzDet_unitι [Module.Free R M] [Module.Finite R M]
 /-- **The parity formula is multiplicative.** If `involute` acts on `x` and on `y` as the scalar
 `lipschitzDet`, it does so on the product. This is the `mul` closure step of
 `involute_eq_det_smul_of_mem_lipschitz`: the two scalars are central, so they collect in front. -/
-private theorem involute_mul_lipschitzDet [Module.Free R M] [Module.Finite R M]
-    (Q : QuadraticForm R M) {x y : (CliffordAlgebra Q)ˣ}
+private theorem involute_mul_lipschitzDet (Q : QuadraticForm R M) {x y : (CliffordAlgebra Q)ˣ}
     (hx : x ∈ lipschitzGroup Q) (hy : y ∈ lipschitzGroup Q)
     (ihx : involute (Q := Q) (x : CliffordAlgebra Q) =
       algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨x, hx⟩)) * x)

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Spin/SpecialOrthogonal.lean
@@ -78,6 +78,30 @@ private theorem lipschitzDet_unitι [Module.Free R M] [Module.Finite R M]
   rw [haction, lipschitzVectorAction_unitι]
   exact QuadraticMap.det_reflection Q v
 
+/-- **The parity formula is multiplicative.** If `involute` acts on `x` and on `y` as the scalar
+`lipschitzDet`, it does so on the product. This is the `mul` closure step of
+`involute_eq_det_smul_of_mem_lipschitz`: the two scalars are central, so they collect in front. -/
+private theorem involute_mul_lipschitzDet [Module.Free R M] [Module.Finite R M]
+    (Q : QuadraticForm R M) {x y : (CliffordAlgebra Q)ˣ}
+    (hx : x ∈ lipschitzGroup Q) (hy : y ∈ lipschitzGroup Q)
+    (ihx : involute (Q := Q) (x : CliffordAlgebra Q) =
+      algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨x, hx⟩)) * x)
+    (ihy : involute (Q := Q) (y : CliffordAlgebra Q) =
+      algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨y, hy⟩)) * y) :
+    involute (Q := Q) ((x : CliffordAlgebra Q) * y) =
+      algebraMap R (CliffordAlgebra Q)
+        (↑(lipschitzDet Q ((⟨x, hx⟩ : lipschitzGroup Q) * ⟨y, hy⟩))) *
+          ((x : CliffordAlgebra Q) * y) := by
+  rw [map_mul, ihx, ihy, map_mul]
+  simp only [Units.val_mul, map_mul]
+  rw [mul_assoc
+    (algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨x, hx⟩)))
+    (x : CliffordAlgebra Q)]
+  rw [← mul_assoc (x : CliffordAlgebra Q)
+    (algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨y, hy⟩))) y]
+  rw [← Algebra.commutes (↑(lipschitzDet Q ⟨y, hy⟩) : R) (x : CliffordAlgebra Q)]
+  noncomm_ring
+
 private theorem involute_eq_det_smul_of_mem_lipschitz [Module.Free R M] [Module.Finite R M]
     (Q : QuadraticForm R M) {x : (CliffordAlgebra Q)ˣ} (hx : x ∈ lipschitzGroup Q) :
     involute (Q := Q) (x : CliffordAlgebra Q) =
@@ -128,26 +152,8 @@ private theorem involute_eq_det_smul_of_mem_lipschitz [Module.Free R M] [Module.
   | mul x y hx hy ihx ihy =>
       have hx' : x ∈ lipschitzGroup Q := hx
       have hy' : y ∈ lipschitzGroup Q := hy
-      have ihx' : involute (Q := Q) (x : CliffordAlgebra Q) =
-          algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨x, hx'⟩)) * x := by
-        simpa only using ihx
-      have ihy' : involute (Q := Q) (y : CliffordAlgebra Q) =
-          algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨y, hy'⟩)) * y := by
-        simpa only using ihy
-      -- Expose multiplication in the ambient Clifford algebra before combining the hypotheses.
-      change involute (Q := Q) ((x : CliffordAlgebra Q) * y) =
-        algebraMap R (CliffordAlgebra Q)
-          (↑(lipschitzDet Q ((⟨x, hx'⟩ : lipschitzGroup Q) * ⟨y, hy'⟩))) *
-            ((x : CliffordAlgebra Q) * y)
-      rw [map_mul, ihx', ihy', map_mul]
-      simp only [Units.val_mul, map_mul]
-      rw [mul_assoc
-        (algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨x, hx'⟩)))
-        (x : CliffordAlgebra Q)]
-      rw [← mul_assoc (x : CliffordAlgebra Q)
-        (algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨y, hy'⟩))) y]
-      rw [← Algebra.commutes (↑(lipschitzDet Q ⟨y, hy'⟩) : R) (x : CliffordAlgebra Q)]
-      noncomm_ring
+      exact involute_mul_lipschitzDet Q hx' hy' (by simpa only using ihx)
+        (by simpa only using ihy)
 
 private theorem mem_even_of_involute_eq (Q : QuadraticForm R M) {x : CliffordAlgebra Q}
     (hx : involute x = x) : x ∈ even Q := by


### PR DESCRIPTION
`involute_eq_det_smul_of_mem_lipschitz` proves its parity formula by `Subgroup.closure_induction`.
The `mul` case was **23 of its 66 lines** and is a self-contained algebraic identity that never
mentions the Lipschitz group: the two `lipschitzDet` scalars are central, so they collect in front.
This gives it a name.

## What moved

```lean
private theorem involute_mul_lipschitzDet [Module.Free R M] [Module.Finite R M]
    (Q : QuadraticForm R M) {x y : (CliffordAlgebra Q)ˣ}
    (hx : x ∈ lipschitzGroup Q) (hy : y ∈ lipschitzGroup Q)
    (ihx : involute (Q := Q) (x : CliffordAlgebra Q) =
      algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨x, hx⟩)) * x)
    (ihy : involute (Q := Q) (y : CliffordAlgebra Q) =
      algebraMap R (CliffordAlgebra Q) (↑(lipschitzDet Q ⟨y, hy⟩)) * y) :
    involute (Q := Q) ((x : CliffordAlgebra Q) * y) =
      algebraMap R (CliffordAlgebra Q)
        (↑(lipschitzDet Q ((⟨x, hx⟩ : lipschitzGroup Q) * ⟨y, hy⟩))) *
          ((x : CliffordAlgebra Q) * y)
```

and the `mul` case becomes the application:

```lean
  | mul x y hx hy ihx ihy =>
      have hx' : x ∈ lipschitzGroup Q := hx
      have hy' : y ∈ lipschitzGroup Q := hy
      exact involute_mul_lipschitzDet Q hx' hy' (by simpa only using ihx)
        (by simpa only using ihy)
```

Measured as source lines of the proof body — the lines after `:= by`:

| | before | after |
|---|---|---|
| `involute_eq_det_smul_of_mem_lipschitz` proof body | 66 | **48** |
| `involute_mul_lipschitzDet` proof body | — | **9** |

By comment-stripped code lines the parent goes 60 → 43. **The parent now clears the 50-line
threshold that `proof-quality` flags; before this it did not.** The file grows 6 lines in total.

## Why the goal restatement lives in the extracted statement

The induction presents this case with the product already formed and the subgroup element written
as `⟨x, hx⟩ * ⟨y, hy⟩`, so the original case opened with a five-line `change` to expose that shape
before it could rewrite. Stating the helper *in* that shape puts the restatement where it belongs —
in the lemma's own statement — and leaves the case as a single application. Keeping the `change` in
the parent instead would have left the parent at 51 lines, i.e. still over the threshold; this is
the difference between the extraction clearing the line and not.

## What this deliberately does not do

The `inv` case (18 lines) is a comparable standalone step and could get the same treatment. I have
not done it here: one cut already takes the parent under the threshold, and a second would make
this two topics. If review would rather see both named, say so and I will do `inv` as a follow-up.

## Notes for review

- Gate: `env LEAN4_GUARDRAILS_BYPASS=1 lake build` of the changed module **and all three of its
  importers** (`Spin.Kernel`, `Spin.SpinorNorm`, `Spin.Surjectivity`) — `Build completed
  successfully (2131 jobs)`, exit 0, zero warnings. Measured at commit `78da2e428` against base
  `42e3806b4`; `main` has since moved 29 files but **none in `CliffordAlgebra/`**, so that gate
  still describes the merge result.
- Linter: `lake exe runLinter TauCeti.LinearAlgebra.CliffordAlgebra.Spin.SpecialOrthogonal` —
  passed. Naming which one because `scripts/lint-env.sh` cannot run under a module-scoped build.
- Contention: the file is untouched by every open PR (`--json files` scan with a live positive
  control derived from the current open-PR set), and the declined ledger has no entry for it
  (control: a genuinely declined name returns 14).
- No name collision: `involute_mul_lipschitzDet` did not exist (control: `lipschitzDet` returns 1
  file).
- Line length: no line I added reaches 100 codepoints; the file maximum is 98, unchanged.
- **Cleanup**: per-declaration checks by hand on the two declarations this diff touches rather than
  a whole-file `/cleanup` — slinging `fm-cleanup` for a file my own PR modifies creates contention
  with my own PR, which I did once and withdrew (bead `tc-doj80`). If a maintainer wants a
  whole-file cleanup here, re-slinging it *after* this lands cleans the post-extraction file.
- `Roadmap: RepresentationTheory` — what **#2523 claimed when it created this file**, not inferred
  from the directory (control: the same query returns `AlgebraicCurves` for my #5090).

Roadmap: RepresentationTheory
