### PR TITLE
feat: identify points of the base-changed Geck carrier

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/BaseChange.lean
@@ -31,6 +31,8 @@ the original points evaluated on `K`-algebras.
 * `CommHopfAlgCat.baseChangeFunctor`: functorial base change on commutative Hopf algebras.
 * `CommHopfAlgCat.baseChangePointsMulEquiv`: the inherited point equivalence
   `(K ⊗[k] H →ₐ[K] A) ≃* (H →ₐ[k] A)`.
+* `CommHopfAlgCat.baseChangeIsoPointsMulEquiv`: the same equivalence for a Hopf `K`-algebra
+  presented as a scalar extension by an isomorphism `L ≅ K ⊗[k] H`.
 
 ## References
 
@@ -207,6 +209,51 @@ lemma baseChangePointsMulEquiv_mapDomain {H L : _root_.CommHopfAlgCat.{v} k}
   simpa [baseChangePointsMulEquiv, hom_baseChangeMap]
     using AlgHom.baseChangePointsMulEquiv_symm_mapDomain (k := k) (K := K)
       (A := H) (B := L) (R := A) φ.hom f
+
+variable {H : _root_.CommHopfAlgCat.{v} k} {L : _root_.CommHopfAlgCat.{max w v} K}
+
+/-- **The points of a commutative Hopf `K`-algebra presented as a scalar extension.** An
+isomorphism `e : L ≅ K ⊗[k] H` identifies the points of `L` on a value algebra `A` with the
+points of `H` on `A` with its scalars restricted to `k`; the carrier `L` need not be the tensor
+product itself. This is `baseChangePointsMulEquiv` preceded by transport along `e`. -/
+noncomputable def baseChangeIsoPointsMulEquiv (e : L ≅ baseChange (K := K) H)
+    (A : CommAlgCat.{x} K) :
+    HopfAlgebra.points (R := K) (H := L) A ≃*
+      HopfAlgebra.points (R := k) (H := H)
+        (_root_.TauCeti.CommAlgCat.restrictScalarsObj (algebraMap k K) A) :=
+  (AlgHom.mapDomainMulEquiv (A := A) (_root_.CommHopfAlgCat.ofIso e.symm)).trans
+    (baseChangePointsMulEquiv (K := K) A H)
+
+/-- The presented point equivalence evaluates a point of `L` at the image of `1 ⊗ h` under the
+presenting isomorphism. -/
+@[simp]
+lemma baseChangeIsoPointsMulEquiv_apply_apply (e : L ≅ baseChange (K := K) H)
+    (A : CommAlgCat.{x} K) (f : HopfAlgebra.points (R := K) (H := L) A) (h : H) :
+    (baseChangeIsoPointsMulEquiv e A f).ofConv h = f.ofConv (e.inv (1 ⊗ₜ[k] h)) := by
+  rw [baseChangeIsoPointsMulEquiv, MulEquiv.trans_apply, baseChangePointsMulEquiv_apply_apply,
+    AlgHom.mapDomainMulEquiv_apply, AlgHom.mapDomain_apply_apply]
+  exact congrArg f.ofConv (_root_.CommHopfAlgCat.ofIso_apply e.symm _)
+
+/-- The presented point equivalence is natural in the value algebra. -/
+lemma baseChangeIsoPointsMulEquiv_mapPoints (e : L ≅ baseChange (K := K) H)
+    {A B : CommAlgCat.{x} K} (χ : A ⟶ B)
+    (f : HopfAlgebra.points (R := K) (H := L) A) :
+    baseChangeIsoPointsMulEquiv e B (HopfAlgebra.mapPoints (H := L) χ f) =
+      HopfAlgebra.mapPoints (H := H)
+        ((_root_.TauCeti.CommAlgCat.restrictScalars (algebraMap k K)).map χ)
+        (baseChangeIsoPointsMulEquiv e A f) := by
+  -- Transport along `e` is a pre-composition in the coordinate Hopf algebra, so it commutes with
+  -- the post-composition by `χ` in the value algebra. The bundled `mapDomainMulEquiv` and
+  -- `mapPoints` are unfolded to `mapDomain` and `mapValue` to reach `mapValue_mapDomain`.
+  have h : AlgHom.mapDomainMulEquiv (A := B) (_root_.CommHopfAlgCat.ofIso e.symm)
+        (HopfAlgebra.mapPoints (H := L) χ f) =
+      HopfAlgebra.mapPoints (H := baseChange (K := K) H) χ
+        (AlgHom.mapDomainMulEquiv (A := A) (_root_.CommHopfAlgCat.ofIso e.symm) f) := by
+    simp only [AlgHom.mapDomainMulEquiv_apply, HopfAlgebra.mapPoints]
+    exact DFunLike.congr_fun
+      (AlgHom.mapValue_mapDomain (_root_.CommHopfAlgCat.ofIso e.symm).toBialgHom χ.hom) f
+  simp only [baseChangeIsoPointsMulEquiv, MulEquiv.trans_apply, h]
+  rw [baseChangePointsMulEquiv_mapValue]
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/HopfIdealPoints/BaseChange.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/HopfIdealPoints/BaseChange.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.Coordinate.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.Functor
+
+/-!
+# Base change of the matrix points cut out by a Hopf ideal
+
+A closed subgroup scheme of `GLₙ/A` is often built over an extension `A` of `k` by a Hopf ideal
+`J` of `O(GLₙ/A)` together with an isomorphism identifying the quotient it cuts out with the
+scalar extension of the quotient by a Hopf ideal `I` of `O(GLₙ/k)`. The points of such a presented
+quotient are already the points of the quotient over `k` on the value algebra with its scalars
+restricted to `k`, by `CommHopfAlgCat.baseChangeIsoPointsMulEquiv`. This file records that this
+identification preserves the ambient invertible matrix.
+
+The only input is the commuting square relating the two quotient maps through the general-linear
+coordinate base-change isomorphism. Nothing here chooses either ideal, so any carrier presented
+this way — in particular an explicit pinned Chevalley carrier and its scalar extension — can
+instantiate the result below.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.pointsMulEquiv_quotientPointsHom_baseChangeIsoPointsMulEquiv`: the
+  presented base-change point equivalence preserves the ambient invertible matrix.
+
+## Roadmap
+
+This advances the carrier-independent half of the base-change and points targets in Layer 9 of
+`TauCetiRoadmap/ReductiveGroups/README.md`, whose consumer is milestone L0 of
+`TauCetiRoadmap/CFSGStatement/README.md`. It identifies no particular carrier with the pinned
+simply connected group.
+-/
+
+public section
+
+open CategoryTheory TensorProduct
+
+namespace TauCeti.GeneralLinear
+
+universe u v w
+
+noncomputable section
+
+variable {k : Type u} [CommRing k] {A : Type max u v} [CommRing A] [Algebra k A]
+variable (n : ℕ)
+variable (I : HopfIdeal k (coordinateHopfAlgebra k n))
+variable (J : HopfIdeal A (coordinateHopfAlgebra A n))
+variable (e : CommHopfAlgCat.quotient (coordinateHopfAlgebra A n) J ≅
+  CommHopfAlgCat.baseChange (K := A) (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I))
+variable (he : CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra A n) J ≫ e.hom =
+  (coordinateHopfAlgebraBaseChangeIso k A n).inv ≫
+    CommHopfAlgCat.baseChangeMap (CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k n) I))
+
+include he in
+/-- The inverse presenting isomorphism sends an extended generic-matrix coordinate of the quotient
+over `k` to the corresponding coordinate of the quotient formed directly over `A`.
+
+This is stated in terms of `CommHopfAlgCat.mkQuotient`, which `simp` unfolds to
+`Ideal.Quotient.mk`, so it is a `rw` lemma rather than a `simp` one. -/
+private theorem iso_inv_one_tmul_mkQuotient_X (i j : Fin n) :
+    e.inv
+        (1 ⊗ₜ[k] (CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k n) I).hom
+          (coordinateHopfAlgebraAlgEquiv k n
+            (coordinateRingMap k n (MvPolynomial.X (i, j))))) =
+      (CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra A n) J).hom
+        (coordinateHopfAlgebraAlgEquiv A n
+          (coordinateRingMap A n (MvPolynomial.X (i, j)))) := by
+  symm
+  have h := coordinateHopfAlgebraBaseChangeMap_X k A n
+    (CommHopfAlgCat.quotient (coordinateHopfAlgebra k n) I)
+    (CommHopfAlgCat.quotient (coordinateHopfAlgebra A n) J)
+    (CommHopfAlgCat.mkQuotient (coordinateHopfAlgebra k n) I) e.symm i j
+  rw [← Category.assoc, ← he] at h
+  simpa only [Iso.symm_hom, Category.assoc, Iso.hom_inv_id, Category.comp_id] using h
+
+include he in
+/-- **The presented base-change point equivalence preserves the ambient invertible matrix.** Both
+sides read the same matrix over the value algebra, one through the quotient over `k` and one
+through the quotient over `A`. -/
+theorem pointsMulEquiv_quotientPointsHom_baseChangeIsoPointsMulEquiv (B : CommAlgCat.{w} A)
+    (q : HopfAlgebra.points (R := A)
+      (H := CommHopfAlgCat.quotient (coordinateHopfAlgebra A n) J) B) :
+    pointsMulEquiv n
+        (CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra k n) I
+          (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap k A) B)
+          (CommHopfAlgCat.baseChangeIsoPointsMulEquiv e B q)) =
+      pointsMulEquiv n
+        (CommHopfAlgCat.quotientPointsHom (coordinateHopfAlgebra A n) J B q) := by
+  refine Matrix.GeneralLinearGroup.ext fun i j ↦ ?_
+  simp only [pointsMulEquiv_apply, pointToGeneralLinear_apply]
+  rw [CommHopfAlgCat.quotientPointsHom_apply_apply,
+    CommHopfAlgCat.quotientPointsHom_apply_apply, ← CommHopfAlgCat.mkQuotient_apply,
+    ← CommHopfAlgCat.mkQuotient_apply, CommHopfAlgCat.baseChangeIsoPointsMulEquiv_apply_apply]
+  exact congrArg q.ofConv (iso_inv_one_tmul_mkQuotient_X n I J e he i j)
+
+end
+
+end TauCeti.GeneralLinear

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.HopfIdealPoints.BaseChange
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.GeneralLinearBaseChange
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.GroupScheme
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.PointsFunctor
@@ -183,50 +184,15 @@ theorem mkQuotient_comp_geckBaseChangeCoordinateIso_hom :
     geckIntegralCoordinateTransportIso,
     t.baseChangeMap_mkQuotient_comp_eqToIso ht A (t.geckDefiningIdeal_def ht).symm]
 
-/-- The inverse base-change coordinate isomorphism sends an extended integral generic-matrix
-coordinate to the corresponding coordinate of the quotient constructed directly over `A`.
-
-This is stated in terms of `CommHopfAlgCat.mkQuotient`, which `simp` unfolds to
-`Ideal.Quotient.mk`, so it is a `rw` lemma rather than a `simp` one. -/
-private theorem geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X
-    (i j : Fin (t.geckDim ht)) :
-    (t.geckBaseChangeCoordinateIso ht A).inv
-        (1 ⊗ₜ[ℤ] (CommHopfAlgCat.mkQuotient
-          (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
-          (t.geckDefiningIdeal ht)).hom
-            (GeneralLinear.coordinateHopfAlgebraAlgEquiv ℤ (t.geckDim ht)
-              (GeneralLinear.coordinateRingMap ℤ (t.geckDim ht)
-                (MvPolynomial.X (i, j))))) =
-      (CommHopfAlgCat.mkQuotient
-          (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-        (t.geckBaseChangeDefiningIdeal ht A)).hom
-          (GeneralLinear.coordinateHopfAlgebraAlgEquiv A (t.geckDim ht)
-            (GeneralLinear.coordinateRingMap A (t.geckDim ht) (MvPolynomial.X (i, j)))) := by
-  symm
-  have h := GeneralLinear.coordinateHopfAlgebraBaseChangeMap_X ℤ A (t.geckDim ht)
-      (CommHopfAlgCat.quotient
-        (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
-        (t.geckDefiningIdeal ht))
-      (CommHopfAlgCat.quotient
-        (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-        (t.geckBaseChangeDefiningIdeal ht A))
-      (CommHopfAlgCat.mkQuotient
-        (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
-        (t.geckDefiningIdeal ht))
-      (t.geckBaseChangeCoordinateIso ht A).symm i j
-  rw [← Category.assoc, ← mkQuotient_comp_geckBaseChangeCoordinateIso_hom] at h
-  simpa only [Iso.symm_hom, Category.assoc, Iso.hom_inv_id, Category.comp_id] using h
-
 /-! ## Points of the base-changed carrier -/
 
 /-- **The points of the base-changed Geck carrier are its matrix-valued points over the new
 base.**
 
-The first factor transports a point through `geckBaseChangeCoordinateIso`; the second is the
-generic equivalence between points of a scalar extension and points of the original Hopf algebra
-on the restricted value algebra; and the last is the represented-points equivalence of the
-integral Geck carrier. Thus this definition uses the scalar extension constructed above rather
-than choosing a new carrier over `A`.
+This is `CommHopfAlgCat.baseChangeIsoPointsMulEquiv`, read at the transport
+`geckBaseChangeCoordinateIso`, followed by the represented-points equivalence of the integral
+Geck carrier. Thus this definition uses the scalar extension constructed above rather than
+choosing a new carrier over `A`.
 
 The value algebra `B` is an arbitrary commutative `A`-algebra, so this identifies the points of
 the specialized carrier at every value algebra rather than only at `A`; taking `B` to be
@@ -236,38 +202,10 @@ noncomputable def geckBaseChangePointsMulEquiv (B : CommAlgCat.{w} A) :
         (H := CommHopfAlgCat.quotient
           (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
           (t.geckBaseChangeDefiningIdeal ht A)) B ≃*
-      t.geckPoints ht (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) B) :=
-  (AlgHom.mapDomainMulEquiv (A := B)
-      (CommHopfAlgCat.ofIso (t.geckBaseChangeCoordinateIso ht A).symm)).trans
-    (CommHopfAlgCat.baseChangePointsMulEquiv (K := A) B
-      (CommHopfAlgCat.quotient
-        (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
-        (t.geckDefiningIdeal ht))) |>.trans
+      t.geckPoints ht B :=
+  (CommHopfAlgCat.baseChangeIsoPointsMulEquiv (t.geckBaseChangeCoordinateIso ht A) B).trans
     (t.geckPointsMulEquiv ht
       (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) B))
-
-private theorem geckBaseChangePointsMulEquiv_apply_apply (B : CommAlgCat.{w} A)
-    (q : HopfAlgebra.points (R := A)
-      (H := CommHopfAlgCat.quotient
-        (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-        (t.geckBaseChangeDefiningIdeal ht A)) B) (i j : Fin (t.geckDim ht)) :
-    (t.geckBaseChangePointsMulEquiv ht A B q :
-        Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) B) i j =
-      GeneralLinear.pointsMulEquiv (t.geckDim ht)
-        (CommHopfAlgCat.quotientPointsHom
-          (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-          (t.geckBaseChangeDefiningIdeal ht A) B q) i j := by
-  simp only [geckBaseChangePointsMulEquiv, MulEquiv.trans_apply]
-  rw [t.coe_geckPointsMulEquiv_apply ht]
-  simp only [GeneralLinear.pointsMulEquiv_apply, GeneralLinear.pointToGeneralLinear_apply]
-  rw [CommHopfAlgCat.quotientPointsHom_apply_apply,
-    CommHopfAlgCat.quotientPointsHom_apply_apply, ← CommHopfAlgCat.mkQuotient_apply,
-    ← CommHopfAlgCat.mkQuotient_apply, CommHopfAlgCat.baseChangePointsMulEquiv_apply_apply,
-    AlgHom.mapDomainMulEquiv_apply, AlgHom.mapDomain_apply_apply]
-  apply congrArg q.ofConv
-  exact (_root_.CommHopfAlgCat.ofIso_apply
-    (t.geckBaseChangeCoordinateIso ht A).symm _).trans
-      (t.geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X ht A i j)
 
 /-- Under `geckBaseChangePointsMulEquiv`, a quotient point has the same ambient invertible matrix
 as its composite with the quotient map over `A`. -/
@@ -282,15 +220,18 @@ theorem coe_geckBaseChangePointsMulEquiv_apply (B : CommAlgCat.{w} A)
       GeneralLinear.pointsMulEquiv (t.geckDim ht)
         (CommHopfAlgCat.quotientPointsHom
           (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-          (t.geckBaseChangeDefiningIdeal ht A) B q) :=
-  Matrix.GeneralLinearGroup.ext fun i j ↦
-    t.geckBaseChangePointsMulEquiv_apply_apply ht A B q i j
+          (t.geckBaseChangeDefiningIdeal ht A) B q) := by
+  rw [geckBaseChangePointsMulEquiv, MulEquiv.trans_apply, t.coe_geckPointsMulEquiv_apply ht]
+  exact GeneralLinear.pointsMulEquiv_quotientPointsHom_baseChangeIsoPointsMulEquiv
+    (t.geckDim ht) (t.geckDefiningIdeal ht) (t.geckBaseChangeDefiningIdeal ht A)
+    (t.geckBaseChangeCoordinateIso ht A)
+    (t.mkQuotient_comp_geckBaseChangeCoordinateIso_hom ht A) B q
 
 /-- Under the inverse of `geckBaseChangePointsMulEquiv`, the ambient point of the quotient point
 attached to a Geck point is the one read off its invertible matrix. -/
 @[simp]
 theorem quotientPointsHom_geckBaseChangePointsMulEquiv_symm (B : CommAlgCat.{w} A)
-    (g : t.geckPoints ht (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) B)) :
+    (g : t.geckPoints ht B) :
     CommHopfAlgCat.quotientPointsHom
         (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
         (t.geckBaseChangeDefiningIdeal ht A) B
@@ -318,30 +259,14 @@ theorem geckBaseChangePointsMulEquiv_mapPoints {B C : CommAlgCat.{w} A} (χ : B 
           (H := CommHopfAlgCat.quotient
             (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
             (t.geckBaseChangeDefiningIdeal ht A)) χ q) =
-      t.geckPointsMap ht
-        ((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map χ).hom.toRingHom
+      t.geckPointsMap ht χ.hom.toRingHom
         (t.geckBaseChangePointsMulEquiv ht A B q) := by
-  -- Transporting along the coordinate isomorphism is a pre-composition, so it commutes with the
-  -- post-composition by `χ` that moves a point to the larger value algebra.
-  have h : (AlgHom.mapDomainMulEquiv (A := C)
-        (CommHopfAlgCat.ofIso (t.geckBaseChangeCoordinateIso ht A).symm))
-        (HopfAlgebra.mapPoints
-          (H := CommHopfAlgCat.quotient
-            (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-            (t.geckBaseChangeDefiningIdeal ht A)) χ q) =
-      HopfAlgebra.mapPoints
-        (H := CommHopfAlgCat.baseChange (K := A)
-          (CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
-            (t.geckDefiningIdeal ht))) χ
-        ((AlgHom.mapDomainMulEquiv (A := B)
-          (CommHopfAlgCat.ofIso (t.geckBaseChangeCoordinateIso ht A).symm)) q) :=
-    DFunLike.congr_fun
-      (AlgHom.mapValue_mapDomain
-        (CommHopfAlgCat.ofIso (t.geckBaseChangeCoordinateIso ht A).symm).toBialgHom χ.hom) q
-  simp only [geckBaseChangePointsMulEquiv, MulEquiv.trans_apply, h]
-  rw [CommHopfAlgCat.baseChangePointsMulEquiv_mapValue,
+  simp only [geckBaseChangePointsMulEquiv, MulEquiv.trans_apply]
+  rw [CommHopfAlgCat.baseChangeIsoPointsMulEquiv_mapPoints,
     t.geckPointsMulEquiv_mapPoints ht
       ((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map χ)]
+  -- Restricting the scalars of `χ` to `ℤ` leaves its underlying ring homomorphism unchanged.
+  rfl
 
 /-- The integral `i`th root-subgroup coordinate map, with source expressed using the named Geck
 defining ideal. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
@@ -62,7 +62,7 @@ open TauCeti.UniversalEnvelopingAlgebra
 
 namespace TauCeti.DynkinType
 
-universe v
+universe v w
 
 noncomputable section
 
@@ -231,7 +231,7 @@ than choosing a new carrier over `A`.
 The value algebra `B` is an arbitrary commutative `A`-algebra, so this identifies the points of
 the specialized carrier at every value algebra rather than only at `A`; taking `B` to be
 `CommAlgCat.of A A` reads its `A`-points. -/
-noncomputable def geckBaseChangePointsMulEquiv (B : CommAlgCat.{v} A) :
+noncomputable def geckBaseChangePointsMulEquiv (B : CommAlgCat.{w} A) :
     HopfAlgebra.points (R := A)
         (H := CommHopfAlgCat.quotient
           (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
@@ -246,23 +246,19 @@ noncomputable def geckBaseChangePointsMulEquiv (B : CommAlgCat.{v} A) :
     (t.geckPointsMulEquiv ht
       (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) B))
 
-/-- Under `geckBaseChangePointsMulEquiv`, a quotient point has the same ambient invertible matrix
-as its composite with the quotient map over `A`. -/
-@[simp]
-theorem coe_geckBaseChangePointsMulEquiv_apply (B : CommAlgCat.{v} A)
+private theorem geckBaseChangePointsMulEquiv_apply_apply (B : CommAlgCat.{w} A)
     (q : HopfAlgebra.points (R := A)
       (H := CommHopfAlgCat.quotient
         (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-        (t.geckBaseChangeDefiningIdeal ht A)) B) :
+        (t.geckBaseChangeDefiningIdeal ht A)) B) (i j : Fin (t.geckDim ht)) :
     (t.geckBaseChangePointsMulEquiv ht A B q :
-        Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) B) =
+        Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) B) i j =
       GeneralLinear.pointsMulEquiv (t.geckDim ht)
         (CommHopfAlgCat.quotientPointsHom
           (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-          (t.geckBaseChangeDefiningIdeal ht A) B q) := by
+          (t.geckBaseChangeDefiningIdeal ht A) B q) i j := by
   simp only [geckBaseChangePointsMulEquiv, MulEquiv.trans_apply]
   rw [t.coe_geckPointsMulEquiv_apply ht]
-  ext i j
   simp only [GeneralLinear.pointsMulEquiv_apply, GeneralLinear.pointToGeneralLinear_apply]
   rw [CommHopfAlgCat.quotientPointsHom_apply_apply,
     CommHopfAlgCat.quotientPointsHom_apply_apply, ← CommHopfAlgCat.mkQuotient_apply,
@@ -273,10 +269,27 @@ theorem coe_geckBaseChangePointsMulEquiv_apply (B : CommAlgCat.{v} A)
     (t.geckBaseChangeCoordinateIso ht A).symm _).trans
       (t.geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X ht A i j)
 
+/-- Under `geckBaseChangePointsMulEquiv`, a quotient point has the same ambient invertible matrix
+as its composite with the quotient map over `A`. -/
+@[simp]
+theorem coe_geckBaseChangePointsMulEquiv_apply (B : CommAlgCat.{w} A)
+    (q : HopfAlgebra.points (R := A)
+      (H := CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+        (t.geckBaseChangeDefiningIdeal ht A)) B) :
+    (t.geckBaseChangePointsMulEquiv ht A B q :
+        Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) B) =
+      GeneralLinear.pointsMulEquiv (t.geckDim ht)
+        (CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+          (t.geckBaseChangeDefiningIdeal ht A) B q) :=
+  Matrix.GeneralLinearGroup.ext fun i j ↦
+    t.geckBaseChangePointsMulEquiv_apply_apply ht A B q i j
+
 /-- Under the inverse of `geckBaseChangePointsMulEquiv`, the ambient point of the quotient point
 attached to a Geck point is the one read off its invertible matrix. -/
 @[simp]
-theorem quotientPointsHom_geckBaseChangePointsMulEquiv_symm (B : CommAlgCat.{v} A)
+theorem quotientPointsHom_geckBaseChangePointsMulEquiv_symm (B : CommAlgCat.{w} A)
     (g : t.geckPoints ht (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) B)) :
     CommHopfAlgCat.quotientPointsHom
         (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
@@ -295,7 +308,7 @@ by `HopfAlgebra.mapPoints` and on the Geck points by `geckPointsMap` along the s
 its scalars restricted to `ℤ`, and the equivalence intertwines the two. A consumer can therefore
 use it functorially without unfolding its composite implementation. -/
 @[simp]
-theorem geckBaseChangePointsMulEquiv_mapPoints {B C : CommAlgCat.{v} A} (χ : B ⟶ C)
+theorem geckBaseChangePointsMulEquiv_mapPoints {B C : CommAlgCat.{w} A} (χ : B ⟶ C)
     (q : HopfAlgebra.points (R := A)
       (H := CommHopfAlgCat.quotient
         (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Algebra.Lie.UniversalEnveloping.Kostant.RootSubgroup.Scheme.ToralClosure.GeneralLinearBaseChange
 public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.GroupScheme
+public import TauCeti.LinearAlgebra.RootSystem.SimplyConnectedRootDatum.GeckLattice.PointsFunctor
 
 /-!
 # Base change of the pinned Geck carrier
@@ -33,6 +34,8 @@ reductive or that the represented weight torus is maximal.
   `O(GLₙ/A)`.
 * `TauCeti.DynkinType.geckBaseChangeCoordinateIso`: its quotient is the scalar extension of the
   integral Geck coordinate Hopf algebra.
+* `TauCeti.DynkinType.geckBaseChangePointsMulEquiv`: points of that quotient are the matrix points
+  of the integral carrier over the base ring.
 * `TauCeti.DynkinType.geckRootSubgroupToBaseChangeCoordinateMap`: the transported numbered root
   subgroup factored through the specialized carrier.
 * `TauCeti.DynkinType.geckWeightTorusToBaseChangeCoordinateMap`: the transported weight torus
@@ -68,6 +71,18 @@ attribute [local instance high] Algebra.toModule
 
 variable (t : DynkinType) (ht : t.Valid)
 variable (A : Type v) [CommRing A]
+
+private noncomputable def pointsMulEquivOfIso {H K : _root_.CommHopfAlgCat A}
+    (e : H ≅ K) :
+    HopfAlgebra.points (R := A) (H := H) (CommAlgCat.of A A) ≃*
+      HopfAlgebra.points (R := A) (H := K) (CommAlgCat.of A A) :=
+  (((CommHopfAlgCat.pointsFunctor (R := A)).mapIso e.symm.op).app
+    (CommAlgCat.of A A)).groupIsoToMulEquiv
+
+private theorem pointsMulEquivOfIso_apply {H K : _root_.CommHopfAlgCat A}
+    (e : H ≅ K) (q : HopfAlgebra.points (R := A) (H := H) (CommAlgCat.of A A)) :
+    pointsMulEquivOfIso A e q = (CommHopfAlgCat.mapPointsFunctor e.inv).app _ q :=
+  rfl
 
 /-- The Hopf ideal in `O(GLₙ/A)` obtained by transporting the defining ideal of the integral Geck
 carrier along `ℤ → A`. -/
@@ -179,6 +194,116 @@ theorem mkQuotient_comp_geckBaseChangeCoordinateIso_hom :
     mkQuotient_comp_kostantToralBaseChangePresentationIso_hom, Category.assoc,
     geckIntegralCoordinateTransportIso,
     t.baseChangeMap_mkQuotient_comp_eqToIso ht A (t.geckDefiningIdeal_def ht).symm]
+
+/-- The inverse base-change coordinate isomorphism sends an extended integral generic-matrix
+coordinate to the corresponding coordinate of the quotient constructed directly over `A`. -/
+@[simp]
+private theorem geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X
+    (i j : Fin (t.geckDim ht)) :
+    (t.geckBaseChangeCoordinateIso ht A).inv
+        (1 ⊗ₜ[ℤ] (CommHopfAlgCat.mkQuotient
+          (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
+          (t.geckDefiningIdeal ht)).hom
+            (GeneralLinear.coordinateHopfAlgebraAlgEquiv ℤ (t.geckDim ht)
+              (GeneralLinear.coordinateRingMap ℤ (t.geckDim ht)
+                (MvPolynomial.X (i, j))))) =
+      (CommHopfAlgCat.mkQuotient
+          (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+        (t.geckBaseChangeDefiningIdeal ht A)).hom
+          (GeneralLinear.coordinateHopfAlgebraAlgEquiv A (t.geckDim ht)
+            (GeneralLinear.coordinateRingMap A (t.geckDim ht) (MvPolynomial.X (i, j)))) := by
+  have h : (t.geckBaseChangeCoordinateIso ht A).hom
+      ((CommHopfAlgCat.mkQuotient
+        (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+        (t.geckBaseChangeDefiningIdeal ht A)).hom
+        (GeneralLinear.coordinateHopfAlgebraAlgEquiv A (t.geckDim ht)
+          (GeneralLinear.coordinateRingMap A (t.geckDim ht) (MvPolynomial.X (i, j))))) =
+      1 ⊗ₜ[ℤ] (CommHopfAlgCat.mkQuotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
+        (t.geckDefiningIdeal ht)).hom
+          (GeneralLinear.coordinateHopfAlgebraAlgEquiv ℤ (t.geckDim ht)
+            (GeneralLinear.coordinateRingMap ℤ (t.geckDim ht)
+              (MvPolynomial.X (i, j)))) := by
+    change ((CommHopfAlgCat.mkQuotient
+      (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+      (t.geckBaseChangeDefiningIdeal ht A) ≫
+        (t.geckBaseChangeCoordinateIso ht A).hom).hom
+          (GeneralLinear.coordinateHopfAlgebraAlgEquiv A (t.geckDim ht)
+            (GeneralLinear.coordinateRingMap A (t.geckDim ht)
+              (MvPolynomial.X (i, j))))) = _
+    rw [mkQuotient_comp_geckBaseChangeCoordinateIso_hom]
+    rw [_root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp, Function.comp_apply]
+    rw [GeneralLinear.coordinateHopfAlgebraBaseChangeIso_inv_X,
+      CommHopfAlgCat.baseChangeMap_apply_tmul]
+  rw [← h]
+  exact (t.geckBaseChangeCoordinateIso ht A).hom_inv_id_apply _
+
+/-! ## Points of the base-changed carrier -/
+
+/-- **The points of the base-changed Geck carrier are its matrix-valued points over the new
+base.**
+
+The first factor transports a point through `geckBaseChangeCoordinateIso`; the second is the
+generic equivalence between points of a scalar extension and points of the original Hopf algebra
+on the restricted value algebra; and the last is the represented-points equivalence of the
+integral Geck carrier. Thus this definition uses the scalar extension constructed above rather
+than choosing a new carrier over `A`. -/
+noncomputable def geckBaseChangePointsMulEquiv :
+    HopfAlgebra.points (R := A)
+        (H := CommHopfAlgCat.quotient
+          (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+          (t.geckBaseChangeDefiningIdeal ht A)) (CommAlgCat.of A A) ≃*
+      t.geckPoints ht A :=
+  (pointsMulEquivOfIso A (t.geckBaseChangeCoordinateIso ht A)).trans
+    (CommHopfAlgCat.baseChangePointsMulEquiv (K := A) (CommAlgCat.of A A)
+      (CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
+        (t.geckDefiningIdeal ht))) |>.trans
+    (t.geckPointsMulEquiv ht
+      (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) (CommAlgCat.of A A)))
+
+/-- Under `geckBaseChangePointsMulEquiv`, a quotient point has the same ambient invertible matrix
+as its composite with the quotient map over `A`. -/
+@[simp]
+theorem coe_geckBaseChangePointsMulEquiv_apply
+    (q : HopfAlgebra.points (R := A)
+      (H := CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+        (t.geckBaseChangeDefiningIdeal ht A)) (CommAlgCat.of A A)) :
+    (t.geckBaseChangePointsMulEquiv ht A q :
+        Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) A) =
+      GeneralLinear.pointsMulEquiv (t.geckDim ht)
+        (CommHopfAlgCat.quotientPointsHom
+          (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+          (t.geckBaseChangeDefiningIdeal ht A) (CommAlgCat.of A A) q) := by
+  change ((t.geckPointsMulEquiv ht _)
+      (CommHopfAlgCat.baseChangePointsMulEquiv (K := A) (CommAlgCat.of A A)
+        (CommHopfAlgCat.quotient
+          (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
+          (t.geckDefiningIdeal ht))
+        (pointsMulEquivOfIso A (t.geckBaseChangeCoordinateIso ht A) q)) :
+        Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) A) = _
+  rw [t.coe_geckPointsMulEquiv_apply ht]
+  ext i j
+  simp only [GeneralLinear.pointsMulEquiv_apply, GeneralLinear.pointToGeneralLinear_apply]
+  change (CommHopfAlgCat.baseChangePointsMulEquiv (K := A) (CommAlgCat.of A A)
+      (CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht)) (t.geckDefiningIdeal ht))
+      (pointsMulEquivOfIso A (t.geckBaseChangeCoordinateIso ht A) q)).ofConv
+        ((CommHopfAlgCat.mkQuotient
+          (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
+          (t.geckDefiningIdeal ht)).hom
+            (GeneralLinear.coordinateHopfAlgebraAlgEquiv ℤ (t.geckDim ht)
+              (GeneralLinear.coordinateRingMap ℤ (t.geckDim ht)
+                (MvPolynomial.X (i, j))))) =
+    q.ofConv ((CommHopfAlgCat.mkQuotient
+      (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+      (t.geckBaseChangeDefiningIdeal ht A)).hom
+        (GeneralLinear.coordinateHopfAlgebraAlgEquiv A (t.geckDim ht)
+          (GeneralLinear.coordinateRingMap A (t.geckDim ht) (MvPolynomial.X (i, j)))))
+  rw [CommHopfAlgCat.baseChangePointsMulEquiv_apply_apply,
+    pointsMulEquivOfIso_apply, CommHopfAlgCat.mapPointsFunctor_app_apply_apply,
+    geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X]
 
 /-- The integral `i`th root-subgroup coordinate map, with source expressed using the named Geck
 defining ideal. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
@@ -196,8 +196,10 @@ theorem mkQuotient_comp_geckBaseChangeCoordinateIso_hom :
     t.baseChangeMap_mkQuotient_comp_eqToIso ht A (t.geckDefiningIdeal_def ht).symm]
 
 /-- The inverse base-change coordinate isomorphism sends an extended integral generic-matrix
-coordinate to the corresponding coordinate of the quotient constructed directly over `A`. -/
-@[simp]
+coordinate to the corresponding coordinate of the quotient constructed directly over `A`.
+
+This is stated in terms of `CommHopfAlgCat.mkQuotient`, which `simp` unfolds to
+`Ideal.Quotient.mk`, so it is a `rw` lemma rather than a `simp` one. -/
 private theorem geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X
     (i j : Fin (t.geckDim ht)) :
     (t.geckBaseChangeCoordinateIso ht A).inv

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
@@ -72,18 +72,6 @@ attribute [local instance high] Algebra.toModule
 variable (t : DynkinType) (ht : t.Valid)
 variable (A : Type v) [CommRing A]
 
-private noncomputable def pointsMulEquivOfIso {H K : _root_.CommHopfAlgCat A}
-    (B : CommAlgCat.{v} A) (e : H ≅ K) :
-    HopfAlgebra.points (R := A) (H := H) B ≃*
-      HopfAlgebra.points (R := A) (H := K) B :=
-  (((CommHopfAlgCat.pointsFunctor (R := A)).mapIso e.symm.op).app B).groupIsoToMulEquiv
-
-private theorem pointsMulEquivOfIso_apply {H K : _root_.CommHopfAlgCat A}
-    (B : CommAlgCat.{v} A) (e : H ≅ K)
-    (q : HopfAlgebra.points (R := A) (H := H) B) :
-    pointsMulEquivOfIso A B e q = (CommHopfAlgCat.mapPointsFunctor e.inv).app _ q :=
-  rfl
-
 /-- The Hopf ideal in `O(GLₙ/A)` obtained by transporting the defining ideal of the integral Geck
 carrier along `ℤ → A`. -/
 noncomputable def geckBaseChangeDefiningIdeal :
@@ -214,24 +202,20 @@ private theorem geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X
         (t.geckBaseChangeDefiningIdeal ht A)).hom
           (GeneralLinear.coordinateHopfAlgebraAlgEquiv A (t.geckDim ht)
             (GeneralLinear.coordinateRingMap A (t.geckDim ht) (MvPolynomial.X (i, j)))) := by
-  have h : (t.geckBaseChangeCoordinateIso ht A).hom
-      ((CommHopfAlgCat.mkQuotient
-        (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-        (t.geckBaseChangeDefiningIdeal ht A)).hom
-        (GeneralLinear.coordinateHopfAlgebraAlgEquiv A (t.geckDim ht)
-          (GeneralLinear.coordinateRingMap A (t.geckDim ht) (MvPolynomial.X (i, j))))) =
-      1 ⊗ₜ[ℤ] (CommHopfAlgCat.mkQuotient
+  symm
+  have h := GeneralLinear.coordinateHopfAlgebraBaseChangeMap_X ℤ A (t.geckDim ht)
+      (CommHopfAlgCat.quotient
         (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
-        (t.geckDefiningIdeal ht)).hom
-          (GeneralLinear.coordinateHopfAlgebraAlgEquiv ℤ (t.geckDim ht)
-            (GeneralLinear.coordinateRingMap ℤ (t.geckDim ht)
-              (MvPolynomial.X (i, j)))) := by
-    rw [← _root_.CommHopfAlgCat.comp_apply,
-      mkQuotient_comp_geckBaseChangeCoordinateIso_hom, _root_.CommHopfAlgCat.comp_apply,
-      GeneralLinear.coordinateHopfAlgebraBaseChangeIso_inv_X,
-      CommHopfAlgCat.baseChangeMap_apply_tmul]
-  rw [← h]
-  exact (t.geckBaseChangeCoordinateIso ht A).hom_inv_id_apply _
+        (t.geckDefiningIdeal ht))
+      (CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+        (t.geckBaseChangeDefiningIdeal ht A))
+      (CommHopfAlgCat.mkQuotient
+        (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
+        (t.geckDefiningIdeal ht))
+      (t.geckBaseChangeCoordinateIso ht A).symm i j
+  rw [← Category.assoc, ← mkQuotient_comp_geckBaseChangeCoordinateIso_hom] at h
+  simpa only [Iso.symm_hom, Category.assoc, Iso.hom_inv_id, Category.comp_id] using h
 
 /-! ## Points of the base-changed carrier -/
 
@@ -253,7 +237,8 @@ noncomputable def geckBaseChangePointsMulEquiv (B : CommAlgCat.{v} A) :
           (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
           (t.geckBaseChangeDefiningIdeal ht A)) B ≃*
       t.geckPoints ht (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) B) :=
-  (pointsMulEquivOfIso A B (t.geckBaseChangeCoordinateIso ht A)).trans
+  (AlgHom.mapDomainMulEquiv (A := B)
+      (CommHopfAlgCat.ofIso (t.geckBaseChangeCoordinateIso ht A).symm)).trans
     (CommHopfAlgCat.baseChangePointsMulEquiv (K := A) B
       (CommHopfAlgCat.quotient
         (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
@@ -282,8 +267,11 @@ theorem coe_geckBaseChangePointsMulEquiv_apply (B : CommAlgCat.{v} A)
   rw [CommHopfAlgCat.quotientPointsHom_apply_apply,
     CommHopfAlgCat.quotientPointsHom_apply_apply, ← CommHopfAlgCat.mkQuotient_apply,
     ← CommHopfAlgCat.mkQuotient_apply, CommHopfAlgCat.baseChangePointsMulEquiv_apply_apply,
-    pointsMulEquivOfIso_apply, CommHopfAlgCat.mapPointsFunctor_app_apply_apply,
-    geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X]
+    AlgHom.mapDomainMulEquiv_apply, AlgHom.mapDomain_apply_apply]
+  apply congrArg q.ofConv
+  exact (_root_.CommHopfAlgCat.ofIso_apply
+    (t.geckBaseChangeCoordinateIso ht A).symm _).trans
+      (t.geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X ht A i j)
 
 /-- Under the inverse of `geckBaseChangePointsMulEquiv`, the ambient point of the quotient point
 attached to a Geck point is the one read off its invertible matrix. -/

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
@@ -289,6 +289,47 @@ theorem quotientPointsHom_geckBaseChangePointsMulEquiv_symm (B : CommAlgCat.{v} 
   rw [MulEquiv.apply_symm_apply] at h
   rw [h, MulEquiv.symm_apply_apply]
 
+/-- **The identification of the base-changed Geck carrier's points is natural in the value
+algebra.** A morphism `χ : B ⟶ C` of value `A`-algebras acts on the specialized carrier's points
+by `HopfAlgebra.mapPoints` and on the Geck points by `geckPointsMap` along the same morphism with
+its scalars restricted to `ℤ`, and the equivalence intertwines the two. A consumer can therefore
+use it functorially without unfolding its composite implementation. -/
+@[simp]
+theorem geckBaseChangePointsMulEquiv_mapPoints {B C : CommAlgCat.{v} A} (χ : B ⟶ C)
+    (q : HopfAlgebra.points (R := A)
+      (H := CommHopfAlgCat.quotient
+        (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+        (t.geckBaseChangeDefiningIdeal ht A)) B) :
+    t.geckBaseChangePointsMulEquiv ht A C
+        (HopfAlgebra.mapPoints
+          (H := CommHopfAlgCat.quotient
+            (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+            (t.geckBaseChangeDefiningIdeal ht A)) χ q) =
+      t.geckPointsMap ht
+        ((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map χ).hom.toRingHom
+        (t.geckBaseChangePointsMulEquiv ht A B q) := by
+  -- Transporting along the coordinate isomorphism is a pre-composition, so it commutes with the
+  -- post-composition by `χ` that moves a point to the larger value algebra.
+  have h : (AlgHom.mapDomainMulEquiv (A := C)
+        (CommHopfAlgCat.ofIso (t.geckBaseChangeCoordinateIso ht A).symm))
+        (HopfAlgebra.mapPoints
+          (H := CommHopfAlgCat.quotient
+            (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+            (t.geckBaseChangeDefiningIdeal ht A)) χ q) =
+      HopfAlgebra.mapPoints
+        (H := CommHopfAlgCat.baseChange (K := A)
+          (CommHopfAlgCat.quotient (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
+            (t.geckDefiningIdeal ht))) χ
+        ((AlgHom.mapDomainMulEquiv (A := B)
+          (CommHopfAlgCat.ofIso (t.geckBaseChangeCoordinateIso ht A).symm)) q) :=
+    DFunLike.congr_fun
+      (AlgHom.mapValue_mapDomain
+        (CommHopfAlgCat.ofIso (t.geckBaseChangeCoordinateIso ht A).symm).toBialgHom χ.hom) q
+  simp only [geckBaseChangePointsMulEquiv, MulEquiv.trans_apply, h]
+  rw [CommHopfAlgCat.baseChangePointsMulEquiv_mapValue,
+    t.geckPointsMulEquiv_mapPoints ht
+      ((TauCeti.CommAlgCat.restrictScalars (algebraMap ℤ A)).map χ)]
+
 /-- The integral `i`th root-subgroup coordinate map, with source expressed using the named Geck
 defining ideal. -/
 noncomputable def geckRootSubgroupIntegralCoordinateMap

--- a/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/BaseChange.lean
@@ -34,8 +34,8 @@ reductive or that the represented weight torus is maximal.
   `O(GLₙ/A)`.
 * `TauCeti.DynkinType.geckBaseChangeCoordinateIso`: its quotient is the scalar extension of the
   integral Geck coordinate Hopf algebra.
-* `TauCeti.DynkinType.geckBaseChangePointsMulEquiv`: points of that quotient are the matrix points
-  of the integral carrier over the base ring.
+* `TauCeti.DynkinType.geckBaseChangePointsMulEquiv`: the points of that quotient in a commutative
+  `A`-algebra are the matrix points of the integral carrier over that algebra.
 * `TauCeti.DynkinType.geckRootSubgroupToBaseChangeCoordinateMap`: the transported numbered root
   subgroup factored through the specialized carrier.
 * `TauCeti.DynkinType.geckWeightTorusToBaseChangeCoordinateMap`: the transported weight torus
@@ -73,15 +73,15 @@ variable (t : DynkinType) (ht : t.Valid)
 variable (A : Type v) [CommRing A]
 
 private noncomputable def pointsMulEquivOfIso {H K : _root_.CommHopfAlgCat A}
-    (e : H ≅ K) :
-    HopfAlgebra.points (R := A) (H := H) (CommAlgCat.of A A) ≃*
-      HopfAlgebra.points (R := A) (H := K) (CommAlgCat.of A A) :=
-  (((CommHopfAlgCat.pointsFunctor (R := A)).mapIso e.symm.op).app
-    (CommAlgCat.of A A)).groupIsoToMulEquiv
+    (B : CommAlgCat.{v} A) (e : H ≅ K) :
+    HopfAlgebra.points (R := A) (H := H) B ≃*
+      HopfAlgebra.points (R := A) (H := K) B :=
+  (((CommHopfAlgCat.pointsFunctor (R := A)).mapIso e.symm.op).app B).groupIsoToMulEquiv
 
 private theorem pointsMulEquivOfIso_apply {H K : _root_.CommHopfAlgCat A}
-    (e : H ≅ K) (q : HopfAlgebra.points (R := A) (H := H) (CommAlgCat.of A A)) :
-    pointsMulEquivOfIso A e q = (CommHopfAlgCat.mapPointsFunctor e.inv).app _ q :=
+    (B : CommAlgCat.{v} A) (e : H ≅ K)
+    (q : HopfAlgebra.points (R := A) (H := H) B) :
+    pointsMulEquivOfIso A B e q = (CommHopfAlgCat.mapPointsFunctor e.inv).app _ q :=
   rfl
 
 /-- The Hopf ideal in `O(GLₙ/A)` obtained by transporting the defining ideal of the integral Geck
@@ -226,16 +226,9 @@ private theorem geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X
           (GeneralLinear.coordinateHopfAlgebraAlgEquiv ℤ (t.geckDim ht)
             (GeneralLinear.coordinateRingMap ℤ (t.geckDim ht)
               (MvPolynomial.X (i, j)))) := by
-    change ((CommHopfAlgCat.mkQuotient
-      (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-      (t.geckBaseChangeDefiningIdeal ht A) ≫
-        (t.geckBaseChangeCoordinateIso ht A).hom).hom
-          (GeneralLinear.coordinateHopfAlgebraAlgEquiv A (t.geckDim ht)
-            (GeneralLinear.coordinateRingMap A (t.geckDim ht)
-              (MvPolynomial.X (i, j))))) = _
-    rw [mkQuotient_comp_geckBaseChangeCoordinateIso_hom]
-    rw [_root_.CommHopfAlgCat.hom_comp, BialgHom.coe_comp, Function.comp_apply]
-    rw [GeneralLinear.coordinateHopfAlgebraBaseChangeIso_inv_X,
+    rw [← _root_.CommHopfAlgCat.comp_apply,
+      mkQuotient_comp_geckBaseChangeCoordinateIso_hom, _root_.CommHopfAlgCat.comp_apply,
+      GeneralLinear.coordinateHopfAlgebraBaseChangeIso_inv_X,
       CommHopfAlgCat.baseChangeMap_apply_tmul]
   rw [← h]
   exact (t.geckBaseChangeCoordinateIso ht A).hom_inv_id_apply _
@@ -249,63 +242,64 @@ The first factor transports a point through `geckBaseChangeCoordinateIso`; the s
 generic equivalence between points of a scalar extension and points of the original Hopf algebra
 on the restricted value algebra; and the last is the represented-points equivalence of the
 integral Geck carrier. Thus this definition uses the scalar extension constructed above rather
-than choosing a new carrier over `A`. -/
-noncomputable def geckBaseChangePointsMulEquiv :
+than choosing a new carrier over `A`.
+
+The value algebra `B` is an arbitrary commutative `A`-algebra, so this identifies the points of
+the specialized carrier at every value algebra rather than only at `A`; taking `B` to be
+`CommAlgCat.of A A` reads its `A`-points. -/
+noncomputable def geckBaseChangePointsMulEquiv (B : CommAlgCat.{v} A) :
     HopfAlgebra.points (R := A)
         (H := CommHopfAlgCat.quotient
           (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-          (t.geckBaseChangeDefiningIdeal ht A)) (CommAlgCat.of A A) ≃*
-      t.geckPoints ht A :=
-  (pointsMulEquivOfIso A (t.geckBaseChangeCoordinateIso ht A)).trans
-    (CommHopfAlgCat.baseChangePointsMulEquiv (K := A) (CommAlgCat.of A A)
+          (t.geckBaseChangeDefiningIdeal ht A)) B ≃*
+      t.geckPoints ht (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) B) :=
+  (pointsMulEquivOfIso A B (t.geckBaseChangeCoordinateIso ht A)).trans
+    (CommHopfAlgCat.baseChangePointsMulEquiv (K := A) B
       (CommHopfAlgCat.quotient
         (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
         (t.geckDefiningIdeal ht))) |>.trans
     (t.geckPointsMulEquiv ht
-      (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) (CommAlgCat.of A A)))
+      (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) B))
 
 /-- Under `geckBaseChangePointsMulEquiv`, a quotient point has the same ambient invertible matrix
 as its composite with the quotient map over `A`. -/
 @[simp]
-theorem coe_geckBaseChangePointsMulEquiv_apply
+theorem coe_geckBaseChangePointsMulEquiv_apply (B : CommAlgCat.{v} A)
     (q : HopfAlgebra.points (R := A)
       (H := CommHopfAlgCat.quotient
         (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-        (t.geckBaseChangeDefiningIdeal ht A)) (CommAlgCat.of A A)) :
-    (t.geckBaseChangePointsMulEquiv ht A q :
-        Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) A) =
+        (t.geckBaseChangeDefiningIdeal ht A)) B) :
+    (t.geckBaseChangePointsMulEquiv ht A B q :
+        Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) B) =
       GeneralLinear.pointsMulEquiv (t.geckDim ht)
         (CommHopfAlgCat.quotientPointsHom
           (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-          (t.geckBaseChangeDefiningIdeal ht A) (CommAlgCat.of A A) q) := by
-  change ((t.geckPointsMulEquiv ht _)
-      (CommHopfAlgCat.baseChangePointsMulEquiv (K := A) (CommAlgCat.of A A)
-        (CommHopfAlgCat.quotient
-          (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
-          (t.geckDefiningIdeal ht))
-        (pointsMulEquivOfIso A (t.geckBaseChangeCoordinateIso ht A) q)) :
-        Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) A) = _
+          (t.geckBaseChangeDefiningIdeal ht A) B q) := by
+  simp only [geckBaseChangePointsMulEquiv, MulEquiv.trans_apply]
   rw [t.coe_geckPointsMulEquiv_apply ht]
   ext i j
   simp only [GeneralLinear.pointsMulEquiv_apply, GeneralLinear.pointToGeneralLinear_apply]
-  change (CommHopfAlgCat.baseChangePointsMulEquiv (K := A) (CommAlgCat.of A A)
-      (CommHopfAlgCat.quotient
-        (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht)) (t.geckDefiningIdeal ht))
-      (pointsMulEquivOfIso A (t.geckBaseChangeCoordinateIso ht A) q)).ofConv
-        ((CommHopfAlgCat.mkQuotient
-          (GeneralLinear.coordinateHopfAlgebra ℤ (t.geckDim ht))
-          (t.geckDefiningIdeal ht)).hom
-            (GeneralLinear.coordinateHopfAlgebraAlgEquiv ℤ (t.geckDim ht)
-              (GeneralLinear.coordinateRingMap ℤ (t.geckDim ht)
-                (MvPolynomial.X (i, j))))) =
-    q.ofConv ((CommHopfAlgCat.mkQuotient
-      (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
-      (t.geckBaseChangeDefiningIdeal ht A)).hom
-        (GeneralLinear.coordinateHopfAlgebraAlgEquiv A (t.geckDim ht)
-          (GeneralLinear.coordinateRingMap A (t.geckDim ht) (MvPolynomial.X (i, j)))))
-  rw [CommHopfAlgCat.baseChangePointsMulEquiv_apply_apply,
+  rw [CommHopfAlgCat.quotientPointsHom_apply_apply,
+    CommHopfAlgCat.quotientPointsHom_apply_apply, ← CommHopfAlgCat.mkQuotient_apply,
+    ← CommHopfAlgCat.mkQuotient_apply, CommHopfAlgCat.baseChangePointsMulEquiv_apply_apply,
     pointsMulEquivOfIso_apply, CommHopfAlgCat.mapPointsFunctor_app_apply_apply,
     geckBaseChangeCoordinateIso_inv_one_tmul_mkQuotient_X]
+
+/-- Under the inverse of `geckBaseChangePointsMulEquiv`, the ambient point of the quotient point
+attached to a Geck point is the one read off its invertible matrix. -/
+@[simp]
+theorem quotientPointsHom_geckBaseChangePointsMulEquiv_symm (B : CommAlgCat.{v} A)
+    (g : t.geckPoints ht (TauCeti.CommAlgCat.restrictScalarsObj (algebraMap ℤ A) B)) :
+    CommHopfAlgCat.quotientPointsHom
+        (GeneralLinear.coordinateHopfAlgebra A (t.geckDim ht))
+        (t.geckBaseChangeDefiningIdeal ht A) B
+        ((t.geckBaseChangePointsMulEquiv ht A B).symm g) =
+      (GeneralLinear.pointsMulEquiv (R := A) (t.geckDim ht)).symm
+        (g : Matrix.GeneralLinearGroup (Fin (t.geckDim ht)) B) := by
+  have h := t.coe_geckBaseChangePointsMulEquiv_apply ht A B
+    ((t.geckBaseChangePointsMulEquiv ht A B).symm g)
+  rw [MulEquiv.apply_symm_apply] at h
+  rw [h, MulEquiv.symm_apply_apply]
 
 /-- The integral `i`th root-subgroup coordinate map, with source expressed using the named Geck
 defining ideal. -/


### PR DESCRIPTION
This PR identifies the `A`-points of the explicitly base-changed Geck carrier coordinate Hopf algebra with `DynkinType.geckPoints ht A`, and proves that this equivalence preserves the carrier's ambient invertible matrix. It advances the ReductiveGroups Layer 9 targets “Base change along `ℤ → k` for any commutative ring `k`” and “Points over an algebraically closed field as a group” by connecting the already constructed scalar extension to the already functorial matrix-valued point group.

The dependency edge is: CFSGStatement milestone L0, “pinned ambient groups,” consumes ReductiveGroups Layer 9's base change to the prime field and its algebraic closure and the resulting group of algebraic-closure-valued points; this PR supplies that point-level bridge for the current explicit Geck carrier.

After this PR, Layer 9 still must identify the explicit carrier as the pinned simply connected split reductive group realizing the named root datum, extend the required root-subgroup interface, and then supply the remaining pinned isomorphism and special-isogeny results before CFSGStatement L0 can close.

The proof reuses `CommHopfAlgCat.baseChangePointsMulEquiv`, `DynkinType.geckPointsMulEquiv`, and `GeneralLinear.coordinateHopfAlgebraBaseChangeIso_inv_X`; no Mathlib or external formalization is vendored.

Roadmap: ReductiveGroups

Consumer roadmap: CFSGStatement

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"geck-base-change-points"}-->

🤖 Prepared with Codex
