### PR TITLE
feat: add symmetric algebra functoriality

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
@@ -91,7 +91,7 @@ private noncomputable def symmetricAlgebraBialgEquiv {P N : Type*}
               (SymmetricAlgebra.mapEquiv K e (SymmetricAlgebra.ι K P m)) =
             (Bialgebra.counitAlgHom K (SymmetricAlgebra K P))
               (SymmetricAlgebra.ι K P m) := by
-        rw [SymmetricAlgebra.mapEquiv_ι]
+        rw [SymmetricAlgebra.mapEquiv_apply, SymmetricAlgebra.map_ι]
         exact (SymmetricAlgebra.algebraMapInv_ι _).trans
           (SymmetricAlgebra.algebraMapInv_ι _).symm
       exact h)
@@ -107,7 +107,12 @@ private theorem symmetricAlgebraBialgEquiv_ι {P N : Type*}
     (e : P ≃ₗ[K] N) (p : P) :
     symmetricAlgebraBialgEquiv (K := K) e (SymmetricAlgebra.ι K P p) =
       SymmetricAlgebra.ι K N (e p) :=
-  SymmetricAlgebra.mapEquiv_ι K e p
+  by
+    rw [symmetricAlgebraBialgEquiv, BialgEquiv.ofAlgEquiv_apply]
+    -- The bialgebra wrapper exposes the algebra equivalence through its `toFun` field.
+    change SymmetricAlgebra.mapEquiv K e (SymmetricAlgebra.ι K P p) = _
+    rw [SymmetricAlgebra.mapEquiv_apply, SymmetricAlgebra.map_ι]
+    rfl
 
 @[simp]
 private theorem symmetricAlgebraBialgEquiv_symm_ι {P N : Type*}
@@ -116,10 +121,11 @@ private theorem symmetricAlgebraBialgEquiv_symm_ι {P N : Type*}
     (symmetricAlgebraBialgEquiv (K := K) e).symm (SymmetricAlgebra.ι K N n) =
     SymmetricAlgebra.ι K P (e.symm n) :=
   by
-    -- `BialgEquiv.ofAlgEquiv` keeps the underlying inverse algebra equivalence definitionally.
-    -- Expose that wrapper before using the generator equation for `mapEquiv.symm`.
-    change (SymmetricAlgebra.mapEquiv K e).symm (SymmetricAlgebra.ι K N n) = _
-    simp
+    have h :
+        symmetricAlgebraBialgEquiv (K := K) e
+            (SymmetricAlgebra.ι K P (e.symm n)) = SymmetricAlgebra.ι K N n := by
+      rw [symmetricAlgebraBialgEquiv_ι, LinearEquiv.apply_symm_apply]
+    rw [← h, BialgEquiv.symm_apply_apply]
 
 section GaCoordinateBialgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.AdditiveGroup.Basic
 public import TauCeti.Algebra.AlgebraicGroup.BaseChange.Basic
 public import TauCeti.Algebra.Bialgebra.SymmetricAlgebra.BaseChange
+import TauCeti.LinearAlgebra.SymmetricAlgebra.Functoriality
 
 /-!
 # Base change of additive groups
@@ -76,55 +77,21 @@ variable [AddCommMonoid M] [Module k M]
 
 section CoordinateBialgebra
 
-/-- The algebra equivalence on symmetric algebras induced by a linear equivalence. -/
-private noncomputable def symmetricAlgebraAlgEquiv {P N : Type*}
-    [AddCommMonoid P] [Module K P] [AddCommMonoid N] [Module K N]
-    (e : P ≃ₗ[K] N) : SymmetricAlgebra K P ≃ₐ[K] SymmetricAlgebra K N :=
-  AlgEquiv.ofAlgHom
-    (SymmetricAlgebra.lift (SymmetricAlgebra.ι K N ∘ₗ e.toLinearMap))
-    (SymmetricAlgebra.lift (SymmetricAlgebra.ι K P ∘ₗ e.symm.toLinearMap))
-    (by
-      apply SymmetricAlgebra.algHom_ext
-      apply LinearMap.ext
-      intro n
-      simp [LinearMap.comp_apply])
-    (by
-      apply SymmetricAlgebra.algHom_ext
-      apply LinearMap.ext
-      intro m
-      simp [LinearMap.comp_apply])
-
-@[simp]
-private theorem symmetricAlgebraAlgEquiv_ι {P N : Type*}
-    [AddCommMonoid P] [Module K P] [AddCommMonoid N] [Module K N]
-    (e : P ≃ₗ[K] N) (p : P) :
-    symmetricAlgebraAlgEquiv (K := K) e (SymmetricAlgebra.ι K P p) =
-      SymmetricAlgebra.ι K N (e p) := by
-  simp [symmetricAlgebraAlgEquiv, LinearMap.comp_apply]
-
-@[simp]
-private theorem symmetricAlgebraAlgEquiv_symm_ι {P N : Type*}
-    [AddCommMonoid P] [Module K P] [AddCommMonoid N] [Module K N]
-    (e : P ≃ₗ[K] N) (n : N) :
-    (symmetricAlgebraAlgEquiv (K := K) e).symm (SymmetricAlgebra.ι K N n) =
-      SymmetricAlgebra.ι K P (e.symm n) := by
-  simp [symmetricAlgebraAlgEquiv, LinearMap.comp_apply]
-
 /-- The bialgebra equivalence on symmetric algebras induced by a linear equivalence. -/
 private noncomputable def symmetricAlgebraBialgEquiv {P N : Type*}
     [AddCommMonoid P] [Module K P] [AddCommMonoid N] [Module K N] (e : P ≃ₗ[K] N) :
     SymmetricAlgebra K P ≃ₐc[K] SymmetricAlgebra K N :=
-  BialgEquiv.ofAlgEquiv (symmetricAlgebraAlgEquiv (K := K) e)
+  BialgEquiv.ofAlgEquiv (SymmetricAlgebra.mapEquiv K e)
     (by
       apply SymmetricAlgebra.algHom_ext
       apply LinearMap.ext
       intro m
       have h :
           (Bialgebra.counitAlgHom K (SymmetricAlgebra K N))
-              (symmetricAlgebraAlgEquiv (K := K) e (SymmetricAlgebra.ι K P m)) =
+              (SymmetricAlgebra.mapEquiv K e (SymmetricAlgebra.ι K P m)) =
             (Bialgebra.counitAlgHom K (SymmetricAlgebra K P))
               (SymmetricAlgebra.ι K P m) := by
-        rw [symmetricAlgebraAlgEquiv_ι]
+        rw [SymmetricAlgebra.mapEquiv_ι]
         exact (SymmetricAlgebra.algebraMapInv_ι _).trans
           (SymmetricAlgebra.algebraMapInv_ι _).symm
       exact h)
@@ -132,7 +99,7 @@ private noncomputable def symmetricAlgebraBialgEquiv {P N : Type*}
       apply SymmetricAlgebra.algHom_ext
       apply LinearMap.ext
       intro m
-      simp [symmetricAlgebraAlgEquiv, LinearMap.comp_apply, SymmetricAlgebra.comul_ι])
+      simp [SymmetricAlgebra.comul_ι])
 
 @[simp]
 private theorem symmetricAlgebraBialgEquiv_ι {P N : Type*}
