### PR TITLE
feat: add the Fredholm alternative for Dirichlet mass shifts

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/VariationalFredholm.lean
+++ b/TauCeti/Analysis/InnerProductSpace/VariationalFredholm.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Adjoint
+public import Mathlib.Analysis.Normed.Operator.Compact.FredholmAlternative
+public import TauCeti.Analysis.InnerProductSpace.LaxMilgram
+public import TauCeti.Analysis.Normed.Operator.Compact.RieszTheory
+
+/-!
+# The Fredholm alternative for compact perturbations of coercive forms
+
+Let `B` be a bounded coercive bilinear form on a real Hilbert space `V`, and let
+`J : V → H` be a continuous linear map to another real Hilbert space.  Lax--Milgram turns the
+quadratic form
+
+`(u, v) ↦ ⟪J u, J v⟫`
+
+into an operator `K : V → V`, characterized by `B (K u) v = ⟪J u, J v⟫`.  When `J` is compact,
+so is `K`.  Mathlib's Fredholm alternative for compact operators can therefore be applied to
+`1 - κK`: either the homogeneous compactly perturbed variational problem has a nonzero solution,
+or every represented forcing has a unique solution.  Its kernel is finite dimensional in either
+case.
+
+This is the abstract functional-analytic assembly used by Lane D.18 of the PDE roadmap.  In that
+application `V = H¹₀(Ω)`, `H = L²(Ω)`, and `J` is the compact Rellich inclusion.
+
+## Main declarations
+
+* `IsCoercive.formPerturbationOperator`: the Lax--Milgram operator representing
+  `(u, v) ↦ ⟪J u, J v⟫`.
+* `IsCoercive.isCompactOperator_formPerturbationOperator`: compactness when `J` is compact.
+* `IsCoercive.finiteDimensional_ker_one_sub_smul_formPerturbationOperator`: finite dimensionality
+  of the homogeneous solution space.
+* `IsCoercive.fredholmAlternative_formPerturbation`: the variational Fredholm alternative.
+
+The construction consumes Mathlib's `IsCompactOperator.hasEigenvalue_or_mem_resolventSet` and
+the Riesz--Schauder kernel theorem
+`TauCeti.IsCompactOperator.finiteDimensional_ker_one_sub`.
+
+## References
+
+L. C. Evans, *Partial Differential Equations*, Section 6.2.3; J. B. Conway, *A Course in
+Functional Analysis*, Chapter VI, Section 5.
+-/
+
+public section
+
+noncomputable section
+
+open Module
+open scoped InnerProduct InnerProductSpace
+
+namespace IsCoercive
+
+variable {V H : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [CompleteSpace V]
+  [NormedAddCommGroup H] [InnerProductSpace ℝ H] [CompleteSpace H]
+  {B : V →L[ℝ] V →L[ℝ] ℝ}
+
+/-- The operator representing the form `(u, v) ↦ ⟪J u, J v⟫` relative to a coercive form `B`.
+It is characterized by `IsCoercive.apply_formPerturbationOperator` without unfolding. -/
+def formPerturbationOperator (hB : IsCoercive B) (J : V →L[ℝ] H) : V →L[ℝ] V :=
+  hB.continuousLinearEquivOfBilin.symm.toContinuousLinearMap.comp ((J†).comp J)
+
+/-- The form perturbation operator is the inverse Lax--Milgram operator applied to `J†J`. -/
+theorem formPerturbationOperator_apply (hB : IsCoercive B) (J : V →L[ℝ] H) (u : V) :
+    hB.formPerturbationOperator J u = hB.solutionOfInner ((J†) (J u)) := by
+  rw [formPerturbationOperator, ContinuousLinearMap.comp_apply,
+    ContinuousLinearMap.comp_apply, solutionOfInner_def]
+  rfl
+
+/-- Characterization of the form perturbation operator by its variational equation. -/
+@[simp]
+theorem apply_formPerturbationOperator (hB : IsCoercive B) (J : V →L[ℝ] H) (u v : V) :
+    B (hB.formPerturbationOperator J u) v = ⟪J u, J v⟫_ℝ := by
+  rw [formPerturbationOperator_apply, apply_solutionOfInner_eq_inner,
+    ContinuousLinearMap.adjoint_inner_left]
+
+/-- If the embedding `J` is compact, so is the operator representing its inner-product form. -/
+theorem isCompactOperator_formPerturbationOperator (hB : IsCoercive B) {J : V →L[ℝ] H}
+    (hJ : IsCompactOperator J) : IsCompactOperator (hB.formPerturbationOperator J) := by
+  rw [formPerturbationOperator]
+  exact (hJ.clm_comp (J†)).clm_comp
+    hB.continuousLinearEquivOfBilin.symm.toContinuousLinearMap
+
+/-- The compactly perturbed operator equation is equivalent to its variational formulation. -/
+theorem one_sub_smul_formPerturbationOperator_apply_eq_iff (hB : IsCoercive B)
+    (J : V →L[ℝ] H) (kappa : ℝ) (F u : V) :
+    (1 - kappa • hB.formPerturbationOperator J : V →L[ℝ] V) u = hB.solutionOfInner F ↔
+      ∀ v : V, B u v - kappa * ⟪J u, J v⟫_ℝ = ⟪F, v⟫_ℝ := by
+  constructor
+  · intro hu v
+    have h := congrArg (fun w => B w v) hu
+    simpa only [sub_apply, one_apply_eq_self, smul_apply, map_sub, map_smul, smul_eq_mul,
+      apply_formPerturbationOperator, apply_solutionOfInner_eq_inner] using h
+  · intro hu
+    apply hB.continuousLinearEquivOfBilin.injective
+    apply ext_inner_right ℝ
+    intro v
+    rw [continuousLinearEquivOfBilin_apply, continuousLinearEquivOfBilin_solutionOfInner]
+    simpa only [sub_apply, one_apply_eq_self, smul_apply, map_sub, map_smul, smul_eq_mul,
+      apply_formPerturbationOperator] using hu v
+
+/-- The compactly perturbed operator equation with an arbitrary continuous functional is
+equivalent to its variational formulation. -/
+theorem one_sub_smul_formPerturbationOperator_apply_eq_iff_functional (hB : IsCoercive B)
+    (J : V →L[ℝ] H) (kappa : ℝ) (ell : StrongDual ℝ V) (u : V) :
+    (1 - kappa • hB.formPerturbationOperator J : V →L[ℝ] V) u =
+        hB.solutionOfFunctional ell ↔
+      ∀ v : V, B u v - kappa * ⟪J u, J v⟫_ℝ = ell v := by
+  rw [solutionOfFunctional_def,
+    one_sub_smul_formPerturbationOperator_apply_eq_iff]
+  simp only [InnerProductSpace.toDual_symm_apply]
+
+/-- The homogeneous solution space of a compactly perturbed coercive variational problem is
+finite dimensional. -/
+theorem finiteDimensional_ker_one_sub_smul_formPerturbationOperator (hB : IsCoercive B)
+    {J : V →L[ℝ] H} (hJ : IsCompactOperator J) (kappa : ℝ) :
+    FiniteDimensional ℝ
+      (LinearMap.ker
+        ((1 - kappa • hB.formPerturbationOperator J : V →L[ℝ] V) : V →ₗ[ℝ] V)) := by
+  exact TauCeti.IsCompactOperator.finiteDimensional_ker_one_sub
+    ((hB.isCompactOperator_formPerturbationOperator hJ).smul kappa)
+
+/-- **The variational Fredholm alternative.**  For a compact embedding `J`, either the homogeneous
+perturbation of `B` by `κ ⟪J ·, J ·⟫` has a nonzero solution, or every represented forcing has a
+unique solution. -/
+theorem fredholmAlternative_formPerturbation (hB : IsCoercive B) {J : V →L[ℝ] H}
+    (hJ : IsCompactOperator J) (kappa : ℝ) :
+    (∃ u : V, u ≠ 0 ∧ ∀ v : V, B u v - kappa * ⟪J u, J v⟫_ℝ = 0) ∨
+      ∀ ell : StrongDual ℝ V, ∃! u : V,
+        ∀ v : V, B u v - kappa * ⟪J u, J v⟫_ℝ = ell v := by
+  let K : V →L[ℝ] V := kappa • hB.formPerturbationOperator J
+  have hK : IsCompactOperator K :=
+    (hB.isCompactOperator_formPerturbationOperator hJ).smul kappa
+  rcases hK.hasEigenvalue_or_mem_resolventSet one_ne_zero with heigen | hresolvent
+  · left
+    obtain ⟨u, hu⟩ := heigen.exists_hasEigenvector
+    refine ⟨u, hu.2, ?_⟩
+    simpa using
+      (hB.one_sub_smul_formPerturbationOperator_apply_eq_iff J kappa 0 u).mp (by
+        have hKu : (kappa • hB.formPerturbationOperator J) u = u := by
+          simpa only [K, one_smul, ContinuousLinearMap.coe_coe] using hu.apply_eq_smul
+        rw [sub_apply, one_apply_eq_self, hKu, sub_self, solutionOfInner_def, map_zero])
+  · right
+    have hunit : IsUnit (1 - K : V →L[ℝ] V) := by
+      simpa only [spectrum.mem_resolventSet_iff, Algebra.algebraMap_eq_smul_one, one_smul]
+        using hresolvent
+    have hbij : Function.Bijective (1 - K : V →L[ℝ] V) :=
+      ContinuousLinearMap.isUnit_iff_bijective.mp hunit
+    intro ell
+    obtain ⟨u, hu, hunique⟩ := hbij.existsUnique (hB.solutionOfFunctional ell)
+    refine ⟨u, ?_, fun y hy => hunique y ?_⟩
+    · exact
+        (hB.one_sub_smul_formPerturbationOperator_apply_eq_iff_functional J kappa ell u).mp <| by
+        simpa only [K] using hu
+    · exact
+        (hB.one_sub_smul_formPerturbationOperator_apply_eq_iff_functional J kappa ell y).mpr hy
+
+end IsCoercive

--- a/TauCeti/Analysis/InnerProductSpace/VariationalFredholm.lean
+++ b/TauCeti/Analysis/InnerProductSpace/VariationalFredholm.lean
@@ -79,7 +79,8 @@ theorem apply_formPerturbationOperator (hB : IsCoercive B) (J : V →L[ℝ] H) (
   rw [formPerturbationOperator_apply, apply_solutionOfInner_eq_inner,
     ContinuousLinearMap.adjoint_inner_left]
 
-/-- If the embedding `J` is compact, so is the operator representing its inner-product form. -/
+/-- If the continuous linear map `J` is compact, so is the operator representing its
+inner-product form. -/
 theorem isCompactOperator_formPerturbationOperator (hB : IsCoercive B) {J : V →L[ℝ] H}
     (hJ : IsCompactOperator J) : IsCompactOperator (hB.formPerturbationOperator J) := by
   rw [formPerturbationOperator]
@@ -125,9 +126,9 @@ theorem finiteDimensional_ker_one_sub_smul_formPerturbationOperator (hB : IsCoer
   exact TauCeti.IsCompactOperator.finiteDimensional_ker_one_sub
     ((hB.isCompactOperator_formPerturbationOperator hJ).smul kappa)
 
-/-- **The variational Fredholm alternative.**  For a compact embedding `J`, either the homogeneous
-perturbation of `B` by `κ ⟪J ·, J ·⟫` has a nonzero solution, or every represented forcing has a
-unique solution. -/
+/-- **The variational Fredholm alternative.**  For a compact continuous linear map `J`, either the
+homogeneous perturbation of `B` by `κ ⟪J ·, J ·⟫` has a nonzero solution, or every represented
+forcing has a unique solution. -/
 theorem fredholmAlternative_formPerturbation (hB : IsCoercive B) {J : V →L[ℝ] H}
     (hJ : IsCompactOperator J) (kappa : ℝ) :
     (∃ u : V, u ≠ 0 ∧ ∀ v : V, B u v - kappa * ⟪J u, J v⟫_ℝ = 0) ∨

--- a/TauCeti/Analysis/PDE/DirichletProblem.lean
+++ b/TauCeti/Analysis/PDE/DirichletProblem.lean
@@ -219,14 +219,6 @@ def weakSolutionDirichlet
     W1p0 mu Omega 2 :=
   hcoercive.solutionOfFunctional (dirichletForcing f)
 
-/-- The Dirichlet weak solution is the Lax--Milgram solution of its forcing functional. -/
-theorem weakSolutionDirichlet_def
-    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
-    (hcoercive : IsCoercive (energyFormH1L0 hcoeff)) (f : Lp ℝ 2 (mu.restrict Omega)) :
-    weakSolutionDirichlet hcoeff hcoercive f =
-      hcoercive.solutionOfFunctional (dirichletForcing f) :=
-  (rfl)
-
 /-- The Lax--Milgram solution is a weak solution of the Dirichlet problem. -/
 theorem isWeakSolutionDirichlet_weakSolutionDirichlet
     (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))

--- a/TauCeti/Analysis/PDE/DirichletProblem.lean
+++ b/TauCeti/Analysis/PDE/DirichletProblem.lean
@@ -219,6 +219,14 @@ def weakSolutionDirichlet
     W1p0 mu Omega 2 :=
   hcoercive.solutionOfFunctional (dirichletForcing f)
 
+/-- The Dirichlet weak solution is the Lax--Milgram solution of its forcing functional. -/
+theorem weakSolutionDirichlet_def
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff)) (f : Lp ℝ 2 (mu.restrict Omega)) :
+    weakSolutionDirichlet hcoeff hcoercive f =
+      hcoercive.solutionOfFunctional (dirichletForcing f) :=
+  (rfl)
+
 /-- The Lax--Milgram solution is a weak solution of the Dirichlet problem. -/
 theorem isWeakSolutionDirichlet_weakSolutionDirichlet
     (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))

