### PR TITLE
refactor(EllipticCurve): name the valuation at infinity of a rational function

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Basic.lean
@@ -271,12 +271,12 @@ theorem infinityPlace.algebraMap_eq_sq (r : RatFunc F) :
   rw [infinityPlace_apply, Algebra.norm_algebraMap, finrank_functionField, map_pow]
 
 open scoped Classical in
-/-- **The valuation at infinity of a rational function of `x`** is `exp` of twice its degree.
+/-- **The valuation at infinity of a nonzero rational function of `x`** is `exp` of twice its
+degree: `v_∞ r = exp (2 * r.intDegree)`, which is `ord_∞ r = -2 * r.intDegree`.
 
-`infinityPlace.algebraMap_eq_sq`, composed with Mathlib's valuation of a nonzero rational function
-at its `intDegree`: the extension `F(W)/F(x)` is quadratic, so the exponent doubles. The pole order
-at infinity is therefore `-2 * intDegree`, which is why a rational function of `x` lies in the
-maximal ideal at infinity exactly when its degree is negative. -/
+The factor two is the ramification index of the place at infinity over the infinite place of
+`F(x)`, so a nonzero rational function of `x` lies in the maximal ideal at infinity exactly when
+its degree is negative. -/
 theorem infinityPlace_algebraMap_ratFunc {r : RatFunc F} (hr : r ≠ 0) :
     infinityPlace W (algebraMap (RatFunc F) W.FunctionField r) =
       WithZero.exp (2 * r.intDegree) := by
@@ -285,10 +285,9 @@ theorem infinityPlace_algebraMap_ratFunc {r : RatFunc F} (hr : r ≠ 0) :
   ring_nf
 
 open scoped Classical in
-/-- **The valuation at infinity of a polynomial in `x`** is `exp` of twice its degree.
-
-The polynomial case of `infinityPlace_algebraMap_ratFunc`, whose `intDegree` is the `natDegree`
-here. `infinityPlace.X` is the further case `p = X`. -/
+/-- **The valuation at infinity of a polynomial in `x`** is `exp` of twice its degree: a nonzero
+polynomial of degree `n` has a pole of order `2 * n` at infinity. `infinityPlace.X` is the case
+`p = X`. -/
 theorem infinityPlace_algebraMap_polynomial {p : F[X]} (hp : p ≠ 0) :
     infinityPlace W (algebraMap F[X] W.FunctionField p) =
       WithZero.exp (2 * (p.natDegree : ℤ)) := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace/Basic.lean
@@ -271,18 +271,29 @@ theorem infinityPlace.algebraMap_eq_sq (r : RatFunc F) :
   rw [infinityPlace_apply, Algebra.norm_algebraMap, finrank_functionField, map_pow]
 
 open scoped Classical in
+/-- **The valuation at infinity of a rational function of `x`** is `exp` of twice its degree.
+
+`infinityPlace.algebraMap_eq_sq`, composed with Mathlib's valuation of a nonzero rational function
+at its `intDegree`: the extension `F(W)/F(x)` is quadratic, so the exponent doubles. The pole order
+at infinity is therefore `-2 * intDegree`, which is why a rational function of `x` lies in the
+maximal ideal at infinity exactly when its degree is negative. -/
+theorem infinityPlace_algebraMap_ratFunc {r : RatFunc F} (hr : r ≠ 0) :
+    infinityPlace W (algebraMap (RatFunc F) W.FunctionField r) =
+      WithZero.exp (2 * r.intDegree) := by
+  rw [infinityPlace.algebraMap_eq_sq, RatFunc.inftyValuation_apply,
+    RatFunc.inftyValuation_of_nonzero F hr, ← WithZero.exp_nsmul]
+  ring_nf
+
+open scoped Classical in
 /-- **The valuation at infinity of a polynomial in `x`** is `exp` of twice its degree.
 