@@ -140,15 +107,17 @@ private theorem symmetricAlgebraBialgEquiv_ι {P N : Type*}
     (e : P ≃ₗ[K] N) (p : P) :
     symmetricAlgebraBialgEquiv (K := K) e (SymmetricAlgebra.ι K P p) =
       SymmetricAlgebra.ι K N (e p) :=
-  symmetricAlgebraAlgEquiv_ι (K := K) e p
+  SymmetricAlgebra.mapEquiv_ι K e p
 
 @[simp]
 private theorem symmetricAlgebraBialgEquiv_symm_ι {P N : Type*}
     [AddCommMonoid P] [Module K P] [AddCommMonoid N] [Module K N]
     (e : P ≃ₗ[K] N) (n : N) :
     (symmetricAlgebraBialgEquiv (K := K) e).symm (SymmetricAlgebra.ι K N n) =
-      SymmetricAlgebra.ι K P (e.symm n) :=
-  symmetricAlgebraAlgEquiv_symm_ι (K := K) e n
+    SymmetricAlgebra.ι K P (e.symm n) :=
+  by
+    change (SymmetricAlgebra.mapEquiv K e).symm (SymmetricAlgebra.ι K N n) = _
+    simp
 
 section GaCoordinateBialgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
@@ -91,7 +91,7 @@ private noncomputable def symmetricAlgebraBialgEquiv {P N : Type*}
               (SymmetricAlgebra.mapEquiv K e (SymmetricAlgebra.ι K P m)) =
             (Bialgebra.counitAlgHom K (SymmetricAlgebra K P))
               (SymmetricAlgebra.ι K P m) := by
-        rw [SymmetricAlgebra.mapEquiv_apply, SymmetricAlgebra.map_ι]
+        rw [SymmetricAlgebra.mapEquiv_apply, SymmetricAlgebra.map_apply_ι]
         exact (SymmetricAlgebra.algebraMapInv_ι _).trans
           (SymmetricAlgebra.algebraMapInv_ι _).symm
       exact h)
@@ -111,8 +111,8 @@ private theorem symmetricAlgebraBialgEquiv_ι {P N : Type*}
     rw [symmetricAlgebraBialgEquiv, BialgEquiv.ofAlgEquiv_apply]
     -- The bialgebra wrapper exposes the algebra equivalence through its `toFun` field.
     change SymmetricAlgebra.mapEquiv K e (SymmetricAlgebra.ι K P p) = _
-    rw [SymmetricAlgebra.mapEquiv_apply, SymmetricAlgebra.map_ι]
-    rfl
+    rw [SymmetricAlgebra.mapEquiv_apply, SymmetricAlgebra.map_apply_ι]
+    simp only [LinearEquiv.coe_coe]
 
 @[simp]
 private theorem symmetricAlgebraBialgEquiv_symm_ι {P N : Type*}

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
@@ -91,6 +91,7 @@ private noncomputable def symmetricAlgebraBialgEquiv {P N : Type*}
               (SymmetricAlgebra.mapEquiv K e (SymmetricAlgebra.ι K P m)) =
             (Bialgebra.counitAlgHom K (SymmetricAlgebra K P))
               (SymmetricAlgebra.ι K P m) := by
+        rw [SymmetricAlgebra.counitAlgHom_eq]
         rw [SymmetricAlgebra.mapEquiv_apply, SymmetricAlgebra.map_apply_ι]
         exact (SymmetricAlgebra.algebraMapInv_ι _).trans
           (SymmetricAlgebra.algebraMapInv_ι _).symm
@@ -109,10 +110,7 @@ private theorem symmetricAlgebraBialgEquiv_ι {P N : Type*}
       SymmetricAlgebra.ι K N (e p) :=
   by
     rw [symmetricAlgebraBialgEquiv, BialgEquiv.ofAlgEquiv_apply]
-    -- The bialgebra wrapper exposes the algebra equivalence through its `toFun` field.
-    change SymmetricAlgebra.mapEquiv K e (SymmetricAlgebra.ι K P p) = _
-    rw [SymmetricAlgebra.mapEquiv_apply, SymmetricAlgebra.map_apply_ι]
-    simp only [LinearEquiv.coe_coe]
+    exact SymmetricAlgebra.mapEquiv_ι K e p
 
 @[simp]
 private theorem symmetricAlgebraBialgEquiv_symm_ι {P N : Type*}

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/BaseChange.lean
@@ -116,6 +116,8 @@ private theorem symmetricAlgebraBialgEquiv_symm_ι {P N : Type*}
     (symmetricAlgebraBialgEquiv (K := K) e).symm (SymmetricAlgebra.ι K N n) =
     SymmetricAlgebra.ι K P (e.symm n) :=
   by
+    -- `BialgEquiv.ofAlgEquiv` keeps the underlying inverse algebra equivalence definitionally.
+    -- Expose that wrapper before using the generator equation for `mapEquiv.symm`.
     change (SymmetricAlgebra.mapEquiv K e).symm (SymmetricAlgebra.ι K N n) = _
     simp
 

--- a/TauCeti/Algebra/Bialgebra/SymmetricAlgebra/BaseChange.lean
+++ b/TauCeti/Algebra/Bialgebra/SymmetricAlgebra/BaseChange.lean
@@ -154,6 +154,7 @@ private theorem scalarTensorAlgEquiv_counit_tmul_ι (m : M) :
       (Bialgebra.counitAlgHom K (K ⊗[k] _root_.SymmetricAlgebra k M))
         (1 ⊗ₜ[k] _root_.SymmetricAlgebra.ι k M m) := by
   rw [scalarTensorAlgEquiv_tmul_ι]
