### PR TITLE
feat: generate type C long and sum roots

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Basic.lean
@@ -493,6 +493,40 @@ theorem negativeLongRootTransvectionHom_apply (i : Fin m) (c : Multiplicative R)
       negativeLongRootTransvectionUnit i (Multiplicative.toAdd c) :=
   (rfl)
 
+/-- Adding parameters multiplies positive long-root transvections. -/
+@[simp]
+theorem positiveLongRootTransvectionUnit_add (i : Fin m) (c d : R) :
+    positiveLongRootTransvectionUnit i (c + d) =
+      positiveLongRootTransvectionUnit i c * positiveLongRootTransvectionUnit i d := by
+  simpa only [positiveLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_mul] using
+    ((positiveLongRootTransvectionHom (R := R) i).map_mul
+      (Multiplicative.ofAdd c) (Multiplicative.ofAdd d))
+
+/-- Inverting a positive long-root transvection negates its parameter. -/
+@[simp]
+theorem positiveLongRootTransvectionUnit_inv (i : Fin m) (c : R) :
+    (positiveLongRootTransvectionUnit i c)⁻¹ =
+      positiveLongRootTransvectionUnit i (-c) := by
+  simpa only [positiveLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_inv] using
+    (map_inv (positiveLongRootTransvectionHom (R := R) i) (Multiplicative.ofAdd c)).symm
+
+/-- Adding parameters multiplies negative long-root transvections. -/
+@[simp]
+theorem negativeLongRootTransvectionUnit_add (i : Fin m) (c d : R) :
+    negativeLongRootTransvectionUnit i (c + d) =
+      negativeLongRootTransvectionUnit i c * negativeLongRootTransvectionUnit i d := by
+  simpa only [negativeLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_mul] using
+    ((negativeLongRootTransvectionHom (R := R) i).map_mul
+      (Multiplicative.ofAdd c) (Multiplicative.ofAdd d))
+
+/-- Inverting a negative long-root transvection negates its parameter. -/
+@[simp]
+theorem negativeLongRootTransvectionUnit_inv (i : Fin m) (c : R) :
+    (negativeLongRootTransvectionUnit i c)⁻¹ =
+      negativeLongRootTransvectionUnit i (-c) := by
+  simpa only [negativeLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_inv] using
+    (map_inv (negativeLongRootTransvectionHom (R := R) i) (Multiplicative.ofAdd c)).symm
+
 /-- Positive long-root transvections are natural in the coefficient ring. -/
 @[simp]
 theorem map_positiveLongRootTransvectionUnit {S : Type*} [CommRing S]

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/Basic.lean
@@ -999,6 +999,26 @@ theorem hom_negativeLong (i : Fin m) :
     (RootSubgroupIndex.negativeLong i).hom (R := R) = negativeLongRootTransvectionHom i := by
   rw [hom]
 
+/-- The difference-root constructor selects the corresponding difference-root homomorphism. -/
+@[simp]
+theorem hom_difference (i j : Fin m) (hij : i ≠ j) :
+    (RootSubgroupIndex.difference i j hij).hom (R := R) = differenceShortRootHom hij := by
+  rw [hom]
+
+/-- The positive-sum constructor selects the corresponding positive-sum homomorphism. -/
+@[simp]
+theorem hom_positiveSum (i j : Fin m) (hij : i < j) :
+    (RootSubgroupIndex.positiveSum i j hij).hom (R := R) =
+      positiveSumShortRootHom hij.ne := by
+  rw [hom]
+
+/-- The negative-sum constructor selects the corresponding negative-sum homomorphism. -/
+@[simp]
+theorem hom_negativeSum (i j : Fin m) (hij : i < j) :
+    (RootSubgroupIndex.negativeSum i j hij).hom (R := R) =
+      negativeSumShortRootHom hij.ne := by
+  rw [hom]
+
 /-- The short constructor selects its family's short-root homomorphism. -/
 @[simp]
 theorem hom_short (family : ShortRootFamily) (i j : Fin m) (hij : i ≠ j) :

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
@@ -29,8 +29,8 @@ opposite relation, and the sum roots are then isolated from either commutator fo
 
 ## Main results
 
-* `TauCeti.GLSymplecticFin.positiveLongRootTransvectionUnit_mem_of_difference` and its negative
-  analogue propagate one long-root subgroup to every index.
+* `TauCeti.GLSymplecticFin.positiveLongRootTransvectionUnit_mem_of_difference_of_long` and its
+  negative analogue propagate one long-root subgroup to every index.
 * `TauCeti.GLSymplecticFin.positiveSumShortRootUnit_mem_of_difference_of_long` and its negative
   analogue generate the two sum-root families.
 * `TauCeti.GLSymplecticFin.RootSubgroupIndex.hom_apply_mem_of_difference_of_long` packages the
@@ -60,59 +60,9 @@ universe u
 
 variable {R : Type u} [CommRing R] {m : ℕ} {i j : Fin m}
 
