### PR TITLE
feat: the Gelfand-Tsetlin dimension formula

### DIFF
--- a/TauCeti/LinearAlgebra/Vandermonde.lean
+++ b/TauCeti/LinearAlgebra/Vandermonde.lean
@@ -111,7 +111,8 @@ theorem sum_Icc_descPochhammer_eval (m : ℕ) {p q : ℤ} (h : p ≤ q) :
       = (descPochhammer ℤ (m + 1)).eval q - (descPochhammer ℤ (m + 1)).eval p := by
   have htel :=
     sum_Icc_sub_telescope (fun t => (descPochhammer ℤ (m + 1)).eval t) p (q - 1) (by omega)
-  rw [show q - 1 + 1 = q by ring] at htel
+  have hq : q - 1 + 1 = q := by omega
+  rw [hq] at htel
   rw [Finset.mul_sum, ← htel]
   exact Finset.sum_congr rfl fun t _ => (descPochhammer_eval_add_one_sub m t).symm
 

--- a/TauCeti/LinearAlgebra/Vandermonde.lean
+++ b/TauCeti/LinearAlgebra/Vandermonde.lean
@@ -1,0 +1,304 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Data.Int.Interval
+public import Mathlib.Data.Nat.Factorial.BigOperators
+public import Mathlib.Data.Pi.Interval
+public import Mathlib.LinearAlgebra.Matrix.Block
+public import Mathlib.LinearAlgebra.Vandermonde
+public import Mathlib.RingTheory.Polynomial.Pochhammer
+
+/-!
+# Summing Vandermonde determinants over a box of nested integer intervals
+
+Let `x₀ ≤ x₁ ≤ ⋯ ≤ xₙ` be integers and let `y` range over the box of integer vectors with
+`xᵢ ≤ yᵢ ≤ xᵢ₊₁ - 1`, one interval for each consecutive pair.  Then
+
+`n ! · ∑ y, det (vandermonde y) = det (vandermonde x)`,
+
+which is `TauCeti.factorial_mul_sum_det_vandermonde`.  Unwinding the determinants, the product
+`∏_{i < j} (yⱼ - yᵢ)` of the differences of an `n`-tuple, summed over the box, is `1 / n !` times
+the corresponding product for the `(n + 1)`-tuple that bounds it.
+
+The identity drives the branching recursion for the Weyl dimension formula of `GL n`: the
+interlacing condition indexing the constituents of an irreducible restricted to `GL (n - 1)` is
+exactly such a box, and the two Vandermonde products are the two Weyl dimension numerators.
+
+## The proof
+
+Three moves; only the last uses the ordering hypothesis.
+
+*The falling-factorial basis.*  The falling factorials `descPochhammer ℤ j` are monic of degree
+`j`, so Mathlib's `Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde` rewrites
+`det (vandermonde y)` as the determinant of the matrix `(descPochhammer ℤ j).eval (yᵢ)`.  The
+point of the change of basis is that falling factorials, unlike powers, have a closed-form
+discrete antiderivative, `TauCeti.sum_Icc_descPochhammer_eval`.
+
+*Multilinearity.*  A determinant is multilinear in its rows and the box constrains the rows
+independently, so the sum of the determinants over the box is the determinant of the matrix of
+row sums (`TauCeti.det_sum_rows`).  Evaluating those row sums, and clearing the denominators
+`1, 2, …, n` by a column scaling, produces the matrix of differences
+`(descPochhammer ℤ (j+1)).eval (xᵢ₊₁) - (descPochhammer ℤ (j+1)).eval (xᵢ)`, whose determinant is
+`n !` times the sum.
+
+*A row reduction.*  That matrix of differences is what remains of the `(n+1) × (n+1)` matrix
+`(descPochhammer ℤ j).eval (xᵢ)` after subtracting each row from its predecessor and deleting the
+column `j = 0`, which is constant equal to `1`.  Multiplying on the left by the bidiagonal matrix
+performing the subtraction contributes a factor `(-1)^{n+1}` to the determinant, and expanding the
+product along its first column — where only the last entry survives — contributes the same sign,
+so the two determinants agree.
+
+## Main results
+
+* `TauCeti.sum_Icc_descPochhammer_eval`: the discrete antiderivative of a falling factorial.
+* `TauCeti.det_sum_rows`: a determinant whose rows are independent sums expands as a sum of
+  determinants.
+* `TauCeti.factorial_mul_sum_det_vandermonde`: **the box-sum identity for Vandermonde
+  determinants.**
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset Matrix Polynomial
+
+/-! ### The discrete antiderivative of a falling factorial -/
+
+/-- Shifting the argument of a falling factorial by one strips off its trailing linear factor:
+the degree `m + 1` falling factorial at `x + 1` is `(x + 1)` times the degree `m` one at `x`. -/
+private theorem descPochhammer_succ_eval_add_one (m : ℕ) (x : ℤ) :
+    (descPochhammer ℤ (m + 1)).eval (x + 1) = (x + 1) * (descPochhammer ℤ m).eval x := by
+  rw [descPochhammer_succ_left, eval_mul, eval_X, eval_comp, eval_sub, eval_X, eval_one,
+    add_sub_cancel_right]
+
+/-- **The discrete derivative of a falling factorial**: the falling factorial of degree `m + 1`
+increases by `m + 1` times the falling factorial of degree `m`.  This is the analogue of
+`(x^{m+1})' = (m+1) x^m`, and the reason the falling factorials, not the powers, are the basis in
+which a Vandermonde determinant can be summed over a range. -/
+private theorem descPochhammer_eval_add_one_sub (m : ℕ) (x : ℤ) :
+    (descPochhammer ℤ (m + 1)).eval (x + 1) - (descPochhammer ℤ (m + 1)).eval x
+      = ((m : ℤ) + 1) * (descPochhammer ℤ m).eval x := by
+  rw [descPochhammer_succ_eval_add_one, descPochhammer_succ_eval]
+  ring
+
+/-- Telescoping a sum of consecutive differences over an integer interval. -/
+private theorem sum_Icc_sub_telescope (f : ℤ → ℤ) (p : ℤ) :
+    ∀ q, p - 1 ≤ q → ∑ t ∈ Finset.Icc p q, (f (t + 1) - f t) = f (q + 1) - f p := by
+  intro q hq
+  induction q, hq using Int.leInduction with
+  | base =>
+    rw [Finset.Icc_eq_empty (by omega), Finset.sum_empty]
+    norm_num
+  | succ q hq ih =>
+    have hins : Finset.Icc p (q + 1) = insert (q + 1) (Finset.Icc p q) := by
+      ext t
+      simp only [Finset.mem_insert, Finset.mem_Icc]
+      omega
+    rw [hins, Finset.sum_insert (by simp only [Finset.mem_Icc, not_and, not_le]; omega), ih]
+    ring
+
+/-- **The discrete antiderivative of a falling factorial.**  Summing the degree `m` falling
+factorial over the integer range `p ≤ t < q` gives the difference of the degree `m + 1` falling
+factorial at the endpoints, divided by `m + 1`; the statement clears that denominator.
+
+The hypothesis `p ≤ q` is what makes the range a range: for `q < p` the sum is empty while the
+right-hand side need not vanish. -/
+theorem sum_Icc_descPochhammer_eval (m : ℕ) {p q : ℤ} (h : p ≤ q) :
+    ((m : ℤ) + 1) * ∑ t ∈ Finset.Icc p (q - 1), (descPochhammer ℤ m).eval t
+      = (descPochhammer ℤ (m + 1)).eval q - (descPochhammer ℤ (m + 1)).eval p := by
+  have htel :=
+    sum_Icc_sub_telescope (fun t => (descPochhammer ℤ (m + 1)).eval t) p (q - 1) (by omega)
+  rw [show q - 1 + 1 = q by ring] at htel
+  rw [Finset.mul_sum, ← htel]
+  exact Finset.sum_congr rfl fun t _ => (descPochhammer_eval_add_one_sub m t).symm
+
+/-! ### Determinants of matrices whose rows are sums -/
+
+/-- **A determinant whose rows are independent sums expands as a sum of determinants.**  This is
+multilinearity of the determinant in the rows, used in every row at once: a term of the expansion
+is a choice of one summand in each row, so the terms are indexed by the choice functions. -/
+theorem det_sum_rows {ι : Type*} [DecidableEq ι] [Fintype ι] {R : Type*} [CommRing R]
+    {α : Type*} (A : ι → Finset α) (g : ι → α → ι → R) :
+    (Matrix.of fun i j => ∑ t ∈ A i, g i t j).det
+      = ∑ y ∈ Fintype.piFinset A, (Matrix.of fun i j => g i (y i) j).det := by
+  have key := (Matrix.detRowAlternating (R := R) (n := ι)).toMultilinearMap.map_sum_finset
+    (g := g) (A := A)
+  have hrow : (fun i : ι => ∑ t ∈ A i, g i t) = fun i : ι => fun j : ι => ∑ t ∈ A i, g i t j := by
+    funext i j
+    exact Finset.sum_apply j (A i) (g i)
+  rw [hrow] at key
+  exact key
+
+/-! ### The box-sum identity -/
+
+/-- The Vandermonde determinant of a node vector, computed in the falling-factorial basis: the
+falling factorials are monic of degree `j`, so they give the same determinant as the powers. -/
+private theorem det_vandermonde_eq_det_descPochhammer (m : ℕ) (y : Fin m → ℤ) :
+    (Matrix.vandermonde y).det
+      = (Matrix.of fun i j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y i)).det :=
+  Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde y
+    (fun j => descPochhammer ℤ (j : ℕ)) (fun j => descPochhammer_natDegree (R := ℤ) (j : ℕ))
+    (fun j => monic_descPochhammer (R := ℤ) (j : ℕ))
+
+/-- The one surviving term of a sum whose summand is supported on the index one step above a
+given one. -/
+private theorem sum_ite_val_eq_succ {m : ℕ} (i : Fin m) (f : Fin (m + 1) → ℤ) :
+    (∑ k : Fin (m + 1), if (k : ℕ) = (i.castSucc : ℕ) + 1 then f k else 0) = f i.succ := by
+  rw [Finset.sum_eq_single i.succ]
+  · simp
+  · intro k _ hk
+    have hne : ¬ ((k : ℕ) = (i : ℕ) + 1) := fun h => hk (by ext; simpa using h)
+    simp only [Fin.val_castSucc, ite_eq_right_iff]
+    exact fun h => absurd h hne
+  · simp
+
+/-- There is no index one step above the last one, so the corresponding sum is empty. -/
+private theorem sum_ite_val_eq_last_succ {m : ℕ} (f : Fin (m + 1) → ℤ) :
+    (∑ k : Fin (m + 1), if (k : ℕ) = ((Fin.last m : Fin (m + 1)) : ℕ) + 1 then f k else 0)
+      = 0 := by
+  refine Finset.sum_eq_zero fun k _ => ?_
+  have hk := k.isLt
+  simp only [Fin.val_last, ite_eq_right_iff]
+  intro h
+  omega
+
+/-- **The row reduction.**  The `n × n` matrix of differences of falling factorials at the
+consecutive nodes `xᵢ`, `xᵢ₊₁` has the same determinant as the `(n+1) × (n+1)` Vandermonde matrix
+of the nodes themselves: it is obtained from the falling-factorial form of the latter by
+subtracting each row from its predecessor and deleting the constant column `j = 0`. -/
+private theorem det_descPochhammer_sub_eq_det_vandermonde {n : ℕ} (x : Fin (n + 1) → ℤ) :
+    (Matrix.of fun i j : Fin n =>
+        (descPochhammer ℤ ((j : ℕ) + 1)).eval (x i.succ)
+          - (descPochhammer ℤ ((j : ℕ) + 1)).eval (x i.castSucc)).det
+      = (Matrix.vandermonde x).det := by
+  classical
+  -- `N` is the Vandermonde matrix of `x` in the falling-factorial basis, and `E` is the bidiagonal
+  -- matrix subtracting each row of `N` from its predecessor.
+  let N : Matrix (Fin (n + 1)) (Fin (n + 1)) ℤ :=
+    Matrix.of fun i j => (descPochhammer ℤ (j : ℕ)).eval (x i)
+  let E : Matrix (Fin (n + 1)) (Fin (n + 1)) ℤ := Matrix.of fun i k =>
+    (if (k : ℕ) = (i : ℕ) + 1 then (1 : ℤ) else 0) - (if k = i then 1 else 0)
+  have hN : ∀ i j, N i j = (descPochhammer ℤ (j : ℕ)).eval (x i) := fun _ _ => rfl
+  have hE : ∀ i k, E i k
+      = (if (k : ℕ) = (i : ℕ) + 1 then (1 : ℤ) else 0) - (if k = i then 1 else 0) :=
+    fun _ _ => rfl
+  have hEN : ∀ i j : Fin (n + 1),
+      (E * N) i j
+        = (∑ k : Fin (n + 1), if (k : ℕ) = (i : ℕ) + 1 then N k j else 0) - N i j := by
+    intro i j
+    rw [Matrix.mul_apply]
+    have hterm : ∀ k : Fin (n + 1), E i k * N k j
+        = (if (k : ℕ) = (i : ℕ) + 1 then N k j else 0) - (if k = i then N k j else 0) := by
+      intro k
+      rw [hE]
+      split_ifs <;> ring
+    rw [Finset.sum_congr rfl fun k _ => hterm k, Finset.sum_sub_distrib]
+    congr 1
+    simp
+  have hEupper : E.IsUpperTriangular := by
+    intro i k hki
+    have hk : (k : ℕ) < (i : ℕ) := hki
+    have h1 : ¬ ((k : ℕ) = (i : ℕ) + 1) := by omega
+    have h2 : ¬ (k = i) := by rintro rfl; omega
+    rw [hE]
+    simp [h1, h2]
+  have hEdet : E.det = (-1 : ℤ) ^ (n + 1) := by
+    rw [Matrix.det_of_isUpperTriangular hEupper]
+    have hdiag : ∀ i : Fin (n + 1), E i i = -1 := by
+      intro i
+      rw [hE]
+      simp
+    rw [Finset.prod_congr rfl fun i _ => hdiag i]
+    simp
+  -- The column `j = 0` of `N` is constant equal to `1`, so `E * N` has a single nonzero entry
+  -- there, in its last row.
+  have hcol : ∀ i : Fin (n + 1), N i 0 = 1 := by
+    intro i
+    rw [hN]
+    simp
+  have hcastSucc : ∀ (i : Fin n) (j : Fin (n + 1)),
+      (E * N) i.castSucc j = N i.succ j - N i.castSucc j := by
+    intro i j
+    rw [hEN, sum_ite_val_eq_succ]
+  have hlast : (E * N) (Fin.last n) 0 = -1 := by
+    rw [hEN, sum_ite_val_eq_last_succ, hcol]
+    ring
+  have hsubmat : (E * N).submatrix (Fin.last n).succAbove Fin.succ
+      = Matrix.of fun i j : Fin n =>
+          (descPochhammer ℤ ((j : ℕ) + 1)).eval (x i.succ)
+            - (descPochhammer ℤ ((j : ℕ) + 1)).eval (x i.castSucc) := by
+    ext i j
+    rw [Matrix.submatrix_apply, Fin.succAbove_last, hcastSucc, hN, hN]
+    simp
+  have hdetEN : (E * N).det = (-1 : ℤ) ^ (n + 1) *
+      (Matrix.of fun i j : Fin n =>
+        (descPochhammer ℤ ((j : ℕ) + 1)).eval (x i.succ)
+          - (descPochhammer ℤ ((j : ℕ) + 1)).eval (x i.castSucc)).det := by
+    rw [Matrix.det_succ_column_zero, Finset.sum_eq_single (Fin.last n)]
+    · rw [hlast, hsubmat, Fin.val_last]
+      ring
+    · intro i _ hi
+      obtain ⟨i, rfl⟩ := Fin.eq_castSucc_of_ne_last hi
+      rw [hcastSucc]
+      simp only [hcol]
+      ring
+    · simp
+  -- Both readings of `det (E * N)` carry the same sign, which therefore cancels.
+  have hdetN : N.det = (Matrix.vandermonde x).det :=
+    (det_vandermonde_eq_det_descPochhammer (n + 1) x).symm
+  rw [Matrix.det_mul, hEdet, hdetN] at hdetEN
+  exact (mul_left_cancel₀ (pow_ne_zero (n + 1) (by norm_num : (-1 : ℤ) ≠ 0)) hdetEN).symm
+
+/-- Clearing the denominators `1, 2, …, n` of the discrete antiderivatives is a column scaling,
+whose determinant is `n !`. -/
+private theorem prod_fin_add_one_eq_factorial (n : ℕ) :
+    (∏ j : Fin n, (((j : ℕ) : ℤ) + 1)) = (Nat.factorial n : ℤ) := by
+  have hcast : ∀ k : ℕ, ((k : ℤ) + 1) = ((k + 1 : ℕ) : ℤ) := by
+    intro k
+    push_cast
+    ring
+  rw [Fin.prod_univ_eq_prod_range fun k : ℕ => ((k : ℤ) + 1)]
+  simp only [hcast, ← Nat.cast_prod, Finset.prod_range_add_one_eq_factorial]
+
+/-- **Summing Vandermonde determinants over a box of nested intervals.**  For integers
+`x₀ ≤ x₁ ≤ ⋯ ≤ xₙ`, the Vandermonde determinant of `y`, summed over all integer vectors with
+`xᵢ ≤ yᵢ ≤ xᵢ₊₁ - 1`, is the Vandermonde determinant of `x` divided by `n !`; the statement clears
+that denominator, so it is an identity over `ℤ`.
+
+The hypothesis is exactly what makes each interval a range of summation; the nodes are otherwise
+arbitrary integers, of either sign. -/
+theorem factorial_mul_sum_det_vandermonde {n : ℕ} (x : Fin (n + 1) → ℤ)
+    (hx : ∀ i : Fin n, x i.castSucc ≤ x i.succ) :
+    (Nat.factorial n : ℤ) *
+        ∑ y ∈ Finset.Icc (fun i : Fin n => x i.castSucc) (fun i : Fin n => x i.succ - 1),
+          (Matrix.vandermonde y).det
+      = (Matrix.vandermonde x).det := by
+  classical
+  have hsum : (∑ y ∈ Finset.Icc (fun i : Fin n => x i.castSucc) (fun i : Fin n => x i.succ - 1),
+      (Matrix.vandermonde y).det)
+      = (Matrix.of fun i j : Fin n =>
+          ∑ t ∈ Finset.Icc (x i.castSucc) (x i.succ - 1),
+            (descPochhammer ℤ (j : ℕ)).eval t).det := by
+    rw [det_sum_rows (fun i : Fin n => Finset.Icc (x i.castSucc) (x i.succ - 1))
+      fun i t j => (descPochhammer ℤ (j : ℕ)).eval t]
+    exact Finset.sum_congr rfl fun y _ => det_vandermonde_eq_det_descPochhammer n y
+  have hscale : (Matrix.of fun i j : Fin n =>
+        (descPochhammer ℤ ((j : ℕ) + 1)).eval (x i.succ)
+          - (descPochhammer ℤ ((j : ℕ) + 1)).eval (x i.castSucc))
+      = (Matrix.of fun i j : Fin n =>
+          ∑ t ∈ Finset.Icc (x i.castSucc) (x i.succ - 1),
+            (descPochhammer ℤ (j : ℕ)).eval t)
+        * Matrix.diagonal fun j : Fin n => ((j : ℕ) : ℤ) + 1 := by
+    ext i j
+    rw [Matrix.mul_diagonal, Matrix.of_apply, Matrix.of_apply, mul_comm]
+    exact (sum_Icc_descPochhammer_eval (j : ℕ) (hx i)).symm
+  have hdet := det_descPochhammer_sub_eq_det_vandermonde x
+  rw [hscale, Matrix.det_mul, Matrix.det_diagonal, prod_fin_add_one_eq_factorial] at hdet
+  rw [hsum, mul_comm, hdet]
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Vandermonde.lean
+++ b/TauCeti/LinearAlgebra/Vandermonde.lean
@@ -40,8 +40,8 @@ discrete antiderivative, `TauCeti.sum_Icc_descPochhammer_eval`.
 
 *Multilinearity.*  A determinant is multilinear in its rows and the box constrains the rows
 independently, so the sum of the determinants over the box is the determinant of the matrix of
