### PR TITLE
feat(DedekindDomain): a non-square unit of the completion at an odd place

### DIFF
--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -45,6 +45,11 @@ global étale algebra with its images in the completions passes through exactly 
   `IsDedekindDomain.HeightOneSpectrum.valuation_adicCompletion_algebraMap`: the two restrictions
   of it the square-class conditions of the `2`-descent are stated in — on units of `K`, and on the
   image of `K`.
+* `IsDedekindDomain.HeightOneSpectrum.ringChar_residueField_adicCompletionIntegers_ne_two`: at a
+  place not dividing `2`, the residue field of `𝒪_v` has odd characteristic.
+* `IsDedekindDomain.HeightOneSpectrum.exists_unit_not_isSquare`: at such a place, with finite
+  residue field, `𝒪_v` carries a unit that is not a square in `K_v`. This is the input the
+  local image count at a good odd place needs.
 * `IsDedekindDomain.HeightOneSpectrum.valued_adicCompletionExtension`: along the extension the
   valuation is raised to the ramification index.
 * `IsDedekindDomain.HeightOneSpectrum.comap_maximalIdeal_adicCompletionIntegersExtension`: the
@@ -78,6 +83,15 @@ The three completion-integers results — `span_singleton_eq_maximalIdeal_pow`,
 `exists_valued_sub_lt_one` and `residueFieldEquivAdicCompletionIntegers` — come from that same
 Stoll file; they are the substrate its residue-field comparison rests on, restated here against
 this repository's `HeightOneSpectrum` interface.
+
+`exists_unit_not_isSquare` comes from the same source file (`:183`). Two deliberate departures from
+its proof: the source contracts the maximal ideal with its own
+`comap_maximalIdeal_adicCompletionIntegers`, which this repository states as
+`under_maximalIdeal_adicCompletionIntegers` (`Ideal.under R I` is by definition
+`I.comap (algebraMap R S)`); and where the source derives `v d = 1` from a square by manipulating
+`WithZero.log`, this uses Mathlib's `mul_self_le_one_iff` and `one_le_mul_self_iff`, which say the
+same thing about the ordered value monoid in one line. The odd-residue-characteristic step is split
+out as `ringChar_residueField_adicCompletionIntegers_ne_two`, which the source keeps inline.
 
 Only the part the `2`-descent consumes is ported: the Henselian and completeness chain of the
 source, which serves other consumers, is deliberately left out. The source is written against Lean
@@ -290,6 +304,68 @@ theorem residueFieldEquivAdicCompletionIntegers_apply_mk (a : R) :
     v.residueFieldEquivAdicCompletionIntegers (K := K) (Ideal.Quotient.mk v.asIdeal a) =
       Ideal.Quotient.mk (IsLocalRing.maximalIdeal (v.adicCompletionIntegers K))
         (algebraMap R (v.adicCompletionIntegers K) a) := (rfl)