-private theorem positiveLongRootTransvectionUnit_mul (i : Fin m) (a b : R) :
-    positiveLongRootTransvectionUnit i a * positiveLongRootTransvectionUnit i b =
-      positiveLongRootTransvectionUnit i (a + b) := by
-  apply (GLSymplecticFin m R).subtype_injective
-  change
-    (positiveLongRootTransvectionUnit i a : GL (Fin (m + m)) R) *
-        (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) =
-      (positiveLongRootTransvectionUnit i (a + b) : GL (Fin (m + m)) R)
-  rw [coe_positiveLongRootTransvectionUnit,
-    coe_positiveLongRootTransvectionUnit, coe_positiveLongRootTransvectionUnit,
-    transvectionUnit_add]
-
-private theorem positiveLongRootTransvectionUnit_inv (i : Fin m) (a : R) :
-    (positiveLongRootTransvectionUnit i a)⁻¹ =
-      positiveLongRootTransvectionUnit i (-a) := by
-  apply (GLSymplecticFin m R).subtype_injective
-  change ((positiveLongRootTransvectionUnit i a : GL (Fin (m + m)) R))⁻¹ =
-    (positiveLongRootTransvectionUnit i (-a) : GL (Fin (m + m)) R)
-  rw [coe_positiveLongRootTransvectionUnit,
-    coe_positiveLongRootTransvectionUnit, transvectionUnit_inv]
-
-private theorem negativeLongRootTransvectionUnit_mul (i : Fin m) (a b : R) :
-    negativeLongRootTransvectionUnit i a * negativeLongRootTransvectionUnit i b =
-      negativeLongRootTransvectionUnit i (a + b) := by
-  apply (GLSymplecticFin m R).subtype_injective
-  change
-    (negativeLongRootTransvectionUnit i a : GL (Fin (m + m)) R) *
-        (negativeLongRootTransvectionUnit i b : GL (Fin (m + m)) R) =
-      (negativeLongRootTransvectionUnit i (a + b) : GL (Fin (m + m)) R)
-  rw [coe_negativeLongRootTransvectionUnit,
-    coe_negativeLongRootTransvectionUnit, coe_negativeLongRootTransvectionUnit,
-    transvectionUnit_add]
-
-private theorem negativeLongRootTransvectionUnit_inv (i : Fin m) (a : R) :
-    (negativeLongRootTransvectionUnit i a)⁻¹ =
-      negativeLongRootTransvectionUnit i (-a) := by
-  apply (GLSymplecticFin m R).subtype_injective
-  change ((negativeLongRootTransvectionUnit i a : GL (Fin (m + m)) R))⁻¹ =
-    (negativeLongRootTransvectionUnit i (-a) : GL (Fin (m + m)) R)
-  rw [coe_negativeLongRootTransvectionUnit,
-    coe_negativeLongRootTransvectionUnit, transvectionUnit_inv]
-
 private theorem commute_positiveSumShortRootUnit_positiveLongRootTransvectionUnit
     (hij : i ≠ j) (a b : R) :
   Commute (positiveSumShortRootUnit hij a) (positiveLongRootTransvectionUnit i b) := by
-  apply (GLSymplecticFin m R).subtype_injective
-  change
-    (positiveSumShortRootUnit hij a : GL (Fin (m + m)) R) *
-        (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) =
-      (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) *
-        (positiveSumShortRootUnit hij a : GL (Fin (m + m)) R)
-  rw [coe_positiveSumShortRootUnit,
-    coe_positiveLongRootTransvectionUnit]
   have hIL : Commute (transvectionUnit (finSumFinEquiv_inl_ne_inr i j) a)
       (transvectionUnit (finSumFinEquiv_inl_ne_inr i i) b) :=
     commute_transvectionUnit (finSumFinEquiv_inl_ne_inr i j)
@@ -123,18 +73,18 @@ private theorem commute_positiveSumShortRootUnit_positiveLongRootTransvectionUni
     commute_transvectionUnit (finSumFinEquiv_inl_ne_inr j i)
       (finSumFinEquiv_inl_ne_inr i i) (finSumFinEquiv_inr_ne_inl i i)
       (finSumFinEquiv_inr_ne_inl i j) a b
-  exact hIL.mul_left hJL
+  have hambient :
+      (positiveSumShortRootUnit hij a : GL (Fin (m + m)) R) *
+          (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) =
+        (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) *
+          (positiveSumShortRootUnit hij a : GL (Fin (m + m)) R) := by
+    rw [coe_positiveSumShortRootUnit, coe_positiveLongRootTransvectionUnit]
+    exact hIL.mul_left hJL
+  exact (GLSymplecticFin m R).subtype_injective hambient
 
 private theorem commute_negativeSumShortRootUnit_negativeLongRootTransvectionUnit
     (hij : i ≠ j) (a b : R) :
     Commute (negativeSumShortRootUnit hij a) (negativeLongRootTransvectionUnit j b) := by
-  apply (GLSymplecticFin m R).subtype_injective
-  change
-    (negativeSumShortRootUnit hij a : GL (Fin (m + m)) R) *
-        (negativeLongRootTransvectionUnit j b : GL (Fin (m + m)) R) =
-      (negativeLongRootTransvectionUnit j b : GL (Fin (m + m)) R) *
-        (negativeSumShortRootUnit hij a : GL (Fin (m + m)) R)
-  rw [coe_negativeSumShortRootUnit, coe_negativeLongRootTransvectionUnit]
   have hIL : Commute (transvectionUnit (finSumFinEquiv_inr_ne_inl i j) a)
       (transvectionUnit (finSumFinEquiv_inr_ne_inl j j) b) :=
     commute_transvectionUnit (finSumFinEquiv_inr_ne_inl i j)
@@ -145,17 +95,19 @@ private theorem commute_negativeSumShortRootUnit_negativeLongRootTransvectionUni
     commute_transvectionUnit (finSumFinEquiv_inr_ne_inl j i)
       (finSumFinEquiv_inr_ne_inl j j) (finSumFinEquiv_inl_ne_inr i j)
       (finSumFinEquiv_inl_ne_inr j j) a b
-  exact hIL.mul_left hJL
-
-private theorem commutatorElement_mem (H : Subgroup (GLSymplecticFin m R))
-    {x y : GLSymplecticFin m R} (hx : x ∈ H) (hy : y ∈ H) : ⁅x, y⁆ ∈ H := by
-  rw [commutatorElement_def]
-  exact H.mul_mem (H.mul_mem (H.mul_mem hx hy) (H.inv_mem hx)) (H.inv_mem hy)
+  have hambient :
+      (negativeSumShortRootUnit hij a : GL (Fin (m + m)) R) *
+          (negativeLongRootTransvectionUnit j b : GL (Fin (m + m)) R) =
+        (negativeLongRootTransvectionUnit j b : GL (Fin (m + m)) R) *
+          (negativeSumShortRootUnit hij a : GL (Fin (m + m)) R) := by
+    rw [coe_negativeSumShortRootUnit, coe_negativeLongRootTransvectionUnit]
+    exact hIL.mul_left hJL
+  exact (GLSymplecticFin m R).subtype_injective hambient
 
 /-- If a subgroup contains every difference-root element and one positive long-root subgroup,
 then it contains every positive long-root element, provided `2` is invertible in the coefficient
 ring. -/
-theorem positiveLongRootTransvectionUnit_mem_of_difference
+theorem positiveLongRootTransvectionUnit_mem_of_difference_of_long
     (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
     (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
       differenceShortRootUnit hij c ∈ H)
@@ -172,12 +124,14 @@ theorem positiveLongRootTransvectionUnit_mem_of_difference
       simp
     have hfirst :
         positiveSumShortRootUnit hir t * positiveLongRootTransvectionUnit i t ∈ H := by
-      have hmem := commutatorElement_mem H (hdifference hir 1) (hpivot t)
+      have hmem := H.commutator_le_self
+        (Subgroup.commutator_mem_commutator (hdifference hir 1) (hpivot t))
       rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit] at hmem
       simpa using hmem
     have hsecond :
         positiveSumShortRootUnit hir t * positiveLongRootTransvectionUnit i (-t) ∈ H := by
