### PR TITLE
feat: Schur-Weyl duality, the image-level double centralizer

### DIFF
--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/SchurWeyl.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/SchurWeyl.lean
@@ -10,7 +10,7 @@ public import TauCeti.RepresentationTheory.Symmetric.TensorAction.Centralizer
 public import TauCeti.RingTheory.Semisimple.DoubleCentralizer
 
 /-!
-# Schur-Weyl duality: the two image algebras are each other's commutants
+# Schur-Weyl duality: the symmetric-group image and the diagonal span are mutual commutants
 
 The symmetric group `S_d` acts on `(kⁿ)^{⊗d}` by permuting the tensor factors, the diagonal
 operators `f^{⊗d}` act by applying one endomorphism of `kⁿ` in every factor, and the two actions
@@ -38,9 +38,15 @@ The distinction between `k[S_d]` and its image is not cosmetic: the algebra map
 the *image* of `k[S_d]` and not `k[S_d]` itself. The statements below are accordingly about
 `AlgHom.range`.
 
-The general linear group enters through the span of the diagonal operators `f^{⊗d}` taken over
-*all* `f : kⁿ →ₗ[k] kⁿ`, matching the half already proved; that this span is also the span of the
-`g^{⊗d}` over the invertible `g` alone is a separate statement, not proved here.
+## What is not proved here
+
+Every statement below takes the span of the diagonal operators `f^{⊗d}` over *all*
+`f : kⁿ →ₗ[k] kⁿ`, matching the half already proved. The general linear group acts through the
+subfamily of `g^{⊗d}` with `g` invertible, so the image of `k[GLₙ]` is contained in this span, but
+the reverse inclusion -- that the invertible `g^{⊗d}` already span everything -- is a separate
+statement and is not proved here. Nothing below is therefore a statement about the image of
+`k[GLₙ]`, and the mutual-commutant results are between the symmetric-group image and the span of
+*all* diagonal operators.
 
 ## Main results
 
