### PR TITLE
feat: minimal projective presentations of modules

### DIFF
--- a/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
+++ b/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
@@ -48,9 +48,12 @@ The file is layered by the coefficients each part needs, as
 readings of it need only a semiring and additive monoids. The degeneration over a projective
 module needs the presented module to be an additive group, that being what uniqueness of covers
 needs. The comparison and uniqueness theorems need a ring, which the syzygy forces rather than the
-proofs choosing it: `ker p₀` is a submodule, a submodule of a module over a semiring carries only
-an `AddCommMonoid`, and the cover statements applied to it are available exactly for a covered
-module that is an additive group.
+proofs choosing it: they apply the cover statements of `TauCeti/Algebra/Module/ProjectiveCover.lean`
+to the syzygy `ker p₀` as the *covered* module, and those are stated for a covered module that is
+an additive group. A submodule of an additive group is itself an additive group only once the
+scalars form a ring — `Submodule.addCommGroup` is a `[Ring R]` instance, and over a semiring a
+submodule need not be closed under negation, as `ℕ ⊆ ℤ` shows — so over a semiring
+`↥(LinearMap.ker p₀)` carries no `AddCommGroup` structure at all.
 
 ## Main definitions
 
@@ -66,9 +69,12 @@ module that is an additive group.
 * `TauCeti.IsMinimalProjectivePresentation.exists_surjective`: **a minimal projective presentation
   is a quotient of every projective presentation**, by a pair of surjections commuting with the
   maps.
-* `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv`: **uniqueness**, as an isomorphism
-  of the whole diagram; `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_ker` records
-  the resulting isomorphism of syzygies.
+* `TauCeti.IsMinimalProjectivePresentation.bijective_of_comp_eq` and
+  `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv`: **uniqueness**, first as
+  bijectivity of any pair of comparison maps between two minimal presentations and then as an
+  isomorphism of the whole diagram;
+  `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_ker` records the resulting
+  isomorphism of syzygies.
 * `TauCeti.IsMinimalProjectivePresentation.bijective_of_projective`,
   `TauCeti.IsMinimalProjectivePresentation.eq_zero_of_projective` and
   `TauCeti.IsMinimalProjectivePresentation.subsingleton_of_projective`: over a projective module
@@ -138,8 +144,7 @@ theorem exact (h : IsMinimalProjectivePresentation p₁ p₀) : Function.Exact p
 /-- The left-hand map of a presentation lands in the syzygy. -/
 theorem apply_mem_ker (h : IsMinimalProjectivePresentation p₁ p₀) (x : P₁) :
     p₁ x ∈ LinearMap.ker p₀ := by
-  rw [← h.range_eq_ker]
-  exact LinearMap.mem_range_self p₁ x
+  simpa using LinearMap.congr_fun h.exact.linearMap_comp_eq_zero x
 
 /-- **Minimality of the left-hand map, in cover form**: corestricted to the syzygy `ker p₀`, the
 map `p₁` is a projective cover of it. This is the reading of the definition that