-row sums (`TauCeti.det_sum_rows`).  Evaluating those row sums, and clearing the denominators
-`1, 2, …, n` by a column scaling, produces the matrix of differences
+row sums (`MultilinearMap.map_sum_finset`).  Evaluating those row sums, and clearing the
+denominators `1, 2, …, n` by a column scaling, produces the matrix of differences
 `(descPochhammer ℤ (j+1)).eval (xᵢ₊₁) - (descPochhammer ℤ (j+1)).eval (xᵢ)`, whose determinant is
 `n !` times the sum.
 
@@ -55,8 +55,6 @@ so the two determinants agree.
 ## Main results
 
 * `TauCeti.sum_Icc_descPochhammer_eval`: the discrete antiderivative of a falling factorial.
-* `TauCeti.det_sum_rows`: a determinant whose rows are independent sums expands as a sum of
-  determinants.
 * `TauCeti.factorial_mul_sum_det_vandermonde`: **the box-sum identity for Vandermonde
   determinants.**
 -/
@@ -116,23 +114,6 @@ theorem sum_Icc_descPochhammer_eval (m : ℕ) {p q : ℤ} (h : p ≤ q) :
   rw [show q - 1 + 1 = q by ring] at htel
   rw [Finset.mul_sum, ← htel]
   exact Finset.sum_congr rfl fun t _ => (descPochhammer_eval_add_one_sub m t).symm
