### PR TITLE
feat: turn Stieltjes transforms into Bernstein functions

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
@@ -105,9 +105,7 @@ theorem integrable_mul_zpow_neg_two_sub_add {μ : Measure ℝ≥0}
   filter_upwards with x
   have htx : t + (x : ℝ) ≠ 0 := (add_pos_of_pos_of_nonneg ht x.coe_nonneg).ne'
   have hexp : -1 - (n : ℤ) = 1 + (-2 - (n : ℤ)) := by omega
-  change (t + (x : ℝ)) ^ (-1 - (n : ℤ)) -
-      t * (t + (x : ℝ)) ^ (-2 - (n : ℤ)) =
-    (x : ℝ) * (t + x) ^ (-2 - (n : ℤ))
+  simp only [Pi.sub_apply]
   rw [hexp, zpow_add₀ htx, zpow_one]
   ring
 

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Analysis.CompletelyMonotone.Stieltjes.CompletelyMonotone
 public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Basic
-import Mathlib.MeasureTheory.Integral.DominatedConvergence
 
 /-!
 # From Stieltjes functions to Bernstein functions
@@ -33,16 +32,18 @@ the normalization `μ {0} = 0` removes the only point where `t / (t + x)` does n
 
 ## Main declarations
 
-* `TauCeti.stieltjesBernsteinTransform` and `TauCeti.stieltjesBernsteinTransform_def`: the
+* `TauCeti.stieltjesBernsteinTransform` and `TauCeti.stieltjesBernsteinTransform_apply`: the
   continuous extension of `t * f(t)` written directly from Stieltjes representing data and its
   defining equation.
 * `TauCeti.stieltjesBernsteinTransform_zero`: the transform takes the value `a` at zero.
-* `TauCeti.iteratedDeriv_stieltjesBernsteinIntegral`: the iterated derivatives of the integral
+* `TauCeti.integrable_mul_zpow_neg_two_sub_add`: the derivative kernels of the integral term are
+  integrable at positive parameters.
+* `TauCeti.iteratedDeriv_integral_div_add`: the iterated derivatives of the integral
   term at positive parameters.
 * `TauCeti.hasDerivAt_stieltjesBernsteinTransform` and
   `TauCeti.deriv_stieltjesBernsteinTransform`: the transform has derivative
   `b + ∫ x, x / (t + x) ^ 2 ∂μ` at positive parameters.
-* `TauCeti.isBernsteinFunction_stieltjesBernsteinIntegral`: the integral term is Bernstein.
+* `TauCeti.isBernsteinFunction_integral_div_add`: the integral term is Bernstein.
 * `TauCeti.isBernsteinFunction_stieltjesBernsteinTransform`: the transform is Bernstein.
 * `TauCeti.RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul`: on `(0, ∞)` the
   transform of a Stieltjes representation of `f` is `t * f(t)`.
@@ -70,12 +71,12 @@ namespace TauCeti
 normalization and integrability hypotheses of `isBernsteinFunction_stieltjesBernsteinTransform`,
 it is a Bernstein function and is continuous on `[0, ∞)`. For representing data, the later theorem
 `RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul` identifies it with `t * f t` for
-positive `t`. Its defining equation is `stieltjesBernsteinTransform_def`. -/
+positive `t`. Its defining equation is `stieltjesBernsteinTransform_apply`. -/
 def stieltjesBernsteinTransform (μ : Measure ℝ≥0) (a b : ℝ≥0) (t : ℝ) : ℝ :=
   a + b * t + ∫ x : ℝ≥0, t / (t + x) ∂μ
 
 /-- The defining equation for the Stieltjes--Bernstein transform. -/
-lemma stieltjesBernsteinTransform_def (μ : Measure ℝ≥0) (a b : ℝ≥0) (t : ℝ) :
+lemma stieltjesBernsteinTransform_apply (μ : Measure ℝ≥0) (a b : ℝ≥0) (t : ℝ) :
     stieltjesBernsteinTransform μ a b t = a + b * t + ∫ x : ℝ≥0, t / (t + x) ∂μ :=
   (rfl)
 
