### PR TITLE
feat: make recurrent prefixes last-exit admissible

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/LastExit.lean
+++ b/TauCeti/Combinatorics/Enumerative/LastExit.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Combinatorics.Enumerative.SuccessorArray
+
+/-!
+# Last-exit admissibility for finite path reconstruction
+
+The successor-array proof of the Diaconis--Freedman theorem reconstructs a finite path after
+permuting entries separately within each successor row. The finite reconstruction theorem needs
+the chosen row permutations to preserve every part of a row used by the prefix and to fix its last
+used entry. This file packages that classical *last-exit condition* and gives its deterministic
+support criterion.
+
+## Main definitions and results
+
+* `TauCeti.LastExitAdmissible` packages the two hypotheses of finite last-exit reconstruction;
+* `TauCeti.lastExitAdmissible_of_support_lt_visitCount` proves the support criterion.
+
+## References
+
+* P. Diaconis and D. Freedman, "de Finetti's theorem for Markov chains", *Annals of Probability*
+  8 (1980), 115--130.
+* S. Fortini, L. Ladelli, G. Petris, and E. Regazzini, "On mixtures of distributions of Markov
+  chains", *Stochastic Processes and their Applications* 100 (2002), 147--165, Lemma 1(b).
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+variable {α : Type*}
+
+/-- A family of successor-row permutations is **last-exit admissible** for the prefix of `x`
+before time `m` when it preserves every used row prefix and fixes the final used position in each
+nonempty row.
+
+These are exactly the two hypotheses needed by finite last-exit reconstruction: the first keeps
+every reindexed successor entry inside the finite prefix, and the second prevents reconstruction
+from closing a proper subtrail before all prescribed entries have been consumed. -/
+def LastExitAdmissible (π : α → Equiv.Perm ℕ) (x : ℕ → α) (m : ℕ) : Prop :=
+  (∀ a k, k < visitCount x a m → π a k < visitCount x a m) ∧
+    ∀ a, 0 < visitCount x a m →
+      π a (visitCount x a m - 1) = visitCount x a m - 1
+
+/-- The two conditions defining last-exit admissibility. -/
+@[simp]
+theorem lastExitAdmissible_iff {π : α → Equiv.Perm ℕ} {x : ℕ → α} {m : ℕ} :
+    LastExitAdmissible π x m ↔
+      (∀ a k, k < visitCount x a m → π a k < visitCount x a m) ∧
+        ∀ a, 0 < visitCount x a m →
+          π a (visitCount x a m - 1) = visitCount x a m - 1 :=
+  Iff.rfl
+
+/-- A last-exit-admissible permutation keeps every used row index inside the used prefix. -/
+theorem LastExitAdmissible.maps_lt_visitCount
+    {π : α → Equiv.Perm ℕ} {x : ℕ → α} {m : ℕ}
+    (h : LastExitAdmissible π x m) {a : α} {k : ℕ} (hk : k < visitCount x a m) :
+    π a k < visitCount x a m :=
+  h.1 a k hk
+
+/-- A last-exit-admissible permutation fixes the last used index of every nonempty row. -/
+theorem LastExitAdmissible.apply_visitCount_sub_one {π : α → Equiv.Perm ℕ}
+    {x : ℕ → α} {m : ℕ} (h : LastExitAdmissible π x m) {a : α}
+    (ha : 0 < visitCount x a m) :
+    π a (visitCount x a m - 1) = visitCount x a m - 1 :=
+  h.2 a ha
+
+/-- If every moved position lies strictly below the last used position of its row, then the row
+permutations are last-exit admissible. -/
+theorem lastExitAdmissible_of_support_lt_visitCount {π : α → Equiv.Perm ℕ}
+    {x : ℕ → α} {m : ℕ}
+    (h : ∀ a, 0 < visitCount x a m → ∀ k, π a k ≠ k → k + 1 < visitCount x a m) :
+    LastExitAdmissible π x m := by
+  rw [lastExitAdmissible_iff]
+  constructor
+  · intro a k hk
+    by_cases hfix : π a k = k
+    · simpa only [hfix] using hk
+    · have himage : π a (π a k) ≠ π a k := by
+        intro himage
+        exact hfix ((π a).injective himage)
+      have hlt := h a (Nat.zero_lt_of_lt hk) (π a k) himage
+      omega
+  · intro a ha
+    by_contra hlast
+    have hlt := h a ha (visitCount x a m - 1) hlast
+    omega
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Probability/Exchangeability/Recurrence/LastExit.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/LastExit.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- Public: recurrence and visit counts occur in the main statements.
+public import TauCeti.Probability.Exchangeability.Recurrence.SuccessorArray
+
+/-!
+# Recurrent prefixes adapted to finite successor reindexings
+
+The successor-array proof of the Diaconis--Freedman theorem reconstructs a finite path after
+permuting entries separately within each successor row.  The finite reconstruction theorem needs
+the chosen row permutations to preserve every part of a row used by the prefix and to fix its last
+used entry.  This is the classical *last-exit condition*.
+
+This file supplies the recurrence step that produces that condition.  A family
+`π : α → Equiv.Perm ℕ` of row permutations with finite total support moves entries in only
+finitely many rows and only at finitely many positions.  Along a recurrent path, every such row is
+either never visited or eventually has more visits than every moved position.  Consequently every
+sufficiently long prefix is `LastExitAdmissible π x`: `π` permutes each used row prefix within
+itself and fixes its last position.
+
+This is the bridge between finite-support reduction for row exchangeability and finite last-exit
+reconstruction in the Layer 8 Markov-exchangeability milestone of
+`TauCetiRoadmap/Exchangeability/README.md`.  The remaining step after this bridge is probabilistic:
+use Markov exchangeability to compare the reconstructed finite prefixes and then pass to the full
+successor-array law.
+
+## Main definitions and results
+
+* `TauCeti.LastExitAdmissible` packages the two hypotheses of finite last-exit reconstruction;
+* `TauCeti.eventually_lastExitAdmissible_of_recurrent` is the pointwise recurrence theorem;
+* `TauCeti.Probability.Recurrent.ae_eventually_lastExitAdmissible` is its process-level form.
+
+## References
+
+* P. Diaconis and D. Freedman, "de Finetti's theorem for Markov chains", *Annals of Probability*
+  8 (1980), 115--130.
+* S. Fortini, L. Ladelli, G. Petris, and E. Regazzini, "On mixtures of distributions of Markov
+  chains", *Stochastic Processes and their Applications* 100 (2002), 147--165, Lemma 1(b).
+
+No material is adapted from `cameronfreer/exchangeability`, which treats exchangeable rather than
+Markov-exchangeable sequences.
+-/
+
+public section
+
+noncomputable section
+
+open Filter MeasureTheory
+
+namespace TauCeti
+
+variable {α : Type*}
+
+/-- A family of successor-row permutations is **last-exit admissible** for the prefix of `x`
+before time `m` when it preserves every used row prefix and fixes the final used position in each
+nonempty row.
+
+These are exactly the two hypotheses needed by finite last-exit reconstruction: the first keeps
+every reindexed successor entry inside the finite prefix, and the second prevents reconstruction
+from closing a proper subtrail before all prescribed entries have been consumed. -/
+def LastExitAdmissible (π : α → Equiv.Perm ℕ) (x : ℕ → α) (m : ℕ) : Prop :=
+  (∀ a k, k < visitCount x a m → π a k < visitCount x a m) ∧
+    ∀ a, 0 < visitCount x a m →
+      π a (visitCount x a m - 1) = visitCount x a m - 1
+
+/-- The two conditions defining last-exit admissibility. -/
+@[simp]
+theorem lastExitAdmissible_iff {π : α → Equiv.Perm ℕ} {x : ℕ → α} {m : ℕ} :
+    LastExitAdmissible π x m ↔
+      (∀ a k, k < visitCount x a m → π a k < visitCount x a m) ∧
+        ∀ a, 0 < visitCount x a m →
+          π a (visitCount x a m - 1) = visitCount x a m - 1 :=
+  Iff.rfl
+
+/-- A last-exit-admissible permutation keeps every used row index inside the used prefix. -/
+theorem LastExitAdmissible.maps_lt_visitCount
+    {π : α → Equiv.Perm ℕ} {x : ℕ → α} {m : ℕ}
+    (h : LastExitAdmissible π x m) {a : α} {k : ℕ} (hk : k < visitCount x a m) :
+    π a k < visitCount x a m :=
+  h.1 a k hk
+
+/-- A last-exit-admissible permutation fixes the last used index of every nonempty row. -/
+theorem LastExitAdmissible.apply_visitCount_sub_one {π : α → Equiv.Perm ℕ}
+    {x : ℕ → α} {m : ℕ} (h : LastExitAdmissible π x m) {a : α}
+    (ha : 0 < visitCount x a m) :
+    π a (visitCount x a m - 1) = visitCount x a m - 1 :=
+  h.2 a ha
+
+/-- If every moved position lies strictly below the last used position of its row, then the row
+permutations are last-exit admissible. -/
+theorem lastExitAdmissible_of_support_lt_visitCount {π : α → Equiv.Perm ℕ}
+    {x : ℕ → α} {m : ℕ}
+    (h : ∀ a, 0 < visitCount x a m → ∀ k, π a k ≠ k → k + 1 < visitCount x a m) :
+    LastExitAdmissible π x m := by
+  rw [lastExitAdmissible_iff]
+  constructor
+  · intro a k hk
+    by_cases hfix : π a k = k
+    · simpa only [hfix] using hk
+    · have himage : π a (π a k) ≠ π a k := by
+        intro himage
+        exact hfix ((π a).injective himage)
+      have hlt := h a (Nat.zero_lt_of_lt hk) (π a k) himage
+      omega
+  · intro a ha
+    by_contra hlast
+    have hlt := h a ha (visitCount x a m - 1) hlast
+    omega
+
+/-- **Finite-support row reindexings are eventually last-exit admissible along a recurrent
+path.** Here recurrence is stated pointwise: every state attained by `x` is attained infinitely
+often.  A row occurring in the finite support is either unattained, in which case its visit count
+is always zero, or its visit count eventually exceeds every supported position. -/
+theorem eventually_lastExitAdmissible_of_recurrent {π : α → Equiv.Perm ℕ} {x : ℕ → α}
+    (hrec : ∀ k : ℕ, {n | x n = x k}.Infinite)
+    (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2}.Finite) :
+    ∀ᶠ m in atTop, LastExitAdmissible π x m := by
+  classical
+  have hsupported : ∀ p ∈ {p : α × ℕ | π p.1 p.2 ≠ p.2},
+      ∀ᶠ m in atTop,
+        visitCount x p.1 m = 0 ∨ p.2 + 1 < visitCount x p.1 m := by
+    intro p hp
+    by_cases hvisited : ∃ t, x t = p.1
+    · obtain ⟨t, ht⟩ := hvisited
+      have hinfinite : {n | x n = p.1}.Infinite := by
+        simpa only [ht] using hrec t
+      have hcount : Tendsto (visitCount x p.1) atTop atTop := by
+        refine tendsto_atTop_atTop.2 fun b => ?_
+        obtain ⟨n, -, hn⟩ := exists_visitCount_of_infinite hinfinite b
+        exact ⟨n, fun m hnm => hn ▸ visitCount_monotone x p.1 hnm⟩
+      obtain ⟨N, hN⟩ := tendsto_atTop_atTop.1 hcount (p.2 + 2)
+      exact eventually_atTop.2 ⟨N, fun m hm => Or.inr (by have := hN m hm; omega)⟩
+    · exact Eventually.of_forall fun m => Or.inl <|
+        visitCount_eq_zero_of_forall_ne fun i _ hi => hvisited ⟨i, hi⟩
+  filter_upwards [hπ.eventually_all.2 hsupported] with m hm
+  apply lastExitAdmissible_of_support_lt_visitCount
+  intro a ha k hk
+  have hmem : (a, k) ∈ {p : α × ℕ | π p.1 p.2 ≠ p.2} := hk
+  rcases hm (a, k) hmem with hzero | hlt
+  · exact (ha.ne' hzero).elim
+  · exact hlt
+
+/-- Pointwise existence form of
+`TauCeti.eventually_lastExitAdmissible_of_recurrent`: beyond every prescribed time there is an
+adapted prefix. -/
+theorem exists_ge_lastExitAdmissible_of_recurrent {π : α → Equiv.Perm ℕ} {x : ℕ → α}
+    (hrec : ∀ k : ℕ, {n | x n = x k}.Infinite)
+    (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2}.Finite) (N : ℕ) :
+    ∃ m, N ≤ m ∧ LastExitAdmissible π x m := by
+  obtain ⟨M, hM⟩ := eventually_atTop.1 (eventually_lastExitAdmissible_of_recurrent hrec hπ)
+  exact ⟨max N M, le_max_left _ _, hM _ (le_max_right _ _)⟩
+
+namespace Probability
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} {X : ℕ → Ω → α}
+
+/-- **A finite-support family of successor-row permutations is almost surely eventually
+last-exit admissible for a recurrent process.** This is the process-level recurrence bridge used
+before finite last-exit reconstruction. -/
+theorem Recurrent.ae_eventually_lastExitAdmissible (h : Recurrent μ X)
+    (π : α → Equiv.Perm ℕ) (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2}.Finite) :
+    ∀ᵐ ω ∂μ, ∀ᶠ m in atTop, LastExitAdmissible π (fun n => X n ω) m := by
+  filter_upwards [h.ae_infinite_setOf_eq] with ω hω
+  exact eventually_lastExitAdmissible_of_recurrent hω hπ
+
+/-- Beyond every deterministic time, a recurrent process almost surely has a prefix adapted to a
+given finite-support family of successor-row permutations. -/
+theorem Recurrent.ae_exists_ge_lastExitAdmissible (h : Recurrent μ X)
+    (π : α → Equiv.Perm ℕ) (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2}.Finite) (N : ℕ) :
+    ∀ᵐ ω ∂μ, ∃ m, N ≤ m ∧ LastExitAdmissible π (fun n => X n ω) m := by
+  filter_upwards [h.ae_eventually_lastExitAdmissible π hπ] with ω hω
+  obtain ⟨M, hM⟩ := eventually_atTop.1 hω
+  exact ⟨max N M, le_max_left _ _, hM _ (le_max_right _ _)⟩
+
+end Probability
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Probability/Exchangeability/Recurrence/LastExit.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/LastExit.lean
@@ -145,16 +145,6 @@ theorem eventually_lastExitAdmissible_of_recurrent {π : α → Equiv.Perm ℕ} 
   · exact (ha.ne' hzero).elim
   · exact hlt
 
-/-- Pointwise existence form of
-`TauCeti.eventually_lastExitAdmissible_of_recurrent`: beyond every prescribed time there is an
-adapted prefix. -/
-theorem exists_ge_lastExitAdmissible_of_recurrent {π : α → Equiv.Perm ℕ} {x : ℕ → α}
-    (hrec : ∀ k : ℕ, {n | x n = x k}.Infinite)
-    (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2}.Finite) (N : ℕ) :
-    ∃ m, N ≤ m ∧ LastExitAdmissible π x m := by
-  obtain ⟨M, hM⟩ := eventually_atTop.1 (eventually_lastExitAdmissible_of_recurrent hrec hπ)
-  exact ⟨max N M, le_max_left _ _, hM _ (le_max_right _ _)⟩
-
 namespace Probability
 
 variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω} {X : ℕ → Ω → α}