@@ -148,10 +153,8 @@ theorem isProjectiveCover_codRestrict (h : IsMinimalProjectivePresentation p₁ 
     IsProjectiveCover (LinearMap.codRestrict (LinearMap.ker p₀) p₁ h.apply_mem_ker) where
   projective := h.projective
   surjective := by
-    intro y
-    have hy : (y : P₀) ∈ LinearMap.range p₁ := by rw [h.range_eq_ker]; exact y.2
-    obtain ⟨x, hx⟩ := hy
-    exact ⟨x, Subtype.ext hx⟩
+    rw [← LinearMap.range_eq_top, LinearMap.range_codRestrict, h.range_eq_ker,
+      Submodule.comap_subtype_self]
   isSuperfluous_ker := by
     rw [LinearMap.ker_codRestrict]
     exact h.isSuperfluous_ker
@@ -176,6 +179,29 @@ theorem IsProjectiveCover.isMinimalProjectivePresentation {p₀ : P₀ →ₗ[R]
       simp
     rw [hker]
     exact h₁.isSuperfluous_ker
+
+/-- **A comparison of presentations descends to the syzygies.** If `f` is a surjection between the
+middle terms of two presentations of `M` commuting with the two presenting maps `a₀` and `b₀`, then
+the induced map `A₁ → ker b₀` on syzygies is again onto: a syzygy of the target is hit in the middle
+term, and exactness of the source sequence lifts it back along `a₁`.
+
+This is the step both comparison theorems below rest on, once for the presentation being compared
+and once for the second minimal presentation. -/
+private theorem surjective_codRestrict_comp {A : Type*} {A₁ : Type*} {B : Type*}
+    [AddCommMonoid A] [Module R A] [AddCommMonoid A₁] [Module R A₁] [AddCommMonoid B] [Module R B]
+    {a₀ : A →ₗ[R] M} {a₁ : A₁ →ₗ[R] A} {b₀ : B →ₗ[R] M} {f : A →ₗ[R] B}
+    (hf : Function.Surjective f) (ha : LinearMap.range a₁ = LinearMap.ker a₀)
+    (hcomp : b₀ ∘ₗ f = a₀) (hmem : ∀ z, (f ∘ₗ a₁) z ∈ LinearMap.ker b₀) :
+    Function.Surjective (LinearMap.codRestrict (LinearMap.ker b₀) (f ∘ₗ a₁) hmem) := by
+  have hbf : ∀ x, b₀ (f x) = a₀ x := fun x => LinearMap.congr_fun hcomp x
+  intro y
+  obtain ⟨u, hu⟩ := hf (y : B)
+  have hu' : u ∈ LinearMap.range a₁ := by
+    rw [ha]
+    have hzero : b₀ (f u) = 0 := by rw [hu]; exact y.2
+    simpa [hbf] using hzero
+  obtain ⟨z, hz⟩ := hu'
+  exact ⟨z, Subtype.ext (by simp [hz, hu])⟩
 
 end Semiring
 
@@ -255,41 +281,26 @@ theorem exists_surjective [AddCommMonoid Q₀] [Module R Q₀] [Module.Projectiv
     intro z
     have hz : q₁ z ∈ LinearMap.ker q₀ := by rw [← hq]; exact LinearMap.mem_range_self q₁ z
     simpa [hpf] using hz
-  -- It is onto, because `f₀` is onto and the source sequence is exact at `Q₀`.
-  have hgsurj : Function.Surjective
-      (LinearMap.codRestrict (LinearMap.ker p₀) (f₀ ∘ₗ q₁) hmem) := by
-    intro y
-    obtain ⟨u, hu⟩ := hf₀surj (y : P₀)
-    have hu' : u ∈ LinearMap.range q₁ := by
-      rw [hq]
-      have hzero : p₀ (f₀ u) = 0 := by rw [hu]; exact y.2
-      simpa [hpf] using hzero
-    obtain ⟨z, hz⟩ := hu'
-    exact ⟨z, Subtype.ext (by simp [hz, hu])⟩
-  obtain ⟨f₁, hf₁, hf₁surj⟩ := h.isProjectiveCover_codRestrict.exists_surjective hgsurj
+  obtain ⟨f₁, hf₁, hf₁surj⟩ := h.isProjectiveCover_codRestrict.exists_surjective
+    (surjective_codRestrict_comp hf₀surj hq hf₀ hmem)
   refine ⟨f₀, f₁, hf₀, LinearMap.ext fun z => ?_, hf₀surj, hf₁surj⟩
   have hval := congrArg Subtype.val (LinearMap.congr_fun hf₁ z)
   simpa using hval.symm
 
 variable [AddCommGroup Q₀] [Module R Q₀] [AddCommGroup Q₁] [Module R Q₁]
 
-/-- **Uniqueness of the minimal projective presentation.** Two minimal projective presentations of
-the same module are isomorphic as diagrams: there are linear equivalences of both sources
-commuting with the presenting map and with the two syzygy maps.
+/-- **Uniqueness of the minimal projective presentation, in comparison-map form.** A pair of maps
+between the sources of two minimal projective presentations of `M` that commutes with the presenting
+maps and with the two left-hand maps consists of two isomorphisms; no further hypothesis on the pair
+is needed.
 
-The comparison surjections come from
-`TauCeti.IsMinimalProjectivePresentation.exists_surjective`; each is bijective because it compares
-two projective covers of the same module — of `M` on the right, and of the syzygy on the left, the
-two syzygies being identified by the right-hand equivalence. -/
-theorem exists_linearEquiv {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
+Each is bijective because it compares two projective covers of the same module — of `M` on the
+right, and of the syzygy on the left, the two syzygies being identified by the right-hand map. -/
+theorem bijective_of_comp_eq {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
     (h : IsMinimalProjectivePresentation p₁ p₀)
-    (h' : IsMinimalProjectivePresentation q₁ q₀) :
-    ∃ (e₀ : P₀ ≃ₗ[R] Q₀) (e₁ : P₁ ≃ₗ[R] Q₁),
-      q₀ ∘ₗ (e₀ : P₀ →ₗ[R] Q₀) = p₀ ∧
-        (e₀ : P₀ →ₗ[R] Q₀) ∘ₗ p₁ = q₁ ∘ₗ (e₁ : P₁ →ₗ[R] Q₁) := by
-  have hP₀ : Module.Projective R P₀ := h.isProjectiveCover.projective
-  have hP₁ : Module.Projective R P₁ := h.projective
-  obtain ⟨f₀, f₁, hcomp, hsquare, -, -⟩ := h'.exists_surjective h.surjective h.range_eq_ker
+    (h' : IsMinimalProjectivePresentation q₁ q₀) {f₀ : P₀ →ₗ[R] Q₀} {f₁ : P₁ →ₗ[R] Q₁}
+    (hcomp : q₀ ∘ₗ f₀ = p₀) (hsquare : f₀ ∘ₗ p₁ = q₁ ∘ₗ f₁) :
+    Function.Bijective f₀ ∧ Function.Bijective f₁ := by
   have hbij₀ : Function.Bijective f₀ :=
     h.isProjectiveCover.bijective_of_comp_eq h'.isProjectiveCover hcomp
   have hqf : ∀ y, q₀ (f₀ y) = p₀ y := fun y => LinearMap.congr_fun hcomp y
@@ -300,24 +311,31 @@ theorem exists_linearEquiv {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M
     simpa [hqf] using hz
   have hkerf₀ : LinearMap.ker f₀ = ⊥ := LinearMap.ker_eq_bot.mpr hbij₀.injective
   have hcover : IsProjectiveCover (LinearMap.codRestrict (LinearMap.ker q₀) (f₀ ∘ₗ p₁) hmem) := by
-    refine ⟨h.projective, ?_, ?_⟩
-    · intro y
-      obtain ⟨u, hu⟩ := hbij₀.2 (y : Q₀)
-      have hu' : u ∈ LinearMap.range p₁ := by
-        rw [h.range_eq_ker]
-        have hzero : q₀ (f₀ u) = 0 := by rw [hu]; exact y.2
-        simpa [hqf] using hzero
-      obtain ⟨z, hz⟩ := hu'
-      exact ⟨z, Subtype.ext (by simp [hz, hu])⟩
-    · have hker : LinearMap.ker (LinearMap.codRestrict (LinearMap.ker q₀) (f₀ ∘ₗ p₁) hmem)
-          = LinearMap.ker p₁ := by
-        rw [LinearMap.ker_codRestrict, LinearMap.ker_comp, hkerf₀, Submodule.comap_bot]
-      rw [hker]
-      exact h.isSuperfluous_ker
-  have hbij₁ : Function.Bijective f₁ := by
-    refine hcover.bijective_of_comp_eq h'.isProjectiveCover_codRestrict ?_
-    refine LinearMap.ext fun z => Subtype.ext ?_
-    simpa using (LinearMap.congr_fun hsquare z).symm
+    refine ⟨h.projective,
+      surjective_codRestrict_comp hbij₀.surjective h.range_eq_ker hcomp hmem, ?_⟩
+    rw [LinearMap.ker_codRestrict, LinearMap.ker_comp, hkerf₀, Submodule.comap_bot]
+    exact h.isSuperfluous_ker
+  refine ⟨hbij₀, hcover.bijective_of_comp_eq h'.isProjectiveCover_codRestrict ?_⟩
+  refine LinearMap.ext fun z => Subtype.ext ?_
+  simpa using (LinearMap.congr_fun hsquare z).symm
+
+/-- **Uniqueness of the minimal projective presentation.** Two minimal projective presentations of
+the same module are isomorphic as diagrams: there are linear equivalences of both sources
+commuting with the presenting map and with the two syzygy maps.
+
+The comparison surjections come from
+`TauCeti.IsMinimalProjectivePresentation.exists_surjective`, and
+`TauCeti.IsMinimalProjectivePresentation.bijective_of_comp_eq` turns them into isomorphisms. -/
+theorem exists_linearEquiv {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
+    (h : IsMinimalProjectivePresentation p₁ p₀)
+    (h' : IsMinimalProjectivePresentation q₁ q₀) :
+    ∃ (e₀ : P₀ ≃ₗ[R] Q₀) (e₁ : P₁ ≃ₗ[R] Q₁),
+      q₀ ∘ₗ (e₀ : P₀ →ₗ[R] Q₀) = p₀ ∧
+        (e₀ : P₀ →ₗ[R] Q₀) ∘ₗ p₁ = q₁ ∘ₗ (e₁ : P₁ →ₗ[R] Q₁) := by
+  have hP₀ : Module.Projective R P₀ := h.isProjectiveCover.projective
+  have hP₁ : Module.Projective R P₁ := h.projective
+  obtain ⟨f₀, f₁, hcomp, hsquare, -, -⟩ := h'.exists_surjective h.surjective h.range_eq_ker
+  obtain ⟨hbij₀, hbij₁⟩ := h.bijective_of_comp_eq h' hcomp hsquare
   exact ⟨LinearEquiv.ofBijective f₀ hbij₀, LinearEquiv.ofBijective f₁ hbij₁, hcomp, hsquare⟩
 
 /-- **The syzygy of a minimal projective presentation is well defined.** The right-hand equivalence
@@ -339,8 +357,7 @@ theorem nonempty_linearEquiv_ker {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →�
       have hy' : q₀ y = p₀ (e₀.symm y) := by
         rw [← hqe (e₀.symm y), e₀.apply_symm_apply]
       simpa [← hy'] using hy0
-  exact ⟨(Submodule.equivMapOfInjective (e₀ : P₀ →ₗ[R] Q₀) e₀.injective _).trans
-    (LinearEquiv.ofEq _ _ hmap)⟩
+  exact ⟨e₀.ofSubmodules (LinearMap.ker p₀) (LinearMap.ker q₀) hmap⟩
 
 end Comparison
 

--- a/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
+++ b/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
@@ -1,0 +1,341 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Exact.Basic
+public import TauCeti.Algebra.Module.ProjectiveCover
+
+/-!
+# Minimal projective presentations
+
+A **projective presentation** of a module `M` is an exact sequence `P₁ → P₀ → M → 0` with `P₀` and
+`P₁` projective. It is **minimal** when both of its maps are as small as they can be: `P₀ → M` is a
+projective cover (`TauCeti.IsProjectiveCover`) and `P₁` covers the syzygy `ker (P₀ → M)`, again as
+a projective cover. This file supplies the predicate `TauCeti.IsMinimalProjectivePresentation` and
+the comparison theorem that makes it useful.
+
+The minimality is packaged as two superfluous kernels rather than as a nested
+`TauCeti.IsProjectiveCover`, because the second cover is a map into the submodule `ker p₀` and
+carrying its corestriction around in the definition would make every consumer corestrict as well.
+`TauCeti.IsMinimalProjectivePresentation.isProjectiveCover_codRestrict` reads the definition back
+in the corestricted form, and `TauCeti.IsProjectiveCover.isMinimalProjectivePresentation` builds a
+minimal presentation from a pair of covers, so the two readings are interchangeable.
+
+The theorem the notion exists for is that a minimal projective presentation is a *retract* of every
+projective presentation: given any projective presentation of the same module there are
+**surjections** from it onto the minimal one commuting with both maps
+(`TauCeti.IsMinimalProjectivePresentation.exists_surjective`). Applying that to a second minimal
+presentation and reading the surjections back through the uniqueness of projective covers makes
+them isomorphisms, so a minimal projective presentation is unique up to isomorphism of the whole
+diagram (`TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv`). That uniqueness is what
+lets a construction be made *from* a minimal presentation: the Auslander-Reiten transpose `Tr M`,
+the cokernel of `Hom(−, A)` applied to a minimal projective presentation of `M`, is well defined
+because of it.
+
+*Existence* is a separate matter, exactly as for projective covers: it is a condition on the ring
+(over a semiperfect algebra every finitely generated module has a projective cover, and iterating
+gives a minimal presentation). Nothing here assumes it; every statement is conditional on a
+presentation being given, and `TauCeti.IsProjectiveCover.isMinimalProjectivePresentation` is the
+step that turns two covers into one presentation.
+
+The coefficients are a ring rather than a semiring, unlike the parts of
+`TauCeti/Algebra/Module/ProjectiveCover.lean` that only need a semiring. That is forced by the
+syzygy: `ker p₀` is a submodule, and a submodule of a module over a semiring carries only an
+`AddCommMonoid`, while the uniqueness statements about projective covers -- and hence everything
+below -- are available exactly for a covered module that is an additive group.
+
+## Main definitions
+
+* `TauCeti.IsMinimalProjectivePresentation p₁ p₀`: `p₀` is a projective cover of `M`, the source of
+  `p₁` is projective, `range p₁ = ker p₀`, and `ker p₁` is superfluous.
+
+## Main results
+
+* `TauCeti.IsMinimalProjectivePresentation.exact`: the two maps do form a presentation.
+* `TauCeti.IsMinimalProjectivePresentation.isProjectiveCover_codRestrict` and
+  `TauCeti.IsProjectiveCover.isMinimalProjectivePresentation`: minimality read as `p₁` being a
+  projective cover of the syzygy, in both directions.
+* `TauCeti.IsMinimalProjectivePresentation.exists_surjective`: **a minimal projective presentation
+  is a quotient of every projective presentation**, by a pair of surjections commuting with the
+  maps.
+* `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv`: **uniqueness**, as an isomorphism
+  of the whole diagram; `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv_ker` records
+  the resulting isomorphism of syzygies.
+* `TauCeti.IsMinimalProjectivePresentation.bijective_of_projective`,
+  `TauCeti.IsMinimalProjectivePresentation.eq_zero_of_projective` and
+  `TauCeti.IsMinimalProjectivePresentation.subsingleton_of_projective`: over a projective module
+  the presentation degenerates, `P₀ ≅ M` and `P₁ = 0`.
+* `TauCeti.IsMinimalProjectivePresentation.range_le_jacobson` and
+  `TauCeti.IsMinimalProjectivePresentation.ker_le_jacobson`: both kernels sit inside the radical,
+  the standard quantitative form of minimality.
+
+## References
+
+This implements the projective half of sublayer 6B, "minimal projective/injective presentations",
+of Layer 6 of
+[the quiver-representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md),
+the prerequisite it names for the transpose `Tr` and the Auslander-Reiten translate `τ = D Tr`
+("it is well-defined only up to projectives, through minimal presentations and duality on
+finite-dimensional modules"). The injective co-presentation is the remaining half, as the injective
+envelope is the remaining half of `TauCeti/Algebra/Module/ProjectiveCover.lean`.
+
+* M. Auslander, I. Reiten, S. O. Smalø, *Representation Theory of Artin Algebras*, Cambridge
+  University Press (1995), Section I.2 and Section IV.1.
+* I. Assem, D. Simson, A. Skowroński, *Elements of the Representation Theory of Associative
+  Algebras, Vol. 1*, Cambridge University Press (2006), Section I.5 and Section IV.2.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w w' x x'
+
+variable {R : Type u} {M : Type v} {P₀ : Type w} {P₁ : Type w'}
+  [Ring R] [AddCommGroup M] [Module R M] [AddCommGroup P₀] [Module R P₀]
+  [AddCommGroup P₁] [Module R P₁]
+
+/-- A **minimal projective presentation** `P₁ → P₀ → M → 0` of `M`: the sequence is exact at `P₀`
+and at `M`, both sources are projective, and both maps are minimal — `p₀` is a projective cover of
+`M`, and `p₁` has superfluous kernel, so that it is a projective cover of the syzygy `ker p₀`
+(`TauCeti.IsMinimalProjectivePresentation.isProjectiveCover_codRestrict`).
+
+Only the exactness at `P₀`, `range p₁ = ker p₀`, is recorded: exactness at `M` is the surjectivity
+of `p₀`, which the projective cover already carries. -/
+structure IsMinimalProjectivePresentation (p₁ : P₁ →ₗ[R] P₀) (p₀ : P₀ →ₗ[R] M) : Prop where
+  /-- The right-hand map is a projective cover of the presented module. -/
+  isProjectiveCover : IsProjectiveCover p₀
+  /-- The left-hand source is projective. -/
+  projective : Module.Projective R P₁
+  /-- Exactness at `P₀`. -/
+  range_eq_ker : LinearMap.range p₁ = LinearMap.ker p₀
+  /-- Minimality of the left-hand map: it covers the syzygy without slack. -/
+  isSuperfluous_ker : IsSuperfluous (LinearMap.ker p₁)
+
+namespace IsMinimalProjectivePresentation
+
+variable {p₁ : P₁ →ₗ[R] P₀} {p₀ : P₀ →ₗ[R] M}
+
+/-- The presenting map of a minimal projective presentation is onto. -/
+theorem surjective (h : IsMinimalProjectivePresentation p₁ p₀) : Function.Surjective p₀ :=
+  h.isProjectiveCover.surjective
+
+/-- **A minimal projective presentation is a presentation**: the sequence `P₁ → P₀ → M` is exact at
+`P₀`. -/
+theorem exact (h : IsMinimalProjectivePresentation p₁ p₀) : Function.Exact p₁ p₀ :=
+  LinearMap.exact_iff.mpr h.range_eq_ker.symm
+
+/-- The left-hand map of a presentation lands in the syzygy. -/
+theorem apply_mem_ker (h : IsMinimalProjectivePresentation p₁ p₀) (x : P₁) :
+    p₁ x ∈ LinearMap.ker p₀ := by
+  rw [← h.range_eq_ker]
+  exact LinearMap.mem_range_self p₁ x
+
+/-- **Minimality of the left-hand map, in cover form**: corestricted to the syzygy `ker p₀`, the
+map `p₁` is a projective cover of it. This is the reading of the definition that
+`TauCeti.IsProjectiveCover.isMinimalProjectivePresentation` inverts. -/
+theorem isProjectiveCover_codRestrict (h : IsMinimalProjectivePresentation p₁ p₀) :
+    IsProjectiveCover (LinearMap.codRestrict (LinearMap.ker p₀) p₁ h.apply_mem_ker) where
+  projective := h.projective
+  surjective := by
+    intro y
+    have hy : (y : P₀) ∈ LinearMap.range p₁ := by rw [h.range_eq_ker]; exact y.2
+    obtain ⟨x, hx⟩ := hy
+    exact ⟨x, Subtype.ext hx⟩
+  isSuperfluous_ker := by
+    rw [LinearMap.ker_codRestrict]
+    exact h.isSuperfluous_ker
+
+end IsMinimalProjectivePresentation
+
+/-- **Two projective covers make a minimal projective presentation.** Given a projective cover `p₀`
+of `M` and a projective cover `c` of its syzygy `ker p₀`, following `c` by the inclusion of the
+syzygy presents `M` minimally. This is the only way a minimal presentation is ever built, so
+existence of minimal presentations is exactly existence of the two covers. -/
+theorem IsProjectiveCover.isMinimalProjectivePresentation {p₀ : P₀ →ₗ[R] M}
+    (h₀ : IsProjectiveCover p₀) {c : P₁ →ₗ[R] LinearMap.ker p₀} (h₁ : IsProjectiveCover c) :
+    IsMinimalProjectivePresentation ((LinearMap.ker p₀).subtype ∘ₗ c) p₀ where
+  isProjectiveCover := h₀
+  projective := h₁.projective
+  range_eq_ker := by
+    rw [LinearMap.range_comp, LinearMap.range_eq_top.mpr h₁.surjective, Submodule.map_top,
+      Submodule.range_subtype]
+  isSuperfluous_ker := by
+    have hker : LinearMap.ker ((LinearMap.ker p₀).subtype ∘ₗ c) = LinearMap.ker c := by
+      ext x
+      simp
+    rw [hker]
+    exact h₁.isSuperfluous_ker
+
+namespace IsMinimalProjectivePresentation
+
+variable {p₁ : P₁ →ₗ[R] P₀} {p₀ : P₀ →ₗ[R] M}
+
+section Comparison
+
+variable {Q₀ : Type x} {Q₁ : Type x'} [AddCommGroup Q₀] [Module R Q₀]
+  [AddCommGroup Q₁] [Module R Q₁]
+
+/-- **A minimal projective presentation is a quotient of every projective presentation.** If
+`Q₁ →ₗ Q₀ ↠ M` is any projective presentation of `M` — projective sources, exact at `Q₀`, onto `M`
+— then it maps onto a minimal projective presentation of `M` by a pair of **surjections**
+commuting with both maps.
+
+Both surjectivities are the minimality of the target: the first is that a projective cover receives
+every projective presentation by a surjection, and the second is the same statement for the induced
+map on syzygies, which is onto because the first one is. -/
+theorem exists_surjective [Module.Projective R Q₀] [Module.Projective R Q₁]
+    (h : IsMinimalProjectivePresentation p₁ p₀) {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
+    (hq₀ : Function.Surjective q₀) (hq : LinearMap.range q₁ = LinearMap.ker q₀) :
+    ∃ (f₀ : Q₀ →ₗ[R] P₀) (f₁ : Q₁ →ₗ[R] P₁),
+      p₀ ∘ₗ f₀ = q₀ ∧ f₀ ∘ₗ q₁ = p₁ ∘ₗ f₁ ∧
+        Function.Surjective f₀ ∧ Function.Surjective f₁ := by
+  obtain ⟨f₀, hf₀, hf₀surj⟩ := h.isProjectiveCover.exists_surjective hq₀
+  have hpf : ∀ y, p₀ (f₀ y) = q₀ y := fun y => LinearMap.congr_fun hf₀ y
+  -- The induced map on the two syzygies, corestricted to `ker p₀`.
+  have hmem : ∀ z : Q₁, (f₀ ∘ₗ q₁) z ∈ LinearMap.ker p₀ := by
+    intro z
+    have hz : q₁ z ∈ LinearMap.ker q₀ := by rw [← hq]; exact LinearMap.mem_range_self q₁ z
+    simpa [hpf] using hz
+  -- It is onto, because `f₀` is onto and the source sequence is exact at `Q₀`.
+  have hgsurj : Function.Surjective
+      (LinearMap.codRestrict (LinearMap.ker p₀) (f₀ ∘ₗ q₁) hmem) := by
+    intro y
+    obtain ⟨u, hu⟩ := hf₀surj (y : P₀)
+    have hu' : u ∈ LinearMap.range q₁ := by
+      rw [hq]
+      have hzero : p₀ (f₀ u) = 0 := by rw [hu]; exact y.2
+      simpa [hpf] using hzero
+    obtain ⟨z, hz⟩ := hu'
+    exact ⟨z, Subtype.ext (by simp [hz, hu])⟩
+  obtain ⟨f₁, hf₁, hf₁surj⟩ := h.isProjectiveCover_codRestrict.exists_surjective hgsurj
+  refine ⟨f₀, f₁, hf₀, LinearMap.ext fun z => ?_, hf₀surj, hf₁surj⟩
+  have hval := congrArg Subtype.val (LinearMap.congr_fun hf₁ z)
+  simpa using hval.symm
+
+/-- **Uniqueness of the minimal projective presentation.** Two minimal projective presentations of
+the same module are isomorphic as diagrams: there are linear equivalences of both sources
+commuting with the presenting map and with the two syzygy maps.
+
+The comparison surjections come from
+`TauCeti.IsMinimalProjectivePresentation.exists_surjective`; each is bijective because it compares
+two projective covers of the same module — of `M` on the right, and of the syzygy on the left, the
+two syzygies being identified by the right-hand equivalence. -/
+theorem exists_linearEquiv {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
+    (h : IsMinimalProjectivePresentation p₁ p₀)
+    (h' : IsMinimalProjectivePresentation q₁ q₀) :
+    ∃ (e₀ : P₀ ≃ₗ[R] Q₀) (e₁ : P₁ ≃ₗ[R] Q₁),
+      q₀ ∘ₗ (e₀ : P₀ →ₗ[R] Q₀) = p₀ ∧
+        (e₀ : P₀ →ₗ[R] Q₀) ∘ₗ p₁ = q₁ ∘ₗ (e₁ : P₁ →ₗ[R] Q₁) := by
+  have hP₀ : Module.Projective R P₀ := h.isProjectiveCover.projective
+  have hP₁ : Module.Projective R P₁ := h.projective
+  obtain ⟨f₀, f₁, hcomp, hsquare, -, -⟩ := h'.exists_surjective h.surjective h.range_eq_ker
+  have hbij₀ : Function.Bijective f₀ :=
+    h.isProjectiveCover.bijective_of_comp_eq h'.isProjectiveCover hcomp
+  have hqf : ∀ y, q₀ (f₀ y) = p₀ y := fun y => LinearMap.congr_fun hcomp y
+  -- The left-hand comparison, read as a map into the syzygy of the second presentation.
+  have hmem : ∀ z : P₁, (f₀ ∘ₗ p₁) z ∈ LinearMap.ker q₀ := by
+    intro z
+    have hz : p₁ z ∈ LinearMap.ker p₀ := h.apply_mem_ker z
+    simpa [hqf] using hz
+  have hkerf₀ : LinearMap.ker f₀ = ⊥ := LinearMap.ker_eq_bot.mpr hbij₀.injective
+  have hcover : IsProjectiveCover (LinearMap.codRestrict (LinearMap.ker q₀) (f₀ ∘ₗ p₁) hmem) := by
+    refine ⟨h.projective, ?_, ?_⟩
+    · intro y
+      obtain ⟨u, hu⟩ := hbij₀.2 (y : Q₀)
+      have hu' : u ∈ LinearMap.range p₁ := by
+        rw [h.range_eq_ker]
+        have hzero : q₀ (f₀ u) = 0 := by rw [hu]; exact y.2
+        simpa [hqf] using hzero
+      obtain ⟨z, hz⟩ := hu'
+      exact ⟨z, Subtype.ext (by simp [hz, hu])⟩
+    · have hker : LinearMap.ker (LinearMap.codRestrict (LinearMap.ker q₀) (f₀ ∘ₗ p₁) hmem)
+          = LinearMap.ker p₁ := by
+        rw [LinearMap.ker_codRestrict, LinearMap.ker_comp, hkerf₀, Submodule.comap_bot]
+      rw [hker]
+      exact h.isSuperfluous_ker
+  have hbij₁ : Function.Bijective f₁ := by
+    refine hcover.bijective_of_comp_eq h'.isProjectiveCover_codRestrict ?_
+    refine LinearMap.ext fun z => Subtype.ext ?_
+    simpa using (LinearMap.congr_fun hsquare z).symm
+  exact ⟨LinearEquiv.ofBijective f₀ hbij₀, LinearEquiv.ofBijective f₁ hbij₁, hcomp, hsquare⟩
+
+/-- **The syzygy of a minimal projective presentation is well defined.** The right-hand equivalence
+of `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv` carries one syzygy onto the
+other. -/
+theorem exists_linearEquiv_ker {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
+    (h : IsMinimalProjectivePresentation p₁ p₀)
+    (h' : IsMinimalProjectivePresentation q₁ q₀) :
+    Nonempty (LinearMap.ker p₀ ≃ₗ[R] LinearMap.ker q₀) := by
+  obtain ⟨e₀, -, hcomp, -⟩ := h.exists_linearEquiv h'
+  have hqe : ∀ z : P₀, q₀ (e₀ z) = p₀ z := fun z => LinearMap.congr_fun hcomp z
+  have hmap : (LinearMap.ker p₀).map (e₀ : P₀ →ₗ[R] Q₀) = LinearMap.ker q₀ := by
+    refine le_antisymm ?_ ?_
+    · rintro _ ⟨z, hz, rfl⟩
+      simpa [hqe] using hz
+    · intro y hy
+      have hy0 : q₀ y = 0 := by simpa using hy
+      refine ⟨e₀.symm y, ?_, by simp⟩
+      have hy' : q₀ y = p₀ (e₀.symm y) := by
+        rw [← hqe (e₀.symm y), e₀.apply_symm_apply]
+      simpa [← hy'] using hy0
+  exact ⟨(Submodule.equivMapOfInjective (e₀ : P₀ →ₗ[R] Q₀) e₀.injective _).trans
+    (LinearEquiv.ofEq _ _ hmap)⟩
+
+end Comparison
+
+section Projective
+
+variable [Module.Projective R M]
+
+/-- **A projective module presents itself.** In a minimal projective presentation of a projective
+module the presenting map is already an isomorphism, being a projective cover of a module that
+covers itself. -/
+theorem bijective_of_projective (h : IsMinimalProjectivePresentation p₁ p₀) :
+    Function.Bijective p₀ :=
+  h.isProjectiveCover.bijective_of_comp_eq isProjectiveCover_id (LinearMap.id_comp p₀)
+
+/-- The syzygy of a projective module vanishes, so the left-hand map of a minimal projective
+presentation of it is zero. -/
+theorem eq_zero_of_projective (h : IsMinimalProjectivePresentation p₁ p₀) : p₁ = 0 := by
+  have hker : LinearMap.ker p₀ = ⊥ :=
+    LinearMap.ker_eq_bot.mpr h.bijective_of_projective.injective
+  have hrange : LinearMap.range p₁ = ⊥ := by rw [h.range_eq_ker, hker]
+  exact LinearMap.range_eq_bot.mp hrange
+
+/-- Minimality forces the left-hand source of a minimal projective presentation of a projective
+module to vanish as well, not merely the map out of it. -/
+theorem subsingleton_of_projective (h : IsMinimalProjectivePresentation p₁ p₀) :
+    Subsingleton P₁ := by
+  have hker : LinearMap.ker p₁ = ⊤ := by
+    rw [h.eq_zero_of_projective]
+    exact LinearMap.ker_zero
+  have hsup := h.isSuperfluous_ker
+  rw [hker] at hsup
+  exact isSuperfluous_top_iff.mp hsup
+
+end Projective
+
+section Radical
+
+/-- **Minimality, quantitatively, on the right**: the image of the left-hand map — equivalently the
+syzygy — lies in the radical of `P₀`. A presentation whose image escaped the radical could be
+shrunk. -/
+theorem range_le_jacobson (h : IsMinimalProjectivePresentation p₁ p₀) :
+    LinearMap.range p₁ ≤ Module.jacobson R P₀ :=
+  h.range_eq_ker ▸ h.isProjectiveCover.ker_le_jacobson
+
+/-- **Minimality, quantitatively, on the left**: the kernel of the left-hand map lies in the
+radical of `P₁`. -/
+theorem ker_le_jacobson (h : IsMinimalProjectivePresentation p₁ p₀) :
+    LinearMap.ker p₁ ≤ Module.jacobson R P₁ :=
+  h.isSuperfluous_ker.le_jacobson
+
+end Radical
+
+end IsMinimalProjectivePresentation
+
+end TauCeti

--- a/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
+++ b/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
@@ -43,11 +43,14 @@ is conditional on a presentation being given, and
 `TauCeti.IsProjectiveCover.isMinimalProjectivePresentation` is the step that turns two covers into
 one presentation.
 
-The coefficients are a ring rather than a semiring, unlike the parts of
-`TauCeti/Algebra/Module/ProjectiveCover.lean` that only need a semiring. That is forced by the
-syzygy: `ker p₀` is a submodule, and a submodule of a module over a semiring carries only an
-`AddCommMonoid`, while the uniqueness statements about projective covers -- and hence everything
-below -- are available exactly for a covered module that is an additive group.
+The file is layered by the coefficients each part needs, as
+`TauCeti/Algebra/Module/ProjectiveCover.lean` is. The predicate itself and the two cover-form
+readings of it need only a semiring and additive monoids. The degeneration over a projective
+module needs the presented module to be an additive group, that being what uniqueness of covers
+needs. The comparison and uniqueness theorems need a ring, which the syzygy forces rather than the
+proofs choosing it: `ker p₀` is a submodule, a submodule of a module over a semiring carries only
+an `AddCommMonoid`, and the cover statements applied to it are available exactly for a covered
+module that is an additive group.
 
 ## Main definitions
 
@@ -96,9 +99,11 @@ namespace TauCeti
 
 universe u v w w' x x'
 
+section Semiring
+
 variable {R : Type u} {M : Type v} {P₀ : Type w} {P₁ : Type w'}
-  [Ring R] [AddCommGroup M] [Module R M] [AddCommGroup P₀] [Module R P₀]
-  [AddCommGroup P₁] [Module R P₁]
+  [Semiring R] [AddCommMonoid M] [Module R M] [AddCommMonoid P₀] [Module R P₀]
+  [AddCommMonoid P₁] [Module R P₁]
 
 /-- A **minimal projective presentation** `P₁ → P₀ → M → 0` of `M`: the sequence is exact at `P₀`
 and at `M`, both sources are projective, and both maps are minimal — `p₀` is a projective cover of
@@ -172,14 +177,61 @@ theorem IsProjectiveCover.isMinimalProjectivePresentation {p₀ : P₀ →ₗ[R]
     rw [hker]
     exact h₁.isSuperfluous_ker
 
+end Semiring
+
+section Projective
+
+variable {R : Type u} {M : Type v} {P₀ : Type w} {P₁ : Type w'}
+  [Semiring R] [AddCommGroup M] [Module R M] [AddCommGroup P₀] [Module R P₀]
+  [AddCommMonoid P₁] [Module R P₁]
+
+namespace IsMinimalProjectivePresentation
+
+variable {p₁ : P₁ →ₗ[R] P₀} {p₀ : P₀ →ₗ[R] M} [Module.Projective R M]
+
+/-- **A projective module presents itself.** In a minimal projective presentation of a projective
+module the presenting map is already an isomorphism, being a projective cover of a module that
+covers itself. -/
+theorem bijective_of_projective (h : IsMinimalProjectivePresentation p₁ p₀) :
+    Function.Bijective p₀ :=
+  h.isProjectiveCover.bijective_of_comp_eq isProjectiveCover_id (LinearMap.id_comp p₀)
+
+/-- The syzygy of a projective module vanishes, so the left-hand map of a minimal projective
+presentation of it is zero. -/
+theorem eq_zero_of_projective (h : IsMinimalProjectivePresentation p₁ p₀) : p₁ = 0 := by
+  have hker : LinearMap.ker p₀ = ⊥ :=
+    LinearMap.ker_eq_bot'.mpr fun m hm => h.bijective_of_projective.injective (by simpa using hm)
+  have hrange : LinearMap.range p₁ = ⊥ := by rw [h.range_eq_ker, hker]
+  exact LinearMap.range_eq_bot.mp hrange
+
+/-- Minimality forces the left-hand source of a minimal projective presentation of a projective
+module to vanish as well, not merely the map out of it. -/
+theorem subsingleton_of_projective (h : IsMinimalProjectivePresentation p₁ p₀) :
+    Subsingleton P₁ := by
+  have hker : LinearMap.ker p₁ = ⊤ := by
+    rw [h.eq_zero_of_projective]
+    exact LinearMap.ker_zero
+  have hsup := h.isSuperfluous_ker
+  rw [hker] at hsup
+  exact isSuperfluous_top_iff.mp hsup
+
+end IsMinimalProjectivePresentation
+
+end Projective
+
+section Ring
+
+variable {R : Type u} {M : Type v} {P₀ : Type w} {P₁ : Type w'}
+  [Ring R] [AddCommGroup M] [Module R M] [AddCommGroup P₀] [Module R P₀]
+  [AddCommGroup P₁] [Module R P₁]
+
 namespace IsMinimalProjectivePresentation
 
 variable {p₁ : P₁ →ₗ[R] P₀} {p₀ : P₀ →ₗ[R] M}
 
 section Comparison
 
-variable {Q₀ : Type x} {Q₁ : Type x'} [AddCommGroup Q₀] [Module R Q₀]
-  [AddCommGroup Q₁] [Module R Q₁]
+variable {Q₀ : Type x} {Q₁ : Type x'}
 
 /-- **A minimal projective presentation is a quotient of every projective presentation.** If
 `Q₁ →ₗ Q₀ ↠ M` is any projective presentation of `M` — projective sources, exact at `Q₀`, onto `M`
@@ -189,7 +241,8 @@ commuting with both maps.
 Both surjectivities are the minimality of the target: the first is that a projective cover receives
 every projective presentation by a surjection, and the second is the same statement for the induced
 map on syzygies, which is onto because the first one is. -/
-theorem exists_surjective [Module.Projective R Q₀] [Module.Projective R Q₁]
+theorem exists_surjective [AddCommMonoid Q₀] [Module R Q₀] [Module.Projective R Q₀]
+    [AddCommMonoid Q₁] [Module R Q₁] [Module.Projective R Q₁]
     (h : IsMinimalProjectivePresentation p₁ p₀) {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
     (hq₀ : Function.Surjective q₀) (hq : LinearMap.range q₁ = LinearMap.ker q₀) :
     ∃ (f₀ : Q₀ →ₗ[R] P₀) (f₁ : Q₁ →ₗ[R] P₁),
@@ -217,6 +270,8 @@ theorem exists_surjective [Module.Projective R Q₀] [Module.Projective R Q₁]
   refine ⟨f₀, f₁, hf₀, LinearMap.ext fun z => ?_, hf₀surj, hf₁surj⟩
   have hval := congrArg Subtype.val (LinearMap.congr_fun hf₁ z)
   simpa using hval.symm
+
+variable [AddCommGroup Q₀] [Module R Q₀] [AddCommGroup Q₁] [Module R Q₁]
 
 /-- **Uniqueness of the minimal projective presentation.** Two minimal projective presentations of
 the same module are isomorphic as diagrams: there are linear equivalences of both sources
@@ -289,38 +344,6 @@ theorem nonempty_linearEquiv_ker {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →�
 
 end Comparison
 
-section Projective
-
-variable [Module.Projective R M]
-
-/-- **A projective module presents itself.** In a minimal projective presentation of a projective
-module the presenting map is already an isomorphism, being a projective cover of a module that
-covers itself. -/
-theorem bijective_of_projective (h : IsMinimalProjectivePresentation p₁ p₀) :
-    Function.Bijective p₀ :=
-  h.isProjectiveCover.bijective_of_comp_eq isProjectiveCover_id (LinearMap.id_comp p₀)
-
-/-- The syzygy of a projective module vanishes, so the left-hand map of a minimal projective
-presentation of it is zero. -/
-theorem eq_zero_of_projective (h : IsMinimalProjectivePresentation p₁ p₀) : p₁ = 0 := by
-  have hker : LinearMap.ker p₀ = ⊥ :=
-    LinearMap.ker_eq_bot.mpr h.bijective_of_projective.injective
-  have hrange : LinearMap.range p₁ = ⊥ := by rw [h.range_eq_ker, hker]
-  exact LinearMap.range_eq_bot.mp hrange
-
-/-- Minimality forces the left-hand source of a minimal projective presentation of a projective
-module to vanish as well, not merely the map out of it. -/
-theorem subsingleton_of_projective (h : IsMinimalProjectivePresentation p₁ p₀) :
-    Subsingleton P₁ := by
-  have hker : LinearMap.ker p₁ = ⊤ := by
-    rw [h.eq_zero_of_projective]
-    exact LinearMap.ker_zero
-  have hsup := h.isSuperfluous_ker
-  rw [hker] at hsup
-  exact isSuperfluous_top_iff.mp hsup
-
-end Projective
-
 section Radical
 
 /-- **Minimality, quantitatively, on the right**: the image of the left-hand map — equivalently the
@@ -339,5 +362,7 @@ theorem ker_le_jacobson (h : IsMinimalProjectivePresentation p₁ p₀) :
 end Radical
 
 end IsMinimalProjectivePresentation
+
+end Ring
 
 end TauCeti

--- a/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
+++ b/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
@@ -24,7 +24,7 @@ carrying its corestriction around in the definition would make every consumer co
 in the corestricted form, and `TauCeti.IsProjectiveCover.isMinimalProjectivePresentation` builds a
 minimal presentation from a pair of covers, so the two readings are interchangeable.
 
-The theorem the notion exists for is that a minimal projective presentation is a *retract* of every
+The theorem the notion exists for is that a minimal projective presentation is a *quotient* of every
 projective presentation: given any projective presentation of the same module there are
 **surjections** from it onto the minimal one commuting with both maps
 (`TauCeti.IsMinimalProjectivePresentation.exists_surjective`). Applying that to a second minimal
@@ -36,10 +36,12 @@ the cokernel of `Hom(−, A)` applied to a minimal projective presentation of `M
 because of it.
 
 *Existence* is a separate matter, exactly as for projective covers: it is a condition on the ring
-(over a semiperfect algebra every finitely generated module has a projective cover, and iterating
-gives a minimal presentation). Nothing here assumes it; every statement is conditional on a
-presentation being given, and `TauCeti.IsProjectiveCover.isMinimalProjectivePresentation` is the
-step that turns two covers into one presentation.
+(over a semiperfect ring every finitely generated module has a projective cover, and over an Artin
+algebra, where finitely generated modules are noetherian and so the syzygy is again finitely
+generated, iterating that gives a minimal presentation). Nothing here assumes it; every statement
+is conditional on a presentation being given, and
+`TauCeti.IsProjectiveCover.isMinimalProjectivePresentation` is the step that turns two covers into
+one presentation.
 
 The coefficients are a ring rather than a semiring, unlike the parts of
 `TauCeti/Algebra/Module/ProjectiveCover.lean` that only need a semiring. That is forced by the
@@ -62,7 +64,7 @@ below -- are available exactly for a covered module that is an additive group.
   is a quotient of every projective presentation**, by a pair of surjections commuting with the
   maps.
 * `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv`: **uniqueness**, as an isomorphism
-  of the whole diagram; `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv_ker` records
+  of the whole diagram; `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_ker` records
   the resulting isomorphism of syzygies.
 * `TauCeti.IsMinimalProjectivePresentation.bijective_of_projective`,
   `TauCeti.IsMinimalProjectivePresentation.eq_zero_of_projective` and
@@ -266,7 +268,7 @@ theorem exists_linearEquiv {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M
 /-- **The syzygy of a minimal projective presentation is well defined.** The right-hand equivalence
 of `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv` carries one syzygy onto the
 other. -/
-theorem exists_linearEquiv_ker {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
+theorem nonempty_linearEquiv_ker {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
     (h : IsMinimalProjectivePresentation p₁ p₀)
     (h' : IsMinimalProjectivePresentation q₁ q₀) :
     Nonempty (LinearMap.ker p₀ ≃ₗ[R] LinearMap.ker q₀) := by

--- a/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
+++ b/TauCeti/Algebra/Module/MinimalProjectivePresentation.lean
@@ -72,9 +72,9 @@ submodule need not be closed under negation, as `ℕ ⊆ ℤ` shows — so over 
 * `TauCeti.IsMinimalProjectivePresentation.bijective_of_comp_eq` and
   `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv`: **uniqueness**, first as
   bijectivity of any pair of comparison maps between two minimal presentations and then as an
-  isomorphism of the whole diagram;
-  `TauCeti.IsMinimalProjectivePresentation.nonempty_linearEquiv_ker` records the resulting
-  isomorphism of syzygies.
+  isomorphism of the whole diagram. The accompanying isomorphism of syzygies needs neither
+  left-hand map and so is stated one layer down, as
+  `TauCeti.IsProjectiveCover.nonempty_linearEquiv_ker` for the two right-hand covers.
 * `TauCeti.IsMinimalProjectivePresentation.bijective_of_projective`,
   `TauCeti.IsMinimalProjectivePresentation.eq_zero_of_projective` and
   `TauCeti.IsMinimalProjectivePresentation.subsingleton_of_projective`: over a projective module
@@ -337,27 +337,6 @@ theorem exists_linearEquiv {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M
   obtain ⟨f₀, f₁, hcomp, hsquare, -, -⟩ := h'.exists_surjective h.surjective h.range_eq_ker
   obtain ⟨hbij₀, hbij₁⟩ := h.bijective_of_comp_eq h' hcomp hsquare
   exact ⟨LinearEquiv.ofBijective f₀ hbij₀, LinearEquiv.ofBijective f₁ hbij₁, hcomp, hsquare⟩
-
-/-- **The syzygy of a minimal projective presentation is well defined.** The right-hand equivalence
-of `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv` carries one syzygy onto the
-other. -/
-theorem nonempty_linearEquiv_ker {q₁ : Q₁ →ₗ[R] Q₀} {q₀ : Q₀ →ₗ[R] M}
-    (h : IsMinimalProjectivePresentation p₁ p₀)
-    (h' : IsMinimalProjectivePresentation q₁ q₀) :
-    Nonempty (LinearMap.ker p₀ ≃ₗ[R] LinearMap.ker q₀) := by
-  obtain ⟨e₀, -, hcomp, -⟩ := h.exists_linearEquiv h'
-  have hqe : ∀ z : P₀, q₀ (e₀ z) = p₀ z := fun z => LinearMap.congr_fun hcomp z
-  have hmap : (LinearMap.ker p₀).map (e₀ : P₀ →ₗ[R] Q₀) = LinearMap.ker q₀ := by
-    refine le_antisymm ?_ ?_
-    · rintro _ ⟨z, hz, rfl⟩
-      simpa [hqe] using hz
-    · intro y hy
-      have hy0 : q₀ y = 0 := by simpa using hy
-      refine ⟨e₀.symm y, ?_, by simp⟩
-      have hy' : q₀ y = p₀ (e₀.symm y) := by
-        rw [← hqe (e₀.symm y), e₀.apply_symm_apply]
-      simpa [← hy'] using hy0
-  exact ⟨e₀.ofSubmodules (LinearMap.ker p₀) (LinearMap.ker q₀) hmap⟩
 
 end Comparison
 

--- a/TauCeti/Algebra/Module/ProjectiveCover.lean
+++ b/TauCeti/Algebra/Module/ProjectiveCover.lean
@@ -53,6 +53,8 @@ statement is conditional on a cover being given.
 * `TauCeti.IsProjectiveCover.bijective_of_comp_eq` and
   `TauCeti.IsProjectiveCover.exists_linearEquiv`: **uniqueness**, first as bijectivity of any
   comparison map between two covers and then as the existence of an isomorphism over `M`.
+* `TauCeti.IsProjectiveCover.nonempty_linearEquiv_ker`: uniqueness read on the kernels — the syzygy
+  cut out by a projective cover of `M` is independent of the cover.
 * `TauCeti.IsProjectiveCover.comp`: composing a projective cover with a surjection that itself
   has superfluous kernel again gives a projective cover.
 * `TauCeti.IsProjectiveCover.ker_le_jacobson`: the kernel of a projective cover lies in the radical
@@ -167,6 +169,17 @@ theorem IsProjectiveCover.exists_linearEquiv {P' : Type*} [AddCommGroup P'] [Mod
   refine ⟨LinearEquiv.ofBijective h (hf.bijective_of_comp_eq hf' hh), ?_⟩
   ext p
   simpa using LinearMap.congr_fun hh p
+
+/-- **The kernel of a projective cover is well defined.** The equivalence of covering modules of
+`TauCeti.IsProjectiveCover.exists_linearEquiv` carries the kernel of one cover onto the kernel of
+the other, so the syzygy that a projective cover of `M` cuts out does not depend on the cover. -/
+theorem IsProjectiveCover.nonempty_linearEquiv_ker {P' : Type*} [AddCommGroup P'] [Module R P']
+    {f : P →ₗ[R] M} {f' : P' →ₗ[R] M} (hf : IsProjectiveCover f) (hf' : IsProjectiveCover f') :
+    Nonempty (LinearMap.ker f ≃ₗ[R] LinearMap.ker f') := by
+  obtain ⟨e, hcomp⟩ := hf.exists_linearEquiv hf'
+  have hmap : (LinearMap.ker f).map (e : P →ₗ[R] P') = LinearMap.ker f' := by
+    rw [← hcomp, LinearMap.ker_comp, Submodule.map_comap_eq_of_surjective e.surjective]
+  exact ⟨e.ofSubmodules (LinearMap.ker f) (LinearMap.ker f') hmap⟩
 
 /-- Composing a projective cover with a surjection whose kernel is superfluous again gives a
 projective cover. -/


### PR DESCRIPTION
This PR adds minimal projective presentations of modules: the predicate `TauCeti.IsMinimalProjectivePresentation p₁ p₀` for an exact sequence `P₁ → P₀ → M → 0` whose two maps are both minimal, the comparison theorem that it is a quotient of every projective presentation, and the uniqueness that follows. It builds sublayer **6B, "minimal projective/injective presentations"**, of Layer 6 of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` — the layer text names the sublayers "each a target on its own", and names 6B as a prerequisite of the transpose `Tr` and the Auslander-Reiten translate: "The `τ = D Tr` composite is **not** a bare definition: it is well-defined only up to projectives, through minimal presentations and duality on finite-dimensional modules, so 6B-6D are prerequisites." Only the projective half lands here; the injective co-presentation is the remaining half, exactly as the injective envelope is the remaining half of the projective-cover file this one sits beside.

The whole development is layered on `TauCeti/Algebra/Module/ProjectiveCover.lean`, which already supplies `TauCeti.IsProjectiveCover`, the fact that a projective cover receives every projective presentation by a surjection, and the uniqueness of a cover as bijectivity of any comparison map; nothing about covers is reproved. Minimality is recorded as two superfluous kernels rather than as a nested `IsProjectiveCover`, because the second cover is a map into the submodule `ker p₀` and carrying its corestriction inside the definition would make every consumer corestrict as well; `TauCeti.IsMinimalProjectivePresentation.isProjectiveCover_codRestrict` and `TauCeti.IsProjectiveCover.isMinimalProjectivePresentation` are the two directions that make the readings interchangeable, the second of them being the step that turns a pair of covers into a presentation, so that existence of minimal presentations is exactly existence of the two covers and nothing here assumes it.

The theorem the notion exists for is `TauCeti.IsMinimalProjectivePresentation.exists_surjective`: any projective presentation of the same module maps onto the minimal one by a pair of **surjections** commuting with both maps. Feeding a second minimal presentation into it and reading the two comparison maps back through the uniqueness of covers turns them into isomorphisms, which is `TauCeti.IsMinimalProjectivePresentation.exists_linearEquiv`, uniqueness as an isomorphism of the whole diagram, with `exists_linearEquiv_ker` recording the resulting isomorphism of syzygies. Alongside these: exactness as `Function.Exact`, the degenerate presentation of a projective module (`P₀ ≅ M`, `p₁ = 0`, and `P₁` subsingleton), and both kernels lying in the module radical. The coefficients are a ring rather than a semiring, which is forced rather than chosen: the syzygy `ker p₀` is a submodule, over a semiring that carries only an `AddCommMonoid`, while the uniqueness statements about covers are available exactly for a covered module that is an additive group; the module docstring records this.

No Mathlib infrastructure was vendored. `lake build`, `lake exe axioms`, `scripts/lint-style.sh`, `scripts/lint-env.sh` and `scripts/lint-dot-notation.py` all pass locally.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"minimal-projective-presentation"}-->

🤖 Prepared with Claude Code
