### PR TITLE
feat: add powers of an isogeny of a root pairing with itself

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.RootSystem.Isogeny.Special
+public import TauCeti.LinearAlgebra.RootSystem.Isogeny.Basic
 
 /-!
 # Powers of an isogeny of a root pairing with itself
@@ -31,20 +31,22 @@ for every `n`, since the restriction to odd exponents belongs to the finite-grou
 not to this identity.
 
 The weight map and the index bijection are monoid homomorphisms out of this monoid; the coweight
-map is an anti-homomorphism, since `comp` reverses on that component, and is therefore left as the
-existing `TauCeti.RootPairingIsogeny.comp_coweightMap`.
+map is only an anti-homomorphism, since `comp` reverses on that component, but its powers still
+follow the weight map's, because the two factors of `f ^ n` are the same map.
 
 The same hypothesis also splits the powers themselves: an even power is a scaling, and an odd power
 is a scaling times `f`, so an odd power permutes the roots exactly as `f` does while multiplying
-its exponents and its weight map by `c ^ m`. The three special isogenies of `B₂`, `G₂` and `F₄` are
-the instance the file exists for, and their power relations close it.
+its exponents and its weight and coweight maps by `c ^ m`. The three special isogenies of `B₂`,
+`G₂` and `F₄` are the instance this exists for; their power relations are in
+`TauCeti/LinearAlgebra/RootSystem/Isogeny/Special.lean`, where they join the square relations they
+come from.
 
 ## Main definitions
 
 * `TauCeti.RootPairingIsogeny.instMonoid`: the composition monoid of isogenies of a root pairing
   with itself.
-* `TauCeti.RootPairingIsogeny.weightMapHom` and `TauCeti.RootPairingIsogeny.indexEquivHom`: the
-  weight map and the index bijection as monoid homomorphisms.
+* `TauCeti.RootPairingIsogeny.weightHom` and `TauCeti.RootPairingIsogeny.indexHom`: the weight map
+  and the index bijection as monoid homomorphisms.
 * `TauCeti.RootPairingIsogeny.smulIdHom`: the scalings, as a monoid homomorphism out of `ℕ+`.
 
 ## Main results
@@ -54,12 +56,11 @@ the instance the file exists for, and their power relations close it.
 * `TauCeti.RootPairingIsogeny.pow_two_mul_eq_smulId` and
   `TauCeti.RootPairingIsogeny.pow_two_mul_add_one_eq_smulId_mul`: such an isogeny has scalings for
   its even powers, and a scaling times itself for its odd ones.
-* `TauCeti.RootPairingIsogeny.pow_two_mul_add_one_indexEquiv`,
-  `TauCeti.RootPairingIsogeny.pow_two_mul_add_one_exponent` and
-  `TauCeti.RootPairingIsogeny.pow_two_mul_add_one_weightMap`: an odd power permutes the roots as
-  the isogeny does and multiplies its exponents and weight map by `c ^ m`.
-* `TauCeti.DynkinType.b2SpecialIsogeny_pow_mul_self`, and its `G₂` and `F₄` counterparts: the
-  powers of the three special isogenies square to the powers of the defining characteristic.
+* `TauCeti.RootPairingIsogeny.indexEquiv_pow_two_mul_add_one`,
+  `TauCeti.RootPairingIsogeny.exponent_pow_two_mul_add_one`,
+  `TauCeti.RootPairingIsogeny.weightMap_pow_two_mul_add_one` and
+  `TauCeti.RootPairingIsogeny.coweightMap_pow_two_mul_add_one`: an odd power permutes the roots as
+  the isogeny does and multiplies its exponents and its two lattice maps by `c ^ m`.
 
 ## References
 
@@ -98,67 +99,77 @@ theorem mul_def (f g : RootPairingIsogeny P P) : f * g = comp f g := (rfl)
 
 theorem one_def : (1 : RootPairingIsogeny P P) = id P := (rfl)
 
-@[simp] theorem mul_weightMap (f g : RootPairingIsogeny P P) :
+@[simp] theorem weightMap_mul (f g : RootPairingIsogeny P P) :
     (f * g).weightMap = f.weightMap ∘ₗ g.weightMap := comp_weightMap f g
 
-@[simp] theorem mul_coweightMap (f g : RootPairingIsogeny P P) :
+@[simp] theorem coweightMap_mul (f g : RootPairingIsogeny P P) :
     (f * g).coweightMap = g.coweightMap ∘ₗ f.coweightMap := comp_coweightMap f g
 
-@[simp] theorem mul_indexEquiv (f g : RootPairingIsogeny P P) :
+@[simp] theorem indexEquiv_mul (f g : RootPairingIsogeny P P) :
     (f * g).indexEquiv = g.indexEquiv.trans f.indexEquiv := comp_indexEquiv f g
 
-@[simp] theorem mul_exponent (f g : RootPairingIsogeny P P) (i : ι) :
+@[simp] theorem exponent_mul (f g : RootPairingIsogeny P P) (i : ι) :
     (f * g).exponent i = g.exponent i * f.exponent (g.indexEquiv i) := comp_exponent f g i
 
-@[simp] theorem one_weightMap : (1 : RootPairingIsogeny P P).weightMap = LinearMap.id :=
+@[simp] theorem weightMap_one : (1 : RootPairingIsogeny P P).weightMap = LinearMap.id :=
   id_weightMap P
 
-@[simp] theorem one_coweightMap : (1 : RootPairingIsogeny P P).coweightMap = LinearMap.id :=
+@[simp] theorem coweightMap_one : (1 : RootPairingIsogeny P P).coweightMap = LinearMap.id :=
   id_coweightMap P
 
