### PR TITLE
feat: the full-weight type-C carrier preserves the alternating form

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/ConstantForm/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/ConstantForm/Basic.lean
@@ -64,6 +64,8 @@ a relation between `C` and `Cᵀ`.
 ## Main declarations
 
 * `TauCeti.ConstantForm.relationMatrix`: the matrix of defining relations `X C Xᵀ - C`.
+* `TauCeti.ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix`: a coordinate
+  morphism whose generic matrix preserves `C` kills the defining ideal.
 * `TauCeti.ConstantForm.definingHopfIdeal`: the Hopf ideal its entries generate.
 * `TauCeti.ConstantForm.coordinateHopfAlgebra` and `TauCeti.ConstantForm.coordinateMap`: the
   quotient coordinate Hopf algebra and the quotient morphism onto it.
@@ -283,6 +285,24 @@ noncomputable def definingHopfIdeal :
 theorem definingHopfIdeal_toIdeal :
     (definingHopfIdeal R n C).toIdeal = Ideal.span (relationSet R n C) := by
   rw [definingHopfIdeal, HopfIdeal.ofSpan_toIdeal]
+
+/-- **A coordinate morphism whose generic matrix preserves `C` kills the defining ideal.** This is
+the criterion by which a subgroup of `GL n` given by generating morphisms is shown to lie in the
+subgroup scheme preserving `C`: it suffices to evaluate the form relation on the generic matrix of
+each generator. -/
+theorem definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix
+    {T : Type*} [CommRing T] [Algebra R T]
+    (phi : GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] T)
+    (hphi : (GeneralLinear.genericMatrix R n).map phi * C.map (algebraMap R T) *
+        ((GeneralLinear.genericMatrix R n).map phi)ᵀ = C.map (algebraMap R T)) :
+    (definingHopfIdeal R n C).toIdeal ≤ RingHom.ker (phi : _ →+* T) := by
+  rw [definingHopfIdeal_toIdeal, Ideal.span_le]
+  intro x hx
+  obtain ⟨a, c, rfl⟩ := (mem_relationSet_iff R n C).mp hx
+  have h := congrFun (congrFun (relationMatrix_map R n C phi) a) c
+  rw [Matrix.map_apply] at h
+  simp only [SetLike.mem_coe, RingHom.mem_ker, RingHom.coe_coe]
+  rw [h, hphi, Matrix.sub_apply, sub_self]
 
 /-- The coordinate Hopf algebra of the subgroup scheme of `GL n` preserving `C`. -/
 noncomputable abbrev coordinateHopfAlgebra : _root_.CommHopfAlgCat.{u} R :=

--- a/TauCeti/Algebra/AlgebraicGroup/ConstantForm/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/ConstantForm/Basic.lean
@@ -64,8 +64,8 @@ a relation between `C` and `Cᵀ`.
 ## Main declarations
 
 * `TauCeti.ConstantForm.relationMatrix`: the matrix of defining relations `X C Xᵀ - C`.
-* `TauCeti.ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix`: a coordinate
-  morphism whose generic matrix preserves `C` kills the defining ideal.
+* `TauCeti.ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix_mul_mul_transpose`:
+  a coordinate morphism whose generic matrix `X` satisfies `X C Xᵀ = C` kills the defining ideal.
 * `TauCeti.ConstantForm.definingHopfIdeal`: the Hopf ideal its entries generate.
 * `TauCeti.ConstantForm.coordinateHopfAlgebra` and `TauCeti.ConstantForm.coordinateMap`: the
   quotient coordinate Hopf algebra and the quotient morphism onto it.
@@ -286,11 +286,11 @@ theorem definingHopfIdeal_toIdeal :
     (definingHopfIdeal R n C).toIdeal = Ideal.span (relationSet R n C) := by
   rw [definingHopfIdeal, HopfIdeal.ofSpan_toIdeal]
 
-/-- **A coordinate morphism whose generic matrix preserves `C` kills the defining ideal.** This is
-the criterion by which a subgroup of `GL n` given by generating morphisms is shown to lie in the
-subgroup scheme preserving `C`: it suffices to evaluate the form relation on the generic matrix of
-each generator. -/
-theorem definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix
+/-- **A coordinate morphism whose generic matrix `X` satisfies `X C Xᵀ = C` kills the defining
+ideal.** This is the criterion by which a subgroup of `GL n` given by generating morphisms is shown
+to lie in the subgroup scheme preserving `C`: it suffices to evaluate the form relation on the
+generic matrix of each generator. -/
+theorem definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix_mul_mul_transpose
     {T : Type*} [CommRing T] [Algebra R T]
     (phi : GeneralLinear.coordinateHopfAlgebra R n →ₐ[R] T)
     (hphi : (GeneralLinear.genericMatrix R n).map phi * C.map (algebraMap R T) *

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/AlternatingForm.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/AlternatingForm.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Symplectic.Basic
 public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Scheme
-public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ClosedImmersion
 
 /-!
 # The full-weight type-C carrier preserves the standard alternating form

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/AlternatingForm.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/AlternatingForm.lean
@@ -35,6 +35,7 @@ is reductive, that its weight torus is maximal, or that any group in sight is fi
 
 * `TauCeti.SpStd.rootIntMatrix`: the integral matrix of a numbered root generator in the
   enumerated coordinate basis of the standard lattice.
+* `TauCeti.SpStd.toSymplectic`: the canonical closed immersion from the carrier to `Sp_(2n+2)`.
 
 ## Main results
 
@@ -48,6 +49,8 @@ is reductive, that its weight torus is maximal, or that any group in sight is fi
   the defining Hopf ideal of the carrier.
 * `TauCeti.SpStd.mem_GLSymplecticFin_of_mem_points`: every matrix point of the carrier preserves
   the standard alternating form.
+* `TauCeti.SpStd.toSymplectic_comp_inclusion`: composing with `Sp_(2n+2) → GL_(2n+2)` recovers the
+  carrier inclusion.
 
 ## References
 
@@ -88,9 +91,9 @@ standard lattice. Its columns are the coefficients of the images of the basis ve
 integral because the generator preserves the lattice. -/
 noncomputable def rootIntMatrix (k : Fin (n + 1) ⊕ Fin (n + 1)) :
     Matrix (Fin ((n + 1) + (n + 1))) (Fin ((n + 1) + (n + 1))) ℤ :=
-  Matrix.of fun r s => (latticeBasis n).repr
+  (latticeBasis n).toMatrix fun s =>
     ⟨rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator n k)) (latticeBasis n s),
-      rep_rootGenerator_mem_lattice n k (latticeBasis n s).2⟩ r
+      rep_rootGenerator_mem_lattice n k (latticeBasis n s).2⟩
 
 /-- A numbered root generator acts on a coordinate basis vector by the corresponding column of
 `TauCeti.SpStd.rootIntMatrix`. -/
@@ -101,9 +104,11 @@ theorem rep_rootGenerator_latticeBasis_eq_sum (k : Fin (n + 1) ⊕ Fin (n + 1))
       ∑ r, rootIntMatrix n k r s •
         ((latticeBasis n r : (lattice n).toAddSubgroup) :
           (Fin (n + 1) ⊕ Fin (n + 1)) → ℚ) := by
-  have h := ((latticeBasis n).sum_repr
-    ⟨rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator n k)) (latticeBasis n s),
-      rep_rootGenerator_mem_lattice n k (latticeBasis n s).2⟩).symm
+  have h := ((latticeBasis n).sum_toMatrix_smul_self
+    (fun s => (⟨rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator n k))
+        (latticeBasis n s),
+      rep_rootGenerator_mem_lattice n k (latticeBasis n s).2⟩ :
+        (lattice n).toAddSubgroup)) s).symm
   have h' := congrArg
     (fun w : (lattice n).toAddSubgroup => (w : (Fin (n + 1) ⊕ Fin (n + 1)) → ℚ)) h
   simp only [AddSubmonoidClass.coe_finsetSum] at h'
@@ -118,7 +123,7 @@ theorem intCast_rootIntMatrix (k : Fin (n + 1) ⊕ Fin (n + 1))
       (rootGenerator n k :
         Matrix (Fin (n + 1) ⊕ Fin (n + 1)) (Fin (n + 1) ⊕ Fin (n + 1)) ℚ)
         (finSumFinEquiv.symm r) (finSumFinEquiv.symm s) := by
-  rw [rootIntMatrix, Matrix.of_apply, intCast_latticeBasis_repr]
+  rw [rootIntMatrix, Module.Basis.toMatrix_apply, intCast_latticeBasis_repr]
   -- Reduce the coercion of the anonymous constructor before rewriting under it.
   dsimp only
   rw [rep_ι_apply, coe_latticeBasis]
