### PR TITLE
feat: identify norm coefficients with the Euler product

### DIFF
--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct.lean
@@ -457,13 +457,6 @@ theorem normCoeff_eq_eulerProduct (hf : f.IsMultiplicative) :
   rw [normCoeff_supportedPart hf S] at hcoeff
   exact hcoeff.symm.trans hprod
 
-/-- Regrouping a multiplicative ideal arithmetic function by absolute norm produces a
-multiplicative arithmetic function. -/
-theorem IsMultiplicative.normCoeff (hf : f.IsMultiplicative) :
-    (normCoeff K f).IsMultiplicative := by
-  rw [normCoeff_eq_eulerProduct hf]
-  exact isMultiplicative_eulerProduct hf.map_one
-
 end IdealArithmeticFunction
 
 end TauCeti

--- a/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct.lean
+++ b/TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct.lean
@@ -28,8 +28,9 @@ coefficients: no convergence hypothesis enters, and the passage to an infinite p
 functions is a later step.
 
 The richer `EulerProductData` package required by Layer 3.1 is not defined here: it must also carry
-a finite bad set and the hypotheses that transport an ideal product through `normCoeff`. The
-canonical factors developed here are prerequisites for that package, not a substitute for it.
+a finite bad set and bundle the coprime-multiplicativity and analytic local hypotheses. The formal
+transport through `normCoeff` is proved here from multiplicativity, so the eventual package can
+expose that theorem without storing an unconstrained equality field.
 
 ## Main definitions
 
@@ -46,6 +47,9 @@ canonical factors developed here are prerequisites for that package, not a subst
 * `TauCeti.IdealArithmeticFunction.normCoeff_supportedPart`: the **finite Euler product**
   `normCoeff (supportedPart f S) = ∏ P ∈ S, localArithmeticFactor f P` for a multiplicative `f`
   and a finite set `S` of height-one primes.
+* `TauCeti.IdealArithmeticFunction.normCoeff_eq_eulerProduct`: the norm coefficients of a
+  multiplicative ideal arithmetic function are Mathlib's formal Euler product of its canonical
+  local factors.
 
 ## Implementation notes
 
@@ -71,7 +75,9 @@ This is the canonical-local-factor prerequisite for Layer **3.1** and the whole 
 is derived here rather than stored. The remaining Layer 3.1 target defines `EulerProductData` with
 its finite bad set and `normCoeff` transport hypotheses, supplies extensionality, and constructs
 restriction, product, conjugation, trivial-weight, and general multiplicative-weight operations.
-Layer 3.3 then passes to the directed limit of finite prime sets under absolute convergence.
+The formal transport theorem `normCoeff_eq_eulerProduct` supplies the coefficient identity that
+package will expose. Layer 3.3 then evaluates it on an absolute-convergence half-plane and passes
+to the analytic product of the local series.
 
 ## References
 
@@ -413,6 +419,50 @@ theorem normCoeff_supportedPart (hf : f.IsMultiplicative)
   | insert P S hPS ih =>
       rw [Finset.coe_insert, supportedPart_insert hf (by simpa using hPS), normCoeff_convolution,
         ih, normCoeff_supportedPart_singleton, Finset.prod_insert hPS, mul_comm]
