### PR TITLE
feat: add the cotangent Liouville form

### DIFF
--- a/TauCeti/Geometry/Symplectic/Cotangent/Liouville.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/Liouville.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Calculus.DifferentialForm.Basic
+public import TauCeti.Geometry.Symplectic.Cotangent.Basic
+
+import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
+import TauCeti.Geometry.Symplectic.SymplecticTransport
+
+/-!
+# The Liouville form on a linear cotangent space
+
+The normed linear cotangent space `V × V'`, formed using the continuous dual, carries the
+tautological, or Liouville, one-form
+
+`λ_(q,p)(δq,δp) = p(δq)`.
+
+This file constructs that differential form and proves the sign convention already used by
+`TauCeti.cotangentSymplecticForm`:
+
+`strongDualCotangentSymplecticForm = -dλ`.
+
+Thus the canonical symplectic form on the linear cotangent model is exact. This is the
+finite-dimensional model for the exact cotangent-bundle geometry used in Lagrangian Floer
+homology. The construction follows McDuff--Salamon, *Introduction to Symplectic Topology*,
+Section 3.2.
+
+## Main declarations
+
+* `TauCeti.cotangentLiouvilleForm`: the tautological one-form on `V × V*`.
+* `TauCeti.cotangentLiouvilleForm_apply`: its evaluation formula.
+* `TauCeti.differentiableAt_cotangentLiouvilleForm`: differentiability of the form-valued map.
+* `TauCeti.strongDualCotangentSymplecticForm`: the canonical symplectic form on `V × V'`.
+* `TauCeti.extDeriv_cotangentLiouvilleForm_apply`: the coordinate formula for the exterior
+  derivative.
+* `TauCeti.neg_extDeriv_cotangentLiouvilleForm_apply`: the exactness identity `ω = -dλ`.
+-/
+
+public section
+
+open ContinuousAlternatingMap
+
+noncomputable section
+
+namespace TauCeti
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+
+private noncomputable def cotangentLiouvilleFormCLM :
+    (V × StrongDual ℝ V) →L[ℝ]
+      ((V × StrongDual ℝ V) [⋀^Fin 1]→L[ℝ] ℝ) :=
+  (LinearIsometryEquiv.toContinuousLinearEquiv <|
+    ContinuousAlternatingMap.ofSubsingletonLIE (𝕜 := ℝ)
+      (E := V × StrongDual ℝ V) (F := ℝ) (0 : Fin 1)).toContinuousLinearMap.comp <|
+    ((ContinuousLinearMap.compL ℝ (V × StrongDual ℝ V) V ℝ).flip
+      (ContinuousLinearMap.fst ℝ V (StrongDual ℝ V))).comp <|
+        ContinuousLinearMap.snd ℝ V (StrongDual ℝ V)
+
+/-- The tautological one-form on the linear cotangent space. At `(q, p)`, it evaluates a tangent
+vector `(δq, δp)` by `p(δq)`. -/
+noncomputable def cotangentLiouvilleForm (x : V × StrongDual ℝ V) :
+    (V × StrongDual ℝ V) [⋀^Fin 1]→L[ℝ] ℝ :=
+  cotangentLiouvilleFormCLM x
+
+/-- The Liouville form evaluates by pairing the covector at the base point with the horizontal
+component of the tangent vector. -/
+@[simp]
+lemma cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
+    (v : Fin 1 → V × StrongDual ℝ V) :
+    cotangentLiouvilleForm x v = x.2 (v 0).1 := by
+  simp [cotangentLiouvilleForm, cotangentLiouvilleFormCLM]
+
+/-- The Liouville form vanishes at every point of the zero section. -/
+@[simp]
+lemma cotangentLiouvilleForm_zero_covector (q : V) :
+    cotangentLiouvilleForm (q, 0) = 0 := by
+  ext v
+  simp
+
+/-- The Liouville form vanishes on vertical tangent vectors. -/
+lemma cotangentLiouvilleForm_vertical_apply (x : V × StrongDual ℝ V)
+    (α : StrongDual ℝ V) :
+    cotangentLiouvilleForm x (fun _ ↦ (0, α)) = 0 := by
+  simp
+
+/-- The Liouville one-form is differentiable as a form-valued function of its base point. -/
+lemma differentiableAt_cotangentLiouvilleForm (x : V × StrongDual ℝ V) :
+    DifferentiableAt ℝ (cotangentLiouvilleForm (V := V)) x := by
+  have heq : cotangentLiouvilleForm (V := V) = cotangentLiouvilleFormCLM := by
+    funext y
+    rfl
+  have h : HasFDerivAt (cotangentLiouvilleFormCLM (V := V))
+      (cotangentLiouvilleFormCLM (V := V)) x :=
+    ContinuousLinearMap.hasFDerivAt _
+  rw [heq]
+  exact h.differentiableAt
+
+/-- The scalar coefficient obtained by evaluating the Liouville form on a fixed vector has the
+expected derivative: only the covector coordinate of the base point varies. -/
+private lemma hasFDerivAt_cotangentLiouvilleForm_apply
+    (v : Fin 1 → V × StrongDual ℝ V)
+    (x : V × StrongDual ℝ V) :
+    HasFDerivAt (fun y ↦ cotangentLiouvilleForm y v)
+      ((ContinuousLinearMap.apply ℝ ℝ (v 0).1).comp
+        (ContinuousLinearMap.snd ℝ V (StrongDual ℝ V))) x := by
+  let L := (ContinuousLinearMap.apply ℝ ℝ (v 0).1).comp
+    (ContinuousLinearMap.snd ℝ V (StrongDual ℝ V))
+  have hfun : (fun y ↦ cotangentLiouvilleForm y v) = L := by
+    funext y
+    simp [L]
+  rw [hfun]
+  exact L.hasFDerivAt
+
+/-- The exterior derivative of the Liouville form is the negative canonical cotangent symplectic
+form. -/
+lemma extDeriv_cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
+    (v : Fin 2 → V × StrongDual ℝ V) :
+    extDeriv cotangentLiouvilleForm x v =
+      (v 0).2 (v 1).1 - (v 1).2 (v 0).1 := by
+  rw [extDeriv_apply]
+  · rw [Fin.sum_univ_two]
+    simp only [Fin.isValue, Fin.val_zero, pow_zero, one_smul,
+      Fin.val_one, pow_one, neg_smul, one_smul]
+    rw [(hasFDerivAt_cotangentLiouvilleForm_apply (Fin.removeNth 0 v) x).fderiv,
+      (hasFDerivAt_cotangentLiouvilleForm_apply (Fin.removeNth 1 v) x).fderiv]
+    simp [Fin.removeNth, sub_eq_add_neg]
+  · exact differentiableAt_cotangentLiouvilleForm x
+
+section FiniteDimensional
+
+variable [FiniteDimensional ℝ V]
+
+/-- Identify the normed linear cotangent space, formed with the continuous dual, with the
+algebraic linear cotangent space. -/
+noncomputable def strongDualCotangentEquiv :
+    (V × StrongDual ℝ V) ≃ₗ[ℝ] (V × Module.Dual ℝ V) :=
+  (LinearEquiv.refl ℝ V).prodCongr LinearMap.toContinuousLinearMap.symm
+
+/-- The canonical symplectic form on a finite-dimensional normed linear cotangent space. This
+is the algebraic canonical form transported from `V × Module.Dual ℝ V` to
+`V × StrongDual ℝ V`. -/
+noncomputable def strongDualCotangentSymplecticForm : SymplecticForm (V × StrongDual ℝ V) :=
+  (cotangentSymplecticForm (V := V)).transport (strongDualCotangentEquiv (V := V)).symm
+
+/-- The canonical symplectic form on the continuous-dual model has the usual evaluation formula. -/
+@[simp]
+lemma strongDualCotangentSymplecticForm_apply (x y : V × StrongDual ℝ V) :
+    strongDualCotangentSymplecticForm x y = y.2 x.1 - x.2 y.1 := by
+  simp [strongDualCotangentSymplecticForm, strongDualCotangentEquiv]
+
+/-- The canonical cotangent symplectic form is minus the exterior derivative of the Liouville
+form, with the identity stated in the direction of the convention `ω = -dλ`. -/
+lemma neg_extDeriv_cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
+    (v : Fin 2 → V × StrongDual ℝ V) :
+    -extDeriv cotangentLiouvilleForm x v =
+      strongDualCotangentSymplecticForm (v 0) (v 1) := by
+  rw [extDeriv_cotangentLiouvilleForm_apply,
+    strongDualCotangentSymplecticForm_apply]
+  ring
+
+end FiniteDimensional
+
+end TauCeti
+
+end