@@ -150,12 +155,6 @@ private theorem mul_J_add_J_mul_transpose_eq_zero_of_mem_sp {l : Type*} [Decidab
     rw [Matrix.mul_assoc, hJ, Matrix.mul_neg, Matrix.mul_one]
   rw [h2, neg_add_cancel]
 
-private theorem eq_zero_of_map_intCast {N : ℕ} {P : Matrix (Fin N) (Fin N) ℤ}
-    (h : P.map (Int.castRingHom ℚ) = 0) : P = 0 := by
-  ext r c
-  have hrc := congrFun (congrFun h r) c
-  simpa using hrc
-
 private theorem rootIntMatrix_mul_JFin_add_eq_zero (k : Fin (n + 1) ⊕ Fin (n + 1)) :
     rootIntMatrix n k * TauCeti.JFin (n + 1) ℤ +
       TauCeti.JFin (n + 1) ℤ * (rootIntMatrix n k)ᵀ = 0 := by
@@ -164,11 +163,13 @@ private theorem rootIntMatrix_mul_JFin_add_eq_zero (k : Fin (n + 1) ⊕ Fin (n +
       (Matrix.J (Fin (n + 1)) ℚ).submatrix finSumFinEquiv.symm finSumFinEquiv.symm := by
     rw [← TauCeti.JFin_submatrix (n + 1) (R := ℚ), Matrix.submatrix_submatrix]
     simp
-  refine eq_zero_of_map_intCast ?_
+  refine Matrix.map_injective (f := ((Int.castRingHom ℚ : ℤ →+* ℚ) : ℤ → ℚ))
+    Int.cast_injective ?_
+  simp only [Matrix.map_zero _ (map_zero (Int.castRingHom ℚ))]
   rw [← RingHom.mapMatrix_apply, map_add, map_mul, map_mul]
   simp only [RingHom.mapMatrix_apply]
   rw [TauCeti.JFin_map (n + 1) (Int.castRingHom ℚ)]
-  rw [show ((Int.castRingHom ℚ : ℤ →+* ℚ) : ℤ → ℚ) = (Int.cast : ℤ → ℚ) from rfl]
+  simp only [Int.coe_castRingHom]
   rw [Matrix.transpose_map, map_rootIntMatrix, hJ, Matrix.transpose_submatrix,
     Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv]
   ext r c
@@ -188,10 +189,11 @@ private theorem rootIntMatrix_mul_self_eq_zero (k : Fin (n + 1) ⊕ Fin (n + 1))
     simp only [LinearMap.zero_apply] at h
     have := congrFun h a
     simpa [Matrix.mulVec_single] using this
-  refine eq_zero_of_map_intCast ?_
+  refine Matrix.map_injective (f := ((Int.castRingHom ℚ : ℤ →+* ℚ) : ℤ → ℚ))
+    Int.cast_injective ?_
+  simp only [Matrix.map_zero _ (map_zero (Int.castRingHom ℚ))]
   rw [← RingHom.mapMatrix_apply, map_mul]
-  simp only [RingHom.mapMatrix_apply]
-  rw [show ((Int.castRingHom ℚ : ℤ →+* ℚ) : ℤ → ℚ) = (Int.cast : ℤ → ℚ) from rfl]
+  simp only [RingHom.mapMatrix_apply, Int.coe_castRingHom]
   rw [map_rootIntMatrix, Matrix.submatrix_mul_equiv, hG]
   simp
 
@@ -249,6 +251,8 @@ theorem rootIntMatrix_map_mul_self_eq_zero {A : Type*} [CommRing A]
   simp only [RingHom.mapMatrix_apply] at h2
   exact h2
 
+open TauCeti.UniversalEnvelopingAlgebra
+  (exists_map_genericMatrix_kostantRootSubgroupCoordinateMap_eq_one_add_smul) in
 private theorem rootCoordinateMap_symplectic (k : Fin (n + 1) ⊕ Fin (n + 1)) :
     (GeneralLinear.genericMatrix ℤ ((n + 1) + (n + 1))).map
         (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator n)
@@ -265,11 +269,11 @@ private theorem rootCoordinateMap_symplectic (k : Fin (n + 1) ⊕ Fin (n + 1)) :
       (TauCeti.JFin (n + 1) ℤ).map
         (algebraMap ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) := by
   obtain ⟨t, ht⟩ :=
-    TauCeti.UniversalEnvelopingAlgebra.exists_map_genericMatrix_kostantRootSubgroupCoordinateMap
+    exists_map_genericMatrix_kostantRootSubgroupCoordinateMap_eq_one_add_smul
       (rootGenerator n) (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
       (fun _ hu _ hv => rep_kostantForm_mem_lattice n hu hv) k
       (isNilpotent_rep_rootGenerator n k) (latticeBasis n) (rootIntMatrix n k)
-      (nilpotencyClass_rep_rootGenerator n k) (rep_rootGenerator_latticeBasis_eq_sum n k)
+      (nilpotencyClass_rep_rootGenerator n k).le (rep_rootGenerator_latticeBasis_eq_sum n k)
   rw [ht, TauCeti.JFin_map (n + 1) (algebraMap ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))]
   exact one_add_smul_mul_mul_transpose _ _ _ (rootIntMatrix_map_mul_JFin_add_eq_zero n k)
     (rootIntMatrix_map_mul_self_eq_zero n k)
@@ -286,6 +290,31 @@ private theorem map_genericMatrix_weightTorusCoordinateMap :
   rw [Matrix.map_apply, GeneralLinear.genericMatrix_apply]
   simp only [BialgHom.coe_toAlgHom]
   rw [GeneralLinear.weightTorusCoordinateMap_X, Matrix.diagonal_apply]
+
+/-- The weight at the symplectic partner of a coordinate is the negative of the weight at the
+coordinate: the standard weights come in the pairs `ε_a` and `-ε_a`. -/
+private theorem basisWeight_inr_eq_neg (x : Fin (n + 1)) :
+    basisWeight n (finSumFinEquiv (Sum.inr x)) =
+      -basisWeight n (finSumFinEquiv (Sum.inl x)) := by
+  funext j
+  rw [basisWeight_apply, basisWeight_apply, Equiv.symm_apply_apply, Equiv.symm_apply_apply,
+    weight_inr, Pi.neg_apply, weight_inl]
+
+/-- The weight-torus characters at a coordinate and at its symplectic partner are inverse to
+each other, because their weights sum to zero. -/
+private theorem torusCharacter_mul_partner (x : Fin (n + 1)) :
+    (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm
+        (basisWeight n (finSumFinEquiv (Sum.inl x))))) (1 : ℤ)) *
+      (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm
+        (basisWeight n (finSumFinEquiv (Sum.inr x))))) (1 : ℤ)) = 1 := by
+  rw [MonoidAlgebra.single_mul_single, mul_one, ← ofAdd_add]
+  have hz : Finsupp.equivFunOnFinite.symm (basisWeight n (finSumFinEquiv (Sum.inl x))) +
+      Finsupp.equivFunOnFinite.symm (basisWeight n (finSumFinEquiv (Sum.inr x))) = 0 := by
+    rw [basisWeight_inr_eq_neg]
+    ext j
+    simp
+  rw [hz]
+  rfl
 
 private theorem torusCoordinateMap_symplectic :
     (GeneralLinear.genericMatrix ℤ ((n + 1) + (n + 1))).map
@@ -305,26 +334,9 @@ private theorem torusCoordinateMap_symplectic :
       (algebraMap ℤ
         (DiagonalizableGroup.coordinateRing ℤ (SplitTorus.characterGroup (Fin (n + 1)))).obj)]
   refine diagonal_mul_mul_transpose_diagonal _ _ ?_
-  have hinv : ∀ x : Fin (n + 1),
-      (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm
-          (basisWeight n (finSumFinEquiv (Sum.inl x))))) (1 : ℤ)) *
-        (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm
-          (basisWeight n (finSumFinEquiv (Sum.inr x))))) (1 : ℤ)) = 1 := by
-    intro x
-    rw [MonoidAlgebra.single_mul_single, mul_one, ← ofAdd_add]
-    have hw : basisWeight n (finSumFinEquiv (Sum.inr x)) =
-        -basisWeight n (finSumFinEquiv (Sum.inl x)) := by
-      funext j
-      rw [basisWeight_apply, basisWeight_apply, Equiv.symm_apply_apply, Equiv.symm_apply_apply,
-        weight_inr, Pi.neg_apply, weight_inl]
-    have hz : Finsupp.equivFunOnFinite.symm (basisWeight n (finSumFinEquiv (Sum.inl x))) +
-        Finsupp.equivFunOnFinite.symm (basisWeight n (finSumFinEquiv (Sum.inr x))) = 0 := by
-      rw [hw]
-      ext j
-      simp
-    rw [hz]
-    rfl
   intro r c
+  -- Name the two indices through the enumeration of the coordinate basis, so that the entry of
+  -- the transported form is an entry of Mathlib's `Matrix.J`.
   obtain ⟨a, rfl⟩ : ∃ a, finSumFinEquiv a = r := ⟨finSumFinEquiv.symm r, by simp⟩
   obtain ⟨b, rfl⟩ : ∃ b, finSumFinEquiv b = c := ⟨finSumFinEquiv.symm c, by simp⟩
   have hJ := congrFun (congrFun (TauCeti.JFin_submatrix (n + 1)
@@ -332,30 +344,25 @@ private theorem torusCoordinateMap_symplectic :
       (SplitTorus.characterGroup (Fin (n + 1)))).obj)) a) b
   rw [Matrix.submatrix_apply] at hJ
   rw [hJ]
+  -- Only the two off-diagonal blocks contribute, and there only at a coordinate and its own
+  -- symplectic partner, where the two characters multiply to one.
   cases a with
   | inl x =>
     cases b with
     | inl y => simp [Matrix.J]
     | inr y =>
-      by_cases hxy : x = y
-      · subst hxy
-        rw [show Matrix.J (Fin (n + 1))
-            (DiagonalizableGroup.coordinateRing ℤ
-              (SplitTorus.characterGroup (Fin (n + 1)))).obj (Sum.inl x) (Sum.inr x) = -1 by
-          simp [Matrix.J]]
-        rw [mul_comm, ← mul_assoc, mul_comm _ (MonoidAlgebra.single _ _)]
-        rw [hinv x, one_mul]
+      rcases eq_or_ne x y with rfl | hxy
+      · simp only [Matrix.J, Matrix.fromBlocks_apply₁₂, Matrix.neg_apply, Matrix.one_apply_eq,
+          mul_neg, mul_one, neg_mul, neg_inj]
+        exact torusCharacter_mul_partner n x
       · simp [Matrix.J, hxy]
   | inr x =>
     cases b with
     | inl y =>
