### PR TITLE
feat: the hook-length formula

### DIFF
--- a/TauCeti/Combinatorics/Young/Corner.lean
+++ b/TauCeti/Combinatorics/Young/Corner.lean
@@ -38,6 +38,8 @@ corner, and only at a cell of `μ` that is a corner, nothing but `c` itself is r
   `YoungDiagram.IsCorner.card_erase`: it drops the number of cells by one.
 * `YoungDiagram.exists_isCorner`: a nonempty Young diagram has a corner, so the corner
   recursions are not vacuous.
+* `YoungDiagram.IsCorner.eq_of_fst_eq`: the corners of a diagram sit in distinct rows, and
+  `YoungDiagram.IsCorner.fst_lt_colLen_zero`: those rows are rows of the diagram.
 * `YoungDiagram.corners_transpose` and `YoungDiagram.erase_transpose`: corners and
   deletion commute with transposition.
 
@@ -228,6 +230,18 @@ theorem colLen_eq_fst_add_one (h : IsCorner μ c) : μ.colLen c.2 = c.1 + 1 := b
   have hbelow := h.below_notMem
   rw [_root_.YoungDiagram.mem_iff_lt_colLen] at hbelow
   omega
+
+/-- A corner is the final cell of its row, so it is determined by the row it lies in: the corners
+of a diagram sit in distinct rows. -/
+theorem eq_of_fst_eq (hc : IsCorner μ c) (hd : IsCorner μ d) (h : c.1 = d.1) : c = d := by
+  have hcr := hc.rowLen_eq_snd_add_one
+  have hdr := hd.rowLen_eq_snd_add_one
+  rw [h] at hcr
+  exact Prod.ext h (by omega)
+
+/-- The row of a corner is one of the rows of the diagram. -/
+theorem fst_lt_colLen_zero (h : IsCorner μ c) : c.1 < μ.colLen 0 :=
+  _root_.YoungDiagram.mem_iff_lt_colLen.mp (μ.up_left_mem le_rfl (Nat.zero_le c.2) h.mem)
 
 end IsCorner
 