--- a/TauCeti/Geometry/Symplectic/Cotangent/Liouville.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/Liouville.lean
@@ -6,10 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Calculus.DifferentialForm.Basic
-public import TauCeti.Geometry.Symplectic.Cotangent.Basic
-
-public import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
-import TauCeti.Geometry.Symplectic.SymplecticTransport
+public import TauCeti.Geometry.Symplectic.Cotangent.StrongDual
 
 /-!
 # The Liouville form on a linear cotangent space
@@ -34,7 +31,6 @@ Section 3.2.
 * `TauCeti.cotangentLiouvilleForm`: the tautological one-form on `V × StrongDual ℝ V`.
 * `TauCeti.cotangentLiouvilleForm_apply`: its evaluation formula.
 * `TauCeti.differentiableAt_cotangentLiouvilleForm`: differentiability of the form-valued map.
-* `TauCeti.strongDualCotangentSymplecticForm`: the canonical symplectic form on `V × V'`.
 * `TauCeti.extDeriv_cotangentLiouvilleForm_apply`: the coordinate formula for the exterior
   derivative.
 * `TauCeti.neg_extDeriv_cotangentLiouvilleForm`: the exactness identity `ω = -dλ`, and
@@ -75,19 +71,6 @@ lemma cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
     cotangentLiouvilleForm x v = x.2 (v 0).1 := by
   simp [cotangentLiouvilleForm, cotangentLiouvilleFormCLM]
 
-/-- The Liouville form vanishes at every point of the zero section. -/
-@[simp]
-lemma cotangentLiouvilleForm_zero_covector (q : V) :
-    cotangentLiouvilleForm (q, 0) = 0 := by
-  ext v
-  simp
-
-/-- The Liouville form vanishes on vertical tangent vectors. -/
-lemma cotangentLiouvilleForm_vertical_apply (x : V × StrongDual ℝ V)
-    (α : StrongDual ℝ V) :
-    cotangentLiouvilleForm x (fun _ ↦ (0, α)) = 0 := by
-  simp
-
 /-- The Liouville one-form is differentiable as a form-valued function of its base point. -/
 lemma differentiableAt_cotangentLiouvilleForm (x : V × StrongDual ℝ V) :
     DifferentiableAt ℝ (cotangentLiouvilleForm (V := V)) x := by
