### PR TITLE
feat: add type B simple coroot actions

### DIFF
--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/DiagonalCartan.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/DiagonalCartan.lean
@@ -251,17 +251,6 @@ instance : IsLieAbelian (typeBDiagonalCartan K ι) where
     apply Subtype.ext
     exact lie_eq_zero_of_isDiag (hd ▸ isDiag_diagonal _) (he ▸ isDiag_diagonal _)
 
-/-- Two elements of the split diagonal Cartan commute in the ambient type-`B` Lie algebra. -/
-theorem typeBDiagonalEquiv_lie_diagonalEquiv (d e : ι → K) :
-    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
-        LieAlgebra.Orthogonal.typeB ι K),
-      ((typeBDiagonalEquiv (K := K) (ι := ι) e : typeBDiagonalCartan K ι) :
-        LieAlgebra.Orthogonal.typeB ι K)⁆ = 0 := by
-  have h : ⁅typeBDiagonalEquiv (K := K) (ι := ι) d,
-      typeBDiagonalEquiv (K := K) (ι := ι) e⁆ = 0 :=
-    LieModule.IsTrivial.trivial _ _
-  exact congrArg Subtype.val h
-
 /-! ### Self-normalization -/
 
 section

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/DiagonalCartan.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/DiagonalCartan.lean
@@ -251,6 +251,17 @@ instance : IsLieAbelian (typeBDiagonalCartan K ι) where
     apply Subtype.ext
     exact lie_eq_zero_of_isDiag (hd ▸ isDiag_diagonal _) (he ▸ isDiag_diagonal _)
 
+/-- Two elements of the split diagonal Cartan commute in the ambient type-`B` Lie algebra. -/
+theorem typeBDiagonalEquiv_lie_diagonalEquiv (d e : ι → K) :
+    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
+        LieAlgebra.Orthogonal.typeB ι K),
+      ((typeBDiagonalEquiv (K := K) (ι := ι) e : typeBDiagonalCartan K ι) :
+        LieAlgebra.Orthogonal.typeB ι K)⁆ = 0 := by
+  have h : ⁅typeBDiagonalEquiv (K := K) (ι := ι) d,
+      typeBDiagonalEquiv (K := K) (ι := ι) e⁆ = 0 :=
+    LieModule.IsTrivial.trivial _ _
+  exact congrArg Subtype.val h
+
 /-! ### Self-normalization -/
 
 section

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
@@ -98,42 +98,56 @@ theorem typeBSimpleCorootGenerator_lie_eq_zero (i j : Fin (n + 1)) :
 @[simp]
 theorem typeBSimpleCorootGenerator_lie_root_last (i : Fin (n + 1)) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
-      typeBSimpleRootGenerator (K := K) (Fin.last n)⁆ =
+      typeBShortRootGenerator (K := K) (Fin.last n)⁆ =
         typeBSimpleCorootCoordinate (K := K) i (Fin.last n) •
-          typeBSimpleRootGenerator (K := K) (Fin.last n) := by
-  rw [typeBSimpleCorootGenerator_eq_diagonal, typeBSimpleRootGenerator_last]
-  exact typeBDiagonalEquiv_lie_shortRootGenerator _ _
+          typeBShortRootGenerator (K := K) (Fin.last n) := by
+  rw [typeBSimpleCorootGenerator_eq_diagonal]
+  simpa only [coe_typeBDiagonalEquiv_apply] using
+    (typeBDiagonalEquiv_lie_shortRootGenerator
+      (typeBSimpleCorootCoordinate (K := K) i) (Fin.last n))
 
 /-- The action of a simple coroot on a positive generator at a long node. -/
 @[simp]
 theorem typeBSimpleCorootGenerator_lie_root_castSucc (i : Fin (n + 1)) (j : Fin n) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
-      typeBSimpleRootGenerator (K := K) j.castSucc⁆ =
+      typeBLongRootGenerator (K := K) j.castSucc j.succ
+        (ne_of_lt j.castSucc_lt_succ)⁆ =
         (typeBSimpleCorootCoordinate (K := K) i j.castSucc -
           typeBSimpleCorootCoordinate (K := K) i j.succ) •
