### PR TITLE
feat: the graph automorphism of the pinned Geck carrier

### DIFF
--- a/TauCeti/CategoryTheory/Aut/Basic.lean
+++ b/TauCeti/CategoryTheory/Aut/Basic.lean
@@ -16,6 +16,8 @@ This file contains general bookkeeping lemmas for automorphisms of objects in a 
 
 * `TauCeti.CategoryTheory.comp_aut_pow_hom_of_comp`: iterating an automorphism that reindexes a
   family of morphisms reindexes that family by the corresponding function iterate.
+* `TauCeti.CategoryTheory.autMulEquivOfIso_hom`: the forward component of an automorphism
+  transported along an isomorphism.
 -/
 
 public section
@@ -27,6 +29,14 @@ open _root_.CategoryTheory
 universe v u
 
 variable {C : Type u} [Category.{v} C] {X Y : C} {iota : Type*}
+
+/-- The forward component of an automorphism transported along an isomorphism is the conjugate of
+its forward component. `Aut.autMulEquivOfIso` is not equipped with `@[simps]`, so this is the
+characterization its consumers use instead of its constructor. -/
+@[simp]
+theorem autMulEquivOfIso_hom (h : X ≅ Y) (a : Aut X) :
+    (Aut.autMulEquivOfIso h a).hom = h.inv ≫ a.hom ≫ h.hom :=
+  rfl
 
 /-- Iterating an automorphism which reindexes a family of morphisms reindexes that family by the
 corresponding function iterate. -/

--- a/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/PinnedSymmetry.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/PinnedSymmetry.lean
@@ -205,7 +205,12 @@ theorem equivFin_symm_geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry)
   simp [geckDiagramFinPerm, Equiv.permCongr_apply]
 
 /-- The pinned Geck-module symmetry permutes the finite-ordinal coordinate basis. This is the
-basis-permutation hypothesis of the Kostant toral-closure symmetry construction. -/
+basis-permutation hypothesis of the Kostant toral-closure symmetry construction.
+
+This is deliberately not a `simp` lemma: `TauCeti.DynkinType.coe_geckCoordinateBasisFin` and
+`TauCeti.DynkinType.geckDiagramModuleEquiv_single` are themselves `simp`, so both sides are
+already rewritten to the same standard coordinate vector and `simp` proves this statement
+outright. -/
 theorem geckDiagramModuleEquiv_geckCoordinateBasisFin (hsigma : sigma ∈ t.diagramSymmetry)
     (i : Fin (t.geckDim ht)) :
     t.geckDiagramModuleEquiv ht hsigma
@@ -219,6 +224,7 @@ theorem geckDiagramModuleEquiv_geckCoordinateBasisFin (hsigma : sigma ∈ t.diag
 /-- The finite-ordinal Geck weights are equivariant for the coordinate permutation and the node
 permutation. This is the weight hypothesis of the Kostant toral-closure symmetry construction, and
 it is what makes the same permutation intertwine the represented split torus with relabelling. -/
+@[simp]
 theorem geckWeightFin_geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry)
     (i : Fin (t.geckDim ht)) (k : Fin t.rank) :
     t.geckWeightFin ht (t.geckDiagramFinPerm ht hsigma i) (sigma k) = t.geckWeightFin ht i k := by
@@ -232,11 +238,15 @@ def diagramRootGeneratorPerm (sigma : Equiv.Perm (Fin t.rank)) :
     Equiv.Perm (Fin t.rank ⊕ Fin t.rank) :=
   Equiv.sumCongr sigma sigma
 
-/-- The permutation of the numbered generator indices is a power in the node permutation, because
-it is the value of `Equiv.Perm.sumCongrHom` on the diagonal. -/
-theorem diagramRootGeneratorPerm_pow (tau : Equiv.Perm (Fin t.rank)) (k : ℕ) :
-    diagramRootGeneratorPerm tau ^ k = diagramRootGeneratorPerm (tau ^ k) :=
-  ((Equiv.Perm.sumCongrHom (Fin t.rank) (Fin t.rank)).map_pow (tau, tau) k).symm
+/-- The permutation of the numbered generator indices is the diagonal value of the bundled
+homomorphism `Equiv.Perm.sumCongrHom`, so it obeys that homomorphism's laws. The body of
+`TauCeti.DynkinType.diagramRootGeneratorPerm` is not exposed, so consumers in other modules need
+this equation to reach them. -/
+theorem diagramRootGeneratorPerm_eq_sumCongrHom (tau : Equiv.Perm (Fin t.rank)) :
+    diagramRootGeneratorPerm tau =
+      Equiv.Perm.sumCongrHom (Fin t.rank) (Fin t.rank) (tau, tau) := by
+  rw [diagramRootGeneratorPerm]
+  rfl
 
 /-- The diagram permutation acts on a raising-generator index through `sigma`. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/PinnedSymmetry.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/PinnedSymmetry.lean
@@ -238,16 +238,6 @@ def diagramRootGeneratorPerm (sigma : Equiv.Perm (Fin t.rank)) :
     Equiv.Perm (Fin t.rank ⊕ Fin t.rank) :=
   Equiv.sumCongr sigma sigma
 
-/-- The permutation of the numbered generator indices is the diagonal value of the bundled
-homomorphism `Equiv.Perm.sumCongrHom`, so it obeys that homomorphism's laws. The body of
-`TauCeti.DynkinType.diagramRootGeneratorPerm` is not exposed, so consumers in other modules need
-this equation to reach them. -/
-theorem diagramRootGeneratorPerm_eq_sumCongrHom (tau : Equiv.Perm (Fin t.rank)) :
-    diagramRootGeneratorPerm tau =
-      Equiv.Perm.sumCongrHom (Fin t.rank) (Fin t.rank) (tau, tau) := by
-  rw [diagramRootGeneratorPerm]
-  rfl
-
 /-- The diagram permutation acts on a raising-generator index through `sigma`. -/
 @[simp]
 theorem diagramRootGeneratorPerm_apply_inl (i : Fin t.rank) :