-      by_cases hxy : x = y
-      · subst hxy
-        rw [show Matrix.J (Fin (n + 1))
-            (DiagonalizableGroup.coordinateRing ℤ
-              (SplitTorus.characterGroup (Fin (n + 1)))).obj (Sum.inr x) (Sum.inl x) = 1 by
-          simp [Matrix.J]]
-        rw [mul_one, mul_comm, hinv x]
+      rcases eq_or_ne x y with rfl | hxy
+      · simp only [Matrix.J, Matrix.fromBlocks_apply₂₁, Matrix.one_apply_eq, mul_one]
+        rw [mul_comm]
+        exact torusCharacter_mul_partner n x
       · simp [Matrix.J, hxy]
     | inr y => simp [Matrix.J]
 
@@ -368,27 +375,52 @@ theorem symplecticDefiningHopfIdeal_le_definingIdeal :
     Symplectic.definingHopfIdeal ℤ (n + 1) ≤ definingIdeal n := by
   rw [definingIdeal_def, TauCeti.UniversalEnvelopingAlgebra.le_kostantToralDefiningIdeal_iff]
   refine ⟨fun k => ?_, ?_⟩
-  · exact ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix ℤ _ _ _
-      (rootCoordinateMap_symplectic n k)
-  · exact ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix ℤ _ _ _
-      (torusCoordinateMap_symplectic n)
+  · exact ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix_mul_mul_transpose
+      ℤ _ _ _ (rootCoordinateMap_symplectic n k)
+  · exact ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix_mul_mul_transpose
+      ℤ _ _ _ (torusCoordinateMap_symplectic n)
 
 /-- Every matrix-valued point of the full-weight type `C_(n+1)` carrier preserves the standard
 alternating form. -/
 theorem mem_GLSymplecticFin_of_mem_points {A : Type v} [CommRing A]
     {g : Matrix.GeneralLinearGroup (Fin ((n + 1) + (n + 1))) A} (hg : g ∈ points n A) :
     g ∈ TauCeti.GLSymplecticFin (n + 1) A := by
+  rw [points_def] at hg
+  have hsp := GeneralLinear.hopfIdealPointsSubgroup_le_of_le ((n + 1) + (n + 1))
+    (symplecticDefiningHopfIdeal_le_definingIdeal n) A hg
+  rw [GeneralLinear.mem_hopfIdealPointsSubgroup_iff] at hsp
   have hmem : ((GeneralLinear.pointsMulEquiv (R := ℤ) ((n + 1) + (n + 1))).symm g) ∈
       CommHopfAlgCat.quotientPointsSubgroup
         (GeneralLinear.coordinateHopfAlgebra ℤ ((n + 1) + (n + 1)))
-        (Symplectic.definingHopfIdeal ℤ (n + 1)) (CommAlgCat.of ℤ A) := by
-    rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
-    intro y hy
-    exact (mem_points_iff n A g).mp hg y
-      (symplecticDefiningHopfIdeal_le_definingIdeal n (HopfIdeal.mem_toIdeal.mpr hy))
+        (Symplectic.definingHopfIdeal ℤ (n + 1)) (CommAlgCat.of ℤ A) :=
+    (CommHopfAlgCat.mem_quotientPointsSubgroup_iff _ _ _ _).mpr hsp
   rw [ConstantForm.mem_definingPointsSubgroup_iff, TauCeti.JFin_map,
     MulEquiv.apply_symm_apply] at hmem
   rw [TauCeti.GLSymplecticFin.mem_iff]
   exact hmem