@@ -118,6 +101,7 @@ private lemma hasFDerivAt_cotangentLiouvilleForm_apply
 
 /-- The exterior derivative of the Liouville form is the negative canonical cotangent symplectic
 form. -/
+@[simp]
 lemma extDeriv_cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
     (v : Fin 2 → V × StrongDual ℝ V) :
     extDeriv cotangentLiouvilleForm x v =
@@ -130,40 +114,6 @@ lemma extDeriv_cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
       (hasFDerivAt_cotangentLiouvilleForm_apply (Fin.removeNth 1 v) x).fderiv]
     simp [Fin.removeNth, sub_eq_add_neg]
   · exact differentiableAt_cotangentLiouvilleForm x
-
-section FiniteDimensional
-
-variable [FiniteDimensional ℝ V]
-
-/-- Identify the normed linear cotangent space, formed with the continuous dual, with the
-algebraic linear cotangent space. -/
-noncomputable def strongDualCotangentEquiv :
-    (V × StrongDual ℝ V) ≃ₗ[ℝ] (V × Module.Dual ℝ V) :=
-  (LinearEquiv.refl ℝ V).prodCongr LinearMap.toContinuousLinearMap.symm
-
-/-- The identification of cotangent models forgets the continuity of the covector. -/
-@[simp]
-lemma strongDualCotangentEquiv_apply (q : V) (p : StrongDual ℝ V) :
-    strongDualCotangentEquiv (q, p) = (q, (p : Module.Dual ℝ V)) := by
-  simp [strongDualCotangentEquiv]
-
-/-- The inverse identification of cotangent models promotes a covector to a continuous one. -/
-@[simp]
-lemma strongDualCotangentEquiv_symm_apply (q : V) (p : Module.Dual ℝ V) :
-    strongDualCotangentEquiv.symm (q, p) = (q, LinearMap.toContinuousLinearMap p) := by
-  simp [strongDualCotangentEquiv]
-
-/-- The canonical symplectic form on a finite-dimensional normed linear cotangent space. This
-is the algebraic canonical form transported from `V × Module.Dual ℝ V` to
-`V × StrongDual ℝ V`. -/
-noncomputable def strongDualCotangentSymplecticForm : SymplecticForm (V × StrongDual ℝ V) :=
-  (cotangentSymplecticForm (V := V)).transport (strongDualCotangentEquiv (V := V)).symm
-
-/-- The canonical symplectic form on the continuous-dual model has the usual evaluation formula. -/
-@[simp]
-lemma strongDualCotangentSymplecticForm_apply (x y : V × StrongDual ℝ V) :
-    strongDualCotangentSymplecticForm x y = y.2 x.1 - x.2 y.1 := by
-  simp [strongDualCotangentSymplecticForm, strongDualCotangentEquiv]
 
 /-- The canonical cotangent symplectic form is minus the exterior derivative of the Liouville
 form, with the identity stated in the direction of the convention `ω = -dλ`. -/
@@ -184,8 +134,6 @@ lemma neg_extDeriv_cotangentLiouvilleForm (x : V × StrongDual ℝ V) :
   funext v w
   rw [neg_extDeriv_cotangentLiouvilleForm_apply]
   simp
-
-end FiniteDimensional
 
 end TauCeti
 

--- a/TauCeti/Geometry/Symplectic/Cotangent/Liouville.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/Liouville.lean
@@ -8,7 +8,7 @@ module
 public import Mathlib.Analysis.Calculus.DifferentialForm.Basic
 public import TauCeti.Geometry.Symplectic.Cotangent.Basic
 
-import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
+public import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
 import TauCeti.Geometry.Symplectic.SymplecticTransport
 
 /-!
@@ -31,13 +31,14 @@ Section 3.2.
 
 ## Main declarations
 
-* `TauCeti.cotangentLiouvilleForm`: the tautological one-form on `V × V*`.
+* `TauCeti.cotangentLiouvilleForm`: the tautological one-form on `V × StrongDual ℝ V`.
 * `TauCeti.cotangentLiouvilleForm_apply`: its evaluation formula.
 * `TauCeti.differentiableAt_cotangentLiouvilleForm`: differentiability of the form-valued map.
 * `TauCeti.strongDualCotangentSymplecticForm`: the canonical symplectic form on `V × V'`.
 * `TauCeti.extDeriv_cotangentLiouvilleForm_apply`: the coordinate formula for the exterior
   derivative.
-* `TauCeti.neg_extDeriv_cotangentLiouvilleForm_apply`: the exactness identity `ω = -dλ`.
+* `TauCeti.neg_extDeriv_cotangentLiouvilleForm`: the exactness identity `ω = -dλ`, and
+  `TauCeti.neg_extDeriv_cotangentLiouvilleForm_apply`, its evaluation on a pair of vectors.
 -/
 
 public section
@@ -140,6 +141,18 @@ noncomputable def strongDualCotangentEquiv :
     (V × StrongDual ℝ V) ≃ₗ[ℝ] (V × Module.Dual ℝ V) :=
   (LinearEquiv.refl ℝ V).prodCongr LinearMap.toContinuousLinearMap.symm
 