@@ -58,7 +64,8 @@ The general linear group enters through the span of the diagonal operators `f^{�
 ## References
 
 * [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
-  Layer 8, "The double centralizer (image-level)".
+  Layer 8, "The double centralizer (image-level)", of which this file proves the form with all
+  diagonal operators in place of the image of `k[GLₙ]`.
 * W. Fulton and J. Harris, *Representation Theory: A First Course*, Lecture 6 and Appendix B.1.
 * C. Procesi, *Lie Groups: An Approach through Invariants and Representations*, Chapter 9.
 -/
@@ -133,11 +140,14 @@ section Field
 variable {k : Type*} {n d : ℕ} [Field k] [NeZero (d ! : k)]
 
 /-- **Schur-Weyl duality.** Over a field in which `d !` is nonzero, the commutant of the diagonal
-operators `f^{⊗d}` on `(kⁿ)^{⊗d}`, through which the general linear group acts, is exactly the
-image of the group algebra `k[S_d]` acting by permuting the tensor factors.
+operators `f^{⊗d}` on `(kⁿ)^{⊗d}`, taken over all endomorphisms `f` of `kⁿ`, is exactly the image
+of the group algebra `k[S_d]` acting by permuting the tensor factors.
 
 Together with `TauCeti.coe_centralizer_range_permTensorActionAlgHom`, which computes the commutant
-in the other direction, this says that the two image algebras are each other's commutants. -/
+in the other direction, this says that the symmetric-group image and the span of the diagonal
+operators are each other's commutants. The general linear group acts through the invertible
+`g^{⊗d}`, which are among the `f^{⊗d}`; that they span the same subalgebra, and hence that the
+commutant here is the commutant of the image of `k[GLₙ]`, is not proved here. -/
 theorem centralizer_span_range_map_const_eq_range_permTensorActionAlgHom :
     Subalgebra.centralizer k
         (Submodule.span k (Set.range fun f : (Fin n → k) →ₗ[k] (Fin n → k) =>

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/SchurWeyl.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/SchurWeyl.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.RepresentationTheory.Maschke
+public import TauCeti.RepresentationTheory.Symmetric.TensorAction.Centralizer
+public import TauCeti.RingTheory.Semisimple.DoubleCentralizer
+
+/-!
+# Schur-Weyl duality: the two image algebras are each other's commutants
+
+The symmetric group `S_d` acts on `(kⁿ)^{⊗d}` by permuting the tensor factors, the diagonal
+operators `f^{⊗d}` act by applying one endomorphism of `kⁿ` in every factor, and the two actions
+commute (`PiTensorProduct.commute_reindexRepresentation_map`). **Schur-Weyl duality** says that
+inside `End_k ((kⁿ)^{⊗d})` the two spans are *exactly* each other's commutants.
+
+One half is already available:
+`TauCeti.mem_span_range_map_const_iff_forall_commute_permTensorAction` says that the commutant of
+the symmetric-group action is the span of the diagonal operators, and it needs only that `d !` is
+invertible. This file records that half as an identity of centralizers
+(`TauCeti.coe_centralizer_range_permTensorActionAlgHom`) and proves the other half, which needs
+semisimplicity: over a field in which `d !` is nonzero, an endomorphism commuting with every
+diagonal operator already lies in the image of the group algebra `k[S_d]`.
+
+## The argument
+
+The image `A` of `k[S_d]` in `End_k ((kⁿ)^{⊗d})` is a quotient of `k[S_d]`, which is semisimple by
+Maschke's theorem, so the double centralizer theorem `TauCeti.centralizer_centralizer_range`
+applies and gives `A'' = A`. The commutant `A'` is the span of the diagonal operators by the half
+already available, so `A` is the commutant of that span.
+
+The distinction between `k[S_d]` and its image is not cosmetic: the algebra map
+`k[S_d] → End_k ((kⁿ)^{⊗d})` is injective only when `d ≤ n`
+(`TauCeti.permTensorActionAlgHom_injective_iff`), so the commutant of the diagonal operators is
+the *image* of `k[S_d]` and not `k[S_d]` itself. The statements below are accordingly about
+`AlgHom.range`.
+
+The general linear group enters through the span of the diagonal operators `f^{⊗d}` taken over
+*all* `f : kⁿ →ₗ[k] kⁿ`, matching the half already proved; that this span is also the span of the
+`g^{⊗d}` over the invertible `g` alone is a separate statement, not proved here.
+
+## Main results
+
+* `TauCeti.commute_permTensorActionAlgHom_of_forall_commute` and
+  `TauCeti.commute_of_mem_span_range_map_const`: commuting with the permutations, respectively
+  with the diagonal operators, propagates to the span each of them generates.
+* `TauCeti.coe_centralizer_range_permTensorActionAlgHom`: the commutant of the symmetric-group
+  image is the span of the diagonal operators.
+* `TauCeti.centralizer_span_range_map_const_eq_range_permTensorActionAlgHom`: **the commutant of
+  the diagonal operators is the symmetric-group image**, the half that needs semisimplicity.
+* `TauCeti.mem_range_permTensorActionAlgHom_iff_forall_commute`: the same statement as a
+  membership criterion, `x` acting as an element of `k[S_d]` exactly when it commutes with every
+  diagonal operator.
+
+## References
+
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 8, "The double centralizer (image-level)".
+* W. Fulton and J. Harris, *Representation Theory: A First Course*, Lecture 6 and Appendix B.1.
+* C. Procesi, *Lie Groups: An Approach through Invariants and Representations*, Chapter 9.
+-/
+
+public section
+
+open scoped Nat TensorProduct
+
+open PiTensorProduct
+
+namespace TauCeti
+
+section CommSemiring
+
+variable {R : Type*} {n d : ℕ} [CommSemiring R]
+
+/-- An endomorphism of `(Rⁿ)^{⊗d}` commuting with every factor permutation commutes with the whole
+image of the group algebra `R[S_d]`, the group algebra being spanned by the permutations. -/
+theorem commute_permTensorActionAlgHom_of_forall_commute
+    {y : Module.End R (⨂[R] _ : Fin d, Fin n → R)}
+    (hy : ∀ σ : Equiv.Perm (Fin d), Commute y (permTensorAction R n d σ))
+    (a : MonoidAlgebra R (Equiv.Perm (Fin d))) :
+    Commute y (permTensorActionAlgHom R n d a) := by
+  induction a using MonoidAlgebra.induction_on with
+  | of σ => rw [permTensorActionAlgHom_of]; exact hy σ
+  | add a b ha hb => rw [map_add]; exact ha.add_right hb
+  | smul r a ha => rw [map_smul]; exact ha.smul_right r
+
+/-- An endomorphism of `(Rⁿ)^{⊗d}` commuting with every diagonal operator `f^{⊗d}` commutes with
+every `R`-linear combination of them. -/
+theorem commute_of_mem_span_range_map_const
+    {y z : Module.End R (⨂[R] _ : Fin d, Fin n → R)}
+    (hy : ∀ f : (Fin n → R) →ₗ[R] (Fin n → R), Commute y (map fun _ : Fin d => f))
+    (hz : z ∈ Submodule.span R
+      (Set.range fun f : (Fin n → R) →ₗ[R] (Fin n → R) => map fun _ : Fin d => f)) :
+    Commute y z := by
+  induction hz using Submodule.span_induction with
+  | mem z hz => obtain ⟨f, rfl⟩ := hz; exact hy f
+  | zero => exact Commute.zero_right y
+  | add a b _ _ ha hb => exact ha.add_right hb
+  | smul r a _ ha => exact ha.smul_right r
+
+end CommSemiring
+
+section CommRing
+
+variable {R : Type*} {n d : ℕ} [CommRing R]
+
+/-- **The commutant of the symmetric-group image is the span of the diagonal operators.** This is
+`TauCeti.mem_span_range_map_const_iff_forall_commute_permTensorAction` read as an identity of
+centralizers rather than as a membership criterion: passing from the permutations to the group
+algebra they span does not change the commutant. -/
+theorem coe_centralizer_range_permTensorActionAlgHom (h : IsUnit (d ! : R)) :
+    (Subalgebra.centralizer R
+        ((permTensorActionAlgHom R n d).range : Set (Module.End R (⨂[R] _ : Fin d, Fin n → R))) :
+        Set (Module.End R (⨂[R] _ : Fin d, Fin n → R))) =
+      (Submodule.span R (Set.range fun f : (Fin n → R) →ₗ[R] (Fin n → R) =>
+        map fun _ : Fin d => f) : Set (Module.End R (⨂[R] _ : Fin d, Fin n → R))) := by
+  ext y
+  rw [SetLike.mem_coe, SetLike.mem_coe,
+    mem_span_range_map_const_iff_forall_commute_permTensorAction h,
+    Subalgebra.mem_centralizer_iff]
+  refine ⟨fun hy σ => (hy _ ⟨MonoidAlgebra.of R _ σ, permTensorActionAlgHom_of R n d σ⟩).symm,
+    fun hy g hg => ?_⟩
+  obtain ⟨a, rfl⟩ := hg
+  exact (commute_permTensorActionAlgHom_of_forall_commute hy a).symm
+
+end CommRing
+
+section Field
+
+variable {k : Type*} {n d : ℕ} [Field k] [NeZero (d ! : k)]
+
+/-- **Schur-Weyl duality.** Over a field in which `d !` is nonzero, the commutant of the diagonal
+operators `f^{⊗d}` on `(kⁿ)^{⊗d}`, through which the general linear group acts, is exactly the
+image of the group algebra `k[S_d]` acting by permuting the tensor factors.
+
+Together with `TauCeti.coe_centralizer_range_permTensorActionAlgHom`, which computes the commutant
+in the other direction, this says that the two image algebras are each other's commutants. -/
+theorem centralizer_span_range_map_const_eq_range_permTensorActionAlgHom :
+    Subalgebra.centralizer k
+        (Submodule.span k (Set.range fun f : (Fin n → k) →ₗ[k] (Fin n → k) =>
+          map fun _ : Fin d => f) : Set (Module.End k (⨂[k] _ : Fin d, Fin n → k))) =
+      (permTensorActionAlgHom k n d).range := by
+  -- Maschke's theorem, for the group `S_d` of order `d !`.
+  have : NeZero (Nat.card (Equiv.Perm (Fin d)) : k) := by
+    rwa [Nat.card_eq_fintype_card, Fintype.card_perm, Fintype.card_fin]
+  rw [← coe_centralizer_range_permTensorActionAlgHom (isUnit_iff_ne_zero.2 (NeZero.ne _))]
+  exact centralizer_centralizer_range (permTensorActionAlgHom k n d)
+
+/-- **Schur-Weyl duality, as a membership criterion.** An endomorphism of `(kⁿ)^{⊗d}` is the action
+of an element of the group algebra `k[S_d]` exactly when it commutes with every diagonal operator
+`f^{⊗d}`. -/
+theorem mem_range_permTensorActionAlgHom_iff_forall_commute
+    (x : Module.End k (⨂[k] _ : Fin d, Fin n → k)) :
+    x ∈ (permTensorActionAlgHom k n d).range ↔
+      ∀ f : (Fin n → k) →ₗ[k] (Fin n → k), Commute x (map fun _ : Fin d => f) := by
+  rw [← centralizer_span_range_map_const_eq_range_permTensorActionAlgHom,
+    Subalgebra.mem_centralizer_iff]
+  exact ⟨fun hx f => (hx _ (Submodule.subset_span ⟨f, rfl⟩)).symm,
+    fun hx g hg => (commute_of_mem_span_range_map_const hx hg).symm⟩
+
+end Field
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/SchurWeyl.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/SchurWeyl.lean
@@ -21,9 +21,9 @@ One half is already available:
 `TauCeti.mem_span_range_map_const_iff_forall_commute_permTensorAction` says that the commutant of
 the symmetric-group action is the span of the diagonal operators, and it needs only that `d !` is
 invertible. This file records that half as an identity of centralizers
