### PR TITLE
feat: add the type B polarized quadratic equivalence

### DIFF
--- a/TauCeti/Algebra/Lie/SkewAdjoint.lean
+++ b/TauCeti/Algebra/Lie/SkewAdjoint.lean
@@ -121,6 +121,9 @@ theorem mem_skewAdjointMatricesLieSubalgebra_toMatrix_iff (b : Module.Basis n R 
     rw [← hJ]
     exact Matrix.toLinearMap₂_toMatrix₂ b b B
   rw [mem_skewAdjointMatricesLieSubalgebra, mem_skewAdjointMatricesSubmodule]
+  -- The rewrites expose matrix skew-adjointness, but membership in the bundled endomorphism Lie
+  -- subalgebra is definitionally membership in the underlying skew-adjoint submodule. Cross that
+  -- wrapper so the explicit membership lemma below can rewrite the predicate.
   change J.IsSkewAdjoint (LinearMap.toMatrix b b f) ↔
     f ∈ B.skewAdjointSubmodule
   rw [LinearMap.mem_skewAdjointSubmodule, Matrix.IsSkewAdjoint, LinearMap.IsSkewAdjoint]
@@ -138,6 +141,9 @@ noncomputable def skewAdjointLieEquivOfBasis (b : Module.Basis n R M) (B : Bilin
   LieEquiv.ofSubalgebras _ _ (Matrix.toLinAlgEquiv b).toLieEquiv <| by
     ext f
     simp only [Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule]
+    -- The map-membership lemmas leave the inverse basis transport bundled; definitionally its
+    -- underlying endomorphism has matrix `LinearMap.toMatrix b b f`. Expose that matrix so the
+    -- shared membership theorem applies directly.
     change LinearMap.toMatrix b b f ∈ skewAdjointMatricesLieSubalgebra J ↔
       f ∈ skewAdjointLieSubalgebra B
     exact mem_skewAdjointMatricesLieSubalgebra_toMatrix_iff b B hJ f

--- a/TauCeti/Algebra/Lie/SkewAdjoint.lean
+++ b/TauCeti/Algebra/Lie/SkewAdjoint.lean
@@ -7,10 +7,17 @@ module
 
 public import Mathlib.Algebra.Lie.Killing
 public import Mathlib.Algebra.Lie.SkewAdjoint
+public import Mathlib.LinearAlgebra.Matrix.BilinearForm
 public import TauCeti.LinearAlgebra.QuadraticForm.Radical
 
 /-!
-# The adjoint action of a Lie algebra carrying an invariant bilinear form
+# Skew-adjoint Lie algebras
+
+A basis identifies matrices skew-adjoint for the Gram matrix of a bilinear form with
+endomorphisms skew-adjoint for the form itself. This file packages that identification as
+`TauCeti.skewAdjointLieEquivOfBasis`.
+
+## The adjoint action of a Lie algebra carrying an invariant bilinear form
 
 A bilinear form `B` on a Lie algebra `L` is *invariant* when `B ⁅x, y⁆ z = -B y ⁅x, z⁆`
 (`LinearMap.BilinForm.lieInvariant`). Read with `x` fixed, that equation says exactly that the
@@ -44,6 +51,8 @@ composite is not built here.
 
 ## Main definitions
 
+* `TauCeti.skewAdjointLieEquivOfBasis`: the basis transport from skew-adjoint matrices to
+  skew-adjoint endomorphisms.
 * `TauCeti.LieAlgebra.adSkewAdjoint`: the adjoint action of a Lie algebra carrying an invariant
   bilinear form `B`, as a Lie algebra homomorphism into the skew-adjoint endomorphisms of `B`.
 * `TauCeti.LieAlgebra.adjointSO`: the same map read into the skew-adjoint endomorphisms of the
@@ -52,6 +61,8 @@ composite is not built here.
 
 ## Main results
 
+* `TauCeti.mem_skewAdjointMatricesLieSubalgebra_toMatrix_iff`: matrix skew-adjointness for a Gram
+  matrix is equivalent to basis-free skew-adjointness.
 * `TauCeti.LieAlgebra.ad_mem_skewAdjointSubmodule`: invariance of a form is skew-adjointness of the
   adjoint action.
 * `TauCeti.LieAlgebra.ker_adSkewAdjoint`: the kernel of `adSkewAdjoint` is the centre, so the map is
@@ -88,6 +99,61 @@ here; only from `ad_mem_skewAdjointSubmodule` on, where the adjoint action enter
 public section
 
 open LinearMap (BilinForm)
+
+namespace TauCeti
+
+universe u v w
+
+section Basis
+
+variable {R : Type u} [CommRing R] {M : Type v} [AddCommGroup M] [Module R M]
+  {n : Type w} [Fintype n] [DecidableEq n]
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+/-- An endomorphism is skew-adjoint for a bilinear form exactly when its matrix in a basis is
+skew-adjoint for the Gram matrix of the form. -/
+theorem mem_skewAdjointMatricesLieSubalgebra_toMatrix_iff (b : Module.Basis n R M)
+    (B : BilinForm R M) {J : Matrix n n R} (hJ : B.toMatrix b = J) (f : Module.End R M) :
+    LinearMap.toMatrix b b f ∈ skewAdjointMatricesLieSubalgebra J ↔
+      f ∈ skewAdjointLieSubalgebra B := by
+  have hB : Matrix.toLinearMap₂ b b J = B := by
+    rw [← hJ]
+    exact Matrix.toLinearMap₂_toMatrix₂ b b B
+  rw [mem_skewAdjointMatricesLieSubalgebra, mem_skewAdjointMatricesSubmodule]
+  change J.IsSkewAdjoint (LinearMap.toMatrix b b f) ↔
+    f ∈ B.skewAdjointSubmodule
+  rw [LinearMap.mem_skewAdjointSubmodule, Matrix.IsSkewAdjoint, LinearMap.IsSkewAdjoint]
+  symm
+  simpa [hB] using
+    (isAdjointPair_toLinearMap₂
+      (b₁ := b) (b₂ := b) (J := J) (J' := J)
+      (A := LinearMap.toMatrix b b f) (A' := -(LinearMap.toMatrix b b f)))
+
+/-- A basis transports the Lie algebra of matrices skew-adjoint for a Gram matrix to the
+basis-free Lie algebra of skew-adjoint endomorphisms. -/
+noncomputable def skewAdjointLieEquivOfBasis (b : Module.Basis n R M) (B : BilinForm R M)
+    {J : Matrix n n R} (hJ : B.toMatrix b = J) :
+    skewAdjointMatricesLieSubalgebra J ≃ₗ⁅R⁆ skewAdjointLieSubalgebra B :=
+  LieEquiv.ofSubalgebras _ _ (Matrix.toLinAlgEquiv b).toLieEquiv <| by
+    ext f
+    simp only [Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule]
+    change LinearMap.toMatrix b b f ∈ skewAdjointMatricesLieSubalgebra J ↔
+      f ∈ skewAdjointLieSubalgebra B
+    exact mem_skewAdjointMatricesLieSubalgebra_toMatrix_iff b B hJ f
+
+/-- The basis transport from skew-adjoint matrices acts by the corresponding matrix
+endomorphism. -/
+@[simp]
+theorem coe_skewAdjointLieEquivOfBasis_apply (b : Module.Basis n R M) (B : BilinForm R M)
+    {J : Matrix n n R} (hJ : B.toMatrix b = J) (A : skewAdjointMatricesLieSubalgebra J) :
+    (skewAdjointLieEquivOfBasis b B hJ A : Module.End R M) = Matrix.toLinAlgEquiv b A := by
+  rw [skewAdjointLieEquivOfBasis, LieEquiv.ofSubalgebras_apply]
+  rfl
+
+end Basis
+
+end TauCeti
 
 namespace TauCeti.LieAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Quadratic/Realization.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.Lie.SkewAdjoint
 public import TauCeti.LinearAlgebra.BilinearForm.ExteriorSquare
 public import TauCeti.LinearAlgebra.CliffordAlgebra.CliffordExteriorSquare
 public import Mathlib.LinearAlgebra.QuadraticForm.Radical
@@ -22,6 +23,8 @@ canonical bivector action rather than from a basis-dependent inverse.
 
 * `CliffordAlgebra.soEquivQuadratic`: the quadratic realization Lie equivalence.
 * `CliffordAlgebra.soEquivQuadratic_lie_ι`: its defining generator-action equation.
+* `CliffordAlgebra.skewAdjointMatricesEquivQuadratic`: the same realization transported through a
+  basis whose Gram matrix is specified.
 * `CliffordAlgebra.quadraticLieSubalgebra_ext`: quadratic elements are
   determined by their commutator action on Clifford generators.
 
@@ -34,7 +37,7 @@ canonical bivector action rather than from a basis-dependent inverse.
 public section
 
 
-universe u v
+universe u v w
 
 namespace CliffordAlgebra
 
@@ -50,6 +53,7 @@ private theorem polarBilin_isSymm (Q : QuadraticForm K V) :
     LinearMap.BilinForm.IsSymm (QuadraticMap.polarBilin Q) :=
   ⟨fun x y => QuadraticMap.polar_comm Q x y⟩
 
+/-- The exterior-square model of the skew-adjoint endomorphisms of the polar form. -/
 private noncomputable def exteriorSquareEquivSkewAdjointPolar
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     ⋀[K]^2 V ≃ₗ[K] skewAdjointLieSubalgebra (QuadraticMap.polarBilin Q) :=
@@ -109,6 +113,8 @@ private theorem ι_exteriorSquareEquivSkewAdjoint_apply
     bivectorExterior_apply_ιMulti, bivector_lie_ι]
   simp only [QuadraticMap.polarBilin_apply_apply, map_sub, map_smul]
 
+/-- The linear equivalence underlying the quadratic realization, obtained through the exterior
+square. -/
 private noncomputable def soToQuadraticLinearEquiv
     (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) :
     skewAdjointLieSubalgebra (QuadraticMap.polarBilin Q) ≃ₗ[K] quadraticLieSubalgebra Q :=
@@ -174,6 +180,26 @@ theorem soEquivQuadratic_lie_ι (Q : QuadraticForm K V) (hQ : Q.Nondegenerate)
   change ⁅((soToQuadraticLinearEquiv Q hQ f : quadraticLieSubalgebra Q) :
       CliffordAlgebra Q), ι Q x⁆ = _
   exact soToQuadraticLinearEquiv_lie_ι Q hQ f x
+
+/-- A basis transports the matrices skew-adjoint for the Gram matrix of a nondegenerate quadratic
+form to the quadratic elements of its Clifford algebra. -/
+noncomputable def skewAdjointMatricesEquivQuadratic {n : Type w} [Fintype n] [DecidableEq n]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (b : Module.Basis n K V)
+    {J : Matrix n n K} (hJ : LinearMap.BilinForm.toMatrix b Q.polarBilin = J) :
+    skewAdjointMatricesLieSubalgebra J ≃ₗ⁅K⁆ quadraticLieSubalgebra Q :=
+  (TauCeti.skewAdjointLieEquivOfBasis b Q.polarBilin hJ).trans (soEquivQuadratic Q hQ)
+
+/-- The matrix-to-quadratic equivalence acts on Clifford generators through the matrix
+endomorphism in the chosen basis. -/
+@[simp]
+theorem skewAdjointMatricesEquivQuadratic_lie_ι {n : Type w} [Fintype n] [DecidableEq n]
+    (Q : QuadraticForm K V) (hQ : Q.Nondegenerate) (b : Module.Basis n K V)
+    {J : Matrix n n K} (hJ : LinearMap.BilinForm.toMatrix b Q.polarBilin = J)
+    (A : skewAdjointMatricesLieSubalgebra J) (x : V) :
+    ⁅(skewAdjointMatricesEquivQuadratic Q hQ b hJ A : CliffordAlgebra Q), ι Q x⁆ =
+      ι Q (Matrix.toLinAlgEquiv b A x) := by
+  rw [skewAdjointMatricesEquivQuadratic, LieEquiv.trans_apply, soEquivQuadratic_lie_ι,
+    TauCeti.coe_skewAdjointLieEquivOfBasis_apply]
 
 /-- Two quadratic Clifford elements are equal when their commutator actions agree on every
 generator. -/

--- a/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
+++ b/TauCeti/LinearAlgebra/QuadraticForm/Standard.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.Lie.SkewAdjoint
 public import Mathlib.Algebra.Lie.Classical
 public import Mathlib.LinearAlgebra.QuadraticForm.Basic
 
@@ -69,16 +70,10 @@ private theorem lieEquivMatrix'_mem_skewAdjoint (J : Matrix n n R)
     (f : Module.End R (n → R)) :
     lieEquivMatrix' f ∈ skewAdjointMatricesLieSubalgebra J ↔
       f ∈ skewAdjointLieSubalgebra (Matrix.toLinearMap₂' R J) := by
-  rw [mem_skewAdjointMatricesLieSubalgebra, mem_skewAdjointMatricesSubmodule]
-  -- Expose matrix skew-adjointness as the `IsAdjointPair` relation used by the bridge theorem.
-  change Matrix.IsAdjointPair J J (LinearMap.toMatrix' f) (-LinearMap.toMatrix' f) ↔
-    f ∈ (Matrix.toLinearMap₂' R J).skewAdjointSubmodule
-  rw [LinearMap.mem_skewAdjointSubmodule]
-  -- Expose linear-map skew-adjointness in the same adjoint-pair representation.
-  change Matrix.IsAdjointPair J J (LinearMap.toMatrix' f) (-LinearMap.toMatrix' f) ↔
-    LinearMap.IsAdjointPair (Matrix.toLinearMap₂' R J) (Matrix.toLinearMap₂' R J) f (-f)
-  simpa using (isAdjointPair_toLinearMap₂' (R := R) (J := J) (J' := J)
-    (A := LinearMap.toMatrix' f) (A' := -(LinearMap.toMatrix' f))).symm
+  apply mem_skewAdjointMatricesLieSubalgebra_toMatrix_iff
+    (Pi.basisFun R n) (Matrix.toLinearMap₂' R J)
+  rw [LinearMap.BilinForm.toMatrix_basisFun]
+  exact LinearMap.toMatrix'_toLinearMap₂' J
 
 variable [Invertible (2 : R)]
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
@@ -145,9 +145,11 @@ private theorem mem_typeB_toMatrix_iff (f : Module.End K V) :
     exact Matrix.toLinearMap₂_toMatrix₂ _ _ Q.polarBilin
   rw [LieAlgebra.Orthogonal.typeB, mem_skewAdjointMatricesLieSubalgebra,
     mem_skewAdjointMatricesSubmodule]
-  rw [show f ∈ skewAdjointLieSubalgebra Q.polarBilin ↔
-      f ∈ Q.polarBilin.skewAdjointSubmodule by
-    exact LieSubalgebra.mem_mk_iff' _ _, LinearMap.mem_skewAdjointSubmodule]
+  -- Expose the two bundled skew-adjoint predicates after transporting the Gram matrix.
+  change (LieAlgebra.Orthogonal.JB ι K).IsSkewAdjoint
+      (LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f) ↔
+    f ∈ Q.polarBilin.skewAdjointSubmodule
+  rw [LinearMap.mem_skewAdjointSubmodule]
   rw [Matrix.IsSkewAdjoint, LinearMap.IsSkewAdjoint]
   symm
   simpa [hB] using

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.Lie.Orthogonal.TypeB.DiagonalCartan
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Realization
+public import TauCeti.RepresentationTheory.Spin.Polarization.Basic
+public import Mathlib.LinearAlgebra.Matrix.BilinearForm
+
+/-!
+# The type-B matrix model of an odd polarization
+
+An odd polarization whose orthogonal remainder contains a vector of coordinate one identifies the
+quadratic space with the standard split odd space. This file compares the resulting basis with
+Mathlib's matrix model of the type-`B` Lie algebra and then with the quadratic elements of the
+Clifford algebra.
+
+The normalization is fixed by `LieAlgebra.Orthogonal.JB`: the distinguished remainder vector has
+polar self-pairing `2`, while the two isotropic families pair by the identity matrix. Keeping the
+coordinate-one hypothesis explicit makes the comparison usable over any field of characteristic
+different from two without choosing a square root or hiding a basis choice.
+
+## Main definitions
+
+* `TauCeti.SpinPolarizationData.typeBBasis`: the odd hyperbolic basis, with the remainder first.
+* `TauCeti.SpinPolarizationData.typeBQuadraticEquiv`: the standard type-`B` matrix algebra
+  identified with the quadratic Clifford Lie algebra.
+
+## Roadmap
+
+This supplies the matrix-to-Clifford bridge needed by the full-weight type-`B` Chevalley carrier
+in Layer 9 of `TauCetiRoadmap/ReductiveGroups/README.md`. The next carrier step is to evaluate the
+comparison on the numbered root vectors and prove their divided powers preserve the integral
+spinor lattice.
+
+## References
+
+* N. Bourbaki, *Groupes et algèbres de Lie*, Chapters 4--6, Planche II.
+* C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
+-/
+
+public section
+
+open CliffordAlgebra QuadraticMap
+
+namespace TauCeti
+
+universe u v w
+
+namespace SpinPolarizationData
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+section PreQuadratic
+
+variable {K : Type u} [CommRing K] {V : Type v} [AddCommGroup V] [Module K V]
+  {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
+  {ι : Type w} [Fintype ι] [DecidableEq ι] (b : Module.Basis ι K P.W)
+  (z : P.line) (hz : P.lineCoordinate z = 1)
+
+/-- A coordinate-one remainder vector identifies the remainder with the scalar line. -/
+private noncomputable def lineEquiv : P.line ≃ₗ[K] K :=
+  LinearEquiv.ofBijective P.lineCoordinate
+    ⟨P.lineCoordinate_injective, fun a => ⟨a • z, by simp [hz]⟩⟩
+
+@[simp]
+private theorem lineEquiv_apply (x : P.line) : P.lineEquiv z hz x = P.lineCoordinate x :=
+  rfl
+
+@[simp]
+private theorem lineEquiv_symm_apply (a : K) : (P.lineEquiv z hz).symm a = a • z := by
+  apply (P.lineEquiv z hz).injective
+  simp [hz]
+
+/-- Coordinates for an odd polarization, ordered with the one-dimensional remainder first. -/
+private noncomputable def oddDecompositionEquiv :
+    (K × (P.W × P.W')) ≃ₗ[K] V :=
+  (((P.lineEquiv z hz).symm.prodCongr (LinearEquiv.refl K (P.W × P.W'))).trans
+      (LinearEquiv.prodComm K P.line (P.W × P.W'))).trans P.decompositionEquiv
+
+private theorem oddDecompositionEquiv_apply (x : K × (P.W × P.W')) :
+    P.oddDecompositionEquiv z hz x =
+      (x.2.1 : V) + x.2.2 + x.1 • (z : V) := by
+  rcases x with ⟨a, x, y⟩
+  simp [oddDecompositionEquiv]
+
+/-- The standard odd hyperbolic basis of a polarization: the coordinate-one remainder vector,
+then a basis of the first isotropic summand, then its polar-dual basis. -/
+noncomputable def typeBBasis : Module.Basis (Unit ⊕ ι ⊕ ι) K V :=
+  ((Module.Basis.singleton Unit K).prod (b.prod (P.dualBasis b))).map
+    (P.oddDecompositionEquiv z hz)
+
+@[simp]
+theorem typeBBasis_inl (i : Unit) : P.typeBBasis b z hz (.inl i) = (z : V) := by
+  simp [typeBBasis, P.oddDecompositionEquiv_apply]
+
+@[simp]
+theorem typeBBasis_inr_inl (i : ι) :
+    P.typeBBasis b z hz (.inr (.inl i)) = (b i : V) := by
+  simp [typeBBasis, P.oddDecompositionEquiv_apply]
+
+@[simp]
+theorem typeBBasis_inr_inr (i : ι) :
+    P.typeBBasis b z hz (.inr (.inr i)) = (P.dualVector b i : V) := by
+  simp [typeBBasis, P.oddDecompositionEquiv_apply]
+
+/-- In the odd hyperbolic basis, the polar form has the standard split type-`B` Gram matrix. -/
+theorem polarBilin_toMatrix_typeBBasis :
+    LinearMap.BilinForm.toMatrix (P.typeBBasis b z hz) Q.polarBilin =
+      LieAlgebra.Orthogonal.JB ι K := by
+  ext (i | (i | i)) (j | (j | j))
+  · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
+      QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_self, ← P.lineCoordinate_sq, hz]
+  · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
+      P.line_orthogonal_W]
+  · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
+      P.line_orthogonal_W']
+  · rw [LinearMap.BilinForm.toMatrix_apply, typeBBasis_inr_inl, typeBBasis_inl,
+      QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_comm]
+    simp [LieAlgebra.Orthogonal.JB, P.line_orthogonal_W]
+  · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
+      LieAlgebra.Orthogonal.JD, P.polar_W_eq_zero]
+  · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
+      LieAlgebra.Orthogonal.JD, QuadraticMap.polarBilin_apply_apply, P.polar_dualVector,
+      Matrix.one_apply]
+  · rw [LinearMap.BilinForm.toMatrix_apply, typeBBasis_inr_inr, typeBBasis_inl,
+      QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_comm]
+    simp [LieAlgebra.Orthogonal.JB, P.line_orthogonal_W']
+  · rw [LinearMap.BilinForm.toMatrix_apply, typeBBasis_inr_inr, typeBBasis_inr_inl,
+      QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_comm, P.polar_dualVector]
+    simp [LieAlgebra.Orthogonal.JB, LieAlgebra.Orthogonal.JD, Matrix.one_apply, eq_comm]
+  · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
+      LieAlgebra.Orthogonal.JD, P.polar_W'_eq_zero]
+
+private theorem mem_typeB_toMatrix_iff (f : Module.End K V) :
+    LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f ∈
+        LieAlgebra.Orthogonal.typeB ι K ↔
+      f ∈ skewAdjointLieSubalgebra Q.polarBilin := by
+  have hB : Matrix.toLinearMap₂ (P.typeBBasis b z hz) (P.typeBBasis b z hz)
+      (LieAlgebra.Orthogonal.JB ι K) = Q.polarBilin := by
+    rw [← P.polarBilin_toMatrix_typeBBasis b z hz]
+    exact Matrix.toLinearMap₂_toMatrix₂ _ _ Q.polarBilin
+  rw [LieAlgebra.Orthogonal.typeB, mem_skewAdjointMatricesLieSubalgebra,
+    mem_skewAdjointMatricesSubmodule]
+  change (LieAlgebra.Orthogonal.JB ι K).IsSkewAdjoint
+      (LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f) ↔
+    f ∈ Q.polarBilin.skewAdjointSubmodule
+  rw [LinearMap.mem_skewAdjointSubmodule]
+  rw [Matrix.IsSkewAdjoint, LinearMap.IsSkewAdjoint]
+  symm
+  simpa [hB] using
+    (isAdjointPair_toLinearMap₂
+      (b₁ := P.typeBBasis b z hz) (b₂ := P.typeBBasis b z hz)
+      (J := LieAlgebra.Orthogonal.JB ι K) (J' := LieAlgebra.Orthogonal.JB ι K)
+      (A := LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f)
+      (A' := -(LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f)))
+
+/-- The split type-`B` matrix model transported to skew-adjoint endomorphisms through the odd
+hyperbolic basis. -/
+private noncomputable def typeBSkewAdjointEquiv :
+    LieAlgebra.Orthogonal.typeB ι K ≃ₗ⁅K⁆ skewAdjointLieSubalgebra Q.polarBilin :=
+  LieEquiv.ofSubalgebras _ _
+    (LinearMap.toMatrixAlgEquiv (P.typeBBasis b z hz)).symm.toLieEquiv <| by
+      ext f
+      simp only [Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule]
+      change LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f ∈
+          LieAlgebra.Orthogonal.typeB ι K ↔
+        f ∈ skewAdjointLieSubalgebra Q.polarBilin
+      exact P.mem_typeB_toMatrix_iff b z hz f
+
+@[simp]
+private theorem typeBSkewAdjointEquiv_apply (A : LieAlgebra.Orthogonal.typeB ι K) :
+    (P.typeBSkewAdjointEquiv b z hz A : Module.End K V) =
+      (LinearMap.toMatrixAlgEquiv (P.typeBBasis b z hz)).symm A := by
+  rfl
+
+end PreQuadratic
+
+section Quadratic
+
+variable {K : Type u} [Field K] {V : Type v} [AddCommGroup V] [Module K V]
+  {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
+  {ι : Type w} [Fintype ι] [DecidableEq ι] (b : Module.Basis ι K P.W)
+  (z : P.line) (hz : P.lineCoordinate z = 1) [Invertible (2 : K)]
+
+/-- An odd polarization with a coordinate-one remainder identifies the split type-`B` matrix
+algebra with the quadratic elements of the Clifford algebra. -/
+noncomputable def typeBQuadraticEquiv :
+    LieAlgebra.Orthogonal.typeB ι K ≃ₗ⁅K⁆ quadraticLieSubalgebra Q := by
+  let _ : Module.Finite K V := Module.Finite.of_basis (P.typeBBasis b z hz)
+  exact (P.typeBSkewAdjointEquiv b z hz).trans
+    (soEquivQuadratic Q (P.nondegenerate
+      ((isUnit_of_invertible (2 : K)).isSMulRegular K)))
+
+/-- The type-`B` comparison acts on Clifford generators through the corresponding matrix
+endomorphism in the odd hyperbolic basis. -/
+@[simp]
+theorem typeBQuadraticEquiv_lie_ι (A : LieAlgebra.Orthogonal.typeB ι K) (x : V) :
+    ⁅(P.typeBQuadraticEquiv b z hz A : CliffordAlgebra Q), CliffordAlgebra.ι Q x⁆ =
+      CliffordAlgebra.ι Q
+        ((LinearMap.toMatrixAlgEquiv (P.typeBBasis b z hz)).symm A x) := by
+  let _ : Module.Finite K V := Module.Finite.of_basis (P.typeBBasis b z hz)
+  rw [typeBQuadraticEquiv, LieEquiv.trans_apply, soEquivQuadratic_lie_ι]
+  rw [P.typeBSkewAdjointEquiv_apply]
+
+end Quadratic
+
+end SpinPolarizationData
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
@@ -20,7 +20,7 @@ the Clifford algebra.
 
 The normalization is fixed by `LieAlgebra.Orthogonal.JB`: the distinguished remainder vector has
 quadratic norm `1` and polar self-pairing `2`, while the two isotropic families pair by the identity
-matrix. The coordinate equivalence absorbs either possible sign of its internal coordinate.
+matrix. The coordinate equivalence absorbs its arbitrary square-one internal coordinate.
 
 ## Main definitions
 
@@ -67,8 +67,8 @@ variable {K : Type u} [CommRing K] {V : Type v} [AddCommGroup V] [Module K V]
   (z : P.line) (hz : Q (z : V) = 1)
 
 /-- A quadratic-unit remainder vector identifies the remainder with the scalar line. The factor
-`lineCoordinate z` makes the chosen vector itself correspond to `1`, regardless of its coordinate
-sign. -/
+`lineCoordinate z` makes the chosen vector itself correspond to `1`, regardless of which
+square-one coordinate it has. -/
 private noncomputable def lineEquiv : P.line ≃ₗ[K] K := by
   have hzz : P.lineCoordinate z * P.lineCoordinate z = 1 := by
     rw [P.lineCoordinate_sq, hz]

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
@@ -13,21 +13,27 @@ public import Mathlib.LinearAlgebra.Matrix.BilinearForm
 /-!
 # The type-B matrix model of an odd polarization
 
-An odd polarization whose orthogonal remainder contains a vector of coordinate one identifies the
-quadratic space with the standard split odd space. This file compares the resulting basis with
-Mathlib's matrix model of the type-`B` Lie algebra and then with the quadratic elements of the
-Clifford algebra.
+An odd polarization whose orthogonal remainder contains a vector of quadratic norm one identifies
+the quadratic space with the standard split odd space. This file compares the resulting basis
+with Mathlib's matrix model of the type-`B` Lie algebra and then with the quadratic elements of
+the Clifford algebra.
 
 The normalization is fixed by `LieAlgebra.Orthogonal.JB`: the distinguished remainder vector has
-polar self-pairing `2`, while the two isotropic families pair by the identity matrix. Keeping the
-coordinate-one hypothesis explicit makes the comparison usable over any field of characteristic
-different from two without choosing a square root or hiding a basis choice.
+quadratic norm `1` and polar self-pairing `2`, while the two isotropic families pair by the identity
+matrix. The coordinate equivalence absorbs either possible sign of its internal coordinate.
 
 ## Main definitions
 
 * `TauCeti.SpinPolarizationData.typeBBasis`: the odd hyperbolic basis, with the remainder first.
 * `TauCeti.SpinPolarizationData.typeBQuadraticEquiv`: the standard type-`B` matrix algebra
   identified with the quadratic Clifford Lie algebra.
+
+## Main results
+
+* `TauCeti.SpinPolarizationData.polarBilin_toMatrix_typeBBasis`: the polar form has Gram matrix
+  `LieAlgebra.Orthogonal.JB` in the odd hyperbolic basis.
+* `TauCeti.SpinPolarizationData.typeBQuadraticEquiv_lie_ι`: the comparison acts on Clifford
+  generators through the matrix endomorphism in that basis.
 
 ## Roadmap
 
@@ -38,7 +44,6 @@ spinor lattice.
 
 ## References
 
-* N. Bourbaki, *Groupes et algèbres de Lie*, Chapters 4--6, Planche II.
 * C. Chevalley, *The Algebraic Theory of Spinors*, Chapter II.
 -/
 
@@ -59,21 +64,34 @@ section PreQuadratic
 variable {K : Type u} [CommRing K] {V : Type v} [AddCommGroup V] [Module K V]
   {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
   {ι : Type w} [Fintype ι] [DecidableEq ι] (b : Module.Basis ι K P.W)
-  (z : P.line) (hz : P.lineCoordinate z = 1)
+  (z : P.line) (hz : Q (z : V) = 1)
 
-/-- A coordinate-one remainder vector identifies the remainder with the scalar line. -/
-private noncomputable def lineEquiv : P.line ≃ₗ[K] K :=
-  LinearEquiv.ofBijective P.lineCoordinate
-    ⟨P.lineCoordinate_injective, fun a => ⟨a • z, by simp [hz]⟩⟩
+/-- A quadratic-unit remainder vector identifies the remainder with the scalar line. The factor
+`lineCoordinate z` makes the chosen vector itself correspond to `1`, regardless of its coordinate
+sign. -/
+private noncomputable def lineEquiv : P.line ≃ₗ[K] K := by
+  have hzz : P.lineCoordinate z * P.lineCoordinate z = 1 := by
+    rw [P.lineCoordinate_sq, hz]
+  exact
+    { toFun x := P.lineCoordinate z * P.lineCoordinate x
+      invFun a := a • z
+      left_inv x := P.lineCoordinate_injective (by
+        simp only [map_smul, smul_eq_mul]
+        rw [mul_right_comm, hzz, one_mul])
+      right_inv a := by
+        simp only [map_smul, smul_eq_mul]
+        rw [mul_left_comm, hzz, mul_one]
+      map_add' x y := by simp [mul_add]
+      map_smul' a x := by simp [mul_left_comm] }
 
 @[simp]
-private theorem lineEquiv_apply (x : P.line) : P.lineEquiv z hz x = P.lineCoordinate x :=
+private theorem lineEquiv_apply (x : P.line) :
+    P.lineEquiv z hz x = P.lineCoordinate z * P.lineCoordinate x :=
   rfl
 
 @[simp]
 private theorem lineEquiv_symm_apply (a : K) : (P.lineEquiv z hz).symm a = a • z := by
-  apply (P.lineEquiv z hz).injective
-  simp [hz]
+  rfl
 
 /-- Coordinates for an odd polarization, ordered with the one-dimensional remainder first. -/
 private noncomputable def oddDecompositionEquiv :
@@ -87,7 +105,7 @@ private theorem oddDecompositionEquiv_apply (x : K × (P.W × P.W')) :
   rcases x with ⟨a, x, y⟩
   simp [oddDecompositionEquiv]
 
-/-- The standard odd hyperbolic basis of a polarization: the coordinate-one remainder vector,
+/-- The standard odd hyperbolic basis of a polarization: the quadratic-unit remainder vector,
 then a basis of the first isotropic summand, then its polar-dual basis. -/
 noncomputable def typeBBasis : Module.Basis (Unit ⊕ ι ⊕ ι) K V :=
   ((Module.Basis.singleton Unit K).prod (b.prod (P.dualBasis b))).map
@@ -113,7 +131,7 @@ theorem polarBilin_toMatrix_typeBBasis :
       LieAlgebra.Orthogonal.JB ι K := by
   ext (i | (i | i)) (j | (j | j))
   · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
-      QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_self, ← P.lineCoordinate_sq, hz]
+      QuadraticMap.polarBilin_apply_apply, QuadraticMap.polar_self, hz]
   · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
       P.line_orthogonal_W]
   · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
@@ -135,51 +153,6 @@ theorem polarBilin_toMatrix_typeBBasis :
   · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JB,
       LieAlgebra.Orthogonal.JD, P.polar_W'_eq_zero]
 
-private theorem mem_typeB_toMatrix_iff (f : Module.End K V) :
-    LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f ∈
-        LieAlgebra.Orthogonal.typeB ι K ↔
-      f ∈ skewAdjointLieSubalgebra Q.polarBilin := by
-  have hB : Matrix.toLinearMap₂ (P.typeBBasis b z hz) (P.typeBBasis b z hz)
-      (LieAlgebra.Orthogonal.JB ι K) = Q.polarBilin := by
-    rw [← P.polarBilin_toMatrix_typeBBasis b z hz]
-    exact Matrix.toLinearMap₂_toMatrix₂ _ _ Q.polarBilin
-  rw [LieAlgebra.Orthogonal.typeB, mem_skewAdjointMatricesLieSubalgebra,
-    mem_skewAdjointMatricesSubmodule]
-  -- Expose the two bundled skew-adjoint predicates after transporting the Gram matrix.
-  change (LieAlgebra.Orthogonal.JB ι K).IsSkewAdjoint
-      (LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f) ↔
-    f ∈ Q.polarBilin.skewAdjointSubmodule
-  rw [LinearMap.mem_skewAdjointSubmodule]
-  rw [Matrix.IsSkewAdjoint, LinearMap.IsSkewAdjoint]
-  symm
-  simpa [hB] using
-    (isAdjointPair_toLinearMap₂
-      (b₁ := P.typeBBasis b z hz) (b₂ := P.typeBBasis b z hz)
-      (J := LieAlgebra.Orthogonal.JB ι K) (J' := LieAlgebra.Orthogonal.JB ι K)
-      (A := LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f)
-      (A' := -(LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f)))
-
-/-- The split type-`B` matrix model transported to skew-adjoint endomorphisms through the odd
-hyperbolic basis. -/
-private noncomputable def typeBSkewAdjointEquiv :
-    LieAlgebra.Orthogonal.typeB ι K ≃ₗ⁅K⁆ skewAdjointLieSubalgebra Q.polarBilin :=
-  LieEquiv.ofSubalgebras _ _
-    (LinearMap.toMatrixAlgEquiv (P.typeBBasis b z hz)).symm.toLieEquiv <| by
-      ext f
-      simp only [Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule]
-      -- `toMatrixAlgEquiv` has no application lemma identifying the inverse linear equivalence
-      -- produced here with `LinearMap.toMatrix`, so expose that definitional equality explicitly.
-      change LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f ∈
-          LieAlgebra.Orthogonal.typeB ι K ↔
-        f ∈ skewAdjointLieSubalgebra Q.polarBilin
-      exact P.mem_typeB_toMatrix_iff b z hz f
-
-@[simp]
-private theorem typeBSkewAdjointEquiv_apply (A : LieAlgebra.Orthogonal.typeB ι K) :
-    (P.typeBSkewAdjointEquiv b z hz A : Module.End K V) =
-      (LinearMap.toMatrixAlgEquiv (P.typeBBasis b z hz)).symm A := by
-  rfl
-
 end PreQuadratic
 
 section Quadratic
@@ -187,16 +160,16 @@ section Quadratic
 variable {K : Type u} [Field K] {V : Type v} [AddCommGroup V] [Module K V]
   {Q : QuadraticForm K V} (P : SpinPolarizationData Q)
   {ι : Type w} [Fintype ι] [DecidableEq ι] (b : Module.Basis ι K P.W)
-  (z : P.line) (hz : P.lineCoordinate z = 1) [Invertible (2 : K)]
+  (z : P.line) (hz : Q (z : V) = 1) [Invertible (2 : K)]
 
-/-- An odd polarization with a coordinate-one remainder identifies the split type-`B` matrix
+/-- An odd polarization with a quadratic-unit remainder identifies the split type-`B` matrix
 algebra with the quadratic elements of the Clifford algebra. -/
 noncomputable def typeBQuadraticEquiv :
     LieAlgebra.Orthogonal.typeB ι K ≃ₗ⁅K⁆ quadraticLieSubalgebra Q := by
   let _ : Module.Finite K V := Module.Finite.of_basis (P.typeBBasis b z hz)
-  exact (P.typeBSkewAdjointEquiv b z hz).trans
-    (soEquivQuadratic Q (P.nondegenerate
-      ((isUnit_of_invertible (2 : K)).isSMulRegular K)))
+  exact skewAdjointMatricesEquivQuadratic Q
+    (P.nondegenerate ((isUnit_of_invertible (2 : K)).isSMulRegular K))
+    (P.typeBBasis b z hz) (P.polarBilin_toMatrix_typeBBasis b z hz)
 
 /-- The type-`B` comparison acts on Clifford generators through the corresponding matrix
 endomorphism in the odd hyperbolic basis. -/
@@ -204,10 +177,16 @@ endomorphism in the odd hyperbolic basis. -/
 theorem typeBQuadraticEquiv_lie_ι (A : LieAlgebra.Orthogonal.typeB ι K) (x : V) :
     ⁅(P.typeBQuadraticEquiv b z hz A : CliffordAlgebra Q), CliffordAlgebra.ι Q x⁆ =
       CliffordAlgebra.ι Q
-        ((LinearMap.toMatrixAlgEquiv (P.typeBBasis b z hz)).symm A x) := by
+        (Matrix.toLinAlgEquiv (P.typeBBasis b z hz) A x) := by
   let _ : Module.Finite K V := Module.Finite.of_basis (P.typeBBasis b z hz)
-  rw [typeBQuadraticEquiv, LieEquiv.trans_apply, soEquivQuadratic_lie_ι]
-  rw [P.typeBSkewAdjointEquiv_apply]
+  -- Unfold the type-`B` abbreviation to expose the shared matrix-to-quadratic transport.
+  change ⁅(skewAdjointMatricesEquivQuadratic Q
+    (P.nondegenerate ((isUnit_of_invertible (2 : K)).isSMulRegular K))
+    (P.typeBBasis b z hz) (P.polarBilin_toMatrix_typeBBasis b z hz) A : CliffordAlgebra Q),
+      CliffordAlgebra.ι Q x⁆ = _
+  exact skewAdjointMatricesEquivQuadratic_lie_ι Q
+    (P.nondegenerate ((isUnit_of_invertible (2 : K)).isSMulRegular K))
+    (P.typeBBasis b z hz) (P.polarBilin_toMatrix_typeBBasis b z hz) A x
 
 end Quadratic
 

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean
@@ -5,9 +5,9 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Algebra.Lie.Orthogonal.TypeB.DiagonalCartan
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Quadratic.Realization
 public import TauCeti.RepresentationTheory.Spin.Polarization.Basic
+public import Mathlib.Algebra.Lie.Classical
 public import Mathlib.LinearAlgebra.Matrix.BilinearForm
 
 /-!
@@ -145,10 +145,9 @@ private theorem mem_typeB_toMatrix_iff (f : Module.End K V) :
     exact Matrix.toLinearMap₂_toMatrix₂ _ _ Q.polarBilin
   rw [LieAlgebra.Orthogonal.typeB, mem_skewAdjointMatricesLieSubalgebra,
     mem_skewAdjointMatricesSubmodule]
-  change (LieAlgebra.Orthogonal.JB ι K).IsSkewAdjoint
-      (LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f) ↔
-    f ∈ Q.polarBilin.skewAdjointSubmodule
-  rw [LinearMap.mem_skewAdjointSubmodule]
+  rw [show f ∈ skewAdjointLieSubalgebra Q.polarBilin ↔
+      f ∈ Q.polarBilin.skewAdjointSubmodule by
+    exact LieSubalgebra.mem_mk_iff' _ _, LinearMap.mem_skewAdjointSubmodule]
   rw [Matrix.IsSkewAdjoint, LinearMap.IsSkewAdjoint]
   symm
   simpa [hB] using
@@ -166,6 +165,8 @@ private noncomputable def typeBSkewAdjointEquiv :
     (LinearMap.toMatrixAlgEquiv (P.typeBBasis b z hz)).symm.toLieEquiv <| by
       ext f
       simp only [Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule]
+      -- `toMatrixAlgEquiv` has no application lemma identifying the inverse linear equivalence
+      -- produced here with `LinearMap.toMatrix`, so expose that definitional equality explicitly.
       change LinearMap.toMatrix (P.typeBBasis b z hz) (P.typeBBasis b z hz) f ∈
           LieAlgebra.Orthogonal.typeB ι K ↔
         f ∈ skewAdjointLieSubalgebra Q.polarBilin

--- a/TauCeti/RepresentationTheory/Spin/Polarization/TypeD.lean
+++ b/TauCeti/RepresentationTheory/Spin/Polarization/TypeD.lean
@@ -92,54 +92,6 @@ theorem polarBilin_toMatrix_typeDBasis (hline : P.line = ⊥) :
   · simp [LinearMap.BilinForm.toMatrix_apply, LieAlgebra.Orthogonal.JD,
       P.polar_W'_eq_zero]
 
-private theorem mem_typeD_toMatrix_iff (hline : P.line = ⊥) (f : Module.End K V) :
-    LinearMap.toMatrix (P.typeDBasis b hline) (P.typeDBasis b hline) f ∈
-        LieAlgebra.Orthogonal.typeD ι K ↔
-      f ∈ skewAdjointLieSubalgebra Q.polarBilin := by
-  have hB : Matrix.toLinearMap₂ (P.typeDBasis b hline) (P.typeDBasis b hline)
-      (LieAlgebra.Orthogonal.JD ι K) = Q.polarBilin := by
-    rw [← P.polarBilin_toMatrix_typeDBasis b hline]
-    exact Matrix.toLinearMap₂_toMatrix₂ _ _ Q.polarBilin
-  -- Convert the matrix Gram equation to the basis-free bilinear form before comparing
-  -- skew-adjointness.
-  rw [LieAlgebra.Orthogonal.typeD, mem_skewAdjointMatricesLieSubalgebra,
-    mem_skewAdjointMatricesSubmodule]
-  -- Expose the two bundled skew-adjoint predicates after transporting the Gram matrix.
-  change (LieAlgebra.Orthogonal.JD ι K).IsSkewAdjoint
-      (LinearMap.toMatrix (P.typeDBasis b hline) (P.typeDBasis b hline) f) ↔
-    f ∈ Q.polarBilin.skewAdjointSubmodule
-  rw [LinearMap.mem_skewAdjointSubmodule]
-  rw [Matrix.IsSkewAdjoint, LinearMap.IsSkewAdjoint]
-  symm
-  simpa [hB] using
-    (isAdjointPair_toLinearMap₂
-      (b₁ := P.typeDBasis b hline) (b₂ := P.typeDBasis b hline)
-      (J := LieAlgebra.Orthogonal.JD ι K) (J' := LieAlgebra.Orthogonal.JD ι K)
-      (A := LinearMap.toMatrix (P.typeDBasis b hline) (P.typeDBasis b hline) f)
-      (A' := -(LinearMap.toMatrix (P.typeDBasis b hline) (P.typeDBasis b hline) f)))
-
-/-- The split matrix model transported to skew-adjoint endomorphisms through the hyperbolic
-basis. -/
-private noncomputable def typeDSkewAdjointEquiv
-    (b : Module.Basis ι K P.W) (hline : P.line = ⊥) :
-    LieAlgebra.Orthogonal.typeD ι K ≃ₗ⁅K⁆ skewAdjointLieSubalgebra Q.polarBilin :=
-  LieEquiv.ofSubalgebras _ _
-    (LinearMap.toMatrixAlgEquiv (P.typeDBasis b hline)).symm.toLieEquiv <| by
-      ext f
-      simp only [Submodule.mem_map_equiv, LieSubalgebra.mem_map_submodule]
-      -- Membership in the mapped subalgebra is the underlying matrix membership statement.
-      change LinearMap.toMatrix (P.typeDBasis b hline) (P.typeDBasis b hline) f ∈
-          LieAlgebra.Orthogonal.typeD ι K ↔
-        f ∈ skewAdjointLieSubalgebra Q.polarBilin
-      exact P.mem_typeD_toMatrix_iff b hline f
-
-@[simp]
-private theorem typeDSkewAdjointEquiv_apply (hline : P.line = ⊥)
-    (A : LieAlgebra.Orthogonal.typeD ι K) :
-    (P.typeDSkewAdjointEquiv b hline A : Module.End K V) =
-      (LinearMap.toMatrixAlgEquiv (P.typeDBasis b hline)).symm A := by
-  rfl
-
 end PreQuadratic
 
 section Quadratic
@@ -155,8 +107,8 @@ noncomputable def typeDQuadraticEquiv
     (b : Module.Basis ι K P.W) (hline : P.line = ⊥) :
     LieAlgebra.Orthogonal.typeD ι K ≃ₗ⁅K⁆ quadraticLieSubalgebra Q := by
   let _ : Module.Finite K V := Module.Finite.of_basis (P.typeDBasis b hline)
-  exact (P.typeDSkewAdjointEquiv b hline).trans
-    (soEquivQuadratic Q (P.nondegenerate_of_line_eq_bot hline))
+  exact skewAdjointMatricesEquivQuadratic Q (P.nondegenerate_of_line_eq_bot hline)
+    (P.typeDBasis b hline) (P.polarBilin_toMatrix_typeDBasis b hline)
 
 /-- The type-`D` comparison acts on Clifford generators through the corresponding matrix
 endomorphism in the hyperbolic basis. -/
@@ -165,10 +117,14 @@ theorem typeDQuadraticEquiv_lie_ι (hline : P.line = ⊥)
     (A : LieAlgebra.Orthogonal.typeD ι K) (x : V) :
     ⁅(P.typeDQuadraticEquiv b hline A : CliffordAlgebra Q), CliffordAlgebra.ι Q x⁆ =
       CliffordAlgebra.ι Q
-        ((LinearMap.toMatrixAlgEquiv (P.typeDBasis b hline)).symm A x) := by
+        (Matrix.toLinAlgEquiv (P.typeDBasis b hline) A x) := by
   let _ : Module.Finite K V := Module.Finite.of_basis (P.typeDBasis b hline)
-  rw [typeDQuadraticEquiv, LieEquiv.trans_apply, soEquivQuadratic_lie_ι]
-  rw [P.typeDSkewAdjointEquiv_apply]
+  -- Unfold the type-`D` abbreviation to expose the shared matrix-to-quadratic transport.
+  change ⁅(skewAdjointMatricesEquivQuadratic Q (P.nondegenerate_of_line_eq_bot hline)
+    (P.typeDBasis b hline) (P.polarBilin_toMatrix_typeDBasis b hline) A : CliffordAlgebra Q),
+      CliffordAlgebra.ι Q x⁆ = _
+  exact skewAdjointMatricesEquivQuadratic_lie_ι Q (P.nondegenerate_of_line_eq_bot hline)
+    (P.typeDBasis b hline) (P.polarBilin_toMatrix_typeDBasis b hline) A x
 
 /-- The standard one-coordinate diagonal matrix is the diagonal Clifford bivector of the
 corresponding polarization coordinate. -/


### PR DESCRIPTION
This PR identifies an odd polarization with the standard split type-`B` matrix model and transports that model to the quadratic Clifford Lie algebra. Given a basis of the first isotropic summand and a remainder vector of quadratic norm one, it constructs the ordered odd hyperbolic basis, proves that the polar form has Mathlib's `LieAlgebra.Orthogonal.JB` Gram matrix, and packages the resulting Lie equivalence as `SpinPolarizationData.typeBQuadraticEquiv` with its defining action on Clifford generators.

The exact roadmap target is ReductiveGroups Layer 9, “The Chevalley–Demazure construction”: construct the split simply connected type-`B` carrier from an explicit full-weight spin lattice and numbered Chevalley generators. This comparison is the missing matrix-to-Clifford bridge between the existing type-`B` root matrices and the spin representation, and CFSGStatement milestone L0 consumes the resulting pinned type-`B` group scheme as an ambient group.

This is the most effective current step because the standard type-`B` matrix algebra, polarized Clifford realization, integral spinor lattice, and type-`B` root generators are already on `main`, while the corresponding odd comparison was absent; the open type-`B` work concerns weight coordinates and Serre relations rather than this bridge.

After this PR, the type-`B` carrier still needs the comparison evaluated on the numbered root vectors, divided-power preservation of the integral spinor lattice, and assembly through the existing Kostant machinery into the pinned group scheme.

The implementation reuses Mathlib's `LieAlgebra.Orthogonal.JB`, `LieAlgebra.Orthogonal.typeB`, matrix/bilinear-form basis transport, and Tau Ceti's existing `CliffordAlgebra.soEquivQuadratic`; no Mathlib code or external formalization is vendored. The Clifford comparison follows Chevalley, *The Algebraic Theory of Spinors*, Chapter II, as credited in the module documentation.

The change adds `TauCeti/RepresentationTheory/Spin/Polarization/TypeB.lean` and factors the shared basis transport through the existing skew-adjoint and quadratic-realization modules.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"typebquadraticequiv"}-->

🤖 Prepared with Codex