@@ -167,15 +157,6 @@ theorem Recurrent.ae_eventually_lastExitAdmissible (h : Recurrent μ X)
     ∀ᵐ ω ∂μ, ∀ᶠ m in atTop, LastExitAdmissible π (fun n => X n ω) m := by
   filter_upwards [h.ae_infinite_setOf_eq] with ω hω
   exact eventually_lastExitAdmissible_of_recurrent hω hπ
-
-/-- Beyond every deterministic time, a recurrent process almost surely has a prefix adapted to a
-given finite-support family of successor-row permutations. -/
-theorem Recurrent.ae_exists_ge_lastExitAdmissible (h : Recurrent μ X)
-    (π : α → Equiv.Perm ℕ) (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2}.Finite) (N : ℕ) :
-    ∀ᵐ ω ∂μ, ∃ m, N ≤ m ∧ LastExitAdmissible π (fun n => X n ω) m := by
-  filter_upwards [h.ae_eventually_lastExitAdmissible π hπ] with ω hω
-  obtain ⟨M, hM⟩ := eventually_atTop.1 hω
-  exact ⟨max N M, le_max_left _ _, hM _ (le_max_right _ _)⟩
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Recurrence/LastExit.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/LastExit.lean
@@ -5,23 +5,17 @@ Authors: The Tau Ceti contributors
 -/
 module
 
