### PR TITLE
feat: close solvable radical candidates under products

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Smooth/Product.lean
@@ -22,6 +22,8 @@ a finite-type ambient affine group.
 
 * `TauCeti.smoothCommHopfAlgProperty.semidirectProduct`: a semidirect product of smooth affine
   groups is smooth.
+* `TauCeti.smoothCommHopfAlgProperty.normalSemidirectProduct`: the conjugation semidirect-product
+  source associated to two smooth closed subgroups is smooth.
 * `TauCeti.smoothCommHopfAlgProperty.productOfNormal`: the multiplication image of a normal
   smooth subgroup and another smooth subgroup is smooth in a finite-type ambient affine group.
 
@@ -58,6 +60,20 @@ theorem semidirectProduct (H K : CommHopfAlgCat.{u} R)
   -- Transport the inferred tensor-product smoothness across the coordinate-algebra equivalence.
   exact Algebra.Smooth.of_equiv A.coordinateAlgEquiv.symm
 
+/-- The conjugation semidirect-product source associated to a normal smooth closed subgroup and
+another smooth closed subgroup is smooth. -/
+theorem normalSemidirectProduct (H : CommHopfAlgCat.{u} R)
+    (I J : HopfIdeal R H) (hI : I.IsNormal)
+    (hIs : smoothCommHopfAlgProperty R (CommHopfAlgCat.quotient H I))
+    (hJs : smoothCommHopfAlgProperty R (CommHopfAlgCat.quotient H J)) :
+    smoothCommHopfAlgProperty R
+      (CommHopfAlgCat.normalSemidirectProduct H I J hI) := by
+  let A := CommHopfAlgCat.quotientNormalConjugation H I J hI
+  exact (smoothCommHopfAlgProperty R).prop_of_iso
+    (CommHopfAlgCat.normalSemidirectProductIso H I J hI).symm
+    (semidirectProduct (CommHopfAlgCat.quotient H I)
+      (CommHopfAlgCat.quotient H J) A hIs hJs)
+
 variable {k : Type u} [Field k]
 
 /-- The scheme-theoretic multiplication image of a normal smooth closed affine subgroup and
@@ -67,12 +83,8 @@ theorem productOfNormal (H : CommHopfAlgCat.{u} k) [Algebra.FiniteType k H]
     (hIs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H I))
     (hJs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H J)) :
     smoothCommHopfAlgProperty k (CommHopfAlgCat.productOfNormal H I J hI) := by
-  let A := CommHopfAlgCat.quotientNormalConjugation H I J hI
   apply image (CommHopfAlgCat.productMapOfNormal H I J hI)
-  exact (smoothCommHopfAlgProperty k).prop_of_iso
-    (CommHopfAlgCat.normalSemidirectProductIso H I J hI).symm
-    (semidirectProduct (CommHopfAlgCat.quotient H I)
-      (CommHopfAlgCat.quotient H J) A hIs hJs)
+  exact normalSemidirectProduct H I J hI hIs hJs
 
 end smoothCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/NormalProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/NormalProduct.lean
@@ -15,7 +15,7 @@ import TauCeti.Algebra.AlgebraicGroup.Smooth.Product
 /-!
 # Solvability of normal products
 
-Let `I` and `J` cut out smooth solvable closed subgroups of a finite-type affine group, with
+Let `I` and `J` cut out smooth solvable closed subgroups of an affine group, with
 `I` normal. Multiplication is a homomorphism from their conjugation semidirect product into the
 ambient group, and `CommHopfAlgCat.productOfNormal` is its scheme-theoretic image.
 
@@ -59,22 +59,22 @@ solvable geometric points when the first subgroup is normal.
 The conjugation semidirect-product source is smooth and solvable. The canonical coordinate map
 from the image into that source is injective, so the derived-word identity for solvability
 descends to the image. -/
