### PR TITLE
feat: the dimension of the morphism space of two irreducible Lie modules

### DIFF
--- a/TauCeti/Algebra/Lie/Basic.lean
+++ b/TauCeti/Algebra/Lie/Basic.lean
@@ -17,6 +17,8 @@ This file supplies general constructions for Lie modules that are missing from M
 ## Main definitions
 
 * `TauCeti.LieModuleEquiv.ofBijective`: a bijective morphism of Lie modules is an equivalence.
+* `TauCeti.LieModuleEquiv.congrRight`: postcomposition with an equivalence of Lie modules, as a
+  linear equivalence of morphism spaces.
 * `TauCeti.lieAnnihilator`: the Lie subalgebra of elements annihilating a vector in a Lie
   module.
 
@@ -30,7 +32,7 @@ This file supplies general constructions for Lie modules that are missing from M
 
 namespace TauCeti
 
-universe u v w w₁
+universe u v w w₁ w₂
 
 variable {R : Type u} {L : Type v} {M : Type w} {N : Type w₁}
 variable [CommRing R] [LieRing L] [AddCommGroup M] [Module R M] [LieRingModule L M]
@@ -52,6 +54,37 @@ theorem ofBijective_apply (f : M →ₗ⁅R,L⁆ N) (hf : Function.Bijective f) 
   -- representation boundary before applying the corresponding linear-equivalence interface lemma.
   change (LinearEquiv.ofBijective (f : M →ₗ[R] N) hf) m = f m
   exact LinearEquiv.ofBijective_apply _ _
+
+section CongrRight
+
+variable {P : Type w₂} [AddCommGroup P] [Module R P] [LieRingModule L P]
+variable [LieAlgebra R L] [LieModule R L M] [LieModule R L N] [LieModule R L P]
+
+/-- **Postcomposition with an equivalence of Lie modules**, as an `R`-linear equivalence
+`(M →ₗ⁅R,L⁆ N) ≃ₗ[R] (M →ₗ⁅R,L⁆ P)` of morphism spaces. This is the Lie-module analogue of
+`LinearEquiv.congrRight`, which is unavailable here because a `LieModuleHom` is not a
+`LinearMap`. -/
+def congrRight (e : N ≃ₗ⁅R,L⁆ P) : (M →ₗ⁅R,L⁆ N) ≃ₗ[R] (M →ₗ⁅R,L⁆ P) where
+  toFun f := (e : N →ₗ⁅R,L⁆ P).comp f
+  invFun g := (e.symm : P →ₗ⁅R,L⁆ N).comp g
+  map_add' _ _ := by ext m; simp
+  map_smul' _ _ := by ext m; simp
+  left_inv f := by ext m; simp
+  right_inv g := by ext m; simp
+
+omit [LieModule R L M] in
+@[simp]
+theorem congrRight_apply (e : N ≃ₗ⁅R,L⁆ P) (f : M →ₗ⁅R,L⁆ N) (m : M) :
+    congrRight (M := M) e f m = e (f m) :=
+  (rfl)
+
+omit [LieModule R L M] in
+@[simp]
+theorem congrRight_symm_apply (e : N ≃ₗ⁅R,L⁆ P) (g : M →ₗ⁅R,L⁆ P) (m : M) :
+    (congrRight (M := M) e).symm g m = e.symm (g m) :=
+  (rfl)
+
+end CongrRight
 
 end LieModuleEquiv
 

