### PR TITLE
improve(Flat): use the Function.Exact API in QuotientRegular, and name the hypothesis

### DIFF
--- a/TauCeti/RingTheory/Flat/QuotientRegular.lean
+++ b/TauCeti/RingTheory/Flat/QuotientRegular.lean
@@ -10,10 +10,10 @@ public import Mathlib.RingTheory.Ideal.Quotient.Operations
 import Mathlib.LinearAlgebra.TensorProduct.RightExactness
 
 /-!
-# Flatness of a quotient by a universally regular element
+# Flatness of `B ⧸ (g)` when `g` acts injectively on each `(R ⧸ I) ⊗[R] B`
 
 Let `B` be a flat algebra over a commutative ring `R` and `g ∈ B`. If multiplication by `g` on
-`R ⧸ I ⊗[R] B` is injective for every finitely generated ideal `I` of `R`, then `B ⧸ (g)` is a
+`(R ⧸ I) ⊗[R] B` is injective for every finitely generated ideal `I` of `R`, then `B ⧸ (g)` is a
 flat `R`-module.
 
 This is the claim inside Wedhorn's proof of Lemma 8.31(2): for `B = A⟨X⟩` over a complete
@@ -22,7 +22,7 @@ multiplication by `g` is injective on `M⟨X⟩ = M ⊗[A] A⟨X⟩` for every f
 in particular for every `M = A ⧸ I`, which is all the argument uses. Wedhorn proves the claim
 with the long exact `Tor` sequence. What the sequence encodes is a diagram chase, and that chase
 is what is carried out here, against Mathlib's ideal criterion for flatness: `B ⧸ (g)` is flat
-once `I ⊗[R] B ⧸ (g) → R ⊗[R] B ⧸ (g)` is injective for every finitely generated ideal `I`.
+once `I ⊗[R] (B ⧸ (g)) → R ⊗[R] (B ⧸ (g))` is injective for every finitely generated ideal `I`.
 
 ## Main results
 
@@ -30,16 +30,16 @@ once `I ⊗[R] B ⧸ (g) → R ⊗[R] B ⧸ (g)` is injective for every finitely
 
 ## Implementation notes
 
-The regularity hypothesis is asked only on `R ⧸ I ⊗[R] B` for finitely generated ideals `I`,
-which is exactly what the chase consumes; a hypothesis on every finitely generated module, as
-Wedhorn states it, specialises to this. It is stated with the coefficient module on the left,
+The hypothesis is asked only on `(R ⧸ I) ⊗[R] B` for finitely generated ideals `I`, which is
+exactly what the chase consumes; a hypothesis on every finitely generated module, as Wedhorn
+states it, specialises to this. It is stated with the coefficient module on the left,
 matching the orientation of Mathlib's `Module.Flat.iff_rTensor_injective`.
 
-The chase, for a finitely generated ideal `I`: an element of `I ⊗ B ⧸ (g)` killed in
-`R ⊗ B ⧸ (g)` lifts to `I ⊗ B`, is there the image of `g` times some `w` in `R ⊗ B`, and
-regularity of `g` on `R ⧸ I ⊗ B` shows that `w` comes from `I ⊗ B`, so the element is `g` times
-an element of `I ⊗ B` and dies in `I ⊗ B ⧸ (g)`. Flatness of `B` enters twice: as exactness of
-`I ⊗ B → R ⊗ B → R ⧸ I ⊗ B`, and as injectivity of `I ⊗ B → R ⊗ B`.
+The chase, for a finitely generated ideal `I`: an element of `I ⊗ (B ⧸ (g))` killed in
+`R ⊗ (B ⧸ (g))` lifts to `I ⊗ B`, is there the image of `g` times some `w` in `R ⊗ B`, and
+injectivity of `g` on `(R ⧸ I) ⊗ B` shows that `w` comes from `I ⊗ B`, so the element is `g`
+times an element of `I ⊗ B` and dies in `I ⊗ (B ⧸ (g))`. Flatness of `B` enters twice: as
+exactness of `I ⊗ B → R ⊗ B → (R ⧸ I) ⊗ B`, and as injectivity of `I ⊗ B → R ⊗ B`.
 
 ## References
 
@@ -54,11 +54,11 @@ namespace Module.Flat
 
 variable {R B : Type*} [CommRing R] [CommRing B] [Algebra R B]
 