-      have hmem := commutatorElement_mem H (hdifference hir (-1)) (hpivot (-t))
+      have hmem := H.commutator_le_self
+        (Subgroup.commutator_mem_commutator (hdifference hir (-1)) (hpivot (-t)))
       rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit] at hmem
       simpa using hmem
     have hquotient := H.mul_mem hfirst (H.inv_mem hsecond)
@@ -191,12 +145,22 @@ theorem positiveLongRootTransvectionUnit_mem_of_difference
               (positiveLongRootTransvectionUnit i t *
                 positiveLongRootTransvectionUnit i t) *
               (positiveSumShortRootUnit hir t)⁻¹ := by
-            rw [_root_.mul_inv_rev, positiveLongRootTransvectionUnit_inv, neg_neg]
+            rw [_root_.mul_inv_rev, show (positiveLongRootTransvectionUnit i (-t))⁻¹ =
+              positiveLongRootTransvectionUnit i t by
+                simpa only [positiveLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_inv,
+                  neg_neg] using
+                  (map_inv (positiveLongRootTransvectionHom (R := R) i)
+                    (Multiplicative.ofAdd (-t))).symm]
             group
         _ = positiveSumShortRootUnit hir t *
               positiveLongRootTransvectionUnit i (t + t) *
               (positiveSumShortRootUnit hir t)⁻¹ := by
-            rw [positiveLongRootTransvectionUnit_mul]
+            rw [show positiveLongRootTransvectionUnit i t *
+                positiveLongRootTransvectionUnit i t =
+              positiveLongRootTransvectionUnit i (t + t) by
+                simpa only [positiveLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_mul] using
+                  ((positiveLongRootTransvectionHom (R := R) i).map_mul
+                    (Multiplicative.ofAdd t) (Multiplicative.ofAdd t)).symm]
         _ = positiveLongRootTransvectionUnit i (t + t) := by
             rw [(commute_positiveSumShortRootUnit_positiveLongRootTransvectionUnit
               hir t (t + t)).eq]
@@ -207,7 +171,7 @@ theorem positiveLongRootTransvectionUnit_mem_of_difference
 /-- If a subgroup contains every difference-root element and one negative long-root subgroup,
 then it contains every negative long-root element, provided `2` is invertible in the coefficient
 ring. -/
-theorem negativeLongRootTransvectionUnit_mem_of_difference
+theorem negativeLongRootTransvectionUnit_mem_of_difference_of_long
     (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
     (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
       differenceShortRootUnit hij c ∈ H)
@@ -225,12 +189,14 @@ theorem negativeLongRootTransvectionUnit_mem_of_difference
     have hri : r ≠ i := Ne.symm hir
     have hfirst :
         negativeSumShortRootUnit hri (-t) * negativeLongRootTransvectionUnit i t ∈ H := by
-      have hmem := commutatorElement_mem H (hdifference hri 1) (hpivot t)
+      have hmem := H.commutator_le_self
+        (Subgroup.commutator_mem_commutator (hdifference hri 1) (hpivot t))
       rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit] at hmem
       simpa using hmem
     have hsecond :
         negativeSumShortRootUnit hri (-t) * negativeLongRootTransvectionUnit i (-t) ∈ H := by
-      have hmem := commutatorElement_mem H (hdifference hri (-1)) (hpivot (-t))
+      have hmem := H.commutator_le_self
+        (Subgroup.commutator_mem_commutator (hdifference hri (-1)) (hpivot (-t)))
       rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit] at hmem
       simpa using hmem
     have hquotient := H.mul_mem hfirst (H.inv_mem hsecond)
@@ -244,12 +210,22 @@ theorem negativeLongRootTransvectionUnit_mem_of_difference
               (negativeLongRootTransvectionUnit i t *
                 negativeLongRootTransvectionUnit i t) *
               (negativeSumShortRootUnit hri (-t))⁻¹ := by
-            rw [_root_.mul_inv_rev, negativeLongRootTransvectionUnit_inv, neg_neg]
+            rw [_root_.mul_inv_rev, show (negativeLongRootTransvectionUnit i (-t))⁻¹ =
+              negativeLongRootTransvectionUnit i t by
+                simpa only [negativeLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_inv,
+                  neg_neg] using
+                  (map_inv (negativeLongRootTransvectionHom (R := R) i)
+                    (Multiplicative.ofAdd (-t))).symm]
             group
         _ = negativeSumShortRootUnit hri (-t) *
               negativeLongRootTransvectionUnit i (t + t) *
               (negativeSumShortRootUnit hri (-t))⁻¹ := by
-            rw [negativeLongRootTransvectionUnit_mul]
+            rw [show negativeLongRootTransvectionUnit i t *
+                negativeLongRootTransvectionUnit i t =
+              negativeLongRootTransvectionUnit i (t + t) by
+                simpa only [negativeLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_mul] using
+                  ((negativeLongRootTransvectionHom (R := R) i).map_mul
+                    (Multiplicative.ofAdd t) (Multiplicative.ofAdd t)).symm]
         _ = negativeLongRootTransvectionUnit i (t + t) := by
             rw [(commute_negativeSumShortRootUnit_negativeLongRootTransvectionUnit
               hri (-t) (t + t)).eq]
@@ -257,30 +233,32 @@ theorem negativeLongRootTransvectionUnit_mem_of_difference
         _ = negativeLongRootTransvectionUnit i c := by rw [ht]
     rwa [heq] at hquotient
 
-/-- If a subgroup contains every difference-root element and every positive long-root element,
-then it contains every positive-sum short-root element. -/
+/-- A positive-sum short-root element lies in a subgroup containing the corresponding
+difference-root element at parameter `1` and the two long-root elements used to isolate it. -/
 theorem positiveSumShortRootUnit_mem_of_difference_of_long
