### PR TITLE
feat: prove type B Serre relations

### DIFF
--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
@@ -193,8 +193,7 @@ private theorem typeBSimpleCorootCoordinate_sub_eq_cartan_transpose
 theorem typeBSimpleCorootGenerator_lie_root (i j : Fin (n + 1)) :
     ⁅typeBSimpleCorootGenerator (K := K) i, typeBSimpleRootGenerator (K := K) j⁆ =
       CartanMatrix.B (n + 1) j i • typeBSimpleRootGenerator j := by
-  change ⁅typeBSimpleCorootGenerator (K := K) i, typeBSimpleRootGenerator (K := K) j⁆ =
-    (CartanMatrix.B (n + 1)).transpose i j • typeBSimpleRootGenerator j
+  rw [← (CartanMatrix.B (n + 1)).transpose_apply i j]
   refine Fin.lastCases ?_ (fun j₀ => ?_) j
   · rw [typeBSimpleRootGenerator_last, typeBSimpleCorootGenerator_lie_root_last,
       typeBSimpleCorootCoordinate_last_eq_cartan_transpose, Int.cast_smul_eq_zsmul]
@@ -207,9 +206,7 @@ theorem typeBSimpleCorootGenerator_lie_negativeRoot (i j : Fin (n + 1)) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
       typeBSimpleNegativeRootGenerator (K := K) j⁆ =
         -(CartanMatrix.B (n + 1) j i • typeBSimpleNegativeRootGenerator j) := by