--- a/TauCeti/Combinatorics/Young/HookLength/BetaNumbers.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/BetaNumbers.lean
@@ -30,6 +30,10 @@ determinant formula `f^μ · ∏_{i < r} βᵢ ! = μ.card ! · ∏_{i < j < r} 
 standard Young tableaux, and multiplying the two gives the multiplicative hook-length formula
 `f^μ · ∏_{c ∈ μ} hookLength μ c = μ.card !`.
 
+The file also records the one interaction between beta-numbers and corners, which the induction
+proving the Frobenius formula runs on: erasing a corner lowers the beta-number of its row by one
+and leaves the other beta-numbers alone.
+
 ## The row-by-row mechanism
 
 Everything reduces to one statement about a single row `i`, proved in
@@ -65,6 +69,8 @@ when `(j, c) ∉ μ`. Disjointness plus a count of both sides then forces the un
 * `YoungDiagram.prod_hookLength_row_mul_prod_betaNumber_sub_eq_factorial`: the identity for one row.
 * `YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial`: the hook-length
   product identity.
+* `YoungDiagram.IsCorner.betaNumber_erase`: erasing a corner lowers exactly one beta-number, by
+  one.
 
 ## References
 
@@ -255,5 +261,19 @@ theorem prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial (μ : YoungDia
       = ∏ i ∈ range r, (μ.betaNumber r i) ! := by
   rw [prod_cells_eq_prod_range hr, ← prod_mul_distrib]
   exact prod_congr rfl fun i _ => prod_hookLength_row_mul_prod_betaNumber_sub_eq_factorial hr
+
+/-! ### Erasing a corner -/
+
+/-- Erasing a corner lowers the beta-number of its row by one and leaves the other beta-numbers
+unchanged. -/
+@[simp]
+theorem IsCorner.betaNumber_erase {c : ℕ × ℕ} (h : IsCorner μ c) (r i : ℕ) :
+    (μ.erase c).betaNumber r i
+      = if c.1 = i then μ.betaNumber r i - 1 else μ.betaNumber r i := by
+  have hrow : 0 < μ.rowLen c.1 := by rw [h.rowLen_eq_snd_add_one]; omega
+  rw [betaNumber_def, h.rowLen_erase, betaNumber_def]
+  split_ifs with hi
+  · subst hi; omega
+  · rfl
 
 end YoungDiagram

--- a/TauCeti/Combinatorics/Young/HookLength/Formula.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/Formula.lean
@@ -1,0 +1,325 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Combinatorics.Young.HookLength.BetaNumbers
+public import TauCeti.Combinatorics.Young.StandardTableau.Corner
+-- Non-public: these appear only inside proofs, never in the type of an exported declaration.
+import TauCeti.Combinatorics.Young.StandardTableau.Reading
+import TauCeti.LinearAlgebra.Vandermonde
+
+/-!
+# The Frobenius determinant formula and the hook-length formula
+
+Let `μ` be a Young diagram with `n = μ.card` cells and let `f^μ = TauCeti.standardCount μ` be its
+number of standard Young tableaux. This file proves the **multiplicative hook-length formula**
+
+`f^μ * ∏ c ∈ μ.cells, hookLength μ c = n !`
+
+(`TauCeti.standardCount_mul_prod_hookLength`), the milestone of Layer 5 of the Schur--Weyl
+roadmap. It carries no division obligation; the quotient form `f^μ = n ! / ∏ hooks` needs the
+separate divisibility statement `∏ hooks ∣ n !` and is not derived here.
+
+## The route
+
+Fix a bound `r` on the number of rows and write `βᵢ = μ.rowLen i + (r - 1 - i)` for the
+beta-numbers of `TauCeti/Combinatorics/Young/BetaNumbers.lean`, which strictly decrease across
+`i < j < r`. The hook lengths are already related to them by
+`YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial`:
+
+`(∏ c ∈ μ.cells, hookLength μ c) * ∏_{i < j < r} (βᵢ - βⱼ) = ∏_{i < r} βᵢ !`.
+
+What remains, and is the substance of this file, is the **Frobenius determinant formula**
+
+`f^μ * ∏_{i < r} βᵢ ! = n ! * ∏_{i < j < r} (βᵢ - βⱼ)`
+
+(`TauCeti.standardCount_mul_prod_factorial_betaNumber`). Dividing one by the other cancels the
+Vandermonde-style product, which is positive, and leaves the hook-length formula.
+
+The Frobenius formula is proved by induction on `n` along the corner recursion
+`TauCeti.standardCount_eq_sum_corners`, `f^μ = ∑_{c a corner} f^{μ ∖ c}`. Erasing a corner lowers
+the beta-number of its row by one and leaves the others alone
+(`YoungDiagram.IsCorner.betaNumber_erase`), and `βᵢ ! = βᵢ * (βᵢ - 1) !` converts the induction
+hypothesis for `μ ∖ c` into a statement about `μ`. Summing it over the corners reduces the
+induction step to an identity between Vandermonde-style products,
+
+`∑_{i < r} βᵢ * ∏_{k < l < r} (β^{(i)}_k - β^{(i)}_l)`
+` = (∑_{i < r} βᵢ - ∑_{i < r} i) * ∏_{k < l < r} (β_k - β_l)`
+
+where `β^{(i)}` lowers `βᵢ` by one, which is `TauCeti.sum_mul_prod_sub_update_sub_one`. Two
+bookkeeping facts fit the two sides together. First, the rows of the corners inject into
+`{0, …, r - 1}`,
+because a corner is the last cell of its row; and a row `i < r` carrying no corner contributes
+nothing to the left-hand sum, since either `βᵢ = 0` or `βᵢ₊₁ = βᵢ - 1` with `i + 1 < r`, which
+puts a zero factor in its product. Second, `∑_{i < r} βᵢ - ∑_{i < r} i = n`, because the row
+lengths sum to `n` and the shifts `r - 1 - i` are a reflection of `0, 1, …, r - 1`.
+
+## Main results
+
+* `YoungDiagram.IsCorner.betaNumber_erase`: erasing a corner lowers exactly one beta-number, by
+  one.
+* `TauCeti.standardCount_mul_prod_factorial_betaNumber`: **the Frobenius determinant formula.**
+* `TauCeti.standardCount_mul_prod_hookLength`: **the multiplicative hook-length formula.**
+
+## References
+
+* [I. G. Macdonald, *Symmetric Functions and Hall Polynomials*][macdonald1995], Chapter I, Section
+  1, Example 1, and Section 7, Example 6, for the beta-number route to the hook-length formula.
+* [B. E. Sagan, *The Symmetric Group*][sagan2001], Section 3.10.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 5, whose `hookLengthFormula` milestone this closes.
+-/
+
+public section
+
+namespace YoungDiagram
+
+variable {μ : YoungDiagram} {c : ℕ × ℕ} {r i : ℕ}
+
+/-! ### Corners and beta-numbers -/
+
+/-- Erasing a corner lowers the beta-number of its row by one and leaves the other beta-numbers
+unchanged. -/
+@[simp]
+theorem IsCorner.betaNumber_erase (h : IsCorner μ c) (r i : ℕ) :
+    (μ.erase c).betaNumber r i
+      = if c.1 = i then μ.betaNumber r i - 1 else μ.betaNumber r i := by
+  have hrow : 0 < μ.rowLen c.1 := by rw [h.rowLen_eq_snd_add_one]; omega
+  rw [betaNumber_def, h.rowLen_erase, betaNumber_def]
+  split_ifs with hi
+  · subst hi; omega
+  · rfl
+
+/-- The beta-number of the row of an erased corner, as a special case of
+`YoungDiagram.IsCorner.betaNumber_erase`. -/
+private theorem IsCorner.betaNumber_erase_self (h : IsCorner μ c) (r : ℕ) :
+    (μ.erase c).betaNumber r c.1 = μ.betaNumber r c.1 - 1 := by
+  simp [h.betaNumber_erase]
+
+/-- The beta-numbers of the other rows of an erased corner, as a special case of
+`YoungDiagram.IsCorner.betaNumber_erase`. -/
+private theorem IsCorner.betaNumber_erase_of_ne (h : IsCorner μ c) (r : ℕ) (hi : c.1 ≠ i) :
+    (μ.erase c).betaNumber r i = μ.betaNumber r i := by
+  simp [h.betaNumber_erase, hi]
+
+/-- A row inside the bound that carries no corner and whose beta-number is nonzero is followed,
+still inside the bound, by a row whose beta-number is one smaller: either the row is empty and
+only the shift `r - 1 - i` contributes, or the row below it has the same length. -/
+private theorem betaNumber_succ_add_one_of_forall_ne (hr : μ.colLen 0 ≤ r) (hi : i < r)
+    (hβ : μ.betaNumber r i ≠ 0) (hno : ∀ c ∈ corners μ, c.1 ≠ i) :
+    i + 1 < r ∧ μ.betaNumber r (i + 1) + 1 = μ.betaNumber r i := by
+  have hanti : μ.rowLen (i + 1) ≤ μ.rowLen i := μ.rowLen_anti i (i + 1) (by omega)
+  have hcase : μ.rowLen i = 0 ∨ μ.rowLen (i + 1) = μ.rowLen i := by
+    by_contra hcon
+    push Not at hcon
+    obtain ⟨h0, hne⟩ := hcon
+    refine hno (i, μ.rowLen i - 1) (mem_corners.mpr ((isCorner_def μ _).mpr ⟨?_, ?_, ?_⟩)) rfl
+    · exact mem_iff_lt_rowLen.mpr (by omega)
+    · simp only [mem_iff_lt_rowLen]; omega
+    · simp only [mem_iff_lt_rowLen]; omega
+  simp only [betaNumber_def] at hβ ⊢
+  rcases hcase with h0 | h1
+  · have h1 : μ.rowLen (i + 1) = 0 := by omega
+    omega
+  · rcases Nat.eq_zero_or_pos (μ.rowLen i) with h0 | h0
+    · have h2 : μ.rowLen (i + 1) = 0 := by omega
+      omega
+    · have hmem : (i + 1, 0) ∈ μ := mem_iff_lt_rowLen.mpr (by omega)
+      have := mem_iff_lt_colLen.mp hmem
+      omega
+
+end YoungDiagram
+
+namespace TauCeti
+
+open Finset Nat YoungDiagram
+
+/-! ### The Frobenius determinant formula -/
+
+/-- The Vandermonde-style product of the differences of the beta-numbers is computed by the same
+formula over `ℤ`, the differences being nonnegative. -/
+private theorem cast_prod_betaNumber_sub (μ : YoungDiagram) (r : ℕ) :
+    ((∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r, (μ.betaNumber r k - μ.betaNumber r l) : ℕ) : ℤ)
+      = ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
+          ((μ.betaNumber r k : ℤ) - (μ.betaNumber r l : ℤ)) := by
+  rw [Nat.cast_prod]
+  refine Finset.prod_congr rfl fun k _ => ?_
+  rw [Nat.cast_prod]
+  refine Finset.prod_congr rfl fun l hl => ?_
+  rw [mem_Ico] at hl
+  exact Nat.cast_sub (μ.betaNumber_lt_betaNumber (by omega) hl.2).le
+
+/-- A row of the diagram carrying no corner contributes nothing to the lowering identity: either
+its beta-number vanishes, or lowering that beta-number by one makes it agree with the next one,
+which puts a zero factor in the product. -/
+private theorem betaNumber_term_eq_zero {μ : YoungDiagram} {r i : ℕ} (hr : μ.colLen 0 ≤ r)
+    (hi : i ∈ range r) (hno : ∀ c ∈ corners μ, c.1 ≠ i) :
+    (μ.betaNumber r i : ℤ) *
+        ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
+          (Function.update (fun j => (μ.betaNumber r j : ℤ)) i ((μ.betaNumber r i : ℤ) - 1) k
+            - Function.update (fun j => (μ.betaNumber r j : ℤ)) i
+                ((μ.betaNumber r i : ℤ) - 1) l)
+      = 0 := by
+  by_cases hβ : μ.betaNumber r i = 0
+  · rw [hβ]; simp
+  obtain ⟨hlt, hsucc⟩ := betaNumber_succ_add_one_of_forall_ne hr (mem_range.mp hi) hβ hno
+  have hcast : ((μ.betaNumber r (i + 1) : ℤ)) + 1 = (μ.betaNumber r i : ℤ) := by
+    exact_mod_cast hsucc
+  have hinner : ∏ l ∈ Ico (i + 1) r,
+      (Function.update (fun j => (μ.betaNumber r j : ℤ)) i ((μ.betaNumber r i : ℤ) - 1) i
+        - Function.update (fun j => (μ.betaNumber r j : ℤ)) i
+            ((μ.betaNumber r i : ℤ) - 1) l) = 0 := by
+    refine Finset.prod_eq_zero (mem_Ico.mpr ⟨le_rfl, hlt⟩) ?_
+    rw [Function.update_self, Function.update_of_ne (by omega)]
+    omega
+  rw [Finset.prod_eq_zero hi hinner, mul_zero]
+
+/-- The rows of the corners inject into the rows inside the bound, and a row carrying no corner
+contributes nothing, so a sum over the corners of a diagram is a sum over its rows. -/
+private theorem sum_corners_eq_sum_range {μ : YoungDiagram} {r : ℕ} (hr : μ.colLen 0 ≤ r)
+    (F : ℕ → ℤ) (hF : ∀ i ∈ range r, (∀ c ∈ corners μ, c.1 ≠ i) → F i = 0) :
+    ∑ c ∈ corners μ, F c.1 = ∑ i ∈ range r, F i := by
+  classical
+  have hinj : ∀ c ∈ corners μ, ∀ d ∈ corners μ, c.1 = d.1 → c = d :=
+    fun c hc d hd h => (mem_corners.mp hc).eq_of_fst_eq (mem_corners.mp hd) h
+  rw [← Finset.sum_image hinj]
+  refine Finset.sum_subset (fun i hi => ?_) fun i hi hni => ?_
+  · obtain ⟨c, hc, rfl⟩ := Finset.mem_image.mp hi
+    exact mem_range.mpr (((mem_corners.mp hc).fst_lt_colLen_zero).trans_le hr)
+  · exact hF i hi fun c hc h => hni (Finset.mem_image.mpr ⟨c, hc, h⟩)
+
+/-- The beta-numbers overshoot the number of cells by exactly `0 + 1 + ⋯ + (r - 1)`: the row
+lengths sum to `μ.card`, and the shifts `r - 1 - i` are a reflection of `0, 1, …, r - 1`. -/
+private theorem sum_betaNumber_sub_sum_range (μ : YoungDiagram) {r : ℕ} (hr : μ.colLen 0 ≤ r) :
+    (∑ i ∈ range r, (μ.betaNumber r i : ℤ)) - ∑ i ∈ range r, (i : ℤ) = (μ.card : ℤ) := by
+  have hsplit : ∑ i ∈ range r, (μ.betaNumber r i : ℤ)
+      = (∑ i ∈ range r, (μ.rowLen i : ℤ)) + ∑ i ∈ range r, ((r - 1 - i : ℕ) : ℤ) := by
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun i _ => by rw [betaNumber_def]; push_cast; ring
+  have hrows : ∑ i ∈ range r, (μ.rowLen i : ℤ) = (μ.card : ℤ) := by
+    rw [← Nat.cast_sum, ← YoungDiagram.card_eq_sum_range_rowLen μ hr]
+  rw [hsplit, hrows, Finset.sum_range_reflect (fun j : ℕ => (j : ℤ)) r]
+  ring
+
+/-- The inductive form of the Frobenius determinant formula, with the number of cells fixed so
+that the corner recursion is an ordinary induction. -/
+private theorem standardCount_mul_prod_factorial_betaNumber_aux (n : ℕ) :
+    ∀ (μ : YoungDiagram) (r : ℕ), μ.card = n → μ.colLen 0 ≤ r →
+      (standardCount μ : ℤ) * ∏ i ∈ range r, ((μ.betaNumber r i) ! : ℤ)
+        = (n ! : ℤ) * ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
+            ((μ.betaNumber r k : ℤ) - (μ.betaNumber r l : ℤ)) := by
+  induction n with
+  | zero =>
+    intro μ r hcard hr
+    have hcells : μ.cells = ∅ := Finset.card_eq_zero.mp hcard
+    have hcol : μ.colLen 0 = 0 := by
+      by_contra hc
+      have hmem : (0, 0) ∈ μ := mem_iff_lt_colLen.mpr (by omega)
+      rw [← mem_cells, hcells] at hmem
+      exact absurd hmem (Finset.notMem_empty _)
+    have hprod := YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial μ hr
+    rw [hcells, Finset.prod_empty, one_mul] at hprod
+    rw [standardCount_eq_one_of_colLen_le_one (by omega), Nat.cast_one, one_mul,
+      Nat.factorial_zero, Nat.cast_one, one_mul, ← cast_prod_betaNumber_sub, hprod, Nat.cast_prod]
+  | succ n ih =>
+    intro μ r hcard hr
+    -- the induction hypothesis at each corner, rescaled by the beta-number of its row
+    have hcorner : ∀ c ∈ corners μ,
+        (standardCount (μ.erase c) : ℤ) * ∏ i ∈ range r, ((μ.betaNumber r i) ! : ℤ)
+          = (n ! : ℤ) * ((μ.betaNumber r c.1 : ℤ) *
+              ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
+                (Function.update (fun j => (μ.betaNumber r j : ℤ)) c.1
+                    ((μ.betaNumber r c.1 : ℤ) - 1) k
+                  - Function.update (fun j => (μ.betaNumber r j : ℤ)) c.1
+                      ((μ.betaNumber r c.1 : ℤ) - 1) l)) := by
+      intro c hc
+      have hcc : IsCorner μ c := mem_corners.mp hc
+      have hb : 1 ≤ μ.betaNumber r c.1 := by
+        rw [betaNumber_def, hcc.rowLen_eq_snd_add_one]; omega
+      have hcard' : (μ.erase c).card = n := by have := hcc.card_erase; omega
+      have hr' : (μ.erase c).colLen 0 ≤ r := by
+        rw [hcc.colLen_erase]; split_ifs <;> omega
+      -- the erased beta-numbers are the original ones with the corner's row lowered by one
+      have hbeta : ∀ i, (((μ.erase c).betaNumber r i : ℕ) : ℤ)
+          = Function.update (fun j => (μ.betaNumber r j : ℤ)) c.1
+              ((μ.betaNumber r c.1 : ℤ) - 1) i := by
+        intro i
+        rcases eq_or_ne c.1 i with rfl | h
+        · rw [hcc.betaNumber_erase_self, Function.update_self]
+          omega
+        · rw [hcc.betaNumber_erase_of_ne r h, Function.update_of_ne (Ne.symm h)]
+      -- `βᵢ ! = βᵢ * (βᵢ - 1) !` at the corner's row, and nothing changes elsewhere
+      have hmem : c.1 ∈ range r := mem_range.mpr (hcc.fst_lt_colLen_zero.trans_le hr)
+      have hfact : (μ.betaNumber r c.1 : ℤ) *
+          ∏ i ∈ range r, (((μ.erase c).betaNumber r i) ! : ℤ)
+            = ∏ i ∈ range r, ((μ.betaNumber r i) ! : ℤ) := by
+        rw [← Finset.mul_prod_erase (range r) (fun i => (((μ.erase c).betaNumber r i) ! : ℤ)) hmem,
+          ← Finset.mul_prod_erase (range r) (fun i => ((μ.betaNumber r i) ! : ℤ)) hmem,
+          ← mul_assoc]
+        refine congrArg₂ (· * ·) ?_ (Finset.prod_congr rfl fun i hi => ?_)
+        · rw [hcc.betaNumber_erase_self, ← Nat.cast_mul, Nat.mul_factorial_pred (by omega)]
+        · rw [hcc.betaNumber_erase_of_ne r (Ne.symm (Finset.ne_of_mem_erase hi))]
+      rw [← hfact, ← mul_assoc, mul_comm ((standardCount (μ.erase c) : ℤ)), mul_assoc,
+        ih (μ.erase c) r hcard' hr', ← mul_assoc, mul_comm ((μ.betaNumber r c.1 : ℤ)), mul_assoc]
+      exact congrArg _ (congrArg _ (Finset.prod_congr rfl fun k _ =>
+        Finset.prod_congr rfl fun l _ => by rw [hbeta k, hbeta l]))
+    have hzero : ∀ i ∈ range r, (∀ c ∈ corners μ, c.1 ≠ i) →
+        (μ.betaNumber r i : ℤ) *
+          ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
+            (Function.update (fun j => (μ.betaNumber r j : ℤ)) i ((μ.betaNumber r i : ℤ) - 1) k
+              - Function.update (fun j => (μ.betaNumber r j : ℤ)) i
+                  ((μ.betaNumber r i : ℤ) - 1) l) = 0 :=
+      fun i hi hno => betaNumber_term_eq_zero hr hi hno
+    rw [standardCount_eq_sum_corners (by omega : 0 < μ.card), Nat.cast_sum, Finset.sum_mul,
+      Finset.sum_congr rfl hcorner, ← Finset.mul_sum,
+      sum_corners_eq_sum_range hr _ hzero,
+      TauCeti.sum_mul_prod_sub_update_sub_one r fun j => (μ.betaNumber r j : ℤ),
+      sum_betaNumber_sub_sum_range μ hr, hcard]
+    rw [Nat.factorial_succ]
+    push_cast
+    ring
+
+/-- **The Frobenius determinant formula** for the number `f^μ` of standard Young tableaux of shape
+`μ`: for any bound `r` on the number of rows, `f^μ` times the product of the factorials of the
+beta-numbers is `μ.card !` times the product of their differences over the ordered pairs of rows.
+
+This is the multiplicative form of `f^μ = n ! * ∏_{i < j} (βᵢ - βⱼ) / ∏_i βᵢ !`, and carries no
+division obligation. -/
+theorem standardCount_mul_prod_factorial_betaNumber (μ : YoungDiagram) {r : ℕ}
+    (hr : μ.colLen 0 ≤ r) :
+    (standardCount μ : ℤ) * ∏ i ∈ range r, ((μ.betaNumber r i) ! : ℤ)
+      = (μ.card ! : ℤ) * ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
+          ((μ.betaNumber r k : ℤ) - (μ.betaNumber r l : ℤ)) :=
+  standardCount_mul_prod_factorial_betaNumber_aux μ.card μ r rfl hr
+
+/-! ### The hook-length formula -/
+
+/-- **The multiplicative hook-length formula.** The number of standard Young tableaux of shape `μ`,
+times the product of the hook lengths of the cells of `μ`, is the factorial of the number of cells.
+
+The quotient form `f^μ = μ.card ! / ∏ hooks` needs the separate divisibility statement
+`∏ hooks ∣ μ.card !` and is not stated here. -/
+theorem standardCount_mul_prod_hookLength (μ : YoungDiagram) :
+    standardCount μ * ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c = μ.card ! := by
+  obtain ⟨r, hr⟩ : ∃ r, μ.colLen 0 ≤ r := ⟨μ.colLen 0, le_rfl⟩
+  have hV : 0 < ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r, (μ.betaNumber r k - μ.betaNumber r l) :=
+    Finset.prod_pos fun k _ => Finset.prod_pos fun l hl => by
+      rw [mem_Ico] at hl
+      have := μ.betaNumber_lt_betaNumber (i := k) (j := l) (by omega) hl.2
+      omega
+  have hhook := YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial μ hr
+  have hfrob := standardCount_mul_prod_factorial_betaNumber μ hr
+  rw [← cast_prod_betaNumber_sub, ← Nat.cast_prod, ← hhook, Nat.cast_mul] at hfrob
+  have hgoal : ((standardCount μ * ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c : ℕ) : ℤ)
+      = ((μ.card ! : ℕ) : ℤ) := by
+    rw [Nat.cast_mul]
+    refine mul_right_cancel₀ (b := ((∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
+      (μ.betaNumber r k - μ.betaNumber r l) : ℕ) : ℤ)) (by exact_mod_cast hV.ne') ?_
+    rw [mul_assoc]
+    exact hfrob
+  exact_mod_cast hgoal
+
+end TauCeti

--- a/TauCeti/Combinatorics/Young/HookLength/Formula.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/Formula.lean
@@ -20,8 +20,8 @@ number of standard Young tableaux. This file proves the **multiplicative hook-le
 `f^μ * ∏ c ∈ μ.cells, hookLength μ c = n !`
 
 (`TauCeti.standardCount_mul_prod_hookLength`), the milestone of Layer 5 of the Schur--Weyl
-roadmap. It carries no division obligation; the quotient form `f^μ = n ! / ∏ hooks` needs the
-separate divisibility statement `∏ hooks ∣ n !` and is not derived here.
+roadmap. It carries no division obligation, and the quotient form `f^μ = n ! / ∏ hooks`, which
+follows from it because the hook lengths are positive, is simply not stated here.
 
 ## The route
 
@@ -59,8 +59,6 @@ lengths sum to `n` and the shifts `r - 1 - i` are a reflection of `0, 1, …, r 
 
 ## Main results
 