-theorem productOfNormal (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+theorem productOfNormal (H : CommHopfAlgCat.{u} k)
     (I J : HopfIdeal k H) (hI : I.IsNormal)
-    (hIs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H.obj I))
-    (hJs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H.obj J))
+    (hIs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H I))
+    (hJs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H J))
     (hIsolv : geometricallySolvablePointsCommHopfAlgProperty k
-      (CommHopfAlgCat.quotient H.obj I))
+      (CommHopfAlgCat.quotient H I))
     (hJsolv : geometricallySolvablePointsCommHopfAlgProperty k
-      (CommHopfAlgCat.quotient H.obj J)) :
+      (CommHopfAlgCat.quotient H J)) :
     geometricallySolvablePointsCommHopfAlgProperty k
-      (CommHopfAlgCat.productOfNormal H.obj I J hI) := by
-  let f := CommHopfAlgCat.productMapOfNormal H.obj I J hI
+      (CommHopfAlgCat.productOfNormal H I J hI) := by
+  let f := CommHopfAlgCat.productMapOfNormal H I J hI
   apply of_injective_of_smooth (CommHopfAlgCat.imageι f)
     (CommHopfAlgCat.imageι_injective f)
   · exact (smoothCommHopfAlgProperty_iff _).mp
-      (smoothCommHopfAlgProperty.normalSemidirectProduct H.obj I J hI hIs hJs)
-  · exact normalSemidirectProduct k H.obj I J hI hIsolv hJsolv
+      (smoothCommHopfAlgProperty.normalSemidirectProduct H I J hI hIs hJs)
+  · exact normalSemidirectProduct k H I J hI hIsolv hJsolv
 
 end geometricallySolvablePointsCommHopfAlgProperty
 

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/NormalProduct.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/NormalProduct.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Smooth.CommHopfAlgCat
+import TauCeti.Algebra.AlgebraicGroup.Solvable.Reduced
+import TauCeti.Algebra.AlgebraicGroup.Solvable.SemidirectProduct
+import TauCeti.Algebra.AlgebraicGroup.Smooth.Product
+
+/-!
+# Solvability of normal products
+
+Let `I` and `J` cut out smooth solvable closed subgroups of a finite-type affine group, with
+`I` normal. Multiplication is a homomorphism from their conjugation semidirect product into the
+ambient group, and `CommHopfAlgCat.productOfNormal` is its scheme-theoretic image.
+
+The semidirect-product source is smooth and has solvable geometric points. Its coordinate map
+from the multiplication image is injective, so solvability descends by the derived-word identity
+criterion for schematically dense morphisms. No faithful-flatness hypothesis on the
+source-to-image morphism is needed.
+
+## Main declaration
+
+* `TauCeti.geometricallySolvablePointsCommHopfAlgProperty.productOfNormal`: the multiplication
+  image of two smooth solvable subgroups has solvable geometric points.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a, 6.a.
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.2.
+
+This supplies the geometric-solvability part of binary-product closure for connected normal
+smooth solvable closed subgroups in Layer 6, "Reductive and semisimple groups", of the
+ReductiveGroups roadmap.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace geometricallySolvablePointsCommHopfAlgProperty
+
+variable {k : Type u} [Field k]
+
+/-- The scheme-theoretic multiplication image of two smooth solvable closed subgroups has
+solvable geometric points when the first subgroup is normal.
+
+The conjugation semidirect-product source is smooth and solvable. The canonical coordinate map
+from the image into that source is injective, so the derived-word identity for solvability
+descends to the image. -/
+theorem productOfNormal (H : FiniteTypeCommHopfAlgCat.{u, u} k)
+    (I J : HopfIdeal k H) (hI : I.IsNormal)
+    (hIs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H.obj I))
+    (hJs : smoothCommHopfAlgProperty k (CommHopfAlgCat.quotient H.obj J))
+    (hIsolv : geometricallySolvablePointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient H.obj I))
+    (hJsolv : geometricallySolvablePointsCommHopfAlgProperty k
+      (CommHopfAlgCat.quotient H.obj J)) :
+    geometricallySolvablePointsCommHopfAlgProperty k
+      (CommHopfAlgCat.productOfNormal H.obj I J hI) := by
+  let f := CommHopfAlgCat.productMapOfNormal H.obj I J hI
+  apply of_injective_of_smooth (CommHopfAlgCat.imageι f)
+    (CommHopfAlgCat.imageι_injective f)
+  · exact (smoothCommHopfAlgProperty_iff _).mp
+      (smoothCommHopfAlgProperty.normalSemidirectProduct H.obj I J hI hIs hJs)
+  · exact normalSemidirectProduct k H.obj I J hI hIsolv hJsolv
+
+end geometricallySolvablePointsCommHopfAlgProperty
+
+end
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Product.lean
@@ -89,7 +89,7 @@ theorem geometricallySolvable_productOfNormal
     (hJ : IsSolvableRadicalCandidate H J) :
     geometricallySolvablePointsCommHopfAlgProperty k
       (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) := by
