### PR TITLE
feat: realize every polynomial dominant weight of gl_n

### DIFF
--- a/TauCeti/Algebra/Lie/GeneralLinear/BlockDiagonal.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/BlockDiagonal.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.ExteriorPower
+
+public section
+
+/-!
+# Block-diagonal actions of general linear Lie algebras
+
+The block-diagonal map sends a matrix `A : Matrix ι ι R` to the matrix with one copy of `A` for
+each element of an auxiliary finite type `κ`. Restricting the standard `gl (ι × κ)` action along
+this map gives a `gl ι` action on every exterior power of `ι × κ → R`.
+
+## Main definitions
+
+* `TauCeti.glBlockDiagonal`: the block-diagonal map from `gl ι` to `gl (ι × κ)`.
+* `TauCeti.glBlockDiagonalLieRingModule` and `TauCeti.glBlockDiagonalLieModule`: the induced
+  action on exterior powers of the standard module.
+-/
+
+namespace TauCeti
+
+open Matrix Module exteriorPower
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable (R : Type*) [CommRing R]
+variable (ι : Type*) [DecidableEq ι] [Fintype ι]
+variable (κ : Type*) [DecidableEq κ] [Fintype κ]
+
+/-- The **block-diagonal map** from `gl ι` to `gl (ι × κ)`, sending a matrix `A` to the block
+diagonal matrix with `κ` copies of `A` down the diagonal. On the standard module `ι × κ → R` this
+is the action of `gl ι` on the first coordinate alone. -/
+def glBlockDiagonal : Matrix ι ι R →ₗ⁅R⁆ Matrix (ι × κ) (ι × κ) R :=
+  (AlgHom.mk'
+    ((blockDiagonalRingHom ι κ R).comp (Pi.constRingHom κ (Matrix ι ι R)))
+    (by
+      intro c A
+      exact blockDiagonal_smul c (fun _ : κ => A))).toLieHom
+
+@[simp]
+theorem glBlockDiagonal_apply (A : Matrix ι ι R) :
+    glBlockDiagonal R ι κ A = blockDiagonal fun _ : κ => A :=
+  (rfl)
+
+variable {R ι κ}
+
+/-- The block-diagonal map takes a matrix unit of `gl ι` to the sum, over the auxiliary coordinate,
+of the matrix units of `gl (ι × κ)` that move a cell from row `t` to row `s` and leave its column
+alone. -/
+theorem glBlockDiagonal_single (s t : ι) :
+    glBlockDiagonal R ι κ (single s t 1) = ∑ c : κ, single (s, c) (t, c) (1 : R) := by
+  ext p q
+  rw [glBlockDiagonal_apply, blockDiagonal_apply, Matrix.sum_apply]
+  by_cases hpq : p.2 = q.2
+  · rw [ite_eq_left hpq, Finset.sum_eq_single p.2]
+    · simp [single_apply, Prod.ext_iff, hpq, eq_comm]
+    · intro c _ hc
+      refine Matrix.single_apply_of_ne _ _ _ _ _ ?_
+      rintro ⟨hp, -⟩
+      exact hc (congrArg Prod.snd hp)
+    · exact fun hc => absurd (Finset.mem_univ p.2) hc
+  · rw [ite_eq_right hpq]
+    refine (Finset.sum_eq_zero fun c _ => Matrix.single_apply_of_ne _ _ _ _ _ ?_).symm
+    rintro ⟨hp, hq⟩
+    have hcp : c = p.2 := congrArg Prod.snd hp
+    have hcq : c = q.2 := congrArg Prod.snd hq
+    exact hpq (hcp.symm.trans hcq)
+
+variable (R ι κ) in
+/-- The bracket of `gl ι` on an exterior power of `ι × κ → R`, pulled back along the block-diagonal
+map from the standard `gl (ι × κ)`-action. -/
+noncomputable scoped instance glBlockDiagonalLieRingModule (N : ℕ) :
+    LieRingModule (Matrix ι ι R) (⋀[R]^N (ι × κ → R)) :=
+  LieRingModule.compLieHom _ (glBlockDiagonal R ι κ)
+
+variable (R ι κ) in
+/-- The compatibility of that bracket with the `R`-module structures, making an exterior power of
+`ι × κ → R` a `gl ι`-module over `R`. -/
+noncomputable scoped instance glBlockDiagonalLieModule (N : ℕ) :
+    LieModule R (Matrix ι ι R) (⋀[R]^N (ι × κ → R)) :=
+  LieModule.compLieHom _ (glBlockDiagonal R ι κ)
+
+/-- The `gl ι`-action on an exterior power of `ι × κ → R` is the `gl (ι × κ)`-action of the
+block-diagonal image. -/
+theorem gl_lie_blockDiagonal_def {N : ℕ} (A : Matrix ι ι R) (x : ⋀[R]^N (ι × κ → R)) :
+    ⁅A, x⁆ = ⁅glBlockDiagonal R ι κ A, x⁆ :=
+  LieRingModule.compLieHom_apply _ _ _ _
+
+/-- A matrix unit of `gl ι` acts on an exterior power of `ι × κ → R` as the sum, over the auxiliary
+coordinate, of the matrix units of `gl (ι × κ)` it is built from. -/
+theorem gl_lie_single {N : ℕ} (s t : ι) (x : ⋀[R]^N (ι × κ → R)) :
+    ⁅(single s t 1 : Matrix ι ι R), x⁆
+      = ∑ c : κ, ⁅(single (s, c) (t, c) 1 : Matrix (ι × κ) (ι × κ) R), x⁆ := by
+  rw [gl_lie_blockDiagonal_def, glBlockDiagonal_single, sum_lie]
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/BlockDiagonal.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/BlockDiagonal.lean
@@ -7,6 +7,8 @@ module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.ExteriorPower
 
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+
 public section
 
 /-!
@@ -26,6 +28,8 @@ this map gives a `gl ι` action on every exterior power of `ι × κ → R`.
 namespace TauCeti
 
 open Matrix Module exteriorPower
+
+open scoped Kronecker
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
@@ -55,22 +59,14 @@ of the matrix units of `gl (ι × κ)` that move a cell from row `t` to row `s` 
 alone. -/
 theorem glBlockDiagonal_single (s t : ι) :
     glBlockDiagonal R ι κ (single s t 1) = ∑ c : κ, single (s, c) (t, c) (1 : R) := by
-  ext p q
-  rw [glBlockDiagonal_apply, blockDiagonal_apply, Matrix.sum_apply]
-  by_cases hpq : p.2 = q.2
-  · rw [ite_eq_left hpq, Finset.sum_eq_single p.2]
-    · simp [single_apply, Prod.ext_iff, hpq, eq_comm]
-    · intro c _ hc
-      refine Matrix.single_apply_of_ne _ _ _ _ _ ?_
-      rintro ⟨hp, -⟩
-      exact hc (congrArg Prod.snd hp)
-    · exact fun hc => absurd (Finset.mem_univ p.2) hc
-  · rw [ite_eq_right hpq]
-    refine (Finset.sum_eq_zero fun c _ => Matrix.single_apply_of_ne _ _ _ _ _ ?_).symm
-    rintro ⟨hp, hq⟩
-    have hcp : c = p.2 := congrArg Prod.snd hp
-    have hcq : c = q.2 := congrArg Prod.snd hq
-    exact hpq (hcp.symm.trans hcq)
+  rw [glBlockDiagonal_apply]
+  calc (blockDiagonal fun _ : κ => single s t (1 : R))
+      = single s t (1 : R) ⊗ₖ (1 : Matrix κ κ R) := (kronecker_one _).symm
+    _ = single s t (1 : R) ⊗ₖ ∑ c : κ, single c c (1 : R) := by rw [sum_single_one]
+    _ = ∑ c : κ, single s t (1 : R) ⊗ₖ single c c (1 : R) :=
+        map_sum (kroneckerBilinear (R := R) (single s t (1 : R))) _ _
+    _ = ∑ c : κ, single (s, c) (t, c) (1 : R) := by
+        simp [single_kronecker_single]
 
 variable (R ι κ) in
 /-- The bracket of `gl ι` on an exterior power of `ι × κ → R`, pulled back along the block-diagonal

--- a/TauCeti/Algebra/Lie/GeneralLinear/ExteriorPower.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/ExteriorPower.lean
@@ -31,8 +31,9 @@ makes the wedge of the first `d` standard basis vectors in `Kⁿ` a highest-weig
 
 ## Main results
 
-* `exteriorPower.lie_single_self_basisWedge` and `exteriorPower.lie_single_basisWedge_of_ne`: how a
-  matrix unit acts on the wedge of a set of standard basis vectors.
+* `exteriorPower.lie_single_self_basisWedge` and
+  `exteriorPower.lie_single_basisWedge_eq_zero_of_ne_of_mem_imp_mem`: how a matrix unit acts on the
+  wedge of a set of standard basis vectors.
 * `exteriorPower.isGlHighestWeightVector_firstBasisWedge`: over a nontrivial ring, the first basis
   wedge is a highest-weight vector when `d ≤ n`.
 
@@ -132,13 +133,6 @@ private theorem exists_orderEmbOfFin_eq {S : Finset n} (h : S.card = N) {p : n} 
     exact Finset.mem_coe.2 hp
   exact hrange
 
-omit [LinearOrder n] in
-private theorem single_mulVec_single (i j p : n) :
-    Matrix.single i j (1 : K) *ᵥ (Pi.single p 1 : n → K) =
-      if j = p then Pi.single i 1 else 0 := by
-  rw [Matrix.single_mulVec_eq, Pi.single_apply]
-  by_cases hjp : j = p <;> simp [hjp]
-
 /-- The diagonal matrix unit `Eᵢᵢ` fixes the factors of a wedge of standard basis vectors that lie
 in direction `i` and kills the others, so it scales the wedge by one when `i` is one of its indices
 and annihilates it otherwise. -/
@@ -146,20 +140,21 @@ theorem lie_single_self_basisWedge (S : Finset n) (h : S.card = N) (i : n) :
     ⁅Matrix.single i i (1 : K), basisWedge K S h⁆ =
       (if i ∈ S then (1 : K) else 0) • basisWedge K S h := by
   rw [basisWedge_eq_ιMulti, gl_lie_def, glLieMap_apply_ιMulti]
-  simp only [single_mulVec_single]
+  simp only [Matrix.single_mulVec_eq, Pi.single_apply, one_mul, ite_smul, one_smul, zero_smul,
+    eq_comm]
   by_cases hiS : i ∈ S
   · obtain ⟨k₀, hk₀⟩ := exists_orderEmbOfFin_eq h hiS
-    rw [ite_eq_left hiS, one_smul, Finset.sum_eq_single k₀]
+    rw [ite_eq_left hiS, Finset.sum_eq_single k₀]
     · rw [ite_eq_left hk₀.symm, ← hk₀]
-      exact congrArg (ιMulti K N) (Function.update_eq_self k₀ _)
+      exact (congrArg (ιMulti K N) (Function.update_eq_self k₀ _)).symm
     · intro k _ hk
       have hik : ¬i = S.orderEmbOfFin h k := fun hik =>
         hk ((S.orderEmbOfFin h).injective (hk₀.trans hik)).symm
       rw [ite_eq_right hik]
       exact (ιMulti K N).map_update_zero _ _
     · exact fun hk => absurd (Finset.mem_univ k₀) hk
-  · rw [ite_eq_right hiS, zero_smul]
-    refine Finset.sum_eq_zero fun k _ => ?_
+  · rw [ite_eq_right hiS]
+    refine (Finset.sum_eq_zero fun k _ => ?_).symm
     have hik : ¬i = S.orderEmbOfFin h k := by
       intro hik
       exact hiS (by rw [hik]; exact Finset.orderEmbOfFin_mem S h k)
@@ -169,12 +164,13 @@ theorem lie_single_self_basisWedge (S : Finset n) (h : S.card = N) (i : n) :
 /-- A matrix unit `Eᵢⱼ` with `i ≠ j` annihilates the wedge of the standard basis vectors indexed by
 `S`, as soon as `S` contains `i` whenever it contains `j`: the `j`-th factor is carried to a factor
 already present, so every summand of the Leibniz expansion has a repeated factor. -/
-theorem lie_single_basisWedge_of_ne (S : Finset n) (h : S.card = N) {i j : n} (hij : i ≠ j)
-    (hS : j ∈ S → i ∈ S) :
+theorem lie_single_basisWedge_eq_zero_of_ne_of_mem_imp_mem (S : Finset n) (h : S.card = N)
+    {i j : n} (hij : i ≠ j) (hS : j ∈ S → i ∈ S) :
     ⁅Matrix.single i j (1 : K), basisWedge K S h⁆ = 0 := by
   rw [basisWedge_eq_ιMulti, gl_lie_def, glLieMap_apply_ιMulti]
-  refine Finset.sum_eq_zero fun k _ => ?_
-  simp only [single_mulVec_single]
+  simp only [Matrix.single_mulVec_eq, Pi.single_apply, one_mul, ite_smul, one_smul, zero_smul,
+    eq_comm]
+  refine (Finset.sum_eq_zero fun k _ => ?_).symm
   by_cases hjk : j = S.orderEmbOfFin h k
   · have hjS : j ∈ S := by rw [hjk]; exact Finset.orderEmbOfFin_mem S h k
     obtain ⟨l, hl⟩ := exists_orderEmbOfFin_eq h (hS hjS)