@@ -261,6 +251,18 @@ theorem diagramRootGeneratorPerm_apply_inr (i : Fin t.rank) :
     diagramRootGeneratorPerm sigma (Sum.inr i) = Sum.inr (sigma i) := by
   rw [diagramRootGeneratorPerm]
   rfl
+
+/-- **A relation satisfied by a diagram symmetry is satisfied by the permutation it induces on the
+numbered generator indices.** The induced permutation is the diagonal value of the bundled
+homomorphism `Equiv.Perm.sumCongrHom`, so it inherits that homomorphism's power law. -/
+theorem diagramRootGeneratorPerm_pow_eq_one {m : ℕ} (hm : sigma ^ m = 1) :
+    diagramRootGeneratorPerm sigma ^ m = 1 := by
+  have hsum : diagramRootGeneratorPerm sigma =
+      Equiv.Perm.sumCongrHom (Fin t.rank) (Fin t.rank) (sigma, sigma) :=
+    Equiv.ext fun i => by cases i <;> simp
+  have hpair : ((sigma, sigma) : Equiv.Perm (Fin t.rank) × Equiv.Perm (Fin t.rank)) ^ m = 1 :=
+    Prod.ext hm hm
+  rw [hsum, ← map_pow, hpair, map_one]
 
 /-- **The pinned Geck-module symmetry intertwines every represented simple root generator with
 the generator carrying the permuted number.** This is exactly the additive pinning equation

--- a/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/PinnedSymmetry.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/GeckConstruction/PinnedSymmetry.lean
@@ -35,6 +35,8 @@ the toral carrier.
 * `TauCeti.DynkinType.geckDiagramIndexEquiv`: the coordinate permutation of the pinned Geck
   module.
 * `TauCeti.DynkinType.geckDiagramModuleEquiv`: the resulting rational linear equivalence.
+* `TauCeti.DynkinType.geckDiagramFinPerm`: the same coordinate permutation in the finite-ordinal
+  indexing used by the group-scheme construction.
 * `TauCeti.DynkinType.diagramRootGeneratorPerm`: the induced permutation of the simple raising and
   lowering indices.
 
@@ -44,6 +46,9 @@ the toral carrier.
   permutation preserves the pinned integral lattice in both directions.
 * `TauCeti.DynkinType.geckWeight_geckDiagramIndexEquiv`: the weights are permuted
   contragrediently.
+* `TauCeti.DynkinType.geckDiagramModuleEquiv_geckCoordinateBasisFin` and
+  `TauCeti.DynkinType.geckWeightFin_geckDiagramFinPerm`: the finite-ordinal basis and weight
+  equations consumed by the Kostant toral-closure symmetry construction.
 * `TauCeti.DynkinType.geckDiagramModuleEquiv_geckRepresentation_rootGenerator`: the defining
   representation intertwines every numbered root generator with its permuted generator.
 
@@ -182,11 +187,56 @@ theorem geckWeight_geckDiagramIndexEquiv (hsigma : sigma ∈ t.diagramSymmetry)
           pairingIn_indexEquiv ℤ (t.rationalDiagramAut ht hsigma).toHom x
             (t.simpleSupportEquiv ht i)
 
+/-! ## The coordinate permutation in the finite-ordinal indexing -/
+
+/-- **The coordinate permutation of a diagram symmetry, in the finite-ordinal indexing.** The
+group-scheme construction indexes the Geck coordinate basis by `Fin (t.geckDim ht)` through
+`Fintype.equivFin`; this is `TauCeti.DynkinType.geckDiagramIndexEquiv` transported along that
+reindexing. -/
+def geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry) :
+    Equiv.Perm (Fin (t.geckDim ht)) :=
+  (Fintype.equivFin (t.GeckIndex ht)).permCongr (t.geckDiagramIndexEquiv ht hsigma)
+
+@[simp]
+theorem equivFin_symm_geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry)
+    (i : Fin (t.geckDim ht)) :
+    (Fintype.equivFin (t.GeckIndex ht)).symm (t.geckDiagramFinPerm ht hsigma i) =
+      t.geckDiagramIndexEquiv ht hsigma ((Fintype.equivFin (t.GeckIndex ht)).symm i) := by
+  simp [geckDiagramFinPerm, Equiv.permCongr_apply]
+
+/-- The pinned Geck-module symmetry permutes the finite-ordinal coordinate basis. This is the
+basis-permutation hypothesis of the Kostant toral-closure symmetry construction. -/
+theorem geckDiagramModuleEquiv_geckCoordinateBasisFin (hsigma : sigma ∈ t.diagramSymmetry)
+    (i : Fin (t.geckDim ht)) :
+    t.geckDiagramModuleEquiv ht hsigma
+        ((t.geckCoordinateBasisFin ht i : (t.geckCoordinateLattice ht).toAddSubgroup) :
+          t.GeckIndex ht → ℚ) =
+      ((t.geckCoordinateBasisFin ht (t.geckDiagramFinPerm ht hsigma i) :
+          (t.geckCoordinateLattice ht).toAddSubgroup) : t.GeckIndex ht → ℚ) := by
+  rw [coe_geckCoordinateBasisFin, coe_geckCoordinateBasisFin, geckDiagramModuleEquiv_single,
+    equivFin_symm_geckDiagramFinPerm]
+
+/-- The finite-ordinal Geck weights are equivariant for the coordinate permutation and the node
+permutation. This is the weight hypothesis of the Kostant toral-closure symmetry construction, and
+it is what makes the same permutation intertwine the represented split torus with relabelling. -/
+theorem geckWeightFin_geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry)
+    (i : Fin (t.geckDim ht)) (k : Fin t.rank) :
+    t.geckWeightFin ht (t.geckDiagramFinPerm ht hsigma i) (sigma k) = t.geckWeightFin ht i k := by
+  simp only [geckWeightFin, equivFin_symm_geckDiagramFinPerm, geckWeight_geckDiagramIndexEquiv]
+
+/-! ## The permutation of the numbered generators -/
+
 /-- The permutation of the simple raising and lowering indices induced by a diagram symmetry. The
 same node permutation acts on both halves. -/
 def diagramRootGeneratorPerm (sigma : Equiv.Perm (Fin t.rank)) :
     Equiv.Perm (Fin t.rank ⊕ Fin t.rank) :=
   Equiv.sumCongr sigma sigma