-  exact geometricallySolvablePointsCommHopfAlgProperty.productOfNormal H I J hI.isNormal
+  exact geometricallySolvablePointsCommHopfAlgProperty.productOfNormal H.obj I J hI.isNormal
     ((smoothCommHopfAlgProperty_iff _).mpr hI.smooth)
     ((smoothCommHopfAlgProperty_iff _).mpr hJ.smooth)
     hI.geometricallySolvable hJ.geometricallySolvable

--- a/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Product.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Product.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Solvable.Radical.Basic
+import TauCeti.Algebra.AlgebraicGroup.Connected.Product
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
+import TauCeti.Algebra.AlgebraicGroup.Smooth.Product
+import TauCeti.Algebra.AlgebraicGroup.Solvable.NormalProduct
+
+/-!
+# Products of solvable-radical candidates
+
+Let `I` and `J` cut out connected normal smooth solvable closed subgroups of a finite-type
+affine group. Since `I` is normal, multiplication on the two subgroups is a homomorphism after
+their product is equipped with the conjugation semidirect-product law. Its scheme-theoretic image
+is the closed subgroup represented by `CommHopfAlgCat.productOfNormal`.
+
+The semidirect-product source is geometrically connected, smooth, and solvable. These properties
+descend to its scheme-theoretic image; for solvability, the source's smoothness lets the
+derived-word identity descend along the injective image coordinate map. Together with normality
+of the product, this proves that solvable-radical candidates are closed under binary products.
+
+## Main declarations
+
+The declarations are in `TauCeti.HopfIdeal.IsSolvableRadicalCandidate`.
+
+* `geometricallyConnected_productOfNormal`: the multiplication image of two candidates is
+  geometrically connected.
+* `smooth_productOfNormal`: the multiplication image of two candidates is smooth.
+* `geometricallySolvable_productOfNormal`: the multiplication image of two candidates has
+  solvable geometric points.
+* `productOfNormal`: solvable-radical candidates are closed under scheme-theoretic
+  multiplication images.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a, 6.a.
+* A. Borel, *Linear Algebraic Groups*, §11.21.
+
+This advances Layer 6, "Reductive and semisimple groups", of the ReductiveGroups roadmap by
+proving binary-product closure for connected normal smooth solvable closed subgroups. This is
+the closure input that makes a maximal-dimensional candidate the solvable radical.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal.IsSolvableRadicalCandidate
+
+variable {k : Type u} [Field k]
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
+
+/-- The scheme-theoretic multiplication image of two solvable-radical candidates is
+geometrically connected. -/
+theorem geometricallyConnected_productOfNormal
+    (hI : IsSolvableRadicalCandidate H I)
+    (hJ : IsSolvableRadicalCandidate H J) :
+    geometricallyConnectedCommHopfAlgProperty k
+      (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) :=
+  geometricallyConnectedCommHopfAlgProperty.productOfNormal H.obj I J hI.isNormal
+    hI.geometricallyConnected hJ.geometricallyConnected
+
+/-- The scheme-theoretic multiplication image of two solvable-radical candidates is smooth. -/
+theorem smooth_productOfNormal
+    (hI : IsSolvableRadicalCandidate H I)
+    (hJ : IsSolvableRadicalCandidate H J) :
+    smoothCommHopfAlgProperty k
+      (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) := by
+  exact smoothCommHopfAlgProperty.productOfNormal H.obj I J hI.isNormal
+    ((smoothCommHopfAlgProperty_iff _).mpr hI.smooth)
+    ((smoothCommHopfAlgProperty_iff _).mpr hJ.smooth)
+
+/-- The scheme-theoretic multiplication image of two solvable-radical candidates has a solvable
+group of geometric points. -/
+theorem geometricallySolvable_productOfNormal
+    (hI : IsSolvableRadicalCandidate H I)
+    (hJ : IsSolvableRadicalCandidate H J) :
+    geometricallySolvablePointsCommHopfAlgProperty k
+      (CommHopfAlgCat.productOfNormal H.obj I J hI.isNormal) := by
+  exact geometricallySolvablePointsCommHopfAlgProperty.productOfNormal H I J hI.isNormal
+    ((smoothCommHopfAlgProperty_iff _).mpr hI.smooth)
+    ((smoothCommHopfAlgProperty_iff _).mpr hJ.smooth)
+    hI.geometricallySolvable hJ.geometricallySolvable
+
+/-- The scheme-theoretic multiplication image of two solvable-radical candidates is again a
+solvable-radical candidate.
+
+Its defining Hopf ideal is the kernel of the multiplication map from the conjugation semidirect
+product. It is normal because both factors are normal, and its quotient is geometrically
+connected, smooth, and geometrically solvable. -/
+theorem productOfNormal
+    (hI : IsSolvableRadicalCandidate H I)
+    (hJ : IsSolvableRadicalCandidate H J) :
+    IsSolvableRadicalCandidate H
+      (HopfIdeal.ker
+        (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom) := by
+  refine .mk
+    (CommHopfAlgCat.isNormal_ker_productMapOfNormal H.obj I J hI.isNormal hJ.isNormal)
+    (hI.geometricallyConnected_productOfNormal hJ)
+    ((smoothCommHopfAlgProperty_iff _).mp (hI.smooth_productOfNormal hJ)) ?_
+  exact hI.geometricallySolvable_productOfNormal hJ
+
+end HopfIdeal.IsSolvableRadicalCandidate
+
+end
+
+end TauCeti


### PR DESCRIPTION
This PR closes solvable-radical candidates under scheme-theoretic binary products. Prove that the multiplication image of two smooth geometrically solvable closed subgroups, with the first normal, remains geometrically solvable by descending a derived-word identity from the smooth conjugation semidirect-product source; then combine this with the existing normality, geometric-connectedness, and smoothness APIs to show the image is again a solvable-radical candidate.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “Reductive and semisimple groups,” specifically “develop the radical `R(G)` (maximal connected normal solvable, geometric).” This is the most effective current step because the maximal-dimensional candidate from #4999 and the smooth-source solvability descent from #5108 are now on `main`, making binary-product closure the named next blocker in the maximal-dimension construction.

Add `TauCeti/Algebra/AlgebraicGroup/Solvable/NormalProduct.lean` (83 lines) for the reusable smooth solvable image theorem and `TauCeti/Algebra/AlgebraicGroup/Solvable/Radical/Product.lean` (119 lines) for the candidate-level closure package. Also expose the already-used smoothness of the named normal semidirect-product source in `Smooth/Product.lean`, and refactor its image theorem through that lemma.

The mathematical organization follows J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a and 6.a; A. Borel, *Linear Algebraic Groups*, §11.21; and J. C. Jantzen, *Representations of Algebraic Groups*, I.2, as cited in the module documentation. No Mathlib implementation or external formalization is vendored; the proof reuses Tau Ceti’s derived-word descent and Mathlib’s smooth-algebra infrastructure.

After this PR, the Layer 6 solvable-radical milestone still needs the Lie-dimension comparison that makes a maximal candidate greatest, followed by packaging that greatest candidate as `R(G)`.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"solvable-radical-candidate-products"}-->

🤖 Prepared with Codex