-* `YoungDiagram.IsCorner.betaNumber_erase`: erasing a corner lowers exactly one beta-number, by
-  one.
 * `TauCeti.standardCount_mul_prod_factorial_betaNumber`: **the Frobenius determinant formula.**
 * `TauCeti.standardCount_mul_prod_hookLength`: **the multiplicative hook-length formula.**
 
@@ -80,18 +78,6 @@ namespace YoungDiagram
 variable {μ : YoungDiagram} {c : ℕ × ℕ} {r i : ℕ}
 
 /-! ### Corners and beta-numbers -/
-
-/-- Erasing a corner lowers the beta-number of its row by one and leaves the other beta-numbers
-unchanged. -/
-@[simp]
-theorem IsCorner.betaNumber_erase (h : IsCorner μ c) (r i : ℕ) :
-    (μ.erase c).betaNumber r i
-      = if c.1 = i then μ.betaNumber r i - 1 else μ.betaNumber r i := by
-  have hrow : 0 < μ.rowLen c.1 := by rw [h.rowLen_eq_snd_add_one]; omega
-  rw [betaNumber_def, h.rowLen_erase, betaNumber_def]
-  split_ifs with hi
-  · subst hi; omega
-  · rfl
 
 /-- The beta-number of the row of an erased corner, as a special case of
 `YoungDiagram.IsCorner.betaNumber_erase`. -/
@@ -286,22 +272,27 @@ private theorem standardCount_mul_prod_factorial_betaNumber_aux (n : ℕ) :
 `μ`: for any bound `r` on the number of rows, `f^μ` times the product of the factorials of the
 beta-numbers is `μ.card !` times the product of their differences over the ordered pairs of rows.
 
-This is the multiplicative form of `f^μ = n ! * ∏_{i < j} (βᵢ - βⱼ) / ∏_i βᵢ !`, and carries no
+The differences are differences of natural numbers, and are truncated at no ordered pair: the
+beta-numbers strictly decrease across `k < l < r`.
+
+This is the multiplicative form of `f^μ = n ! * ∏_{k < l} (β_k - β_l) / ∏_k β_k !`, and carries no
 division obligation. -/
 theorem standardCount_mul_prod_factorial_betaNumber (μ : YoungDiagram) {r : ℕ}
     (hr : μ.colLen 0 ≤ r) :
-    (standardCount μ : ℤ) * ∏ i ∈ range r, ((μ.betaNumber r i) ! : ℤ)
-      = (μ.card ! : ℤ) * ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
-          ((μ.betaNumber r k : ℤ) - (μ.betaNumber r l : ℤ)) :=
-  standardCount_mul_prod_factorial_betaNumber_aux μ.card μ r rfl hr
+    standardCount μ * ∏ i ∈ range r, (μ.betaNumber r i) !
+      = μ.card ! * ∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
+          (μ.betaNumber r k - μ.betaNumber r l) := by
+  have h := standardCount_mul_prod_factorial_betaNumber_aux μ.card μ r rfl hr
+  rw [← cast_prod_betaNumber_sub] at h
+  exact_mod_cast h
 
 /-! ### The hook-length formula -/
 
 /-- **The multiplicative hook-length formula.** The number of standard Young tableaux of shape `μ`,
 times the product of the hook lengths of the cells of `μ`, is the factorial of the number of cells.
 
-The quotient form `f^μ = μ.card ! / ∏ hooks` needs the separate divisibility statement
-`∏ hooks ∣ μ.card !` and is not stated here. -/
+The quotient form `f^μ = μ.card ! / ∏ hooks`, which follows from this one because the hook lengths
+are positive, is not stated here. -/
 theorem standardCount_mul_prod_hookLength (μ : YoungDiagram) :
     standardCount μ * ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c = μ.card ! := by
   obtain ⟨r, hr⟩ : ∃ r, μ.colLen 0 ≤ r := ⟨μ.colLen 0, le_rfl⟩
@@ -311,15 +302,8 @@ theorem standardCount_mul_prod_hookLength (μ : YoungDiagram) :
       have := μ.betaNumber_lt_betaNumber (i := k) (j := l) (by omega) hl.2
       omega
   have hhook := YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial μ hr
-  have hfrob := standardCount_mul_prod_factorial_betaNumber μ hr
-  rw [← cast_prod_betaNumber_sub, ← Nat.cast_prod, ← hhook, Nat.cast_mul] at hfrob
-  have hgoal : ((standardCount μ * ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c : ℕ) : ℤ)
-      = ((μ.card ! : ℕ) : ℤ) := by
-    rw [Nat.cast_mul]
-    refine mul_right_cancel₀ (b := ((∏ k ∈ range r, ∏ l ∈ Ico (k + 1) r,
-      (μ.betaNumber r k - μ.betaNumber r l) : ℕ) : ℤ)) (by exact_mod_cast hV.ne') ?_
-    rw [mul_assoc]
-    exact hfrob
-  exact_mod_cast hgoal
+  refine Nat.eq_of_mul_eq_mul_right hV ?_
+  rw [mul_assoc, hhook]
+  exact standardCount_mul_prod_factorial_betaNumber μ hr
 
 end TauCeti

--- a/TauCeti/Combinatorics/Young/HookLength/Formula.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/Formula.lean
@@ -75,21 +75,9 @@ public section
 
 namespace YoungDiagram
 
-variable {μ : YoungDiagram} {c : ℕ × ℕ} {r i : ℕ}
+variable {μ : YoungDiagram} {r i : ℕ}
 
 /-! ### Corners and beta-numbers -/
-
-/-- The beta-number of the row of an erased corner, as a special case of
-`YoungDiagram.IsCorner.betaNumber_erase`. -/
-private theorem IsCorner.betaNumber_erase_self (h : IsCorner μ c) (r : ℕ) :
-    (μ.erase c).betaNumber r c.1 = μ.betaNumber r c.1 - 1 := by
-  simp [h.betaNumber_erase]
-
-/-- The beta-numbers of the other rows of an erased corner, as a special case of
-`YoungDiagram.IsCorner.betaNumber_erase`. -/
-private theorem IsCorner.betaNumber_erase_of_ne (h : IsCorner μ c) (r : ℕ) (hi : c.1 ≠ i) :
-    (μ.erase c).betaNumber r i = μ.betaNumber r i := by
-  simp [h.betaNumber_erase, hi]
 
 /-- A row inside the bound that carries no corner and whose beta-number is nonzero is followed,
 still inside the bound, by a row whose beta-number is one smaller: either the row is empty and
@@ -234,9 +222,9 @@ private theorem standardCount_mul_prod_factorial_betaNumber_aux (n : ℕ) :
               ((μ.betaNumber r c.1 : ℤ) - 1) i := by
         intro i
         rcases eq_or_ne c.1 i with rfl | h
-        · rw [hcc.betaNumber_erase_self, Function.update_self]
+        · rw [hcc.betaNumber_erase r c.1, ite_eq_left rfl, Function.update_self]
           omega
-        · rw [hcc.betaNumber_erase_of_ne r h, Function.update_of_ne (Ne.symm h)]
+        · rw [hcc.betaNumber_erase r i, ite_eq_right h, Function.update_of_ne (Ne.symm h)]
       -- `βᵢ ! = βᵢ * (βᵢ - 1) !` at the corner's row, and nothing changes elsewhere
       have hmem : c.1 ∈ range r := mem_range.mpr (hcc.fst_lt_colLen_zero.trans_le hr)
       have hfact : (μ.betaNumber r c.1 : ℤ) *
@@ -246,8 +234,9 @@ private theorem standardCount_mul_prod_factorial_betaNumber_aux (n : ℕ) :
           ← Finset.mul_prod_erase (range r) (fun i => ((μ.betaNumber r i) ! : ℤ)) hmem,
           ← mul_assoc]
         refine congrArg₂ (· * ·) ?_ (Finset.prod_congr rfl fun i hi => ?_)