-/-- **A flat algebra modulo a universally regular element is flat.** Let `B` be a flat
-`R`-algebra and `g ∈ B`. If `id ⊗ (g • ·) : R ⧸ I ⊗[R] B → R ⧸ I ⊗[R] B` is injective for every
-finitely generated ideal `I`, then `B ⧸ (g)` is a flat `R`-module. This is the `Tor`-sequence
-step of Wedhorn's Lemma 8.31(2); a consumer holding injectivity for every finitely generated
-module, as Wedhorn states it, passes it at `M = R ⧸ I`. -/
+/-- **A flat algebra modulo an element acting injectively on each `(R ⧸ I) ⊗[R] B` is flat.**
+Let `B` be a flat `R`-algebra and `g ∈ B`. If `id ⊗ (g • ·) : (R ⧸ I) ⊗[R] B → (R ⧸ I) ⊗[R] B` is
+injective for every finitely generated ideal `I`, then `B ⧸ (g)` is a flat `R`-module. This is the
+`Tor`-sequence step of Wedhorn's Lemma 8.31(2); a consumer holding injectivity for every finitely
+generated module, as Wedhorn states it, passes it at `M = R ⧸ I`. -/
 theorem quotient_span_singleton_of_lTensor_mulLeft_injective [Flat R B] (g : B)
     (hg : ∀ ⦃I : Ideal R⦄, I.FG →
       Function.Injective (LinearMap.lTensor (R ⧸ I) (LinearMap.mulLeft R g))) :
@@ -72,11 +72,9 @@ theorem quotient_span_singleton_of_lTensor_mulLeft_injective [Flat R B] (g : B)
     simp only [hπ, AlgHom.toLinearMap_apply, Ideal.Quotient.mkₐ_eq_mk,
       Ideal.Quotient.eq_zero_iff_mem, Ideal.mem_span_singleton', Set.mem_range, hv,
       LinearMap.mulLeft_apply]
-    exact ⟨fun ⟨a, ha⟩ ↦ ⟨a, by rw [mul_comm]; exact ha⟩,
-      fun ⟨a, ha⟩ ↦ ⟨a, by rw [mul_comm]; exact ha⟩⟩
-  have hπv : π ∘ₗ v = 0 := LinearMap.ext fun x ↦ hexact.apply_apply_eq_zero x
-  have hqι : I.mkQ ∘ₗ I.subtype = 0 :=
-    LinearMap.ext fun x ↦ (Submodule.Quotient.mk_eq_zero I).mpr x.2
+    exact exists_congr fun a ↦ by rw [mul_comm]
+  have hπv : π ∘ₗ v = 0 := hexact.linearMap_comp_eq_zero
+  have hqι : I.mkQ ∘ₗ I.subtype = 0 := (LinearMap.exact_subtype_mkQ I).linearMap_comp_eq_zero
   rw [injective_iff_map_eq_zero]
   intro z hz
   obtain ⟨z', rfl⟩ := LinearMap.lTensor_surjective I (g := π) Ideal.Quotient.mk_surjective z
@@ -85,7 +83,7 @@ theorem quotient_span_singleton_of_lTensor_mulLeft_injective [Flat R B] (g : B)
     rwa [← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor, ← LinearMap.rTensor_comp_lTensor,
       LinearMap.comp_apply]
   obtain ⟨w, hw⟩ := ((lTensor_exact R hexact) _).mp h1