+/-- The identification of cotangent models forgets the continuity of the covector. -/
+@[simp]
+lemma strongDualCotangentEquiv_apply (q : V) (p : StrongDual ℝ V) :
+    strongDualCotangentEquiv (q, p) = (q, (p : Module.Dual ℝ V)) := by
+  simp [strongDualCotangentEquiv]
+
+/-- The inverse identification of cotangent models promotes a covector to a continuous one. -/
+@[simp]
+lemma strongDualCotangentEquiv_symm_apply (q : V) (p : Module.Dual ℝ V) :
+    strongDualCotangentEquiv.symm (q, p) = (q, LinearMap.toContinuousLinearMap p) := by
+  simp [strongDualCotangentEquiv]
+
 /-- The canonical symplectic form on a finite-dimensional normed linear cotangent space. This
 is the algebraic canonical form transported from `V × Module.Dual ℝ V` to
 `V × StrongDual ℝ V`. -/
@@ -161,6 +174,16 @@ lemma neg_extDeriv_cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
   rw [extDeriv_cotangentLiouvilleForm_apply,
     strongDualCotangentSymplecticForm_apply]
   ring
+
+/-- Exactness with no tangent vectors supplied: at every base point, the negative exterior
+derivative of the Liouville form is the canonical symplectic form as a form on the tangent
+space. -/
+lemma neg_extDeriv_cotangentLiouvilleForm (x : V × StrongDual ℝ V) :
+    (fun v w ↦ -extDeriv cotangentLiouvilleForm x ![v, w]) =
+      ⇑(strongDualCotangentSymplecticForm (V := V)) := by
+  funext v w
+  rw [neg_extDeriv_cotangentLiouvilleForm_apply]
+  simp
 
 end FiniteDimensional
 

--- a/TauCeti/Geometry/Symplectic/Cotangent/Liouville.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/Liouville.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Calculus.DifferentialForm.Basic
 public import TauCeti.Geometry.Symplectic.Cotangent.StrongDual
+public import TauCeti.LinearAlgebra.BilinearForm.Multilinear
 
 /-!
 # The Liouville form on a linear cotangent space
@@ -21,20 +22,25 @@ This file constructs that differential form and proves the sign convention alrea
 
 `strongDualCotangentSymplecticForm = -dλ`.
 
-Thus the canonical symplectic form on the linear cotangent model is exact. This is the
-finite-dimensional model for the exact cotangent-bundle geometry used in Lagrangian Floer
-homology. The construction follows McDuff--Salamon, *Introduction to Symplectic Topology*,
-Section 3.2.
+Thus the canonical symplectic form on the linear cotangent model is exact. This is the linear
+(vector-space) model for the exact cotangent-bundle geometry used in Lagrangian Floer homology;
+nothing in this file assumes finite dimension. The construction follows McDuff--Salamon,
+*Introduction to Symplectic Topology*, Section 3.2.
 
 ## Main declarations
 
+* `TauCeti.cotangentLiouvilleFormCLM`: the Liouville form as a continuous linear map of the base
+  point, which is what makes it smooth.
 * `TauCeti.cotangentLiouvilleForm`: the tautological one-form on `V × StrongDual ℝ V`.
 * `TauCeti.cotangentLiouvilleForm_apply`: its evaluation formula.
-* `TauCeti.differentiableAt_cotangentLiouvilleForm`: differentiability of the form-valued map.
+* `TauCeti.contDiff_cotangentLiouvilleForm`: smoothness of the form-valued map, from which
+  `TauCeti.differentiable_cotangentLiouvilleForm` and
+  `TauCeti.differentiableAt_cotangentLiouvilleForm` follow.
 * `TauCeti.extDeriv_cotangentLiouvilleForm_apply`: the coordinate formula for the exterior
   derivative.
-* `TauCeti.neg_extDeriv_cotangentLiouvilleForm`: the exactness identity `ω = -dλ`, and
-  `TauCeti.neg_extDeriv_cotangentLiouvilleForm_apply`, its evaluation on a pair of vectors.
+* `TauCeti.neg_extDeriv_cotangentLiouvilleForm`: the exactness identity `ω = -dλ`, as an equality
+  of alternating two-forms, and `TauCeti.neg_extDeriv_cotangentLiouvilleForm_apply`, its
+  evaluation on a pair of tangent vectors.
 -/
 
 public section
@@ -47,7 +53,10 @@ namespace TauCeti
 
 variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
 