-    (H : Subgroup (GLSymplecticFin m R))
-    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
-      differenceShortRootUnit hij c ∈ H)
-    (hlong : ∀ (i : Fin m) (c : R), positiveLongRootTransvectionUnit i c ∈ H)
-    (hij : i ≠ j) (c : R) : positiveSumShortRootUnit hij c ∈ H := by
-  have hproduct := commutatorElement_mem H (hdifference hij 1) (hlong j c)
+    (H : Subgroup (GLSymplecticFin m R)) (hij : i ≠ j) (c : R)
+    (hdifference : differenceShortRootUnit hij 1 ∈ H)
+    (hlongj : positiveLongRootTransvectionUnit j c ∈ H)
+    (hlongi : positiveLongRootTransvectionUnit i c ∈ H) :
+    positiveSumShortRootUnit hij c ∈ H := by
+  have hproduct := H.commutator_le_self
+    (Subgroup.commutator_mem_commutator hdifference hlongj)
   rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit] at hproduct
-  have hisolate := H.mul_mem hproduct (H.inv_mem (hlong i c))
+  have hisolate := H.mul_mem hproduct (H.inv_mem hlongi)
   simpa only [one_mul, one_pow, mul_assoc, mul_inv_cancel, mul_one] using hisolate
 
-/-- If a subgroup contains every difference-root element and every negative long-root element,
-then it contains every negative-sum short-root element. -/
+/-- A negative-sum short-root element lies in a subgroup containing the corresponding
+difference-root element at parameter `1` and the two long-root elements used to isolate it. -/
 theorem negativeSumShortRootUnit_mem_of_difference_of_long
-    (H : Subgroup (GLSymplecticFin m R))
-    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
-      differenceShortRootUnit hij c ∈ H)
-    (hlong : ∀ (i : Fin m) (c : R), negativeLongRootTransvectionUnit i c ∈ H)
-    (hij : i ≠ j) (c : R) : negativeSumShortRootUnit hij c ∈ H := by
-  have hproduct := commutatorElement_mem H (hdifference hij 1) (hlong i (-c))
+    (H : Subgroup (GLSymplecticFin m R)) (hij : i ≠ j) (c : R)
+    (hdifference : differenceShortRootUnit hij 1 ∈ H)
+    (hlongi : negativeLongRootTransvectionUnit i (-c) ∈ H)
+    (hlongj : negativeLongRootTransvectionUnit j (-c) ∈ H) :
+    negativeSumShortRootUnit hij c ∈ H := by
+  have hproduct := H.commutator_le_self
+    (Subgroup.commutator_mem_commutator hdifference hlongi)
   rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit] at hproduct
-  have hisolate := H.mul_mem hproduct (H.inv_mem (hlong j (-c)))
+  have hisolate := H.mul_mem hproduct (H.inv_mem hlongj)
   simpa only [one_mul, one_pow, neg_neg, mul_assoc, mul_inv_cancel, mul_one] using hisolate
 
 namespace RootSubgroupIndex
@@ -297,9 +275,11 @@ theorem hom_apply_mem_of_difference_of_long
     (hnegative : ∀ c : R, negativeLongRootTransvectionUnit r c ∈ H)
     (root : RootSubgroupIndex m) (c : Multiplicative R) : root.hom c ∈ H := by
   have hp (i : Fin m) (a : R) : positiveLongRootTransvectionUnit i a ∈ H :=
-    positiveLongRootTransvectionUnit_mem_of_difference H h2 r hdifference hpositive i a
+    positiveLongRootTransvectionUnit_mem_of_difference_of_long
+      H h2 r hdifference hpositive i a
   have hn (i : Fin m) (a : R) : negativeLongRootTransvectionUnit i a ∈ H :=
-    negativeLongRootTransvectionUnit_mem_of_difference H h2 r hdifference hnegative i a
+    negativeLongRootTransvectionUnit_mem_of_difference_of_long
+      H h2 r hdifference hnegative i a
   cases root with
   | positiveLong i =>
       simpa only [hom_positiveLong, positiveLongRootTransvectionHom_apply] using hp i c.toAdd
@@ -309,10 +289,12 @@ theorem hom_apply_mem_of_difference_of_long
       simpa only [hom_difference, differenceShortRootHom_apply] using hdifference hij c.toAdd
   | positiveSum i j hij =>
       simpa only [hom_positiveSum, positiveSumShortRootHom_apply] using
-        positiveSumShortRootUnit_mem_of_difference_of_long H hdifference hp hij.ne c.toAdd
+        positiveSumShortRootUnit_mem_of_difference_of_long H hij.ne c.toAdd
+          (hdifference hij.ne 1) (hp j c.toAdd) (hp i c.toAdd)
   | negativeSum i j hij =>
       simpa only [hom_negativeSum, negativeSumShortRootHom_apply] using