-            typeBSimpleRootGenerator (K := K) j.castSucc := by
-  rw [typeBSimpleCorootGenerator_eq_diagonal, typeBSimpleRootGenerator_castSucc]
-  exact typeBDiagonalEquiv_lie_longRootGenerator _ _ _ _
+            typeBLongRootGenerator (K := K) j.castSucc j.succ
+              (ne_of_lt j.castSucc_lt_succ) := by
+  rw [typeBSimpleCorootGenerator_eq_diagonal]
+  simpa only [coe_typeBDiagonalEquiv_apply] using
+    (typeBDiagonalEquiv_lie_longRootGenerator
+      (typeBSimpleCorootCoordinate (K := K) i) j.castSucc j.succ
+        (ne_of_lt j.castSucc_lt_succ))
 
 /-- The action of a simple coroot on the negative generator at the final short node. -/
 @[simp]
 theorem typeBSimpleCorootGenerator_lie_negativeRoot_last (i : Fin (n + 1)) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
-      typeBSimpleNegativeRootGenerator (K := K) (Fin.last n)⁆ =
+      typeBShortNegativeRootGenerator (K := K) (Fin.last n)⁆ =
         -(typeBSimpleCorootCoordinate (K := K) i (Fin.last n)) •
-          typeBSimpleNegativeRootGenerator (K := K) (Fin.last n) := by
-  rw [typeBSimpleCorootGenerator_eq_diagonal, typeBSimpleNegativeRootGenerator_last]
-  exact typeBDiagonalEquiv_lie_shortNegativeRootGenerator _ _
+          typeBShortNegativeRootGenerator (K := K) (Fin.last n) := by
+  rw [typeBSimpleCorootGenerator_eq_diagonal]
+  simpa only [coe_typeBDiagonalEquiv_apply] using
+    (typeBDiagonalEquiv_lie_shortNegativeRootGenerator
+      (typeBSimpleCorootCoordinate (K := K) i) (Fin.last n))
 
 /-- The action of a simple coroot on a negative generator at a long node. -/
 @[simp]
 theorem typeBSimpleCorootGenerator_lie_negativeRoot_castSucc (i : Fin (n + 1)) (j : Fin n) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
-      typeBSimpleNegativeRootGenerator (K := K) j.castSucc⁆ =
+      typeBLongRootGenerator (K := K) j.succ j.castSucc
+        (ne_of_gt j.castSucc_lt_succ)⁆ =
         (typeBSimpleCorootCoordinate (K := K) i j.succ -
           typeBSimpleCorootCoordinate (K := K) i j.castSucc) •
-            typeBSimpleNegativeRootGenerator (K := K) j.castSucc := by
-  rw [typeBSimpleCorootGenerator_eq_diagonal, typeBSimpleNegativeRootGenerator_castSucc]
-  exact typeBDiagonalEquiv_lie_longRootGenerator _ _ _ _
+            typeBLongRootGenerator (K := K) j.succ j.castSucc
+              (ne_of_gt j.castSucc_lt_succ) := by
+  rw [typeBSimpleCorootGenerator_eq_diagonal]
+  simpa only [coe_typeBDiagonalEquiv_apply] using
+    (typeBDiagonalEquiv_lie_longRootGenerator
+      (typeBSimpleCorootCoordinate (K := K) i) j.succ j.castSucc
+        (ne_of_gt j.castSucc_lt_succ))
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
@@ -27,7 +27,7 @@ Cartan matrix, and proving the remaining mixed and higher Serre relations, are s
 
 * `TauCeti.typeBSimpleCorootCoordinate`: the diagonal coordinate of a simple coroot.
 * `TauCeti.typeBSimpleCorootGenerator_eq_diagonal`: the corresponding matrix identity.
-* `TauCeti.typeBSimpleCorootGenerator_lie_coroot`: simple coroots commute.
+* `TauCeti.typeBSimpleCorootGenerator_lie_eq_zero`: simple coroots commute.
 * `TauCeti.typeBSimpleCorootGenerator_lie_root_last` and
   `TauCeti.typeBSimpleCorootGenerator_lie_root_castSucc`: Cartan action on positive generators.
 * `TauCeti.typeBSimpleCorootGenerator_lie_negativeRoot_last` and
@@ -83,13 +83,19 @@ theorem typeBSimpleCorootGenerator_eq_diagonal (i : Fin (n + 1)) :
 
 /-- The simple coroot generators in the standard split type-`B` model commute. -/
 @[simp]