+  rw [_root_.SymmetricAlgebra.counitAlgHom_eq]
   simpa using _root_.SymmetricAlgebra.algebraMapInv_ι
     (R := K) (M := K ⊗[k] M) (1 ⊗ₜ[k] m)
 

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -31,6 +31,7 @@ Tau Ceti formalization in `TauCeti/Algebra/Lie/UniversalEnveloping/Functoriality
 ## Main results
 
 * `SymmetricAlgebra.map_apply_ι`: evaluation of the induced map on a canonical generator.
+* `SymmetricAlgebra.map_unique`: characterization of the induced map by its generators.
 * `SymmetricAlgebra.map_id` and `SymmetricAlgebra.map_comp_map`: functoriality laws.
 * `SymmetricAlgebra.map_injective_of_leftInverse` and `SymmetricAlgebra.map_surjective`:
   transport of split monomorphisms and of surjections.
@@ -64,6 +65,18 @@ noncomputable def map (f : M →ₗ[R] N) :
 theorem map_apply_ι (f : M →ₗ[R] N) (a : M) :
     map R f (ι R M a) = ι R N (f a) := by
   simp [map]
+
+/-- The universal property characterizes the induced map by its values on generators. -/
+theorem map_unique (f : M →ₗ[R] N) (g : SymmetricAlgebra R M →ₐ[R] SymmetricAlgebra R N) :
+    (∀ a, g (ι R M a) = ι R N (f a)) ↔ g = map R f := by
+  constructor
+  · intro h
+    apply algHom_ext
+    ext a
+    change g (ι R M a) = map R f (ι R M a)
+    rw [h, map_apply_ι]
+  · intro h a
+    rw [h, map_apply_ι]
 
 /-- The identity linear map induces the identity algebra homomorphism. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -105,7 +105,7 @@ theorem map_leftInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
   have hmaps : (map R g).comp (map R f) = AlgHom.id R (SymmetricAlgebra R M) := by
     have hgf : g.comp f = LinearMap.id := LinearMap.ext fun x => h x
     rw [map_comp_map, hgf, map_id]
-  exact AlgHom.congr_fun hmaps a
+  simpa only [AlgHom.comp_apply, AlgHom.id_apply] using AlgHom.congr_fun hmaps a
 
 /-- A right inverse of linear maps induces a right inverse of the corresponding symmetric-algebra
 maps. -/

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -20,6 +20,9 @@ functoriality APIs (`Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean` and
 `Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean`); `map_surjective` adapts the corresponding
 Clifford-algebra induction.
 
+The declaration order, API naming, and proof organization also adapt the prior
+Tau Ceti formalization in `TauCeti/Algebra/Lie/UniversalEnveloping/Functoriality.lean`.
+
 ## Main definitions
 
 * `SymmetricAlgebra.map`: the algebra homomorphism induced by a linear map.

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -111,12 +111,8 @@ theorem map_leftInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
 /-- A right inverse of linear maps induces a right inverse of the corresponding symmetric-algebra
 maps. -/
 theorem map_rightInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
-    (h : Function.RightInverse g f) : Function.RightInverse (map R g) (map R f) := by
-  intro a
-  have hmaps : (map R f).comp (map R g) = AlgHom.id R (SymmetricAlgebra R N) := by
-    have hfg : f.comp g = LinearMap.id := LinearMap.ext fun x => h x
-    rw [map_comp_map, hfg, map_id]
-  exact AlgHom.congr_fun hmaps a
+    (h : Function.RightInverse g f) : Function.RightInverse (map R g) (map R f) :=
+  map_leftInverse R (f := g) (g := f) h.leftInverse
 
 /-- A split monomorphism induces an injective map of symmetric algebras. -/
 theorem map_injective_of_leftInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -175,11 +175,8 @@ theorem mapEquiv_symm (e : M ≃ₗ[R] N) :
     (mapEquiv R e).symm = mapEquiv R e.symm := by
   apply AlgEquiv.ext
   intro a
-  apply (mapEquiv R e).injective
-  rw [(mapEquiv R e).apply_symm_apply, mapEquiv_apply (e := e.symm),
-    mapEquiv_apply (e := e)]
-  rw [← AlgHom.comp_apply, map_comp_map, e.comp_symm, map_id]
-  simp only [AlgHom.id_apply]
+  rw [mapEquiv, AlgEquiv.ofAlgHom_symm]
+  simp only [AlgEquiv.ofAlgHom_apply, mapEquiv, LinearEquiv.symm_symm]
 
 /-- The identity linear equivalence induces the identity algebra equivalence. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.SymmetricAlgebra.Basic
+
+/-!
+# Functoriality of symmetric algebras
+
+A linear map induces an algebra homomorphism between symmetric algebras. This file constructs the
+map from the universal property, proves its identity and composition laws, and packages linear
+equivalences as algebra equivalences. Chosen one-sided inverses remain one-sided inverses after
+passing to symmetric algebras.
+
+## Main definitions
+
+* `SymmetricAlgebra.map`: the algebra homomorphism induced by a linear map.
+* `SymmetricAlgebra.mapEquiv`: the algebra equivalence induced by a linear equivalence.
+
+## Main results
+
+* `SymmetricAlgebra.map_ι`: evaluation of the induced map on a canonical generator.
+* `SymmetricAlgebra.map_id` and `SymmetricAlgebra.map_comp`: functoriality laws.
+* `SymmetricAlgebra.map_injective_of_leftInverse` and
+  `SymmetricAlgebra.map_surjective_of_rightInverse`: transport of split morphisms.
+
+## Roadmap
+
+This supplies the symmetric-algebra side of functoriality for subalgebras and direct sums in
+Layer 3 of the LieHighestWeight roadmap. The product comparison and naturality of the canonical
+map to the PBW associated graded are downstream.
+-/
+
+public section
+
+namespace SymmetricAlgebra
+
+universe u v w x
+
+variable (R : Type u) [CommSemiring R]
+variable {M : Type v} {N : Type w} {P : Type x}
+variable [AddCommMonoid M] [Module R M]
+variable [AddCommMonoid N] [Module R N]
+variable [AddCommMonoid P] [Module R P]
+
+/-- The algebra homomorphism between symmetric algebras induced by a linear map. -/
+noncomputable def map (f : M →ₗ[R] N) :
+    SymmetricAlgebra R M →ₐ[R] SymmetricAlgebra R N :=
+  lift ((ι R N).comp f)
+
+/-- A symmetric-algebra map acts on canonical generators by the original linear map. -/
+@[simp]
+theorem map_ι (f : M →ₗ[R] N) (a : M) :
+    map R f (ι R M a) = ι R N (f a) := by
+  simp [map]
+
+/-- An algebra homomorphism between symmetric algebras is induced by `f` exactly when it has the
+prescribed value on every canonical generator. -/
+theorem map_unique (f : M →ₗ[R] N)
+    (g : SymmetricAlgebra R M →ₐ[R] SymmetricAlgebra R N) :
+    (∀ a, g (ι R M a) = ι R N (f a)) ↔ g = map R f := by
+  constructor
+  · intro h
+    apply algHom_ext
+    apply LinearMap.ext
+    intro a
+    simp only [LinearMap.comp_apply]
+    exact (h a).trans (map_ι R f a).symm
+  · rintro rfl
+    exact map_ι R f
+
+/-- The identity linear map induces the identity algebra homomorphism. -/
+@[simp]
+theorem map_id :
+    map R (LinearMap.id (R := R) (M := M)) = AlgHom.id R (SymmetricAlgebra R M) := by
+  apply algHom_ext
+  ext a
+  simp
+
+/-- Composition of linear maps becomes composition of the induced algebra homomorphisms. -/
+@[simp]
+theorem map_comp (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
+    map R (g.comp f) = (map R g).comp (map R f) := by
+  apply algHom_ext
+  ext a
+  simp
+
+/-- A left inverse of linear maps induces a left inverse of the corresponding symmetric-algebra
+maps. -/
+theorem map_leftInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
+    (h : g.comp f = LinearMap.id) : Function.LeftInverse (map R g) (map R f) := by
+  intro a
+  have hmaps : (map R g).comp (map R f) = AlgHom.id R (SymmetricAlgebra R M) := by
+    rw [← map_comp, h, map_id]
+  exact AlgHom.congr_fun hmaps a
+
+/-- A right inverse of linear maps induces a right inverse of the corresponding symmetric-algebra
+maps. -/
+theorem map_rightInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
+    (h : f.comp g = LinearMap.id) : Function.RightInverse (map R g) (map R f) := by
+  intro a
+  have hmaps : (map R f).comp (map R g) = AlgHom.id R (SymmetricAlgebra R N) := by
+    rw [← map_comp, h, map_id]
+  exact AlgHom.congr_fun hmaps a
+
+/-- A split monomorphism induces an injective map of symmetric algebras. -/
+theorem map_injective_of_leftInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
+    (h : g.comp f = LinearMap.id) : Function.Injective (map R f) :=
+  (map_leftInverse R h).injective
+
+/-- A split epimorphism induces a surjective map of symmetric algebras. -/
+theorem map_surjective_of_rightInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
+    (h : f.comp g = LinearMap.id) : Function.Surjective (map R f) :=
+  (map_rightInverse R h).surjective
+
+/-- A linear equivalence induces an algebra equivalence of symmetric algebras. -/
+noncomputable def mapEquiv (e : M ≃ₗ[R] N) :
+    SymmetricAlgebra R M ≃ₐ[R] SymmetricAlgebra R N :=
+  AlgEquiv.ofAlgHom (map R e.toLinearMap) (map R e.symm.toLinearMap)
+    (by rw [← map_comp, e.comp_symm, map_id])
+    (by rw [← map_comp, e.symm_comp, map_id])
+
+/-- The algebra homomorphism underlying `mapEquiv` is induced by the underlying linear map. -/
+@[simp]
+theorem mapEquiv_toAlgHom (e : M ≃ₗ[R] N) :
+    (mapEquiv R e).toAlgHom = map R e.toLinearMap := by
+  rw [mapEquiv, AlgEquiv.toAlgHom_ofAlgHom]
+
+/-- The induced algebra equivalence acts on canonical generators by the original linear
+equivalence. -/
+@[simp]
+theorem mapEquiv_ι (e : M ≃ₗ[R] N) (a : M) :
+    mapEquiv R e (ι R M a) = ι R N (e a) := by
+  rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom, map_ι, LinearEquiv.coe_toLinearMap]
+
+/-- Passing the inverse linear equivalence to symmetric algebras gives the inverse algebra
+equivalence. -/
+@[simp]
+theorem mapEquiv_symm (e : M ≃ₗ[R] N) :
+    (mapEquiv R e).symm = mapEquiv R e.symm := by
+  apply AlgEquiv.ext
+  intro a
+  rw [mapEquiv, AlgEquiv.ofAlgHom_symm]
+  simp only [AlgEquiv.ofAlgHom_apply, mapEquiv, LinearEquiv.symm_symm]
+
+/-- The identity linear equivalence induces the identity algebra equivalence. -/
+@[simp]
+theorem mapEquiv_refl :
+    mapEquiv R (LinearEquiv.refl R M) = AlgEquiv.refl := by
+  apply AlgEquiv.coe_toAlgHom_injective
+  rw [mapEquiv_toAlgHom, LinearEquiv.refl_toLinearMap, map_id, AlgEquiv.refl_toAlgHom]
+
+/-- Composition of linear equivalences becomes composition of the induced algebra
+equivalences. -/
+@[simp]
+theorem mapEquiv_trans (e : M ≃ₗ[R] N) (d : N ≃ₗ[R] P) :
+    (mapEquiv R e).trans (mapEquiv R d) = mapEquiv R (e.trans d) := by
+  apply AlgEquiv.coe_toAlgHom_injective
+  rw [mapEquiv_toAlgHom]
+  have htrans : ((mapEquiv R e).trans (mapEquiv R d)).toAlgHom =
+      (mapEquiv R d).toAlgHom.comp (mapEquiv R e).toAlgHom := by
+    apply AlgHom.ext
+    intro a
+    simp only [AlgEquiv.toAlgHom_apply, AlgEquiv.trans_apply, AlgHom.comp_apply]
+  rw [htrans, mapEquiv_toAlgHom, mapEquiv_toAlgHom]
+  have h : (e.trans d).toLinearMap = d.toLinearMap.comp e.toLinearMap := by
+    ext a
+    simp only [LinearMap.comp_apply, LinearEquiv.trans_apply, LinearEquiv.coe_toLinearMap]
+  rw [h, map_comp]
+
+end SymmetricAlgebra

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -179,7 +179,7 @@ theorem mapEquiv_symm (e : M ≃ₗ[R] N) :
   rw [(mapEquiv R e).apply_symm_apply, mapEquiv_apply (e := e.symm),
     mapEquiv_apply (e := e)]
   rw [← AlgHom.comp_apply, map_comp_map, e.comp_symm, map_id]
-  rfl
+  simp only [AlgHom.id_apply]
 
 /-- The identity linear equivalence induces the identity algebra equivalence. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -69,6 +69,7 @@ theorem map_unique (f : M →ₗ[R] N) (g : SymmetricAlgebra R M →ₐ[R] Symme
   · intro h
     apply algHom_ext
     ext a
+    -- `algHom_ext` and `ext` leave the generator equality under bundled maps.
     change g (ι R M a) = map R f (ι R M a)
     rw [h, map_apply_ι]
   · intro h a
@@ -96,6 +97,36 @@ theorem map_comp_map (f : M →ₗ[R] N) (g : N →ₗ[R] P) :
   apply algHom_ext
   ext a
   simp
+
+/-- A left inverse of linear maps induces a left inverse of the corresponding symmetric-algebra
+maps. -/
+theorem map_leftInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
+    (h : Function.LeftInverse g f) : Function.LeftInverse (map R g) (map R f) := by
+  intro a
+  have hmaps : (map R g).comp (map R f) = AlgHom.id R (SymmetricAlgebra R M) := by
+    have hgf : g.comp f = LinearMap.id := LinearMap.ext fun x => h x
+    rw [map_comp_map, hgf, map_id]
+  exact AlgHom.congr_fun hmaps a
+
+/-- A right inverse of linear maps induces a right inverse of the corresponding symmetric-algebra
+maps. -/
+theorem map_rightInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
+    (h : Function.RightInverse g f) : Function.RightInverse (map R g) (map R f) := by
+  intro a
+  have hmaps : (map R f).comp (map R g) = AlgHom.id R (SymmetricAlgebra R N) := by
+    have hfg : f.comp g = LinearMap.id := LinearMap.ext fun x => h x
+    rw [map_comp_map, hfg, map_id]
+  exact AlgHom.congr_fun hmaps a
+
+/-- A split monomorphism induces an injective map of symmetric algebras. -/
+theorem map_injective_of_leftInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
+    (h : Function.LeftInverse g f) : Function.Injective (map R f) :=
+  (map_leftInverse R h).injective
+
+/-- A split epimorphism induces a surjective map of symmetric algebras. -/
+theorem map_surjective_of_rightInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
+    (h : Function.RightInverse g f) : Function.Surjective (map R f) :=
+  (map_rightInverse R h).surjective
 
 /-- A linear equivalence induces an algebra equivalence of symmetric algebras. -/
 noncomputable def mapEquiv (e : M ≃ₗ[R] N) :

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -24,8 +24,8 @@ passing to symmetric algebras.
 
 * `SymmetricAlgebra.map_ι`: evaluation of the induced map on a canonical generator.
 * `SymmetricAlgebra.map_id` and `SymmetricAlgebra.map_comp`: functoriality laws.
-* `SymmetricAlgebra.map_injective_of_leftInverse` and
-  `SymmetricAlgebra.map_surjective_of_rightInverse`: transport of split morphisms.
+* `SymmetricAlgebra.map_injective_of_leftInverse` and `SymmetricAlgebra.map_surjective`:
+  transport of injective and surjective morphisms.
 
 ## Roadmap
 
@@ -111,10 +111,24 @@ theorem map_injective_of_leftInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
     (h : g.comp f = LinearMap.id) : Function.Injective (map R f) :=
   (map_leftInverse R h).injective
 
-/-- A split epimorphism induces a surjective map of symmetric algebras. -/
-theorem map_surjective_of_rightInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
-    (h : f.comp g = LinearMap.id) : Function.Surjective (map R f) :=
-  (map_rightInverse R h).surjective
+/-- A surjective linear map induces a surjective map of symmetric algebras. -/
+theorem map_surjective {f : M →ₗ[R] N} (hf : Function.Surjective f) :
+    Function.Surjective (map R f) := by
+  intro a
+  induction a using SymmetricAlgebra.induction with
+  | algebraMap r =>
+      exact ⟨algebraMap R (SymmetricAlgebra R M) r, by simp [map]⟩
+  | ι n =>
+      obtain ⟨m, rfl⟩ := hf n
+      exact ⟨ι R M m, by simp⟩
+  | mul a b ha hb =>
+      obtain ⟨a', ha'⟩ := ha
+      obtain ⟨b', hb'⟩ := hb
+      exact ⟨a' * b', by simp [ha', hb']⟩
+  | add a b ha hb =>
+      obtain ⟨a', ha'⟩ := ha
+      obtain ⟨b', hb'⟩ := hb
+      exact ⟨a' + b', by simp [ha', hb']⟩
 
 /-- A linear equivalence induces an algebra equivalence of symmetric algebras. -/
 noncomputable def mapEquiv (e : M ≃ₗ[R] N) :

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -27,7 +27,7 @@ Clifford-algebra induction.
 
 ## Main results
 
-* `SymmetricAlgebra.map_ι`: evaluation of the induced map on a canonical generator.
+* `SymmetricAlgebra.map_apply_ι`: evaluation of the induced map on a canonical generator.
 * `SymmetricAlgebra.map_id` and `SymmetricAlgebra.map_comp_map`: functoriality laws.
 * `SymmetricAlgebra.map_injective_of_leftInverse` and `SymmetricAlgebra.map_surjective`:
   transport of split monomorphisms and of surjections.
@@ -58,7 +58,7 @@ noncomputable def map (f : M →ₗ[R] N) :
 
 /-- A symmetric-algebra map acts on canonical generators by the original linear map. -/
 @[simp]
-theorem map_ι (f : M →ₗ[R] N) (a : M) :
+theorem map_apply_ι (f : M →ₗ[R] N) (a : M) :
     map R f (ι R M a) = ι R N (f a) := by
   simp [map]
 
@@ -70,7 +70,7 @@ theorem map_id :
   ext a
   simp
 
-/-- The induced map composed with the canonical generator map is the original linear map. -/
+/-- The induced map commutes with the canonical generator maps. -/
 @[simp]
 theorem map_comp_ι (f : M →ₗ[R] N) :
     (map R f).toLinearMap ∘ₗ ι R M = ι R N ∘ₗ f := by
@@ -145,12 +145,8 @@ theorem mapEquiv_symm (e : M ≃ₗ[R] N) :
     (mapEquiv R e).symm = mapEquiv R e.symm := by
   apply AlgEquiv.ext
   intro a
-  rw [AlgEquiv.symm_apply_eq, mapEquiv_apply, mapEquiv_apply]
-  have hcomp : (map R e.toLinearMap).comp (map R e.symm.toLinearMap) =
-      AlgHom.id R (SymmetricAlgebra R N) := by
-    rw [map_comp_map, e.comp_symm, map_id]
-  rw [← AlgHom.comp_apply, hcomp]
-  rfl
+  rw [mapEquiv, AlgEquiv.ofAlgHom_symm]
+  simp only [AlgEquiv.ofAlgHom_apply, mapEquiv, LinearEquiv.symm_symm]
 
 /-- The identity linear equivalence induces the identity algebra equivalence. -/
 @[simp]
@@ -168,7 +164,8 @@ theorem mapEquiv_trans (e : M ≃ₗ[R] N) (d : N ≃ₗ[R] P) :
   intro a
   simp only [AlgEquiv.trans_apply, mapEquiv_apply]
   calc
-    _ = ((map R d.toLinearMap).comp (map R e.toLinearMap)) a := rfl
+    _ = ((map R d.toLinearMap).comp (map R e.toLinearMap)) a := by
+      rw [AlgHom.comp_apply]
     _ = map R (d.toLinearMap.comp e.toLinearMap) a := by rw [map_comp_map]
     _ = _ := by rw [LinearEquiv.coe_trans]
 

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -161,13 +161,13 @@ theorem mapEquiv_toAlgHom (e : M ≃ₗ[R] N) :
   rw [mapEquiv, AlgEquiv.toAlgHom_ofAlgHom]
 
 /-- The induced equivalence agrees with the induced algebra map on every element. -/
+@[simp]
 theorem mapEquiv_apply (e : M ≃ₗ[R] N) (a : SymmetricAlgebra R M) :
     mapEquiv R e a = map R e.toLinearMap a := by
   rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom]
 
 /-- The bundled equivalence acts on canonical generators by the underlying linear equivalence. -/
-@[simp]
-theorem mapEquiv_apply_ι (e : M ≃ₗ[R] N) (a : M) :
+theorem mapEquiv_ι (e : M ≃ₗ[R] N) (a : M) :
     mapEquiv R e (ι R M a) = ι R N (e a) := by
   simp [mapEquiv_apply]
 

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -70,8 +70,7 @@ theorem map_unique (f : M →ₗ[R] N) (g : SymmetricAlgebra R M →ₐ[R] Symme
     apply algHom_ext
     ext a
     -- `algHom_ext` and `ext` leave the generator equality under bundled maps.
-    change g (ι R M a) = map R f (ι R M a)
-    rw [h, map_apply_ι]
+    simpa [LinearMap.comp_apply, map_apply_ι] using h a
   · intro h a
     rw [h, map_apply_ι]
 
@@ -125,7 +124,7 @@ theorem map_surjective_of_rightInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
   (map_rightInverse R h).surjective
 
 /-- A surjective linear map induces a surjective map of symmetric algebras. -/
-theorem map_surjective_of_surjective (f : M →ₗ[R] N)
+theorem map_surjective (f : M →ₗ[R] N)
     (h : Function.Surjective f) : Function.Surjective (map R f) := by
   intro b
   induction b using SymmetricAlgebra.induction with

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -117,7 +117,6 @@ theorem mapEquiv_apply (e : M ≃ₗ[R] N) (a : SymmetricAlgebra R M) :
   rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom]
 
 /-- The bundled equivalence acts on canonical generators by the underlying linear equivalence. -/
-@[simp]
 theorem mapEquiv_apply_ι (e : M ≃ₗ[R] N) (a : M) :
     mapEquiv R e (ι R M a) = ι R N (e a) := by
   simp [mapEquiv_apply]

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -163,6 +163,7 @@ theorem mapEquiv_apply (e : M ≃ₗ[R] N) (a : SymmetricAlgebra R M) :
   rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom]
 
 /-- The bundled equivalence acts on canonical generators by the underlying linear equivalence. -/
+@[simp, nolint simpNF]
 theorem mapEquiv_ι (e : M ≃ₗ[R] N) (a : M) :
     mapEquiv R e (ι R M a) = ι R N (e a) := by
   simp [mapEquiv_apply]
@@ -174,8 +175,11 @@ theorem mapEquiv_symm (e : M ≃ₗ[R] N) :
     (mapEquiv R e).symm = mapEquiv R e.symm := by
   apply AlgEquiv.ext
   intro a
-  rw [mapEquiv, AlgEquiv.ofAlgHom_symm]
-  simp only [AlgEquiv.ofAlgHom_apply, mapEquiv, LinearEquiv.symm_symm]
+  apply (mapEquiv R e).injective
+  rw [(mapEquiv R e).apply_symm_apply, mapEquiv_apply (e := e.symm),
+    mapEquiv_apply (e := e)]
+  rw [← AlgHom.comp_apply, map_comp_map, e.comp_symm, map_id]
+  rfl
 
 /-- The identity linear equivalence induces the identity algebra equivalence. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -33,8 +33,6 @@ Tau Ceti formalization in `TauCeti/Algebra/Lie/UniversalEnveloping/Functoriality
 * `SymmetricAlgebra.map_apply_ι`: evaluation of the induced map on a canonical generator.
 * `SymmetricAlgebra.map_unique`: characterization of the induced map by its generators.
 * `SymmetricAlgebra.map_id` and `SymmetricAlgebra.map_comp_map`: functoriality laws.
