### PR TITLE
feat: the principal-series character values of GL2(F_q)

### DIFF
--- a/TauCeti/GroupTheory/QuotientGroup/Basic.lean
+++ b/TauCeti/GroupTheory/QuotientGroup/Basic.lean
@@ -19,6 +19,9 @@ coset for that action, and, for the trivial subgroup, the compatibility of the i
 The stabilizer of the coset `sH` is the conjugate subgroup `sHs⁻¹`
 (`TauCeti.stabilizer_quotientGroup_mk`); this is Mathlib's `MulAction.stabilizer_quotient`, which
 covers the trivial coset, transported along `MulAction.stabilizer_smul_eq_stabilizer_map_conj`.
+Read on elements, it says that `g` fixes `sH` exactly when `s⁻¹ g s` lies in `H`
+(`TauCeti.smul_quotientGroup_mk_eq_self_iff`), which is the form a fixed-coset count is checked
+in.
 
 The cosets of `⊥` in a group `G` are the elements of `G`, and Mathlib's
 `QuotientGroup.quotientBot` is that identification.  The identification is equivariant for left
@@ -27,6 +30,8 @@ translation, and the only element of `G` fixing a coset of `⊥` is the identity
 ## Main statements
 
 * `TauCeti.stabilizer_quotientGroup_mk`: the stabilizer of `sH` in `G` is `sHs⁻¹`.
+* `TauCeti.smul_quotientGroup_mk_eq_self_iff`: `g` fixes the coset `sH` exactly when `s⁻¹ g s`
+  lies in `H`.
 * `TauCeti.quotientBot_equivariant`: `QuotientGroup.quotientBot` intertwines left translation on
   `G ⧸ ⊥` with left translation in `G`.
 * `TauCeti.quotientBot_smul_eq_self_iff`: a group element fixes a coset of the trivial subgroup
@@ -56,6 +61,17 @@ theorem stabilizer_quotientGroup_mk (H : Subgroup G) (s : G) :
   ext x
   rw [Subgroup.mem_map_equiv, Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← map_inv,
     MulAut.smul_def, MulAut.conj_symm_apply, MulAut.conj_apply, inv_inv]
+
+/-- **A group element fixes the coset `sH` exactly when its conjugate `s⁻¹gs` lies in `H`.**  This
+is `TauCeti.stabilizer_quotientGroup_mk` read on elements.
+
+Not a `simp` lemma: `MulAction.Quotient.smul_coe` rewrites the translation inside the left-hand
+side first, so the left-hand side is not in `simp`-normal form. -/
+theorem smul_quotientGroup_mk_eq_self_iff (H : Subgroup G) (g s : G) :
+    g • (s : G ⧸ H) = s ↔ s⁻¹ * g * s ∈ H := by
+  rw [← mem_stabilizer_iff, stabilizer_quotientGroup_mk,
+    Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← map_inv, MulAut.smul_def, MulAut.conj_apply]
+  simp
 
 /-- Left translation on the cosets of the trivial subgroup is left translation in the group.
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/CharacterValues.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/CharacterValues.lean
@@ -8,10 +8,12 @@ module
 -- `TauCeti.GL2Steinberg` and `TauCeti.GL2PrincipalSeries` are the representations whose characters
 -- are computed here.
 public import TauCeti.RepresentationTheory.CharacterTable.GL2.Steinberg
--- The fixed-coset counts are the content of every proof below, and this module re-exports
--- `TauCeti.diagGL`, `TauCeti.jordanGL` and `TauCeti.GL2NonSplitTorusHom`, which occur in the
--- statements.
+-- The fixed-coset counts are the content of every Steinberg proof below, and this module
+-- re-exports `TauCeti.diagGL`, `TauCeti.jordanGL` and `TauCeti.GL2NonSplitTorusHom`, which occur
+-- in the statements.
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.ProjectiveLine
+-- The boundary principal-series row is the general principal-series row at `α = β = 1`.
+public import TauCeti.RepresentationTheory.CharacterTable.GL2.PrincipalSeries.CharacterValues
 
 /-!
 # The Steinberg character of `GL₂(𝔽_q)` on the four families of conjugacy classes
@@ -116,26 +118,29 @@ end Elliptic
 /-! ### The boundary principal series
 
 At `α = β = 1` the principal series is the permutation representation of the projective line, so
-its character is the fixed-point count itself: one more than the Steinberg value. -/
+its character is the fixed-point count itself: one more than the Steinberg value. These four
+values are the general principal-series row
+(`TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean`) at the
+trivial pair of characters, and are read off it rather than proved a second time. -/
 
 /-- The boundary principal series has character `q + 1` at a central element. -/
 theorem character_GL2PrincipalSeries_one_one_scalar (u : Fˣ) :
     (GL2PrincipalSeries F 1 1).character (Matrix.GeneralLinearGroup.scalar (Fin 2) u) =
       (Fintype.card F : ℂ) + 1 := by