-theorem typeBSimpleCorootGenerator_lie_coroot (i j : Fin (n + 1)) :
+theorem typeBSimpleCorootGenerator_lie_eq_zero (i j : Fin (n + 1)) :
     ⁅typeBSimpleCorootGenerator (K := K) i, typeBSimpleCorootGenerator (K := K) j⁆ = 0 := by
   rw [typeBSimpleCorootGenerator_eq_diagonal,
     typeBSimpleCorootGenerator_eq_diagonal]
-  exact typeBDiagonalEquiv_lie_diagonalEquiv _ _
+  have h : ⁅typeBDiagonalEquiv (K := K) (ι := Fin (n + 1))
+      (typeBSimpleCorootCoordinate i),
+      typeBDiagonalEquiv (K := K) (ι := Fin (n + 1))
+        (typeBSimpleCorootCoordinate j)⁆ = 0 :=
+    LieModule.IsTrivial.trivial _ _
+  exact congrArg Subtype.val h
 
 /-- The action of a simple coroot on the positive generator at the final short node. -/
+@[simp]
 theorem typeBSimpleCorootGenerator_lie_root_last (i : Fin (n + 1)) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
       typeBSimpleRootGenerator (K := K) (Fin.last n)⁆ =
@@ -99,6 +105,7 @@ theorem typeBSimpleCorootGenerator_lie_root_last (i : Fin (n + 1)) :
   exact typeBDiagonalEquiv_lie_shortRootGenerator _ _
 
 /-- The action of a simple coroot on a positive generator at a long node. -/
+@[simp]
 theorem typeBSimpleCorootGenerator_lie_root_castSucc (i : Fin (n + 1)) (j : Fin n) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
       typeBSimpleRootGenerator (K := K) j.castSucc⁆ =
