### PR TITLE
feat(ModularForms): the Fricke character-space transport

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/Fricke/CharacterSpace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/CharacterSpace.lean
@@ -119,24 +119,20 @@ public theorem frickeOperatorCusp_mem_cuspFormCharSpace (k : ℤ) (χ : (ZMod N)
 /-- **The Fricke operator restricted to a nebentypus space**, as a `ℂ`-linear map
 `M_k(Γ₁(N), χ) →ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)`.
 
-This is `frickeOperator` cut down by `LinearMap.restrict`. Naming the restriction destroys the
-`LinearMap.restrict` head symbol, so mathlib's `LinearMap.coe_restrict_apply` no longer fires on
-it; `coe_frickeCharRestrict_apply` below restates it under this name. -/
+This is `frickeOperator` cut down by `LinearMap.restrict`. -/
 public noncomputable def frickeCharRestrict (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
     modFormCharSpace k χ →ₗ[ℂ] modFormCharSpace k χ⁻¹ :=
   (frickeOperator k).restrict fun _ hf ↦ frickeOperator_mem_modFormCharSpace k χ hf
 
-/-- On underlying modular forms, `frickeCharRestrict` is `frickeOperator`.
-
-Mathlib's `LinearMap.coe_restrict_apply` cannot fire here: naming the restriction as a `def`
-destroys the `LinearMap.restrict` head symbol, so the `simp` lemma no longer matches. This states
-the same fact through the name that does. -/
+/-- On underlying modular forms, `frickeCharRestrict` is `frickeOperator`. -/
 @[simp]
 public theorem coe_frickeCharRestrict_apply (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
     (f : modFormCharSpace k χ) :
     ((frickeCharRestrict k χ f : modFormCharSpace k χ⁻¹) :
         ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
       frickeOperator k (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  -- Naming the restriction as a `def` destroys the `LinearMap.restrict` head symbol, so
+  -- `LinearMap.coe_restrict_apply` does not fire as a `simp` lemma; it still applies by name.
   LinearMap.coe_restrict_apply _ _
 
 /-- **The Fricke operator restricted to a nebentypus space of cusp forms**, as a `ℂ`-linear map
@@ -155,20 +151,17 @@ public theorem coe_frickeCharCuspRestrict_apply (k : ℤ) (χ : (ZMod N)ˣ →* 
       frickeOperatorCusp k (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
   LinearMap.coe_restrict_apply _ _
 
-/-- **The Fricke automorphism carries the `χ`-space onto the `χ⁻¹`-space.**
-
-This is the surjective refinement of `frickeOperator_mem_modFormCharSpace`, which gives only the
-forward inclusion. The reverse one is the same statement read at `χ⁻¹`: a `g` in the `χ⁻¹`-space
-is the image of `(frickeOperatorEquiv k).symm g`, which lies in the `χ`-space because
-`frickeOperator k g` does — by `frickeOperator_mem_modFormCharSpace` at `χ⁻¹` and `χ⁻¹⁻¹ = χ` —
-and the space is closed under the scalar. Stated as a `Submodule.map` equality because that is
-what `LinearEquiv.ofSubmodules` consumes. -/
+/-- **The Fricke automorphism carries the `χ`-space onto the `χ⁻¹`-space.** The surjective
+refinement of `frickeOperator_mem_modFormCharSpace`, which gives only the forward inclusion. -/
+@[simp]
 public theorem map_frickeOperatorEquiv_modFormCharSpace (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
     (modFormCharSpace k χ).map (frickeOperatorEquiv (N := N) k : _ →ₗ[ℂ] _) =
       modFormCharSpace k χ⁻¹ := by
   refine le_antisymm ?_ fun g hg ↦ ?_
   · rintro _ ⟨f, hf, rfl⟩
     simpa using frickeOperator_mem_modFormCharSpace k χ hf
+  -- The reverse inclusion is the same statement read at `χ⁻¹`, via `χ⁻¹⁻¹ = χ` and closure
+  -- of the space under the scalar.
   · refine ⟨(frickeOperatorEquiv (N := N) k).symm g, ?_,
       by simp [smul_smul, inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]⟩
     have h := frickeOperator_mem_modFormCharSpace k χ⁻¹ hg
@@ -179,9 +172,7 @@ public theorem map_frickeOperatorEquiv_modFormCharSpace (k : ℤ) (χ : (ZMod N)
 `M_k(Γ₁(N), χ) ≃ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)`.
 
 The ambient automorphism `frickeOperatorEquiv` restricted to the pair of character spaces it
-matches up, via `LinearEquiv.ofSubmodules`. The inverse and both round trips come from the
-ambient equivalence; only the surjectivity of the restriction is proved here, as
-`map_frickeOperatorEquiv_modFormCharSpace`. -/
+matches up. -/
 public noncomputable def frickeCharEquiv (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
     modFormCharSpace k χ ≃ₗ[ℂ] modFormCharSpace k χ⁻¹ :=
   (frickeOperatorEquiv (N := N) k).ofSubmodules _ _
@@ -207,7 +198,8 @@ public theorem coe_frickeCharEquiv_symm_apply (k : ℤ) (χ : (ZMod N)ˣ →* �
   simp [frickeCharEquiv]
 
 /-- **The Fricke automorphism carries the `χ`-space of cusp forms onto the `χ⁻¹`-space.** The
-cusp-form counterpart of `map_frickeOperatorEquiv_modFormCharSpace`, proved the same way. -/
+cusp-form counterpart of `map_frickeOperatorEquiv_modFormCharSpace`. -/
+@[simp]
 public theorem map_frickeOperatorCuspEquiv_cuspFormCharSpace (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
     (cuspFormCharSpace k χ).map (frickeOperatorCuspEquiv (N := N) k : _ →ₗ[ℂ] _) =
       cuspFormCharSpace k χ⁻¹ := by

--- a/TauCeti/NumberTheory/ModularForms/Fricke/CharacterSpace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/CharacterSpace.lean
@@ -119,12 +119,25 @@ public theorem frickeOperatorCusp_mem_cuspFormCharSpace (k : ℤ) (χ : (ZMod N)
 /-- **The Fricke operator restricted to a nebentypus space**, as a `ℂ`-linear map
 `M_k(Γ₁(N), χ) →ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)`.
 
-This is `frickeOperator` cut down by `LinearMap.restrict`, so mathlib's
-`LinearMap.coe_restrict_apply` is already the `simp` lemma identifying it with `frickeOperator`
-on underlying forms; no separate coercion lemma is stated here. -/
+This is `frickeOperator` cut down by `LinearMap.restrict`. Naming the restriction destroys the
+`LinearMap.restrict` head symbol, so mathlib's `LinearMap.coe_restrict_apply` no longer fires on
+it; `coe_frickeCharRestrict_apply` below restates it under this name. -/
 public noncomputable def frickeCharRestrict (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
     modFormCharSpace k χ →ₗ[ℂ] modFormCharSpace k χ⁻¹ :=
   (frickeOperator k).restrict fun _ hf ↦ frickeOperator_mem_modFormCharSpace k χ hf
+
+/-- On underlying modular forms, `frickeCharRestrict` is `frickeOperator`.
+
+Mathlib's `LinearMap.coe_restrict_apply` cannot fire here: naming the restriction as a `def`
+destroys the `LinearMap.restrict` head symbol, so the `simp` lemma no longer matches. This states
+the same fact through the name that does. -/
+@[simp]
+public theorem coe_frickeCharRestrict_apply (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (f : modFormCharSpace k χ) :
+    ((frickeCharRestrict k χ f : modFormCharSpace k χ⁻¹) :
+        ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      frickeOperator k (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  LinearMap.coe_restrict_apply _ _
 
 /-- **The Fricke operator restricted to a nebentypus space of cusp forms**, as a `ℂ`-linear map
 `S_k(Γ₁(N), χ) →ₗ[ℂ] S_k(Γ₁(N), χ⁻¹)`. The cusp-form counterpart of `frickeCharRestrict`. -/
@@ -132,22 +145,47 @@ public noncomputable def frickeCharCuspRestrict (k : ℤ) (χ : (ZMod N)ˣ →* 
     cuspFormCharSpace k χ →ₗ[ℂ] cuspFormCharSpace k χ⁻¹ :=
   (frickeOperatorCusp k).restrict fun _ hf ↦ frickeOperatorCusp_mem_cuspFormCharSpace k χ hf
 
+/-- On underlying cusp forms, `frickeCharCuspRestrict` is `frickeOperatorCusp`. The cusp-form
+counterpart of `coe_frickeCharRestrict_apply`, stated for the same reason. -/
+@[simp]
+public theorem coe_frickeCharCuspRestrict_apply (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (f : cuspFormCharSpace k χ) :
+    ((frickeCharCuspRestrict k χ f : cuspFormCharSpace k χ⁻¹) :
+        CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      frickeOperatorCusp k (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  LinearMap.coe_restrict_apply _ _
+
+/-- **The Fricke automorphism carries the `χ`-space onto the `χ⁻¹`-space.**
+
+This is the surjective refinement of `frickeOperator_mem_modFormCharSpace`, which gives only the
+forward inclusion. The reverse one is the same statement read at `χ⁻¹`: a `g` in the `χ⁻¹`-space
+is the image of `(frickeOperatorEquiv k).symm g`, which lies in the `χ`-space because
+`frickeOperator k g` does — by `frickeOperator_mem_modFormCharSpace` at `χ⁻¹` and `χ⁻¹⁻¹ = χ` —
+and the space is closed under the scalar. Stated as a `Submodule.map` equality because that is
+what `LinearEquiv.ofSubmodules` consumes. -/
+public theorem map_frickeOperatorEquiv_modFormCharSpace (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
+    (modFormCharSpace k χ).map (frickeOperatorEquiv (N := N) k : _ →ₗ[ℂ] _) =
+      modFormCharSpace k χ⁻¹ := by
+  refine le_antisymm ?_ fun g hg ↦ ?_
+  · rintro _ ⟨f, hf, rfl⟩
+    simpa using frickeOperator_mem_modFormCharSpace k χ hf
+  · refine ⟨(frickeOperatorEquiv (N := N) k).symm g, ?_,
+      by simp [smul_smul, inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]⟩
+    have h := frickeOperator_mem_modFormCharSpace k χ⁻¹ hg
+    rw [inv_inv_monoidHom] at h
+    simpa using Submodule.smul_mem _ ((frickeScalar N k)⁻¹) h
+
 /-- **The Fricke isomorphism between nebentypus spaces**
 `M_k(Γ₁(N), χ) ≃ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)`.
 
-The forward map is `frickeCharRestrict`; the inverse is `(frickeScalar N k)⁻¹ •` the Fricke
-operator again, which lands back in the `χ`-space because `χ⁻¹⁻¹ = χ`. Both round trips are
-`frickeOperator_frickeOperator_apply` followed by cancelling the nonzero `frickeScalar N k`. -/
+The ambient automorphism `frickeOperatorEquiv` restricted to the pair of character spaces it
+matches up, via `LinearEquiv.ofSubmodules`. The inverse and both round trips come from the
+ambient equivalence; only the surjectivity of the restriction is proved here, as
+`map_frickeOperatorEquiv_modFormCharSpace`. -/
 public noncomputable def frickeCharEquiv (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
     modFormCharSpace k χ ≃ₗ[ℂ] modFormCharSpace k χ⁻¹ :=
-  LinearEquiv.ofLinearMap (frickeCharRestrict k χ)
-    ((frickeScalar N k)⁻¹ • (frickeOperator k).restrict fun _ hf ↦ by
-      have h := frickeOperator_mem_modFormCharSpace k χ⁻¹ hf
-      rwa [inv_inv_monoidHom] at h)
-    (LinearMap.ext fun _ ↦ Subtype.ext (by
-      simp [frickeCharRestrict, smul_smul, inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]))
-    (LinearMap.ext fun _ ↦ Subtype.ext (by
-      simp [frickeCharRestrict, smul_smul, inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]))
+  (frickeOperatorEquiv (N := N) k).ofSubmodules _ _
+    (map_frickeOperatorEquiv_modFormCharSpace k χ)
 
 /-- On underlying modular forms, `frickeCharEquiv` is `frickeOperator`. -/
 @[simp]
@@ -155,7 +193,8 @@ public theorem coe_frickeCharEquiv_apply (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
     (f : modFormCharSpace k χ) :
     ((frickeCharEquiv k χ f : modFormCharSpace k χ⁻¹) :
         ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      frickeOperator k (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := (rfl)
+      frickeOperator k (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  simp [frickeCharEquiv]
 
 /-- On underlying modular forms, the inverse of `frickeCharEquiv` is
 `(frickeScalar N k)⁻¹ • frickeOperator`. -/
@@ -164,23 +203,29 @@ public theorem coe_frickeCharEquiv_symm_apply (k : ℤ) (χ : (ZMod N)ˣ →* �
     (g : modFormCharSpace k χ⁻¹) :
     (((frickeCharEquiv k χ).symm g : modFormCharSpace k χ) :
         ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      (frickeScalar N k)⁻¹ • frickeOperator k (g : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
-  (rfl)
+      (frickeScalar N k)⁻¹ • frickeOperator k (g : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  simp [frickeCharEquiv]
+
+/-- **The Fricke automorphism carries the `χ`-space of cusp forms onto the `χ⁻¹`-space.** The
+cusp-form counterpart of `map_frickeOperatorEquiv_modFormCharSpace`, proved the same way. -/
+public theorem map_frickeOperatorCuspEquiv_cuspFormCharSpace (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
+    (cuspFormCharSpace k χ).map (frickeOperatorCuspEquiv (N := N) k : _ →ₗ[ℂ] _) =
+      cuspFormCharSpace k χ⁻¹ := by
+  refine le_antisymm ?_ fun g hg ↦ ?_
+  · rintro _ ⟨f, hf, rfl⟩
+    simpa using frickeOperatorCusp_mem_cuspFormCharSpace k χ hf
+  · refine ⟨(frickeOperatorCuspEquiv (N := N) k).symm g, ?_,
+      by simp [smul_smul, inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]⟩
+    have h := frickeOperatorCusp_mem_cuspFormCharSpace k χ⁻¹ hg
+    rw [inv_inv_monoidHom] at h
+    simpa using Submodule.smul_mem _ ((frickeScalar N k)⁻¹) h
 
 /-- **The Fricke isomorphism between nebentypus spaces of cusp forms**
 `S_k(Γ₁(N), χ) ≃ₗ[ℂ] S_k(Γ₁(N), χ⁻¹)`. The cusp-form counterpart of `frickeCharEquiv`. -/
 public noncomputable def frickeCharCuspEquiv (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
     cuspFormCharSpace k χ ≃ₗ[ℂ] cuspFormCharSpace k χ⁻¹ :=
-  LinearEquiv.ofLinearMap (frickeCharCuspRestrict k χ)
-    ((frickeScalar N k)⁻¹ • (frickeOperatorCusp k).restrict fun _ hf ↦ by
-      have h := frickeOperatorCusp_mem_cuspFormCharSpace k χ⁻¹ hf
-      rwa [inv_inv_monoidHom] at h)
-    (LinearMap.ext fun _ ↦ Subtype.ext (by
-      simp [frickeCharCuspRestrict, smul_smul,
-        inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]))
-    (LinearMap.ext fun _ ↦ Subtype.ext (by
-      simp [frickeCharCuspRestrict, smul_smul,
-        inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]))
+  (frickeOperatorCuspEquiv (N := N) k).ofSubmodules _ _
+    (map_frickeOperatorCuspEquiv_cuspFormCharSpace k χ)
 
 /-- On underlying cusp forms, `frickeCharCuspEquiv` is `frickeOperatorCusp`. -/
 @[simp]
@@ -188,7 +233,8 @@ public theorem coe_frickeCharCuspEquiv_apply (k : ℤ) (χ : (ZMod N)ˣ →* ℂ
     (f : cuspFormCharSpace k χ) :
     ((frickeCharCuspEquiv k χ f : cuspFormCharSpace k χ⁻¹) :
         CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      frickeOperatorCusp k (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := (rfl)
+      frickeOperatorCusp k (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  simp [frickeCharCuspEquiv]
 
 /-- On underlying cusp forms, the inverse of `frickeCharCuspEquiv` is
 `(frickeScalar N k)⁻¹ • frickeOperatorCusp`. -/
@@ -197,7 +243,7 @@ public theorem coe_frickeCharCuspEquiv_symm_apply (k : ℤ) (χ : (ZMod N)ˣ →
     (g : cuspFormCharSpace k χ⁻¹) :
     (((frickeCharCuspEquiv k χ).symm g : cuspFormCharSpace k χ) :
         CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      (frickeScalar N k)⁻¹ • frickeOperatorCusp k (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
-  (rfl)
+      (frickeScalar N k)⁻¹ • frickeOperatorCusp k (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := by
+  simp [frickeCharCuspEquiv]
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Fricke/CharacterSpace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/CharacterSpace.lean
@@ -22,7 +22,7 @@ carries `M_k(Γ₁(N), χ)` into `M_k(Γ₁(N), χ⁻¹)`, and since `W_N ∘ W_
   `χ`-nebentypus space, landing in the `χ⁻¹`-nebentypus space, on modular and on cusp forms.
 * `TauCeti.frickeCharEquiv`, `TauCeti.frickeCharCuspEquiv`: those restrictions bundled as linear
   isomorphisms `M_k(Γ₁(N), χ) ≃ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)` and `S_k(Γ₁(N), χ) ≃ₗ[ℂ] S_k(Γ₁(N), χ⁻¹)`,
-  with inverse `frickeScalar N k⁻¹ • W_N`.
+  with inverse `(frickeScalar N k)⁻¹ • W_N`.
 
 ## Main results
 
@@ -36,8 +36,12 @@ The target character is mathlib's `χ⁻¹`, the inverse in the commutative grou
 (`MonoidHom.instCommGroup`), for which `MonoidHom.inv_apply` gives `χ⁻¹ d = (χ d)⁻¹`. The source
 introduces a named `chiConj χ = χ.comp invMonoidHom` for this; that is the same monoid hom —
 `χ d⁻¹ = (χ d)⁻¹` is `map_inv` — so no definition is made here, matching the `χ⁻¹` spelling
-already used in the module docstring of `Fricke/Operator.lean`. The round trip a two-sided
-inverse needs is then mathlib's `inv_inv` rather than a bespoke `chiConj_chiConj` lemma.
+already used in the module docstring of `Fricke/Operator.lean`.
+
+The round trip `χ⁻¹⁻¹ = χ` that a two-sided inverse needs is `inv_inv_monoidHom` below. That is
+mathlib's `inv_inv` mathematically, but `inv_inv` is stated for `InvolutiveInv` and does not match
+the `Inv (M →* G)` instance path syntactically, so it is proved pointwise instead, where the
+inversion happens in `ℂˣ`.
 
 ## Provenance
 
@@ -113,87 +117,87 @@ public theorem frickeOperatorCusp_mem_cuspFormCharSpace (k : ℤ) (χ : (ZMod N)
     using h.symm
 
 /-- **The Fricke operator restricted to a nebentypus space**, as a `ℂ`-linear map
-`M_k(Γ₁(N), χ) →ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)`. This is `frickeCharEquiv` without its inverse; it is
-`frickeOperator` on underlying forms (`frickeCharRestrict_coe`). -/
-public noncomputable def frickeCharRestrict (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
-    modFormCharSpace k χ →ₗ[ℂ] modFormCharSpace k χ⁻¹ where
-  toFun f := ⟨frickeOperator k (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k),
-    frickeOperator_mem_modFormCharSpace k χ f.property⟩
-  map_add' _ _ := Subtype.ext (map_add (frickeOperator k) _ _)
-  map_smul' c _ := Subtype.ext (map_smul (frickeOperator k) c _)
+`M_k(Γ₁(N), χ) →ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)`.
 
-/-- On underlying modular forms, `frickeCharRestrict` is `frickeOperator`. -/
-@[simp]
-public theorem frickeCharRestrict_coe (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
-    (f : modFormCharSpace k χ) :
-    ((frickeCharRestrict k χ f : modFormCharSpace k χ⁻¹) :
-        ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      frickeOperator k (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := (rfl)
+This is `frickeOperator` cut down by `LinearMap.restrict`, so mathlib's
+`LinearMap.coe_restrict_apply` is already the `simp` lemma identifying it with `frickeOperator`
+on underlying forms; no separate coercion lemma is stated here. -/
+public noncomputable def frickeCharRestrict (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
+    modFormCharSpace k χ →ₗ[ℂ] modFormCharSpace k χ⁻¹ :=
+  (frickeOperator k).restrict fun _ hf ↦ frickeOperator_mem_modFormCharSpace k χ hf
 
 /-- **The Fricke operator restricted to a nebentypus space of cusp forms**, as a `ℂ`-linear map
 `S_k(Γ₁(N), χ) →ₗ[ℂ] S_k(Γ₁(N), χ⁻¹)`. The cusp-form counterpart of `frickeCharRestrict`. -/
 public noncomputable def frickeCharCuspRestrict (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
-    cuspFormCharSpace k χ →ₗ[ℂ] cuspFormCharSpace k χ⁻¹ where
-  toFun f := ⟨frickeOperatorCusp k (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k),
-    frickeOperatorCusp_mem_cuspFormCharSpace k χ f.property⟩
-  map_add' _ _ := Subtype.ext (map_add (frickeOperatorCusp k) _ _)
-  map_smul' c _ := Subtype.ext (map_smul (frickeOperatorCusp k) c _)
-
-/-- On underlying cusp forms, `frickeCharCuspRestrict` is `frickeOperatorCusp`. -/
-@[simp]
-public theorem frickeCharCuspRestrict_coe (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
-    (f : cuspFormCharSpace k χ) :
-    ((frickeCharCuspRestrict k χ f : cuspFormCharSpace k χ⁻¹) :
-        CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
-      frickeOperatorCusp k (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := (rfl)
+    cuspFormCharSpace k χ →ₗ[ℂ] cuspFormCharSpace k χ⁻¹ :=
+  (frickeOperatorCusp k).restrict fun _ hf ↦ frickeOperatorCusp_mem_cuspFormCharSpace k χ hf
 
 /-- **The Fricke isomorphism between nebentypus spaces**
 `M_k(Γ₁(N), χ) ≃ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)`.
 
-The forward map is `frickeCharRestrict`; the inverse is `frickeScalar N k⁻¹ •` the Fricke
+The forward map is `frickeCharRestrict`; the inverse is `(frickeScalar N k)⁻¹ •` the Fricke
 operator again, which lands back in the `χ`-space because `χ⁻¹⁻¹ = χ`. Both round trips are
-`frickeOperator_frickeOperator_apply` followed by cancelling the nonzero
-`frickeScalar N k`. -/
+`frickeOperator_frickeOperator_apply` followed by cancelling the nonzero `frickeScalar N k`. -/
 public noncomputable def frickeCharEquiv (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
-    modFormCharSpace k χ ≃ₗ[ℂ] modFormCharSpace k χ⁻¹ where
-  toLinearMap := frickeCharRestrict k χ
-  invFun g := ⟨(frickeScalar N k)⁻¹ • frickeOperator k (g : ModularForm _ k), by
-    have h := frickeOperator_mem_modFormCharSpace k χ⁻¹ g.property
-    rw [inv_inv_monoidHom] at h
-    exact Submodule.smul_mem _ _ h⟩
-  left_inv f := by
-    apply Subtype.ext
-    change (frickeScalar N k)⁻¹ • frickeOperator k (frickeOperator k
-      (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) = (f : ModularForm _ k)
-    rw [frickeOperator_frickeOperator_apply, smul_smul,
-      inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k), one_smul]
-  right_inv g := by
-    apply Subtype.ext
-    change frickeOperator k ((frickeScalar N k)⁻¹ • frickeOperator k
-      (g : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) = (g : ModularForm _ k)
-    rw [map_smul, frickeOperator_frickeOperator_apply, smul_smul,
-      inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k), one_smul]
+    modFormCharSpace k χ ≃ₗ[ℂ] modFormCharSpace k χ⁻¹ :=
+  LinearEquiv.ofLinearMap (frickeCharRestrict k χ)
+    ((frickeScalar N k)⁻¹ • (frickeOperator k).restrict fun _ hf ↦ by
+      have h := frickeOperator_mem_modFormCharSpace k χ⁻¹ hf
+      rwa [inv_inv_monoidHom] at h)
+    (LinearMap.ext fun _ ↦ Subtype.ext (by
+      simp [frickeCharRestrict, smul_smul, inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]))
+    (LinearMap.ext fun _ ↦ Subtype.ext (by
+      simp [frickeCharRestrict, smul_smul, inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]))
+
+/-- On underlying modular forms, `frickeCharEquiv` is `frickeOperator`. -/
+@[simp]
+public theorem coe_frickeCharEquiv_apply (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (f : modFormCharSpace k χ) :
+    ((frickeCharEquiv k χ f : modFormCharSpace k χ⁻¹) :
+        ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      frickeOperator k (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := (rfl)
+
+/-- On underlying modular forms, the inverse of `frickeCharEquiv` is
+`(frickeScalar N k)⁻¹ • frickeOperator`. -/
+@[simp]
+public theorem coe_frickeCharEquiv_symm_apply (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (g : modFormCharSpace k χ⁻¹) :
+    (((frickeCharEquiv k χ).symm g : modFormCharSpace k χ) :
+        ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      (frickeScalar N k)⁻¹ • frickeOperator k (g : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  (rfl)
 
 /-- **The Fricke isomorphism between nebentypus spaces of cusp forms**
 `S_k(Γ₁(N), χ) ≃ₗ[ℂ] S_k(Γ₁(N), χ⁻¹)`. The cusp-form counterpart of `frickeCharEquiv`. -/
 public noncomputable def frickeCharCuspEquiv (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
-    cuspFormCharSpace k χ ≃ₗ[ℂ] cuspFormCharSpace k χ⁻¹ where
-  toLinearMap := frickeCharCuspRestrict k χ
-  invFun g := ⟨(frickeScalar N k)⁻¹ • frickeOperatorCusp k (g : CuspForm _ k), by
-    have h := frickeOperatorCusp_mem_cuspFormCharSpace k χ⁻¹ g.property
-    rw [inv_inv_monoidHom] at h
-    exact Submodule.smul_mem _ _ h⟩
-  left_inv f := by
-    apply Subtype.ext
-    change (frickeScalar N k)⁻¹ • frickeOperatorCusp k (frickeOperatorCusp k
-      (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) = (f : CuspForm _ k)
-    rw [frickeOperatorCusp_frickeOperatorCusp_apply, smul_smul,
-      inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k), one_smul]
-  right_inv g := by
-    apply Subtype.ext
-    change frickeOperatorCusp k ((frickeScalar N k)⁻¹ • frickeOperatorCusp k
-      (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) = (g : CuspForm _ k)
-    rw [map_smul, frickeOperatorCusp_frickeOperatorCusp_apply, smul_smul,
-      inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k), one_smul]
+    cuspFormCharSpace k χ ≃ₗ[ℂ] cuspFormCharSpace k χ⁻¹ :=
+  LinearEquiv.ofLinearMap (frickeCharCuspRestrict k χ)
+    ((frickeScalar N k)⁻¹ • (frickeOperatorCusp k).restrict fun _ hf ↦ by
+      have h := frickeOperatorCusp_mem_cuspFormCharSpace k χ⁻¹ hf
+      rwa [inv_inv_monoidHom] at h)
+    (LinearMap.ext fun _ ↦ Subtype.ext (by
+      simp [frickeCharCuspRestrict, smul_smul,
+        inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]))
+    (LinearMap.ext fun _ ↦ Subtype.ext (by
+      simp [frickeCharCuspRestrict, smul_smul,
+        inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k)]))
+
+/-- On underlying cusp forms, `frickeCharCuspEquiv` is `frickeOperatorCusp`. -/
+@[simp]
+public theorem coe_frickeCharCuspEquiv_apply (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (f : cuspFormCharSpace k χ) :
+    ((frickeCharCuspEquiv k χ f : cuspFormCharSpace k χ⁻¹) :
+        CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      frickeOperatorCusp k (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := (rfl)
+
+/-- On underlying cusp forms, the inverse of `frickeCharCuspEquiv` is
+`(frickeScalar N k)⁻¹ • frickeOperatorCusp`. -/
+@[simp]
+public theorem coe_frickeCharCuspEquiv_symm_apply (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (g : cuspFormCharSpace k χ⁻¹) :
+    (((frickeCharCuspEquiv k χ).symm g : cuspFormCharSpace k χ) :
+        CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      (frickeScalar N k)⁻¹ • frickeOperatorCusp k (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :=
+  (rfl)
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Fricke/CharacterSpace.lean
+++ b/TauCeti/NumberTheory/ModularForms/Fricke/CharacterSpace.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.Fricke.Involution
+
+/-!
+# The Fricke operator on nebentypus character spaces
+
+The Fricke operator `W_N` of `TauCeti/NumberTheory/ModularForms/Fricke/Operator.lean` shifts the
+diamond label by an inverse, `W_N ∘ ⟨d⟩ = ⟨d⁻¹⟩ ∘ W_N` (`frickeOperator_diamondOp`). Reading that
+on a joint eigenspace of the diamond operators turns it into a statement about nebentypus: `W_N`
+carries `M_k(Γ₁(N), χ)` into `M_k(Γ₁(N), χ⁻¹)`, and since `W_N ∘ W_N` is the nonzero scalar
+`frickeScalar N k` (`frickeOperator_frickeOperator_apply`), that transport is an isomorphism.
+
+## Main definitions
+
+* `TauCeti.frickeCharRestrict`, `TauCeti.frickeCharCuspRestrict`: `W_N` restricted to the
+  `χ`-nebentypus space, landing in the `χ⁻¹`-nebentypus space, on modular and on cusp forms.
+* `TauCeti.frickeCharEquiv`, `TauCeti.frickeCharCuspEquiv`: those restrictions bundled as linear
+  isomorphisms `M_k(Γ₁(N), χ) ≃ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)` and `S_k(Γ₁(N), χ) ≃ₗ[ℂ] S_k(Γ₁(N), χ⁻¹)`,
+  with inverse `frickeScalar N k⁻¹ • W_N`.
+
+## Main results
+
+* `TauCeti.frickeOperator_mem_modFormCharSpace`,
+  `TauCeti.frickeOperatorCusp_mem_cuspFormCharSpace`: the transport itself, `W_N` maps the
+  `χ`-nebentypus space into the `χ⁻¹`-nebentypus space.
+
+## The inverse character
+
+The target character is mathlib's `χ⁻¹`, the inverse in the commutative group `(ZMod N)ˣ →* ℂˣ`
+(`MonoidHom.instCommGroup`), for which `MonoidHom.inv_apply` gives `χ⁻¹ d = (χ d)⁻¹`. The source
+introduces a named `chiConj χ = χ.comp invMonoidHom` for this; that is the same monoid hom —
+`χ d⁻¹ = (χ d)⁻¹` is `map_inv` — so no definition is made here, matching the `χ⁻¹` spelling
+already used in the module docstring of `Fricke/Operator.lean`. The round trip a two-sided
+inverse needs is then mathlib's `inv_inv` rather than a bespoke `chiConj_chiConj` lemma.
+
+## Provenance
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GL2/Fricke.lean`](https://github.com/CBirkbeck/AINTLIB),
+commit `340875adfb2`, Apache-2.0, Chris Birkbeck), realizing part of Layer 6 of the ModularForms
+roadmap.
+
+Three changes from the source. Its `chiConj` is dropped in favour of mathlib's `χ⁻¹`, as above.
+Its `private frickeOperator_sq_apply` is dropped: `frickeOperator_frickeOperator_apply` of
+`Fricke/Involution.lean` is that statement, already public. And the cusp-form halves, which the
+source does not carry, are included here, since `cuspFormCharSpace` and
+`frickeOperatorCusp_diamondOpCusp` are both available and every other result in this Fricke
+development is stated on modular and on cusp forms alike.
+
+## References
+
+* [F. Diamond and J. Shurman, *A First Course in Modular Forms*][diamondshurman2005], §5.
+-/
+
+open Matrix Matrix.SpecialLinearGroup CongruenceSubgroup UpperHalfPlane
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+variable {N : ℕ} [NeZero N]
+
+omit [NeZero N] in
+/-- The character round trip `χ⁻¹⁻¹ = χ`, proved pointwise.
+
+This is mathlib's `inv_inv` mathematically, but that lemma is stated for `InvolutiveInv` and does
+not match the `Inv (M →* G)` instance path syntactically, so neither `rw` nor `simp` closes the
+goal with it. Proving it pointwise reduces to `inv_inv` in `ℂˣ`, which is a genuine group. -/
+private theorem inv_inv_monoidHom (χ : (ZMod N)ˣ →* ℂˣ) : χ⁻¹⁻¹ = χ := by
+  ext d
+  simp
+
+/-- **The Fricke operator shifts the nebentypus to its inverse**: it carries `M_k(Γ₁(N), χ)` into
+`M_k(Γ₁(N), χ⁻¹)`.
+
+On an `f` with `⟨d⟩ f = χ(d) • f`, the diamond-shift `frickeOperator_diamondOp` read at `d⁻¹`
+gives `⟨d⟩ (W f) = W (⟨d⁻¹⟩ f) = χ(d⁻¹) • (W f)`, and `χ(d⁻¹) = χ⁻¹(d)`. -/
+public theorem frickeOperator_mem_modFormCharSpace (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ modFormCharSpace k χ) :
+    frickeOperator k f ∈ modFormCharSpace k χ⁻¹ := by
+  rw [mem_modFormCharSpace_iff]
+  intro d
+  -- `diamondOpHom` is not `@[expose]`d, so it is not interchangeable with `diamondOp` by
+  -- definitional unfolding; `diamondOpHom_apply` is the bridge.
+  have hd : diamondOpHom k d⁻¹ f = ((χ d⁻¹ : ℂˣ) : ℂ) • f :=
+    (mem_modFormCharSpace_iff k χ f).mp hf d⁻¹
+  rw [diamondOpHom_apply] at hd
+  have h := LinearMap.congr_fun (frickeOperator_diamondOp (N := N) k d⁻¹) f
+  rw [LinearMap.comp_apply, LinearMap.comp_apply, inv_inv, hd, map_smul] at h
+  simpa only [diamondOpHom_apply, MonoidHom.inv_apply, map_inv, Units.val_inv_eq_inv_val]
+    using h.symm
+
+/-- **The Fricke operator shifts the nebentypus to its inverse, on cusp forms**: it carries
+`S_k(Γ₁(N), χ)` into `S_k(Γ₁(N), χ⁻¹)`. The cusp-form counterpart of
+`frickeOperator_mem_modFormCharSpace`, from the cusp-form diamond-shift. -/
+public theorem frickeOperatorCusp_mem_cuspFormCharSpace (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k} (hf : f ∈ cuspFormCharSpace k χ) :
+    frickeOperatorCusp k f ∈ cuspFormCharSpace k χ⁻¹ := by
+  rw [mem_cuspFormCharSpace_iff]
+  intro d
+  have hd : diamondOpCuspHom k d⁻¹ f = ((χ d⁻¹ : ℂˣ) : ℂ) • f :=
+    (mem_cuspFormCharSpace_iff k χ f).mp hf d⁻¹
+  rw [diamondOpCuspHom_apply] at hd
+  have h := LinearMap.congr_fun (frickeOperatorCusp_diamondOpCusp (N := N) k d⁻¹) f
+  rw [LinearMap.comp_apply, LinearMap.comp_apply, inv_inv, hd, map_smul] at h
+  simpa only [diamondOpCuspHom_apply, MonoidHom.inv_apply, map_inv, Units.val_inv_eq_inv_val]
+    using h.symm
+
+/-- **The Fricke operator restricted to a nebentypus space**, as a `ℂ`-linear map
+`M_k(Γ₁(N), χ) →ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)`. This is `frickeCharEquiv` without its inverse; it is
+`frickeOperator` on underlying forms (`frickeCharRestrict_coe`). -/
+public noncomputable def frickeCharRestrict (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
+    modFormCharSpace k χ →ₗ[ℂ] modFormCharSpace k χ⁻¹ where
+  toFun f := ⟨frickeOperator k (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k),
+    frickeOperator_mem_modFormCharSpace k χ f.property⟩
+  map_add' _ _ := Subtype.ext (map_add (frickeOperator k) _ _)
+  map_smul' c _ := Subtype.ext (map_smul (frickeOperator k) c _)
+
+/-- On underlying modular forms, `frickeCharRestrict` is `frickeOperator`. -/
+@[simp]
+public theorem frickeCharRestrict_coe (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (f : modFormCharSpace k χ) :
+    ((frickeCharRestrict k χ f : modFormCharSpace k χ⁻¹) :
+        ModularForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      frickeOperator k (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) := (rfl)
+
+/-- **The Fricke operator restricted to a nebentypus space of cusp forms**, as a `ℂ`-linear map
+`S_k(Γ₁(N), χ) →ₗ[ℂ] S_k(Γ₁(N), χ⁻¹)`. The cusp-form counterpart of `frickeCharRestrict`. -/
+public noncomputable def frickeCharCuspRestrict (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
+    cuspFormCharSpace k χ →ₗ[ℂ] cuspFormCharSpace k χ⁻¹ where
+  toFun f := ⟨frickeOperatorCusp k (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k),
+    frickeOperatorCusp_mem_cuspFormCharSpace k χ f.property⟩
+  map_add' _ _ := Subtype.ext (map_add (frickeOperatorCusp k) _ _)
+  map_smul' c _ := Subtype.ext (map_smul (frickeOperatorCusp k) c _)
+
+/-- On underlying cusp forms, `frickeCharCuspRestrict` is `frickeOperatorCusp`. -/
+@[simp]
+public theorem frickeCharCuspRestrict_coe (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ)
+    (f : cuspFormCharSpace k χ) :
+    ((frickeCharCuspRestrict k χ f : cuspFormCharSpace k χ⁻¹) :
+        CuspForm ((Gamma1 N).map (mapGL ℝ)) k) =
+      frickeOperatorCusp k (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) := (rfl)
+
+/-- **The Fricke isomorphism between nebentypus spaces**
+`M_k(Γ₁(N), χ) ≃ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)`.
+
+The forward map is `frickeCharRestrict`; the inverse is `frickeScalar N k⁻¹ •` the Fricke
+operator again, which lands back in the `χ`-space because `χ⁻¹⁻¹ = χ`. Both round trips are
+`frickeOperator_frickeOperator_apply` followed by cancelling the nonzero
+`frickeScalar N k`. -/
+public noncomputable def frickeCharEquiv (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
+    modFormCharSpace k χ ≃ₗ[ℂ] modFormCharSpace k χ⁻¹ where
+  toLinearMap := frickeCharRestrict k χ
+  invFun g := ⟨(frickeScalar N k)⁻¹ • frickeOperator k (g : ModularForm _ k), by
+    have h := frickeOperator_mem_modFormCharSpace k χ⁻¹ g.property
+    rw [inv_inv_monoidHom] at h
+    exact Submodule.smul_mem _ _ h⟩
+  left_inv f := by
+    apply Subtype.ext
+    change (frickeScalar N k)⁻¹ • frickeOperator k (frickeOperator k
+      (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) = (f : ModularForm _ k)
+    rw [frickeOperator_frickeOperator_apply, smul_smul,
+      inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k), one_smul]
+  right_inv g := by
+    apply Subtype.ext
+    change frickeOperator k ((frickeScalar N k)⁻¹ • frickeOperator k
+      (g : ModularForm ((Gamma1 N).map (mapGL ℝ)) k)) = (g : ModularForm _ k)
+    rw [map_smul, frickeOperator_frickeOperator_apply, smul_smul,
+      inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k), one_smul]
+
+/-- **The Fricke isomorphism between nebentypus spaces of cusp forms**
+`S_k(Γ₁(N), χ) ≃ₗ[ℂ] S_k(Γ₁(N), χ⁻¹)`. The cusp-form counterpart of `frickeCharEquiv`. -/
+public noncomputable def frickeCharCuspEquiv (k : ℤ) (χ : (ZMod N)ˣ →* ℂˣ) :
+    cuspFormCharSpace k χ ≃ₗ[ℂ] cuspFormCharSpace k χ⁻¹ where
+  toLinearMap := frickeCharCuspRestrict k χ
+  invFun g := ⟨(frickeScalar N k)⁻¹ • frickeOperatorCusp k (g : CuspForm _ k), by
+    have h := frickeOperatorCusp_mem_cuspFormCharSpace k χ⁻¹ g.property
+    rw [inv_inv_monoidHom] at h
+    exact Submodule.smul_mem _ _ h⟩
+  left_inv f := by
+    apply Subtype.ext
+    change (frickeScalar N k)⁻¹ • frickeOperatorCusp k (frickeOperatorCusp k
+      (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) = (f : CuspForm _ k)
+    rw [frickeOperatorCusp_frickeOperatorCusp_apply, smul_smul,
+      inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k), one_smul]
+  right_inv g := by
+    apply Subtype.ext
+    change frickeOperatorCusp k ((frickeScalar N k)⁻¹ • frickeOperatorCusp k
+      (g : CuspForm ((Gamma1 N).map (mapGL ℝ)) k)) = (g : CuspForm _ k)
+    rw [map_smul, frickeOperatorCusp_frickeOperatorCusp_apply, smul_smul,
+      inv_mul_cancel₀ (frickeScalar_ne_zero (N := N) k), one_smul]
+
+end TauCeti


### PR DESCRIPTION
The Fricke operator shifts the nebentypus character to its inverse, and because `W_N ∘ W_N` is a
nonzero scalar that shift is an isomorphism. This adds
`TauCeti/NumberTheory/ModularForms/Fricke/CharacterSpace.lean`:

* `frickeOperator_mem_modFormCharSpace`, `frickeOperatorCusp_mem_cuspFormCharSpace` — `W_N`
  carries `M_k(Γ₁(N), χ)` into `M_k(Γ₁(N), χ⁻¹)`, and the same on cusp forms.
* `frickeCharRestrict`, `frickeCharCuspRestrict` — that transport as a `ℂ`-linear map, with
  `@[simp]` coercion lemmas identifying it with `frickeOperator` on underlying forms.
* `frickeCharEquiv`, `frickeCharCuspEquiv` — bundled as linear isomorphisms
  `M_k(Γ₁(N), χ) ≃ₗ[ℂ] M_k(Γ₁(N), χ⁻¹)` and `S_k(Γ₁(N), χ) ≃ₗ[ℂ] S_k(Γ₁(N), χ⁻¹)`, with inverse
  `frickeScalar N k⁻¹ • W_N`.

This is the "character-space transport" that two modules already on `main` name as future work:
`Fricke/Operator.lean` defers the diamond-shift to "that definition and the character-space
transport", and `Fricke/Involution.lean` describes `slash_mul_frickeGL` as "the form the
character-space transport will consume".

## Roadmap target

`TauCetiRoadmap/ModularForms/README.md`, node **`### Layer 6: Atkin–Lehner and Fricke
operators`**, third bullet, which names these declarations outright:

> AINTLIB provides the Fricke side to migrate — `frickeOperator`/`frickeOperatorCusp`, the
> normalizing `frickeScalar`, and the character-space transport `frickeCharRestrict`/
> `frickeCharEquiv` (`HeckeRIngs/GL2/Fricke.lean`) […]

The same pairing is repeated in the migration inventory (**Fricke (L6)**). This PR is the
`frickeCharRestrict`/`frickeCharEquiv` half of that bullet; `frickeOperator`,
`frickeOperatorCusp` and `frickeScalar` landed in #4455 and #4484.

Two things the node says that this PR deliberately does *not* do, so they are not read as
omissions. The general `W_Q` family for exact divisors `Q ‖ N` and the sign theory on newforms
are marked **new** there rather than migrated, and are out of scope here. And the node specifies
the *normalized* operator `𝒲_N = (√N)^{2−k}·(· ∣[k] W)`; `main`'s `frickeOperator` is
deliberately the raw slash, carrying no normalizing scalar (its own docstring says so), which is
a decision already taken in #4455. Nothing here depends on which of the two is used: the raw and
normalized operators differ by a nonzero scalar, and a character space is a submodule, so
membership, the restriction and the isomorphism are the same statements either way.

## The target character is mathlib's `χ⁻¹`, not a new definition

The source defines `chiConj χ := χ.comp invMonoidHom` for the target character. That is not
ported, and no replacement is defined: `(ZMod N)ˣ →* ℂˣ` is a `CommGroup`
(`MonoidHom.instCommGroup`), so `χ⁻¹` already exists, and it is the same monoid hom —
`MonoidHom.inv_apply` gives `χ⁻¹ d = (χ d)⁻¹` and `map_inv` gives `χ d⁻¹ = (χ d)⁻¹`.

The roadmap node describes the target character as the *conjugate* (`χ̄_Q·χ_{N/Q}`), and the
source calls its definition the "inverse-conjugate character". These agree here and the inverse
is the better formulation: `(ZMod N)ˣ` is finite, so every value of `χ` is a root of unity and
`χ̄ = χ⁻¹` — but `χ⁻¹` is the one that needs no appeal to unitarity to state or to use.

Three reasons beyond "it exists":

1. **`main` has already chosen this spelling.** `Fricke/Operator.lean` states, in prose, that `W`
   carries `M_k(Γ₁(N), χ)` into `M_k(Γ₁(N), χ⁻¹)`. A `chiConj` definition would contradict the
   docstring of the module it builds on.
2. **A named wrapper for a mathlib composite with no outside consumers is a known blocker on this
   repo** — it is what the `reuse` rubric found on #4822, and the same call was made against
   adding `Gamma0MapUnits` for this development.
3. **It makes the mathematics shorter.** The two-sided inverse needs `χ⁻¹⁻¹ = χ`; with `χ⁻¹` that
   is mathlib's `inv_inv`, where `chiConj` would need its own round-trip lemma.

## Source window, and what is deliberately not ported

AINTLIB `LeanModularForms/HeckeRIngs/GL2/Fricke.lean` at `340875adfb2`, lines 442–507 (to the
closing `end HeckeRing.GL2`). Every declaration in that window, including `private` ones:

| source | line | disposition |
|---|---|---|
| `chiConj` | 442 | dropped — is `χ⁻¹`, see above |
| `chiConj_apply` | 447 | dropped — is `MonoidHom.inv_apply` / `map_inv` |
| `frickeOperator_mem_charSpace` | 451 | ported as `frickeOperator_mem_modFormCharSpace` |
| `frickeCharRestrict` | 464 | ported |
| `frickeCharRestrict_coe` | 472 | ported |
| `frickeOperator_sq_apply` | 479 | dropped — is `frickeOperator_frickeOperator_apply`, already public in `Fricke/Involution.lean` |
| `frickeCharEquiv` | 487 | ported |

Renamed to match `main`'s spelling: the character spaces here are `modFormCharSpace` and
`cuspFormCharSpace`, so the membership theorem names the space it is about rather than the
source's generic `charSpace`.

## Beyond the source: the cusp-form halves

The source carries only the modular-form statements. The cusp-form halves are added here because
`cuspFormCharSpace` is on `main`, the cusp diamond-shift `frickeOperatorCusp_diamondOpCusp` is
available, and every other result in this Fricke development ships both halves
(`frickeOperatorEquiv`/`frickeOperatorCuspEquiv`,
`frickeOperator_frickeOperator`/`frickeOperatorCusp_frickeOperatorCusp`). Shipping only the
modular half would leave a gap that the rest of the file layout does not have.

## Naming and statement shape follow `main`'s existing family

These are not new conventions. `main` already carries the same shape — an operator, the space it
maps into, implicit `{f}` with an explicit membership hypothesis:

* `heckeTNat_mem_modFormCharSpace_of_primeFactors_subset` /
  `heckeTCuspNat_mem_cuspFormCharSpace_of_primeFactors_subset` (`HeckeSlash/LevelSupported.lean`)
* `ModularForm.levelRaise_mem_modFormCharSpace_of_dvd`, `ModularForm.ofLe_mem_modFormCharSpace`,
  `CuspForm.ofLe_mem_cuspFormCharSpace` (`Degeneracy.lean`)

The `levelRaise` and `ofLe` lemmas also *change the character* in the conclusion, and they write
the new one as an inline composite — `χ.comp (ZMod.unitsMap h)` — rather than giving it a name.
That is the same call made here for `χ⁻¹`, which is shorter still. Neither of my membership
theorems takes an `_of_` suffix, since neither has a hypothesis beyond membership.

## Placement

A new file rather than an addition to `Fricke/Operator.lean` or `Fricke/Involution.lean`: it is a
distinct topic — nebentypus transport rather than the operator or its involution — and it is the
topic both of those modules name when they defer this work. It imports `Fricke/Involution.lean`,
which is what supplies the nonzero scalar making the transport invertible.

## Three places the module system, not the mathematics, shaped the proof

Flagging these because each looks like a worse choice than an available alternative, and in each
case the alternative was tried first and does not compile here.

1. **`private inv_inv_monoidHom : χ⁻¹⁻¹ = χ` is not a duplicate of mathlib's `inv_inv`.**
   `inv_inv` is stated for `InvolutiveInv`, and does not match the `Inv (M →* G)` instance path
   syntactically — neither `rw [inv_inv]` nor `simp only [inv_inv]` closes the goal (the former
   reports "did not find an occurrence of the pattern `?a⁻¹⁻¹`" against a target that visibly
   contains `χ⁻¹⁻¹`). Proved pointwise it reduces to `inv_inv` in `ℂˣ`, a genuine group, in two
   lines. If there is a spelling that makes mathlib's lemma fire directly, I would rather use it.
2. **`diamondOpHom_apply` is needed as an explicit bridge.** `diamondOp` and `diamondOpHom` are
   not interchangeable by unfolding here, because neither definition is exposed — stating the
   eigenvalue hypothesis over `diamondOp` fails with a type mismatch that names both as
   unexposed.
3. **The character equation is rewritten at the hypothesis, not transported with `▸`.** The
   substitution's motive fails to compute, because the character also occurs in the type of the
   element being transported.

## Linters: what was and was not run

`scripts/lint-env.sh` was **not** run locally — it needs a full library build, which this lane
does not do on developer machines. CI's `pr-build` runs it. I am not substituting a
`lake exe runLinter` result for it: there is no such target in `lakefile.toml` (it resolves only
via Batteries), and under the module system it misreads this library — `docStringExt` has
`exported := #[]`, so imported declarations appear undocumented, and theorems whose proofs sit in
non-`@[expose]`d oleans surface as axioms. Pointing it at an explicit module does not avoid that.

So, the exposure of this diff argued by construction. It adds **one new file and modifies no
existing one** (183 insertions, 0 deletions), which bounds most of the set:

* **simpNF — live.** Two `@[simp]` lemmas are added, `frickeCharRestrict_coe` and
  `frickeCharCuspRestrict_coe`. Both are `rfl`, and both have an LHS headed by the submodule
  coercion of a definition introduced in this same file, so no pre-existing simp lemma can
  rewrite them — the symbol did not exist before. Their RHS is `frickeOperator k ↑f` as a
  *form*, not its function coercion, so main's `@[simp] coe_frickeOperator` (which fires on
  `⇑(frickeOperator k f)`) does not overlap. What I cannot check locally is simpNF's own
  "LHS already simplifies" condition; if CI flags either lemma the fix is to drop the attribute,
  and I will do that rather than restate the lemma.
* **unusedArguments — live**, for the eight new signatures. `k` and `χ` occur in every statement;
  `N` occurs in every type and `[NeZero N]` is required by `modFormCharSpace` and `frickeOperator`
  themselves, so neither section binder is inert.
* **docBlame — not the operative instrument** (`lint-env.sh` excludes it and substitutes a direct
  scan), but all 8 declarations carry docstrings.
* **File-length and style** — 183 lines against the 1000-line new-file guard; no line exceeds 100
  *codepoints* (measured by codepoint, since this file is Unicode-dense and a byte-based check
  reports phantom violations here).
* Rubrics that judge *modified* declarations do not apply: nothing existing is touched.

Roadmap: ModularForms