-private noncomputable def cotangentLiouvilleFormCLM :
+/-- The Liouville form read as a continuous linear map of the base point: `(q, p)` is sent to the
+one-form `(δq, δp) ↦ p(δq)`, which depends linearly and continuously on `(q, p)`. This packaging
+is what gives the smoothness of `TauCeti.cotangentLiouvilleForm`. -/
+noncomputable def cotangentLiouvilleFormCLM :
     (V × StrongDual ℝ V) →L[ℝ]
       ((V × StrongDual ℝ V) [⋀^Fin 1]→L[ℝ] ℝ) :=
   (LinearIsometryEquiv.toContinuousLinearEquiv <|
@@ -63,6 +72,13 @@ noncomputable def cotangentLiouvilleForm (x : V × StrongDual ℝ V) :
     (V × StrongDual ℝ V) [⋀^Fin 1]→L[ℝ] ℝ :=
   cotangentLiouvilleFormCLM x
 
+/-- The Liouville form is the underlying function of the continuous linear map
+`TauCeti.cotangentLiouvilleFormCLM`. -/
+lemma cotangentLiouvilleForm_eq_coe :
+    cotangentLiouvilleForm (V := V) = ⇑(cotangentLiouvilleFormCLM (V := V)) := by
+  funext y
+  rfl
+
 /-- The Liouville form evaluates by pairing the covector at the base point with the horizontal
 component of the tangent vector. -/
 @[simp]
@@ -71,17 +87,23 @@ lemma cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
     cotangentLiouvilleForm x v = x.2 (v 0).1 := by
   simp [cotangentLiouvilleForm, cotangentLiouvilleFormCLM]
 
+/-- The Liouville one-form is smooth as a form-valued function of its base point, being a
+continuous linear function of that point. -/
+lemma contDiff_cotangentLiouvilleForm {n : WithTop ℕ∞} :
+    ContDiff ℝ n (cotangentLiouvilleForm (V := V)) := by
+  rw [cotangentLiouvilleForm_eq_coe]
+  exact ContinuousLinearMap.contDiff _
+
 /-- The Liouville one-form is differentiable as a form-valued function of its base point. -/
+lemma differentiable_cotangentLiouvilleForm :
+    Differentiable ℝ (cotangentLiouvilleForm (V := V)) := by
+  rw [cotangentLiouvilleForm_eq_coe]
+  exact ContinuousLinearMap.differentiable _
+
+/-- The Liouville one-form is differentiable at every base point. -/
 lemma differentiableAt_cotangentLiouvilleForm (x : V × StrongDual ℝ V) :
-    DifferentiableAt ℝ (cotangentLiouvilleForm (V := V)) x := by
-  have heq : cotangentLiouvilleForm (V := V) = cotangentLiouvilleFormCLM := by
-    funext y
-    rfl
-  have h : HasFDerivAt (cotangentLiouvilleFormCLM (V := V))
-      (cotangentLiouvilleFormCLM (V := V)) x :=
-    ContinuousLinearMap.hasFDerivAt _
-  rw [heq]
-  exact h.differentiableAt
+    DifferentiableAt ℝ (cotangentLiouvilleForm (V := V)) x :=
+  differentiable_cotangentLiouvilleForm x
 
 /-- The scalar coefficient obtained by evaluating the Liouville form on a fixed vector has the
 expected derivative: only the covector coordinate of the base point varies. -/
@@ -99,8 +121,8 @@ private lemma hasFDerivAt_cotangentLiouvilleForm_apply
   rw [hfun]
   exact L.hasFDerivAt
 
-/-- The exterior derivative of the Liouville form is the negative canonical cotangent symplectic
-form. -/
+/-- Coordinate formula for the exterior derivative of the Liouville form, evaluated on two
+tangent vectors: `dλ_x(v, w) = δp_v(δq_w) - δp_w(δq_v)`. -/
 @[simp]
 lemma extDeriv_cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
     (v : Fin 2 → V × StrongDual ℝ V) :
@@ -125,14 +147,17 @@ lemma neg_extDeriv_cotangentLiouvilleForm_apply (x : V × StrongDual ℝ V)
     strongDualCotangentSymplecticForm_apply]
   ring
 
-/-- Exactness with no tangent vectors supplied: at every base point, the negative exterior
-derivative of the Liouville form is the canonical symplectic form as a form on the tangent
-space. -/
+/-- **Exactness of the canonical cotangent symplectic form.** At every base point, minus the
+exterior derivative of the Liouville form is `TauCeti.strongDualCotangentSymplecticForm`, as an
+equality of alternating two-forms on the tangent space. This is the convention `ω = -dλ`. -/
 lemma neg_extDeriv_cotangentLiouvilleForm (x : V × StrongDual ℝ V) :
-    (fun v w ↦ -extDeriv cotangentLiouvilleForm x ![v, w]) =
-      ⇑(strongDualCotangentSymplecticForm (V := V)) := by
-  funext v w
-  rw [neg_extDeriv_cotangentLiouvilleForm_apply]
+    -(extDeriv cotangentLiouvilleForm x).toAlternatingMap =
+      (strongDualCotangentSymplecticForm (V := V)).isAlt.toAlternatingMap := by
+  ext v
+  -- `SymplecticForm.isAlt` is stated for `LinearMap.BilinForm.IsAlt`, so the evaluation lemma is
+  -- applied as a term rather than rewritten with, to reach `LinearMap.IsAlt.toAlternatingMap`.
+  rw [LinearMap.IsAlt.toAlternatingMap_apply
+    (strongDualCotangentSymplecticForm (V := V)).isAlt v]
   simp
 
 end TauCeti

--- a/TauCeti/Geometry/Symplectic/Cotangent/StrongDual.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/StrongDual.lean
@@ -111,7 +111,6 @@ lemma strongDualCotangentEquiv_symm_apply (q : V) (p : Module.Dual ℝ V) :
 
 /-- The finite-dimensional identification of cotangent models preserves their canonical
 symplectic forms. -/
-@[simp]
 lemma cotangentSymplecticForm_strongDualCotangentEquiv_apply
     (x y : V × StrongDual ℝ V) :
     cotangentSymplecticForm (strongDualCotangentEquiv x) (strongDualCotangentEquiv y) =