-* `SymmetricAlgebra.map_injective_of_leftInverse` and `SymmetricAlgebra.map_surjective`:
-  transport of split monomorphisms and of surjections.
 
 ## Roadmap
 
@@ -101,46 +99,6 @@ theorem map_comp_map (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
   ext a
   simp
 
-/-- A left inverse of linear maps induces a left inverse of the corresponding symmetric-algebra
-maps. -/
-theorem map_leftInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
-    (h : Function.LeftInverse g f) : Function.LeftInverse (map R g) (map R f) := by
-  intro a
-  have hmaps : (map R g).comp (map R f) = AlgHom.id R (SymmetricAlgebra R M) := by
-    have hgf : g.comp f = LinearMap.id := LinearMap.ext fun x => h x
-    rw [map_comp_map, hgf, map_id]
-  exact AlgHom.congr_fun hmaps a
-
-/-- A right inverse of linear maps induces a right inverse of the corresponding symmetric-algebra
-maps. -/
-theorem map_rightInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
-    (h : Function.RightInverse g f) : Function.RightInverse (map R g) (map R f) :=
-  map_leftInverse R h
-
-/-- A split monomorphism induces an injective map of symmetric algebras. -/
-theorem map_injective_of_leftInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
-    (h : Function.LeftInverse g f) : Function.Injective (map R f) :=
-  (map_leftInverse R h).injective
-
-/-- A surjective linear map induces a surjective map of symmetric algebras. -/
-theorem map_surjective {f : M →ₗ[R] N} (hf : Function.Surjective f) :
-    Function.Surjective (map R f) := by
-  intro a
-  induction a using SymmetricAlgebra.induction with
-  | algebraMap r =>
-      exact ⟨algebraMap R (SymmetricAlgebra R M) r, by simp⟩
-  | ι n =>
-      obtain ⟨m, rfl⟩ := hf n
-      exact ⟨ι R M m, by simp⟩
-  | mul a b ha hb =>
-      obtain ⟨a', ha'⟩ := ha
-      obtain ⟨b', hb'⟩ := hb
-      exact ⟨a' * b', by simp [ha', hb']⟩
-  | add a b ha hb =>
-      obtain ⟨a', ha'⟩ := ha
-      obtain ⟨b', hb'⟩ := hb
-      exact ⟨a' + b', by simp [ha', hb']⟩
-
 /-- A linear equivalence induces an algebra equivalence of symmetric algebras. -/
 noncomputable def mapEquiv (e : M ≃ₗ[R] N) :
     SymmetricAlgebra R M ≃ₐ[R] SymmetricAlgebra R N :=
@@ -159,6 +117,12 @@ theorem mapEquiv_toAlgHom (e : M ≃ₗ[R] N) :
 theorem mapEquiv_apply (e : M ≃ₗ[R] N) (a : SymmetricAlgebra R M) :
     mapEquiv R e a = map R e.toLinearMap a := by
   rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom]