-(`TauCeti.coe_centralizer_range_permTensorActionAlgHom`) and proves the other half, which needs
-semisimplicity: over a field in which `d !` is nonzero, an endomorphism commuting with every
-diagonal operator already lies in the image of the group algebra `k[S_d]`.
+(`TauCeti.coe_centralizer_range_permTensorActionAlgHom_eq_span_range_map_const`) and proves the
+other half, which needs semisimplicity: over a field in which `d !` is nonzero, an endomorphism
+commuting with every diagonal operator already lies in the image of the group algebra `k[S_d]`.
 
 ## The argument
 
@@ -50,11 +50,12 @@ statement and is not proved here. Nothing below is therefore a statement about t
 
 ## Main results
 
-* `TauCeti.commute_permTensorActionAlgHom_of_forall_commute` and
-  `TauCeti.commute_of_mem_span_range_map_const`: commuting with the permutations, respectively
-  with the diagonal operators, propagates to the span each of them generates.
-* `TauCeti.coe_centralizer_range_permTensorActionAlgHom`: the commutant of the symmetric-group
-  image is the span of the diagonal operators.
+* `TauCeti.commute_permTensorActionAlgHom_of_forall_commute`: commuting with every factor
+  permutation propagates to the whole image of the group algebra the permutations span. (In the
+  other direction, commuting with every diagonal operator propagates to their span by Mathlib's
+  `Commute.span_right`.)
+* `TauCeti.coe_centralizer_range_permTensorActionAlgHom_eq_span_range_map_const`: the commutant of
+  the symmetric-group image is the span of the diagonal operators.
 * `TauCeti.centralizer_span_range_map_const_eq_range_permTensorActionAlgHom`: **the commutant of
   the diagonal operators is the symmetric-group image**, the half that needs semisimplicity.
 * `TauCeti.mem_range_permTensorActionAlgHom_iff_forall_commute`: the same statement as a