+
+/-- The permutation of the numbered generator indices is a power in the node permutation, because
+it is the value of `Equiv.Perm.sumCongrHom` on the diagonal. -/
+theorem diagramRootGeneratorPerm_pow (tau : Equiv.Perm (Fin t.rank)) (k : ℕ) :
+    diagramRootGeneratorPerm tau ^ k = diagramRootGeneratorPerm (tau ^ k) :=
+  ((Equiv.Perm.sumCongrHom (Fin t.rank) (Fin t.rank)).map_pow (tau, tau) k).symm
 
 /-- The diagram permutation acts on a raising-generator index through `sigma`. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.NumberedSymmetry
+public import TauCeti.CategoryTheory.Aut.Basic
 public import TauCeti.LinearAlgebra.RootSystem.GeckConstruction.PinnedSymmetry
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.GroupScheme
 
@@ -109,8 +110,8 @@ def geckGraphAut (hsigma : sigma ∈ t.diagramSymmetry) : Aut (t.geckGroupScheme
 private theorem geckGraphAut_hom (hsigma : sigma ∈ t.diagramSymmetry) :
     (t.geckGraphAut ht hsigma).hom =
       eqToHom (t.geckGroupScheme_def ht) ≫ (toralGraphAut ht hsigma).hom ≫
-        eqToHom (t.geckGroupScheme_def ht).symm :=
-  rfl
+        eqToHom (t.geckGroupScheme_def ht).symm := by
+  rw [geckGraphAut, TauCeti.CategoryTheory.autMulEquivOfIso_hom, eqToIso.inv, eqToIso.hom]
 
 /-- The graph automorphism renumbers every pinned raising and lowering root subgroup by the diagram
 symmetry, without changing its additive parameter. -/
@@ -145,7 +146,8 @@ theorem geckWeightTorus_comp_geckGraphAut_hom (hsigma : sigma ∈ t.diagramSymme
     TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral_comp_numberedSymmetryIso_hom,
     Category.assoc]
 
-/-- The inverse graph automorphism relabels the weight torus by the inverse symmetry. -/
+/-- The inverse graph automorphism relabels the coordinates of the weight torus by `σ` itself,
+undoing the relabelling by `σ⁻¹` that the forward automorphism performs. -/
 @[reassoc (attr := simp)]
 theorem geckWeightTorus_comp_geckGraphAut_inv (hsigma : sigma ∈ t.diagramSymmetry) :
     t.geckWeightTorus ht ≫ (t.geckGraphAut ht hsigma).inv =
@@ -168,10 +170,7 @@ the numbered diagram therefore gives `γ ^ 2 = 1`, and the triality of `D₄` gi
 @[simp]
 theorem geckGraphAut_pow_eq_one (hsigma : sigma ∈ t.diagramSymmetry) {m : ℕ}
     (hm : sigma ^ m = 1) : t.geckGraphAut ht hsigma ^ m = 1 := by
-  have hpair : ((sigma, sigma) : Equiv.Perm (Fin t.rank) × Equiv.Perm (Fin t.rank)) ^ m = 1 :=
-    Prod.ext hm hm
-  have hgen : diagramRootGeneratorPerm sigma ^ m = 1 := by
-    rw [diagramRootGeneratorPerm_eq_sumCongrHom, ← map_pow, hpair, map_one]
+  have hgen : diagramRootGeneratorPerm sigma ^ m = 1 := diagramRootGeneratorPerm_pow_eq_one hm
   have htoral : toralGraphAut ht hsigma ^ m = 1 :=
     TauCeti.UniversalEnvelopingAlgebra.kostantToralNumberedSymmetryIso_pow_eq_one _ _ _ _ _ _ _ _
       _ _ _ _ _ _ _ _ _ m (by rw [← Equiv.Perm.coe_pow, hgen]; rfl) hm

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
@@ -41,8 +41,6 @@ asserts reductivity, maximality of the weight torus, or any finiteness or simpli
 
 ## Main definitions
 
-* `TauCeti.DynkinType.geckDiagramFinPerm`: the coordinate permutation of a diagram symmetry, in the
-  finite-ordinal indexing used by the group-scheme construction.
 * `TauCeti.DynkinType.geckGraphAut`: the graph automorphism of the pinned Geck carrier.
 
 ## Main results
@@ -50,7 +48,7 @@ asserts reductivity, maximality of the weight torus, or any finiteness or simpli
 * `TauCeti.DynkinType.geckRootSubgroup_comp_geckGraphAut_hom` and its inverse counterpart: the
   graph automorphism renumbers the pinned root subgroups by `σ`.
 * `TauCeti.DynkinType.geckWeightTorus_comp_geckGraphAut_hom` and its inverse counterpart: it
-  normalizes the represented weight torus and acts on it by relabelling.
+  intertwines the weight torus morphism with the relabelling of its coordinates.
 * `TauCeti.DynkinType.geckGraphAut_pow_eq_one`: the order relation.
 * `TauCeti.DynkinType.geckGraphAut_one`: the identity symmetry gives the identity automorphism.
 
@@ -77,45 +75,6 @@ namespace TauCeti.DynkinType
 noncomputable section
 
 variable {t : DynkinType} (ht : t.Valid) {sigma : Equiv.Perm (Fin t.rank)}
-
-/-! ## The coordinate permutation in the finite-ordinal indexing -/
-
-/-- **The coordinate permutation of a diagram symmetry, in the finite-ordinal indexing.** The
-group-scheme construction indexes the Geck coordinate basis by `Fin (t.geckDim ht)` through
-`Fintype.equivFin`; this is `TauCeti.DynkinType.geckDiagramIndexEquiv` transported along that
-reindexing. -/
-def geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry) :
-    Equiv.Perm (Fin (t.geckDim ht)) :=
-  (Fintype.equivFin (t.GeckIndex ht)).permCongr (t.geckDiagramIndexEquiv ht hsigma)
-
-@[simp]
-theorem equivFin_symm_geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry)
-    (i : Fin (t.geckDim ht)) :
-    (Fintype.equivFin (t.GeckIndex ht)).symm (t.geckDiagramFinPerm ht hsigma i) =
-      t.geckDiagramIndexEquiv ht hsigma ((Fintype.equivFin (t.GeckIndex ht)).symm i) := by
-  simp [geckDiagramFinPerm, Equiv.permCongr_apply]
-
-/-- The pinned Geck-module symmetry permutes the finite-ordinal coordinate basis. This is the
-basis-permutation hypothesis of the Kostant toral-closure symmetry construction. -/
-theorem geckDiagramModuleEquiv_geckCoordinateBasisFin (hsigma : sigma ∈ t.diagramSymmetry)
-    (i : Fin (t.geckDim ht)) :
-    t.geckDiagramModuleEquiv ht hsigma
-        ((t.geckCoordinateBasisFin ht i : (t.geckCoordinateLattice ht).toAddSubgroup) :
-          t.GeckIndex ht → ℚ) =
-      ((t.geckCoordinateBasisFin ht (t.geckDiagramFinPerm ht hsigma i) :
-          (t.geckCoordinateLattice ht).toAddSubgroup) : t.GeckIndex ht → ℚ) := by
-  rw [coe_geckCoordinateBasisFin, coe_geckCoordinateBasisFin, geckDiagramModuleEquiv_single,
-    equivFin_symm_geckDiagramFinPerm]
-
-/-- The finite-ordinal Geck weights are equivariant for the coordinate permutation and the node
-permutation. This is the weight hypothesis of the Kostant toral-closure symmetry construction, and
-it is what makes the same permutation normalize the represented weight torus. -/
-theorem geckWeightFin_geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry)
-    (i : Fin (t.geckDim ht)) (k : Fin t.rank) :
-    t.geckWeightFin ht (t.geckDiagramFinPerm ht hsigma i) (sigma k) = t.geckWeightFin ht i k := by
-  simp only [geckWeightFin, equivFin_symm_geckDiagramFinPerm, geckWeight_geckDiagramIndexEquiv]
-
-/-! ## The graph automorphism -/
 
 /-- The Kostant toral-closure symmetry of the pinned Geck data. -/
 private def toralGraphAut (hsigma : sigma ∈ t.diagramSymmetry) :