--- Public: recurrence and visit counts occur in the main statements.
-public import TauCeti.Probability.Exchangeability.Recurrence.SuccessorArray
+public import TauCeti.Combinatorics.Enumerative.LastExit
+public import TauCeti.Probability.Recurrent
 
 /-!
 # Recurrent prefixes adapted to finite successor reindexings
 
-The successor-array proof of the Diaconis--Freedman theorem reconstructs a finite path after
-permuting entries separately within each successor row.  The finite reconstruction theorem needs
-the chosen row permutations to preserve every part of a row used by the prefix and to fix its last
-used entry.  This is the classical *last-exit condition*.
-
-This file supplies the recurrence step that produces that condition.  A family
-`π : α → Equiv.Perm ℕ` of row permutations with finite total support moves entries in only
-finitely many rows and only at finitely many positions.  Along a recurrent path, every such row is
-either never visited or eventually has more visits than every moved position.  Consequently every
-sufficiently long prefix is `LastExitAdmissible π x`: `π` permutes each used row prefix within
-itself and fixes its last position.
+This file supplies the recurrence step that produces the last-exit condition. A family
+`π : α → Equiv.Perm ℕ` of row permutations that moves only finitely many positions on rows attained
+by a recurrent path eventually has every such position below the last visit to its row.
+Consequently every sufficiently long prefix is `LastExitAdmissible π x`: `π` permutes each used
+row prefix within itself and fixes its last position.
 
 This is the bridge between finite-support reduction for row exchangeability and finite last-exit
 reconstruction in the Layer 8 Markov-exchangeability milestone of