--- a/TauCeti/Geometry/Symplectic/Cotangent/StrongDual.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/StrongDual.lean
@@ -27,6 +27,8 @@ model with the algebraic cotangent model `V × Module.Dual ℝ V`.
   `V × StrongDual ℝ V`.
 * `TauCeti.strongDualCotangentEquiv`: the finite-dimensional identification with
   `V × Module.Dual ℝ V`.
+* `TauCeti.cotangentSymplecticForm_strongDualCotangentEquiv_apply`: the identification
+  preserves the canonical symplectic forms.
 -/
 
 public section
@@ -40,34 +42,15 @@ variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
 /-- The bilinear form underlying the canonical symplectic form on
 `V × StrongDual ℝ V`. -/
 private def strongDualCotangentBilinForm :
-    LinearMap.BilinForm ℝ (V × StrongDual ℝ V) where
-  toFun x :=
-    { toFun := fun y ↦ y.2 x.1 - x.2 y.1
-      map_add' := by
-        intro y z
-        simp
-        ring
-      map_smul' := by
-        intro c y
-        simp
-        ring }
-  map_add' := by
-    intro x y
-    apply LinearMap.ext
-    intro z
-    simp
-    ring
-  map_smul' := by
-    intro c x
-    apply LinearMap.ext
-    intro y
-    simp
-    ring
+    LinearMap.BilinForm ℝ (V × StrongDual ℝ V) :=
+  (cotangentSymplecticForm (V := V)).toBilinForm.compl₁₂
+    (LinearMap.prodMap LinearMap.id (ContinuousLinearMap.coeLM ℝ))
+    (LinearMap.prodMap LinearMap.id (ContinuousLinearMap.coeLM ℝ))
 
 @[simp]
 private lemma strongDualCotangentBilinForm_apply (x y : V × StrongDual ℝ V) :
     strongDualCotangentBilinForm x y = y.2 x.1 - x.2 y.1 := by
-  rfl
+  simp [strongDualCotangentBilinForm]
 
 private lemma strongDualCotangentBilinForm_isAlt :
     (strongDualCotangentBilinForm (V := V)).IsAlt := by
@@ -102,7 +85,7 @@ noncomputable def strongDualCotangentSymplecticForm :
 @[simp]
 lemma strongDualCotangentSymplecticForm_apply (x y : V × StrongDual ℝ V) :
     strongDualCotangentSymplecticForm x y = y.2 x.1 - x.2 y.1 := by
-  rfl
+  exact strongDualCotangentBilinForm_apply x y
 
 section FiniteDimensional
 
@@ -125,6 +108,17 @@ lemma strongDualCotangentEquiv_apply (q : V) (p : StrongDual ℝ V) :
 lemma strongDualCotangentEquiv_symm_apply (q : V) (p : Module.Dual ℝ V) :
     strongDualCotangentEquiv.symm (q, p) = (q, LinearMap.toContinuousLinearMap p) := by
   simp [strongDualCotangentEquiv]
+
+/-- The finite-dimensional identification of cotangent models preserves their canonical
+symplectic forms. -/
+@[simp]
+lemma cotangentSymplecticForm_strongDualCotangentEquiv_apply
+    (x y : V × StrongDual ℝ V) :
+    cotangentSymplecticForm (strongDualCotangentEquiv x) (strongDualCotangentEquiv y) =
+      strongDualCotangentSymplecticForm x y := by
+  rcases x with ⟨q, p⟩
+  rcases y with ⟨r, s⟩
+  simp
 
 end FiniteDimensional
 

--- a/TauCeti/Geometry/Symplectic/Cotangent/StrongDual.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/StrongDual.lean
@@ -5,8 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
+public import Mathlib.Topology.Algebra.Module.FiniteDimension
 public import TauCeti.Geometry.Symplectic.Cotangent.Basic
+public import TauCeti.Geometry.Symplectic.SymplecticTransport
 
 import Mathlib.Analysis.LocallyConvex.SeparatingDual
 
@@ -18,8 +19,10 @@ the canonical symplectic form
 
 `ω((v, α), (w, β)) = β(v) - α(w)`.
 
-This file constructs the form directly and, in finite dimension, identifies the continuous-dual
-model with the algebraic cotangent model `V × Module.Dual ℝ V`.
+The form is obtained by restricting `TauCeti.cotangentSymplecticForm` along the coercion of the
+continuous dual into the algebraic dual, which is why the two models agree by construction; only
+nondegeneracy is new, and it comes from Hahn--Banach rather than from a basis. In finite
+dimension the two models are moreover identified as symplectic vector spaces.
 
 ## Main declarations
 
@@ -27,8 +30,8 @@ model with the algebraic cotangent model `V × Module.Dual ℝ V`.
   `V × StrongDual ℝ V`.
 * `TauCeti.strongDualCotangentEquiv`: the finite-dimensional identification with
   `V × Module.Dual ℝ V`.
-* `TauCeti.cotangentSymplecticForm_strongDualCotangentEquiv_apply`: the identification
-  preserves the canonical symplectic forms.
+* `TauCeti.isSymplectomorphism_strongDualCotangentEquiv`: that identification is a
+  symplectomorphism.
 -/
 
 public section