-  rw [character_GL2PrincipalSeries_one_one_eq_one_add, character_GL2Steinberg_scalar]
-  ring
+  rw [character_GL2PrincipalSeries_scalar]
+  simp
 
 /-- The boundary principal series has character `2` at a split semisimple element. -/
 theorem character_GL2PrincipalSeries_one_one_diagGL {a b : Fˣ} (hab : a ≠ b) :
     (GL2PrincipalSeries F 1 1).character (diagGL ![a, b]) = 2 := by
-  rw [character_GL2PrincipalSeries_one_one_eq_one_add, character_GL2Steinberg_diagGL hab]
+  rw [character_GL2PrincipalSeries_diagGL _ _ hab]
   norm_num
 
 /-- The boundary principal series has character `1` at a non-semisimple element. -/
 theorem character_GL2PrincipalSeries_one_one_jordanGL (a : Fˣ) {b : F} (hb : b ≠ 0) :
     (GL2PrincipalSeries F 1 1).character (jordanGL a b) = 1 := by
-  rw [character_GL2PrincipalSeries_one_one_eq_one_add, character_GL2Steinberg_jordanGL a hb]
-  ring
+  rw [character_GL2PrincipalSeries_jordanGL _ _ a hb]
+  simp
 
 section Elliptic
 
@@ -145,10 +150,8 @@ variable {E : Type*} [Field E] [Algebra F E] (hE : Module.finrank F E = 2)
 projective line is fixed, so the permutation character vanishes. -/
 theorem character_GL2PrincipalSeries_one_one_gl2NonSplitTorusHom {x : Eˣ}
     (hx : (x : E) ∉ Set.range (algebraMap F E)) :
-    (GL2PrincipalSeries F 1 1).character (GL2NonSplitTorusHom F E hE x) = 0 := by
-  rw [character_GL2PrincipalSeries_one_one_eq_one_add,
-    character_GL2Steinberg_gl2NonSplitTorusHom hE hx]
-  ring
+    (GL2PrincipalSeries F 1 1).character (GL2NonSplitTorusHom F E hE x) = 0 :=
+  character_GL2PrincipalSeries_gl2NonSplitTorusHom _ _ hE hx
 
 end Elliptic
 

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean
@@ -11,7 +11,7 @@ public import TauCeti.RepresentationTheory.CharacterTable.GL2.PrincipalSeries.Ba
 -- `TauCeti.indClassFun_ofFDRep_character` rewrites the character of an induced representation as
 -- the induced class function, whose coset sum `TauCeti.indClassFun_eq_sum_of_smul_eq_self_mem`
 -- then cuts down to the fixed cosets.
-public import TauCeti.RepresentationTheory.Induction.Character
+import TauCeti.RepresentationTheory.Induction.Character
 -- The fixed-coset counts of the four families, and the representatives `TauCeti.diagGL`,
 -- `TauCeti.jordanGL` and `TauCeti.GL2NonSplitTorusHom` at which they are stated.
 public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.ProjectiveLine

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean
@@ -47,8 +47,10 @@ hand: the trivial coset `B` and, for a split semisimple element, the coset of th
 `w = !![0, 1; 1, 0]`. Conjugating `diag(a, b)` by `w` swaps the two entries, which is where the
 second summand `α(b) β(a)` comes from.
 
-Only the central value uses the finiteness of `F` for more than the definition of the principal
-series, through the index `q + 1` of the Borel subgroup; the other three values are `q`-free.
+Only the central formula contains `q`, as the index `q + 1` of the Borel subgroup, and it is the
+one whose fixed-coset count `TauCeti.GL2Borel.natCard_fixedCosets_scalar` is about a finite field.
+The other three counts hold over any field; all four proofs still need `F` finite, because the
+coset sum they run on is the one of a finite-index subgroup.
 
 ## Main results
 