--- a/TauCeti/Algebra/Lie/Schur.lean
+++ b/TauCeti/Algebra/Lie/Schur.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+public import TauCeti.Algebra.Lie.Basic
+public import TauCeti.Algebra.Lie.Weights.Central
+
+public section
+
+/-!
+# The space of morphisms between irreducible Lie modules
+
+Let `M` and `N` be irreducible Lie modules over a Lie algebra `L`. A nonzero morphism `M → N` has
+kernel and range that are Lie submodules, so both are trivial or everything; being nonzero forces
+the kernel to be `⊥` and the range to be `⊤`, and the morphism is an equivalence
+(`TauCeti.LieModule.bijective_of_ne_zero`). So the morphism space is zero unless `M` and `N` are
+equivalent.
+
+Over an algebraically closed field the other case is just as rigid. Schur's lemma
+(`TauCeti.exists_forall_apply_eq_smul`) makes every self-morphism of a finite-dimensional
+irreducible module a scalar, so the endomorphism space is the line spanned by the identity, and
+transporting along an equivalence gives the same for `M → N`. Together:
+
+`dim_K (M →ₗ⁅K,L⁆ N) = 1` if `M ≃ₗ⁅K,L⁆ N`, and `0` otherwise.
+
+That dichotomy is what makes `dim_K (S →ₗ⁅K,L⁆ M)` a *multiplicity*: it is `1` for each summand of
+a decomposition of `M` equivalent to `S` and `0` for every other summand, so the count does not
+depend on the decomposition chosen.
+
+## Main results
+
+* `TauCeti.LieModule.bijective_of_ne_zero`: **a nonzero morphism between irreducible Lie modules
+  is bijective**, over an arbitrary commutative ring.
+* `TauCeti.LieModule.eq_zero_of_isEmpty_lieModuleEquiv` and
+  `TauCeti.LieModule.subsingleton_lieModuleHom`: inequivalent irreducible Lie modules admit only
+  the zero morphism.
+* `TauCeti.LieModule.nonempty_lieModuleEquiv_iff_exists_ne_zero`: two irreducible Lie modules are
+  equivalent exactly when some morphism between them is nonzero.
+* `TauCeti.LieModule.finrank_lieModuleHom_self`: **the endomorphisms of a finite-dimensional
+  irreducible Lie module over an algebraically closed field are the scalars**, so the
+  endomorphism space is a line.
+* `TauCeti.LieModule.finrank_lieModuleHom_eq_one_iff`,
+  `TauCeti.LieModule.finrank_lieModuleHom_eq_zero_iff` and
+  `TauCeti.LieModule.finrank_lieModuleHom_le_one`: the dimension of the morphism space is `1` when
+  the two irreducible modules are equivalent and `0` when they are not, packaged as
+  `TauCeti.LieModule.finrank_lieModuleHom`.
+
+## Implementation notes
+
+Schur's lemma itself, `TauCeti.exists_forall_apply_eq_smul`, stays in
+`TauCeti/Algebra/Lie/Weights/Central.lean`, where it is proved and where the central weight of an
+irreducible module consumes it. This file is its consequence for whole morphism *spaces*, which
+needs the morphism-space linear structure and nothing about weights.
+
+## Roadmap
+
+This is the uniqueness input for the multiplicity `m_λ = dim Hom_L(L(λ), M)` of the decomposition
+toolkit in Layer 6 of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`
+(the `isotypicMultiplicity` target of its `Suggested.lean`, whose "`Hom` definition is the one that
+makes uniqueness automatic"): the morphism space between irreducibles has dimension `1` or `0`
+according as they are equivalent, so counting with it counts summands.
+
+## References
+
+* J. E. Humphreys, *Introduction to Lie Algebras and Representation Theory*, GTM 9, §6.1.
+* The statements mirror the categorical
+  `CategoryTheory.finrank_hom_simple_simple` of `Mathlib/CategoryTheory/Preadditive/Schur.lean`,
+  which is unavailable here: Mathlib has no category of Lie modules over a fixed Lie algebra.
+-/
+
+namespace TauCeti.LieModule
+
+open Module (finrank)
+
+universe u v w w₁
+
+/-! ### Over an arbitrary commutative ring -/
+
+section CommRing
+
+variable {R : Type u} {L : Type v} {M : Type w} {N : Type w₁}
+variable [CommRing R] [LieRing L] [LieAlgebra R L]
+variable [AddCommGroup M] [Module R M] [LieRingModule L M] [_root_.LieModule R L M]
+variable [AddCommGroup N] [Module R N] [LieRingModule L N] [_root_.LieModule R L N]
+variable [_root_.LieModule.IsIrreducible R L M] [_root_.LieModule.IsIrreducible R L N]
+
+-- The `LieAlgebra` and `LieModule` instances above are needed only to state the irreducibility
+-- hypotheses; the results themselves are about the underlying `LieRingModule` structure.
+omit [LieAlgebra R L] [_root_.LieModule R L M] [_root_.LieModule R L N]
+
+/-- **Schur's lemma for Lie modules, in its bijectivity form**: a nonzero morphism between
+irreducible Lie modules is bijective. Its kernel is a Lie submodule of `M` other than `⊤` and its
+range is a Lie submodule of `N` other than `⊥`, and irreducibility leaves no other option. -/
+theorem bijective_of_ne_zero {f : M →ₗ⁅R,L⁆ N} (hf : f ≠ 0) : Function.Bijective f := by
+  constructor
+  · rw [← LieModuleHom.ker_eq_bot]
+    refine (IsSimpleOrder.eq_bot_or_eq_top f.ker).resolve_right fun h ↦ hf ?_
+    ext m
+    simpa using LieModuleHom.mem_ker.1 (h ▸ LieSubmodule.mem_top m)
+  · rw [← LieModuleHom.range_eq_top]
+    refine (IsSimpleOrder.eq_bot_or_eq_top f.range).resolve_left fun h ↦ hf ?_
+    ext m
+    have hmem : f m ∈ f.range := (LieModuleHom.mem_range f _).2 ⟨m, rfl⟩
+    rw [h, LieSubmodule.mem_bot] at hmem
+    simpa using hmem
+
+/-- A nonzero morphism between irreducible Lie modules makes them equivalent. -/
+theorem nonempty_lieModuleEquiv_of_ne_zero {f : M →ₗ⁅R,L⁆ N} (hf : f ≠ 0) :
+    Nonempty (M ≃ₗ⁅R,L⁆ N) :=
+  ⟨LieModuleEquiv.ofBijective f (bijective_of_ne_zero hf)⟩
+
+/-- **Inequivalent irreducible Lie modules admit only the zero morphism.** -/
+theorem eq_zero_of_isEmpty_lieModuleEquiv (h : IsEmpty (M ≃ₗ⁅R,L⁆ N)) (f : M →ₗ⁅R,L⁆ N) : f = 0 :=
+  by_contra fun hf ↦ (nonempty_lieModuleEquiv_of_ne_zero hf).elim h.elim
+
+/-- The morphism space between inequivalent irreducible Lie modules is trivial. -/
+theorem subsingleton_lieModuleHom (h : IsEmpty (M ≃ₗ⁅R,L⁆ N)) :
+    Subsingleton (M →ₗ⁅R,L⁆ N) :=
+  ⟨fun f g ↦ by
+    rw [eq_zero_of_isEmpty_lieModuleEquiv h f, eq_zero_of_isEmpty_lieModuleEquiv h g]⟩
+
+/-- **Two irreducible Lie modules are equivalent exactly when they admit a nonzero morphism.** -/
+theorem nonempty_lieModuleEquiv_iff_exists_ne_zero :
+    Nonempty (M ≃ₗ⁅R,L⁆ N) ↔ ∃ f : M →ₗ⁅R,L⁆ N, f ≠ 0 := by
+  refine ⟨fun ⟨e⟩ ↦ ⟨(e : M →ₗ⁅R,L⁆ N), fun h ↦ ?_⟩, fun ⟨_, hf⟩ ↦
+    nonempty_lieModuleEquiv_of_ne_zero hf⟩
+  have _i : Nontrivial M := _root_.LieModule.nontrivial_of_isIrreducible R L M
+  obtain ⟨m, hm⟩ := exists_ne (0 : M)
+  exact hm (e.injective (by simpa using congrArg (fun g : M →ₗ⁅R,L⁆ N ↦ g m) h))
+
+end CommRing
+
+/-! ### Over an algebraically closed field -/
+
+section IsAlgClosed
+
+variable (K : Type u) (L : Type v) (M : Type w) {N : Type w₁}
+variable [Field K] [IsAlgClosed K] [LieRing L] [LieAlgebra K L]
+variable [AddCommGroup M] [Module K M] [LieRingModule L M] [_root_.LieModule K L M]
+variable [AddCommGroup N] [Module K N] [LieRingModule L N] [_root_.LieModule K L N]
+variable [FiniteDimensional K M] [_root_.LieModule.IsIrreducible K L M]
+
+/-- **The endomorphism space of a finite-dimensional irreducible Lie module is a line.** Over an
+algebraically closed field Schur's lemma makes every endomorphism a scalar multiple of the
+identity, and the identity is nonzero because an irreducible module is nontrivial. -/
+theorem finrank_lieModuleHom_self : finrank K (M →ₗ⁅K,L⁆ M) = 1 := by
+  have _i : Nontrivial M := _root_.LieModule.nontrivial_of_isIrreducible K L M
+  obtain ⟨m₀, hm₀⟩ := exists_ne (0 : M)
+  have hid : (LieModuleHom.id : M →ₗ⁅K,L⁆ M) ≠ 0 := fun h ↦
+    hm₀ (by simpa using congrArg (fun g : M →ₗ⁅K,L⁆ M ↦ g m₀) h)
+  rw [finrank_eq_one_iff_of_nonzero' _ hid]
+  intro f
+  obtain ⟨c, hc⟩ := exists_forall_apply_eq_smul K L M f
+  exact ⟨c, by ext m; simpa using (hc m).symm⟩
+
+variable {M}
+
+/-- Equivalent finite-dimensional irreducible Lie modules have a one-dimensional morphism space:
+postcomposing with the equivalence identifies it with the endomorphism space. -/
+theorem finrank_lieModuleHom_eq_one_of_nonempty_lieModuleEquiv (h : Nonempty (M ≃ₗ⁅K,L⁆ N)) :
+    finrank K (M →ₗ⁅K,L⁆ N) = 1 := by
+  rw [← (LieModuleEquiv.congrRight (M := M) h.some).finrank_eq]
+  exact finrank_lieModuleHom_self K L M
+
+variable [_root_.LieModule.IsIrreducible K L N]
+
+omit [IsAlgClosed K] [_root_.LieModule K L M] [FiniteDimensional K M] in
+/-- Inequivalent irreducible Lie modules have a zero-dimensional morphism space. -/
+theorem finrank_lieModuleHom_eq_zero_of_isEmpty_lieModuleEquiv (h : IsEmpty (M ≃ₗ⁅K,L⁆ N)) :
+    finrank K (M →ₗ⁅K,L⁆ N) = 0 :=
+  have := subsingleton_lieModuleHom h
+  Module.finrank_zero_of_subsingleton
+
+/-- **The morphism space of two finite-dimensional irreducible Lie modules is one-dimensional
+exactly when they are equivalent.** -/
+theorem finrank_lieModuleHom_eq_one_iff :
+    finrank K (M →ₗ⁅K,L⁆ N) = 1 ↔ Nonempty (M ≃ₗ⁅K,L⁆ N) := by
+  refine ⟨fun h ↦ ?_, finrank_lieModuleHom_eq_one_of_nonempty_lieModuleEquiv K L⟩
+  rw [← not_isEmpty_iff]
+  intro hempty
+  rw [finrank_lieModuleHom_eq_zero_of_isEmpty_lieModuleEquiv K L hempty] at h
+  exact zero_ne_one h
+
+/-- **The morphism space of two finite-dimensional irreducible Lie modules vanishes exactly when
+they are inequivalent.** -/
+theorem finrank_lieModuleHom_eq_zero_iff :
+    finrank K (M →ₗ⁅K,L⁆ N) = 0 ↔ IsEmpty (M ≃ₗ⁅K,L⁆ N) := by
+  refine ⟨fun h ↦ ?_, finrank_lieModuleHom_eq_zero_of_isEmpty_lieModuleEquiv K L⟩
+  rw [← not_nonempty_iff]
+  intro hne
+  rw [finrank_lieModuleHom_eq_one_of_nonempty_lieModuleEquiv K L hne] at h
+  exact one_ne_zero h
+
+/-- **The morphism space of two finite-dimensional irreducible Lie modules is at most a line.** -/
+theorem finrank_lieModuleHom_le_one : finrank K (M →ₗ⁅K,L⁆ N) ≤ 1 := by
+  rcases isEmpty_or_nonempty (M ≃ₗ⁅K,L⁆ N) with h | h
+  · exact le_of_eq_of_le (finrank_lieModuleHom_eq_zero_of_isEmpty_lieModuleEquiv K L h) zero_le_one
+  · exact le_of_eq (finrank_lieModuleHom_eq_one_of_nonempty_lieModuleEquiv K L h)
+
+open scoped Classical in
+/-- **Schur's lemma for finite-dimensional irreducible Lie modules over an algebraically closed
+field, in its dimension form**: the morphism space is a line for equivalent modules and zero for
+inequivalent ones. This is what makes `dim_K (S →ₗ⁅K,L⁆ M)` count the summands of `M` equivalent
+to `S`. -/
+theorem finrank_lieModuleHom :
+    finrank K (M →ₗ⁅K,L⁆ N) = if Nonempty (M ≃ₗ⁅K,L⁆ N) then 1 else 0 := by
+  split
+  · exact finrank_lieModuleHom_eq_one_of_nonempty_lieModuleEquiv K L ‹_›
+  · exact finrank_lieModuleHom_eq_zero_of_isEmpty_lieModuleEquiv K L (not_nonempty_iff.1 ‹_›)
+
+end IsAlgClosed
+
+end TauCeti.LieModule

--- a/TauCeti/Algebra/Lie/Schur.lean
+++ b/TauCeti/Algebra/Lie/Schur.lean
@@ -5,7 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 public import TauCeti.Algebra.Lie.Basic
 public import TauCeti.Algebra.Lie.Weights.Central
 
@@ -27,17 +26,19 @@ transporting along an equivalence gives the same for `M → N`. Together:
 
 `dim_K (M →ₗ⁅K,L⁆ N) = 1` if `M ≃ₗ⁅K,L⁆ N`, and `0` otherwise.
 
-That dichotomy is what makes `dim_K (S →ₗ⁅K,L⁆ M)` a *multiplicity*: it is `1` for each summand of
-a decomposition of `M` equivalent to `S` and `0` for every other summand, so the count does not
-depend on the decomposition chosen.
+That dichotomy is the input a *multiplicity* count needs: in a decomposition of `M` into
+irreducibles, each summand contributes `1` to `dim_K (S →ₗ⁅K,L⁆ M)` when it is equivalent to `S`
+and `0` when it is not. Reading the multiplicity off `dim_K (S →ₗ⁅K,L⁆ M)` needs one further
+ingredient, additivity of the morphism space over a direct sum, which is not proved here; this
+file goes no further than the two-irreducible dimension count.
 
 ## Main results
 
 * `TauCeti.LieModule.bijective_of_ne_zero`: **a nonzero morphism between irreducible Lie modules
   is bijective**, over an arbitrary commutative ring.
 * `TauCeti.LieModule.eq_zero_of_isEmpty_lieModuleEquiv` and
-  `TauCeti.LieModule.subsingleton_lieModuleHom`: inequivalent irreducible Lie modules admit only
-  the zero morphism.
+  `TauCeti.LieModule.subsingleton_lieModuleHom_of_isEmpty_lieModuleEquiv`: inequivalent irreducible
+  Lie modules admit only the zero morphism.
 * `TauCeti.LieModule.nonempty_lieModuleEquiv_iff_exists_ne_zero`: two irreducible Lie modules are
   equivalent exactly when some morphism between them is nonzero.
 * `TauCeti.LieModule.finrank_lieModuleHom_self`: **the endomorphisms of a finite-dimensional
@@ -62,7 +63,9 @@ This is the uniqueness input for the multiplicity `m_λ = dim Hom_L(L(λ), M)` o
 toolkit in Layer 6 of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`
 (the `isotypicMultiplicity` target of its `Suggested.lean`, whose "`Hom` definition is the one that
 makes uniqueness automatic"): the morphism space between irreducibles has dimension `1` or `0`
-according as they are equivalent, so counting with it counts summands.
+according as they are equivalent. The multiplicity theorem itself is not proved here; it needs, in
+addition, additivity of the morphism space over a direct-sum decomposition, and for the
+`L(λ)`-indexed form the irreducible quotient `L(λ)`.
 
 ## References
 
@@ -118,7 +121,7 @@ theorem eq_zero_of_isEmpty_lieModuleEquiv (h : IsEmpty (M ≃ₗ⁅R,L⁆ N)) (f
   by_contra fun hf ↦ (nonempty_lieModuleEquiv_of_ne_zero hf).elim h.elim
 
 /-- The morphism space between inequivalent irreducible Lie modules is trivial. -/
-theorem subsingleton_lieModuleHom (h : IsEmpty (M ≃ₗ⁅R,L⁆ N)) :
+theorem subsingleton_lieModuleHom_of_isEmpty_lieModuleEquiv (h : IsEmpty (M ≃ₗ⁅R,L⁆ N)) :
     Subsingleton (M →ₗ⁅R,L⁆ N) :=
   ⟨fun f g ↦ by
     rw [eq_zero_of_isEmpty_lieModuleEquiv h f, eq_zero_of_isEmpty_lieModuleEquiv h g]⟩
@@ -172,7 +175,7 @@ omit [IsAlgClosed K] [_root_.LieModule K L M] [FiniteDimensional K M] in
 /-- Inequivalent irreducible Lie modules have a zero-dimensional morphism space. -/
 theorem finrank_lieModuleHom_eq_zero_of_isEmpty_lieModuleEquiv (h : IsEmpty (M ≃ₗ⁅K,L⁆ N)) :
     finrank K (M →ₗ⁅K,L⁆ N) = 0 :=
-  have := subsingleton_lieModuleHom h
+  have := subsingleton_lieModuleHom_of_isEmpty_lieModuleEquiv h
   Module.finrank_zero_of_subsingleton
 
 /-- **The morphism space of two finite-dimensional irreducible Lie modules is one-dimensional
@@ -204,8 +207,9 @@ theorem finrank_lieModuleHom_le_one : finrank K (M →ₗ⁅K,L⁆ N) ≤ 1 := b
 open scoped Classical in
 /-- **Schur's lemma for finite-dimensional irreducible Lie modules over an algebraically closed
 field, in its dimension form**: the morphism space is a line for equivalent modules and zero for
-inequivalent ones. This is what makes `dim_K (S →ₗ⁅K,L⁆ M)` count the summands of `M` equivalent
-to `S`. -/
+inequivalent ones. This is the per-summand contribution that a multiplicity count of `S` in `M`
+reads off `dim_K (S →ₗ⁅K,L⁆ M)`, once additivity of the morphism space over a decomposition of `M`
+is available. -/
 theorem finrank_lieModuleHom :
     finrank K (M →ₗ⁅K,L⁆ N) = if Nonempty (M ≃ₗ⁅K,L⁆ N) then 1 else 0 := by
   split


### PR DESCRIPTION
This PR proves **Schur's lemma for Lie modules in its dimension form**: for finite-dimensional irreducible Lie modules `M` and `N` over a Lie algebra `L` over an algebraically closed field `K`, `dim_K (M →ₗ⁅K,L⁆ N)` is `1` when `M ≃ₗ⁅K,L⁆ N` and `0` otherwise (`TauCeti.LieModule.finrank_lieModuleHom`, with the two halves `finrank_lieModuleHom_eq_one_iff` and `finrank_lieModuleHom_eq_zero_iff`). Underneath it, over an arbitrary commutative ring, a nonzero morphism between irreducible Lie modules is bijective (`TauCeti.LieModule.bijective_of_ne_zero`), so inequivalent irreducibles admit only the zero morphism and two irreducibles are equivalent exactly when some morphism between them is nonzero.

This serves the decomposition-toolkit milestone of Layer 6 of `TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md`, "Isotypic components and multiplicities, through the enveloping-algebra dictionary", whose pinned `isotypicMultiplicity` in that roadmap's `Suggested.lean` is `Module.finrank K (irreducibleQuotient base lam →ₗ⁅K,L⁆ M)` and whose docstring says "the `Hom` definition is the one that makes uniqueness automatic". This dichotomy is exactly that uniqueness: the morphism space contributes `1` for each summand of a decomposition equivalent to `L(λ)` and `0` for every other summand. Turning that per-summand contribution into the multiplicity itself is left to a later PR; this one proves only the two-irreducible dimension count. What remains for the milestone after this PR is the multiplicity itself — `isotypicMultiplicity` and the finrank identity `dim (isotypic component) = m_λ · dim L(λ)` — which additionally needs the additivity of the morphism space over a direct-sum decomposition and, for the `L(λ)`-indexed form, the irreducible quotient `L(λ)` of Layer 3.

Schur's lemma proper, `TauCeti.exists_forall_apply_eq_smul`, already stands in `TauCeti/Algebra/Lie/Weights/Central.lean` and is consumed rather than reproved; it is what makes the endomorphism space of a finite-dimensional irreducible module the line spanned by the identity, and postcomposition with an equivalence carries that to `M →ₗ⁅K,L⁆ N`. That postcomposition is the one piece of general infrastructure added, `TauCeti.LieModuleEquiv.congrRight`, in `TauCeti/Algebra/Lie/Basic.lean` beside `LieModuleEquiv.ofBijective`: Mathlib's `LinearEquiv.congrRight` does not apply, since a `LieModuleHom` is not a `LinearMap`. The statements mirror the categorical `CategoryTheory.finrank_hom_simple_simple` of `Mathlib/CategoryTheory/Preadditive/Schur.lean`, which is unavailable here because Mathlib has no category of Lie modules over a fixed Lie algebra; that file is credited in the module docstring, along with Humphreys, *Introduction to Lie Algebras and Representation Theory*, §6.1.

The bijectivity half asks only for a commutative ring and the `LieRingModule` structure, so the `LieAlgebra`/`LieModule` instances needed to state irreducibility are omitted from it; algebraic closure and finite-dimensionality enter only where the dimension count does.

Adds `TauCeti/Algebra/Lie/Schur.lean` (221 lines) and 34 lines to `TauCeti/Algebra/Lie/Basic.lean`.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"finrank-lie-module-hom-simple-simple"}-->

🤖 Prepared with Claude Code

