### PR TITLE
feat: strongly continuous one-parameter groups and their generators

### DIFF
--- a/TauCeti/Analysis/Normed/Operator/Basic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Basic.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Operator.Basic
+
+/-!
+# Basic facts about bounded operators
+
+This file records general-purpose facts about continuous linear maps.
+-/
+
+public section
+
+open scoped Topology
+open Filter
+
+namespace TauCeti
+
+variable {𝕜 X Y : Type*} [NontriviallyNormedField 𝕜]
+variable [NormedAddCommGroup X] [NormedSpace 𝕜 X]
+variable [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
+
+namespace ContinuousLinearMap
+
+/-- A uniformly bounded family of continuous linear maps is jointly continuous along convergent
+operator evaluations and arguments. -/
+theorem tendsto_apply_of_eventually_norm_le {ι : Type*} {l : Filter ι}
+    {T : ι → X →L[𝕜] Y} {C : ℝ} {g : ι → X} {z : X} {w : Y}
+    (hT : ∀ᶠ i in l, ‖T i‖ ≤ C) (hz : Tendsto (fun i => T i z) l (𝓝 w))
+    (hg : Tendsto g l (𝓝 z)) : Tendsto (fun i => T i (g i)) l (𝓝 w) := by
+  have hmove : Tendsto (fun i => T i (g i - z)) l (𝓝 0) := by
+    refine squeeze_zero_norm' (a := fun i => C * ‖g i - z‖) ?_ ?_
+    · filter_upwards [hT] with i hi
+      exact (ContinuousLinearMap.le_opNorm _ _).trans
+        (mul_le_mul_of_nonneg_right hi (norm_nonneg _))
+    · simpa using (tendsto_iff_norm_sub_tendsto_zero.mp hg).const_mul C
+  have hsplit : ∀ i, T i (g i) = T i (g i - z) + T i z := fun i => by
+    rw [← ContinuousLinearMap.map_add, sub_add_cancel]
+  simpa using (hmove.add hz).congr fun i => (hsplit i).symm
+
+end ContinuousLinearMap
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Normed/Operator/Basic.lean
+++ b/TauCeti/Analysis/Normed/Operator/Basic.lean
@@ -10,7 +10,12 @@ public import Mathlib.Analysis.Normed.Operator.Basic
 /-!
 # Basic facts about bounded operators
 
-This file records general-purpose facts about continuous linear maps.
+This file records a shared uniform-bound lemma for continuous linear maps. It lets an evaluation
+`T i (g i)` pass to the limit when the operators `T i` are eventually uniformly bounded, their
+values at the limiting argument converge, and the arguments `g i` converge. In particular, it
+supplies the common continuity step for
+`StronglyContinuousSemigroup.tendsto_realOperator_apply` and
+`StronglyContinuousGroup.tendsto_apply`.
 -/
 
 public section
@@ -26,8 +31,8 @@ variable [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
 
 namespace ContinuousLinearMap
 
-/-- A uniformly bounded family of continuous linear maps is jointly continuous along convergent
-operator evaluations and arguments. -/
+/-- If `T i` is eventually uniformly bounded, `T i z` tends to `w`, and `g i` tends to `z`, then
+the moving evaluations `T i (g i)` tend to `w`. -/
 theorem tendsto_apply_of_eventually_norm_le {ι : Type*} {l : Filter ι}
     {T : ι → X →L[𝕜] Y} {C : ℝ} {g : ι → X} {z : X} {w : Y}
     (hT : ∀ᶠ i in l, ‖T i‖ ≤ C) (hz : Tendsto (fun i => T i z) l (𝓝 w))

--- a/TauCeti/Analysis/Normed/Operator/Exponential.lean
+++ b/TauCeti/Analysis/Normed/Operator/Exponential.lean
@@ -45,6 +45,16 @@ theorem norm_exp_le_exp_norm (h_one : ‖(1 : 𝔸)‖ ≤ 1) (x : 𝔸) :
 
 variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
 
+/-- The exponential of a real scalar multiple of a bounded operator satisfies
+`‖exp (t A)‖ ≤ exp (‖A‖ |t|)`. -/
+theorem norm_exp_smul_le [CompleteSpace X] (A : X →L[ℝ] X) (t : ℝ) :
+    ‖exp (t • A)‖ ≤ Real.exp (‖A‖ * |t|) := by
+  let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
+  calc
+    ‖exp (t • A)‖ ≤ Real.exp ‖t • A‖ :=
+      norm_exp_le_exp_norm ContinuousLinearMap.norm_id_le _
+    _ = Real.exp (‖A‖ * |t|) := by rw [norm_smul, Real.norm_eq_abs, mul_comm]
+
 namespace ContinuousLinearMap
 
 /-- If every power of a bounded operator `B` has norm at most `M`, then

--- a/TauCeti/Analysis/Normed/Operator/Exponential.lean
+++ b/TauCeti/Analysis/Normed/Operator/Exponential.lean
@@ -47,7 +47,7 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
 
 /-- The exponential of a real scalar multiple of a bounded operator satisfies
 `‖exp (t A)‖ ≤ exp (‖A‖ |t|)`. -/
-theorem norm_exp_smul_le [CompleteSpace X] (A : X →L[ℝ] X) (t : ℝ) :
+theorem norm_exp_smul_le (A : X →L[ℝ] X) (t : ℝ) :
     ‖exp (t • A)‖ ≤ Real.exp (‖A‖ * |t|) := by
   let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
   calc

--- a/TauCeti/Analysis/Normed/Operator/Exponential.lean
+++ b/TauCeti/Analysis/Normed/Operator/Exponential.lean
@@ -55,6 +55,13 @@ theorem norm_exp_smul_le (A : X →L[ℝ] X) (t : ℝ) :
       norm_exp_le_exp_norm ContinuousLinearMap.norm_id_le _
     _ = Real.exp (‖A‖ * |t|) := by rw [norm_smul, Real.norm_eq_abs, mul_comm]
 
+/-- Exponentials of real scalar multiples of the same bounded operator split over addition. -/
+theorem exp_add_smul [CompleteSpace X] (A : X →L[ℝ] X) (s t : ℝ) :
+    exp ((s + t) • A) = (exp (s • A)).comp (exp (t • A)) := by
+  let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
+  rw [add_smul, exp_add_of_commute (((Commute.refl A).smul_left _).smul_right _),
+    ContinuousLinearMap.mul_def]
+
 namespace ContinuousLinearMap
 
 /-- If every power of a bounded operator `B` has norm at most `M`, then

--- a/TauCeti/Analysis/Semigroups/BoundedGenerator/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator/Basic.lean
@@ -58,9 +58,7 @@ def ofBounded (A : X →L[ℝ] X) : StronglyContinuousSemigroup X where
   map_zero' := by
     rw [NNReal.coe_zero, zero_smul, exp_zero, ContinuousLinearMap.one_def]
   map_add' s t := by
-    let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
-    rw [NNReal.coe_add, add_smul,
-      exp_add_of_commute (((Commute.refl A).smul_left _).smul_right _), ContinuousLinearMap.mul_def]
+    rw [NNReal.coe_add, TauCeti.exp_add_smul]
   continuousAt_zero' x :=
     (((differentiable_exp_smul_const ℝ A).continuous.comp NNReal.continuous_coe).clm_apply
       continuous_const).continuousAt

--- a/TauCeti/Analysis/Semigroups/BoundedGenerator/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator/Basic.lean
@@ -100,13 +100,9 @@ theorem ofBounded_realOperator_continuousOn_Ici (A : X →L[ℝ] X) :
 
 /-- The semigroup `ofBounded A` has the growth bound `(‖A‖, 1)`: `‖exp (t • A)‖ ≤ e^{‖A‖ t}`. -/
 theorem ofBounded_hasGrowthBound (A : X →L[ℝ] X) : (ofBounded A).HasGrowthBound ‖A‖ 1 := by
-  let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
   refine hasGrowthBound_of_bound le_rfl (fun t ht => ?_)
   rw [one_mul, ofBounded_realOperator_of_nonneg A ht]
-  calc ‖exp (t • A)‖ ≤ Real.exp ‖t • A‖ :=
-        TauCeti.norm_exp_le_exp_norm ContinuousLinearMap.norm_id_le _
-    _ = Real.exp (‖A‖ * t) := by
-        rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg ht, mul_comm]
+  simpa only [abs_of_nonneg ht] using TauCeti.norm_exp_smul_le A t
 
 /-- The difference quotient `(exp (t • A) x - x)/t` tends to `A x` as `t → 0⁺`: the strong
 derivative of `ofBounded A` at time `0` is `A`. -/

--- a/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
+++ b/TauCeti/Analysis/Semigroups/Generation/LimitSemigroup.lean
@@ -6,6 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Semigroups.Generation.Yosida.Basic
+import TauCeti.Analysis.Normed.Operator.Basic
+import TauCeti.Analysis.Normed.Operator.Exponential
 import Mathlib.Topology.UniformSpace.UniformApproximation
 
 /-!
@@ -130,10 +132,7 @@ theorem yosidaLimit_zero (A : X →ₗ.[ℝ] X) (x : X) : yosidaLimit A 0 x = x 
 pointwise, for a bounded operator `B`. -/
 private theorem exp_add_smul_apply (B : X →L[ℝ] X) (s t : ℝ) (x : X) :
     exp ((s + t) • B) x = exp (s • B) (exp (t • B) x) := by
-  let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
-  rw [add_smul, exp_add_of_commute (((Commute.refl B).smul_left s).smul_right t),
-    ContinuousLinearMap.mul_def]
-  rfl
+  exact DFunLike.congr_fun (TauCeti.exp_add_smul B s t) x
 
 /-! ## Shared limit-semigroup scaffolding -/
 
@@ -179,34 +178,10 @@ private theorem yosidaLimit_time_add_of_tendsto_of_norm_le {A : X →ₗ.[ℝ] X
       (𝓝 (yosidaLimit A (s + t) x)))
     (hbound_s : ∀ᶠ lambda in atTop, ‖exp (s • yosidaApproximation A lambda)‖ ≤ M) :
     yosidaLimit A (s + t) x = yosidaLimit A s (yosidaLimit A t x) := by
-  set y := yosidaLimit A t x with hy
-  set z := yosidaLimit A s y with hz
-  have hstep : Tendsto (fun lambda : ℝ => exp ((s + t) • yosidaApproximation A lambda) x - z)
-      atTop (𝓝 0) := by
-    refine squeeze_zero_norm' (a := fun lambda : ℝ =>
-      M * ‖exp (t • yosidaApproximation A lambda) x - y‖ +
-        ‖exp (s • yosidaApproximation A lambda) y - z‖) ?_ ?_
-    · filter_upwards [hbound_s] with lambda hbound
-      have hsplit : exp ((s + t) • yosidaApproximation A lambda) x - z =
-          exp (s • yosidaApproximation A lambda)
-              (exp (t • yosidaApproximation A lambda) x - y) +
-            (exp (s • yosidaApproximation A lambda) y - z) := by
-        rw [map_sub, exp_add_smul_apply]
-        abel
-      rw [hsplit]
-      refine (norm_add_le _ _).trans ?_
-      refine add_le_add ?_ le_rfl
-      exact (ContinuousLinearMap.le_opNorm _ _).trans
-        (mul_le_mul_of_nonneg_right hbound (norm_nonneg _))
-    · have h1 : Tendsto
-          (fun lambda : ℝ => ‖exp (t • yosidaApproximation A lambda) x - y‖) atTop (𝓝 0) :=
-        tendsto_iff_norm_sub_tendsto_zero.mp htend_t
-      have h2 : Tendsto
-          (fun lambda : ℝ => ‖exp (s • yosidaApproximation A lambda) y - z‖) atTop (𝓝 0) :=
-        tendsto_iff_norm_sub_tendsto_zero.mp htend_s
-      simpa using (h1.const_mul M).add h2
   refine tendsto_nhds_unique htend_st ?_
-  simpa using hstep.add_const z
+  have hcomp := TauCeti.ContinuousLinearMap.tendsto_apply_of_eventually_norm_le
+    hbound_s htend_s htend_t
+  simpa only [exp_add_smul_apply] using hcomp
 
 /-- The Yosida limit is continuous in time on a compact interval whenever the approximating
 exponentials converge uniformly there. -/

--- a/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/IteratedDomain.lean
@@ -9,6 +9,7 @@ public import TauCeti.Analysis.Normed.Operator.Dense
 public import TauCeti.Analysis.Normed.Operator.Resolvent.DomainPow
 public import TauCeti.Analysis.Semigroups.Generator.Invariance
 public import TauCeti.Analysis.Semigroups.Resolvent.Identity
+import TauCeti.Analysis.Normed.Operator.Basic
 
 /-!
 # The iterated generator domains of a strongly continuous semigroup are dense
