### PR TITLE
feat: multiply Bruhat cells in a Tits system

### DIFF
--- a/TauCeti/GroupTheory/TitsSystem/Basic.lean
+++ b/TauCeti/GroupTheory/TitsSystem/Basic.lean
@@ -54,25 +54,25 @@ structure TitsSystem (G : Type u) [Group G] where
   closure_subgroupB_union_subgroupN :
     Subgroup.closure ((subgroupB : Set G) ∪ subgroupN) = ⊤
   /-- The intersection `B ∩ N`, regarded inside `N`, is normal. -/
-  intersection_normal : (subgroupB.comap subgroupN.subtype).Normal
+  intersection_normal : (subgroupB.subgroupOf subgroupN).Normal
   /-- The simple reflections in the Weyl quotient `N / (B ∩ N)`. -/
-  simple : Set (subgroupN ⧸ subgroupB.comap subgroupN.subtype)
+  simple : Set (subgroupN ⧸ subgroupB.subgroupOf subgroupN)
   /-- The simple reflections generate the Weyl quotient. -/
   closure_simple :
     let _ := intersection_normal
     Subgroup.closure simple = ⊤
   /-- Every simple reflection has a representative whose square lies in `B ∩ N`. -/
   exists_simpleRep_sq_mem
-      (s : subgroupN ⧸ subgroupB.comap subgroupN.subtype) (hs : s ∈ simple) :
+      (s : subgroupN ⧸ subgroupB.subgroupOf subgroupN) (hs : s ∈ simple) :
     ∃ r : subgroupN,
-      (QuotientGroup.mk r : subgroupN ⧸ subgroupB.comap subgroupN.subtype) = s ∧
-        r * r ∈ subgroupB.comap subgroupN.subtype
+      (QuotientGroup.mk r : subgroupN ⧸ subgroupB.subgroupOf subgroupN) = s ∧
+        r * r ∈ subgroupB.subgroupOf subgroupN
   /-- Multiplying a Bruhat cell on the left by a simple cell produces at most the adjacent cell
   and the original cell. -/
   mul_doubleCoset_subset
-      (s : subgroupN ⧸ subgroupB.comap subgroupN.subtype) (hs : s ∈ simple) :
+      (s : subgroupN ⧸ subgroupB.subgroupOf subgroupN) (hs : s ∈ simple) :
     ∃ r : subgroupN,
-      (QuotientGroup.mk r : subgroupN ⧸ subgroupB.comap subgroupN.subtype) = s ∧
+      (QuotientGroup.mk r : subgroupN ⧸ subgroupB.subgroupOf subgroupN) = s ∧
         ∀ w : subgroupN,
           DoubleCoset.doubleCoset (r : G) subgroupB subgroupB *
               DoubleCoset.doubleCoset (w : G) subgroupB subgroupB ⊆
@@ -80,9 +80,9 @@ structure TitsSystem (G : Type u) [Group G] where
               DoubleCoset.doubleCoset (w : G) subgroupB subgroupB
   /-- No simple reflection conjugates `B` into `B`. -/
   exists_conj_not_mem
-      (s : subgroupN ⧸ subgroupB.comap subgroupN.subtype) (hs : s ∈ simple) :
+      (s : subgroupN ⧸ subgroupB.subgroupOf subgroupN) (hs : s ∈ simple) :
     ∃ r : subgroupN,
-      (QuotientGroup.mk r : subgroupN ⧸ subgroupB.comap subgroupN.subtype) = s ∧
+      (QuotientGroup.mk r : subgroupN ⧸ subgroupB.subgroupOf subgroupN) = s ∧
         ∃ b : subgroupB, (r : G) * (b : G) * (r : G)⁻¹ ∉ subgroupB
 
 namespace TitsSystem
@@ -91,7 +91,7 @@ variable {G : Type u} [Group G] (T : TitsSystem G)
 
 /-- The intersection `B ∩ N`, regarded as a subgroup of `N`. -/
 abbrev intersection : Subgroup T.subgroupN :=
-  T.subgroupB.comap T.subgroupN.subtype
+  T.subgroupB.subgroupOf T.subgroupN
 
 /-- Membership in the intersection means membership in `B` after forgetting the `N` subtype. -/
 theorem mem_intersection (n : T.subgroupN) : n ∈ T.intersection ↔ (n : G) ∈ T.subgroupB :=

--- a/TauCeti/GroupTheory/TitsSystem/Basic.lean
+++ b/TauCeti/GroupTheory/TitsSystem/Basic.lean
@@ -27,7 +27,7 @@ double cosets satisfy the Tits multiplication and nondegeneracy axioms.
 
 ## References
 
-* J. E. Humphreys, *Linear Algebraic Groups* (1975), Section 28.1.
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), Sections 29.1--29.2.
 * T. A. Springer, *Linear Algebraic Groups*, second edition (1998), Section 8.3.
 -/
 

--- a/TauCeti/GroupTheory/TitsSystem/Bruhat.lean
+++ b/TauCeti/GroupTheory/TitsSystem/Bruhat.lean
@@ -29,11 +29,11 @@ subgroup containing both `B` and `N`, hence is all of `G` by the generation axio
 
 * `TauCeti.TitsSystem.bruhatCells`: the union of the double cosets `B n B`, for `n ∈ N`.
 * `TauCeti.TitsSystem.bruhatCell`: the Bruhat cell indexed by an element of the Weyl group.
+* `TauCeti.TitsSystem.mem_bruhatCell_iff`: membership in a Weyl-indexed Bruhat cell in terms of
+  a representative in `N`.
 * `TauCeti.TitsSystem.bruhatCells_eq_univ`: the Bruhat cells cover the ambient group.
-* `TauCeti.TitsSystem.doubleCoset_eq_of_mk_eq`: a Bruhat cell depends only on the Weyl-group
-  element represented by its element of `N`.
-* `TauCeti.TitsSystem.mul_doubleCoset_eq_or_eq_union_of_mem_simple`: multiplication on the left
-  by a simple Bruhat cell gives either the adjacent cell or its union with the original cell.
+* `TauCeti.TitsSystem.bruhatCell_mul_eq_or_eq_union_of_mem_simple`: multiplication on the left by
+  a simple Bruhat cell gives either the adjacent cell or its union with the original cell.
 * `TauCeti.TitsSystem.bruhatCell_mul_self_eq_union_of_mem_simple`: the square of a simple cell is
   its union with the identity cell.
 * `TauCeti.TitsSystem.exists_mem_doubleCoset`: every group element lies in a cell represented
@@ -43,7 +43,7 @@ subgroup containing both `B` and `N`, hence is all of `G` by the generation axio
 
 ## References
 
