### PR TITLE
feat(HeckeRing): the per-prime product formula at level Γ₀(N)

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimePower.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimePower.lean
@@ -8,6 +8,9 @@ module
 public import TauCeti.NumberTheory.HeckeRing.Associativity
 public import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.Elem
 
+import TauCeti.Algebra.LinearRecurrence.OrderTwo
+import TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.AtkinLehner
+
 /-!
 # The diagonal generators of the `Γ₀(N)` Hecke ring
 
@@ -44,6 +47,9 @@ factorisation is proved here; this file supplies the generators those need.
 * `HeckeRing.GL2.heckeTGeneratorRecGamma0_succ_succ`: the recurrence, as a rewriting rule.
 * `HeckeRing.GL2.heckeTGeneratorRecGamma0_eq_generator_pow_of_not_coprime`: when `p` shares a
   factor with the level, the recurrence degenerates to a power of the generator.
+* `HeckeRing.GL2.heckeTGeneratorRecGamma0_mul`: **Shimura, Theorem 3.24(3)** at level `Γ₀(N)`,
+  the per-prime product formula `T_{p^r} · T_{p^s} = ∑_{i ≤ r} pⁱ · S_pⁱ · T_{p^{r+s−2i}}`
+  for `r ≤ s`.
 
 ## References
 