@@ -29,9 +23,8 @@ reconstruction in the Layer 8 Markov-exchangeability milestone of
 use Markov exchangeability to compare the reconstructed finite prefixes and then pass to the full
 successor-array law.
 
-## Main definitions and results
+## Main results
 
-* `TauCeti.LastExitAdmissible` packages the two hypotheses of finite last-exit reconstruction;
 * `TauCeti.eventually_lastExitAdmissible_of_recurrent` is the pointwise recurrence theorem;
 * `TauCeti.Probability.Recurrent.ae_eventually_lastExitAdmissible` is its process-level form.
 
@@ -56,94 +49,36 @@ namespace TauCeti
 
 variable {α : Type*}
 
-/-- A family of successor-row permutations is **last-exit admissible** for the prefix of `x`
-before time `m` when it preserves every used row prefix and fixes the final used position in each
-nonempty row.
-
-These are exactly the two hypotheses needed by finite last-exit reconstruction: the first keeps
-every reindexed successor entry inside the finite prefix, and the second prevents reconstruction
-from closing a proper subtrail before all prescribed entries have been consumed. -/
-def LastExitAdmissible (π : α → Equiv.Perm ℕ) (x : ℕ → α) (m : ℕ) : Prop :=
-  (∀ a k, k < visitCount x a m → π a k < visitCount x a m) ∧
-    ∀ a, 0 < visitCount x a m →
-      π a (visitCount x a m - 1) = visitCount x a m - 1
-
-/-- The two conditions defining last-exit admissibility. -/
-@[simp]
-theorem lastExitAdmissible_iff {π : α → Equiv.Perm ℕ} {x : ℕ → α} {m : ℕ} :
-    LastExitAdmissible π x m ↔
-      (∀ a k, k < visitCount x a m → π a k < visitCount x a m) ∧
-        ∀ a, 0 < visitCount x a m →
-          π a (visitCount x a m - 1) = visitCount x a m - 1 :=
-  Iff.rfl
-
-/-- A last-exit-admissible permutation keeps every used row index inside the used prefix. -/
-theorem LastExitAdmissible.maps_lt_visitCount
-    {π : α → Equiv.Perm ℕ} {x : ℕ → α} {m : ℕ}
-    (h : LastExitAdmissible π x m) {a : α} {k : ℕ} (hk : k < visitCount x a m) :
-    π a k < visitCount x a m :=
-  h.1 a k hk
-
-/-- A last-exit-admissible permutation fixes the last used index of every nonempty row. -/
-theorem LastExitAdmissible.apply_visitCount_sub_one {π : α → Equiv.Perm ℕ}
-    {x : ℕ → α} {m : ℕ} (h : LastExitAdmissible π x m) {a : α}
-    (ha : 0 < visitCount x a m) :
-    π a (visitCount x a m - 1) = visitCount x a m - 1 :=
-  h.2 a ha
-
-/-- If every moved position lies strictly below the last used position of its row, then the row
-permutations are last-exit admissible. -/
-theorem lastExitAdmissible_of_support_lt_visitCount {π : α → Equiv.Perm ℕ}
-    {x : ℕ → α} {m : ℕ}
-    (h : ∀ a, 0 < visitCount x a m → ∀ k, π a k ≠ k → k + 1 < visitCount x a m) :
-    LastExitAdmissible π x m := by
-  rw [lastExitAdmissible_iff]
-  constructor
-  · intro a k hk
-    by_cases hfix : π a k = k
-    · simpa only [hfix] using hk
-    · have himage : π a (π a k) ≠ π a k := by
-        intro himage
-        exact hfix ((π a).injective himage)
-      have hlt := h a (Nat.zero_lt_of_lt hk) (π a k) himage
-      omega
-  · intro a ha
-    by_contra hlast
-    have hlt := h a ha (visitCount x a m - 1) hlast
-    omega
-
-/-- **Finite-support row reindexings are eventually last-exit admissible along a recurrent
-path.** Here recurrence is stated pointwise: every state attained by `x` is attained infinitely
-often.  A row occurring in the finite support is either unattained, in which case its visit count
-is always zero, or its visit count eventually exceeds every supported position. -/
+/-- **Finitely many moved cells on attained rows are eventually last-exit admissible along a
+recurrent path.** Here recurrence is stated pointwise: every state attained by `x` is attained
+infinitely often. Each attained row's visit count eventually exceeds every moved position in the
+finite attained support. -/
 theorem eventually_lastExitAdmissible_of_recurrent {π : α → Equiv.Perm ℕ} {x : ℕ → α}
     (hrec : ∀ k : ℕ, {n | x n = x k}.Infinite)