-* J. E. Humphreys, *Linear Algebraic Groups* (1975), Section 28.1.
+* J. E. Humphreys, *Linear Algebraic Groups* (1975), Sections 29.1--29.2.
 * T. A. Springer, *Linear Algebraic Groups*, second edition (1998), Section 8.3.
 
 This supplies the abstract Bruhat decomposition in Layer 7, "Bruhat decomposition and BN-pairs /
@@ -73,25 +73,23 @@ theorem mem_bruhatCells_iff (g : G) :
         g ∈ DoubleCoset.doubleCoset (n : G) T.subgroupB T.subgroupB := by
   simp only [bruhatCells, Set.mem_iUnion]
 
-/-- Representatives of the same element of `N / (B ∩ N)` determine the same Bruhat cell. -/
-theorem doubleCoset_eq_of_mk_eq {n m : T.subgroupN}
-    (h : (QuotientGroup.mk n : T.WeylGroup) = QuotientGroup.mk m) :
-    DoubleCoset.doubleCoset (n : G) T.subgroupB T.subgroupB =
-      DoubleCoset.doubleCoset (m : G) T.subgroupB T.subgroupB := by
-  obtain ⟨z, hz, hnz⟩ := (QuotientGroup.mk'_eq_mk' T.intersection).mp h
+/-- Representatives of the same class modulo `B ∩ N` determine the same `B`-double coset. -/
+private theorem doubleCoset_eq_of_mk_eq (B N : Subgroup G) [(B.subgroupOf N).Normal]
+    {n m : N}
+    (h : (QuotientGroup.mk n : N ⧸ (B.subgroupOf N)) = QuotientGroup.mk m) :
+    DoubleCoset.doubleCoset (n : G) B B = DoubleCoset.doubleCoset (m : G) B B := by
+  obtain ⟨z, hz, hnz⟩ := (QuotientGroup.mk'_eq_mk' (B.subgroupOf N)).mp h
   apply DoubleCoset.doubleCoset_eq_of_mem
   apply DoubleCoset.mem_doubleCoset.mpr
-  refine ⟨1, T.subgroupB.one_mem, (z⁻¹ : G),
-    T.subgroupB.inv_mem ((T.mem_intersection z).mp hz), ?_⟩
+  refine ⟨1, B.one_mem, (z⁻¹ : G), B.inv_mem hz, ?_⟩
   simpa only [one_mul, Subgroup.coe_mul, Subgroup.coe_inv] using
     congrArg Subtype.val (eq_mul_inv_of_mul_eq hnz)
 
-/-- The Bruhat cell `B w B` indexed by an element `w` of the Weyl group. Representatives in
-`N` give the same set by `TauCeti.TitsSystem.doubleCoset_eq_of_mk_eq`. -/
+/-- The Bruhat cell `B w B` indexed by an element `w` of the Weyl group. -/
 noncomputable def bruhatCell (w : T.WeylGroup) : Set G :=
   w.liftOn' (fun n : T.subgroupN ↦
     DoubleCoset.doubleCoset (n : G) T.subgroupB T.subgroupB) fun _n _m h ↦
-      T.doubleCoset_eq_of_mk_eq (Quotient.sound h)
+      doubleCoset_eq_of_mk_eq T.subgroupB T.subgroupN (Quotient.sound h)
 
 /-- The Bruhat cell at the class of `n ∈ N` is the double coset `B n B`. -/
 @[simp]
@@ -99,6 +97,19 @@ theorem bruhatCell_mk (n : T.subgroupN) :
     T.bruhatCell (QuotientGroup.mk n) =
       DoubleCoset.doubleCoset (n : G) T.subgroupB T.subgroupB :=
   Quotient.liftOn'_mk'' _ _ _
+
+/-- Membership in a Weyl-indexed Bruhat cell is witnessed by any representative in `N`. -/
+theorem mem_bruhatCell_iff {g : G} {w : T.WeylGroup} :
+    g ∈ T.bruhatCell w ↔
+      ∃ n : T.subgroupN, QuotientGroup.mk n = w ∧
+        g ∈ DoubleCoset.doubleCoset (n : G) T.subgroupB T.subgroupB := by
+  obtain ⟨n, rfl⟩ := QuotientGroup.mk_surjective w
+  constructor
+  · intro hg
+    exact ⟨n, rfl, by simpa only [bruhatCell_mk] using hg⟩
+  · rintro ⟨m, hm, hg⟩
+    rw [bruhatCell_mk, ← doubleCoset_eq_of_mk_eq T.subgroupB T.subgroupN hm]
+    exact hg
 
 /-- The Bruhat cell indexed by the identity of the Weyl group is `B`. -/
 @[simp]
@@ -113,57 +124,45 @@ theorem bruhatCell_one : T.bruhatCell 1 = (T.subgroupB : Set G) := by
 group. -/
 theorem bruhatCells_eq_iUnion_bruhatCell :
     T.bruhatCells = ⋃ w : T.WeylGroup, T.bruhatCell w := by