+
+/-- **At a place not dividing `2`, the residue characteristic is odd.** The residue field of `𝒪_v`
+is the residue field of `v` by `residueFieldEquivAdicCompletionIntegers`, so this is the hypothesis
+`2 ∉ v` transported along that equivalence — stated as a statement about `ringChar` because that is
+the form `FiniteField.exists_nonsquare` consumes. -/
+theorem ringChar_residueField_adicCompletionIntegers_ne_two (hv2 : (2 : R) ∉ v.asIdeal) :
+    ringChar (IsLocalRing.ResidueField (v.adicCompletionIntegers K)) ≠ 2 := by
+  -- first, `2` is not in the maximal ideal of `𝒪_v`: it contracts to `v`
+  have h2 : IsLocalRing.residue (v.adicCompletionIntegers K) 2 ≠ 0 := by
+    intro h0
+    have hmem : (2 : v.adicCompletionIntegers K) ∈
+        IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) :=
+      Ideal.Quotient.eq_zero_iff_mem.mp h0
+    rw [show (2 : v.adicCompletionIntegers K) = algebraMap R (v.adicCompletionIntegers K) 2
+        from (map_ofNat _ 2).symm, ← Ideal.mem_comap, ← Ideal.under_def,
+      v.under_maximalIdeal_adicCompletionIntegers] at hmem
+    exact hv2 hmem
+  -- characteristic `2` would make the residue of `2` vanish
+  intro h
+  refine h2 ?_
+  have h0 : ((2 : ℕ) : IsLocalRing.ResidueField (v.adicCompletionIntegers K)) = 0 := by
+    rw [← h]; exact ringChar.Nat.cast_ringChar
+  rw [Nat.cast_ofNat] at h0
+  rw [show IsLocalRing.residue (v.adicCompletionIntegers K) 2 =
+    (2 : IsLocalRing.ResidueField (v.adicCompletionIntegers K)) from map_ofNat _ 2]
+  exact h0
+
+/-- **At a place of odd residue characteristic and finite residue field, `𝒪_v` has a unit that is
+not a square in `K_v`.** Any lift of a non-square of the residue field works: a square root in
+`K_v` would have valuation `1`, hence lie in `𝒪_v`, and would reduce to a square root of the
+non-square. -/
+theorem exists_unit_not_isSquare [Finite (R ⧸ v.asIdeal)] (hv2 : (2 : R) ∉ v.asIdeal) :
+    ∃ c : (v.adicCompletionIntegers K)ˣ,
+      ¬ IsSquare (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K)
+        (c : v.adicCompletionIntegers K)) := by
+  have hfin : Finite (IsLocalRing.ResidueField (v.adicCompletionIntegers K)) :=
+    Finite.of_equiv _ (v.residueFieldEquivAdicCompletionIntegers (K := K)).toEquiv
+  obtain ⟨a, ha⟩ := FiniteField.exists_nonsquare
+    (v.ringChar_residueField_adicCompletionIntegers_ne_two (K := K) hv2)
+  have ha0 : a ≠ 0 := fun h ↦ ha (h ▸ IsSquare.zero)
+  -- lift the non-square to a unit of `𝒪_v`
+  obtain ⟨x, rfl⟩ := IsLocalRing.residue_surjective (R := v.adicCompletionIntegers K) a
+  have hxu : IsUnit x := by
+    by_contra h
+    exact ha0 (Ideal.Quotient.eq_zero_iff_mem.mpr h)
+  refine ⟨hxu.unit, fun ⟨d, hd⟩ ↦ ?_⟩
+  rw [IsUnit.unit_spec] at hd
+  -- a square root of a unit has valuation `1`, because the value group is torsion-free
+  have hx1 : Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) x) = 1 := by
+    rw [show x = (hxu.unit : v.adicCompletionIntegers K) from hxu.unit_spec.symm]
+    exact (Valuation.valuationSubring.integers (v := Valued.v)).valuation_unit hxu.unit
+  rw [hd, map_mul] at hx1
+  have hd1 : Valued.v d = 1 :=
+    le_antisymm (mul_self_le_one_iff.mp hx1.le) (one_le_mul_self_iff.mp hx1.ge)
+  -- hence it lies in `𝒪_v` and reduces to a square root of the non-square
+  have hdmem : d ∈ v.adicCompletionIntegers K := (mem_adicCompletionIntegers R K v).mpr hd1.le
+  have hinj : Function.Injective
+      (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K)) :=
+    fun a b h ↦ Subtype.ext h
+  have hx_eq : x = (⟨d, hdmem⟩ : v.adicCompletionIntegers K) * ⟨d, hdmem⟩ :=
+    hinj (by rw [map_mul]; exact hd)
+  exact ha ⟨IsLocalRing.residue _ ⟨d, hdmem⟩, by rw [hx_eq, map_mul]⟩
 
 end IsDedekindDomain.HeightOneSpectrum
 