--- a/TauCeti/Analysis/PDE/FredholmAlternative.lean
+++ b/TauCeti/Analysis/PDE/FredholmAlternative.lean
@@ -30,8 +30,9 @@ form to a coercive form by adding a sufficiently large constant.
 
 ## Main declarations
 
-* `TauCeti.PDE.dirichletMassOperator`: the compact operator representing the `L²` mass form
-  relative to the coercive energy form.
+* `TauCeti.PDE.dirichletMassOperator`: the operator representing the `L²` mass form relative to
+  the coercive energy form; `TauCeti.PDE.isCompactOperator_dirichletMassOperator` proves it compact
+  on bounded domains.
 * `TauCeti.PDE.IsWeakSolutionDirichletMassShift`: the weak equation with scalar mass shift.
 * `TauCeti.PDE.finiteDimensional_ker_one_sub_smul_dirichletMassOperator`: finite dimensionality
   of its homogeneous solution space.
@@ -108,8 +109,20 @@ def IsWeakSolutionDirichletMassShift (a : EuclideanSpace ℝ ι → Matrix ι ι
         kappa * ⟪W1p.value (u : W1p mu Omega 2), W1p.value (v : W1p mu Omega 2)⟫_ℝ =
       dirichletForcing f v
 
+/-- Being a mass-shifted weak solution, written out as the integral identity
+`B(u, v) - κ⟪u, v⟫_{L²} = ∫_Ω f v`. -/
+@[simp]
+theorem isWeakSolutionDirichletMassShift_iff (kappa : ℝ)
+    (f : Lp ℝ 2 (mu.restrict Omega)) (u : W1p0 mu Omega 2) :
+    IsWeakSolutionDirichletMassShift a b c kappa f u ↔
+      ∀ v : W1p0 mu Omega 2,
+        energyFormH1 a b c (u : W1p mu Omega 2) (v : W1p mu Omega 2) -
+            kappa * ⟪W1p.value (u : W1p mu Omega 2), W1p.value (v : W1p mu Omega 2)⟫_ℝ =
+          ∫ x in Omega, f x * W1p.value (v : W1p mu Omega 2) x ∂mu := by
+  simp only [IsWeakSolutionDirichletMassShift, dirichletForcing_apply_eq_setIntegral]
+
 /-- The mass-shifted weak equation written as an operator equation on `H¹₀(Ω)`. -/
-theorem isWeakSolutionDirichletMassShift_iff
+theorem isWeakSolutionDirichletMassShift_iff_operator_eq
     (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
     (hcoercive : IsCoercive (energyFormH1L0 hcoeff)) (kappa : ℝ)
     (f : Lp ℝ 2 (mu.restrict Omega)) (u : W1p0 mu Omega 2) :

--- a/TauCeti/Analysis/PDE/FredholmAlternative.lean
+++ b/TauCeti/Analysis/PDE/FredholmAlternative.lean
@@ -121,7 +121,11 @@ theorem isWeakSolutionDirichletMassShift_iff (kappa : ℝ)
           ∫ x in Omega, f x * W1p.value (v : W1p mu Omega 2) x ∂mu := by
   simp only [IsWeakSolutionDirichletMassShift, dirichletForcing_apply_eq_setIntegral]
 
-/-- A zero mass shift recovers the unshifted Dirichlet weak equation. -/
+/-- A zero mass shift recovers the unshifted Dirichlet weak equation.
+
+This named specialization is not a simp lemma because
+`isWeakSolutionDirichletMassShift_iff` already reduces its left-hand side; registering both
+lemmas would violate the `simpNF` linter. -/
 theorem isWeakSolutionDirichletMassShift_zero_iff (f : Lp ℝ 2 (mu.restrict Omega))
     (u : W1p0 mu Omega 2) :
     IsWeakSolutionDirichletMassShift a b c 0 f u ↔ IsWeakSolutionDirichlet a b c f u := by

--- a/TauCeti/Analysis/PDE/FredholmAlternative.lean
+++ b/TauCeti/Analysis/PDE/FredholmAlternative.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.InnerProductSpace.VariationalFredholm
+public import TauCeti.Analysis.PDE.DirichletProblem
+public import TauCeti.Analysis.Sobolev.RellichKondrachov
+
+/-!
+# The Fredholm alternative for the Dirichlet problem
+
+Let `B` be the bounded coercive energy form of a divergence-form operator on `H¹₀(Ω)`.  Shifting
+its mass coefficient by a constant `-κ` changes the weak equation to
+
+`B(u, v) - κ ⟪u, v⟫_{L²} = ⟪f, v⟫_{L²}`.
+
+When `Ω` is bounded, Rellich--Kondrachov makes the value inclusion
+`H¹₀(Ω) → L²(Ω)` compact.  The abstract variational Fredholm alternative therefore gives the
+classical dichotomy: either the homogeneous shifted problem has a nonzero solution, or every
+`L²` forcing has a unique weak solution.  The homogeneous solution space is always finite
+dimensional.
+
+This is the compact-resolvent step of Lane D.18 of `TauCetiRoadmap/PDE/README.md`.  The unshifted
+form `B` can itself contain bounded measurable principal, drift, and mass coefficients; only the
+additional perturbation is the scalar mass shift.  This is the standard reduction of a Gårding
+form to a coercive form by adding a sufficiently large constant.
+
+## Main declarations
+
+* `TauCeti.PDE.dirichletMassOperator`: the compact operator representing the `L²` mass form
+  relative to the coercive energy form.
+* `TauCeti.PDE.IsWeakSolutionDirichletMassShift`: the weak equation with scalar mass shift.
+* `TauCeti.PDE.finiteDimensional_ker_one_sub_smul_dirichletMassOperator`: finite dimensionality
+  of its homogeneous solution space.
+* `TauCeti.PDE.fredholmAlternative_isWeakSolutionDirichletMassShift`: the Fredholm dichotomy.
+
+## References
+
+Lane D, item 18 of `TauCetiRoadmap/PDE/README.md`; L. C. Evans, *Partial Differential Equations*,
+Section 6.2.3; D. Gilbarg and N. Trudinger, *Elliptic Partial Differential Equations of Second
+Order*, Chapter 8, Theorem 8.3.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+namespace PDE
+
+open Bornology MeasureTheory Set TopologicalSpace
+open scoped ENNReal InnerProduct InnerProductSpace
+
+variable {ι : Type*} [Fintype ι] {mu : Measure (EuclideanSpace ℝ ι)} [mu.IsAddHaarMeasure]
+  {Omega : Opens (EuclideanSpace ℝ ι)} {a : EuclideanSpace ℝ ι → Matrix ι ι ℝ}
+  {b : EuclideanSpace ℝ ι → EuclideanSpace ℝ ι}
+  {c : EuclideanSpace ℝ ι → ℝ}
+
+/-- Shortcut normed group instance on `H¹₀(Ω)`, needed by the inherited Hilbert structure. -/
+noncomputable local instance instNormedAddCommGroupH1ZeroFredholm :
+    NormedAddCommGroup (W1p0 mu Omega 2) := inferInstance
+
+/-- Shortcut inner-product instance on `H¹₀(Ω)`. -/
+noncomputable local instance instInnerProductSpaceH1ZeroFredholm :
+    InnerProductSpace ℝ (W1p0 mu Omega 2) := inferInstance
+
+/-- The Lax--Milgram operator representing the `L²` mass form on `H¹₀(Ω)`.  It is characterized
+by `TauCeti.PDE.energyFormH1_dirichletMassOperator`. -/
+def dirichletMassOperator
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff)) :
+    W1p0 mu Omega 2 →L[ℝ] W1p0 mu Omega 2 :=
+  hcoercive.formPerturbationOperator W1p0.valueL
+
+/-- The Dirichlet mass operator represents the `L²` inner product relative to the base energy
+form. -/
+@[simp]
+theorem energyFormH1_dirichletMassOperator
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff)) (u v : W1p0 mu Omega 2) :
+    energyFormH1 a b c (dirichletMassOperator hcoeff hcoercive u : W1p mu Omega 2)
+        (v : W1p mu Omega 2) =
+      ⟪W1p.value (u : W1p mu Omega 2), W1p.value (v : W1p mu Omega 2)⟫_ℝ := by
+  rw [← energyFormH1L0_apply hcoeff, dirichletMassOperator,
+    hcoercive.apply_formPerturbationOperator, W1p0.valueL_apply, W1p0.valueL_apply]
+
+/-- On a bounded domain, the Dirichlet mass operator is compact by Rellich--Kondrachov. -/
+theorem isCompactOperator_dirichletMassOperator
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff))
+    (hOmega : IsBounded (Omega : Set (EuclideanSpace ℝ ι))) :
+    IsCompactOperator (dirichletMassOperator hcoeff hcoercive) := by
+  apply hcoercive.isCompactOperator_formPerturbationOperator
+  exact W1p0.isCompactOperator_valueL (by simp) hOmega
+
+/-- The weak Dirichlet equation obtained by shifting the base operator's mass coefficient by the
+constant `-κ`.  It says `B(u,v) - κ⟪u,v⟫_{L²} = ⟪f,v⟫_{L²}` for every
+`v ∈ H¹₀(Ω)`. -/
+def IsWeakSolutionDirichletMassShift (a : EuclideanSpace ℝ ι → Matrix ι ι ℝ)
+    (b : EuclideanSpace ℝ ι → EuclideanSpace ℝ ι) (c : EuclideanSpace ℝ ι → ℝ)
+    (kappa : ℝ) (f : Lp ℝ 2 (mu.restrict Omega)) (u : W1p0 mu Omega 2) : Prop :=
+  ∀ v : W1p0 mu Omega 2,
+    energyFormH1 a b c (u : W1p mu Omega 2) (v : W1p mu Omega 2) -
+        kappa * ⟪W1p.value (u : W1p mu Omega 2), W1p.value (v : W1p mu Omega 2)⟫_ℝ =
+      dirichletForcing f v
+
+/-- The mass-shifted weak equation written as an operator equation on `H¹₀(Ω)`. -/
+theorem isWeakSolutionDirichletMassShift_iff
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff)) (kappa : ℝ)
+    (f : Lp ℝ 2 (mu.restrict Omega)) (u : W1p0 mu Omega 2) :
+    IsWeakSolutionDirichletMassShift a b c kappa f u ↔
+      (1 - kappa • dirichletMassOperator hcoeff hcoercive :
+          W1p0 mu Omega 2 →L[ℝ] W1p0 mu Omega 2) u =
+        weakSolutionDirichlet hcoeff hcoercive f := by
+  rw [weakSolutionDirichlet_def]
+  simpa only [dirichletMassOperator, IsWeakSolutionDirichletMassShift,
+    energyFormH1L0_apply, W1p0.valueL_apply] using
+    (hcoercive.one_sub_smul_formPerturbationOperator_apply_eq_iff_functional
+      (W1p0.valueL (mu := mu) (Omega := Omega) (p := 2)) kappa (dirichletForcing f) u).symm
+
+/-- The homogeneous solution space of a scalar mass shift of a coercive Dirichlet form is finite
+dimensional on a bounded domain. -/
+theorem finiteDimensional_ker_one_sub_smul_dirichletMassOperator
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff))
+    (hOmega : IsBounded (Omega : Set (EuclideanSpace ℝ ι)))
+    (kappa : ℝ) :
+    FiniteDimensional ℝ
+      (LinearMap.ker
+        ((1 - kappa • dirichletMassOperator hcoeff hcoercive :
+          W1p0 mu Omega 2 →L[ℝ] W1p0 mu Omega 2) :
+            W1p0 mu Omega 2 →ₗ[ℝ] W1p0 mu Omega 2)) :=
+  hcoercive.finiteDimensional_ker_one_sub_smul_formPerturbationOperator
+    (W1p0.isCompactOperator_valueL (by simp) hOmega) kappa
+
+/-- **The Fredholm alternative for the mass-shifted Dirichlet problem.**  On a bounded domain,
+either the homogeneous shifted problem has a nonzero weak solution, or every `L²` forcing has a
+unique weak solution. -/
+theorem fredholmAlternative_isWeakSolutionDirichletMassShift
+    (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
+    (hcoercive : IsCoercive (energyFormH1L0 hcoeff))
+    (hOmega : IsBounded (Omega : Set (EuclideanSpace ℝ ι)))
+    (kappa : ℝ) :
+    (∃ u : W1p0 mu Omega 2, u ≠ 0 ∧ IsWeakSolutionDirichletMassShift a b c kappa 0 u) ∨
+      ∀ f : Lp ℝ 2 (mu.restrict Omega),
+        ∃! u : W1p0 mu Omega 2, IsWeakSolutionDirichletMassShift a b c kappa f u := by
+  rcases hcoercive.fredholmAlternative_formPerturbation
+      (W1p0.isCompactOperator_valueL (by simp) hOmega) kappa with hkernel | hunique
+  · left
+    obtain ⟨u, hune, hu⟩ := hkernel
+    refine ⟨u, hune, fun v => ?_⟩
+    simpa only [energyFormH1L0_apply, W1p0.valueL_apply, dirichletForcing_apply, inner_zero_left]
+      using hu v
+  · right
+    intro f
+    obtain ⟨u, hu, huniq⟩ := hunique (dirichletForcing f)
+    refine ⟨u, fun v => ?_, fun y hy => huniq y fun v => ?_⟩
+    · simpa only [energyFormH1L0_apply, W1p0.valueL_apply] using hu v
+    · simpa only [energyFormH1L0_apply, W1p0.valueL_apply] using hy v
+
+end PDE
+
+end TauCeti

--- a/TauCeti/Analysis/PDE/FredholmAlternative.lean
+++ b/TauCeti/Analysis/PDE/FredholmAlternative.lean
@@ -121,6 +121,14 @@ theorem isWeakSolutionDirichletMassShift_iff (kappa : ℝ)
           ∫ x in Omega, f x * W1p.value (v : W1p mu Omega 2) x ∂mu := by
   simp only [IsWeakSolutionDirichletMassShift, dirichletForcing_apply_eq_setIntegral]
 
+/-- A zero mass shift recovers the unshifted Dirichlet weak equation. -/
+@[simp]
+theorem isWeakSolutionDirichletMassShift_zero_iff (f : Lp ℝ 2 (mu.restrict Omega))
+    (u : W1p0 mu Omega 2) :
+    IsWeakSolutionDirichletMassShift a b c 0 f u ↔ IsWeakSolutionDirichlet a b c f u := by
+  rw [isWeakSolutionDirichletMassShift_iff, isWeakSolutionDirichlet_iff]
+  simp only [zero_mul, sub_zero]
+
 /-- The mass-shifted weak equation written as an operator equation on `H¹₀(Ω)`. -/
 theorem isWeakSolutionDirichletMassShift_iff_operator_eq
     (hcoeff : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ (mu.restrict Omega))
@@ -130,11 +138,25 @@ theorem isWeakSolutionDirichletMassShift_iff_operator_eq
       (1 - kappa • dirichletMassOperator hcoeff hcoercive :
           W1p0 mu Omega 2 →L[ℝ] W1p0 mu Omega 2) u =
         weakSolutionDirichlet hcoeff hcoercive f := by
-  rw [weakSolutionDirichlet_def]
-  simpa only [dirichletMassOperator, IsWeakSolutionDirichletMassShift,
-    energyFormH1L0_apply, W1p0.valueL_apply] using
-    (hcoercive.one_sub_smul_formPerturbationOperator_apply_eq_iff_functional
-      (W1p0.valueL (mu := mu) (Omega := Omega) (p := 2)) kappa (dirichletForcing f) u).symm
+  have habstract :
+      IsWeakSolutionDirichletMassShift a b c kappa f u ↔
+        (1 - kappa • dirichletMassOperator hcoeff hcoercive :
+            W1p0 mu Omega 2 →L[ℝ] W1p0 mu Omega 2) u =
+          hcoercive.solutionOfFunctional (dirichletForcing f) := by
+    simpa only [dirichletMassOperator, IsWeakSolutionDirichletMassShift,
+      energyFormH1L0_apply, W1p0.valueL_apply] using
+      (hcoercive.one_sub_smul_formPerturbationOperator_apply_eq_iff_functional
+        (W1p0.valueL (mu := mu) (Omega := Omega) (p := 2)) kappa (dirichletForcing f) u).symm
+  have hsolution :
+      weakSolutionDirichlet hcoeff hcoercive f =
+        hcoercive.solutionOfFunctional (dirichletForcing f) :=
+    hcoercive.eq_solutionOfFunctional fun v => by
+    rw [energyFormH1L0_apply, dirichletForcing_apply_eq_setIntegral]
+    exact (isWeakSolutionDirichlet_iff f _).mp
+      (isWeakSolutionDirichlet_weakSolutionDirichlet hcoeff hcoercive f) v
+  constructor
+  · exact fun h => (habstract.mp h).trans hsolution.symm
+  · exact fun h => habstract.mpr (h.trans hsolution)
 
 /-- The homogeneous solution space of a scalar mass shift of a coercive Dirichlet form is finite
 dimensional on a bounded domain. -/

--- a/TauCeti/Analysis/PDE/FredholmAlternative.lean
+++ b/TauCeti/Analysis/PDE/FredholmAlternative.lean
@@ -122,7 +122,6 @@ theorem isWeakSolutionDirichletMassShift_iff (kappa : ℝ)
   simp only [IsWeakSolutionDirichletMassShift, dirichletForcing_apply_eq_setIntegral]
 
 /-- A zero mass shift recovers the unshifted Dirichlet weak equation. -/
-@[simp]
 theorem isWeakSolutionDirichletMassShift_zero_iff (f : Lp ℝ 2 (mu.restrict Omega))
     (u : W1p0 mu Omega 2) :
     IsWeakSolutionDirichletMassShift a b c 0 f u ↔ IsWeakSolutionDirichlet a b c f u := by


### PR DESCRIPTION
This PR adds the Fredholm alternative for scalar mass shifts of a coercive Dirichlet form on `H¹₀(Ω)`. It constructs the Lax–Milgram operator representing the `L²` mass form, proves that operator compact from zero-boundary Rellich–Kondrachov on bounded domains, and derives both finite-dimensionality of the homogeneous solution space and the dichotomy between a nonzero homogeneous solution and unique solvability for every `L²` forcing.

It advances the exact `TauCetiRoadmap/PDE/README.md` Lane D.18 target, “The Fredholm alternative (non-coercive case)”: use Rellich to make the resolvent compact and obtain the either-unique-solution-or-finite-dimensional-kernel dichotomy for `Lu = f`. This is the most effective current step because Lane D.17’s coercive Dirichlet solver and Lane A.6’s zero-boundary Rellich compactness are already merged, so their promised D.18 consumer can now be assembled directly. After this PR, D.18 still needs the coefficient-level packaging that rewrites a general Gårding form as one of these coercive scalar mass shifts; Lane D.19 then develops the discrete Dirichlet spectrum.

The abstract proof consumes Mathlib’s `IsCompactOperator.hasEigenvalue_or_mem_resolventSet`, Tau Ceti’s `IsCompactOperator.finiteDimensional_ker_one_sub`, its Lax–Milgram API, and `W1p0.isCompactOperator_valueL`. No Mathlib source or external formalization is vendored.

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"fredholm-alternative-dirichlet"}-->

🤖 Prepared with Codex