+
+/-- The bundled equivalence acts on canonical generators by the underlying linear equivalence. -/
+@[simp]
+theorem mapEquiv_apply_ι (e : M ≃ₗ[R] N) (a : M) :
+    mapEquiv R e (ι R M a) = ι R N (e a) := by
+  simp [mapEquiv_apply]
 
 /-- Passing the inverse linear equivalence to symmetric algebras gives the inverse algebra
 equivalence. -/

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -15,6 +15,11 @@ map from the universal property, proves its identity and composition laws, and p
 equivalences as algebra equivalences. Chosen one-sided inverses remain one-sided inverses after
 passing to symmetric algebras.
 
+The construction and its lemma set follow Mathlib's `CliffordAlgebra.map` and `ExteriorAlgebra.map`
+functoriality APIs (`Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean` and
+`Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean`); `map_surjective` adapts the corresponding
+Clifford-algebra induction.
+
 ## Main definitions
 
 * `SymmetricAlgebra.map`: the algebra homomorphism induced by a linear map.
@@ -23,9 +28,9 @@ passing to symmetric algebras.
 ## Main results
 
 * `SymmetricAlgebra.map_ι`: evaluation of the induced map on a canonical generator.
-* `SymmetricAlgebra.map_id` and `SymmetricAlgebra.map_comp`: functoriality laws.
+* `SymmetricAlgebra.map_id` and `SymmetricAlgebra.map_comp_map`: functoriality laws.
 * `SymmetricAlgebra.map_injective_of_leftInverse` and `SymmetricAlgebra.map_surjective`:
-  transport of injective and surjective morphisms.
+  transport of split monomorphisms and of surjections.
 
 ## Roadmap
 
@@ -57,21 +62,6 @@ theorem map_ι (f : M →ₗ[R] N) (a : M) :
     map R f (ι R M a) = ι R N (f a) := by
   simp [map]
 
-/-- An algebra homomorphism between symmetric algebras is induced by `f` exactly when it has the
-prescribed value on every canonical generator. -/
-theorem map_unique (f : M →ₗ[R] N)
-    (g : SymmetricAlgebra R M →ₐ[R] SymmetricAlgebra R N) :
-    (∀ a, g (ι R M a) = ι R N (f a)) ↔ g = map R f := by
-  constructor
-  · intro h
-    apply algHom_ext
-    apply LinearMap.ext
-    intro a
-    simp only [LinearMap.comp_apply]
-    exact (h a).trans (map_ι R f a).symm
-  · rintro rfl
-    exact map_ι R f
-
 /-- The identity linear map induces the identity algebra homomorphism. -/
 @[simp]
 theorem map_id :
@@ -80,10 +70,17 @@ theorem map_id :
   ext a
   simp
 
+/-- The induced map composed with the canonical generator map is the original linear map. -/
+@[simp]
+theorem map_comp_ι (f : M →ₗ[R] N) :
+    (map R f).toLinearMap ∘ₗ ι R M = ι R N ∘ₗ f := by
+  ext a
+  simp
+
 /-- Composition of linear maps becomes composition of the induced algebra homomorphisms. -/
 @[simp]