+
+/-- The canonical morphism from the full-weight type `C_(n+1)` carrier to `Sp_(2n+2)`, induced by
+the containment of defining Hopf ideals. -/
+noncomputable def toSymplectic : groupScheme n ⟶ Symplectic.groupScheme ℤ (n + 1) :=
+  CommHopfAlgCat.quotientSpecMapOfLe
+    (GeneralLinear.coordinateHopfAlgebra ℤ ((n + 1) + (n + 1)))
+    ((symplecticDefiningHopfIdeal_le_definingIdeal n).trans (le_of_eq (definingIdeal_def n)))
+
+/-- The canonical morphism from the type `C_(n+1)` carrier to `Sp_(2n+2)` is a closed
+immersion. -/
+instance isClosedImmersion_toSymplectic :
+    AlgebraicGeometry.IsClosedImmersion (toSymplectic n).hom.hom.left := by
+  rw [toSymplectic]
+  infer_instance
+
+/-- Including the type `C_(n+1)` carrier into `Sp_(2n+2)` and then into `GL_(2n+2)` recovers its
+original ambient closed immersion. -/
+@[simp]
+theorem toSymplectic_comp_inclusion :
+    toSymplectic n ≫ Symplectic.inclusion ℤ (n + 1) = carrierι n := by
+  rw [toSymplectic, Symplectic.inclusion_def, GeneralLinear.hopfIdealInclusion_def,
+    carrierι_def, TauCeti.UniversalEnvelopingAlgebra.kostantToralGroupSchemeι_def,
+    ← Category.assoc, CommHopfAlgCat.quotientSpecMapOfLe_comp_quotientSpecι]
+  simp
 
 end TauCeti.SpStd

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/AlternatingForm.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/AlternatingForm.lean
@@ -156,28 +156,20 @@ private theorem eq_zero_of_map_intCast {N : ℕ} {P : Matrix (Fin N) (Fin N) ℤ
   have hrc := congrFun (congrFun h r) c
   simpa using hrc
 
-private theorem JFin_apply {m : ℕ} {R : Type*} [CommRing R] (r c : Fin (m + m)) :
-    TauCeti.JFin m R r c =
-      Matrix.J (Fin m) R (finSumFinEquiv.symm r) (finSumFinEquiv.symm c) := by
-  rw [← TauCeti.JFin_submatrix m (R := R), Matrix.submatrix_apply, Equiv.apply_symm_apply,
-    Equiv.apply_symm_apply]
-
-private theorem JFin_eq_submatrix (m : ℕ) (R : Type*) [CommRing R] :
-    TauCeti.JFin m R =
-      (Matrix.J (Fin m) R).submatrix finSumFinEquiv.symm finSumFinEquiv.symm := by
-  ext r c
-  rw [Matrix.submatrix_apply, JFin_apply]
-
 private theorem rootIntMatrix_mul_JFin_add_eq_zero (k : Fin (n + 1) ⊕ Fin (n + 1)) :
     rootIntMatrix n k * TauCeti.JFin (n + 1) ℤ +
       TauCeti.JFin (n + 1) ℤ * (rootIntMatrix n k)ᵀ = 0 := by
   have key := mul_J_add_J_mul_transpose_eq_zero_of_mem_sp (rootGenerator n k).2
+  have hJ : TauCeti.JFin (n + 1) ℚ =
+      (Matrix.J (Fin (n + 1)) ℚ).submatrix finSumFinEquiv.symm finSumFinEquiv.symm := by
+    rw [← TauCeti.JFin_submatrix (n + 1) (R := ℚ), Matrix.submatrix_submatrix]
+    simp
   refine eq_zero_of_map_intCast ?_
   rw [← RingHom.mapMatrix_apply, map_add, map_mul, map_mul]
   simp only [RingHom.mapMatrix_apply]
   rw [TauCeti.JFin_map (n + 1) (Int.castRingHom ℚ)]
   rw [show ((Int.castRingHom ℚ : ℤ →+* ℚ) : ℤ → ℚ) = (Int.cast : ℤ → ℚ) from rfl]
-  rw [Matrix.transpose_map, map_rootIntMatrix, JFin_eq_submatrix, Matrix.transpose_submatrix,
+  rw [Matrix.transpose_map, map_rootIntMatrix, hJ, Matrix.transpose_submatrix,
     Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv]
   ext r c
   have h := congrFun (congrFun key (finSumFinEquiv.symm r)) (finSumFinEquiv.symm c)
@@ -335,7 +327,11 @@ private theorem torusCoordinateMap_symplectic :
   intro r c
   obtain ⟨a, rfl⟩ : ∃ a, finSumFinEquiv a = r := ⟨finSumFinEquiv.symm r, by simp⟩
   obtain ⟨b, rfl⟩ : ∃ b, finSumFinEquiv b = c := ⟨finSumFinEquiv.symm c, by simp⟩
-  rw [JFin_apply, Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+  have hJ := congrFun (congrFun (TauCeti.JFin_submatrix (n + 1)
+    (R := (DiagonalizableGroup.coordinateRing ℤ
+      (SplitTorus.characterGroup (Fin (n + 1)))).obj)) a) b
+  rw [Matrix.submatrix_apply] at hJ
+  rw [hJ]
   cases a with
   | inl x =>
     cases b with

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/AlternatingForm.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/AlternatingForm.lean
@@ -1,0 +1,398 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Symplectic.Basic
+public import TauCeti.Algebra.Lie.Symplectic.StandardCarrier.Scheme
+public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ClosedImmersion
+
+/-!
+# The full-weight type-C carrier preserves the standard alternating form
+
+`TauCeti.SpStd.groupScheme n` is the explicit full-weight Chevalley carrier of type `C_(n+1)`: the
+smallest closed subgroup scheme of `GL_(2n+2)` containing the divided-power exponentials of the
+Bourbaki-numbered Chevalley generators of `sp_(2n+2)` together with the weight torus of the
+standard lattice. This file proves that it sits inside the symplectic group scheme
+`TauCeti.Symplectic.groupScheme`, the subgroup scheme of `GL_(2n+2)` cut out by `X J Xᵀ = J`.
+
+The proof is the two generator computations the toral-closure construction reduces to. A root
+generator squares to zero in the standard representation, so its divided-power exponential is
+`1 + t X` for `X` the integral matrix `TauCeti.SpStd.rootIntMatrix` of the generator itself; that
+matrix is skew-adjoint for `J` because the generator lies in Mathlib's `LieAlgebra.Symplectic.sp`,
+and `(1 + t X) J (1 + t X)ᵀ = J` follows from skew-adjointness together with `X ^ 2 = 0`. The weight
+torus contributes a diagonal matrix whose entries at a coordinate and at its symplectic partner are
+inverse characters, because the standard weights come in the pairs `ε_a` and `-ε_a`, and a diagonal
+matrix preserves `J` exactly when each such pair multiplies to one.
+
+The reverse inclusion is not proved: identifying the carrier with `Sp_(2n+2)` needs a generation
+theorem, as in the type-`A` case, and none is asserted here. Nothing below claims that the carrier
+is reductive, that its weight torus is maximal, or that any group in sight is finite or simple.
+
+## Main definitions
+
+* `TauCeti.SpStd.rootIntMatrix`: the integral matrix of a numbered root generator in the
+  enumerated coordinate basis of the standard lattice.
+
+## Main results
+
+* `TauCeti.SpStd.rep_rootGenerator_latticeBasis_eq_sum` and
+  `TauCeti.SpStd.map_rootIntMatrix`: that matrix is the matrix of the root generator, on the
+  lattice and after extending scalars to `ℚ`.
+* `TauCeti.SpStd.rootIntMatrix_map_mul_JFin_add_eq_zero` and
+  `TauCeti.SpStd.rootIntMatrix_map_mul_self_eq_zero`: it is skew-adjoint for the transported
+  alternating form, and squares to zero, over every value ring.
+* `TauCeti.SpStd.symplecticDefiningHopfIdeal_le_definingIdeal`: the symplectic relations belong to
+  the defining Hopf ideal of the carrier.
+* `TauCeti.SpStd.mem_GLSymplecticFin_of_mem_points`: every matrix point of the carrier preserves
+  the standard alternating form.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 11.3.
+* J. E. Humphreys, *Linear Algebraic Groups*, §§26--27.
+* R. Steinberg, *Lectures on Chevalley Groups*, §3.
+
+The file follows the type-`A` counterpart
+`TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/DeterminantOne.lean`, which proves the same
+containment for the special linear group; the class-two exponential computation and the symplectic
+matrix identities are specific to this file.
+
+This advances Layer 9, "The Chevalley--Demazure construction", of
+`TauCetiRoadmap/ReductiveGroups/README.md`: the full-weight type `C` carrier is now proved to lie
+in the expected pinned ambient group. Its consumer is milestone L0 of
+`TauCetiRoadmap/CFSGStatement/README.md`, which needs a simply connected pinned carrier for the
+`C_n(q)` family.
+-/
+
+public section
+
+open CategoryTheory Matrix WithConv
+
+namespace TauCeti.SpStd
+
+open LieAlgebra.Symplectic
+
+attribute [local instance] TauCeti.moduleNNRat
+attribute [local instance 100] LieRing.ofAssociativeRing
+attribute [local instance high] Algebra.toModule
+
+universe v
+
+variable (n : ℕ)
+
+/-- The integral matrix of a numbered root generator in the enumerated coordinate basis of the
+standard lattice. Its columns are the coefficients of the images of the basis vectors, which are
+integral because the generator preserves the lattice. -/
+noncomputable def rootIntMatrix (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    Matrix (Fin ((n + 1) + (n + 1))) (Fin ((n + 1) + (n + 1))) ℤ :=
+  Matrix.of fun r s => (latticeBasis n).repr
+    ⟨rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator n k)) (latticeBasis n s),
+      rep_rootGenerator_mem_lattice n k (latticeBasis n s).2⟩ r
+
+/-- A numbered root generator acts on a coordinate basis vector by the corresponding column of
+`TauCeti.SpStd.rootIntMatrix`. -/
+theorem rep_rootGenerator_latticeBasis_eq_sum (k : Fin (n + 1) ⊕ Fin (n + 1))
+    (s : Fin ((n + 1) + (n + 1))) :
+    rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator n k))
+        ((latticeBasis n s : (lattice n).toAddSubgroup) : (Fin (n + 1) ⊕ Fin (n + 1)) → ℚ) =
+      ∑ r, rootIntMatrix n k r s •
+        ((latticeBasis n r : (lattice n).toAddSubgroup) :
+          (Fin (n + 1) ⊕ Fin (n + 1)) → ℚ) := by
+  have h := ((latticeBasis n).sum_repr
+    ⟨rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator n k)) (latticeBasis n s),
+      rep_rootGenerator_mem_lattice n k (latticeBasis n s).2⟩).symm
+  have h' := congrArg
+    (fun w : (lattice n).toAddSubgroup => (w : (Fin (n + 1) ⊕ Fin (n + 1)) → ℚ)) h
+  simp only [AddSubmonoidClass.coe_finsetSum] at h'
+  exact h'
+
+/-- Extending an entry of `TauCeti.SpStd.rootIntMatrix` to `ℚ` recovers the corresponding entry of
+the rational matrix of the root generator, at the standard indices enumerated by the coordinate
+basis. -/
+theorem intCast_rootIntMatrix (k : Fin (n + 1) ⊕ Fin (n + 1))
+    (r s : Fin ((n + 1) + (n + 1))) :
+    ((rootIntMatrix n k r s : ℤ) : ℚ) =
+      (rootGenerator n k :
+        Matrix (Fin (n + 1) ⊕ Fin (n + 1)) (Fin (n + 1) ⊕ Fin (n + 1)) ℚ)
+        (finSumFinEquiv.symm r) (finSumFinEquiv.symm s) := by
+  rw [rootIntMatrix, Matrix.of_apply, intCast_latticeBasis_repr]
+  -- Reduce the coercion of the anonymous constructor before rewriting under it.
+  dsimp only
+  rw [rep_ι_apply, coe_latticeBasis]
+  simp [Matrix.mulVec_single]
+
+/-- `TauCeti.SpStd.rootIntMatrix` is the reindexed rational matrix of the root generator. -/
+theorem map_rootIntMatrix (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    (rootIntMatrix n k).map (Int.cast : ℤ → ℚ) =
+      (rootGenerator n k :
+          Matrix (Fin (n + 1) ⊕ Fin (n + 1)) (Fin (n + 1) ⊕ Fin (n + 1)) ℚ).submatrix
+        finSumFinEquiv.symm finSumFinEquiv.symm := by
+  ext r s
+  rw [Matrix.map_apply, Matrix.submatrix_apply, intCast_rootIntMatrix]
+
+/-! ### Skew-adjointness and squaring to zero, over ℤ -/
+
+private theorem mul_J_add_J_mul_transpose_eq_zero_of_mem_sp {l : Type*} [DecidableEq l]
+    [Fintype l] {R : Type*} [CommRing R] {G : Matrix (l ⊕ l) (l ⊕ l) R}
+    (hG : G ∈ sp l R) :
+    G * Matrix.J l R + Matrix.J l R * Gᵀ = 0 := by
+  rw [sp, mem_skewAdjointMatricesLieSubalgebra, mem_skewAdjointMatricesSubmodule] at hG
+  simp only [Matrix.IsSkewAdjoint, Matrix.IsAdjointPair, Matrix.mul_neg] at hG
+  have hJ : Matrix.J l R * Matrix.J l R = -1 := Matrix.J_squared _ _
+  have h1 : Matrix.J l R * Gᵀ * Matrix.J l R = G := by
+    rw [Matrix.mul_assoc, hG, Matrix.mul_neg, ← Matrix.mul_assoc, hJ, Matrix.neg_mul,
+      Matrix.one_mul, neg_neg]
+  have h2 : G * Matrix.J l R = -(Matrix.J l R * Gᵀ) := by
+    conv_lhs => rw [← h1]
+    rw [Matrix.mul_assoc, hJ, Matrix.mul_neg, Matrix.mul_one]
+  rw [h2, neg_add_cancel]
+
+private theorem eq_zero_of_map_intCast {N : ℕ} {P : Matrix (Fin N) (Fin N) ℤ}
+    (h : P.map (Int.castRingHom ℚ) = 0) : P = 0 := by
+  ext r c
+  have hrc := congrFun (congrFun h r) c
+  simpa using hrc
+
+private theorem JFin_apply {m : ℕ} {R : Type*} [CommRing R] (r c : Fin (m + m)) :
+    TauCeti.JFin m R r c =
+      Matrix.J (Fin m) R (finSumFinEquiv.symm r) (finSumFinEquiv.symm c) := by
+  rw [← TauCeti.JFin_submatrix m (R := R), Matrix.submatrix_apply, Equiv.apply_symm_apply,
+    Equiv.apply_symm_apply]
+
+private theorem JFin_eq_submatrix (m : ℕ) (R : Type*) [CommRing R] :
+    TauCeti.JFin m R =
+      (Matrix.J (Fin m) R).submatrix finSumFinEquiv.symm finSumFinEquiv.symm := by
+  ext r c
+  rw [Matrix.submatrix_apply, JFin_apply]
+
+private theorem rootIntMatrix_mul_JFin_add_eq_zero (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    rootIntMatrix n k * TauCeti.JFin (n + 1) ℤ +
+      TauCeti.JFin (n + 1) ℤ * (rootIntMatrix n k)ᵀ = 0 := by
+  have key := mul_J_add_J_mul_transpose_eq_zero_of_mem_sp (rootGenerator n k).2
+  refine eq_zero_of_map_intCast ?_
+  rw [← RingHom.mapMatrix_apply, map_add, map_mul, map_mul]
+  simp only [RingHom.mapMatrix_apply]
+  rw [TauCeti.JFin_map (n + 1) (Int.castRingHom ℚ)]
+  rw [show ((Int.castRingHom ℚ : ℤ →+* ℚ) : ℤ → ℚ) = (Int.cast : ℤ → ℚ) from rfl]
+  rw [Matrix.transpose_map, map_rootIntMatrix, JFin_eq_submatrix, Matrix.transpose_submatrix,
+    Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv]
+  ext r c
+  have h := congrFun (congrFun key (finSumFinEquiv.symm r)) (finSumFinEquiv.symm c)
+  simpa using h
+
+private theorem rootIntMatrix_mul_self_eq_zero (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    rootIntMatrix n k * rootIntMatrix n k = 0 := by
+  have hsq := pow_two_rep_rootGenerator_eq_zero n k
+  have hG : (rootGenerator n k :
+      Matrix (Fin (n + 1) ⊕ Fin (n + 1)) (Fin (n + 1) ⊕ Fin (n + 1)) ℚ) *
+      (rootGenerator n k : Matrix _ _ ℚ) = 0 := by
+    ext a b
+    have h := DFunLike.congr_fun hsq (Pi.single b (1 : ℚ))
+    rw [pow_two, Module.End.mul_apply, rep_ι_apply, rep_ι_apply,
+      Matrix.mulVec_mulVec] at h
+    simp only [LinearMap.zero_apply] at h
+    have := congrFun h a
+    simpa [Matrix.mulVec_single] using this
+  refine eq_zero_of_map_intCast ?_
+  rw [← RingHom.mapMatrix_apply, map_mul]
+  simp only [RingHom.mapMatrix_apply]
+  rw [show ((Int.castRingHom ℚ : ℤ →+* ℚ) : ℤ → ℚ) = (Int.cast : ℤ → ℚ) from rfl]
+  rw [map_rootIntMatrix, Matrix.submatrix_mul_equiv, hG]
+  simp
+
+/-! ### The two generator matrices preserve the form -/
+
+private theorem diagonal_mul_mul_transpose_diagonal {N : ℕ} {A : Type*} [CommRing A]
+    (d : Fin N → A) (Jm : Matrix (Fin N) (Fin N) A)
+    (hd : ∀ r c, d r * Jm r c * d c = Jm r c) :
+    Matrix.diagonal d * Jm * (Matrix.diagonal d)ᵀ = Jm := by
+  ext r c
+  rw [Matrix.diagonal_transpose, Matrix.mul_diagonal, Matrix.diagonal_mul]
+  exact hd r c
+
+private theorem one_add_smul_mul_mul_transpose {N : ℕ} {A : Type*} [CommRing A]
+    (Jm Y : Matrix (Fin N) (Fin N) A) (t : A)
+    (hskew : Y * Jm + Jm * Yᵀ = 0) (hsq : Y * Y = 0) :
+    (1 + t • Y) * Jm * (1 + t • Y)ᵀ = Jm := by
+  have hYJ : Y * Jm = -(Jm * Yᵀ) := by
+    rw [eq_neg_iff_add_eq_zero]
+    exact hskew
+  have hcube : Y * Jm * Yᵀ = 0 := by
+    rw [hYJ, Matrix.neg_mul, Matrix.mul_assoc, ← Matrix.transpose_mul, hsq,
+      Matrix.transpose_zero, Matrix.mul_zero, neg_zero]
+  simp only [Matrix.transpose_add, Matrix.transpose_one, Matrix.transpose_smul,
+    Matrix.add_mul, Matrix.mul_add, Matrix.one_mul, Matrix.mul_one, Matrix.smul_mul,
+    Matrix.mul_smul]
+  rw [hcube, smul_zero, add_zero, hYJ, smul_neg]
+  abel
+
+/-- **A numbered root generator is skew-adjoint for the transported alternating form**, over every
+value ring: `X J + J Xᵀ = 0`. -/
+theorem rootIntMatrix_map_mul_JFin_add_eq_zero {A : Type*} [CommRing A]
+    (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    (rootIntMatrix n k).map (Int.cast : ℤ → A) * TauCeti.JFin (n + 1) A +
+      TauCeti.JFin (n + 1) A * ((rootIntMatrix n k).map (Int.cast : ℤ → A))ᵀ = 0 := by
+  have h2 : ((rootIntMatrix n k * TauCeti.JFin (n + 1) ℤ +
+      TauCeti.JFin (n + 1) ℤ * (rootIntMatrix n k)ᵀ).map (Int.castRingHom A)) = 0 := by
+    rw [rootIntMatrix_mul_JFin_add_eq_zero]
+    simp
+  rw [← RingHom.mapMatrix_apply, map_add, map_mul, map_mul] at h2
+  simp only [RingHom.mapMatrix_apply] at h2
+  rw [Matrix.transpose_map, TauCeti.JFin_map (n + 1) (Int.castRingHom A)] at h2
+  exact h2
+
+/-- A numbered root generator squares to zero on the enumerated coordinate basis, over every value
+ring. -/
+theorem rootIntMatrix_map_mul_self_eq_zero {A : Type*} [CommRing A]
+    (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    (rootIntMatrix n k).map (Int.cast : ℤ → A) *
+      (rootIntMatrix n k).map (Int.cast : ℤ → A) = 0 := by
+  have h2 : ((rootIntMatrix n k * rootIntMatrix n k).map (Int.castRingHom A)) = 0 := by
+    rw [rootIntMatrix_mul_self_eq_zero]
+    simp
+  rw [← RingHom.mapMatrix_apply, map_mul] at h2
+  simp only [RingHom.mapMatrix_apply] at h2
+  exact h2
+
+private theorem rootCoordinateMap_symplectic (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    (GeneralLinear.genericMatrix ℤ ((n + 1) + (n + 1))).map
+        (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator n)
+          (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
+          (fun _ hu _ hv => rep_kostantForm_mem_lattice n hu hv) k
+          (isNilpotent_rep_rootGenerator n k) (latticeBasis n)).hom.toAlgHom *
+        (TauCeti.JFin (n + 1) ℤ).map
+          (algebraMap ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) *
+        ((GeneralLinear.genericMatrix ℤ ((n + 1) + (n + 1))).map
+          (TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap (rootGenerator n)
+            (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
+            (fun _ hu _ hv => rep_kostantForm_mem_lattice n hu hv) k
+            (isNilpotent_rep_rootGenerator n k) (latticeBasis n)).hom.toAlgHom)ᵀ =
+      (TauCeti.JFin (n + 1) ℤ).map
+        (algebraMap ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ)) := by
+  obtain ⟨t, ht⟩ :=
+    TauCeti.UniversalEnvelopingAlgebra.exists_map_genericMatrix_kostantRootSubgroupCoordinateMap
+      (rootGenerator n) (cartanGenerator n) (rep n) (lattice n).toAddSubgroup
+      (fun _ hu _ hv => rep_kostantForm_mem_lattice n hu hv) k
+      (isNilpotent_rep_rootGenerator n k) (latticeBasis n) (rootIntMatrix n k)
+      (nilpotencyClass_rep_rootGenerator n k) (rep_rootGenerator_latticeBasis_eq_sum n k)
+  rw [ht, TauCeti.JFin_map (n + 1) (algebraMap ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))]
+  exact one_add_smul_mul_mul_transpose _ _ _ (rootIntMatrix_map_mul_JFin_add_eq_zero n k)
+    (rootIntMatrix_map_mul_self_eq_zero n k)
+
+/-! ### The weight torus preserves the form -/
+
+private theorem map_genericMatrix_weightTorusCoordinateMap :
+    (GeneralLinear.genericMatrix ℤ ((n + 1) + (n + 1))).map
+        (GeneralLinear.weightTorusCoordinateMap (R := ℤ) (basisWeight n)).hom.toAlgHom =
+      Matrix.diagonal fun a => MonoidAlgebra.single
+        (Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm (basisWeight n a))) 1 := by
+  apply Matrix.ext
+  intro a c
+  rw [Matrix.map_apply, GeneralLinear.genericMatrix_apply]
+  simp only [BialgHom.coe_toAlgHom]
+  rw [GeneralLinear.weightTorusCoordinateMap_X, Matrix.diagonal_apply]
+
+private theorem torusCoordinateMap_symplectic :
+    (GeneralLinear.genericMatrix ℤ ((n + 1) + (n + 1))).map
+        (GeneralLinear.weightTorusCoordinateMap (R := ℤ) (basisWeight n)).hom.toAlgHom *
+        (TauCeti.JFin (n + 1) ℤ).map
+          (algebraMap ℤ
+            (DiagonalizableGroup.coordinateRing ℤ
+              (SplitTorus.characterGroup (Fin (n + 1)))).obj) *
+        ((GeneralLinear.genericMatrix ℤ ((n + 1) + (n + 1))).map
+          (GeneralLinear.weightTorusCoordinateMap (R := ℤ) (basisWeight n)).hom.toAlgHom)ᵀ =
+      (TauCeti.JFin (n + 1) ℤ).map
+        (algebraMap ℤ
+          (DiagonalizableGroup.coordinateRing ℤ
+            (SplitTorus.characterGroup (Fin (n + 1)))).obj) := by
+  rw [map_genericMatrix_weightTorusCoordinateMap,
+    TauCeti.JFin_map (n + 1)
+      (algebraMap ℤ
+        (DiagonalizableGroup.coordinateRing ℤ (SplitTorus.characterGroup (Fin (n + 1)))).obj)]
+  refine diagonal_mul_mul_transpose_diagonal _ _ ?_
+  have hinv : ∀ x : Fin (n + 1),
+      (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm
+          (basisWeight n (finSumFinEquiv (Sum.inl x))))) (1 : ℤ)) *
+        (MonoidAlgebra.single (Multiplicative.ofAdd (Finsupp.equivFunOnFinite.symm
+          (basisWeight n (finSumFinEquiv (Sum.inr x))))) (1 : ℤ)) = 1 := by
+    intro x
+    rw [MonoidAlgebra.single_mul_single, mul_one, ← ofAdd_add]
+    have hw : basisWeight n (finSumFinEquiv (Sum.inr x)) =
+        -basisWeight n (finSumFinEquiv (Sum.inl x)) := by
+      funext j
+      rw [basisWeight_apply, basisWeight_apply, Equiv.symm_apply_apply, Equiv.symm_apply_apply,
+        weight_inr, Pi.neg_apply, weight_inl]
+    have hz : Finsupp.equivFunOnFinite.symm (basisWeight n (finSumFinEquiv (Sum.inl x))) +
+        Finsupp.equivFunOnFinite.symm (basisWeight n (finSumFinEquiv (Sum.inr x))) = 0 := by
+      rw [hw]
+      ext j
+      simp
+    rw [hz]
+    rfl
+  intro r c
+  obtain ⟨a, rfl⟩ : ∃ a, finSumFinEquiv a = r := ⟨finSumFinEquiv.symm r, by simp⟩
+  obtain ⟨b, rfl⟩ : ∃ b, finSumFinEquiv b = c := ⟨finSumFinEquiv.symm c, by simp⟩
+  rw [JFin_apply, Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+  cases a with
+  | inl x =>
+    cases b with
+    | inl y => simp [Matrix.J]
+    | inr y =>
+      by_cases hxy : x = y
+      · subst hxy
+        rw [show Matrix.J (Fin (n + 1))
+            (DiagonalizableGroup.coordinateRing ℤ
+              (SplitTorus.characterGroup (Fin (n + 1)))).obj (Sum.inl x) (Sum.inr x) = -1 by
+          simp [Matrix.J]]
+        rw [mul_comm, ← mul_assoc, mul_comm _ (MonoidAlgebra.single _ _)]
+        rw [hinv x, one_mul]
+      · simp [Matrix.J, hxy]
+  | inr x =>
+    cases b with
+    | inl y =>
+      by_cases hxy : x = y
+      · subst hxy
+        rw [show Matrix.J (Fin (n + 1))
+            (DiagonalizableGroup.coordinateRing ℤ
+              (SplitTorus.characterGroup (Fin (n + 1)))).obj (Sum.inr x) (Sum.inl x) = 1 by
+          simp [Matrix.J]]
+        rw [mul_one, mul_comm, hinv x]
+      · simp [Matrix.J, hxy]
+    | inr y => simp [Matrix.J]
+
+/-! ### The carrier lies in the symplectic group scheme -/
+
+/-- **The symplectic relations belong to the defining Hopf ideal of the full-weight type
+`C_(n+1)` carrier.** Equivalently, every represented root subgroup and the represented weight torus
+factor through `Sp_(2n+2)`. -/
+theorem symplecticDefiningHopfIdeal_le_definingIdeal :
+    Symplectic.definingHopfIdeal ℤ (n + 1) ≤ definingIdeal n := by
+  rw [definingIdeal_def, TauCeti.UniversalEnvelopingAlgebra.le_kostantToralDefiningIdeal_iff]
+  refine ⟨fun k => ?_, ?_⟩
+  · exact ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix ℤ _ _ _
+      (rootCoordinateMap_symplectic n k)
+  · exact ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix ℤ _ _ _
+      (torusCoordinateMap_symplectic n)
+
+/-- Every matrix-valued point of the full-weight type `C_(n+1)` carrier preserves the standard
+alternating form. -/
+theorem mem_GLSymplecticFin_of_mem_points {A : Type v} [CommRing A]
+    {g : Matrix.GeneralLinearGroup (Fin ((n + 1) + (n + 1))) A} (hg : g ∈ points n A) :
+    g ∈ TauCeti.GLSymplecticFin (n + 1) A := by
+  have hmem : ((GeneralLinear.pointsMulEquiv (R := ℤ) ((n + 1) + (n + 1))).symm g) ∈
+      CommHopfAlgCat.quotientPointsSubgroup
+        (GeneralLinear.coordinateHopfAlgebra ℤ ((n + 1) + (n + 1)))
+        (Symplectic.definingHopfIdeal ℤ (n + 1)) (CommAlgCat.of ℤ A) := by
+    rw [CommHopfAlgCat.mem_quotientPointsSubgroup_iff]
+    intro y hy
+    exact (mem_points_iff n A g).mp hg y
+      (symplecticDefiningHopfIdeal_le_definingIdeal n (HopfIdeal.mem_toIdeal.mpr hy))
+  rw [ConstantForm.mem_definingPointsSubgroup_iff, TauCeti.JFin_map,
+    MulEquiv.apply_symm_apply] at hmem
+  rw [TauCeti.GLSymplecticFin.mem_iff]
+  exact hmem
+
+end TauCeti.SpStd

--- a/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/Basic.lean
+++ b/TauCeti/Algebra/Lie/Symplectic/StandardCarrier/Basic.lean
@@ -71,8 +71,11 @@ asserted here.
   the numbered generators.
 * `TauCeti.SpStd.lie_cartanGenerator_rootGenerator`: the numbered Cartan generators act on the
   root generators through the rows of the type-`C` Cartan matrix.
-* `TauCeti.SpStd.isNilpotent_rep_rootGenerator`: each numbered root generator squares to zero on
-  the standard module.
+* `TauCeti.SpStd.isNilpotent_rep_rootGenerator` and
+  `TauCeti.SpStd.nilpotencyClass_rep_rootGenerator`: each numbered root generator squares to zero
+  on the standard module, and has nilpotency class exactly two.
+* `TauCeti.SpStd.intCast_latticeBasis_repr`: the coordinate-basis coefficients of a lattice vector
+  are its rational coordinates.
 * `TauCeti.SpStd.rep_kostantForm_mem_lattice`: the Kostant `ℤ`-form preserves the standard
   lattice, so the lattice is admissible.
 * `TauCeti.SpStd.span_range_weight_eq_top`: the weights of the standard module generate the full
@@ -758,6 +761,15 @@ noncomputable def latticeBasis :
   rw [Module.Basis.reindex_apply, ← Pi.basisFun_apply]
   exact TauCeti.coe_coordinateLatticeBasis (Fin (n + 1) ⊕ Fin (n + 1)) _
 
+/-- The coordinate-basis coefficients of a lattice vector are its rational coordinates: extending
+the `a`-th coefficient to `ℚ` recovers the coordinate at the standard index enumerated by `a`. -/
+@[simp] theorem intCast_latticeBasis_repr (v : (lattice n).toAddSubgroup)
+    (a : Fin ((n + 1) + (n + 1))) :
+    (((latticeBasis n).repr v a : ℤ) : ℚ) =
+      (v : (Fin (n + 1) ⊕ Fin (n + 1)) → ℚ) (finSumFinEquiv.symm a) := by
+  unfold latticeBasis lattice at *
+  rw [Module.Basis.repr_reindex_apply, TauCeti.intCast_coordinateLatticeBasis_repr]
+
 /-- The weight attached to the enumerated coordinate basis. -/
 def basisWeight (a : Fin ((n + 1) + (n + 1))) : Fin (n + 1) → ℤ :=
   weight n (finSumFinEquiv.symm a)
@@ -846,6 +858,22 @@ theorem rep_rootGenerator_latticeBasis (k : Fin (n + 1) ⊕ Fin (n + 1)) :
       · simp [hi]
 
 attribute [local instance high] Algebra.toModule
+
+/-- Every numbered root generator has nilpotency class exactly two in the standard
+representation. -/
+theorem nilpotencyClass_rep_rootGenerator (k : Fin (n + 1) ⊕ Fin (n + 1)) :
+    nilpotencyClass
+        (rep n (_root_.UniversalEnvelopingAlgebra.ι ℚ (rootGenerator n k))) = 2 := by
+  refine nilpotencyClass_eq_succ_iff.mpr ⟨pow_two_rep_rootGenerator_eq_zero n k, ?_⟩
+  rw [pow_one]
+  intro hzero
+  have h := DFunLike.congr_fun hzero
+    ((latticeBasis n (finSumFinEquiv (rootSource n k)) : (lattice n).toAddSubgroup) :
+      (Fin (n + 1) ⊕ Fin (n + 1)) → ℚ)
+  rw [rep_rootGenerator_latticeBasis, one_smul, coe_latticeBasis] at h
+  simp only [LinearMap.zero_apply, Equiv.symm_apply_apply] at h
+  have h2 := congrFun h (rootTarget n k)
+  simp at h2
 
 /-- Every coordinate basis vector of the standard lattice is a Cartan weight vector. -/
 theorem isCartanWeightVector_latticeBasis (a : Fin ((n + 1) + (n + 1))) :

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ClosedImmersion.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ClosedImmersion.lean
@@ -53,10 +53,11 @@ left to the caller in the general construction.
   the class-two exponential formula for an operator with one nonzero basis column.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_transvectionUnit_of_action`:
   a class-two root operator with one nonzero basis column exponentiates to a transvection.
-* `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul` and
-  `TauCeti.UniversalEnvelopingAlgebra.exists_map_genericMatrix_kostantRootSubgroupCoordinateMap`:
-  without the rank-one hypothesis a class-two root operator still exponentiates to `1 + t X`, on a
-  point and on the generic matrix respectively.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul` and, in the same
+  namespace,
+  `exists_map_genericMatrix_kostantRootSubgroupCoordinateMap_eq_one_add_smul`:
+  without the single-column hypothesis a square-zero root operator still exponentiates to
+  `1 + t X`, on a point and on the generic matrix respectively.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupPoints_injective`: the root subgroup is
   faithfully parametrized by `𝔾ₐ`.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap_surjective`: the coordinate
@@ -433,16 +434,16 @@ variable (hnil : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)
 variable {η : Type*} [Fintype η] [DecidableEq η] (b : Module.Basis η ℤ M)
 
 include hnil in
-/-- **The matrix of a class-two root subgroup is `1 + t X`.** When the root operator squares to
+/-- **The matrix of a square-zero root subgroup is `1 + t X`.** When the root operator squares to
 zero its divided-power exponential stops after the linear term, so the root-subgroup matrix at
 parameter `t` is the identity plus `t` times the integral matrix `X` of the operator itself.
 Unlike `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_transvectionUnit_of_action`
-this does not assume the operator has rank one, so it also covers the root generators of the
-multiply-laced families, which move two basis vectors. -/
+this does not assume the operator has a single nonzero basis column, so it also covers operators
+with several nonzero columns, such as the nonfinal root generators of type `C`. -/
 theorem kostantRootSubgroupMatrix_eq_one_add_smul {A : Type*} [CommRing A]
     (X : Matrix η η ℤ)
     (hclass : nilpotencyClass
-      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) = 2)
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) ≤ 2)
     (haction : ∀ s, ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) (b s : V) =
       ∑ r, X r s • (b r : V))
     (f : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
@@ -460,16 +461,24 @@ theorem kostantRootSubgroupMatrix_eq_one_add_smul {A : Type*} [CommRing A]
       haction]
     push_cast
     simp