-  -- The image of `w` in `R ⧸ I ⊗ B` is killed by `g`, hence zero, so `w` comes from `I ⊗ B`.
+  -- The image of `w` in `(R ⧸ I) ⊗ B` is killed by `g`, hence zero, so `w` comes from `I ⊗ B`.
   have h2 : LinearMap.lTensor (R ⧸ I) v (LinearMap.rTensor B I.mkQ w) = 0 := by
     rw [← LinearMap.comp_apply, LinearMap.lTensor_comp_rTensor, ← LinearMap.rTensor_comp_lTensor,
       LinearMap.comp_apply, hw, ← LinearMap.comp_apply, ← LinearMap.rTensor_comp, hqι,
@@ -94,7 +92,7 @@ theorem quotient_span_singleton_of_lTensor_mulLeft_injective [Flat R B] (g : B)
     ((injective_iff_map_eq_zero _).mp (hg hI) _ h2)
   -- Flatness of `B` makes `I ⊗ B → R ⊗ B` injective, so `z' = g • z₀`.
   have h4 : LinearMap.lTensor I v z₀ = z' :=
-    rTensor_preserves_injective_linearMap I.subtype Subtype.val_injective <| by
+    rTensor_preserves_injective_linearMap I.subtype I.injective_subtype <| by
       rw [← LinearMap.comp_apply, LinearMap.rTensor_comp_lTensor, ← LinearMap.lTensor_comp_rTensor,
         LinearMap.comp_apply, hz₀, hw]
   rw [← h4, ← LinearMap.comp_apply, ← LinearMap.lTensor_comp, hπv, LinearMap.lTensor_zero,


### PR DESCRIPTION
Post-merge review of #4644 listed five improvements to `TauCeti/RingTheory/Flat/QuotientRegular.lean`,
all of them replacing something hand-derived with API that already exists, or saying plainly what the
hypothesis is. Statement, name and signature of the one theorem are unchanged.

Roadmap: AdicSpaces

Attribution only — this improves already-merged code, which `.claude/CLAUDE.md` puts in scope with no
fresh roadmap claim; the diff adds and removes no declaration. `AdicSpaces` is the roadmap chiefly
motivating the file, verified from the material at roadmap `origin/main` rather than inherited from a
bead label: `AdicSpaces/README.md:563-567` reads "Lemma 8.31: prove that `A⟨X⟩` is faithfully flat
over `A`, and that the quotients `A⟨X⟩/(f-X)`, `A⟨X⟩/(1-fX)` …" — which is exactly this file's
subject, as its own module docstring says ("the claim inside Wedhorn's proof of Lemma 8.31(2)").

## The change

One file, +17 / −18, no import added, no declaration added or removed.

**Existing API instead of hand-derived facts.**

* `hπv : π ∘ₗ v = 0` was `LinearMap.ext fun x ↦ hexact.apply_apply_eq_zero x` — a pointwise argument
  for a fact `Function.Exact` states directly. It is `hexact.linearMap_comp_eq_zero`
  (`Mathlib/Algebra/Exact/Basic.lean:315`).
* `hqι : I.mkQ ∘ₗ I.subtype = 0` was the same shape over `Submodule.Quotient.mk_eq_zero`. It is
  `(LinearMap.exact_subtype_mkQ I).linearMap_comp_eq_zero` — the same lemma applied to the exactness
  Mathlib already provides for a submodule and its quotient.
* `rTensor_preserves_injective_linearMap I.subtype Subtype.val_injective` relied on an undocumented
  defeq between `I.subtype` and `Subtype.val`. It now passes `I.injective_subtype`
  (`Submodule.injective_subtype`), which is the lemma actually about this map.

**One tactic simplification.** The exactness closure was a symmetric pair of anonymous constructors,
each rebuilding the witness to apply `mul_comm` in one direction:

```lean
exact ⟨fun ⟨a, ha⟩ ↦ ⟨a, by rw [mul_comm]; exact ha⟩,
  fun ⟨a, ha⟩ ↦ ⟨a, by rw [mul_comm]; exact ha⟩⟩
```

Both sides quantify over the same witness and differ only by commutativity, so the whole thing is
`exact exists_congr fun a ↦ by rw [mul_comm]`.

**Two documentation fixes, and the second is a correctness issue in prose.**

* Mixed quotient/tensor formulas are now parenthesised in the module docstring, the theorem docstring
  and the proof comments. `⧸` binds *looser* than `⊗`, so the previous `R ⧸ I ⊗[R] B` reads as
  `R ⧸ (I ⊗[R] B)` — not the intended `(R ⧸ I) ⊗[R] B`. Likewise `I ⊗ B ⧸ (g)` is now
  `I ⊗ (B ⧸ (g))`.
* The coined term "universally regular" is dropped from the module title and the theorem headline in
  favour of the hypothesis itself: `g` acts injectively on `(R ⧸ I) ⊗[R] B` for every finitely
  generated ideal `I`. That is what is assumed and what the proof consumes.

**Deliberately not done.** The review also suggested extracting `hexact` as a named lemma. It has two
use sites inside this one proof, so a private helper would be the one-call-site-shaped surface the
`reuse` rubric objects to; the closure it wanted cleaned up is cleaned up in place instead. And a
separate finding asking to change "complete noetherian Tate ring" to "strongly noetherian" is
**wrong** and was not applied: Wedhorn's Lemma 8.31 reads verbatim "Let `A` be a noetherian complete
Tate ring" (arXiv:1910.05934v1); *strongly* noetherian is Proposition 8.30's hypothesis.

## Checks

* `lake build TauCeti.RingTheory.Flat.QuotientRegular TauCeti.RingTheory.Huber.Restricted.Laurent`:
  exit `0`, `Build completed successfully (2426 jobs)`, zero `error:` / `warning:` / `info:`, with
  `✔ Built …Flat.QuotientRegular (73s)` in the log so the target was really elaborated.
* `lake exe runLinter TauCeti.RingTheory.Flat.QuotientRegular`: exit `0`, `Linting passed`.
* **The importer, stated precisely.** `Huber/Restricted/Laurent.lean:9` carries
  `public import TauCeti.RingTheory.Flat.QuotientRegular`, so I requested it as a build target too;
  lake accepted it and exited 0 without re-elaborating it. That is consistent with the diff changing
  no exported signature — only proof internals and docstrings — and the change cannot affect a
  consumer by construction, since the theorem's statement, name and binders are untouched. Flagging
  it rather than asserting a rebuild I did not observe. (The bead recorded "no importers yet"; that
  was true when filed on 2026-08-26 and is now stale.)
* No line over 100 codepoints (max 99), measured in codepoints rather than bytes.
* Rebased onto `origin/main` immediately before pushing: 0 behind / 1 ahead. The two commits merged
  meanwhile touch `Data/Int/MulPred`, `GroupTheory/TitsSystem/*`, `Matrix/…/Diagonal/TitsSystem` and
  `LowDimTopology/Plumbing/*`; none appears in the 2426-module closure the build log enumerates
  (positive control: the target module appears 3 times), so the rebase cannot have invalidated it.
* `scripts/lint-env.sh` not run — it needs a fully built library, which the no-local-full-builds rule
  forbids here; CI's `pr-build` runs it, and it remains the fuller check because of its grandfathered
  baseline, which per-module `runLinter` has no notion of.
