### PR TITLE
feat: generalize maximal radical comparison

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Maximal.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.SmoothContainment
+import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
+import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
+
+/-!
+# Maximal-dimensional families of normal closed subgroups
+
+Let `H` be the coordinate Hopf algebra of a finite-type affine group over a field, and let
+`P` be a family of normal closed subgroups that are smooth and geometrically connected. Suppose
+that `P` is closed under scheme-theoretic multiplication images. Then any member of `P` of
+maximal Lie dimension contains every other member.
+
+Indeed, multiplying a maximal-dimensional member `I` by another member `J` gives a member that
+contains `I`. Dimension maximality and monotonicity force the two tangent spaces to have the same
+dimension. The resulting closed immersion is an equality because both groups are smooth and
+connected. Since the product also contains `J`, the subgroup represented by `I` contains `J`.
+
+This argument is independent of the additional property defining the family. It is used for the
+unipotent radical and is also the dimension-comparison step in the construction of the solvable
+radical.
+
+## Main declaration
+
+* `TauCeti.HopfIdeal.le_of_finrank_maximal_of_product`: a maximal-dimensional member of a
+  product-closed family of smooth geometrically connected normal closed subgroups is greatest.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a, 6.a, 10.a.
+* A. Borel, *Linear Algebraic Groups*, Section 11.21.
+
+This supplies the shared maximal-dimension comparison used in Layers 5 and 6 of the
+ReductiveGroups roadmap to construct the unipotent and solvable radicals.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+noncomputable section
+
+namespace HopfIdeal
+
+variable {k : Type u} [Field k]
+variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
+
+/-- A maximal-dimensional member of a product-closed family of smooth geometrically connected
+normal closed subgroups contains every member of the family.
+
+The order on Hopf ideals reverses inclusion of represented closed subgroups, so the conclusion
+`I ≤ J` says that the subgroup cut out by `I` contains the one cut out by `J`. -/
+theorem le_of_finrank_maximal_of_product
+    (P : HopfIdeal k H → Prop)
+    (normal : ∀ {K : HopfIdeal k H}, P K → K.IsNormal)
+    (connected : ∀ {K : HopfIdeal k H}, P K →
+      geometricallyConnectedCommHopfAlgProperty k
+        (FiniteTypeCommHopfAlgCat.quotient H K).obj)
+    (smooth : ∀ {K : HopfIdeal k H}, P K →
+      Algebra.Smooth k (FiniteTypeCommHopfAlgCat.quotient H K))
+    (product : ∀ {K L : HopfIdeal k H} (hK : P K), P L →
+      P (HopfIdeal.ker
+        (CommHopfAlgCat.productMapOfNormal H.obj K L (normal hK)).hom))
+    (hI : P I)
+    (hmax : ∀ K : HopfIdeal k H, P K →
+      Module.finrank k
+          (Derivation k (H ⧸ K.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
+        Module.finrank k
+          (Derivation k (H ⧸ I.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
+    (hJ : P J) : I ≤ J := by
+  let hI_normal := normal hI
+  let K : HopfIdeal k H :=
+    HopfIdeal.ker (CommHopfAlgCat.productMapOfNormal H.obj I J hI_normal).hom
+  have hK : P K := product hI hJ
+  have hKI : K ≤ I :=
+    CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI_normal
+  have hfinrank :
+      Module.finrank k
+          (Derivation k (H ⧸ K.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) =
+        Module.finrank k
+          (Derivation k (H ⧸ I.toIdeal)
+            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) := by
+    apply le_antisymm
+    · exact hmax K hK
+    · exact finrank_quotientLie_antitone hKI
+  let q := FiniteTypeCommHopfAlgCat.toBialgHom
+    (FiniteTypeCommHopfAlgCat.quotientMapOfLe H hKI)
+  have hq_surjective : Function.Surjective q :=
+    FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hKI
+  have hq_bijective : Function.Bijective (derivationCompLieHom (B := k) q) :=
+    derivationCompLieHom_bijective_of_surjective_of_finrank_eq q hq_surjective hfinrank.symm
+  have hconormal : conormalSubspace (HopfIdeal.ker q) = ⊥ :=
+    conormalSubspace_ker_eq_bot_of_surjective_of_derivationCompLieHom_surjective
+      q hq_surjective hq_bijective.2
+  have hK_smooth : smoothCommHopfAlgProperty k
+      (_root_.CommHopfAlgCat.of k (H ⧸ K.toIdeal)) :=
+    (smoothCommHopfAlgProperty_iff _).mpr (smooth hK)
+  have hI_smooth : smoothCommHopfAlgProperty k
+      (_root_.CommHopfAlgCat.of k (H ⧸ I.toIdeal)) :=
+    (smoothCommHopfAlgProperty_iff _).mpr (smooth hI)
+  have hK_connected : ConnectedSpace (PrimeSpectrum (H ⧸ K.toIdeal)) :=
+    geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ (connected hK)
+  have hI_connected : ConnectedSpace (PrimeSpectrum (H ⧸ I.toIdeal)) :=
+    geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ (connected hI)
+  have hq_kernel : HopfIdeal.ker q = ⊥ :=
+    ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot q hq_surjective
+      hK_smooth hK_connected hI_smooth hI_connected hconormal
+  have hmap : I.map (Bialgebra.Quotient.mkBialgHom K.toIdeal) = ⊥ := by
+    rw [← CommHopfAlgCat.ker_quotientMapOfLe H.obj hKI]
+    exact hq_kernel
+  have hIK : I ≤ K := by
+    rw [← toIdeal_le_toIdeal]
+    have hle := (HopfIdeal.map_eq_bot_iff I
+      (Bialgebra.Quotient.mkBialgHom K.toIdeal)).mp hmap
+    intro x hx
+    have hxker := hle hx
+    rw [RingHom.mem_ker] at hxker
+    exact Ideal.Quotient.eq_zero_iff_mem.mp hxker
+  have hKI_eq : K = I := le_antisymm hKI hIK
+  rw [← hKI_eq]
+  exact CommHopfAlgCat.ker_productMapOfNormal_le_right H.obj I J hI_normal
+
+end HopfIdeal
+
+end
+
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Maximal.lean
@@ -15,7 +15,7 @@ import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
 # Maximal-dimensional families of normal closed subgroups
 
 Let `H` be the coordinate Hopf algebra of a finite-type affine group over a field, and let
-`P` be a family of normal closed subgroups that are smooth and geometrically connected. Suppose
+`P` be a family of normal closed subgroups that are smooth and connected. Suppose
 that `P` is closed under scheme-theoretic multiplication images. Then any member of `P` of
 maximal Lie dimension contains every other member.
 
@@ -30,8 +30,8 @@ radical.
 
 ## Main declaration
 
-* `TauCeti.HopfIdeal.le_of_finrank_maximal_of_product`: a maximal-dimensional member of a
-  product-closed family of smooth geometrically connected normal closed subgroups is greatest.
+* `TauCeti.HopfIdeal.le_of_product_of_finrank_maximal`: a maximal-dimensional member of a
+  product-closed family of smooth connected normal closed subgroups is greatest.
 
 ## References
 
@@ -55,17 +55,16 @@ namespace HopfIdeal
 variable {k : Type u} [Field k]
 variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
 
-/-- A maximal-dimensional member of a product-closed family of smooth geometrically connected
+/-- A maximal-dimensional member of a product-closed family of smooth connected
 normal closed subgroups contains every member of the family.
 
 The order on Hopf ideals reverses inclusion of represented closed subgroups, so the conclusion
 `I ≤ J` says that the subgroup cut out by `I` contains the one cut out by `J`. -/
-theorem le_of_finrank_maximal_of_product
+theorem le_of_product_of_finrank_maximal
     (P : HopfIdeal k H → Prop)
     (normal : ∀ {K : HopfIdeal k H}, P K → K.IsNormal)
     (connected : ∀ {K : HopfIdeal k H}, P K →
-      geometricallyConnectedCommHopfAlgProperty k
-        (FiniteTypeCommHopfAlgCat.quotient H K).obj)
+      ConnectedSpace (PrimeSpectrum (H ⧸ K.toIdeal)))
     (smooth : ∀ {K : HopfIdeal k H}, P K →
       Algebra.Smooth k (FiniteTypeCommHopfAlgCat.quotient H K))
     (product : ∀ {K L : HopfIdeal k H} (hK : P K), P L →
@@ -111,10 +110,8 @@ theorem le_of_finrank_maximal_of_product
   have hI_smooth : smoothCommHopfAlgProperty k
       (_root_.CommHopfAlgCat.of k (H ⧸ I.toIdeal)) :=
     (smoothCommHopfAlgProperty_iff _).mpr (smooth hI)
-  have hK_connected : ConnectedSpace (PrimeSpectrum (H ⧸ K.toIdeal)) :=
-    geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ (connected hK)
-  have hI_connected : ConnectedSpace (PrimeSpectrum (H ⧸ I.toIdeal)) :=
-    geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ (connected hI)
+  have hK_connected : ConnectedSpace (PrimeSpectrum (H ⧸ K.toIdeal)) := connected hK
+  have hI_connected : ConnectedSpace (PrimeSpectrum (H ⧸ I.toIdeal)) := connected hI
   have hq_kernel : HopfIdeal.ker q = ⊥ :=
     ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot q hq_surjective
       hK_smooth hK_connected hI_smooth hI_connected hconormal
@@ -122,13 +119,7 @@ theorem le_of_finrank_maximal_of_product
     rw [← CommHopfAlgCat.ker_quotientMapOfLe H.obj hKI]
     exact hq_kernel
   have hIK : I ≤ K := by
-    rw [← toIdeal_le_toIdeal]
-    have hle := (HopfIdeal.map_eq_bot_iff I
-      (Bialgebra.Quotient.mkBialgHom K.toIdeal)).mp hmap
-    intro x hx
-    have hxker := hle hx
-    rw [RingHom.mem_ker] at hxker
-    exact Ideal.Quotient.eq_zero_iff_mem.mp hxker
+    simpa using (HopfIdeal.map_eq_bot_iff_le_ker I _ Ideal.Quotient.mk_surjective).mp hmap
   have hKI_eq : K = I := le_antisymm hKI hIK
   rw [← hKI_eq]
   exact CommHopfAlgCat.ker_productMapOfNormal_le_right H.obj I J hI_normal

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Maximal.lean
@@ -5,19 +5,18 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Connected.CommHopfAlgCat
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.SmoothContainment
 import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
 import TauCeti.Algebra.AlgebraicGroup.Tangent.FiniteType
 
 /-!
-# Maximal-dimensional families of normal closed subgroups
+# Maximal-dimensional families of closed subgroups
 
 Let `H` be the coordinate Hopf algebra of a finite-type affine group over a field, and let
-`P` be a family of normal closed subgroups that are smooth and connected. Suppose
-that `P` is closed under scheme-theoretic multiplication images. Then any member of `P` of
-maximal Lie dimension contains every other member.
+`P` be a family of smooth connected closed subgroups. Suppose a normal member `I` of `P` has
+maximal Lie dimension and the scheme-theoretic product of `I` with each member of `P` remains in
+`P`. Then `I` contains every other member.
 
 Indeed, multiplying a maximal-dimensional member `I` by another member `J` gives a member that
 contains `I`. Dimension maximality and monotonicity force the two tangent spaces to have the same
@@ -30,8 +29,8 @@ radical.
 
 ## Main declaration
 
-* `TauCeti.HopfIdeal.le_of_product_of_finrank_maximal`: a maximal-dimensional member of a
-  product-closed family of smooth connected normal closed subgroups is greatest.
+* `TauCeti.HopfIdeal.le_of_product_of_finrank_maximal`: a normal maximal-dimensional member of a
+  family of smooth connected closed subgroups, closed under its products, is greatest.
 
 ## References
 
@@ -55,21 +54,21 @@ namespace HopfIdeal
 variable {k : Type u} [Field k]
 variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
 
-/-- A maximal-dimensional member of a product-closed family of smooth connected
-normal closed subgroups contains every member of the family.
+/-- A normal maximal-dimensional member of a family of smooth connected closed subgroups contains
+every member when its product with each family member remains in the family.
 
 The order on Hopf ideals reverses inclusion of represented closed subgroups, so the conclusion
 `I ≤ J` says that the subgroup cut out by `I` contains the one cut out by `J`. -/
 theorem le_of_product_of_finrank_maximal
     (P : HopfIdeal k H → Prop)
-    (normal : ∀ {K : HopfIdeal k H}, P K → K.IsNormal)
+    (hI_normal : I.IsNormal)
     (connected : ∀ {K : HopfIdeal k H}, P K →
       ConnectedSpace (PrimeSpectrum (H ⧸ K.toIdeal)))
     (smooth : ∀ {K : HopfIdeal k H}, P K →
       Algebra.Smooth k (FiniteTypeCommHopfAlgCat.quotient H K))
-    (product : ∀ {K L : HopfIdeal k H} (hK : P K), P L →
+    (product : ∀ {L : HopfIdeal k H}, P L →
       P (HopfIdeal.ker
-        (CommHopfAlgCat.productMapOfNormal H.obj K L (normal hK)).hom))
+        (CommHopfAlgCat.productMapOfNormal H.obj I L hI_normal).hom))
     (hI : P I)
     (hmax : ∀ K : HopfIdeal k H, P K →
       Module.finrank k
@@ -79,10 +78,9 @@ theorem le_of_product_of_finrank_maximal
           (Derivation k (H ⧸ I.toIdeal)
             (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
     (hJ : P J) : I ≤ J := by
-  let hI_normal := normal hI
   let K : HopfIdeal k H :=
     HopfIdeal.ker (CommHopfAlgCat.productMapOfNormal H.obj I J hI_normal).hom
-  have hK : P K := product hI hJ
+  have hK : P K := product hJ
   have hKI : K ≤ I :=
     CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI_normal
   have hfinrank :

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -5,10 +5,8 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Maximal
 public import TauCeti.Algebra.AlgebraicGroup.Unipotent.Radical.Product
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Normal.Product.Properties
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.SmoothContainment
-import TauCeti.Algebra.AlgebraicGroup.Tangent.Dimension
 
 /-!
 # Maximal-dimensional unipotent-radical candidates
@@ -18,35 +16,23 @@ maximal-dimension construction chooses a connected normal smooth unipotent close
 whose Lie dimension is at least that of every other such subgroup. The existing product theorem
 shows that the scheme-theoretic product `UV` is another candidate containing both `U` and `V`.
 
-This file combines those two inputs. Containment makes Lie dimension monotone, while maximality
-gives the reverse inequality, so `U` and `UV` have equal Lie dimension for every candidate `V`.
-The resulting tangent-space equality, together with smoothness and connectedness, proves `UV = U`
-and hence that `U` contains every candidate.
+The general maximal-dimension theorem for product-closed families now applies: smoothness and
+connectedness upgrade equality of tangent-space dimensions to `UV = U`. Consequently `U`
+contains every candidate.
 
-## Main declarations
+## Main declaration
 
-The declarations are in `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate`.
-
-* `finrank_quotientLie_productOfNormal_eq_of_maximal`:
-  multiplying a maximal-dimensional candidate by any candidate preserves its Lie dimension.
-* `derivationCompLieHom_productOfNormal_bijective_of_maximal`:
-  the inclusion of a maximal candidate into its product with another candidate induces a
-  bijection on tangent Lie algebras.
-* `conormalSubspace_productOfNormal_le_left_eq_bot_of_maximal`:
-  the relative defining ideal of the maximal candidate in that product has zero conormal space.
-* `productOfNormal_eq_left_of_maximal`:
-  a maximal-dimensional candidate contains every candidate, because their product equals it.
-* `le_of_finrank_maximal`:
-  a maximal-dimensional candidate is the greatest unipotent-radical candidate.
+* `TauCeti.HopfIdeal.IsUnipotentRadicalCandidate.le_of_finrank_maximal`: a
+  maximal-dimensional unipotent-radical candidate is the greatest candidate.
 
 ## References
 
-* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and §§6.45--6.46.
-* A. Borel, *Linear Algebraic Groups*, §11.21.
+* J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a, 6.a, 10.a.
+* A. Borel, *Linear Algebraic Groups*, Section 11.21.
 
-This advances Layer 5, "The unipotent radical", of the ReductiveGroups roadmap. It is the
-dimension-comparison step between binary-product closure and the zero-dimensional quotient
-argument that makes a maximal candidate the greatest candidate.
+This completes the maximal-dimension step in Layer 5, "The unipotent radical", of the
+ReductiveGroups roadmap. The shared argument also supplies the corresponding comparison step
+for the solvable radical in Layer 6.
 -/
 
 public section
@@ -62,163 +48,6 @@ namespace HopfIdeal.IsUnipotentRadicalCandidate
 variable {k : Type u} [Field k]
 variable {H : FiniteTypeCommHopfAlgCat.{u, u} k} {I J : HopfIdeal k H}
 
-/-- Multiplying a maximal-dimensional unipotent-radical candidate by any other candidate does
-not change its Lie dimension. -/
-theorem finrank_quotientLie_productOfNormal_eq_of_maximal
-    (hI : IsUnipotentRadicalCandidate H I)
-    (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
-      Module.finrank k
-          (Derivation k (H ⧸ K.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
-        Module.finrank k
-          (Derivation k (H ⧸ I.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
-    (hJ : IsUnipotentRadicalCandidate H J) :
-    Module.finrank k
-        (Derivation k
-          (H ⧸ (HopfIdeal.ker
-            (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom).toIdeal)
-          (Bialgebra.CounitAlgebra k
-            (H ⧸ (HopfIdeal.ker
-              (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom).toIdeal) k)) =
-      Module.finrank k
-        (Derivation k (H ⧸ I.toIdeal)
-          (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)) := by
-  let P : HopfIdeal k H :=
-    HopfIdeal.ker (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom
-  have hP : IsUnipotentRadicalCandidate H P := hI.productOfNormal hJ
-  apply le_antisymm
-  · exact hmax P hP
-  · exact HopfIdeal.finrank_quotientLie_antitone
-      (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)
-
-/-- The closed-subgroup inclusion from a maximal-dimensional unipotent-radical candidate into
-its product with another candidate induces a bijection on tangent Lie algebras. -/
-theorem derivationCompLieHom_productOfNormal_bijective_of_maximal
-    (hI : IsUnipotentRadicalCandidate H I)
-    (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
-      Module.finrank k
-          (Derivation k (H ⧸ K.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
-        Module.finrank k
-          (Derivation k (H ⧸ I.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
-    (hJ : IsUnipotentRadicalCandidate H J) :
-    Function.Bijective
-      (derivationCompLieHom (B := k)
-        (FiniteTypeCommHopfAlgCat.toBialgHom
-          (FiniteTypeCommHopfAlgCat.quotientMapOfLe H
-            (CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal)))) := by
-  let hPI := CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal
-  have hfinrank := hI.finrank_quotientLie_productOfNormal_eq_of_maximal hmax hJ
-  exact derivationCompLieHom_bijective_of_surjective_of_finrank_eq _
-    (FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hPI) hfinrank.symm
-
-/-- The relative defining ideal of a maximal-dimensional unipotent-radical candidate inside its
-product with any other candidate has zero conormal space at the identity.
-
-Thus the maximal candidate and the product candidate agree to first order. The remaining
-maximality step is global: smoothness and connectedness must upgrade this infinitesimal equality
-to equality of the two closed subgroups. -/
-theorem conormalSubspace_productOfNormal_le_left_eq_bot_of_maximal
-    (hI : IsUnipotentRadicalCandidate H I)
-    (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
-      Module.finrank k
-          (Derivation k (H ⧸ K.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
-        Module.finrank k
-          (Derivation k (H ⧸ I.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
-    (hJ : IsUnipotentRadicalCandidate H J) :
-    HopfIdeal.conormalSubspace
-      (I.map (Bialgebra.Quotient.mkBialgHom
-        (HopfIdeal.ker
-          (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom).toIdeal)) =
-      ⊥ := by
-  let P : HopfIdeal k H :=
-    HopfIdeal.ker (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom
-  let hPI : P ≤ I :=
-    CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal
-  let q := FiniteTypeCommHopfAlgCat.toBialgHom
-    (FiniteTypeCommHopfAlgCat.quotientMapOfLe H hPI)
-  have hq_surjective : Function.Surjective q :=
-    FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hPI
-  have hdq_surjective :
-      Function.Surjective (derivationCompLieHom (B := k) q) :=
-    (hI.derivationCompLieHom_productOfNormal_bijective_of_maximal hmax hJ).2
-  have hconormal : HopfIdeal.conormalSubspace (HopfIdeal.ker q) = ⊥ :=
-    HopfIdeal.conormalSubspace_ker_eq_bot_of_surjective_of_derivationCompLieHom_surjective
-      q hq_surjective hdq_surjective
-  have hker : HopfIdeal.ker q =
-      I.map (Bialgebra.Quotient.mkBialgHom P.toIdeal) :=
-    CommHopfAlgCat.ker_quotientMapOfLe H.obj hPI
-  simpa only [P] using hker ▸ hconormal
-
-/-- Multiplying a maximal-dimensional unipotent-radical candidate by any other candidate does
-not enlarge it.
-
-The preceding tangent-space calculation gives zero conormal space for the inclusion of the
-maximal candidate in the product. Both groups are smooth and connected, so
-`HopfIdeal.ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot` upgrades this
-first-order equality to equality of the closed subgroups. -/
-theorem productOfNormal_eq_left_of_maximal
-    (hI : IsUnipotentRadicalCandidate H I)
-    (hmax : ∀ K : HopfIdeal k H, IsUnipotentRadicalCandidate H K →
-      Module.finrank k
-          (Derivation k (H ⧸ K.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ K.toIdeal) k)) ≤
-        Module.finrank k
-          (Derivation k (H ⧸ I.toIdeal)
-            (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
-    (hJ : IsUnipotentRadicalCandidate H J) :
-    HopfIdeal.ker
-        (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom = I := by
-  let P : HopfIdeal k H :=
-    HopfIdeal.ker (CommHopfAlgCat.productMapOfNormal H.obj I J hI.isNormal).hom
-  let hPI : P ≤ I :=
-    CommHopfAlgCat.ker_productMapOfNormal_le_left H.obj I J hI.isNormal
-  let q := FiniteTypeCommHopfAlgCat.toBialgHom
-    (FiniteTypeCommHopfAlgCat.quotientMapOfLe H hPI)
-  have hP : IsUnipotentRadicalCandidate H P := hI.productOfNormal hJ
-  have hP_smooth : smoothCommHopfAlgProperty k
-      (_root_.CommHopfAlgCat.of k (H ⧸ P.toIdeal)) :=
-    (smoothCommHopfAlgProperty_iff _).mpr
-      ((smoothUnipotentCommHopfAlgProperty_iff k
-        (FiniteTypeCommHopfAlgCat.quotient H P)).mp hP.smoothUnipotent).1
-  have hI_smooth : smoothCommHopfAlgProperty k
-      (_root_.CommHopfAlgCat.of k (H ⧸ I.toIdeal)) :=
-    (smoothCommHopfAlgProperty_iff _).mpr
-      ((smoothUnipotentCommHopfAlgProperty_iff k
-        (FiniteTypeCommHopfAlgCat.quotient H I)).mp hI.smoothUnipotent).1
-  have hP_connected : ConnectedSpace (PrimeSpectrum (H ⧸ P.toIdeal)) :=
-    geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ hP.geometricallyConnected
-  have hI_connected : ConnectedSpace (PrimeSpectrum (H ⧸ I.toIdeal)) :=
-    geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ hI.geometricallyConnected
-  have hker_q : HopfIdeal.ker q =
-      I.map (Bialgebra.Quotient.mkBialgHom P.toIdeal) :=
-    CommHopfAlgCat.ker_quotientMapOfLe H.obj hPI
-  have hconormal_q : HopfIdeal.conormalSubspace (HopfIdeal.ker q) = ⊥ := by
-    rw [hker_q]
-    simpa only [P] using
-      hI.conormalSubspace_productOfNormal_le_left_eq_bot_of_maximal hmax hJ
-  have hqker : HopfIdeal.ker q = ⊥ :=
-    HopfIdeal.ker_eq_bot_of_smooth_of_connected_of_conormalSubspace_eq_bot q
-      (FiniteTypeCommHopfAlgCat.quotientMapOfLe_surjective H hPI)
-      hP_smooth hP_connected hI_smooth hI_connected
-      hconormal_q
-  have hmap : I.map (Bialgebra.Quotient.mkBialgHom P.toIdeal) = ⊥ := by
-    rw [← CommHopfAlgCat.ker_quotientMapOfLe H.obj hPI]
-    exact hqker
-  have hIP : I ≤ P := by
-    rw [← toIdeal_le_toIdeal]
-    have hle := (HopfIdeal.map_eq_bot_iff I
-      (Bialgebra.Quotient.mkBialgHom P.toIdeal)).mp hmap
-    intro x hx
-    have hxker := hle hx
-    rw [RingHom.mem_ker] at hxker
-    exact Ideal.Quotient.eq_zero_iff_mem.mp hxker
-  exact le_antisymm hPI hIP
-
 /-- A maximal-dimensional unipotent-radical candidate is the greatest candidate.
 
 The order on Hopf ideals reverses inclusion of the represented closed subgroups: `I ≤ J` says
@@ -233,8 +62,15 @@ theorem le_of_finrank_maximal
           (Derivation k (H ⧸ I.toIdeal)
             (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
     (hJ : IsUnipotentRadicalCandidate H J) : I ≤ J := by
-  rw [← hI.productOfNormal_eq_left_of_maximal hmax hJ]
-  exact CommHopfAlgCat.ker_productMapOfNormal_le_right H.obj I J hI.isNormal
+  apply HopfIdeal.le_of_finrank_maximal_of_product
+      (IsUnipotentRadicalCandidate H)
+      (fun hK ↦ hK.isNormal)
+      (fun hK ↦ hK.geometricallyConnected)
+      (fun hK ↦
+        ((smoothUnipotentCommHopfAlgProperty_iff k
+          (FiniteTypeCommHopfAlgCat.quotient H _)).mp hK.smoothUnipotent).1)
+      (fun hK hL ↦ hK.productOfNormal hL)
+      hI hmax hJ
 
 end HopfIdeal.IsUnipotentRadicalCandidate
 

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -64,13 +64,13 @@ theorem le_of_finrank_maximal
     (hJ : IsUnipotentRadicalCandidate H J) : I ≤ J := by
   apply HopfIdeal.le_of_product_of_finrank_maximal
       (IsUnipotentRadicalCandidate H)
-      (fun hK ↦ hK.isNormal)
+      hI.isNormal
       (fun hK ↦
         geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ hK.geometricallyConnected)
       (fun hK ↦
         ((smoothUnipotentCommHopfAlgProperty_iff k
           (FiniteTypeCommHopfAlgCat.quotient H _)).mp hK.smoothUnipotent).1)
-      (fun hK hL ↦ hK.productOfNormal hL)
+      (fun hK ↦ hI.productOfNormal hK)
       hI hmax hJ
 
 end HopfIdeal.IsUnipotentRadicalCandidate

--- a/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean
@@ -62,10 +62,11 @@ theorem le_of_finrank_maximal
           (Derivation k (H ⧸ I.toIdeal)
             (Bialgebra.CounitAlgebra k (H ⧸ I.toIdeal) k)))
     (hJ : IsUnipotentRadicalCandidate H J) : I ≤ J := by
-  apply HopfIdeal.le_of_finrank_maximal_of_product
+  apply HopfIdeal.le_of_product_of_finrank_maximal
       (IsUnipotentRadicalCandidate H)
       (fun hK ↦ hK.isNormal)
-      (fun hK ↦ hK.geometricallyConnected)
+      (fun hK ↦
+        geometricallyConnectedCommHopfAlgProperty.connectedSpace k _ hK.geometricallyConnected)
       (fun hK ↦
         ((smoothUnipotentCommHopfAlgProperty_iff k
           (FiniteTypeCommHopfAlgCat.quotient H _)).mp hK.smoothUnipotent).1)


### PR DESCRIPTION
This PR factors the maximal-dimension comparison for normal closed subgroups into `HopfIdeal.le_of_finrank_maximal_of_product`: for any product-closed family of smooth geometrically connected normal closed subgroups, a member of maximal Lie dimension contains every other member. Apply the theorem immediately to the existing unipotent-radical candidates, preserving the canonical `IsUnipotentRadicalCandidate.le_of_finrank_maximal` conclusion while removing four implementation-only intermediate declarations.

The exact roadmap target is `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 6, milestone “Reductive and semisimple groups,” specifically “develop the radical `R(G)` (maximal connected normal solvable, geometric).” The solvable-radical candidates and their maximal-dimensional member are on `main`, and open PR #5157 supplies their binary-product closure; this PR supplies the next comparison step without duplicating the argument already used by the unipotent radical. After this PR, the Layer 6 radical milestone still needs that product-closure PR to land, specialization of this theorem to solvable candidates, and packaging of the resulting greatest candidate as `R(G)`.

The proof forms the scheme-theoretic product of the maximal candidate with an arbitrary candidate. Product containment and maximality force equality of Lie dimensions; tangent/cotangent duality turns this into zero conormal space, and the existing smooth-connected containment theorem makes the closed immersion an equality. The other product containment then gives the required reversed Hopf-ideal inequality. The hypotheses are stated on an arbitrary family because both the unipotent and solvable radical constructions consume exactly this argument; the unipotent specialization is the immediate nontrivial witness on `main`.

Add `TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal/Product/Maximal.lean` (141 lines) and reduce `TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Maximal.lean` from 244 to 79 lines. The mathematical organization follows J. S. Milne, *Algebraic Groups* (2017), Proposition 6.42 and Sections 5.a, 6.a, and 10.a, and A. Borel, *Linear Algebraic Groups*, Section 11.21, as cited in both module documentations. No Mathlib source or external formalization is vendored.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"maximal-dimensional-candidate-greatest"}-->

🤖 Prepared with Codex