-  have hzero : ∀ s : η, integralDividedPower
-      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M 0
-      (fun _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i 0 hv)
-      (b s) = b s := by
-    intro s
-    rw [integralDividedPower_zero]
-    rfl
   ext r s
-  rw [kostantRootSubgroupMatrix_apply, repr_kostantRootSubgroupPoints_baseChange, hclass,
-    Finset.sum_range_succ, Finset.sum_range_one, hzero, hone, map_sum]
+  -- Past the nilpotency class the divided powers vanish, so the exponential sum may be padded
+  -- out to the two terms that the square-zero truncation leaves.
+  have hpad : ∑ k ∈ Finset.range
+        (nilpotencyClass (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)))),
+      b.repr (integralDividedPower (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M k
+          (fun _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i k hv)
+          (b s)) r • Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv f) ^ k =
+      ∑ k ∈ Finset.range 2,
+        b.repr (integralDividedPower (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M k
+            (fun _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i k hv)
+            (b s)) r • Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv f) ^ k := by
+    refine Finset.sum_subset (Finset.range_subset_range.2 hclass) fun k _ hk => ?_
+    rw [Finset.mem_range, not_lt] at hk
+    rw [integralDividedPower_eq_zero_of_le _ _ _ _ (pow_nilpotencyClass hnil) hk]
+    simp
+  rw [kostantRootSubgroupMatrix_apply, repr_kostantRootSubgroupPoints_baseChange, hpad,
+    Finset.sum_range_succ, Finset.sum_range_one, integralDividedPower_zero_apply, hone, map_sum]
   simp only [Finsupp.coe_finsetSum, Finset.sum_apply, map_zsmul, Module.Basis.repr_self,
     Finsupp.smul_single, smul_eq_mul, mul_one, Finsupp.single_apply, pow_zero, pow_one,
     Matrix.add_apply, Matrix.one_apply, Matrix.smul_apply, Matrix.map_apply, zsmul_eq_mul,
@@ -495,15 +504,15 @@ variable (hnil : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)
 variable {N : ℕ} (bb : Module.Basis (Fin N) ℤ M)
 
 include hnil in
-/-- **The generic matrix of a class-two root subgroup is `1 + t X`.** This is
+/-- **The generic matrix of a square-zero root subgroup is `1 + t X`.** This is
 `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul` read on the
 coordinate morphism rather than on a point: the entries of the generic matrix of `GL N` are carried
 to those of `1 + t X` for the parameter `t` of the universal point of `𝔾ₐ`. A consumer that has to
 check a matrix equation on every algebra-valued point at once evaluates it here instead. -/
-theorem exists_map_genericMatrix_kostantRootSubgroupCoordinateMap
+theorem exists_map_genericMatrix_kostantRootSubgroupCoordinateMap_eq_one_add_smul
     (X : Matrix (Fin N) (Fin N) ℤ)
     (hclass : nilpotencyClass
-      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) = 2)
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) ≤ 2)
     (haction : ∀ s, ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) (bb s : V) =
       ∑ r, X r s • (bb r : V)) :
     ∃ t : AdditiveGroup.coordinateHopfAlgebra ℤ,

