### PR TITLE
feat: the unitary description of the type-A twisted Frobenius fixed points

### DIFF
--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
@@ -26,9 +26,9 @@ is that condition wherever the `q`-power map is an involution. At the generality
 `q`-power map is only a ring endomorphism: the Frobenius of a ring of exponential characteristic
 `p` need not square to the identity, and on `(ZMod p)[X]` it does not. It is an involution on the
 subring fixed by the `q ^ 2`-power Frobenius, and every entry of a fixed point lies in that
-subring by `TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobenius_eq_self`.
-`TauCeti.SlStd.mem_map_subtype_fixedSubgroup_twistedFrobenius_iff` states the description as a
-membership criterion inside `GL_{r+1}(A)`.
+subring by `TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobenius_eq_self`. To read the
+fixed group inside `GL_{r+1}(A)`, rewrite with `TauCeti.map_subtype_fixedSubgroup_of_coe_eq` and
+`TauCeti.SlStd.coe_twistedFrobenius` and then with the equivalence below.
 
 For `p` prime, `0 < k`, `2 ≤ r`, and `A` an algebraic closure of `ZMod p`, that subring is the
 field of `q ^ 2` elements and the equation here is the usual unitary equation of the twisted
@@ -49,8 +49,6 @@ than the identity.
 * `TauCeti.SlStd.twistedFrobenius_eq_self_iff` and
   `TauCeti.SlStd.twistedFrobenius_eq_self_iff_transpose`: a carrier point is fixed by the
   graph-twisted Frobenius exactly when it preserves the pinned `q`-power-semilinear form.
-* `TauCeti.SlStd.mem_map_subtype_fixedSubgroup_twistedFrobenius_iff`: the same description of the
-  fixed group as a subgroup of the ambient general linear group.
 
 ## References
 
