### PR TITLE
feat: add local integral bases at places

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.DedekindDomain.Different
-public import TauCeti.FieldTheory.FunctionField.AffineModel.Extension
+public import TauCeti.FieldTheory.FunctionField.Place.Extension.IntegralBasis
 
 /-!
 # The different exponent of a place
@@ -24,15 +24,12 @@ The complementary module `C_P = {z | Tr_{F'/F} (z · 𝒪'_P) ⊆ 𝒪_P}` is an
 for a generator `t` of `C_P` is the multiplicity of the centre of `P'` on `𝒪'_P` in that ideal.
 That multiplicity is the definition used here, and no complementary module is rebuilt.
 
-The local model `𝒪_P ⊆ 𝒪'_P` is a pair of affine models in the sense of
-`TauCeti/FieldTheory/FunctionField/AffineModel/`, the smallest one that sees `P`: `𝒪_P` is a
-discrete valuation ring with fraction field `F`, and `𝒪'_P` is a Dedekind domain, module-finite
-over it, with fraction field `F'`.  The identification of the extension-theoretic data of `P'`
-with the ideal-theoretic data of its centre on `𝒪'_P` is then the affine-model dictionary of
-`TauCeti/FieldTheory/FunctionField/AffineModel/Extension.lean`.  The action of `𝒪_P` on `F'` is
-deliberately not a global instance — for `F' = F` it would compete with the action of a valuation
-subring on its own field — so it, and the scalar tower it sits in, are provided as `local`
-instances to be reinstalled by consumers.
+The local model `𝒪_P ⊆ 𝒪'_P` is constructed in
+`TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean`, the smallest one that sees
+`P`: `𝒪_P` is a discrete valuation ring with fraction field `F`, and `𝒪'_P` is a Dedekind domain,
+module-finite over it, with fraction field `F'`.  The identification of the extension-theoretic
+data of `P'` with the ideal-theoretic data of its centre on `𝒪'_P` is then the affine-model
+dictionary of `TauCeti/FieldTheory/FunctionField/AffineModel/Extension.lean`.
 
 Separability of `F' / F` is the hypothesis of record for the different: without it the
 complementary module degenerates.  Nothing here needs an exactness hypothesis on the constant
@@ -40,9 +37,6 @@ fields, and nothing needs `k` perfect.
 
 ## Main definitions
 
-* `TauCeti.Place.algebraIntegersExtension` and `TauCeti.Place.isScalarTowerIntegersExtension`: the
-  action of the valuation ring of a place of `F / k` on an extension field `F'`, to be installed
-  with `attribute [local instance 10]`.
 * `TauCeti.Place.centerIntegralClosure`: the centre of `P'` on the local model `𝒪'_P`.
 * `TauCeti.Place.differentExponent`: the different exponent `d(P' ∣ P)` (Stichtenoth,
   Definition 3.4.3).