@@ -109,6 +116,7 @@ theorem typeBSimpleCorootGenerator_lie_root_castSucc (i : Fin (n + 1)) (j : Fin 
   exact typeBDiagonalEquiv_lie_longRootGenerator _ _ _ _
 
 /-- The action of a simple coroot on the negative generator at the final short node. -/
+@[simp]
 theorem typeBSimpleCorootGenerator_lie_negativeRoot_last (i : Fin (n + 1)) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
       typeBSimpleNegativeRootGenerator (K := K) (Fin.last n)⁆ =
@@ -118,6 +126,7 @@ theorem typeBSimpleCorootGenerator_lie_negativeRoot_last (i : Fin (n + 1)) :
   exact typeBDiagonalEquiv_lie_shortNegativeRootGenerator _ _
 
 /-- The action of a simple coroot on a negative generator at a long node. -/
+@[simp]
 theorem typeBSimpleCorootGenerator_lie_negativeRoot_castSucc (i : Fin (n + 1)) (j : Fin n) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
       typeBSimpleNegativeRootGenerator (K := K) j.castSucc⁆ =

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.Orthogonal.TypeB.RootGenerators
+
+/-!
+# Cartan action on the split type-B root generators
+
+This file records the coordinates of the Bourbaki simple coroots in the split diagonal Cartan and
+uses them to compute their action on both signs of every simple root. If `dᵢ` is the coordinate
+vector of the `i`th simple coroot, the formulas are
+
+```text
+[hᵢ, eⱼ] = dᵢ(j) eⱼ                         (j the short node),
+[hᵢ, eⱼ] = (dᵢ(j) - dᵢ(j+1)) eⱼ            (j a long node),
+```
+
+with the negatives of these scalars on the negative-root generators. These are the coordinate
+form of the Cartan relations. Identifying the scalars uniformly with entries of Mathlib's type-`B`
+Cartan matrix, and proving the remaining mixed and higher Serre relations, are subsequent steps.
+
+## Main results
+
+* `TauCeti.typeBSimpleCorootCoordinate`: the diagonal coordinate of a simple coroot.
+* `TauCeti.typeBSimpleCorootGenerator_eq_diagonal`: the corresponding matrix identity.
+* `TauCeti.typeBSimpleCorootGenerator_lie_coroot`: simple coroots commute.
+* `TauCeti.typeBSimpleCorootGenerator_lie_root_last` and
+  `TauCeti.typeBSimpleCorootGenerator_lie_root_castSucc`: Cartan action on positive generators.
+* `TauCeti.typeBSimpleCorootGenerator_lie_negativeRoot_last` and
+  `TauCeti.typeBSimpleCorootGenerator_lie_negativeRoot_castSucc`: Cartan action on negative
+  generators.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate II.
+* R. W. Carter, *Simple Groups of Lie Type*, Section 4.2.
+
+This supplies the next matrix-model input to the Chevalley--Demazure construction and pinnings in
+Layer 9 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+variable {K : Type u} [CommRing K]
+variable {n : ℕ}
+
+/-- The coordinate vector of a Bourbaki simple coroot of `Bₙ₊₁` in the split diagonal Cartan.
+The first `n` nodes are `εᵢ - εᵢ₊₁`, while the final short node has coroot `2εₙ`. -/
+def typeBSimpleCorootCoordinate (i : Fin (n + 1)) : Fin (n + 1) → K :=
+  Fin.lastCases (2 • Pi.single (Fin.last n) 1)
+    (fun j => Pi.single j.castSucc 1 - Pi.single j.succ 1) i
+
+@[simp]
+theorem typeBSimpleCorootCoordinate_last :
+    typeBSimpleCorootCoordinate (K := K) (Fin.last n) =
+      2 • Pi.single (Fin.last n) 1 := by
+  simp [typeBSimpleCorootCoordinate]
+
+@[simp]
+theorem typeBSimpleCorootCoordinate_castSucc (i : Fin n) :
+    typeBSimpleCorootCoordinate (K := K) i.castSucc =
+      Pi.single i.castSucc 1 - Pi.single i.succ 1 := by
+  simp [typeBSimpleCorootCoordinate]
+
+/-- A simple coroot generator is the split diagonal element with the corresponding coordinate
+vector. -/
+theorem typeBSimpleCorootGenerator_eq_diagonal (i : Fin (n + 1)) :
+    typeBSimpleCorootGenerator (K := K) i =
+      ((typeBDiagonalEquiv (K := K) (ι := Fin (n + 1))
+        (typeBSimpleCorootCoordinate i) : typeBDiagonalCartan K (Fin (n + 1))) :
+          LieAlgebra.Orthogonal.typeB (Fin (n + 1)) K) := by
+  refine Fin.lastCases ?_ (fun i₀ => ?_) i
+  · simp [typeBShortCorootGenerator_eq_diagonal]
+  · simp [typeBLongCorootGenerator_eq_diagonal]
+
+/-- The simple coroot generators in the standard split type-`B` model commute. -/
+@[simp]
+theorem typeBSimpleCorootGenerator_lie_coroot (i j : Fin (n + 1)) :
+    ⁅typeBSimpleCorootGenerator (K := K) i, typeBSimpleCorootGenerator (K := K) j⁆ = 0 := by
+  rw [typeBSimpleCorootGenerator_eq_diagonal,
+    typeBSimpleCorootGenerator_eq_diagonal]
+  exact typeBDiagonalEquiv_lie_diagonalEquiv _ _
+
+/-- The action of a simple coroot on the positive generator at the final short node. -/
+theorem typeBSimpleCorootGenerator_lie_root_last (i : Fin (n + 1)) :
+    ⁅typeBSimpleCorootGenerator (K := K) i,
+      typeBSimpleRootGenerator (K := K) (Fin.last n)⁆ =
+        typeBSimpleCorootCoordinate (K := K) i (Fin.last n) •
+          typeBSimpleRootGenerator (K := K) (Fin.last n) := by
+  rw [typeBSimpleCorootGenerator_eq_diagonal, typeBSimpleRootGenerator_last]
+  exact typeBDiagonalEquiv_lie_shortRootGenerator _ _
+
+/-- The action of a simple coroot on a positive generator at a long node. -/
+theorem typeBSimpleCorootGenerator_lie_root_castSucc (i : Fin (n + 1)) (j : Fin n) :
+    ⁅typeBSimpleCorootGenerator (K := K) i,
+      typeBSimpleRootGenerator (K := K) j.castSucc⁆ =
+        (typeBSimpleCorootCoordinate (K := K) i j.castSucc -
+          typeBSimpleCorootCoordinate (K := K) i j.succ) •
+            typeBSimpleRootGenerator (K := K) j.castSucc := by
+  rw [typeBSimpleCorootGenerator_eq_diagonal, typeBSimpleRootGenerator_castSucc]
+  exact typeBDiagonalEquiv_lie_longRootGenerator _ _ _ _
+
+/-- The action of a simple coroot on the negative generator at the final short node. -/
+theorem typeBSimpleCorootGenerator_lie_negativeRoot_last (i : Fin (n + 1)) :
+    ⁅typeBSimpleCorootGenerator (K := K) i,
+      typeBSimpleNegativeRootGenerator (K := K) (Fin.last n)⁆ =
+        -(typeBSimpleCorootCoordinate (K := K) i (Fin.last n)) •
+          typeBSimpleNegativeRootGenerator (K := K) (Fin.last n) := by
+  rw [typeBSimpleCorootGenerator_eq_diagonal, typeBSimpleNegativeRootGenerator_last]
+  exact typeBDiagonalEquiv_lie_shortNegativeRootGenerator _ _
+
+/-- The action of a simple coroot on a negative generator at a long node. -/
+theorem typeBSimpleCorootGenerator_lie_negativeRoot_castSucc (i : Fin (n + 1)) (j : Fin n) :
+    ⁅typeBSimpleCorootGenerator (K := K) i,
+      typeBSimpleNegativeRootGenerator (K := K) j.castSucc⁆ =
+        (typeBSimpleCorootCoordinate (K := K) i j.succ -
+          typeBSimpleCorootCoordinate (K := K) i j.castSucc) •
+            typeBSimpleNegativeRootGenerator (K := K) j.castSucc := by
+  rw [typeBSimpleCorootGenerator_eq_diagonal, typeBSimpleNegativeRootGenerator_castSucc]
+  exact typeBDiagonalEquiv_lie_longRootGenerator _ _ _ _
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
@@ -205,11 +205,10 @@ theorem coe_typeBShortNegativeRootGenerator (i : ι) :
 weight. -/
 @[simp]
 theorem typeBDiagonalEquiv_lie_longRootGenerator (d : ι → K) (i j : ι) (hij : i ≠ j) :
-    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
+    ⁅(⟨typeBDiagonalMatrix d, typeBDiagonalMatrix_mem_typeB d⟩ :
         LieAlgebra.Orthogonal.typeB ι K), typeBLongRootGenerator (K := K) i j hij⁆ =
       (d i - d j) • typeBLongRootGenerator i j hij := by
   apply Subtype.ext
-  rw [coe_typeBDiagonalEquiv_apply]
   -- The subtype bracket reduces definitionally to the ambient matrix commutator.
   change typeBDiagonalMatrix d * typeBLongRootMatrix i j hij -
       typeBLongRootMatrix i j hij * typeBDiagonalMatrix d =
@@ -224,11 +223,10 @@ theorem typeBDiagonalEquiv_lie_longRootGenerator (d : ι → K) (i j : ι) (hij 
 /-- A split diagonal element acts on the positive short-root vector of weight `εᵢ`. -/
 @[simp]
 theorem typeBDiagonalEquiv_lie_shortRootGenerator (d : ι → K) (i : ι) :
-    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
+    ⁅(⟨typeBDiagonalMatrix d, typeBDiagonalMatrix_mem_typeB d⟩ :
         LieAlgebra.Orthogonal.typeB ι K), typeBShortRootGenerator (K := K) i⁆ =
       d i • typeBShortRootGenerator i := by
   apply Subtype.ext
-  rw [coe_typeBDiagonalEquiv_apply]
   -- The subtype bracket reduces definitionally to the ambient matrix commutator.
   change typeBDiagonalMatrix d * typeBShortRootMatrix i -
       typeBShortRootMatrix i * typeBDiagonalMatrix d = d i • typeBShortRootMatrix i
@@ -239,11 +237,10 @@ theorem typeBDiagonalEquiv_lie_shortRootGenerator (d : ι → K) (i : ι) :
 /-- A split diagonal element acts on the negative short-root vector of weight `-εᵢ`. -/
 @[simp]
 theorem typeBDiagonalEquiv_lie_shortNegativeRootGenerator (d : ι → K) (i : ι) :
-    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
+    ⁅(⟨typeBDiagonalMatrix d, typeBDiagonalMatrix_mem_typeB d⟩ :
         LieAlgebra.Orthogonal.typeB ι K), typeBShortNegativeRootGenerator (K := K) i⁆ =
       -(d i) • typeBShortNegativeRootGenerator i := by
   apply Subtype.ext
-  rw [coe_typeBDiagonalEquiv_apply]
   -- The subtype bracket reduces definitionally to the ambient matrix commutator.
   change typeBDiagonalMatrix d * typeBShortNegativeRootMatrix i -
       typeBShortNegativeRootMatrix i * typeBDiagonalMatrix d =

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
@@ -203,6 +203,7 @@ theorem coe_typeBShortNegativeRootGenerator (i : ι) :
 
 /-- A split diagonal element acts on the long-root vector of weight `εᵢ - εⱼ` by that
 weight. -/
+@[simp]
 theorem typeBDiagonalEquiv_lie_longRootGenerator (d : ι → K) (i j : ι) (hij : i ≠ j) :
     ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
         LieAlgebra.Orthogonal.typeB ι K), typeBLongRootGenerator (K := K) i j hij⁆ =
@@ -221,6 +222,7 @@ theorem typeBDiagonalEquiv_lie_longRootGenerator (d : ι → K) (i j : ι) (hij 
       by_cases hib : i = b <;> by_cases hjb : j = b <;> simp_all <;> aesop
 
 /-- A split diagonal element acts on the positive short-root vector of weight `εᵢ`. -/
+@[simp]
 theorem typeBDiagonalEquiv_lie_shortRootGenerator (d : ι → K) (i : ι) :
     ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
         LieAlgebra.Orthogonal.typeB ι K), typeBShortRootGenerator (K := K) i⁆ =
@@ -235,6 +237,7 @@ theorem typeBDiagonalEquiv_lie_shortRootGenerator (d : ι → K) (i : ι) :
       Matrix.single_apply] <;> aesop
 
 /-- A split diagonal element acts on the negative short-root vector of weight `-εᵢ`. -/