-    (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2}.Finite) :
+    (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2 ∧ ∃ t, x t = p.1}.Finite) :
     ∀ᶠ m in atTop, LastExitAdmissible π x m := by
   classical
-  have hsupported : ∀ p ∈ {p : α × ℕ | π p.1 p.2 ≠ p.2},
-      ∀ᶠ m in atTop,
-        visitCount x p.1 m = 0 ∨ p.2 + 1 < visitCount x p.1 m := by
+  have hsupported : ∀ p ∈ {p : α × ℕ | π p.1 p.2 ≠ p.2 ∧ ∃ t, x t = p.1},
+      ∀ᶠ m in atTop, p.2 + 1 < visitCount x p.1 m := by
     intro p hp
-    by_cases hvisited : ∃ t, x t = p.1
-    · obtain ⟨t, ht⟩ := hvisited
-      have hinfinite : {n | x n = p.1}.Infinite := by
-        simpa only [ht] using hrec t
-      have hcount : Tendsto (visitCount x p.1) atTop atTop := by
-        refine tendsto_atTop_atTop.2 fun b => ?_
-        obtain ⟨n, -, hn⟩ := exists_visitCount_of_infinite hinfinite b
-        exact ⟨n, fun m hnm => hn ▸ visitCount_monotone x p.1 hnm⟩
-      obtain ⟨N, hN⟩ := tendsto_atTop_atTop.1 hcount (p.2 + 2)
-      exact eventually_atTop.2 ⟨N, fun m hm => Or.inr (by have := hN m hm; omega)⟩
-    · exact Eventually.of_forall fun m => Or.inl <|
-        visitCount_eq_zero_of_forall_ne fun i _ hi => hvisited ⟨i, hi⟩
+    obtain ⟨t, ht⟩ := hp.2
+    have hinfinite : {n | x n = p.1}.Infinite := by
+      simpa only [ht] using hrec t
+    have hcount : Tendsto (visitCount x p.1) atTop atTop := by
+      refine tendsto_atTop_atTop.2 fun b => ?_
+      obtain ⟨n, -, hn⟩ := exists_visitCount_of_infinite hinfinite b
+      exact ⟨n, fun m hnm => hn ▸ visitCount_monotone x p.1 hnm⟩
+    obtain ⟨N, hN⟩ := tendsto_atTop_atTop.1 hcount (p.2 + 2)
+    exact eventually_atTop.2 ⟨N, fun m hm => by have := hN m hm; omega⟩
   filter_upwards [hπ.eventually_all.2 hsupported] with m hm
   apply lastExitAdmissible_of_support_lt_visitCount
   intro a ha k hk