-  apply Set.Subset.antisymm
-  · intro g hg
-    obtain ⟨n, hn⟩ := (T.mem_bruhatCells_iff g).mp hg
-    exact Set.mem_iUnion.mpr ⟨QuotientGroup.mk n, by simpa only [bruhatCell_mk]⟩
-  · intro g hg
-    obtain ⟨w, hw⟩ := Set.mem_iUnion.mp hg
-    obtain ⟨n, rfl⟩ := QuotientGroup.mk'_surjective T.intersection w
-    exact (T.mem_bruhatCells_iff g).mpr
-      ⟨n, by simpa only [QuotientGroup.mk'_apply, Subgroup.comap_subtype,
-        bruhatCell_mk] using hw⟩
+  rw [bruhatCells, ← (QuotientGroup.mk'_surjective T.intersection).iUnion_comp]
+  simp only [QuotientGroup.mk'_apply, bruhatCell_mk]
 
-/-- A product of two `B`-double cosets is a union of `B`-double cosets: if it contains an
-element, it contains that element's entire double coset. -/
-private theorem doubleCoset_subset_mul_doubleCoset_of_mem {a c x : G}
-    (hx : x ∈
-      DoubleCoset.doubleCoset a T.subgroupB T.subgroupB *
-        DoubleCoset.doubleCoset c T.subgroupB T.subgroupB) :
-    DoubleCoset.doubleCoset x T.subgroupB T.subgroupB ⊆
-      DoubleCoset.doubleCoset a T.subgroupB T.subgroupB *
-        DoubleCoset.doubleCoset c T.subgroupB T.subgroupB := by
+/-- A product of double cosets is stable under the outer subgroup actions. -/
+private theorem doubleCoset_subset_mul_doubleCoset_of_mem (B C D : Subgroup G) {a c x : G}
+    (hx : x ∈ DoubleCoset.doubleCoset a B C * DoubleCoset.doubleCoset c C D) :
+    DoubleCoset.doubleCoset x B D ⊆
+      DoubleCoset.doubleCoset a B C * DoubleCoset.doubleCoset c C D := by
   rintro y hy
   obtain ⟨b₁, hb₁, b₂, hb₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hy
   obtain ⟨u, hu, v, hv, rfl⟩ := hx
   refine ⟨b₁ * u, ?_, v * b₂, ?_, by simp only [mul_assoc]⟩
   · obtain ⟨a₁, ha₁, a₂, ha₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hu
     exact DoubleCoset.mem_doubleCoset.mpr
-      ⟨b₁ * a₁, T.subgroupB.mul_mem hb₁ ha₁, a₂, ha₂, by simp [mul_assoc]⟩
+      ⟨b₁ * a₁, B.mul_mem hb₁ ha₁, a₂, ha₂, by simp [mul_assoc]⟩
   · obtain ⟨c₁, hc₁, c₂, hc₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hv
     exact DoubleCoset.mem_doubleCoset.mpr
-      ⟨c₁, hc₁, c₂ * b₂, T.subgroupB.mul_mem hc₂ hb₂, by simp [mul_assoc]⟩
+      ⟨c₁, hc₁, c₂ * b₂, D.mul_mem hc₂ hb₂, by simp [mul_assoc]⟩
 
-/-- The adjacent cell `B (r w) B` occurs in the product `(B r B)(B w B)`. -/
-private theorem doubleCoset_mul_subset_mul_doubleCoset (r w : T.subgroupN) :
-    DoubleCoset.doubleCoset ((r * w : T.subgroupN) : G) T.subgroupB T.subgroupB ⊆
-      DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB *
-        DoubleCoset.doubleCoset (w : G) T.subgroupB T.subgroupB := by
+/-- The double coset of a product occurs in the product of the corresponding double cosets. -/
+private theorem doubleCoset_mul_subset_mul_doubleCoset (B C D : Subgroup G) (r w : G) :
+    DoubleCoset.doubleCoset (r * w) B D ⊆
+      DoubleCoset.doubleCoset r B C * DoubleCoset.doubleCoset w C D := by
   rintro x hx
   obtain ⟨b₁, hb₁, b₂, hb₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hx
-  refine ⟨b₁ * (r : G), ?_, (w : G) * b₂, ?_, ?_⟩
+  refine ⟨b₁ * r, ?_, w * b₂, ?_, ?_⟩
   · exact DoubleCoset.mem_doubleCoset.mpr
-      ⟨b₁, hb₁, 1, T.subgroupB.one_mem, by simp⟩
+      ⟨b₁, hb₁, 1, C.one_mem, by simp⟩
   · exact DoubleCoset.mem_doubleCoset.mpr
-      ⟨1, T.subgroupB.one_mem, b₂, hb₂, by simp⟩
-  · simp only [Subgroup.coe_mul, mul_assoc]
+      ⟨1, C.one_mem, b₂, hb₂, by simp⟩
+  · simp only [mul_assoc]
 
 /-- **Multiplication by a simple Bruhat cell.** If `r` represents a simple reflection and `w`
 lies in `N`, then `(B r B)(B w B)` is either the adjacent cell `B (r w) B` or the union of that
 cell with `B w B`.
 
 The conclusion is independent of the chosen representative `r` of the simple reflection. -/
-theorem mul_doubleCoset_eq_or_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s ∈ T.simple)
+private theorem mul_doubleCoset_eq_or_eq_union_of_mem_simple {s : T.WeylGroup}
+    (hs : s ∈ T.simple)
     (r : T.subgroupN) (hr : (QuotientGroup.mk r : T.WeylGroup) = s)
     (w : T.subgroupN) :
     DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB *
@@ -177,11 +176,11 @@ theorem mul_doubleCoset_eq_or_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s �
   have hrr₀ :
       DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB =
         DoubleCoset.doubleCoset (r₀ : G) T.subgroupB T.subgroupB :=
-    T.doubleCoset_eq_of_mk_eq (hr.trans hr₀.symm)
+    doubleCoset_eq_of_mk_eq T.subgroupB T.subgroupN (hr.trans hr₀.symm)
   have hrwr₀w :
       DoubleCoset.doubleCoset ((r * w : T.subgroupN) : G) T.subgroupB T.subgroupB =
         DoubleCoset.doubleCoset ((r₀ * w : T.subgroupN) : G) T.subgroupB T.subgroupB := by
-    apply T.doubleCoset_eq_of_mk_eq
+    apply doubleCoset_eq_of_mk_eq T.subgroupB T.subgroupN
     rw [QuotientGroup.mk_mul, QuotientGroup.mk_mul, hr, hr₀]
   rw [hrr₀, hrwr₀w]
   let A := DoubleCoset.doubleCoset (r₀ : G) T.subgroupB T.subgroupB *
@@ -189,12 +188,16 @@ theorem mul_doubleCoset_eq_or_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s �
   let C := DoubleCoset.doubleCoset ((r₀ * w : T.subgroupN) : G)
     T.subgroupB T.subgroupB
   let D := DoubleCoset.doubleCoset (w : G) T.subgroupB T.subgroupB
-  have hC : C ⊆ A := T.doubleCoset_mul_subset_mul_doubleCoset r₀ w
+  have hC : C ⊆ A := by
+    simpa only [C, A, Subgroup.coe_mul] using
+      doubleCoset_mul_subset_mul_doubleCoset T.subgroupB T.subgroupB T.subgroupB
+        (r₀ : G) (w : G)
   have hsubset' : A ⊆ C ∪ D := hsubset w
   by_cases hw : (w : G) ∈ A
   · right
     apply Set.Subset.antisymm hsubset'
-    exact Set.union_subset hC (T.doubleCoset_subset_mul_doubleCoset_of_mem hw)
+    exact Set.union_subset hC
+      (doubleCoset_subset_mul_doubleCoset_of_mem T.subgroupB T.subgroupB T.subgroupB hw)
   · left
     apply Set.Subset.antisymm
     · intro x hx
@@ -202,7 +205,8 @@ theorem mul_doubleCoset_eq_or_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s �
       · exact hxC
       · exfalso
         apply hw
-        apply T.doubleCoset_subset_mul_doubleCoset_of_mem hx
+        apply doubleCoset_subset_mul_doubleCoset_of_mem
+          T.subgroupB T.subgroupB T.subgroupB hx
         rw [DoubleCoset.doubleCoset_eq_of_mem hxD]
         exact DoubleCoset.mem_doubleCoset_self T.subgroupB T.subgroupB (w : G)
     · exact hC
@@ -225,6 +229,7 @@ theorem bruhatCell_mul_eq_or_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s �
 
 The nondegeneracy axiom rules out the smaller alternative in
 `TauCeti.TitsSystem.bruhatCell_mul_eq_or_eq_union_of_mem_simple`. -/
+@[simp]
 theorem bruhatCell_mul_self_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s ∈ T.simple) :
     T.bruhatCell s * T.bruhatCell s = T.bruhatCell 1 ∪ T.bruhatCell s := by
   obtain ⟨r, hr, b, hb⟩ := T.exists_conj_not_mem s hs
@@ -237,36 +242,29 @@ theorem bruhatCell_mul_self_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s ∈
       _ = s⁻¹ := congrArg Inv.inv hr
       _ = s := hs_inv
       _ = QuotientGroup.mk r := hr.symm
-  have hr_inv_cell := T.doubleCoset_eq_of_mk_eq hr_inv
+  have hr_inv_cell :=
+    doubleCoset_eq_of_mk_eq T.subgroupB T.subgroupN hr_inv
   have hsecond :
       (b : G) * (r⁻¹ : T.subgroupN) ∈
         DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB := by
     rw [← hr_inv_cell]
     exact DoubleCoset.mem_doubleCoset.mpr
       ⟨b, b.property, 1, T.subgroupB.one_mem, by simp⟩
-  have hx : (r : G) * (b : G) * (r : G)⁻¹ ∈
+  have hx_rep : (r : G) * (b : G) * (r : G)⁻¹ ∈
       DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB *
         DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB := by
     refine ⟨r, DoubleCoset.mem_doubleCoset_self T.subgroupB T.subgroupB (r : G),
       (b : G) * (r⁻¹ : T.subgroupN), hsecond, ?_⟩
     simp only [Subgroup.coe_inv, mul_assoc]
-  have hsq :
-      DoubleCoset.doubleCoset ((r * r : T.subgroupN) : G) T.subgroupB T.subgroupB =
-        (T.subgroupB : Set G) := by
-    calc
-      DoubleCoset.doubleCoset ((r * r : T.subgroupN) : G) T.subgroupB T.subgroupB =
-          DoubleCoset.doubleCoset (1 : G) T.subgroupB T.subgroupB := by
-        apply T.doubleCoset_eq_of_mk_eq (n := r * r) (m := 1)
-        rw [QuotientGroup.mk_mul, hr, T.simple_sq_eq_one hs, QuotientGroup.mk_one]
-      _ = T.subgroupB := doubleCoset_one_self T.subgroupB
-  rcases T.mul_doubleCoset_eq_or_eq_union_of_mem_simple hs r hr r with hsmall | hbig
+  have hx : (r : G) * (b : G) * (r : G)⁻¹ ∈ T.bruhatCell s * T.bruhatCell s := by
+    rw [← hr]
+    simpa only [Subgroup.comap_subtype, bruhatCell_mk] using hx_rep
+  rcases T.bruhatCell_mul_eq_or_eq_union_of_mem_simple hs s with hsmall | hbig
   · exfalso
     have hx' := hx
-    rw [hsmall, hsq] at hx'
+    rw [hsmall, T.simple_sq_eq_one hs, bruhatCell_one] at hx'
     exact hb hx'
-  · rw [hsq] at hbig
-    rw [← hr]
-    simpa only [Subgroup.comap_subtype, bruhatCell_mk, bruhatCell_one] using hbig
+  · simpa only [T.simple_sq_eq_one hs] using hbig
 
 /-- The identity Bruhat cell acts on the union of Bruhat cells by left multiplication. -/
 private theorem oneCell_mul_bruhatCells_subset :
@@ -292,7 +290,7 @@ private def MultipliesBruhatCells (q : T.WeylGroup) : Prop :=
 /-- The identity of the Weyl group preserves the union of Bruhat cells. -/
 private theorem multipliesBruhatCells_one : T.MultipliesBruhatCells 1 := by
   intro n hn w
-  rw [T.doubleCoset_eq_of_mk_eq hn]
+  rw [doubleCoset_eq_of_mk_eq T.subgroupB T.subgroupN hn]
   exact (Set.mul_subset_mul_left <| Set.subset_iUnion (fun v : T.subgroupN ↦
       DoubleCoset.doubleCoset (v : G) T.subgroupB T.subgroupB) w).trans
     T.oneCell_mul_bruhatCells_subset
@@ -302,7 +300,7 @@ private theorem multipliesBruhatCells_simple
     (q : T.WeylGroup) (hq : q ∈ T.simple) : T.MultipliesBruhatCells q := by
   obtain ⟨r, hrq, hr⟩ := T.mul_doubleCoset_subset q hq
   intro n hn w
-  rw [T.doubleCoset_eq_of_mk_eq (hn.trans hrq.symm)]
+  rw [doubleCoset_eq_of_mk_eq T.subgroupB T.subgroupN (hn.trans hrq.symm)]
   refine (hr w).trans ?_
   rw [Set.union_subset_iff]
   exact ⟨Set.subset_iUnion (fun v : T.subgroupN ↦
@@ -319,7 +317,7 @@ private theorem MultipliesBruhatCells.mul {q₁ q₂ : T.WeylGroup}
   obtain ⟨n₂, hn₂⟩ := QuotientGroup.mk'_surjective T.intersection q₂
   have hn₁n₂ : QuotientGroup.mk (n₁ * n₂) = q₁ * q₂ := by
     rw [← QuotientGroup.mk'_apply T.intersection, map_mul, hn₁, hn₂]
-  rw [T.doubleCoset_eq_of_mk_eq (hn.trans hn₁n₂.symm)]
+  rw [doubleCoset_eq_of_mk_eq T.subgroupB T.subgroupN (hn.trans hn₁n₂.symm)]
   rintro g ⟨x, hx, y, hy, rfl⟩
   obtain ⟨b₁, hb₁, b₂, hb₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hx
   let x₁ : G := b₁ * (n₁ : G)

--- a/TauCeti/GroupTheory/TitsSystem/Bruhat.lean
+++ b/TauCeti/GroupTheory/TitsSystem/Bruhat.lean
@@ -98,7 +98,7 @@ theorem bruhatCell_mk (n : T.subgroupN) :
       DoubleCoset.doubleCoset (n : G) T.subgroupB T.subgroupB :=
   Quotient.liftOn'_mk'' _ _ _
 
-/-- Membership in a Weyl-indexed Bruhat cell is witnessed by any representative in `N`. -/
+/-- Membership in a Weyl-indexed Bruhat cell is witnessed by some representative in `N`. -/
 theorem mem_bruhatCell_iff {g : G} {w : T.WeylGroup} :
     g ∈ T.bruhatCell w ↔
       ∃ n : T.subgroupN, QuotientGroup.mk n = w ∧

--- a/TauCeti/GroupTheory/TitsSystem/Bruhat.lean
+++ b/TauCeti/GroupTheory/TitsSystem/Bruhat.lean
@@ -15,6 +15,11 @@ For a Tits system `(B, N)`, every element of the ambient group belongs to a doub
 `B n B` represented by an element `n ∈ N`. Thus the canonical map from `N` to `B \ G / B`
 is surjective, and the union of the Bruhat cells is the whole group.
 
+The file also establishes the rank-one multiplication law. If `s` is simple and `w` belongs to
+the Weyl group, then `(B s B)(B w B)` is either `B (s w) B` or
+`B (s w) B ∪ B w B`. This sharpens the subset appearing among the Tits-system axioms: the
+adjacent cell always occurs, and the product can acquire only the original cell in addition.
+
 The proof uses the multiplication axiom first for a simple reflection. Since the simple
 reflections generate `W = N / (B ∩ N)` and are involutions, induction in `W` shows that left
 multiplication by any Bruhat cell preserves the union of the cells. That union is consequently a
@@ -23,7 +28,14 @@ subgroup containing both `B` and `N`, hence is all of `G` by the generation axio
 ## Main declarations
 
 * `TauCeti.TitsSystem.bruhatCells`: the union of the double cosets `B n B`, for `n ∈ N`.
+* `TauCeti.TitsSystem.bruhatCell`: the Bruhat cell indexed by an element of the Weyl group.
 * `TauCeti.TitsSystem.bruhatCells_eq_univ`: the Bruhat cells cover the ambient group.
+* `TauCeti.TitsSystem.doubleCoset_eq_of_mk_eq`: a Bruhat cell depends only on the Weyl-group
+  element represented by its element of `N`.
+* `TauCeti.TitsSystem.mul_doubleCoset_eq_or_eq_union`: multiplication on the left by a simple
+  Bruhat cell gives either the adjacent cell or its union with the original cell.
+* `TauCeti.TitsSystem.bruhatCell_simple_mul_self`: the square of a simple cell is its union with
+  the identity cell.
 * `TauCeti.TitsSystem.exists_mem_doubleCoset`: every group element lies in a cell represented
   by `N`.
 * `TauCeti.TitsSystem.doubleCosetMk_surjective`: the induced map `N → B \ G / B` is
@@ -62,7 +74,7 @@ theorem mem_bruhatCells_iff (g : G) :
   simp only [bruhatCells, Set.mem_iUnion]
 
 /-- Representatives of the same element of `N / (B ∩ N)` determine the same Bruhat cell. -/
-private theorem doubleCoset_eq_of_mk_eq {n m : T.subgroupN}
+theorem doubleCoset_eq_of_mk_eq {n m : T.subgroupN}
     (h : (QuotientGroup.mk n : T.WeylGroup) = QuotientGroup.mk m) :
     DoubleCoset.doubleCoset (n : G) T.subgroupB T.subgroupB =
       DoubleCoset.doubleCoset (m : G) T.subgroupB T.subgroupB := by
@@ -73,6 +85,188 @@ private theorem doubleCoset_eq_of_mk_eq {n m : T.subgroupN}
     T.subgroupB.inv_mem ((T.mem_intersection z).mp hz), ?_⟩
   simpa only [one_mul, Subgroup.coe_mul, Subgroup.coe_inv] using
     congrArg Subtype.val (eq_mul_inv_of_mul_eq hnz)
+
+/-- The Bruhat cell `B w B` indexed by an element `w` of the Weyl group. Representatives in
+`N` give the same set by `TauCeti.TitsSystem.doubleCoset_eq_of_mk_eq`. -/
+noncomputable def bruhatCell (w : T.WeylGroup) : Set G :=
+  w.liftOn' (fun n : T.subgroupN ↦
+    DoubleCoset.doubleCoset (n : G) T.subgroupB T.subgroupB) fun _n _m h ↦
+      T.doubleCoset_eq_of_mk_eq (Quotient.sound h)
+
+/-- The Bruhat cell at the class of `n ∈ N` is the double coset `B n B`. -/
+@[simp]
+theorem bruhatCell_mk (n : T.subgroupN) :
+    T.bruhatCell (QuotientGroup.mk n) =
+      DoubleCoset.doubleCoset (n : G) T.subgroupB T.subgroupB :=
+  Quotient.liftOn'_mk'' _ _ _
+
+/-- The Bruhat cell indexed by the identity of the Weyl group is `B`. -/
+@[simp]
+theorem bruhatCell_one : T.bruhatCell 1 = (T.subgroupB : Set G) := by
+  calc
+    T.bruhatCell 1 = T.bruhatCell (QuotientGroup.mk (1 : T.subgroupN)) := by
+      rw [QuotientGroup.mk_one]
+    _ = DoubleCoset.doubleCoset (1 : G) T.subgroupB T.subgroupB := T.bruhatCell_mk 1
+    _ = T.subgroupB := doubleCoset_one_self T.subgroupB
+
+/-- The union over `N` defining `bruhatCells` can equivalently be indexed without repetition by
+the Weyl group. -/
+theorem bruhatCells_eq_iUnion_bruhatCell :
+    T.bruhatCells = ⋃ w : T.WeylGroup, T.bruhatCell w := by
+  apply Set.Subset.antisymm
+  · intro g hg
+    obtain ⟨n, hn⟩ := (T.mem_bruhatCells_iff g).mp hg
+    exact Set.mem_iUnion.mpr ⟨QuotientGroup.mk n, by simpa only [bruhatCell_mk]⟩
+  · intro g hg
+    obtain ⟨w, hw⟩ := Set.mem_iUnion.mp hg
+    obtain ⟨n, rfl⟩ := QuotientGroup.mk'_surjective T.intersection w
+    exact (T.mem_bruhatCells_iff g).mpr
+      ⟨n, by simpa only [QuotientGroup.mk'_apply, Subgroup.comap_subtype,
+        bruhatCell_mk] using hw⟩
+
+/-- A product of two `B`-double cosets is a union of `B`-double cosets: if it contains an
+element, it contains that element's entire double coset. -/
+private theorem doubleCoset_subset_mul_doubleCoset_of_mem {a c x : G}
+    (hx : x ∈
+      DoubleCoset.doubleCoset a T.subgroupB T.subgroupB *
+        DoubleCoset.doubleCoset c T.subgroupB T.subgroupB) :
+    DoubleCoset.doubleCoset x T.subgroupB T.subgroupB ⊆
+      DoubleCoset.doubleCoset a T.subgroupB T.subgroupB *
+        DoubleCoset.doubleCoset c T.subgroupB T.subgroupB := by
+  rintro y hy
+  obtain ⟨b₁, hb₁, b₂, hb₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hy
+  obtain ⟨u, hu, v, hv, rfl⟩ := hx
+  refine ⟨b₁ * u, ?_, v * b₂, ?_, by simp only [mul_assoc]⟩
+  · obtain ⟨a₁, ha₁, a₂, ha₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hu
+    exact DoubleCoset.mem_doubleCoset.mpr
+      ⟨b₁ * a₁, T.subgroupB.mul_mem hb₁ ha₁, a₂, ha₂, by simp [mul_assoc]⟩
+  · obtain ⟨c₁, hc₁, c₂, hc₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hv
+    exact DoubleCoset.mem_doubleCoset.mpr
+      ⟨c₁, hc₁, c₂ * b₂, T.subgroupB.mul_mem hc₂ hb₂, by simp [mul_assoc]⟩
+
+/-- The adjacent cell `B (r w) B` occurs in the product `(B r B)(B w B)`. -/
+private theorem doubleCoset_mul_subset_mul_doubleCoset (r w : T.subgroupN) :
+    DoubleCoset.doubleCoset ((r * w : T.subgroupN) : G) T.subgroupB T.subgroupB ⊆
+      DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB *
+        DoubleCoset.doubleCoset (w : G) T.subgroupB T.subgroupB := by
+  rintro x hx
+  obtain ⟨b₁, hb₁, b₂, hb₂, rfl⟩ := DoubleCoset.mem_doubleCoset.mp hx
+  refine ⟨b₁ * (r : G), ?_, (w : G) * b₂, ?_, ?_⟩
+  · exact DoubleCoset.mem_doubleCoset.mpr
+      ⟨b₁, hb₁, 1, T.subgroupB.one_mem, by simp⟩
+  · exact DoubleCoset.mem_doubleCoset.mpr
+      ⟨1, T.subgroupB.one_mem, b₂, hb₂, by simp⟩
+  · simp only [Subgroup.coe_mul, mul_assoc]
+
+/-- **Multiplication by a simple Bruhat cell.** If `r` represents a simple reflection and `w`
+lies in `N`, then `(B r B)(B w B)` is either the adjacent cell `B (r w) B` or the union of that
+cell with `B w B`.
+
+The conclusion is independent of the chosen representative `r` of the simple reflection. -/
+theorem mul_doubleCoset_eq_or_eq_union {s : T.WeylGroup} (hs : s ∈ T.simple)
+    (r : T.subgroupN) (hr : (QuotientGroup.mk r : T.WeylGroup) = s)
+    (w : T.subgroupN) :
+    DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB *
+          DoubleCoset.doubleCoset (w : G) T.subgroupB T.subgroupB =
+        DoubleCoset.doubleCoset ((r * w : T.subgroupN) : G) T.subgroupB T.subgroupB ∨
+      DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB *
+          DoubleCoset.doubleCoset (w : G) T.subgroupB T.subgroupB =
+        DoubleCoset.doubleCoset ((r * w : T.subgroupN) : G) T.subgroupB T.subgroupB ∪
+          DoubleCoset.doubleCoset (w : G) T.subgroupB T.subgroupB := by
+  obtain ⟨r₀, hr₀, hsubset⟩ := T.mul_doubleCoset_subset s hs
+  have hrr₀ :
+      DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB =
+        DoubleCoset.doubleCoset (r₀ : G) T.subgroupB T.subgroupB :=
+    T.doubleCoset_eq_of_mk_eq (hr.trans hr₀.symm)
+  have hrwr₀w :
+      DoubleCoset.doubleCoset ((r * w : T.subgroupN) : G) T.subgroupB T.subgroupB =
+        DoubleCoset.doubleCoset ((r₀ * w : T.subgroupN) : G) T.subgroupB T.subgroupB := by
+    apply T.doubleCoset_eq_of_mk_eq
+    rw [QuotientGroup.mk_mul, QuotientGroup.mk_mul, hr, hr₀]
+  rw [hrr₀, hrwr₀w]
+  let A := DoubleCoset.doubleCoset (r₀ : G) T.subgroupB T.subgroupB *
+    DoubleCoset.doubleCoset (w : G) T.subgroupB T.subgroupB
+  let C := DoubleCoset.doubleCoset ((r₀ * w : T.subgroupN) : G)
+    T.subgroupB T.subgroupB
+  let D := DoubleCoset.doubleCoset (w : G) T.subgroupB T.subgroupB
+  have hC : C ⊆ A := T.doubleCoset_mul_subset_mul_doubleCoset r₀ w
+  have hsubset' : A ⊆ C ∪ D := hsubset w
+  by_cases hw : (w : G) ∈ A
+  · right
+    apply Set.Subset.antisymm hsubset'
+    exact Set.union_subset hC (T.doubleCoset_subset_mul_doubleCoset_of_mem hw)
+  · left
+    apply Set.Subset.antisymm
+    · intro x hx
+      rcases hsubset' hx with hxC | hxD
+      · exact hxC
+      · exfalso
+        apply hw
+        apply T.doubleCoset_subset_mul_doubleCoset_of_mem hx
+        rw [DoubleCoset.doubleCoset_eq_of_mem hxD]
+        exact DoubleCoset.mem_doubleCoset_self T.subgroupB T.subgroupB (w : G)
+    · exact hC
+
+/-- **Weyl-indexed multiplication by a simple Bruhat cell.** For a simple reflection `s` and a
+Weyl-group element `w`, the product of their cells is either the cell at `s * w` or its union
+with the cell at `w`. -/
+theorem bruhatCell_mul_eq_or_eq_union {s : T.WeylGroup} (hs : s ∈ T.simple)
+    (w : T.WeylGroup) :
+    T.bruhatCell s * T.bruhatCell w = T.bruhatCell (s * w) ∨
+      T.bruhatCell s * T.bruhatCell w = T.bruhatCell (s * w) ∪ T.bruhatCell w := by
+  obtain ⟨r, rfl⟩ := QuotientGroup.mk'_surjective T.intersection s
+  obtain ⟨n, rfl⟩ := QuotientGroup.mk'_surjective T.intersection w
+  simpa only [QuotientGroup.mk'_apply, ← QuotientGroup.mk_mul, Subgroup.comap_subtype,
+    bruhatCell_mk] using
+    T.mul_doubleCoset_eq_or_eq_union hs r rfl n
+
+/-- The square of a simple Bruhat cell is the union of that cell with the identity cell:
+`(B s B)(B s B) = B ∪ B s B`.
+
+The nondegeneracy axiom rules out the smaller alternative in
+`TauCeti.TitsSystem.bruhatCell_mul_eq_or_eq_union`. -/
+theorem bruhatCell_simple_mul_self {s : T.WeylGroup} (hs : s ∈ T.simple) :
+    T.bruhatCell s * T.bruhatCell s = T.bruhatCell 1 ∪ T.bruhatCell s := by
+  obtain ⟨r, hr, b, hb⟩ := T.exists_conj_not_mem s hs
+  have hs_inv : s⁻¹ = s := inv_eq_of_mul_eq_one_right (T.simple_sq_eq_one hs)
+  have hr_inv :
+      (QuotientGroup.mk r⁻¹ : T.WeylGroup) = QuotientGroup.mk r := by
+    calc
+      (QuotientGroup.mk r⁻¹ : T.WeylGroup) = (QuotientGroup.mk r)⁻¹ :=
+        QuotientGroup.mk_inv T.intersection r
+      _ = s⁻¹ := congrArg Inv.inv hr
+      _ = s := hs_inv
+      _ = QuotientGroup.mk r := hr.symm
+  have hr_inv_cell := T.doubleCoset_eq_of_mk_eq hr_inv
+  have hsecond :
+      (b : G) * (r⁻¹ : T.subgroupN) ∈
+        DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB := by
+    rw [← hr_inv_cell]
+    exact DoubleCoset.mem_doubleCoset.mpr
+      ⟨b, b.property, 1, T.subgroupB.one_mem, by simp⟩
+  have hx : (r : G) * (b : G) * (r : G)⁻¹ ∈
+      DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB *
+        DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB := by
+    refine ⟨r, DoubleCoset.mem_doubleCoset_self T.subgroupB T.subgroupB (r : G),
+      (b : G) * (r⁻¹ : T.subgroupN), hsecond, ?_⟩
+    simp only [Subgroup.coe_inv, mul_assoc]
+  have hsq :
+      DoubleCoset.doubleCoset ((r * r : T.subgroupN) : G) T.subgroupB T.subgroupB =
+        (T.subgroupB : Set G) := by
+    calc
+      DoubleCoset.doubleCoset ((r * r : T.subgroupN) : G) T.subgroupB T.subgroupB =
+          DoubleCoset.doubleCoset (1 : G) T.subgroupB T.subgroupB := by
+        apply T.doubleCoset_eq_of_mk_eq (n := r * r) (m := 1)
+        rw [QuotientGroup.mk_mul, hr, T.simple_sq_eq_one hs, QuotientGroup.mk_one]
+      _ = T.subgroupB := doubleCoset_one_self T.subgroupB
+  rcases T.mul_doubleCoset_eq_or_eq_union hs r hr r with hsmall | hbig
+  · exfalso
+    have hx' := hx
+    rw [hsmall, hsq] at hx'
+    exact hb hx'
+  · rw [hsq] at hbig
+    rw [← hr]
+    simpa only [Subgroup.comap_subtype, bruhatCell_mk, bruhatCell_one] using hbig
 
 /-- The identity Bruhat cell acts on the union of Bruhat cells by left multiplication. -/
 private theorem oneCell_mul_bruhatCells_subset :

--- a/TauCeti/GroupTheory/TitsSystem/Bruhat.lean
+++ b/TauCeti/GroupTheory/TitsSystem/Bruhat.lean
@@ -32,10 +32,10 @@ subgroup containing both `B` and `N`, hence is all of `G` by the generation axio
 * `TauCeti.TitsSystem.bruhatCells_eq_univ`: the Bruhat cells cover the ambient group.
 * `TauCeti.TitsSystem.doubleCoset_eq_of_mk_eq`: a Bruhat cell depends only on the Weyl-group
   element represented by its element of `N`.
-* `TauCeti.TitsSystem.mul_doubleCoset_eq_or_eq_union`: multiplication on the left by a simple
-  Bruhat cell gives either the adjacent cell or its union with the original cell.
-* `TauCeti.TitsSystem.bruhatCell_simple_mul_self`: the square of a simple cell is its union with
-  the identity cell.
+* `TauCeti.TitsSystem.mul_doubleCoset_eq_or_eq_union_of_mem_simple`: multiplication on the left
+  by a simple Bruhat cell gives either the adjacent cell or its union with the original cell.
+* `TauCeti.TitsSystem.bruhatCell_mul_self_eq_union_of_mem_simple`: the square of a simple cell is
+  its union with the identity cell.
 * `TauCeti.TitsSystem.exists_mem_doubleCoset`: every group element lies in a cell represented
   by `N`.
 * `TauCeti.TitsSystem.doubleCosetMk_surjective`: the induced map `N → B \ G / B` is
@@ -109,8 +109,8 @@ theorem bruhatCell_one : T.bruhatCell 1 = (T.subgroupB : Set G) := by
     _ = DoubleCoset.doubleCoset (1 : G) T.subgroupB T.subgroupB := T.bruhatCell_mk 1
     _ = T.subgroupB := doubleCoset_one_self T.subgroupB
 
-/-- The union over `N` defining `bruhatCells` can equivalently be indexed without repetition by
-the Weyl group. -/
+/-- The union over `N` defining `bruhatCells` can equivalently be indexed canonically by the Weyl
+group. -/
 theorem bruhatCells_eq_iUnion_bruhatCell :
     T.bruhatCells = ⋃ w : T.WeylGroup, T.bruhatCell w := by
   apply Set.Subset.antisymm
@@ -163,7 +163,7 @@ lies in `N`, then `(B r B)(B w B)` is either the adjacent cell `B (r w) B` or th
 cell with `B w B`.
 
 The conclusion is independent of the chosen representative `r` of the simple reflection. -/
-theorem mul_doubleCoset_eq_or_eq_union {s : T.WeylGroup} (hs : s ∈ T.simple)
+theorem mul_doubleCoset_eq_or_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s ∈ T.simple)
     (r : T.subgroupN) (hr : (QuotientGroup.mk r : T.WeylGroup) = s)
     (w : T.subgroupN) :
     DoubleCoset.doubleCoset (r : G) T.subgroupB T.subgroupB *
@@ -210,7 +210,7 @@ theorem mul_doubleCoset_eq_or_eq_union {s : T.WeylGroup} (hs : s ∈ T.simple)
 /-- **Weyl-indexed multiplication by a simple Bruhat cell.** For a simple reflection `s` and a
 Weyl-group element `w`, the product of their cells is either the cell at `s * w` or its union
 with the cell at `w`. -/
-theorem bruhatCell_mul_eq_or_eq_union {s : T.WeylGroup} (hs : s ∈ T.simple)
+theorem bruhatCell_mul_eq_or_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s ∈ T.simple)
     (w : T.WeylGroup) :
     T.bruhatCell s * T.bruhatCell w = T.bruhatCell (s * w) ∨
       T.bruhatCell s * T.bruhatCell w = T.bruhatCell (s * w) ∪ T.bruhatCell w := by