--- a/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
+++ b/TauCeti/RingTheory/DedekindDomain/AdicCompletionExtension.lean
@@ -314,22 +314,15 @@ theorem ringChar_residueField_adicCompletionIntegers_ne_two (hv2 : (2 : R) ∉ v
   -- first, `2` is not in the maximal ideal of `𝒪_v`: it contracts to `v`
   have h2 : IsLocalRing.residue (v.adicCompletionIntegers K) 2 ≠ 0 := by
     intro h0
-    have hmem : (2 : v.adicCompletionIntegers K) ∈
-        IsLocalRing.maximalIdeal (v.adicCompletionIntegers K) :=
-      Ideal.Quotient.eq_zero_iff_mem.mp h0
-    rw [show (2 : v.adicCompletionIntegers K) = algebraMap R (v.adicCompletionIntegers K) 2
-        from (map_ofNat _ 2).symm, ← Ideal.mem_comap, ← Ideal.under_def,
-      v.under_maximalIdeal_adicCompletionIntegers] at hmem
-    exact hv2 hmem
+    refine hv2 ?_
+    rw [← v.under_maximalIdeal_adicCompletionIntegers (K := K), Ideal.under_def, Ideal.mem_comap,
+      map_ofNat]
+    exact Ideal.Quotient.eq_zero_iff_mem.mp h0
   -- characteristic `2` would make the residue of `2` vanish
   intro h
   refine h2 ?_
-  have h0 : ((2 : ℕ) : IsLocalRing.ResidueField (v.adicCompletionIntegers K)) = 0 := by
-    rw [← h]; exact ringChar.Nat.cast_ringChar
-  rw [Nat.cast_ofNat] at h0
-  rw [show IsLocalRing.residue (v.adicCompletionIntegers K) 2 =
-    (2 : IsLocalRing.ResidueField (v.adicCompletionIntegers K)) from map_ofNat _ 2]
-  exact h0
+  rw [map_ofNat, ← Nat.cast_ofNat, ← h]
+  exact ringChar.Nat.cast_ringChar
 
 /-- **At a place of odd residue characteristic and finite residue field, `𝒪_v` has a unit that is
 not a square in `K_v`.** Any lift of a non-square of the residue field works: a square root in
@@ -341,30 +334,27 @@ theorem exists_unit_not_isSquare [Finite (R ⧸ v.asIdeal)] (hv2 : (2 : R) ∉ v
         (c : v.adicCompletionIntegers K)) := by
   have hfin : Finite (IsLocalRing.ResidueField (v.adicCompletionIntegers K)) :=
     Finite.of_equiv _ (v.residueFieldEquivAdicCompletionIntegers (K := K)).toEquiv
+  -- `𝒪_v` is the ring of integers of the valuation of `K_v`; that supplies both the
+  -- injectivity of `𝒪_v → K_v` and the characterization of its units by valuation `1`
+  have hint := adicCompletionIntegers.integers K v
   obtain ⟨a, ha⟩ := FiniteField.exists_nonsquare
     (v.ringChar_residueField_adicCompletionIntegers_ne_two (K := K) hv2)
   have ha0 : a ≠ 0 := fun h ↦ ha (h ▸ IsSquare.zero)
   -- lift the non-square to a unit of `𝒪_v`
   obtain ⟨x, rfl⟩ := IsLocalRing.residue_surjective (R := v.adicCompletionIntegers K) a
-  have hxu : IsUnit x := by
-    by_contra h
-    exact ha0 (Ideal.Quotient.eq_zero_iff_mem.mpr h)
+  have hxu : IsUnit x := (IsLocalRing.residue_ne_zero_iff_isUnit x).mp ha0
   refine ⟨hxu.unit, fun ⟨d, hd⟩ ↦ ?_⟩
   rw [IsUnit.unit_spec] at hd
   -- a square root of a unit has valuation `1`, because the value group is torsion-free
-  have hx1 : Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) x) = 1 := by
-    rw [show x = (hxu.unit : v.adicCompletionIntegers K) from hxu.unit_spec.symm]
-    exact (Valuation.valuationSubring.integers (v := Valued.v)).valuation_unit hxu.unit
+  have hx1 : Valued.v (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) x) = 1 :=
+    hint.isUnit_iff_valuation_eq_one.mp hxu
   rw [hd, map_mul] at hx1
   have hd1 : Valued.v d = 1 :=
     le_antisymm (mul_self_le_one_iff.mp hx1.le) (one_le_mul_self_iff.mp hx1.ge)
   -- hence it lies in `𝒪_v` and reduces to a square root of the non-square
   have hdmem : d ∈ v.adicCompletionIntegers K := (mem_adicCompletionIntegers R K v).mpr hd1.le
-  have hinj : Function.Injective
-      (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K)) :=
-    fun a b h ↦ Subtype.ext h
   have hx_eq : x = (⟨d, hdmem⟩ : v.adicCompletionIntegers K) * ⟨d, hdmem⟩ :=
-    hinj (by rw [map_mul]; exact hd)
+    hint.hom_inj (by rw [map_mul]; exact hd)
   exact ha ⟨IsLocalRing.residue _ ⟨d, hdmem⟩, by rw [hx_eq, map_mul]⟩
 
 end IsDedekindDomain.HeightOneSpectrum


### PR DESCRIPTION
At a place `v` with finite residue field and `2 ∉ v`, the ring of integers of `K_v` carries a unit
that is not a square in `K_v`:

```lean
theorem exists_unit_not_isSquare [Finite (R ⧸ v.asIdeal)] (hv2 : (2 : R) ∉ v.asIdeal) :
    ∃ c : (v.adicCompletionIntegers K)ˣ,
      ¬ IsSquare (algebraMap (v.adicCompletionIntegers K) (v.adicCompletion K) c)
```

Any lift of a non-square of the residue field works. A square root in `K_v` would have valuation
`1`, hence lie in `𝒪_v`, and would then reduce to a square root of the non-square. The residue field
of `𝒪_v` is the residue field of `v` via `residueFieldEquivAdicCompletionIntegers`, so the
hypothesis `2 ∉ v` transports to odd residue characteristic; that step is split out as
`ringChar_residueField_adicCompletionIntegers_ne_two`, a reusable statement in its own right.

## Round 1 review findings, both fixed

