### PR TITLE
refactor(FunctionField): name the fibre-wide linear independence of Stichtenoth's family

### DIFF
--- a/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Basic.lean
@@ -216,6 +216,21 @@ theorem ord_sum_eq_of_forall_lt {ι : Type*} {s : Finset ι} {f : ι → F} {j :
     P.ord (∑ i ∈ s, f i) = P.ord (f j) :=
   Valuation.ord_sum_eq_of_forall_lt P.valuation hj hfj hlt
 
+/-- **Normalizing a family of coefficients.** A finite family in `F` that does not vanish
+identically has a nonzero member by which the whole family can be divided without leaving `𝒪_P`;
+a member of least order at `P` is one. This is what turns a relation with coefficients in `F`
+into a relation with coefficients in `𝒪_P`, one of which is a unit. -/
+theorem exists_ne_zero_forall_div_mem_integers {ι : Type*} [Finite ι] (c : ι → F) {i₁ : ι}
+    (hi₁ : c i₁ ≠ 0) : ∃ i₀, c i₀ ≠ 0 ∧ ∀ i, c i / c i₀ ∈ P.integers := by
+  obtain ⟨i₀, hi₀, hmin⟩ :=
+    Set.exists_min_image {i | c i ≠ 0} (fun i ↦ P.ord (c i)) (Set.toFinite _) ⟨i₁, hi₁⟩
+  refine ⟨i₀, hi₀, fun i ↦ ?_⟩
+  rcases eq_or_ne (c i) 0 with h | h
+  · simp [h]
+  · rw [P.mem_integers_iff_ord_nonneg, P.ord_div h hi₀]
+    have := hmin i h
+    omega
+
 section Constants
 
 @[simp]

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Basic.lean
@@ -587,19 +587,8 @@ private theorem exists_ord_sum_eq_mul {ι : Type*} [Fintype ι] (s : ι → P'.i
     (c : ι → F) {i₁ : ι} (hi₁ : c i₁ ≠ 0) :
     (∑ i, algebraMap F F' (c i) * (s i : F')) ≠ 0 ∧
       ∃ m : ℤ, P'.ord (∑ i, algebraMap F F' (c i) * (s i : F')) = ramificationIdx F P' * m := by
-  classical
-  set P := P'.restrict k F with hP
-  set S : Finset ι := {i | c i ≠ 0} with hS
-  have hSne : S.Nonempty := ⟨i₁, by simp [hS, hi₁]⟩
-  obtain ⟨i₀, hi₀S, hi₀⟩ := S.exists_min_image (fun i ↦ P.ord (c i)) hSne
-  have hd : c i₀ ≠ 0 := by simpa [hS] using hi₀S
-  have hb : ∀ i, c i / c i₀ ∈ P.integers := by
-    intro i
-    rcases eq_or_ne (c i) 0 with h | h
-    · simp [h]
-    · rw [P.mem_integers_iff_ord_nonneg, P.ord_div h hd]
-      have := hi₀ i (by simp [hS, h])
-      omega
+  set P := P'.restrict k F
+  obtain ⟨i₀, hd, hb⟩ := P.exists_ne_zero_forall_div_mem_integers c hi₁
   set b : ι → P.integers := fun i ↦ ⟨c i / c i₀, hb i⟩ with hbdef
   have hb₀ : IsUnit (b i₀) := by
     have hb_eq_one : b i₀ = 1 := Subtype.ext (by simp [hbdef, div_self hd])

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Fibre.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Fibre.lean
@@ -131,18 +131,23 @@ private theorem sum_block_ne_zero_and_ord_le (P' : Place k' F') {ι : Type*} [Fi
     _ = ((l₀ : ℕ) : ℤ) := by
         rw [hT, P'.ord_mul hA₀ne (pow_ne_zero _ ht0), P'.ord_pow, hA₀ord, ht, mul_one, zero_add]
 
-/-- **The family `w i j * τ i ^ l` is `F`-linearly independent.** Given, at each place `Q i` over
-`P`, a uniformizer `τ i` that is a unit at the other places of the family, and lifts `w i j` of an
-`F`-linearly independent family of residues, of order at least `[F' : F]` at the other places,
-the `e(Q i ∣ P) · f(Q i ∣ P)` products `w i j * τ i ^ l` are linearly independent over `F`.
-Counting them is what gives the fundamental inequality. -/
+/-- **The products `w i j * τ i ^ l` are `F`-linearly independent across the whole fibre.** Given,
+at each place `Q i` over `P`, a prime element `τ i` for `Q i` that is integral at the other places
+of the family, and lifts `w i j` of a family of residues independent over the residue field of `P`,
+each of order at least `e(Q m ∣ P)` at every other place `Q m`, the `e(Q i ∣ P) · f(Q i ∣ P)`
+products `w i j * τ i ^ l` are linearly independent over `F` **jointly over all of `i`** — which is
+what distinguishes this from the one-place
+`TauCeti.Place.linearIndependent_mul_pow_of_linearIndependent_residue` in `Extension/Basic.lean`.
+Counting the resulting `∑ i, e(Q i ∣ P) · f(Q i ∣ P)` products is what gives the fundamental
+inequality. -/
 private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {ι : Type*}
-    [Finite ι] [DecidableEq ι] {Q : ι → Place k' F'} {P : Place k F}
+    [Finite ι] {Q : ι → Place k' F'} {P : Place k F}
     (hQP : ∀ i, (Q i).restrict k F = P)
-    {τ : ι → F'} (hτ : ∀ i m, (Q m).ord (τ i) = if m = i then 1 else 0)
+    {τ : ι → F'} (hτone : ∀ i, (Q i).ord (τ i) = 1)
+    (hτint : ∀ i m, m ≠ i → 0 ≤ (Q m).ord (τ i))
     {w : ∀ i, Fin (relativeDegree k F (Q i)) → F'} (hwmem : ∀ i j, w i j ∈ (Q i).integers)
     (hwN : ∀ (i : ι) (j : Fin (relativeDegree k F (Q i))) (m : ι), m ≠ i →
-      (Module.finrank F F' : ℤ) ≤ (Q m).ord (w i j))
+      (ramificationIdx F (Q m) : ℤ) ≤ (Q m).ord (w i j))
     (hindres : ∀ i, LinearIndependent ((Q i).restrict k F).ResidueField
       fun j ↦ IsLocalRing.residue (Q i).integers (⟨w i j, hwmem i j⟩ : (Q i).integers)) :
     LinearIndependent F
@@ -150,10 +155,6 @@ private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {�
         w p.1 p.2.1 * τ p.1 ^ (p.2.2 : ℕ)) := by
   classical
   have _ : Fintype ι := Fintype.ofFinite ι
-  set N : ℕ := Module.finrank F F'
-  have hN1 : 1 ≤ N := Module.finrank_pos
-  have hτone : ∀ i, (Q i).ord (τ i) = 1 := fun i ↦ by simpa using hτ i i
-  have hτ0 : ∀ i, τ i ≠ 0 := fun i h ↦ by simpa [h] using hτone i
   set V : (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) → F' :=
     fun p ↦ w p.1 p.2.1 * τ p.1 ^ (p.2.2 : ℕ) with hV
   rw [Fintype.linearIndependent_iff]
@@ -176,7 +177,7 @@ private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {�
       have := hp₀min p (by simp [hS, h])
       omega
   set b : (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) →
-    ((Q i₀).restrict k F).integers := fun p ↦ ⟨g p / g ⟨i₀, j₀, l₀⟩, hbmem p⟩ with hb
+    ((Q i₀).restrict k F).integers := fun p ↦ ⟨g p / g ⟨i₀, j₀, l₀⟩, hbmem p⟩
   have hbcoe : ∀ p, ((b p : F)) = g p / g ⟨i₀, j₀, l₀⟩ := fun _ ↦ rfl
   have hb₀ : b ⟨i₀, j₀, l₀⟩ = 1 := Subtype.ext (by simp [hbcoe, div_self hg₀])
   -- The relation splits into one block per place of the family, and the blocks sum to zero.
@@ -196,14 +197,16 @@ private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {�
           simp only [hZ]
           rw [Finset.sum_sigma', Finset.univ_sigma_univ]
       _ = 0 := hgsum
-  -- The block at `i₀` is nonzero of order less than the ramification index there; the type
-  -- ascription is what identifies `Z i₀` with the sum the block lemma speaks about.
-  obtain ⟨hZne, hZord⟩ : Z i₀ ≠ 0 ∧ (Q i₀).ord (Z i₀) ≤ ((l₀ : ℕ) : ℤ) :=
-    sum_block_ne_zero_and_ord_le k F (Q i₀)
+  -- The block at `i₀` is nonzero of order less than the ramification index there. Unfolding `Z`
+  -- and `V` is what puts it in the shape the block lemma speaks about.
+  obtain ⟨hZne, hZord⟩ : Z i₀ ≠ 0 ∧ (Q i₀).ord (Z i₀) ≤ ((l₀ : ℕ) : ℤ) := by
+    have hblock := sum_block_ne_zero_and_ord_le k F (Q i₀)
       (fun j ↦ (⟨w i₀ j, hwmem i₀ j⟩ : (Q i₀).integers)) (hindres i₀)
       (fun q ↦ b ⟨i₀, q⟩) (j₀ := j₀) (l₀ := l₀) (hb₀ ▸ isUnit_one) (hτone i₀)
-  -- Every other block has order at least `[F' : F]` at `Q i₀`.
-  have hZm : ∀ m, m ≠ i₀ → (Q i₀).valuation (Z m) ≤ WithZero.exp (-(N : ℤ)) := by
+    simpa only [hZ, hV] using hblock
+  -- Every other block has order at least `e(Q i₀ ∣ P)` at `Q i₀`.
+  have hZm : ∀ m, m ≠ i₀ →
+      (Q i₀).valuation (Z m) ≤ WithZero.exp (-(ramificationIdx F (Q i₀) : ℤ)) := by
     intro m hm
     simp only [hZ]
     refine Valuation.map_sum_le _ fun q _ ↦ ?_
@@ -212,20 +215,23 @@ private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {�
       rw [ord_algebraMap_restrict k F (Q i₀) ((b ⟨m, q⟩ : F))]
       exact mul_nonneg (by positivity)
         (((Q i₀).restrict k F).mem_integers_iff_ord_nonneg.mp (b ⟨m, q⟩).2)
-    have hwval : (Q i₀).valuation (w m q.1) ≤ WithZero.exp (-(N : ℤ)) := by
+    have hwval : (Q i₀).valuation (w m q.1) ≤
+        WithZero.exp (-(ramificationIdx F (Q i₀) : ℤ)) := by
       have hne : w m q.1 ≠ 0 := by
         intro h
         have hh := hwN m q.1 i₀ (Ne.symm hm)
+        have he := ramificationIdx_pos (F := F) (Q i₀)
         rw [h, ord_zero] at hh
         omega
       rw [(Q i₀).valuation_eq_exp_neg_ord hne]
       exact WithZero.exp_le_exp.2 (neg_le_neg (hwN m q.1 i₀ (Ne.symm hm)))
-    have hτval : (Q i₀).valuation (τ m ^ (q.2 : ℕ)) = 1 := by
-      rw [map_pow, (Q i₀).valuation_eq_exp_neg_ord (hτ0 m), hτ m i₀]
-      simp [Ne.symm hm]
+    have hτval : (Q i₀).valuation (τ m ^ (q.2 : ℕ)) ≤ 1 := by
+      rw [map_pow]
+      exact pow_le_one' ((Q i₀).mem_integers_iff.mp
+        ((Q i₀).mem_integers_iff_ord_nonneg.mpr (hτint m i₀ (Ne.symm hm)))) _
     simp only [hV]
-    rw [map_mul, map_mul, hτval, mul_one]
-    exact (mul_le_of_le_one_left' hb1).trans hwval
+    rw [map_mul, map_mul]
+    exact (mul_le_of_le_one_left' hb1).trans ((mul_le_of_le_one_right' hτval).trans hwval)
   -- The strict triangle inequality contradicts `∑ i, Z i = 0`.
   have hlt : ∀ m ∈ (Finset.univ : Finset ι) \ {i₀},
       (Q i₀).valuation (Z m) < (Q i₀).valuation (Z i₀) := by
@@ -234,8 +240,6 @@ private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {�
     refine lt_of_le_of_lt (hZm m hmem.2) ?_
     rw [(Q i₀).valuation_eq_exp_neg_ord hZne, WithZero.exp_lt_exp]
     have hl₀ : (l₀ : ℕ) < ramificationIdx F (Q i₀) := l₀.2
-    have hle : ramificationIdx F (Q i₀) ≤ Module.finrank F F' :=
-      ramificationIdx_le_finrank F (Q i₀)
     omega
   have hval := (Q i₀).valuation.map_sum_eq_of_lt (Finset.mem_univ i₀) hlt
   rw [hZsum, map_zero] at hval
@@ -290,8 +294,11 @@ private theorem sum_relativeDegree_mul_ramificationIdx_le_finrank {ι : Type*} [
     simpa only [hwres] using hz i
   -- The candidate independent family: `e(Q i ∣ P) · f(Q i ∣ P)` functions for each `i`.
   have hind :=
-    linearIndependent_mul_pow_of_forall_linearIndependent_residue k F hQP hτ hwmem
-      (fun i j m hm ↦ (hwN i j m hm).ge) hindres
+    linearIndependent_mul_pow_of_forall_linearIndependent_residue k F hQP
+      (fun i ↦ by simpa using hτ i i) (fun i m hm ↦ by simp [hτ i m, hm]) hwmem
+      (fun i j m hm ↦ by
+        rw [hwN i j m hm, hNdef]
+        exact_mod_cast ramificationIdx_le_finrank F (Q m)) hindres
   simpa [Fintype.card_sigma, Fintype.card_prod] using hind.fintype_card_le_finrank
 
 /-- **The fundamental inequality** (Stichtenoth, Theorem 3.1.11): the ramification indices and

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Fibre.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Fibre.lean
@@ -162,20 +162,10 @@ private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {�
   by_contra hex
   obtain ⟨p₁, hp₁⟩ := not_forall.mp hex
   -- Pick a coefficient of least order at `P` among the nonzero ones and divide by it.
-  set S : Finset (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) :=
-    {p | g p ≠ 0} with hS
-  obtain ⟨p₀, hp₀S, hp₀min⟩ :=
-    S.exists_min_image (fun p ↦ P.ord (g p)) ⟨p₁, by simp [hS, hp₁]⟩
-  obtain ⟨i₀, j₀, l₀⟩ := p₀
-  have hg₀ : g ⟨i₀, j₀, l₀⟩ ≠ 0 := by simpa [hS] using hp₀S
-  have hbmem : ∀ p, g p / g ⟨i₀, j₀, l₀⟩ ∈ ((Q i₀).restrict k F).integers := by
-    intro p
-    rw [hQP i₀, P.mem_integers_iff_ord_nonneg]
-    rcases eq_or_ne (g p) 0 with h | h
-    · simp [h]
-    · rw [P.ord_div h hg₀]
-      have := hp₀min p (by simp [hS, h])
-      omega
+  obtain ⟨⟨i₀, j₀, l₀⟩, hg₀, hbP⟩ := P.exists_ne_zero_forall_div_mem_integers g hp₁
+  have hbmem : ∀ p, g p / g ⟨i₀, j₀, l₀⟩ ∈ ((Q i₀).restrict k F).integers := fun p ↦ by
+    rw [hQP i₀]
+    exact hbP p
   set b : (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) →
     ((Q i₀).restrict k F).integers := fun p ↦ ⟨g p / g ⟨i₀, j₀, l₀⟩, hbmem p⟩
   have hbcoe : ∀ p, ((b p : F)) = g p / g ⟨i₀, j₀, l₀⟩ := fun _ ↦ rfl

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Fibre.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Fibre.lean
@@ -133,7 +133,7 @@ private theorem sum_block_ne_zero_and_ord_le (P' : Place k' F') {ι : Type*} [Fi
 
 /-- **The family `w i j * τ i ^ l` is `F`-linearly independent.** Given, at each place `Q i` over
 `P`, a uniformizer `τ i` that is a unit at the other places of the family, and lifts `w i j` of an
-`F`-linearly independent family of residues that are as small as `[F' : F]` at the other places,
+`F`-linearly independent family of residues, of order at least `[F' : F]` at the other places,
 the `e(Q i ∣ P) · f(Q i ∣ P)` products `w i j * τ i ^ l` are linearly independent over `F`.
 Counting them is what gives the fundamental inequality. -/
 private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {ι : Type*}
@@ -142,7 +142,7 @@ private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {�
     {τ : ι → F'} (hτ : ∀ i m, (Q m).ord (τ i) = if m = i then 1 else 0)
     {w : ∀ i, Fin (relativeDegree k F (Q i)) → F'} (hwmem : ∀ i j, w i j ∈ (Q i).integers)
     (hwN : ∀ (i : ι) (j : Fin (relativeDegree k F (Q i))) (m : ι), m ≠ i →
-      (Q m).ord (w i j) = (Module.finrank F F' : ℤ))
+      (Module.finrank F F' : ℤ) ≤ (Q m).ord (w i j))
     (hindres : ∀ i, LinearIndependent ((Q i).restrict k F).ResidueField
       fun j ↦ IsLocalRing.residue (Q i).integers (⟨w i j, hwmem i j⟩ : (Q i).integers)) :
     LinearIndependent F
@@ -212,19 +212,20 @@ private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {�
       rw [ord_algebraMap_restrict k F (Q i₀) ((b ⟨m, q⟩ : F))]
       exact mul_nonneg (by positivity)
         (((Q i₀).restrict k F).mem_integers_iff_ord_nonneg.mp (b ⟨m, q⟩).2)
-    have hwval : (Q i₀).valuation (w m q.1) = WithZero.exp (-(N : ℤ)) := by
+    have hwval : (Q i₀).valuation (w m q.1) ≤ WithZero.exp (-(N : ℤ)) := by
       have hne : w m q.1 ≠ 0 := by
         intro h
         have hh := hwN m q.1 i₀ (Ne.symm hm)
         rw [h, ord_zero] at hh
         omega
-      rw [(Q i₀).valuation_eq_exp_neg_ord hne, hwN m q.1 i₀ (Ne.symm hm)]
+      rw [(Q i₀).valuation_eq_exp_neg_ord hne]
+      exact WithZero.exp_le_exp.2 (neg_le_neg (hwN m q.1 i₀ (Ne.symm hm)))
     have hτval : (Q i₀).valuation (τ m ^ (q.2 : ℕ)) = 1 := by
       rw [map_pow, (Q i₀).valuation_eq_exp_neg_ord (hτ0 m), hτ m i₀]
       simp [Ne.symm hm]
     simp only [hV]
-    rw [map_mul, map_mul, hwval, hτval, mul_one]
-    exact mul_le_of_le_one_left' hb1
+    rw [map_mul, map_mul, hτval, mul_one]
+    exact (mul_le_of_le_one_left' hb1).trans hwval
   -- The strict triangle inequality contradicts `∑ i, Z i = 0`.
   have hlt : ∀ m ∈ (Finset.univ : Finset ι) \ {i₀},
       (Q i₀).valuation (Z m) < (Q i₀).valuation (Z i₀) := by
@@ -289,7 +290,8 @@ private theorem sum_relativeDegree_mul_ramificationIdx_le_finrank {ι : Type*} [
     simpa only [hwres] using hz i
   -- The candidate independent family: `e(Q i ∣ P) · f(Q i ∣ P)` functions for each `i`.
   have hind :=
-    linearIndependent_mul_pow_of_forall_linearIndependent_residue k F hQP hτ hwmem hwN hindres
+    linearIndependent_mul_pow_of_forall_linearIndependent_residue k F hQP hτ hwmem
+      (fun i j m hm ↦ (hwN i j m hm).ge) hindres
   simpa [Fintype.card_sigma, Fintype.card_prod] using hind.fintype_card_le_finrank
 
 /-- **The fundamental inequality** (Stichtenoth, Theorem 3.1.11): the ramification indices and

--- a/TauCeti/FieldTheory/FunctionField/Place/Extension/Fibre.lean
+++ b/TauCeti/FieldTheory/FunctionField/Place/Extension/Fibre.lean
@@ -131,6 +131,115 @@ private theorem sum_block_ne_zero_and_ord_le (P' : Place k' F') {ι : Type*} [Fi
     _ = ((l₀ : ℕ) : ℤ) := by
         rw [hT, P'.ord_mul hA₀ne (pow_ne_zero _ ht0), P'.ord_pow, hA₀ord, ht, mul_one, zero_add]
 
+/-- **The family `w i j * τ i ^ l` is `F`-linearly independent.** Given, at each place `Q i` over
+`P`, a uniformizer `τ i` that is a unit at the other places of the family, and lifts `w i j` of an
+`F`-linearly independent family of residues that are as small as `[F' : F]` at the other places,
+the `e(Q i ∣ P) · f(Q i ∣ P)` products `w i j * τ i ^ l` are linearly independent over `F`.
+Counting them is what gives the fundamental inequality. -/
+private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {ι : Type*}
+    [Finite ι] [DecidableEq ι] {Q : ι → Place k' F'} {P : Place k F}
+    (hQP : ∀ i, (Q i).restrict k F = P)
+    {τ : ι → F'} (hτ : ∀ i m, (Q m).ord (τ i) = if m = i then 1 else 0)
+    {w : ∀ i, Fin (relativeDegree k F (Q i)) → F'} (hwmem : ∀ i j, w i j ∈ (Q i).integers)
+    (hwN : ∀ (i : ι) (j : Fin (relativeDegree k F (Q i))) (m : ι), m ≠ i →
+      (Q m).ord (w i j) = (Module.finrank F F' : ℤ))
+    (hindres : ∀ i, LinearIndependent ((Q i).restrict k F).ResidueField
+      fun j ↦ IsLocalRing.residue (Q i).integers (⟨w i j, hwmem i j⟩ : (Q i).integers)) :
+    LinearIndependent F
+      (fun p : Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i)) ↦
+        w p.1 p.2.1 * τ p.1 ^ (p.2.2 : ℕ)) := by
+  classical
+  have _ : Fintype ι := Fintype.ofFinite ι
+  set N : ℕ := Module.finrank F F'
+  have hN1 : 1 ≤ N := Module.finrank_pos
+  have hτone : ∀ i, (Q i).ord (τ i) = 1 := fun i ↦ by simpa using hτ i i
+  have hτ0 : ∀ i, τ i ≠ 0 := fun i h ↦ by simpa [h] using hτone i
+  set V : (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) → F' :=
+    fun p ↦ w p.1 p.2.1 * τ p.1 ^ (p.2.2 : ℕ) with hV
+  rw [Fintype.linearIndependent_iff]
+  intro g hg
+  by_contra hex
+  obtain ⟨p₁, hp₁⟩ := not_forall.mp hex
+  -- Pick a coefficient of least order at `P` among the nonzero ones and divide by it.
+  set S : Finset (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) :=
+    {p | g p ≠ 0} with hS
+  obtain ⟨p₀, hp₀S, hp₀min⟩ :=
+    S.exists_min_image (fun p ↦ P.ord (g p)) ⟨p₁, by simp [hS, hp₁]⟩
+  obtain ⟨i₀, j₀, l₀⟩ := p₀
+  have hg₀ : g ⟨i₀, j₀, l₀⟩ ≠ 0 := by simpa [hS] using hp₀S
+  have hbmem : ∀ p, g p / g ⟨i₀, j₀, l₀⟩ ∈ ((Q i₀).restrict k F).integers := by
+    intro p
+    rw [hQP i₀, P.mem_integers_iff_ord_nonneg]
+    rcases eq_or_ne (g p) 0 with h | h
+    · simp [h]
+    · rw [P.ord_div h hg₀]
+      have := hp₀min p (by simp [hS, h])
+      omega
+  set b : (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) →
+    ((Q i₀).restrict k F).integers := fun p ↦ ⟨g p / g ⟨i₀, j₀, l₀⟩, hbmem p⟩ with hb
+  have hbcoe : ∀ p, ((b p : F)) = g p / g ⟨i₀, j₀, l₀⟩ := fun _ ↦ rfl
+  have hb₀ : b ⟨i₀, j₀, l₀⟩ = 1 := Subtype.ext (by simp [hbcoe, div_self hg₀])
+  -- The relation splits into one block per place of the family, and the blocks sum to zero.
+  set Z : ι → F' := fun i ↦
+    ∑ q : Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i)),
+      algebraMap F F' ((b ⟨i, q⟩ : F)) * V ⟨i, q⟩ with hZ
+  have hZsum : ∑ i, Z i = 0 := by
+    have hgsum : ∑ p, algebraMap F F' ((b p : F)) * V p = 0 := by
+      have hterm : ∑ p, algebraMap F F' ((b p : F)) * V p =
+          (algebraMap F F' (g ⟨i₀, j₀, l₀⟩))⁻¹ * ∑ p, g p • V p := by
+        rw [Finset.mul_sum]
+        refine Finset.sum_congr rfl fun p _ ↦ ?_
+        rw [hbcoe, div_eq_inv_mul, map_mul, map_inv₀, Algebra.smul_def]
+        ring
+      rw [hterm, hg, mul_zero]
+    calc ∑ i, Z i = ∑ p, algebraMap F F' ((b p : F)) * V p := by
+          simp only [hZ]
+          rw [Finset.sum_sigma', Finset.univ_sigma_univ]
+      _ = 0 := hgsum
+  -- The block at `i₀` is nonzero of order less than the ramification index there; the type
+  -- ascription is what identifies `Z i₀` with the sum the block lemma speaks about.
+  obtain ⟨hZne, hZord⟩ : Z i₀ ≠ 0 ∧ (Q i₀).ord (Z i₀) ≤ ((l₀ : ℕ) : ℤ) :=
+    sum_block_ne_zero_and_ord_le k F (Q i₀)
+      (fun j ↦ (⟨w i₀ j, hwmem i₀ j⟩ : (Q i₀).integers)) (hindres i₀)
+      (fun q ↦ b ⟨i₀, q⟩) (j₀ := j₀) (l₀ := l₀) (hb₀ ▸ isUnit_one) (hτone i₀)
+  -- Every other block has order at least `[F' : F]` at `Q i₀`.
+  have hZm : ∀ m, m ≠ i₀ → (Q i₀).valuation (Z m) ≤ WithZero.exp (-(N : ℤ)) := by
+    intro m hm
+    simp only [hZ]
+    refine Valuation.map_sum_le _ fun q _ ↦ ?_
+    have hb1 : (Q i₀).valuation (algebraMap F F' ((b ⟨m, q⟩ : F))) ≤ 1 := by
+      refine (Q i₀).mem_integers_iff.mp ((Q i₀).mem_integers_iff_ord_nonneg.mpr ?_)
+      rw [ord_algebraMap_restrict k F (Q i₀) ((b ⟨m, q⟩ : F))]
+      exact mul_nonneg (by positivity)
+        (((Q i₀).restrict k F).mem_integers_iff_ord_nonneg.mp (b ⟨m, q⟩).2)
+    have hwval : (Q i₀).valuation (w m q.1) = WithZero.exp (-(N : ℤ)) := by
+      have hne : w m q.1 ≠ 0 := by
+        intro h
+        have hh := hwN m q.1 i₀ (Ne.symm hm)
+        rw [h, ord_zero] at hh
+        omega
+      rw [(Q i₀).valuation_eq_exp_neg_ord hne, hwN m q.1 i₀ (Ne.symm hm)]
+    have hτval : (Q i₀).valuation (τ m ^ (q.2 : ℕ)) = 1 := by
+      rw [map_pow, (Q i₀).valuation_eq_exp_neg_ord (hτ0 m), hτ m i₀]
+      simp [Ne.symm hm]
+    simp only [hV]
+    rw [map_mul, map_mul, hwval, hτval, mul_one]
+    exact mul_le_of_le_one_left' hb1
+  -- The strict triangle inequality contradicts `∑ i, Z i = 0`.
+  have hlt : ∀ m ∈ (Finset.univ : Finset ι) \ {i₀},
+      (Q i₀).valuation (Z m) < (Q i₀).valuation (Z i₀) := by
+    intro m hmem
+    simp only [Finset.mem_sdiff, Finset.mem_singleton] at hmem
+    refine lt_of_le_of_lt (hZm m hmem.2) ?_
+    rw [(Q i₀).valuation_eq_exp_neg_ord hZne, WithZero.exp_lt_exp]
+    have hl₀ : (l₀ : ℕ) < ramificationIdx F (Q i₀) := l₀.2
+    have hle : ramificationIdx F (Q i₀) ≤ Module.finrank F F' :=
+      ramificationIdx_le_finrank F (Q i₀)
+    omega
+  have hval := (Q i₀).valuation.map_sum_eq_of_lt (Finset.mem_univ i₀) hlt
+  rw [hZsum, map_zero] at hval
+  exact ((Valuation.ne_zero_iff _).mpr hZne) hval.symm
+
 /-- **The fundamental inequality**, for a family of places indexed by a finite type. This is the
 form the proof produces; `TauCeti.Place.sum_ramificationIdx_mul_relativeDegree_le_finrank` is the
 `Finset` restatement used elsewhere. -/
@@ -140,13 +249,10 @@ private theorem sum_relativeDegree_mul_ramificationIdx_le_finrank {ι : Type*} [
     ∑ i, relativeDegree k F (Q i) * ramificationIdx F (Q i) ≤ Module.finrank F F' := by
   classical
   set N : ℕ := Module.finrank F F' with hNdef
-  have hN1 : 1 ≤ N := Module.finrank_pos
   -- A function with a simple zero at `Q i` and a unit value at every other place of the family.
   obtain ⟨τ, hτ⟩ : ∃ τ : ι → F', ∀ i m, (Q m).ord (τ i) = if m = i then 1 else 0 := by
     choose τ hτ using fun i : ι ↦ exists_forall_ord_eq hQ fun m ↦ if m = i then (1 : ℤ) else 0
     exact ⟨τ, hτ⟩
-  have hτone : ∀ i, (Q i).ord (τ i) = 1 := fun i ↦ by simpa using hτ i i
-  have hτ0 : ∀ i, τ i ≠ 0 := fun i h ↦ by simpa [h] using hτone i
   -- Lifts to `𝒪_{Q i}` of a basis of the residue field extension at `Q i`, …
   choose z hz using fun i : ι ↦ exists_linearIndependent_residue k F (Q i)
   -- … moved by weak approximation away from the other places of the family.
@@ -182,92 +288,8 @@ private theorem sum_relativeDegree_mul_ramificationIdx_le_finrank {ι : Type*} [
       rwa [map_sub, sub_eq_zero] at hzero
     simpa only [hwres] using hz i
   -- The candidate independent family: `e(Q i ∣ P) · f(Q i ∣ P)` functions for each `i`.
-  set V : (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) → F' :=
-    fun p ↦ w p.1 p.2.1 * τ p.1 ^ (p.2.2 : ℕ) with hV
-  have hind : LinearIndependent F V := by
-    rw [Fintype.linearIndependent_iff]
-    intro g hg
-    by_contra hex
-    obtain ⟨p₁, hp₁⟩ := not_forall.mp hex
-    -- Pick a coefficient of least order at `P` among the nonzero ones and divide by it.
-    set S : Finset (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) :=
-      {p | g p ≠ 0} with hS
-    obtain ⟨p₀, hp₀S, hp₀min⟩ :=
-      S.exists_min_image (fun p ↦ P.ord (g p)) ⟨p₁, by simp [hS, hp₁]⟩
-    obtain ⟨i₀, j₀, l₀⟩ := p₀
-    have hg₀ : g ⟨i₀, j₀, l₀⟩ ≠ 0 := by simpa [hS] using hp₀S
-    have hbmem : ∀ p, g p / g ⟨i₀, j₀, l₀⟩ ∈ ((Q i₀).restrict k F).integers := by
-      intro p
-      rw [hQP i₀, P.mem_integers_iff_ord_nonneg]
-      rcases eq_or_ne (g p) 0 with h | h
-      · simp [h]
-      · rw [P.ord_div h hg₀]
-        have := hp₀min p (by simp [hS, h])
-        omega
-    set b : (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) →
-      ((Q i₀).restrict k F).integers := fun p ↦ ⟨g p / g ⟨i₀, j₀, l₀⟩, hbmem p⟩ with hb
-    have hbcoe : ∀ p, ((b p : F)) = g p / g ⟨i₀, j₀, l₀⟩ := fun _ ↦ rfl
-    have hb₀ : b ⟨i₀, j₀, l₀⟩ = 1 := Subtype.ext (by simp [hbcoe, div_self hg₀])
-    -- The relation splits into one block per place of the family, and the blocks sum to zero.
-    set Z : ι → F' := fun i ↦
-      ∑ q : Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i)),
-        algebraMap F F' ((b ⟨i, q⟩ : F)) * V ⟨i, q⟩ with hZ
-    have hZsum : ∑ i, Z i = 0 := by
-      have hgsum : ∑ p, algebraMap F F' ((b p : F)) * V p = 0 := by
-        have hterm : ∑ p, algebraMap F F' ((b p : F)) * V p =
-            (algebraMap F F' (g ⟨i₀, j₀, l₀⟩))⁻¹ * ∑ p, g p • V p := by
-          rw [Finset.mul_sum]
-          refine Finset.sum_congr rfl fun p _ ↦ ?_
-          rw [hbcoe, div_eq_inv_mul, map_mul, map_inv₀, Algebra.smul_def]
-          ring
-        rw [hterm, hg, mul_zero]
-      calc ∑ i, Z i = ∑ p, algebraMap F F' ((b p : F)) * V p := by
-            simp only [hZ]
-            rw [Finset.sum_sigma', Finset.univ_sigma_univ]
-        _ = 0 := hgsum
-    -- The block at `i₀` is nonzero of order less than the ramification index there; the type
-    -- ascription is what identifies `Z i₀` with the sum the block lemma speaks about.
-    obtain ⟨hZne, hZord⟩ : Z i₀ ≠ 0 ∧ (Q i₀).ord (Z i₀) ≤ ((l₀ : ℕ) : ℤ) :=
-      sum_block_ne_zero_and_ord_le k F (Q i₀)
-        (fun j ↦ (⟨w i₀ j, hwmem i₀ j⟩ : (Q i₀).integers)) (hindres i₀)
-        (fun q ↦ b ⟨i₀, q⟩) (j₀ := j₀) (l₀ := l₀) (hb₀ ▸ isUnit_one) (hτone i₀)
-    -- Every other block has order at least `[F' : F]` at `Q i₀`.
-    have hZm : ∀ m, m ≠ i₀ → (Q i₀).valuation (Z m) ≤ WithZero.exp (-(N : ℤ)) := by
-      intro m hm
-      simp only [hZ]
-      refine Valuation.map_sum_le _ fun q _ ↦ ?_
-      have hb1 : (Q i₀).valuation (algebraMap F F' ((b ⟨m, q⟩ : F))) ≤ 1 := by
-        refine (Q i₀).mem_integers_iff.mp ((Q i₀).mem_integers_iff_ord_nonneg.mpr ?_)
-        rw [ord_algebraMap_restrict k F (Q i₀) ((b ⟨m, q⟩ : F))]
-        exact mul_nonneg (by positivity)
-          (((Q i₀).restrict k F).mem_integers_iff_ord_nonneg.mp (b ⟨m, q⟩).2)
-      have hwval : (Q i₀).valuation (w m q.1) = WithZero.exp (-(N : ℤ)) := by
-        have hne : w m q.1 ≠ 0 := by
-          intro h
-          have hh := hwN m q.1 i₀ (Ne.symm hm)
-          rw [h, ord_zero] at hh
-          omega
-        rw [(Q i₀).valuation_eq_exp_neg_ord hne, hwN m q.1 i₀ (Ne.symm hm)]
-      have hτval : (Q i₀).valuation (τ m ^ (q.2 : ℕ)) = 1 := by
-        rw [map_pow, (Q i₀).valuation_eq_exp_neg_ord (hτ0 m), hτ m i₀]
-        simp [Ne.symm hm]
-      simp only [hV]
-      rw [map_mul, map_mul, hwval, hτval, mul_one]
-      exact mul_le_of_le_one_left' hb1
-    -- The strict triangle inequality contradicts `∑ i, Z i = 0`.
-    have hlt : ∀ m ∈ (Finset.univ : Finset ι) \ {i₀},
-        (Q i₀).valuation (Z m) < (Q i₀).valuation (Z i₀) := by
-      intro m hmem
-      simp only [Finset.mem_sdiff, Finset.mem_singleton] at hmem
-      refine lt_of_le_of_lt (hZm m hmem.2) ?_
-      rw [(Q i₀).valuation_eq_exp_neg_ord hZne, WithZero.exp_lt_exp]
-      have hl₀ : (l₀ : ℕ) < ramificationIdx F (Q i₀) := l₀.2
-      have hle : ramificationIdx F (Q i₀) ≤ Module.finrank F F' :=
-        ramificationIdx_le_finrank F (Q i₀)
-      omega
-    have hval := (Q i₀).valuation.map_sum_eq_of_lt (Finset.mem_univ i₀) hlt
-    rw [hZsum, map_zero] at hval
-    exact ((Valuation.ne_zero_iff _).mpr hZne) hval.symm
+  have hind :=
+    linearIndependent_mul_pow_of_forall_linearIndependent_residue k F hQP hτ hwmem hwN hindres
   simpa [Fintype.card_sigma, Fintype.card_prod] using hind.fintype_card_le_finrank
 
 /-- **The fundamental inequality** (Stichtenoth, Theorem 3.1.11): the ramification indices and


### PR DESCRIPTION
`sum_relativeDegree_mul_ramificationIdx_le_finrank` — the linear-independence half of
Stichtenoth's fundamental inequality — was a **131-line** proof of which **84 lines were a single
anonymous `have hind`**, with exactly one line after it. This gives that block a name.

## What moved

The theorem does two things: exhibit an `F`-linearly independent family of size
`∑ e(Q i ∣ P) · f(Q i ∣ P)`, and count it. Only the counting was visible as a step — the exhibiting
was an anonymous `have`, and the line after it is the whole of the counting:

```lean
  simpa [Fintype.card_sigma, Fintype.card_prod] using hind.fintype_card_le_finrank
```

The block is now a named private theorem stated above its consumer:

```lean
private theorem linearIndependent_mul_pow_of_forall_linearIndependent_residue {ι : Type*}
    [Finite ι] {Q : ι → Place k' F'} {P : Place k F}
    (hQP : ∀ i, (Q i).restrict k F = P)
    {τ : ι → F'} (hτone : ∀ i, (Q i).ord (τ i) = 1)
    (hτint : ∀ i m, m ≠ i → 0 ≤ (Q m).ord (τ i))
    {w : ∀ i, Fin (relativeDegree k F (Q i)) → F'} (hwmem : ∀ i j, w i j ∈ (Q i).integers)
    (hwN : ∀ (i : ι) (j : Fin (relativeDegree k F (Q i))) (m : ι), m ≠ i →
      (ramificationIdx F (Q m) : ℤ) ≤ (Q m).ord (w i j))
    (hindres : ∀ i, LinearIndependent ((Q i).restrict k F).ResidueField
      fun j ↦ IsLocalRing.residue (Q i).integers (⟨w i j, hwmem i j⟩ : (Q i).integers)) :
    LinearIndependent F
      (fun p : Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i)) ↦
        w p.1 p.2.1 * τ p.1 ^ (p.2.2 : ℕ))
```

Measured as source lines of the proof body — the lines after `:= by`:

| | before | after |
|---|---|---|
| `sum_relativeDegree_mul_ramificationIdx_le_finrank` | 131 | **45** |
| `linearIndependent_mul_pow_of_forall_linearIndependent_residue` | — | 92 |

Comment-stripped code lines: 120 → 40, and 86. The file grows 23 lines (328 → 351).

## 79 of the 83 moved lines are byte-identical

Verified mechanically rather than by eye: after the helper's preamble, **79 of the original block's
83 lines are byte-identical after a two-space dedent**, and the other four are the `generality` fix
of round 2 — three adjacent hunks inside `hZm`, listed in full at the bottom of this description.
Outside those, no tactic was rewritten, reordered or re-golfed, and every inline comment is carried
over in place. The preamble is

```lean
  classical
  have _ : Fintype ι := Fintype.ofFinite ι
  set V : (Σ i : ι, Fin (relativeDegree k F (Q i)) × Fin (ramificationIdx F (Q i))) → F' :=
    fun p ↦ w p.1 p.2.1 * τ p.1 ^ (p.2.2 : ℕ) with hV
```

and every line of it is a fact the block consumes, re-derived here rather than inherited:

* **The statement is over the explicit family, not over a `set`-bound name.** The original block
  proved `LinearIndependent F V` for a `set V … with hV`. Carrying `V` into the interface would make
  the helper depend on that binding's definitional transparency; stating it over the lambda and
  re-introducing `set V … with hV` inside keeps the body unchanged — including the `simp only [hV]`
  near the end of the block, which still fires.
* **`hτone` is now taken, and `hτ0`/`hN1` are gone.** Round 3's `generality` fix replaced the
  packed `hτ` by the two facts the body actually consumes, so `hτone` is a hypothesis rather than a
  one-line derivation; `hτ0` and `hN1` were each used only by steps that round deleted.

## The hypotheses were derived from the block's body

At the extraction point the parent also has `hQ`, `z`, `hz`, `hw`, `hNdef` and `hN1` in scope. **The
block uses none of them**, so none is a parameter: it needs exactly `hQP`, `hτ`, `w`, `hwmem`,
`hwN`, `hindres`. I established that by counting each name's occurrences inside the block rather
than by reading the enclosing signature.

The two instance binders are the two the *statement* needs, and no more:

* `[DecidableEq ι]` **is gone as of round 3.** It was required only by the `if m = i` in the old
  packed `hτ`; splitting that hypothesis into `hτone` and `hτint` removes the only decidable
  equality in the statement, so the instance went with it. `generality` identified this
  dependency explicitly, and it is the reason the two changes are one change.
* `[Finite ι]`, **not** `[Fintype ι]`. `Fintype` was what the parent had and what I first wrote;
  `linter.unusedFintypeInType` rejected it — the conclusion is a `LinearIndependent`, which does not
  mention finiteness — and the proof gets its `Fintype` from `Fintype.ofFinite ι` after `classical`.
  That is both the linter's own suggested fix and the idiom already used by the single-place sibling
  in `Place/Extension/Basic.lean`.

## Three facts the consumer no longer derives are deleted from it

`hN1 : 1 ≤ N`, `hτone` and `hτ0` were each used *only* inside the extracted block, so all three are
removed from `sum_relativeDegree_mul_ramificationIdx_le_finrank` rather than left as dead `have`s
beside the new call. `set N` stays in the parent: `N` is still used to state `happrox`, and after
round 3 its `with hNdef` is used too, to discharge the new `ramificationIdx ≤ finrank` step at the
call site.

## Why this name, next to a lemma whose name is one word shorter

`Place/Extension/Basic.lean` already has `linearIndependent_mul_pow_of_linearIndependent_residue`:
the **single-place** statement, that `s i * t ^ j` are independent for one place `P'` and one prime
element `t`. This one is the **fibre** statement — independence of `w i j * τ i ^ l` across *all*
places `Q i` above `P` simultaneously, which is a strictly stronger fact proved by the strict
triangle inequality between the blocks. Hence `_of_forall_linearIndependent_residue`: the hypothesis
is `∀ i, LinearIndependent …`. The extracted proof consumes the single-place machinery through
`sum_block_ne_zero_and_ord_le`; it does not duplicate it.

## The helper is 81 lines, and where the second cut was

Splitting a 131-line proof put the consumer under the 50-line threshold and left the extracted
argument above it. Within *this* file there is still no second cut worth making: the block's own
sub-blocks are 10, 18, 16, 5, 22 and 12 lines, so the largest candidate is 22 — and each of them
closes over `b`, `Z`, `V`, `i₀`, `j₀` and `l₀`, so lifting one would need a helper whose signature is
longer than the body it removes.

The cut that *is* worth making crosses a file boundary. Round 4 makes it — see below.

**Correction (round 3), acted on in round 4.** An earlier version of this description said flatly
that I had looked for a second cut and there was none. `proof-quality` was right that this is wrong,
and the counter-example is across a file boundary rather than inside this one: the helper's first
sub-block — take the coefficient of least order at `P`, divide through by it, and land the quotients
in `𝒪_P` — is near-verbatim the opening of `exists_ord_sum_eq_mul` in
`Place/Extension/Basic.lean`. Round 3 deferred that to a follow-up PR and offered to fold it in if a
reviewer preferred; round 4 re-raised it as the only blocking finding, so **it is folded in here**.

## Notes for review

- Gates, each run as its own step with its exit code read. Round 4 re-ran them over all **three**
  changed modules: `lake build` → exit 0, `Build completed successfully (2549 jobs)`;
  `lake exe runLinter` on each of `Place.Basic`, `Place.Extension.Basic` and `Place.Extension.Fibre`
  → exit 0, `Linting passed` for each. `scripts/lint-env.sh` needs a full library build, so
  `unusedArguments` and cross-library `simpNF` are CI-only here.
- Line length: measured per line in **codepoints**, not bytes — this file is Unicode-dense. Maximum
  is 89; no line reaches 100.
- Contention, re-measured for round 4 over **all 129 open PRs** (every file list fetched):
  `Place/Basic.lean` and `Place/Extension/Basic.lean` are touched by **no** open PR, and
  `Place/Extension/Fibre.lean` by none but this one. No open PR renames any of the three.
- Cleanup: file-level audit clean (copyright, module docstring, no `set_option`, no `λ`, no `$`, no
  `push_neg`, no `haveI`/`letI`, no `erw`), plus a per-declaration pass on the two declarations this
  diff touches. The signature's binder lines were repacked to match the two neighbouring
  declarations in this file, which put the type binders on the declaration line.

## Round 2 — the `generality` finding, applied

`generality` asked for `hwN` to take a **lower bound** on the off-place order rather than an exact
value, since the argument never uses the upper half. Applied as asked. The hypothesis is now

```lean
    (hwN : … m ≠ i → (Module.finrank F F' : ℤ) ≤ (Q m).ord (w i j))
```

**The block really does use only the bound.** `hwN` has exactly two uses, both inside `hZm`:

* proving `w m q.1 ≠ 0` — under `w m q.1 = 0` the hypothesis reads `N ≤ 0`, which `omega` refutes
  from the ambient `hN1 : 1 ≤ N` exactly as the equation did;
* bounding the valuation — `hwval` weakens from `= WithZero.exp (-N)` to `≤`, obtained by
  `WithZero.exp_le_exp.2 (neg_le_neg …)`, and the final step chains through it with
  `(mul_le_of_le_one_left' hb1).trans hwval` instead of rewriting.

**The caller is unaffected.** `hwN` there still comes from `choose … using happrox` as an equation,
and `(hwN i j m hm).ge` supplies the weaker form at the one call site.

The three hunks, which are the whole of the change inside the moved block:

```diff
-    have hwval : (Q i₀).valuation (w m q.1) = WithZero.exp (-(N : ℤ)) := by
+    have hwval : (Q i₀).valuation (w m q.1) ≤ WithZero.exp (-(N : ℤ)) := by
-      rw [(Q i₀).valuation_eq_exp_neg_ord hne, hwN m q.1 i₀ (Ne.symm hm)]
+      rw [(Q i₀).valuation_eq_exp_neg_ord hne]
+      exact WithZero.exp_le_exp.2 (neg_le_neg (hwN m q.1 i₀ (Ne.symm hm)))
-    rw [map_mul, map_mul, hwval, hτval, mul_one]
-    exact mul_le_of_le_one_left' hb1
+    rw [map_mul, map_mul, hτval, mul_one]
+    exact (mul_le_of_le_one_left' hb1).trans hwval
```

**Net size cost: +2 lines** (the helper 91 → 92, its consumer 44 → 45; the consumer stays under 50).
The docstring's "residues that are as small as `[F' : F]`" becomes "of order at least `[F' : F]`",
which is what the hypothesis now says.

## Round 3 — `correctness`, `generality`, `naming`, `documentation`, `proof-quality`

Five rubrics, three root causes. Grouped by the source line they point at rather than by rubric.

**1. The docstring (fixes `correctness`, `naming`, `documentation`).** Three rubrics quoted the same
two sentences. It said the residue family was *`F`*-linearly independent, where `hindres` states
independence over `((Q i).restrict k F).ResidueField` — the residue field of `P`, not `F`; and it
described the conclusion as the per-place statement, which is exactly the single-place sibling in
`Extension/Basic.lean` and so failed to say what this declaration is *for*. It now names the
residue field correctly, says the independence is **joint over all of `i`**, and points at the
sibling by name so the two are told apart on sight. The bound it quotes is also the new one.

**2. Two hypotheses weakened, and an instance dropped (fixes `generality`).**

| | before | after |
|---|---|---|
| off-place `τ` | `(Q m).ord (τ i) = if m = i then 1 else 0` | `hτone : (Q i).ord (τ i) = 1` **+** `hτint : m ≠ i → 0 ≤ (Q m).ord (τ i)` |
| off-place `w` | `(Module.finrank F F' : ℤ) ≤ (Q m).ord (w i j)` | `(ramificationIdx F (Q m) : ℤ) ≤ (Q m).ord (w i j)` |
| instances | `[Finite ι] [DecidableEq ι]` | `[Finite ι]` |

Both were flagged as carrying more than the body consumes, and both check out:

* `hτ`'s off-diagonal half was used once, in `hτval`, to rewrite the valuation of `τ m ^ l` to
  exactly `1`. The step only needs `≤ 1`, i.e. integrality, so `hτval` is now
  `pow_le_one' (mem_integers_iff.mp …)` and the final bound chains
  `(mul_le_of_le_one_left' hb1).trans ((mul_le_of_le_one_right' hτval).trans hwval)`.
  Dropping the `if` is what removes `[DecidableEq ι]`.
* `hwN` was used twice, both inside `hZm`, and neither use needs `finrank`: the non-vanishing of
  `w m q.1` needs only a positive bound (`ramificationIdx_pos`), and the valuation bound feeds
  `hlt`, which compares against `l₀ < ramificationIdx F (Q i₀)`. With the smaller bound the helper
  no longer mentions `Module.finrank` at all, and `ramificationIdx_le_finrank` moved out of the
  helper to the one call site.

The caller supplies the weaker forms from what it already had, so nothing upstream changed shape.

**3. Proof hygiene (fixes `proof-quality`).** Two dead `set … with` names removed — `with hb` in the
helper, and the parent's `with hNdef` is now genuinely used by the `ramificationIdx ≤ finrank` step
rather than deleted. The block-lemma application no longer typechecks by definitional unfolding of a
`set` binding: the type ascription is replaced by an explicit
`simpa only [hZ, hV] using hblock`, which names the two bindings being unfolded. The third part of
that finding — the cross-file duplication with `exists_ord_sum_eq_mul` — is answered under
*The helper is 92 lines* above.

Audited after the change: every `set … with` binder in the file now has at least one use, and every
hypothesis of the helper is consumed. Module build exit 0 (`2549 jobs`); line length re-measured in
codepoints, maximum unchanged at 89.

## Round 4 — `proof-quality`: the cross-file duplication, folded in

The only non-green rubric asked for the coefficient-normalization argument shared with
`exists_ord_sum_eq_mul` to be factored out. Done. Both proofs opened with the same step — pick a
coefficient of least order at `P` among the nonzero ones, divide the family through by it, observe
the quotients land in `𝒪_P` — written out in full in each place.

It is now named once:

```lean
/-- **Normalizing a family of coefficients.** A finite family in `F` that does not vanish
identically has a nonzero member by which the whole family can be divided without leaving `𝒪_P`;
a member of least order at `P` is one. … -/
theorem exists_ne_zero_forall_div_mem_integers {ι : Type*} [Finite ι] (c : ι → F) {i₁ : ι}
    (hi₁ : c i₁ ≠ 0) : ∃ i₀, c i₀ ≠ 0 ∧ ∀ i, c i / c i₀ ∈ P.integers
```

and both proofs call it — `exists_ord_sum_eq_mul` as one line, this PR's helper as three (the extra
two transport the membership along `hQP i₀ : (Q i₀).restrict k F = P`).

**It is public, and in `Place/Basic.lean`, and both of those are forced.** The follow-up bead I
filed in round 3 proposed a `private` lemma in `Extension/Basic.lean`; preparing it showed that plan
was wrong twice over, so this is not what that bead described:

* `private` is module-scoped, so `Extension/Fibre.lean` could not see it. A lemma with call sites in
  two modules cannot be private. (It also means the `reuse` rubric's one-call-site objection does
  not apply: there are two consumers, in two files.)
* Its statement mentions only `P : Place k F` — no `F'`, no `P'`, nothing from either Extension
  file — and the two lemmas its proof uses, `ord_div` and `mem_integers_iff_ord_nonneg`, are both in
  `Place/Basic.lean`. So it belongs there, beside the other finite-family order lemmas, immediately
  after `ord_sum_eq_of_forall_lt`. Putting it in `Extension/Basic.lean` would have made it public
  API about a single place sitting in a file about extensions.

`[Finite ι]`, not `[Fintype ι]`: the proof needs only `Set.exists_min_image … (Set.toFinite _)`.
Both call sites happen to carry `Fintype`, so the weaker binder is free. **No import is added** —
`Place/Basic.lean` is already a transitive import of both files.

Measured, by one counter applied to both endpoints:

| | before round 4 | after |
|---|---|---|
| `linearIndependent_mul_pow_of_forall_linearIndependent_residue` | 91 | **81** |
| `exists_ord_sum_eq_mul` | 31 | **20** |
| `exists_ne_zero_forall_div_mem_integers` | — | 8 |

Two things fell out of the extraction and are included:

* the `Finset` comprehension is gone from `exists_ord_sum_eq_mul`, so its `classical` is no longer
  needed and is removed. I tested this **greedily** — removing the `classical` from both proofs at
  once — and the build failed inside `Fibre.lean` with a `Finset` term elaborated to `sorry`; a
  bisect confirms that one is load-bearing, so it stays. Only the redundant one is dropped.
* `set P := P'.restrict k F with hP` loses its `with hP`: `hP` had **zero** uses. That is the same
  dead-binder defect `proof-quality` flagged in round 3, in the proof this round rewrites.

**On `scope`.** This adds two files to a diff that `scope` approved as a single-file refactor, so it
is worth saying why it is still one topic: every line of it is the fix `proof-quality` asked for, in
the two declarations it named. If `scope` now reads the three-file diff as two topics, that is a
direct conflict with this round's blocking `proof-quality` finding rather than an independent
objection, and I will raise it as such rather than reverting one to satisfy the other.

Roadmap: AlgebraicCurves