@@ -83,74 +77,6 @@ universe u u' v v'
 variable {k : Type u} {k' : Type u'} {F : Type v} {F' : Type v'}
 variable [Field k] [Field F] [Field F']
 variable [Algebra k F] [Algebra F F']
-
-section LocalModel
-
-variable (F') (P : Place k F)
-
-/-- **The valuation ring of a place of `F / k` acts on an extension field `F'`**, through `F`.
-
-This is not a global instance: for `F' = F` it would compete with the action of a valuation
-subring on its own field.  Install it, together with
-`TauCeti.Place.isScalarTowerIntegersExtension`, with `attribute [local instance 10]` in any file
-that works with the local model of the extension at `P` — at low priority, so that the case
-`F' = F` still resolves to the valuation subring's own action, as the fraction-field instances
-expect. -/
-@[instance_reducible]
-noncomputable def algebraIntegersExtension : Algebra (P.integers) F' :=
-  ((algebraMap F F').comp (algebraMap (P.integers) F)).toAlgebra
-
-attribute [local instance 10] algebraIntegersExtension
-
-/-- The action of `TauCeti.Place.algebraIntegersExtension` on `F'` factors through `F`. -/
-theorem isScalarTowerIntegersExtension : IsScalarTower (P.integers) F F' :=
-  .of_algebraMap_eq fun _ ↦ rfl
-
-attribute [local instance 10] isScalarTowerIntegersExtension
-
-theorem algebraMap_integersExtension_injective :
-    Function.Injective (algebraMap (P.integers) F') := by
-  rw [IsScalarTower.algebraMap_eq (P.integers) F F', RingHom.coe_comp]
-  exact (algebraMap F F').injective.comp (FaithfulSMul.algebraMap_injective (P.integers) F)
-
-instance isTorsionFree_integersExtension : Module.IsTorsionFree (P.integers) F' :=
-  Module.IsTorsionFree.comap (M := F') (algebraMap (P.integers) F')
-    (fun _ hr ↦ isRegular_iff_ne_zero'.mpr fun h ↦ isRegular_iff_ne_zero'.mp hr
-      (algebraMap_integersExtension_injective F' P (by simpa using h)))
-    (fun r m ↦ (Algebra.smul_def r m).symm)
-
-variable [FiniteDimensional F F'] [Algebra.IsSeparable F F']
-
-/-- The local model `𝒪'_P` — the integral closure of `𝒪_P` in `F'` — has fraction field `F'`. -/
-instance isFractionRing_integralClosure :
-    IsFractionRing (integralClosure (P.integers) F') F' :=
-  IsIntegralClosure.isFractionRing_of_finite_extension (P.integers) F F' _
-
-/-- The local model `𝒪'_P` is a Dedekind domain. -/
-instance isDedekindDomain_integralClosure :
-    IsDedekindDomain (integralClosure (P.integers) F') :=
-  integralClosure.isDedekindDomain (A := P.integers) (K := F) (L := F')
-
-/-- The local model `𝒪'_P` is module-finite over `𝒪_P`. -/
-instance moduleFinite_integralClosure :
-    Module.Finite (P.integers) (integralClosure (P.integers) F') :=
-  IsIntegralClosure.finite (A := P.integers) (K := F) (L := F') _
-
-/-- Separability of `F' / F`, transported to the fraction fields over which Mathlib states the
-different ideal. -/
-instance isSeparable_fractionRing_integralClosure :
-    Algebra.IsSeparable (FractionRing (P.integers))
-      (FractionRing (integralClosure (P.integers) F')) := by
-  refine Algebra.IsSeparable.of_equiv_equiv (FractionRing.algEquiv (P.integers) F).symm.toRingEquiv
-    (FractionRing.algEquiv (integralClosure (P.integers) F') F').symm.toRingEquiv ?_
-  apply IsLocalization.ringHom_ext (P.integers)⁰
-  ext a
-  simp only [RingHom.coe_comp, Function.comp_apply, RingHom.coe_coe, AlgEquiv.coe_ringEquiv,
-    AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
-  rw [IsScalarTower.algebraMap_apply (P.integers) (integralClosure (P.integers) F') F',
-    AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
-
-end LocalModel
 
 section DifferentExponent
 

--- a/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.DedekindDomain.Different
+public import TauCeti.FieldTheory.FunctionField.AffineModel.Extension
 public import TauCeti.FieldTheory.FunctionField.Place.Extension.IntegralBasis
 
 /-!
@@ -24,12 +25,15 @@ The complementary module `C_P = {z | Tr_{F'/F} (z · 𝒪'_P) ⊆ 𝒪_P}` is an
 for a generator `t` of `C_P` is the multiplicity of the centre of `P'` on `𝒪'_P` in that ideal.
 That multiplicity is the definition used here, and no complementary module is rebuilt.
 
-The local model `𝒪_P ⊆ 𝒪'_P` is constructed in
-`TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean`, the smallest one that sees
-`P`: `𝒪_P` is a discrete valuation ring with fraction field `F`, and `𝒪'_P` is a Dedekind domain,
-module-finite over it, with fraction field `F'`.  The identification of the extension-theoretic
-data of `P'` with the ideal-theoretic data of its centre on `𝒪'_P` is then the affine-model
-dictionary of `TauCeti/FieldTheory/FunctionField/AffineModel/Extension.lean`.
+The local model `𝒪_P ⊆ 𝒪'_P` is a pair of affine models in the sense of
+`TauCeti/FieldTheory/FunctionField/AffineModel/`, the smallest one that sees `P`: `𝒪_P` is a
+discrete valuation ring with fraction field `F`, and `𝒪'_P` is a Dedekind domain, module-finite
+over it, with fraction field `F'`.  It is constructed in
+`TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean`; the action of `𝒪_P` on `F'`
+and the scalar tower it sits in are deliberately not global instances, so they are reinstalled
+here as `local` instances.  The identification of the extension-theoretic data of `P'` with the
+ideal-theoretic data of its centre on `𝒪'_P` is then the affine-model dictionary of
+`TauCeti/FieldTheory/FunctionField/AffineModel/Extension.lean`.
 
 Separability of `F' / F` is the hypothesis of record for the different: without it the
 complementary module degenerates.  Nothing here needs an exactness hypothesis on the constant

--- a/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Different/Basic.lean
@@ -7,7 +7,6 @@ module
 
 public import Mathlib.RingTheory.DedekindDomain.Different
 public import TauCeti.FieldTheory.FunctionField.AffineModel.Extension
-public import TauCeti.FieldTheory.FunctionField.Place.Extension.IntegralBasis
 
 /-!
 # The different exponent of a place
@@ -29,7 +28,7 @@ The local model `𝒪_P ⊆ 𝒪'_P` is a pair of affine models in the sense of
 `TauCeti/FieldTheory/FunctionField/AffineModel/`, the smallest one that sees `P`: `𝒪_P` is a
 discrete valuation ring with fraction field `F`, and `𝒪'_P` is a Dedekind domain, module-finite
 over it, with fraction field `F'`.  It is constructed in
-`TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean`; the action of `𝒪_P` on `F'`
+`TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean`; the action of `𝒪_P` on `F'`
 and the scalar tower it sits in are deliberately not global instances, so they are reinstalled
 here as `local` instances.  The identification of the extension-theoretic data of `P'` with the
 ideal-theoretic data of its centre on `𝒪'_P` is then the affine-model dictionary of

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean
@@ -30,10 +30,18 @@ that are independent over `F_P`, multiplied by the powers `t^j` of a prime eleme
 `0 ≤ j < e`, are independent over `F`, because the orders of the resulting blocks are pairwise
 distinct modulo `e`.
 
+The file also records the action of the valuation ring `𝒪_P` of a place `P` of `F / k` on the
+extension field `F'`, through `F`.  That action is not a global instance — for `F' = F` it would
+compete with the action of a valuation subring on its own field — so it, and the scalar tower it
+sits in, are provided to be reinstalled by consumers with `attribute [local instance 10]`.
+
 ## Main definitions
 
 * `TauCeti.Place.constantsEquiv`: the places of `F' / k` are the places of `F' / k'`, for `k'`
   integral over `k`; enlarging the constants by an algebraic extension changes nothing.
+* `TauCeti.Place.algebraIntegersExtension` and `TauCeti.Place.isScalarTowerIntegersExtension`: the
+  action of the valuation ring of a place of `F / k` on an extension field `F'`, to be installed
+  with `attribute [local instance 10]`.
 * `TauCeti.Place.restrict`: the place of `F / k` that a place of `F' / k'` lies over.
 * `TauCeti.Place.ramificationIdx`: the ramification index `e(P' | P)`.
 * `TauCeti.Place.relativeDegree`: the relative degree `f(P' | P) = [F'_{P'} : F_P]`.
@@ -83,6 +91,44 @@ variable {k : Type u} {k' : Type u'} {F : Type v} {F' : Type v'}
 variable [Field k] [Field k'] [Field F] [Field F']
 variable [Algebra k k'] [Algebra k F] [Algebra k' F'] [Algebra F F'] [Algebra k F']
 variable [IsScalarTower k k' F'] [IsScalarTower k F F']
+
+section LocalModel
+
+omit [Field k'] [Algebra k k'] [Algebra k' F'] [Algebra k F'] [IsScalarTower k k' F']
+  [IsScalarTower k F F']
+
+variable (F') (P : Place k F)
+
+/-- **The valuation ring of a place of `F / k` acts on an extension field `F'`**, through `F`.
+
+This is not a global instance: for `F' = F` it would compete with the action of a valuation
+subring on its own field.  Install it, together with
+`TauCeti.Place.isScalarTowerIntegersExtension`, with `attribute [local instance 10]` in any file
+that works with the local model of the extension at `P` — at low priority, so that the case
+`F' = F` still resolves to the valuation subring's own action, as the fraction-field instances
+expect. -/
+@[instance_reducible]
+noncomputable def algebraIntegersExtension : Algebra (P.integers) F' :=
+  ((algebraMap F F').comp (algebraMap (P.integers) F)).toAlgebra
+
+attribute [local instance 10] algebraIntegersExtension
+
+/-- The action of `TauCeti.Place.algebraIntegersExtension` on `F'` factors through `F`. -/
+theorem isScalarTowerIntegersExtension : IsScalarTower (P.integers) F F' :=
+  .of_algebraMap_eq fun _ ↦ rfl
+
+attribute [local instance 10] isScalarTowerIntegersExtension
+
+theorem algebraMap_integersExtension_injective :
+    Function.Injective (algebraMap (P.integers) F') := by
+  rw [IsScalarTower.algebraMap_eq (P.integers) F F', RingHom.coe_comp]
+  exact (algebraMap F F').injective.comp (FaithfulSMul.algebraMap_injective (P.integers) F)
+
+instance isTorsionFree_integersExtension : Module.IsTorsionFree (P.integers) F' :=
+  Module.isTorsionFree_iff_algebraMap_injective.mpr
+    (algebraMap_integersExtension_injective F' P)
+
+end LocalModel
 
 section Constants
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.Valuation.Extension
+public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
 public import TauCeti.FieldTheory.FunctionField.Place.Basic
 public import TauCeti.RingTheory.Valuation.Discrete.Normalize
 
@@ -34,6 +35,10 @@ The file also records the action of the valuation ring `𝒪_P` of a place `P` o
 extension field `F'`, through `F`.  That action is not a global instance — for `F' = F` it would
 compete with the action of a valuation subring on its own field — so it, and the scalar tower it
 sits in, are provided to be reinstalled by consumers with `attribute [local instance 10]`.
+For a finite extension, it also records the standard local integral-closure model
+`𝒪_P ⊆ 𝒪'_P`: `F'` is the fraction field and the localization of `𝒪'_P` at `(𝒪_P)⁰`; for a
+separable extension, `𝒪'_P` is Dedekind and module-finite over `𝒪_P`, and separability transports
+to the canonical fraction fields used by Mathlib's different API.
 
 ## Main definitions
 
@@ -70,6 +75,12 @@ sits in, are provided to be reinstalled by consumers with `attribute [local inst
 * `TauCeti.Place.finrank_mul_degree_eq_relativeDegree_mul_degree_restrict`:
   `[k' : k] · deg P' = f(P' ∣ P) · deg P`, the comparison of the degrees of `P'` and of the place
   it lies over.
+* `TauCeti.Place.isFractionRing_integralClosure`,
+  `TauCeti.Place.isLocalization_integralClosure`,
+  `TauCeti.Place.isDedekindDomain_integralClosure`,
+  `TauCeti.Place.moduleFinite_integralClosure`, and
+  `TauCeti.Place.isSeparable_fractionRing_integralClosure`: the fraction-field, localization,
+  Dedekind, finiteness, and separability properties of the local integral closure `𝒪'_P`.
 
 ## References
 
@@ -79,7 +90,12 @@ sits in, are provided to be reinstalled by consumers with `attribute [local inst
 
 public section
 
+open IsDedekindDomain
+
 open scoped WithZero
+open scoped nonZeroDivisors
+
+attribute [local instance] FractionRing.liftAlgebra FractionRing.isScalarTower_liftAlgebra
 
 namespace TauCeti
 
@@ -129,6 +145,57 @@ instance isTorsionFree_integersExtension : Module.IsTorsionFree (P.integers) F' 
     (algebraMap_integersExtension_injective F' P)
 
 end LocalModel
+
+section LocalIntegralClosure
+
+omit [Field k'] [Algebra k k'] [Algebra k' F'] [Algebra k F'] [IsScalarTower k k' F']
+  [IsScalarTower k F F']
+
+variable (F') (P : Place k F)
+
+attribute [local instance 10] algebraIntegersExtension isScalarTowerIntegersExtension
+
+variable [FiniteDimensional F F']
+
+/-- The local model `𝒪'_P` — the integral closure of `𝒪_P` in `F'` — has fraction field `F'`. -/
+instance isFractionRing_integralClosure :
+    IsFractionRing (integralClosure (P.integers) F') F' :=
+  IsIntegralClosure.isFractionRing_of_finite_extension (P.integers) F F' _
+
+/-- More precisely, `F'` is the localization of the local model `𝒪'_P` at the nonzero divisors
+of `𝒪_P`. -/
+theorem isLocalization_integralClosure :
+    IsLocalization
+      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
+  IsIntegralClosure.isLocalization (P.integers) F F' _
+
+variable [Algebra.IsSeparable F F']
+
+/-- The local model `𝒪'_P` is a Dedekind domain. -/
+instance isDedekindDomain_integralClosure :
+    IsDedekindDomain (integralClosure (P.integers) F') :=
+  integralClosure.isDedekindDomain (A := P.integers) (K := F) (L := F')
+
+/-- The local model `𝒪'_P` is module-finite over `𝒪_P`. -/
+instance moduleFinite_integralClosure :
+    Module.Finite (P.integers) (integralClosure (P.integers) F') :=
+  IsIntegralClosure.finite (A := P.integers) (K := F) (L := F') _
+
+/-- Separability of `F' / F`, transported to the canonical fraction fields used by the
+integral-closure API. -/
+instance isSeparable_fractionRing_integralClosure :
+    Algebra.IsSeparable (FractionRing (P.integers))
+      (FractionRing (integralClosure (P.integers) F')) := by
+  refine Algebra.IsSeparable.of_equiv_equiv (FractionRing.algEquiv (P.integers) F).symm.toRingEquiv
+    (FractionRing.algEquiv (integralClosure (P.integers) F') F').symm.toRingEquiv ?_
+  apply IsLocalization.ringHom_ext (P.integers)⁰
+  ext a
+  simp only [RingHom.coe_comp, Function.comp_apply, RingHom.coe_coe, AlgEquiv.coe_ringEquiv,
+    AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
+  rw [IsScalarTower.algebraMap_apply (P.integers) (integralClosure (P.integers) F') F',
+    AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
+
+end LocalIntegralClosure
 
 section Constants
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Fundamental.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Fundamental.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.FieldTheory.FunctionField.AffineModel.Extension
-public import TauCeti.FieldTheory.FunctionField.Place.Extension.IntegralBasis
 
 /-!
 # The fundamental identity at an arbitrary place
@@ -30,7 +29,7 @@ affine-model reconciliation consumes.  No separability-free finiteness of a norm
 available, so the unconditional form of Stichtenoth's Theorem 3.1.11 waits on one.
 
 That local model is the one set up in
-`TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean`; the action of `𝒪_P` on `F'`
+`TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean`; the action of `𝒪_P` on `F'`
 and the scalar tower it sits in are not global instances, so they are reinstalled here.
 
 ## Main result

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Fundamental.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Fundamental.lean
@@ -5,8 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
 public import TauCeti.FieldTheory.FunctionField.AffineModel.Extension
+public import TauCeti.FieldTheory.FunctionField.Place.Extension.IntegralBasis
 
 /-!
 # The fundamental identity at an arbitrary place
@@ -28,6 +28,10 @@ discrete valuation ring with fraction field `F`, together with the integral clos
 `𝒪_P`-module — the hypothesis of Mathlib's `Ideal.sum_ramification_inertia_eq_finrank`, which the
 affine-model reconciliation consumes.  No separability-free finiteness of a normalization is
 available, so the unconditional form of Stichtenoth's Theorem 3.1.11 waits on one.
+
+That local model is the one set up in
+`TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean`; the action of `𝒪_P` on `F'`
+and the scalar tower it sits in are not global instances, so they are reinstalled here.
 
 ## Main result
 
@@ -59,6 +63,8 @@ variable [FiniteDimensional F F'] [Algebra.IsSeparable F F'] [Algebra.IsIntegral
 
 variable (k F)
 
+attribute [local instance 10] algebraIntegersExtension isScalarTowerIntegersExtension
+
 /-- **The fundamental identity** (Stichtenoth, Theorem 3.1.11) at an arbitrary place `P` of
 `F / k`, for an extension `F' / k'` whose extension of function fields `F' / F` is finite and
 **separable**: the ramification indices and relative degrees of the places of `F' / k'` lying
@@ -77,8 +83,6 @@ theorem sum_ramificationIdx_mul_relativeDegree_eq_finrank_of_isSeparable (P : Pl
   have hR : ∀ r : P.integers, algebraMap P.integers F r ∈ P.integers := fun r ↦ by
     rw [ValuationSubring.algebraMap_apply]
     exact r.2
-  let _ : Algebra P.integers F' := ((algebraMap F F').comp (algebraMap P.integers F)).toAlgebra
-  have : IsScalarTower P.integers F F' := .of_algebraMap_eq fun _ ↦ rfl
   have : IsScalarTower k P.integers F' := .of_algebraMap_eq fun c ↦ by
     rw [IsScalarTower.algebraMap_apply P.integers F F',
       ← IsScalarTower.algebraMap_apply k P.integers F, ← IsScalarTower.algebraMap_apply k F F']
@@ -89,12 +93,6 @@ theorem sum_ramificationIdx_mul_relativeDegree_eq_finrank_of_isSeparable (P : Pl
   let _ : Algebra k' (integralClosure P.integers F') :=
     ((algebraMap k' F').codRestrict (integralClosure P.integers F') hk').toAlgebra
   have : IsScalarTower k' (integralClosure P.integers F') F' := .of_algebraMap_eq fun _ ↦ rfl
-  have : IsFractionRing (integralClosure P.integers F') F' :=
-    IsIntegralClosure.isFractionRing_of_finite_extension P.integers F F' _
-  have : IsDedekindDomain (integralClosure P.integers F') :=
-    integralClosure.isDedekindDomain (A := P.integers) (K := F) (L := F')
-  have : Module.Finite P.integers (integralClosure P.integers F') :=
-    IsIntegralClosure.finite (A := P.integers) (K := F) (L := F') _
   -- `P` is the place of the maximal ideal of `𝒪_P`, so the affine-model identity applies to it.
   refine sum_ramificationIdx_mul_relativeDegree_eq_finrank (S := integralClosure P.integers F')
     k F (P.center hR) fun P' ↦ ?_

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
@@ -1,0 +1,237 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
+public import TauCeti.FieldTheory.FunctionField.AffineModel.Extension
+
+/-!
+# Local integral bases of extensions of algebraic function fields
+
+Let `F' / F` be a finite separable extension and let `P` be a place of `F / k`.  Its local
+integral closure
+
+`𝒪'_P = integralClosure 𝒪_P F'`
+
+is a finite free module over the discrete valuation ring `𝒪_P`, of rank `[F' : F]`.  Choosing a
+basis of that module and extending scalars from `𝒪_P` to its fraction field `F` gives a basis of
+`F' / F` consisting of elements integral over `𝒪_P`.  This is the local integral basis of
+Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Corollary 3.3.5.
+
+The freeness and rank calculation are specializations of Mathlib's generic integral-closure
+theorems `IsIntegralClosure.module_free` and `IsIntegralClosure.rank`.  The point of this file is
+the function-field interface: the basis is indexed by `Fin [F' : F]`, its vectors are visibly
+integral, and their `𝒪_P`-span inside `F'` is exactly `𝒪'_P`.  These are the forms used by the
+complementary module and different of the next layer.
+
+## Main definitions
+
+* `TauCeti.Place.IsIntegralBasis`: the property that an `F`-basis of `F'` is an integral basis
+  at `P`.
+* `TauCeti.Place.integralClosureFinBasis`: an `𝒪_P`-basis of `𝒪'_P`, indexed by
+  `Fin [F' : F]`.
+* `TauCeti.Place.localIntegralBasis`: the resulting `F`-basis of `F'`.
+
+## Main results
+
+* `TauCeti.Place.localIntegralBasis_isIntegral`: every basis vector is integral over `𝒪_P`.
+* `TauCeti.Place.span_localIntegralBasis`: the `𝒪_P`-span of the basis vectors is exactly the
+  integral closure `𝒪'_P` inside `F'`.
+* `TauCeti.Place.mem_span_localIntegralBasis_iff`: an element of `F'` has integral coordinates
+  in the local basis exactly when it is integral over `𝒪_P`.
+
+## References
+
+* H. Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., GTM 254, Springer, 2009,
+  Corollary 3.3.5.
+-/
+
+public section
+
+open IsDedekindDomain
+open Module
+
+open scoped nonZeroDivisors
+
+attribute [local instance] FractionRing.liftAlgebra FractionRing.isScalarTower_liftAlgebra
+
+namespace TauCeti
+
+namespace Place
+
+universe u v v'
+
+variable {k : Type u} {F : Type v} {F' : Type v'}
+variable [Field k] [Field F] [Field F'] [Algebra k F] [Algebra F F']
+
+/-! ### The local integral closure -/
+
+variable (F') (P : Place k F)
+
+/-- **The valuation ring of a place of `F / k` acts on an extension field `F'`**, through `F`.
+
+This is not a global instance: for `F' = F` it would compete with the action of a valuation
+subring on its own field. Install it, together with
+`TauCeti.Place.isScalarTowerIntegersExtension`, with `attribute [local instance 10]` in any file
+that works with the local model of the extension at `P`. -/
+@[instance_reducible]
+noncomputable def algebraIntegersExtension : Algebra (P.integers) F' :=
+  ((algebraMap F F').comp (algebraMap (P.integers) F)).toAlgebra
+
+attribute [local instance 10] algebraIntegersExtension
+
+/-- The action of `TauCeti.Place.algebraIntegersExtension` on `F'` factors through `F`. -/
+theorem isScalarTowerIntegersExtension : IsScalarTower (P.integers) F F' :=
+  .of_algebraMap_eq fun _ ↦ rfl
+
+attribute [local instance 10] isScalarTowerIntegersExtension
+
+theorem algebraMap_integersExtension_injective :
+    Function.Injective (algebraMap (P.integers) F') := by
+  rw [IsScalarTower.algebraMap_eq (P.integers) F F', RingHom.coe_comp]
+  exact (algebraMap F F').injective.comp (FaithfulSMul.algebraMap_injective (P.integers) F)
+
+instance isTorsionFree_integersExtension : Module.IsTorsionFree (P.integers) F' :=
+  Module.IsTorsionFree.comap (M := F') (algebraMap (P.integers) F')
+    (fun _ hr ↦ isRegular_iff_ne_zero'.mpr fun h ↦ isRegular_iff_ne_zero'.mp hr
+      (algebraMap_integersExtension_injective F' P (by simpa using h)))
+    (fun r m ↦ (Algebra.smul_def r m).symm)
+
+/-- An `F`-basis of `F'` is an **integral basis at `P`** when its `𝒪_P`-span is exactly the
+integral closure `𝒪'_P` inside `F'` (Stichtenoth, Section III.3). -/
+def IsIntegralBasis {ι : Type*} (b : Basis ι F F') : Prop :=
+  Submodule.span (P.integers) (Set.range b) = (integralClosure (P.integers) F').toSubmodule
+
+/-- Every vector of an integral basis at `P` is integral over `𝒪_P`. -/
+theorem IsIntegralBasis.isIntegral {ι : Type*} {b : Basis ι F F'} (hb : P.IsIntegralBasis F' b)
+    (i : ι) : IsIntegral (P.integers) (b i) := by
+  rw [← mem_integralClosure_iff, ← Subalgebra.mem_toSubmodule, ← hb]
+  exact Submodule.subset_span (Set.mem_range_self i)
+
+/-- Membership in the integral span of an integral basis at `P` is the same as integrality over
+`𝒪_P`. -/
+theorem IsIntegralBasis.mem_span_iff_isIntegral {ι : Type*} {b : Basis ι F F'}
+    (hb : P.IsIntegralBasis F' b) {x : F'} :
+    x ∈ Submodule.span (P.integers) (Set.range b) ↔ IsIntegral (P.integers) x := by
+  rw [hb, Subalgebra.mem_toSubmodule]
+  exact mem_integralClosure_iff (P.integers) F'
+
+variable [FiniteDimensional F F'] [Algebra.IsSeparable F F']
+
+/-- The local model `𝒪'_P` — the integral closure of `𝒪_P` in `F'` — has fraction field `F'`. -/
+instance isFractionRing_integralClosure :
+    IsFractionRing (integralClosure (P.integers) F') F' :=
+  IsIntegralClosure.isFractionRing_of_finite_extension (P.integers) F F' _
+
+/-- The local model `𝒪'_P` is a Dedekind domain. -/
+instance isDedekindDomain_integralClosure :
+    IsDedekindDomain (integralClosure (P.integers) F') :=
+  integralClosure.isDedekindDomain (A := P.integers) (K := F) (L := F')
+
+/-- The local model `𝒪'_P` is module-finite over `𝒪_P`. -/
+instance moduleFinite_integralClosure :
+    Module.Finite (P.integers) (integralClosure (P.integers) F') :=
+  IsIntegralClosure.finite (A := P.integers) (K := F) (L := F') _
+
+/-- Separability of `F' / F`, transported to the canonical fraction fields used by the
+integral-closure API. -/
+instance isSeparable_fractionRing_integralClosure :
+    Algebra.IsSeparable (FractionRing (P.integers))
+      (FractionRing (integralClosure (P.integers) F')) := by
+  refine Algebra.IsSeparable.of_equiv_equiv (FractionRing.algEquiv (P.integers) F).symm.toRingEquiv
+    (FractionRing.algEquiv (integralClosure (P.integers) F') F').symm.toRingEquiv ?_
+  apply IsLocalization.ringHom_ext (P.integers)⁰
+  ext a
+  simp only [RingHom.coe_comp, Function.comp_apply, RingHom.coe_coe, AlgEquiv.coe_ringEquiv,
+    AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
+  rw [IsScalarTower.algebraMap_apply (P.integers) (integralClosure (P.integers) F') F',
+    AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
+
+/-- The rank of the local integral closure is the degree of the field extension:
+`rank_{𝒪_P} 𝒪'_P = [F' : F]`. -/
+theorem finrank_integralClosure :
+    Module.finrank (P.integers) (integralClosure (P.integers) F') = Module.finrank F F' :=
+  IsIntegralClosure.rank (P.integers) F F' _
+
+/-! ### A local integral basis -/
+
+/-- An `𝒪_P`-basis of the local integral closure `𝒪'_P`, indexed by the degree `[F' : F]`. -/
+noncomputable def integralClosureFinBasis :
+    Basis (Fin (Module.finrank F F')) (P.integers) (integralClosure (P.integers) F') :=
+  Module.finBasisOfFinrankEq (P.integers) (integralClosure (P.integers) F')
+    (finrank_integralClosure F' P)
+
+/-- **A local integral basis at `P`** (Stichtenoth, Corollary 3.3.5): extend an `𝒪_P`-basis of
+the local integral closure `𝒪'_P` to the fraction fields. The resulting `F`-basis of `F'` is
+indexed by `Fin [F' : F]`, and its `𝒪_P`-span is exactly `𝒪'_P`. -/
+noncomputable def localIntegralBasis : Basis (Fin (Module.finrank F F')) F F' := by
+  letI : IsLocalization
+      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
+    IsIntegralClosure.isLocalization (P.integers) F F' (integralClosure (P.integers) F')
+  exact (integralClosureFinBasis F' P).localizationLocalization F (P.integers)⁰ F'
+
+/-- A vector of the local integral basis is the image in `F'` of the corresponding vector of
+the `𝒪_P`-basis of `𝒪'_P`. -/
+@[simp]
+theorem localIntegralBasis_apply (i : Fin (Module.finrank F F')) :
+    localIntegralBasis F' P i =
+      algebraMap (integralClosure (P.integers) F') F' (integralClosureFinBasis F' P i) := by
+  let _ : IsLocalization
+      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
+    IsIntegralClosure.isLocalization (P.integers) F F' (integralClosure (P.integers) F')
+  exact Basis.localizationLocalization_apply F (P.integers)⁰ F'
+    (integralClosureFinBasis F' P) i
+
+/-- The coordinates of an integral element in the local integral basis are the images in `F` of
+its coordinates in the `𝒪_P`-basis of `𝒪'_P`. -/
+@[simp]
+theorem localIntegralBasis_repr_coe (x : integralClosure (P.integers) F')
+    (i : Fin (Module.finrank F F')) :
+    (localIntegralBasis F' P).repr (x : F') i =
+      algebraMap (P.integers) F ((integralClosureFinBasis F' P).repr x i) := by
+  let _ : IsLocalization
+      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
+    IsIntegralClosure.isLocalization (P.integers) F F' (integralClosure (P.integers) F')
+  rw [localIntegralBasis]
+  simpa only [Subalgebra.algebraMap_apply] using
+    Basis.localizationLocalization_repr_algebraMap F (P.integers)⁰ F'
+      (integralClosureFinBasis F' P) x i
+
+/-- **The integral span of a local integral basis is the local integral closure `𝒪'_P`.** -/
+theorem span_localIntegralBasis :
+    Submodule.span (P.integers) (Set.range (localIntegralBasis F' P)) =
+      (integralClosure (P.integers) F').toSubmodule := by
+  let _ : IsLocalization
+      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
+    IsIntegralClosure.isLocalization (P.integers) F F' (integralClosure (P.integers) F')
+  rw [localIntegralBasis]
+  rw [Basis.localizationLocalization_span F (P.integers)⁰ F']
+  ext x
+  simp
+
+/-- The chosen `localIntegralBasis` is an integral basis at `P`. This is the existence statement
+of Stichtenoth, Corollary 3.3.5. -/
+theorem isIntegralBasis_localIntegralBasis :
+    P.IsIntegralBasis F' (localIntegralBasis F' P) :=
+  span_localIntegralBasis F' P
+
+/-- Every vector of the chosen local integral basis is integral over `𝒪_P`. -/
+theorem localIntegralBasis_isIntegral (i : Fin (Module.finrank F F')) :
+    IsIntegral (P.integers) (localIntegralBasis F' P i) :=
+  IsIntegralBasis.isIntegral (F' := F') (P := P) (isIntegralBasis_localIntegralBasis F' P) i
+
+/-- An element of `F'` has integral coordinates in the local integral basis exactly when it is
+integral over `𝒪_P`. -/
+theorem mem_span_localIntegralBasis_iff {x : F'} :
+    x ∈ Submodule.span (P.integers) (Set.range (localIntegralBasis F' P)) ↔
+      IsIntegral (P.integers) x := by
+  exact (isIntegralBasis_localIntegralBasis F' P).mem_span_iff_isIntegral
+
+end Place
+
+end TauCeti
+
+end

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
@@ -134,7 +134,6 @@ theorem IsIntegralBasis.mem_span_iff_isIntegral {ι : Type*} {b : Basis ι F F'}
 
 /-- Integrality over `𝒪_P`, expressed in the coordinate normal form supplied by an integral
 basis at `P`. -/
-@[simp]
 theorem IsIntegralBasis.isIntegral_iff_repr_mem {ι : Type*} {b : Basis ι F F'}
     (hb : P.IsIntegralBasis F' b) {x : F'} :
     IsIntegral (P.integers) x ↔ ∀ i, b.repr x i ∈ P.integers :=
@@ -205,6 +204,7 @@ theorem isIntegralBasis_localIntegralBasis :
 
 /-- **An element of `F'` is integral over `𝒪_P` exactly when all of its coordinates in the local
 integral basis lie in `𝒪_P`** (Stichtenoth, Corollary 3.3.5). -/
+@[simp]
 theorem isIntegral_iff_repr_mem {x : F'} :
     IsIntegral (P.integers) x ↔
       ∀ i, (localIntegralBasis F' P).repr x i ∈ P.integers := by

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
@@ -22,12 +22,9 @@ basis of that module and extending scalars from `𝒪_P` to its fraction field `
 `F' / F` consisting of elements integral over `𝒪_P`.  This is the local integral basis of
 Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Corollary 3.3.5.
 
-This file also owns the local model `𝒪_P ⊆ 𝒪'_P` that the later layers work with: on top of the
-action of `𝒪_P` on `F'` supplied by
-`TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean` it records that `F'` is the
-fraction field — indeed the localization at `(𝒪_P)⁰` — of `𝒪'_P`, that `𝒪'_P` is a Dedekind domain
-and module-finite over `𝒪_P`, and it transports separability to the canonical fraction fields over
-which Mathlib states the different.
+The local model `𝒪_P ⊆ 𝒪'_P` and its fraction-field, localization, Dedekind, finiteness, and
+separability infrastructure are supplied by
+`TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean`.
 
 The freeness and rank calculation are specializations of Mathlib's generic integral-closure
 theorems `IsIntegralClosure.module_free` and `IsIntegralClosure.rank`.  The point of this file is
@@ -58,8 +55,8 @@ The basis material is the place-local analogue of Mathlib's `NumberField.integra
 * `TauCeti.Place.IsIntegralBasis.isIntegral` and
   `TauCeti.Place.IsIntegralBasis.mem_span_iff_isIntegral`: what an integral basis at `P` gives —
   integral vectors, and an integral span that detects integrality.
-* `TauCeti.Place.isLocalization_integralClosure`: `F'` is the localization of `𝒪'_P` at the
-  nonzero divisors of `𝒪_P`.
+* `TauCeti.Place.isIntegralBasis_iff_isIntegral_iff_repr_mem`: an arbitrary basis is integral
+  exactly when integrality is detected coordinatewise over `𝒪_P`.
 * `TauCeti.Place.finrank_integralClosure`: `rank_{𝒪_P} 𝒪'_P = [F' : F]`.
 * `TauCeti.Place.isIntegralBasis_localizationLocalization`: extending any `𝒪_P`-basis of `𝒪'_P`
   to the fraction fields gives an integral basis at `P`.
@@ -106,12 +103,20 @@ integral closure `𝒪'_P` inside `F'` (Stichtenoth, Section III.3). -/
 def IsIntegralBasis {ι : Type*} (b : Basis ι F F') : Prop :=
   Submodule.span (P.integers) (Set.range b) = (integralClosure (P.integers) F').toSubmodule
 
-/-- An `F`-basis of `F'` is an integral basis at `P` exactly when its `𝒪_P`-span is the local
-integral closure `𝒪'_P`. -/
-theorem isIntegralBasis_iff {ι : Type*} (b : Basis ι F F') :
+/-- A basis is an integral basis at `P` exactly when integrality over `𝒪_P` is equivalent to all
+of its coordinates lying in `𝒪_P`. -/
+theorem isIntegralBasis_iff_isIntegral_iff_repr_mem {ι : Type*} (b : Basis ι F F') :
     P.IsIntegralBasis F' b ↔
-      Submodule.span (P.integers) (Set.range b) =
-        (integralClosure (P.integers) F').toSubmodule := Iff.rfl
+      ∀ x, IsIntegral (P.integers) x ↔ ∀ i, b.repr x i ∈ P.integers := by
+  rw [IsIntegralBasis, Submodule.ext_iff]
+  apply forall_congr'
+  intro x
+  rw [Basis.mem_span_iff_repr_mem, Subalgebra.mem_toSubmodule,
+    mem_integralClosure_iff]
+  have hmem (y : F) :
+      y ∈ Set.range (algebraMap (P.integers) F) ↔ y ∈ P.integers :=
+    ⟨fun ⟨r, hr⟩ ↦ hr ▸ r.2, fun hy ↦ ⟨⟨y, hy⟩, rfl⟩⟩
+  simp only [hmem, iff_comm]
 
 /-- Every vector of an integral basis at `P` is integral over `𝒪_P`. -/
 theorem IsIntegralBasis.isIntegral {ι : Type*} {b : Basis ι F F'} (hb : P.IsIntegralBasis F' b)
@@ -127,21 +132,17 @@ theorem IsIntegralBasis.mem_span_iff_isIntegral {ι : Type*} {b : Basis ι F F'}
   rw [hb, Subalgebra.mem_toSubmodule]
   exact mem_integralClosure_iff (P.integers) F'
 
+/-- Integrality over `𝒪_P`, expressed in the coordinate normal form supplied by an integral
+basis at `P`. -/
+@[simp]
+theorem IsIntegralBasis.isIntegral_iff_repr_mem {ι : Type*} {b : Basis ι F F'}
+    (hb : P.IsIntegralBasis F' b) {x : F'} :
+    IsIntegral (P.integers) x ↔ ∀ i, b.repr x i ∈ P.integers :=
+  (isIntegralBasis_iff_isIntegral_iff_repr_mem F' P b).mp hb x
+
 /-! ### The local integral closure -/
 
 variable [FiniteDimensional F F']
-
-/-- The local model `𝒪'_P` — the integral closure of `𝒪_P` in `F'` — has fraction field `F'`. -/
-instance isFractionRing_integralClosure :
-    IsFractionRing (integralClosure (P.integers) F') F' :=
-  IsIntegralClosure.isFractionRing_of_finite_extension (P.integers) F F' _
-
-/-- More precisely, `F'` is the localization of the local model `𝒪'_P` at the nonzero divisors
-of `𝒪_P`.  This is the form in which the `Basis.localizationLocalization` API consumes it. -/
-theorem isLocalization_integralClosure :
-    IsLocalization
-      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
-  IsIntegralClosure.isLocalization (P.integers) F F' _
 
 attribute [local instance] isLocalization_integralClosure
 
@@ -150,35 +151,11 @@ an integral basis at `P`.  This is Stichtenoth, Corollary 3.3.5. -/
 theorem isIntegralBasis_localizationLocalization {ι : Type*}
     (c : Basis ι (P.integers) (integralClosure (P.integers) F')) :
     P.IsIntegralBasis F' (c.localizationLocalization F (P.integers)⁰ F') := by
-  rw [isIntegralBasis_iff, Basis.localizationLocalization_span F (P.integers)⁰ F']
+  rw [IsIntegralBasis, Basis.localizationLocalization_span F (P.integers)⁰ F']
   ext x
   simp
 
 variable [Algebra.IsSeparable F F']
-
-/-- The local model `𝒪'_P` is a Dedekind domain. -/
-instance isDedekindDomain_integralClosure :
-    IsDedekindDomain (integralClosure (P.integers) F') :=
-  integralClosure.isDedekindDomain (A := P.integers) (K := F) (L := F')
-
-/-- The local model `𝒪'_P` is module-finite over `𝒪_P`. -/
-instance moduleFinite_integralClosure :
-    Module.Finite (P.integers) (integralClosure (P.integers) F') :=
-  IsIntegralClosure.finite (A := P.integers) (K := F) (L := F') _
-
-/-- Separability of `F' / F`, transported to the canonical fraction fields used by the
-integral-closure API. -/
-instance isSeparable_fractionRing_integralClosure :
-    Algebra.IsSeparable (FractionRing (P.integers))
-      (FractionRing (integralClosure (P.integers) F')) := by
-  refine Algebra.IsSeparable.of_equiv_equiv (FractionRing.algEquiv (P.integers) F).symm.toRingEquiv
-    (FractionRing.algEquiv (integralClosure (P.integers) F') F').symm.toRingEquiv ?_
-  apply IsLocalization.ringHom_ext (P.integers)⁰
-  ext a
-  simp only [RingHom.coe_comp, Function.comp_apply, RingHom.coe_coe, AlgEquiv.coe_ringEquiv,
-    AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
-  rw [IsScalarTower.algebraMap_apply (P.integers) (integralClosure (P.integers) F') F',
-    AlgEquiv.commutes, ← IsScalarTower.algebraMap_apply]
 
 /-- The rank of the local integral closure is the degree of the field extension:
 `rank_{𝒪_P} 𝒪'_P = [F' : F]`. -/
@@ -231,10 +208,7 @@ integral basis lie in `𝒪_P`** (Stichtenoth, Corollary 3.3.5). -/
 theorem isIntegral_iff_repr_mem {x : F'} :
     IsIntegral (P.integers) x ↔
       ∀ i, (localIntegralBasis F' P).repr x i ∈ P.integers := by
-  rw [← (isIntegralBasis_localIntegralBasis F' P).mem_span_iff_isIntegral,
-    Basis.mem_span_iff_repr_mem (P.integers) (localIntegralBasis F' P) x]
-  exact forall_congr' fun _ ↦
-    ⟨fun ⟨r, hr⟩ ↦ hr ▸ r.2, fun hy ↦ ⟨⟨_, hy⟩, rfl⟩⟩
+  exact (isIntegralBasis_localIntegralBasis F' P).isIntegral_iff_repr_mem
 
 end Place
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
@@ -141,9 +141,10 @@ theorem IsIntegralBasis.isIntegral_iff_repr_mem {ι : Type*} {b : Basis ι F F'}
 
 /-! ### The local integral closure -/
 
-variable [FiniteDimensional F F']
+section Localization
 
-attribute [local instance] isLocalization_integralClosure
+variable [IsLocalization
+  (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F']
 
 /-- Extending any `𝒪_P`-basis of the local integral closure `𝒪'_P` to the fraction fields gives
 an integral basis at `P`.  This is Stichtenoth, Corollary 3.3.5. -/
@@ -153,6 +154,12 @@ theorem isIntegralBasis_localizationLocalization {ι : Type*}
   rw [IsIntegralBasis, Basis.localizationLocalization_span F (P.integers)⁰ F']
   ext x
   simp
+
+end Localization
+
+variable [FiniteDimensional F F']
+
+attribute [local instance] isLocalization_integralClosure
 
 variable [Algebra.IsSeparable F F']
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
@@ -6,7 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.RingTheory.DedekindDomain.IntegralClosure
-public import TauCeti.FieldTheory.FunctionField.AffineModel.Extension
+public import Mathlib.RingTheory.Localization.Module
+public import TauCeti.FieldTheory.FunctionField.Place.Extension.Basic
 
 /-!
 # Local integral bases of extensions of algebraic function fields
@@ -21,11 +22,28 @@ basis of that module and extending scalars from `𝒪_P` to its fraction field `
 `F' / F` consisting of elements integral over `𝒪_P`.  This is the local integral basis of
 Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Corollary 3.3.5.
 
+This file also owns the local model `𝒪_P ⊆ 𝒪'_P` that the later layers work with: on top of the
+action of `𝒪_P` on `F'` supplied by
+`TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean` it records that `F'` is the
+fraction field — indeed the localization at `(𝒪_P)⁰` — of `𝒪'_P`, that `𝒪'_P` is a Dedekind domain
+and module-finite over `𝒪_P`, and it transports separability to the canonical fraction fields over
+which Mathlib states the different.
+
 The freeness and rank calculation are specializations of Mathlib's generic integral-closure
 theorems `IsIntegralClosure.module_free` and `IsIntegralClosure.rank`.  The point of this file is
 the function-field interface: the basis is indexed by `Fin [F' : F]`, its vectors are visibly
 integral, and their `𝒪_P`-span inside `F'` is exactly `𝒪'_P`.  These are the forms used by the
 complementary module and different of the next layer.
+
+The basis material is the place-local analogue of Mathlib's `NumberField.integralBasis` API in
+`Mathlib.NumberTheory.NumberField.Basic`, and is built the same way:
+`TauCeti.Place.finrank_integralClosure` matches `NumberField.RingOfIntegers.rank`,
+`TauCeti.Place.localIntegralBasis` matches `NumberField.integralBasis`,
+`TauCeti.Place.localIntegralBasis_apply` and
+`TauCeti.Place.localIntegralBasis_repr_algebraMap` match `NumberField.integralBasis_apply` and
+`NumberField.integralBasis_repr_apply`, and
+`TauCeti.Place.isIntegralBasis_localizationLocalization` plays the role of
+`NumberField.mem_span_integralBasis`.
 
 ## Main definitions
 
@@ -37,11 +55,21 @@ complementary module and different of the next layer.
 
 ## Main results
 
-* `TauCeti.Place.localIntegralBasis_isIntegral`: every basis vector is integral over `𝒪_P`.
-* `TauCeti.Place.span_localIntegralBasis`: the `𝒪_P`-span of the basis vectors is exactly the
-  integral closure `𝒪'_P` inside `F'`.
-* `TauCeti.Place.mem_span_localIntegralBasis_iff`: an element of `F'` has integral coordinates
-  in the local basis exactly when it is integral over `𝒪_P`.
+* `TauCeti.Place.IsIntegralBasis.isIntegral` and
+  `TauCeti.Place.IsIntegralBasis.mem_span_iff_isIntegral`: what an integral basis at `P` gives —
+  integral vectors, and an integral span that detects integrality.
+* `TauCeti.Place.isLocalization_integralClosure`: `F'` is the localization of `𝒪'_P` at the
+  nonzero divisors of `𝒪_P`.
+* `TauCeti.Place.finrank_integralClosure`: `rank_{𝒪_P} 𝒪'_P = [F' : F]`.
+* `TauCeti.Place.isIntegralBasis_localizationLocalization`: extending any `𝒪_P`-basis of `𝒪'_P`
+  to the fraction fields gives an integral basis at `P`.
+* `TauCeti.Place.isIntegralBasis_localIntegralBasis`: the chosen basis
+  `TauCeti.Place.localIntegralBasis` is one; this is the existence statement of Stichtenoth,
+  Corollary 3.3.5.
+* `TauCeti.Place.localIntegralBasis_repr_algebraMap`: the coordinates of an integral element in
+  the local integral basis are the images of its coordinates in the `𝒪_P`-basis of `𝒪'_P`.
+* `TauCeti.Place.isIntegral_iff_repr_mem`: an element of `F'` is integral over `𝒪_P` exactly when
+  all its coordinates in the local integral basis lie in `𝒪_P`.
 
 ## References
 
@@ -67,43 +95,21 @@ universe u v v'
 variable {k : Type u} {F : Type v} {F' : Type v'}
 variable [Field k] [Field F] [Field F'] [Algebra k F] [Algebra F F']
 
-/-! ### The local integral closure -/
+attribute [local instance 10] algebraIntegersExtension isScalarTowerIntegersExtension
+
+/-! ### Integral bases at a place -/
 
 variable (F') (P : Place k F)
-
-/-- **The valuation ring of a place of `F / k` acts on an extension field `F'`**, through `F`.
-
-This is not a global instance: for `F' = F` it would compete with the action of a valuation
-subring on its own field. Install it, together with
-`TauCeti.Place.isScalarTowerIntegersExtension`, with `attribute [local instance 10]` in any file
-that works with the local model of the extension at `P`. -/
-@[instance_reducible]
-noncomputable def algebraIntegersExtension : Algebra (P.integers) F' :=
-  ((algebraMap F F').comp (algebraMap (P.integers) F)).toAlgebra
-
-attribute [local instance 10] algebraIntegersExtension
-
-/-- The action of `TauCeti.Place.algebraIntegersExtension` on `F'` factors through `F`. -/
-theorem isScalarTowerIntegersExtension : IsScalarTower (P.integers) F F' :=
-  .of_algebraMap_eq fun _ ↦ rfl
-
-attribute [local instance 10] isScalarTowerIntegersExtension
-
-theorem algebraMap_integersExtension_injective :
-    Function.Injective (algebraMap (P.integers) F') := by
-  rw [IsScalarTower.algebraMap_eq (P.integers) F F', RingHom.coe_comp]
-  exact (algebraMap F F').injective.comp (FaithfulSMul.algebraMap_injective (P.integers) F)
-
-instance isTorsionFree_integersExtension : Module.IsTorsionFree (P.integers) F' :=
-  Module.IsTorsionFree.comap (M := F') (algebraMap (P.integers) F')
-    (fun _ hr ↦ isRegular_iff_ne_zero'.mpr fun h ↦ isRegular_iff_ne_zero'.mp hr
-      (algebraMap_integersExtension_injective F' P (by simpa using h)))
-    (fun r m ↦ (Algebra.smul_def r m).symm)
 
 /-- An `F`-basis of `F'` is an **integral basis at `P`** when its `𝒪_P`-span is exactly the
 integral closure `𝒪'_P` inside `F'` (Stichtenoth, Section III.3). -/
 def IsIntegralBasis {ι : Type*} (b : Basis ι F F') : Prop :=
   Submodule.span (P.integers) (Set.range b) = (integralClosure (P.integers) F').toSubmodule
+
+theorem isIntegralBasis_iff {ι : Type*} (b : Basis ι F F') :
+    P.IsIntegralBasis F' b ↔
+      Submodule.span (P.integers) (Set.range b) =
+        (integralClosure (P.integers) F').toSubmodule := Iff.rfl
 
 /-- Every vector of an integral basis at `P` is integral over `𝒪_P`. -/
 theorem IsIntegralBasis.isIntegral {ι : Type*} {b : Basis ι F F'} (hb : P.IsIntegralBasis F' b)
@@ -119,12 +125,34 @@ theorem IsIntegralBasis.mem_span_iff_isIntegral {ι : Type*} {b : Basis ι F F'}
   rw [hb, Subalgebra.mem_toSubmodule]
   exact mem_integralClosure_iff (P.integers) F'
 
-variable [FiniteDimensional F F'] [Algebra.IsSeparable F F']
+/-! ### The local integral closure -/
+
+variable [FiniteDimensional F F']
 
 /-- The local model `𝒪'_P` — the integral closure of `𝒪_P` in `F'` — has fraction field `F'`. -/
 instance isFractionRing_integralClosure :
     IsFractionRing (integralClosure (P.integers) F') F' :=
   IsIntegralClosure.isFractionRing_of_finite_extension (P.integers) F F' _
+
+/-- More precisely, `F'` is the localization of the local model `𝒪'_P` at the nonzero divisors
+of `𝒪_P`.  This is the form in which the `Basis.localizationLocalization` API consumes it. -/
+theorem isLocalization_integralClosure :
+    IsLocalization
+      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
+  IsIntegralClosure.isLocalization (P.integers) F F' _
+
+attribute [local instance] isLocalization_integralClosure
+
+/-- Extending any `𝒪_P`-basis of the local integral closure `𝒪'_P` to the fraction fields gives
+an integral basis at `P`.  This is Stichtenoth, Corollary 3.3.5. -/
+theorem isIntegralBasis_localizationLocalization {ι : Type*}
+    (c : Basis ι (P.integers) (integralClosure (P.integers) F')) :
+    P.IsIntegralBasis F' (c.localizationLocalization F (P.integers)⁰ F') := by
+  rw [isIntegralBasis_iff, Basis.localizationLocalization_span F (P.integers)⁰ F']
+  ext x
+  simp
+
+variable [Algebra.IsSeparable F F']
 
 /-- The local model `𝒪'_P` is a Dedekind domain. -/
 instance isDedekindDomain_integralClosure :
@@ -167,68 +195,44 @@ noncomputable def integralClosureFinBasis :
 /-- **A local integral basis at `P`** (Stichtenoth, Corollary 3.3.5): extend an `𝒪_P`-basis of
 the local integral closure `𝒪'_P` to the fraction fields. The resulting `F`-basis of `F'` is
 indexed by `Fin [F' : F]`, and its `𝒪_P`-span is exactly `𝒪'_P`. -/
-noncomputable def localIntegralBasis : Basis (Fin (Module.finrank F F')) F F' := by
-  letI : IsLocalization
-      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
-    IsIntegralClosure.isLocalization (P.integers) F F' (integralClosure (P.integers) F')
-  exact (integralClosureFinBasis F' P).localizationLocalization F (P.integers)⁰ F'
+noncomputable def localIntegralBasis : Basis (Fin (Module.finrank F F')) F F' :=
+  (integralClosureFinBasis F' P).localizationLocalization F (P.integers)⁰ F'
 
 /-- A vector of the local integral basis is the image in `F'` of the corresponding vector of
 the `𝒪_P`-basis of `𝒪'_P`. -/
 @[simp]
 theorem localIntegralBasis_apply (i : Fin (Module.finrank F F')) :
     localIntegralBasis F' P i =
-      algebraMap (integralClosure (P.integers) F') F' (integralClosureFinBasis F' P i) := by
-  let _ : IsLocalization
-      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
-    IsIntegralClosure.isLocalization (P.integers) F F' (integralClosure (P.integers) F')
-  exact Basis.localizationLocalization_apply F (P.integers)⁰ F'
-    (integralClosureFinBasis F' P) i
+      algebraMap (integralClosure (P.integers) F') F' (integralClosureFinBasis F' P i) :=
+  Basis.localizationLocalization_apply F (P.integers)⁰ F' (integralClosureFinBasis F' P) i
 
 /-- The coordinates of an integral element in the local integral basis are the images in `F` of
 its coordinates in the `𝒪_P`-basis of `𝒪'_P`. -/
 @[simp]
-theorem localIntegralBasis_repr_coe (x : integralClosure (P.integers) F')
+theorem localIntegralBasis_repr_algebraMap (x : integralClosure (P.integers) F')
     (i : Fin (Module.finrank F F')) :
-    (localIntegralBasis F' P).repr (x : F') i =
-      algebraMap (P.integers) F ((integralClosureFinBasis F' P).repr x i) := by
-  let _ : IsLocalization
-      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
-    IsIntegralClosure.isLocalization (P.integers) F F' (integralClosure (P.integers) F')
-  rw [localIntegralBasis]
-  simpa only [Subalgebra.algebraMap_apply] using
-    Basis.localizationLocalization_repr_algebraMap F (P.integers)⁰ F'
-      (integralClosureFinBasis F' P) x i
+    (localIntegralBasis F' P).repr
+        (algebraMap (integralClosure (P.integers) F') F' x) i =
+      algebraMap (P.integers) F ((integralClosureFinBasis F' P).repr x i) :=
+  Basis.localizationLocalization_repr_algebraMap F (P.integers)⁰ F'
+    (integralClosureFinBasis F' P) x i
 
-/-- **The integral span of a local integral basis is the local integral closure `𝒪'_P`.** -/
-theorem span_localIntegralBasis :
-    Submodule.span (P.integers) (Set.range (localIntegralBasis F' P)) =
-      (integralClosure (P.integers) F').toSubmodule := by
-  let _ : IsLocalization
-      (Algebra.algebraMapSubmonoid (integralClosure (P.integers) F') (P.integers)⁰) F' :=
-    IsIntegralClosure.isLocalization (P.integers) F F' (integralClosure (P.integers) F')
-  rw [localIntegralBasis]
-  rw [Basis.localizationLocalization_span F (P.integers)⁰ F']
-  ext x
-  simp
-
-/-- The chosen `localIntegralBasis` is an integral basis at `P`. This is the existence statement
-of Stichtenoth, Corollary 3.3.5. -/
+/-- **The chosen `localIntegralBasis` is an integral basis at `P`**: its `𝒪_P`-span is exactly
+the local integral closure `𝒪'_P`.  This is the existence statement of Stichtenoth,
+Corollary 3.3.5. -/
 theorem isIntegralBasis_localIntegralBasis :
     P.IsIntegralBasis F' (localIntegralBasis F' P) :=
-  span_localIntegralBasis F' P
+  isIntegralBasis_localizationLocalization F' P (integralClosureFinBasis F' P)
 
-/-- Every vector of the chosen local integral basis is integral over `𝒪_P`. -/
-theorem localIntegralBasis_isIntegral (i : Fin (Module.finrank F F')) :
-    IsIntegral (P.integers) (localIntegralBasis F' P i) :=
-  IsIntegralBasis.isIntegral (F' := F') (P := P) (isIntegralBasis_localIntegralBasis F' P) i
-
-/-- An element of `F'` has integral coordinates in the local integral basis exactly when it is
-integral over `𝒪_P`. -/
-theorem mem_span_localIntegralBasis_iff {x : F'} :
-    x ∈ Submodule.span (P.integers) (Set.range (localIntegralBasis F' P)) ↔
-      IsIntegral (P.integers) x := by
-  exact (isIntegralBasis_localIntegralBasis F' P).mem_span_iff_isIntegral
+/-- **An element of `F'` is integral over `𝒪_P` exactly when all of its coordinates in the local
+integral basis lie in `𝒪_P`** (Stichtenoth, Corollary 3.3.5). -/
+theorem isIntegral_iff_repr_mem {x : F'} :
+    IsIntegral (P.integers) x ↔
+      ∀ i, (localIntegralBasis F' P).repr x i ∈ P.integers := by
+  rw [← (isIntegralBasis_localIntegralBasis F' P).mem_span_iff_isIntegral,
+    Basis.mem_span_iff_repr_mem (P.integers) (localIntegralBasis F' P) x]
+  exact forall_congr' fun _ ↦
+    ⟨fun ⟨r, hr⟩ ↦ hr ▸ r.2, fun hy ↦ ⟨⟨_, hy⟩, rfl⟩⟩
 
 end Place
 

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
@@ -213,11 +213,11 @@ its coordinates in the `𝒪_P`-basis of `𝒪'_P`. -/
 @[simp]
 theorem localIntegralBasis_repr_algebraMap (x : integralClosure (P.integers) F')
     (i : Fin (Module.finrank F F')) :
-    (localIntegralBasis F' P).repr
-        (algebraMap (integralClosure (P.integers) F') F' x) i =
-      algebraMap (P.integers) F ((integralClosureFinBasis F' P).repr x i) :=
-  Basis.localizationLocalization_repr_algebraMap F (P.integers)⁰ F'
-    (integralClosureFinBasis F' P) x i
+    (localIntegralBasis F' P).repr (x : F') i =
+      algebraMap (P.integers) F ((integralClosureFinBasis F' P).repr x i) := by
+  simpa only [localIntegralBasis, Subalgebra.algebraMap_apply] using
+    Basis.localizationLocalization_repr_algebraMap F (P.integers)⁰ F'
+      (integralClosureFinBasis F' P) x i
 
 /-- **The chosen `localIntegralBasis` is an integral basis at `P`**: its `𝒪_P`-span is exactly
 the local integral closure `𝒪'_P`.  This is the existence statement of Stichtenoth,

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean
@@ -106,6 +106,8 @@ integral closure `𝒪'_P` inside `F'` (Stichtenoth, Section III.3). -/
 def IsIntegralBasis {ι : Type*} (b : Basis ι F F') : Prop :=
   Submodule.span (P.integers) (Set.range b) = (integralClosure (P.integers) F').toSubmodule
 
+/-- An `F`-basis of `F'` is an integral basis at `P` exactly when its `𝒪_P`-span is the local
+integral closure `𝒪'_P`. -/
 theorem isIntegralBasis_iff {ι : Type*} (b : Basis ι F F') :
     P.IsIntegralBasis F' b ↔
       Submodule.span (P.integers) (Set.range b) =


### PR DESCRIPTION
This PR constructs a local integral basis for a finite separable extension `F' / F` at a place `P`: the integral closure `𝒪'_P` is finite free of rank `[F' : F]` over the discrete valuation ring `𝒪_P`, and extending an `𝒪_P`-basis to the fraction fields gives an `F`-basis of `F'` whose integral span is exactly `𝒪'_P`. The mathematics is Stichtenoth, *Algebraic Function Fields and Codes*, 2nd ed., Corollary 3.3.5.

The exact target is `TauCetiRoadmap/AlgebraicCurves/README.md`, Layer 6, “Integral closures and local integral bases (III.2–III.3),” specifically “`𝒪'_P =` integral closure of `𝒪_P` in `F'` with **local integral bases** for separable `F'/F` (Cor. 3.3.5, Thm. 3.3.6: almost every basis is one).” This PR supplies Corollary 3.3.5 and the predicate needed to state its sequel; after it, this item still needs Theorem 3.3.6, that any fixed `F`-basis is an integral basis at all but finitely many places.

This is the most effective unclaimed step on the current dependency path because the Layer-4 duality theorem is waiting on the open divisor-of-a-Weil-differential work, while local integral bases are the remaining Layer-6 input to the complementary-module and cotrace development in Layer 7. It does not overlap open PR #4954: that PR identifies the integral closure with the intersection of the valuation rings over `P`, while this one proves freeness, rank, and supplies a basis and coordinate API.

The new 237-line module `TauCeti/FieldTheory/FunctionField/Place/Extension/IntegralBasis.lean` defines `Place.IsIntegralBasis`, constructs `Place.integralClosureFinBasis` and `Place.localIntegralBasis` indexed by `Fin [F' : F]`, computes the coordinates of integral elements, and proves that the `𝒪_P`-span of the basis is exactly the integral closure. It reuses Mathlib’s `IsIntegralClosure.module_free`, `IsIntegralClosure.rank`, `Module.finBasisOfFinrankEq`, and `Basis.localizationLocalization`; no Mathlib code or external formalization is vendored.

The PR also relocates the 74-line local integral-closure setup from `Different/Basic.lean` into the new Layer-6 module, so the earlier local-basis theory owns the algebra/scalar-tower, fraction-field, finiteness, Dedekind, and separability infrastructure that the different continues to consume. Declaration names are unchanged, and no compatibility surface is added.

Roadmap: AlgebraicCurves

<!--tauceti-target:v1 {"focus":"AlgebraicCurves","id":"local-integral-bases"}-->

🤖 Prepared with Codex