@@ -216,5 +222,40 @@ theorem heckeTGeneratorRecGamma0_eq_generator_pow_of_not_coprime {p : ℕ}
   | more r _ih0 ih1 =>
     simp [heckeTGeneratorRecGamma0_succ_succ, heckeTScalarGamma0_of_not_coprime N hpN, ih1,
       ← pow_succ']
+
+/-! ## The product formula
+
+`heckeTGeneratorRecGamma0` is a two-term linear recurrence with `D = T_p` and `S = p · S_p`, so
+a product of two of its terms is an instance of `TauCeti.linearRec₂_mul_eq_sum_pow_mul`. That is
+the route `heckeT_prime_pow_mul` already takes at level one (`GL2/Recurrence.lean`); the only
+input beyond the recurrence is that `D` and `S` commute. -/
+
+/-- `T_p` commutes with the scalar `p · S_p`.
+
+The `Γ₀(N)` Hecke ring is commutative: `atkinLehnerAntiInvolution` fixes every double coset
+(`atkinLehnerAntiInvolution_onHeckeCoset_eq_self`), which is what
+`HeckeCosetModule.mul_comm_of_antiInvolution` asks for. An integer multiple of a commuting
+element still commutes. -/
+private lemma commute_heckeTGeneratorGamma0_smul_heckeTScalarGamma0 (p : ℕ) :
+    Commute (heckeTGeneratorGamma0 N p) ((p : ℤ) • heckeTScalarGamma0 N p) :=
+  Commute.smul_right (HeckeCosetModule.mul_comm_of_antiInvolution ℤ
+    (atkinLehnerAntiInvolution N) (atkinLehnerAntiInvolution_onHeckeCoset_eq_self N) _ _) _
+
+/-- **Shimura, Theorem 3.24(3)** at level `Γ₀(N)` — the per-prime product formula:
+`T_{p^r} · T_{p^s} = ∑_{i ≤ r} pⁱ · S_pⁱ · T_{p^{r+s−2i}}` for `r ≤ s`, so that no product of
+two `T`-values survives on the right.
+
+No primality is asked of `p`, for the same reason the recurrence does not ask it. When `p`
+shares a factor with the level `S_p = 0`, every summand but `i = 0` drops and the identity
+degenerates to `T_p^r · T_p^s = T_p^{r+s}`. -/
+theorem heckeTGeneratorRecGamma0_mul (p : ℕ) {r s : ℕ} (hrs : r ≤ s) :
+    heckeTGeneratorRecGamma0 N p r * heckeTGeneratorRecGamma0 N p s =
+      ∑ i ∈ Finset.range (r + 1), (p : ℤ) ^ i • (heckeTScalarGamma0 N p ^ i *
+        heckeTGeneratorRecGamma0 N p (r + s - 2 * i)) := by
+  rw [TauCeti.linearRec₂_mul_eq_sum_pow_mul (heckeTGeneratorRecGamma0_zero N p)
+    (heckeTGeneratorRecGamma0_one N p)
+    (commute_heckeTGeneratorGamma0_smul_heckeTScalarGamma0 N p)
+    (heckeTGeneratorRecGamma0_succ_succ N p) hrs]
+  exact Finset.sum_congr rfl fun i _ ↦ by rw [smul_pow, smul_mul_assoc]
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimePower.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimePower.lean
@@ -33,8 +33,8 @@ asks `Nat.Prime` either. The elements *are* the classical `T_p` and `T_{p^r}` of
 exactly when `p` is prime — that is the intended reading, and the recurrence is chosen to
 match it — but nothing below assumes it, so nothing below is named for it.
 
-Neither the per-prime product formula nor the composite element assembled over a prime
-factorisation is proved here; this file supplies the generators those need.
+The composite element assembled over a prime factorisation is not built here; this file
+supplies the generators it needs, and the per-prime product formula they satisfy.
 
 ## Main definitions
 
@@ -62,14 +62,14 @@ factorisation is proved here; this file supplies the generators those need.
   `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck,
   `LeanModularForms/HeckeRIngs/GL2/Unified/Gamma0RingDn.lean`, declarations `heckeRingDp`,
   `heckeRingSpp`, `heckeRingSpp_of_not_coprime`, `heckeRingDppow`, `heckeRingDppow_zero`,
-  `heckeRingDppow_one`, `heckeRingDppow_succ_succ` and
-  `heckeRingDppow_eq_pow_of_not_coprime`. Three hypotheses of the source are dropped here: the
-  generator no longer asks `0 < p`, and neither the scalar generator nor the iterated family
-  asks `Nat.Prime p` — none is needed to define the elements or to prove the
-  recurrence, and carrying them would force every consumer to supply a primality proof for a
-  statement that does not use it. The names follow this namespace's `heckeT*` family rather
-  than the source's `heckeRing*`, and drop the source's `p`/`prime` vocabulary along with the
-  hypothesis it stood for.
+  `heckeRingDppow_one`, `heckeRingDppow_succ_succ`, `heckeRingDppow_eq_pow_of_not_coprime`
+  and `heckeRingDppow_mul`. Four hypotheses of the source are dropped here: the generator no
+  longer asks `0 < p`, and none of the scalar generator, the iterated family and the product
+  formula asks `Nat.Prime p` — none is needed to define the elements, to prove the recurrence,
+  or to derive the product formula from it, and carrying them would force every consumer to
+  supply a primality proof for a statement that does not use it. The names follow this
+  namespace's `heckeT*` family rather than the source's `heckeRing*`, and drop the source's
+  `p`/`prime` vocabulary along with the hypothesis it stood for.
 -/
 
 public section


### PR DESCRIPTION
**Shimura, Theorem 3.24(3), at level `Γ₀(N)`.** For `r ≤ s`,

`T_{p^r} · T_{p^s} = ∑_{i ≤ r} pⁱ · S_pⁱ · T_{p^{r+s−2i}}`

so that no product of two `T`-values survives on the right.

### What it adds

One theorem and one private input in `TauCeti/NumberTheory/HeckeRing/GL2/Gamma0/Diagonal/PrimePower.lean`:

* `heckeTGeneratorRecGamma0_mul` — the product formula above.
* `commute_heckeTGeneratorGamma0_smul_heckeTScalarGamma0` (private) — `T_p` commutes with `p · S_p`.

### It is an instantiation, not a proof

`heckeTGeneratorRecGamma0` is *defined* on `main` by the Diamond–Shurman recurrence `T₀ = 1`, `T₁ = T_p`, `T_{r+2} = T_p · T_{r+1} − (p · S_p) · T_r`. That is exactly the shape of `TauCeti.linearRec₂_mul_eq_sum_pow_mul` (`Algebra/LinearRecurrence/OrderTwo.lean`, merged in #4796) at `D = T_p`, `S = p · S_p`, so the whole proof is one `rw` plus a `Finset.sum_congr` matching the summand — the general statement writes `S ^ i * _` where this one writes `pⁱ • (S_pⁱ * _)`.

**This is deliberately the same route `heckeT_prime_pow_mul` already takes at level one** (`GL2/Recurrence.lean`), down to the shape of the private commutation lemma beside it. Level one had the identical hand-rolled induction until it was replaced by the same instantiation; doing the level-`N` case any other way would re-introduce what that refactor removed. That precedent is also why the commutation input is a `private lemma` with a single call site rather than an inline `have`.

The commutation is the centrality of the scalar class: `atkinLehnerAntiInvolution` fixes every double coset of `Δ₀(N)` (`atkinLehnerAntiInvolution_onHeckeCoset_eq_self`), which is what `HeckeCosetModule.mul_comm_of_antiInvolution` asks for, and an integer multiple of a commuting element still commutes. `Diagonal/Composite.lean` already discharges its commutation obligations from the same lemma, so no instance is swapped in here either.

### More general than the source

The source asks `hp : Nat.Prime p`. This does not, because nothing in the argument uses it: the recurrence that defines `heckeTGeneratorRecGamma0` is stated at every natural `p`, and this is a consequence of that recurrence. That matches the file's existing convention — none of `heckeTGeneratorGamma0`, `heckeTScalarGamma0` or `heckeTGeneratorRecGamma0` asks primality, and the module docstring says so explicitly. At `p` sharing a factor with the level `S_p = 0`, every summand but `i = 0` drops, and the identity degenerates to `T_p^r · T_p^s = T_p^{r+s}`.

### Placement

Beside the recurrence it consumes, in `Diagonal/PrimePower.lean`, mirroring level one where `heckeT_prime_pow_mul` sits directly after `heckeT_prime_pow_recurrence` in `GL2/Recurrence.lean`. Two non-public imports are added, both proof-only: `Algebra.LinearRecurrence.OrderTwo` and `GL2.Gamma0.AtkinLehner`. Neither creates a cycle — `AtkinLehner.lean` imports `Diagonal/Coset.lean`, which is below this file, and `Diagonal/Composite.lean` already imports both of these together.

### Scope — and the scalar composite, measured

Only the per-prime formula. The `D_n`/`S_n` composite form (source `heckeRingDn_ppow_mul`) is **not** included, and the reason is a measurement the work bead asked for.

The source declares a separate composite scalar `heckeRingSn` — with `heckeRingSn_eq_zero_of_not_coprime`, a 35-line strong induction, and `heckeRingSn_ppow` — *only* because its `heckeRingSpp` demands `Nat.Prime p`. `main` has no such restriction: `heckeTScalarGamma0` is already defined at every natural `d`. So the composite scalar should not be ported at all; what is needed instead is that `d ↦ heckeTScalarGamma0 N d` is multiplicative, i.e. that `diag(d, d)` being central makes its double coset a single coset.

Measured on `main`:

* the level-one form of exactly that fact **is** present — `GLn/ScalarMul.lean`, `diagElem_const_mul` / `diagElem_mul_const` / `diagElem_const_pow`, Shimura Proposition 3.17;
* the level-`N` form is **absent**. `diagElemGamma0` occurs only in `Diagonal/Elem.lean` (20 occurrences) and `Diagonal/PrimePower.lean` (15), nowhere else in the library, and there is no `mulMap`/`multiplicity` development under `GL2/Gamma0/` to run the degree-one argument through.

So the answer to "does `primePowerProd (fun p v ↦ S_p^v) d = heckeTScalarGamma0 N d` hold" is: yes mathematically, the tool exists one level down, and the transfer is unbuilt. That transfer is its own topic and is filed separately; this PR does not guess at it.

### Gates

`lake build` of the changed module and its only direct importer (`Diagonal/Composite.lean`) — exit 0, 2554 jobs, zero log matches for `error`, `warning`, `info:`, `Try this`/`Try these` and `sorry`. `lake exe runLinter TauCeti.NumberTheory.HeckeRing.GL2.Gamma0.Diagonal.PrimePower` — exit 0, "Linting passed". `#print axioms HeckeRing.GL2.heckeTGeneratorRecGamma0_mul` — `[propext, Classical.choice, Quot.sound]`. `scripts/lint-style.sh` exit 0. No line over 100 codepoints.

### Attribution

Adapted from [AINTLIB](https://github.com/CBirkbeck/AINTLIB) commit `2baa76f742bdb4fb8ee323fabba41203bd390e08`, Apache-2.0, Chris Birkbeck, `LeanModularForms/HeckeRIngs/GL2/Unified/Gamma0RingDn.lean`, declaration `heckeRingDppow_mul` (line 496). The source obtains its commutation by installing a `CommRing` instance on the whole Hecke ring (`instCommRing_Gamma0`); here the single `Commute` the general lemma asks for is supplied directly, as `Diagonal/Composite.lean` already does.

Roadmap: ModularForms

Target: `TauCetiRoadmap/ModularForms/README.md:435` names `heckeRingDn : 𝕋 (Gamma0_pair N) ℤ` as the route by which the diamond direction enters the `Γ₀(N)`-pair ring; the prime-power product formula is the multiplication law that ring is assembled from, and Layer 5 (README:603-625, `strongMultiplicityOne`) consumes it.