@@ -218,14 +218,14 @@ theorem bruhatCell_mul_eq_or_eq_union {s : T.WeylGroup} (hs : s ∈ T.simple)
   obtain ⟨n, rfl⟩ := QuotientGroup.mk'_surjective T.intersection w
   simpa only [QuotientGroup.mk'_apply, ← QuotientGroup.mk_mul, Subgroup.comap_subtype,
     bruhatCell_mk] using
-    T.mul_doubleCoset_eq_or_eq_union hs r rfl n
+    T.mul_doubleCoset_eq_or_eq_union_of_mem_simple hs r rfl n
 
 /-- The square of a simple Bruhat cell is the union of that cell with the identity cell:
 `(B s B)(B s B) = B ∪ B s B`.
 
 The nondegeneracy axiom rules out the smaller alternative in
-`TauCeti.TitsSystem.bruhatCell_mul_eq_or_eq_union`. -/
-theorem bruhatCell_simple_mul_self {s : T.WeylGroup} (hs : s ∈ T.simple) :
+`TauCeti.TitsSystem.bruhatCell_mul_eq_or_eq_union_of_mem_simple`. -/
+theorem bruhatCell_mul_self_eq_union_of_mem_simple {s : T.WeylGroup} (hs : s ∈ T.simple) :
     T.bruhatCell s * T.bruhatCell s = T.bruhatCell 1 ∪ T.bruhatCell s := by
   obtain ⟨r, hr, b, hb⟩ := T.exists_conj_not_mem s hs
   have hs_inv : s⁻¹ = s := inv_eq_of_mul_eq_one_right (T.simple_sq_eq_one hs)