-The polynomial case of `infinityPlace.algebraMap_eq_sq`, composed with Mathlib's valuation of a
-nonzero polynomial at its degree: the extension `F(W)/F(x)` is quadratic, so the exponent
-doubles. `infinityPlace.X` is the case `p = X`. -/
+The polynomial case of `infinityPlace_algebraMap_ratFunc`, whose `intDegree` is the `natDegree`
+here. `infinityPlace.X` is the further case `p = X`. -/
 theorem infinityPlace_algebraMap_polynomial {p : F[X]} (hp : p ≠ 0) :
     infinityPlace W (algebraMap F[X] W.FunctionField p) =
       WithZero.exp (2 * (p.natDegree : ℤ)) := by
   rw [IsScalarTower.algebraMap_apply F[X] (RatFunc F) W.FunctionField,
-    infinityPlace.algebraMap_eq_sq, RatFunc.inftyValuation_apply,
-    RatFunc.inftyValuation.polynomial F hp, ← WithZero.exp_nsmul]
-  ring_nf
+    infinityPlace_algebraMap_ratFunc W (by simpa using hp), RatFunc.intDegree_polynomial]
 
 open scoped Classical in
 /-- **The valuation is trivial on the base field**: a nonzero constant has value `1`, so `v_∞`

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/PointPlace.lean
@@ -197,11 +197,9 @@ theorem degree_infinity : (infinity W).degree = 1 := by
     · have hAc0 : A - RatFunc.C c ≠ 0 := by
         intro h
         simp [h] at hAc
-      rw [WeierstrassCurve.Affine.infinityPlace.algebraMap_eq_sq,
-        sq_lt_one_iff₀ zero_le, RatFunc.inftyValuation_apply,
-        RatFunc.inftyValuation_of_nonzero F hAc0, ← WithZero.exp_zero,
-        WithZero.exp_lt_exp]
-      exact hAc
+      rw [WeierstrassCurve.Affine.infinityPlace_algebraMap_ratFunc W hAc0,
+        ← WithZero.exp_zero, WithZero.exp_lt_exp]
+      omega
   have hBval : W.infinityPlace
       (algebraMap (RatFunc F) W.FunctionField B *
         algebraMap W.CoordinateRing W.FunctionField
@@ -210,12 +208,10 @@ theorem degree_infinity : (infinity W).degree = 1 := by
     · simp [hB]
     · by_cases hB0 : B = 0
       · simp [hB0]
-      · have hBnegative : 2 * B.intDegree + 3 < 0 := by omega
-        rw [map_mul, WeierstrassCurve.Affine.infinityPlace.algebraMap_eq_sq,
-          RatFunc.inftyValuation_apply, RatFunc.inftyValuation_of_nonzero F hB0,
-          WeierstrassCurve.Affine.infinityPlace.mk_Y, ← WithZero.exp_nsmul,
-          ← WithZero.exp_add, ← WithZero.exp_zero, WithZero.exp_lt_exp]
-        simpa [two_nsmul] using hBnegative
+      · rw [map_mul, WeierstrassCurve.Affine.infinityPlace_algebraMap_ratFunc W hB0,
+          WeierstrassCurve.Affine.infinityPlace.mk_Y, ← WithZero.exp_add,
+          ← WithZero.exp_zero, WithZero.exp_lt_exp]
+        omega
   calc
     W.infinityPlace (f - algebraMap F W.FunctionField c) =
         W.infinityPlace


### PR DESCRIPTION
## What

`InfinityPlace/Basic.lean` carried the **polynomial** case of the valuation at infinity
(`infinityPlace_algebraMap_polynomial`, phrased in `natDegree`) but not the rational-function
case. As a result `PointPlace.degree_infinity` re-derived that computation inline, **twice**,
each time expanding `infinityPlace.algebraMap_eq_sq` by hand through
`RatFunc.inftyValuation_apply`, `RatFunc.inftyValuation_of_nonzero` and the `WithZero.exp`
arithmetic.

This names the general fact and routes the existing consumers through it:

* **new** `WeierstrassCurve.Affine.infinityPlace_algebraMap_ratFunc`: for `r ≠ 0`,
  `v_∞ (algebraMap (RatFunc F) F(W) r) = exp (2 * r.intDegree)`.
* `infinityPlace_algebraMap_polynomial` becomes its **corollary** via
  `RatFunc.intDegree_polynomial` — its own three-step derivation is deleted, not duplicated.
* the two `have`s in `degree_infinity` that put `A - C c` and `B * y` in the maximal ideal at
  infinity now rewrite with the new lemma and close by `omega`; `sq_lt_one_iff₀`,
  `RatFunc.inftyValuation_apply`, `RatFunc.inftyValuation_of_nonzero`, `WithZero.exp_nsmul` and
  `two_nsmul` all leave those call sites.

**Three call sites**, so the new lemma is not a one-use wrapper.

**No statement, name or signature changes.** `infinityPlace_algebraMap_polynomial` and
`degree_infinity` keep their exact statements; only proofs move.

## Why this is the right generality

`intDegree` is the honest invariant: `infinityPlace.algebraMap_eq_sq` already lands in
`RatFunc.inftyValuation`, whose value at a nonzero argument *is* `exp intDegree`. The `natDegree`
form was the special case, and having only the special case is precisely what forced both
consumers to re-expand the general one.

Deliberately **not** `@[simp]`: `infinityPlace.algebraMap_eq_sq` is already a simp lemma with the
identical left-hand side `infinityPlace W (algebraMap (RatFunc F) W.FunctionField r)`, so tagging
this one would put two simp lemmas on the same LHS. `infinityPlace_algebraMap_polynomial` is
untagged for the same reason; this matches it.

## Round 1: documentation

`documentation` asked that the two docstrings describe their results rather than the lemmas their
proofs compose. Both are rewritten to state only the result: the valuation, the pole order in this
file's own `ord_∞ = -exp` convention (matching `infinityPlace.X` and `infinityPlace.mk_Y` directly
above), the ramification index that accounts for the factor two (the language
`infinityPlace.algebraMap_eq_sq` already uses), and the maximal-ideal characterisation that is
what both `degree_infinity` call sites actually consume.

