### PR TITLE
feat: identify preprojective algebras with their opposites

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Opposite.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Opposite
+public import Mathlib.Algebra.BigOperators.Group.Finset.Defs
+public import Mathlib.Combinatorics.Quiver.Symmetric
+public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.Basic
+
+/-!
+# Opposites of path algebras
+
+Reversing every path in a quiver with involutive arrow reversal identifies its path algebra with
+its opposite algebra. This file constructs that identification directly on the path basis and
+records its action on paths, vertices, and arrows.
+
+## Main definitions
+
+* `TauCeti.Quiver.TotalPath.reverse`: reversal of an indexed path, including its endpoints.
+* `TauCeti.PathAlgebra.reverseOpAlgEquiv`: the algebra isomorphism from a path algebra to its
+  opposite induced by path reversal.
+
+## References
+
+This is the path-algebra prerequisite for the opposite-algebra comparison in Layer 4 of
+`TauCetiRoadmap/ZigzagPreprojective/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Quiver MulOpposite
+
+universe u v w
+
+namespace Quiver.TotalPath
+
+variable {Q : Type u} [Quiver.{v} Q]
+
+/-- Reverse an indexed path and exchange its source and target. -/
+def reverse [HasReverse Q] (x : TotalPath Q) : TotalPath Q :=
+  ⟨x.2.1, x.1, x.2.2.reverse⟩
+
+/-- Reversal of an explicitly indexed path reverses its underlying path. -/
+@[simp]
+theorem reverse_mk [HasReverse Q] {a b : Q} (p : Path a b) :
+    reverse (⟨a, b, p⟩ : TotalPath Q) = ⟨b, a, p.reverse⟩ :=
+  (rfl)
+
+/-- Reversing an indexed path twice returns the original path. -/
+@[simp]
+theorem reverse_reverse [HasInvolutiveReverse Q] (x : TotalPath Q) :
+    x.reverse.reverse = x := by
+  obtain ⟨a, b, p⟩ := x
+  simp
+
+end Quiver.TotalPath
+
+namespace PathAlgebra
+
+section Reverse
+
+variable (k : Type w) (Q : Type u) [CommSemiring k] [Quiver.{v} Q]
+  [HasInvolutiveReverse Q] [Finite Q]
+
+omit [Finite Q] in
+private theorem reverseOp_hcomp {a b c : Q} (p : Path a b) (q : Path c a) :
+    op (ofPath (Quiver.TotalPath.reverse ⟨a, b, p⟩) : pathAlgebra k Q) *
+        op (ofPath (Quiver.TotalPath.reverse ⟨c, a, q⟩) : pathAlgebra k Q) =
+      op (ofPath (Quiver.TotalPath.reverse ⟨c, b, q.comp p⟩) : pathAlgebra k Q) := by
+  rw [← op_mul, Quiver.TotalPath.reverse_mk, Quiver.TotalPath.reverse_mk,
+    ofPath_mul_ofPath_of_comp, Quiver.TotalPath.reverse_mk, Path.reverse_comp]
+
+private theorem reverseOp_hzero {x y : Quiver.TotalPath Q} (h : y.2.1 ≠ x.1) :
+    op (ofPath x.reverse : pathAlgebra k Q) * op (ofPath y.reverse : pathAlgebra k Q) = 0 := by
+  rw [← op_mul, ofPath_mul_ofPath_of_not_composable]
+  · exact op_zero
+  · exact fun hxy ↦ h hxy.symm
+
+private theorem reverseOp_hone :
+    letI := Fintype.ofFinite Q
+    ∑ a : Q, op (ofPath (Quiver.TotalPath.reverse ⟨a, a, Path.nil⟩) : pathAlgebra k Q) = 1 := by
+  let _ := Fintype.ofFinite Q
+  simp only [Quiver.TotalPath.reverse_mk, Path.reverse, ofPath_eq_single,
+    ← vertexIdempotent_eq_single]
+  rw [← Finset.op_sum Finset.univ]
+  exact (congrArg op (one_def (k := k) (Q := Q))).symm
+
+private noncomputable def reverseOpAlgHom :
+    pathAlgebra k Q →ₐ[k] (pathAlgebra k Q)ᵐᵒᵖ :=
+  liftAlgHom k (fun x ↦ op (ofPath x.reverse)) (reverseOp_hcomp k Q)
+    (reverseOp_hzero k Q) (reverseOp_hone k Q)
+
+@[simp]
+private theorem reverseOpAlgHom_ofPath (x : Quiver.TotalPath Q) :
+    reverseOpAlgHom k Q (ofPath x) = op (ofPath x.reverse) := by
+  rw [reverseOpAlgHom, liftAlgHom_ofPath]
+
+/-- Reversing paths identifies the path algebra of a quiver with involutive arrow reversal with
+its opposite algebra. -/
+noncomputable def reverseOpAlgEquiv : pathAlgebra k Q ≃ₐ[k] (pathAlgebra k Q)ᵐᵒᵖ :=
+  AlgEquiv.ofAlgHom (reverseOpAlgHom k Q) (AlgHom.opComm (reverseOpAlgHom k Q))
+    (by
+      apply AlgHom.ext
+      intro z
+      obtain ⟨y, rfl⟩ := MulOpposite.op_surjective z
+      change reverseOpAlgHom k Q
+          (AlgHom.opComm (reverseOpAlgHom k Q) (op y)) = op y
+      induction y using induction_linear with
+      | zero => simp
+      | add y₁ y₂ h₁ h₂ => rw [op_add, map_add, map_add, h₁, h₂]
+      | single x c =>
+          rw [single_eq_smul_ofPath, op_smul, map_smul, map_smul,
+            AlgHom.opComm_apply_apply, unop_op, reverseOpAlgHom_ofPath,
+            unop_op, reverseOpAlgHom_ofPath, Quiver.TotalPath.reverse_reverse])
+    (algHom_ext k fun x ↦ by
+      rw [AlgHom.comp_apply, reverseOpAlgHom_ofPath, AlgHom.opComm_apply_apply, unop_op,
+        reverseOpAlgHom_ofPath, Quiver.TotalPath.reverse_reverse]
+      rfl)
+
+/-- The path-reversal isomorphism sends a basis path to the opposite of its reverse. -/
+@[simp]
+theorem reverseOpAlgEquiv_ofPath (x : Quiver.TotalPath Q) :
+    reverseOpAlgEquiv k Q (ofPath x) = op (ofPath x.reverse) := by
+  rw [reverseOpAlgEquiv, AlgEquiv.ofAlgHom_apply, reverseOpAlgHom_ofPath]
+
+/-- The inverse path-reversal isomorphism sends the opposite of a basis path to its reverse. -/
+@[simp]
+theorem reverseOpAlgEquiv_symm_op_ofPath (x : Quiver.TotalPath Q) :
+    (reverseOpAlgEquiv k Q).symm (op (ofPath x)) = ofPath x.reverse := by
+  rw [reverseOpAlgEquiv, AlgEquiv.ofAlgHom_symm, AlgEquiv.ofAlgHom_apply,
+    AlgHom.opComm_apply_apply, unop_op, reverseOpAlgHom_ofPath, unop_op]
+
+/-- Path reversal fixes vertex idempotents, up to passage to the opposite algebra. -/
+@[simp]
+theorem reverseOpAlgEquiv_vertexIdempotent (a : Q) :
+    reverseOpAlgEquiv k Q (vertexIdempotent k a) = op (vertexIdempotent k a) := by
+  rw [vertexIdempotent_eq_single, ← ofPath_eq_single, reverseOpAlgEquiv_ofPath,
+    Quiver.TotalPath.reverse_mk, Path.reverse, ofPath_eq_single, ← vertexIdempotent_eq_single]
+
+/-- Path reversal sends an arrow to the opposite of its reversed arrow. -/
+theorem reverseOpAlgEquiv_ofArrow {a b : Q} (e : a ⟶ b) :
+    reverseOpAlgEquiv k Q (ofArrow e) = op (ofArrow (Quiver.reverse e)) := by
+  rw [ofArrow_eq_ofPath, reverseOpAlgEquiv_ofPath, Quiver.TotalPath.reverse_mk,
+    Path.reverse_toPath, ofArrow_eq_ofPath]
+
+end Reverse
+
+end PathAlgebra
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Opposite.lean
@@ -108,6 +108,8 @@ noncomputable def reverseOpAlgEquiv : pathAlgebra k Q ≃ₐ[k] (pathAlgebra k Q
       apply AlgHom.ext
       intro z
       obtain ⟨y, rfl⟩ := MulOpposite.op_surjective z
+      -- `AlgHom.opComm` and composition are hidden behind coercions here; expose their
+      -- applications definitionally so their computation lemmas can rewrite below.
       change reverseOpAlgHom k Q
           (AlgHom.opComm (reverseOpAlgHom k Q) (op y)) = op y
       induction y using induction_linear with

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra/Opposite.lean
@@ -108,10 +108,7 @@ noncomputable def reverseOpAlgEquiv : pathAlgebra k Q ≃ₐ[k] (pathAlgebra k Q
       apply AlgHom.ext
       intro z
       obtain ⟨y, rfl⟩ := MulOpposite.op_surjective z
-      -- `AlgHom.opComm` and composition are hidden behind coercions here; expose their
-      -- applications definitionally so their computation lemmas can rewrite below.
-      change reverseOpAlgHom k Q
-          (AlgHom.opComm (reverseOpAlgHom k Q) (op y)) = op y
+      rw [AlgHom.comp_apply, AlgHom.id_apply]
       induction y using induction_linear with
       | zero => simp
       | add y₁ y₂ h₁ h₂ => rw [op_add, map_add, map_add, h₁, h₂]
@@ -121,8 +118,7 @@ noncomputable def reverseOpAlgEquiv : pathAlgebra k Q ≃ₐ[k] (pathAlgebra k Q
             unop_op, reverseOpAlgHom_ofPath, Quiver.TotalPath.reverse_reverse])
     (algHom_ext k fun x ↦ by
       rw [AlgHom.comp_apply, reverseOpAlgHom_ofPath, AlgHom.opComm_apply_apply, unop_op,
-        reverseOpAlgHom_ofPath, Quiver.TotalPath.reverse_reverse]
-      rfl)
+        reverseOpAlgHom_ofPath, Quiver.TotalPath.reverse_reverse, AlgHom.id_apply, unop_op])
 
 /-- The path-reversal isomorphism sends a basis path to the opposite of its reverse. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Gauge.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Gauge.lean
@@ -320,6 +320,14 @@ theorem preprojectiveAlgebraEquivGaugedOne_preprojectiveMk
   rw [preprojectiveAlgebraEquivGaugedOne, preprojectiveMk_apply,
     gaugedPreprojectiveMk_apply, Ideal.quotientEquivAlgOfEq_mk]
 
+/-- The inverse constant-gauge identification preserves the quotient generators. -/
+@[simp]
+theorem preprojectiveAlgebraEquivGaugedOne_symm_gaugedPreprojectiveMk
+    (x : pathAlgebra k (Symmetrify Q)) :
+    (preprojectiveAlgebraEquivGaugedOne (Q := Q) k).symm
+        (gaugedPreprojectiveMk k (fun _ _ _ => 1) x) = preprojectiveMk k Q x := by
+  rw [AlgEquiv.symm_apply_eq, preprojectiveAlgebraEquivGaugedOne_preprojectiveMk]
+
 /-- **Every unit-valued gauge presents the preprojective algebra.** In particular a labelling of
 the arrows of `Q` by signs presents `Π_k(Q)` for every choice of signs. -/
 noncomputable def preprojectiveAlgebraEquivGauged (ε : ∀ ⦃i j : Q⦄, (i ⟶ j) → k)

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
@@ -6,22 +6,27 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.Opposite
-public import TauCeti.RepresentationTheory.Quiver.Preprojective.Basic
+public import TauCeti.RepresentationTheory.Quiver.Preprojective.Gauge
 
 /-!
 # The opposite of a preprojective algebra
 
 Reversing every path of the doubled quiver preserves each of the two backtracks attached to an
-original arrow. It therefore preserves the signed preprojective relator and descends to an
-isomorphism from the additive preprojective algebra to its opposite. On a path class this
-isomorphism takes the class of the path to the opposite of the class of its reverse.
+original arrow. It therefore preserves every gauged preprojective relator `ρ_ε`, whatever the
+labelling `ε`, and descends to an isomorphism from the gauged preprojective algebra to its
+opposite. Specializing to the constant labelling `1` gives the same isomorphism for the additive
+preprojective algebra. On a path class the isomorphism takes the class of the path to the opposite
+of the class of its reverse.
 
 ## Main results
 
-* `TauCeti.reverseOpAlgEquiv_preprojectiveRelator`: path reversal preserves the preprojective
-  relator, up to passage to the opposite algebra.
-* `TauCeti.reverseOpAlgEquiv_localPreprojectiveRelator`: the same statement for each local
-  relator.
+* `TauCeti.reverseOpAlgEquiv_gaugedPreprojectiveRelator`: path reversal preserves every gauged
+  preprojective relator, up to passage to the opposite algebra.
+* `TauCeti.reverseOpAlgEquiv_preprojectiveRelator` and
+  `TauCeti.reverseOpAlgEquiv_localPreprojectiveRelator`: the same statement for the preprojective
+  relator and for each local relator.
+* `TauCeti.gaugedPreprojectiveOpAlgEquiv`: every gauged preprojective algebra is isomorphic to its
+  opposite.
 * `TauCeti.preprojectiveOpAlgEquiv`: the preprojective algebra is isomorphic to its opposite.
 
 ## References
@@ -76,18 +81,29 @@ end Backtrack
 
 section Relator
 
-variable (k : Type w) (Q : Type u) [CommRing k] [Quiver.{v + 1} Q] [Fintype Q]
+variable (k : Type w) {Q : Type u} [CommRing k] [Quiver.{v + 1} Q] [Fintype Q]
   [∀ i j : Q, Fintype (i ⟶ j)]
 
+/-- **Path reversal preserves every gauged preprojective relator**, up to passage to the opposite
+path algebra. Both backtracks of every arrow are palindromic, so each signed difference is fixed
+however its coefficient is chosen. -/
+@[simp]
+theorem reverseOpAlgEquiv_gaugedPreprojectiveRelator (ε : ∀ ⦃i j : Q⦄, (i ⟶ j) → k) :
+    reverseOpAlgEquiv k (Symmetrify Q) (gaugedPreprojectiveRelator k ε) =
+      op (gaugedPreprojectiveRelator k ε) := by
+  rw [gaugedPreprojectiveRelator_def]
+  simp only [map_sum, map_smul, map_sub, reverseOpAlgEquiv_headBacktrackElem,
+    reverseOpAlgEquiv_tailBacktrackElem, Finset.op_sum, op_smul, op_sub]
+
+variable (Q)
+
 /-- **Path reversal preserves the preprojective relator**, up to passage to the opposite path
-algebra. Both backtracks of every arrow are palindromic, so their signed difference is fixed. -/
+algebra. This is the constant labelling `1` of the gauged statement. -/
 @[simp]
 theorem reverseOpAlgEquiv_preprojectiveRelator :
     reverseOpAlgEquiv k (Symmetrify Q) (preprojectiveRelator k Q) =
       op (preprojectiveRelator k Q) := by
-  rw [preprojectiveRelator_def]
-  simp only [map_sum, map_sub, reverseOpAlgEquiv_headBacktrackElem,
-    reverseOpAlgEquiv_tailBacktrackElem, Finset.op_sum, op_sub]
+  rw [← gaugedPreprojectiveRelator_one, reverseOpAlgEquiv_gaugedPreprojectiveRelator]
 
 /-- Path reversal preserves each local preprojective relator, up to passage to the opposite path
 algebra. -/
@@ -103,57 +119,57 @@ end Relator
 
 section Quotient
 
-variable (k : Type w) (Q : Type u) [CommRing k] [Quiver.{v + 1} Q] [Fintype Q]
-  [∀ i j : Q, Fintype (i ⟶ j)]
+variable (k : Type w) {Q : Type u} [CommRing k] [Quiver.{v + 1} Q] [Fintype Q]
+  [∀ i j : Q, Fintype (i ⟶ j)] (ε : ∀ ⦃i j : Q⦄, (i ⟶ j) → k)
 
-/-- Reversal followed by the opposite of the preprojective quotient map. -/
-private noncomputable def preprojectiveReversePathAlgHom :
-    pathAlgebra k (Symmetrify Q) →ₐ[k] (preprojectiveAlgebra k Q)ᵐᵒᵖ :=
-  (AlgHom.op (preprojectiveMk k Q)).comp
+/-- Reversal followed by the opposite of the gauged preprojective quotient map. -/
+private noncomputable def gaugedPreprojectiveReversePathAlgHom :
+    pathAlgebra k (Symmetrify Q) →ₐ[k] (gaugedPreprojectiveAlgebra k ε)ᵐᵒᵖ :=
+  (AlgHom.op (gaugedPreprojectiveMk k ε)).comp
     (reverseOpAlgEquiv k (Symmetrify Q)).toAlgHom
 
-private theorem preprojectiveReversePathAlgHom_relator :
-    preprojectiveReversePathAlgHom k Q (preprojectiveRelator k Q) = 0 := by
-  rw [preprojectiveReversePathAlgHom, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply,
-    reverseOpAlgEquiv_preprojectiveRelator]
+private theorem gaugedPreprojectiveReversePathAlgHom_relator :
+    gaugedPreprojectiveReversePathAlgHom k ε (gaugedPreprojectiveRelator k ε) = 0 := by
+  rw [gaugedPreprojectiveReversePathAlgHom, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply,
+    reverseOpAlgEquiv_gaugedPreprojectiveRelator]
   simp
 
-/-- The path-reversal homomorphism from a preprojective algebra to its opposite, obtained by
-descending reversal of the doubled path algebra through the preprojective relation. -/
-private noncomputable def preprojectiveReverseOpAlgHom :
-    preprojectiveAlgebra k Q →ₐ[k] (preprojectiveAlgebra k Q)ᵐᵒᵖ :=
-  preprojectiveLift (preprojectiveReversePathAlgHom k Q)
-    (preprojectiveReversePathAlgHom_relator k Q)
+/-- The path-reversal homomorphism from a gauged preprojective algebra to its opposite, obtained
+by descending reversal of the doubled path algebra through the gauged relation. -/
+private noncomputable def gaugedPreprojectiveReverseOpAlgHom :
+    gaugedPreprojectiveAlgebra k ε →ₐ[k] (gaugedPreprojectiveAlgebra k ε)ᵐᵒᵖ :=
+  gaugedPreprojectiveLift k ε (gaugedPreprojectiveReversePathAlgHom k ε)
+    (gaugedPreprojectiveReversePathAlgHom_relator k ε)
 
-private theorem preprojectiveReverseOpAlgHom_preprojectiveMk (x) :
-    preprojectiveReverseOpAlgHom k Q (preprojectiveMk k Q x) =
-      preprojectiveReversePathAlgHom k Q x := by
-  rw [preprojectiveReverseOpAlgHom, preprojectiveLift_preprojectiveMk]
+private theorem gaugedPreprojectiveReverseOpAlgHom_gaugedPreprojectiveMk (x) :
+    gaugedPreprojectiveReverseOpAlgHom k ε (gaugedPreprojectiveMk k ε x) =
+      gaugedPreprojectiveReversePathAlgHom k ε x := by
+  rw [gaugedPreprojectiveReverseOpAlgHom, gaugedPreprojectiveLift_gaugedPreprojectiveMk]
 
-private theorem preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath
+private theorem gaugedPreprojectiveReverseOpAlgHom_gaugedPreprojectiveMk_ofPath
     (x : Quiver.TotalPath (Symmetrify Q)) :
-    preprojectiveReverseOpAlgHom k Q (preprojectiveMk k Q (ofPath x)) =
-      op (preprojectiveMk k Q (ofPath x.reverse)) := by
-  rw [preprojectiveReverseOpAlgHom_preprojectiveMk, preprojectiveReversePathAlgHom,
-    AlgHom.comp_apply, AlgEquiv.toAlgHom_apply, reverseOpAlgEquiv_ofPath,
-    AlgHom.op_apply_apply, unop_op]
+    gaugedPreprojectiveReverseOpAlgHom k ε (gaugedPreprojectiveMk k ε (ofPath x)) =
+      op (gaugedPreprojectiveMk k ε (ofPath x.reverse)) := by
+  rw [gaugedPreprojectiveReverseOpAlgHom_gaugedPreprojectiveMk,
+    gaugedPreprojectiveReversePathAlgHom, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply,
+    reverseOpAlgEquiv_ofPath, AlgHom.op_apply_apply, unop_op]
 
-private theorem preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath
+private theorem gaugedPreprojectiveReverseOpAlgHom_opComm_op_gaugedPreprojectiveMk_ofPath
     (x : Quiver.TotalPath (Symmetrify Q)) :
-    AlgHom.opComm (preprojectiveReverseOpAlgHom k Q)
-        (op (preprojectiveMk k Q (ofPath x))) =
-      preprojectiveMk k Q (ofPath x.reverse) := by
+    AlgHom.opComm (gaugedPreprojectiveReverseOpAlgHom k ε)
+        (op (gaugedPreprojectiveMk k ε (ofPath x))) =
+      gaugedPreprojectiveMk k ε (ofPath x.reverse) := by
   rw [AlgHom.opComm_apply_apply, unop_op,
-    preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath, unop_op]
+    gaugedPreprojectiveReverseOpAlgHom_gaugedPreprojectiveMk_ofPath, unop_op]
 
-private theorem preprojectiveReverseOpAlgHom_involutive_preprojectiveMk
+private theorem gaugedPreprojectiveReverseOpAlgHom_involutive_gaugedPreprojectiveMk
     (x : pathAlgebra k (Symmetrify Q)) :
-    (preprojectiveReverseOpAlgHom k Q
-          (AlgHom.opComm (preprojectiveReverseOpAlgHom k Q)
-            (op (preprojectiveMk k Q x))) = op (preprojectiveMk k Q x)) ∧
-      (AlgHom.opComm (preprojectiveReverseOpAlgHom k Q)
-          (preprojectiveReverseOpAlgHom k Q (preprojectiveMk k Q x)) =
-        preprojectiveMk k Q x) := by
+    (gaugedPreprojectiveReverseOpAlgHom k ε
+          (AlgHom.opComm (gaugedPreprojectiveReverseOpAlgHom k ε)
+            (op (gaugedPreprojectiveMk k ε x))) = op (gaugedPreprojectiveMk k ε x)) ∧
+      (AlgHom.opComm (gaugedPreprojectiveReverseOpAlgHom k ε)
+          (gaugedPreprojectiveReverseOpAlgHom k ε (gaugedPreprojectiveMk k ε x)) =
+        gaugedPreprojectiveMk k ε x) := by
   induction x using PathAlgebra.induction_linear with
   | zero => simp
   | add x₁ x₂ h₁ h₂ =>
@@ -165,33 +181,76 @@ private theorem preprojectiveReverseOpAlgHom_involutive_preprojectiveMk
   | single x c =>
       constructor
       · rw [single_eq_smul_ofPath, map_smul, op_smul, map_smul, map_smul,
-          preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath,
-          preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath,
+          gaugedPreprojectiveReverseOpAlgHom_opComm_op_gaugedPreprojectiveMk_ofPath,
+          gaugedPreprojectiveReverseOpAlgHom_gaugedPreprojectiveMk_ofPath,
           Quiver.TotalPath.reverse_reverse]
       · rw [single_eq_smul_ofPath, map_smul, map_smul, map_smul,
-          preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath,
-          preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath,
+          gaugedPreprojectiveReverseOpAlgHom_gaugedPreprojectiveMk_ofPath,
+          gaugedPreprojectiveReverseOpAlgHom_opComm_op_gaugedPreprojectiveMk_ofPath,
           Quiver.TotalPath.reverse_reverse]
 
-/-- **The additive preprojective algebra is isomorphic to its opposite algebra.** The isomorphism
-is induced by reversing every path of the doubled quiver. -/
-noncomputable def preprojectiveOpAlgEquiv :
-    preprojectiveAlgebra k Q ≃ₐ[k] (preprojectiveAlgebra k Q)ᵐᵒᵖ :=
-  AlgEquiv.ofAlgHom (preprojectiveReverseOpAlgHom k Q)
-    (AlgHom.opComm (preprojectiveReverseOpAlgHom k Q))
+/-- **A gauged preprojective algebra is isomorphic to its opposite algebra.** The isomorphism is
+induced by reversing every path of the doubled quiver, which fixes both backtracks of every arrow
+and hence the gauged relator, whatever the labelling. -/
+noncomputable def gaugedPreprojectiveOpAlgEquiv :
+    gaugedPreprojectiveAlgebra k ε ≃ₐ[k] (gaugedPreprojectiveAlgebra k ε)ᵐᵒᵖ :=
+  AlgEquiv.ofAlgHom (gaugedPreprojectiveReverseOpAlgHom k ε)
+    (AlgHom.opComm (gaugedPreprojectiveReverseOpAlgHom k ε))
     (by
       apply AlgHom.ext
       intro z
       obtain ⟨y, rfl⟩ := MulOpposite.op_surjective z
-      obtain ⟨x, rfl⟩ := preprojectiveMk_surjective k Q y
+      obtain ⟨x, rfl⟩ := gaugedPreprojectiveMk_surjective k ε y
       simp only [AlgHom.comp_apply, AlgHom.id_apply]
-      exact (preprojectiveReverseOpAlgHom_involutive_preprojectiveMk k Q x).1)
+      exact (gaugedPreprojectiveReverseOpAlgHom_involutive_gaugedPreprojectiveMk k ε x).1)
     (by
       apply AlgHom.ext
       intro y
-      obtain ⟨x, rfl⟩ := preprojectiveMk_surjective k Q y
+      obtain ⟨x, rfl⟩ := gaugedPreprojectiveMk_surjective k ε y
       simp only [AlgHom.comp_apply, AlgHom.id_apply]
-      exact (preprojectiveReverseOpAlgHom_involutive_preprojectiveMk k Q x).2)
+      exact (gaugedPreprojectiveReverseOpAlgHom_involutive_gaugedPreprojectiveMk k ε x).2)
+
+/-- On an arbitrary path-algebra representative, the gauged opposite-algebra isomorphism reverses
+the representative before applying the opposite of the quotient map. -/
+@[simp]
+theorem gaugedPreprojectiveOpAlgEquiv_gaugedPreprojectiveMk (x : pathAlgebra k (Symmetrify Q)) :
+    gaugedPreprojectiveOpAlgEquiv k ε (gaugedPreprojectiveMk k ε x) =
+      (AlgHom.op (gaugedPreprojectiveMk k ε)) (reverseOpAlgEquiv k (Symmetrify Q) x) := by
+  rw [gaugedPreprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_apply,
+    gaugedPreprojectiveReverseOpAlgHom_gaugedPreprojectiveMk,
+    gaugedPreprojectiveReversePathAlgHom, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply]
+
+/-- On the opposite of an arbitrary path-algebra representative, the inverse gauged
+opposite-algebra isomorphism reverses the representative before applying the quotient map. -/
+@[simp]
+theorem gaugedPreprojectiveOpAlgEquiv_symm_op_gaugedPreprojectiveMk
+    (x : pathAlgebra k (Symmetrify Q)) :
+    (gaugedPreprojectiveOpAlgEquiv k ε).symm (op (gaugedPreprojectiveMk k ε x)) =
+      gaugedPreprojectiveMk k ε (unop (reverseOpAlgEquiv k (Symmetrify Q) x)) := by
+  rw [gaugedPreprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_symm, AlgEquiv.ofAlgHom_apply,
+    AlgHom.opComm_apply_apply, unop_op, gaugedPreprojectiveReverseOpAlgHom_gaugedPreprojectiveMk,
+    gaugedPreprojectiveReversePathAlgHom, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply,
+    AlgHom.op_apply_apply, unop_op]
+
+variable (Q)
+
+private theorem preprojectiveAlgebraEquivGaugedOne_op_symm_op
+    (y : (pathAlgebra k (Symmetrify Q))ᵐᵒᵖ) :
+    (AlgEquiv.op (preprojectiveAlgebraEquivGaugedOne (Q := Q) k)).symm
+        ((AlgHom.op (gaugedPreprojectiveMk k fun _ _ _ => 1)) y) =
+      (AlgHom.op (preprojectiveMk k Q)) y := by
+  rw [AlgEquiv.symm_apply_eq, AlgHom.op_apply_apply, AlgEquiv.op_apply_apply,
+    AlgHom.op_apply_apply, unop_op, preprojectiveAlgebraEquivGaugedOne_preprojectiveMk]
+
+/-- **The additive preprojective algebra is isomorphic to its opposite algebra.** The isomorphism
+is induced by reversing every path of the doubled quiver; it is the constant labelling `1` of
+`TauCeti.gaugedPreprojectiveOpAlgEquiv`, transported along the identification of the two
+presentations. -/
+noncomputable def preprojectiveOpAlgEquiv :
+    preprojectiveAlgebra k Q ≃ₐ[k] (preprojectiveAlgebra k Q)ᵐᵒᵖ :=
+  (preprojectiveAlgebraEquivGaugedOne (Q := Q) k).trans <|
+    (gaugedPreprojectiveOpAlgEquiv k fun _ _ _ => 1).trans <|
+      (AlgEquiv.op (preprojectiveAlgebraEquivGaugedOne (Q := Q) k)).symm
 
 /-- On an arbitrary path-algebra representative, the opposite-algebra isomorphism reverses the
 representative before applying the opposite of the quotient map. -/
@@ -199,9 +258,10 @@ representative before applying the opposite of the quotient map. -/
 theorem preprojectiveOpAlgEquiv_preprojectiveMk (x : pathAlgebra k (Symmetrify Q)) :
     preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q x) =
       (AlgHom.op (preprojectiveMk k Q)) (reverseOpAlgEquiv k (Symmetrify Q) x) := by
-  rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_apply,
-    preprojectiveReverseOpAlgHom_preprojectiveMk, preprojectiveReversePathAlgHom,
-    AlgHom.comp_apply, AlgEquiv.toAlgHom_apply]
+  rw [preprojectiveOpAlgEquiv, AlgEquiv.trans_apply, AlgEquiv.trans_apply,
+    preprojectiveAlgebraEquivGaugedOne_preprojectiveMk,
+    gaugedPreprojectiveOpAlgEquiv_gaugedPreprojectiveMk,
+    preprojectiveAlgebraEquivGaugedOne_op_symm_op]
 
 /-- On the opposite of an arbitrary path-algebra representative, the inverse opposite-algebra
 isomorphism reverses the representative before applying the quotient map. -/
@@ -209,10 +269,11 @@ isomorphism reverses the representative before applying the quotient map. -/
 theorem preprojectiveOpAlgEquiv_symm_op_preprojectiveMk (x : pathAlgebra k (Symmetrify Q)) :
     (preprojectiveOpAlgEquiv k Q).symm (op (preprojectiveMk k Q x)) =
       preprojectiveMk k Q (unop (reverseOpAlgEquiv k (Symmetrify Q) x)) := by
-  rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_symm, AlgEquiv.ofAlgHom_apply,
-    AlgHom.opComm_apply_apply, unop_op, preprojectiveReverseOpAlgHom_preprojectiveMk,
-    preprojectiveReversePathAlgHom, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply,
-    AlgHom.op_apply_apply, unop_op]
+  rw [preprojectiveOpAlgEquiv, AlgEquiv.symm_trans_apply, AlgEquiv.symm_trans_apply,
+    AlgEquiv.symm_symm, AlgEquiv.op_apply_apply, unop_op,
+    preprojectiveAlgebraEquivGaugedOne_preprojectiveMk,
+    gaugedPreprojectiveOpAlgEquiv_symm_op_gaugedPreprojectiveMk,
+    preprojectiveAlgebraEquivGaugedOne_symm_gaugedPreprojectiveMk]
 
 /- The generator formulas below specialize the two representative rules above, which are the simp
 normal forms: `simp` derives each of them from those rules, so they carry no `@[simp]` attribute
@@ -232,8 +293,7 @@ theorem preprojectiveOpAlgEquiv_symm_op_preprojectiveMk_ofPath
     (x : Quiver.TotalPath (Symmetrify Q)) :
     (preprojectiveOpAlgEquiv k Q).symm (op (preprojectiveMk k Q (ofPath x))) =
       preprojectiveMk k Q (ofPath x.reverse) := by
-  rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_symm, AlgEquiv.ofAlgHom_apply,
-    preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath]
+  rw [preprojectiveOpAlgEquiv_symm_op_preprojectiveMk, reverseOpAlgEquiv_ofPath, unop_op]
 
 /-- The opposite-algebra isomorphism fixes every vertex idempotent class, up to passage to the
 opposite algebra. -/

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.PathAlgebra.Opposite
+public import TauCeti.RepresentationTheory.Quiver.Preprojective.Basic
+
+/-!
+# The opposite of a preprojective algebra
+
+Reversing every path of the doubled quiver preserves each of the two backtracks attached to an
+original arrow. It therefore preserves the signed preprojective relator and descends to an
+isomorphism from the additive preprojective algebra to its opposite. On a path class this
+isomorphism takes the class of the path to the opposite of the class of its reverse.
+
+## Main results
+
+* `TauCeti.reverseOpAlgEquiv_preprojectiveRelator`: path reversal preserves the preprojective
+  relator, up to passage to the opposite algebra.
+* `TauCeti.preprojectiveOpAlgEquiv`: the preprojective algebra is isomorphic to its opposite.
+
+## References
+
+This proves the opposite-algebra comparison in the first bullet of Layer 4 of
+`TauCetiRoadmap/ZigzagPreprojective/README.md`. The preprojective presentation and its signs
+follow Crawley-Boevey, *Quiver algebras, weighted projective lines, and the Deligne--Simpson
+problem*, Section 1.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Quiver MulOpposite PathAlgebra
+
+universe u v w
+
+section Relator
+
+variable (k : Type w) {Q : Type u} [CommRing k] [Quiver.{v + 1} Q] [Finite Q]
+
+/-- Reversal fixes the head backtrack of an original arrow, up to passage to the opposite path
+algebra. -/
+@[simp]
+theorem reverseOpAlgEquiv_headBacktrackElem {i j : Q} (a : i ⟶ j) :
+    reverseOpAlgEquiv k (Symmetrify Q) (headBacktrackElem k a) =
+      op (headBacktrackElem k a) := by
+  rw [← ofArrow_mul_ofArrow_reverse_eq_headBacktrackElem]
+  rw [map_mul, reverseOpAlgEquiv_ofArrow, reverseOpAlgEquiv_ofArrow,
+    Quiver.reverse_reverse, ← op_mul]
+
+/-- Reversal fixes the tail backtrack of an original arrow, up to passage to the opposite path
+algebra. -/
+@[simp]
+theorem reverseOpAlgEquiv_tailBacktrackElem {i j : Q} (a : i ⟶ j) :
+    reverseOpAlgEquiv k (Symmetrify Q) (tailBacktrackElem k a) =
+      op (tailBacktrackElem k a) := by
+  rw [← ofArrow_reverse_mul_ofArrow_eq_tailBacktrackElem]
+  rw [map_mul, reverseOpAlgEquiv_ofArrow, reverseOpAlgEquiv_ofArrow,
+    Quiver.reverse_reverse, ← op_mul]
+
+variable (Q) [Fintype Q] [∀ i j : Q, Fintype (i ⟶ j)]
+
+/-- **Path reversal preserves the preprojective relator**, up to passage to the opposite path
+algebra. Both backtracks of every arrow are palindromic, so their signed difference is fixed. -/
+theorem reverseOpAlgEquiv_preprojectiveRelator :
+    reverseOpAlgEquiv k (Symmetrify Q) (preprojectiveRelator k Q) =
+      op (preprojectiveRelator k Q) := by
+  rw [preprojectiveRelator_def]
+  simp only [map_sum, map_sub, reverseOpAlgEquiv_headBacktrackElem,
+    reverseOpAlgEquiv_tailBacktrackElem, Finset.op_sum, op_sub]
+
+end Relator
+
+section Quotient
+
+variable (k : Type w) (Q : Type u) [CommRing k] [Quiver.{v + 1} Q] [Fintype Q]
+  [∀ i j : Q, Fintype (i ⟶ j)]
+
+/-- Reversal followed by the opposite of the preprojective quotient map. -/
+private noncomputable def preprojectiveReversePathAlgHom :
+    pathAlgebra k (Symmetrify Q) →ₐ[k] (preprojectiveAlgebra k Q)ᵐᵒᵖ :=
+  (AlgHom.op (preprojectiveMk k Q)).comp
+    (reverseOpAlgEquiv k (Symmetrify Q)).toAlgHom
+
+private theorem preprojectiveReversePathAlgHom_relator :
+    preprojectiveReversePathAlgHom k Q (preprojectiveRelator k Q) = 0 := by
+  rw [preprojectiveReversePathAlgHom, AlgHom.comp_apply]
+  -- Expose the coerced `AlgEquiv` application so its characteristic lemma can rewrite it.
+  change (AlgHom.op (preprojectiveMk k Q))
+    (reverseOpAlgEquiv k (Symmetrify Q) (preprojectiveRelator k Q)) = 0
+  rw [reverseOpAlgEquiv_preprojectiveRelator]
+  simp
+
+/-- The path-reversal homomorphism from a preprojective algebra to its opposite, obtained by
+descending reversal of the doubled path algebra through the preprojective relation. -/
+private noncomputable def preprojectiveReverseOpAlgHom :
+    preprojectiveAlgebra k Q →ₐ[k] (preprojectiveAlgebra k Q)ᵐᵒᵖ :=
+  preprojectiveLift (preprojectiveReversePathAlgHom k Q)
+    (preprojectiveReversePathAlgHom_relator k Q)
+
+private theorem preprojectiveReverseOpAlgHom_preprojectiveMk (x) :
+    preprojectiveReverseOpAlgHom k Q (preprojectiveMk k Q x) =
+      preprojectiveReversePathAlgHom k Q x := by
+  rw [preprojectiveReverseOpAlgHom, preprojectiveLift_preprojectiveMk]
+
+private theorem preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath
+    (x : Quiver.TotalPath (Symmetrify Q)) :
+    preprojectiveReverseOpAlgHom k Q (preprojectiveMk k Q (ofPath x)) =
+      op (preprojectiveMk k Q (ofPath x.reverse)) := by
+  rw [preprojectiveReverseOpAlgHom_preprojectiveMk, preprojectiveReversePathAlgHom,
+    AlgHom.comp_apply]
+  -- Expose the coerced `AlgEquiv` application so its path formula can rewrite it.
+  change (AlgHom.op (preprojectiveMk k Q))
+    (reverseOpAlgEquiv k (Symmetrify Q) (ofPath x)) = _
+  rw [reverseOpAlgEquiv_ofPath]
+  rfl
+
+private theorem preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath
+    (x : Quiver.TotalPath (Symmetrify Q)) :
+    AlgHom.opComm (preprojectiveReverseOpAlgHom k Q)
+        (op (preprojectiveMk k Q (ofPath x))) =
+      preprojectiveMk k Q (ofPath x.reverse) := by
+  simp [AlgHom.opComm, preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath]
+
+/-- **The additive preprojective algebra is isomorphic to its opposite algebra.** The isomorphism
+is induced by reversing every path of the doubled quiver. -/
+noncomputable def preprojectiveOpAlgEquiv :
+    preprojectiveAlgebra k Q ≃ₐ[k] (preprojectiveAlgebra k Q)ᵐᵒᵖ :=
+  AlgEquiv.ofAlgHom (preprojectiveReverseOpAlgHom k Q)
+    (AlgHom.opComm (preprojectiveReverseOpAlgHom k Q))
+    (by
+      apply AlgHom.ext
+      intro z
+      obtain ⟨y, rfl⟩ := MulOpposite.op_surjective z
+      obtain ⟨x, rfl⟩ := preprojectiveMk_surjective k Q y
+      simp only [AlgHom.comp_apply, AlgHom.id_apply]
+      induction x using PathAlgebra.induction_linear with
+      | zero => simp
+      | add x₁ x₂ h₁ h₂ => rw [map_add, op_add, map_add, map_add, h₁, h₂]
+      | single x c =>
+          rw [single_eq_smul_ofPath, map_smul, op_smul, map_smul, map_smul,
+            preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath,
+            preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath,
+            Quiver.TotalPath.reverse_reverse])
+    (by
+      apply AlgHom.ext
+      intro y
+      obtain ⟨x, rfl⟩ := preprojectiveMk_surjective k Q y
+      simp only [AlgHom.comp_apply, AlgHom.id_apply]
+      induction x using PathAlgebra.induction_linear with
+      | zero => simp
+      | add x₁ x₂ h₁ h₂ => rw [map_add, map_add, map_add, h₁, h₂]
+      | single x c =>
+          rw [single_eq_smul_ofPath, map_smul, map_smul, map_smul,
+            preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath,
+            preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath,
+            Quiver.TotalPath.reverse_reverse])
+
+/-- On a path class, the opposite-algebra isomorphism takes the opposite of the class of the
+reversed path. -/
+@[simp]
+theorem preprojectiveOpAlgEquiv_preprojectiveMk_ofPath
+    (x : Quiver.TotalPath (Symmetrify Q)) :
+    preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q (ofPath x)) =
+      op (preprojectiveMk k Q (ofPath x.reverse)) := by
+  rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_apply,
+    preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath]
+
+/-- The inverse opposite-algebra isomorphism reverses a path representative as well. -/
+@[simp]
+theorem preprojectiveOpAlgEquiv_symm_op_preprojectiveMk_ofPath
+    (x : Quiver.TotalPath (Symmetrify Q)) :
+    (preprojectiveOpAlgEquiv k Q).symm (op (preprojectiveMk k Q (ofPath x))) =
+      preprojectiveMk k Q (ofPath x.reverse) := by
+  rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_symm, AlgEquiv.ofAlgHom_apply,
+    preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath]
+
+/-- The opposite-algebra isomorphism fixes every vertex idempotent class, up to passage to the
+opposite algebra. -/
+@[simp]
+theorem preprojectiveOpAlgEquiv_doubledVertexIdempotent (i : Q) :
+    preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q (doubledVertexIdempotent k i)) =
+      op (preprojectiveMk k Q (doubledVertexIdempotent k i)) := by
+  rw [doubledVertexIdempotent_def, vertexIdempotent_eq_single, ← ofPath_eq_single,
+    preprojectiveOpAlgEquiv_preprojectiveMk_ofPath, Quiver.TotalPath.reverse_mk, Path.reverse,
+    ofPath_eq_single, ← vertexIdempotent_eq_single]
+
+/-- The opposite-algebra isomorphism sends a doubled arrow class to the opposite of the class of
+its formal reverse. -/
+theorem preprojectiveOpAlgEquiv_ofArrow {i j : Symmetrify Q} (a : i ⟶ j) :
+    preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q (ofArrow a)) =
+      op (preprojectiveMk k Q (ofArrow (Quiver.reverse a))) := by
+  rw [ofArrow_eq_ofPath, preprojectiveOpAlgEquiv_preprojectiveMk_ofPath,
+    Quiver.TotalPath.reverse_mk, Path.reverse_toPath, ofArrow_eq_ofPath]
+
+end Quotient
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
@@ -20,6 +20,8 @@ isomorphism takes the class of the path to the opposite of the class of its reve
 
 * `TauCeti.reverseOpAlgEquiv_preprojectiveRelator`: path reversal preserves the preprojective
   relator, up to passage to the opposite algebra.
+* `TauCeti.reverseOpAlgEquiv_localPreprojectiveRelator`: the same statement for each local
+  relator.
 * `TauCeti.preprojectiveOpAlgEquiv`: the preprojective algebra is isomorphic to its opposite.
 
 ## References
@@ -78,6 +80,16 @@ theorem reverseOpAlgEquiv_preprojectiveRelator :
   simp only [map_sum, map_sub, reverseOpAlgEquiv_headBacktrackElem,
     reverseOpAlgEquiv_tailBacktrackElem, Finset.op_sum, op_sub]
 
+/-- Path reversal preserves each local preprojective relator, up to passage to the opposite path
+algebra. -/
+@[simp]
+theorem reverseOpAlgEquiv_localPreprojectiveRelator (v : Q) :
+    reverseOpAlgEquiv k (Symmetrify Q) (localPreprojectiveRelator k v) =
+      op (localPreprojectiveRelator k v) := by
+  rw [← preprojectiveRelator_vertexCorner_eq_localPreprojectiveRelator,
+    doubledVertexIdempotent_def, map_mul, map_mul, reverseOpAlgEquiv_vertexIdempotent,
+    reverseOpAlgEquiv_preprojectiveRelator, ← op_mul, ← op_mul, mul_assoc]
+
 end Relator
 
 section Quotient
@@ -129,7 +141,35 @@ private theorem preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath
     AlgHom.opComm (preprojectiveReverseOpAlgHom k Q)
         (op (preprojectiveMk k Q (ofPath x))) =
       preprojectiveMk k Q (ofPath x.reverse) := by
-  simp [AlgHom.opComm, preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath]
+  rw [AlgHom.opComm_apply_apply, unop_op,
+    preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath, unop_op]
+
+private theorem preprojectiveReverseOpAlgHom_involutive_preprojectiveMk
+    (x : pathAlgebra k (Symmetrify Q)) :
+    (preprojectiveReverseOpAlgHom k Q
+          (AlgHom.opComm (preprojectiveReverseOpAlgHom k Q)
+            (op (preprojectiveMk k Q x))) = op (preprojectiveMk k Q x)) ∧
+      (AlgHom.opComm (preprojectiveReverseOpAlgHom k Q)
+          (preprojectiveReverseOpAlgHom k Q (preprojectiveMk k Q x)) =
+        preprojectiveMk k Q x) := by
+  induction x using PathAlgebra.induction_linear with
+  | zero => simp
+  | add x₁ x₂ h₁ h₂ =>
+      obtain ⟨h₁₁, h₁₂⟩ := h₁
+      obtain ⟨h₂₁, h₂₂⟩ := h₂
+      constructor
+      · rw [map_add, op_add, map_add, map_add, h₁₁, h₂₁]
+      · rw [map_add, map_add, map_add, h₁₂, h₂₂]
+  | single x c =>
+      constructor
+      · rw [single_eq_smul_ofPath, map_smul, op_smul, map_smul, map_smul,
+          preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath,
+          preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath,
+          Quiver.TotalPath.reverse_reverse]
+      · rw [single_eq_smul_ofPath, map_smul, map_smul, map_smul,
+          preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath,
+          preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath,
+          Quiver.TotalPath.reverse_reverse]
 
 /-- **The additive preprojective algebra is isomorphic to its opposite algebra.** The isomorphism
 is induced by reversing every path of the doubled quiver. -/
@@ -143,27 +183,13 @@ noncomputable def preprojectiveOpAlgEquiv :
       obtain ⟨y, rfl⟩ := MulOpposite.op_surjective z
       obtain ⟨x, rfl⟩ := preprojectiveMk_surjective k Q y
       simp only [AlgHom.comp_apply, AlgHom.id_apply]
-      induction x using PathAlgebra.induction_linear with
-      | zero => simp
-      | add x₁ x₂ h₁ h₂ => rw [map_add, op_add, map_add, map_add, h₁, h₂]
-      | single x c =>
-          rw [single_eq_smul_ofPath, map_smul, op_smul, map_smul, map_smul,
-            preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath,
-            preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath,
-            Quiver.TotalPath.reverse_reverse])
+      exact (preprojectiveReverseOpAlgHom_involutive_preprojectiveMk k Q x).1)
     (by
       apply AlgHom.ext
       intro y
       obtain ⟨x, rfl⟩ := preprojectiveMk_surjective k Q y
       simp only [AlgHom.comp_apply, AlgHom.id_apply]
-      induction x using PathAlgebra.induction_linear with
-      | zero => simp
-      | add x₁ x₂ h₁ h₂ => rw [map_add, map_add, map_add, h₁, h₂]
-      | single x c =>
-          rw [single_eq_smul_ofPath, map_smul, map_smul, map_smul,
-            preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath,
-            preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath,
-            Quiver.TotalPath.reverse_reverse])
+      exact (preprojectiveReverseOpAlgHom_involutive_preprojectiveMk k Q x).2)
 
 /-- On an arbitrary path-algebra representative, the opposite-algebra isomorphism reverses the
 representative before applying the opposite of the quotient map. -/
@@ -197,7 +223,7 @@ theorem preprojectiveOpAlgEquiv_symm_op_preprojectiveMk_ofPath
 /-- The opposite-algebra isomorphism fixes every vertex idempotent class, up to passage to the
 opposite algebra. -/
 @[simp]
-theorem preprojectiveOpAlgEquiv_doubledVertexIdempotent (i : Q) :
+theorem preprojectiveOpAlgEquiv_preprojectiveMk_doubledVertexIdempotent (i : Q) :
     preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q (doubledVertexIdempotent k i)) =
       op (preprojectiveMk k Q (doubledVertexIdempotent k i)) := by
   rw [doubledVertexIdempotent_def, vertexIdempotent_eq_single, ← ofPath_eq_single,
@@ -206,7 +232,7 @@ theorem preprojectiveOpAlgEquiv_doubledVertexIdempotent (i : Q) :
 
 /-- The opposite-algebra isomorphism sends a doubled arrow class to the opposite of the class of
 its formal reverse. -/
-theorem preprojectiveOpAlgEquiv_ofArrow {i j : Symmetrify Q} (a : i ⟶ j) :
+theorem preprojectiveOpAlgEquiv_preprojectiveMk_ofArrow {i j : Symmetrify Q} (a : i ⟶ j) :
     preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q (ofArrow a)) =
       op (preprojectiveMk k Q (ofArrow (Quiver.reverse a))) := by
   rw [ofArrow_eq_ofPath, preprojectiveOpAlgEquiv_preprojectiveMk_ofPath,

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
@@ -64,6 +64,14 @@ theorem reverseOpAlgEquiv_tailBacktrackElem {i j : Q} (a : i ⟶ j) :
   rw [map_mul, reverseOpAlgEquiv_ofArrow, reverseOpAlgEquiv_ofArrow,
     Quiver.reverse_reverse, ← op_mul]
 
+/-- Reversal fixes the vertex idempotent of the doubled quiver, up to passage to the opposite
+path algebra. -/
+@[simp]
+theorem reverseOpAlgEquiv_doubledVertexIdempotent (i : Q) :
+    reverseOpAlgEquiv k (Symmetrify Q) (doubledVertexIdempotent k i) =
+      op (doubledVertexIdempotent k i) := by
+  rw [doubledVertexIdempotent_def, reverseOpAlgEquiv_vertexIdempotent]
+
 end Backtrack
 
 section Relator
@@ -73,6 +81,7 @@ variable (k : Type w) (Q : Type u) [CommRing k] [Quiver.{v + 1} Q] [Fintype Q]
 
 /-- **Path reversal preserves the preprojective relator**, up to passage to the opposite path
 algebra. Both backtracks of every arrow are palindromic, so their signed difference is fixed. -/
+@[simp]
 theorem reverseOpAlgEquiv_preprojectiveRelator :
     reverseOpAlgEquiv k (Symmetrify Q) (preprojectiveRelator k Q) =
       op (preprojectiveRelator k Q) := by
@@ -193,6 +202,7 @@ noncomputable def preprojectiveOpAlgEquiv :
 
 /-- On an arbitrary path-algebra representative, the opposite-algebra isomorphism reverses the
 representative before applying the opposite of the quotient map. -/
+@[simp]
 theorem preprojectiveOpAlgEquiv_preprojectiveMk (x : pathAlgebra k (Symmetrify Q)) :
     preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q x) =
       (AlgHom.op (preprojectiveMk k Q)) (reverseOpAlgEquiv k (Symmetrify Q) x) := by
@@ -201,9 +211,25 @@ theorem preprojectiveOpAlgEquiv_preprojectiveMk (x : pathAlgebra k (Symmetrify Q
     AlgHom.comp_apply]
   rfl
 
+/-- On the opposite of an arbitrary path-algebra representative, the inverse opposite-algebra
+isomorphism reverses the representative before applying the quotient map. -/
+@[simp]
+theorem preprojectiveOpAlgEquiv_symm_op_preprojectiveMk (x : pathAlgebra k (Symmetrify Q)) :
+    (preprojectiveOpAlgEquiv k Q).symm (op (preprojectiveMk k Q x)) =
+      preprojectiveMk k Q (unop (reverseOpAlgEquiv k (Symmetrify Q) x)) := by
+  rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_symm, AlgEquiv.ofAlgHom_apply,
+    AlgHom.opComm_apply_apply, unop_op, preprojectiveReverseOpAlgHom_preprojectiveMk,
+    preprojectiveReversePathAlgHom, AlgHom.comp_apply]
+  -- Expose the coerced `AlgEquiv` application so `AlgHom.op` can compute on it.
+  change unop ((AlgHom.op (preprojectiveMk k Q)) (reverseOpAlgEquiv k (Symmetrify Q) x)) = _
+  rw [AlgHom.op_apply_apply, unop_op]
+
+/- The generator formulas below specialize the two representative rules above, which are the simp
+normal forms: `simp` derives each of them from those rules, so they carry no `@[simp]` attribute
+of their own. -/
+
 /-- On a path class, the opposite-algebra isomorphism takes the opposite of the class of the
 reversed path. -/
-@[simp]
 theorem preprojectiveOpAlgEquiv_preprojectiveMk_ofPath
     (x : Quiver.TotalPath (Symmetrify Q)) :
     preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q (ofPath x)) =
@@ -212,7 +238,6 @@ theorem preprojectiveOpAlgEquiv_preprojectiveMk_ofPath
   rfl
 
 /-- The inverse opposite-algebra isomorphism reverses a path representative as well. -/
-@[simp]
 theorem preprojectiveOpAlgEquiv_symm_op_preprojectiveMk_ofPath
     (x : Quiver.TotalPath (Symmetrify Q)) :
     (preprojectiveOpAlgEquiv k Q).symm (op (preprojectiveMk k Q (ofPath x))) =
@@ -222,13 +247,11 @@ theorem preprojectiveOpAlgEquiv_symm_op_preprojectiveMk_ofPath
 
 /-- The opposite-algebra isomorphism fixes every vertex idempotent class, up to passage to the
 opposite algebra. -/
-@[simp]
 theorem preprojectiveOpAlgEquiv_preprojectiveMk_doubledVertexIdempotent (i : Q) :
     preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q (doubledVertexIdempotent k i)) =
       op (preprojectiveMk k Q (doubledVertexIdempotent k i)) := by
-  rw [doubledVertexIdempotent_def, vertexIdempotent_eq_single, ← ofPath_eq_single,
-    preprojectiveOpAlgEquiv_preprojectiveMk_ofPath, Quiver.TotalPath.reverse_mk, Path.reverse,
-    ofPath_eq_single, ← vertexIdempotent_eq_single]
+  rw [preprojectiveOpAlgEquiv_preprojectiveMk, reverseOpAlgEquiv_doubledVertexIdempotent,
+    AlgHom.op_apply_apply, unop_op]
 
 /-- The opposite-algebra isomorphism sends a doubled arrow class to the opposite of the class of
 its formal reverse. -/

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
@@ -114,11 +114,8 @@ private noncomputable def preprojectiveReversePathAlgHom :
 
 private theorem preprojectiveReversePathAlgHom_relator :
     preprojectiveReversePathAlgHom k Q (preprojectiveRelator k Q) = 0 := by
-  rw [preprojectiveReversePathAlgHom, AlgHom.comp_apply]
-  -- Expose the coerced `AlgEquiv` application so its characteristic lemma can rewrite it.
-  change (AlgHom.op (preprojectiveMk k Q))
-    (reverseOpAlgEquiv k (Symmetrify Q) (preprojectiveRelator k Q)) = 0
-  rw [reverseOpAlgEquiv_preprojectiveRelator]
+  rw [preprojectiveReversePathAlgHom, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply,
+    reverseOpAlgEquiv_preprojectiveRelator]
   simp
 
 /-- The path-reversal homomorphism from a preprojective algebra to its opposite, obtained by
@@ -138,12 +135,8 @@ private theorem preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath
     preprojectiveReverseOpAlgHom k Q (preprojectiveMk k Q (ofPath x)) =
       op (preprojectiveMk k Q (ofPath x.reverse)) := by
   rw [preprojectiveReverseOpAlgHom_preprojectiveMk, preprojectiveReversePathAlgHom,
-    AlgHom.comp_apply]
-  -- Expose the coerced `AlgEquiv` application so its path formula can rewrite it.
-  change (AlgHom.op (preprojectiveMk k Q))
-    (reverseOpAlgEquiv k (Symmetrify Q) (ofPath x)) = _
-  rw [reverseOpAlgEquiv_ofPath]
-  rfl
+    AlgHom.comp_apply, AlgEquiv.toAlgHom_apply, reverseOpAlgEquiv_ofPath,
+    AlgHom.op_apply_apply, unop_op]
 
 private theorem preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath
     (x : Quiver.TotalPath (Symmetrify Q)) :
@@ -208,8 +201,7 @@ theorem preprojectiveOpAlgEquiv_preprojectiveMk (x : pathAlgebra k (Symmetrify Q
       (AlgHom.op (preprojectiveMk k Q)) (reverseOpAlgEquiv k (Symmetrify Q) x) := by
   rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_apply,
     preprojectiveReverseOpAlgHom_preprojectiveMk, preprojectiveReversePathAlgHom,
-    AlgHom.comp_apply]
-  rfl
+    AlgHom.comp_apply, AlgEquiv.toAlgHom_apply]
 
 /-- On the opposite of an arbitrary path-algebra representative, the inverse opposite-algebra
 isomorphism reverses the representative before applying the quotient map. -/
@@ -219,10 +211,8 @@ theorem preprojectiveOpAlgEquiv_symm_op_preprojectiveMk (x : pathAlgebra k (Symm
       preprojectiveMk k Q (unop (reverseOpAlgEquiv k (Symmetrify Q) x)) := by
   rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_symm, AlgEquiv.ofAlgHom_apply,
     AlgHom.opComm_apply_apply, unop_op, preprojectiveReverseOpAlgHom_preprojectiveMk,
-    preprojectiveReversePathAlgHom, AlgHom.comp_apply]
-  -- Expose the coerced `AlgEquiv` application so `AlgHom.op` can compute on it.
-  change unop ((AlgHom.op (preprojectiveMk k Q)) (reverseOpAlgEquiv k (Symmetrify Q) x)) = _
-  rw [AlgHom.op_apply_apply, unop_op]
+    preprojectiveReversePathAlgHom, AlgHom.comp_apply, AlgEquiv.toAlgHom_apply,
+    AlgHom.op_apply_apply, unop_op]
 
 /- The generator formulas below specialize the two representative rules above, which are the simp
 normal forms: `simp` derives each of them from those rules, so they carry no `@[simp]` attribute
@@ -234,8 +224,8 @@ theorem preprojectiveOpAlgEquiv_preprojectiveMk_ofPath
     (x : Quiver.TotalPath (Symmetrify Q)) :
     preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q (ofPath x)) =
       op (preprojectiveMk k Q (ofPath x.reverse)) := by
-  rw [preprojectiveOpAlgEquiv_preprojectiveMk, reverseOpAlgEquiv_ofPath]
-  rfl
+  rw [preprojectiveOpAlgEquiv_preprojectiveMk, reverseOpAlgEquiv_ofPath,
+    AlgHom.op_apply_apply, unop_op]
 
 /-- The inverse opposite-algebra isomorphism reverses a path representative as well. -/
 theorem preprojectiveOpAlgEquiv_symm_op_preprojectiveMk_ofPath

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
@@ -38,9 +38,9 @@ open _root_.Quiver MulOpposite PathAlgebra
 
 universe u v w
 
-section Relator
+section Backtrack
 
-variable (k : Type w) {Q : Type u} [CommRing k] [Quiver.{v + 1} Q] [Finite Q]
+variable (k : Type w) {Q : Type u} [CommSemiring k] [Quiver.{v + 1} Q] [Finite Q]
 
 /-- Reversal fixes the head backtrack of an original arrow, up to passage to the opposite path
 algebra. -/
@@ -62,7 +62,12 @@ theorem reverseOpAlgEquiv_tailBacktrackElem {i j : Q} (a : i ⟶ j) :
   rw [map_mul, reverseOpAlgEquiv_ofArrow, reverseOpAlgEquiv_ofArrow,
     Quiver.reverse_reverse, ← op_mul]
 
-variable (Q) [Fintype Q] [∀ i j : Q, Fintype (i ⟶ j)]
+end Backtrack
+
+section Relator
+
+variable (k : Type w) (Q : Type u) [CommRing k] [Quiver.{v + 1} Q] [Fintype Q]
+  [∀ i j : Q, Fintype (i ⟶ j)]
 
 /-- **Path reversal preserves the preprojective relator**, up to passage to the opposite path
 algebra. Both backtracks of every arrow are palindromic, so their signed difference is fixed. -/
@@ -160,6 +165,17 @@ noncomputable def preprojectiveOpAlgEquiv :
             preprojectiveReverseOpAlgHom_opComm_op_preprojectiveMk_ofPath,
             Quiver.TotalPath.reverse_reverse])
 
+/-- On an arbitrary path-algebra representative, the opposite-algebra isomorphism reverses the
+representative before applying the opposite of the quotient map. -/
+@[simp]
+theorem preprojectiveOpAlgEquiv_preprojectiveMk (x : pathAlgebra k (Symmetrify Q)) :
+    preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q x) =
+      (AlgHom.op (preprojectiveMk k Q)) (reverseOpAlgEquiv k (Symmetrify Q) x) := by
+  rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_apply,
+    preprojectiveReverseOpAlgHom_preprojectiveMk, preprojectiveReversePathAlgHom,
+    AlgHom.comp_apply]
+  rfl
+
 /-- On a path class, the opposite-algebra isomorphism takes the opposite of the class of the
 reversed path. -/
 @[simp]
@@ -167,8 +183,8 @@ theorem preprojectiveOpAlgEquiv_preprojectiveMk_ofPath
     (x : Quiver.TotalPath (Symmetrify Q)) :
     preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q (ofPath x)) =
       op (preprojectiveMk k Q (ofPath x.reverse)) := by
-  rw [preprojectiveOpAlgEquiv, AlgEquiv.ofAlgHom_apply,
-    preprojectiveReverseOpAlgHom_preprojectiveMk_ofPath]
+  rw [preprojectiveOpAlgEquiv_preprojectiveMk, reverseOpAlgEquiv_ofPath]
+  rfl
 
 /-- The inverse opposite-algebra isomorphism reverses a path representative as well. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean
@@ -167,7 +167,6 @@ noncomputable def preprojectiveOpAlgEquiv :
 
 /-- On an arbitrary path-algebra representative, the opposite-algebra isomorphism reverses the
 representative before applying the opposite of the quotient map. -/
-@[simp]
 theorem preprojectiveOpAlgEquiv_preprojectiveMk (x : pathAlgebra k (Symmetrify Q)) :
     preprojectiveOpAlgEquiv k Q (preprojectiveMk k Q x) =
       (AlgHom.op (preprojectiveMk k Q)) (reverseOpAlgEquiv k (Symmetrify Q) x) := by


### PR DESCRIPTION
This PR identifies the additive preprojective algebra of a finite quiver with its opposite by reversing paths in the doubled quiver. It first constructs the reusable path-algebra equivalence and proves its formulas on paths, vertices, and arrows; it then proves that both signed backtracks, hence the global preprojective relator, are fixed and descends the involution through the quotient.

The exact target is Layer 4's first bullet in `TauCetiRoadmap/ZigzagPreprojective/README.md`: define `Π_k(Q) = kQ̄ / (ρ)` with its "opposite-algebra comparison." This is the next effective critical-path step because the presentation, quotient universal property, local relations, orientation independence, gauge independence, and grading are already present, while the opposite comparison is needed to pass between the strict left modules here and the right-module-primary derived interfaces used in Layer 7. After this PR, base change is the only item remaining in Layer 4's first bullet; the later finite/infinite type and moment-map comparisons remain separate Layer 4 work.

The path-algebra module works over a commutative semiring for any finite quiver with involutive arrow reversal. The preprojective result works over a commutative ring and handles arbitrary finite quivers, including loops and parallel arrows. Construction homomorphisms stay private; the public API consists of the equivalences and computation lemmas on canonical generators.

The preprojective presentation and sign convention follow Crawley-Boevey, *Quiver algebras, weighted projective lines, and the Deligne--Simpson problem*, Section 1, as cited in the module documentation. The implementation reuses Mathlib's `AlgHom.op`, `AlgHom.opComm`, and `AlgEquiv.ofAlgHom`, together with Tau Ceti's `PathAlgebra.liftAlgHom` and `preprojectiveLift`; no external formalization or Mathlib infrastructure is vendored.

This adds `TauCeti/RepresentationTheory/Quiver/PathAlgebra/Opposite.lean` and `TauCeti/RepresentationTheory/Quiver/Preprojective/Opposite.lean`. The relator invariance and the quotient isomorphism are stated for an arbitrary gauged relator `ρ_ε`, with the preprojective case derived from the constant labelling `1`; that derivation uses the inverse constant-gauge computation rule `preprojectiveAlgebraEquivGaugedOne_symm_gaugedPreprojectiveMk`, which is added next to its existing forward version in `TauCeti/RepresentationTheory/Quiver/Preprojective/Gauge.lean`.

Roadmap: ZigzagPreprojective

<!--tauceti-target:v1 {"focus":"ZigzagPreprojective","id":"preprojective-opposite-algebra-comparison"}-->

🤖 Prepared with Codex