+@[simp]
 theorem typeBDiagonalEquiv_lie_shortNegativeRootGenerator (d : ι → K) (i : ι) :
     ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
         LieAlgebra.Orthogonal.typeB ι K), typeBShortNegativeRootGenerator (K := K) i⁆ =

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
@@ -107,6 +107,15 @@ theorem coe_typeBLongCorootGenerator (i j : ι) (hij : i ≠ j) :
       Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K) = typeBLongCorootMatrix i j hij :=
   (rfl)
 
+/-- The long coroot has coordinate vector `εᵢ - εⱼ` in the split diagonal Cartan. -/
+theorem typeBLongCorootGenerator_eq_diagonal (i j : ι) (hij : i ≠ j) :
+    typeBLongCorootGenerator (K := K) i j hij =
+      ((typeBDiagonalEquiv (K := K) (ι := ι) (Pi.single i 1 - Pi.single j 1) :
+        typeBDiagonalCartan K ι) : LieAlgebra.Orthogonal.typeB ι K) := by
+  apply Subtype.ext
+  rw [coe_typeBDiagonalEquiv_apply]
+  rfl
+
 /-- Opposite long-root vectors bracket to their diagonal coroot. -/
 @[simp]
 theorem typeBLongRootGenerator_lie_swap (i j : ι) (hij : i ≠ j) :