While rewriting, the rational-function docstring also gained the **nonzero** qualifier it had
always needed: the formula fails at `r = 0`, where `intDegree 0 = 0` but the valuation is `0`, so
the unqualified heading promised more than the statement delivers. The polynomial docstring
already said "nonzero".

**No Lean statement, signature or proof changed in this round** — docstring text only.

## Gates

* `lake build` of both changed modules and the two direct importers of the changed API
  (`InfinityPlace.Unique`, `Isogeny.MulByInt.InfinityPlace`) — **green** at this head, 2898 jobs,
  exit 0, no warnings. Re-run after rebasing onto current `main`.
* `lake exe runLinter` on `...InfinityPlace.Basic` and `...PointPlace` — **passed**, both exit 0.
* `scripts/lint-env.sh` could not run locally: it needs a full-library build to elaborate its
  docstring-scan driver and fails with `object file ... TauCeti/Algebra/AddCircle.olean does not
  exist`, a module outside this change's dependency closure. That is the known partial-build
  driver limitation, not a finding against this diff; CI's full `pr-build` covers it.

Roadmap: EllipticCurves

Attribution measured, not inferred from the directory name:
`TauCetiRoadmap/EllipticCurves/README.md:343-344` names `W.infinityPlace` by its Lean name with
its pole orders and residue field, and :356 names the degree-`1` places `O ↦ infinityPlace` —
the milestone `degree_infinity` discharges. (`AlgebraicCurves` and `BelyiMaps` also discuss
residue degrees, but generically; neither names `W.infinityPlace`.) No new mathematics: this is a
refactor plus a modest generalisation of an existing lemma, which `.claude/CLAUDE.md` puts in
scope without a roadmap entry.