@@ -99,24 +102,23 @@ noncomputable def strongDualCotangentEquiv :
 
 /-- The identification of cotangent models forgets the continuity of the covector. -/
 @[simp]
-lemma strongDualCotangentEquiv_apply (q : V) (p : StrongDual ℝ V) :
-    strongDualCotangentEquiv (q, p) = (q, (p : Module.Dual ℝ V)) := by
+lemma strongDualCotangentEquiv_apply (x : V × StrongDual ℝ V) :
+    strongDualCotangentEquiv x = (x.1, (x.2 : Module.Dual ℝ V)) := by
   simp [strongDualCotangentEquiv]
 
 /-- The inverse identification of cotangent models promotes a covector to a continuous one. -/
 @[simp]
-lemma strongDualCotangentEquiv_symm_apply (q : V) (p : Module.Dual ℝ V) :
-    strongDualCotangentEquiv.symm (q, p) = (q, LinearMap.toContinuousLinearMap p) := by
+lemma strongDualCotangentEquiv_symm_apply (x : V × Module.Dual ℝ V) :
+    strongDualCotangentEquiv.symm x = (x.1, LinearMap.toContinuousLinearMap x.2) := by
   simp [strongDualCotangentEquiv]
 
-/-- The finite-dimensional identification of cotangent models preserves their canonical
-symplectic forms. -/
-lemma cotangentSymplecticForm_strongDualCotangentEquiv_apply
-    (x y : V × StrongDual ℝ V) :
-    cotangentSymplecticForm (strongDualCotangentEquiv x) (strongDualCotangentEquiv y) =
-      strongDualCotangentSymplecticForm x y := by
-  rcases x with ⟨q, p⟩
-  rcases y with ⟨r, s⟩
+/-- The finite-dimensional identification of cotangent models is a symplectomorphism from the
+continuous-dual model to the algebraic one. -/
+lemma isSymplectomorphism_strongDualCotangentEquiv :
+    SymplecticForm.IsSymplectomorphism (strongDualCotangentSymplecticForm (V := V))
+      (cotangentSymplecticForm (V := V)) (strongDualCotangentEquiv (V := V)) := by
+  rw [SymplecticForm.isSymplectomorphism_iff]
+  intro x y
   simp
 
 end FiniteDimensional