-  have hmem : (a, k) ∈ {p : α × ℕ | π p.1 p.2 ≠ p.2} := hk
-  rcases hm (a, k) hmem with hzero | hlt
-  · exact (ha.ne' hzero).elim
-  · exact hlt
+  have hvisited : ∃ t, x t = a := by
+    by_contra hvisited
+    push Not at hvisited
+    have hzero := visitCount_eq_zero_of_forall_ne (n := m) fun i _ => hvisited i
+    omega
+  exact hm (a, k) ⟨hk, hvisited⟩
 
 namespace Probability
 
@@ -156,7 +91,7 @@ theorem Recurrent.ae_eventually_lastExitAdmissible (h : Recurrent μ X)
     (π : α → Equiv.Perm ℕ) (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2}.Finite) :
     ∀ᵐ ω ∂μ, ∀ᶠ m in atTop, LastExitAdmissible π (fun n => X n ω) m := by
   filter_upwards [h.ae_infinite_setOf_eq] with ω hω
-  exact eventually_lastExitAdmissible_of_recurrent hω hπ
+  exact eventually_lastExitAdmissible_of_recurrent hω <| hπ.subset fun _ hp => hp.1
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/Recurrence/LastExit.lean
+++ b/TauCeti/Probability/Exchangeability/Recurrence/LastExit.lean
@@ -50,20 +50,18 @@ namespace TauCeti
 variable {α : Type*}
 
 /-- **Finitely many moved cells on attained rows are eventually last-exit admissible along a