-theorem map_comp (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
-    map R (g.comp f) = (map R g).comp (map R f) := by
+theorem map_comp_map (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
+    (map R g).comp (map R f) = map R (g.comp f) := by
   apply algHom_ext
   ext a
   simp
@@ -91,24 +88,16 @@ theorem map_comp (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
 /-- A left inverse of linear maps induces a left inverse of the corresponding symmetric-algebra
 maps. -/
 theorem map_leftInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
-    (h : g.comp f = LinearMap.id) : Function.LeftInverse (map R g) (map R f) := by
+    (h : Function.LeftInverse g f) : Function.LeftInverse (map R g) (map R f) := by
   intro a
   have hmaps : (map R g).comp (map R f) = AlgHom.id R (SymmetricAlgebra R M) := by
-    rw [← map_comp, h, map_id]
-  exact AlgHom.congr_fun hmaps a
-
-/-- A right inverse of linear maps induces a right inverse of the corresponding symmetric-algebra
-maps. -/
-theorem map_rightInverse {f : M →ₗ[R] N} {g : N →ₗ[R] M}
-    (h : f.comp g = LinearMap.id) : Function.RightInverse (map R g) (map R f) := by
-  intro a
-  have hmaps : (map R f).comp (map R g) = AlgHom.id R (SymmetricAlgebra R N) := by
-    rw [← map_comp, h, map_id]
+    have hgf : g.comp f = LinearMap.id := LinearMap.ext fun x => h x
+    rw [map_comp_map, hgf, map_id]
   exact AlgHom.congr_fun hmaps a
 
 /-- A split monomorphism induces an injective map of symmetric algebras. -/
 theorem map_injective_of_leftInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
-    (h : g.comp f = LinearMap.id) : Function.Injective (map R f) :=
+    (h : Function.LeftInverse g f) : Function.Injective (map R f) :=
   (map_leftInverse R h).injective
 
 /-- A surjective linear map induces a surjective map of symmetric algebras. -/
@@ -117,7 +106,7 @@ theorem map_surjective {f : M →ₗ[R] N} (hf : Function.Surjective f) :
   intro a
   induction a using SymmetricAlgebra.induction with
   | algebraMap r =>
-      exact ⟨algebraMap R (SymmetricAlgebra R M) r, by simp [map]⟩
+      exact ⟨algebraMap R (SymmetricAlgebra R M) r, by simp⟩
   | ι n =>
       obtain ⟨m, rfl⟩ := hf n
       exact ⟨ι R M m, by simp⟩
@@ -134,8 +123,8 @@ theorem map_surjective {f : M →ₗ[R] N} (hf : Function.Surjective f) :
 noncomputable def mapEquiv (e : M ≃ₗ[R] N) :
     SymmetricAlgebra R M ≃ₐ[R] SymmetricAlgebra R N :=
   AlgEquiv.ofAlgHom (map R e.toLinearMap) (map R e.symm.toLinearMap)
-    (by rw [← map_comp, e.comp_symm, map_id])
-    (by rw [← map_comp, e.symm_comp, map_id])
+    (by rw [map_comp_map, e.comp_symm, map_id])
+    (by rw [map_comp_map, e.symm_comp, map_id])
 
 /-- The algebra homomorphism underlying `mapEquiv` is induced by the underlying linear map. -/
 @[simp]
@@ -143,12 +132,11 @@ theorem mapEquiv_toAlgHom (e : M ≃ₗ[R] N) :
     (mapEquiv R e).toAlgHom = map R e.toLinearMap := by
   rw [mapEquiv, AlgEquiv.toAlgHom_ofAlgHom]
 
-/-- The induced algebra equivalence acts on canonical generators by the original linear
-equivalence. -/
+/-- The induced equivalence agrees with the induced algebra map on every element. -/
 @[simp]
-theorem mapEquiv_ι (e : M ≃ₗ[R] N) (a : M) :
-    mapEquiv R e (ι R M a) = ι R N (e a) := by
-  rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom, map_ι, LinearEquiv.coe_toLinearMap]
+theorem mapEquiv_apply (e : M ≃ₗ[R] N) (a : SymmetricAlgebra R M) :
+    mapEquiv R e a = map R e.toLinearMap a := by
+  rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom]
 
 /-- Passing the inverse linear equivalence to symmetric algebras gives the inverse algebra
 equivalence. -/
@@ -157,8 +145,12 @@ theorem mapEquiv_symm (e : M ≃ₗ[R] N) :
     (mapEquiv R e).symm = mapEquiv R e.symm := by
   apply AlgEquiv.ext
   intro a
-  rw [mapEquiv, AlgEquiv.ofAlgHom_symm]
-  simp only [AlgEquiv.ofAlgHom_apply, mapEquiv, LinearEquiv.symm_symm]
+  rw [AlgEquiv.symm_apply_eq, mapEquiv_apply, mapEquiv_apply]
+  have hcomp : (map R e.toLinearMap).comp (map R e.symm.toLinearMap) =
+      AlgHom.id R (SymmetricAlgebra R N) := by
+    rw [map_comp_map, e.comp_symm, map_id]
+  rw [← AlgHom.comp_apply, hcomp]
+  rfl
 
 /-- The identity linear equivalence induces the identity algebra equivalence. -/
 @[simp]
@@ -172,17 +164,12 @@ equivalences. -/
 @[simp]
 theorem mapEquiv_trans (e : M ≃ₗ[R] N) (d : N ≃ₗ[R] P) :
     (mapEquiv R e).trans (mapEquiv R d) = mapEquiv R (e.trans d) := by
-  apply AlgEquiv.coe_toAlgHom_injective
-  rw [mapEquiv_toAlgHom]
-  have htrans : ((mapEquiv R e).trans (mapEquiv R d)).toAlgHom =
-      (mapEquiv R d).toAlgHom.comp (mapEquiv R e).toAlgHom := by
-    apply AlgHom.ext
-    intro a
-    simp only [AlgEquiv.toAlgHom_apply, AlgEquiv.trans_apply, AlgHom.comp_apply]
-  rw [htrans, mapEquiv_toAlgHom, mapEquiv_toAlgHom]
-  have h : (e.trans d).toLinearMap = d.toLinearMap.comp e.toLinearMap := by
-    ext a
-    simp only [LinearMap.comp_apply, LinearEquiv.trans_apply, LinearEquiv.coe_toLinearMap]
-  rw [h, map_comp]
+  apply AlgEquiv.ext
+  intro a
+  simp only [AlgEquiv.trans_apply, mapEquiv_apply]
+  calc
+    _ = ((map R d.toLinearMap).comp (map R e.toLinearMap)) a := rfl
+    _ = map R (d.toLinearMap.comp e.toLinearMap) a := by rw [map_comp_map]
+    _ = _ := by rw [LinearEquiv.coe_trans]
 
 end SymmetricAlgebra

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -128,6 +128,25 @@ theorem map_surjective_of_rightInverse (f : M →ₗ[R] N) (g : N →ₗ[R] M)
     (h : Function.RightInverse g f) : Function.Surjective (map R f) :=
   (map_rightInverse R h).surjective
 
+/-- A surjective linear map induces a surjective map of symmetric algebras. -/
+theorem map_surjective_of_surjective (f : M →ₗ[R] N)
+    (h : Function.Surjective f) : Function.Surjective (map R f) := by
+  intro b
+  induction b using SymmetricAlgebra.induction with
+  | algebraMap r =>
+      exact ⟨algebraMap R (SymmetricAlgebra R M) r, by simp⟩
+  | ι y =>
+      obtain ⟨x, rfl⟩ := h y
+      exact ⟨ι R M x, by simp⟩
+  | mul a b ha hb =>
+      obtain ⟨a', ha'⟩ := ha
+      obtain ⟨b', hb'⟩ := hb
+      exact ⟨a' * b', by simp [ha', hb']⟩
+  | add a b ha hb =>
+      obtain ⟨a', ha'⟩ := ha
+      obtain ⟨b', hb'⟩ := hb
+      exact ⟨a' + b', by simp [ha', hb']⟩
+
 /-- A linear equivalence induces an algebra equivalence of symmetric algebras. -/
 noncomputable def mapEquiv (e : M ≃ₗ[R] N) :
     SymmetricAlgebra R M ≃ₐ[R] SymmetricAlgebra R N :=
@@ -148,6 +167,7 @@ theorem mapEquiv_apply (e : M ≃ₗ[R] N) (a : SymmetricAlgebra R M) :
   rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom]
 
 /-- The bundled equivalence acts on canonical generators by the underlying linear equivalence. -/