-        negativeSumShortRootUnit_mem_of_difference_of_long H hdifference hn hij.ne c.toAdd
+        negativeSumShortRootUnit_mem_of_difference_of_long H hij.ne c.toAdd
+          (hdifference hij.ne 1) (hn i (-c.toAdd)) (hn j (-c.toAdd))
 
 end RootSubgroupIndex
 

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
@@ -1,0 +1,319 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.LinearAlgebra.Matrix.GeneralLinearGroup.Symplectic.ChevalleyRelations
+
+/-!
+# Generating long and sum roots in the symplectic group
+
+This file develops the root-subgroup generation step for the standard type-`C` symplectic group
+beyond its type-`A` subsystem of difference roots. Over a commutative ring in which `2` is a unit,
+the difference-root subgroups and one pair of opposite long-root subgroups generate every long and
+sum root subgroup.
+
+The long roots are extracted from the multiply-laced Chevalley relation by comparing the parameters
+`1` and `-1`:
+
+```text
+⁅x_{eᵢ-eⱼ}(1),  x_{2eⱼ}(t)⁆  = x_{eᵢ+eⱼ}(t) x_{2eᵢ}(t),
+⁅x_{eᵢ-eⱼ}(-1), x_{2eⱼ}(-t)⁆ = x_{eᵢ+eⱼ}(t) x_{2eᵢ}(-t).
+```
+
+Their quotient is `x_{2eᵢ}(2t)`, since the displayed sum-root subgroup commutes with the long
+root subgroup. Invertibility of `2` makes this every parameter. The negative roots follow from the
+opposite relation, and the sum roots are then isolated from either commutator formula.
+
+## Main results
+
+* `TauCeti.GLSymplecticFin.positiveLongRootTransvectionUnit_mem_of_difference` and its negative
+  analogue propagate one long-root subgroup to every index.
+* `TauCeti.GLSymplecticFin.positiveSumShortRootUnit_mem_of_difference_of_long` and its negative
+  analogue generate the two sum-root families.
+* `TauCeti.GLSymplecticFin.RootSubgroupIndex.hom_apply_mem_of_difference_of_long` packages the
+  result for every standard symplectic root subgroup.
+
+## References
+
+* R. W. Carter, *Simple Groups of Lie Type* (1972), §5.2.
+* R. Steinberg, *Lectures on Chevalley Groups* (1968), §§3--4.
+
+This advances Layer 9, "The Chevalley--Demazure construction", of
+`TauCetiRoadmap/ReductiveGroups/README.md`: together with generation of all difference roots from
+the numbered adjacent roots, it supplies every root subgroup required for the reverse inclusion of
+the full-weight type-`C` carrier in the standard symplectic group. The restriction that `2` be a
+unit matches the odd-characteristic type-`C` branch of milestone L0 in
+`TauCetiRoadmap/CFSGStatement/README.md`.
+-/
+
+public section
+
+open Matrix
+open scoped commutatorElement
+
+namespace TauCeti.GLSymplecticFin
+
+universe u
+
+variable {R : Type u} [CommRing R] {m : ℕ} {i j : Fin m}
+
+private theorem positiveLongRootTransvectionUnit_mul (i : Fin m) (a b : R) :
+    positiveLongRootTransvectionUnit i a * positiveLongRootTransvectionUnit i b =
+      positiveLongRootTransvectionUnit i (a + b) := by
+  apply (GLSymplecticFin m R).subtype_injective
+  change
+    (positiveLongRootTransvectionUnit i a : GL (Fin (m + m)) R) *
+        (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) =
+      (positiveLongRootTransvectionUnit i (a + b) : GL (Fin (m + m)) R)
+  rw [coe_positiveLongRootTransvectionUnit,
+    coe_positiveLongRootTransvectionUnit, coe_positiveLongRootTransvectionUnit,
+    transvectionUnit_add]
+
+private theorem positiveLongRootTransvectionUnit_inv (i : Fin m) (a : R) :
+    (positiveLongRootTransvectionUnit i a)⁻¹ =
+      positiveLongRootTransvectionUnit i (-a) := by
+  apply (GLSymplecticFin m R).subtype_injective
+  change ((positiveLongRootTransvectionUnit i a : GL (Fin (m + m)) R))⁻¹ =
+    (positiveLongRootTransvectionUnit i (-a) : GL (Fin (m + m)) R)
+  rw [coe_positiveLongRootTransvectionUnit,
+    coe_positiveLongRootTransvectionUnit, transvectionUnit_inv]
+
+private theorem negativeLongRootTransvectionUnit_mul (i : Fin m) (a b : R) :
+    negativeLongRootTransvectionUnit i a * negativeLongRootTransvectionUnit i b =
+      negativeLongRootTransvectionUnit i (a + b) := by
+  apply (GLSymplecticFin m R).subtype_injective
+  change
+    (negativeLongRootTransvectionUnit i a : GL (Fin (m + m)) R) *
+        (negativeLongRootTransvectionUnit i b : GL (Fin (m + m)) R) =
+      (negativeLongRootTransvectionUnit i (a + b) : GL (Fin (m + m)) R)
+  rw [coe_negativeLongRootTransvectionUnit,
+    coe_negativeLongRootTransvectionUnit, coe_negativeLongRootTransvectionUnit,
+    transvectionUnit_add]
+
+private theorem negativeLongRootTransvectionUnit_inv (i : Fin m) (a : R) :
+    (negativeLongRootTransvectionUnit i a)⁻¹ =
+      negativeLongRootTransvectionUnit i (-a) := by
+  apply (GLSymplecticFin m R).subtype_injective
+  change ((negativeLongRootTransvectionUnit i a : GL (Fin (m + m)) R))⁻¹ =
+    (negativeLongRootTransvectionUnit i (-a) : GL (Fin (m + m)) R)
+  rw [coe_negativeLongRootTransvectionUnit,
+    coe_negativeLongRootTransvectionUnit, transvectionUnit_inv]
+
+private theorem commute_positiveSumShortRootUnit_positiveLongRootTransvectionUnit
+    (hij : i ≠ j) (a b : R) :
+  Commute (positiveSumShortRootUnit hij a) (positiveLongRootTransvectionUnit i b) := by
+  apply (GLSymplecticFin m R).subtype_injective
+  change
+    (positiveSumShortRootUnit hij a : GL (Fin (m + m)) R) *
+        (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) =
+      (positiveLongRootTransvectionUnit i b : GL (Fin (m + m)) R) *
+        (positiveSumShortRootUnit hij a : GL (Fin (m + m)) R)
+  rw [coe_positiveSumShortRootUnit,
+    coe_positiveLongRootTransvectionUnit]
+  have hIL : Commute (transvectionUnit (finSumFinEquiv_inl_ne_inr i j) a)
+      (transvectionUnit (finSumFinEquiv_inl_ne_inr i i) b) :=
+    commute_transvectionUnit (finSumFinEquiv_inl_ne_inr i j)
+      (finSumFinEquiv_inl_ne_inr i i) (finSumFinEquiv_inr_ne_inl j i)
+      (finSumFinEquiv_inr_ne_inl i i) a b
+  have hJL : Commute (transvectionUnit (finSumFinEquiv_inl_ne_inr j i) a)
+      (transvectionUnit (finSumFinEquiv_inl_ne_inr i i) b) :=
+    commute_transvectionUnit (finSumFinEquiv_inl_ne_inr j i)
+      (finSumFinEquiv_inl_ne_inr i i) (finSumFinEquiv_inr_ne_inl i i)
+      (finSumFinEquiv_inr_ne_inl i j) a b
+  exact hIL.mul_left hJL
+
+private theorem commute_negativeSumShortRootUnit_negativeLongRootTransvectionUnit
+    (hij : i ≠ j) (a b : R) :
+    Commute (negativeSumShortRootUnit hij a) (negativeLongRootTransvectionUnit j b) := by
+  apply (GLSymplecticFin m R).subtype_injective
+  change
+    (negativeSumShortRootUnit hij a : GL (Fin (m + m)) R) *
+        (negativeLongRootTransvectionUnit j b : GL (Fin (m + m)) R) =
+      (negativeLongRootTransvectionUnit j b : GL (Fin (m + m)) R) *
+        (negativeSumShortRootUnit hij a : GL (Fin (m + m)) R)
+  rw [coe_negativeSumShortRootUnit, coe_negativeLongRootTransvectionUnit]
+  have hIL : Commute (transvectionUnit (finSumFinEquiv_inr_ne_inl i j) a)
+      (transvectionUnit (finSumFinEquiv_inr_ne_inl j j) b) :=
+    commute_transvectionUnit (finSumFinEquiv_inr_ne_inl i j)
+      (finSumFinEquiv_inr_ne_inl j j) (finSumFinEquiv_inl_ne_inr j j)
+      (finSumFinEquiv_inl_ne_inr j i) a b
+  have hJL : Commute (transvectionUnit (finSumFinEquiv_inr_ne_inl j i) a)
+      (transvectionUnit (finSumFinEquiv_inr_ne_inl j j) b) :=
+    commute_transvectionUnit (finSumFinEquiv_inr_ne_inl j i)
+      (finSumFinEquiv_inr_ne_inl j j) (finSumFinEquiv_inl_ne_inr i j)
+      (finSumFinEquiv_inl_ne_inr j j) a b
+  exact hIL.mul_left hJL
+
+private theorem commutatorElement_mem (H : Subgroup (GLSymplecticFin m R))
+    {x y : GLSymplecticFin m R} (hx : x ∈ H) (hy : y ∈ H) : ⁅x, y⁆ ∈ H := by
+  rw [commutatorElement_def]
+  exact H.mul_mem (H.mul_mem (H.mul_mem hx hy) (H.inv_mem hx)) (H.inv_mem hy)
+
+/-- If a subgroup contains every difference-root element and one positive long-root subgroup,
+then it contains every positive long-root element, provided `2` is invertible in the coefficient
+ring. -/
+theorem positiveLongRootTransvectionUnit_mem_of_difference
+    (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
+    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
+      differenceShortRootUnit hij c ∈ H)
+    (hpivot : ∀ c : R, positiveLongRootTransvectionUnit r c ∈ H)
+    (i : Fin m) (c : R) : positiveLongRootTransvectionUnit i c ∈ H := by
+  by_cases hir : i = r
+  · subst i
+    exact hpivot c
+  · obtain ⟨u, hu⟩ := h2
+    let t : R := ((u⁻¹ : Rˣ) : R) * c
+    have ht : t + t = c := by
+      dsimp only [t]
+      rw [← two_mul, ← hu]
+      simp
+    have hfirst :
+        positiveSumShortRootUnit hir t * positiveLongRootTransvectionUnit i t ∈ H := by
+      have hmem := commutatorElement_mem H (hdifference hir 1) (hpivot t)
+      rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit] at hmem
+      simpa using hmem
+    have hsecond :
+        positiveSumShortRootUnit hir t * positiveLongRootTransvectionUnit i (-t) ∈ H := by
+      have hmem := commutatorElement_mem H (hdifference hir (-1)) (hpivot (-t))
+      rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit] at hmem
+      simpa using hmem
+    have hquotient := H.mul_mem hfirst (H.inv_mem hsecond)
+    have heq :
+        (positiveSumShortRootUnit hir t * positiveLongRootTransvectionUnit i t) *
+            (positiveSumShortRootUnit hir t *
+              positiveLongRootTransvectionUnit i (-t))⁻¹ =
+          positiveLongRootTransvectionUnit i c := by
+      calc
+        _ = positiveSumShortRootUnit hir t *
+              (positiveLongRootTransvectionUnit i t *
+                positiveLongRootTransvectionUnit i t) *
+              (positiveSumShortRootUnit hir t)⁻¹ := by
+            rw [_root_.mul_inv_rev, positiveLongRootTransvectionUnit_inv, neg_neg]
+            group
+        _ = positiveSumShortRootUnit hir t *
+              positiveLongRootTransvectionUnit i (t + t) *
+              (positiveSumShortRootUnit hir t)⁻¹ := by
+            rw [positiveLongRootTransvectionUnit_mul]
+        _ = positiveLongRootTransvectionUnit i (t + t) := by
+            rw [(commute_positiveSumShortRootUnit_positiveLongRootTransvectionUnit
+              hir t (t + t)).eq]
+            group
+        _ = positiveLongRootTransvectionUnit i c := by rw [ht]
+    rwa [heq] at hquotient
+
+/-- If a subgroup contains every difference-root element and one negative long-root subgroup,
+then it contains every negative long-root element, provided `2` is invertible in the coefficient
+ring. -/
+theorem negativeLongRootTransvectionUnit_mem_of_difference
+    (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
+    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
+      differenceShortRootUnit hij c ∈ H)
+    (hpivot : ∀ c : R, negativeLongRootTransvectionUnit r c ∈ H)
+    (i : Fin m) (c : R) : negativeLongRootTransvectionUnit i c ∈ H := by
+  by_cases hir : i = r
+  · subst i
+    exact hpivot c
+  · obtain ⟨u, hu⟩ := h2
+    let t : R := ((u⁻¹ : Rˣ) : R) * c
+    have ht : t + t = c := by
+      dsimp only [t]
+      rw [← two_mul, ← hu]
+      simp
+    have hri : r ≠ i := Ne.symm hir
+    have hfirst :
+        negativeSumShortRootUnit hri (-t) * negativeLongRootTransvectionUnit i t ∈ H := by
+      have hmem := commutatorElement_mem H (hdifference hri 1) (hpivot t)
+      rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit] at hmem
+      simpa using hmem
+    have hsecond :
+        negativeSumShortRootUnit hri (-t) * negativeLongRootTransvectionUnit i (-t) ∈ H := by
+      have hmem := commutatorElement_mem H (hdifference hri (-1)) (hpivot (-t))
+      rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit] at hmem
+      simpa using hmem
+    have hquotient := H.mul_mem hfirst (H.inv_mem hsecond)
+    have heq :
+        (negativeSumShortRootUnit hri (-t) * negativeLongRootTransvectionUnit i t) *
+            (negativeSumShortRootUnit hri (-t) *
+              negativeLongRootTransvectionUnit i (-t))⁻¹ =
+          negativeLongRootTransvectionUnit i c := by
+      calc
+        _ = negativeSumShortRootUnit hri (-t) *
+              (negativeLongRootTransvectionUnit i t *
+                negativeLongRootTransvectionUnit i t) *
+              (negativeSumShortRootUnit hri (-t))⁻¹ := by
+            rw [_root_.mul_inv_rev, negativeLongRootTransvectionUnit_inv, neg_neg]
+            group
+        _ = negativeSumShortRootUnit hri (-t) *
+              negativeLongRootTransvectionUnit i (t + t) *
+              (negativeSumShortRootUnit hri (-t))⁻¹ := by
+            rw [negativeLongRootTransvectionUnit_mul]
+        _ = negativeLongRootTransvectionUnit i (t + t) := by
+            rw [(commute_negativeSumShortRootUnit_negativeLongRootTransvectionUnit
+              hri (-t) (t + t)).eq]
+            group
+        _ = negativeLongRootTransvectionUnit i c := by rw [ht]
+    rwa [heq] at hquotient
+
+/-- If a subgroup contains every difference-root element and every positive long-root element,
+then it contains every positive-sum short-root element. -/
+theorem positiveSumShortRootUnit_mem_of_difference_of_long
+    (H : Subgroup (GLSymplecticFin m R))
+    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
+      differenceShortRootUnit hij c ∈ H)
+    (hlong : ∀ (i : Fin m) (c : R), positiveLongRootTransvectionUnit i c ∈ H)
+    (hij : i ≠ j) (c : R) : positiveSumShortRootUnit hij c ∈ H := by
+  have hproduct := commutatorElement_mem H (hdifference hij 1) (hlong j c)
+  rw [commutatorElement_differenceShortRootUnit_positiveLongRootTransvectionUnit] at hproduct
+  have hisolate := H.mul_mem hproduct (H.inv_mem (hlong i c))
+  simpa only [one_mul, one_pow, mul_assoc, mul_inv_cancel, mul_one] using hisolate
+
+/-- If a subgroup contains every difference-root element and every negative long-root element,
+then it contains every negative-sum short-root element. -/
+theorem negativeSumShortRootUnit_mem_of_difference_of_long
+    (H : Subgroup (GLSymplecticFin m R))
+    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
+      differenceShortRootUnit hij c ∈ H)
+    (hlong : ∀ (i : Fin m) (c : R), negativeLongRootTransvectionUnit i c ∈ H)
+    (hij : i ≠ j) (c : R) : negativeSumShortRootUnit hij c ∈ H := by
+  have hproduct := commutatorElement_mem H (hdifference hij 1) (hlong i (-c))
+  rw [commutatorElement_differenceShortRootUnit_negativeLongRootTransvectionUnit] at hproduct
+  have hisolate := H.mul_mem hproduct (H.inv_mem (hlong j (-c)))
+  simpa only [one_mul, one_pow, neg_neg, mul_assoc, mul_inv_cancel, mul_one] using hisolate
+
+namespace RootSubgroupIndex
+
+/-- **Difference roots and one opposite pair of long-root subgroups generate every symplectic root
+subgroup when `2` is invertible.** More precisely, if `H` contains every difference-root element
+and both long-root subgroups at one index, then the value of every root one-parameter subgroup lies
+in `H`. -/
+theorem hom_apply_mem_of_difference_of_long
+    (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
+    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
+      differenceShortRootUnit hij c ∈ H)
+    (hpositive : ∀ c : R, positiveLongRootTransvectionUnit r c ∈ H)
+    (hnegative : ∀ c : R, negativeLongRootTransvectionUnit r c ∈ H)
+    (root : RootSubgroupIndex m) (c : Multiplicative R) : root.hom c ∈ H := by
+  have hp (i : Fin m) (a : R) : positiveLongRootTransvectionUnit i a ∈ H :=
+    positiveLongRootTransvectionUnit_mem_of_difference H h2 r hdifference hpositive i a
+  have hn (i : Fin m) (a : R) : negativeLongRootTransvectionUnit i a ∈ H :=
+    negativeLongRootTransvectionUnit_mem_of_difference H h2 r hdifference hnegative i a
+  cases root with
+  | positiveLong i =>
+      simpa only [hom_positiveLong, positiveLongRootTransvectionHom_apply] using hp i c.toAdd
+  | negativeLong i =>
+      simpa only [hom_negativeLong, negativeLongRootTransvectionHom_apply] using hn i c.toAdd
+  | difference i j hij =>
+      simpa only [hom_difference, differenceShortRootHom_apply] using hdifference hij c.toAdd
+  | positiveSum i j hij =>
+      simpa only [hom_positiveSum, positiveSumShortRootHom_apply] using
+        positiveSumShortRootUnit_mem_of_difference_of_long H hdifference hp hij.ne c.toAdd
+  | negativeSum i j hij =>
+      simpa only [hom_negativeSum, negativeSumShortRootHom_apply] using
+        negativeSumShortRootUnit_mem_of_difference_of_long H hdifference hn hij.ne c.toAdd
+
+end RootSubgroupIndex
+
+end TauCeti.GLSymplecticFin

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
@@ -104,13 +104,13 @@ private theorem commute_negativeSumShortRootUnit_negativeLongRootTransvectionUni
     exact hIL.mul_left hJL
   exact (GLSymplecticFin m R).subtype_injective hambient
 