@@ -173,8 +132,10 @@ theorem geckRootSubgroup_comp_geckGraphAut_inv (hsigma : sigma ∈ t.diagramSymm
   rw [← geckRootSubgroup_comp_geckGraphAut_hom ht hsigma i, Category.assoc,
     (t.geckGraphAut ht hsigma).hom_inv_id, Category.comp_id]
 
-/-- **The graph automorphism normalizes the represented weight torus**, acting on it by the
-relabelling attached to the diagram symmetry. -/
+/-- **The graph automorphism intertwines the represented weight torus with the relabelling**
+attached to the diagram symmetry: composing the torus morphism with `γ` is the same as relabelling
+its coordinates by `σ⁻¹` first. Nothing here asserts that this morphism is an immersion, so this
+is an equation of morphisms and not a statement that `γ` normalizes a subgroup scheme. -/
 @[reassoc (attr := simp)]
 theorem geckWeightTorus_comp_geckGraphAut_hom (hsigma : sigma ∈ t.diagramSymmetry) :
     t.geckWeightTorus ht ≫ (t.geckGraphAut ht hsigma).hom =
@@ -201,13 +162,6 @@ theorem geckWeightTorus_comp_geckGraphAut_inv (hsigma : sigma ∈ t.diagramSymme
         simp only [Category.assoc]
     _ = SplitTorus.relabel ℤ sigma ≫ t.geckWeightTorus ht := by
         rw [Category.assoc, (t.geckGraphAut ht hsigma).hom_inv_id, Category.comp_id]
-
-/-- The permutation of the numbered generator indices is a power in the node permutation. -/
-private theorem diagramRootGeneratorPerm_pow (tau : Equiv.Perm (Fin t.rank)) (k : ℕ) :
-    diagramRootGeneratorPerm tau ^ k = diagramRootGeneratorPerm (tau ^ k) := by
-  induction k with
-  | zero => ext x; cases x <;> simp
-  | succ k ih => ext x; cases x <;> simp [pow_succ, ih]
 
 /-- **The order of the graph automorphism divides that of the diagram symmetry.** An involution of
 the numbered diagram therefore gives `γ ^ 2 = 1`, and the triality of `D₄` gives `γ ^ 3 = 1`. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
@@ -168,10 +168,10 @@ the numbered diagram therefore gives `γ ^ 2 = 1`, and the triality of `D₄` gi
 @[simp]
 theorem geckGraphAut_pow_eq_one (hsigma : sigma ∈ t.diagramSymmetry) {m : ℕ}
     (hm : sigma ^ m = 1) : t.geckGraphAut ht hsigma ^ m = 1 := by
+  have hpair : ((sigma, sigma) : Equiv.Perm (Fin t.rank) × Equiv.Perm (Fin t.rank)) ^ m = 1 :=
+    Prod.ext hm hm
   have hgen : diagramRootGeneratorPerm sigma ^ m = 1 := by
-    rw [diagramRootGeneratorPerm_pow, hm]
-    ext x
-    cases x <;> simp
+    rw [diagramRootGeneratorPerm_eq_sumCongrHom, ← map_pow, hpair, map_one]
   have htoral : toralGraphAut ht hsigma ^ m = 1 :=
     TauCeti.UniversalEnvelopingAlgebra.kostantToralNumberedSymmetryIso_pow_eq_one _ _ _ _ _ _ _ _
       _ _ _ _ _ _ _ _ _ m (by rw [← Equiv.Perm.coe_pow, hgen]; rfl) hm

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
@@ -1,0 +1,233 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.NumberedSymmetry
+public import TauCeti.LinearAlgebra.RootSystem.GeckConstruction.PinnedSymmetry
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.GroupScheme
+
+/-!
+# The graph automorphism of the pinned Geck carrier
+
+`TauCeti.DynkinType.geckGroupScheme` is the explicit affine group scheme over `ℤ` attached to a
+valid Dynkin type: the smallest closed subgroup scheme of `GLₙ` containing the divided-power
+exponential root subgroups of the Bourbaki-numbered Chevalley generators together with the weight
+torus of the Geck coordinate lattice. This file equips it with the automorphism attached to a
+symmetry `σ` of its Dynkin diagram.
+
+Both halves of the construction already exist. A symmetry of the numbered Kostant data induces an
+automorphism of a Kostant toral closure, and Geck's coordinate permutation is such a symmetry: it
+preserves the integral lattice, intertwines the represented simple root generators, and permutes
+the weights contragrediently. What this file adds is the reading of the second as the first, and
+the resulting pinning equations on the carrier itself, namely
+
+```text
+γ ∘ x_i = x_{σ i},        γ ∘ (weight torus) = (weight torus) ∘ relabel σ⁻¹.
+```
+
+The first equation is the one that pins `γ`: the numbering permutation acts identically on the
+raising and the lowering generators and leaves the additive parameter of every root subgroup
+alone. The order of `γ` divides that of `σ`, so an involution of the diagram gives `γ ^ 2 = 1` and
+the triality of `D₄` gives `γ ^ 3 = 1`; on the identity symmetry `γ` is the identity.
+
+The automorphism is that of the carrier over `ℤ`, before any base change or passage to points, and
+it acts on the whole carrier rather than on the elementary subgroup its root subgroups generate.
+The Geck weights span the root lattice rather than, in general, the full character lattice, so this
+carrier is not yet the simply connected one a finite group of Lie type is built from. Nothing here
+asserts reductivity, maximality of the weight torus, or any finiteness or simplicity statement.
+
+## Main definitions
+
+* `TauCeti.DynkinType.geckDiagramFinPerm`: the coordinate permutation of a diagram symmetry, in the
+  finite-ordinal indexing used by the group-scheme construction.
+* `TauCeti.DynkinType.geckGraphAut`: the graph automorphism of the pinned Geck carrier.
+
+## Main results
+
+* `TauCeti.DynkinType.geckRootSubgroup_comp_geckGraphAut_hom` and its inverse counterpart: the
+  graph automorphism renumbers the pinned root subgroups by `σ`.
+* `TauCeti.DynkinType.geckWeightTorus_comp_geckGraphAut_hom` and its inverse counterpart: it
+  normalizes the represented weight torus and acts on it by relabelling.
+* `TauCeti.DynkinType.geckGraphAut_pow_eq_one`: the order relation.
+* `TauCeti.DynkinType.geckGraphAut_one`: the identity symmetry gives the identity automorphism.
+
+## References
+
+* M. Geck, *On the construction of semisimple Lie algebras and Chevalley groups*,
+  Proc. Amer. Math. Soc. **145** (2017), 3233--3247.
+* R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.15.
+* J. E. Humphreys, *Linear Algebraic Groups*, §27.
+
+This is the pinned instance of the graph-automorphism half of "Pinnings ... This is what makes
+'the' graph automorphism well defined" in Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md`. Its consumer is milestone L1, ordinary and
+graph-twisted Steinberg maps, of `TauCetiRoadmap/CFSGStatement/README.md`, whose twisted branches
+compose such a `γ` with the field Frobenius.
+-/
+
+public section
+
+open AlgebraicGeometry CategoryTheory
+
+namespace TauCeti.DynkinType
+
+noncomputable section
+
+variable {t : DynkinType} (ht : t.Valid) {sigma : Equiv.Perm (Fin t.rank)}
+
+/-! ## The coordinate permutation in the finite-ordinal indexing -/
+
+/-- **The coordinate permutation of a diagram symmetry, in the finite-ordinal indexing.** The
+group-scheme construction indexes the Geck coordinate basis by `Fin (t.geckDim ht)` through
+`Fintype.equivFin`; this is `TauCeti.DynkinType.geckDiagramIndexEquiv` transported along that
+reindexing. -/
+def geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry) :
+    Equiv.Perm (Fin (t.geckDim ht)) :=
+  (Fintype.equivFin (t.GeckIndex ht)).permCongr (t.geckDiagramIndexEquiv ht hsigma)
+
+@[simp]
+theorem equivFin_symm_geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry)
+    (i : Fin (t.geckDim ht)) :
+    (Fintype.equivFin (t.GeckIndex ht)).symm (t.geckDiagramFinPerm ht hsigma i) =
+      t.geckDiagramIndexEquiv ht hsigma ((Fintype.equivFin (t.GeckIndex ht)).symm i) := by
+  simp [geckDiagramFinPerm, Equiv.permCongr_apply]
+
+/-- The pinned Geck-module symmetry permutes the finite-ordinal coordinate basis. This is the
+basis-permutation hypothesis of the Kostant toral-closure symmetry construction. -/
+theorem geckDiagramModuleEquiv_geckCoordinateBasisFin (hsigma : sigma ∈ t.diagramSymmetry)
+    (i : Fin (t.geckDim ht)) :
+    t.geckDiagramModuleEquiv ht hsigma
+        ((t.geckCoordinateBasisFin ht i : (t.geckCoordinateLattice ht).toAddSubgroup) :
+          t.GeckIndex ht → ℚ) =
+      ((t.geckCoordinateBasisFin ht (t.geckDiagramFinPerm ht hsigma i) :
+          (t.geckCoordinateLattice ht).toAddSubgroup) : t.GeckIndex ht → ℚ) := by
+  rw [coe_geckCoordinateBasisFin, coe_geckCoordinateBasisFin, geckDiagramModuleEquiv_single,
+    equivFin_symm_geckDiagramFinPerm]
+
+/-- The finite-ordinal Geck weights are equivariant for the coordinate permutation and the node
+permutation. This is the weight hypothesis of the Kostant toral-closure symmetry construction, and
+it is what makes the same permutation normalize the represented weight torus. -/
+theorem geckWeightFin_geckDiagramFinPerm (hsigma : sigma ∈ t.diagramSymmetry)
+    (i : Fin (t.geckDim ht)) (k : Fin t.rank) :
+    t.geckWeightFin ht (t.geckDiagramFinPerm ht hsigma i) (sigma k) = t.geckWeightFin ht i k := by
+  simp only [geckWeightFin, equivFin_symm_geckDiagramFinPerm, geckWeight_geckDiagramIndexEquiv]
+
+/-! ## The graph automorphism -/
+
+/-- The Kostant toral-closure symmetry of the pinned Geck data. -/
+private def toralGraphAut (hsigma : sigma ∈ t.diagramSymmetry) :
+    Aut (TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupScheme
+      (t.lieBasis ht).rootGenerator (t.lieBasis ht).h (t.geckRepresentation ht)
+      (t.geckCoordinateLattice ht).toAddSubgroup
+      (t.geckRepresentation_kostantForm_mem_geckCoordinateLattice ht)
+      (t.isNilpotent_geckRepresentation_rootGenerator ht)
+      (t.geckCoordinateBasisFin ht) (t.geckWeightFin ht)) :=
+  TauCeti.UniversalEnvelopingAlgebra.kostantToralNumberedSymmetryIso
+    (t.lieBasis ht).rootGenerator (t.lieBasis ht).h (t.geckRepresentation ht)
+    (t.geckCoordinateLattice ht).toAddSubgroup
+    (t.geckRepresentation_kostantForm_mem_geckCoordinateLattice ht)
+    (t.isNilpotent_geckRepresentation_rootGenerator ht)
+    (t.geckCoordinateBasisFin ht) (t.geckWeightFin ht)
+    ⇑(diagramRootGeneratorPerm sigma) (t.geckDiagramModuleEquiv ht hsigma)
+    (t.geckDiagramModuleEquiv_mem_geckCoordinateLattice_iff ht hsigma)
+    (fun i v => by
+      simpa only [_root_.UniversalEnvelopingAlgebra.ι_apply] using
+        t.geckDiagramModuleEquiv_geckRepresentation_rootGenerator ht hsigma i v)
+    (diagramRootGeneratorPerm sigma).surjective
+    (t.geckDiagramFinPerm ht hsigma)
+    (t.geckDiagramModuleEquiv_geckCoordinateBasisFin ht hsigma)
+    sigma (t.geckWeightFin_geckDiagramFinPerm ht hsigma)
+
+/-- **The graph automorphism of the pinned Geck carrier** attached to a symmetry of its
+Bourbaki-numbered Dynkin diagram. It renumbers the pinned root subgroups by the symmetry without
+changing their parameters, and relabels the coordinates of the represented weight torus. -/
+def geckGraphAut (hsigma : sigma ∈ t.diagramSymmetry) : Aut (t.geckGroupScheme ht) :=
+  Aut.autMulEquivOfIso (eqToIso (t.geckGroupScheme_def ht).symm) (toralGraphAut ht hsigma)
+
+private theorem geckGraphAut_hom (hsigma : sigma ∈ t.diagramSymmetry) :
+    (t.geckGraphAut ht hsigma).hom =
+      eqToHom (t.geckGroupScheme_def ht) ≫ (toralGraphAut ht hsigma).hom ≫
+        eqToHom (t.geckGroupScheme_def ht).symm :=
+  rfl
+
+/-- The graph automorphism renumbers every pinned raising and lowering root subgroup by the diagram
+symmetry, without changing its additive parameter. -/
+@[reassoc (attr := simp)]
+theorem geckRootSubgroup_comp_geckGraphAut_hom (hsigma : sigma ∈ t.diagramSymmetry)
+    (i : Fin t.rank ⊕ Fin t.rank) :
+    t.geckRootSubgroup ht i ≫ (t.geckGraphAut ht hsigma).hom =
+      t.geckRootSubgroup ht (diagramRootGeneratorPerm sigma i) := by
+  rw [geckGraphAut_hom, geckRootSubgroup_def, geckRootSubgroup_def, Category.assoc,
+    eqToHom_trans_assoc, eqToHom_refl, Category.id_comp, toralGraphAut, ← Category.assoc,
+    TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupToToral_comp_numberedSymmetryIso_hom]
+
+/-- The inverse graph automorphism restores the original numbering of a pinned root subgroup. -/
+@[reassoc (attr := simp)]
+theorem geckRootSubgroup_comp_geckGraphAut_inv (hsigma : sigma ∈ t.diagramSymmetry)
+    (i : Fin t.rank ⊕ Fin t.rank) :
+    t.geckRootSubgroup ht (diagramRootGeneratorPerm sigma i) ≫ (t.geckGraphAut ht hsigma).inv =
+      t.geckRootSubgroup ht i := by
+  rw [← geckRootSubgroup_comp_geckGraphAut_hom ht hsigma i, Category.assoc,
+    (t.geckGraphAut ht hsigma).hom_inv_id, Category.comp_id]
+
+/-- **The graph automorphism normalizes the represented weight torus**, acting on it by the
+relabelling attached to the diagram symmetry. -/
+@[reassoc (attr := simp)]
+theorem geckWeightTorus_comp_geckGraphAut_hom (hsigma : sigma ∈ t.diagramSymmetry) :
+    t.geckWeightTorus ht ≫ (t.geckGraphAut ht hsigma).hom =
+      SplitTorus.relabel ℤ sigma⁻¹ ≫ t.geckWeightTorus ht := by
+  rw [geckGraphAut_hom, geckWeightTorus_def, Category.assoc,
+    eqToHom_trans_assoc, eqToHom_refl, Category.id_comp, toralGraphAut, ← Category.assoc,
+    TauCeti.UniversalEnvelopingAlgebra.kostantWeightTorusToToral_comp_numberedSymmetryIso_hom,
+    Category.assoc]
+
+/-- The inverse graph automorphism relabels the weight torus by the inverse symmetry. -/
+@[reassoc (attr := simp)]
+theorem geckWeightTorus_comp_geckGraphAut_inv (hsigma : sigma ∈ t.diagramSymmetry) :
+    t.geckWeightTorus ht ≫ (t.geckGraphAut ht hsigma).inv =
+      SplitTorus.relabel ℤ sigma ≫ t.geckWeightTorus ht := by
+  calc t.geckWeightTorus ht ≫ (t.geckGraphAut ht hsigma).inv
+      = (SplitTorus.relabel ℤ sigma ≫ SplitTorus.relabel ℤ sigma⁻¹ ≫ t.geckWeightTorus ht) ≫
+          (t.geckGraphAut ht hsigma).inv := by
+        simp only [← Category.assoc, SplitTorus.relabel_comp, mul_inv_cancel,
+          SplitTorus.relabel_one, Category.id_comp]
+    _ = SplitTorus.relabel ℤ sigma ≫
+          (t.geckWeightTorus ht ≫ (t.geckGraphAut ht hsigma).hom) ≫
+            (t.geckGraphAut ht hsigma).inv := by
+        rw [geckWeightTorus_comp_geckGraphAut_hom]
+        simp only [Category.assoc]
+    _ = SplitTorus.relabel ℤ sigma ≫ t.geckWeightTorus ht := by
+        rw [Category.assoc, (t.geckGraphAut ht hsigma).hom_inv_id, Category.comp_id]
+
+/-- The permutation of the numbered generator indices is a power in the node permutation. -/
+private theorem diagramRootGeneratorPerm_pow (tau : Equiv.Perm (Fin t.rank)) (k : ℕ) :
+    diagramRootGeneratorPerm tau ^ k = diagramRootGeneratorPerm (tau ^ k) := by
+  induction k with
+  | zero => ext x; cases x <;> simp
+  | succ k ih => ext x; cases x <;> simp [pow_succ, ih]
+
+/-- **The order of the graph automorphism divides that of the diagram symmetry.** An involution of
+the numbered diagram therefore gives `γ ^ 2 = 1`, and the triality of `D₄` gives `γ ^ 3 = 1`. -/
+theorem geckGraphAut_pow_eq_one (hsigma : sigma ∈ t.diagramSymmetry) {m : ℕ}
+    (hm : sigma ^ m = 1) : t.geckGraphAut ht hsigma ^ m = 1 := by
+  have hgen : diagramRootGeneratorPerm sigma ^ m = 1 := by
+    rw [diagramRootGeneratorPerm_pow, hm]
+    ext x
+    cases x <;> simp
+  have htoral : toralGraphAut ht hsigma ^ m = 1 :=
+    TauCeti.UniversalEnvelopingAlgebra.kostantToralNumberedSymmetryIso_pow_eq_one _ _ _ _ _ _ _ _
+      _ _ _ _ _ _ _ _ _ m (by rw [← Equiv.Perm.coe_pow, hgen]; rfl) hm
+  rw [geckGraphAut, ← map_pow, htoral, map_one]
+
+/-- The identity symmetry of the diagram gives the identity automorphism of the Geck carrier. -/
+@[simp]
+theorem geckGraphAut_one (h1 : (1 : Equiv.Perm (Fin t.rank)) ∈ t.diagramSymmetry) :
+    t.geckGraphAut ht h1 = 1 := by
+  simpa using geckGraphAut_pow_eq_one ht h1 (m := 1) (pow_one _)
+
+end
+
+end TauCeti.DynkinType

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/GraphAutomorphism.lean
@@ -211,6 +211,7 @@ private theorem diagramRootGeneratorPerm_pow (tau : Equiv.Perm (Fin t.rank)) (k 
 
 /-- **The order of the graph automorphism divides that of the diagram symmetry.** An involution of
 the numbered diagram therefore gives `γ ^ 2 = 1`, and the triality of `D₄` gives `γ ^ 3 = 1`. -/
+@[simp]
 theorem geckGraphAut_pow_eq_one (hsigma : sigma ∈ t.diagramSymmetry) {m : ℕ}
     (hm : sigma ^ m = 1) : t.geckGraphAut ht hsigma ^ m = 1 := by
   have hgen : diagramRootGeneratorPerm sigma ^ m = 1 := by
@@ -224,9 +225,8 @@ theorem geckGraphAut_pow_eq_one (hsigma : sigma ∈ t.diagramSymmetry) {m : ℕ}
 
 /-- The identity symmetry of the diagram gives the identity automorphism of the Geck carrier. -/
 @[simp]
-theorem geckGraphAut_one (h1 : (1 : Equiv.Perm (Fin t.rank)) ∈ t.diagramSymmetry) :
-    t.geckGraphAut ht h1 = 1 := by
-  simpa using geckGraphAut_pow_eq_one ht h1 (m := 1) (pow_one _)
+theorem geckGraphAut_one : t.geckGraphAut ht t.diagramSymmetry.one_mem = 1 := by
+  simpa using geckGraphAut_pow_eq_one ht t.diagramSymmetry.one_mem (m := 1) (pow_one _)
 
 end
 


### PR DESCRIPTION
This PR equips the pinned Geck carrier `TauCeti.DynkinType.geckGroupScheme` with the graph automorphism attached to a symmetry of its Bourbaki-numbered Dynkin diagram, and proves the pinning equations that determine it: `γ ∘ x_i = x_{σ i}` on every numbered raising and lowering root subgroup, without change of additive parameter, and `γ ∘ (weight torus) = (weight torus) ∘ relabel σ⁻¹`. The order of `γ` divides that of `σ`, so a diagram involution gives `γ ^ 2 = 1` and the triality of `D₄` gives `γ ^ 3 = 1`, and the identity symmetry gives the identity automorphism.

Both halves of the construction already existed and neither had been joined to the other. `TauCeti.UniversalEnvelopingAlgebra.kostantToralNumberedSymmetryIso` builds the automorphism of a Kostant toral closure from a symmetry of the numbered data, and `TauCeti.LinearAlgebra.RootSystem.GeckConstruction.PinnedSymmetry` supplies the lattice stability and the intertwining of the represented simple root generators, closing with the observation that its weight equation "is the remaining input for extending the root-generated symmetry to the toral carrier". What is new here is that reading, the finite-ordinal form of the basis and weight hypotheses that the group-scheme construction consumes (`geckDiagramFinPerm`, `geckDiagramModuleEquiv_geckCoordinateBasisFin`, `geckWeightFin_geckDiagramFinPerm`), and the resulting equations transported onto the pinned carrier itself. `TauCeti.SlStd.graphAutomorphism` is the same statement for the full-weight type-A standard carrier only, reached through an explicit `GL` matrix automorphism; nothing there covers a general Dynkin type.

This is the graph-automorphism half of the "Pinnings" target in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md` — "A pinning `(G, T, B, {X_α})` ... This is what makes 'the' graph automorphism well defined, so it is data, not a property" — for the explicit Chevalley–Demazure carrier that Layer 9 constructs. Its consumer is milestone L1, "ordinary and graph-twisted Steinberg maps", of `TauCetiRoadmap/CFSGStatement/README.md`, whose twisted branches are `γ ∘ Frob_q` and which requires exactly the simple-root-subgroup equation `γ (x_α(t)) = x_{γ α}(t)` and the order relations `γ ^ 2 = 1`, `γ ^ 3 = 1` proved here; the declaration that will consume it is `TauCeti.GraphTwistedIndex.graphAut`, whose root-datum-level counterpart `TauCeti.GraphTwistedIndex.datumGraphAut` is already on `main`. Nothing is asserted about reductivity, maximality of the weight torus, finiteness, or simplicity.

After this PR, L1 still needs the pinned carrier to reach the simply connected form (an admissible lattice whose weights span the full character lattice, which the Geck weights do only for `E₈`, `F₄` and `G₂`) and needs this scheme automorphism read on points over an algebraic closure of `ZMod p`, before `GraphTwistedIndex.graphAut` and the composite `γ ∘ Frob_q` can be defined.

No Mathlib material is vendored. The construction follows R. W. Carter, *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §1.15 and J. E. Humphreys, *Linear Algebraic Groups*, §27, on the carrier of M. Geck, *On the construction of semisimple Lie algebras and Chevalley groups*, Proc. Amer. Math. Soc. **145** (2017), 3233–3247, as cited in the module docstring.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geck-carrier-graph-automorphism"}-->

🤖 Prepared with Claude Code