@@ -94,20 +95,6 @@ theorem commute_permTensorActionAlgHom_of_forall_commute
   | add a b ha hb => rw [map_add]; exact ha.add_right hb
   | smul r a ha => rw [map_smul]; exact ha.smul_right r
 
-/-- An endomorphism of `(Rⁿ)^{⊗d}` commuting with every diagonal operator `f^{⊗d}` commutes with
-every `R`-linear combination of them. -/
-theorem commute_of_mem_span_range_map_const
-    {y z : Module.End R (⨂[R] _ : Fin d, Fin n → R)}
-    (hy : ∀ f : (Fin n → R) →ₗ[R] (Fin n → R), Commute y (map fun _ : Fin d => f))
-    (hz : z ∈ Submodule.span R
-      (Set.range fun f : (Fin n → R) →ₗ[R] (Fin n → R) => map fun _ : Fin d => f)) :
-    Commute y z := by
-  induction hz using Submodule.span_induction with
-  | mem z hz => obtain ⟨f, rfl⟩ := hz; exact hy f
-  | zero => exact Commute.zero_right y
-  | add a b _ _ ha hb => exact ha.add_right hb
-  | smul r a _ ha => exact ha.smul_right r
-
 end CommSemiring
 
 section CommRing
@@ -118,7 +105,8 @@ variable {R : Type*} {n d : ℕ} [CommRing R]
 `TauCeti.mem_span_range_map_const_iff_forall_commute_permTensorAction` read as an identity of
 centralizers rather than as a membership criterion: passing from the permutations to the group
 algebra they span does not change the commutant. -/
-theorem coe_centralizer_range_permTensorActionAlgHom (h : IsUnit (d ! : R)) :
+theorem coe_centralizer_range_permTensorActionAlgHom_eq_span_range_map_const
+    (h : IsUnit (d ! : R)) :
     (Subalgebra.centralizer R
         ((permTensorActionAlgHom R n d).range : Set (Module.End R (⨂[R] _ : Fin d, Fin n → R))) :
         Set (Module.End R (⨂[R] _ : Fin d, Fin n → R))) =
@@ -143,11 +131,11 @@ variable {k : Type*} {n d : ℕ} [Field k] [NeZero (d ! : k)]
 operators `f^{⊗d}` on `(kⁿ)^{⊗d}`, taken over all endomorphisms `f` of `kⁿ`, is exactly the image
 of the group algebra `k[S_d]` acting by permuting the tensor factors.
 
-Together with `TauCeti.coe_centralizer_range_permTensorActionAlgHom`, which computes the commutant
-in the other direction, this says that the symmetric-group image and the span of the diagonal
-operators are each other's commutants. The general linear group acts through the invertible
-`g^{⊗d}`, which are among the `f^{⊗d}`; that they span the same subalgebra, and hence that the
-commutant here is the commutant of the image of `k[GLₙ]`, is not proved here. -/
+Together with `TauCeti.coe_centralizer_range_permTensorActionAlgHom_eq_span_range_map_const`, which
+computes the commutant in the other direction, this says that the symmetric-group image and the
+span of the diagonal operators are each other's commutants. The general linear group acts through
+the invertible `g^{⊗d}`, which are among the `f^{⊗d}`; that they span the same subalgebra, and
+hence that the commutant here is the commutant of the image of `k[GLₙ]`, is not proved here. -/
 @[simp]
 theorem centralizer_span_range_map_const_eq_range_permTensorActionAlgHom :
     Subalgebra.centralizer k
@@ -157,7 +145,8 @@ theorem centralizer_span_range_map_const_eq_range_permTensorActionAlgHom :
   -- Maschke's theorem, for the group `S_d` of order `d !`.
   have : NeZero (Nat.card (Equiv.Perm (Fin d)) : k) := by
     rwa [Nat.card_eq_fintype_card, Fintype.card_perm, Fintype.card_fin]
-  rw [← coe_centralizer_range_permTensorActionAlgHom (isUnit_iff_ne_zero.2 (NeZero.ne _))]
+  rw [← coe_centralizer_range_permTensorActionAlgHom_eq_span_range_map_const
+    (isUnit_iff_ne_zero.2 (NeZero.ne _))]
   exact centralizer_centralizer_range (permTensorActionAlgHom k n d)
 
 /-- **Schur-Weyl duality, as a membership criterion.** An endomorphism of `(kⁿ)^{⊗d}` is the action