-recurrent path.** Here recurrence is stated pointwise: every state attained by `x` is attained
-infinitely often. Each attained row's visit count eventually exceeds every moved position in the
-finite attained support. -/
+recurrent path.** Here recurrence is needed only for attained rows on which `π` moves a cell.
+Each such row's visit count eventually exceeds every moved position in the finite attained
+support. -/
 theorem eventually_lastExitAdmissible_of_recurrent {π : α → Equiv.Perm ℕ} {x : ℕ → α}
-    (hrec : ∀ k : ℕ, {n | x n = x k}.Infinite)
+    (hrec : ∀ a, (∃ k, π a k ≠ k) → (∃ t, x t = a) → {n | x n = a}.Infinite)
     (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2 ∧ ∃ t, x t = p.1}.Finite) :
     ∀ᶠ m in atTop, LastExitAdmissible π x m := by
   classical
   have hsupported : ∀ p ∈ {p : α × ℕ | π p.1 p.2 ≠ p.2 ∧ ∃ t, x t = p.1},
       ∀ᶠ m in atTop, p.2 + 1 < visitCount x p.1 m := by
     intro p hp
-    obtain ⟨t, ht⟩ := hp.2
-    have hinfinite : {n | x n = p.1}.Infinite := by
-      simpa only [ht] using hrec t
+    have hinfinite := hrec p.1 ⟨p.2, hp.1⟩ hp.2
     have hcount : Tendsto (visitCount x p.1) atTop atTop := by
       refine tendsto_atTop_atTop.2 fun b => ?_
       obtain ⟨n, -, hn⟩ := exists_visitCount_of_infinite hinfinite b