-@[simp] theorem one_indexEquiv : (1 : RootPairingIsogeny P P).indexEquiv = Equiv.refl ι :=
+@[simp] theorem indexEquiv_one : (1 : RootPairingIsogeny P P).indexEquiv = Equiv.refl ι :=
   id_indexEquiv P
 
-@[simp] theorem one_exponent (i : ι) : (1 : RootPairingIsogeny P P).exponent i = 1 :=
+@[simp] theorem exponent_one (i : ι) : (1 : RootPairingIsogeny P P).exponent i = 1 :=
   id_exponent P i
 
 /-! ## The two multiplicative components -/
 
 /-- **The weight map of an isogeny, as a monoid homomorphism** into the endomorphism monoid of the
 weight space. -/
-def weightMapHom (P : RootPairing ι R M N) : RootPairingIsogeny P P →* Module.End R M where
+def weightHom (P : RootPairing ι R M N) : RootPairingIsogeny P P →* Module.End R M where
   toFun f := f.weightMap
-  map_one' := one_weightMap
-  map_mul' := mul_weightMap
+  map_one' := weightMap_one
+  map_mul' := weightMap_mul
 
-@[simp] theorem weightMapHom_apply (f : RootPairingIsogeny P P) :
-    weightMapHom P f = f.weightMap := (rfl)
+@[simp] theorem weightHom_apply (f : RootPairingIsogeny P P) :
+    weightHom P f = f.weightMap := (rfl)
 
 /-- The weight map of a power of an isogeny is the corresponding power of its weight map. -/
-@[simp] theorem pow_weightMap (f : RootPairingIsogeny P P) (n : ℕ) :
+@[simp] theorem weightMap_pow (f : RootPairingIsogeny P P) (n : ℕ) :
     (f ^ n).weightMap = f.weightMap ^ n :=