@@ -190,6 +199,64 @@ theorem coe_typeBShortNegativeRootGenerator (i : ι) :
       Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K) = typeBShortNegativeRootMatrix i :=
   (rfl)
 
+/-! ### Diagonal action on root generators -/
+
+/-- Two elements of the split diagonal Cartan commute in the ambient type-`B` Lie algebra. -/
+theorem typeBDiagonalEquiv_lie_diagonalEquiv (d e : ι → K) :
+    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
+        LieAlgebra.Orthogonal.typeB ι K),
+      ((typeBDiagonalEquiv (K := K) (ι := ι) e : typeBDiagonalCartan K ι) :
+        LieAlgebra.Orthogonal.typeB ι K)⁆ = 0 := by
+  have h : ⁅typeBDiagonalEquiv (K := K) (ι := ι) d,
+      typeBDiagonalEquiv (K := K) (ι := ι) e⁆ = 0 :=
+    LieModule.IsTrivial.trivial _ _
+  exact congrArg Subtype.val h
+
+/-- A split diagonal element acts on the long-root vector of weight `εᵢ - εⱼ` by that
+weight. -/
+theorem typeBDiagonalEquiv_lie_longRootGenerator (d : ι → K) (i j : ι) (hij : i ≠ j) :
+    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
+        LieAlgebra.Orthogonal.typeB ι K), typeBLongRootGenerator (K := K) i j hij⁆ =
+      (d i - d j) • typeBLongRootGenerator i j hij := by
+  apply Subtype.ext
+  rw [coe_typeBDiagonalEquiv_apply]
+  change typeBDiagonalMatrix d * typeBLongRootMatrix i j hij -
+      typeBLongRootMatrix i j hij * typeBDiagonalMatrix d =
+        (d i - d j) • typeBLongRootMatrix i j hij
+  ext (a | (a | a)) (b | (b | b)) <;>
+    simp [typeBLongRootMatrix, typeBDiagonalMatrix_apply, Matrix.mul_apply,
+      Matrix.single_apply, sub_eq_add_neg]
+  all_goals
+    by_cases hia : i = a <;> by_cases hja : j = a <;>
+      by_cases hib : i = b <;> by_cases hjb : j = b <;> simp_all <;> aesop
+
+/-- A split diagonal element acts on the positive short-root vector of weight `εᵢ`. -/
+theorem typeBDiagonalEquiv_lie_shortRootGenerator (d : ι → K) (i : ι) :
+    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
+        LieAlgebra.Orthogonal.typeB ι K), typeBShortRootGenerator (K := K) i⁆ =
+      d i • typeBShortRootGenerator i := by
+  apply Subtype.ext
+  rw [coe_typeBDiagonalEquiv_apply]
+  change typeBDiagonalMatrix d * typeBShortRootMatrix i -
+      typeBShortRootMatrix i * typeBDiagonalMatrix d = d i • typeBShortRootMatrix i
+  ext (a | (a | a)) (b | (b | b)) <;>
+    simp [typeBShortRootMatrix, typeBDiagonalMatrix_apply, Matrix.mul_apply,
+      Matrix.single_apply] <;> aesop
+
+/-- A split diagonal element acts on the negative short-root vector of weight `-εᵢ`. -/
+theorem typeBDiagonalEquiv_lie_shortNegativeRootGenerator (d : ι → K) (i : ι) :
+    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
+        LieAlgebra.Orthogonal.typeB ι K), typeBShortNegativeRootGenerator (K := K) i⁆ =
+      -(d i) • typeBShortNegativeRootGenerator i := by
+  apply Subtype.ext
+  rw [coe_typeBDiagonalEquiv_apply]
+  change typeBDiagonalMatrix d * typeBShortNegativeRootMatrix i -
+      typeBShortNegativeRootMatrix i * typeBDiagonalMatrix d =
+        -(d i) • typeBShortNegativeRootMatrix i
+  ext (a | (a | a)) (b | (b | b)) <;>
+    simp [typeBShortNegativeRootMatrix, typeBDiagonalMatrix_apply, Matrix.mul_apply,
+      Matrix.single_apply] <;> aesop
+
 /-- The diagonal short coroot `2εᵢ` in the standard type-`B` coordinates. -/
 def typeBShortCorootMatrix (i : ι) : Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K :=
   typeBDiagonalMatrix (2 • Pi.single i 1)