-/-- If a subgroup contains every difference-root element and one positive long-root subgroup,
-then it contains every positive long-root element, provided `2` is invertible in the coefficient
-ring. -/
+/-- If a subgroup contains every difference-root element pointing to `r` and the positive
+long-root subgroup at `r`, then it contains every positive long-root element, provided `2` is
+invertible in the coefficient ring. -/
 theorem positiveLongRootTransvectionUnit_mem_of_difference_of_long
     (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
-    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
-      differenceShortRootUnit hij c ∈ H)
+    (hdifference : ∀ {i : Fin m} (hir : i ≠ r) (c : R),
+      differenceShortRootUnit hir c ∈ H)
     (hpivot : ∀ c : R, positiveLongRootTransvectionUnit r c ∈ H)
     (i : Fin m) (c : R) : positiveLongRootTransvectionUnit i c ∈ H := by
   by_cases hir : i = r
@@ -158,13 +158,13 @@ theorem positiveLongRootTransvectionUnit_mem_of_difference_of_long
         _ = positiveLongRootTransvectionUnit i c := by rw [ht]
     rwa [heq] at hquotient
 
-/-- If a subgroup contains every difference-root element and one negative long-root subgroup,
-then it contains every negative long-root element, provided `2` is invertible in the coefficient
-ring. -/
+/-- If a subgroup contains every difference-root element pointing from `r` and the negative
+long-root subgroup at `r`, then it contains every negative long-root element, provided `2` is
+invertible in the coefficient ring. -/
 theorem negativeLongRootTransvectionUnit_mem_of_difference_of_long
     (H : Subgroup (GLSymplecticFin m R)) (h2 : IsUnit (2 : R)) (r : Fin m)