@@ -259,7 +259,7 @@ theorem bruhatCell_simple_mul_self {s : T.WeylGroup} (hs : s ∈ T.simple) :
         apply T.doubleCoset_eq_of_mk_eq (n := r * r) (m := 1)
         rw [QuotientGroup.mk_mul, hr, T.simple_sq_eq_one hs, QuotientGroup.mk_one]
       _ = T.subgroupB := doubleCoset_one_self T.subgroupB
-  rcases T.mul_doubleCoset_eq_or_eq_union hs r hr r with hsmall | hbig
+  rcases T.mul_doubleCoset_eq_or_eq_union_of_mem_simple hs r hr r with hsmall | hbig
   · exfalso
     have hx' := hx
     rw [hsmall, hsq] at hx'

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
@@ -195,7 +195,7 @@ def gl2TitsSystem : TitsSystem (GL (Fin 2) k) where
   subgroupN := GL2DiagonalNormalizer k
   closure_subgroupB_union_subgroupN := gl2_borel_normalizer_closure k
   intersection_normal := by
-    rw [gl2_borel_comap_normalizer_eq_diagonal]
+    rw [← Subgroup.comap_subtype, gl2_borel_comap_normalizer_eq_diagonal]
     exact Subgroup.normal_in_normalizer
   simple := {QuotientGroup.mk (gl2WeylNormalizer k)}
   closure_simple := by