@@ -275,7 +271,7 @@ theorem isGlHighestWeightVector_firstBasisWedge [Nontrivial K] (d n : ℕ) (h : 
     ⟨basisWedge_ne_zero _ _, fun i => ?_, fun i j hij => ?_⟩
   · rw [lie_single_self_basisWedge, fundamentalWeight_apply]
     simp only [mem_firstBasisSet]
-  · exact lie_single_basisWedge_of_ne _ _ hij.ne fun hj =>
+  · exact lie_single_basisWedge_eq_zero_of_ne_of_mem_imp_mem _ _ hij.ne fun hj =>
       (mem_firstBasisSet d n h i).2
         ((Fin.lt_def.1 hij).trans ((mem_firstBasisSet d n h j).1 hj))
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/ExteriorPower.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/ExteriorPower.lean
@@ -15,17 +15,24 @@ import Mathlib.LinearAlgebra.ExteriorPower.Basis
 # Exterior powers of the standard general-linear module
 
 The infinitesimal exterior-power action restricts along the matrix-to-endomorphism equivalence to
-an action of a general linear Lie algebra. Over a nontrivial ring, for `d ≤ n`, the wedge of the
-first `d` standard basis vectors in `Kⁿ` is a highest-weight vector for this action.
+an action of a general linear Lie algebra. A matrix unit acts on the wedge of the standard basis
+vectors indexed by a finite set `S` of coordinates in a way read off from `S`: the diagonal unit
+`Eᵢᵢ` scales it by one or by zero according as `i` lies in `S`, and `Eᵢⱼ` with `i ≠ j` annihilates
+it whenever `S` contains `i` as soon as it contains `j`. Over a nontrivial ring, for `d ≤ n`, this
+makes the wedge of the first `d` standard basis vectors in `Kⁿ` a highest-weight vector.
 
 ## Main definitions
 
 * `exteriorPower.glLieMap`: the action of matrices on an exterior power.
+* `exteriorPower.basisWedge`: the wedge of the standard basis vectors indexed by a finite set of
+  coordinates.
 * `exteriorPower.firstBasisWedge`: the wedge of the first standard basis vectors.
 * `exteriorPower.fundamentalWeight`: the first-`d` coordinate-indicator weight.
 
-## Main result
+## Main results
 
+* `exteriorPower.lie_single_self_basisWedge` and `exteriorPower.lie_single_basisWedge_of_ne`: how a
+  matrix unit acts on the wedge of a set of standard basis vectors.
 * `exteriorPower.isGlHighestWeightVector_firstBasisWedge`: over a nontrivial ring, the first basis
   wedge is a highest-weight vector when `d ≤ n`.
 
@@ -85,9 +92,114 @@ theorem gl_lie_def (d : ℕ) {n : Type*} [DecidableEq n] [Fintype n]
     ⁅A, x⁆ = glLieMap d A x := by
   rw [LieRingModule.compLieHom_apply, Module.End.lie_apply]
 
+section BasisWedge
+
+variable {n : Type*} [DecidableEq n] [Fintype n] [LinearOrder n] {N : ℕ}
+
+variable (K) in
+/-- The wedge of the standard basis vectors of `n → K` indexed by a finite set `S` of coordinates,
+an element of the exterior power of degree the size of `S`. The factors are wedged together in the
+order `S` inherits from `n`. -/
+noncomputable def basisWedge (S : Finset n) (h : S.card = N) : ⋀[K]^N (n → K) :=
+  ιMulti_family K N (Pi.basisFun K n) ⟨S, h⟩
+
+omit [DecidableEq n] in
+/-- The wedge of a set of basis vectors is the member of the standard basis of the exterior power
+that the set indexes. -/
+theorem basisWedge_eq_ιMulti_family (S : Finset n) (h : S.card = N) :
+    basisWedge K S h = ιMulti_family K N (Pi.basisFun K n) ⟨S, h⟩ := by
+  rw [basisWedge]
+
+/-- The wedge of a set of basis vectors, written as an exterior product. -/
+theorem basisWedge_eq_ιMulti (S : Finset n) (h : S.card = N) :
+    basisWedge K S h = ιMulti K N fun k => Pi.single (S.orderEmbOfFin h k) 1 := by
+  rw [basisWedge_eq_ιMulti_family, ιMulti_family]
+  refine congrArg (ιMulti K N) (funext fun k => ?_)
+  simp [Pi.basisFun_apply, Set.powersetCard.ofFinEmbEquiv_symm_apply]
+
+omit [DecidableEq n] in
+/-- The wedge of a set of basis vectors is nonzero. -/
+theorem basisWedge_ne_zero [Nontrivial K] (S : Finset n) (h : S.card = N) :
+    basisWedge K S h ≠ 0 := by
+  rw [basisWedge_eq_ιMulti_family]
+  exact (ιMulti_family_linearIndependent_ofBasis K N (Pi.basisFun K n)).ne_zero _
+
+omit [DecidableEq n] [Fintype n] in
+private theorem exists_orderEmbOfFin_eq {S : Finset n} (h : S.card = N) {p : n} (hp : p ∈ S) :
+    ∃ k, S.orderEmbOfFin h k = p := by
+  have hrange : p ∈ Set.range (S.orderEmbOfFin h) := by
+    rw [Finset.range_orderEmbOfFin]
+    exact Finset.mem_coe.2 hp
+  exact hrange
+
+omit [LinearOrder n] in
+private theorem single_mulVec_single (i j p : n) :
+    Matrix.single i j (1 : K) *ᵥ (Pi.single p 1 : n → K) =
+      if j = p then Pi.single i 1 else 0 := by
+  rw [Matrix.single_mulVec_eq, Pi.single_apply]
+  by_cases hjp : j = p <;> simp [hjp]
+
+/-- The diagonal matrix unit `Eᵢᵢ` fixes the factors of a wedge of standard basis vectors that lie
+in direction `i` and kills the others, so it scales the wedge by one when `i` is one of its indices
+and annihilates it otherwise. -/
+theorem lie_single_self_basisWedge (S : Finset n) (h : S.card = N) (i : n) :
+    ⁅Matrix.single i i (1 : K), basisWedge K S h⁆ =
+      (if i ∈ S then (1 : K) else 0) • basisWedge K S h := by
+  rw [basisWedge_eq_ιMulti, gl_lie_def, glLieMap_apply_ιMulti]
+  simp only [single_mulVec_single]
+  by_cases hiS : i ∈ S
+  · obtain ⟨k₀, hk₀⟩ := exists_orderEmbOfFin_eq h hiS
+    rw [ite_eq_left hiS, one_smul, Finset.sum_eq_single k₀]
+    · rw [ite_eq_left hk₀.symm, ← hk₀]
+      exact congrArg (ιMulti K N) (Function.update_eq_self k₀ _)
+    · intro k _ hk
+      have hik : ¬i = S.orderEmbOfFin h k := fun hik =>
+        hk ((S.orderEmbOfFin h).injective (hk₀.trans hik)).symm
+      rw [ite_eq_right hik]
+      exact (ιMulti K N).map_update_zero _ _
+    · exact fun hk => absurd (Finset.mem_univ k₀) hk
+  · rw [ite_eq_right hiS, zero_smul]
+    refine Finset.sum_eq_zero fun k _ => ?_
+    have hik : ¬i = S.orderEmbOfFin h k := by
+      intro hik
+      exact hiS (by rw [hik]; exact Finset.orderEmbOfFin_mem S h k)
+    rw [ite_eq_right hik]
+    exact (ιMulti K N).map_update_zero _ _
+
+/-- A matrix unit `Eᵢⱼ` with `i ≠ j` annihilates the wedge of the standard basis vectors indexed by
+`S`, as soon as `S` contains `i` whenever it contains `j`: the `j`-th factor is carried to a factor
+already present, so every summand of the Leibniz expansion has a repeated factor. -/
+theorem lie_single_basisWedge_of_ne (S : Finset n) (h : S.card = N) {i j : n} (hij : i ≠ j)
+    (hS : j ∈ S → i ∈ S) :
+    ⁅Matrix.single i j (1 : K), basisWedge K S h⁆ = 0 := by
+  rw [basisWedge_eq_ιMulti, gl_lie_def, glLieMap_apply_ιMulti]
+  refine Finset.sum_eq_zero fun k _ => ?_
+  simp only [single_mulVec_single]
+  by_cases hjk : j = S.orderEmbOfFin h k
+  · have hjS : j ∈ S := by rw [hjk]; exact Finset.orderEmbOfFin_mem S h k
+    obtain ⟨l, hl⟩ := exists_orderEmbOfFin_eq h (hS hjS)
+    have hlk : l ≠ k := by
+      rintro rfl
+      exact hij (hl.symm.trans hjk.symm)
+    rw [ite_eq_left hjk]
+    refine (ιMulti K N).map_eq_zero_of_eq _ (i := l) (j := k) ?_ hlk
+    rw [Function.update_of_ne hlk, Function.update_self, hl]
+  · rw [ite_eq_right hjk]
+    exact (ιMulti K N).map_update_zero _ _
+
+end BasisWedge
+
 /-- The subset of the first `d` coordinates in `Fin n`. -/
 private noncomputable def firstBasisSet (d n : ℕ) (h : d ≤ n) : Set.powersetCard (Fin n) d :=
   Set.powersetCard.ofFinEmbEquiv (Fin.castLEOrderEmb h)
+
+private theorem mem_firstBasisSet (d n : ℕ) (h : d ≤ n) (k : Fin n) :
+    k ∈ (firstBasisSet d n h : Finset (Fin n)) ↔ (k : ℕ) < d := by
+  rw [Set.powersetCard.mem_coe_iff, firstBasisSet,
+    Set.powersetCard.mem_ofFinEmbEquiv_iff_mem_range]
+  refine ⟨?_, fun hk => ⟨⟨k, hk⟩, rfl⟩⟩
+  rintro ⟨l, rfl⟩
+  exact l.isLt
 
 /-- The wedge of the first `d` standard basis vectors of `K^n`. -/
 noncomputable def firstBasisWedge (d n : ℕ) (h : d ≤ n) : ⋀[K]^d (Fin n → K) :=
@@ -102,6 +214,13 @@ theorem firstBasisWedge_eq_ιMulti (d n : ℕ) (h : d ≤ n) :
   apply congrArg (ιMulti K d)
   funext i x
   simp [Pi.basisFun_apply, Pi.single_apply]
+
+/-- The first basis wedge is the wedge of the basis vectors indexed by the first `d` coordinates. -/
+private theorem firstBasisWedge_eq_basisWedge (d n : ℕ) (h : d ≤ n) :
+    firstBasisWedge (K := K) d n h =
+      basisWedge K (firstBasisSet d n h : Finset (Fin n))
+        (Set.powersetCard.card_eq (firstBasisSet d n h)) :=
+  rfl
 
 end Action
 
@@ -141,84 +260,8 @@ theorem isGlDominantIntegral_fundamentalWeight [CharZero K] (d n : ℕ) :
 /-- The first basis wedge is nonzero. -/
 theorem firstBasisWedge_ne_zero [Nontrivial K] (d n : ℕ) (h : d ≤ n) :
     firstBasisWedge (K := K) d n h ≠ 0 := by
-  rw [firstBasisWedge]
-  exact (ιMulti_family_linearIndependent_ofBasis K d (Pi.basisFun K (Fin n))).ne_zero
-    (firstBasisSet d n h)
-
-private theorem single_mulVec_firstBasis (d n : ℕ) (h : d ≤ n) (i j : Fin n) (k : Fin d) :
-    Matrix.single i j 1 *ᵥ (Pi.single (Fin.castLE h k) 1 : Fin n → K) =
-      if j = Fin.castLE h k then Pi.single i 1 else 0 := by
-  rw [Matrix.single_mulVec_eq]
-  by_cases hjk : j = Fin.castLE h k
-  · subst j
-    simp
-  · simp [hjk]
-
-private theorem lie_single_self_firstBasisWedge (d n : ℕ) (h : d ≤ n) (k : Fin n) :
-    letI : LieRingModule (Matrix (Fin n) (Fin n) K) (⋀[K]^d (Fin n → K)) :=
-      glLieRingModule (K := K) (n := Fin n) d
-    ⁅Matrix.single k k (1 : K), firstBasisWedge (K := K) d n h⁆ =
-      fundamentalWeight (K := K) d n k • firstBasisWedge (K := K) d n h := by
-  classical
-  rw [firstBasisWedge_eq_ιMulti, gl_lie_def, glLieMap_apply_ιMulti]
-  simp_rw [single_mulVec_firstBasis d n h]
-  by_cases hk : k.val < d
-  · let a : Fin d := ⟨k.val, hk⟩
-    have hka : k = Fin.castLE h a := Fin.ext rfl
-    simp only [fundamentalWeight_apply, hk, ite_true, one_smul]
-    rw [Finset.sum_eq_single a]
-    · simp only [hka, ite_true]
-      simp
-    · intro b _ hba
-      have hkb : k ≠ Fin.castLE h b := by
-        intro hkb
-        exact hba (Fin.castLE_injective h (hkb.symm.trans hka))
-      simp only [hkb, ite_false]
-      exact (ιMulti K d).map_update_zero _ _
-    · simp
-  · simp only [fundamentalWeight_apply, hk, ite_false, zero_smul]
-    apply Finset.sum_eq_zero
-    intro a _
-    have hka : k ≠ Fin.castLE h a := by
-      intro hka
-      apply hk
-      rw [hka]
-      exact a.isLt
-    simp only [hka, ite_false]
-    exact (ιMulti K d).map_update_zero _ _
-
-private theorem lie_single_firstBasisWedge_of_lt (d n : ℕ) (h : d ≤ n)
-    {i j : Fin n} (hij : i < j) :
-    letI : LieRingModule (Matrix (Fin n) (Fin n) K) (⋀[K]^d (Fin n → K)) :=
-      glLieRingModule (K := K) (n := Fin n) d
-    ⁅Matrix.single i j (1 : K), firstBasisWedge (K := K) d n h⁆ = 0 := by
-  classical
-  rw [firstBasisWedge_eq_ιMulti, gl_lie_def, glLieMap_apply_ιMulti]
-  simp_rw [single_mulVec_firstBasis d n h]
-  apply Finset.sum_eq_zero
-  intro k _
-  by_cases hjk : j = Fin.castLE h k
-  · simp only [hjk, ite_true]
-    have hjd : j.val < d := by
-      rw [hjk]
-      exact k.isLt
-    have hi : i.val < d := lt_trans hij hjd
-    let l : Fin d := ⟨i.val, hi⟩
-    have hil : i = Fin.castLE h l := Fin.ext rfl
-    have hlk : l ≠ k := by
-      intro hlk
-      apply hij.ne
-      rw [hil, hjk, hlk]
-    refine (ιMulti K d).map_eq_zero_of_eq
-      (Function.update
-        (fun a : Fin d => (Pi.single (Fin.castLE h a) (1 : K) : Fin n → K)) k
-        (Pi.single i 1))
-      (i := l) (j := k) ?_ hlk
-    rw [Function.update_of_ne hlk]
-    rw [hil]
-    rw [Function.update_self]
-  · simp only [hjk, ite_false]
-    exact (ιMulti K d).map_update_zero _ _
+  rw [firstBasisWedge_eq_basisWedge]
+  exact basisWedge_ne_zero _ _
 
 /-- Over a nontrivial ring, the first basis wedge is a highest-weight vector for the exterior-power
 action when `d ≤ n`. -/
@@ -227,10 +270,14 @@ theorem isGlHighestWeightVector_firstBasisWedge [Nontrivial K] (d n : ℕ) (h : 
       glLieRingModule (K := K) (n := Fin n) d
     TauCeti.IsGlHighestWeightVector (fundamentalWeight (K := K) d n)
       (firstBasisWedge (K := K) d n h) := by
+  rw [firstBasisWedge_eq_basisWedge]
   refine TauCeti.isGlHighestWeightVector_iff.mpr
-    ⟨firstBasisWedge_ne_zero (K := K) d n h, fun i => ?_, fun i j hij => ?_⟩
-  · exact lie_single_self_firstBasisWedge (K := K) d n h i
-  · exact lie_single_firstBasisWedge_of_lt (K := K) d n h hij
+    ⟨basisWedge_ne_zero _ _, fun i => ?_, fun i j hij => ?_⟩
+  · rw [lie_single_self_basisWedge, fundamentalWeight_apply]
+    simp only [mem_firstBasisSet]
+  · exact lie_single_basisWedge_of_ne _ _ hij.ne fun hj =>
+      (mem_firstBasisSet d n h i).2
+        ((Fin.lt_def.1 hij).trans ((mem_firstBasisSet d n h j).1 hj))
 
 end HighestWeight
 

--- a/TauCeti/Algebra/Lie/GeneralLinear/ExteriorPower.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/ExteriorPower.lean
@@ -85,7 +85,6 @@ noncomputable scoped instance glLieModule (d : ℕ) {n : Type*} [DecidableEq n] 
   LieModule.compLieHom _ (glLieMap d)
 
 /-- The scoped Lie action is the action represented by `glLieMap`. -/
-@[simp]
 theorem gl_lie_def (d : ℕ) {n : Type*} [DecidableEq n] [Fintype n]
     (A : Matrix n n K) (x : ⋀[K]^d (n → K)) :
     letI : LieRingModule (Matrix n n K) (⋀[K]^d (n → K)) :=
@@ -136,6 +135,7 @@ private theorem exists_orderEmbOfFin_eq {S : Finset n} (h : S.card = N) {p : n} 
 /-- The diagonal matrix unit `Eᵢᵢ` fixes the factors of a wedge of standard basis vectors that lie
 in direction `i` and kills the others, so it scales the wedge by one when `i` is one of its indices
 and annihilates it otherwise. -/
+@[simp]
 theorem lie_single_self_basisWedge (S : Finset n) (h : S.card = N) (i : n) :
     ⁅Matrix.single i i (1 : K), basisWedge K S h⁆ =
       (if i ∈ S then (1 : K) else 0) • basisWedge K S h := by

--- a/TauCeti/Algebra/Lie/GeneralLinear/ExteriorPower.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/ExteriorPower.lean
@@ -124,14 +124,6 @@ theorem basisWedge_ne_zero [Nontrivial K] (S : Finset n) (h : S.card = N) :
   rw [basisWedge_eq_ιMulti_family]
   exact (ιMulti_family_linearIndependent_ofBasis K N (Pi.basisFun K n)).ne_zero _
 
-omit [DecidableEq n] [Fintype n] in
-private theorem exists_orderEmbOfFin_eq {S : Finset n} (h : S.card = N) {p : n} (hp : p ∈ S) :
-    ∃ k, S.orderEmbOfFin h k = p := by
-  have hrange : p ∈ Set.range (S.orderEmbOfFin h) := by
-    rw [Finset.range_orderEmbOfFin]
-    exact Finset.mem_coe.2 hp
-  exact hrange
-
 /-- The diagonal matrix unit `Eᵢᵢ` fixes the factors of a wedge of standard basis vectors that lie
 in direction `i` and kills the others, so it scales the wedge by one when `i` is one of its indices
 and annihilates it otherwise. -/
@@ -143,7 +135,7 @@ theorem lie_single_self_basisWedge (S : Finset n) (h : S.card = N) (i : n) :
   simp only [Matrix.single_mulVec_eq, Pi.single_apply, one_mul, ite_smul, one_smul, zero_smul,
     eq_comm]
   by_cases hiS : i ∈ S
-  · obtain ⟨k₀, hk₀⟩ := exists_orderEmbOfFin_eq h hiS
+  · obtain ⟨k₀, hk₀⟩ := (S.range_orderEmbOfFin h).ge (Finset.mem_coe.2 hiS)
     rw [ite_eq_left hiS, Finset.sum_eq_single k₀]
     · rw [ite_eq_left hk₀.symm, ← hk₀]
       exact (congrArg (ιMulti K N) (Function.update_eq_self k₀ _)).symm
@@ -173,7 +165,7 @@ theorem lie_single_basisWedge_eq_zero_of_ne_of_mem_imp_mem (S : Finset n) (h : S
   refine (Finset.sum_eq_zero fun k _ => ?_).symm
   by_cases hjk : j = S.orderEmbOfFin h k
   · have hjS : j ∈ S := by rw [hjk]; exact Finset.orderEmbOfFin_mem S h k
-    obtain ⟨l, hl⟩ := exists_orderEmbOfFin_eq h (hS hjS)
+    obtain ⟨l, hl⟩ := (S.range_orderEmbOfFin h).ge (Finset.mem_coe.2 (hS hjS))
     have hlk : l ≠ k := by
       rintro rfl
       exact hij (hl.symm.trans hjk.symm)
@@ -193,9 +185,7 @@ private theorem mem_firstBasisSet (d n : ℕ) (h : d ≤ n) (k : Fin n) :
     k ∈ (firstBasisSet d n h : Finset (Fin n)) ↔ (k : ℕ) < d := by
   rw [Set.powersetCard.mem_coe_iff, firstBasisSet,
     Set.powersetCard.mem_ofFinEmbEquiv_iff_mem_range]
-  refine ⟨?_, fun hk => ⟨⟨k, hk⟩, rfl⟩⟩
-  rintro ⟨l, rfl⟩
-  exact l.isLt
+  simp [Fin.castLEOrderEmb, Fin.range_castLE]
 
 /-- The wedge of the first `d` standard basis vectors of `K^n`. -/
 noncomputable def firstBasisWedge (d n : ℕ) (h : d ≤ n) : ⋀[K]^d (Fin n → K) :=

--- a/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
@@ -98,7 +98,7 @@ variable {ι : Type*} [Fintype ι] [LinearOrder ι]
 variable {κ : Type*} [Fintype κ] [LinearOrder κ]
 
 /-- The local lexicographic order fixes the order of the wedge factors. -/
-local instance : LinearOrder (ι × κ) :=
+local instance cellLinearOrder : LinearOrder (ι × κ) :=
   LinearOrder.lift' (⇑(toLex : (ι × κ) ≃ ι ×ₗ κ)) (Equiv.injective _)
 
 open CellDiagram
@@ -142,7 +142,7 @@ variable {R : Type*} [CommRing R]
 variable {ι : Type*} [Fintype ι] [LinearOrder ι]
 
 /-- The local lexicographic order fixes the order of the wedge factors. -/
-local instance {m : ℕ} : LinearOrder (ι × Fin m) :=
+local instance cellFinLinearOrder {m : ℕ} : LinearOrder (ι × Fin m) :=
   LinearOrder.lift' (⇑(toLex : (ι × Fin m) ≃ ι ×ₗ Fin m)) (Equiv.injective _)
 
 open CellDiagram

--- a/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.GeneralLinear.ExteriorPower
+public import TauCeti.Algebra.Lie.GeneralLinear.BlockDiagonal
 public import TauCeti.Combinatorics.Young.Cells
 
 import Mathlib.LinearAlgebra.ExteriorPower.Basis
@@ -30,25 +30,20 @@ row `s` and leave its column alone (`TauCeti.glBlockDiagonal_single`).
 For a finite set of cells `D ⊆ ι × κ` the wedge `exteriorPower.basisWedge R D` of the standard
 basis vectors `e_p`, `p ∈ D`, is then a weight vector for the diagonal: summing
 `exteriorPower.lie_single_self_basisWedge` over the columns, `Eₛₛ` scales the wedge by the number
-of cells of `D` in row `s`. And if `D` is row lower closed — containing with every cell the cells
+of cells of `D` in row `s`. And if `D` is a row lower set — containing with every cell the cells
 directly above it, which is exactly the shape of a Young diagram — then every raising operator
-`Eₛₜ` with `s < t` annihilates the wedge by `exteriorPower.lie_single_basisWedge_of_ne`, since
-moving a cell from row `t` up to row `s` lands on a cell already present.
+`Eₛₜ` with `s < t` annihilates the wedge by
+`exteriorPower.lie_single_basisWedge_eq_zero_of_ne_of_mem_imp_mem`, since moving a cell from row
+`t` up to row `s` lands on a cell already present.
 
 The weight read off this way is the row-length function of `D`. Taking `κ = Fin m` and `D` the
-Young diagram `TauCeti.CellDiagram.ofRowLens a m` of a weakly decreasing `a : ι → ℕ`, the row
-lengths are the `a i` themselves, which realizes `a` as a highest weight.
-
-## Main definitions
-
-* `TauCeti.glBlockDiagonal`: the block-diagonal map from `gl ι` to `gl (ι × κ)`, together with the
-  `gl ι`-module structure it induces on the exterior powers of `ι × κ → R`.
-* `TauCeti.prodLexLinearOrder`: the lexicographic order on `ι × κ`, which fixes the order in which
-  the basis vectors of a set of cells are wedged together.
+Young diagram `TauCeti.CellDiagram.ofRowLens a m` of a weakly decreasing `a : ι → ℕ`, and taking
+`m` with `∀ i, a i ≤ m`, the row lengths are the `a i` themselves, which realizes `a` as a highest
+weight.
 
 ## Main results
 
-* `TauCeti.isGlHighestWeightVector_basisWedge`: **the wedge of a row lower closed set of cells is a
+* `TauCeti.isGlHighestWeightVector_basisWedge`: **the wedge of a row lower set of cells is a
   highest weight vector**, of weight the row lengths of the set.
 * `TauCeti.isGlHighestWeightVector_basisWedge_ofRowLens` and
   `TauCeti.exists_isGlHighestWeightVector_natCast`: **every weakly decreasing tuple of natural
@@ -67,12 +62,11 @@ weights with natural number entries, the existence input to that classification;
 ## Implementation notes
 
 `TauCeti.glBlockDiagonal` is the constant family map followed by `Matrix.blockDiagonalRingHom`,
-but it is packaged directly as a `LieHom` rather than through `AlgHom.toLieHom`, since only the
-multiplicativity lemma `Matrix.blockDiagonal_mul` is needed and no unit or `algebraMap` bookkeeping.
-It is not injective when `κ` is empty, so it is a map rather than an embedding.
+promoted to an `AlgHom`, and then viewed as a `LieHom`. It is not injective when `κ` is empty, so it
+is a map rather than an embedding.
 
 A single-column diagram gives back the fundamental weights: for `κ` a singleton, the row lower
-closed set of the first `d` rows is the wedge `exteriorPower.firstBasisWedge`, transported along
+set of the first `d` rows is the wedge `exteriorPower.firstBasisWedge`, transported along
 `ι × κ ≃ ι`. The two are not literally the same declaration because the ambient index types differ,
 and it is the second coordinate — absent there — that lets a row be repeated, which is what a
 general weakly decreasing tuple needs.
@@ -95,95 +89,7 @@ open Matrix Module exteriorPower
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
-/-! ### The block-diagonal map from `gl ι` to `gl (ι × κ)` -/
-
-section BlockDiagonal
-
-variable (R : Type*) [CommRing R]
-variable (ι : Type*) [DecidableEq ι] [Fintype ι]
-variable (κ : Type*) [DecidableEq κ] [Fintype κ]
-
-/-- The **block-diagonal map** from `gl ι` to `gl (ι × κ)`, sending a matrix `A` to the block
-diagonal matrix with `κ` copies of `A` down the diagonal. On the standard module `ι × κ → R` this
-is the action of `gl ι` on the first coordinate alone. -/
-def glBlockDiagonal : Matrix ι ι R →ₗ⁅R⁆ Matrix (ι × κ) (ι × κ) R where
-  toFun A := blockDiagonal fun _ : κ => A
-  map_add' A B := by rw [← blockDiagonal_add]; rfl
-  map_smul' c A := by rw [RingHom.id_apply, ← blockDiagonal_smul]; rfl
-  map_lie' {A B} := by
-    rw [LieRing.of_associative_ring_bracket, LieRing.of_associative_ring_bracket,
-      ← blockDiagonal_mul, ← blockDiagonal_mul, ← blockDiagonal_sub]
-    rfl
-
-@[simp]
-theorem glBlockDiagonal_apply (A : Matrix ι ι R) :
-    glBlockDiagonal R ι κ A = blockDiagonal fun _ : κ => A :=
-  (rfl)
-
-variable {R ι κ}
-
-/-- The block-diagonal map takes a matrix unit of `gl ι` to the sum, over the auxiliary coordinate,
-of the matrix units of `gl (ι × κ)` that move a cell from row `t` to row `s` and leave its column
-alone. -/
-theorem glBlockDiagonal_single (s t : ι) :
-    glBlockDiagonal R ι κ (single s t 1) = ∑ c : κ, single (s, c) (t, c) (1 : R) := by
-  ext p q
-  rw [glBlockDiagonal_apply, blockDiagonal_apply, Matrix.sum_apply]
-  by_cases hpq : p.2 = q.2
-  · rw [ite_eq_left hpq, Finset.sum_eq_single p.2]
-    · simp [single_apply, Prod.ext_iff, hpq, eq_comm]
-    · intro c _ hc
-      refine Matrix.single_apply_of_ne _ _ _ _ _ ?_
-      rintro ⟨hp, -⟩
-      exact hc (congrArg Prod.snd hp)
-    · exact fun hc => absurd (Finset.mem_univ p.2) hc
-  · rw [ite_eq_right hpq]
-    refine (Finset.sum_eq_zero fun c _ => Matrix.single_apply_of_ne _ _ _ _ _ ?_).symm
-    rintro ⟨hp, hq⟩
-    have hcp : c = p.2 := congrArg Prod.snd hp
-    have hcq : c = q.2 := congrArg Prod.snd hq
-    exact hpq (hcp.symm.trans hcq)
-
-/-! ### The `gl ι`-module structure on exterior powers of `ι × κ → R` -/
-
-variable (R ι κ) in
-/-- The bracket of `gl ι` on an exterior power of `ι × κ → R`, pulled back along the block-diagonal
-map from the standard `gl (ι × κ)`-action. -/
-noncomputable scoped instance glBlockDiagonalLieRingModule (N : ℕ) :
-    LieRingModule (Matrix ι ι R) (⋀[R]^N (ι × κ → R)) :=
-  LieRingModule.compLieHom _ (glBlockDiagonal R ι κ)
-
-variable (R ι κ) in
-/-- The compatibility of that bracket with the `R`-module structures, making an exterior power of
-`ι × κ → R` a `gl ι`-module over `R`. -/
-noncomputable scoped instance glBlockDiagonalLieModule (N : ℕ) :
-    LieModule R (Matrix ι ι R) (⋀[R]^N (ι × κ → R)) :=
-  LieModule.compLieHom _ (glBlockDiagonal R ι κ)
-
-/-- The `gl ι`-action on an exterior power of `ι × κ → R` is the `gl (ι × κ)`-action of the
-block-diagonal image. -/
-theorem gl_lie_blockDiagonal_def {N : ℕ} (A : Matrix ι ι R) (x : ⋀[R]^N (ι × κ → R)) :
-    ⁅A, x⁆ = ⁅glBlockDiagonal R ι κ A, x⁆ :=
-  LieRingModule.compLieHom_apply _ _ _ _
-
-/-- A matrix unit of `gl ι` acts on an exterior power of `ι × κ → R` as the sum, over the auxiliary
-coordinate, of the matrix units of `gl (ι × κ)` it is built from. -/
-theorem gl_lie_single {N : ℕ} (s t : ι) (x : ⋀[R]^N (ι × κ → R)) :
-    ⁅(single s t 1 : Matrix ι ι R), x⁆
-      = ∑ c : κ, ⁅(single (s, c) (t, c) 1 : Matrix (ι × κ) (ι × κ) R), x⁆ := by
-  rw [gl_lie_blockDiagonal_def, glBlockDiagonal_single, sum_lie]
-
-end BlockDiagonal
-
-/-! ### Ordering the cells -/
-
-/-- The lexicographic order on `ι × κ`, transported from `ι ×ₗ κ`. It is used only to fix the order
-in which the basis vectors indexed by a finite set of cells are wedged together. -/
-@[instance_reducible]
-def prodLexLinearOrder {ι κ : Type*} [LinearOrder ι] [LinearOrder κ] : LinearOrder (ι × κ) :=
-  LinearOrder.lift' (⇑(toLex : (ι × κ) ≃ ι ×ₗ κ)) (Equiv.injective _)
-
-/-! ### Row lower closed sets of cells give highest weight vectors -/
+/-! ### Row lower sets of cells give highest weight vectors -/
 
 section Wedge
 
@@ -191,7 +97,9 @@ variable {R : Type*} [CommRing R]
 variable {ι : Type*} [Fintype ι] [LinearOrder ι]
 variable {κ : Type*} [Fintype κ] [LinearOrder κ]
 
-attribute [local instance] prodLexLinearOrder
+/-- The local lexicographic order fixes the order of the wedge factors. -/
+local instance : LinearOrder (ι × κ) :=
+  LinearOrder.lift' (⇑(toLex : (ι × κ) ≃ ι ×ₗ κ)) (Equiv.injective _)
 
 open CellDiagram
 
@@ -204,24 +112,25 @@ theorem gl_lie_single_self_basisWedge {N : ℕ} (D : Finset (ι × κ)) (h : D.c
   simp only [lie_single_self_basisWedge, ← Finset.sum_smul, Finset.sum_boole]
   rw [rowLen_eq_card_filter_mem]
 
-/-- The raising matrix units annihilate the wedge of a row lower closed set of cells: moving a cell
+/-- The raising matrix units annihilate the wedge of a row lower set of cells: moving a cell
 up lands on a cell that is already there, so every summand has a repeated factor. -/
-theorem gl_lie_single_basisWedge_of_lt {N : ℕ} {D : Finset (ι × κ)} (h : D.card = N)
-    (hD : IsRowLowerClosed D) {s t : ι} (hst : s < t) :
+theorem gl_lie_single_basisWedge_eq_zero_of_isRowLowerSet_of_lt {N : ℕ}
+    {D : Finset (ι × κ)} (h : D.card = N) (hD : IsRowLowerSet D) {s t : ι} (hst : s < t) :
     ⁅(single s t 1 : Matrix ι ι R), basisWedge R D h⁆ = 0 := by
   rw [gl_lie_single]
   refine Finset.sum_eq_zero fun c _ => ?_
-  refine lie_single_basisWedge_of_ne D h (fun hc => hst.ne (congrArg Prod.fst hc)) fun hmem => ?_
-  exact isRowLowerClosed_iff.1 hD _ hmem s hst
+  refine lie_single_basisWedge_eq_zero_of_ne_of_mem_imp_mem D h
+    (fun hc => hst.ne (congrArg Prod.fst hc)) fun hmem => ?_
+  exact isRowLowerSet_iff.1 hD _ hmem s hst
 
-/-- **The wedge of a row lower closed set of cells is a highest weight vector** for `gl ι`, of
+/-- **The wedge of a row lower set of cells is a highest weight vector** for `gl ι`, of
 weight the row lengths of the set. -/
 theorem isGlHighestWeightVector_basisWedge [Nontrivial R] {N : ℕ} {D : Finset (ι × κ)}
-    (h : D.card = N) (hD : IsRowLowerClosed D) :
+    (h : D.card = N) (hD : IsRowLowerSet D) :
     IsGlHighestWeightVector (fun i => (rowLen D i : R)) (basisWedge R D h) :=
   isGlHighestWeightVector_iff.mpr ⟨basisWedge_ne_zero D h,
     fun i => gl_lie_single_self_basisWedge D h i,
-    fun _ _ hst => gl_lie_single_basisWedge_of_lt h hD hst⟩
+    fun _ _ hst => gl_lie_single_basisWedge_eq_zero_of_isRowLowerSet_of_lt h hD hst⟩
 
 end Wedge
 
@@ -232,7 +141,9 @@ section YoungDiagram
 variable {R : Type*} [CommRing R]
 variable {ι : Type*} [Fintype ι] [LinearOrder ι]
 
-attribute [local instance] prodLexLinearOrder
+/-- The local lexicographic order fixes the order of the wedge factors. -/
+local instance {m : ℕ} : LinearOrder (ι × Fin m) :=
+  LinearOrder.lift' (⇑(toLex : (ι × Fin m) ≃ ι ×ₗ Fin m)) (Equiv.injective _)
 
 open CellDiagram
 
@@ -241,11 +152,11 @@ prescribes.** Its exterior degree is the size `∑ i, a i` of the diagram. -/
 theorem isGlHighestWeightVector_basisWedge_ofRowLens [Nontrivial R] {a : ι → ℕ} (ha : Antitone a)
     {m : ℕ} (hm : ∀ i, a i ≤ m) :
     IsGlHighestWeightVector (fun i => (a i : R))
-      (basisWedge R (ofRowLens a m) (card_ofRowLens hm)) := by
+      (basisWedge R (ofRowLens a m) (card_ofRowLens_of_le hm)) := by
   have hweight : (fun i => ((rowLen (ofRowLens a m) i : ℕ) : R)) = fun i => ((a i : ℕ) : R) :=
-    funext fun i => by rw [rowLen_ofRowLens hm]
+    funext fun i => by rw [rowLen_ofRowLens_of_le hm]
   rw [← hweight]
-  exact isGlHighestWeightVector_basisWedge _ (isRowLowerClosed_ofRowLens ha m)
+  exact isGlHighestWeightVector_basisWedge _ (isRowLowerSet_ofRowLens ha m)
 
 /-- **Every weakly decreasing tuple of natural numbers is a highest weight** of `gl ι`: it is the
 weight of a highest weight vector in the exterior power `⋀^|a| (ι × Fin |a| → R)` of the standard

--- a/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
@@ -29,8 +29,8 @@ For a finite set of cells `D ⊆ ι × κ` the wedge `exteriorPower.basisWedge R
 basis vectors `e_p`, `p ∈ D`, is then a weight vector for the diagonal: summing
 `exteriorPower.lie_single_self_basisWedge` over the columns, `Eₛₛ` scales the wedge by the number
 of cells of `D` in row `s`. And if `D` is a row lower set — containing with every cell the cells
-directly above it, which is exactly the shape of a Young diagram — then every raising operator
-`Eₛₜ` with `s < t` annihilates the wedge by
+directly above it, which is the closure in the row direction that the raising operators need —
+then every raising operator `Eₛₜ` with `s < t` annihilates the wedge by
 `exteriorPower.lie_single_basisWedge_eq_zero_of_ne_of_mem_imp_mem`, since moving a cell from row
 `t` up to row `s` lands on a cell already present.
 
@@ -60,8 +60,8 @@ weights with natural number entries, the existence input to that classification;
 ## Implementation notes
 
 `TauCeti.glBlockDiagonal` is the constant family map followed by `Matrix.blockDiagonalRingHom`,
-promoted to an `AlgHom`, and then viewed as a `LieHom`. It is not injective when `κ` is empty, so it
-is a map rather than an embedding.
+promoted to an `AlgHom`, and then viewed as a `LieHom`. It need not be injective when `κ` is empty,
+so it is a map rather than an embedding.
 
 A single-column diagram gives back the fundamental weights: for `κ` a singleton, the row lower
 set of the first `d` rows is the wedge `exteriorPower.firstBasisWedge`, transported along
@@ -70,9 +70,11 @@ and it is the second coordinate — absent there — that lets a row be repeated
 general weakly decreasing tuple needs.
 
 The cells of a diagram are wedged together in the order `exteriorPower.basisWedge` reads off the
-linear order on `ι × κ`; the lexicographic one is used, as a local instance, purely to fix that
-order. Nothing below depends on the choice: a different order permutes the factors and changes the
-wedge by a sign, which affects neither being nonzero nor being a highest weight vector.
+linear order on `ι × κ`, and that order is a parameter of the results below: nothing depends on the
+choice, since a different order permutes the factors and changes the wedge by a sign, which affects
+neither being nonzero nor being a highest weight vector. Only
+`TauCeti.exists_isGlHighestWeightVector_natCast`, which has to produce a witness, picks one, and it
+picks the lexicographic order, supplied as a local instance.
 
 ## References
 
@@ -93,11 +95,7 @@ section Wedge
 
 variable {R : Type*} [CommRing R]
 variable {ι : Type*} [Fintype ι] [LinearOrder ι]
-variable {κ : Type*} [Fintype κ] [LinearOrder κ]
-
-/-- The local lexicographic order fixes the order of the wedge factors. -/
-local instance cellLinearOrder : LinearOrder (ι × κ) :=
-  LinearOrder.lift' (⇑(toLex : (ι × κ) ≃ ι ×ₗ κ)) (Equiv.injective _)
+variable {κ : Type*} [DecidableEq κ] [Fintype κ] [LinearOrder (ι × κ)]
 
 open CellDiagram
 
@@ -139,22 +137,23 @@ section YoungDiagram
 variable {R : Type*} [CommRing R]
 variable {ι : Type*} [Fintype ι] [LinearOrder ι]
 
-/-- The local lexicographic order fixes the order of the wedge factors. -/
-local instance cellFinLinearOrder {m : ℕ} : LinearOrder (ι × Fin m) :=
-  LinearOrder.lift' (⇑(toLex : (ι × Fin m) ≃ ι ×ₗ Fin m)) (Equiv.injective _)
-
 open CellDiagram
 
 /-- **The wedge of a Young diagram is a highest weight vector of the weight the diagram
 prescribes.** Its exterior degree is the size `∑ i, a i` of the diagram. -/
 theorem isGlHighestWeightVector_basisWedge_ofRowLens [Nontrivial R] {a : ι → ℕ} (ha : Antitone a)
-    {m : ℕ} (hm : ∀ i, a i ≤ m) :
+    {m : ℕ} [LinearOrder (ι × Fin m)] (hm : ∀ i, a i ≤ m) :
     IsGlHighestWeightVector (fun i => (a i : R))
       (basisWedge R (ofRowLens a m) (card_ofRowLens_of_le hm)) := by
   have hweight : (fun i => ((rowLen (ofRowLens a m) i : ℕ) : R)) = fun i => ((a i : ℕ) : R) :=
     funext fun i => by rw [rowLen_ofRowLens_of_le hm]
   rw [← hweight]
   exact isGlHighestWeightVector_basisWedge _ (isRowLowerSet_ofRowLens ha m)
+
+/-- The lexicographic order on the cells, used only to fix the order of the wedge factors in the
+existential witness below. -/
+local instance cellFinLinearOrder {m : ℕ} : LinearOrder (ι × Fin m) :=
+  LinearOrder.lift' (⇑(toLex : (ι × Fin m) ≃ ι ×ₗ Fin m)) (Equiv.injective _)
 
 /-- **Every weakly decreasing tuple of natural numbers is a highest weight** of `gl ι`: it is the
 weight of a highest weight vector in the exterior power `⋀^|a| (ι × Fin |a| → R)` of the standard

--- a/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
@@ -8,8 +8,6 @@ module
 public import TauCeti.Algebra.Lie.GeneralLinear.BlockDiagonal
 public import TauCeti.Combinatorics.Young.Cells
 
-import Mathlib.LinearAlgebra.ExteriorPower.Basis
-
 public section
 
 /-!

--- a/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
@@ -1,0 +1,425 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.GeneralLinear.ExteriorPower
+
+import Mathlib.LinearAlgebra.ExteriorPower.Basis
+
+public section
+
+/-!
+# Highest weight vectors of `gl ι` from Young diagrams
+
+Every weakly decreasing tuple of natural numbers is the weight of a highest weight vector in a
+finite-dimensional `gl ι`-module. The module is a single exterior power, and the vector is a wedge
+of standard basis vectors indexed by the cells of a Young diagram.
+
+## The construction
+
+Let `κ` index a second, auxiliary coordinate, so that `ι × κ → R` is the standard module of
+`gl (ι × κ)` and `gl ι` acts on it through the block-diagonal embedding `TauCeti.glBlockDiagonal`,
+which sends `A` to `Matrix.blockDiagonal fun _ : κ => A`. Concretely the matrix unit `Eₛₜ` sends
+the standard basis vector `e₍ₚ,ᵣ₎` to `e₍ₛ,ᵣ₎` when `t = p`, and to `0` otherwise: it moves a cell
+from row `t` to row `s` and leaves its column alone.
+
+For a finite set of cells `D ⊆ ι × κ` the wedge `TauCeti.glDiagramWedge R D` of the basis vectors
+`e_p`, `p ∈ D`, is then a weight vector for the diagonal: `Eₛₛ` fixes each of its factors lying in
+row `s` and kills the others, so it scales the wedge by the number of cells of `D` in row `s`. And
+if `D` is **row closed** — with every cell it contains the cells directly above it, which is
+exactly the shape of a Young diagram — the wedge is annihilated by every raising operator `Eₛₜ`
+with `s < t`: moving a cell from row `t` up to row `s` lands on a cell already present, so every
+summand of the Leibniz expansion is a wedge with a repeated factor.
+
+The weight read off this way is the row-count function of `D`. Taking `κ = Fin m` and `D` the Young
+diagram `{(i, c) | c < a i}` of a weakly decreasing `a : ι → ℕ`, the row counts are the `a i`
+themselves, which realizes `a` as a highest weight.
+
+## Main definitions
+
+* `TauCeti.glBlockDiagonal`: the block-diagonal embedding of `gl ι` in `gl (ι × κ)`, together
+  with the `gl ι`-module structure it induces on the exterior powers of `ι × κ → R`.
+* `TauCeti.glDiagramWedge`: the wedge of the standard basis vectors indexed by a finite set of
+  cells, and `TauCeti.rowCard`, the number of cells in a row.
+* `TauCeti.IsRowClosed`: the Young-diagram shape condition on a finite set of cells.
+* `TauCeti.youngCells`: the Young diagram of a tuple of row lengths, as a finite set of cells.
+
+## Main results
+
+* `TauCeti.isGlHighestWeightVector_glDiagramWedge`: **the wedge of a row-closed set of cells is a
+  highest weight vector**, of weight the row counts of the set.
+* `TauCeti.isGlHighestWeightVector_glDiagramWedge_youngCells` and
+  `TauCeti.exists_isGlHighestWeightVector_natCast`: **every weakly decreasing tuple of natural
+  numbers is a highest weight** of a finite-dimensional `gl ι`-module.
+
+## Roadmap context
+
+Layer 9 of the
+[highest weight roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieHighestWeight/README.md)
+asks for the finite-dimensional irreducible `gl n`-module of each dominant weight.
+`TauCeti.exists_isGlHighestWeightVector_natCast` supplies highest weight vectors for the dominant
+weights with natural number entries, the existence input to that classification;
+`TauCeti.nonempty_lieModuleEquiv_of_isGlHighestWeightVector` and
+`TauCeti.finrank_le_of_isGlHighestWeightVector` are the uniqueness half, already proved.
+
+## Implementation notes
+
+Mathlib's `YoungDiagram` is a set of cells in `ℕ × ℕ` closed downwards in *both* directions, and
+its rows are indexed by `ℕ`. The rows here are indexed by the abstract `gl` index type `ι`, and
+only closure in the row direction is needed — that is precisely what makes the raising operators
+act by zero — so the diagrams below are plain finite sets of cells with
+`TauCeti.IsRowClosed` imposed where it is used.
+
+`TauCeti.glBlockDiagonal` is the constant family map followed by `Matrix.blockDiagonalRingHom`,
+but it is packaged directly as a `LieHom` rather than through `AlgHom.toLieHom`, since only the
+multiplicativity lemma `Matrix.blockDiagonal_mul` is needed and no unit or `algebraMap` bookkeeping.
+
+A single-column diagram gives back the fundamental weights: for `κ` a singleton, the row-closed set
+of the first `d` rows is the wedge `exteriorPower.firstBasisWedge`, transported along
+`ι × κ ≃ ι`. The two are not literally the same declaration because the ambient index types differ,
+and it is the second coordinate — absent there — that lets a row be repeated, which is what a
+general weakly decreasing tuple needs.
+
+The cells of a diagram are wedged together in the order they receive from `Finset.orderEmbOfFin`,
+which needs a linear order on `ι × κ`; the lexicographic one is used, as a local instance, purely
+to fix that order, and `TauCeti.cellEmb` forgets it again. Nothing below depends on the choice: a
+different order permutes the factors and changes the wedge by a sign, which affects neither being
+nonzero nor being a highest weight vector.
+
+## References
+
+* R. Goodman, N. R. Wallach, *Symmetry, Representations, and Invariants*, GTM 255, §5.5 and §9.1,
+  where the modules of the classical groups are realized inside exterior powers of `Kⁿ ⊗ Kᵐ`.
+* W. Fulton, J. Harris, *Representation Theory: A First Course*, GTM 129, §15.5.
+-/
+
+namespace TauCeti
+
+open Matrix Module exteriorPower
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+/-! ### The block-diagonal embedding of `gl ι` in `gl (ι × κ)` -/
+
+section BlockDiagonal
+
+variable (R : Type*) [CommRing R]
+variable (ι : Type*) [DecidableEq ι] [Fintype ι]
+variable (κ : Type*) [DecidableEq κ] [Fintype κ]
+
+/-- The **block-diagonal embedding** of `gl ι` in `gl (ι × κ)`, sending a matrix `A` to the block
+diagonal matrix with `κ` copies of `A` down the diagonal. On the standard module `ι × κ → R` this
+is the action of `gl ι` on the first coordinate alone. -/
+def glBlockDiagonal : Matrix ι ι R →ₗ⁅R⁆ Matrix (ι × κ) (ι × κ) R where
+  toFun A := blockDiagonal fun _ : κ => A
+  map_add' A B := by rw [← blockDiagonal_add]; rfl
+  map_smul' c A := by rw [RingHom.id_apply, ← blockDiagonal_smul]; rfl
+  map_lie' {A B} := by
+    rw [LieRing.of_associative_ring_bracket, LieRing.of_associative_ring_bracket,
+      ← blockDiagonal_mul, ← blockDiagonal_mul, ← blockDiagonal_sub]
+    rfl
+
+@[simp]
+theorem glBlockDiagonal_apply (A : Matrix ι ι R) :
+    glBlockDiagonal R ι κ A = blockDiagonal fun _ : κ => A :=
+  (rfl)
+
+variable {R ι κ}
+
+/-- A matrix unit of `gl ι`, acting through the block-diagonal embedding, moves a cell of the
+standard basis of `ι × κ → R` from row `p.1` to row `s`. -/
+theorem glBlockDiagonal_single_mulVec_of_eq (s t : ι) {p : ι × κ} (h : t = p.1) :
+    glBlockDiagonal R ι κ (single s t 1) *ᵥ (Pi.single p 1 : ι × κ → R)
+      = Pi.single (s, p.2) 1 := by
+  subst h
+  ext q
+  simp only [glBlockDiagonal_apply, mulVec_single_one, Matrix.col_apply, blockDiagonal_apply,
+    single_apply, Pi.single_apply, Prod.ext_iff]
+  by_cases hq : q.2 = p.2
+  · by_cases hs : q.1 = s
+    · simp [hq, hs]
+    · simp [hq, hs, Ne.symm hs]
+  · simp [hq]
+
+/-- A matrix unit of `gl ι`, acting through the block-diagonal embedding, kills the cells of the
+standard basis of `ι × κ → R` lying outside its source row. -/
+theorem glBlockDiagonal_single_mulVec_of_ne (s t : ι) {p : ι × κ} (h : t ≠ p.1) :
+    glBlockDiagonal R ι κ (single s t 1) *ᵥ (Pi.single p 1 : ι × κ → R) = 0 := by
+  ext q
+  simp only [glBlockDiagonal_apply, mulVec_single_one, Matrix.col_apply, blockDiagonal_apply,
+    single_apply, Pi.zero_apply]
+  by_cases hq : q.2 = p.2 <;> simp [hq, h]
+
+/-! ### The `gl ι`-module structure on exterior powers of `ι × κ → R` -/
+
+variable (R ι κ) in
+/-- The `gl ι`-module structure on an exterior power of `ι × κ → R`, pulled back along the
+block-diagonal embedding from the standard `gl (ι × κ)`-action. -/
+noncomputable scoped instance glBlockDiagonalLieRingModule (N : ℕ) :
+    LieRingModule (Matrix ι ι R) (⋀[R]^N (ι × κ → R)) :=
+  LieRingModule.compLieHom _ (glBlockDiagonal R ι κ)
+
+variable (R ι κ) in
+/-- The `gl ι`-module structure on an exterior power of `ι × κ → R`, pulled back along the
+block-diagonal embedding from the standard `gl (ι × κ)`-action. -/
+noncomputable scoped instance glBlockDiagonalLieModule (N : ℕ) :
+    LieModule R (Matrix ι ι R) (⋀[R]^N (ι × κ → R)) :=
+  LieModule.compLieHom _ (glBlockDiagonal R ι κ)
+
+/-- The `gl ι`-action on an exterior power of `ι × κ → R` is the `gl (ι × κ)`-action of the
+block-diagonal image. -/
+theorem gl_lie_blockDiagonal_def {N : ℕ} (A : Matrix ι ι R) (x : ⋀[R]^N (ι × κ → R)) :
+    ⁅A, x⁆ = ⁅glBlockDiagonal R ι κ A, x⁆ :=
+  LieRingModule.compLieHom_apply _ _ _ _
+
+/-- A matrix of `gl ι` acts on a decomposable wedge in `⋀^N (ι × κ → R)` by acting on one factor at
+a time. -/
+theorem gl_lie_ιMulti {N : ℕ} (A : Matrix ι ι R) (v : Fin N → (ι × κ → R)) :
+    ⁅A, ιMulti R N v⁆ =
+      ∑ k : Fin N, ιMulti R N (Function.update v k (glBlockDiagonal R ι κ A *ᵥ v k)) := by
+  rw [gl_lie_blockDiagonal_def, gl_lie_def, glLieMap_apply_ιMulti]
+
+end BlockDiagonal
+
+/-! ### Enumerating a finite set of cells -/
+
+section Cells
+
+variable {ι κ : Type*} [LinearOrder ι] [LinearOrder κ]
+
+/-- The lexicographic order on cells. It is used only to enumerate a finite set of cells in a fixed
+order when wedging their basis vectors together. -/
+@[instance_reducible]
+def cellLinearOrder : LinearOrder (ι × κ) :=
+  LinearOrder.lift' (⇑(toLex : (ι × κ) ≃ ι ×ₗ κ)) (Equiv.injective _)
+
+attribute [local instance] cellLinearOrder
+
+/-- The enumeration of a finite set of cells in lexicographic order, in which their basis vectors
+are wedged together by `TauCeti.glDiagramWedge`. -/
+noncomputable def cellEmb (D : Finset (ι × κ)) : Fin D.card ↪ (ι × κ) :=
+  (D.orderEmbOfFin rfl).toEmbedding
+
+private theorem cellEmb_apply (D : Finset (ι × κ)) (k : Fin D.card) :
+    cellEmb D k = D.orderEmbOfFin rfl k :=
+  (rfl)
+
+@[simp]
+theorem cellEmb_mem (D : Finset (ι × κ)) (k : Fin D.card) : cellEmb D k ∈ D := by
+  rw [cellEmb_apply]
+  exact D.orderEmbOfFin_mem rfl k
+
+/-- Every cell of `D` is enumerated by `TauCeti.cellEmb`. -/
+theorem exists_cellEmb_eq {D : Finset (ι × κ)} {p : ι × κ} (hp : p ∈ D) :
+    ∃ k, cellEmb D k = p := by
+  have hrange : p ∈ Set.range (D.orderEmbOfFin rfl) := by
+    rw [Finset.range_orderEmbOfFin]
+    exact Finset.mem_coe.2 hp
+  obtain ⟨k, hk⟩ := hrange
+  exact ⟨k, (cellEmb_apply D k).trans hk⟩
+
+end Cells
+
+/-! ### The wedge of a set of cells -/
+
+section Wedge
+
+variable {R : Type*} [CommRing R]
+variable {ι : Type*} [Fintype ι] [LinearOrder ι]
+variable {κ : Type*} [Fintype κ] [LinearOrder κ]
+
+attribute [local instance] cellLinearOrder
+
+variable (R) in
+/-- The wedge of the standard basis vectors indexed by a finite set `D` of cells, an element of the
+`D.card`-th exterior power of `ι × κ → R`. -/
+noncomputable def glDiagramWedge (D : Finset (ι × κ)) : ⋀[R]^D.card (ι × κ → R) :=
+  ιMulti R D.card fun k => Pi.single (cellEmb D k) 1
+
+omit [Fintype ι] [Fintype κ] in
+/-- The wedge of a set of cells, unfolded. -/
+@[simp]
+theorem glDiagramWedge_eq_ιMulti (D : Finset (ι × κ)) :
+    glDiagramWedge R D = ιMulti R D.card fun k => Pi.single (cellEmb D k) 1 := by
+  rw [glDiagramWedge]
+
+omit [Fintype ι] [Fintype κ] in
+/-- The wedge of a set of cells is the member of the standard basis of the exterior power that the
+set indexes. -/
+theorem glDiagramWedge_eq_ιMulti_family [Finite ι] [Finite κ] (D : Finset (ι × κ)) :
+    glDiagramWedge R D
+      = ιMulti_family (I := ι × κ) R D.card (Pi.basisFun R (ι × κ)) ⟨D, rfl⟩ := by
+  rw [glDiagramWedge_eq_ιMulti, ιMulti_family]
+  refine congrArg (ιMulti R D.card) (funext fun k => ?_)
+  simp [Pi.basisFun_apply, cellEmb, Set.powersetCard.ofFinEmbEquiv_symm_apply]
+
+omit [Fintype ι] [Fintype κ] in
+/-- The wedge of a set of cells is nonzero. -/
+theorem glDiagramWedge_ne_zero [Nontrivial R] [Finite ι] [Finite κ] (D : Finset (ι × κ)) :
+    glDiagramWedge R D ≠ 0 := by
+  have h := (ιMulti_family_linearIndependent_ofBasis (I := ι × κ) R D.card
+    (Pi.basisFun R (ι × κ))).ne_zero (⟨D, rfl⟩ : ↥(Set.powersetCard (ι × κ) D.card))
+  rwa [glDiagramWedge_eq_ιMulti_family]
+
+/-! ### Row-closed sets of cells give highest weight vectors -/
+
+/-- The number of cells of `D` in row `i`. It is the `i`-th entry of the weight of
+`TauCeti.glDiagramWedge R D`. -/
+def rowCard (D : Finset (ι × κ)) (i : ι) : ℕ :=
+  (D.filter fun p => p.1 = i).card
+
+omit [Fintype ι] [Fintype κ] in
+private theorem card_filter_cellEmb_eq (D : Finset (ι × κ)) (i : ι) :
+    (Finset.univ.filter fun k => (cellEmb D k).1 = i).card = rowCard D i := by
+  rw [rowCard, ← Finset.card_image_of_injective _ (cellEmb D).injective]
+  refine congrArg Finset.card (Finset.ext fun p => ?_)
+  simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and]
+  refine ⟨?_, ?_⟩
+  · rintro ⟨k, hk, rfl⟩
+    exact ⟨cellEmb_mem D k, hk⟩
+  · rintro ⟨hp, hpi⟩
+    obtain ⟨k, rfl⟩ := exists_cellEmb_eq hp
+    exact ⟨k, hpi, rfl⟩
+
+/-- The diagonal matrix unit `Eᵢᵢ` scales the wedge of a set of cells by the number of cells the
+set has in row `i`. -/
+theorem lie_single_self_glDiagramWedge (D : Finset (ι × κ)) (i : ι) :
+    ⁅(single i i 1 : Matrix ι ι R), glDiagramWedge R D⁆ =
+      (rowCard D i : R) • glDiagramWedge R D := by
+  classical
+  rw [glDiagramWedge_eq_ιMulti, gl_lie_ιMulti,
+    ← Finset.sum_filter_add_sum_filter_not Finset.univ fun k => (cellEmb D k).1 = i]
+  have hmem : ∀ k ∈ Finset.univ.filter fun k => (cellEmb D k).1 = i,
+      ιMulti R D.card (Function.update (fun k => (Pi.single (cellEmb D k) 1 : ι × κ → R)) k
+          (glBlockDiagonal R ι κ (single i i 1) *ᵥ Pi.single (cellEmb D k) 1))
+        = ιMulti R D.card fun k => (Pi.single (cellEmb D k) 1 : ι × κ → R) := by
+    intro k hk
+    have hki : (cellEmb D k).1 = i := (Finset.mem_filter.1 hk).2
+    have hcell : ((i, (cellEmb D k).2) : ι × κ) = cellEmb D k := by rw [← hki]
+    rw [glBlockDiagonal_single_mulVec_of_eq i i hki.symm, hcell, Function.update_eq_self]
+  have hnotMem : ∀ k ∈ Finset.univ.filter fun k => ¬(cellEmb D k).1 = i,
+      ιMulti R D.card (Function.update (fun k => (Pi.single (cellEmb D k) 1 : ι × κ → R)) k
+          (glBlockDiagonal R ι κ (single i i 1) *ᵥ Pi.single (cellEmb D k) 1)) = 0 := by
+    intro k hk
+    rw [glBlockDiagonal_single_mulVec_of_ne i i fun h => (Finset.mem_filter.1 hk).2 h.symm]
+    exact (ιMulti R D.card).map_update_zero _ _
+  rw [Finset.sum_congr rfl hmem, Finset.sum_congr rfl hnotMem, Finset.sum_const_zero, add_zero,
+    Finset.sum_const, card_filter_cellEmb_eq, ← Nat.cast_smul_eq_nsmul R]
+
+/-- A set of cells is **row closed** when with every cell it contains all the cells directly above
+it: if `(j, c)` is a cell and `i < j`, then `(i, c)` is a cell. This is the shape condition on a
+Young diagram, and it is what makes the raising operators annihilate
+`TauCeti.glDiagramWedge R D`. -/
+def IsRowClosed (D : Finset (ι × κ)) : Prop :=
+  ∀ p ∈ D, ∀ i : ι, i < p.1 → (i, p.2) ∈ D
+
+/-- The raising matrix units annihilate the wedge of a row-closed set of cells: moving a cell up
+lands on a cell that is already there, so every summand has a repeated factor. -/
+theorem lie_single_glDiagramWedge_of_lt {D : Finset (ι × κ)} (hD : IsRowClosed D) {s t : ι}
+    (hst : s < t) : ⁅(single s t 1 : Matrix ι ι R), glDiagramWedge R D⁆ = 0 := by
+  classical
+  rw [glDiagramWedge_eq_ιMulti, gl_lie_ιMulti]
+  refine Finset.sum_eq_zero fun k _ => ?_
+  by_cases htk : t = (cellEmb D k).1
+  · obtain ⟨l, hl⟩ := exists_cellEmb_eq (hD _ (cellEmb_mem D k) s (htk ▸ hst))
+    have hlk : l ≠ k := by
+      rintro rfl
+      exact hst.ne' (htk.trans (congrArg Prod.fst hl))
+    rw [glBlockDiagonal_single_mulVec_of_eq s t htk]
+    refine (ιMulti R D.card).map_eq_zero_of_eq
+      (Function.update (fun k => (Pi.single (cellEmb D k) (1 : R) : ι × κ → R)) k
+        (Pi.single (s, (cellEmb D k).2) 1)) (i := l) (j := k) ?_ hlk
+    rw [Function.update_of_ne hlk, Function.update_self, hl]
+  · rw [glBlockDiagonal_single_mulVec_of_ne s t htk]
+    exact (ιMulti R D.card).map_update_zero _ _
+
+/-- **The wedge of a row-closed set of cells is a highest weight vector** for `gl ι`, of weight the
+row counts of the set. -/
+theorem isGlHighestWeightVector_glDiagramWedge [Nontrivial R] {D : Finset (ι × κ)}
+    (hD : IsRowClosed D) :
+    IsGlHighestWeightVector (fun i => (rowCard D i : R)) (glDiagramWedge R D) :=
+  isGlHighestWeightVector_iff.mpr ⟨glDiagramWedge_ne_zero D,
+    fun i => lie_single_self_glDiagramWedge D i,
+    fun _ _ hst => lie_single_glDiagramWedge_of_lt hD hst⟩
+
+end Wedge
+
+/-! ### Young diagrams -/
+
+section YoungDiagram
+
+variable {R : Type*} [CommRing R]
+variable {ι : Type*} [Fintype ι] [LinearOrder ι]
+
+attribute [local instance] cellLinearOrder
+
+/-- The **Young diagram** of a tuple `a : ι → ℕ` of row lengths, as the set of cells `(i, c)` whose
+column index `c` is smaller than the `i`-th row length. -/
+def youngCells (a : ι → ℕ) (m : ℕ) : Finset (ι × Fin m) :=
+  Finset.univ.filter fun p => (p.2 : ℕ) < a p.1
+
+omit [LinearOrder ι] in
+@[simp]
+theorem mem_youngCells_iff {a : ι → ℕ} {m : ℕ} {p : ι × Fin m} :
+    p ∈ youngCells a m ↔ (p.2 : ℕ) < a p.1 := by
+  simp [youngCells]
+
+/-- A Young diagram is row closed exactly because its row lengths are weakly decreasing. -/
+theorem isRowClosed_youngCells {a : ι → ℕ} (ha : Antitone a) (m : ℕ) :
+    IsRowClosed (youngCells a m) := by
+  intro p hp i hi
+  have hlt : (p.2 : ℕ) < a p.1 := mem_youngCells_iff.1 hp
+  exact mem_youngCells_iff.2 (lt_of_lt_of_le hlt (ha hi.le))
+
+/-- The rows of the Young diagram of `a` have the lengths `a` prescribes, as soon as the diagram is
+wide enough to hold them. -/
+theorem rowCard_youngCells {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) (i : ι) :
+    rowCard (youngCells a m) i = a i := by
+  classical
+  have himage : (youngCells a m).filter (fun p => p.1 = i)
+      = Finset.univ.image fun c : Fin (a i) => ((i, Fin.castLE (hm i) c) : ι × Fin m) := by
+    refine Finset.ext fun p => ?_
+    simp only [Finset.mem_filter, Finset.mem_image, Finset.mem_univ, true_and, mem_youngCells_iff]
+    refine ⟨?_, ?_⟩
+    · rintro ⟨hlt, rfl⟩
+      exact ⟨⟨p.2, hlt⟩, by simp⟩
+    · rintro ⟨c, rfl⟩
+      exact ⟨c.isLt, rfl⟩
+  rw [rowCard, himage, Finset.card_image_of_injective _ fun c d h =>
+      Fin.castLE_injective (hm i) (congrArg Prod.snd h),
+    Finset.card_univ, Fintype.card_fin]
+
+/-- The Young diagram of `a` has one cell for each unit of each row length. -/
+theorem card_youngCells {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) :
+    (youngCells a m).card = ∑ i, a i := by
+  classical
+  rw [Finset.card_eq_sum_card_fiberwise (f := fun p : ι × Fin m => p.1) (t := Finset.univ)
+    fun _ _ => Finset.mem_univ _]
+  exact Finset.sum_congr rfl fun i _ => rowCard_youngCells hm i
+
+/-- **The wedge of a Young diagram is a highest weight vector of the weight the diagram
+prescribes.** -/
+theorem isGlHighestWeightVector_glDiagramWedge_youngCells [Nontrivial R] {a : ι → ℕ}
+    (ha : Antitone a) {m : ℕ} (hm : ∀ i, a i ≤ m) :
+    IsGlHighestWeightVector (fun i => (a i : R)) (glDiagramWedge R (youngCells a m)) := by
+  have hweight : (fun i => ((rowCard (youngCells a m) i : ℕ) : R)) = fun i => ((a i : ℕ) : R) :=
+    funext fun i => by rw [rowCard_youngCells hm]
+  rw [← hweight]
+  exact isGlHighestWeightVector_glDiagramWedge (isRowClosed_youngCells ha m)
+
+/-- **Every weakly decreasing tuple of natural numbers is a highest weight** of `gl ι`: it is the
+weight of a highest weight vector in the exterior power `⋀^|a| (ι × Fin m → R)` of the standard
+module of `gl (ι × Fin m)`, which is a finite `R`-module by `exteriorPower.instFinite`. Its
+exterior degree is the size `∑ i, a i` of the Young diagram, by `TauCeti.card_youngCells`. -/
+theorem exists_isGlHighestWeightVector_natCast [Nontrivial R] {a : ι → ℕ} (ha : Antitone a)
+    {m : ℕ} (hm : ∀ i, a i ≤ m) :
+    ∃ v : ⋀[R]^((youngCells a m).card) (ι × Fin m → R),
+      IsGlHighestWeightVector (fun i => (a i : R)) v :=
+  ⟨_, isGlHighestWeightVector_glDiagramWedge_youngCells ha hm⟩
+
+end YoungDiagram
+
+end TauCeti

--- a/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
+++ b/TauCeti/Algebra/Lie/GeneralLinear/YoungWedge.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Algebra.Lie.GeneralLinear.ExteriorPower
+public import TauCeti.Combinatorics.Young.Cells
 
 import Mathlib.LinearAlgebra.ExteriorPower.Basis
 
@@ -15,45 +16,43 @@ public section
 # Highest weight vectors of `gl ι` from Young diagrams
 
 Every weakly decreasing tuple of natural numbers is the weight of a highest weight vector in a
-finite-dimensional `gl ι`-module. The module is a single exterior power, and the vector is a wedge
-of standard basis vectors indexed by the cells of a Young diagram.
+`gl ι`-module finite over the base ring. The module is a single exterior power, and the vector is
+a wedge of standard basis vectors indexed by the cells of a Young diagram.
 
 ## The construction
 
 Let `κ` index a second, auxiliary coordinate, so that `ι × κ → R` is the standard module of
-`gl (ι × κ)` and `gl ι` acts on it through the block-diagonal embedding `TauCeti.glBlockDiagonal`,
-which sends `A` to `Matrix.blockDiagonal fun _ : κ => A`. Concretely the matrix unit `Eₛₜ` sends
-the standard basis vector `e₍ₚ,ᵣ₎` to `e₍ₛ,ᵣ₎` when `t = p`, and to `0` otherwise: it moves a cell
-from row `t` to row `s` and leaves its column alone.
+`gl (ι × κ)` and `gl ι` acts on it through the block-diagonal map `TauCeti.glBlockDiagonal`, which
+sends `A` to `Matrix.blockDiagonal fun _ : κ => A`. Concretely the matrix unit `Eₛₜ` of `gl ι` goes
+to the sum `∑ c, E₍ₛ,c₎₍ₜ,c₎` of the matrix units of `gl (ι × κ)` that move a cell from row `t` to
+row `s` and leave its column alone (`TauCeti.glBlockDiagonal_single`).
 
-For a finite set of cells `D ⊆ ι × κ` the wedge `TauCeti.glDiagramWedge R D` of the basis vectors
-`e_p`, `p ∈ D`, is then a weight vector for the diagonal: `Eₛₛ` fixes each of its factors lying in
-row `s` and kills the others, so it scales the wedge by the number of cells of `D` in row `s`. And
-if `D` is **row closed** — with every cell it contains the cells directly above it, which is
-exactly the shape of a Young diagram — the wedge is annihilated by every raising operator `Eₛₜ`
-with `s < t`: moving a cell from row `t` up to row `s` lands on a cell already present, so every
-summand of the Leibniz expansion is a wedge with a repeated factor.
+For a finite set of cells `D ⊆ ι × κ` the wedge `exteriorPower.basisWedge R D` of the standard
+basis vectors `e_p`, `p ∈ D`, is then a weight vector for the diagonal: summing
+`exteriorPower.lie_single_self_basisWedge` over the columns, `Eₛₛ` scales the wedge by the number
+of cells of `D` in row `s`. And if `D` is row lower closed — containing with every cell the cells
+directly above it, which is exactly the shape of a Young diagram — then every raising operator
+`Eₛₜ` with `s < t` annihilates the wedge by `exteriorPower.lie_single_basisWedge_of_ne`, since
+moving a cell from row `t` up to row `s` lands on a cell already present.
 
-The weight read off this way is the row-count function of `D`. Taking `κ = Fin m` and `D` the Young
-diagram `{(i, c) | c < a i}` of a weakly decreasing `a : ι → ℕ`, the row counts are the `a i`
-themselves, which realizes `a` as a highest weight.
+The weight read off this way is the row-length function of `D`. Taking `κ = Fin m` and `D` the
+Young diagram `TauCeti.CellDiagram.ofRowLens a m` of a weakly decreasing `a : ι → ℕ`, the row
+lengths are the `a i` themselves, which realizes `a` as a highest weight.
 
 ## Main definitions
 
-* `TauCeti.glBlockDiagonal`: the block-diagonal embedding of `gl ι` in `gl (ι × κ)`, together
-  with the `gl ι`-module structure it induces on the exterior powers of `ι × κ → R`.
-* `TauCeti.glDiagramWedge`: the wedge of the standard basis vectors indexed by a finite set of
-  cells, and `TauCeti.rowCard`, the number of cells in a row.
-* `TauCeti.IsRowClosed`: the Young-diagram shape condition on a finite set of cells.
-* `TauCeti.youngCells`: the Young diagram of a tuple of row lengths, as a finite set of cells.
+* `TauCeti.glBlockDiagonal`: the block-diagonal map from `gl ι` to `gl (ι × κ)`, together with the
+  `gl ι`-module structure it induces on the exterior powers of `ι × κ → R`.
+* `TauCeti.prodLexLinearOrder`: the lexicographic order on `ι × κ`, which fixes the order in which
+  the basis vectors of a set of cells are wedged together.
 
 ## Main results
 
-* `TauCeti.isGlHighestWeightVector_glDiagramWedge`: **the wedge of a row-closed set of cells is a
-  highest weight vector**, of weight the row counts of the set.
-* `TauCeti.isGlHighestWeightVector_glDiagramWedge_youngCells` and
+* `TauCeti.isGlHighestWeightVector_basisWedge`: **the wedge of a row lower closed set of cells is a
+  highest weight vector**, of weight the row lengths of the set.
+* `TauCeti.isGlHighestWeightVector_basisWedge_ofRowLens` and
   `TauCeti.exists_isGlHighestWeightVector_natCast`: **every weakly decreasing tuple of natural
-  numbers is a highest weight** of a finite-dimensional `gl ι`-module.
+  numbers is a highest weight** of a `gl ι`-module finite over `R`.
 
 ## Roadmap context
 
@@ -67,27 +66,21 @@ weights with natural number entries, the existence input to that classification;
 
 ## Implementation notes
 
-Mathlib's `YoungDiagram` is a set of cells in `ℕ × ℕ` closed downwards in *both* directions, and
-its rows are indexed by `ℕ`. The rows here are indexed by the abstract `gl` index type `ι`, and
-only closure in the row direction is needed — that is precisely what makes the raising operators
-act by zero — so the diagrams below are plain finite sets of cells with
-`TauCeti.IsRowClosed` imposed where it is used.
-
 `TauCeti.glBlockDiagonal` is the constant family map followed by `Matrix.blockDiagonalRingHom`,
 but it is packaged directly as a `LieHom` rather than through `AlgHom.toLieHom`, since only the
 multiplicativity lemma `Matrix.blockDiagonal_mul` is needed and no unit or `algebraMap` bookkeeping.
+It is not injective when `κ` is empty, so it is a map rather than an embedding.
 
-A single-column diagram gives back the fundamental weights: for `κ` a singleton, the row-closed set
-of the first `d` rows is the wedge `exteriorPower.firstBasisWedge`, transported along
+A single-column diagram gives back the fundamental weights: for `κ` a singleton, the row lower
+closed set of the first `d` rows is the wedge `exteriorPower.firstBasisWedge`, transported along
 `ι × κ ≃ ι`. The two are not literally the same declaration because the ambient index types differ,
 and it is the second coordinate — absent there — that lets a row be repeated, which is what a
 general weakly decreasing tuple needs.
 
-The cells of a diagram are wedged together in the order they receive from `Finset.orderEmbOfFin`,
-which needs a linear order on `ι × κ`; the lexicographic one is used, as a local instance, purely
-to fix that order, and `TauCeti.cellEmb` forgets it again. Nothing below depends on the choice: a
-different order permutes the factors and changes the wedge by a sign, which affects neither being
-nonzero nor being a highest weight vector.
+The cells of a diagram are wedged together in the order `exteriorPower.basisWedge` reads off the
+linear order on `ι × κ`; the lexicographic one is used, as a local instance, purely to fix that
+order. Nothing below depends on the choice: a different order permutes the factors and changes the
+wedge by a sign, which affects neither being nonzero nor being a highest weight vector.
 
 ## References
 
@@ -102,7 +95,7 @@ open Matrix Module exteriorPower
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
-/-! ### The block-diagonal embedding of `gl ι` in `gl (ι × κ)` -/
+/-! ### The block-diagonal map from `gl ι` to `gl (ι × κ)` -/
 
 section BlockDiagonal
 
@@ -110,7 +103,7 @@ variable (R : Type*) [CommRing R]
 variable (ι : Type*) [DecidableEq ι] [Fintype ι]
 variable (κ : Type*) [DecidableEq κ] [Fintype κ]
 
-/-- The **block-diagonal embedding** of `gl ι` in `gl (ι × κ)`, sending a matrix `A` to the block
+/-- The **block-diagonal map** from `gl ι` to `gl (ι × κ)`, sending a matrix `A` to the block
 diagonal matrix with `κ` copies of `A` down the diagonal. On the standard module `ι × κ → R` this
 is the action of `gl ι` on the first coordinate alone. -/
 def glBlockDiagonal : Matrix ι ι R →ₗ⁅R⁆ Matrix (ι × κ) (ι × κ) R where
@@ -129,42 +122,40 @@ theorem glBlockDiagonal_apply (A : Matrix ι ι R) :
 
 variable {R ι κ}
 
-/-- A matrix unit of `gl ι`, acting through the block-diagonal embedding, moves a cell of the
-standard basis of `ι × κ → R` from row `p.1` to row `s`. -/
-theorem glBlockDiagonal_single_mulVec_of_eq (s t : ι) {p : ι × κ} (h : t = p.1) :
-    glBlockDiagonal R ι κ (single s t 1) *ᵥ (Pi.single p 1 : ι × κ → R)
-      = Pi.single (s, p.2) 1 := by
-  subst h
-  ext q
-  simp only [glBlockDiagonal_apply, mulVec_single_one, Matrix.col_apply, blockDiagonal_apply,
-    single_apply, Pi.single_apply, Prod.ext_iff]
-  by_cases hq : q.2 = p.2
-  · by_cases hs : q.1 = s
-    · simp [hq, hs]
-    · simp [hq, hs, Ne.symm hs]
-  · simp [hq]
-
-/-- A matrix unit of `gl ι`, acting through the block-diagonal embedding, kills the cells of the
-standard basis of `ι × κ → R` lying outside its source row. -/
-theorem glBlockDiagonal_single_mulVec_of_ne (s t : ι) {p : ι × κ} (h : t ≠ p.1) :
-    glBlockDiagonal R ι κ (single s t 1) *ᵥ (Pi.single p 1 : ι × κ → R) = 0 := by
-  ext q
-  simp only [glBlockDiagonal_apply, mulVec_single_one, Matrix.col_apply, blockDiagonal_apply,
-    single_apply, Pi.zero_apply]
-  by_cases hq : q.2 = p.2 <;> simp [hq, h]
+/-- The block-diagonal map takes a matrix unit of `gl ι` to the sum, over the auxiliary coordinate,
+of the matrix units of `gl (ι × κ)` that move a cell from row `t` to row `s` and leave its column
+alone. -/
+theorem glBlockDiagonal_single (s t : ι) :
+    glBlockDiagonal R ι κ (single s t 1) = ∑ c : κ, single (s, c) (t, c) (1 : R) := by
+  ext p q
+  rw [glBlockDiagonal_apply, blockDiagonal_apply, Matrix.sum_apply]
+  by_cases hpq : p.2 = q.2
+  · rw [ite_eq_left hpq, Finset.sum_eq_single p.2]
+    · simp [single_apply, Prod.ext_iff, hpq, eq_comm]
+    · intro c _ hc
+      refine Matrix.single_apply_of_ne _ _ _ _ _ ?_
+      rintro ⟨hp, -⟩
+      exact hc (congrArg Prod.snd hp)
+    · exact fun hc => absurd (Finset.mem_univ p.2) hc
+  · rw [ite_eq_right hpq]
+    refine (Finset.sum_eq_zero fun c _ => Matrix.single_apply_of_ne _ _ _ _ _ ?_).symm
+    rintro ⟨hp, hq⟩
+    have hcp : c = p.2 := congrArg Prod.snd hp
+    have hcq : c = q.2 := congrArg Prod.snd hq
+    exact hpq (hcp.symm.trans hcq)
 
 /-! ### The `gl ι`-module structure on exterior powers of `ι × κ → R` -/
 
 variable (R ι κ) in
-/-- The `gl ι`-module structure on an exterior power of `ι × κ → R`, pulled back along the
-block-diagonal embedding from the standard `gl (ι × κ)`-action. -/
+/-- The bracket of `gl ι` on an exterior power of `ι × κ → R`, pulled back along the block-diagonal
+map from the standard `gl (ι × κ)`-action. -/
 noncomputable scoped instance glBlockDiagonalLieRingModule (N : ℕ) :
     LieRingModule (Matrix ι ι R) (⋀[R]^N (ι × κ → R)) :=
   LieRingModule.compLieHom _ (glBlockDiagonal R ι κ)
 
 variable (R ι κ) in
-/-- The `gl ι`-module structure on an exterior power of `ι × κ → R`, pulled back along the
-block-diagonal embedding from the standard `gl (ι × κ)`-action. -/
+/-- The compatibility of that bracket with the `R`-module structures, making an exterior power of
+`ι × κ → R` a `gl ι`-module over `R`. -/
 noncomputable scoped instance glBlockDiagonalLieModule (N : ℕ) :
     LieModule R (Matrix ι ι R) (⋀[R]^N (ι × κ → R)) :=
   LieModule.compLieHom _ (glBlockDiagonal R ι κ)
@@ -175,55 +166,24 @@ theorem gl_lie_blockDiagonal_def {N : ℕ} (A : Matrix ι ι R) (x : ⋀[R]^N (�
     ⁅A, x⁆ = ⁅glBlockDiagonal R ι κ A, x⁆ :=
   LieRingModule.compLieHom_apply _ _ _ _
 
-/-- A matrix of `gl ι` acts on a decomposable wedge in `⋀^N (ι × κ → R)` by acting on one factor at
-a time. -/
-theorem gl_lie_ιMulti {N : ℕ} (A : Matrix ι ι R) (v : Fin N → (ι × κ → R)) :
-    ⁅A, ιMulti R N v⁆ =
-      ∑ k : Fin N, ιMulti R N (Function.update v k (glBlockDiagonal R ι κ A *ᵥ v k)) := by
-  rw [gl_lie_blockDiagonal_def, gl_lie_def, glLieMap_apply_ιMulti]
+/-- A matrix unit of `gl ι` acts on an exterior power of `ι × κ → R` as the sum, over the auxiliary
+coordinate, of the matrix units of `gl (ι × κ)` it is built from. -/
+theorem gl_lie_single {N : ℕ} (s t : ι) (x : ⋀[R]^N (ι × κ → R)) :
+    ⁅(single s t 1 : Matrix ι ι R), x⁆
+      = ∑ c : κ, ⁅(single (s, c) (t, c) 1 : Matrix (ι × κ) (ι × κ) R), x⁆ := by
+  rw [gl_lie_blockDiagonal_def, glBlockDiagonal_single, sum_lie]
 
 end BlockDiagonal
 
-/-! ### Enumerating a finite set of cells -/
+/-! ### Ordering the cells -/
 
-section Cells
-
-variable {ι κ : Type*} [LinearOrder ι] [LinearOrder κ]
-
-/-- The lexicographic order on cells. It is used only to enumerate a finite set of cells in a fixed
-order when wedging their basis vectors together. -/
+/-- The lexicographic order on `ι × κ`, transported from `ι ×ₗ κ`. It is used only to fix the order
+in which the basis vectors indexed by a finite set of cells are wedged together. -/
 @[instance_reducible]
-def cellLinearOrder : LinearOrder (ι × κ) :=
+def prodLexLinearOrder {ι κ : Type*} [LinearOrder ι] [LinearOrder κ] : LinearOrder (ι × κ) :=
   LinearOrder.lift' (⇑(toLex : (ι × κ) ≃ ι ×ₗ κ)) (Equiv.injective _)
 
-attribute [local instance] cellLinearOrder
-
-/-- The enumeration of a finite set of cells in lexicographic order, in which their basis vectors
-are wedged together by `TauCeti.glDiagramWedge`. -/
-noncomputable def cellEmb (D : Finset (ι × κ)) : Fin D.card ↪ (ι × κ) :=
-  (D.orderEmbOfFin rfl).toEmbedding
-
-private theorem cellEmb_apply (D : Finset (ι × κ)) (k : Fin D.card) :
-    cellEmb D k = D.orderEmbOfFin rfl k :=
-  (rfl)
-
-@[simp]
-theorem cellEmb_mem (D : Finset (ι × κ)) (k : Fin D.card) : cellEmb D k ∈ D := by
-  rw [cellEmb_apply]
-  exact D.orderEmbOfFin_mem rfl k
-
-/-- Every cell of `D` is enumerated by `TauCeti.cellEmb`. -/
-theorem exists_cellEmb_eq {D : Finset (ι × κ)} {p : ι × κ} (hp : p ∈ D) :
-    ∃ k, cellEmb D k = p := by
-  have hrange : p ∈ Set.range (D.orderEmbOfFin rfl) := by
-    rw [Finset.range_orderEmbOfFin]
-    exact Finset.mem_coe.2 hp
-  obtain ⟨k, hk⟩ := hrange
-  exact ⟨k, (cellEmb_apply D k).trans hk⟩
-
-end Cells
-
-/-! ### The wedge of a set of cells -/
+/-! ### Row lower closed sets of cells give highest weight vectors -/
 
 section Wedge
 
@@ -231,119 +191,37 @@ variable {R : Type*} [CommRing R]
 variable {ι : Type*} [Fintype ι] [LinearOrder ι]
 variable {κ : Type*} [Fintype κ] [LinearOrder κ]
 
-attribute [local instance] cellLinearOrder
+attribute [local instance] prodLexLinearOrder
 
-variable (R) in
-/-- The wedge of the standard basis vectors indexed by a finite set `D` of cells, an element of the
-`D.card`-th exterior power of `ι × κ → R`. -/
-noncomputable def glDiagramWedge (D : Finset (ι × κ)) : ⋀[R]^D.card (ι × κ → R) :=
-  ιMulti R D.card fun k => Pi.single (cellEmb D k) 1
-
-omit [Fintype ι] [Fintype κ] in
-/-- The wedge of a set of cells, unfolded. -/
-@[simp]
-theorem glDiagramWedge_eq_ιMulti (D : Finset (ι × κ)) :
-    glDiagramWedge R D = ιMulti R D.card fun k => Pi.single (cellEmb D k) 1 := by
-  rw [glDiagramWedge]
-
-omit [Fintype ι] [Fintype κ] in
-/-- The wedge of a set of cells is the member of the standard basis of the exterior power that the
-set indexes. -/
-theorem glDiagramWedge_eq_ιMulti_family [Finite ι] [Finite κ] (D : Finset (ι × κ)) :
-    glDiagramWedge R D
-      = ιMulti_family (I := ι × κ) R D.card (Pi.basisFun R (ι × κ)) ⟨D, rfl⟩ := by
-  rw [glDiagramWedge_eq_ιMulti, ιMulti_family]
-  refine congrArg (ιMulti R D.card) (funext fun k => ?_)
-  simp [Pi.basisFun_apply, cellEmb, Set.powersetCard.ofFinEmbEquiv_symm_apply]
-
-omit [Fintype ι] [Fintype κ] in
-/-- The wedge of a set of cells is nonzero. -/
-theorem glDiagramWedge_ne_zero [Nontrivial R] [Finite ι] [Finite κ] (D : Finset (ι × κ)) :
-    glDiagramWedge R D ≠ 0 := by
-  have h := (ιMulti_family_linearIndependent_ofBasis (I := ι × κ) R D.card
-    (Pi.basisFun R (ι × κ))).ne_zero (⟨D, rfl⟩ : ↥(Set.powersetCard (ι × κ) D.card))
-  rwa [glDiagramWedge_eq_ιMulti_family]
-
-/-! ### Row-closed sets of cells give highest weight vectors -/
-
-/-- The number of cells of `D` in row `i`. It is the `i`-th entry of the weight of
-`TauCeti.glDiagramWedge R D`. -/
-def rowCard (D : Finset (ι × κ)) (i : ι) : ℕ :=
-  (D.filter fun p => p.1 = i).card
-
-omit [Fintype ι] [Fintype κ] in
-private theorem card_filter_cellEmb_eq (D : Finset (ι × κ)) (i : ι) :
-    (Finset.univ.filter fun k => (cellEmb D k).1 = i).card = rowCard D i := by
-  rw [rowCard, ← Finset.card_image_of_injective _ (cellEmb D).injective]
-  refine congrArg Finset.card (Finset.ext fun p => ?_)
-  simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and]
-  refine ⟨?_, ?_⟩
-  · rintro ⟨k, hk, rfl⟩
-    exact ⟨cellEmb_mem D k, hk⟩
-  · rintro ⟨hp, hpi⟩
-    obtain ⟨k, rfl⟩ := exists_cellEmb_eq hp
-    exact ⟨k, hpi, rfl⟩
+open CellDiagram
 
 /-- The diagonal matrix unit `Eᵢᵢ` scales the wedge of a set of cells by the number of cells the
 set has in row `i`. -/
-theorem lie_single_self_glDiagramWedge (D : Finset (ι × κ)) (i : ι) :
-    ⁅(single i i 1 : Matrix ι ι R), glDiagramWedge R D⁆ =
-      (rowCard D i : R) • glDiagramWedge R D := by
-  classical
-  rw [glDiagramWedge_eq_ιMulti, gl_lie_ιMulti,
-    ← Finset.sum_filter_add_sum_filter_not Finset.univ fun k => (cellEmb D k).1 = i]
-  have hmem : ∀ k ∈ Finset.univ.filter fun k => (cellEmb D k).1 = i,
-      ιMulti R D.card (Function.update (fun k => (Pi.single (cellEmb D k) 1 : ι × κ → R)) k
-          (glBlockDiagonal R ι κ (single i i 1) *ᵥ Pi.single (cellEmb D k) 1))
-        = ιMulti R D.card fun k => (Pi.single (cellEmb D k) 1 : ι × κ → R) := by
-    intro k hk
-    have hki : (cellEmb D k).1 = i := (Finset.mem_filter.1 hk).2
-    have hcell : ((i, (cellEmb D k).2) : ι × κ) = cellEmb D k := by rw [← hki]
-    rw [glBlockDiagonal_single_mulVec_of_eq i i hki.symm, hcell, Function.update_eq_self]
-  have hnotMem : ∀ k ∈ Finset.univ.filter fun k => ¬(cellEmb D k).1 = i,
-      ιMulti R D.card (Function.update (fun k => (Pi.single (cellEmb D k) 1 : ι × κ → R)) k
-          (glBlockDiagonal R ι κ (single i i 1) *ᵥ Pi.single (cellEmb D k) 1)) = 0 := by
-    intro k hk
-    rw [glBlockDiagonal_single_mulVec_of_ne i i fun h => (Finset.mem_filter.1 hk).2 h.symm]
-    exact (ιMulti R D.card).map_update_zero _ _
-  rw [Finset.sum_congr rfl hmem, Finset.sum_congr rfl hnotMem, Finset.sum_const_zero, add_zero,
-    Finset.sum_const, card_filter_cellEmb_eq, ← Nat.cast_smul_eq_nsmul R]
+@[simp]
+theorem gl_lie_single_self_basisWedge {N : ℕ} (D : Finset (ι × κ)) (h : D.card = N) (i : ι) :
+    ⁅(single i i 1 : Matrix ι ι R), basisWedge R D h⁆ = (rowLen D i : R) • basisWedge R D h := by
+  rw [gl_lie_single]
+  simp only [lie_single_self_basisWedge, ← Finset.sum_smul, Finset.sum_boole]
+  rw [rowLen_eq_card_filter_mem]
 
-/-- A set of cells is **row closed** when with every cell it contains all the cells directly above
-it: if `(j, c)` is a cell and `i < j`, then `(i, c)` is a cell. This is the shape condition on a
-Young diagram, and it is what makes the raising operators annihilate
-`TauCeti.glDiagramWedge R D`. -/
-def IsRowClosed (D : Finset (ι × κ)) : Prop :=
-  ∀ p ∈ D, ∀ i : ι, i < p.1 → (i, p.2) ∈ D
+/-- The raising matrix units annihilate the wedge of a row lower closed set of cells: moving a cell
+up lands on a cell that is already there, so every summand has a repeated factor. -/
+theorem gl_lie_single_basisWedge_of_lt {N : ℕ} {D : Finset (ι × κ)} (h : D.card = N)
+    (hD : IsRowLowerClosed D) {s t : ι} (hst : s < t) :
+    ⁅(single s t 1 : Matrix ι ι R), basisWedge R D h⁆ = 0 := by
+  rw [gl_lie_single]
+  refine Finset.sum_eq_zero fun c _ => ?_
+  refine lie_single_basisWedge_of_ne D h (fun hc => hst.ne (congrArg Prod.fst hc)) fun hmem => ?_
+  exact isRowLowerClosed_iff.1 hD _ hmem s hst
 
-/-- The raising matrix units annihilate the wedge of a row-closed set of cells: moving a cell up
-lands on a cell that is already there, so every summand has a repeated factor. -/
-theorem lie_single_glDiagramWedge_of_lt {D : Finset (ι × κ)} (hD : IsRowClosed D) {s t : ι}
-    (hst : s < t) : ⁅(single s t 1 : Matrix ι ι R), glDiagramWedge R D⁆ = 0 := by
-  classical
-  rw [glDiagramWedge_eq_ιMulti, gl_lie_ιMulti]
-  refine Finset.sum_eq_zero fun k _ => ?_
-  by_cases htk : t = (cellEmb D k).1
-  · obtain ⟨l, hl⟩ := exists_cellEmb_eq (hD _ (cellEmb_mem D k) s (htk ▸ hst))
-    have hlk : l ≠ k := by
-      rintro rfl
-      exact hst.ne' (htk.trans (congrArg Prod.fst hl))
-    rw [glBlockDiagonal_single_mulVec_of_eq s t htk]
-    refine (ιMulti R D.card).map_eq_zero_of_eq
-      (Function.update (fun k => (Pi.single (cellEmb D k) (1 : R) : ι × κ → R)) k
-        (Pi.single (s, (cellEmb D k).2) 1)) (i := l) (j := k) ?_ hlk
-    rw [Function.update_of_ne hlk, Function.update_self, hl]
-  · rw [glBlockDiagonal_single_mulVec_of_ne s t htk]
-    exact (ιMulti R D.card).map_update_zero _ _
-
-/-- **The wedge of a row-closed set of cells is a highest weight vector** for `gl ι`, of weight the
-row counts of the set. -/
-theorem isGlHighestWeightVector_glDiagramWedge [Nontrivial R] {D : Finset (ι × κ)}
-    (hD : IsRowClosed D) :
-    IsGlHighestWeightVector (fun i => (rowCard D i : R)) (glDiagramWedge R D) :=
-  isGlHighestWeightVector_iff.mpr ⟨glDiagramWedge_ne_zero D,
-    fun i => lie_single_self_glDiagramWedge D i,
-    fun _ _ hst => lie_single_glDiagramWedge_of_lt hD hst⟩
+/-- **The wedge of a row lower closed set of cells is a highest weight vector** for `gl ι`, of
+weight the row lengths of the set. -/
+theorem isGlHighestWeightVector_basisWedge [Nontrivial R] {N : ℕ} {D : Finset (ι × κ)}
+    (h : D.card = N) (hD : IsRowLowerClosed D) :
+    IsGlHighestWeightVector (fun i => (rowLen D i : R)) (basisWedge R D h) :=
+  isGlHighestWeightVector_iff.mpr ⟨basisWedge_ne_zero D h,
+    fun i => gl_lie_single_self_basisWedge D h i,
+    fun _ _ hst => gl_lie_single_basisWedge_of_lt h hD hst⟩
 
 end Wedge
 
@@ -354,71 +232,31 @@ section YoungDiagram
 variable {R : Type*} [CommRing R]
 variable {ι : Type*} [Fintype ι] [LinearOrder ι]
 
-attribute [local instance] cellLinearOrder
+attribute [local instance] prodLexLinearOrder
 
-/-- The **Young diagram** of a tuple `a : ι → ℕ` of row lengths, as the set of cells `(i, c)` whose
-column index `c` is smaller than the `i`-th row length. -/
-def youngCells (a : ι → ℕ) (m : ℕ) : Finset (ι × Fin m) :=
-  Finset.univ.filter fun p => (p.2 : ℕ) < a p.1
-
-omit [LinearOrder ι] in
-@[simp]
-theorem mem_youngCells_iff {a : ι → ℕ} {m : ℕ} {p : ι × Fin m} :
-    p ∈ youngCells a m ↔ (p.2 : ℕ) < a p.1 := by
-  simp [youngCells]
-
-/-- A Young diagram is row closed exactly because its row lengths are weakly decreasing. -/
-theorem isRowClosed_youngCells {a : ι → ℕ} (ha : Antitone a) (m : ℕ) :
-    IsRowClosed (youngCells a m) := by
-  intro p hp i hi
-  have hlt : (p.2 : ℕ) < a p.1 := mem_youngCells_iff.1 hp
-  exact mem_youngCells_iff.2 (lt_of_lt_of_le hlt (ha hi.le))
-
-/-- The rows of the Young diagram of `a` have the lengths `a` prescribes, as soon as the diagram is
-wide enough to hold them. -/
-theorem rowCard_youngCells {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) (i : ι) :
-    rowCard (youngCells a m) i = a i := by
-  classical
-  have himage : (youngCells a m).filter (fun p => p.1 = i)
-      = Finset.univ.image fun c : Fin (a i) => ((i, Fin.castLE (hm i) c) : ι × Fin m) := by
-    refine Finset.ext fun p => ?_
-    simp only [Finset.mem_filter, Finset.mem_image, Finset.mem_univ, true_and, mem_youngCells_iff]
-    refine ⟨?_, ?_⟩
-    · rintro ⟨hlt, rfl⟩
-      exact ⟨⟨p.2, hlt⟩, by simp⟩
-    · rintro ⟨c, rfl⟩
-      exact ⟨c.isLt, rfl⟩
-  rw [rowCard, himage, Finset.card_image_of_injective _ fun c d h =>
-      Fin.castLE_injective (hm i) (congrArg Prod.snd h),
-    Finset.card_univ, Fintype.card_fin]
-
-/-- The Young diagram of `a` has one cell for each unit of each row length. -/
-theorem card_youngCells {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) :
-    (youngCells a m).card = ∑ i, a i := by
-  classical
-  rw [Finset.card_eq_sum_card_fiberwise (f := fun p : ι × Fin m => p.1) (t := Finset.univ)
-    fun _ _ => Finset.mem_univ _]
-  exact Finset.sum_congr rfl fun i _ => rowCard_youngCells hm i
+open CellDiagram
 
 /-- **The wedge of a Young diagram is a highest weight vector of the weight the diagram
-prescribes.** -/
-theorem isGlHighestWeightVector_glDiagramWedge_youngCells [Nontrivial R] {a : ι → ℕ}
-    (ha : Antitone a) {m : ℕ} (hm : ∀ i, a i ≤ m) :
-    IsGlHighestWeightVector (fun i => (a i : R)) (glDiagramWedge R (youngCells a m)) := by
-  have hweight : (fun i => ((rowCard (youngCells a m) i : ℕ) : R)) = fun i => ((a i : ℕ) : R) :=
-    funext fun i => by rw [rowCard_youngCells hm]
+prescribes.** Its exterior degree is the size `∑ i, a i` of the diagram. -/
+theorem isGlHighestWeightVector_basisWedge_ofRowLens [Nontrivial R] {a : ι → ℕ} (ha : Antitone a)
+    {m : ℕ} (hm : ∀ i, a i ≤ m) :
+    IsGlHighestWeightVector (fun i => (a i : R))
+      (basisWedge R (ofRowLens a m) (card_ofRowLens hm)) := by
+  have hweight : (fun i => ((rowLen (ofRowLens a m) i : ℕ) : R)) = fun i => ((a i : ℕ) : R) :=
+    funext fun i => by rw [rowLen_ofRowLens hm]
   rw [← hweight]
-  exact isGlHighestWeightVector_glDiagramWedge (isRowClosed_youngCells ha m)
+  exact isGlHighestWeightVector_basisWedge _ (isRowLowerClosed_ofRowLens ha m)
 
 /-- **Every weakly decreasing tuple of natural numbers is a highest weight** of `gl ι`: it is the
-weight of a highest weight vector in the exterior power `⋀^|a| (ι × Fin m → R)` of the standard
-module of `gl (ι × Fin m)`, which is a finite `R`-module by `exteriorPower.instFinite`. Its
-exterior degree is the size `∑ i, a i` of the Young diagram, by `TauCeti.card_youngCells`. -/
-theorem exists_isGlHighestWeightVector_natCast [Nontrivial R] {a : ι → ℕ} (ha : Antitone a)
-    {m : ℕ} (hm : ∀ i, a i ≤ m) :
-    ∃ v : ⋀[R]^((youngCells a m).card) (ι × Fin m → R),
+weight of a highest weight vector in the exterior power `⋀^|a| (ι × Fin |a| → R)` of the standard
+module of `gl (ι × Fin |a|)`, where `|a| = ∑ i, a i`, a module finite over `R` by
+`exteriorPower.instFinite`. The auxiliary width is taken to be `|a|` itself, which is wide enough
+to hold every row. -/
+theorem exists_isGlHighestWeightVector_natCast [Nontrivial R] {a : ι → ℕ} (ha : Antitone a) :
+    ∃ v : ⋀[R]^(∑ i, a i) (ι × Fin (∑ i, a i) → R),
       IsGlHighestWeightVector (fun i => (a i : R)) v :=
-  ⟨_, isGlHighestWeightVector_glDiagramWedge_youngCells ha hm⟩
+  ⟨_, isGlHighestWeightVector_basisWedge_ofRowLens ha fun i =>
+    Finset.single_le_sum (f := a) (fun _ _ => Nat.zero_le _) (Finset.mem_univ i)⟩
 
 end YoungDiagram
 

--- a/TauCeti/Combinatorics/Young/Cells.lean
+++ b/TauCeti/Combinatorics/Young/Cells.lean
@@ -17,9 +17,8 @@ public section
 
 A finite set `D : Finset (ι × κ)` of **cells** has its rows indexed by `ι` and its columns indexed
 by `κ`. This file counts the cells of `D` one row at a time (`TauCeti.CellDiagram.rowLen`), imposes
-the shape condition that makes such a set look like a Young diagram
-(`TauCeti.CellDiagram.IsRowLowerSet`: with every cell, `D` contains the cells directly above it),
-and builds the set of cells lying under a prescribed tuple of row lengths
+closure in the row direction (`TauCeti.CellDiagram.IsRowLowerSet`: with every cell, `D` contains the
+cells directly above it), and builds the set of cells lying under a prescribed tuple of row lengths
 (`TauCeti.CellDiagram.ofRowLens`).
 
 ## Main definitions
@@ -89,7 +88,8 @@ end RowLen
 
 /-- A set of cells is a **row lower set** when with every cell it contains all the cells directly
 above it: if `(j, c)` is a cell and `i < j`, then `(i, c)` is a cell. In other words `D` is a lower
-set in its row index. This is the shape condition on a Young diagram. -/
+set in its row index. This is one of the two conditions on the shape of a Young diagram, the one in
+the row direction; closure in the column direction is not imposed. -/
 def IsRowLowerSet [LT ι] (D : Finset (ι × κ)) : Prop :=
   ∀ p ∈ D, ∀ i : ι, i < p.1 → (i, p.2) ∈ D
 

--- a/TauCeti/Combinatorics/Young/Cells.lean
+++ b/TauCeti/Combinatorics/Young/Cells.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import Mathlib.Data.Fintype.Prod
+public import Mathlib.Order.Monotone.Defs
+
+public section
+
+/-!
+# Finite sets of cells, closed in the row direction
+
+A finite set `D : Finset (ι × κ)` of **cells** has its rows indexed by `ι` and its columns indexed
+by `κ`. This file counts the cells of `D` one row at a time (`TauCeti.CellDiagram.rowLen`), imposes
+the shape condition that makes such a set look like a Young diagram
+(`TauCeti.CellDiagram.IsRowLowerClosed`: with every cell, `D` contains the cells directly above it),
+and builds the set of cells lying under a prescribed tuple of row lengths
+(`TauCeti.CellDiagram.ofRowLens`).
+
+## Main definitions
+
+* `TauCeti.CellDiagram.rowLen`: the number of cells of a set lying in a given row.
+* `TauCeti.CellDiagram.IsRowLowerClosed`: closure of a set of cells in the row direction.
+* `TauCeti.CellDiagram.ofRowLens`: the cells lying under a tuple of row lengths.
+
+## Main results
+
+* `TauCeti.CellDiagram.isRowLowerClosed_ofRowLens`: the cells under a weakly decreasing tuple of
+  row lengths are closed in the row direction.
+* `TauCeti.CellDiagram.rowLen_ofRowLens` and `TauCeti.CellDiagram.card_ofRowLens`: the rows of
+  those cells have the prescribed lengths, and there are `∑ i, a i` cells in all.
+
+## Implementation notes
+
+Mathlib's `YoungDiagram` is a set of cells in `ℕ × ℕ` closed downwards in *both* directions, and
+its rows are indexed by `ℕ`. The rows here are indexed by an abstract type `ι`, and only closure in
+the row direction is imposed, because that is the condition the consumers need: it is exactly what
+makes the raising operators of `gl ι` annihilate the wedge of the basis vectors indexed by the
+cells, in `TauCeti.isGlHighestWeightVector_basisWedge`.
+-/
+
+namespace TauCeti.CellDiagram
+
+variable {ι κ : Type*}
+
+/-! ### Counting the cells of a row -/
+
+section RowLen
+
+variable [DecidableEq ι]
+
+/-- The number of cells of `D` lying in row `i`. -/
+def rowLen (D : Finset (ι × κ)) (i : ι) : ℕ :=
+  (D.filter fun p => p.1 = i).card
+
+/-- `TauCeti.CellDiagram.rowLen` unfolded. The definition is not exposed, so this is how the row
+lengths are computed outside this file. -/
+theorem rowLen_eq_card_filter (D : Finset (ι × κ)) (i : ι) :
+    rowLen D i = (D.filter fun p => p.1 = i).card := by
+  rw [rowLen]
+
+/-- The cells of `D` in row `i`, counted by their column index. -/
+theorem rowLen_eq_card_filter_mem [Fintype κ] [DecidableEq κ] (D : Finset (ι × κ)) (i : ι) :
+    rowLen D i = (Finset.univ.filter fun c : κ => (i, c) ∈ D).card := by
+  have hinj : Function.Injective fun c : κ => ((i, c) : ι × κ) := fun c d h => congrArg Prod.snd h
+  rw [rowLen_eq_card_filter, ← Finset.card_image_of_injective
+    (Finset.univ.filter fun c : κ => (i, c) ∈ D) hinj]
+  refine congrArg Finset.card (Finset.ext ?_)
+  rintro ⟨x, c⟩
+  simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and, Prod.mk.injEq]
+  constructor
+  · rintro ⟨hmem, hx⟩
+    subst hx
+    exact ⟨c, hmem, rfl, rfl⟩
+  · rintro ⟨d, hd, hx, hc⟩
+    subst hx
+    subst hc
+    exact ⟨hd, rfl⟩
+
+end RowLen
+
+/-! ### Closure in the row direction -/
+
+/-- A set of cells is **row lower closed** when with every cell it contains all the cells directly
+above it: if `(j, c)` is a cell and `i < j`, then `(i, c)` is a cell. In other words `D` is a lower
+set in its row index. This is the shape condition on a Young diagram. -/
+def IsRowLowerClosed [LT ι] (D : Finset (ι × κ)) : Prop :=
+  ∀ p ∈ D, ∀ i : ι, i < p.1 → (i, p.2) ∈ D
+
+/-- `TauCeti.CellDiagram.IsRowLowerClosed` unfolded. The definition is not exposed, so this is how
+the condition is introduced and eliminated outside this file. -/
+theorem isRowLowerClosed_iff [LT ι] {D : Finset (ι × κ)} :
+    IsRowLowerClosed D ↔ ∀ p ∈ D, ∀ i : ι, i < p.1 → (i, p.2) ∈ D :=
+  Iff.rfl
+
+/-! ### The cells under a tuple of row lengths -/
+
+section OfRowLens
+
+variable [Fintype ι]
+
+/-- The cells lying under the row lengths `a`: those cells `(i, c)` whose column index `c` is
+smaller than the `i`-th row length. The columns are drawn from `Fin m`, so a row longer than `m` is
+truncated. -/
+def ofRowLens (a : ι → ℕ) (m : ℕ) : Finset (ι × Fin m) :=
+  Finset.univ.filter fun p => (p.2 : ℕ) < a p.1
+
+@[simp]
+theorem mem_ofRowLens_iff {a : ι → ℕ} {m : ℕ} {p : ι × Fin m} :
+    p ∈ ofRowLens a m ↔ (p.2 : ℕ) < a p.1 := by
+  simp [ofRowLens]
+
+/-- The cells under a weakly decreasing tuple of row lengths are closed in the row direction. -/
+theorem isRowLowerClosed_ofRowLens [Preorder ι] {a : ι → ℕ} (ha : Antitone a) (m : ℕ) :
+    IsRowLowerClosed (ofRowLens a m) := by
+  intro p hp i hi
+  exact mem_ofRowLens_iff.2 ((mem_ofRowLens_iff.1 hp).trans_le (ha hi.le))
+
+variable [DecidableEq ι]
+
+/-- The rows of the cells under `a` have the lengths `a` prescribes, as soon as there are enough
+columns to hold them. -/
+theorem rowLen_ofRowLens {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) (i : ι) :
+    rowLen (ofRowLens a m) i = a i := by
+  have himage : (ofRowLens a m).filter (fun p => p.1 = i)
+      = Finset.univ.image fun c : Fin (a i) => ((i, Fin.castLE (hm i) c) : ι × Fin m) := by
+    refine Finset.ext fun p => ?_
+    simp only [Finset.mem_filter, Finset.mem_image, Finset.mem_univ, true_and, mem_ofRowLens_iff]
+    refine ⟨?_, ?_⟩
+    · rintro ⟨hlt, rfl⟩
+      exact ⟨⟨p.2, hlt⟩, by simp⟩
+    · rintro ⟨c, rfl⟩
+      exact ⟨c.isLt, rfl⟩
+  rw [rowLen_eq_card_filter, himage, Finset.card_image_of_injective _ (fun c d h =>
+      Fin.val_injective (congrArg (fun p : ι × Fin m => (p.2 : ℕ)) h)),
+    Finset.card_univ, Fintype.card_fin]
+
+omit [DecidableEq ι] in
+/-- The cells under `a` are one for each unit of each row length, as soon as there are enough
+columns to hold them. -/
+theorem card_ofRowLens {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) :
+    (ofRowLens a m).card = ∑ i, a i := by
+  classical
+  rw [Finset.card_eq_sum_card_fiberwise (f := fun p : ι × Fin m => p.1) (t := Finset.univ)
+    fun _ _ => Finset.mem_univ _]
+  exact Finset.sum_congr rfl fun i _ =>
+    (rowLen_eq_card_filter (ofRowLens a m) i).symm.trans (rowLen_ofRowLens hm i)
+
+end OfRowLens
+
+end TauCeti.CellDiagram

--- a/TauCeti/Combinatorics/Young/Cells.lean
+++ b/TauCeti/Combinatorics/Young/Cells.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import Mathlib.Data.Fintype.Fin
 public import Mathlib.Data.Fintype.Prod
 public import Mathlib.Order.Monotone.Defs
 
@@ -17,22 +18,23 @@ public section
 A finite set `D : Finset (ι × κ)` of **cells** has its rows indexed by `ι` and its columns indexed
 by `κ`. This file counts the cells of `D` one row at a time (`TauCeti.CellDiagram.rowLen`), imposes
 the shape condition that makes such a set look like a Young diagram
-(`TauCeti.CellDiagram.IsRowLowerClosed`: with every cell, `D` contains the cells directly above it),
+(`TauCeti.CellDiagram.IsRowLowerSet`: with every cell, `D` contains the cells directly above it),
 and builds the set of cells lying under a prescribed tuple of row lengths
 (`TauCeti.CellDiagram.ofRowLens`).
 
 ## Main definitions
 
 * `TauCeti.CellDiagram.rowLen`: the number of cells of a set lying in a given row.
-* `TauCeti.CellDiagram.IsRowLowerClosed`: closure of a set of cells in the row direction.
+* `TauCeti.CellDiagram.IsRowLowerSet`: the lower-set property in the row direction.
 * `TauCeti.CellDiagram.ofRowLens`: the cells lying under a tuple of row lengths.
 
 ## Main results
 
-* `TauCeti.CellDiagram.isRowLowerClosed_ofRowLens`: the cells under a weakly decreasing tuple of
+* `TauCeti.CellDiagram.isRowLowerSet_ofRowLens`: the cells under a weakly decreasing tuple of
   row lengths are closed in the row direction.
 * `TauCeti.CellDiagram.rowLen_ofRowLens` and `TauCeti.CellDiagram.card_ofRowLens`: the rows of
-  those cells have the prescribed lengths, and there are `∑ i, a i` cells in all.
+  those cells have lengths `min (a i) m`, and there are `∑ i, min (a i) m` cells in all. When
+  `∀ i, a i ≤ m`, the corresponding `of_le` corollaries give the prescribed row lengths and total.
 
 ## Implementation notes
 
@@ -85,16 +87,16 @@ end RowLen
 
 /-! ### Closure in the row direction -/
 
-/-- A set of cells is **row lower closed** when with every cell it contains all the cells directly
+/-- A set of cells is a **row lower set** when with every cell it contains all the cells directly
 above it: if `(j, c)` is a cell and `i < j`, then `(i, c)` is a cell. In other words `D` is a lower
 set in its row index. This is the shape condition on a Young diagram. -/
-def IsRowLowerClosed [LT ι] (D : Finset (ι × κ)) : Prop :=
+def IsRowLowerSet [LT ι] (D : Finset (ι × κ)) : Prop :=
   ∀ p ∈ D, ∀ i : ι, i < p.1 → (i, p.2) ∈ D
 
-/-- `TauCeti.CellDiagram.IsRowLowerClosed` unfolded. The definition is not exposed, so this is how
+/-- `TauCeti.CellDiagram.IsRowLowerSet` unfolded. The definition is not exposed, so this is how
 the condition is introduced and eliminated outside this file. -/
-theorem isRowLowerClosed_iff [LT ι] {D : Finset (ι × κ)} :
-    IsRowLowerClosed D ↔ ∀ p ∈ D, ∀ i : ι, i < p.1 → (i, p.2) ∈ D :=
+theorem isRowLowerSet_iff [LT ι] {D : Finset (ι × κ)} :
+    IsRowLowerSet D ↔ ∀ p ∈ D, ∀ i : ι, i < p.1 → (i, p.2) ∈ D :=
   Iff.rfl
 
 /-! ### The cells under a tuple of row lengths -/
@@ -115,40 +117,43 @@ theorem mem_ofRowLens_iff {a : ι → ℕ} {m : ℕ} {p : ι × Fin m} :
   simp [ofRowLens]
 
 /-- The cells under a weakly decreasing tuple of row lengths are closed in the row direction. -/
-theorem isRowLowerClosed_ofRowLens [Preorder ι] {a : ι → ℕ} (ha : Antitone a) (m : ℕ) :
-    IsRowLowerClosed (ofRowLens a m) := by
+theorem isRowLowerSet_ofRowLens [Preorder ι] {a : ι → ℕ} (ha : Antitone a) (m : ℕ) :
+    IsRowLowerSet (ofRowLens a m) := by
   intro p hp i hi
   exact mem_ofRowLens_iff.2 ((mem_ofRowLens_iff.1 hp).trans_le (ha hi.le))
 
 variable [DecidableEq ι]
 
-/-- The rows of the cells under `a` have the lengths `a` prescribes, as soon as there are enough
-columns to hold them. -/
-theorem rowLen_ofRowLens {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) (i : ι) :
+/-- A row of the cells under `a` has the requested length, truncated to the available width `m`. -/
+@[simp]
+theorem rowLen_ofRowLens (a : ι → ℕ) (m : ℕ) (i : ι) :
+    rowLen (ofRowLens a m) i = min (a i) m := by
+  rw [rowLen_eq_card_filter_mem]
+  simpa [mem_ofRowLens_iff, min_comm] using (Fin.card_filter_val_lt (n := m) (m := a i))
+
+/-- The rows of the cells under `a` have the lengths `a` prescribes when there are enough columns
+to hold them. -/
+theorem rowLen_ofRowLens_of_le {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) (i : ι) :
     rowLen (ofRowLens a m) i = a i := by
-  have himage : (ofRowLens a m).filter (fun p => p.1 = i)
-      = Finset.univ.image fun c : Fin (a i) => ((i, Fin.castLE (hm i) c) : ι × Fin m) := by
-    refine Finset.ext fun p => ?_
-    simp only [Finset.mem_filter, Finset.mem_image, Finset.mem_univ, true_and, mem_ofRowLens_iff]
-    refine ⟨?_, ?_⟩
-    · rintro ⟨hlt, rfl⟩
-      exact ⟨⟨p.2, hlt⟩, by simp⟩
-    · rintro ⟨c, rfl⟩
-      exact ⟨c.isLt, rfl⟩
-  rw [rowLen_eq_card_filter, himage, Finset.card_image_of_injective _ (fun c d h =>
-      Fin.val_injective (congrArg (fun p : ι × Fin m => (p.2 : ℕ)) h)),
-    Finset.card_univ, Fintype.card_fin]
+  simp [hm i]
 
 omit [DecidableEq ι] in
-/-- The cells under `a` are one for each unit of each row length, as soon as there are enough
-columns to hold them. -/
-theorem card_ofRowLens {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) :
-    (ofRowLens a m).card = ∑ i, a i := by
+/-- The number of cells under `a` is the sum of the row lengths truncated to width `m`. -/
+@[simp]
+theorem card_ofRowLens (a : ι → ℕ) (m : ℕ) :
+    (ofRowLens a m).card = ∑ i, min (a i) m := by
   classical
   rw [Finset.card_eq_sum_card_fiberwise (f := fun p : ι × Fin m => p.1) (t := Finset.univ)
     fun _ _ => Finset.mem_univ _]
   exact Finset.sum_congr rfl fun i _ =>
-    (rowLen_eq_card_filter (ofRowLens a m) i).symm.trans (rowLen_ofRowLens hm i)
+    (rowLen_eq_card_filter (ofRowLens a m) i).symm.trans (rowLen_ofRowLens a m i)
+
+omit [DecidableEq ι] in
+/-- The cells under `a` are one for each unit of each row length when there are enough columns to
+hold them. -/
+theorem card_ofRowLens_of_le {a : ι → ℕ} {m : ℕ} (hm : ∀ i, a i ≤ m) :
+    (ofRowLens a m).card = ∑ i, a i := by
+  simp [hm]
 
 end OfRowLens
 


### PR DESCRIPTION
This PR realizes every weakly decreasing tuple of natural numbers as the highest weight of a `gl ι`-module. Let `κ` index an auxiliary second coordinate, so that `gl ι` acts on the standard module `ι × κ → R` of `gl (ι × κ)` through the block-diagonal map `A ↦ Matrix.blockDiagonal fun _ : κ => A`, and hence on its exterior powers. A matrix unit `Eₛₜ` of `gl ι` goes to the sum `∑ c, E₍ₛ,c₎₍ₜ,c₎` over the auxiliary coordinate, so its action on a wedge of standard basis vectors is read off column by column from `exteriorPower.lie_single_self_basisWedge` and `exteriorPower.lie_single_basisWedge_of_ne`. For a finite set `D` of cells the wedge `exteriorPower.basisWedge R D` of the standard basis vectors indexed by `D` is a weight vector for the diagonal, of weight the row lengths of `D`, and when `D` is row lower closed — containing with every cell the cells directly above it, the shape condition on a Young diagram — every raising matrix unit annihilates it. Taking `κ = Fin m` and `D` the cells `CellDiagram.ofRowLens a m` under a weakly decreasing `a : ι → ℕ`, the row lengths are the `a i` themselves, so `exists_isGlHighestWeightVector_natCast` produces a highest weight vector of weight `a` in the exterior power of degree `∑ i, a i`, a module finite over `R`.

The matrix-unit action on a wedge of basis vectors is proved once, for an arbitrary finite set of coordinates and at an arbitrary exterior degree, in `GeneralLinear/ExteriorPower.lean`; `exteriorPower.firstBasisWedge` and the block-diagonal action here are both derived from it, replacing the private one-off proofs that file used to carry. The purely combinatorial layer — row lengths, closure in the row direction, and the cells under a tuple of row lengths — has no Lie-theoretic dependency and lives in `TauCeti/Combinatorics/Young/Cells.lean`.

Roadmap: RepresentationTheory

The milestone is "the classification and the named carrier" in Layer 9 (reductive Lie algebras and `gl_n`) of `RepresentationTheory/LieHighestWeight/README.md`, which asks for the named carrier `glIrreducible n μ` of each dominant weight together with the pin that it carries a highest weight vector of weight `μ`. Its uniqueness half is on `main` (`nonempty_lieModuleEquiv_of_isGlHighestWeightVector`, `finrank_le_of_isGlHighestWeightVector`, `exists_isGlHighestWeightVector_and_isGlDominantIntegral`), while the existence half had modules only for the fundamental weights (`exteriorPower.isGlHighestWeightVector_firstBasisWedge`); this PR supplies them for every dominant weight with natural number entries. What remains for the milestone: passing to an irreducible subquotient of the module generated by the vector, and the twist by the central character that carries the natural number weights to the general dominant weights, whose entries are arbitrary in `K` with only the consecutive differences in `ℕ`.

Nothing is vendored: the exterior-power action, the `ιMulti` and `ιMulti_family` API, `Finset.orderEmbOfFin`, and `Matrix.blockDiagonal` with its arithmetic lemmas are Mathlib's, and the highest weight vocabulary is `TauCeti.IsGlHighestWeightVector`. The construction is the classical realization of the modules of `GL(V)` inside `⋀(V ⊗ Kᵐ)`, as in Goodman-Wallach, *Symmetry, Representations, and Invariants*, GTM 255, §5.5 and §9.1, and Fulton-Harris, GTM 129, §15.5; both are cited in the file.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"gl-young-wedge-highest-weight-vector"}-->

🤖 Prepared with Claude Code