@@ -91,7 +89,9 @@ theorem Recurrent.ae_eventually_lastExitAdmissible (h : Recurrent μ X)
     (π : α → Equiv.Perm ℕ) (hπ : {p : α × ℕ | π p.1 p.2 ≠ p.2}.Finite) :
     ∀ᵐ ω ∂μ, ∀ᶠ m in atTop, LastExitAdmissible π (fun n => X n ω) m := by
   filter_upwards [h.ae_infinite_setOf_eq] with ω hω
-  exact eventually_lastExitAdmissible_of_recurrent hω <| hπ.subset fun _ hp => hp.1
+  exact eventually_lastExitAdmissible_of_recurrent
+    (fun _ _ ⟨t, ht⟩ => by simpa only [ht] using hω t) <|
+      hπ.subset fun _ hp => hp.1
 
 end Probability
 


### PR DESCRIPTION
This PR makes every finite-support family of successor-row permutations last-exit admissible along all sufficiently long recurrent prefixes. It introduces `LastExitAdmissible`, proves the sharp support-below-the-last-visit criterion, and supplies both pointwise and almost-sure eventual forms for recurrent processes.

The exact target is `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, “Markov exchangeability,” specifically the missing Diaconis–Freedman bridge proving that a recurrent Markov-exchangeable process has a row-exchangeable successor array. This is the most effective current step because open PR #4789 reduces row exchangeability to families of finite total support and open PR #4791 reconstructs a finite path once such a family preserves each used row prefix and fixes its last exit; this PR proves that recurrence eventually supplies exactly those two hypotheses. After this PR and those two in-flight prerequisites, the milestone still needs the probabilistic comparison of reconstructed finite-prefix laws and its passage to invariance of the full successor-array law.

Add `TauCeti/Probability/Exchangeability/Recurrence/LastExit.lean` (186 lines). The pointwise theorem assumes only that every attained state recurs infinitely often, with no measurable-space or countability hypotheses; the process wrapper then reads this directly from `Recurrent`. The proof intersects eventual visit-count bounds over the finite set of actually moved cells, leaving never-visited rows at visit count zero, and proves that the image of a moved index is moved as well before establishing prefix preservation and last-position fixedness.

The mathematical organization follows Diaconis and Freedman, “de Finetti's theorem for Markov chains” (1980), and the last-exit reconstruction of Fortini, Ladelli, Petris, and Regazzini, “On mixtures of distributions of Markov chains” (2002), Lemma 1(b); both are cited in the module documentation. No Mathlib infrastructure or external formalization is vendored, and the declarations were checked against the pinned Mathlib and current Tau Ceti sources before implementation.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"recurrent-last-exit-admissibility"}-->

🤖 Prepared with Codex