--- a/TauCeti/Geometry/Symplectic/Cotangent/StrongDual.lean
+++ b/TauCeti/Geometry/Symplectic/Cotangent/StrongDual.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Algebra.Module.FiniteDimensionBilinear
+public import TauCeti.Geometry.Symplectic.Cotangent.Basic
+
+import Mathlib.Analysis.LocallyConvex.SeparatingDual
+
+/-!
+# The canonical symplectic form on a continuous-dual cotangent space
+
+For a real normed space `V`, the continuous-dual cotangent model `V × StrongDual ℝ V` carries
+the canonical symplectic form
+
+`ω((v, α), (w, β)) = β(v) - α(w)`.
+
+This file constructs the form directly and, in finite dimension, identifies the continuous-dual
+model with the algebraic cotangent model `V × Module.Dual ℝ V`.
+
+## Main declarations
+
+* `TauCeti.strongDualCotangentSymplecticForm`: the canonical symplectic form on
+  `V × StrongDual ℝ V`.
+* `TauCeti.strongDualCotangentEquiv`: the finite-dimensional identification with
+  `V × Module.Dual ℝ V`.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+variable {V : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+
+/-- The bilinear form underlying the canonical symplectic form on
+`V × StrongDual ℝ V`. -/
+private def strongDualCotangentBilinForm :
+    LinearMap.BilinForm ℝ (V × StrongDual ℝ V) where
+  toFun x :=
+    { toFun := fun y ↦ y.2 x.1 - x.2 y.1
+      map_add' := by
+        intro y z
+        simp
+        ring
+      map_smul' := by
+        intro c y
+        simp
+        ring }
+  map_add' := by
+    intro x y
+    apply LinearMap.ext
+    intro z
+    simp
+    ring
+  map_smul' := by
+    intro c x
+    apply LinearMap.ext
+    intro y
+    simp
+    ring
+
+@[simp]
+private lemma strongDualCotangentBilinForm_apply (x y : V × StrongDual ℝ V) :
+    strongDualCotangentBilinForm x y = y.2 x.1 - x.2 y.1 := by
+  rfl
+
+private lemma strongDualCotangentBilinForm_isAlt :
+    (strongDualCotangentBilinForm (V := V)).IsAlt := by
+  intro x
+  simp
+
+private lemma strongDualCotangentBilinForm_nondegenerate :
+    (strongDualCotangentBilinForm (V := V)).Nondegenerate := by
+  refine (LinearMap.IsAlt.isRefl
+    strongDualCotangentBilinForm_isAlt).nondegenerate_iff_separatingLeft.mpr ?_
+  rintro ⟨v, α⟩ h
+  have hα : α = 0 := by
+    apply ContinuousLinearMap.ext
+    intro w
+    have := h (w, 0)
+    simpa using this
+  have hv : v = 0 := by
+    exact SeparatingDual.eq_zero_of_forall_dual_eq_zero (R := ℝ) fun β ↦ by
+      have := h (0, β)
+      simpa using this
+  exact Prod.ext hv hα
+
+/-- The canonical symplectic form on the normed linear cotangent space
+`V × StrongDual ℝ V`. -/
+noncomputable def strongDualCotangentSymplecticForm :
+    SymplecticForm (V × StrongDual ℝ V) where
+  toBilinForm := strongDualCotangentBilinForm
+  isAlt := strongDualCotangentBilinForm_isAlt
+  nondegenerate := strongDualCotangentBilinForm_nondegenerate
+
+/-- The canonical symplectic form on the continuous-dual model has the usual evaluation formula. -/
+@[simp]
+lemma strongDualCotangentSymplecticForm_apply (x y : V × StrongDual ℝ V) :
+    strongDualCotangentSymplecticForm x y = y.2 x.1 - x.2 y.1 := by
+  rfl
+
+section FiniteDimensional
+
+variable [FiniteDimensional ℝ V]
+
+/-- Identify the normed linear cotangent space, formed with the continuous dual, with the
+algebraic linear cotangent space. -/
+noncomputable def strongDualCotangentEquiv :
+    (V × StrongDual ℝ V) ≃ₗ[ℝ] (V × Module.Dual ℝ V) :=
+  (LinearEquiv.refl ℝ V).prodCongr LinearMap.toContinuousLinearMap.symm
+
+/-- The identification of cotangent models forgets the continuity of the covector. -/
+@[simp]
+lemma strongDualCotangentEquiv_apply (q : V) (p : StrongDual ℝ V) :
+    strongDualCotangentEquiv (q, p) = (q, (p : Module.Dual ℝ V)) := by
+  simp [strongDualCotangentEquiv]
+
+/-- The inverse identification of cotangent models promotes a covector to a continuous one. -/
+@[simp]
+lemma strongDualCotangentEquiv_symm_apply (q : V) (p : Module.Dual ℝ V) :
+    strongDualCotangentEquiv.symm (q, p) = (q, LinearMap.toContinuousLinearMap p) := by
+  simp [strongDualCotangentEquiv]
+
+end FiniteDimensional
+
+end TauCeti
+
+end


### PR DESCRIPTION
This PR adds the tautological Liouville one-form on the normed linear cotangent model `V × StrongDual ℝ V`, computes its exterior derivative, and proves the canonical symplectic form of that model satisfies the sign convention `ω = -dλ`.

**What is new, in full.** The PR adds two files, both entirely at the vector-space (pointwise) layer:

1. `TauCeti/Geometry/Symplectic/Cotangent/StrongDual.lean` introduces a *second* cotangent model, `V × StrongDual ℝ V`, and its canonical symplectic form `strongDualCotangentSymplecticForm`. This is not an independent construction: the underlying bilinear form is the already-merged `cotangentSymplecticForm.toBilinForm` restricted along the coercion `StrongDual ℝ V → Module.Dual ℝ V`, so the two models agree by construction; the only new content is nondegeneracy, which on the continuous dual comes from Hahn–Banach (`SeparatingDual`) rather than from `Module.forall_dual_apply_eq_zero_iff`. The continuous-dual model is forced by the differential-form layer: Mathlib's `extDeriv` and `ContinuousAlternatingMap` require normed spaces, so the exactness statement cannot be made on `V × Module.Dual ℝ V` at all. In finite dimension the file also records `strongDualCotangentEquiv` and `isSymplectomorphism_strongDualCotangentEquiv`, which identify the two models as symplectic vector spaces; that is what keeps the new model from being a disconnected duplicate — the zero section and cotangent-fibre Lagrangians of `Cotangent/Basic.lean` transport along it via the existing `IsSymplectomorphism` API.

2. `TauCeti/Geometry/Symplectic/Cotangent/Liouville.lean` defines `cotangentLiouvilleForm` (with its continuous-linear packaging, hence smoothness), computes `extDeriv`, and proves `ω = -dλ` as an equality of alternating two-forms.

**Roadmap path.** It advances the exact target in `HeegaardFloer/README.md`, Lane F3 milestone “Lagrangian Floer homology, exact case,” whose cotangent specialization uses the zero section and a Hamiltonian image in `T*M`; exactness of the canonical form is what kills bubbling there, and this is the linear-model exactness result behind the canonical cotangent model already merged in `Cotangent/Basic.lean`. That merged file's own module docstring already asserts the convention “`ω = -dλ`, where the tautological one-form is `λ_(q,p)(δq,δp) = p(δq)`” without proof; this PR discharges that assertion, in the same pointwise layer where `Cotangent/Basic.lean`, `Cotangent/Compatible.lean`, and `Symplectic/Manifold/TwoForm.lean` already sit. The finite-dimensional model comparison is part of the same target: it is the bridge between the algebraic model carrying the Lagrangian API and the normed model carrying the differential forms.

After this PR, Lane F3 still needs the bundle-level Liouville form on cotangent manifolds (blocked upstream: pinned Mathlib has no exterior derivative of manifold differential forms), exact Lagrangians and their action functional, and the Floer differential, compactness, continuation, and invariance arguments.

The implementation reuses Mathlib's differential-form exterior derivative, continuous alternating maps, and finite-dimensional equivalence between algebraic and continuous duals, together with Tau Ceti's existing cotangent symplectic form, `IsSymplectomorphism` transport API, and `LinearMap.IsAlt.toAlternatingMap` bridge. The mathematical convention follows McDuff--Salamon, *Introduction to Symplectic Topology*, Section 3.2; no external implementation is vendored.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"cotangent-liouville-form"}-->

🤖 Prepared with Codex