@@ -169,8 +158,11 @@ theorem mem_range_permTensorActionAlgHom_iff_forall_commute
       ∀ f : (Fin n → k) →ₗ[k] (Fin n → k), Commute x (map fun _ : Fin d => f) := by
   rw [← centralizer_span_range_map_const_eq_range_permTensorActionAlgHom,
     Subalgebra.mem_centralizer_iff]
-  exact ⟨fun hx f => (hx _ (Submodule.subset_span ⟨f, rfl⟩)).symm,
-    fun hx g hg => (commute_of_mem_span_range_map_const hx hg).symm⟩
+  refine ⟨fun hx f => (hx _ (Submodule.subset_span ⟨f, rfl⟩)).symm, fun hx g hg => ?_⟩
+  -- Commuting with every diagonal operator propagates to their span.
+  refine (Commute.span_right ?_ g hg).symm
+  rintro _ ⟨f, rfl⟩
+  exact hx f
 
 end Field
 

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/SchurWeyl.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/SchurWeyl.lean
@@ -148,6 +148,7 @@ in the other direction, this says that the symmetric-group image and the span of
 operators are each other's commutants. The general linear group acts through the invertible
 `g^{⊗d}`, which are among the `f^{⊗d}`; that they span the same subalgebra, and hence that the
 commutant here is the commutant of the image of `k[GLₙ]`, is not proved here. -/