@@ -83,7 +84,7 @@ lemma stieltjesBernsteinTransform_def (μ : Measure ℝ≥0) (a b : ℝ≥0) (t 
 @[simp]
 theorem stieltjesBernsteinTransform_zero (μ : Measure ℝ≥0) (a b : ℝ≥0) :
     stieltjesBernsteinTransform μ a b 0 = a := by
-  simp [stieltjesBernsteinTransform_def]
+  simp [stieltjesBernsteinTransform_apply]
 
 private lemma stieltjesBernsteinIntegral_eq_mul_integral_inv_add (μ : Measure ℝ≥0)
     (t : ℝ) :
@@ -91,6 +92,24 @@ private lemma stieltjesBernsteinIntegral_eq_mul_integral_inv_add (μ : Measure �
       t * ∫ x : ℝ≥0, (t + x)⁻¹ ∂μ := by
   rw [← integral_const_mul]
   exact integral_congr_ae (Filter.Eventually.of_forall fun x => by simp [div_eq_mul_inv])
+
+/-- The kernels in the iterated derivative formula for the integral term of the
+Stieltjes--Bernstein transform are integrable at positive parameters. -/
+theorem integrable_mul_zpow_neg_two_sub_add {μ : Measure ℝ≥0}
+    (hμ : Integrable stieltjesWeight μ) (n : ℕ) {t : ℝ} (ht : 0 < t) :
+    Integrable (fun x : ℝ≥0 => (x : ℝ) * (t + x) ^ (-2 - (n : ℤ))) μ := by
+  have hexpSucc : -1 - ((n + 1 : ℕ) : ℤ) = -2 - (n : ℤ) := by omega
+  have hpowInt : Integrable (fun x : ℝ≥0 => (t + (x : ℝ)) ^ (-2 - (n : ℤ))) μ := by
+    simpa only [hexpSucc] using integrable_zpow_neg_one_sub_add hμ (n + 1) ht
+  refine ((integrable_zpow_neg_one_sub_add hμ n ht).sub (hpowInt.const_mul t)).congr ?_
+  filter_upwards with x
+  have htx : t + (x : ℝ) ≠ 0 := (add_pos_of_pos_of_nonneg ht x.coe_nonneg).ne'
+  have hexp : -1 - (n : ℤ) = 1 + (-2 - (n : ℤ)) := by omega
+  change (t + (x : ℝ)) ^ (-1 - (n : ℤ)) -
+      t * (t + (x : ℝ)) ^ (-2 - (n : ℤ)) =
+    (x : ℝ) * (t + x) ^ (-2 - (n : ℤ))
+  rw [hexp, zpow_add₀ htx, zpow_one]
+  ring
 
 private lemma integral_mul_zpow_eq_sub {μ : Measure ℝ≥0}
     (hμ : Integrable stieltjesWeight μ) (n : ℕ) {t : ℝ} (ht : 0 < t) :
@@ -142,7 +161,7 @@ private lemma iteratedDeriv_succ_id_mul {F : ℝ → ℝ} {n : ℕ} {t : ℝ}
 
 /-- The iterated derivatives of the integral term in the Stieltjes--Bernstein transform at a
 positive parameter. -/
-theorem iteratedDeriv_stieltjesBernsteinIntegral {μ : Measure ℝ≥0}
+theorem iteratedDeriv_integral_div_add {μ : Measure ℝ≥0}
     (hμ : Integrable stieltjesWeight μ) (n : ℕ) {t : ℝ} (ht : 0 < t) :
     iteratedDeriv (n + 1) (fun u : ℝ => ∫ x : ℝ≥0, u / (u + x) ∂μ) t =
       (-1 : ℝ) ^ n * (n + 1).factorial *
@@ -176,12 +195,12 @@ theorem hasDerivAt_stieltjesBernsteinTransform {μ : Measure ℝ≥0} {a b : ℝ
   have hderiv : deriv (fun u : ℝ => ∫ x : ℝ≥0, u / (u + x) ∂μ) t =
       ∫ x : ℝ≥0, (x : ℝ) / (t + x) ^ 2 ∂μ := by
     simpa [iteratedDeriv_one, div_eq_mul_inv, zpow_neg, zpow_ofNat] using
-      iteratedDeriv_stieltjesBernsteinIntegral hμ 0 ht
+      iteratedDeriv_integral_div_add hμ 0 ht
   have hlinear : HasDerivAt (fun u : ℝ => (a : ℝ) + (b : ℝ) * u) b t := by
     simpa using ((hasDerivAt_id t).const_mul (b : ℝ)).const_add (a : ℝ)
   refine (hlinear.add (hdiff.hasDerivAt.congr_deriv hderiv)).congr_of_eventuallyEq ?_
   filter_upwards with u
-  rw [stieltjesBernsteinTransform_def]
+  rw [stieltjesBernsteinTransform_apply]
   simp only [Pi.add_apply]
 
 /-- The derivative formula for the Stieltjes--Bernstein transform at a positive parameter. -/
@@ -199,7 +218,7 @@ private lemma isCompletelyMonotoneOnIoi_deriv_stieltjesBernsteinIntegral
   · exact ((contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi).mp
       (contDiffOn_stieltjesBernsteinIntegral hμ)).2
   · intro n t ht
-    rw [← iteratedDeriv_succ', iteratedDeriv_stieltjesBernsteinIntegral hμ n ht]
+    rw [← iteratedDeriv_succ', iteratedDeriv_integral_div_add hμ n ht]
     have hsign : (-1 : ℝ) ^ n * (-1 : ℝ) ^ n = 1 := by
       rw [← pow_add]
       norm_num [two_mul n]
@@ -245,7 +264,7 @@ private lemma continuousWithinAt_stieltjesBernsteinIntegral_zero
 
 /-- The integral term in the Stieltjes--Bernstein transform is a Bernstein function under the
 normalization and integrability hypotheses on the representing measure. -/
-theorem isBernsteinFunction_stieltjesBernsteinIntegral {μ : Measure ℝ≥0}
+theorem isBernsteinFunction_integral_div_add {μ : Measure ℝ≥0}
     (hzero : μ {0} = 0) (hμ : Integrable stieltjesWeight μ) :
     IsBernsteinFunction (fun t : ℝ => ∫ x : ℝ≥0, t / (t + x) ∂μ) := by
   have hjumpCont : ContinuousOn
@@ -266,9 +285,9 @@ theorem isBernsteinFunction_stieltjesBernsteinTransform {μ : Measure ℝ≥0} {
     (hzero : μ {0} = 0) (hμ : Integrable stieltjesWeight μ) :
     IsBernsteinFunction (stieltjesBernsteinTransform μ a b) := by
   apply ((isBernsteinFunction_affine a.coe_nonneg b.coe_nonneg).add
-    (isBernsteinFunction_stieltjesBernsteinIntegral hzero hμ)).congr
+    (isBernsteinFunction_integral_div_add hzero hμ)).congr
   intro t _
-  rw [stieltjesBernsteinTransform_def]
+  rw [stieltjesBernsteinTransform_apply]
   simp only [Pi.add_apply]
 
 namespace RepresentsStieltjes
@@ -279,7 +298,7 @@ variable {μ : Measure ℝ≥0} {a b : ℝ≥0} {f : ℝ → ℝ}
 transform on the open half-line. -/
 theorem stieltjesBernsteinTransform_eq_mul (h : RepresentsStieltjes μ a b f) {t : ℝ}
     (ht : 0 < t) : stieltjesBernsteinTransform μ a b t = t * f t := by
-  rw [h.eq_div_add_add_integral_inv_add ht, stieltjesBernsteinTransform_def]
+  rw [h.eq_div_add_add_integral_inv_add ht, stieltjesBernsteinTransform_apply]
   rw [stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
   field_simp [ht.ne']
 

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
@@ -37,8 +37,10 @@ the normalization `mu {0} = 0` removes the only point where `t / (t + x)` does n
 * `TauCeti.stieltjesBernsteinTransform`: the continuous extension of `t * f(t)` written directly
   from Stieltjes representing data.
 * `TauCeti.isBernsteinFunction_stieltjesBernsteinTransform`: the transform is Bernstein.
-* `TauCeti.RepresentsStieltjes.isBernsteinFunction_stieltjesBernsteinTransform`: a Stieltjes
-  representation produces a Bernstein extension agreeing with `t * f(t)` on `(0, infinity)`.
+* `TauCeti.RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul`: on `(0, infinity)` the
+  transform of a Stieltjes representation of `f` is `t * f(t)`.
+* `TauCeti.RepresentsStieltjes.isBernsteinFunction_stieltjesBernsteinTransform`: the transform of
+  a Stieltjes representation is Bernstein.
 * `TauCeti.IsStieltjesFunction.exists_isBernsteinFunction_eq_mul`: every Stieltjes function has
   a Bernstein extension of its product with the parameter on `(0, infinity)`.
 
@@ -61,21 +63,15 @@ namespace TauCeti
 normalization and integrability hypotheses of `isBernsteinFunction_stieltjesBernsteinTransform`,
 it is a Bernstein function and is continuous at zero. For representing data, the later theorem
 `RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul` identifies it with `t * f t` for
-positive `t`. -/
+positive `t`.  The body is `@[expose]`d, so `simp [stieltjesBernsteinTransform]` evaluates it. -/
+@[expose]
 def stieltjesBernsteinTransform (mu : Measure NNReal) (a b : NNReal) (t : Real) : Real :=
   a + b * t + ∫ x : NNReal, t / (t + x) ∂mu
-
-/-- Evaluation of the Stieltjes--Bernstein transform. -/
-@[simp]
-theorem stieltjesBernsteinTransform_apply (mu : Measure NNReal) (a b : NNReal) (t : Real) :
-    stieltjesBernsteinTransform mu a b t =
-      a + b * t + ∫ x : NNReal, t / (t + x) ∂mu := by
-  rw [stieltjesBernsteinTransform]
 
 /-- The Stieltjes--Bernstein transform takes the value `a` at zero. -/
 theorem stieltjesBernsteinTransform_zero (mu : Measure NNReal) (a b : NNReal) :
     stieltjesBernsteinTransform mu a b 0 = a := by
-  simp
+  simp [stieltjesBernsteinTransform]
 
 private lemma stieltjesBernsteinIntegral_eq_mul_integral_inv_add (mu : Measure NNReal)
     (t : Real) :
@@ -133,7 +129,7 @@ theorem hasDerivAt_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNRe
     simpa using ((hasDerivAt_id t).const_mul (b : Real)).const_add (a : Real)
   refine ((hlinear.add hjump).congr_of_eventuallyEq ?_).congr_deriv rfl
   filter_upwards [] with u
-  rw [stieltjesBernsteinTransform_apply,
+  rw [stieltjesBernsteinTransform,
     stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
   rfl
 
@@ -143,6 +139,50 @@ theorem deriv_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNReal}
     deriv (stieltjesBernsteinTransform mu a b) t =
       (b : Real) + ∫ x : NNReal, (x : Real) / (t + x) ^ 2 ∂mu :=
   (hasDerivAt_stieltjesBernsteinTransform hmu ht).deriv
+
+/-- The Leibniz expansion of `t * F t` collapses to two terms, because every derivative of the
+identity beyond the first vanishes. -/
+private lemma iteratedDeriv_succ_id_mul {F : Real → Real} {n : Nat} {t : Real}
+    (hF : ContDiffAt Real (n + 1 : Nat) F t) :
+    iteratedDeriv (n + 1) (fun u : Real => u * F u) t =
+      t * iteratedDeriv (n + 1) F t + ((n : Real) + 1) * iteratedDeriv n F t := by
+  have hmulFun : (fun u : Real => u * F u) = id * F := rfl
+  rw [hmulFun, iteratedDeriv_mul contDiffAt_id hF,
+    ← Finset.add_sum_erase _ _ (by simp : 0 ∈ Finset.range (n + 1 + 1)),
+    ← Finset.add_sum_erase _ _ (by simp : 1 ∈ (Finset.range (n + 1 + 1)).erase 0)]
+  have hrest :
+      (∑ x ∈ ((Finset.range (n + 1 + 1)).erase 0).erase 1,
+        ((n + 1).choose x : Real) * iteratedDeriv x id t *
+          iteratedDeriv (n + 1 - x) F t) = 0 := by
+    refine Finset.sum_eq_zero fun x hx => ?_
+    have hx1 : x ≠ 1 := (Finset.mem_erase.mp hx).1
+    have hx0 : x ≠ 0 := (Finset.mem_erase.mp (Finset.mem_erase.mp hx).2).1
+    simp [iteratedDeriv_id, hx0, hx1]
+  have hid0 : iteratedDeriv 0 id t = t := by simp
+  have hid1 : iteratedDeriv 1 id t = 1 := by simp [iteratedDeriv_one]
+  rw [hrest, hid0, hid1]
+  simp only [Nat.choose_zero_right, Nat.choose_one_right, Nat.cast_one, one_mul,
+    Nat.sub_zero, add_zero]
+  rw [Nat.add_sub_cancel, mul_one, Nat.cast_add, Nat.cast_one]
+
+/-- Lowering the exponent of a Stieltjes derivative kernel by one costs a factor at most `t`,
+because `t ≤ t + x`. -/
+private lemma mul_integral_zpow_neg_two_sub_le {mu : Measure NNReal}
+    (hmu : Integrable stieltjesWeight mu) (n : Nat) {t : Real} (ht : 0 < t) :
+    (t * ∫ x : NNReal, (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu) ≤
+      ∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu := by
+  have hexpSucc : -1 - ((n + 1 : Nat) : Int) = -2 - (n : Int) := by omega
+  have hIntSucc : Integrable
+      (fun x : NNReal => (t + (x : Real)) ^ (-2 - (n : Int))) mu := by
+    simpa only [hexpSucc] using integrable_zpow_neg_one_sub_add hmu (n + 1) ht
+  rw [← integral_const_mul]
+  refine integral_mono (hIntSucc.const_mul t)
+    (integrable_zpow_neg_one_sub_add hmu n ht) fun x => ?_
+  have htx : 0 < t + (x : Real) := add_pos_of_pos_of_nonneg ht x.coe_nonneg
+  have hexp : -1 - (n : Int) = 1 + (-2 - (n : Int)) := by omega
+  rw [hexp, zpow_add₀ htx.ne', zpow_one]
+  exact mul_le_mul_of_nonneg_right (le_add_of_nonneg_right x.coe_nonneg)
+    (zpow_nonneg htx.le _)
 
 private lemma isCompletelyMonotoneOnIoi_deriv_stieltjesBernsteinIntegral
     {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) :
@@ -164,53 +204,20 @@ private lemma isCompletelyMonotoneOnIoi_deriv_stieltjesBernsteinIntegral
   · rw [contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi] at hjumpContDiff
     exact hjumpContDiff.2.congr hderivEq
   · intro n t ht
-    rw [(hderivEq.eventuallyEq_of_mem
-      (isOpen_Ioi.mem_nhds ht)).iteratedDeriv_eq n, ← iteratedDeriv_succ']
+    -- Turn the `n`-th derivative of the derivative into the `(n + 1)`-st derivative of
+    -- `t * F t`, and expand the latter by the two-term Leibniz rule.
     have hFdiff : ContDiffAt Real (n + 1 : Nat) F t :=
       (hFcm.contDiffOn.contDiffAt (isOpen_Ioi.mem_nhds ht)).of_le (by simp)
-    have hmulFun : (fun u => u * F u) = id * F := rfl
-    rw [hmulFun, iteratedDeriv_mul contDiffAt_id hFdiff]
-    rw [← Finset.add_sum_erase _ _
-      (by simp : 0 ∈ Finset.range (n + 1 + 1))]
-    rw [← Finset.add_sum_erase _ _
-      (by simp : 1 ∈ (Finset.range (n + 1 + 1)).erase 0)]
-    have hrest :
-        (∑ x ∈ ((Finset.range (n + 1 + 1)).erase 0).erase 1,
-          ((n + 1).choose x : Real) * iteratedDeriv x id t *
-            iteratedDeriv (n + 1 - x) F t) = 0 := by
-      apply Finset.sum_eq_zero
-      intro x hx
-      have hx1 : x ≠ 1 := (Finset.mem_erase.mp hx).1
-      have hx0 : x ≠ 0 := (Finset.mem_erase.mp (Finset.mem_erase.mp hx).2).1
-      simp [iteratedDeriv_id, hx0, hx1]
-    rw [hrest]
-    have hid0 : iteratedDeriv 0 id t = t := by simp
-    have hid1 : iteratedDeriv 1 id t = 1 := by simp [iteratedDeriv_one]
-    rw [hid0, hid1]
-    simp only [Nat.choose_zero_right, Nat.choose_one_right, Nat.cast_one, one_mul,
-      Nat.sub_zero, add_zero]
-    rw [Nat.add_sub_cancel, mul_one, Nat.cast_add, Nat.cast_one]
+    rw [(hderivEq.eventuallyEq_of_mem
+      (isOpen_Ioi.mem_nhds ht)).iteratedDeriv_eq n, ← iteratedDeriv_succ',
+      iteratedDeriv_succ_id_mul hFdiff]
+    -- Insert the two derivative formulas for `F`; the exponents are `-1 - n` and `-2 - n`.
     have hn := iteratedDeriv_integral_inv_add hmu n ht
     have hn1 := iteratedDeriv_integral_inv_add hmu (n + 1) ht
     have hexpSucc : -1 - ((n + 1 : Nat) : Int) = -2 - (n : Int) := by omega
     rw [hexpSucc] at hn1
     rw [hn, hn1]
-    have hle : t * ∫ x : NNReal,
-          (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu ≤
-        ∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu := by
-      have hIntSucc : Integrable
-          (fun x : NNReal => (t + (x : Real)) ^ (-2 - (n : Int))) mu := by
-        simpa only [hexpSucc] using integrable_zpow_neg_one_sub_add hmu (n + 1) ht
-      rw [← integral_const_mul]
-      exact integral_mono
-        (hIntSucc.const_mul t)
-        (integrable_zpow_neg_one_sub_add hmu n ht) fun x => by
-          have htx : 0 < t + (x : Real) :=
-            add_pos_of_pos_of_nonneg ht x.coe_nonneg
-          have hexp : -1 - (n : Int) = 1 + (-2 - (n : Int)) := by omega
-          rw [hexp, zpow_add₀ htx.ne', zpow_one]
-          exact mul_le_mul_of_nonneg_right (le_add_of_nonneg_right x.coe_nonneg)
-            (zpow_nonneg htx.le _)
+    -- The two factors `(-1) ^ n` cancel, leaving `(n + 1)!` times the kernel difference.
     have hsign : (-1 : Real) ^ n * (-1 : Real) ^ n = 1 := by
       rw [← pow_add]
       norm_num [two_mul n]
@@ -233,7 +240,8 @@ private lemma isCompletelyMonotoneOnIoi_deriv_stieltjesBernsteinIntegral
                   (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu) := by ring
         _ = _ := by rw [hsign]; ring
     rw [heq]
-    exact mul_nonneg (Nat.cast_nonneg _) (sub_nonneg.mpr hle)
+    exact mul_nonneg (Nat.cast_nonneg _)
+      (sub_nonneg.mpr (mul_integral_zpow_neg_two_sub_le hmu n ht))
 
 private lemma continuousWithinAt_stieltjesBernsteinIntegral_zero
     {mu : Measure NNReal} (hzero : mu {0} = 0) (hmu : Integrable stieltjesWeight mu) :
@@ -310,7 +318,7 @@ theorem isBernsteinFunction_stieltjesBernsteinTransform {mu : Measure NNReal} {a
   apply ((isBernsteinFunction_affine a.coe_nonneg b.coe_nonneg).add
     (isBernsteinFunction_stieltjesBernsteinIntegral hzero hmu)).congr
   intro t _
-  rw [stieltjesBernsteinTransform_apply]
+  rw [stieltjesBernsteinTransform]
   simp only [Pi.add_apply]
 
 namespace RepresentsStieltjes
@@ -321,12 +329,13 @@ variable {mu : Measure NNReal} {a b : NNReal} {f : Real → Real}
 transform on the open half-line. -/
 theorem stieltjesBernsteinTransform_eq_mul (h : RepresentsStieltjes mu a b f) {t : Real}
     (ht : 0 < t) : stieltjesBernsteinTransform mu a b t = t * f t := by
-  rw [h.eq_div_add_add_integral_inv_add ht, stieltjesBernsteinTransform_apply]
+  rw [h.eq_div_add_add_integral_inv_add ht, stieltjesBernsteinTransform]
   rw [stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
   field_simp [ht.ne']
 
-/-- A Stieltjes representation produces a Bernstein function that agrees with `t * f(t)` for
-every positive `t` and has the canonical boundary value `a` at zero. -/
+/-- The transform attached to a Stieltjes representation is a Bernstein function.  Its agreement
+with `t * f(t)` on `(0, ∞)` is `RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul`, and its
+boundary value at zero is `stieltjesBernsteinTransform_zero`. -/
 theorem isBernsteinFunction_stieltjesBernsteinTransform (h : RepresentsStieltjes mu a b f) :
     IsBernsteinFunction (stieltjesBernsteinTransform mu a b) :=
   TauCeti.isBernsteinFunction_stieltjesBernsteinTransform

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
@@ -7,19 +7,18 @@ module
 
 public import TauCeti.Analysis.CompletelyMonotone.Stieltjes.CompletelyMonotone
 public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Basic
-import Mathlib.Analysis.Calculus.ParametricIntegral
-import Mathlib.Analysis.Calculus.Deriv.ZPow
+import Mathlib.MeasureTheory.Integral.DominatedConvergence
 
 /-!
 # From Stieltjes functions to Bernstein functions
 
 If
 
-`f(t) = a / t + b + integral x, (t + x)^(-1) partial mu`,
+`f t = a / t + b + ∫ x, (t + x)⁻¹ ∂μ`,
 
 then its continuously extended product with the parameter is a Bernstein function:
 
-`g(t) = a + b * t + integral x, t / (t + x) partial mu`.
+`g t = a + b * t + ∫ x, t / (t + x) ∂μ`.
 
 On the open half-line this is exactly `t * f(t)`, while `g(0) = a`.  The value at zero is
 essential: the literal product `0 * f(0)` would lose the coefficient of the possible `a / t`
@@ -27,22 +26,30 @@ singularity.  This is the first standard Stieltjes--Bernstein correspondence.
 
 The proof differentiates the integral on the open half-line.  Its derivative is
 
-`integral x, x / (t + x)^2 partial mu`,
+`∫ x, x / (t + x) ^ 2 ∂μ`,
 
 whose derivatives have alternating signs.  Continuity at zero follows by dominated convergence;
-the normalization `mu {0} = 0` removes the only point where `t / (t + x)` does not tend to zero.
+the normalization `μ {0} = 0` removes the only point where `t / (t + x)` does not tend to zero.
 
 ## Main declarations
 
-* `TauCeti.stieltjesBernsteinTransform`: the continuous extension of `t * f(t)` written directly
-  from Stieltjes representing data.
+* `TauCeti.stieltjesBernsteinTransform` and `TauCeti.stieltjesBernsteinTransform_def`: the
+  continuous extension of `t * f(t)` written directly from Stieltjes representing data and its
+  defining equation.
+* `TauCeti.stieltjesBernsteinTransform_zero`: the transform takes the value `a` at zero.
+* `TauCeti.iteratedDeriv_stieltjesBernsteinIntegral`: the iterated derivatives of the integral
+  term at positive parameters.
+* `TauCeti.hasDerivAt_stieltjesBernsteinTransform` and
+  `TauCeti.deriv_stieltjesBernsteinTransform`: the transform has derivative
+  `b + ∫ x, x / (t + x) ^ 2 ∂μ` at positive parameters.
+* `TauCeti.isBernsteinFunction_stieltjesBernsteinIntegral`: the integral term is Bernstein.
 * `TauCeti.isBernsteinFunction_stieltjesBernsteinTransform`: the transform is Bernstein.
-* `TauCeti.RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul`: on `(0, infinity)` the
+* `TauCeti.RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul`: on `(0, ∞)` the
   transform of a Stieltjes representation of `f` is `t * f(t)`.
 * `TauCeti.RepresentsStieltjes.isBernsteinFunction_stieltjesBernsteinTransform`: the transform of
   a Stieltjes representation is Bernstein.
-* `TauCeti.IsStieltjesFunction.exists_isBernsteinFunction_eq_mul`: every Stieltjes function has
-  a Bernstein extension of its product with the parameter on `(0, infinity)`.
+* `TauCeti.IsStieltjesFunction.exists_isBernsteinFunction_eqOn_mul`: every Stieltjes function has
+  a Bernstein extension of its product with the parameter on `(0, ∞)`.
 
 ## References
 
@@ -55,104 +62,74 @@ public section
 noncomputable section
 
 open MeasureTheory Set Filter
-open scoped ContDiff Topology
+open scoped ContDiff NNReal Topology
 
 namespace TauCeti
 
 /-- The candidate Bernstein transform associated to Stieltjes representing data. Under the
 normalization and integrability hypotheses of `isBernsteinFunction_stieltjesBernsteinTransform`,
-it is a Bernstein function and is continuous at zero. For representing data, the later theorem
+it is a Bernstein function and is continuous on `[0, ∞)`. For representing data, the later theorem
 `RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul` identifies it with `t * f t` for
-positive `t`.  The body is `@[expose]`d, so `simp [stieltjesBernsteinTransform]` evaluates it. -/
-@[expose]
-def stieltjesBernsteinTransform (mu : Measure NNReal) (a b : NNReal) (t : Real) : Real :=
-  a + b * t + ∫ x : NNReal, t / (t + x) ∂mu
+positive `t`. Its defining equation is `stieltjesBernsteinTransform_def`. -/
+def stieltjesBernsteinTransform (μ : Measure ℝ≥0) (a b : ℝ≥0) (t : ℝ) : ℝ :=
+  a + b * t + ∫ x : ℝ≥0, t / (t + x) ∂μ
+
+/-- The defining equation for the Stieltjes--Bernstein transform. -/
+lemma stieltjesBernsteinTransform_def (μ : Measure ℝ≥0) (a b : ℝ≥0) (t : ℝ) :
+    stieltjesBernsteinTransform μ a b t = a + b * t + ∫ x : ℝ≥0, t / (t + x) ∂μ :=
+  (rfl)
 
 /-- The Stieltjes--Bernstein transform takes the value `a` at zero. -/
-theorem stieltjesBernsteinTransform_zero (mu : Measure NNReal) (a b : NNReal) :
-    stieltjesBernsteinTransform mu a b 0 = a := by
-  simp [stieltjesBernsteinTransform]
+@[simp]
+theorem stieltjesBernsteinTransform_zero (μ : Measure ℝ≥0) (a b : ℝ≥0) :
+    stieltjesBernsteinTransform μ a b 0 = a := by
+  simp [stieltjesBernsteinTransform_def]
 
-private lemma stieltjesBernsteinIntegral_eq_mul_integral_inv_add (mu : Measure NNReal)
-    (t : Real) :
-    (∫ x : NNReal, t / (t + x) ∂mu) =
-      t * ∫ x : NNReal, (t + x)⁻¹ ∂mu := by
+private lemma stieltjesBernsteinIntegral_eq_mul_integral_inv_add (μ : Measure ℝ≥0)
+    (t : ℝ) :
+    (∫ x : ℝ≥0, t / (t + x) ∂μ) =
+      t * ∫ x : ℝ≥0, (t + x)⁻¹ ∂μ := by
   rw [← integral_const_mul]
   exact integral_congr_ae (Filter.Eventually.of_forall fun x => by simp [div_eq_mul_inv])
 
-private lemma integral_stieltjesBernsteinDerivKernel_eq_sub {mu : Measure NNReal}
-    (hmu : Integrable stieltjesWeight mu) {t : Real} (ht : 0 < t) :
-    (∫ x : NNReal, (x : Real) / (t + x) ^ 2 ∂mu) =
-      (∫ x : NNReal, (t + x)⁻¹ ∂mu) -
-        t * ∫ x : NNReal, (t + x) ^ (-2 : Int) ∂mu := by
-  have hpowInt : Integrable (fun x : NNReal => (t + (x : Real)) ^ (-2 : Int)) mu := by
-    simpa using integrable_zpow_neg_one_sub_add hmu 1 ht
+private lemma integral_mul_zpow_eq_sub {μ : Measure ℝ≥0}
+    (hμ : Integrable stieltjesWeight μ) (n : ℕ) {t : ℝ} (ht : 0 < t) :
+    (∫ x : ℝ≥0, (x : ℝ) * (t + x) ^ (-2 - (n : ℤ)) ∂μ) =
+      (∫ x : ℝ≥0, (t + x) ^ (-1 - (n : ℤ)) ∂μ) -
+        t * ∫ x : ℝ≥0, (t + x) ^ (-2 - (n : ℤ)) ∂μ := by
+  have hexpSucc : -1 - ((n + 1 : ℕ) : ℤ) = -2 - (n : ℤ) := by omega
+  have hpowInt : Integrable (fun x : ℝ≥0 => (t + (x : ℝ)) ^ (-2 - (n : ℤ))) μ := by
+    simpa only [hexpSucc] using integrable_zpow_neg_one_sub_add hμ (n + 1) ht
   rw [← integral_const_mul,
-    ← integral_sub (integrable_inv_add hmu ht) (hpowInt.const_mul t)]
+    ← integral_sub (integrable_zpow_neg_one_sub_add hμ n ht) (hpowInt.const_mul t)]
   exact integral_congr_ae (Filter.Eventually.of_forall fun x => by
-    have htx : t + (x : Real) ≠ 0 :=
-      (add_pos_of_pos_of_nonneg ht x.coe_nonneg).ne'
-    have hzpow : (t + (x : Real)) ^ (-2 : Int) = ((t + (x : Real)) ^ 2)⁻¹ := by
-      rw [zpow_neg, zpow_ofNat]
-    dsimp only
-    rw [hzpow, inv_eq_one_div]
-    field_simp
+    have htx : t + (x : ℝ) ≠ 0 := (add_pos_of_pos_of_nonneg ht x.coe_nonneg).ne'
+    have hexp : -1 - (n : ℤ) = 1 + (-2 - (n : ℤ)) := by omega
+    simp only
+    rw [hexp, zpow_add₀ htx, zpow_one]
     ring)
 
-private lemma contDiffOn_stieltjesBernsteinIntegral {mu : Measure NNReal}
-    (hmu : Integrable stieltjesWeight mu) :
-    ContDiffOn Real ∞ (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (Ioi 0) := by
+private lemma contDiffOn_stieltjesBernsteinIntegral {μ : Measure ℝ≥0}
+    (hμ : Integrable stieltjesWeight μ) :
+    ContDiffOn ℝ ∞ (fun t : ℝ => ∫ x : ℝ≥0, t / (t + x) ∂μ) (Ioi 0) := by
   refine (contDiffOn_id.mul
-    (isCompletelyMonotoneOnIoi_integral_inv_add hmu).contDiffOn).congr fun t _ => ?_
-  simpa only [id_eq] using stieltjesBernsteinIntegral_eq_mul_integral_inv_add mu t
-
-/-- The derivative of the Stieltjes--Bernstein transform at a positive parameter. -/
-theorem hasDerivAt_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNReal}
-    (hmu : Integrable stieltjesWeight mu) {t : Real} (ht : 0 < t) :
-    HasDerivAt (stieltjesBernsteinTransform mu a b)
-      ((b : Real) + ∫ x : NNReal, (x : Real) / (t + x) ^ 2 ∂mu) t := by
-  let F := fun u : Real => ∫ x : NNReal, (u + (x : Real))⁻¹ ∂mu
-  have hFdiff : DifferentiableAt Real F t :=
-    ((isCompletelyMonotoneOnIoi_integral_inv_add hmu).contDiffOn.differentiableOn
-      (by simp)).differentiableAt (isOpen_Ioi.mem_nhds ht)
-  have hFderiv : deriv F t = -∫ x : NNReal, (t + (x : Real)) ^ (-2 : Int) ∂mu := by
-    simpa [F, iteratedDeriv_one] using
-      iteratedDeriv_integral_inv_add hmu 1 ht
-  have hjump : HasDerivAt (fun u => u * F u)
-      (∫ x : NNReal, (x : Real) / (t + x) ^ 2 ∂mu) t := by
-    refine ((hasDerivAt_id t).mul hFdiff.hasDerivAt).congr_deriv ?_
-    rw [hFderiv]
-    rw [integral_stieltjesBernsteinDerivKernel_eq_sub hmu ht]
-    simp only [F, id_eq]
-    ring
-  have hlinear : HasDerivAt (fun u : Real => (a : Real) + (b : Real) * u) b t := by
-    simpa using ((hasDerivAt_id t).const_mul (b : Real)).const_add (a : Real)
-  refine ((hlinear.add hjump).congr_of_eventuallyEq ?_).congr_deriv rfl
-  filter_upwards [] with u
-  rw [stieltjesBernsteinTransform,
-    stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
-  rfl
-
-/-- The derivative formula for the Stieltjes--Bernstein transform at a positive parameter. -/
-theorem deriv_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNReal}
-    (hmu : Integrable stieltjesWeight mu) {t : Real} (ht : 0 < t) :
-    deriv (stieltjesBernsteinTransform mu a b) t =
-      (b : Real) + ∫ x : NNReal, (x : Real) / (t + x) ^ 2 ∂mu :=
-  (hasDerivAt_stieltjesBernsteinTransform hmu ht).deriv
+    (isCompletelyMonotoneOnIoi_integral_inv_add hμ).contDiffOn).congr fun t _ => ?_
+  simpa only [id_eq] using stieltjesBernsteinIntegral_eq_mul_integral_inv_add μ t
 
 /-- The Leibniz expansion of `t * F t` collapses to two terms, because every derivative of the
 identity beyond the first vanishes. -/
-private lemma iteratedDeriv_succ_id_mul {F : Real → Real} {n : Nat} {t : Real}
-    (hF : ContDiffAt Real (n + 1 : Nat) F t) :
-    iteratedDeriv (n + 1) (fun u : Real => u * F u) t =
-      t * iteratedDeriv (n + 1) F t + ((n : Real) + 1) * iteratedDeriv n F t := by
-  have hmulFun : (fun u : Real => u * F u) = id * F := rfl
-  rw [hmulFun, iteratedDeriv_mul contDiffAt_id hF,
+private lemma iteratedDeriv_succ_id_mul {F : ℝ → ℝ} {n : ℕ} {t : ℝ}
+    (hF : ContDiffAt ℝ (n + 1 : ℕ) F t) :
+    iteratedDeriv (n + 1) (fun u : ℝ => u * F u) t =
+      t * iteratedDeriv (n + 1) F t + ((n : ℝ) + 1) * iteratedDeriv n F t := by
+  have hmul := iteratedDeriv_fun_mul (n := n + 1) (x := t) contDiffAt_id hF
+  simp only [id_eq] at hmul
+  rw [hmul,
     ← Finset.add_sum_erase _ _ (by simp : 0 ∈ Finset.range (n + 1 + 1)),
     ← Finset.add_sum_erase _ _ (by simp : 1 ∈ (Finset.range (n + 1 + 1)).erase 0)]
   have hrest :
       (∑ x ∈ ((Finset.range (n + 1 + 1)).erase 0).erase 1,
-        ((n + 1).choose x : Real) * iteratedDeriv x id t *
+        ((n + 1).choose x : ℝ) * iteratedDeriv x id t *
           iteratedDeriv (n + 1 - x) F t) = 0 := by
     refine Finset.sum_eq_zero fun x hx => ?_
     have hx1 : x ≠ 1 := (Finset.mem_erase.mp hx).1
@@ -161,183 +138,156 @@ private lemma iteratedDeriv_succ_id_mul {F : Real → Real} {n : Nat} {t : Real}
   have hid0 : iteratedDeriv 0 id t = t := by simp
   have hid1 : iteratedDeriv 1 id t = 1 := by simp [iteratedDeriv_one]
   rw [hrest, hid0, hid1]
-  simp only [Nat.choose_zero_right, Nat.choose_one_right, Nat.cast_one, one_mul,
-    Nat.sub_zero, add_zero]
-  rw [Nat.add_sub_cancel, mul_one, Nat.cast_add, Nat.cast_one]
+  simp [Nat.choose_one_right]
 
-/-- Lowering the exponent of a Stieltjes derivative kernel by one costs a factor at most `t`,
-because `t ≤ t + x`. -/
-private lemma mul_integral_zpow_neg_two_sub_le {mu : Measure NNReal}
-    (hmu : Integrable stieltjesWeight mu) (n : Nat) {t : Real} (ht : 0 < t) :
-    (t * ∫ x : NNReal, (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu) ≤
-      ∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu := by
-  have hexpSucc : -1 - ((n + 1 : Nat) : Int) = -2 - (n : Int) := by omega
-  have hIntSucc : Integrable
-      (fun x : NNReal => (t + (x : Real)) ^ (-2 - (n : Int))) mu := by
-    simpa only [hexpSucc] using integrable_zpow_neg_one_sub_add hmu (n + 1) ht
-  rw [← integral_const_mul]
-  refine integral_mono (hIntSucc.const_mul t)
-    (integrable_zpow_neg_one_sub_add hmu n ht) fun x => ?_
-  have htx : 0 < t + (x : Real) := add_pos_of_pos_of_nonneg ht x.coe_nonneg
-  have hexp : -1 - (n : Int) = 1 + (-2 - (n : Int)) := by omega
-  rw [hexp, zpow_add₀ htx.ne', zpow_one]
-  exact mul_le_mul_of_nonneg_right (le_add_of_nonneg_right x.coe_nonneg)
-    (zpow_nonneg htx.le _)
+/-- The iterated derivatives of the integral term in the Stieltjes--Bernstein transform at a
+positive parameter. -/
+theorem iteratedDeriv_stieltjesBernsteinIntegral {μ : Measure ℝ≥0}
+    (hμ : Integrable stieltjesWeight μ) (n : ℕ) {t : ℝ} (ht : 0 < t) :
+    iteratedDeriv (n + 1) (fun u : ℝ => ∫ x : ℝ≥0, u / (u + x) ∂μ) t =
+      (-1 : ℝ) ^ n * (n + 1).factorial *
+        ∫ x : ℝ≥0, (x : ℝ) * (t + x) ^ (-2 - (n : ℤ)) ∂μ := by
+  let F := fun u : ℝ => ∫ x : ℝ≥0, (u + (x : ℝ))⁻¹ ∂μ
+  have hFdiff : ContDiffAt ℝ (n + 1 : ℕ) F t :=
+    ((isCompletelyMonotoneOnIoi_integral_inv_add hμ).contDiffOn.contDiffAt
+      (isOpen_Ioi.mem_nhds ht)).of_le (by simp)
+  have hjumpEq : (fun u : ℝ => ∫ x : ℝ≥0, u / (u + x) ∂μ) =
+      fun u => u * F u := by
+    funext u
+    exact stieltjesBernsteinIntegral_eq_mul_integral_inv_add μ u
+  rw [hjumpEq, iteratedDeriv_succ_id_mul hFdiff]
+  have hn := iteratedDeriv_integral_inv_add hμ n ht
+  have hn1 := iteratedDeriv_integral_inv_add hμ (n + 1) ht
+  have hexpSucc : -1 - ((n + 1 : ℕ) : ℤ) = -2 - (n : ℤ) := by omega
+  rw [hexpSucc] at hn1
+  rw [hn, hn1, integral_mul_zpow_eq_sub hμ n ht]
+  rw [pow_succ, Nat.factorial_succ]
+  push_cast
+  ring
+
+/-- The derivative of the Stieltjes--Bernstein transform at a positive parameter. -/
+theorem hasDerivAt_stieltjesBernsteinTransform {μ : Measure ℝ≥0} {a b : ℝ≥0}
+    (hμ : Integrable stieltjesWeight μ) {t : ℝ} (ht : 0 < t) :
+    HasDerivAt (stieltjesBernsteinTransform μ a b)
+      ((b : ℝ) + ∫ x : ℝ≥0, (x : ℝ) / (t + x) ^ 2 ∂μ) t := by
+  have hdiff : DifferentiableAt ℝ (fun u : ℝ => ∫ x : ℝ≥0, u / (u + x) ∂μ) t :=
+    ((contDiffOn_stieltjesBernsteinIntegral hμ).differentiableOn (by simp)).differentiableAt
+      (isOpen_Ioi.mem_nhds ht)
+  have hderiv : deriv (fun u : ℝ => ∫ x : ℝ≥0, u / (u + x) ∂μ) t =
+      ∫ x : ℝ≥0, (x : ℝ) / (t + x) ^ 2 ∂μ := by
+    simpa [iteratedDeriv_one, div_eq_mul_inv, zpow_neg, zpow_ofNat] using
+      iteratedDeriv_stieltjesBernsteinIntegral hμ 0 ht
+  have hlinear : HasDerivAt (fun u : ℝ => (a : ℝ) + (b : ℝ) * u) b t := by
+    simpa using ((hasDerivAt_id t).const_mul (b : ℝ)).const_add (a : ℝ)
+  refine (hlinear.add (hdiff.hasDerivAt.congr_deriv hderiv)).congr_of_eventuallyEq ?_
+  filter_upwards with u
+  rw [stieltjesBernsteinTransform_def]
+  simp only [Pi.add_apply]
+
+/-- The derivative formula for the Stieltjes--Bernstein transform at a positive parameter. -/
+theorem deriv_stieltjesBernsteinTransform {μ : Measure ℝ≥0} {a b : ℝ≥0}
+    (hμ : Integrable stieltjesWeight μ) {t : ℝ} (ht : 0 < t) :
+    deriv (stieltjesBernsteinTransform μ a b) t =
+      (b : ℝ) + ∫ x : ℝ≥0, (x : ℝ) / (t + x) ^ 2 ∂μ :=
+  (hasDerivAt_stieltjesBernsteinTransform hμ ht).deriv
 
 private lemma isCompletelyMonotoneOnIoi_deriv_stieltjesBernsteinIntegral
-    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) :
+    {μ : Measure ℝ≥0} (hμ : Integrable stieltjesWeight μ) :
     IsCompletelyMonotoneOnIoi
-      (deriv fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) := by
-  let F := fun u : Real => ∫ x : NNReal, (u + (x : Real))⁻¹ ∂mu
-  have hFcm : IsCompletelyMonotoneOnIoi F :=
-    isCompletelyMonotoneOnIoi_integral_inv_add hmu
-  have hjumpContDiff : ContDiffOn Real ∞ (fun t => t * F t) (Ioi 0) :=
-    contDiffOn_id.mul hFcm.contDiffOn
-  have hjumpEq : EqOn (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
-      (fun t => t * F t) (Ioi 0) := fun t _ =>
-    stieltjesBernsteinIntegral_eq_mul_integral_inv_add mu t
-  have hderivEq : EqOn
-      (deriv fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
-      (deriv fun t => t * F t) (Ioi 0) := fun t ht =>
-    (hjumpEq.eventuallyEq_of_mem (isOpen_Ioi.mem_nhds ht)).deriv_eq
+      (deriv fun t : ℝ => ∫ x : ℝ≥0, t / (t + x) ∂μ) := by
   refine ⟨?_, ?_⟩
-  · rw [contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi] at hjumpContDiff
-    exact hjumpContDiff.2.congr hderivEq
+  · exact ((contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi).mp
+      (contDiffOn_stieltjesBernsteinIntegral hμ)).2
   · intro n t ht
-    -- Turn the `n`-th derivative of the derivative into the `(n + 1)`-st derivative of
-    -- `t * F t`, and expand the latter by the two-term Leibniz rule.
-    have hFdiff : ContDiffAt Real (n + 1 : Nat) F t :=
-      (hFcm.contDiffOn.contDiffAt (isOpen_Ioi.mem_nhds ht)).of_le (by simp)
-    rw [(hderivEq.eventuallyEq_of_mem
-      (isOpen_Ioi.mem_nhds ht)).iteratedDeriv_eq n, ← iteratedDeriv_succ',
-      iteratedDeriv_succ_id_mul hFdiff]
-    -- Insert the two derivative formulas for `F`; the exponents are `-1 - n` and `-2 - n`.
-    have hn := iteratedDeriv_integral_inv_add hmu n ht
-    have hn1 := iteratedDeriv_integral_inv_add hmu (n + 1) ht
-    have hexpSucc : -1 - ((n + 1 : Nat) : Int) = -2 - (n : Int) := by omega
-    rw [hexpSucc] at hn1
-    rw [hn, hn1]
-    -- The two factors `(-1) ^ n` cancel, leaving `(n + 1)!` times the kernel difference.
-    have hsign : (-1 : Real) ^ n * (-1 : Real) ^ n = 1 := by
+    rw [← iteratedDeriv_succ', iteratedDeriv_stieltjesBernsteinIntegral hμ n ht]
+    have hsign : (-1 : ℝ) ^ n * (-1 : ℝ) ^ n = 1 := by
       rw [← pow_add]
       norm_num [two_mul n]
-    have heq :
-        (-1 : Real) ^ n *
-          (t * ((-1 : Real) ^ (n + 1) * (n + 1).factorial *
-              ∫ x : NNReal, (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu) +
-            ((n : Real) + 1) * ((-1 : Real) ^ n * n.factorial *
-              ∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu)) =
-          ((n + 1).factorial : Real) *
-            ((∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu) -
-              t * ∫ x : NNReal,
-                (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu) := by
-      rw [pow_succ, Nat.factorial_succ]
-      push_cast
-      calc
-        _ = ((-1 : Real) ^ n * (-1 : Real) ^ n) * ((n : Real) + 1) * n.factorial *
-              ((∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu) -
-                t * ∫ x : NNReal,
-                  (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu) := by ring
-        _ = _ := by rw [hsign]; ring
-    rw [heq]
-    exact mul_nonneg (Nat.cast_nonneg _)
-      (sub_nonneg.mpr (mul_integral_zpow_neg_two_sub_le hmu n ht))
+    calc
+      0 ≤ ((n + 1).factorial : ℝ) *
+          ∫ x : ℝ≥0, (x : ℝ) * (t + x) ^ (-2 - (n : ℤ)) ∂μ :=
+        mul_nonneg (Nat.cast_nonneg _) (integral_nonneg fun x : ℝ≥0 =>
+          mul_nonneg x.coe_nonneg (zpow_nonneg (add_nonneg ht.le x.coe_nonneg) _))
+      _ = ((-1 : ℝ) ^ n * (-1 : ℝ) ^ n) * (n + 1).factorial *
+          ∫ x : ℝ≥0, (x : ℝ) * (t + x) ^ (-2 - (n : ℤ)) ∂μ := by rw [hsign, one_mul]
+      _ = _ := by ring
 
 private lemma continuousWithinAt_stieltjesBernsteinIntegral_zero
-    {mu : Measure NNReal} (hzero : mu {0} = 0) (hmu : Integrable stieltjesWeight mu) :
-    ContinuousWithinAt (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
+    {μ : Measure ℝ≥0} (hzero : μ {0} = 0) (hμ : Integrable stieltjesWeight μ) :
+    ContinuousWithinAt (fun t : ℝ => ∫ x : ℝ≥0, t / (t + x) ∂μ)
       (Ici 0) 0 := by
-  -- Expose the filter formulation required by dominated convergence.
-  change Tendsto (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (nhdsWithin 0 (Ici 0))
-    (nhds (∫ x : NNReal, (0 : Real) / (0 + x) ∂mu))
-  have hDCT : Tendsto (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
-      (nhdsWithin 0 (Ici 0)) (nhds (∫ _x : NNReal, (0 : Real) ∂mu)) := by
-    refine tendsto_integral_filter_of_dominated_convergence
-      (μ := mu) (l := nhdsWithin (0 : Real) (Ici 0))
-      (F := fun (t : Real) (x : NNReal) => t / (t + (x : Real)))
-      (f := fun _ : NNReal => (0 : Real))
-      (bound := stieltjesWeight) ?_ ?_ hmu ?_
-    · filter_upwards [eventually_mem_nhdsWithin] with t ht
-      by_cases ht0 : t = 0
-      · subst t
-        simpa using
-          (continuous_const : Continuous fun _ : NNReal => (0 : Real)).aestronglyMeasurable
-      · have htpos : 0 < t := lt_of_le_of_ne ht (Ne.symm ht0)
-        exact (continuous_const.div (continuous_const.add NNReal.continuous_coe)
-          fun x => (add_pos_of_pos_of_nonneg htpos x.coe_nonneg).ne').aestronglyMeasurable
-    · have hlt : ∀ᶠ t in nhdsWithin (0 : Real) (Ici 0), t < 1 :=
-        nhdsWithin_le_nhds (Iio_mem_nhds (by norm_num))
-      filter_upwards [eventually_mem_nhdsWithin, hlt] with t ht ht_one
-      filter_upwards with x
-      rw [Real.norm_eq_abs, abs_of_nonneg (div_nonneg ht (add_nonneg ht x.coe_nonneg))]
-      rw [stieltjesWeight_apply]
-      by_cases ht0 : t = 0
-      · subst t
-        rw [zero_div]
-        exact inv_nonneg.mpr (by positivity)
-      · have htpos : 0 < t := lt_of_le_of_ne ht (Ne.symm ht0)
-        have hden : 0 < t + (x : Real) := add_pos_of_pos_of_nonneg htpos x.coe_nonneg
-        have h1x : 0 < 1 + (x : Real) := by positivity
-        rw [inv_eq_one_div, div_le_div_iff₀ hden h1x]
-        nlinarith [mul_nonneg ht x.coe_nonneg]
-    · have hne : ∀ᵐ x ∂mu, x ≠ 0 := by
-        rw [ae_iff]
-        simp [hzero]
-      filter_upwards [hne] with x hx
-      have hx0 : (x : Real) ≠ 0 := NNReal.coe_ne_zero.mpr hx
-      have hid : Tendsto id (nhdsWithin (0 : Real) (Ici 0)) (nhds 0) :=
-        tendsto_id.mono_left nhdsWithin_le_nhds
-      have hquot := hid.div (hid.add_const (x : Real)) (by simpa using hx0)
-      have hquot' : Tendsto (id / fun y : Real => y + (x : Real))
-          (nhdsWithin 0 (Ici 0)) (nhds 0) := by simpa using hquot
-      refine hquot'.congr' ?_
-      filter_upwards with y
-      rfl
-  simpa using hDCT
+  refine continuousWithinAt_of_dominated (μ := μ) (bound := stieltjesWeight) ?_ ?_ hμ ?_
+  · exact Filter.Eventually.of_forall fun _ =>
+      (measurable_const.div
+        (measurable_const.add NNReal.continuous_coe.measurable)).aestronglyMeasurable
+  · have hlt : ∀ᶠ t in nhdsWithin (0 : ℝ) (Ici 0), t < 1 :=
+      nhdsWithin_le_nhds (Iio_mem_nhds (by norm_num))
+    filter_upwards [eventually_mem_nhdsWithin, hlt] with t ht ht_one
+    filter_upwards with x
+    rw [Real.norm_eq_abs, abs_of_nonneg (div_nonneg ht (add_nonneg ht x.coe_nonneg))]
+    rw [stieltjesWeight_apply]
+    by_cases ht0 : t = 0
+    · subst t
+      rw [zero_div]
+      exact inv_nonneg.mpr (by positivity)
+    · have htpos : 0 < t := lt_of_le_of_ne ht (Ne.symm ht0)
+      have hden : 0 < t + (x : ℝ) := add_pos_of_pos_of_nonneg htpos x.coe_nonneg
+      have h1x : 0 < 1 + (x : ℝ) := by positivity
+      rw [inv_eq_one_div, div_le_div_iff₀ hden h1x]
+      nlinarith [mul_nonneg ht x.coe_nonneg]
+  · have hne : ∀ᵐ x ∂μ, x ≠ 0 := by
+      rw [ae_iff]
+      simp [hzero]
+    filter_upwards [hne] with x hx
+    have hx0 : (x : ℝ) ≠ 0 := NNReal.coe_ne_zero.mpr hx
+    exact (continuousAt_id.div (continuousAt_id.add continuousAt_const)
+      (by simpa using hx0)).continuousWithinAt
 
-private lemma isBernsteinFunction_stieltjesBernsteinIntegral {mu : Measure NNReal}
-    (hzero : mu {0} = 0) (hmu : Integrable stieltjesWeight mu) :
-    IsBernsteinFunction (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) := by
+/-- The integral term in the Stieltjes--Bernstein transform is a Bernstein function under the
+normalization and integrability hypotheses on the representing measure. -/
+theorem isBernsteinFunction_stieltjesBernsteinIntegral {μ : Measure ℝ≥0}
+    (hzero : μ {0} = 0) (hμ : Integrable stieltjesWeight μ) :
+    IsBernsteinFunction (fun t : ℝ => ∫ x : ℝ≥0, t / (t + x) ∂μ) := by
   have hjumpCont : ContinuousOn
-      (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (Ici 0) := by
+      (fun t : ℝ => ∫ x : ℝ≥0, t / (t + x) ∂μ) (Ici 0) := by
     intro t ht
     have ht' : 0 ≤ t := ht
     rcases ht'.eq_or_lt with rfl | ht
-    · exact continuousWithinAt_stieltjesBernsteinIntegral_zero hzero hmu
-    · exact ((contDiffOn_stieltjesBernsteinIntegral hmu).contDiffAt
+    · exact continuousWithinAt_stieltjesBernsteinIntegral_zero hzero hμ
+    · exact ((contDiffOn_stieltjesBernsteinIntegral hμ).contDiffAt
         (isOpen_Ioi.mem_nhds ht)).continuousAt.continuousWithinAt
   rw [isBernsteinFunction_iff]
-  exact ⟨hjumpCont, contDiffOn_stieltjesBernsteinIntegral hmu,
+  exact ⟨hjumpCont, contDiffOn_stieltjesBernsteinIntegral hμ,
     fun t ht => integral_nonneg fun x => div_nonneg ht (add_nonneg ht x.coe_nonneg),
-    isCompletelyMonotoneOnIoi_deriv_stieltjesBernsteinIntegral hmu⟩
+    isCompletelyMonotoneOnIoi_deriv_stieltjesBernsteinIntegral hμ⟩
 
 /-- The transform built from normalized Stieltjes representing data is a Bernstein function. -/
-theorem isBernsteinFunction_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNReal}
-    (hzero : mu {0} = 0) (hmu : Integrable stieltjesWeight mu) :
-    IsBernsteinFunction (stieltjesBernsteinTransform mu a b) := by
+theorem isBernsteinFunction_stieltjesBernsteinTransform {μ : Measure ℝ≥0} {a b : ℝ≥0}
+    (hzero : μ {0} = 0) (hμ : Integrable stieltjesWeight μ) :
+    IsBernsteinFunction (stieltjesBernsteinTransform μ a b) := by
   apply ((isBernsteinFunction_affine a.coe_nonneg b.coe_nonneg).add
-    (isBernsteinFunction_stieltjesBernsteinIntegral hzero hmu)).congr
+    (isBernsteinFunction_stieltjesBernsteinIntegral hzero hμ)).congr
   intro t _
-  rw [stieltjesBernsteinTransform]
+  rw [stieltjesBernsteinTransform_def]
   simp only [Pi.add_apply]
 
 namespace RepresentsStieltjes
 
-variable {mu : Measure NNReal} {a b : NNReal} {f : Real → Real}
+variable {μ : Measure ℝ≥0} {a b : ℝ≥0} {f : ℝ → ℝ}
 
 /-- Multiplying a represented Stieltjes function by its parameter gives the associated Bernstein
 transform on the open half-line. -/
-theorem stieltjesBernsteinTransform_eq_mul (h : RepresentsStieltjes mu a b f) {t : Real}
-    (ht : 0 < t) : stieltjesBernsteinTransform mu a b t = t * f t := by
-  rw [h.eq_div_add_add_integral_inv_add ht, stieltjesBernsteinTransform]
+theorem stieltjesBernsteinTransform_eq_mul (h : RepresentsStieltjes μ a b f) {t : ℝ}
+    (ht : 0 < t) : stieltjesBernsteinTransform μ a b t = t * f t := by
+  rw [h.eq_div_add_add_integral_inv_add ht, stieltjesBernsteinTransform_def]
   rw [stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
   field_simp [ht.ne']
 
 /-- The transform attached to a Stieltjes representation is a Bernstein function.  Its agreement
 with `t * f(t)` on `(0, ∞)` is `RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul`, and its
 boundary value at zero is `stieltjesBernsteinTransform_zero`. -/
-theorem isBernsteinFunction_stieltjesBernsteinTransform (h : RepresentsStieltjes mu a b f) :
-    IsBernsteinFunction (stieltjesBernsteinTransform mu a b) :=
+theorem isBernsteinFunction_stieltjesBernsteinTransform (h : RepresentsStieltjes μ a b f) :
+    IsBernsteinFunction (stieltjesBernsteinTransform μ a b) :=
   TauCeti.isBernsteinFunction_stieltjesBernsteinTransform
     h.measure_singleton_zero h.integrable_weight
 
@@ -345,15 +295,15 @@ end RepresentsStieltjes
 
 namespace IsStieltjesFunction
 
-variable {f : Real → Real}
+variable {f : ℝ → ℝ}
 
 /-- Every Stieltjes function has a Bernstein extension of its product with the parameter on the
 open positive half-line. -/
-theorem exists_isBernsteinFunction_eq_mul (h : IsStieltjesFunction f) :
-    ∃ g : Real → Real, IsBernsteinFunction g ∧ EqOn g (fun t => t * f t) (Ioi 0) := by
+theorem exists_isBernsteinFunction_eqOn_mul (h : IsStieltjesFunction f) :
+    ∃ g : ℝ → ℝ, IsBernsteinFunction g ∧ EqOn g (fun t => t * f t) (Ioi 0) := by
   rw [isStieltjesFunction_iff] at h
-  obtain ⟨a, b, mu, hrep⟩ := h
-  exact ⟨stieltjesBernsteinTransform mu a b,
+  obtain ⟨a, b, μ, hrep⟩ := h
+  exact ⟨stieltjesBernsteinTransform μ a b,
     hrep.isBernsteinFunction_stieltjesBernsteinTransform,
     fun _ ht => hrep.stieltjesBernsteinTransform_eq_mul ht⟩
 

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
@@ -1,0 +1,401 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Stieltjes.CompletelyMonotone
+public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Basic
+import Mathlib.Analysis.Calculus.ParametricIntegral
+import Mathlib.Analysis.Calculus.Deriv.ZPow
+import Mathlib.MeasureTheory.Integral.DominatedConvergence
+
+/-!
+# From Stieltjes functions to Bernstein functions
+
+If
+
+`f(t) = a / t + b + integral x, (t + x)^(-1) partial mu`,
+
+then its continuously extended product with the parameter is a Bernstein function:
+
+`g(t) = a + b * t + integral x, t / (t + x) partial mu`.
+
+On the open half-line this is exactly `t * f(t)`, while `g(0) = a`.  The value at zero is
+essential: the literal product `0 * f(0)` would lose the coefficient of the possible `a / t`
+singularity.  This is the first standard Stieltjes--Bernstein correspondence.
+
+The proof differentiates the integral on the open half-line.  Its derivative is
+
+`integral x, x / (t + x)^2 partial mu`,
+
+whose derivatives have alternating signs.  Continuity at zero follows by dominated convergence;
+the normalization `mu {0} = 0` removes the only point where `t / (t + x)` does not tend to zero.
+
+## Main declarations
+
+* `TauCeti.stieltjesBernsteinTransform`: the continuous extension of `t * f(t)` written directly
+  from Stieltjes representing data.
+* `TauCeti.isBernsteinFunction_stieltjesBernsteinTransform`: the transform is Bernstein.
+* `TauCeti.RepresentsStieltjes.isBernsteinFunction_transform`: a Stieltjes representation produces
+  a Bernstein extension agreeing with `t * f(t)` on `(0, infinity)`.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondracek, *Bernstein Functions: Theory and Applications*,
+  de Gruyter, 2nd ed. (2012), Chapter 7.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set Filter
+open scoped ContDiff Topology
+
+namespace TauCeti
+
+/-- The Bernstein function associated to Stieltjes representing data.  For positive `t`, this is
+`t` times the represented Stieltjes function; the formula also supplies its continuous value `a`
+at zero. -/
+def stieltjesBernsteinTransform (mu : Measure NNReal) (a b : NNReal) (t : Real) : Real :=
+  a + b * t + ∫ x : NNReal, t / (t + x) ∂mu
+
+/-- Evaluation of the Stieltjes--Bernstein transform. -/
+@[simp]
+theorem stieltjesBernsteinTransform_apply (mu : Measure NNReal) (a b : NNReal) (t : Real) :
+    stieltjesBernsteinTransform mu a b t =
+      a + b * t + ∫ x : NNReal, t / (t + x) ∂mu := by
+  rw [stieltjesBernsteinTransform]
+
+/-- The Stieltjes--Bernstein transform takes the value `a` at zero. -/
+@[simp]
+theorem stieltjesBernsteinTransform_zero (mu : Measure NNReal) (a b : NNReal) :
+    stieltjesBernsteinTransform mu a b 0 = a := by
+  simp
+
+private def stieltjesBernsteinDerivKernel (n : Nat) (t : Real) (x : NNReal) : Real :=
+  (-1 : Real) ^ n * (n + 1).factorial * x *
+    (t + (x : Real)) ^ (-2 - (n : Int))
+
+private def stieltjesBernsteinDerivIntegral (mu : Measure NNReal) (n : Nat) (t : Real) : Real :=
+  ∫ x, stieltjesBernsteinDerivKernel n t x ∂mu
+
+private lemma stieltjesBernsteinDerivKernel_zero (t : Real) (x : NNReal) :
+    stieltjesBernsteinDerivKernel 0 t x = (x : Real) / (t + x) ^ 2 := by
+  simp [stieltjesBernsteinDerivKernel, zpow_neg, div_eq_mul_inv]
+
+private lemma hasDerivAt_stieltjesBernsteinDerivKernel (n : Nat) (x : NNReal) {t : Real}
+    (ht : 0 < t) :
+    HasDerivAt (fun u => stieltjesBernsteinDerivKernel n u x)
+      (stieltjesBernsteinDerivKernel (n + 1) t x) t := by
+  have hne : t + (x : Real) ≠ 0 := (add_pos_of_pos_of_nonneg ht x.coe_nonneg).ne'
+  have hbase : HasDerivAt (fun u : Real => u + (x : Real)) 1 t := by
+    simpa using (hasDerivAt_id t).add_const (x : Real)
+  have hpow := (hasDerivAt_zpow (-2 - (n : Int)) (t + (x : Real)) (Or.inl hne)).comp t hbase
+  have h := hpow.const_mul ((-1 : Real) ^ n * (n + 1).factorial * (x : Real))
+  refine (h.congr_of_eventuallyEq ?_).congr_deriv ?_
+  · filter_upwards [] with u
+    simp only [stieltjesBernsteinDerivKernel, Function.comp_def]
+  · unfold stieltjesBernsteinDerivKernel
+    have hexp : -2 - ((n + 1 : Nat) : Int) = -2 - (n : Int) - 1 := by omega
+    rw [hexp]
+    push_cast [Nat.factorial_succ]
+    ring
+
+private lemma integrable_stieltjesBernsteinDerivKernel
+    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) (n : Nat) {t : Real}
+    (ht : 0 < t) : Integrable (stieltjesBernsteinDerivKernel n t) mu := by
+  have hbase := integrable_zpow_neg_one_sub_add hmu n ht
+  refine (hbase.const_mul ((n + 1).factorial : Real)).mono' ?_ ?_
+  · have hpowCont : Continuous (fun x : NNReal =>
+        (t + (x : Real)) ^ (-2 - (n : Int))) :=
+      (by fun_prop : Continuous fun x : NNReal => t + (x : Real)).zpow₀ _ fun x =>
+        Or.inl (add_pos_of_pos_of_nonneg ht x.coe_nonneg).ne'
+    exact (((continuous_const.mul continuous_const).mul NNReal.continuous_coe).mul
+      hpowCont).aestronglyMeasurable
+  filter_upwards with x
+  have htx : 0 < t + (x : Real) := add_pos_of_pos_of_nonneg ht x.coe_nonneg
+  have hpow : (x : Real) * (t + (x : Real)) ^ (-2 - (n : Int)) ≤
+      (t + (x : Real)) ^ (-1 - (n : Int)) := by
+    rw [show -1 - (n : Int) = 1 + (-2 - (n : Int)) by omega,
+      zpow_add₀ htx.ne', zpow_one]
+    exact mul_le_mul_of_nonneg_right (le_add_of_nonneg_left ht.le)
+      (zpow_nonneg htx.le _)
+  simpa only [stieltjesBernsteinDerivKernel, Real.norm_eq_abs, abs_mul, abs_pow, abs_neg,
+    abs_one, one_pow, Nat.abs_cast, abs_of_nonneg x.coe_nonneg,
+    abs_of_pos (zpow_pos htx _), mul_assoc, one_mul] using
+      mul_le_mul_of_nonneg_left hpow (Nat.cast_nonneg (n + 1).factorial)
+
+private lemma zpow_neg_le_zpow_neg {a b : Real} (ha : 0 < a) (hab : a ≤ b) (k : Nat) :
+    b ^ (-(k : Int)) ≤ a ^ (-(k : Int)) := by
+  rw [zpow_neg, zpow_natCast, zpow_neg, zpow_natCast]
+  exact (inv_le_inv₀ (pow_pos (ha.trans_le hab) k) (pow_pos ha k)).2
+    (pow_le_pow_left₀ ha.le hab k)
+
+private lemma norm_stieltjesBernsteinDerivKernel_le (n : Nat) (x : NNReal) {r t : Real}
+    (hr : 0 < r) (hrt : r <= t) :
+    norm (stieltjesBernsteinDerivKernel n t x) <=
+      norm (stieltjesBernsteinDerivKernel n r x) := by
+  have hrx : 0 < r + (x : Real) := add_pos_of_pos_of_nonneg hr x.coe_nonneg
+  have htx : 0 < t + (x : Real) := by linarith
+  have hexp : -2 - (n : Int) = -((n + 2 : Nat) : Int) := by omega
+  have hpow := zpow_neg_le_zpow_neg hrx (by linarith : r + (x : Real) ≤ t + x) (n + 2)
+  simp only [stieltjesBernsteinDerivKernel, hexp, Real.norm_eq_abs, abs_mul, abs_pow, abs_neg,
+    abs_one, one_pow, Nat.abs_cast, abs_of_nonneg x.coe_nonneg,
+    abs_of_pos (zpow_pos htx _), abs_of_pos (zpow_pos hrx _)]
+  have hcoeff : 0 ≤ (1 : Real) * ((n + 1).factorial : Real) * (x : Real) := by positivity
+  exact mul_le_mul_of_nonneg_left hpow hcoeff
+
+private lemma hasDerivAt_stieltjesBernsteinDerivIntegral
+    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) (n : Nat) {t : Real}
+    (ht : 0 < t) :
+    HasDerivAt (stieltjesBernsteinDerivIntegral mu n)
+      (stieltjesBernsteinDerivIntegral mu (n + 1) t) t := by
+  let r := t / 2
+  have hr : 0 < r := by dsimp [r]; linarith
+  have htr : t ∈ Ioi r := by change r < t; dsimp [r]; linarith
+  have hs : Ioi r ∈ nhds t := isOpen_Ioi.mem_nhds htr
+  have hmeas : ∀ᶠ u in nhds t,
+      AEStronglyMeasurable (stieltjesBernsteinDerivKernel n u) mu := by
+    filter_upwards [hs] with u hu
+    exact (integrable_stieltjesBernsteinDerivKernel hmu n (hr.trans hu)).aestronglyMeasurable
+  have hderivMeas : AEStronglyMeasurable (stieltjesBernsteinDerivKernel (n + 1) t) mu :=
+    (integrable_stieltjesBernsteinDerivKernel hmu (n + 1) ht).aestronglyMeasurable
+  have hbound : ∀ᵐ x ∂mu, ∀ u ∈ Ioi r,
+      ‖stieltjesBernsteinDerivKernel (n + 1) u x‖ ≤
+        ‖stieltjesBernsteinDerivKernel (n + 1) r x‖ := by
+    filter_upwards with x
+    intro u hu
+    exact norm_stieltjesBernsteinDerivKernel_le (n + 1) x hr hu.le
+  have hdiff : ∀ᵐ x ∂mu, ∀ u ∈ Ioi r,
+      HasDerivAt (fun v => stieltjesBernsteinDerivKernel n v x)
+        (stieltjesBernsteinDerivKernel (n + 1) u x) u := by
+    filter_upwards with x
+    intro u hu
+    exact hasDerivAt_stieltjesBernsteinDerivKernel n x (hr.trans hu)
+  exact (hasDerivAt_integral_of_dominated_loc_of_deriv_le hs hmeas
+    (integrable_stieltjesBernsteinDerivKernel hmu n ht) hderivMeas hbound
+    (integrable_stieltjesBernsteinDerivKernel hmu (n + 1) hr).norm hdiff).2
+
+private lemma contDiffOn_stieltjesBernsteinDerivIntegral
+    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) (n : Nat) :
+    ContDiffOn Real ∞ (stieltjesBernsteinDerivIntegral mu n) (Ioi 0) := by
+  rw [contDiffOn_infty]
+  intro k
+  induction k generalizing n with
+  | zero =>
+      exact contDiffOn_zero.mpr fun t ht =>
+        (hasDerivAt_stieltjesBernsteinDerivIntegral hmu n ht).continuousAt.continuousWithinAt
+  | succ k ih =>
+      rw [Nat.cast_succ, contDiffOn_succ_iff_deriv_of_isOpen isOpen_Ioi]
+      refine ⟨fun t ht =>
+          DifferentiableAt.differentiableWithinAt
+            (hasDerivAt_stieltjesBernsteinDerivIntegral hmu n ht).differentiableAt
+        , by simp, ?_⟩
+      exact (ih (n + 1)).congr fun t ht =>
+        (hasDerivAt_stieltjesBernsteinDerivIntegral hmu n ht).deriv
+
+private lemma iteratedDeriv_stieltjesBernsteinDerivIntegral_zero
+    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) (n : Nat) {t : Real}
+    (ht : 0 < t) :
+    iteratedDeriv n (stieltjesBernsteinDerivIntegral mu 0) t =
+      stieltjesBernsteinDerivIntegral mu n t := by
+  induction n generalizing t with
+  | zero => simp [iteratedDeriv_zero]
+  | succ n ih =>
+      have heq : iteratedDeriv n (stieltjesBernsteinDerivIntegral mu 0) =ᶠ[nhds t]
+          stieltjesBernsteinDerivIntegral mu n := by
+        filter_upwards [isOpen_Ioi.mem_nhds ht] with u hu using ih hu
+      rw [iteratedDeriv_succ, heq.deriv_eq,
+        (hasDerivAt_stieltjesBernsteinDerivIntegral hmu n ht).deriv, Nat.add_comm n 1]
+
+private lemma isCompletelyMonotoneOnIoi_stieltjesBernsteinDerivIntegral
+    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) :
+    IsCompletelyMonotoneOnIoi (stieltjesBernsteinDerivIntegral mu 0) := by
+  refine ⟨contDiffOn_stieltjesBernsteinDerivIntegral hmu 0, ?_⟩
+  intro n t ht
+  rw [iteratedDeriv_stieltjesBernsteinDerivIntegral_zero hmu n ht,
+    stieltjesBernsteinDerivIntegral]
+  have hint : 0 ≤ ∫ x : NNReal,
+      (x : Real) * (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu :=
+    integral_nonneg fun x => mul_nonneg x.coe_nonneg
+      (zpow_pos (add_pos_of_pos_of_nonneg ht x.coe_nonneg) _).le
+  have hconst : 0 ≤ ((-1 : Real) ^ n) ^ 2 * (n + 1).factorial :=
+    mul_nonneg (sq_nonneg _) (Nat.cast_nonneg _)
+  rw [show (fun x => stieltjesBernsteinDerivKernel n t x) =
+      fun x : NNReal => ((-1 : Real) ^ n * (n + 1).factorial) *
+        ((x : Real) * (t + (x : Real)) ^ (-2 - (n : Int))) by
+    funext x
+    simp only [stieltjesBernsteinDerivKernel]
+    ring]
+  rw [integral_const_mul]
+  nlinarith
+
+private lemma hasDerivAt_stieltjesBernsteinIntegral
+    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) {t : Real} (ht : 0 < t) :
+    HasDerivAt (fun u : Real => ∫ x : NNReal, u / (u + x) ∂mu)
+      (stieltjesBernsteinDerivIntegral mu 0 t) t := by
+  let r := t / 2
+  have hr : 0 < r := by dsimp [r]; linarith
+  have htr : t ∈ Ioi r := by change r < t; dsimp [r]; linarith
+  have hs : Ioi r ∈ nhds t := isOpen_Ioi.mem_nhds htr
+  have hmeas : ∀ᶠ u : Real in nhds t,
+      AEStronglyMeasurable (fun x : NNReal => u / (u + (x : Real))) mu := by
+    filter_upwards [hs] with u hu
+    exact ((integrable_inv_add hmu (hr.trans hu)).const_mul u).aestronglyMeasurable
+  have hderivMeas : AEStronglyMeasurable (stieltjesBernsteinDerivKernel 0 t) mu :=
+    (integrable_stieltjesBernsteinDerivKernel hmu 0 ht).aestronglyMeasurable
+  have hbound : ∀ᵐ x ∂mu, ∀ u ∈ Ioi r,
+      ‖stieltjesBernsteinDerivKernel 0 u x‖ ≤
+        ‖stieltjesBernsteinDerivKernel 0 r x‖ := by
+    filter_upwards with x
+    intro u hu
+    exact norm_stieltjesBernsteinDerivKernel_le 0 x hr hu.le
+  have hdiff : ∀ᵐ x : NNReal ∂mu, ∀ u ∈ Ioi r,
+      HasDerivAt (fun v : Real => v / (v + (x : Real)))
+        (stieltjesBernsteinDerivKernel 0 u x) u := by
+    filter_upwards with x
+    intro u hu
+    have hne : u + (x : Real) ≠ 0 :=
+      (add_pos_of_pos_of_nonneg (hr.trans hu) x.coe_nonneg).ne'
+    have hden : HasDerivAt (fun v : Real => v + x) 1 u := by
+      simpa using (hasDerivAt_id u).add_const (x : Real)
+    have hform := (hasDerivAt_const u (1 : Real)).sub ((hden.inv hne).const_mul (x : Real))
+    refine (hform.congr_of_eventuallyEq ?_).congr_deriv ?_
+    · filter_upwards [hden.continuousAt.eventually_ne hne] with v hv
+      change v / (v + (x : Real)) = (1 : Real) - (x : Real) * (v + x)⁻¹
+      field_simp
+      ring
+    · change 0 - (x : Real) * (-1 / (u + x) ^ 2) =
+        stieltjesBernsteinDerivKernel 0 u x
+      rw [stieltjesBernsteinDerivKernel_zero]
+      field_simp
+      ring
+  exact (hasDerivAt_integral_of_dominated_loc_of_deriv_le hs hmeas
+    ((integrable_inv_add hmu ht).const_mul t) hderivMeas hbound
+    (integrable_stieltjesBernsteinDerivKernel hmu 0 hr).norm hdiff).2
+
+private lemma continuousWithinAt_stieltjesBernsteinIntegral_zero
+    {mu : Measure NNReal} (hzero : mu {0} = 0) (hmu : Integrable stieltjesWeight mu) :
+    ContinuousWithinAt (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
+      (Ici 0) 0 := by
+  change Tendsto (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (nhdsWithin 0 (Ici 0))
+    (nhds (∫ x : NNReal, (0 : Real) / (0 + x) ∂mu))
+  have hDCT : Tendsto (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
+      (nhdsWithin 0 (Ici 0)) (nhds (∫ _x : NNReal, (0 : Real) ∂mu)) := by
+    refine tendsto_integral_filter_of_dominated_convergence
+      (μ := mu) (l := nhdsWithin (0 : Real) (Ici 0))
+      (F := fun (t : Real) (x : NNReal) => t / (t + (x : Real)))
+      (f := fun _ : NNReal => (0 : Real))
+      (bound := stieltjesWeight) ?_ ?_ hmu ?_
+    · filter_upwards [eventually_mem_nhdsWithin] with t ht
+      by_cases ht0 : t = 0
+      · subst t
+        simpa using
+          (continuous_const : Continuous fun _ : NNReal => (0 : Real)).aestronglyMeasurable
+      · have htpos : 0 < t := lt_of_le_of_ne ht (Ne.symm ht0)
+        exact (continuous_const.div (continuous_const.add NNReal.continuous_coe)
+          fun x => (add_pos_of_pos_of_nonneg htpos x.coe_nonneg).ne').aestronglyMeasurable
+    · have hlt : ∀ᶠ t in nhdsWithin (0 : Real) (Ici 0), t < 1 :=
+        nhdsWithin_le_nhds (Iio_mem_nhds (by norm_num))
+      filter_upwards [eventually_mem_nhdsWithin, hlt] with t ht ht_one
+      filter_upwards with x
+      rw [Real.norm_eq_abs, abs_of_nonneg (div_nonneg ht (add_nonneg ht x.coe_nonneg))]
+      rw [stieltjesWeight_apply]
+      by_cases ht0 : t = 0
+      · subst t
+        rw [zero_div]
+        exact inv_nonneg.mpr (by positivity)
+      · have htpos : 0 < t := lt_of_le_of_ne ht (Ne.symm ht0)
+        have hden : 0 < t + (x : Real) := add_pos_of_pos_of_nonneg htpos x.coe_nonneg
+        have h1x : 0 < 1 + (x : Real) := by positivity
+        rw [inv_eq_one_div, div_le_div_iff₀ hden h1x]
+        nlinarith [mul_nonneg ht x.coe_nonneg]
+    · have hne : ∀ᵐ x ∂mu, x ≠ 0 := by
+        rw [ae_iff]
+        simp [hzero]
+      filter_upwards [hne] with x hx
+      have hx0 : (x : Real) ≠ 0 := NNReal.coe_ne_zero.mpr hx
+      have hid : Tendsto id (nhdsWithin (0 : Real) (Ici 0)) (nhds 0) :=
+        tendsto_id.mono_left nhdsWithin_le_nhds
+      have hquot := hid.div (hid.add_const (x : Real)) (by simpa using hx0)
+      have hquot' : Tendsto (id / fun y : Real => y + (x : Real))
+          (nhdsWithin 0 (Ici 0)) (nhds 0) := by simpa using hquot
+      refine hquot'.congr' ?_
+      filter_upwards with y
+      rfl
+  simpa using hDCT
+
+/-- The transform built from normalized Stieltjes representing data is a Bernstein function. -/
+theorem isBernsteinFunction_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNReal}
+    (hzero : mu {0} = 0) (hmu : Integrable stieltjesWeight mu) :
+    IsBernsteinFunction (stieltjesBernsteinTransform mu a b) := by
+  have hjump_cont : ContinuousOn
+      (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (Ici 0) := by
+    intro t ht
+    have ht' : 0 ≤ t := ht
+    rcases ht'.eq_or_lt with rfl | ht
+    · exact continuousWithinAt_stieltjesBernsteinIntegral_zero hzero hmu
+    · exact (hasDerivAt_stieltjesBernsteinIntegral hmu ht).continuousAt.continuousWithinAt
+  have hderiv : EqOn (deriv (stieltjesBernsteinTransform mu a b))
+      (fun t => (b : Real) + stieltjesBernsteinDerivIntegral mu 0 t) (Ioi 0) := by
+    intro t ht
+    have hlin : HasDerivAt (fun u : Real => (a : Real) + (b : Real) * u) b t := by
+      simpa using ((hasDerivAt_id t).const_mul (b : Real)).const_add (a : Real)
+    unfold stieltjesBernsteinTransform
+    exact (hlin.add (hasDerivAt_stieltjesBernsteinIntegral hmu ht)).deriv
+  rw [isBernsteinFunction_iff]
+  have hjump_diff : DifferentiableOn Real
+      (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (Ioi 0) := fun t ht =>
+    (hasDerivAt_stieltjesBernsteinIntegral hmu ht).differentiableAt.differentiableWithinAt
+  have hjump_deriv : EqOn (deriv fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
+      (stieltjesBernsteinDerivIntegral mu 0) (Ioi 0) := fun t ht =>
+    (hasDerivAt_stieltjesBernsteinIntegral hmu ht).deriv
+  have hjump_contDiff : ContDiffOn Real ∞
+      (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (Ioi 0) := by
+    rw [contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi]
+    exact ⟨hjump_diff,
+      (contDiffOn_stieltjesBernsteinDerivIntegral hmu 0).congr hjump_deriv⟩
+  refine ⟨(continuousOn_const.add (continuousOn_const.mul continuousOn_id)).add hjump_cont,
+    ?_, ?_, ?_⟩
+  · exact ((contDiffOn_const.add (contDiffOn_const.mul contDiffOn_id)).add
+      hjump_contDiff).congr fun _ _ => (stieltjesBernsteinTransform_apply mu a b _).symm
+  · intro t ht
+    exact add_nonneg (add_nonneg a.coe_nonneg (mul_nonneg b.coe_nonneg ht))
+      (integral_nonneg fun x => div_nonneg ht (add_nonneg ht x.coe_nonneg))
+  · exact ((isCompletelyMonotone_const b.coe_nonneg).isCompletelyMonotoneOnIoi.add
+      (isCompletelyMonotoneOnIoi_stieltjesBernsteinDerivIntegral hmu)).congr hderiv
+
+namespace RepresentsStieltjes
+
+variable {mu : Measure NNReal} {a b : NNReal} {f : Real → Real}
+
+/-- Multiplying a represented Stieltjes function by its parameter gives the associated Bernstein
+transform on the open half-line. -/
+theorem stieltjesBernsteinTransform_eq_mul (h : RepresentsStieltjes mu a b f) {t : Real}
+    (ht : 0 < t) : stieltjesBernsteinTransform mu a b t = t * f t := by
+  rw [h.eq_div_add_add_integral_inv_add ht, stieltjesBernsteinTransform_apply]
+  have hint : (∫ x : NNReal, t / (t + x) ∂mu) =
+      t * ∫ x : NNReal, (t + x)⁻¹ ∂mu := by
+    rw [← integral_const_mul]
+    apply integral_congr_ae
+    filter_upwards with x
+    simp [div_eq_mul_inv]
+  rw [hint]
+  field_simp [ht.ne']
+
+/-- A Stieltjes representation produces a Bernstein function that agrees with `t * f(t)` for
+every positive `t` and has the canonical boundary value `a` at zero. -/
+theorem isBernsteinFunction_transform (h : RepresentsStieltjes mu a b f) :
+    IsBernsteinFunction (stieltjesBernsteinTransform mu a b) :=
+  isBernsteinFunction_stieltjesBernsteinTransform h.measure_singleton_zero h.integrable_weight
+
+end RepresentsStieltjes
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
@@ -70,7 +70,6 @@ theorem stieltjesBernsteinTransform_apply (mu : Measure NNReal) (a b : NNReal) (
   rw [stieltjesBernsteinTransform]
 
 /-- The Stieltjes--Bernstein transform takes the value `a` at zero. -/
-@[simp]
 theorem stieltjesBernsteinTransform_zero (mu : Measure NNReal) (a b : NNReal) :
     stieltjesBernsteinTransform mu a b 0 = a := by
   simp

--- a/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean
@@ -9,7 +9,6 @@ public import TauCeti.Analysis.CompletelyMonotone.Stieltjes.CompletelyMonotone
 public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Basic
 import Mathlib.Analysis.Calculus.ParametricIntegral
 import Mathlib.Analysis.Calculus.Deriv.ZPow
-import Mathlib.MeasureTheory.Integral.DominatedConvergence
 
 /-!
 # From Stieltjes functions to Bernstein functions
@@ -38,8 +37,10 @@ the normalization `mu {0} = 0` removes the only point where `t / (t + x)` does n
 * `TauCeti.stieltjesBernsteinTransform`: the continuous extension of `t * f(t)` written directly
   from Stieltjes representing data.
 * `TauCeti.isBernsteinFunction_stieltjesBernsteinTransform`: the transform is Bernstein.
-* `TauCeti.RepresentsStieltjes.isBernsteinFunction_transform`: a Stieltjes representation produces
-  a Bernstein extension agreeing with `t * f(t)` on `(0, infinity)`.
+* `TauCeti.RepresentsStieltjes.isBernsteinFunction_stieltjesBernsteinTransform`: a Stieltjes
+  representation produces a Bernstein extension agreeing with `t * f(t)` on `(0, infinity)`.
+* `TauCeti.IsStieltjesFunction.exists_isBernsteinFunction_eq_mul`: every Stieltjes function has
+  a Bernstein extension of its product with the parameter on `(0, infinity)`.
 
 ## References
 
@@ -56,9 +57,11 @@ open scoped ContDiff Topology
 
 namespace TauCeti
 
-/-- The Bernstein function associated to Stieltjes representing data.  For positive `t`, this is
-`t` times the represented Stieltjes function; the formula also supplies its continuous value `a`
-at zero. -/
+/-- The candidate Bernstein transform associated to Stieltjes representing data. Under the
+normalization and integrability hypotheses of `isBernsteinFunction_stieltjesBernsteinTransform`,
+it is a Bernstein function and is continuous at zero. For representing data, the later theorem
+`RepresentsStieltjes.stieltjesBernsteinTransform_eq_mul` identifies it with `t * f t` for
+positive `t`. -/
 def stieltjesBernsteinTransform (mu : Measure NNReal) (a b : NNReal) (t : Real) : Real :=
   a + b * t + ∫ x : NNReal, t / (t + x) ∂mu
 
@@ -74,212 +77,169 @@ theorem stieltjesBernsteinTransform_zero (mu : Measure NNReal) (a b : NNReal) :
     stieltjesBernsteinTransform mu a b 0 = a := by
   simp
 
-private def stieltjesBernsteinDerivKernel (n : Nat) (t : Real) (x : NNReal) : Real :=
-  (-1 : Real) ^ n * (n + 1).factorial * x *
-    (t + (x : Real)) ^ (-2 - (n : Int))
+private lemma stieltjesBernsteinIntegral_eq_mul_integral_inv_add (mu : Measure NNReal)
+    (t : Real) :
+    (∫ x : NNReal, t / (t + x) ∂mu) =
+      t * ∫ x : NNReal, (t + x)⁻¹ ∂mu := by
+  rw [← integral_const_mul]
+  exact integral_congr_ae (Filter.Eventually.of_forall fun x => by simp [div_eq_mul_inv])
 
-private def stieltjesBernsteinDerivIntegral (mu : Measure NNReal) (n : Nat) (t : Real) : Real :=
-  ∫ x, stieltjesBernsteinDerivKernel n t x ∂mu
+private lemma integral_stieltjesBernsteinDerivKernel_eq_sub {mu : Measure NNReal}
+    (hmu : Integrable stieltjesWeight mu) {t : Real} (ht : 0 < t) :
+    (∫ x : NNReal, (x : Real) / (t + x) ^ 2 ∂mu) =
+      (∫ x : NNReal, (t + x)⁻¹ ∂mu) -
+        t * ∫ x : NNReal, (t + x) ^ (-2 : Int) ∂mu := by
+  have hpowInt : Integrable (fun x : NNReal => (t + (x : Real)) ^ (-2 : Int)) mu := by
+    simpa using integrable_zpow_neg_one_sub_add hmu 1 ht
+  rw [← integral_const_mul,
+    ← integral_sub (integrable_inv_add hmu ht) (hpowInt.const_mul t)]
+  exact integral_congr_ae (Filter.Eventually.of_forall fun x => by
+    have htx : t + (x : Real) ≠ 0 :=
+      (add_pos_of_pos_of_nonneg ht x.coe_nonneg).ne'
+    have hzpow : (t + (x : Real)) ^ (-2 : Int) = ((t + (x : Real)) ^ 2)⁻¹ := by
+      rw [zpow_neg, zpow_ofNat]
+    dsimp only
+    rw [hzpow, inv_eq_one_div]
+    field_simp
+    ring)
 
-private lemma stieltjesBernsteinDerivKernel_zero (t : Real) (x : NNReal) :
-    stieltjesBernsteinDerivKernel 0 t x = (x : Real) / (t + x) ^ 2 := by
-  simp [stieltjesBernsteinDerivKernel, zpow_neg, div_eq_mul_inv]
+private lemma contDiffOn_stieltjesBernsteinIntegral {mu : Measure NNReal}
+    (hmu : Integrable stieltjesWeight mu) :
+    ContDiffOn Real ∞ (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (Ioi 0) := by
+  refine (contDiffOn_id.mul
+    (isCompletelyMonotoneOnIoi_integral_inv_add hmu).contDiffOn).congr fun t _ => ?_
+  simpa only [id_eq] using stieltjesBernsteinIntegral_eq_mul_integral_inv_add mu t
 
-private lemma hasDerivAt_stieltjesBernsteinDerivKernel (n : Nat) (x : NNReal) {t : Real}
-    (ht : 0 < t) :
-    HasDerivAt (fun u => stieltjesBernsteinDerivKernel n u x)
-      (stieltjesBernsteinDerivKernel (n + 1) t x) t := by
-  have hne : t + (x : Real) ≠ 0 := (add_pos_of_pos_of_nonneg ht x.coe_nonneg).ne'
-  have hbase : HasDerivAt (fun u : Real => u + (x : Real)) 1 t := by
-    simpa using (hasDerivAt_id t).add_const (x : Real)
-  have hpow := (hasDerivAt_zpow (-2 - (n : Int)) (t + (x : Real)) (Or.inl hne)).comp t hbase
-  have h := hpow.const_mul ((-1 : Real) ^ n * (n + 1).factorial * (x : Real))
-  refine (h.congr_of_eventuallyEq ?_).congr_deriv ?_
-  · filter_upwards [] with u
-    simp only [stieltjesBernsteinDerivKernel, Function.comp_def]
-  · unfold stieltjesBernsteinDerivKernel
-    have hexp : -2 - ((n + 1 : Nat) : Int) = -2 - (n : Int) - 1 := by omega
-    rw [hexp]
-    push_cast [Nat.factorial_succ]
+/-- The derivative of the Stieltjes--Bernstein transform at a positive parameter. -/
+theorem hasDerivAt_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNReal}
+    (hmu : Integrable stieltjesWeight mu) {t : Real} (ht : 0 < t) :
+    HasDerivAt (stieltjesBernsteinTransform mu a b)
+      ((b : Real) + ∫ x : NNReal, (x : Real) / (t + x) ^ 2 ∂mu) t := by
+  let F := fun u : Real => ∫ x : NNReal, (u + (x : Real))⁻¹ ∂mu
+  have hFdiff : DifferentiableAt Real F t :=
+    ((isCompletelyMonotoneOnIoi_integral_inv_add hmu).contDiffOn.differentiableOn
+      (by simp)).differentiableAt (isOpen_Ioi.mem_nhds ht)
+  have hFderiv : deriv F t = -∫ x : NNReal, (t + (x : Real)) ^ (-2 : Int) ∂mu := by
+    simpa [F, iteratedDeriv_one] using
+      iteratedDeriv_integral_inv_add hmu 1 ht
+  have hjump : HasDerivAt (fun u => u * F u)
+      (∫ x : NNReal, (x : Real) / (t + x) ^ 2 ∂mu) t := by
+    refine ((hasDerivAt_id t).mul hFdiff.hasDerivAt).congr_deriv ?_
+    rw [hFderiv]
+    rw [integral_stieltjesBernsteinDerivKernel_eq_sub hmu ht]
+    simp only [F, id_eq]
     ring
+  have hlinear : HasDerivAt (fun u : Real => (a : Real) + (b : Real) * u) b t := by
+    simpa using ((hasDerivAt_id t).const_mul (b : Real)).const_add (a : Real)
+  refine ((hlinear.add hjump).congr_of_eventuallyEq ?_).congr_deriv rfl
+  filter_upwards [] with u
+  rw [stieltjesBernsteinTransform_apply,
+    stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
+  rfl
 
-private lemma integrable_stieltjesBernsteinDerivKernel
-    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) (n : Nat) {t : Real}
-    (ht : 0 < t) : Integrable (stieltjesBernsteinDerivKernel n t) mu := by
-  have hbase := integrable_zpow_neg_one_sub_add hmu n ht
-  refine (hbase.const_mul ((n + 1).factorial : Real)).mono' ?_ ?_
-  · have hpowCont : Continuous (fun x : NNReal =>
-        (t + (x : Real)) ^ (-2 - (n : Int))) :=
-      (by fun_prop : Continuous fun x : NNReal => t + (x : Real)).zpow₀ _ fun x =>
-        Or.inl (add_pos_of_pos_of_nonneg ht x.coe_nonneg).ne'
-    exact (((continuous_const.mul continuous_const).mul NNReal.continuous_coe).mul
-      hpowCont).aestronglyMeasurable
-  filter_upwards with x
-  have htx : 0 < t + (x : Real) := add_pos_of_pos_of_nonneg ht x.coe_nonneg
-  have hpow : (x : Real) * (t + (x : Real)) ^ (-2 - (n : Int)) ≤
-      (t + (x : Real)) ^ (-1 - (n : Int)) := by
-    rw [show -1 - (n : Int) = 1 + (-2 - (n : Int)) by omega,
-      zpow_add₀ htx.ne', zpow_one]
-    exact mul_le_mul_of_nonneg_right (le_add_of_nonneg_left ht.le)
-      (zpow_nonneg htx.le _)
-  simpa only [stieltjesBernsteinDerivKernel, Real.norm_eq_abs, abs_mul, abs_pow, abs_neg,
-    abs_one, one_pow, Nat.abs_cast, abs_of_nonneg x.coe_nonneg,
-    abs_of_pos (zpow_pos htx _), mul_assoc, one_mul] using
-      mul_le_mul_of_nonneg_left hpow (Nat.cast_nonneg (n + 1).factorial)
+/-- The derivative formula for the Stieltjes--Bernstein transform at a positive parameter. -/
+theorem deriv_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNReal}
+    (hmu : Integrable stieltjesWeight mu) {t : Real} (ht : 0 < t) :
+    deriv (stieltjesBernsteinTransform mu a b) t =
+      (b : Real) + ∫ x : NNReal, (x : Real) / (t + x) ^ 2 ∂mu :=
+  (hasDerivAt_stieltjesBernsteinTransform hmu ht).deriv
 
-private lemma zpow_neg_le_zpow_neg {a b : Real} (ha : 0 < a) (hab : a ≤ b) (k : Nat) :
-    b ^ (-(k : Int)) ≤ a ^ (-(k : Int)) := by
-  rw [zpow_neg, zpow_natCast, zpow_neg, zpow_natCast]
-  exact (inv_le_inv₀ (pow_pos (ha.trans_le hab) k) (pow_pos ha k)).2
-    (pow_le_pow_left₀ ha.le hab k)
-
-private lemma norm_stieltjesBernsteinDerivKernel_le (n : Nat) (x : NNReal) {r t : Real}
-    (hr : 0 < r) (hrt : r <= t) :
-    norm (stieltjesBernsteinDerivKernel n t x) <=
-      norm (stieltjesBernsteinDerivKernel n r x) := by
-  have hrx : 0 < r + (x : Real) := add_pos_of_pos_of_nonneg hr x.coe_nonneg
-  have htx : 0 < t + (x : Real) := by linarith
-  have hexp : -2 - (n : Int) = -((n + 2 : Nat) : Int) := by omega
-  have hpow := zpow_neg_le_zpow_neg hrx (by linarith : r + (x : Real) ≤ t + x) (n + 2)
-  simp only [stieltjesBernsteinDerivKernel, hexp, Real.norm_eq_abs, abs_mul, abs_pow, abs_neg,
-    abs_one, one_pow, Nat.abs_cast, abs_of_nonneg x.coe_nonneg,
-    abs_of_pos (zpow_pos htx _), abs_of_pos (zpow_pos hrx _)]
-  have hcoeff : 0 ≤ (1 : Real) * ((n + 1).factorial : Real) * (x : Real) := by positivity
-  exact mul_le_mul_of_nonneg_left hpow hcoeff
-
-private lemma hasDerivAt_stieltjesBernsteinDerivIntegral
-    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) (n : Nat) {t : Real}
-    (ht : 0 < t) :
-    HasDerivAt (stieltjesBernsteinDerivIntegral mu n)
-      (stieltjesBernsteinDerivIntegral mu (n + 1) t) t := by
-  let r := t / 2
-  have hr : 0 < r := by dsimp [r]; linarith
-  have htr : t ∈ Ioi r := by change r < t; dsimp [r]; linarith
-  have hs : Ioi r ∈ nhds t := isOpen_Ioi.mem_nhds htr
-  have hmeas : ∀ᶠ u in nhds t,
-      AEStronglyMeasurable (stieltjesBernsteinDerivKernel n u) mu := by
-    filter_upwards [hs] with u hu
-    exact (integrable_stieltjesBernsteinDerivKernel hmu n (hr.trans hu)).aestronglyMeasurable
-  have hderivMeas : AEStronglyMeasurable (stieltjesBernsteinDerivKernel (n + 1) t) mu :=
-    (integrable_stieltjesBernsteinDerivKernel hmu (n + 1) ht).aestronglyMeasurable
-  have hbound : ∀ᵐ x ∂mu, ∀ u ∈ Ioi r,
-      ‖stieltjesBernsteinDerivKernel (n + 1) u x‖ ≤
-        ‖stieltjesBernsteinDerivKernel (n + 1) r x‖ := by
-    filter_upwards with x
-    intro u hu
-    exact norm_stieltjesBernsteinDerivKernel_le (n + 1) x hr hu.le
-  have hdiff : ∀ᵐ x ∂mu, ∀ u ∈ Ioi r,
-      HasDerivAt (fun v => stieltjesBernsteinDerivKernel n v x)
-        (stieltjesBernsteinDerivKernel (n + 1) u x) u := by
-    filter_upwards with x
-    intro u hu
-    exact hasDerivAt_stieltjesBernsteinDerivKernel n x (hr.trans hu)
-  exact (hasDerivAt_integral_of_dominated_loc_of_deriv_le hs hmeas
-    (integrable_stieltjesBernsteinDerivKernel hmu n ht) hderivMeas hbound
-    (integrable_stieltjesBernsteinDerivKernel hmu (n + 1) hr).norm hdiff).2
-
-private lemma contDiffOn_stieltjesBernsteinDerivIntegral
-    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) (n : Nat) :
-    ContDiffOn Real ∞ (stieltjesBernsteinDerivIntegral mu n) (Ioi 0) := by
-  rw [contDiffOn_infty]
-  intro k
-  induction k generalizing n with
-  | zero =>
-      exact contDiffOn_zero.mpr fun t ht =>
-        (hasDerivAt_stieltjesBernsteinDerivIntegral hmu n ht).continuousAt.continuousWithinAt
-  | succ k ih =>
-      rw [Nat.cast_succ, contDiffOn_succ_iff_deriv_of_isOpen isOpen_Ioi]
-      refine ⟨fun t ht =>
-          DifferentiableAt.differentiableWithinAt
-            (hasDerivAt_stieltjesBernsteinDerivIntegral hmu n ht).differentiableAt
-        , by simp, ?_⟩
-      exact (ih (n + 1)).congr fun t ht =>
-        (hasDerivAt_stieltjesBernsteinDerivIntegral hmu n ht).deriv
-
-private lemma iteratedDeriv_stieltjesBernsteinDerivIntegral_zero
-    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) (n : Nat) {t : Real}
-    (ht : 0 < t) :
-    iteratedDeriv n (stieltjesBernsteinDerivIntegral mu 0) t =
-      stieltjesBernsteinDerivIntegral mu n t := by
-  induction n generalizing t with
-  | zero => simp [iteratedDeriv_zero]
-  | succ n ih =>
-      have heq : iteratedDeriv n (stieltjesBernsteinDerivIntegral mu 0) =ᶠ[nhds t]
-          stieltjesBernsteinDerivIntegral mu n := by
-        filter_upwards [isOpen_Ioi.mem_nhds ht] with u hu using ih hu
-      rw [iteratedDeriv_succ, heq.deriv_eq,
-        (hasDerivAt_stieltjesBernsteinDerivIntegral hmu n ht).deriv, Nat.add_comm n 1]
-
-private lemma isCompletelyMonotoneOnIoi_stieltjesBernsteinDerivIntegral
+private lemma isCompletelyMonotoneOnIoi_deriv_stieltjesBernsteinIntegral
     {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) :
-    IsCompletelyMonotoneOnIoi (stieltjesBernsteinDerivIntegral mu 0) := by
-  refine ⟨contDiffOn_stieltjesBernsteinDerivIntegral hmu 0, ?_⟩
-  intro n t ht
-  rw [iteratedDeriv_stieltjesBernsteinDerivIntegral_zero hmu n ht,
-    stieltjesBernsteinDerivIntegral]
-  have hint : 0 ≤ ∫ x : NNReal,
-      (x : Real) * (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu :=
-    integral_nonneg fun x => mul_nonneg x.coe_nonneg
-      (zpow_pos (add_pos_of_pos_of_nonneg ht x.coe_nonneg) _).le
-  have hconst : 0 ≤ ((-1 : Real) ^ n) ^ 2 * (n + 1).factorial :=
-    mul_nonneg (sq_nonneg _) (Nat.cast_nonneg _)
-  rw [show (fun x => stieltjesBernsteinDerivKernel n t x) =
-      fun x : NNReal => ((-1 : Real) ^ n * (n + 1).factorial) *
-        ((x : Real) * (t + (x : Real)) ^ (-2 - (n : Int))) by
-    funext x
-    simp only [stieltjesBernsteinDerivKernel]
-    ring]
-  rw [integral_const_mul]
-  nlinarith
-
-private lemma hasDerivAt_stieltjesBernsteinIntegral
-    {mu : Measure NNReal} (hmu : Integrable stieltjesWeight mu) {t : Real} (ht : 0 < t) :
-    HasDerivAt (fun u : Real => ∫ x : NNReal, u / (u + x) ∂mu)
-      (stieltjesBernsteinDerivIntegral mu 0 t) t := by
-  let r := t / 2
-  have hr : 0 < r := by dsimp [r]; linarith
-  have htr : t ∈ Ioi r := by change r < t; dsimp [r]; linarith
-  have hs : Ioi r ∈ nhds t := isOpen_Ioi.mem_nhds htr
-  have hmeas : ∀ᶠ u : Real in nhds t,
-      AEStronglyMeasurable (fun x : NNReal => u / (u + (x : Real))) mu := by
-    filter_upwards [hs] with u hu
-    exact ((integrable_inv_add hmu (hr.trans hu)).const_mul u).aestronglyMeasurable
-  have hderivMeas : AEStronglyMeasurable (stieltjesBernsteinDerivKernel 0 t) mu :=
-    (integrable_stieltjesBernsteinDerivKernel hmu 0 ht).aestronglyMeasurable
-  have hbound : ∀ᵐ x ∂mu, ∀ u ∈ Ioi r,
-      ‖stieltjesBernsteinDerivKernel 0 u x‖ ≤
-        ‖stieltjesBernsteinDerivKernel 0 r x‖ := by
-    filter_upwards with x
-    intro u hu
-    exact norm_stieltjesBernsteinDerivKernel_le 0 x hr hu.le
-  have hdiff : ∀ᵐ x : NNReal ∂mu, ∀ u ∈ Ioi r,
-      HasDerivAt (fun v : Real => v / (v + (x : Real)))
-        (stieltjesBernsteinDerivKernel 0 u x) u := by
-    filter_upwards with x
-    intro u hu
-    have hne : u + (x : Real) ≠ 0 :=
-      (add_pos_of_pos_of_nonneg (hr.trans hu) x.coe_nonneg).ne'
-    have hden : HasDerivAt (fun v : Real => v + x) 1 u := by
-      simpa using (hasDerivAt_id u).add_const (x : Real)
-    have hform := (hasDerivAt_const u (1 : Real)).sub ((hden.inv hne).const_mul (x : Real))
-    refine (hform.congr_of_eventuallyEq ?_).congr_deriv ?_
-    · filter_upwards [hden.continuousAt.eventually_ne hne] with v hv
-      change v / (v + (x : Real)) = (1 : Real) - (x : Real) * (v + x)⁻¹
-      field_simp
-      ring
-    · change 0 - (x : Real) * (-1 / (u + x) ^ 2) =
-        stieltjesBernsteinDerivKernel 0 u x
-      rw [stieltjesBernsteinDerivKernel_zero]
-      field_simp
-      ring
-  exact (hasDerivAt_integral_of_dominated_loc_of_deriv_le hs hmeas
-    ((integrable_inv_add hmu ht).const_mul t) hderivMeas hbound
-    (integrable_stieltjesBernsteinDerivKernel hmu 0 hr).norm hdiff).2
+    IsCompletelyMonotoneOnIoi
+      (deriv fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) := by
+  let F := fun u : Real => ∫ x : NNReal, (u + (x : Real))⁻¹ ∂mu
+  have hFcm : IsCompletelyMonotoneOnIoi F :=
+    isCompletelyMonotoneOnIoi_integral_inv_add hmu
+  have hjumpContDiff : ContDiffOn Real ∞ (fun t => t * F t) (Ioi 0) :=
+    contDiffOn_id.mul hFcm.contDiffOn
+  have hjumpEq : EqOn (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
+      (fun t => t * F t) (Ioi 0) := fun t _ =>
+    stieltjesBernsteinIntegral_eq_mul_integral_inv_add mu t
+  have hderivEq : EqOn
+      (deriv fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
+      (deriv fun t => t * F t) (Ioi 0) := fun t ht =>
+    (hjumpEq.eventuallyEq_of_mem (isOpen_Ioi.mem_nhds ht)).deriv_eq
+  refine ⟨?_, ?_⟩
+  · rw [contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi] at hjumpContDiff
+    exact hjumpContDiff.2.congr hderivEq
+  · intro n t ht
+    rw [(hderivEq.eventuallyEq_of_mem
+      (isOpen_Ioi.mem_nhds ht)).iteratedDeriv_eq n, ← iteratedDeriv_succ']
+    have hFdiff : ContDiffAt Real (n + 1 : Nat) F t :=
+      (hFcm.contDiffOn.contDiffAt (isOpen_Ioi.mem_nhds ht)).of_le (by simp)
+    have hmulFun : (fun u => u * F u) = id * F := rfl
+    rw [hmulFun, iteratedDeriv_mul contDiffAt_id hFdiff]
+    rw [← Finset.add_sum_erase _ _
+      (by simp : 0 ∈ Finset.range (n + 1 + 1))]
+    rw [← Finset.add_sum_erase _ _
+      (by simp : 1 ∈ (Finset.range (n + 1 + 1)).erase 0)]
+    have hrest :
+        (∑ x ∈ ((Finset.range (n + 1 + 1)).erase 0).erase 1,
+          ((n + 1).choose x : Real) * iteratedDeriv x id t *
+            iteratedDeriv (n + 1 - x) F t) = 0 := by
+      apply Finset.sum_eq_zero
+      intro x hx
+      have hx1 : x ≠ 1 := (Finset.mem_erase.mp hx).1
+      have hx0 : x ≠ 0 := (Finset.mem_erase.mp (Finset.mem_erase.mp hx).2).1
+      simp [iteratedDeriv_id, hx0, hx1]
+    rw [hrest]
+    have hid0 : iteratedDeriv 0 id t = t := by simp
+    have hid1 : iteratedDeriv 1 id t = 1 := by simp [iteratedDeriv_one]
+    rw [hid0, hid1]
+    simp only [Nat.choose_zero_right, Nat.choose_one_right, Nat.cast_one, one_mul,
+      Nat.sub_zero, add_zero]
+    rw [Nat.add_sub_cancel, mul_one, Nat.cast_add, Nat.cast_one]
+    have hn := iteratedDeriv_integral_inv_add hmu n ht
+    have hn1 := iteratedDeriv_integral_inv_add hmu (n + 1) ht
+    have hexpSucc : -1 - ((n + 1 : Nat) : Int) = -2 - (n : Int) := by omega
+    rw [hexpSucc] at hn1
+    rw [hn, hn1]
+    have hle : t * ∫ x : NNReal,
+          (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu ≤
+        ∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu := by
+      have hIntSucc : Integrable
+          (fun x : NNReal => (t + (x : Real)) ^ (-2 - (n : Int))) mu := by
+        simpa only [hexpSucc] using integrable_zpow_neg_one_sub_add hmu (n + 1) ht
+      rw [← integral_const_mul]
+      exact integral_mono
+        (hIntSucc.const_mul t)
+        (integrable_zpow_neg_one_sub_add hmu n ht) fun x => by
+          have htx : 0 < t + (x : Real) :=
+            add_pos_of_pos_of_nonneg ht x.coe_nonneg
+          have hexp : -1 - (n : Int) = 1 + (-2 - (n : Int)) := by omega
+          rw [hexp, zpow_add₀ htx.ne', zpow_one]
+          exact mul_le_mul_of_nonneg_right (le_add_of_nonneg_right x.coe_nonneg)
+            (zpow_nonneg htx.le _)
+    have hsign : (-1 : Real) ^ n * (-1 : Real) ^ n = 1 := by
+      rw [← pow_add]
+      norm_num [two_mul n]
+    have heq :
+        (-1 : Real) ^ n *
+          (t * ((-1 : Real) ^ (n + 1) * (n + 1).factorial *
+              ∫ x : NNReal, (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu) +
+            ((n : Real) + 1) * ((-1 : Real) ^ n * n.factorial *
+              ∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu)) =
+          ((n + 1).factorial : Real) *
+            ((∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu) -
+              t * ∫ x : NNReal,
+                (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu) := by
+      rw [pow_succ, Nat.factorial_succ]
+      push_cast
+      calc
+        _ = ((-1 : Real) ^ n * (-1 : Real) ^ n) * ((n : Real) + 1) * n.factorial *
+              ((∫ x : NNReal, (t + (x : Real)) ^ (-1 - (n : Int)) ∂mu) -
+                t * ∫ x : NNReal,
+                  (t + (x : Real)) ^ (-2 - (n : Int)) ∂mu) := by ring
+        _ = _ := by rw [hsign]; ring
+    rw [heq]
+    exact mul_nonneg (Nat.cast_nonneg _) (sub_nonneg.mpr hle)
 
 private lemma continuousWithinAt_stieltjesBernsteinIntegral_zero
     {mu : Measure NNReal} (hzero : mu {0} = 0) (hmu : Integrable stieltjesWeight mu) :
     ContinuousWithinAt (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
       (Ici 0) 0 := by
+  -- Expose the filter formulation required by dominated convergence.
   change Tendsto (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (nhdsWithin 0 (Ici 0))
     (nhds (∫ x : NNReal, (0 : Real) / (0 + x) ∂mu))
   have hDCT : Tendsto (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
@@ -327,45 +287,31 @@ private lemma continuousWithinAt_stieltjesBernsteinIntegral_zero
       rfl
   simpa using hDCT
 
-/-- The transform built from normalized Stieltjes representing data is a Bernstein function. -/
-theorem isBernsteinFunction_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNReal}
+private lemma isBernsteinFunction_stieltjesBernsteinIntegral {mu : Measure NNReal}
     (hzero : mu {0} = 0) (hmu : Integrable stieltjesWeight mu) :
-    IsBernsteinFunction (stieltjesBernsteinTransform mu a b) := by
-  have hjump_cont : ContinuousOn
+    IsBernsteinFunction (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) := by
+  have hjumpCont : ContinuousOn
       (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (Ici 0) := by
     intro t ht
     have ht' : 0 ≤ t := ht
     rcases ht'.eq_or_lt with rfl | ht
     · exact continuousWithinAt_stieltjesBernsteinIntegral_zero hzero hmu
-    · exact (hasDerivAt_stieltjesBernsteinIntegral hmu ht).continuousAt.continuousWithinAt
-  have hderiv : EqOn (deriv (stieltjesBernsteinTransform mu a b))
-      (fun t => (b : Real) + stieltjesBernsteinDerivIntegral mu 0 t) (Ioi 0) := by
-    intro t ht
-    have hlin : HasDerivAt (fun u : Real => (a : Real) + (b : Real) * u) b t := by
-      simpa using ((hasDerivAt_id t).const_mul (b : Real)).const_add (a : Real)
-    unfold stieltjesBernsteinTransform
-    exact (hlin.add (hasDerivAt_stieltjesBernsteinIntegral hmu ht)).deriv
+    · exact ((contDiffOn_stieltjesBernsteinIntegral hmu).contDiffAt
+        (isOpen_Ioi.mem_nhds ht)).continuousAt.continuousWithinAt
   rw [isBernsteinFunction_iff]
-  have hjump_diff : DifferentiableOn Real
-      (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (Ioi 0) := fun t ht =>
-    (hasDerivAt_stieltjesBernsteinIntegral hmu ht).differentiableAt.differentiableWithinAt
-  have hjump_deriv : EqOn (deriv fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu)
-      (stieltjesBernsteinDerivIntegral mu 0) (Ioi 0) := fun t ht =>
-    (hasDerivAt_stieltjesBernsteinIntegral hmu ht).deriv
-  have hjump_contDiff : ContDiffOn Real ∞
-      (fun t : Real => ∫ x : NNReal, t / (t + x) ∂mu) (Ioi 0) := by
-    rw [contDiffOn_infty_iff_deriv_of_isOpen isOpen_Ioi]
-    exact ⟨hjump_diff,
-      (contDiffOn_stieltjesBernsteinDerivIntegral hmu 0).congr hjump_deriv⟩
-  refine ⟨(continuousOn_const.add (continuousOn_const.mul continuousOn_id)).add hjump_cont,
-    ?_, ?_, ?_⟩
-  · exact ((contDiffOn_const.add (contDiffOn_const.mul contDiffOn_id)).add
-      hjump_contDiff).congr fun _ _ => (stieltjesBernsteinTransform_apply mu a b _).symm
-  · intro t ht
-    exact add_nonneg (add_nonneg a.coe_nonneg (mul_nonneg b.coe_nonneg ht))
-      (integral_nonneg fun x => div_nonneg ht (add_nonneg ht x.coe_nonneg))
-  · exact ((isCompletelyMonotone_const b.coe_nonneg).isCompletelyMonotoneOnIoi.add
-      (isCompletelyMonotoneOnIoi_stieltjesBernsteinDerivIntegral hmu)).congr hderiv
+  exact ⟨hjumpCont, contDiffOn_stieltjesBernsteinIntegral hmu,
+    fun t ht => integral_nonneg fun x => div_nonneg ht (add_nonneg ht x.coe_nonneg),
+    isCompletelyMonotoneOnIoi_deriv_stieltjesBernsteinIntegral hmu⟩
+
+/-- The transform built from normalized Stieltjes representing data is a Bernstein function. -/
+theorem isBernsteinFunction_stieltjesBernsteinTransform {mu : Measure NNReal} {a b : NNReal}
+    (hzero : mu {0} = 0) (hmu : Integrable stieltjesWeight mu) :
+    IsBernsteinFunction (stieltjesBernsteinTransform mu a b) := by
+  apply ((isBernsteinFunction_affine a.coe_nonneg b.coe_nonneg).add
+    (isBernsteinFunction_stieltjesBernsteinIntegral hzero hmu)).congr
+  intro t _
+  rw [stieltjesBernsteinTransform_apply]
+  simp only [Pi.add_apply]
 
 namespace RepresentsStieltjes
 
@@ -376,22 +322,33 @@ transform on the open half-line. -/
 theorem stieltjesBernsteinTransform_eq_mul (h : RepresentsStieltjes mu a b f) {t : Real}
     (ht : 0 < t) : stieltjesBernsteinTransform mu a b t = t * f t := by
   rw [h.eq_div_add_add_integral_inv_add ht, stieltjesBernsteinTransform_apply]
-  have hint : (∫ x : NNReal, t / (t + x) ∂mu) =
-      t * ∫ x : NNReal, (t + x)⁻¹ ∂mu := by
-    rw [← integral_const_mul]
-    apply integral_congr_ae
-    filter_upwards with x
-    simp [div_eq_mul_inv]
-  rw [hint]
+  rw [stieltjesBernsteinIntegral_eq_mul_integral_inv_add]
   field_simp [ht.ne']
 
 /-- A Stieltjes representation produces a Bernstein function that agrees with `t * f(t)` for
 every positive `t` and has the canonical boundary value `a` at zero. -/
-theorem isBernsteinFunction_transform (h : RepresentsStieltjes mu a b f) :
+theorem isBernsteinFunction_stieltjesBernsteinTransform (h : RepresentsStieltjes mu a b f) :
     IsBernsteinFunction (stieltjesBernsteinTransform mu a b) :=
-  isBernsteinFunction_stieltjesBernsteinTransform h.measure_singleton_zero h.integrable_weight
+  TauCeti.isBernsteinFunction_stieltjesBernsteinTransform
+    h.measure_singleton_zero h.integrable_weight
 
 end RepresentsStieltjes
+
+namespace IsStieltjesFunction
+
+variable {f : Real → Real}
+
+/-- Every Stieltjes function has a Bernstein extension of its product with the parameter on the
+open positive half-line. -/
+theorem exists_isBernsteinFunction_eq_mul (h : IsStieltjesFunction f) :
+    ∃ g : Real → Real, IsBernsteinFunction g ∧ EqOn g (fun t => t * f t) (Ioi 0) := by
+  rw [isStieltjesFunction_iff] at h
+  obtain ⟨a, b, mu, hrep⟩ := h
+  exact ⟨stieltjesBernsteinTransform mu a b,
+    hrep.isBernsteinFunction_stieltjesBernsteinTransform,
+    fun _ ht => hrep.stieltjesBernsteinTransform_eq_mul ht⟩
+
+end IsStieltjesFunction
 
 end TauCeti
 


### PR DESCRIPTION
This PR turns every normalized Stieltjes representation into a Bernstein function by introducing the canonical transform `a + b * t + ∫ x, t / (t + x) ∂μ`, proving it Bernstein on `[0, ∞)`, and identifying it with `t * f t` for every positive `t`. The value at zero is the reciprocal coefficient `a`, so the construction retains the boundary value that the literal product `0 * f 0` would lose.

The exact roadmap target is `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B, API bullet “The Stieltjes / Bernstein-function relationships,” within the developed-theory milestone surrounding Bernstein's theorem. This is the next effective step because #4957 supplied the normalized Stieltjes representation and #5114 proved Stieltjes functions completely monotone, while their standard passage to Bernstein functions remained absent.

The proof differentiates the integral on `(0, ∞)`: its derivative is `∫ x, x / (t + x) ^ 2 ∂μ`, with the general alternating derivative kernel proved integrable from the sharp Stieltjes weight. Continuity at zero follows by dominated convergence; the normalization `μ {0} = 0` removes the unique point where `t / (t + x)` fails to converge to zero.

After this PR, the Stieltjes/Bernstein relationship target still needs the complete-Bernstein-function characterization and the reciprocal correspondences.

Add `TauCeti/Analysis/CompletelyMonotone/Stieltjes/Bernstein.lean` (401 lines). No Mathlib infrastructure or external formalization is vendored. The mathematical statement follows Schilling, Song, and Vondraček, *Bernstein Functions: Theory and Applications*, Chapter 7, as cited in the module documentation.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"stieltjes-mul-id-bernstein"}-->

🤖 Prepared with Codex