+@[simp]
 theorem mapEquiv_apply_ι (e : M ≃ₗ[R] N) (a : M) :
     mapEquiv R e (ι R M a) = ι R N (e a) := by
   simp [mapEquiv_apply]

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -12,13 +12,11 @@ public import Mathlib.LinearAlgebra.SymmetricAlgebra.Basic
 
 A linear map induces an algebra homomorphism between symmetric algebras. This file constructs the
 map from the universal property, proves its identity and composition laws, and packages linear
-equivalences as algebra equivalences. Chosen one-sided inverses remain one-sided inverses after
-passing to symmetric algebras.
+equivalences as algebra equivalences.
 
 The construction and its lemma set follow Mathlib's `CliffordAlgebra.map` and `ExteriorAlgebra.map`
 functoriality APIs (`Mathlib/LinearAlgebra/CliffordAlgebra/Basic.lean` and
-`Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean`); `map_surjective` adapts the corresponding
-Clifford-algebra induction.
+`Mathlib/LinearAlgebra/ExteriorAlgebra/Basic.lean`).
 
 The declaration order, API naming, and proof organization also adapt the prior
 Tau Ceti formalization in `TauCeti/Algebra/Lie/UniversalEnveloping/Functoriality.lean`.

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -91,7 +91,7 @@ theorem map_comp_ι (f : M →ₗ[R] N) :
 
 /-- Composition of linear maps becomes composition of the induced algebra homomorphisms. -/
 @[simp]
-theorem map_comp_map (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
+theorem map_comp_map (f : M →ₗ[R] N) (g : N →ₗ[R] P) :
     (map R g).comp (map R f) = map R (g.comp f) := by
   apply algHom_ext
   ext a

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -162,7 +162,6 @@ theorem mapEquiv_apply (e : M ≃ₗ[R] N) (a : SymmetricAlgebra R M) :
   rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom]
 
 /-- The bundled equivalence acts on canonical generators by the underlying linear equivalence. -/
-@[simp, nolint simpNF]
 theorem mapEquiv_ι (e : M ≃ₗ[R] N) (a : M) :
     mapEquiv R e (ι R M a) = ι R N (e a) := by
   simp [mapEquiv_apply]

--- a/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
+++ b/TauCeti/LinearAlgebra/SymmetricAlgebra/Functoriality.lean
@@ -161,7 +161,6 @@ theorem mapEquiv_toAlgHom (e : M ≃ₗ[R] N) :
   rw [mapEquiv, AlgEquiv.toAlgHom_ofAlgHom]
 
 /-- The induced equivalence agrees with the induced algebra map on every element. -/
-@[simp]
 theorem mapEquiv_apply (e : M ≃ₗ[R] N) (a : SymmetricAlgebra R M) :
     mapEquiv R e a = map R e.toLinearMap a := by
   rw [← AlgEquiv.toAlgHom_apply, mapEquiv_toAlgHom]

--- a/scripts/lint-nolints-allowlist.txt
+++ b/scripts/lint-nolints-allowlist.txt
@@ -1,0 +1,1 @@
+simpNF SymmetricAlgebra.mapEquiv_ι

--- a/scripts/lint-nolints-allowlist.txt
+++ b/scripts/lint-nolints-allowlist.txt
@@ -1,1 +1,0 @@
-simpNF SymmetricAlgebra.mapEquiv_ι


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the missing functorial API for symmetric algebras.

- Constructs the algebra homomorphism induced by a linear map.
- Proves generator, identity, composition, split-morphism, and surjectivity equations.
- Packages linear equivalences as algebra equivalences with inverse, identity, and composition laws.
- Replaces the downstream additive-group base-change duplicate with the canonical equivalence API.

## Roadmap target

Supplies the symmetric-algebra functoriality prerequisite named in [LieHighestWeight Layer 3](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md#layer-3-enveloping-algebra-verma-modules-and-l%CE%BB), where PBW functoriality for subalgebras and direct sums is a pinned intermediate target.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"LieHighestWeight/README.md#layer-3-enveloping-algebra-verma-modules-and-l%CE%BB"}-->

## Verification

The exact public head is `0e596be9086ceab73493e2f4231043bbc877acae`, based on merge-base `cf980b419369bba045afbb1d63262d9349ce5618`. The metadata-clean history preserves every public tree; source gates and a fresh exact-head review are running on this head.

## Scale and generality

Adds one 175-line file over a commutative semiring and arbitrary modules, with no field, basis, freeness, finite-dimension, or PBW assumptions.

## Scope

- **Consumes:** the universal property of `SymmetricAlgebra`.
- **Provides:** canonical `map` and `mapEquiv` constructions, characteristic generator and composition equations, split-monomorphism and surjectivity consequences, and equivalence laws.
- **Fits:** supplies the symmetric-algebra side of Layer 3 PBW functoriality.
- **Boundary:** product comparison and naturality of the canonical map to the PBW associated graded remain downstream.

<sub>🤖 GPT-5.6 Sol high · rubrics @ [8221941](https://github.com/utensil/TauCetiReview/commit/8221941939eac06957cfddfddc7aabc959fa2552) · ut-lean-review @ [97a7a2](https://github.com/utensil/formal-land/tree/97a7a23961e14bbcff01d3f6e8d7184404f89293/lean4/skills/ut-lean-review) · ut-lean-golf @ [8ebe5d](https://github.com/utensil/formal-land/tree/8ebe5d01879563853268eb9d754f51950e23c978/lean4/skills/ut-lean-golf) · no source review claimed; exact-head review pending</sub>