+
+/-- At a fixed coefficient, restricting to a sufficiently large finite set of prime ideals does
+not change the norm coefficient. One may take all prime ideals of norm at most `n`: every prime
+divisor of an ideal of norm `n` belongs to that finite set. -/
+theorem eventually_normCoeff_supportedPart_eq (f : IdealArithmeticFunction K) (n : ℕ) :
+    ∀ᶠ S : Finset (HeightOneSpectrum (𝓞 K)) in Filter.atTop,
+      normCoeff K (supportedPart f (S : Set (HeightOneSpectrum (𝓞 K)))) n =
+        normCoeff K f n := by
+  classical
+  let T : Finset (HeightOneSpectrum (𝓞 K)) :=
+    (Northcott.finite_le
+      (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal) n).toFinset
+  filter_upwards [Filter.eventually_ge_atTop T] with S hTS
+  rw [normCoeff_eq_sum_normFiber, normCoeff_eq_sum_normFiber]
+  refine Finset.sum_congr rfl fun A hA ↦ supportedPart_apply_of_isPrimeTo_compl ?_
+  rw [Ideal.isPrimeTo_iff]
+  refine ⟨nonZeroDivisors.coe_ne_zero A, fun P hP hPdvd ↦ hP ?_⟩
+  have hnormP : Ideal.absNorm P.asIdeal ≤ n := by
+    have hnormdvd : Ideal.absNorm P.asIdeal ∣ Ideal.absNorm (A : Ideal (𝓞 K)) :=
+      Ideal.absNorm_dvd_absNorm_of_le (Ideal.dvd_iff_le.mp hPdvd)
+    have hnormA : Ideal.absNorm (A : Ideal (𝓞 K)) = n := (mem_normFiber K).mp hA
+    rw [hnormA] at hnormdvd
+    exact Nat.le_of_dvd (hnormA ▸ Ideal.absNorm_pos_of_nonZeroDivisors A) hnormdvd
+  exact hTS ((Northcott.finite_le
+    (h := fun P : HeightOneSpectrum (𝓞 K) ↦ Ideal.absNorm P.asIdeal) n).mem_toFinset.mpr hnormP)
+
+/-- **The formal Euler product of norm coefficients.** The norm coefficients of a multiplicative
+ideal arithmetic function are Mathlib's `ArithmeticFunction.eulerProduct` of the canonical local
+arithmetic factors. This is an equality of arithmetic functions; the analytic infinite product
+obtained after evaluating their `LSeries` is the separate absolute-convergence step of Layer 3.3. -/
+theorem normCoeff_eq_eulerProduct (hf : f.IsMultiplicative) :
+    normCoeff K f = ArithmeticFunction.eulerProduct f.localArithmeticFactor := by
+  ext n
+  obtain ⟨S, hcoeff, hprod⟩ := ((eventually_normCoeff_supportedPart_eq f n).and
+    (tendsTo_eulerProduct_localArithmeticFactor f hf.map_one n)).exists
+  rw [normCoeff_supportedPart hf S] at hcoeff
+  exact hcoeff.symm.trans hprod
+
+/-- Regrouping a multiplicative ideal arithmetic function by absolute norm produces a
+multiplicative arithmetic function. -/
+theorem IsMultiplicative.normCoeff (hf : f.IsMultiplicative) :
+    (normCoeff K f).IsMultiplicative := by
+  rw [normCoeff_eq_eulerProduct hf]
+  exact isMultiplicative_eulerProduct hf.map_one
 
 end IdealArithmeticFunction
 


### PR DESCRIPTION
This PR identifies the norm coefficients of a coprime-multiplicative ideal arithmetic function with Mathlib's formal Euler product of its canonical prime-ideal local factors. `TauCeti.IdealArithmeticFunction.eventually_normCoeff_supportedPart_eq` proves coefficientwise stabilization: at coefficient `n`, every ideal in the norm fibre is supported on the finite set of prime ideals of norm at most `n`. Combining this with the finite factorization `normCoeff_supportedPart` and Mathlib's `ArithmeticFunction.tendsTo_eulerProduct_ofPowerSeries` yields `TauCeti.IdealArithmeticFunction.normCoeff_eq_eulerProduct`. (An `IsMultiplicative.normCoeff` corollary was dropped in response to the `placement` review: it cannot be stated in an earlier module without an import cycle, so it is left to a consumer, being a one-liner from `normCoeff_eq_eulerProduct`.)

The exact target is Layer 3.1 "Local data" of `TauCetiRoadmap/ArithmeticDirichletSeries/README.md`, specifically the `normCoeff` transport that the `EulerProductData` package must expose, and it is the next prerequisite for Layer 3.3 "Infinite Euler product." This is the most effective current critical-path step because Layer 3.2's finite Euler product is now on `main`, while Layer 7.2's all-prime normalization remains blocked on the Layer 3.3 analytic product. After this PR, Layer 3.1 still needs the finite-bad-set `EulerProductData` bundle and its operations, and Layer 3.3 must evaluate this formal identity under absolute convergence to obtain the analytic product.

The proof reuses Mathlib's `ArithmeticFunction.eulerProduct`, `ArithmeticFunction.tendsTo_eulerProduct_ofPowerSeries`, and the Northcott instance for prime-ideal absolute norm; it also reuses Tau Ceti's landed `normCoeff_supportedPart`. No Mathlib infrastructure or external formalization is vendored. Modify `TauCeti/NumberTheory/ArithmeticDirichletSeries/EulerProduct.lean` only.

Roadmap: ArithmeticDirichletSeries

<!--tauceti-target:v1 {"focus":"ArithmeticDirichletSeries","id":"normcoeff-eq-eulerproduct"}-->

🤖 Prepared with Codex