-
-/-! ### Determinants of matrices whose rows are sums -/
-
-/-- **A determinant whose rows are independent sums expands as a sum of determinants.**  This is
-multilinearity of the determinant in the rows, used in every row at once: a term of the expansion
-is a choice of one summand in each row, so the terms are indexed by the choice functions. -/
-theorem det_sum_rows {ι : Type*} [DecidableEq ι] [Fintype ι] {R : Type*} [CommRing R]
-    {α : Type*} (A : ι → Finset α) (g : ι → α → ι → R) :
-    (Matrix.of fun i j => ∑ t ∈ A i, g i t j).det
-      = ∑ y ∈ Fintype.piFinset A, (Matrix.of fun i j => g i (y i) j).det := by
-  have key := (Matrix.detRowAlternating (R := R) (n := ι)).toMultilinearMap.map_sum_finset
-    (g := g) (A := A)
-  have hrow : (fun i : ι => ∑ t ∈ A i, g i t) = fun i : ι => fun j : ι => ∑ t ∈ A i, g i t j := by
-    funext i j
-    exact Finset.sum_apply j (A i) (g i)
-  rw [hrow] at key
-  exact key
 
 /-! ### The box-sum identity -/
 
@@ -279,13 +260,29 @@ theorem factorial_mul_sum_det_vandermonde {n : ℕ} (x : Fin (n + 1) → ℤ)
           (Matrix.vandermonde y).det
       = (Matrix.vandermonde x).det := by
   classical