-  map_pow (weightMapHom P) f n
+  map_pow (weightHom P) f n
+
+/-- The coweight map of a power of an isogeny is the corresponding power of its coweight map.
+Composition reverses on the coweight component, so this is not an instance of a monoid
+homomorphism; but the two factors of `f ^ (n + 1)` are the same map, so the reversal is
+immaterial. -/
+@[simp] theorem coweightMap_pow (f : RootPairingIsogeny P P) (n : ℕ) :
+    (f ^ n).coweightMap = f.coweightMap ^ n := by
+  induction n with
+  | zero => simp [Module.End.one_eq_id]
+  | succ n ih => rw [pow_succ, coweightMap_mul, ih, pow_succ', Module.End.mul_eq_comp]
 
 /-- **The index bijection of an isogeny, as a monoid homomorphism** into the permutation group of
 the index set. -/
-def indexEquivHom (P : RootPairing ι R M N) : RootPairingIsogeny P P →* Equiv.Perm ι where
+def indexHom (P : RootPairing ι R M N) : RootPairingIsogeny P P →* Equiv.Perm ι where
   toFun f := f.indexEquiv
-  map_one' := one_indexEquiv
-  map_mul' := mul_indexEquiv
+  map_one' := indexEquiv_one
+  map_mul' := indexEquiv_mul
 
-@[simp] theorem indexEquivHom_apply (f : RootPairingIsogeny P P) :
-    indexEquivHom P f = f.indexEquiv := (rfl)
+@[simp] theorem indexHom_apply (f : RootPairingIsogeny P P) :
+    indexHom P f = f.indexEquiv := (rfl)
 
 /-- The index bijection of a power of an isogeny is the corresponding power of its index
 bijection. -/
-@[simp] theorem pow_indexEquiv (f : RootPairingIsogeny P P) (n : ℕ) :
+@[simp] theorem indexEquiv_pow (f : RootPairingIsogeny P P) (n : ℕ) :
     (f ^ n).indexEquiv = f.indexEquiv ^ n :=
-  map_pow (indexEquivHom P) f n
+  map_pow (indexHom P) f n
 
 /-- The exponent of a power of an isogeny, in terms of the exponents of the lower power. -/
-theorem pow_succ_exponent (f : RootPairingIsogeny P P) (n : ℕ) (i : ι) :
+theorem exponent_pow_succ (f : RootPairingIsogeny P P) (n : ℕ) (i : ι) :
     (f ^ (n + 1)).exponent i = f.exponent i * (f ^ n).exponent (f.indexEquiv i) := by
-  rw [pow_succ, mul_exponent]
+  rw [pow_succ, exponent_mul]
 
 /-! ## The scalings -/
 
@@ -209,9 +220,9 @@ theorem pow_two_mul_add_one_eq_smulId_mul (h : f * f = smulId P c) (m : ℕ) :
 
 /-- **An odd power of an isogeny whose square is a scaling permutes the roots exactly as the
 isogeny does**, since a scaling fixes every index. -/
-theorem pow_two_mul_add_one_indexEquiv (h : f * f = smulId P c) (m : ℕ) :
+theorem indexEquiv_pow_two_mul_add_one (h : f * f = smulId P c) (m : ℕ) :
     (f ^ (2 * m + 1)).indexEquiv = f.indexEquiv := by
-  rw [pow_two_mul_add_one_eq_smulId_mul P h, mul_indexEquiv, smulId_indexEquiv, Equiv.trans_refl]
+  rw [pow_two_mul_add_one_eq_smulId_mul P h, indexEquiv_mul, smulId_indexEquiv, Equiv.trans_refl]
 
 /-- **The rescaling exponents of an odd power** are those of the isogeny times `c ^ m`.
 
@@ -219,51 +230,30 @@ Read at a special isogeny in characteristic `p`, so at `c = p`: the `exponent` f
 the source of the character map, and is `1` at a short simple root and `p` at a long one
 (`TauCeti.DynkinType.b2SpecialIsogeny_exponent_typeBSimpleIndex_eq_one_iff`), so the odd power has
 exponent `p ^ m` at a short simple root and `p ^ (m + 1)` at a long one. -/
-theorem pow_two_mul_add_one_exponent (h : f * f = smulId P c) (m : ℕ) (i : ι) :
+theorem exponent_pow_two_mul_add_one (h : f * f = smulId P c) (m : ℕ) (i : ι) :
     (f ^ (2 * m + 1)).exponent i = f.exponent i * (c : ℤ) ^ m := by
-  rw [pow_two_mul_add_one_eq_smulId_mul P h, mul_exponent, smulId_exponent]
+  rw [pow_two_mul_add_one_eq_smulId_mul P h, exponent_mul, smulId_exponent]
   push_cast [PNat.pow_coe]
   ring
 
 /-- **The weight map of an odd power** is `c ^ m` times that of the isogeny. -/
-theorem pow_two_mul_add_one_weightMap (h : f * f = smulId P c) (m : ℕ) :
+theorem weightMap_pow_two_mul_add_one (h : f * f = smulId P c) (m : ℕ) :
     (f ^ (2 * m + 1)).weightMap = ((c : ℕ) ^ m) • f.weightMap := by
-  rw [pow_two_mul_add_one_eq_smulId_mul P h, mul_weightMap, smulId_weightMap]
+  rw [pow_two_mul_add_one_eq_smulId_mul P h, weightMap_mul, smulId_weightMap]
   ext x
   simp [PNat.pow_coe]
+
+/-- **The coweight map of an odd power** is `c ^ m` times that of the isogeny. Composition reverses
+on this component, but a scaling is central, so the formula is the same as for the weight map. -/
+theorem coweightMap_pow_two_mul_add_one (h : f * f = smulId P c) (m : ℕ) :
+    (f ^ (2 * m + 1)).coweightMap = ((c : ℕ) ^ m) • f.coweightMap := by
+  rw [pow_two_mul_add_one_eq_smulId_mul P h, coweightMap_mul, smulId_coweightMap]
+  ext x
+  simp only [LinearMap.comp_apply, LinearMap.smul_apply, LinearMap.id_apply, map_nsmul,
+    PNat.pow_coe]
 
 end Scaling
 
 end RootPairingIsogeny
-
-/-! ## The three special isogenies -/
-
-namespace DynkinType
-
-open RootPairingIsogeny
-
-/-- **The powers of the special isogeny of `B₂` square to the powers of two.** At `n = 2 * m + 1`
-this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
-fixed points are the Suzuki group `²B₂(2 ^ (2 * m + 1))`. -/
-theorem b2SpecialIsogeny_pow_mul_self (n : ℕ) :
-    b2SpecialIsogeny ^ n * b2SpecialIsogeny ^ n =
-      smulId (typeBSimplyConnectedRootDatum 2) (2 ^ n) :=
-  pow_mul_self_eq_smulId _ b2SpecialIsogeny_comp_self n
-
-/-- **The powers of the special isogeny of `G₂` square to the powers of three.** At `n = 2 * m + 1`
-this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
-fixed points are the Ree group `²G₂(3 ^ (2 * m + 1))`. -/
-theorem g2SpecialIsogeny_pow_mul_self (n : ℕ) :
-    g2SpecialIsogeny ^ n * g2SpecialIsogeny ^ n = smulId g2SimplyConnectedRootDatum (3 ^ n) :=
-  pow_mul_self_eq_smulId _ g2SpecialIsogeny_comp_self n
-
-/-- **The powers of the special isogeny of `F₄` square to the powers of two.** At `n = 2 * m + 1`
-this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
-fixed points are the Ree group `²F₄(2 ^ (2 * m + 1))`; at `n = 1` it belongs to the Tits group. -/
-theorem f4SpecialIsogeny_pow_mul_self (n : ℕ) :
-    f4SpecialIsogeny ^ n * f4SpecialIsogeny ^ n = smulId f4SimplyConnectedRootDatum (2 ^ n) :=
-  pow_mul_self_eq_smulId _ f4SpecialIsogeny_comp_self n
-
-end DynkinType
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
@@ -30,9 +30,11 @@ of `steinberg (m) ^ 2 = Frob_(p ^ (2 * m + 1))` for `steinberg (m) = τ ^ (2 * m
 for every `n`, since the restriction to odd exponents belongs to the finite-group construction and
 not to this identity.
 
-The weight map and the index bijection are monoid homomorphisms out of this monoid; the coweight
-map is only an anti-homomorphism, since `comp` reverses on that component, but its powers still
-follow the weight map's, because the two factors of `f ^ n` are the same map.
+All three of the weight map, the coweight map and the index bijection are monoid homomorphisms out
+of this monoid, the coweight map into the opposite endomorphism monoid because `comp` reverses on
+that component. This is the same shape as `RootPairing.Hom.weightHom`,
+`RootPairing.Hom.coweightHom` and `RootPairing.Hom.indexHom` for the endomorphism monoid of a root
+pairing, and the powers of all three components are `map_pow`.
 
 The same hypothesis also splits the powers themselves: an even power is a scaling, and an odd power
 is a scaling times `f`, so an odd power permutes the roots exactly as `f` does while multiplying
@@ -45,8 +47,9 @@ come from.
 
 * `TauCeti.RootPairingIsogeny.instMonoid`: the composition monoid of isogenies of a root pairing
   with itself.
-* `TauCeti.RootPairingIsogeny.weightHom` and `TauCeti.RootPairingIsogeny.indexHom`: the weight map
-  and the index bijection as monoid homomorphisms.
+* `TauCeti.RootPairingIsogeny.weightHom`, `TauCeti.RootPairingIsogeny.coweightHom` and
+  `TauCeti.RootPairingIsogeny.indexHom`: the weight map, the coweight map and the index bijection
+  as monoid homomorphisms, the coweight map into the opposite endomorphism monoid.
 * `TauCeti.RootPairingIsogeny.smulIdHom`: the scalings, as a monoid homomorphism out of `ℕ+`.
 
 ## Main results
@@ -123,7 +126,7 @@ theorem one_def : (1 : RootPairingIsogeny P P) = id P := (rfl)
 @[simp] theorem exponent_one (i : ι) : (1 : RootPairingIsogeny P P).exponent i = 1 :=
   id_exponent P i
 
-/-! ## The two multiplicative components -/
+/-! ## The multiplicative components -/
 
 /-- **The weight map of an isogeny, as a monoid homomorphism** into the endomorphism monoid of the
 weight space. -/
@@ -140,15 +143,25 @@ def weightHom (P : RootPairing ι R M N) : RootPairingIsogeny P P →* Module.En
     (f ^ n).weightMap = f.weightMap ^ n :=
   map_pow (weightHom P) f n
 
-/-- The coweight map of a power of an isogeny is the corresponding power of its coweight map.
-Composition reverses on the coweight component, so this is not an instance of a monoid
-homomorphism; but the two factors of `f ^ (n + 1)` are the same map, so the reversal is
-immaterial. -/
+/-- **The coweight map of an isogeny, as a monoid homomorphism** into the opposite of the
+endomorphism monoid of the coweight space. Composition reverses on this component, exactly as for
+`RootPairing.Hom.coweightHom`. -/
+def coweightHom (P : RootPairing ι R M N) : RootPairingIsogeny P P →* (Module.End R N)ᵐᵒᵖ where
+  toFun f := MulOpposite.op f.coweightMap
+  map_one' := by simp only [MulOpposite.op_eq_one_iff, coweightMap_one, Module.End.one_eq_id]
+  map_mul' f g := by
+    simp only [← MulOpposite.op_mul, coweightMap_mul, Module.End.mul_eq_comp]
+
+@[simp] theorem coweightHom_apply (f : RootPairingIsogeny P P) :
+    coweightHom P f = MulOpposite.op f.coweightMap := (rfl)
+
+/-- The coweight map of a power of an isogeny is the corresponding power of its coweight map. The
+reversal in `TauCeti.RootPairingIsogeny.coweightHom` is immaterial here, since the two factors of
+`f ^ (n + 1)` are the same map. -/
 @[simp] theorem coweightMap_pow (f : RootPairingIsogeny P P) (n : ℕ) :
-    (f ^ n).coweightMap = f.coweightMap ^ n := by
-  induction n with
-  | zero => simp [Module.End.one_eq_id]
-  | succ n ih => rw [pow_succ, coweightMap_mul, ih, pow_succ', Module.End.mul_eq_comp]
+    (f ^ n).coweightMap = f.coweightMap ^ n :=
+  MulOpposite.op_injective <| by
+    rw [MulOpposite.op_pow, ← coweightHom_apply, ← coweightHom_apply, map_pow]
 
 /-- **The index bijection of an isogeny, as a monoid homomorphism** into the permutation group of
 the index set. -/

--- a/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean
@@ -1,0 +1,269 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.Isogeny.Special
+
+/-!
+# Powers of an isogeny of a root pairing with itself
+
+An isogeny of a root pairing with itself can be composed with itself, and the Suzuki and Ree
+groups are cut out by the *odd powers* of a special isogeny rather than by the isogeny itself.
+This file gives the isogenies of a fixed root pairing with itself their monoid structure under
+composition, so that `f ^ n` is available with the whole `Monoid` API, and computes the square of
+a power of a special isogeny.
+
+The monoid is the one composition already determines: `TauCeti.RootPairingIsogeny.comp` is
+associative with `TauCeti.RootPairingIsogeny.id` as a two-sided unit, and nothing new is proved to
+put it together. What the monoid buys is the identity
+
+```text
+f ^ n * f ^ n = smulId P (c ^ n)      whenever      f * f = smulId P c,
+```
+
+`TauCeti.RootPairingIsogeny.pow_mul_self_eq_smulId`, which is pure monoid algebra: `f ^ n * f ^ n`
+is `(f * f) ^ n`. Read at `c` the defining characteristic and `n` odd, this is the root-datum form
+of `steinberg (m) ^ 2 = Frob_(p ^ (2 * m + 1))` for `steinberg (m) = τ ^ (2 * m + 1)`. It is stated
+for every `n`, since the restriction to odd exponents belongs to the finite-group construction and
+not to this identity.
+
+The weight map and the index bijection are monoid homomorphisms out of this monoid; the coweight
+map is an anti-homomorphism, since `comp` reverses on that component, and is therefore left as the
+existing `TauCeti.RootPairingIsogeny.comp_coweightMap`.
+
+The same hypothesis also splits the powers themselves: an even power is a scaling, and an odd power
+is a scaling times `f`, so an odd power permutes the roots exactly as `f` does while multiplying
+its exponents and its weight map by `c ^ m`. The three special isogenies of `B₂`, `G₂` and `F₄` are
+the instance the file exists for, and their power relations close it.
+
+## Main definitions
+
+* `TauCeti.RootPairingIsogeny.instMonoid`: the composition monoid of isogenies of a root pairing
+  with itself.
+* `TauCeti.RootPairingIsogeny.weightMapHom` and `TauCeti.RootPairingIsogeny.indexEquivHom`: the
+  weight map and the index bijection as monoid homomorphisms.
+* `TauCeti.RootPairingIsogeny.smulIdHom`: the scalings, as a monoid homomorphism out of `ℕ+`.
+
+## Main results
+
+* `TauCeti.RootPairingIsogeny.pow_mul_self_eq_smulId`: a power of an isogeny whose square is a
+  scaling squares to the corresponding power of that scaling.
+* `TauCeti.RootPairingIsogeny.pow_two_mul_eq_smulId` and
+  `TauCeti.RootPairingIsogeny.pow_two_mul_add_one_eq_smulId_mul`: such an isogeny has scalings for
+  its even powers, and a scaling times itself for its odd ones.
+* `TauCeti.RootPairingIsogeny.pow_two_mul_add_one_indexEquiv`,
+  `TauCeti.RootPairingIsogeny.pow_two_mul_add_one_exponent` and
+  `TauCeti.RootPairingIsogeny.pow_two_mul_add_one_weightMap`: an odd power permutes the roots as
+  the isogeny does and multiplies its exponents and weight map by `c ^ m`.
+* `TauCeti.DynkinType.b2SpecialIsogeny_pow_mul_self`, and its `G₂` and `F₄` counterparts: the
+  powers of the three special isogenies square to the powers of the defining characteristic.
+
+## References
+
+* Schémas en groupes (SGA 3), Exposé XXI, 6.8.
+* R. Steinberg, *Endomorphisms of linear algebraic groups*, Memoirs AMS 80 (1968), §11.
+
+The odd powers of the special isogeny are what milestone L2 of
+`TauCetiRoadmap/CFSGStatement/README.md` asks for, "`steinberg(m) = τ_X ^ (2m + 1)`,
+`steinberg(m) ^ 2 = Frob_(p ^ (2m + 1))`", once the special isogeny itself has been lifted from
+root data to the pinned group schemes of Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {ι R M N : Type*} [CommRing R] [AddCommGroup M] [Module R M]
+  [AddCommGroup N] [Module R N] {P : RootPairing ι R M N}
+
+namespace RootPairingIsogeny
+
+/-! ## The composition monoid -/
+
+/-- **The isogenies of a root pairing with itself form a monoid** under composition, with the
+identity isogeny as unit. Multiplication is composition in the same order as
+`TauCeti.RootPairingIsogeny.comp`, so `f * g` applies `g` first. -/
+instance : Monoid (RootPairingIsogeny P P) where
+  one := id P
+  mul f g := comp f g
+  mul_assoc := comp_assoc
+  one_mul := comp_id
+  mul_one := id_comp
+
+theorem mul_def (f g : RootPairingIsogeny P P) : f * g = comp f g := (rfl)
+
+theorem one_def : (1 : RootPairingIsogeny P P) = id P := (rfl)
+
+@[simp] theorem mul_weightMap (f g : RootPairingIsogeny P P) :
+    (f * g).weightMap = f.weightMap ∘ₗ g.weightMap := comp_weightMap f g
+
+@[simp] theorem mul_coweightMap (f g : RootPairingIsogeny P P) :
+    (f * g).coweightMap = g.coweightMap ∘ₗ f.coweightMap := comp_coweightMap f g
+
+@[simp] theorem mul_indexEquiv (f g : RootPairingIsogeny P P) :
+    (f * g).indexEquiv = g.indexEquiv.trans f.indexEquiv := comp_indexEquiv f g
+
+@[simp] theorem mul_exponent (f g : RootPairingIsogeny P P) (i : ι) :
+    (f * g).exponent i = g.exponent i * f.exponent (g.indexEquiv i) := comp_exponent f g i
+
+@[simp] theorem one_weightMap : (1 : RootPairingIsogeny P P).weightMap = LinearMap.id :=
+  id_weightMap P
+
+@[simp] theorem one_coweightMap : (1 : RootPairingIsogeny P P).coweightMap = LinearMap.id :=
+  id_coweightMap P
+
+@[simp] theorem one_indexEquiv : (1 : RootPairingIsogeny P P).indexEquiv = Equiv.refl ι :=
+  id_indexEquiv P
+
+@[simp] theorem one_exponent (i : ι) : (1 : RootPairingIsogeny P P).exponent i = 1 :=
+  id_exponent P i
+
+/-! ## The two multiplicative components -/
+
+/-- **The weight map of an isogeny, as a monoid homomorphism** into the endomorphism monoid of the
+weight space. -/
+def weightMapHom (P : RootPairing ι R M N) : RootPairingIsogeny P P →* Module.End R M where
+  toFun f := f.weightMap
+  map_one' := one_weightMap
+  map_mul' := mul_weightMap
+
+@[simp] theorem weightMapHom_apply (f : RootPairingIsogeny P P) :
+    weightMapHom P f = f.weightMap := (rfl)
+
+/-- The weight map of a power of an isogeny is the corresponding power of its weight map. -/
+@[simp] theorem pow_weightMap (f : RootPairingIsogeny P P) (n : ℕ) :
+    (f ^ n).weightMap = f.weightMap ^ n :=
+  map_pow (weightMapHom P) f n
+
+/-- **The index bijection of an isogeny, as a monoid homomorphism** into the permutation group of
+the index set. -/
+def indexEquivHom (P : RootPairing ι R M N) : RootPairingIsogeny P P →* Equiv.Perm ι where
+  toFun f := f.indexEquiv
+  map_one' := one_indexEquiv
+  map_mul' := mul_indexEquiv
+
+@[simp] theorem indexEquivHom_apply (f : RootPairingIsogeny P P) :
+    indexEquivHom P f = f.indexEquiv := (rfl)
+
+/-- The index bijection of a power of an isogeny is the corresponding power of its index
+bijection. -/
+@[simp] theorem pow_indexEquiv (f : RootPairingIsogeny P P) (n : ℕ) :
+    (f ^ n).indexEquiv = f.indexEquiv ^ n :=
+  map_pow (indexEquivHom P) f n
+
+/-- The exponent of a power of an isogeny, in terms of the exponents of the lower power. -/
+theorem pow_succ_exponent (f : RootPairingIsogeny P P) (n : ℕ) (i : ι) :
+    (f ^ (n + 1)).exponent i = f.exponent i * (f ^ n).exponent (f.indexEquiv i) := by
+  rw [pow_succ, mul_exponent]
+
+/-! ## The scalings -/
+
+section Scaling
+
+variable [Module.Free ℤ M] [Module.Finite ℤ M] [Module.Free ℤ N] [Module.Finite ℤ N]
+  (P : RootPairing ι ℤ M N)
+
+@[simp] theorem smulId_one : smulId P 1 = 1 := by
+  refine RootPairingIsogeny.ext ?_ ?_ ?_ ?_ <;> ext <;> simp
+
+@[simp] theorem smulId_mul_smulId (c d : ℕ+) : smulId P c * smulId P d = smulId P (c * d) := by
+  refine RootPairingIsogeny.ext ?_ ?_ ?_ ?_ <;> ext <;> simp [← mul_smul, mul_comm]
+
+/-- **The scalings of a root pairing, as a monoid homomorphism** out of the positive integers. At a
+prime this picks out the root-datum shadow of the Frobenius isogeny. -/
+def smulIdHom : ℕ+ →* RootPairingIsogeny P P where
+  toFun c := smulId P c
+  map_one' := smulId_one P
+  map_mul' c d := (smulId_mul_smulId P c d).symm
+
+@[simp] theorem smulIdHom_apply (c : ℕ+) : smulIdHom P c = smulId P c := (rfl)
+
+/-- A power of a scaling is the scaling by the corresponding power. -/
+@[simp] theorem smulId_pow (c : ℕ+) (n : ℕ) : smulId P c ^ n = smulId P (c ^ n) :=
+  (map_pow (smulIdHom P) c n).symm
+
+variable {f : RootPairingIsogeny P P} {c : ℕ+}
+
+/-- **An even power of an isogeny whose square is a scaling is itself a scaling.** -/
+theorem pow_two_mul_eq_smulId (h : f * f = smulId P c) (m : ℕ) :
+    f ^ (2 * m) = smulId P (c ^ m) := by
+  rw [pow_mul, pow_two, h, smulId_pow]
+
+/-- **A power of an isogeny whose square is a scaling squares to the corresponding power of that
+scaling.** For `c` the defining characteristic and `n = 2 * m + 1`, this is the root-datum form of
+the relation `steinberg (m) ^ 2 = Frob_(p ^ (2 * m + 1))` satisfied by the odd powers of a special
+isogeny; the identity itself holds at every exponent. -/
+theorem pow_mul_self_eq_smulId (h : f * f = smulId P c) (n : ℕ) :
+    f ^ n * f ^ n = smulId P (c ^ n) := by
+  rw [← pow_add, ← two_mul, pow_two_mul_eq_smulId P h]
+
+/-- **An odd power of an isogeny whose square is a scaling is a scaling times the isogeny.** This
+is what makes the odd powers genuinely new maps rather than scalings: the factor `f` survives. -/
+theorem pow_two_mul_add_one_eq_smulId_mul (h : f * f = smulId P c) (m : ℕ) :
+    f ^ (2 * m + 1) = smulId P (c ^ m) * f := by
+  rw [pow_succ, pow_two_mul_eq_smulId P h]
+
+/-- **An odd power of an isogeny whose square is a scaling permutes the roots exactly as the
+isogeny does**, since a scaling fixes every index. -/
+theorem pow_two_mul_add_one_indexEquiv (h : f * f = smulId P c) (m : ℕ) :
+    (f ^ (2 * m + 1)).indexEquiv = f.indexEquiv := by
+  rw [pow_two_mul_add_one_eq_smulId_mul P h, mul_indexEquiv, smulId_indexEquiv, Equiv.trans_refl]
+
+/-- **The rescaling exponents of an odd power** are those of the isogeny times `c ^ m`.
+
+Read at a special isogeny in characteristic `p`, so at `c = p`: the `exponent` field is indexed by
+the source of the character map, and is `1` at a short simple root and `p` at a long one
+(`TauCeti.DynkinType.b2SpecialIsogeny_exponent_typeBSimpleIndex_eq_one_iff`), so the odd power has
+exponent `p ^ m` at a short simple root and `p ^ (m + 1)` at a long one. -/
+theorem pow_two_mul_add_one_exponent (h : f * f = smulId P c) (m : ℕ) (i : ι) :
+    (f ^ (2 * m + 1)).exponent i = f.exponent i * (c : ℤ) ^ m := by
+  rw [pow_two_mul_add_one_eq_smulId_mul P h, mul_exponent, smulId_exponent]
+  push_cast [PNat.pow_coe]
+  ring
+
+/-- **The weight map of an odd power** is `c ^ m` times that of the isogeny. -/
+theorem pow_two_mul_add_one_weightMap (h : f * f = smulId P c) (m : ℕ) :
+    (f ^ (2 * m + 1)).weightMap = ((c : ℕ) ^ m) • f.weightMap := by
+  rw [pow_two_mul_add_one_eq_smulId_mul P h, mul_weightMap, smulId_weightMap]
+  ext x
+  simp [PNat.pow_coe]
+
+end Scaling
+
+end RootPairingIsogeny
+
+/-! ## The three special isogenies -/
+
+namespace DynkinType
+
+open RootPairingIsogeny
+
+/-- **The powers of the special isogeny of `B₂` square to the powers of two.** At `n = 2 * m + 1`
+this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
+fixed points are the Suzuki group `²B₂(2 ^ (2 * m + 1))`. -/
+theorem b2SpecialIsogeny_pow_mul_self (n : ℕ) :
+    b2SpecialIsogeny ^ n * b2SpecialIsogeny ^ n =
+      smulId (typeBSimplyConnectedRootDatum 2) (2 ^ n) :=
+  pow_mul_self_eq_smulId _ b2SpecialIsogeny_comp_self n
+
+/-- **The powers of the special isogeny of `G₂` square to the powers of three.** At `n = 2 * m + 1`
+this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
+fixed points are the Ree group `²G₂(3 ^ (2 * m + 1))`. -/
+theorem g2SpecialIsogeny_pow_mul_self (n : ℕ) :
+    g2SpecialIsogeny ^ n * g2SpecialIsogeny ^ n = smulId g2SimplyConnectedRootDatum (3 ^ n) :=
+  pow_mul_self_eq_smulId _ g2SpecialIsogeny_comp_self n
+
+/-- **The powers of the special isogeny of `F₄` square to the powers of two.** At `n = 2 * m + 1`
+this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
+fixed points are the Ree group `²F₄(2 ^ (2 * m + 1))`; at `n = 1` it belongs to the Tits group. -/
+theorem f4SpecialIsogeny_pow_mul_self (n : ℕ) :
+    f4SpecialIsogeny ^ n * f4SpecialIsogeny ^ n = smulId f4SimplyConnectedRootDatum (2 ^ n) :=
+  pow_mul_self_eq_smulId _ f4SpecialIsogeny_comp_self n
+
+end DynkinType
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Isogeny/Special.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isogeny/Special.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.LinearAlgebra.RootSystem.Isogeny.Basic
+public import TauCeti.LinearAlgebra.RootSystem.Isogeny.Power
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.B.SpecialMap
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.F4.SpecialMap
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.G2.SpecialMap
@@ -78,6 +78,10 @@ in each case, and the relations that are statements about it.
   `TauCeti.DynkinType.g2SpecialIsogeny_comp_self` and
   `TauCeti.DynkinType.f4SpecialIsogeny_comp_self`: composing the special isogeny with itself gives
   scaling by the characteristic, which is the root-datum form of `τ ^ 2 = Frob_p`.
+* `TauCeti.DynkinType.b2SpecialIsogeny_pow_mul_self`,
+  `TauCeti.DynkinType.g2SpecialIsogeny_pow_mul_self` and
+  `TauCeti.DynkinType.f4SpecialIsogeny_pow_mul_self`: the same relation at every power, which at an
+  odd exponent is the square relation the Suzuki and Ree groups are cut out by.
 * `TauCeti.DynkinType.b2SpecialIsogeny_weightMap_root_typeBSimpleIndex`,
   `TauCeti.DynkinType.g2SpecialIsogeny_weightMap_root_castLE` and
   `TauCeti.DynkinType.f4SpecialIsogeny_weightMap_root_castAdd`: the defining relation on the simple
@@ -169,6 +173,14 @@ theorem b2SpecialIsogeny_comp_self :
     rw [htwo]
     simpa only [b2SpecialIsogeny_exponent, b2SpecialIsogeny_indexEquiv_apply] using
       b2SpecialIsogenyExponent_mul_exponent i
+
+/-- **The powers of the special isogeny of `B₂` square to the powers of two.** At `n = 2 * m + 1`
+this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
+fixed points are the Suzuki group `²B₂(2 ^ (2 * m + 1))`. -/
+theorem b2SpecialIsogeny_pow_mul_self (n : ℕ) :
+    b2SpecialIsogeny ^ n * b2SpecialIsogeny ^ n =
+      RootPairingIsogeny.smulId (typeBSimplyConnectedRootDatum 2) (2 ^ n) :=
+  RootPairingIsogeny.pow_mul_self_eq_smulId _ b2SpecialIsogeny_comp_self n
 
 /-- **The defining relation of the special isogeny of `B₂` on the simple roots.** The character
 map carries the simple root at the length-exchanged node to the simple root at `i`, rescaled by
@@ -277,6 +289,14 @@ theorem g2SpecialIsogeny_comp_self :
     simpa only [g2SpecialIsogeny_exponent, g2SpecialIsogeny_indexEquiv_apply] using
       g2Length_mul_g2Length_g2SpecialIsogenyIndex i
 
+/-- **The powers of the special isogeny of `G₂` square to the powers of three.** At `n = 2 * m + 1`
+this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
+fixed points are the Ree group `²G₂(3 ^ (2 * m + 1))`. -/
+theorem g2SpecialIsogeny_pow_mul_self (n : ℕ) :
+    g2SpecialIsogeny ^ n * g2SpecialIsogeny ^ n =
+      RootPairingIsogeny.smulId g2SimplyConnectedRootDatum (3 ^ n) :=
+  RootPairingIsogeny.pow_mul_self_eq_smulId _ g2SpecialIsogeny_comp_self n
+
 /-- **The defining relation of the special isogeny of `G₂` on the simple roots.** The character
 map carries the simple root at the length-exchanged node to the simple root at `i`, rescaled by
 the squared length of that other node. This is the root-datum form of
@@ -353,6 +373,14 @@ theorem f4SpecialIsogeny_comp_self :
     rw [htwo]
     simpa only [f4SpecialIsogeny_exponent, f4SpecialIsogeny_indexEquiv_apply] using
       f4Length_mul_f4Length_specialIsogenyIndex i
+
+/-- **The powers of the special isogeny of `F₄` square to the powers of two.** At `n = 2 * m + 1`
+this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
+fixed points are the Ree group `²F₄(2 ^ (2 * m + 1))`; at `n = 1` it belongs to the Tits group. -/
+theorem f4SpecialIsogeny_pow_mul_self (n : ℕ) :
+    f4SpecialIsogeny ^ n * f4SpecialIsogeny ^ n =
+      RootPairingIsogeny.smulId f4SimplyConnectedRootDatum (2 ^ n) :=
+  RootPairingIsogeny.pow_mul_self_eq_smulId _ f4SpecialIsogeny_comp_self n
 
 /-- **The defining relation of the special isogeny of `F₄` on the simple roots.** The character
 map carries the simple root at the length-exchanged node to the simple root at `i`, rescaled by

--- a/TauCeti/LinearAlgebra/RootSystem/Isogeny/Special.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Isogeny/Special.lean
@@ -376,7 +376,8 @@ theorem f4SpecialIsogeny_comp_self :
 
 /-- **The powers of the special isogeny of `F₄` square to the powers of two.** At `n = 2 * m + 1`
 this is the root-datum form of the square relation satisfied by the Steinberg endomorphism whose
-fixed points are the Ree group `²F₄(2 ^ (2 * m + 1))`; at `n = 1` it belongs to the Tits group. -/
+fixed points are the Ree group `²F₄(2 ^ (2 * m + 1))`; at `n = 1` it underlies `²F₄(2)`, whose
+derived subgroup is the Tits group. -/
 theorem f4SpecialIsogeny_pow_mul_self (n : ℕ) :
     f4SpecialIsogeny ^ n * f4SpecialIsogeny ^ n =
       RootPairingIsogeny.smulId f4SimplyConnectedRootDatum (2 ^ n) :=


### PR DESCRIPTION
This PR gives the isogenies of a root pairing with itself their monoid structure under composition, so that `f ^ n` is available with the whole `Monoid` API, and computes the powers of an isogeny whose square is a scaling: `f ^ (2 * m)` is `smulId P (c ^ m)`, `f ^ (2 * m + 1)` is `smulId P (c ^ m) * f`, and hence `f ^ n * f ^ n = smulId P (c ^ n)` at every exponent. An odd power therefore permutes the roots exactly as the isogeny does while multiplying its rescaling exponents and its weight map by `c ^ m`. The three special isogenies of `B₂`, `G₂` and `F₄` are the instance this exists for, and their power relations close the file.

The exact roadmap target is Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`, "Special isogenies in characteristics two and three ... the exceptional isogeny `τ` with `τ² = Frob_p`": `TauCeti.RootPairingIsogeny.smulId P p` is the root-datum shadow of `Frob_p`, `TauCeti.DynkinType.b2SpecialIsogeny_comp_self` and its `G₂` and `F₄` counterparts are `τ² = Frob_p` on root data, and this PR is what those relations say about the powers of `τ`.

The dependency edge is that milestone L2 of `TauCetiRoadmap/CFSGStatement/README.md` owns "taking the odd power": it sets `steinberg(m) = τ_X ^ (2m + 1)` and requires `steinberg(m) ^ 2 = Frob_(p ^ (2m + 1))`. `TauCeti.DynkinType.b2SpecialIsogeny_pow_mul_self`, `g2SpecialIsogeny_pow_mul_self` and `f4SpecialIsogeny_pow_mul_self` are that statement on root data, at `n = 2m + 1`; `TauCeti.RootPairingIsogeny.pow_two_mul_add_one_exponent` and `pow_two_mul_add_one_indexEquiv` are the accompanying root-subgroup data L2 states its conventions against, and they are what the group-level `ValidLieTypeIndex.steinberg` will be checked against once the special isogeny has been lifted from root data to the pinned group schemes of Layer 9. The milestone this serves is L2, "Suzuki--Ree Steinberg maps"; after this PR L2 still needs that lift, which needs the pinned Chevalley--Demazure carriers Layer 9 is still building, and then the selection of `τ_X` for a given `SuzukiReeIndex`.

This was the most effective current step because everything below it had landed and nothing joined it up: `TauCeti.RootPairingIsogeny` with `comp`, `id`, `comp_assoc`, `comp_id`, `id_comp` and `smulId` is on `main` in `TauCeti/LinearAlgebra/RootSystem/Isogeny/Basic.lean`, the three special isogenies and their square relations are on `main` in `TauCeti/LinearAlgebra/RootSystem/Isogeny/Special.lean`, and no iterate of an isogeny was expressible at all, so the odd powers the Suzuki and Ree groups are cut out by could not be written down. The square relation is stated for every `n` rather than only for odd ones: the restriction to odd exponents belongs to the finite-group construction, not to this identity.

The monoid is the one composition already determines; nothing new is proved to assemble it. The weight map and the index bijection become monoid homomorphisms, so their powers follow from `map_pow`; the coweight map is an anti-homomorphism, since `comp` reverses on that component, and is left as the existing `comp_coweightMap`.

Add `TauCeti/LinearAlgebra/RootSystem/Isogeny/Power.lean` (269 lines). No Mathlib infrastructure or external formalization is vendored; the construction reuses Mathlib's `Monoid`, `MonoidHom`, `Module.End` and `Equiv.Perm` API together with the in-repository isogeny and special-isogeny developments cited above. The notion of isogeny and the exceptional isogenies follow Schémas en groupes (SGA 3), Exposé XXI, 6.8, and R. Steinberg, *Endomorphisms of linear algebraic groups*, Memoirs AMS 80 (1968), §11, as recorded in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"odd-powers-of-the-special-isogeny"}-->

🤖 Prepared with Claude Code
