### PR TITLE
feat: generate type C sum-root subgroups

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Basic.lean
@@ -964,6 +964,26 @@ def short (family : ShortRootFamily) (i j : Fin m) (hij : i ≠ j) :
       if h : i < j then .negativeSum i j h
       else .negativeSum j i (lt_of_le_of_ne (le_of_not_gt h) hij.symm)
 
+/-- The canonical short-root index leaves a difference root ordered. -/
+@[simp]
+theorem short_difference (i j : Fin m) (hij : i ≠ j) :
+    short .difference i j hij = .difference i j hij := by
+  rw [short]
+
+/-- Increasing indices are already the canonical order for a positive sum root. -/
+@[simp]
+theorem short_positiveSum_of_lt (i j : Fin m) (hij : i < j) :
+    short .positiveSum i j hij.ne = .positiveSum i j hij := by
+  rw [short]
+  simp only [hij, ↓reduceDIte]
+
+/-- Increasing indices are already the canonical order for a negative sum root. -/
+@[simp]
+theorem short_negativeSum_of_lt (i j : Fin m) (hij : i < j) :
+    short .negativeSum i j hij.ne = .negativeSum i j hij := by
+  rw [short]
+  simp only [hij, ↓reduceDIte]
+
 /-- Swapping the inputs gives the same canonical positive-sum root index. -/
 theorem short_positiveSum_swap (i j : Fin m) (hij : i ≠ j) :
     short .positiveSum i j hij = short .positiveSum j i hij.symm := by

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/SumRootGeneration.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/SumRootGeneration.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.ChevalleyRelations
+
+/-!
+# Generating the sum-root subgroups of the symplectic group
+
+The standard type-`C_m` root system has short roots `eᵢ - eⱼ`, `eᵢ + eⱼ`, and
+`-eᵢ - eⱼ`, together with the long roots `±2eᵢ`. This file uses the multiply-laced
+Chevalley relations to recover the two sum-root families from the difference-root and long-root
+families. For distinct `i` and `j`, specializing the positive relation at parameter one gives
+
+```text
+⁅x_{eᵢ-eⱼ}(1), x_{2eⱼ}(c)⁆ = x_{eᵢ+eⱼ}(c) x_{2eᵢ}(c),
+```
+
+and the negative relation at `-c` gives the corresponding formula for `-eᵢ-eⱼ`. Thus a
+subgroup containing every difference-root and long-root element contains every root element of
+the standard symplectic realization. The argument uses no division, so it works over every
+commutative ring, including characteristic two.
+
+## Main results
+
+* `TauCeti.GLSymplecticFin.positiveSumShortRootUnit_mem_of_difference_long`: a positive sum-root
+  element belongs to a subgroup containing the three elements in the specialized commutator
+  relation.
+* `TauCeti.GLSymplecticFin.negativeSumShortRootUnit_mem_of_difference_long`: the parallel negative
+  result.
+* `TauCeti.GLSymplecticFin.rootSubgroupHom_mem_of_difference_long`: difference-root and long-root
+  families generate every root family.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type* (1972), §5.2.
+* R. Steinberg, *Lectures on Chevalley Groups* (1968), §§3--4.
+
+This advances Layer 9, "The Chevalley--Demazure construction", of
+`TauCetiRoadmap/ReductiveGroups/README.md`: it is the sum-root generation step needed to identify
+the explicit full-weight type-`C` carrier with the standard symplectic group on field-valued
+points. That identification is consumed by the `C_n(q)` branch of milestone L0 in
+`TauCetiRoadmap/CFSGStatement/README.md`.
+-/
+
+public section
+
+open scoped commutatorElement
+
+namespace TauCeti.GLSymplecticFin
+
+universe u
+
+variable {R : Type u} [CommRing R] {m : ℕ} {i j : Fin m}
+
+/-- A positive sum-root element lies in any subgroup containing the parameter-one difference-root
+element and the two positive long-root elements occurring in its Chevalley commutator formula. -/
+theorem positiveSumShortRootUnit_mem_of_difference_long
+    (H : Subgroup (GLSymplecticFin m R)) (hij : i ≠ j) (c : R)
+    (hdifference : differenceShortRootUnit hij 1 ∈ H)
+    (hsource : positiveLongRootTransvectionUnit j c ∈ H)
+    (htarget : positiveLongRootTransvectionUnit i c ∈ H) :
+    positiveSumShortRootUnit hij c ∈ H := by
+  have hcomm :
+      ⁅differenceShortRootUnit hij (1 : R), positiveLongRootTransvectionUnit j c⁆ ∈ H :=
+    by
+      rw [commutatorElement_def]
+      exact H.mul_mem (H.mul_mem (H.mul_mem hdifference hsource) (H.inv_mem hdifference))
+        (H.inv_mem hsource)
+  rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit,
+    one_mul, one_pow, one_mul] at hcomm
+  exact (H.mul_mem_cancel_right htarget).mp hcomm
+
+/-- A negative sum-root element lies in any subgroup containing the parameter-one difference-root
+element and the two negative long-root elements occurring in its Chevalley commutator formula. -/
+theorem negativeSumShortRootUnit_mem_of_difference_long
+    (H : Subgroup (GLSymplecticFin m R)) (hij : i ≠ j) (c : R)
+    (hdifference : differenceShortRootUnit hij 1 ∈ H)
+    (hsource : negativeLongRootTransvectionUnit i (-c) ∈ H)
+    (htarget : negativeLongRootTransvectionUnit j (-c) ∈ H) :
+    negativeSumShortRootUnit hij c ∈ H := by
+  have hcomm :
+      ⁅differenceShortRootUnit hij (1 : R), negativeLongRootTransvectionUnit i (-c)⁆ ∈ H :=
+    by
+      rw [commutatorElement_def]
+      exact H.mul_mem (H.mul_mem (H.mul_mem hdifference hsource) (H.inv_mem hdifference))
+        (H.inv_mem hsource)
+  rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit,
+    one_mul, neg_neg, one_pow, one_mul] at hcomm
+  exact (H.mul_mem_cancel_right htarget).mp hcomm
+
+/-- If a subgroup of the standard symplectic group contains every difference-root element and
+every positive and negative long-root element, then it contains every standard root-subgroup
+element. This is valid over an arbitrary commutative ring. -/
+theorem rootSubgroupHom_mem_of_difference_long
+    (H : Subgroup (GLSymplecticFin m R))
+    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
+      differenceShortRootUnit hij c ∈ H)
+    (hpositiveLong : ∀ (i : Fin m) (c : R), positiveLongRootTransvectionUnit i c ∈ H)
+    (hnegativeLong : ∀ (i : Fin m) (c : R), negativeLongRootTransvectionUnit i c ∈ H)
+    (root : RootSubgroupIndex m) (c : Multiplicative R) :
+    root.hom c ∈ H := by
+  cases root with
+  | positiveLong i =>
+      rw [RootSubgroupIndex.hom_positiveLong, positiveLongRootTransvectionHom_apply]
+      exact hpositiveLong i c.toAdd
+  | negativeLong i =>
+      rw [RootSubgroupIndex.hom_negativeLong, negativeLongRootTransvectionHom_apply]
+      exact hnegativeLong i c.toAdd
+  | difference i j hij =>
+      rw [← RootSubgroupIndex.short_difference i j hij, RootSubgroupIndex.hom_short,
+        ShortRootFamily.hom_difference,
+        differenceShortRootHom_apply]
+      exact hdifference hij c.toAdd
+  | positiveSum i j hij =>
+      rw [← RootSubgroupIndex.short_positiveSum_of_lt i j hij,
+        RootSubgroupIndex.hom_short, ShortRootFamily.hom_positiveSum,
+        positiveSumShortRootHom_apply]
+      exact positiveSumShortRootUnit_mem_of_difference_long H hij.ne c.toAdd
+        (hdifference hij.ne 1) (hpositiveLong j c.toAdd) (hpositiveLong i c.toAdd)
+  | negativeSum i j hij =>
+      rw [← RootSubgroupIndex.short_negativeSum_of_lt i j hij,
+        RootSubgroupIndex.hom_short, ShortRootFamily.hom_negativeSum,
+        negativeSumShortRootHom_apply]
+      exact negativeSumShortRootUnit_mem_of_difference_long H hij.ne c.toAdd
+        (hdifference hij.ne 1) (hnegativeLong i (-c.toAdd)) (hnegativeLong j (-c.toAdd))
+
+end TauCeti.GLSymplecticFin