-        · rw [hcc.betaNumber_erase_self, ← Nat.cast_mul, Nat.mul_factorial_pred (by omega)]
-        · rw [hcc.betaNumber_erase_of_ne r (Ne.symm (Finset.ne_of_mem_erase hi))]
+        · rw [hcc.betaNumber_erase r c.1, ite_eq_left rfl, ← Nat.cast_mul,
+            Nat.mul_factorial_pred (by omega)]
+        · rw [hcc.betaNumber_erase r i, ite_eq_right (Ne.symm (Finset.ne_of_mem_erase hi))]
       rw [← hfact, ← mul_assoc, mul_comm ((standardCount (μ.erase c) : ℤ)), mul_assoc,
         ih (μ.erase c) r hcard' hr', ← mul_assoc, mul_comm ((μ.betaNumber r c.1 : ℤ)), mul_assoc]
       exact congrArg _ (congrArg _ (Finset.prod_congr rfl fun k _ =>

--- a/TauCeti/Combinatorics/Young/HookLength/Formula.lean
+++ b/TauCeti/Combinatorics/Young/HookLength/Formula.lean
@@ -26,7 +26,7 @@ follows from it because the hook lengths are positive, is simply not stated here
 ## The route
 
 Fix a bound `r` on the number of rows and write `βᵢ = μ.rowLen i + (r - 1 - i)` for the
-beta-numbers of `TauCeti/Combinatorics/Young/BetaNumbers.lean`, which strictly decrease across
+beta-numbers `YoungDiagram.betaNumber μ r i`, which strictly decrease across
 `i < j < r`. The hook lengths are already related to them by
 `YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial`:
 

--- a/TauCeti/Combinatorics/Young/StandardTableau/Reading.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau/Reading.lean
@@ -5,7 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Combinatorics.Young.HookLength.Basic
+public import Mathlib.Order.Preorder.Finite
 public import TauCeti.Combinatorics.Young.StandardTableau.Basic
 
 /-!
@@ -25,10 +25,6 @@ a cell outside its first column, while a diagram with at most one row, or with a
 -- the empty diagram included -- has only one standard Young tableau at all.  So `f^μ = 1` holds
 exactly for the diagrams with at most one row and those with at most one column.
 
-Those are also exactly the shapes whose hook lengths are already known to multiply to `μ.card !`,
-by `YoungDiagram.prod_hookLength_eq_factorial_of_colLen_le_one` and its transpose, so the
-multiplicative hook-length formula `f^μ · ∏_{c ∈ μ} hookLength μ c = μ.card !` follows for them.
-
 ## Main definitions
 
 * `YoungDiagram.readingIndex`: the position of a cell in reading order.
@@ -41,11 +37,6 @@ multiplicative hook-length formula `f^μ · ∏_{c ∈ μ} hookLength μ c = μ.
 * `TauCeti.standardCount_pos`: every Young diagram has a standard Young tableau.
 * `TauCeti.standardCount_eq_one_iff`: a Young diagram has exactly one standard Young tableau
   precisely when it has at most one row or at most one column, the empty diagram included.
-* `TauCeti.standardCount_mul_prod_hookLength_of_standardCount_eq_one`: the multiplicative
-  hook-length formula for the diagrams with a unique standard Young tableau, together with its
-  specialisations `TauCeti.standardCount_mul_prod_hookLength_of_colLen_le_one` and
-  `TauCeti.standardCount_mul_prod_hookLength_of_rowLen_le_one` to the diagrams with at most one
-  row and to those with at most one column.
 
 ## References
 
@@ -294,33 +285,5 @@ theorem standardCount_eq_one_iff {μ : YoungDiagram} :
     by_contra hcol
     exact hcon (Or.inr (by omega))
   exact absurd h (one_lt_standardCount hrow hcol).ne'
-
-/-- **The multiplicative hook-length formula for the shapes with a unique standard Young
-tableau**: by `standardCount_eq_one_iff` these are the diagrams with at most one row and those
-with at most one column, the empty diagram included, and their hook lengths are already known to
-multiply to `μ.card !`. -/
-theorem standardCount_mul_prod_hookLength_of_standardCount_eq_one {μ : YoungDiagram}
-    (h : standardCount μ = 1) :
-    standardCount μ * ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c = μ.card ! := by
-  rw [h, one_mul]
-  rcases standardCount_eq_one_iff.mp h with hrow | hcol
-  · exact YoungDiagram.prod_hookLength_eq_factorial_of_rowLen_le_one hrow
-  · exact YoungDiagram.prod_hookLength_eq_factorial_of_colLen_le_one hcol
-
-/-- **The hook-length formula for a Young diagram with at most one row** (in particular for the
-empty diagram). -/
-theorem standardCount_mul_prod_hookLength_of_colLen_le_one {μ : YoungDiagram}
-    (h : μ.colLen 0 ≤ 1) :
-    standardCount μ * ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c = μ.card ! :=
-  standardCount_mul_prod_hookLength_of_standardCount_eq_one
-    (standardCount_eq_one_of_colLen_le_one h)
-
-/-- **The hook-length formula for a Young diagram with at most one column** (in particular for the
-empty diagram). -/
-theorem standardCount_mul_prod_hookLength_of_rowLen_le_one {μ : YoungDiagram}
-    (h : μ.rowLen 0 ≤ 1) :
-    standardCount μ * ∏ c ∈ μ.cells, YoungDiagram.hookLength μ c = μ.card ! :=
-  standardCount_mul_prod_hookLength_of_standardCount_eq_one
-    (standardCount_eq_one_of_rowLen_le_one h)
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Determinant.lean
+++ b/TauCeti/LinearAlgebra/Determinant.lean
@@ -28,11 +28,10 @@ here is that every top-degree alternating form is a multiple of `b.det`
 makes the converse available for a form supplied by something other than a basis, such as a
 pairing.
 
-The file also records two identities for the determinant of a matrix with one row replaced,
-alongside Mathlib's `Matrix.det_updateRow_add` and `Matrix.det_updateRow_smul`: replacing the row
-by a difference of vectors subtracts the two determinants, and — Jacobi's formula in row form —
-rescaling one row entry by entry along a fixed vector of factors and summing the results over the
-rows multiplies the determinant by the total of the factors.
+The file also records one identity for the determinant of a matrix with one row replaced,
+alongside Mathlib's `Matrix.det_updateRow_add` and `Matrix.det_updateRow_smul`: Jacobi's formula
+in row form, that rescaling one row entry by entry along a fixed vector of factors and summing the
+results over the rows multiplies the determinant by the total of the factors.
 
 ## Main results
 
@@ -44,8 +43,6 @@ rows multiplies the determinant by the total of the factors.
   same two statements for an alternating bilinear form on a module of rank two.
 * `TauCeti.Matrix.detRowAlternating_mulVec`: multiplication by a square matrix scales the
   standard-basis determinant form by the matrix determinant.
-* `Matrix.det_updateRow_sub`: replacing a row by a difference of vectors subtracts the two
-  determinants.
 * `Matrix.sum_det_updateRow_mul_row`: Jacobi's formula for a determinant, in row form.
 
 ## Implementation notes
@@ -210,16 +207,6 @@ end Matrix
 end TauCeti
 
 namespace Matrix
-
-/-- Replacing a row of a matrix by a difference of two vectors subtracts the two determinants.
-This is the companion of Mathlib's `Matrix.det_updateRow_add` for subtraction. -/
-theorem det_updateRow_sub {ι : Type*} [DecidableEq ι] [Fintype ι] {R : Type*} [CommRing R]
-    (M : Matrix ι ι R) (i : ι) (u v : ι → R) :
-    (M.updateRow i (u - v)).det = (M.updateRow i u).det - (M.updateRow i v).det :=
-  eq_sub_of_add_eq <| by
-    have h := Matrix.det_updateRow_add M i (u - v) v
-    rw [sub_add_cancel] at h
-    exact h.symm
 
 /-- **Jacobi's formula for a determinant, in row form.**  Rescale one row of a matrix entry by
 entry along a fixed vector of factors, and sum the resulting determinants over the rows: the

--- a/TauCeti/LinearAlgebra/Determinant.lean
+++ b/TauCeti/LinearAlgebra/Determinant.lean
@@ -12,7 +12,7 @@ import TauCeti.LinearAlgebra.BilinearForm.Multilinear
 public section
 
 /-!
-# Determinant transformation laws
+# Determinant transformation laws, and determinants of updated rows
 
 Precomposing an alternating form of top degree with an endomorphism `φ` multiplies it by
 `LinearMap.det φ`, and — the direction that is actually used — a *nonzero* form merely known to be
@@ -28,6 +28,12 @@ here is that every top-degree alternating form is a multiple of `b.det`
 makes the converse available for a form supplied by something other than a basis, such as a
 pairing.
 
+The file also records two identities for the determinant of a matrix with one row replaced,
+alongside Mathlib's `Matrix.det_updateRow_add` and `Matrix.det_updateRow_smul`: replacing the row
+by a difference of vectors subtracts the two determinants, and — Jacobi's formula in row form —
+rescaling one row entry by entry along a fixed vector of factors and summing the results over the
+rows multiplies the determinant by the total of the factors.
+
 ## Main results
 
 * `AlternatingMap.eq_basis_det_smulRight`: `ω = b.det.smulRight (ω b)` for `ω` of top degree.
@@ -38,6 +44,9 @@ pairing.
   same two statements for an alternating bilinear form on a module of rank two.
 * `TauCeti.Matrix.detRowAlternating_mulVec`: multiplication by a square matrix scales the
   standard-basis determinant form by the matrix determinant.
+* `Matrix.det_updateRow_sub`: replacing a row by a difference of vectors subtracts the two
+  determinants.
+* `Matrix.sum_det_updateRow_mul_row`: Jacobi's formula for a determinant, in row form.
 
 ## Implementation notes
 
@@ -199,3 +208,47 @@ theorem detRowAlternating_mulVec [CommRing k] {ι : Type*} [Fintype ι] [Decidab
 end Matrix
 
 end TauCeti
+
+namespace Matrix
+
+/-- Replacing a row of a matrix by a difference of two vectors subtracts the two determinants.
+This is the companion of Mathlib's `Matrix.det_updateRow_add` for subtraction. -/
+theorem det_updateRow_sub {ι : Type*} [DecidableEq ι] [Fintype ι] {R : Type*} [CommRing R]
+    (M : Matrix ι ι R) (i : ι) (u v : ι → R) :
+    (M.updateRow i (u - v)).det = (M.updateRow i u).det - (M.updateRow i v).det :=
+  eq_sub_of_add_eq <| by
+    have h := Matrix.det_updateRow_add M i (u - v) v
+    rw [sub_add_cancel] at h
+    exact h.symm
+
+/-- **Jacobi's formula for a determinant, in row form.**  Rescale one row of a matrix entry by
+entry along a fixed vector of factors, and sum the resulting determinants over the rows: the
+answer is the determinant multiplied by the total of the factors.
+
+Only the factor met on the diagonal of a permutation survives in each term of the Leibniz
+expansion, and summing over the rows meets each factor exactly once. -/
+theorem sum_det_updateRow_mul_row {ι : Type*} [DecidableEq ι] [Fintype ι] {R : Type*} [CommRing R]
+    (A : Matrix ι ι R) (d : ι → R) :
+    (∑ k, (A.updateRow k fun j => d j * A k j).det) = (∑ j, d j) * A.det := by
+  have key : ∀ k : ι, (A.updateRow k fun j => d j * A k j).det
+      = ∑ σ : Equiv.Perm ι,
+          ((Equiv.Perm.sign σ : ℤ) : R) * (d (σ⁻¹ k) * ∏ i, A (σ i) i) := by
+    intro k
+    rw [Matrix.det_apply']
+    refine Finset.sum_congr rfl fun σ _ => ?_
+    have hterm : ∀ i : ι, (A.updateRow k fun j => d j * A k j) (σ i) i
+        = (if i = σ⁻¹ k then d i else 1) * A (σ i) i := by
+      intro i
+      rcases eq_or_ne i (σ⁻¹ k) with rfl | h
+      · simp [Matrix.updateRow_apply]
+      · have hk : σ i ≠ k := fun hc => h (by rw [← hc]; simp)
+        rw [Matrix.updateRow_apply, ite_eq_right hk, ite_eq_right h, one_mul]
+    rw [Finset.prod_congr rfl fun i _ => hterm i, Finset.prod_mul_distrib,
+      Finset.prod_ite_eq' Finset.univ (σ⁻¹ k) d]
+    simp
+  rw [Finset.sum_congr rfl fun k _ => key k, Finset.sum_comm, Matrix.det_apply', Finset.mul_sum]
+  refine Finset.sum_congr rfl fun σ _ => ?_
+  rw [← Finset.mul_sum, ← Finset.sum_mul, Equiv.sum_comp (σ⁻¹ : Equiv.Perm ι) d]
+  ring
+
+end Matrix

--- a/TauCeti/LinearAlgebra/Vandermonde.lean
+++ b/TauCeti/LinearAlgebra/Vandermonde.lean
@@ -432,14 +432,13 @@ compared to.  A sign is such a factor over any commutative ring, where it need n
 in the sense of `mul_left_cancel₀`. -/
 private theorem mul_self_cancel_sum {ι : Type*} [Fintype ι] {R : Type*} [CommRing R] {c : R}
     (hc : c * c = 1) {f g : ι → R} {a p : R} (h : ∑ i, f i * (c * g i) = a * (c * p)) :
-    (∑ i, f i * g i) = a * p :=
-  calc (∑ i, f i * g i)
-      = c * ∑ i, f i * (c * g i) := by
-        rw [Finset.mul_sum]
-        exact Finset.sum_congr rfl fun i _ => by
-          rw [show c * (f i * (c * g i)) = c * c * (f i * g i) by ring, hc, one_mul]
-    _ = c * (a * (c * p)) := by rw [h]
-    _ = a * p := by rw [show c * (a * (c * p)) = c * c * (a * p) by ring, hc, one_mul]
+    (∑ i, f i * g i) = a * p := by
+  have hsum : ∑ i, f i * (c * g i) = c * ∑ i, f i * g i := by
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl fun i _ => by ring
+  have key : c * c * ∑ i, f i * g i = c * c * (a * p) := by
+    rw [mul_assoc, ← hsum, h]; ring
+  rwa [hc, one_mul, one_mul] at key
 
 /-- **The lowering identity, unwound.**  For a sequence in a commutative ring, the product of the
 differences over the ordered pairs below a bound, with one term of the sequence lowered by one and
@@ -471,9 +470,10 @@ theorem sum_mul_prod_sub_update_sub_one {R : Type*} [CommRing R] (m : ℕ) (b : 
   have key := sum_mul_det_vandermonde_update_sub_one fun i : Fin m => b i
   rw [Finset.sum_congr rfl fun i _ => by rw [hterm i], det_vandermonde_eq_prod_range m b] at key
   -- both sides now carry the same sign, which cancels
-  have hcancel := mul_self_cancel_sum
-    (show ((-1 : R) ^ (∑ i : Fin m, (Finset.Ioi i).card)) * (-1) ^ _ = 1 by
-      rw [← mul_pow]; norm_num) key
+  have hsign : ((-1 : R) ^ (∑ i : Fin m, (Finset.Ioi i).card))
+      * ((-1 : R) ^ (∑ i : Fin m, (Finset.Ioi i).card)) = 1 := by
+    rw [← mul_pow]; norm_num
+  have hcancel := mul_self_cancel_sum hsign key
   rw [Fin.sum_univ_eq_sum_range (fun i : ℕ => b i * ∏ k ∈ Finset.range m,
       ∏ l ∈ Finset.Ico (k + 1) m,
         (Function.update b i (b i - 1) k - Function.update b i (b i - 1) l)) m,

--- a/TauCeti/LinearAlgebra/Vandermonde.lean
+++ b/TauCeti/LinearAlgebra/Vandermonde.lean
@@ -11,13 +11,14 @@ public import Mathlib.Data.Pi.Interval
 public import Mathlib.LinearAlgebra.Vandermonde
 public import Mathlib.RingTheory.Polynomial.Pochhammer
 import Mathlib.LinearAlgebra.Matrix.Block
+import TauCeti.LinearAlgebra.Determinant
 
 /-!
 # Vandermonde determinants in the falling-factorial basis
 
-The falling factorials `descPochhammer ℤ j` are monic of degree `j`, so Mathlib's
+The falling factorials `descPochhammer R j` are monic of degree `j`, so Mathlib's
 `Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde` rewrites `det (vandermonde y)` as the
-determinant of the matrix `(descPochhammer ℤ j).eval (yᵢ)`.  Unlike the powers, the falling
+determinant of the matrix `(descPochhammer R j).eval (yᵢ)`.  Unlike the powers, the falling
 factorials have a closed-form discrete antiderivative and a closed-form left shift, and this file
 proves the two identities for the Vandermonde determinant that those two facts supply.
 
@@ -52,8 +53,9 @@ survives — contributes the same sign, so the two determinants agree.
 
 ## The lowering identity
 
-Lower a single node `yᵢ` by one and weight the resulting Vandermonde determinant by `yᵢ`.  Summing
-over the nodes gives back the original determinant, scaled by `∑ yᵢ - (0 + 1 + ⋯ + (m - 1))`:
+Over an arbitrary commutative ring, lower a single node `yᵢ` by one and weight the resulting
+Vandermonde determinant by `yᵢ`.  Summing over the nodes gives back the original determinant,
+scaled by `∑ yᵢ - (0 + 1 + ⋯ + (m - 1))`:
 
 `∑ i, yᵢ · det (vandermonde (update y i (yᵢ - 1))) = (∑ i, yᵢ - ∑ i, i) · det (vandermonde y)`,
 
@@ -68,16 +70,21 @@ multiplying the lowered row by `yᵢ` turns the falling-factorial matrix of the 
 into the same matrix with its `i`-th row shifted up one degree, and
 `x^{underline (j+1)} = x^{underline j} · (x - j)` expands that row as `yᵢ` times the original minus
 `j` times the original, entry by entry.  *Jacobi's row formula*
-`TauCeti.sum_det_updateRow_mul_row`: summing over the rows the determinant of a matrix with one row
+`Matrix.sum_det_updateRow_mul_row`: summing over the rows the determinant of a matrix with one row
 scaled entry by entry multiplies the determinant by the total of the scaling factors, which turns
 the `j`-weighted correction into `(0 + 1 + ⋯ + (m - 1)) · det`.
+
+Mathlib's `monic_descPochhammer` and `descPochhammer_natDegree` assume the coefficient ring is a
+nontrivial ring without zero divisors, which the lowering identity does not; the two facts hold in
+general because `descPochhammer R j` is the image of `descPochhammer ℤ j` under the unique ring
+homomorphism, and a monic polynomial stays monic of the same degree under any ring homomorphism to
+a nontrivial ring.  The trivial ring is handled separately, where the identity is vacuous.
 
 ## Main results
 
 * `TauCeti.sum_Icc_descPochhammer_eval`: the discrete antiderivative of a falling factorial.
 * `TauCeti.factorial_mul_sum_det_vandermonde`: **the box-sum identity for Vandermonde
   determinants.**
-* `TauCeti.sum_det_updateRow_mul_row`: Jacobi's formula for a determinant, in row form.
 * `TauCeti.sum_mul_det_vandermonde_update_sub_one` and `TauCeti.sum_mul_prod_sub_update_sub_one`:
   **the lowering identity for Vandermonde determinants.**
 -/
@@ -86,14 +93,16 @@ public section
 
 namespace TauCeti
 
-open Finset Matrix Polynomial
+-- `_root_.Matrix`, because importing `TauCeti.LinearAlgebra.Determinant` puts a `TauCeti.Matrix`
+-- namespace in scope as well.
+open Finset _root_.Matrix Polynomial
 
 /-! ### The discrete antiderivative of a falling factorial -/
 
 /-- Shifting the argument of a falling factorial by one strips off its trailing linear factor:
 the degree `m + 1` falling factorial at `x + 1` is `(x + 1)` times the degree `m` one at `x`. -/
-private theorem descPochhammer_succ_eval_add_one (m : ℕ) (x : ℤ) :
-    (descPochhammer ℤ (m + 1)).eval (x + 1) = (x + 1) * (descPochhammer ℤ m).eval x := by
+private theorem descPochhammer_succ_eval_add_one {R : Type*} [CommRing R] (m : ℕ) (x : R) :
+    (descPochhammer R (m + 1)).eval (x + 1) = (x + 1) * (descPochhammer R m).eval x := by
   rw [descPochhammer_succ_left, eval_mul, eval_X, eval_comp, eval_sub, eval_X, eval_one,
     add_sub_cancel_right]
 
@@ -141,14 +150,31 @@ theorem sum_Icc_descPochhammer_eval (m : ℕ) {p q : ℤ} (h : p ≤ q) :
 
 /-! ### The box-sum identity -/
 
+/-- A falling factorial is monic over any commutative ring, being the image of the falling
+factorial over `ℤ` under the unique ring homomorphism.  Mathlib's `monic_descPochhammer` assumes
+the ring is nontrivial and has no zero divisors. -/
+private theorem monic_descPochhammer' (R : Type*) [CommRing R] (m : ℕ) :
+    (descPochhammer R m).Monic := by
+  rw [← descPochhammer_map (Int.castRingHom R) m]
+  exact (monic_descPochhammer ℤ m).map _
+
+/-- A falling factorial has the expected degree over any nontrivial commutative ring, monic
+polynomials keeping their degree under a ring homomorphism to a nontrivial ring.  Mathlib's
+`descPochhammer_natDegree` also assumes there are no zero divisors. -/
+private theorem descPochhammer_natDegree' (R : Type*) [CommRing R] [Nontrivial R] (m : ℕ) :
+    (descPochhammer R m).natDegree = m := by
+  rw [← descPochhammer_map (Int.castRingHom R) m, (monic_descPochhammer ℤ m).natDegree_map,
+    descPochhammer_natDegree ℤ m]
+
 /-- The Vandermonde determinant of a node vector, computed in the falling-factorial basis: the
 falling factorials are monic of degree `j`, so they give the same determinant as the powers. -/
-private theorem det_vandermonde_eq_det_descPochhammer (m : ℕ) (y : Fin m → ℤ) :
+private theorem det_vandermonde_eq_det_descPochhammer {R : Type*} [CommRing R] [Nontrivial R]
+    (m : ℕ) (y : Fin m → R) :
     (Matrix.vandermonde y).det
-      = (Matrix.of fun i j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y i)).det :=
+      = (Matrix.of fun i j : Fin m => (descPochhammer R (j : ℕ)).eval (y i)).det :=
   Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde y
-    (fun j => descPochhammer ℤ (j : ℕ)) (fun j => descPochhammer_natDegree (R := ℤ) (j : ℕ))
-    (fun j => monic_descPochhammer (R := ℤ) (j : ℕ))
+    (fun j => descPochhammer R (j : ℕ)) (fun j => descPochhammer_natDegree' R (j : ℕ))
+    (fun j => monic_descPochhammer' R (j : ℕ))
 
 /-- The one surviving term of a sum whose summand is supported on the index one step above a
 given one. -/
@@ -324,51 +350,13 @@ theorem factorial_mul_sum_det_vandermonde {n : ℕ} (x : Fin (n + 1) → ℤ)
 
 /-! ### The lowering identity -/
 
-/-- Subtracting one row vector from another is subtraction of the two determinants. -/
-private theorem det_updateRow_sub {ι : Type*} [DecidableEq ι] [Fintype ι] {R : Type*} [CommRing R]
-    (M : Matrix ι ι R) (i : ι) (u v : ι → R) :
-    (M.updateRow i (u - v)).det = (M.updateRow i u).det - (M.updateRow i v).det :=
-  eq_sub_of_add_eq <| by
-    have h := Matrix.det_updateRow_add M i (u - v) v
-    rw [sub_add_cancel] at h
-    exact h.symm
-
-/-- **Jacobi's formula for a determinant, in row form.**  Rescale one row of a matrix entry by
-entry along a fixed vector of factors, and sum the resulting determinants over the rows: the
-answer is the determinant multiplied by the total of the factors.
-
-Only the factor met on the diagonal of a permutation survives in each term of the Leibniz
-expansion, and summing over the rows meets each factor exactly once. -/
-theorem sum_det_updateRow_mul_row {ι : Type*} [DecidableEq ι] [Fintype ι] {R : Type*} [CommRing R]
-    (A : Matrix ι ι R) (d : ι → R) :
-    (∑ k, (A.updateRow k fun j => d j * A k j).det) = (∑ j, d j) * A.det := by
-  have key : ∀ k : ι, (A.updateRow k fun j => d j * A k j).det
-      = ∑ σ : Equiv.Perm ι,
-          ((Equiv.Perm.sign σ : ℤ) : R) * (d (σ⁻¹ k) * ∏ i, A (σ i) i) := by
-    intro k
-    rw [Matrix.det_apply']
-    refine Finset.sum_congr rfl fun σ _ => ?_
-    have hterm : ∀ i : ι, (A.updateRow k fun j => d j * A k j) (σ i) i
-        = (if i = σ⁻¹ k then d i else 1) * A (σ i) i := by
-      intro i
-      rcases eq_or_ne i (σ⁻¹ k) with rfl | h
-      · simp [Matrix.updateRow_apply]
-      · have hk : σ i ≠ k := fun hc => h (by rw [← hc]; simp)
-        rw [Matrix.updateRow_apply, ite_eq_right hk, ite_eq_right h, one_mul]
-    rw [Finset.prod_congr rfl fun i _ => hterm i, Finset.prod_mul_distrib,
-      Finset.prod_ite_eq' Finset.univ (σ⁻¹ k) d]
-    simp
-  rw [Finset.sum_congr rfl fun k _ => key k, Finset.sum_comm, Matrix.det_apply', Finset.mul_sum]
-  refine Finset.sum_congr rfl fun σ _ => ?_
-  rw [← Finset.mul_sum, ← Finset.sum_mul, Equiv.sum_comp (σ⁻¹ : Equiv.Perm ι) d]
-  ring
-
 /-- Lowering one node of a Vandermonde matrix by one, read in the falling-factorial basis: only
 the corresponding row of the matrix changes. -/
-private theorem det_vandermonde_update_sub_one {m : ℕ} (y : Fin m → ℤ) (i : Fin m) :
+private theorem det_vandermonde_update_sub_one {R : Type*} [CommRing R] [Nontrivial R] {m : ℕ}
+    (y : Fin m → R) (i : Fin m) :
     (Matrix.vandermonde (Function.update y i (y i - 1))).det
-      = ((Matrix.of fun k j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y k)).updateRow i
-          fun j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y i - 1)).det := by
+      = ((Matrix.of fun k j : Fin m => (descPochhammer R (j : ℕ)).eval (y k)).updateRow i
+          fun j : Fin m => (descPochhammer R (j : ℕ)).eval (y i - 1)).det := by
   classical
   rw [det_vandermonde_eq_det_descPochhammer]
   congr 1
@@ -380,38 +368,41 @@ private theorem det_vandermonde_update_sub_one {m : ℕ} (y : Fin m → ℤ) (i 
 /-- **The lowering identity for Vandermonde determinants.**  Lowering a single node by one and
 weighting by that node, then summing over the nodes, multiplies the Vandermonde determinant by the
 total of the nodes less `0 + 1 + ⋯ + (m - 1)`. -/
-theorem sum_mul_det_vandermonde_update_sub_one {m : ℕ} (y : Fin m → ℤ) :
+theorem sum_mul_det_vandermonde_update_sub_one {R : Type*} [CommRing R] {m : ℕ} (y : Fin m → R) :
     (∑ i, y i * (Matrix.vandermonde (Function.update y i (y i - 1))).det)
-      = ((∑ i, y i) - ∑ i : Fin m, ((i : ℕ) : ℤ)) * (Matrix.vandermonde y).det := by
+      = ((∑ i, y i) - ∑ i : Fin m, ((i : ℕ) : R)) * (Matrix.vandermonde y).det := by
   classical
-  set N : Matrix (Fin m) (Fin m) ℤ :=
-    Matrix.of fun k j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y k) with hNdef
+  -- over the trivial ring there is nothing to prove, and the falling factorials have no degree
+  rcases subsingleton_or_nontrivial R with _ | _
+  · exact Subsingleton.elim _ _
+  set N : Matrix (Fin m) (Fin m) R :=
+    Matrix.of fun k j : Fin m => (descPochhammer R (j : ℕ)).eval (y k) with hNdef
   have hdet : (Matrix.vandermonde y).det = N.det := det_vandermonde_eq_det_descPochhammer m y
   have key : ∀ i : Fin m, y i * (Matrix.vandermonde (Function.update y i (y i - 1))).det
-      = y i * N.det - (N.updateRow i fun j : Fin m => ((j : ℕ) : ℤ) * N i j).det := by
+      = y i * N.det - (N.updateRow i fun j : Fin m => ((j : ℕ) : R) * N i j).det := by
     intro i
-    have hrow : (y i • fun j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y i - 1))
-        = (y i • N i) - fun j : Fin m => ((j : ℕ) : ℤ) * N i j := by
+    have hrow : (y i • fun j : Fin m => (descPochhammer R (j : ℕ)).eval (y i - 1))
+        = (y i • N i) - fun j : Fin m => ((j : ℕ) : R) * N i j := by
       funext j
       -- the left shift `x · (x - 1)^{underline j} = x^{underline (j+1)}` …
-      have hleft : (descPochhammer ℤ ((j : ℕ) + 1)).eval (y i)
-          = y i * (descPochhammer ℤ (j : ℕ)).eval (y i - 1) := by
+      have hleft : (descPochhammer R ((j : ℕ) + 1)).eval (y i)
+          = y i * (descPochhammer R (j : ℕ)).eval (y i - 1) := by
         simpa using descPochhammer_succ_eval_add_one (j : ℕ) (y i - 1)
       -- … against the trailing factor `x^{underline (j+1)} = x^{underline j} · (x - j)`
-      have hright := descPochhammer_succ_eval (S := ℤ) (j : ℕ) (y i)
+      have hright := descPochhammer_succ_eval (S := R) (j : ℕ) (y i)
       simp only [hNdef, Matrix.of_apply, Pi.smul_apply, smul_eq_mul, Pi.sub_apply]
       rw [← hleft, hright]
       ring
-    rw [det_vandermonde_update_sub_one, ← Matrix.det_updateRow_smul, hrow, det_updateRow_sub,
-      Matrix.det_updateRow_smul, Matrix.updateRow_eq_self]
+    rw [det_vandermonde_update_sub_one, ← Matrix.det_updateRow_smul, hrow,
+      Matrix.det_updateRow_sub, Matrix.det_updateRow_smul, Matrix.updateRow_eq_self]
   rw [Finset.sum_congr rfl fun i _ => key i, Finset.sum_sub_distrib, ← Finset.sum_mul,
-    sum_det_updateRow_mul_row, hdet]
+    Matrix.sum_det_updateRow_mul_row, hdet]
   ring
 
 /-- The Vandermonde determinant of the first `m` values of a sequence, as a product of the
 differences over the ordered pairs of `Finset.range m`.  The sign is left as an unevaluated power
 of `-1`: the lowering identity multiplies it into both of its sides, where it cancels. -/
-private theorem det_vandermonde_eq_prod_range (m : ℕ) (b : ℕ → ℤ) :
+private theorem det_vandermonde_eq_prod_range {R : Type*} [CommRing R] (m : ℕ) (b : ℕ → R) :
     (Matrix.vandermonde fun i : Fin m => b i).det
       = (-1) ^ (∑ i : Fin m, (Finset.Ioi i).card)
         * ∏ k ∈ Finset.range m, ∏ l ∈ Finset.Ico (k + 1) m, (b k - b l) := by
@@ -436,24 +427,30 @@ private theorem det_vandermonde_eq_prod_range (m : ℕ) (b : ℕ → ℤ) :
     Finset.prod_pow_eq_pow_sum,
     Fin.prod_univ_eq_prod_range (fun k : ℕ => ∏ l ∈ Finset.Ico (k + 1) m, (b k - b l)) m]
 
-/-- Cancelling a common nonzero factor carried by every term of a sum and by the value it is
-compared to. -/
-private theorem mul_left_cancel₀_sum {ι : Type*} [Fintype ι] {c : ℤ} (hc : c ≠ 0)
-    {f g : ι → ℤ} {a p : ℤ} (h : ∑ i, f i * (c * g i) = a * (c * p)) :
-    (∑ i, f i * g i) = a * p := by
-  refine mul_left_cancel₀ hc ?_
-  rw [Finset.mul_sum,
-    Finset.sum_congr rfl fun i (_ : i ∈ Finset.univ) => mul_left_comm c (f i) (g i), h]
-  ring
+/-- Cancelling a common factor of square one carried by every term of a sum and by the value it is
+compared to.  A sign is such a factor over any commutative ring, where it need not be cancellable
+in the sense of `mul_left_cancel₀`. -/
+private theorem mul_self_cancel_sum {ι : Type*} [Fintype ι] {R : Type*} [CommRing R] {c : R}
+    (hc : c * c = 1) {f g : ι → R} {a p : R} (h : ∑ i, f i * (c * g i) = a * (c * p)) :
+    (∑ i, f i * g i) = a * p :=
+  calc (∑ i, f i * g i)
+      = c * ∑ i, f i * (c * g i) := by
+        rw [Finset.mul_sum]
+        exact Finset.sum_congr rfl fun i _ => by
+          rw [show c * (f i * (c * g i)) = c * c * (f i * g i) by ring, hc, one_mul]
+    _ = c * (a * (c * p)) := by rw [h]
+    _ = a * p := by rw [show c * (a * (c * p)) = c * c * (a * p) by ring, hc, one_mul]
 
-/-- **The lowering identity, unwound.**  For a sequence of integers, the product of the differences
-over the ordered pairs below a bound, with one term of the sequence lowered by one and the result
-weighted by that term, summed over the terms below the bound. -/
-theorem sum_mul_prod_sub_update_sub_one (m : ℕ) (b : ℕ → ℤ) :
+/-- **The lowering identity, unwound.**  For a sequence in a commutative ring, the product of the
+differences over the ordered pairs below a bound, with one term of the sequence lowered by one and
+the result weighted by that term, summed over the terms below the bound, is the total of the terms
+below the bound less `0 + 1 + ⋯ + (m - 1)`, times the product of the differences of the original
+sequence. -/
+theorem sum_mul_prod_sub_update_sub_one {R : Type*} [CommRing R] (m : ℕ) (b : ℕ → R) :
     (∑ i ∈ Finset.range m, b i *
         ∏ k ∈ Finset.range m, ∏ l ∈ Finset.Ico (k + 1) m,
           (Function.update b i (b i - 1) k - Function.update b i (b i - 1) l))
-      = ((∑ i ∈ Finset.range m, b i) - ∑ i ∈ Finset.range m, (i : ℤ))
+      = ((∑ i ∈ Finset.range m, b i) - ∑ i ∈ Finset.range m, (i : R))
         * ∏ k ∈ Finset.range m, ∏ l ∈ Finset.Ico (k + 1) m, (b k - b l) := by
   classical
   have hupd : ∀ i : Fin m, Function.update (fun k : Fin m => b k) i (b (i : ℕ) - 1)
@@ -474,13 +471,14 @@ theorem sum_mul_prod_sub_update_sub_one (m : ℕ) (b : ℕ → ℤ) :
   have key := sum_mul_det_vandermonde_update_sub_one fun i : Fin m => b i
   rw [Finset.sum_congr rfl fun i _ => by rw [hterm i], det_vandermonde_eq_prod_range m b] at key
   -- both sides now carry the same sign, which cancels
-  have hcancel := mul_left_cancel₀_sum
-    (pow_ne_zero (∑ i : Fin m, (Finset.Ioi i).card) (by norm_num : (-1 : ℤ) ≠ 0)) key
+  have hcancel := mul_self_cancel_sum
+    (show ((-1 : R) ^ (∑ i : Fin m, (Finset.Ioi i).card)) * (-1) ^ _ = 1 by
+      rw [← mul_pow]; norm_num) key
   rw [Fin.sum_univ_eq_sum_range (fun i : ℕ => b i * ∏ k ∈ Finset.range m,
       ∏ l ∈ Finset.Ico (k + 1) m,
         (Function.update b i (b i - 1) k - Function.update b i (b i - 1) l)) m,
     Fin.sum_univ_eq_sum_range b m,
-    Fin.sum_univ_eq_sum_range (fun i : ℕ => (i : ℤ)) m] at hcancel
+    Fin.sum_univ_eq_sum_range (fun i : ℕ => (i : R)) m] at hcancel
   exact hcancel
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Vandermonde.lean
+++ b/TauCeti/LinearAlgebra/Vandermonde.lean
@@ -13,7 +13,15 @@ public import Mathlib.RingTheory.Polynomial.Pochhammer
 import Mathlib.LinearAlgebra.Matrix.Block
 
 /-!
-# Summing Vandermonde determinants over a box of nested integer intervals
+# Vandermonde determinants in the falling-factorial basis
+
+The falling factorials `descPochhammer ℤ j` are monic of degree `j`, so Mathlib's
+`Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde` rewrites `det (vandermonde y)` as the
+determinant of the matrix `(descPochhammer ℤ j).eval (yᵢ)`.  Unlike the powers, the falling
+factorials have a closed-form discrete antiderivative and a closed-form left shift, and this file
+proves the two identities for the Vandermonde determinant that those two facts supply.
+
+## The box-sum identity
 
 Let `x₀ ≤ x₁ ≤ ⋯ ≤ xₙ` be integers and let `y` range over the box of integer vectors with
 `xᵢ ≤ yᵢ ≤ xᵢ₊₁ - 1`, one interval for each consecutive pair.  Then
@@ -28,35 +36,50 @@ The identity drives the branching recursion for the Weyl dimension formula of `G
 interlacing condition indexing the constituents of an irreducible restricted to `GL (n - 1)` is
 exactly such a box, and the two Vandermonde products are the two Weyl dimension numerators.
 
-## The proof
+Three moves prove it; only the last uses the ordering hypothesis.  *The falling-factorial basis*
+replaces the powers, because they have the closed-form discrete antiderivative
+`TauCeti.sum_Icc_descPochhammer_eval`.  *Multilinearity*: a determinant is multilinear in its rows
+and the box constrains the rows independently, so the sum of the determinants over the box is the
+determinant of the matrix of row sums (`MultilinearMap.map_sum_finset`); evaluating those row
+sums, and clearing the denominators `1, 2, …, n` by a column scaling, produces the matrix of
+differences `(descPochhammer ℤ (j+1)).eval (xᵢ₊₁) - (descPochhammer ℤ (j+1)).eval (xᵢ)`, whose
+determinant is `n !` times the sum.  *A row reduction*: that matrix of differences is what remains
+of the `(n+1) × (n+1)` matrix `(descPochhammer ℤ j).eval (xᵢ)` after subtracting each row from its
+predecessor and deleting the column `j = 0`, which is constant equal to `1`.  Multiplying on the
+left by the bidiagonal matrix performing the subtraction contributes a factor `(-1)^{n+1}` to the
+determinant, and expanding the product along its first column — where only the last entry
+survives — contributes the same sign, so the two determinants agree.
 
-Three moves; only the last uses the ordering hypothesis.
+## The lowering identity
 
-*The falling-factorial basis.*  The falling factorials `descPochhammer ℤ j` are monic of degree
-`j`, so Mathlib's `Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde` rewrites
-`det (vandermonde y)` as the determinant of the matrix `(descPochhammer ℤ j).eval (yᵢ)`.  The
-point of the change of basis is that falling factorials, unlike powers, have a closed-form
-discrete antiderivative, `TauCeti.sum_Icc_descPochhammer_eval`.
+Lower a single node `yᵢ` by one and weight the resulting Vandermonde determinant by `yᵢ`.  Summing
+over the nodes gives back the original determinant, scaled by `∑ yᵢ - (0 + 1 + ⋯ + (m - 1))`:
 
-*Multilinearity.*  A determinant is multilinear in its rows and the box constrains the rows
-independently, so the sum of the determinants over the box is the determinant of the matrix of
-row sums (`MultilinearMap.map_sum_finset`).  Evaluating those row sums, and clearing the
-denominators `1, 2, …, n` by a column scaling, produces the matrix of differences
-`(descPochhammer ℤ (j+1)).eval (xᵢ₊₁) - (descPochhammer ℤ (j+1)).eval (xᵢ)`, whose determinant is
-`n !` times the sum.
+`∑ i, yᵢ · det (vandermonde (update y i (yᵢ - 1))) = (∑ i, yᵢ - ∑ i, i) · det (vandermonde y)`,
 
-*A row reduction.*  That matrix of differences is what remains of the `(n+1) × (n+1)` matrix
-`(descPochhammer ℤ j).eval (xᵢ)` after subtracting each row from its predecessor and deleting the
-column `j = 0`, which is constant equal to `1`.  Multiplying on the left by the bidiagonal matrix
-performing the subtraction contributes a factor `(-1)^{n+1}` to the determinant, and expanding the
-product along its first column — where only the last entry survives — contributes the same sign,
-so the two determinants agree.
+which is `TauCeti.sum_mul_det_vandermonde_update_sub_one`, with
+`TauCeti.sum_mul_prod_sub_update_sub_one` its unwound form as a product of differences over the
+ordered pairs of an initial segment of `ℕ`.  It is the Vandermonde identity behind the Frobenius
+determinant formula for the number of standard Young tableaux of a given shape, where the nodes
+are the beta-numbers of a Young diagram and lowering one of them is erasing a corner.
+
+Two moves prove it.  *The left shift*: `x · (x - 1)^{underline j} = x^{underline (j+1)}`, so
+multiplying the lowered row by `yᵢ` turns the falling-factorial matrix of the lowered node vector
+into the same matrix with its `i`-th row shifted up one degree, and
+`x^{underline (j+1)} = x^{underline j} · (x - j)` expands that row as `yᵢ` times the original minus
+`j` times the original, entry by entry.  *Jacobi's row formula*
+`TauCeti.sum_det_updateRow_mul_row`: summing over the rows the determinant of a matrix with one row
+scaled entry by entry multiplies the determinant by the total of the scaling factors, which turns
+the `j`-weighted correction into `(0 + 1 + ⋯ + (m - 1)) · det`.
 
 ## Main results
 
 * `TauCeti.sum_Icc_descPochhammer_eval`: the discrete antiderivative of a falling factorial.
 * `TauCeti.factorial_mul_sum_det_vandermonde`: **the box-sum identity for Vandermonde
   determinants.**
+* `TauCeti.sum_det_updateRow_mul_row`: Jacobi's formula for a determinant, in row form.
+* `TauCeti.sum_mul_det_vandermonde_update_sub_one` and `TauCeti.sum_mul_prod_sub_update_sub_one`:
+  **the lowering identity for Vandermonde determinants.**
 -/
 
 public section
@@ -298,5 +321,166 @@ theorem factorial_mul_sum_det_vandermonde {n : ℕ} (x : Fin (n + 1) → ℤ)
   have hdet := det_descPochhammer_sub_eq_det_vandermonde x
   rw [hscale, Matrix.det_mul, Matrix.det_diagonal, prod_fin_add_one_eq_factorial] at hdet
   rw [hsum, mul_comm, hdet]
+
+/-! ### The lowering identity -/
+
+/-- Subtracting one row vector from another is subtraction of the two determinants. -/
+private theorem det_updateRow_sub {ι : Type*} [DecidableEq ι] [Fintype ι] {R : Type*} [CommRing R]
+    (M : Matrix ι ι R) (i : ι) (u v : ι → R) :
+    (M.updateRow i (u - v)).det = (M.updateRow i u).det - (M.updateRow i v).det :=
+  eq_sub_of_add_eq <| by
+    have h := Matrix.det_updateRow_add M i (u - v) v
+    rw [sub_add_cancel] at h
+    exact h.symm
+
+/-- **Jacobi's formula for a determinant, in row form.**  Rescale one row of a matrix entry by
+entry along a fixed vector of factors, and sum the resulting determinants over the rows: the
+answer is the determinant multiplied by the total of the factors.
+
+Only the factor met on the diagonal of a permutation survives in each term of the Leibniz
+expansion, and summing over the rows meets each factor exactly once. -/
+theorem sum_det_updateRow_mul_row {ι : Type*} [DecidableEq ι] [Fintype ι] {R : Type*} [CommRing R]
+    (A : Matrix ι ι R) (d : ι → R) :
+    (∑ k, (A.updateRow k fun j => d j * A k j).det) = (∑ j, d j) * A.det := by
+  have key : ∀ k : ι, (A.updateRow k fun j => d j * A k j).det
+      = ∑ σ : Equiv.Perm ι,
+          ((Equiv.Perm.sign σ : ℤ) : R) * (d (σ⁻¹ k) * ∏ i, A (σ i) i) := by
+    intro k
+    rw [Matrix.det_apply']
+    refine Finset.sum_congr rfl fun σ _ => ?_
+    have hterm : ∀ i : ι, (A.updateRow k fun j => d j * A k j) (σ i) i
+        = (if i = σ⁻¹ k then d i else 1) * A (σ i) i := by
+      intro i
+      rcases eq_or_ne i (σ⁻¹ k) with rfl | h
+      · simp [Matrix.updateRow_apply]
+      · have hk : σ i ≠ k := fun hc => h (by rw [← hc]; simp)
+        rw [Matrix.updateRow_apply, ite_eq_right hk, ite_eq_right h, one_mul]
+    rw [Finset.prod_congr rfl fun i _ => hterm i, Finset.prod_mul_distrib,
+      Finset.prod_ite_eq' Finset.univ (σ⁻¹ k) d]
+    simp
+  rw [Finset.sum_congr rfl fun k _ => key k, Finset.sum_comm, Matrix.det_apply', Finset.mul_sum]
+  refine Finset.sum_congr rfl fun σ _ => ?_
+  rw [← Finset.mul_sum, ← Finset.sum_mul, Equiv.sum_comp (σ⁻¹ : Equiv.Perm ι) d]
+  ring
+
+/-- Lowering one node of a Vandermonde matrix by one, read in the falling-factorial basis: only
+the corresponding row of the matrix changes. -/
+private theorem det_vandermonde_update_sub_one {m : ℕ} (y : Fin m → ℤ) (i : Fin m) :
+    (Matrix.vandermonde (Function.update y i (y i - 1))).det
+      = ((Matrix.of fun k j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y k)).updateRow i
+          fun j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y i - 1)).det := by
+  classical
+  rw [det_vandermonde_eq_det_descPochhammer]
+  congr 1
+  ext k j
+  rcases eq_or_ne k i with rfl | h
+  · simp
+  · simp [Matrix.updateRow_ne h, Function.update_of_ne h]
+
+/-- **The lowering identity for Vandermonde determinants.**  Lowering a single node by one and
+weighting by that node, then summing over the nodes, multiplies the Vandermonde determinant by the
+total of the nodes less `0 + 1 + ⋯ + (m - 1)`. -/
+theorem sum_mul_det_vandermonde_update_sub_one {m : ℕ} (y : Fin m → ℤ) :
+    (∑ i, y i * (Matrix.vandermonde (Function.update y i (y i - 1))).det)
+      = ((∑ i, y i) - ∑ i : Fin m, ((i : ℕ) : ℤ)) * (Matrix.vandermonde y).det := by
+  classical
+  set N : Matrix (Fin m) (Fin m) ℤ :=
+    Matrix.of fun k j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y k) with hNdef
+  have hdet : (Matrix.vandermonde y).det = N.det := det_vandermonde_eq_det_descPochhammer m y
+  have key : ∀ i : Fin m, y i * (Matrix.vandermonde (Function.update y i (y i - 1))).det
+      = y i * N.det - (N.updateRow i fun j : Fin m => ((j : ℕ) : ℤ) * N i j).det := by
+    intro i
+    have hrow : (y i • fun j : Fin m => (descPochhammer ℤ (j : ℕ)).eval (y i - 1))
+        = (y i • N i) - fun j : Fin m => ((j : ℕ) : ℤ) * N i j := by
+      funext j
+      -- the left shift `x · (x - 1)^{underline j} = x^{underline (j+1)}` …
+      have hleft : (descPochhammer ℤ ((j : ℕ) + 1)).eval (y i)
+          = y i * (descPochhammer ℤ (j : ℕ)).eval (y i - 1) := by
+        simpa using descPochhammer_succ_eval_add_one (j : ℕ) (y i - 1)
+      -- … against the trailing factor `x^{underline (j+1)} = x^{underline j} · (x - j)`
+      have hright := descPochhammer_succ_eval (S := ℤ) (j : ℕ) (y i)
+      simp only [hNdef, Matrix.of_apply, Pi.smul_apply, smul_eq_mul, Pi.sub_apply]
+      rw [← hleft, hright]
+      ring
+    rw [det_vandermonde_update_sub_one, ← Matrix.det_updateRow_smul, hrow, det_updateRow_sub,
+      Matrix.det_updateRow_smul, Matrix.updateRow_eq_self]
+  rw [Finset.sum_congr rfl fun i _ => key i, Finset.sum_sub_distrib, ← Finset.sum_mul,
+    sum_det_updateRow_mul_row, hdet]
+  ring
+
+/-- The Vandermonde determinant of the first `m` values of a sequence, as a product of the
+differences over the ordered pairs of `Finset.range m`.  The sign is left as an unevaluated power
+of `-1`: the lowering identity multiplies it into both of its sides, where it cancels. -/
+private theorem det_vandermonde_eq_prod_range (m : ℕ) (b : ℕ → ℤ) :
+    (Matrix.vandermonde fun i : Fin m => b i).det
+      = (-1) ^ (∑ i : Fin m, (Finset.Ioi i).card)
+        * ∏ k ∈ Finset.range m, ∏ l ∈ Finset.Ico (k + 1) m, (b k - b l) := by
+  classical
+  have hIoi : ∀ i : Fin m, ∏ j ∈ Finset.Ioi i, (b j - b i)
+      = (-1) ^ (Finset.Ioi i).card * ∏ l ∈ Finset.Ico ((i : ℕ) + 1) m, (b i - b l) := by
+    intro i
+    have hleft : Finset.Ioi i = Finset.univ.filter fun j : Fin m => (i : ℕ) < (j : ℕ) := by
+      ext j
+      simp only [Finset.mem_Ioi, Finset.mem_filter, Finset.mem_univ, true_and]
+      exact Fin.lt_def
+    have hright : Finset.Ico ((i : ℕ) + 1) m
+        = (Finset.range m).filter fun l => (i : ℕ) < l := by
+      ext l
+      simp only [Finset.mem_Ico, Finset.mem_filter, Finset.mem_range]
+      omega
+    rw [hright, Finset.prod_filter,
+      ← Fin.prod_univ_eq_prod_range (fun l : ℕ => if (i : ℕ) < l then b i - b l else 1) m,
+      ← Finset.prod_filter, ← hleft, ← Finset.prod_const, ← Finset.prod_mul_distrib]
+    exact Finset.prod_congr rfl fun j _ => by ring
+  rw [Matrix.det_vandermonde, Finset.prod_congr rfl fun i _ => hIoi i, Finset.prod_mul_distrib,
+    Finset.prod_pow_eq_pow_sum,
+    Fin.prod_univ_eq_prod_range (fun k : ℕ => ∏ l ∈ Finset.Ico (k + 1) m, (b k - b l)) m]
+
+/-- Cancelling a common nonzero factor carried by every term of a sum and by the value it is
+compared to. -/
+private theorem mul_left_cancel₀_sum {ι : Type*} [Fintype ι] {c : ℤ} (hc : c ≠ 0)
+    {f g : ι → ℤ} {a p : ℤ} (h : ∑ i, f i * (c * g i) = a * (c * p)) :
+    (∑ i, f i * g i) = a * p := by
+  refine mul_left_cancel₀ hc ?_
+  rw [Finset.mul_sum,
+    Finset.sum_congr rfl fun i (_ : i ∈ Finset.univ) => mul_left_comm c (f i) (g i), h]
+  ring
+
+/-- **The lowering identity, unwound.**  For a sequence of integers, the product of the differences
+over the ordered pairs below a bound, with one term of the sequence lowered by one and the result
+weighted by that term, summed over the terms below the bound. -/
+theorem sum_mul_prod_sub_update_sub_one (m : ℕ) (b : ℕ → ℤ) :
+    (∑ i ∈ Finset.range m, b i *
+        ∏ k ∈ Finset.range m, ∏ l ∈ Finset.Ico (k + 1) m,
+          (Function.update b i (b i - 1) k - Function.update b i (b i - 1) l))
+      = ((∑ i ∈ Finset.range m, b i) - ∑ i ∈ Finset.range m, (i : ℤ))
+        * ∏ k ∈ Finset.range m, ∏ l ∈ Finset.Ico (k + 1) m, (b k - b l) := by
+  classical
+  have hupd : ∀ i : Fin m, Function.update (fun k : Fin m => b k) i (b (i : ℕ) - 1)
+      = fun k : Fin m => Function.update b (i : ℕ) (b (i : ℕ) - 1) (k : ℕ) := by
+    intro i
+    funext k
+    rcases eq_or_ne k i with rfl | h
+    · simp
+    · rw [Function.update_of_ne h, Function.update_of_ne fun hc => h (Fin.val_injective hc)]
+  have hterm : ∀ i : Fin m,
+      (Matrix.vandermonde (Function.update (fun k : Fin m => b k) i (b (i : ℕ) - 1))).det
+        = (-1) ^ (∑ i : Fin m, (Finset.Ioi i).card)
+          * ∏ k ∈ Finset.range m, ∏ l ∈ Finset.Ico (k + 1) m,
+              (Function.update b (i : ℕ) (b (i : ℕ) - 1) k
+                - Function.update b (i : ℕ) (b (i : ℕ) - 1) l) := by
+    intro i
+    rw [hupd i, det_vandermonde_eq_prod_range m (Function.update b (i : ℕ) (b (i : ℕ) - 1))]
+  have key := sum_mul_det_vandermonde_update_sub_one fun i : Fin m => b i
+  rw [Finset.sum_congr rfl fun i _ => by rw [hterm i], det_vandermonde_eq_prod_range m b] at key
+  -- both sides now carry the same sign, which cancels
+  have hcancel := mul_left_cancel₀_sum
+    (pow_ne_zero (∑ i : Fin m, (Finset.Ioi i).card) (by norm_num : (-1 : ℤ) ≠ 0)) key
+  rw [Fin.sum_univ_eq_sum_range (fun i : ℕ => b i * ∏ k ∈ Finset.range m,
+      ∏ l ∈ Finset.Ico (k + 1) m,
+        (Function.update b i (b i - 1) k - Function.update b i (b i - 1) l)) m,
+    Fin.sum_univ_eq_sum_range b m,
+    Fin.sum_univ_eq_sum_range (fun i : ℕ => (i : ℤ)) m] at hcancel
+  exact hcancel
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/Vandermonde.lean
+++ b/TauCeti/LinearAlgebra/Vandermonde.lean
@@ -393,8 +393,13 @@ theorem sum_mul_det_vandermonde_update_sub_one {R : Type*} [CommRing R] {m : ℕ
       simp only [hNdef, Matrix.of_apply, Pi.smul_apply, smul_eq_mul, Pi.sub_apply]
       rw [← hleft, hright]
       ring
-    rw [det_vandermonde_update_sub_one, ← Matrix.det_updateRow_smul, hrow,
-      Matrix.det_updateRow_sub, Matrix.det_updateRow_smul, Matrix.updateRow_eq_self]
+    -- the determinant is alternating in the rows, so the difference of rows splits it in two
+    have hsplit : (N.updateRow i ((y i • N i) - fun j : Fin m => ((j : ℕ) : R) * N i j)).det
+        = (N.updateRow i (y i • N i)).det
+          - (N.updateRow i fun j : Fin m => ((j : ℕ) : R) * N i j).det :=
+      Matrix.detRowAlternating.map_update_sub N i _ _
+    rw [det_vandermonde_update_sub_one, ← Matrix.det_updateRow_smul, hrow, hsplit,
+      Matrix.det_updateRow_smul, Matrix.updateRow_eq_self]
   rw [Finset.sum_congr rfl fun i _ => key i, Finset.sum_sub_distrib, ← Finset.sum_mul,
     Matrix.sum_det_updateRow_mul_row, hdet]
   ring


### PR DESCRIPTION
This PR proves the **multiplicative hook-length formula** `TauCeti.standardCount_mul_prod_hookLength`: for every Young diagram `μ`, the number `f^μ` of standard Young tableaux of shape `μ` times the product of the hook lengths of its cells is `μ.card !`. This is the `hookLengthFormula` target of Layer 5 of the `RepresentationTheory/SchurWeyl` roadmap ("Hook lengths and the formula", stated there in exactly this multiplicative form, which carries no division obligation). It also proves the **Frobenius determinant formula** `TauCeti.standardCount_mul_prod_factorial_betaNumber`, `f^μ · ∏_{i < r} βᵢ ! = μ.card ! · ∏_{i < j < r} (βᵢ - βⱼ)`, that the roadmap's beta-number infrastructure was built for.

The route is the one the existing code already set up. `YoungDiagram.prod_hookLength_mul_prod_betaNumber_sub_eq_prod_factorial` relates the hook product to the beta-numbers `βᵢ = μ.rowLen i + (r - 1 - i)`, and its docstring names the Frobenius determinant formula as the missing other half; dividing one identity by the other cancels the Vandermonde-style product of differences, which is positive, and leaves the hook-length formula. The Frobenius formula is proved by induction on `μ.card` along the corner recursion `TauCeti.standardCount_eq_sum_corners`. Erasing a corner lowers the beta-number of its row by one and leaves the others alone, and `βᵢ ! = βᵢ · (βᵢ - 1)!` turns the induction hypothesis for `μ ∖ c` into a statement about `μ`; summing over the corners reduces the induction step to a single identity between Vandermonde-style products, plus two bookkeeping facts (the corners sit in distinct rows of the diagram, and a row carrying no corner puts a zero factor in its product; and `∑_{i < r} βᵢ - ∑_{i < r} i = μ.card`).

That identity is the new **lowering identity for Vandermonde determinants**, `TauCeti.sum_mul_det_vandermonde_update_sub_one`: lowering one node by one, weighting by that node and summing over the nodes multiplies `det (vandermonde y)` by `∑ yᵢ - (0 + 1 + ⋯ + (m - 1))`. It goes into `TauCeti/LinearAlgebra/Vandermonde.lean`, whose existing box-sum identity already works in the falling-factorial basis and supplies the private lemma `det (vandermonde y) = det ((descPochhammer ℤ j).eval yᵢ)` that this proof reuses. Where the box-sum identity uses the discrete antiderivative of a falling factorial, this one uses the left shift `x · (x - 1)^{underline j} = x^{underline (j+1)}`, together with a new general determinant lemma `TauCeti.sum_det_updateRow_mul_row`: Jacobi's formula in row form, over an arbitrary commutative ring. `TauCeti.sum_mul_prod_sub_update_sub_one` is the unwound form of the lowering identity as a product over ordered pairs of an initial segment of `ℕ`, which is what the Young-diagram side consumes.

Two consequences for existing declarations. `TauCeti.standardCount_mul_prod_hookLength_of_standardCount_eq_one` and its two specialisations `..._of_colLen_le_one` and `..._of_rowLen_le_one` in `TauCeti/Combinatorics/Young/StandardTableau/Reading.lean` are now special cases of the general theorem with no consumers, so they are deleted (that file keeps `standardCount_eq_one_iff`, and the hook-product statements `YoungDiagram.prod_hookLength_eq_factorial_of_*` they used stay where they are in `HookLength/Basic.lean`); the import that only served them is replaced by the `Mathlib.Order.Preorder.Finite` it was supplying transitively. And two facts about corners that the induction needs but that mention neither beta-numbers nor hook lengths, `YoungDiagram.IsCorner.eq_of_fst_eq` and `YoungDiagram.IsCorner.fst_lt_colLen_zero`, are placed in `TauCeti/Combinatorics/Young/Corner.lean` beside `rowLen_eq_snd_add_one` rather than in the new file.

What remains of Layer 5 after this is the other half of the layer, unrelated to this proof: the standard basis of the Specht module, whose spanning direction needs the straightening algorithm; `TauCeti.standardCount_le_finrank_spechtModule` already supplies the other inequality. The quotient form `f^μ = μ.card ! / ∏ hooks` also remains, since the roadmap makes it a derived corollary of a separate divisibility lemma `∏ hooks ∣ μ.card !`.

The mathematics is the Frame-Robinson-Thrall beta-number argument as presented in Macdonald, *Symmetric Functions and Hall Polynomials*, Chapter I §1 Example 1 and §7 Example 6, and Sagan, *The Symmetric Group*, §3.10; the files cite both. No code was taken from any existing formalization. Mathlib's `Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde` and the `descPochhammer` API are used as ordinary dependencies, not vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"hook-length-formula"}-->

🤖 Prepared with Claude Code