@@ -241,7 +241,7 @@ def gl2TitsSystem : TitsSystem (GL (Fin 2) k) where
   exists_simpleRep_sq_mem s hs := by
     rw [Set.mem_singleton_iff] at hs
     refine ⟨gl2WeylNormalizer k, hs.symm, ?_⟩
-    rw [Subgroup.mem_comap, map_mul]
+    rw [← Subgroup.comap_subtype, Subgroup.mem_comap, map_mul]
     simp only [Subgroup.subtype_apply, gl2WeylNormalizer]
     rw [gl2WeylElement_mul_self]
     exact (GL2Borel k).one_mem


### PR DESCRIPTION
This PR sharpens the abstract Bruhat decomposition of a Tits system, indexes Bruhat cells canonically by the Weyl quotient, and proves the rank-one multiplication law: for a simple reflection `s`, `(B s B)(B w B)` is either `B(sw)B` or `B(sw)B ∪ BwB`. It uses the nondegeneracy axiom to obtain the exact quadratic formula `(B s B)² = B ∪ B s B`.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 7, “Bruhat decomposition and BN-pairs / Tits systems.” The designated structure-theory milestone is the reusable Bruhat theory of an abstract BN-pair. This is the most effective current step because the abstract `TitsSystem`, its `GL₂` witness, and Bruhat coverage are on `main`, while the multiplication law is the next input needed to prove that Weyl-indexed cells are disjoint and to extract the Coxeter structure; the general `GLₙ` instance still first needs its separate matrix Bruhat decomposition.