+  -- Multilinearity of the determinant in the rows, used in every row at once: a term of the
+  -- expansion is a choice of one summand in each row, so the terms are indexed by the box.
+  have hbox : (Matrix.of fun i j : Fin n =>
+        ∑ t ∈ Finset.Icc (x i.castSucc) (x i.succ - 1), (descPochhammer ℤ (j : ℕ)).eval t).det
+      = ∑ y ∈ Fintype.piFinset fun i : Fin n => Finset.Icc (x i.castSucc) (x i.succ - 1),
+          (Matrix.of fun i j : Fin n => (descPochhammer ℤ (j : ℕ)).eval (y i)).det := by
+    have key := (Matrix.detRowAlternating (R := ℤ) (n := Fin n)).toMultilinearMap.map_sum_finset
+      (A := fun i : Fin n => Finset.Icc (x i.castSucc) (x i.succ - 1))
+      (g := fun (_ : Fin n) (t : ℤ) (j : Fin n) => (descPochhammer ℤ (j : ℕ)).eval t)
+    have hrow : (fun i : Fin n => ∑ t ∈ Finset.Icc (x i.castSucc) (x i.succ - 1),
+          fun j : Fin n => (descPochhammer ℤ (j : ℕ)).eval t)
+        = fun i j : Fin n =>
+          ∑ t ∈ Finset.Icc (x i.castSucc) (x i.succ - 1), (descPochhammer ℤ (j : ℕ)).eval t := by
+      funext i j
+      exact Finset.sum_apply j _ _
+    rw [hrow] at key
+    exact key
   have hsum : (∑ y ∈ Finset.Icc (fun i : Fin n => x i.castSucc) (fun i : Fin n => x i.succ - 1),
       (Matrix.vandermonde y).det)
       = (Matrix.of fun i j : Fin n =>
           ∑ t ∈ Finset.Icc (x i.castSucc) (x i.succ - 1),
             (descPochhammer ℤ (j : ℕ)).eval t).det := by