-    (hdifference : ∀ {i j : Fin m} (hij : i ≠ j) (c : R),
-      differenceShortRootUnit hij c ∈ H)
+    (hdifference : ∀ {i : Fin m} (hri : r ≠ i) (c : R),
+      differenceShortRootUnit hri c ∈ H)
     (hpivot : ∀ c : R, negativeLongRootTransvectionUnit r c ∈ H)
     (i : Fin m) (c : R) : negativeLongRootTransvectionUnit i c ∈ H := by
   by_cases hir : i = r

--- a/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
+++ b/TauCeti/LinearAlgebra/Matrix/GeneralLinearGroup/Symplectic/RootGeneration.lean
@@ -145,22 +145,12 @@ theorem positiveLongRootTransvectionUnit_mem_of_difference_of_long
               (positiveLongRootTransvectionUnit i t *
                 positiveLongRootTransvectionUnit i t) *
               (positiveSumShortRootUnit hir t)⁻¹ := by
-            rw [_root_.mul_inv_rev, show (positiveLongRootTransvectionUnit i (-t))⁻¹ =
-              positiveLongRootTransvectionUnit i t by
-                simpa only [positiveLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_inv,
-                  neg_neg] using
-                  (map_inv (positiveLongRootTransvectionHom (R := R) i)
-                    (Multiplicative.ofAdd (-t))).symm]
+            rw [_root_.mul_inv_rev, positiveLongRootTransvectionUnit_inv, neg_neg]
             group
         _ = positiveSumShortRootUnit hir t *
               positiveLongRootTransvectionUnit i (t + t) *
               (positiveSumShortRootUnit hir t)⁻¹ := by
