### PR TITLE
feat: add exact cyclotomic conjugation

### DIFF
--- a/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
@@ -24,6 +24,7 @@ Burnside--Dixon--Schneider character-table solver.
 ## Main definitions
 
 * `TauCeti.Cyclotomic.conj`: computable conjugation on exact cyclotomic integers.
+* `TauCeti.Cyclotomic.instStar`: the `star` notation, defined to be `conj`.
 * `TauCeti.Cyclotomic.instStarRing`: the canonical star-ring structure for positive conductor.
 
 ## Main results
@@ -48,7 +49,8 @@ namespace TauCeti.Cyclotomic
 variable {e : ℕ}
 
 /-- Evaluate the canonical coefficient vector after replacing `ζ_e` by `ζ_e ^ (e - 1)`.
-This is complex conjugation on exact `e`-th cyclotomic integers. -/
+For positive `e` this power is `ζ_e⁻¹`, so the substitution is complex conjugation on exact
+`e`-th cyclotomic integers. -/
 @[expose] def conj (x : Cyclotomic e) : Cyclotomic e :=
   evalCoeffs (Int.castRingHom (Cyclotomic e)) (zeta e ^ (e - 1)) x
 
@@ -101,6 +103,8 @@ private theorem conj_zeta : conj (zeta e) = zeta e ^ (e - 1) := by
   rw [complexEmbedding_conj, ← starRingEnd_apply, complexEmbedding_zeta,
     conj_complexRoot_eq_pow_sub_one, map_pow, complexEmbedding_zeta]
 
+/-- `star` on exact cyclotomic integers is the computable substitution `conj`, that is,
+evaluation of the canonical coefficient vector at `ζ_e ^ (e - 1)`. -/
 instance instStar : Star (Cyclotomic e) where
   star := conj
 
@@ -146,8 +150,8 @@ theorem star_zeta : star (zeta e) = zeta e ^ (e - 1) :=
   conj_zeta
 
 omit [NeZero e] in