@@ -115,8 +117,12 @@ private theorem indTerm_character_GL2BorelRep_eq (a b : Fˣ) {g x : GL (Fin 2) F
     (h1 : ((c : GL (Fin 2) F) : Matrix (Fin 2) (Fin 2) F) 1 1 = (b : F)) :
     indTerm (GL2BorelRep F α β).character g x = (α a : ℂ) * (β b : ℂ) := by
   have hmem : x⁻¹ * g * x ∈ GL2Borel F := hc ▸ c.2
-  rw [indTerm_of_mem _ hmem, show (⟨x⁻¹ * g * x, hmem⟩ : GL2Borel F) = c from Subtype.ext hc,
-    character_GL2BorelRep_eq α β c h0 h1]
+  -- After the case split, the summand is the Borel character at the *subgroup* element
+  -- `⟨x⁻¹ * g * x, hmem⟩`, whereas `hc` equates underlying matrices.  Rewriting by `hc` there
+  -- would have to move the membership proof `hmem` along with it, so it is the equality of
+  -- subgroup elements, obtained from `hc` by `Subtype.ext`, that rewrites.
+  have hsub : (⟨x⁻¹ * g * x, hmem⟩ : GL2Borel F) = c := Subtype.ext hc
+  rw [indTerm_apply, dite_eq_left hmem, hsub, character_GL2BorelRep_eq α β c h0 h1]
 
 /-- The character of the Borel representation is a class function, so its summands depend only on
 the coset of their representative. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean
@@ -1,0 +1,254 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+-- `TauCeti.GL2PrincipalSeries` and the Borel character `TauCeti.GL2BorelRep` it is induced from
+-- are the subject.
+public import TauCeti.RepresentationTheory.CharacterTable.GL2.PrincipalSeries.Basic
+-- `TauCeti.indClassFun_ofFDRep_character` rewrites the character of an induced representation as
+-- the induced class function, whose coset sum `TauCeti.indClassFun_eq_sum_of_smul_eq_self_mem`
+-- then cuts down to the fixed cosets.
+public import TauCeti.RepresentationTheory.Induction.Character
+-- The fixed-coset counts of the four families, and the representatives `TauCeti.diagGL`,
+-- `TauCeti.jordanGL` and `TauCeti.GL2NonSplitTorusHom` at which they are stated.
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.ProjectiveLine
+-- Non-public: that the Weyl element is the permutation matrix of the transposition is what
+-- computes the second fixed coset of a split semisimple element, inside a proof only.
+import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Diagonal.Bruhat
+
+/-!
+# The character of the principal series of `GL₂(𝔽_q)` on the four families of conjugacy classes
+
+The conjugacy classes of `GL₂(𝔽_q)` fall into four families
+(`TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/ConjugacyClasses.lean`), with representatives
+the **central** scalar `diag(a, a)`, the **split semisimple** `diag(a, b)` with `a ≠ b`, the
+**non-semisimple** Jordan block `!![a, b; 0, a]` with `b ≠ 0`, and the **elliptic** image of an
+element of `E ∖ F` under the non-split torus of a quadratic extension `E/F`. This file evaluates
+the character of the principal series `Ind_B^{GL₂}(α ⊗ β)` at each of the four, giving the row
+
+`χ_{α,β} = (q + 1) α(a) β(a)`, `α(a) β(b) + α(b) β(a)`, `α(a) β(a)`, `0`
+
+of the character table of `GL₂(𝔽_q)`. At `α = β = 1` these are the fixed-point counts on the
+projective line, which is the boundary case
+`TauCeti/RepresentationTheory/CharacterTable/GL2/CharacterValues.lean` reads off.
+
+The computation is the induced-character formula in the form
+`TauCeti.indClassFun_eq_sum_of_smul_eq_self_mem`: the character of an induction at `g` is the sum
+of the inducing character over the cosets of `B` that `g` fixes, evaluated at the conjugate of `g`
+into `B` that each such coset exhibits. Which cosets are fixed is already known — a scalar fixes
+all `q + 1` of them, a split semisimple element exactly `2`, a Jordan block exactly `1`, and an
+elliptic element none
+(`TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/ProjectiveLine.lean`) — and those counts are
+enough to *identify* the fixed cosets, because in each case a list of that many fixed cosets is at
+hand: the trivial coset `B` and, for a split semisimple element, the coset of the Weyl element
+`w = !![0, 1; 1, 0]`. Conjugating `diag(a, b)` by `w` swaps the two entries, which is where the
+second summand `α(b) β(a)` comes from.
+
+Only the central value uses the finiteness of `F` for more than the definition of the principal
+series, through the index `q + 1` of the Borel subgroup; the other three values are `q`-free.
+
+## Main results
+
+* `TauCeti.character_GL2PrincipalSeries_scalar`, `TauCeti.character_GL2PrincipalSeries_diagGL`,
+  `TauCeti.character_GL2PrincipalSeries_jordanGL` and
+  `TauCeti.character_GL2PrincipalSeries_gl2NonSplitTorusHom`: the four values above.
+
+## References
+
+This supplies the principal-series row of the character-value formulas of Layer 9 ("the
+representation theory of `GL₂(𝔽_q)`") of
+`TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`. See also W. Fulton and J. Harris,
+*Representation Theory: A First Course*, GTM 129, §5.2, and C. Bonnafé, *Representations of
+`SL₂(𝔽_q)`* (2011), Chapter 5.
+-/
+
+public section
+
+namespace TauCeti
+
+open Matrix
+
+universe u
+
+variable {F : Type u} [Field F]
+
+/-- Conjugating a diagonal matrix by the Weyl element swaps its two entries. This is
+`TauCeti.permutationGL_mul_diagGL_mul_inv` at the transposition, which
+`TauCeti.gl2WeylElement_eq_permutationGL_swap` identifies the Weyl element with.
+
+`TauCeti.GL2Borel.inv_weyl_mul_torusHom_mul_weyl` is the same fact for the split torus
+`TauCeti.GL2Borel.torusHom` of the Borel subgroup rather than for `TauCeti.diagGL`. The two
+presentations of a diagonal matrix are equal but not definitionally so, and the conjugacy-class
+representatives of `GL₂(𝔽_q)` are stated with `TauCeti.diagGL`; nothing is recomputed here, the
+general permutation lemma above does the work. -/
+private theorem inv_gl2WeylElement_mul_diagGL_mul_gl2WeylElement (a b : Fˣ) :
+    (GL2WeylElement F)⁻¹ * diagGL ![a, b] * GL2WeylElement F = diagGL ![b, a] := by
+  have hinv : (permutationGL (k := F) (Equiv.swap (0 : Fin 2) 1))⁻¹ =
+      permutationGL (k := F) (Equiv.swap (0 : Fin 2) 1) := by
+    rw [← map_inv, Equiv.swap_inv]
+  rw [gl2WeylElement_inv, gl2WeylElement_eq_permutationGL_swap]
+  nth_rewrite 2 [← hinv]
+  rw [permutationGL_mul_diagGL_mul_inv]
+  exact congrArg diagGL (funext fun i => by fin_cases i <;> simp)
+
+/-! ### The summands of the induced-character formula -/
+
+variable (α β : Fˣ →* ℂˣ)
+
+/-- The character of the Borel representation `α ⊗ β`, read off the two diagonal entries. -/
+private theorem character_GL2BorelRep_eq (g : GL2Borel F) {a b : Fˣ}
+    (h0 : ((g : GL (Fin 2) F) : Matrix (Fin 2) (Fin 2) F) 0 0 = (a : F))
+    (h1 : ((g : GL (Fin 2) F) : Matrix (Fin 2) (Fin 2) F) 1 1 = (b : F)) :
+    (GL2BorelRep F α β).character g = (α a : ℂ) * (β b : ℂ) := by
+  have ha : (GL2Borel.diag g).1 = a := Units.ext (by rw [GL2Borel.diag_fst_val]; exact h0)
+  have hb : (GL2Borel.diag g).2 = b := Units.ext (by rw [GL2Borel.diag_snd_val]; exact h1)
+  rw [character_GL2BorelRep, GL2Borel.linearChar_apply, ha, hb, Units.val_mul]
+
+/-- The summand of the induced-character formula at a representative `x` whose conjugate
+`x⁻¹ g x` is a named element `c` of the Borel subgroup with known diagonal entries. -/
+private theorem indTerm_character_GL2BorelRep_eq (a b : Fˣ) {g x : GL (Fin 2) F} {c : GL2Borel F}
+    (hc : x⁻¹ * g * x = (c : GL (Fin 2) F))
+    (h0 : ((c : GL (Fin 2) F) : Matrix (Fin 2) (Fin 2) F) 0 0 = (a : F))
+    (h1 : ((c : GL (Fin 2) F) : Matrix (Fin 2) (Fin 2) F) 1 1 = (b : F)) :
+    indTerm (GL2BorelRep F α β).character g x = (α a : ℂ) * (β b : ℂ) := by
+  have hmem : x⁻¹ * g * x ∈ GL2Borel F := hc ▸ c.2
+  rw [indTerm_of_mem _ hmem, show (⟨x⁻¹ * g * x, hmem⟩ : GL2Borel F) = c from Subtype.ext hc,
+    character_GL2BorelRep_eq α β c h0 h1]
+
+/-- The character of the Borel representation is a class function, so its summands depend only on
+the coset of their representative. -/
+private theorem character_GL2BorelRep_mem_classFunction :
+    (GL2BorelRep F α β).character ∈ ClassFunction ℂ (GL2Borel F) :=
+  ClassFunction.mem_iff.mpr fun s t => (GL2BorelRep F α β).char_conj s t
+
+/-- The summand may be computed at any representative of its coset, in particular at a chosen one
+rather than at `Quotient.out`. -/
+private theorem indTerm_out_eq (g x : GL (Fin 2) F) :
+    indTerm (GL2BorelRep F α β).character g
+        (Quotient.out (QuotientGroup.mk x : GL (Fin 2) F ⧸ GL2Borel F)) =
+      indTerm (GL2BorelRep F α β).character g x :=
+  indTerm_eq_of_mk_eq (character_GL2BorelRep_mem_classFunction α β) _ _ _
+    (QuotientGroup.out_eq' _)
+
+/-! ### The four values -/
+
+section FiniteField
+
+variable [Fintype F]
+
+/-- The character of the principal series is the induced class function of the Borel character. -/
+private theorem character_GL2PrincipalSeries_eq_indClassFun (g : GL (Fin 2) F) :
+    (GL2PrincipalSeries F α β).character g =
+      indClassFun (GL2Borel F) (GL2BorelRep F α β).character g := by
+  rw [GL2PrincipalSeries_def, ← indClassFun_ofFDRep_character]
+
+/-- **The principal series has character `(q + 1) α(a) β(a)` at a central element.** A scalar
+matrix is central, so every one of the `q + 1` cosets of the Borel subgroup is fixed, and each
+contributes the value of `α ⊗ β` at the scalar itself. -/
+theorem character_GL2PrincipalSeries_scalar (u : Fˣ) :
+    (GL2PrincipalSeries F α β).character (Matrix.GeneralLinearGroup.scalar (Fin 2) u) =
+      ((Fintype.card F : ℂ) + 1) * ((α u : ℂ) * (β u : ℂ)) := by
+  classical
+  let _ : Fintype (GL (Fin 2) F ⧸ GL2Borel F) := Fintype.ofFinite _
+  have hterm : ∀ t : GL (Fin 2) F ⧸ GL2Borel F,
+      indTerm (GL2BorelRep F α β).character (Matrix.GeneralLinearGroup.scalar (Fin 2) u)
+        (Quotient.out t) = (α u : ℂ) * (β u : ℂ) := fun t =>
+    indTerm_character_GL2BorelRep_eq α β u u (c := ⟨_, GL2Borel.scalar_mem F u⟩)
+      (by rw [mul_assoc, Matrix.GeneralLinearGroup.scalar_commute, inv_mul_cancel_left])
+      (by simp [Matrix.scalar_apply]) (by simp [Matrix.scalar_apply])
+  have hcard : Fintype.card (GL (Fin 2) F ⧸ GL2Borel F) = Fintype.card F + 1 := by
+    rw [← Nat.card_eq_fintype_card, ← Subgroup.index_eq_card, GL2Borel.index_eq]
+  rw [character_GL2PrincipalSeries_eq_indClassFun,
+    indClassFun_eq_sum_of_smul_eq_self_mem _ _ Finset.univ fun t _ => Finset.mem_univ t,
+    Finset.sum_congr rfl fun t _ => hterm t, Finset.sum_const, Finset.card_univ, hcard,
+    nsmul_eq_mul]
+  push_cast
+  ring
+
+/-- **The principal series has character `α(a) β(b) + α(b) β(a)` at a split semisimple element.**
+A diagonal matrix with distinct entries fixes exactly two cosets of the Borel subgroup, the
+trivial one and the one of the Weyl element; conjugating by the Weyl element swaps the two
+diagonal entries, so the two cosets contribute `α(a) β(b)` and `α(b) β(a)`. -/
+theorem character_GL2PrincipalSeries_diagGL {a b : Fˣ} (hab : a ≠ b) :
+    (GL2PrincipalSeries F α β).character (diagGL ![a, b]) =
+      (α a : ℂ) * (β b : ℂ) + (α b : ℂ) * (β a : ℂ) := by
+  classical
+  have hab' : diagGL ![a, b] ∈ GL2Borel F := GL2Borel.mem_iff.2 (by simp)
+  have hba : diagGL ![b, a] ∈ GL2Borel F := GL2Borel.mem_iff.2 (by simp)
+  have hconj := inv_gl2WeylElement_mul_diagGL_mul_gl2WeylElement a b
+  have hne : (QuotientGroup.mk 1 : GL (Fin 2) F ⧸ GL2Borel F) ≠
+      QuotientGroup.mk (GL2WeylElement F) := by
+    rw [Ne, QuotientGroup.eq]
+    simp
+  -- both cosets below are fixed, and there are only two fixed cosets, so these are they
+  have hsub : ({QuotientGroup.mk 1, QuotientGroup.mk (GL2WeylElement F)} :
+      Set (GL (Fin 2) F ⧸ GL2Borel F)) ⊆ {t | diagGL ![a, b] • t = t} := by
+    rintro t (rfl | rfl)
+    · rw [Set.mem_ofPred_eq, smul_quotientGroup_mk_eq_self_iff]
+      simp
+    · rw [Set.mem_ofPred_eq, smul_quotientGroup_mk_eq_self_iff, hconj]
+      exact hba
+  have hfixed : ({QuotientGroup.mk 1, QuotientGroup.mk (GL2WeylElement F)} :
+      Set (GL (Fin 2) F ⧸ GL2Borel F)) = {t | diagGL ![a, b] • t = t} :=
+    Set.eq_of_subset_of_ncard_le hsub
+      (by rw [Set.ncard_pair hne]; exact le_of_eq (GL2Borel.natCard_fixedCosets_diagGL hab))
+      (Set.toFinite _)
+  rw [character_GL2PrincipalSeries_eq_indClassFun,
+    indClassFun_eq_sum_of_smul_eq_self_mem _ _
+      ({QuotientGroup.mk 1, QuotientGroup.mk (GL2WeylElement F)} : Finset _)
+      (fun t ht => by simpa using hfixed.ge ht),
+    Finset.sum_pair hne, indTerm_out_eq, indTerm_out_eq,
+    indTerm_character_GL2BorelRep_eq α β a b (c := ⟨_, hab'⟩) (by group) (by simp) (by simp),
+    indTerm_character_GL2BorelRep_eq α β b a (c := ⟨_, hba⟩) hconj (by simp) (by simp)]
+
+/-- **The principal series has character `α(a) β(a)` at a non-semisimple element.** A Jordan block
+fixes exactly one coset of the Borel subgroup, the trivial one, and it is upper triangular with
+both diagonal entries equal to `a`. -/
+theorem character_GL2PrincipalSeries_jordanGL (a : Fˣ) {b : F} (hb : b ≠ 0) :
+    (GL2PrincipalSeries F α β).character (jordanGL a b) = (α a : ℂ) * (β a : ℂ) := by
+  classical
+  have hmem : jordanGL a b ∈ GL2Borel F := jordanGL_mem_gl2Borel a b
+  have hsub : ({QuotientGroup.mk 1} : Set (GL (Fin 2) F ⧸ GL2Borel F)) ⊆
+      {t | jordanGL a b • t = t} := by
+    rintro t rfl
+    rw [Set.mem_ofPred_eq, smul_quotientGroup_mk_eq_self_iff]
+    simp
+  have hfixed : ({QuotientGroup.mk 1} : Set (GL (Fin 2) F ⧸ GL2Borel F)) =
+      {t | jordanGL a b • t = t} :=
+    Set.eq_of_subset_of_ncard_le hsub
+      (by rw [Set.ncard_singleton]; exact le_of_eq (GL2Borel.natCard_fixedCosets_jordanGL a hb))
+      (Set.toFinite _)
+  rw [character_GL2PrincipalSeries_eq_indClassFun,
+    indClassFun_eq_sum_of_smul_eq_self_mem _ _ ({QuotientGroup.mk 1} : Finset _)
+      (fun t ht => by simpa using hfixed.ge ht),
+    Finset.sum_singleton, indTerm_out_eq,
+    indTerm_character_GL2BorelRep_eq α β a a (c := ⟨_, hmem⟩) (by group) (by simp) (by simp)]
+
+section Elliptic
+
+variable {E : Type*} [Field E] [Algebra F E] (hE : Module.finrank F E = 2)
+
+/-- **The principal series vanishes at an elliptic element.** An element of the non-split torus
+coming from `E ∖ F` has no eigenline over `F`, so it fixes no coset of the Borel subgroup and the
+induced-character sum is empty. -/
+theorem character_GL2PrincipalSeries_gl2NonSplitTorusHom {x : Eˣ}
+    (hx : (x : E) ∉ Set.range (algebraMap F E)) :
+    (GL2PrincipalSeries F α β).character (GL2NonSplitTorusHom F E hE x) = 0 := by
+  classical
+  rw [character_GL2PrincipalSeries_eq_indClassFun,
+    indClassFun_eq_sum_of_smul_eq_self_mem _ _ (∅ : Finset _) fun t ht => ?_, Finset.sum_empty]
+  have : Nonempty {c : GL (Fin 2) F ⧸ GL2Borel F //
+      GL2NonSplitTorusHom F E hE x • c = c} := ⟨⟨t, ht⟩⟩
+  have hpos := Nat.card_pos (α := {c : GL (Fin 2) F ⧸ GL2Borel F //
+    GL2NonSplitTorusHom F E hE x • c = c})
+  rw [GL2Borel.natCard_fixedCosets_gl2NonSplitTorusHom hE hx] at hpos
+  exact absurd hpos (lt_irrefl 0)
+
+end Elliptic
+
+end FiniteField
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/Induction/ClassFunction.lean
@@ -32,7 +32,7 @@ and to deduce `TauCeti.character_ind` from `TauCeti.indClassFun_eq_natCard_inv_m
   when `x⁻¹ g x` lies in the subgroup and `0` otherwise.  It is the summand of the
   induced-character formula too, which the character file uses at `f = ρ.character`, together
   with the coset-invariance lemma `TauCeti.indTerm_eq_of_mk_eq` and the evaluations
-  `TauCeti.indTerm_of_mem`, `TauCeti.indTerm_conj` and `TauCeti.indTerm_one`.
+  `TauCeti.indTerm_conj` and `TauCeti.indTerm_one`.
 * `TauCeti.indClassFun S f`: the function `G → k` obtained from `f : S → k` by summing `f` over
   those left coset representatives that conjugate `g` into `S`.  There is no division by `|S|`,
   so it needs no invertibility hypothesis and no more than an additive commutative monoid of
@@ -107,12 +107,6 @@ open scoped Classical in
 theorem indTerm_apply (f : S → k) (g x : G) :
     indTerm f g x = if h : x⁻¹ * g * x ∈ S then f ⟨x⁻¹ * g * x, h⟩ else 0 :=
   (rfl)
-
-/-- The value of the summand at a representative that does conjugate `g` into the subgroup. -/
-theorem indTerm_of_mem (f : S → k) {g x : G} (h : x⁻¹ * g * x ∈ S) :
-    indTerm f g x = f ⟨x⁻¹ * g * x, h⟩ := by
-  classical
-  rw [indTerm, dite_eq_left h]
 
 /-- **A summand vanishes unless `g` fixes the coset of its representative.**  The conjugate
 `x⁻¹ g x` lies in `S` exactly when `g • xS = xS`, so only the fixed cosets contribute to

--- a/TauCeti/RepresentationTheory/Induction/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/Induction/ClassFunction.lean
@@ -6,6 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.RepresentationTheory.CharacterTable.ClassFunction
+-- The translation action `g • (x : G ⧸ S)` occurs in the statements about which summands vanish.
+public import Mathlib.GroupTheory.GroupAction.Quotient
+-- Non-public: `TauCeti.smul_quotientGroup_mk_eq_self_iff` is used only inside a proof.
+import TauCeti.GroupTheory.QuotientGroup.Basic
 
 /-!
 # The induced class function
@@ -28,7 +32,7 @@ and to deduce `TauCeti.character_ind` from `TauCeti.indClassFun_eq_natCard_inv_m
   when `x⁻¹ g x` lies in the subgroup and `0` otherwise.  It is the summand of the
   induced-character formula too, which the character file uses at `f = ρ.character`, together
   with the coset-invariance lemma `TauCeti.indTerm_eq_of_mk_eq` and the evaluations
-  `TauCeti.indTerm_conj` and `TauCeti.indTerm_one`.
+  `TauCeti.indTerm_of_mem`, `TauCeti.indTerm_conj` and `TauCeti.indTerm_one`.
 * `TauCeti.indClassFun S f`: the function `G → k` obtained from `f : S → k` by summing `f` over
   those left coset representatives that conjugate `g` into `S`.  There is no division by `|S|`,
   so it needs no invertibility hypothesis and no more than an additive commutative monoid of
@@ -41,6 +45,10 @@ and to deduce `TauCeti.character_ind` from `TauCeti.indClassFun_eq_natCard_inv_m
 
 ## Main statements
 
+* `TauCeti.indTerm_eq_zero_of_smul_mk_ne` and
+  `TauCeti.indClassFun_eq_sum_of_smul_eq_self_mem`: only the cosets `g` fixes contribute, so the
+  coset sum may be taken over any finite set of cosets containing the fixed ones.  This is what
+  turns the formula into a finite explicit computation for a concrete group.
 * `TauCeti.indClassFun_mem_classFunction`: the induced function of a class function is a class
   function.
 * `TauCeti.natCard_mul_indClassFun`: the group-sum form, `|S| · (Ind f)(g) = ∑_{x ∈ G} f(x⁻¹gx)`,
@@ -100,6 +108,20 @@ theorem indTerm_apply (f : S → k) (g x : G) :
     indTerm f g x = if h : x⁻¹ * g * x ∈ S then f ⟨x⁻¹ * g * x, h⟩ else 0 :=
   (rfl)
 
+/-- The value of the summand at a representative that does conjugate `g` into the subgroup. -/
+theorem indTerm_of_mem (f : S → k) {g x : G} (h : x⁻¹ * g * x ∈ S) :
+    indTerm f g x = f ⟨x⁻¹ * g * x, h⟩ := by
+  classical
+  rw [indTerm, dite_eq_left h]
+
+/-- **A summand vanishes unless `g` fixes the coset of its representative.**  The conjugate
+`x⁻¹ g x` lies in `S` exactly when `g • xS = xS`, so only the fixed cosets contribute to
+`TauCeti.indClassFun`. -/
+theorem indTerm_eq_zero_of_smul_mk_ne (f : S → k) {g x : G}
+    (h : g • (x : G ⧸ S) ≠ (x : G ⧸ S)) : indTerm f g x = 0 := by
+  classical
+  rw [indTerm, dite_eq_right fun hx => h (smul_quotientGroup_mk_eq_self_iff S g x |>.2 hx)]
+
 /-- Conjugating the argument of the summand translates the representative. -/
 theorem indTerm_conj (f : S → k) (g x c : G) :
     indTerm f (c * g * c⁻¹) x = indTerm f g (c⁻¹ * x) := by
@@ -140,6 +162,18 @@ theorem indClassFun_apply [S.FiniteIndex] (f : S → k) (g : G) :
           f ⟨(Quotient.out t)⁻¹ * g * Quotient.out t, h⟩
         else 0 :=
   (rfl)
+
+/-- **The induced class function is a sum over the cosets that `g` fixes.**  The summand attached
+to any other coset vanishes (`TauCeti.indTerm_eq_zero_of_smul_mk_ne`), so summing over a finite
+set `T` of cosets that contains every fixed one already gives the whole sum.  In practice `T` is
+the set of fixed cosets itself, which for a concrete group is a short explicit list. -/
+theorem indClassFun_eq_sum_of_smul_eq_self_mem [S.FiniteIndex] (f : S → k) (g : G)
+    (T : Finset (G ⧸ S)) (hT : ∀ t : G ⧸ S, g • t = t → t ∈ T) :
+    indClassFun S f g = ∑ t ∈ T, indTerm f g (Quotient.out t) := by
+  let := Fintype.ofFinite (G ⧸ S)
+  refine ((Finset.sum_subset (Finset.subset_univ T) fun t _ ht => ?_).trans rfl).symm
+  refine indTerm_eq_zero_of_smul_mk_ne f fun hfix => ht (hT t ?_)
+  rwa [QuotientGroup.out_eq'] at hfix
 
 /-! ### Additivity -/
 


### PR DESCRIPTION
This PR computes the character of the principal series `Ind_B^{GL₂}(α ⊗ β)` of `GL₂(𝔽_q)` on each of the four families of conjugacy classes, giving the row `(q + 1) α(a) β(a)`, `α(a) β(b) + α(b) β(a)`, `α(a) β(a)`, `0` at a central, split semisimple, non-semisimple and elliptic element respectively, and supplies the two general facts about induced class functions that the computation runs on: a summand of the coset formula vanishes unless its coset is fixed, so the induced class function is a sum over any finite set of cosets containing the fixed ones.

The milestone is Layer 9 of `RepresentationTheory/CharacterTheory`, "the representation theory of `GL₂(𝔽_q)`", whose bullet "Character-value formulas (build targets)" asks to "pin the explicit character values of the linear, Steinberg, principal-series, and cuspidal rows on each of the four class families; this is the bulk of the layer". The Steinberg row already landed (`TauCeti.character_GL2Steinberg_scalar` and its three companions), together with the class classification and count `card_conjClasses_GL2`, the fixed-coset counts of the four families, `GL2PrincipalSeries` with its dimension `q + 1`, and `simple_GL2PrincipalSeries_iff`; this PR adds the principal-series row. After it, the layer still needs the cuspidal representations `GL2Cuspidal` with their dimension `q - 1` and character values, the explicit linear row, and the assembly of the `(q² - 1) × (q² - 1)` table.

The computation is the induced-character formula, and the only new input it needs is which cosets of the Borel subgroup each representative fixes. That is already known as a *count* — a scalar fixes all `q + 1`, a split semisimple element `2`, a Jordan block `1`, an elliptic element none — and the counts are enough to identify the cosets, because a list of exactly that many fixed cosets is at hand in each case: the trivial coset, and for a split semisimple element also the coset of the Weyl element `w = !![0, 1; 1, 0]`. Conjugation by `w` swaps the two diagonal entries, which produces the second summand `α(b) β(a)`; that conjugation is obtained from the general `TauCeti.permutationGL_mul_diagGL_mul_inv` rather than recomputed, and its docstring records that `TauCeti.GL2Borel.inv_weyl_mul_torusHom_mul_weyl` is the same fact in the `torusHom` presentation of a diagonal matrix.

The four boundary values `TauCeti.character_GL2PrincipalSeries_one_one_*`, previously proved through the Steinberg permutation character, are now read off the general row at `α = β = 1` rather than proved a second time; their statements are unchanged and they remain the numeral form of the table entry.

Files:

- `TauCeti/RepresentationTheory/CharacterTable/GL2/PrincipalSeries/CharacterValues.lean` (new, 254 lines): the four character values.
- `TauCeti/RepresentationTheory/Induction/ClassFunction.lean`: `indTerm_of_mem`, `indTerm_eq_zero_of_smul_mk_ne` and `indClassFun_eq_sum_of_smul_eq_self_mem`.
- `TauCeti/GroupTheory/QuotientGroup/Basic.lean`: `smul_quotientGroup_mk_eq_self_iff`, the elementwise reading of the neighbouring `stabilizer_quotientGroup_mk`.
- `TauCeti/RepresentationTheory/CharacterTable/GL2/CharacterValues.lean`: the boundary row derived from the general one.

Nothing is vendored or adapted from an existing formalization; the mathematics is standard, following Fulton–Harris §5.2 and Bonnafé, *Representations of `SL₂(𝔽_q)`*, Chapter 5, both cited in the new file.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"character-gl2principalseries"}-->

🤖 Prepared with Claude Code