-            rw [show positiveLongRootTransvectionUnit i t *
-                positiveLongRootTransvectionUnit i t =
-              positiveLongRootTransvectionUnit i (t + t) by
-                simpa only [positiveLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_mul] using
-                  ((positiveLongRootTransvectionHom (R := R) i).map_mul
-                    (Multiplicative.ofAdd t) (Multiplicative.ofAdd t)).symm]
+            rw [← positiveLongRootTransvectionUnit_add]
         _ = positiveLongRootTransvectionUnit i (t + t) := by
             rw [(commute_positiveSumShortRootUnit_positiveLongRootTransvectionUnit
               hir t (t + t)).eq]
@@ -210,22 +200,12 @@ theorem negativeLongRootTransvectionUnit_mem_of_difference_of_long
               (negativeLongRootTransvectionUnit i t *
                 negativeLongRootTransvectionUnit i t) *
               (negativeSumShortRootUnit hri (-t))⁻¹ := by
-            rw [_root_.mul_inv_rev, show (negativeLongRootTransvectionUnit i (-t))⁻¹ =
-              negativeLongRootTransvectionUnit i t by
-                simpa only [negativeLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_inv,
-                  neg_neg] using
-                  (map_inv (negativeLongRootTransvectionHom (R := R) i)
-                    (Multiplicative.ofAdd (-t))).symm]
+            rw [_root_.mul_inv_rev, negativeLongRootTransvectionUnit_inv, neg_neg]
             group
         _ = negativeSumShortRootUnit hri (-t) *
               negativeLongRootTransvectionUnit i (t + t) *
               (negativeSumShortRootUnit hri (-t))⁻¹ := by
-            rw [show negativeLongRootTransvectionUnit i t *
-                negativeLongRootTransvectionUnit i t =
-              negativeLongRootTransvectionUnit i (t + t) by
-                simpa only [negativeLongRootTransvectionHom_apply, toAdd_ofAdd, toAdd_mul] using
-                  ((negativeLongRootTransvectionHom (R := R) i).map_mul
-                    (Multiplicative.ofAdd t) (Multiplicative.ofAdd t)).symm]
+            rw [← negativeLongRootTransvectionUnit_add]
         _ = negativeLongRootTransvectionUnit i (t + t) := by
             rw [(commute_negativeSumShortRootUnit_negativeLongRootTransvectionUnit
               hri (-t) (t + t)).eq]


### PR DESCRIPTION
This PR proves that, over a commutative ring in which `2` is a unit, every standard type-`C` long and sum root subgroup lies in a subgroup containing all difference roots and one opposite pair of long-root subgroups. It extracts arbitrary long-root parameters by comparing the multiply-laced Chevalley commutators at `1` and `-1`, isolates both sum-root families, and packages the result through `RootSubgroupIndex.hom`. It also adds the missing characteristic simplification lemmas for the three short-root constructors.

The exact roadmap target is ReductiveGroups Layer 9, “The Chevalley–Demazure construction,” specifically the reverse-generation step for the explicit full-weight type-`C` symplectic carrier. The designated consumer milestone is CFSGStatement L0, where the odd-characteristic type-`C` entry of `ValidLieTypeIndex.AmbientGroup` consumes that pinned carrier. The dependency edge is: CFSGStatement L0 type-`C` ambient group ← ReductiveGroups Layer 9 explicit pinned symplectic carrier ← generation of all standard root subgroups proved here.

This is the most effective currently unclaimed step because the existing Chevalley relations already compute the required multiply-laced commutators, while the adjacent-difference-root propagation is separately in flight. After this PR, that propagation can supply the difference-root hypothesis; what remains for this carrier is to prove field-valued symplectic generation by the resulting root subgroups and lift the equality to the scheme, reductivity, root datum, and pinning data required by Layer 9.

The new module contains 319 lines of documented, ring-general, sorry-free proofs and reuses Tau Ceti's symplectic transvection and Chevalley-commutator infrastructure. No Mathlib implementation is copied or vendored.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"type-c-long-sum-root-generation"}-->

🤖 Prepared with Codex