-/-- Evaluation at a cyclotomic root intertwines `star` with substituting the inverse power of
-that root. -/
+/-- Evaluation at a cyclotomic root `r` intertwines `star` with substituting `r ^ (e - 1)`, the
+inverse of `r` when `e` is positive. -/
 theorem evalRingHom_star {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
     (hr : (Polynomial.cyclotomic e ℤ).eval₂ f r = 0) (x : Cyclotomic e) :
     evalRingHom f r hr (star x) = evalCoeffs f (r ^ (e - 1)) x := by
@@ -157,9 +161,10 @@ theorem evalRingHom_star {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
   · rw [map_pow, evalRingHom_zeta]
 
 omit [NeZero e] in
-/-- **Reduction intertwines conjugation with inversion of the chosen cyclotomic root.** Reducing
-`star x` at `r` is the same as reducing `x` at `r ^ (e - 1)`. This is the exact relation between
-conjugate cyclotomic entries and the residue tuples used by the Dixon lift. -/
+/-- **Reduction intertwines `star` with passing to the `(e - 1)`-st power of the chosen cyclotomic
+root.** Reducing `star x` at `r` is the same as reducing `x` at `r ^ (e - 1)`, which for positive
+`e` and primitive `r` is `r⁻¹`. This is the exact relation between conjugate cyclotomic entries
+and the residue tuples used by the Dixon lift. -/
 theorem reduce_star (p : ℕ) (r : ZMod p)
     (hr : (Polynomial.cyclotomic e ℤ).eval₂ (Int.castRingHom (ZMod p)) r = 0)
     (x : Cyclotomic e) :

--- a/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.RingTheory.Cyclotomic.Basic
+
+/-!
+# Complex conjugation on exact cyclotomic integers
+
+For positive `e`, complex conjugation preserves `ℤ[ζ_e]` and is determined by
+`ζ_e ↦ ζ_e⁻¹ = ζ_e ^ (e - 1)`.  This file implements that substitution directly on the
+coefficient-vector type `TauCeti.Cyclotomic e`, proves that it agrees with complex conjugation
+under the distinguished embedding into `ℂ`, and equips the exact ring with its canonical
+star-ring structure.
+
+The operation is a genuine computation: it evaluates the canonical coefficient list at
+`ζ_e ^ (e - 1)` using `TauCeti.Cyclotomic.evalCoeffs`.  In particular, exact Hermitian products
+can be checked before any passage to `ℂ`; this is needed by the cyclotomic stage of the
+Burnside--Dixon--Schneider character-table solver.
+
+## Main definitions
+
+* `TauCeti.Cyclotomic.conj`: computable conjugation on exact cyclotomic integers.
+* `TauCeti.Cyclotomic.instStarRing`: the canonical star-ring structure for positive conductor.
+
+## Main results
+
+* `TauCeti.Cyclotomic.conj_zeta`: conjugation sends `ζ_e` to `ζ_e ^ (e - 1)`.
+* `TauCeti.Cyclotomic.complexEmbedding_conj`: the distinguished complex embedding intertwines
+  exact and complex conjugation.
+* `TauCeti.Cyclotomic.reduce_star`: reducing a conjugate at a primitive root `r` is reduction of
+  the original exact integer at `r ^ (e - 1)`.
+
+## References
+
+This supplies the exact conjugation needed by Layer 6, “The assembled solver”, of the character
+theory roadmap: the exact checker must verify the Hermitian row-orthogonality relation in
+`Cyclotomic e` before embedding its output into `ℂ`.
+-/
+
+public section
+
+namespace TauCeti.Cyclotomic
+
+variable {e : ℕ}
+
+/-- Evaluate the canonical coefficient vector after replacing `ζ_e` by `ζ_e ^ (e - 1)`.
+This is complex conjugation on exact `e`-th cyclotomic integers. -/
+@[expose] def conj (x : Cyclotomic e) : Cyclotomic e :=
+  evalCoeffs (Int.castRingHom (Cyclotomic e)) (zeta e ^ (e - 1)) x
+
+/-- Exact cyclotomic conjugation, unfolded as evaluation at `ζ_e ^ (e - 1)`. -/
+theorem conj_def (x : Cyclotomic e) :
+    conj x = evalCoeffs (Int.castRingHom (Cyclotomic e)) (zeta e ^ (e - 1)) x :=
+  (rfl)
+
+private theorem map_evalCoeffs {R S : Type*} [CommRing R] [CommRing S]
+    (g : R →+* S) (f : ℤ →+* R) (r : R) (x : Cyclotomic e) :
+    g (evalCoeffs f r x) = evalCoeffs (g.comp f) (g r) x := by
+  rw [evalCoeffs_eq_eval₂, evalCoeffs_eq_eval₂, Polynomial.hom_eval₂]
+
+variable [NeZero e]
+
+private theorem complexEmbedding_eq_evalCoeffs (x : Cyclotomic e) :
+    complexEmbedding x = evalCoeffs (Int.castRingHom ℂ) (complexRoot e) x := by
+  rw [complexEmbedding_apply, evalCoeffs_eq_eval₂, Polynomial.aeval_def, algebraMap_int_eq]
+
+/-- **The distinguished complex embedding intertwines exact conjugation with complex
+conjugation.** -/
+theorem complexEmbedding_conj (x : Cyclotomic e) :
+    complexEmbedding (conj x) = star (complexEmbedding x) := by
+  calc
+    complexEmbedding (conj x) =
+        evalCoeffs (complexEmbedding.comp (Int.castRingHom (Cyclotomic e)))
+          (complexEmbedding (zeta e ^ (e - 1))) x := by
+      rw [conj_def, map_evalCoeffs]
+    _ = evalCoeffs (Int.castRingHom ℂ) (complexRoot e ^ (e - 1)) x := by
+      congr 1
+      · exact RingHom.ext_int _ _
+      · rw [map_pow, complexEmbedding_zeta]
+    _ = evalCoeffs (Int.castRingHom ℂ) (star (complexRoot e)) x := by
+      congr 1
+      simpa only [starRingEnd_apply] using
+        (conj_complexRoot_eq_pow_sub_one (e := e)).symm
+    _ = star (evalCoeffs (Int.castRingHom ℂ) (complexRoot e) x) := by
+      have h := (map_evalCoeffs (e := e) (starRingEnd ℂ) (Int.castRingHom ℂ)
+        (complexRoot e) x).symm
+      rw [RingHom.ext_int ((starRingEnd ℂ).comp (Int.castRingHom ℂ))
+        (Int.castRingHom ℂ)] at h
+      exact h
+    _ = star (complexEmbedding x) := by rw [complexEmbedding_eq_evalCoeffs]
+
+/-- Exact cyclotomic conjugation sends the distinguished generator to its inverse power
+`ζ_e ^ (e - 1)`. -/
+@[simp]
+theorem conj_zeta : conj (zeta e) = zeta e ^ (e - 1) := by
+  apply complexEmbedding_injective
+  rw [complexEmbedding_conj, ← starRingEnd_apply, complexEmbedding_zeta,
+    conj_complexRoot_eq_pow_sub_one, map_pow, complexEmbedding_zeta]
+
+instance instStar : Star (Cyclotomic e) where
+  star := conj
+
+omit [NeZero e] in
+/-- On exact cyclotomic integers, `star` is the computable substitution
+`ζ_e ↦ ζ_e ^ (e - 1)`. -/
+theorem star_eq_conj (x : Cyclotomic e) : star x = conj x :=
+  (rfl)
+
+/-- The distinguished complex embedding is compatible with the star operations. -/
+@[simp]
+theorem complexEmbedding_star (x : Cyclotomic e) :
+    complexEmbedding (star x) = star (complexEmbedding x) :=
+  complexEmbedding_conj x
+
+/-- Exact cyclotomic integers form a star ring under complex conjugation. -/
+instance instStarRing : StarRing (Cyclotomic e) where
+  star_involutive x := complexEmbedding_injective <| calc
+    complexEmbedding (star (star x)) = star (complexEmbedding (star x)) :=
+      complexEmbedding_star _
+    _ = star (star (complexEmbedding x)) := by rw [complexEmbedding_star]
+    _ = complexEmbedding x := star_star _
+  star_add x y := complexEmbedding_injective <| calc
+    complexEmbedding (star (x + y)) = star (complexEmbedding (x + y)) :=
+      complexEmbedding_star _
+    _ = star (complexEmbedding x + complexEmbedding y) := by rw [map_add]
+    _ = star (complexEmbedding x) + star (complexEmbedding y) := star_add _ _
+    _ = complexEmbedding (star x) + complexEmbedding (star y) := by
+      rw [complexEmbedding_star, complexEmbedding_star]
+    _ = complexEmbedding (star x + star y) := (map_add _ _ _).symm
+  star_mul x y := complexEmbedding_injective <| calc
+    complexEmbedding (star (x * y)) = star (complexEmbedding (x * y)) :=
+      complexEmbedding_star _
+    _ = star (complexEmbedding x * complexEmbedding y) := by rw [map_mul]
+    _ = star (complexEmbedding y) * star (complexEmbedding x) := star_mul _ _
+    _ = complexEmbedding (star y) * complexEmbedding (star x) := by
+      rw [complexEmbedding_star, complexEmbedding_star]
+    _ = complexEmbedding (star y * star x) := (map_mul _ _ _).symm
+
+/-- Conjugation sends the distinguished generator to `ζ_e ^ (e - 1)`. -/
+@[simp]
+theorem star_zeta : star (zeta e) = zeta e ^ (e - 1) :=
+  conj_zeta
+
+/-- **Reduction intertwines conjugation with inversion of the chosen primitive root.** Reducing
+`star x` at `r` is the same as reducing `x` at `r ^ (e - 1) = r⁻¹`. This is the exact relation
+between conjugate cyclotomic entries and the residue tuples used by the Dixon lift. -/
+theorem reduce_star (p : ℕ) [Fact p.Prime] (r : ZMod p) (hr : IsPrimitiveRoot r e)
+    (x : Cyclotomic e) :
+    reduce p r (star x) = reduce p (r ^ (e - 1)) x := by
+  rw [star_eq_conj, conj_def, ← reduceRingHom_apply p r hr, map_evalCoeffs]
+  congr 1
+  · exact RingHom.ext_int _ _
+  · rw [map_pow, reduceRingHom_apply, reduce_zeta p r hr]
+
+/-! The exact operation reduces in the kernel. -/
+
+example : star (zeta 3) = zeta 3 ^ 2 := by decide
+
+example : star (zeta 4 + 1) = -(zeta 4) + 1 := by decide
+
+end TauCeti.Cyclotomic

--- a/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
@@ -28,10 +28,10 @@ Burnside--Dixon--Schneider character-table solver.
 
 ## Main results
 
-* `TauCeti.Cyclotomic.conj_zeta`: conjugation sends `ζ_e` to `ζ_e ^ (e - 1)`.
-* `TauCeti.Cyclotomic.complexEmbedding_conj`: the distinguished complex embedding intertwines
+* `TauCeti.Cyclotomic.star_zeta`: conjugation sends `ζ_e` to `ζ_e ^ (e - 1)`.
+* `TauCeti.Cyclotomic.complexEmbedding_star`: the distinguished complex embedding intertwines
   exact and complex conjugation.
-* `TauCeti.Cyclotomic.reduce_star`: reducing a conjugate at a primitive root `r` is reduction of
+* `TauCeti.Cyclotomic.reduce_star`: reducing a conjugate at a cyclotomic root `r` is reduction of
   the original exact integer at `r ^ (e - 1)`.
 
 ## References
@@ -70,7 +70,7 @@ private theorem complexEmbedding_eq_evalCoeffs (x : Cyclotomic e) :
 
 /-- **The distinguished complex embedding intertwines exact conjugation with complex
 conjugation.** -/
-theorem complexEmbedding_conj (x : Cyclotomic e) :
+private theorem complexEmbedding_conj (x : Cyclotomic e) :
     complexEmbedding (conj x) = star (complexEmbedding x) := by
   calc
     complexEmbedding (conj x) =
@@ -96,7 +96,7 @@ theorem complexEmbedding_conj (x : Cyclotomic e) :
 /-- Exact cyclotomic conjugation sends the distinguished generator to its inverse power
 `ζ_e ^ (e - 1)`. -/
 @[simp]
-theorem conj_zeta : conj (zeta e) = zeta e ^ (e - 1) := by
+private theorem conj_zeta : conj (zeta e) = zeta e ^ (e - 1) := by
   apply complexEmbedding_injective
   rw [complexEmbedding_conj, ← starRingEnd_apply, complexEmbedding_zeta,
     conj_complexRoot_eq_pow_sub_one, map_pow, complexEmbedding_zeta]
@@ -145,16 +145,26 @@ instance instStarRing : StarRing (Cyclotomic e) where
 theorem star_zeta : star (zeta e) = zeta e ^ (e - 1) :=
   conj_zeta
 
-/-- **Reduction intertwines conjugation with inversion of the chosen primitive root.** Reducing
-`star x` at `r` is the same as reducing `x` at `r ^ (e - 1) = r⁻¹`. This is the exact relation
-between conjugate cyclotomic entries and the residue tuples used by the Dixon lift. -/
-theorem reduce_star (p : ℕ) [Fact p.Prime] (r : ZMod p) (hr : IsPrimitiveRoot r e)
-    (x : Cyclotomic e) :
-    reduce p r (star x) = reduce p (r ^ (e - 1)) x := by
-  rw [star_eq_conj, conj_def, ← reduceRingHom_apply p r hr, map_evalCoeffs]
+omit [NeZero e] in
+/-- Evaluation at a cyclotomic root intertwines `star` with substituting the inverse power of
+that root. -/
+theorem evalRingHom_star {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
+    (hr : (Polynomial.cyclotomic e ℤ).eval₂ f r = 0) (x : Cyclotomic e) :
+    evalRingHom f r hr (star x) = evalCoeffs f (r ^ (e - 1)) x := by
+  rw [star_eq_conj, conj_def, map_evalCoeffs]
   congr 1
   · exact RingHom.ext_int _ _
-  · rw [map_pow, reduceRingHom_apply, reduce_zeta p r hr]
+  · rw [map_pow, evalRingHom_zeta]
+
+omit [NeZero e] in
+/-- **Reduction intertwines conjugation with inversion of the chosen cyclotomic root.** Reducing
+`star x` at `r` is the same as reducing `x` at `r ^ (e - 1)`. This is the exact relation between
+conjugate cyclotomic entries and the residue tuples used by the Dixon lift. -/
+theorem reduce_star (p : ℕ) (r : ZMod p)
+    (hr : (Polynomial.cyclotomic e ℤ).eval₂ (Int.castRingHom (ZMod p)) r = 0)
+    (x : Cyclotomic e) :
+    reduce p r (star x) = reduce p (r ^ (e - 1)) x := by
+  rw [reduce, evalCoeffs_eq_eval₂, ← evalRingHom_apply _ _ hr, evalRingHom_star, reduce]
 
 /-! The exact operation reduces in the kernel. -/
 

--- a/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
@@ -23,12 +23,14 @@ Burnside--Dixon--Schneider character-table solver.
 
 ## Main definitions
 
-* `TauCeti.Cyclotomic.conj`: computable conjugation on exact cyclotomic integers.
-* `TauCeti.Cyclotomic.instStar`: the `star` notation, defined to be `conj`.
+* `TauCeti.Cyclotomic.instStar`: computable conjugation on exact cyclotomic integers, given by the
+  substitution `ζ_e ↦ ζ_e ^ (e - 1)`.
 * `TauCeti.Cyclotomic.instStarRing`: the canonical star-ring structure for positive conductor.
 
 ## Main results
 
+* `TauCeti.Cyclotomic.star_def`: `star` evaluates the canonical coefficient vector at
+  `ζ_e ^ (e - 1)`.
 * `TauCeti.Cyclotomic.star_zeta`: conjugation sends `ζ_e` to `ζ_e ^ (e - 1)`.
 * `TauCeti.Cyclotomic.complexEmbedding_star`: the distinguished complex embedding intertwines
   exact and complex conjugation.
@@ -48,11 +50,18 @@ namespace TauCeti.Cyclotomic
 
 variable {e : ℕ}
 
-/-- Evaluate the canonical coefficient vector after replacing `ζ_e` by `ζ_e ^ (e - 1)`.
-For positive `e` this power is `ζ_e⁻¹`, so the substitution is complex conjugation on exact
-`e`-th cyclotomic integers. -/
-@[expose] def conj (x : Cyclotomic e) : Cyclotomic e :=
-  evalCoeffs (Int.castRingHom (Cyclotomic e)) (zeta e ^ (e - 1)) x
+/-- `star` on exact cyclotomic integers evaluates the canonical coefficient vector after replacing
+`ζ_e` by `ζ_e ^ (e - 1)`.  For positive `e` this power is `ζ_e⁻¹`, so the substitution is complex
+conjugation on exact `e`-th cyclotomic integers. -/
+instance instStar : Star (Cyclotomic e) where
+  star x := evalCoeffs (Int.castRingHom (Cyclotomic e)) (zeta e ^ (e - 1)) x
+
+/-- `star` is the computable substitution `ζ_e ↦ ζ_e ^ (e - 1)`: it evaluates the canonical
+coefficient vector at that power.  This is the defining equation of `Star (Cyclotomic e)`; it is
+not `simp`, since it unfolds into coefficient lists. -/
+theorem star_def (x : Cyclotomic e) :
+    star x = evalCoeffs (Int.castRingHom (Cyclotomic e)) (zeta e ^ (e - 1)) x :=
+  rfl
 
 private theorem map_evalCoeffs {R S : Type*} [CommRing R] [CommRing S]
     (g : R →+* S) (f : ℤ →+* R) (r : R) (x : Cyclotomic e) :
@@ -67,13 +76,14 @@ private theorem complexEmbedding_eq_evalCoeffs (x : Cyclotomic e) :
 
 /-- **The distinguished complex embedding intertwines exact conjugation with complex
 conjugation.** -/
-private theorem complexEmbedding_conj (x : Cyclotomic e) :
-    complexEmbedding (conj x) = star (complexEmbedding x) := by
+@[simp]
+theorem complexEmbedding_star (x : Cyclotomic e) :
+    complexEmbedding (star x) = star (complexEmbedding x) := by
   calc
-    complexEmbedding (conj x) =
+    complexEmbedding (star x) =
         evalCoeffs (complexEmbedding.comp (Int.castRingHom (Cyclotomic e)))
           (complexEmbedding (zeta e ^ (e - 1))) x := by
-      rw [conj, map_evalCoeffs]
+      rw [star_def, map_evalCoeffs]
     _ = evalCoeffs (Int.castRingHom ℂ) (complexRoot e ^ (e - 1)) x := by
       congr 1
       · exact RingHom.ext_int _ _
@@ -89,31 +99,6 @@ private theorem complexEmbedding_conj (x : Cyclotomic e) :
         (Int.castRingHom ℂ)] at h
       exact h
     _ = star (complexEmbedding x) := by rw [complexEmbedding_eq_evalCoeffs]
-
-/-- Exact cyclotomic conjugation sends the distinguished generator to its inverse power
-`ζ_e ^ (e - 1)`. -/
-@[simp]
-private theorem conj_zeta : conj (zeta e) = zeta e ^ (e - 1) := by
-  apply complexEmbedding_injective
-  rw [complexEmbedding_conj, ← starRingEnd_apply, complexEmbedding_zeta,
-    conj_complexRoot_eq_pow_sub_one, map_pow, complexEmbedding_zeta]
-
-/-- `star` on exact cyclotomic integers is the computable substitution `conj`, that is,
-evaluation of the canonical coefficient vector at `ζ_e ^ (e - 1)`. -/
-instance instStar : Star (Cyclotomic e) where
-  star := conj
-
-omit [NeZero e] in
-/-- On exact cyclotomic integers, `star` is the computable substitution
-`ζ_e ↦ ζ_e ^ (e - 1)`. -/
-theorem star_eq_conj (x : Cyclotomic e) : star x = conj x :=
-  (rfl)
-
-/-- The distinguished complex embedding is compatible with the star operations. -/
-@[simp]
-theorem complexEmbedding_star (x : Cyclotomic e) :
-    complexEmbedding (star x) = star (complexEmbedding x) :=
-  complexEmbedding_conj x
 
 /-- Exact cyclotomic integers form a star ring under complex conjugation. -/
 instance instStarRing : StarRing (Cyclotomic e) where
@@ -141,8 +126,10 @@ instance instStarRing : StarRing (Cyclotomic e) where
 
 /-- Conjugation sends the distinguished generator to `ζ_e ^ (e - 1)`. -/
 @[simp]
-theorem star_zeta : star (zeta e) = zeta e ^ (e - 1) :=
-  conj_zeta
+theorem star_zeta : star (zeta e) = zeta e ^ (e - 1) := by
+  apply complexEmbedding_injective
+  rw [complexEmbedding_star, ← starRingEnd_apply, complexEmbedding_zeta,
+    conj_complexRoot_eq_pow_sub_one, map_pow, complexEmbedding_zeta]
 
 omit [NeZero e] in
 /-- Evaluation at a cyclotomic root `r` intertwines `star` with substituting `r ^ (e - 1)`, the
@@ -150,7 +137,7 @@ inverse of `r` when `e` is positive. -/
 theorem evalRingHom_star {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
     (hr : (Polynomial.cyclotomic e ℤ).eval₂ f r = 0) (x : Cyclotomic e) :
     evalRingHom f r hr (star x) = evalCoeffs f (r ^ (e - 1)) x := by
-  rw [star_eq_conj, conj, map_evalCoeffs]
+  rw [star_def, map_evalCoeffs]
   congr 1
   · exact RingHom.ext_int _ _
   · rw [map_pow, evalRingHom_zeta]

--- a/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
+++ b/TauCeti/RingTheory/Cyclotomic/Conjugation.lean
@@ -54,11 +54,6 @@ For positive `e` this power is `ζ_e⁻¹`, so the substitution is complex conju
 @[expose] def conj (x : Cyclotomic e) : Cyclotomic e :=
   evalCoeffs (Int.castRingHom (Cyclotomic e)) (zeta e ^ (e - 1)) x
 
-/-- Exact cyclotomic conjugation, unfolded as evaluation at `ζ_e ^ (e - 1)`. -/
-theorem conj_def (x : Cyclotomic e) :
-    conj x = evalCoeffs (Int.castRingHom (Cyclotomic e)) (zeta e ^ (e - 1)) x :=
-  (rfl)
-
 private theorem map_evalCoeffs {R S : Type*} [CommRing R] [CommRing S]
     (g : R →+* S) (f : ℤ →+* R) (r : R) (x : Cyclotomic e) :
     g (evalCoeffs f r x) = evalCoeffs (g.comp f) (g r) x := by
@@ -78,7 +73,7 @@ private theorem complexEmbedding_conj (x : Cyclotomic e) :
     complexEmbedding (conj x) =
         evalCoeffs (complexEmbedding.comp (Int.castRingHom (Cyclotomic e)))
           (complexEmbedding (zeta e ^ (e - 1))) x := by
-      rw [conj_def, map_evalCoeffs]
+      rw [conj, map_evalCoeffs]
     _ = evalCoeffs (Int.castRingHom ℂ) (complexRoot e ^ (e - 1)) x := by
       congr 1
       · exact RingHom.ext_int _ _
@@ -155,7 +150,7 @@ inverse of `r` when `e` is positive. -/
 theorem evalRingHom_star {R : Type*} [CommRing R] (f : ℤ →+* R) (r : R)
     (hr : (Polynomial.cyclotomic e ℤ).eval₂ f r = 0) (x : Cyclotomic e) :
     evalRingHom f r hr (star x) = evalCoeffs f (r ^ (e - 1)) x := by
-  rw [star_eq_conj, conj_def, map_evalCoeffs]
+  rw [star_eq_conj, conj, map_evalCoeffs]
   congr 1
   · exact RingHom.ext_int _ _
   · rw [map_pow, evalRingHom_zeta]


### PR DESCRIPTION
This PR equips the computable coefficient-vector ring `Cyclotomic e` with exact complex conjugation, implemented by the substitution `ζ_e ↦ ζ_e ^ (e - 1)`, and installs the resulting canonical `StarRing` structure for positive conductor.

The concrete target is the prerequisite exact arithmetic for `RepresentationTheory/CharacterTheory/README.md`, Layer 6, “The assembled solver”: the solver must return an exact cyclotomic table together with a checker certificate, while `IsCharacterTableSpec.row_orthonormal` requires Hermitian products. Before this PR the integer-valued checker could use the trivial involution on `ℤ`, but a general `Cyclotomic e` checker had no exact operation corresponding to complex conjugation. After this PR, exact Hermitian identities can be stated and evaluated in `Cyclotomic e`; what remains for the milestone is the general cyclotomic checker, assembly of modular eigenvector search, structured lifting and degree recovery into `characterTableDixon`, and the summit theorem `characterTable_eq`.

The new operation is a genuine kernel computation via `Cyclotomic.evalCoeffs`. Its characteristic API proves the image of `ζ_e`, compatibility with the distinguished embedding into `ℂ`, involutivity and the star-ring laws, and compatibility with modular reduction: reducing `star x` at a primitive root `r` equals reducing `x` at `r ^ (e - 1)`. The proofs reuse Mathlib's `Polynomial.hom_eval₂` and Tau Ceti's existing injective `Cyclotomic.complexEmbedding`; no code or proof was copied from another formalization or from the supplementary source snapshot.

The only added file is `TauCeti/RingTheory/Cyclotomic/Conjugation.lean` (165 lines), beside the exact cyclotomic ring and structured lift it extends.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"cyclotomic-conjugation"}-->

🤖 Prepared with Codex