After this PR, the milestone still needs injectivity of the Weyl-to-double-coset map and the Coxeter-system consequences, followed by Tits-system instances for general `GLₙ` and general split reductive groups.

The public API adds `TitsSystem.bruhatCell`, its representative, membership, and identity equations, Weyl-indexed coverage, the canonical multiplication dichotomy, and `bruhatCell_mul_self_eq_union_of_mem_simple`. The proof observes that a product of two `B`-double cosets is itself a union of double cosets, so the axiom's upper bound and the always-present adjacent cell leave exactly two possibilities. It normalizes the existing intersection spelling to Mathlib's canonical `Subgroup.subgroupOf` (definitionally the previous `comap`) and updates the `GL₂` constructor at its two affected proof steps so the characteristic `bruhatCell_mk` equation is simp-normal.

It extends `TauCeti/GroupTheory/TitsSystem/Bruhat.lean` by 195 added lines and makes definitional-only updates in `TauCeti/GroupTheory/TitsSystem/Basic.lean` and `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean`. The mathematical organization follows Humphreys, *Linear Algebraic Groups*, §§29.1–29.2, and Springer, *Linear Algebraic Groups*, second edition, §8.3, as cited in the module documentation. It reuses Mathlib's quotient-group, double-coset, subgroup, and pointwise-set APIs directly; no Mathlib code or external formalization is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tits-system-bruhat-cell-multiplication"}-->

🤖 Prepared with Codex