+@[simp]
 theorem centralizer_span_range_map_const_eq_range_permTensorActionAlgHom :
     Subalgebra.centralizer k
         (Submodule.span k (Set.range fun f : (Fin n → k) →ₗ[k] (Fin n → k) =>

--- a/TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean
+++ b/TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean
@@ -288,9 +288,14 @@ theorem centralizer_centralizer_of_isSemisimpleModule [Module.Finite K N]
     { toFun := x
       map_add' := x.map_add
       map_smul' := fun g m => by
+        -- Evaluating the commutation of `x` with `g.restrictScalars K` at `m` gives
+        -- `x (g m) = g (x m)`, which is the required `A'`-linearity once the scalar action of
+        -- `Module.End ↥A N` on `N` is `Module.End.smul_def` and the restriction of scalars is
+        -- `LinearMap.coe_restrictScalars`.
         have h := congrArg (fun t : Module.End K N => t m)
           (hx _ (restrictScalars_mem_centralizer A g))
-        simpa using h.symm }
+        simpa only [Module.End.smul_def, RingHom.id_apply, Module.End.mul_apply,
+          LinearMap.coe_restrictScalars] using h.symm }
   obtain ⟨a, ha⟩ := Module.Finite.toModuleEnd_moduleEnd_surjective (R := A) (M := N) f
   have hx' : x = (a : Module.End K N) := by
     ext m

--- a/TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean
+++ b/TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean
@@ -52,8 +52,8 @@ implies the other.
 * `TauCeti.algEquivEndEndOfIsSimpleRing`: the finite-dimensional-algebra form, where the finiteness
   hypothesis is supplied by finiteness over a commutative base ring acting compatibly.
 * `TauCeti.centralizer_centralizer_of_isSemisimpleModule`: the **subalgebra form**. A subalgebra
-  `A` of `Module.End K N` over which `N` is semisimple, `N` finite over `K`, is its own double
-  centralizer inside `Module.End K N`.
+  `A` of `Module.End K N` over which `N` is semisimple, `N` finite over `Module.End A N`, is its
+  own double centralizer inside `Module.End K N`.
 * `TauCeti.centralizer_centralizer_range`: the same statement for the image of a semisimple
   algebra, the form a representation supplies. The image, not the algebra itself, is what the
   double centralizer returns, since the representation need not be faithful.
@@ -268,21 +268,23 @@ private theorem restrictScalars_mem_centralizer (g : Module.End A N) :
   exact (g.map_smul ⟨a, ha⟩ m).symm
 
 /-- **The double centralizer theorem inside an endomorphism algebra.** Let `A` be a `K`-subalgebra
-of `Module.End K N` for a finite `K`-module `N`, and suppose `N` is semisimple as an `A`-module.
-Then `A` is its own double centralizer: an endomorphism commuting with everything that commutes
-with `A` already lies in `A`.
+of `Module.End K N`, and suppose `N` is semisimple as an `A`-module and finite over
+`Module.End A N`. Then `A` is its own double centralizer: an endomorphism commuting with everything
+that commutes with `A` already lies in `A`.
 
 The inclusion `A ≤ A''` is formal (`Subalgebra.le_centralizer_centralizer`); the content is the
 reverse one, which is Jacobson density. The centralizer `A'` is the ring of `A`-linear
 endomorphisms of `N`, so an element of `A''` is an `A'`-linear endomorphism, and density writes
-every such endomorphism as the action of an element of `A`. -/
-theorem centralizer_centralizer_of_isSemisimpleModule [Module.Finite K N]
+every such endomorphism as the action of an element of `A`.
+
+Finiteness is over `Module.End A N`, the hypothesis density actually needs; a caller with a finite
+`K`-module `N` gets it from `TauCeti.finite_end_of_smulCommClass`. -/
+theorem centralizer_centralizer_of_isSemisimpleModule [Module.Finite (Module.End A N) N]
     [IsSemisimpleModule A N] :
     Subalgebra.centralizer K
         (Subalgebra.centralizer K (A : Set (Module.End K N)) : Set (Module.End K N)) = A := by
   refine le_antisymm (fun x hx => ?_) (Subalgebra.le_centralizer_centralizer K)
   rw [Subalgebra.mem_centralizer_iff] at hx
-  have hfin : Module.Finite (Module.End A N) N := finite_end_of_smulCommClass (R := A) K
   -- `x` commutes with every `A`-linear endomorphism, so it is `A'`-linear.
   let f : Module.End (Module.End A N) N :=
     { toFun := x
@@ -307,8 +309,9 @@ semisimple `K`-algebra `S` in `Module.End K N`, for a finite `K`-module `N`, is 
 centralizer.
 
 The image is a quotient of `S`, hence semisimple, so `N` is a semisimple module over it and
-`TauCeti.centralizer_centralizer_of_isSemisimpleModule` applies. It is the image and not `S` that
-is recovered: the representation `S → Module.End K N` need not be injective. -/
+`TauCeti.centralizer_centralizer_of_isSemisimpleModule` applies, its finiteness hypothesis coming
+from `TauCeti.finite_end_of_smulCommClass`. It is the image and not `S` that is recovered: the
+representation `S → Module.End K N` need not be injective. -/
 theorem centralizer_centralizer_range [Module.Finite K N] {S : Type*} [Ring S] [Algebra K S]
     [IsSemisimpleRing S] (ρ : S →ₐ[K] Module.End K N) :
     Subalgebra.centralizer K
@@ -318,6 +321,7 @@ theorem centralizer_centralizer_range [Module.Finite K N] {S : Type*} [Ring S] [
     RingHom.isSemisimpleRing_of_surjective ρ.rangeRestrict.toRingHom
       (AlgHom.rangeRestrict_surjective _)
   have : IsSemisimpleModule ρ.range N := IsSemisimpleRing.isSemisimpleModule
+  have : Module.Finite (Module.End ρ.range N) N := finite_end_of_smulCommClass (R := ρ.range) K
   exact centralizer_centralizer_of_isSemisimpleModule _
 
 end EndSubalgebra

--- a/TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean
+++ b/TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import Mathlib.Algebra.Algebra.Subalgebra.Basic
 public import Mathlib.LinearAlgebra.Basis.VectorSpace
 public import Mathlib.RingTheory.SimpleModule.Basic
 public import Mathlib.RingTheory.SimpleRing.Basic
@@ -24,6 +25,16 @@ two-sided ideal not containing `1`. So over a simple ring every simple module fi
 gives `R ≃+* Module.End D M`, which is the Wedderburn presentation of a simple ring in
 module-internal form -- no ambient base field is involved, only finiteness over `D`.
 
+The last section restates the theorem in the form a representation uses: for a subalgebra `A` of
+`Module.End K N` over which `N` is semisimple, the double centralizer of `A` *inside*
+`Module.End K N` is `A` itself. Here faithfulness is automatic, `A` being a set of endomorphisms,
+so only Mathlib's surjectivity is needed; the centralizer `A'` is the ring of `A`-linear
+endomorphisms of `N`, and an element of `A''` is exactly an `A'`-linear endomorphism. This is a
+different theorem from `TauCeti.centralizer_centralizer` of
+`TauCeti/Algebra/CentralSimple/Centralizer.lean`, which computes the double centralizer of a
+*central simple* subalgebra of a central simple algebra by a dimension count; neither hypothesis
+implies the other.
+
 ## Main results
 
 * `TauCeti.faithfulSMul_of_isSimpleRing`: a nontrivial module over a simple ring is faithful.
@@ -40,6 +51,12 @@ module-internal form -- no ambient base field is involved, only finiteness over 
   finiteness hypothesis density needs.
 * `TauCeti.algEquivEndEndOfIsSimpleRing`: the finite-dimensional-algebra form, where the finiteness
   hypothesis is supplied by finiteness over a commutative base ring acting compatibly.
+* `TauCeti.centralizer_centralizer_of_isSemisimpleModule`: the **subalgebra form**. A subalgebra
+  `A` of `Module.End K N` over which `N` is semisimple, `N` finite over `K`, is its own double
+  centralizer inside `Module.End K N`.
+* `TauCeti.centralizer_centralizer_range`: the same statement for the image of a semisimple
+  algebra, the form a representation supplies. The image, not the algebra itself, is what the
+  double centralizer returns, since the representation need not be faithful.
 
 ## Implementation notes
 
@@ -61,8 +78,11 @@ roadmap calls the same statement `toModuleEnd_bijective`.
 
 This implements the Layer 3 target `toModuleEnd_bijective` of the
 [semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md),
-together with its Jacobson-Chevalley corollary. See T. Y. Lam, *A First Course in Noncommutative
-Rings*, GTM 131, Chapter 4, and N. Jacobson, *Basic Algebra II*, Chapter 4.
+together with its Jacobson-Chevalley corollary. The subalgebra form is what Layer 8 of the
+[Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md)
+calls "a case of the double-centralizer theorem for the semisimple algebra `ℂ[Sₙ]`". See T. Y. Lam,
+*A First Course in Noncommutative Rings*, GTM 131, Chapter 4, and N. Jacobson, *Basic Algebra II*,
+Chapter 4.
 -/
 
 public section
@@ -231,5 +251,70 @@ theorem algEquivEndEndOfIsSimpleRing_symm_smul (K : Type*) [CommSemiring K] [Alg
     (algEquivEndEndOfIsSimpleRing R M K).symm f • m = f m := by
   rw [← algEquivEndEndOfIsSimpleRing_apply K ((algEquivEndEndOfIsSimpleRing R M K).symm f) m,
     AlgEquiv.apply_symm_apply]
+
+/-! ### The double centralizer of a subalgebra of an endomorphism algebra -/
+
+section EndSubalgebra
+
+variable {K : Type*} [CommRing K] {N : Type*} [AddCommGroup N] [Module K N]
+  (A : Subalgebra K (Module.End K N))
+
+/-- An `A`-linear endomorphism of `N`, for `A` a `K`-subalgebra of `Module.End K N`, commutes with
+every element of `A`, so its restriction of scalars lies in the centralizer of `A`. -/
+private theorem restrictScalars_mem_centralizer (g : Module.End A N) :
+    g.restrictScalars K ∈ Subalgebra.centralizer K (A : Set (Module.End K N)) := by
+  refine (Subalgebra.mem_centralizer_iff K).2 fun a ha => ?_
+  ext m
+  exact (g.map_smul ⟨a, ha⟩ m).symm
+
+/-- **The double centralizer theorem inside an endomorphism algebra.** Let `A` be a `K`-subalgebra
+of `Module.End K N` for a finite `K`-module `N`, and suppose `N` is semisimple as an `A`-module.
+Then `A` is its own double centralizer: an endomorphism commuting with everything that commutes
+with `A` already lies in `A`.
+
+The inclusion `A ≤ A''` is formal (`Subalgebra.le_centralizer_centralizer`); the content is the
+reverse one, which is Jacobson density. The centralizer `A'` is the ring of `A`-linear
+endomorphisms of `N`, so an element of `A''` is an `A'`-linear endomorphism, and density writes
+every such endomorphism as the action of an element of `A`. -/
+theorem centralizer_centralizer_of_isSemisimpleModule [Module.Finite K N]
+    [IsSemisimpleModule A N] :
+    Subalgebra.centralizer K
+        (Subalgebra.centralizer K (A : Set (Module.End K N)) : Set (Module.End K N)) = A := by
+  refine le_antisymm (fun x hx => ?_) (Subalgebra.le_centralizer_centralizer K)
+  rw [Subalgebra.mem_centralizer_iff] at hx
+  have hfin : Module.Finite (Module.End A N) N := finite_end_of_smulCommClass (R := A) K
+  -- `x` commutes with every `A`-linear endomorphism, so it is `A'`-linear.
+  let f : Module.End (Module.End A N) N :=
+    { toFun := x
+      map_add' := x.map_add
+      map_smul' := fun g m => by
+        have h := congrArg (fun t : Module.End K N => t m)
+          (hx _ (restrictScalars_mem_centralizer A g))
+        simpa using h.symm }
+  obtain ⟨a, ha⟩ := Module.Finite.toModuleEnd_moduleEnd_surjective (R := A) (M := N) f
+  have hx' : x = (a : Module.End K N) := by
+    ext m
+    exact (congrArg (fun t : Module.End (Module.End A N) N => t m) ha).symm
+  exact hx' ▸ a.2
+
+/-- **The double centralizer theorem for the image of a semisimple algebra.** The image of a
+semisimple `K`-algebra `S` in `Module.End K N`, for a finite `K`-module `N`, is its own double
+centralizer.
+
+The image is a quotient of `S`, hence semisimple, so `N` is a semisimple module over it and
+`TauCeti.centralizer_centralizer_of_isSemisimpleModule` applies. It is the image and not `S` that
+is recovered: the representation `S → Module.End K N` need not be injective. -/
+theorem centralizer_centralizer_range [Module.Finite K N] {S : Type*} [Ring S] [Algebra K S]
+    [IsSemisimpleRing S] (ρ : S →ₐ[K] Module.End K N) :
+    Subalgebra.centralizer K
+        (Subalgebra.centralizer K (ρ.range : Set (Module.End K N)) : Set (Module.End K N)) =
+      ρ.range := by
+  have : IsSemisimpleRing ρ.range :=
+    RingHom.isSemisimpleRing_of_surjective ρ.rangeRestrict.toRingHom
+      (AlgHom.rangeRestrict_surjective _)
+  have : IsSemisimpleModule ρ.range N := IsSemisimpleRing.isSemisimpleModule
+  exact centralizer_centralizer_of_isSemisimpleModule _
+
+end EndSubalgebra
 
 end TauCeti


### PR DESCRIPTION
This PR proves the second half of Schur-Weyl duality: on the tensor power `(kⁿ)^{⊗d}` over a field in which `d !` is nonzero, the commutant of the diagonal operators `f^{⊗d}`, taken over *all* endomorphisms `f` of `kⁿ`, is exactly the image of the group algebra `k[S_d]` acting by permuting the tensor factors (`TauCeti.centralizer_span_range_map_const_eq_range_permTensorActionAlgHom`, with the membership form `TauCeti.mem_range_permTensorActionAlgHom_iff_forall_commute`). Together with the already-merged `TauCeti.mem_span_range_map_const_iff_forall_commute_permTensorAction`, recorded here as the identity of centralizers `TauCeti.coe_centralizer_range_permTensorActionAlgHom_eq_span_range_map_const`, the image of `k[S_d]` and the span of the diagonal operators are each other's commutants inside `End_k ((kⁿ)^{⊗d})`.

This is the milestone "The double centralizer (image-level)" in Layer 8, "Schur-Weyl duality", of `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, in the form with all diagonal operators in place of the image of `k[GLₙ]`. The roadmap's statement is that "the image of `ℂ[Sₙ]` and the image of `ℂ[GLₔ]` are each other's centralizers ..., a case of the double-centralizer theorem for the semisimple algebra `ℂ[Sₙ]`"; the general linear group acts through the invertible `g^{⊗d}`, so its image is contained in the span used here, but that the invertible `g^{⊗d}` already span everything is a separate statement, not proved here, and nothing in this PR is therefore a statement about the image of `k[GLₙ]`. The module docstring says so. The already-merged `TensorAction/Centralizer.lean` says in its own module docstring that "the other half, that the commutant of the diagonal operators is the symmetric-group image, is not proved here"; this PR supplies it. The roadmap's separate faithfulness refinement is already on `main` as `TauCeti.permTensorActionAlgHom_injective_iff`, and the roadmap's insistence on *image* subalgebras is exactly why: the map `k[S_d] → End_k ((kⁿ)^{⊗d})` is injective only for `d ≤ n`. What remains for Layer 8 after this PR is the decomposition `(kⁿ)^{⊗d} ≅ ⊕_λ S^λ ⊗ 𝕊^λ(kⁿ)` and the Schur functors, together with that identification of the two spans, which would let the statement be phrased with `k[GLₙ]` in place of `End_k (kⁿ)`.

The prerequisite is the double centralizer theorem in the form a representation supplies it, and it goes in `TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean`, the file that already holds the module-internal form `TauCeti.toModuleEnd_moduleEnd_bijective`. Two statements are added there: `TauCeti.centralizer_centralizer_of_isSemisimpleModule`, that a subalgebra `A` of `Module.End K N` over which `N` is semisimple, with `N` finite over `Module.End A N`, is its own double centralizer inside `Module.End K N`; and `TauCeti.centralizer_centralizer_range`, the same for the image of a semisimple `K`-algebra. Faithfulness, the extra input the bijective form needs, is automatic here because `A` is a set of endomorphisms, so the proof runs on Mathlib's `Module.Finite.toModuleEnd_moduleEnd_surjective` alone: the centralizer `A'` is the ring of `A`-linear endomorphisms of `N`, an element of `A''` is an `A'`-linear endomorphism, and density writes it as the action of an element of `A`. This is a different theorem from `TauCeti.centralizer_centralizer` of `TauCeti/Algebra/CentralSimple/Centralizer.lean`, which computes the double centralizer of a central simple subalgebra of a central simple algebra by a dimension count; neither hypothesis implies the other, and the file docstrings now say so. It is kept in this PR rather than split off because on its own it would have no consumer.

Semisimplicity of `k[S_d]` is Mathlib's Maschke instance, and the spanning lemma `TauCeti.commute_permTensorActionAlgHom_of_forall_commute` says that commuting with every factor permutation propagates to the image of the group algebra they span (in the other direction, Mathlib's `Commute.span_right` does the same for the diagonal operators); it is stated over a commutative semiring, and the centralizer identity over a commutative ring with `d !` invertible, the field and the nonvanishing of `d !` being needed only where Maschke is.

Adds one file, `TauCeti/RepresentationTheory/Symmetric/TensorAction/SchurWeyl.lean` (169 lines), and 96 lines to `TauCeti/RingTheory/Semisimple/DoubleCentralizer.lean`. No Mathlib infrastructure was vendored; Jacobson density, Maschke's theorem and `RingHom.isSemisimpleRing_of_surjective` are consumed from Mathlib. The argument is the standard one of Fulton-Harris, *Representation Theory: A First Course*, Lecture 6 and Appendix B.1, and Procesi, *Lie Groups*, Chapter 9, both cited in the new file.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"schur-weyl-duality-double-centralizer"}-->

🤖 Prepared with Claude Code


