### PR TITLE
refactor(GL2): name the simple-reflection generation axiom of the GL2 Tits system

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Diagonal/TitsSystem.lean
@@ -187,6 +187,54 @@ private theorem gl2_tits_exists_conj_not_mem
   simp [gl2WeylNormalizer, Units.val_mul, GL2Borel.coe_mk, Matrix.mul_apply,
     Fin.sum_univ_two]
 
+/-- The intersection `B ∩ N` is normal in `N`: under `gl2_borel_comap_normalizer_eq_diagonal` it
+is the diagonal torus, which is normal in its own normalizer. Stated as an instance because the
+Weyl quotient `N ⧸ (B ∩ N)` is only a group once it is available. -/
+private instance :
+    ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype).Normal := by
+  rw [gl2_borel_comap_normalizer_eq_diagonal]
+  exact Subgroup.normal_in_normalizer
+
+/-- The class of the Weyl permutation matrix generates the Weyl quotient `N ⧸ (B ∩ N)` of `GL₂`. -/
+private theorem gl2_closure_simple : Subgroup.closure ({QuotientGroup.mk (gl2WeylNormalizer k)} :
+    Set (GL2DiagonalNormalizer k ⧸ (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype)) = ⊤ := by
+  apply top_unique
+  intro s _
+  obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective
+    ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype) s
+  have hg : g ∈ Subgroup.closure
+      (((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype :
+          Set (GL2DiagonalNormalizer k)) ∪ {gl2WeylNormalizer k}) := by
+    rw [gl2_normalizer_closure]
+    exact Subgroup.mem_top g
+  have hmap : QuotientGroup.mk'
+        ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype) g ∈
+      (Subgroup.closure
+        (((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype :
+            Set (GL2DiagonalNormalizer k)) ∪ {gl2WeylNormalizer k})).map
+          (QuotientGroup.mk'
+            ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype)) :=
+    ⟨g, hg, rfl⟩
+  rw [MonoidHom.map_closure] at hmap
+  exact ((Subgroup.closure_le
+    (Subgroup.closure
+      ({QuotientGroup.mk (gl2WeylNormalizer k)} :
+        Set (GL2DiagonalNormalizer k ⧸
+          (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype)))).mpr (fun x hx ↦ by
+    obtain ⟨y, hy, rfl⟩ := hx
+    rcases hy with hy | hy
+    · have hqy : QuotientGroup.mk'
+          ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype) y = 1 :=
+        (QuotientGroup.eq_one_iff y).mpr hy
+      rw [hqy]
+      exact (Subgroup.closure
+        ({QuotientGroup.mk (gl2WeylNormalizer k)} :
+          Set (GL2DiagonalNormalizer k ⧸
+            (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype))).one_mem
+    · rw [Set.mem_singleton_iff] at hy
+      subst y
+      exact Subgroup.subset_closure (Set.mem_singleton _))) hmap
+
 /-- The standard rank-one Tits system of `GL₂(k)`: `B` is the upper-triangular subgroup,
 `N` is the diagonal-torus normalizer, and its unique simple reflection is represented by the
 Weyl permutation matrix. -/
@@ -195,49 +243,10 @@ def gl2TitsSystem : TitsSystem (GL (Fin 2) k) where
   subgroupN := GL2DiagonalNormalizer k
   closure_subgroupB_union_subgroupN := gl2_borel_normalizer_closure k
   intersection_normal := by
-    rw [← Subgroup.comap_subtype, gl2_borel_comap_normalizer_eq_diagonal]
-    exact Subgroup.normal_in_normalizer
+    rw [← Subgroup.comap_subtype]
+    infer_instance
   simple := {QuotientGroup.mk (gl2WeylNormalizer k)}
-  closure_simple := by
-    let _ : ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype).Normal := by
-      rw [gl2_borel_comap_normalizer_eq_diagonal]
-      exact Subgroup.normal_in_normalizer
-    apply top_unique
-    intro s _
-    obtain ⟨g, rfl⟩ := QuotientGroup.mk'_surjective
-      ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype) s
-    have hg : g ∈ Subgroup.closure
-        (((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype :
-            Set (GL2DiagonalNormalizer k)) ∪ {gl2WeylNormalizer k}) := by
-      rw [gl2_normalizer_closure]
-      exact Subgroup.mem_top g
-    have hmap : QuotientGroup.mk'
-          ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype) g ∈
-        (Subgroup.closure
-          (((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype :
-              Set (GL2DiagonalNormalizer k)) ∪ {gl2WeylNormalizer k})).map
-            (QuotientGroup.mk'
-              ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype)) :=
-      ⟨g, hg, rfl⟩
-    rw [MonoidHom.map_closure] at hmap
-    exact ((Subgroup.closure_le
-      (Subgroup.closure
-        ({QuotientGroup.mk (gl2WeylNormalizer k)} :
-          Set (GL2DiagonalNormalizer k ⧸
-            (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype)))).mpr (fun x hx ↦ by
-      obtain ⟨y, hy, rfl⟩ := hx
-      rcases hy with hy | hy
-      · have hqy : QuotientGroup.mk'
-            ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype) y = 1 :=
-          (QuotientGroup.eq_one_iff y).mpr hy
-        rw [hqy]
-        exact (Subgroup.closure
-          ({QuotientGroup.mk (gl2WeylNormalizer k)} :
-            Set (GL2DiagonalNormalizer k ⧸
-              (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype))).one_mem
-      · rw [Set.mem_singleton_iff] at hy
-        subst y
-        exact Subgroup.subset_closure (Set.mem_singleton _))) hmap
+  closure_simple := gl2_closure_simple k
   exists_simpleRep_sq_mem s hs := by
     rw [Set.mem_singleton_iff] at hs
     refine ⟨gl2WeylNormalizer k, hs.symm, ?_⟩


### PR DESCRIPTION
`gl2TitsSystem` builds the standard rank-one Tits system of `GL₂(k)` from six structure fields.
Four of them already delegate to named private lemmas in this file — `gl2_borel_normalizer_closure`,
`gl2_normalizer_closure`, `gl2_doubleCoset_weyl_mul_union_eq_univ`, `gl2_tits_exists_conj_not_mem`.
`closure_simple` was the outlier: **40 lines inlined into the field**, which is why the `def` body
ran to 64 lines. This makes it the fifth named lemma.

## What moved

The simple-reflection generation axiom is now stated on its own, in the file's existing style:

```lean
/-- The class of the Weyl permutation matrix generates the Weyl quotient `N ⧸ (B ∩ N)` of `GL₂`. -/
private theorem gl2_closure_simple : Subgroup.closure ({QuotientGroup.mk (gl2WeylNormalizer k)} :
    Set (GL2DiagonalNormalizer k ⧸ (GL2Borel k).comap (GL2DiagonalNormalizer k).subtype)) = ⊤
```

and the field is `closure_simple := gl2_closure_simple k`.

| | before | after |
|---|---|---|
| `gl2TitsSystem` body | 64 | **25** |
| `gl2_closure_simple` body | — | 36 |

**Both sides clear the 50-line threshold**, and the file grows 9 lines (308 → 317).

## The 36 moved lines are byte-identical

Verified mechanically: the extracted proof is byte-identical to the field's argument after a
two-space dedent, and nothing follows it. No tactic was rewritten, reordered or re-golfed.

## The `Normal` instance was proved twice, and is now proved once

`closure_simple` opened by re-establishing an instance the `def` had already produced one field
earlier:

```lean
  intersection_normal := by
    rw [← Subgroup.comap_subtype, gl2_borel_comap_normalizer_eq_diagonal]
    exact Subgroup.normal_in_normalizer
  simple := …
  closure_simple := by
    let _ : ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype).Normal := by
      rw [gl2_borel_comap_normalizer_eq_diagonal]          -- ← the same two lines again
      exact Subgroup.normal_in_normalizer
```

That duplication is not incidental to the extraction — it is what forces it. The Weyl quotient
`N ⧸ (B ∩ N)` carries a group structure only once that `Normal` instance is available, so a
free-standing `gl2_closure_simple` cannot even be *stated* without it. Naming the fact once, as an
anonymous private instance, both removes the duplicate and makes the statement elaborate:

```lean
private instance :
    ((GL2Borel k).comap (GL2DiagonalNormalizer k).subtype).Normal := by
  rw [gl2_borel_comap_normalizer_eq_diagonal]
  exact Subgroup.normal_in_normalizer
```

`intersection_normal` then reduces to `rw [← Subgroup.comap_subtype]; infer_instance`. The instance
is anonymous because nothing refers to it by name.

## Notes for review

- **The five private lemmas are one-call-site by design, and that is this file's existing shape.**
  `gl2_borel_normalizer_closure`, `gl2_normalizer_closure`,
  `gl2_doubleCoset_weyl_mul_union_eq_univ` and `gl2_tits_exists_conj_not_mem` are each used exactly
  once, by the field they discharge. `gl2_closure_simple` joins them rather than introducing a new
  convention; the alternative — leaving one field's proof inline at 40 lines while its four
  siblings are named — is the inconsistency this PR removes.
- Gates, each run as its own step with its exit code read: `lake build` of the changed module →
  exit 0, `Build completed successfully (2546 jobs)`; `lake exe runLinter` on the module → exit 0,
  `Linting passed`. The module has **no importers in the repository** (control: the module it
  imports, `GroupTheory.TitsSystem.Basic`, has 2), so the module-scoped gate is the whole
  downstream surface. `scripts/lint-env.sh` needs a full library build, so `unusedArguments` and
  cross-library `simpNF` remain CI-only here.
- The data fields `subgroupB`, `subgroupN` and `simple` are untouched, so the `@[simp]` lemmas
  below the `def` that unfold it (`gl2TitsSystem_subgroupB`, `gl2TitsSystem_subgroupN`,
  `gl2TitsSystem_simple`) are unaffected; only `Prop`-valued fields changed.
- Line length: measured per line in codepoints, not bytes. Maximum in the file is 99; none reaches
  100.
- Contention: the file is untouched by **all 129 open PRs** (their file lists fetched, with
  controls), and the only off-`main` commits touching it belong to `prheads/5005`, which **merged
  2026-08-28T20:15:16Z**.
- Cleanup: file-level audit clean (copyright, module docstring, no `set_option`, no `λ`, no `$`, no
  `push_neg`, no `haveI`/`letI`, no `erw`, no `≥`/`>` in the new Lean code), plus a
  per-declaration pass on the three declarations this diff touches.

Roadmap: ReductiveGroups