@@ -203,6 +270,15 @@ theorem coe_typeBShortCorootGenerator (i : ι) :
     (typeBShortCorootGenerator (K := K) i :
       Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K) = typeBShortCorootMatrix i :=
   (rfl)
+
+/-- The short coroot has coordinate vector `2εᵢ` in the split diagonal Cartan. -/
+theorem typeBShortCorootGenerator_eq_diagonal (i : ι) :
+    typeBShortCorootGenerator (K := K) i =
+      ((typeBDiagonalEquiv (K := K) (ι := ι) (2 • Pi.single i 1) :
+        typeBDiagonalCartan K ι) : LieAlgebra.Orthogonal.typeB ι K) := by
+  apply Subtype.ext
+  rw [coe_typeBDiagonalEquiv_apply]
+  rfl
 
 /-- The positive and negative short-root vectors bracket to the short coroot. -/
 @[simp]

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
@@ -201,17 +201,6 @@ theorem coe_typeBShortNegativeRootGenerator (i : ι) :
 
 /-! ### Diagonal action on root generators -/
 
-/-- Two elements of the split diagonal Cartan commute in the ambient type-`B` Lie algebra. -/
-theorem typeBDiagonalEquiv_lie_diagonalEquiv (d e : ι → K) :
-    ⁅((typeBDiagonalEquiv (K := K) (ι := ι) d : typeBDiagonalCartan K ι) :
-        LieAlgebra.Orthogonal.typeB ι K),
-      ((typeBDiagonalEquiv (K := K) (ι := ι) e : typeBDiagonalCartan K ι) :
-        LieAlgebra.Orthogonal.typeB ι K)⁆ = 0 := by
-  have h : ⁅typeBDiagonalEquiv (K := K) (ι := ι) d,
-      typeBDiagonalEquiv (K := K) (ι := ι) e⁆ = 0 :=
-    LieModule.IsTrivial.trivial _ _
-  exact congrArg Subtype.val h
-
 /-- A split diagonal element acts on the long-root vector of weight `εᵢ - εⱼ` by that
 weight. -/
 theorem typeBDiagonalEquiv_lie_longRootGenerator (d : ι → K) (i j : ι) (hij : i ≠ j) :