--- a/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ClosedImmersion.lean
+++ b/TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ClosedImmersion.lean
@@ -53,6 +53,10 @@ left to the caller in the general construction.
   the class-two exponential formula for an operator with one nonzero basis column.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_transvectionUnit_of_action`:
   a class-two root operator with one nonzero basis column exponentiates to a transvection.
+* `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul` and
+  `TauCeti.UniversalEnvelopingAlgebra.exists_map_genericMatrix_kostantRootSubgroupCoordinateMap`:
+  without the rank-one hypothesis a class-two root operator still exponentiates to `1 + t X`, on a
+  point and on the generic matrix respectively.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupPoints_injective`: the root subgroup is
   faithfully parametrized by `𝔾ₐ`.
 * `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupCoordinateMap_surjective`: the coordinate
@@ -414,5 +418,120 @@ theorem coe_kostantRootSubgroupClosedSubgroup :
   ClosedSubgroupScheme.coe_mk _
 
 end Scheme
+
+section ClassTwo
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {ι : Type w} {κ : Type*}
+variable {V : Type v} [AddCommGroup V] [Module ℚ V]
+variable (e : ι → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
+variable (i : ι)
+variable (hnil : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+variable {η : Type*} [Fintype η] [DecidableEq η] (b : Module.Basis η ℤ M)
+
+include hnil in
+/-- **The matrix of a class-two root subgroup is `1 + t X`.** When the root operator squares to
+zero its divided-power exponential stops after the linear term, so the root-subgroup matrix at
+parameter `t` is the identity plus `t` times the integral matrix `X` of the operator itself.
+Unlike `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_transvectionUnit_of_action`
+this does not assume the operator has rank one, so it also covers the root generators of the
+multiply-laced families, which move two basis vectors. -/
+theorem kostantRootSubgroupMatrix_eq_one_add_smul {A : Type*} [CommRing A]
+    (X : Matrix η η ℤ)
+    (hclass : nilpotencyClass
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) = 2)
+    (haction : ∀ s, ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) (b s : V) =
+      ∑ r, X r s • (b r : V))
+    (f : WithConv (SymmetricAlgebra ℤ ℤ →ₐ[ℤ] A)) :
+    (kostantRootSubgroupMatrix e h ρ M hM i hnil b f).val =
+      1 + Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv f) •
+        X.map (Int.cast : ℤ → A) := by
+  classical
+  have hone : ∀ s : η, integralDividedPower
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M 1
+      (fun _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i 1 hv)
+      (b s) = ∑ r, X r s • b r := by
+    intro s
+    apply Subtype.ext
+    rw [coe_integralDividedPower_apply, Associative.dividedPower_one, Module.End.smul_def,
+      haction]
+    push_cast
+    simp
+  have hzero : ∀ s : η, integralDividedPower
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) M 0
+      (fun _ hv => dividedPower_apply_mem_of_kostantForm_apply_mem e h ρ hM i 0 hv)
+      (b s) = b s := by
+    intro s
+    rw [integralDividedPower_zero]
+    rfl
+  ext r s
+  rw [kostantRootSubgroupMatrix_apply, repr_kostantRootSubgroupPoints_baseChange, hclass,
+    Finset.sum_range_succ, Finset.sum_range_one, hzero, hone, map_sum]
+  simp only [Finsupp.coe_finsetSum, Finset.sum_apply, map_zsmul, Module.Basis.repr_self,
+    Finsupp.smul_single, smul_eq_mul, mul_one, Finsupp.single_apply, pow_zero, pow_one,
+    Matrix.add_apply, Matrix.one_apply, Matrix.smul_apply, Matrix.map_apply, zsmul_eq_mul,
+    Int.cast_ite, Int.cast_one, Int.cast_zero]
+  rw [Finset.sum_ite_eq' Finset.univ r fun x => X x s]
+  rcases eq_or_ne r s with rfl | hrs
+  · simp [mul_comm]
+  · simp [hrs, hrs.symm, mul_comm]
+
+end ClassTwo
+
+section GenericMatrix
+
+variable {L : Type u} [LieRing L] [LieAlgebra ℚ L]
+variable {ι : Type w} {κ : Type*}
+variable {V : Type} [AddCommGroup V] [Module ℚ V]
+variable (e : ι → L) (h : κ → L)
+variable (ρ : _root_.UniversalEnvelopingAlgebra ℚ L →ₐ[ℚ] Module.End ℚ V)
+variable (M : AddSubgroup V)
+variable (hM : ∀ u ∈ kostantForm e h, ∀ v ∈ M, ρ u v ∈ M)
+variable (i : ι)
+variable (hnil : IsNilpotent (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))))
+variable {N : ℕ} (bb : Module.Basis (Fin N) ℤ M)
+
+include hnil in
+/-- **The generic matrix of a class-two root subgroup is `1 + t X`.** This is
+`TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul` read on the
+coordinate morphism rather than on a point: the entries of the generic matrix of `GL N` are carried
+to those of `1 + t X` for the parameter `t` of the universal point of `𝔾ₐ`. A consumer that has to
+check a matrix equation on every algebra-valued point at once evaluates it here instead. -/
+theorem exists_map_genericMatrix_kostantRootSubgroupCoordinateMap
+    (X : Matrix (Fin N) (Fin N) ℤ)
+    (hclass : nilpotencyClass
+      (ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i))) = 2)
+    (haction : ∀ s, ρ (_root_.UniversalEnvelopingAlgebra.ι ℚ (e i)) (bb s : V) =
+      ∑ r, X r s • (bb r : V)) :
+    ∃ t : AdditiveGroup.coordinateHopfAlgebra ℤ,
+      (GeneralLinear.genericMatrix ℤ N).map
+          (kostantRootSubgroupCoordinateMap e h ρ M hM i hnil bb).hom.toAlgHom =
+        1 + t • X.map (Int.cast : ℤ → AdditiveGroup.coordinateHopfAlgebra ℤ) := by
+  let f := kostantRootSubgroupCoordinateMap e h ρ M hM i hnil bb
+  let q : WithConv (AdditiveGroup.coordinateHopfAlgebra ℤ →ₐ[ℤ]
+      AdditiveGroup.coordinateHopfAlgebra ℤ) :=
+    toConv (AlgHom.id ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ))
+  have hq : q.ofConv = AlgHom.id ℤ (AdditiveGroup.coordinateHopfAlgebra ℤ) :=
+    WithConv.ofConv_toConv _
+  let m := kostantRootSubgroupMatrix e h ρ M hM i hnil bb q
+  have hpoint : GeneralLinear.pointToGeneralLinear N
+      (toConv (q.ofConv.comp f.hom.toAlgHom)) = m :=
+    pointsMulEquiv_kostantRootSubgroupCoordinateMap e h ρ M hM i hnil bb
+      (AdditiveGroup.coordinateHopfAlgebra ℤ) q
+  have hpoint' : GeneralLinear.pointToGeneralLinear N (toConv f.hom.toAlgHom) = m := by
+    simpa only [hq, AlgHom.id_comp, WithConv.ofConv_toConv] using hpoint
+  have hmval : m.val = 1 + Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv q) •
+      X.map (Int.cast : ℤ → AdditiveGroup.coordinateHopfAlgebra ℤ) :=
+    kostantRootSubgroupMatrix_eq_one_add_smul e h ρ M hM i hnil bb X hclass haction q
+  refine ⟨Multiplicative.toAdd (AdditiveGroup.gaPointsMulEquiv q), ?_⟩
+  rw [← hmval, ← hpoint']
+  ext a c
+  rw [Matrix.map_apply, GeneralLinear.genericMatrix_apply,
+    GeneralLinear.pointToGeneralLinear_apply, WithConv.ofConv_toConv]
+
+end GenericMatrix
 
 end TauCeti.UniversalEnvelopingAlgebra


### PR DESCRIPTION
This PR proves that the explicit full-weight type-`C_(n+1)` Chevalley carrier lies in the symplectic subgroup scheme of `GL_(2n+2)`. `TauCeti.SpStd.symplecticDefiningHopfIdeal_le_definingIdeal` puts the symplectic relations `X J Xᵀ - J` inside the carrier's defining Hopf ideal, and `TauCeti.SpStd.mem_GLSymplecticFin_of_mem_points` reads that on points: every matrix point of the carrier preserves the standard alternating form. The two generator computations behind it are `TauCeti.SpStd.rootIntMatrix`, the integral matrix of a numbered root generator in the enumerated coordinate basis, together with `rootIntMatrix_map_mul_JFin_add_eq_zero` and `rootIntMatrix_map_mul_self_eq_zero`, which say it is skew-adjoint for the transported form and squares to zero, and the fact that the weight-torus characters at a coordinate and at its symplectic partner are inverse to each other, because the standard weights come in the pairs `ε_a` and `-ε_a`.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

The exact roadmap target is Layer 9, "The Chevalley--Demazure construction", of `TauCetiRoadmap/ReductiveGroups/README.md`: "For each root datum, an explicitly constructed split reductive group scheme over `ℤ` realizing it, via a Chevalley basis and the Kostant `ℤ`-form of the enveloping algebra. Constructed, not asserted to exist." The dependency edge is milestone L0, "explicit pinned Chevalley--Demazure groups", of `TauCetiRoadmap/CFSGStatement/README.md`, whose output is "the actual body of `ValidLieTypeIndex.AmbientGroup`, its `Group` instance, `ValidLieTypeIndex.Closure`, and `ValidLieTypeIndex.simpleRootSubgroup`" and which lists "the pinned Chevalley--Demazure group scheme over `ℤ`" among the Layer 9 declarations it consumes. L0 needs the *simply connected* carrier of each valid Dynkin type; for type `C_n` that is `Sp_(2n)`, so knowing that the full-weight carrier lands in the symplectic group scheme is what lets a reviewer of the `C_n(q)` branch trace the carrier to the group it is meant to be. After this PR, L0 still needs the reverse inclusion for type `C` (a generation theorem, as in type `A`), the remaining full-weight carriers for the `B`, `D`, `E₆` and `E₇` diagrams, and then the root-datum and reductivity statements that turn a carrier into a pinned split reductive group scheme.

This was the most effective current step because the type-`C` carrier lane had reached exactly the point where the type-`A` lane took this step. `TauCeti.SpStd.groupScheme` with its root subgroups and weight torus is on `main` in `TauCeti/Algebra/Lie/Symplectic/StandardCarrier/{Basic,Scheme}.lean` (feat: add the type C full-weight carrier https://github.com/TauCetiProject/TauCeti/pull/4628) and its Frobenius in `Frobenius.lean` (feat: the Frobenius of the full-weight type-C carrier https://github.com/TauCetiProject/TauCeti/pull/5149); the symplectic subgroup scheme with its points identification is on `main` in `TauCeti/Algebra/AlgebraicGroup/Symplectic/Basic.lean`; and no declaration related the two. The type-`A` counterpart, `TauCeti/Algebra/Lie/SpecialLinear/StandardCarrier/DeterminantOne.lean`, is the file this one mirrors, and both carriers' own module documentation records this identification as the piece still owed.

Add `TauCeti/Algebra/Lie/Symplectic/StandardCarrier/AlternatingForm.lean` (398 lines). Three groups of supporting declarations land in the files that own them rather than in the new one. `TauCeti.ConstantForm.definingHopfIdeal_toIdeal_le_ker_of_map_genericMatrix` goes next to `definingHopfIdeal_toIdeal` in `TauCeti/Algebra/AlgebraicGroup/ConstantForm/Basic.lean`: it holds for an arbitrary constant form over an arbitrary base, so stating it for the symplectic form would be strictly weaker than the proof, and it is the criterion by which any subgroup given by generating morphisms is shown to preserve a form. `TauCeti.UniversalEnvelopingAlgebra.kostantRootSubgroupMatrix_eq_one_add_smul` and `exists_map_genericMatrix_kostantRootSubgroupCoordinateMap` go next to `kostantRootSubgroupMatrix_eq_transvectionUnit_of_action` in `TauCeti/Algebra/Lie/UniversalEnveloping/Kostant/RootSubgroup/Scheme/ClosedImmersion.lean`: that lemma exponentiates a class-two root operator only when it has one nonzero basis column, which the short root generators of the multiply-laced families do not, and the general `1 + t X` form is what those families need. `TauCeti.SpStd.nilpotencyClass_rep_rootGenerator` and `TauCeti.SpStd.intCast_latticeBasis_repr` go next to `isNilpotent_rep_rootGenerator` and `latticeBasis` in the carrier's own `Basic.lean`.

The reverse inclusion is not proved, and no statement here asserts that the carrier is reductive, that its weight torus is maximal, that the carrier is the symplectic group scheme, or that any group in sight is finite or simple.

No Mathlib source or external formalization is vendored. Mathlib's `Matrix.J`, `Matrix.J_squared` and `LieAlgebra.Symplectic.sp` are reused rather than restated, and the skew-adjointness of a numbered generator is read off its membership in `sp` rather than recomputed from the block matrices. The conventions follow R. W. Carter, *Simple Groups of Lie Type*, §§4.4 and 11.3, J. E. Humphreys, *Linear Algebraic Groups*, §§26--27, and R. Steinberg, *Lectures on Chevalley Groups*, §3, as recorded in the module documentation.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"spstd-tosymplectic"}-->

🤖 Prepared with Claude Code