@@ -149,23 +150,12 @@ limit. This is the induction step behind the convergence of `lambdaⁿ R(lambda)
 private theorem tendsto_smul_resolventFun_comp (hb : S.HasGrowthBound omega M) {f : ℝ → X} {x : X}
     (hf : Tendsto f atTop (nhds x)) :
     Tendsto (fun lambda : ℝ => lambda • S.resolventFun hb lambda (f lambda)) atTop (nhds x) := by
-  have hsmall : Tendsto
-      (fun lambda : ℝ => (lambda • S.resolventFun hb lambda) (f lambda - x)) atTop (nhds 0) := by
-    have hnorm : Tendsto (fun lambda : ℝ => 2 * M * ‖f lambda - x‖) atTop (nhds 0) := by
-      simpa using (tendsto_iff_norm_sub_tendsto_zero.mp hf).const_mul (2 * M)
-    refine squeeze_zero_norm' ?_ hnorm
+  have hbound : ∀ᶠ lambda : ℝ in atTop, ‖lambda • S.resolventFun hb lambda‖ ≤ 2 * M := by
     filter_upwards [eventually_ge_atTop (2 * |omega| + 1)] with lambda hlambda
-    calc ‖(lambda • S.resolventFun hb lambda) (f lambda - x)‖
-        ≤ ‖lambda • S.resolventFun hb lambda‖ * ‖f lambda - x‖ :=
-          ContinuousLinearMap.le_opNorm _ _
-      _ ≤ 2 * M * ‖f lambda - x‖ := by
-          gcongr
-          exact S.norm_smul_resolventFun_le hb hlambda
-  have hsum := hsmall.add (S.tendsto_smul_resolventFun_apply hb x)
-  rw [zero_add] at hsum
-  refine hsum.congr fun lambda => ?_
-  rw [map_sub]
-  simp
+    exact S.norm_smul_resolventFun_le hb hlambda
+  simpa only [smul_apply] using
+    (TauCeti.ContinuousLinearMap.tendsto_apply_of_eventually_norm_le hbound
+      (S.tendsto_smul_resolventFun_apply hb x) hf)
 
 /-- **The iterated scaled resolvents converge strongly to the identity**:
 `lambdaⁿ R(lambda)ⁿ x → x` as `lambda → ∞`. -/

--- a/TauCeti/Analysis/Semigroups/Group/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Basic.lean
@@ -219,8 +219,11 @@ theorem toSemigroup_realOperator_of_nonneg (U : StronglyContinuousGroup X) {t : 
     U.toSemigroup.realOperator t = U t := by
   rw [StronglyContinuousSemigroup.realOperator_def, toSemigroup_apply, Real.coe_toNNReal t ht]
 
-/-- At a nonnegative real time the reversed group's forward semigroup runs `U` backwards. -/
-@[simp]
+/-- At a nonnegative real time the reversed group's forward semigroup runs `U` backwards.
+
+Not a `simp` lemma: `simp` already reaches this form through
+`toSemigroup_realOperator_of_nonneg` and `reflect_apply`, so tagging it duplicates a rule
+`simp` derives anyway. -/
 theorem reflect_toSemigroup_realOperator_of_nonneg
     (U : StronglyContinuousGroup X) {t : ℝ} (ht : 0 ≤ t) :
     U.reflect.toSemigroup.realOperator t = U (-t) := by

--- a/TauCeti/Analysis/Semigroups/Group/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Basic.lean
@@ -213,7 +213,6 @@ theorem toSemigroup_realOperator (U : StronglyContinuousGroup X) {t : ℝ} (ht :
   rw [StronglyContinuousSemigroup.realOperator_def, toSemigroup_apply, Real.coe_toNNReal t ht]
 
 /-- At a nonnegative real time the reversed group's forward semigroup runs `U` backwards. -/
-@[simp]
 theorem reflect_toSemigroup_realOperator (U : StronglyContinuousGroup X) {t : ℝ} (ht : 0 ≤ t) :
     U.reflect.toSemigroup.realOperator t = U (-t) := by
   rw [U.reflect.toSemigroup_realOperator ht, reflect_apply]

--- a/TauCeti/Analysis/Semigroups/Group/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Basic.lean
@@ -10,7 +10,7 @@ public import TauCeti.Analysis.Semigroups.GrowthBound
 /-!
 # Strongly continuous one-parameter groups
 
-A **C₀-group** on a Banach space `X` is a family `U : ℝ → X →L[ℝ] X` indexed by *all* of `ℝ`
+A **C₀-group** on a real normed space `X` is a family `U : ℝ → X →L[ℝ] X` indexed by *all* of `ℝ`
 with `U 0 = 1`, `U (s + t) = U s ∘ U t`, and `t ↦ U t x` continuous at `0`. It is not reached by
 the C₀-semigroup API: the two-sided law makes every `U t` invertible, with inverse `U (-t)`, and
 forces the orbits to be continuous on the whole line rather than only on `[0, ∞)`. The unitary
@@ -65,10 +65,11 @@ namespace TauCeti.Semigroups
 
 variable (X : Type*) [NormedAddCommGroup X] [NormedSpace ℝ X]
 
-/-- A strongly continuous one-parameter group (C₀-group) on a Banach space.
+/-- A strongly continuous one-parameter group (C₀-group) on a real normed space.
 
 The family is indexed by all of `ℝ`; the axioms are `U 0 = Id`, `U (s + t) = U s ∘ U t` at every
-pair of real times, and strong continuity at `0`. -/
+pair of real times, and strong continuity at `0`. Completeness is imposed separately on results
+that require it, such as `existsGrowthBound`. -/
 structure StronglyContinuousGroup where
   /-- The group operator at time `t : ℝ`. -/
   toFun : ℝ → X →L[ℝ] X
@@ -294,7 +295,7 @@ theorem existsGrowthBound (U : StronglyContinuousGroup X) :
       (Real.exp_nonneg _) (le_trans zero_le_one (le_max_of_le_left hb₁.one_le)))
     exact mul_le_mul_of_nonneg_right (le_max_left _ _) ht
   · have hnt : 0 ≤ -t := by linarith
-    rw [show t = -(-t) by ring, ← U.reflect_toSemigroup_realOperator hnt, abs_neg,
+    rw [← neg_neg t, ← U.reflect_toSemigroup_realOperator hnt, abs_neg,
       abs_of_nonneg hnt]
     refine (hb₂.bound (-t) hnt).trans (mul_le_mul (le_max_right _ _) (Real.exp_le_exp.mpr ?_)
       (Real.exp_nonneg _) (le_trans zero_le_one (le_max_of_le_left hb₁.one_le)))

--- a/TauCeti/Analysis/Semigroups/Group/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Basic.lean
@@ -1,0 +1,344 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.GrowthBound
+
+/-!
+# Strongly continuous one-parameter groups
+
+A **C₀-group** on a Banach space `X` is a family `U : ℝ → X →L[ℝ] X` indexed by *all* of `ℝ`
+with `U 0 = 1`, `U (s + t) = U s ∘ U t`, and `t ↦ U t x` continuous at `0`. It is not reached by
+the C₀-semigroup API: the two-sided law makes every `U t` invertible, with inverse `U (-t)`, and
+forces the orbits to be continuous on the whole line rather than only on `[0, ∞)`. The unitary
+group `e^{itH}` of a Schrödinger evolution is the motivating example.
+
+This file sets up the object and the two ways of viewing it through the existing
+`StronglyContinuousSemigroup` theory:
+
+* the **forward semigroup** `U.toSemigroup`, the restriction of `U` to `[0, ∞)`;
+* the **time reversal** `U.reflect`, the C₀-group `t ↦ U (-t)`, whose forward semigroup is the
+  backward half of `U`.
+
+Every statement about negative times is obtained by applying a semigroup statement to
+`U.reflect`, so no half of the theory is developed twice.
+
+## Main definitions
+
+* `TauCeti.Semigroups.StronglyContinuousGroup`: the C₀-group structure.
+* `TauCeti.Semigroups.StronglyContinuousGroup.toContinuousLinearEquiv`: `U t` as a continuous
+  linear equivalence, with inverse `U (-t)`.
+* `TauCeti.Semigroups.StronglyContinuousGroup.reflect`: the time-reversed group `t ↦ U (-t)`.
+* `TauCeti.Semigroups.StronglyContinuousGroup.toSemigroup`: the forward C₀-semigroup.
+* `TauCeti.Semigroups.StronglyContinuousGroup.HasGrowthBound`: the two-sided growth bound
+  `‖U t‖ ≤ M * exp (ω * |t|)`.
+
+## Main results
+
+* `TauCeti.Semigroups.StronglyContinuousGroup.continuous_apply`: the orbits of a C₀-group are
+  continuous on all of `ℝ`, not merely at `0`.
+* `TauCeti.Semigroups.StronglyContinuousGroup.existsGrowthBound`: every C₀-group has a finite
+  two-sided exponential growth bound.
+* `TauCeti.Semigroups.StronglyContinuousGroup.isometry_of_norm_le_one`: a C₀-group that
+  contracts in both time directions is a group of isometries.
+* `TauCeti.Semigroups.StronglyContinuousGroup.tendsto_apply`: joint strong continuity
+  `U (f i) (g i) → U r z`, at every real time and without a sign restriction.
+
+## References
+
+Engel--Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Section II.3.11;
+Pazy, *Semigroups of Linear Operators and Applications to Partial Differential Equations*,
+Section 1.6.
+-/
+
+public section
+
+noncomputable section
+
+open scoped Topology NNReal
+open Filter
+
+namespace TauCeti.Semigroups
+
+variable (X : Type*) [NormedAddCommGroup X] [NormedSpace ℝ X]
+
+/-- A strongly continuous one-parameter group (C₀-group) on a Banach space.
+
+The family is indexed by all of `ℝ`; the axioms are `U 0 = Id`, `U (s + t) = U s ∘ U t` at every
+pair of real times, and strong continuity at `0`. -/
+structure StronglyContinuousGroup where
+  /-- The group operator at time `t : ℝ`. -/
+  toFun : ℝ → X →L[ℝ] X
+  /-- `U 0 = Id`. -/
+  map_zero' : toFun 0 = ContinuousLinearMap.id ℝ X
+  /-- `U (s + t) = U s ∘ U t`, at every pair of real times. -/
+  map_add' : ∀ s t : ℝ, toFun (s + t) = (toFun s).comp (toFun t)
+  /-- Strong continuity at `0`. -/
+  continuousAt_zero' : ∀ x : X, ContinuousAt (fun t : ℝ => toFun t x) 0
+
+variable {X}
+
+namespace StronglyContinuousGroup
+
+instance instFunLike : FunLike (StronglyContinuousGroup X) ℝ (X →L[ℝ] X) where
+  coe := toFun
+  coe_injective := by
+    intro U V h
+    cases U
+    cases V
+    congr
+
+@[ext]
+theorem ext {U V : StronglyContinuousGroup X} (h : ∀ t, U t = V t) : U = V :=
+  DFunLike.ext _ _ h
+
+/-- The group operator at time `0` is the identity. -/
+@[simp]
+theorem map_zero (U : StronglyContinuousGroup X) : U 0 = ContinuousLinearMap.id ℝ X :=
+  U.map_zero'
+
+/-- Pointwise form of `StronglyContinuousGroup.map_zero`. -/
+theorem map_zero_apply (U : StronglyContinuousGroup X) (x : X) : U 0 x = x := by
+  rw [U.map_zero]
+  rfl
+
+/-- The two-sided group law. -/
+@[simp]
+theorem map_add (U : StronglyContinuousGroup X) (s t : ℝ) : U (s + t) = (U s).comp (U t) :=
+  U.map_add' s t
+
+/-- Pointwise form of `StronglyContinuousGroup.map_add`. -/
+theorem map_add_apply (U : StronglyContinuousGroup X) (s t : ℝ) (x : X) :
+    U (s + t) x = U s (U t x) := by
+  rw [U.map_add]
+  rfl
+
+/-! ## Invertibility -/
+
+/-- `U (-t)` is a left inverse of `U t`. -/
+@[simp]
+theorem map_neg_apply_map_apply (U : StronglyContinuousGroup X) (t : ℝ) (x : X) :
+    U (-t) (U t x) = x := by
+  rw [← U.map_add_apply, neg_add_cancel, U.map_zero_apply]
+
+/-- `U (-t)` is a right inverse of `U t`. -/
+@[simp]
+theorem map_apply_map_neg_apply (U : StronglyContinuousGroup X) (t : ℝ) (x : X) :
+    U t (U (-t) x) = x := by
+  rw [← U.map_add_apply, add_neg_cancel, U.map_zero_apply]
+
+/-- The group operator at time `t`, packaged as a continuous linear equivalence whose inverse is
+the operator at time `-t`. -/
+def toContinuousLinearEquiv (U : StronglyContinuousGroup X) (t : ℝ) : X ≃L[ℝ] X :=
+  ContinuousLinearEquiv.equivOfInverse (U t) (U (-t)) (U.map_neg_apply_map_apply t)
+    (U.map_apply_map_neg_apply t)
+
+@[simp]
+theorem toContinuousLinearEquiv_apply (U : StronglyContinuousGroup X) (t : ℝ) (x : X) :
+    U.toContinuousLinearEquiv t x = U t x := by
+  rw [toContinuousLinearEquiv]
+  rfl
+
+@[simp]
+theorem toContinuousLinearEquiv_symm_apply (U : StronglyContinuousGroup X) (t : ℝ) (x : X) :
+    (U.toContinuousLinearEquiv t).symm x = U (-t) x := by
+  rw [toContinuousLinearEquiv]
+  rfl
+
+/-- Every operator of a C₀-group is bijective. -/
+theorem bijective (U : StronglyContinuousGroup X) (t : ℝ) : Function.Bijective (U t) :=
+  (U.toContinuousLinearEquiv t).bijective
+
+/-! ## Strong continuity on the whole line -/
+
+/-- **The orbits of a C₀-group are continuous on all of `ℝ`.** The two-sided group law turns the
+increment at `t₀` into an increment at `0`, where continuity is assumed. -/
+theorem continuous_apply (U : StronglyContinuousGroup X) (x : X) :
+    Continuous fun t : ℝ => U t x := by
+  rw [continuous_iff_continuousAt]
+  intro t₀
+  have hshift : ContinuousAt (fun t : ℝ => t - t₀) t₀ := by
+    fun_prop
+  have hinner : ContinuousAt (fun t : ℝ => U (t - t₀) x) t₀ :=
+    ContinuousAt.comp_of_eq (U.continuousAt_zero' x) hshift (sub_self t₀)
+  have hfun : (fun t : ℝ => U t x) = fun t : ℝ => U t₀ (U (t - t₀) x) := by
+    funext t
+    have ht : t₀ + (t - t₀) = t := by ring
+    rw [← U.map_add_apply, ht]
+  rw [hfun]
+  exact (U t₀).continuous.continuousAt.comp hinner
+
+/-! ## Time reversal and the forward semigroup -/
+
+/-- The time-reversed C₀-group `t ↦ U (-t)`. -/
+def reflect (U : StronglyContinuousGroup X) : StronglyContinuousGroup X where
+  toFun t := U (-t)
+  map_zero' := by rw [neg_zero, U.map_zero]
+  map_add' s t := by rw [← U.map_add, ← neg_add]
+  continuousAt_zero' x :=
+    ContinuousAt.comp_of_eq (U.continuousAt_zero' x) (by fun_prop) neg_zero
+
+@[simp]
+theorem reflect_apply (U : StronglyContinuousGroup X) (t : ℝ) : U.reflect t = U (-t) := by
+  rw [reflect]
+  rfl
+
+@[simp]
+theorem reflect_reflect (U : StronglyContinuousGroup X) : U.reflect.reflect = U := by
+  ext t
+  rw [reflect_apply, reflect_apply, neg_neg]
+
+/-- The forward C₀-semigroup of a C₀-group: the restriction of `U` to nonnegative times. -/
+def toSemigroup (U : StronglyContinuousGroup X) : StronglyContinuousSemigroup X where
+  toFun t := U t
+  map_zero' := by rw [NNReal.coe_zero, U.map_zero]
+  map_add' s t := by rw [NNReal.coe_add, U.map_add]
+  continuousAt_zero' x :=
+    ContinuousAt.comp_of_eq (U.continuousAt_zero' x)
+      (NNReal.continuous_coe.continuousAt (x := 0)) NNReal.coe_zero
+
+@[simp]
+theorem toSemigroup_apply (U : StronglyContinuousGroup X) (t : ℝ≥0) :
+    U.toSemigroup t = U (t : ℝ) := by
+  rw [toSemigroup]
+  rfl
+
+/-- At a nonnegative real time the forward semigroup's real-time shim is the group operator. -/
+@[simp]
+theorem toSemigroup_realOperator (U : StronglyContinuousGroup X) {t : ℝ} (ht : 0 ≤ t) :
+    U.toSemigroup.realOperator t = U t := by
+  rw [StronglyContinuousSemigroup.realOperator_def, toSemigroup_apply, Real.coe_toNNReal t ht]
+
+/-- At a nonnegative real time the reversed group's forward semigroup runs `U` backwards. -/
+@[simp]
+theorem reflect_toSemigroup_realOperator (U : StronglyContinuousGroup X) {t : ℝ} (ht : 0 ≤ t) :
+    U.reflect.toSemigroup.realOperator t = U (-t) := by
+  rw [U.reflect.toSemigroup_realOperator ht, reflect_apply]
+
+/-! ## Two-sided growth bounds -/
+
+/-- A C₀-group has exponential growth bound `(ω, M)`, with `M ≥ 1`, if `‖U t‖ ≤ M e^{ω |t|}` at
+every real time. The absolute value is what distinguishes this from the semigroup bound: a
+C₀-group grows at most exponentially in *both* time directions. -/
+def HasGrowthBound (U : StronglyContinuousGroup X) (ω M : ℝ) : Prop :=
+  1 ≤ M ∧ ∀ t : ℝ, ‖U t‖ ≤ M * Real.exp (ω * |t|)
+
+/-- The multiplicative constant in a growth bound is at least one. -/
+theorem HasGrowthBound.one_le {U : StronglyContinuousGroup X} {ω M : ℝ}
+    (hb : U.HasGrowthBound ω M) : 1 ≤ M :=
+  hb.1
+
+/-- The operator-norm estimate supplied by a growth bound. -/
+theorem HasGrowthBound.bound {U : StronglyContinuousGroup X} {ω M : ℝ}
+    (hb : U.HasGrowthBound ω M) (t : ℝ) : ‖U t‖ ≤ M * Real.exp (ω * |t|) :=
+  hb.2 t
+
+/-- Constructor for a two-sided growth bound from the multiplicative lower bound and the
+operator-norm estimate. -/
+theorem hasGrowthBound_of_bound {U : StronglyContinuousGroup X} {ω M : ℝ} (hM : 1 ≤ M)
+    (hbound : ∀ t : ℝ, ‖U t‖ ≤ M * Real.exp (ω * |t|)) : U.HasGrowthBound ω M :=
+  ⟨hM, hbound⟩
+
+/-- A two-sided growth bound restricts to a growth bound for the forward semigroup. -/
+theorem HasGrowthBound.toSemigroup {U : StronglyContinuousGroup X} {ω M : ℝ}
+    (hb : U.HasGrowthBound ω M) : U.toSemigroup.HasGrowthBound ω M := by
+  refine StronglyContinuousSemigroup.hasGrowthBound_of_bound hb.one_le fun t ht => ?_
+  rw [U.toSemigroup_realOperator ht]
+  simpa [abs_of_nonneg ht] using hb.bound t
+
+/-- A two-sided growth bound is invariant under time reversal. -/
+theorem HasGrowthBound.reflect {U : StronglyContinuousGroup X} {ω M : ℝ}
+    (hb : U.HasGrowthBound ω M) : U.reflect.HasGrowthBound ω M :=
+  ⟨hb.one_le, fun t => by simpa [abs_neg] using hb.bound (-t)⟩
+
+/-- Growth bound `(0, 1)` is exactly contractivity at every real time. -/
+theorem hasGrowthBound_zero_one_iff (U : StronglyContinuousGroup X) :
+    U.HasGrowthBound 0 1 ↔ ∀ t : ℝ, ‖U t‖ ≤ 1 := by
+  refine ⟨fun hb t => by simpa using hb.bound t, fun h => hasGrowthBound_of_bound le_rfl ?_⟩
+  intro t
+  simpa using h t
+
+/-! ## Contraction groups are groups of isometries -/
+
+/-- **A C₀-group that contracts in both time directions preserves norms.** A strict contraction
+at time `t` would have to be undone by an expansion at time `-t`, which contractivity forbids.
+This is the norm preservation behind unitary groups such as `e^{itH}`. -/
+theorem norm_map_apply_eq_of_norm_le_one (U : StronglyContinuousGroup X)
+    (h : ∀ t : ℝ, ‖U t‖ ≤ 1) (t : ℝ) (x : X) : ‖U t x‖ = ‖x‖ := by
+  have key : ∀ (s : ℝ) (y : X), ‖U s y‖ ≤ ‖y‖ := fun s y =>
+    ((U s).le_opNorm y).trans (mul_le_of_le_one_left (norm_nonneg y) (h s))
+  refine le_antisymm (key t x) ?_
+  calc ‖x‖ = ‖U (-t) (U t x)‖ := by rw [U.map_neg_apply_map_apply]
+    _ ≤ ‖U t x‖ := key (-t) _
+
+/-- Every operator of a contractive C₀-group is an isometry. -/
+theorem isometry_of_norm_le_one (U : StronglyContinuousGroup X) (h : ∀ t : ℝ, ‖U t‖ ≤ 1)
+    (t : ℝ) : Isometry (U t) :=
+  AddMonoidHomClass.isometry_of_norm _ (U.norm_map_apply_eq_of_norm_le_one h t)
+
+variable [CompleteSpace X]
+
+/-- **Every C₀-group has a finite two-sided exponential growth bound.** The forward and backward
+halves are C₀-semigroups, so each has a growth bound; taking the larger exponent and the larger
+constant covers both time directions at once. -/
+theorem existsGrowthBound (U : StronglyContinuousGroup X) :
+    ∃ ω M : ℝ, U.HasGrowthBound ω M := by
+  obtain ⟨ω₁, M₁, hb₁⟩ := U.toSemigroup.existsGrowthBound
+  obtain ⟨ω₂, M₂, hb₂⟩ := U.reflect.toSemigroup.existsGrowthBound
+  refine ⟨max ω₁ ω₂, max M₁ M₂, le_max_of_le_left hb₁.one_le, fun t => ?_⟩
+  rcases le_or_gt 0 t with ht | ht
+  · rw [← U.toSemigroup_realOperator ht, abs_of_nonneg ht]
+    refine (hb₁.bound t ht).trans (mul_le_mul (le_max_left _ _) (Real.exp_le_exp.mpr ?_)
+      (Real.exp_nonneg _) (le_trans zero_le_one (le_max_of_le_left hb₁.one_le)))
+    exact mul_le_mul_of_nonneg_right (le_max_left _ _) ht
+  · have hnt : 0 ≤ -t := by linarith
+    rw [show t = -(-t) by ring, ← U.reflect_toSemigroup_realOperator hnt, abs_neg,
+      abs_of_nonneg hnt]
+    refine (hb₂.bound (-t) hnt).trans (mul_le_mul (le_max_right _ _) (Real.exp_le_exp.mpr ?_)
+      (Real.exp_nonneg _) (le_trans zero_le_one (le_max_of_le_left hb₁.one_le)))
+    exact mul_le_mul_of_nonneg_right (le_max_right _ _) hnt
+
+/-- **Joint strong continuity of a C₀-group**: if `f i → r` and `g i → z`, then
+`U (f i) (g i) → U r z`.
+
+This is the two-sided counterpart of
+`TauCeti.Semigroups.StronglyContinuousSemigroup.tendsto_realOperator_apply`, and needs no sign
+hypothesis on the times: the group has a growth bound valid on the whole line, which supplies
+the uniform operator bound that strong continuity alone does not. -/
+theorem tendsto_apply {ι : Type*} {l : Filter ι} (U : StronglyContinuousGroup X) {f : ι → ℝ}
+    {g : ι → X} {r : ℝ} {z : X} (hf : Tendsto f l (𝓝 r)) (hg : Tendsto g l (𝓝 z)) :
+    Tendsto (fun i => U (f i) (g i)) l (𝓝 (U r z)) := by
+  obtain ⟨ω, M, hb⟩ := U.existsGrowthBound
+  have hM : (0 : ℝ) < M := lt_of_lt_of_le zero_lt_one hb.one_le
+  -- One operator-norm bound valid at every time eventually visited by `f`.
+  have hbound : ∀ᶠ i in l, ‖U (f i)‖ ≤ M * Real.exp (|ω| * (|r| + 1)) := by
+    filter_upwards [hf.eventually (eventually_abs_sub_lt r one_pos)] with i hi
+    have habs : |f i| ≤ |r| + 1 := by
+      have := abs_sub_abs_le_abs_sub (f i) r
+      linarith
+    refine (hb.bound (f i)).trans (mul_le_mul_of_nonneg_left (Real.exp_le_exp.mpr ?_) hM.le)
+    calc ω * |f i| ≤ |ω| * |f i| := mul_le_mul_of_nonneg_right (le_abs_self ω) (abs_nonneg _)
+      _ ≤ |ω| * (|r| + 1) := mul_le_mul_of_nonneg_left habs (abs_nonneg ω)
+  -- The vector moves: uniformly bounded operators send a vanishing increment to `0`.
+  have h1 : Tendsto (fun i => U (f i) (g i - z)) l (𝓝 0) := by
+    refine squeeze_zero_norm' (a := fun i => M * Real.exp (|ω| * (|r| + 1)) * ‖g i - z‖) ?_ ?_
+    · filter_upwards [hbound] with i hi
+      exact (ContinuousLinearMap.le_opNorm _ _).trans
+        (mul_le_mul_of_nonneg_right hi (norm_nonneg _))
+    · simpa using
+        (tendsto_iff_norm_sub_tendsto_zero.mp hg).const_mul (M * Real.exp (|ω| * (|r| + 1)))
+  -- The time moves: this is continuity of the orbit of the fixed vector `z`.
+  have h2 : Tendsto (fun i => U (f i) z) l (𝓝 (U r z)) :=
+    ((U.continuous_apply z).tendsto r).comp hf
+  have hsplit : ∀ i, U (f i) (g i) = U (f i) (g i - z) + U (f i) z := fun i => by
+    rw [← ContinuousLinearMap.map_add, sub_add_cancel]
+  simpa using (h1.add h2).congr fun i => (hsplit i).symm
+
+end StronglyContinuousGroup
+
+end TauCeti.Semigroups
+
+end

--- a/TauCeti/Analysis/Semigroups/Group/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Basic.lean
@@ -23,8 +23,9 @@ This file sets up the object and the two ways of viewing it through the existing
 * the **time reversal** `U.reflect`, the C₀-group `t ↦ U (-t)`, whose forward semigroup is the
   backward half of `U`.
 
-Statements that need the backward semigroup -- the growth bound and generator uniqueness -- are
-obtained by applying a semigroup statement to `U.reflect`.
+The growth bound is obtained by applying semigroup results to both halves. The generator API in
+`TauCeti.Analysis.Semigroups.Group.Generator`, including generator uniqueness, similarly uses
+`U.reflect` for the backward half.
 
 ## Main definitions
 
@@ -214,14 +215,16 @@ theorem toSemigroup_apply (U : StronglyContinuousGroup X) (t : ℝ≥0) :
 
 /-- At a nonnegative real time the forward semigroup's real-time shim is the group operator. -/
 @[simp]
-theorem toSemigroup_realOperator (U : StronglyContinuousGroup X) {t : ℝ} (ht : 0 ≤ t) :
+theorem toSemigroup_realOperator_of_nonneg (U : StronglyContinuousGroup X) {t : ℝ} (ht : 0 ≤ t) :
     U.toSemigroup.realOperator t = U t := by
   rw [StronglyContinuousSemigroup.realOperator_def, toSemigroup_apply, Real.coe_toNNReal t ht]
 
 /-- At a nonnegative real time the reversed group's forward semigroup runs `U` backwards. -/
-theorem reflect_toSemigroup_realOperator (U : StronglyContinuousGroup X) {t : ℝ} (ht : 0 ≤ t) :
+@[simp]
+theorem reflect_toSemigroup_realOperator_of_nonneg
+    (U : StronglyContinuousGroup X) {t : ℝ} (ht : 0 ≤ t) :
     U.reflect.toSemigroup.realOperator t = U (-t) := by
-  rw [U.reflect.toSemigroup_realOperator ht, reflect_apply]
+  rw [U.reflect.toSemigroup_realOperator_of_nonneg ht, reflect_apply]
 
 /-! ## Two-sided growth bounds -/
 
@@ -273,7 +276,7 @@ theorem hasGrowthBound_of_bound {U : StronglyContinuousGroup X} {ω M : ℝ} (hM
 theorem HasGrowthBound.toSemigroup {U : StronglyContinuousGroup X} {ω M : ℝ}
     (hb : U.HasGrowthBound ω M) : U.toSemigroup.HasGrowthBound ω M := by
   refine StronglyContinuousSemigroup.hasGrowthBound_of_bound hb.one_le fun t ht => ?_
-  rw [U.toSemigroup_realOperator ht]
+  rw [U.toSemigroup_realOperator_of_nonneg ht]
   simpa [abs_of_nonneg ht] using hb.bound t
 
 /-- A two-sided growth bound is invariant under time reversal. -/
@@ -319,10 +322,10 @@ theorem existsGrowthBound (U : StronglyContinuousGroup X) :
   have hb₂' := hb₂.mono (le_max_right ω₁ ω₂) (le_max_right M₁ M₂)
   refine ⟨max ω₁ ω₂, max M₁ M₂, le_max_of_le_left hb₁.one_le, fun t => ?_⟩
   rcases le_or_gt 0 t with ht | ht
-  · rw [← U.toSemigroup_realOperator ht, abs_of_nonneg ht]
+  · rw [← U.toSemigroup_realOperator_of_nonneg ht, abs_of_nonneg ht]
     exact hb₁'.bound t ht
   · have hnt : 0 ≤ -t := by linarith
-    rw [← neg_neg t, ← U.reflect_toSemigroup_realOperator hnt, abs_neg,
+    rw [← neg_neg t, ← U.reflect_toSemigroup_realOperator_of_nonneg hnt, abs_neg,
       abs_of_nonneg hnt]
     exact hb₂'.bound (-t) hnt
 
@@ -350,7 +353,7 @@ theorem tendsto_apply {ι : Type*} {l : Filter ι} (U : StronglyContinuousGroup 
   -- The time moves: this is continuity of the orbit of the fixed vector `z`.
   have h2 : Tendsto (fun i => U (f i) z) l (𝓝 (U r z)) :=
     ((U.continuous_orbit z).tendsto r).comp hf
-  exact tendsto_apply_of_eventually_norm_le hbound h2 hg
+  exact TauCeti.ContinuousLinearMap.tendsto_apply_of_eventually_norm_le hbound h2 hg
 
 end StronglyContinuousGroup
 

--- a/TauCeti/Analysis/Semigroups/Group/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Basic.lean
@@ -23,8 +23,8 @@ This file sets up the object and the two ways of viewing it through the existing
 * the **time reversal** `U.reflect`, the C₀-group `t ↦ U (-t)`, whose forward semigroup is the
   backward half of `U`.
 
-Every statement about negative times is obtained by applying a semigroup statement to
-`U.reflect`, so no half of the theory is developed twice.
+Statements that need the backward semigroup -- the growth bound and generator uniqueness -- are
+obtained by applying a semigroup statement to `U.reflect`.
 
 ## Main definitions
 
@@ -38,11 +38,11 @@ Every statement about negative times is obtained by applying a semigroup stateme
 
 ## Main results
 
-* `TauCeti.Semigroups.StronglyContinuousGroup.continuous_apply`: the orbits of a C₀-group are
+* `TauCeti.Semigroups.StronglyContinuousGroup.continuous_orbit`: the orbits of a C₀-group are
   continuous on all of `ℝ`, not merely at `0`.
 * `TauCeti.Semigroups.StronglyContinuousGroup.existsGrowthBound`: every C₀-group has a finite
   two-sided exponential growth bound.
-* `TauCeti.Semigroups.StronglyContinuousGroup.isometry_of_norm_le_one`: a C₀-group that
+* `TauCeti.Semigroups.StronglyContinuousGroup.isometry_of_forall_norm_le_one`: a C₀-group that
   contracts in both time directions is a group of isometries.
 * `TauCeti.Semigroups.StronglyContinuousGroup.tendsto_apply`: joint strong continuity
   `U (f i) (g i) → U r z`, at every real time and without a sign restriction.
@@ -117,6 +117,11 @@ theorem map_add_apply (U : StronglyContinuousGroup X) (s t : ℝ) (x : X) :
   rw [U.map_add]
   rfl
 
+/-- Operators at different times commute. -/
+theorem map_comm (U : StronglyContinuousGroup X) (s t : ℝ) (x : X) :
+    U s (U t x) = U t (U s x) := by
+  rw [← U.map_add_apply, add_comm, U.map_add_apply]
+
 /-! ## Invertibility -/
 
 /-- `U (-t)` is a left inverse of `U t`. -/
@@ -157,7 +162,7 @@ theorem bijective (U : StronglyContinuousGroup X) (t : ℝ) : Function.Bijective
 
 /-- **The orbits of a C₀-group are continuous on all of `ℝ`.** The two-sided group law turns the
 increment at `t₀` into an increment at `0`, where continuity is assumed. -/
-theorem continuous_apply (U : StronglyContinuousGroup X) (x : X) :
+theorem continuous_orbit (U : StronglyContinuousGroup X) (x : X) :
     Continuous fun t : ℝ => U t x := by
   rw [continuous_iff_continuousAt]
   intro t₀
@@ -236,6 +241,28 @@ theorem HasGrowthBound.bound {U : StronglyContinuousGroup X} {ω M : ℝ}
     (hb : U.HasGrowthBound ω M) (t : ℝ) : ‖U t‖ ≤ M * Real.exp (ω * |t|) :=
   hb.2 t
 
+/-- A two-sided growth bound can be weakened by increasing both the exponential rate and the
+multiplicative constant. -/
+theorem HasGrowthBound.mono {U : StronglyContinuousGroup X} {ω M ω' M' : ℝ}
+    (hb : U.HasGrowthBound ω M) (hω : ω ≤ ω') (hM : M ≤ M') :
+    U.HasGrowthBound ω' M' := by
+  refine ⟨hb.one_le.trans hM, fun t => ?_⟩
+  have hM_nonneg : 0 ≤ M := zero_le_one.trans hb.one_le
+  have hexp : Real.exp (ω * |t|) ≤ Real.exp (ω' * |t|) :=
+    Real.exp_le_exp.mpr (mul_le_mul_of_nonneg_right hω (abs_nonneg t))
+  exact (hb.bound t).trans
+    (mul_le_mul hM hexp (Real.exp_nonneg _) (hM_nonneg.trans hM))
+
+/-- A two-sided growth bound can be weakened by increasing the exponential rate. -/
+theorem HasGrowthBound.mono_omega {U : StronglyContinuousGroup X} {ω M ω' : ℝ}
+    (hb : U.HasGrowthBound ω M) (hω : ω ≤ ω') : U.HasGrowthBound ω' M :=
+  hb.mono hω le_rfl
+
+/-- A two-sided growth bound can be weakened by increasing the multiplicative constant. -/
+theorem HasGrowthBound.mono_const {U : StronglyContinuousGroup X} {ω M M' : ℝ}
+    (hb : U.HasGrowthBound ω M) (hM : M ≤ M') : U.HasGrowthBound ω M' :=
+  hb.mono le_rfl hM
+
 /-- Constructor for a two-sided growth bound from the multiplicative lower bound and the
 operator-norm estimate. -/
 theorem hasGrowthBound_of_bound {U : StronglyContinuousGroup X} {ω M : ℝ} (hM : 1 ≤ M)
@@ -266,18 +293,18 @@ theorem hasGrowthBound_zero_one_iff (U : StronglyContinuousGroup X) :
 /-- **A C₀-group that contracts in both time directions preserves norms.** A strict contraction
 at time `t` would have to be undone by an expansion at time `-t`, which contractivity forbids.
 This is the norm preservation behind unitary groups such as `e^{itH}`. -/
-theorem norm_map_apply_eq_of_norm_le_one (U : StronglyContinuousGroup X)
-    (h : ∀ t : ℝ, ‖U t‖ ≤ 1) (t : ℝ) (x : X) : ‖U t x‖ = ‖x‖ := by
-  have key : ∀ (s : ℝ) (y : X), ‖U s y‖ ≤ ‖y‖ := fun s y =>
-    ((U s).le_opNorm y).trans (mul_le_of_le_one_left (norm_nonneg y) (h s))
-  refine le_antisymm (key t x) ?_
+theorem norm_map_apply_eq_of_norm_le_one (U : StronglyContinuousGroup X) (t : ℝ)
+    (ht : ‖U t‖ ≤ 1) (ht' : ‖U (-t)‖ ≤ 1) (x : X) : ‖U t x‖ = ‖x‖ := by
+  have key (s : ℝ) (hs : ‖U s‖ ≤ 1) (y : X) : ‖U s y‖ ≤ ‖y‖ :=
+    ((U s).le_opNorm y).trans (mul_le_of_le_one_left (norm_nonneg y) hs)
+  refine le_antisymm (key t ht x) ?_
   calc ‖x‖ = ‖U (-t) (U t x)‖ := by rw [U.map_neg_apply_map_apply]
-    _ ≤ ‖U t x‖ := key (-t) _
+    _ ≤ ‖U t x‖ := key (-t) ht' _
 
 /-- Every operator of a contractive C₀-group is an isometry. -/
-theorem isometry_of_norm_le_one (U : StronglyContinuousGroup X) (h : ∀ t : ℝ, ‖U t‖ ≤ 1)
-    (t : ℝ) : Isometry (U t) :=
-  AddMonoidHomClass.isometry_of_norm _ (U.norm_map_apply_eq_of_norm_le_one h t)
+theorem isometry_of_forall_norm_le_one (U : StronglyContinuousGroup X)
+    (h : ∀ t : ℝ, ‖U t‖ ≤ 1) (t : ℝ) : Isometry (U t) :=
+  AddMonoidHomClass.isometry_of_norm _ (U.norm_map_apply_eq_of_norm_le_one t (h t) (h (-t)))
 
 variable [CompleteSpace X]
 
@@ -288,18 +315,16 @@ theorem existsGrowthBound (U : StronglyContinuousGroup X) :
     ∃ ω M : ℝ, U.HasGrowthBound ω M := by
   obtain ⟨ω₁, M₁, hb₁⟩ := U.toSemigroup.existsGrowthBound
   obtain ⟨ω₂, M₂, hb₂⟩ := U.reflect.toSemigroup.existsGrowthBound
+  have hb₁' := hb₁.mono (le_max_left ω₁ ω₂) (le_max_left M₁ M₂)
+  have hb₂' := hb₂.mono (le_max_right ω₁ ω₂) (le_max_right M₁ M₂)
   refine ⟨max ω₁ ω₂, max M₁ M₂, le_max_of_le_left hb₁.one_le, fun t => ?_⟩
   rcases le_or_gt 0 t with ht | ht
   · rw [← U.toSemigroup_realOperator ht, abs_of_nonneg ht]
-    refine (hb₁.bound t ht).trans (mul_le_mul (le_max_left _ _) (Real.exp_le_exp.mpr ?_)
-      (Real.exp_nonneg _) (le_trans zero_le_one (le_max_of_le_left hb₁.one_le)))
-    exact mul_le_mul_of_nonneg_right (le_max_left _ _) ht
+    exact hb₁'.bound t ht
   · have hnt : 0 ≤ -t := by linarith
     rw [← neg_neg t, ← U.reflect_toSemigroup_realOperator hnt, abs_neg,
       abs_of_nonneg hnt]
-    refine (hb₂.bound (-t) hnt).trans (mul_le_mul (le_max_right _ _) (Real.exp_le_exp.mpr ?_)
-      (Real.exp_nonneg _) (le_trans zero_le_one (le_max_of_le_left hb₁.one_le)))
-    exact mul_le_mul_of_nonneg_right (le_max_right _ _) hnt
+    exact hb₂'.bound (-t) hnt
 
 /-- **Joint strong continuity of a C₀-group**: if `f i → r` and `g i → z`, then
 `U (f i) (g i) → U r z`.
@@ -322,20 +347,10 @@ theorem tendsto_apply {ι : Type*} {l : Filter ι} (U : StronglyContinuousGroup 
     refine (hb.bound (f i)).trans (mul_le_mul_of_nonneg_left (Real.exp_le_exp.mpr ?_) hM.le)
     calc ω * |f i| ≤ |ω| * |f i| := mul_le_mul_of_nonneg_right (le_abs_self ω) (abs_nonneg _)
       _ ≤ |ω| * (|r| + 1) := mul_le_mul_of_nonneg_left habs (abs_nonneg ω)
-  -- The vector moves: uniformly bounded operators send a vanishing increment to `0`.
-  have h1 : Tendsto (fun i => U (f i) (g i - z)) l (𝓝 0) := by
-    refine squeeze_zero_norm' (a := fun i => M * Real.exp (|ω| * (|r| + 1)) * ‖g i - z‖) ?_ ?_
-    · filter_upwards [hbound] with i hi
-      exact (ContinuousLinearMap.le_opNorm _ _).trans
-        (mul_le_mul_of_nonneg_right hi (norm_nonneg _))
-    · simpa using
-        (tendsto_iff_norm_sub_tendsto_zero.mp hg).const_mul (M * Real.exp (|ω| * (|r| + 1)))
   -- The time moves: this is continuity of the orbit of the fixed vector `z`.
   have h2 : Tendsto (fun i => U (f i) z) l (𝓝 (U r z)) :=
-    ((U.continuous_apply z).tendsto r).comp hf
-  have hsplit : ∀ i, U (f i) (g i) = U (f i) (g i - z) + U (f i) z := fun i => by
-    rw [← ContinuousLinearMap.map_add, sub_add_cancel]
-  simpa using (h1.add h2).congr fun i => (hsplit i).symm
+    ((U.continuous_orbit z).tendsto r).comp hf
+  exact tendsto_apply_of_eventually_norm_le hbound h2 hg
 
 end StronglyContinuousGroup
 

--- a/TauCeti/Analysis/Semigroups/Group/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Generator.lean
@@ -84,7 +84,7 @@ private theorem genQuot_eventuallyEq (U : StronglyContinuousGroup X) (x : X) :
     (fun t : ℝ => (1 / t) • (U.toSemigroup.realOperator t x - x))
       =ᶠ[𝓝[>] (0 : ℝ)] fun t : ℝ => (1 / t) • (U t x - x) := by
   filter_upwards [self_mem_nhdsWithin] with t ht
-  rw [U.toSemigroup_realOperator (le_of_lt ht)]
+  rw [U.toSemigroup_realOperator_of_nonneg (le_of_lt ht)]
 
 /-- A vector lies in the generator domain iff its difference quotient `(U t x - x)/t` converges
 as `t → 0⁺`. -/
@@ -266,11 +266,12 @@ theorem eq_of_generator_eq {U V : StronglyContinuousGroup X} (h : U.generator = 
     StronglyContinuousSemigroup.eq_of_generator_eq hrefl
   refine ext fun t => ?_
   rcases le_or_gt 0 t with ht | ht
-  · rw [← U.toSemigroup_realOperator ht, ← V.toSemigroup_realOperator ht, hfwd]
+  · rw [← U.toSemigroup_realOperator_of_nonneg ht,
+      ← V.toSemigroup_realOperator_of_nonneg ht, hfwd]
   · have hnt : (0 : ℝ) ≤ -t := by linarith
     have hst := congrArg (fun S : StronglyContinuousSemigroup X => S.realOperator (-t)) hbwd
-    simpa only [U.reflect_toSemigroup_realOperator hnt, V.reflect_toSemigroup_realOperator hnt,
-      neg_neg] using hst
+    simpa only [U.reflect_toSemigroup_realOperator_of_nonneg hnt,
+      V.reflect_toSemigroup_realOperator_of_nonneg hnt, neg_neg] using hst
 
 /-- Injectivity form of `TauCeti.Semigroups.StronglyContinuousGroup.eq_of_generator_eq`. -/
 theorem generator_injective :
@@ -299,12 +300,14 @@ theorem ofBounded_apply (A : X →L[ℝ] X) (t : ℝ) : ofBounded A t = exp (t �
   rfl
 
 /-- The forward semigroup of `ofBounded A` is the bounded-generator semigroup of `A`. -/
+@[simp]
 theorem ofBounded_toSemigroup (A : X →L[ℝ] X) :
     (ofBounded A).toSemigroup = StronglyContinuousSemigroup.ofBounded A := by
   ext t
   rw [toSemigroup_apply, ofBounded_apply, StronglyContinuousSemigroup.ofBounded_apply]
 
 /-- Time reversal of `ofBounded A` is the group of `-A`. -/
+@[simp]
 theorem ofBounded_reflect (A : X →L[ℝ] X) : (ofBounded A).reflect = ofBounded (-A) := by
   ext t
   rw [reflect_apply, ofBounded_apply, ofBounded_apply, neg_smul, smul_neg]

--- a/TauCeti/Analysis/Semigroups/Group/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Generator.lean
@@ -60,19 +60,17 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
 
 /-- The domain `D(A)` of the generator of a C₀-group: the generator domain of its forward
 semigroup. -/
-@[expose]
 def domain (U : StronglyContinuousGroup X) : Submodule ℝ X := U.toSemigroup.domain
 
 /-- The infinitesimal generator of a C₀-group, as an unbounded operator: the generator of its
 forward semigroup. The two-sided law makes the defining limit two-sided as well
 (`TauCeti.Semigroups.StronglyContinuousGroup.hasDerivAt`). -/
-@[expose]
 def generator (U : StronglyContinuousGroup X) : X →ₗ.[ℝ] X := U.toSemigroup.generator
 
-theorem domain_eq (U : StronglyContinuousGroup X) : U.domain = U.toSemigroup.domain := rfl
+theorem domain_eq (U : StronglyContinuousGroup X) : U.domain = U.toSemigroup.domain := (rfl)
 
 theorem generator_eq (U : StronglyContinuousGroup X) :
-    U.generator = U.toSemigroup.generator := rfl
+    U.generator = U.toSemigroup.generator := (rfl)
 
 @[simp]
 theorem generator_domain (U : StronglyContinuousGroup X) : U.generator.domain = U.domain := by
@@ -301,7 +299,7 @@ theorem ofBounded_reflect (A : X →L[ℝ] X) : (ofBounded A).reflect = ofBounde
 
 /-- The generator domain of `ofBounded A` is the whole space. -/
 @[simp]
-theorem ofBounded_domain (A : X →L[ℝ] X) : (ofBounded A).domain = ⊤ := by
+theorem ofBounded_domain_eq_top (A : X →L[ℝ] X) : (ofBounded A).domain = ⊤ := by
   rw [domain_eq, ofBounded_toSemigroup, StronglyContinuousSemigroup.ofBounded_domain_eq_top]
 
 /-- The generator of `ofBounded A` is `A` itself, viewed as a total unbounded operator. -/

--- a/TauCeti/Analysis/Semigroups/Group/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Generator.lean
@@ -135,7 +135,7 @@ theorem generator_map (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
 
 /-- The positive-time difference quotient at `0` extracted from a two-sided derivative of an
 orbit. -/
-theorem generator_tendsto_of_hasDerivAt_zero (U : StronglyContinuousGroup X) {y c : X}
+theorem tendsto_of_hasDerivAt_zero (U : StronglyContinuousGroup X) {y c : X}
     (h : HasDerivAt (fun s : ℝ => U s y) c 0) :
     Tendsto (fun t : ℝ => (1 / t) • (U t y - y)) (𝓝[>] (0 : ℝ)) (𝓝 c) := by
   rw [hasDerivAt_iff_tendsto_slope] at h
@@ -146,14 +146,14 @@ theorem generator_tendsto_of_hasDerivAt_zero (U : StronglyContinuousGroup X) {y 
 /-- A vector whose orbit is differentiable at `0` belongs to the generator domain. -/
 theorem mem_domain_of_hasDerivAt_zero (U : StronglyContinuousGroup X) {x y : X}
     (h : HasDerivAt (fun t : ℝ => U t x) y 0) : x ∈ U.domain :=
-  (U.mem_domain_iff_tendsto x).mpr ⟨y, U.generator_tendsto_of_hasDerivAt_zero h⟩
+  (U.mem_domain_iff_tendsto x).mpr ⟨y, U.tendsto_of_hasDerivAt_zero h⟩
 
 /-- The generator value is the derivative at `0` of the orbit. -/
 theorem generator_eq_of_hasDerivAt_zero (U : StronglyContinuousGroup X) {x y : X}
     (h : HasDerivAt (fun t : ℝ => U t x) y 0) :
     U.generator ⟨x, by rw [U.generator_domain]; exact U.mem_domain_of_hasDerivAt_zero h⟩ = y :=
   U.generator_eq_of_tendsto (U.mem_domain_of_hasDerivAt_zero h)
-    (U.generator_tendsto_of_hasDerivAt_zero h)
+    (U.tendsto_of_hasDerivAt_zero h)
 
 variable [CompleteSpace X]
 
@@ -287,9 +287,7 @@ def ofBounded (A : X →L[ℝ] X) : StronglyContinuousGroup X where
   toFun t := exp (t • A)
   map_zero' := by rw [zero_smul, exp_zero, ContinuousLinearMap.one_def]
   map_add' s t := by
-    let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
-    rw [add_smul, exp_add_of_commute (((Commute.refl A).smul_left _).smul_right _),
-      ContinuousLinearMap.mul_def]
+    rw [TauCeti.exp_add_smul]
   continuousAt_zero' x :=
     (((differentiable_exp_smul_const ℝ A).continuous).clm_apply continuous_const).continuousAt
 

--- a/TauCeti/Analysis/Semigroups/Group/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Generator.lean
@@ -36,7 +36,8 @@ forward half directly and the backward half through `U.reflect`.
 * `TauCeti.Semigroups.StronglyContinuousGroup.eq_of_generator_eq`: a C₀-group is determined by
   its generator.
 * `TauCeti.Semigroups.StronglyContinuousGroup.ofBounded`: the C₀-group `t ↦ exp (t • A)` of a
-  bounded operator, with generator `A`; every C₀-group with a bounded generator is of this form.
+  bounded operator, with generator `A`; every C₀-group whose generator is `A` on all of `X` is of
+  this form.
 
 ## References
 
@@ -67,14 +68,14 @@ forward semigroup. The two-sided law makes the defining limit two-sided as well
 (`TauCeti.Semigroups.StronglyContinuousGroup.hasDerivAt`). -/
 def generator (U : StronglyContinuousGroup X) : X →ₗ.[ℝ] X := U.toSemigroup.generator
 
-theorem domain_eq (U : StronglyContinuousGroup X) : U.domain = U.toSemigroup.domain := (rfl)
+theorem domain_def (U : StronglyContinuousGroup X) : U.domain = U.toSemigroup.domain := (rfl)
 
-theorem generator_eq (U : StronglyContinuousGroup X) :
+theorem generator_def (U : StronglyContinuousGroup X) :
     U.generator = U.toSemigroup.generator := (rfl)
 
 @[simp]
 theorem generator_domain (U : StronglyContinuousGroup X) : U.generator.domain = U.domain := by
-  rw [generator_eq, domain_eq, StronglyContinuousSemigroup.generator_domain]
+  rw [generator_def, domain_def, StronglyContinuousSemigroup.generator_domain]
 
 /-! ## The defining limit -/
 
@@ -90,7 +91,7 @@ as `t → 0⁺`. -/
 theorem mem_domain_iff_tendsto (U : StronglyContinuousGroup X) (x : X) :
     x ∈ U.domain ↔ ∃ y, Tendsto (fun t : ℝ => (1 / t) • (U t x - x))
       (𝓝[>] (0 : ℝ)) (𝓝 y) := by
-  rw [domain_eq, U.toSemigroup.mem_domain_iff_tendsto]
+  rw [domain_def, U.toSemigroup.mem_domain_iff_tendsto]
   exact exists_congr fun y => tendsto_congr' (U.genQuot_eventuallyEq x)
 
 /-- Characteristic property of the generator: for `x ∈ D(A)` the difference quotient converges
@@ -107,8 +108,34 @@ theorem generator_eq_of_tendsto (U : StronglyContinuousGroup X) {x : X} (hx : x 
     U.generator ⟨x, by rw [U.generator_domain]; exact hx⟩ = y :=
   U.toSemigroup.generator_eq_of_tendsto hx ((tendsto_congr' (U.genQuot_eventuallyEq x)).mpr h)
 
-/-- The difference quotient at `0` extracted from a two-sided derivative of an orbit. -/
-private theorem tendsto_genQuot_of_hasDerivAt (U : StronglyContinuousGroup X) {y c : X}
+/-- The difference quotient based at `U r x` is `U r` applied to the difference quotient based
+at `x`. -/
+private theorem tendsto_genQuot_map (U : StronglyContinuousGroup X) (r : ℝ) {x y : X}
+    (h : Tendsto (fun t : ℝ => (1 / t) • (U t x - x)) (𝓝[>] (0 : ℝ)) (𝓝 y)) :
+    Tendsto (fun t : ℝ => (1 / t) • (U t (U r x) - U r x))
+      (𝓝[>] (0 : ℝ)) (𝓝 (U r y)) := by
+  refine ((U r).continuous.continuousAt.tendsto.comp h).congr' ?_
+  filter_upwards with t
+  simp only [Function.comp_apply, U.map_comm t r x, map_smul, map_sub]
+
+/-- **The generator domain is invariant under the whole group**, at negative times as well as
+positive ones. -/
+theorem map_mem_domain (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
+    U t (x : X) ∈ U.domain := by
+  obtain ⟨y, hy⟩ := (U.mem_domain_iff_tendsto (x : X)).mp x.property
+  exact (U.mem_domain_iff_tendsto _).mpr ⟨U t y, U.tendsto_genQuot_map t hy⟩
+
+/-- **The generator commutes with the group.** -/
+theorem generator_map (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
+    U.generator ⟨U t (x : X), by
+      rw [U.generator_domain]; exact U.map_mem_domain x t⟩
+      = U t (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩) :=
+  U.generator_eq_of_tendsto (U.map_mem_domain x t)
+    (U.tendsto_genQuot_map t (U.generator_tendsto x))
+
+/-- The positive-time difference quotient at `0` extracted from a two-sided derivative of an
+orbit. -/
+theorem generator_tendsto_of_hasDerivAt_zero (U : StronglyContinuousGroup X) {y c : X}
     (h : HasDerivAt (fun s : ℝ => U s y) c 0) :
     Tendsto (fun t : ℝ => (1 / t) • (U t y - y)) (𝓝[>] (0 : ℝ)) (𝓝 c) := by
   rw [hasDerivAt_iff_tendsto_slope] at h
@@ -116,13 +143,25 @@ private theorem tendsto_genQuot_of_hasDerivAt (U : StronglyContinuousGroup X) {y
   refine (h.mono_left hmono).congr fun t => ?_
   rw [slope_def_module, sub_zero, U.map_zero_apply, one_div]
 
+/-- A vector whose orbit is differentiable at `0` belongs to the generator domain. -/
+theorem mem_domain_of_hasDerivAt_zero (U : StronglyContinuousGroup X) {x y : X}
+    (h : HasDerivAt (fun t : ℝ => U t x) y 0) : x ∈ U.domain :=
+  (U.mem_domain_iff_tendsto x).mpr ⟨y, U.generator_tendsto_of_hasDerivAt_zero h⟩
+
+/-- The generator value is the derivative at `0` of the orbit. -/
+theorem generator_eq_of_hasDerivAt_zero (U : StronglyContinuousGroup X) {x y : X}
+    (h : HasDerivAt (fun t : ℝ => U t x) y 0) :
+    U.generator ⟨x, by rw [U.generator_domain]; exact U.mem_domain_of_hasDerivAt_zero h⟩ = y :=
+  U.generator_eq_of_tendsto (U.mem_domain_of_hasDerivAt_zero h)
+    (U.generator_tendsto_of_hasDerivAt_zero h)
+
 variable [CompleteSpace X]
 
 /-! ## Time reversal -/
 
 /-- The difference quotient of the time-reversed group converges to the negative of the limit
-for `U`: on positive times the two quotients differ by the operator `U (-t)`, which converges
-strongly to the identity. -/
+for `U`: on positive times the two quotients differ by the operator `U (-t)` and a sign, while the
+operator converges strongly to the identity. -/
 private theorem tendsto_reflect_genQuot (U : StronglyContinuousGroup X) {x y : X}
     (h : Tendsto (fun t : ℝ => (1 / t) • (U t x - x)) (𝓝[>] (0 : ℝ)) (𝓝 y)) :
     Tendsto (fun t : ℝ => (1 / t) • (U.reflect t x - x)) (𝓝[>] (0 : ℝ)) (𝓝 (-y)) := by
@@ -136,6 +175,7 @@ private theorem tendsto_reflect_genQuot (U : StronglyContinuousGroup X) {x y : X
     U.map_neg_apply_map_apply, ← smul_neg, neg_sub]
 
 /-- **The generator domain is invariant under time reversal.** -/
+@[simp]
 theorem reflect_domain (U : StronglyContinuousGroup X) : U.reflect.domain = U.domain := by
   have key : ∀ V : StronglyContinuousGroup X, ∀ x ∈ V.domain, x ∈ V.reflect.domain := by
     intro V x hx
@@ -151,6 +191,7 @@ theorem reflect_domain (U : StronglyContinuousGroup X) : U.reflect.domain = U.do
 /-- **The generator of the time-reversed group is the negative of the generator**, on the same
 domain. This is the two-sided statement that makes the backward half of a C₀-group accessible
 to the semigroup API. -/
+@[simp]
 theorem reflect_generator (U : StronglyContinuousGroup X) :
     U.reflect.generator = -U.generator := by
   refine LinearPMap.ext ?_ ?_
@@ -164,8 +205,9 @@ theorem reflect_generator (U : StronglyContinuousGroup X) :
 /-! ## Two-sided differentiability of the orbits -/
 
 /-- For a domain vector the difference quotient converges from the left as well, to the same
-limit: the left quotient is the reversed group's right quotient, which converges to `-A x`. -/
-theorem tendsto_genQuot_nhdsLT (U : StronglyContinuousGroup X) (x : U.domain) :
+limit: the left quotient is minus the reversed group's right quotient, which converges to
+`-A x`. -/
+theorem generator_tendsto_nhdsLT (U : StronglyContinuousGroup X) (x : U.domain) :
     Tendsto (fun t : ℝ => (1 / t) • (U t (x : X) - (x : X))) (𝓝[<] (0 : ℝ))
       (𝓝 (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩)) := by
   have hneg : Tendsto (fun t : ℝ => -t) (𝓝[<] (0 : ℝ)) (𝓝[>] (0 : ℝ)) := by
@@ -189,7 +231,7 @@ theorem hasDerivAt_zero (U : StronglyContinuousGroup X) (x : U.domain) :
     funext t
     rw [slope_def_module, sub_zero, U.map_zero_apply, one_div]
   rw [hslope, ← nhdsLT_sup_nhdsGT, tendsto_sup]
-  exact ⟨U.tendsto_genQuot_nhdsLT x, U.generator_tendsto x⟩
+  exact ⟨U.generator_tendsto_nhdsLT x, U.generator_tendsto x⟩
 
 /-- **The abstract Cauchy problem on the whole line.** For `x ∈ D(A)` the orbit `t ↦ U t x` is
 differentiable at every real time, with derivative `U t (A x)`. -/
@@ -208,36 +250,6 @@ theorem hasDerivAt (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
     rw [Function.comp_apply, ← U.map_add_apply, hts]
   rw [hfun]
   exact h
-
-/-! ## Invariance of the domain -/
-
-/-- The orbit of a domain vector, restarted at time `t`, is again differentiable at `0`. -/
-private theorem hasDerivAt_zero_map (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
-    HasDerivAt (fun s : ℝ => U s (U t (x : X)))
-      (U t (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩)) 0 := by
-  have hadd : HasDerivAt (fun s : ℝ => s + t) 1 (0 : ℝ) := (hasDerivAt_id (0 : ℝ)).add_const t
-  have h := (U.hasDerivAt x t).scomp_of_eq (0 : ℝ) hadd (zero_add t).symm
-  have hfun : (fun s : ℝ => U s (U t (x : X)))
-      = (fun s : ℝ => U s (x : X)) ∘ fun s : ℝ => s + t := by
-    funext s
-    rw [Function.comp_apply, ← U.map_add_apply]
-  rw [hfun]
-  simpa using h
-
-/-- **The generator domain is invariant under the whole group**, at negative times as well as
-positive ones. -/
-theorem map_mem_domain (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
-    U t (x : X) ∈ U.domain :=
-  (U.mem_domain_iff_tendsto _).mpr
-    ⟨_, U.tendsto_genQuot_of_hasDerivAt (U.hasDerivAt_zero_map x t)⟩
-
-/-- **The generator commutes with the group.** -/
-theorem generator_map (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
-    U.generator ⟨U t (x : X), by
-      rw [U.generator_domain]; exact U.map_mem_domain x t⟩
-      = U t (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩) :=
-  U.generator_eq_of_tendsto (U.map_mem_domain x t)
-    (U.tendsto_genQuot_of_hasDerivAt (U.hasDerivAt_zero_map x t))
 
 /-! ## Uniqueness -/
 
@@ -300,22 +312,19 @@ theorem ofBounded_reflect (A : X →L[ℝ] X) : (ofBounded A).reflect = ofBounde
 /-- The generator domain of `ofBounded A` is the whole space. -/
 @[simp]
 theorem ofBounded_domain_eq_top (A : X →L[ℝ] X) : (ofBounded A).domain = ⊤ := by
-  rw [domain_eq, ofBounded_toSemigroup, StronglyContinuousSemigroup.ofBounded_domain_eq_top]
+  rw [domain_def, ofBounded_toSemigroup, StronglyContinuousSemigroup.ofBounded_domain_eq_top]
 
 /-- The generator of `ofBounded A` is `A` itself, viewed as a total unbounded operator. -/
 @[simp]
 theorem ofBounded_generator (A : X →L[ℝ] X) :
     (ofBounded A).generator = (A : X →ₗ[ℝ] X).toPMap ⊤ := by
-  rw [generator_eq, ofBounded_toSemigroup, StronglyContinuousSemigroup.ofBounded_generator]
+  rw [generator_def, ofBounded_toSemigroup, StronglyContinuousSemigroup.ofBounded_generator]
 
 /-- `ofBounded A` has the two-sided growth bound `(‖A‖, 1)`: `‖exp (t • A)‖ ≤ e^{‖A‖ |t|}`. -/
 theorem ofBounded_hasGrowthBound (A : X →L[ℝ] X) : (ofBounded A).HasGrowthBound ‖A‖ 1 := by
-  let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
   refine hasGrowthBound_of_bound le_rfl fun t => ?_
   rw [one_mul, ofBounded_apply]
-  calc ‖exp (t • A)‖ ≤ Real.exp ‖t • A‖ :=
-        TauCeti.norm_exp_le_exp_norm ContinuousLinearMap.norm_id_le _
-    _ = Real.exp (‖A‖ * |t|) := by rw [norm_smul, Real.norm_eq_abs, mul_comm]
+  exact TauCeti.norm_exp_smul_le A t
 
 /-- A C₀-group whose generator is the bounded operator `A`, defined on all of `X`, is the
 operator exponential `t ↦ exp (t • A)`. -/

--- a/TauCeti/Analysis/Semigroups/Group/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Group/Generator.lean
@@ -1,0 +1,332 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.Group.Basic
+public import TauCeti.Analysis.Semigroups.BoundedGenerator.Basic
+-- Non-public: the exponential norm bound supplies the growth bound of `ofBounded`.
+import TauCeti.Analysis.Normed.Operator.Exponential
+
+/-!
+# The generator of a strongly continuous group
+
+The generator of a C₀-group `U` is the generator of its forward semigroup. What is new on a
+group is that the difference quotient converges from *both* sides: the time-reversed group
+`U.reflect` has the same generator domain and the negated generator
+(`TauCeti.Semigroups.StronglyContinuousGroup.reflect_generator`), and combining the two
+one-sided limits upgrades the right derivative of an orbit to a genuine two-sided derivative on
+all of `ℝ`. So for `x ∈ D(A)` the orbit `u (t) = U t x` is a classical solution of `u' = A u`
+on the whole line, not just on `[0, ∞)`.
+
+Because a semigroup is determined by its generator, so is a group: the generator fixes the
+forward half directly and the backward half through `U.reflect`.
+
+## Main results
+
+* `TauCeti.Semigroups.StronglyContinuousGroup.reflect_generator`: the generator of the
+  time-reversed group is `-A`, on the same domain.
+* `TauCeti.Semigroups.StronglyContinuousGroup.hasDerivAt`: for `x ∈ D(A)` the orbit
+  `t ↦ U t x` is differentiable at every real time, with derivative `U t (A x)`.
+* `TauCeti.Semigroups.StronglyContinuousGroup.map_mem_domain` and
+  `TauCeti.Semigroups.StronglyContinuousGroup.generator_map`: `D(A)` is invariant under the
+  whole group and `A` commutes with it.
+* `TauCeti.Semigroups.StronglyContinuousGroup.eq_of_generator_eq`: a C₀-group is determined by
+  its generator.
+* `TauCeti.Semigroups.StronglyContinuousGroup.ofBounded`: the C₀-group `t ↦ exp (t • A)` of a
+  bounded operator, with generator `A`; every C₀-group with a bounded generator is of this form.
+
+## References
+
+Engel--Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Section II.3.11;
+Pazy, *Semigroups of Linear Operators and Applications to Partial Differential Equations*,
+Section 1.6.
+-/
+
+public section
+
+noncomputable section
+
+open scoped Topology NNReal
+open Filter NormedSpace
+
+namespace TauCeti.Semigroups
+
+namespace StronglyContinuousGroup
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X]
+
+/-- The domain `D(A)` of the generator of a C₀-group: the generator domain of its forward
+semigroup. -/
+@[expose]
+def domain (U : StronglyContinuousGroup X) : Submodule ℝ X := U.toSemigroup.domain
+
+/-- The infinitesimal generator of a C₀-group, as an unbounded operator: the generator of its
+forward semigroup. The two-sided law makes the defining limit two-sided as well
+(`TauCeti.Semigroups.StronglyContinuousGroup.hasDerivAt`). -/
+@[expose]
+def generator (U : StronglyContinuousGroup X) : X →ₗ.[ℝ] X := U.toSemigroup.generator
+
+theorem domain_eq (U : StronglyContinuousGroup X) : U.domain = U.toSemigroup.domain := rfl
+
+theorem generator_eq (U : StronglyContinuousGroup X) :
+    U.generator = U.toSemigroup.generator := rfl
+
+@[simp]
+theorem generator_domain (U : StronglyContinuousGroup X) : U.generator.domain = U.domain := by
+  rw [generator_eq, domain_eq, StronglyContinuousSemigroup.generator_domain]
+
+/-! ## The defining limit -/
+
+/-- On positive times the forward semigroup's difference quotient is the group's. -/
+private theorem genQuot_eventuallyEq (U : StronglyContinuousGroup X) (x : X) :
+    (fun t : ℝ => (1 / t) • (U.toSemigroup.realOperator t x - x))
+      =ᶠ[𝓝[>] (0 : ℝ)] fun t : ℝ => (1 / t) • (U t x - x) := by
+  filter_upwards [self_mem_nhdsWithin] with t ht
+  rw [U.toSemigroup_realOperator (le_of_lt ht)]
+
+/-- A vector lies in the generator domain iff its difference quotient `(U t x - x)/t` converges
+as `t → 0⁺`. -/
+theorem mem_domain_iff_tendsto (U : StronglyContinuousGroup X) (x : X) :
+    x ∈ U.domain ↔ ∃ y, Tendsto (fun t : ℝ => (1 / t) • (U t x - x))
+      (𝓝[>] (0 : ℝ)) (𝓝 y) := by
+  rw [domain_eq, U.toSemigroup.mem_domain_iff_tendsto]
+  exact exists_congr fun y => tendsto_congr' (U.genQuot_eventuallyEq x)
+
+/-- Characteristic property of the generator: for `x ∈ D(A)` the difference quotient converges
+to `A x` as `t → 0⁺`. -/
+theorem generator_tendsto (U : StronglyContinuousGroup X) (x : U.domain) :
+    Tendsto (fun t : ℝ => (1 / t) • (U t (x : X) - (x : X))) (𝓝[>] (0 : ℝ))
+      (𝓝 (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩)) :=
+  (tendsto_congr' (U.genQuot_eventuallyEq (x : X))).mp (U.toSemigroup.generator_tendsto x)
+
+/-- Eliminator for the generator: if the difference quotient of an `x ∈ D(A)` converges to `y`,
+then `A x = y`. -/
+theorem generator_eq_of_tendsto (U : StronglyContinuousGroup X) {x : X} (hx : x ∈ U.domain)
+    {y : X} (h : Tendsto (fun t : ℝ => (1 / t) • (U t x - x)) (𝓝[>] (0 : ℝ)) (𝓝 y)) :
+    U.generator ⟨x, by rw [U.generator_domain]; exact hx⟩ = y :=
+  U.toSemigroup.generator_eq_of_tendsto hx ((tendsto_congr' (U.genQuot_eventuallyEq x)).mpr h)
+
+/-- The difference quotient at `0` extracted from a two-sided derivative of an orbit. -/
+private theorem tendsto_genQuot_of_hasDerivAt (U : StronglyContinuousGroup X) {y c : X}
+    (h : HasDerivAt (fun s : ℝ => U s y) c 0) :
+    Tendsto (fun t : ℝ => (1 / t) • (U t y - y)) (𝓝[>] (0 : ℝ)) (𝓝 c) := by
+  rw [hasDerivAt_iff_tendsto_slope] at h
+  have hmono : (𝓝[>] (0 : ℝ)) ≤ 𝓝[≠] (0 : ℝ) := nhdsWithin_mono _ fun z hz => ne_of_gt hz
+  refine (h.mono_left hmono).congr fun t => ?_
+  rw [slope_def_module, sub_zero, U.map_zero_apply, one_div]
+
+variable [CompleteSpace X]
+
+/-! ## Time reversal -/
+
+/-- The difference quotient of the time-reversed group converges to the negative of the limit
+for `U`: on positive times the two quotients differ by the operator `U (-t)`, which converges
+strongly to the identity. -/
+private theorem tendsto_reflect_genQuot (U : StronglyContinuousGroup X) {x y : X}
+    (h : Tendsto (fun t : ℝ => (1 / t) • (U t x - x)) (𝓝[>] (0 : ℝ)) (𝓝 y)) :
+    Tendsto (fun t : ℝ => (1 / t) • (U.reflect t x - x)) (𝓝[>] (0 : ℝ)) (𝓝 (-y)) := by
+  have hneg : Tendsto (fun t : ℝ => -t) (𝓝[>] (0 : ℝ)) (𝓝 (0 : ℝ)) := by
+    simpa using (continuous_neg.tendsto (0 : ℝ)).mono_left nhdsWithin_le_nhds
+  have hjoint := U.tendsto_apply hneg h.neg
+  rw [U.map_zero_apply] at hjoint
+  refine hjoint.congr' ?_
+  filter_upwards [self_mem_nhdsWithin] with t _
+  rw [reflect_apply, map_neg, ContinuousLinearMap.map_smul, map_sub,
+    U.map_neg_apply_map_apply, ← smul_neg, neg_sub]
+
+/-- **The generator domain is invariant under time reversal.** -/
+theorem reflect_domain (U : StronglyContinuousGroup X) : U.reflect.domain = U.domain := by
+  have key : ∀ V : StronglyContinuousGroup X, ∀ x ∈ V.domain, x ∈ V.reflect.domain := by
+    intro V x hx
+    obtain ⟨y, hy⟩ := (V.mem_domain_iff_tendsto x).mp hx
+    exact (V.reflect.mem_domain_iff_tendsto x).mpr ⟨-y, V.tendsto_reflect_genQuot hy⟩
+  refine le_antisymm ?_ ?_
+  · intro x hx
+    have hxx := key U.reflect x hx
+    rwa [reflect_reflect] at hxx
+  · intro x hx
+    exact key U x hx
+
+/-- **The generator of the time-reversed group is the negative of the generator**, on the same
+domain. This is the two-sided statement that makes the backward half of a C₀-group accessible
+to the semigroup API. -/
+theorem reflect_generator (U : StronglyContinuousGroup X) :
+    U.reflect.generator = -U.generator := by
+  refine LinearPMap.ext ?_ ?_
+  · rw [LinearPMap.neg_domain, U.generator_domain, U.reflect.generator_domain, U.reflect_domain]
+  · intro x _ hg
+    rw [LinearPMap.neg_domain, U.generator_domain] at hg
+    rw [LinearPMap.neg_apply]
+    exact U.reflect.generator_eq_of_tendsto (by rw [U.reflect_domain]; exact hg)
+      (U.tendsto_reflect_genQuot (U.generator_tendsto ⟨x, hg⟩))
+
+/-! ## Two-sided differentiability of the orbits -/
+
+/-- For a domain vector the difference quotient converges from the left as well, to the same
+limit: the left quotient is the reversed group's right quotient, which converges to `-A x`. -/
+theorem tendsto_genQuot_nhdsLT (U : StronglyContinuousGroup X) (x : U.domain) :
+    Tendsto (fun t : ℝ => (1 / t) • (U t (x : X) - (x : X))) (𝓝[<] (0 : ℝ))
+      (𝓝 (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩)) := by
+  have hneg : Tendsto (fun t : ℝ => -t) (𝓝[<] (0 : ℝ)) (𝓝[>] (0 : ℝ)) := by
+    refine tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _ ?_ ?_
+    · simpa using (continuous_neg.tendsto (0 : ℝ)).mono_left nhdsWithin_le_nhds
+    · filter_upwards [self_mem_nhdsWithin] with t ht
+      exact Set.mem_Ioi.mpr (neg_pos.mpr (Set.mem_Iio.mp ht))
+  have h := ((U.tendsto_reflect_genQuot (U.generator_tendsto x)).comp hneg).neg
+  rw [neg_neg] at h
+  refine h.congr fun t => ?_
+  simp only [Function.comp_apply, reflect_apply, neg_neg]
+  rw [one_div, one_div, inv_neg, neg_smul, neg_neg]
+
+/-- **The orbit of a domain vector is two-sidedly differentiable at `0`.** -/
+theorem hasDerivAt_zero (U : StronglyContinuousGroup X) (x : U.domain) :
+    HasDerivAt (fun t : ℝ => U t (x : X))
+      (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩) 0 := by
+  rw [hasDerivAt_iff_tendsto_slope]
+  have hslope : slope (fun t : ℝ => U t (x : X)) 0
+      = fun t : ℝ => (1 / t) • (U t (x : X) - (x : X)) := by
+    funext t
+    rw [slope_def_module, sub_zero, U.map_zero_apply, one_div]
+  rw [hslope, ← nhdsLT_sup_nhdsGT, tendsto_sup]
+  exact ⟨U.tendsto_genQuot_nhdsLT x, U.generator_tendsto x⟩
+
+/-- **The abstract Cauchy problem on the whole line.** For `x ∈ D(A)` the orbit `t ↦ U t x` is
+differentiable at every real time, with derivative `U t (A x)`. -/
+theorem hasDerivAt (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
+    HasDerivAt (fun s : ℝ => U s (x : X))
+      (U t (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩)) t := by
+  have hsub : HasDerivAt (fun s : ℝ => s - t) 1 t := (hasDerivAt_id t).sub_const t
+  have hinner : HasDerivAt (fun s : ℝ => U (s - t) (x : X))
+      (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩) t := by
+    simpa [Function.comp_def] using
+      (U.hasDerivAt_zero x).scomp_of_eq t hsub (sub_self t).symm
+  have h := ((U t).hasFDerivAt).comp_hasDerivAt t hinner
+  have hfun : (fun s : ℝ => U s (x : X)) = (U t) ∘ fun s : ℝ => U (s - t) (x : X) := by
+    funext s
+    have hts : t + (s - t) = s := by ring
+    rw [Function.comp_apply, ← U.map_add_apply, hts]
+  rw [hfun]
+  exact h
+
+/-! ## Invariance of the domain -/
+
+/-- The orbit of a domain vector, restarted at time `t`, is again differentiable at `0`. -/
+private theorem hasDerivAt_zero_map (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
+    HasDerivAt (fun s : ℝ => U s (U t (x : X)))
+      (U t (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩)) 0 := by
+  have hadd : HasDerivAt (fun s : ℝ => s + t) 1 (0 : ℝ) := (hasDerivAt_id (0 : ℝ)).add_const t
+  have h := (U.hasDerivAt x t).scomp_of_eq (0 : ℝ) hadd (zero_add t).symm
+  have hfun : (fun s : ℝ => U s (U t (x : X)))
+      = (fun s : ℝ => U s (x : X)) ∘ fun s : ℝ => s + t := by
+    funext s
+    rw [Function.comp_apply, ← U.map_add_apply]
+  rw [hfun]
+  simpa using h
+
+/-- **The generator domain is invariant under the whole group**, at negative times as well as
+positive ones. -/
+theorem map_mem_domain (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
+    U t (x : X) ∈ U.domain :=
+  (U.mem_domain_iff_tendsto _).mpr
+    ⟨_, U.tendsto_genQuot_of_hasDerivAt (U.hasDerivAt_zero_map x t)⟩
+
+/-- **The generator commutes with the group.** -/
+theorem generator_map (U : StronglyContinuousGroup X) (x : U.domain) (t : ℝ) :
+    U.generator ⟨U t (x : X), by
+      rw [U.generator_domain]; exact U.map_mem_domain x t⟩
+      = U t (U.generator ⟨(x : X), by rw [U.generator_domain]; exact x.property⟩) :=
+  U.generator_eq_of_tendsto (U.map_mem_domain x t)
+    (U.tendsto_genQuot_of_hasDerivAt (U.hasDerivAt_zero_map x t))
+
+/-! ## Uniqueness -/
+
+/-- **A C₀-group is determined by its generator.** The generator fixes the forward semigroup by
+uniqueness for semigroups, and it fixes the backward half through the reversed group, whose
+generator is `-A`. -/
+theorem eq_of_generator_eq {U V : StronglyContinuousGroup X} (h : U.generator = V.generator) :
+    U = V := by
+  have hfwd : U.toSemigroup = V.toSemigroup :=
+    StronglyContinuousSemigroup.eq_of_generator_eq h
+  have hrefl : U.reflect.generator = V.reflect.generator := by
+    rw [U.reflect_generator, V.reflect_generator, h]
+  have hbwd : U.reflect.toSemigroup = V.reflect.toSemigroup :=
+    StronglyContinuousSemigroup.eq_of_generator_eq hrefl
+  refine ext fun t => ?_
+  rcases le_or_gt 0 t with ht | ht
+  · rw [← U.toSemigroup_realOperator ht, ← V.toSemigroup_realOperator ht, hfwd]
+  · have hnt : (0 : ℝ) ≤ -t := by linarith
+    have hst := congrArg (fun S : StronglyContinuousSemigroup X => S.realOperator (-t)) hbwd
+    simpa only [U.reflect_toSemigroup_realOperator hnt, V.reflect_toSemigroup_realOperator hnt,
+      neg_neg] using hst
+
+/-- Injectivity form of `TauCeti.Semigroups.StronglyContinuousGroup.eq_of_generator_eq`. -/
+theorem generator_injective :
+    Function.Injective (generator : StronglyContinuousGroup X → X →ₗ.[ℝ] X) :=
+  fun _ _ h => eq_of_generator_eq h
+
+/-! ## The group generated by a bounded operator -/
+
+/-- The uniformly continuous C₀-group `U(t) = exp (t • A)` of a bounded operator `A`. Unlike the
+semigroup `TauCeti.Semigroups.StronglyContinuousSemigroup.ofBounded`, this runs in both time
+directions: `exp (-t • A)` inverts `exp (t • A)`. -/
+def ofBounded (A : X →L[ℝ] X) : StronglyContinuousGroup X where
+  toFun t := exp (t • A)
+  map_zero' := by rw [zero_smul, exp_zero, ContinuousLinearMap.one_def]
+  map_add' s t := by
+    let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
+    rw [add_smul, exp_add_of_commute (((Commute.refl A).smul_left _).smul_right _),
+      ContinuousLinearMap.mul_def]
+  continuousAt_zero' x :=
+    (((differentiable_exp_smul_const ℝ A).continuous).clm_apply continuous_const).continuousAt
+
+/-- The operator of `ofBounded A` at time `t` is `exp (t • A)`. -/
+@[simp]
+theorem ofBounded_apply (A : X →L[ℝ] X) (t : ℝ) : ofBounded A t = exp (t • A) := by
+  rw [ofBounded]
+  rfl
+
+/-- The forward semigroup of `ofBounded A` is the bounded-generator semigroup of `A`. -/
+theorem ofBounded_toSemigroup (A : X →L[ℝ] X) :
+    (ofBounded A).toSemigroup = StronglyContinuousSemigroup.ofBounded A := by
+  ext t
+  rw [toSemigroup_apply, ofBounded_apply, StronglyContinuousSemigroup.ofBounded_apply]
+
+/-- Time reversal of `ofBounded A` is the group of `-A`. -/
+theorem ofBounded_reflect (A : X →L[ℝ] X) : (ofBounded A).reflect = ofBounded (-A) := by
+  ext t
+  rw [reflect_apply, ofBounded_apply, ofBounded_apply, neg_smul, smul_neg]
+
+/-- The generator domain of `ofBounded A` is the whole space. -/
+@[simp]
+theorem ofBounded_domain (A : X →L[ℝ] X) : (ofBounded A).domain = ⊤ := by
+  rw [domain_eq, ofBounded_toSemigroup, StronglyContinuousSemigroup.ofBounded_domain_eq_top]
+
+/-- The generator of `ofBounded A` is `A` itself, viewed as a total unbounded operator. -/
+@[simp]
+theorem ofBounded_generator (A : X →L[ℝ] X) :
+    (ofBounded A).generator = (A : X →ₗ[ℝ] X).toPMap ⊤ := by
+  rw [generator_eq, ofBounded_toSemigroup, StronglyContinuousSemigroup.ofBounded_generator]
+
+/-- `ofBounded A` has the two-sided growth bound `(‖A‖, 1)`: `‖exp (t • A)‖ ≤ e^{‖A‖ |t|}`. -/
+theorem ofBounded_hasGrowthBound (A : X →L[ℝ] X) : (ofBounded A).HasGrowthBound ‖A‖ 1 := by
+  let +nondep : NormedAlgebra ℚ (X →L[ℝ] X) := .restrictScalars ℚ ℝ _
+  refine hasGrowthBound_of_bound le_rfl fun t => ?_
+  rw [one_mul, ofBounded_apply]
+  calc ‖exp (t • A)‖ ≤ Real.exp ‖t • A‖ :=
+        TauCeti.norm_exp_le_exp_norm ContinuousLinearMap.norm_id_le _
+    _ = Real.exp (‖A‖ * |t|) := by rw [norm_smul, Real.norm_eq_abs, mul_comm]
+
+/-- A C₀-group whose generator is the bounded operator `A`, defined on all of `X`, is the
+operator exponential `t ↦ exp (t • A)`. -/
+theorem eq_ofBounded_of_generator_eq {U : StronglyContinuousGroup X} (A : X →L[ℝ] X)
+    (h : U.generator = (A : X →ₗ[ℝ] X).toPMap ⊤) : U = ofBounded A :=
+  eq_of_generator_eq (h.trans (ofBounded_generator A).symm)
+
+end StronglyContinuousGroup
+
+end TauCeti.Semigroups
+
+end

--- a/TauCeti/Analysis/Semigroups/GrowthBound.lean
+++ b/TauCeti/Analysis/Semigroups/GrowthBound.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Semigroups.Basic
+public import TauCeti.Analysis.Normed.Operator.Basic
 public import Mathlib.Analysis.SpecialFunctions.Log.Basic
 
 /-!
@@ -201,23 +202,6 @@ theorem StronglyContinuousSemigroup.existsGrowthBound_ge
 
 /-! ## Joint strong continuity -/
 
-omit [CompleteSpace X] in
-/-- A uniformly bounded family of continuous linear maps is jointly continuous along convergent
-operator evaluations and arguments. -/
-theorem tendsto_apply_of_eventually_norm_le {ι : Type*} {l : Filter ι}
-    {T : ι → X →L[ℝ] X} {C : ℝ} {g : ι → X} {z w : X}
-    (hT : ∀ᶠ i in l, ‖T i‖ ≤ C) (hz : Filter.Tendsto (fun i => T i z) l (𝓝 w))
-    (hg : Filter.Tendsto g l (𝓝 z)) : Filter.Tendsto (fun i => T i (g i)) l (𝓝 w) := by
-  have hmove : Filter.Tendsto (fun i => T i (g i - z)) l (𝓝 0) := by
-    refine squeeze_zero_norm' (a := fun i => C * ‖g i - z‖) ?_ ?_
-    · filter_upwards [hT] with i hi
-      exact (ContinuousLinearMap.le_opNorm _ _).trans
-        (mul_le_mul_of_nonneg_right hi (norm_nonneg _))
-    · simpa using (tendsto_iff_norm_sub_tendsto_zero.mp hg).const_mul C
-  have hsplit : ∀ i, T i (g i) = T i (g i - z) + T i z := fun i => by
-    rw [← ContinuousLinearMap.map_add, sub_add_cancel]
-  simpa using (hmove.add hz).congr fun i => (hsplit i).symm
-
 /-- **Joint strong continuity**: if `f i → r` through nonnegative values and `g i → z`, then
 `S (f i) (g i) → S r z`.
 
@@ -243,7 +227,7 @@ theorem StronglyContinuousSemigroup.tendsto_realOperator_apply {ι : Type*} {l :
     have hfw : Filter.Tendsto f l (𝓝[Set.Ici 0] r) :=
       tendsto_nhdsWithin_iff.mpr ⟨hf, hf0⟩
     simpa [Function.comp_def] using (S.realOperator_continuousWithinAt z r hr).tendsto.comp hfw
-  exact tendsto_apply_of_eventually_norm_le hbound h2 hg
+  exact TauCeti.ContinuousLinearMap.tendsto_apply_of_eventually_norm_le hbound h2 hg
 
 /-- The `ContinuousOn` form of joint strong continuity: a continuous nonnegative time
 reparametrization applied to a continuous vector-valued map gives a continuous orbit. -/

--- a/TauCeti/Analysis/Semigroups/GrowthBound.lean
+++ b/TauCeti/Analysis/Semigroups/GrowthBound.lean
@@ -201,6 +201,23 @@ theorem StronglyContinuousSemigroup.existsGrowthBound_ge
 
 /-! ## Joint strong continuity -/
 
+omit [CompleteSpace X] in
+/-- A uniformly bounded family of continuous linear maps is jointly continuous along convergent
+operator evaluations and arguments. -/
+theorem tendsto_apply_of_eventually_norm_le {ι : Type*} {l : Filter ι}
+    {T : ι → X →L[ℝ] X} {C : ℝ} {g : ι → X} {z w : X}
+    (hT : ∀ᶠ i in l, ‖T i‖ ≤ C) (hz : Filter.Tendsto (fun i => T i z) l (𝓝 w))
+    (hg : Filter.Tendsto g l (𝓝 z)) : Filter.Tendsto (fun i => T i (g i)) l (𝓝 w) := by
+  have hmove : Filter.Tendsto (fun i => T i (g i - z)) l (𝓝 0) := by
+    refine squeeze_zero_norm' (a := fun i => C * ‖g i - z‖) ?_ ?_
+    · filter_upwards [hT] with i hi
+      exact (ContinuousLinearMap.le_opNorm _ _).trans
+        (mul_le_mul_of_nonneg_right hi (norm_nonneg _))
+    · simpa using (tendsto_iff_norm_sub_tendsto_zero.mp hg).const_mul C
+  have hsplit : ∀ i, T i (g i) = T i (g i - z) + T i z := fun i => by
+    rw [← ContinuousLinearMap.map_add, sub_add_cancel]
+  simpa using (hmove.add hz).congr fun i => (hsplit i).symm
+
 /-- **Joint strong continuity**: if `f i → r` through nonnegative values and `g i → z`, then
 `S (f i) (g i) → S r z`.
 
@@ -221,24 +238,12 @@ theorem StronglyContinuousSemigroup.tendsto_realOperator_apply {ι : Type*} {l :
     refine mul_le_mul_of_nonneg_left (Real.exp_le_exp.mpr ?_) hM.le
     calc omega * f i ≤ |omega| * f i := mul_le_mul_of_nonneg_right (le_abs_self omega) hi0
       _ ≤ |omega| * (r + 1) := mul_le_mul_of_nonneg_left hi1.le (abs_nonneg omega)
-  -- The argument moves: the operator norms are uniformly bounded, so this contribution vanishes.
-  have h1 : Filter.Tendsto (fun i => S.realOperator (f i) (g i - z)) l (𝓝 0) := by
-    refine squeeze_zero_norm' (a := fun i => M * Real.exp (|omega| * (r + 1)) * ‖g i - z‖) ?_ ?_
-    · filter_upwards [hbound] with i hi
-      exact (ContinuousLinearMap.le_opNorm _ _).trans
-        (mul_le_mul_of_nonneg_right hi (norm_nonneg _))
-    · simpa using
-        (tendsto_iff_norm_sub_tendsto_zero.mp hg).const_mul (M * Real.exp (|omega| * (r + 1)))
   -- The time moves: this is strong continuity of the orbit of the fixed vector `z`.
   have h2 : Filter.Tendsto (fun i => S.realOperator (f i) z) l (𝓝 (S.realOperator r z)) := by
     have hfw : Filter.Tendsto f l (𝓝[Set.Ici 0] r) :=
       tendsto_nhdsWithin_iff.mpr ⟨hf, hf0⟩
     simpa [Function.comp_def] using (S.realOperator_continuousWithinAt z r hr).tendsto.comp hfw
-  have hsplit : ∀ i, S.realOperator (f i) (g i)
-      = S.realOperator (f i) (g i - z) + S.realOperator (f i) z := by
-    intro i
-    rw [← ContinuousLinearMap.map_add, sub_add_cancel]
-  simpa using (h1.add h2).congr fun i => (hsplit i).symm
+  exact tendsto_apply_of_eventually_norm_le hbound h2 hg
 
 /-- The `ContinuousOn` form of joint strong continuity: a continuous nonnegative time
 reparametrization applied to a continuous vector-valued map gives a continuous orbit. -/


### PR DESCRIPTION
This PR adds strongly continuous one-parameter groups (C₀-groups) on a real Banach space, with the generator theory that the two-sided law unlocks. It serves the `OneParameterSemigroups` Part A generality-bar target "C₀ groups as a stretch": *"Two-sided strongly continuous groups `(S(t))_{t∈ℝ}` — e.g. the unitary `e^{itH}` of Schrödinger — are not reached by the contraction-semigroup API; include them as a stretch goal / example (Stone's theorem on Hilbert space)."* Part A's named milestones — Hille–Yosida, Lumer–Phillips and the abstract Cauchy problem — have all landed, and the C₀-group layer is the one Part A item that had not been started at all; after this PR the remaining work on that target is Stone's theorem itself, that is, a complex Hilbert space, skew-adjointness of the generator of a unitary group, and the converse construction of `e^{itH}` from a self-adjoint `H`.

`TauCeti/Analysis/Semigroups/Group/Basic.lean` introduces `StronglyContinuousGroup`, whose law `U (s + t) = U s ∘ U t` is imposed at *all* real times. Each `U t` is therefore invertible, packaged as `toContinuousLinearEquiv` with inverse `U (-t)`, and the increment at `t₀` factors through the increment at `0`, so the orbits are continuous on the whole line rather than only on `[0, ∞)`. Two views connect the object to the existing semigroup theory without developing either half twice: the forward semigroup `toSemigroup`, the restriction to `[0, ∞)`, and the time reversal `reflect`, the C₀-group `t ↦ U (-t)`, whose forward semigroup is the backward half of `U`. The growth bound is stated two-sidedly as `‖U t‖ ≤ M * exp (ω * |t|)`; `existsGrowthBound` obtains one from the two halves, and it supplies the uniform operator bound behind `tendsto_apply`, the two-sided counterpart of the semigroups' joint strong continuity. A short section shows that a C₀-group contracting in both time directions preserves norms and is a group of isometries — the norm preservation behind unitary groups, and the bridge the eventual Stone statement will use.

`TauCeti/Analysis/Semigroups/Group/Generator.lean` defines the generator as the generator of the forward semigroup, and then proves what is genuinely new on a group. `reflect_generator` identifies the generator of the reversed group with `-A` on the same domain, obtained by transporting the difference quotient across `U (-t)` and using strong continuity at `0`. Combining the two one-sided limits gives `hasDerivAt_zero` and then `hasDerivAt`: for `x ∈ D(A)` the orbit `t ↦ U t x` is differentiable at every real time with derivative `U t (A x)`, so it solves `u' = A u` on the whole line and not just on `[0, ∞)`. Restarting the orbit at time `t` gives `map_mem_domain` and `generator_map`, the invariance of `D(A)` under the whole group and the commutation of `A` with it, at negative times as well as positive ones. `eq_of_generator_eq` shows a C₀-group is determined by its generator: the generator fixes the forward half by semigroup uniqueness and the backward half through the reversed group. Finally `ofBounded A`, the group `t ↦ exp (t • A)` of a bounded operator, is the acceptance example: its forward semigroup is the existing `StronglyContinuousSemigroup.ofBounded`, its reversal is the group of `-A`, its generator is `A` on all of `X`, it has growth bound `(‖A‖, 1)`, and every C₀-group with that generator equals it.

No new mathematics is duplicated from Mathlib and nothing is vendored: the semigroup laws, generator, uniqueness, dissipativity and exponential API are all consumed from `TauCeti/Analysis/Semigroups/` and Mathlib's `LinearPMap`, `ContinuousLinearEquiv.equivOfInverse` and `NormedSpace.exp`. The two group files land in a fresh `TauCeti/Analysis/Semigroups/Group/` directory. Shared support adds `TauCeti/Analysis/Normed/Operator/Basic.lean`, extends `Normed/Operator/Exponential.lean`, and refactors `Semigroups/GrowthBound.lean`, `Semigroups/BoundedGenerator/Basic.lean`, `Semigroups/Generator/IteratedDomain.lean`, and `Semigroups/Generation/LimitSemigroup.lean` to consume those helpers; no existing module moves.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"stronglycontinuousgroup"}-->

🤖 Prepared with Claude Code