`reuse` and `proof-quality` requested changes at head `81ba2059a`; the other eight rubrics approved.
Both findings had the same root — the proof was re-deriving facts that Mathlib already states about
this ring — so both are answered by taking them from the API instead.

* **reuse (`:350`)** — `hxu : IsUnit x` was converting non-unit membership into a vanishing residue
  by hand. It is now `(IsLocalRing.residue_ne_zero_iff_isUnit x).mp ha0`.
* **proof-quality (`:320`, `:330`, `:356`)** — the three undocumented `show` bridges are gone rather
  than documented. The two in `ringChar_residueField_adicCompletionIntegers_ne_two` disappear when
  the contraction is run forwards, so `map_ofNat` applies as an ordinary left-to-right `rw`; the one
  in `exists_unit_not_isSquare` disappears because `Valuation.Integers.isUnit_iff_valuation_eq_one`
  is already stated about `algebraMap`, so `x` never has to be rewritten into `hxu.unit`.
* **proof-quality (`:363`)** — `hinj := fun a b h ↦ Subtype.ext h` did rely on the algebra map
  unfolding definitionally to the subtype inclusion. It is now `hint.hom_inj`, the `Integers`
  structure's own injectivity field.

The last two both come from `adicCompletionIntegers.integers K v`, Mathlib's witness that `𝒪_v` is
the ring of integers of `Valued.v` — so one named `have` now supplies both the injectivity of
`𝒪_v → K_v` and the characterization of its units, replacing an ad-hoc `Valuation.valuationSubring`
instantiation. Net **−10 lines**; no statement changed.

## Why this is in scope now

`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, lines 813–822 — the "Explicit 2-descent (core,
this layer)" bullet. The repository rule admits *a prerequisite that a specific target needs*, and
this is one: the local image count at a good odd place needs a non-square unit to separate the two
square classes of `𝒪_v`.

**Stated plainly: there is no in-repository consumer yet.** The consumers are EC-14a, EC-14b, EC-12c
and EC-15, none of which has landed. I am not asking for an exception — this is the same position,
in the same file, on the same roadmap line, as the six sibling exports of this substrate that have
already merged: #4864, #4867 and #5061 (that last one 10/10 earlier today). This PR completes that
substrate; it is its seventh and final export, and the file's own `## Roadmap` section already
carries the argument for the group.

## Two departures from the source proof

Both are recorded in the module's `## Provenance`, which also gains this declaration — the
declaration list there is part of the attribution, not decoration.

1. The source contracts the maximal ideal with its own `comap_maximalIdeal_adicCompletionIntegers`.
   This repository states that as `under_maximalIdeal_adicCompletionIntegers`
   (`AdicValuation/Completion.lean:49`); it is the same statement, since `Ideal.under R I` is by
   definition `I.comap (algebraMap R S)`. #5061 needed the same rename.
2. Where the source derives `v d = 1` from a square by manipulating `WithZero.log` over five lines,
   this uses Mathlib's `mul_self_le_one_iff` and `one_le_mul_self_iff`
   (`Algebra/Order/Monoid/Defs.lean:116,:124`), which state the same fact about the ordered value
   monoid in one line.

## Prior art

`exists_unit_not_isSquare` is absent from `main` **and** from the pinned Mathlib, measured by a
compiled name probe against the built environment — not a name grep — with every positive control
resolving and every negative control failing. Each remaining input resolves:
`FiniteField.exists_nonsquare`, `IsLocalRing.residue_surjective`,
`IsLocalRing.residue_ne_zero_iff_isUnit`, `mem_adicCompletionIntegers` and
`adicCompletionIntegers.integers` (with `Valuation.Integers.isUnit_iff_valuation_eq_one` and its
`hom_inj` field) in Mathlib, and `residueFieldEquivAdicCompletionIntegers` on `main`.

## Gate

`lake build` of the changed module: **`Build completed successfully (3341 jobs)`**, olean written,
**zero** error/warning/info lines, at head `0bc2dc202`. The module is a **leaf** — nothing in
`TauCeti/` imports it — so the blast radius is exactly this file, and the 3341 job count is
unchanged from the round-1 gate because the round adds no imports. No new `simp` attributes, no new
definitions, no line over 100 codepoints. Both proofs are well under the 50-line ceiling: counted
from the `theorem` keyword to the last line of the proof they are **14** and **28** lines, down from
21 and 31 at the round-1 head. None of this module's imports moved on `main` since the base, and
there is no pin bump in that range.

`scripts/lint-env.sh` was **not** run locally: it generates a driver importing every `TauCeti`
module, so it needs a full library build, which the standing build policy forbids. CI's `pr-build`
runs it. The change adds no attributes and no new normal forms, so the `#lint` set has nothing new
to judge; both new declarations carry docstrings.

Roadmap: EllipticCurves