-  change ⁅typeBSimpleCorootGenerator (K := K) i,
-      typeBSimpleNegativeRootGenerator (K := K) j⁆ =
-    -((CartanMatrix.B (n + 1)).transpose i j • typeBSimpleNegativeRootGenerator j)
+  rw [← (CartanMatrix.B (n + 1)).transpose_apply i j]
   refine Fin.lastCases ?_ (fun j₀ => ?_) j
   · rw [typeBSimpleNegativeRootGenerator_last,
       typeBSimpleCorootGenerator_lie_negativeRoot_last,

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/GeneratorRelations.lean
@@ -192,7 +192,9 @@ private theorem typeBSimpleCorootCoordinate_sub_eq_cartan_transpose
 @[simp]
 theorem typeBSimpleCorootGenerator_lie_root (i j : Fin (n + 1)) :
     ⁅typeBSimpleCorootGenerator (K := K) i, typeBSimpleRootGenerator (K := K) j⁆ =
-      (CartanMatrix.B (n + 1)).transpose i j • typeBSimpleRootGenerator j := by
+      CartanMatrix.B (n + 1) j i • typeBSimpleRootGenerator j := by
+  change ⁅typeBSimpleCorootGenerator (K := K) i, typeBSimpleRootGenerator (K := K) j⁆ =
+    (CartanMatrix.B (n + 1)).transpose i j • typeBSimpleRootGenerator j
   refine Fin.lastCases ?_ (fun j₀ => ?_) j
   · rw [typeBSimpleRootGenerator_last, typeBSimpleCorootGenerator_lie_root_last,
       typeBSimpleCorootCoordinate_last_eq_cartan_transpose, Int.cast_smul_eq_zsmul]
@@ -204,7 +206,10 @@ theorem typeBSimpleCorootGenerator_lie_root (i j : Fin (n + 1)) :
 theorem typeBSimpleCorootGenerator_lie_negativeRoot (i j : Fin (n + 1)) :
     ⁅typeBSimpleCorootGenerator (K := K) i,
       typeBSimpleNegativeRootGenerator (K := K) j⁆ =
-        -((CartanMatrix.B (n + 1)).transpose i j • typeBSimpleNegativeRootGenerator j) := by
+        -(CartanMatrix.B (n + 1) j i • typeBSimpleNegativeRootGenerator j) := by
+  change ⁅typeBSimpleCorootGenerator (K := K) i,
+      typeBSimpleNegativeRootGenerator (K := K) j⁆ =
+    -((CartanMatrix.B (n + 1)).transpose i j • typeBSimpleNegativeRootGenerator j)
   refine Fin.lastCases ?_ (fun j₀ => ?_) j
   · rw [typeBSimpleNegativeRootGenerator_last,
       typeBSimpleCorootGenerator_lie_negativeRoot_last,

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
@@ -65,6 +65,14 @@ def typeBLongRootMatrix (i j : ι) (_hij : i ≠ j) :
   single (.inr (.inl i)) (.inr (.inl j)) 1 -
     single (.inr (.inr j)) (.inr (.inr i)) 1
 
+omit [Fintype ι] in
+/-- The long type-`B` root matrix as a difference of two matrix units. -/
+theorem typeBLongRootMatrix_def (i j : ι) (hij : i ≠ j) :
+    typeBLongRootMatrix (K := K) i j hij =
+      single (.inr (.inl i)) (.inr (.inl j)) 1 -
+        single (.inr (.inr j)) (.inr (.inr i)) 1 :=
+  (rfl)
+
 /-- The long-root matrix is skew-adjoint for the split odd orthogonal form. -/
 theorem typeBLongRootMatrix_mem_typeB (i j : ι) (hij : i ≠ j) :
     typeBLongRootMatrix (K := K) i j hij ∈ LieAlgebra.Orthogonal.typeB ι K := by
@@ -151,9 +159,23 @@ normalization adapted to the middle coefficient `2` in `LieAlgebra.Orthogonal.JB
 def typeBShortRootMatrix (i : ι) : Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K :=
   single (.inr (.inl i)) (.inl ()) 2 - single (.inl ()) (.inr (.inr i)) 1
 
+omit [Fintype ι] in
+/-- The positive short type-`B` root matrix as a difference of two matrix units. -/
+theorem typeBShortRootMatrix_def (i : ι) :
+    typeBShortRootMatrix (K := K) i =
+      single (.inr (.inl i)) (.inl ()) 2 - single (.inl ()) (.inr (.inr i)) 1 :=
+  (rfl)
+
 /-- The ambient root matrix for the opposite short root `-εᵢ`. -/
 def typeBShortNegativeRootMatrix (i : ι) : Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K :=
   single (.inl ()) (.inr (.inl i)) 1 - single (.inr (.inr i)) (.inl ()) 2
+
+omit [Fintype ι] in
+/-- The negative short type-`B` root matrix as a difference of two matrix units. -/
+theorem typeBShortNegativeRootMatrix_def (i : ι) :
+    typeBShortNegativeRootMatrix (K := K) i =
+      single (.inl ()) (.inr (.inl i)) 1 - single (.inr (.inr i)) (.inl ()) 2 :=
+  (rfl)
 
 /-- The positive short-root matrix is skew-adjoint for the split odd orthogonal form. -/
 theorem typeBShortRootMatrix_mem_typeB (i : ι) :

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/RootGenerators.lean
@@ -73,6 +73,26 @@ theorem typeBLongRootMatrix_def (i j : ι) (hij : i ≠ j) :
         single (.inr (.inr j)) (.inr (.inr i)) 1 :=
   (rfl)
 
+/-- Two long type-`B` root matrices bracket to zero when their directed index pairs cannot
+concatenate in either order. -/
+theorem typeBLongRootMatrix_lie_longRootMatrix_of_ne (i j k l : ι)
+    (hij : i ≠ j) (hkl : k ≠ l) (hjk : j ≠ k) (hil : i ≠ l) :
+    ⁅typeBLongRootMatrix (K := K) i j hij, typeBLongRootMatrix (K := K) k l hkl⁆ = 0 := by
+  rw [LieRing.of_associative_ring_bracket]
+  simp [typeBLongRootMatrix_def, mul_sub, sub_mul, Matrix.single_mul_single_of_ne,
+    hjk, hjk.symm, hil, hil.symm]
+
+/-- The bracket of two concatenated long type-`B` root matrices is the long root matrix for the
+concatenated index pair. -/
+theorem typeBLongRootMatrix_lie_longRootMatrix_chain (i j k l : ι)
+    (hij : i ≠ j) (hkl : k ≠ l) (hjk : j = k) (hil : i ≠ l) :
+    ⁅typeBLongRootMatrix (K := K) i j hij, typeBLongRootMatrix (K := K) k l hkl⁆ =
+      typeBLongRootMatrix (K := K) i l hil := by
+  subst k
+  rw [LieRing.of_associative_ring_bracket]
+  simp [typeBLongRootMatrix_def, mul_sub, sub_mul, Matrix.single_mul_single_same,
+    Matrix.single_mul_single_of_ne, hil, hil.symm]
+
 /-- The long-root matrix is skew-adjoint for the split odd orthogonal form. -/
 theorem typeBLongRootMatrix_mem_typeB (i j : ι) (hij : i ≠ j) :
     typeBLongRootMatrix (K := K) i j hij ∈ LieAlgebra.Orthogonal.typeB ι K := by
@@ -160,7 +180,7 @@ def typeBShortRootMatrix (i : ι) : Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕
   single (.inr (.inl i)) (.inl ()) 2 - single (.inl ()) (.inr (.inr i)) 1
 
 omit [Fintype ι] in
-/-- The positive short type-`B` root matrix as a difference of two matrix units. -/
+/-- The positive short type-`B` root matrix as `2 Eᵢ₀ - E₀,₋ᵢ`. -/
 theorem typeBShortRootMatrix_def (i : ι) :
     typeBShortRootMatrix (K := K) i =
       single (.inr (.inl i)) (.inl ()) 2 - single (.inl ()) (.inr (.inr i)) 1 :=
@@ -171,11 +191,35 @@ def typeBShortNegativeRootMatrix (i : ι) : Matrix (Unit ⊕ ι ⊕ ι) (Unit �
   single (.inl ()) (.inr (.inl i)) 1 - single (.inr (.inr i)) (.inl ()) 2
 
 omit [Fintype ι] in
-/-- The negative short type-`B` root matrix as a difference of two matrix units. -/
+/-- The negative short type-`B` root matrix as `E₀ᵢ - 2 E₋ᵢ,₀`. -/
 theorem typeBShortNegativeRootMatrix_def (i : ι) :
     typeBShortNegativeRootMatrix (K := K) i =
       single (.inl ()) (.inr (.inl i)) 1 - single (.inr (.inr i)) (.inl ()) 2 :=
   (rfl)
+
+/-- The bracket of a positive short type-`B` root matrix with a long root matrix. -/
+theorem typeBShortRootMatrix_lie_longRootMatrix (i k l : ι) (hkl : k ≠ l) :
+    ⁅typeBShortRootMatrix (K := K) i, typeBLongRootMatrix (K := K) k l hkl⁆ =
+      -(if i = l then typeBShortRootMatrix (K := K) k else 0) := by
+  rw [LieRing.of_associative_ring_bracket]
+  split_ifs with hil
+  · subst l
+    simp [typeBShortRootMatrix_def, typeBLongRootMatrix_def, mul_sub, sub_mul,
+      Matrix.single_mul_single_same, Matrix.single_mul_single_of_ne]
+  · simp [typeBShortRootMatrix_def, typeBLongRootMatrix_def, mul_sub, sub_mul,
+      Matrix.single_mul_single_of_ne, hil, Ne.symm hil]
+
+/-- The bracket of a negative short type-`B` root matrix with a long root matrix. -/
+theorem typeBShortNegativeRootMatrix_lie_longRootMatrix (i k l : ι) (hkl : k ≠ l) :
+    ⁅typeBShortNegativeRootMatrix (K := K) i, typeBLongRootMatrix (K := K) k l hkl⁆ =
+      if i = k then typeBShortNegativeRootMatrix (K := K) l else 0 := by
+  rw [LieRing.of_associative_ring_bracket]
+  split_ifs with hik
+  · subst k
+    simp [typeBShortNegativeRootMatrix_def, typeBLongRootMatrix_def, mul_sub, sub_mul,
+      Matrix.single_mul_single_same, Matrix.single_mul_single_of_ne]
+  · simp [typeBShortNegativeRootMatrix_def, typeBLongRootMatrix_def, mul_sub, sub_mul,
+      Matrix.single_mul_single_of_ne, hik, Ne.symm hik]
 
 /-- The positive short-root matrix is skew-adjoint for the split odd orthogonal form. -/
 theorem typeBShortRootMatrix_mem_typeB (i : ι) :

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.Cartan
+public import TauCeti.Algebra.Lie.Orthogonal.TypeB.GeneratorRelations
+import TauCeti.Algebra.Lie.GeneralLinear.Basic
+
+/-!
+# Serre relations in the standard split Lie algebra of type B
+
+The Bourbaki-numbered matrices in
+`TauCeti.Algebra.Lie.Orthogonal.TypeB.RootGenerators` give explicit positive-root,
+negative-root, and coroot generators for the standard integral split orthogonal Lie algebra of
+type `B`. This file proves the two families of Serre relations not supplied by the Cartan-action
+computations:
+
+* positive and negative generators at distinct simple nodes commute;
+* the iterated adjoint actions between two positive generators, and between two negative
+  generators, vanish with the exponents prescribed by the transposed type-`B` Cartan matrix.
+
+The transpose is the convention used by the existing Cartan-action API: the coroot index is the
+first index in `⁅hᵢ, eⱼ⁆`. All results hold over an arbitrary commutative ring, including in
+characteristic two. Together with the Cartan-action relations, these are the inputs for packaging
+the standard matrices as a `TauCeti.IsSerreSystem` and hence for mapping the integral Kostant form
+into the standard type-`B` representation.
+
+## Main results
+
+* `TauCeti.typeBSimpleRootGenerator_lie_negativeRoot_of_ne`: distinct positive and negative
+  simple-root generators commute.
+* `TauCeti.ad_pow_lie_typeBSimpleRootGenerator`: the higher positive Serre relations.
+* `TauCeti.ad_pow_lie_typeBSimpleNegativeRootGenerator`: the higher negative Serre relations.
+
+## References
+
+* N. Bourbaki, *Lie Groups and Lie Algebras, Chapters 4--6*, Plate II.
+* J.-P. Serre, *Complex Semisimple Lie Algebras*, Chapter VI, Appendix.
+
+This supplies the mixed and higher generator relations needed by the Chevalley--Demazure
+construction and pinnings in Layer 9 of the ReductiveGroups roadmap.
+-/
+
+public section
+
+namespace TauCeti
+
+open LieAlgebra Matrix
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+universe u
+
+variable {K : Type u} [CommRing K]
+variable {n : ℕ}
+
+private theorem lie_typeBSimpleRootMatrix_typeBSimpleNegativeRootMatrix_of_ne
+    (i j : Fin (n + 1)) (hij : i ≠ j) :
+    ⁅typeBSimpleRootMatrix (K := K) i, typeBSimpleNegativeRootMatrix (K := K) j⁆ = 0 := by
+  induction i using Fin.lastCases with
+  | last =>
+      induction j using Fin.lastCases with
+      | last => exact (hij rfl).elim
+      | cast j₀ =>
+          simp only [typeBSimpleRootMatrix_last, typeBSimpleNegativeRootMatrix_castSucc]
+          simp [typeBShortRootMatrix_def, typeBLongRootMatrix_def, lie_sub, sub_lie,
+            lie_single_single, hij]
+  | cast i₀ =>
+      induction j using Fin.lastCases with
+      | last =>
+          have hlast : Fin.last n ≠ i₀.castSucc := fun h ↦ hij h.symm
+          simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleNegativeRootMatrix_last]
+          simp [typeBLongRootMatrix_def, typeBShortNegativeRootMatrix_def, lie_sub, sub_lie,
+            lie_single_single, hij, hlast]
+      | cast j₀ =>
+          have hij₀ : i₀ ≠ j₀ := fun h ↦ hij (congrArg Fin.castSucc h)
+          simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleNegativeRootMatrix_castSucc]
+          simp [typeBLongRootMatrix_def, lie_sub, sub_lie, lie_single_single, hij₀,
+            hij₀.symm]
+
+/-- Positive and negative simple-root generators at distinct Bourbaki nodes commute. -/
+@[simp]
+theorem typeBSimpleRootGenerator_lie_negativeRoot_of_ne
+    (i j : Fin (n + 1)) (hij : i ≠ j) :
+    ⁅typeBSimpleRootGenerator (K := K) i, typeBSimpleNegativeRootGenerator (K := K) j⁆ = 0 := by
+  apply Subtype.ext
+  simpa only [coe_typeBSimpleRootGenerator, coe_typeBSimpleNegativeRootGenerator,
+    LieSubalgebra.coe_bracket, ZeroMemClass.coe_zero] using
+      lie_typeBSimpleRootMatrix_typeBSimpleNegativeRootMatrix_of_ne (K := K) i j hij
+
+/-- The higher Serre relation for the positive simple-root generators of the standard split
+type-`B` Lie algebra. The Cartan matrix is transposed to match the coroot-first convention in the
+Cartan-action relations. -/
+@[simp]
+theorem ad_pow_lie_typeBSimpleRootGenerator (i j : Fin (n + 1)) :
+    (ad K (LieAlgebra.Orthogonal.typeB (Fin (n + 1)) K)
+        (typeBSimpleRootGenerator (K := K) i) ^
+      (-(CartanMatrix.B (n + 1)).transpose i j).toNat)
+        ⁅typeBSimpleRootGenerator (K := K) i, typeBSimpleRootGenerator (K := K) j⁆ = 0 := by
+  apply Subtype.ext
+  rw [LieSubalgebra.coe_ad_pow, LieSubalgebra.coe_bracket,
+    coe_typeBSimpleRootGenerator, coe_typeBSimpleRootGenerator]
+  simp only [ZeroMemClass.coe_zero]
+  refine Fin.lastCases ?_ (fun i₀ ↦ ?_) i
+  · refine Fin.lastCases ?_ (fun j₀ ↦ ?_) j
+    · simp
+    · simp only [typeBSimpleRootMatrix_last, typeBSimpleRootMatrix_castSucc]
+      simp_rw [typeBShortRootMatrix_def, typeBLongRootMatrix_def]
+      rcases j₀ with ⟨j, hj⟩
+      have hjn : j ≠ n := by omega
+      have hnj : n ≠ j := hjn.symm
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
+        lie_single_single, Fin.ext_iff, pow_two, Module.End.mul_apply] <;>
+        omega
+  · refine Fin.lastCases ?_ (fun j₀ ↦ ?_) j
+    · simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleRootMatrix_last]
+      simp_rw [typeBLongRootMatrix_def, typeBShortRootMatrix_def]
+      rcases i₀ with ⟨i, hi⟩
+      have hin : i ≠ n := by omega
+      have hni : n ≠ i := hin.symm
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
+        lie_single_single, Fin.ext_iff] <;>
+        omega
+    · simp only [typeBSimpleRootMatrix_castSucc]
+      simp_rw [typeBLongRootMatrix_def]
+      rcases i₀ with ⟨i, hi⟩
+      rcases j₀ with ⟨j, hj⟩
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      split_ifs <;> simp only [Fin.succ_mk, map_sub, Int.reduceNeg, neg_neg,
+        Int.reduceToNat, Int.toNat_one, pow_one, neg_zero, Int.toNat_zero, pow_zero,
+        lie_sub, sub_lie, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,
+        Fin.mk.injEq, mul_one, reduceCtorEq, ↓reduceIte, sub_self, sub_zero, zero_sub,
+        neg_sub, LinearMap.sub_apply, LieAlgebra.ad_apply, Module.End.one_apply] <;>
+        (first | omega | split_ifs) <;>
+        try simp only [lie_zero, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,
+          Fin.mk.injEq, mul_one, Nat.add_eq_left, one_ne_zero, ↓reduceIte, sub_zero,
+          zero_sub, reduceCtorEq, sub_self, Nat.left_eq_add, sub_neg_eq_add, zero_add] <;>
+        simp only [Fin.ext_iff] at * <;>
+        (first | omega | (split_ifs; simp))
+      all_goals omega
+
+/-- The higher Serre relation for the negative simple-root generators of the standard split
+type-`B` Lie algebra. -/
+@[simp]
+theorem ad_pow_lie_typeBSimpleNegativeRootGenerator (i j : Fin (n + 1)) :
+    (ad K (LieAlgebra.Orthogonal.typeB (Fin (n + 1)) K)
+        (typeBSimpleNegativeRootGenerator (K := K) i) ^
+      (-(CartanMatrix.B (n + 1)).transpose i j).toNat)
+        ⁅typeBSimpleNegativeRootGenerator (K := K) i,
+          typeBSimpleNegativeRootGenerator (K := K) j⁆ = 0 := by
+  apply Subtype.ext
+  rw [LieSubalgebra.coe_ad_pow, LieSubalgebra.coe_bracket,
+    coe_typeBSimpleNegativeRootGenerator, coe_typeBSimpleNegativeRootGenerator]
+  simp only [ZeroMemClass.coe_zero]
+  refine Fin.lastCases ?_ (fun i₀ ↦ ?_) i
+  · refine Fin.lastCases ?_ (fun j₀ ↦ ?_) j
+    · simp
+    · simp only [typeBSimpleNegativeRootMatrix_last,
+        typeBSimpleNegativeRootMatrix_castSucc]
+      simp_rw [typeBShortNegativeRootMatrix_def, typeBLongRootMatrix_def]
+      rcases j₀ with ⟨j, hj⟩
+      have hjn : j ≠ n := by omega
+      have hnj : n ≠ j := hjn.symm
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
+        lie_single_single, Fin.ext_iff, pow_two, Module.End.mul_apply] <;>
+        omega
+  · refine Fin.lastCases ?_ (fun j₀ ↦ ?_) j
+    · simp only [typeBSimpleNegativeRootMatrix_castSucc,
+        typeBSimpleNegativeRootMatrix_last]
+      simp_rw [typeBLongRootMatrix_def, typeBShortNegativeRootMatrix_def]
+      rcases i₀ with ⟨i, hi⟩
+      have hin : i ≠ n := by omega
+      have hni : n ≠ i := hin.symm
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
+        lie_single_single, Fin.ext_iff] <;>
+        omega
+    · simp only [typeBSimpleNegativeRootMatrix_castSucc]
+      simp_rw [typeBLongRootMatrix_def]
+      rcases i₀ with ⟨i, hi⟩
+      rcases j₀ with ⟨j, hj⟩
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      split_ifs <;> simp only [Fin.succ_mk, map_sub, Int.reduceNeg, neg_neg,
+        Int.reduceToNat, Int.toNat_one, pow_one, neg_zero, Int.toNat_zero, pow_zero,
+        lie_sub, sub_lie, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,
+        Fin.mk.injEq, mul_one, reduceCtorEq, ↓reduceIte, sub_self, sub_zero, zero_sub,
+        neg_sub, LinearMap.sub_apply, LieAlgebra.ad_apply, Module.End.one_apply] <;>
+        (first | omega | split_ifs) <;>
+        try simp only [lie_zero, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,
+          Fin.mk.injEq, mul_one, Nat.add_eq_left, one_ne_zero, ↓reduceIte, sub_zero,
+          zero_sub, reduceCtorEq, sub_self, Nat.left_eq_add, sub_neg_eq_add, zero_add] <;>
+        simp only [Fin.ext_iff] at * <;>
+        (first | omega | (split_ifs; simp))
+      all_goals omega
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -166,7 +166,7 @@ private theorem typeBSignReindex_typeBSimpleRootMatrix (i : Fin (n + 1)) :
       simp [typeBSignReindex, typeBSignEquiv, Matrix.reindex_apply,
         typeBLongRootMatrix_def, Matrix.single_apply]
 
-private theorem LieEquiv.map_ad_pow {L L' : Type*} [LieRing L] [LieAlgebra K L]
+private theorem lieEquiv_map_ad_pow {L L' : Type*} [LieRing L] [LieAlgebra K L]
     [LieRing L'] [LieAlgebra K L'] (e : L ≃ₗ⁅K⁆ L') (x y : L) (m : ℕ) :
     e (((ad K L x) ^ m) y) = ((ad K L' (e x)) ^ m) (e y) := by
   induction m with
@@ -184,7 +184,7 @@ private theorem ad_pow_lie_typeBSimpleNegativeRootMatrix (i j : Fin (n + 1)) :
           typeBSimpleNegativeRootMatrix (K := K) j⁆ = 0 := by
   let e := typeBSignReindex (K := K) (Fin (n + 1))
   have h := congrArg e (ad_pow_lie_typeBSimpleRootMatrix (K := K) i j)
-  rw [map_zero, LieEquiv.map_ad_pow, e.map_lie,
+  rw [map_zero, lieEquiv_map_ad_pow, e.map_lie,
     typeBSignReindex_typeBSimpleRootMatrix,
     typeBSignReindex_typeBSimpleRootMatrix] at h
   simp only [neg_lie, lie_neg, neg_neg] at h

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Algebra.Lie.Orthogonal.TypeB.GeneratorRelations
 import TauCeti.Algebra.Lie.GeneralLinear.Basic
-import TauCeti.Algebra.Lie.Presentation.Serre
+public import TauCeti.Algebra.Lie.Presentation.Serre
 
 /-!
 # Serre relations in the standard split Lie algebra of type B
@@ -22,12 +22,10 @@ computations:
 * the iterated adjoint actions between two positive generators, and between two negative
   generators, vanish with the exponents prescribed by the type-`B` Cartan matrix.
 
-The reversed matrix indices encode the convention used by the existing Cartan-action API: the
-coroot index is the first index in `⁅hᵢ, eⱼ⁆`. All results hold over an arbitrary commutative
-ring, including in characteristic two. Together with the Cartan-action relations, these are the
-inputs for packaging
-the standard matrices as a `TauCeti.IsSerreSystem` and hence for mapping the integral Kostant form
-into the standard type-`B` representation.
+All results hold over an arbitrary commutative ring, including in characteristic two. Together
+with the Cartan-action relations, they package the standard matrices as a
+`TauCeti.IsSerreSystem`, the input for mapping the integral Kostant form into the standard
+type-`B` representation.
 
 ## Main results
 
@@ -37,6 +35,8 @@ into the standard type-`B` representation.
   Serre relations.
 * `TauCeti.ad_pow_lie_typeBSimpleNegativeRootGenerator_typeBSimpleNegativeRootGenerator`: the
   higher negative Serre relations.
+* `TauCeti.isSerreSystem_typeBSimpleRootGenerator`: the standard type-`B` generators form a Serre
+  system for the transposed type-`B` Cartan matrix.
 
 ## References
 
@@ -69,20 +69,46 @@ private theorem lie_typeBSimpleRootMatrix_typeBSimpleNegativeRootMatrix_of_ne
       | last => exact (hij rfl).elim
       | cast j₀ =>
           simp only [typeBSimpleRootMatrix_last, typeBSimpleNegativeRootMatrix_castSucc]
-          simp [typeBShortRootMatrix_def, typeBLongRootMatrix_def, lie_sub, sub_lie,
-            lie_single_single, hij]
+          rcases j₀ with ⟨j, hj⟩
+          rw [typeBShortRootMatrix_lie_longRootMatrix]
+          simp only [Fin.succ_mk, Fin.castSucc_mk, neg_eq_zero]
+          split_ifs with h
+          · simp only [Fin.ext_iff, Fin.val_last] at h
+            omega
+          · rfl
   | cast i₀ =>
       induction j using Fin.lastCases with
       | last =>
-          have hlast : Fin.last n ≠ i₀.castSucc := fun h ↦ hij h.symm
           simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleNegativeRootMatrix_last]
-          simp [typeBLongRootMatrix_def, typeBShortNegativeRootMatrix_def, lie_sub, sub_lie,
-            lie_single_single, hij, hlast]
+          rcases i₀ with ⟨i, hi⟩
+          calc
+            ⁅typeBLongRootMatrix (K := K) (⟨i, hi⟩ : Fin n).castSucc
+                (⟨i, hi⟩ : Fin n).succ (ne_of_lt Fin.castSucc_lt_succ),
+                typeBShortNegativeRootMatrix (Fin.last n)⁆ =
+                -⁅typeBShortNegativeRootMatrix (K := K) (Fin.last n),
+                  typeBLongRootMatrix (⟨i, hi⟩ : Fin n).castSucc
+                    (⟨i, hi⟩ : Fin n).succ (ne_of_lt Fin.castSucc_lt_succ)⁆ :=
+                      (lie_skew _ _).symm
+            _ = 0 := by
+              rw [typeBShortNegativeRootMatrix_lie_longRootMatrix]
+              simp only [neg_eq_zero]
+              split_ifs with h
+              · exact (hij h.symm).elim
+              · rfl
       | cast j₀ =>
           have hij₀ : i₀ ≠ j₀ := fun h ↦ hij (congrArg Fin.castSucc h)
           simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleNegativeRootMatrix_castSucc]
-          simp [typeBLongRootMatrix_def, lie_sub, sub_lie, lie_single_single, hij₀,
-            hij₀.symm]
+          apply typeBLongRootMatrix_lie_longRootMatrix_of_ne
+          · intro h
+            apply hij₀
+            apply Fin.ext
+            have hval := congrArg (fun x : Fin (n + 1) ↦ x.val) h
+            simp only [Fin.val_succ] at hval
+            omega
+          · intro h
+            apply hij₀
+            apply Fin.ext
+            exact congrArg (fun x : Fin (n + 1) ↦ x.val) h
 
 /-- Positive and negative simple-root generators at distinct Bourbaki nodes commute. -/
 @[simp]
@@ -98,29 +124,169 @@ private theorem lie_typeBSimpleRootMatrix_castSucc_of_nonadjacent
     (i j : Fin n) (hij : i.val + 1 ≠ j.val) (hji : j.val + 1 ≠ i.val) :
     ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
       typeBSimpleRootMatrix (K := K) j.castSucc⁆ = 0 := by
-  have hij' : i.val ≠ j.val + 1 := by omega
-  have hji' : j.val ≠ i.val + 1 := by omega
   simp only [typeBSimpleRootMatrix_castSucc]
-  simp [typeBLongRootMatrix_def, lie_sub, sub_lie, lie_single_single,
-    Fin.ext_iff, hij, hji, hij', hji']
+  apply typeBLongRootMatrix_lie_longRootMatrix_of_ne
+  · intro h
+    have hval := congrArg Fin.val h
+    simp only [Fin.val_succ, Fin.val_castSucc] at hval
+    exact hij hval
+  · intro h
+    have hval := congrArg Fin.val h
+    simp only [Fin.val_succ, Fin.val_castSucc] at hval
+    exact hji hval.symm
 
-private theorem lie_lie_typeBSimpleRootMatrix_castSucc_of_adjacent
-    (i j : Fin n) (hij : i.val + 1 = j.val ∨ j.val + 1 = i.val) :
+private theorem lie_lie_typeBSimpleRootMatrix_castSucc (i j : Fin n) :
     ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
       ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
         typeBSimpleRootMatrix (K := K) j.castSucc⁆⁆ = 0 := by
+  by_cases hij : i.val + 1 = j.val
+  · have hmid : i.succ = j.castSucc := Fin.ext hij
+    have hout : i.castSucc ≠ j.succ := by
+      intro h
+      have hval := congrArg Fin.val h
+      simp only [Fin.val_castSucc, Fin.val_succ] at hval
+      omega
+    have hinner :
+        ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+          typeBSimpleRootMatrix (K := K) j.castSucc⁆ =
+            typeBLongRootMatrix i.castSucc j.succ hout := by
+      simp only [typeBSimpleRootMatrix_castSucc]
+      exact typeBLongRootMatrix_lie_longRootMatrix_chain (K := K)
+        i.castSucc i.succ j.castSucc j.succ (ne_of_lt i.castSucc_lt_succ)
+        (ne_of_lt j.castSucc_lt_succ) hmid hout
+    rw [hinner]
+    simp only [typeBSimpleRootMatrix_castSucc]
+    apply typeBLongRootMatrix_lie_longRootMatrix_of_ne
+    · intro h
+      have hval := congrArg Fin.val h
+      simp only [Fin.val_succ, Fin.val_castSucc] at hval
+      omega
+    · exact hout
+  · by_cases hji : j.val + 1 = i.val
+    · have hmid : j.succ = i.castSucc := Fin.ext hji
+      have hout : j.castSucc ≠ i.succ := by
+        intro h
+        have hval := congrArg Fin.val h
+        simp only [Fin.val_castSucc, Fin.val_succ] at hval
+        omega
+      have hreverse :
+          ⁅typeBSimpleRootMatrix (K := K) j.castSucc,
+            typeBSimpleRootMatrix (K := K) i.castSucc⁆ =
+              typeBLongRootMatrix j.castSucc i.succ hout := by
+        simp only [typeBSimpleRootMatrix_castSucc]
+        exact typeBLongRootMatrix_lie_longRootMatrix_chain (K := K)
+          j.castSucc j.succ i.castSucc i.succ (ne_of_lt j.castSucc_lt_succ)
+          (ne_of_lt i.castSucc_lt_succ) hmid hout
+      have hinner :
+          ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+            typeBSimpleRootMatrix (K := K) j.castSucc⁆ =
+              -typeBLongRootMatrix j.castSucc i.succ hout := by
+        calc
+          ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+              typeBSimpleRootMatrix (K := K) j.castSucc⁆ =
+              -⁅typeBSimpleRootMatrix (K := K) j.castSucc,
+                typeBSimpleRootMatrix (K := K) i.castSucc⁆ := (lie_skew _ _).symm
+          _ = -typeBLongRootMatrix j.castSucc i.succ hout := by rw [hreverse]
+      rw [hinner, lie_neg]
+      simp only [typeBSimpleRootMatrix_castSucc, neg_eq_zero]
+      apply typeBLongRootMatrix_lie_longRootMatrix_of_ne
+      · intro h
+        have hval := congrArg Fin.val h
+        simp only [Fin.val_succ, Fin.val_castSucc] at hval
+        omega
+      · exact ne_of_lt i.castSucc_lt_succ
+    · rw [lie_typeBSimpleRootMatrix_castSucc_of_nonadjacent (K := K) i j hij hji,
+        lie_zero]
+
+private theorem neg_typeBCartan_castSucc_castSucc_toNat (i j : Fin n) :
+    (-CartanMatrix.B (n + 1) j.castSucc i.castSucc).toNat =
+      if i.val + 1 = j.val ∨ j.val + 1 = i.val then 1 else 0 := by
+  simp only [CartanMatrix.B, Matrix.of_apply, Fin.ext_iff,
+    Fin.val_castSucc]
+  split_ifs <;> omega
+
+private theorem neg_typeBCartan_last_castSucc_toNat (j : Fin n) :
+    (-CartanMatrix.B (n + 1) j.castSucc (Fin.last n)).toNat =
+      if j.val + 1 = n then 2 else 0 := by
+  simp only [CartanMatrix.B, Matrix.of_apply, Fin.ext_iff,
+    Fin.val_castSucc, Fin.val_last]
+  split_ifs <;> omega
+
+private theorem neg_typeBCartan_castSucc_last_toNat (i : Fin n) :
+    (-CartanMatrix.B (n + 1) (Fin.last n) i.castSucc).toNat =
+      if i.val + 1 = n then 1 else 0 := by
+  simp only [CartanMatrix.B, Matrix.of_apply, Fin.ext_iff,
+    Fin.val_castSucc, Fin.val_last]
+  split_ifs <;> omega
+
+private theorem lie_typeBSimpleRootMatrix_last_castSucc_of_nonadjacent
+    (j : Fin n) (hj : j.val + 1 ≠ n) :
+    ⁅typeBSimpleRootMatrix (K := K) (Fin.last n),
+      typeBSimpleRootMatrix (K := K) j.castSucc⁆ = 0 := by
+  simp only [typeBSimpleRootMatrix_last, typeBSimpleRootMatrix_castSucc]
+  rw [typeBShortRootMatrix_lie_longRootMatrix]
+  simp only [neg_eq_zero]
+  split_ifs with h
+  · have hval := congrArg Fin.val h
+    simp only [Fin.val_last, Fin.val_succ] at hval
+    exact (hj hval.symm).elim
+  · rfl
+
+private theorem lie_typeBSimpleRootMatrix_castSucc_last_of_nonadjacent
+    (i : Fin n) (hi : i.val + 1 ≠ n) :
+    ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+      typeBSimpleRootMatrix (K := K) (Fin.last n)⁆ = 0 := by
+  calc
+    ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+        typeBSimpleRootMatrix (K := K) (Fin.last n)⁆ =
+        -⁅typeBSimpleRootMatrix (K := K) (Fin.last n),
+          typeBSimpleRootMatrix (K := K) i.castSucc⁆ := (lie_skew _ _).symm
+    _ = 0 := neg_eq_zero.mpr
+      (lie_typeBSimpleRootMatrix_last_castSucc_of_nonadjacent (K := K) i hi)
+
+private theorem ad_sq_lie_typeBSimpleRootMatrix_last_castSucc
+    (j : Fin n) (hj : j.val + 1 = n) :
+    (ad K (Matrix (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1))
+        (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1)) K)
+        (typeBSimpleRootMatrix (K := K) (Fin.last n)) ^ 2)
+      ⁅typeBSimpleRootMatrix (K := K) (Fin.last n),
+        typeBSimpleRootMatrix (K := K) j.castSucc⁆ = 0 := by
+  simp only [pow_two, Module.End.mul_apply, LieAlgebra.ad_apply,
+    typeBSimpleRootMatrix_last, typeBSimpleRootMatrix_castSucc]
+  rw [typeBShortRootMatrix_lie_longRootMatrix]
+  have hlast : Fin.last n = j.succ := Fin.ext (by simp only [Fin.val_last, Fin.val_succ]; omega)
+  rw [ite_eq_left hlast]
+  simp only [lie_neg, neg_eq_zero]
+  simp [typeBShortRootMatrix_def, lie_sub, sub_lie, lie_single_single]
+
+private theorem lie_lie_typeBSimpleRootMatrix_castSucc_last
+    (i : Fin n) (hi : i.val + 1 = n) :
+    ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+      ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+        typeBSimpleRootMatrix (K := K) (Fin.last n)⁆⁆ = 0 := by
+  have hlast : Fin.last n = i.succ := Fin.ext (by simp only [Fin.val_last, Fin.val_succ]; omega)
+  have hne : i.castSucc ≠ i.succ := ne_of_lt i.castSucc_lt_succ
+  have hinner :
+      ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+        typeBSimpleRootMatrix (K := K) (Fin.last n)⁆ =
+          typeBShortRootMatrix i.castSucc := by
+    simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleRootMatrix_last]
+    calc
+      ⁅typeBLongRootMatrix (K := K) i.castSucc i.succ hne,
+          typeBShortRootMatrix (Fin.last n)⁆ =
+          -⁅typeBShortRootMatrix (K := K) (Fin.last n),
+            typeBLongRootMatrix i.castSucc i.succ hne⁆ := (lie_skew _ _).symm
+      _ = typeBShortRootMatrix i.castSucc := by
+        rw [typeBShortRootMatrix_lie_longRootMatrix, ite_eq_left hlast]
+        simp
+  rw [hinner]
   simp only [typeBSimpleRootMatrix_castSucc]
-  rcases hij with hij | hji
-  · have hne : i.val ≠ j.val := by omega
-    have hne' : j.val ≠ i.val := hne.symm
-    have hreverse : j.val + 1 ≠ i.val := by omega
-    have hreverse' : i.val ≠ j.val + 1 := by omega
-    simp [typeBLongRootMatrix_def, lie_sub, sub_lie, lie_single_single,
-      Fin.ext_iff, hij, hne, hne', hreverse, hreverse']
-  · have hreverse : i.val + 1 ≠ j.val := by omega
-    have hreverse' : j.val ≠ i.val + 1 := by omega
-    simp [typeBLongRootMatrix_def, lie_sub, sub_lie, lie_single_single,
-      Fin.ext_iff, hji, hreverse, hreverse']
+  calc
+    ⁅typeBLongRootMatrix (K := K) i.castSucc i.succ hne,
+        typeBShortRootMatrix i.castSucc⁆ =
+        -⁅typeBShortRootMatrix (K := K) i.castSucc,
+          typeBLongRootMatrix i.castSucc i.succ hne⁆ := (lie_skew _ _).symm
+    _ = 0 := by rw [typeBShortRootMatrix_lie_longRootMatrix]; simp [hne]
 
 /- The four `Fin.lastCases` branches separate ordinary long-root nodes from the terminal short-root
 node. Only the positive orientation is computed: the sign-reindexing below transports it to the
@@ -134,56 +300,26 @@ private theorem ad_pow_lie_typeBSimpleRootMatrix (i j : Fin (n + 1)) :
   refine Fin.lastCases ?_ (fun i₀ ↦ ?_) i
   · refine Fin.lastCases ?_ (fun j₀ ↦ ?_) j
     · simp
-    · simp only [typeBSimpleRootMatrix_last, typeBSimpleRootMatrix_castSucc]
-      simp_rw [typeBShortRootMatrix_def, typeBLongRootMatrix_def]
-      rcases j₀ with ⟨j, hj⟩
-      have hjn : j ≠ n := by omega
-      have hnj : n ≠ j := hjn.symm
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
-      split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
-        lie_single_single, Fin.ext_iff, pow_two, Module.End.mul_apply] <;>
-        omega
+    · rw [neg_typeBCartan_last_castSucc_toNat]
+      by_cases hj : j₀.val + 1 = n
+      · rw [ite_eq_left hj]
+        exact ad_sq_lie_typeBSimpleRootMatrix_last_castSucc (K := K) j₀ hj
+      · rw [ite_eq_right hj, pow_zero, Module.End.one_apply]
+        exact lie_typeBSimpleRootMatrix_last_castSucc_of_nonadjacent (K := K) j₀ hj
   · refine Fin.lastCases ?_ (fun j₀ ↦ ?_) j
-    · simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleRootMatrix_last]
-      simp_rw [typeBLongRootMatrix_def, typeBShortRootMatrix_def]
-      rcases i₀ with ⟨i, hi⟩
-      have hin : i ≠ n := by omega
-      have hni : n ≠ i := hin.symm
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
-      split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
-        lie_single_single, Fin.ext_iff] <;>
-        omega
-    · rcases i₀ with ⟨i, hi⟩
-      rcases j₀ with ⟨j, hj⟩
-      by_cases hij : i = j
-      · subst j
-        simp only [lie_self, map_zero]
-      · by_cases hij' : i + 1 = j
-        · have hpow :
-              (-CartanMatrix.B (n + 1) (⟨j, hj⟩ : Fin n).castSucc
-                (⟨i, hi⟩ : Fin n).castSucc).toNat = 1 := by
-            simp [CartanMatrix.B, Matrix.of_apply, Fin.ext_iff]
-            omega
-          rw [hpow, pow_one, LieAlgebra.ad_apply]
-          exact lie_lie_typeBSimpleRootMatrix_castSucc_of_adjacent
-            (K := K) ⟨i, hi⟩ ⟨j, hj⟩ (Or.inl hij')
-        · by_cases hji' : j + 1 = i
-          · have hpow :
-                (-CartanMatrix.B (n + 1) (⟨j, hj⟩ : Fin n).castSucc
-                  (⟨i, hi⟩ : Fin n).castSucc).toNat = 1 := by
-              simp [CartanMatrix.B, Matrix.of_apply, Fin.ext_iff]
-              omega
-            rw [hpow, pow_one, LieAlgebra.ad_apply]
-            exact lie_lie_typeBSimpleRootMatrix_castSucc_of_adjacent
-              (K := K) ⟨i, hi⟩ ⟨j, hj⟩ (Or.inr hji')
-          · have hpow :
-                (-CartanMatrix.B (n + 1) (⟨j, hj⟩ : Fin n).castSucc
-                  (⟨i, hi⟩ : Fin n).castSucc).toNat = 0 := by
-              simp [CartanMatrix.B, Matrix.of_apply, Fin.ext_iff]
-              omega
-            rw [hpow, pow_zero, Module.End.one_apply]
-            exact lie_typeBSimpleRootMatrix_castSucc_of_nonadjacent
-              (K := K) ⟨i, hi⟩ ⟨j, hj⟩ hij' hji'
+    · rw [neg_typeBCartan_castSucc_last_toNat]
+      by_cases hi : i₀.val + 1 = n
+      · rw [ite_eq_left hi, pow_one, LieAlgebra.ad_apply]
+        exact lie_lie_typeBSimpleRootMatrix_castSucc_last (K := K) i₀ hi
+      · rw [ite_eq_right hi, pow_zero, Module.End.one_apply]
+        exact lie_typeBSimpleRootMatrix_castSucc_last_of_nonadjacent (K := K) i₀ hi
+    · rw [neg_typeBCartan_castSucc_castSucc_toNat]
+      by_cases hij : i₀.val + 1 = j₀.val ∨ j₀.val + 1 = i₀.val
+      · rw [ite_eq_left hij, pow_one, LieAlgebra.ad_apply]
+        exact lie_lie_typeBSimpleRootMatrix_castSucc (K := K) i₀ j₀
+      · rw [ite_eq_right hij, pow_zero, Module.End.one_apply]
+        exact lie_typeBSimpleRootMatrix_castSucc_of_nonadjacent (K := K) i₀ j₀
+          (not_or.mp hij).1 (not_or.mp hij).2
 
 /-- The coordinate equivalence that fixes the middle coordinate and swaps the signed blocks. -/
 private def typeBSignEquiv (ι : Type*) : Unit ⊕ ι ⊕ ι ≃ Unit ⊕ ι ⊕ ι :=
@@ -227,8 +363,7 @@ private theorem ad_pow_lie_typeBSimpleNegativeRootMatrix (i j : Fin (n + 1)) :
   simpa only [neg_neg] using ad_neg_pow_apply_eq_zero h
 
 /-- The higher Serre relation for the positive simple-root generators of the standard split
-type-`B` Lie algebra. The reversed Cartan-matrix indices match the coroot-first convention in the
-Cartan-action relations. -/
+type-`B` Lie algebra. -/
 @[simp]
 theorem ad_pow_lie_typeBSimpleRootGenerator_typeBSimpleRootGenerator
     (i j : Fin (n + 1)) :
@@ -257,5 +392,27 @@ theorem ad_pow_lie_typeBSimpleNegativeRootGenerator_typeBSimpleNegativeRootGener
     coe_typeBSimpleNegativeRootGenerator, coe_typeBSimpleNegativeRootGenerator]
   simp only [ZeroMemClass.coe_zero]
   exact ad_pow_lie_typeBSimpleNegativeRootMatrix i j
+
+/-- The standard type-`B` Chevalley generators satisfy the Serre relations for the transposed
+type-`B` Cartan matrix, in the convention used by `IsSerreSystem`. -/
+theorem isSerreSystem_typeBSimpleRootGenerator :
+    IsSerreSystem K (CartanMatrix.B (n + 1))ᵀ
+      (typeBSimpleCorootGenerator (K := K))
+      (typeBSimpleRootGenerator (K := K))
+      (typeBSimpleNegativeRootGenerator (K := K)) where
+  lie_H_H := typeBSimpleCorootGenerator_lie_eq_zero
+  lie_E_F_self := typeBSimpleRootGenerator_lie_negative
+  lie_E_F_of_ne := typeBSimpleRootGenerator_lie_negative_of_ne
+  lie_H_E i j := by
+    simpa only [Matrix.transpose_apply] using typeBSimpleCorootGenerator_lie_root (K := K) i j
+  lie_H_F i j := by
+    simpa only [Matrix.transpose_apply] using
+      typeBSimpleCorootGenerator_lie_negativeRoot (K := K) i j
+  ad_pow_lie_E_E i j := by
+    simpa only [Matrix.transpose_apply] using
+      ad_pow_lie_typeBSimpleRootGenerator_typeBSimpleRootGenerator (K := K) i j
+  ad_pow_lie_F_F i j := by
+    simpa only [Matrix.transpose_apply] using
+      ad_pow_lie_typeBSimpleNegativeRootGenerator_typeBSimpleNegativeRootGenerator (K := K) i j
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -20,11 +20,12 @@ computations:
 
 * positive and negative generators at distinct simple nodes commute;
 * the iterated adjoint actions between two positive generators, and between two negative
-  generators, vanish with the exponents prescribed by the transposed type-`B` Cartan matrix.
+  generators, vanish with the exponents prescribed by the type-`B` Cartan matrix.
 
-The transpose is the convention used by the existing Cartan-action API: the coroot index is the
-first index in `⁅hᵢ, eⱼ⁆`. All results hold over an arbitrary commutative ring, including in
-characteristic two. Together with the Cartan-action relations, these are the inputs for packaging
+The reversed matrix indices encode the convention used by the existing Cartan-action API: the
+coroot index is the first index in `⁅hᵢ, eⱼ⁆`. All results hold over an arbitrary commutative
+ring, including in characteristic two. Together with the Cartan-action relations, these are the
+inputs for packaging
 the standard matrices as a `TauCeti.IsSerreSystem` and hence for mapping the integral Kostant form
 into the standard type-`B` representation.
 
@@ -92,13 +93,13 @@ theorem typeBSimpleRootGenerator_lie_negativeRoot_of_ne
       lie_typeBSimpleRootMatrix_typeBSimpleNegativeRootMatrix_of_ne (K := K) i j hij
 
 /-- The higher Serre relation for the positive simple-root generators of the standard split
-type-`B` Lie algebra. The Cartan matrix is transposed to match the coroot-first convention in the
+type-`B` Lie algebra. The reversed Cartan-matrix indices match the coroot-first convention in the
 Cartan-action relations. -/
 @[simp]
 theorem ad_pow_lie_typeBSimpleRootGenerator (i j : Fin (n + 1)) :
     (ad K (LieAlgebra.Orthogonal.typeB (Fin (n + 1)) K)
         (typeBSimpleRootGenerator (K := K) i) ^
-      (-(CartanMatrix.B (n + 1)).transpose i j).toNat)
+      (-CartanMatrix.B (n + 1) j i).toNat)
         ⁅typeBSimpleRootGenerator (K := K) i, typeBSimpleRootGenerator (K := K) j⁆ = 0 := by
   apply Subtype.ext
   rw [LieSubalgebra.coe_ad_pow, LieSubalgebra.coe_bracket,
@@ -112,7 +113,7 @@ theorem ad_pow_lie_typeBSimpleRootGenerator (i j : Fin (n + 1)) :
       rcases j₀ with ⟨j, hj⟩
       have hjn : j ≠ n := by omega
       have hnj : n ≠ j := hjn.symm
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
       split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
         lie_single_single, Fin.ext_iff, pow_two, Module.End.mul_apply] <;>
         omega
@@ -122,7 +123,7 @@ theorem ad_pow_lie_typeBSimpleRootGenerator (i j : Fin (n + 1)) :
       rcases i₀ with ⟨i, hi⟩
       have hin : i ≠ n := by omega
       have hni : n ≠ i := hin.symm
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
       split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
         lie_single_single, Fin.ext_iff] <;>
         omega
@@ -130,7 +131,7 @@ theorem ad_pow_lie_typeBSimpleRootGenerator (i j : Fin (n + 1)) :
       simp_rw [typeBLongRootMatrix_def]
       rcases i₀ with ⟨i, hi⟩
       rcases j₀ with ⟨j, hj⟩
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
       split_ifs <;> simp only [Fin.succ_mk, map_sub, Int.reduceNeg, neg_neg,
         Int.reduceToNat, Int.toNat_one, pow_one, neg_zero, Int.toNat_zero, pow_zero,
         lie_sub, sub_lie, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,
@@ -150,7 +151,7 @@ type-`B` Lie algebra. -/
 theorem ad_pow_lie_typeBSimpleNegativeRootGenerator (i j : Fin (n + 1)) :
     (ad K (LieAlgebra.Orthogonal.typeB (Fin (n + 1)) K)
         (typeBSimpleNegativeRootGenerator (K := K) i) ^
-      (-(CartanMatrix.B (n + 1)).transpose i j).toNat)
+      (-CartanMatrix.B (n + 1) j i).toNat)
         ⁅typeBSimpleNegativeRootGenerator (K := K) i,
           typeBSimpleNegativeRootGenerator (K := K) j⁆ = 0 := by
   apply Subtype.ext
@@ -166,7 +167,7 @@ theorem ad_pow_lie_typeBSimpleNegativeRootGenerator (i j : Fin (n + 1)) :
       rcases j₀ with ⟨j, hj⟩
       have hjn : j ≠ n := by omega
       have hnj : n ≠ j := hjn.symm
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
       split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
         lie_single_single, Fin.ext_iff, pow_two, Module.End.mul_apply] <;>
         omega
@@ -177,7 +178,7 @@ theorem ad_pow_lie_typeBSimpleNegativeRootGenerator (i j : Fin (n + 1)) :
       rcases i₀ with ⟨i, hi⟩
       have hin : i ≠ n := by omega
       have hni : n ≠ i := hin.symm
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
       split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
         lie_single_single, Fin.ext_iff] <;>
         omega
@@ -185,7 +186,7 @@ theorem ad_pow_lie_typeBSimpleNegativeRootGenerator (i j : Fin (n + 1)) :
       simp_rw [typeBLongRootMatrix_def]
       rcases i₀ with ⟨i, hi⟩
       rcases j₀ with ⟨j, hj⟩
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.transpose_apply, Matrix.of_apply]
+      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
       split_ifs <;> simp only [Fin.succ_mk, map_sub, Int.reduceNeg, neg_neg,
         Int.reduceToNat, Int.toNat_one, pow_one, neg_zero, Int.toNat_zero, pow_zero,
         lie_sub, sub_lie, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -7,7 +7,9 @@ module
 
 public import Mathlib.LinearAlgebra.Matrix.Cartan
 public import TauCeti.Algebra.Lie.Orthogonal.TypeB.GeneratorRelations
+public import TauCeti.Algebra.Lie.Presentation.Basic
 import TauCeti.Algebra.Lie.GeneralLinear.Basic
+import TauCeti.Algebra.Lie.Presentation.Serre
 
 /-!
 # Serre relations in the standard split Lie algebra of type B
@@ -158,22 +160,12 @@ private theorem typeBSignReindex_typeBSimpleRootMatrix (i : Fin (n + 1)) :
       -typeBSimpleNegativeRootMatrix (K := K) i := by
   refine Fin.lastCases ?_ (fun i₀ ↦ ?_) i
   · simp only [typeBSimpleRootMatrix_last, typeBSimpleNegativeRootMatrix_last]
-    ext (a | (a | a)) (b | (b | b)) <;>
-      simp [typeBSignReindex, typeBSignEquiv, Matrix.reindex_apply,
-        typeBShortRootMatrix_def, typeBShortNegativeRootMatrix_def, Matrix.single_apply]
+    simp [typeBSignReindex, typeBSignEquiv, Matrix.reindex_apply,
+      Matrix.submatrix_sub, Matrix.submatrix_single_equiv, typeBShortRootMatrix_def,
+      typeBShortNegativeRootMatrix_def]
   · simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleNegativeRootMatrix_castSucc]
-    ext (a | (a | a)) (b | (b | b)) <;>
-      simp [typeBSignReindex, typeBSignEquiv, Matrix.reindex_apply,
-        typeBLongRootMatrix_def, Matrix.single_apply]
-
-private theorem lieEquiv_map_ad_pow {L L' : Type*} [LieRing L] [LieAlgebra K L]
-    [LieRing L'] [LieAlgebra K L'] (e : L ≃ₗ⁅K⁆ L') (x y : L) (m : ℕ) :
-    e (((ad K L x) ^ m) y) = ((ad K L' (e x)) ^ m) (e y) := by
-  induction m with
-  | zero => simp
-  | succ m ih =>
-      rw [pow_succ', Module.End.mul_apply, LieAlgebra.ad_apply, e.map_lie, ih,
-        pow_succ', Module.End.mul_apply, LieAlgebra.ad_apply]
+    simp [typeBSignReindex, typeBSignEquiv, Matrix.reindex_apply,
+      Matrix.submatrix_sub, Matrix.submatrix_single_equiv, typeBLongRootMatrix_def]
 
 private theorem ad_pow_lie_typeBSimpleNegativeRootMatrix (i j : Fin (n + 1)) :
     (ad K (Matrix (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1))
@@ -183,23 +175,16 @@ private theorem ad_pow_lie_typeBSimpleNegativeRootMatrix (i j : Fin (n + 1)) :
         ⁅typeBSimpleNegativeRootMatrix (K := K) i,
           typeBSimpleNegativeRootMatrix (K := K) j⁆ = 0 := by
   let e := typeBSignReindex (K := K) (Fin (n + 1))
-  have h := congrArg e (ad_pow_lie_typeBSimpleRootMatrix (K := K) i j)
-  rw [map_zero, lieEquiv_map_ad_pow, e.map_lie,
-    typeBSignReindex_typeBSimpleRootMatrix,
-    typeBSignReindex_typeBSimpleRootMatrix] at h
+  have h := congrArg e.toLieHom (ad_pow_lie_typeBSimpleRootMatrix (K := K) i j)
+  have he (k : Fin (n + 1)) :
+      e.toLieHom (typeBSimpleRootMatrix (K := K) k) =
+        -typeBSimpleNegativeRootMatrix (K := K) k := by
+    change e (typeBSimpleRootMatrix (K := K) k) = _
+    simpa [e] using typeBSignReindex_typeBSimpleRootMatrix (K := K) k
+  rw [map_zero, LieHom.map_ad_pow, LieHom.map_lie,
+    he i, he j] at h
   simp only [neg_lie, lie_neg, neg_neg] at h
-  have had :
-      ad K (Matrix (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1))
-        (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1)) K)
-          (-typeBSimpleNegativeRootMatrix (K := K) i) =
-        -ad K (Matrix (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1))
-          (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1)) K)
-            (typeBSimpleNegativeRootMatrix (K := K) i) := by
-    exact map_neg (ad K _) _
-  rw [had] at h
-  rcases Nat.even_or_odd (-CartanMatrix.B (n + 1) j i).toNat with he | ho
-  · simpa only [he.neg_pow] using h
-  · simpa only [ho.neg_pow, LinearMap.neg_apply, neg_eq_zero] using h
+  simpa only [neg_neg] using ad_neg_pow_apply_eq_zero h
 
 /-- The higher Serre relation for the positive simple-root generators of the standard split
 type-`B` Lie algebra. The reversed Cartan-matrix indices match the coroot-first convention in the

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -33,7 +33,7 @@ into the standard type-`B` representation.
 
 ## Main results
 
-* `TauCeti.typeBSimpleRootGenerator_lie_negativeRoot_of_ne`: distinct positive and negative
+* `TauCeti.typeBSimpleRootGenerator_lie_negative_of_ne`: distinct positive and negative
   simple-root generators commute.
 * `TauCeti.ad_pow_lie_typeBSimpleRootGenerator_typeBSimpleRootGenerator`: the higher positive
   Serre relations.
@@ -88,13 +88,41 @@ private theorem lie_typeBSimpleRootMatrix_typeBSimpleNegativeRootMatrix_of_ne
 
 /-- Positive and negative simple-root generators at distinct Bourbaki nodes commute. -/
 @[simp]
-theorem typeBSimpleRootGenerator_lie_negativeRoot_of_ne
+theorem typeBSimpleRootGenerator_lie_negative_of_ne
     (i j : Fin (n + 1)) (hij : i ≠ j) :
     ⁅typeBSimpleRootGenerator (K := K) i, typeBSimpleNegativeRootGenerator (K := K) j⁆ = 0 := by
   apply Subtype.ext
   simpa only [coe_typeBSimpleRootGenerator, coe_typeBSimpleNegativeRootGenerator,
     LieSubalgebra.coe_bracket, ZeroMemClass.coe_zero] using
       lie_typeBSimpleRootMatrix_typeBSimpleNegativeRootMatrix_of_ne (K := K) i j hij
+
+private theorem lie_typeBSimpleRootMatrix_castSucc_of_nonadjacent
+    (i j : Fin n) (hij : i.val + 1 ≠ j.val) (hji : j.val + 1 ≠ i.val) :
+    ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+      typeBSimpleRootMatrix (K := K) j.castSucc⁆ = 0 := by
+  have hij' : i.val ≠ j.val + 1 := by omega
+  have hji' : j.val ≠ i.val + 1 := by omega
+  simp only [typeBSimpleRootMatrix_castSucc]
+  simp [typeBLongRootMatrix_def, lie_sub, sub_lie, lie_single_single,
+    Fin.ext_iff, hij, hji, hij', hji']
+
+private theorem lie_lie_typeBSimpleRootMatrix_castSucc_of_adjacent
+    (i j : Fin n) (hij : i.val + 1 = j.val ∨ j.val + 1 = i.val) :
+    ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+      ⁅typeBSimpleRootMatrix (K := K) i.castSucc,
+        typeBSimpleRootMatrix (K := K) j.castSucc⁆⁆ = 0 := by
+  simp only [typeBSimpleRootMatrix_castSucc]
+  rcases hij with hij | hji
+  · have hne : i.val ≠ j.val := by omega
+    have hne' : j.val ≠ i.val := hne.symm
+    have hreverse : j.val + 1 ≠ i.val := by omega
+    have hreverse' : i.val ≠ j.val + 1 := by omega
+    simp [typeBLongRootMatrix_def, lie_sub, sub_lie, lie_single_single,
+      Fin.ext_iff, hij, hne, hne', hreverse, hreverse']
+  · have hreverse : i.val + 1 ≠ j.val := by omega
+    have hreverse' : j.val ≠ i.val + 1 := by omega
+    simp [typeBLongRootMatrix_def, lie_sub, sub_lie, lie_single_single,
+      Fin.ext_iff, hji, hreverse, hreverse']
 
 /- The four `Fin.lastCases` branches separate ordinary long-root nodes from the terminal short-root
 node. Only the positive orientation is computed: the sign-reindexing below transports it to the
@@ -127,23 +155,37 @@ private theorem ad_pow_lie_typeBSimpleRootMatrix (i j : Fin (n + 1)) :
       split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
         lie_single_single, Fin.ext_iff] <;>
         omega
-    · simp only [typeBSimpleRootMatrix_castSucc]
-      simp_rw [typeBLongRootMatrix_def]
-      rcases i₀ with ⟨i, hi⟩
+    · rcases i₀ with ⟨i, hi⟩
       rcases j₀ with ⟨j, hj⟩
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
-      split_ifs <;> simp only [Fin.succ_mk, map_sub, Int.reduceNeg, neg_neg,
-        Int.reduceToNat, Int.toNat_one, pow_one, neg_zero, Int.toNat_zero, pow_zero,
-        lie_sub, sub_lie, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,
-        Fin.mk.injEq, mul_one, reduceCtorEq, ↓reduceIte, sub_self, sub_zero, zero_sub,
-        neg_sub, LinearMap.sub_apply, LieAlgebra.ad_apply, Module.End.one_apply] <;>
-        (first | omega | split_ifs) <;>
-        try simp only [lie_zero, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,
-          Fin.mk.injEq, mul_one, Nat.add_eq_left, one_ne_zero, ↓reduceIte, sub_zero,
-          zero_sub, reduceCtorEq, sub_self, Nat.left_eq_add, sub_neg_eq_add, zero_add] <;>
-        simp only [Fin.ext_iff] at * <;>
-        (first | omega | (split_ifs; simp))
-      all_goals omega
+      by_cases hij : i = j
+      · subst j
+        simp only [lie_self, map_zero]
+      · by_cases hij' : i + 1 = j
+        · have hpow :
+              (-CartanMatrix.B (n + 1) (⟨j, hj⟩ : Fin n).castSucc
+                (⟨i, hi⟩ : Fin n).castSucc).toNat = 1 := by
+            simp [CartanMatrix.B, Matrix.of_apply, Fin.ext_iff]
+            omega
+          rw [hpow, pow_one, LieAlgebra.ad_apply]
+          exact lie_lie_typeBSimpleRootMatrix_castSucc_of_adjacent
+            (K := K) ⟨i, hi⟩ ⟨j, hj⟩ (Or.inl hij')
+        · by_cases hji' : j + 1 = i
+          · have hpow :
+                (-CartanMatrix.B (n + 1) (⟨j, hj⟩ : Fin n).castSucc
+                  (⟨i, hi⟩ : Fin n).castSucc).toNat = 1 := by
+              simp [CartanMatrix.B, Matrix.of_apply, Fin.ext_iff]
+              omega
+            rw [hpow, pow_one, LieAlgebra.ad_apply]
+            exact lie_lie_typeBSimpleRootMatrix_castSucc_of_adjacent
+              (K := K) ⟨i, hi⟩ ⟨j, hj⟩ (Or.inr hji')
+          · have hpow :
+                (-CartanMatrix.B (n + 1) (⟨j, hj⟩ : Fin n).castSucc
+                  (⟨i, hi⟩ : Fin n).castSucc).toNat = 0 := by
+              simp [CartanMatrix.B, Matrix.of_apply, Fin.ext_iff]
+              omega
+            rw [hpow, pow_zero, Module.End.one_apply]
+            exact lie_typeBSimpleRootMatrix_castSucc_of_nonadjacent
+              (K := K) ⟨i, hi⟩ ⟨j, hj⟩ hij' hji'
 
 /-- The coordinate equivalence that fixes the middle coordinate and swaps the signed blocks. -/
 private def typeBSignEquiv (ι : Type*) : Unit ⊕ ι ⊕ ι ≃ Unit ⊕ ι ⊕ ι :=
@@ -179,8 +221,8 @@ private theorem ad_pow_lie_typeBSimpleNegativeRootMatrix (i j : Fin (n + 1)) :
   have he (k : Fin (n + 1)) :
       e.toLieHom (typeBSimpleRootMatrix (K := K) k) =
         -typeBSimpleNegativeRootMatrix (K := K) k := by
-    change e (typeBSimpleRootMatrix (K := K) k) = _
-    simpa [e] using typeBSignReindex_typeBSimpleRootMatrix (K := K) k
+    simpa only [LieEquiv.coe_toLieHom, e] using
+      typeBSignReindex_typeBSimpleRootMatrix (K := K) k
   rw [map_zero, LieHom.map_ad_pow, LieHom.map_lie,
     he i, he j] at h
   simp only [neg_lie, lie_neg, neg_neg] at h

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -33,8 +33,10 @@ into the standard type-`B` representation.
 
 * `TauCeti.typeBSimpleRootGenerator_lie_negativeRoot_of_ne`: distinct positive and negative
   simple-root generators commute.
-* `TauCeti.ad_pow_lie_typeBSimpleRootGenerator`: the higher positive Serre relations.
-* `TauCeti.ad_pow_lie_typeBSimpleNegativeRootGenerator`: the higher negative Serre relations.
+* `TauCeti.ad_pow_lie_typeBSimpleRootGenerator_typeBSimpleRootGenerator`: the higher positive
+  Serre relations.
+* `TauCeti.ad_pow_lie_typeBSimpleNegativeRootGenerator_typeBSimpleNegativeRootGenerator`: the
+  higher negative Serre relations.
 
 ## References
 
@@ -92,19 +94,15 @@ theorem typeBSimpleRootGenerator_lie_negativeRoot_of_ne
     LieSubalgebra.coe_bracket, ZeroMemClass.coe_zero] using
       lie_typeBSimpleRootMatrix_typeBSimpleNegativeRootMatrix_of_ne (K := K) i j hij
 
-/-- The higher Serre relation for the positive simple-root generators of the standard split
-type-`B` Lie algebra. The reversed Cartan-matrix indices match the coroot-first convention in the
-Cartan-action relations. -/
-@[simp]
-theorem ad_pow_lie_typeBSimpleRootGenerator (i j : Fin (n + 1)) :
-    (ad K (LieAlgebra.Orthogonal.typeB (Fin (n + 1)) K)
-        (typeBSimpleRootGenerator (K := K) i) ^
+/- The four `Fin.lastCases` branches separate ordinary long-root nodes from the terminal short-root
+node. Only the positive orientation is computed: the sign-reindexing below transports it to the
+negative orientation. -/
+private theorem ad_pow_lie_typeBSimpleRootMatrix (i j : Fin (n + 1)) :
+    (ad K (Matrix (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1))
+        (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1)) K)
+        (typeBSimpleRootMatrix (K := K) i) ^
       (-CartanMatrix.B (n + 1) j i).toNat)
-        ⁅typeBSimpleRootGenerator (K := K) i, typeBSimpleRootGenerator (K := K) j⁆ = 0 := by
-  apply Subtype.ext
-  rw [LieSubalgebra.coe_ad_pow, LieSubalgebra.coe_bracket,
-    coe_typeBSimpleRootGenerator, coe_typeBSimpleRootGenerator]
-  simp only [ZeroMemClass.coe_zero]
+        ⁅typeBSimpleRootMatrix (K := K) i, typeBSimpleRootMatrix (K := K) j⁆ = 0 := by
   refine Fin.lastCases ?_ (fun i₀ ↦ ?_) i
   · refine Fin.lastCases ?_ (fun j₀ ↦ ?_) j
     · simp
@@ -145,10 +143,85 @@ theorem ad_pow_lie_typeBSimpleRootGenerator (i j : Fin (n + 1)) :
         (first | omega | (split_ifs; simp))
       all_goals omega
 
+/-- The coordinate equivalence that fixes the middle coordinate and swaps the signed blocks. -/
+private def typeBSignEquiv (ι : Type*) : Unit ⊕ ι ⊕ ι ≃ Unit ⊕ ι ⊕ ι :=
+  Equiv.sumCongr (Equiv.refl Unit) (Equiv.sumComm ι ι)
+
+/-- Reindexing matrices along `typeBSignEquiv`, as an equivalence of Lie algebras. -/
+private def typeBSignReindex (ι : Type*) [DecidableEq ι] [Fintype ι] :
+    Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K ≃ₗ⁅K⁆
+      Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K :=
+  (Matrix.reindexAlgEquiv K K (typeBSignEquiv ι)).toLieEquiv
+
+private theorem typeBSignReindex_typeBSimpleRootMatrix (i : Fin (n + 1)) :
+    typeBSignReindex (K := K) (Fin (n + 1)) (typeBSimpleRootMatrix (K := K) i) =
+      -typeBSimpleNegativeRootMatrix (K := K) i := by
+  refine Fin.lastCases ?_ (fun i₀ ↦ ?_) i
+  · simp only [typeBSimpleRootMatrix_last, typeBSimpleNegativeRootMatrix_last]
+    ext (a | (a | a)) (b | (b | b)) <;>
+      simp [typeBSignReindex, typeBSignEquiv, Matrix.reindex_apply,
+        typeBShortRootMatrix_def, typeBShortNegativeRootMatrix_def, Matrix.single_apply]
+  · simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleNegativeRootMatrix_castSucc]
+    ext (a | (a | a)) (b | (b | b)) <;>
+      simp [typeBSignReindex, typeBSignEquiv, Matrix.reindex_apply,
+        typeBLongRootMatrix_def, Matrix.single_apply]
+
+private theorem LieEquiv.map_ad_pow {L L' : Type*} [LieRing L] [LieAlgebra K L]
+    [LieRing L'] [LieAlgebra K L'] (e : L ≃ₗ⁅K⁆ L') (x y : L) (m : ℕ) :
+    e (((ad K L x) ^ m) y) = ((ad K L' (e x)) ^ m) (e y) := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+      rw [pow_succ', Module.End.mul_apply, LieAlgebra.ad_apply, e.map_lie, ih,
+        pow_succ', Module.End.mul_apply, LieAlgebra.ad_apply]
+
+private theorem ad_pow_lie_typeBSimpleNegativeRootMatrix (i j : Fin (n + 1)) :
+    (ad K (Matrix (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1))
+        (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1)) K)
+        (typeBSimpleNegativeRootMatrix (K := K) i) ^
+      (-CartanMatrix.B (n + 1) j i).toNat)
+        ⁅typeBSimpleNegativeRootMatrix (K := K) i,
+          typeBSimpleNegativeRootMatrix (K := K) j⁆ = 0 := by
+  let e := typeBSignReindex (K := K) (Fin (n + 1))
+  have h := congrArg e (ad_pow_lie_typeBSimpleRootMatrix (K := K) i j)
+  rw [map_zero, LieEquiv.map_ad_pow, e.map_lie,
+    typeBSignReindex_typeBSimpleRootMatrix,
+    typeBSignReindex_typeBSimpleRootMatrix] at h
+  simp only [neg_lie, lie_neg, neg_neg] at h
+  have had :
+      ad K (Matrix (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1))
+        (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1)) K)
+          (-typeBSimpleNegativeRootMatrix (K := K) i) =
+        -ad K (Matrix (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1))
+          (Unit ⊕ Fin (n + 1) ⊕ Fin (n + 1)) K)
+            (typeBSimpleNegativeRootMatrix (K := K) i) := by
+    exact map_neg (ad K _) _
+  rw [had] at h
+  rcases Nat.even_or_odd (-CartanMatrix.B (n + 1) j i).toNat with he | ho
+  · simpa only [he.neg_pow] using h
+  · simpa only [ho.neg_pow, LinearMap.neg_apply, neg_eq_zero] using h
+
+/-- The higher Serre relation for the positive simple-root generators of the standard split
+type-`B` Lie algebra. The reversed Cartan-matrix indices match the coroot-first convention in the
+Cartan-action relations. -/
+@[simp]
+theorem ad_pow_lie_typeBSimpleRootGenerator_typeBSimpleRootGenerator
+    (i j : Fin (n + 1)) :
+    (ad K (LieAlgebra.Orthogonal.typeB (Fin (n + 1)) K)
+        (typeBSimpleRootGenerator (K := K) i) ^
+      (-CartanMatrix.B (n + 1) j i).toNat)
+        ⁅typeBSimpleRootGenerator (K := K) i, typeBSimpleRootGenerator (K := K) j⁆ = 0 := by
+  apply Subtype.ext
+  rw [LieSubalgebra.coe_ad_pow, LieSubalgebra.coe_bracket,
+    coe_typeBSimpleRootGenerator, coe_typeBSimpleRootGenerator]
+  simp only [ZeroMemClass.coe_zero]
+  exact ad_pow_lie_typeBSimpleRootMatrix i j
+
 /-- The higher Serre relation for the negative simple-root generators of the standard split
 type-`B` Lie algebra. -/
 @[simp]
-theorem ad_pow_lie_typeBSimpleNegativeRootGenerator (i j : Fin (n + 1)) :
+theorem ad_pow_lie_typeBSimpleNegativeRootGenerator_typeBSimpleNegativeRootGenerator
+    (i j : Fin (n + 1)) :
     (ad K (LieAlgebra.Orthogonal.typeB (Fin (n + 1)) K)
         (typeBSimpleNegativeRootGenerator (K := K) i) ^
       (-CartanMatrix.B (n + 1) j i).toNat)
@@ -158,46 +231,6 @@ theorem ad_pow_lie_typeBSimpleNegativeRootGenerator (i j : Fin (n + 1)) :
   rw [LieSubalgebra.coe_ad_pow, LieSubalgebra.coe_bracket,
     coe_typeBSimpleNegativeRootGenerator, coe_typeBSimpleNegativeRootGenerator]
   simp only [ZeroMemClass.coe_zero]
-  refine Fin.lastCases ?_ (fun i₀ ↦ ?_) i
-  · refine Fin.lastCases ?_ (fun j₀ ↦ ?_) j
-    · simp
-    · simp only [typeBSimpleNegativeRootMatrix_last,
-        typeBSimpleNegativeRootMatrix_castSucc]
-      simp_rw [typeBShortNegativeRootMatrix_def, typeBLongRootMatrix_def]
-      rcases j₀ with ⟨j, hj⟩
-      have hjn : j ≠ n := by omega
-      have hnj : n ≠ j := hjn.symm
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
-      split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
-        lie_single_single, Fin.ext_iff, pow_two, Module.End.mul_apply] <;>
-        omega
-  · refine Fin.lastCases ?_ (fun j₀ ↦ ?_) j
-    · simp only [typeBSimpleNegativeRootMatrix_castSucc,
-        typeBSimpleNegativeRootMatrix_last]
-      simp_rw [typeBLongRootMatrix_def, typeBShortNegativeRootMatrix_def]
-      rcases i₀ with ⟨i, hi⟩
-      have hin : i ≠ n := by omega
-      have hni : n ≠ i := hin.symm
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
-      split_ifs <;> simp_all [LieAlgebra.ad_apply, lie_sub, sub_lie,
-        lie_single_single, Fin.ext_iff] <;>
-        omega
-    · simp only [typeBSimpleNegativeRootMatrix_castSucc]
-      simp_rw [typeBLongRootMatrix_def]
-      rcases i₀ with ⟨i, hi⟩
-      rcases j₀ with ⟨j, hj⟩
-      simp only [Fin.castSucc_mk, CartanMatrix.B, Matrix.of_apply]
-      split_ifs <;> simp only [Fin.succ_mk, map_sub, Int.reduceNeg, neg_neg,
-        Int.reduceToNat, Int.toNat_one, pow_one, neg_zero, Int.toNat_zero, pow_zero,
-        lie_sub, sub_lie, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,
-        Fin.mk.injEq, mul_one, reduceCtorEq, ↓reduceIte, sub_self, sub_zero, zero_sub,
-        neg_sub, LinearMap.sub_apply, LieAlgebra.ad_apply, Module.End.one_apply] <;>
-        (first | omega | split_ifs) <;>
-        try simp only [lie_zero, lie_single_single, Sum.inr.injEq, Sum.inl.injEq,
-          Fin.mk.injEq, mul_one, Nat.add_eq_left, one_ne_zero, ↓reduceIte, sub_zero,
-          zero_sub, reduceCtorEq, sub_self, Nat.left_eq_add, sub_neg_eq_add, zero_add] <;>
-        simp only [Fin.ext_iff] at * <;>
-        (first | omega | (split_ifs; simp))
-      all_goals omega
+  exact ad_pow_lie_typeBSimpleNegativeRootMatrix i j
 
 end TauCeti

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -5,9 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.LinearAlgebra.Matrix.Cartan
 public import TauCeti.Algebra.Lie.Orthogonal.TypeB.GeneratorRelations
-public import TauCeti.Algebra.Lie.Presentation.Basic
 import TauCeti.Algebra.Lie.GeneralLinear.Basic
 import TauCeti.Algebra.Lie.Presentation.Serre
 

--- a/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
+++ b/TauCeti/Algebra/Lie/Orthogonal/TypeB/SerreRelations.lean
@@ -325,22 +325,16 @@ private theorem ad_pow_lie_typeBSimpleRootMatrix (i j : Fin (n + 1)) :
 private def typeBSignEquiv (ι : Type*) : Unit ⊕ ι ⊕ ι ≃ Unit ⊕ ι ⊕ ι :=
   Equiv.sumCongr (Equiv.refl Unit) (Equiv.sumComm ι ι)
 
-/-- Reindexing matrices along `typeBSignEquiv`, as an equivalence of Lie algebras. -/
-private def typeBSignReindex (ι : Type*) [DecidableEq ι] [Fintype ι] :
-    Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K ≃ₗ⁅K⁆
-      Matrix (Unit ⊕ ι ⊕ ι) (Unit ⊕ ι ⊕ ι) K :=
-  (Matrix.reindexAlgEquiv K K (typeBSignEquiv ι)).toLieEquiv
-
 private theorem typeBSignReindex_typeBSimpleRootMatrix (i : Fin (n + 1)) :
-    typeBSignReindex (K := K) (Fin (n + 1)) (typeBSimpleRootMatrix (K := K) i) =
-      -typeBSimpleNegativeRootMatrix (K := K) i := by
+    Matrix.reindexLieEquiv (R := K) (typeBSignEquiv (Fin (n + 1)))
+        (typeBSimpleRootMatrix (K := K) i) = -typeBSimpleNegativeRootMatrix (K := K) i := by
   refine Fin.lastCases ?_ (fun i₀ ↦ ?_) i
   · simp only [typeBSimpleRootMatrix_last, typeBSimpleNegativeRootMatrix_last]
-    simp [typeBSignReindex, typeBSignEquiv, Matrix.reindex_apply,
+    simp [typeBSignEquiv, Matrix.reindex_apply,
       Matrix.submatrix_sub, Matrix.submatrix_single_equiv, typeBShortRootMatrix_def,
       typeBShortNegativeRootMatrix_def]
   · simp only [typeBSimpleRootMatrix_castSucc, typeBSimpleNegativeRootMatrix_castSucc]
-    simp [typeBSignReindex, typeBSignEquiv, Matrix.reindex_apply,
+    simp [typeBSignEquiv, Matrix.reindex_apply,
       Matrix.submatrix_sub, Matrix.submatrix_single_equiv, typeBLongRootMatrix_def]
 
 private theorem ad_pow_lie_typeBSimpleNegativeRootMatrix (i j : Fin (n + 1)) :
@@ -350,7 +344,7 @@ private theorem ad_pow_lie_typeBSimpleNegativeRootMatrix (i j : Fin (n + 1)) :
       (-CartanMatrix.B (n + 1) j i).toNat)
         ⁅typeBSimpleNegativeRootMatrix (K := K) i,
           typeBSimpleNegativeRootMatrix (K := K) j⁆ = 0 := by
-  let e := typeBSignReindex (K := K) (Fin (n + 1))
+  let e := Matrix.reindexLieEquiv (R := K) (typeBSignEquiv (Fin (n + 1)))
   have h := congrArg e.toLieHom (ad_pow_lie_typeBSimpleRootMatrix (K := K) i j)
   have he (k : Fin (n + 1)) :
       e.toLieHom (typeBSimpleRootMatrix (K := K) k) =

--- a/TauCeti/Algebra/Lie/Presentation/Basic.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Basic.lean
@@ -29,7 +29,8 @@ The second is that a homomorphism transports an iterated adjoint action,
 `TauCeti.LieHom.map_ad_pow`. Relations of a presentation are frequently written as the vanishing of
 `(ad x) ^ n y` — Serre's relations for a Cartan matrix are the standard example — and such a
 relation says nothing about the presented algebra until it is known to be carried along by the map
-that checks it.
+that checks it. The companion `TauCeti.ad_neg_pow_apply_eq_zero` transports such a vanishing result
+from `x` to `-x`.
 
 The third is that a free Lie algebra is generated, as a Lie subalgebra, by its generators:
 `TauCeti.FreeLieAlgebra.lieSpan_range_of_eq_top`. This is what makes the images of the generators
@@ -46,6 +47,8 @@ generate the presented algebra, rather than merely determine maps out of it.
 * `TauCeti.LieIdeal.liftQ_comp_mkQ` and `TauCeti.LieIdeal.lieHom_qext`: the lifted homomorphism
   restricts to the original one along the quotient map, and is the only homomorphism that does.
 * `TauCeti.LieHom.map_ad_pow`: a homomorphism carries `(ad x) ^ n y` to `(ad (f x)) ^ n (f y)`.
+* `TauCeti.ad_neg_pow_apply_eq_zero`: negating the element acting by `ad` preserves the vanishing of
+  an iterated adjoint action.
 * `TauCeti.FreeLieAlgebra.lieSpan_range_of_eq_top`: the generators of a free Lie algebra generate it
   as a Lie subalgebra.
 
@@ -170,6 +173,15 @@ theorem map_ad_pow (f : L →ₗ⁅R⁆ L') (x : L) (n : ℕ) (y : L) :
     rw [ih, f.map_lie]
 
 end LieHom
+
+variable {R L : Type*} [CommRing R] [LieRing L] [LieAlgebra R L]
+
+/-- If the `n`-fold adjoint action of `x` annihilates `y`, then so does that of `-x`. -/
+theorem ad_neg_pow_apply_eq_zero {x y : L} {n : ℕ} (h : (LieAlgebra.ad R L x ^ n) y = 0) :
+    (LieAlgebra.ad R L (-x) ^ n) y = 0 := by
+  have hneg : LieAlgebra.ad R L (-x) = (-1 : R) • LieAlgebra.ad R L x := by
+    rw [map_neg, neg_smul, one_smul]
+  rw [hneg, smul_pow, LinearMap.smul_apply, h, smul_zero]
 
 namespace FreeLieAlgebra
 

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -290,13 +290,6 @@ section Stability
 variable {R CM} {H E F : B → L} {σ : Equiv.Perm B}
 
 omit [DecidableEq B] in
-/-- If the `n`-fold adjoint action of `x` annihilates `y`, then so does that of `-x`. -/
-theorem ad_neg_pow_apply_eq_zero {x y : L} {n : ℕ} (h : (ad R L x ^ n) y = 0) :
-    (ad R L (-x) ^ n) y = 0 := by
-  have hneg : ad R L (-x) = (-1 : R) • ad R L x := by rw [map_neg, neg_smul, one_smul]
-  rw [hneg, smul_pow, LinearMap.smul_apply, h, smul_zero]
-
-omit [DecidableEq B] in
 /-- Reindexing a Serre system along an injective map of index sets gives a Serre system for the
 matrix reindexed the same way. -/
 theorem IsSerreSystem.submatrix {B' : Type*} {f : B' → B} (hf : Function.Injective f)

--- a/TauCeti/Algebra/Lie/Presentation/Serre.lean
+++ b/TauCeti/Algebra/Lie/Presentation/Serre.lean
@@ -291,7 +291,7 @@ variable {R CM} {H E F : B → L} {σ : Equiv.Perm B}
 
 omit [DecidableEq B] in
 /-- If the `n`-fold adjoint action of `x` annihilates `y`, then so does that of `-x`. -/
-private theorem ad_neg_pow_apply_eq_zero {x y : L} {n : ℕ} (h : (ad R L x ^ n) y = 0) :
+theorem ad_neg_pow_apply_eq_zero {x y : L} {n : ℕ} (h : (ad R L x ^ n) y = 0) :
     (ad R L (-x) ^ n) y = 0 := by
   have hneg : ad R L (-x) = (-1 : R) • ad R L x := by rw [map_neg, neg_smul, one_smul]
   rw [hneg, smul_pow, LinearMap.smul_apply, h, smul_zero]


### PR DESCRIPTION
This PR proves the mixed and higher Serre relations for the explicit Bourbaki type-`B` root generators over every commutative ring. It identifies the adjoint exponents directly with entries of Mathlib's transposed `CartanMatrix.B`, including the terminal double edge, and proves the off-diagonal positive/negative brackets by matrix-unit calculation.

This advances Layer 9's exact **The Chevalley–Demazure construction** target—an explicit split reductive group scheme over `ℤ` via a Chevalley basis and the Kostant `ℤ`-form—and its **Pinnings** target, because these relations are the missing generator input for the standard type-`B` Serre system. With the root generators, coroot brackets, and uniform Cartan action already landed, this is the most direct next step on that construction path.

The designated milestone is the Layer 9 pinned Chevalley–Demazure construction; with the uniform Cartan action and packaged `IsSerreSystem` now in place, the next step is constructing the associated Kostant-form representation.

The implementation reuses Mathlib's `CartanMatrix.B`, Tau Ceti's shared `lie_single_single` matrix-unit bracket formula, and Mathlib's `LieSubalgebra.coe_ad_pow`. It adds public `_def` equations for the three existing root-matrix definitions so downstream relation proofs can compute through the intended API without exposing implementation bodies.

The changed modules build without `sorry`, and the changed-declaration axiom and lint audits pass.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-b-serre-relations"}-->

🤖 Prepared with Codex