### PR DESCRIPTION
This PR derives both positive and negative type-`C` sum-root subgroup elements from the existing multiply-laced Chevalley relations, and exposes the aggregate result that a subgroup of the standard symplectic group containing every difference-root and long-root element contains every standard root-subgroup element. It specializes the positive commutator at parameter one and the negative commutator at the negated target parameter, then cancels only long-root elements already known to lie in the subgroup; consequently the result holds over every commutative ring, including characteristic two. It also adds the canonical `RootSubgroupIndex.short` computation lemmas needed to consume its sealed API without unfolding it.

The exact roadmap target is ReductiveGroups Layer 9, “The Chevalley–Demazure construction,” specifically the type-`C` generation step needed to identify the explicit full-weight Chevalley carrier with the standard symplectic group on field-valued points. The designated consumer is CFSGStatement milestone L0, “explicit pinned Chevalley--Demazure groups”: its `C_n(q)` branch of `ValidLieTypeIndex.AmbientGroup` consumes the resulting named simply connected symplectic carrier and its pinned root subgroups.

Dependency edge: CFSGStatement L0 `ValidLieTypeIndex.AmbientGroup` ← ReductiveGroups Layer 9 explicit type-`C` carrier identification ← generation of the positive and negative sum-root subgroups from the difference-root and long-root families.

This is the most effective current step because open PR #5182 supplies difference-root generation and open PR #5187 supplies transport of the long-root family, while both explicitly leave sum-root generation to be combined with the Chevalley relations already on `main`; this PR fills exactly that distinct bridge without depending on either unmerged branch.

After this PR, combine these sum-root lemmas with the in-flight difference-root and long-root results to prove field-valued symplectic generation, then identify the full-weight carrier with the symplectic group scheme and connect its pinning to the integral simply connected type-`C` root datum before CFSGStatement L0 can consume it.

Add `TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/SumRootGeneration.lean` (131 lines) and add 20 lines to `Symplectic/Basic.lean`. No Mathlib infrastructure is vendored. The commutator conventions follow R. W. Carter, *Simple Groups of Lie Type*, §5.2, and R. Steinberg, *Lectures on Chevalley Groups*, §§3–4, as recorded in the module documentation.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-c-sum-root-generation"}-->

🤖 Prepared with Codex