@@ -124,29 +122,6 @@ theorem twistedFrobenius_eq_self_iff_transpose (g : points r A) :
           (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
   rw [Subtype.ext_iff, coe_twistedFrobenius, typeAGraphAutomorphism_eq_iff_transpose,
     coe_map_iterateFrobenius]
-
-/-- **The graph-twisted Frobenius-fixed points of the full-weight type-`A_r` carrier are the
-carrier points preserving the pinned `q`-power-semilinear form.** Read inside the ambient general
-linear group, membership in the fixed group is carrier membership together with the invariance
-equation of `TauCeti.SlStd.twistedFrobenius_eq_self_iff`.
-
-This is not a `simp` lemma: `simp` already reduces its left-hand side, through
-`Subgroup.mem_map`, `TauCeti.SlStd.mem_points_iff` and the `simp` lemma above, so tagging it makes
-the `simpNF` linter fail. -/
-theorem mem_map_subtype_fixedSubgroup_twistedFrobenius_iff
-    (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
-    g ∈ (fixedSubgroup (twistedFrobenius r p k A)).map (points r A).subtype ↔
-      g ∈ points r A ∧
-        (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
-              (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
-              ((g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k)).transpose =
-            (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
-  rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (twistedFrobenius r p k A)
-      ((typeAGraphAutomorphism r A).toMonoidHom.comp
-        (Matrix.GeneralLinearGroup.map (iterateFrobenius A p k)))
-      (coe_twistedFrobenius r p k A),
-    Subgroup.mem_inf, mem_fixedSubgroup, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
-    typeAGraphAutomorphism_eq_iff, coe_map_iterateFrobenius]
 
 end
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
@@ -20,40 +20,37 @@ point is fixed exactly when
 g * Q * (g^{(q)})ᵀ = Q,      equivalently      (g^{(q)})ᵀ * Q * g = Q,
 ```
 
-the second being the classical unitarity condition `g* Q g = Q` for the `q`-power-sesquilinear
-form of Gram matrix `Q`, with `g* = (g^{(q)})ᵀ`. So the fixed group is the group of `Q`-unitary
-carrier points, and `TauCeti.SlStd.mem_map_subtype_fixedSubgroup_twistedFrobenius_iff` states that
-description as a membership criterion inside `GL_{r+1}(A)`.
+the second being the invariance of the `q`-power-semilinear form of Gram matrix `Q`, written
+`g* Q g = Q` with `g* = (g^{(q)})ᵀ`. That is the shape of the classical unitarity condition, and
+is that condition wherever the `q`-power map is an involution. At the generality assumed here the
+`q`-power map is only a ring endomorphism: the Frobenius of a ring of exponential characteristic
+`p` need not square to the identity, and on `(ZMod p)[X]` it does not. It is an involution on the
+subring fixed by the `q ^ 2`-power Frobenius, and every entry of a fixed point lies in that
+subring by `TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobenius_eq_self`.
+`TauCeti.SlStd.mem_map_subtype_fixedSubgroup_twistedFrobenius_iff` states the description as a
+membership criterion inside `GL_{r+1}(A)`.
 
-For `p` prime, `0 < k`, `2 ≤ r`, and `A` an algebraic closure of `ZMod p`, that is the usual
-matrix realization of the twisted family `²A_r(q)`: the already available
-`TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobenius_eq_self` puts the entries of a fixed
-point in the field of `q ^ 2` elements, and the equation here is unitarity with respect to the
-`q`-power involution of that field. None of those hypotheses are assumed below, and nothing here
-asserts that the fixed group is finite, is perfect, or is simple, nor that it agrees with any other
-construction of a unitary group.
+For `p` prime, `0 < k`, `2 ≤ r`, and `A` an algebraic closure of `ZMod p`, that subring is the
+field of `q ^ 2` elements and the equation here is the usual unitary equation of the twisted
+family `²A_r(q)` over it. Identifying the fixed group with that family is not done here and does
+not follow from what is proved: it would need the carrier identified with `SL_{r+1}` and the
+derived subgroup and central quotient taken. None of those hypotheses are assumed below, and
+nothing here asserts that the fixed group is finite, is perfect, or is simple, nor that it agrees
+with any other construction of a unitary group.
 
-Mathlib's `Matrix.unitaryGroup` is not the object described here and is not available for it: it is
-the unitary group of the conjugate-transpose involution supplied by a `StarRing` structure on the
-coefficients, whereas the involution here is the `q`-power ring endomorphism of a ring of
-exponential characteristic `p`, which carries no such structure, and the Gram matrix is the pinned
-`Q` rather than the identity.
-
-The last two results record that the pinned generators of the carrier lie in the fixed group under
-the expected numerical conditions, so the group is not described vacuously: a torus point is fixed
-when its coordinates are exchanged by the `q`-power map along the reversal of the Bourbaki
-numbering, and a root-subgroup point is fixed when it sits at a node fixed by that reversal and its
-parameter is fixed by the `q`-power map.
+Mathlib's `Matrix.unitaryGroup` is not the object described here: it is the unitary group of the
+conjugate-transpose involution supplied by a `StarRing` structure on the coefficients, whereas the
+map here is the `q`-power ring endomorphism of a ring of exponential characteristic `p`, no
+compatible `StarRing` structure on `A` is assumed, and the Gram matrix is the pinned `Q` rather
+than the identity.
 
 ## Main results
 
 * `TauCeti.SlStd.twistedFrobenius_eq_self_iff` and
   `TauCeti.SlStd.twistedFrobenius_eq_self_iff_transpose`: a carrier point is fixed by the
-  graph-twisted Frobenius exactly when it is unitary for the pinned `q`-power-sesquilinear form.
+  graph-twisted Frobenius exactly when it preserves the pinned `q`-power-semilinear form.
 * `TauCeti.SlStd.mem_map_subtype_fixedSubgroup_twistedFrobenius_iff`: the same description of the
   fixed group as a subgroup of the ambient general linear group.
-* `TauCeti.SlStd.twistedFrobenius_weightTorusPoints_eq_self` and
-  `TauCeti.SlStd.twistedFrobenius_rootSubgroupPoints_eq_self`: pinned points of the fixed group.
 
 ## References
 
@@ -87,10 +84,12 @@ private theorem coe_map_iterateFrobenius (g : Matrix.GeneralLinearGroup (Fin (r 
     ((Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g :
           Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
         Matrix (Fin (r + 1)) (Fin (r + 1)) A) =
-      (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k) := (rfl)
+      (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k) := by
+  ext i j
+  rw [Matrix.GeneralLinearGroup.map_apply, Matrix.map_apply, iterateFrobenius_def]
 
 /-- **A type-`A_r` carrier point is fixed by the graph-twisted Frobenius exactly when it preserves
-the pinned `q`-power-sesquilinear form**, `q = p ^ k`, whose Gram matrix is the signed reversal
+the pinned `q`-power-semilinear form**, `q = p ^ k`, whose Gram matrix is the signed reversal
 matrix `TauCeti.typeAGraphConjugator`.
 
 `TauCeti.SlStd.map_subtype_fixedSubgroup_twistedFrobenius_le` places a fixed point among the
@@ -108,13 +107,13 @@ theorem twistedFrobenius_eq_self_iff (g : points r A) :
   rw [Subtype.ext_iff, coe_twistedFrobenius, typeAGraphAutomorphism_eq_iff,
     coe_map_iterateFrobenius]
 
-/-- **A type-`A_r` carrier point is fixed by the graph-twisted Frobenius exactly when it is
-unitary for the pinned `q`-power-sesquilinear form**, `q = p ^ k`: writing `g*` for the transpose
-of the entrywise `q`-th power of `g`, the condition is `g* * Q * g = Q`.
+/-- **A type-`A_r` carrier point is fixed by the graph-twisted Frobenius exactly when it satisfies
+the unitary equation of the pinned `q`-power-semilinear form**, `q = p ^ k`: writing `g*` for the
+transpose of the entrywise `q`-th power of `g`, the condition is `g* * Q * g = Q`.
 
-This is the classical form of the condition; `TauCeti.SlStd.twistedFrobenius_eq_self_iff` is the
-same condition with the two outer factors exchanged, which is the form the graph automorphism
-produces directly. -/
+This is the classical form of the condition, an involution being what makes `g ↦ g*` an adjoint;
+`TauCeti.SlStd.twistedFrobenius_eq_self_iff` is the same condition with the two outer factors
+exchanged, which is the form the graph automorphism produces directly. -/
 theorem twistedFrobenius_eq_self_iff_transpose (g : points r A) :
     twistedFrobenius r p k A g = g ↔
       (((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
@@ -127,9 +126,13 @@ theorem twistedFrobenius_eq_self_iff_transpose (g : points r A) :
     coe_map_iterateFrobenius]
 
 /-- **The graph-twisted Frobenius-fixed points of the full-weight type-`A_r` carrier are the
-`Q`-unitary carrier points.** Read inside the ambient general linear group, membership in the fixed
-group is carrier membership together with the invariance equation of
-`TauCeti.SlStd.twistedFrobenius_eq_self_iff`. -/
+carrier points preserving the pinned `q`-power-semilinear form.** Read inside the ambient general
+linear group, membership in the fixed group is carrier membership together with the invariance
+equation of `TauCeti.SlStd.twistedFrobenius_eq_self_iff`.
+
+This is not a `simp` lemma: `simp` already reduces its left-hand side, through
+`Subgroup.mem_map`, `TauCeti.SlStd.mem_points_iff` and the `simp` lemma above, so tagging it makes
+the `simpNF` linter fail. -/
 theorem mem_map_subtype_fixedSubgroup_twistedFrobenius_iff
     (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
     g ∈ (fixedSubgroup (twistedFrobenius r p k A)).map (points r A).subtype ↔
@@ -138,32 +141,12 @@ theorem mem_map_subtype_fixedSubgroup_twistedFrobenius_iff
               (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
               ((g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k)).transpose =
             (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
-  constructor
-  · rintro ⟨x, hx, rfl⟩
-    exact ⟨x.2, (twistedFrobenius_eq_self_iff r p k A x).mp (mem_fixedSubgroup.mp hx)⟩
-  · rintro ⟨hmem, heq⟩
-    exact ⟨⟨g, hmem⟩,
-      mem_fixedSubgroup.mpr ((twistedFrobenius_eq_self_iff r p k A ⟨g, hmem⟩).mpr heq), rfl⟩
-
-/-! ## Pinned points of the fixed group -/
-
-/-- **A pinned torus point is fixed by the graph-twisted Frobenius when the `q`-power map exchanges
-its coordinates along the reversal of the Bourbaki numbering.** -/
-theorem twistedFrobenius_weightTorusPoints_eq_self {s : Fin r → Aˣ}
-    (hs : ∀ i, s i.rev ^ p ^ k = s i) :
-    twistedFrobenius r p k A (weightTorusPoints r A s) = weightTorusPoints r A s := by
-  rw [twistedFrobenius_weightTorusPoints]
-  exact congrArg (weightTorusPoints r A) (funext hs)
-
-/-- **A pinned root-subgroup point is fixed by the graph-twisted Frobenius when its node is fixed
-by the reversal of the Bourbaki numbering and its parameter is fixed by the `q`-power map.** For
-`0 < r` such a node exists exactly when `r` is odd, the middle node of the diagram. -/
-theorem twistedFrobenius_rootSubgroupPoints_eq_self {i : Fin r ⊕ Fin r} {u : Multiplicative A}
-    (hi : graphRootPerm r i = i)
-    (hu : Multiplicative.toAdd u ^ p ^ k = Multiplicative.toAdd u) :
-    twistedFrobenius r p k A (rootSubgroupPoints r i A u) = rootSubgroupPoints r i A u := by
-  rw [twistedFrobenius_rootSubgroupPoints, hi, hu]
-  rfl
+  rw [TauCeti.map_subtype_fixedSubgroup_of_coe_eq (twistedFrobenius r p k A)
+      ((typeAGraphAutomorphism r A).toMonoidHom.comp
+        (Matrix.GeneralLinearGroup.map (iterateFrobenius A p k)))
+      (coe_twistedFrobenius r p k A),
+    Subgroup.mem_inf, mem_fixedSubgroup, MonoidHom.comp_apply, MulEquiv.coe_toMonoidHom,
+    typeAGraphAutomorphism_eq_iff, coe_map_iterateFrobenius]
 
 end
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
@@ -65,9 +65,10 @@ than the identity.
 
 ## Main results
 
-* `TauCeti.SlStd.twistedFrobenius_eq_self_iff` and
-  `TauCeti.SlStd.twistedFrobenius_eq_self_iff_transpose`: a carrier point is fixed by the
-  graph-twisted Frobenius exactly when it is an isometry of the pinned `q`-power-semilinear form.
+* `TauCeti.SlStd.twistedFrobenius_eq_self_iff_mul_conjugator_mul_transpose_eq` and
+  `TauCeti.SlStd.twistedFrobenius_eq_self_iff_transpose_mul_conjugator_mul_eq`: a carrier point is
+  fixed by the graph-twisted Frobenius exactly when it is an isometry of the pinned
+  `q`-power-semilinear form.
 
 ## References
 
@@ -96,7 +97,7 @@ variable (r p k : ℕ) (A : Type) [CommRing A] [ExpChar A p]
 /-! ## The fixed points as isometries of the pinned semilinear form -/
 
 -- The point-level Frobenius is entrywise exponentiation; this is the form the invariance equation
--- of `TauCeti.typeAGraphAutomorphism_eq_iff` is stated in.
+-- of `TauCeti.typeAGraphAutomorphism_eq_iff_mul_conjugator_mul_transpose_eq` is stated in.
 private theorem coe_map_iterateFrobenius (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
     ((Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g :
           Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
@@ -113,7 +114,7 @@ matrix `TauCeti.typeAGraphConjugator`.
 points over the `q ^ 2`-power Frobenius-fixed subring and claims no reverse containment; the
 equation here says exactly which carrier points are fixed. -/
 @[simp]
-theorem twistedFrobenius_eq_self_iff (g : points r A) :
+theorem twistedFrobenius_eq_self_iff_mul_conjugator_mul_transpose_eq (g : points r A) :
     twistedFrobenius r p k A g = g ↔
       ((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
               Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
@@ -121,8 +122,8 @@ theorem twistedFrobenius_eq_self_iff (g : points r A) :
             (((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
                 Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k)).transpose =
           (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
-  rw [Subtype.ext_iff, coe_twistedFrobenius, typeAGraphAutomorphism_eq_iff,
-    coe_map_iterateFrobenius]
+  rw [Subtype.ext_iff, coe_twistedFrobenius,
+    typeAGraphAutomorphism_eq_iff_mul_conjugator_mul_transpose_eq, coe_map_iterateFrobenius]
 
 /-- **A type-`A_r` carrier point is fixed by the graph-twisted Frobenius exactly when it is an
 isometry of the pinned `q`-power-semilinear form**, `q = p ^ k`: writing `g*` for the transpose of
@@ -132,9 +133,10 @@ This is the shape in which the classical unitarity condition is written, `g ↦ 
 adjoint where the `q`-power map is an involution; since `Qᵀ = (-1) ^ r • Q`, the form there is
 Hermitian for even `r` and skew-Hermitian for odd `r`, the latter being Hermitian too where
 `-1 = 1`, as the module documentation records.
-`TauCeti.SlStd.twistedFrobenius_eq_self_iff` is the same condition with the two outer factors
-exchanged, which is the form the graph automorphism produces directly. -/
-theorem twistedFrobenius_eq_self_iff_transpose (g : points r A) :
+`TauCeti.SlStd.twistedFrobenius_eq_self_iff_mul_conjugator_mul_transpose_eq` is the same condition
+with the two outer factors exchanged, which is the form the graph automorphism produces
+directly. -/
+theorem twistedFrobenius_eq_self_iff_transpose_mul_conjugator_mul_eq (g : points r A) :
     twistedFrobenius r p k A g = g ↔
       (((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
                 Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k)).transpose *
@@ -142,8 +144,8 @@ theorem twistedFrobenius_eq_self_iff_transpose (g : points r A) :
             ((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
               Matrix (Fin (r + 1)) (Fin (r + 1)) A) =
           (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
-  rw [Subtype.ext_iff, coe_twistedFrobenius, typeAGraphAutomorphism_eq_iff_transpose,
-    coe_map_iterateFrobenius]
+  rw [Subtype.ext_iff, coe_twistedFrobenius,
+    typeAGraphAutomorphism_eq_iff_transpose_mul_conjugator_mul_eq, coe_map_iterateFrobenius]
 
 end
 

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.SpecialLinear.StandardCarrier.TwistedFrobenius
+
+/-!
+# The points of the type-A carrier fixed by the graph-twisted Frobenius
+
+`TauCeti.SlStd.twistedFrobenius r p k A` is the composite `γ ∘ Frob_q` of the pinned type-`A_r`
+graph automorphism with the entrywise `q`-power Frobenius, `q = p ^ k`. This file identifies the
+points it fixes by a single matrix equation. Writing `Q` for the signed reversal matrix
+`TauCeti.typeAGraphConjugator r A` and `g^{(q)}` for the entrywise `q`-th power of `g`, a carrier
+point is fixed exactly when
+
+```text
+g * Q * (g^{(q)})ᵀ = Q,      equivalently      (g^{(q)})ᵀ * Q * g = Q,
+```
+
+the second being the classical unitarity condition `g* Q g = Q` for the `q`-power-sesquilinear
+form of Gram matrix `Q`, with `g* = (g^{(q)})ᵀ`. So the fixed group is the group of `Q`-unitary
+carrier points, and `TauCeti.SlStd.mem_map_subtype_fixedSubgroup_twistedFrobenius_iff` states that
+description as a membership criterion inside `GL_{r+1}(A)`.
+
+For `p` prime, `0 < k`, `2 ≤ r`, and `A` an algebraic closure of `ZMod p`, that is the usual
+matrix realization of the twisted family `²A_r(q)`: the already available
+`TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobenius_eq_self` puts the entries of a fixed
+point in the field of `q ^ 2` elements, and the equation here is unitarity with respect to the
+`q`-power involution of that field. None of those hypotheses are assumed below, and nothing here
+asserts that the fixed group is finite, is perfect, or is simple, nor that it agrees with any other
+construction of a unitary group.
+
+Mathlib's `Matrix.unitaryGroup` is not the object described here and is not available for it: it is
+the unitary group of the conjugate-transpose involution supplied by a `StarRing` structure on the
+coefficients, whereas the involution here is the `q`-power ring endomorphism of a ring of
+exponential characteristic `p`, which carries no such structure, and the Gram matrix is the pinned
+`Q` rather than the identity.
+
+The last two results record that the pinned generators of the carrier lie in the fixed group under
+the expected numerical conditions, so the group is not described vacuously: a torus point is fixed
+when its coordinates are exchanged by the `q`-power map along the reversal of the Bourbaki
+numbering, and a root-subgroup point is fixed when it sits at a node fixed by that reversal and its
+parameter is fixed by the `q`-power map.
+
+## Main results
+
+* `TauCeti.SlStd.twistedFrobenius_eq_self_iff` and
+  `TauCeti.SlStd.twistedFrobenius_eq_self_iff_transpose`: a carrier point is fixed by the
+  graph-twisted Frobenius exactly when it is unitary for the pinned `q`-power-sesquilinear form.
+* `TauCeti.SlStd.mem_map_subtype_fixedSubgroup_twistedFrobenius_iff`: the same description of the
+  fixed group as a subgroup of the ambient general linear group.
+* `TauCeti.SlStd.twistedFrobenius_weightTorusPoints_eq_self` and
+  `TauCeti.SlStd.twistedFrobenius_rootSubgroupPoints_eq_self`: pinned points of the fixed group.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, Chapter 14, for the unitary description of the fixed
+  points of a graph-twisted Steinberg map in type `A`.
+* R. Steinberg, *Lectures on Chevalley Groups*, §11.
+* D. Gorenstein, R. Lyons and R. Solomon, *The Classification of the Finite Simple Groups*, for the
+  small-field convention that indexes the twisted type-`A` family by `q` rather than by `q ^ 2`.
+
+This advances the "points over an algebraically closed field" target of Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md`, by describing the group of points fixed by the induced
+endomorphism the previous file constructed. Its consumer is milestone L3 of
+`TauCetiRoadmap/CFSGStatement/README.md`, which sets `H_d = fixedSubgroup d.steinberg` with
+`d.steinberg` the map `γ₂ ∘ Frob_q` of milestone L1 on the `²A` branch; the equation proved here is
+what lets a reader of that branch see which matrices `H_d` contains.
+-/
+
+public section
+
+namespace TauCeti.SlStd
+
+noncomputable section
+
+variable (r p k : ℕ) (A : Type) [CommRing A] [ExpChar A p]
+
+/-! ## The unitary description of the fixed points -/
+
+-- The point-level Frobenius is entrywise exponentiation; this is the form the invariance equation
+-- of `TauCeti.typeAGraphAutomorphism_eq_iff` is stated in.
+private theorem coe_map_iterateFrobenius (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+    ((Matrix.GeneralLinearGroup.map (iterateFrobenius A p k) g :
+          Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+        Matrix (Fin (r + 1)) (Fin (r + 1)) A) =
+      (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k) := (rfl)
+
+/-- **A type-`A_r` carrier point is fixed by the graph-twisted Frobenius exactly when it preserves
+the pinned `q`-power-sesquilinear form**, `q = p ^ k`, whose Gram matrix is the signed reversal
+matrix `TauCeti.typeAGraphConjugator`.
+
+`TauCeti.SlStd.map_subtype_fixedSubgroup_twistedFrobenius_le` places a fixed point among the
+points over the `q ^ 2`-power Frobenius-fixed subring and claims no reverse containment; the
+equation here says exactly which carrier points are fixed. -/
+@[simp]
+theorem twistedFrobenius_eq_self_iff (g : points r A) :
+    twistedFrobenius r p k A g = g ↔
+      ((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+              Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
+            (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
+            (((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+                Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k)).transpose =
+          (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
+  rw [Subtype.ext_iff, coe_twistedFrobenius, typeAGraphAutomorphism_eq_iff,
+    coe_map_iterateFrobenius]
+
+/-- **A type-`A_r` carrier point is fixed by the graph-twisted Frobenius exactly when it is
+unitary for the pinned `q`-power-sesquilinear form**, `q = p ^ k`: writing `g*` for the transpose
+of the entrywise `q`-th power of `g`, the condition is `g* * Q * g = Q`.
+
+This is the classical form of the condition; `TauCeti.SlStd.twistedFrobenius_eq_self_iff` is the
+same condition with the two outer factors exchanged, which is the form the graph automorphism
+produces directly. -/
+theorem twistedFrobenius_eq_self_iff_transpose (g : points r A) :
+    twistedFrobenius r p k A g = g ↔
+      (((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+                Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k)).transpose *
+            (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
+            ((g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+              Matrix (Fin (r + 1)) (Fin (r + 1)) A) =
+          (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
+  rw [Subtype.ext_iff, coe_twistedFrobenius, typeAGraphAutomorphism_eq_iff_transpose,
+    coe_map_iterateFrobenius]
+
+/-- **The graph-twisted Frobenius-fixed points of the full-weight type-`A_r` carrier are the
+`Q`-unitary carrier points.** Read inside the ambient general linear group, membership in the fixed
+group is carrier membership together with the invariance equation of
+`TauCeti.SlStd.twistedFrobenius_eq_self_iff`. -/
+theorem mem_map_subtype_fixedSubgroup_twistedFrobenius_iff
+    (g : Matrix.GeneralLinearGroup (Fin (r + 1)) A) :
+    g ∈ (fixedSubgroup (twistedFrobenius r p k A)).map (points r A).subtype ↔
+      g ∈ points r A ∧
+        (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
+              (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
+              ((g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).map (· ^ p ^ k)).transpose =
+            (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    exact ⟨x.2, (twistedFrobenius_eq_self_iff r p k A x).mp (mem_fixedSubgroup.mp hx)⟩
+  · rintro ⟨hmem, heq⟩
+    exact ⟨⟨g, hmem⟩,
+      mem_fixedSubgroup.mpr ((twistedFrobenius_eq_self_iff r p k A ⟨g, hmem⟩).mpr heq), rfl⟩
+
+/-! ## Pinned points of the fixed group -/
+
+/-- **A pinned torus point is fixed by the graph-twisted Frobenius when the `q`-power map exchanges
+its coordinates along the reversal of the Bourbaki numbering.** -/
+theorem twistedFrobenius_weightTorusPoints_eq_self {s : Fin r → Aˣ}
+    (hs : ∀ i, s i.rev ^ p ^ k = s i) :
+    twistedFrobenius r p k A (weightTorusPoints r A s) = weightTorusPoints r A s := by
+  rw [twistedFrobenius_weightTorusPoints]
+  exact congrArg (weightTorusPoints r A) (funext hs)
+
+/-- **A pinned root-subgroup point is fixed by the graph-twisted Frobenius when its node is fixed
+by the reversal of the Bourbaki numbering and its parameter is fixed by the `q`-power map.** For
+`0 < r` such a node exists exactly when `r` is odd, the middle node of the diagram. -/
+theorem twistedFrobenius_rootSubgroupPoints_eq_self {i : Fin r ⊕ Fin r} {u : Multiplicative A}
+    (hi : graphRootPerm r i = i)
+    (hu : Multiplicative.toAdd u ^ p ^ k = Multiplicative.toAdd u) :
+    twistedFrobenius r p k A (rootSubgroupPoints r i A u) = rootSubgroupPoints r i A u := by
+  rw [twistedFrobenius_rootSubgroupPoints, hi, hu]
+  rfl
+
+end
+
+end TauCeti.SlStd

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
@@ -20,23 +20,41 @@ point is fixed exactly when
 g * Q * (g^{(q)})ᵀ = Q,      equivalently      (g^{(q)})ᵀ * Q * g = Q,
 ```
 
-the second being the invariance of the `q`-power-semilinear form of Gram matrix `Q`, written
-`g* Q g = Q` with `g* = (g^{(q)})ᵀ`. That is the shape of the classical unitarity condition, and
-is that condition wherever the `q`-power map is an involution. At the generality assumed here the
-`q`-power map is only a ring endomorphism: the Frobenius of a ring of exponential characteristic
-`p` need not square to the identity, and on `(ZMod p)[X]` it does not. It is an involution on the
-subring fixed by the `q ^ 2`-power Frobenius, and every entry of a fixed point lies in that
-subring by `TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobenius_eq_self`. To read the
-fixed group inside `GL_{r+1}(A)`, rewrite with `TauCeti.map_subtype_fixedSubgroup_of_coe_eq` and
-`TauCeti.SlStd.coe_twistedFrobenius` and then with either equivalence below.
+the second saying that `g` is an isometry of the `q`-power-semilinear form of Gram matrix `Q`,
+written `g* Q g = Q` with `g* = (g^{(q)})ᵀ`. That is the shape of the classical unitarity
+condition, but two things are needed before it may be called that condition, and the generality
+assumed here supplies neither.
+
+First, the `q`-power map is only a ring endomorphism: the Frobenius of a ring of exponential
+characteristic `p` need not square to the identity, and on `(ZMod p)[X]` it does not. It is an
+involution on the subring fixed by the `q ^ 2`-power Frobenius, and every entry of a fixed point
+lies in that subring by `TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobenius_eq_self`.
+
+Second, the pinned Gram matrix has a parity. `Q` is the reversal matrix with alternating signs, so
+transposing it reverses the sign pattern: `Qᵀ = (-1) ^ r • Q`, equivalently `Qᵀ = Q⁻¹` together
+with `Q * Q = (-1) ^ r`, which is `TauCeti.typeAGraphConjugator_mul_self`. Where the `q`-power map
+is an involution the form is therefore Hermitian for even `r` and skew-Hermitian for odd `r`; and
+where the `q`-power map is the identity, as on `ZMod p` with `q = p`, the form is bilinear,
+symmetric for even `r` and alternating for odd `r`, so that the equation is then the symplectic
+condition (for `r = 3`, `A = ZMod 3` and `q = 3` it is exactly `gᵀ * Q * g = Q` for a
+nondegenerate alternating form). So involutivity alone does not make the equation a unitary one.
+
+To read the fixed group inside `GL_{r+1}(A)`, rewrite with
+`TauCeti.map_subtype_fixedSubgroup_of_coe_eq` and `TauCeti.SlStd.coe_twistedFrobenius` and then
+with either equivalence below.
 
 For `p` prime, `0 < k`, `2 ≤ r`, and `A` an algebraic closure of `ZMod p`, that subring is the
-field of `q ^ 2` elements and the equation here is the usual unitary equation of the twisted
-family `²A_r(q)` over it. Identifying the fixed group with that family is not done here and does
-not follow from what is proved: it would need the carrier identified with `SL_{r+1}` and the
-derived subgroup and central quotient taken. None of those hypotheses are assumed below, and
-nothing here asserts that the fixed group is finite, is perfect, or is simple, nor that it agrees
-with any other construction of a unitary group.
+field `F` of `q ^ 2` elements, on which the `q`-power map is the involution fixing the field of
+`q` elements, and the equation here is the isometry equation over `F` of the Hermitian form `Q`
+for even `r` and of the skew-Hermitian form `Q` for odd `r`. In the odd case the isometries are
+still those of a Hermitian form: choosing `c` in `F` with `c ^ q = -c` (take `c = 1` when `q` is
+even) makes `c • Q` Hermitian, and rescaling the invertible Gram matrix by a unit does not change
+which matrices satisfy the equation. That is the usual unitary equation of the twisted family
+`²A_r(q)`. Identifying the fixed group with that family is not done here and does not follow from
+what is proved: it would need the carrier identified with `SL_{r+1}` and the derived subgroup and
+central quotient taken. None of those hypotheses are assumed below, and nothing here asserts that
+the fixed group is finite, is perfect, or is simple, nor that it agrees with any other
+construction of a unitary group.
 
 Mathlib's `Matrix.unitaryGroup` is not the object described here: it is the unitary group of the
 conjugate-transpose involution supplied by a `StarRing` structure on the coefficients, whereas the
@@ -48,7 +66,7 @@ than the identity.
 
 * `TauCeti.SlStd.twistedFrobenius_eq_self_iff` and
   `TauCeti.SlStd.twistedFrobenius_eq_self_iff_transpose`: a carrier point is fixed by the
-  graph-twisted Frobenius exactly when it preserves the pinned `q`-power-semilinear form.
+  graph-twisted Frobenius exactly when it is an isometry of the pinned `q`-power-semilinear form.
 
 ## References
 
@@ -74,7 +92,7 @@ noncomputable section
 
 variable (r p k : ℕ) (A : Type) [CommRing A] [ExpChar A p]
 
-/-! ## The unitary description of the fixed points -/
+/-! ## The fixed points as isometries of the pinned semilinear form -/
 
 -- The point-level Frobenius is entrywise exponentiation; this is the form the invariance equation
 -- of `TauCeti.typeAGraphAutomorphism_eq_iff` is stated in.
@@ -105,11 +123,13 @@ theorem twistedFrobenius_eq_self_iff (g : points r A) :
   rw [Subtype.ext_iff, coe_twistedFrobenius, typeAGraphAutomorphism_eq_iff,
     coe_map_iterateFrobenius]
 
-/-- **A type-`A_r` carrier point is fixed by the graph-twisted Frobenius exactly when it satisfies
-the unitary equation of the pinned `q`-power-semilinear form**, `q = p ^ k`: writing `g*` for the
-transpose of the entrywise `q`-th power of `g`, the condition is `g* * Q * g = Q`.
+/-- **A type-`A_r` carrier point is fixed by the graph-twisted Frobenius exactly when it is an
+isometry of the pinned `q`-power-semilinear form**, `q = p ^ k`: writing `g*` for the transpose of
+the entrywise `q`-th power of `g`, the condition is `g* * Q * g = Q`.
 
-This is the classical form of the condition, an involution being what makes `g ↦ g*` an adjoint;
+This is the shape in which the classical unitarity condition is written, `g ↦ g*` being an
+adjoint where the `q`-power map is an involution; since `Qᵀ = (-1) ^ r • Q`, the form there is
+Hermitian for even `r` and skew-Hermitian for odd `r`, as the module documentation records.
 `TauCeti.SlStd.twistedFrobenius_eq_self_iff` is the same condition with the two outer factors
 exchanged, which is the form the graph automorphism produces directly. -/
 theorem twistedFrobenius_eq_self_iff_transpose (g : points r A) :

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
@@ -28,7 +28,7 @@ is that condition wherever the `q`-power map is an involution. At the generality
 subring fixed by the `q ^ 2`-power Frobenius, and every entry of a fixed point lies in that
 subring by `TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobenius_eq_self`. To read the
 fixed group inside `GL_{r+1}(A)`, rewrite with `TauCeti.map_subtype_fixedSubgroup_of_coe_eq` and
-`TauCeti.SlStd.coe_twistedFrobenius` and then with the equivalence below.
+`TauCeti.SlStd.coe_twistedFrobenius` and then with either equivalence below.
 
 For `p` prime, `0 < k`, `2 ≤ r`, and `A` an algebraic closure of `ZMod p`, that subring is the
 field of `q ^ 2` elements and the equation here is the usual unitary equation of the twisted

--- a/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
+++ b/TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean
@@ -33,7 +33,8 @@ lies in that subring by `TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobe
 Second, the pinned Gram matrix has a parity. `Q` is the reversal matrix with alternating signs, so
 transposing it reverses the sign pattern: `Qᵀ = (-1) ^ r • Q`, equivalently `Qᵀ = Q⁻¹` together
 with `Q * Q = (-1) ^ r`, which is `TauCeti.typeAGraphConjugator_mul_self`. Where the `q`-power map
-is an involution the form is therefore Hermitian for even `r` and skew-Hermitian for odd `r`; and
+is an involution the form is therefore Hermitian for even `r` and skew-Hermitian for odd `r`, the
+latter being Hermitian too exactly where `-1 = 1`, as in characteristic two; and
 where the `q`-power map is the identity, as on `ZMod p` with `q = p`, the form is bilinear,
 symmetric for even `r` and alternating for odd `r`, so that the equation is then the symplectic
 condition (for `r = 3`, `A = ZMod 3` and `q = 3` it is exactly `gᵀ * Q * g = Q` for a
@@ -129,7 +130,8 @@ the entrywise `q`-th power of `g`, the condition is `g* * Q * g = Q`.
 
 This is the shape in which the classical unitarity condition is written, `g ↦ g*` being an
 adjoint where the `q`-power map is an involution; since `Qᵀ = (-1) ^ r • Q`, the form there is
-Hermitian for even `r` and skew-Hermitian for odd `r`, as the module documentation records.
+Hermitian for even `r` and skew-Hermitian for odd `r`, the latter being Hermitian too where
+`-1 = 1`, as the module documentation records.
 `TauCeti.SlStd.twistedFrobenius_eq_self_iff` is the same condition with the two outer factors
 exchanged, which is the form the graph automorphism produces directly. -/
 theorem twistedFrobenius_eq_self_iff_transpose (g : points r A) :

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -256,8 +256,10 @@ Composing with an entrywise ring endomorphism `σ` and taking `g = σ h` reads t
 invariance of the `σ`-sesquilinear form of Gram matrix `Q` under `h`, in the transposed form
 recorded by `TauCeti.typeAGraphAutomorphism_eq_iff_transpose`. That is the shape of a unitarity
 condition, but not yet that condition: `σ` is only assumed to be a ring endomorphism, and `Q` is
-the reversal matrix with alternating signs, so `Qᵀ = (-1) ^ r • Q` and the form is Hermitian only
-for even `r`, being skew-Hermitian for odd `r`. -/
+the reversal matrix with alternating signs, so `Qᵀ = (-1) ^ r • Q`. Even `r` therefore makes the
+form Hermitian; odd `r` makes it skew-Hermitian, which is again Hermitian exactly where `-1 = 1`,
+as in characteristic two. -/
+@[simp]
 theorem typeAGraphAutomorphism_eq_iff (r : ℕ) (g h : GL (Fin (r + 1)) A) :
     typeAGraphAutomorphism r A g = h ↔
       (h : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
@@ -295,8 +297,9 @@ square of the signed reversal matrix is a scalar. Composing with an entrywise ri
 `σ` and taking `g = σ h`, this is the equation `h* * Q * h = Q` saying that `h` is an isometry of
 the `σ`-sesquilinear form of Gram matrix `Q`, with `h* = (σ h)ᵀ`. It is the classical unitarity
 condition only where that form is Hermitian, which needs `σ` an involution, not assumed here, and
-`r` even, since `Qᵀ = (-1) ^ r • Q`; for odd `r` the form is skew-Hermitian, and for `σ` the
-identity it is symmetric for even `r` and alternating for odd `r`. -/
+needs `Qᵀ = Q`: since `Qᵀ = (-1) ^ r • Q`, even `r` gives that outright, while odd `r` gives a
+skew-Hermitian form, again Hermitian exactly where `-1 = 1`, as in characteristic two. For `σ` the
+identity the form is bilinear, symmetric for even `r` and alternating for odd `r`. -/
 theorem typeAGraphAutomorphism_eq_iff_transpose (r : ℕ) (g h : GL (Fin (r + 1)) A) :
     typeAGraphAutomorphism r A g = h ↔
       (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).transpose *

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -97,13 +97,6 @@ theorem coe_inverseTranspose (g : GL n A) :
     (inverseTranspose g : Matrix n n A) = ((g⁻¹ : GL n A) : Matrix n n A).transpose :=
   (rfl)
 
-/-- The matrix of the inverse of the inverse transpose of `g` is the transpose of the matrix of
-`g`. Inverse transpose is a group automorphism, whereas transpose alone is anti-multiplicative, so
-this is the shape in which the transpose of an invertible matrix is available inside `GL n A`. -/
-theorem coe_inv_inverseTranspose (g : GL n A) :
-    (((inverseTranspose g)⁻¹ : GL n A) : Matrix n n A) = (g : Matrix n n A).transpose := by
-  rw [← map_inv, coe_inverseTranspose, inv_inv]
-
 /-- Inverse transpose is an involution. -/
 @[simp]
 theorem inverseTranspose_inverseTranspose (g : GL n A) :
@@ -271,7 +264,7 @@ theorem typeAGraphAutomorphism_eq_iff (r : ℕ) (g h : GL (Fin (r + 1)) A) :
             (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).transpose =
           (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
   rw [typeAGraphAutomorphism_eq_iff_gl, ← Units.val_inj]
-  simp only [Units.val_mul, Matrix.GeneralLinearGroup.coe_inv_inverseTranspose]
+  simp only [Units.val_mul, ← map_inv, Matrix.GeneralLinearGroup.coe_inverseTranspose, inv_inv]
 
 -- The square of the signed reversal matrix is a scalar, hence central, so the two outer factors of
 -- an invariance equation may be exchanged.
@@ -310,7 +303,7 @@ theorem typeAGraphAutomorphism_eq_iff_transpose (r : ℕ) (g h : GL (Fin (r + 1)
   rw [typeAGraphAutomorphism_eq_iff_gl]
   refine Iff.trans ⟨mul_typeAGraphConjugator_mul_swap r, mul_typeAGraphConjugator_mul_swap r⟩ ?_
   rw [← Units.val_inj]
-  simp only [Units.val_mul, Matrix.GeneralLinearGroup.coe_inv_inverseTranspose]
+  simp only [Units.val_mul, ← map_inv, Matrix.GeneralLinearGroup.coe_inverseTranspose, inv_inv]
 
 /-- Applying the pinned type-`A` graph automorphism twice is the identity. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -253,10 +253,11 @@ private theorem typeAGraphAutomorphism_eq_iff_gl (r : ℕ) (g h : GL (Fin (r + 1
 carries `g` to `h` exactly when `h * Q * gᵀ = Q`, with `Q` the signed reversal matrix.
 
 Composing with an entrywise ring endomorphism `σ` and taking `g = σ h` reads the equation as the
-invariance of the `σ`-semilinear form of Gram matrix `Q` under `h`, in the transposed form
+invariance of the `σ`-sesquilinear form of Gram matrix `Q` under `h`, in the transposed form
 recorded by `TauCeti.typeAGraphAutomorphism_eq_iff_transpose`. That is the shape of a unitarity
-condition, and is one when `σ` is an involution; `σ` is only assumed to be a ring endomorphism
-here. -/
+condition, but not yet that condition: `σ` is only assumed to be a ring endomorphism, and `Q` is
+the reversal matrix with alternating signs, so `Qᵀ = (-1) ^ r • Q` and the form is Hermitian only
+for even `r`, being skew-Hermitian for odd `r`. -/
 theorem typeAGraphAutomorphism_eq_iff (r : ℕ) (g h : GL (Fin (r + 1)) A) :
     typeAGraphAutomorphism r A g = h ↔
       (h : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
@@ -291,9 +292,11 @@ automorphism carries `g` to `h` exactly when `gᵀ * Q * h = Q`.
 
 The two outer factors of `TauCeti.typeAGraphAutomorphism_eq_iff` may be exchanged because the
 square of the signed reversal matrix is a scalar. Composing with an entrywise ring endomorphism
-`σ` and taking `g = σ h`, this is the equation `h* * Q * h = Q` for the `σ`-semilinear form of
-Gram matrix `Q`, with `h* = (σ h)ᵀ`: the classical unitarity condition when `σ` is an involution,
-which is not assumed here. -/
+`σ` and taking `g = σ h`, this is the equation `h* * Q * h = Q` saying that `h` is an isometry of
+the `σ`-sesquilinear form of Gram matrix `Q`, with `h* = (σ h)ᵀ`. It is the classical unitarity
+condition only where that form is Hermitian, which needs `σ` an involution, not assumed here, and
+`r` even, since `Qᵀ = (-1) ^ r • Q`; for odd `r` the form is skew-Hermitian, and for `σ` the
+identity it is symmetric for even `r` and alternating for odd `r`. -/
 theorem typeAGraphAutomorphism_eq_iff_transpose (r : ℕ) (g h : GL (Fin (r + 1)) A) :
     typeAGraphAutomorphism r A g = h ↔
       (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).transpose *

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -36,6 +36,9 @@ carrier.
 
 ## Main results
 
+* `TauCeti.typeAGraphAutomorphism_eq_iff` and
+  `TauCeti.typeAGraphAutomorphism_eq_iff_transpose`: the automorphism carries `g` to `h` exactly
+  when `h * Q * gᵀ = Q`, equivalently when `gᵀ * Q * h = Q`.
 * `TauCeti.typeAGraphAutomorphism_transvectionUnit`: the sign-free equation on every positive
   simple-root subgroup.
 * `TauCeti.typeAGraphAutomorphism_transvectionUnit_lower`: the corresponding equation on every
@@ -93,6 +96,13 @@ def inverseTranspose : GL n A ≃* GL n A where
 theorem coe_inverseTranspose (g : GL n A) :
     (inverseTranspose g : Matrix n n A) = ((g⁻¹ : GL n A) : Matrix n n A).transpose :=
   (rfl)
+
+/-- The matrix of the inverse of the inverse transpose of `g` is the transpose of the matrix of
+`g`. Inverse transpose is a group automorphism, whereas transpose alone is anti-multiplicative, so
+this is the shape in which the transpose of an invertible matrix is available inside `GL n A`. -/
+theorem coe_inv_inverseTranspose (g : GL n A) :
+    (((inverseTranspose g)⁻¹ : GL n A) : Matrix n n A) = (g : Matrix n n A).transpose := by
+  rw [← map_inv, coe_inverseTranspose, inv_inv]
 
 /-- Inverse transpose is an involution. -/
 @[simp]
@@ -238,6 +248,66 @@ theorem typeAGraphConjugator_mul_self (r : ℕ) :
       apply Units.ext
       rw [diagGL_coe, Matrix.GeneralLinearGroup.coe_scalar]
       rw [Matrix.scalar_apply]
+
+private theorem typeAGraphAutomorphism_eq_iff_gl (r : ℕ) (g h : GL (Fin (r + 1)) A) :
+    typeAGraphAutomorphism r A g = h ↔
+      h * typeAGraphConjugator r A * (Matrix.GeneralLinearGroup.inverseTranspose g)⁻¹ =
+        typeAGraphConjugator r A := by
+  rw [typeAGraphAutomorphism_apply, mul_inv_eq_iff_eq_mul, mul_inv_eq_iff_eq_mul]
+  exact eq_comm
+
+/-- **The pinned type-`A` graph automorphism, read as an invariance equation.** The automorphism
+carries `g` to `h` exactly when `h * Q * gᵀ = Q`, with `Q` the signed reversal matrix.
+
+Composing with an entrywise ring endomorphism `σ` turns this into a unitarity condition: taking
+`g = σ h`, the equation says that `h` preserves the `σ`-sesquilinear form of Gram matrix `Q`, in
+the transposed form recorded by `TauCeti.typeAGraphAutomorphism_eq_iff_transpose`. -/
+theorem typeAGraphAutomorphism_eq_iff (r : ℕ) (g h : GL (Fin (r + 1)) A) :
+    typeAGraphAutomorphism r A g = h ↔
+      (h : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
+            (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
+            (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).transpose =
+          (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
+  rw [typeAGraphAutomorphism_eq_iff_gl, ← Units.val_inj]
+  simp only [Units.val_mul, Matrix.GeneralLinearGroup.coe_inv_inverseTranspose]
+
+-- The square of the signed reversal matrix is a scalar, hence central, so the two outer factors of
+-- an invariance equation may be exchanged.
+private theorem mul_typeAGraphConjugator_mul_swap (r : ℕ) {a b : GL (Fin (r + 1)) A}
+    (h : a * typeAGraphConjugator r A * b = typeAGraphConjugator r A) :
+    b * typeAGraphConjugator r A * a = typeAGraphConjugator r A := by
+  have hb : b = (a * typeAGraphConjugator r A)⁻¹ * typeAGraphConjugator r A :=
+    eq_inv_mul_iff_mul_eq.mpr h
+  subst hb
+  calc (a * typeAGraphConjugator r A)⁻¹ * typeAGraphConjugator r A *
+        typeAGraphConjugator r A * a
+      = (a * typeAGraphConjugator r A)⁻¹ *
+          (typeAGraphConjugator r A * typeAGraphConjugator r A) * a := by group
+    _ = (a * typeAGraphConjugator r A)⁻¹ *
+          (Matrix.GeneralLinearGroup.scalar (Fin (r + 1)) ((-1 : Aˣ) ^ r) * a) := by
+        rw [typeAGraphConjugator_mul_self, mul_assoc]
+    _ = (a * typeAGraphConjugator r A)⁻¹ *
+          (a * (typeAGraphConjugator r A * typeAGraphConjugator r A)) := by
+        rw [Matrix.GeneralLinearGroup.scalar_commute, typeAGraphConjugator_mul_self]
+    _ = typeAGraphConjugator r A := by group
+
+/-- **The invariance equation of the pinned type-`A` graph automorphism, transposed.** The
+automorphism carries `g` to `h` exactly when `gᵀ * Q * h = Q`.
+
+The two outer factors of `TauCeti.typeAGraphAutomorphism_eq_iff` may be exchanged because the
+square of the signed reversal matrix is a scalar. Composing with an entrywise ring endomorphism
+`σ` and taking `g = σ h`, this is the classical unitarity condition `h* * Q * h = Q` for the
+`σ`-sesquilinear form of Gram matrix `Q`, with `h* = (σ h)ᵀ`. -/
+theorem typeAGraphAutomorphism_eq_iff_transpose (r : ℕ) (g h : GL (Fin (r + 1)) A) :
+    typeAGraphAutomorphism r A g = h ↔
+      (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).transpose *
+            (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
+            (h : Matrix (Fin (r + 1)) (Fin (r + 1)) A) =
+          (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) := by
+  rw [typeAGraphAutomorphism_eq_iff_gl]
+  refine Iff.trans ⟨mul_typeAGraphConjugator_mul_swap r, mul_typeAGraphConjugator_mul_swap r⟩ ?_
+  rw [← Units.val_inj]
+  simp only [Units.val_mul, Matrix.GeneralLinearGroup.coe_inv_inverseTranspose]
 
 /-- Applying the pinned type-`A` graph automorphism twice is the identity. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -259,9 +259,11 @@ private theorem typeAGraphAutomorphism_eq_iff_gl (r : ℕ) (g h : GL (Fin (r + 1
 /-- **The pinned type-`A` graph automorphism, read as an invariance equation.** The automorphism
 carries `g` to `h` exactly when `h * Q * gᵀ = Q`, with `Q` the signed reversal matrix.
 
-Composing with an entrywise ring endomorphism `σ` turns this into a unitarity condition: taking
-`g = σ h`, the equation says that `h` preserves the `σ`-sesquilinear form of Gram matrix `Q`, in
-the transposed form recorded by `TauCeti.typeAGraphAutomorphism_eq_iff_transpose`. -/
+Composing with an entrywise ring endomorphism `σ` and taking `g = σ h` reads the equation as the
+invariance of the `σ`-semilinear form of Gram matrix `Q` under `h`, in the transposed form
+recorded by `TauCeti.typeAGraphAutomorphism_eq_iff_transpose`. That is the shape of a unitarity
+condition, and is one when `σ` is an involution; `σ` is only assumed to be a ring endomorphism
+here. -/
 theorem typeAGraphAutomorphism_eq_iff (r : ℕ) (g h : GL (Fin (r + 1)) A) :
     typeAGraphAutomorphism r A g = h ↔
       (h : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
@@ -296,8 +298,9 @@ automorphism carries `g` to `h` exactly when `gᵀ * Q * h = Q`.
 
 The two outer factors of `TauCeti.typeAGraphAutomorphism_eq_iff` may be exchanged because the
 square of the signed reversal matrix is a scalar. Composing with an entrywise ring endomorphism
-`σ` and taking `g = σ h`, this is the classical unitarity condition `h* * Q * h = Q` for the
-`σ`-sesquilinear form of Gram matrix `Q`, with `h* = (σ h)ᵀ`. -/
+`σ` and taking `g = σ h`, this is the equation `h* * Q * h = Q` for the `σ`-semilinear form of
+Gram matrix `Q`, with `h* = (σ h)ᵀ`: the classical unitarity condition when `σ` is an involution,
+which is not assumed here. -/
 theorem typeAGraphAutomorphism_eq_iff_transpose (r : ℕ) (g h : GL (Fin (r + 1)) A) :
     typeAGraphAutomorphism r A g = h ↔
       (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).transpose *

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean
@@ -36,9 +36,9 @@ carrier.
 
 ## Main results
 
-* `TauCeti.typeAGraphAutomorphism_eq_iff` and
-  `TauCeti.typeAGraphAutomorphism_eq_iff_transpose`: the automorphism carries `g` to `h` exactly
-  when `h * Q * gᵀ = Q`, equivalently when `gᵀ * Q * h = Q`.
+* `TauCeti.typeAGraphAutomorphism_eq_iff_mul_conjugator_mul_transpose_eq` and
+  `TauCeti.typeAGraphAutomorphism_eq_iff_transpose_mul_conjugator_mul_eq`: the automorphism carries
+  `g` to `h` exactly when `h * Q * gᵀ = Q`, equivalently when `gᵀ * Q * h = Q`.
 * `TauCeti.typeAGraphAutomorphism_transvectionUnit`: the sign-free equation on every positive
   simple-root subgroup.
 * `TauCeti.typeAGraphAutomorphism_transvectionUnit_lower`: the corresponding equation on every
@@ -254,13 +254,14 @@ carries `g` to `h` exactly when `h * Q * gᵀ = Q`, with `Q` the signed reversal
 
 Composing with an entrywise ring endomorphism `σ` and taking `g = σ h` reads the equation as the
 invariance of the `σ`-sesquilinear form of Gram matrix `Q` under `h`, in the transposed form
-recorded by `TauCeti.typeAGraphAutomorphism_eq_iff_transpose`. That is the shape of a unitarity
-condition, but not yet that condition: `σ` is only assumed to be a ring endomorphism, and `Q` is
-the reversal matrix with alternating signs, so `Qᵀ = (-1) ^ r • Q`. Even `r` therefore makes the
-form Hermitian; odd `r` makes it skew-Hermitian, which is again Hermitian exactly where `-1 = 1`,
-as in characteristic two. -/
+recorded by `TauCeti.typeAGraphAutomorphism_eq_iff_transpose_mul_conjugator_mul_eq`. That is the
+shape of a unitarity condition, but not yet that condition: `σ` is only assumed to be a ring
+endomorphism, and `Q` is the reversal matrix with alternating signs, so `Qᵀ = (-1) ^ r • Q`. Even
+`r` therefore makes the form Hermitian; odd `r` makes it skew-Hermitian, which is again Hermitian
+exactly where `-1 = 1`, as in characteristic two. -/
 @[simp]
-theorem typeAGraphAutomorphism_eq_iff (r : ℕ) (g h : GL (Fin (r + 1)) A) :
+theorem typeAGraphAutomorphism_eq_iff_mul_conjugator_mul_transpose_eq (r : ℕ)
+    (g h : GL (Fin (r + 1)) A) :
     typeAGraphAutomorphism r A g = h ↔
       (h : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
             (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *
@@ -292,15 +293,17 @@ private theorem mul_typeAGraphConjugator_mul_swap (r : ℕ) {a b : GL (Fin (r + 
 /-- **The invariance equation of the pinned type-`A` graph automorphism, transposed.** The
 automorphism carries `g` to `h` exactly when `gᵀ * Q * h = Q`.
 
-The two outer factors of `TauCeti.typeAGraphAutomorphism_eq_iff` may be exchanged because the
-square of the signed reversal matrix is a scalar. Composing with an entrywise ring endomorphism
-`σ` and taking `g = σ h`, this is the equation `h* * Q * h = Q` saying that `h` is an isometry of
-the `σ`-sesquilinear form of Gram matrix `Q`, with `h* = (σ h)ᵀ`. It is the classical unitarity
-condition only where that form is Hermitian, which needs `σ` an involution, not assumed here, and
-needs `Qᵀ = Q`: since `Qᵀ = (-1) ^ r • Q`, even `r` gives that outright, while odd `r` gives a
-skew-Hermitian form, again Hermitian exactly where `-1 = 1`, as in characteristic two. For `σ` the
-identity the form is bilinear, symmetric for even `r` and alternating for odd `r`. -/
-theorem typeAGraphAutomorphism_eq_iff_transpose (r : ℕ) (g h : GL (Fin (r + 1)) A) :
+The two outer factors of `TauCeti.typeAGraphAutomorphism_eq_iff_mul_conjugator_mul_transpose_eq`
+may be exchanged because the square of the signed reversal matrix is a scalar. Composing with an
+entrywise ring endomorphism `σ` and taking `g = σ h`, this is the equation `h* * Q * h = Q` saying
+that `h` is an isometry of the `σ`-sesquilinear form of Gram matrix `Q`, with `h* = (σ h)ᵀ`. It is
+the classical unitarity condition only where that form is Hermitian, which needs `σ` an involution,
+not assumed here, and needs `Qᵀ = Q`: since `Qᵀ = (-1) ^ r • Q`, even `r` gives that outright,
+while odd `r` gives a skew-Hermitian form, again Hermitian exactly where `-1 = 1`, as in
+characteristic two. For `σ` the identity the form is bilinear, symmetric for even `r` and
+alternating for odd `r`. -/
+theorem typeAGraphAutomorphism_eq_iff_transpose_mul_conjugator_mul_eq (r : ℕ)
+    (g h : GL (Fin (r + 1)) A) :
     typeAGraphAutomorphism r A g = h ↔
       (g : Matrix (Fin (r + 1)) (Fin (r + 1)) A).transpose *
             (typeAGraphConjugator r A : Matrix (Fin (r + 1)) (Fin (r + 1)) A) *


### PR DESCRIPTION
This PR identifies the points of the full-weight type-`A_r` Chevalley carrier that are fixed by the graph-twisted Frobenius `γ ∘ Frob_q`. Writing `Q` for the pinned signed reversal matrix `TauCeti.typeAGraphConjugator r A` and `g^{(q)}` for the entrywise `q`-th power of `g`, `TauCeti.SlStd.twistedFrobenius_eq_self_iff_mul_conjugator_mul_transpose_eq` says a carrier point is fixed exactly when `g * Q * (g^{(q)})ᵀ = Q`, and `TauCeti.SlStd.twistedFrobenius_eq_self_iff_transpose_mul_conjugator_mul_eq` gives the form `(g^{(q)})ᵀ * Q * g = Q` of the same condition, the shape of the classical unitarity equation for the `q`-power-semilinear form of Gram matrix `Q`. Both invariance equations come from a general statement about the ambient matrix group, `TauCeti.typeAGraphAutomorphism_eq_iff_mul_conjugator_mul_transpose_eq` and `TauCeti.typeAGraphAutomorphism_eq_iff_transpose_mul_conjugator_mul_eq`: the pinned graph automorphism carries `g` to `h` exactly when `h * Q * gᵀ = Q`, equivalently `gᵀ * Q * h = Q`, the two forms being exchangeable because the square of `Q` is a scalar.

The target is the "points over an algebraically closed field as a group, functorially in the field, so that a field endomorphism induces a group endomorphism of the points" item of Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`. That bullet adds that "the `q`-power Frobenius is the case a consumer asks for first"; `γ ∘ Frob_q` is the next induced endomorphism the same layer builds, and it is already on `main` as `TauCeti.SlStd.twistedFrobenius`.

Roadmap: ReductiveGroups

What makes this PR necessary to that bullet is an asymmetry `main` currently carries between the two induced endomorphisms. For the first, `TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/Frobenius.lean` is merged citing exactly this target, and its listed main results say which points are fixed: `TauCeti.SlStd.frobenius_eq_self_iff` and the resulting equality `TauCeti.SlStd.map_subtype_fixedSubgroup_frobenius_eq`. For the second, `main` carries only the one-way containment `TauCeti.SlStd.map_subtype_fixedSubgroup_twistedFrobenius_le`, whose own docstring records the asymmetry: "The corresponding statement for the Frobenius itself, `TauCeti.SlStd.map_subtype_fixedSubgroup_frobenius_eq`, is an equality; here only the containment holds." A containment does not determine the fixed set, since it is satisfied when the fixed group is trivial, so nothing in the repo yet says which points `twistedFrobenius` fixes. This is that statement, and it brings the twisted map level with the untwisted one. The shape is forced rather than chosen: for `Frob_q` the fixed points admit an entrywise description, while the signed reverse-inverse-transpose factor couples the entries, so the twisted fixed set is cut out by a single matrix equation.

The eventual consumer is the fixed-group milestone of the CFSG statement roadmap, which sets `H_d` to be the fixed subgroup of a Steinberg map that is `γ₂ ∘ Frob_q` on the `²A` branch; the equation proved here is what lets a reader of that branch see which matrices `H_d` contains. That is a note about who will read the result, not a claim to be building that milestone: nothing here mentions `ValidLieTypeIndex`, `AmbientGroup` or `steinberg`, and neither of the latter two is a declaration on `main`. For `p` prime, `0 < k`, `2 ≤ r`, and `A` an algebraic closure of `ZMod p`, the merged `TauCeti.SlStd.mem_frobeniusFixedSubring_of_twistedFrobenius_eq_self` puts the entries of a fixed point in the field of `q ^ 2` elements, on which the `q`-power map is an involution, and the condition here is the usual unitary equation over that field. None of those hypotheses are assumed, no identification with any other construction of `²A_r(q)` is established, and nothing is asserted about finiteness, perfectness, or simplicity.

Add `TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/UnitaryFixedPoints.lean`. The two general invariance equations land in `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/GraphAutomorphism.lean`, the file that owns `typeAGraphAutomorphism` and `typeAGraphConjugator`: they hold for every commutative ring and every pair of invertible matrices, so stating them only for a carrier point at a fixed Frobenius parameter would be strictly weaker than the proof. Reading the fixed group inside `GL_{r+1}(A)` needs no new declaration: `TauCeti.map_subtype_fixedSubgroup_of_coe_eq` and `TauCeti.SlStd.coe_twistedFrobenius` reduce membership to the equivalences proved here, and the module documentation records that route. Mathlib's `Matrix.unitaryGroup` is not reused because it is the unitary group of the conjugate-transpose involution of a `StarRing`, whereas the map here is the `q`-power ring endomorphism of a ring of exponential characteristic `p`, no compatible `StarRing` structure is assumed, and the Gram matrix is the pinned `Q` rather than the identity; the module documentation records that, together with the fact that at this generality the `q`-power map is a ring endomorphism and an involution only on the `q ^ 2`-power Frobenius-fixed subring where the entries of a fixed point live. No Mathlib source or external formalization is vendored. The conventions follow R. W. Carter, *Simple Groups of Lie Type*, Chapter 14, and *Finite Groups of Lie Type: Conjugacy Classes and Complex Characters*, §§1.15 and 1.17, R. Steinberg, *Lectures on Chevalley Groups*, §11, and Gorenstein--Lyons--Solomon for the small-field convention indexing the twisted type-`A` family by `q`, as cited in the module documentation.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"slstd-twistedfrobenius-eq-self-iff"}-->

🤖 Prepared with Claude Code