@@ -220,6 +209,7 @@ theorem typeBDiagonalEquiv_lie_longRootGenerator (d : ι → K) (i j : ι) (hij 
       (d i - d j) • typeBLongRootGenerator i j hij := by
   apply Subtype.ext
   rw [coe_typeBDiagonalEquiv_apply]
+  -- The subtype bracket reduces definitionally to the ambient matrix commutator.
   change typeBDiagonalMatrix d * typeBLongRootMatrix i j hij -
       typeBLongRootMatrix i j hij * typeBDiagonalMatrix d =
         (d i - d j) • typeBLongRootMatrix i j hij
@@ -237,6 +227,7 @@ theorem typeBDiagonalEquiv_lie_shortRootGenerator (d : ι → K) (i : ι) :
       d i • typeBShortRootGenerator i := by
   apply Subtype.ext
   rw [coe_typeBDiagonalEquiv_apply]
+  -- The subtype bracket reduces definitionally to the ambient matrix commutator.
   change typeBDiagonalMatrix d * typeBShortRootMatrix i -
       typeBShortRootMatrix i * typeBDiagonalMatrix d = d i • typeBShortRootMatrix i
   ext (a | (a | a)) (b | (b | b)) <;>
@@ -250,6 +241,7 @@ theorem typeBDiagonalEquiv_lie_shortNegativeRootGenerator (d : ι → K) (i : ι
       -(d i) • typeBShortNegativeRootGenerator i := by
   apply Subtype.ext
   rw [coe_typeBDiagonalEquiv_apply]
+  -- The subtype bracket reduces definitionally to the ambient matrix commutator.
   change typeBDiagonalMatrix d * typeBShortNegativeRootMatrix i -
       typeBShortNegativeRootMatrix i * typeBDiagonalMatrix d =
         -(d i) • typeBShortNegativeRootMatrix i


### PR DESCRIPTION
This PR adds the simple-coroot coordinate and root-action layer for the standard split type-`B` matrix model. It identifies each Bourbaki simple coroot generator with its coordinate vector in the diagonal Cartan, proves that the simple coroots commute, and computes their brackets with both positive and negative long- and short-root generators.

The exact ReductiveGroups roadmap target is Layer 9's **Chevalley--Demazure construction**, serving the **Pinnings** milestone: these weight computations are the next relations needed after the explicit type-`B` simple generators. After this PR, it remains to identify the displayed coordinate scalars uniformly with Mathlib's type-`B` Cartan-matrix entries and prove the mixed and higher Serre relations before constructing the full Chevalley basis and Kostant form.

The matrix realization and normalization follow Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate II, and Carter, *Simple Groups of Lie Type*, Section 4.2; both are cited in the module documentation. The implementation reuses Tau Ceti's split diagonal Cartan equivalence and Mathlib's matrix Lie-bracket infrastructure rather than introducing a parallel model.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-b-simple-coroot-action"}-->

🤖 Prepared with Codex