-    rw [det_sum_rows (fun i : Fin n => Finset.Icc (x i.castSucc) (x i.succ - 1))
-      fun i t j => (descPochhammer ℤ (j : ℕ)).eval t]
+    rw [hbox]
     exact Finset.sum_congr rfl fun y _ => det_vandermonde_eq_det_descPochhammer n y
   have hscale : (Matrix.of fun i j : Fin n =>
         (descPochhammer ℤ ((j : ℕ) + 1)).eval (x i.succ)

--- a/TauCeti/LinearAlgebra/Vandermonde.lean
+++ b/TauCeti/LinearAlgebra/Vandermonde.lean
@@ -8,9 +8,9 @@ module
 public import Mathlib.Data.Int.Interval
 public import Mathlib.Data.Nat.Factorial.BigOperators
 public import Mathlib.Data.Pi.Interval
-public import Mathlib.LinearAlgebra.Matrix.Block
 public import Mathlib.LinearAlgebra.Vandermonde
 public import Mathlib.RingTheory.Polynomial.Pochhammer
+import Mathlib.LinearAlgebra.Matrix.Block
 
 /-!
 # Summing Vandermonde determinants over a box of nested integer intervals

--- a/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Dimension.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Dimension.lean
@@ -5,9 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.Vandermonde
 public import TauCeti.RepresentationTheory.ClassicalGroups.GelfandTsetlin.Count
 public import TauCeti.RepresentationTheory.ClassicalGroups.WeylDimension
+import TauCeti.LinearAlgebra.Vandermonde
 
 /-!
 # The Gelfand-Tsetlin dimension formula

--- a/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Dimension.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Dimension.lean
@@ -23,8 +23,10 @@ This is `TauCeti.GTPattern.card_topRow_eq_weylDimension`, and its `DominantWeigh
 `TauCeti.RepresentationTheory.ClassicalGroups.WeylDimension`.  What is proved here is that they
 agree, so that the two candidate dimensions for the irreducible rational representation of `GL n`
 of highest weight `λ` — the number of Gelfand-Tsetlin patterns, and the Weyl product formula —
-are the same natural number.  Neither the representation nor the basis is used; this is an
-identity between a lattice-point count and a product formula.
+are the same natural number.  That either of them *is* the dimension of a representation is not
+proved here and cannot yet be stated: no representation and no Gelfand-Tsetlin basis is
+constructed, and none is used.  This is an identity between a lattice-point count and a product
+formula.
 
 ## The proof
 
@@ -35,10 +37,9 @@ satisfies the same recursion, `∑_{μ ≺ λ} dim V_μ = dim V_λ`.
 
 In the shifted coordinates `xₖ = k - λₖ`, which turn a weakly decreasing sequence into a weakly
 increasing one, the Weyl numerator `∏_{i<j} (λᵢ - λⱼ + j - i)` is the Vandermonde determinant of
-`x` (`TauCeti.prod_Ioi_eq_det_vandermonde`), and the interlacing condition becomes the box
-`xᵢ ≤ yᵢ ≤ xᵢ₊₁ - 1`.  The recursion is then exactly the box-sum identity
-`TauCeti.factorial_mul_sum_det_vandermonde`, the factor `n !` being the ratio of the two
-superfactorial denominators.
+`x`, and the interlacing condition becomes the box `xᵢ ≤ yᵢ ≤ xᵢ₊₁ - 1`.  The recursion is then
+exactly the box-sum identity `TauCeti.factorial_mul_sum_det_vandermonde`, the factor `n !` being
+the ratio of the two superfactorial denominators.
 
 ## Main results
 
@@ -173,10 +174,16 @@ private theorem card_topRow_mul_superFactorial :
 weakly decreasing sequence `λ` are counted by the Weyl dimension formula
 `∏_{i < j} (λᵢ - λⱼ + j - i) / (j - i)`.
 
-Both sides are the dimension of the irreducible rational representation of `GL n` with highest
-weight `λ`, but neither that representation nor the Gelfand-Tsetlin basis enters the proof: this
-is the identity of a lattice-point count with a product formula, obtained by checking that both
-satisfy the branching recursion of `GL (n + 1) ↓ GL n`. -/
+Both sides are candidates for the dimension of the irreducible rational representation of `GL n`
+with highest weight `λ`, but that representation and the Gelfand-Tsetlin basis are not built here
+and do not enter the proof: what is proved is the identity of a lattice-point count with a product
+formula, obtained by checking that both satisfy the branching recursion of `GL (n + 1) ↓ GL n`.
+
+This is deliberately not a `simp` lemma: `{P : GTPattern n // P.topRow = l}` carries a `Fintype`
+instance, so `Nat.card_eq_fintype_card` rewrites the left-hand side first and the `simpNF` linter
+rejects the tag.  The `DominantWeight`-indexed
+`TauCeti.GTPattern.card_topWeight_eq_weylDimension` below, whose subtype has no such instance, is
+the `simp` form. -/
 theorem card_topRow_eq_weylDimension {n : ℕ} (l : DominantWeight n) :
     Nat.card {P : GTPattern n // P.topRow = (l : Fin n → ℤ)} = weylDimension l := by
   have hsf : ((n - 1).superFactorial : ℤ) ≠ 0 := by
@@ -191,6 +198,7 @@ theorem card_topRow_eq_weylDimension {n : ℕ} (l : DominantWeight n) :
 
 /-- **The Gelfand-Tsetlin dimension formula, indexed by a dominant weight.**  The form the
 downstream representation theory consumes: fixing the top weight rather than the top row. -/
+@[simp]
 theorem card_topWeight_eq_weylDimension {n : ℕ} (l : DominantWeight n) :
     Nat.card {P : GTPattern n // P.topWeight = l} = weylDimension l :=
   (card_topWeight_eq_card_topRow l).trans (card_topRow_eq_weylDimension l)

--- a/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Dimension.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/GelfandTsetlin/Dimension.lean
@@ -1,0 +1,209 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Vandermonde
+public import TauCeti.RepresentationTheory.ClassicalGroups.GelfandTsetlin.Count
+public import TauCeti.RepresentationTheory.ClassicalGroups.WeylDimension
+
+/-!
+# The Gelfand-Tsetlin dimension formula
+
+The Gelfand-Tsetlin patterns with a given weakly decreasing top row `λ` are counted by the Weyl
+dimension formula for `GL n`:
+
+`#{P : GTPattern n | topRow P = λ} = ∏_{i < j} (λᵢ - λⱼ + j - i) / (j - i)`.
+
+This is `TauCeti.GTPattern.card_topRow_eq_weylDimension`, and its `DominantWeight`-indexed form
+`TauCeti.GTPattern.card_topWeight_eq_weylDimension`.  Both sides are already built: the left by
+`TauCeti.RepresentationTheory.ClassicalGroups.GelfandTsetlin.Count`, the right by
+`TauCeti.RepresentationTheory.ClassicalGroups.WeylDimension`.  What is proved here is that they
+agree, so that the two candidate dimensions for the irreducible rational representation of `GL n`
+of highest weight `λ` — the number of Gelfand-Tsetlin patterns, and the Weyl product formula —
+are the same natural number.  Neither the representation nor the basis is used; this is an
+identity between a lattice-point count and a product formula.
+
+## The proof
+
+The proof is the branching recursion, exactly as the roadmap asks: deleting the top row of a
+pattern gives `TauCeti.GTPattern.card_topRow_succ`, which counts the patterns over `λ` by the
+patterns over each sequence interlacing `λ`.  So it suffices to know that the Weyl dimension
+satisfies the same recursion, `∑_{μ ≺ λ} dim V_μ = dim V_λ`.
+
+In the shifted coordinates `xₖ = k - λₖ`, which turn a weakly decreasing sequence into a weakly
+increasing one, the Weyl numerator `∏_{i<j} (λᵢ - λⱼ + j - i)` is the Vandermonde determinant of
+`x` (`TauCeti.prod_Ioi_eq_det_vandermonde`), and the interlacing condition becomes the box
+`xᵢ ≤ yᵢ ≤ xᵢ₊₁ - 1`.  The recursion is then exactly the box-sum identity
+`TauCeti.factorial_mul_sum_det_vandermonde`, the factor `n !` being the ratio of the two
+superfactorial denominators.
+
+## Main results
+
+* `TauCeti.GTPattern.card_topRow_eq_weylDimension`: **the Gelfand-Tsetlin dimension formula.**
+* `TauCeti.GTPattern.card_topWeight_eq_weylDimension`: the same, indexed by a dominant weight.
+* `TauCeti.weylDimension_two_one_zero`: the `GL 3` acceptance example, `dim V_{(2,1,0)} = 8`.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 6, "The Gelfand-Tsetlin dimension formula".
+* W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), §15.3 and Exercise 15.4.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset
+
+/-! ### Two reformulations -/
+
+/-- The superfactorial denominators of consecutive Weyl dimension formulas differ by `n !`. -/
+private theorem superFactorial_eq_factorial_mul (n : ℕ) :
+    (n.superFactorial : ℤ) = (Nat.factorial n : ℤ) * ((n - 1).superFactorial : ℤ) := by
+  cases n with
+  | zero => simp
+  | succ m => simp [Nat.superFactorial_succ]
+
+/-- **The Weyl numerator is a Vandermonde determinant.**  Subtracting a weight from the staircase,
+`k ↦ k - λₖ`, turns a weakly decreasing sequence into a weakly increasing one and rewrites
+`∏_{i < j} (λᵢ - λⱼ + j - i)` as the Vandermonde determinant of the result.  This is the
+reformulation in which the branching recursion is a statement about Vandermonde determinants.
+
+The existing `TauCeti.weylDimensionNumerator_eq_det_vandermonde` reverses the index instead of
+negating it; that reindexing does not carry the interlacing condition to a box of nested
+intervals, which is what the recursion below needs. -/
+private theorem prod_Ioi_eq_det_vandermonde {n : ℕ} (l : Fin n → ℤ) :
+    (∏ i : Fin n, ∏ j ∈ Ioi i, (l i - l j + ((j : ℤ) - i)))
+      = (Matrix.vandermonde fun k : Fin n => (k : ℤ) - l k).det := by
+  rw [Matrix.det_vandermonde]
+  exact Finset.prod_congr rfl fun i _ => Finset.prod_congr rfl fun j _ => by ring
+
+/-! ### The branching recursion for the Weyl numerator -/
+
+/-- **The Weyl numerators satisfy the branching recursion.**  Summing the Weyl numerator over the
+sequences interlacing `l` gives the Weyl numerator of `l`, up to the factor `n !` by which the two
+superfactorial denominators differ.  Equivalently: `∑_{μ ≺ λ} dim V_μ = dim V_λ`, the numerical
+shadow of the multiplicity-free branching `GL (n + 1) ↓ GL n`. -/
+private theorem factorial_mul_sum_interlacing_prod {n : ℕ} (l : Fin (n + 1) → ℤ)
+    (hl : Antitone l) :
+    (Nat.factorial n : ℤ) * ∑ m ∈ interlacingFinset l,
+        ∏ i : Fin n, ∏ j ∈ Ioi i, (m i - m j + ((j : ℤ) - i))
+      = ∏ i : Fin (n + 1), ∏ j ∈ Ioi i, (l i - l j + ((j : ℤ) - i)) := by
+  have hmono : ∀ i : Fin n,
+      ((i.castSucc : Fin (n + 1)) : ℤ) - l i.castSucc
+        ≤ ((i.succ : Fin (n + 1)) : ℤ) - l i.succ := by
+    intro i
+    have h := hl (Fin.castSucc_le_succ i)
+    simp only [Fin.val_succ, Fin.val_castSucc]
+    omega
+  have hmain := factorial_mul_sum_det_vandermonde (fun k : Fin (n + 1) => (k : ℤ) - l k) hmono
+  rw [prod_Ioi_eq_det_vandermonde l, ← hmain,
+    Finset.sum_congr rfl fun m (_ : m ∈ interlacingFinset l) => prod_Ioi_eq_det_vandermonde m]
+  congr 1
+  refine Finset.sum_nbij' (fun m => fun k : Fin n => (k : ℤ) - m k)
+    (fun y => fun k : Fin n => (k : ℤ) - y k) ?_ ?_ ?_ ?_ ?_
+  · intro m hm
+    rw [mem_interlacingFinset] at hm
+    rw [Finset.mem_Icc]
+    refine ⟨fun k => ?_, fun k => ?_⟩
+    · have := hm.le_castSucc k
+      simp only [Fin.val_castSucc]
+      omega
+    · have := hm.succ_le k
+      simp only [Fin.val_succ]
+      omega
+  · intro y hy
+    rw [Finset.mem_Icc] at hy
+    rw [mem_interlacingFinset, interlaces_iff]
+    intro k
+    have h1 := hy.1 k
+    have h2 := hy.2 k
+    simp only [Fin.val_succ, Fin.val_castSucc] at h1 h2
+    omega
+  · exact fun m _ => funext fun k => by ring
+  · exact fun y _ => funext fun k => by ring
+  · exact fun m _ => rfl
+
+/-! ### The dimension formula -/
+
+namespace GTPattern
+
+/-- **The Gelfand-Tsetlin count times the Weyl denominator is the Weyl numerator.**  The
+division-free form of the dimension formula, proved by induction on `n` from the branching
+recursion `TauCeti.GTPattern.card_topRow_succ`.
+
+The hypothesis that `l` is weakly decreasing is needed: a sequence that is not carries no pattern
+at all, while the product on the right is generally nonzero. -/
+private theorem card_topRow_mul_superFactorial :
+    ∀ (n : ℕ) (l : Fin n → ℤ), Antitone l →
+      (Nat.card {P : GTPattern n // P.topRow = l} : ℤ) * ((n - 1).superFactorial : ℤ)
+        = ∏ i : Fin n, ∏ j ∈ Ioi i, (l i - l j + ((j : ℤ) - i)) := by
+  intro n
+  induction n with
+  | zero =>
+    intro l _
+    have hcard : Nat.card {P : GTPattern 0 // P.topRow = l} = 1 :=
+      Nat.card_eq_one_iff_unique.mpr
+        ⟨⟨fun a b => Subtype.ext (Subsingleton.elim _ _)⟩, ⟨⟨default, funext fun i => i.elim0⟩⟩⟩
+    rw [hcard]
+    simp
+  | succ n ih =>
+    intro l hl
+    have hstep : (Nat.card {P : GTPattern (n + 1) // P.topRow = l} : ℤ)
+        = ∑ m ∈ interlacingFinset l, (Nat.card {Q : GTPattern n // Q.topRow = m} : ℤ) := by
+      rw [card_topRow_succ, Nat.cast_sum]
+    have hsf : ((n + 1 - 1).superFactorial : ℤ)
+        = (Nat.factorial n : ℤ) * ((n - 1).superFactorial : ℤ) := by
+      simpa using superFactorial_eq_factorial_mul n
+    have hL : (Nat.card {P : GTPattern (n + 1) // P.topRow = l} : ℤ)
+          * ((n + 1 - 1).superFactorial : ℤ)
+        = (Nat.factorial n : ℤ) * ∑ m ∈ interlacingFinset l,
+            (Nat.card {Q : GTPattern n // Q.topRow = m} : ℤ) * ((n - 1).superFactorial : ℤ) := by
+      rw [hstep, hsf, Finset.mul_sum, Finset.sum_mul]
+      exact Finset.sum_congr rfl fun m _ => by ring
+    rw [hL, Finset.sum_congr rfl fun m hm =>
+      ih m (mem_interlacingFinset.mp hm).antitone]
+    exact factorial_mul_sum_interlacing_prod l hl
+
+/-- **The Gelfand-Tsetlin dimension formula.**  The Gelfand-Tsetlin patterns with top row a
+weakly decreasing sequence `λ` are counted by the Weyl dimension formula
+`∏_{i < j} (λᵢ - λⱼ + j - i) / (j - i)`.
+
+Both sides are the dimension of the irreducible rational representation of `GL n` with highest
+weight `λ`, but neither that representation nor the Gelfand-Tsetlin basis enters the proof: this
+is the identity of a lattice-point count with a product formula, obtained by checking that both
+satisfy the branching recursion of `GL (n + 1) ↓ GL n`. -/
+theorem card_topRow_eq_weylDimension {n : ℕ} (l : DominantWeight n) :
+    Nat.card {P : GTPattern n // P.topRow = (l : Fin n → ℤ)} = weylDimension l := by
+  have hsf : ((n - 1).superFactorial : ℤ) ≠ 0 := by
+    intro h0
+    have hmul := weylDimension_mul_superFactorial l
+    rw [h0, mul_zero] at hmul
+    exact (weylDimensionNumerator_pos l).ne hmul
+  have h := (card_topRow_mul_superFactorial n l.1 l.2).trans
+    (weylDimensionNumerator_eq_prod_prod l).symm
+  have h' := h.trans (weylDimension_mul_superFactorial l).symm
+  exact_mod_cast mul_right_cancel₀ hsf h'
+
+/-- **The Gelfand-Tsetlin dimension formula, indexed by a dominant weight.**  The form the
+downstream representation theory consumes: fixing the top weight rather than the top row. -/
+theorem card_topWeight_eq_weylDimension {n : ℕ} (l : DominantWeight n) :
+    Nat.card {P : GTPattern n // P.topWeight = l} = weylDimension l :=
+  (card_topWeight_eq_card_topRow l).trans (card_topRow_eq_weylDimension l)
+
+end GTPattern
+
+/-- **The `GL 3` acceptance example**: the weight `(2, 1, 0)` has Weyl dimension `8`, the dimension
+of the adjoint representation of `SL 3`.  Read off the eight Gelfand-Tsetlin patterns over that top
+row (`TauCeti.GTPattern.card_topRow_three_two_one_zero`) through the dimension formula, rather than
+by evaluating the product. -/
+theorem weylDimension_two_one_zero :
+    weylDimension (⟨![2, 1, 0], by decide⟩ : DominantWeight 3) = 8 :=
+  (GTPattern.card_topRow_eq_weylDimension ⟨![2, 1, 0], by decide⟩).symm.trans
+    GTPattern.card_topRow_three_two_one_zero
+
+end TauCeti


### PR DESCRIPTION
This PR proves the Gelfand-Tsetlin dimension formula: the Gelfand-Tsetlin patterns with a given weakly decreasing top row `λ` are counted by the Weyl dimension formula for `GL n`, `#{P : GTPattern n | topRow P = λ} = ∏_{i<j} (λᵢ - λⱼ + j - i) / (j - i)`. Both sides were already on `main` — the pattern count with its branching recursion in `GelfandTsetlin/Count.lean`, the product formula in `WeylDimension.lean` — and this PR shows they agree, so the two candidate dimensions for the irreducible rational representation of `GL n` of highest weight `λ` are the same natural number. Neither the representation nor the Gelfand-Tsetlin basis is used: this is an identity between a lattice-point count and a product formula.

The named target is the "Gelfand-Tsetlin dimension formula" milestone of Layer 6 of `RepresentationTheory/ClassicalGroups/README.md`, pinned in that roadmap's `Suggested.lean` as `card_gtPatterns_eq_weylDimension`. The roadmap asks for the count to be proved from the branching side and then compared with `weylDimension`; the comparison is what lands here. `GelfandTsetlin/Count.lean` already states in its module docstring that iterating its recursion "is how the Gelfand-Tsetlin dimension formula is meant to be proved". After this PR the milestone still needs its representation-theoretic half: the `GL n ↓ GL (n-1)` branching rule itself, and the basis `gtBasis` indexed by patterns, neither of which is expressible before the Layer 3 highest-weight classification of `GL n`-irreducibles exists.

The proof is the branching recursion. Deleting the top row of a pattern gives `GTPattern.card_topRow_succ`, which counts the patterns over `λ` by the patterns over each interlacing `μ`, so it suffices that the Weyl dimension satisfies the same recursion `∑_{μ ≺ λ} dim V_μ = dim V_λ`. In the shifted coordinates `xₖ = k - λₖ`, which turn a weakly decreasing sequence into a weakly increasing one, the Weyl numerator is the Vandermonde determinant of `x` and the interlacing condition becomes a box of nested intervals `xᵢ ≤ yᵢ ≤ xᵢ₊₁ - 1`. (The existing `weylDimensionNumerator_eq_det_vandermonde` reverses the index rather than negating it; that reindexing does not carry interlacing to such a box, which is why the negated form is used instead.)

That reduces the recursion to a general identity about integer Vandermonde determinants, proved in the new `TauCeti/LinearAlgebra/Vandermonde.lean` and stated there with no reference to weights: for integers `x₀ ≤ ⋯ ≤ xₙ`, summing `det (vandermonde y)` over the box gives `det (vandermonde x) / n !`. Its proof changes basis to the falling factorials — monic of degree `j`, so Mathlib's `Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde` applies, and unlike the powers they have a closed-form discrete antiderivative — expands the box sum by multilinearity of the determinant in the rows, clears the denominators `1, …, n` by a column scaling, and identifies the resulting matrix of differences as a row reduction of the `(n+1) × (n+1)` matrix with its constant first column deleted.

The `GL 3` acceptance example of the roadmap is recorded as `weylDimension_two_one_zero`: the weight `(2, 1, 0)` has Weyl dimension `8`, read off the eight patterns over that top row rather than by evaluating the product.

Nothing was vendored or adapted from an existing formalization; the mathematics follows Fulton and Harris, *Representation Theory: A First Course*, §15.3 and Exercise 15.4, cited in both files.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"card-gtpatterns-eq-weyldimension"}-->

🤖 Prepared with Claude Code
